### PR TITLE
[SID:2023] 색 토큰 규율 — 죽은 클래스 소생 + L5 위반 16곳 info 교체 + 근사표현 정식화

### DIFF
--- a/apps/web/src/app/(authenticated)/inbox/page.tsx
+++ b/apps/web/src/app/(authenticated)/inbox/page.tsx
@@ -469,7 +469,8 @@ export default function InboxPage() {
                         return (
                           <div key={`group-${item.key}`}>
                             <div className="relative flex items-stretch transition hover:bg-muted/40">
-                              {item.hasUnread ? <span className="absolute left-0 top-0 h-full w-0.5 bg-brand" aria-hidden /> : null}
+                              {/* story #2023 ⓑ: 미읽음=L5(시스템 상태), 브랜드 아님 */}
+                              {item.hasUnread ? <span className="absolute left-0 top-0 h-full w-0.5 bg-info" aria-hidden /> : null}
                               <button
                                 type="button"
                                 onClick={() => toggleGroup(item.key)}
@@ -494,7 +495,8 @@ export default function InboxPage() {
                                       <p className={`min-w-0 truncate text-sm ${item.hasUnread ? 'font-semibold text-foreground' : 'text-muted-foreground'}`}>
                                         {item.latest.title}
                                       </p>
-                                      <span className="shrink-0 rounded-full border border-brand/30 bg-brand/10 px-1.5 py-0.5 text-[10px] font-medium text-brand">
+                                      {/* story #2023 ⓑ: 카운트 칩=L5(시스템 상태), 브랜드 아님 */}
+                                      <span className="shrink-0 rounded-full border border-info/30 bg-info/10 px-1.5 py-0.5 text-[10px] font-medium text-info">
                                         {t('statusChangeCount', { count: item.count })}
                                       </span>
                                     </div>
@@ -529,8 +531,8 @@ export default function InboxPage() {
                           onClick={() => void selectNotification(notification)}
                           className={`relative flex w-full items-start gap-3 px-3 py-2.5 text-left transition ${isSelected ? 'bg-accent' : 'hover:bg-muted/40'}`}
                         >
-                          {/* 목업 ④: unread=좌측 accent strip(박시 카드 bg 대체) */}
-                          {!notification.is_read ? <span className="absolute left-0 top-0 h-full w-0.5 bg-brand" aria-hidden /> : null}
+                          {/* 목업 ④: unread=좌측 accent strip(박시 카드 bg 대체). story #2023 ⓑ: L5(시스템 상태), 브랜드 아님 */}
+                          {!notification.is_read ? <span className="absolute left-0 top-0 h-full w-0.5 bg-info" aria-hidden /> : null}
                           <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-white/6 text-muted-foreground">
                             <NotifIcon type={notification.type} fallback={Info} className="size-4" />
                           </div>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -107,6 +107,12 @@
   --color-info: var(--info);
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
+  /* story #2023(ⓐ): 값은 :root/.dark에 있었으나 @theme inline 매핑이 없어 Tailwind
+     유틸리티(bg-brand-soft 등)가 생성되지 않던 죽은 토큰 — 매핑 추가로 되살린다. */
+  --color-brand-soft: var(--brand-soft);
+  --color-brand-strong: var(--brand-strong);
+  --color-brand-contrast: var(--brand-contrast);
+  --color-info-foreground: var(--info-foreground);
   --color-primary-tint: var(--primary-tint);
   --color-priority: var(--priority);
   --color-accent-foreground: var(--accent-foreground);
@@ -230,6 +236,11 @@
   --success: oklch(0.55 0.16 145);
   --warning: oklch(0.75 0.16 85);
   --info: oklch(0.55 0.18 250);
+  /* story #2023(ⓐ): 신설 — L5(진행중·작업중·미읽음·측정·LLM 호출) 위반을 info로 교체하면서
+     배경(bg-info) 위 텍스트가 올라가는 자리가 생긴다. 라이트/다크가 반대로 필요(핸드오프
+     doc §3-3 실측: 흰 텍스트는 다크 bg-info 위에서 3.24:1 AA 미달) — --primary-foreground
+     다크값과 동일 패턴(어두운 남색)으로 보정. */
+  --info-foreground: oklch(0.985 0 0);
   --priority: oklch(0.65 0.18 50);
 
   /* Scrollbar */
@@ -342,6 +353,9 @@
   --success: oklch(0.65 0.15 145);
   --warning: oklch(0.70 0.16 85);
   --info: oklch(0.65 0.18 250);
+  /* story #2023(ⓐ): 라이트와 다른 값(어두운 남색) — 다크 bg-info는 밝은 파랑이라 밝은
+     텍스트로는 AA 미달(실측 3.24:1). --primary-foreground 다크와 동일 보정 패턴. */
+  --info-foreground: oklch(0.16 0.038 250);
   --priority: oklch(0.70 0.18 50);
 
   /* Scrollbar */

--- a/apps/web/src/app/internal-dogfood/page.tsx
+++ b/apps/web/src/app/internal-dogfood/page.tsx
@@ -187,7 +187,8 @@ export default async function InternalDogfoodPage({ searchParams }: PageProps) {
           <SectionCardBody className="text-sm text-muted-foreground">
             이 경로는 임시 Moonlabs 내부 dogfooding 전용인. auth plane 복구 후 env flag를 내리면 바로 비활성화되는 구조인.
             {' '}
-            <Link href="/login" className="text-[color:var(--brand-soft)] underline">일반 로그인 페이지로 이동</Link>
+            {/* story #2023 ⓒ(§5-2): 유틸 부재로 인한 var() 우회 참조를 정식 토큰으로 되돌림 — 평문 링크색, L1~L5 재분류 아님 */}
+            <Link href="/login" className="text-brand-soft underline">일반 로그인 페이지로 이동</Link>
           </SectionCardBody>
         </SectionCard>
       </div>

--- a/apps/web/src/components/agents/agent-run-detail.tsx
+++ b/apps/web/src/components/agents/agent-run-detail.tsx
@@ -461,7 +461,7 @@ export function AgentRunDetail({
                           hasError
                             ? 'border-destructive bg-destructive/20'
                             : isLlm
-                              ? 'border-brand bg-brand/20'
+                              ? 'border-info bg-info/20' /* story #2023 AC6: LLM 호출=info(기계 축), 브랜드 블루=인간 서명 전용 */
                               : 'border-success bg-success-tint'
                         }`} />
                         <div className="min-w-0 flex-1 rounded-xl border border-white/8 bg-white/4 px-3 py-2">

--- a/apps/web/src/components/chat/asset-picker-popover.tsx
+++ b/apps/web/src/components/chat/asset-picker-popover.tsx
@@ -177,8 +177,9 @@ export function AssetPickerPopover({ projectId, currentFolderId, onSelect, onClo
                 on ? 'border-transparent bg-info/10 font-semibold text-info' : 'border-border text-muted-foreground hover:bg-muted'
               }`}
             >
+              {/* story #2023 ⓑ: 상태 점=L5, 브랜드 아님 */}
               {s.id === 'project' ? (
-                <span className="inline-block size-[7px] rounded-full bg-brand" aria-hidden />
+                <span className="inline-block size-[7px] rounded-full bg-info" aria-hidden />
               ) : s.id === 'folder' ? (
                 <Folder className="size-3" aria-hidden />
               ) : null}

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -106,8 +106,9 @@ function ConversationRow({
         <span className="max-w-[80px] truncate rounded bg-muted px-1 py-0.5 font-medium text-muted-foreground">
           {others[0]?.name ?? '...'}
         </span>
+        {/* story #2023 ⓑ: L5(시스템 상태), 브랜드 아님 */}
         {isAgentInConv && (
-          <span className="flex-shrink-0 rounded border border-brand/30 bg-brand/12 px-1.5 py-0.5 text-[10px] font-medium text-brand-strong">
+          <span className="flex-shrink-0 rounded border border-info/30 bg-info/12 px-1.5 py-0.5 text-[10px] font-medium text-info">
             {t('agent')}
           </span>
         )}
@@ -121,8 +122,9 @@ function ConversationRow({
               className="relative flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded-full bg-muted text-[9px] font-medium text-muted-foreground ring-1 ring-background"
             >
               {p.name?.slice(0, 1) ?? '?'}
+              {/* story #2023 ⓑ: 죽은 클래스(bg-brand-strong 미매핑)이면서 L5 위반 — info로 교체해 둘 다 닫음 */}
               {p.type === 'agent' && (
-                <span className="absolute -bottom-px -right-px h-[6px] w-[6px] rounded-full bg-brand-strong ring-1 ring-background" />
+                <span className="absolute -bottom-px -right-px h-[6px] w-[6px] rounded-full bg-info ring-1 ring-background" />
               )}
             </div>
           ))}

--- a/apps/web/src/components/chat/presence-dot.tsx
+++ b/apps/web/src/components/chat/presence-dot.tsx
@@ -24,10 +24,10 @@ const STATUS_LABEL_KEY: Record<PresenceStatus, string> = {
 };
 
 /**
- * 활동 축 — working 시 avatar 래퍼에 덧대는 ring(brand pulse). dot과 별개(축 합침 금지).
- * prefers-reduced-motion 시 정적 ring(모션 0).
+ * 활동 축 — working 시 avatar 래퍼에 덧대는 ring(info pulse — L5 시스템 활동, story #2023
+ * ⓑ). dot과 별개(축 합침 금지). prefers-reduced-motion 시 정적 ring(모션 0).
  */
-export const WORKING_RING_CLASS = 'ring-2 ring-brand ring-offset-1 ring-offset-card motion-safe:animate-pulse';
+export const WORKING_RING_CLASS = 'ring-2 ring-info ring-offset-1 ring-offset-card motion-safe:animate-pulse';
 
 // 2505d27d: 패널은 큰 영역이라 prominent하게(size-3·12px) — 채팅 dot(size-2.5·10px)보다 가시성↑(모바일 교훈).
 const SIZE_CLASS = { sm: 'size-2.5', md: 'size-3' } as const;

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -564,7 +564,9 @@ export function DocContentRenderer({
     '[&_h2]:scroll-mt-24 [&_h2]:mt-10 [&_h2]:text-2xl [&_h2]:font-semibold',
     '[&_h3]:scroll-mt-24 [&_h3]:mt-8 [&_h3]:text-xl [&_h3]:font-semibold',
     '[&_p]:leading-7 [&_p]:text-foreground/92',
-    '[&_a]:text-[color:var(--brand-soft)] [&_a]:underline [&_a]:underline-offset-4',
+    // story #2023 ⓒ(§5-2): 유틸 부재로 인한 var() 우회 참조를 정식 토큰으로 되돌림 — 문서 본문
+    // 링크색, L1~L5 재분류 아님(콘텐츠 하이퍼링크는 서명·시스템상태 어느 축도 아님).
+    '[&_a]:text-brand-soft [&_a]:underline [&_a]:underline-offset-4',
     '[&_blockquote]:border-l-2 [&_blockquote]:border-border [&_blockquote]:bg-muted/30 [&_blockquote]:px-4 [&_blockquote]:py-3 [&_blockquote]:text-muted-foreground',
     '[&_img]:max-h-[32rem] [&_img]:w-full [&_img]:rounded-xl [&_img]:border [&_img]:border-border [&_img]:object-contain',
     '[&_table]:w-full [&_table]:border-collapse [&_table]:overflow-hidden [&_table]:rounded-xl [&_table]:border [&_table]:border-border [&_table]:bg-muted/20',

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -351,8 +351,9 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
                         title={m.name}
                       >
                         {getInitials(m.name)}
+                        {/* story #2023 ⓑ: 죽은 클래스(bg-brand-strong 미매핑)이면서 L5 위반 — info로 교체해 둘 다 닫음 */}
                         {m.type === 'agent' && (
-                          <span className="absolute -bottom-px -right-px h-[6px] w-[6px] rounded-full bg-brand-strong ring-1 ring-background" />
+                          <span className="absolute -bottom-px -right-px h-[6px] w-[6px] rounded-full bg-info ring-1 ring-background" />
                         )}
                       </div>
                     ))}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -80,7 +80,7 @@ interface StoryDetailPanelProps {
 
 function taskTone(status: string) {
   if (status === 'done') return 'bg-success';
-  if (status === 'in-progress') return 'bg-brand';
+  if (status === 'in-progress') return 'bg-info'; // story #2023 ⓑ: 진행중=시스템 상태(L5), 브랜드 아님
   return 'bg-background/20';
 }
 

--- a/apps/web/src/components/meetings/audio-recorder.tsx
+++ b/apps/web/src/components/meetings/audio-recorder.tsx
@@ -64,7 +64,7 @@ function SttProgressBar({ progress, label }: { progress: number; label: string }
       </div>
       <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
         <div
-          className="h-full rounded-full bg-brand transition-all duration-300"
+          className="h-full rounded-full bg-info transition-all duration-300" /* story #2023 ⓑ: 업로드 진행률=L5(측정/진행), 브랜드 아님 */
           style={{ width: `${Math.min(progress, 100)}%` }}
         />
       </div>

--- a/apps/web/src/components/presence/team-presence-panel.tsx
+++ b/apps/web/src/components/presence/team-presence-panel.tsx
@@ -8,8 +8,9 @@ import { cn } from '@/lib/utils';
 import type { TeamPresenceItem } from './use-team-presence';
 
 type GroupKey = 'working' | 'online' | 'offline';
+// story #2023(ⓑ): working=시스템 활동 신호(L5) — brand(인간 서명)가 아니라 info.
 const GROUP_DOT: Record<GroupKey, string> = {
-  working: 'bg-brand',
+  working: 'bg-info',
   online: 'bg-success',
   offline: 'bg-muted-foreground/40',
 };
@@ -53,12 +54,12 @@ function PresenceRow({ item }: { item: TeamPresenceItem }) {
         </p>
         <div className="truncate text-xs text-muted-foreground">
           {item.working ? (
-            <span className="inline-flex max-w-full items-center gap-1 text-brand">
+            <span className="inline-flex max-w-full items-center gap-1 text-info">
               <span className="shrink-0">{t('working')}</span>
               <span className="inline-flex shrink-0 gap-0.5" aria-hidden>
-                <span className="size-1 rounded-full bg-brand motion-safe:animate-bounce" />
-                <span className="size-1 rounded-full bg-brand motion-safe:animate-bounce [animation-delay:150ms]" />
-                <span className="size-1 rounded-full bg-brand motion-safe:animate-bounce [animation-delay:300ms]" />
+                <span className="size-1 rounded-full bg-info motion-safe:animate-bounce" />
+                <span className="size-1 rounded-full bg-info motion-safe:animate-bounce [animation-delay:150ms]" />
+                <span className="size-1 rounded-full bg-info motion-safe:animate-bounce [animation-delay:300ms]" />
               </span>
               {item.active_story ? (
                 <span className="truncate text-muted-foreground">· {t('assignedStory', { title: item.active_story.title })}</span>

--- a/apps/web/src/components/presence/team-presence-toggle.tsx
+++ b/apps/web/src/components/presence/team-presence-toggle.tsx
@@ -48,7 +48,8 @@ export function PresenceToggleButton() {
       <Users className="size-4" />
       {workingCount > 0 ? (
         <span
-          className="absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-brand px-1 text-[10px] font-bold tabular-nums text-brand-foreground"
+          // story #2023 ⓑ: working 카운트 배지=L5(시스템 상태). info-foreground는 §3-3에서 신설(다크 AA 보정 포함).
+          className="absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-info px-1 text-[10px] font-bold tabular-nums text-info-foreground"
           aria-hidden
         >
           {workingCount}

--- a/apps/web/src/components/settings/slack-integration-settings.tsx
+++ b/apps/web/src/components/settings/slack-integration-settings.tsx
@@ -231,7 +231,7 @@ export function SlackIntegrationSettingsSection() {
           <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
             <div className="space-y-1">
               <div className="flex items-center gap-2">
-                <MessageSquareShare className="size-4 text-[color:var(--brand-soft)]" />
+                <MessageSquareShare className="size-4 text-brand-soft" />
                 <h2 className="text-base font-semibold text-foreground">{t('title')}</h2>
               </div>
               <p className="text-sm text-muted-foreground">{t('description')}</p>
@@ -333,7 +333,7 @@ export function SlackIntegrationSettingsSection() {
             </div>
           ) : data.status === 'disconnected' ? (
             <GlassPanel className="border-dashed border-white/14 bg-muted/28 p-6 text-center">
-              <MessageSquareShare className="mx-auto size-9 text-[color:var(--brand-soft)]" />
+              <MessageSquareShare className="mx-auto size-9 text-brand-soft" />
               <h3 className="mt-4 text-lg font-semibold text-foreground">{t('disconnectedTitle')}</h3>
               <p className="mx-auto mt-2 max-w-2xl text-sm text-muted-foreground">{t('disconnectedBody')}</p>
               <div className="mt-5 flex flex-wrap items-center justify-center gap-3">
@@ -349,7 +349,7 @@ export function SlackIntegrationSettingsSection() {
             </GlassPanel>
           ) : filteredChannels.length === 0 ? (
             <GlassPanel className="border-dashed border-white/14 bg-muted/28 p-6 text-center">
-              <MessageSquareShare className="mx-auto size-9 text-[color:var(--brand-soft)]" />
+              <MessageSquareShare className="mx-auto size-9 text-brand-soft" />
               <h3 className="mt-4 text-lg font-semibold text-foreground">{t('emptyTitle')}</h3>
               <p className="mx-auto mt-2 max-w-2xl text-sm text-muted-foreground">{t('emptyBody')}</p>
             </GlassPanel>
@@ -424,7 +424,7 @@ export function SlackIntegrationSettingsSection() {
                           </Button>
                         </div>
                         {mappedElsewhere ? (
-                          <div className="xl:col-span-2 rounded-2xl border border-brand/18 bg-brand/10 px-3 py-3 text-sm text-[color:var(--brand-soft)]">
+                          <div className="xl:col-span-2 rounded-2xl border border-brand/18 bg-brand/10 px-3 py-3 text-sm text-brand-soft">
                             {t('mappedElsewhereHint', { project: currentMapping?.project_name ?? t('unknownProject') })}
                           </div>
                         ) : null}

--- a/apps/web/src/components/storage/storage-folder-tree.tsx
+++ b/apps/web/src/components/storage/storage-folder-tree.tsx
@@ -177,7 +177,8 @@ export function StorageFolderTree({
           type="button"
           className="flex w-full items-center gap-2 rounded-[0.5rem] border border-border bg-card px-[10px] py-2 text-[12px] text-foreground"
         >
-          <span className="size-2 shrink-0 rounded-full bg-brand" />
+          {/* story #2023 ⓑ: 상태 점=L5, 브랜드 아님 */}
+          <span className="size-2 shrink-0 rounded-full bg-info" />
           <span className="truncate">{projectName ?? 'Sprintable'}</span>
           <ChevronDown className="ml-auto size-3.5 shrink-0 opacity-50" />
         </button>

--- a/apps/web/src/components/storage/storage-source-usage-list.tsx
+++ b/apps/web/src/components/storage/storage-source-usage-list.tsx
@@ -20,11 +20,14 @@ const TYPE_ICON: Record<AssetSourceLinkType, LucideIcon> = {
   manual: Paperclip,
 };
 
-// 목업 `.uic.*` 토큰 매핑. conversation: --brand-soft 유틸리티 부재 → bg-brand/15 로 근사(NOTE).
+// story #2023 ⓒ(핸드오프 §5-1): conversation은 원래 --brand-soft 유틸리티 부재로 bg-brand/15
+// 근사였다 — 브랜드 블루는 인간 서명 축인데 이 자리는 첨부파일 "출처 분류"(story/doc/
+// conversation/manual) 축이라 서명과 무관하다. 브랜드 계열을 아예 안 쓰고 중립 계열(secondary)
+// 로 간다 — manual(muted)과는 다른 톤이라 4분류 시각 구분은 유지된다.
 const TYPE_TINT: Record<AssetSourceLinkType, string> = {
   story: 'bg-info/15 text-info',
   doc: 'bg-success/15 text-success',
-  conversation_message: 'bg-brand/15 text-brand',
+  conversation_message: 'bg-secondary text-secondary-foreground',
   manual: 'bg-muted text-muted-foreground',
 };
 


### PR DESCRIPTION
유나 핸드오프(doc \`67e83179\`, brand 토큰 사용처 106건 전수)를 순서대로 반영: **ⓐ 토큰 매핑 → ⓑ L5 위반을 info로 → ⓒ 근사·우회 표현을 정식 토큰으로**.

## ⓐ 토큰 매핑 — 죽은 클래스 소생
\`--brand-soft\`/\`--brand-strong\`/\`--brand-contrast\`는 값은 있었으나 \`@theme inline\` 매핑이 없어 Tailwind 유틸리티가 생성되지 않았다(실측: \`bg-brand-strong\`이 빌드 CSS에 문자열조차 없었음 — 온라인 점이 조용히 깨져 있었다). 매핑 4개 추가(brand-soft/strong/contrast + 신설 \`--info-foreground\`).

**신설 \`--info-foreground\`**: L5를 info로 옮기면 배경 위 텍스트 자리(team-presence-toggle 배지)가 생기는데 라이트/다크가 반대로 필요(다크 bg-info 위 흰 텍스트 실측 3.24:1 AA 미달) — \`--primary-foreground\` 다크와 동일 보정 패턴 재사용.

독립 재검증(OKLab 역변환+감마 인코딩): info+info-foreground 라이트 4.59:1/다크 5.99:1 — 문서 실측(4.61/5.98)과 오차 0.02 이내, AA 통과.

## ⓑ L5(AI·자동·시스템 상태) 위반 16곳 → info
브랜드 블루=인간 서명(§4-1)인데 진행중/작업중/미읽음/측정/**LLM 호출**에 브랜드가 섞여 있었다.

- \`agent-run-detail.tsx\`: LLM 호출 타임라인 점(같은 항목 배지는 이미 info인데 점만 브랜드였음)
- \`team-presence-panel.tsx\`(×5)·\`presence-dot.tsx\`(WORKING_RING_CLASS)·\`story-detail-panel.tsx\`·\`audio-recorder.tsx\`(진행률 바만, 드래그 상태는 L4라 미터치)
- \`inbox/page.tsx\`(×3)·\`team-presence-toggle.tsx\`(§3-3 신설분 최초 소비처)
- \`storage-folder-tree.tsx\`·\`asset-picker-popover.tsx\`(상태 점)
- \`chat-list-view.tsx\`(×2)·\`story-card.tsx\`: 죽은 클래스이면서 동시에 L5 위반 — 교체로 두 문제 함께 닫음

전체 \`git grep\` 스윕으로 잔여 \`-brand\` 사용처 전수 확인 — L1(브랜드 서명)·L3(포커스링/accent)·L4(§6 명시 별건: 문서 에디터·목업 에디터·에이전트 정책 화면)만 남음. 놓친 L5 없음.

⚠️ JSX 조건부 렌더 내부에 주석을 형제처럼 넣어 구문 오류 3곳 — 즉시 발견해 주석을 조건식 밖으로 이동, type-check 재확인.

## ⓒ 근사·우회 표현 정식화
- \`storage-source-usage-list.tsx\`(§5-1): conversation_message tint가 브랜드 근사(\`bg-brand/15\`)였다 — 서명 축 아닌 분류 축이라 중립(secondary)으로.
- \`var(--brand-soft)\` 우회 참조 중 순수 링크·아이콘 색만 정식 유틸로 되돌림: internal-dogfood, doc-content-renderer, slack-integration-settings(×3).
- \`agent-hitl-policy-editor.tsx\`(4곳)는 핸드오프 doc이 "에이전트 정책 화면이면 L5일 수 있다"고 명시 경고한 자리라 **판정 없이 갈아끼우지 않고 PO 판단 대기로 남김**. L4로 이미 분류된 파일들의 var() 참조도 이번 스코프 밖.

## 라이브 검증
로컬 dev에 \`bg-info\`+\`text-info-foreground\`(§3-3 핵심 신규 패턴) 실 마운트 — 라이트/다크 스크린샷 확認, 다크에서 어두운 남색 텍스트로 정상 legible.

## 게이트
- type-check/lint: 0 errors
- build: EXIT 0

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>