### PR TITLE
[SID:bb93ada4] #2056 — /me org-member 폴백이 계정 핸들 대신 members 앵커 정본 이름 반환하도록

### DIFF
--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -73,8 +73,21 @@ async def get_me(
             if org_member:
                 user_result = await session.execute(select(User).where(User.id == uid))
                 user = user_result.scalar_one_or_none()
+                # SID bb93ada4/#2056: canonical members 앵커의 name이 정본(update_me PATCH가
+                # 여기 쓴다 — line ~247). 이 GET 폴백은 그동안 users.display_name만 읽어
+                # /team-members(정본 이름 "송윤재")와 조직 브리핑 인사말(계정 핸들
+                # "sellerking")이 다른 값을 보여주는 "이름 출처 두 곳" 결함이었다. members
+                # 앵커 우선 조회, 없거나 비어있을 때만 display_name/email로 떨어진다.
+                member_anchor = (await session.execute(
+                    select(Member.name).where(
+                        Member.user_id == uid,
+                        Member.org_id == uuid.UUID(org_id_str),
+                        Member.type == "human",
+                        Member.deleted_at.is_(None),
+                    )
+                )).scalar_one_or_none()
                 # E-ONBOARDING S2: display_name 우선, 없을 때만 email (기존 무조건 email → 실명 반영)
-                name = (user.display_name or user.email) if user else str(uid)
+                name = member_anchor or ((user.display_name or user.email) if user else str(uid))
                 try:
                     proj_id = uuid.UUID(project_id_str) if project_id_str else org_member.org_id
                 except (ValueError, AttributeError):

--- a/backend/tests/test_e_onboarding_s2_me_realname.py
+++ b/backend/tests/test_e_onboarding_s2_me_realname.py
@@ -1,6 +1,11 @@
 """E-ONBOARDING S2: /me 실명+email — 스키마 노출 + org-member fallback name 우선순위.
 
 데모 centerpiece: 초대 멤버가 가입해도 이름이 '-'/email로 뜨지 않고 실명(display_name) 반영.
+
+SID bb93ada4/#2056: 이 폴백은 users.display_name/email만 읽어 canonical members 앵커
+(update_me PATCH가 쓰는 정본 이름 — /team-members가 읽는 그 값)와 어긋날 수 있었다
+("송윤재" 멤버 앵커 vs "sellerking" 계정 핸들이 동시에 존재하던 실제 버그). members 앵커를
+최우선으로 조회하도록 갱신 — display_name/email 폴백 순서는 앵커가 없을 때만 그대로 유지.
 """
 from __future__ import annotations
 
@@ -32,8 +37,9 @@ def test_org_member_response_exposes_name():
 
 # ── org-member fallback: display_name 우선, email은 폴백 ──────────────────────
 
-def _fallback_session(user):
-    """member 없음 → org_member 존재 → user 조회 순서로 execute side_effect 구성."""
+def _fallback_session(user, member_anchor_name=None):
+    """TeamMember 없음 → org_member 존재 → user 조회 → members 앵커 name 조회 순서로
+    execute side_effect 구성(SID bb93ada4/#2056: 앵커 조회가 마지막에 추가됨)."""
     org_member = MagicMock()
     org_member.id = uuid.uuid4()
     org_member.org_id = uuid.uuid4()
@@ -45,9 +51,11 @@ def _fallback_session(user):
     om_result.scalar_one_or_none.return_value = org_member
     user_result = MagicMock()
     user_result.scalar_one_or_none.return_value = user
+    anchor_result = MagicMock()
+    anchor_result.scalar_one_or_none.return_value = member_anchor_name
 
     s = AsyncMock()
-    s.execute = AsyncMock(side_effect=[member_result, om_result, user_result])
+    s.execute = AsyncMock(side_effect=[member_result, om_result, user_result, anchor_result])
     return s, org_member
 
 
@@ -61,26 +69,42 @@ def _auth(org_id):
 
 
 @pytest.mark.anyio
-async def test_fallback_prefers_display_name():
+async def test_fallback_prefers_display_name_when_no_member_anchor():
     user = MagicMock()
     user.display_name = "초대된 실명"
     user.email = "invited@example.com"
     user.hashed_password = "x"
     org_id = uuid.uuid4()
-    session, _ = _fallback_session(user)
+    session, _ = _fallback_session(user, member_anchor_name=None)
     res = await get_me(member_id=None, session=session, auth=_auth(org_id))
-    assert res.name == "초대된 실명"  # display_name 우선
+    assert res.name == "초대된 실명"  # 앵커 없으면 display_name 우선(기존 폴백 순서 유지)
     assert res.email == "invited@example.com"  # email 노출
 
 
 @pytest.mark.anyio
-async def test_fallback_uses_email_when_no_display_name():
+async def test_fallback_uses_email_when_no_display_name_and_no_member_anchor():
     user = MagicMock()
     user.display_name = None
     user.email = "invited@example.com"
     user.hashed_password = "x"
     org_id = uuid.uuid4()
-    session, _ = _fallback_session(user)
+    session, _ = _fallback_session(user, member_anchor_name=None)
     res = await get_me(member_id=None, session=session, auth=_auth(org_id))
-    assert res.name == "invited@example.com"  # display_name 없으면 email 폴백
+    assert res.name == "invited@example.com"  # display_name도 앵커도 없으면 email 폴백
     assert res.email == "invited@example.com"
+
+
+@pytest.mark.anyio
+async def test_fallback_prefers_member_anchor_over_display_name_and_email():
+    """⭐SID bb93ada4/#2056 핵심 회귀 게이트 — 실제 버그 재현: members 앵커 이름("송윤재")과
+    계정 display_name/email("sellerking")이 다를 때, 앵커가 이겨야 한다(조직 브리핑 인사말이
+    /team-members와 같은 이름을 봐야 한다)."""
+    user = MagicMock()
+    user.display_name = "sellerking"  # 계정 핸들 — 이게 실제 버그에서 뜨던 값
+    user.email = "sellerking@example.com"
+    user.hashed_password = "x"
+    org_id = uuid.uuid4()
+    session, _ = _fallback_session(user, member_anchor_name="송윤재")
+    res = await get_me(member_id=None, session=session, auth=_auth(org_id))
+    assert res.name == "송윤재"  # members 앵커가 display_name/email보다 우선
+    assert res.email == "sellerking@example.com"  # email 필드 자체는 계정 값 그대로


### PR DESCRIPTION
## Summary
조직 브리핑이 사람 이름 대신 계정 핸들("sellerking")로 인사하던 결함(P5 촬영 블로커). `/team-members`는 같은 사람을 정본 이름("송윤재")으로 정확히 반환하는데, `GET /me`의 org-member 폴백(TeamMember 행이 없는 org-member-only 휴먼 경로)은 `users.display_name/email`만 읽고 `update_me` PATCH가 실제로 쓰는 canonical `members` 앵커(`Member.name`)를 조회하지 않았다 — "이름 출처가 두 곳"이던 비대칭.

- `members` 앵커(`org_id`+`user_id`+`type='human'`) 조회를 최우선으로, 없거나 비어있을 때만 기존 `display_name`→`email` 폴백 순서를 그대로 유지(무회귀).
- FE 교차조회가 아니라 BE에서 고친 이유: `/me.name`은 여러 화면의 공통 소스라 여기서 고치면 한 번에 전부 맞는다(다른 소비자가 여전히 틀린 이름을 받는 상태를 남기지 않음).

## Test plan
- [x] `test_e_onboarding_s2_me_realname.py` 5 passed — 신규 회귀 케이스(앵커 "송윤재" vs display_name "sellerking" 동시 존재 시 앵커 우선, 실제 버그 재현 시나리오)
- [x] 인접 onboarding/S-MBR-03 스위트 18 passed
- [x] `python -c "from app.main import app"` — 489 routes, import 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)