### PR TITLE
[SID:2056] 조직 브리핑이 계정 핸들로 인사하던 것 — 조직 내 멤버 이름으로 교차조회

### DIFF
--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -4,6 +4,7 @@ import { getServerSession } from '@/lib/db/server';
 import { buildLoginRedirect } from '@/lib/auth/session-redirect';
 import { DashboardShell } from '../dashboard/dashboard-shell';
 import { StorageCapacityToastProvider } from '@/components/storage/storage-capacity-toast-provider';
+import { resolveOrgMemberName } from '@/lib/resolve-member-name';
 
 interface MemberContext {
   id: string;
@@ -76,12 +77,15 @@ export default async function AuthenticatedLayout({
   // 현재 project의 slug가 필요 — /me/memberships는 slug를 안 실어 보내(BE 스코프 밖, FE 단독
   // 수정 범위 유지 위해 이미 존재하는 단건 조회를 재사용). 실패해도 sidebar/cmd-palette는
   // bare `/docs`로 폴백해 미들웨어 리다이렉트 안전망을 타므로 무해.
-  const currentProjectSlug = me?.project_id
-    ? await fetch(`${fastapiUrl}/api/v2/projects/${me.project_id}`, { headers: authHeader, cache: 'no-store' })
-        .then((r) => (r.ok ? r.json() : null))
-        .then((json: { slug?: string | null } | null) => json?.slug ?? undefined)
-        .catch(() => undefined)
-    : undefined;
+  const [currentProjectSlug, userName] = await Promise.all([
+    me?.project_id
+      ? fetch(`${fastapiUrl}/api/v2/projects/${me.project_id}`, { headers: authHeader, cache: 'no-store' })
+          .then((r) => (r.ok ? r.json() : null))
+          .then((json: { slug?: string | null } | null) => json?.slug ?? undefined)
+          .catch(() => undefined)
+      : undefined,
+    resolveOrgMemberName(fastapiUrl, authHeader, me?.id, me?.name),
+  ]);
 
   return (
     <DashboardShell
@@ -90,7 +94,7 @@ export default async function AuthenticatedLayout({
       projectId={me?.project_id}
       projectName={me?.project_name ?? undefined}
       currentProjectSlug={currentProjectSlug}
-      userName={me?.name}
+      userName={userName}
       role={me?.role}
       projectMemberships={projectMemberships}
       orgMemberships={orgMemberships}

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { getServerSession } from '@/lib/db/server';
 import { DashboardShell } from './dashboard-shell';
+import { resolveOrgMemberName } from '@/lib/resolve-member-name';
 
 interface MemberContext {
   id: string;
@@ -51,13 +52,15 @@ export default async function DashboardLayout({
     role: o.role,
   }));
 
+  const userName = await resolveOrgMemberName(fastapiUrl, authHeader, me?.id, me?.name);
+
   return (
     <DashboardShell
       currentTeamMemberId={me?.id}
       orgId={me?.org_id}
       projectId={me?.project_id}
       projectName={me?.project_name ?? undefined}
-      userName={me?.name}
+      userName={userName}
       projectMemberships={projectMemberships}
       orgMemberships={orgMemberships}
     >

--- a/apps/web/src/lib/resolve-member-name.test.ts
+++ b/apps/web/src/lib/resolve-member-name.test.ts
@@ -1,0 +1,51 @@
+// story #2056 — 조직 브리핑/사이드바 인사가 계정 핸들("sellerking")을 쓰던 회귀 재현.
+// `/api/v2/me`의 name은 org-level grant-only/owner 휴먼일 때 User.display_name(계정 핸들)로
+// 폴백하지만, `/api/v2/team-members`(org-level)는 org_members SSOT를 직접 해소해 올바른
+// 조직 내 이름을 돌려준다(id로 교차조회 가능). 이 테스트는 그 교차조회 로직 자체를 잠근다.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolveOrgMemberName } from './resolve-member-name';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('resolveOrgMemberName — story #2056', () => {
+  it('team-members에서 id가 일치하는 멤버의 name을 쓴다(계정 핸들 아님)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => [
+          { id: 'other-member', name: '다른 사람' },
+          { id: 'me-id-1', name: '송윤재' },
+        ],
+      })),
+    );
+
+    const name = await resolveOrgMemberName('http://fastapi', {}, 'me-id-1', 'sellerking');
+    expect(name).toBe('송윤재');
+  });
+
+  it('team-members 조회 실패 시 계정 이름으로 폴백한다(AC2)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false })));
+    const name = await resolveOrgMemberName('http://fastapi', {}, 'me-id-1', 'sellerking');
+    expect(name).toBe('sellerking');
+  });
+
+  it('id가 목록에 없으면 계정 이름으로 폴백한다(AC2)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => [{ id: 'someone-else', name: '다른 사람' }] })),
+    );
+    const name = await resolveOrgMemberName('http://fastapi', {}, 'me-id-1', 'sellerking');
+    expect(name).toBe('sellerking');
+  });
+
+  it('meId가 없으면 fetch 없이 계정 이름으로 폴백한다', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const name = await resolveOrgMemberName('http://fastapi', {}, undefined, 'sellerking');
+    expect(name).toBe('sellerking');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/resolve-member-name.ts
+++ b/apps/web/src/lib/resolve-member-name.ts
@@ -1,0 +1,22 @@
+// story #2056: `/api/v2/me`의 name은 TeamMember 행을 못 찾는 경우(org-level grant-only/owner
+// 휴먼) User.display_name(계정 핸들)로 폴백한다 — 조직 안의 신원(멤버 레코드)이 아니다.
+// `/api/v2/team-members`(org-level, project_id 미지정)는 org_members SSOT를 직접 해소해
+// 이 경우에도 올바른 조직 내 이름을 돌려준다(story S:166051f0). id는 두 응답 모두 동일
+// canonical 값(TeamMember.id 또는 org_member.id)이라 id 매칭으로 교차조회할 수 있다.
+export async function resolveOrgMemberName(
+  fastapiUrl: string,
+  authHeader: Record<string, string>,
+  meId: string | undefined,
+  fallbackName: string | undefined,
+): Promise<string | undefined> {
+  if (!meId) return fallbackName;
+  try {
+    const res = await fetch(`${fastapiUrl}/api/v2/team-members`, { headers: authHeader, cache: 'no-store' });
+    if (!res.ok) return fallbackName;
+    const members = (await res.json()) as Array<{ id?: string; name?: string }>;
+    const match = members.find((m) => m.id === meId);
+    return match?.name ?? fallbackName;
+  } catch {
+    return fallbackName;
+  }
+}


### PR DESCRIPTION
댄 어윈 발견(P5 촬영 중): 팀 멤버 목록 API는 name: "송윤재"를 정확히 돌려주는데, 조직 브리핑 헤딩은 "sellerking, here's your org today"로 계정 핸들을 썼다.

## 근본원인 (BE 코드 확인, FE만 수정)
`/api/v2/me`(backend/app/routers/me.py)는 두 경로를 갖는다:
- 정상: `TeamMember` 행을 찾으면 `member.name` 그대로.
- **폴백**(org-level grant-only/owner 휴먼처럼 TeamMember 행이 없는 경우): `name = (user.display_name or user.email)` — **계정 레벨 이름으로 조용히 대체된다.** sellerking 테스트 계정이 정확히 이 폴백 경로를 탄다.

반면 `/api/v2/team-members`(org-level, project_id 미지정)는 story S:166051f0 이후 `org_members` SSOT를 **직접** 해소해 grant-only/owner 휴먼도 올바른 이름으로 반환한다 — 두 응답의 `id`는 동일 canonical 값이라 id로 교차조회할 수 있다.

## 수정 (apps/web만, backend 미변경)
- `lib/resolve-member-name.ts`(신규): `/api/v2/team-members`(org-level)를 조회해 `me.id`와 일치하는 항목의 `name`을 쓴다. 못 찾거나 fetch 실패 시 기존 `me.name`으로 폴백한다(AC2).
- `(authenticated)/layout.tsx`·`dashboard/layout.tsx`(중복 경로 둘 다): `userName`을 `resolveOrgMemberName()` 결과로 교체.

## AC3 — 같은 값을 쓰는 다른 자리 전수 확認
`userName`은 두 layout에서만 만들어져 `DashboardCtx`를 거쳐 정확히 두 곳(`AppSidebar`의 `ProfileMenu`, `org-briefing-shell`의 인사말)에서만 소비된다. grep으로 전수 확인 — 이 두 곳 외 `userName`을 직접 읽는 자리 없음. 인사말만 고쳤다면 사이드바에 계정 핸들이 남아 "한 화면에 두 이름" 문제가 났을 것.

## 검증
- 라이브(dev, sellerking/송윤재 재현 조건): 수정 전 `/org-briefing`에서 **"sellerking님, 오늘 조직의 지금이에요"** 실측 확認 — 배포 후 "송윤재님"으로 바뀌는지가 진짜 게이트(PO가 배포 후 직접 확認 예정, #2050과 동일 패턴).
- 단위테스트(`resolve-member-name.test.ts`, 4개 PASS): id 일치 시 멤버 이름 사용·fetch 실패 폴백·id 불일치 폴백·meId 없으면 fetch 생략.
- type-check/lint: 0 errors. build: EXIT 0.

## 미완(AC5)
조직 전환 시 그 조직의 멤버 이름으로 바뀌는지는 배포 후 실 조직 전환으로 확인 필요.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>