### PR TITLE
[SID:2009] fetchMeta 목록 통호출+.find() → 단독조회 1건 교체 (FE, BE #2286 후속)

### DIFF
--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
@@ -57,24 +57,25 @@ export default function ConversationPage() {
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState('');
 
+  // story #2009: 목록 통호출(`/api/conversations?project_id=`, default limit 30)+client
+  // `.find()` 우회를 폐기 — 대화 1건 메타 보려고 매번 최대30건치 쿼리(latest_message N+1
+  // 포함)를 낭비했고, org 대화가 30건 넘으면 최근 30건 밖 대화를 열 때 `.find()`가 undefined를
+  // 반환해 헤더가 영구 공백이었다(정합성 버그, BE #2286이 단독조회에 participants 추가해 해소).
   const fetchMeta = useCallback(async () => {
     if (!projectId) return;
     try {
-      const res = await fetch(`/api/conversations?project_id=${projectId}`);
+      const res = await fetch(`/api/conversations/${conversation_id}`);
       if (!res.ok) return;
-      const json = await res.json() as {
-        data: Array<{ id: string; title: string | null; type: 'dm' | 'group'; participants?: Participant[]; muted?: boolean; last_read_at?: string | null }>;
+      const conv = await res.json() as {
+        title: string | null; type: 'dm' | 'group'; participants?: Participant[]; muted?: boolean; last_read_at?: string | null;
       };
-      const conv = json.data.find((c) => c.id === conversation_id);
-      if (conv) {
-        setMeta({
-          title: conv.title,
-          type: conv.type,
-          participants: conv.participants ?? [],
-          muted: conv.muted ?? false,
-          lastReadAt: conv.last_read_at ?? null,
-        });
-      }
+      setMeta({
+        title: conv.title,
+        type: conv.type,
+        participants: conv.participants ?? [],
+        muted: conv.muted ?? false,
+        lastReadAt: conv.last_read_at ?? null,
+      });
     } catch { /* non-critical */ }
   }, [conversation_id, projectId]);
 

--- a/apps/web/src/app/api/conversations/[conversation_id]/route.ts
+++ b/apps/web/src/app/api/conversations/[conversation_id]/route.ts
@@ -3,6 +3,13 @@ import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ conversation_id: string }> };
 
+/** GET — 단독 대화 메타 조회(title/type/participants/muted). story #2009: chat 상세 헤더가
+ * 목록 통호출+.find() 대신 이 엔드포인트를 쓰도록 교체(BE #2286에서 participants 추가 완료). */
+export async function GET(request: NextRequest, { params }: RouteParams): Promise<Response> {
+  const { conversation_id } = await params;
+  return proxyToFastapi(request, `/api/v2/conversations/${conversation_id}`);
+}
+
 /** PATCH — edit a conversation (e.g. room title). Thin-proxy to the BE (EF-S2). */
 export async function PATCH(request: NextRequest, { params }: RouteParams): Promise<Response> {
   const { conversation_id } = await params;


### PR DESCRIPTION
## 요약
BE #2286(단독조회 `GET /conversations/{id}`에 `participants` 필드 추가, develop 머지 `704d3c1f`)에 이은 FE 슬라이스.

- FE proxy `api/conversations/[conversation_id]/route.ts`에 GET 핸들러 신설(기존 PATCH만 있었음).
- `chats/[conversation_id]/page.tsx`의 `fetchMeta`를 목록 통호출(`GET /api/conversations?project_id=X`, default `limit=30`)+client `.find()` 우회에서 단독조회 `GET /api/conversations/{conversation_id}` 1건으로 교체.

**수정 전 결함**: 대화 1건 메타(제목·참여자·mute) 보려고 매번 최대 30건치 쿼리(latest_message N+1 포함)를 낭비했고, org 대화가 30건을 넘으면 최근 30건 밖의 대화를 열 때 `.find()`가 `undefined`를 반환해 헤더가 영구 공백으로 렌더링되는 정합성 버그가 있었음 — 선생님 계정(대화 92개) 조건에서 실발현 유력으로 지목됨.

## 반응형 확인
데스크톱만 관련(채팅 상세 헤더, 모바일 레이아웃 변경 없음).

## 실증 (격리 스택)
대화 36건 시드(실 self-DM 1건을 40일 전으로 backdate + 나머지 35건을 더 최근으로 채워 top-30 밖으로 밀어냄):
- `GET /conversations?limit=30`에 대상 미포함 확인
- 해당 대화 직접 진입 → 네트워크 워터폴에 **목록 호출 완전 소거·단독조회 1건만** 확인 → 헤더 "DM" 정상 렌더(수정 전이면 영구 공백이었을 자리)
- top-30 이내 정상 대화(제목 있는 케이스)도 회귀 없이 정상 렌더 확인

## 게이트
- tsc 0 error
- lint 0 error (기존 무관 warning 5건)
- vitest 257 files / 1713 passed
- build success

🤖 Generated with [Claude Code](https://claude.com/claude-code)