### PR TITLE
feat(mcp): agent doc-mention token synthesis in send_chat_message (#1995)

### DIFF
--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -582,7 +582,9 @@ _TOOL_DEFS: list[tuple] = [
      ProposeCanonicalInput, propose_canonical_version),
     # Chat (4)
     ("sprintable_send_chat_message",
-     "[조직] conversation thread에 채팅 메시지 발송.",
+     "[조직] conversation thread에 채팅 메시지 발송. mentions=[{type:\"doc\", id, title?}]로 human"
+     " `#`-검색 doc mention과 동형인 `[title](entity:doc:id)` 토큰을 content에 합성(title 생략 시"
+     " 서버가 doc title 조회) — agent 발신 메시지에서도 doc 링크/backlink가 동작하게 한다.",
      SendChatInput, send_chat_message),
     ("sprintable_create_conversation",
      "[조직] 새 conversation thread 생성.",

--- a/backend/sprintable_mcp/tools/chat.py
+++ b/backend/sprintable_mcp/tools/chat.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import logging
+import re
+from typing import Literal
 
 from mcp.types import TextContent
 
@@ -11,6 +13,37 @@ from ..schemas import SprintableInput
 from .attachments import upload_attachments
 
 logger = logging.getLogger(__name__)
+
+# story 1995: `[title](entity:type:id) ` 토큰 구조를 변조하는 문자(`\ [ ] ( )`)를 escape.
+# FE applyAsset()(chat-input.tsx ~L78-79)의 escape 로직 미러 — raw title에 `]`/`(`/`)`가 섞이면
+# markdown-link 토큰 구조를 깨고 임의 링크를 위조할 수 있다(예: `x](https://phish)[y` →
+# 렌더 시 phishing 링크로 탈바꿈). 개행은 토큰 한 줄 구조를 깨므로 공백으로 접는다.
+_MENTION_TITLE_ESCAPE_RE = re.compile(r"[\\\[\]()]")
+_MENTION_TITLE_NEWLINE_RE = re.compile(r"[\r\n]+")
+
+
+def escape_mention_title(title: str) -> str:
+    """agent-authored mention 토큰의 title을 escape — token-injection/forged-link 방지.
+
+    FE `applyAsset()`(chat-input.tsx)와 동일 규칙을 Python으로 미러: `\\`, `[`, `]`, `(`, `)`를
+    백슬래시로 escape하고, `\r`/`\n` 연속을 단일 공백으로 접는다. title이 caller 제공이든
+    (agent가 임의 문자열 전달 가능) DB에서 fetch한 것이든(문서 제목에 임의 문자 가능) 동일하게
+    적용해야 `[{title}](entity:doc:{id})` 토큰 구조가 깨지지 않는다.
+    """
+    escaped = _MENTION_TITLE_ESCAPE_RE.sub(lambda m: "\\" + m.group(0), title)
+    return _MENTION_TITLE_NEWLINE_RE.sub(" ", escaped)
+
+
+class MentionRef(SprintableInput):
+    """agent 발신 채팅 메시지에 첨부할 entity mention — story 1995(doc 링크 안 됨 근본수정).
+
+    type은 스키마 레벨에서 "doc"만 허용(Literal) — MCP tool-call 검증 단계에서 그 외 값은
+    핸들러 코드 진입 전에 거부된다(AC1).
+    """
+
+    type: Literal["doc"]
+    id: str
+    title: str | None = None
 
 
 class SendChatInput(SprintableInput):
@@ -22,6 +55,10 @@ class SendChatInput(SprintableInput):
     metadata: dict | None = None
     # [{content_base64, name, content_type}, ...] — 스샷/작은 문서(최대 5개·파일당 2MiB·총 6MiB).
     attachments: list[dict] | None = None
+    # story 1995: agent가 human의 `#` 트리거 doc mention(chat-input.tsx applyEntity())과 동형인
+    # `[title](entity:doc:id) ` 토큰을 content에 합성 — human 경로가 만드는 토큰을 agent 경로도
+    # 만들 수 있게 해 doc backlink/link가 agent 발신 메시지에서도 동작하게 한다.
+    mentions: list[MentionRef] | None = None
 
 
 class CreateConversationInput(SprintableInput):
@@ -40,22 +77,47 @@ class GetChatMessageInput(SprintableInput):
     message_id: str
 
 
+async def _resolve_mention_content(args: SendChatInput) -> str:
+    """story 1995: mentions → `[title](entity:doc:id) ` 토큰을 합성해 content에 붙인다.
+
+    title 미지정 mention은 GET /api/v2/docs/{id}로 canonical title을 조회(AC3) — 404/기타 에러는
+    그대로 propagate(호출자 send_chat_message의 try/except가 잡아 err()로 노출·메시지 POST 자체를
+    막는다 — broken 토큰이 실린 반쪽 메시지가 저장되는 걸 방지).
+
+    join 컨벤션: 각 토큰은 FE applyEntity()/applyAsset() 관례와 동일하게 trailing space를 포함
+    (`[title](entity:doc:id) `) — 여러 mention은 토큰을 그대로 이어붙이고(토큰마다 이미 뒤 공백이
+    있어 추가 구분자 불필요), 원 content가 비어있지 않으면 content와 토큰 블록 사이에 공백 하나를
+    삽입한다. 예: content="see this" + mentions=[{title:"My Doc", id:"<uuid>"}] →
+    "see this [My Doc](entity:doc:<uuid>) ".
+    """
+    tokens: list[str] = []
+    for mention in args.mentions or []:
+        title = mention.title
+        if title is None:
+            doc = await client.get(f"/api/v2/docs/{mention.id}")
+            title = (doc.get("title") or "") if isinstance(doc, dict) else ""
+        tokens.append(f"[{escape_mention_title(title)}](entity:doc:{mention.id}) ")
+    token_block = "".join(tokens)
+    return f"{args.content} {token_block}" if args.content else token_block
+
+
 async def send_chat_message(args: SendChatInput) -> list[TextContent]:
     """conversation thread에 채팅 메시지 발송."""
-    payload: dict = {"content": args.content}
-    if args.reply_thread_id:
-        payload["thread_id"] = args.reply_thread_id
-    meta: dict = {}
-    if args.metadata:
-        meta.update(args.metadata)
-    if args.message_type:
-        meta["message_type"] = args.message_type
-    if args.review_type:
-        meta["review_type"] = args.review_type
-    if meta:
-        payload["metadata"] = meta
     uploaded_urls: list[str] = []
     try:
+        content = await _resolve_mention_content(args) if args.mentions else args.content
+        payload: dict = {"content": content}
+        if args.reply_thread_id:
+            payload["thread_id"] = args.reply_thread_id
+        meta: dict = {}
+        if args.metadata:
+            meta.update(args.metadata)
+        if args.message_type:
+            meta["message_type"] = args.message_type
+        if args.review_type:
+            meta["review_type"] = args.review_type
+        if meta:
+            payload["metadata"] = meta
         attachments = await upload_attachments(
             f"/api/v2/conversations/{args.thread_id}/attachments", args.attachments,
         )

--- a/backend/tests/test_mcp_s1995_agent_doc_mentions.py
+++ b/backend/tests/test_mcp_s1995_agent_doc_mentions.py
@@ -1,0 +1,196 @@
+"""story #1995: `sprintable_send_chat_message`의 agent doc-mention 토큰 합성 — MCP 쪽 검증.
+
+근본 원인: human이 채팅 UI에서 `#`으로 doc를 검색하면 chat-input.tsx의 applyEntity()가
+`[title](entity:doc:id) ` 토큰을 삽입해 doc 링크/backlink가 동작한다. agent가
+sprintable_send_chat_message로 보내는 raw content엔 이 토큰을 만들 방법이 없어 agent 발신
+메시지의 doc 참조가 링크되지 않았다(선생님 "doc 링크 안 됨" 리포트 근본원인).
+
+이 테스트는 (1) escape helper 단위 테스트(adversarial title — token-injection/forged-link
+방지), (2) mentions→토큰 합성 통합 테스트(title 명시/생략 양쪽 경로 + 404 전파),
+(3) mentions 생략 시 회귀 0(가장 중요), (4) type Literal["doc"] 외 값이 Pydantic 스키마
+레벨에서 거부되는지를 검증한다.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from sprintable_mcp.tools import chat as chat_mod
+from sprintable_mcp.tools.chat import (
+    MentionRef,
+    SendChatInput,
+    escape_mention_title,
+    send_chat_message,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── escape_mention_title ──────────────────────────────────────────────────────
+def test_escape_mention_title_plain_string_passthrough():
+    assert escape_mention_title("My Doc") == "My Doc"
+
+
+def test_escape_mention_title_empty_string():
+    assert escape_mention_title("") == ""
+
+
+def test_escape_mention_title_adversarial_forged_link():
+    """`x](https://evil.example)[y` — escape 없으면 markdown-link 토큰 구조를 깨고
+    `[x](https://evil.example)[y](entity:doc:id) ` 처럼 임의 링크를 위조할 수 있다."""
+    raw = "x](https://evil.example)[y"
+    escaped = escape_mention_title(raw)
+    assert escaped == r"x\]\(https://evil.example\)\[y"
+    # 합성된 토큰 안에서 title 부분의 `]`/`(`/`)`가 전부 escape되어 링크 구조 경계가 title
+    # 내부로 침범하지 않는다.
+    token = f"[{escaped}](entity:doc:doc-1) "
+    assert token == r"[x\]\(https://evil.example\)\[y](entity:doc:doc-1) "
+
+
+def test_escape_mention_title_backslash():
+    assert escape_mention_title("a\\b") == "a\\\\b"
+
+
+def test_escape_mention_title_brackets_and_parens():
+    assert escape_mention_title("[a](b)") == r"\[a\]\(b\)"
+
+
+def test_escape_mention_title_collapses_newlines_to_single_space():
+    assert escape_mention_title("line1\nline2") == "line1 line2"
+    assert escape_mention_title("a\r\n\r\nb") == "a b"
+
+
+# ── MentionRef schema validation ──────────────────────────────────────────────
+def test_mention_ref_rejects_invalid_type():
+    """type이 "doc" 외 값이면 Pydantic 스키마 레벨에서 거부(AC1) — 핸들러 코드 진입 전 차단."""
+    with pytest.raises(ValidationError):
+        MentionRef(type="story", id="s-1")
+
+
+def test_send_chat_input_rejects_invalid_mention_type():
+    with pytest.raises(ValidationError):
+        SendChatInput(thread_id="conv-1", content="hi", mentions=[{"type": "task", "id": "t-1"}])
+
+
+def test_mention_ref_accepts_doc_type():
+    m = MentionRef(type="doc", id="d-1", title="My Doc")
+    assert m.type == "doc"
+
+
+# ── send_chat_message: token synthesis (title given) ─────────────────────────
+@pytest.mark.anyio
+async def test_send_chat_message_synthesizes_token_with_given_title():
+    args = SendChatInput(
+        thread_id="conv-1",
+        content="see this",
+        mentions=[{"type": "doc", "id": "11111111-1111-1111-1111-111111111111", "title": "My Doc"}],
+    )
+    with patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m, \
+         patch.object(chat_mod.client, "get", new=AsyncMock()) as g:
+        result = await send_chat_message(args)
+        g.assert_not_called()  # title 명시 → doc GET 조회 스킵
+        _, kwargs = m.call_args
+        assert kwargs["json"]["content"] == (
+            "see this [My Doc](entity:doc:11111111-1111-1111-1111-111111111111) "
+        )
+        assert "Error" not in result[0].text
+
+
+@pytest.mark.anyio
+async def test_send_chat_message_synthesizes_token_multiple_mentions_no_double_space():
+    args = SendChatInput(
+        thread_id="conv-1",
+        content="see these",
+        mentions=[
+            {"type": "doc", "id": "doc-a", "title": "Doc A"},
+            {"type": "doc", "id": "doc-b", "title": "Doc B"},
+        ],
+    )
+    with patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m:
+        await send_chat_message(args)
+        _, kwargs = m.call_args
+        assert kwargs["json"]["content"] == (
+            "see these [Doc A](entity:doc:doc-a) [Doc B](entity:doc:doc-b) "
+        )
+
+
+@pytest.mark.anyio
+async def test_send_chat_message_escapes_adversarial_given_title():
+    args = SendChatInput(
+        thread_id="conv-1",
+        content="see this",
+        mentions=[{"type": "doc", "id": "doc-1", "title": "x](https://evil.example)[y"}],
+    )
+    with patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m:
+        await send_chat_message(args)
+        _, kwargs = m.call_args
+        assert kwargs["json"]["content"] == (
+            r"see this [x\]\(https://evil.example\)\[y](entity:doc:doc-1) "
+        )
+
+
+# ── send_chat_message: title omitted → fetched via client.get ────────────────
+@pytest.mark.anyio
+async def test_send_chat_message_fetches_title_when_omitted():
+    args = SendChatInput(
+        thread_id="conv-1",
+        content="see this",
+        mentions=[{"type": "doc", "id": "doc-1"}],
+    )
+    with patch.object(chat_mod.client, "get", new=AsyncMock(return_value={"id": "doc-1", "title": "Fetched Doc"})) as g, \
+         patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m:
+        result = await send_chat_message(args)
+        g.assert_awaited_once_with("/api/v2/docs/doc-1")
+        _, kwargs = m.call_args
+        assert kwargs["json"]["content"] == "see this [Fetched Doc](entity:doc:doc-1) "
+        assert "Error" not in result[0].text
+
+
+# ── send_chat_message: 404 on doc fetch propagates, no message POST ──────────
+@pytest.mark.anyio
+async def test_send_chat_message_mention_doc_not_found_errors_without_posting_message():
+    args = SendChatInput(
+        thread_id="conv-1",
+        content="see this",
+        mentions=[{"type": "doc", "id": "missing-doc"}],
+    )
+
+    with patch.object(chat_mod.client, "get", new=AsyncMock(side_effect=RuntimeError("404 Not Found"))) as g, \
+         patch.object(chat_mod.client, "post", new=AsyncMock()) as m:
+        result = await send_chat_message(args)
+        g.assert_awaited_once_with("/api/v2/docs/missing-doc")
+        m.assert_not_called()  # broken 토큰이 실린 반쪽 메시지가 저장되지 않는다
+        assert result[0].text.startswith("Error")
+        assert "404" in result[0].text
+
+
+# ── mentions 생략 → 회귀 0 (가장 중요) ─────────────────────────────────────────
+@pytest.mark.anyio
+async def test_send_chat_message_mentions_omitted_byte_identical_to_current_behavior():
+    """mentions 필드 자체를 안 넘긴 기존 호출자는 payload가 이 변경 前과 완전히 동일해야 한다."""
+    args = SendChatInput(thread_id="conv-1", content="hi there")
+    assert args.mentions is None
+    with patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m, \
+         patch.object(chat_mod.client, "get", new=AsyncMock()) as g:
+        result = await send_chat_message(args)
+        g.assert_not_called()
+        _, kwargs = m.call_args
+        assert kwargs["json"] == {"content": "hi there"}
+        assert "attachments" not in kwargs["json"]
+        assert "mentions" not in kwargs["json"]
+        assert "Error" not in result[0].text
+
+
+@pytest.mark.anyio
+async def test_send_chat_message_empty_mentions_list_byte_identical():
+    """mentions=[] (falsy) 도 mentions=None과 동일하게 동작 — content 변조 없음."""
+    args = SendChatInput(thread_id="conv-1", content="hi there", mentions=[])
+    with patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m:
+        await send_chat_message(args)
+        _, kwargs = m.call_args
+        assert kwargs["json"]["content"] == "hi there"


### PR DESCRIPTION
## Summary
- Story #1995 — MCP-server-layer only (`backend/sprintable_mcp/`). Root cause: agent-authored chat messages via `sprintable_send_chat_message` had no way to produce the `[title](entity:doc:id) ` token that the FE chat UI's `applyEntity()` inserts for human `#`-triggered doc mentions (`apps/web/src/components/chat/chat-input.tsx`), so agent doc references never linked/backlinked — traced from 선생님's "doc 링크 안 됨" report.
- Adds `SendChatInput.mentions: list[MentionRef] | None`, with `MentionRef.type: Literal["doc"]` enforced at the Pydantic/MCP schema layer (AC1 — invalid `type` fails tool-call validation before handler code runs).
- `send_chat_message` resolves each mention's title (caller-supplied as-is, or fetched via `GET /api/v2/docs/{id}` when omitted — same client-call pattern as `docs.py`'s `get_doc`), escapes it, synthesizes the FE-equivalent token, and appends it to `content` before the backend POST. A 404/error on title fetch propagates as an `err()` for the whole call — no partial/dangling message with a broken token is ever sent.
- Backend contract (`SendMessageRequest`) is **untouched** — token synthesis happens entirely inside the MCP tool function before the HTTP POST body is built (`{"content": ..., "thread_id": ..., "metadata": ..., "attachments": ...}` shape unchanged). Confirmed no other MCP tool internally reuses `send_chat_message`/`SendChatInput` (only `server.py`'s tool registration calls it).

## Security note (escaping)
The same token-injection risk already fixed on the FE side for asset tokens (`applyAsset()`, chat-input.tsx ~L71-80) applies here: an unescaped title containing `]`, `(`, `)`, or `\` can break out of the markdown-link token structure and forge an arbitrary link (e.g. `x](https://phish)[y` renders as a phishing link). `escape_mention_title()` in `backend/sprintable_mcp/tools/chat.py` replicates that FE escaping exactly (backslash-escape `\ [ ] ( )`, collapse `\r`/`\n` runs to a single space) and is applied uniformly whether the title is caller-supplied or DB-fetched.

**FE gap flagged, not fixed here**: `applyEntity()` (the FE path used for *human* `#`-triggered doc mentions) does **not** have this escaping — only `applyAsset()` does. This is a pre-existing FE gap, out of scope for this MCP-layer PR. Flagging separately for the FE owner (미르코).

## Independently mergeable
- No dependency on #2272/#2276.
- Depends only on the chat-token *shape* documented from story #1993's `mention_parser.py` regex (`\[[^\]]*\]\(entity:(?P<type>[a-z]+):(?P<id><uuid>)\)`), not on that module's code — branch is based on plain `develop`, no schema/migration dependency.

## Test plan
- [x] `escape_mention_title()` unit tests: adversarial forged-link title, backslash, brackets/parens, newline-run collapsing, empty string, plain passthrough.
- [x] Token synthesis (title given): single mention, multiple mentions (no double-space), adversarial title escaping.
- [x] Title-omitted path: mocked `client.get` fetch + used in token.
- [x] 404 path: mocked `client.get` raises → `err()` returned, `client.post` (message create) never called.
- [x] `mentions` omitted / `mentions=[]` → byte-identical payload to pre-change behavior (regression, most important).
- [x] Invalid `type` (not `"doc"`) rejected by Pydantic at schema-construction time.
- [x] Existing chat/attachment/contract/toolset test suites re-run clean (no regressions).

`uv run pytest tests/test_mcp_s1995_agent_doc_mentions.py -q` → **16 passed**.
Broader regression sweep (`tests/test_e_mcp_opt_s2_chat_attachment_tool.py`, `tests/mcp/test_contract.py`, `tests/test_e_mcp_s2_toolset.py`, `tests/test_e_mcp_opt_s1_tools_list_scope_filter.py`, `tests/test_mcp_get_chat_message_3cf50d90.py`) → **64 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)