### PR TITLE
[SID:2054] Gate/HitlRequest 통합 결재함 인박스 GET /api/v2/gates/inbox

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -2,10 +2,10 @@
 import logging
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -13,6 +13,7 @@ from app.dependencies.auth import get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.doc import Doc
 from app.models.gate import Gate, is_valid_transition
+from app.models.hitl import HitlRequest
 from app.models.pm import Story, Task
 from app.routers.agent_gateway import wake_agent
 from app.services.gate_service import (
@@ -106,6 +107,10 @@ class WorkItemSummary(BaseModel):
 class GateResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
+    # story #2054: 결재함 통합 인박스(/gates/inbox)에서 Gate/HitlRequest 두 출처를 구분하는
+    # discriminator. 기존 단독 엔드포인트(list_gates/get_gate/transition 등)는 항상 "gate"
+    # 고정값 — additive, 기존 응답 shape 비파괴.
+    source: Literal["gate"] = "gate"
     id: uuid.UUID
     org_id: uuid.UUID
     # story #1970(P1a-S4): GET /{id} 단건 조회 신규 enrich(Gate 모델 자체엔 project_id 컬럼이
@@ -417,6 +422,179 @@ async def list_gates(
         elif g.id in eligible_ids:
             filtered.append(resp)
     return filtered
+
+
+class HitlInboxItem(BaseModel):
+    """story #2054: `agent_hitl_requests`(gate_approval 종류) 결재함 인박스 노출용 최소 스키마.
+
+    Gate와 별도 API로 승인/거부(`PATCH /hitl/requests/{id}`)하므로 GateResponse 필드를 그대로
+    빌리지 않는다 — `source` 로 FE가 액션 라우팅. 미르코(FE)와 합의한 계약(conversation
+    eaa1b6cb-5d73-4019-bca8-7e320087f827) 그대로: id/request_type/title/prompt/status/
+    requires_human/work_item_id/work_type/created_at/expires_at.
+    """
+    model_config = ConfigDict(from_attributes=True)
+
+    source: Literal["hitl"] = "hitl"
+    id: uuid.UUID
+    request_type: str
+    title: str
+    prompt: str
+    status: str
+    # gate_enforce.py _SAFETY_FLOOR: work_type='merge'는 최소 ask — HitlRequest로 park된 항목은
+    # 정의상 항상 사람 승인 대상이라 고정 True(Gate.requires_human과 동형 의미).
+    requires_human: bool = True
+    work_item_id: uuid.UUID | None = None
+    work_type: str | None = None
+    created_at: datetime
+    expires_at: datetime | None = None
+
+
+# gate_enforce.py:22/gate_metrics.py:24 선례(cross-module import 대신 로컬 재선언) — HitlRequest 중
+# 결재함 인박스가 다루는 부분집합(merge/done 게이트 승인 park)만. 그 외 request_type(예: 수동
+# HITL 승인 요청)은 #2054 스코프 밖(별도 화면 유지) — Gate와 동일 병목에서 충돌하는 것만 통합.
+_GATE_REQUEST_TYPE = "gate_approval"
+
+
+async def _list_hitl_inbox_rows(
+    session: AsyncSession, org_id: uuid.UUID, status: str | None,
+) -> list[HitlRequest]:
+    q = select(HitlRequest).where(
+        HitlRequest.org_id == org_id,
+        HitlRequest.request_type == _GATE_REQUEST_TYPE,
+        HitlRequest.deleted_at.is_(None),
+    )
+    if status:
+        q = q.where(HitlRequest.status == status)
+    return list((await session.execute(q)).scalars().all())
+
+
+def _hitl_item_from_row(r: HitlRequest) -> HitlInboxItem:
+    meta = r.hitl_metadata or {}
+    wi_raw = meta.get("work_item_id")
+    try:
+        work_item_id = uuid.UUID(wi_raw) if wi_raw else None
+    except (ValueError, TypeError, AttributeError):
+        work_item_id = None
+    return HitlInboxItem(
+        id=r.id,
+        request_type=r.request_type,
+        title=r.title,
+        prompt=r.prompt,
+        status=r.status,
+        work_item_id=work_item_id,
+        work_type=meta.get("work_type"),
+        created_at=r.created_at,
+        expires_at=r.expires_at,
+    )
+
+
+@router.get(
+    "/inbox",
+    response_model=list[Annotated[GateResponse | HitlInboxItem, Field(discriminator="source")]],
+)
+async def list_gate_inbox(
+    status: str | None = Query(default=None),
+    sort: str | None = Query(default=None),
+    assigned_to_me: bool = Query(default=False),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> list[GateResponse | HitlInboxItem]:
+    """story #2054: `Gate`(결재함)와 `HitlRequest`(gate_approval park) 통합 조회 — 두 체계가
+    같은 승인 병목(merge)에서 서로를 못 보던 결함 해소. 데이터모델은 안 합치고(Gate 미러 생성
+    금지 — 오르테가 판정) 이 read-layer에서만 통합. 액션은 각자 native API로
+    (`PATCH /gates/{id}/transition` vs `PATCH /hitl/requests/{id}`) — `source` 필드로 라우팅.
+
+    미르코(FE)와 합의한 계약(conversation eaa1b6cb): 페이지네이션 없음(기존 GET /gates 관례 유지)·
+    기본 정렬 created_at DESC·`sort=urgency`는 Gate 쪽 기존 SLA 로직 그대로 + HitlRequest는
+    age(created_at)만으로 같은 정렬축에 끼워 넣는 best-effort(HitlRequest엔 SLA/held 개념이 없어
+    완전 동형 아님 — 이는 미리 합의된 단순화).
+    """
+    gate_items = await list_gates(
+        work_item_id=None, work_item_type=None, status=status, sort=sort,
+        assigned_to_me=assigned_to_me, session=session, org_id=org_id, auth=auth,
+    )
+    hitl_rows = await _list_hitl_inbox_rows(session, org_id, status)
+
+    if assigned_to_me:
+        # Gate의 non-doc assigned_to_me(WHO)와 동일 규칙 재사용: gate_approval park 대상
+        # work_item_id는 실무상 항상 Story(work_type∈{done,merge}는 story 라이프사이클 단계) —
+        # project 해소되면 project owner/admin, 구조적으로 project-무관이면 org owner/admin.
+        resolved = None
+        _uid: uuid.UUID | None = None
+        if hitl_rows:
+            try:
+                resolved = await resolve_member(auth, org_id, session)
+                _uid = uuid.UUID(auth.user_id)
+            except Exception:  # noqa: BLE001 — caller resolve 실패는 목록 비중단(fail-closed).
+                logger.warning(
+                    "list_gate_inbox hitl caller resolve 실패(비중단) org=%s", org_id, exc_info=True,
+                )
+        if resolved is None or resolved.type != "human":
+            hitl_rows = []
+        else:
+            story_ids = set()
+            parsed: dict[uuid.UUID, uuid.UUID | None] = {}
+            for r in hitl_rows:
+                wi_raw = (r.hitl_metadata or {}).get("work_item_id")
+                try:
+                    wid = uuid.UUID(wi_raw) if wi_raw else None
+                except (ValueError, TypeError, AttributeError):
+                    wid = None
+                parsed[r.id] = wid
+                if wid is not None:
+                    story_ids.add(wid)
+            project_by_story: dict[uuid.UUID, uuid.UUID] = {}
+            if story_ids:
+                rows = (await session.execute(
+                    select(Story.id, Story.project_id).where(
+                        Story.id.in_(story_ids), Story.org_id == org_id,
+                    )
+                )).all()
+                project_by_story = {sid: pid for sid, pid in rows}
+            role_cache: dict[uuid.UUID, bool] = {}
+            org_admin_cache: bool | None = None
+            eligible: list[HitlRequest] = []
+            for r in hitl_rows:
+                pid = project_by_story.get(parsed.get(r.id))
+                if pid is not None:
+                    if pid not in role_cache:
+                        role_cache[pid] = await _non_doc_gate_approvable(session, _uid, org_id, pid)
+                    ok = role_cache[pid]
+                else:
+                    if org_admin_cache is None:
+                        org_admin_cache = await _non_doc_gate_approvable(session, _uid, org_id, None)
+                    ok = org_admin_cache
+                if ok:
+                    eligible.append(r)
+            hitl_rows = eligible
+
+    hitl_items = [_hitl_item_from_row(r) for r in hitl_rows]
+
+    if sort == "urgency":
+        # Gate 쪽은 이미 (held_rank, overdue_rank, created_at ASC)로 정렬돼 도착 — HitlRequest는
+        # SLA/held 개념이 없어 "non-held·non-overdue" 티어(각 rank=0/1 아님 held=0-tier 아님 →
+        # overdue_rank=1 동일 티어)로 취급하고 age(created_at ASC)만으로 그 안에 merge. 안정 정렬
+        # (Python Timsort)로 gate_items의 기존 상대순서는 보존된다.
+        # ⚠️정직한 단순화(미리 합의): gate_items의 overdue 여부는 SQL(apply_gate_urgency_sort의
+        # correlated EXISTS)에서만 판정되고 GateResponse엔 그 필드가 노출되지 않는다 — 파이썬
+        # 레벨에서 gate/hitl 총정렬을 다시 만드는 이상 overdue 랭크는 재구성 불가하므로 여기선
+        # held(가진 필드로 재확인 가능)만 최하단 유지하고, 나머지는 age(created_at ASC) 단일
+        # 축으로 합친다. 결과적으로 "overdue gate가 항상 non-overdue보다 위"라는 하드 보장은
+        # 없어지고 age로 근사(실무상 overdue는 대개 오래된 항목이라 대체로 유지되나 보장은 아님) —
+        # 미르코와 합의한 "HitlRequest는 age 기준으로만 끼워 넣는다"는 문구 그대로의 트레이드오프.
+        combined: list[GateResponse | HitlInboxItem] = list(gate_items) + list(hitl_items)
+        combined.sort(
+            key=lambda it: (
+                1 if (isinstance(it, GateResponse) and it.held_until and it.held_until > datetime.now(it.held_until.tzinfo)) else 0,
+                it.created_at,
+            )
+        )
+        return combined
+
+    combined = list(gate_items) + list(hitl_items)
+    combined.sort(key=lambda it: it.created_at, reverse=True)
+    return combined
 
 
 async def _resolve_work_item_summary(

--- a/backend/tests/test_2054_gate_inbox.py
+++ b/backend/tests/test_2054_gate_inbox.py
@@ -1,0 +1,429 @@
+"""story #2054: 결재함(Gate) + HITL 승인 대기(HitlRequest) 통합 인박스 ``GET /api/v2/gates/inbox``.
+
+배경: `Gate`(``/gates``·`/gates/[id]` 화면)와 `HitlRequest`(``enforce_gate()``가 파킹·
+``/organization/workforce/hitl`` 화면)가 같은 승인 병목(merge/done)에서 각각 독립적으로 발동하는데
+서로를 못 봐서, 사람이 한쪽 화면만 보고 승인했다고 믿어도 다른 쪽 대기가 남아 있을 수 있었다.
+오르테가 판정: 데이터모델은 안 합치고(Gate 미러 생성 금지) **read-layer만** 통합 — 액션은 각자
+native API로(``PATCH /gates/{id}/transition`` vs ``PATCH /hitl/requests/{id}``).
+
+미르코(FE)와 합의한 계약(conversation eaa1b6cb-5d73-4019-bca8-7e320087f827):
+  - 페이지네이션 없음(기존 ``GET /gates`` 관례 그대로).
+  - 기본 정렬 ``created_at DESC``(두 출처 통일).
+  - ``sort=urgency``는 Gate 쪽 기존 SLA/held 로직 그대로 + HitlRequest는 age(created_at)만으로
+    같은 정렬축에 best-effort로 끼워 넣는다(HitlRequest엔 SLA/held 개념이 없어 완전 동형은 아님 —
+    미리 합의된 단순화).
+  - 각 항목 ``source: "gate"|"hitl"``로 FE가 액션 라우팅.
+
+스코프: HitlRequest 쪽은 ``request_type == "gate_approval"``(gate_enforce.py 파킹분)만 — 그 외
+수동 HITL 승인 요청은 #2054 스코프 밖(Gate와 동일 병목에서 충돌하는 것만 통합).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# realdb 섹션이 Base.metadata.create_all 을 호출한다 — conftest.py AST 가드(story 8236bbc3) 대응.
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+_REAL_DB_SKIP = pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    import app.models  # noqa: F401 — 전 모델 메타데이터 로드
+    from app.core.database import Base
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, user_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {}})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _seed_org_project_users(session):
+    """org + project + 2명(A: project owner grant, B: project member grant) — test_1974 선례 재사용."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    user_a = User(id=uuid.uuid4(), email=f"a-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    user_b = User(id=uuid.uuid4(), email=f"b-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add_all([user_a, user_b])
+    await session.commit()
+
+    om_a = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=user_a.id, role="member")
+    om_b = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=user_b.id, role="member")
+    session.add_all([om_a, om_b])
+    await session.commit()
+
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=om_a.id,
+        permission="granted", role="owner",
+    ))
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=om_b.id,
+        permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id,
+        "user_a_id": user_a.id, "user_b_id": user_b.id,
+        "org_member_a_id": om_a.id, "org_member_b_id": om_b.id,
+    }
+
+
+def _hitl_request(*, org_id, project_id, work_item_id, work_type="merge", status="pending",
+                   request_type="gate_approval", created_at=None):
+    from app.models.hitl import HitlRequest
+
+    return HitlRequest(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id,
+        agent_id=uuid.uuid4(), request_type=request_type,
+        title="승인 필요: merge", prompt="merge 전이에 사람 승인이 필요합니다.",
+        requested_for=uuid.uuid4(), status=status,
+        hitl_metadata={"work_item_id": str(work_item_id), "work_type": work_type},
+        created_at=created_at or datetime.now(timezone.utc),
+    )
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_inbox_combines_gate_and_hitl_sources():
+    """Gate 1건 + HitlRequest(gate_approval) 1건이 같은 응답에 source 로 구분돼 함께 나온다."""
+    from app.main import app
+    from app.models.gate import Gate
+    from app.models.pm import Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_users(s)
+            org_id, project_id, a_id = seeded["org_id"], seeded["project_id"], seeded["user_a_id"]
+
+            story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="s1")
+            s.add(story)
+            await s.flush()
+            gate = Gate(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=story.id, work_item_type="story",
+                gate_type="merge", status="pending",
+            )
+            s.add(gate)
+
+            story2 = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="s2")
+            s.add(story2)
+            await s.flush()
+            hitl = _hitl_request(org_id=org_id, project_id=project_id, work_item_id=story2.id)
+            s.add(hitl)
+            await s.commit()
+
+        await _setup_app(app, Session, org_id, a_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/gates/inbox")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            by_id = {row["id"]: row for row in body}
+            assert str(gate.id) in by_id
+            assert str(hitl.id) in by_id
+            assert by_id[str(gate.id)]["source"] == "gate"
+            assert by_id[str(hitl.id)]["source"] == "hitl"
+            assert by_id[str(hitl.id)]["status"] == "pending"
+            assert by_id[str(hitl.id)]["requires_human"] is True
+            assert by_id[str(hitl.id)]["work_item_id"] == str(story2.id)
+            assert by_id[str(hitl.id)]["work_type"] == "merge"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_inbox_excludes_non_gate_approval_hitl_requests():
+    """request_type != 'gate_approval' 인 HitlRequest(수동 승인 등)는 #2054 스코프 밖 — 인박스에 안 뜬다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_users(s)
+            org_id, project_id, a_id = seeded["org_id"], seeded["project_id"], seeded["user_a_id"]
+
+            other = _hitl_request(
+                org_id=org_id, project_id=project_id, work_item_id=uuid.uuid4(),
+                request_type="approval",
+            )
+            s.add(other)
+            await s.commit()
+
+        await _setup_app(app, Session, org_id, a_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/gates/inbox")
+            assert resp.status_code == 200, resp.text
+            ids = {row["id"] for row in resp.json()}
+            assert str(other.id) not in ids
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_inbox_status_filter_applies_to_both_sources():
+    from app.main import app
+    from app.models.gate import Gate
+    from app.models.pm import Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_users(s)
+            org_id, project_id, a_id = seeded["org_id"], seeded["project_id"], seeded["user_a_id"]
+
+            story_pending = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="pending")
+            story_approved = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="approved")
+            s.add_all([story_pending, story_approved])
+            await s.flush()
+            gate_pending = Gate(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=story_pending.id, work_item_type="story",
+                gate_type="merge", status="pending",
+            )
+            gate_approved = Gate(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=story_approved.id, work_item_type="story",
+                gate_type="merge", status="approved", resolver_id=uuid.uuid4(),
+            )
+            s.add_all([gate_pending, gate_approved])
+
+            hitl_pending = _hitl_request(
+                org_id=org_id, project_id=project_id, work_item_id=uuid.uuid4(), status="pending",
+            )
+            hitl_approved = _hitl_request(
+                org_id=org_id, project_id=project_id, work_item_id=uuid.uuid4(), status="approved",
+            )
+            s.add_all([hitl_pending, hitl_approved])
+            await s.commit()
+
+        await _setup_app(app, Session, org_id, a_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/gates/inbox", params={"status": "pending"})
+            assert resp.status_code == 200, resp.text
+            ids = {row["id"] for row in resp.json()}
+            assert ids == {str(gate_pending.id), str(hitl_pending.id)}
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_inbox_default_sort_created_at_desc_across_sources():
+    """정렬 미지정 시 created_at DESC — Gate/HitlRequest 출처 무관 단일 시계열로 섞여야 한다."""
+    from app.main import app
+    from app.models.gate import Gate
+    from app.models.pm import Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_users(s)
+            org_id, project_id, a_id = seeded["org_id"], seeded["project_id"], seeded["user_a_id"]
+
+            story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="s1")
+            s.add(story)
+            await s.flush()
+
+            now = datetime.now(timezone.utc)
+            gate_old = Gate(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=story.id, work_item_type="story",
+                gate_type="merge", status="pending", created_at=now - timedelta(minutes=30),
+            )
+            hitl_mid = _hitl_request(
+                org_id=org_id, project_id=project_id, work_item_id=uuid.uuid4(),
+                created_at=now - timedelta(minutes=20),
+            )
+            gate_new = Gate(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=story.id, work_item_type="story",
+                gate_type="qa", status="pending", created_at=now - timedelta(minutes=5),
+            )
+            s.add_all([gate_old, hitl_mid, gate_new])
+            await s.commit()
+
+        await _setup_app(app, Session, org_id, a_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/gates/inbox")
+            assert resp.status_code == 200, resp.text
+            ids_in_order = [row["id"] for row in resp.json()]
+            assert ids_in_order == [str(gate_new.id), str(hitl_mid.id), str(gate_old.id)]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_inbox_assigned_to_me_filters_both_sources():
+    """assigned_to_me=true: A(project owner grant)는 두 출처 모두 자격 있는 항목이 보이고,
+    B(project member grant)는 둘 다 배제(project-role 불가)된다 — WHO 판정을 Gate와 동일 규칙으로
+    HitlRequest(work_item_id=story) 에도 적용."""
+    from app.main import app
+    from app.models.gate import Gate
+    from app.models.pm import Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_users(s)
+            org_id, project_id = seeded["org_id"], seeded["project_id"]
+            a_id, b_id = seeded["user_a_id"], seeded["user_b_id"]
+
+            story_g = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="s-gate")
+            story_h = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="s-hitl")
+            s.add_all([story_g, story_h])
+            await s.flush()
+
+            gate = Gate(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=story_g.id, work_item_type="story",
+                gate_type="merge", status="pending",
+            )
+            hitl = _hitl_request(org_id=org_id, project_id=project_id, work_item_id=story_h.id)
+            s.add_all([gate, hitl])
+            await s.commit()
+
+        # A: project owner grant → 둘 다 보임.
+        await _setup_app(app, Session, org_id, a_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/gates/inbox", params={"assigned_to_me": "true"})
+            assert resp.status_code == 200, resp.text
+            ids_a = {row["id"] for row in resp.json()}
+            assert ids_a == {str(gate.id), str(hitl.id)}
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+
+        # B: project member grant(승인 불가) → 둘 다 배제, 빈 목록.
+        await _setup_app(app, Session, org_id, b_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/gates/inbox", params={"assigned_to_me": "true"})
+            assert resp.status_code == 200, resp.text
+            assert resp.json() == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_inbox_urgency_sort_interleaves_hitl_by_age():
+    """sort=urgency: HitlRequest는 SLA/held 개념이 없어 age(created_at ASC) 축으로만 Gate 사이에
+    끼워진다 — 오래된(더 나이든) 항목이 상위(먼저)로 온다는 age 성분만 최소 실증."""
+    from app.main import app
+    from app.models.gate import Gate
+    from app.models.pm import Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_users(s)
+            org_id, project_id, a_id = seeded["org_id"], seeded["project_id"], seeded["user_a_id"]
+
+            story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="s1")
+            s.add(story)
+            await s.flush()
+
+            now = datetime.now(timezone.utc)
+            hitl_older = _hitl_request(
+                org_id=org_id, project_id=project_id, work_item_id=uuid.uuid4(),
+                created_at=now - timedelta(hours=2),
+            )
+            gate_newer = Gate(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=story.id, work_item_type="story",
+                gate_type="merge", status="pending", created_at=now - timedelta(minutes=5),
+            )
+            s.add_all([hitl_older, gate_newer])
+            await s.commit()
+
+        await _setup_app(app, Session, org_id, a_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/gates/inbox", params={"sort": "urgency"})
+            assert resp.status_code == 200, resp.text
+            ids_in_order = [row["id"] for row in resp.json()]
+            # 둘 다 non-held·age 축 비교 대상 — 더 오래된 hitl_older가 앞선다.
+            assert ids_in_order == [str(hitl_older.id), str(gate_newer.id)]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- 두 개의 독립적인 사람-승인 게이팅 체계(`Gate`/결재함, `HitlRequest`/`enforce_gate()` 파킹)가 동일 병목(merge)에서 각각 발동하지만 서로를 못 보던 결함(#2054) 해소.
- 오르테가 판정에 따라 데이터모델은 합치지 않고(Gate 미러 생성 금지) **read-layer만** 통합 — 승인/거부 액션은 각자 native API로(`PATCH /gates/{id}/transition` vs `PATCH /hitl/requests/{id}`).
- 신규 `GET /api/v2/gates/inbox` — `Gate`(`list_gates()` 재사용, enrich 로직 그대로)와 `HitlRequest`(`request_type=="gate_approval"` 파킹분만, #2054 스코프)를 하나의 목록으로, 각 항목 `source: "gate"|"hitl"`로 액션 라우팅.
- `assigned_to_me`는 Gate의 non-doc WHO 규칙(`_non_doc_gate_approvable`)을 HitlRequest에도 동일 적용.
- `sort=urgency`: Gate는 기존 SLA/held 로직 그대로, HitlRequest는 age(created_at)만으로 같은 정렬축에 best-effort 병합(SLA 개념 부재 — 미르코와 사전 합의된 단순화).
- 페이지네이션 없음(기존 `GET /gates` 관례 유지), 기본 정렬 `created_at DESC`.

계약은 미르코(FE)와 conversation `eaa1b6cb-5d73-4019-bca8-7e320087f827`에서 직접 합의(Option A: 신규 병합 엔드포인트).

## Test plan
- [x] 신규 realdb 회귀 6종(`test_2054_gate_inbox.py`): Gate+HitlRequest 혼합 반환/source 구분, `gate_approval` 외 request_type 배제, status 필터 양쪽 적용, 기본 정렬 created_at DESC 혼합, assigned_to_me 양쪽 적용(A=보임/B=배제), sort=urgency age 병합 — 로컬 pg@16 실측 6/6 통과.
- [x] 기존 gates 관련 unit+realdb 66종 회귀 없음 확인(`test_1974/1970/1973/1968/1983`).
- [x] gate/hitl 키워드 전체 unit 스위트(244 passed, 61 skipped — realdb 별도) 회귀 없음.
- [x] `/inbox` 라우트가 `/{id}` 보다 먼저 등록됨을 앱 임포트로 실측 확인(경로 충돌 방지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)