### PR TITLE
fix(a2a): /rpc 타임아웃 명시화 — 서버 핸들러 상한 + Cloud Run 실효값 문서화 (story #2005)

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -55,6 +55,12 @@ jobs:
             # (PgBouncer 풀러 불필요 — Cloud Run raw TCP 미지원으로 중앙 PgBouncer 불가·관리형 풀링은 Enterprise Plus
             # 전용. maxScale 10 은 2×10×5+20=120>100 이라 폐기. 향후 트래픽↑ 시 tier업 동반해야 maxScale 상향.)
             echo "backend_max_instances=5" >> "$GITHUB_OUTPUT"
+            # story #2005: PO 라이브 gcloud 실측(2026-07-17) — backend-prod 현재 유효 Cloud Run
+            # 요청 타임아웃=300s. 지금까지 `cloudbuild.yaml`에 `--timeout` 플래그가 없어 이
+            # 값은 인프라 기본값이었을 뿐 어디에도 명시돼 있지 않았다 — 이제 이 워크플로우가
+            # 명시 소스가 된다(cloudbuild.yaml의 `_BACKEND_TIMEOUT` dev-safe 기본값 3600을
+            # prod에서 이 output으로 override, `backend_max_instances`와 동일 배선 패턴).
+            echo "backend_timeout=300" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=G-RYHFE7XM3X" >> "$GITHUB_OUTPUT"
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"
@@ -67,6 +73,11 @@ jobs:
             # DB_MAX_OVERFLOW=1 은 cloudbuild.yaml --update-env-vars 로 durable(lingering env 덮어씀).
             # (⚠️ dev/prod 공유 DB라면 prod(2×5×5+admin)와 합산 점검 필요 — PO 토폴로지 확認.)
             echo "backend_max_instances=8" >> "$GITHUB_OUTPUT"
+            # story #2005: PO 라이브 gcloud 실측(2026-07-17) — backend-dev 현재 유효 Cloud Run
+            # 요청 타임아웃=3600s(Cloud Run 요청 타임아웃 상한). cloudbuild.yaml의
+            # `_BACKEND_TIMEOUT` 기본값(3600)과 동일값이라 이 output이 없어도 기본값으로
+            # 굴러가지만, `backend_max_instances`와 대칭 배선을 위해 dev도 명시.
+            echo "backend_timeout=3600" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=" >> "$GITHUB_OUTPUT"
           fi
 
@@ -75,6 +86,6 @@ jobs:
           gcloud builds submit \
             --config=cloudbuild.yaml \
             --project="${{ secrets.GCP_PROJECT_ID }}" \
-            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}",_BACKEND_MIN_INSTANCES="${{ steps.env.outputs.backend_min_instances }}",_BACKEND_MAX_INSTANCES="${{ steps.env.outputs.backend_max_instances }}",_GA4_MEASUREMENT_ID="${{ steps.env.outputs.ga4_measurement_id }}" \
+            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}",_BACKEND_MIN_INSTANCES="${{ steps.env.outputs.backend_min_instances }}",_BACKEND_MAX_INSTANCES="${{ steps.env.outputs.backend_max_instances }}",_BACKEND_TIMEOUT="${{ steps.env.outputs.backend_timeout }}",_GA4_MEASUREMENT_ID="${{ steps.env.outputs.ga4_measurement_id }}" \
             --suppress-logs \
             .

--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -72,6 +72,7 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+import time
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -144,6 +145,24 @@ _VERSION_NOT_SUPPORTED = -32009  # 스펙 §14.2.1: A2A-Version 헤더가 지원
 _UNAUTHORIZED = -32010  # 401/403 — reserved server-error range(-32000~-32099), 기존 -32001/-32009와 미충돌
 _AGENT_NOT_FOUND = -32011  # 404 — `_get_agent_member`의 404 이스케이프. `get_agent_card`(REST 라우트)는 이 매핑을 타지 않는다(경로 불일치, 아래 `is_a2a_rpc_path` 참조) — REST 엔벨로프 그대로 유지.
 _INTERNAL_ERROR = -32603  # JSON-RPC 2.0 표준 코드("Internal error", 스펙 §7) — 미처리 예외 전용, 커스텀 번호 금지
+_REQUEST_TIMEOUT = -32012  # 서버 핸들러 상한 초과(reserved server-error range, 다음 free 번호 — -32001/-32009/-32010/-32011과 미충돌)
+
+# story #2005(Phase B P1-c, E-A2A-PROTO 리라이어빌리티): `/rpc`엔 오늘까지 애플리케이션 레벨
+# 타임아웃이 전혀 없었다(grep 확認 — `asyncio.wait_for`/`asyncio.timeout` 0건, 전체 파일). 유일한
+# 상한은 Cloud Run 플랫폼 자체 요청 타임아웃뿐이었고, 그마저도 `cloudbuild.yaml`의
+# `deploy-backend` 스텝에 `--timeout` 플래그가 명시된 적이 없어(grep 확認) 인프라 기본값에
+# 암묵 의존 중이었다. PO가 라이브 `gcloud`로 실측한 현재 유효값(2026-07-17 확認, 이 세션은
+# gcloud 접근 없이 그 실측을 그대로 신뢰):
+#   - backend-prod  = 300s
+#   - backend-dev   = 3600s
+#   - mcp-prod      = 300s (concurrency=80)
+# 아래 상한은 그 실측값 중 가장 빡빡한 값(prod 300s)보다 낮게 잡아(20s 여유) Cloud Run이
+# 커넥션을 강제로 끊기 전에 애플리케이션이 먼저 깔끔한 JSON-RPC 에러 envelope(story #2003의
+# `error.data.retryable` 계약 재사용, 타임아웃은 본질적으로 일시적이라 True 고정)으로 응답하게
+# 한다 — 원시 커넥션 킬은 클라가 파싱할 body가 없어 실패 원인을 알 수 없다. SendStreamingMessage
+# (SSE)의 전체-스트림 상한에도 동일 상수를 재사용한다(아래 `_stream_send_message` 참조) — dev의
+# 3600s는 이 상수보다 훨씬 커서 두 환경 모두에서 안전하게 먼저 트리거된다.
+_A2A_RPC_TIMEOUT_SECONDS = 280
 
 # HTTP status → JSON-RPC code(SSOT 단일 테이블, 감사/확장 용이하게 조건 흩뿌리지 않음). 표에
 # 없는 status(5xx 포함)는 표준 Internal error로 수렴 — unhandled_exception_handler는 항상 500만
@@ -262,9 +281,12 @@ _TERMINAL_STATES = {
 
 
 class _JsonRpcException(Exception):
-    def __init__(self, code: int, message: str) -> None:
+    def __init__(self, code: int, message: str, data: dict | None = None) -> None:
         self.code = code
         self.message = message
+        # story #2005: optional — 기존 4개 raise 지점(invalid params/task not found)은 여전히
+        # data 없이 생성돼 무회귀(`error.data`가 None으로 렌더, story #2003 이전 동작 그대로).
+        self.data = data
 
 
 def _caller_project_hint(auth: AuthContext) -> uuid.UUID | None:
@@ -855,6 +877,18 @@ def _sse_frame(request_id: str | int | None, result: dict) -> str:
     return f"data: {json.dumps(envelope)}\n\n"
 
 
+def _sse_error_frame(request_id: str | int | None, code: int, message: str) -> str:
+    """story #2005: SSE 스트림 도중 애플리케이션 상한에 걸렸을 때 쓰는 에러 프레임 —
+    `_sse_frame`의 `result` oneof 대신 JSON-RPC 2.0 표준 `error` 필드를 실은 envelope(§7).
+    커넥션을 그냥 끊는(원시 kill) 대신 클라가 파싱 가능한 마지막 프레임을 하나 보내고
+    종료한다."""
+    envelope = {
+        "jsonrpc": "2.0", "id": request_id,
+        "error": {"code": code, "message": message, "data": {"retryable": True}},
+    }
+    return f"data: {json.dumps(envelope)}\n\n"
+
+
 async def _stream_send_message(
     request: Request, request_id: str | int | None,
     session: AsyncSession, member: TeamMember, org_id: uuid.UUID, params: dict,
@@ -876,10 +910,29 @@ async def _stream_send_message(
     member_id = member.id
 
     async def generate():
+        # story #2005: SSE는 "사실상 무기한"이라 blanket `asyncio.wait_for`로 이 제너레이터
+        # 전체를 감싸는 건 어색하다(정상적으로 긴 스트림까지 함께 끊어버림) — 대신 여기서
+        # deadline을 직접 추적하는 **overall-ceiling** 방식을 택했다. per-chunk/idle-timeout
+        # (매 이벤트마다 리셋)도 검토했지만 기각: (1) task는 이미 DB에 영속돼 있어(GetTask로
+        # 계속 조회 가능) SSE는 그 상태를 미러링하는 부가 채널일 뿐이고, (2) 폴링 간격이
+        # `_STREAM_POLL_INTERVAL_SECONDS`(2s)로 고정이라 "활동"이 사실상 항상 있어 idle-timeout이
+        # 트리거될 일이 거의 없어 의미가 옅다, (3) Cloud Run 자신도 "한 커넥션 = 한 상한"
+        # 모델(idle 여부 무관)이라 여기서도 그 모델을 그대로 미러링하는 게 정합적이다.
+        # 상한은 non-streaming 경로와 동일한 `_A2A_RPC_TIMEOUT_SECONDS`(prod 실효값 300s보다
+        # 낮게, dev 3600s보다는 훨씬 낮게 — 두 환경 모두에서 Cloud Run이 끊기 전에 먼저
+        # 트리거됨) 재사용.
+        stream_deadline = time.monotonic() + _A2A_RPC_TIMEOUT_SECONDS
+
         yield _sse_frame(request_id, {"task": send_result["task"]})
 
         last_state: str | None = send_result["task"]["status"]["state"]
         while not await request.is_disconnected():
+            if time.monotonic() >= stream_deadline:
+                yield _sse_error_frame(
+                    request_id, _REQUEST_TIMEOUT,
+                    f"Stream exceeded server timeout ({_A2A_RPC_TIMEOUT_SECONDS}s)",
+                )
+                return
             async with async_session_factory() as db:
                 result = await db.execute(
                     select(A2ATask).where(A2ATask.id == task_id, A2ATask.member_id == member_id)
@@ -951,12 +1004,30 @@ async def a2a_rpc(
     # 응답 타입 자체가 달라(JsonRpcResponse 단일 vs SSE) 균일 _METHODS 디스패치에 안 넣고
     # 여기서 조기 분기한다.
     if body.method == "SendStreamingMessage":
+        # story #2005: 이 await는 `_stream_send_message`의 task-생성 단계(`_handle_send_message`)
+        # 까지만 감싼다 — 스트림 본문(`generate()`)은 이 함수가 반환한 `StreamingResponse`가
+        # FastAPI에 의해 나중에 소비되며 실행되므로 여기 wait_for 밖이다(그 부분의 상한은
+        # `generate()` 내부의 overall-ceiling 로직, 위 `_stream_send_message` 참조).
         try:
-            return await _stream_send_message(
-                request, body.id, session, member, org_id, body.params or {}, active_extensions,
+            return await asyncio.wait_for(
+                _stream_send_message(
+                    request, body.id, session, member, org_id, body.params or {}, active_extensions,
+                ),
+                timeout=_A2A_RPC_TIMEOUT_SECONDS,
             )
         except _JsonRpcException as exc:
-            return JsonRpcResponse(id=body.id, error=JsonRpcError(code=exc.code, message=exc.message))
+            return JsonRpcResponse(
+                id=body.id, error=JsonRpcError(code=exc.code, message=exc.message, data=exc.data),
+            )
+        except TimeoutError:
+            return JsonRpcResponse(
+                id=body.id,
+                error=JsonRpcError(
+                    code=_REQUEST_TIMEOUT,
+                    message=f"SendStreamingMessage setup exceeded server timeout ({_A2A_RPC_TIMEOUT_SECONDS}s)",
+                    data={"retryable": True},
+                ),
+            )
 
     handler = _METHODS.get(body.method)
     if handler is None:
@@ -965,10 +1036,28 @@ async def a2a_rpc(
             error=JsonRpcError(code=_METHOD_NOT_FOUND, message=f"Method not found: {body.method}"),
         )
 
+    # story #2005(Phase B P1-c): 서버 핸들러 상한 — `/rpc`엔 오늘까지 애플리케이션 레벨
+    # 타임아웃이 전혀 없었다(Cloud Run 플랫폼 타임아웃에만 암묵 의존, 위 `_A2A_RPC_TIMEOUT_SECONDS`
+    # 주석 참조). `asyncio.TimeoutError`는 3.11+부터 `TimeoutError`의 별칭이라 `except TimeoutError`
+    # 로 충분(`asyncio.wait_for`가 실제로 raise하는 타입도 이것).
     try:
-        result = await handler(session, member, body.params or {}, active_extensions)
+        result = await asyncio.wait_for(
+            handler(session, member, body.params or {}, active_extensions),
+            timeout=_A2A_RPC_TIMEOUT_SECONDS,
+        )
     except _JsonRpcException as exc:
-        return JsonRpcResponse(id=body.id, error=JsonRpcError(code=exc.code, message=exc.message))
+        return JsonRpcResponse(
+            id=body.id, error=JsonRpcError(code=exc.code, message=exc.message, data=exc.data),
+        )
+    except TimeoutError:
+        return JsonRpcResponse(
+            id=body.id,
+            error=JsonRpcError(
+                code=_REQUEST_TIMEOUT,
+                message=f"Method {body.method} exceeded server timeout ({_A2A_RPC_TIMEOUT_SECONDS}s)",
+                data={"retryable": True},
+            ),
+        )
 
     return JsonRpcResponse(id=body.id, result=result)
 

--- a/backend/tests/test_2005_a2a_rpc_timeout.py
+++ b/backend/tests/test_2005_a2a_rpc_timeout.py
@@ -1,0 +1,264 @@
+"""story #2005(Phase B P1-c, E-A2A-PROTO 리라이어빌리티): `/rpc` 타임아웃 명시화 검증.
+
+배경(grep 확認, story 스펙): `/rpc`엔 서버 핸들러 상한이 전혀 없었다(`asyncio.wait_for`/
+`asyncio.timeout` 0건, 전체 `a2a.py`) — 유일한 상한은 Cloud Run 플랫폼 타임아웃뿐이었고, 그마저도
+`cloudbuild.yaml`에 `--timeout` 플래그가 명시된 적이 없어 인프라 기본값에 암묵 의존 중이었다.
+이 파일은 그 갭을 메운 `_A2A_RPC_TIMEOUT_SECONDS`(non-streaming 핸들러 상한)와 SSE
+overall-ceiling(`_stream_send_message.generate()`)이 실제로 동작하는지를 검증한다.
+
+이 스토리는 lower-stakes(low-priority/lightweight)로 명시돼 mock/unit 중심 — story #2003·
+S-A4의 기존 mock 패턴(test_a2a.py의 `_authed_client`/`_mock_member`/`_result`, S-A4 realdb
+스트리밍 테스트의 `_stream_send_message` 직접 순회 패턴)을 그대로 재사용한다. 실 280초/300초를
+기다리지 않도록 `_A2A_RPC_TIMEOUT_SECONDS`(+ SSE 쪽은 `_STREAM_POLL_INTERVAL_SECONDS`도 함께)를
+monkeypatch로 test-friendly 값으로 낮춘다."""
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.routers import a2a as a2a_mod
+
+MEMBER_ID = uuid.uuid4()
+
+
+def _mock_member() -> MagicMock:
+    m = MagicMock()
+    m.id = MEMBER_ID
+    m.org_id = uuid.uuid4()
+    m.name = "Timeout Test Agent"
+    m.type = "agent"
+    m.is_active = True
+    return m
+
+
+def _result(value):
+    """test_a2a.py와 동일 헬퍼 — `_get_agent_member`가 `.scalars().first()`로 조회한다."""
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = value
+    r.scalar_one.return_value = value
+    r.first.return_value = value
+    r.scalars.return_value.first.return_value = value
+    return r
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _authed_client(org_id: uuid.UUID):
+    """test_a2a.py의 `_authed_client`와 동형(중복 최소화보다 이 파일의 독립성을 우선 — 기존
+    테스트 파일을 이 파일이 import하면 그 파일의 fixture/전역상태에 암묵 결합된다)."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        ctx = MagicMock()
+        ctx.user_id = str(uuid.uuid4())
+        ctx.claims = {"app_metadata": {"org_id": str(org_id)}}
+        return ctx
+
+    async def override_org():
+        return org_id
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    app.dependency_overrides[get_verified_org_id] = override_org
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+# ── 상수 sanity ──────────────────────────────────────────────────────────────
+
+
+def test_timeout_constant_is_below_po_measured_prod_cloud_run_ceiling():
+    """PO 실측(2026-07-17): backend-prod 실효 Cloud Run 타임아웃=300s. 애플리케이션 상한은
+    그보다 낮아야(플랫폼이 커넥션을 강제로 끊기 전에 앱이 먼저 깔끔한 에러를 낼 수 있게) 의미가
+    있다 — 역전되면(>=300) 이 스토리의 핵심 목적(원시 커넥션 킬 방지) 자체가 무의미해진다."""
+    assert 0 < a2a_mod._A2A_RPC_TIMEOUT_SECONDS < 300
+
+
+def test_timeout_error_code_does_not_collide_with_existing_custom_codes():
+    """story #2003이 도입한 -32010(_UNAUTHORIZED)/-32011(_AGENT_NOT_FOUND)와 미충돌 + 표준
+    JSON-RPC 코드(-32601/-32602/-32603)와도 미충돌 — 신규 -32012가 실제로 '다음 free 번호'인지
+    코드 레벨로 고정."""
+    existing = {
+        a2a_mod._METHOD_NOT_FOUND, a2a_mod._INVALID_PARAMS, a2a_mod._TASK_NOT_FOUND,
+        a2a_mod._VERSION_NOT_SUPPORTED, a2a_mod._UNAUTHORIZED, a2a_mod._AGENT_NOT_FOUND,
+        a2a_mod._INTERNAL_ERROR,
+    }
+    assert a2a_mod._REQUEST_TIMEOUT == -32012
+    assert a2a_mod._REQUEST_TIMEOUT not in existing
+
+
+# ── AC1: 느린/행 핸들러 → 클린 JSON-RPC 타임아웃 에러(핸행 없음) ────────────────
+
+
+@pytest.mark.anyio
+async def test_slow_method_handler_times_out_with_clean_jsonrpc_error():
+    client, session, app = await _authed_client(uuid.uuid4())
+    try:
+        member = _mock_member()
+        session.execute = AsyncMock(return_value=_result(member))
+
+        hang_started = asyncio.Event()
+
+        async def _hanging_handler(*_a, **_kw):
+            hang_started.set()
+            await asyncio.sleep(5)  # patched 타임아웃(아래)보다 훨씬 김 — 실제로 5초 기다리면 FAIL
+            return {"never": "reached"}  # pragma: no cover
+
+        req = {"jsonrpc": "2.0", "id": "slow-1", "method": "SlowMethod", "params": {}}
+
+        with patch.dict(a2a_mod._METHODS, {"SlowMethod": _hanging_handler}), \
+             patch.object(a2a_mod, "_A2A_RPC_TIMEOUT_SECONDS", 0.05):
+            async with client as c:
+                resp = await asyncio.wait_for(
+                    c.post(f"/api/v2/a2a/members/{MEMBER_ID}/rpc", json=req), timeout=10,
+                )
+
+        assert hang_started.is_set()  # 핸들러가 실제로 호출됐음(타임아웃이 호출 자체를 막은 게 아님)
+        assert resp.status_code == 200, resp.text  # story #2003 컨벤션: transport=200, 에러는 body
+        body = resp.json()
+        assert body["jsonrpc"] == "2.0"
+        assert body["id"] == "slow-1"
+        assert body["result"] is None
+        error = body["error"]
+        assert isinstance(error["code"], int)
+        assert error["code"] == a2a_mod._REQUEST_TIMEOUT
+        assert error["data"]["retryable"] is True
+        assert "0.05" in error["message"] or "timeout" in error["message"].lower()
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── AC2: 정상 빠른 호출은 무회귀(회귀 가드) ─────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_fast_method_completes_normally_under_timeout():
+    client, session, app = await _authed_client(uuid.uuid4())
+    try:
+        member = _mock_member()
+        session.execute = AsyncMock(return_value=_result(member))
+
+        async def _fast_handler(*_a, **_kw):
+            return {"ok": True, "echoed": True}
+
+        req = {"jsonrpc": "2.0", "id": "fast-1", "method": "FastMethod", "params": {}}
+
+        with patch.dict(a2a_mod._METHODS, {"FastMethod": _fast_handler}), \
+             patch.object(a2a_mod, "_A2A_RPC_TIMEOUT_SECONDS", 5.0):
+            async with client as c:
+                resp = await c.post(f"/api/v2/a2a/members/{MEMBER_ID}/rpc", json=req)
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["error"] is None
+        assert body["result"] == {"ok": True, "echoed": True}
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── AC3: SSE — 무기한 스트림이 overall ceiling에서 깔끔히 종료 ──────────────────
+
+
+class _FakeDbCtx:
+    """`async_session_factory()`의 `async with ... as db:` 대역 — 매 tick 항상 동일한
+    (never-completing) TASK_STATE_WORKING 행을 반환."""
+
+    def __init__(self, task_row):
+        self._task_row = task_row
+
+    async def __aenter__(self):
+        db = AsyncMock()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = self._task_row
+        db.execute = AsyncMock(return_value=result)
+        return db
+
+    async def __aexit__(self, *_exc):
+        return False
+
+
+def _mock_stream_request() -> MagicMock:
+    req = MagicMock()
+    req.is_disconnected = AsyncMock(return_value=False)
+    return req
+
+
+@pytest.mark.anyio
+async def test_sse_stream_terminates_at_overall_ceiling_instead_of_running_forever():
+    """느린/never-ending 스트림 제너레이터를 모킹(task가 영원히 TASK_STATE_WORKING) — 실제
+    S-A4 폴링 로직이라면 클라가 붙어있는 한(`is_disconnected`=False 고정) 영원히 안 끝난다.
+    overall-ceiling이 없으면 이 테스트는 타임아웃(무한루프)으로 실패한다."""
+    member = _mock_member()
+    task_row = MagicMock()
+    task_row.state = "TASK_STATE_WORKING"
+
+    send_result = {
+        "task": {
+            "id": str(uuid.uuid4()),
+            "contextId": str(uuid.uuid4()),
+            "status": {"state": "TASK_STATE_WORKING"},
+        }
+    }
+
+    session = AsyncMock()
+
+    with patch.object(a2a_mod, "_handle_send_message", new=AsyncMock(return_value=send_result)), \
+         patch.object(a2a_mod, "async_session_factory", side_effect=lambda: _FakeDbCtx(task_row)), \
+         patch.object(a2a_mod, "_advance_task_state", new=AsyncMock(return_value=task_row)), \
+         patch.object(
+             a2a_mod, "_task_to_dict",
+             return_value={**send_result["task"], "artifacts": []},
+         ), \
+         patch.object(a2a_mod, "_A2A_RPC_TIMEOUT_SECONDS", 0.05), \
+         patch.object(a2a_mod, "_STREAM_POLL_INTERVAL_SECONDS", 0.01):
+        resp = await a2a_mod._stream_send_message(
+            _mock_stream_request(), "stream-1", session, member, member.org_id, {}, frozenset(),
+        )
+
+        gen = resp.body_iterator
+        first = await asyncio.wait_for(gen.__anext__(), timeout=5)
+        assert '"task"' in first
+
+        frames: list[dict] = []
+        async for chunk in _bounded(gen, overall_timeout=5):
+            for line in chunk.split("\n"):
+                if line.startswith("data: "):
+                    frames.append(json.loads(line[len("data: "):]))
+
+    assert frames, "expected a terminal error frame before the stream closed"
+    last = frames[-1]
+    assert "error" in last and last.get("result") is None
+    assert last["error"]["code"] == a2a_mod._REQUEST_TIMEOUT
+    assert last["error"]["data"]["retryable"] is True
+    assert last["id"] == "stream-1"
+
+
+async def _bounded(gen, *, overall_timeout: float):
+    """async generator를 순회하되 전체 소요시간을 감싸 테스트 자체가 실수로 무한 대기하지
+    않도록 방어(overall-ceiling 구현에 버그가 있어도 CI가 행 걸리는 대신 명확히 FAIL)."""
+    async def _drain():
+        async for item in gen:
+            yield item
+
+    it = _drain()
+    while True:
+        try:
+            item = await asyncio.wait_for(it.__anext__(), timeout=overall_timeout)
+        except StopAsyncIteration:
+            return
+        yield item

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,6 +20,21 @@ substitutions:
   #    불가·관리형 풀링 Enterprise Plus 전용 → 채택 안 함. 트래픽↑ 時 tier업 동반해야 maxScale 상향.)
   _BACKEND_MAX_INSTANCES: '1'
   _GA4_MEASUREMENT_ID: ""  # dev 기본값 빈 문자열 — prod 트리거에서 G-RYHFE7XM3X 주입
+  # story #2005(Phase B P1-c, E-A2A-PROTO 리라이어빌리티): Cloud Run 요청 타임아웃이
+  # `deploy-backend` 스텝에 `--timeout` 플래그로 명시된 적이 한 번도 없어(grep 확認) 인프라
+  # 기본값에 암묵 의존 중이었다(A2A `/rpc` 특히 `SendStreamingMessage` SSE가 사실상 무기한
+  # 실행되는 배경). PO가 라이브 `gcloud`로 실측한 현재 유효값(2026-07-17, 이 세션은 gcloud
+  # 접근 없이 그 실측을 신뢰): backend-prod=300s · backend-dev=3600s · mcp-prod=300s
+  # (concurrency=80). 아래 기본값(3600)은 `_DEPLOY_ENV: dev` 기본값과 정합한 dev-safe
+  # fallback(위 `_BACKEND_MIN_INSTANCES` 주석과 동일 컨벤션) — dev 측정값을 그대로 명시해
+  # "인프라 기본값 암묵 의존"에서 "이 파일에 명시된 의도값"으로 전환한다. prod override(300)는
+  # `.github/workflows/cloud-build.yml`의 `steps.env`(브랜치별 backend_timeout 산출 후
+  # `--substitutions`로 주입, `_BACKEND_MAX_INSTANCES`와 동일 배선)에서 온다 — 이 저장소의
+  # "트리거"는 별도 GCP Cloud Build Trigger 리소스가 아니라 그 GHA 워크플로우 자체(파일 상단
+  # 주석 "트리거: main→prod, develop→dev (GitHub Actions cloud-build.yml)" 참조)라 prod override
+  # 도 이 레포 안에서 완결된다(PO/infra-lane이 GCP 콘솔에서 별도로 설정할 트리거-레벨
+  # override는 존재하지 않음 — 확認 후 아래 GHA 워크플로우도 함께 배선함).
+  _BACKEND_TIMEOUT: '3600'
 
 steps:
   # ─── Frontend (Next.js standalone) ────────────────────────────────────────
@@ -137,6 +152,9 @@ steps:
       - --region=${_AR_REGION}
       - --min-instances=${_BACKEND_MIN_INSTANCES}
       - --max-instances=${_BACKEND_MAX_INSTANCES}
+      # story #2005: 요청 타임아웃 명시화(위 `_BACKEND_TIMEOUT` 주석 참조) — 이전엔 이 플래그
+      # 자체가 없어 Cloud Run 인프라 기본값에 암묵 의존했다.
+      - --timeout=${_BACKEND_TIMEOUT}
       # ⭐frontend 가 NEXT_PUBLIC_FASTAPI_URL 로 backend 를 직접 호출(public 필수). 플래그 없으면
       # gcloud run deploy 가 기존 IAM 을 preserve(non-deterministic) → 신규/리셋 시 allUsers invoker
       # 유실로 403(2026-06-21 prod promotion 사건). 명시적·멱등 설정으로 매 배포 public 보장(dev/prod 공통).


### PR DESCRIPTION
## Summary

Story #2005 (Phase B P1-c, E-A2A-PROTO 리라이어빌리티 에픽) — A2A `/rpc`에 예측 가능한 상한(predictable upper bound)을 준다. 이 스토리는 low-priority/lightweight로 명시돼 있어 구현을 그에 맞춰 proportionate하게 유지했다.

**배경(grep 확認)**: `/rpc`(`backend/app/routers/a2a.py`)엔 애플리케이션 레벨 타임아웃이 전혀 없었다 — `asyncio.wait_for`/`asyncio.timeout` 0건. `SendStreamingMessage`는 `StreamingResponse`(SSE)를 반환해 사실상 무기한 실행되며 클라이언트 disconnect에만 의존한다. 유일한 실 타임아웃 강제는 Cloud Run 플랫폼 자체 요청 타임아웃뿐이었는데, 그마저 `cloudbuild.yaml`의 `deploy-backend` 스텝에 `--timeout` 플래그가 명시된 적이 없어(grep 확認) 서비스가 인프라 기본값에 조용히 의존해왔다.

## Code changes (`backend/app/routers/a2a.py`)

1. **`_A2A_RPC_TIMEOUT_SECONDS = 280`** — non-streaming 핸들러 디스패치(`a2a_rpc`의 `handler(...)` 호출)를 `asyncio.wait_for(...)`로 감싸는 상한. PO 실측 prod 유효값(300s)보다 20s 낮게 잡아, Cloud Run이 커넥션을 강제로 끊기 전에 애플리케이션이 먼저 깔끔한 JSON-RPC 에러를 낸다.
2. **`_REQUEST_TIMEOUT = -32012`** — 신규 JSON-RPC 에러 코드(reserved server-error range, story #2003의 `-32010`/`-32011` 다음 free 번호, 충돌 없음). `error.data.retryable=True`(타임아웃은 본질적으로 일시적) — story #2003이 도입한 JSON-RPC 에러 계약을 그대로 재사용.
3. **`_JsonRpcException`을 `data: dict | None` optional 파라미터로 확장** — 타임아웃 외 기존 4개 raise 지점(invalid params/task not found)은 여전히 `data=None`으로 무회귀.
4. **SendStreamingMessage(SSE) — overall-ceiling 방식 채택**: `_stream_send_message`의 초기 task-생성 단계(`_handle_send_message` 호출)는 동일 상수로 `wait_for` 감쌌고, 스트림 본문(`generate()`)은 그 밖이라(StreamingResponse가 나중에 소비) 별도로 `time.monotonic()` 기반 deadline을 폴링 루프 매 tick에서 체크한다. 상한 도달 시 새 `_sse_error_frame()` 헬퍼로 JSON-RPC 에러 프레임(`error.code=-32012, data.retryable=true`)을 한 번 보내고 정상 종료(원시 커넥션 kill 대신).

### SSE 타임아웃 형태(overall-ceiling vs per-chunk idle-timeout) — 결정 및 이유

per-chunk/idle-timeout(매 이벤트마다 리셋, 무기한 긴 스트림 허용)도 검토했지만 **overall ceiling만 채택**했다:
- task는 이미 DB에 영속돼 있어(`GetTask`로 계속 조회 가능) SSE는 그 상태를 미러링하는 부가 채널일 뿐이다.
- 폴링 간격이 `_STREAM_POLL_INTERVAL_SECONDS`(2s)로 고정이라 "활동"이 사실상 항상 있어 idle-timeout이 트리거될 일이 거의 없어 의미가 옅다.
- Cloud Run 자신도 "한 커넥션 = 한 상한" 모델(idle 여부 무관)이라 여기서도 그 모델을 그대로 미러링하는 게 정합적이고, 스토리 자체 프레이밍("SSE는 사실상 무기한")이 요구하는 최소 바도 overall ceiling이면 충족한다.

이 결정은 코드 주석(`_stream_send_message.generate()` 안)에도 남겼다.

## Infra changes (`cloudbuild.yaml` + `.github/workflows/cloud-build.yml`)

- `cloudbuild.yaml`: `_BACKEND_TIMEOUT` substitution 추가(dev-safe 기본값 `3600`, `_DEPLOY_ENV: dev` 기본값 컨벤션과 정합) + `deploy-backend` 스텝에 `--timeout=${_BACKEND_TIMEOUT}` 플래그 추가.
- **발견**: 이 저장소의 "Cloud Build 트리거"는 별도 GCP 콘솔 Trigger 리소스가 아니라 `.github/workflows/cloud-build.yml`(GHA)이 `gcloud builds submit --substitutions=...`으로 매 push마다 직접 제출하는 구조다(`cloudbuild.yaml` 상단 주석 "트리거: main→prod, develop→dev (GitHub Actions cloud-build.yml)" 확認). 즉 prod override(300s)도 **이 저장소 안에서 완결**된다 — 그래서 `steps.env`에 `backend_timeout` output(prod=300, dev=3600)을 추가하고 `--substitutions`에 `_BACKEND_TIMEOUT`을 배선했다(`_BACKEND_MAX_INSTANCES`와 동일 패턴).

## 문서화된 실측값 (PO gcloud 라이브 측정, 2026-07-17)

| 서비스 | 실효 타임아웃 |
|---|---|
| backend-prod | 300s |
| backend-dev | 3600s |
| mcp-prod | 300s (concurrency=80) |

`a2a.py`의 `_A2A_RPC_TIMEOUT_SECONDS` 주석 + `cloudbuild.yaml`의 `_BACKEND_TIMEOUT` 주석 양쪽에 이 값을 기록해 Sprintable 채팅 메시지로만 남았던 지식을 저장소에 durable하게 옮겼다.

## Tests (`backend/tests/test_2005_a2a_rpc_timeout.py`, 신규 5개)

Mock/unit 중심(story 자체가 lower-stakes로 명시). 타임아웃 상수는 monkeypatch로 test-friendly 값(0.05s 등)으로 낮춰 실 280초/300초를 기다리지 않는다.

1. `test_timeout_constant_is_below_po_measured_prod_cloud_run_ceiling` — 상수 sanity(< 300s)
2. `test_timeout_error_code_does_not_collide_with_existing_custom_codes` — -32012가 기존 코드와 미충돌
3. `test_slow_method_handler_times_out_with_clean_jsonrpc_error` — 행 핸들러 → 클린 JSON-RPC 타임아웃 에러(retryable=true, code=-32012), 핸들러가 실제로 호출됐음도 확인
4. `test_fast_method_completes_normally_under_timeout` — 정상 빠른 호출 무회귀
5. `test_sse_stream_terminates_at_overall_ceiling_instead_of_running_forever` — 무기한(never-completing) 스트림 목이 overall ceiling에서 클린 에러 프레임 후 종료(overall-ceiling 없으면 이 테스트는 무한루프로 FAIL)

**결과**: 5 passed (신규) / **47 passed, 34 skipped, 0 failed**(전체 A2A 관련 스위트 재실행 — `test_a2a.py` 42개 + 신규 5개, `*_realdb.py` 34개는 로컬에 alembic-migrated PG가 없어 baseline과 동일하게 skip, 이 변경으로 새로 skip된 것 아님).

## ⚠️ PO/infra-lane 확인 필요 (non-technical 요약)

이 PR은 코드/설정을 전부 저장소 안에서 완결했다 — `_BACKEND_TIMEOUT`이 dev(3600s)/prod(300s) 둘 다 이 저장소의 GHA 워크플로우가 배포 시점에 자동으로 주입한다(별도 GCP 콘솔 조작 불필요, `_BACKEND_MAX_INSTANCES`가 이미 쓰던 것과 동일한 검증된 배선 방식). 다만 나(에이전트)는 gcloud/GCP 접근이 없어 **실제 배포 후 라이브로 확인은 못 했다** — 다음 dev/prod 배포가 이 워크플로우를 타면서 `--timeout` 플래그가 실제로 적용되는지(배포 로그 또는 `gcloud run services describe`로 timeoutSeconds 필드 확인) PO/infra-lane이 한 번 라이브로 검증해주면 좋겠다. 실패하면 배포 자체가 실패하므로(gcloud 플래그 오류 시 deploy-backend 스텝이 실패) 위험도는 낮지만, "설정이 의도대로 반영됐다"는 최종 확인은 PO 쪽에서 눈으로 봐주는 게 안전하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)