### PR TITLE
[SID:2021] 채팅 문서 임베드 미리보기 모달 폴링 닫힘 근본수정 (재발행)

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx
@@ -122,23 +122,25 @@ function ProgressBar({ done, total }: { done: number; total: number }) {
   );
 }
 
+// story #2021 후속(PO 리뷰): components 객체를 렌더 함수 안에서 인라인으로 만들면 매 렌더
+// 새 함수 참조가 되어 react-markdown이 서브트리를 리마운트한다(chat-bubble 근본원인과 동형).
+// props/상태 의존 없는 순수 상수·자식도 stateless라 모듈 스코프로 끌어올려 참조를 고정한다.
+const mdBodyComponents = {
+  p: ({ children }: { children?: React.ReactNode }) => <p className="mb-2 text-sm leading-6">{children}</p>,
+  h1: ({ children }: { children?: React.ReactNode }) => <h1 className="mb-2 text-lg font-bold">{children}</h1>,
+  h2: ({ children }: { children?: React.ReactNode }) => <h2 className="mb-2 text-base font-bold">{children}</h2>,
+  h3: ({ children }: { children?: React.ReactNode }) => <h3 className="mb-1.5 text-sm font-bold">{children}</h3>,
+  ul: ({ children }: { children?: React.ReactNode }) => <ul className="mb-2 ml-4 list-disc space-y-0.5">{children}</ul>,
+  ol: ({ children }: { children?: React.ReactNode }) => <ol className="mb-2 ml-4 list-decimal space-y-0.5">{children}</ol>,
+  li: ({ children }: { children?: React.ReactNode }) => <li className="text-sm leading-6">{children}</li>,
+  code: ({ children }: { children?: React.ReactNode }) => <code className="rounded px-1 py-0.5 font-mono text-sm bg-muted">{children}</code>,
+  strong: ({ children }: { children?: React.ReactNode }) => <strong className="font-semibold">{children}</strong>,
+  em: ({ children }: { children?: React.ReactNode }) => <em className="italic">{children}</em>,
+};
+
 function MdBody({ content }: { content: string }) {
   return (
-    <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
-      components={{
-        p: ({ children }) => <p className="mb-2 text-sm leading-6">{children}</p>,
-        h1: ({ children }) => <h1 className="mb-2 text-lg font-bold">{children}</h1>,
-        h2: ({ children }) => <h2 className="mb-2 text-base font-bold">{children}</h2>,
-        h3: ({ children }) => <h3 className="mb-1.5 text-sm font-bold">{children}</h3>,
-        ul: ({ children }) => <ul className="mb-2 ml-4 list-disc space-y-0.5">{children}</ul>,
-        ol: ({ children }) => <ol className="mb-2 ml-4 list-decimal space-y-0.5">{children}</ol>,
-        li: ({ children }) => <li className="text-sm leading-6">{children}</li>,
-        code: ({ children }) => <code className="rounded px-1 py-0.5 font-mono text-sm bg-muted">{children}</code>,
-        strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
-        em: ({ children }) => <em className="italic">{children}</em>,
-      }}
-    >
+    <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdBodyComponents}>
       {content}
     </ReactMarkdown>
   );

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+//
+// story #2021 — 채팅 문서 임베드 미리보기 모달이 폴링 주기마다 닫히던 회귀 재현.
+// 근본원인: ChatMarkdown이 매 렌더 `components={{ a: ..., code: ... }}` 객체를 인라인으로 새로
+// 만들었고, hast-util-to-jsx-runtime이 이 함수 참조를 그대로 React 엘리먼트 type으로 쓰기 때문에
+// (state.components[name]) 무관한 부모 리렌더(presence 폴링 등)마다 `a`(엔티티 칩 포함) 서브트리가
+// 타입 불일치로 언마운트→리마운트되고, 그 안의 로컬 state(EntityChip의 showModal)가 초기화됐다.
+// 이 테스트는 실제 DOM(createRoot)으로 "열림 → 무관한 prop 변경으로 인한 리렌더 → 여전히 열려
+// 있는가"를 왕복 검증한다 — 정적 "이제 안 닫힘" 주장이 아니라 리렌더를 실제로 트리거해 확認한다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { ChatBubble } from './chat-bubble';
+import type { ChatMessage } from '@/hooks/use-chat-sse';
+import koMessages from '../../../messages/ko.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => ({ projectId: 'proj-1', currentTeamMemberId: 'member-1' }),
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+const DOC_ID = '11111111-1111-1111-1111-111111111111';
+
+const baseMessage: ChatMessage = {
+  id: 'msg-1',
+  memo_id: 'conv-1',
+  created_by: 'agent-1',
+  sender_name: '오르테가',
+  sender_type: 'agent',
+  content: `[제안서.md](entity:doc:${DOC_ID})`,
+  attachments: [],
+  created_at: '2026-07-20T00:00:00.000Z',
+};
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  // EntityPreviewModal의 doc 2단계 fetch — 모달이 열려 있는지 자체와는 무관, 실패해도
+  // 컴포넌트는 loading→fallback으로 graceful. 회귀 검증에 필요한 건 close 버튼 생존 여부뿐.
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, json: async () => ({}) })));
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe('ChatBubble 문서 임베드 미리보기 모달 — 폴링 유발 리렌더 생존', () => {
+  it('무관한 prop(presenceStatus)이 바뀌어 부모가 리렌더돼도 열린 모달이 유지된다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble message={baseMessage} isMine={false} presenceStatus="online" isWorking={false} />,
+      ));
+    });
+
+    const chip = container.querySelector('button');
+    expect(chip).not.toBeNull();
+    await act(async () => { chip!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    // 모달이 열렸다 — 닫기 버튼(aria-label="닫기")으로 확認.
+    expect(container.querySelector('button[aria-label="닫기"]')).not.toBeNull();
+
+    // story #2021 재현 지점: presence 폴링이 15s마다 새 presenceById를 흘려 ChatBubble을
+    // 리렌더시키는 것과 동형 — 모달 자체와는 무관한 prop만 바뀐 리렌더.
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble message={baseMessage} isMine={false} presenceStatus="idle" isWorking={false} />,
+      ));
+    });
+
+    // 회귀 시 여기서 실패한다: components 객체가 매 렌더 재생성되면 `a` 서브트리(EntityChip)가
+    // 리마운트되어 showModal이 초기화 — 닫기 버튼이 사라진다.
+    expect(container.querySelector('button[aria-label="닫기"]')).not.toBeNull();
+  });
+});

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
@@ -103,6 +103,54 @@ function ChatMarkdown({ content, isMine }: { content: string; isMine: boolean })
   const hasMention = /@[\w가-힣]+/.test(content);
   const hasMarkdown = /[*_`#\[\]>~]|entity:/.test(content);
 
+  // story #2021: react-markdown이 리졸브한 컴포넌트 함수 참조를 그대로 React 엘리먼트 type으로
+  // 쓴다(hast-util-to-jsx-runtime `state.components[name]`). 이 객체를 매 렌더 인라인으로 새로
+  // 만들면 `a`(엔티티 칩/미리보기 모달 포함)·`code`(CopyableCode) 서브트리가 타입 불일치로
+  // 매번 언마운트→리마운트된다 — 무관한 부모 리렌더(presence 폴링 등)마다 열려 있던 문서
+  // 미리보기 모달의 로컬 state(showModal)가 통째로 날아가 닫히던 근본 원인. isMine이 안 바뀌는
+  // 한 참조를 고정해 react-markdown이 같은 컴포넌트 인스턴스를 재사용하게 한다. hasMarkdown이
+  // false인 이른 return보다 위에 둬 훅 호출 순서를 무조건화한다(rules-of-hooks).
+  const components = useMemo(() => ({
+    p: ({ children }: { children?: React.ReactNode }) => <p className={`mb-1.5 [overflow-wrap:anywhere] text-sm leading-relaxed last:mb-0 ${text}`}>{children}</p>,
+    strong: ({ children }: { children?: React.ReactNode }) => <strong className={`font-semibold ${text}`}>{children}</strong>,
+    em: ({ children }: { children?: React.ReactNode }) => <em className={`italic ${text}`}>{children}</em>,
+    code: ({ className, children }: { className?: string; children?: React.ReactNode }) => {
+      const raw = String(children).replace(/\n$/, '');
+      const inline = !className?.includes('language-') && !raw.includes('\n');
+      return (
+        <CopyableCode
+          raw={raw}
+          inline={inline}
+          className={`rounded px-1 py-0.5 font-mono text-xs [overflow-wrap:anywhere] ${codeBg}`}
+        />
+      );
+    },
+    pre: ({ children }: { children?: React.ReactNode }) => <pre className={`mb-1.5 overflow-x-auto rounded-lg p-2.5 text-xs ${codeBg}`}>{children}</pre>,
+    ul: ({ children }: { children?: React.ReactNode }) => <ul className={`mb-1.5 ml-4 list-disc space-y-0.5 text-sm ${text}`}>{children}</ul>,
+    ol: ({ children }: { children?: React.ReactNode }) => <ol className={`mb-1.5 ml-4 list-decimal space-y-0.5 text-sm ${text}`}>{children}</ol>,
+    li: ({ children }: { children?: React.ReactNode }) => <li className={`text-sm leading-relaxed ${text}`}>{children}</li>,
+    blockquote: ({ children }: { children?: React.ReactNode }) => <blockquote className={`mb-1.5 border-l-2 pl-3 ${border} ${muted}`}>{children}</blockquote>,
+    a: ({ href, children }: { href?: string; children?: React.ReactNode }) => {
+      if (href?.startsWith('mention:')) {
+        return (
+          <span className={`font-medium ${isMine ? 'text-primary-foreground underline decoration-primary-foreground/40' : 'text-primary'}`}>
+            {children}
+          </span>
+        );
+      }
+      // id 는 UUID 만 허용 — `dead`·`----` 등 비-UUID는 매칭 실패→평문 링크로 폴백(엔티티 칩/카드 미렌더).
+      const m = href?.match(/^entity:(\w+):([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i);
+      if (m) {
+        // S6: 자산 토큰은 컴팩트 칩 대신 리치 임베드 카드(썸네일+메타+화살표).
+        if (m[1]!.toLowerCase() === 'asset') {
+          return <AssetEmbedCard entityId={m[2]!} label={String(children)} ownMessage={isMine} />;
+        }
+        return <EntityChip entityType={m[1]!} entityId={m[2]!} label={String(children)} href={getEntityHref(m[1]!, m[2]!)} />;
+      }
+      return <a href={href} target="_blank" rel="noopener noreferrer" className={`underline underline-offset-2 ${text}`}>{children}</a>;
+    },
+  }), [text, muted, codeBg, border, isMine]);
+
   if (!hasMarkdown && !hasMention) {
     return (
       <span className={`whitespace-pre-wrap [overflow-wrap:anywhere] text-sm leading-relaxed ${text}`}>
@@ -119,46 +167,7 @@ function ChatMarkdown({ content, isMine }: { content: string; isMine: boolean })
       urlTransform={(url) =>
         url.startsWith('entity:') || url.startsWith('mention:') ? url : defaultUrlTransform(url)
       }
-      components={{
-        p: ({ children }) => <p className={`mb-1.5 [overflow-wrap:anywhere] text-sm leading-relaxed last:mb-0 ${text}`}>{children}</p>,
-        strong: ({ children }) => <strong className={`font-semibold ${text}`}>{children}</strong>,
-        em: ({ children }) => <em className={`italic ${text}`}>{children}</em>,
-        code: ({ className, children }) => {
-          const raw = String(children).replace(/\n$/, '');
-          const inline = !className?.includes('language-') && !raw.includes('\n');
-          return (
-            <CopyableCode
-              raw={raw}
-              inline={inline}
-              className={`rounded px-1 py-0.5 font-mono text-xs [overflow-wrap:anywhere] ${codeBg}`}
-            />
-          );
-        },
-        pre: ({ children }) => <pre className={`mb-1.5 overflow-x-auto rounded-lg p-2.5 text-xs ${codeBg}`}>{children}</pre>,
-        ul: ({ children }) => <ul className={`mb-1.5 ml-4 list-disc space-y-0.5 text-sm ${text}`}>{children}</ul>,
-        ol: ({ children }) => <ol className={`mb-1.5 ml-4 list-decimal space-y-0.5 text-sm ${text}`}>{children}</ol>,
-        li: ({ children }) => <li className={`text-sm leading-relaxed ${text}`}>{children}</li>,
-        blockquote: ({ children }) => <blockquote className={`mb-1.5 border-l-2 pl-3 ${border} ${muted}`}>{children}</blockquote>,
-        a: ({ href, children }) => {
-          if (href?.startsWith('mention:')) {
-            return (
-              <span className={`font-medium ${isMine ? 'text-primary-foreground underline decoration-primary-foreground/40' : 'text-primary'}`}>
-                {children}
-              </span>
-            );
-          }
-          // id 는 UUID 만 허용 — `dead`·`----` 등 비-UUID는 매칭 실패→평문 링크로 폴백(엔티티 칩/카드 미렌더).
-          const m = href?.match(/^entity:(\w+):([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i);
-          if (m) {
-            // S6: 자산 토큰은 컴팩트 칩 대신 리치 임베드 카드(썸네일+메타+화살표).
-            if (m[1]!.toLowerCase() === 'asset') {
-              return <AssetEmbedCard entityId={m[2]!} label={String(children)} ownMessage={isMine} />;
-            }
-            return <EntityChip entityType={m[1]!} entityId={m[2]!} label={String(children)} href={getEntityHref(m[1]!, m[2]!)} />;
-          }
-          return <a href={href} target="_blank" rel="noopener noreferrer" className={`underline underline-offset-2 ${text}`}>{children}</a>;
-        },
-      }}
+      components={components}
     >
       {prepared}
     </ReactMarkdown>

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -63,24 +63,27 @@ const MdBadge = ({ label }: { label: string }) => (
   </span>
 );
 
+// story #2021 후속(PO 리뷰): components 객체를 렌더 함수 안에서 인라인으로 만들면 매 렌더
+// 새 함수 참조가 되어 react-markdown이 서브트리를 리마운트한다(chat-bubble 근본원인과 동형).
+// 이 객체는 props/상태에 의존하지 않는 순수 상수이고 자식도 전부 stateless라 useMemo조차
+// 불필요 — 모듈 스코프로 끌어올려 참조를 영구 고정한다.
+const mdBodyComponents = {
+  p: ({ children }: { children?: React.ReactNode }) => <p className="mb-2 text-sm leading-6">{children}</p>,
+  h1: ({ children }: { children?: React.ReactNode }) => <h1 className="mb-2 text-lg font-bold">{children}</h1>,
+  h2: ({ children }: { children?: React.ReactNode }) => <h2 className="mb-2 text-base font-bold">{children}</h2>,
+  h3: ({ children }: { children?: React.ReactNode }) => <h3 className="mb-1.5 text-sm font-bold">{children}</h3>,
+  ul: ({ children }: { children?: React.ReactNode }) => <ul className="mb-2 ml-4 list-disc space-y-0.5">{children}</ul>,
+  ol: ({ children }: { children?: React.ReactNode }) => <ol className="mb-2 ml-4 list-decimal space-y-0.5">{children}</ol>,
+  li: ({ children }: { children?: React.ReactNode }) => <li className="text-sm leading-6">{children}</li>,
+  pre: ({ children }: { children?: React.ReactNode }) => <pre className="mb-2 overflow-x-auto rounded-lg p-3 text-[13px] bg-muted">{children}</pre>,
+  code: ({ children }: { children?: React.ReactNode }) => <code className="rounded px-1 py-0.5 font-mono text-[13px] bg-muted">{children}</code>,
+  blockquote: ({ children }: { children?: React.ReactNode }) => <blockquote className="mb-2 border-l-2 pl-3 border-border text-muted-foreground">{children}</blockquote>,
+  strong: ({ children }: { children?: React.ReactNode }) => <strong className="font-semibold">{children}</strong>,
+  em: ({ children }: { children?: React.ReactNode }) => <em className="italic">{children}</em>,
+};
+
 const MdBody = ({ content }: { content: string }) => (
-  <ReactMarkdown
-    remarkPlugins={[remarkGfm]}
-    components={{
-      p: ({ children }) => <p className="mb-2 text-sm leading-6">{children}</p>,
-      h1: ({ children }) => <h1 className="mb-2 text-lg font-bold">{children}</h1>,
-      h2: ({ children }) => <h2 className="mb-2 text-base font-bold">{children}</h2>,
-      h3: ({ children }) => <h3 className="mb-1.5 text-sm font-bold">{children}</h3>,
-      ul: ({ children }) => <ul className="mb-2 ml-4 list-disc space-y-0.5">{children}</ul>,
-      ol: ({ children }) => <ol className="mb-2 ml-4 list-decimal space-y-0.5">{children}</ol>,
-      li: ({ children }) => <li className="text-sm leading-6">{children}</li>,
-      pre: ({ children }) => <pre className="mb-2 overflow-x-auto rounded-lg p-3 text-[13px] bg-muted">{children}</pre>,
-      code: ({ children }) => <code className="rounded px-1 py-0.5 font-mono text-[13px] bg-muted">{children}</code>,
-      blockquote: ({ children }) => <blockquote className="mb-2 border-l-2 pl-3 border-border text-muted-foreground">{children}</blockquote>,
-      strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
-      em: ({ children }) => <em className="italic">{children}</em>,
-    }}
-  >
+  <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdBodyComponents}>
     {content}
   </ReactMarkdown>
 );

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -7,6 +7,7 @@ import { detectEmbedService } from './extensions/embed-node';
 import { renderKatex } from './extensions/math-node';
 import { renderMermaid } from './lib/mermaid-renderer';
 import ReactMarkdown from 'react-markdown';
+import type { Components } from 'react-markdown';
 import DOMPurify from 'dompurify';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
@@ -503,6 +504,60 @@ export function DocContentRenderer({
     return decorateHtmlContent(sanitized, headings, codeCopyLabel);
   }, [codeCopyLabel, content, contentFormat, headings]);
 
+  // story #2021 후속(PO 리뷰): 이 components 객체를 매 렌더 인라인으로 새로 만들면
+  // hast-util-to-jsx-runtime이 그 함수 참조를 그대로 React 엘리먼트 type으로 써서([[feedback:
+  // chat-bubble 근본원인과 동형]]) 소프트 내비게이션·polling으로 부모가 리렌더될 때마다
+  // img→`DocAssetImage`(로딩 state)·code→`MermaidReadonlyBlock`(svg 렌더 state)·
+  // `ShikiCodeBlock`(복사 피드백 state)가 언마운트→리마운트된다 — 이미지 깜빡임·mermaid
+  // 재렌더·복사 피드백 조기소실로 이어진다. useMemo로 이 핸들러들의 참조를 고정한다. 아래
+  // contentFormat==='html' 이른 return보다 위에 둬 훅 호출 순서를 무조건화한다(rules-of-hooks).
+  //
+  // h1/h2/h3는 여기 포함하지 않는다 — 그 자식은 plain <h1>뿐(로컬 state 없음)이라 리마운트돼도
+  // 잃을 게 없고, headingIndex가 ReactMarkdown이 AST를 훑는 매 패스(=매 렌더)마다 0부터 다시
+  // 매겨져야 하는데 메모이즈된 클로저에 넣으면 그 리셋이 깨진다 — 그래서 h1/h2/h3는 아래
+  // components 병합 시 매 렌더 새로 만드는 채로 둔다(무해 remount).
+  const stableMarkdownComponents = useMemo<Components>(() => ({
+    blockquote: ({ children }: { children?: ReactNode }) => <blockquote>{children}</blockquote>,
+    img: (props) => {
+      const { src, alt } = props as { src?: unknown; alt?: string };
+      const hasSrc = typeof src === 'string' && src.length > 0;
+      // asset-ref(data-asset-id·src 없음) — authed 에서만 서명 해석. public 모드는 절대
+      // fetch 하지 않고(401-leak 경계) NextImage(src="")로 두어 위 DOM effect 의 inert
+      // placeholder 치환에 맡긴다.
+      const assetId = !publicMode ? extractAssetId(props) : null;
+      if (assetId && !hasSrc) {
+        return <DocAssetImage assetId={assetId} alt={alt ?? ''} errorLabel={assetImageErrorLabel} />;
+      }
+      return <NextImage src={hasSrc ? (src as string) : ''} alt={alt ?? ''} width={800} height={600} style={{ maxWidth: '100%', height: 'auto' }} unoptimized />;
+    },
+    table: ({ children }: { children?: ReactNode }) => (
+      <div className="not-prose overflow-x-auto rounded-xl border border-border">
+        <table>{children}</table>
+      </div>
+    ),
+    pre: ({ children }: { children?: ReactNode }) => <>{children}</>,
+    code: (props) => {
+      const { children, className: codeClassName } = props as { children?: ReactNode; className?: string };
+      const childText = Array.isArray(children) ? children.join('') : String(children ?? '');
+      const inline = !String(codeClassName ?? '').includes('language-') && !childText.includes('\n');
+      if (!inline) {
+        const lang = String(codeClassName ?? '').replace('language-', '') || null;
+        if (lang === 'mermaid') {
+          return <MermaidReadonlyBlock code={childText} />;
+        }
+        return (
+          <ShikiCodeBlock
+            code={childText}
+            language={lang}
+            copyLabel={codeCopyLabel}
+            copiedLabel={codeCopiedLabel}
+          />
+        );
+      }
+      return <code>{children}</code>;
+    },
+  }), [publicMode, assetImageErrorLabel, codeCopyLabel, codeCopiedLabel]);
+
   const rootClassName = cn(
     'doc-renderer prose dark:prose-invert prose-sm max-w-none text-foreground',
     '[&_h1]:scroll-mt-24 [&_h1]:text-3xl [&_h1]:font-bold [&_h1]:tracking-tight',
@@ -536,6 +591,8 @@ export function DocContentRenderer({
     );
   }
 
+  // ReactMarkdown이 이 AST 패스에서 h1/h2/h3를 문서 순서대로 호출하는 동안 매길 인덱스 —
+  // 매 렌더(=매 패스) 0부터 다시 시작해야 하므로 스코프를 여기(렌더 본문)에 둔다.
   let headingIndex = 0;
 
   return (
@@ -556,45 +613,7 @@ export function DocContentRenderer({
             const heading = headings[headingIndex++];
             return <h3 id={heading?.id}>{children}</h3>;
           },
-          blockquote: ({ children }) => <blockquote>{children}</blockquote>,
-          img: (props) => {
-            const { src, alt } = props as { src?: unknown; alt?: string };
-            const hasSrc = typeof src === 'string' && src.length > 0;
-            // asset-ref(data-asset-id·src 없음) — authed 에서만 서명 해석. public 모드는 절대
-            // fetch 하지 않고(401-leak 경계) NextImage(src="")로 두어 위 DOM effect 의 inert
-            // placeholder 치환에 맡긴다.
-            const assetId = !publicMode ? extractAssetId(props) : null;
-            if (assetId && !hasSrc) {
-              return <DocAssetImage assetId={assetId} alt={alt ?? ''} errorLabel={assetImageErrorLabel} />;
-            }
-            return <NextImage src={hasSrc ? (src as string) : ''} alt={alt ?? ''} width={800} height={600} style={{ maxWidth: '100%', height: 'auto' }} unoptimized />;
-          },
-          table: ({ children }) => (
-            <div className="not-prose overflow-x-auto rounded-xl border border-border">
-              <table>{children}</table>
-            </div>
-          ),
-          pre: ({ children }) => <>{children}</>,
-          code: (props) => {
-            const { children, className: codeClassName } = props as { children?: ReactNode; className?: string };
-            const childText = Array.isArray(children) ? children.join('') : String(children ?? '');
-            const inline = !String(codeClassName ?? '').includes('language-') && !childText.includes('\n');
-            if (!inline) {
-              const lang = String(codeClassName ?? '').replace('language-', '') || null;
-              if (lang === 'mermaid') {
-                return <MermaidReadonlyBlock code={childText} />;
-              }
-              return (
-                <ShikiCodeBlock
-                  code={childText}
-                  language={lang}
-                  copyLabel={codeCopyLabel}
-                  copiedLabel={codeCopiedLabel}
-                />
-              );
-            }
-            return <code>{children}</code>;
-          },
+          ...stableMarkdownComponents,
         }}
       >
         {content}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -87,27 +87,34 @@ function taskTone(status: string) {
 // BE _MAX_STORY_ATTACHMENTS 정합 (schemas/story.py)
 const STORY_ATTACHMENT_LIMIT = 10;
 
+// story #2021 후속(PO 리뷰): components 객체를 렌더 함수 안에서 인라인으로 만들면 매 렌더
+// 새 함수 참조가 되어 react-markdown이 서브트리를 리마운트한다(chat-bubble 근본원인과 동형).
+// 이 패널은 댓글/액티비티 폴링·낙관 업데이트로 자주 리렌더되는 화면이라 위험이 실재한다.
+// 다만 여기 오버라이드는 전부 stateless 순수 태그(a도 target=_blank 평문 링크, 자체 state
+// 없음)라 useMemo조차 불필요 — 모듈 스코프 상수로 끌어올려 참조를 영구 고정한다.
+const descriptionViewerComponents = {
+  p: ({ children }: { children?: React.ReactNode }) => <p className="mb-2 break-words text-sm leading-6 text-muted-foreground last:mb-0">{children}</p>,
+  h1: ({ children }: { children?: React.ReactNode }) => <h1 className="mb-2 text-lg font-bold text-foreground">{children}</h1>,
+  h2: ({ children }: { children?: React.ReactNode }) => <h2 className="mb-2 text-base font-bold text-foreground">{children}</h2>,
+  h3: ({ children }: { children?: React.ReactNode }) => <h3 className="mb-1.5 text-sm font-bold text-foreground">{children}</h3>,
+  ul: ({ children }: { children?: React.ReactNode }) => <ul className="mb-2 ml-4 list-disc space-y-0.5 text-muted-foreground">{children}</ul>,
+  ol: ({ children }: { children?: React.ReactNode }) => <ol className="mb-2 ml-4 list-decimal space-y-0.5 text-muted-foreground">{children}</ol>,
+  li: ({ children }: { children?: React.ReactNode }) => <li className="text-sm leading-6">{children}</li>,
+  pre: ({ children }: { children?: React.ReactNode }) => <pre className="mb-2 overflow-x-auto rounded-lg bg-muted p-3 text-[13px] text-foreground">{children}</pre>,
+  code: ({ children }: { children?: React.ReactNode }) => <code className="rounded bg-muted px-1 py-0.5 font-mono text-[13px] text-foreground">{children}</code>,
+  blockquote: ({ children }: { children?: React.ReactNode }) => <blockquote className="mb-2 border-l-2 border-border pl-3 text-muted-foreground">{children}</blockquote>,
+  a: ({ href, children }: { href?: string; children?: React.ReactNode }) => <a href={href} target="_blank" rel="noopener noreferrer" className="text-primary underline underline-offset-2">{children}</a>,
+  strong: ({ children }: { children?: React.ReactNode }) => <strong className="font-semibold text-foreground">{children}</strong>,
+  em: ({ children }: { children?: React.ReactNode }) => <em className="italic text-muted-foreground">{children}</em>,
+  hr: () => <hr className="my-2 border-border" />,
+};
+
 function DescriptionViewer({ description }: { description: string }) {
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
       rehypePlugins={[rehypeSanitize]}
-      components={{
-        p: ({ children }) => <p className="mb-2 break-words text-sm leading-6 text-muted-foreground last:mb-0">{children}</p>,
-        h1: ({ children }) => <h1 className="mb-2 text-lg font-bold text-foreground">{children}</h1>,
-        h2: ({ children }) => <h2 className="mb-2 text-base font-bold text-foreground">{children}</h2>,
-        h3: ({ children }) => <h3 className="mb-1.5 text-sm font-bold text-foreground">{children}</h3>,
-        ul: ({ children }) => <ul className="mb-2 ml-4 list-disc space-y-0.5 text-muted-foreground">{children}</ul>,
-        ol: ({ children }) => <ol className="mb-2 ml-4 list-decimal space-y-0.5 text-muted-foreground">{children}</ol>,
-        li: ({ children }) => <li className="text-sm leading-6">{children}</li>,
-        pre: ({ children }) => <pre className="mb-2 overflow-x-auto rounded-lg bg-muted p-3 text-[13px] text-foreground">{children}</pre>,
-        code: ({ children }) => <code className="rounded bg-muted px-1 py-0.5 font-mono text-[13px] text-foreground">{children}</code>,
-        blockquote: ({ children }) => <blockquote className="mb-2 border-l-2 border-border pl-3 text-muted-foreground">{children}</blockquote>,
-        a: ({ href, children }) => <a href={href} target="_blank" rel="noopener noreferrer" className="text-primary underline underline-offset-2">{children}</a>,
-        strong: ({ children }) => <strong className="font-semibold text-foreground">{children}</strong>,
-        em: ({ children }) => <em className="italic text-muted-foreground">{children}</em>,
-        hr: () => <hr className="my-2 border-border" />,
-      }}
+      components={descriptionViewerComponents}
     >
       {description}
     </ReactMarkdown>


### PR DESCRIPTION
## 재발행 사유
원 PR #2310(`fix/2021-doc-preview-modal-poll-close`)에서 최초 커밋(`ec6289e1`) 이후 연속 2개 커밋(`6e3ae02f`, `920708c0` — 빈 커밋 재트리거 포함)에 GitHub Actions 러너가 생성되지 않음(`check-runs` API 응답 0건). 리포 전역은 정상 작동 중(동시간대 다른 브랜치는 정상 실행 확인), 워크플로 경로 필터 무관(`ci.yml`은 경로 필터 없음), 빈 커밋 재트리거도 무효 — **해당 PR/브랜치에 한정된 GitHub 웹훅/Actions 라우팅 문제**로 판단해 브랜치를 이전한다. (다음에 같은 증상이 재발하면 이 기록이 진단 근거가 된다.)

**⚠️ "체크가 없다"는 통과가 아니다** — check-runs 0건 상태로 머지했다면 이 PR의 변경분(sweep 4곳 포함)이 미검증인 채로 develop에 들어갔을 것이다. green을 실제로 본 뒤에만 머지한다.

## 원 PR과 동일 커밋
`fix/2021-doc-preview-modal-poll-close`(PR #2310)와 **완전히 동일한 커밋**(브랜치만 이전, 코드 변경 없음):
- `ec6289e1` — 채팅 문서 임베드 미리보기 모달 폴링 닫힘 근본수정
- `6e3ae02f` — PO 리뷰 반영, 같은 패턴 나머지 4곳 정리
- `920708c0` — CI 재트리거 시도(빈 커밋)

상세 변경 내용·근본원인·회귀 테스트 근거는 #2310 본문 참조. 이 PR은 그 내용의 CI 우회 재발행이다.

## 게이트 (원 PR과 동일, 재확인됨)
- type-check/lint: 0 errors
- build: EXIT 0
- vitest: 신규 회귀 테스트 1건 PASS(RED→GREEN 재현 검증)

#2310은 이 PR의 CI green 확인 후 참조 남기고 닫는다.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>