### PR TITLE
[SID:2000] loading=finally 하우스룰 위반 전수 소탕

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -566,6 +566,7 @@
     "skip": "Skip",
     "stepOf": "{current} / {total}",
     "createOrgFailed": "Failed to create organization",
+    "networkError": "Network error — please check your connection and try again",
     "apiKeyFailedMembers": "API key generation failed. Go to Settings > Members > Agents to issue one manually.",
     "goToMembersAgents": "Manage in Members > Agents",
     "copyConfig": "Copy",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -566,6 +566,7 @@
     "skip": "건너뛰기",
     "stepOf": "{current} / {total}",
     "createOrgFailed": "조직 생성에 실패했습니다",
+    "networkError": "네트워크 오류 — 연결을 확인하고 다시 시도해 주세요",
     "apiKeyFailedMembers": "API Key 발급에 실패했습니다. Settings > Members > Agents에서 수동으로 발급하세요.",
     "goToMembersAgents": "Members > Agents에서 관리하기",
     "copyConfig": "복사",

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -67,26 +67,33 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
     setLoading(true);
     setError('');
 
-    const res = await fetch('/api/organizations', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: orgName.trim(), slug: orgSlug.trim() }),
-    });
-    const json = await res.json();
+    // story #2000: 아래 fetch/json 파싱이 네트워크 단에서 throw하면(오프라인 등) try 없이는
+    // setLoading(false)가 영영 안 불려 폼이 영구 로딩으로 멈춘다(온보딩 진입 자체를 막는 심각한
+    // 케이스) — try/catch/finally로 봉합, 기존 error 상태를 그대로 재사용.
+    try {
+      const res = await fetch('/api/organizations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: orgName.trim(), slug: orgSlug.trim() }),
+      });
+      const json = await res.json();
 
-    if (!res.ok) {
-      setError(json?.error?.message ?? t('createOrgFailed'));
+      if (!res.ok) {
+        setError(json?.error?.message ?? t('createOrgFailed'));
+        return;
+      }
+
+      setOrgId(json.data.id);
+      // E-ONB S5 FINAL: org 생성 시 org_member가 최초 생성됨 → 즉시 토큰 refresh로
+      // 새 JWT에 org_id(BE auth Path4 org_member fallback) 반영. 이래야 다음 단계 project 생성의
+      // getAuthContext(/api/v2/me)가 통과한다(미refresh 시 fresh JWT엔 team_member 없어 me null → 401).
+      await fetch('/api/auth/refresh', { method: 'POST' }).catch(() => null);
+      setStep('project');
+    } catch {
+      setError(t('networkError'));
+    } finally {
       setLoading(false);
-      return;
     }
-
-    setOrgId(json.data.id);
-    // E-ONB S5 FINAL: org 생성 시 org_member가 최초 생성됨 → 즉시 토큰 refresh로
-    // 새 JWT에 org_id(BE auth Path4 org_member fallback) 반영. 이래야 다음 단계 project 생성의
-    // getAuthContext(/api/v2/me)가 통과한다(미refresh 시 fresh JWT엔 team_member 없어 me null → 401).
-    await fetch('/api/auth/refresh', { method: 'POST' }).catch(() => null);
-    setStep('project');
-    setLoading(false);
   };
 
   // E-ONB S5: 온보딩 완료 후 /dashboard 이동 전 토큰 refresh.
@@ -102,50 +109,52 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
     setLoading(true);
     setError('');
 
-    // E-ONB S5 FINAL: org 생성 직후 refresh(handleCreateOrg)로 JWT에 org_id 반영됨 → X-Org-Id 불요(제거).
-    const res = await fetch('/api/projects', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ org_id: orgId, name: projectName.trim(), description: projectDesc.trim() || null }),
-    });
-    const json = await res.json();
+    try {
+      // E-ONB S5 FINAL: org 생성 직후 refresh(handleCreateOrg)로 JWT에 org_id 반영됨 → X-Org-Id 불요(제거).
+      const res = await fetch('/api/projects', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ org_id: orgId, name: projectName.trim(), description: projectDesc.trim() || null }),
+      });
+      const json = await res.json();
 
-    if (!res.ok) {
-      if (json?.error?.code === 'UPGRADE_REQUIRED') {
-        setUpgradeReason(json.error.message);
-        setShowUpgrade(true);
-        setLoading(false);
+      if (!res.ok) {
+        if (json?.error?.code === 'UPGRADE_REQUIRED') {
+          setUpgradeReason(json.error.message);
+          setShowUpgrade(true);
+          return;
+        }
+        setError(json?.error?.message ?? t('createProjectFailed'));
         return;
       }
-      setError(json?.error?.message ?? t('createProjectFailed'));
+
+      const project = json.data;
+      if (!project) {
+        setError(t('createProjectFailed'));
+        return;
+      }
+
+      setProjectId(project.id);
+
+      // 휴먼 members 앵커는 BE가 org/project 생성 시 ensure_human_member로 보장한다(#1317 휴먼판).
+      // 과거 여기서 호출하던 /api/team-members(type=human) POST는 410 Gone(데드 경로)이라 제거.
+
+      await fetch('/api/current-project', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ project_id: project.id }),
+      }).catch(() => null);
+
+      if (initialStep === 'project') {
+        await finishToDashboard();
+        return;
+      }
+      setStep('agent');
+    } catch {
+      setError(t('networkError'));
+    } finally {
       setLoading(false);
-      return;
     }
-
-    const project = json.data;
-    if (!project) {
-      setError(t('createProjectFailed'));
-      setLoading(false);
-      return;
-    }
-
-    setProjectId(project.id);
-
-    // 휴먼 members 앵커는 BE가 org/project 생성 시 ensure_human_member로 보장한다(#1317 휴먼판).
-    // 과거 여기서 호출하던 /api/team-members(type=human) POST는 410 Gone(데드 경로)이라 제거.
-
-    await fetch('/api/current-project', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ project_id: project.id }),
-    }).catch(() => null);
-
-    if (initialStep === 'project') {
-      await finishToDashboard();
-      return;
-    }
-    setStep('agent');
-    setLoading(false);
   };
 
   const handleCreateAgent = async () => {
@@ -153,40 +162,43 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
     setLoading(true);
     setError('');
 
-    const memberRes = await fetch('/api/team-members', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        org_id: orgId,
-        project_id: projectId,
-        type: 'agent',
-        name: agentName.trim(),
-        role: agentRole,
-      }),
-    });
-    const memberJson = await memberRes.json() as { data?: { id: string; api_key?: string }; error?: { message?: string } };
-    if (!memberRes.ok) {
-      setError(memberJson?.error?.message ?? 'Failed to create agent');
+    try {
+      const memberRes = await fetch('/api/team-members', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          org_id: orgId,
+          project_id: projectId,
+          type: 'agent',
+          name: agentName.trim(),
+          role: agentRole,
+        }),
+      });
+      const memberJson = await memberRes.json() as { data?: { id: string; api_key?: string }; error?: { message?: string } };
+      if (!memberRes.ok) {
+        setError(memberJson?.error?.message ?? 'Failed to create agent');
+        return;
+      }
+
+      const newAgentId = memberJson.data?.id;
+      if (!newAgentId) {
+        setError('Failed to create agent');
+        return;
+      }
+      setAgentId(newAgentId);
+
+      // 에이전트 생성 응답에 이미 plaintext api_key가 포함됨(BE team_members.py: type=agent 생성 시 항상 발급).
+      // 별도 발급 호출(POST /api/agents/{id}/api-key)은 BE가 body 필수라 빈 본문 시 422 → 응답 키를 그대로 사용.
+      if (memberJson.data?.api_key) {
+        setNewApiKey(memberJson.data.api_key);
+      }
+
+      setStep('connect');
+    } catch {
+      setError(t('networkError'));
+    } finally {
       setLoading(false);
-      return;
     }
-
-    const newAgentId = memberJson.data?.id;
-    if (!newAgentId) {
-      setError('Failed to create agent');
-      setLoading(false);
-      return;
-    }
-    setAgentId(newAgentId);
-
-    // 에이전트 생성 응답에 이미 plaintext api_key가 포함됨(BE team_members.py: type=agent 생성 시 항상 발급).
-    // 별도 발급 호출(POST /api/agents/{id}/api-key)은 BE가 body 필수라 빈 본문 시 422 → 응답 키를 그대로 사용.
-    if (memberJson.data?.api_key) {
-      setNewApiKey(memberJson.data.api_key);
-    }
-
-    setStep('connect');
-    setLoading(false);
   };
 
   const handleFinish = () => {

--- a/apps/web/src/components/activity/activity-log-view.tsx
+++ b/apps/web/src/components/activity/activity-log-view.tsx
@@ -78,6 +78,7 @@ export function ActivityLogView({ projectId }: ActivityLogViewProps) {
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [forbidden, setForbidden] = useState(false);
+  const [loadError, setLoadError] = useState(false);
 
   const [actorFilter, setActorFilter] = useState(ALL);
   const [actionFilter, setActionFilter] = useState(ALL);
@@ -122,18 +123,28 @@ export function ActivityLogView({ projectId }: ActivityLogViewProps) {
     [buildParams],
   );
 
+  // story #2000: fetchLogs 내부 raw fetch가 네트워크 단에서 throw하면(오프라인 등) try 없이
+  // setLoading(false)가 영영 안 불려 스켈레톤이 무한행 — 세 진입점(load/loadMore/reload)
+  // 모두 try/catch/finally로 봉합, 기존 forbidden 패턴과 동형으로 loadError 상태+reload 재사용.
+
   // reset + reload on filter change
   useEffect(() => {
     let cancelled = false;
     async function load() {
       setLoading(true);
       setForbidden(false);
+      setLoadError(false);
       setOffset(0);
-      const result = await fetchLogs(0);
-      if (cancelled) return;
-      setItems(result?.items ?? []);
-      setTotal(result?.total ?? 0);
-      setLoading(false);
+      try {
+        const result = await fetchLogs(0);
+        if (cancelled) return;
+        setItems(result?.items ?? []);
+        setTotal(result?.total ?? 0);
+      } catch {
+        if (!cancelled) setLoadError(true);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
     }
     void load();
     return () => { cancelled = true; };
@@ -142,24 +153,34 @@ export function ActivityLogView({ projectId }: ActivityLogViewProps) {
   const loadMore = async () => {
     const nextOffset = offset + PAGE_SIZE;
     setLoadingMore(true);
-    const result = await fetchLogs(nextOffset);
-    if (result) {
-      setItems((prev) => [...prev, ...result.items]);
-      setOffset(nextOffset);
-      setTotal(result.total);
+    try {
+      const result = await fetchLogs(nextOffset);
+      if (result) {
+        setItems((prev) => [...prev, ...result.items]);
+        setOffset(nextOffset);
+        setTotal(result.total);
+      }
+    } catch {
+      // 더보기 실패는 조용히 두고 버튼을 그대로 남겨(재클릭으로 재시도 가능).
+    } finally {
+      setLoadingMore(false);
     }
-    setLoadingMore(false);
   };
 
-  const reload = () => {
+  const reload = async () => {
     setForbidden(false);
+    setLoadError(false);
     setLoading(true);
     setOffset(0);
-    fetchLogs(0).then((result) => {
+    try {
+      const result = await fetchLogs(0);
       setItems(result?.items ?? []);
       setTotal(result?.total ?? 0);
+    } catch {
+      setLoadError(true);
+    } finally {
       setLoading(false);
-    });
+    }
   };
 
   // ─── Dropdown options ──────────────────────────────────────────────────────
@@ -232,6 +253,19 @@ export function ActivityLogView({ projectId }: ActivityLogViewProps) {
           {forbidden ? (
             <div className="flex h-64 items-center justify-center">
               <EmptyState title={t('forbiddenTitle')} description={t('forbiddenDescription')} />
+            </div>
+          ) : loadError ? (
+            <div className="flex h-64 items-center justify-center">
+              <EmptyState
+                title={tc('error')}
+                description={tc('errorDescription')}
+                action={
+                  <Button variant="glass" size="sm" onClick={reload}>
+                    <RefreshCw className="mr-1.5 size-3.5" />
+                    {tc('retry')}
+                  </Button>
+                }
+              />
             </div>
           ) : loading ? (
             <div className="space-y-1.5">

--- a/apps/web/src/components/agents/agent-runs-list.tsx
+++ b/apps/web/src/components/agents/agent-runs-list.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
-import { Activity, ChevronDown, Clock3, Cpu, Hash, Zap } from 'lucide-react';
+import { Activity, ChevronDown, Clock3, Cpu, Hash, RotateCw, Zap } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -104,6 +104,8 @@ export function AgentRunsList() {
 
   const [runs, setRuns] = useState<AgentRun[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [retryKey, setRetryKey] = useState(0);
   const [statusFilter, setStatusFilter] = useState(DEFAULT_RUN_STATUS_FILTER);
   const [{ fromDate: initialFromDate, toDate: initialToDate }] = useState(() => getDefaultRunDateFilters());
   const [fromDate, setFromDate] = useState(initialFromDate);
@@ -131,28 +133,42 @@ export function AgentRunsList() {
     };
   }, [statusFilter, fromDate, toDate]);
 
+  // story #2000: 원 raw fetch가 네트워크 단에서 throw하면(오프라인 등) try 없이 setLoading(false)가
+  // 영영 안 불려 스켈레톤이 무한행 — try/catch/finally + loadError/retryKey로 봉합(D #1989 패턴).
   useEffect(() => {
     let cancelled = false;
     async function load() {
       setLoading(true);
+      setLoadError(false);
       setSelectedRunId(null);
-      const result = await fetchRuns();
-      if (cancelled) return;
-      setRuns(result.items);
-      setNextCursor(result.nextCursor);
-      setLoading(false);
+      try {
+        const result = await fetchRuns();
+        if (cancelled) return;
+        setRuns(result.items);
+        setNextCursor(result.nextCursor);
+      } catch {
+        if (!cancelled) setLoadError(true);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
     }
     void load();
     return () => { cancelled = true; };
-  }, [fetchRuns]);
+  }, [fetchRuns, retryKey]);
 
   const loadMore = async () => {
     if (!nextCursor) return;
     setLoadingMore(true);
-    const result = await fetchRuns(nextCursor);
-    setRuns((prev) => [...prev, ...result.items]);
-    setNextCursor(result.nextCursor);
-    setLoadingMore(false);
+    try {
+      const result = await fetchRuns(nextCursor);
+      setRuns((prev) => [...prev, ...result.items]);
+      setNextCursor(result.nextCursor);
+    } catch {
+      // 더보기 실패는 조용히 두고 버튼을 그대로 남겨(재클릭으로 재시도 가능) — 이미 로드된
+      // runs 목록은 유지, 별도 에러 UI 없이도 재시도 affordance가 버튼 자체로 성립.
+    } finally {
+      setLoadingMore(false);
+    }
   };
 
   if (selectedRunId) {
@@ -211,6 +227,15 @@ export function AgentRunsList() {
               {[1, 2, 3, 4, 5].map((i) => (
                 <div key={i} className="h-20 animate-pulse rounded-md bg-muted" />
               ))}
+            </div>
+          ) : loadError ? (
+            <div className="flex flex-col items-center gap-3 py-12 text-center">
+              <p className="text-sm font-medium text-foreground">{tc('error')}</p>
+              <p className="text-xs text-muted-foreground">{tc('errorDescription')}</p>
+              <Button variant="glass" size="sm" onClick={() => setRetryKey((k) => k + 1)}>
+                <RotateCw className="mr-1.5 size-3.5" />
+                {tc('retry')}
+              </Button>
             </div>
           ) : runs.length === 0 ? (
             <EmptyState title={t('emptyTitle')} description={t('emptyDescription')} />


### PR DESCRIPTION
## 요약
D(#1989)가 봉합한 2곳 이후, 같은 패턴(`setLoading(true)` 직후 try 부재 → 네트워크 실패 시 로딩 스켈레톤 무한)이 더 있는지 47개 파일 전수 grep 후 검증.

**grep만으론 오탐이 많았다** — 다수 파일이 내부 `fetchJson` 래퍼(자체 try/catch, 절대 throw 안 함)나 `.catch(()=>null)` 패턴으로 이미 안전(artifact-gallery-view.tsx·story-picker-dialog.tsx·attention-queue-view.tsx·use-ai-summarize.ts 등). "1-finally" 그룹도 스팟체크로 기존 finally가 정확히 해당 setLoading을 커버함을 확인.

**실제 확定된 위반 3개 파일(8개 호출부)**만 fix:
- `onboarding-form.tsx`: 3개 핸들러(조직/프로젝트/에이전트 생성) — 온보딩 진입 자체를 막을 수 있는 심각한 케이스. networkError i18n 키 신설.
- `agent-runs-list.tsx`: load/loadMore 2곳 — D 패턴(loadError+retryKey) 재사용.
- `activity-log-view.tsx`: load/loadMore/reload 3곳 — 기존 forbidden 상태 동형 확장, 기존 reload() 재사용(신규 UI 0).

## 반응형 확인
데스크톱만 관련(로딩/에러 상태 표면, 모바일 레이아웃 변경 없음).

## 실증 (격리 스택, `window.fetch` 몽키패치로 대상 엔드포인트만 reject 주입)
3개 표면 전부: 스켈레톤 무한 0 · 에러 UI("문제가 발생했습니다"/"다시 시도") 정상 노출 → fetch 원복 후 재시도 클릭 → 정상 데이터 로드 확인. onboarding-form은 org 생성 단계에서 재현+happy path 회귀 없음까지 확인.

## 게이트
- tsc 0 error
- lint 0 error (기존 무관 warning 5건)
- vitest 257 files / 1713 passed
- build success

🤖 Generated with [Claude Code](https://claude.com/claude-code)