### PR TITLE
[SID:1988] retro·doc-tree 터치-드래그 하이재킹 — 0d142311 패턴 적용

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
-import { DndContext, PointerSensor, useDraggable, useDroppable, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
+import { DndContext, useDraggable, useDroppable, type DragEndEvent } from '@dnd-kit/core';
 import { Check } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Badge } from '@/components/ui/badge';
@@ -12,6 +12,7 @@ import { EmptyState } from '@/components/ui/empty-state';
 import { OperatorInput, OperatorSelect, OperatorTextarea } from '@/components/ui/operator-control';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
+import { useTouchSafePointerSensor } from '@/hooks/use-touch-safe-pointer-sensor';
 import { cn } from '@/lib/utils';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { useRetroRoute } from '../retro-context';
@@ -480,7 +481,9 @@ export default function RetroSessionPage() {
     void groupItem(String(active.id), String(over.id));
   }
 
-  const dndSensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+  // story #1988(C): 순수 PointerSensor는 모바일 터치 스크롤을 드래그로 하이재킹한다 —
+  // kanban-board.tsx 0d142311 fix와 동일하게 터치는 드래그 활성화 자체를 배제.
+  const dndSensors = useTouchSafePointerSensor(8);
 
   async function addAction() {
     const text = newActionText.trim();

--- a/apps/web/src/components/docs/doc-tree.tsx
+++ b/apps/web/src/components/docs/doc-tree.tsx
@@ -3,10 +3,11 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { ChevronDown, ChevronRight, FileText, Folder, FolderOpen, GripVertical, MoreVertical } from 'lucide-react';
-import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors, closestCenter } from '@dnd-kit/core';
+import { DndContext, DragEndEvent, closestCenter } from '@dnd-kit/core';
 import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { cn } from '@/lib/utils';
+import { useTouchSafePointerSensor } from '@/hooks/use-touch-safe-pointer-sensor';
 import { useTreeExpanded } from './use-tree-expanded';
 
 // ─── Preview Card ─────────────────────────────────────────────────────────────
@@ -345,7 +346,9 @@ function TreeNode({
 
 export function DocTree({ docs, selectedSlug, onSelect, onReorder, onMove, onMoveDenied, onRename, onDelete, onAddChild, emptyFolderLabel, projectId, visibleIds, matchedIds, searchQuery, isSearching }: DocTreeProps) {
   const rootDocs = docs.filter((entry) => !entry.parent_id).sort((a, b) => a.sort_order - b.sort_order);
-  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+  // story #1988(C): 순수 PointerSensor는 모바일 터치 스크롤을 드래그로 하이재킹한다 —
+  // kanban-board.tsx 0d142311 fix와 동일하게 터치는 드래그 활성화 자체를 배제.
+  const sensors = useTouchSafePointerSensor(5);
   const { isExpanded, toggleExpanded } = useTreeExpanded(projectId);
 
   const handleDragEnd = useCallback(async (event: DragEndEvent) => {

--- a/apps/web/src/hooks/use-touch-safe-pointer-sensor.ts
+++ b/apps/web/src/hooks/use-touch-safe-pointer-sensor.ts
@@ -1,0 +1,22 @@
+import { PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+
+/**
+ * story #1988(C, 유나 UX 감사) — kanban-board.tsx의 터치-드래그 하이재킹 fix(0d142311,
+ * 프로덕션 재발 근본 원인)를 dnd-kit을 쓰는 다른 표면(retro 아이템 그룹핑·doc-tree 재정렬)에도
+ * 동일 적용하기 위한 공유 센서. 순수 PointerSensor(distance constraint만)는 터치 스크롤
+ * 제스처를 드래그로 오인해 하이재킹한다 — pointerType!=='touch'로 터치는 아예 드래그 활성화
+ * 자체를 하지 않게 배제해야 네이티브 스크롤이 보존된다.
+ */
+class MousePointerSensor extends PointerSensor {
+  static activators = [
+    {
+      eventName: 'onPointerDown' as const,
+      handler: ({ nativeEvent }: { nativeEvent: PointerEvent }) =>
+        nativeEvent.isPrimary && nativeEvent.button === 0 && nativeEvent.pointerType !== 'touch',
+    },
+  ];
+}
+
+export function useTouchSafePointerSensor(distance: number) {
+  return useSensors(useSensor(MousePointerSensor, { activationConstraint: { distance } }));
+}


### PR DESCRIPTION
## Summary
- `retro/[id]/page.tsx:483`·`doc-tree.tsx:348` 둘 다 순수 `PointerSensor`(터치 배제 없음·distance constraint만)라 모바일 터치 스크롤이 드래그로 하이재킹됐다(kanban-board.tsx의 프로덕션 재발 근본 fix `0d142311`이 이 두 형제 표면엔 미적용).
- `MousePointerSensor`(pointerType!=='touch' 배제) 클래스를 공유 훅(`use-touch-safe-pointer-sensor.ts`)으로 추출해 두 표면에 적용 — kanban-board.tsx 자체는 무변경(이미 QA 통과, 불필요한 회귀 리스크 배제).

## Test plan
- [x] tsc/lint/vitest(257/1712)/build 클린
- [x] 격리 docker-compose 스택 라이브 확인(390px+hasTouch):
  - doc-tree(모바일 드로어, 문서 15건): CDP Touch 터치+드래그 재현 — `touchmove.defaultPrevented===false`(드래그 미시작·네이티브 스크롤 패스스루 보존), 순서 변경 없음 스크린샷 확인
  - retro(vote 단계, 실 세션+아이템 3건): 동일 재현 — `defaultPrevented===false`·병합/재정렬 미발동 스크린샷 확인
  - 두 표면 모두 데스크톱 마우스 드래그 경로 무변경(센서 클래스만 교체)

🤖 Generated with [Claude Code](https://claude.com/claude-code)