### PR TITLE
[SID:2062] 칸반 카드 포커스 링 3면 잘림 — 스크롤 컨테이너 여백 0 근본수정

### DIFF
--- a/apps/web/src/components/kanban/kanban-column.test.tsx
+++ b/apps/web/src/components/kanban/kanban-column.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+//
+// story #2062 — kanban-column.tsx의 스크롤 컨테이너(overflow-y-auto)가 패딩 0이라 카드
+// 포커스 링(#2057, outline-offset 2px+width 2px=4px 돌출)이 스크롤 클리핑 박스에 위·좌·우
+// 3면이 잘리던 회귀. 스크롤 컨테이너 자신에게 여백(p-1.5=6px, 4px 돌출분보다 넉넉)이 있는지를
+// 실제 DOM(createRoot)으로 잠근다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { DndContext } from '@dnd-kit/core';
+import { KanbanColumn } from './kanban-column';
+import type { KanbanStory } from './types';
+import koMessages from '../../../messages/ko.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      <DndContext>{node}</DndContext>
+    </NextIntlClientProvider>
+  );
+}
+
+function story(overrides: Partial<KanbanStory>): KanbanStory {
+  return {
+    id: 's1',
+    title: '테스트 스토리',
+    status: 'backlog',
+    priority: 'medium',
+    story_points: null,
+    epic_id: null,
+    assignee_id: null,
+    assignee_ids: [],
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  } as KanbanStory;
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+describe('KanbanColumn — story #2062 포커스 링 클리핑', () => {
+  it('카드 스크롤 컨테이너(overflow-y-auto)에 여백(p-1.5)이 있다 — 링 4면 보임 자리 확보', async () => {
+    await act(async () => {
+      root.render(
+        wrap(
+          <KanbanColumn
+            id="backlog"
+            label="백로그"
+            stories={[story({ id: 's1' })]}
+            epicMap={{}}
+            memberMap={{}}
+            onStoryClick={vi.fn()}
+          />,
+        ),
+      );
+    });
+
+    const scrollContainer = container.querySelector('.overflow-y-auto');
+    expect(scrollContainer).not.toBeNull();
+    expect(scrollContainer?.className).toContain('p-1.5');
+  });
+});

--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -290,7 +290,11 @@ export function KanbanColumn({
       {!collapsed && (
         <>
           <SortableContextCompat items={stories.map((s) => s.id)} strategy={verticalListSortingStrategy}>
-            <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-y-auto [&>*]:shrink-0">
+            {/* story #2062: overflow-y-auto가 패딩 0이면 #2057 포커스 링(outline-offset 2px+
+                width 2px=4px 돌출)이 이 스크롤 클리핑 박스에 위·좌·우 3면이 잘린다(CSS 스펙상
+                overflow-y만 지정해도 overflow-x가 auto로 계산돼 좌우도 클리핑 박스가 된다).
+                p-1.5(6px)로 4px 돌출분보다 넉넉한 여백을 준다. */}
+            <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-y-auto p-1.5 [&>*]:shrink-0">
               {stories.length === 0 && !composing ? (
                 <div className="flex min-h-[100px] items-center justify-center px-4 text-center">
                   <p className="text-xs text-muted-foreground/60">{t('noStories')}</p>


### PR DESCRIPTION
까심 아르야 실제 키보드 Tab 검수: 칸반 카드에 포커스가 가면 링(#2057, outline-offset 2px+width 2px=4px 돌출)의 위·좌·우 3면이 완전히 잘려 안 보였다. 아래쪽만 카드 사이 gap-2(8px) 덕에 살아남았다.

## 원인
`kanban-column.tsx:293`의 스크롤 컨테이너가 `overflow-y-auto`인데 패딩이 0이다. CSS 스펙상 overflow-y만 지정해도 overflow-x가 auto로 계산되므로 좌우도 클리핑 박스가 된다. 색·알파 문제가 아니라 순수 레이아웃 문제라 #2057(알파 제거) 스코프로는 못 고치는 자리였다.

## 수정
스크롤 컨테이너 자신에게 `p-1.5`(6px, 4px 돌출분보다 넉넉한 버퍼) 추가.

## 검증
RED→GREEN: kanban-column.tsx만 stash 후 재실행 → 신규 테스트 정확히 실패, 복원 후 pass. type-check/lint(0 errors)/build(EXIT 0)/vitest 전체(285파일·1963개) 전부 green.

## AC3(다른 스크롤 컨테이너 전수) — 별도 PR로 분리
126개 스크롤 컨테이너 전수 감사 결과 33곳(이 파일 포함)에서 같은 패턴 발견. 유나 홀름과 디자인 판단(전역 inset-ring은 primary 버튼 대비 1.00으로 무력화돼 불가 — 컨테이너 단위 `.focus-inset` 유틸리티로 절충) 완료, 별도 PR로 진행 중.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>