### PR TITLE
fix(a2a): /rpc 에러 계약 통일 — JSON-RPC envelope 일원화 + retryable (story #2003)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -102,6 +102,15 @@ _HTTP_CODE_MAP: dict[int, str] = {
 
 @app.exception_handler(HTTPException)
 async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    # story #2003(Phase B P1-a, E-A2A-PROTO): /rpc는 JSON-RPC 2.0 엔드포인트라 auth 실패
+    # (get_verified_org_id/get_current_user Depends)와 agent-not-found(_get_agent_member)가
+    # 핸들러 try/except 밖(dependency 단계/조기 호출)에서 raise 돼 REST 엔벨로프 대신 JSON-RPC
+    # error envelope으로 렌더해야 한다. 경로 정밀 매치(`is_a2a_rpc_path`)라 이 파일의 다른 라우트
+    # (agent-card.json 등)는 전혀 영향받지 않는다 — 아래 mapped/REST 분기는 그대로 유지.
+    if a2a.is_a2a_rpc_path(request.url.path):
+        message = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+        return await a2a.build_rpc_error_response(request, exc.status_code, message)
+
     mapped = _HTTP_CODE_MAP.get(exc.status_code, f"HTTP_{exc.status_code}")
     detail = exc.detail
     # dict detail 은 구조화 에러 의도(code/message/suggestion·retry_after 등) → error 객체로 패스스루.
@@ -138,6 +147,12 @@ async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONR
     """예상치 못한 500 에러 — 내부 정보는 로그에만, 클라이언트엔 일반 메시지."""
     _logger.exception("Unhandled exception on %s %s: %s", request.method, request.url.path, exc)
     detail = str(exc) if settings.debug else "Internal server error"
+
+    # story #2003: /rpc의 미처리 예외도 JSON-RPC envelope으로(code=-32603 표준 Internal error,
+    # retryable=True — 5xx 분류). http_exception_handler와 동일 경로-정밀 매치.
+    if a2a.is_a2a_rpc_path(request.url.path):
+        return await a2a.build_rpc_error_response(request, 500, detail)
+
     return JSONResponse(
         status_code=500,
         content={"data": None, "error": {"code": "INTERNAL_ERROR", "message": detail}, "meta": None},

--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -71,11 +71,12 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import uuid
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -131,6 +132,92 @@ _METHOD_NOT_FOUND = -32601
 _INVALID_PARAMS = -32602
 _TASK_NOT_FOUND = -32001  # A2A-specific error range(-32001~-32099)
 _VERSION_NOT_SUPPORTED = -32009  # 스펙 §14.2.1: A2A-Version 헤더가 지원 범위 밖일 때
+
+# story #2003(Phase B P1-a, E-A2A-PROTO 리라이어빌리티): 위 4개는 `a2a_rpc`의 자체 try/except가
+# 잡는 `_JsonRpcException`용(핸들러 body 안에서 발생 — 정상 JSON-RPC 경로). 아래는 핸들러 밖에서
+# 발생해 main.py의 글로벌 예외 핸들러(HTTPException/Exception)로 이스케이프하는 3가지 축용:
+# auth 실패(`get_verified_org_id`/`get_current_user` Depends, endpoint body 진입 前)·agent-not
+# -found(`_get_agent_member`의 `HTTPException(404)`, try/except 밖에서 호출됨)·미처리 예외.
+# 이전엔 이 3축이 전부 REST 엔벨로프(`{"data":None,"error":{...},"meta":None}`)로 렌더돼 스펙
+# 준수 A2A 클라이언트가 파싱 불가했다(root cause) — main.py가 `is_a2a_rpc_path`로 /rpc 요청만
+# 정밀 매치해 이 테이블로 JSON-RPC envelope을 대신 렌더한다(아래 `build_rpc_error_response`).
+_UNAUTHORIZED = -32010  # 401/403 — reserved server-error range(-32000~-32099), 기존 -32001/-32009와 미충돌
+_AGENT_NOT_FOUND = -32011  # 404 — `_get_agent_member`의 404 이스케이프. `get_agent_card`(REST 라우트)는 이 매핑을 타지 않는다(경로 불일치, 아래 `is_a2a_rpc_path` 참조) — REST 엔벨로프 그대로 유지.
+_INTERNAL_ERROR = -32603  # JSON-RPC 2.0 표준 코드("Internal error", 스펙 §7) — 미처리 예외 전용, 커스텀 번호 금지
+
+# HTTP status → JSON-RPC code(SSOT 단일 테이블, 감사/확장 용이하게 조건 흩뿌리지 않음). 표에
+# 없는 status(5xx 포함)는 표준 Internal error로 수렴 — unhandled_exception_handler는 항상 500만
+# 넘기므로 자동으로 이 폴백을 탄다.
+_RPC_HTTP_STATUS_TO_JSONRPC_CODE: dict[int, int] = {
+    400: _INVALID_PARAMS,
+    401: _UNAUTHORIZED,
+    403: _UNAUTHORIZED,
+    404: _AGENT_NOT_FOUND,
+    422: _INVALID_PARAMS,
+}
+
+
+def rpc_error_code_for_status(status_code: int) -> int:
+    return _RPC_HTTP_STATUS_TO_JSONRPC_CODE.get(status_code, _INTERNAL_ERROR)
+
+
+def rpc_error_is_retryable(status_code: int) -> bool:
+    """5xx/transient(연결 레벨 포함)=True, 4xx/permanent(400/401/403/404/422 등)=False —
+    `error.data.retryable` 힌트(클라가 자동 재시도해도 되는지)."""
+    return status_code >= 500
+
+
+_RPC_PATH_PATTERN = re.compile(r"^/api/v2/a2a/members/[^/]+/rpc$")
+
+
+def is_a2a_rpc_path(path: object) -> bool:
+    """main.py 글로벌 핸들러가 /rpc 요청만 정밀 매치하기 위한 헬퍼 — 토큰경계 정규식(느슨한
+    substring 아님): `/api/v2/a2a/members/{id}/rpc`만 매치하고, 이 파일의 다른 라우트
+    (`agent-card.json`(unauth·REST 계약 유지 필수)·`/members`(발견)·`link-gate`)는 매치하지
+    않는다 — REST 엔벨로프 유지가 필요한 라우트에 실수로 번지는 걸 구조적으로 차단.
+
+    실 FastAPI `Request.url.path`는 항상 str이지만, 기존 단위테스트
+    (`test_error_envelope_dict_detail.py`)가 핸들러를 `MagicMock()` request로 직접 호출하는
+    선례가 있어(`request.url.path`가 MagicMock) — 그 경로에서 TypeError로 깨지지 않도록
+    non-str은 그냥 False(REST 엔벨로프 유지)로 방어."""
+    if not isinstance(path, str):
+        return False
+    return bool(_RPC_PATH_PATTERN.match(path))
+
+
+async def _best_effort_rpc_id(request: Request) -> str | int | None:
+    """JSON-RPC 2.0 §5: id 판정 불가 시 null이 스펙 준수 폴백. Starlette가 `Request.body()`를
+    최초 read 시 캐시하므로, dependency 단계(get_verified_org_id 등)가 이미 body를 소비한
+    뒤라도 여기서 재조회하면 여전히 실 id를 스레딩할 수 있다 — 파싱 자체가 불가능한 경우
+    (빈 body·비JSON·JSON이지만 dict 아님·id 타입이 str/int가 아님)에만 null로 폴백."""
+    try:
+        payload = await request.json()
+    except Exception:  # noqa: BLE001 — 파싱 불가는 id=null 폴백(과설계 회피, 스펙 허용 범위)
+        return None
+    if not isinstance(payload, dict):
+        return None
+    rpc_id = payload.get("id")
+    return rpc_id if isinstance(rpc_id, (str, int)) else None
+
+
+async def build_rpc_error_response(request: Request, status_code: int, message: str) -> JSONResponse:
+    """main.py의 `http_exception_handler`/`unhandled_exception_handler`가 `is_a2a_rpc_path`로
+    매치된 요청에서만 호출 — REST 엔벨로프 대신 JSON-RPC 2.0 error envelope을 렌더한다.
+
+    HTTP status는 200 고정 — `a2a_rpc` 자신의 기존 in-handler JSON-RPC 에러 반환(`_JsonRpcException`
+    을 잡아 `JsonRpcResponse(...)`를 정상 return — 예외가 아니라 return이라 FastAPI 기본 status는
+    200)과 동일 컨벤션(JSON-RPC-over-HTTP 관례: transport status=success, 에러는 body에)을 맞춘다
+    — 여기서 실 HTTP status(401/404/500 등)를 그대로 쓰면 같은 엔드포인트 안에 세 번째 불일치
+    (in-handler=200 vs global-handler=실status)가 새로 생긴다."""
+    response = JsonRpcResponse(
+        id=await _best_effort_rpc_id(request),
+        error=JsonRpcError(
+            code=rpc_error_code_for_status(status_code),
+            message=message,
+            data={"retryable": rpc_error_is_retryable(status_code)},
+        ),
+    )
+    return JSONResponse(status_code=200, content=response.model_dump(mode="json"))
 
 # E-A2A-PROTO P1(2026-07-06): 스펙 §14.2.1 — 클라이언트는 A2A-Version 헤더를 MUST 전송.
 # 우리는 1.0만 지원(Card의 protocol_version과 동일 소스). ⚠️tradeoff(정직 문서화): 헤더

--- a/backend/app/schemas/a2a.py
+++ b/backend/app/schemas/a2a.py
@@ -227,11 +227,16 @@ class JsonRpcRequest(BaseModel):
 class JsonRpcError(BaseModel):
     code: int
     message: str
-    data: list[dict] | None = None
+    # story #2003(Phase B P1-a): `data.retryable`(bool) 힌트를 싣기 위해 dict 허용 — 기존
+    # `list[dict]`는 실 생성지가 전무해(grep 확認) 하위호환 손실 없이 dict로 교체.
+    data: dict | None = None
 
 
 class JsonRpcResponse(BaseModel):
     jsonrpc: Literal["2.0"] = "2.0"
-    id: str | int
+    # story #2003: main.py 글로벌 예외 핸들러(auth 실패 등 body 파싱 前 발생)가 id를 결정 못 할
+    # 수 있다 — JSON-RPC 2.0 §5는 이 경우 id=null을 스펙 준수 폴백으로 허용. 기존 in-handler
+    # 생성지(a2a.py)는 전부 `body.id`(non-None)를 넘기므로 회귀 없음(grep 확認, 아래 참조).
+    id: str | int | None
     result: dict | None = None
     error: JsonRpcError | None = None

--- a/backend/tests/test_2003_a2a_rpc_error_contract_realdb.py
+++ b/backend/tests/test_2003_a2a_rpc_error_contract_realdb.py
@@ -1,0 +1,435 @@
+"""story #2003(Phase B P1-a, E-A2A-PROTO 리라이어빌리티): `/rpc`(JSON-RPC 2.0 엔드포인트)의
+에러 계약 통일 검증 — 실 PG(alembic-migrated, `team_members` VIEW 필요·8236bbc3
+destructive_schema 컨벤션 아님, `test_a2a_sa8_multiproject_member_scope_realdb.py`와 동일
+패턴).
+
+Root cause: `_get_agent_member`(a2a.py:196)의 404·`get_verified_org_id`/`get_current_user`
+Depends의 401/403은 `a2a_rpc` 자신의 try/except **밖**(dependency 단계·핸들러 조기 호출)에서
+발생해 main.py의 글로벌 예외 핸들러로 이스케이프 → 그 핸들러가 REST 엔벨로프
+(`{"data":None,"error":{...},"meta":None}`)를 그대로 렌더해 스펙 준수 JSON-RPC 클라이언트가
+파싱 불가했다. main.py의 두 글로벌 핸들러가 `is_a2a_rpc_path`로 `/rpc` 요청만 정밀 매치해
+JSON-RPC envelope(`{"jsonrpc":"2.0","id":...,"error":{"code":int,"message":str,
+"data":{"retryable":bool}}}`)을 대신 렌더하도록 고쳤다 — 이 파일은 그 축 전부(auth 실패·
+agent-not-found·미처리 예외) + 기존 in-handler JSON-RPC 에러(invalid params) 무회귀 +
+`get_agent_card`(REST 계약 유지 필수 라우트) 비회귀 + 경로-분기 자체의 mutation self-check를
+검증한다."""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(
+        not _REAL_DB_URL,
+        reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요 — alembic upgrade heads 적용된 DB(team_members VIEW)",
+    ),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """S-A8 선례와 동일 격리 조치 — anyio 테스트마다 새 이벤트루프가 뜨는데 `app.core.database`의
+    모듈-전역 engine은 첫 테스트의 루프에 바인딩된 채 남아 다음 테스트(다른 루프)에서 asyncpg가
+    cross-loop RuntimeError를 낸다. 각 테스트 뒤 전역 풀을 폐기."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_agent(session):
+    """단일-project agent 1명 + 소속 org/project — 이 파일의 전 테스트가 공유하는 최소 시드."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="S2003 Org", slug=f"s2003-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="S2003 Project")
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="S2003 Agent", is_active=True)
+    session.add_all([project, agent])
+    await session.commit()
+
+    grant = ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted", role="member",
+    )
+    session.add(grant)
+    await session.commit()
+    return org.id, project.id, agent.id
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    # raise_app_exceptions=False: Starlette의 ServerErrorMiddleware는 `@app.exception_handler
+    # (Exception)`이 응답을 이미 만들어 보낸 뒤에도 원본 예외를 항상 재-raise한다(ASGI 서버
+    # 로그 가시성을 위한 표준 동작) — 강제 unhandled 500 테스트가 그 재-raise를 pytest 실패로
+    # 오인하지 않도록 여기서 억제하고 실제 렌더된 JSONResponse만 검사한다.
+    return AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False), base_url="http://test",
+    )
+
+
+async def _authed_overrides(app, org_id: uuid.UUID, caller_id: uuid.UUID | None = None):
+    """S-A8 선례와 동일 — 유효 인증(caller org=agent org)으로 오버라이드."""
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(caller_id or uuid.uuid4()), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+_SEND_MESSAGE_REQ_TEMPLATE = {
+    "jsonrpc": "2.0", "id": "1", "method": "SendMessage",
+    "params": {"message": {
+        "messageId": str(uuid.uuid4()), "role": "ROLE_USER",
+        "parts": [{"text": "s2003 test"}],
+    }},
+}
+
+
+# ── AC1: auth 실패 (missing/invalid token) ─────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_rpc_auth_failure_returns_jsonrpc_envelope():
+    """Authorization 헤더 없음 → get_current_user Depends가 endpoint body 진입 前 401 raise
+    (`a2a_rpc`의 try/except 밖) → main.py 글로벌 HTTPException 핸들러가 /rpc 경로 매치해
+    JSON-RPC envelope으로 렌더해야 한다. REST 엔벨로프 필드(문자열 code)가 전혀 섞이면 안 됨."""
+    from app.main import app
+    from app.dependencies.database import get_db
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            _org_id, _project_id, agent_id = await _seed_agent(s)
+
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        app.dependency_overrides[get_db] = _db
+        # get_current_user/get_verified_org_id는 의도적으로 오버라이드하지 않음 — 실 인증
+        # 경로(Authorization 헤더 없음 → 401)를 그대로 태운다.
+
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/a2a/members/{agent_id}/rpc",
+                json=_SEND_MESSAGE_REQ_TEMPLATE,
+            )
+            assert resp.status_code == 200, resp.text  # in-handler JSON-RPC 에러와 동일 컨벤션
+            body = resp.json()
+            assert body["jsonrpc"] == "2.0"
+            assert body.get("result") is None
+            assert "id" in body  # null이어도 키 자체는 존재(JSON-RPC §5)
+            error = body["error"]
+            assert isinstance(error["code"], int), error  # REST 문자열 코드("UNAUTHORIZED") 아님
+            assert error["code"] == -32010
+            assert isinstance(error["message"], str) and error["message"]
+            assert error["data"]["retryable"] is False
+            assert "data" not in body or "error" not in (body.get("data") or {})  # REST data 필드 유입 없음
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── AC2: agent not found (valid auth, nonexistent/wrong-org member_id) ────────
+
+
+@pytest.mark.anyio
+async def test_rpc_agent_not_found_returns_jsonrpc_envelope():
+    """유효 인증이지만 존재하지 않는 member_id → `_get_agent_member`의 HTTPException(404)이
+    `a2a_rpc`의 try/except 밖에서 raise돼 이스케이프 → JSON-RPC envelope(-32011)으로 렌더."""
+    from app.main import app
+    from app.dependencies.database import get_db
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _project_id, _agent_id = await _seed_agent(s)
+
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        app.dependency_overrides[get_db] = _db
+        await _authed_overrides(app, org_id)
+
+        client = _client_for(app)
+        try:
+            nonexistent_member_id = uuid.uuid4()
+            resp = await client.post(
+                f"/api/v2/a2a/members/{nonexistent_member_id}/rpc",
+                json=_SEND_MESSAGE_REQ_TEMPLATE,
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["jsonrpc"] == "2.0"
+            assert body["id"] == "1"  # body가 파싱 가능했으므로 real id 스레딩(null 폴백 아님)
+            error = body["error"]
+            assert isinstance(error["code"], int)
+            assert error["code"] == -32011
+            assert error["data"]["retryable"] is False
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_rpc_agent_wrong_org_returns_jsonrpc_envelope_not_leak():
+    """cross-org(IDOR 축, P1-S2/S-A8 선례): caller org와 다른 org의 agent → 존재 유무 누설
+    없이 동일 -32011로 차단(회귀 아님 — 판정 자체는 불변, 렌더 형식만 바뀜)."""
+    from app.main import app
+    from app.dependencies.database import get_db
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            _org_id, _project_id, agent_id = await _seed_agent(s)
+        other_org_id = uuid.uuid4()
+
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        app.dependency_overrides[get_db] = _db
+        await _authed_overrides(app, other_org_id)  # agent의 org와 다른 org로 인증
+
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/a2a/members/{agent_id}/rpc",
+                json=_SEND_MESSAGE_REQ_TEMPLATE,
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["error"]["code"] == -32011
+            assert body["error"]["data"]["retryable"] is False
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── AC3: 강제 unhandled 500 ─────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_rpc_unhandled_exception_returns_standard_internal_error():
+    """메소드 핸들러가 plain 미처리 예외를 던지면(방어 코드가 못 잡는 진짜 버그 시뮬레이션)
+    main.py `unhandled_exception_handler`가 /rpc 경로 매치해 JSON-RPC **표준** Internal error
+    (-32603, 스펙 §7 — 커스텀 번호 아님) + retryable=True로 렌더해야 한다."""
+    from app.main import app
+    from app.dependencies.database import get_db
+    from app.routers import a2a as a2a_mod
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _project_id, agent_id = await _seed_agent(s)
+
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        app.dependency_overrides[get_db] = _db
+        await _authed_overrides(app, org_id)
+
+        async def _boom(*_args, **_kwargs):
+            raise RuntimeError("s2003 forced unhandled failure")
+
+        client = _client_for(app)
+        try:
+            with patch.dict(a2a_mod._METHODS, {"SendMessage": _boom}):
+                resp = await client.post(
+                    f"/api/v2/a2a/members/{agent_id}/rpc",
+                    json=_SEND_MESSAGE_REQ_TEMPLATE,
+                )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["jsonrpc"] == "2.0"
+            error = body["error"]
+            assert isinstance(error["code"], int)
+            assert error["code"] == -32603  # JSON-RPC 2.0 표준 코드(스펙 §7) — 커스텀 번호 아님
+            assert error["data"]["retryable"] is True  # 5xx 분류
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── AC4: invalid params(기존 _JsonRpcException 경로) 재검증 — 무회귀 ────────────
+
+
+@pytest.mark.anyio
+async def test_rpc_invalid_params_still_in_handler_jsonrpc_error_unaffected():
+    """`_JsonRpcException`(핸들러 body 안, `a2a_rpc`의 자체 try/except가 잡는 경로)은 이번
+    변경이 손대지 않은 축 — 여전히 200 + error.code=-32602(INVALID_PARAMS)로 정상 동작해야
+    한다(글로벌 핸들러 경로-분기와 완전히 독립적인 기존 계약)."""
+    from app.main import app
+    from app.dependencies.database import get_db
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _project_id, agent_id = await _seed_agent(s)
+
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        app.dependency_overrides[get_db] = _db
+        await _authed_overrides(app, org_id)
+
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/a2a/members/{agent_id}/rpc",
+                json={"jsonrpc": "2.0", "id": "1", "method": "SendMessage", "params": {}},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["error"]["code"] == -32602
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── AC5: get_agent_card REST 계약 비회귀 ────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_get_agent_card_rest_contract_unchanged_for_nonexistent_member():
+    """`GET /members/{id}/agent-card.json`(SEC-S2로 authed+same-org, `_get_agent_member`를
+    `/rpc`와 공유 호출) — 존재하지 않는 member_id는 여전히 **REST 엔벨로프**
+    (`{"data":None,"error":{"code":"NOT_FOUND",...},"meta":None}`)여야 한다. `is_a2a_rpc_path`가
+    이 라우트(`.../agent-card.json`)를 매치하지 않으므로 회귀 없음이 정밀 경로 매치의
+    핵심 증거."""
+    from app.main import app
+    from app.dependencies.database import get_db
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _project_id, _agent_id = await _seed_agent(s)
+
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        app.dependency_overrides[get_db] = _db
+        await _authed_overrides(app, org_id)
+
+        client = _client_for(app)
+        try:
+            nonexistent_member_id = uuid.uuid4()
+            resp = await client.get(f"/api/v2/a2a/members/{nonexistent_member_id}/agent-card.json")
+            assert resp.status_code == 404, resp.text
+            body = resp.json()
+            assert body == {
+                "data": None,
+                "error": {"code": "NOT_FOUND", "message": "Agent not found"},
+                "meta": None,
+            }
+            assert "jsonrpc" not in body  # JSON-RPC envelope 유입 없음(경로 정밀 매치 증거)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── AC6: mutation self-check — 경로-분기가 실제로 load-bearing인지 ─────────────
+
+
+@pytest.mark.anyio
+async def test_mutation_self_check_path_branch_is_load_bearing():
+    """경로-분기(`is_a2a_rpc_path`)를 무력화하면(monkeypatch로 항상 False — 실제 소스를
+    편집해 되돌리는 대신, 그 분기가 참조하는 판정 함수 자체를 끈다: main.py 핸들러가
+    호출하는 지점은 동일하게 유지하면서 판정 결과만 뒤집는다) RED(REST 엔벨로프로 회귀)가
+    재현되고, 되돌리면(monkeypatch 해제) GREEN(JSON-RPC envelope)으로 복귀해야 한다 —
+    이 테스트 없이는 `is_a2a_rpc_path`가 실제로 아무것도 안 해도(예: 상수 True/False로
+    박제) 다른 테스트가 우연히 통과할 여지가 있었다는 증거를 남긴다."""
+    from app.main import app
+    from app.dependencies.database import get_db
+    from app.routers import a2a as a2a_mod
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            _org_id, _project_id, agent_id = await _seed_agent(s)
+
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        app.dependency_overrides[get_db] = _db
+        # 인증 미오버라이드 — 실 401 경로.
+
+        client = _client_for(app)
+        try:
+            # RED: 경로-분기를 무력화하면 옛 REST 엔벨로프로 회귀해야 한다.
+            with patch.object(a2a_mod, "is_a2a_rpc_path", return_value=False):
+                red_resp = await client.post(
+                    f"/api/v2/a2a/members/{agent_id}/rpc", json=_SEND_MESSAGE_REQ_TEMPLATE,
+                )
+            assert red_resp.status_code == 401, red_resp.text
+            red_body = red_resp.json()
+            assert red_body["error"]["code"] == "UNAUTHORIZED"  # REST 문자열 코드(JSON-RPC 아님)
+            assert "jsonrpc" not in red_body
+
+            # GREEN: monkeypatch 해제 → 정상 JSON-RPC envelope 복귀.
+            green_resp = await client.post(
+                f"/api/v2/a2a/members/{agent_id}/rpc", json=_SEND_MESSAGE_REQ_TEMPLATE,
+            )
+            assert green_resp.status_code == 200, green_resp.text
+            green_body = green_resp.json()
+            assert green_body["jsonrpc"] == "2.0"
+            assert green_body["error"]["code"] == -32010
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -839,7 +839,13 @@ async def test_unknown_method_returns_method_not_found():
 
 @pytest.mark.anyio
 async def test_rpc_requires_auth():
-    """P1-S2(story 7b93eb10): /rpc는 action-triggering이라 authed(PO 크럭스)."""
+    """P1-S2(story 7b93eb10): /rpc는 action-triggering이라 authed(PO 크럭스).
+
+    story #2003(Phase B P1-a): 인증 실패는 이제 REST status(401/403)가 아니라 JSON-RPC 2.0
+    envelope(HTTP 200 고정 + error.code=-32010 UNAUTHORIZED)으로 렌더 — get_current_user
+    Depends가 endpoint body 진입 前 raise한 HTTPException이 main.py 글로벌 핸들러의 /rpc
+    경로-분기로 이스케이프해 JSON-RPC 계약을 유지한다(회귀 아님 — 보안 판정 자체는 불변,
+    렌더 형식만 계약 통일)."""
     from app.main import app
     from app.dependencies.database import get_db
 
@@ -852,15 +858,23 @@ async def test_rpc_requires_auth():
     try:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
             resp = await c.post(f"/api/v2/a2a/members/{MEMBER_ID}/rpc", json=_SEND_REQ)
-        assert resp.status_code in (401, 403)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["jsonrpc"] == "2.0"
+        assert body.get("result") is None
+        assert body["error"]["code"] == -32010
+        assert body["error"]["data"]["retryable"] is False
+        assert isinstance(body["error"]["code"], int)  # REST 엔벨로프 문자열 코드("UNAUTHORIZED")가 아님
     finally:
         app.dependency_overrides.clear()
 
 
 @pytest.mark.anyio
 async def test_rpc_cross_org_blocked():
-    """P1-S2(A): caller org와 다른 org의 agent에게는 404(존재 여부 누설 없이 차단) —
-    `_get_agent_member`에 org_id 검증 추가로 오늘 S20 클래스 IDOR 봉인."""
+    """P1-S2(A): caller org와 다른 org의 agent에게는 존재 여부 누설 없이 차단(`_get_agent_member`
+    에 org_id 검증 추가로 오늘 S20 클래스 IDOR 봉인) — story #2003: 이제 REST 404가 아니라
+    JSON-RPC envelope(HTTP 200 + error.code=-32011 AGENT_NOT_FOUND)으로 렌더된다. IDOR 차단
+    자체(0-row 조회)는 완전히 불변, 렌더 형식만 바뀜."""
     client, session, app = await _authed_client(uuid.uuid4())
     try:
         session.execute = AsyncMock(return_value=_result(None))  # org_id 불일치 → 조회 0행
@@ -868,7 +882,11 @@ async def test_rpc_cross_org_blocked():
         async with client as c:
             resp = await c.post(f"/api/v2/a2a/members/{MEMBER_ID}/rpc", json=_SEND_REQ)
 
-        assert resp.status_code == 404
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["jsonrpc"] == "2.0"
+        assert body["error"]["code"] == -32011
+        assert body["error"]["data"]["retryable"] is False
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary

story #2003(Phase B P1-a, E-A2A-PROTO 리라이어빌리티) — `/rpc`(JSON-RPC 2.0 엔드포인트, `backend/app/routers/a2a.py` `POST /members/{member_id}/rpc`)의 에러가 이중 포맷이었던 버그를 고칩니다.

### Root cause

`/rpc`의 핸들러 body 안에서 발생하는 `_JsonRpcException`(invalid params·task-not-found·method-not-found·version-not-supported)은 `a2a_rpc`의 자체 try/except가 잡아 `JsonRpcResponse`로 정상 렌더됩니다. 하지만:

- **auth 실패** — `org_id: uuid.UUID = Depends(get_verified_org_id)` / `auth: AuthContext = Depends(get_current_user)`가 핸들러 body 진입 **前**(dependency 단계)에 `HTTPException(401/403)`을 raise
- **agent-not-found** — `_get_agent_member(session, member_id, org_id, auth)` 호출(a2a.py:860 부근, `a2a_rpc`의 try/except **밖**)이 `HTTPException(404)`를 raise
- **미처리 예외** — 메소드 핸들러의 진짜 버그

이 세 축 전부가 `a2a_rpc`의 try/except를 우회해 `main.py`의 글로벌 예외 핸들러(`http_exception_handler`/`unhandled_exception_handler`)로 이스케이프하고, 그 핸들러는 앱 표준 REST 엔벨로프(`{"data":None,"error":{...},"meta":None}`)를 그대로 렌더했습니다 — 표준 A2A/JSON-RPC 클라이언트(`a2a-sdk` 등)는 이 shape을 파싱하지 못하고 opaque parse error로 봅니다.

### Fix — 경로-정밀 분기(단일 메커니즘)

`main.py`의 두 글로벌 핸들러 상단에 경로-정밀 분기를 추가했습니다:

```python
if a2a.is_a2a_rpc_path(request.url.path):
    return await a2a.build_rpc_error_response(request, exc.status_code, message)
```

`is_a2a_rpc_path`는 토큰경계 정규식(`^/api/v2/a2a/members/[^/]+/rpc$`)만 매치 — 이 파일의 다른 라우트(`GET .../agent-card.json`, `GET /members`, `POST /tasks/{id}/link-gate`)는 전혀 건드리지 않습니다. `_get_agent_member`가 REST 라우트(`get_agent_card`)와 `/rpc` 양쪽에서 호출되는 동일 함수라도, **어느 라우트에서 이스케이프했는지**에 따라 렌더링만 갈라집니다 — `a2a_rpc` 안에 개별 try/except를 추가하지 않고 이 한 메커니즘으로 두 이스케이프 지점(auth Depends + `_get_agent_member` 호출)을 동시에 커버합니다.

HTTP status는 **200 고정**입니다 — `a2a_rpc` 자신의 기존 in-handler JSON-RPC 에러 반환(`_JsonRpcException`을 잡아 `JsonRpcResponse(...)`를 정상 return — FastAPI 기본 status가 200)과 동일 컨벤션(JSON-RPC-over-HTTP 관례: transport status=success, 에러는 body에)을 맞췄습니다. 여기서 실 HTTP status를 쓰면 같은 엔드포인트 안에 세 번째 불일치가 새로 생깁니다.

### 코드 매핑 + retryable (SSOT 테이블, `a2a.py`)

```python
_UNAUTHORIZED = -32010      # 401/403 — reserved server-error range(-32000~-32099)
_AGENT_NOT_FOUND = -32011   # 404 — _get_agent_member 이스케이프
_INTERNAL_ERROR = -32603    # JSON-RPC 2.0 표준 코드("Internal error", 스펙 §7) — 커스텀 번호 아님

_RPC_HTTP_STATUS_TO_JSONRPC_CODE = {
    400: _INVALID_PARAMS, 401: _UNAUTHORIZED, 403: _UNAUTHORIZED,
    404: _AGENT_NOT_FOUND, 422: _INVALID_PARAMS,
}
def rpc_error_code_for_status(status_code): ...  # 표에 없으면 -32603 폴백
def rpc_error_is_retryable(status_code): return status_code >= 500  # 5xx=true, 4xx=false
```

- `-32010`/`-32011`은 A2A 예약 서버-에러 범위(-32000~-32099)에서 기존 `_TASK_NOT_FOUND(-32001)`/`_VERSION_NOT_SUPPORTED(-32009)`와 충돌 없는 값 선택
- `-32603`은 JSON-RPC 2.0 **표준** 코드 — 스펙에서 이미 정의된 값이라 커스텀 번호를 쓰지 않음(요청사항 그대로)

### `id` best-effort

`JsonRpcResponse.id`를 `str | int` → `str | int | None`로 완화(스키마, `id` 결정 불가 시 JSON-RPC 2.0 §5가 허용하는 null 폴백). Starlette가 `Request.body()`를 캐시하므로, dependency 단계가 이미 body를 소비한 뒤라도 글로벌 핸들러에서 `await request.json()`으로 재조회해 실 `id`를 스레딩합니다(파싱 자체가 불가능한 경우에만 null). 기존 in-handler 생성지는 전부 `body.id`(non-None)라 회귀 없음(grep 확인).

### `get_agent_card` REST 계약 — 명시 확인

`is_a2a_rpc_path`가 `GET .../agent-card.json`을 매치하지 않으므로 그 라우트의 404는 여전히 REST 엔벨로프(`{"data":None,"error":{"code":"NOT_FOUND",...},"meta":None}`) 그대로입니다. `test_2003_a2a_rpc_error_contract_realdb.py::test_get_agent_card_rest_contract_unchanged_for_nonexistent_member`로 실PG against 명시 검증(response body 전체를 dict-equal로 assert).

## Files changed

- `backend/app/main.py` — 두 글로벌 핸들러에 경로-정밀 분기 추가
- `backend/app/routers/a2a.py` — 코드 매핑 테이블 + `is_a2a_rpc_path`/`build_rpc_error_response`/`_best_effort_rpc_id` 헬퍼
- `backend/app/schemas/a2a.py` — `JsonRpcResponse.id` nullable, `JsonRpcError.data` dict로 완화
- `backend/tests/test_2003_a2a_rpc_error_contract_realdb.py`(신규, realPG) — 7 tests
- `backend/tests/test_a2a.py` — `test_rpc_requires_auth`/`test_rpc_cross_org_blocked`을 새 계약에 맞게 갱신(차단 판정 자체는 불변)

## Test plan

- [x] `backend/tests/test_2003_a2a_rpc_error_contract_realdb.py`(신규, realPG/alembic-migrated) — 7/7 pass: auth 실패·agent-not-found·cross-org·강제 unhandled 500·invalid params 무회귀·get_agent_card REST 비회귀·mutation self-check(RED→GREEN)
- [x] `backend/tests/test_a2a.py` — 42/42 pass(2개 재작성: 새 계약 200+JSON-RPC error.code로)
- [x] `test_a2a_sa8_multiproject_member_scope_realdb.py`(realPG) — 4/4 pass
- [x] `test_a2a_p1_s1_recruit_card_contract_realdb.py` + `test_a2a_sa3_link_gate_to_task_realdb.py` + `test_a2a_sa4_streaming_realdb.py` + `test_a2a_sa5_auth_required_realdb.py` + `test_a2a_sa1_deadline_sweeper_realdb.py`(realPG, destructive_schema — 별도 DB) — 23/23 pass
- [x] 전체 mock 스위트(`pytest tests/ -k "not realdb"`) — 3668 passed(기존 3661 + 이 PR로 새로 GREEN화된 `test_error_envelope_dict_detail.py` 7개), 7 failed(전부 로컬 `.mcp.json` 경로 드리프트 — `git stash`로 unmodified develop에서도 동일 재현 확인, 이 PR과 무관)
- [x] 광역 sanity sweep(무관 라우트 에러 경로): `test_projects.py::test_get_project_404`/`test_get_project_unauthorized_404`, `test_stories.py::test_get_story_404` — 3/3 pass(경로-분기가 `/rpc` 밖으로 안 샘 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)