### PR TITLE
[SID:1974] 결재함 배지 개인화 파라미터(assigned_to_me) — prod 승격 예정

### DIFF
--- a/apps/web/src/components/nav/mobile-tab-bar.tsx
+++ b/apps/web/src/components/nav/mobile-tab-bar.tsx
@@ -41,6 +41,12 @@ export function MobileTabBar() {
   // `/api/gates?status=pending` 재사용(신규 집계 안 만듦). gate_overridden은 override 시
   // approver row status가 "overridden"으로 전이돼(gate_service.py) pending 조회에서 자동 제외
   // — 별도 필터 불요(백엔드 확認 완료).
+  //
+  // ⚠️fix(story #1974, 선생님 실사용 지적, prod 승격 예정): 이 fetch가 caller 스코프 필터 없이
+  // org 전체 pending을 반환해 "남의 게이트도 내 배지로 세는" 구조적 오배지였다(코드로 확定).
+  // `assigned_to_me=true`(디디 BE 계약, #1974)로 "내가 승인 가능한 것만" 스코프. BE 배포 전엔
+  // FastAPI가 미인식 쿼리파라미터를 무시하므로 안전한 no-op(기존과 동일 org-wide 동작) — 배포되면
+  // 자동으로 개인화 적용.
   const [pendingCount, setPendingCount] = useState(0);
 
   useEffect(() => {
@@ -54,7 +60,7 @@ export function MobileTabBar() {
     let cancelled = false;
     void (async () => {
       try {
-        const res = await fetch('/api/gates?status=pending');
+        const res = await fetch('/api/gates?status=pending&assigned_to_me=true');
         if (!res.ok) return;
         const gates = (await res.json()) as GateItem[];
         if (!cancelled) setPendingCount(Array.isArray(gates) ? gates.length : 0);

--- a/apps/web/src/components/nav/mobile-tab-bar.tsx
+++ b/apps/web/src/components/nav/mobile-tab-bar.tsx
@@ -58,7 +58,12 @@ export function MobileTabBar() {
     if (typeof window === 'undefined' || window.innerWidth >= MOBILE_BREAKPOINT) return;
 
     let cancelled = false;
-    void (async () => {
+    // ⚠️fix(story #1974, 선생님 실사용 지적): 마운트 1회 fetch뿐이라 게이트를 다른 탭/기기에서
+    // 처리해도 배지가 안 줄어드는 stale 문제 — DB 실측(2026-07-17)으로 확認(dev pending=0인데
+    // 사용자 배지는 그대로 남아있었음). window focus 복귀 시 재조회해 완화(전형적인 "다른 곳에서
+    // 처리하고 이 탭으로 돌아옴" 시나리오를 커버 — 실시간 push는 아니지만 이 스토리 스코프에선
+    // 충분, 완전한 실시간 갱신은 #1960 결재함 큐 스코프).
+    async function loadPendingCount() {
       try {
         const res = await fetch('/api/gates?status=pending&assigned_to_me=true');
         if (!res.ok) return;
@@ -67,9 +72,13 @@ export function MobileTabBar() {
       } catch {
         // 배지 카운트 실패는 치명적이지 않음 — 숫자 없이 탭만 정상 동작.
       }
-    })();
+    }
+
+    void loadPendingCount();
+    window.addEventListener('focus', loadPendingCount);
     return () => {
       cancelled = true;
+      window.removeEventListener('focus', loadPendingCount);
     };
   }, []);
 


### PR DESCRIPTION
## Summary
선생님 실사용 지적(2026-07-17) — 결재함 배지가 항상 1로 붙는 문제. 그라운딩 결과 원인 2건 모두 확定, 둘 다 이 PR에 반영:

1. **개인화 부재**: `list_gates`가 caller 스코프 필터 없이 org 전체 pending을 반환하는 구조적 갭(코드로 확定, story #1974 등재). 디디군 BE 계약(`GET /api/v2/gates?status=pending&assigned_to_me=true`)에 맞춰 FE가 파라미터를 실어 보내도록 수정.
2. **stale**: 마운트 1회 fetch뿐이라 게이트가 처리돼도 배지가 안 줄어듦 — 선생님 "껐다 켜니 사라짐" 재확認으로 이게 실 증상의 정면 원인으로 확定. `window` `focus` 이벤트 시 재조회 추가.

**개인화만으론 안 됨**(count 대상만 바뀔 뿐 stale은 그대로) — **개인화+refetch 둘 다** 있어야 완결.

BE가 아직 `assigned_to_me` 파라미터를 모르면 FastAPI가 무시 → 기존 동작 유지, **안전한 no-op**. BE(#1974) 배포와 동시에 자동 활성화.

## ⚠️Prod 승격 시퀀싱 (오르테가군 조율)
이 FE 커밋 단독으로는 개인화가 실효 없음 — 디디군 BE PR(`assigned_to_me` 필터 구현)과 **base를 맞춰 dev에서 함께 배포·개인화 실동작 검증(내 것만 배지로 뜨는지) 후, 두 커밋을 묶어 prod로 cherry-pick 승격** 예정.

## Test plan
- [x] `npx tsc --noEmit` PASS
- [x] `pnpm lint` — 신규 이슈 0
- [x] `pnpm build` EXIT 0
- [x] 전체 스위트 255 files / 1692 tests GREEN(회귀 0)
- [x] `pnpm --filter web verify:no-new-md-breakpoint` PASS
- [ ] dev 배포 후 BE(#1974)와 함께 개인화+refetch 실동작 라이브 실측(디디군 PR 배포 대기)

🤖 Generated with [Claude Code](https://claude.com/claude-code)