### PR TITLE
feat(chat): story #1992 — GET /api/v2/conversations/unread-count (GNB total)

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -1011,12 +1011,13 @@ async def get_unread_count_total(
     """GET /api/v2/conversations/unread-count — story #1992: GNB 채팅 unread 총합(count-only).
 
     caller(인증된 member)가 참여 중인 **전 대화**(페이지네이션 무관)의 unread_count를 SUM한
-    `{"total": int}`만 반환 — 대화 메타데이터(제목/참가자 등) 미포함. list_conversations의
+    `{"count": int}`만 반환 — 대화 메타데이터(제목/참가자 등) 미포함. list_conversations의
     per-conversation unread_count(story #1976, §4-2 `_list_unread_counts_stmt`)와 동일
     SSOT 쿼리를 확장(`_total_unread_count_stmt`)해 재사용 — 계산 로직 재구현 없음.
 
     project_id 미지정: GNB는 프로젝트 무관 org-wide 집계(다른 count-only 엔드포인트인
-    event-notifications/unread-count와 동일 관례 — `{"total": int}` shape로 통일).
+    event-notifications/unread-count·notifications/count와 동일 관례로 `{"count": int}`
+    shape 통일 — PO 정정, 2026-07-18: 초안은 `{"total"}`이었으나 API 일관성 우선).
 
     주의(기존 아키텍처 갭 · 본 story 스코프 밖): `_resolve_member`가 project_id 없이 호출되면
     복수 project의 team_member 행을 가진 human은 `.first()`로 임의 1개 project만 해소된다
@@ -1025,7 +1026,7 @@ async def get_unread_count_total(
     """
     sender = await _resolve_member(auth, org_id, db)
     total = (await db.execute(_total_unread_count_stmt(sender.id))).scalar_one()
-    return {"total": int(total)}
+    return {"count": int(total)}
 
 
 @router.get("/{conversation_id}", response_model=ConversationResponse)

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -280,17 +280,21 @@ def _unread_count_stmt(conversation_id: uuid.UUID, member_id: uuid.UUID, since: 
     )
 
 
-def _list_unread_counts_stmt(member_id: uuid.UUID, conv_id_list: list[uuid.UUID]):
+def _list_unread_counts_stmt(member_id: uuid.UUID, conv_id_list: list[uuid.UUID] | None = None):
     """list_conversations 배치 unread_count — 단일 JOIN+GROUP BY(N+1 방지, §4-2).
 
     대화마다 기준 시각(last_read_at)이 다른 상관 카운트라 순수 IN 배치로는 불가 — JOIN
     조건에 기준 시각 비교를 박아 넣어 페이지 대화 수(N)와 무관하게 쿼리 1회로 해결.
     INNER JOIN이라 unread=0인 대화는 결과행 자체가 없음(호출부가 dict.get(id, 0)으로 처리).
+
+    conv_id_list=None이면 caller가 참여 중인 **모든** 대화를 대상(전량, 페이지네이션 무관) —
+    story #1992(GNB unread 총합)가 `_total_unread_count_stmt`로 이 "전량 모드"를 서브쿼리로
+    감싸 SUM 재사용(동일 JOIN+`IS DISTINCT FROM` 조건 SSOT, 중복 없음).
     """
-    return (
+    stmt = (
         select(
             ConversationParticipant.conversation_id,
-            func.count(ConversationMessage.id),
+            func.count(ConversationMessage.id).label("unread_count"),
         )
         .join(
             ConversationMessage,
@@ -302,12 +306,26 @@ def _list_unread_counts_stmt(member_id: uuid.UUID, conv_id_list: list[uuid.UUID]
                 ConversationMessage.sender_id.is_distinct_from(member_id),
             ),
         )
-        .where(
-            ConversationParticipant.member_id == member_id,
-            ConversationParticipant.conversation_id.in_(conv_id_list),
-        )
+        .where(ConversationParticipant.member_id == member_id)
         .group_by(ConversationParticipant.conversation_id)
     )
+    if conv_id_list is not None:
+        stmt = stmt.where(ConversationParticipant.conversation_id.in_(conv_id_list))
+    return stmt
+
+
+def _total_unread_count_stmt(member_id: uuid.UUID):
+    """story #1992: GNB 채팅 unread 총합(count-only) — caller의 전 참여 대화(페이지네이션 무관)
+    unread_count SUM.
+
+    `_list_unread_counts_stmt(member_id)`(conv_id_list=None → 전량 모드)를 서브쿼리로 감싸
+    SUM 래퍼만 추가한다 — JOIN+`IS DISTINCT FROM` 계산 로직 재구현 없음(단일 SSOT, list_conversations
+    의 per-conversation unread_count와 동일 정의). INNER JOIN 특성상 대화별 최소 1건이라도 unread가
+    있어야 그룹행이 생기므로, 참여 대화가 전무하거나 전부 unread 0이면 서브쿼리 결과가 0행 —
+    COALESCE(SUM(...), 0)으로 NULL을 0으로 정규화한다.
+    """
+    per_conv = _list_unread_counts_stmt(member_id).subquery()
+    return select(func.coalesce(func.sum(per_conv.c.unread_count), 0))
 
 
 _SUMMARY_PREVIEW_MAX = 80
@@ -982,6 +1000,32 @@ async def list_conversations(
         })
 
     return {"data": result, "total": total, "limit": limit, "offset": offset}
+
+
+@router.get("/unread-count")
+async def get_unread_count_total(
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """GET /api/v2/conversations/unread-count — story #1992: GNB 채팅 unread 총합(count-only).
+
+    caller(인증된 member)가 참여 중인 **전 대화**(페이지네이션 무관)의 unread_count를 SUM한
+    `{"total": int}`만 반환 — 대화 메타데이터(제목/참가자 등) 미포함. list_conversations의
+    per-conversation unread_count(story #1976, §4-2 `_list_unread_counts_stmt`)와 동일
+    SSOT 쿼리를 확장(`_total_unread_count_stmt`)해 재사용 — 계산 로직 재구현 없음.
+
+    project_id 미지정: GNB는 프로젝트 무관 org-wide 집계(다른 count-only 엔드포인트인
+    event-notifications/unread-count와 동일 관례 — `{"total": int}` shape로 통일).
+
+    주의(기존 아키텍처 갭 · 본 story 스코프 밖): `_resolve_member`가 project_id 없이 호출되면
+    복수 project의 team_member 행을 가진 human은 `.first()`로 임의 1개 project만 해소된다
+    (event_notifications.py `_resolve_member_id`도 동일 관례). grant-only 휴먼은 canonical
+    org_member.id로 해소되어 이 갭이 없다.
+    """
+    sender = await _resolve_member(auth, org_id, db)
+    total = (await db.execute(_total_unread_count_stmt(sender.id))).scalar_one()
+    return {"total": int(total)}
 
 
 @router.get("/{conversation_id}", response_model=ConversationResponse)

--- a/backend/tests/test_1992_unread_count_total_realdb.py
+++ b/backend/tests/test_1992_unread_count_total_realdb.py
@@ -1,0 +1,346 @@
+"""story #1992: GET /api/v2/conversations/unread-count — GNB 채팅 unread 총합(count-only)
+realPG 통합 테스트.
+
+story #1976(read state 서버 truth)이 만든 `_list_unread_counts_stmt`(list_conversations
+배치 unread_count SSOT)를 확장한 `_total_unread_count_stmt`가 caller의 전 참여 대화
+unread_count를 정확히 SUM하는지 실증. 커버:
+- 대화 3개(unread 3 + 0 + 2) → total=5.
+- mark-read 후 total 감소.
+- 본인 발신 메시지 제외(`IS DISTINCT FROM`).
+- 비참여 대화는 total에 미포함.
+- N+1 방지(참여 대화 수 늘어도 쿼리 수 고정).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _make_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org, project
+
+
+async def _make_human_member(session, org_id, project_id):
+    from app.models.member import Member
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    user = User(id=user_id, email=f"human-{user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    m = Member(id=uuid.uuid4(), org_id=org_id, type="human", user_id=user_id, name=f"M-{user_id.hex[:6]}")
+    session.add(m)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_id, member_id=m.id, permission="granted", role="member",
+    ))
+    await session.commit()
+    return m.id, user_id
+
+
+async def _make_conversation(session, org_id, project_id, member_ids, created_by):
+    from app.models.conversation import Conversation, ConversationParticipant
+
+    conv = Conversation(
+        id=uuid.uuid4(), project_id=project_id, org_id=org_id, type="group",
+        title="Test convo", created_by=created_by,
+    )
+    session.add(conv)
+    await session.flush()
+    for mid in member_ids:
+        session.add(ConversationParticipant(conversation_id=conv.id, member_id=mid))
+    await session.commit()
+    return conv.id
+
+
+async def _add_message(session, conv_id, sender_id, content: str, created_at: datetime):
+    from app.models.conversation import ConversationMessage
+    msg = ConversationMessage(
+        id=uuid.uuid4(), conversation_id=conv_id, sender_id=sender_id,
+        content=content, created_at=created_at,
+    )
+    session.add(msg)
+    await session.commit()
+    return msg
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+T0 = datetime(2026, 7, 17, 8, 0, 0, tzinfo=timezone.utc)
+
+
+def _t(minutes: int) -> datetime:
+    return T0 + timedelta(minutes=minutes)
+
+
+async def _seed_three_conversations(session):
+    """org(1) + project(1) + me + other. 대화 A(unread 3) + 대화 B(unread 0, 내가 이미 다 읽음)
+    + 대화 C(unread 2). A/B/C 전부 me+other 2인 group. 반환: org_id/project_id/me/other/user_id_me/
+    conv_ids(dict)."""
+    org, project = await _make_org_project(session)
+    me, user_id_me = await _make_human_member(session, org.id, project.id)
+    other, _user_id_other = await _make_human_member(session, org.id, project.id)
+
+    conv_a = await _make_conversation(session, org.id, project.id, [me, other], created_by=me)
+    await _add_message(session, conv_a, other, "A-msg1", _t(1))
+    await _add_message(session, conv_a, other, "A-msg2", _t(2))
+    await _add_message(session, conv_a, other, "A-msg3", _t(3))
+    # 본인 발신 메시지도 섞는다 — total에서 제외돼야 함(회귀 감지용).
+    await _add_message(session, conv_a, me, "A-mine", _t(4))
+
+    conv_b = await _make_conversation(session, org.id, project.id, [me, other], created_by=me)
+    await _add_message(session, conv_b, other, "B-msg1", _t(1))
+    # conv_b는 내가 이미 다 읽은 상태로 만든다(last_read_at을 미래로 세팅) — unread 0.
+    from app.models.conversation import ConversationParticipant
+    from sqlalchemy import update
+    await session.execute(
+        update(ConversationParticipant)
+        .where(
+            ConversationParticipant.conversation_id == conv_b,
+            ConversationParticipant.member_id == me,
+        )
+        .values(last_read_at=_t(100))
+    )
+    await session.commit()
+
+    conv_c = await _make_conversation(session, org.id, project.id, [me, other], created_by=me)
+    await _add_message(session, conv_c, other, "C-msg1", _t(1))
+    await _add_message(session, conv_c, other, "C-msg2", _t(2))
+
+    return {
+        "org_id": org.id, "project_id": project.id, "me": me, "other": other,
+        "user_id_me": user_id_me,
+        "conv_a": conv_a, "conv_b": conv_b, "conv_c": conv_c,
+    }
+
+
+# ─── AC3 done-gate: total=5 (3 + 0 + 2), 본인 제외, mark-read 후 감소, 비참여 제외 ──────
+
+@pytest.mark.anyio
+async def test_unread_count_total_sums_across_all_participating_conversations():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_three_conversations(s)
+
+        await _setup_app_human(app, Session, seeded["user_id_me"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/conversations/unread-count")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            # count-only: total 외 다른 필드(제목/참가자 등) 없어야 함.
+            assert set(body.keys()) == {"total"}, body
+            assert body["total"] == 5, body  # A:3(본인발신 1건 제외) + B:0 + C:2
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unread_count_total_decreases_after_mark_read():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_three_conversations(s)
+
+        await _setup_app_human(app, Session, seeded["user_id_me"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp0 = await client.get("/api/v2/conversations/unread-count")
+            assert resp0.json()["total"] == 5, resp0.json()
+
+            # conv_a 전체 read 처리 (unread 3 -> 0).
+            mark_resp = await client.post(
+                f"/api/v2/conversations/{seeded['conv_a']}/read", json={},
+            )
+            assert mark_resp.status_code == 200, mark_resp.text
+
+            resp1 = await client.get("/api/v2/conversations/unread-count")
+            assert resp1.status_code == 200, resp1.text
+            assert resp1.json()["total"] == 2, resp1.json()  # C만 남음
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unread_count_total_excludes_non_participating_conversation():
+    """caller가 참여하지 않는 대화(제3자 group)는 total에 전혀 반영되지 않아야 한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_three_conversations(s)
+            # 제3자 전용 대화(caller 미참여) — unread가 있어도 caller total에 안 들어가야.
+            third, _third_user_id = await _make_human_member(s, seeded["org_id"], seeded["project_id"])
+            fourth, _fourth_user_id = await _make_human_member(s, seeded["org_id"], seeded["project_id"])
+            other_conv = await _make_conversation(
+                s, seeded["org_id"], seeded["project_id"], [third, fourth], created_by=third,
+            )
+            await _add_message(s, other_conv, fourth, "not-mine", _t(1))
+
+        await _setup_app_human(app, Session, seeded["user_id_me"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/conversations/unread-count")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["total"] == 5, resp.json()  # 제3자 대화 미반영, 여전히 5
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unread_count_total_zero_when_no_conversations():
+    """참여 대화가 전무한 caller는 total=0(INNER JOIN 서브쿼리 0행 → COALESCE(SUM,0) 정규화)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _make_org_project(s)
+            me, user_id_me = await _make_human_member(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, user_id_me, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/conversations/unread-count")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["total"] == 0, resp.json()
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── N+1 방지: 참여 대화 수가 늘어도 unread-count 쿼리는 정확히 1회 ─────────────
+
+@pytest.mark.anyio
+async def test_unread_count_total_single_query_not_n_plus_1():
+    from app.main import app
+    from sqlalchemy import event
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _make_org_project(s)
+            me, user_id_me = await _make_human_member(s, org.id, project.id)
+            other, _ = await _make_human_member(s, org.id, project.id)
+
+            conv_ids = []
+            for i in range(5):
+                conv_id = await _make_conversation(s, org.id, project.id, [me, other], created_by=me)
+                await _add_message(s, conv_id, other, f"unread in convo {i}", _t(i))
+                conv_ids.append(conv_id)
+
+        await _setup_app_human(app, Session, user_id_me, org.id)
+        client = _client_for(app)
+
+        unread_query_count = 0
+
+        def _before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+            nonlocal unread_query_count
+            low = statement.lower()
+            if "join conversation_messages" in low and "group by" in low:
+                unread_query_count += 1
+
+        event.listen(engine.sync_engine, "before_cursor_execute", _before_cursor_execute)
+        try:
+            resp = await client.get("/api/v2/conversations/unread-count")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["total"] == 5, resp.json()
+        finally:
+            event.remove(engine.sync_engine, "before_cursor_execute", _before_cursor_execute)
+            await client.aclose()
+
+        assert unread_query_count == 1, (
+            f"unread-count total 쿼리가 {unread_query_count}회 실행됨(N+1 의심, 대화 5개)"
+        )
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_1992_unread_count_total_realdb.py
+++ b/backend/tests/test_1992_unread_count_total_realdb.py
@@ -204,8 +204,8 @@ async def test_unread_count_total_sums_across_all_participating_conversations():
             assert resp.status_code == 200, resp.text
             body = resp.json()
             # count-only: total 외 다른 필드(제목/참가자 등) 없어야 함.
-            assert set(body.keys()) == {"total"}, body
-            assert body["total"] == 5, body  # A:3(본인발신 1건 제외) + B:0 + C:2
+            assert set(body.keys()) == {"count"}, body
+            assert body["count"] == 5, body  # A:3(본인발신 1건 제외) + B:0 + C:2
         finally:
             await client.aclose()
     finally:
@@ -226,7 +226,7 @@ async def test_unread_count_total_decreases_after_mark_read():
         client = _client_for(app)
         try:
             resp0 = await client.get("/api/v2/conversations/unread-count")
-            assert resp0.json()["total"] == 5, resp0.json()
+            assert resp0.json()["count"] == 5, resp0.json()
 
             # conv_a 전체 read 처리 (unread 3 -> 0).
             mark_resp = await client.post(
@@ -236,7 +236,7 @@ async def test_unread_count_total_decreases_after_mark_read():
 
             resp1 = await client.get("/api/v2/conversations/unread-count")
             assert resp1.status_code == 200, resp1.text
-            assert resp1.json()["total"] == 2, resp1.json()  # C만 남음
+            assert resp1.json()["count"] == 2, resp1.json()  # C만 남음
         finally:
             await client.aclose()
     finally:
@@ -266,7 +266,7 @@ async def test_unread_count_total_excludes_non_participating_conversation():
         try:
             resp = await client.get("/api/v2/conversations/unread-count")
             assert resp.status_code == 200, resp.text
-            assert resp.json()["total"] == 5, resp.json()  # 제3자 대화 미반영, 여전히 5
+            assert resp.json()["count"] == 5, resp.json()  # 제3자 대화 미반영, 여전히 5
         finally:
             await client.aclose()
     finally:
@@ -290,7 +290,7 @@ async def test_unread_count_total_zero_when_no_conversations():
         try:
             resp = await client.get("/api/v2/conversations/unread-count")
             assert resp.status_code == 200, resp.text
-            assert resp.json()["total"] == 0, resp.json()
+            assert resp.json()["count"] == 0, resp.json()
         finally:
             await client.aclose()
     finally:
@@ -333,7 +333,7 @@ async def test_unread_count_total_single_query_not_n_plus_1():
         try:
             resp = await client.get("/api/v2/conversations/unread-count")
             assert resp.status_code == 200, resp.text
-            assert resp.json()["total"] == 5, resp.json()
+            assert resp.json()["count"] == 5, resp.json()
         finally:
             event.remove(engine.sync_engine, "before_cursor_execute", _before_cursor_execute)
             await client.aclose()


### PR DESCRIPTION
## Summary
- story #1992: GNB 채팅 unread 총합 count-only 엔드포인트 신설 — `GET /api/v2/conversations/unread-count` → `{"total": int}`.
- caller가 참여 중인 **전 대화**(페이지네이션 무관) unread_count를 SUM. 대화 메타데이터(제목/참가자 등) 미포함.
- story #1976의 SSOT 쿼리를 **재사용/확장**했다(계산 로직 재구현 없음):
  - `_list_unread_counts_stmt(member_id, conv_id_list=None)` — `conv_id_list`를 옵셔널화(기존 `list_conversations` 호출부는 그대로 non-None 전달·회귀 없음). `None`이면 caller의 참여 대화 전량을 대상으로 하는 동일 JOIN+GROUP BY 쿼리가 된다.
  - `_total_unread_count_stmt(member_id)` — 위 "전량 모드" 쿼리를 서브쿼리로 감싸 `SUM(unread_count)` 래퍼만 추가. JOIN 조건·`IS DISTINCT FROM`(sender nullable 3값논리 함정 회피) 로직은 단 한 곳(`_list_unread_counts_stmt`)에만 존재.
- 라우트는 동적 라우트 `/{conversation_id}` **앞**에 등록(정적 경로 우선 매칭 — 안 그러면 `unread-count`가 `conversation_id: uuid.UUID`로 파싱 시도돼 422).
- 응답 shape `{"total": int}`는 story AC 명시 그대로. (참고: 레포 내 다른 count-only 엔드포인트인 `event-notifications/unread-count`·`/notifications/count`는 `{"count": int}` 관례를 쓰지만, 본 story AC가 `{"total": int}`를 명시해 그대로 따름.)

## realPG 실증 (`sprintable_s1976_test`, PG 16, alembic head 0199)
전량 로그: 커밋에 포함된 `backend/tests/test_1992_unread_count_total_realdb.py` 5건 + 회귀 45건 = **50 passed**.

```
tests/test_1992_unread_count_total_realdb.py::test_unread_count_total_sums_across_all_participating_conversations PASSED
tests/test_1992_unread_count_total_realdb.py::test_unread_count_total_decreases_after_mark_read PASSED
tests/test_1992_unread_count_total_realdb.py::test_unread_count_total_excludes_non_participating_conversation PASSED
tests/test_1992_unread_count_total_realdb.py::test_unread_count_total_zero_when_no_conversations PASSED
tests/test_1992_unread_count_total_realdb.py::test_unread_count_total_single_query_not_n_plus_1 PASSED
...
tests/test_1976_read_state_realdb.py (9) PASSED
tests/test_1976_read_state_query_builders.py (12) PASSED
tests/test_conversations.py (15) PASSED
tests/test_eventbus_s5.py (9) PASSED
======================== 50 passed, 1 warning in 2.27s ========================
```

- **total=5 케이스**: 대화 A(unread 3, 본인 발신 1건 별도 시드) + 대화 B(unread 0, 이미 읽음) + 대화 C(unread 2) → `GET /unread-count` = `{"total": 5}` (AC3 done-gate 정확 일치).
- **mark-read 후 감소**: 초기 total=5 → 대화 A `/read` 호출(전체 읽음) → total=2(C만 잔존).
- **본인 발신 제외**: 대화 A에 본인 발신 메시지("A-mine")를 섞어 시드 — total 계산에서 제외됨을 5(=3+0+2, 본인 발신 미포함)로 확인. 뮤테이션 셀프체크로도 재확인(아래).
- **비참여 대화 제외**: caller 미참여 제3자 group 대화(unread 있음)를 추가 시드해도 total 불변(여전히 5).
- **참여 0건**: 대화가 전무한 caller는 total=0 (INNER JOIN 서브쿼리 0행 → `COALESCE(SUM,0)` 정규화 확인).

## N+1 방지 실측
`before_cursor_execute` 이벤트로 실행 SQL 캡처(story #1973/#1974/#1976과 동일 패턴) — 참여 대화 5개에도 `unread-count` 산출 쿼리는 정확히 **1회**(`assert unread_query_count == 1`).

## 뮤테이션 셀프체크
`_list_unread_counts_stmt`의 `ConversationMessage.sender_id.is_distinct_from(member_id)` 조건을 `text("true")`로 무력화(본인 발신 제외 조건 제거) →

```
FAILED test_unread_count_total_sums_across_all_participating_conversations — AssertionError: {'total': 6} != 5
FAILED test_unread_count_total_decreases_after_mark_read
FAILED test_unread_count_total_excludes_non_participating_conversation
3 failed, 11 passed
```

원복 후 재실행 → 50 passed(GREEN). `git diff --stat` 확인 결과 프로브 잔존 없음.

## Test plan
- [x] realPG(`sprintable_s1976_test`, PG16) 통합 테스트 5건 신규 — total=5/mark-read 감소/본인제외/비참여0/참여0
- [x] N+1 방지 실측(쿼리 1회 고정)
- [x] 뮤테이션 셀프체크(RED→GREEN)
- [x] 회귀: #1976 read-state realdb/query-builder + conversations + eventbus_s5 — 45건 전부 GREEN
- [x] 정적 라우트(`/unread-count`) vs 동적 라우트(`/{conversation_id}`) 순서 검증(app.routes 출력으로 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)