### PR TITLE
[SID:265f5b13] #2049 P0 — 신규/기존 조직 기본 참여 역할 백필

### DIFF
--- a/backend/alembic/versions/0204_seed_default_participation_roles.py
+++ b/backend/alembic/versions/0204_seed_default_participation_roles.py
@@ -1,0 +1,63 @@
+"""SID 265f5b13/#2049 P0: 기본 참여 역할 세트 백필 — merge 게이트가 신규/기존 조직 전부에서
+원천적으로 안 도는 결함 수정(AC2).
+
+Revision ID: 0204
+Revises: 0203
+Create Date: 2026-07-20
+
+발견 경위: #2047 AC5 라이브 검증 중 dev 테스트 조직 4곳을 조회했더니 `is_default=True` 참여
+역할을 가진 조직이 뭉클랩(`54bac162-...`) 하나뿐이었다. `merge_verdict_gate` →
+`resolve_implementation_participation`(app/services/verdict_capture.py:55-63)은
+`is_default=True` 역할부터 찾고 없으면 None을 반환 — 호출자는 그대로 skip해 **게이트가 아예
+생성되지 않는다.** 즉 신규 고객 조직은 물론, 이미 만들어진 dev 테스트 조직 대부분이 이 상태였다.
+
+뭉클랩이 실측으로 보유한 5종 세트(implementation/po/qa/design/devops, 전부 2026-05-31 동시
+생성)를 그대로 재사용한다 — app/repositories/organization.py의 DEFAULT_PARTICIPATION_ROLES와
+byte-identical(AC1이 신규 조직에 심는 것과 같은 세트를 기존 조직에도 맞춘다). `hypothesis_owner`
+(2026-06-13 별도 경로로 추가)는 이 "기본 세트"에서 제외 — 이미 0119가 전 org에 보장한다.
+
+멱등: 0063이 만든 uq_participation_role_org_key(org_id,key)로 ON CONFLICT DO NOTHING —
+**이미 해당 key를 가진 조직(뭉클랩 등)은 자연히 건드리지 않는다**(AC2 "멀쩡한 것을 손대지
+않는다" 요구를 스키마 제약으로 강제). 0119(hypothesis_owner seed)와 동일 패턴.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0204"
+down_revision = "0203"
+branch_labels = None
+depends_on = None
+
+# app/repositories/organization.py::DEFAULT_PARTICIPATION_ROLES와 byte-identical 유지 —
+# 신규 조직(AC1)과 기존 조직 백필(AC2)이 같은 세트를 갖도록.
+_DEFAULT_ROLES: tuple[tuple[str, str, bool], ...] = (
+    ("implementation", "구현", True),
+    ("po", "PO", False),
+    ("qa", "QA", False),
+    ("design", "디자인", False),
+    ("devops", "DevOps", False),
+)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    if "participation_role" not in insp.get_table_names() or "organizations" not in insp.get_table_names():
+        return  # 테이블 부재(이론상 없음) — no-op.
+
+    for key, label, is_default in _DEFAULT_ROLES:
+        op.execute(
+            sa.text(
+                "INSERT INTO participation_role (id, org_id, key, label, is_default, created_at) "
+                "SELECT gen_random_uuid(), o.id, :key, :label, :is_default, now() FROM organizations o "
+                "ON CONFLICT (org_id, key) DO NOTHING"
+            ).bindparams(key=key, label=label, is_default=is_default)
+        )
+
+
+def downgrade() -> None:
+    # 재백필은 순수 데이터 정합성 수정(#2039/0203 선례와 동형) — 되돌리면 다시 게이트가 원천적으로
+    # 안 도는 상태로 회귀하므로 downgrade는 no-op("고쳐진 상태 유지"가 유일하게 안전한 downgrade).
+    pass

--- a/backend/app/repositories/organization.py
+++ b/backend/app/repositories/organization.py
@@ -8,7 +8,24 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.organization import Organization
+from app.models.participation import ParticipationRole
 from app.models.project import OrgMember, Project
+
+# SID 265f5b13/#2049 AC1: 신규 조직 생성 직후 참여 역할 세트가 하나도 안 만들어져
+# `resolve_implementation_participation`(app/services/verdict_capture.py:55-63)이 항상
+# is_default=True 역할을 못 찾고 None을 반환 — merge 게이트가 신규 조직 전부에서 원천적으로
+# 안 만들어지는 P0였다(#2047 AC5 라이브 검증 중 발견: dev 테스트 조직 4곳 중 3곳은 role 0,
+# 1곳은 is_default 없는 role 1개뿐). 뭉클랩(유일하게 정상 동작하는 조직)이 실측으로 보유한
+# 5종 세트(implementation/po/qa/design/devops, 전부 2026-05-31 동시 생성)를 그대로 재사용한다
+# — `hypothesis_owner`(2026-06-13 추가)는 다른 시점에 다른 경로로 생긴 역할이라 이 "기본 세트"
+# 결정에서 제외한다(근거: created_at이 나머지 5개와 다름 → 별도 기능의 부산물로 판단).
+DEFAULT_PARTICIPATION_ROLES: tuple[tuple[str, str, bool], ...] = (
+    ("implementation", "구현", True),
+    ("po", "PO", False),
+    ("qa", "QA", False),
+    ("design", "디자인", False),
+    ("devops", "DevOps", False),
+)
 
 
 @dataclass
@@ -57,6 +74,12 @@ class OrganizationRepository:
         self.session.add(org)
         await self.session.flush()
         await self.session.refresh(org)
+        # SID 265f5b13/#2049 AC1: 참여 역할 세트를 org 생성과 함께 심어 merge 게이트(및
+        # participation을 전제하는 다른 모든 경로)가 신규 조직에서도 처음부터 동작하게 한다.
+        self.session.add_all([
+            ParticipationRole(org_id=org.id, key=key, label=label, is_default=is_default)
+            for key, label, is_default in DEFAULT_PARTICIPATION_ROLES
+        ])
         if owner_member_id is not None:
             await self.session.execute(
                 text(

--- a/backend/tests/test_2049_default_participation_roles.py
+++ b/backend/tests/test_2049_default_participation_roles.py
@@ -1,0 +1,144 @@
+"""SID 265f5b13/#2049 AC3: 실DB 회귀 테스트 — 신규 조직에 기본 참여 역할이 생기고,
+그 역할로 resolve_implementation_participation이 None을 반환하지 않는지.
+
+배경: #2047 AC5 라이브 검증 중 dev 테스트 조직 4곳 중 3곳이 참여 역할 0개, 1곳은
+is_default=True 역할이 없는 상태였다 — merge_verdict_gate의 no-substance chokepoint(#2047)에
+닿기도 전에 "no implementation participation"으로 조기 반환돼 게이트가 원천적으로 안 생겼다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)"),
+    pytest.mark.destructive_schema,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    return _REAL_DB_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+        "postgresql://", "postgresql+asyncpg://"
+    )
+
+
+async def _engine_and_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest.mark.anyio
+async def test_new_org_gets_default_participation_role():
+    """ⓐ OrganizationRepository.create() 직후 is_default=True 역할이 존재한다."""
+    from app.core.database import Base
+    from app.repositories.organization import OrganizationRepository
+
+    engine, Session = await _engine_and_session()
+    try:
+        async with Session() as s:
+            repo = OrganizationRepository(s)
+            org = await repo.create(name="AC3 Test Org", slug=f"ac3-{uuid.uuid4().hex[:8]}", owner_member_id=None)
+            await s.commit()
+            assert org is not None
+
+            from sqlalchemy import select
+            from app.models.participation import ParticipationRole
+
+            roles = (await s.execute(
+                select(ParticipationRole).where(ParticipationRole.org_id == org.id)
+            )).scalars().all()
+            assert len(roles) == 5, f"기본 역할 5종이 생겨야: {[r.key for r in roles]}"
+            default_roles = [r for r in roles if r.is_default]
+            assert len(default_roles) == 1 and default_roles[0].key == "implementation", (
+                f"is_default=True는 implementation 하나여야: {[(r.key, r.is_default) for r in roles]}"
+            )
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_resolve_implementation_participation_not_none_for_new_org():
+    """ⓑ 신규 조직에서 resolve_implementation_participation이 None을 반환하지 않는다
+    (participation 행이 있으면) — #2047의 no-substance chokepoint에 실제로 도달 가능함을 증명."""
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.models.participation import Participation
+    from app.models.pm import Story
+    from app.repositories.organization import OrganizationRepository
+    from app.services.verdict_capture import resolve_implementation_participation
+
+    engine, Session = await _engine_and_session()
+    try:
+        async with Session() as s:
+            repo = OrganizationRepository(s)
+            org = await repo.create(name="AC3 Test Org 2", slug=f"ac3b-{uuid.uuid4().hex[:8]}", owner_member_id=None)
+            await s.commit()
+
+            from sqlalchemy import select
+            from app.models.participation import ParticipationRole
+
+            default_role = (await s.execute(
+                select(ParticipationRole).where(
+                    ParticipationRole.org_id == org.id, ParticipationRole.is_default.is_(True),
+                ).limit(1)
+            )).scalar_one()
+
+            story_id, member_id, project_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add_all([
+                Story(id=story_id, org_id=org.id, project_id=project_id, title="AC3", status="in-review"),
+                Participation(
+                    id=uuid.uuid4(), org_id=org.id, story_id=story_id,
+                    member_id=member_id, role_id=default_role.id,
+                ),
+            ])
+            await s.commit()
+
+            participation = await resolve_implementation_participation(s, org.id, story_id)
+            assert participation is not None, "기본 역할이 있으면 participation 해소가 None이면 안 된다"
+            assert participation.member_id == member_id
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_without_participation_still_resolves_none_before_fix_scenario():
+    """대조군: participation 행 자체가 없으면(정책 백필과 무관) 여전히 None이 맞다 —
+    이 테스트가 무너지면 resolve_implementation_participation의 다른 불변식이 깨진 것."""
+    from app.repositories.organization import OrganizationRepository
+    from app.services.verdict_capture import resolve_implementation_participation
+    from app.core.database import Base
+
+    engine, Session = await _engine_and_session()
+    try:
+        async with Session() as s:
+            repo = OrganizationRepository(s)
+            org = await repo.create(name="AC3 Test Org 3", slug=f"ac3c-{uuid.uuid4().hex[:8]}", owner_member_id=None)
+            await s.commit()
+
+            participation = await resolve_implementation_participation(s, org.id, uuid.uuid4())
+            assert participation is None
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()


### PR DESCRIPTION
## Summary
#2047 AC5 라이브 검증 중 발견한 더 근본적인 P0. dev 테스트 조직 4곳 중 3곳은 참여 역할이 0개, 1곳은 `is_default=True` 역할이 없었다 — `merge_verdict_gate`가 쓰는 `resolve_implementation_participation`이 `is_default=True` 역할을 못 찾으면 None을 반환해 호출자가 skip, **게이트가 아예 생성되지 않는다.** `is_default=True` 역할을 가진 조직은 뭉클랩 하나뿐이었다 — #2047(명시 ask 정책 우회 차단)을 고쳐도 신규 고객 조직은 그 로직에 닿기도 전에 끝나는 상태였다.

- **AC1**: `OrganizationRepository.create()`에 기본 참여 역할 5종(뭉클랩 실측 세트 재사용) 시딩 — 신규 조직은 생성 즉시 게이트 판정 대상.
- **AC2**: alembic `0204` — 기존 조직 백필. `0119`(hypothesis_owner seed) 선례와 동일 패턴(`ON CONFLICT (org_id, key) DO NOTHING`) — 뭉클랩은 자연히 안 건드려짐.
- **AC3**: 실DB 회귀 테스트 3종, 로컬 pg@16 격리 실행 green.
- **AC5**: #2049가 선행돼야 #2047 AC5가 라이브로 닫힌다 — 순서 명시.
- **AC6**: 역할 생성 REST API는 이 P0 스코프에서 추가 안 함(판단 근거는 커밋 메시지 참고) — 후속 분리 권고.

## Test plan
- [x] `test_2049_default_participation_roles.py` 3 passed(로컬 pg@16, `alembic upgrade head` 완주 후 격리 실행)
- [x] 인접 organization/participation mocked 스위트 29 passed
- [x] `python -c "from app.main import app"` — 489 routes, import 정상
- [ ] merge→dev 배포 후 HITL Dogfood Test 조직에서 라이브 재검증(#2047 AC5로 이어짐)

🤖 Generated with [Claude Code](https://claude.com/claude-code)