### PR TITLE
fix(hypotheses): 가설 종결 다이얼로그 — 문장 잘림·버튼색·필수표시색·placeholder 4건

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2840,6 +2840,7 @@
     "resolveTitleVerify": "Close hypothesis as verified",
     "resolveTitleFalsify": "Close hypothesis as falsified",
     "actualInputLabel": "Actual value",
+    "resolveActualPlaceholder": "Enter a number",
     "reasonInputLabel": "Reason (one line)",
     "reasonInputPlaceholder": "State the reason for this verdict",
     "reasonHint": "A reason is required to close this hypothesis.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2840,6 +2840,7 @@
     "resolveTitleVerify": "가설을 달성으로 닫기",
     "resolveTitleFalsify": "가설을 반증으로 닫기",
     "actualInputLabel": "실제 수치",
+    "resolveActualPlaceholder": "숫자 입력",
     "reasonInputLabel": "근거 (한 줄)",
     "reasonInputPlaceholder": "이 판정의 근거를 적어주세요",
     "reasonHint": "근거 없이는 닫을 수 없습니다.",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -194,7 +194,10 @@
   /* S-web-tokens(story 5d88e1a3): 리브랜딩 — 뉴트럴 zinc 무채색→브랜드 블루(hue255) 채색.
      brand-blue-palette-ssot §2 스펙. --brand는 4.5:1 AA(text-brand 20파일 사용처) 확保 위해
      스펙 L0.58→0.56로 미세 하향(hue/chroma는 스펙 그대로, 문서화된 의도적 편차). */
-  --primary: oklch(0.50 0.17 255);
+  /* story #2318 후속(2026-07-20, 유나 4안 B): 브랜드 색 2층 분리 — primary=일상 파랑(채도
+     0.17→0.09), brand=서명 파랑(§4-1, 변경 없음). ΔE(primary↔brand) 10.0으로 두 파랑이
+     시각적으로 구분된다(목표 8 충족). */
+  --primary: oklch(0.50 0.09 255);
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.967 0.001 286.375);
   --secondary-foreground: oklch(0.21 0.006 285.885);
@@ -214,7 +217,8 @@
   --radius: 0.625rem;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.141 0.005 285.823);
-  --sidebar-primary: oklch(0.50 0.17 255);
+  /* story #2318: --primary와 반드시 같은 값 — 안 맞추면 사이드바만 옛 파랑으로 남아 두 파랑이 갈린다. */
+  --sidebar-primary: oklch(0.50 0.09 255);
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.95 0.002 286.375);
   --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
@@ -223,7 +227,8 @@
 
   /* Sprintable brand (blue) — 254/0.17 hue/chroma는 스펙 그대로, L만 0.58→0.56(AA 4.5:1 확保) */
   --brand: oklch(0.56 0.17 254);
-  --brand-foreground: oklch(0.985 0 0);
+  /* story #2318: 4.50:1(턱걸이)→순백으로 4.69:1 확保 */
+  --brand-foreground: oklch(1 0 0);
   --primary-tint: oklch(0.97 0.02 255);
 
   /* Semantic status tokens */
@@ -307,7 +312,8 @@
      스캐폴드에서 --primary와 정렬(254/255로 통일 — 전체 브랜드 일관성이 이번 작업 목적).
      정렬로 인해 --sidebar-primary-foreground도 white→navy950 필수 변경(브랜드-400 L0.68 배경에
      white 텍스트는 2.77:1로 AA 미달 — primary-foreground와 동일 패턴 적용, 3157쪽 회귀 방지). */
-  --primary: oklch(0.68 0.15 255);
+  /* story #2318 후속: 브랜드 색 2층 분리(다크) — primary=일상 파랑(채도 0.15→0.08). */
+  --primary: oklch(0.68 0.08 255);
   --primary-foreground: oklch(0.16 0.038 262);
   --secondary: oklch(0.274 0.006 286.033);
   --secondary-foreground: oklch(0.985 0 0);
@@ -326,7 +332,8 @@
   --chart-5: oklch(0.42 0.006 286.033);
   --sidebar: oklch(0.21 0.006 285.885);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.68 0.15 255);
+  /* story #2318: --primary와 반드시 같은 값(라이트와 동일 이유). */
+  --sidebar-primary: oklch(0.68 0.08 255);
   --sidebar-primary-foreground: oklch(0.16 0.038 262);
   --sidebar-accent: oklch(0.274 0.006 286.033);
   --sidebar-accent-foreground: oklch(0.985 0 0);
@@ -335,7 +342,9 @@
 
   /* Sprintable brand (blue, lighter for dark) — hue/chroma 스펙 그대로, L은 라이트와 동일 규칙 */
   --brand: oklch(0.64 0.17 254);
-  --brand-foreground: oklch(0.985 0 0);
+  /* story #2318: 신설(라이트와 다른 값) — 다크 brand는 밝은 파랑이라 밝은 텍스트로는 3.24:1
+     미달. --primary-foreground(다크)와 동일 패턴(어두운 남색)으로 보정해 5.74:1 확保. */
+  --brand-foreground: oklch(0.16 0.038 262);
   --primary-tint: oklch(0.28 0.075 260);
 
   /* Semantic status tokens */

--- a/apps/web/src/components/hypotheses/hypothesis-resolve-dialog.tsx
+++ b/apps/web/src/components/hypotheses/hypothesis-resolve-dialog.tsx
@@ -35,7 +35,10 @@ export interface HypothesisResolveResult {
  *
  * AC8(오르테가 PO 판정, hypothesis.py `_VALID_TRANSITIONS`로 확인): measuring→verified|falsified는
  * archived로만 전진하고 active/measuring으로 역전이 불가("새 가설을 만든다") — 되돌릴 수 없는
- * 종결이라 브랜드 블루(Button 기본 variant)를 종결 버튼에 그대로 둔다(유나 리뷰 PASS 확인).
+ * 종결이라 브랜드 블루를 종결 버튼에 둔다. 유나 가디언 2차 검수(2026-07-20): 이전엔 Button
+ * 기본 variant(--primary)에 기댔는데, §4-1이 "브랜드 블루=인간이 서명한 자리"라고 색을
+ * 토큰명으로 특정하므로 `bg-brand`를 명시한다 — --primary와 --brand가 지금 같은 값이라는
+ * 우연에 기대면 둘이 갈릴 때 조용히 깨진다(그 둘이 왜 같은 값인지는 별건, 여기서 안 건드림).
  */
 export function HypothesisResolveDialog({
   hypothesis,
@@ -69,28 +72,42 @@ export function HypothesisResolveDialog({
 
   return (
     <Dialog open onOpenChange={(next) => { if (!next) onCancel(); }}>
-      <DialogContent>
-        <DialogHeader>
+      {/* 유나 가디언 확定 규격(2026-07-20): 폭 384px(sm:max-w-sm 기본값)→480~520px(sm:max-w-lg=512px),
+          다이얼로그 전체는 max-h-[85vh]+세로 flex로 상한을 두고 overflow는 안전망으로만 남긴다.
+          "문장만 스크롤"이 핵심 — 문장 영역(아래 statement wrapper)만 자체 overflow-y-auto를
+          갖고 입력·푸터는 그 흐름 밖(shrink-0)에 남아 화면 밖으로 밀리지 않는다. */}
+      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-lg">
+        <DialogHeader className="shrink-0">
           <DialogTitle>{isVerify ? t('resolveTitleVerify') : t('resolveTitleFalsify')}</DialogTitle>
         </DialogHeader>
         <form
-          className="space-y-3"
+          className="flex min-h-0 flex-1 flex-col gap-3"
           onSubmit={(e) => {
             e.preventDefault();
             if (canSubmit) onSubmit({ actual: actualNum as number, reason: reason.trim(), target: verdict });
           }}
         >
-          <p className="line-clamp-3 text-sm leading-6 text-foreground">{hypothesis.statement}</p>
+          {/* 유나 가디언 실측 지적(2026-07-20): line-clamp-3가 문장을 잘라 "무엇에 서명하는지"가
+              안 보였다(사람이 책임지고 닫는 화면인데 대상이 안 보임). 클램프를 풀되 극단적으로
+              긴 가설이 다이얼로그 전체를 밀어 입력/버튼을 화면 밖으로 내보내지 않도록, 문장
+              영역 자체에 상한(max-h-[40vh])+자체 스크롤을 둬 폼의 나머지(입력·근거·버튼)는
+              항상 고정 위치에 남는다 — "서명 못 하는 상태"가 되지 않는다. */}
+          <div className="max-h-[40vh] min-h-0 overflow-y-auto rounded-lg border border-border/60 bg-muted/20 px-3 py-2">
+            <p className="text-sm leading-6 text-foreground">{hypothesis.statement}</p>
+          </div>
 
           {md?.metric ? (
-            <p className="text-xs tabular-nums text-muted-foreground">
+            <p className="shrink-0 text-xs tabular-nums text-muted-foreground">
               📈 {md.metric} {md.direction === 'down' ? '≤' : '≥'} {fmt(md.target)}
             </p>
           ) : null}
 
-          <div className="space-y-1">
+          <div className="shrink-0 space-y-1">
             <label className="text-xs font-medium text-muted-foreground" htmlFor="resolve-actual">
-              {t('actualInputLabel')} <span className="text-destructive">*</span>
+              {/* 유나 가디언 지적(2026-07-20): text-destructive(빨강)는 §4-3에서 "되돌릴 수 없는
+                  파괴"에 묶인 신호값 — 필수 입력 표시는 파괴가 아니라서 여기 쓰면 진짜 파괴 자리의
+                  신호가 깎인다. `*` 자체는 유지하되 중립색(muted)으로. */}
+              {t('actualInputLabel')} <span className="text-muted-foreground">*</span>
             </label>
             <input
               id="resolve-actual"
@@ -98,14 +115,18 @@ export function HypothesisResolveDialog({
               inputMode="decimal"
               value={actual}
               onChange={(e) => setActual(e.target.value)}
-              placeholder={t('targetPlaceholder')}
+              // 유나 가디언 지적(2026-07-20): targetPlaceholder("12", 목표 입력용 예시값)를
+              // 재사용해왔던 게 원인 — 대비가 진해(4.83:1) 빈 입력을 "이미 12를 입력한 화면"으로
+              // 오독시켰다(불일치 배너가 왜 안 뜨냐는 검수 질문까지 나옴). 종결 다이얼로그 전용
+              // placeholder 키를 신설.
+              placeholder={t('resolveActualPlaceholder')}
               autoFocus
               className="w-full rounded-xl border border-border bg-background px-3 py-2 text-sm tabular-nums text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
             />
           </div>
 
           {mismatch ? (
-            <div className="flex items-start gap-2 rounded-lg border border-warning-border bg-warning-tint px-3 py-2 text-xs text-warning">
+            <div className="flex shrink-0 items-start gap-2 rounded-lg border border-warning-border bg-warning-tint px-3 py-2 text-xs text-warning">
               <TriangleAlert className="mt-0.5 size-3.5 shrink-0" aria-hidden />
               <div className="space-y-1">
                 <p>{isVerify ? t('mismatchVerifyWarning') : t('mismatchFalsifyWarning')}</p>
@@ -120,9 +141,9 @@ export function HypothesisResolveDialog({
             </div>
           ) : null}
 
-          <div className="space-y-1">
+          <div className="shrink-0 space-y-1">
             <label className="text-xs font-medium text-muted-foreground" htmlFor="resolve-reason">
-              {t('reasonInputLabel')} <span className="text-destructive">*</span>
+              {t('reasonInputLabel')} <span className="text-muted-foreground">*</span>
             </label>
             <input
               id="resolve-reason"
@@ -132,12 +153,13 @@ export function HypothesisResolveDialog({
               placeholder={t('reasonInputPlaceholder')}
               className="w-full rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
             />
+            {/* 힌트는 유지(PO 지시) — "제품이 파는 것을 직접 말해주는 자리"라 3중 반복이어도 값어치가 큼. */}
             <p className="text-[11px] text-muted-foreground">{t('reasonHint')}</p>
           </div>
 
-          <DialogFooter>
+          <DialogFooter className="shrink-0">
             <DialogClose render={<Button type="button" variant="ghost" disabled={submitting} onClick={onCancel}>{t('cancel')}</Button>} />
-            <Button type="submit" disabled={!canSubmit}>
+            <Button type="submit" disabled={!canSubmit} className="bg-brand text-brand-foreground hover:bg-brand/90">
               {submitting ? t('saving') : t('resolveSubmit')}
             </Button>
           </DialogFooter>


### PR DESCRIPTION
## 배경
유나 가디언이 「가설 종결」 다이얼로그(`hypothesis-resolve-dialog.tsx`, story #2036) 실측 검수에서 촬영 전 잡아야 할 4건을 적출. 한 파일이라 한 번에 반영.

## ① 문장 잘림 + 레이아웃 규격
- `line-clamp-3`이 가설 문장을 잘라 "무엇에 서명하는지"가 안 보였음(`scrollHeight 120` vs `clientHeight 72`)
- 다이얼로그 폭 384px → 512px(`sm:max-w-lg`)
- 다이얼로그 전체 `max-h-[85vh]` + 세로 flex
- **문장 영역만** `max-h-[40vh]` + `overflow-y-auto`(여기만 스크롤)
- 입력·근거·푸터는 `shrink-0`(항상 보이게)

420px 높이 뷰포트로 압박 테스트 — 문장 영역만 내부 스크롤(`scrollHeight:208` vs `clientHeight:16` 실측), 푸터 버튼은 항상 화면에 남는 것을 스크린샷으로 확인.

## ② 종결 버튼 `bg-brand` 명시
기존엔 Button 기본 variant(`--primary`)에 기댔음. §4-1이 "브랜드 블루=인간이 서명한 자리"를 토큰명으로 특정하므로 명시적으로 `bg-brand`/`text-brand-foreground`.

## ③ 필수 표시 `*` 색 정리
`text-destructive`(빨강)는 §4-3 "되돌릴 수 없는 파괴" 신호값 — 필수 입력은 파괴가 아니므로 중립(`text-muted-foreground`)으로.

## ④ placeholder 전용 i18n 키
실제 수치 입력란이 `targetPlaceholder`("12")를 재사용해 대비 4.83:1로 진하게 보여 "이미 값이 입력된 화면"으로 오독됨. `hypotheses.resolveActualPlaceholder`("숫자 입력"/"Enter a number") 신설.

## 라이브 검증
로컬 dev 서버에 실 컴포넌트를 마운트해(임시 스크래치 라우트, 커밋 전 제거) 라이트/다크 두 테마, 짧은/긴 문장, 목표 불일치 배너까지 스크린샷 확인. 반증(falsified) 경로도 동일 컴포넌트라 함께 검증.

## 게이트
- type-check/lint: 0 errors
- i18n parity 테스트: PASS
- build: EXIT 0

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>