### PR TITLE
feat(gate): create_gate() 잔여 3개 호출부 project_id threading (story #1968)

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -17,6 +17,7 @@ from app.routers.agent_gateway import wake_agent
 from app.services.gate_service import (
     create_gate,
     hold_gate,
+    resolve_work_item_project_id,
     transition_gate,
     unhold_gate,
     void_gate,
@@ -177,6 +178,11 @@ async def create_gate_endpoint(
             status_code=403,
             detail="doc 결재 게이트는 doc 상신 경로로만 생성됩니다 (직접 생성 불가).",
         )
+    # story #1968: 제네릭 게이트 생성은 story/doc/task 등 work_item 객체를 로드하지 않으므로
+    # (client가 work_item_id/work_item_type만 보냄) resolve_work_item_project_id()로 신규 조회.
+    project_id = await resolve_work_item_project_id(
+        session, org_id, body.work_item_type, body.work_item_id,
+    )
     gate = await create_gate(
         session=session,
         org_id=org_id,
@@ -186,6 +192,7 @@ async def create_gate_endpoint(
         member_id=body.member_id,
         role_id=body.role_id,
         neutral_facts=body.neutral_facts,
+        project_id=project_id,
     )
     await session.commit()
     return GateResponse.model_validate(gate)

--- a/backend/app/schemas/deeplink_manifest.py
+++ b/backend/app/schemas/deeplink_manifest.py
@@ -192,10 +192,16 @@ class DeepLinkPayloadFields(BaseModel):
         description=(
             "push data payload에 project_id가 포함되는가. story #1953 갱신: 대부분의 "
             "알림 타입은 project-scoped 엔티티(story/epic/doc/sprint/hypothesis 등, "
-            "project_id NOT NULL 컬럼)에서 발화돼 True. 예외(False로 남은 엔트리) = "
-            "`gate.pending_approval`·`gate_overridden` — 이 둘은 여러 gate_type/여러 "
-            "호출부(create_gate 공용 chokepoint, 일부는 org-level work_item)에 걸쳐 있어 "
-            "project_id가 항상 보장되지 않는다(엔트리별 주석 참고)."
+            "project_id NOT NULL 컬럼)에서 발화돼 True. story #1968(P1a-S3 잔여) 갱신: "
+            "`gate.pending_approval`·`gate_overridden`도 True로 승격(31/33→33/33) — "
+            "create_gate() 7개 호출부 전부(routers/gates.py 제네릭 생성·"
+            "workflow_line_config.py·merge_verdict_gate.py 잔여 3곳 포함)가 이제 "
+            "work_item_type별로 project_id를 조회/재사용해 넘기고, override_gate()의 "
+            "gate_overridden 알림도 sr(활성 step_run)=None 폴백 시 동일 로직"
+            "(gate_service.resolve_work_item_project_id)으로 조회한다. 유일한 구조적 "
+            "None 케이스(workflow_line_config의 org-level 'wf_line_version' — project "
+            "자체가 없는 org 전체 config)는 실패/미해결이 아니라 project-scoped가 아니라는 "
+            "정직한 값이다(엔트리별 주석 참고)."
         ),
     )
     required_payload: list[str] = Field(
@@ -335,14 +341,17 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
                 type="gate.pending_approval", target="gate_detail", parent_tab=ParentTab.approvals,
                 target_promotion_pending=True,
             ),
-            # story #1953(P1a-S3): org_id는 전 타입 공통으로 이제 항상 포함(True). project_id는
-            # create_gate()가 여러 gate_type(merge/doc_approval/artifact_canonicalize/
-            # workflow_config_publish/직접생성 등) 공용 chokepoint라 호출부별로 project_id를
-            # 아는 경우(artifact_canonicalize·doc_approval·parallel merge 등)에만 실어 보내고,
-            # 모르는 호출부(범용 gates.py 직접생성·workflow_line_config 등 org-level work_item)는
-            # 그대로 생략된다 — 전부 보장은 아니라서 False로 정직하게 유지(실측 불일치 방지).
+            # story #1953(P1a-S3): org_id는 전 타입 공통으로 이제 항상 포함(True).
+            # story #1968(P1a-S3 잔여): project_id도 True로 승격 — create_gate()가 여러
+            # gate_type(merge/doc_approval/artifact_canonicalize/workflow_config_publish/
+            # 직접생성 등) 공용 chokepoint인 건 여전하지만, 이제 호출부 7곳 전부가 project_id를
+            # 싣는다 — 이미 로드된 엔티티에서 재사용(artifact_canonicalize·doc_approval·
+            # loop_decision·parallel merge)하거나, work_item_id만 있으면
+            # gate_service.resolve_work_item_project_id()로 신규 조회(범용 gates.py 직접생성·
+            # merge 게이트). workflow_line_config(org-level 'wf_line_version')만 구조적으로
+            # None일 수 있다(project 자체가 없는 org 전체 config — 미해결 아님).
             payload=DeepLinkPayloadFields(
-                org_id_included=True, project_id_included=False,
+                org_id_included=True, project_id_included=True,
                 required_payload=["reference_id"],
             ),
         ),
@@ -401,11 +410,12 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
                 counts_toward_queue_badge=False,
                 target_promotion_pending=True,  # gate_detail 공통 사유 — 위 결재함 섹션 헤더 주석 참고.
             ),
-            # story #1953: project_id는 라인 step_run(sr)이 해소될 때만 실림(gate_service.py
-            # override_gate — 단일 gate엔 활성 step_run이 없을 수 있어 sr=None 케이스 존재) →
-            # 항상 보장은 아니라 False.
+            # story #1953: project_id는 라인 step_run(sr)이 해소될 때 그 값(신규 쿼리 0).
+            # story #1968(P1a-S3 잔여): sr=None 케이스(단일 gate·활성 step_run 없음)도
+            # gate_service.resolve_work_item_project_id(gate.work_item_type/work_item_id)로
+            # 폴백 조회하도록 override_gate()를 갱신 — True로 승격.
             payload=DeepLinkPayloadFields(
-                org_id_included=True, project_id_included=False,
+                org_id_included=True, project_id_included=True,
                 required_payload=["reference_id"],
             ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -23,7 +23,9 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.doc import Doc
 from app.models.gate import Gate, is_valid_transition
+from app.models.pm import Story, Task
 from app.models.workflow_line import (
     WorkflowLineStepApproval,
     WorkflowLineStepRun,
@@ -69,6 +71,39 @@ _DISPOSITION_TO_STATUS: dict[str, str] = {
     "deny": "rejected",
 }
 
+async def resolve_work_item_project_id(
+    session: AsyncSession, org_id: uuid.UUID, work_item_type: str, work_item_id: uuid.UUID,
+) -> uuid.UUID | None:
+    """story #1968: work_item_type/work_item_id → project_id 타입별 조회(신규 쿼리).
+
+    ⚠️호출 전 먼저 확인: 그 함수 스코프에 이미 로드된 엔티티(story/doc/task/loop/artifact 등
+    객체)가 있으면 이 헬퍼를 쓰지 말고 그 객체의 ``.project_id``를 직접 재사용할 것(신규 쿼리
+    최소 원칙 — doc.py/loop.py/visual_artifacts.py/workflow_parallel_approval.py가 이미 이렇게
+    한다). 이 헬퍼는 work_item_id(uuid)만 있고 엔티티가 아직 로드 안 된 호출부 전용
+    (routers/gates.py 제네릭 생성 엔드포인트·merge_verdict_gate.py evaluate_merge_gate)과
+    override_gate()의 sr(step_run)=None 폴백용.
+
+    Story/Doc.project_id는 NOT NULL이라 row가 있으면 항상 값이 있다. Task는 project_id 컬럼이
+    없어 story JOIN. 미지원/미인식 work_item_type(예: workflow_line_config의 org-level
+    'wf_line_version' — 실제로 project-무관일 수 있음)은 None(best-effort — silent 실패가
+    아니라 구조적으로 project-scoped가 아닐 수 있다는 정직한 신호)."""
+    if work_item_type == "story":
+        return (await session.execute(
+            select(Story.project_id).where(Story.id == work_item_id, Story.org_id == org_id)
+        )).scalar_one_or_none()
+    if work_item_type == "task":
+        return (await session.execute(
+            select(Story.project_id)
+            .join(Task, Task.story_id == Story.id)
+            .where(Task.id == work_item_id, Task.org_id == org_id)
+        )).scalar_one_or_none()
+    if work_item_type == "doc":
+        return (await session.execute(
+            select(Doc.project_id).where(Doc.id == work_item_id, Doc.org_id == org_id)
+        )).scalar_one_or_none()
+    return None
+
+
 # doc-gate v2 갭1: deliberate 인간 결재 gate — org allow_auto/deny posture 무관하게 항상 manual(pending).
 # disposition auto-pass/auto-deny 제외(인간 deliberation 이 정책 자동결정보다 우선).
 # 'loop_decision'(E-LOOP-LEDGER S5): variant 선택도 동일 이유로 항상 human pending — GATE_TYPES에도
@@ -92,12 +127,15 @@ async def create_gate(
 ) -> Gate:
     """config 기반 게이트 생성 (멱등: 이미 있으면 기존 반환).
 
-    project_id: story #1953(P1a-S3) — gate.pending_approval 알림 payload의 project_id 보강용
-    (선택적). create_gate()는 gate_type/work_item_type을 가리지 않는 공용 chokepoint라
-    work_item_type별 project_id 해소 로직을 여기 내장하지 않는다 — 호출부가 이미 알고 있으면
-    (artifact_canonicalize·doc_approval·parallel merge 등) 그대로 넘기고, 모르는 호출부(범용
-    gates.py 직접생성·workflow_line_config 등 org-level work_item)는 생략(None)해도 무방하다
-    (신규 조회 강제 없음 — 매니페스트 project_id_included=False로 이 부분성을 정직하게 표시).
+    project_id: story #1953(P1a-S3)이 처음 배선·story #1968(P1a-S3 잔여)이 완성 — gate.pending_
+    approval 알림 payload의 project_id 보강용(선택적). create_gate()는 gate_type/work_item_type을
+    가리지 않는 공용 chokepoint라 work_item_type별 project_id 해소 로직을 여기 내장하지 않는다 —
+    호출부가 이미 로드된 엔티티에서 알고 있으면(artifact_canonicalize·doc_approval·loop_decision·
+    parallel merge 등) 그대로 넘기고, work_item_id만 갖고 엔티티가 없는 호출부(범용 gates.py
+    직접생성·merge 게이트)는 ``resolve_work_item_project_id()``로 조회해 넘긴다(story #1968).
+    workflow_line_config(wf_line_version)처럼 진짜 org-level(project 무관)일 수 있는 work_item은
+    ``version.project_id``(nullable)를 그대로 넘겨 None이 나올 수 있다 — 이건 미해결이 아니라
+    구조적으로 project-scoped가 아니라는 정직한 값이다.
     """
     # 멱등: 이미 존재하면 기존 반환
     existing_r = await session.execute(
@@ -772,10 +810,16 @@ async def override_gate(
                 title="게이트가 강제 결정되었습니다",
                 body=f"owner 가 게이트를 {decision} 로 강제 결정했습니다: {reason}",
                 reference_type="gate", reference_id=gate_id,
-                # story #1953: sr(라인 step_run)이 해소된 경우에만 project_id를 안다(단일
-                # gate엔 활성 step_run이 없을 수 있어 sr=None 케이스 존재 — 그래서 매니페스트
-                # project_id_included=False로 정직하게 유지·여기선 best-effort로만 실음).
-                source_project_id=(sr.project_id if sr is not None else None),
+                # story #1953: sr(라인 step_run)이 해소된 경우 project_id는 그 값 그대로(신규
+                # 쿼리 0). story #1968: sr=None(단일 gate·활성 step_run 없음) 케이스는
+                # resolve_work_item_project_id()로 gate.work_item_type/work_item_id에서
+                # 폴백 조회 — best-effort(실패해도 이 알림 전체가 try 블록 안이라 비중단).
+                source_project_id=(
+                    sr.project_id if sr is not None
+                    else await resolve_work_item_project_id(
+                        session, org_id, gate.work_item_type, gate.work_item_id,
+                    )
+                ),
             )
         except Exception:  # noqa: BLE001 — notification 실패는 비중단(override 자체는 성공).
             pass

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -22,7 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.models.participation import ParticipationRole
 from app.services.gate_resolver import resolve_disposition
-from app.services.gate_service import create_gate
+from app.services.gate_service import create_gate, resolve_work_item_project_id
 from app.services.trust_score import compute_member_trust_scores
 from app.services.verdict_capture import (
     capture_pr_ci_verdict,
@@ -300,6 +300,9 @@ async def evaluate_merge_gate(
     self_report_only = bool(capture.get("skipped_reason")) or not capture.get("recorded")
 
     # 3. 정책 disposition 아티팩트 gate row(Cage·AC⑥). create_gate가 disposition→status 설정·멱등.
+    # story #1968: 이 함수는 story_id(uuid)만 갖고 Story 객체를 로드하지 않으므로(participation/
+    # verdict/trust 경로 전부 story_id만 소비) resolve_work_item_project_id()로 신규 조회.
+    project_id = await resolve_work_item_project_id(session, org_id, "story", story_id)
     gate = await create_gate(
         session,
         org_id,
@@ -308,6 +311,7 @@ async def evaluate_merge_gate(
         MERGE_GATE_TYPE,
         member_id,
         role_id,
+        project_id=project_id,
         neutral_facts={
             "ci_result": ci,
             "pr_result": pr,

--- a/backend/app/services/workflow_line_config.py
+++ b/backend/app/services/workflow_line_config.py
@@ -291,6 +291,11 @@ async def request_publish(
             "requested_by_member_id": str(member_id),
             "entity_type": version.entity_type,
         },
+        # story #1968: version은 이미 로드된 엔티티(request_publish 파라미터) — 신규 쿼리
+        # 없이 그대로 재사용. project-level override면 값이 있고, org-level config면
+        # 구조적으로 None(project 무관 — 미해결 아님, workflow_line_config는 org/project
+        # 양쪽에서 config를 가질 수 있는 유일한 create_gate 호출부).
+        project_id=version.project_id,
     )
     version.review_gate_id = gate.id
     await session.flush()

--- a/backend/tests/test_1968_gate_project_id_threading.py
+++ b/backend/tests/test_1968_gate_project_id_threading.py
@@ -1,0 +1,364 @@
+"""story #1968 (P1a-S3 잔여): create_gate() 3개 호출부 project_id threading + override_gate
+sr=None 폴백 — gate.pending_approval/gate_overridden 딥링크 매니페스트 project_id_included
+31/33 → 33/33 승격 근거.
+
+배경: `Gate` 모델 자체엔 project_id 컬럼이 없다(org_id + work_item_id/work_item_type 폴리모픽
+참조뿐). `create_gate()` 7개 호출부 중 4개(visual_artifacts.py·doc.py·
+workflow_parallel_approval.py·loop.py)는 이미 project_id를 threading했고, 나머지 3개
+(routers/gates.py 제네릭 생성·workflow_line_config.py·merge_verdict_gate.py)가 미threading
+이었다 — 이 스토리가 마무리한다. `override_gate()`(gate_overridden 알림)의 sr(활성
+step_run)=None 폴백도 `gate_service.resolve_work_item_project_id()`로 project_id 0이었던
+갭을 닫는다.
+
+테스트 구성:
+- resolve_work_item_project_id 타입별 분기(story/task/doc/미인식) — mocked session, 신규 쿼리
+  없이 검증(요청 순수 로직).
+- routers/gates.py 제네릭 create_gate_endpoint — mocked session, project_id 조회→threading 확인.
+- merge_verdict_gate.evaluate_merge_gate — mocked cage 의존성, project_id threading 확인.
+- workflow_line_config.request_publish — 실 Postgres(org-level None·project-level 값 둘 다).
+- gate_service.override_gate — 실 Postgres, sr=None 폴백이 실제로 project_id를 조회하는지 확인.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# 이 파일은 workflow_line_config/override_gate 실 DB 테스트에서 Base.metadata.create_all을
+# 호출한다 — conftest.py의 AST 가드(story 8236bbc3)가 마커 누락을 즉시 UsageError로 표면화한다.
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _scalar_result(value):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = value
+    return r
+
+
+# ── resolve_work_item_project_id: 타입별 분기 (mocked session — 신규 쿼리 최소 원칙 검증) ──
+
+
+@pytest.mark.anyio
+async def test_resolve_project_id_story_type():
+    from app.services.gate_service import resolve_work_item_project_id
+
+    org_id, story_id, project_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_scalar_result(project_id))
+
+    result = await resolve_work_item_project_id(session, org_id, "story", story_id)
+
+    assert result == project_id
+    session.execute.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_resolve_project_id_doc_type():
+    from app.services.gate_service import resolve_work_item_project_id
+
+    org_id, doc_id, project_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_scalar_result(project_id))
+
+    result = await resolve_work_item_project_id(session, org_id, "doc", doc_id)
+
+    assert result == project_id
+    session.execute.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_resolve_project_id_task_type_joins_story():
+    """Task 는 project_id 컬럼이 없어(story_id만 보유) Story JOIN 경유로 조회한다."""
+    from app.services.gate_service import resolve_work_item_project_id
+
+    org_id, task_id, project_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_scalar_result(project_id))
+
+    result = await resolve_work_item_project_id(session, org_id, "task", task_id)
+
+    assert result == project_id
+    session.execute.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_resolve_project_id_unknown_type_returns_none_no_query():
+    """미인식 work_item_type(예: 조직-레벨 'wf_line_version')은 신규 쿼리 없이 즉시 None —
+    silent 실패가 아니라 구조적으로 project-scoped 가 아닐 수 있다는 정직한 신호."""
+    from app.services.gate_service import resolve_work_item_project_id
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=AssertionError("미인식 타입은 쿼리하면 안 됨"))
+
+    result = await resolve_work_item_project_id(session, uuid.uuid4(), "wf_line_version", uuid.uuid4())
+
+    assert result is None
+    session.execute.assert_not_awaited()
+
+
+# ── routers/gates.py 제네릭 생성 엔드포인트 ──────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_generic_gate_endpoint_threads_resolved_project_id():
+    """POST /api/v2/gates(work_item_type='story')가 project_id를 조회해 create_gate로
+    넘겨야 한다(story #1968 스코프①)."""
+    from app.routers import gates as gates_mod
+    from app.routers.gates import GateCreateRequest, create_gate_endpoint
+
+    org_id, work_item_id, project_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    session = AsyncMock()
+    session.commit = AsyncMock()
+    gate = SimpleNamespace(id=uuid.uuid4(), status="pending")
+    body = GateCreateRequest(
+        work_item_id=work_item_id, work_item_type="story", gate_type="merge",
+        member_id=uuid.uuid4(), role_id=uuid.uuid4(),
+    )
+
+    with patch.object(gates_mod, "resolve_work_item_project_id",
+                       AsyncMock(return_value=project_id)) as resolve_spy, \
+         patch.object(gates_mod, "create_gate", AsyncMock(return_value=gate)) as create_spy, \
+         patch.object(gates_mod.GateResponse, "model_validate", lambda g: "OK"):
+        await create_gate_endpoint(body=body, session=session, org_id=org_id, _auth=SimpleNamespace())
+
+    resolve_spy.assert_awaited_once_with(session, org_id, "story", work_item_id)
+    assert create_spy.await_args.kwargs["project_id"] == project_id
+
+
+@pytest.mark.anyio
+async def test_generic_gate_endpoint_unresolvable_type_passes_none():
+    """미인식 work_item_type이면 project_id=None 그대로 넘어간다(크래시 아님 — best-effort)."""
+    from app.routers import gates as gates_mod
+    from app.routers.gates import GateCreateRequest, create_gate_endpoint
+
+    org_id, work_item_id = uuid.uuid4(), uuid.uuid4()
+    session = AsyncMock()
+    session.commit = AsyncMock()
+    gate = SimpleNamespace(id=uuid.uuid4(), status="pending")
+    body = GateCreateRequest(
+        work_item_id=work_item_id, work_item_type="mystery_type", gate_type="qa",
+        member_id=uuid.uuid4(), role_id=uuid.uuid4(),
+    )
+
+    with patch.object(gates_mod, "resolve_work_item_project_id",
+                       AsyncMock(return_value=None)), \
+         patch.object(gates_mod, "create_gate", AsyncMock(return_value=gate)) as create_spy, \
+         patch.object(gates_mod.GateResponse, "model_validate", lambda g: "OK"):
+        await create_gate_endpoint(body=body, session=session, org_id=org_id, _auth=SimpleNamespace())
+
+    assert create_spy.await_args.kwargs["project_id"] is None
+
+
+# ── merge_verdict_gate.py evaluate_merge_gate ────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_merge_gate_threads_resolved_project_id():
+    """evaluate_merge_gate는 story_id(uuid)만 갖고 있어(Story 객체 미로드)
+    resolve_work_item_project_id("story", story_id)로 신규 조회 후 create_gate에 넘겨야 한다."""
+    from app.services import merge_verdict_gate as mvg
+
+    org_id, story_id, project_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    session = AsyncMock()
+    part = SimpleNamespace(member_id=uuid.uuid4(), role_id=uuid.uuid4())
+    gate = SimpleNamespace(id=uuid.uuid4(), status="auto_passed")
+
+    with patch.object(mvg, "resolve_implementation_participation", AsyncMock(return_value=part)), \
+         patch.object(mvg, "_role_key", AsyncMock(return_value="implementation")), \
+         patch.object(mvg, "capture_pr_ci_verdict",
+                       AsyncMock(return_value={"recorded": ["pr"], "skipped_reason": None})), \
+         patch.object(mvg, "compute_member_trust_scores",
+                       AsyncMock(return_value={"scores": [{
+                           "role_key": "implementation", "hit": 90, "resolved": 100,
+                           "pending": 0, "hit_rate": 0.9}]})), \
+         patch.object(mvg, "resolve_work_item_project_id",
+                       AsyncMock(return_value=project_id)) as resolve_spy, \
+         patch.object(mvg, "create_gate", AsyncMock(return_value=gate)) as create_spy:
+        await mvg.evaluate_merge_gate(
+            session, org_id, story_id, pr_number=1, repo="o/r", ci_result="pass",
+        )
+
+    resolve_spy.assert_awaited_once_with(session, org_id, "story", story_id)
+    assert create_spy.await_args.kwargs["project_id"] == project_id
+
+
+# ── workflow_line_config.py request_publish (실 Postgres) ───────────────────────
+
+
+def _clean_wf_config() -> dict:
+    return {
+        "name": "line",
+        "steps": [{
+            "step_key": "s", "step_type": "merge-gate", "from_status": "a", "to_status": "b",
+            "step_order": 1,
+            "approval_policy": {"approvers": ["role:po"], "self_approval": "forbid"},
+            "assignee_policy": {"role": "po", "deputy": "role:lead"},
+            "routing_rules": [{"mode": "all", "conditions": [
+                {"field": "trust_score", "op": "gte", "value": 0.8}], "decision": "auto_route"}],
+            "sla_policy": {"timeout_minutes": 60, "on_timeout": "escalate"},
+        }],
+    }
+
+
+async def _wfc_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401 — 전 모델 메타데이터 로드
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_workflow_line_config_project_level_threads_version_project_id():
+    """project-level workflow line config publish gate는 version.project_id(이미 로드된
+    엔티티 — 신규 쿼리 0)가 create_gate로 그대로 실린다."""
+    from app.models.participation import ParticipationRole
+    from app.services import workflow_line_config as wlc_mod
+    from app.services.workflow_line_config import create_draft, request_publish
+
+    engine, Session = await _wfc_session()
+    org_id, project_id, member = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    async with Session() as session:
+        session.add(ParticipationRole(
+            id=uuid.uuid4(), org_id=org_id, key="default", label="Default", is_default=True))
+        await session.flush()
+        version = await create_draft(session, org_id, project_id, "story", _clean_wf_config(), member)
+
+        captured: dict = {}
+        real_create_gate = wlc_mod.create_gate
+
+        async def _spy(*a, **k):
+            captured.update(k)
+            return await real_create_gate(*a, **k)
+
+        with patch.object(wlc_mod, "create_gate", side_effect=_spy):
+            await request_publish(session, org_id, version, member)
+
+        assert captured.get("project_id") == project_id
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_workflow_line_config_org_level_version_project_id_is_none():
+    """org-level workflow line config(project_id=None)는 None 그대로 threading된다 — 이건
+    미해결 갭이 아니라 구조적으로 project 무관(org 전체 config)이라는 정직한 값이다."""
+    from app.models.participation import ParticipationRole
+    from app.services import workflow_line_config as wlc_mod
+    from app.services.workflow_line_config import create_draft, request_publish
+
+    engine, Session = await _wfc_session()
+    org_id, member = uuid.uuid4(), uuid.uuid4()
+    async with Session() as session:
+        session.add(ParticipationRole(
+            id=uuid.uuid4(), org_id=org_id, key="default", label="Default", is_default=True))
+        await session.flush()
+        version = await create_draft(session, org_id, None, "story", _clean_wf_config(), member)
+
+        captured: dict = {}
+        real_create_gate = wlc_mod.create_gate
+
+        async def _spy(*a, **k):
+            captured.update(k)
+            return await real_create_gate(*a, **k)
+
+        with patch.object(wlc_mod, "create_gate", side_effect=_spy):
+            await request_publish(session, org_id, version, member)
+
+        assert "project_id" in captured and captured["project_id"] is None
+    await engine.dispose()
+
+
+# ── gate_service.py override_gate — sr(활성 step_run)=None 폴백 (실 Postgres) ───────
+
+
+async def _override_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.participation  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_override_gate_no_active_step_run_falls_back_to_resolved_project_id():
+    """story #1968: override_gate의 gate_overridden 알림이 sr(활성 step_run)=None이어도
+    gate.work_item_type/work_item_id로 project_id를 조회해 dispatch_notification에 싣는다
+    (이전엔 sr=None → source_project_id=None 고정 갭 — story #1953 주석 참고)."""
+    from app.models.gate import Gate
+    from app.models.pm import Story
+    from app.models.project import Project
+    from app.models.workflow_line import WorkflowLineStepApproval
+    from app.services.gate_service import override_gate
+
+    engine, Session = await _override_session()
+    org_id, project_id, story_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    requester, approver, owner = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+
+    async with Session() as session:
+        session.add(Project(id=project_id, org_id=org_id, name="p"))
+        await session.flush()
+        session.add(Story(id=story_id, org_id=org_id, project_id=project_id, title="s"))
+        await session.flush()
+        gate = Gate(id=uuid.uuid4(), org_id=org_id, work_item_id=story_id,
+                     work_item_type="story", gate_type="merge", status="pending")
+        session.add(gate)
+        await session.flush()
+        # 의도적으로 WorkflowLineStepRun을 만들지 않는다 — find_active_step_run_for_gate가
+        # 항상 None을 반환하는 상황(활성 step_run 없음)을 재현한다. step_run_id는 FK 제약이
+        # 없는 평문 UUID 컬럼이라 존재하지 않는 값을 넣어도 approver row는 유효하다.
+        session.add(WorkflowLineStepApproval(
+            org_id=org_id, project_id=project_id, step_run_id=uuid.uuid4(), gate_id=gate.id,
+            approval_group_id=uuid.uuid4(), approver_member_id=approver, approver_member_type="human",
+            kind="approver", blocking=True, status="pending", requested_by_member_id=requester,
+        ))
+        await session.commit()
+
+        captured: dict = {}
+
+        async def _capture(*a, **k):
+            captured.update(k)
+
+        with patch(
+            "app.services.notification_dispatch.dispatch_notification",
+            AsyncMock(side_effect=_capture),
+        ):
+            result = await override_gate(session, org_id, gate.id, owner, "approved", "강제 승인")
+            await session.commit()
+
+        assert result.status == "approved"
+        assert captured.get("event_type") == "gate_overridden"
+        assert captured.get("source_project_id") == project_id
+    await engine.dispose()

--- a/backend/tests/test_merge_verdict_gate.py
+++ b/backend/tests/test_merge_verdict_gate.py
@@ -136,7 +136,8 @@ def test_wilson_lower_bound_sample_aware():
 
 # ── evaluate_merge_gate 오케스트레이션 (Cage 합성·AC⑥) ──────────────────────────
 
-def _patch_cage(*, gate_status="auto_passed", trust_scores=None, capture=None, participation=True):
+def _patch_cage(*, gate_status="auto_passed", trust_scores=None, capture=None, participation=True,
+                 project_id=None):
     part = SimpleNamespace(member_id=uuid.uuid4(), role_id=uuid.uuid4()) if participation else None
     gate = SimpleNamespace(id=uuid.uuid4(), status=gate_status)
     ctx = [
@@ -148,6 +149,10 @@ def _patch_cage(*, gate_status="auto_passed", trust_scores=None, capture=None, p
                      AsyncMock(return_value=trust_scores or {"scores": [{
                          "role_key": "implementation", "clean_pass_rate": 0.9,
                          "hit": 90, "resolved": 100, "pending": 0, "hit_rate": 0.9}]})),
+        # story #1968: evaluate_merge_gate이 story_id만 갖고 있어(Story 객체 미로드)
+        # resolve_work_item_project_id()로 project_id를 신규 조회 — 실 DB 없는 단위테스트라 mock.
+        patch.object(mod, "resolve_work_item_project_id",
+                     AsyncMock(return_value=project_id if project_id is not None else uuid.uuid4())),
         patch.object(mod, "create_gate", AsyncMock(return_value=gate)),
     ]
     return ctx, gate
@@ -252,6 +257,7 @@ async def test_trust_computed_before_capture_records():
          patch.object(mod, "_role_key", AsyncMock(return_value="implementation")), \
          patch.object(mod, "compute_member_trust_scores", side_effect=_trust), \
          patch.object(mod, "capture_pr_ci_verdict", side_effect=_capture), \
+         patch.object(mod, "resolve_work_item_project_id", AsyncMock(return_value=uuid.uuid4())), \
          patch.object(mod, "create_gate", AsyncMock(return_value=SimpleNamespace(id=uuid.uuid4(), status="auto_passed"))):
         await evaluate_merge_gate(AsyncMock(), uuid.uuid4(), uuid.uuid4(), pr_number=1, repo="o/r", ci_result="pass")
 


### PR DESCRIPTION
## Summary
- story #1953(P1a-S3)이 배선한 gate 알림 payload project_id 보강의 잔여 3개 호출부를 마무리한다.
- `create_gate()` 7개 호출부 중 미threading이던 `routers/gates.py`(제네릭 생성)·`workflow_line_config.py`·`merge_verdict_gate.py`가 이제 전부 project_id를 넘긴다.
- `override_gate()`의 `gate_overridden` 알림도 활성 step_run(sr)=None 폴백 시 동일 로직으로 project_id를 조회하도록 갱신.
- 딥링크 매니페스트 Layer2 `gate.pending_approval`·`gate_overridden`의 `project_id_included`를 True로 승격 (31/33 → 33/33).

## 구현
- `backend/app/services/gate_service.py`: 공용 헬퍼 `resolve_work_item_project_id(session, org_id, work_item_type, work_item_id) -> uuid.UUID | None` 신설 — story/doc은 NOT NULL 컬럼 직조회, task는 project_id 컬럼이 없어 Story JOIN, 미인식 타입은 신규 쿼리 없이 즉시 None.
- `backend/app/routers/gates.py`, `backend/app/services/merge_verdict_gate.py`: work_item 엔티티를 로드하지 않는 호출부라 위 헬퍼로 신규 조회 후 `create_gate(project_id=...)`.
- `backend/app/services/workflow_line_config.py`: `request_publish()`가 이미 갖고 있는 `version.project_id`를 그대로 재사용(신규 쿼리 0) — org-level config는 구조적으로 None일 수 있음(미해결 아님).
- `backend/app/services/gate_service.py::override_gate`: `gate_overridden` 알림의 sr=None 폴백을 `resolve_work_item_project_id(gate.work_item_type, gate.work_item_id)`로 보강.
- `backend/app/schemas/deeplink_manifest.py`: 두 엔트리 `project_id_included=True`로 승격 + 근거 주석 갱신.

## Test plan
- [x] `tests/test_deeplink_manifest_contract.py` 14/14 green (Layer2 33/33 확인).
- [x] `tests/test_1968_gate_project_id_threading.py`(신규 10개) — resolve_work_item_project_id 타입별 분기, gates.py 엔드포인트 threading, merge_verdict_gate threading, workflow_line_config org/project-level, override_gate sr=None 폴백(실 Postgres).
- [x] 회귀: `test_merge_verdict_gate.py`·`test_edg_s2_config_governance.py`·`test_edg_s33_override.py`·`test_e_cage_referee_p3_gate_object.py`·`test_gate_can_approve_48f064e5.py` 전부 green — 총 105 passed.
- [x] 뮤테이션 셀프체크: 3개 호출부 + override_gate 폴백 각각 threading을 일부러 제거 → 관련 테스트 RED 확인 → 원복 → 재확인 GREEN.