### PR TITLE
feat(mcp): sprintable_delete_artifact — 시각 산출물 소프트 삭제 도구 (story #1922)

### DIFF
--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -344,6 +344,14 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_edit_artifact", "sprintable_propose_canonical_version",
     "sprintable_list_spec_pins", "sprintable_create_spec_pin", "sprintable_update_spec_pin",
     "sprintable_delete_spec_pin",
+    # story #1922: sprintable_delete_artifact — artifact soft delete(생성자 전용) 전용 신설.
+    # #2010(sprintable_transition_goal)이 이 SSOT 목록 등록을 처음 커밋에서 빠뜨려 role-template
+    # picker 카탈로그/신규 에이전트 채용 치트시트에서 누락됐던 갭(follow-up 커밋 8126465e로 정정)을
+    # 이번엔 최초 커밋부터 함께 반영. tool_group()은 "artifact" substring 매칭으로 "canvas" 그룹
+    # 귀속(create_artifact/edit_artifact/delete_spec_pin과 동일 경로) — role_template의 "canvas"
+    # literal이 그대로 커버해 데이터 마이그 불요. is_destructive()도 "sprintable_delete" 접두로
+    # True(delete_spec_pin과 동형 — canvas 그룹 + destructive scope 둘 다 필요).
+    "sprintable_delete_artifact",
     # projects (E-MCP-OPT story ff6cb90d)
     "sprintable_list_projects", "sprintable_set_default_project",
 )

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -30,11 +30,11 @@ from .toolset import is_tool_allowed
 from .tools.a2a import LinkGateToTaskInput, link_gate_to_task
 from .tools.evidence import AddEvidenceInput, add_evidence
 from .tools.visual_artifacts import (
-    AddArtifactCommentInput, CreateArtifactInput, CreateSpecPinInput, DeleteSpecPinInput,
-    EditArtifactInput, GetArtifactInput, ListArtifactCommentsInput, ListArtifactsInput,
-    ListSpecPinsInput, ProposeCanonicalInput, UpdateSpecPinInput,
-    add_artifact_comment, create_artifact, create_spec_pin, delete_spec_pin, edit_artifact,
-    get_artifact, list_artifact_comments, list_artifacts, list_spec_pins,
+    AddArtifactCommentInput, CreateArtifactInput, CreateSpecPinInput, DeleteArtifactInput,
+    DeleteSpecPinInput, EditArtifactInput, GetArtifactInput, ListArtifactCommentsInput,
+    ListArtifactsInput, ListSpecPinsInput, ProposeCanonicalInput, UpdateSpecPinInput,
+    add_artifact_comment, create_artifact, create_spec_pin, delete_artifact, delete_spec_pin,
+    edit_artifact, get_artifact, list_artifact_comments, list_artifacts, list_spec_pins,
     propose_canonical_version, update_spec_pin,
 )
 from .tools.agent_runs import (
@@ -533,8 +533,8 @@ _TOOL_DEFS: list[tuple] = [
      "done을 스스로 증명하는 자기 서명 첨부(PR·배포·지표·발행물 링크 등) — story/task에 evidence"
      " 남김. 선택제(첨부 안 해도 무불이익).",
      AddEvidenceInput, add_evidence),
-    # Visual artifacts (11) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안) +
-    # 핀 저작(story 7fe16274)
+    # Visual artifacts (12) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안) +
+    # 핀 저작(story 7fe16274) + story #1922(delete_artifact, soft delete·생성자 전용)
     ("sprintable_create_artifact",
      "[일감] 시각 산출물 생성(에이전트 생성 입구) — 트리(nodes[])로 구조화. 임포트된 raw HTML/이미지는"
      " type=\"html_blob\" 노드 하나로 감싸도 됨. canvas_bounds{w,h}(선택): 렌더 자기 프레임 크기"
@@ -586,6 +586,12 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_delete_spec_pin",
      "[일감] 스펙 핀 삭제(최신 버전 소속만 대상). ⭐더 이상 유효하지 않은 스펙 핀을 치울 때.",
      DeleteSpecPinInput, delete_spec_pin),
+    ("sprintable_delete_artifact",
+     "[일감] artifact 삭제(soft delete — deleted_at만 세팅, 자식 row 물리삭제 없음). **생성자만"
+     " 삭제 가능**(story/task/epic처럼 admin/owner가 아니라 생성자 본인만·403 시 '생성자만 삭제할"
+     " 수 있습니다'). 삭제 후 get_artifact/list_artifacts에서 더 이상 노출되지 않는다. ⭐잘못"
+     " 만들었거나 빈/중복 산출물을 치울 때(재발행 대신 이걸로 정리).",
+     DeleteArtifactInput, delete_artifact),
     ("sprintable_propose_canonical_version",
      "[신뢰] 이 버전을 정본으로 제안(게이트 생성) — 제안만, 승인/반려는 항상 휴먼. ⭐이 버전이 확定될"
      " 준비가 됐다고 판단될 때 휴먼 승인을 요청.",

--- a/backend/sprintable_mcp/tools/visual_artifacts.py
+++ b/backend/sprintable_mcp/tools/visual_artifacts.py
@@ -1,6 +1,8 @@
-"""시각 산출물(visual_artifact) MCP 도구(7개) — E-CANVAS C1-S3(story 8bace49e)+
+"""시각 산출물(visual_artifact) MCP 도구(8개) — E-CANVAS C1-S3(story 8bace49e)+
 C2-S6(story 0edca31e, 코멘트 왕복)+C3-S7(story 940266db, 편집 왕복)+C4-S8(story a5118cb0,
-정본 제안 — 승인은 always-HITL이라 MCP 미제공)."""
+정본 제안 — 승인은 always-HITL이라 MCP 미제공)+story #1922(delete_artifact, soft delete·
+생성자 전용 — delete_story/delete_task/delete_epic류 hard-delete cascade 차단(SEC-S1)과
+다른 리스크 클래스. deleted_at 타임스탬프 플립일 뿐 자식 row 물리삭제 없음)."""
 from __future__ import annotations
 
 from mcp.types import TextContent
@@ -104,6 +106,10 @@ class UpdateSpecPinInput(SprintableInput):
 class DeleteSpecPinInput(SprintableInput):
     artifact_id: str
     pin_id: str
+
+
+class DeleteArtifactInput(SprintableInput):
+    artifact_id: str
 
 
 class ProposeCanonicalInput(SprintableInput):
@@ -278,6 +284,18 @@ async def delete_spec_pin(args: DeleteSpecPinInput) -> list[TextContent]:
     """스펙 핀 삭제(최신 버전 소속만 대상)."""
     try:
         result = await client.delete(f"/api/v2/visual-artifacts/{args.artifact_id}/pins/{args.pin_id}")
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def delete_artifact(args: DeleteArtifactInput) -> list[TextContent]:
+    """artifact 삭제(soft delete — deleted_at 타임스탬프만 세팅, 자식 row 물리삭제 없음).
+    **생성자만 삭제 가능**(story/task/epic/doc의 admin/owner 게이트보다 좁은 범위 — "누가
+    주어인가" Evidence 패턴 계승). 생성자가 아니면 403(생성자만 삭제할 수 있습니다). 삭제 후
+    get_artifact/list_artifacts에서 더 이상 노출되지 않는다."""
+    try:
+        result = await client.delete(f"/api/v2/visual-artifacts/{args.artifact_id}")
         return ok(result)
     except Exception as exc:
         return err(str(exc))

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -93,13 +93,13 @@ EXPECTED_TOOLS = {
     "sprintable_link_gate_to_task",
     # evidence (1) — E-VERIFY V0-S1
     "sprintable_add_evidence",
-    # visual artifacts (11) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안) +
-    # 핀 저작(story 7fe16274)
+    # visual artifacts (12) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안) +
+    # 핀 저작(story 7fe16274) + story #1922(delete_artifact, soft delete·생성자 전용)
     "sprintable_create_artifact", "sprintable_get_artifact", "sprintable_list_artifacts",
     "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
     "sprintable_edit_artifact", "sprintable_propose_canonical_version",
     "sprintable_list_spec_pins", "sprintable_create_spec_pin", "sprintable_update_spec_pin",
-    "sprintable_delete_spec_pin",
+    "sprintable_delete_spec_pin", "sprintable_delete_artifact",
     # smoke
     "ping",
 }
@@ -113,8 +113,9 @@ def test_total_tool_count():
     # 계층 리네이밍 B1(story 1925): sprintable_*_goal 4종 신설(add/list/update/get_progress) —
     # 구 sprintable_*_epic 4종은 deprecated 별칭으로 유지(제거 아님) — 107→111.
     # story #2010: sprintable_transition_goal 1종 신설(목표 lifecycle 전이, 구 _epic 별칭 없음) —
-    # 111→112.
-    assert len(_TOOLS) == 112
+    # 111→112. story #1922: sprintable_delete_artifact 1종 신설(artifact soft delete, 생성자
+    # 전용) — 112→113.
+    assert len(_TOOLS) == 113
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_e_recruit_s2_compose_prompt.py
+++ b/backend/tests/test_e_recruit_s2_compose_prompt.py
@@ -259,6 +259,16 @@ def test_compose_kit_tool_cheat_sheet_includes_transition_goal_in_epics_group():
     assert "**epics**:" in out
 
 
+def test_compose_kit_tool_cheat_sheet_includes_delete_artifact_in_canvas_group():
+    """story #1922: sprintable_delete_artifact — canvas 권한을 받은 role 의 치트시트에 실제로
+    노출돼야 신규 채용 에이전트가 artifact 삭제 도구를 발견/사용할 수 있다(discoverability,
+    #2010과 동일 회귀 클래스 — 이번엔 ALL_TOOL_NAMES 최초 커밋부터 등록해 실패하지 않아야 함)."""
+    role = _role(default_tool_groups=["canvas"])
+    out = compose_kit(role, "claude-code")["onboarding"]
+    assert "sprintable_delete_artifact" in out
+    assert "**canvas**:" in out
+
+
 def test_compose_kit_always_allowed_tools_present_regardless_of_groups():
     """core(_ALWAYS_ALLOWED) 도구는 role 의 default_tool_groups 와 무관하게 항상 치트시트에 존재."""
     role = _role(default_tool_groups=["stories"])

--- a/backend/tests/test_mcp_1922_delete_artifact_tool.py
+++ b/backend/tests/test_mcp_1922_delete_artifact_tool.py
@@ -1,0 +1,290 @@
+"""story #1922: sprintable_delete_artifact MCP 도구 테스트.
+
+DELETE /api/v2/visual-artifacts/{id}(생성자 전용 soft delete)의 얇은 래퍼 — delete_spec_pin과
+동형 최소 구현(backend/sprintable_mcp/tools/visual_artifacts.py). SEC-S1이 차단한
+delete_story/delete_task/delete_epic/delete_doc류(hard-delete cascade)와 다른 리스크 클래스:
+deleted_at 타임스탬프 플립일 뿐 자식 row 물리삭제 없음 — 그래서 MCP 표면에 유지된다.
+
+핵심 AC: 403("생성자만 삭제할 수 있습니다")이 라우터의 로컬 _err() 엔벨로프
+({"error": {"code","message"}})를 거쳐 api_client._extract_error_message()에서
+가독 텍스트로 나와야 한다(불투명 실패 금지) — mock 만이 아니라 그 엔벨로프 shape 자체를
+직접 검증한다(아래 test_error_envelope_shape_matches_router_err_helper).
+"""
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sprintable_mcp.api_client import SprintableApiError, _extract_error_message
+from sprintable_mcp.tools import visual_artifacts as va
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _client(**methods):
+    c = MagicMock()
+    c.project_id = "proj-1"
+    c.require_project_id = MagicMock(return_value="proj-1")
+    for name, ret in methods.items():
+        setattr(c, name, AsyncMock(return_value=ret))
+    return c
+
+
+def _error_client(exc: Exception):
+    c = MagicMock()
+    c.project_id = "proj-1"
+    c.require_project_id = MagicMock(return_value="proj-1")
+    c.delete = AsyncMock(side_effect=exc)
+    return c
+
+
+# ── 0. 라우터 _err() 엔벨로프 shape가 _extract_error_message()에서 가독 텍스트로 뽑히는지 ──
+# (backend/app/routers/visual_artifacts.py:46 _err()가 만드는 정확한 shape로 직접 검증)
+
+def test_error_envelope_shape_matches_router_err_helper():
+    """router._err("FORBIDDEN", "생성자만 삭제할 수 있습니다", 403)이 JSONResponse로 만드는
+    본문 {"data": None, "error": {"code": "FORBIDDEN", "message": "..."}, "meta": None}을
+    httpx가 그대로 resp.json()해 api_client._extract_error_message에 넘긴 경우를 재현 —
+    표준 {error:{code,message}} 엔벨로프(shape 1)와 정확히 일치해 가독 메시지가 나와야 한다."""
+    body = {"data": None, "error": {"code": "FORBIDDEN", "message": "생성자만 삭제할 수 있습니다"}, "meta": None}
+    msg = _extract_error_message(403, body)
+    assert msg == "FORBIDDEN: 생성자만 삭제할 수 있습니다"
+
+    body_404 = {"data": None, "error": {"code": "NOT_FOUND", "message": "Artifact not found"}, "meta": None}
+    assert _extract_error_message(404, body_404) == "NOT_FOUND: Artifact not found"
+
+
+# ── 1. 생성자 본인 삭제 성공 ────────────────────────────────────────────────────
+
+async def test_creator_deletes_own_artifact_success():
+    client = _client(delete={"ok": True, "id": "a1"})
+    args = va.DeleteArtifactInput(artifact_id="a1")
+    with patch.object(va, "client", client):
+        out = await va.delete_artifact(args)
+    assert client.delete.call_args.args[0] == "/api/v2/visual-artifacts/a1"
+    data = json.loads(out[0].text)
+    assert data == {"ok": True, "id": "a1"}
+
+
+# ── 2. 비-생성자 403 — 가독 메시지(불투명 "an error occurred" 아님) ──────────────
+
+async def test_non_creator_gets_readable_403():
+    client = _error_client(SprintableApiError(403, "FORBIDDEN: 생성자만 삭제할 수 있습니다"))
+    args = va.DeleteArtifactInput(artifact_id="a1")
+    with patch.object(va, "client", client):
+        out = await va.delete_artifact(args)
+    text = out[0].text
+    assert text.startswith("Error:")
+    assert "생성자만 삭제할 수 있습니다" in text
+    assert "FORBIDDEN" in text
+    # 불투명 실패가 아님을 명시적으로 반증 — "an error occurred" 류의 무의미 텍스트가 아니다.
+    assert text != "Error: an error occurred"
+
+
+# ── 3. 존재하지 않는 artifact — 가독 404 ────────────────────────────────────────
+
+async def test_nonexistent_artifact_readable_404():
+    client = _error_client(SprintableApiError(404, "NOT_FOUND: Artifact not found"))
+    args = va.DeleteArtifactInput(artifact_id="does-not-exist")
+    with patch.object(va, "client", client):
+        out = await va.delete_artifact(args)
+    text = out[0].text
+    assert text.startswith("Error:")
+    assert "NOT_FOUND" in text
+    assert "Artifact not found" in text
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# realdb: create → delete → list/get-excludes 왕복(라우터의 deleted_at 필터링 실증)
+# ═══════════════════════════════════════════════════════════════════════════
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark_realdb = pytest.mark.skipif(
+    not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"
+)
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id}
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, project_id, user_id=None):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id or uuid.uuid4()), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytestmark_realdb
+@pytest.mark.anyio
+async def test_realdb_creator_only_403_readable_via_http():
+    """라이브 HTTP 왕복: 비-생성자 DELETE → 403 + 라우터 _err() 본문이 그대로 나오는지(router-level,
+    creator-only 게이트 자체는 test_e_canvas_c1_s3_visual_artifact_realdb.py에 이미 커버 —
+    여기선 message 가독성 초점)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        creator_id = uuid.uuid4()
+        other_id = uuid.uuid4()
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], user_id=creator_id)
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Mine"})
+            artifact_id = create_resp.json()["data"]["id"]
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], user_id=other_id)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/visual-artifacts/{artifact_id}")
+            assert resp.status_code == 403, resp.text
+            body = resp.json()
+            assert body["error"]["code"] == "FORBIDDEN"
+            assert body["error"]["message"] == "생성자만 삭제할 수 있습니다"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytestmark_realdb
+@pytest.mark.anyio
+async def test_realdb_mcp_create_delete_then_get_and_list_exclude():
+    """AC4 실증(⭐핵심): MCP sprintable_create_artifact → sprintable_delete_artifact →
+    sprintable_get_artifact(더 이상 안 보임, 404) + sprintable_list_artifacts(제외) 왕복.
+    라우터의 _get_artifact_or_404(deleted_at.is_(None) 필터, line 186)와 list_artifacts의
+    직접 deleted_at 필터(line 290)가 실제로 동작하는지 end-to-end로 실증 — 필터가 깨져 있으면
+    (진짜 결함이면) 이 테스트가 실패해야 한다."""
+    import httpx
+
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        # 고정 caller_id — _setup_app(user_id=None)은 매 요청마다 새 랜덤 uuid를 발급해(각 _auth()
+        # 클로저 호출 시점 평가) create/delete 요청이 서로 다른 사용자로 인증될 수 있다(생성자-전용
+        # 게이트가 자기 자신의 delete까지 403으로 막는 self-testing 함정) — 고정 id로 회피.
+        caller_id = uuid.uuid4()
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], user_id=caller_id)
+
+        os.environ.setdefault("SPRINTABLE_API_URL", "http://test")
+        os.environ.setdefault("AGENT_API_KEY", "sk_test")
+
+        from sprintable_mcp.tools.visual_artifacts import (
+            CreateArtifactInput, DeleteArtifactInput, GetArtifactInput, ListArtifactsInput,
+            create_artifact, delete_artifact, get_artifact, list_artifacts,
+        )
+        from sprintable_mcp import api_client as api_client_mod
+
+        transport = httpx.ASGITransport(app=app)
+        real_client = api_client_mod.client
+        test_http_client = httpx.AsyncClient(transport=transport, base_url="http://test")
+
+        async def _post(path, **kwargs):
+            r = await test_http_client.post(path, **kwargs)
+            r.raise_for_status()
+            return r.json()["data"]
+
+        async def _get(path, **kwargs):
+            r = await test_http_client.get(path, **kwargs)
+            r.raise_for_status()
+            return r.json()["data"]
+
+        async def _delete(path, **kwargs):
+            r = await test_http_client.delete(path, **kwargs)
+            r.raise_for_status()
+            return r.json()["data"]
+
+        orig_post, orig_get, orig_delete = real_client.post, real_client.get, real_client.delete
+        real_client.post, real_client.get, real_client.delete = _post, _get, _delete
+        try:
+            created = json.loads((await create_artifact(CreateArtifactInput(title="To Delete")))[0].text)
+            artifact_id = created["id"]
+
+            # 삭제 전: list에 보임.
+            before = json.loads((await list_artifacts(ListArtifactsInput()))[0].text)
+            assert any(a["id"] == artifact_id for a in before)
+
+            del_result = json.loads((await delete_artifact(DeleteArtifactInput(artifact_id=artifact_id)))[0].text)
+            assert del_result == {"ok": True, "id": artifact_id}
+
+            # 삭제 후: get_artifact → 404(err() 텍스트로 나옴, exception이 아니라 도구 반환값).
+            get_result = await get_artifact(GetArtifactInput(artifact_id=artifact_id))
+            get_text = get_result[0].text
+            assert get_text.startswith("Error:")
+            assert "404" in get_text or "NOT_FOUND" in get_text or "Artifact not found" in get_text
+
+            # 삭제 후: list_artifacts에서 제외.
+            after = json.loads((await list_artifacts(ListArtifactsInput()))[0].text)
+            assert not any(a["id"] == artifact_id for a in after)
+        finally:
+            real_client.post, real_client.get, real_client.delete = orig_post, orig_get, orig_delete
+            await test_http_client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_mcp_axis_prefix_b_surface.py
+++ b/backend/tests/test_mcp_axis_prefix_b_surface.py
@@ -62,6 +62,7 @@ def test_anchor_tools_match_doc_examples():
 def test_tool_names_and_param_models_untouched():
     """이름·시그니처 불변 — 계층 리네이밍 B1(story 1925)이 sprintable_*_goal 4종을 신설(구
     sprintable_*_epic 4종은 deprecated 별칭 유지, 제거 아님) — 106→110. story #2010:
-    sprintable_transition_goal 1종 신설(구 _epic 별칭 없음) — 110→111."""
-    assert len(_TOOL_DEFS) == 111
+    sprintable_transition_goal 1종 신설(구 _epic 별칭 없음) — 110→111. story #1922:
+    sprintable_delete_artifact 1종 신설(artifact soft delete, 생성자 전용) — 111→112."""
+    assert len(_TOOL_DEFS) == 112
     assert all(name.startswith("sprintable_") for name in _TOOLS)

--- a/backend/tests/test_toolset_catalog.py
+++ b/backend/tests/test_toolset_catalog.py
@@ -100,6 +100,11 @@ def test_tool_group_mapping_examples():
     # 이 도구가 SSOT 목록에서 빠져 role-template picker/치트시트에 노출되지 않던 회귀 가드).
     # "goal" substring 매칭으로 add_goal/update_goal/list_goals와 동일 "epics" 그룹.
     assert by_tool["sprintable_transition_goal"] == "epics"
+    # story #1922: sprintable_delete_artifact — ALL_TOOL_NAMES 누락 시 KeyError(#2010과 동일
+    # 회귀 클래스, 이번엔 최초 커밋부터 등록해 애초에 발생하지 않게 함 — 이 assert는 그 보장의
+    # 회귀 가드). "artifact" substring 매칭으로 create_artifact/edit_artifact/delete_spec_pin과
+    # 동일 "canvas" 그룹.
+    assert by_tool["sprintable_delete_artifact"] == "canvas"
 
 
 # ── 엔드포인트 admin 게이트 ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- story #1922 — `#2010`(sprintable_transition_goal, PR #2289)과 동형 구조의 얇은 MCP 도구 신설: 기존 `DELETE /api/v2/visual-artifacts/{id}`(생성자 전용 soft delete — `deleted_at` 타임스탬프 플립만, 자식 row 물리삭제 없음)를 감싼다. `delete_spec_pin`과 동일한 최소 구현(`backend/sprintable_mcp/tools/visual_artifacts.py`) — SEC-S1이 차단한 `delete_story`/`delete_task`/`delete_epic`/`delete_doc`류(hard-delete cascade)와는 다른 리스크 클래스라 MCP 표면에 유지하는 것이 안전.
- **`ALL_TOOL_NAMES` 최초 커밋부터 등록**: #2010이 첫 커밋에서 이 SSOT 등록을 빠뜨려 follow-up 커밋(8126465e)이 필요했던 전례를 이번엔 반복하지 않음 — `backend/app/services/mcp_toolset.py`의 `ALL_TOOL_NAMES`에 `"sprintable_delete_artifact"`를 이번 커밋에 함께 반영.
- `tool_group()` 런타임 확인 완료: `"artifact"` substring 매칭으로 `create_artifact`/`edit_artifact`/`delete_spec_pin`과 동일 **`"canvas"`** 그룹 귀속. `build_toolset_catalog()`와 `agent_recruiter._tool_cheat_sheet()` 양쪽에 실제로 노출됨을 라이브 함수 호출로 왕복 확인(정적 읽기가 아님, #2010 follow-up과 동일 검증 방식).
- 403("생성자만 삭제할 수 있습니다") 플루밍을 직접 추적: 라우터의 로컬 `_err()` 엔벨로프(`{"error":{"code","message"}}`)가 `api_client._extract_error_message()`의 표준 shape 1과 정확히 일치해 가독 메시지로 나온다 — 갭 없음. 엔벨로프 shape 자체를 직접 검증하는 테스트로 증명(`test_error_envelope_shape_matches_router_err_helper`).
- 로컬 pg@16(create_all, pgvector 불요) realdb 왕복 테스트로 라우터의 `deleted_at` 필터링이 `get_artifact`/`list_artifacts` 양쪽에서 실제로 동작함을 실증(삭제 후 미노출 확인).

## Fact-check (AC 명시 요구사항 — 스코프 확장 없이 사실만 보고)
스토리는 artifact `8de4e981`("조직 가속 — 어떻게 이루어지는가")가 깨진/빈 중복본이었고, "유나"가 이를 지우는 대신 정정본(`0f067bc5`)을 재발행해 우회했다는 실제 pain point에서 출발함.

- `sprintable_list_artifacts`로 전체 uuid 확인: `8de4e981-9e1d-4712-ab9e-083dba40ad2c`
- `created_by` = `111f1cca-73c7-4fbb-9aed-3cbae19da286` = **유나 홀름**(agent, active member) — 재발행본 `0f067bc5-274d-4f92-958f-b90123c27698`도 동일 창작자.
- 생성자-전용(creator-only) 스코프이므로 **유나 본인**이 `sprintable_delete_artifact`를 호출하면 `8de4e981`을 스스로 정리할 수 있다 → **원 pain은 "본인 재호출" 케이스에 한해 해소된다.** 제3자(다른 agent/휴먼)의 admin-delete는 이 도구의 스코프 밖 — AC 지시대로 admin-delete/ownership-transfer 확장은 하지 않았다(별도 authz-policy story 영역).

## Test plan
- [x] `test_mcp_1922_delete_artifact_tool.py` (신규, 6 tests): 생성자 삭제 성공 · 비-생성자 가독 403 · 존재하지 않는 artifact 가독 404 · 라우터 `_err()` 엔벨로프 shape 직접 검증 · realdb 왕복(creator-only 403 raw HTTP + create→delete→get/list 제외 확인, 로컬 pg@16 create_all)
- [x] `test_mcp_axis_prefix_b_surface.py::test_tool_names_and_param_models_untouched` — `_TOOL_DEFS` 111→112
- [x] `tests/mcp/test_contract.py::test_total_tool_count` + `test_all_expected_tools_registered`(양방향) — 112→113, `sprintable_delete_artifact` EXPECTED_TOOLS 추가
- [x] `test_toolset_catalog.py::test_tool_group_mapping_examples` — `sprintable_delete_artifact` == `"canvas"` 회귀 가드(#2010과 동일 패턴)
- [x] `test_e_recruit_s2_compose_prompt.py::test_compose_kit_tool_cheat_sheet_includes_delete_artifact_in_canvas_group` — 치트시트 노출 회귀 가드(#2010과 동일 패턴)
- [x] 전체 회귀: 위 파일들 전부 + 기존 `test_e_canvas_c1_s3_visual_artifact_realdb.py` 합쳐 81 passed (realdb 포함), mock-only는 73 passed / 8 skipped
- [x] 이 diff 범위 ruff 에러 = baseline과 동일(34개, 사전 존재 — 이 PR이 신규 유발한 것 없음. backend Python ruff는 CI 게이트 아님)

🤖 Generated with [Claude Code](https://claude.com/claude-code)