### PR TITLE
feat(mobile): 전 타입 payload enrichment — org/project/story/sprint 식별자 (story #1953, P1a-S3)

### DIFF
--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -438,6 +438,9 @@ async def close_sprint(
                 body=None,
                 reference_type="sprint",
                 reference_id=sprint.id,
+                # story #1953: 이미 `if sprint.project_id and ...`로 non-null 확인된 후라
+                # 신규 조회 없이 그대로 실음.
+                source_project_id=sprint.project_id,
             )
     return SprintResponse.model_validate(sprint)
 

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -963,6 +963,8 @@ async def update_story(
                     body=None,
                     reference_type="story",
                     reference_id=story.id,
+                    # story #1953: story.project_id NOT NULL — 신규 조회 없이 그대로 실음.
+                    source_project_id=story.project_id,
                 )
         if actor_id:
             try:

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -175,6 +175,9 @@ async def update_task(
                 reference_id=task.id,
                 # S2: 멀티프로젝트 에이전트 assignee를 스토리 프로젝트로 정확 라우팅
                 source_project_id=story_row.project_id,
+                # story #1953(P1a-S3): task는 항상 story 소속(story_id NOT NULL) — 신규 조회
+                # 없이 FK 그대로 payload에 실음(향후 story_detail 폴백 승격 발판).
+                story_id=task.story_id,
             )
     await _attach_has_evidence(db, [task])
     return TaskResponse.model_validate(task)

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -320,6 +320,9 @@ async def create_team_member(
                 body=f"{actor.name}(에이전트)이 {member.name}을 생성했습니다.",
                 reference_type="team_member",
                 reference_id=member.id,
+                # story #1953: 신규 에이전트(member) 자신의 project_id — TeamMember.project_id
+                # NOT NULL, 신규 조회 없이 그대로 실음.
+                source_project_id=member.project_id,
             )
 
     # AC3: agent 생성 시 API key 자동 생성 + response에 포함

--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -1078,6 +1078,7 @@ async def propose_canonical_version(
             "version_number": version_number, "requested_by_member_id": str(proposer_id),
             "artifact_title": artifact.title,
         },
+        project_id=project_id,
     )
     await session.commit()
     return _ok({

--- a/backend/app/schemas/deeplink_manifest.py
+++ b/backend/app/schemas/deeplink_manifest.py
@@ -14,11 +14,19 @@
 `grep -rl "Notification(" backend/app` 결과 `models/notification.py`(정의)와
 `services/notification_dispatch.py`(유일한 사용처) 뿐).
 
-Expo push data payload(`ee/services/expo_push.py:deliver_expo_push`)는 다음 필드만 담는다:
-    {"event_type": str, "reference_type": str | None, "reference_id": str | None}
-→ 클라이언트가 딥링크를 결정할 수 있는 **유일한 실제 재료**가 이 세 필드다. 이 매니페스트의
+Expo push data payload(`ee/services/expo_push.py:deliver_expo_push`)는 (story #1951 초안 당시)
+다음 필드만 담았다: {"event_type": str, "reference_type": str | None, "reference_id": str | None}
+→ 클라이언트가 딥링크를 결정할 수 있는 **유일한 실제 재료**가 이 세 필드였다. 이 매니페스트의
 `type`/`entity_type` 룩업 키는 이 payload 필드와 정확히 대응하도록 설계했다(아래 "룩업 알고리즘"
 참고).
+
+**갱신(story #1953, P1a-S3, 2026-07-17)**: S1이 남긴 열린 질문 5번(org_id/project_id가 실제로
+필요하면 BE가 아직 안 보내고 있다는 뜻) 정정 — `_build_push_data_payload()`
+(ee/services/expo_push.py)가 이제 `org_id`(전 타입 항상)·`project_id`(호출부가 아는 경우)를
+payload에 추가로 싣는다. `task_completed`는 `story_id`, 가설 관련(`dispatched`/`handoff_stuck`의
+entity_type="hypothesis") 엔트리는 `sprint_id`도 추가로 싣는다(§ Layer 2 필드 상세는
+`DeepLinkPayloadFields` 참고). event_type/reference_type/reference_id 3필드 거동은 무변경
+(PATCH 수준 additive — schema_version 안 올림).
 
 ## 3-레이어 필드 분리 (AC3)
 
@@ -172,14 +180,24 @@ class DeepLinkPayloadFields(BaseModel):
     org_id_included: bool = Field(
         default=False,
         description=(
-            "push data payload에 org_id가 포함되는가. 현재 deliver_expo_push()는 "
-            "data payload에 org_id를 넣지 않는다(코드 실측: event_type/reference_type/"
-            "reference_id 셋뿐) — 이 필드가 org_id 전부 False인 이유. AC 스코프 필드명 "
-            "그대로 유지하되 '항상 False'라는 사실 자체가 열린 질문 5번(org_id/project_id "
-            "가 실제로 필요하면 BE가 아직 안 보내고 있다는 뜻)."
+            "push data payload에 org_id가 포함되는가. story #1953(P1a-S3) 갱신: "
+            "deliver_expo_push()의 _build_push_data_payload()가 org_id를 전 타입 항상 "
+            "포함한다(dispatch_notification()의 org_id는 non-null 필수 파라미터라 항상 "
+            "값이 있음) — 그래서 매니페스트 전 엔트리가 True. (S1 초안 당시엔 실제로 "
+            "전부 False였다 — 이 갭이 이번 스토리의 존재 이유였다.)"
         ),
     )
-    project_id_included: bool = Field(default=False)
+    project_id_included: bool = Field(
+        default=False,
+        description=(
+            "push data payload에 project_id가 포함되는가. story #1953 갱신: 대부분의 "
+            "알림 타입은 project-scoped 엔티티(story/epic/doc/sprint/hypothesis 등, "
+            "project_id NOT NULL 컬럼)에서 발화돼 True. 예외(False로 남은 엔트리) = "
+            "`gate.pending_approval`·`gate_overridden` — 이 둘은 여러 gate_type/여러 "
+            "호출부(create_gate 공용 chokepoint, 일부는 org-level work_item)에 걸쳐 있어 "
+            "project_id가 항상 보장되지 않는다(엔트리별 주석 참고)."
+        ),
+    )
     required_payload: list[str] = Field(
         default_factory=list,
         description=(
@@ -317,14 +335,26 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
                 type="gate.pending_approval", target="gate_detail", parent_tab=ParentTab.approvals,
                 target_promotion_pending=True,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            # story #1953(P1a-S3): org_id는 전 타입 공통으로 이제 항상 포함(True). project_id는
+            # create_gate()가 여러 gate_type(merge/doc_approval/artifact_canonicalize/
+            # workflow_config_publish/직접생성 등) 공용 chokepoint라 호출부별로 project_id를
+            # 아는 경우(artifact_canonicalize·doc_approval·parallel merge 등)에만 실어 보내고,
+            # 모르는 호출부(범용 gates.py 직접생성·workflow_line_config 등 org-level work_item)는
+            # 그대로 생략된다 — 전부 보장은 아니라서 False로 정직하게 유지(실측 불일치 방지).
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=False,
+                required_payload=["reference_id"],
+            ),
         ),
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="gate_approval_requested", target="gate_detail", parent_tab=ParentTab.approvals,
                 target_promotion_pending=True,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a2),
         ),
         DeepLinkManifestEntry(
@@ -332,7 +362,10 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
                 type="gate_reassigned", target="gate_detail", parent_tab=ParentTab.approvals,
                 target_promotion_pending=True,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a2),
         ),
         DeepLinkManifestEntry(
@@ -340,7 +373,10 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
                 type="gate_escalated", target="gate_detail", parent_tab=ParentTab.approvals,
                 target_promotion_pending=True,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
         ),
         DeepLinkManifestEntry(
@@ -348,7 +384,10 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
                 type="gate_reminder", target="gate_detail", parent_tab=ParentTab.approvals,
                 target_promotion_pending=True,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a2),
         ),
         DeepLinkManifestEntry(
@@ -362,7 +401,13 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
                 counts_toward_queue_badge=False,
                 target_promotion_pending=True,  # gate_detail 공통 사유 — 위 결재함 섹션 헤더 주석 참고.
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            # story #1953: project_id는 라인 step_run(sr)이 해소될 때만 실림(gate_service.py
+            # override_gate — 단일 gate엔 활성 step_run이 없을 수 있어 sr=None 케이스 존재) →
+            # 항상 보장은 아니라 False.
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=False,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
         ),
         DeepLinkManifestEntry(
@@ -372,7 +417,10 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
                 type="doc_approval_requested", target="gate_detail", parent_tab=ParentTab.approvals,
                 target_promotion_pending=True,  # gate_detail 공통 사유 — 위 결재함 섹션 헤더 주석 참고.
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a2),
         ),
 
@@ -387,13 +435,19 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             app=DeepLinkAppFields(
                 type="dispatched", entity_type="story", target="story_detail", parent_tab=ParentTab.all,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
         ),
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="dispatched", entity_type="epic", target="goal_detail", parent_tab=ParentTab.all,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
         ),
         DeepLinkManifestEntry(
             # 미르코 point ④(3자 검토): doc_detail 착지 시 id↔slug 불일치 우려 — 신규
@@ -405,7 +459,10 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             app=DeepLinkAppFields(
                 type="dispatched", entity_type="doc", target="doc_detail", parent_tab=ParentTab.all,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
         ),
         DeepLinkManifestEntry(
             # 열린 질문 7번 답변(유나, 3자 검토) — "target 실존 원칙": hypothesis 독립 상세
@@ -417,19 +474,34 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             # PR에서 target이 실제 라우트로 승격되면 이 값과 flag를 갱신한다.
             # (handoff_stuck:hypothesis 엔트리도 동일 원칙으로 통일됨 — 오르테가 정정,
             # 2026-07-17.)
+            #
+            # story #1953(P1a-S3) GATE1 재확인(2026-07-17): apps/web에 hypothesis 상세 라우트가
+            # 여전히 없다(`apps/web/src/app/**/hypotheses/**` 0건·searchParams 기반 hypothesis
+            # id 소비 컴포넌트도 0건 — epics/sprints 페이지에 인라인 카드/뱃지(hypothesis-
+            # declaration-card 등)만 있고 독립 상세 화면 없음). target 실존 원칙(S1 열린 질문
+            # 7번 결론) 유지 — target="now" 폴백·target_promotion_pending=True 그대로 보류.
+            # sprint_id는 target 승격과 무관하게 이번 스토리 스코프(가설 관련 알림에 타겟
+            # 식별자 보강) — FE가 향후 라우트를 만들 때 바로 쓸 수 있도록 payload에는 먼저
+            # 싣는다(HypothesisRepository.get_sprint_id 재사용, N:1 — 가설당 최대 1개).
             app=DeepLinkAppFields(
                 type="dispatched", entity_type="hypothesis", target="now",
                 parent_tab=ParentTab.all,
                 target_promotion_pending=True,
                 return_policy=ReturnPolicy.fallback_now,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id", "sprint_id"],
+            ),
         ),
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="dispatched", entity_type="sprint", target="sprint_detail", parent_tab=ParentTab.all,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
         ),
 
         # --- story 계열 ---
@@ -440,14 +512,20 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             app=DeepLinkAppFields(
                 type="story_assigned", target="story_detail", parent_tab=ParentTab.all,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a2),
         ),
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="story_status_changed", target="story_detail", parent_tab=ParentTab.all,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
         ),
         DeepLinkManifestEntry(
@@ -455,7 +533,10 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
                 type="comment.created", entity_type="story", target="story_detail",
                 parent_tab=ParentTab.all,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
         ),
 
         # --- task — 열린 질문 8번 답변(유나+미르코, 3자 검토): task_completed payload에
@@ -467,10 +548,17 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
         # derive-attention-queue.ts에서 이미 쓰는 패턴 — story_id 없이도 보드로 착지).
         # 등급은 B(정보성) — #1956 채널 등급 확정 시 참고.
         DeepLinkManifestEntry(
+            # story #1953(P1a-S3): story_id를 payload에 추가(발판 — 향후 story_detail 폴백
+            # 승격 시 이 필드로 "/board?story=" 조립 없이 직접 착지 가능해진다). task.story_id
+            # FK는 tasks.py 호출부가 이미 story_row.id로 알고 있어(task는 항상 story 소속)
+            # 신규 조회 없이 그대로 흘려보낸다 — 항상 존재(Task는 story 없이 존재 불가).
             app=DeepLinkAppFields(
                 type="task_completed", target="/board?story=", parent_tab=ParentTab.all,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id", "story_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
         ),
 
@@ -490,14 +578,20 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
                 type="comment.created", entity_type="visual_artifact", target="artifact_detail",
                 parent_tab=ParentTab.all, target_promotion_pending=True,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
         ),
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="artifact.created", target="artifact_detail", parent_tab=ParentTab.all,
                 target_promotion_pending=True,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
         ),
         DeepLinkManifestEntry(
@@ -505,7 +599,10 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
                 type="artifact.exported", target="artifact_detail", parent_tab=ParentTab.all,
                 target_promotion_pending=True,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
         ),
         DeepLinkManifestEntry(
@@ -513,7 +610,10 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
                 type="artifact.updated", target="artifact_detail", parent_tab=ParentTab.all,
                 target_promotion_pending=True,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
         ),
         DeepLinkManifestEntry(
@@ -521,7 +621,10 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
                 type="artifact.canonicalized", target="artifact_detail", parent_tab=ParentTab.all,
                 target_promotion_pending=True,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
         ),
 
@@ -530,14 +633,20 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             app=DeepLinkAppFields(
                 type="conversation.mention", target="chat_thread", parent_tab=ParentTab.chat,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a2),
         ),
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="conversation.message", target="chat_thread", parent_tab=ParentTab.chat,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
         ),
 
@@ -546,14 +655,20 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             app=DeepLinkAppFields(
                 type="epic_created", target="goal_detail", parent_tab=ParentTab.all,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
         ),
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="epic_status_changed", target="goal_detail", parent_tab=ParentTab.all,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
         ),
 
@@ -562,7 +677,10 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             app=DeepLinkAppFields(
                 type="sprint_closed", target="sprint_detail", parent_tab=ParentTab.all,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
         ),
 
@@ -571,7 +689,10 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             app=DeepLinkAppFields(
                 type="agent_joined", target="team_member_detail", parent_tab=ParentTab.all,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
         ),
 
@@ -597,7 +718,10 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
                 type="handoff_stuck", entity_type="story", target="story_detail",
                 parent_tab=ParentTab.all,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
         ),
         DeepLinkManifestEntry(
@@ -605,7 +729,10 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
                 type="handoff_stuck", entity_type="epic", target="goal_detail",
                 parent_tab=ParentTab.all,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
         ),
         DeepLinkManifestEntry(
@@ -613,7 +740,10 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
                 type="handoff_stuck", entity_type="doc", target="doc_detail",
                 parent_tab=ParentTab.all,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
         ),
         DeepLinkManifestEntry(
@@ -624,13 +754,24 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             # 동일 target을 쓰면서 다른 처리를 받는 내부 불일치. dispatched:hypothesis와
             # 동일 원칙(target 실존 원칙)으로 통일 — target="now" 폴백 + 승격 대기 표시.
             # S3(가설 상세 라우트 신설) PR에서 dispatched:hypothesis와 함께 일괄 승격.
+            #
+            # story #1953(P1a-S3) 재확인(2026-07-17): FE에 hypothesis 상세 라우트 여전히 없음
+            # (위 dispatched:hypothesis 엔트리 주석 참고 — 동일 GATE1 조사) → 승격 보류 유지.
+            # sprint_id는 required_payload에 추가(가설 관련 알림 타겟 보강 — 이번 스토리 스코프).
+            # sprint_id가 없을 수 있는 가설(sprint 미연결)은 validate_push_payload가
+            # MissingRequiredDeepLinkPayloadError → AC4 폴백으로 처리하는데, 이 엔트리는 이미
+            # target="now"라 폴백 목적지와 동일(무해) — sprint-anchored 가설만 향후 승격 시
+            # 정밀 착지가 가능해진다는 신호로 남겨둔다.
             app=DeepLinkAppFields(
                 type="handoff_stuck", entity_type="hypothesis", target="now",
                 parent_tab=ParentTab.all,
                 target_promotion_pending=True,
                 return_policy=ReturnPolicy.fallback_now,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id", "sprint_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
         ),
         DeepLinkManifestEntry(
@@ -638,7 +779,10 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
                 type="handoff_stuck", entity_type="sprint", target="sprint_detail",
                 parent_tab=ParentTab.all,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
         ),
         DeepLinkManifestEntry(
@@ -646,7 +790,10 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
                 type="handoff_fallback", entity_type="story", target="story_detail",
                 parent_tab=ParentTab.all,
             ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
         ),
     ],

--- a/backend/app/services/agent_dispatch.py
+++ b/backend/app/services/agent_dispatch.py
@@ -163,6 +163,17 @@ async def _finalize_dispatch(
     await extract_activities_best_effort(db, [event.id])
 
     if member_type != "agent":
+        # story #1953(P1a-S3): 가설(hypothesis) dispatched 알림은 sprint_id를 타겟 보강
+        # 식별자로 추가(딥링크 매니페스트 Layer 2 계약 — HypothesisRepository.get_sprint_id
+        # 재사용, N:1이라 가설당 최대 1개). 다른 4종 엔티티(story/epic/doc/sprint)는
+        # sprint 링크 개념이 없어 None(생략).
+        _sprint_id: uuid.UUID | None = None
+        if entity_type == "hypothesis":
+            from app.repositories.hypothesis import HypothesisRepository
+            try:
+                _sprint_id = await HypothesisRepository(db, org_id).get_sprint_id(entity_id)
+            except Exception:  # noqa: BLE001 — best-effort 보강, dispatch critical path 비중단.
+                _sprint_id = None
         await dispatch_notification(
             db,
             org_id=org_id,
@@ -172,6 +183,9 @@ async def _finalize_dispatch(
             body=message or None,
             reference_type=entity_type,
             reference_id=entity_id,
+            # story #1953: project_id는 이미 함수 파라미터로 갖고 있음(신규 조회 0).
+            source_project_id=project_id,
+            sprint_id=_sprint_id,
         )
 
     if commit:

--- a/backend/app/services/doc.py
+++ b/backend/app/services/doc.py
@@ -94,6 +94,7 @@ async def transition_doc(
             session, org_id, doc.id, DOC_GATE_WORK_ITEM_TYPE, DOC_GATE_TYPE,
             caller.id, role_id,
             neutral_facts={"requested_by_member_id": str(caller.id), "doc_title": doc.title},
+            project_id=doc.project_id,
         )
         # ⚠️재상신 RC(산티아고): uq(work_item_id,gate_type)=1 gate·terminal(approved/rejected)=immutable →
         # create_gate 멱등이 기존 **terminal gate 를 반환**해(상태필터 없음) 재상신 시 새 pending gate 0 →

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -88,8 +88,17 @@ async def create_gate(
     member_id: uuid.UUID,
     role_id: uuid.UUID,
     neutral_facts: dict[str, Any] | None = None,
+    project_id: uuid.UUID | None = None,
 ) -> Gate:
-    """config 기반 게이트 생성 (멱등: 이미 있으면 기존 반환)."""
+    """config 기반 게이트 생성 (멱등: 이미 있으면 기존 반환).
+
+    project_id: story #1953(P1a-S3) — gate.pending_approval 알림 payload의 project_id 보강용
+    (선택적). create_gate()는 gate_type/work_item_type을 가리지 않는 공용 chokepoint라
+    work_item_type별 project_id 해소 로직을 여기 내장하지 않는다 — 호출부가 이미 알고 있으면
+    (artifact_canonicalize·doc_approval·parallel merge 등) 그대로 넘기고, 모르는 호출부(범용
+    gates.py 직접생성·workflow_line_config 등 org-level work_item)는 생략(None)해도 무방하다
+    (신규 조회 강제 없음 — 매니페스트 project_id_included=False로 이 부분성을 정직하게 표시).
+    """
     # 멱등: 이미 존재하면 기존 반환
     existing_r = await session.execute(
         select(Gate).where(
@@ -139,6 +148,7 @@ async def create_gate(
                     title="결재 대기 중인 게이트가 있습니다",
                     body=f"{gate_type} 게이트가 승인/거부를 기다리고 있습니다.",
                     reference_type="gate", reference_id=gate.id,
+                    source_project_id=project_id,
                 )
         except Exception:
             logger.warning(
@@ -762,6 +772,10 @@ async def override_gate(
                 title="게이트가 강제 결정되었습니다",
                 body=f"owner 가 게이트를 {decision} 로 강제 결정했습니다: {reason}",
                 reference_type="gate", reference_id=gate_id,
+                # story #1953: sr(라인 step_run)이 해소된 경우에만 project_id를 안다(단일
+                # gate엔 활성 step_run이 없을 수 있어 sr=None 케이스 존재 — 그래서 매니페스트
+                # project_id_included=False로 정직하게 유지·여기선 best-effort로만 실음).
+                source_project_id=(sr.project_id if sr is not None else None),
             )
         except Exception:  # noqa: BLE001 — notification 실패는 비중단(override 자체는 성공).
             pass

--- a/backend/app/services/loop.py
+++ b/backend/app/services/loop.py
@@ -303,6 +303,7 @@ async def decide_loop_artifacts(
         session, org_id, loop.id, "loop", "loop_decision",
         caller.id, role_id,
         neutral_facts={"requested_by_member_id": str(caller.id), "loop_title": loop.title},
+        project_id=loop.project_id,
     )
     # 재-결정 방지: 이 loop의 결정 프로세스가 이미 종결(approved/rejected)됐으면 side-effect 전 조기 차단.
     if gate.status != "pending":

--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -139,6 +139,8 @@ async def dispatch_notification(
     reference_id: uuid.UUID | None = None,
     source_project_id: uuid.UUID | None = None,
     context: dict | None = None,
+    story_id: uuid.UUID | None = None,
+    sprint_id: uuid.UUID | None = None,
 ) -> None:
     """notification_settings 필터 후 enabled member에게 알림 발송.
 
@@ -153,6 +155,13 @@ async def dispatch_notification(
     뷰가 멀티프로젝트 멤버를 N행(동일 id)으로 내는데, 주어지면 dedup에서 그 프로젝트 행을 우선
     선택하고 에이전트 Event를 그 프로젝트로 스코프한다 — 임의 first-project로 떨구는 오라우팅 방지.
     미지정 시 기존 거동(첫 행) 유지 → 휴먼 1-알림 dedup 무회귀(additive·하위호환).
+
+    story #1953(P1a-S3): source_project_id는 Expo push data payload의 project_id로도 그대로
+    재사용된다(딥링크 매니페스트 Layer 2 계약 — org_id/project_id 전 타입 포함). 호출부가
+    안 넘기면, 아래에서 이미 조회한 대상 member들의 project_id가 전부 동일할 때만(모호성 없을
+    때만) 그 값으로 폴백한다 — 새 쿼리 없이 기존 조회 결과를 재사용(신규 DB 왕복 0).
+    story_id(task_completed)·sprint_id(가설 관련 dispatched/handoff_stuck)는 호출부가 이미
+    알고 있는 값을 그대로 실어 보내는 통과 파라미터(신규 조회는 호출부 책임, 여기선 없음).
     """
     if not target_member_ids:
         return
@@ -240,6 +249,19 @@ async def dispatch_notification(
             elif source_project_id is not None and getattr(_m, "project_id", None) == source_project_id:
                 _picked[_m.id] = _m  # 트리거 프로젝트 행으로 교체
         members = list(_picked.values())
+
+        # story #1953: Expo push data payload용 project_id 해소. source_project_id가 명시되면
+        # 그대로 우선 사용(신뢰 가능한 트리거 프로젝트). 없으면 위에서 이미 조회한 members의
+        # project_id가 전부 동일할 때만(모호성 0) 그 값으로 폴백 — 신규 쿼리 없이 기존 조회
+        # 결과만 재사용. 여러 프로젝트가 섞여 있으면(org-wide 브로드캐스트 등) None으로 둬
+        # 오라우팅(잘못된 프로젝트로 딥링크) 방지.
+        _push_project_id = source_project_id
+        if _push_project_id is None:
+            _member_project_ids = {
+                getattr(_m, "project_id", None) for _m in members
+            } - {None}
+            if len(_member_project_ids) == 1:
+                _push_project_id = next(iter(_member_project_ids))
 
         inserted = False
         created_events: list[Event] = []  # L1 BE-3: fan-out 수렴용 event 수집
@@ -345,6 +367,7 @@ async def dispatch_notification(
                 db, org_id, enabled_member_ids, title=title, body=body, event_type=event_type,
                 reference_type=reference_type, reference_id=reference_id, context=context,
                 muted_member_ids=muted_member_ids,
+                project_id=_push_project_id, story_id=story_id, sprint_id=sprint_id,
             )
 
     except Exception:

--- a/backend/app/services/workflow_fallback_notify.py
+++ b/backend/app/services/workflow_fallback_notify.py
@@ -67,6 +67,8 @@ async def fallback_notify(
             title="Stuck handoff — fallback to human",
             body=f"{sr.entity_type} {story_id} agent handoff stalled — human intervention requested",
             reference_type="story", reference_id=story_id,
+            # story #1953: sr.project_id NOT NULL — 신규 조회 없이 그대로 실음.
+            source_project_id=sr.project_id,
         )
 
     # idempotent marker(통지 0명이어도 기록 — 재통지 방지). ⭐status 변경 없음(rollback 0).

--- a/backend/app/services/workflow_handoff_watchdog.py
+++ b/backend/app/services/workflow_handoff_watchdog.py
@@ -36,12 +36,27 @@ async def _fallback_notify(session: AsyncSession, sr: WorkflowLineStepRun,
         return
     try:
         from app.services.notification_dispatch import dispatch_notification
+
+        # story #1953(P1a-S3): entity_type="hypothesis"면 sprint_id를 타겟 보강 식별자로 추가
+        # (딥링크 매니페스트 Layer 2 계약 — dispatched:hypothesis와 동형). 나머지 4종
+        # 엔티티(story/epic/doc/sprint)는 sprint 링크 개념이 없어 None.
+        _sprint_id: uuid.UUID | None = None
+        if sr.entity_type == "hypothesis":
+            from app.repositories.hypothesis import HypothesisRepository
+            try:
+                _sprint_id = await HypothesisRepository(session, sr.org_id).get_sprint_id(sr.entity_id)
+            except Exception:  # noqa: BLE001 — best-effort 보강, watchdog 비중단.
+                _sprint_id = None
+
         await dispatch_notification(
             session, org_id=sr.org_id, event_type="handoff_stuck",
             target_member_ids=[recipient_id],
             title="Handoff stalled — no ACK within SLA",
             body=f"{sr.entity_type} {sr.entity_id} {sr.from_status}→{sr.to_status} handoff unacked",
             reference_type=sr.entity_type, reference_id=sr.entity_id,
+            # story #1953: sr.project_id는 함수 파라미터로 이미 갖고 있음(신규 조회 0).
+            source_project_id=sr.project_id,
+            sprint_id=_sprint_id,
         )
     except Exception:  # noqa: BLE001 — notification 실패는 watchdog 비중단(best-effort).
         sr.delivery_error = (sr.delivery_error or "") + "; notify_failed"

--- a/backend/app/services/workflow_parallel_approval.py
+++ b/backend/app/services/workflow_parallel_approval.py
@@ -74,6 +74,7 @@ async def create_parallel_gate(
             "requested_by_member_id": str(requested_by_member_id) if requested_by_member_id else None,
             "parallel": True,
         },
+        project_id=step_run.project_id,
     )
     group_id = uuid.uuid4()
     step_run.gate_id = gate.id  # ⭐S6 hook 연결: transition_gate→find_active_step_run_for_gate→라인 전이
@@ -341,6 +342,9 @@ async def reassign_approver(
             target_member_ids=[new_approver_id], title="결재자로 재지정됨",
             body="관리자가 당신을 이 결재의 새 결재자로 지정했습니다.",
             reference_type="gate", reference_id=gate_id,
+            # story #1953: target(WorkflowLineStepApproval).project_id NOT NULL — 신규 조회
+            # 없이 그대로 실음.
+            source_project_id=target.project_id,
         )
     except Exception:  # noqa: BLE001 — notification 실패는 비중단(재지정 자체는 성공).
         pass

--- a/backend/app/services/workflow_sla_processor.py
+++ b/backend/app/services/workflow_sla_processor.py
@@ -84,6 +84,8 @@ async def _notify(session: AsyncSession, sr: WorkflowLineStepRun, target_id: uui
             session, org_id=sr.org_id, event_type=event_type, target_member_ids=[target_id],
             title=title, body=f"{sr.entity_type} {sr.entity_id} {sr.from_status}→{sr.to_status}",
             reference_type=sr.entity_type, reference_id=sr.entity_id,
+            # story #1953: sr.project_id NOT NULL — 신규 조회 없이 그대로 실음.
+            source_project_id=sr.project_id,
         )
     except Exception:  # noqa: BLE001 — notification 실패는 비중단(best-effort).
         pass

--- a/backend/ee/services/expo_push.py
+++ b/backend/ee/services/expo_push.py
@@ -56,6 +56,41 @@ async def _expo_send_chunk(messages: list[dict]) -> list[dict]:
     return []
 
 
+def _build_push_data_payload(
+    *,
+    event_type: str,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID | None = None,
+    reference_type: str | None = None,
+    reference_id: uuid.UUID | None = None,
+    story_id: uuid.UUID | None = None,
+    sprint_id: uuid.UUID | None = None,
+) -> dict:
+    """story #1953(P1a-S3): Expo push data payload 구성(순수 함수 — DB/IO 없음).
+
+    org_id는 dispatch_notification()의 non-null 필수 파라미터라 **전 타입 항상 포함**
+    (manifest DeepLinkPayloadFields.org_id_included=True 근거). project_id는 호출부가
+    알고 있으면 포함하되(대부분의 타입은 project-scoped라 알고 있음), org-wide 브로드캐스트
+    등 미상인 경우 키 자체를 생략(None/빈문자열로 오염하지 않음 — 클라이언트가 "값 없음"과
+    "필드 없음"을 구분할 필요가 없게 아예 안 실음).
+
+    story_id(task_completed)·sprint_id(가설 관련 dispatched/handoff_stuck)는 특정 타입에서만
+    유의미한 타겟 보강 식별자 — 호출부가 안 넘기면(None) 생략.
+    """
+    data: dict = {"event_type": event_type, "org_id": str(org_id)}
+    if project_id:
+        data["project_id"] = str(project_id)
+    if reference_type:
+        data["reference_type"] = reference_type
+    if reference_id:
+        data["reference_id"] = str(reference_id)
+    if story_id:
+        data["story_id"] = str(story_id)
+    if sprint_id:
+        data["sprint_id"] = str(sprint_id)
+    return data
+
+
 async def deliver_expo_push(
     db: AsyncSession,
     org_id: uuid.UUID,
@@ -68,6 +103,9 @@ async def deliver_expo_push(
     reference_id: uuid.UUID | None = None,
     context: dict | None = None,
     muted_member_ids: set[uuid.UUID] | None = None,
+    project_id: uuid.UUID | None = None,
+    story_id: uuid.UUID | None = None,
+    sprint_id: uuid.UUID | None = None,
 ) -> None:
     """활성 push_devices 로 Expo push 발송(웹훅과 나란한 별개 채널).
 
@@ -75,6 +113,8 @@ async def deliver_expo_push(
     - 디바이스당 1발(이중발송 0). 배치 ≤100·메시지 최소화(≤4096B).
     - best-effort: 어떤 실패도 알림 파이프라인으로 전파 안 함(발송 실패가 in-app/Event 안 되돌림).
     - DeviceNotRegistered ticket → 그 토큰 is_active=false(자동 만료). 재발송 대상서 제외됨.
+    - story #1953(P1a-S3): project_id/story_id/sprint_id는 딥링크 매니페스트 Layer 2 계약
+      보강 필드 — dispatch_notification()이 이미 아는 값을 그대로 흘려보낸다(신규 조회 없음).
     """
     try:
         if not member_ids:
@@ -96,11 +136,11 @@ async def deliver_expo_push(
             return
 
         # 딥링크용 data(4096B 상한 고려 최소 필드만 — 탭→화면 착지에 필요한 것).
-        data_payload: dict = {"event_type": event_type}
-        if reference_type:
-            data_payload["reference_type"] = reference_type
-        if reference_id:
-            data_payload["reference_id"] = str(reference_id)
+        data_payload = _build_push_data_payload(
+            event_type=event_type, org_id=org_id, project_id=project_id,
+            reference_type=reference_type, reference_id=reference_id,
+            story_id=story_id, sprint_id=sprint_id,
+        )
 
         messages = [
             {

--- a/backend/tests/test_expo_push_ee.py
+++ b/backend/tests/test_expo_push_ee.py
@@ -72,6 +72,69 @@ async def test_send_chunk_retries_on_5xx_then_empty():
     assert post.await_count == expo._WEBHOOK_MAX_RETRIES  # 전량 재시도 소진
 
 
+# ─── _build_push_data_payload (story #1953 P1a-S3: org/project/story/sprint 식별자 enrichment) ──
+
+def test_build_push_data_payload_always_includes_org_id():
+    """전 타입 공통: org_id는 항상 payload에 포함(dispatch_notification의 org_id는 non-null
+    필수 파라미터라 언제나 값이 있음 — manifest DeepLinkPayloadFields.org_id_included=True 근거)."""
+    org_id = uuid.uuid4()
+    data = expo._build_push_data_payload(event_type="agent_joined", org_id=org_id)
+    assert data["org_id"] == str(org_id)
+    assert data["event_type"] == "agent_joined"
+
+
+def test_build_push_data_payload_includes_project_id_when_given():
+    org_id, project_id = uuid.uuid4(), uuid.uuid4()
+    data = expo._build_push_data_payload(event_type="story_assigned", org_id=org_id, project_id=project_id)
+    assert data["project_id"] == str(project_id)
+
+
+def test_build_push_data_payload_omits_project_id_when_none():
+    """project_id 미상(예: 멀티프로젝트 org-wide 브로드캐스트) — 없는 키로 생략(빈 문자열/None 오염 금지)."""
+    data = expo._build_push_data_payload(event_type="agent_joined", org_id=uuid.uuid4(), project_id=None)
+    assert "project_id" not in data
+
+
+def test_build_push_data_payload_includes_story_id_for_task_completed():
+    org_id = uuid.uuid4()
+    story_id = uuid.uuid4()
+    data = expo._build_push_data_payload(
+        event_type="task_completed", org_id=org_id, reference_type="task",
+        reference_id=uuid.uuid4(), story_id=story_id,
+    )
+    assert data["story_id"] == str(story_id)
+
+
+def test_build_push_data_payload_includes_sprint_id_for_hypothesis_dispatch():
+    org_id = uuid.uuid4()
+    sprint_id = uuid.uuid4()
+    data = expo._build_push_data_payload(
+        event_type="dispatched", org_id=org_id, reference_type="hypothesis",
+        reference_id=uuid.uuid4(), sprint_id=sprint_id,
+    )
+    assert data["sprint_id"] == str(sprint_id)
+
+
+def test_build_push_data_payload_omits_story_id_and_sprint_id_when_none():
+    data = expo._build_push_data_payload(event_type="epic_created", org_id=uuid.uuid4())
+    assert "story_id" not in data
+    assert "sprint_id" not in data
+
+
+def test_build_push_data_payload_preserves_existing_reference_fields():
+    """무회귀: event_type/reference_type/reference_id 기존 3필드 거동 불변."""
+    org_id, ref_id = uuid.uuid4(), uuid.uuid4()
+    data = expo._build_push_data_payload(
+        event_type="gate.pending_approval", org_id=org_id, reference_type="gate", reference_id=ref_id,
+    )
+    assert data == {
+        "event_type": "gate.pending_approval",
+        "org_id": str(org_id),
+        "reference_type": "gate",
+        "reference_id": str(ref_id),
+    }
+
+
 # ─── deliver_expo_push (배치·만료·mute·best-effort) ───────────────────────────
 
 @pytest.mark.anyio
@@ -148,6 +211,34 @@ async def test_no_send_when_no_devices():
     with patch("ee.services.expo_push._expo_send_chunk", new=sent):
         await expo.deliver_expo_push(db, uuid.uuid4(), [uuid.uuid4()], title="T", body="B", event_type="e")
     sent.assert_not_awaited()  # 디바이스 0 → 발송 없음
+
+
+@pytest.mark.anyio
+async def test_deliver_expo_push_includes_org_project_story_sprint_in_data_payload():
+    """story #1953: deliver_expo_push가 실제로 org_id/project_id/story_id/sprint_id를
+    push data payload에 실어 보내는지(구성 함수 호출뿐 아니라 실제 배선까지) 확인."""
+    dev = _dev("ExponentPushToken[GOOD]")
+    db = _mock_db([dev])
+    org_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    story_id = uuid.uuid4()
+    captured: list[dict] = []
+
+    async def _fake_chunk(msgs):
+        captured.extend(msgs)
+        return [{"status": "ok"} for _ in msgs]
+
+    with patch("ee.services.expo_push._expo_send_chunk", new=_fake_chunk):
+        await expo.deliver_expo_push(
+            db, org_id, [dev.member_id], title="T", body="B", event_type="task_completed",
+            reference_type="task", reference_id=uuid.uuid4(),
+            project_id=project_id, story_id=story_id,
+        )
+    assert len(captured) == 1
+    data = captured[0]["data"]
+    assert data["org_id"] == str(org_id)
+    assert data["project_id"] == str(project_id)
+    assert data["story_id"] == str(story_id)
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_notification_dispatch.py
+++ b/backend/tests/test_notification_dispatch.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import uuid
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -46,8 +46,11 @@ def _settings_result(rows: list[tuple]) -> MagicMock:
     return result
 
 
-def _members_result(rows: list[tuple]) -> MagicMock:
-    """[(id, user_id), ...] → execute mock result."""
+def _members_result(rows: list[tuple], project_id=None) -> MagicMock:
+    """[(id, user_id), ...] → execute mock result.
+
+    project_id: story #1953 — 단일 project_id를 전 행에 부여(단일-프로젝트 unambiguous 폴백
+    추론 테스트용). 기본 None(기존 거동 무회귀 — Event INSERT 스킵)."""
     result = MagicMock()
     rows_mock = []
     for mid, uid in rows:
@@ -55,7 +58,7 @@ def _members_result(rows: list[tuple]) -> MagicMock:
         row.id = mid
         row.user_id = uid
         row.type = "human"      # human → Notification INSERT
-        row.project_id = None   # None → Event INSERT 스킵 (1번 add)
+        row.project_id = project_id
         rows_mock.append(row)
     result.all.return_value = rows_mock
     return result
@@ -352,5 +355,143 @@ async def test_dispatch_agent_no_source_falls_back_first_row(mock_session, org_i
     events = [c.args[0] for c in mock_session.add.call_args_list if isinstance(c.args[0], Event)]
     assert len(events) == 1
     assert events[0].project_id == p1  # 첫 행
+
+
+# ─── story #1953(P1a-S3): org_id/project_id 전 타입 payload enrichment ────────
+
+def _ee_on():
+    """dispatch_notification 내부의 `_settings.is_ee_enabled` 를 결정적으로 True 로."""
+    from app.core.config import settings
+    return patch.object(type(settings), "is_ee_enabled", property(lambda self: True))
+
+
+def _no_webhook_configs_result() -> MagicMock:
+    """_deliver_personal_webhooks 의 WebhookConfig 조회 — 활성 개인 webhook 0건(빈 결과)."""
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = []
+    return result
+
+
+@pytest.mark.anyio
+async def test_dispatch_passes_source_project_id_to_expo_push(mock_session, org_id):
+    """source_project_id가 주어지면 그대로 Expo push project_id kwarg로 전달돼야 한다."""
+    from app.services.notification_dispatch import dispatch_notification
+
+    member_id, user_id, project_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    settings_r = _settings_result([])
+    wh_result = MagicMock()
+    wh_result.scalars.return_value.all.return_value = []
+    members = _members_result([(member_id, user_id)])
+    mock_session.execute.side_effect = [settings_r, wh_result, members, _no_webhook_configs_result()]
+
+    with _ee_on(), patch(
+        "ee.services.expo_push.deliver_expo_push", new=AsyncMock()
+    ) as mock_push:
+        await dispatch_notification(
+            mock_session, org_id=org_id, event_type="story_assigned",
+            target_member_ids=[member_id], title="담당자 지정",
+            reference_type="story", reference_id=uuid.uuid4(),
+            source_project_id=project_id,
+        )
+
+    assert mock_push.await_args.kwargs["project_id"] == project_id
+
+
+@pytest.mark.anyio
+async def test_dispatch_infers_project_id_when_members_share_single_project(
+    mock_session, org_id, monkeypatch,
+):
+    """source_project_id 미지정 + 대상 member 전원이 동일 project_id → 그 값으로 폴백(신규
+    쿼리 없이 기존 members 조회 결과 재사용)."""
+    from app.services.notification_dispatch import dispatch_notification
+
+    monkeypatch.setattr(
+        "app.services.activity_stream.extract_activities_best_effort",
+        AsyncMock(return_value=None),
+    )
+
+    member_id, user_id, project_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    settings_r = _settings_result([])
+    wh_result = MagicMock()
+    wh_result.scalars.return_value.all.return_value = []
+    members = _members_result([(member_id, user_id)], project_id=project_id)
+    mock_session.execute.side_effect = [settings_r, wh_result, members, _no_webhook_configs_result()]
+
+    with _ee_on(), patch(
+        "ee.services.expo_push.deliver_expo_push", new=AsyncMock()
+    ) as mock_push:
+        await dispatch_notification(
+            mock_session, org_id=org_id, event_type="agent_joined",
+            target_member_ids=[member_id], title="새 에이전트",
+            reference_type="team_member", reference_id=uuid.uuid4(),
+        )
+
+    assert mock_push.await_args.kwargs["project_id"] == project_id
+
+
+@pytest.mark.anyio
+async def test_dispatch_project_id_none_when_members_span_multiple_projects(
+    mock_session, org_id, monkeypatch,
+):
+    """source_project_id 미지정 + 대상 member들이 서로 다른 project_id(org-wide 브로드캐스트) →
+    모호성이 있으므로 project_id=None(오라우팅 방지, 억지 폴백 금지)."""
+    from app.services.notification_dispatch import dispatch_notification
+
+    monkeypatch.setattr(
+        "app.services.activity_stream.extract_activities_best_effort",
+        AsyncMock(return_value=None),
+    )
+
+    m1, m2 = uuid.uuid4(), uuid.uuid4()
+    u1, u2 = uuid.uuid4(), uuid.uuid4()
+    p1, p2 = uuid.uuid4(), uuid.uuid4()
+    settings_r = _settings_result([])
+    wh_result = MagicMock()
+    wh_result.scalars.return_value.all.return_value = []
+    result = MagicMock()
+    row1, row2 = MagicMock(), MagicMock()
+    row1.id, row1.user_id, row1.type, row1.project_id = m1, u1, "human", p1
+    row2.id, row2.user_id, row2.type, row2.project_id = m2, u2, "human", p2
+    result.all.return_value = [row1, row2]
+    mock_session.execute.side_effect = [settings_r, wh_result, result, _no_webhook_configs_result()]
+
+    with _ee_on(), patch(
+        "ee.services.expo_push.deliver_expo_push", new=AsyncMock()
+    ) as mock_push:
+        await dispatch_notification(
+            mock_session, org_id=org_id, event_type="agent_joined",
+            target_member_ids=[m1, m2], title="새 에이전트",
+            reference_type="team_member", reference_id=uuid.uuid4(),
+        )
+
+    assert mock_push.await_args.kwargs["project_id"] is None
+
+
+@pytest.mark.anyio
+async def test_dispatch_passes_story_id_and_sprint_id_through_to_expo_push(mock_session, org_id):
+    """task_completed의 story_id·가설 관련 dispatched의 sprint_id — 호출부가 넘긴 값이
+    그대로 deliver_expo_push에 전달돼야 한다(신규 조회 0·pass-through)."""
+    from app.services.notification_dispatch import dispatch_notification
+
+    member_id, user_id = uuid.uuid4(), uuid.uuid4()
+    story_id, sprint_id = uuid.uuid4(), uuid.uuid4()
+    settings_r = _settings_result([])
+    wh_result = MagicMock()
+    wh_result.scalars.return_value.all.return_value = []
+    members = _members_result([(member_id, user_id)])
+    mock_session.execute.side_effect = [settings_r, wh_result, members, _no_webhook_configs_result()]
+
+    with _ee_on(), patch(
+        "ee.services.expo_push.deliver_expo_push", new=AsyncMock()
+    ) as mock_push:
+        await dispatch_notification(
+            mock_session, org_id=org_id, event_type="task_completed",
+            target_member_ids=[member_id], title="작업 완료",
+            reference_type="task", reference_id=uuid.uuid4(),
+            story_id=story_id, sprint_id=sprint_id,
+        )
+
+    assert mock_push.await_args.kwargs["story_id"] == story_id
+    assert mock_push.await_args.kwargs["sprint_id"] == sprint_id
 
 


### PR DESCRIPTION
## Summary
- S1(#1951)이 남긴 열린 질문 5번(`org_id_included`/`project_id_included` 전부 False)을 정정 — `deliver_expo_push()`의 Expo push data payload에 `org_id`(전 타입 항상)·`project_id`(project-scoped 타입 대부분)를 실제로 싣는다.
- `task_completed`에 `story_id`, 가설(`hypothesis`) 관련 `dispatched`/`handoff_stuck`에 `sprint_id`를 타겟 보강 식별자로 추가 — 신규 조회 없이 호출부가 이미 아는 값을 그대로 흘려보내는 pass-through 설계.
- 매니페스트(`deeplink_manifest.py`)의 Layer 2(`DeepLinkPayloadFields`)를 실제 코드에 맞게 갱신 — 33개 엔트리 중 31개가 `project_id_included=True`(project-scoped NOT NULL 컬럼 확인), `gate.pending_approval`/`gate_overridden` 2개는 `create_gate()`가 여러 gate_type 공용 chokepoint라 project_id 커버리지가 부분적이라 정직하게 `False` 유지.

## 스코프 밖(FE 대기)
- 가설 상세 라우트: `apps/web`을 재조사한 결과 여전히 미존재(`**/hypotheses/**` 페이지 0건·`useSearchParams` 기반 hypothesis id 소비 컴포넌트 0건 — 인라인 카드/뱃지만 존재). S1의 "target 실존 원칙"에 따라 `dispatched:hypothesis`·`handoff_stuck:hypothesis`는 `target="now"` 폴백 승격을 보류했다. FE 라우트 신설은 미르코 몫.
- dev 실 payload URL 390/1024 착지+액션 노출 검증은 FE 관여라 이 PR의 BE 파트에서 닫지 못한다 — BE 몫은 "매니페스트 승격 diff CI green"까지.

## 브랜치 관계
S2(story #1952, PR #2247)가 착수 시점엔 develop에 머지되지 않아 S2 브랜치 위에서 작업을 시작했으나, 작업 도중 S2가 develop에 머지됐다(`c6db66f9`). `origin/develop`으로 rebase 완료 — 이 PR은 develop 기준 순수 diff만 포함한다.

## Test plan
- [x] `pytest tests/test_expo_push_ee.py` — 16 passed (신규 `_build_push_data_payload` pure-function 테스트 7개 + 배선 통합 테스트 1개 포함, TDD RED→GREEN)
- [x] `pytest tests/test_notification_dispatch.py` — 13 passed (신규 project_id 추론/폴백·story_id/sprint_id passthrough 테스트 4개 포함)
- [x] `pytest tests/test_deeplink_manifest_contract.py tests/test_deeplink_manifest_endpoint.py` — 14+4 passed (AC1/AC2/AC3 계약 CI 전부 green)
- [x] 전체 백엔드 스위트(`pytest tests/ -k "not realdb"`): 3538 passed / 8 failed(전부 로컬 `.mcp.json`/MCP 인스턴스 환경 의존 — 이 PR 무관, pre-existing) / 322 skipped
- [ ] dev 실 payload URL 착지 확인 — FE(미르코) 대기

🤖 Generated with [Claude Code](https://claude.com/claude-code)