### PR TITLE
[SID:1991] 하단 4탭 active 미매핑 — parentTab 판정 통일

### DIFF
--- a/apps/web/src/components/nav/mobile-tab-bar.test.ts
+++ b/apps/web/src/components/nav/mobile-tab-bar.test.ts
@@ -1,0 +1,43 @@
+// story #1991(navigate 불안정 1차 근원 B) — 하단 4탭 active 판정 회귀가드. 기존 isTabActive는
+// 4탭 href 자체+직계 하위만 인식해 gate/doc/story 상세·프로젝트/org 영역(board/goals/loops/
+// organization/settings 등, #1958 "전체" 스텁 목록 그대로)이 전부 회색이었다. getActiveTabKey가
+// #1951 매니페스트 SSOT(상세→parentTab)를 그대로 재사용해 정확히 판정하는지 고정.
+import { describe, expect, it } from 'vitest';
+import { getActiveTabKey } from './mobile-tab-bar';
+
+describe('getActiveTabKey', () => {
+  it('/glance 및 하위 경로는 now', () => {
+    expect(getActiveTabKey('/glance')).toBe('now');
+    expect(getActiveTabKey('/glance/foo')).toBe('now');
+  });
+
+  it('/inbox 정확일치는 approvals', () => {
+    expect(getActiveTabKey('/inbox')).toBe('approvals');
+  });
+
+  it('게이트 canonical 상세(/gates/{id})는 approvals — #1951 parentTab=/inbox 매핑 그대로', () => {
+    expect(getActiveTabKey('/gates/7d0fc67b-d6c2-4767-a156-1bcf7c786ad0')).toBe('approvals');
+  });
+
+  it('/chats 및 대화 상세(/chats/{id})는 chat', () => {
+    expect(getActiveTabKey('/chats')).toBe('chat');
+    expect(getActiveTabKey('/chats/abc123')).toBe('chat');
+  });
+
+  it('프로젝트/org 영역(board·goals·loops·organization·settings 등)은 more — #1958 "전체" 스텁 목록과 정합', () => {
+    expect(getActiveTabKey('/board')).toBe('more');
+    expect(getActiveTabKey('/qa-org/qa-proj/board')).toBe('more');
+    expect(getActiveTabKey('/qa-org/qa-proj/goals/abc')).toBe('more');
+    expect(getActiveTabKey('/qa-org/qa-proj/loops/abc')).toBe('more');
+    expect(getActiveTabKey('/organization/workforce/abc')).toBe('more');
+    expect(getActiveTabKey('/settings')).toBe('more');
+  });
+
+  it('문서 상세(/{ws}/{proj}/docs/[slug])는 more — #1951 parentTab=/more 매핑과 정합', () => {
+    expect(getActiveTabKey('/qa-org/qa-proj/docs/my-doc')).toBe('more');
+  });
+
+  it('/more 자기 자신도 more', () => {
+    expect(getActiveTabKey('/more')).toBe('more');
+  });
+});

--- a/apps/web/src/components/nav/mobile-tab-bar.tsx
+++ b/apps/web/src/components/nav/mobile-tab-bar.tsx
@@ -26,12 +26,27 @@ const TABS = [
   { key: 'more', href: '/more', icon: Grid2x2, labelKey: 'more' as const },
 ] as const;
 
-function isTabActive(pathname: string, href: string): boolean {
-  if (href === '/inbox') {
-    // "결재함" 탭은 /inbox 루트만 자기 것으로 친다(하위 라우트 없음 — bare path 매치).
-    return pathname === '/inbox';
-  }
-  return pathname === href || pathname.startsWith(`${href}/`);
+// story #1991(navigate 불안정 1차 근원 B, 유나 UX 감사): 기존 isTabActive는 4탭 href 자체와
+// 정확일치/그 직계 하위 경로만 인식해, gate/doc/story 상세(canonical 라우트가 탭 href 트리
+// 밖에 있음)나 프로젝트/org 영역(board/goals/loops/organization/... 등, #1965 "전체" 스텁
+// 목록 그대로) 전부 활성 탭이 없어 하단바가 회색이 됐다. #1951 매니페스트가 이미 확定해둔
+// 상세→parentTab 매핑(useSyntheticParentTabHistory 호출부와 동일 SSOT)을 여기서도 재사용해
+// "이 경로는 소속상 어느 탭인가"를 판정하는 단일 함수로 교체한다.
+//
+// 판정 순서(구체적인 것부터, 마지막이 fallback):
+//  ① /glance — "지금" 탭 자기 자신(+하위 경로 있으면 포함).
+//  ② /inbox(정확일치) 또는 /gates/* — "결재함". gate 상세는 #1951에서 parentTab=/inbox로
+//     이미 확定(gates/[id]/page.tsx의 useSyntheticParentTabHistory('/inbox') 그대로).
+//  ③ /chats(+하위) — "채팅".
+//  ④ 그 외 전부 — "전체"(more). doc 상세(parentTab=/more)·story 상세(parentTab=/more)·
+//     board/goals/loops/sprints/standup/retro/organization/settings/... 는 애초에 4탭
+//     밖의 프로젝트/org 영역이라 more 페이지 자체가 이들의 진입점(ITEMS 목록, #1958 확定)
+//     — "전체"가 이 전부의 소속 탭이라는 게 이미 그 스텁 페이지 설계로 확定돼 있다.
+export function getActiveTabKey(pathname: string): (typeof TABS)[number]['key'] {
+  if (pathname === '/glance' || pathname.startsWith('/glance/')) return 'now';
+  if (pathname === '/inbox' || pathname.startsWith('/gates/')) return 'approvals';
+  if (pathname === '/chats' || pathname.startsWith('/chats/')) return 'chat';
+  return 'more';
 }
 
 export function MobileTabBar() {
@@ -82,13 +97,15 @@ export function MobileTabBar() {
     };
   }, []);
 
+  const activeKey = getActiveTabKey(pathname);
+
   return (
     <nav
       aria-label={t('navLabel')}
       className="flex h-16 shrink-0 border-t border-border bg-card lg:hidden"
     >
       {TABS.map(({ key, href, icon: Icon, labelKey }) => {
-        const active = isTabActive(pathname, href);
+        const active = key === activeKey;
         const badge = key === 'approvals' && pendingCount > 0 ? pendingCount : null;
         return (
           <Link


### PR DESCRIPTION
## Summary
- `isTabActive(pathname, href)`가 4탭 href 자체+직계 하위만 인식해 gate canonical 상세·doc/story 상세·프로젝트/org 영역(board/goals/loops/organization/settings 등) 전부 활성 탭 없이 회색으로 떴음(딥링크 착지도 동일).
- `#1951` 매니페스트가 이미 확定한 상세→parentTab 매핑(`useSyntheticParentTabHistory` 호출부와 동일 SSOT)을 재사용해 `getActiveTabKey(pathname)` 단일 함수로 교체.
- 판정: `/glance`(+하위)=now · `/inbox`(정확일치) 또는 `/gates/*`=approvals · `/chats`(+하위)=chat · 그 외 전부=more.
- `getActiveTabKey` export + 순수함수 유닛테스트 7건 신설.

## Test plan
- [x] tsc/lint/vitest(257 files·1710 tests)/build 클린
- [x] 격리 docker-compose 스택 라이브 확인: doc 상세="전체" active·gate canonical 상세="결재함" active·board="전체" active·organization/workforce="전체" active — 전부 스크린샷 확인
- [x] 콜드 딥링크 착지(로그인 직후 `/gates/{id}` 직접 진입) 즉시 "결재함" active — 회색→점프 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)