### PR TITLE
[SID:2007][긴급] GNB unread 배지 SSE 연결 중복 제거 — 앱 웹뷰 H1/H2 연결캡 완화

### DIFF
--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -20,6 +20,7 @@ import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
 import { ContextualPanelLayout, useContextualPanelState } from '@/components/ui/contextual-panel-layout';
 import { TeamPresencePanel } from '@/components/presence/team-presence-panel';
 import { useTeamPresence } from '@/components/presence/use-team-presence';
+import { useChatUnreadTotal } from '@/hooks/use-chat-unread-total';
 import { ReleaseNotesProvider } from '@/components/release-notes/release-notes-gate';
 import { RefreshProvider } from '@/contexts/refresh-context';
 import { TeamPresenceToggleProvider } from '@/components/presence/team-presence-toggle';
@@ -63,7 +64,7 @@ function isTabRootPage(pathname: string): boolean {
   return TAB_ROOT_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`));
 }
 
-function ScrollShell({ showTopBar, tabletCentered, children }: { showTopBar: boolean; tabletCentered: boolean; children: React.ReactNode }) {
+function ScrollShell({ showTopBar, tabletCentered, chatUnreadTotal, children }: { showTopBar: boolean; tabletCentered: boolean; chatUnreadTotal: number; children: React.ReactNode }) {
   const { setScrollContainer } = useTopBar();
   const setRef = useCallback((el: HTMLDivElement | null) => {
     setScrollContainer(el);
@@ -111,7 +112,7 @@ function ScrollShell({ showTopBar, tabletCentered, children }: { showTopBar: boo
       {/* story #1958(P2-S2): <1024(lg 미만) 전용 하단 탭바 — SidebarInset의 flex-col 안에서
           scroll 컨테이너의 형제(자식 아님)로 둬야 콘텐츠가 스크롤돼도 탭바가 자기 flex row를
           유지한다(position:fixed 오버레이+패딩 보정 불요 — 시안 511bc035의 flex 레이아웃과 동형). */}
-      <MobileTabBar currentTeamMemberId={currentTeamMemberId} />
+      <MobileTabBar chatUnreadTotal={chatUnreadTotal} />
     </SidebarInset>
     </TeamPresenceToggleProvider>
     </ReleaseNotesProvider>
@@ -187,6 +188,13 @@ export function DashboardShell({
   // 갈렸으면 살짝 stale 할 수 있으나, "문서로 가기" 바로가기 링크 용도라 무해(틀려도 미들웨어
   // 리다이렉트 안전망이 받는다). 완전 동기화는 이 슬라이스 스코프 밖(over-engineering).
 
+  // story #2007(perf·서버부하): GNB 채팅 unread 총합을 AppSidebar+MobileTabBar가 각자
+  // useChatUnreadTotal()을 호출해 SSE(EventSource) 연결을 독립적으로 2개 열던 것을 여기 한
+  // 곳에서만 계산해 두 표면에 값만 prop으로 내려준다 — 동일 유저 event-stream 동시 연결
+  // 4개(presence·notifications·GNB×2) 중 2개를 1개로 줄인다(배지 값은 뷰포트 무관 동일해야
+  // 하므로 공유가 정확도 손실 없이 순수 절감).
+  const chatUnreadTotal = useChatUnreadTotal(currentTeamMemberId);
+
   return (
     <DashboardCtx.Provider value={{ currentTeamMemberId, orgId, projectId: effectiveProjectId, projectName: effectiveProjectName, currentProjectSlug, userName, role, projectMemberships, orgMemberships }}>
       <RefreshProvider>
@@ -194,15 +202,15 @@ export function DashboardShell({
         <TopBarProvider>
           <SidebarProvider className="h-svh">
             <AppSidebar
-              currentTeamMemberId={currentTeamMemberId}
               projectId={effectiveProjectId}
               currentProjectSlug={currentProjectSlug}
               projectMemberships={projectMemberships}
               orgId={orgId}
               orgMemberships={orgMemberships}
               userName={userName}
+              chatUnreadTotal={chatUnreadTotal}
             />
-            <ScrollShell showTopBar={showTopBar} tabletCentered={tabletCentered}>
+            <ScrollShell showTopBar={showTopBar} tabletCentered={tabletCentered} chatUnreadTotal={chatUnreadTotal}>
               {children}
             </ScrollShell>
           </SidebarProvider>

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -34,7 +34,6 @@ import { ThemeToggle } from '@/components/nav/theme-toggle';
 import { CommandPalette } from '@/components/command-palette/command-palette';
 import { ProfileMenu } from '@/components/nav/profile-menu';
 import { UnifiedSwitcher, type OrgSwitcherItem } from '@/components/nav/unified-switcher';
-import { useChatUnreadTotal } from '@/hooks/use-chat-unread-total';
 import {
   Sidebar,
   SidebarContent,
@@ -52,7 +51,6 @@ import {
 } from '@/components/ui/sidebar';
 
 interface AppSidebarProps {
-  currentTeamMemberId?: string;
   orgId?: string;
   orgMemberships?: OrgSwitcherItem[];
   projectId?: string;
@@ -61,6 +59,9 @@ interface AppSidebarProps {
   currentProjectSlug?: string;
   projectMemberships: Array<{ projectId: string; projectName: string }>;
   userName?: string;
+  // story #2007(perf·서버부하): dashboard-shell.tsx가 단일 useChatUnreadTotal() 호출 결과를
+  // prop으로 내려준다 — 여기서 직접 훅을 호출하면 MobileTabBar와 각자 SSE 연결을 열게 된다.
+  chatUnreadTotal: number;
 }
 
 function KbdHint({ children }: { children: React.ReactNode }) {
@@ -72,13 +73,13 @@ function KbdHint({ children }: { children: React.ReactNode }) {
 }
 
 export function AppSidebar({
-  currentTeamMemberId,
   orgId,
   orgMemberships = [],
   projectId,
   currentProjectSlug,
   projectMemberships,
   userName,
+  chatUnreadTotal,
 }: AppSidebarProps) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -114,8 +115,8 @@ export function AppSidebar({
   }, [pathname, isMobile, setOpenMobile]);
 
   const [inboxUnreadCount, setInboxUnreadCount] = useState(0);
-  // story #1977(트랙B): GNB ③ 채팅 unread 총합(유나 시안 768e89b5 v2).
-  const chatUnreadTotal = useChatUnreadTotal(currentTeamMemberId);
+  // story #1977(트랙B) GNB ③ 채팅 unread 총합 — story #2007로 dashboard-shell.tsx의 단일
+  // useChatUnreadTotal() 호출 결과를 prop으로 받는다(MobileTabBar와 SSE 연결 중복 제거).
   const [paletteOpen, setPaletteOpen] = useState(false);
 
   const openPalette = useCallback(() => setPaletteOpen(true), []);

--- a/apps/web/src/components/nav/mobile-tab-bar.tsx
+++ b/apps/web/src/components/nav/mobile-tab-bar.tsx
@@ -8,7 +8,6 @@ import { CircleDot, Inbox, MessageSquare, Grid2x2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { GateItem } from '@/components/kanban/types';
 import { MOBILE_BREAKPOINT } from '@/hooks/use-mobile';
-import { useChatUnreadTotal } from '@/hooks/use-chat-unread-total';
 
 // story #1958(P2-S2, mobile-p2-p1a-story-breakdown SSOT) — 모바일 4탭 셸. <1024(lg 미만)에서만
 // 렌더되고 데스크톱 GNB(AppSidebar)를 대체한다(P2-S1의 lg:1024 SSOT와 동일 경계 — route 내
@@ -50,14 +49,13 @@ export function getActiveTabKey(pathname: string): (typeof TABS)[number]['key'] 
   return 'more';
 }
 
-export function MobileTabBar({ currentTeamMemberId }: { currentTeamMemberId?: string }) {
+export function MobileTabBar({ chatUnreadTotal }: { chatUnreadTotal: number }) {
   const t = useTranslations('mobileTabBar');
   const pathname = usePathname();
   // story #1977(트랙B): GNB ③ 채팅 unread 총합(유나 시안 768e89b5 v2) — 데스크톱 사이드바
-  // 채팅 항목(app-sidebar.tsx)과 동일 훅·동일 소스. AppSidebar와 같은 이유로 currentTeamMemberId를
-  // dashboard-shell.tsx(ScrollShell)에서 prop으로 받는다 — useDashboardContext() 직접 import는
-  // MobileTabBar를 dashboard-shell.tsx가 직접 렌더하므로 순환 참조가 된다(AppSidebar와 동일 회피).
-  const chatUnreadTotal = useChatUnreadTotal(currentTeamMemberId);
+  // 채팅 항목(app-sidebar.tsx)과 동일 소스. story #2007(perf·서버부하): 여기서 직접
+  // useChatUnreadTotal()을 호출하면 AppSidebar와 각자 SSE(EventSource) 연결을 열어 동일
+  // 유저 event-stream 연결이 중복된다 — dashboard-shell.tsx가 단일 호출한 값을 prop으로 받는다.
   // 결재함 배지 = 서명 대기 수(유나 §3.1 정합) — GateInbox가 이미 쓰는 것과 동일한
   // `/api/gates?status=pending` 재사용(신규 집계 안 만듦). gate_overridden은 override 시
   // approver row status가 "overridden"으로 전이돼(gate_service.py) pending 조회에서 자동 제외


### PR DESCRIPTION
## Summary
- `app-sidebar.tsx`(데스크톱)·`mobile-tab-bar.tsx`(모바일) 둘 다 항상 마운트된 채(모바일 탭바는 `lg:hidden`이 CSS 시각 게이팅일 뿐 마운트/effect는 안 막음) 각자 독립적으로 `useChatUnreadTotal()`을 호출해 SSE(EventSource) 연결을 따로 열고 있었음 — 배지 값은 뷰포트 무관 동일해야 하는데 2개 연결로 계산.
- 동일 유저 `event-stream` 연결이 team-presence·notifications·GNB×2 해서 동시 4개(perf 재실측 발견) → `dashboard-shell.tsx` 한 곳에서만 `useChatUnreadTotal()`을 호출해 값을 두 표면에 prop으로 내려주는 방식으로 전환 — **4→3**.
- **PO 근원 가설**: 선생님 "겁나 느림"이 앱(간헐적)+"발생 시 전체 탭 하위 전부 느려짐" 패턴 — 앱 네이티브 웹뷰가 H1/H2(HTTP/3 미지원)라면 SSE 4개가 브라우저 6-연결/origin 캡을 먹어 이후 모든 fetch가 큐잉되는 게 정확히 일치(웹은 H3라 무해했던 것과 대칭). 이 dedup이 그 캡 여유를 만드는 직접 완화책.
- **(검토, AC2) presence·notifications·unread 완전 단일 멀티플렉스 통합은 이번 PR 스코프에서 제외** — 이미 독립적으로 잘 동작 중인 3개 서브시스템을 하나로 합치는 건 회귀 리스크가 실재하는 더 큰 설계 변경이라, 이 긴급 dedup과 분리해 별도 스토리로 판단받는 게 맞다고 봄(no over-engineering under time pressure).

## Test plan
- [x] tsc/lint/vitest(257/1712)/build 클린
- [x] `grep useChatUnreadTotal(` — 실 호출부가 코드상 정확히 1곳(dashboard-shell.tsx)임을 확인, 구조적으로 SSE 연결 중복이 불가능해짐
- [x] 격리 스택 데스크톱+모바일(390px) 둘 다 렌더 정상·크래시 0 — 배지 로직 자체는 #1977에서 이미 라이브 검증된 것 그대로(호출 위치만 이동, 로직 무변경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)