### PR TITLE
[SID:1996] 채팅 doc 임베드 미리보기 + 문서뷰 pageEmbed 카드 fix

### DIFF
--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -5,7 +5,8 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { ExternalLink, X, FileText, File, Layers, CheckSquare, Hash, type LucideIcon } from 'lucide-react';
+import { ExternalLink, X, FileText, File, Layers, CheckSquare, Hash, Eye, type LucideIcon } from 'lucide-react';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 
 // 글리프(📋📄🎯✅) → lucide. 타입 식별=아이콘·색은 신호 토큰만(다크 무파손).
 export const ENTITY_ICONS: Record<string, LucideIcon> = {
@@ -44,10 +45,15 @@ export interface EmbedCardData {
   position?: number;
 }
 
+// story #1996: 'doc'는 여기 없다(의도적) — GET /api/docs/{id}는 lightweight timestamp-only
+// polling 엔드포인트(`{ updated_at }`만 반환, route.ts 자체 주석 "Lightweight timestamp check
+// for remote-change polling")라 content/slug가 없다. 전 코드(이 파일의 예전 handleDocClick
+// 포함)가 이 엔드포인트를 "풀 doc 조회"로 오인해 호출해왔던 게 실측으로 드러난 진짜 결함 —
+// EntityPreviewModal이 doc 타입을 별도 2단계 fetch(preview로 slug 해소→project_id+slug로
+// 본문 조회, doc 뷰 페이지와 동일 패턴)로 처리한다.
 const ENTITY_API: Record<string, (id: string) => string> = {
   story: (id) => `/api/stories/${id}`,
   epic: (id) => `/api/goals/${id}`,
-  doc: (id) => `/api/docs/${id}`,
   asset: (id) => `/api/assets/${id}`,
 };
 
@@ -142,6 +148,9 @@ function EntityPreviewModal({
   const overlayRef = useRef<HTMLDivElement>(null);
   const [detail, setDetail] = useState<Record<string, unknown> | null>(null);
   const [loading, setLoading] = useState(entityType !== 'task');
+  // story #1996: doc 본문 조회는 project_id+slug 조합 엔드포인트(getDoc)라 project_id가
+  // 필요 — doc 뷰 페이지([slug]/view/page.tsx)와 동일 소스(useDashboardContext).
+  const { projectId } = useDashboardContext();
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
@@ -150,14 +159,42 @@ function EntityPreviewModal({
   }, [onClose]);
 
   useEffect(() => {
+    let cancelled = false;
+
+    if (entityType === 'doc') {
+      // story #1996: doc은 2단계 — ①/api/docs/preview?q=(slug-or-uuid)로 entityId(uuid)를
+      // slug로 해소 ②project_id+slug로 본문 조회(getDoc, 다른 doc 뷰 표면과 동일 SSOT 패턴).
+      // /api/docs/{id}(lightweight timestamp-only)를 "풀 doc 조회"로 오인했던 게 원 결함.
+      if (!projectId) { setLoading(false); return; }
+      void (async () => {
+        try {
+          const previewRes = await fetch(`/api/docs/preview?q=${encodeURIComponent(entityId)}`);
+          if (!previewRes.ok) throw new Error();
+          const previewJson = (await previewRes.json()) as { data?: { slug?: string } };
+          const slug = previewJson.data?.slug;
+          if (!slug) throw new Error();
+          const docRes = await fetch(`/api/docs?project_id=${projectId}&slug=${encodeURIComponent(slug)}`);
+          if (!docRes.ok) throw new Error();
+          const docJson = (await docRes.json()) as { data?: Record<string, unknown> };
+          if (!cancelled) setDetail(docJson.data ?? null);
+        } catch {
+          /* fetch 실패 시 fallback만 표시 */
+        } finally {
+          if (!cancelled) setLoading(false);
+        }
+      })();
+      return () => { cancelled = true; };
+    }
+
     const url = ENTITY_API[entityType]?.(entityId);
     if (!url) return;
     fetch(url)
       .then((r) => r.ok ? r.json() : Promise.reject())
-      .then((json) => setDetail((json as { data?: Record<string, unknown> }).data ?? json as Record<string, unknown>))
+      .then((json) => { if (!cancelled) setDetail((json as { data?: Record<string, unknown> }).data ?? json as Record<string, unknown>); })
       .catch(() => { /* fetch 실패 시 fallback만 표시 */ })
-      .finally(() => setLoading(false));
-  }, [entityType, entityId]);
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [entityType, entityId, projectId]);
 
   const handleOverlayClick = useCallback((e: React.MouseEvent) => {
     if (e.target === overlayRef.current) onClose();
@@ -166,6 +203,12 @@ function EntityPreviewModal({
   const Icon = ENTITY_ICONS[entityType] ?? Hash;
   const colorClass = ENTITY_COLORS[entityType] ?? 'border-border bg-muted text-foreground';
   const label = title ?? entityId;
+  // story #1996: getEntityHref('doc', id)의 `/docs?id=` 는 어느 라우트도 소비하지 않는 죽은
+  // 패턴(grep 0건) — 실 라우트는 slug 기반(`/docs/{slug}/view`, embed-card의 handleDocClick과
+  // 동형). doc 상세 fetch(위 useEffect)가 이미 slug를 포함해 내려주므로 로드 후 그걸로 override —
+  // "미리보기 살리기"가 이 죽은 링크를 처음으로 실사용 도달 가능하게 만드는 지점이라 같이 고친다.
+  const docSlug = entityType === 'doc' ? (detail as { slug?: string } | null)?.slug : undefined;
+  const resolvedHref = entityType === 'doc' ? (docSlug ? `/docs/${docSlug}/view` : null) : href;
 
   return (
     <div
@@ -206,10 +249,10 @@ function EntityPreviewModal({
           ) : null}
         </div>
         {/* Footer */}
-        {href && (
+        {resolvedHref && (
           <div className="flex-shrink-0 px-6 py-3 border-t border-border">
             <Link
-              href={href}
+              href={resolvedHref}
               onClick={onClose}
               className="flex items-center gap-1.5 text-sm text-primary hover:underline"
             >
@@ -235,7 +278,10 @@ export function EmbedCard({ entity_type, entity_id, title, status }: EmbedCardDa
   const handleDocClick = useCallback(async () => {
     setNavigating(true);
     try {
-      const res = await fetch(`/api/docs/${entity_id}`);
+      // story #1996: /api/docs/{id}는 lightweight timestamp-only 엔드포인트(`{updated_at}`만
+      // 반환) — 이 컴포넌트가 실측 이전엔 `data.slug`를 기대해왔으나 실제로 항상 undefined였다
+      // (`/docs/undefined/view`로 404). /api/docs/preview?q=가 id→slug 해소 전용 엔드포인트.
+      const res = await fetch(`/api/docs/preview?q=${encodeURIComponent(entity_id)}`);
       if (!res.ok) throw new Error();
       const { data } = await res.json() as { data: { slug: string } };
       router.push(`/docs/${data.slug}/view`);
@@ -256,15 +302,46 @@ export function EmbedCard({ entity_type, entity_id, title, status }: EmbedCardDa
   );
 
   if (entity_type === 'doc') {
+    // story #1996(no-sloppy): 전체 카드가 항상 이동만 해 EntityPreviewModal(doc content 렌더
+    // 이미 지원, EntityDetail의 doc 분기)에 도달할 방법이 없었다 — 주 클릭=이동(기존 UX 유지)·
+    // 보조 아이콘=미리보기(모달)로 병렬 배치.
     return (
-      <button
-        type="button"
-        onClick={handleDocClick}
-        disabled={navigating}
-        className="block w-full text-left transition-opacity hover:opacity-80 disabled:opacity-60"
-      >
-        {inner}
-      </button>
+      <>
+        <div className={`flex items-center gap-1 rounded-md border pl-3 pr-1.5 py-2 text-sm ${colorClass}`}>
+          <button
+            type="button"
+            onClick={handleDocClick}
+            disabled={navigating}
+            className="flex min-w-0 flex-1 items-center gap-2 text-left disabled:opacity-60"
+          >
+            <Icon className="size-4 shrink-0" />
+            <span className="min-w-0 flex-1 truncate font-medium">{label}</span>
+            {status ? (
+              <span className="shrink-0 rounded px-1.5 py-0.5 text-xs bg-black/10 dark:bg-white/10">{status}</span>
+            ) : null}
+            {navigating && <span className="h-3 w-3 shrink-0 animate-spin rounded-full border-2 border-current border-t-transparent" />}
+          </button>
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); setShowModal(true); }}
+            className="shrink-0 rounded p-1 opacity-70 transition-opacity hover:bg-black/10 hover:opacity-100 dark:hover:bg-white/10"
+            aria-label="미리보기"
+            title="미리보기"
+          >
+            <Eye className="size-3.5" />
+          </button>
+        </div>
+        {showModal && (
+          <EntityPreviewModal
+            entityType={entity_type}
+            entityId={entity_id}
+            title={title}
+            status={status}
+            href={href}
+            onClose={() => setShowModal(false)}
+          />
+        )}
+      </>
     );
   }
 

--- a/apps/web/src/components/docs/doc-content-renderer.test.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.test.tsx
@@ -55,6 +55,21 @@ describe('DocContentRenderer', () => {
     expect(markup).toContain('SELECT 1;');
   });
 
+  it('story #1996: preserves pageEmbed data attributes through markdown sanitize (previously stripped, grep 0 handler)', () => {
+    const markup = renderToStaticMarkup(
+      <DocContentRenderer
+        content={'<div data-page-embed data-doc-id="doc-1" data-title="설계 문서" data-icon="📄" data-slug="design-doc"></div>'}
+        contentFormat="markdown"
+      />,
+    );
+
+    // rehype-sanitize의 기존 스키마는 이 속성들이 allowlist 밖이라 전부 걷어냈다 — 스키마
+    // 확장이 없으면 이 assertion들이 실패해 회귀를 잡는다.
+    expect(markup).toContain('data-page-embed');
+    expect(markup).toContain('data-title="설계 문서"');
+    expect(markup).toContain('data-slug="design-doc"');
+  });
+
   it('sanitizes dangerous heading attributes and inner tags', () => {
     const markup = renderToStaticMarkup(
       <DocContentRenderer

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -57,6 +57,14 @@ const docMarkdownSanitizeSchema = {
       'dataSize',
       'dataMimeType',
       'dataFileData',
+      // story #1996: pageEmbed 원자 노드(page-embed-node.tsx renderHTML) 속성 — 이전엔
+      // 스키마 미포함이라 markdown 포맷 문서에서 rehype-sanitize가 전부 걷어내 querySelector
+      // 식별 자체가 불가능했다(HTML 포맷 문서만 우연히 살아남았을 갭).
+      'dataPageEmbed',
+      'dataDocId',
+      'dataTitle',
+      'dataIcon',
+      'dataSlug',
     ],
   },
 };
@@ -245,6 +253,36 @@ export function DocContentRenderer({
       const handleClick = () => { if (slug) window.location.href = `/docs/${slug}`; };
       span.addEventListener('click', handleClick);
       return () => span.removeEventListener('click', handleClick);
+    });
+
+    // Page embed handlers (viewer) — story #1996(no-sloppy): 에디터 NodeView(PageEmbedExtension
+    // renderHTML)가 만드는 <div data-page-embed data-doc-id data-title data-icon data-slug>
+    // 원자 노드를 읽기전용 뷰가 렌더할 핸들러가 아예 없어(grep 0건) 빈 div로 깨져 보였다.
+    // wikiLink 핸들러와 동일 관례(카드 자체는 publicMode에서도 유지 — 제목/아이콘은 이미 원본
+    // 문서에 박힌 정적 메타라 노출 자체는 meta-leak 아님·클릭 네비게이션만 authed 전용으로 제한).
+    const pageEmbeds = Array.from(root.querySelectorAll<HTMLElement>('[data-page-embed]'));
+    const pageEmbedCleanup = pageEmbeds.map((block) => {
+      const title = block.getAttribute('data-title') || '';
+      const icon = block.getAttribute('data-icon') || '';
+      const slug = block.getAttribute('data-slug') || '';
+      const iconMarkup = icon
+        ? `<span class="shrink-0 text-lg">${escapeHtmlText(icon)}</span>`
+        : '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="flex-shrink-0 text-muted-foreground"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/></svg>';
+      block.className = publicMode || !slug
+        ? 'not-prose my-2 flex items-center gap-3 rounded-xl border border-border bg-muted/20 px-4 py-3'
+        : 'not-prose my-2 flex cursor-pointer items-center gap-3 rounded-xl border border-border bg-muted/20 px-4 py-3 transition-colors hover:bg-muted/40';
+      block.innerHTML = `
+        ${iconMarkup}
+        <div class="min-w-0 flex-1">
+          <p class="truncate text-sm font-medium">${escapeHtmlText(title || '(제목 없음)')}</p>
+          ${slug ? `<p class="truncate text-xs opacity-60">/${escapeHtmlText(slug)}</p>` : ''}
+        </div>`;
+      // publicMode: doc-to-doc traversal 금지(wikiLink와 동일 meta-leak 경계) — 카드 렌더는
+      // 유지하되 클릭 네비게이션만 뺀다.
+      if (publicMode || !slug) return () => { /* no handler attached */ };
+      const handleClick = () => { window.location.href = `/docs/${slug}`; };
+      block.addEventListener('click', handleClick);
+      return () => block.removeEventListener('click', handleClick);
     });
 
     // Math block rendering (viewer)
@@ -452,6 +490,7 @@ export function DocContentRenderer({
     return () => {
       cleanup.forEach((dispose) => dispose());
       wikiCleanup.forEach((dispose) => dispose());
+      pageEmbedCleanup.forEach((dispose) => dispose());
       fileCleanup.forEach((dispose) => dispose());
       assetImgCleanup.forEach((dispose) => dispose());
       toggleCleanup.forEach((dispose) => dispose());


### PR DESCRIPTION
## 요약
- AC1(embed-card.tsx): doc 미리보기 아이콘 버튼 추가 + EntityPreviewModal 연결. 실사용 경로(EntityChip)와 명시 타겟(EmbedCard, grep 소비처 0건 확인된 죽은 코드)이 동일 EntityPreviewModal을 공유해 두 곳 다 적용됨.
- **부수 발견·수정(더 근본적 결함)**: `ENTITY_API['doc']`/`handleDocClick`이 `GET /api/docs/{id}`(lightweight timestamp-only 폴링 전용, `{updated_at}`만 반환)를 "풀 doc 조회"로 오인해 호출해왔음 — doc 미리보기는 항상 본문·링크 없이 빈 카드, handleDocClick은 항상 `/docs/undefined/view` 404. `/api/docs/preview?q=`(slug 해소) + `GET /api/docs?project_id&slug=`(getDoc, doc 뷰 페이지와 동일 SSOT)로 교체.
- AC2(doc-content-renderer.tsx): `[data-page-embed]` 렌더 핸들러 신설(핸들러 자체 부재로 빈 깨진 div였음) + markdown sanitize 스키마에 data-page-embed 5개 속성 allowlist 추가(누락 시 sanitize 단계에서 통째로 제거됨).

## 스크린샷 (격리 스택 실렌더)
- AC2: 문서뷰 pageEmbed 카드 정상 렌더(아이콘·제목·슬러그) → 클릭 → 대상 문서 정상 이동
- AC1 실질경로(EntityChip): before(수정 전) 헤더 제목만 뜨고 본문·"전체 보기" 링크 모두 비어있음 → after 실제 본문("이것은 임베드 대상 문서 본문입니다.") + "전체 보기"(href=/docs/design-doc/view) 정상 렌더 → 클릭 → `/embed-org/embed-project/docs/design-doc/view` 정상 네비게이트

## 반응형 확인
데스크톱 뷰만 관련(채팅/문서 데스크톱-우선 표면, 모바일 레이아웃 변경 없음).

## 게이트
- tsc 0 error
- lint 0 error (기존 무관 warning 5건)
- vitest 257 files / 1713 passed
- build success

🤖 Generated with [Claude Code](https://claude.com/claude-code)