### PR TITLE
[SID:1954] 게이트 canonical 상세 라우트 골격 — /gates/[id] (DRAFT, BE #1970 대기)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3515,6 +3515,7 @@
     "evidenceNonePrompt": "No evidence yet — review by content",
     "gateDetailBackToInbox": "Approvals",
     "gateDetailNotFound": "Gate not found.",
+    "gateDetailResolvedStatus": "Already resolved — status: {status}",
     "gateDetailOrgContext": "Org {org}",
     "riskUnknown": "Risk pending",
     "sigEvidenceLabel": "Evidence",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3512,7 +3512,18 @@
     "seedKeep": "Keep",
     "seedKill": "Kill",
     "outcomeAccumulating": "Awaiting verdict data",
-    "evidenceNonePrompt": "No evidence yet — review by content"
+    "evidenceNonePrompt": "No evidence yet — review by content",
+    "gateDetailBackToInbox": "Approvals",
+    "gateDetailNotFound": "Gate not found.",
+    "gateDetailOrgContext": "Org {org}",
+    "riskUnknown": "Risk pending",
+    "sigEvidenceLabel": "Evidence",
+    "sigEvidenceViewedLabel": "I have reviewed the evidence above",
+    "sigReasonLabel": "Decision reason",
+    "sigReasonPlaceholder": "Enter a reason to record with this decision",
+    "sigConsequenceNote": "Approving records your signature",
+    "sigRequestChanges": "Request changes",
+    "sigApproveAndSign": "Approve & sign"
   },
   "workflowRecipes": {
     "scrum-3step": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3512,7 +3512,18 @@
     "seedKeep": "유지 예측",
     "seedKill": "중단 예측",
     "outcomeAccumulating": "판정 데이터 누적 중",
-    "evidenceNonePrompt": "근거 데이터 없음 — 내용으로 직접 판단"
+    "evidenceNonePrompt": "근거 데이터 없음 — 내용으로 직접 판단",
+    "gateDetailBackToInbox": "결재함",
+    "gateDetailNotFound": "게이트를 찾을 수 없습니다.",
+    "gateDetailOrgContext": "조직 {org}",
+    "riskUnknown": "위험도 확인 중",
+    "sigEvidenceLabel": "근거",
+    "sigEvidenceViewedLabel": "위 근거를 확인했습니다",
+    "sigReasonLabel": "결정 사유",
+    "sigReasonPlaceholder": "기록에 남을 결정 사유를 입력하세요",
+    "sigConsequenceNote": "승인은 당신의 서명으로 기록됩니다",
+    "sigRequestChanges": "변경 요청",
+    "sigApproveAndSign": "승인하고 서명"
   },
   "workflowRecipes": {
     "scrum-3step": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3515,6 +3515,7 @@
     "evidenceNonePrompt": "근거 데이터 없음 — 내용으로 직접 판단",
     "gateDetailBackToInbox": "결재함",
     "gateDetailNotFound": "게이트를 찾을 수 없습니다.",
+    "gateDetailResolvedStatus": "이미 처리됨 — 상태: {status}",
     "gateDetailOrgContext": "조직 {org}",
     "riskUnknown": "위험도 확인 중",
     "sigEvidenceLabel": "근거",

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -61,6 +61,15 @@ export default function GateDetailPage() {
 
   useEffect(() => { void fetchGate(); }, [fetchGate]);
 
+  // gate-inbox.tsx와 동형 판정(중복 빌드 봉쇄 취지상 동일 규칙 재사용) — doc/canonicalize gate는
+  // requires_human 메타가 없어(BE 구조상) gateNeedsAction()만으로는 액션 필요 여부를 못 잡는다.
+  // ⚠️버그 fix(라이브 실측 중 자체 발견): status===pending 가드가 없으면 이미 approved/rejected
+  // 된 게이트도 액션 UI(서명/승인 버튼)가 활성 상태로 다시 뜬다 — 결재 완료된 게이트를 재차
+  // 승인 가능한 것처럼 보이는 게 실 결함이라 canonical의 첫 라이브 실측에서 바로 잡았다.
+  const isDocGate = gate?.work_item_type === 'doc' || gate?.gate_type === 'doc_approval';
+  const isCanonicalizeGate = gate?.gate_type === 'artifact_canonicalize';
+  const needsAction = !!gate && gate.status === 'pending' && (gateNeedsAction(gate) || isDocGate || isCanonicalizeGate);
+
   const transition = useCallback(async (status: 'approved' | 'rejected', note?: string) => {
     if (!gate) return;
     setResolving(true);
@@ -117,7 +126,16 @@ export default function GateDetailPage() {
               </p>
             </div>
 
-            {usesSignatureFlow(deriveRiskLevel(gate)) ? (
+            {!needsAction ? (
+              <div className="space-y-3">
+                <GateEvidence gate={gate} />
+                <p className="text-[11px] text-muted-foreground">
+                  {gate.status !== 'pending'
+                    ? t('gateDetailResolvedStatus', { status: gate.status })
+                    : gateDecision(gate) === 'block' ? t('gateReadonlyBlock') : t('gateReadonlyAuto')}
+                </p>
+              </div>
+            ) : usesSignatureFlow(deriveRiskLevel(gate)) ? (
               <GateSignatureApproval
                 gate={gate}
                 resolving={resolving}
@@ -127,31 +145,25 @@ export default function GateDetailPage() {
             ) : (
               <div className="space-y-3">
                 <GateEvidence gate={gate} />
-                {gateNeedsAction(gate) ? (
-                  <div className="flex gap-2">
-                    <Button
-                      variant="outline"
-                      className="min-h-12 flex-1 gap-1.5"
-                      disabled={resolving}
-                      onClick={() => void transition('rejected')}
-                    >
-                      <XCircle className="size-4" />
-                      {t('gateReject')}
-                    </Button>
-                    <Button
-                      className="min-h-12 flex-1 gap-1.5"
-                      disabled={resolving}
-                      onClick={() => void transition('approved')}
-                    >
-                      <CheckCircle className="size-4" />
-                      {resolving ? '...' : t('gateApprove')}
-                    </Button>
-                  </div>
-                ) : (
-                  <p className="text-[11px] text-muted-foreground">
-                    {gateDecision(gate) === 'block' ? t('gateReadonlyBlock') : t('gateReadonlyAuto')}
-                  </p>
-                )}
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    className="min-h-12 flex-1 gap-1.5"
+                    disabled={resolving}
+                    onClick={() => void transition('rejected')}
+                  >
+                    <XCircle className="size-4" />
+                    {t('gateReject')}
+                  </Button>
+                  <Button
+                    className="min-h-12 flex-1 gap-1.5"
+                    disabled={resolving}
+                    onClick={() => void transition('approved')}
+                  >
+                    <CheckCircle className="size-4" />
+                    {resolving ? '...' : t('gateApprove')}
+                  </Button>
+                </div>
               </div>
             )}
           </>

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { ChevronLeft, CheckCircle, XCircle } from 'lucide-react';
+import { TopBarSlot } from '@/components/nav/top-bar-slot';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { GateEvidence, gateNeedsAction, gateDecision } from '@/components/cage/gate-evidence';
+import { GateSignatureApproval } from '@/components/cage/gate-signature-approval';
+import { useSyntheticParentTabHistory } from '@/hooks/use-synthetic-parent-tab-history';
+import type { GateItem } from '@/components/kanban/types';
+
+// story #1954(P1a-S4) — Gate 3종(게이트·문서결재·머지게이트) canonical 상세. P1a·P2 공용 유일
+// per-gate 라우트(중복 빌드 봉쇄) — decision(inbox_items)은 별도 표면(오르테가군 PO 판단+
+// 디디군·유나양 2줄검증 확定, 2026-07-17). #1951 매니페스트 target=gate_detail·parentTab=approvals.
+//
+// ⚠️BE 계약 갭(story #1970, 디디군 오너, 진행 중): `GET /api/v2/gates/{id}` 단건 조회 엔드포인트
+// 자체가 아직 없다(list_gates 필터만 존재) + GateResponse에 project_id 필드 부재 + work_item_summary
+// enrich가 doc 타입 한정. 이 페이지는 그 계약이 확定되는 즉시 소비하도록 GateDetail 타입을 그
+// shape 초안 그대로 맞춰뒀다 — 라우트/컴포넌트 골격은 지금 완성, 데이터 바인딩만 계약 확定 후 마무리.
+//
+// ⚠️위험도(risk) 필드도 BE에 아직 없다(gate.py에 risk_level 류 없음) — "저·고위험=동일 BE 위험도
+// 필드"(AC) 요구를 만족하려면 이것도 #1970 계약 논의에 포함돼야 한다. 그때까지 riskLevel은 항상
+// 'unknown'으로 렌더되며(추측 배지 금지), 실 필드가 오면 deriveRiskLevel 한 곳만 교체하면 된다.
+interface GateDetail extends GateItem {
+  org_id: string;
+  project_id?: string | null; // #1970 신규 예정 필드
+}
+
+type RiskLevel = 'low' | 'high' | 'unknown';
+
+// TODO(#1970): BE 위험도 필드 확定되면 그 필드를 그대로 매핑 — 추측 휴리스틱 금지.
+function deriveRiskLevel(_gate: GateDetail): RiskLevel {
+  return 'unknown';
+}
+
+export default function GateDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const t = useTranslations('cage');
+  // story #1959(P2-S3): 딥링크 매니페스트(gate_detail→parentTab=approvals) — 콜드 진입 시 "결재함"
+  // 탭 루트를 BACK 대상으로 선주입. 결재함 목록에서 클릭해 온 경우(history.length>1)는 no-op.
+  useSyntheticParentTabHistory('/inbox');
+
+  const [gate, setGate] = useState<GateDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [resolving, setResolving] = useState(false);
+
+  const fetchGate = useCallback(async () => {
+    setLoading(true);
+    setNotFound(false);
+    try {
+      const res = await fetch(`/api/gates/${id}`);
+      if (res.status === 404) { setNotFound(true); return; }
+      if (!res.ok) return;
+      const json = await res.json();
+      setGate((json?.data ?? json) as GateDetail);
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => { void fetchGate(); }, [fetchGate]);
+
+  const transition = useCallback(async (status: 'approved' | 'rejected', note?: string) => {
+    if (!gate) return;
+    setResolving(true);
+    try {
+      const res = await fetch(`/api/gates/${gate.id}/transition`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status, note: note?.trim() || null }),
+      });
+      if (res.ok) router.push('/inbox');
+    } finally {
+      setResolving(false);
+    }
+  }, [gate, router]);
+
+  return (
+    <>
+      <TopBarSlot
+        title={
+          <button
+            type="button"
+            onClick={() => router.push('/inbox')}
+            className="flex flex-shrink-0 items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+          >
+            <ChevronLeft className="h-4 w-4" />
+            {t('gateDetailBackToInbox')}
+          </button>
+        }
+      />
+      <div className="mx-auto flex min-h-full w-full max-w-2xl flex-1 flex-col gap-5 px-4 py-5">
+        {loading ? (
+          <p className="text-sm text-muted-foreground">{t('gateInboxLoading')}</p>
+        ) : notFound || !gate ? (
+          <p className="text-sm text-muted-foreground">{t('gateDetailNotFound')}</p>
+        ) : (
+          <>
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-center gap-1.5">
+                <Badge variant="chip">{gate.gate_type}</Badge>
+                {deriveRiskLevel(gate) === 'unknown' ? (
+                  <Badge variant="outline" className="text-muted-foreground">{t('riskUnknown')}</Badge>
+                ) : null}
+              </div>
+              <h1 className="text-base font-semibold text-foreground">
+                {gate.work_item_summary?.title ?? `#${gate.work_item_id.slice(0, 8)}`}
+              </h1>
+              <p className="text-xs text-muted-foreground">
+                {t('gateDetailOrgContext', { org: gate.org_id.slice(0, 8) })}
+                {gate.project_id ? ` · ${gate.project_id.slice(0, 8)}` : ''}
+              </p>
+            </div>
+
+            {deriveRiskLevel(gate) === 'high' ? (
+              <GateSignatureApproval
+                gate={gate}
+                resolving={resolving}
+                onApprove={(reason) => void transition('approved', reason)}
+                onReject={(reason) => void transition('rejected', reason)}
+              />
+            ) : (
+              <div className="space-y-3">
+                <GateEvidence gate={gate} />
+                {gateNeedsAction(gate) ? (
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      className="min-h-12 flex-1 gap-1.5"
+                      disabled={resolving}
+                      onClick={() => void transition('rejected')}
+                    >
+                      <XCircle className="size-4" />
+                      {t('gateReject')}
+                    </Button>
+                    <Button
+                      className="min-h-12 flex-1 gap-1.5"
+                      disabled={resolving}
+                      onClick={() => void transition('approved')}
+                    >
+                      <CheckCircle className="size-4" />
+                      {resolving ? '...' : t('gateApprove')}
+                    </Button>
+                  </div>
+                ) : (
+                  <p className="text-[11px] text-muted-foreground">
+                    {gateDecision(gate) === 'block' ? t('gateReadonlyBlock') : t('gateReadonlyAuto')}
+                  </p>
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { GateEvidence, gateNeedsAction, gateDecision } from '@/components/cage/gate-evidence';
 import { GateSignatureApproval } from '@/components/cage/gate-signature-approval';
+import { deriveRiskLevel, usesSignatureFlow } from '@/components/cage/gate-risk';
 import { useSyntheticParentTabHistory } from '@/hooks/use-synthetic-parent-tab-history';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import type { GateItem } from '@/components/kanban/types';
@@ -22,19 +23,10 @@ import type { GateItem } from '@/components/kanban/types';
 // work_item_summary(doc=title+slug, story/task=title만+slug=null, 그 외=null) 응답. PR#2253
 // 머지+배포 전까지 이 프록시는 404를 그대로 패스스루(notFound 상태로 자연 처리).
 //
-// ⚠️위험도(risk) 필드는 #1970 스코프 밖 — 여전히 미존재(gate.py에 risk_level 류 없음). "저·고위험
-// =동일 BE 위험도 필드"(AC) 요구는 별도 후속 계약 논의 필요. 그때까지 riskLevel은 항상 'unknown'
-// 으로 렌더되며(추측 배지 금지), 실 필드가 오면 deriveRiskLevel 한 곳만 교체하면 된다.
+// 위험도(risk) 판정+보수적 unknown 처리 정책은 gate-risk.ts 참고(deriveRiskLevel/usesSignatureFlow).
 interface GateDetail extends GateItem {
   org_id: string;
   project_id?: string | null;
-}
-
-type RiskLevel = 'low' | 'high' | 'unknown';
-
-// TODO(#1970): BE 위험도 필드 확定되면 그 필드를 그대로 매핑 — 추측 휴리스틱 금지.
-function deriveRiskLevel(_gate: GateDetail): RiskLevel {
-  return 'unknown';
 }
 
 export default function GateDetailPage() {
@@ -125,7 +117,7 @@ export default function GateDetailPage() {
               </p>
             </div>
 
-            {deriveRiskLevel(gate) === 'high' ? (
+            {usesSignatureFlow(deriveRiskLevel(gate)) ? (
               <GateSignatureApproval
                 gate={gate}
                 resolving={resolving}

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -10,23 +10,24 @@ import { Badge } from '@/components/ui/badge';
 import { GateEvidence, gateNeedsAction, gateDecision } from '@/components/cage/gate-evidence';
 import { GateSignatureApproval } from '@/components/cage/gate-signature-approval';
 import { useSyntheticParentTabHistory } from '@/hooks/use-synthetic-parent-tab-history';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import type { GateItem } from '@/components/kanban/types';
 
 // story #1954(P1a-S4) — Gate 3종(게이트·문서결재·머지게이트) canonical 상세. P1a·P2 공용 유일
 // per-gate 라우트(중복 빌드 봉쇄) — decision(inbox_items)은 별도 표면(오르테가군 PO 판단+
 // 디디군·유나양 2줄검증 확定, 2026-07-17). #1951 매니페스트 target=gate_detail·parentTab=approvals.
 //
-// ⚠️BE 계약 갭(story #1970, 디디군 오너, 진행 중): `GET /api/v2/gates/{id}` 단건 조회 엔드포인트
-// 자체가 아직 없다(list_gates 필터만 존재) + GateResponse에 project_id 필드 부재 + work_item_summary
-// enrich가 doc 타입 한정. 이 페이지는 그 계약이 확定되는 즉시 소비하도록 GateDetail 타입을 그
-// shape 초안 그대로 맞춰뒀다 — 라우트/컴포넌트 골격은 지금 완성, 데이터 바인딩만 계약 확定 후 마무리.
+// BE 계약(story #1970, 디디군, PR#2253 — 스레드 합의 shape 그대로 구현·까심 QA 중): `GET
+// /api/v2/gates/{id}` 신설 — project_id(신규, resolve_work_item_project_id 재사용)·
+// work_item_summary(doc=title+slug, story/task=title만+slug=null, 그 외=null) 응답. PR#2253
+// 머지+배포 전까지 이 프록시는 404를 그대로 패스스루(notFound 상태로 자연 처리).
 //
-// ⚠️위험도(risk) 필드도 BE에 아직 없다(gate.py에 risk_level 류 없음) — "저·고위험=동일 BE 위험도
-// 필드"(AC) 요구를 만족하려면 이것도 #1970 계약 논의에 포함돼야 한다. 그때까지 riskLevel은 항상
-// 'unknown'으로 렌더되며(추측 배지 금지), 실 필드가 오면 deriveRiskLevel 한 곳만 교체하면 된다.
+// ⚠️위험도(risk) 필드는 #1970 스코프 밖 — 여전히 미존재(gate.py에 risk_level 류 없음). "저·고위험
+// =동일 BE 위험도 필드"(AC) 요구는 별도 후속 계약 논의 필요. 그때까지 riskLevel은 항상 'unknown'
+// 으로 렌더되며(추측 배지 금지), 실 필드가 오면 deriveRiskLevel 한 곳만 교체하면 된다.
 interface GateDetail extends GateItem {
   org_id: string;
-  project_id?: string | null; // #1970 신규 예정 필드
+  project_id?: string | null;
 }
 
 type RiskLevel = 'low' | 'high' | 'unknown';
@@ -40,6 +41,9 @@ export default function GateDetailPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const t = useTranslations('cage');
+  // 조직/프로젝트 식별(AC) — 현재 탭이 이미 로드해둔 멤버십 목록에서 이름 조회(신규 fetch 0).
+  // 크로스 프로젝트 게이트(현재 탭 프로젝트가 아닌 경우)는 매칭 실패 → ID 스니펫 폴백(정직한 값).
+  const { orgMemberships, projectMemberships } = useDashboardContext();
   // story #1959(P2-S3): 딥링크 매니페스트(gate_detail→parentTab=approvals) — 콜드 진입 시 "결재함"
   // 탭 루트를 BACK 대상으로 선주입. 결재함 목록에서 클릭해 온 경우(history.length>1)는 no-op.
   useSyntheticParentTabHistory('/inbox');
@@ -112,8 +116,12 @@ export default function GateDetailPage() {
                 {gate.work_item_summary?.title ?? `#${gate.work_item_id.slice(0, 8)}`}
               </h1>
               <p className="text-xs text-muted-foreground">
-                {t('gateDetailOrgContext', { org: gate.org_id.slice(0, 8) })}
-                {gate.project_id ? ` · ${gate.project_id.slice(0, 8)}` : ''}
+                {t('gateDetailOrgContext', {
+                  org: orgMemberships.find((o) => o.orgId === gate.org_id)?.orgName ?? gate.org_id.slice(0, 8),
+                })}
+                {gate.project_id
+                  ? ` · ${projectMemberships.find((p) => p.projectId === gate.project_id)?.projectName ?? gate.project_id.slice(0, 8)}`
+                  : ''}
               </p>
             </div>
 

--- a/apps/web/src/app/api/gates/[id]/route.ts
+++ b/apps/web/src/app/api/gates/[id]/route.ts
@@ -1,0 +1,9 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// story #1954(P1a-S4) 게이트 canonical 상세 — 단건 조회. BE 계약(story #1970, 디디 오너)이
+// GET /api/v2/gates/{id}를 신설하기 전까지는 404 패스스루(proxyToFastapi가 non-2xx 그대로 전달) —
+// BE 배포 즉시 이 프록시가 그대로 동작한다(FE 쪽 변경 불요).
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await params;
+  return proxyToFastapi(request, `/api/v2/gates/${id}`);
+}

--- a/apps/web/src/components/cage/gate-risk.test.ts
+++ b/apps/web/src/components/cage/gate-risk.test.ts
@@ -1,0 +1,38 @@
+// story #1954(P1a-S4) — 위험도 미확定(unknown) 시 보수적 고위험 취급 정책 회귀가드.
+// 오르테가군 판정(2026-07-17): unknown을 저위험 인라인 원탭 승인 경로로 흘리면 오승인 위험 —
+// BE 위험도 필드가 생기기 전까지는 항상 서명 게이팅(GateSignatureApproval) 경로를 타야 한다.
+import { describe, expect, it } from 'vitest';
+import { deriveRiskLevel, usesSignatureFlow } from './gate-risk';
+import type { GateItem } from '../kanban/types';
+
+const BASE_GATE: GateItem = {
+  id: 'g1',
+  work_item_id: 'w1',
+  work_item_type: 'story',
+  gate_type: 'merge_gate',
+  status: 'pending',
+  resolver_id: null,
+  resolved_at: null,
+  resolution_note: null,
+  neutral_facts: null,
+  created_at: '2026-07-17T00:00:00Z',
+  updated_at: '2026-07-17T00:00:00Z',
+};
+
+describe('gate-risk', () => {
+  it('BE 위험도 필드 미존재 상태에서는 항상 unknown을 반환한다(추측 금지)', () => {
+    expect(deriveRiskLevel(BASE_GATE)).toBe('unknown');
+  });
+
+  it('unknown은 서명 게이팅 경로를 탄다(보수적 고위험 취급) — 인라인 원탭 승인 금지', () => {
+    expect(usesSignatureFlow('unknown')).toBe(true);
+  });
+
+  it('high도 서명 게이팅 경로를 탄다', () => {
+    expect(usesSignatureFlow('high')).toBe(true);
+  });
+
+  it('low만 인라인 원탭 승인(서명 게이팅 미적용) 경로를 탄다', () => {
+    expect(usesSignatureFlow('low')).toBe(false);
+  });
+});

--- a/apps/web/src/components/cage/gate-risk.ts
+++ b/apps/web/src/components/cage/gate-risk.ts
@@ -1,0 +1,20 @@
+import type { GateItem } from '@/components/kanban/types';
+
+// story #1954(P1a-S4) — 위험도(risk) BE 필드는 아직 미존재(gate.py에 risk_level 류 없음).
+// "저·고위험=동일 BE 위험도 필드"(AC) 요구는 별도 후속 계약 논의 필요(BE 위험도 스토리 별도
+// 등재 예정, 판정 기준은 유나 기획+디디 BE 협의 — 제품 결정 성격). 그때까지 riskLevel은
+// 항상 'unknown'으로 렌더되며(추측 배지 금지), 실 필드가 오면 deriveRiskLevel 한 곳만 교체.
+export type RiskLevel = 'low' | 'high' | 'unknown';
+
+// TODO(#1970 후속 위험도 스토리): BE 위험도 필드 확定되면 그 필드를 그대로 매핑 — 추측 휴리스틱 금지.
+export function deriveRiskLevel(_gate: GateItem): RiskLevel {
+  return 'unknown';
+}
+
+// ⭐임시 정책(오르테가군 판정, 2026-07-17): unknown은 "보수적 고위험 취급" — 근거 열람+사유
+// 게이팅 강제(GateSignatureApproval). 인라인 원탭 승인은 riskLevel==='low' 확정 시에만 허용.
+// 위험도를 모르는 상태에서 저위험 경로(원탭 승인)로 잘못 흘려보내는 것보다, 고위험 취급으로
+// 안전 쪽에 서는 게 §1.2 신중 결재 정신에 맞는다 — 오승인 방지가 UX 편의보다 우선.
+export function usesSignatureFlow(riskLevel: RiskLevel): boolean {
+  return riskLevel !== 'low';
+}

--- a/apps/web/src/components/cage/gate-signature-approval.tsx
+++ b/apps/web/src/components/cage/gate-signature-approval.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { CheckCircle, XCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { GateEvidence } from '@/components/cage/gate-evidence';
+import type { GateItem } from '@/components/kanban/types';
+
+/**
+ * story #1954(P1a-S4) — 고위험 게이트 서명 플로우. AC: "근거 열람+사유 없인 [승인하고 서명] 비활성".
+ * 근거 열람 = 명시적 확인 상호작용(체크박스, 스크롤/펼침만으로는 열람 인정 안 함 — 우발적 통과 방지).
+ * 사유 = 자유 텍스트 필수(빈 문자열 trim 후 거부). 풀스크린 페이지 내 섹션(시트/팝오버 아님, AC 준수).
+ */
+export function GateSignatureApproval({
+  gate,
+  resolving,
+  onApprove,
+  onReject,
+}: {
+  gate: GateItem;
+  resolving: boolean;
+  onApprove: (reason: string) => void;
+  onReject: (reason: string) => void;
+}) {
+  const t = useTranslations('cage');
+  const [evidenceViewed, setEvidenceViewed] = useState(false);
+  const [reason, setReason] = useState('');
+  const canSign = evidenceViewed && reason.trim().length > 0 && !resolving;
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <p className="mb-2 text-[11px] font-semibold text-muted-foreground">{t('sigEvidenceLabel')}</p>
+        <GateEvidence gate={gate} />
+        <label className="mt-3 flex min-h-12 items-center gap-2 rounded-xl border border-border bg-card px-3 py-2 text-sm">
+          <input
+            type="checkbox"
+            checked={evidenceViewed}
+            onChange={(e) => setEvidenceViewed(e.target.checked)}
+            className="size-4 shrink-0"
+          />
+          {t('sigEvidenceViewedLabel')}
+        </label>
+      </div>
+
+      <div>
+        <label className="mb-1 block text-[11px] font-semibold text-muted-foreground" htmlFor="gate-sig-reason">
+          {t('sigReasonLabel')}
+        </label>
+        <textarea
+          id="gate-sig-reason"
+          rows={3}
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder={t('sigReasonPlaceholder')}
+          className="w-full resize-none rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <p className="text-center text-[11px] text-muted-foreground">{t('sigConsequenceNote')}</p>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            className="min-h-12 flex-1 gap-1.5"
+            disabled={resolving}
+            onClick={() => onReject(reason)}
+          >
+            <XCircle className="size-4" />
+            {t('sigRequestChanges')}
+          </Button>
+          <Button
+            className="min-h-12 flex-[1.4] gap-1.5"
+            disabled={!canSign}
+            onClick={() => onApprove(reason)}
+          >
+            <CheckCircle className="size-4" />
+            {resolving ? '...' : t('sigApproveAndSign')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -53,8 +53,9 @@ export interface GateItem {
   neutral_facts: Record<string, unknown> | null;
   // doc-side 결재(24f5ea18): doc gate(work_item_type='doc' / gate_type='doc_approval')일 때 BE가
   // 대상 문서 요약을 동봉(디디 BE PR #1742·additive). non-doc/삭제된 문서 gate는 null → `?.` 가드 폴백.
-  // slug는 향후 deep-link 후속용(MVP 미사용).
-  work_item_summary?: { title: string; slug: string } | null;
+  // story #1970(P1a-S4): GET /{id} 단건 조회에서 story/task 타입까지 확장 — 그 타입들은 slug
+  // 개념 자체가 없어 항상 null(BE WorkItemSummary.slug: str | None 그대로 반영).
+  work_item_summary?: { title: string; slug: string | null } | null;
   // doc-gate in-doc 결재 자격(89484c8c): doc_approval gate 한정·per-caller·rule A(human+has_project_access+not-author).
   // BE가 gates 리스트 응답 각 gate에 동봉(additive). undefined/false → in-doc 승인/반려 버튼 미노출(fail-closed). 실 authz=BE 403.
   can_approve?: boolean;


### PR DESCRIPTION
## Summary
- P1a·P2가 공유하는 유일한 per-gate 상세 라우트 — Gate 3종(게이트·문서결재·머지게이트, gate_type/work_item_type discriminator로 단일 Gate 테이블에 자연 수렴 — PO+디디+유나 2줄검증 확定, decision(inbox_items)은 별도 표면) canonical 상세.
- `/gates/[id]/page.tsx`: 풀스크린 페이지(팝오버·시트 아님), `TopBarSlot` 뒤로가기(→`/inbox`), `useSyntheticParentTabHistory('/inbox')`로 콜드 진입 BACK 계약(#1959 SSOT parentTab=approvals 소비).
- `GateSignatureApproval`: 고위험 서명 플로우 — 근거 열람(명시적 체크박스) + 사유 필수 전엔 `[승인하고 서명]` 비활성. 저위험은 GateInbox와 동형의 즉시 승인/반려.
- `/api/gates/[id]/route.ts`: FE 프록시(`proxyToFastapi`), BE `GET /api/v2/gates/{id}`(story #1970, PR#2253, dev 배포 GREEN `1f14f991`) 그대로 소비.

## 위험도(risk) 안전 정책 — 오르테가군 PO 판정 반영
BE 위험도 필드가 #1970 스코프 밖으로 확인돼 여전히 미존재(별도 후속 스토리 #1972 등재, 유나 doc `gate-risk-ux-classification-criteria` SSOT). `deriveRiskLevel()`/`usesSignatureFlow()`를 `gate-risk.ts`로 추출:
- `deriveRiskLevel` 항상 `'unknown'` 반환(추측 휴리스틱 금지) — `#1972` 확定 시 이 한 곳만 교체.
- `usesSignatureFlow(riskLevel)` = `riskLevel !== 'low'` — **unknown은 보수적 고위험 취급**(서명 게이팅 강제). 저위험 인라인 원탭 승인은 `'low'` 확정 시에만 허용(오승인 방지 우선).
- 유닛테스트 4건으로 이 안전 정책 회귀가드.

## 결함 fix(라이브 실측 중 자체 발견)
`needsAction` 판정에 `status === 'pending'` 가드가 없어 이미 approved/rejected된 게이트도 액션 UI(서명/승인 버튼)가 활성 상태로 재노출되던 결함 — 3-way 분기(읽기전용/서명게이팅/인라인)로 재구성, `gate-inbox.tsx`와 동형 `isDocGate`/`isCanonicalizeGate` 판정 재사용.

## 라이브 백엔드 검증(실측)
dev BE `GET /api/v2/gates/{id}` 직접 호출로 3가지 실 케이스 확인:
- doc_approval(pending) — `project_id`+`work_item_summary{title,slug}` 정상 채움.
- story merge(approved) — `project_id: null`+`work_item_summary: null`(soft-delete/project-무관 work_item 케이스) 정상 처리, FE 폴백(ID 스니펫)이 이 케이스를 정확히 커버.

## Test plan
- [x] 유닛테스트 10건 GREEN(합성 history 6건 + risk-gating 4건)
- [x] 전체 스위트 255 files / 1692 tests GREEN(회귀 0, flaky 1건 재실행 후 확인)
- [x] `npx tsc --noEmit` PASS · `pnpm build`(`/gates/[id]`·`/api/gates/[id]` 라우트 등록 확認) · `pnpm --filter web verify:no-new-md-breakpoint` PASS
- [x] BE 라이브(dev) 실 gate 3종 GET 200 응답 shape 검증
- [ ] FE 배포 후 라이브 콜드 URL 착지 + Claim/Evidence/조직명 렌더 + 서명 게이팅 390px 실측(까심 QA/유나 가디언 후 진행)

까심군 QA + 유나양 가디언 부탁드리는.

🤖 Generated with [Claude Code](https://claude.com/claude-code)