### PR TITLE
[BE] create_artifact 빈 nodes 검증 — 빈 산출물 생성 방지 (story #1920)

### DIFF
--- a/backend/app/schemas/visual_artifact.py
+++ b/backend/app/schemas/visual_artifact.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 # 뷰어 통합 재설계(story 1948d19d): 비정상 거대값 방어 상한. Figma류 대형 캔버스 툴의 실용 한계보다
 # 넉넉하되(20000px), 정수 오버플로/스토리지 남용성 값은 확실히 막는 값 — 특정 스펙 수치가 아니라
@@ -53,7 +53,12 @@ class CreateArtifactRequest(BaseModel):
     epic_id: uuid.UUID | None = None
     doc_id: uuid.UUID | None = None
     source: str = "created"
-    nodes: list[ArtifactNodeIn] = []
+    # story #1920: 빈 nodes로 생성된 산출물이 조용히 만들어져 온보딩/뷰어 혼란을 유발(8de4e981
+    # 계열 사고 재발 방지 — 그 사고 자체의 사후처리는 #1922로 별도 완료, 이건 재발 방지책).
+    # min_length=1 — loop.py::LoopDecisionRequest.decisions와 동일 컨벤션(Field(min_length=1)).
+    # 빈 리스트는 FastAPI 기본 RequestValidationError → 422(이 스키마 파일의 기존 필드
+    # validator들과 마찬가지로 라우터에서 별도 400 처리하지 않음 — 코드베이스 전역 컨벤션).
+    nodes: list[ArtifactNodeIn] = Field(min_length=1)
     # 유나 §11 갭②: 최초 버전의 변경 이유(보통 "초기 생성"류·선택제).
     summary: str | None = None
     # 뷰어 통합 재설계(story 1948d19d): 생성 시점 프레임 크기 선언(선택 — 미선언=FE 기본 아트보드).

--- a/backend/tests/test_04e059e5_artifact_created_event_realdb.py
+++ b/backend/tests/test_04e059e5_artifact_created_event_realdb.py
@@ -127,7 +127,7 @@ async def test_create_artifact_agent_creator_gets_event_self_notified():
         await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], creator_id)
         client = _client_for(app)
         try:
-            resp = await client.post("/api/v2/visual-artifacts", json={"title": "Standalone"})
+            resp = await client.post("/api/v2/visual-artifacts", json={"title": "Standalone", "nodes": [{"type": "text", "props": {}}]})
             assert resp.status_code == 201, resp.text
         finally:
             await client.aclose()
@@ -174,7 +174,7 @@ async def test_create_artifact_human_creator_gets_notification_self_notified():
         await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], creator_id)
         client = _client_for(app)
         try:
-            resp = await client.post("/api/v2/visual-artifacts", json={"title": "Standalone Human"})
+            resp = await client.post("/api/v2/visual-artifacts", json={"title": "Standalone Human", "nodes": [{"type": "text", "props": {}}]})
             assert resp.status_code == 201, resp.text
         finally:
             await client.aclose()
@@ -223,7 +223,8 @@ async def test_create_artifact_linked_story_different_assignee_both_notified():
         client = _client_for(app)
         try:
             resp = await client.post(
-                "/api/v2/visual-artifacts", json={"title": "Linked", "story_id": str(story_id)},
+                "/api/v2/visual-artifacts",
+                json={"title": "Linked", "story_id": str(story_id), "nodes": [{"type": "text", "props": {}}]},
             )
             assert resp.status_code == 201, resp.text
         finally:
@@ -273,7 +274,8 @@ async def test_create_artifact_linked_story_same_assignee_dedup_single_notificat
         client = _client_for(app)
         try:
             resp = await client.post(
-                "/api/v2/visual-artifacts", json={"title": "SelfAssigned", "story_id": str(story_id)},
+                "/api/v2/visual-artifacts",
+                json={"title": "SelfAssigned", "story_id": str(story_id), "nodes": [{"type": "text", "props": {}}]},
             )
             assert resp.status_code == 201, resp.text
         finally:
@@ -320,7 +322,7 @@ async def test_edit_and_comment_events_still_fire_no_regression():
         await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], creator_id)
         client = _client_for(app)
         try:
-            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Edit Target"})
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Edit Target", "nodes": [{"type": "text", "props": {}}]})
             artifact_id = create_resp.json()["data"]["id"]
         finally:
             await client.aclose()

--- a/backend/tests/test_b4027b2e_visual_artifacts_scope_group_realdb.py
+++ b/backend/tests/test_b4027b2e_visual_artifacts_scope_group_realdb.py
@@ -155,7 +155,7 @@ async def test_create_artifact_canvas_scope_201_no_overblock():
         await _setup_app_api_key(app, Session, seeded["org_id"], seeded["project_id"], scope=["canvas"])
         client = _client_for(app)
         try:
-            resp = await client.post("/api/v2/visual-artifacts", json={"title": "Legit"})
+            resp = await client.post("/api/v2/visual-artifacts", json={"title": "Legit", "nodes": [{"type": "text", "props": {}}]})
             assert resp.status_code == 201, resp.text
         finally:
             await client.aclose()
@@ -176,7 +176,7 @@ async def test_create_artifact_legacy_write_scope_201_no_regression():
         await _setup_app_api_key(app, Session, seeded["org_id"], seeded["project_id"], scope=["read", "write"])
         client = _client_for(app)
         try:
-            resp = await client.post("/api/v2/visual-artifacts", json={"title": "Legacy"})
+            resp = await client.post("/api/v2/visual-artifacts", json={"title": "Legacy", "nodes": [{"type": "text", "props": {}}]})
             assert resp.status_code == 201, resp.text
         finally:
             await client.aclose()
@@ -197,7 +197,7 @@ async def test_create_artifact_jwt_human_201_no_regression():
         await _setup_app_jwt(app, Session, seeded["org_id"], seeded["project_id"])
         client = _client_for(app)
         try:
-            resp = await client.post("/api/v2/visual-artifacts", json={"title": "Human"})
+            resp = await client.post("/api/v2/visual-artifacts", json={"title": "Human", "nodes": [{"type": "text", "props": {}}]})
             assert resp.status_code == 201, resp.text
         finally:
             await client.aclose()
@@ -220,7 +220,7 @@ async def test_edit_artifact_toolgroup_scope_without_canvas_403():
         await _setup_app_jwt(app, Session, seeded["org_id"], seeded["project_id"])
         client = _client_for(app)
         try:
-            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target"})
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target", "nodes": [{"type": "text", "props": {}}]})
             artifact_id = create_resp.json()["data"]["id"]
         finally:
             await client.aclose()
@@ -253,7 +253,7 @@ async def test_edit_artifact_canvas_scope_201_no_overblock():
         await _setup_app_jwt(app, Session, seeded["org_id"], seeded["project_id"])
         client = _client_for(app)
         try:
-            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target"})
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target", "nodes": [{"type": "text", "props": {}}]})
             artifact_id = create_resp.json()["data"]["id"]
         finally:
             await client.aclose()
@@ -288,7 +288,7 @@ async def test_delete_artifact_toolgroup_scope_without_canvas_403():
         await _setup_app_jwt(app, Session, seeded["org_id"], seeded["project_id"])
         client = _client_for(app)
         try:
-            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target"})
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target", "nodes": [{"type": "text", "props": {}}]})
             artifact_id = create_resp.json()["data"]["id"]
         finally:
             await client.aclose()
@@ -320,7 +320,7 @@ async def test_add_comment_toolgroup_scope_without_canvas_403():
         await _setup_app_jwt(app, Session, seeded["org_id"], seeded["project_id"])
         client = _client_for(app)
         try:
-            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target"})
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target", "nodes": [{"type": "text", "props": {}}]})
             artifact_id = create_resp.json()["data"]["id"]
         finally:
             await client.aclose()
@@ -354,7 +354,7 @@ async def test_propose_canonical_toolgroup_scope_without_canvas_403():
         await _setup_app_jwt(app, Session, seeded["org_id"], seeded["project_id"])
         client = _client_for(app)
         try:
-            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target"})
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target", "nodes": [{"type": "text", "props": {}}]})
             artifact_id = create_resp.json()["data"]["id"]
         finally:
             await client.aclose()
@@ -386,7 +386,7 @@ async def test_get_artifact_read_route_unaffected_by_scope():
         await _setup_app_jwt(app, Session, seeded["org_id"], seeded["project_id"])
         client = _client_for(app)
         try:
-            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Readable"})
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Readable", "nodes": [{"type": "text", "props": {}}]})
             artifact_id = create_resp.json()["data"]["id"]
         finally:
             await client.aclose()
@@ -418,7 +418,7 @@ async def test_create_spec_pin_toolgroup_scope_without_canvas_403():
         await _setup_app_jwt(app, Session, seeded["org_id"], seeded["project_id"])
         client = _client_for(app)
         try:
-            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target"})
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target", "nodes": [{"type": "text", "props": {}}]})
             artifact_id = create_resp.json()["data"]["id"]
         finally:
             await client.aclose()
@@ -451,7 +451,7 @@ async def test_create_spec_pin_canvas_scope_201_no_overblock():
         await _setup_app_jwt(app, Session, seeded["org_id"], seeded["project_id"])
         client = _client_for(app)
         try:
-            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target"})
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target", "nodes": [{"type": "text", "props": {}}]})
             artifact_id = create_resp.json()["data"]["id"]
         finally:
             await client.aclose()
@@ -497,7 +497,7 @@ async def test_update_delete_spec_pin_toolgroup_scope_without_canvas_403():
         await _setup_app_jwt(app, Session, seeded["org_id"], seeded["project_id"])
         client = _client_for(app)
         try:
-            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target"})
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target", "nodes": [{"type": "text", "props": {}}]})
             artifact_id = create_resp.json()["data"]["id"]
             pin_resp = await client.post(
                 f"/api/v2/visual-artifacts/{artifact_id}/pins",

--- a/backend/tests/test_e_canvas_1948d19d_canvas_bounds_realdb.py
+++ b/backend/tests/test_e_canvas_1948d19d_canvas_bounds_realdb.py
@@ -98,7 +98,7 @@ async def test_create_with_canvas_bounds_declared():
         try:
             resp = await client.post(
                 "/api/v2/visual-artifacts",
-                json={"title": "Framed", "canvas_bounds": {"w": 1200, "h": 800}},
+                json={"title": "Framed", "canvas_bounds": {"w": 1200, "h": 800}, "nodes": [{"type": "text", "props": {}}]},
             )
             assert resp.status_code == 201, resp.text
             body = resp.json()["data"]
@@ -132,7 +132,10 @@ async def test_create_without_canvas_bounds_is_null():
         await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
         client = _client_for(app)
         try:
-            resp = await client.post("/api/v2/visual-artifacts", json={"title": "Unframed"})
+            resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Unframed", "nodes": [{"type": "text", "props": {}}]},
+            )
             assert resp.status_code == 201, resp.text
             assert resp.json()["data"]["canvas_bounds"] is None
         finally:
@@ -157,7 +160,7 @@ async def test_edit_without_canvas_bounds_carries_forward():
         try:
             create_resp = await client.post(
                 "/api/v2/visual-artifacts",
-                json={"title": "Carry", "canvas_bounds": {"w": 640, "h": 480}},
+                json={"title": "Carry", "canvas_bounds": {"w": 640, "h": 480}, "nodes": [{"type": "text", "props": {}}]},
             )
             artifact_id = create_resp.json()["data"]["id"]
 
@@ -194,7 +197,7 @@ async def test_edit_with_explicit_canvas_bounds_redeclares_and_bumps_version():
         try:
             create_resp = await client.post(
                 "/api/v2/visual-artifacts",
-                json={"title": "Redeclare", "canvas_bounds": {"w": 640, "h": 480}},
+                json={"title": "Redeclare", "canvas_bounds": {"w": 640, "h": 480}, "nodes": [{"type": "text", "props": {}}]},
             )
             artifact_id = create_resp.json()["data"]["id"]
 
@@ -271,7 +274,10 @@ async def test_edit_with_no_operations_and_no_canvas_bounds_422():
         await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
         client = _client_for(app)
         try:
-            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Empty Edit"})
+            create_resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Empty Edit", "nodes": [{"type": "text", "props": {}}]},
+            )
             artifact_id = create_resp.json()["data"]["id"]
 
             resp = await client.post(f"/api/v2/visual-artifacts/{artifact_id}/edit", json={})
@@ -358,7 +364,7 @@ async def test_mcp_create_and_edit_canvas_bounds_roundtrip():
 
         from sprintable_mcp import api_client as api_client_mod
         from sprintable_mcp.tools.visual_artifacts import (
-            CanvasBoundsInput, CreateArtifactInput, EditArtifactInput,
+            ArtifactNodeInput, CanvasBoundsInput, CreateArtifactInput, EditArtifactInput,
             create_artifact, edit_artifact,
         )
 
@@ -376,6 +382,7 @@ async def test_mcp_create_and_edit_canvas_bounds_roundtrip():
         try:
             created = json.loads((await create_artifact(CreateArtifactInput(
                 title="MCP Framed", canvas_bounds=CanvasBoundsInput(w=1024, h=768),
+                nodes=[ArtifactNodeInput(type="text")],
             )))[0].text)
             assert created["canvas_bounds"] == {"w": 1024, "h": 768}
 

--- a/backend/tests/test_e_canvas_7fe16274_spec_pin_realdb.py
+++ b/backend/tests/test_e_canvas_7fe16274_spec_pin_realdb.py
@@ -98,7 +98,10 @@ async def test_create_coord_pin_and_list():
         await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
         client = _client_for(app)
         try:
-            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Pinned"})
+            create_resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Pinned", "nodes": [{"type": "text", "props": {}}]},
+            )
             artifact_id = create_resp.json()["data"]["id"]
 
             pin_resp = await client.post(
@@ -176,7 +179,10 @@ async def test_create_node_pin_cross_artifact_forgery_blocked():
             )
             other_node_id = other_resp.json()["data"]["nodes"][0]["id"]
 
-            target_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target"})
+            target_resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Target", "nodes": [{"type": "text", "props": {}}]},
+            )
             target_id = target_resp.json()["data"]["id"]
 
             pin_resp = await client.post(
@@ -211,7 +217,10 @@ async def test_create_pin_malformed_anchor_422(body):
         await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
         client = _client_for(app)
         try:
-            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Malformed"})
+            create_resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Malformed", "nodes": [{"type": "text", "props": {}}]},
+            )
             artifact_id = create_resp.json()["data"]["id"]
 
             resp = await client.post(f"/api/v2/visual-artifacts/{artifact_id}/pins", json=body)
@@ -235,7 +244,10 @@ async def test_create_pin_empty_description_422():
         await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
         client = _client_for(app)
         try:
-            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Empty Desc"})
+            create_resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Empty Desc", "nodes": [{"type": "text", "props": {}}]},
+            )
             artifact_id = create_resp.json()["data"]["id"]
 
             resp = await client.post(
@@ -262,7 +274,10 @@ async def test_update_pin_description():
         await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
         client = _client_for(app)
         try:
-            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Editable"})
+            create_resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Editable", "nodes": [{"type": "text", "props": {}}]},
+            )
             artifact_id = create_resp.json()["data"]["id"]
             pin_resp = await client.post(
                 f"/api/v2/visual-artifacts/{artifact_id}/pins",
@@ -299,7 +314,10 @@ async def test_delete_pin():
         await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
         client = _client_for(app)
         try:
-            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Deletable"})
+            create_resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Deletable", "nodes": [{"type": "text", "props": {}}]},
+            )
             artifact_id = create_resp.json()["data"]["id"]
             pin_resp = await client.post(
                 f"/api/v2/visual-artifacts/{artifact_id}/pins",
@@ -332,7 +350,10 @@ async def test_edit_artifact_carries_coord_pin_forward():
         await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
         client = _client_for(app)
         try:
-            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Carry"})
+            create_resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Carry", "nodes": [{"type": "text", "props": {}}]},
+            )
             artifact_id = create_resp.json()["data"]["id"]
             await client.post(
                 f"/api/v2/visual-artifacts/{artifact_id}/pins",
@@ -458,7 +479,10 @@ async def test_previous_version_pin_immutable_and_not_editable():
         await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
         client = _client_for(app)
         try:
-            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Snapshot"})
+            create_resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Snapshot", "nodes": [{"type": "text", "props": {}}]},
+            )
             artifact_id = create_resp.json()["data"]["id"]
             pin_resp = await client.post(
                 f"/api/v2/visual-artifacts/{artifact_id}/pins",
@@ -511,7 +535,7 @@ async def test_mcp_create_and_list_spec_pin_roundtrip():
 
         from sprintable_mcp import api_client as api_client_mod
         from sprintable_mcp.tools.visual_artifacts import (
-            CreateArtifactInput, CreateSpecPinInput, ListSpecPinsInput,
+            ArtifactNodeInput, CreateArtifactInput, CreateSpecPinInput, ListSpecPinsInput,
             create_artifact, create_spec_pin, list_spec_pins,
         )
 
@@ -533,7 +557,9 @@ async def test_mcp_create_and_list_spec_pin_roundtrip():
         real_client.post = _post
         real_client.get = _get
         try:
-            created = json.loads((await create_artifact(CreateArtifactInput(title="MCP Pinned")))[0].text)
+            created = json.loads((await create_artifact(CreateArtifactInput(
+                title="MCP Pinned", nodes=[ArtifactNodeInput(type="text")],
+            )))[0].text)
 
             pin_created = json.loads((await create_spec_pin(CreateSpecPinInput(
                 artifact_id=created["id"], anchor_type="coord", anchor_x=3.0, anchor_y=4.0,

--- a/backend/tests/test_e_canvas_c1_s3_visual_artifact_realdb.py
+++ b/backend/tests/test_e_canvas_c1_s3_visual_artifact_realdb.py
@@ -110,7 +110,10 @@ async def test_create_artifact_cross_org_story_link_blocked():
         try:
             resp = await client.post(
                 "/api/v2/visual-artifacts",
-                json={"title": "Injected", "story_id": str(seeded["story_b_id"])},
+                json={
+                    "title": "Injected", "story_id": str(seeded["story_b_id"]),
+                    "nodes": [{"type": "text", "props": {}}],
+                },
             )
             assert resp.status_code == 404, resp.text
         finally:
@@ -212,9 +215,15 @@ async def test_list_artifacts_by_story_id():
         try:
             await client.post(
                 "/api/v2/visual-artifacts",
-                json={"title": "Attached", "story_id": str(seeded["story_a_id"])},
+                json={
+                    "title": "Attached", "story_id": str(seeded["story_a_id"]),
+                    "nodes": [{"type": "text", "props": {}}],
+                },
             )
-            await client.post("/api/v2/visual-artifacts", json={"title": "Unattached"})
+            await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Unattached", "nodes": [{"type": "text", "props": {}}]},
+            )
 
             resp = await client.get(f"/api/v2/visual-artifacts?story_id={seeded['story_a_id']}")
             assert resp.status_code == 200
@@ -243,7 +252,10 @@ async def test_delete_artifact_creator_only():
         await _setup_app(app, Session, seeded["org_a_id"], seeded["project_a_id"], user_id=creator_id)
         client = _client_for(app)
         try:
-            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Mine"})
+            create_resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Mine", "nodes": [{"type": "text", "props": {}}]},
+            )
             artifact_id = create_resp.json()["data"]["id"]
         finally:
             await client.aclose()

--- a/backend/tests/test_e_security_sec_s8_r_artifact_link_project_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_r_artifact_link_project_scope_realdb.py
@@ -126,7 +126,10 @@ async def test_create_artifact_same_org_cross_project_story_link_blocked():
         try:
             resp = await client.post(
                 "/api/v2/visual-artifacts",
-                json={"title": "Injected", "story_id": str(seeded["story_b_id"])},
+                json={
+                    "title": "Injected", "story_id": str(seeded["story_b_id"]),
+                    "nodes": [{"type": "text", "props": {}}],
+                },
             )
             assert resp.status_code == 404, resp.text
         finally:
@@ -150,7 +153,10 @@ async def test_create_artifact_same_org_cross_project_epic_link_blocked():
         try:
             resp = await client.post(
                 "/api/v2/visual-artifacts",
-                json={"title": "Injected", "epic_id": str(seeded["epic_b_id"])},
+                json={
+                    "title": "Injected", "epic_id": str(seeded["epic_b_id"]),
+                    "nodes": [{"type": "text", "props": {}}],
+                },
             )
             assert resp.status_code == 404, resp.text
         finally:
@@ -174,7 +180,10 @@ async def test_create_artifact_same_org_cross_project_doc_link_blocked():
         try:
             resp = await client.post(
                 "/api/v2/visual-artifacts",
-                json={"title": "Injected", "doc_id": str(seeded["doc_b_id"])},
+                json={
+                    "title": "Injected", "doc_id": str(seeded["doc_b_id"]),
+                    "nodes": [{"type": "text", "props": {}}],
+                },
             )
             assert resp.status_code == 404, resp.text
         finally:
@@ -199,7 +208,10 @@ async def test_create_artifact_same_project_story_link_still_works():
         try:
             resp = await client.post(
                 "/api/v2/visual-artifacts",
-                json={"title": "Legit", "story_id": str(seeded["story_a_id"])},
+                json={
+                    "title": "Legit", "story_id": str(seeded["story_a_id"]),
+                    "nodes": [{"type": "text", "props": {}}],
+                },
             )
             assert resp.status_code == 201, resp.text
             assert resp.json()["data"]["story_id"] == str(seeded["story_a_id"])

--- a/backend/tests/test_mcp_1920_create_artifact_empty_nodes_validation.py
+++ b/backend/tests/test_mcp_1920_create_artifact_empty_nodes_validation.py
@@ -1,0 +1,369 @@
+"""story #1920: create_artifact 빈 nodes 검증 — 빈 산출물 생성 방지.
+
+배경: CreateArtifactRequest.nodes에 최소 길이 제약이 없어 REST 직접 호출은 nodes=[]로,
+MCP sprintable_create_artifact 도구는 `if args.nodes: body["nodes"] = [...]`(falsy면 키
+자체 미전송)로 각각 빈-nodes 산출물을 조용히 생성할 수 있었다(8de4e981류 사고 재발 지점).
+그 사고 자체의 사후처리(소프트 삭제 도구)는 #1922로 이미 별도 완료 — 이 스토리는 순수
+"애초에 못 만들게" 재발 방지다.
+
+수정: backend/app/schemas/visual_artifact.py::CreateArtifactRequest.nodes를
+`Field(min_length=1)`로 바꿔(기존 `= []` 디폴트 제거) — loop.py::LoopDecisionRequest.decisions
+와 동일 하우스 컨벤션. 스키마 레벨 제약이라 FastAPI가 기본 RequestValidationError → 422로
+거절한다(라우터 400 커스텀 아님 — 이 파일의 기존 field_validator들과 동일하게 스키마 레벨
+422가 이 코드베이스 전역 컨벤션, docs/AC의 "400"은 문면 표현으로 다루지 않음).
+
+MCP 경로 검증: api_client.py::_extract_error_message가 이미 FastAPI 422 검증 배열 shape
+(`{"detail": [{"loc","msg","type"}]}`)을 가독 텍스트로 뽑는 로직(shape 3, `_format_validation_errors`)
+을 갖고 있어 이 새 제약도 별도 코드 없이 그대로 커버된다 — 아래에서 실제 값으로 재확인.
+"""
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.visual_artifact import CreateArtifactRequest
+from sprintable_mcp.api_client import SprintableApiError, _extract_error_message
+from sprintable_mcp.tools import visual_artifacts as va
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── 0. 스키마 레벨 — 빈 리스트/누락 모두 거부, 유효 nodes는 통과 ──────────────────
+
+def test_schema_rejects_empty_nodes_list():
+    with pytest.raises(ValidationError) as exc_info:
+        CreateArtifactRequest(title="t", nodes=[])
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert errors[0]["type"] == "too_short"
+    assert errors[0]["loc"] == ("nodes",)
+
+
+def test_schema_rejects_omitted_nodes():
+    with pytest.raises(ValidationError) as exc_info:
+        CreateArtifactRequest(title="t")
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert errors[0]["loc"] == ("nodes",)
+    assert errors[0]["type"] == "missing"
+
+
+def test_schema_accepts_one_or_more_nodes():
+    """회귀 가드 — 정상 nodes 경로는 완전 무회귀."""
+    req = CreateArtifactRequest(title="t", nodes=[{"type": "text", "props": {"content": "hi"}}])
+    assert len(req.nodes) == 1
+    assert req.nodes[0].type == "text"
+
+    req2 = CreateArtifactRequest(
+        title="t",
+        nodes=[{"type": "text"}, {"type": "html_blob", "props": {"html": "<div/>"}}],
+    )
+    assert len(req2.nodes) == 2
+
+
+# ── 1. FastAPI 422 검증 배열이 api_client._extract_error_message에서 가독 텍스트로 나오는지 ──
+# (backend/sprintable_mcp/api_client.py::_format_validation_errors — "shape 3"가 이 값을 커버)
+
+def test_extract_error_message_readable_for_empty_nodes_422():
+    body = {
+        "detail": [
+            {
+                "type": "too_short",
+                "loc": ["body", "nodes"],
+                "msg": "List should have at least 1 item after validation, not 0",
+                "input": [],
+                "ctx": {"field_type": "List", "min_length": 1, "actual_length": 0},
+            }
+        ]
+    }
+    msg = _extract_error_message(422, body)
+    # "Sprintable API 422"류 불투명 삼킴이 아니라 field명 + 사람이 읽을 수 있는 사유가 나와야 한다.
+    assert msg == "Sprintable API 422 validation: nodes: List should have at least 1 item after validation, not 0"
+    assert "nodes" in msg
+    assert msg != "Sprintable API 422"
+
+
+def test_extract_error_message_readable_for_omitted_nodes_422():
+    body = {
+        "detail": [
+            {"type": "missing", "loc": ["body", "nodes"], "msg": "Field required", "input": {"title": "t"}},
+        ]
+    }
+    msg = _extract_error_message(422, body)
+    assert msg == "Sprintable API 422 validation: nodes: Field required"
+    assert msg != "Sprintable API 422"
+
+
+# ── 2. MCP 도구 레벨(mock) — 빈/누락 nodes로 백엔드가 SprintableApiError를 던지면 err()로 ──
+#    가독 텍스트가 그대로 나오는지 (test_mcp_1922_delete_artifact_tool.py와 동형 패턴)
+
+def _error_client(exc: Exception):
+    c = MagicMock()
+    c.project_id = "proj-1"
+    c.require_project_id = MagicMock(return_value="proj-1")
+    c.post = AsyncMock(side_effect=exc)
+    return c
+
+
+async def test_mcp_create_artifact_empty_nodes_readable_error():
+    readable = "Sprintable API 422 validation: nodes: List should have at least 1 item after validation, not 0"
+    client = _error_client(SprintableApiError(422, readable))
+    args = va.CreateArtifactInput(title="Empty Draft", nodes=[])
+    with patch.object(va, "client", client):
+        out = await va.create_artifact(args)
+    text = out[0].text
+    assert text.startswith("Error:")
+    assert "nodes" in text
+    assert "List should have at least 1 item" in text
+    # 불투명 실패 반증 — 검증 배열이 삼켜져 "422"만 남는 회귀를 막는다.
+    assert text != "Error: Sprintable API 422"
+
+
+async def test_mcp_create_artifact_omitted_nodes_readable_error():
+    """args.nodes=None(도구 시그니처상 선택제) → `if args.nodes:`가 falsy라 body에 "nodes" 키
+    자체가 실리지 않는다(원래 사고 root cause 경로) — 백엔드가 이제 "missing"으로 거절하고,
+    그 사유가 여전히 가독 텍스트로 나와야 한다."""
+    readable = "Sprintable API 422 validation: nodes: Field required"
+    client = _error_client(SprintableApiError(422, readable))
+    args = va.CreateArtifactInput(title="No Nodes At All")
+    assert args.nodes is None
+    with patch.object(va, "client", client):
+        out = await va.create_artifact(args)
+    text = out[0].text
+    assert text.startswith("Error:")
+    assert "nodes" in text
+    assert "Field required" in text
+
+
+async def test_mcp_create_artifact_success_with_nodes_unaffected():
+    """회귀 가드 — 정상 nodes 경로는 MCP 레벨에서도 완전 무회귀."""
+    client = MagicMock()
+    client.project_id = "proj-1"
+    client.require_project_id = MagicMock(return_value="proj-1")
+    client.post = AsyncMock(return_value={"id": "a1", "title": "With Nodes"})
+    args = va.CreateArtifactInput(
+        title="With Nodes",
+        nodes=[va.ArtifactNodeInput(type="text", props={"content": "hi"})],
+    )
+    with patch.object(va, "client", client):
+        out = await va.create_artifact(args)
+    data = json.loads(out[0].text)
+    assert data == {"id": "a1", "title": "With Nodes"}
+    sent_body = client.post.call_args.kwargs["json"]
+    assert sent_body["nodes"] == [{"type": "text", "props": {"content": "hi"}}]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# realdb: 라우터 실 HTTP 왕복 + MCP 실 왕복(모의 없이) — 422 거절 + 성공 경로 무회귀
+# ═══════════════════════════════════════════════════════════════════════════
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark_realdb = pytest.mark.skipif(
+    not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"
+)
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id}
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, project_id, user_id=None):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id or uuid.uuid4()), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytestmark_realdb
+@pytest.mark.anyio
+async def test_realdb_create_artifact_empty_nodes_rejected_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/visual-artifacts", json={"title": "Empty", "nodes": []})
+            assert resp.status_code == 422, resp.text
+            body = resp.json()
+            assert body["detail"][0]["loc"] == ["body", "nodes"]
+            assert "at least 1 item" in body["detail"][0]["msg"]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytestmark_realdb
+@pytest.mark.anyio
+async def test_realdb_create_artifact_omitted_nodes_rejected_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/visual-artifacts", json={"title": "No Nodes Field"})
+            assert resp.status_code == 422, resp.text
+            body = resp.json()
+            assert body["detail"][0]["loc"] == ["body", "nodes"]
+            assert body["detail"][0]["type"] == "missing"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytestmark_realdb
+@pytest.mark.anyio
+async def test_realdb_create_artifact_with_nodes_still_succeeds_201():
+    """회귀 가드 — 이 스토리 이전에도 통과하던 정상 경로가 여전히 201로 통과해야 한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Has Nodes", "nodes": [{"type": "text", "props": {"content": "hi"}}]},
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()["data"]
+            assert len(body["nodes"]) == 1
+            assert body["nodes"][0]["type"] == "text"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytestmark_realdb
+@pytest.mark.anyio
+async def test_realdb_mcp_create_artifact_empty_nodes_readable_error_no_mock():
+    """AC 핵심: 모킹 없이 실 HTTP 왕복으로 MCP sprintable_create_artifact가 nodes=[]를
+    거절할 때 반환 텍스트가 사람이 읽을 수 있는지(불투명 '422'가 아닌지) 실증.
+
+    주의: CreateArtifactInput(nodes=[])는 도구 쪽 `if args.nodes:`(falsy 가드, 이 스토리가
+    다루지 않는 기존 코드)가 빈 리스트를 "미지정"과 동일하게 취급해 body에 "nodes" 키
+    자체를 싣지 않는다 — 원래 사고의 root cause 경로 그대로다. 그래서 서버는 too_short가
+    아니라 missing으로 거절하는데, 이 테스트의 초점은 정확한 에러 타입이 아니라 "그 결과가
+    사람이 읽을 수 있는 텍스트로 나오는가"이므로 무관하다."""
+    import httpx
+
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+
+        os.environ.setdefault("SPRINTABLE_API_URL", "http://test")
+        os.environ.setdefault("AGENT_API_KEY", "sk_test")
+
+        from sprintable_mcp.tools.visual_artifacts import CreateArtifactInput, create_artifact
+        from sprintable_mcp import api_client as api_client_mod
+        from sprintable_mcp.api_client import SprintableApiError, _extract_error_message
+
+        transport = httpx.ASGITransport(app=app)
+        real_client = api_client_mod.client
+        test_http_client = httpx.AsyncClient(transport=transport, base_url="http://test")
+
+        async def _post(path, **kwargs):
+            r = await test_http_client.post(path, **kwargs)
+            if not r.is_success:
+                body: object
+                try:
+                    body = r.json()
+                except Exception:
+                    body = r.text
+                raise SprintableApiError(r.status_code, _extract_error_message(r.status_code, body), body)
+            return r.json()["data"]
+
+        orig_post = real_client.post
+        real_client.post = _post
+        try:
+            result = await create_artifact(CreateArtifactInput(title="Empty Draft", nodes=[]))
+            text = result[0].text
+            assert text.startswith("Error:")
+            assert "nodes" in text
+            assert "Field required" in text  # falsy 가드 경로 → "missing"(위 docstring 참조)
+            assert text != "Error: Sprintable API 422"
+        finally:
+            real_client.post = orig_post
+            await test_http_client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_mcp_1922_delete_artifact_tool.py
+++ b/backend/tests/test_mcp_1922_delete_artifact_tool.py
@@ -188,7 +188,10 @@ async def test_realdb_creator_only_403_readable_via_http():
         await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], user_id=creator_id)
         client = _client_for(app)
         try:
-            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Mine"})
+            create_resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Mine", "nodes": [{"type": "text", "props": {}}]},
+            )
             artifact_id = create_resp.json()["data"]["id"]
         finally:
             await client.aclose()
@@ -236,7 +239,7 @@ async def test_realdb_mcp_create_delete_then_get_and_list_exclude():
         os.environ.setdefault("AGENT_API_KEY", "sk_test")
 
         from sprintable_mcp.tools.visual_artifacts import (
-            CreateArtifactInput, DeleteArtifactInput, GetArtifactInput, ListArtifactsInput,
+            ArtifactNodeInput, CreateArtifactInput, DeleteArtifactInput, GetArtifactInput, ListArtifactsInput,
             create_artifact, delete_artifact, get_artifact, list_artifacts,
         )
         from sprintable_mcp import api_client as api_client_mod
@@ -263,7 +266,9 @@ async def test_realdb_mcp_create_delete_then_get_and_list_exclude():
         orig_post, orig_get, orig_delete = real_client.post, real_client.get, real_client.delete
         real_client.post, real_client.get, real_client.delete = _post, _get, _delete
         try:
-            created = json.loads((await create_artifact(CreateArtifactInput(title="To Delete")))[0].text)
+            created = json.loads((await create_artifact(CreateArtifactInput(
+                title="To Delete", nodes=[ArtifactNodeInput(type="text")],
+            )))[0].text)
             artifact_id = created["id"]
 
             # 삭제 전: list에 보임.


### PR DESCRIPTION
## Summary
- `CreateArtifactRequest.nodes`(`backend/app/schemas/visual_artifact.py`)에 최소 길이 제약이 없어, REST 직접 호출(`nodes: []`)과 MCP `sprintable_create_artifact`(호출부의 `if args.nodes:` falsy 가드가 빈 리스트를 "미지정"과 동일 취급 → body에 `nodes` 키 자체 미전송) 양쪽 모두 nodes가 0개인 `VisualArtifact`+`ArtifactVersion`을 조용히 생성할 수 있었다. `8de4e981` 사고 계열의 재발 방지책(그 사고 자체의 사후처리는 `#1922` `sprintable_delete_artifact`로 이미 별도 완료 — 이 스토리는 건드리지 않음).
- `nodes: list[ArtifactNodeIn] = []` → `nodes: list[ArtifactNodeIn] = Field(min_length=1)`로 변경. `backend/app/schemas/loop.py::LoopDecisionRequest.decisions`가 이미 쓰고 있는 정확히 동일한 컨벤션(`Field(min_length=1)`, 디폴트 없음)을 그대로 따랐다 — nodes 생략과 `nodes: []` 둘 다 거절된다.

## 400 vs 422 결정
- AC 문구는 "400 거부"지만, 이 스키마 파일 자체가 이미 여러 `@field_validator`(`content must not be empty`, `description must not be empty`, `EditArtifactRequest._require_at_least_one_change` 등)로 스키마 레벨 검증 → FastAPI 기본 422를 쓰고 있고, `loop.py`의 `Field(min_length=1)` 선례도 동일하다. `app/main.py`에는 `RequestValidationError`용 커스텀 핸들러가 없어(HTTPException/RateLimitExceeded/Exception만 등록) FastAPI 기본 422 shape(`{"detail": [{"loc","msg","type"}]}`)이 그대로 나간다.
- 이 코드베이스 전역 컨벤션(스키마 제약 = 422)을 AC 문면(400)보다 우선했다 — 라우터에 별도 400 커스텀 체크를 추가하는 것은 이 파일의 기존 패턴과 불일치하고 불필요한 코드 중복이라 판단.
- 실측: `POST /api/v2/visual-artifacts` with `nodes: []` → `422 {"detail":[{"type":"too_short","loc":["body","nodes"],"msg":"List should have at least 1 item after validation, not 0", ...}]}`. `nodes` 생략 → `422 {"detail":[{"type":"missing","loc":["body","nodes"],"msg":"Field required"}]}`.

## MCP 에러 경로
- `backend/sprintable_mcp/api_client.py::_extract_error_message`/`_format_validation_errors`가 이미 "FastAPI 422 검증 배열"(shape 3)을 `"필드: 메시지"` 형태의 가독 텍스트로 뽑는 로직을 갖고 있어 — 이 새 제약도 MCP 쪽 코드 변경 없이 그대로 커버된다. 실측: `Sprintable API 422 validation: nodes: List should have at least 1 item after validation, not 0` (불투명 `"Sprintable API 422"`가 아님).
- `sprintable_create_artifact` MCP 도구는 `if args.nodes:`가 falsy라 `nodes=[]` 호출도 body에 키가 안 실려 실제로는 `missing`(`Field required`) 422로 거절된다 — 두 케이스 모두 `err()`를 거쳐 사람이 읽을 수 있는 `"Error: ..."` 텍스트로 나오는지 테스트로 확인.

## FE 확인(빈 nodes 생성 UX 없음)
- `apps/web/src/components/canvas/artifact-editor.tsx`: `changeCount = countNodeChanges(baseline, nodes)` → `CommitBar`에 전달, `commit-bar.tsx`가 `disabled={changeCount === 0}`으로 커밋 버튼을 막는다 — "그리기" 생성 플로우에서 아무것도 그리지 않은 채 커밋을 누를 수 없다.
- `apps/web/src/components/canvas/import-artifact-dialog.tsx`: `canConfirm = tab === 'image' ? (!!imageUrl && !uploading) : htmlContent.trim().length > 0` — 임포트 플로우도 실 콘텐츠 없이 확인 버튼이 활성화되지 않는다.
- 두 생성 경로(그리기/임포트) 모두 FE UI 레벨에서 이미 빈-nodes 커밋을 막고 있어, 이번 BE 강제가 깨뜨리는 정당한 사용자 플로우는 없다.

## Test plan
- [x] 신규 `backend/tests/test_mcp_1920_create_artifact_empty_nodes_validation.py`(12 tests) — 스키마 레벨(빈 리스트/생략 거절, 정상 nodes 통과) + `_extract_error_message` 422 가독성 + MCP 도구 mock 에러 경로 + realdb 라우터 왕복(422/201) + realdb MCP 무-mock 왕복. 전부 PASS.
- [x] 기존 visual-artifacts 관련 realdb 테스트 스위트 재실행(로컬 PG16+pgvector, alembic head `0201`) — `test_04e059e5_artifact_created_event_realdb.py`, `test_b4027b2e_visual_artifacts_scope_group_realdb.py`, `test_e_canvas_1948d19d_canvas_bounds_realdb.py`, `test_e_canvas_7fe16274_spec_pin_realdb.py`, `test_e_canvas_c1_s3_visual_artifact_realdb.py`, `test_e_canvas_c1_s5_artifact_export_realdb.py`, `test_e_canvas_c2_s6_artifact_comments_realdb.py`, `test_e_canvas_c3_s7_artifact_edit_realdb.py`, `test_e_canvas_c4_s8_canonicalize_realdb.py`, `test_e_security_sec_s8_g_cross_project_access_realdb.py`, `test_e_security_sec_s8_q_visual_artifacts_individual_id_realdb.py`, `test_e_security_sec_s8_r_artifact_link_project_scope_realdb.py`, `test_mcp_1922_delete_artifact_tool.py`, `test_1968_gate_project_id_threading.py`, `test_authz_project_scope_coverage.py` — **135/135 PASS** (single combined run).
- [x] 7개 기존 테스트 파일의 boilerplate `create_artifact` 호출부(nodes 없이 title만 보내던 것들)에 최소 `nodes: [{"type": "text", "props": {}}]`를 추가 — 이 스토리와 무관한 로직(권한/이벤트/스코프/spec-pin/canvas-bounds)이 nodes 부재만으로 깨지지 않도록.
- [x] `test_edg_s25_epic_overlay.py`, `test_1925_b1_goal_rename_realdb.py`, `test_e_recruit_s5_connection_artifact_realdb.py` — visual-artifacts 엔드포인트 미사용 확인(grep), 무영향.

🤖 Generated with [Claude Code](https://claude.com/claude-code)