### PR TITLE
fix(models): app/models/__init__.py에 hitl_config·participation 모듈 import 누락 — develop CI 적출

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -64,6 +64,14 @@ from app.models.release_note import ReleaseNote
 from app.models.role_template import RoleTemplate
 from app.models.trust_snapshot import OrgMemberTrustSnapshot
 from app.models.visual_artifact import ArtifactNode, ArtifactVersion, VisualArtifact
+# fix(2026-07-20, #2058 후속 CI 적출): 이 두 모듈이 여기 없어 `import app.models`만으로는
+# Base.metadata에 등록 안 됐다 — participation_role을 참조하는 FK(hitl_config.OrgGateOverride/
+# MemberGateOverride.role_id, participation.Participation.role_id)를 가진 realdb 테스트가
+# create_all() 시점에 NoReferencedTableError로 깨졌다(다른 테스트 파일과 조합 실행 시엔 그
+# 파일의 import 경로로 sys.modules에 우연히 이미 로드돼 안 드러났던 것으로 추정 — CI가 파일별로
+# 완전히 격리된 새 프로세스로 도는 조건에서 처음 노출).
+from app.models.hitl_config import MemberGateOverride, OrgGateOverride, OrgGatePolicy
+from app.models.participation import Participation, ParticipationRole
 
 __all__ = [
     "RoleTemplate",


### PR DESCRIPTION
## Summary
⛔ develop CI RED (#2333 머지 직후, 오르테가 PO 실측 + 미르코군 #2336 CI 추적).

```
sqlalchemy.exc.NoReferencedTableError:
  Foreign key associated with column 'org_gate_override.role_id'
  could not find table 'participation_role'
```

**근본**: `app/models/__init__.py`가 `hitl_config.py`(`OrgGatePolicy`/`OrgGateOverride`/`MemberGateOverride`)와 `participation.py`(`ParticipationRole`/`Participation`)를 애초에 import한 적이 없었다 — `import app.models`만으로는 이 5개 모델이 `Base.metadata`에 등록 안 됐다. 다른 테스트 파일과 조합 실행 시엔 그 파일의 개별 import 경로로 `sys.modules`에 우연히 이미 로드돼 안 드러났던 것으로 추정 — CI가 파일별 완전 격리 프로세스로 도는 조건(#2058의 `test_2058_hitl_human_only.py`에 `create_all` 추가한 #2333)에서 처음 노출됨.

**fix**: 두 모듈 import를 `__init__.py`에 추가 — `import app.models`가 항상 완전한 모델 그래프를 등록하도록 보장.

## Test plan
- [x] 실패 재현 DB(완전 격리, CI와 동일 시나리오)에서 `test_2058_hitl_human_only.py` 5/5 통과 확인.
- [x] `python -c "from app.main import app"` — import 정상(490 routes).
- [ ] **머지 후 develop CI가 실제로 초록으로 돌아오는 것까지 확인 필요**(PR CI 통과 ≠ develop 통과 — 이번 사고의 핵심 교훈).

🤖 Generated with [Claude Code](https://claude.com/claude-code)