### PR TITLE
[SID:2013][긴급] 목표 상태 전이 드롭다운 — PATCH(422 거부)→POST /transition 교체 + 실패 삼킴 제거

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2858,6 +2858,8 @@
     "transitionAction": "Change status",
     "transitionPending": "Pending approval",
     "transitionGateHint": "This transition goes through an approval gate",
+    "transitionFailedTitle": "Status change failed",
+    "transitionFailedFallback": "Couldn't change status due to a temporary issue. Please try again shortly.",
     "fieldStatus": "Status",
     "doneSp": "Done SP",
     "totalSp": "Total SP",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2858,6 +2858,8 @@
     "transitionAction": "상태 변경",
     "transitionPending": "승인 대기",
     "transitionGateHint": "이 전이는 승인 게이트를 거칩니다",
+    "transitionFailedTitle": "상태 변경 실패",
+    "transitionFailedFallback": "일시적인 문제로 상태를 변경하지 못했습니다. 잠시 후 다시 시도해 주세요.",
     "fieldStatus": "상태",
     "doneSp": "완료 SP",
     "totalSp": "전체 SP",

--- a/apps/web/src/app/api/goals/[id]/transition/route.ts
+++ b/apps/web/src/app/api/goals/[id]/transition/route.ts
@@ -1,0 +1,14 @@
+import { proxyToFastapiWrapped } from '@/lib/fastapi-proxy';
+
+/**
+ * POST /api/goals/{id}/transition — story #2013. generic PATCH /api/goals/{id}는 BE가 status
+ * 변경을 422로 거부(FSM/SoD/gate 우회 방지, routers/goals.py:297) — 전이는 이 전용 엔드포인트로.
+ *
+ * proxyToFastapiWrapped 사용 이유: 형제 표면 steer-dispatch/route.ts와 동일 근거 — 리포지토리
+ * (fastapiCall→mapApiError) 경로는 구조화 에러(HUMAN_CONFIRM_REQUIRED/INVALID_EPIC_TRANSITION의
+ * code+message)를 뭉갠다. 이 스토리의 핵심 AC(거부 사유 표면화)가 그 구조화 에러 보존에 의존한다.
+ */
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await params;
+  return proxyToFastapiWrapped(request, `/api/v2/goals/${id}/transition`);
+}

--- a/apps/web/src/components/epics/epic-status-transition.test.tsx
+++ b/apps/web/src/components/epics/epic-status-transition.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+//
+// story #2013 리뷰 fix B — 핵심 경로 회귀가드 2종(codex REQUEST_CHANGES 무테스트 지적 해소):
+// (1) 구조화 에러(403 HUMAN_CONFIRM_REQUIRED·422 INVALID_EPIC_TRANSITION) 응답 시 토스트가 뜨고
+// code+message가 둘 다 verbatim으로 화면에 남는지, (2) 200이지만 status 불변(enforcing gate 생성)
+// 응답 시 낙관적 반영 없이 "승인 대기" 배지만 뜨고 onTransitioned가 호출되지 않는지.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { EpicStatusTransition } from './epic-status-transition';
+import koMessages from '../../../messages/ko.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function mount(onTransitioned: (s: string) => void) {
+  await act(async () => {
+    root.render(wrap(<EpicStatusTransition epicId="epic-1" status="active" onTransitioned={onTransitioned} />));
+  });
+}
+
+// active → done은 GATED("active>done") 대상이자 VALID_NEXT 상 유효 전이 — 드롭다운을 열고
+// "Done" 항목을 클릭해 실제 POST /api/goals/:id/transition 왕복 경로(transition() 핸들러)를 태운다.
+async function clickTransitionToDone() {
+  const trigger = [...document.body.querySelectorAll('button')].find((b) => b.getAttribute('aria-label') === '상태 변경')!;
+  expect(trigger).not.toBeUndefined();
+  await act(async () => { trigger.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+  const item = [...document.body.querySelectorAll('[role="menuitem"]')].find((el) => el.textContent?.includes('Done'))!;
+  expect(item).not.toBeUndefined();
+  await act(async () => {
+    item.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+  });
+}
+
+function stubFetchOnce(response: { ok: boolean; status: number; json: () => Promise<unknown> }) {
+  vi.stubGlobal('fetch', vi.fn(async () => response));
+}
+
+describe('EpicStatusTransition — 구조화 에러 표면화(story #2013 리뷰 FIX A)', () => {
+  it('403 HUMAN_CONFIRM_REQUIRED: 토스트가 뜨고 code+message가 둘 다 화면에 그대로 남는다', async () => {
+    stubFetchOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: { code: 'HUMAN_CONFIRM_REQUIRED', message: '이 전이는 사람의 확인이 필요합니다' } }),
+    });
+    const onTransitioned = vi.fn();
+    await mount(onTransitioned);
+    await clickTransitionToDone();
+
+    expect(container.textContent).toContain('상태 변경 실패'); // transitionFailedTitle
+    expect(container.textContent).toContain('HUMAN_CONFIRM_REQUIRED'); // 코드 verbatim
+    expect(container.textContent).toContain('이 전이는 사람의 확인이 필요합니다'); // 메시지 verbatim
+    expect(onTransitioned).not.toHaveBeenCalled();
+  });
+
+  it('422 INVALID_EPIC_TRANSITION: 토스트가 뜨고 code+message가 둘 다 화면에 그대로 남는다', async () => {
+    stubFetchOnce({
+      ok: false,
+      status: 422,
+      json: async () => ({ error: { code: 'INVALID_EPIC_TRANSITION', message: '이 상태로는 전이할 수 없습니다' } }),
+    });
+    const onTransitioned = vi.fn();
+    await mount(onTransitioned);
+    await clickTransitionToDone();
+
+    expect(container.textContent).toContain('상태 변경 실패');
+    expect(container.textContent).toContain('INVALID_EPIC_TRANSITION');
+    expect(container.textContent).toContain('이 상태로는 전이할 수 없습니다');
+    expect(onTransitioned).not.toHaveBeenCalled();
+  });
+});
+
+describe('EpicStatusTransition — gate 생성·승인 대기(story #2013 PO note② — 낙관적 반영 금지)', () => {
+  it('200이지만 반환 status가 요청과 다르면(gate 생성) "승인 대기"만 뜨고 onTransitioned는 호출되지 않는다', async () => {
+    // active → done 요청했지만 enforcing gate가 생성돼 status는 active로 유지된 응답.
+    stubFetchOnce({ ok: true, status: 200, json: async () => ({ data: { status: 'active' } }) });
+    const onTransitioned = vi.fn();
+    await mount(onTransitioned);
+    await clickTransitionToDone();
+
+    expect(container.textContent).toContain('승인 대기'); // transitionPending
+    expect(onTransitioned).not.toHaveBeenCalled(); // 낙관적 반영 X
+    expect(container.textContent).not.toContain('상태 변경 실패'); // 에러 토스트 오탐 0
+  });
+});

--- a/apps/web/src/components/epics/epic-status-transition.tsx
+++ b/apps/web/src/components/epics/epic-status-transition.tsx
@@ -72,12 +72,15 @@ export function EpicStatusTransition({
         error?: { code?: string; message?: string };
       };
       if (!res.ok) {
-        // story #2013: 무반응이 이 버그의 본체 — 거부 사유(HUMAN_CONFIRM_REQUIRED·
-        // INVALID_EPIC_TRANSITION 등)를 그대로 화면에 띄운다(삼키지 않음).
+        // story #2013 리뷰 FIX A: 무반응이 이 버그의 본체 — 거부 사유(HUMAN_CONFIRM_REQUIRED·
+        // INVALID_EPIC_TRANSITION 등)를 그대로 화면에 띄운다(삼키지 않음). code+message 둘 다
+        // verbatim 보존(code만 있고 message가 없어도, message만 있어도 안 잃도록 각각 optional).
+        const code = json?.error?.code;
+        const message = json?.error?.message || t('transitionFailedFallback');
         addToast({
           type: 'error',
           title: t('transitionFailedTitle'),
-          body: json?.error?.message || t('transitionFailedFallback'),
+          body: code ? `[${code}] ${message}` : message,
         });
         return;
       }

--- a/apps/web/src/components/epics/epic-status-transition.tsx
+++ b/apps/web/src/components/epics/epic-status-transition.tsx
@@ -5,12 +5,18 @@ import { useTranslations } from 'next-intl';
 import { ChevronDown, ShieldCheck, Clock } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import { ToastContainer, useToast } from '@/components/ui/toast';
 
 /**
  * E-DG RC#2 ⓶ — epic status-transition 컨트롤(상세 헤더). status badge + 유효 next-state만 dropdown
- * → PATCH /api/goals/{id} {status}. FSM 유효 전이만 노출(invalid 미노출·"보이는=실행가능"·422 차단).
- * (8fc51517 fix: 존재한 적 없는 POST .../transition 대신 실재하는 PATCH 엔드포인트로 교정 — 클릭해도
- * 조용히 실패하던 사전 버그, 이번 rename sweep 중 발견 즉시 수정.)
+ * → POST /api/goals/{id}/transition. FSM 유효 전이만 노출(invalid 미노출·"보이는=실행가능").
+ *
+ * story #2013(2026-07-19, 선생님 draft→active 차단 재보고): 8fc51517이 그때는 옳게(POST .../transition이
+ * 존재한 적 없어 PATCH로 교정)했으나, 이후 E-DG S25가 POST .../transition을 신설하며 동시에 generic
+ * PATCH의 status 변경을 422로 막았음(routers/goals.py:297) — FE만 옛 경로에 남아 시차 드리프트,
+ * 클릭해도 무반응(422 삼킴)이었던 것을 이번에 POST 경로 교체 + 에러 표면화로 근본 수정.
+ * 형제표면 steer-dispatch/route.ts와 동일 근거로 proxyToFastapiWrapped 사용(구조화 에러 보존).
+ *
  * ⭐draft→active·active→done은 human/aggregate-gate(overlay)라 enforcing 시 gate 생성·status 유지 →
  * 낙관적 반영 X·반환 status가 target과 다르면(미변경) "승인 대기"(gate pending) 표시(PO note②·S24 gate 어휘).
  * BE _EPIC_VALID_TRANSITIONS 미러. 신규 토큰 0(ChevronDown/ShieldCheck/Clock).
@@ -48,6 +54,7 @@ export function EpicStatusTransition({
   const t = useTranslations('goals');
   const [busy, setBusy] = useState(false);
   const [pending, setPending] = useState(false); // gate 생성·승인 대기(status 미변경)
+  const { toasts, addToast, dismissToast } = useToast();
 
   const nexts = VALID_NEXT[status] ?? [];
 
@@ -55,13 +62,25 @@ export function EpicStatusTransition({
     if (busy) return;
     setBusy(true);
     try {
-      const res = await fetch(`/api/goals/${epicId}`, {
-        method: 'PATCH',
+      const res = await fetch(`/api/goals/${epicId}/transition`, {
+        method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ status: to }),
       });
-      if (!res.ok) return;
-      const json = (await res.json()) as { data?: { status?: string } };
+      const json = (await res.json()) as {
+        data?: { status?: string };
+        error?: { code?: string; message?: string };
+      };
+      if (!res.ok) {
+        // story #2013: 무반응이 이 버그의 본체 — 거부 사유(HUMAN_CONFIRM_REQUIRED·
+        // INVALID_EPIC_TRANSITION 등)를 그대로 화면에 띄운다(삼키지 않음).
+        addToast({
+          type: 'error',
+          title: t('transitionFailedTitle'),
+          body: json?.error?.message || t('transitionFailedFallback'),
+        });
+        return;
+      }
       const returned = json?.data?.status;
       if (returned === to) {
         setPending(false);
@@ -70,6 +89,8 @@ export function EpicStatusTransition({
         // enforcing gate 생성 → status 유지·승인 대기(낙관적 반영 X·PO note②)
         setPending(true);
       }
+    } catch {
+      addToast({ type: 'error', title: t('transitionFailedTitle'), body: t('transitionFailedFallback') });
     } finally {
       setBusy(false);
     }
@@ -108,6 +129,7 @@ export function EpicStatusTransition({
           </DropdownMenuContent>
         </DropdownMenu>
       ) : null}
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
     </div>
   );
 }


### PR DESCRIPTION
## 요약
선생님 실사용 차단(draft→active 클릭해도 무반응) 긴급 발주.

**근본**: 시차 드리프트. B1 sweep(8fc51517)이 "존재한 적 없는 POST .../transition 대신 실재하는 PATCH로 교정"했을 때는 옳았으나, 이후 E-DG S25가 `POST /goals/{id}/transition`을 신설하며 동시에 generic PATCH의 status 변경을 422로 막았음(routers/goals.py:297) — FE만 옛 PATCH 경로에 남아 매 클릭이 422→`if (!res.ok) return;`로 조용히 삼켜짐. **무반응이 버그의 본체.**

- `api/goals/[id]/transition/route.ts` 신설 — 형제표면 `steer-dispatch/route.ts`와 동일 근거로 `proxyToFastapiWrapped` 사용(리포지토리 경로의 `fastapiCall`→`mapApiError`는 구조화 에러 code/message를 뭉갬, 핵심 AC가 그 보존에 의존).
- `epic-status-transition.tsx`: PATCH 호출을 `POST /api/goals/{id}/transition`으로 교체. 실패 시 `error.message`를 기존 `useToast`(형제표면 `entity-dispatch-panel.tsx` 동일 패턴)로 표면화. 성공 시 기존 gate-pending 판별 로직 그대로 유지.
- i18n 2키 신설(transitionFailedTitle/transitionFailedFallback, ko/en 대칭).

## 스크린샷 (격리 스택 실렌더)
- 에러 토스트 실제 렌더: "상태 변경 실패" / "불법 전이: archived → archived"(빨간 좌측보더, 우하단 위치, ✕ 닫기)

## 반응형 확인
데스크톱 표면(목표 상세 헤더 컨트롤). 모바일 레이아웃 변경 없음.

## 실증 (격리 스택, 신규 계정)
- **ⓐ 성공 케이스**: draft 목표 생성 → "Active" 클릭 → 네트워크에서 `POST /api/goals/{id}/transition` 정확히 발화(구 PATCH 아님) 확인 → 배지 즉시 "Active"로 갱신 → 재조회(`GET /api/goals/{id}`)로 `status=active` write→read 왕복 확인.
- **ⓑ 실패 케이스**: 실제 레이스 시나리오로 재현(백그라운드에서 목표를 이미 archived로 전이시킨 뒤, 마운트된 UI가 여전히 보여주는 "Archived" 드롭다운 항목을 실제 클릭) → BE 422("불법 전이: archived → archived") → 토스트 "상태 변경 실패" + 정확한 사유 문구 렌더 확인(무반응 0). 스크린샷 첨부.

## 게이트
- tsc 0 error
- lint 0 error (기존 무관 warning 5건)
- vitest 257 files / 1715 passed
- build success

🤖 Generated with [Claude Code](https://claude.com/claude-code)