### PR TITLE
[SID:1986] /inbox 768seam — md: 마스터-디테일을 lg(1024) SSOT로 정합

### DIFF
--- a/apps/web/src/app/(authenticated)/inbox/page.tsx
+++ b/apps/web/src/app/(authenticated)/inbox/page.tsx
@@ -438,9 +438,12 @@ export default function InboxPage() {
         )}
 
         <div className="flex min-h-0 flex-1 overflow-hidden">
-        {/* Left: notification list. max-md master-detail (efcb3840 ⓑ): full-width list,
-            hidden once a detail is open so the detail can take the screen (md+ unchanged). */}
-        <div className={`flex w-full min-w-[320px] flex-col border-r border-border/80 md:max-w-[420px] max-md:min-w-0 ${selectedId ? 'max-md:hidden' : ''}`}>
+        {/* Left: notification list. max-lg master-detail (efcb3840 ⓑ, story #1986 breakpoint fix):
+            full-width list, hidden once a detail is open so the detail can take the screen
+            (lg+ unchanged). lg(1024px) matches MOBILE_BREAKPOINT/GNB lg:hidden SSOT — md(768px)
+            caused a 768-1023 tablet seam where the mobile bottom-tab shell and this master-detail
+            split disagreed on what "mobile" means. */}
+        <div className={`flex w-full min-w-[320px] flex-col border-r border-border/80 lg:max-w-[420px] max-lg:min-w-0 ${selectedId ? 'max-lg:hidden' : ''}`}>
           <div className="flex-1 overflow-y-auto py-2">
             {loading ? (
               <div className="space-y-2 px-3 pt-2">
@@ -563,14 +566,14 @@ export default function InboxPage() {
           </div>
         </div>
 
-        {/* Right: detail panel. max-md: hidden when nothing selected (the list owns the
-            screen); full-screen with a back button when an item is tapped (efcb3840 ⓑ). */}
-        <div className={`flex min-w-0 flex-1 flex-col overflow-y-auto ${!selectedId ? 'max-md:hidden' : ''}`}>
+        {/* Right: detail panel. max-lg: hidden when nothing selected (the list owns the
+            screen); full-screen with a back button when an item is tapped (efcb3840 ⓑ, #1986). */}
+        <div className={`flex min-w-0 flex-1 flex-col overflow-y-auto ${!selectedId ? 'max-lg:hidden' : ''}`}>
           {selectedNotification ? (
             <button
               type="button"
               onClick={() => setSelectedId(null)}
-              className="flex shrink-0 items-center gap-1.5 border-b border-border/80 px-4 py-2.5 text-sm font-medium text-muted-foreground transition hover:text-foreground md:hidden"
+              className="flex shrink-0 items-center gap-1.5 border-b border-border/80 px-4 py-2.5 text-sm font-medium text-muted-foreground transition hover:text-foreground lg:hidden"
             >
               <ArrowLeft className="size-4" />
               {t('backToList')}


### PR DESCRIPTION
## Summary
- `/inbox` 마스터-디테일 분할(story efcb3840)이 Tailwind 기본 `md`(768px)를 썼는데, 전역 모바일 판정 SSOT는 `MOBILE_BREAKPOINT=1024`(GNB `lg:hidden`과 동일)라 768-1023px 구간에서 하단 모바일 탭바가 뜬 채로 인박스만 데스크톱 2단(우측 빈 디테일 패널) 레이아웃으로 렌더되는 seam이 있었음.
- `#1958`이 dashboard-shell의 같은 종류 seam(768-1023 tablet-density)은 고쳤으나 inbox 표면은 놓침.
- `md:`/`max-md:` → `lg:`/`max-lg:`로 치환(Tailwind v4 기본 `lg`=1024px, 커스텀 breakpoint override 없음 확인) — 3곳(마스터 패널 폭, 디테일 패널 숨김, 백버튼 `lg:hidden`).

## Test plan
- [x] tsc/lint/vitest(256 files·1703 tests) 클린
- [x] 격리 docker-compose 스택 라이브 확인: 768px·834px 둘 다 전체폭 단일 컬럼(빈 패널 낭비 0)·1024px+(1200px)는 기존 마스터-디테일 2단 그대로(회귀 없음) — 전부 스크린샷 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)