### PR TITLE
feat(mcp): sprintable_transition_goal — 목표 lifecycle 전이 도구 (story #2010)

### DIFF
--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -315,7 +315,13 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_mark_notification_read", "sprintable_my_dashboard", "sprintable_poll_events",
     "sprintable_save_standup", "sprintable_search_docs", "sprintable_search_stories",
     "sprintable_send_chat_message", "sprintable_sprint_summary", "sprintable_standup_history",
-    "sprintable_standup_missing", "sprintable_trigger_ai_summary",
+    "sprintable_standup_missing",
+    # story #2010: sprintable_transition_goal — 목표 lifecycle 전이 전용 신설(구 _epic 별칭
+    # 없음). tool_group()은 "goal" substring 매칭으로 "epics" 그룹에 귀속(add_goal/update_goal/
+    # list_goals와 동일 그룹) — role_template.default_tool_groups의 "epics" literal이 그대로
+    # 커버하므로 role_template 데이터 마이그 불요.
+    "sprintable_transition_goal",
+    "sprintable_trigger_ai_summary",
     "sprintable_unassign_story_from_sprint", "sprintable_unclaim_story", "sprintable_unlock_files",
     "sprintable_update_doc", "sprintable_update_epic", "sprintable_update_goal",
     "sprintable_update_meeting",

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -64,8 +64,8 @@ from .tools.docs import (
     create_doc, get_doc, list_docs, search_docs, update_doc,
 )
 from .tools.goals import (
-    AddGoalInput, ListGoalsInput, UpdateGoalInput,
-    add_goal, list_goals, update_goal,
+    AddGoalInput, ListGoalsInput, TransitionGoalInput, UpdateGoalInput,
+    add_goal, list_goals, transition_goal, update_goal,
 )
 from .tools.hypotheses import (
     ConfirmHypothesisInput, CreateHypothesisInput, GetHypothesisInput,
@@ -358,7 +358,7 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_update_task_status",
      "[일감] 태스크 상태 변경.",
      UpdateTaskStatusInput, update_task_status),
-    # Goals(구 Epics, 3) — E-SECURITY SEC-S1 확장: delete_goal 제거(에이전트 hard-delete 차단).
+    # Goals(구 Epics, 4) — E-SECURITY SEC-S1 확장: delete_goal 제거(에이전트 hard-delete 차단).
     # 계층 리네이밍 B1(story 1925): 신 이름이 primary, 구 이름(sprintable_*_epic)은 **같은 핸들러
     # 함수**를 참조하는 deprecated 별칭(hierarchy-rename-alias-mechanism-design §1 — 로직 복제
     # 0, 드리프트 불가). 별칭 유지 기간 동안 무중단 서빙.
@@ -371,6 +371,16 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_update_goal",
      "[일감] 목표 수정.",
      UpdateGoalInput, update_goal),
+    # story #2010: 목표 lifecycle 전이 전용 도구(rename B1 이후 신설이라 구 _epic 별칭 없음 —
+    # update_goal의 status 필드는 백엔드가 422로 거부해 이 도구만이 유일한 전이 경로).
+    # ⚠️draft→active·active→done 은 line overlay-gated — enforcing 라인이면 백엔드가 200을
+    # 반환하면서도 status는 유지(결재 대기)한다. 이 도구는 응답 status가 요청 status와 다르면
+    # transitioned=False + note로 명시해 겉보기 성공과 구분한다(tools/goals.py 참고).
+    ("sprintable_transition_goal",
+     "[일감] 목표 상태 전이(draft/active/done/archived). draft→active는 휴먼 전용"
+     "(에이전트 호출 시 HUMAN_CONFIRM_REQUIRED). 결재 게이트가 있으면 status가 유지된 채"
+     " '결재 대기' 응답을 받을 수 있다(transitioned=False로 표시).",
+     TransitionGoalInput, transition_goal),
     ("sprintable_list_epics",
      "[일감] [DEPRECATED→sprintable_list_goals] 에픽 목록 조회.",
      ListGoalsInput, list_goals),

--- a/backend/sprintable_mcp/tools/goals.py
+++ b/backend/sprintable_mcp/tools/goals.py
@@ -1,10 +1,15 @@
-"""목표(구 에픽) 관련 MCP 도구 (3개) — E-SECURITY SEC-S1 확장: delete_goal 제거(에이전트
+"""목표(구 에픽) 관련 MCP 도구 (4개) — E-SECURITY SEC-S1 확장: delete_goal 제거(에이전트
 hard-delete 차단, delete_story와 동형 조치. 까심 적대적 QA 발견 갭 — cascade로 소속 stories까지
 물리삭제).
 
 계층 리네이밍 B1(story 1925): 구 tools/epics.py — REST 호출 대상을 신 경로(/api/v2/goals)로
 전환. tool 이름 자체는 server.py의 _TOOL_DEFS가 신(sprintable_*_goal)+구(sprintable_*_epic)
 양쪽으로 별칭 등록(같은 함수 재사용, 로직 복제 0) — hierarchy-rename-alias-mechanism-design §1.
+
+story #2010: transition_goal(신규) 추가 — 목표 lifecycle 전이(draft/active/done/archived) 전용
+도구. update_goal의 status 필드는 백엔드가 422로 거부(FSM 우회 방지, goals.py:280 주석 "use POST
+/transition instead")하므로 이 도구를 통해서만 전이 가능. transition_goal은 rename(B1) 이후
+신설이라 구 sprintable_*_epic 별칭 없음(server.py 참고).
 """
 from __future__ import annotations
 
@@ -87,5 +92,40 @@ async def update_goal(args: UpdateGoalInput) -> list[TextContent]:
         updates["target_sp"] = args.target_sp
     try:
         return ok(await client.patch(f"/api/v2/goals/{args.goal_id}", json=updates))
+    except Exception as exc:
+        return err(str(exc))
+
+
+class TransitionGoalInput(SprintableInput):
+    goal_id: str
+    status: GoalStatus
+
+
+async def transition_goal(args: TransitionGoalInput) -> list[TextContent]:
+    """목표 상태 전이(lifecycle transition) — draft/active/done/archived. update_goal의 status 필드는
+    422로 거부되므로(FSM 우회 방지), 상태 전이는 이 도구를 써야 한다.
+
+    ⚠️결재 게이트 주의: draft→active·active→done 은 line overlay-gated 전이라 라인이 enforcing이면
+    백엔드가 200을 반환하면서도 실제 status는 바꾸지 않고(게이트 생성·결재 대기) 그대로 둔다(요청
+    실패가 아니라 '보류'). 이 도구는 응답의 status가 요청한 status와 다르면 이를 감지해
+    transitioned=False + 안내 메시지로 명시한다 — 겉보기 200 성공과 절대 혼동하지 말 것.
+    """
+    try:
+        resp = await client.post(
+            f"/api/v2/goals/{args.goal_id}/transition", json={"status": args.status.value}
+        )
+        actual_status = resp.get("status") if isinstance(resp, dict) else None
+        if actual_status is not None and actual_status != args.status.value:
+            return ok({
+                **resp,
+                "transitioned": False,
+                "requested_status": args.status.value,
+                "note": (
+                    "결재 게이트가 생성되어 status가 변경되지 않았습니다(결재 대기) — "
+                    f"현재 status는 여전히 '{actual_status}'입니다. 게이트가 승인되면 자동으로 "
+                    f"'{args.status.value}'로 전이됩니다. 이 응답은 성공이 아니라 보류 상태입니다."
+                ),
+            })
+        return ok({**resp, "transitioned": True}) if isinstance(resp, dict) else ok(resp)
     except Exception as exc:
         return err(str(exc))

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -27,11 +27,14 @@ EXPECTED_TOOLS = {
     # tasks (6) — E-SECURITY SEC-S1(확장): delete_task 의도적 제거(에이전트 hard-delete 차단)
     "sprintable_list_tasks", "sprintable_list_my_tasks", "sprintable_get_task",
     "sprintable_add_task", "sprintable_update_task", "sprintable_update_task_status",
-    # epics/goals (6) — E-SECURITY SEC-S1(확장): delete_epic 의도적 제거(에이전트 hard-delete
+    # epics/goals (7) — E-SECURITY SEC-S1(확장): delete_epic 의도적 제거(에이전트 hard-delete
     # 차단). 계층 리네이밍 B1(story 1925): sprintable_*_goal이 신(primary)·sprintable_*_epic은
     # 같은 핸들러를 가리키는 deprecated 별칭(hierarchy-rename-alias-mechanism-design §1).
+    # story #2010: sprintable_transition_goal 신설(목표 lifecycle 전이 전용, rename 이후 신설이라
+    # 구 _epic 별칭 없음).
     "sprintable_list_epics", "sprintable_add_epic", "sprintable_update_epic",
     "sprintable_list_goals", "sprintable_add_goal", "sprintable_update_goal",
+    "sprintable_transition_goal",
     # hypotheses (6) — E1-S5
     "sprintable_list_hypotheses", "sprintable_get_hypothesis", "sprintable_create_hypothesis",
     "sprintable_update_hypothesis", "sprintable_link_hypothesis", "sprintable_confirm_hypothesis",
@@ -109,7 +112,9 @@ def test_total_tool_count():
     # story 3cf50d90: get_chat_message(단건 원문 조회) 추가 — 106→107.
     # 계층 리네이밍 B1(story 1925): sprintable_*_goal 4종 신설(add/list/update/get_progress) —
     # 구 sprintable_*_epic 4종은 deprecated 별칭으로 유지(제거 아님) — 107→111.
-    assert len(_TOOLS) == 111
+    # story #2010: sprintable_transition_goal 1종 신설(목표 lifecycle 전이, 구 _epic 별칭 없음) —
+    # 111→112.
+    assert len(_TOOLS) == 112
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_e_recruit_s2_compose_prompt.py
+++ b/backend/tests/test_e_recruit_s2_compose_prompt.py
@@ -249,6 +249,16 @@ def test_compose_kit_tool_cheat_sheet_excludes_ungranted_groups():
     assert "sprintable_add_story" in out  # stories 그룹은 포함
 
 
+def test_compose_kit_tool_cheat_sheet_includes_transition_goal_in_epics_group():
+    """story #2010: sprintable_transition_goal — epics 권한을 받은 role 의 치트시트에 실제로
+    노출돼야 신규 채용 에이전트가 목표 lifecycle 전이 도구를 발견/사용할 수 있다(discoverability).
+    ALL_TOOL_NAMES 에서 누락되면(당초 상태) 이 테스트가 실패한다."""
+    role = _role(default_tool_groups=["epics"])
+    out = compose_kit(role, "claude-code")["onboarding"]
+    assert "sprintable_transition_goal" in out
+    assert "**epics**:" in out
+
+
 def test_compose_kit_always_allowed_tools_present_regardless_of_groups():
     """core(_ALWAYS_ALLOWED) 도구는 role 의 default_tool_groups 와 무관하게 항상 치트시트에 존재."""
     role = _role(default_tool_groups=["stories"])

--- a/backend/tests/test_mcp_2010_transition_goal_tool.py
+++ b/backend/tests/test_mcp_2010_transition_goal_tool.py
@@ -1,0 +1,125 @@
+"""story #2010: sprintable_transition_goal MCP 도구 테스트.
+
+목표 lifecycle 전이 전용 도구 — POST /api/v2/goals/{id}/transition 의 얇은 래퍼.
+핵심 AC(가장 중요): line overlay 게이트가 개입해 백엔드가 200을 반환하면서도 실제로는
+status를 바꾸지 않는(결재 대기) 케이스를 도구가 감지해 겉보기 성공과 명확히 구분해야 한다
+(backend/app/services/goal.py:74-76 — enforcing 라인 → status 유지 채 200 반환).
+"""
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sprintable_mcp.api_client import SprintableApiError
+from sprintable_mcp.tools import goals as g
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _client(**methods):
+    c = MagicMock()
+    c.project_id = "proj-1"
+    c.require_project_id = MagicMock(return_value="proj-1")
+    for name, ret in methods.items():
+        setattr(c, name, AsyncMock(return_value=ret))
+    return c
+
+
+def _error_client(exc: Exception):
+    c = MagicMock()
+    c.project_id = "proj-1"
+    c.require_project_id = MagicMock(return_value="proj-1")
+    c.post = AsyncMock(side_effect=exc)
+    return c
+
+
+# ── 1. active→done 정상 전이 ─────────────────────────────────────────────────
+
+async def test_active_to_done_success_no_pending_note():
+    client = _client(post={"id": "g1", "status": "done", "title": "T"})
+    args = g.TransitionGoalInput(goal_id="g1", status=g.GoalStatus.done)
+    with patch.object(g, "client", client):
+        out = await g.transition_goal(args)
+    assert client.post.call_args.args[0] == "/api/v2/goals/g1/transition"
+    assert client.post.call_args.kwargs["json"] == {"status": "done"}
+    data = json.loads(out[0].text)
+    assert data["status"] == "done"
+    assert data["transitioned"] is True
+    assert "note" not in data
+
+
+# ── 2. draft→active(에이전트 호출) — HUMAN_CONFIRM_REQUIRED 가독 노출 ─────────────
+
+async def test_draft_to_active_human_confirm_required_readable():
+    client = _error_client(
+        SprintableApiError(403, "HUMAN_CONFIRM_REQUIRED: active(activation) 전이는 휴먼만 가능합니다.")
+    )
+    args = g.TransitionGoalInput(goal_id="g1", status=g.GoalStatus.active)
+    with patch.object(g, "client", client):
+        out = await g.transition_goal(args)
+    text = out[0].text
+    assert text.startswith("Error:")
+    assert "HUMAN_CONFIRM_REQUIRED" in text
+    assert "휴먼" in text
+
+
+# ── 3. 불법 전이 — INVALID_EPIC_TRANSITION 가독 노출 ─────────────────────────────
+
+async def test_invalid_transition_readable():
+    client = _error_client(
+        SprintableApiError(422, "INVALID_EPIC_TRANSITION: 불법 전이: done → draft")
+    )
+    args = g.TransitionGoalInput(goal_id="g1", status=g.GoalStatus.draft)
+    with patch.object(g, "client", client):
+        out = await g.transition_goal(args)
+    text = out[0].text
+    assert text.startswith("Error:")
+    assert "INVALID_EPIC_TRANSITION" in text
+
+
+# ── 4. 존재하지 않는 goal — EPIC_NOT_FOUND 가독 노출 ─────────────────────────────
+
+async def test_nonexistent_goal_readable():
+    client = _error_client(SprintableApiError(404, "EPIC_NOT_FOUND: 목표를 찾을 수 없습니다."))
+    args = g.TransitionGoalInput(goal_id="does-not-exist", status=g.GoalStatus.done)
+    with patch.object(g, "client", client):
+        out = await g.transition_goal(args)
+    text = out[0].text
+    assert text.startswith("Error:")
+    assert "EPIC_NOT_FOUND" in text
+
+
+# ── 5. ⭐핵심 AC: overlay 게이트 silent-no-op 감지 ────────────────────────────────
+
+async def test_overlay_gate_silent_no_op_flagged_as_pending():
+    """enforcing 라인이 active→done 전이를 가로채면 백엔드는 200 + status='active'(미변경)를
+    반환한다(goal.py transition_goal: gate 생성 + goal 그대로 반환, 예외 없음). 도구는 요청한
+    status(done)와 응답 status(active)가 다름을 감지해 transitioned=False + 명확한 안내를 붙여야
+    한다 — 절대 평범한 성공처럼 보이면 안 된다."""
+    client = _client(post={"id": "g1", "status": "active", "title": "T"})  # 요청은 done, 응답은 active(미변경)
+    args = g.TransitionGoalInput(goal_id="g1", status=g.GoalStatus.done)
+    with patch.object(g, "client", client):
+        out = await g.transition_goal(args)
+    data = json.loads(out[0].text)
+    assert data["status"] == "active"  # 실제로는 안 바뀜
+    assert data["transitioned"] is False  # 평범한 성공이 아님을 명시
+    assert data["requested_status"] == "done"
+    assert "note" in data and data["note"]  # 사람이 읽을 안내 문구 존재
+    # 응답이 결재 대기 상태임을 텍스트로 확인할 수 있어야 한다.
+    assert "결재" in data["note"] or "대기" in data["note"]
+
+
+# ── 6. 회귀: update_goal의 status 필드는 여전히 그대로 patch body에 실린다(변경 안 함) ──
+
+async def test_update_goal_status_field_untouched_regression():
+    """update_goal 자체는 이 story의 스코프가 아니다 — status 필드가 여전히 patch body에
+    포함되는 기존 동작(백엔드가 422로 거부하는 것은 백엔드 책임)을 건드리지 않았음을 확인."""
+    client = _client(patch={"id": "g1"})
+    args = g.UpdateGoalInput(goal_id="g1", status=g.GoalStatus.done)
+    with patch.object(g, "client", client):
+        await g.update_goal(args)
+    assert client.patch.call_args.args[0] == "/api/v2/goals/g1"
+    assert client.patch.call_args.kwargs["json"] == {"status": "done"}

--- a/backend/tests/test_mcp_axis_prefix_b_surface.py
+++ b/backend/tests/test_mcp_axis_prefix_b_surface.py
@@ -61,6 +61,7 @@ def test_anchor_tools_match_doc_examples():
 
 def test_tool_names_and_param_models_untouched():
     """이름·시그니처 불변 — 계층 리네이밍 B1(story 1925)이 sprintable_*_goal 4종을 신설(구
-    sprintable_*_epic 4종은 deprecated 별칭 유지, 제거 아님) — 106→110."""
-    assert len(_TOOL_DEFS) == 110
+    sprintable_*_epic 4종은 deprecated 별칭 유지, 제거 아님) — 106→110. story #2010:
+    sprintable_transition_goal 1종 신설(구 _epic 별칭 없음) — 110→111."""
+    assert len(_TOOL_DEFS) == 111
     assert all(name.startswith("sprintable_") for name in _TOOLS)

--- a/backend/tests/test_toolset_catalog.py
+++ b/backend/tests/test_toolset_catalog.py
@@ -96,6 +96,10 @@ def test_tool_group_mapping_examples():
     # 정상 그룹 매핑 sanity
     assert by_tool["sprintable_add_story"] == "stories"
     assert by_tool["sprintable_get_velocity"] == "analytics"
+    # story #2010: sprintable_transition_goal — ALL_TOOL_NAMES 누락 시 KeyError로 실패(당초
+    # 이 도구가 SSOT 목록에서 빠져 role-template picker/치트시트에 노출되지 않던 회귀 가드).
+    # "goal" substring 매칭으로 add_goal/update_goal/list_goals와 동일 "epics" 그룹.
+    assert by_tool["sprintable_transition_goal"] == "epics"
 
 
 # ── 엔드포인트 admin 게이트 ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Story #2010: agents currently have zero way to close a completed goal (epic) via MCP — `update_goal`'s `status` field 422s (deliberate FSM-bypass guard, `backend/app/routers/goals.py:280`, "use POST /transition instead"). Six goals were stuck as a result.
- Adds `sprintable_transition_goal` — a thin MCP wrapper around the existing `POST /api/v2/goals/{id}/transition` endpoint (`backend/app/routers/goals.py:396` → `transition_goal()` in `backend/app/services/goal.py`), mirroring the exact conventions of the other 3 goal tools in `backend/sprintable_mcp/tools/goals.py`.
- Registered in `backend/sprintable_mcp/server.py` as `sprintable_transition_goal` only — no legacy `sprintable_*_epic` alias, since this tool postdates the hierarchy rename (B1, story 1925).

## Silent-no-op (overlay gate) detection — the core AC

`draft→active` and `active→done` are line overlay-gated transitions (`_OVERLAY_TRANSITIONS` in `goal.py`). When an overlay line is enforcing, `transition_goal()` creates an approval gate and returns the goal **unchanged** — the HTTP call succeeds with 200, but `status` did not actually change. No exception is raised, so a naive wrapper would report a plain success even though nothing happened.

The new tool detects this by comparing the requested `status` against the response's actual `status`:

- **Match** (real transition happened): `ok({**resp, "transitioned": True})`
- **Mismatch** (gate intercepted it, status held at old value):
  ```json
  {
    "...(all original response fields)...",
    "status": "active",
    "transitioned": false,
    "requested_status": "done",
    "note": "결재 게이트가 생성되어 status가 변경되지 않았습니다(결재 대기) — 현재 status는 여전히 'active'입니다. 게이트가 승인되면 자동으로 'done'로 전이됩니다. 이 응답은 성공이 아니라 보류 상태입니다."
  }
  ```

Error propagation (`HUMAN_CONFIRM_REQUIRED` / `INVALID_EPIC_TRANSITION` / `EPIC_NOT_FOUND` / `INVALID_STATUS`) was verified to already surface readably via the existing `try/except Exception as exc: return err(str(exc))` pattern — `api_client.py`'s `_extract_error_message` already parses the `{"error": {"code","message"}}` envelope into `"CODE: message"` strings, no special-casing needed.

## Also touched (contract-test sync, discovered on-sight)

Adding a tool shifts the total registered-tool count, so two existing contract tests needed their literal counts/expected-sets bumped (no behavior change, pure sync):
- `backend/tests/mcp/test_contract.py`: `EXPECTED_TOOLS` +`sprintable_transition_goal`, `test_total_tool_count` 111→112.
- `backend/tests/test_mcp_axis_prefix_b_surface.py`: `test_tool_names_and_param_models_untouched` 110→111 (the axis-prefix coverage tests pass automatically since the new tool's description already starts with `[일감] `).

## Stuck-goals status (per story background)

- **E-GLANCE**: already manually closed via direct API call as an immediate stopgap (done before this PR, not through this tool since it didn't exist yet).
- **E-ARCH-FASTAPI Phase B, E-ARCH-MONOREPO Phase A, E-CONTRACT-ENGINE, E-PERF-INFRA, E-WORKFLOW-CONTRACT**: checked and are actually in `draft` status, not `active`. `draft→active` is human-only (`HUMAN_CONFIRM_REQUIRED` for agent callers) — a **human** must transition these to `active` first before any agent (via this tool or otherwise) can close them. This tool alone does not unstick these 5; that requires human action first.

## Test plan

- [x] `backend/tests/test_mcp_2010_transition_goal_tool.py` (new, 6 tests, all passing):
  - `test_active_to_done_success_no_pending_note` — plain success, no pending note.
  - `test_draft_to_active_human_confirm_required_readable` — `HUMAN_CONFIRM_REQUIRED` surfaces readably.
  - `test_invalid_transition_readable` — `INVALID_EPIC_TRANSITION` surfaces readably.
  - `test_nonexistent_goal_readable` — `EPIC_NOT_FOUND` surfaces readably.
  - `test_overlay_gate_silent_no_op_flagged_as_pending` — **core AC**: mismatched requested/actual status flagged as `transitioned: False` + note, not a bare success.
  - `test_update_goal_status_field_untouched_regression` — `update_goal`'s existing status-field passthrough behavior is untouched.
- [x] `backend/tests/mcp/test_contract.py`, `backend/tests/test_mcp_axis_prefix_b_surface.py` — updated + passing.
- [x] Full `-k mcp` sweep (`pytest tests/ -k mcp`): 283 passed, 26 skipped, 7 pre-existing failures identical to `origin/develop` baseline (verified via a separate `origin/develop` worktree — all 7 are environment-dependent, e.g. checking live `.mcp.json`/running processes, unrelated to this change).
- [x] `test_edg_s25_epic_overlay.py`, `test_epics.py` (underlying goal-transition service/router, untouched by this PR): 23 passed, 3 skipped — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up: catalog + recruiter cheat-sheet discoverability fix

The MCP tool itself worked, but `sprintable_transition_goal` was never added to `backend/app/services/mcp_toolset.py`'s `ALL_TOOL_NAMES` — the backend-owned SSOT list consumed by two discoverability surfaces:

1. **`mcp_toolset.build_toolset_catalog()`** — the role-template permission picker's group catalog (admin UI), which iterates `ALL_TOOL_NAMES` grouped via `tool_group()`.
2. **`agent_recruiter._tool_cheat_sheet()`** (~line 90-95) — the onboarding "tool cheat sheet" every newly-recruited agent receives, generated from the same `ALL_TOOL_NAMES` list. Without this fix, new agents' onboarding materials silently omitted `sprintable_transition_goal`, defeating story #2010's own discoverability goal.

**Fix**: added `"sprintable_transition_goal"` to `ALL_TOOL_NAMES` (`backend/app/services/mcp_toolset.py`).

**`tool_group()` classification, verified by trace**: stripping the `sprintable_` prefix leaves `transition_goal`. Walking `_GROUP_KEYWORDS` in order, the first (and only) match is the `"epics"` group via its `"goal"` keyword (`("epics", ("epic", "goal"))`) — same match path as `sprintable_add_goal`/`sprintable_update_goal`/`sprintable_list_goals`. Checked for an earlier collision (e.g. some group matching on `"trans"`/`"sprint"`/etc. before reaching `epics`): none of the preceding groups' keywords (`reward/wallet/leaderboard`, `velocity/health/.../goal_progress`, `agent_run/run_status/update_run`, `audit`, `webhook`, `notification`, `meeting`, `retro`, `standup`, `doc/search_docs`, `chat/message/conversation`, `sprint`, `hypothes`) appear as a substring of `transition_goal` — confirmed via runtime check (`tool_group("sprintable_transition_goal") == "epics"`) plus manual substring trace. No collision risk found.

**Round-trip verification** (ran live, not just read):
```python
tool_group("sprintable_transition_goal")  # -> "epics"
build_toolset_catalog()["groups"] -> epics group tools include "sprintable_transition_goal"
agent_recruiter._tool_cheat_sheet(["epics"], "ko") -> "epics" section includes "`sprintable_transition_goal`"
```

**Tests**: extended (not duplicated) two existing suites that already assert on `ALL_TOOL_NAMES`/`tool_group()`/cheat-sheet output:
- `backend/tests/test_toolset_catalog.py::test_tool_group_mapping_examples` — added `assert by_tool["sprintable_transition_goal"] == "epics"`.
- `backend/tests/test_e_recruit_s2_compose_prompt.py::test_compose_kit_tool_cheat_sheet_includes_transition_goal_in_epics_group` (new) — asserts the tool text appears in `compose_kit(...)["onboarding"]` when the role is granted the `epics` group.

Both verified to fail (`KeyError` / `AssertionError`) against the pre-fix `ALL_TOOL_NAMES` and pass after the fix.

**`test_mcp_axis_prefix_b_surface.py` / `mcp/test_contract.py`**: re-ran both — all pass, no further constant bump needed. These two suites derive their tool counts/sets from `sprintable_mcp.server` (`_TOOL_DEFS` / `mcp._tool_manager._tools`, the actual MCP server registry), a **separate source of truth** from `mcp_toolset.ALL_TOOL_NAMES` — they were already correctly updated in the prior commit (110→111 / 111→112) and are unaffected by this catalog/recruiter-only fix.

**Pre-existing SSOT drift noted (not introduced by this PR, not fixed here)**: `ALL_TOOL_NAMES` and the live MCP server registry are not byte-identical even now — `ALL_TOOL_NAMES` contains `"sprintable_ping"` while the server registers the tool literally as `ping` (`@mcp.tool() async def ping()` in `server.py:309-310`, outside the `_TOOL_DEFS` list mechanism). This is handled intentionally elsewhere (`_ALWAYS_ALLOWED` includes both `"ping"` and `"sprintable_ping"` per its own comment), but flagging the mismatch for visibility since the story asked not to silently paper over any discovered drift.
