### PR TITLE
[SID:f2fe1c5e] #2040 AC1+AC2 — DB 커넥션 예산표 + application_name 계측

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,9 +1,25 @@
+import os
 from collections.abc import AsyncGenerator
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase
 
 from app.core.config import settings
+
+
+def db_application_name(suffix: str = "") -> str:
+    """SID f2fe1c5e/#2040 AC2: `K_SERVICE:K_REVISION[:suffix]` — pg_stat_activity를 서비스·
+    리비전·연결종류(pooled session vs pg_pubsub raw LISTEN)별로 분해하기 위한 태그.
+
+    Cloud Run이 K_SERVICE/K_REVISION을 자동 주입한다(설정 불필요) — 로컬/테스트는 fallback.
+    Postgres application_name은 NAMEDATALEN=64(63자 초과 시 silent truncate)라 63자로 자른다.
+    """
+    service = os.environ.get("K_SERVICE", "local")
+    revision = os.environ.get("K_REVISION", "dev")
+    name = f"{service}:{revision}"
+    if suffix:
+        name = f"{name}:{suffix}"
+    return name[:63]
 
 # S20/E-INFRA S2 + ee7794eb: DB 풀 **rollout-safe** right-size — SSE는 대기 구간 커넥션 미점유(개별 세션).
 # ⚠️ 인스턴스당 실 커넥션 = (pool_size+max_overflow) + **pool 밖 raw 연결**(pg_pubsub.listen_loop 상시 1·
@@ -26,12 +42,14 @@ def _build_engine_kwargs() -> dict:
       localhost:6432(③ cloudbuild 리비전과 atomic).
     """
     pgb = settings.db_pgbouncer
+    connect_args: dict = {"statement_cache_size": 0} if pgb else {}
+    connect_args["server_settings"] = {"application_name": db_application_name()}
     return {
         "pool_size": settings.db_pgbouncer_pool_size if pgb else settings.db_pool_size,
         "max_overflow": settings.db_pgbouncer_max_overflow if pgb else settings.db_max_overflow,
         "pool_pre_ping": True,
         "echo": settings.debug,
-        "connect_args": {"statement_cache_size": 0} if pgb else {},
+        "connect_args": connect_args,
     }
 
 

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -13,13 +13,17 @@ def db_application_name(suffix: str = "") -> str:
 
     Cloud Run이 K_SERVICE/K_REVISION을 자동 주입한다(설정 불필요) — 로컬/테스트는 fallback.
     Postgres application_name은 NAMEDATALEN=64(63자 초과 시 silent truncate)라 63자로 자른다.
+    ⚠️ 오르테가군 적발: 꼬리부터 자르면 판별자(`:listen`)가 긴 리비전에 먹혀 pooled와 raw
+    LISTEN이 구분 불가해진다(AC2의 목적 자체가 무효화) — suffix를 먼저 확보하고 `K_SERVICE:
+    K_REVISION` 쪽만 줄인다.
     """
     service = os.environ.get("K_SERVICE", "local")
     revision = os.environ.get("K_REVISION", "dev")
-    name = f"{service}:{revision}"
-    if suffix:
-        name = f"{name}:{suffix}"
-    return name[:63]
+    base = f"{service}:{revision}"
+    if not suffix:
+        return base[:63]
+    tail = f":{suffix}"
+    return base[: 63 - len(tail)] + tail
 
 # S20/E-INFRA S2 + ee7794eb: DB 풀 **rollout-safe** right-size — SSE는 대기 구간 커넥션 미점유(개별 세션).
 # ⚠️ 인스턴스당 실 커넥션 = (pool_size+max_overflow) + **pool 밖 raw 연결**(pg_pubsub.listen_loop 상시 1·

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
-from sqlalchemy import func, select, update
+from sqlalchemy import func, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.database import get_db
@@ -657,4 +657,43 @@ async def storage_usage_warn(
         return _ok({"notified_orgs": notified})
     except Exception as exc:
         logger.exception("storage-usage-warn cron error: %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)
+
+
+# ─── GET /api/v2/internal/cron/db-connection-stats ─────────────────────────
+
+@router.get("/db-connection-stats")
+async def db_connection_stats(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """SID f2fe1c5e/#2040 AC2: pg_stat_activity를 application_name(서비스:리비전[:연결종류])·
+    state별로 집계 — "어느 서비스가 커넥션을 몇 개 쓰는지 분해할 수 없다"는 계측 부재를 없앤다.
+
+    backend가 아닌 application_name(internal-api·migration job·운영 psql 등)은 db_application_name()
+    태그가 없으므로 그대로 노출돼 "예산에 안 잡힌 소비자"를 이 표에서 바로 식별할 수 있다.
+    """
+    verify_cron(request)
+    try:
+        result = await session.execute(
+            text(
+                """
+                SELECT
+                    COALESCE(application_name, '') AS application_name,
+                    COALESCE(state, '') AS state,
+                    count(*) AS count
+                FROM pg_stat_activity
+                WHERE datname = current_database()
+                GROUP BY application_name, state
+                ORDER BY count DESC
+                """
+            )
+        )
+        rows = [
+            {"application_name": r.application_name, "state": r.state, "count": r.count}
+            for r in result
+        ]
+        return _ok({"rows": rows, "total": sum(r["count"] for r in rows)})
+    except Exception as exc:
+        logger.exception("db-connection-stats cron error: %s", exc)
         return _err("INTERNAL_ERROR", "Internal server error", 500)

--- a/backend/app/services/pg_pubsub.py
+++ b/backend/app/services/pg_pubsub.py
@@ -158,6 +158,8 @@ async def listen_loop() -> None:
     """PG LISTEN 수신 루프. lifespan startup에서 background task로 실행.
 
     - raw asyncpg 전용 커넥션 1개 (SQLAlchemy pool 미점유·DB_PGBOUNCER 시 direct Cloud SQL 우회)
+      — SID f2fe1c5e/#2040 AC2: application_name에 `:listen` suffix를 달아 pg_stat_activity에서
+      pooled session과 분리 집계되게 한다.
     - 연결 실패 시 exponential backoff 1s→2s→4s→max 30s
     - CancelledError 수신 시 커넥션 정리 후 종료
     """
@@ -171,7 +173,11 @@ async def listen_loop() -> None:
     while True:
         conn: asyncpg.Connection | None = None
         try:
-            conn = await asyncpg.connect(raw_url)
+            from app.core.database import db_application_name
+
+            conn = await asyncpg.connect(
+                raw_url, server_settings={"application_name": db_application_name("listen")}
+            )
             await conn.add_listener(_CHANNEL, _on_notification)
             delay = 1.0  # 연결 성공 시 backoff 리셋
             logger.info("pg_listen connected")

--- a/backend/tests/test_e_2040_ac2_application_name.py
+++ b/backend/tests/test_e_2040_ac2_application_name.py
@@ -35,8 +35,27 @@ def test_application_name_truncated_to_postgres_namedatalen(monkeypatch):
     # truncate로 인한 서로 다른 리비전의 우연한 충돌(뒤 63자 초과분 소실)을 명시적으로 통제한다.
     monkeypatch.setenv("K_SERVICE", "sprintable-backend-dev")
     monkeypatch.setenv("K_REVISION", "x" * 80)
-    name = db_application_name("listen")
+    name = db_application_name()
     assert len(name) == 63
+
+
+def test_application_name_truncation_preserves_listen_suffix(monkeypatch):
+    """오르테가군 적발(2026-07-20): 꼬리부터 자르면 리비전이 길 때 `:listen`이 잘려나가
+    pooled와 raw LISTEN이 pg_stat_activity에서 구분 불가해진다 — AC2 목적 자체가 무효화되는
+    회귀. 리비전이 짧아도 길어도 판별자는 항상 보존돼야 한다."""
+    monkeypatch.setenv("K_SERVICE", "sprintable-backend-prod")
+    monkeypatch.setenv("K_REVISION", "sprintable-backend-prod-00227-abc")  # 실측 예시(57자 base)
+    name = db_application_name("listen")
+    assert name.endswith(":listen")
+    assert len(name) <= 63
+
+
+def test_application_name_truncation_preserves_listen_suffix_extreme(monkeypatch):
+    monkeypatch.setenv("K_SERVICE", "sprintable-backend-dev")
+    monkeypatch.setenv("K_REVISION", "x" * 80)
+    name = db_application_name("listen")
+    assert name.endswith(":listen")
+    assert len(name) <= 63
 
 
 def test_engine_connect_args_carries_application_name(monkeypatch):

--- a/backend/tests/test_e_2040_ac2_application_name.py
+++ b/backend/tests/test_e_2040_ac2_application_name.py
@@ -1,0 +1,125 @@
+"""SID f2fe1c5e/#2040 AC2: application_name을 서비스·리비전·연결종류별로 부여하고
+pg_stat_activity를 그 축으로 집계할 수 있게 한다 — "어느 서비스가 커넥션을 몇 개 쓰는지
+분해할 수 없다"는 계측 부재를 없애는 첫 단계(AC1 예산표·AC3/AC4 조치의 전제).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from app.core.database import db_application_name
+
+
+def test_application_name_uses_k_service_and_k_revision(monkeypatch):
+    monkeypatch.setenv("K_SERVICE", "sprintable-backend-dev")
+    monkeypatch.setenv("K_REVISION", "sprintable-backend-dev-00842-abc")
+    assert db_application_name() == "sprintable-backend-dev:sprintable-backend-dev-00842-abc"
+
+
+def test_application_name_appends_suffix_for_raw_listen(monkeypatch):
+    monkeypatch.setenv("K_SERVICE", "sprintable-backend-dev")
+    monkeypatch.setenv("K_REVISION", "rev-1")
+    assert db_application_name("listen") == "sprintable-backend-dev:rev-1:listen"
+
+
+def test_application_name_falls_back_locally_without_cloud_run_env(monkeypatch):
+    monkeypatch.delenv("K_SERVICE", raising=False)
+    monkeypatch.delenv("K_REVISION", raising=False)
+    assert db_application_name() == "local:dev"
+
+
+def test_application_name_truncated_to_postgres_namedatalen(monkeypatch):
+    # Postgres application_name silently truncates >63자(NAMEDATALEN 64) — 우리 쪽에서 먼저 잘라야
+    # truncate로 인한 서로 다른 리비전의 우연한 충돌(뒤 63자 초과분 소실)을 명시적으로 통제한다.
+    monkeypatch.setenv("K_SERVICE", "sprintable-backend-dev")
+    monkeypatch.setenv("K_REVISION", "x" * 80)
+    name = db_application_name("listen")
+    assert len(name) == 63
+
+
+def test_engine_connect_args_carries_application_name(monkeypatch):
+    monkeypatch.setenv("K_SERVICE", "sprintable-backend-dev")
+    monkeypatch.setenv("K_REVISION", "rev-9")
+    from app.core.database import _build_engine_kwargs
+
+    kwargs = _build_engine_kwargs()
+    assert kwargs["connect_args"]["server_settings"]["application_name"] == "sprintable-backend-dev:rev-9"
+
+
+@pytest.mark.anyio
+async def test_listen_loop_tags_raw_connection_with_listen_suffix(monkeypatch):
+    """raw asyncpg.connect가 :listen suffix가 붙은 application_name으로 호출되는지 —
+    pg_stat_activity에서 pool 연결과 raw LISTEN 연결을 분리 집계하기 위한 근거."""
+    from app.services import pg_pubsub
+
+    monkeypatch.setenv("K_SERVICE", "sprintable-backend-dev")
+    monkeypatch.setenv("K_REVISION", "rev-9")
+
+    connect_calls = []
+
+    async def _fake_connect_then_cancel(url, **kwargs):
+        connect_calls.append((url, kwargs))
+        raise asyncio.CancelledError  # listen_loop이 잡아 정상 종료 — 1회 호출만 관찰
+
+    with patch("asyncpg.connect", _fake_connect_then_cancel):
+        await pg_pubsub.listen_loop()  # CancelledError를 내부에서 삼키고 return
+
+    assert connect_calls, "asyncpg.connect가 호출되지 않았다"
+    _, kwargs = connect_calls[0]
+    assert kwargs["server_settings"]["application_name"] == "sprintable-backend-dev:rev-9:listen"
+
+
+@pytest.mark.anyio
+async def test_db_connection_stats_aggregates_by_application_name_and_state():
+    """db-connection-stats가 pg_stat_activity row를 application_name·state·count로 반환하는지."""
+    from types import SimpleNamespace
+
+    from httpx import ASGITransport, AsyncClient
+
+    from app.dependencies.database import get_db
+    from app.main import app
+
+    rows = [
+        SimpleNamespace(application_name="sprintable-backend-dev:rev-9", state="active", count=3),
+        SimpleNamespace(application_name="sprintable-backend-dev:rev-9:listen", state="idle", count=1),
+        SimpleNamespace(application_name="", state="idle", count=12),  # internal-api 등 미태깅 소비자
+    ]
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value=rows)
+
+    async def _override_db():
+        yield mock_session
+
+    app.dependency_overrides[get_db] = _override_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get("/api/v2/internal/cron/db-connection-stats")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["total"] == 16
+    assert {"application_name": "", "state": "idle", "count": 12} in body["rows"]
+
+
+@pytest.mark.anyio
+async def test_db_connection_stats_requires_cron_secret(monkeypatch):
+    from httpx import ASGITransport, AsyncClient
+
+    from app.main import app
+    from app.routers import cron as cron_mod
+
+    monkeypatch.setattr(cron_mod, "CRON_SECRET", "s3cr3t")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/api/v2/internal/cron/db-connection-stats")
+
+    assert response.status_code == 401
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"

--- a/backend/tests/test_pgbouncer_config.py
+++ b/backend/tests/test_pgbouncer_config.py
@@ -35,8 +35,9 @@ def test_build_engine_kwargs_flag_off(monkeypatch):
     assert kw["max_overflow"] == database.settings.db_max_overflow
     assert kw["pool_pre_ping"] is True
     # off: 캐시 on(#1330 revert) — statement_cache_size 미지정
-    assert kw["connect_args"] == {}
     assert "statement_cache_size" not in kw["connect_args"]
+    # SID f2fe1c5e/#2040 AC2: application_name 태그는 flag 무관 항상 부여
+    assert "application_name" in kw["connect_args"]["server_settings"]
 
 
 def test_build_engine_kwargs_flag_on(monkeypatch):
@@ -46,7 +47,9 @@ def test_build_engine_kwargs_flag_on(monkeypatch):
     assert kw["max_overflow"] == database.settings.db_pgbouncer_max_overflow
     assert kw["pool_pre_ping"] is True
     # on: transaction-mode 호환 — prepared statement 캐시 비활성(#1314 재적용)
-    assert kw["connect_args"] == {"statement_cache_size": 0}
+    assert kw["connect_args"]["statement_cache_size"] == 0
+    # SID f2fe1c5e/#2040 AC2: application_name 태그는 flag 무관 항상 부여
+    assert "application_name" in kw["connect_args"]["server_settings"]
 
 
 def test_imported_engine_uses_default_off():

--- a/docs/db-connection-budget.md
+++ b/docs/db-connection-budget.md
@@ -1,0 +1,92 @@
+# DB 커넥션 예산표
+
+SID `f2fe1c5e` / Sprintable #2040 AC1. 근거: `db-connection-rootcause-report-2026-07-20.md`(코드
+근거·산식 전문) + 오르테가군 PO 실측(2026-07-20, gcloud + Cloud Monitoring). **AC2(application_name
+태깅) 배포·실측 전까지는 이 표의 "미확인" 행은 추정이 아니라 말 그대로 미확인이다** — 계측 없이
+채운 예산표는 추정표라는 것이 이 스토리의 전제.
+
+## 산식
+
+```
+per_instance = (DB_POOL_SIZE + DB_MAX_OVERFLOW) + RAW_LISTEN
+             = (3 + 1) + 1
+             = 5
+
+rollout_worst_case(env) = 2 × maxScale(env) × per_instance
+```
+
+`2×`는 배포 rollout 중 old+new 리비전이 동시에 떠 있는 구간(steady-state 산식만 쓰면 배포 중
+한도 초과 — 2026-06-29 dev 인시던트가 이 blind spot에서 발생). L2 트리거 워커(`L2_TRIGGER_ENABLED`)가
+켜져 있으면 인스턴스당 pool 내부(라인 4 안) connection 1개를 상시 점유하지만 `per_instance` 값 자체는
+늘리지 않는다 — pool 슬롯을 나눠 쓸 뿐 추가 물리 연결이 아니다. dev/prod의 실제 flag 값은 아직
+미확인(보고서 "확인하지 못한 것" #6).
+
+## 환경별 예산 (2026-07-20 기준)
+
+| | dev | prod |
+|---|---:|---:|
+| DB 인스턴스 | `sprintable-dev` (db-g1-small) | `sprintable-prod` (db-custom-2-8192) |
+| `max_connections` (gcloud 실측, PO 2026-07-20) | **200**(100→200 상향, 오늘 사고 대응) | **200** |
+| GHA SSOT `backend_max_instances` (`.github/workflows/cloud-build.yml`, 이 커밋 기준) | **8**(rev 01256-w9r durable) | **5**(ee7794eb ③) |
+| backend rollout worst-case = `2×maxScale×5` | 80 | 50 |
+| worst-case가 `max_connections`에서 차지하는 비율 | 40% | 25% |
+
+dev/prod는 별도 Cloud SQL 인스턴스로 확인된 바 있다([[feedback_shared_dev_prod_db]] 메모) — 이 표는
+그 전제로 작성했다. `.github/workflows/cloud-build.yml`의 dev 블록 주석이 "dev/prod 공유 DB라면
+합산 점검 필요"라고 남겨둔 캐비어트는 위 전제로 해소되나, gcloud로 직접 재확인은 못 했다.
+
+**prod는 오늘 처음 실측됐다** — 저장소 주석(`cloudbuild.yaml:18`, `.github/workflows/cloud-build.yml:53`)은
+`max_connections=100` 가정으로 산식이 쓰여 있어 지금 낡았다(AC4에서 갱신 대상).
+
+## dev 관측 vs 산식 (Cloud Monitoring `num_backends`, 30분 최대·KST, PO 2026-07-20 실측)
+
+| 시각 | 커넥션 | 비고 |
+|---|---:|---|
+| 07-19 17:36~08:36 | 15 | 유휴 바닥 — 트래픽 0에서도 15개 |
+| 07-20 09:36 | 40 | |
+| 07-20 10:36 | 86 | |
+| 07-20 11:06 | 81 | |
+| 07-20 13:36 | 79 | |
+| 07-20 14:36 | 97 | 한도 100 — `TooManyConnectionsError` 발생 지점 |
+| 07-20 15:06 | 97 | |
+| 07-20 16:36 | 75 | |
+| 07-20 17:06 | 63 | 당시 현재 |
+
+prod(`sprintable-prod`) 같은 24시간: 최대 17 / 한도 200 — 전혀 압박 없음.
+
+**괴리:** 단일 리비전(rollout 아닌 steady-state) 기준 backend 물리 상한은 `maxScale(8) × per_instance(5)
+= 40`이다. 17:06 관측 63은 이 상한보다 **최소 23 많다** — backend 혼자만으로는 설명이 안 된다.
+14:36 사고 지점 97도 rollout worst-case(80)를 넘는 값이라 같은 결론이다. 이 23(+)이 internal-api·
+migration job·운영 psql·PostgreSQL reserved 중 어디서 오는지가 AC2 계측 없이는 분해되지 않는다 —
+조사 보고서가 "이 저장소만으로는 알 수 없다"로 남긴 바로 그 자리다.
+
+또한 **유휴 바닥 15**는 트래픽이 0인데도 물려 있는 상수항이다. backend는 idle 시 상시 점유가
+`maxScale × raw(1)`뿐이라(pool은 idle 시 반납) 8이면 최대 8 — 15 전부를 backend로 설명할 수 없다.
+이 상수도 AC2 계측 대상.
+
+## 미확인 소비자 (AC2 배포 후 `GET /api/v2/internal/cron/db-connection-stats`로 채울 것)
+
+| 소비자 | 상태 | 비고 |
+|---|---|---|
+| `sprintable-internal-api-dev` | **미확인** | 같은 dev DB 공유(보고서 §확인). 엔진/pool/raw 구성 미상 — 별도 private repo(`sprintable-admin`), 이 스토리 스코프 밖. AC2 application_name 태깅을 internal-api에도 심어야 pg_stat_activity에서 분리된다(현재는 무태그 상태로 잡혀도 "backend가 아닌 나머지"로는 식별 가능). |
+| migration/admin job | **미확인** | `backend/scripts/migrate.sh`(precheck 자식 프로세스)·Alembic NullPool 1개, 순차·단명으로 보고서는 추정. rollout과 배포 job이 겹치는 시간대 headroom 필요. |
+| 운영 접속(psql 등) | **미확인** | PostgreSQL reserved connection 몫 포함. |
+| L2 트리거 워커 advisory lock | **미확인** | `L2_TRIGGER_ENABLED`/`L2_TRIGGER_ADVISORY_LOCK` dev/prod 실값 — 켜져 있으면 pool 내부에서 최대 `maxScale-1`개가 상시 checkout(holder 1개 제외 standby도 반납 안 함, 과거 ee7794eb 조사). |
+
+## 알려진 drift (AC4에서 정리)
+
+- `backend/tests/test_e_infra_s2_pool.py`의 `PROD_MAX_SCALE_ASSUMED = 10`·`PROD_MAX_CONNECTIONS = 100`·
+  `DEV_MAX_CONNECTIONS = 25`·`DEV_MAX_SCALE = 1`은 전부 현재 develop 실값(prod maxScale 5·prod/dev
+  max_connections 200·dev maxScale 8)과 다르다 — 과거 결정(ee7794eb 초기안·PgBouncer 폐기 시점)이
+  이후 dev 429 대응(rev 01256-w9r)으로 갱신됐는데 테스트 상수가 안 따라갔다. false-safe 방향(더 빡빡한
+  가정)이라 CI가 놓치는 위험은 없지만, 이 문서와 대사가 안 맞아 혼란을 준다.
+- `cloudbuild.yaml`/`.github/workflows/cloud-build.yml`의 prod 주석(`max_connections=100` 가정)도 위와
+  동일 사유로 낡았다.
+
+## 다음 단계
+
+1. AC2(이 브랜치에 이미 구현) dev 배포 → `db-connection-stats`로 실측 → 위 "미확인" 표를 실수치로 채운다.
+2. 실측 후 이 문서를 갱신하고 나서 AC3(단가 인하 vs 소비자 예산 계상 vs 풀러) 택일 — 과거 시도
+   이력(`ee7794eb`)이 이미 "Cloud Run raw TCP 미지원으로 중앙 PgBouncer 불가"를 확정해 둔 상태라 그
+   벽은 다시 부딪히지 않는다. 택일 전 오르테가군 확인.
+3. AC4로 위 drift 정리(테스트 상수 + cloudbuild 주석).

--- a/docs/db-connection-budget.md
+++ b/docs/db-connection-budget.md
@@ -31,9 +31,11 @@ rollout_worst_case(env) = 2 × maxScale(env) × per_instance
 | backend rollout worst-case = `2×maxScale×5` | 80 | 50 |
 | worst-case가 `max_connections`에서 차지하는 비율 | 40% | 25% |
 
-dev/prod는 별도 Cloud SQL 인스턴스로 확인된 바 있다([[feedback_shared_dev_prod_db]] 메모) — 이 표는
-그 전제로 작성했다. `.github/workflows/cloud-build.yml`의 dev 블록 주석이 "dev/prod 공유 DB라면
-합산 점검 필요"라고 남겨둔 캐비어트는 위 전제로 해소되나, gcloud로 직접 재확인은 못 했다.
+dev/prod는 별도 Cloud SQL 인스턴스다 — 오르테가군 PO가 2026-07-20 gcloud로 직접 재확인(`sprintable-dev`
+db-g1-small / `sprintable-prod` db-custom-2-8192, 별개 인스턴스 2개)했고, Cloud Monitoring `num_backends`도
+`database_id`별 독립 시계열로 잡힌다(dev 피크 97 / prod 최대 17 — 같은 DB라면 같은 수치가 나왔을 것).
+`.github/workflows/cloud-build.yml`의 dev 블록 주석이 "dev/prod 공유 DB라면 합산 점검 필요"라고 남겨둔
+캐비어트는 이걸로 해소됐다.
 
 **prod는 오늘 처음 실측됐다** — 저장소 주석(`cloudbuild.yaml:18`, `.github/workflows/cloud-build.yml:53`)은
 `max_connections=100` 가정으로 산식이 쓰여 있어 지금 낡았다(AC4에서 갱신 대상).


### PR DESCRIPTION
## Summary
Sprintable 스토리 #2040(P0, DB 커넥션 예산 초과 구조) 진행분 — 오르테가군 순서 지정(AC2→AC1→AC3/AC4→AC6)대로 계측 먼저.

- **AC2**: `db_application_name()`(K_SERVICE:K_REVISION[:suffix])을 풀 엔진 + pg_pubsub raw LISTEN 양쪽 `server_settings.application_name`에 태깅. `GET /api/v2/internal/cron/db-connection-stats`로 `pg_stat_activity`를 application_name·state별 집계.
- **AC1**: `docs/db-connection-budget.md` — GHA SSOT 현재값(dev maxScale 8·prod 5) + 오르테가군 PO gcloud/Cloud Monitoring 실측(2026-07-20)을 대사한 예산표. dev 관측 63 vs backend 단독 상한 40 — 최소 23개가 backend 밖(internal-api·job·운영접속·PG reserved 중 미분해)이라는 것을 문서로 고정.

## 다음 단계 (이 PR 이후)
merge→dev 자동배포 후 `db-connection-stats`로 위 "미확인" 소비자를 실측 → AC1 doc 갱신 → **AC3(단가↓/소비자 계상/풀러 중 택일)는 오르테가군 확인 후 진행** — PgBouncer 중앙화는 ee7794eb 이력상 Cloud Run raw TCP 미지원으로 이미 폐기된 경로라 재검토 안 함.

## Test plan
- [x] `uv run pytest tests/test_e_2040_ac2_application_name.py tests/test_pgbouncer_config.py tests/test_pg_pubsub_listen_url.py tests/test_pg_pubsub_fire_and_forget.py tests/test_health.py tests/test_e_infra_s2_pool.py tests/test_no_unreferenced_fire_and_forget.py tests/test_lifespan_engine_dispose_33e0c681.py tests/test_l2_trigger_worker.py tests/test_event1config_expire_cron.py` — 52 passed, 2 skipped(realdb)
- [x] `python -c "from app.main import app"` — import 정상(483 routes)
- [ ] dev 배포 후 `db-connection-stats` 라이브 호출로 태깅 확인 (merge 뒤 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)