### PR TITLE
story #2009: GET /conversations/{id} participants 필드 — FE 30건 캡 workaround 버그 제거

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy import and_, func, select, text, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -326,6 +326,49 @@ def _total_unread_count_stmt(member_id: uuid.UUID):
     """
     per_conv = _list_unread_counts_stmt(member_id).subquery()
     return select(func.coalesce(func.sum(per_conv.c.unread_count), 0))
+
+
+async def _fetch_conversation_participants(
+    conv_ids: list[uuid.UUID],
+    db: AsyncSession,
+) -> dict[uuid.UUID, list[dict]]:
+    """story #2009: conversation(들)의 participants 배치 조회 — list_conversations의 기존
+    N+1 방지 배치 로직을 단건(`get_conversation`)에서도 재사용하도록 추출(로직 복제 금지, AC).
+
+    반환 dict shape는 두 엔드포인트가 항상 동일 JSON을 내려주도록 고정:
+    `{"member_id", "name", "avatar_url", "type", "runtime_type"}` (list_conversations의
+    participants 항목과 byte-identical — FE 파싱 일관성).
+    """
+    if not conv_ids:
+        return {}
+
+    p_rows = (await db.execute(
+        select(ConversationParticipant.conversation_id, ConversationParticipant.member_id)
+        .where(ConversationParticipant.conversation_id.in_(conv_ids))
+    )).all()
+
+    all_member_ids = {r.member_id for r in p_rows}
+    resolved_map = await lookup_members_by_ids(all_member_ids, db) if all_member_ids else {}
+
+    # E-CHAT-CMD S8b: participant 의 runtime_type 노출(team_members 뷰서 read — 에이전트만 값, 휴먼 NULL).
+    runtime_type_map: dict[uuid.UUID, str | None] = {}
+    if all_member_ids:
+        rt_rows = (await db.execute(
+            select(TeamMember.id, TeamMember.runtime_type).where(TeamMember.id.in_(all_member_ids))
+        )).all()
+        runtime_type_map = {r.id: r.runtime_type for r in rt_rows}
+
+    conv_participants: dict[uuid.UUID, list[dict]] = defaultdict(list)
+    for r in p_rows:
+        resolved = resolved_map.get(r.member_id)
+        conv_participants[r.conversation_id].append({
+            "member_id": str(r.member_id),
+            "name": resolved.name if resolved else str(r.member_id)[:8],
+            "avatar_url": getattr(resolved, "avatar_url", None) if resolved else None,
+            "type": resolved.type if resolved else "human",
+            "runtime_type": runtime_type_map.get(r.member_id),
+        })
+    return conv_participants
 
 
 _SUMMARY_PREVIEW_MAX = 80
@@ -687,6 +730,9 @@ class ConversationResponse(BaseModel):
     # 파생 unread_count. 비참여자(admin-bypass agent-only 대화)는 last_read_at=None·unread_count=0.
     last_read_at: datetime | None = None
     unread_count: int = 0
+    # story #2009: list_conversations와 동일 shape의 participants(재사용, 로직 복제 금지 — AC).
+    # dict 그대로 노출(별도 Pydantic 서브모델 미도입) — list 엔드포인트와 byte-identical JSON 보장.
+    participants: list[dict] = Field(default_factory=list)
 
 
 # E-FILE S1: 채팅 첨부. GCS 기록은 FE-proxy(uploadToGcs)가 처리하고 BE는 URL+메타만 저장.
@@ -931,35 +977,9 @@ async def list_conversations(
         .limit(limit).offset(offset)
     )).scalars().all()
 
-    # participants 배치 조회 (N+1 방지)
+    # participants 배치 조회 (N+1 방지) — story #2009: get_conversation과 공유하는 헬퍼로 추출.
     conv_id_list = [c.id for c in convs]
-    p_rows = (await db.execute(
-        select(ConversationParticipant.conversation_id, ConversationParticipant.member_id)
-        .where(ConversationParticipant.conversation_id.in_(conv_id_list))
-    )).all()
-
-    all_member_ids = {r.member_id for r in p_rows}
-    resolved_map = await lookup_members_by_ids(all_member_ids, db) if all_member_ids else {}
-
-    # E-CHAT-CMD S8b: participant 의 runtime_type 노출(team_members 뷰서 read — 에이전트만 값, 휴먼 NULL).
-    # S8 composer 가 미지원 런타임 에이전트 pre-send 경고를 그리려면 participant 응답에 runtime_type 필요.
-    runtime_type_map: dict[uuid.UUID, str | None] = {}
-    if all_member_ids:
-        rt_rows = (await db.execute(
-            select(TeamMember.id, TeamMember.runtime_type).where(TeamMember.id.in_(all_member_ids))
-        )).all()
-        runtime_type_map = {r.id: r.runtime_type for r in rt_rows}
-
-    conv_participants: dict[uuid.UUID, list[dict]] = defaultdict(list)
-    for r in p_rows:
-        resolved = resolved_map.get(r.member_id)
-        conv_participants[r.conversation_id].append({
-            "member_id": str(r.member_id),
-            "name": resolved.name if resolved else str(r.member_id)[:8],
-            "avatar_url": getattr(resolved, "avatar_url", None) if resolved else None,
-            "type": resolved.type if resolved else "human",
-            "runtime_type": runtime_type_map.get(r.member_id),
-        })
+    conv_participants = await _fetch_conversation_participants(conv_id_list, db)
 
     # story #1976: unread_count 배치 — 단일 JOIN+GROUP BY(N+1 방지, §4-2). INNER JOIN이라
     # unread=0 대화는 결과행 없음 → dict.get(id, 0)으로 자연 0 처리.
@@ -1073,13 +1093,31 @@ async def get_conversation(
             ConversationParticipant.member_id == sender.id,
         )
     )).one_or_none()
-    resp = ConversationResponse.model_validate(conv)
+    # story #2009: `ConversationResponse.model_validate(conv)`(from_attributes) 대신 필드별
+    # 명시 구성 — `Conversation.participants`는 SQLAlchemy 관계(lazy="select")라 동명의
+    # Pydantic 필드를 자동추출 시도하면 sync getattr가 비동기 세션 lazy-load를 트리거해
+    # `MissingGreenlet`으로 500(신규 필드 도입 시 실측 발견). 배치 헬퍼 결과로 아래서 명시 대입.
+    resp = ConversationResponse(
+        id=conv.id,
+        project_id=conv.project_id,
+        org_id=conv.org_id,
+        type=conv.type,
+        title=conv.title,
+        status=conv.status,
+        created_by=conv.created_by,
+        created_at=conv.created_at,
+        updated_at=conv.updated_at,
+    )
     resp.muted = caller_row is not None and caller_row.muted_at is not None
     if caller_row is not None:
         resp.last_read_at = caller_row.last_read_at
         resp.unread_count = (await db.execute(
             _unread_count_stmt(conversation_id, sender.id, caller_row.last_read_at)
         )).scalar_one()
+    # story #2009: 단건 조회도 list_conversations와 동일 participants shape을 자체 포함 —
+    # FE가 30건 캡 있는 list 엔드포인트에 기대던 workaround(.find() miss 버그) 제거.
+    participants_map = await _fetch_conversation_participants([conversation_id], db)
+    resp.participants = participants_map.get(conversation_id, [])
     return resp
 
 

--- a/backend/tests/test_2009_conversation_detail_participants_realdb.py
+++ b/backend/tests/test_2009_conversation_detail_participants_realdb.py
@@ -1,0 +1,375 @@
+"""story #2009 — GET /api/v2/conversations/{id} participants 필드 realPG 통합 테스트.
+
+배경: list_conversations(GET /conversations?project_id=...)는 participants를 배치 조회해
+내려주지만, 단건 get_conversation(GET /conversations/{id})은 그 필드가 없었다. FE는 이를
+list 엔드포인트(default limit=30, updated_at desc)를 호출해 client-side `.find()`로 우회
+했는데, org 대화가 30건을 넘고 열람 대상이 최근 30건 안에 없으면 `.find()`가 undefined를
+반환해 헤더(title/participants/mute)가 영구 공백으로 렌더링되는 실 버그가 있었다(founder
+계정 92개 대화 — "채팅이 느리다/깨졌다" 제보의 유력 근본원인으로 지목).
+
+본 테스트가 증명하는 것:
+1. **핵심 회귀**: org에 35개+ 대화가 있고, 호출 대상이 top-30-by-updated_at 밖(오래된 대화)
+   이어도 GET /conversations/{id} 단건 호출만으로 participants가 정확히 채워진다(더 이상
+   list 페이지 위치에 의존하지 않음 — FE workaround 제거 가능).
+2. **shape parity**: 같은 대화에 대해 단건 응답의 participants와 list 응답의 participants
+   항목이 완전히 동일(추출 리팩터가 두 엔드포인트 간 드리프트를 만들지 않았음 실증).
+3. **엣지 케이스**: human+agent 혼합 참가자(type/runtime_type 분기), 그리고 caller 단독
+   참가자(추가 participant 0명)인 대화.
+
+`_fetch_conversation_participants` 헬퍼(list_conversations의 기존 배치 로직을 추출한 것)를
+get_conversation이 호출하도록 한 리팩터 + `ConversationResponse.participants` 신규 필드를
+검증한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+T0 = datetime(2026, 7, 17, 8, 0, 0, tzinfo=timezone.utc)
+
+
+def _t(minutes: int) -> datetime:
+    return T0 + timedelta(minutes=minutes)
+
+
+async def _make_org_project_member(session, *, name: str = "Me"):
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    user_id = uuid.uuid4()
+    session.add(User(id=user_id, email=f"me-{user_id.hex[:8]}@test.com", hashed_password="x"))
+    await session.commit()
+    me = Member(id=uuid.uuid4(), org_id=org.id, type="human", user_id=user_id, name=name)
+    session.add(me)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=me.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {"org": org, "project": project, "user_id": user_id, "member": me}
+
+
+async def _make_human_member(session, org_id, project_id, *, name: str):
+    from app.models.member import Member
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    session.add(User(id=user_id, email=f"{name}-{user_id.hex[:8]}@test.com", hashed_password="x"))
+    await session.commit()
+    m = Member(id=uuid.uuid4(), org_id=org_id, type="human", user_id=user_id, name=name)
+    session.add(m)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_id, member_id=m.id, permission="granted", role="member",
+    ))
+    await session.commit()
+    return m
+
+
+async def _make_agent_member(session, org_id, project_id, *, name: str, runtime_type: str | None = "claude_code"):
+    from app.models.member import Member
+    from app.models.project_access import ProjectAccess
+
+    a = Member(
+        id=uuid.uuid4(), org_id=org_id, type="agent", name=name,
+        runtime_type=runtime_type, is_active=True,
+    )
+    session.add(a)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_id, member_id=a.id, permission="granted", role="member",
+    ))
+    await session.commit()
+    return a
+
+
+async def _make_conversation(session, org_id, project_id, *, title, created_by, updated_at, participant_ids):
+    from app.models.conversation import Conversation, ConversationParticipant
+
+    conv = Conversation(
+        id=uuid.uuid4(), project_id=project_id, org_id=org_id, type="group",
+        title=title, created_by=created_by,
+    )
+    session.add(conv)
+    await session.flush()
+    for pid in participant_ids:
+        session.add(ConversationParticipant(conversation_id=conv.id, member_id=pid))
+    await session.commit()
+
+    # updated_at은 server_default(now())라 seed 후 명시 override — 최신순 정렬 시나리오 구성용.
+    from sqlalchemy import update as sa_update
+    await session.execute(
+        sa_update(Conversation).where(Conversation.id == conv.id).values(updated_at=updated_at)
+    )
+    await session.commit()
+    return conv
+
+
+# ─── 1. 핵심 회귀: 30건 경계 밖 대화도 단건 조회에 participants가 채워진다 ────
+
+@pytest.mark.anyio
+async def test_get_conversation_beyond_top30_boundary_has_participants():
+    """org에 35개 대화(caller가 전부 참여) 시드 — 가장 오래된(=updated_at 최솟값=list 정렬상
+    30번째보다 뒤) 대화 하나를 골라 단건 조회. 과거엔 FE가 list(limit=30, desc)에서 이걸
+    못 찾아 참가자를 영영 못 봤다(undefined). 지금은 단건 엔드포인트 자체가 participants를
+    포함하므로 list 페이지 위치와 무관하게 정확한 값이 와야 한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            ctx = await _make_org_project_member(s, name="Me")
+            other = await _make_human_member(s, ctx["org"].id, ctx["project"].id, name="Other")
+
+            convs = []
+            for i in range(35):
+                # updated_at 내림차순 = i가 클수록 최신. i=0이 가장 오래됨(=top-30 밖으로 밀림).
+                conv = await _make_conversation(
+                    s, ctx["org"].id, ctx["project"].id,
+                    title=f"Conv {i}", created_by=ctx["member"].id,
+                    updated_at=_t(i),
+                    participant_ids=[ctx["member"].id, other.id],
+                )
+                convs.append(conv)
+
+        # convs[0]이 가장 오래됨(updated_at=_t(0)) → desc 정렬 시 35개 중 인덱스 34(맨 끝),
+        # limit=30 기본 페이지에는 절대 안 들어옴(31~35번째 대화 밖).
+        target = convs[0]
+
+        await _setup_app_human(app, Session, ctx["user_id"], ctx["org"].id)
+        client = _client_for(app)
+        try:
+            # 사전 확인: 기본 limit=30 list에는 target이 없다(경계 시나리오 실측).
+            list_resp = await client.get(
+                "/api/v2/conversations", params={"project_id": str(ctx["project"].id)},
+            )
+            assert list_resp.status_code == 200, list_resp.text
+            list_ids = {item["id"] for item in list_resp.json()["data"]}
+            assert len(list_resp.json()["data"]) == 30
+            assert str(target.id) not in list_ids, (
+                "테스트 전제 붕괴: target이 top-30 안에 있음 — 경계 시나리오가 재현 안 됨"
+            )
+
+            # 본 fix 검증: 단건 조회만으로 participants가 채워져야 한다.
+            resp = await client.get(f"/api/v2/conversations/{target.id}")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["id"] == str(target.id)
+            assert "participants" in body
+            participant_ids_in_resp = {p["member_id"] for p in body["participants"]}
+            assert participant_ids_in_resp == {str(ctx["member"].id), str(other.id)}, body["participants"]
+            assert len(body["participants"]) == 2
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── 2. shape parity: 단건 vs list 항목이 완전히 동일 ────────────────────────
+
+@pytest.mark.anyio
+async def test_get_conversation_participants_shape_matches_list_conversations():
+    """대화가 list 페이지(top-30) 안에 있을 때, GET /conversations/{id}의 participants와
+    GET /conversations?project_id=...의 동일 대화 항목 participants가 완전히 동일해야 한다
+    (추출 리팩터가 두 경로 간 드리프트를 만들지 않았음 실증)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            ctx = await _make_org_project_member(s, name="Me")
+            other = await _make_human_member(s, ctx["org"].id, ctx["project"].id, name="Other")
+            agent = await _make_agent_member(
+                s, ctx["org"].id, ctx["project"].id, name="Bot", runtime_type="claude_code",
+            )
+            conv = await _make_conversation(
+                s, ctx["org"].id, ctx["project"].id,
+                title="Parity Conv", created_by=ctx["member"].id,
+                updated_at=_t(0),
+                participant_ids=[ctx["member"].id, other.id, agent.id],
+            )
+
+        await _setup_app_human(app, Session, ctx["user_id"], ctx["org"].id)
+        client = _client_for(app)
+        try:
+            get_resp = await client.get(f"/api/v2/conversations/{conv.id}")
+            assert get_resp.status_code == 200, get_resp.text
+            get_participants = get_resp.json()["participants"]
+
+            list_resp = await client.get(
+                "/api/v2/conversations", params={"project_id": str(ctx["project"].id)},
+            )
+            assert list_resp.status_code == 200, list_resp.text
+            list_item = next(
+                item for item in list_resp.json()["data"] if item["id"] == str(conv.id)
+            )
+            list_participants = list_item["participants"]
+
+            def _by_member_id(rows):
+                return {r["member_id"]: r for r in rows}
+
+            assert _by_member_id(get_participants) == _by_member_id(list_participants), (
+                get_participants, list_participants,
+            )
+            assert len(get_participants) == 3
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── 3. 엣지 케이스: human+agent 혼합 / 참가자 caller 단독(추가 0명) ─────────
+
+@pytest.mark.anyio
+async def test_get_conversation_participants_mixed_human_agent_type_and_runtime_type():
+    """human+agent 혼합 참가자 — type/runtime_type 분기 실증. human은 runtime_type=None,
+    agent는 seed한 runtime_type 값이 그대로 노출돼야 한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            ctx = await _make_org_project_member(s, name="Me")
+            other = await _make_human_member(s, ctx["org"].id, ctx["project"].id, name="Other")
+            agent = await _make_agent_member(
+                s, ctx["org"].id, ctx["project"].id, name="Bot", runtime_type="claude_code",
+            )
+            conv = await _make_conversation(
+                s, ctx["org"].id, ctx["project"].id,
+                title="Mixed Conv", created_by=ctx["member"].id,
+                updated_at=_t(0),
+                participant_ids=[ctx["member"].id, other.id, agent.id],
+            )
+
+        await _setup_app_human(app, Session, ctx["user_id"], ctx["org"].id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/conversations/{conv.id}")
+            assert resp.status_code == 200, resp.text
+            by_id = {p["member_id"]: p for p in resp.json()["participants"]}
+
+            assert by_id[str(ctx["member"].id)]["type"] == "human"
+            assert by_id[str(ctx["member"].id)]["runtime_type"] is None
+            assert by_id[str(other.id)]["type"] == "human"
+            assert by_id[str(other.id)]["runtime_type"] is None
+            assert by_id[str(agent.id)]["type"] == "agent"
+            assert by_id[str(agent.id)]["runtime_type"] == "claude_code"
+            assert by_id[str(agent.id)]["name"] == "Bot"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_conversation_participants_caller_only_no_extra_participants():
+    """caller 단독 참가(추가 participant 0명) 대화 — participants는 caller 자기 자신 1건만
+    (빈 리스트가 아니라 caller 본인 포함 1건)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            ctx = await _make_org_project_member(s, name="Solo")
+            conv = await _make_conversation(
+                s, ctx["org"].id, ctx["project"].id,
+                title="Solo Conv", created_by=ctx["member"].id,
+                updated_at=_t(0),
+                participant_ids=[ctx["member"].id],
+            )
+
+        await _setup_app_human(app, Session, ctx["user_id"], ctx["org"].id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/conversations/{conv.id}")
+            assert resp.status_code == 200, resp.text
+            participants = resp.json()["participants"]
+            assert len(participants) == 1, participants
+            assert participants[0]["member_id"] == str(ctx["member"].id)
+            assert participants[0]["type"] == "human"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_chat_visibility_admin_bypass.py
+++ b/backend/tests/test_chat_visibility_admin_bypass.py
@@ -181,15 +181,37 @@ def _admin_routing_db(*, conv, project_id, participant_member_ids, agent_ids, ad
     - _effective_org_role(OrgMember.role) → admin_role
     - 헬퍼 participant/agent 조회 → human 판별
     - participant 체크 → requester_is_participant
+    - story #2009: get_conversation이 `_fetch_conversation_participants`(participants 배치
+      + lookup_members_by_ids + runtime_type 배치)를 추가로 호출 — 컬럼명 기반으로 정밀 분기.
     """
+    from collections import namedtuple
+
     sender = MagicMock()
     sender.id = uuid.uuid4()
     sender.role = "member"  # raw project role 낮음 — org에서 admin 상속
     sender.type = "human"
     sender.name = "admin user"
 
+    ParticipantRow = namedtuple("ParticipantRow", ["conversation_id", "member_id"])
+    RuntimeTypeRow = namedtuple("RuntimeTypeRow", ["id", "runtime_type"])
+
+    def _resolved_member_mock(mid):
+        m = MagicMock()
+        m.id = mid
+        m.user_id = uuid.uuid4()
+        m.name = f"member-{str(mid)[:8]}"
+        m.type = "agent" if mid in agent_ids else "human"
+        m.role = "member"
+        m.org_id = conv.org_id
+        m.project_id = project_id
+        m.avatar_url = None
+        return m
+
     async def _execute(stmt, *a, **k):
         sql = str(stmt).lower()
+        cols = list(stmt.selected_columns) if hasattr(stmt, "selected_columns") else []
+        col_names = {c.name for c in cols} if cols else set()
+
         # Conversation 단건 조회(participant 테이블 미포함 + conversations FROM)
         if "from conversations" in sql and "conversation_participants" not in sql:
             res = MagicMock()
@@ -199,23 +221,43 @@ def _admin_routing_db(*, conv, project_id, participant_member_ids, agent_ids, ad
             res = MagicMock()
             res.scalar_one_or_none.return_value = admin_role
             return res
-        if "team_members" in sql and "conversation_participants" not in sql:
-            # 두 용도: _resolve_member(sender) 또는 헬퍼 agent 확정
-            if "type" in sql and ("in (" in sql or "in(" in sql):
-                return _scalars_all(list(agent_ids))
-            res = MagicMock()
-            res.scalars.return_value.first.return_value = sender
-            return res
         if "conversation_participants" in sql:
-            cols = stmt.selected_columns if hasattr(stmt, "selected_columns") else None
-            ncols = len(list(cols)) if cols is not None else 1
-            if ncols >= 2:
-                return _rows_all([(conv.id, mid) for mid in participant_member_ids])
-            # 단건: member_id 헬퍼 또는 participant 체크
-            # participant 체크는 scalar_one_or_none 사용 → 별도 분기
+            if col_names == {"conversation_id", "member_id"}:
+                # story #2009: `_fetch_conversation_participants`(및 `_conversations_with_human_
+                # participant`)의 배치 조회 — attribute+tuple 겸용 namedtuple로 실 Row 흉내.
+                return _rows_all([
+                    ParticipantRow(conversation_id=conv.id, member_id=mid)
+                    for mid in participant_member_ids
+                ])
+            if col_names == {"muted_at", "last_read_at"}:
+                # 270c87e6/#1976: caller mute/read-state 조회 — one_or_none() 사용.
+                res = MagicMock()
+                row = MagicMock()
+                row.muted_at = None
+                row.last_read_at = None
+                res.one_or_none.return_value = row if requester_is_participant else None
+                return res
+            # 단건: member_id 헬퍼(1-col) 또는 participant 체크(scalar_one_or_none)
             res = MagicMock()
             res.scalars.return_value.all.return_value = list(participant_member_ids)
             res.scalar_one_or_none.return_value = (uuid.uuid4() if requester_is_participant else None)
+            return res
+        if "team_members" in sql:
+            # 4용도: _resolve_member(sender) / 헬퍼 agent 확정(1-col) /
+            # story #2009 lookup_members_by_ids(full-row) / runtime_type 배치(2-col).
+            if col_names == {"id", "runtime_type"}:
+                return _rows_all([
+                    RuntimeTypeRow(id=mid, runtime_type=("claude_code" if mid in agent_ids else None))
+                    for mid in participant_member_ids
+                ])
+            if col_names == {"id"} and "type" in sql and ("in (" in sql or "in(" in sql):
+                return _scalars_all(list(agent_ids))
+            if "team_members.id in" in sql or "team_members.id in(" in sql:
+                # story #2009: lookup_members_by_ids(전체 컬럼 select, id IN 필터).
+                return _scalars_all([_resolved_member_mock(mid) for mid in participant_member_ids])
+            # _resolve_member: user_id/org_id(/project_id) 등치 필터, id IN 아님.
+            res = MagicMock()
+            res.scalars.return_value.first.return_value = sender
             return res
         res = MagicMock()
         res.scalars.return_value.all.return_value = []

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -412,7 +412,16 @@ async def test_get_conversation_200_returns_project_id():
         muted_result = MagicMock()
         muted_result.one_or_none.return_value = None
 
-        session.execute = AsyncMock(side_effect=[conv_result, member_result, pids_result, agents_result, muted_result])
+        # story #2009: get_conversation이 `_fetch_conversation_participants`(list_conversations와
+        # 공유하는 배치 헬퍼)를 마지막에 1회 더 호출 — participant 행 0건으로 모킹(단순화, 이
+        # 테스트의 검증 대상은 project_id이지 participants shape 자체는 아래 shape parity 테스트가
+        # 커버)하면 후속 lookup_members_by_ids/runtime_type 쿼리도 스킵된다(all_member_ids 공집합).
+        participants_result = MagicMock()
+        participants_result.all.return_value = []
+
+        session.execute = AsyncMock(side_effect=[
+            conv_result, member_result, pids_result, agents_result, muted_result, participants_result,
+        ])
 
         async with client as c:
             resp = await c.get(f"/api/v2/conversations/{CONV_ID}")
@@ -421,6 +430,7 @@ async def test_get_conversation_200_returns_project_id():
         body = resp.json()
         assert body["id"] == str(CONV_ID)
         assert body["project_id"] == str(PROJECT_ID)  # 업로드 path server-side 도출의 근거
+        assert body["participants"] == []
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary

`GET /api/v2/conversations/{id}`(단건 조회)에 `participants` 필드가 없어, FE는 `GET /conversations?project_id=...`(list, 기본 `limit=30`, `updated_at desc`)를 호출해 client-side `.find()`로 우회해왔다. org 대화가 30건을 넘고 열람 대상이 top-30 밖(오래된 대화)이면 `.find()`가 `undefined`를 반환해 대화 헤더(title/participants/mute)가 영구 공백으로 렌더링되는 실 버그가 있었다 — founder 계정 92개 대화, "채팅이 느리다/깨졌다" 제보의 유력 근본원인으로 지목.

- **`_fetch_conversation_participants(conv_ids, db)`** 헬퍼를 신설(`backend/app/routers/conversations.py`, `_total_unread_count_stmt` 바로 아래) — `list_conversations`의 기존 participants 배치 조회(N+1 방지) 로직을 그대로 추출. 로직 복제 없음(AC).
- **`list_conversations`**: 인라인 블록을 헬퍼 호출로 교체 — 순수 리팩터, 행동 무변경(기존 `test_conversations.py` 전체로 회귀 검증).
- **`ConversationResponse`**: `participants: list[dict] = Field(default_factory=list)` 추가 — list 엔드포인트와 동일 dict shape(`member_id`/`name`/`avatar_url`/`type`/`runtime_type`), 별도 서브모델 미도입(FE 파싱 일관성).
- **`get_conversation`**: 헬퍼로 `[conversation_id]` 조회 → `resp.participants` 채움(기존 `resp.muted` 대입 바로 아래).

### 리팩터 중 실측 발견 + 수정
`ConversationResponse.model_validate(conv)`가 `Conversation.participants`(SQLAlchemy 관계, `lazy="select"`)와 신규 Pydantic 필드명이 충돌 — pydantic의 `from_attributes` 자동추출이 sync `getattr(conv, "participants")`를 호출해 비동기 세션에서 lazy-load를 트리거, `MissingGreenlet`으로 500. `get_conversation`을 필드별 명시 `ConversationResponse(...)` 구성으로 전환해 해결(관계 attribute 접근 자체를 회피). realdb 테스트로 실증(수정 전 4개 중 3개 FAIL).

## Scope

이 PR은 위 내용에만 엄격히 한정. 작업 중 발견했으나 **의도적으로 미수정**:
- `get_conversation`의 authz 로직이 canonical `_can_read_conversation`을 재사용하지 않는 별도 추적 중인 기존 갭(스토리 밖) — 손대지 않음.

## Test plan

새 realdb 통합 테스트(`backend/tests/test_2009_conversation_detail_participants_realdb.py`, 실 PG 필요, 4개 모두 PASS):
- `test_get_conversation_beyond_top30_boundary_has_participants` — **핵심 회귀**: org 35개 대화 시드, 기본 `limit=30` list에 없는(top-30 밖) 가장 오래된 대화를 단건 조회해도 participants가 정확히 채워짐을 실증. 사전 조건으로 list 응답에 target이 없음을 먼저 확인(`assert str(target.id) not in list_ids`), 그다음 단건 조회로 `participant_ids_in_resp == {caller, other}` 확인.
- `test_get_conversation_participants_shape_matches_list_conversations` — shape parity: 같은 대화에 대해 단건/list 응답의 participants가 완전히 동일(추출 리팩터가 드리프트를 만들지 않았음).
- `test_get_conversation_participants_mixed_human_agent_type_and_runtime_type` — human+agent 혼합, type/runtime_type 분기.
- `test_get_conversation_participants_caller_only_no_extra_participants` — 추가 participant 0명 엣지 케이스.

기존 mock 기반 테스트 갱신(신규 쿼리/필드 반영, 로직 변경 없음):
- `test_conversations.py::test_get_conversation_200_returns_project_id` — 신규 participants 배치 쿼리 mock 1건 추가.
- `test_chat_visibility_admin_bypass.py::_admin_routing_db` — 컬럼명 기반 정밀 라우팅으로 강화(신규 participants/lookup_members_by_ids/runtime_type 쿼리 지원). 11개 전체 PASS.

전체 회귀: `pytest -q -m "not destructive_schema"` → **4415 passed, 9 failed(모두 pre-existing·본 diff와 무관 — MCP 도구 개수/python 경로 설정·라이브 e2e 로그인 테스트, `conversations` 미참조 확인), 32 skipped, 8 xfailed**.

- [x] 신규 realdb 테스트 4/4 PASS(30건 경계 시나리오 포함)
- [x] `test_conversations.py` 15/15 PASS(list_conversations 행동 불변)
- [x] `test_chat_visibility_admin_bypass.py` 11/11 PASS
- [x] `test_e_security_sec_s8_v_conversation_agent_admin_bypass_realdb.py` 5/5 PASS
- [x] 전체 백엔드 스위트 회귀(pre-existing 실패 9건은 diff 무관 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)