### PR TITLE
fix(projects): enforce ASCII project slugs, backfill broken ones (#2039, P0)

### DIFF
--- a/backend/alembic/versions/0203_backfill_ascii_project_org_slugs.py
+++ b/backend/alembic/versions/0203_backfill_ascii_project_org_slugs.py
@@ -1,0 +1,153 @@
+"""story #2039(P0): 비ASCII(한글 등) workspace/project slug 백필 — ASCII 강제 + 이력 기록.
+
+Revision ID: 0203
+Revises: 0202
+Create Date: 2026-07-20
+
+증상: 프로젝트 이름이 한글이면 보드·스프린트·목표·문서가 전부 클라이언트 사이드 404(서버는 200,
+네트워크 요청 0 — 로그로 안 잡힘). 실측(오르테가 PO): `/api/projects` slug가 `장사왕`→`장사왕`,
+`제로고`→`제로고`(원문 그대로) — 반면 `B2B Sales GTM`→`b2b-sales-gtm`처럼 ASCII 이름은 정상.
+
+근본: 0185가 도입한 백필+router의 신규 생성 auto-derive 둘 다 `app.services.doc_slug.slugify`
+(유니코드 letter/number 보존 — 한글도 그대로 통과)를 썼다. workspace/project slug는 URL path
+segment로 그대로 쓰이는데, 한글이 percent-encode된 채로 FE 라우트 매처를 못 통과해 위 증상이
+났다. organizations는 생성 시 client가 명시 ASCII slug를 필수로 제출(is_valid_slug_format 강제)
+해 auto-derive 자체가 없어 우연히 무사했다 — 그래서 project 축만 깨졌다(app/services/entity_slug.py
+상단 주석에 3안 검토(음역/치환/id-fallback) + id-fallback 채택 근거 기록).
+
+이 마이그는 순수 재백필(스키마 변경 0) — slugify_ascii_or_fallback()로 is_valid_slug_format을
+어기는 기존 slug 전부를 org-scope(project)/전역(organization) 유일성 유지하며 교체하고,
+entity_slug_history에 old→new 매핑을 남긴다. `/api/v2/resolve`(story ddac96fd)가 이미 이 테이블로
+구 slug 요청을 canonical slug로 redirect 처리하므로 북마크된 구 링크도 404 없이 살아난다(요구사항
+③ — 별도 인프라 신설 없이 기존 메커니즘 재사용).
+
+organizations는 이론상 전부 이미 ASCII(auto-derive 경로가 없으므로)지만, 방어적으로 동일 스캔을
+같이 돌린다(발견 즉시 수정 원칙 + PO "전수" 지시 — org 케이스가 실제로 없어도 no-op이라 비용 0).
+"""
+from __future__ import annotations
+
+import re
+import unicodedata
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0203"
+down_revision = "0202"
+branch_labels = None
+depends_on = None
+
+# app.services.entity_slug와 byte-identical(마이그는 app 코드 직접 import 대신 이 시점의 알고리즘을
+# 고정 — 0185 선례(그 마이그 안에 own copy)와 동형. 향후 entity_slug.py가 바뀌어도 이 마이그의
+# 재실행 결과가 달라지지 않아야 하므로 의도적 인라인 복제).
+_SLUG_FORMAT_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+_ASCII_STRIP_RE = re.compile(r"[^a-z0-9\s-]")
+_WS_RE = re.compile(r"\s+")
+_DASH_RUN_RE = re.compile(r"-{2,}")
+_MAX_SLUG_LEN = 200
+
+
+def _is_valid_slug_format(slug: str | None) -> bool:
+    return bool(slug) and bool(_SLUG_FORMAT_RE.match(slug))
+
+
+def _slugify_ascii_or_fallback(title: str, fallback_prefix: str) -> str:
+    s = unicodedata.normalize("NFC", title or "").strip().lower()
+    s = _WS_RE.sub("-", s)
+    s = _ASCII_STRIP_RE.sub("", s)
+    s = _DASH_RUN_RE.sub("-", s).strip("-")
+    if len(s) > _MAX_SLUG_LEN:
+        s = s[:_MAX_SLUG_LEN].rstrip("-")
+    if s:
+        return s
+    return f"{fallback_prefix}-{uuid.uuid4().hex[:8]}"
+
+
+def upgrade() -> None:
+    _backfill_project_slugs()
+    _backfill_organization_slugs()
+
+
+def _backfill_project_slugs() -> None:
+    conn = op.get_bind()
+    rows = conn.execute(
+        sa.text("SELECT id, org_id, name, slug FROM projects WHERE deleted_at IS NULL ORDER BY created_at ASC")
+    ).fetchall()
+
+    # org-scope 유일성 — 이미 유효(ASCII)한 기존 slug도 점유분으로 미리 채워야 새 slug가 충돌 안 함.
+    used_per_org: dict[str, set[str]] = {}
+    for row in rows:
+        if _is_valid_slug_format(row.slug):
+            used_per_org.setdefault(str(row.org_id), set()).add(row.slug)
+
+    for row in rows:
+        if _is_valid_slug_format(row.slug):
+            continue
+        org_key = str(row.org_id)
+        used = used_per_org.setdefault(org_key, set())
+        base = _slugify_ascii_or_fallback(row.name or "", "project")
+        candidate = base
+        n = 2
+        while candidate in used:
+            candidate = f"{base}-{n}"
+            n += 1
+        used.add(candidate)
+        old_slug = row.slug
+        conn.execute(
+            sa.text("UPDATE projects SET slug = :slug WHERE id = :id"),
+            {"slug": candidate, "id": row.id},
+        )
+        # old_slug가 None(0185 이전 raw seed 등 nullable 잔존)이면 아무도 그 링크로 못 왔으므로
+        # 이력 기록 불필요 — 실제로 깨진 문자열 slug였을 때만 구-링크 호환 이력을 남긴다.
+        if old_slug:
+            conn.execute(
+                sa.text(
+                    "INSERT INTO entity_slug_history (id, org_id, entity_type, entity_id, old_slug, new_slug)"
+                    " VALUES (:id, :org_id, 'project', :entity_id, :old_slug, :new_slug)"
+                ),
+                {
+                    "id": str(uuid.uuid4()), "org_id": row.org_id, "entity_id": row.id,
+                    "old_slug": old_slug, "new_slug": candidate,
+                },
+            )
+
+
+def _backfill_organization_slugs() -> None:
+    conn = op.get_bind()
+    rows = conn.execute(sa.text("SELECT id, name, slug FROM organizations ORDER BY created_at ASC")).fetchall()
+
+    used: set[str] = {row.slug for row in rows if _is_valid_slug_format(row.slug)}
+
+    for row in rows:
+        if _is_valid_slug_format(row.slug):
+            continue
+        base = _slugify_ascii_or_fallback(row.name or "", "workspace")
+        candidate = base
+        n = 2
+        while candidate in used:
+            candidate = f"{base}-{n}"
+            n += 1
+        used.add(candidate)
+        old_slug = row.slug
+        conn.execute(
+            sa.text("UPDATE organizations SET slug = :slug WHERE id = :id"),
+            {"slug": candidate, "id": row.id},
+        )
+        if old_slug:
+            conn.execute(
+                sa.text(
+                    "INSERT INTO entity_slug_history (id, org_id, entity_type, entity_id, old_slug, new_slug)"
+                    " VALUES (:id, :org_id, 'organization', :entity_id, :old_slug, :new_slug)"
+                ),
+                {
+                    "id": str(uuid.uuid4()), "org_id": row.id, "entity_id": row.id,
+                    "old_slug": old_slug, "new_slug": candidate,
+                },
+            )
+
+
+def downgrade() -> None:
+    # 재백필은 순수 데이터 정합성 수정 — 되돌리면 다시 깨진(비ASCII) slug로 회귀하므로 downgrade는
+    # no-op(0185/0186 선례 없음·이 케이스는 "고쳐진 상태 유지"가 유일하게 안전한 downgrade).
+    pass

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -15,7 +15,7 @@ from app.services.entity_slug import (
     is_project_slug_taken,
     is_valid_slug_format,
     resolve_unique_project_slug,
-    slugify,
+    slugify_ascii_or_fallback,
 )
 from app.services.project_auth import (
     accessible_project_ids_in_org,
@@ -69,7 +69,10 @@ async def create_project(
             raise HTTPException(status_code=409, detail="Slug already exists")
         slug = body.slug
     else:
-        base_slug = slugify(body.name) or "project"
+        # story #2039(P0): 이전엔 slugify()(유니코드 보존)가 한글 등 비ASCII 이름을 그대로
+        # slug에 실어 URL 라우팅이 깨졌다(app/services/entity_slug.py 상단 주석 근거 기록 참고).
+        # ASCII 산출 실패(순수 비ASCII 이름) 시 id-fallback — name 자체는 그대로 저장/표시.
+        base_slug = slugify_ascii_or_fallback(body.name)
         slug = await resolve_unique_project_slug(session, org_id, base_slug)
 
     project = await repo.create(name=body.name, description=body.description, slug=slug)

--- a/backend/app/services/entity_slug.py
+++ b/backend/app/services/entity_slug.py
@@ -7,6 +7,7 @@ denylist만 추가한다.
 from __future__ import annotations
 
 import re
+import unicodedata
 import uuid
 
 from sqlalchemy import func, select
@@ -15,14 +16,55 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.services.doc_slug import MAX_SLUG_LEN, slugify
 
 # 클라이언트가 직접 slug를 지정하는 경로(org/project 생성·rename) 용 형식 가드 — slugify()
-# 산출물과 동형 문자 집합(소문자 라틴+숫자+하이픈, 앞뒤 하이픈 금지)만 허용. 유니코드(한글 등)
-# slug는 auto-derive(slugify) 경로로만 나오게 하고 client raw 입력은 URL-safe ASCII로 제한
-# (workspace/project slug는 URL path segment라 인코딩 이슈 회피가 우선).
+# 산출물과 동형 문자 집합(소문자 라틴+숫자+하이픈, 앞뒤 하이픈 금지)만 허용.
 _SLUG_FORMAT_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 
 
 def is_valid_slug_format(slug: str) -> bool:
     return bool(slug) and bool(_SLUG_FORMAT_RE.match(slug))
+
+
+# story #2039(P0): "유니코드 slug는 auto-derive 경로로만 나오게 한다"던 위 주석의 원래 가정이
+# 틀렸다 — slugify()는 유니코드 letter/number(한글 포함)를 그대로 보존하므로, project 생성 시
+# name→slug auto-derive(라우터가 slug 미지정 시 호출)가 실제로 한글 slug를 만들어낸다. org는
+# 이 경로를 안 탄다(생성 시 client가 명시 slug 필수 + is_valid_slug_format 강제라 애초에 auto-
+# derive 자체가 없음) — 그래서 조직 축만 우연히 무사했다. workspace/project slug는 URL path
+# segment로 그대로 쓰이는데, 한글이 percent-encode된 상태로 FE 라우트 매처를 통과 못 해 클라이언트
+# 사이드 404(서버 200·네트워크 요청 0·콘솔 에러 0이라 로그로 안 잡힘, PR #2039 실측)로 이어졌다.
+#
+# 해법 판단(음역/치환/id-fallback 3안 중 id-fallback 채택, 근거 기록):
+#   - 음역(로마자 변환)은 별도 라이브러리 의존 + 기계 음역이 부정확/일관성 없을 위험(사람 이름·
+#     상호명일수록 오역 체감이 큼) — 이 스토리 스코프에서 배제.
+#   - 치환(예: 한글 문자를 'x'로 1:1 매핑)은 "장사왕"→"xxx"류로 여러 프로젝트가 동일 slug로
+#     수렴해 유일화 suffix(-2,-3…)만 무의미하게 늘어남 — 식별력 0.
+#   - id-fallback: ASCII만 남기고(라틴/숫자/공백/하이픈), 그 결과가 비면(순수 한글/일본어/이모지
+#     이름 등) 짧은 랜덤 접미사로 폴백. GitHub/Linear/Vercel류가 쓰는 관례와 동형 — 라이브러리
+#     의존 0·유일성 자연 보장·"한글 이름 자체를 막지 않는다"(PO 명시 제약)를 그대로 만족한다
+#     (name 컬럼은 원문 그대로 저장·표시 — slug만 URL-safe로 별도 파생).
+_ASCII_STRIP_RE = re.compile(r"[^a-z0-9\s-]")
+
+
+def slugify_ascii(title: str) -> str:
+    """title → ASCII-only slug 시도. 비ASCII(한글 등)는 제거(치환 아님 — 남는 라틴/숫자만 이어
+    붙임). 결과가 비면 빈 문자열(호출부가 id-fallback 처리 — slugify_ascii_or_fallback 참고)."""
+    if not title:
+        return ""
+    s = unicodedata.normalize("NFC", title).strip().lower()
+    s = re.sub(r"\s+", "-", s)
+    s = _ASCII_STRIP_RE.sub("", s)
+    s = re.sub(r"-{2,}", "-", s).strip("-")
+    if len(s) > MAX_SLUG_LEN:
+        s = s[:MAX_SLUG_LEN].rstrip("-")
+    return s
+
+
+def slugify_ascii_or_fallback(title: str, *, fallback_prefix: str = "project") -> str:
+    """workspace/project auto-derive 전용(§ 위 주석). ASCII 산출이 비면(순수 비ASCII 이름)
+    `{fallback_prefix}-{8자 hex}`로 폴백 — 항상 is_valid_slug_format을 통과하는 값을 반환한다."""
+    base = slugify_ascii(title)
+    if base:
+        return base
+    return f"{fallback_prefix}-{uuid.uuid4().hex[:8]}"
 
 # 유나 doc org-1st-class-surface-ia-design-b §2a — root bare workspace slug라 앱 라우트와
 # 충돌 방지(GitHub org 예약어 관례). project slug는 workspace 하위(non-root)라 denylist 불요.
@@ -115,6 +157,8 @@ async def resolve_unique_project_slug(
 
 __all__ = [
     "slugify",
+    "slugify_ascii",
+    "slugify_ascii_or_fallback",
     "is_valid_slug_format",
     "RESERVED_WORKSPACE_SLUGS",
     "ReservedSlugError",

--- a/backend/tests/test_2039_project_slug_ascii.py
+++ b/backend/tests/test_2039_project_slug_ascii.py
@@ -1,0 +1,291 @@
+"""story #2039(P0): 한글 등 비ASCII 프로젝트/워크스페이스 이름의 slug 깨짐 → 클라이언트 사이드 404.
+
+배경(오르테가 PO 실측): `/api/projects` 응답에서 `장사왕`→slug `장사왕`(원문 그대로) — 반면
+`B2B Sales GTM`→`b2b-sales-gtm`. slug가 URL에서 percent-encode되고 FE 라우트 매처가 못 통과해
+보드·스프린트·목표·문서가 전부 404(서버는 200, 콘솔 에러도 0이라 로그로 안 잡힘). 조직은 생성 시
+client가 명시 ASCII slug를 필수 제출해(is_valid_slug_format) 이 경로를 안 타 우연히 무사했다.
+
+이 파일 구성:
+- `slugify_ascii`/`slugify_ascii_or_fallback` 순수 함수 매트릭스(한글·일본어·이모지·공백·특수문자
+  ·혼합·순수 라틴).
+- real-PG: `POST /api/v2/projects`에 한글 이름 → 응답 slug가 ASCII(is_valid_slug_format)이고
+  org 내 유일.
+- real-PG: 마이그레이션 0203이 기존 깨진(비ASCII) slug를 실제로 백필하고 `entity_slug_history`에
+  이력을 남기며, `/api/v2/resolve`가 그 이력으로 구 slug 요청을 canonical slug로 redirect
+  처리함을 실증(요구사항③ — 별도 인프라 없이 기존 메커니즘 재사용 확인).
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+_REAL_DB_SKIP = pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+
+
+# ── slugify_ascii / slugify_ascii_or_fallback 순수 함수 매트릭스 ────────────────
+
+@pytest.mark.parametrize("name,expected", [
+    ("B2B Sales GTM", "b2b-sales-gtm"),
+    ("OB Test Project", "ob-test-project"),
+    ("  leading and trailing  ", "leading-and-trailing"),
+    ("Multiple   Spaces", "multiple-spaces"),
+    ("Special!@#$%Chars", "specialchars"),
+    ("MixedÜnïcode123", "mixedncode123"),  # 라틴 확장(ü,ï)은 ASCII 아니므로 제거되고 나머지만 남음
+])
+def test_slugify_ascii_matrix(name, expected):
+    from app.services.entity_slug import slugify_ascii
+    assert slugify_ascii(name) == expected
+
+
+@pytest.mark.parametrize("name", [
+    "장사왕",         # 순수 한글
+    "제로고",         # 순수 한글
+    "こんにちは",      # 일본어
+    "🎉🚀✨",         # 이모지만
+    "   ",           # 공백뿐
+    "",              # 빈 문자열
+])
+def test_slugify_ascii_pure_nonascii_returns_empty(name):
+    from app.services.entity_slug import slugify_ascii
+    assert slugify_ascii(name) == ""
+
+
+@pytest.mark.parametrize("name", ["장사왕", "제로고", "こんにちは", "🎉🚀✨", "   ", ""])
+def test_slugify_ascii_or_fallback_always_valid_format(name):
+    """순수 비ASCII 이름은 id-fallback으로 떨어지되, 결과는 항상 is_valid_slug_format을 통과한다
+    (한글 이름 자체를 막지 않는다는 PO 제약 — name은 그대로 저장, slug만 폴백)."""
+    from app.services.entity_slug import is_valid_slug_format, slugify_ascii_or_fallback
+
+    slug = slugify_ascii_or_fallback(name, fallback_prefix="project")
+    assert is_valid_slug_format(slug), slug
+    assert slug.startswith("project-"), slug
+
+
+def test_slugify_ascii_or_fallback_mixed_name_keeps_latin_part():
+    from app.services.entity_slug import slugify_ascii_or_fallback
+    assert slugify_ascii_or_fallback("B2B 세일즈 GTM") == "b2b-gtm"
+
+
+def test_slugify_ascii_or_fallback_two_pure_korean_names_get_distinct_fallbacks():
+    """치환(문자→고정기호) 대신 id-fallback을 택한 근거 실증 — 서로 다른 두 한글 이름이 같은
+    슬러그로 수렴하지 않는다(식별력 보존)."""
+    from app.services.entity_slug import slugify_ascii_or_fallback
+    a = slugify_ascii_or_fallback("장사왕", fallback_prefix="project")
+    b = slugify_ascii_or_fallback("제로고", fallback_prefix="project")
+    assert a != b
+
+
+# ── real-PG: 신규 생성 경로 ──────────────────────────────────────────────────
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+def _sync_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+asyncpg://", "postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+psycopg2://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401 — 전 모델 메타데이터 로드(entity_slug_history 포함)
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, user_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {}})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _seed_org_with_human_member(session):
+    from app.models.organization import Organization
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    caller = User(id=uuid.uuid4(), email=f"caller-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    session.add(OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller.id, role="owner"))
+    await session.commit()
+
+    return {"org_id": org.id, "caller_user_id": caller.id}
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_create_project_korean_name_gets_ascii_slug():
+    from app.main import app
+    from app.services.entity_slug import is_valid_slug_format
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_with_human_member(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_user_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/projects", json={"name": "장사왕", "org_id": str(seeded["org_id"])},
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["name"] == "장사왕", body  # 이름은 원문 그대로 저장/표시
+            assert is_valid_slug_format(body["slug"]), body  # slug만 ASCII-safe
+
+            # 두 번째 한글 프로젝트(다른 이름)도 서로 다른 slug를 받는다(충돌 없음).
+            resp2 = await client.post(
+                "/api/v2/projects", json={"name": "제로고", "org_id": str(seeded["org_id"])},
+            )
+            assert resp2.status_code == 201, resp2.text
+            assert resp2.json()["slug"] != body["slug"]
+            assert is_valid_slug_format(resp2.json()["slug"])
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── real-PG: 마이그레이션 0203 — 기존 깨진 slug 백필 + 구 링크 호환 ───────────────
+
+def _load_migration_0203():
+    spec = importlib.util.spec_from_file_location(
+        "m0203", os.path.join(os.path.dirname(__file__), "..", "alembic", "versions",
+                               "0203_backfill_ascii_project_org_slugs.py"),
+    )
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_migration_0203_backfills_broken_slug_and_records_history():
+    """0185/router가 예전엔 만들어냈을 "깨진" 상태(slug=한글 원문)를 raw insert로 재현한 뒀,
+    0203을 직접 구동(reference_local_migration_verify 패턴 — Operations API 직구동)해 slug가
+    ASCII로 교체되고 entity_slug_history에 old→new가 남는지, 그리고 /api/v2/resolve가 그 이력으로
+    구 slug 요청을 새 slug로 redirect 처리하는지까지 엔드투엔드로 확인한다."""
+    import sqlalchemy as sa
+    from alembic.operations import Operations
+    from alembic.runtime.migration import MigrationContext
+
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_with_human_member(s)
+            from app.models.project import Project
+            broken = Project(
+                id=uuid.uuid4(), org_id=seeded["org_id"], name="장사왕", slug="장사왕",
+            )
+            s.add(broken)
+            await s.commit()
+            broken_id = broken.id
+
+        # 마이그레이션은 동기(psycopg2) op.get_bind() 계약 — reference_local_migration_verify.
+        m = _load_migration_0203()
+        sync_engine = sa.create_engine(_sync_url())
+        with sync_engine.begin() as conn:
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                m.upgrade()
+        sync_engine.dispose()
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_user_id"])
+        client = _client_for(app)
+        try:
+            from app.services.entity_slug import is_valid_slug_format
+
+            get_resp = await client.get(f"/api/v2/projects/{broken_id}")
+            assert get_resp.status_code == 200, get_resp.text
+            new_slug = get_resp.json()["slug"]
+            assert is_valid_slug_format(new_slug), get_resp.json()
+            assert new_slug != "장사왕"
+
+            # entity_slug_history 이력 확인(재조회 — feedback_verify_commit_race).
+            async with Session() as s2:
+                from app.models.entity_slug_history import EntitySlugHistory
+                from sqlalchemy import select
+                hist = (await s2.execute(
+                    select(EntitySlugHistory).where(
+                        EntitySlugHistory.entity_type == "project",
+                        EntitySlugHistory.entity_id == broken_id,
+                    )
+                )).scalar_one()
+                assert hist.old_slug == "장사왕"
+                assert hist.new_slug == new_slug
+
+            # /api/v2/resolve — 구 slug(장사왕)로 요청해도 redirect 필드로 새 slug를 알려준다.
+            from app.repositories.organization import OrganizationRepository
+            async with Session() as s3:
+                org = await OrganizationRepository(s3).get(seeded["org_id"])
+                org_slug = org.slug
+
+            resolve_resp = await client.get(
+                "/api/v2/resolve", params={"workspace": org_slug, "project": "장사왕"},
+            )
+            assert resolve_resp.status_code == 200, resolve_resp.text
+            rbody = resolve_resp.json()
+            assert rbody["project_slug"] == new_slug, rbody
+            assert rbody["redirect"]["project"] == new_slug, rbody
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- Projects with non-ASCII (mainly Korean) names got a slug equal to the raw name — `slugify()` preserves any Unicode letter/number, so `장사왕` produced slug `장사왕` instead of something URL-safe. That slug gets percent-encoded in the URL and the FE route matcher can't resolve it, so board/sprints/goals/docs all 404 **client-side** (server returns 200, zero network errors, zero console errors — unreproducible from logs alone). Reported by the teacher, reproduced in-browser by Ortega.
- Organizations never hit this: org creation requires the client to submit an explicit ASCII slug (`is_valid_slug_format` enforced server-side) — there's no auto-derive path for orgs at all. Projects auto-derive silently from `name` with zero ASCII enforcement, which is the actual asymmetry Ortega asked me to look at first.

## Fix
- `entity_slug.py`: new `slugify_ascii()` / `slugify_ascii_or_fallback()`. ASCII-only characters are kept; if that yields nothing (pure Korean/Japanese/emoji names), falls back to a short random-suffixed slug (`project-<8 hex>`).
- **Why id-fallback over transliteration or substitution** (documented inline, per the AC's "record the rationale" requirement): transliteration needs a library dependency and machine romanization is often wrong/inconsistent for names; character substitution (e.g. mapping every non-ASCII char to a fixed symbol) would collapse many distinct Korean names onto the same slug, killing identifiability. id-fallback matches how GitHub/Linear/Vercel handle this, needs no new dependency, and never blocks the name itself — only slug derivation changes (`name` is stored/shown untouched).
- `projects.py`: `create_project`'s auto-derive branch now uses the new function.
- **Migration 0203**: re-backfills every project (and, defensively, every organization — shouldn't exist given the above, but the scan costs nothing) whose slug fails `is_valid_slug_format`, using the same logic, and records old→new in `entity_slug_history` for each one.

## Old-link compatibility — no new infra needed
`entity_slug_history` + the `/api/v2/resolve` endpoint that consumes it (story ddac96fd) **already exist** and already handle old-slug bookmarks via a `redirect` field in the response. The migration just populates that table correctly for the slugs it's fixing — verified end-to-end in the test (see below), not assumed.

## Companion defect — determined FE-only, handing to Mirko
Ortega also flagged: switching projects doesn't update the URL path's slug segment, only `?p=`. Read `unified-switcher.tsx`'s `switchProject()` — it calls `router.push(\`${pathname}?${sp}\`)` with the **unchanged** `pathname` and only bumps the `?p=` query param, so if the project's slug lives in the path (`/{ws}/{proj}/...`) it stays stale. This is FE component logic only, no backend involvement — confirmed by reading the code, not guessed. Not touched in this PR.

## Test plan
- [x] Parametrized unit tests for `slugify_ascii`/`slugify_ascii_or_fallback`: Korean, Japanese, emoji-only, whitespace-only, empty, special chars, mixed Latin+non-ASCII, two distinct Korean names get distinct fallbacks (identifiability check).
- [x] realdb: `POST /api/v2/projects` with a Korean name via the real endpoint → response slug passes `is_valid_slug_format`, `name` unchanged.
- [x] realdb: seed a pre-existing broken (raw Korean slug) project → run migration 0203 via direct Operations-API invocation (pgvector-avoidance pattern) → slug fixed, `entity_slug_history` row recorded → `GET /api/v2/resolve?workspace=...&project=<old slug>` redirects to the new slug, verified end-to-end through the real endpoint.
- [x] Mutation-killed the router fix: reverted to the old `slugify()` call, confirmed the create test reproduces the exact original bug (slug `장사왕` unchanged), restored.
- [x] Full regression sweep (78 tests) across every file touching slug infrastructure (`test_139d2405_slug_infra_realdb.py`, `test_doc_slug_4dd399c6.py`, `test_onboarding_member_anchor_0b115f5d.py`, `test_projects.py`, `test_s_resolve_ddac96fd_realdb.py`) — all green.
- [x] `ruff check` clean, `alembic heads` confirms a single head (0203) — no dual-head.

## Completion note
Per Ortega: prod already has real broken projects (`장사왕`, `제로고`), so prod promotion of this migration is part of this story's completion, not a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)