### PR TITLE
[SID:2016] bare /goals 404 — MIGRATED_RESOURCES에 신 이름 키 누락 (호스트/쿠키 무관)

### DIFF
--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -406,7 +406,7 @@ describe('proxy — legacy resource redirect generalized to non-docs resources (
     delete process.env['JWT_SECRET'];
   });
 
-  it.each(['standup', 'retro', 'loops', 'artifacts', 'mockups', 'sprints', 'storage', 'epics', 'board'])(
+  it.each(['standup', 'retro', 'loops', 'artifacts', 'mockups', 'sprints', 'storage', 'epics', 'board', 'goals'])(
     'bare /%s(/*) → 실 slug로 301(redirectLegacyResourcePath 일반화 증명)',
     async (resource) => {
       const token = await makeAccessToken({ orgId: 'org-1' });

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -123,6 +123,13 @@ const MIGRATED_RESOURCES: Record<string, string[]> = {
   storage: [],
   epics: [],
   board: [],
+  // story #2016: 8fc51517(B1 리네이밍)이 epics→goals 경로 리터럴을 바꾸면서 RENAMED_RESOURCES에만
+  // 반영되고 여기(MIGRATED_RESOURCES)엔 신 이름 'goals'를 안 넣었다 — bare `/epics`는 이 표를 거쳐
+  // `/{ws}/{proj}/epics`로 301된 뒤 redirectRenamedResourcePath가 2차로 `goals`로 다시 301하지만,
+  // bare `/goals`(신 이름 그대로 오는 딥링크·북마크·검색결과)는 애초에 이 표에 키가 없어 redirectLegacyResourcePath가
+  // 즉시 null 반환 → Next 자체 404. 호스트/쿠키 무관 리소스 등록 누락 실측 확認(direct Cloud Run 호스트에서
+  // /board는 301 정상·/goals만 404, 동일 JWT fallback 경로 재사용).
+  goals: [],
 };
 
 /**


### PR DESCRIPTION
## 요약
#2013 라이브 검증 중 발견된 "직통 Cloud Run 호스트에서만 bare `/goals` 404"라는 최초 가설(host/cookie 조건 의심)을 실측으로 반증하고 진짜 근본을 확定.

**실측(실 dev 환경, 동일 호스트에서 대조)**: `/board`(MIGRATED_RESOURCES 등록 리소스)는 301 정상, `/goals`만 404 — 같은 JWT fallback 경로(#1999)를 공유하는 두 리소스가 같은 호스트에서 다른 결과를 낸다는 것 자체가 host/cookie 가설을 반증.

**근본**: 8fc51517(B1 리네이밍)이 epics→goals 경로 리터럴을 바꾸며 `RENAMED_RESOURCES`(이미 `/{ws}/{proj}/{resource}` 형태인 경로의 3번째 세그먼트만 치환)엔 반영했으나, `MIGRATED_RESOURCES`(ws/proj 세그먼트가 아예 없는 bare flat 링크를 org/project 재조회로 채워 301하는 표)엔 신 이름 'goals'를 추가하지 않았다. bare `/epics`(구 이름)는 그 표의 'epics' 키로 잡혀 2단계 301로 우회 도달하지만, bare `/goals`(신 이름 그대로 오는 딥링크·북마크·검색결과)는 표에 키가 없어 즉시 Next 자체 404. **호스트/쿠키/미들웨어 매칭과 전혀 무관.**

fix: `MIGRATED_RESOURCES`에 `goals: []` 추가(1줄). 기존 `epics` 키는 구 북마크 호환을 위해 그대로 유지.

## 반응형 확인
미들웨어(라우팅) 레벨 fix, UI 변경 없음 — 반응형 무관.

## 실증
- 실 dev 환경(direct Cloud Run host) `/board` vs `/goals` 대조 curl로 근본원인 사전 확定.
- 격리 스택(신규 org/project)에서 로그인 후 bare `/goals` 접근 → `/{ws}/{proj}/goals` 301+정상 로드 확認(curl+브라우저 왕복).

## 게이트
- tsc 0 error
- lint 0 error (기존 무관 warning 5건)
- vitest 259 files / 1727 passed(기존 `it.each` 파라미터화 회귀가드에 'goals' 케이스 추가, 신규 테스트 파일 없음)
- build success

🤖 Generated with [Claude Code](https://claude.com/claude-code)