### PR TITLE
fix(be): merge gate fallback reason 정확도 — pr==fail인데 lower_bound 사유 오분류 (#1388)

### DIFF
--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -204,10 +204,21 @@ def _decide(
     # ask posture → 사람 보류.
     if gate_status == "pending":
         return ASK_HUMAN, "policy disposition=ask"
-    # 기본 안전 — 자동 조건 미충족(하한<임계, PR fail 등). 근거 명시.
+    # 기본 안전 — 자동 조건(gate_status==auto_passed·ci==pass·pr==pass·lower_bound>=threshold)
+    # 중 실제로 미충족된 항목만 정확히 명시(#1388: 이전엔 항상 lower_bound 미달로 표시돼 pr==fail
+    # 등 다른 실제 사유를 오분류했다). 동시에 여러 조건이 미충족일 수 있어 전부 열거한다(단일 사유로
+    # 단순화 금지 — 그러면 미달로 표시 안 된 나머지 조건에서 동일한 부정확 문제가 재발한다).
+    unmet: list[str] = []
+    if gate_status != "auto_passed":
+        unmet.append(f"policy disposition!=allow_auto (gate_status={gate_status})")
+    if ci != "pass":
+        unmet.append(f"CI!=pass (ci={ci})")
+    if pr != "pass":
+        unmet.append(f"PR!=pass (pr={pr})")
+    if outcome.lower_bound < threshold:
+        unmet.append(f"outcome lower_bound {outcome.lower_bound:.2f}<{threshold}")
     return ASK_HUMAN, (
-        f"auto-merge conditions unmet (outcome lower_bound {outcome.lower_bound:.2f}<{threshold}, "
-        f"basis={TRUST_BASIS})"
+        f"auto-merge conditions unmet ({', '.join(unmet)}, basis={TRUST_BASIS})"
     )
 
 

--- a/backend/tests/test_merge_verdict_gate.py
+++ b/backend/tests/test_merge_verdict_gate.py
@@ -107,6 +107,46 @@ def test_decide_pr_fail_not_auto():
     assert _d(pr="fail")[0] == ASK_HUMAN
 
 
+# ── story #1388: fallback reason 정확도(pr==fail인데 lower_bound 사유로 오분류 금지) ──────
+
+def test_decide_pr_fail_reason_names_pr_not_lower_bound():
+    # 정확 재현 시나리오: pr=="fail"이지만 outcome lower_bound는 임계 이상(정상) — reason이
+    # lower_bound 미달을 주장하면 안 되고, PR 실패를 실제 사유로 명시해야 한다.
+    dec, reason = _d(pr="fail", outcome=_OC_STRONG)  # _OC_STRONG lower_bound ≈0.83>=0.8
+    assert dec == ASK_HUMAN
+    assert "lower_bound" not in reason  # LB는 실제로 멀쩡 — 오분류 금지.
+    assert "PR" in reason and "fail" in reason  # 실제 사유(PR fail)가 명시돼야.
+
+
+def test_decide_lower_bound_below_threshold_reason_cites_lower_bound():
+    # 회귀 가드: pr/ci/gate_status 전부 정상이나 lower_bound만 미달 → reason은 여전히
+    # lower_bound를 정확히 지목해야(이전부터 맞았던 케이스 — 변경으로 깨지면 안 됨).
+    dec, reason = _d(outcome=_oc(8, 10))  # LB≈0.49<0.8
+    assert dec == ASK_HUMAN
+    assert "lower_bound" in reason
+    assert "PR" not in reason  # PR은 정상이므로 사유에 섞이면 안 됨.
+
+
+def test_decide_multiple_unmet_conditions_names_all():
+    # pr fail AND lower_bound 미달이 동시 발생 → 둘 다 사유에 명시(단일 사유로 뭉개기 금지).
+    dec, reason = _d(pr="fail", outcome=_oc(8, 10))
+    assert dec == ASK_HUMAN
+    assert "PR" in reason and "fail" in reason
+    assert "lower_bound" in reason
+
+
+def test_decide_reason_accuracy_does_not_change_decision():
+    # decision(ASK_HUMAN)은 reason 정확도 수정과 무관하게 그대로여야 — 이 스토리는 진단
+    # 메시지 품질 수정이지 decision 로직 변경이 아님.
+    for kwargs in (
+        {"pr": "fail", "outcome": _OC_STRONG},
+        {"outcome": _oc(8, 10)},
+        {"pr": "fail", "outcome": _oc(8, 10)},
+    ):
+        dec, _ = _d(**kwargs)
+        assert dec == ASK_HUMAN
+
+
 # ── helper ─────────────────────────────────────────────────────────────────────
 
 def test_normalize_result():


### PR DESCRIPTION
## Summary
- `merge_verdict_gate.py::_decide()`의 마지막 fallback 분기(자동 조건 미충족)가 실제 원인과 무관하게 항상 "outcome lower_bound 미달"로 reason을 하드코딩했다. `pr=="fail"`처럼 다른 서브 조건이 실패해도 lower_bound 탓으로 오분류하는 진단 메시지 정확도 버그(story #1388).
- fallback 분기를 `gate_status`/`ci`/`pr`/`lower_bound` 4개 서브 조건을 개별 검사하도록 재작성해, 실제로 미충족된 조건만(복수 동시 미충족 시 전부) reason에 나열하도록 수정.
- `decision`(항상 `ASK_HUMAN`)과 `gate.auto_decision_reason`은 무변경 — QA(#1498)가 이미 confirm한 대로 decision 로직 자체는 정확함. 이번 수정은 human-readable `reason` 문자열 내용만 대상.
- 파일 내 다른 hardcoded reason 문자열(`outcome sample insufficient`, AUTO_MERGE 성공 사유)은 grep 결과 동형 버그 없음 — 각각 단일/전-참 조건만 보고하므로 정확함.

## Before / After (story의 정확 재현 시나리오: `pr=="fail"`, outcome lower_bound는 정상(≥threshold))

**Before (버그):**
```
auto-merge conditions unmet (outcome lower_bound 0.83<0.8, basis=hypothesis_outcome)
```
→ 0.83은 실제로 0.8 미만이 아닌데도(threshold 충족) lower_bound 미달로 잘못 주장. 실제 원인(PR fail)은 전혀 언급되지 않음.

**After (수정):**
```
auto-merge conditions unmet (PR!=pass (pr=fail), basis=hypothesis_outcome)
```
→ 실제로 미충족된 조건(PR fail)만 정확히 명시. lower_bound는 정상이므로 언급되지 않음.

동시에 여러 조건이 미충족인 경우(e.g. `pr=="fail"` AND `lower_bound<threshold`) 둘 다 나열됨:
```
auto-merge conditions unmet (PR!=pass (pr=fail), outcome lower_bound 0.49<0.8, basis=hypothesis_outcome)
```

## Test plan
- [x] `test_decide_pr_fail_reason_names_pr_not_lower_bound` — story 정확 재현: pr fail + LB 정상 → reason이 lower_bound를 주장하지 않고 PR fail을 명시
- [x] `test_decide_lower_bound_below_threshold_reason_cites_lower_bound` — 회귀 가드: LB만 미달인 케이스는 그대로 lower_bound를 정확히 지목(기존 정확했던 케이스 보존)
- [x] `test_decide_multiple_unmet_conditions_names_all` — pr fail + LB 미달 동시 발생 시 둘 다 나열
- [x] `test_decide_reason_accuracy_does_not_change_decision` — decision(ASK_HUMAN)은 reason 변경과 무관하게 불변
- [x] `backend/tests/test_merge_verdict_gate.py` 전체: 29 passed, 2 skipped(real Postgres 필요, 무변경) — 기존 브랜치(`CI fail`/`CI unknown`/`policy disposition=deny`/`outcome sample insufficient`/`AUTO_MERGE`/`policy disposition=ask`) 전 회귀 없음
- [x] 연관 테스트 파일(`test_h1_s10_e2e.py`, `test_1968_gate_project_id_threading.py`, `test_h1_s4_merge_gate_wiring.py`, `test_edg_s5_merge_gate.py`, `test_h1_s5_board_gate.py`, `test_workflow_report.py`): 38 passed, 9 skipped(기존과 무관한 fixture 요구) — 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)