### PR TITLE
fix(logging): story #1743 — GCP Error Reporting 자동 감지/그룹핑 호환

### DIFF
--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from typing import Any
 
@@ -18,13 +19,32 @@ class JsonFormatter(logging.Formatter):
             logging.ERROR: "ERROR",
             logging.CRITICAL: "CRITICAL",
         }
+        message = record.getMessage()
         payload: dict[str, Any] = {
             "severity": severity_map.get(record.levelno, "DEFAULT"),
-            "message": record.getMessage(),
+            "message": message,
             "logger": record.name,
         }
         if record.exc_info:
-            payload["exception"] = self.formatException(record.exc_info)
+            formatted_exc = self.formatException(record.exc_info)
+            # story #1743: 기존 jsonPayload.exception(커스텀 필드)은 하위호환을 위해 유지한다
+            # (다른 소비자 없음을 grep으로 확인했지만 breaking 방지 차 additive만 적용).
+            # GCP Error Reporting은 jsonPayload.message(또는 stack_trace/exception) 필드 값이
+            # 지원 언어의 스택 트레이스 포맷을 담고 있어야 자동 감지/그룹핑한다
+            # (https://cloud.google.com/error-reporting/docs/formatting-error-messages
+            # "Log a stack trace" 섹션). message에도 traceback 텍스트를 포함시켜 자동 감지
+            # 경로를 명시적으로 커버 — exception 필드만 있을 때 발생할 수 있는 파서 엣지케이스에
+            # 대한 안전망(additive, 회귀 없음).
+            payload["message"] = f"{message}\n{formatted_exc}" if message else formatted_exc
+            payload["exception"] = formatted_exc
+            # Cloud Run에서 serviceContext.service/version 부재 시 리소스 타입이 cloud_run_revision이
+            # 아닌 global로 잡혀 Error Reporting이 에러를 그룹핑하지 못하는 알려진 함정이 있다
+            # (K_SERVICE/K_REVISION은 Cloud Run이 자동 주입하는 표준 env var — 로컬/테스트 환경에서는
+            # 없으므로 고정 fallback 사용). exc_info가 있을 때만 부여 — 평시 로그 스키마는 불변.
+            payload["serviceContext"] = {
+                "service": os.getenv("K_SERVICE", "sprintable-backend"),
+                "version": os.getenv("K_REVISION", "unknown"),
+            }
         if hasattr(record, "request_id"):
             payload["httpRequest"] = {"requestId": record.request_id}
         # E-LOOP-LEDGER P1-S8: 임의 구조화 필드 pass-through(logger.info(..., extra={"structured": {...}}))

--- a/backend/tests/test_1743_error_reporting_compat.py
+++ b/backend/tests/test_1743_error_reporting_compat.py
@@ -1,0 +1,74 @@
+"""story #1743(재스코핑): GCP Error Reporting 자동 감지/그룹핑 호환.
+
+배경: JsonFormatter가 exc_info 있을 때 traceback을 jsonPayload.exception(커스텀 필드)에만
+넣었다 — 이 데이터는 Cloud Logging에 도달하지만(Log Explorer에서 확인 가능), GCP Error
+Reporting은 이 비표준 필드명을 자동으로 감지/그룹핑하지 못한다. Error Reporting 문서
+("Log a stack trace" — jsonPayload.message/stack_trace/exception 중 하나에 지원 언어
+스택 트레이스 포맷이 있어야 자동 인식)에 맞춰 message 필드에도 traceback 텍스트를 포함시킨다.
+기존 jsonPayload.exception 필드는 하위호환을 위해 그대로 유지(additive, 회귀 없음).
+"""
+import json
+import logging
+
+from app.core.logging_config import JsonFormatter
+
+
+def _make_record_with_exc_info(msg: str = "boom") -> logging.LogRecord:
+    try:
+        raise ValueError("test exception for 1743")
+    except ValueError:
+        import sys
+        exc_info = sys.exc_info()
+    return logging.LogRecord(
+        name="test", level=logging.ERROR, pathname="x", lineno=1,
+        msg=msg, args=(), exc_info=exc_info,
+    )
+
+
+def test_message_field_includes_traceback_when_exc_info_present():
+    """핵심 불변식: exc_info 있으면 message 필드 자체에 traceback 패턴이 포함된다
+    (Error Reporting 자동 감지 대상은 message/stack_trace/exception 필드)."""
+    formatter = JsonFormatter()
+    record = _make_record_with_exc_info("boom")
+    payload = json.loads(formatter.format(record))
+    assert "Traceback (most recent call last)" in payload["message"]
+    assert "ValueError: test exception for 1743" in payload["message"]
+    # 원래 로그 메시지도 유실되지 않고 message 안에 남아있어야 한다.
+    assert "boom" in payload["message"]
+
+
+def test_existing_exception_field_preserved_for_backward_compat():
+    """기존 jsonPayload.exception 필드는 다른 소비자가 있을 수 있으므로 additive만 —
+    제거/변경 금지. message와 동일한 traceback 텍스트를 그대로 유지한다."""
+    formatter = JsonFormatter()
+    record = _make_record_with_exc_info("boom")
+    payload = json.loads(formatter.format(record))
+    assert "exception" in payload
+    assert "Traceback (most recent call last)" in payload["exception"]
+    assert "ValueError: test exception for 1743" in payload["exception"]
+
+
+def test_service_context_added_when_exc_info_present():
+    """Cloud Run 알려진 함정: serviceContext.service/version 부재 시 리소스 타입이
+    global로 잡혀 Error Reporting 그룹핑 실패. K_SERVICE/K_REVISION(Cloud Run 자동 주입
+    표준 env var) 기반으로 채운다."""
+    formatter = JsonFormatter()
+    record = _make_record_with_exc_info("boom")
+    payload = json.loads(formatter.format(record))
+    assert "serviceContext" in payload
+    assert "service" in payload["serviceContext"]
+    assert payload["serviceContext"]["service"]  # non-empty
+
+
+def test_no_exc_info_leaves_message_and_schema_unchanged():
+    """exc_info 없는 평시 로그는 스키마 불변 — message에 traceback 안 붙고
+    exception/serviceContext 키 자체가 없어야 한다(회귀 방지)."""
+    formatter = JsonFormatter()
+    record = logging.LogRecord(
+        name="test", level=logging.INFO, pathname="x", lineno=1,
+        msg="plain log", args=(), exc_info=None,
+    )
+    payload = json.loads(formatter.format(record))
+    assert payload["message"] == "plain log"
+    assert "exception" not in payload
+    assert "serviceContext" not in payload


### PR DESCRIPTION
## Summary
- story #1743(재스코핑): `jsonPayload.exception`(커스텀 필드)은 Cloud Logging에는 도달하지만 GCP Error Reporting 자동 감지 대상 필드가 아니다. GCP 공식 문서("Log a stack trace" 섹션, https://docs.cloud.google.com/error-reporting/docs/formatting-error-messages)에 따르면 jsonPayload의 `message`/`stack_trace`/`exception` 세 필드만 자동 스캔되며, 값이 지원 언어의 스택 트레이스 포맷이어야 한다.
- `JsonFormatter.format()`에서 `exc_info`가 있을 때 traceback 텍스트를 `message` 필드에도 포함(기존 `exception` 필드는 하위호환 위해 그대로 유지 — additive, 회귀 없음. grep으로 다른 소비자 없음 확인).
- Cloud Run에서 `serviceContext.service`/`version` 부재 시 리소스 타입이 `cloud_run_revision`이 아닌 `global`로 잡혀 Error Reporting이 그룹핑하지 못하는 알려진 함정이 있어(리서치로 확인), `K_SERVICE`/`K_REVISION`(Cloud Run 자동 주입 표준 env var) 기반 `serviceContext`를 exc_info 있을 때만 추가.
- **라이브 실측으로 갭 실재 확인**: `clouderrorreporting.googleapis.com` groupStats API를 직접 조회 — dev 프로젝트(`sprintable-494803`)에 현재 14개 에러 그룹이 존재하는데, 전부 message 필드에 raw traceback 텍스트가 이미 들어있던 케이스(uvicorn/starlette 등 다른 경로)뿐이었고, `unhandled_exception_handler`(main.py:139) 경로로 발생한 에러(`"Unhandled exception on ..."` 메시지 prefix)는 단 하나도 그룹화되지 않았음을 확인했다. 이 fix로 해당 경로 에러도 그룹화 대상이 된다.

## Test plan
- [x] 유닛 테스트 RED→GREEN: `backend/tests/test_1743_error_reporting_compat.py` 4종(신규) — message에 traceback 포함, exception 필드 하위호환 유지, serviceContext 부여, 평시 로그 스키마 불변.
- [x] 뮤테이션 셀프체크: message 필드 변경 되돌려서 RED 확인 → 원복 → GREEN 재확인.
- [x] 기존 로깅 관련 테스트(`test_e_loop_ledger_p1_s8_a2_instrumentation.py`) 회귀 없음 확인.
- [ ] **dev 배포 후 라이브 Error Reporting 대시보드에서 그룹핑 실제 확인 필요** — 이 PR은 코드 fix만 포함. 배포 권한/프로세스가 이 세션 범위 밖(develop merge 시 Cloud Build 자동배선 여부는 확인했으나 머지 자체는 하지 않음)이라 머지+배포 후 별도 라이브 검증 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)