### PR TITLE
[SID:1977] 채팅 unread UI — 리스트 배지·여기부터 안읽음 마커·mark-read·GNB 총합

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3186,6 +3186,7 @@
     "empty": "No agents to show"
   },
   "chats": {
+    "unreadMarker": "Unread from here",
     "inputPlaceholderMobile": "Type a message… (@ mention)",
     "inputPlaceholderFull": "Type a message… (Enter to send / Shift+Enter for new line / @ mention / # entity)",
     "isTyping": "{name} is typing",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3186,6 +3186,7 @@
     "empty": "표시할 에이전트가 없습니다"
   },
   "chats": {
+    "unreadMarker": "여기부터 안읽음",
     "inputPlaceholderMobile": "메시지를 입력하세요… (@ 멘션)",
     "inputPlaceholderFull": "메시지를 입력하세요… (Enter 전송 / Shift+Enter 줄바꿈 / @ 멘션 / # 엔티티)",
     "isTyping": "{name} 님이 입력 중",

--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
@@ -26,6 +26,9 @@ interface ConversationMeta {
   // per-대화 알림 mute (270c87e6). conversation list/detail 응답의 caller `muted`
   // (#1427에서 노출)로 벨 초기 상태를 그린다. 부재 시 false로 graceful(하위호환).
   muted: boolean;
+  // story #1977(트랙B): #1976 read state 계약 — caller last_read_at. ChatView의 "여기부터
+  // 안읽음" 마커 경계로 소비(진입 시점 값만 필요, 마커는 이 화면 방문 내내 동결).
+  lastReadAt: string | null;
 }
 
 function formatHeaderTitle(meta: ConversationMeta, currentMemberId: string): string {
@@ -60,10 +63,18 @@ export default function ConversationPage() {
       const res = await fetch(`/api/conversations?project_id=${projectId}`);
       if (!res.ok) return;
       const json = await res.json() as {
-        data: Array<{ id: string; title: string | null; type: 'dm' | 'group'; participants?: Participant[]; muted?: boolean }>;
+        data: Array<{ id: string; title: string | null; type: 'dm' | 'group'; participants?: Participant[]; muted?: boolean; last_read_at?: string | null }>;
       };
       const conv = json.data.find((c) => c.id === conversation_id);
-      if (conv) setMeta({ title: conv.title, type: conv.type, participants: conv.participants ?? [], muted: conv.muted ?? false });
+      if (conv) {
+        setMeta({
+          title: conv.title,
+          type: conv.type,
+          participants: conv.participants ?? [],
+          muted: conv.muted ?? false,
+          lastReadAt: conv.last_read_at ?? null,
+        });
+      }
     } catch { /* non-critical */ }
   }, [conversation_id, projectId]);
 
@@ -238,6 +249,7 @@ export default function ConversationPage() {
           commandTargets={commandTargets}
           presenceById={presenceById}
           scrollToMessageId={scrollToMessageId}
+          initialLastReadAt={meta ? meta.lastReadAt : undefined}
         />
       </div>
 

--- a/apps/web/src/app/api/conversations/[conversation_id]/read/route.ts
+++ b/apps/web/src/app/api/conversations/[conversation_id]/read/route.ts
@@ -1,0 +1,14 @@
+import { type NextRequest } from 'next/server';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// POST /api/v2/conversations/{id}/read 프록시 — story #1976 mark-read(GREATEST 래칫·멱등).
+// body {up_to?: ISO datetime} → caller participant.last_read_at 갱신 + conversation.read SSE
+// 본인 타 커넥션 전파. BE가 raw {conversation_id, member_id, last_read_at, unread_count}를
+// 반환하므로 proxyToFastapi 패스스루(소비부 raw, mute route와 동형).
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ conversation_id: string }> },
+): Promise<Response> {
+  const { conversation_id } = await params;
+  return proxyToFastapi(request, `/api/v2/conversations/${conversation_id}/read`);
+}

--- a/apps/web/src/app/api/conversations/unread-count/route.ts
+++ b/apps/web/src/app/api/conversations/unread-count/route.ts
@@ -1,0 +1,9 @@
+import { type NextRequest } from 'next/server';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// GET /api/v2/conversations/unread-count 프록시 — story #1992: GNB 채팅 unread 총합(count-only).
+// caller 전 참여 대화(페이지네이션 무관) unread_count SUM → {count: int}. story #1977이 GNB
+// 3표면(사이드바 채팅 항목+모바일 4탭 채팅 탭) 배지 소스로 소비.
+export async function GET(request: NextRequest): Promise<Response> {
+  return proxyToFastapi(request, '/api/v2/conversations/unread-count');
+}

--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -111,7 +111,7 @@ function ScrollShell({ showTopBar, tabletCentered, children }: { showTopBar: boo
       {/* story #1958(P2-S2): <1024(lg 미만) 전용 하단 탭바 — SidebarInset의 flex-col 안에서
           scroll 컨테이너의 형제(자식 아님)로 둬야 콘텐츠가 스크롤돼도 탭바가 자기 flex row를
           유지한다(position:fixed 오버레이+패딩 보정 불요 — 시안 511bc035의 flex 레이아웃과 동형). */}
-      <MobileTabBar />
+      <MobileTabBar currentTeamMemberId={currentTeamMemberId} />
     </SidebarInset>
     </TeamPresenceToggleProvider>
     </ReleaseNotesProvider>

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -7,7 +7,7 @@ import { useTranslations } from 'next-intl';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { NewConversationModal } from './new-conversation-modal';
-import { useChatSse } from '@/hooks/use-chat-sse';
+import { useChatSse, type SseConversationReadPayload } from '@/hooks/use-chat-sse';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 
 interface Participant {
@@ -301,9 +301,19 @@ export function ChatListView({ projectId, currentTeamMemberId, open, onOpenChang
     }
   }, [fetchConversations, fetchAllConversations]);
 
+  // story #1977(트랙B): 다른 탭/기기에서 mark-read → conversation.read SSE(#1976, 본인 타
+  // 커넥션 전파)로 이 목록이 열려있는 동안에도 unread 배지가 즉시 서버 truth로 자가정정.
+  const handleConversationRead = useCallback((payload: SseConversationReadPayload) => {
+    const applyRead = (list: ConversationItem[]) =>
+      list.map((c) => (c.id === payload.conversation_id ? { ...c, unread_count: payload.unread_count } : c));
+    setConversations(applyRead);
+    if (agentLoadedRef.current) setAllConversations(applyRead);
+  }, []);
+
   useChatSse({
     currentTeamMemberId,
     onConversationMessage: handleConversationMessage,
+    onConversationRead: handleConversationRead,
   });
 
   const handleCreated = (conversationId: string) => {

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -25,6 +25,10 @@ interface ChatViewProps {
   presenceById?: Record<string, PresenceStatus>;
   // Deeplink (ade2d6d5): 진입 시 스크롤+하이라이트할 메시지 id(?messageId=). 없으면 일반 동작(하단 스크롤).
   scrollToMessageId?: string;
+  // story #1977(트랙B): #1976 read state 계약(last_read_at)의 caller 값. undefined=아직 로드
+  // 전(meta fetch 레이스, "여기부터 안읽음" 마커 계산을 그 값 도착까지 보류) · null=한 번도 안
+  // 읽음(모든 타인 메시지 앞에 마커) · string=그 시각 이후 타인 메시지 앞에 마커.
+  initialLastReadAt?: string | null;
 }
 
 interface MessageGroup {
@@ -47,7 +51,7 @@ function groupByDate(messages: ChatMessage[]): MessageGroup[] {
   return Object.entries(groups).map(([date, msgs]) => ({ date, messages: msgs }));
 }
 
-export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix = '/api/chats', commandTargets, presenceById, scrollToMessageId }: ChatViewProps) {
+export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix = '/api/chats', commandTargets, presenceById, scrollToMessageId, initialLastReadAt }: ChatViewProps) {
   const router = useRouter();
   const pathname = usePathname();
   const t = useTranslations('chats');
@@ -107,6 +111,31 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   const [pullDistance, setPullDistance] = useState(0);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const PULL_THRESHOLD = 64;
+  // story #1977: "여기부터 안읽음" 마커 경계 — 진입 시점 initialLastReadAt에 동결(첫 정의값에서만
+  // 1회 세팅). initialLastReadAt은 meta fetch(page.tsx)와 별개 레이스로 undefined→값 순서로
+  // 도착할 수 있어 useEffect로 "처음 정의되는 순간"을 잡는다 — 그 이후로는 이 화면에서 스크롤이나
+  // mark-read가 일어나도 마커 위치가 안 움직인다(같은 방문 세션 내 유지, 재방문 시에만 재계산).
+  const [markerBoundary, setMarkerBoundary] = useState<string | null | undefined>(undefined);
+  useEffect(() => {
+    if (markerBoundary === undefined && initialLastReadAt !== undefined) {
+      setMarkerBoundary(initialLastReadAt);
+    }
+  }, [initialLastReadAt, markerBoundary]);
+  // story #1977: mark-read 중복 POST 가드 — 이미 이 up_to까지 보냈으면 재전송 안 함(멱등이라
+  // 서버는 안전하지만, 스크롤/신규메시지마다 매번 쏘는 낭비 방지).
+  const markedReadUpToRef = useRef<string | null>(null);
+  const markRead = useCallback((upToIso: string) => {
+    if (markedReadUpToRef.current && markedReadUpToRef.current >= upToIso) return;
+    markedReadUpToRef.current = upToIso;
+    fetch(`${apiPrefix}/${threadId}/read`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ up_to: upToIso }),
+    }).catch(() => {
+      // 실패 시 재시도 허용 — 다음 스크롤/신규메시지 트리거가 다시 시도(§4-3 GREATEST 래칫이라 안전).
+      markedReadUpToRef.current = null;
+    });
+  }, [apiPrefix, threadId]);
 
   const scrollToBottom = useCallback((smooth = false) => {
     bottomRef.current?.scrollIntoView({ behavior: smooth ? 'smooth' : 'instant' });
@@ -151,10 +180,16 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
     if (!loading && isFirstLoad.current) {
       // Deeplink (ade2d6d5): scrollToMessageId가 있으면 하단 자동스크롤을 건너뛴다
       // (scroll-to-message와 충돌 방지). 일반 진입(messageId 부재)은 기존대로 하단 스크롤.
-      if (!scrollToMessageId) scrollToBottom();
+      if (!scrollToMessageId) {
+        scrollToBottom();
+        // story #1977: 딥링크(특정 옛 메시지로 진입)가 아닌 일반 진입은 곧장 최신까지 본 것 —
+        // 마지막 메시지 시각으로 mark-read. 딥링크 경로는 스크롤로 하단 도달 시(아래 onScroll)에만.
+        const latest = messages[messages.length - 1];
+        if (latest) markRead(latest.created_at);
+      }
       isFirstLoad.current = false;
     }
-  }, [loading, scrollToBottom, scrollToMessageId]);
+  }, [loading, scrollToBottom, scrollToMessageId, messages, markRead]);
 
   // Deeplink (ade2d6d5): 언마운트 시 타이머/rAF 정리(메모리·setState-after-unmount 방지).
   useEffect(() => () => {
@@ -178,10 +213,13 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
     // CB-S8: setTimeout 대신 ref 플래그 → render 완료 후 useEffect에서 스크롤
     if (nearBottom) {
       shouldScrollToBottomRef.current = true;
+      // story #1977: 이미 하단을 보고 있던 활성 뷰어라면 신규 메시지도 즉시 mark-read —
+      // 안 그러면 GNB/리스트 배지가 능동 열람 중에도 잠깐 튀어오른다.
+      markRead(msg.created_at);
     } else {
       setShowNewIndicator(true);
     }
-  }, [isNearBottom, clearTyping]);
+  }, [isNearBottom, clearTyping, markRead]);
 
   const handleNewMessage = useCallback((msg: ChatMessage) => {
     if (msg.memo_id !== threadId) return;
@@ -439,14 +477,21 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
     }
   }, [scrollToMessageId, loading, messages, hasMore, loadingMore, handleLoadMore]);
 
-  // 스크롤을 직접 내리면 인디케이터 자동 해제
+  // 스크롤을 직접 내리면 인디케이터 자동 해제 + story #1977: 하단 근접 시 mark-read(마커를
+  // 지나 실제로 최신까지 봤을 때만 — 시안 "스크롤 하단 근접 시 POST /read up_to=최신 본 메시지").
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
-    const onScroll = () => { if (isNearBottom()) setShowNewIndicator(false); };
+    const onScroll = () => {
+      if (isNearBottom()) {
+        setShowNewIndicator(false);
+        const latest = messages[messages.length - 1];
+        if (latest) markRead(latest.created_at);
+      }
+    };
     el.addEventListener('scroll', onScroll, { passive: true });
     return () => el.removeEventListener('scroll', onScroll);
-  }, [isNearBottom]);
+  }, [isNearBottom, messages, markRead]);
 
   // Auto-load when scrolled to top (IntersectionObserver watches topSentinelRef inside scrollRef)
   useEffect(() => {
@@ -468,6 +513,17 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   }, [loading, hasMore, loadingMore, handleLoadMore]);
 
   const groups = groupByDate(messages);
+
+  // story #1977: "여기부터 안읽음" 마커 위치 — markerBoundary(동결된 진입 시점 last_read_at)
+  // 이후·타인 발신(§4-1 BE unread 정의 sender IS DISTINCT FROM 나와 동형) 첫 메시지 앞.
+  // markerBoundary===undefined(아직 로드 전)면 마커 계산을 보류(오판 방지) — 값 도착 시 자동 재계산.
+  const unreadMarkerMessageId = markerBoundary === undefined ? null : (() => {
+    const boundaryMs = markerBoundary === null ? 0 : new Date(markerBoundary).getTime();
+    const firstUnread = messages.find(
+      (m) => m.created_by !== currentTeamMemberId && new Date(m.created_at).getTime() > boundaryMs,
+    );
+    return firstUnread?.id ?? null;
+  })();
 
   // CB-S9: 모바일에서 스레드 뷰로 전환 중인지 (< lg)
   const isMobileThreadView = activeThread !== null;
@@ -554,6 +610,16 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
                       const isGrouped = Boolean(prev && prev.created_by === msg.created_by);
                       return (
                         <Fragment key={msg.id}>
+                          {/* story #1977: "여기부터 안읽음" — info 톤(안내), 빨강 0(시안 768e89b5 v2). */}
+                          {msg.id === unreadMarkerMessageId && (
+                            <div className="my-1 flex items-center gap-2.5" role="separator" aria-label={t('unreadMarker')}>
+                              <div className="h-px flex-1 bg-info/50" />
+                              <span className="rounded-full bg-info-tint px-3 py-0.5 text-[11px] font-bold text-info">
+                                {t('unreadMarker')}
+                              </span>
+                              <div className="h-px flex-1 bg-info/50" />
+                            </div>
+                          )}
                           <ChatBubble
                             message={msg}
                             isMine={msg.created_by === currentTeamMemberId}

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -34,6 +34,7 @@ import { ThemeToggle } from '@/components/nav/theme-toggle';
 import { CommandPalette } from '@/components/command-palette/command-palette';
 import { ProfileMenu } from '@/components/nav/profile-menu';
 import { UnifiedSwitcher, type OrgSwitcherItem } from '@/components/nav/unified-switcher';
+import { useChatUnreadTotal } from '@/hooks/use-chat-unread-total';
 import {
   Sidebar,
   SidebarContent,
@@ -71,6 +72,7 @@ function KbdHint({ children }: { children: React.ReactNode }) {
 }
 
 export function AppSidebar({
+  currentTeamMemberId,
   orgId,
   orgMemberships = [],
   projectId,
@@ -112,6 +114,8 @@ export function AppSidebar({
   }, [pathname, isMobile, setOpenMobile]);
 
   const [inboxUnreadCount, setInboxUnreadCount] = useState(0);
+  // story #1977(트랙B): GNB ③ 채팅 unread 총합(유나 시안 768e89b5 v2).
+  const chatUnreadTotal = useChatUnreadTotal(currentTeamMemberId);
   const [paletteOpen, setPaletteOpen] = useState(false);
 
   const openPalette = useCallback(() => setPaletteOpen(true), []);
@@ -298,6 +302,13 @@ export function AppSidebar({
                 >
                   <MessageSquare />
                   <span>{t('chats')}</span>
+                  {/* story #1977(트랙B): 유나 시안 768e89b5 v2 ③ — 결재함 배지와 동일 brand,
+                      구분은 색이 아니라 아이콘+탭 순서(디자인 노트). */}
+                  {chatUnreadTotal > 0 ? (
+                    <SidebarMenuBadge>
+                      {chatUnreadTotal > 99 ? '99+' : chatUnreadTotal}
+                    </SidebarMenuBadge>
+                  ) : null}
                 </SidebarMenuButton>
               </SidebarMenuItem>
             </SidebarMenu>

--- a/apps/web/src/components/nav/mobile-tab-bar.tsx
+++ b/apps/web/src/components/nav/mobile-tab-bar.tsx
@@ -8,6 +8,7 @@ import { CircleDot, Inbox, MessageSquare, Grid2x2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { GateItem } from '@/components/kanban/types';
 import { MOBILE_BREAKPOINT } from '@/hooks/use-mobile';
+import { useChatUnreadTotal } from '@/hooks/use-chat-unread-total';
 
 // story #1958(P2-S2, mobile-p2-p1a-story-breakdown SSOT) — 모바일 4탭 셸. <1024(lg 미만)에서만
 // 렌더되고 데스크톱 GNB(AppSidebar)를 대체한다(P2-S1의 lg:1024 SSOT와 동일 경계 — route 내
@@ -49,9 +50,14 @@ export function getActiveTabKey(pathname: string): (typeof TABS)[number]['key'] 
   return 'more';
 }
 
-export function MobileTabBar() {
+export function MobileTabBar({ currentTeamMemberId }: { currentTeamMemberId?: string }) {
   const t = useTranslations('mobileTabBar');
   const pathname = usePathname();
+  // story #1977(트랙B): GNB ③ 채팅 unread 총합(유나 시안 768e89b5 v2) — 데스크톱 사이드바
+  // 채팅 항목(app-sidebar.tsx)과 동일 훅·동일 소스. AppSidebar와 같은 이유로 currentTeamMemberId를
+  // dashboard-shell.tsx(ScrollShell)에서 prop으로 받는다 — useDashboardContext() 직접 import는
+  // MobileTabBar를 dashboard-shell.tsx가 직접 렌더하므로 순환 참조가 된다(AppSidebar와 동일 회피).
+  const chatUnreadTotal = useChatUnreadTotal(currentTeamMemberId);
   // 결재함 배지 = 서명 대기 수(유나 §3.1 정합) — GateInbox가 이미 쓰는 것과 동일한
   // `/api/gates?status=pending` 재사용(신규 집계 안 만듦). gate_overridden은 override 시
   // approver row status가 "overridden"으로 전이돼(gate_service.py) pending 조회에서 자동 제외
@@ -106,7 +112,13 @@ export function MobileTabBar() {
     >
       {TABS.map(({ key, href, icon: Icon, labelKey }) => {
         const active = key === activeKey;
-        const badge = key === 'approvals' && pendingCount > 0 ? pendingCount : null;
+        // story #1977: "채팅" 탭 배지 = GNB unread 총합(결재함 배지와 동일 brand, 구분은
+        // 색이 아니라 아이콘+탭 순서 — 유나 시안 768e89b5 v2 디자인 노트).
+        const badge = key === 'approvals' && pendingCount > 0
+          ? pendingCount
+          : key === 'chat' && chatUnreadTotal > 0
+            ? chatUnreadTotal
+            : null;
         return (
           <Link
             key={key}
@@ -124,7 +136,8 @@ export function MobileTabBar() {
                   aria-hidden
                   className="absolute -top-1 left-full ml-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-bold leading-none text-primary-foreground"
                 >
-                  {badge > 9 ? '9+' : badge}
+                  {/* story #1977: 채팅 unread 총합은 99+ 상한(시안 768e89b5 v2) — 결재함은 기존 9+ 유지 */}
+                  {key === 'chat' ? (badge > 99 ? '99+' : badge) : badge > 9 ? '9+' : badge}
                 </span>
               ) : null}
             </span>

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -63,6 +63,14 @@ export interface SseWorkingPayload {
   working: Array<{ member_id: string; state?: string }>;
 }
 
+/** story #1977: conversation.read SSE payload — #1976 mark-read 응답과 동일 shape(본인 타 커넥션 전파). */
+export interface SseConversationReadPayload {
+  conversation_id: string;
+  member_id: string;
+  last_read_at: string;
+  unread_count: number;
+}
+
 interface UseChatSseOptions {
   currentTeamMemberId?: string;
   onNewMessage?: (message: ChatMessage) => void;
@@ -70,12 +78,14 @@ interface UseChatSseOptions {
   onConversationMessage?: (payload: Record<string, unknown>) => void;
   // R2: 채팅 working/typing — 1.5s 폴(/conversations/{id}/working) 대체.
   onWorking?: (payload: SseWorkingPayload) => void;
+  // story #1977: conversation.read — 다른 탭/기기에서 읽음 처리 시 이 탭의 unread 배지(리스트+GNB) 자가정정.
+  onConversationRead?: (payload: SseConversationReadPayload) => void;
   onReconnect?: () => void;
 }
 
 const RECONNECT_DELAYS_MS = [5_000, 30_000, 60_000, 300_000];
 
-export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, onConversationMessage, onWorking, onReconnect }: UseChatSseOptions) {
+export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, onConversationMessage, onWorking, onConversationRead, onReconnect }: UseChatSseOptions) {
   const [connected, setConnected] = useState(false);
   const sourceRef = useRef<EventSource | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -85,6 +95,7 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
   const onReplyCreatedRef = useRef(onReplyCreated);
   const onConversationMessageRef = useRef(onConversationMessage);
   const onWorkingRef = useRef(onWorking);
+  const onConversationReadRef = useRef(onConversationRead);
   const onReconnectRef = useRef(onReconnect);
   const memberIdRef = useRef(currentTeamMemberId);
 
@@ -94,6 +105,7 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
   useLayoutEffect(() => { onReplyCreatedRef.current = onReplyCreated; }, [onReplyCreated]);
   useLayoutEffect(() => { onConversationMessageRef.current = onConversationMessage; }, [onConversationMessage]);
   useLayoutEffect(() => { onWorkingRef.current = onWorking; }, [onWorking]);
+  useLayoutEffect(() => { onConversationReadRef.current = onConversationRead; }, [onConversationRead]);
   useLayoutEffect(() => { onReconnectRef.current = onReconnect; }, [onReconnect]);
   useLayoutEffect(() => { memberIdRef.current = currentTeamMemberId; }, [currentTeamMemberId]);
 
@@ -169,6 +181,16 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
         try {
           const payload = JSON.parse(e.data as string) as SseWorkingPayload;
           if (payload.conversation_id) onWorkingRef.current?.(payload);
+        } catch { /* ignore parse errors */ }
+      });
+
+      // story #1977: conversation.read — #1976이 본인 타 커넥션에만 전파(read-receipt 아님).
+      // 다른 탭/기기에서 mark-read 하면 이 탭의 리스트 배지·GNB 총합을 서버 truth로 자가정정.
+      source.addEventListener('conversation.read', (e: MessageEvent) => {
+        if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
+        try {
+          const payload = JSON.parse(e.data as string) as SseConversationReadPayload;
+          if (payload.conversation_id) onConversationReadRef.current?.(payload);
         } catch { /* ignore parse errors */ }
       });
 

--- a/apps/web/src/hooks/use-chat-unread-total.ts
+++ b/apps/web/src/hooks/use-chat-unread-total.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useChatSse } from './use-chat-sse';
+
+/**
+ * story #1977(트랙B) — GNB 채팅 unread 총합(3번째 표면: 데스크톱 사이드바 채팅 항목 +
+ * 모바일 4탭 채팅 탭, 유나 시안 768e89b5 v2 ③). `/api/conversations/unread-count`(story #1992,
+ * caller 전 참여 대화 unread_count SUM)를 서버 truth로 삼는다.
+ *
+ * mount 시 1회 fetch + `conversation.read` SSE(#1976, 본인 타 커넥션 전파)로 다른 탭/기기에서
+ * mark-read 시 자가정정 — mark-read를 호출한 그 화면(chat-view.tsx)은 자신의 SSE 커넥션에는
+ * 에코되지 않으므로, 사이드바/탭바가 별도 커넥션으로 그 이벤트를 받아 갱신한다. `conversation.
+ * message_created`(신규 메시지 수신 — SSE는 실 참여자에게만 전달되므로 항상 +1 정확)는 낙관
+ * 증분. mobile-tab-bar.tsx의 기존 pendingCount(마운트 1회 fetch+focus 재조회) 패턴과 동일
+ * 구조(단일 effect·로컬 async 함수)로 맞췄다.
+ */
+export function useChatUnreadTotal(currentTeamMemberId?: string): number {
+  const [total, setTotal] = useState(0);
+  const fetchTotalRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchTotal() {
+      try {
+        const res = await fetch('/api/conversations/unread-count');
+        if (!res.ok || cancelled) return;
+        const json = (await res.json()) as { count?: number };
+        if (!cancelled) setTotal(json.count ?? 0);
+      } catch {
+        /* non-critical — 다음 트리거(SSE/visibility)에서 재시도 */
+      }
+    }
+    fetchTotalRef.current = () => void fetchTotal();
+
+    void fetchTotal();
+    const handleVisibility = () => {
+      if (!document.hidden) void fetchTotal();
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    window.addEventListener('focus', handleVisibility);
+
+    return () => {
+      cancelled = true;
+      fetchTotalRef.current = null;
+      document.removeEventListener('visibilitychange', handleVisibility);
+      window.removeEventListener('focus', handleVisibility);
+    };
+  }, []);
+
+  useChatSse({
+    currentTeamMemberId,
+    onConversationMessage: () => setTotal((prev) => prev + 1),
+    onConversationRead: () => fetchTotalRef.current?.(),
+  });
+
+  return total;
+}


### PR DESCRIPTION
## Summary
- 선생님 실사용 재보고("채팅 unread count가 read 처리 안 되는 버그") 근본원인 = `chat-list-view.tsx:205` SSE +1 클라 휘발 카운터에 mark-read/리셋이 앱 전체에 아예 없었음.
- `#1976`(트랙A read state 계약: last_read_at·unread_count·POST /read GREATEST 래칫·conversation.read SSE)·`#1992`(GET /conversations/unread-count GNB 총합) 계약 배포 확인 후 유나 시안 768e89b5 v2(3표면) 구현.
- **mark-read 트리거**(시안 확定: 진입 즉시 전량 아닌·스크롤 하단 근접 시): 일반 진입 후 자동 하단 스크롤 직후 · 스크롤 near-bottom · 활성 열람 중 신규 메시지 도착 시.
- **"여기부터 안읽음" 마커**: 진입 시점 last_read_at에 동결(방문 세션 내 유지), info 톤(빨강 0).
- **리스트 배지**: 이미 서버 unread_count 소비 중이었음 — conversation.read SSE 자가정정만 추가.
- **GNB 총합**(3번째 표면, 신규): 공유 훅(`use-chat-unread-total.ts`)으로 데스크톱 사이드바+모바일 4탭 재사용, mount fetch+SSE 자가정정+focus 백스톱.
- BE 프록시 신설: `POST /api/conversations/{id}/read`, `GET /api/conversations/unread-count`.

## Test plan
- [x] tsc/lint/vitest(257/1710)/build 클린
- [x] 격리 docker-compose 스택 라이브 확인(실 계약, Account A/B 2계정 실 DM, 마이그레이션 0199 확인):
  - 리스트 배지=서버 unread_count 정확 표시
  - 상세 진입 시 "여기부터 안읽음" 마커가 정확히 첫 미열람 메시지 앞에 위치
  - 하단 자동스크롤 직후 mark-read 자동 발화 → 리스트+GNB 배지 즉시 0 자가정정
  - GNB 총합(데스크톱 사이드바 "채팅" + 모바일 4탭 "채팅") 리스트 배지와 정합
  - 모바일(390px)+데스크톱, 라이트+다크 전부 스크린샷 확인
  - 백그라운드 탭 conversation.read SSE 교차-탭 자가정정 부수 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)