### PR TITLE
[SID:301ee45d] #2047 P0 — 명시 ask 정책 우회 차단(resolve_disposition 출처 노출)

### DIFF
--- a/backend/app/routers/hitl_config.py
+++ b/backend/app/routers/hitl_config.py
@@ -206,11 +206,12 @@ async def resolve(
     precedence: member_override > org_override > org_posture > system_default(ask).
     risk_level 입력 없음 — 플랫폼 위험도 판정 안 함.
     """
-    disposition = await resolve_disposition(
+    disposition, source = await resolve_disposition(
         session, org_id, body.member_id, body.role_id, body.gate_type
     )
     return ResolveResponse(
         disposition=disposition,
+        source=source,
         member_id=body.member_id,
         role_id=body.role_id,
         gate_type=body.gate_type,

--- a/backend/app/schemas/hitl_config.py
+++ b/backend/app/schemas/hitl_config.py
@@ -97,6 +97,9 @@ class ResolveRequest(BaseModel):
 
 class ResolveResponse(BaseModel):
     disposition: str
+    # SID 301ee45d/#2047 AC1: "member_override"|"org_override"|"org_policy"|"system_default" —
+    # 이 disposition이 누군가 명시 설정한 값인지 시스템 기본값인지 API 응답에서 바로 보이게 한다.
+    source: str
     member_id: uuid.UUID
     role_id: uuid.UUID
     gate_type: str

--- a/backend/app/services/disposition_advisor.py
+++ b/backend/app/services/disposition_advisor.py
@@ -55,8 +55,9 @@ async def get_disposition_recommendation(
             "skipped_reason": str | None,
         }
     """
-    # 1. 현재 disposition 해소
-    current = await resolve_disposition(session, org_id, member_id, role_id, gate_type)
+    # 1. 현재 disposition 해소 (SID 301ee45d/#2047: 반환값이 (disposition, source) — 이 추천
+    # 로직은 현재값만 필요해 source는 버린다)
+    current, _source = await resolve_disposition(session, org_id, member_id, role_id, gate_type)
 
     # 2. 신뢰점수 조회
     trust = await compute_member_trust_scores(

--- a/backend/app/services/gate_resolver.py
+++ b/backend/app/services/gate_resolver.py
@@ -24,17 +24,33 @@ from app.models.hitl_config import (
 )
 
 
+# SID 301ee45d/#2047 AC1: resolve_disposition 반환값의 두 번째 요소 — 어느 precedence 단계에서
+# disposition이 나왔는지(명시 설정 vs 시스템 기본). "system_default"만 비명시(암묵) — 나머지 셋은
+# 조직/멤버가 어떤 형태로든 명시한 값이라 explicit로 취급한다(호출부의 `source != "system_default"`
+# 판정 기준).
+SOURCE_MEMBER_OVERRIDE = "member_override"
+SOURCE_ORG_OVERRIDE = "org_override"
+SOURCE_ORG_POLICY = "org_policy"
+SOURCE_SYSTEM_DEFAULT = "system_default"
+
+
 async def resolve_disposition(
     session: AsyncSession,
     org_id: uuid.UUID,
     member_id: uuid.UUID,
     role_id: uuid.UUID,
     gate_type: str,
-) -> str:
-    """(org, member, role, gate_type) → disposition 해소.
+) -> tuple[str, str]:
+    """(org, member, role, gate_type) → (disposition, source) 해소.
+
+    SID 301ee45d/#2047 AC1: 이전엔 disposition 문자열만 돌려줘 호출부가 "조직이 명시
+    설정했다"와 "아무도 설정 안 해서 시스템 기본이 나왔다"를 구분할 수 없었다 — 그래서 증거
+    없는 merge 게이트 경로가 명시 ask 정책까지 시스템 기본 ask와 똑같이 취급해 우회했다
+    (merge_verdict_gate.py의 no-substance 체크). source를 노출해 그 구분을 가능하게 한다.
 
     Returns:
-        'allow_auto' | 'ask' | 'deny'
+        (disposition, source) — disposition: 'allow_auto' | 'ask' | 'deny'.
+        source: SOURCE_MEMBER_OVERRIDE | SOURCE_ORG_OVERRIDE | SOURCE_ORG_POLICY | SOURCE_SYSTEM_DEFAULT.
     """
     # 1. member_gate_override (최우선)
     mo_r = await session.execute(
@@ -46,7 +62,7 @@ async def resolve_disposition(
     )
     mo = mo_r.scalar_one_or_none()
     if mo is not None:
-        return mo.disposition
+        return mo.disposition, SOURCE_MEMBER_OVERRIDE
 
     # 2. org_gate_override (role × gate_type)
     ro_r = await session.execute(
@@ -58,7 +74,7 @@ async def resolve_disposition(
     )
     ro = ro_r.scalar_one_or_none()
     if ro is not None:
-        return ro.disposition
+        return ro.disposition, SOURCE_ORG_OVERRIDE
 
     # 3. org posture 기본값
     policy_r = await session.execute(
@@ -66,7 +82,7 @@ async def resolve_disposition(
     )
     policy = policy_r.scalar_one_or_none()
     if policy is not None:
-        return posture_to_disposition(policy.posture)
+        return posture_to_disposition(policy.posture), SOURCE_ORG_POLICY
 
     # 4. 시스템 기본값
-    return SYSTEM_DEFAULT_DISPOSITION
+    return SYSTEM_DEFAULT_DISPOSITION, SOURCE_SYSTEM_DEFAULT

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -257,7 +257,10 @@ async def create_gate(
     if existing is not None:
         return existing
 
-    disposition = await resolve_disposition(session, org_id, member_id, role_id, gate_type)
+    # SID 301ee45d/#2047: 반환값이 (disposition, source) — 이 범용 생성기는 disposition→status
+    # 매핑만 필요해 source는 버린다(explicit-ask 판정은 merge_verdict_gate.py의 no-substance
+    # 체크에서만 쓰인다).
+    disposition, _source = await resolve_disposition(session, org_id, member_id, role_id, gate_type)
     status = _DISPOSITION_TO_STATUS.get(disposition, "pending")
     # doc-gate v2 갭1(선생님 실 Web): doc_approval 류 deliberate gate 는 disposition auto-pass 무관하게
     # 항상 pending. auto_passed 면 수동 결재가 Gate inbox 에 안 떠 결재 불능(인간 결재 의도 우선).

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -21,7 +21,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.models.participation import ParticipationRole
-from app.services.gate_resolver import SOURCE_SYSTEM_DEFAULT, resolve_disposition
+from app.services.gate_resolver import (
+    SOURCE_MEMBER_OVERRIDE,
+    SOURCE_ORG_OVERRIDE,
+    SOURCE_ORG_POLICY,
+    resolve_disposition,
+)
 from app.services.gate_service import create_gate, resolve_work_item_project_id
 from app.services.trust_score import compute_member_trust_scores
 from app.services.verdict_capture import (
@@ -46,6 +51,30 @@ BLOCK = "block"
 
 # gate status(정책 disposition 아티팩트) → 원 disposition 역추론(관측용).
 _STATUS_TO_DISPOSITION = {"auto_passed": "allow_auto", "pending": "ask", "rejected": "deny"}
+
+
+async def _is_meaningfully_explicit_ask(
+    session: AsyncSession, org_id: uuid.UUID, source: str,
+) -> bool:
+    """SID 301ee45d/#2047 PO 리뷰(2026-07-20): resolve_disposition의 ``source``는 "어느
+    precedence 단계에서 나왔나"(출처)만 말하지 "그 값을 실제로 골랐나"(값)는 말하지 않는다.
+    ``member_gate_override``/``org_gate_override``는 gate_type 단위로 콕 집어 만든 행이라
+    존재 자체가 의사표시지만, ``org_gate_policy.posture``는 ``PUT /gate-config/policy``에
+    본문을 `{}`로 보내도 pydantic 기본값 "balanced"가 그대로 저장되고(``OrgGatePolicyCreate.
+    posture: str = "balanced"``) balanced→ask로 매핑된다 — 조직이 아무 말도 안 했는데 "명시
+    ask"로 오판해 원 버그와 같은 계열의 함정에 빠진다. ``balanced``/``permissive``는 아무도
+    의도 없이도 얻는 값이라 명시로 인정하지 않고, 아무도 기본으로 얻지 않는 ``conservative``만
+    명시로 인정한다."""
+    if source in (SOURCE_MEMBER_OVERRIDE, SOURCE_ORG_OVERRIDE):
+        return True
+    if source == SOURCE_ORG_POLICY:
+        from app.models.hitl_config import OrgGatePolicy
+
+        r = await session.execute(
+            select(OrgGatePolicy.posture).where(OrgGatePolicy.org_id == org_id).limit(1)
+        )
+        return r.scalar_one_or_none() == "conservative"
+    return False
 
 
 def _evidence_status(decision: str) -> str:
@@ -275,15 +304,21 @@ async def evaluate_merge_gate(
     # source)를 돌려준다. 과거엔 'ask'가 SYSTEM_DEFAULT든 조직이 명시 설정했든 구분 없이 여기서
     # no-gate로 우회됐다 — "코드가 아닌 일(콘텐츠·마케팅 등, PR/CI 자체가 없는 작업)에는 조직이
     # '반드시 사람이 서명'이라고 ask를 명시해도 사람 결재가 원리적으로 안 걸리는" 결함이었다(댄
-    # 어윈 실측 반증). 이제 source가 SYSTEM_DEFAULT가 아니면(member/org override든 org posture든
-    # 어떤 형태로든 조직·멤버가 명시한 값) 'ask'도 deny와 동일하게 substance로 인정해 게이트를
-    # 만든다. **설정 안 한 조직(SYSTEM_DEFAULT)은 지금과 동일하게 게이트가 안 생긴다** — 빈 shell
-    # 박멸 의도는 그대로 보존.
+    # 어윈 실측 반증). ⚠️PO 리뷰: source가 SYSTEM_DEFAULT가 아니라는 것만으로는 부족하다 —
+    # org_gate_policy.posture는 PUT 본문을 비워도 pydantic 기본값("balanced")이 저장돼 "출처는
+    # org_policy(명시 행 있음)이지만 값은 아무도 안 고른 기본값"인 경우가 생긴다. 그래서
+    # `_is_meaningfully_explicit_ask()`가 출처(source)와 별개로 **값 자체가 골라졌는지**까지
+    # 판정한다 — member/org override는 gate_type 단위로 콕 집은 행이라 존재=의사표시지만,
+    # org_policy는 posture=='conservative'(아무도 기본으로 얻지 않는 값)일 때만 명시로 인정한다.
+    # **설정 안 한 조직(SYSTEM_DEFAULT) + balanced/permissive posture는 지금과 동일하게 게이트가
+    # 안 생긴다** — 빈 shell 박멸 의도는 그대로 보존.
     if ci is None and pr_number <= 0:
         disposition, disposition_source = await resolve_disposition(
             session, org_id, member_id, role_id, MERGE_GATE_TYPE
         )
-        explicit_ask = disposition == "ask" and disposition_source != SOURCE_SYSTEM_DEFAULT
+        explicit_ask = disposition == "ask" and await _is_meaningfully_explicit_ask(
+            session, org_id, disposition_source
+        )
         if disposition != "deny" and not explicit_ask:
             logger.info(
                 "merge gate: no substance (ci=None pr_number=0 disposition=%s source=%s) story=%s "

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -21,7 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.models.participation import ParticipationRole
-from app.services.gate_resolver import resolve_disposition
+from app.services.gate_resolver import SOURCE_SYSTEM_DEFAULT, resolve_disposition
 from app.services.gate_service import create_gate, resolve_work_item_project_id
 from app.services.trust_score import compute_member_trust_scores
 from app.services.verdict_capture import (
@@ -264,28 +264,35 @@ async def evaluate_merge_gate(
     role_key = await _role_key(session, role_id)
 
     # P0(E-DG-REAL 1ff89d23): evidence-driven materialization — 빈 'CI unknown' shell 양산 박멸.
-    # 게이트는 **실 신호(CI 결과 · 연결 PR · 명시 deny 정책)**가 있을 때만 만든다. CI/PR 증거가
-    # 둘 다 없을 때만 정책을 확인하고, deny가 아니면(ask=시스템 기본이라 그 자체론 신호 아님) 사람이
-    # 판단할 게 없는 빈 shell이 되므로 **게이트를 만들지 않는다**(no-gate·row 0·done 통과). 실 CI
-    # 증거는 GitHub 앱(S5)이 native 당김. 3 트리거(board preflight·report-done·line-engine) 모두
-    # 이 단일 chokepoint를 거쳐 일관 적용. (증거 있으면 resolve_disposition 호출조차 생략.)
+    # 게이트는 **실 신호(CI 결과 · 연결 PR · 명시 deny 정책 · 명시 ask 정책)**가 있을 때만 만든다.
+    # CI/PR 증거가 둘 다 없을 때만 정책을 확인하고, deny도 아니고 명시 ask도 아니면(=시스템 기본
+    # ask거나 allow_auto) 사람이 판단할 게 없는 빈 shell이 되므로 **게이트를 만들지 않는다**(no-gate·
+    # row 0·done 통과). 실 CI 증거는 GitHub 앱(S5)이 native 당김. 3 트리거(board preflight·
+    # report-done·line-engine) 모두 이 단일 chokepoint를 거쳐 일관 적용. (증거 있으면
+    # resolve_disposition 호출조차 생략.)
+    #
+    # SID 301ee45d/#2047(선생님 지시 2026-07-20 — P0): resolve_disposition이 이제 (disposition,
+    # source)를 돌려준다. 과거엔 'ask'가 SYSTEM_DEFAULT든 조직이 명시 설정했든 구분 없이 여기서
+    # no-gate로 우회됐다 — "코드가 아닌 일(콘텐츠·마케팅 등, PR/CI 자체가 없는 작업)에는 조직이
+    # '반드시 사람이 서명'이라고 ask를 명시해도 사람 결재가 원리적으로 안 걸리는" 결함이었다(댄
+    # 어윈 실측 반증). 이제 source가 SYSTEM_DEFAULT가 아니면(member/org override든 org posture든
+    # 어떤 형태로든 조직·멤버가 명시한 값) 'ask'도 deny와 동일하게 substance로 인정해 게이트를
+    # 만든다. **설정 안 한 조직(SYSTEM_DEFAULT)은 지금과 동일하게 게이트가 안 생긴다** — 빈 shell
+    # 박멸 의도는 그대로 보존.
     if ci is None and pr_number <= 0:
-        disposition = await resolve_disposition(session, org_id, member_id, role_id, MERGE_GATE_TYPE)
-        # follow-up(enforcing 롤아웃·GitHub앱 S5 때 재고): substance로 인정하는 정책은 현재 'deny'만.
-        # 'ask'는 SYSTEM_DEFAULT(=ask)라 그 자체론 신호가 아니므로 증거 0이면 no-gate. 다만 resolve_disposition
-        # 은 disposition 문자열만 돌려주고 **출처(시스템 기본 vs 명시 override/posture)를 구분하지 않는다** →
-        # 어떤 org가 '증거 무관 전-머지 휴먼 사인오프' 의도로 ask를 명시 설정해도 지금은 bypass된다. 그 의도를
-        # 살리려면 resolve_disposition이 explicit-ask를 default-ask와 구분(출처 노출)해야 한다. P0(즉시 sloppy
-        # 탈출)에선 빈 shell 박멸이 우선이라 deny-only로 둔다.
-        if disposition != "deny":
+        disposition, disposition_source = await resolve_disposition(
+            session, org_id, member_id, role_id, MERGE_GATE_TYPE
+        )
+        explicit_ask = disposition == "ask" and disposition_source != SOURCE_SYSTEM_DEFAULT
+        if disposition != "deny" and not explicit_ask:
             logger.info(
-                "merge gate: no substance (ci=None pr_number=0 disposition=%s) story=%s "
+                "merge gate: no substance (ci=None pr_number=0 disposition=%s source=%s) story=%s "
                 "— gate not materialized (no-gate)",
-                disposition, story_id,
+                disposition, disposition_source, story_id,
             )
             return MergeGateDecision(
                 decision=AUTO_MERGE,
-                reason="no-substance: no CI/PR evidence and policy is not deny — gate not materialized",
+                reason="no-substance: no CI/PR evidence and policy is not deny/explicit-ask — gate not materialized",
                 gate_id=None,
                 gate_status=None,
                 disposition=disposition,

--- a/backend/tests/test_2047_explicit_ask_gate.py
+++ b/backend/tests/test_2047_explicit_ask_gate.py
@@ -153,6 +153,56 @@ async def test_unset_org_no_gate_without_evidence():
 
 
 @pytest.mark.anyio
+async def test_org_policy_row_with_default_posture_still_no_gate():
+    """⛔PO 리뷰(2026-07-20) 회귀 게이트 — org_gate_policy **행 자체는 존재**하지만 posture를
+    지정하지 않아 pydantic/컬럼 기본값 "balanced"가 들어간 조직(=`PUT /gate-config/policy`에
+    본문 `{}`만 보낸 것과 동형)은, 증거 없이는 여전히 게이트가 서면 안 된다.
+
+    "행이 존재함"과 "값을 골랐음"은 다른 자리다 — source=org_policy라는 사실만으로 명시로
+    인정하면 원 버그와 같은 계열의 함정(명시와 기본을 못 구분)에 한 겹 안쪽에서 다시 빠진다.
+    다음 사람이 "명시니까 통과"로 판정 범위를 넓히면 이 테스트가 잡는다."""
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.models.hitl_config import OrgGatePolicy
+    from app.services.merge_verdict_gate import AUTO_MERGE, evaluate_merge_gate
+
+    engine, Session = await _engine_and_session()
+    org, project, story_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    member, role_id = uuid.uuid4(), uuid.uuid4()
+    try:
+        async with Session() as s:
+            await _seed_story_with_participation(
+                s, org=org, project=project, story_id=story_id, member=member, role_id=role_id,
+            )
+            await s.execute(_text("SET session_replication_role = replica"))
+            # posture 미지정 — 컬럼 server_default("balanced")가 그대로 들어간다(모델 정의 확인:
+            # OrgGatePolicy.posture: server_default="balanced").
+            s.add(OrgGatePolicy(org_id=org))
+            await s.commit()
+
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            decision = await evaluate_merge_gate(
+                s, org, story_id, pr_number=0, repo="", ci_result=None, pr_result=None,
+            )
+            await s.commit()
+
+        assert decision.decision == AUTO_MERGE
+        assert decision.gate_id is None, "posture=balanced(기본값)는 '명시'가 아니라 게이트가 서면 안 된다"
+
+        async with Session() as s:
+            count = (await s.execute(
+                _text("SELECT count(*) FROM gate WHERE work_item_id=:sid AND gate_type='merge'"),
+                {"sid": story_id},
+            )).scalar()
+            assert count == 0
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_explicit_deny_still_materializes_gate_unchanged():
     """ⓒ 명시 deny(org_gate_override) → 증거 없어도 게이트 생성(기존 동작 무회귀).
 

--- a/backend/tests/test_2047_explicit_ask_gate.py
+++ b/backend/tests/test_2047_explicit_ask_gate.py
@@ -1,0 +1,196 @@
+"""SID 301ee45d/#2047 AC3: 실DB 회귀 테스트 3종 — 증거 없는(ci=None·pr_number=0) merge 게이트
+경로에서 명시 ask 정책이 더 이상 우회되지 않는지 실제 Postgres 왕복으로 확인한다.
+
+배경(선생님 지시 2026-07-20, P0): `merge_verdict_gate.evaluate_merge_gate`의 no-substance
+chokepoint가 'ask'를 시스템 기본값이든 조직이 명시 설정했든 구분 없이 취급해, "코드가 아닌 일에는
+사람 결재가 원리적으로 안 걸리는" 결함이었다(댄 어윈 실측). `resolve_disposition`이 이제
+(disposition, source)를 돌려주고, source가 SYSTEM_DEFAULT가 아니면(=조직/멤버가 어떤 형태로든
+명시) 'ask'도 'deny'와 동일하게 substance로 인정해 게이트를 만든다.
+
+균형점(AC2): 명시하지 않은 조직은 지금과 동일하게 게이트가 안 선다 — 빈 shell 박멸 의도 보존.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)"),
+    pytest.mark.destructive_schema,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    return _REAL_DB_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+        "postgresql://", "postgresql+asyncpg://"
+    )
+
+
+async def _engine_and_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401 — 전 모델 메타데이터 로드
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_story_with_participation(session, *, org, project, story_id, member, role_id):
+    from sqlalchemy import text as _text
+    from app.models.participation import Participation, ParticipationRole
+    from app.models.pm import Story
+
+    await session.execute(_text("SET session_replication_role = replica"))
+    session.add_all([
+        ParticipationRole(id=role_id, org_id=org, key="implementation", label="구현", is_default=True),
+        Story(id=story_id, org_id=org, project_id=project, title="#2047 AC3", status="in-review", story_points=3),
+        Participation(id=uuid.uuid4(), org_id=org, story_id=story_id, member_id=member, role_id=role_id),
+    ])
+    await session.commit()
+
+
+@pytest.mark.anyio
+async def test_explicit_org_policy_ask_materializes_gate_without_evidence():
+    """ⓐ 명시 ask(org posture) + 증거 없음(ci=None·pr=0) → 게이트 생성·requires_human=true.
+
+    이게 이 스토리의 핵심 회귀 게이트 — 댄 어윈이 실측한 그 시나리오(콘텐츠 프로젝트·PR/CI 없음)를
+    그대로 재현한다."""
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.models.hitl_config import OrgGatePolicy
+    from app.services.merge_verdict_gate import ASK_HUMAN, AUTO_MERGE, evaluate_merge_gate
+
+    engine, Session = await _engine_and_session()
+    org, project, story_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    member, role_id = uuid.uuid4(), uuid.uuid4()
+    try:
+        async with Session() as s:
+            await _seed_story_with_participation(
+                s, org=org, project=project, story_id=story_id, member=member, role_id=role_id,
+            )
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add(OrgGatePolicy(org_id=org, posture="conservative"))  # → 명시 ask(org_policy).
+            await s.commit()
+
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            decision = await evaluate_merge_gate(
+                s, org, story_id, pr_number=0, repo="", ci_result=None, pr_result=None,
+            )
+            await s.commit()
+
+        assert decision.decision != AUTO_MERGE
+        assert decision.decision == ASK_HUMAN
+        assert decision.gate_id is not None, "명시 ask 정책은 증거 없어도 게이트가 서야 한다"
+
+        async with Session() as s:
+            meta = (await s.execute(
+                _text("SELECT requires_human, status FROM gate WHERE work_item_id=:sid AND gate_type='merge'"),
+                {"sid": story_id},
+            )).one()
+            assert meta.requires_human is True
+            assert meta.status == "pending"
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unset_org_no_gate_without_evidence():
+    """ⓑ 정책 미설정(SYSTEM_DEFAULT ask) + 증거 없음 → 게이트 미생성(row 0)·현행 유지.
+
+    빈 shell 박멸 의도 보존 — AC2의 균형점을 지키는 회귀 게이트."""
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.services.merge_verdict_gate import AUTO_MERGE, evaluate_merge_gate
+
+    engine, Session = await _engine_and_session()
+    org, project, story_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    member, role_id = uuid.uuid4(), uuid.uuid4()
+    try:
+        async with Session() as s:
+            await _seed_story_with_participation(
+                s, org=org, project=project, story_id=story_id, member=member, role_id=role_id,
+            )
+            # OrgGatePolicy 행 없음 — precedence 4단(SYSTEM_DEFAULT)로 떨어진다.
+
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            decision = await evaluate_merge_gate(
+                s, org, story_id, pr_number=0, repo="", ci_result=None, pr_result=None,
+            )
+            await s.commit()
+
+        assert decision.decision == AUTO_MERGE
+        assert decision.gate_id is None
+        assert "no-substance" in decision.reason
+
+        async with Session() as s:
+            count = (await s.execute(
+                _text("SELECT count(*) FROM gate WHERE work_item_id=:sid AND gate_type='merge'"),
+                {"sid": story_id},
+            )).scalar()
+            assert count == 0, "명시 안 한 조직은 빈 shell 게이트가 생기면 안 된다"
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_explicit_deny_still_materializes_gate_unchanged():
+    """ⓒ 명시 deny(org_gate_override) → 증거 없어도 게이트 생성(기존 동작 무회귀).
+
+    deny는 이 스토리 이전에도 substance로 인정됐다 — 그 경로가 이번 변경으로 안 깨지는지 확인."""
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.models.hitl_config import OrgGateOverride
+    from app.services.merge_verdict_gate import AUTO_MERGE, evaluate_merge_gate
+
+    engine, Session = await _engine_and_session()
+    org, project, story_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    member, role_id = uuid.uuid4(), uuid.uuid4()
+    try:
+        async with Session() as s:
+            await _seed_story_with_participation(
+                s, org=org, project=project, story_id=story_id, member=member, role_id=role_id,
+            )
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add(OrgGateOverride(org_id=org, role_id=role_id, gate_type="merge", disposition="deny"))
+            await s.commit()
+
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            decision = await evaluate_merge_gate(
+                s, org, story_id, pr_number=0, repo="", ci_result=None, pr_result=None,
+            )
+            await s.commit()
+
+        assert decision.decision != AUTO_MERGE
+        assert decision.gate_id is not None
+
+        async with Session() as s:
+            count = (await s.execute(
+                _text("SELECT count(*) FROM gate WHERE work_item_id=:sid AND gate_type='merge'"),
+                {"sid": story_id},
+            )).scalar()
+            assert count == 1
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()

--- a/backend/tests/test_e_cage_referee_p3_dynamic_adjustment.py
+++ b/backend/tests/test_e_cage_referee_p3_dynamic_adjustment.py
@@ -49,7 +49,7 @@ async def test_recommend_relax_ask_to_allow_auto():
 
     with patch("app.services.disposition_advisor.resolve_disposition", new_callable=AsyncMock) as mock_disp, \
          patch("app.services.disposition_advisor.compute_member_trust_scores", new_callable=AsyncMock) as mock_trust:
-        mock_disp.return_value = "ask"
+        mock_disp.return_value = ("ask", "system_default")
         mock_trust.return_value = _trust_result(0.95, 20)
 
         result = await get_disposition_recommendation(
@@ -69,7 +69,7 @@ async def test_no_recommend_when_already_allow_auto_high_rate():
 
     with patch("app.services.disposition_advisor.resolve_disposition", new_callable=AsyncMock) as mock_disp, \
          patch("app.services.disposition_advisor.compute_member_trust_scores", new_callable=AsyncMock) as mock_trust:
-        mock_disp.return_value = "allow_auto"
+        mock_disp.return_value = ("allow_auto", "system_default")
         mock_trust.return_value = _trust_result(0.98, 20)
 
         result = await get_disposition_recommendation(
@@ -89,7 +89,7 @@ async def test_recommend_tighten_allow_auto_to_ask():
 
     with patch("app.services.disposition_advisor.resolve_disposition", new_callable=AsyncMock) as mock_disp, \
          patch("app.services.disposition_advisor.compute_member_trust_scores", new_callable=AsyncMock) as mock_trust:
-        mock_disp.return_value = "allow_auto"
+        mock_disp.return_value = ("allow_auto", "system_default")
         mock_trust.return_value = _trust_result(0.60, 15)
 
         result = await get_disposition_recommendation(
@@ -108,7 +108,7 @@ async def test_no_recommend_tighten_when_ask():
 
     with patch("app.services.disposition_advisor.resolve_disposition", new_callable=AsyncMock) as mock_disp, \
          patch("app.services.disposition_advisor.compute_member_trust_scores", new_callable=AsyncMock) as mock_trust:
-        mock_disp.return_value = "ask"
+        mock_disp.return_value = ("ask", "system_default")
         mock_trust.return_value = _trust_result(0.50, 15)
 
         result = await get_disposition_recommendation(
@@ -128,7 +128,7 @@ async def test_low_sample_guard_no_recommendation():
 
     with patch("app.services.disposition_advisor.resolve_disposition", new_callable=AsyncMock) as mock_disp, \
          patch("app.services.disposition_advisor.compute_member_trust_scores", new_callable=AsyncMock) as mock_trust:
-        mock_disp.return_value = "ask"
+        mock_disp.return_value = ("ask", "system_default")
         mock_trust.return_value = _trust_result(0.99, 3)  # 3건 < DEFAULT 10건
 
         result = await get_disposition_recommendation(
@@ -147,7 +147,7 @@ async def test_custom_min_verdicts():
 
     with patch("app.services.disposition_advisor.resolve_disposition", new_callable=AsyncMock) as mock_disp, \
          patch("app.services.disposition_advisor.compute_member_trust_scores", new_callable=AsyncMock) as mock_trust:
-        mock_disp.return_value = "ask"
+        mock_disp.return_value = ("ask", "system_default")
         mock_trust.return_value = _trust_result(0.95, 3)
 
         result = await get_disposition_recommendation(
@@ -166,7 +166,7 @@ async def test_no_verdicts_low_sample():
 
     with patch("app.services.disposition_advisor.resolve_disposition", new_callable=AsyncMock) as mock_disp, \
          patch("app.services.disposition_advisor.compute_member_trust_scores", new_callable=AsyncMock) as mock_trust:
-        mock_disp.return_value = "ask"
+        mock_disp.return_value = ("ask", "system_default")
         mock_trust.return_value = {"member_id": str(MEMBER_ID), "scores": [], "window_days": 90}
 
         result = await get_disposition_recommendation(

--- a/backend/tests/test_e_cage_referee_p3_gate_object.py
+++ b/backend/tests/test_e_cage_referee_p3_gate_object.py
@@ -62,7 +62,7 @@ async def test_create_gate_ask_gives_pending():
     session.refresh = AsyncMock()
 
     with patch("app.services.gate_service.resolve_disposition", new_callable=AsyncMock) as mock_disp:
-        mock_disp.return_value = "ask"
+        mock_disp.return_value = ("ask", "system_default")
 
         gate = MagicMock()
         gate.status = "pending"
@@ -89,7 +89,7 @@ async def test_create_gate_allow_auto_gives_auto_passed():
     session.refresh = AsyncMock()
 
     with patch("app.services.gate_service.resolve_disposition", new_callable=AsyncMock) as mock_disp:
-        mock_disp.return_value = "allow_auto"
+        mock_disp.return_value = ("allow_auto", "system_default")
 
         await create_gate(session, ORG_ID, STORY_ID, "story", "pr_review", MEMBER_ID, ROLE_ID)
 
@@ -112,7 +112,7 @@ async def test_create_gate_deny_gives_rejected():
     session.refresh = AsyncMock()
 
     with patch("app.services.gate_service.resolve_disposition", new_callable=AsyncMock) as mock_disp:
-        mock_disp.return_value = "deny"
+        mock_disp.return_value = ("deny", "system_default")
 
         await create_gate(session, ORG_ID, STORY_ID, "story", "merge", MEMBER_ID, ROLE_ID)
 

--- a/backend/tests/test_e_cage_referee_p3_hitl_config.py
+++ b/backend/tests/test_e_cage_referee_p3_hitl_config.py
@@ -6,7 +6,13 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from app.models.hitl_config import posture_to_disposition, SYSTEM_DEFAULT_DISPOSITION
-from app.services.gate_resolver import resolve_disposition
+from app.services.gate_resolver import (
+    SOURCE_MEMBER_OVERRIDE,
+    SOURCE_ORG_OVERRIDE,
+    SOURCE_ORG_POLICY,
+    SOURCE_SYSTEM_DEFAULT,
+    resolve_disposition,
+)
 
 ORG_ID = uuid.uuid4()
 MEMBER_ID = uuid.uuid4()
@@ -66,7 +72,7 @@ async def test_member_override_wins():
     session = _make_session(member_override=mo)
 
     result = await resolve_disposition(session, ORG_ID, MEMBER_ID, ROLE_ID, "pr_review")
-    assert result == "deny"
+    assert result == ("deny", SOURCE_MEMBER_OVERRIDE)
 
 
 @pytest.mark.anyio
@@ -77,7 +83,7 @@ async def test_org_override_wins_when_no_member_override():
     session = _make_session(member_override=None, org_override=oo)
 
     result = await resolve_disposition(session, ORG_ID, MEMBER_ID, ROLE_ID, "qa")
-    assert result == "allow_auto"
+    assert result == ("allow_auto", SOURCE_ORG_OVERRIDE)
 
 
 @pytest.mark.anyio
@@ -88,7 +94,7 @@ async def test_org_posture_wins_when_no_overrides():
     session = _make_session(member_override=None, org_override=None, policy=policy)
 
     result = await resolve_disposition(session, ORG_ID, MEMBER_ID, ROLE_ID, "merge")
-    assert result == "allow_auto"
+    assert result == ("allow_auto", SOURCE_ORG_POLICY)
 
 
 @pytest.mark.anyio
@@ -97,7 +103,7 @@ async def test_system_default_when_no_policy():
     session = _make_session(member_override=None, org_override=None, policy=None)
 
     result = await resolve_disposition(session, ORG_ID, MEMBER_ID, ROLE_ID, "deploy")
-    assert result == "ask"
+    assert result == ("ask", SOURCE_SYSTEM_DEFAULT)
 
 
 @pytest.mark.anyio
@@ -108,7 +114,7 @@ async def test_conservative_posture_gives_ask():
     session = _make_session(member_override=None, org_override=None, policy=policy)
 
     result = await resolve_disposition(session, ORG_ID, MEMBER_ID, ROLE_ID, "pr_review")
-    assert result == "ask"
+    assert result == ("ask", SOURCE_ORG_POLICY)
 
 
 @pytest.mark.anyio
@@ -130,7 +136,7 @@ async def test_all_gate_types_resolve():
     for gt in gate_types:
         session = _make_session()
         result = await resolve_disposition(session, ORG_ID, MEMBER_ID, ROLE_ID, gt)
-        assert result == "ask"
+        assert result == ("ask", SOURCE_SYSTEM_DEFAULT)
 
 
 # ── 엔드포인트 통합 테스트 ────────────────────────────────────────────────────
@@ -172,6 +178,7 @@ async def test_resolve_endpoint_200():
         assert resp.status_code == 200
         body = resp.json()
         assert body["disposition"] == "ask"  # 시스템 기본값
+        assert body["source"] == SOURCE_SYSTEM_DEFAULT  # SID 301ee45d/#2047 AC1: 출처도 응답에 노출
         assert body["gate_type"] == "pr_review"
     finally:
         app.dependency_overrides.clear()
@@ -223,4 +230,4 @@ async def test_org_isolation_resolve():
     session = _make_session()
     other_org = uuid.uuid4()
     result = await resolve_disposition(session, other_org, MEMBER_ID, ROLE_ID, "qa")
-    assert result == "ask"
+    assert result == ("ask", SOURCE_SYSTEM_DEFAULT)

--- a/backend/tests/test_edg_doc_gate_inbox.py
+++ b/backend/tests/test_edg_doc_gate_inbox.py
@@ -201,7 +201,7 @@ async def test_doc_approval_always_pending_despite_allow_auto():
     session.flush = AsyncMock(); session.refresh = AsyncMock()
     no_existing = MagicMock(); no_existing.scalar_one_or_none.return_value = None
     session.execute = AsyncMock(return_value=no_existing)
-    with patch("app.services.gate_service.resolve_disposition", new=AsyncMock(return_value="allow_auto")):
+    with patch("app.services.gate_service.resolve_disposition", new=AsyncMock(return_value=("allow_auto", "system_default"))):
         await create_gate(session, uuid.uuid4(), uuid.uuid4(), "doc", "doc_approval",
                           uuid.uuid4(), uuid.uuid4())
     assert captured["gate"].status == "pending"  # allow_auto → 그래도 pending(force)
@@ -217,7 +217,7 @@ async def test_non_doc_gate_still_auto_passes():
     session.flush = AsyncMock(); session.refresh = AsyncMock()
     no_existing = MagicMock(); no_existing.scalar_one_or_none.return_value = None
     session.execute = AsyncMock(return_value=no_existing)
-    with patch("app.services.gate_service.resolve_disposition", new=AsyncMock(return_value="allow_auto")):
+    with patch("app.services.gate_service.resolve_disposition", new=AsyncMock(return_value=("allow_auto", "system_default"))):
         await create_gate(session, uuid.uuid4(), uuid.uuid4(), "story", "merge",
                           uuid.uuid4(), uuid.uuid4())
     assert captured["gate"].status == "auto_passed"

--- a/backend/tests/test_merge_verdict_gate.py
+++ b/backend/tests/test_merge_verdict_gate.py
@@ -498,12 +498,20 @@ async def test_strong_outcome_track_record_auto_merges_real_db():
 import contextlib  # noqa: E402
 
 
-async def _run_substance(*, ci_result, pr_number, disposition, source="system_default"):
+async def _run_substance(*, ci_result, pr_number, disposition, source="system_default", explicit=None):
     """substance 가드 경로 — participation 있음, (disposition, source) 주입, create_gate spy 반환.
 
     SID 301ee45d/#2047: resolve_disposition이 (disposition, source) 튜플을 돌려준다 — source
     기본값은 SYSTEM_DEFAULT(기존 테스트들의 암묵 전제였던 "누구도 명시 설정 안 함").
+
+    PO 리뷰(2026-07-20): source만으로는 부족하다 — org_policy는 값(posture) 수준까지 봐야
+    "진짜 명시"인지 판정된다(`_is_meaningfully_explicit_ask`, 실 DB 대조는
+    test_2047_explicit_ask_gate.py의 posture=conservative/balanced 케이스가 담당). 이 단위
+    테스트는 그 판정 함수 자체를 직접 mock해 "explicit_ask=True/False일 때 게이트 생성 배선이
+    맞는지"만 검증한다 — 판정 로직 자체는 realdb 스위트가 실증.
     """
+    if explicit is None:
+        explicit = source != "system_default"  # 기존 테스트들의 암묵 기대(하위호환 기본값)
     part = SimpleNamespace(member_id=uuid.uuid4(), role_id=uuid.uuid4())
     gate = SimpleNamespace(id=uuid.uuid4(), status="pending")
     with contextlib.ExitStack() as stack:
@@ -512,6 +520,8 @@ async def _run_substance(*, ci_result, pr_number, disposition, source="system_de
         stack.enter_context(patch.object(mod, "_role_key", AsyncMock(return_value="implementation")))
         stack.enter_context(patch.object(mod, "resolve_disposition",
                                          AsyncMock(return_value=(disposition, source))))
+        stack.enter_context(patch.object(mod, "_is_meaningfully_explicit_ask",
+                                         AsyncMock(return_value=explicit)))
         stack.enter_context(patch.object(mod, "capture_pr_ci_verdict",
                                          AsyncMock(return_value={"recorded": [], "skipped_reason": "no_sid_tag"})))
         stack.enter_context(patch.object(mod, "compute_member_trust_scores",
@@ -553,15 +563,31 @@ async def test_no_substance_allow_auto_also_no_gate():
 
 @pytest.mark.anyio
 async def test_no_substance_explicit_ask_materializes_gate():
-    """⭐SID 301ee45d/#2047 AC2 — 조직이 ask를 명시(org_policy)했으면 증거가 없어도 게이트가
-    서고 requires_human=true가 된다. 이게 이 스토리의 핵심 회귀 게이트: 명시 안 한 조직은
-    위 test_no_substance_no_gate_materialized처럼 여전히 no-gate라는 것과 짝을 이룬다."""
+    """⭐SID 301ee45d/#2047 AC2 — 조직이 ask를 **값까지 명시**(org_policy·posture=conservative,
+    즉 `_is_meaningfully_explicit_ask`가 True)했으면 증거가 없어도 게이트가 서고
+    requires_human=true가 된다. 이게 이 스토리의 핵심 회귀 게이트: 명시 안 한 조직은 위
+    test_no_substance_no_gate_materialized처럼 여전히 no-gate라는 것과 짝을 이룬다."""
     res, create_spy = await _run_substance(
-        ci_result=None, pr_number=0, disposition="ask", source="org_policy",
+        ci_result=None, pr_number=0, disposition="ask", source="org_policy", explicit=True,
     )
     assert res.gate_id is not None
     assert res.decision == ASK_HUMAN
     create_spy.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_no_substance_org_policy_default_posture_not_explicit_no_gate():
+    """⛔PO 리뷰(2026-07-20) 회귀 게이트 — org_gate_policy 행이 존재해도(source="org_policy")
+    posture가 기본값(balanced)이면 "출처는 명시"지만 "값은 아무도 안 고른 기본값"이라
+    `_is_meaningfully_explicit_ask`가 False를 내야 하고, 그러면 게이트가 안 서야 한다.
+    `PUT /gate-config/policy`에 본문 `{}`만 보내도 posture="balanced"가 저장되는 경로가
+    "명시 ask"로 오판되면 원 버그와 같은 계열의 함정에 다시 빠진다."""
+    res, create_spy = await _run_substance(
+        ci_result=None, pr_number=0, disposition="ask", source="org_policy", explicit=False,
+    )
+    assert res.decision == AUTO_MERGE
+    assert res.gate_id is None
+    create_spy.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_merge_verdict_gate.py
+++ b/backend/tests/test_merge_verdict_gate.py
@@ -498,8 +498,12 @@ async def test_strong_outcome_track_record_auto_merges_real_db():
 import contextlib  # noqa: E402
 
 
-async def _run_substance(*, ci_result, pr_number, disposition):
-    """substance 가드 경로 — participation 있음, disposition 주입, create_gate spy 반환."""
+async def _run_substance(*, ci_result, pr_number, disposition, source="system_default"):
+    """substance 가드 경로 — participation 있음, (disposition, source) 주입, create_gate spy 반환.
+
+    SID 301ee45d/#2047: resolve_disposition이 (disposition, source) 튜플을 돌려준다 — source
+    기본값은 SYSTEM_DEFAULT(기존 테스트들의 암묵 전제였던 "누구도 명시 설정 안 함").
+    """
     part = SimpleNamespace(member_id=uuid.uuid4(), role_id=uuid.uuid4())
     gate = SimpleNamespace(id=uuid.uuid4(), status="pending")
     with contextlib.ExitStack() as stack:
@@ -507,7 +511,7 @@ async def _run_substance(*, ci_result, pr_number, disposition):
                                          AsyncMock(return_value=part)))
         stack.enter_context(patch.object(mod, "_role_key", AsyncMock(return_value="implementation")))
         stack.enter_context(patch.object(mod, "resolve_disposition",
-                                         AsyncMock(return_value=disposition)))
+                                         AsyncMock(return_value=(disposition, source))))
         stack.enter_context(patch.object(mod, "capture_pr_ci_verdict",
                                          AsyncMock(return_value={"recorded": [], "skipped_reason": "no_sid_tag"})))
         stack.enter_context(patch.object(mod, "compute_member_trust_scores",
@@ -523,8 +527,12 @@ async def _run_substance(*, ci_result, pr_number, disposition):
 
 @pytest.mark.anyio
 async def test_no_substance_no_gate_materialized():
-    """무증거(ci None·pr 0·정책 ask) → 게이트 미생성·no-gate(AUTO_MERGE)·row 0."""
-    res, create_spy = await _run_substance(ci_result=None, pr_number=0, disposition="ask")
+    """무증거(ci None·pr 0·정책 ask=SYSTEM_DEFAULT) → 게이트 미생성·no-gate(AUTO_MERGE)·row 0.
+
+    아무도 명시 설정 안 한 조직(빈 shell 박멸 의도가 지키려는 대상)의 현행 동작 보존."""
+    res, create_spy = await _run_substance(
+        ci_result=None, pr_number=0, disposition="ask", source="system_default",
+    )
     assert res.decision == AUTO_MERGE
     assert res.gate_id is None
     assert "no-substance" in res.reason
@@ -533,10 +541,38 @@ async def test_no_substance_no_gate_materialized():
 
 @pytest.mark.anyio
 async def test_no_substance_allow_auto_also_no_gate():
-    """무증거 + 정책 allow_auto → 동일하게 no-gate(done 통과·row 0)."""
-    res, create_spy = await _run_substance(ci_result=None, pr_number=0, disposition="allow_auto")
+    """무증거 + 정책 allow_auto(명시든 기본이든) → 동일하게 no-gate(done 통과·row 0).
+
+    AC2: allow_auto는 "사람이 볼 필요 없다"는 의미라 명시했어도 게이트가 서면 안 된다."""
+    res, create_spy = await _run_substance(
+        ci_result=None, pr_number=0, disposition="allow_auto", source="org_policy",
+    )
     assert res.decision == AUTO_MERGE and res.gate_id is None
     create_spy.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_no_substance_explicit_ask_materializes_gate():
+    """⭐SID 301ee45d/#2047 AC2 — 조직이 ask를 명시(org_policy)했으면 증거가 없어도 게이트가
+    서고 requires_human=true가 된다. 이게 이 스토리의 핵심 회귀 게이트: 명시 안 한 조직은
+    위 test_no_substance_no_gate_materialized처럼 여전히 no-gate라는 것과 짝을 이룬다."""
+    res, create_spy = await _run_substance(
+        ci_result=None, pr_number=0, disposition="ask", source="org_policy",
+    )
+    assert res.gate_id is not None
+    assert res.decision == ASK_HUMAN
+    create_spy.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_no_substance_member_override_ask_materializes_gate():
+    """member_gate_override로 ask를 명시한 경우도 동일하게 게이트가 선다(precedence 최상위)."""
+    res, create_spy = await _run_substance(
+        ci_result=None, pr_number=0, disposition="ask", source="member_override",
+    )
+    assert res.gate_id is not None
+    assert res.decision == ASK_HUMAN
+    create_spy.assert_awaited_once()
 
 
 @pytest.mark.anyio
@@ -558,7 +594,7 @@ async def test_connected_pr_materializes_gate():
 
 @pytest.mark.anyio
 async def test_deny_policy_materializes_even_without_evidence():
-    """명시 deny 정책 → 증거 없어도 게이트 생성(하드블록 honor)."""
+    """명시 deny 정책 → 증거 없어도 게이트 생성(하드블록 honor) — source 무관(deny는 항상 substance)."""
     res, create_spy = await _run_substance(ci_result=None, pr_number=0, disposition="deny")
     assert res.gate_id is not None
     create_spy.assert_awaited_once()


### PR DESCRIPTION
## Summary
선생님 지시(2026-07-20, 최우선): 코드가 아닌 일(콘텐츠·마케팅 등, PR/CI 자체가 없는 작업)에는 조직이 "반드시 사람이 서명"이라고 `ask` 정책을 명시해도 사람 결재가 원리적으로 안 걸리던 결함(댄 어윈 실측이 PO의 "근거 부족이면 오히려 ask_human으로 간다"는 초기 답을 반증). 근본은 `merge_verdict_gate.py`의 no-substance chokepoint가 `resolve_disposition`의 `ask`를 시스템 기본값이든 조직이 명시 설정했든 구분 없이 취급해 항상 no-gate로 우회한 것.

- **AC1**: `resolve_disposition`이 `(disposition, source)` 튜플 반환. 호출부 4곳 전부 무회귀 갱신. `POST /gate-config/resolve` 응답에도 `source` 노출.
- **AC2**: 명시 ask(source != system_default)면 deny와 동일하게 substance로 인정 — 게이트 생성 + `requires_human=true`. **명시 안 한 조직은 지금과 동일하게 게이트 안 생김**(빈 shell 박멸 의도 보존 — 이 스토리의 균형점).
- **AC3**: 실DB 회귀 테스트 3종(`test_2047_explicit_ask_gate.py`) — 명시 ask/미설정/명시 deny.
- **AC6 조사**: FE 전체에서 이 메커니즘(`org_gate_policy`/`*_override`) 참조 0건 — **API 직접 호출로만 설정 가능**(설정 화면 없음). `gate_config.py`(work_type×actor_type×level 매트릭스)는 별개 서브시스템이라 혼동 주의. 후속 스토리로 분리 필요.

## 이 PR에 없는 것 (명시)
- **AC4**(사람이 게이트를 실제 승인/거부 — #2043과 짝): FE 작업이라 포함 안 됨. **이 스토리 단독으로 done 선언하지 않음.**
- **AC5**(dev 라이브 확認): 이 PR이 dev에 배포된 뒤에만 가능 — merge 후 이어서 진행.

## Test plan
- [x] 관련 mocked 스위트 378 passed (`-k "gate or hitl or disposition"`)
- [x] 신규 realdb 3건(`test_2047_explicit_ask_gate.py`) + 인접 실DB 스위트(H1-S10 E2E 포함) 22건 — 로컬 pg@16(`alembic upgrade head` 완주) 격리 실행 green
- [x] `python -c "from app.main import app"` — 489 routes, import 정상
- [ ] merge→dev 배포 후 AC5 라이브 확認 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)