### PR TITLE
[SID:2035] 모바일 채팅 표·코드블록 가로 오버플로 fix

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -135,6 +135,18 @@ function ChatMarkdown({ content, isMine }: { content: string; isMine: boolean })
           );
         },
         pre: ({ children }) => <pre className={`mb-1.5 overflow-x-auto rounded-lg p-2.5 text-xs ${codeBg}`}>{children}</pre>,
+        // story #2035 AC2 — 표는 자기 컨테이너 안에서만 가로 스크롤(doc-content-renderer.tsx의
+        // 검증된 not-prose overflow-x-auto 패턴 재사용). whitespace-nowrap 없으면 브라우저가
+        // 열 텍스트를 좁은 말풍선 폭에 맞춰 줄바꿈/축약해버려 "열 삭제·축약 금지" 위반이 됨 —
+        // nowrap으로 열 폭을 원문 그대로 유지하고 넘치는 만큼 래퍼가 스크롤하게 한다.
+        table: ({ children }) => (
+          <div className={`mb-1.5 overflow-x-auto rounded-lg border ${border}`}>
+            <table className="whitespace-nowrap text-xs">{children}</table>
+          </div>
+        ),
+        thead: ({ children }) => <thead className={muted}>{children}</thead>,
+        th: ({ children }) => <th className={`border-b px-2 py-1 text-left font-semibold ${border} ${text}`}>{children}</th>,
+        td: ({ children }) => <td className={`border-b px-2 py-1 ${border} ${text}`}>{children}</td>,
         ul: ({ children }) => <ul className={`mb-1.5 ml-4 list-disc space-y-0.5 text-sm ${text}`}>{children}</ul>,
         ol: ({ children }) => <ol className={`mb-1.5 ml-4 list-decimal space-y-0.5 text-sm ${text}`}>{children}</ol>,
         li: ({ children }) => <li className={`text-sm leading-relaxed ${text}`}>{children}</li>,
@@ -280,9 +292,15 @@ export function ChatBubble({ message, isMine, isGrouped = false, onOpenThread, o
             </div>
           )}
 
-          {/* Content — S8: command 전용 버블(brand·mono·⌘ 태그) vs 일반(리터럴은 dequote 표시) */}
+          {/* Content — S8: command 전용 버블(brand·mono·⌘ 태그) vs 일반(리터럴은 dequote 표시).
+              story #2035: min-w-0+max-w-full — 부모 컬럼(min-w-0 max-w-[72%] items-start/end)이
+              flex-item 자식을 cross-axis에서 stretch가 아닌 shrink-to-fit으로 배치하므로, 이
+              말풍선 배경 div 자체에 상한이 없으면 표·코드블록의 min-content가 부모 max-w를
+              무시하고 새어나간다(재현·측정 확認 — 아래 근거 참고). max-w-full로 컬럼의 269px
+              상한을 이 자식에도 강제해야 안의 pre(overflow-x-auto)·표(overflow-x-auto 래퍼)가
+              비로소 자기 박스 안에서 스크롤된다. */}
           {isCmd ? (
-            <div className={`rounded-xl border border-info/30 bg-info/8 px-3.5 py-2 ${isMine ? 'rounded-tr-sm' : 'rounded-tl-sm'}`}>
+            <div className={`min-w-0 max-w-full rounded-xl border border-info/30 bg-info/8 px-3.5 py-2 ${isMine ? 'rounded-tr-sm' : 'rounded-tl-sm'}`}>
               <div className="mb-1 flex items-center gap-1 text-[10px] font-medium text-info">
                 <Terminal className="h-3 w-3" aria-hidden />
                 {t('commandTag')}
@@ -293,7 +311,7 @@ export function ChatBubble({ message, isMine, isGrouped = false, onOpenThread, o
               </code>
             </div>
           ) : (
-            <div className={`rounded-xl px-3.5 py-2 text-sm leading-relaxed [overflow-wrap:anywhere] ${
+            <div className={`min-w-0 max-w-full rounded-xl px-3.5 py-2 text-sm leading-relaxed [overflow-wrap:anywhere] ${
               isMine
                 ? 'rounded-tr-sm bg-primary text-primary-foreground'
                 : 'rounded-tl-sm bg-muted text-foreground'


### PR DESCRIPTION
## 배경 (story #2035)
선생님 실기기 제보 — 모바일 채팅에서 화면 전체가 가로로 스크롤됨. 표·코드블록이 말풍선 폭을 넘어감.

## AC5 — 재현으로 근본 특정 (추정 아님)

로컬 워크트리는 dev BE와 JWT_SECRET 불일치로 실 앱 인증이 pre-merge에 불가([[reference-live-fe-verify-deployed-only]])해서, chat-bubble.tsx의 **실제 Tailwind 클래스 문자열을 그대로 옮긴 격리 정적 HTML**로 DOM 구조를 재현하고 390px에서 각 레벨 `clientWidth`/`scrollWidth`를 측정했습니다(코드 추정 아닌 실측).

**수정 전 측정** (표+코드블록 포함 메시지, 390px 뷰포트):
| 요소 | clientWidth | scrollWidth | 비고 |
|---|---|---|---|
| `#list`(메시지 리스트=화면) | 390 | **1284** | 화면 전체가 894px 넘게 밀림 — 제보 증상과 일치 |
| `col`(부모 컬럼, `min-w-0 max-w-[72%]`) | **269** | 1240 | max-width는 박스 자체엔 정확히 적용됨(정상) |
| `msgbg`(말풍선 배경 div, col의 직계 자식) | **1240** | 1240 | ⚠️ 부모가 269인데 자식은 1240 — 캡이 자식에 전파 안 됨 |
| `pre`(코드블록, 기존에 이미 `overflow-x-auto` 있음) | 1212 | 1212 | overflow-x-auto가 있어도 발동 안 함(잘릴 "박스"가 없음) |

**근본**: `col`이 `flex-col items-start/items-end`라 cross-axis가 stretch가 아니라 shrink-to-fit입니다. 부모의 `max-w-[72%]`는 **col 자기 자신의 박스**만 캡하고, **직계 자식(msgbg)에는 강제로 전파되지 않습니다** — 이게 flexbox의 실제 동작(추정 아니라 위 표로 실측). `pre`는 애초에 `overflow-x-auto`를 갖고 있었는데도(line 137, 기존 코드) 부모가 안 잘려 있으니 스크롤할 경계 자체가 없어 무력화됐던 것입니다. `<table>`은 아예 컴포넌트 오버라이드가 없어 overflow 제어가 전무했습니다.

**수정 후 측정** (동일 콘텐츠, 동일 뷰포트):
| 요소 | clientWidth | scrollWidth |
|---|---|---|
| `#list` | 390 | **390** ✅ 화면 가로 스크롤 0 |
| `col` | 269 | 269 |
| `msgbg`(+`max-w-full` 추가) | **269** | 269 ✅ |
| `tablewrap`(신설 `overflow-x-auto` 래퍼) | 239 | **825** ✅ 표 안에서만 스크롤, 열 축약 0 |
| `pre` | 241 | **1212** ✅ 이제 실제로 스크롤 발동 |

## 변경
- `chat-bubble.tsx`: 말풍선 배경 div(cmd 버블·일반 버블 2곳) `min-w-0 max-w-full` 추가 — 부모 컬럼의 72% 캡을 자식에 강제.
- `ChatMarkdown`: `table`/`thead`/`th`/`td` 컴포넌트 신설 — `doc-content-renderer.tsx`의 검증된 `not-prose overflow-x-auto` 래퍼 패턴 재사용. `td`/`th`에 `whitespace-nowrap` 필수(없으면 브라우저가 좁은 폭에 맞춰 열 텍스트를 줄바꿈해버려 AC2 "열 삭제·축약 금지" 위반 — 실측으로 확인 후 추가).

## AC 대조
- AC1: 재현+수정 확인(위 표) — `#list.scrollWidth` 1284→390.
- AC2: 표 열 텍스트 원문 그대로(줄바꿈/축약 0), `tablewrap`이 자기 영역 안에서만 스크롤(scrollWidth 825 vs clientWidth 239).
- AC3: 코드 원문 보존 — 줄바꿈 대신 스크롤 선택(코드는 토큰 단위 줄바꿈이 원문을 훼손할 수 있어 doc-content-renderer.tsx의 `pre` 처리와 동일하게 스크롤 유지).
- AC4: 인라인 코드/URL은 기존에 이미 `[overflow-wrap:anywhere]`로 처리돼 있어 별도 컨테이너 픽스 불요(shrink-to-fit의 available-width 계산에 정상 포함됨 — min-content가 작아 애초에 문제 없음).
- AC5: 위 재현+측정표.
- AC6: 데스크톱(1280px) 동일 콘텐츠 스크린샷 — 여유 폭에선 스크롤바 없이 전체 렌더, 회귀 없음.

## ⚠️ 미완 — 실 앱 라이브 캡처
위 재현은 격리된 정적 HTML(동일 클래스 재현)이라 root cause 특정에는 충분하지만, **실 배포 앱에서 신고된 실제 메시지로 최종 확認**은 develop 배포 후 진행하겠습니다(#2029/#2036과 동일 패턴).

## 검증
- `pnpm type-check`: PASS
- `pnpm lint`: 0 errors
- `pnpm build`: EXIT 0

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
