### PR TITLE
[SID:2036] 가설 달성/반증 UI — 사람이 직접 닫는 경로 신설

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2834,7 +2834,18 @@
     "drafting": "Drafting…",
     "draftReviewTitle": "AI draft",
     "draftNote": "AI-suggested from activity. Review before adding.",
-    "draftAccept": "Confirm & add"
+    "draftAccept": "Confirm & add",
+    "resolveVerify": "Close as verified",
+    "resolveFalsify": "Close as falsified",
+    "resolveTitleVerify": "Close hypothesis as verified",
+    "resolveTitleFalsify": "Close hypothesis as falsified",
+    "actualInputLabel": "Actual value",
+    "reasonInputLabel": "Reason (one line)",
+    "reasonInputPlaceholder": "State the reason for this verdict",
+    "reasonHint": "A reason is required to close this hypothesis.",
+    "resolveSubmit": "Save verdict",
+    "closedByHuman": "Resolved by {name}",
+    "closedByAuto": "Auto-scored"
   },
   "goals": {
     "title": "Goals",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2845,7 +2845,11 @@
     "reasonHint": "A reason is required to close this hypothesis.",
     "resolveSubmit": "Save verdict",
     "closedByHuman": "Resolved by {name}",
-    "closedByAuto": "Auto-scored"
+    "closedByAuto": "Auto-scored",
+    "mismatchVerifyWarning": "The actual value doesn't meet the target. If you still close this as verified, note why in the reason.",
+    "mismatchFalsifyWarning": "The actual value meets the target. If you still close this as falsified, note why in the reason.",
+    "switchToFalsify": "Switch to falsified",
+    "switchToVerify": "Switch to verified"
   },
   "goals": {
     "title": "Goals",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2845,7 +2845,11 @@
     "reasonHint": "근거 없이는 닫을 수 없습니다.",
     "resolveSubmit": "판정 저장",
     "closedByHuman": "{name} 판정",
-    "closedByAuto": "자동 채점"
+    "closedByAuto": "자동 채점",
+    "mismatchVerifyWarning": "입력한 실제 수치가 목표 조건에 못 미칩니다. 그래도 달성으로 저장하려면 근거에 사유를 남기세요.",
+    "mismatchFalsifyWarning": "입력한 실제 수치가 목표 조건을 충족합니다. 그래도 반증으로 저장하려면 근거에 사유를 남기세요.",
+    "switchToFalsify": "반증으로 전환",
+    "switchToVerify": "달성으로 전환"
   },
   "goals": {
     "title": "목표",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2834,7 +2834,18 @@
     "drafting": "초안 생성 중…",
     "draftReviewTitle": "AI 초안",
     "draftNote": "AI가 흐름에서 제안한 초안입니다. 확인 후 추가하세요.",
-    "draftAccept": "확인하고 추가"
+    "draftAccept": "확인하고 추가",
+    "resolveVerify": "달성으로 닫기",
+    "resolveFalsify": "반증으로 닫기",
+    "resolveTitleVerify": "가설을 달성으로 닫기",
+    "resolveTitleFalsify": "가설을 반증으로 닫기",
+    "actualInputLabel": "실제 수치",
+    "reasonInputLabel": "근거 (한 줄)",
+    "reasonInputPlaceholder": "이 판정의 근거를 적어주세요",
+    "reasonHint": "근거 없이는 닫을 수 없습니다.",
+    "resolveSubmit": "판정 저장",
+    "closedByHuman": "{name} 판정",
+    "closedByAuto": "자동 채점"
   },
   "goals": {
     "title": "목표",

--- a/apps/web/src/components/hypotheses/hypotheses-section.tsx
+++ b/apps/web/src/components/hypotheses/hypotheses-section.tsx
@@ -234,7 +234,10 @@ export function HypothesesSection({ epicId, projectId }: { epicId: string; proje
     if (!resolving) return;
     setResolveSubmitting(true);
     try {
-      const { hypothesis: h, target } = resolving;
+      const { hypothesis: h } = resolving;
+      // 유나 가디언 리뷰: 다이얼로그 내 불일치 배너로 판정을 전환할 수 있으므로 열 때의
+      // target이 아니라 결과가 실어온 target(사용자가 최종 선택한 판정)을 그대로 쓴다.
+      const target = result.target;
       const md = h.metric_definition;
       const res = await fetch(`/api/hypotheses/${h.id}/transition`, {
         method: 'POST',

--- a/apps/web/src/components/hypotheses/hypotheses-section.tsx
+++ b/apps/web/src/components/hypotheses/hypotheses-section.tsx
@@ -226,10 +226,14 @@ export function HypothesesSection({ epicId, projectId }: { epicId: string; proje
 
   // story #2036 AC2/AC3: outcome_result는 transition endpoint가 통째로 덮어쓰므로(병합 아님)
   // 기존 metric_definition 값을 그대로 실어 채점 카드(target/direction) 표시를 보존하고,
-  // reason(근거)·closed_by(누가 닫았는지)를 함께 적재한다. AC4: 서버 cron 채점기는
-  // `status IN ('active','measuring')`인 가설만 조회하므로(hypothesis_scorer.py) 사람이
-  // 한 번 verified/falsified로 닫으면 그 즉시 채점 대상에서 빠져 자동 채점이 재덮어쓰기할
-  // 수 없다 — measure_after 도래 직후의 클릭↔cron 경합만 "먼저 전이한 쪽이 승리"로 남는다.
+  // reason(근거)을 함께 적재한다. AC4: 서버 cron 채점기는 `status IN ('active','measuring')`인
+  // 가설만 조회하므로(hypothesis_scorer.py) 사람이 한 번 verified/falsified로 닫으면 그 즉시
+  // 채점 대상에서 빠져 자동 채점이 재덮어쓰기할 수 없다 — measure_after 도래 직후의 클릭↔cron
+  // 경합만 "먼저 전이한 쪽이 승리"로 남는다.
+  // PO 리뷰(2026-07-20): closed_by/closed_by_member_id는 "누가 닫았는가"를 결정하는 신뢰축
+  // 필드라 클라이언트가 자칭해선 안 된다 — API를 직접 호출하면 에이전트가 닫은 걸 human으로
+  // 위장할 수 있는 구멍이었다. 서버(hypotheses.py의 인증된 caller)가 채워 넣도록 넘기고,
+  // FE는 이 필드를 아예 보내지 않는다(계약을 명확히 하기 위해 값 자체를 생략).
   const handleResolveSubmit = useCallback(async (result: HypothesisResolveResult) => {
     if (!resolving) return;
     setResolveSubmitting(true);
@@ -251,8 +255,6 @@ export function HypothesesSection({ epicId, projectId }: { epicId: string; proje
             actual: result.actual,
             scored_at: new Date().toISOString(),
             reason: result.reason,
-            closed_by: 'human',
-            closed_by_member_id: currentTeamMemberId ?? null,
           },
         }),
       });
@@ -260,7 +262,7 @@ export function HypothesesSection({ epicId, projectId }: { epicId: string; proje
     } finally {
       setResolveSubmitting(false);
     }
-  }, [resolving, currentTeamMemberId, load]);
+  }, [resolving, load]);
 
   // 대표 가설(첫 primary) 상단·verdict 우선 노출.
   const sorted = items ? [...items] : [];

--- a/apps/web/src/components/hypotheses/hypotheses-section.tsx
+++ b/apps/web/src/components/hypotheses/hypotheses-section.tsx
@@ -8,6 +8,7 @@ import { HypothesisRow, type HypothesisRowActions } from './hypothesis-row';
 import { HypothesisVerdictCard } from './hypothesis-verdict-card';
 import { HypothesisForm, type HypothesisFormValue } from './hypothesis-form';
 import { HypothesisGateBadge } from './hypothesis-gate-badge';
+import { HypothesisResolveDialog, type HypothesisResolveResult } from './hypothesis-resolve-dialog';
 import type { GateItem } from '@/components/kanban/types';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 
@@ -97,6 +98,9 @@ export function HypothesesSection({ epicId, projectId }: { epicId: string; proje
   const [hypGatesMap, setHypGatesMap] = useState<Record<string, GateItem>>({});
   const [memberNames, setMemberNames] = useState<Record<string, string>>({});
   const { currentTeamMemberId } = useDashboardContext();
+  // story #2036 — measuring 가설을 달성/반증으로 닫는 다이얼로그 상태.
+  const [resolving, setResolving] = useState<{ hypothesis: Hypothesis; target: 'verified' | 'falsified' } | null>(null);
+  const [resolveSubmitting, setResolveSubmitting] = useState(false);
 
   const load = useCallback(async () => {
     try {
@@ -216,7 +220,44 @@ export function HypothesesSection({ epicId, projectId }: { epicId: string; proje
       // Story picker는 별도 affordance(§6.5 story 패널 picker와 공유) — 후속 배선.
       void h;
     },
+    // story #2036 — 다이얼로그를 여는 것까지만. 실제 transition은 handleResolveSubmit.
+    onResolve: (h, target) => setResolving({ hypothesis: h, target }),
   };
+
+  // story #2036 AC2/AC3: outcome_result는 transition endpoint가 통째로 덮어쓰므로(병합 아님)
+  // 기존 metric_definition 값을 그대로 실어 채점 카드(target/direction) 표시를 보존하고,
+  // reason(근거)·closed_by(누가 닫았는지)를 함께 적재한다. AC4: 서버 cron 채점기는
+  // `status IN ('active','measuring')`인 가설만 조회하므로(hypothesis_scorer.py) 사람이
+  // 한 번 verified/falsified로 닫으면 그 즉시 채점 대상에서 빠져 자동 채점이 재덮어쓰기할
+  // 수 없다 — measure_after 도래 직후의 클릭↔cron 경합만 "먼저 전이한 쪽이 승리"로 남는다.
+  const handleResolveSubmit = useCallback(async (result: HypothesisResolveResult) => {
+    if (!resolving) return;
+    setResolveSubmitting(true);
+    try {
+      const { hypothesis: h, target } = resolving;
+      const md = h.metric_definition;
+      const res = await fetch(`/api/hypotheses/${h.id}/transition`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          status: target,
+          outcome_result: {
+            metric: md?.metric ?? null,
+            target: md?.target ?? null,
+            direction: md?.direction ?? null,
+            actual: result.actual,
+            scored_at: new Date().toISOString(),
+            reason: result.reason,
+            closed_by: 'human',
+            closed_by_member_id: currentTeamMemberId ?? null,
+          },
+        }),
+      });
+      if (res.ok) { setResolving(null); await load(); }
+    } finally {
+      setResolveSubmitting(false);
+    }
+  }, [resolving, currentTeamMemberId, load]);
 
   // 대표 가설(첫 primary) 상단·verdict 우선 노출.
   const sorted = items ? [...items] : [];
@@ -282,7 +323,7 @@ export function HypothesesSection({ epicId, projectId }: { epicId: string; proje
                 onResolved={() => void load()}
               />
               {isVerdict(h) ? (
-                <HypothesisVerdictCard hypothesis={h} />
+                <HypothesisVerdictCard hypothesis={h} resolveName={(id) => memberNames[id] ?? id.slice(0, 6)} />
               ) : (
                 <HypothesisRow hypothesis={h} actions={actions} />
               )}
@@ -290,6 +331,16 @@ export function HypothesesSection({ epicId, projectId }: { epicId: string; proje
           ))
         )}
       </div>
+
+      {resolving ? (
+        <HypothesisResolveDialog
+          hypothesis={resolving.hypothesis}
+          target={resolving.target}
+          submitting={resolveSubmitting}
+          onSubmit={(result) => void handleResolveSubmit(result)}
+          onCancel={() => setResolving(null)}
+        />
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/components/hypotheses/hypothesis-resolve-dialog.tsx
+++ b/apps/web/src/components/hypotheses/hypothesis-resolve-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { TriangleAlert } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -18,6 +19,7 @@ const fmt = (n: number) => (Number.isInteger(n) ? String(n) : n.toFixed(2));
 export interface HypothesisResolveResult {
   actual: number;
   reason: string;
+  target: 'verified' | 'falsified';
 }
 
 /**
@@ -25,10 +27,19 @@ export interface HypothesisResolveResult {
  * AC2: 실제 수치 + 한 줄 근거 둘 다 없으면 제출 불가(근거 없는 "달성" 버튼=조직 자기기만 통로).
  * 반증(falsify)도 같은 폼 구조 — soul-lock(§hypothesis-status-badge.tsx): 반증을 실패처럼
  * 취급하는 문구/색 금지, 담담한 "판정 저장" 톤 유지.
+ *
+ * 유나 가디언 리뷰(PR #2303) 수정요청: 목표 미달 수치를 입력해도 "달성"으로 조용히 저장되는
+ * 통로가 있었다 — 목표(target)를 화면에 보여주면서 불일치를 막지 않은 게 문제. 차단하지 않고
+ * (측정 방식 변경·정성 판단 등 정당한 override 사유가 있을 수 있음 — 근거 필드가 그 자리)
+ * 불일치를 인지시키는 방향으로: 입력값이 현재 판정 조건과 안 맞으면 배너+반대 판정 전환 버튼.
+ *
+ * AC8(오르테가 PO 판정, hypothesis.py `_VALID_TRANSITIONS`로 확인): measuring→verified|falsified는
+ * archived로만 전진하고 active/measuring으로 역전이 불가("새 가설을 만든다") — 되돌릴 수 없는
+ * 종결이라 브랜드 블루(Button 기본 variant)를 종결 버튼에 그대로 둔다(유나 리뷰 PASS 확인).
  */
 export function HypothesisResolveDialog({
   hypothesis,
-  target,
+  target: initialTarget,
   submitting,
   onSubmit,
   onCancel,
@@ -41,12 +52,20 @@ export function HypothesisResolveDialog({
 }) {
   const t = useTranslations('hypotheses');
   const md = hypothesis.metric_definition;
+  const [verdict, setVerdict] = useState<'verified' | 'falsified'>(initialTarget);
   const [actual, setActual] = useState('');
   const [reason, setReason] = useState('');
 
   const actualNum = actual.trim() === '' ? null : Number(actual);
   const canSubmit = actualNum !== null && !Number.isNaN(actualNum) && reason.trim().length > 0 && !submitting;
-  const isVerify = target === 'verified';
+  const isVerify = verdict === 'verified';
+
+  // 유나 가디언 수정요청 — 입력값이 현재 선택된 판정의 목표 조건과 맞는지. null=판단 불가(입력 전
+  // 또는 target 없음), true/false=충족 여부. mismatch면 저장을 막지 않고 배너로만 알린다.
+  const meetsTarget = actualNum !== null && !Number.isNaN(actualNum) && typeof md?.target === 'number'
+    ? (md.direction === 'down' ? actualNum <= md.target : actualNum >= md.target)
+    : null;
+  const mismatch = meetsTarget !== null && meetsTarget !== isVerify;
 
   return (
     <Dialog open onOpenChange={(next) => { if (!next) onCancel(); }}>
@@ -58,7 +77,7 @@ export function HypothesisResolveDialog({
           className="space-y-3"
           onSubmit={(e) => {
             e.preventDefault();
-            if (canSubmit) onSubmit({ actual: actualNum as number, reason: reason.trim() });
+            if (canSubmit) onSubmit({ actual: actualNum as number, reason: reason.trim(), target: verdict });
           }}
         >
           <p className="line-clamp-3 text-sm leading-6 text-foreground">{hypothesis.statement}</p>
@@ -84,6 +103,22 @@ export function HypothesisResolveDialog({
               className="w-full rounded-xl border border-border bg-background px-3 py-2 text-sm tabular-nums text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
             />
           </div>
+
+          {mismatch ? (
+            <div className="flex items-start gap-2 rounded-lg border border-warning-border bg-warning-tint px-3 py-2 text-xs text-warning">
+              <TriangleAlert className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+              <div className="space-y-1">
+                <p>{isVerify ? t('mismatchVerifyWarning') : t('mismatchFalsifyWarning')}</p>
+                <button
+                  type="button"
+                  onClick={() => setVerdict(isVerify ? 'falsified' : 'verified')}
+                  className="font-medium underline underline-offset-2"
+                >
+                  {isVerify ? t('switchToFalsify') : t('switchToVerify')}
+                </button>
+              </div>
+            </div>
+          ) : null}
 
           <div className="space-y-1">
             <label className="text-xs font-medium text-muted-foreground" htmlFor="resolve-reason">

--- a/apps/web/src/components/hypotheses/hypothesis-resolve-dialog.tsx
+++ b/apps/web/src/components/hypotheses/hypothesis-resolve-dialog.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogClose,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import type { Hypothesis } from '@sprintable/core-storage';
+
+const fmt = (n: number) => (Number.isInteger(n) ? String(n) : n.toFixed(2));
+
+export interface HypothesisResolveResult {
+  actual: number;
+  reason: string;
+}
+
+/**
+ * story #2036 — 검증 중(measuring) 가설을 사람이 달성/반증으로 닫는 유일한 표면.
+ * AC2: 실제 수치 + 한 줄 근거 둘 다 없으면 제출 불가(근거 없는 "달성" 버튼=조직 자기기만 통로).
+ * 반증(falsify)도 같은 폼 구조 — soul-lock(§hypothesis-status-badge.tsx): 반증을 실패처럼
+ * 취급하는 문구/색 금지, 담담한 "판정 저장" 톤 유지.
+ */
+export function HypothesisResolveDialog({
+  hypothesis,
+  target,
+  submitting,
+  onSubmit,
+  onCancel,
+}: {
+  hypothesis: Hypothesis;
+  target: 'verified' | 'falsified';
+  submitting: boolean;
+  onSubmit: (result: HypothesisResolveResult) => void;
+  onCancel: () => void;
+}) {
+  const t = useTranslations('hypotheses');
+  const md = hypothesis.metric_definition;
+  const [actual, setActual] = useState('');
+  const [reason, setReason] = useState('');
+
+  const actualNum = actual.trim() === '' ? null : Number(actual);
+  const canSubmit = actualNum !== null && !Number.isNaN(actualNum) && reason.trim().length > 0 && !submitting;
+  const isVerify = target === 'verified';
+
+  return (
+    <Dialog open onOpenChange={(next) => { if (!next) onCancel(); }}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{isVerify ? t('resolveTitleVerify') : t('resolveTitleFalsify')}</DialogTitle>
+        </DialogHeader>
+        <form
+          className="space-y-3"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (canSubmit) onSubmit({ actual: actualNum as number, reason: reason.trim() });
+          }}
+        >
+          <p className="line-clamp-3 text-sm leading-6 text-foreground">{hypothesis.statement}</p>
+
+          {md?.metric ? (
+            <p className="text-xs tabular-nums text-muted-foreground">
+              📈 {md.metric} {md.direction === 'down' ? '≤' : '≥'} {fmt(md.target)}
+            </p>
+          ) : null}
+
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-muted-foreground" htmlFor="resolve-actual">
+              {t('actualInputLabel')} <span className="text-destructive">*</span>
+            </label>
+            <input
+              id="resolve-actual"
+              type="number"
+              inputMode="decimal"
+              value={actual}
+              onChange={(e) => setActual(e.target.value)}
+              placeholder={t('targetPlaceholder')}
+              autoFocus
+              className="w-full rounded-xl border border-border bg-background px-3 py-2 text-sm tabular-nums text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-muted-foreground" htmlFor="resolve-reason">
+              {t('reasonInputLabel')} <span className="text-destructive">*</span>
+            </label>
+            <input
+              id="resolve-reason"
+              type="text"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder={t('reasonInputPlaceholder')}
+              className="w-full rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+            />
+            <p className="text-[11px] text-muted-foreground">{t('reasonHint')}</p>
+          </div>
+
+          <DialogFooter>
+            <DialogClose render={<Button type="button" variant="ghost" disabled={submitting} onClick={onCancel}>{t('cancel')}</Button>} />
+            <Button type="submit" disabled={!canSubmit}>
+              {submitting ? t('saving') : t('resolveSubmit')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/hypotheses/hypothesis-row.tsx
+++ b/apps/web/src/components/hypotheses/hypothesis-row.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
-import { MoreHorizontal, Link2, Play, XCircle } from 'lucide-react';
+import { MoreHorizontal, Link2, Play, XCircle, CheckCircle2, CircleSlash } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import {
   DropdownMenu,
@@ -20,6 +20,8 @@ export interface HypothesisRowActions {
   onActivate: (h: Hypothesis) => void;
   onLinkStory: (h: Hypothesis) => void;
   onKill: (h: Hypothesis) => void;
+  // story #2036 — measuring 가설을 사람이 달성/반증으로 닫는 진입점(다이얼로그는 호출부가 연다).
+  onResolve: (h: Hypothesis, target: 'verified' | 'falsified') => void;
 }
 
 /** Compact in-flight / terminal row (§4.2). verified/falsified use the VerdictCard instead. */
@@ -120,8 +122,10 @@ function HypothesisActions({
   actions: HypothesisRowActions;
   t: ReturnType<typeof useTranslations>;
 }) {
-  // 활성화는 §12.2ⓑ대로 row 인라인에 노출(연속 흐름) — 메뉴엔 연결/kill만.
+  // 활성화는 §12.2ⓑ대로 row 인라인에 노출(연속 흐름) — 메뉴엔 연결/kill/달성/반증만.
   const canKill = hypothesis.status === 'proposed' || hypothesis.status === 'active' || hypothesis.status === 'measuring';
+  // story #2036 — 달성/반증은 measuring 상태에서만 열린다(BE 합법 전이가 measuring→verified|falsified뿐).
+  const canResolve = hypothesis.status === 'measuring';
 
   return (
     <DropdownMenu>
@@ -136,6 +140,18 @@ function HypothesisActions({
           <Link2 className="mr-2 size-4" />
           {t('linkStory')}
         </DropdownMenuItem>
+        {canResolve ? (
+          <>
+            <DropdownMenuItem onClick={() => actions.onResolve(hypothesis, 'verified')} className="text-success focus:text-success">
+              <CheckCircle2 className="mr-2 size-4" />
+              {t('resolveVerify')}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => actions.onResolve(hypothesis, 'falsified')} className="text-info focus:text-info">
+              <CircleSlash className="mr-2 size-4" />
+              {t('resolveFalsify')}
+            </DropdownMenuItem>
+          </>
+        ) : null}
         {canKill ? (
           <DropdownMenuItem onClick={() => actions.onKill(hypothesis)} className="text-destructive focus:text-destructive">
             <XCircle className="mr-2 size-4" />

--- a/apps/web/src/components/hypotheses/hypothesis-verdict-card.tsx
+++ b/apps/web/src/components/hypotheses/hypothesis-verdict-card.tsx
@@ -15,12 +15,33 @@ import type { Hypothesis } from '@sprintable/core-storage';
  */
 const fmt = (n: number) => (Number.isInteger(n) ? String(n) : n.toFixed(2));
 
-export function HypothesisVerdictCard({ hypothesis }: { hypothesis: Hypothesis }) {
+export function HypothesisVerdictCard({
+  hypothesis,
+  resolveName,
+}: {
+  hypothesis: Hypothesis;
+  /** story #2036 AC3 — closed_by_member_id → 표시 이름. 없으면 id 그대로 폴백. */
+  resolveName?: (id: string) => string;
+}) {
   const t = useTranslations('hypotheses');
   const isVerified = hypothesis.status === 'verified';
   const result = (hypothesis.outcome_result ?? null) as
-    | { metric?: string; target?: number; actual?: number; direction?: 'up' | 'down'; scored_at?: string }
+    | {
+        metric?: string;
+        target?: number;
+        actual?: number;
+        direction?: 'up' | 'down';
+        scored_at?: string;
+        reason?: string;
+        closed_by?: 'human';
+        closed_by_member_id?: string;
+      }
     | null;
+  // story #2036 AC3 — 사람이 닫았으면 closed_by='human'이 outcome_result에 실린다(BE 컬럼
+  // 없음·JSONB 자체 적재). 없으면 cron 자동 채점(hypothesis_scorer.py)이 닫은 것.
+  const closedByLabel = result?.closed_by === 'human'
+    ? t('closedByHuman', { name: result.closed_by_member_id ? (resolveName?.(result.closed_by_member_id) ?? result.closed_by_member_id) : t('owner') })
+    : result?.scored_at ? t('closedByAuto') : null;
 
   return (
     <div
@@ -55,6 +76,13 @@ export function HypothesisVerdictCard({ hypothesis }: { hypothesis: Hypothesis }
           </div>
           <DeltaTrack target={result.target} actual={result.actual} isVerified={isVerified} />
         </>
+      ) : null}
+
+      {result?.reason ? (
+        <p className="mt-3 text-xs leading-5 text-muted-foreground">&ldquo;{result.reason}&rdquo;</p>
+      ) : null}
+      {closedByLabel ? (
+        <p className="mt-1.5 text-[11px] text-muted-foreground">{closedByLabel}</p>
       ) : null}
     </div>
   );


### PR DESCRIPTION
## 배경 (story #2036)
prod 라이브 실측(2026-07-20, 홍보영상 촬영용 데모 데이터 제작 중 발견): 검증 중(measuring) 가설을 사람이 달성/반증으로 닫을 UI가 어디에도 없었음. 선생님 지시로 최우선 — 촬영이 "제품 수정 후" 조건에 막혀 있었음.

## 백엔드 조사 결과 (착수 전 grep으로 확인 — 추측 금지)
- `backend/app/models/hypothesis.py` `_VALID_TRANSITIONS`에 `measuring→verified`/`measuring→falsified`가 이미 있고, 휴먼 caller 제약은 `target=='active'`에만 걸려있음(`services/hypothesis.py:328-331`). **verified/falsified는 오늘 이미 사람이 호출 가능** — 백엔드 변경 0.
- `HypothesisTransition` 스키마(`schemas/hypothesis.py`)는 `{status, note, outcome_result}`뿐이고 `note`는 `target=='killed'`일 때만 소비됨(verified/falsified에선 드롭). `outcome_result`는 **병합이 아니라 통째로 교체**되므로 metric/target/direction을 매번 다시 실어야 함.
- 모델에 "누가 닫았는지" 컬럼 없음(`confirmed_by_member_id`는 active 전이 전용). `outcome_result` JSONB에 `closed_by`/`closed_by_member_id`/`reason`을 추가 필드로 적재하는 방식으로 해결(스키마 자유필드라 안전).
- 자동채점 cron(`hypothesis_scorer.py:73-76`) 쿼리: `WHERE measure_after<=now AND status IN ('active','measuring')`. **사람이 verified/falsified로 닫는 순간 이 조회 스코프에서 빠짐** — AC4가 요구한 "자동↔수동 충돌 규칙"의 답: 한 번 닫히면 자동 채점이 재덮어쓸 수 없음. 유일한 경합 창은 measure_after 도래 직후 사람 클릭과 cron 배치 사이(먼저 전이한 쪽이 DB status를 바꾸고, 늦은 쪽은 `is_valid_transition`이 걸러냄).

## 변경 (apps/web만, BE 무접촉)
- `hypothesis-resolve-dialog.tsx`(신규): 실제 수치+한 줄 근거 **둘 다** 없으면 제출 버튼 disabled(AC2). verify/falsify 공용 구조, "실패" 어휘·destructive 색 미사용(soul-lock).
- `hypothesis-row.tsx`: measuring 상태에서만 드롭다운에 "달성으로 닫기"/"반증으로 닫기" 노출(`text-success`/`text-info`만 사용, destructive는 kill 전용 유지).
- `hypotheses-section.tsx`: 다이얼로그 상태+제출 핸들러. `outcome_result`에 기존 `metric_definition`(metric/target/direction) + `actual`(입력값) + `scored_at`(now) + `reason` + `closed_by:'human'` + `closed_by_member_id`(currentTeamMemberId) 패킹.
- `hypothesis-verdict-card.tsx`: 근거 텍스트 + 판정자(`closedByHuman`/`closedByAuto`) 표시 추가. member 이름 해소는 기존 `memberNames` 맵 재사용(신규 fetch 0).
- i18n: `hypotheses` 네임스페이스에 12키 추가(ko/en 동수, parity 스크립트 확인).

## AC 대조 (grep/코드 근거 첨부 — [[feedback-ac-claim-needs-grep-evidence]] 적용)
- **AC1**: 4개 변경 파일 전수 `grep -nP '[가-힣]' <file>` 결과 — 전부 주석/JSDoc뿐, 렌더 문자열 0건(스크린샷 대신 raw grep 출력 첨부):
  ```
  hypothesis-resolve-dialog.tsx: L24-27 (JSDoc)만
  hypotheses-section.tsx: L26-29,93,97,101,112,119,154,173-174,190,200,209,220,223,227-232,262,317 전부 // 또는 /* 주석
  hypothesis-row.tsx: L23,37-40,44,89,125,127 전부 주석
  hypothesis-verdict-card.tsx: L12-14,23,40-41,91 전부 주석/JSDoc
  ```
- **AC2**: `hypothesis-resolve-dialog.tsx:48` `canSubmit = actualNum !== null && !Number.isNaN(actualNum) && reason.trim().length > 0` — 근거 없이 제출 불가.
- **AC3**: `hypothesis-verdict-card.tsx` `closedByLabel` — `closed_by==='human'`이면 이름, 아니면(scored_at만 있으면) 자동 채점 라벨.
- **AC4**: 위 "cron 쿼리 스코프" 문서화 + `hypotheses-section.tsx:227-232` 코드 주석에 동일 내용 박제.
- **AC5**: falsified 배지·verdict card 전부 `variant="info"`(청) 유지, 신규 다이얼로그도 destructive 미사용. `grep -n "실패" messages/ko.json`으로 hypotheses 네임스페이스 신규 키 중 "실패" 어휘 0건 확인.
- **AC6**: `derive-loop-face.ts::parseHypotheses`는 `status`/`statement`/`id`/`epic_ids`/`created_at`만 읽고 `outcome_result` 형태에 의존 안 함(코드 확인) — LoopFace/sprint-cockpit/org-briefing 전부 status 문자열 기반이라 회귀 없음. **단, `attribute_loop_outcome`은 이미 measuring 상태인 Loop이 가설에 연결돼 있어야만 귀속되고, 없으면 스킵**(BE 코드 확인) — 이 프로젝트는 루프 0건이라 이번 PR로 새 Loop이 자동 생성되진 않음(기존 자동채점 경로와 동일 동작, 이번 PR이 만든 회귀 아님. Loop 생성 트리거는 별도 스토리 영역).
- **AC7**: EN 로케일 키 12개 en.json 동시 추가, parity 스크립트로 ko/en 3,592키 동수 확인.

## ⚠️ 미완 — AC1/AC2 라이브 왕복 증빙
[[reference-live-fe-verify-deployed-only]] 사유로 로컬 워크트리는 dev BE와 인증 불일치라 pre-merge 라이브 검증 불가. develop 배포 확인 후 목표 상세에서 실제 달성/반증 클릭 왕복(측정 중 가설 필요 — 없으면 테스트용 가설 하나 measure_after를 과거로 만들어 재현)까지 마치고 이 PR에 결과 추가하겠음.

## 검증
- `pnpm type-check`: PASS
- `pnpm lint`: 0 errors (기존 무관 warning 5건)
- `pnpm verify:no-new-md-breakpoint`: PASS
- `pnpm build`: EXIT 0
- `vitest run src/lib/i18n.test.ts src/services/hypothesis-declaration*.test.ts src/components/sprints/hypothesis-declaration-section.test.tsx`: 16/16 PASS (기존 가설 관련 테스트 전체 회귀 0)
- 신규 컴포넌트(HypothesisResolveDialog) 자체 유닛테스트는 base-ui Dialog가 `document.body`에 포털 렌더돼 이 레포의 `renderToStaticMarkup` 컨벤션으로는 못 잡음(testing-library 의존성 자체가 레포에 없음) — AC2 gating은 위 라이브 왕복 검증으로 대체 증빙 예정.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
