### PR TITLE
fix(deeplink): task_completed target을 웹 전용 경로 조각에서 의미 식별자로 승격

### DIFF
--- a/backend/app/routers/deeplink_manifest.py
+++ b/backend/app/routers/deeplink_manifest.py
@@ -27,6 +27,19 @@ VERSION_POLICY = (
     "returnPolicy 의미) 변경 시에만 발생한다."
 )
 
+# 2026-07-21(오르테가 PO 확認 요청): target_promotion_pending 뜻이 지금까지 BE 소스의
+# Pydantic Field(description=...)에만 있었고(스키마 모듈 코드를 읽어야만 알 수 있었다),
+# 실제 응답 payload 어디에도 소비자가 읽을 수 있는 형태로 없었다 — VERSION_POLICY와
+# 동일하게 여기서도 응답 자체에 명시한다.
+TARGET_PROMOTION_PENDING_POLICY = (
+    "entries[].app.target_promotion_pending가 true인 엔트리는 target이 가리키는 화면이 "
+    "이 클라이언트 플랫폼에는 아직 전용 라우트로 존재하지 않는 잠정/폴백 상태임을 뜻한다. "
+    "target 문자열 자체는 유효한 의미 식별자다(장차 승격될 실제 화면 이름) — 클라이언트는 "
+    "이 값을 조건부로 해석(예: URL 조립)하지 말고, 그 화면이 아직 없으면 자신의 현재 "
+    "최선의 대체 착지(상위 화면 등)로 매핑하거나 AC4 안전 폴백(`지금` 탭)을 적용해야 한다. "
+    "승격되면(전용 라우트 신설) 이 플래그가 false로 바뀌고 클라이언트는 정식 매핑을 쓴다."
+)
+
 
 def _serialize_entry(entry) -> dict:
     """엔트리 1개 직렬화. 미르코 point ①(nested 구조·snake_case)은 유지 — 기존
@@ -47,6 +60,7 @@ async def get_deeplink_manifest(_: AuthContext = Depends(get_current_user)) -> d
         {
           "schema_version": 1,
           "version_policy": "<MAJOR 불일치 시 폴백 계약 설명>",
+          "target_promotion_pending_policy": "<target_promotion_pending 플래그 뜻 설명>",
           "entries": [{"lookup_key": "dispatched:story", "app": {...}, "payload": {...},
                        "channel": {...}}, ...]
         }
@@ -54,5 +68,6 @@ async def get_deeplink_manifest(_: AuthContext = Depends(get_current_user)) -> d
     return {
         "schema_version": MANIFEST_SCHEMA_VERSION,
         "version_policy": VERSION_POLICY,
+        "target_promotion_pending_policy": TARGET_PROMOTION_PENDING_POLICY,
         "entries": [_serialize_entry(e) for e in DEEPLINK_MANIFEST.entries],
     }

--- a/backend/app/schemas/deeplink_manifest.py
+++ b/backend/app/schemas/deeplink_manifest.py
@@ -551,19 +551,28 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
 
         # --- task — 열린 질문 8번 답변(유나+미르코, 3자 검토): task_completed payload에
         # story_id가 없다(reference_type="task"·reference_id=task.id뿐) — 전용 task 상세
-        # 화면도 신설하지 않는다(신규 라우트 불필요, 미르코 point ⑤와 동일 원칙). target을
-        # 조건부 로직을 암시하는 이름("task_detail_or_story_fallback" — "FE가 조건 분기해야
-        # 하나?"라는 오해 유발, SSOT 위반) 대신 팀이 이미 쓰는 고정 폴백 컨벤션인
-        # "/board?story="로 확정한다(apps/web goals-client.tsx·embed-card.tsx·
-        # derive-attention-queue.ts에서 이미 쓰는 패턴 — story_id 없이도 보드로 착지).
+        # 화면도 신설하지 않는다(신규 라우트 불필요, 미르코 point ⑤와 동일 원칙).
+        #
+        # 승격(2026-07-21, 오르테가 PO 확定): 원래 target을 팀이 이미 쓰는 웹 전용 URL 조립
+        # 컨벤션 "/board?story="로 뒀었으나, 이 매니페스트의 다른 29개 엔트리가 전부 순수
+        # 의미 식별자(클라이언트 룩업 테이블 조회용, 문자열 조립 불요)인데 이 엔트리만 웹
+        # 라우팅 문법을 계약에 흘려보내고 있었다(미르코 관측 — 모바일이 의미 이름으로 못
+        # 해석해 "지금" 탭 폴백으로 떨어짐) + target_promotion_pending 플래그도 누락돼
+        # "이미 유효한 목적지"로 오인될 수 있었다. story #1953이 이미 예고해둔 값
+        # "story_detail"(task는 항상 story 소속이라 의미상 정확 — 없는 화면 이름을 지어내는
+        # 대신 실제로 존재하는 상위 화면으로 보낸다)로 승격 + target_promotion_pending=True
+        # (gate_detail/artifact_detail과 동일 패턴 — 전용 모바일 라우트 신설 전까지 안전
+        # 폴백). 웹 4곳(goals-client.tsx·embed-card.tsx·derive-attention-queue.ts 등)은
+        # story_id로 이미 "/board?story=" 클라이언트측 조립을 하고 있어 무변경.
         # 등급은 B(정보성) — #1956 채널 등급 확정 시 참고.
         DeepLinkManifestEntry(
-            # story #1953(P1a-S3): story_id를 payload에 추가(발판 — 향후 story_detail 폴백
-            # 승격 시 이 필드로 "/board?story=" 조립 없이 직접 착지 가능해진다). task.story_id
-            # FK는 tasks.py 호출부가 이미 story_row.id로 알고 있어(task는 항상 story 소속)
-            # 신규 조회 없이 그대로 흘려보낸다 — 항상 존재(Task는 story 없이 존재 불가).
+            # story #1953(P1a-S3): story_id를 payload에 추가(이 승격이 바로 그 발판을 쓰는
+            # 자리다 — 조립 없이 story_id로 직접 착지). task.story_id FK는 tasks.py 호출부가
+            # 이미 story_row.id로 알고 있어(task는 항상 story 소속) 신규 조회 없이 그대로
+            # 흘려보낸다 — 항상 존재(Task는 story 없이 존재 불가).
             app=DeepLinkAppFields(
-                type="task_completed", target="/board?story=", parent_tab=ParentTab.all,
+                type="task_completed", target="story_detail", parent_tab=ParentTab.all,
+                target_promotion_pending=True,
             ),
             payload=DeepLinkPayloadFields(
                 org_id_included=True, project_id_included=True,

--- a/backend/tests/deeplink_contract_lib.py
+++ b/backend/tests/deeplink_contract_lib.py
@@ -395,12 +395,16 @@ TARGET_ROUTE_GLOBS: dict[str, tuple[str, ...]] = {
 
 def resolve_target_route(target: str) -> tuple[str, ...] | None:
     """target(논리적 화면 식별자 또는 `/board?story=`류 리터럴 경로)을 apps/web 파일시스템
-    후보 경로들로 변환. 매핑이 없으면 None(호출자가 fail-closed 처리)."""
+    후보 경로들로 변환. 매핑이 없으면 None(호출자가 fail-closed 처리).
+
+    ⚠️2026-07-21: 이 `/`-접두 분기의 원 동기였던 `task_completed`("/board?story=")는
+    `story_detail`(순수 의미 식별자) + `target_promotion_pending=True`로 승격돼 더 이상
+    이 분기를 안 탄다(오르테가 PO 확定 — 매니페스트의 다른 29개 엔트리와 동형인 순수 의미
+    식별자로 통일). 현재 매니페스트엔 `/`-접두 target이 없다 — 이 분기는 향후 같은 패턴이
+    재도입될 경우를 위한 방어적 fallback으로 남겨둔다(죽은 코드는 아니지만 지금은 미도달)."""
     if target in TARGET_ROUTE_GLOBS:
         return TARGET_ROUTE_GLOBS[target]
     if target.startswith("/"):
-        # task_completed의 "/board?story=" 같은 팀 기존 폴백 컨벤션 — 쿼리스트링 제거 후
-        # 첫 경로 세그먼트를 프로젝트-스코프 라우트로 매핑.
         path_part = target.split("?", 1)[0].strip("/")
         segment = path_part.split("/", 1)[0] if path_part else ""
         if segment:

--- a/backend/tests/test_deeplink_manifest_endpoint.py
+++ b/backend/tests/test_deeplink_manifest_endpoint.py
@@ -70,3 +70,42 @@ async def test_deeplink_manifest_endpoint_requires_auth():
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         resp = await c.get("/api/v2/deeplink-manifest")
     assert resp.status_code in (401, 403)
+
+
+@pytest.mark.anyio
+async def test_target_promotion_pending_policy_explained_in_response():
+    """2026-07-21(오르테가 PO 확認 요청): target_promotion_pending 뜻이 BE 소스 코드
+    (Pydantic Field description)에만 있고 실제 응답 payload엔 없던 갭 — 소비자가 raw JSON만
+    보고도 플래그 의미를 알 수 있어야 한다."""
+    app.dependency_overrides[get_current_user] = _override_auth
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get("/api/v2/deeplink-manifest")
+    finally:
+        app.dependency_overrides.clear()
+
+    body = resp.json()
+    assert isinstance(body["target_promotion_pending_policy"], str)
+    assert body["target_promotion_pending_policy"]
+
+
+@pytest.mark.anyio
+async def test_task_completed_promoted_to_story_detail_semantic_target():
+    """2026-07-21(오르테가 PO 확定): task_completed의 target이 웹 전용 URL 조립 컨벤션
+    ("/board?story=")에서 다른 29개 엔트리와 동형인 순수 의미 식별자("story_detail")로
+    승격됐다 — story #1953이 이미 payload에 실어둔 story_id를 그 발판으로 쓴다.
+    target_promotion_pending=True(전용 모바일 라우트 신설 전까지 안전 폴백,
+    gate_detail/artifact_detail과 동일 패턴)."""
+    app.dependency_overrides[get_current_user] = _override_auth
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get("/api/v2/deeplink-manifest")
+    finally:
+        app.dependency_overrides.clear()
+
+    body = resp.json()
+    task_entry = next(e for e in body["entries"] if e["app"]["type"] == "task_completed")
+    assert task_entry["app"]["target"] == "story_detail"
+    assert not task_entry["app"]["target"].startswith("/")
+    assert task_entry["app"]["target_promotion_pending"] is True
+    assert "story_id" in task_entry["payload"]["required_payload"]


### PR DESCRIPTION
## Summary
민군 관측(딥링크 매니페스트 `target`에 의미 이름 대신 경로 조각 발견) + 오르테가 PO 재조사 정정(오타 아니라 의도적 재사용이었으나 계약 레벨에서는 고쳐야 함) 후속.

`task_completed` 엔트리만 `target="/board?story="`(웹 전용 URL 조립 컨벤션)를 계약에 흘려보내고 있었다 — 다른 29개 엔트리는 전부 순수 의미 식별자. 모바일이 의미 이름으로 못 찾아 "지금" 탭 폴백으로 떨어지던 증상.

- `target`: `"/board?story="` → `"story_detail"`(새 이름 발명 아님 — story #1953이 이미 이 승격을 예고, payload에 `story_id`도 그 목적으로 이미 실려있음).
- `target_promotion_pending=True` 추가(`gate_detail`/`artifact_detail`과 동일 패턴).
- 부수: `target_promotion_pending` 플래그 뜻이 BE 소스에만 있고 응답 payload엔 없던 갭 — `target_promotion_pending_policy` 필드로 응답에 명시.
- `deeplink_contract_lib.py`의 `/board?story=` 특례 분기 주석 갱신(이제 미도달 — 방어적 fallback으로 유지).

**무중단**: 앱이 모르는 target을 만나면 기존 `reference_type` 규칙으로 폴백(민군 기존 구현) — 서버가 먼저 나가도 안전. 순서: 서버(이 PR) → 앱 매핑(민군, 오르테가군이 붙임) → 스냅샷 갱신 → (필요시) 옛 값 완전 제거.

## Test plan
- [x] 기존 16종(AC1~AC4 CI 게이트 포함) 무회귀.
- [x] 신규 2종: `target_promotion_pending_policy` 응답 노출 확인 / `task_completed`가 `story_detail`+`target_promotion_pending=True`+`story_id` required_payload로 정확히 승격됐는지 확인.
- [x] `python -c "from app.main import app"` — import 정상.
- [x] realdb 무관(순수 unit, 마이그 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)