### PR TITLE
[SID:8c9a6a3a] #2060 AC1 — uvicorn timeout-graceful-shutdown 상한(5초)으로 pg_pubsub 정리 보장

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -43,4 +43,12 @@ USER appuser
 
 EXPOSE 8000
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# story #2060(SID f2fe1c5e #2040 AC5 후속): timeout_graceful_shutdown 기본값이 uvicorn 0.46.0에서
+# None(무기한)이다(server.py:271-300 — 활성 커넥션이 다 끝나야 lifespan.shutdown()을 부른다). 이
+# 서비스는 장수명 SSE 스트림(text/event-stream)을 서빙하므로 클라이언트가 SIGTERM 시점에 안
+# 끊겨 있으면 pg_pubsub LISTEN 정리(main.py lifespan finally)가 영영 안 불리고 Cloud Run의
+# SIGKILL(terminationGracePeriodSeconds 기본 10초, dev/prod 둘 다 미설정=기본값 — 오르테가군
+# gcloud 실측 2026-07-20)에 그대로 죽는다 — 오늘 실측된 67분짜리 좀비 LISTEN 연결의 근본원인.
+# 5초: 드레인 5초 + 정리(밀리초 단위) 5초 여유 — 10초 한도 안에서 안전 마진(8초는 정리에 2초만
+# 남아 아슬아슬해 기각).
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--timeout-graceful-shutdown", "5"]

--- a/backend/tests/test_deploy_env.py
+++ b/backend/tests/test_deploy_env.py
@@ -207,3 +207,23 @@ def test_deploy_frontend_single_set_env_vars():
     assert src.count("--set-env-vars=") == 1, "--set-env-vars 중복 → env 유실 위험"
     for kv in ("NODE_ENV=production", "NEXT_TELEMETRY_DISABLED=1", "NEXT_PUBLIC_FASTAPI_URL="):
         assert kv in src, f"{kv} 누락"
+
+
+# ── story #2060(SID f2fe1c5e #2040 AC5 후속): uvicorn graceful shutdown 상한 ────────
+
+def test_dockerfile_uvicorn_bounds_graceful_shutdown():
+    """uvicorn 0.46.0 `timeout_graceful_shutdown` 기본값은 None(무기한) — 장수명 SSE 스트림이
+    안 끊기면 lifespan.shutdown()(pg_pubsub LISTEN 정리)이 영영 안 불리고 Cloud Run SIGKILL
+    (terminationGracePeriodSeconds 기본 10초, dev/prod 둘 다 미설정 — 오르테가군 gcloud 실측
+    2026-07-20)에 정리 없이 죽는다. `--timeout-graceful-shutdown 5`로 상한을 강제해
+    드레인 5초+정리(밀리초 단위) 5초 여유를 10초 한도 안에 확보한다."""
+    with open(_DOCKERFILE) as f:
+        src = f.read()
+    cmd_lines = [ln for ln in src.splitlines() if ln.strip().startswith("CMD")]
+    assert cmd_lines, "CMD 인스트럭션을 찾을 수 없음"
+    cmd = cmd_lines[-1]
+    assert "--timeout-graceful-shutdown" in cmd, (
+        "uvicorn CMD에 --timeout-graceful-shutdown 누락 — 기본값 None(무기한)으로 되돌아가면 "
+        "pg_pubsub LISTEN 정리가 SIGKILL에 밀려 좀비 커넥션이 재발한다."
+    )
+    assert '"5"' in cmd, "timeout 값이 5초가 아님 — Cloud Run 10초 유예 안에서의 안전 마진 확認 필요"


### PR DESCRIPTION
## Summary
uvicorn 0.46.0 `timeout_graceful_shutdown` 기본값이 `None`(무기한) — SIGTERM 시 활성 커넥션(장수명 SSE 스트림 포함)이 다 끝나야 `lifespan.shutdown()`(pg_pubsub LISTEN 정리가 걸린 지점)을 부른다(`uvicorn/server.py:271-300` 확인). SSE 클라이언트가 안 끊긴 채 Cloud Run의 `terminationGracePeriodSeconds`(기본 10초, dev/prod 둘 다 미설정 — 오르테가군 gcloud 실측 2026-07-20)가 끝나면 SIGKILL로 정리 없이 죽는다 — #2040에서 실측한 67분짜리 좀비 `:listen` 연결의 근본원인.

- `--timeout-graceful-shutdown 5`를 `Dockerfile` CMD에 추가. `backend/Dockerfile`은 dev/prod 공용 빌드 경로(`cloudbuild.yaml` `build-backend`)라 이 한 곳 수정으로 양쪽 다 적용됨.
- N=5 근거: 드레인 5초 + 정리(밀리초 단위) 5초 여유, 10초 유예 안에서 안전 마진(8초안은 정리 여유 2초뿐이라 기각·오르테가군 판정).
- 방식 선택 근거: `signal.signal`/`loop.add_signal_handler` 커스텀 핸들러는 uvicorn 자체 SIGTERM 처리와 충돌 위험(시그널 슬롯 1개)이 있어 기각 — uvicorn이 이미 제공하는 안전판을 켜는 쪽으로(신규 코드·시그널 수술 0, 회귀 면적 최소).

## Test plan
- [x] `test_dockerfile_uvicorn_bounds_graceful_shutdown`(신규) — CMD에 플래그+값 5초 반영 확인.
- [x] `test_deploy_env.py` 전체 20종 통과(회귀 없음).
- [x] `uv run uvicorn --help`로 플래그명 실측 확인(오탈자 방지).
- [ ] **AC3(이 스토리의 진짜 게이트)**: merge→dev 배포 후 라이브 실측으로 구 리비전 `:listen`이 안 남는지 확인 — 디디는 `CRON_SECRET` 미보유(PO/infra lane)라 오르테가군 쪽에서 확인 필요.

## Out of scope (오르테가군 확인됨)
- AC2(SSE 평시 수명 상한): 이 timeout이 종료 시점 상한을 이미 강제해 재연결 폭증 대가를 감수할 근거가 없음 — 별도 조치 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)