### PR TITLE
ci(1982): Backend pytest job에 real-PG postgres service + env 배선

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,43 @@ jobs:
   backend-test:
     name: Backend pytest
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # story #1982(2026-07-17): postgres service + real-PG env 배선. 이 갭은 story #1472
+    # (2026-06-21)에서 이미 발견됐고, story 8236bbc3(#1619, 2026-07-03)이 "backend-test job
+    # 무변경(회귀0 최대보수)"으로 의도적으로 유보했던 트레이드오프다 — 그 결과 `_REAL_DB_SKIP`
+    # 마커 테스트(예: test_1974_gate_assigned_to_me.py의 realdb 3건)가 이 job에서 조용히 skip
+    # 되어 CI green이 realPG 왕복 거동을 실제로 보증하지 못했다. 여기서 alembic-fresh-db job과
+    # 동일 자격증명·동일 2단계 구조(non-destructive 공유 DB + destructive_schema 격리 순회)를
+    # 재사용해 닫는다. destructive_schema 마커 테스트를 이 postgres 위에서 격리 없이 평면
+    # `pytest`로 돌리면 파일마다 붙는 autouse 스키마-리셋 fixture(tests/conftest.py:84,
+    # DROP SCHEMA public CASCADE)가 공유 alembic-migrated 스키마를 오염시켜 story 8236bbc3가
+    # 문서화한 116건 연쇄 실패를 이 job에서도 재현하므로, 단일 평면 실행이 아니라 반드시
+    # 동일한 2단계 분리 구조가 필요하다(217초 실측 + 격리 순회 버퍼 — alembic-fresh-db와 동일
+    # timeout-minutes: 20으로 상향).
+    timeout-minutes: 20
+
+    services:
+      postgres:
+        # pgvector image: the baseline schema declares `CREATE EXTENSION vector` (embeddings),
+        # which the stock postgres:16 image lacks. Cloud SQL (dev/prod) has pgvector available.
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: sprintable
+          POSTGRES_PASSWORD: sprintable
+          POSTGRES_DB: sprintable_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      ALEMBIC_DATABASE_URL: postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test
+      PARITY_TEST_DATABASE_URL: postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test
+      DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
+      JWT_SECRET: ci-test-secret-at-least-32-chars-long
+      SECRET_KEY: ci-test-secret-at-least-32-chars-long
 
     steps:
       - name: Checkout
@@ -247,8 +283,50 @@ jobs:
         with:
           version: 'latest'
 
-      - name: Run pytest
-        run: cd backend && uv run pytest
+      # non-destructive real-PG 테스트(84개 파일, destructive_schema 마커 제외)는 alembic-migrated
+      # 스키마(view·nullable·seed 포함 baseline)에 의존한다 — alembic-fresh-db job과 동일하게
+      # fresh DB를 먼저 heads까지 올린다(그렇지 않으면 테이블 부재로 realdb 테스트가 실패한다).
+      - name: alembic upgrade heads (fresh DB → baseline)
+        working-directory: backend
+        run: uv run alembic upgrade heads
+
+      - name: Run pytest (non-destructive, real-PG auto-discovered via marker)
+        working-directory: backend
+        run: uv run pytest -q -m "not destructive_schema"
+
+      # destructive_schema 마커 파일(Base.metadata.create_all/drop_all로 자체 스키마 직접 관리)은
+      # 위 alembic-migrated 공유 DB(sprintable_test)에서 절대 실행하지 않는다 — story 8236bbc3
+      # 실측대로 drop_all()이 DB를 오염시켜 같은 세션 후속 테스트 전부를 연쇄 실패시킬 수 있다.
+      # 파일마다 독립 throwaway DB(sprintable_test_iso)로 완전 격리한다.
+      - name: Run pytest (destructive schema — isolated fresh DB per file)
+        working-directory: backend
+        run: |
+          set -uo pipefail
+          # set -e를 여기선 안 쓴다(alembic-fresh-db job과 동일 이유) — 첫 실패 파일이 스크립트를
+          # 즉시 죽이면 나머지 파일은 조용히 미실행된 것과 동일한 결과가 된다.
+          mapfile -t files < <(
+            uv run pytest -q -m destructive_schema --collect-only \
+              | grep -oE '^tests/[a-zA-Z0-9_]+\.py' | sort -u
+          )
+          echo "destructive files: ${#files[@]}"
+          failed_files=()
+          for f in "${files[@]}"; do
+            echo "::group::isolated $f"
+            PGPASSWORD=sprintable dropdb -h localhost -U sprintable --if-exists sprintable_test_iso
+            PGPASSWORD=sprintable createdb -h localhost -U sprintable sprintable_test_iso
+            PGPASSWORD=sprintable psql -h localhost -U sprintable -d sprintable_test_iso \
+              -c 'CREATE EXTENSION IF NOT EXISTS vector;'
+            ALEMBIC_DATABASE_URL=postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test_iso \
+            PARITY_TEST_DATABASE_URL=postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test_iso \
+            DATABASE_URL=postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test_iso \
+            uv run pytest -q "$f" || failed_files+=("$f")
+            echo "::endgroup::"
+          done
+          if [ "${#failed_files[@]}" -gt 0 ]; then
+            echo "FAILED files: ${failed_files[*]}"
+            exit 1
+          fi
+          echo "OK: all ${#files[@]} isolated destructive-schema files passed"
 
   ci:
     name: Lint, Type Check, Test, Build

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -396,7 +396,7 @@ async def list_gates(
         if g.gate_type == "doc_approval":
             if resp.can_approve:
                 filtered.append(resp)
-        elif g.id in eligible_ids and g.status == "pending":
+        elif g.id in eligible_ids:
             filtered.append(resp)
     return filtered
 

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -396,7 +396,7 @@ async def list_gates(
         if g.gate_type == "doc_approval":
             if resp.can_approve:
                 filtered.append(resp)
-        elif g.id in eligible_ids:
+        elif g.id in eligible_ids and g.status == "pending":
             filtered.append(resp)
     return filtered
 


### PR DESCRIPTION
## Summary
- story #1982: `Backend pytest`(`backend-test`) job에 `alembic-fresh-db` job과 동일한 `pgvector/pgvector:pg16` postgres service + `ALEMBIC_DATABASE_URL`/`PARITY_TEST_DATABASE_URL`/`DATABASE_URL` env를 배선해, `_REAL_DB_SKIP` 마커 realPG 라운드트립 테스트가 이 job에서 silent skip되던 갭을 닫는다.
- `alembic upgrade heads` 스텝을 추가해 non-destructive real-PG 테스트(alembic-migrated 공유 스키마 의존, 84개 파일)가 정상 동작하도록 보장.
- destructive_schema 마커 파일(Base.metadata.create_all/drop_all 직접 호출)은 `alembic-fresh-db` job과 동일하게 파일별 독립 throwaway DB(`sprintable_test_iso`)로 격리 순회 — 이 분리 없이 단일 `pytest` 평면 실행을 하면 autouse 스키마-리셋 fixture(DROP SCHEMA public CASCADE)가 공유 DB를 오염시켜 story 8236bbc3이 문서화한 116건 연쇄 실패를 재현한다.
- story #1472(2026-06-21, 동일 갭 조기 발견)와 중복 — 이 PR 머지로 함께 닫을 수 있음(상태 변경은 코디네이터가 처리).

## 배경/판단 근거
- story 8236bbc3(#1619, 2026-07-03)은 이 갭을 알고도 "backend-test job 무변경(회귀0 최대보수)"으로 의도적으로 유보했다. 이번 story #1982가 그 트레이드오프를 재검토해 배선을 완료한다.
- alembic upgrade 필요 여부: `test_1974_gate_assigned_to_me.py`의 `_session_factory()`는 `Base.metadata.create_all()`을 직접 호출해 자체 스키마를 구성하므로(그래서 `destructive_schema` 마커 대상 → 격리 DB 경로) 이 파일 자체는 alembic 불필요. 하지만 `-m "not destructive_schema"`로 실행되는 나머지 ~84개 non-destructive real-PG 파일은 alembic-migrated 공유 스키마(view/seed 포함)에 의존하므로 migration 스텝은 필요.
- 인프라 중복(AC4): 두 job이 이제 사실상 동일한 전체 pytest 스윕(3391여개 전체 + real-DB 포함)을 postgres 위에서 반복 실행한다. 병렬 실행이라 wall-clock 영향은 작지만 compute 비용은 2배다. destructive_schema 분리 로직 없이 축소할 방법이 없어(위 근거) 이번 스토리에서는 **job 통합/삭제까지는 하지 않고 최소 침습으로 wiring만 수행**했다 — 완전 통합(예: `backend-test` job 폐기, `alembic-fresh-db`를 단일 SSOT로) 여부는 별도 후속 스토리로 코디네이터/PO 판단 권장.

## Test plan
- [x] 로컬 `python3 -c "import yaml; yaml.safe_load(...)"` 로 ci.yml 문법 검증
- [x] 로컬 `pgvector/pgvector:pg16` Docker 컨테이너 + `alembic upgrade heads` 성공 확인
- [x] 로컬 `pytest -m "not destructive_schema"` 전체 스윕 실행(4304 passed, 7 failed — 모두 MCP 프로세스/경로 관련 pre-existing 로컬 환경 이슈, real-DB/gates 무관 확인)
- [x] 로컬 격리 DB로 `test_1974_gate_assigned_to_me.py` 단독 실행 — 23/23 pass, skip 0 확인
- [x] 뮤테이션 실증: `app/routers/gates.py`의 `assigned_to_me` 필터에 `status == "pending"` 하드코딩을 일시 주입 → `test_realdb_status_held_assigned_to_me_included`(+연관 2건) RED 확인 → 원복 → 23/23 GREEN 재확인(로컬)
- [ ] 이 PR을 열어 실제 GitHub Actions "Backend pytest" job 로그에서 skip 0 재확인(원격 CI) — Actions run URL은 별도 보고

🤖 Generated with [Claude Code](https://claude.com/claude-code)