### PR TITLE
[SID:1999] 긴급: bare 레거시 flat 링크 404 — CURRENT_PROJECT_COOKIE JWT fallback

### DIFF
--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -14,12 +14,14 @@ import { proxy as middleware } from './proxy';
 
 const JWT_SECRET = 'test-secret-for-proxy-tests';
 
-async function makeAccessToken(overrides: { exp?: number; type?: string; orgId?: string } = {}): Promise<string> {
+async function makeAccessToken(overrides: { exp?: number; type?: string; orgId?: string; projectId?: string } = {}): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
   return new SignJWT({
     type: overrides.type ?? 'access',
     email: 'test@example.com',
-    ...(overrides.orgId ? { app_metadata: { org_id: overrides.orgId } } : {}),
+    ...((overrides.orgId || overrides.projectId)
+      ? { app_metadata: { ...(overrides.orgId ? { org_id: overrides.orgId } : {}), ...(overrides.projectId ? { project_id: overrides.projectId } : {}) } }
+      : {}),
   })
     .setProtectedHeader({ alg: 'HS256' })
     .setSubject('user-123')
@@ -424,6 +426,39 @@ describe('proxy — legacy resource redirect generalized to non-docs resources (
       expect(response.headers.get('location')).toBe(`https://app.example.com/moonklabs/sprintable/${resource}`);
     },
   );
+
+  it('story #1999: CURRENT_PROJECT_COOKIE 부재(평범한 로그인 직후) 시 access token app_metadata.project_id로 fallback — 여전히 301', async () => {
+    const token = await makeAccessToken({ orgId: 'org-1', projectId: 'proj-1' });
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/api/v2/organizations/org-1')) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'org-1', slug: 'moonklabs' }) });
+      }
+      if (url.includes('/api/v2/projects/proj-1')) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'proj-1', slug: 'sprintable' }) });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+    // 쿠키 없이 sp_at만 — 온보딩/switch-project를 거치지 않은 순수 로그인 세션 재현.
+    const response = await middleware(makeRequest('/board?story=abc', { sp_at: token }));
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/sprintable/board?story=abc');
+  });
+
+  it('story #1999: 쿠키와 JWT project_id가 다르면 쿠키 우선(명시 switch-project 결과 존중)', async () => {
+    const token = await makeAccessToken({ orgId: 'org-1', projectId: 'proj-old' });
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/api/v2/organizations/org-1')) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'org-1', slug: 'moonklabs' }) });
+      }
+      if (url.includes('/api/v2/projects/proj-new')) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'proj-new', slug: 'newer-project' }) });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+    const response = await middleware(makeRequest('/board', { sp_at: token, sprintable_current_project_id: 'proj-new' }));
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/newer-project/board');
+  });
 
   it('이관 안 된 리소스(예: /meetings — dead feature, S-route-project 스코프 밖)는 개입 없이 통과 — MIGRATED_RESOURCES 밖', async () => {
     // story a539c649 S3d: board는 이관 완료(MIGRATED_RESOURCES 편입)라 이 예시로 더 이상 부적합

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -89,6 +89,24 @@ async function getOrgIdFromAccessToken(token: string): Promise<string | null> {
   }
 }
 
+// story #1998(급, 선생님 실사용 "보드가 404") — access token의 app_metadata.project_id를
+// CURRENT_PROJECT_COOKIE 부재 시 fallback으로 쓴다. 근본원인: 이 쿠키는 onboarding-form.tsx·
+// switch-project·switch-org 명시 액션에서만 SET되고 평범한 로그인(POST /api/auth/login)에서는
+// 전혀 SET되지 않는다(grep 확認·curl 재현: 로그인 직후 쿠키잔에 sp_at/sp_rt만 있고 이 쿠키는
+// 없음) — 즉 온보딩 세션이 만료/새 기기/쿠키 삭제 후 "그냥 로그인"한 리턴 유저는 전원 이 안전망이
+// 무력화돼 bare 레거시 링크(board·loops·docs 등, MIGRATED_RESOURCES)가 즉시 404. JWT 자체엔
+// 로그인 시점 project_id가 이미 실려있으므로(app_metadata, org_id와 동일 위치) 그걸 재사용하면
+// 추가 DB조회 없이 이 갭을 메운다 — 쿠키가 있으면 쿠키 우선(명시 switch-project 결과 존중).
+async function getProjectIdFromAccessToken(token: string): Promise<string | null> {
+  try {
+    const { payload } = await jwtVerify(token, getJwtSecretBytes());
+    const projectId = (payload['app_metadata'] as Record<string, unknown> | undefined)?.['project_id'];
+    return typeof projectId === 'string' ? projectId : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * story a539c649 S-route-project — 이관 완료된 Project-tier 리소스 목록(flat 첫 세그먼트 →
  * 그 리소스 밑에서 project-scope 아닌 채로 존치되는 서브패스 제외 목록). 슬라이스가 리소스를
@@ -124,7 +142,9 @@ async function redirectLegacyResourcePath(
   if (excluded.some((sub) => pathname.startsWith(`/${resourceName}/${sub}`))) return null;
 
   const orgId = await getOrgIdFromAccessToken(accessToken);
-  const projectId = request.cookies.get(CURRENT_PROJECT_COOKIE)?.value;
+  // story #1998: 쿠키 우선(명시 switch-project 결과) — 없으면 JWT app_metadata.project_id로 fallback.
+  const projectId = request.cookies.get(CURRENT_PROJECT_COOKIE)?.value
+    ?? await getProjectIdFromAccessToken(accessToken);
   if (!orgId || !projectId) return null;
 
   const fastapiUrl = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';


### PR DESCRIPTION
## Summary
- 선생님 실사용 재보고("보드가 지금 404") — `redirectLegacyResourcePath()`(MIGRATED_RESOURCES 안전망)가 CURRENT_PROJECT_COOKIE 부재 시 무력화되는 게 근본원인.
- `CURRENT_PROJECT_COOKIE`(`sprintable_current_project_id`)는 onboarding-form.tsx·switch-project·switch-org 명시 액션에서만 SET — 평범한 로그인(`POST /api/auth/login`)에서는 전혀 SET 안 됨(curl 재현: 로그인 직후 쿠키잔에 sp_at/sp_rt만 존재).
- 온보딩 세션 만료/새 기기/쿠키 삭제 후 "그냥 로그인"한 리턴 유저는 전원 이 안전망이 무력화 → bare 레거시 링크(board·loops·docs·retro 등) 즉시 404.
- access token(`app_metadata`)에 이미 로그인 시점 `project_id`가 실려있으므로(`org_id`와 동일 위치) fallback 소스로 재사용 — 추가 DB조회 없음. 쿠키 존재 시 쿠키 우선(명시 switch-project 결과 존중).

## Test plan
- [x] tsc/lint/vitest(257/1712, 신규 2건 포함)/build 클린
- [x] `proxy.test.ts` 48/48 GREEN (기존 MIGRATED_RESOURCES 9종 parameterized 회귀 + 신규 fallback/쿠키우선 2건 + docs/design-tokens 제외 서브패스 회귀 없음)
- [x] 격리 스택 라이브 실증: curl 순수 로그인 세션 재현 → 수정 전 `/board`·`/loops` 404 확인 → 수정+재빌드 후 둘 다 301(쿼리스트링 보존) → 브라우저로 `/board?story={id}` 직접 진입 → 301 해소 → 보드 로드 + 스토리 상세 딥링크 정상 오픈 end-to-end 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)