### PR TITLE
fix(gate): assigned_to_me held 게이트 배제 회귀 수정 (story #1974 후속)

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -343,16 +343,21 @@ async def list_gates(
     if resolved is None or resolved.type != "human":
         return []
 
-    non_doc_pending = [
+    # 오르테가 정정(까심 #1960 QA 적출, story #1974 후속): assigned_to_me 은 게이트가 **누구
+    # 것인지(WHO)** 의 문제지 pending/held 등 상태와 무관하다 — held 게이트도 같은 approver가
+    # 승인할 대상이고 paused 일 뿐 "내 것"이다. 바깥 `status` 쿼리 필터가 이미 gates 를 원하는
+    # 상태로 좁혀놨으니(예: status=held) 여기서 다시 "pending" 으로 하드코딩해 재필터하면 안
+    # 된다 — 예전엔 그래서 `status=held&assigned_to_me=true` 가 항상 빈 배열이었다.
+    non_doc_gates = [
         (resp, g) for resp, g in zip(responses, gates)
-        if g.gate_type != "doc_approval" and g.status == "pending"
+        if g.gate_type != "doc_approval"
     ]
 
     # project_id 배치 해소(story #1968 resolve_work_item_project_id 의 IN-clause 배치 버전 — 개별
     # gate 마다 신규 쿼리 금지). doc 은 위에서 이미 배치 조회한 doc_proj 재사용(중복 쿼리 0).
     project_id_by_work_item: dict[uuid.UUID, uuid.UUID | None] = dict(doc_proj)
-    story_ids = {g.work_item_id for _, g in non_doc_pending if g.work_item_type == "story"}
-    task_ids = {g.work_item_id for _, g in non_doc_pending if g.work_item_type == "task"}
+    story_ids = {g.work_item_id for _, g in non_doc_gates if g.work_item_type == "story"}
+    task_ids = {g.work_item_id for _, g in non_doc_gates if g.work_item_type == "task"}
     if story_ids:
         rows = (await session.execute(
             select(Story.id, Story.project_id).where(
@@ -373,7 +378,7 @@ async def list_gates(
     role_cache: dict[uuid.UUID, bool] = {}
     org_admin_cache: bool | None = None
     eligible_ids: set[uuid.UUID] = set()
-    for _resp, g in non_doc_pending:
+    for _resp, g in non_doc_gates:
         pid = project_id_by_work_item.get(g.work_item_id)
         if pid is not None:
             if pid not in role_cache:
@@ -388,8 +393,6 @@ async def list_gates(
 
     filtered: list[GateResponse] = []
     for resp, g in zip(responses, gates):
-        if g.status != "pending":
-            continue
         if g.gate_type == "doc_approval":
             if resp.can_approve:
                 filtered.append(resp)

--- a/backend/tests/test_1974_gate_assigned_to_me.py
+++ b/backend/tests/test_1974_gate_assigned_to_me.py
@@ -267,12 +267,30 @@ async def test_assigned_to_me_org_level_none_project_member_excluded():
 
 
 @pytest.mark.anyio
-async def test_assigned_to_me_non_pending_status_excluded():
+async def test_assigned_to_me_held_status_included():
+    """까심 #1960 QA 적출 회귀: assigned_to_me 은 WHO(승인 자격) 판정이지 STATE(pending/held)
+    판정이 아니다. `status=held&assigned_to_me=true`가 항상 빈 배열이었던 버그(g.status!="pending"
+    하드코딩 2곳) 수정 — held 게이트도 caller가 project owner/admin이면 포함돼야 한다(바깥
+    `status` 쿼리 필터가 이미 gates 목록을 원하는 상태로 좁혀놨다는 전제 — 이 테스트는 그 전제를
+    시뮬레이션하듯 held 게이트를 직접 넘겨 eligibility 판정만 검증)."""
+    g = _story_gate(gate_type="merge", status="held")
+    out = await _call_list_gates(
+        [g], project_role="owner", story_rows=[(g.work_item_id, uuid.uuid4())],
+    )
+    assert len(out) == 1
+    assert out[0].id == g.id
+
+
+@pytest.mark.anyio
+async def test_assigned_to_me_approved_status_included_when_role_eligible():
+    """터미널 상태(approved)도 STATE 필터가 아니라 WHO 필터라 role eligible이면 포함 — status
+    필터링 책임은 전적으로 바깥 `status` 쿼리 파라미터(list_gates 최상단 select)에 있다."""
     g = _story_gate(gate_type="merge", status="approved")
     out = await _call_list_gates(
         [g], project_role="owner", story_rows=[(g.work_item_id, uuid.uuid4())],
     )
-    assert out == []  # terminal status → 애초에 non_doc_pending 대상 아님
+    assert len(out) == 1
+    assert out[0].id == g.id
 
 
 @pytest.mark.anyio
@@ -643,4 +661,55 @@ async def test_realdb_assigned_to_me_query_count_scales_with_unique_projects_not
             await client.aclose()
     finally:
         app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_status_held_assigned_to_me_included():
+    """까심 #1960 QA 적출 회귀(story #1974 후속): `?status=held&assigned_to_me=true`가 항상 빈
+    배열이었던 버그 — held+merge+human+project-owner 조합이 이제 정확히 1건 반환되는지 실 HTTP
+    라운드트립으로 실측(구두 주장 아니라 캡처)."""
+    from app.main import app
+    from app.models.gate import Gate
+    from app.models.pm import Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_users(s)
+            org_id, project_id = seeded["org_id"], seeded["project_id"]
+            a_id = seeded["user_a_id"]
+
+            story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="held-story")
+            s.add(story)
+            await s.flush()
+            held_gate = Gate(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=story.id, work_item_type="story",
+                gate_type="merge", status="held", held_until=None,
+            )
+            s.add(held_gate)
+            await s.commit()
+
+        await _setup_app(app, Session, org_id, a_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/gates", params={"status": "held", "assigned_to_me": "true"},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            print("\n=== realdb status=held&assigned_to_me=true capture (A=project-owner-grant) ===")
+            for row in body:
+                print(f"  id={row['id']} status={row['status']} gate_type={row['gate_type']}")
+            ids = {row["id"] for row in body}
+            assert str(held_gate.id) in ids, (
+                "held+merge+human+owner 조합이 assigned_to_me=true 결과에서 빠짐 — "
+                "status!='pending' 하드코딩 회귀 재발"
+            )
+            assert len(body) == 1
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+    finally:
         await engine.dispose()


### PR DESCRIPTION
## Summary
- 까심 #1960 QA 크로스-PR 통합 검증 적출: `list_gates`의 `assigned_to_me` 분기가 `g.status != "pending"`을 두 곳에서 하드코딩 → `?status=held&assigned_to_me=true`가 항상 빈 배열.
- `assigned_to_me`은 WHO(승인 자격) 판정이지 STATE(pending/held) 판정이 아니다 — 바깥 `status` 쿼리 필터가 이미 gates를 원하는 상태로 좁혀놨으니 여기서 재필터 금지(오르테가 판단, "일반화가 정답"). 하드코딩 2곳 제거, `non_doc_pending`→`non_doc_gates` 재명명.
- prod 영향 0(list_gates 직접 호출 프로덕션 경로 없음), dev/CI 회귀만.
- FE 배지(#2256, 이미 dev 머지)는 `status=pending&assigned_to_me=true`만 쓰므로 이 버그의 영향을 받지 않음을 확인함(`apps/web/src/components/nav/mobile-tab-bar.tsx:68`).

## Test plan
- [x] 신규 unit 2건: held/approved 상태에서 role-eligible 게이트가 포함되는지.
- [x] 신규 realdb 1건: `status=held&assigned_to_me=true` 실 HTTP 라운드트립으로 held+merge+human+owner 조합이 정확히 반환되는지(캡처 로그 첨부, 아래).
- [x] 뮤테이션 셀프체크: 하드코딩 재도입 → 신규 3개 테스트 전부 RED(원 버그 정확히 재현) → 원복 → GREEN.
- [x] gate 관련 스위트 105 passed(회귀 없음).
- [x] ruff clean(gates.py), 워크플로우 yaml 무변경.

### realdb 캡처 (RED, 하드코딩 재도입 후 — 버그 재현, mutation self-check)
```
tests/test_1974_gate_assigned_to_me.py::test_realdb_status_held_assigned_to_me_included FAILED
AssertionError: held+merge+human+owner 조합이 assigned_to_me=true 결과에서 빠짐 —
status!='pending' 하드코딩 회귀 재발
assert 'b132166c-e39e-47d6-be01-56256a90a395' in set()
```

### realdb 캡처 (GREEN, fix 적용 후 — 별도 실행이라 gate id는 다름, 매 테스트 실행마다 uuid4 신규 생성)
```
tests/test_1974_gate_assigned_to_me.py::test_realdb_status_held_assigned_to_me_included PASSED
=== realdb status=held&assigned_to_me=true capture (A=project-owner-grant) ===
  id=c4b8f905-a76c-44f6-865f-636dc50ad869 status=held gate_type=merge
```

🤖 Generated with Claude Code