### PR TITLE
fix(gates): enforce resolution note for high-risk gate approvals (#2027)

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -541,6 +541,19 @@ async def transition_gate_endpoint(
                 status_code=403,
                 detail="doc 결재 권한이 없습니다 (대상 프로젝트 접근 필요).",
             )
+    # story #2027(까심 QA 적출): 고위험(risk_grade=high) 게이트의 approved 전이는 사유(note) 서버측
+    # 강제 — void_gate/override_gate 기존 관례(reason 없으면 ValueError→422, void_gate 참고)에
+    # 맞추는 작업이다(신규 규칙 아님). 이전엔 FE 버튼 disable(evidenceViewed && reason.trim())만
+    # 있고 서버는 무검증이라 POST /transition 직접 호출 시 사유 없이 통과했다. 저위험은 기존대로
+    # note 없이 통과(과도 강제 금지 — PO AC). risk_grade 는 list_gates/get_gate 와 동일 파생 경로
+    # (derive_risk_grade+get_org_posture) 재사용(DRY·N+1 0 — org당 posture 1쿼리).
+    if body.status == "approved" and _gate is not None:
+        _posture = await get_org_posture(session, org_id)
+        if derive_risk_grade(_posture, _gate.gate_type) == "high" and not (body.note or "").strip():
+            raise HTTPException(
+                status_code=422,
+                detail="고위험(risk_grade=high) 게이트 승인은 사유(note) 입력이 필수입니다.",
+            )
     # ⭐S23 RC① + RC#1(방어심층): resolver_id 를 **전 status 무조건 인증 caller 로 강제**(body 무시).
     # body 조작(타인 UUID)으로 SoD(approver≠owner) 우회·confirmed_by_member_id 위조 차단.
     _resolver_id = resolved.id

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -342,7 +342,9 @@ async def transition_gate(
     gate.status = new_status
     gate.resolver_id = resolver_id
     gate.resolved_at = datetime.now(timezone.utc)
-    if new_status == "rejected" and note:
+    # story #2027: 이전엔 rejected 에만 저장 — approved 도 note 를 받을 수 있는데(override 의
+    # reason·이번 고위험 강제 사유 포함) 조용히 버려졌다(감사 추적 훼손). status 무관 note 있으면 저장.
+    if note:
         gate.resolution_note = note
 
     # H1-S7: 사람 게이트 해소(approve/reject)를 verdict로 기록 — trust로 환류.
@@ -876,8 +878,10 @@ async def override_gate(
         a.status = "overridden"
         a.resolved_at = now
 
-    # ⭐gate 행에 override 마커(FE cheap 신호·event fetch 없이 "강제 결정됨" 배지). transition_gate 는
-    # resolution_note 를 rejected 에만 세팅하므로 approved override 사유가 누락 → neutral_facts 로 보존.
+    # ⭐gate 행에 override 마커(FE cheap 신호·event fetch 없이 "강제 결정됨" 배지). story #2027 이전엔
+    # transition_gate 가 resolution_note 를 rejected 에만 세팅해 approved override 사유가 누락됐었다 —
+    # 지금은 resolution_note 에도 저장되지만(status 무관), neutral_facts 마커는 override 전용 배지·
+    # bypassed_sod 등 override 고유 메타 보존 목적으로 유지(중복 저장 무해·용도 분리).
     # 전체 audit/메타(owner·시각·bypassed_sod)는 gate_overridden 이벤트가 SSOT(S32 reassign 동형).
     gate.neutral_facts = {
         **(gate.neutral_facts or {}),

--- a/backend/tests/test_2027_gate_approval_reason_enforce.py
+++ b/backend/tests/test_2027_gate_approval_reason_enforce.py
@@ -1,0 +1,245 @@
+"""story #2027: 고위험(risk_grade=high) 게이트 approved 전이의 사유(note) 서버측 강제.
+
+배경(까심 QA 실 PG+실 HTTP 재현): 고위험 게이트의 "근거 열람 + 사유 입력" 요건이 FE 버튼
+disable(evidenceViewed && reason.trim())로만 있었고 서버는 무검증이었다 — `POST /gates/{id}
+/transition`을 직접 호출하면 사유 없이 200으로 통과하고 `resolution_note`가 null로 남았다.
+
+핵심 판단(오르테가 PO): 같은 라우터의 void_gate/override_gate는 이미 reason 을 서버에서 강제하는데
+(reason 없으면 ValueError→422) approved 전이만 그 관례에서 이탈해 있었다 — 새 규칙이 아니라 기존
+관례에 맞추는 정합 작업.
+
+이 파일 구성:
+- risk_grade=high + note 없음 → 422·전이 미적용(뮤테이션 0, GET 재조회로 확인).
+- risk_grade=high + note 있음 → 200·resolution_note 실제 저장(재조회로 확인 — story #2027 이전엔
+  approved 에 resolution_note 가 전혀 저장되지 않았다).
+- risk_grade=low(posture=permissive 가 gate_type=merge 를 오버라이드) → note 없이도 기존대로 200
+  (과도 강제 금지 — 저위험 회귀 없음).
+
+seed/client 헬퍼는 test_1972_gate_risk_grade.py 의 realdb 섹션과 동일 패턴(파일별 로컬 중복이
+이 테스트 스위트의 기존 관례).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# realdb 섹션이 Base.metadata.create_all을 호출한다 — conftest.py AST 가드(story 8236bbc3) 대응.
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+_REAL_DB_SKIP = pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401 — 전 모델 메타데이터 로드
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, user_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {}})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _seed_common(session):
+    """org + project + caller(project grant, has_project_access True 경로)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    caller = User(id=uuid.uuid4(), email=f"caller-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller.id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=caller_om.id,
+        permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "caller_id": caller.id}
+
+
+async def _seed_gate(session, *, posture: str, gate_type: str, story_title: str):
+    from app.models.gate import Gate
+    from app.models.hitl_config import OrgGatePolicy
+    from app.models.pm import Story
+
+    seeded = await _seed_common(session)
+    session.add(OrgGatePolicy(org_id=seeded["org_id"], posture=posture))
+    await session.commit()
+    story = Story(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+                  title=story_title)
+    session.add(story)
+    await session.commit()
+    gate = Gate(id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story.id,
+                work_item_type="story", gate_type=gate_type, status="pending")
+    session.add(gate)
+    await session.commit()
+    return seeded, gate.id
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_high_risk_approve_without_note_422_and_no_mutation():
+    """conservative posture → pr_review 도 high(1차 축이 이김, test_1972 동일 조합). note 없이
+    approve 시도 → 422·gate 는 pending 그대로(전이 미적용)를 재조회로 확인 — 강제 이전엔 이 조합이
+    200으로 통과하고 resolution_note 가 null 로 남았었다(까심 QA 재현)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded, gate_id = await _seed_gate(
+                s, posture="conservative", gate_type="pr_review", story_title="고위험 승인 대상",
+            )
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition", json={"status": "approved"},
+            )
+            assert resp.status_code == 422, resp.text
+            # app.main.http_exception_handler 가 HTTPException.detail(str)을 {"error":{"message":...}}
+            # 봉투로 재포장(story #2003 REST 엔벨로프) — {"detail":...} 아님(raw FastAPI 기본과 다름).
+            assert "사유" in resp.json()["error"]["message"], resp.json()
+
+            # 뮤테이션 0 확인 — 재조회(feedback_verify_commit_race: 직후 상태를 API 재조회로 입증).
+            recheck = await client.get(f"/api/v2/gates/{gate_id}")
+            assert recheck.status_code == 200, recheck.text
+            body = recheck.json()
+            assert body["status"] == "pending", body
+            assert body["resolution_note"] is None, body
+            assert body["resolved_at"] is None, body
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_high_risk_approve_with_note_persists_resolution_note():
+    """같은 고위험 조합에 note 를 실어 보내면 200·resolution_note 가 실제로 저장된다(재조회로 확인
+    — story #2027 이전엔 approved 전이가 resolution_note 를 rejected 전용 분기라 저장하지 않았다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded, gate_id = await _seed_gate(
+                s, posture="conservative", gate_type="pr_review", story_title="고위험 승인(사유 有)",
+            )
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            note = "PR diff 전체 + CI green 확인, 마이그레이션 없음 확인 후 승인"
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition",
+                json={"status": "approved", "note": note},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["resolution_note"] == note, resp.json()
+            assert resp.json()["status"] == "approved", resp.json()
+
+            recheck = await client.get(f"/api/v2/gates/{gate_id}")
+            assert recheck.status_code == 200, recheck.text
+            body = recheck.json()
+            assert body["status"] == "approved", body
+            assert body["resolution_note"] == note, body
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_low_risk_approve_without_note_still_succeeds():
+    """permissive posture 가 gate_type=merge(2차 축이면 high)를 오버라이드해 low(test_1972 동일
+    조합). note 없이 approve 해도 기존대로 200 — 과도 강제 금지(PO AC 명시)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded, gate_id = await _seed_gate(
+                s, posture="permissive", gate_type="merge", story_title="저위험 승인 대상",
+            )
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition", json={"status": "approved"},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["status"] == "approved", resp.json()
+            assert resp.json()["resolution_note"] is None, resp.json()
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_ccbcd9da_gate_wake_wiring_realdb.py
+++ b/backend/tests/test_ccbcd9da_gate_wake_wiring_realdb.py
@@ -169,8 +169,10 @@ async def test_transition_gate_endpoint_wakes_after_commit(monkeypatch):
                  patch.object(gates_mod, "wake_agent", _fake_wake_agent), \
                  patch("app.services.conversation_webhook.deliver_injected_event_webhook", _fake_deliver):
                 bg = BackgroundTasks()
+                # story #2027: gate_type="custom_review"는 risk 매트릭스 폴백(미분류→고위험)이라
+                # 이 파일의 관심사(wake 배선)와 무관한 사유-강제 가드를 note로 우회.
                 await transition_gate_endpoint(
-                    id=seeded["gate"], body=GateTransitionRequest(status="approved"),
+                    id=seeded["gate"], body=GateTransitionRequest(status="approved", note="테스트 사유"),
                     background_tasks=bg,
                     session=s2, org_id=seeded["org"],
                     auth=type("A", (), {"user_id": str(uuid.uuid4())})(),

--- a/backend/tests/test_e_cage_referee_p3_gate_object.py
+++ b/backend/tests/test_e_cage_referee_p3_gate_object.py
@@ -310,8 +310,14 @@ async def test_transition_rejected_saves_note():
 
 
 @pytest.mark.anyio
-async def test_transition_approved_does_not_save_note():
-    """approved 전이 시 note 전달해도 resolution_note 저장 안 함."""
+async def test_transition_approved_saves_note():
+    """approved 전이 시 note 전달하면 resolution_note로 저장(story #2027 계약 변경).
+
+    이전 계약("approved는 note를 버린다")은 고위험 게이트 승인에 사유를 **요구**하면서
+    저장은 안 하는 모순을 낳았다(요건은 지켜도 감사 추적은 비어 있었다) — void_gate/
+    override_gate가 이미 reason을 필수+영속화하는 것과도 어긋났다. `resolution_note`는
+    rejection 전용 필드가 아니라 승인·반려 양쪽의 해소 사유를 담는 필드라 이 계약 변경이
+    필드 의미와도 정합한다."""
     from app.services.gate_service import transition_gate
 
     gate = MagicMock()
@@ -326,9 +332,9 @@ async def test_transition_approved_does_not_save_note():
     session.flush = AsyncMock()
     session.refresh = AsyncMock()
 
-    await transition_gate(session, ORG_ID, GATE_ID, "approved", MEMBER_ID, "의미없는 노트")
+    await transition_gate(session, ORG_ID, GATE_ID, "approved", MEMBER_ID, "고위험 승인 사유")
     assert gate.status == "approved"
-    assert not hasattr(gate, "resolution_note") or gate.resolution_note != "의미없는 노트"
+    assert gate.resolution_note == "고위험 승인 사유"
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_e_canvas_c4_s8_canonicalize_realdb.py
+++ b/backend/tests/test_e_canvas_c4_s8_canonicalize_realdb.py
@@ -247,7 +247,12 @@ async def test_approve_sets_anchor_version_and_notifies_creator():
         await _setup_transition_app(app, Session, seeded["org_id"], seeded["approver_user_id"])
         client = _client_for(app)
         try:
-            resp = await client.post(f"/api/v2/gates/{gate_id}/transition", json={"status": "approved"})
+            # story #2027: gate_type="artifact_canonicalize"는 risk 매트릭스 폴백(미분류→고위험)이라
+            # 이 파일의 관심사(anchor_version 배선)와 무관한 사유-강제 가드를 note로 우회.
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition",
+                json={"status": "approved", "note": "테스트 사유"},
+            )
             assert resp.status_code == 200, resp.text
         finally:
             await client.aclose()

--- a/backend/tests/test_edg_s23_hypothesis_overlay.py
+++ b/backend/tests/test_edg_s23_hypothesis_overlay.py
@@ -42,7 +42,9 @@ async def test_gate_transition_forces_resolver_id_to_caller(monkeypatch):
     monkeypatch.setattr(gm, "resolve_member", AsyncMock(return_value=caller))
     monkeypatch.setattr(gm, "transition_gate", _fake_transition)
     monkeypatch.setattr(gm.GateResponse, "model_validate", staticmethod(lambda g: g))
-    body = gm.GateTransitionRequest(status="approved", resolver_id=spoofed)
+    # story #2027: gate_type="merge"는 risk 매트릭스상 고위험(_HIGH_RISK_GATE_TYPES)이라 이 파일의
+    # 관심사(resolver_id 강제)와 무관한 사유-강제 가드를 note로 우회.
+    body = gm.GateTransitionRequest(status="approved", resolver_id=spoofed, note="테스트 사유")
     # 48f064e5: 엔드포인트가 doc-gate authz용 게이트 로드 → 비-doc 게이트 반환으로 그 분기 skip.
     _sess = AsyncMock()
     _gr = MagicMock()

--- a/backend/tests/test_gate_can_approve_48f064e5.py
+++ b/backend/tests/test_gate_can_approve_48f064e5.py
@@ -50,7 +50,10 @@ def _doc_gate(requester_id: uuid.UUID):
 
 async def _call(resolved, *, execute_results, has_access=None, status="approved"):
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=execute_results)
+    # story #2027: status="approved" 경로는 이 authz 체크들 뒤에 get_org_posture()로 session.execute
+    # 를 1회 더 호출한다(risk_grade 사유-강제 가드) — side_effect 리스트 끝에 그 몫을 추가. 이 파일의
+    # 관심사(project-access/self-approval authz)와 무관하므로 결과값은 무의미(None으로 충분).
+    session.execute = AsyncMock(side_effect=[*execute_results, _result(None)])
     transition = AsyncMock(return_value=SimpleNamespace())
     auth = SimpleNamespace(user_id=str(uuid.uuid4()))
     patches = [
@@ -65,7 +68,9 @@ async def _call(resolved, *, execute_results, has_access=None, status="approved"
         for p in patches:
             stack.enter_context(p)
         result = await transition_gate_endpoint(
-            id=uuid.uuid4(), body=GateTransitionRequest(status=status),
+            # note 동봉: risk_grade 폴백(미분류 gate_type→고위험)이 이 authz 테스트의 관심사가
+            # 아닌 사유-강제 가드에 걸리지 않도록.
+            id=uuid.uuid4(), body=GateTransitionRequest(status=status, note="테스트 사유"),
             background_tasks=BackgroundTasks(),
             session=session, org_id=uuid.uuid4(), auth=auth,
         )

--- a/backend/tests/test_gate_transition_human_only.py
+++ b/backend/tests/test_gate_transition_human_only.py
@@ -32,7 +32,10 @@ def _resolved(member_type: str) -> ResolvedMember:
 
 async def _call(status: str, member_type: str):
     org_id = uuid.uuid4()
-    body = GateTransitionRequest(status=status, resolver_id=uuid.uuid4())
+    # story #2027: note 동봉 — 이 테스트는 휴먼/에이전트 authz만 검증(risk_grade 무관). note 없으면
+    # gate_type="merge_approval"이 risk 매트릭스 두 세트 어디에도 없어 폴백(보수적 고위험)으로 떨어져
+    # approve 가 새 사유-강제 가드에 걸린다 — 이 파일의 관심사가 아니므로 note 로 그 분기를 우회한다.
+    body = GateTransitionRequest(status=status, resolver_id=uuid.uuid4(), note="테스트 사유")
     session = AsyncMock()
     # 48f064e5: 엔드포인트가 doc-gate authz용 게이트 로드 → 비-doc 게이트 반환(merge 등)으로 그 분기 skip.
     _gr = MagicMock()

--- a/backend/tests/test_rc1_body_trust_actor.py
+++ b/backend/tests/test_rc1_body_trust_actor.py
@@ -69,8 +69,10 @@ async def test_transition_forces_resolver_ignoring_body():
     from fastapi import BackgroundTasks
     with patch.object(mod, "resolve_member", AsyncMock(return_value=caller)), \
          patch.object(mod, "transition_gate", _fake_transition):
+        # story #2027: _non_doc_gate_session()의 gate_type="merge"는 고위험(_HIGH_RISK_GATE_TYPES)이라
+        # 이 파일의 관심사(resolver_id 강제)와 무관한 사유-강제 가드를 note로 우회.
         await transition_gate_endpoint(
-            id=uuid.uuid4(), body=GateTransitionRequest(status="approved", resolver_id=forged),
+            id=uuid.uuid4(), body=GateTransitionRequest(status="approved", resolver_id=forged, note="테스트 사유"),
             background_tasks=BackgroundTasks(),
             session=_non_doc_gate_session(), org_id=uuid.uuid4(),
             auth=SimpleNamespace(user_id=str(uuid.uuid4())))


### PR DESCRIPTION
## Summary
- `POST /gates/{id}/transition` accepted `approved` transitions on `risk_grade=high` gates with no note, and even when a note was sent it was silently dropped (`resolution_note` was only ever persisted for `rejected`). The FE only disabled the approve button client-side (`evidenceViewed && reason.trim()`), so a direct API call bypassed it entirely.
- `transition_gate_endpoint` now derives `risk_grade` the same way `list_gates`/`get_gate` already do (`derive_risk_grade` + `get_org_posture`) and returns 422 when an `approved` transition on a high-risk gate has no note — same convention `void_gate`/`override_gate` already enforce (reason required → `ValueError` → 422). Low-risk gates are unaffected (no note required, unchanged).
- `transition_gate` now persists `resolution_note` for any status when a note is supplied, not just `rejected`, so the newly-enforced reason is actually audited (previously it would have been accepted and thrown away).

## Scope note: evidence_viewed
The AC also asked whether "evidence viewed" can be enforced server-side. It can't, in this story's scope: the FE `evidenceViewed` checkbox (`gate-signature-approval.tsx`) is pure client component state — it's never sent in the transition request body, so there's no server-side signal to check today. Enforcing it for real would require a new field/endpoint (e.g. a view-tracking timestamp), which is a new feature surface, not an alignment with an existing convention. The available alternative today is the audit trail: `resolution_note` is now actually persisted on approve, so the "why" is recorded even without proof the evidence was viewed.

## Test plan
- [x] New `backend/tests/test_2027_gate_approval_reason_enforce.py` (real PG, 3 tests): high-risk + no note → 422, no mutation (re-fetched via GET); high-risk + note → 200, `resolution_note` persisted (re-fetched); low-risk + no note → 200 unchanged.
- [x] Mutation check: temporarily disabled the new guard locally and confirmed the 422 test goes red and reproduces the original bug exactly (200 OK, `resolution_note: null`) — then restored.
- [x] Full regression sweep of every test file exercising `POST /gates/{id}/transition` (`test_1972_gate_risk_grade.py`, `test_gate_transition_human_only.py`, `test_gate_can_approve_48f064e5.py`, `test_gate_decider_can_approve_89484c8c.py`, `test_edg_s5_merge_gate.py`, `test_1974_gate_assigned_to_me.py`, `test_ccbcd9da_gate_wake_wiring_realdb.py`, `test_edg_s23_hypothesis_overlay.py`, `test_rc1_body_trust_actor.py`, `test_e_dg_s25_epic_transition_500_realdb.py`, `test_e_security_sec_s8_cc_sprint_project_scope_realdb.py`) — 128 passed. 6 files needed a `note` added to their request bodies (their mocked/unclassified gate_types fell into the risk-grade fallback default of "high"); no assertions in those files changed.
- [x] Confirmed 2 unrelated pre-existing failures (`test_e_canvas_c4_s8_canonicalize_realdb.py::test_approve_sets_anchor_version_and_notifies_creator`, `test_e_glance_wedge_roadmap_steer_realdb.py::test_steer_dispatch_delivers_only_to_human_specified_recipient_not_relay_owner`) also fail identically on unmodified `origin/develop` — not caused by this change.
- [x] `ruff check` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)