### PR TITLE
[SID:1972] 게이트 위험도 UX 이원화 활성 — risk_grade 실배선

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3520,6 +3520,7 @@
     "queueAgeDays": "Waiting {days}d",
     "gateDetailOrgContext": "Org {org}",
     "riskUnknown": "Risk pending",
+    "riskHigh": "High risk · review closely",
     "sigEvidenceLabel": "Evidence",
     "sigEvidenceViewedLabel": "I have reviewed the evidence above",
     "sigReasonLabel": "Decision reason",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3520,6 +3520,7 @@
     "queueAgeDays": "{days}일 대기",
     "gateDetailOrgContext": "조직 {org}",
     "riskUnknown": "위험도 확인 중",
+    "riskHigh": "고위험 · 신중 결재",
     "sigEvidenceLabel": "근거",
     "sigEvidenceViewedLabel": "위 근거를 확인했습니다",
     "sigReasonLabel": "결정 사유",

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -109,7 +109,9 @@ export default function GateDetailPage() {
             <div className="space-y-2">
               <div className="flex flex-wrap items-center gap-1.5">
                 <Badge variant="chip">{gate.gate_type}</Badge>
-                {deriveRiskLevel(gate) === 'unknown' ? (
+                {deriveRiskLevel(gate) === 'high' ? (
+                  <Badge variant="warning">{t('riskHigh')}</Badge>
+                ) : deriveRiskLevel(gate) === 'unknown' ? (
                   <Badge variant="outline" className="text-muted-foreground">{t('riskUnknown')}</Badge>
                 ) : null}
               </div>

--- a/apps/web/src/components/cage/gate-risk.test.ts
+++ b/apps/web/src/components/cage/gate-risk.test.ts
@@ -1,27 +1,43 @@
-// story #1954(P1a-S4) — 위험도 미확定(unknown) 시 보수적 고위험 취급 정책 회귀가드.
-// 오르테가군 판정(2026-07-17): unknown을 저위험 인라인 원탭 승인 경로로 흘리면 오승인 위험 —
-// BE 위험도 필드가 생기기 전까지는 항상 서명 게이팅(GateSignatureApproval) 경로를 타야 한다.
+// story #1972(P1a-S4) — 위험도 UX 이원화 활성. deriveRiskLevel이 BE risk_grade를 그대로 매핑하는지,
+// risk_grade 부재(구버전 응답) 시 여전히 'unknown'(보수적 고위험 안전판)으로 폴백하는지 고정.
+// usesSignatureFlow 축은 story #1954 정책(오르테가군 판정, 2026-07-17) 그대로 유지 — unknown/high는
+// 서명 게이팅, low만 인라인 원탭 승인.
 import { describe, expect, it } from 'vitest';
 import { deriveRiskLevel, usesSignatureFlow } from './gate-risk';
 import type { GateItem } from '../kanban/types';
 
-const BASE_GATE: GateItem = {
-  id: 'g1',
-  work_item_id: 'w1',
-  work_item_type: 'story',
-  gate_type: 'merge_gate',
-  status: 'pending',
-  resolver_id: null,
-  resolved_at: null,
-  resolution_note: null,
-  neutral_facts: null,
-  created_at: '2026-07-17T00:00:00Z',
-  updated_at: '2026-07-17T00:00:00Z',
-};
+function gate(overrides: Partial<GateItem>): GateItem {
+  return {
+    id: 'g1',
+    work_item_id: 'w1',
+    work_item_type: 'story',
+    gate_type: 'merge_gate',
+    status: 'pending',
+    resolver_id: null,
+    resolved_at: null,
+    resolution_note: null,
+    neutral_facts: null,
+    created_at: '2026-07-17T00:00:00Z',
+    updated_at: '2026-07-17T00:00:00Z',
+    ...overrides,
+  };
+}
 
 describe('gate-risk', () => {
-  it('BE 위험도 필드 미존재 상태에서는 항상 unknown을 반환한다(추측 금지)', () => {
-    expect(deriveRiskLevel(BASE_GATE)).toBe('unknown');
+  it('BE risk_grade="low"를 그대로 low로 매핑한다', () => {
+    expect(deriveRiskLevel(gate({ risk_grade: 'low' }))).toBe('low');
+  });
+
+  it('BE risk_grade="high"를 그대로 high로 매핑한다', () => {
+    expect(deriveRiskLevel(gate({ risk_grade: 'high' }))).toBe('high');
+  });
+
+  it('risk_grade가 null이면 unknown으로 폴백한다(구버전 응답 안전판)', () => {
+    expect(deriveRiskLevel(gate({ risk_grade: null }))).toBe('unknown');
+  });
+
+  it('risk_grade가 undefined(필드 자체 부재)이면 unknown으로 폴백한다', () => {
+    expect(deriveRiskLevel(gate({}))).toBe('unknown');
   });
 
   it('unknown은 서명 게이팅 경로를 탄다(보수적 고위험 취급) — 인라인 원탭 승인 금지', () => {

--- a/apps/web/src/components/cage/gate-risk.ts
+++ b/apps/web/src/components/cage/gate-risk.ts
@@ -1,14 +1,13 @@
 import type { GateItem } from '@/components/kanban/types';
 
-// story #1954(P1a-S4) — 위험도(risk) BE 필드는 아직 미존재(gate.py에 risk_level 류 없음).
-// "저·고위험=동일 BE 위험도 필드"(AC) 요구는 별도 후속 계약 논의 필요(BE 위험도 스토리 별도
-// 등재 예정, 판정 기준은 유나 기획+디디 BE 협의 — 제품 결정 성격). 그때까지 riskLevel은
-// 항상 'unknown'으로 렌더되며(추측 배지 금지), 실 필드가 오면 deriveRiskLevel 한 곳만 교체.
+// story #1972(P1a-S4) — 위험도 UX 이원화 활성. BE `risk_grade`(gate_service.derive_risk_grade,
+// OrgGatePolicy.posture+gate_type 순수 파생, doc `gate-risk-ux-classification-criteria` §2)를
+// 그대로 매핑한다 — FE는 추측/휴리스틱을 두지 않는다(SSOT=BE). risk_grade가 null/undefined인
+// 구버전 응답만 'unknown'(보수적 고위험 안전판)으로 폴백.
 export type RiskLevel = 'low' | 'high' | 'unknown';
 
-// TODO(#1970 후속 위험도 스토리): BE 위험도 필드 확定되면 그 필드를 그대로 매핑 — 추측 휴리스틱 금지.
-export function deriveRiskLevel(_gate: GateItem): RiskLevel {
-  return 'unknown';
+export function deriveRiskLevel(gate: GateItem): RiskLevel {
+  return gate.risk_grade ?? 'unknown';
 }
 
 // ⭐임시 정책(오르테가군 판정, 2026-07-17): unknown은 "보수적 고위험 취급" — 근거 열람+사유

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -86,6 +86,8 @@ export function ApprovalsQueue() {
               <Badge variant="chip">{gate.gate_type}</Badge>
               {held ? (
                 <Badge variant="secondary">{t('heldBadge')}</Badge>
+              ) : deriveRiskLevel(gate) === 'high' ? (
+                <Badge variant="warning">{t('riskHigh')}</Badge>
               ) : deriveRiskLevel(gate) === 'unknown' ? (
                 <Badge variant="outline" className="text-muted-foreground">{t('riskUnknown')}</Badge>
               ) : null}

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -62,6 +62,10 @@ export interface GateItem {
   // doc-gate in-doc 결재 자격(89484c8c): doc_approval gate 한정·per-caller·rule A(human+has_project_access+not-author).
   // BE가 gates 리스트 응답 각 gate에 동봉(additive). undefined/false → in-doc 승인/반려 버튼 미노출(fail-closed). 실 authz=BE 403.
   can_approve?: boolean;
+  // story #1972(P1a-S4): 위험도 UX 등급 파생 결과("low"|"high") — BE gate_service.derive_risk_grade()
+  // 가 OrgGatePolicy.posture+gate_type에서 순수 파생해 list/단건 조회 둘 다 동봉(additive). null/undefined는
+  // BE가 아직 못 보낸 구버전 응답 대비 방어적 폴백일 뿐 — 정상 응답은 항상 "low"|"high" 둘 중 하나.
+  risk_grade?: 'low' | 'high' | null;
   // H1-S3 머지 verdict 게이트 evidence(GateResponse·additive·하위호환 default). null≠0(AC③).
   requires_human?: boolean;
   evidence_status?: string | null; // sufficient | blocked | insufficient


### PR DESCRIPTION
## Summary
- BE `risk_grade`(story #1972, dev 배포 완료)를 `gate-risk.ts`의 임시 파생(항상 'unknown') 대신 실 필드로 매핑 — 한 곳만 교체(설계 의도대로).
- `usesSignatureFlow` 정책(unknown/high=서명 게이팅·low만 인라인)은 그대로 유지, `GateItem.risk_grade` 필드 additive 추가.
- 위험도 배지 가시성 추가(`gate-risk-ux-classification-criteria` §3 UX 매핑): high=warning 톤 "고위험 · 신중 결재" 배지 신규, low=무배지, unknown=기존 배지 유지. canonical 상세(#1954)+결재함 큐(#1960) 양쪽 적용.
- `gate-risk.test.ts`: low/high/null/undefined 4가지 매핑 케이스로 교체.

## Test plan
- [x] tsc/lint/build/vitest(256 files·1703 tests) 클린
- [x] 격리 docker-compose 스택에서 `org_gate_policy.posture` 직접 제어(permissive→low, conservative→high)로 실 doc_approval 게이트 생성 → canonical 상세 low=인라인 승인/반려 확認, high=배지+서명 게이팅(체크박스+사유+disabled 제출) 확認 → 결재함 큐도 high 배지 확認, 390px 스크린샷 확보 → 스택 완전 정리(`down -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)