### PR TITLE
fix(a2a): SendMessage 멱등키 — message_id dedup 봉인 (story #2004)

### DIFF
--- a/backend/alembic/versions/0201_a2a_tasks_client_message_id.py
+++ b/backend/alembic/versions/0201_a2a_tasks_client_message_id.py
@@ -1,0 +1,43 @@
+"""story #2004(E-A2A-PROTO Phase B P1-b) — A2A SendMessage 멱등키: `a2a_tasks.client_message_id`.
+
+클라이언트가 `Message.message_id`(A2A 스펙 REQUIRED 필드, 임의 문자열)로 재시도(네트워크
+타임아웃·수동 재발송)했을 때 동일 `(member_id, client_message_id)` 쌍을 재사용해 중복
+Task/중복 CC 위임을 막기 위한 dedup 키. 방어선 1은 `_handle_send_message`의
+`pg_advisory_xact_lock`(체크-then-액트 TOCTOU를 구조적으로 막음, [[feedback_check_then_insert_toctou]]
+교훈) — 이 UNIQUE 인덱스는 방어선 2(락 우회 경로가 생기더라도 DB 레벨에서 최종 봉인).
+
+partial UNIQUE 인덱스(`WHERE client_message_id IS NOT NULL`)를 명시적으로 선택 — plain
+UNIQUE 제약도 Postgres가 다중 NULL을 서로 distinct로 취급해 기존/레거시 행(컬럼 없던 시절
+생성된 row, NULL)들끼리 충돌하지 않지만, 그 동작이 "우연히 안전"이 아니라 "의도"임을 DDL
+자체가 읽는 사람에게 명시하도록 partial 형태를 택했다(story 지시 — 두 방식 다 허용, 명시성
+우선).
+
+Revision ID: 0201
+Revises: 0200
+Create Date: 2026-07-18
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0201"
+down_revision = "0200"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("a2a_tasks", sa.Column("client_message_id", sa.Text(), nullable=True))
+    op.create_index(
+        "uq_a2a_tasks_member_client_message_id",
+        "a2a_tasks",
+        ["member_id", "client_message_id"],
+        unique=True,
+        postgresql_where=sa.text("client_message_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_a2a_tasks_member_client_message_id", table_name="a2a_tasks")
+    op.drop_column("a2a_tasks", "client_message_id")

--- a/backend/app/models/a2a_task.py
+++ b/backend/app/models/a2a_task.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, Text, func
+from sqlalchemy import DateTime, Index, Text, func, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -10,7 +10,12 @@ from app.core.database import Base
 
 class A2ATask(Base):
     """E-A2A-POC S1(story 480e81fb): A2A Task 생명주기 저장소. PoC 스코프 — org_id/인증 없음
-    (member_id로만 스코프, Phase 3서 org-scope+인증 추가 예정)."""
+    (member_id로만 스코프, Phase 3서 org-scope+인증 추가 예정).
+
+    story #2004(E-A2A-PROTO Phase B P1-b, 마이그 0201): `client_message_id`(=클라이언트
+    `Message.message_id`)는 SendMessage 멱등 dedup 키 — 방어선 1은
+    `_handle_send_message`의 `pg_advisory_xact_lock`(TOCTOU 구조적 봉인), 이 partial
+    UNIQUE 인덱스는 방어선 2(DB 레벨 최종 백스톱, 락 우회 시에도 중복 row는 못 들어옴)."""
 
     __tablename__ = "a2a_tasks"
 
@@ -35,3 +40,13 @@ class A2ATask(Base):
     # 무관하게 판정할 수 있도록 생성 시점에 명시 기록. NULL=마이그 이전 레거시 행(폴백은
     # 소비 코드가 created_at + A2A_TASK_TIMEOUT_MINUTES로 처리).
     deadline_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    client_message_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    __table_args__ = (
+        Index(
+            "uq_a2a_tasks_member_client_message_id",
+            "member_id", "client_message_id",
+            unique=True,
+            postgresql_where=text("client_message_id IS NOT NULL"),
+        ),
+    )

--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -66,6 +66,25 @@ persona 존재 시 무조건 persona.slug/config.tool_allowlist 파생 단일 sk
 당시 스냅샷이 아니라 카탈로그 갱신을 재-recruit 없이 그대로 따라간다. role_template.skills가
 비어있으면(아직 구조화 미완료) 기존 persona 파생 단일 skill로 그레이스풀 폴백 — 무회귀(오늘
 수작업으로 만든 8명의 persona는 role_template_id가 없어 이 폴백 그대로, 크래시 없음).
+
+**SendMessage 멱등키(2026-07-18, story #2004, E-A2A-PROTO Phase B P1-b)**: 클라가 네트워크
+타임아웃/수동 재시도로 동일 `message_id`를 재발송하면 기존엔 매번 새 Conversation+Task+실
+위임(webhook/Event+wake_agent)이 벌어졌다(중복 실행). `_handle_send_message`가 이제
+`(member_id, client_message_id)`를 dedup 키로 쓴다 — `pg_advisory_xact_lock`(첫 DB
+연산으로 획득)이 "존재 확인→A2ATask insert→(그 A2ATask insert를 포함하는) 첫 commit"까지의
+전 구간을 직렬화해 TOCTOU를 구조적으로 막는다(naive insert-then-catch-conflict는 이미 실
+webhook/Event 부작용이 나간 뒤에야 충돌을 잡아 AC3 위반 — 채택 안 함).
+
+⚠️설계 노트(기존 흐름과의 유일한 순서 변경): 이 함수는 `A2ATask` insert를 원래 맨 끝(webhook/
+Event 디스패치 이후)에서 **Conversation/Message insert 직후·기존 첫 commit 이전**으로
+당겼다. 이유: `deliver_conversation_message_webhook`이 별도 세션(`async_session_factory`)으로
+Conversation/Participant를 재조회하므로 그 첫 commit은 원래도 필수였다(제거 불가) — advisory
+xact lock은 commit 시 자동 해제되므로, A2ATask insert가 원래 위치(그 이후, 두 번째·세 번째
+commit 뒤)에 남아 있으면 락이 실제 dedup-마커 커밋 전에 먼저 풀려 동시 두 콜이 모두 "미존재"를
+보고 통과할 수 있었다(레이스 미봉인). A2ATask를 첫 commit **안**으로 포함시키면 락이 커버하는
+구간 = "그 dedup 마커가 durable해지는 시점"과 정확히 일치해 구조적으로 막힌다. webhook/Event
+디스패치 로직 자체(내용·순서·별도 세션)는 완전히 무변경 — fakechat 경로의
+`task_metadata["connected_at_send"]`만 이제 이미 insert된 행에 대한 후속 UPDATE로 반영한다.
 """
 from __future__ import annotations
 
@@ -79,6 +98,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import async_session_factory
@@ -498,6 +518,36 @@ def _first_text(message: Message) -> str:
     return ""
 
 
+async def _acquire_send_message_dedup_lock(
+    session: AsyncSession, member_id: uuid.UUID, client_message_id: str,
+) -> A2ATask | None:
+    """story #2004(E-A2A-PROTO Phase B P1-b): `_handle_send_message`의 첫 DB 연산 —
+    `(member_id, client_message_id)` 네임스페이스 advisory xact lock(story.py::
+    allocate_story_number/recruit_service.py::acquire_agent_mutation_lock과 동일 관례,
+    [[feedback_check_then_insert_toctou]] 교훈 재적용) 획득 직후 같은 키의 기존 task를
+    재확인한다. 반환값이 not-None이면 그게 곧 멱등 재생 대상(caller는 그걸 그대로 반환하고
+    Conversation/Message/webhook/Event/wake_agent/새 A2ATask 무엇도 만들면 안 된다) — None이면
+    신규 처리를 계속한다.
+
+    락은 트랜잭션 종료(commit/rollback) 시 자동 해제 — caller가 이 함수 반환 후 A2ATask
+    insert를 기존 첫 commit 안에 포함시켜야(모듈 docstring "설계 노트") 이 락이 "dedup
+    마커가 durable해지는 시점"까지 끊김 없이 커버한다.
+
+    순수 리팩터로 분리(동작 무변경) — mutation self-check 테스트가 이 함수만 monkeypatch해
+    (예: 항상 None 반환) dedup을 우회시켜 RED(중복 task+중복 dispatch)를 실증하고, 원복해
+    GREEN을 확인할 수 있도록."""
+    await session.execute(
+        select(func.pg_advisory_xact_lock(
+            func.hashtext(f"a2a_send_message:{member_id}:{client_message_id}")
+        ))
+    )
+    return (await session.execute(
+        select(A2ATask).where(
+            A2ATask.member_id == member_id, A2ATask.client_message_id == client_message_id,
+        )
+    )).scalar_one_or_none()
+
+
 async def _handle_send_message(
     session: AsyncSession, member: TeamMember, params: dict,
     active_extensions: frozenset[str] = frozenset(),
@@ -510,20 +560,32 @@ async def _handle_send_message(
     incoming = send_params.message
     text = _first_text(incoming)
 
+    # story #2004: client_message_id = 클라 Message.message_id — 어떤 DB write보다도 먼저
+    # 추출(멱등 락/조회 키). commit() 이후 이 세션에 로드된 모든 ORM 객체(member 포함)의
+    # 속성이 expire_on_commit 기본값으로 만료돼 greenlet 컨텍스트 밖 lazy-load
+    # (MissingGreenlet)를 유발한다 — commit 전에 필요한 member 필드를 로컬 변수로 고정해두고
+    # 이후엔 이것만 쓴다.
+    client_message_id = incoming.message_id
+    member_id = member.id
+    member_org_id = member.org_id
+    member_project_id = member.project_id
+    member_name = member.name
+
+    # story #2004: 첫 DB 연산 — advisory xact lock 획득 + 같은 키 기존 task 재확인(분리된
+    # 이유·의미론은 `_acquire_send_message_dedup_lock` 참조).
+    existing_task = await _acquire_send_message_dedup_lock(session, member_id, client_message_id)
+    if existing_task is not None:
+        # 멱등 재생 경로 — 락 보유 중 재확인해 이미 커밋된 task를 찾았으니 Conversation/Message/
+        # webhook/Event/wake_agent/새 A2ATask 그 무엇도 만들지 않고 그대로 반환한다(AC3:
+        # 중복 실행 지시 0).
+        return {"task": _task_to_dict(existing_task)}
+
     # E-A2A-EXT project-context(profile, opt-in): 클라가 A2A-Extensions 헤더로 이 URI를
     # 선언했고 Message.metadata에 그 키가 있으면 구조화 컨텍스트를 보존한다. 미선언 시
     # 이 블록 전체가 스킵돼 기존 동작과 완전히 동일(무회귀).
     project_context = None
     if PROJECT_CONTEXT_EXTENSION_URI in active_extensions and incoming.metadata:
         project_context = incoming.metadata.get(PROJECT_CONTEXT_EXTENSION_URI)
-
-    # commit() 이후 이 세션에 로드된 모든 ORM 객체(member 포함)의 속성이 expire_on_commit
-    # 기본값으로 만료돼 greenlet 컨텍스트 밖 lazy-load(MissingGreenlet)를 유발한다 —
-    # commit 전에 필요한 member 필드를 로컬 변수로 고정해두고 이후엔 이것만 쓴다.
-    member_id = member.id
-    member_org_id = member.org_id
-    member_project_id = member.project_id
-    member_name = member.name
 
     # S2(정정 2026-07-06)+P1-S3 §10(SSOT 교체): 플랫폼 기존 라우팅과 동형으로 택일 —
     # member-bound WebhookConfig 有→Discord webhook, 無→fakechat WS(_broadcast). "존재 여부"
@@ -576,13 +638,51 @@ async def _handle_send_message(
         created_at=now,
     ))
     await session.flush()
-    await session.commit()
 
     task_metadata: dict = {"delivery_channel": "webhook" if has_webhook else "fakechat_ws"}
     if active_extensions:
         task_metadata["activated_extensions"] = sorted(active_extensions)
     if project_context is not None:
         task_metadata["project_context"] = project_context
+
+    # story #2004: A2ATask(=dedup 마커) insert를 여기(원래 함수 맨 끝, webhook/Event 디스패치
+    # 이후)에서 이 지점(Conversation/Message insert 직후, 기존 첫 commit 이전)으로 당겼다 —
+    # 모듈 docstring "설계 노트" 참조. advisory xact lock이 이 commit까지 끊김 없이 커버해야
+    # dedup이 구조적으로 봉인되기 때문. task_metadata는 아직 webhook/Event 디스패치 전이라
+    # `connected_at_send`(fakechat 경로 전용)는 비어 있다 — 아래에서 후속 UPDATE로 채운다.
+    task_id = uuid.uuid4()
+    task = A2ATask(
+        id=task_id,
+        context_id=conv_id,
+        root_message_id=root_message_id,
+        member_id=member_id,
+        client_message_id=client_message_id,
+        state="TASK_STATE_WORKING",
+        task_metadata=task_metadata,
+        history=[incoming.model_dump(by_alias=True, mode="json")],
+        artifacts=[],
+        # S-A1(story 2a57dc0f): 생성 시점에 명시 기록 — cron 스위퍼가 폴링과 무관하게 판정.
+        deadline_at=now + timedelta(minutes=A2A_TASK_TIMEOUT_MINUTES),
+    )
+    session.add(task)
+    try:
+        await session.flush()
+    except IntegrityError:
+        # 방어선 2(백스톱, story #2004): 정상 동작에선 advisory lock이 이 경합을 구조적으로
+        # 막아 여기 도달하지 않아야 한다 — 그래도 락이 우회되는 경로가 생기면 UNIQUE 인덱스
+        # (마이그 0201, `uq_a2a_tasks_member_client_message_id`)가 최종 봉인. 이 미커밋
+        # 트랜잭션의 Conversation/Participant/Message도 함께 rollback하고, 승자가 이미 커밋한
+        # task를 재조회해 그대로 반환한다(크래시 대신 멱등 응답).
+        await session.rollback()
+        winner = (await session.execute(
+            select(A2ATask).where(
+                A2ATask.member_id == member_id, A2ATask.client_message_id == client_message_id,
+            )
+        )).scalar_one_or_none()
+        if winner is not None:
+            return {"task": _task_to_dict(winner)}
+        raise
+    await session.commit()
 
     if has_webhook:
         # ⚠️스코프 경계(E-A2A-EXT 첫 착수, 의도적): deliver_conversation_message_webhook은
@@ -637,24 +737,18 @@ async def _handle_send_message(
         await session.commit()
         # "미연결" 신호(P1-S2 C 유지) — 죽은 ws_chat._rooms 대신 agent_gateway의 실제 SSE 연결
         # 큐(_agent_connections)로 판정해야 "지금 CC가 진짜 붙어있나"를 뜻한다.
-        task_metadata["connected_at_send"] = str(member_id) in _agent_connections
+        #
+        # story #2004: task는 위에서 이미 insert+commit된 행이라(dedup 마커, 첫 commit 안에
+        # 포함) 여기선 새 A2ATask를 만들지 않고 그 task_metadata를 채워 후속 UPDATE로 반영한다
+        # — 전체 재대입(`task.task_metadata = {...}`)이라 SQLAlchemy dirty-tracking이 그대로
+        # 잡는다(부분 in-place mutation 아님, MutableDict 불요).
+        task.task_metadata = {
+            **(task.task_metadata or {}),
+            "connected_at_send": str(member_id) in _agent_connections,
+        }
         wake_agent(str(member_id), recipient_seq)
-
-    task_id = uuid.uuid4()
-    session.add(A2ATask(
-        id=task_id,
-        context_id=conv_id,
-        root_message_id=root_message_id,
-        member_id=member_id,
-        state="TASK_STATE_WORKING",
-        task_metadata=task_metadata,
-        history=[incoming.model_dump(by_alias=True, mode="json")],
-        artifacts=[],
-        # S-A1(story 2a57dc0f): 생성 시점에 명시 기록 — cron 스위퍼가 폴링과 무관하게 판정.
-        deadline_at=now + timedelta(minutes=A2A_TASK_TIMEOUT_MINUTES),
-    ))
-    await session.flush()
-    await session.commit()
+        await session.flush()
+        await session.commit()
 
     task = (await session.execute(
         select(A2ATask).where(A2ATask.id == task_id)

--- a/backend/tests/test_2004_a2a_sendmessage_idempotency_realdb.py
+++ b/backend/tests/test_2004_a2a_sendmessage_idempotency_realdb.py
@@ -1,0 +1,334 @@
+"""story #2004(E-A2A-PROTO Phase B P1-b): A2A SendMessage 멱등키 — 실 Postgres 검증.
+
+`_handle_send_message`는 클라 `Message.message_id`(=`client_message_id`)를 dedup 키로 써서
+동일 `(member_id, client_message_id)` 재시도가 **중복 Conversation/Task는 물론 중복 실
+위임(webhook 또는 Event+wake_agent)도** 만들지 않도록 봉인한다. 핵심 메커니즘은
+`_acquire_send_message_dedup_lock`의 `pg_advisory_xact_lock`(첫 DB 연산) — naive
+insert-then-catch-conflict(맨 끝에서 UNIQUE 충돌만 잡는 안)는 그 전에 이미 나간
+webhook/Event 부작용을 못 막아 AC3("중복 실행 지시 0")를 위반하므로 채택하지 않았다(모듈
+docstring "설계 노트" 참조).
+
+story 8236bbc3 컨벤션: `Base.metadata.create_all`로 자체 스키마 구축(공유 alembic-migrated
+DB 오염 방지) — `team_members`는 이 스키마에서 일반 테이블(VIEW 아님, S-A8 멀티프로젝트
+fan-out은 이 테스트 스코프 밖)이라 `create_all`로 충분(`test_a2a_sa4_streaming_realdb.py`와
+동일 패턴). 이 테스트들은 fakechat(무-webhook) 경로로 고정 — `wake_agent`를 spy해 실 위임
+호출 횟수를 직접 센다(webhook 경로는 별도 세션을 여는 `deliver_conversation_message_webhook`
+자체가 검증 대상이 아니라 dispatch 여부만 중요하므로, 더 가벼운 fakechat 경로로 통일)."""
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """다른 a2a realdb 테스트들과 동일 관례 — `app.core.database`의 모듈-전역 engine을 각
+    테스트 뒤 폐기해 다음 테스트(다른 anyio 이벤트루프)의 asyncpg cross-loop RuntimeError를
+    막는다."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _engine_and_sessionmaker():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _bypass_fk(session) -> None:
+    """`ALEMBIC_DATABASE_URL`이 실 alembic-migrated DB를 가리키면 `team_members.project_id`
+    FK(→projects)가 실제로 걸려 있다 — 이 테스트들의 관심사는 project 그래프가 아니라
+    `_handle_send_message` dedup 이므로, 다른 a2a realdb 테스트(S-A1)와 동일 관례로 세션
+    스코프 FK 검증을 끈다."""
+    from sqlalchemy import text as _text
+    await session.execute(_text("SET session_replication_role = replica"))
+
+
+async def _seed_agent_member(session) -> uuid.UUID:
+    """team_members 행 하나면 `_handle_send_message`가 필요로 하는 전부다(org_id/project_id는
+    이 테스트 관심사 밖 — `_bypass_fk`로 FK 검증을 끈 뒤 임의 UUID를 그대로 쓴다)."""
+    from app.models.team import TeamMember
+
+    await _bypass_fk(session)
+    member = TeamMember(
+        id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(), type="agent",
+        name="Idempotency Test Agent", role="member", is_active=True,
+    )
+    session.add(member)
+    await session.commit()
+    return member.id
+
+
+def _send_params(message_id: str, text: str) -> dict:
+    return {
+        "message": {
+            "messageId": message_id,
+            "role": "ROLE_USER",
+            "parts": [{"text": text}],
+        }
+    }
+
+
+async def _load_member(session, member_id: uuid.UUID):
+    """`_handle_send_message`가 이 세션으로 Conversation(project_id/org_id FK) insert를
+    할 것이므로, 매 세션(=매 커넥션 체크아웃, `SET session_replication_role`은 커넥션-스코프라
+    이전 세션의 설정이 이어진다는 보장이 없다 — 특히 진짜 동시성 테스트는 서로 다른 커넥션을
+    쓴다)마다 여기서 `_bypass_fk`를 다시 건다."""
+    from app.models.team import TeamMember
+
+    await _bypass_fk(session)
+    return (await session.execute(
+        select(TeamMember).where(TeamMember.id == member_id)
+    )).scalar_one()
+
+
+async def _tasks_for_member(session, member_id: uuid.UUID) -> list:
+    from app.models.a2a_task import A2ATask
+
+    return list((await session.execute(
+        select(A2ATask).where(A2ATask.member_id == member_id)
+    )).scalars().all())
+
+
+@pytest.mark.anyio
+async def test_sequential_replay_dedupes_task_and_dispatch():
+    """AC1/AC3: 동일 message_id로 순차 2회 호출 — task 1개, 두 응답 모두 같은 task id, wake_agent
+    정확히 1회(fakechat 경로 고정이므로 wake_agent가 실 위임의 대리 신호)."""
+    from app.routers.a2a import _handle_send_message
+
+    engine, Session = await _engine_and_sessionmaker()
+    try:
+        async with Session() as s:
+            member_id = await _seed_agent_member(s)
+
+        message_id = str(uuid.uuid4())
+
+        with patch("app.routers.a2a.wake_agent") as mock_wake_agent:
+            async with Session() as s:
+                member = await _load_member(s, member_id)
+                result1 = await _handle_send_message(s, member, _send_params(message_id, "hello"))
+
+            async with Session() as s:
+                member = await _load_member(s, member_id)
+                result2 = await _handle_send_message(
+                    s, member, _send_params(message_id, "hello again (retry)"),
+                )
+
+        assert result1["task"]["id"] == result2["task"]["id"]
+        assert mock_wake_agent.call_count == 1, (
+            f"expected exactly 1 delegation dispatch, got {mock_wake_agent.call_count}"
+        )
+
+        async with Session() as s:
+            tasks = await _tasks_for_member(s, member_id)
+            assert len(tasks) == 1, f"expected exactly 1 A2ATask row, found {len(tasks)}"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_true_concurrency_race_single_task_single_dispatch():
+    """AC2(핵심): 동일 message_id를 진짜 동시에(asyncio.gather, 별도 세션/커넥션 2개) 발사해도
+    advisory xact lock 직렬화 덕에 task 1개·dispatch 1회만 나간다 — 순차 재호출이 아니라 실
+    레이스에서 TOCTOU가 구조적으로 막힌다는 증거(이 테스트가 통과해야 story #2004의 핵심
+    주장이 실증된다)."""
+    from app.routers.a2a import _handle_send_message
+
+    engine, Session = await _engine_and_sessionmaker()
+    try:
+        async with Session() as s:
+            member_id = await _seed_agent_member(s)
+
+        message_id = str(uuid.uuid4())
+
+        async def _call(text: str) -> dict:
+            async with Session() as s:
+                member = await _load_member(s, member_id)
+                return await _handle_send_message(s, member, _send_params(message_id, text))
+
+        with patch("app.routers.a2a.wake_agent") as mock_wake_agent:
+            result1, result2 = await asyncio.gather(
+                _call("concurrent call A"), _call("concurrent call B"),
+            )
+
+        assert result1["task"]["id"] == result2["task"]["id"], (
+            "두 동시 호출이 서로 다른 task id를 반환 — advisory lock 직렬화 실패(레이스 재발)"
+        )
+        assert mock_wake_agent.call_count == 1, (
+            f"true-concurrency race에서 중복 dispatch 발생: wake_agent 호출 {mock_wake_agent.call_count}회"
+        )
+
+        async with Session() as s:
+            tasks = await _tasks_for_member(s, member_id)
+            assert len(tasks) == 1, (
+                f"true-concurrency race에서 중복 A2ATask 발생: {len(tasks)}행"
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_different_message_ids_produce_independent_tasks_and_dispatches():
+    """회귀 가드: message_id가 다르면(같은 member) 완전히 독립된 task 2개 + dispatch 2회 —
+    락/dedup 키가 member_id 단독으로 과확장되지 않았음을 확인(story #2004 요구 §3)."""
+    from app.routers.a2a import _handle_send_message
+
+    engine, Session = await _engine_and_sessionmaker()
+    try:
+        async with Session() as s:
+            member_id = await _seed_agent_member(s)
+
+        with patch("app.routers.a2a.wake_agent") as mock_wake_agent:
+            async with Session() as s:
+                member = await _load_member(s, member_id)
+                result1 = await _handle_send_message(
+                    s, member, _send_params(str(uuid.uuid4()), "first independent message"),
+                )
+            async with Session() as s:
+                member = await _load_member(s, member_id)
+                result2 = await _handle_send_message(
+                    s, member, _send_params(str(uuid.uuid4()), "second independent message"),
+                )
+
+        assert result1["task"]["id"] != result2["task"]["id"]
+        assert mock_wake_agent.call_count == 2
+
+        async with Session() as s:
+            tasks = await _tasks_for_member(s, member_id)
+            assert len(tasks) == 2
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mutation_self_check_dedup_bypass_goes_red_then_restored_green():
+    """5(mutation self-check): `_acquire_send_message_dedup_lock`을 항상 None 반환(=dedup
+    우회)으로 monkeypatch하면 test 1과 동형 시나리오(동일 message_id 2콜)가 RED여야 한다 —
+    중복 task 2개 + 중복 dispatch 2회가 실제로 관측돼야 한다(그래야 원래 테스트가 "우연히
+    통과"가 아니라 이 메커니즘을 실제로 검증한다는 증거). 그 다음 원복해 GREEN(정상 dedup)을
+    재확인한다.
+
+    ⚠️함정(방어선 2가 방어선 1의 우회를 가려버림): 마이그 0201 partial UNIQUE 인덱스가 여전히
+    걸려 있으면, 락+재확인만 우회해도 두 번째 콜의 A2ATask insert가 UNIQUE violation →
+    `_handle_send_message`의 IntegrityError 백스톱이 그 경합을 조용히 흡수해 여전히 task
+    1개·dispatch 1회로 끝난다(defense-in-depth가 "우연히" RED를 GREEN처럼 보이게 만듦 —
+    이 테스트가 검증하려는 게 바로 "락이 실제로 기여하는가"이므로 이 흡수는 무의미한 통과다).
+    그래서 RED 구간에서는 UNIQUE 인덱스도 함께 임시 제거해 **락 메커니즘 단독**의 기여를
+    격리 관찰하고, GREEN 구간 전에 원복한다(GREEN 자체는 락만으로 충분 — existing_task
+    재확인이 두 번째 콜의 insert 시도 자체를 막으므로 UNIQUE 인덱스에 의존하지 않는다)."""
+    import app.routers.a2a as a2a_module
+    from sqlalchemy import text as sa_text
+
+    _DROP_UQ_SQL = "DROP INDEX IF EXISTS uq_a2a_tasks_member_client_message_id"
+    _CREATE_UQ_SQL = (
+        "CREATE UNIQUE INDEX uq_a2a_tasks_member_client_message_id ON a2a_tasks "
+        "(member_id, client_message_id) WHERE client_message_id IS NOT NULL"
+    )
+
+    engine, Session = await _engine_and_sessionmaker()
+    try:
+        async with Session() as s:
+            member_id = await _seed_agent_member(s)
+
+        message_id = str(uuid.uuid4())
+
+        # ── RED: 방어선 1(락+재확인) 우회 + 방어선 2(UNIQUE 인덱스) 임시 제거 — "이 메커니즘이
+        # 없으면 정말로 중복이 난다"를 순수하게 격리 실증.
+        async def _bypass_always_none(session, member_id, client_message_id):  # noqa: ARG001
+            return None
+
+        original = a2a_module._acquire_send_message_dedup_lock
+        a2a_module._acquire_send_message_dedup_lock = _bypass_always_none
+        async with Session() as s:
+            await s.execute(sa_text(_DROP_UQ_SQL))
+            await s.commit()
+        try:
+            with patch("app.routers.a2a.wake_agent") as mock_wake_agent:
+                async with Session() as s:
+                    member = await _load_member(s, member_id)
+                    await a2a_module._handle_send_message(
+                        s, member, _send_params(message_id, "red call 1"),
+                    )
+                async with Session() as s:
+                    member = await _load_member(s, member_id)
+                    await a2a_module._handle_send_message(
+                        s, member, _send_params(message_id, "red call 2 (same message_id)"),
+                    )
+
+            async with Session() as s:
+                tasks_red = await _tasks_for_member(s, member_id)
+            assert len(tasks_red) == 2, (
+                "mutation self-check 실패: 방어선을 모두 걷어냈는데도 task가 1개뿐 — 이 테스트가 "
+                "실제로 dedup 메커니즘을 검증하고 있지 않다는 뜻(가짜 GREEN 위험)"
+            )
+            assert mock_wake_agent.call_count == 2, (
+                "mutation self-check 실패: 방어선을 모두 걷어냈는데도 dispatch가 1회뿐"
+            )
+        finally:
+            a2a_module._acquire_send_message_dedup_lock = original
+            # RED 구간이 의도적으로 만든 중복 행(같은 member_id+client_message_id 2개)부터
+            # 청소해야 UNIQUE 인덱스 재생성이 성공한다 — 정리 없이 그대로 재생성하면 방금 만든
+            # 그 중복 자체가 CREATE UNIQUE INDEX를 막는다.
+            async with Session() as s:
+                await s.execute(sa_text(
+                    "DELETE FROM a2a_tasks WHERE member_id = :mid AND client_message_id = :cmid"
+                ), {"mid": str(member_id), "cmid": message_id})
+                await s.execute(sa_text(_CREATE_UQ_SQL))
+                await s.commit()
+
+        # ── GREEN: 원복 후 동일 시나리오(새 message_id로, 앞선 RED 오염과 독립) 재확인.
+        message_id_2 = str(uuid.uuid4())
+        with patch("app.routers.a2a.wake_agent") as mock_wake_agent:
+            async with Session() as s:
+                member = await _load_member(s, member_id)
+                result1 = await a2a_module._handle_send_message(
+                    s, member, _send_params(message_id_2, "green call 1"),
+                )
+            async with Session() as s:
+                member = await _load_member(s, member_id)
+                result2 = await a2a_module._handle_send_message(
+                    s, member, _send_params(message_id_2, "green call 2 (same message_id)"),
+                )
+
+        assert result1["task"]["id"] == result2["task"]["id"]
+        assert mock_wake_agent.call_count == 1
+
+        async with Session() as s:
+            tasks_for_id2 = [
+                t for t in await _tasks_for_member(s, member_id)
+                if t.client_message_id == message_id_2
+            ]
+            assert len(tasks_for_id2) == 1
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -460,6 +460,10 @@ async def test_send_message_working_when_webhook_configured():
             if call_count == 1:
                 return _result(member)
             if call_count == 2:
+                return _result(None)  # story #2004: advisory lock select — 반환값 미사용
+            if call_count == 3:
+                return _result(None)  # story #2004: existing_task lookup — 신규 message_id라 없음
+            if call_count == 4:
                 return _list_result([MEMBER_ID])  # active_webhook_member_ids: 활성 webhook 존재
             return _result(working_task)  # 최종 requery
 
@@ -499,6 +503,10 @@ async def test_send_message_working_when_member_has_multiple_active_webhooks():
             if call_count == 1:
                 return _result(member)
             if call_count == 2:
+                return _result(None)  # story #2004: advisory lock select — 반환값 미사용
+            if call_count == 3:
+                return _result(None)  # story #2004: existing_task lookup — 신규 message_id라 없음
+            if call_count == 4:
                 return _list_result([MEMBER_ID, MEMBER_ID])  # 활성 webhook 2개 이상(같은 멤버) 시뮬레이션
             return _result(working_task)
 
@@ -537,6 +545,10 @@ async def test_send_message_working_via_sse_pipeline_when_no_webhook():
             if call_count == 1:
                 return _result(member)
             if call_count == 2:
+                return _result(None)  # story #2004: advisory lock select — 반환값 미사용
+            if call_count == 3:
+                return _result(None)  # story #2004: existing_task lookup — 신규 message_id라 없음
+            if call_count == 4:
                 return _list_result([])  # webhook 없음
             return _result(working_task)
 
@@ -579,6 +591,10 @@ async def test_send_message_response_wraps_task_in_spec_envelope():
             if call_count == 1:
                 return _result(member)
             if call_count == 2:
+                return _result(None)  # story #2004: advisory lock select — 반환값 미사용
+            if call_count == 3:
+                return _result(None)  # story #2004: existing_task lookup — 신규 message_id라 없음
+            if call_count == 4:
                 return _list_result([])  # webhook 없음 → SSE 경로
             return _result(working_task)
 
@@ -620,6 +636,10 @@ async def test_send_message_delivered_content_embeds_completion_protocol_hint():
             if call_count == 1:
                 return _result(member)
             if call_count == 2:
+                return _result(None)  # story #2004: advisory lock select — 반환값 미사용
+            if call_count == 3:
+                return _result(None)  # story #2004: existing_task lookup — 신규 message_id라 없음
+            if call_count == 4:
                 return _list_result([MEMBER_ID])  # webhook 있음
             return _result(working_task)
 
@@ -1290,6 +1310,10 @@ async def test_project_context_extension_preserved_when_declared_no_webhook():
             if call_count == 1:
                 return _result(member)
             if call_count == 2:
+                return _result(None)  # story #2004: advisory lock select — 반환값 미사용
+            if call_count == 3:
+                return _result(None)  # story #2004: existing_task lookup — 신규 message_id라 없음
+            if call_count == 4:
                 return _list_result([])  # webhook 없음
             return _result(working_task)
 
@@ -1342,6 +1366,10 @@ async def test_project_context_extension_ignored_when_not_declared():
             if call_count == 1:
                 return _result(member)
             if call_count == 2:
+                return _result(None)  # story #2004: advisory lock select — 반환값 미사용
+            if call_count == 3:
+                return _result(None)  # story #2004: existing_task lookup — 신규 message_id라 없음
+            if call_count == 4:
                 return _list_result([])
             return _result(working_task)
 


### PR DESCRIPTION
## Summary

- `_handle_send_message`(A2A `SendMessage`/`SendStreamingMessage` 공용 핸들러)가 클라이언트가 보내는 `Message.message_id`를 지금까지 `A2ATask.history`에 inert하게 저장만 하고 dedup 키로 전혀 쓰지 않았다. 타임아웃 재시도/수동 재발송으로 동일 `message_id`가 다시 오면 매번 새 `Conversation`+`A2ATask` + **실 CC 위임(webhook 또는 Event+wake_agent)**을 중복 실행했다.
- 마이그 `0201`: `a2a_tasks.client_message_id`(nullable `Text`) + partial UNIQUE 인덱스 `uq_a2a_tasks_member_client_message_id ON (member_id, client_message_id) WHERE client_message_id IS NOT NULL` — 레거시/미지정 행끼리는 충돌하지 않도록 명시적으로 partial 선택(plain UNIQUE도 PG가 NULL을 distinct로 취급해 동일하게 안전하지만, partial이 "의도"를 DDL 자체에 드러낸다).
- `_acquire_send_message_dedup_lock`(신규 헬퍼): `pg_advisory_xact_lock(hashtext(member_id:client_message_id))`을 `_handle_send_message`의 **첫 DB 연산**으로 획득한 뒤 같은 키의 기존 `A2ATask`를 재확인 — 있으면 그걸 그대로 반환(Conversation/Message/webhook/Event/wake_agent/새 A2ATask 전부 스킵).

## 왜 naive insert-then-catch-conflict가 아닌가

"맨 끝에 A2ATask를 insert하고 UNIQUE 충돌을 catch해서 재조회" 패턴은 이 함수에서는 **불충분**하다 — 그 시점이면 이미 `Conversation`/`ConversationMessage` 생성과, 무엇보다 **실 webhook 발송 또는 Event+`wake_agent`(CC에게 실제로 위임 지시)가 나간 뒤**이기 때문이다. 충돌을 그 시점에 잡아봐야 DB 행 중복만 막을 뿐 AC3("중복 실행 지시 0")는 이미 깨진 뒤다. 그래서 advisory lock을 **가장 먼저** 잡아 "검사→위임→커밋" 구간 전체를 직렬화했다.

## 설계 노트 — A2ATask insert 위치를 옮긴 이유(유일한 순서 변경)

`_handle_send_message`는 원래도 중간에 `await session.commit()`을 여러 번 호출한다 — 특히 `Conversation`/`ConversationMessage` 생성 직후의 첫 commit은 `deliver_conversation_message_webhook`이 **별도 세션**(`async_session_factory()`)으로 그 행들을 재조회하기 때문에 원래도 필수였다(제거 불가).

`pg_advisory_xact_lock`은 트랜잭션이 commit될 때 자동 해제된다. A2ATask(=dedup 마커) insert를 원래 위치(함수 맨 끝, webhook/Event 디스패치 이후)에 그대로 뒀다면, 락은 그 첫 commit 시점에 이미 풀려버려 — dedup 마커가 실제로 durable해지기 전에 동시 두 콜이 모두 "기존 task 없음"을 보고 통과할 수 있는 레이스 윈도우가 남는다.

그래서 A2ATask insert를 **Conversation/Message insert 직후·기존 첫 commit 이전**으로 당겼다. webhook/Event 디스패치 로직 자체(내용·순서·별도 세션 사용)는 완전히 무변경 — fakechat 경로 전용 필드(`task_metadata.connected_at_send`)만 이미 insert된 행에 대한 후속 UPDATE로 반영한다. UNIQUE 인덱스는 방어선 2(백스톱) — 정상 동작에선 advisory lock이 경합을 구조적으로 막아 여기 도달하지 않아야 하지만, 락이 우회되는 경로가 생기면 `IntegrityError`를 잡아 rollback 후 승자의 committed task를 재조회해 반환한다(크래시 대신 멱등 응답).

## 동시성 테스트 증거

`backend/tests/test_2004_a2a_sendmessage_idempotency_realdb.py`(신규, 실 PG):

1. **순차 재생**: 동일 `message_id` 2콜 → task 1개, 같은 task id, `wake_agent` 1회.
2. **진짜 동시성 레이스**(핵심): `asyncio.gather`로 별도 세션/커넥션 2개에서 동일 `message_id`를 진짜 동시에 발사 → advisory lock 직렬화 덕에 task 1개·`wake_agent` 1회만 나간다는 걸 5회 반복 실행으로 안정성까지 확인.
3. **다른 `message_id`**: 완전 독립된 task 2개 + dispatch 2회(락/키가 `member_id` 단독으로 과확장되지 않았음을 확인).
4. **Mutation self-check**: `_acquire_send_message_dedup_lock`을 no-op으로 monkeypatch **+ UNIQUE 인덱스도 임시 제거**(방어선 2가 방어선 1의 우회를 조용히 흡수해버리는 걸 막기 위해 — 안 그러면 락만 꺼도 백스톱이 대신 막아 가짜 GREEN이 난다) → 실제로 task 2개·dispatch 2회(RED) 확인 후 원복해 GREEN 재확인.

## Test plan

- [x] `alembic upgrade head`/`downgrade -1`/`upgrade head` 왕복 — 로컬 pg@16(alembic-migrated, 0201까지) 클린 적용 확인.
- [x] `pytest backend/tests/test_2004_a2a_sendmessage_idempotency_realdb.py` — 4 passed (동시성 테스트 5회 반복 재확인).
- [x] `pytest backend/tests/test_a2a.py` — 42 passed(신규 lock/existing-task-lookup DB 콜 2개가 추가돼 SendMessage 관련 7개 테스트의 `call_count` 매핑을 갱신).
- [x] 기존 A2A realdb 스위트(`test_a2a_sa1/sa3/sa4/sa5/sa8/p1_s1`) 전체 재실행 — 실패 8건은 로컬 `.env`가 미기동 Supabase(port 54322)를 가리켜 발생하는 환경 이슈로, `origin/develop` 베이스라인에서도 동일 시그니처로 재현(내 diff와 무관, 회귀 아님).
- [x] `ruff check` — 변경 파일 전부 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>