### PR TITLE
fix(story #2068): claim이 project_id override를 무시하던 결함 수정

### DIFF
--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -2,7 +2,7 @@ import os
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -23,6 +23,12 @@ from app.services.project_auth import has_project_access
 
 class ClaimBody(BaseModel):
     story_id: uuid.UUID
+    # story #2068: MCP SprintableClient가 멀티프로젝트 override 시 이 필드로 project_id를 자동
+    # 주입한다(api_client.py request()). 지금까지 이 필드가 없어 body에 실려 와도 FastAPI가
+    # 조용히 버렸고, 아래 로직은 member.project_id(anchor) 하나로만 story를 찾아 org-agent가
+    # 멀티프로젝트 grant로 다른 프로젝트 스토리를 claim하면 "Story not found in this project"가
+    # 났다(스토리는 실재했다 — 찾은 project가 틀렸을 뿐).
+    project_id: uuid.UUID | None = None
 
 
 async def _inject_active_stories(
@@ -468,6 +474,7 @@ async def heartbeat(
 async def claim_story(
     id: uuid.UUID,
     body: ClaimBody,
+    request: Request,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
@@ -480,6 +487,19 @@ async def claim_story(
 
     S19(발견·회귀수정): resolve_member()/.id 직접비교는 휴먼 JWT caller의 axis(OrgMember.id)가
     이 path의 team_members뷰 id와 달라 본인 claim도 403났다 — assert_caller_is_member로 교체.
+
+    story #2068(발견·회귀수정): story 존재 검증이 `member.project_id`(claim 대상 team_members
+    행의 anchor project) 하나로만 스코프됐다 — org-agent 멀티프로젝트 grant(85429ee0)로 다른
+    프로젝트 story를 claim하려 하면 project_id override(body/X-Project-Id)가 통째로 무시되고
+    항상 "Story not found in this project"가 났다. 명시(body) > 헤더(has_project_access 검증)
+    > `member.project_id`(이 claim 대상 행 자체의 anchor) 순으로 해소한다.
+
+    ⚠️ `app.dependencies.project_scope.resolve_required_project_id`(SSOT)를 쓰지 않는다 — 그건
+    "기본값 없으면 **caller**의 default project"로 폴백하는데, 여기서는 `id`(claim 대상
+    team_members 행)가 이미 자기 project로 결정론적으로 고정돼 있다. caller 기본 프로젝트로
+    폴백하면 override 없는 통상 케이스(caller==member, 프로젝트 1개)에서도 값이 갈릴 수 있는
+    축을 새로 여는 것이라, override가 없을 때는 기존 그대로 `member.project_id`를 쓴다(무회귀 —
+    override 있을 때만 새 분기를 탄다).
     """
     repo = TeamMemberRepository(session, org_id)
     member = await repo.get(id)
@@ -488,13 +508,45 @@ async def claim_story(
 
     await assert_caller_is_member(id, auth, session, org_id, detail="Cannot claim as another member")
 
+    override_project_id = body.project_id
+    if override_project_id is None:
+        header = request.headers.get("X-Project-Id")
+        if header:
+            try:
+                override_project_id = uuid.UUID(header)
+            except ValueError:
+                raise HTTPException(status_code=400, detail="Invalid X-Project-Id format")
+    if override_project_id is not None:
+        if not await has_project_access(session, uuid.UUID(str(auth.user_id)), override_project_id, org_id):
+            raise HTTPException(status_code=403, detail="No access to the specified project")
+        effective_project_id = override_project_id
+    else:
+        effective_project_id = member.project_id
+
     # AC3: story가 해당 project에 존재하는지 검증
     story_result = await session.execute(
-        select(Story).where(Story.id == body.story_id, Story.project_id == member.project_id)
+        select(Story).where(Story.id == body.story_id, Story.project_id == effective_project_id)
     )
     story = story_result.scalar_one_or_none()
     if story is None:
-        raise HTTPException(status_code=400, detail="Story not found in this project")
+        # story #2068 AC3: 존재하지 않는 것과 "다른 project에 있는 것"을 구분해서 알려준다 —
+        # 전자는 오타/삭제, 후자는 project_id 지정 문제(둘 다 "not found"로만 뭉치면 사람이
+        # 원인을 못 좁힌다). org 필터는 유지(타 org story 존재 여부는 노출하지 않는다).
+        elsewhere = await session.execute(
+            select(Story.project_id).where(Story.id == body.story_id, Story.org_id == org_id)
+        )
+        actual_project_id = elsewhere.scalar_one_or_none()
+        if actual_project_id is not None:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Story {body.story_id} exists in project {actual_project_id}, not in "
+                    f"project {effective_project_id} (resolved from "
+                    f"{'the specified project_id' if override_project_id is not None else 'this team member\'s assigned project'}"
+                    "). Pass the correct project_id explicitly if you have access to it."
+                ),
+            )
+        raise HTTPException(status_code=404, detail="Story not found")
 
     now = datetime.now(timezone.utc)
     # AC3-4 2-2: anchor-only — agent_project_profiles가 presence 유일 소스.

--- a/backend/tests/test_s2_4_claim_unclaim.py
+++ b/backend/tests/test_s2_4_claim_unclaim.py
@@ -229,11 +229,12 @@ async def test_unclaim_story_403_when_caller_is_different_member():
         app.dependency_overrides.clear()
 
 
-# ─── AC3: story 없으면 400 ────────────────────────────────────────────────────
+# ─── AC3: story 없으면 400/404 ─────────────────────────────────────────────────
 
 @pytest.mark.anyio
-async def test_claim_story_400_if_story_not_in_project():
-    """AC3: story가 project에 없으면 400."""
+async def test_claim_story_404_if_story_does_not_exist_anywhere():
+    """AC3(story #2068 갱신): 어느 project에도 없는(오타/삭제) story면 404 — "다른
+    project에 있음"(400, 아래 별도 테스트)과 구분된다."""
     client, session, app = await _client()
     try:
         member = _mock_member()
@@ -247,7 +248,7 @@ async def test_claim_story_400_if_story_not_in_project():
             if call_count == 1:
                 result.scalar_one_or_none.return_value = member
             else:
-                result.scalar_one_or_none.return_value = None  # story 없음
+                result.scalar_one_or_none.return_value = None  # story 자체가 없음
             return result
 
         session.execute = mock_execute
@@ -260,7 +261,121 @@ async def test_claim_story_400_if_story_not_in_project():
                     json={"story_id": str(uuid.uuid4())},
                 )
 
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_claim_story_400_if_story_exists_in_different_project():
+    """story #2068 AC3: story가 실재하지만 다른 project 소속이면 400 + 실제 project_id를
+    메시지에 담는다(오타/삭제와 project_id 지정 문제를 구분)."""
+    client, session, app = await _client()
+    try:
+        member = _mock_member()
+        other_project_id = uuid.uuid4()
+        story_id = uuid.uuid4()
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = member
+            elif call_count == 2:
+                result.scalar_one_or_none.return_value = None  # 이 project엔 없음
+            else:
+                result.scalar_one_or_none.return_value = other_project_id  # 다른 project엔 있음
+            return result
+
+        session.execute = mock_execute
+
+        with patch("app.routers.team_members.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/team-members/{MEMBER_ID}/claim",
+                    json={"story_id": str(story_id)},
+                )
+
         assert resp.status_code == 400
+        assert str(other_project_id) in resp.json()["error"]["message"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_claim_story_200_with_project_id_override_targets_different_project():
+    """story #2068 AC1/AC2: project_id override 시 member.project_id(anchor) 대신 override로
+    story를 찾는다 — org-agent 멀티프로젝트 grant로 다른 project story를 claim하는 경로."""
+    client, session, app = await _client()
+    try:
+        member = _mock_member()
+        other_project_id = uuid.uuid4()
+        story = _mock_story()
+        story.project_id = other_project_id
+        updated = _mock_member(active_story_id=STORY_ID)
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = member
+            elif call_count == 2:
+                result.scalar_one_or_none.return_value = story
+            else:
+                result.scalar_one_or_none.return_value = updated
+            return result
+
+        session.execute = mock_execute
+        session.flush = AsyncMock()
+        session.refresh = AsyncMock()
+
+        with patch("app.routers.team_members.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None), \
+             patch("app.routers.team_members.has_project_access", new_callable=AsyncMock,
+                   return_value=True) as mock_access:
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/team-members/{MEMBER_ID}/claim",
+                    json={"story_id": str(STORY_ID), "project_id": str(other_project_id)},
+                )
+
+        assert resp.status_code == 200
+        mock_access.assert_awaited_once()
+        assert mock_access.await_args.args[2] == other_project_id
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_claim_story_403_when_no_access_to_override_project():
+    """story #2068: project_id override했지만 그 project에 접근권 없으면 403(무권한 project
+    story 존재 여부를 노출하지 않는다 — story 조회 자체를 안 탐)."""
+    client, session, app = await _client()
+    try:
+        member = _mock_member()
+        other_project_id = uuid.uuid4()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = member
+        session.execute = AsyncMock(return_value=result)
+
+        with patch("app.routers.team_members.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None), \
+             patch("app.routers.team_members.has_project_access", new_callable=AsyncMock,
+                   return_value=False):
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/team-members/{MEMBER_ID}/claim",
+                    json={"story_id": str(STORY_ID), "project_id": str(other_project_id)},
+                )
+
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## 요약
story #2068(high) — MCP `claim_story`가 `project_id` 인자를 지정해도 무시되고 항상 agent의 default project로 판정, 실재하는 story에 "Story not found in this project" 400이 나던 결함.

## 근본원인
`POST /api/v2/team-members/{id}/claim`이 `member.project_id`(claim 대상 team_members 행의 anchor project) 하나로만 story를 조회했다. MCP `SprintableClient`는 override 시 `project_id`를 body(자동 주입, `api_client.py`)와 `X-Project-Id` 헤더(85429ee0) 양쪽에 실어 보내지만, `ClaimBody` 스키마에 `project_id` 필드 자체가 없어 FastAPI가 body 값을 조용히 버렸고 헤더도 이 라우트에서 읽는 곳이 없었다.

## 변경사항
- `ClaimBody`에 `project_id: uuid.UUID | None = None` 추가.
- 해소 순서: 명시(body) > `X-Project-Id` 헤더(`has_project_access` 검증) > `member.project_id`(override 없을 때 기존 그대로 — 무회귀).
  - `app.dependencies.project_scope.resolve_required_project_id`(SSOT)를 의도적으로 안 씀 — 그건 최종 폴백이 "caller의 default project"인데, 이 라우트는 `id`(claim 대상 행)가 이미 자기 project로 결정론적으로 고정돼 있어 caller 기본값으로 바꾸면 override 없는 통상 케이스에서도 값이 갈릴 수 있는 새 축이 열린다.
- AC3(에러 메시지 정확도): story가 아예 없음(404) vs 다른 project에 있음(400 + 실제 project_id 노출, org 필터 유지)을 구분.

## 검증
- `uv run pytest tests/test_s2_4_claim_unclaim.py tests/test_claim_participation.py` — 15 passed, 2 skipped.
- `uv run pytest tests/ -k "team_member or claim"` — 90 passed, 17 skipped, 무회귀.
- 기존 AC3 테스트 하나는 의미가 갈려(진짜 없음 vs 다른 project) 404/400 두 테스트로 분리, override 성공/403(무권한) 테스트 2건 신규 추가.
- app import 검증 완료(490 routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)