### PR TITLE
fix(guard): verify-no-new-md-breakpoint allowlist에서 inbox/page.tsx 제외

### DIFF
--- a/apps/web/scripts/verify-no-new-md-breakpoint.ts
+++ b/apps/web/scripts/verify-no-new-md-breakpoint.ts
@@ -22,7 +22,6 @@ export const ALLOWLIST = new Set([
   'app/(authenticated)/[ws]/[proj]/mockups/page.tsx',
   'app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx',
   'app/(authenticated)/[ws]/[proj]/standup/standup-client.tsx',
-  'app/(authenticated)/inbox/page.tsx',
   'app/(authenticated)/settings/page.tsx',
   'app/internal-dogfood/page.tsx',
   'components/agents/agent-deployment-verification-step.tsx',


### PR DESCRIPTION
## Summary
- story #1986(#2268)로 `inbox/page.tsx`의 `md:` 사용이 `lg:`로 전부 전환돼 grandfather 사유가 소멸했다(까심 disclose 지적).
- allowlist에 남겨두면 향후 `md:` 재도입(#1986 원인 버그 재발)을 이 가드가 못 잡는 반쪽짜리가 된다.
- grep으로 해당 파일 `md:` 잔존 0건 재확인 후 제거.

## Test plan
- [x] `pnpm verify:no-new-md-breakpoint` green (grandfather 26→25개 파일 기준 전수 재검사 OK)
- [x] tsc/lint/vitest(257/1710) 클린

🤖 Generated with [Claude Code](https://claude.com/claude-code)