### PR TITLE
feat(be): agent_audit_logs org+event_type index — story #1616 (measure-first)

### DIFF
--- a/backend/alembic/versions/0202_agent_audit_logs_org_event_index.py
+++ b/backend/alembic/versions/0202_agent_audit_logs_org_event_index.py
@@ -1,0 +1,61 @@
+"""story #1616(측정선행): agent_audit_logs — (org_id, event_type, created_at DESC) 인덱스 추가.
+
+관련: A3 `f4a882cc`(별도 사설 internal-api 레포의 admin audit 조회 — 현재 safe-mode로
+org_id 필수+7일 윈도우+limit<=50 제한 하에서만 동작). 원 스토리는 이 테이블에 PK 외
+인덱스가 전혀 없다고 가정했으나 실측 결과 오류 — baseline schema.sql에 이미 4개 인덱스가
+있다: idx_agent_audit_logs_event_type(event_type, created_at DESC) ·
+idx_agent_audit_logs_org_project_created(org_id, project_id, created_at DESC) ·
+idx_agent_audit_logs_run(run_id, created_at DESC) WHERE run_id IS NOT NULL ·
+idx_agent_audit_logs_session(session_id, created_at DESC) WHERE session_id IS NOT NULL.
+
+**측정 방법**: 로컬 pg@16(alembic head 적용) 스크래치 DB에 org_id/project_id 분포가 현실적인
+~1.075M행(150 org 균등분포 org당 ~6-7k행·4 project + medium org 25k행(전체 2.3%) + mega org
+150k행(전체 14%, 의도적 극단치))을 시드하고 "safe-mode 해제" 후 실제 목표 접근 패턴
+(org 전역·project_id 미필터·시간창 미제한, ORDER BY created_at DESC LIMIT 50)을
+EXPLAIN(ANALYZE, BUFFERS)로 실측.
+
+**결과 A — org만 필터(프로젝트/이벤트타입 무필터)**: 기존
+idx_agent_audit_logs_org_project_created 로 Bitmap Heap Scan + top-N heapsort. 실측 6~52ms
+(0.58%~14% 선택도 전 구간, 후자는 비현실적 극단치인데도) — 신규 인덱스 불필요로 판정,
+추가하지 않음.
+
+**결과 B — org + event_type 필터**: 기존 idx_agent_audit_logs_event_type(event_type,
+created_at DESC) 를 org_id는 사후 Filter로만 적용하는 Index Scan으로 처리 — 대상 org의
+전역 event_type 점유율이 낮을수록 스캔해야 하는 행 수가 O(1/점유율)로 증가. 실측: 점유율
+0.58% org 기준 웜캐시 12.2ms(6565 버퍼)·콜드캐시 46.7ms(디스크 read 4817+hint-bit write
+1703) — 프로덕션 규모(테이블이 더 크고 org별 점유율이 이보다 낮은 경우 흔함)에서 이 패턴은
+구조적으로 더 악화된다. → **증명된 갭**. `(org_id, event_type, created_at DESC, id DESC)`
+인덱스 추가 후 동일 케이스 재측정: Index Scan 단독(정렬 노드 소멸)으로 0.44ms(버퍼 54개) —
+전 org 규모(0.58%/2.3%/14%)에서 균일하게 <1ms. `id DESC`는 created_at 동시분 tie-break용
+(무제한창 페이지네이션이 안정적 순서를 요구 — AC 권고 그대로).
+
+AC가 제시한 두 후보 중 `(org_id, created_at DESC, id DESC)`는 결과 A가 이미 충분히 빠름을
+증명했으므로 **추가하지 않는다**(반사적 양쪽 추가 금지 — 실측이 가리키는 것만).
+
+전체 측정 방법론·EXPLAIN 원문(트림)은 PR 본문 참고.
+
+Revision ID: 0202
+Revises: 0201
+Create Date: 2026-07-19
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0202"
+down_revision = "0201"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "idx_agent_audit_logs_org_event_created",
+        "agent_audit_logs",
+        ["org_id", "event_type", sa.text("created_at DESC"), sa.text("id DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_agent_audit_logs_org_event_created", table_name="agent_audit_logs")


### PR DESCRIPTION
## Summary

Story #1616 is MEASURE-FIRST: the referenced hypothesis (`idx_agent_audit_logs_org_project_created` being suboptimal for "org-wide across all projects, time-ordered" queries because `project_id` sits between `org_id` and `created_at`) was verified **FALSE at every tested data volume** — no index change needed for that pattern. Measurement instead surfaced a **different, real, proven gap** in a query shape the story also asked to test (`org_id` + `event_type` filter): that pattern was falling through to the wrong existing index and scaling as O(1/org-event-share). This PR adds the one index that closes that specific gap.

This PR does **not** touch the private `internal-api` repo's safe-mode relaxation logic (`org_id` required→optional, limit/window changes) — that is a separate repo/deployment pipeline, out of scope, follow-up story.

## Methodology

- Local pg@16 (pgvector-built), full `alembic upgrade head` (baseline + 0002‑0201), scratch DB.
- Seeded via bulk `INSERT ... SELECT generate_series(...)` (no row-by-row Python):
  - 150 orgs × 2‑6 projects each (600 projects), ~900k rows, uniform distribution (~6-7k rows/org, ~0.6% share each)
  - +1 "medium" org: 25k rows / 4 projects (2.3% of total) — realistic heavier org
  - +1 "mega" org: 150k rows / 5 projects (14% of total) — deliberately extreme power-user stress case
  - Total: **1,075,000 rows**, 152 distinct orgs, 604 distinct projects, `created_at` spread over 180 days, 7 distinct `event_type` values, weighted `severity` distribution (matches CHECK constraint), table size ~370MB.
- Queries tested (per AC's stated intent — safe-mode-removed shape, no internal-api access):
  - (a) `WHERE org_id = :org_id ORDER BY created_at DESC LIMIT 50` (no project filter, no time window)
  - (b) same + `AND event_type = :event_type`
  - (c) 90-day-window variants of both
- `EXPLAIN (ANALYZE, BUFFERS)` run cold and warm, across all three org sizes (0.58% / 2.3% / 14% selectivity).

## Result A — org-only query (no project_id/event_type filter): **no index needed**

Existing `idx_agent_audit_logs_org_project_created (org_id, project_id, created_at DESC)` already handles this via Bitmap Heap Scan (org_id equality prefix) + top-N heapsort — a Sort node does appear (confirming the *mechanism* of the original hypothesis), but it's cheap because it's a top-N heapsort over a small result set, not a full sort.

| org share | plan | execution time |
|---|---|---|
| 0.58% (6,215 rows) | Bitmap Heap Scan + top-N sort | 12.4ms |
| 2.3% (25,000 rows) | Bitmap Heap Scan + top-N sort | 6.3ms |
| 14% (150,000 rows, extreme) | Parallel Seq Scan + top-N sort | 30-52ms |

Even the deliberately unrealistic 14%-of-corpus single-org case stays well under 100ms. **Decision: do not add `(org_id, created_at DESC, id DESC)`** — measurement doesn't justify it, and the AC explicitly says not to add both candidates reflexively.

## Result B — org + event_type filter: **proven gap, index added**

Existing indexes have nothing with `org_id` leading + `event_type`. The planner falls back to the *global* `idx_agent_audit_logs_event_type (event_type, created_at DESC)`, scanning that index in time order and applying `org_id` as a post-filter — cost scales as `O(1 / org-event-share)`, i.e. it gets **worse** the smaller an org's share of that event_type is (structurally, not just a small-dataset artifact).

Before (0.58%-share org, `event_type='agent.failed'`):
```
Limit (actual time=0.459..46.666 rows=50) [cold cache]
 -> Index Scan using idx_agent_audit_logs_event_type
    Index Cond: (event_type = 'agent.failed')
    Filter: (org_id = ...)
    Rows Removed by Filter: 6466
    Buffers: shared hit=1748 read=4817 written=1703
 Execution Time: 46.682 ms
```
Warm-cache re-run: still 12.243ms, `Buffers: shared hit=6565` — i.e. it has to touch ~6,500 pages regardless of cache state to find 50 matching rows. This scales with table growth and gets worse for lower-share orgs.

After adding `idx_agent_audit_logs_org_event_created (org_id, event_type, created_at DESC, id DESC)`:
```
Limit (actual time=0.277..0.435 rows=50)
 -> Index Scan using idx_agent_audit_logs_org_event_created
    Index Cond: (org_id = ... AND event_type = 'agent.failed')
    Buffers: shared hit=50 read=4
 Execution Time: 0.445 ms
```
No Sort node (index already delivers `created_at DESC` order), no post-filter row scanning. Same improvement holds uniformly across all three tested org sizes (0.58% / 2.3% / 14%): all settle to sub-1ms after the index, vs. 0.06ms–46.7ms (highly variable, worst on small-share orgs) before.

`id DESC` is included as a tiebreaker for `created_at` ties — required for stable/deterministic ordering under an unbounded-window, paginated admin query (matches AC's suggested shape).

Sanity check: the new index does not change the plan for the org-only query (Result A) — Parallel Seq Scan + Sort still selected for the 14% org, confirming no interference/regression.

## Migration

`backend/alembic/versions/0202_agent_audit_logs_org_event_index.py` — `down_revision = "0201"` (verified free of conflicts across all open PRs as of this session). Plain `op.create_index` inside the alembic transaction — matched against this repo's established convention (checked recent index-adding migrations, e.g. `0071_per_recipient_dense_seq.py`, `0201_a2a_tasks_client_message_id.py`; none use `CREATE INDEX CONCURRENTLY` — the house pattern is transactional `create_index`, so this migration follows suit rather than inventing a new pattern).

Verified: `alembic upgrade head` (0201→0202), `alembic downgrade -1` (0202→0201, index dropped), `alembic upgrade head` again (re-applies cleanly) — all against the seeded 1.075M-row scratch DB. Single alembic head confirmed (`0202 (ee_pricing, core) (head)`).

## Out of scope (explicit)

Does not touch the private `internal-api` repo's safe-mode relaxation logic (`org_id` required→optional, 7-day window removal, `limit<=50` cap changes). That is a separate repo/deployment pipeline — follow-up story after this one.

## Test plan

- [x] `alembic upgrade head` on fresh baseline+migrations DB — clean apply
- [x] `alembic downgrade -1` / re-`upgrade head` — clean round-trip
- [x] `ruff check` on the new migration file — passes
- [x] `EXPLAIN (ANALYZE, BUFFERS)` before/after on 3 org sizes — documented above
- [x] Confirmed no regression to the org-only query plan after adding the new index

🤖 Generated with [Claude Code](https://claude.com/claude-code)