### PR TITLE
[SID:1990] back 재진입 트랩 — push→replace 백버튼 통일

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx
@@ -262,7 +262,8 @@ export default function EpicDetailPage() {
       <TopBarSlot
         title={
           <div className="flex items-center gap-2">
-            <Link href={`/${wsSlug}/${projSlug}/goals`} className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
+            {/* story #1990: replace, 기본 push 아님 — 뒤로가기 재진입 트랩 방지(gates/chats와 동일 원칙, §3.2). */}
+            <Link href={`/${wsSlug}/${projSlug}/goals`} replace className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
               <ArrowLeft className="h-3.5 w-3.5" />
               목표 목록
             </Link>

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/loops/[id]/loop-detail-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/loops/[id]/loop-detail-client.tsx
@@ -126,7 +126,8 @@ export function LoopDetailClient({ loopId, wsSlug, projSlug }: { loopId: string;
         <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
         <div className="flex h-64 flex-col items-center justify-center gap-3">
           <p className="text-sm text-muted-foreground">{t('notFound')}</p>
-          <button type="button" onClick={() => router.push(`/${wsSlug}/${projSlug}/loops`)} className="text-xs text-primary hover:underline">
+          {/* story #1990: replace — 뒤로가기 재진입 트랩 방지(§3.2). */}
+          <button type="button" onClick={() => router.replace(`/${wsSlug}/${projSlug}/loops`)} className="text-xs text-primary hover:underline">
             {t('backToList')}
           </button>
         </div>
@@ -144,7 +145,10 @@ export function LoopDetailClient({ loopId, wsSlug, projSlug }: { loopId: string;
         title={
           <button
             type="button"
-            onClick={() => router.push(`/${wsSlug}/${projSlug}/loops`)}
+            // story #1990: replace(), not push() — 콜드-진입 합성 스택에 세번째 엔트리를
+            // 쌓지 않아 브라우저 BACK 재진입 트랩을 없앤다(§3.2). back()류 직접호출 금지
+            // ([[feedback-history-back-nextjs]]) 준수.
+            onClick={() => router.replace(`/${wsSlug}/${projSlug}/loops`)}
             className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground"
           >
             <ArrowLeft className="size-3.5" />

--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
@@ -163,7 +163,10 @@ export default function ConversationPage() {
           <div className="flex min-w-0 items-center gap-1">
             <button
               type="button"
-              onClick={() => router.push('/chats')}
+              // story #1990: replace(), not push() — 콜드-진입 합성 스택에 세번째 엔트리를
+              // 쌓지 않아 브라우저 BACK 재진입 트랩을 구조적으로 없앤다(§3.2). back()류 직접
+              // 호출은 하지 않는다([[feedback-history-back-nextjs]]).
+              onClick={() => router.replace('/chats')}
               className="flex flex-shrink-0 items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
             >
               <ChevronLeft className="h-4 w-4" />

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -79,7 +79,11 @@ export default function GateDetailPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ status, note: note?.trim() || null }),
       });
-      if (res.ok) router.push('/inbox');
+      // story #1990: push()는 콜드-진입 합성 스택([parentTab, target])에 세번째 엔트리를
+      // 쌓아 브라우저 BACK 1회가 이 상세를 재진입시키는 트랩을 만든다(§3.2 재진입 트랩).
+      // replace()는 현재 엔트리를 그대로 교체해 스택 길이를 늘리지 않는다 — router.back()/
+      // window.history.back() 직접호출([[feedback-history-back-nextjs]] 금지) 없이 동일 효과.
+      if (res.ok) router.replace('/inbox');
     } finally {
       setResolving(false);
     }
@@ -91,7 +95,7 @@ export default function GateDetailPage() {
         title={
           <button
             type="button"
-            onClick={() => router.push('/inbox')}
+            onClick={() => router.replace('/inbox')}
             className="flex flex-shrink-0 items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
           >
             <ChevronLeft className="h-4 w-4" />

--- a/apps/web/src/app/(authenticated)/organization/workforce/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/[id]/page.tsx
@@ -140,7 +140,8 @@ export default function AgentDetailPage() {
 
   const fetchAgent = useCallback(async () => {
     const res = await fetch(`/api/team-members/${id}`);
-    if (!res.ok) { router.push('/organization/workforce?tab=manage'); return; }
+    // story #1990: replace — 뒤로가기 재진입 트랩 방지(§3.2 원칙, gate/chat/goal/loop과 동일).
+    if (!res.ok) { router.replace('/organization/workforce?tab=manage'); return; }
     const json = await res.json() as { data: AgentMember };
     setAgent(json.data);
   }, [id, router]);
@@ -388,7 +389,8 @@ export default function AgentDetailPage() {
   return (
     <div className="w-full max-w-3xl mx-auto p-6 space-y-6">
       <div className="flex items-center gap-3">
-        <Link href="/organization/workforce?tab=manage" className="text-muted-foreground hover:text-foreground transition-colors">
+        {/* story #1990: replace, 기본 push 아님 — 뒤로가기 재진입 트랩 방지(§3.2). */}
+        <Link href="/organization/workforce?tab=manage" replace className="text-muted-foreground hover:text-foreground transition-colors">
           <ArrowLeft className="h-4 w-4" />
         </Link>
         <h1 className="text-lg font-semibold text-foreground">{t('orgAgentsTitle')}</h1>

--- a/apps/web/src/app/(authenticated)/settings/integrations/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/integrations/page.tsx
@@ -30,7 +30,7 @@ export default function IntegrationsPage() {
 
   return (
     <div className="mx-auto w-full max-w-3xl p-6">
-      <Link href="/settings" className="inline-flex items-center gap-1 text-xs text-muted-foreground transition hover:text-foreground">
+      <Link href="/settings" replace className="inline-flex items-center gap-1 text-xs text-muted-foreground transition hover:text-foreground">
         <ArrowLeft className="size-3.5" />{t('title')}
       </Link>
       <h1 className="mt-3 text-sm font-semibold text-foreground">{t('tabIntegrations')}</h1>

--- a/apps/web/src/components/agents/agent-hitl-requests-list.tsx
+++ b/apps/web/src/components/agents/agent-hitl-requests-list.tsx
@@ -100,6 +100,8 @@ export function AgentHitlRequestsList() {
               <RefreshCw className={`mr-1.5 size-3.5 ${refreshing ? 'animate-spin' : ''}`} />
               {t('refresh')}
             </Button>
+            {/* story #1990 스코프 제외(까심 확認, 2026-07-18): 이 컴포넌트는 import/렌더 0인 죽은코드라
+                라이브 트랩 재현 불가 — push() 미교체는 의도적(no-fiction). */}
             <Link href="/organization/workforce" className={buttonVariants({ variant: 'outline', size: 'sm' })}>
               <ArrowLeft className="mr-1.5 size-3.5" />
               {t('backToAgents')}


### PR DESCRIPTION
## Summary
- 상세 화면 온스크린 백버튼이 `router.push(parentHref)`라 콜드-진입 합성 history 스택([parentTab, target])에 세번째 엔트리를 쌓아, 브라우저 BACK 1회가 방금 나온 상세를 재진입시키는 트랩(§3.2)이 있었음.
- `router.back()`/`window.history.back()` 직접호출은 하우스룰([[feedback-history-back-nextjs]]) 위반이라 채택 안 함 — 대신 `router.replace(parentHref)`로 현재 엔트리만 교체해 스택을 늘리지 않는 방식으로 재진입 트랩을 구조적으로 제거.
- 소비처 5곳: gates/[id], chats/[conversation_id], goals/[id](Link→replace prop), loops/[id], organization/workforce/[id](스윕 중 발견, 동일 패턴 추가 수정).
- docs/[slug]·story-detail-panel(kanban-board.tsx)은 확인 결과 대상 아님(전자는 전용 백버튼 없음, 후자는 이미 replace() 사용 중).

## Test plan
- [x] tsc/lint/vitest(256 files·1703 tests)/build 클린
- [x] 격리 docker-compose 스택 라이브 시퀀스 재현(gates/[id]): /glance → /gates/{id}(history +1) → 백버튼(length 불변, URL만 교체) → 브라우저 BACK → /glance 착지(재진입 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)