### PR TITLE
[SID:1989] 에이전트 상세/관리 fetch try/catch 부재 — 로딩 스켈레톤 무한 봉합

### DIFF
--- a/apps/web/src/components/agents/agent-management-tab.tsx
+++ b/apps/web/src/components/agents/agent-management-tab.tsx
@@ -39,10 +39,16 @@ interface AgentManagementTabProps {
 export function AgentManagementTab({ onAddAgent }: AgentManagementTabProps) {
   const t = useTranslations('settings');
   const ta = useTranslations('agents');
+  const tc = useTranslations('common');
   const [agents, setAgents] = useState<OrgAgent[]>([]);
   const [grantCounts, setGrantCounts] = useState<Record<string, number>>({});
   const [isAdmin, setIsAdmin] = useState(false);
   const [loading, setLoading] = useState(true);
+  // story #1989: mount effect가 try/catch 없이 fetch를 직결해 네트워크 실패(오프라인 등) 시
+  // fetch가 throw → setLoading(false)가 영영 안 불려 스켈레톤이 무한 행("loading은 finally에서
+  // 해소" 하우스룰 위반). loadError로 실패를 별도 상태화해 재시도 affordance를 노출한다.
+  const [loadError, setLoadError] = useState(false);
+  const [retryKey, setRetryKey] = useState(0);
   const [togglingId, setTogglingId] = useState<string | null>(null);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
@@ -79,24 +85,30 @@ export function AgentManagementTab({ onAddAgent }: AgentManagementTabProps) {
   useEffect(() => {
     void (async () => {
       setLoading(true);
-      const [meRes, projectsRes] = await Promise.all([
-        fetch('/api/me'),
-        fetch('/api/projects'),
-      ]);
-      if (meRes.ok) {
-        const meJson = await meRes.json() as { data?: { role?: string } };
-        const role = meJson.data?.role ?? 'member';
-        setIsAdmin(role === 'admin' || role === 'owner');
+      setLoadError(false);
+      try {
+        const [meRes, projectsRes] = await Promise.all([
+          fetch('/api/me'),
+          fetch('/api/projects'),
+        ]);
+        if (meRes.ok) {
+          const meJson = await meRes.json() as { data?: { role?: string } };
+          const role = meJson.data?.role ?? 'member';
+          setIsAdmin(role === 'admin' || role === 'owner');
+        }
+        let projectList: ProjectOption[] = [];
+        if (projectsRes.ok) {
+          const json = await projectsRes.json() as { data?: ProjectOption[] };
+          projectList = (json.data ?? []).slice().sort((a, b) => a.name.localeCompare(b.name));
+        }
+        await Promise.all([refreshAgents(), refreshGrantCounts(projectList)]);
+      } catch {
+        setLoadError(true);
+      } finally {
+        setLoading(false);
       }
-      let projectList: ProjectOption[] = [];
-      if (projectsRes.ok) {
-        const json = await projectsRes.json() as { data?: ProjectOption[] };
-        projectList = (json.data ?? []).slice().sort((a, b) => a.name.localeCompare(b.name));
-      }
-      await Promise.all([refreshAgents(), refreshGrantCounts(projectList)]);
-      setLoading(false);
     })();
-  }, []);
+  }, [retryKey]);
 
   const handleToggleActive = async (agent: OrgAgent) => {
     setTogglingId(agent.id);
@@ -142,6 +154,14 @@ export function AgentManagementTab({ onAddAgent }: AgentManagementTabProps) {
           {loading ? (
             <div className="space-y-2">
               {[1, 2, 3].map((i) => <div key={i} className="h-14 animate-pulse rounded-md bg-muted" />)}
+            </div>
+          ) : loadError ? (
+            <div className="flex flex-col items-center gap-3 rounded-md border border-dashed border-border px-3 py-8 text-center">
+              <p className="text-sm text-muted-foreground">{tc('error')}</p>
+              <p className="text-xs text-muted-foreground">{tc('errorDescription')}</p>
+              <Button size="sm" variant="outline" onClick={() => setRetryKey((k) => k + 1)}>
+                {tc('retry')}
+              </Button>
             </div>
           ) : agents.length === 0 ? (
             <div className="rounded-md border border-dashed border-border px-3 py-8 text-center">

--- a/apps/web/src/components/agents/agent-run-detail.tsx
+++ b/apps/web/src/components/agents/agent-run-detail.tsx
@@ -190,21 +190,33 @@ export function AgentRunDetail({
   const { toasts, addToast, dismissToast } = useToast();
   const [run, setRun] = useState<RunDetail | null>(null);
   const [loading, setLoading] = useState(true);
+  // story #1989: fetch 자체에 try/catch가 없어 네트워크 실패(오프라인 등) 시 fetch가 throw →
+  // setLoading(false)가 영영 안 불려 스켈레톤이 무한 행("loading은 finally에서 해소" 하우스룰
+  // 위반). loadError로 실패를 별도 상태화해 재시도 affordance를 노출한다.
+  const [loadError, setLoadError] = useState(false);
   const [retrying, setRetrying] = useState(false);
+  const [retryKey, setRetryKey] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
     async function load() {
       setLoading(true);
-      const res = await fetch(`/api/v1/agent-runs/${runId}`);
-      const json = res.ok ? await res.json() : null;
-      if (cancelled) return;
-      setRun(json?.data ?? null);
-      setLoading(false);
+      setLoadError(false);
+      try {
+        const res = await fetch(`/api/v1/agent-runs/${runId}`);
+        const json = res.ok ? await res.json() : null;
+        if (cancelled) return;
+        setRun(json?.data ?? null);
+        if (!res.ok) setLoadError(true);
+      } catch {
+        if (!cancelled) setLoadError(true);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
     }
     void load();
     return () => { cancelled = true; };
-  }, [runId]);
+  }, [runId, retryKey]);
 
   const handleRetry = async () => {
     setRetrying(true);
@@ -227,6 +239,18 @@ export function AgentRunDetail({
       <div className="space-y-4">
         <div className="h-24 animate-pulse rounded-xl bg-muted" />
         <div className="h-64 animate-pulse rounded-xl bg-muted" />
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-20 text-center text-muted-foreground">
+        <p>{tc('error')}</p>
+        <p className="text-xs">{tc('errorDescription')}</p>
+        <Button size="sm" variant="outline" onClick={() => setRetryKey((k) => k + 1)}>
+          {tc('retry')}
+        </Button>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- `agent-run-detail.tsx:196`·`agent-management-tab.tsx:79` 둘 다 mount effect가 fetch를 try/catch 없이 직결 — 네트워크 실패 시 `setLoading(false)`가 영영 안 불려 스켈레톤 무한 행("loading은 finally에서 해소" 하우스룰 위반).
- 두 곳 모두 try/catch/finally로 감싸 loading은 finally에서 항상 해소, 실패는 `loadError` state로 표현해 재시도 affordance 노출(기존 `common.error/errorDescription/retry` i18n 키 재사용).
- `retryKey` state를 effect dependency에 넣어 재시도 버튼이 같은 로드 로직 재실행 — 신규 useCallback 없이 기존 plain-헬퍼 컨벤션 유지.

## Test plan
- [x] tsc/lint/vitest(257/1712)/build 클린
- [x] 격리 스택 라이브 실패주입: `agent-management-tab.tsx` — `window.fetch` 오버라이드로 `/api/me`·`/api/projects` reject 주입 → 탭 재마운트 시 스켈레톤 무한 없이 에러 UI 즉시 전환 확인(스크린샷) → fetch 복원 후 "다시 시도" 클릭 → 정상 재조회 확인(전체 재시도 사이클 검증)
- [x] `agent-run-detail.tsx`는 실 agent run 부재로 동일 라이브 트리거는 못했으나 완전히 동일한 try/catch/finally+retryKey 패턴 적용(코드 검토 확인)
- [x] grep 재확인: 유사 패턴이 스코프 밖 다수 파일에도 존재 — 별도 보고 예정(스코프 확장 안 함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)