### PR TITLE
[SID:2039] P0 FE절반 — 프로젝트 전환 시 URL 경로 slug 즉시 갱신

### DIFF
--- a/apps/web/src/components/nav/unified-switcher.test.ts
+++ b/apps/web/src/components/nav/unified-switcher.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { withSwitchedSlugs } from './unified-switcher';
+
+describe('withSwitchedSlugs (story #2039 AC4)', () => {
+  it('replaces both org and project slug segments, preserving the rest of the path (current screen)', () => {
+    expect(withSwitchedSlugs('/moonklabs/sprintable-content/docs', 'moonklabs', 'moonklabs', 'jangsawang'))
+      .toBe('/moonklabs/jangsawang/docs');
+  });
+
+  it('preserves deep sub-paths (e.g. a specific doc slug) after switching project', () => {
+    expect(withSwitchedSlugs('/moonklabs/sprintable-content/docs/my-doc', 'moonklabs', 'moonklabs', 'jangsawang'))
+      .toBe('/moonklabs/jangsawang/docs/my-doc');
+  });
+
+  it('swaps the org segment too when switching org+project together', () => {
+    expect(withSwitchedSlugs('/moonklabs/sprintable-content/board', 'moonklabs', 'other-org', 'other-project'))
+      .toBe('/other-org/other-project/board');
+  });
+
+  it('returns null for paths that are not project-scoped (e.g. global routes), leaving the caller to fall back to the unmodified pathname', () => {
+    expect(withSwitchedSlugs('/glance', 'moonklabs', 'moonklabs', 'jangsawang')).toBeNull();
+    expect(withSwitchedSlugs('/inbox', 'moonklabs', 'moonklabs', 'jangsawang')).toBeNull();
+  });
+
+  it('returns null when the current org slug is unknown (avoids constructing a bogus path)', () => {
+    expect(withSwitchedSlugs('/moonklabs/sprintable-content/docs', undefined, 'moonklabs', 'jangsawang')).toBeNull();
+  });
+
+  it("returns null when the path's first segment doesn't match the current org slug (stale/unexpected state)", () => {
+    expect(withSwitchedSlugs('/some-other-org/proj/docs', 'moonklabs', 'moonklabs', 'jangsawang')).toBeNull();
+  });
+});

--- a/apps/web/src/components/nav/unified-switcher.tsx
+++ b/apps/web/src/components/nav/unified-switcher.tsx
@@ -39,6 +39,33 @@ interface ProjectItem {
   projectName: string;
 }
 
+// story #2039 AC4 — 라이브 재현 확認(2026-07-20): switchProject/switchOrgAndProject가 URL 경로는
+// 그대로 두고 `?p=`만 갈아끼워서 ①목록이 안 바뀐 것처럼 보이고 ②사이드바를 누르는 순간에야 새
+// 프로젝트 slug로 이동해 그 slug가 미정규화(한글 등)면 404가 터진다(#2039 본체와 결합해 증폭).
+// `/{ws}/{proj}/...` 아래 라우트는 `[ws]` 밑에 `[proj]`만 존재(다른 org-레벨 세그먼트 없음)라
+// pathname 첫 세그먼트가 현재 org slug와 일치하면 그 경로는 반드시 project-scoped이고, 둘째
+// 세그먼트가 project slug다 — 그 둘만 교체하면 나머지(리소스+하위 경로)는 그대로 보존된다.
+// 현재 화면 유지가 컨텍스트 보존에 맞다고 판단(PO 동의) — 기본 화면으로 보내는 대안은 기각.
+export function withSwitchedSlugs(
+  pathname: string,
+  currentOrgSlug: string | undefined,
+  newOrgSlug: string,
+  newProjectSlug: string,
+): string | null {
+  const segments = pathname.split('/').filter(Boolean);
+  if (segments.length < 2 || !currentOrgSlug || segments[0] !== currentOrgSlug) return null;
+  segments[0] = newOrgSlug;
+  segments[1] = newProjectSlug;
+  return `/${segments.join('/')}`;
+}
+
+async function fetchProjectSlug(projectId: string): Promise<string | null> {
+  return fetch(`/api/projects/${projectId}`)
+    .then((r) => (r.ok ? r.json() : null))
+    .then((json: { data?: { slug?: string | null } } | null) => json?.data?.slug ?? null)
+    .catch(() => null);
+}
+
 interface UnifiedSwitcherProps {
   orgs: OrgSwitcherItem[];
   currentOrgId?: string;
@@ -168,7 +195,11 @@ export function UnifiedSwitcher({
       if (typeof window !== 'undefined') window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, projectId);
       const sp = new URLSearchParams(Array.from(searchParams.entries()));
       sp.set('p', projectId);
-      router.push(`${pathname}?${sp.toString()}`);
+      // story #2039 AC4 — org+project 동시 전환도 경로 세그먼트 둘 다 갱신.
+      const newOrgSlug = orgs.find((o) => o.orgId === nextOrgId)?.orgSlug;
+      const newSlug = newOrgSlug ? await fetchProjectSlug(projectId) : null;
+      const switchedPath = newOrgSlug && newSlug ? withSwitchedSlugs(pathname, currentOrg?.orgSlug, newOrgSlug, newSlug) : null;
+      router.push(`${switchedPath ?? pathname}?${sp.toString()}`);
       router.refresh();
     } finally {
       setPending(false);
@@ -184,7 +215,13 @@ export function UnifiedSwitcher({
       if (typeof window !== 'undefined') window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, nextProjectId);
       const sp = new URLSearchParams(Array.from(searchParams.entries()));
       sp.set('p', nextProjectId);
-      router.push(`${pathname}?${sp.toString()}`);
+      // story #2039 AC4 — 경로의 프로젝트 slug 세그먼트를 즉시 새 프로젝트로 교체(같은 org라
+      // org 세그먼트는 유지). 실패(slug 조회 불가 등)하면 안전하게 기존 pathname으로 폴백 —
+      // ?p만 갈아끼우던 원래 동작과 동일하게 degrade, 새 오류를 만들지 않는다.
+      const orgSlug = currentOrg?.orgSlug;
+      const newSlug = orgSlug ? await fetchProjectSlug(nextProjectId) : null;
+      const switchedPath = orgSlug && newSlug ? withSwitchedSlugs(pathname, orgSlug, orgSlug, newSlug) : null;
+      router.push(`${switchedPath ?? pathname}?${sp.toString()}`);
       // 쿠키/JWT 동기화(이 탭 RSC·첫 렌더용). 공유 쿠키가 덮여도 per-tab 정합은 `?p=`+sessionStorage+
       // fetch X-Project-Id 헤더가 보장하므로 무해.
       await fetch('/api/switch-project', {


### PR DESCRIPTION
## 배경 (story #2039, P0)
선생님 제보 → 브라우저 재현: 한글 이름 프로젝트는 모든 화면이 404. BE(slug 정규화·백필)는 디디군이 잡는다. 이 PR은 **동반 결함(AC4)만** 다룬다: 프로젝트 전환 시 URL 경로의 slug가 즉시 갱신되지 않는 문제.

## 착수 전 재현 (PO 지시 — 추측 금지, 댄 오보고와 대비해 반드시 재현부터)
dev(sellerking 계정)에서 실제로 스위처를 클릭해 재현:
1. `/moonklabs/sprintable-content/docs` 진입 → 스위처에서 "장사왕" 클릭
2. `location.href` 확인: `.../moonklabs/sprintable-content/docs?p=<장사왕 project id>` — **경로는 그대로, `?p=`만 바뀜** (스크린샷 첨부 예정)
3. 사이드바 "보드" 클릭 → `location.href`: `.../moonklabs/%EC%9E%A5%EC%82%AC%EC%99%95/board` — **404 렌더 확인**(스크린샷 첨부 예정)

재현 완료 후 PO 승인 받고 착수.

## 근본
`unified-switcher.tsx`의 `switchProject`/`switchOrgAndProject` 둘 다 `router.push(`${pathname}?${sp}`)`에서 **기존 `pathname`을 그대로 재사용**하고 `?p=` 쿼리만 교체 — 경로 세그먼트를 다시 만드는 로직이 아예 없었음.

## 수정
- `GET /api/projects/{id}`(기존 엔드포인트 — BE 신규 작업 없음, `ApiProjectRepository.getById`가 raw FastAPI 응답을 그대로 통과시켜 `slug` 필드가 이미 실려 있음)로 새 프로젝트 slug 조회.
- `withSwitchedSlugs(pathname, currentOrgSlug, newOrgSlug, newProjectSlug)` 신설 — `/{ws}/{proj}/...` 라우트는 `[ws]` 밑에 `[proj]`만 존재(다른 org-레벨 세그먼트 없음)라, pathname 첫 세그먼트가 현재 org slug와 일치하면 그 경로는 반드시 project-scoped라는 라우트 구조 확인 후 첫/둘째 세그먼트만 교체, 나머지(리소스+하위경로)는 보존.
- **현재 화면 유지로 판단**(PO 동의 확인 완료) — docs에 있었으면 전환 후에도 새 프로젝트의 docs로. 기본 화면 이동 대안은 컨텍스트 손실이라 기각.
- slug 조회 실패 시 안전 폴백(기존 pathname 그대로) — 새 회귀 없이 원래 동작으로 degrade.
- `withSwitchedSlugs` 유닛테스트 6건(org/project 세그먼트 교체, 하위경로 보존, non-project-scoped 경로 null, org slug 불명 시 null, mismatched 경로 null).

## 스코프 경계
`switchOrg`(프로젝트 미지정 채 조직만 전환하는 별도 경로 — "이 조직으로 전환" 버튼)는 같은 클래스의 잠재 결함이 있어 보이나 이번 P0 재현·보고 범위 밖이라 손대지 않음. 필요하면 별도 확인.

## AC 대조 (이 PR 몫)
- AC4: 완료(위 재현+수정).
- AC1/AC2/AC3/AC6/AC7: BE(디디), 이 PR 무관.
- AC5(4화면 정상 렌더 캡처): 디디군 slug 백필 완료 후 함께 라이브 확認 예정(한글 slug 자체가 아직 정규화 전이라 이 PR 단독으로는 4화면 정상화까지는 안 됨 — 이 PR은 "?p와 경로 어긋남 창" 제거까지가 몫).

## 검증
- `pnpm type-check`/`lint`(0 errors)/`build`(EXIT 0)
- `vitest run src/components/nav/unified-switcher.test.ts`: 6/6 PASS

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
