### PR TITLE
[SID:2002] 채팅 inline/fence code 원클릭 클립보드 복사

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -4,7 +4,7 @@ import { useCallback, useRef, useState } from 'react';
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
-import { Bot, MessageSquare, Terminal, User } from 'lucide-react';
+import { Bot, Check, Copy, MessageSquare, Terminal, User } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
 import { commandName, dequoteLiteral, isCommand } from '@/lib/command-classifier';
@@ -40,6 +40,60 @@ function prepareMentions(content: string): string {
   return content.replace(/(?<![[(])@([\w가-힣]+)/g, '[@$1](mention:$1)');
 }
 
+// story #2002: 원클릭 복사 — inline(단일 백틱)은 클릭 즉시 복사, 블록(펜스)은 호버 시 드러나는
+// 코너 버튼. inline/block 판별은 doc-content-renderer.tsx의 기존 검증된 휴리스틱과 동일
+// (className에 language- 없음 + 개행 없음 = inline) — 팀 컨벤션 재사용.
+function CopyableCode({ raw, inline, className }: { raw: string; inline: boolean; className: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    void (async () => {
+      try {
+        if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(raw);
+        } else {
+          return;
+        }
+      } catch {
+        return; // 클립보드 권한거부/미지원 — 조용히 무시(피드백 미표시로 실패가 드러남)
+      }
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    })();
+  }, [raw]);
+
+  if (inline) {
+    return (
+      <code
+        role="button"
+        tabIndex={0}
+        onClick={handleCopy}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleCopy(); } }}
+        title={copied ? '복사됨' : '클릭해 복사'}
+        className={`${className} cursor-pointer transition hover:brightness-95 active:brightness-90`}
+      >
+        {raw}
+        {copied && <Check className="ml-0.5 inline size-3 align-text-top" aria-hidden />}
+      </code>
+    );
+  }
+
+  return (
+    <span className="group/code relative block">
+      <code className={className}>{raw}</code>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={copied ? '복사됨' : '코드 복사'}
+        title={copied ? '복사됨' : '코드 복사'}
+        className="absolute right-1 top-1 rounded p-1 opacity-60 transition hover:bg-black/10 group-hover/code:opacity-100 dark:hover:bg-white/10"
+      >
+        {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+      </button>
+    </span>
+  );
+}
+
 function ChatMarkdown({ content, isMine }: { content: string; isMine: boolean }) {
   const text = isMine ? 'text-primary-foreground' : 'text-foreground';
   const muted = isMine ? 'text-primary-foreground/70' : 'text-muted-foreground';
@@ -69,7 +123,17 @@ function ChatMarkdown({ content, isMine }: { content: string; isMine: boolean })
         p: ({ children }) => <p className={`mb-1.5 [overflow-wrap:anywhere] text-sm leading-relaxed last:mb-0 ${text}`}>{children}</p>,
         strong: ({ children }) => <strong className={`font-semibold ${text}`}>{children}</strong>,
         em: ({ children }) => <em className={`italic ${text}`}>{children}</em>,
-        code: ({ children }) => <code className={`rounded px-1 py-0.5 font-mono text-xs [overflow-wrap:anywhere] ${codeBg}`}>{children}</code>,
+        code: ({ className, children }) => {
+          const raw = String(children).replace(/\n$/, '');
+          const inline = !className?.includes('language-') && !raw.includes('\n');
+          return (
+            <CopyableCode
+              raw={raw}
+              inline={inline}
+              className={`rounded px-1 py-0.5 font-mono text-xs [overflow-wrap:anywhere] ${codeBg}`}
+            />
+          );
+        },
         pre: ({ children }) => <pre className={`mb-1.5 overflow-x-auto rounded-lg p-2.5 text-xs ${codeBg}`}>{children}</pre>,
         ul: ({ children }) => <ul className={`mb-1.5 ml-4 list-disc space-y-0.5 text-sm ${text}`}>{children}</ul>,
         ol: ({ children }) => <ol className={`mb-1.5 ml-4 list-decimal space-y-0.5 text-sm ${text}`}>{children}</ol>,


### PR DESCRIPTION
## 요약
선생님 실사용 제안(API키·명령어·ID 등 code span 원클릭 복사). `chat-bubble.tsx` `ChatMarkdown`에 `CopyableCode` 컴포넌트 신설:
- inline code(단일 백틱): 클릭 즉시 `navigator.clipboard.writeText` + 체크 아이콘 피드백. 키보드(Enter/Space) 접근성 포함.
- fence 코드(멀티라인): 코너에 항상 은은히 보이는 복사 버튼(모바일 터치 친화, 호버 시 또렷)+Copy/Check 토글.
- inline/block 판별은 `doc-content-renderer.tsx`가 이미 쓰던 휴리스틱 재사용(`className`에 `language-` 없음 + 개행 없음 = inline).
- 클립보드 미지원/권한거부는 조용히 무시(에러 UI 없음, 피드백 미표시로 실패가 자연히 드러남).

## 스크린샷 (격리 스택 실렌더)
- 데스크톱: inline code 파란 배경 pill + fence 블록 코너 복사 아이콘
- 다크테마: 동일 렌더, 대비 확인
- 모바일(390px): fence 코너 버튼 항상 반투명 노출(터치 발견성)

## 반응형 확인
데스크톱 1280px / 모바일 390px 둘 다 확인. 레이아웃 변경 없음(기존 code/pre 스타일 유지, 클릭 핸들러+아이콘만 additive).

## 실증
`navigator.clipboard.writeText` 몽키패치로 실제 클릭 이벤트 후 호출 인자 검증:
- inline: `"sk-live-abc123"` 정확 일치
- fence: 멀티라인 원문(`npm install ...\nnpm run deploy`) 개행 보존 일치

## 게이트
- tsc 0 error
- lint 0 error (기존 무관 warning 5건)
- vitest 257 files / 1712 passed
- build success

🤖 Generated with [Claude Code](https://claude.com/claude-code)