### PR TITLE
feat(chat): story #1976(E-CHAT-REALTIME 트랙A) — read state 서버 truth

### DIFF
--- a/backend/alembic/versions/0199_conversation_participant_last_read_at.py
+++ b/backend/alembic/versions/0199_conversation_participant_last_read_at.py
@@ -1,0 +1,49 @@
+"""story #1976 (E-CHAT-REALTIME 트랙A): conversation_participants.last_read_at — read state 서버 truth.
+
+Revision ID: 0199
+Revises: 0198
+Create Date: 2026-07-17
+
+배경: chat-realtime-unread-diagnosis(#1975) 갭 A — 서버 read state truth 부재. unread 배지가
+클라 세션 휘발 카운터(SSE 수신 시 +1, 영속/차감/mark-read 전무)라 콜드스타트·새 탭에서 리셋됨.
+last_read_at을 서버 truth로 신설 — unread_count = last_read_at 이후 메시지(sender IS DISTINCT
+FROM 나) 카운트로 대체(doc: chat-realtime-track-a-read-state-design §2).
+
+NULL=한 번도 안 읽음(과거 참가자 전원 포함 — 백필 없음, 마이그 시점 기존 row는 전량 NULL로
+시작해 다음 조회 시 전체 unread로 보인다 — 의도된 동작, 최초 mark-read 호출로 해소).
+default 없음(server_default 미부여) — INSERT 시 항상 NULL(신규 참가자="아직 안 읽음",
+muted_at과 동형 시맨틱). additive·nullable — 구코드 호환. idempotent(컬럼 부재 시만 추가),
+0115(muted_at 신설) 스타일 정합.
+
+**백필은 이 마이그 스코프 밖**(설계 doc §6-5 열린 질문 — 배포 직후 전체 unread UX 허용 가능
+여부는 선생님 확認 대기, 월요일로 밀림). 이 마이그는 순수 ADD COLUMN만 수행하며 UPDATE는
+절대 포함하지 않는다. 백필 여부/전략은 후속 결정 대기.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0199"
+down_revision = "0198"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    cols = {c["name"] for c in insp.get_columns("conversation_participants")}
+    if "last_read_at" not in cols:
+        op.add_column(
+            "conversation_participants",
+            sa.Column("last_read_at", sa.DateTime(timezone=True), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    cols = {c["name"] for c in insp.get_columns("conversation_participants")}
+    if "last_read_at" in cols:
+        op.drop_column("conversation_participants", "last_read_at")

--- a/backend/app/models/conversation.py
+++ b/backend/app/models/conversation.py
@@ -58,6 +58,10 @@ class ConversationParticipant(Base):
     )
     # 270c87e6: per-대화 알림 mute. set=무음·null=알림 ON. 참여자 지위·가시성·수신은 불변(알림만).
     muted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # story #1976 (E-CHAT-REALTIME 트랙A): read state 서버 truth. NULL=한 번도 안 읽음
+    # (과거 참가자 전원 포함 — 마이그 시점 전량 NULL, 백필 없음). unread_count 계산 기준선
+    # (last_read_at 이후 메시지 중 sender IS DISTINCT FROM 나). muted_at과 동형(수동 mark 컬럼).
+    last_read_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     conversation: Mapped[Conversation] = relationship("Conversation", back_populates="participants")
 

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict, field_validator
-from sqlalchemy import and_, func, select, update
+from sqlalchemy import and_, func, select, text, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -233,6 +233,81 @@ async def _conversations_with_human_participant(conv_ids: list[uuid.UUID], db: A
         if mid not in agent_ids:  # human 참가자 발견
             result.add(cid)
     return result
+
+
+# ─── story #1976 (E-CHAT-REALTIME 트랙A): read state 서버 truth ──────────────────
+# doc: chat-realtime-track-a-read-state-design §3/§4. 순수 SQLAlchemy 쿼리/stmt 조립
+# 함수(DB 실행 없음) — 단위 테스트 가능(TDD RED→GREEN, DB 미기동 시에도 compile() 검증 가능).
+
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)  # last_read_at NULL(한 번도 안 읽음) 기준선
+
+
+def _mark_read_update_stmt(conversation_id: uuid.UUID, member_id: uuid.UUID, up_to: datetime):
+    """GREATEST 래칫 UPDATE — last_read_at을 단조증가만 허용(멱등·역행 방지, §4-3).
+
+    GREATEST(COALESCE(last_read_at, epoch), up_to): 이미 더 최신 read 상태면 과거 up_to로
+    덮어쓰지 않는다. WHERE가 (conversation_id, member_id) 매치 0행이면 비참여자 — 호출부가
+    RETURNING 결과 None으로 403 판단.
+    """
+    return (
+        update(ConversationParticipant)
+        .where(
+            ConversationParticipant.conversation_id == conversation_id,
+            ConversationParticipant.member_id == member_id,
+        )
+        .values(
+            last_read_at=func.greatest(
+                func.coalesce(ConversationParticipant.last_read_at, text("'epoch'::timestamptz")),
+                up_to,
+            )
+        )
+        .returning(ConversationParticipant.last_read_at)
+    )
+
+
+def _unread_count_stmt(conversation_id: uuid.UUID, member_id: uuid.UUID, since: datetime | None):
+    """단건 unread_count — last_read_at(since) 이후 & sender IS DISTINCT FROM 나(§4-1).
+
+    IS DISTINCT FROM(NOT !=) 필수: sender_id nullable(발신자 탈퇴 시 SET NULL) 이라 `!=`는
+    SQL 3-값 논리상 NULL != x → NULL(제외) 이 돼 발신자소실 메시지가 unread에서 누락된다.
+    since=None(한 번도 안 읽음)이면 _EPOCH 기준선 사용.
+    """
+    baseline = since if since is not None else _EPOCH
+    return select(func.count(ConversationMessage.id)).where(
+        ConversationMessage.conversation_id == conversation_id,
+        ConversationMessage.created_at > baseline,
+        ConversationMessage.sender_id.is_distinct_from(member_id),
+    )
+
+
+def _list_unread_counts_stmt(member_id: uuid.UUID, conv_id_list: list[uuid.UUID]):
+    """list_conversations 배치 unread_count — 단일 JOIN+GROUP BY(N+1 방지, §4-2).
+
+    대화마다 기준 시각(last_read_at)이 다른 상관 카운트라 순수 IN 배치로는 불가 — JOIN
+    조건에 기준 시각 비교를 박아 넣어 페이지 대화 수(N)와 무관하게 쿼리 1회로 해결.
+    INNER JOIN이라 unread=0인 대화는 결과행 자체가 없음(호출부가 dict.get(id, 0)으로 처리).
+    """
+    return (
+        select(
+            ConversationParticipant.conversation_id,
+            func.count(ConversationMessage.id),
+        )
+        .join(
+            ConversationMessage,
+            and_(
+                ConversationMessage.conversation_id == ConversationParticipant.conversation_id,
+                ConversationMessage.created_at > func.coalesce(
+                    ConversationParticipant.last_read_at, text("'epoch'::timestamptz")
+                ),
+                ConversationMessage.sender_id.is_distinct_from(member_id),
+            ),
+        )
+        .where(
+            ConversationParticipant.member_id == member_id,
+            ConversationParticipant.conversation_id.in_(conv_id_list),
+        )
+        .group_by(ConversationParticipant.conversation_id)
+    )
 
 
 _SUMMARY_PREVIEW_MAX = 80
@@ -590,6 +665,10 @@ class ConversationResponse(BaseModel):
     updated_at: datetime
     # 270c87e6: caller의 알림 mute 상태(participant muted_at 기반) — FE mute 토글 초기 상태용(#1426).
     muted: bool = False
+    # story #1976 (E-CHAT-REALTIME 트랙A): caller의 read state(participant.last_read_at) +
+    # 파생 unread_count. 비참여자(admin-bypass agent-only 대화)는 last_read_at=None·unread_count=0.
+    last_read_at: datetime | None = None
+    unread_count: int = 0
 
 
 # E-FILE S1: 채팅 첨부. GCS 기록은 FE-proxy(uploadToGcs)가 처리하고 BE는 URL+메타만 저장.
@@ -695,6 +774,13 @@ class MuteRequest(BaseModel):
     muted: bool
 
 
+class MarkReadRequest(BaseModel):
+    """story #1976: up_to 지정 시 그 시각으로 SET(FE 실 렌더 마지막 메시지 timestamp — 권장 경로).
+    up_to 생략 시 서버 now() 사용 — 이는 "전체 읽음"(mark-all-read) 명시 액션 전용 의도(§3-2)."""
+
+    up_to: datetime | None = None
+
+
 # ─── Endpoints ────────────────────────────────────────────────────────────────
 
 @router.post("", status_code=201)
@@ -767,7 +853,11 @@ async def list_conversations(
         raise HTTPException(status_code=403, detail="Only owner/admin can view agent conversations.")
 
     conv_ids_result = await db.execute(
-        select(ConversationParticipant.conversation_id, ConversationParticipant.muted_at).where(
+        select(
+            ConversationParticipant.conversation_id,
+            ConversationParticipant.muted_at,
+            ConversationParticipant.last_read_at,
+        ).where(
             ConversationParticipant.member_id == sender.id
         )
     )
@@ -776,6 +866,9 @@ async def list_conversations(
     # 270c87e6: caller의 대화별 mute 상태(FE 토글 초기 상태·#1426). admin-bypass로 추가되는
     # agent-only 대화는 caller가 참여자 아니라 자연히 False.
     caller_muted = {r.conversation_id: r.muted_at is not None for r in _caller_rows}
+    # story #1976: caller의 대화별 read state(participant.last_read_at) — 같은 배치 쿼리에 편승
+    # (신규 쿼리 추가 아님·N+1 무영향). admin-bypass agent-only 대화는 caller 미참여라 자연히 None.
+    caller_last_read_at = {r.conversation_id: r.last_read_at for r in _caller_rows}
 
     # AC1/2 + #1262: admin-bypass는 **agent-only 대화로 한정**(사적 DM 프라이버시).
     # project 내 agent type member가 participant인 conversation 후보를 모으되,
@@ -850,6 +943,13 @@ async def list_conversations(
             "runtime_type": runtime_type_map.get(r.member_id),
         })
 
+    # story #1976: unread_count 배치 — 단일 JOIN+GROUP BY(N+1 방지, §4-2). INNER JOIN이라
+    # unread=0 대화는 결과행 없음 → dict.get(id, 0)으로 자연 0 처리.
+    unread_rows = (await db.execute(
+        _list_unread_counts_stmt(sender.id, conv_id_list)
+    )).all() if conv_id_list else []
+    unread_map: dict[uuid.UUID, int] = {r[0]: r[1] for r in unread_rows}
+
     result = []
     for conv in convs:
         latest_msg = (await db.execute(
@@ -868,6 +968,12 @@ async def list_conversations(
             "resolved_at": conv.resolved_at.isoformat() if conv.resolved_at else None,
             "participants": conv_participants.get(conv.id, []),
             "muted": caller_muted.get(conv.id, False),  # 270c87e6: FE mute 토글 초기 상태
+            # story #1976: caller read state + 파생 unread_count(단일 JOIN+GROUP BY, N+1 없음).
+            "last_read_at": (
+                caller_last_read_at.get(conv.id).isoformat()
+                if caller_last_read_at.get(conv.id) else None
+            ),
+            "unread_count": unread_map.get(conv.id, 0),
             "latest_message": {
                 "content": latest_msg.content,
                 "created_at": latest_msg.created_at.isoformat(),
@@ -915,14 +1021,20 @@ async def get_conversation(
             raise HTTPException(status_code=403, detail="Not a participant")
 
     # 270c87e6: caller의 mute 상태 노출(FE 토글 초기 상태·#1426). 비참여자(admin-bypass agent-only)는 False.
-    caller_muted_at = (await db.execute(
-        select(ConversationParticipant.muted_at).where(
+    # story #1976: 같은 단건 조회에 last_read_at도 편승(신규 쿼리 아님) — unread_count는 참여자일 때만 계산.
+    caller_row = (await db.execute(
+        select(ConversationParticipant.muted_at, ConversationParticipant.last_read_at).where(
             ConversationParticipant.conversation_id == conversation_id,
             ConversationParticipant.member_id == sender.id,
         )
-    )).scalar_one_or_none()
+    )).one_or_none()
     resp = ConversationResponse.model_validate(conv)
-    resp.muted = caller_muted_at is not None
+    resp.muted = caller_row is not None and caller_row.muted_at is not None
+    if caller_row is not None:
+        resp.last_read_at = caller_row.last_read_at
+        resp.unread_count = (await db.execute(
+            _unread_count_stmt(conversation_id, sender.id, caller_row.last_read_at)
+        )).scalar_one()
     return resp
 
 
@@ -1157,6 +1269,63 @@ async def set_conversation_mute(
     participant.muted_at = datetime.now(timezone.utc) if body.muted else None
     await db.commit()
     return {"conversation_id": str(conversation_id), "muted": body.muted}
+
+
+@router.post("/{conversation_id}/read")
+async def mark_conversation_read(
+    conversation_id: uuid.UUID,
+    body: MarkReadRequest,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """POST /api/v2/conversations/{id}/read — read state 서버 truth 갱신(멱등·GREATEST 래칫).
+
+    story #1976(E-CHAT-REALTIME 트랙A, doc chat-realtime-track-a-read-state-design §3):
+    up_to 지정 시 그 시각으로 SET(FE가 실 렌더된 마지막 메시지 timestamp 전달 — 권장 경로,
+    §4-3 레이스 방지). up_to 생략 시 서버 now() 사용 — "전체 읽음"(mark-all-read) 명시 액션
+    전용 의도(§3-2/§3-4). GREATEST(last_read_at, up_to) 원자 UPDATE로 역행 방지(여러 번
+    호출해도 안전 — 오래된 up_to가 늦게 도착해도 무해). 비참여자는 403(읽음 상태는 본인 것만
+    의미 있음 — admin-bypass 없음).
+    """
+    conv = (await db.execute(
+        select(Conversation).where(Conversation.id == conversation_id, Conversation.org_id == org_id)
+    )).scalar_one_or_none()
+    if conv is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    sender = await _resolve_member(auth, org_id, db, project_id=conv.project_id)
+    up_to = body.up_to or datetime.now(timezone.utc)
+
+    result = await db.execute(_mark_read_update_stmt(conversation_id, sender.id, up_to))
+    new_last_read_at = result.scalar_one_or_none()
+    if new_last_read_at is None:
+        raise HTTPException(status_code=403, detail="Not a participant")
+    await db.commit()
+
+    # 재계산(가정 아님 — up_to가 최신 메시지보다 과거인 엣지케이스에서 0이 아닐 수 있음, §3-3).
+    unread_count = (await db.execute(
+        _unread_count_stmt(conversation_id, sender.id, new_last_read_at)
+    )).scalar_one()
+
+    sse_payload = {
+        "event_type": "conversation.read",
+        "conversation_id": str(conversation_id),
+        "member_id": str(sender.id),
+        "last_read_at": new_last_read_at.isoformat(),
+        "unread_count": unread_count,
+    }
+    # 본인의 타 커넥션에만 전파(read-receipt=상대방 노출은 스코프 아웃, §5-1 PO 확定).
+    # _push_to_agent가 member_id의 모든 열린 탭/기기 큐에 자동 팬아웃(trust_pipeline.py 선례
+    # 동형 패턴, §1-3/§5-2) — Event DB row 미생성(순수 transient push, org 브로드캐스트 아님).
+    _push_to_agent(str(sender.id), sse_payload)
+
+    return {
+        "conversation_id": str(conversation_id),
+        "member_id": str(sender.id),
+        "last_read_at": new_last_read_at.isoformat(),
+        "unread_count": unread_count,
+    }
 
 
 @router.post("/{conversation_id}/participants", status_code=201)

--- a/backend/tests/test_1976_read_state_query_builders.py
+++ b/backend/tests/test_1976_read_state_query_builders.py
@@ -1,0 +1,114 @@
+"""story #1976 (E-CHAT-REALTIME 트랙A): read state 쿼리 조립 순수 단위 테스트(DB 미기동).
+
+doc chat-realtime-track-a-read-state-design §3(mark-read GREATEST 래칫)/§4(unread_count
+JOIN+GROUP BY, sender IS DISTINCT FROM). `_mark_read_update_stmt`/`_unread_count_stmt`/
+`_list_unread_counts_stmt`는 SQLAlchemy 문(Statement) 조립만 하는 순수 함수 — compile()로
+생성 SQL을 직접 검증(DB 라운드트립 불요, 실PG 없어도 실행 가능).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy.dialects import postgresql
+
+from app.routers.conversations import (
+    _EPOCH,
+    _list_unread_counts_stmt,
+    _mark_read_update_stmt,
+    _unread_count_stmt,
+)
+
+_CONV_ID = uuid.uuid4()
+_MEMBER_ID = uuid.uuid4()
+_UP_TO = datetime(2026, 7, 17, 9, 0, 0, tzinfo=timezone.utc)
+
+
+def _sql(stmt) -> str:
+    return str(stmt.compile(dialect=postgresql.dialect()))
+
+
+# ─── _mark_read_update_stmt: GREATEST 래칫 ───────────────────────────────────
+
+def test_mark_read_uses_greatest_ratchet():
+    sql = _sql(_mark_read_update_stmt(_CONV_ID, _MEMBER_ID, _UP_TO))
+    assert "greatest(" in sql.lower()
+
+
+def test_mark_read_coalesces_null_last_read_at_to_epoch():
+    """last_read_at NULL(한 번도 안 읽음)이어도 GREATEST가 안전하게 up_to로 세팅되도록
+    COALESCE(last_read_at, epoch) 사용 — 설계 doc §3-4 그대로."""
+    sql = _sql(_mark_read_update_stmt(_CONV_ID, _MEMBER_ID, _UP_TO))
+    assert "coalesce(conversation_participants.last_read_at" in sql.lower()
+    assert "epoch" in sql.lower()
+
+
+def test_mark_read_scoped_to_conversation_and_member():
+    sql = _sql(_mark_read_update_stmt(_CONV_ID, _MEMBER_ID, _UP_TO))
+    assert "conversation_participants.conversation_id" in sql
+    assert "conversation_participants.member_id" in sql
+
+
+def test_mark_read_returns_last_read_at_for_403_detection():
+    """WHERE 매치 0행(비참여자) 시 RETURNING이 빈 결과 → 호출부가 None 판정으로 403."""
+    stmt = _mark_read_update_stmt(_CONV_ID, _MEMBER_ID, _UP_TO)
+    sql = _sql(stmt)
+    assert "returning conversation_participants.last_read_at" in sql.lower()
+
+
+# ─── _unread_count_stmt: IS DISTINCT FROM(3-값 논리 함정 회피) ───────────────
+
+def test_unread_count_uses_is_distinct_from_not_noteq():
+    """핵심 함정 회피: sender_id nullable(발신자 탈퇴 시 SET NULL) — `!=`는 3-값 논리상
+    NULL != x → NULL(제외)이 돼 발신자소실 메시지가 unread에서 누락된다. IS DISTINCT FROM만
+    NULL을 올바르게 '나와 다름'으로 취급한다."""
+    sql = _sql(_unread_count_stmt(_CONV_ID, _MEMBER_ID, _UP_TO))
+    assert "is distinct from" in sql.lower()
+    # 정확히 IS DISTINCT FROM만 써야 — 동시에 순수 `!=`(<>) 비교로도 sender를 거르면 안 된다.
+    assert "sender_id !=" not in sql.lower()
+    assert "sender_id <>" not in sql.lower()
+
+
+def test_unread_count_filters_by_created_at_after_since():
+    sql = _sql(_unread_count_stmt(_CONV_ID, _MEMBER_ID, _UP_TO))
+    assert "conversation_messages.created_at >" in sql
+
+
+def test_unread_count_since_none_uses_epoch_baseline():
+    """last_read_at=NULL(한 번도 안 읽음) 케이스 — since=None이면 _EPOCH 기준선을 바인딩."""
+    stmt = _unread_count_stmt(_CONV_ID, _MEMBER_ID, None)
+    compiled = stmt.compile(dialect=postgresql.dialect())
+    bound = compiled.params
+    assert any(v == _EPOCH for v in bound.values())
+
+
+def test_unread_count_scoped_to_single_conversation():
+    sql = _sql(_unread_count_stmt(_CONV_ID, _MEMBER_ID, _UP_TO))
+    assert "conversation_messages.conversation_id =" in sql
+
+
+# ─── _list_unread_counts_stmt: 단일 JOIN+GROUP BY(N+1 방지) ─────────────────
+
+def test_list_unread_counts_is_single_join_not_subquery_per_conv():
+    """대화마다 개별 쿼리(N+1) 대신 JOIN 조건에 기준시각 비교를 박아 단일 쿼리로 해결(§4-2)."""
+    sql = _sql(_list_unread_counts_stmt(_MEMBER_ID, [_CONV_ID]))
+    assert "join conversation_messages" in sql.lower()
+    assert "group by conversation_participants.conversation_id" in sql.lower()
+
+
+def test_list_unread_counts_join_condition_carries_per_row_baseline():
+    """JOIN 조건 자체에 coalesce(last_read_at, epoch) 비교가 들어가야 대화별로 다른 기준
+    시각을 단일 쿼리로 처리할 수 있다 — 순수 IN 배치만으론 불가능한 이유."""
+    sql = _sql(_list_unread_counts_stmt(_MEMBER_ID, [_CONV_ID]))
+    assert "coalesce(conversation_participants.last_read_at" in sql.lower()
+
+
+def test_list_unread_counts_uses_is_distinct_from():
+    sql = _sql(_list_unread_counts_stmt(_MEMBER_ID, [_CONV_ID]))
+    assert "is distinct from" in sql.lower()
+
+
+def test_list_unread_counts_filters_member_and_conv_id_list():
+    sql = _sql(_list_unread_counts_stmt(_MEMBER_ID, [_CONV_ID]))
+    assert "conversation_participants.member_id =" in sql
+    assert "conversation_participants.conversation_id in" in sql.lower()

--- a/backend/tests/test_1976_read_state_realdb.py
+++ b/backend/tests/test_1976_read_state_realdb.py
@@ -1,0 +1,523 @@
+"""story #1976 (E-CHAT-REALTIME 트랙A): read state 서버 truth — realPG 통합 테스트.
+
+doc chat-realtime-track-a-read-state-design(§3 mark-read 계약/§4 unread_count/§5 SSE)의
+실 구현 실증. 커버:
+- unread_count 정의(last_read_at 이후 & sender IS DISTINCT FROM 나) — NULL 케이스 포함.
+- mark-read up_to 지정/생략(now() 폴백) 계약.
+- GREATEST 래칫 — 멱등 + 역행 방지.
+- list_conversations unread_count 단일 JOIN+GROUP BY(N+1 방지) 쿼리수 실측.
+- conversation.read SSE — 본인의 타 커넥션에만 전파(다른 유저 미수신 실측).
+- 비참여자 403.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_conversation(session, *, n_members: int = 2):
+    """org(1) + project(1) + n_members human members(project_access member) + 1 group conversation
+    (전원 참가). 반환: org_id/project_id/conv_id/member_ids(list)/user_ids(list, member 순서 대응)."""
+    from app.models.conversation import Conversation, ConversationParticipant
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    member_ids = []
+    user_ids = []
+    for i in range(n_members):
+        user_id = uuid.uuid4()
+        user = User(id=user_id, email=f"human-{user_id.hex[:8]}@test.com", hashed_password="x")
+        session.add(user)
+        await session.commit()
+        m = Member(id=uuid.uuid4(), org_id=org.id, type="human", user_id=user_id, name=f"Member{i}")
+        session.add(m)
+        await session.commit()
+        session.add(ProjectAccess(
+            id=uuid.uuid4(), project_id=project.id, member_id=m.id, permission="granted", role="member",
+        ))
+        await session.commit()
+        member_ids.append(m.id)
+        user_ids.append(user_id)
+
+    conv = Conversation(
+        id=uuid.uuid4(), project_id=project.id, org_id=org.id, type="group",
+        title="Test convo", created_by=member_ids[0],
+    )
+    session.add(conv)
+    await session.flush()
+    for mid in member_ids:
+        session.add(ConversationParticipant(conversation_id=conv.id, member_id=mid))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "conv_id": conv.id,
+        "member_ids": member_ids, "user_ids": user_ids,
+    }
+
+
+async def _add_message(session, conv_id, sender_id, content: str, created_at: datetime):
+    from app.models.conversation import ConversationMessage
+    msg = ConversationMessage(
+        id=uuid.uuid4(), conversation_id=conv_id, sender_id=sender_id,
+        content=content, created_at=created_at,
+    )
+    session.add(msg)
+    await session.commit()
+    return msg
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+T0 = datetime(2026, 7, 17, 8, 0, 0, tzinfo=timezone.utc)
+
+
+def _t(minutes: int) -> datetime:
+    return T0 + timedelta(minutes=minutes)
+
+
+# ─── unread_count 정의: last_read_at 이후 & sender IS DISTINCT FROM 나 ───────
+
+@pytest.mark.anyio
+async def test_unread_count_excludes_own_messages_includes_others():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_conversation(s, n_members=2)
+            me, other = seeded["member_ids"]
+            await _add_message(s, seeded["conv_id"], me, "내 메시지", _t(0))
+            await _add_message(s, seeded["conv_id"], other, "상대 메시지1", _t(1))
+            await _add_message(s, seeded["conv_id"], other, "상대 메시지2", _t(2))
+
+        await _setup_app_human(app, Session, seeded["user_ids"][0], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/conversations/{seeded['conv_id']}")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["last_read_at"] is None
+            # last_read_at NULL(한 번도 안 읽음) → 전체 3건 중 내 발신 1건 제외 = 2건
+            assert body["unread_count"] == 2, body
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unread_count_null_sender_counts_as_unread():
+    """IS DISTINCT FROM 함정 실증: sender_id NULL(발신자 탈퇴) 메시지도 '나 아님'이라 unread에
+    포함돼야 한다 — `!=` 였다면 3-값 논리로 조용히 누락됐을 케이스."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_conversation(s, n_members=2)
+            me, other = seeded["member_ids"]
+            await _add_message(s, seeded["conv_id"], None, "발신자 소실 메시지", _t(0))
+
+        await _setup_app_human(app, Session, seeded["user_ids"][0], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/conversations/{seeded['conv_id']}")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["unread_count"] == 1, resp.json()
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── mark-read: up_to 지정 / 생략(now 폴백) / 멱등 / GREATEST 래칫 ───────────
+
+@pytest.mark.anyio
+async def test_mark_read_with_up_to_sets_exact_value_and_recomputes_unread():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_conversation(s, n_members=2)
+            me, other = seeded["member_ids"]
+            await _add_message(s, seeded["conv_id"], other, "msg1", _t(1))
+            await _add_message(s, seeded["conv_id"], other, "msg2", _t(2))
+            await _add_message(s, seeded["conv_id"], other, "msg3", _t(3))
+
+        await _setup_app_human(app, Session, seeded["user_ids"][0], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            up_to = _t(2).isoformat()
+            resp = await client.post(
+                f"/api/v2/conversations/{seeded['conv_id']}/read", json={"up_to": up_to},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["last_read_at"].startswith("2026-07-17T08:02:00")
+            # msg1,msg2(<=up_to) 읽음 처리, msg3(>up_to)만 unread
+            assert body["unread_count"] == 1, body
+
+            # 상세 조회로도 동일 값 재확인(GET이 같은 로직 재사용).
+            resp2 = await client.get(f"/api/v2/conversations/{seeded['conv_id']}")
+            assert resp2.json()["unread_count"] == 1
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mark_read_without_up_to_uses_now_mark_all_read():
+    """up_to 생략 = "전체 읽음"(mark-all-read) 의도 — 서버 now()로 SET, 기존 메시지 전부 read."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_conversation(s, n_members=2)
+            me, other = seeded["member_ids"]
+            await _add_message(s, seeded["conv_id"], other, "msg1", _t(1))
+            await _add_message(s, seeded["conv_id"], other, "msg2", _t(2))
+
+        await _setup_app_human(app, Session, seeded["user_ids"][0], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/conversations/{seeded['conv_id']}/read", json={})
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["unread_count"] == 0, body
+            # last_read_at ~= now(), 훨씬 미래(2026-07-17 8시대 seed보다 한참 뒤)여야.
+            last_read_at = datetime.fromisoformat(body["last_read_at"])
+            assert last_read_at > _t(2)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mark_read_greatest_ratchet_prevents_regression():
+    """역행 방지 실증: 최신 up_to로 mark-read한 뒤, 더 과거 up_to로 재호출해도 last_read_at이
+    줄어들지 않는다(GREATEST 래칫, §4-3)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_conversation(s, n_members=2)
+            me, other = seeded["member_ids"]
+            await _add_message(s, seeded["conv_id"], other, "msg1", _t(1))
+            await _add_message(s, seeded["conv_id"], other, "msg2", _t(2))
+            await _add_message(s, seeded["conv_id"], other, "msg3", _t(3))
+
+        await _setup_app_human(app, Session, seeded["user_ids"][0], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            # 먼저 최신 시각(t3)으로 mark-read.
+            resp1 = await client.post(
+                f"/api/v2/conversations/{seeded['conv_id']}/read",
+                json={"up_to": _t(3).isoformat()},
+            )
+            assert resp1.status_code == 200, resp1.text
+            assert resp1.json()["unread_count"] == 0
+
+            # 더 과거 시각(t1)으로 역행 시도 — last_read_at 이 t3에서 줄어들면 안 됨.
+            resp2 = await client.post(
+                f"/api/v2/conversations/{seeded['conv_id']}/read",
+                json={"up_to": _t(1).isoformat()},
+            )
+            assert resp2.status_code == 200, resp2.text
+            body2 = resp2.json()
+            assert body2["last_read_at"].startswith("2026-07-17T08:03:00"), body2  # 여전히 t3
+            assert body2["unread_count"] == 0, body2  # 역행 안 됐으니 여전히 0(다시 unread로 안 보임)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mark_read_idempotent_repeated_calls_same_up_to():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_conversation(s, n_members=2)
+            me, other = seeded["member_ids"]
+            await _add_message(s, seeded["conv_id"], other, "msg1", _t(1))
+
+        await _setup_app_human(app, Session, seeded["user_ids"][0], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            up_to = _t(1).isoformat()
+            r1 = await client.post(f"/api/v2/conversations/{seeded['conv_id']}/read", json={"up_to": up_to})
+            r2 = await client.post(f"/api/v2/conversations/{seeded['conv_id']}/read", json={"up_to": up_to})
+            r3 = await client.post(f"/api/v2/conversations/{seeded['conv_id']}/read", json={"up_to": up_to})
+            for r in (r1, r2, r3):
+                assert r.status_code == 200, r.text
+            assert r1.json()["last_read_at"] == r2.json()["last_read_at"] == r3.json()["last_read_at"]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mark_read_non_participant_403():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_conversation(s, n_members=2)
+            from app.models.member import Member
+            from app.models.user import User
+            outsider_user_id = uuid.uuid4()
+            s.add(User(
+                id=outsider_user_id, email=f"outsider-{outsider_user_id.hex[:8]}@test.com",
+                hashed_password="x",
+            ))
+            await s.commit()
+            outsider = Member(
+                id=uuid.uuid4(), org_id=seeded["org_id"], type="human",
+                user_id=outsider_user_id, name="Outsider",
+            )
+            s.add(outsider)
+            await s.commit()
+
+        await _setup_app_human(app, Session, outsider_user_id, seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/conversations/{seeded['conv_id']}/read", json={},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── list_conversations: N+1 방지 실측(쿼리 수 카운트) ──────────────────────
+
+@pytest.mark.anyio
+async def test_list_conversations_unread_count_single_query_not_n_plus_1():
+    """대화 3개 각각 unread 메시지가 있어도 unread_count 산출 쿼리는 정확히 1회여야 한다
+    (N+1이면 대화 수만큼 증가) — SQLAlchemy 엔진 이벤트로 실행된 SQL 캡처."""
+    from app.main import app
+    from sqlalchemy import event
+
+    engine, Session = await _session_factory()
+    try:
+        from app.models.conversation import Conversation, ConversationParticipant
+        from app.models.member import Member
+        from app.models.organization import Organization
+        from app.models.project import Project
+        from app.models.project_access import ProjectAccess
+        from app.models.user import User
+
+        async with Session() as s:
+            org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+            s.add(org)
+            await s.commit()
+            project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+            s.add(project)
+            await s.commit()
+
+            user_id = uuid.uuid4()
+            s.add(User(id=user_id, email=f"me-{user_id.hex[:8]}@test.com", hashed_password="x"))
+            await s.commit()
+            me = Member(id=uuid.uuid4(), org_id=org.id, type="human", user_id=user_id, name="Me")
+            s.add(me)
+            await s.commit()
+            s.add(ProjectAccess(
+                id=uuid.uuid4(), project_id=project.id, member_id=me.id, permission="granted", role="member",
+            ))
+            await s.commit()
+
+            other_user_id = uuid.uuid4()
+            s.add(User(id=other_user_id, email=f"other-{other_user_id.hex[:8]}@test.com", hashed_password="x"))
+            await s.commit()
+            other = Member(id=uuid.uuid4(), org_id=org.id, type="human", user_id=other_user_id, name="Other")
+            s.add(other)
+            await s.commit()
+            s.add(ProjectAccess(
+                id=uuid.uuid4(), project_id=project.id, member_id=other.id, permission="granted", role="member",
+            ))
+            await s.commit()
+
+            conv_ids = []
+            for i in range(3):
+                conv = Conversation(
+                    id=uuid.uuid4(), project_id=project.id, org_id=org.id, type="group",
+                    title=f"Convo {i}", created_by=me.id,
+                )
+                s.add(conv)
+                await s.flush()
+                s.add(ConversationParticipant(conversation_id=conv.id, member_id=me.id))
+                s.add(ConversationParticipant(conversation_id=conv.id, member_id=other.id))
+                await s.commit()
+                await _add_message(s, conv.id, other.id, f"unread in convo {i}", _t(i))
+                conv_ids.append(conv.id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+
+        # unread_count 산출 쿼리(conversation_participants JOIN conversation_messages ... GROUP BY)
+        # 발생 횟수를 센다.
+        unread_query_count = 0
+
+        def _before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+            nonlocal unread_query_count
+            low = statement.lower()
+            if "join conversation_messages" in low and "group by" in low:
+                unread_query_count += 1
+
+        event.listen(engine.sync_engine, "before_cursor_execute", _before_cursor_execute)
+        try:
+            resp = await client.get(
+                "/api/v2/conversations", params={"project_id": str(project.id)},
+            )
+            assert resp.status_code == 200, resp.text
+            data = resp.json()["data"]
+            assert len(data) == 3
+            for item in data:
+                assert item["unread_count"] == 1, item
+        finally:
+            event.remove(engine.sync_engine, "before_cursor_execute", _before_cursor_execute)
+            await client.aclose()
+
+        assert unread_query_count == 1, f"unread_count 쿼리가 {unread_query_count}회 실행됨(N+1 의심, 대화 3개)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── SSE conversation.read: 본인의 타 커넥션에만(read-receipt 스코프 아웃) ──
+
+@pytest.mark.anyio
+async def test_conversation_read_sse_pushed_only_to_self_not_other_participant():
+    """본인(sender)의 다른 커넥션 큐에는 conversation.read가 도착하고, 대화 상대방(다른 유저)의
+    큐에는 절대 도착하지 않아야 한다(read-receipt 스코프 아웃, §5-1 PO 확定) — 실 큐 실측."""
+    import asyncio
+    from app.main import app
+    import app.routers.events as events_mod
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_conversation(s, n_members=2)
+            me, other = seeded["member_ids"]
+            await _add_message(s, seeded["conv_id"], other, "msg1", _t(1))
+
+        await _setup_app_human(app, Session, seeded["user_ids"][0], seeded["org_id"])
+        client = _client_for(app)
+
+        my_other_tab_queue: asyncio.Queue = asyncio.Queue(maxsize=100)
+        other_user_queue: asyncio.Queue = asyncio.Queue(maxsize=100)
+        events_mod._agent_connections[str(me)].add(my_other_tab_queue)
+        events_mod._agent_connections[str(other)].add(other_user_queue)
+        try:
+            resp = await client.post(
+                f"/api/v2/conversations/{seeded['conv_id']}/read",
+                json={"up_to": _t(1).isoformat()},
+            )
+            assert resp.status_code == 200, resp.text
+
+            # 본인의 다른 탭 큐 — conversation.read 수신 확인.
+            received = my_other_tab_queue.get_nowait()
+            assert received["event_type"] == "conversation.read"
+            assert received["conversation_id"] == str(seeded["conv_id"])
+            assert received["member_id"] == str(me)
+
+            # 대화 상대방(other) 큐 — 절대 미수신(read-receipt 스코프 아웃 실측).
+            assert other_user_queue.empty(), "read-receipt가 상대방에게 새어나갔다 — 스코프 아웃 위반"
+        finally:
+            events_mod._agent_connections[str(me)].discard(my_other_tab_queue)
+            events_mod._agent_connections[str(other)].discard(other_user_queue)
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -294,7 +294,10 @@ async def test_list_conversations():
 
         conv_ids_result = MagicMock()
         # 270c87e6: conv_ids 쿼리가 (conversation_id, muted_at) 2컬럼 반환 — Row 속성 접근 정합.
-        conv_ids_result.all.return_value = [MagicMock(conversation_id=CONV_ID, muted_at=None)]
+        # story #1976: last_read_at 3번째 컬럼 편승(같은 배치 쿼리, 신규 쿼리 아님).
+        conv_ids_result.all.return_value = [
+            MagicMock(conversation_id=CONV_ID, muted_at=None, last_read_at=None)
+        ]
 
         total_result = MagicMock()
         total_result.scalar_one.return_value = 1
@@ -305,12 +308,16 @@ async def test_list_conversations():
         p_rows_result = MagicMock()
         p_rows_result.all.return_value = []
 
+        # story #1976: unread_count 배치 쿼리(단일 JOIN+GROUP BY) — 빈 결과=전 대화 unread 0.
+        unread_result = MagicMock()
+        unread_result.all.return_value = []
+
         latest_msg_result = MagicMock()
         latest_msg_result.scalar_one_or_none.return_value = mock_msg
 
         session.execute = AsyncMock(side_effect=[
             member_result, conv_ids_result, total_result,
-            convs_result, p_rows_result, latest_msg_result,
+            convs_result, p_rows_result, unread_result, latest_msg_result,
         ])
 
         async with client as c:
@@ -400,9 +407,10 @@ async def test_get_conversation_200_returns_project_id():
         agents_result = MagicMock()
         agents_result.scalars.return_value.all.return_value = [agent_id]  # 전원 agent 확정
 
-        # 270c87e6: detail이 caller muted_at 조회 1건 추가 — 비참여(agent-only)면 None=미mute.
+        # 270c87e6: detail이 caller (muted_at, last_read_at) 조회 1건 추가(story #1976: last_read_at
+        # 편승) — 비참여(agent-only)면 row 자체가 None(=미mute·unread_count 계산 스킵).
         muted_result = MagicMock()
-        muted_result.scalar_one_or_none.return_value = None
+        muted_result.one_or_none.return_value = None
 
         session.execute = AsyncMock(side_effect=[conv_result, member_result, pids_result, agents_result, muted_result])
 


### PR DESCRIPTION
## Summary
- doc `chat-realtime-track-a-read-state-design`(PO in-principle 승인) 그대로 구현 — 임의 변경 없음.
- `conversation_participants.last_read_at` 컬럼 신설(마이그 `0199`, `down_revision="0198"`). nullable·server_default 없음(`muted_at`과 동형 스타일, `0115` 선례 정합).
- **백필 UPDATE 미포함** — 순수 `ADD COLUMN`만. 기존 참가자 row는 마이그 시점 전량 `last_read_at=NULL`("한 번도 안 읽음")로 그대로. 선생님이 이후 확定: **(a) NULL 반영 — 백필 없음이 영구 확定**(임시 보류 아님).
- `POST /api/v2/conversations/{id}/read` — mark-read. body `up_to`(optional timestamp).
  - `up_to` 지정 시 그 시각으로 SET(FE가 실 렌더된 마지막 메시지 timestamp 전달 — 권장 경로).
  - `up_to` 생략 시 서버 `now()` 사용 — 이는 명시적 **"전체 읽음"(mark-all-read)** 의도 전용.
  - `GREATEST(COALESCE(last_read_at, epoch), up_to)` 원자 UPDATE — 멱등 + 역행 방지(래칫).
  - 비참여자는 403.
- `unread_count` 정의 = **`last_read_at` 이후 & `sender_id IS DISTINCT FROM` 나** — `!=` 아님(`sender_id` nullable이라 3-값 논리 함정 회피).
- `list_conversations`/`get_conversation` 양쪽에 `unread_count`+`last_read_at` 노출. `list_conversations`는 단일 **JOIN+GROUP BY**(N+1 방지) — 쿼리수 실측 테스트로 대화 수 무관 1회 확인.
- `conversation.read` SSE — 기존 검증된 `_push_to_agent(member_id, payload)` 패턴 재사용(Event row 미생성, org 브로드캐스트 아님). **본인의 타 커넥션에만** 전파 — read-receipt(상대방 노출)는 명시적 스코프 아웃, 실측 테스트로 타 유저 미수신 확인.

## Test plan
- [x] 순수 쿼리조립 단위 테스트 12건(`tests/test_1976_read_state_query_builders.py`) — GREATEST/COALESCE/IS DISTINCT FROM/JOIN+GROUP BY 컴파일 SQL 검증. DB 불요.
- [x] realPG 통합 테스트 9건(`tests/test_1976_read_state_realdb.py`):
  - unread_count 정의(자기발신 제외/타인포함, NULL sender 포함)
  - mark-read `up_to` 지정 정확성, `up_to` 생략 시 now() mark-all-read
  - GREATEST 래칫 역행 방지(과거 up_to 재호출해도 안 줄어듦)
  - mark-read 멱등(3회 반복 호출 동일 결과)
  - 비참여자 403
  - `list_conversations` unread_count 쿼리수 실측 — 대화 3개에도 정확히 1회
  - `conversation.read` SSE 본인 타 커넥션 수신 + 대화 상대방 큐 미수신(read-receipt 스코프 아웃) 실측
- [x] 기존 `test_conversations.py` 회귀 스위트(30건, 신규 쿼리 반영해 mock 갱신) GREEN.
- [x] 뮤테이션 셀프체크: `IS DISTINCT FROM`→`!=`, GREATEST 제거 — 각각 대상 테스트 RED 확인 후 Edit로 원복, 전체 재확인 GREEN.
- [x] `uvx ruff check` clean(diff 범위 내).
- [ ] CI green — push 후 `gh pr checks`로 확인 예정.

**머지하지 않음** — PO(오르테가)가 CI green + realPG 실증 확인 후 직접 머지 결정.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>