### PR TITLE
[SID:2054] 결재함 통합 인박스 — Gate + HitlRequest FE 연결(P0)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3468,6 +3468,7 @@
     "fallbackNotifyError": "Failed to notify",
     "gateApprove": "Approve",
     "gateReject": "Reject",
+    "hitlRequestBadge": "Approval request",
     "gateTransitionError": "Couldn't process: {reason}",
     "docGateTitlePrefix": "Approval: ",
     "gateOpenInDoc": "Open in doc",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3468,6 +3468,7 @@
     "fallbackNotifyError": "통지에 실패했습니다",
     "gateApprove": "승인",
     "gateReject": "반려",
+    "hitlRequestBadge": "승인 요청",
     "gateTransitionError": "처리하지 못했습니다: {reason}",
     "docGateTitlePrefix": "결재: ",
     "gateOpenInDoc": "문서에서 검토",

--- a/apps/web/src/app/(authenticated)/organization/workforce/hitl/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/hitl/page.tsx
@@ -1,3 +1,9 @@
-export default async function AgentHitlRequestsPage() {
-  return null;
+import { redirect } from 'next/navigation';
+
+// story #2054(AC4): 이 화면은 원래 빈 스텁(`return null`)이라 HitlRequest 승인 대기가 어디에도
+// 안 뜨는 근본원인 중 하나였다 — 통합 인박스(`/inbox` 결재함 탭, ApprovalsQueue)가 Gate와
+// HitlRequest를 함께 보여주는 정식 표면이 됐으니, 이 라우트로 오는 기존 링크/북마크 사용자를
+// 그쪽으로 안내한다(기존 화면 사용자를 빈 화면에 버리지 않는다).
+export default function AgentHitlRequestsPage() {
+  redirect('/inbox');
 }

--- a/apps/web/src/app/api/gates/inbox/route.ts
+++ b/apps/web/src/app/api/gates/inbox/route.ts
@@ -1,0 +1,6 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// story #2054: 결재함 통합 인박스 — Gate + HitlRequest(gate_approval park) 통합 조회.
+export async function GET(request: Request): Promise<Response> {
+  return proxyToFastapi(request, '/api/v2/gates/inbox');
+}

--- a/apps/web/src/components/inbox/approvals-queue.test.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.test.tsx
@@ -10,7 +10,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
-import type { GateItem } from '../kanban/types';
+import type { GateItem, HitlInboxItem } from '../kanban/types';
 
 const { useDashboardContextMock, pushMock } = vi.hoisted(() => ({
   useDashboardContextMock: vi.fn(),
@@ -52,6 +52,25 @@ function gate(overrides: Partial<GateItem>): GateItem {
     neutral_facts: null,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
+    source: 'gate',
+    ...overrides,
+  };
+}
+
+// story #2054: HitlRequest(gate_approval park) 결재함 인박스 항목 픽스처.
+function hitl(overrides: Partial<HitlInboxItem>): HitlInboxItem {
+  return {
+    source: 'hitl',
+    id: 'h-default',
+    request_type: 'gate_approval',
+    title: '기본 승인 요청',
+    prompt: 'merge 전이는 사람 승인 대기',
+    status: 'pending',
+    requires_human: true,
+    work_item_id: null,
+    work_type: 'merge',
+    created_at: new Date().toISOString(),
+    expires_at: null,
     ...overrides,
   };
 }
@@ -74,10 +93,17 @@ afterEach(async () => {
   pushMock.mockReset();
 });
 
-function mockFetches(pending: GateItem[], held: GateItem[]) {
-  const calls: string[] = [];
-  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
-    calls.push(url);
+// story #2054: /api/gates → /api/gates/inbox로 교체(Gate+HitlRequest 통합). pending/held
+// 각각에 gate·hitl 항목을 섞어 반환할 수 있다. PATCH(hitl 승인/반려)도 같은 mock으로 기록한다.
+function mockFetches(
+  pending: (GateItem | HitlInboxItem)[],
+  held: (GateItem | HitlInboxItem)[],
+  patchOk = true,
+) {
+  const calls: { url: string; method?: string; body?: string }[] = [];
+  vi.stubGlobal('fetch', vi.fn(async (url: string, init?: { method?: string; body?: string }) => {
+    calls.push({ url, method: init?.method, body: init?.body });
+    if (init?.method === 'PATCH') return { ok: patchOk, json: async () => ({}) };
     if (url.includes('status=pending')) return { ok: true, json: async () => pending };
     if (url.includes('status=held')) return { ok: true, json: async () => held };
     return { ok: true, json: async () => [] };
@@ -95,8 +121,9 @@ describe('ApprovalsQueue', () => {
   it('pending·held 두 상태를 각각 sort=urgency+assigned_to_me=true로 조회한다(파라미터 조합 회귀가드)', async () => {
     const calls = mockFetches([], []);
     await mount();
-    expect(calls).toContain('/api/gates?status=pending&sort=urgency&assigned_to_me=true');
-    expect(calls).toContain('/api/gates?status=held&sort=urgency&assigned_to_me=true');
+    const urls = calls.map((c) => c.url);
+    expect(urls).toContain('/api/gates/inbox?status=pending&sort=urgency&assigned_to_me=true');
+    expect(urls).toContain('/api/gates/inbox?status=held&sort=urgency&assigned_to_me=true');
   });
 
   it('4유형(게이트·문서결재·머지게이트·보류) 모두 렌더하고 gate_type 배지를 표시한다', async () => {
@@ -162,5 +189,52 @@ describe('ApprovalsQueue', () => {
     await mount();
     expect(container.querySelectorAll('button').length).toBe(1);
     expect(container.textContent).not.toContain(koMessages.cage.gateInboxEmpty);
+  });
+
+  // story #2054 — Gate와 HitlRequest가 같은 승인 병목(merge)에서 서로를 못 보던 결함의
+  // 회귀가드. hitl 항목은 상세 페이지가 없어 큐 안에서 바로 승인/반려한다(Gate처럼 클릭
+  // 시 상세로 이동하지 않는다 — 별도 버튼).
+  it('hitl 항목을 렌더하고 승인 요청 배지·title·prompt를 보여준다', async () => {
+    mockFetches([hitl({ id: 'h1', title: 'merge 승인 대기', prompt: '사람 승인이 필요합니다' })], []);
+    await mount();
+    const text = container.textContent ?? '';
+    expect(text).toContain(koMessages.cage.hitlRequestBadge);
+    expect(text).toContain('merge 승인 대기');
+    expect(text).toContain('사람 승인이 필요합니다');
+  });
+
+  it('hitl 항목 승인 클릭 시 PATCH /api/v1/hitl-requests/{id}를 status=approved로 호출하고 목록에서 사라진다', async () => {
+    const calls = mockFetches([hitl({ id: 'h-approve' })], []);
+    await mount();
+    const approveButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.cage.gateApprove));
+    await act(async () => { approveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const patchCall = calls.find((c) => c.method === 'PATCH');
+    expect(patchCall?.url).toBe('/api/v1/hitl-requests/h-approve');
+    expect(JSON.parse(patchCall?.body ?? '{}')).toEqual({ status: 'approved' });
+    expect(container.textContent).toContain(koMessages.cage.gateInboxEmpty);
+  });
+
+  it('hitl 항목 반려 클릭 시 PATCH를 status=rejected로 호출한다', async () => {
+    const calls = mockFetches([hitl({ id: 'h-reject' })], []);
+    await mount();
+    const rejectButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.cage.gateReject));
+    await act(async () => { rejectButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const patchCall = calls.find((c) => c.method === 'PATCH');
+    expect(JSON.parse(patchCall?.body ?? '{}')).toEqual({ status: 'rejected' });
+  });
+
+  it('gate·hitl 항목이 섞인 목록에서 gate만 상세로 push하고 hitl은 push하지 않는다', async () => {
+    mockFetches(
+      [
+        gate({ id: 'g-mixed', work_item_summary: { title: '머지 게이트', slug: null } }),
+        hitl({ id: 'h-mixed', title: 'HITL 승인' }),
+      ],
+      [],
+    );
+    await mount();
+    const gateButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('머지 게이트'));
+    await act(async () => { gateButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(pushMock).toHaveBeenCalledWith('/gates/g-mixed');
+    expect(pushMock).not.toHaveBeenCalledWith(expect.stringContaining('h-mixed'));
   });
 });

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -4,9 +4,11 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { CheckCircle, XCircle } from 'lucide-react';
 import { deriveRiskLevel } from '@/components/cage/gate-risk';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
-import type { GateItem } from '@/components/kanban/types';
+import type { GateInboxItem, GateItem, HitlInboxItem } from '@/components/kanban/types';
 
 // story #1960(P2-S4) — 결재함 통합 큐. Gate 3종(게이트·문서결재·머지게이트, gate_type/
 // work_item_type discriminator로 단일 Gate 테이블에 자연 수렴 — #1954에서 확定된 스코프
@@ -23,12 +25,23 @@ import type { GateItem } from '@/components/kanban/types';
 // 스코프. BE 배포 전엔 FastAPI가 미인식 쿼리파라미터를 무시하므로 안전한 no-op(기존과
 // 동일 org-wide) — 배포되면 자동 개인화. fetchGates()를 단일 함수로 캡슐화해 이 지점만
 // 교체하면 되도록 설계했다 — 컴포넌트 나머지는 무영향.
-async function fetchGates(): Promise<GateItem[]> {
+//
+// story #2054(P0): Gate/HitlRequest 두 체계가 같은 승인 병목(merge)에서 서로를 못 보던 결함
+// 해소 — `/api/gates`(Gate 단독)에서 `/api/gates/inbox`(Gate+HitlRequest 통합, `source`로
+// 판별)로 교체한다. 데이터모델은 안 합치고(디디 BE·오르테가 판정) 이 read-layer만 통합했다.
+// HitlRequest 항목은 상세 페이지가 없어(간단한 park 요청이라 `/gates/[id]`급 화면이 불필요)
+// 이 큐 안에서 바로 승인/반려하는 인라인 액션으로 둔다 — Gate 항목은 기존대로 클릭 시
+// `/gates/{id}` 상세로 이동.
+async function fetchGates(): Promise<GateInboxItem[]> {
   const [pending, held] = await Promise.all([
-    fetch('/api/gates?status=pending&sort=urgency&assigned_to_me=true').then((r) => (r.ok ? r.json() : [])),
-    fetch('/api/gates?status=held&sort=urgency&assigned_to_me=true').then((r) => (r.ok ? r.json() : [])),
+    fetch('/api/gates/inbox?status=pending&sort=urgency&assigned_to_me=true').then((r) => (r.ok ? r.json() : [])),
+    fetch('/api/gates/inbox?status=held&sort=urgency&assigned_to_me=true').then((r) => (r.ok ? r.json() : [])),
   ]);
-  return [...(pending as GateItem[]), ...(held as GateItem[])];
+  return [...(pending as GateInboxItem[]), ...(held as GateInboxItem[])];
+}
+
+function isHitl(item: GateInboxItem): item is HitlInboxItem {
+  return item.source === 'hitl';
 }
 
 function isHeld(gate: GateItem): boolean {
@@ -46,23 +59,40 @@ export function ApprovalsQueue() {
   const t = useTranslations('cage');
   const router = useRouter();
   const { orgMemberships } = useDashboardContext();
-  const [gates, setGates] = useState<GateItem[]>([]);
+  const [items, setItems] = useState<GateInboxItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [resolving, setResolving] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     void fetchGates().then((rows) => {
       if (!cancelled) {
-        setGates(rows);
+        setItems(rows);
         setLoading(false);
       }
     });
     return () => { cancelled = true; };
   }, []);
 
+  // story #2054 AC3: HitlRequest는 상세 페이지가 없어 이 큐 안에서 바로 승인/반려한다 —
+  // 승인 후 원래 작업(report-done)이 통과하는지는 사용자 왕복(재시도)으로 확認된다.
+  const resolveHitl = async (id: string, status: 'approved' | 'rejected') => {
+    setResolving(id);
+    try {
+      const res = await fetch(`/api/v1/hitl-requests/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status }),
+      });
+      if (res.ok) setItems((prev) => prev.filter((it) => it.id !== id));
+    } finally {
+      setResolving(null);
+    }
+  };
+
   if (loading) return <p className="text-xs text-muted-foreground">{t('gateInboxLoading')}</p>;
 
-  if (gates.length === 0) {
+  if (items.length === 0) {
     return (
       <div className="rounded-xl border border-dashed border-border bg-muted/20 px-4 py-5 text-center">
         <p className="text-sm text-muted-foreground">{t('gateInboxEmpty')}</p>
@@ -72,7 +102,43 @@ export function ApprovalsQueue() {
 
   return (
     <div className="space-y-2">
-      {gates.map((gate) => {
+      {items.map((item) => {
+        if (isHitl(item)) {
+          return (
+            <div key={item.id} className="flex flex-col gap-1.5 rounded-xl border border-info/30 bg-info/5 px-4 py-3">
+              <div className="flex w-full flex-wrap items-center gap-1.5">
+                <Badge variant="chip">{t('hitlRequestBadge')}</Badge>
+                <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">{formatAge(item.created_at, t)}</span>
+              </div>
+              <p className="text-sm text-foreground">{item.title}</p>
+              <p className="line-clamp-2 text-[11px] text-muted-foreground">{item.prompt}</p>
+              <div className="mt-1 flex justify-end gap-1.5">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 gap-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                  disabled={resolving === item.id}
+                  onClick={() => void resolveHitl(item.id, 'rejected')}
+                >
+                  <XCircle className="size-3.5" />
+                  {t('gateReject')}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 gap-1 text-success hover:bg-success-tint hover:text-success"
+                  disabled={resolving === item.id}
+                  onClick={() => void resolveHitl(item.id, 'approved')}
+                >
+                  <CheckCircle className="size-3.5" />
+                  {t('gateApprove')}
+                </Button>
+              </div>
+            </div>
+          );
+        }
+
+        const gate = item;
         const held = isHeld(gate);
         const orgName = orgMemberships.find((o) => o.orgId === gate.org_id)?.orgName;
         return (

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -73,7 +73,30 @@ export interface GateItem {
   auto_decision_reason?: string | null; // auto_merge | ask_human | block (raw decision)
   created_at: string;
   updated_at: string;
+  // story #2054: 결재함 통합 인박스(`/api/gates/inbox`)에서 Gate/HitlRequest 두 출처를 구분하는
+  // discriminator(BE GateResponse.source, additive). 단독 엔드포인트(`/api/gates` 등)는 이 필드가
+  // 응답에 없을 수 있어 optional — 그 경로 소비부는 항상 gate이므로 값이 없으면 'gate'로 취급한다.
+  source?: 'gate';
 }
+
+// story #2054: 결재함 통합 인박스에서 HitlRequest(gate_approval park) 항목 최소 스키마(BE
+// HitlInboxItem 미러) — Gate와 다른 API로 승인/거부(`PATCH /api/v1/hitl-requests/{id}`)하므로
+// GateItem을 재사용하지 않고 별도 타입으로 둔다. `source`로 FE가 렌더/액션을 분기한다.
+export interface HitlInboxItem {
+  source: 'hitl';
+  id: string;
+  request_type: string;
+  title: string;
+  prompt: string;
+  status: string;
+  requires_human: boolean;
+  work_item_id: string | null;
+  work_type: string | null;
+  created_at: string;
+  expires_at: string | null;
+}
+
+export type GateInboxItem = GateItem | HitlInboxItem;
 
 // E-DG S32: gate approver row(GateApproverResponse 미러). reassign 재지정 메타 enrich(이벤트서·null=미재지정).
 export interface GateApproverItem {


### PR DESCRIPTION
디디군이 이미 머지한 백엔드 계약(\`GET /api/v2/gates/inbox\`, \`source\`로 Gate/HitlRequest 판별)에 FE를 붙인다. 오늘 하루 이 축에서 판 네 겹의 마지막 칸 — 화면 도달 없음(#2043) → 서버가 정책 무시(#2047) → 신규 조직 판정 대상 아님(#2049) → **승인 체계가 둘인데 화면이 없음(#2054, 이번 건)**.

## 발견 — 진짜 렌더 표면은 GateInbox가 아니었다
"결재함"이 \`/gates\` 리스트 페이지가 아니라 \`/inbox\`(결재함 탭)의 \`ApprovalsQueue\` 컴포넌트인 것부터 그라운딩했다. \`cage/gate-inbox.tsx\`(승인/반려·재지정·보류·무효화 등 풍부한 기능)는 grep으로 전수 확認한 결과 **어디서도 import되지 않는 죽은 컴포넌트**였다(#1960에서 ApprovalsQueue로 대체된 뒤 삭제 안 된 것으로 보임 — 이번 스코프 밖이라 미터치). 실제 수정 대상은 \`approvals-queue.tsx\` 하나다.

## 수정
- \`api/gates/inbox/route.ts\`(신규): \`/api/v2/gates/inbox\` 프록시.
- \`kanban/types.ts\`: \`GateItem.source?: 'gate'\`(additive) + 신규 \`HitlInboxItem\` 타입 + \`GateInboxItem\` 유니온.
- \`approvals-queue.tsx\`: \`fetchGates()\`가 \`/api/gates/inbox\`를 호출(pending·held 2회, 기존 파라미터 유지). \`source\`로 렌더/액션 분기 — Gate는 클릭 시 상세 이동 그대로, HitlRequest는 상세 페이지가 없어 **큐 안에서 바로 승인/반려**(\`PATCH /api/v1/hitl-requests/{id}\`, 기존 FE 프록시 재사용). AC2("어디로 가야 하나 고민 안 함")를 위해 두 출처가 같은 카드 리스트에 자연스럽게 섞이게 했다.
- \`organization/workforce/hitl/page.tsx\`(AC4): 기존 \`return null\` 빈 스텁을 \`/inbox\`로 redirect — 이 화면이 근본원인 중 하나였다.

## AC1
오르테가 판정 그대로 — 데이터모델은 안 합친다. read-layer(BE \`/gates/inbox\` + FE \`ApprovalsQueue\`)에서만 표면 통합.

## 검증
- RED→GREEN: stash로 원본 복원 후 재실행 → 신규 5개 테스트 전부 실패(URL 불일치·hitl 항목을 GateItem으로 취급해 크래시) 확認, 복원 후 12/12 통과.
- 신규 테스트 4개: hitl 렌더 · 승인 PATCH status=approved · 반려 PATCH status=rejected · gate/hitl 혼재 시 gate만 push.
- type-check/lint: 0 errors. build: EXIT 0. i18n parity: PASS.

## 미완 — 라이브 E2E(AC3·AC6)
"막힘→발견→승인→통과" 실제 왕복은 \`posture=conservative\` 조직 + 진짜 blocked merge가 필요해 단위테스트 범위 밖. PO 지시대로 배포 후 까심군이 사람 계정으로 재확認 — 그게 서면 #2043 AC2·AC3도 같이 검증된다.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>