### PR TITLE
[SID:2058][보안·critical] HITL 승인 경로 human-only 불변식 + 헬퍼 봉인 + scope 허용목록

### DIFF
--- a/backend/app/routers/hitl.py
+++ b/backend/app/routers/hitl.py
@@ -9,6 +9,7 @@ from app.dependencies.database import get_db
 from app.dependencies.project_scope import enforce_write_scope, resolve_required_project_id
 from app.repositories.hitl import HitlRepository
 from app.schemas.hitl import PatchHitlPolicyRequest, ResolveHitlRequestBody
+from app.services.member_resolver import resolve_member
 
 router = APIRouter(prefix="/api/v2/hitl", tags=["hitl", "Trust"])
 
@@ -112,6 +113,14 @@ async def resolve_hitl_request(
     org_id, project_id = _get_org_project(auth)
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
+    # story #2058 AC1: gates.py transition_gate_endpoint 와 같은 human-only 불변식.
+    # HitlRequest 승인/거부는 여기 하나뿐이던 무방비 경로 — legacy write-scope 를 쥔 agent 키가
+    # (자기 것이 아닌) 남의 gate_approval 요청까지 승인/거부할 수 있었다(GATE_SELF_APPROVAL 은
+    # self 조합만 막았다). resolve_member 로 실 신원(type)을 확인 — auth.user_id 만으론(agent는
+    # team_member id 공간이라) 사람 여부를 알 수 없다.
+    resolved = await resolve_member(auth, org_id, repo.session, project_id=project_id)
+    if resolved.type != "human":
+        return _err("FORBIDDEN", "HITL 승인/거부는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)", 403)
     row = await repo.resolve_request(
         request_id=request_id,
         org_id=org_id,

--- a/backend/app/schemas/api_key.py
+++ b/backend/app/schemas/api_key.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ApiKeyResponse(BaseModel):
@@ -35,3 +35,28 @@ class RotateApiKeyRequest(BaseModel):
 class CreateApiKeyRequest(BaseModel):
     scope: list[str] | None = None
     expires_at: datetime | None = None
+
+    @field_validator("scope")
+    @classmethod
+    def validate_scope(cls, v: list[str] | None) -> list[str] | None:
+        """story #2058 AC4: 이전엔 임의 문자열을 무검증 저장했다(`api_keys.py:82`) — 오타/garbage
+        scope가 조용히 저장돼 나중에 `path_allowed_for_scope`에서 전부 거부되는 형태로만 드러났다
+        (fail-closed라 악용 벡터는 아니었으나 UX/디버깅 결함). `mcp_toolset.ALL_GROUPS`(agent_
+        recruiter.validate_tool_groups와 동일 SSOT 재사용) ∪ 레거시 `read`/`write` 만 허용한다.
+
+        ⚠️ **기존 키 무영향**: 이 검증은 CREATE 시점(이 스키마)에만 적용된다 — rotate_api_key는
+        scope를 건드리지 않고(app/routers/api_keys.py) 기존 저장값을 그대로 유지하며, auth 해석
+        (`_check_api_key_scope`/`enforce_write_scope`)도 이미 저장된 scope를 그대로 읽을 뿐 재검증
+        하지 않는다. 따라서 이미 발급된 키(legacy read/write 포함)는 이 변경으로 깨지지 않는다.
+        """
+        if v is None:
+            return v
+        from app.services.mcp_toolset import ALL_GROUPS, _LEGACY_SCOPES
+
+        allowed = set(ALL_GROUPS) | _LEGACY_SCOPES
+        unknown = [tok for tok in v if tok not in allowed]
+        if unknown:
+            raise ValueError(
+                f"scope contains unknown token(s): {unknown} (valid: {sorted(allowed)})"
+            )
+        return v

--- a/backend/app/services/gate_enforce.py
+++ b/backend/app/services/gate_enforce.py
@@ -211,6 +211,18 @@ async def enforce_gate(
         if req_status == "approved":
             # S-GATE-3 ①: self-approval 차단(§3d hard) — 승인자(responded_by)가 원 트리거 actor
             # (park 시 metadata.actor_id)와 동일하면 거부(다른 승인자 필요). 둘 다 known·동일일 때만.
+            #
+            # story #2058 AC3: hitl.py::resolve_hitl_request 에 human-only 불변식이 생긴 뒤로
+            # (#2058 AC1) responded_by 는 이제 **항상 human**이다. 이 work_type(done/merge) 파킹의
+            # orig_actor_id 는 report-done 경로 자체가 agent_id 만 받아(#2047 AC5 조사 확인) **항상
+            # agent**다 — 서로 다른 identity 공간(사람의 id 축 vs 에이전트의 id 축)이라 이
+            # 비교는 이 흐름에서는 **구조적으로 항상 False**(죽은 코드는 아니다 — 우연한 문자열
+            # 충돌 없이는 못 걸리는 방어심층). 겨냥 조합이었던 "agent↔agent(동일 identity)
+            # self-approval"은 이제 애초에 requester=agent·resolver=human 불일치로 도달 자체가
+            # 막힌다. **human↔human self-approval**(사람이 스스로 트리거·스스로 승인)은 이
+            # work_type(done/merge, agent-only 트리거) 경로에는 존재하지 않지만, `enforce_gate`가
+            # 향후 human-triggerable work_type/request_type으로 확장되면 그 조합에서 이 분기가
+            # 다시 실제로 걸릴 수 있다 — 그래서 제거하지 않고 방어심층으로 유지한다.
             if (
                 responded_by is not None
                 and orig_actor_id is not None

--- a/backend/app/services/project_auth.py
+++ b/backend/app/services/project_auth.py
@@ -401,11 +401,19 @@ async def is_org_owner_or_admin(
     user_id: uuid.UUID,
     org_id: uuid.UUID,
 ) -> bool:
-    """user 가 해당 org 의 owner/admin 인지. 파괴적 작업(프로젝트 삭제 등) 게이트용.
+    """user 가 해당 org 의 owner/admin 인지. 파괴적 작업(프로젝트 삭제 등)·gate void/hold/unhold/
+    reassign·workflow config publish 승인 게이트용.
 
     grant(project_access)만으론 불가 — org-level 역할만 통과. has_project_access 의
     owner/admin 분기와 동일 기준(team_member 봐주기 없음).
-    """
+
+    story #2058 AC5②: 이 결과가 human-only 로 통하는 건 지금은 **org_members가 human 전용
+    테이블이라는 부산물**일 뿐이었다(agent auth는 id 공간이 달라 우연히 매치가 안 될 뿐 —
+    이 함수 자체엔 human 판정이 없었다). 아래 NOT EXISTS로 그 불변식을 **명시** 강제한다 —
+    이 user_id가 `members.type='agent'`로 존재하면(미래에 org_members에 agent 연동 user_id가
+    들어오는 경로가 생기더라도) 무조건 실패. `members` 행 자체가 없는 인간(멤버싱크 갭,
+    project_members_sync_gap 선례)은 걸러지지 않는다 — "agent로 확인됨"만 배제(positive
+    exclusion), "human으로 확인 안 됨"으로 막지 않음(fail-open 방향 아님·기존 회귀 0)."""
     row = await session.execute(
         text(
             """
@@ -414,6 +422,12 @@ async def is_org_owner_or_admin(
               AND org_id = :org_id
               AND deleted_at IS NULL
               AND role IN ('owner', 'admin')
+              AND NOT EXISTS (
+                SELECT 1 FROM members m
+                WHERE m.user_id = org_members.user_id
+                  AND m.org_id = org_members.org_id
+                  AND m.type = 'agent'
+              )
             LIMIT 1
             """
         ),
@@ -429,7 +443,7 @@ async def is_org_owner(
 ) -> bool:
     """user 가 해당 org 의 **owner** 인지(admin 제외). ⭐E-DG S33 gate override 전용 — override 는
     SoD 우회=가장 강력한 액션이라 admin(void/hold/reassign)보다 좁게 owner-only 로 게이트한다.
-    is_org_owner_or_admin 과 동일 구조·role='owner' 만."""
+    is_org_owner_or_admin 과 동일 구조·role='owner' 만(agent-exclusion NOT EXISTS 도 동형 — #2058)."""
     row = await session.execute(
         text(
             """
@@ -438,6 +452,12 @@ async def is_org_owner(
               AND org_id = :org_id
               AND deleted_at IS NULL
               AND role = 'owner'
+              AND NOT EXISTS (
+                SELECT 1 FROM members m
+                WHERE m.user_id = org_members.user_id
+                  AND m.org_id = org_members.org_id
+                  AND m.type = 'agent'
+              )
             LIMIT 1
             """
         ),

--- a/backend/tests/test_2058_apikey_scope_allowlist.py
+++ b/backend/tests/test_2058_apikey_scope_allowlist.py
@@ -1,0 +1,55 @@
+"""story #2058 AC4: `CreateApiKeyRequest.scope` 허용 목록 검증.
+
+이전엔 `POST /agents/{id}/api-keys`가 scope를 무검증 저장했다(오타/garbage도 그대로 DB에
+들어간 뒤 `path_allowed_for_scope`에서 전부 거부되는 형태로만 드러났다 — fail-closed라 악용
+벡터는 아니었지만 UX/디버깅 결함). `mcp_toolset.ALL_GROUPS`(agent_recruiter.validate_tool_groups와
+동일 SSOT) ∪ 레거시 `read`/`write`만 허용한다.
+
+⚠️ CREATE 시점 검증만(스키마 레벨) — 기존 발급 키/rotate는 무영향(별도로 재검증하지 않음).
+"""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.api_key import CreateApiKeyRequest
+from app.services.mcp_toolset import ALL_GROUPS, _LEGACY_SCOPES
+
+
+def test_none_scope_passes():
+    req = CreateApiKeyRequest(scope=None)
+    assert req.scope is None
+
+
+def test_legacy_read_write_scope_passes():
+    req = CreateApiKeyRequest(scope=["read", "write"])
+    assert req.scope == ["read", "write"]
+
+
+@pytest.mark.parametrize("group", list(ALL_GROUPS))
+def test_every_known_toolgroup_passes(group):
+    req = CreateApiKeyRequest(scope=[group])
+    assert req.scope == [group]
+
+
+def test_unknown_token_rejected():
+    with pytest.raises(ValidationError, match="unknown token"):
+        CreateApiKeyRequest(scope=["not_a_real_group"])
+
+
+def test_admin_group_rejected_not_grantable():
+    """"admin"은 ALL_GROUPS에서 의도적으로 제외돼 있다(mcp_toolset.py:103) — scope로 부여 불가."""
+    assert "admin" not in ALL_GROUPS
+    with pytest.raises(ValidationError, match="unknown token"):
+        CreateApiKeyRequest(scope=["admin"])
+
+
+def test_mixed_valid_and_invalid_rejects_whole_list():
+    with pytest.raises(ValidationError, match="unknown token"):
+        CreateApiKeyRequest(scope=["stories", "bogus"])
+
+
+def test_allowed_set_is_groups_union_legacy():
+    allowed = set(ALL_GROUPS) | _LEGACY_SCOPES
+    req = CreateApiKeyRequest(scope=sorted(allowed))
+    assert set(req.scope) == allowed

--- a/backend/tests/test_2058_hitl_human_only.py
+++ b/backend/tests/test_2058_hitl_human_only.py
@@ -1,0 +1,281 @@
+"""story #2058[보안·critical]: HITL 승인 경로 human-only 불변식.
+
+배경: `gates.py::transition_gate_endpoint`는 `resolved.type != "human"`이면 403으로 막는데,
+`hitl.py::resolve_hitl_request`(HitlRequest 승인/거부 — 같은 승인 병목의 다른 절반)엔 그 불변식이
+없었다. legacy write-scope를 가진 agent 키라면 **자기 것이 아닌 남의 gate_approval 요청**도
+승인/거부할 수 있었다(GATE_SELF_APPROVAL은 self 조합만 막는다).
+
+AC1: resolve_hitl_request에 gates.py와 동형인 human-only 강제.
+AC2: 회귀 — agent(write scope)는 거부, human은 통과. 특히 **타인의 요청을 승인하는 조합**(자기승인
+   방어로는 안 잡히는 조합)을 명시적으로 재현.
+AC5②: is_org_owner_or_admin/is_org_owner 헬퍼 자체에 "agent가 org_members에 있으면 거부" 불변식을
+   명시(NOT EXISTS members.type='agent') — 6개 암묵-의존 콜사이트(void/hold/unhold/reassign/
+   override/workflow_line_config approve·reject)는 개별 수정하지 않고 이 헬퍼가 지키면 전부 지켜짐.
+   에이전트 신원이 org_members에 (가정상) 올라간 상황을 직접 시뮬레이션해 헬퍼가 여전히 거부하는지
+   실증한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _request(path: str, method: str):
+    from unittest.mock import MagicMock
+    req = MagicMock()
+    req.headers.get = lambda key, default=None: default
+    req.method = method
+    req.url.path = path
+    return req
+
+
+def _agent_auth(agent_id: uuid.UUID, org_id: uuid.UUID, project_id: uuid.UUID, *, scope: list[str]):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {
+            "org_id": str(org_id), "project_id": str(project_id),
+            "api_key_id": str(uuid.uuid4()), "scope": scope,
+        }},
+        org_id=str(org_id),
+    )
+
+
+def _human_auth(user_id: uuid.UUID, org_id: uuid.UUID, project_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(user_id), email="h@test.com",
+        claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        org_id=str(org_id),
+    )
+
+
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id):
+    from app.models.member import Member
+    from app.models.project_access import ProjectAccess
+
+    agent = Member(id=uuid.uuid4(), org_id=org_id, type="agent", name="Agent")
+    session.add(agent)
+    await session.commit()
+    session.add(ProjectAccess(id=uuid.uuid4(), project_id=project_id, member_id=agent.id, permission="granted"))
+    await session.commit()
+    return agent.id
+
+
+async def _seed_human(session, org_id, project_id, *, role="member"):
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role=role)
+    session.add(om)
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_id, org_member_id=om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+    return user.id, om.id
+
+
+async def _seed_hitl_request(session, org_id, project_id, requester_agent_id, *, requested_for=None):
+    from app.models.hitl import HitlRequest
+    req = HitlRequest(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, agent_id=requester_agent_id,
+        request_type="gate_approval", title="t", prompt="p",
+        requested_for=requested_for or requester_agent_id, status="pending",
+    )
+    session.add(req)
+    await session.commit()
+    return req.id
+
+
+# ── AC1/AC2: human-only 게이트 — 특히 "타인의 요청 승인"(self-approval 방어로는 안 잡히는 조합) ──
+
+
+@pytest.mark.anyio
+async def test_agent_cannot_approve_another_agents_request():
+    """이게 #2058의 headline 재현 — 자기 것이 아닌 요청도 agent가 승인 가능했던 결함."""
+    from app.repositories.hitl import HitlRepository
+    from app.routers.hitl import resolve_hitl_request
+    from app.schemas.hitl import ResolveHitlRequestBody
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            requester_agent_id = await _seed_agent(s, org_id, project_id)
+            approver_agent_id = await _seed_agent(s, org_id, project_id)  # 타 에이전트(다른 identity)
+            req_id = await _seed_hitl_request(s, org_id, project_id, requester_agent_id)
+
+        async with Session() as s:
+            resp = await resolve_hitl_request(
+                request_id=req_id,
+                body=ResolveHitlRequestBody(status="approved"),
+                request=_request("/api/v2/hitl/requests/x", "PATCH"),
+                auth=_agent_auth(approver_agent_id, org_id, project_id, scope=["read", "write"]),
+                repo=HitlRepository(s),
+            )
+            assert resp.status_code == 403, resp.body
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_human_can_approve_agents_request():
+    from app.repositories.hitl import HitlRepository
+    from app.routers.hitl import resolve_hitl_request
+    from app.schemas.hitl import ResolveHitlRequestBody
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            requester_agent_id = await _seed_agent(s, org_id, project_id)
+            user_id, _ = await _seed_human(s, org_id, project_id)
+            req_id = await _seed_hitl_request(s, org_id, project_id, requester_agent_id)
+
+        async with Session() as s:
+            resp = await resolve_hitl_request(
+                request_id=req_id,
+                body=ResolveHitlRequestBody(status="approved"),
+                request=_request("/api/v2/hitl/requests/x", "PATCH"),
+                auth=_human_auth(user_id, org_id, project_id),
+                repo=HitlRepository(s),
+            )
+            assert resp.status_code == 200, resp.body
+    finally:
+        await engine.dispose()
+
+
+# ── AC5②: is_org_owner_or_admin/is_org_owner 헬퍼 자체의 명시 불변식 ──────────────
+
+
+@pytest.mark.anyio
+async def test_is_org_owner_or_admin_rejects_agent_even_if_somehow_in_org_members():
+    """org_members에 agent 소유 user_id가 owner/admin role로 (가정상) 올라간 상황을 직접
+    시뮬레이션 — 헬퍼가 여전히 False를 내야 한다(#2058 AC5② — 개별 6곳 대신 이 헬퍼가 봉인)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember
+    from app.models.user import User
+    from app.services.project_auth import is_org_owner, is_org_owner_or_admin
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+            s.add(org)
+            await s.commit()
+            # agent를 만들되, 같은 user_id로 org_members에도(가정상 침투) owner row를 만든다 —
+            # 정상 경로로는 절대 안 생기는 조합을 직접 구성해 헬퍼의 명시 불변식만 단독 실증.
+            fake_user_id = uuid.uuid4()
+            user = User(id=fake_user_id, email=f"agent-user-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+            s.add(user)
+            await s.commit()
+            agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", user_id=fake_user_id, name="Agent")
+            s.add(agent)
+            om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=fake_user_id, role="owner")
+            s.add(om)
+            await s.commit()
+
+            assert await is_org_owner_or_admin(s, fake_user_id, org.id) is False
+            assert await is_org_owner(s, fake_user_id, org.id) is False
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_is_org_owner_or_admin_human_owner_unaffected_no_regression():
+    """정상 human owner/admin은 이 NOT EXISTS 가드로 회귀 없음(members 행이 아예 없는 human도 통과 —
+    members-sync 갭 선례 고려해 members row 존재를 요구하지 않는다)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember
+    from app.models.user import User
+    from app.services.project_auth import is_org_owner, is_org_owner_or_admin
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+            s.add(org)
+            await s.commit()
+            user = User(id=uuid.uuid4(), email=f"owner-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+            s.add(user)
+            await s.commit()
+            om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=user.id, role="owner")
+            s.add(om)
+            await s.commit()
+
+            # members 테이블에 이 human의 row가 전혀 없다(멤버싱크 갭 시뮬레이션) — 그래도 통과해야 함.
+            assert await is_org_owner_or_admin(s, user.id, org.id) is True
+            assert await is_org_owner(s, user.id, org.id) is True
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_is_org_owner_or_admin_human_member_role_still_false_no_regression():
+    from app.models.organization import Organization
+    from app.models.project import OrgMember
+    from app.models.user import User
+    from app.services.project_auth import is_org_owner_or_admin
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+            s.add(org)
+            await s.commit()
+            user = User(id=uuid.uuid4(), email=f"member-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+            s.add(user)
+            await s.commit()
+            om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=user.id, role="member")
+            s.add(om)
+            await s.commit()
+
+            assert await is_org_owner_or_admin(s, user.id, org.id) is False
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_d764522c_apikey_writescope_realdb.py
+++ b/backend/tests/test_d764522c_apikey_writescope_realdb.py
@@ -413,7 +413,10 @@ async def test_resolve_hitl_request_read_key_403():
         await engine.dispose()
 
 
-async def test_resolve_hitl_request_write_key_200_no_regression():
+async def test_resolve_hitl_request_agent_write_key_403_human_only_since_2058():
+    """story #2058 AC1: write-scope 만으론 더 이상 충분치 않다 — agent 신원은 human-only 게이트에서
+    막힌다. 이 테스트는 예전엔 200(no_regression)을 주장했으나 그 200 자체가 #2058이 닫은 결함이었다
+    (agent가 write-scope만 있으면 남의 gate_approval 요청도 승인 가능했던 것) — 이제 403이 정답."""
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
@@ -431,7 +434,63 @@ async def test_resolve_hitl_request_write_key_200_no_regression():
                 auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["read", "write"]),
                 repo=HitlRepository(s),
             )
-            assert resp.status_code == 200
+            assert resp.status_code == 403
+    finally:
+        await engine.dispose()
+
+
+async def test_resolve_hitl_request_human_200_no_regression():
+    """write-scope 게이트 자체는 무회귀 — human(JWT) caller는 여전히 200(#2058 AC1 신설 human-only
+    게이트도 통과)."""
+    from app.dependencies.auth import AuthContext
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+            s.add(org)
+            await s.commit()
+            project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+            s.add(project)
+            await s.commit()
+            user = User(id=uuid.uuid4(), email=f"h-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+            s.add(user)
+            await s.commit()
+            om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=user.id, role="member")
+            s.add(om)
+            s.add(ProjectAccess(
+                id=uuid.uuid4(), project_id=project.id, org_member_id=om.id,
+                permission="granted", role="member",
+            ))
+            await s.commit()
+            from app.models.member import Member
+            agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent")
+            s.add(agent)
+            await s.commit()
+            req_id = await _seed_hitl_request(s, org.id, project.id, agent.id)
+
+        async with Session() as s:
+            from app.routers.hitl import resolve_hitl_request
+            from app.repositories.hitl import HitlRepository
+            from app.schemas.hitl import ResolveHitlRequestBody
+
+            human_auth = AuthContext(
+                user_id=str(user.id), email=user.email,
+                claims={"app_metadata": {"org_id": str(org.id), "project_id": str(project.id)}},
+                org_id=str(org.id),
+            )
+            resp = await resolve_hitl_request(
+                request_id=req_id,
+                body=ResolveHitlRequestBody(status="approved"),
+                request=_request("/api/v2/hitl/requests/x", "PATCH"),
+                auth=human_auth,
+                repo=HitlRepository(s),
+            )
+            assert resp.status_code == 200, resp.body
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_s45.py
+++ b/backend/tests/test_s45.py
@@ -21,7 +21,10 @@ def anyio_backend() -> str:
 async def _client():
     from app.main import app
     ctx = MagicMock()
-    ctx.user_id = USER_ID
+    # story #2058: resolve_hitl_request가 resolve_member(auth.user_id)를 uuid.UUID(str)로 파싱
+    # — AuthContext.user_id는 항상 str 계약(app/dependencies/auth.py)이라 여기도 맞춘다(fixture
+    # 결함 — 이전엔 uuid.UUID(auth.user_id) 호출 자체가 없어서 안 드러났을 뿐).
+    ctx.user_id = str(USER_ID)
     ctx.email = "test@example.com"
     ctx.claims = {"app_metadata": {"org_id": str(ORG_ID), "project_id": str(PROJECT_ID)}, "sub": str(USER_ID)}
     mock_session = AsyncMock()
@@ -194,6 +197,12 @@ async def test_resolve_hitl_request_approved():
         row.id = REQUEST_ID
         row.status = "approved"
         row.responded_at = datetime(2026, 4, 30, 0, 0, 0, tzinfo=timezone.utc)
+        # story #2058: resolve_hitl_request가 이제 resolve_member(human-only 체크)로 DB를
+        # 몇 차례 더 왕복한다 — session이 순정 AsyncMock이면 .scalar_one_or_none()까지 재귀적으로
+        # AsyncMock화돼 미await 코루틴을 반환한다(mock 함정, 실 SQLAlchemy Result와 무관). 반환값을
+        # 평범한 MagicMock으로 고정해 이 체인이 동기적으로 truthy 값을 내도록 한다(JWT 휴먼 경로
+        # 통과 목적 — human 여부 자체는 auth.claims에 api_key_id가 없어 이미 human으로 하드결정됨).
+        session.execute = AsyncMock(return_value=MagicMock())
         with patch("app.repositories.hitl.HitlRepository.resolve_request", new_callable=AsyncMock) as mock_resolve:
             mock_resolve.return_value = row
             async with client as c:
@@ -210,6 +219,7 @@ async def test_resolve_hitl_request_approved():
 async def test_resolve_hitl_request_not_found_404():
     client, session, app, ctx = await _client()
     try:
+        session.execute = AsyncMock(return_value=MagicMock())  # story #2058 — 위 테스트와 동일 사유.
         with patch("app.repositories.hitl.HitlRepository.resolve_request", new_callable=AsyncMock) as mock_resolve:
             mock_resolve.return_value = None
             async with client as c:


### PR DESCRIPTION
## Summary
`gates.py::transition_gate_endpoint`엔 있는 human-only 불변식(`resolved.type != "human"` → 403)이 `hitl.py::resolve_hitl_request`엔 없었다 — legacy write-scope 에이전트 키가 자기 것이 아닌 남의 `gate_approval` 요청도 승인/거부할 수 있었다(`GATE_SELF_APPROVAL`은 self 조합만 막았다).

오르테가 스코프 판정 그대로:
- **①** `resolve_hitl_request`에 `gates.py`와 동형인 human-only 강제(AC1).
- **②** `void/hold/unhold/reassign/override`(gates.py)·`approve/reject`(workflow_line_config.py) 6곳 — `is_org_owner_or_admin`/`is_org_owner` 헬퍼 자체에 `NOT EXISTS(members.type='agent')` 불변식을 명시해 한 곳에서 봉인(개별 6곳 수정 안 함 — 헬퍼가 지키면 아래는 자동으로 지켜짐).
- **③** `GATE_SELF_APPROVAL`(gate_enforce.py)과의 관계를 주석으로 정리.
- **④** `POST /agents/{id}/api-keys`의 `scope` 허용목록 검증(`mcp_toolset.ALL_GROUPS` ∪ legacy read/write) — CREATE 시점 전용, 기존 발급 키/rotate 무영향 확인 후 진행.

## Test plan
- [x] `test_2058_hitl_human_only.py`(신규, realdb): agent가 타 agent 요청 승인 시도 → 403 / human 승인 → 200 / `is_org_owner_or_admin`·`is_org_owner`에 agent가 org_members에 (가정상) 침투해도 거부 / human owner(members row 없음, sync-갭 시뮬레이션)는 무회귀 통과 / human member role은 여전히 False.
- [x] `test_2058_apikey_scope_allowlist.py`(신규): 전 toolgroup 통과·legacy read/write 통과·garbage 거부·`admin`(의도적 미포함) 거부.
- [x] `test_d764522c_apikey_writescope_realdb.py`: agent+write-scope의 "200 no_regression" 가정이 #2058이 닫은 결함이었음을 발견 — human 케이스로 교체, write-scope 게이트 자체 무회귀 별도 확인.
- [x] `test_s45.py`: 새 `resolve_member` DB 왕복 경로에서 좌초하던 mock 세션 결함 수정(AuthContext.user_id는 str 계약).
- [x] `test_edg_s31_hold`/`s32_reassign`/`s30_void_recovery`/`workflow_line_config_org_scope`: 헬퍼 변경 무회귀.
- [x] realdb 27종(로컬 pg@16, 격리 재현)+unit 297종 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)