### PR TITLE
[SID:2062] AC3 — 스크롤 컨테이너 포커스 링 클리핑 전수 수정 (focus-inset, 유나 규격)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,11 @@ jobs:
       - name: "Verify no hand-rolled modal without accessibility (story #2061 regression guard)"
         run: pnpm --filter web verify:no-handrolled-modal
 
+      # story #2062 회귀가드: 패딩도 focus-inset(유나 규격)도 없는 overflow-*-auto|scroll
+      # 스크롤 컨테이너가 새로 들어오면 이 스텝이 실패한다(#2057 포커스 링 클리핑 재발 방지).
+      - name: "Verify focus-inset coverage on scroll containers (story #2062 regression guard)"
+        run: pnpm --filter web verify:focus-inset-coverage
+
       - name: Test
         # set -o pipefail so vitest's non-zero exit propagates through `| tail` instead
         # of being masked by tail's 0 — without it the unit-test gate was a no-op

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "verify:no-new-md-breakpoint": "tsx scripts/verify-no-new-md-breakpoint.ts",
     "verify:no-alpha-focus-ring": "tsx scripts/verify-no-alpha-focus-ring.ts",
     "verify:no-handrolled-modal": "tsx scripts/verify-no-handrolled-modal.ts",
+    "verify:focus-inset-coverage": "tsx scripts/verify-focus-inset-coverage.ts",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
     "e2e:report": "playwright show-report"

--- a/apps/web/scripts/verify-focus-inset-coverage.test.ts
+++ b/apps/web/scripts/verify-focus-inset-coverage.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { findFocusInsetViolations } from './verify-focus-inset-coverage';
+
+describe('verify-focus-inset-coverage — story #2062 회귀가드', () => {
+  it('패딩도 focus-inset도 없는 overflow-y-auto 컨테이너를 잡는다', () => {
+    const violations = findFocusInsetViolations(`
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+        {items.map((i) => <button key={i.id}>{i.label}</button>)}
+      </div>
+    `);
+    expect(violations).toHaveLength(1);
+  });
+
+  it('focus-inset이 있으면 안전으로 판정한다', () => {
+    const violations = findFocusInsetViolations(`
+      <div className="focus-inset flex min-h-0 flex-1 flex-col overflow-y-auto">
+        {items.map((i) => <button key={i.id}>{i.label}</button>)}
+      </div>
+    `);
+    expect(violations).toHaveLength(0);
+  });
+
+  it('패딩(p-*)이 있으면 안전으로 판정한다', () => {
+    const violations = findFocusInsetViolations(`
+      <div className="max-h-64 overflow-y-auto p-1.5">
+        <button>ok</button>
+      </div>
+    `);
+    expect(violations).toHaveLength(0);
+  });
+
+  it('템플릿 리터럴 className도 검사한다', () => {
+    const violations = findFocusInsetViolations(
+      '<div className={`flex flex-1 overflow-y-auto ${extra}`}><button>a</button></div>',
+    );
+    expect(violations).toHaveLength(1);
+  });
+
+  it('DialogContent는 자체 p-4 내장이라 패딩/focus-inset 없어도 안전하다', () => {
+    const violations = findFocusInsetViolations(`
+      <DialogContent className="max-h-[80vh] max-w-lg overflow-y-auto">
+        <button>ok</button>
+      </DialogContent>
+    `);
+    expect(violations).toHaveLength(0);
+  });
+
+  it('컨테이너 자신이 <pre>(코드/텍스트 렌더)면 안전으로 판정한다', () => {
+    const violations = findFocusInsetViolations(`
+      <pre className="max-h-48 overflow-auto whitespace-pre-wrap">
+        {streamText}
+      </pre>
+    `);
+    expect(violations).toHaveLength(0);
+  });
+
+  it('컨테이너 바로 다음이 <table>이면 안전으로 판정한다(읽기전용 표)', () => {
+    const violations = findFocusInsetViolations(`
+      <div className="overflow-x-auto rounded-md border">
+        <table className="w-full">
+          <tbody />
+        </table>
+      </div>
+    `);
+    expect(violations).toHaveLength(0);
+  });
+
+  it('KaTeX 렌더(className에 .katex 셀렉터)는 안전으로 판정한다', () => {
+    const violations = findFocusInsetViolations(`
+      <div className="flex justify-center overflow-x-auto [&_.katex]:text-foreground" />
+    `);
+    expect(violations).toHaveLength(0);
+  });
+});

--- a/apps/web/scripts/verify-focus-inset-coverage.ts
+++ b/apps/web/scripts/verify-focus-inset-coverage.ts
@@ -1,0 +1,153 @@
+/**
+ * story #2062 회귀가드 — `overflow-*-auto|scroll` 스크롤 컨테이너가 패딩도 없고
+ * `focus-inset`(유나 규격, story #2062)도 없이 새로 들어오는 것을 잡는다.
+ *
+ * 배경: 패딩 0인 스크롤 컨테이너는 #2057의 포커스 링(outline-offset 2px+width 2px=4px
+ * 돌출)이 스크롤 클리핑 박스에 잘린다(CSS 스펙상 overflow-y만 지정해도 overflow-x가
+ * auto로 계산돼 좌우도 클리핑된다). 33곳(칸반 포함)을 오늘 고쳤다 — 칸반은 패딩(p-1.5),
+ * 나머지 32곳은 `focus-inset` 유틸리티 클래스(globals.css, outline-offset:-2px로 링을
+ * 안쪽에 그려 클리핑을 원천 회피)로. 이 가드는 그 규율이 34번째 컨테이너에서 또 깨지지
+ * 않게 지킨다.
+ *
+ * 판정: 같은 className 문자열 안에 overflow 패턴이 있고, 패딩 클래스(p-/px-/py-/pt-/pb-/
+ * pl-/pr-)도 `focus-inset`도 없으면 위반. "표식이 아니라 효과"까지 정적으로 검증하긴
+ * 어렵다(globals.css의 실제 CSS 규칙이 살아있는지는 별개) — 그건 회귀 시 유닛 테스트가
+ * globals.css 자체를 깨뜨리면 별도로 드러난다. 이 가드는 "새 컨테이너가 그 표식을
+ * 빠뜨렸는가"만 잡는다.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const OVERFLOW_RE = /overflow(-[xy])?-(auto|scroll)\b/;
+const PADDING_RE = /\b(p|px|py|pt|pb|pl|pr)-(\d|\[)/;
+const FOCUS_INSET_RE = /\bfocus-inset\b/;
+
+// 읽기전용 콘텐츠 wrapper — 컨테이너 바로 다음(3줄 이내)이 표/코드블록/수식 렌더면 포커스
+// 가능 자식이 없어 클리핑될 링 자체가 없다(실측: chat-bubble/doc-content-renderer의
+// markdown 표 렌더러, math-node의 KaTeX, ai-summarize-button의 스트리밍 <pre>). 이걸 넘어
+// "포커스 가능 자식이 아예 없다"를 라인 수 기반 부재-휴리스틱으로 일반화하지 않는다 —
+// 없음을 증명하는 것은 있음을 증명하는 것보다 오탐(진짜 위반 누락) 위험이 커서, 구조가
+// 명확한 이 3개 패턴만 명시적으로 안전 처리한다(PO 판단: "표식이 아니라 효과"까지 완벽히
+// 보는 건 과할 수 있으니 판단해서 — 이 선이 그 판단선이다).
+const READONLY_CONTENT_LOOKAHEAD_RE = /<(table|pre)\b|\.katex/;
+const LOOKAHEAD_LINES = 3;
+
+export interface FocusInsetViolation {
+  line: number;
+  snippet: string;
+}
+
+// className 리터럴/템플릿 리터럴 어느 쪽이든, overflow 패턴이 등장하는 "그 속성 문자열"만
+// 본다 — 파일 전체가 아니라 className={`...`} 또는 className="..." 한 덩어리. 직전 JSX 태그
+// 이름(tagContext)과 다음 몇 줄(lookahead)도 같이 캡처한다.
+function extractClassAttrs(
+  content: string,
+): { line: number; text: string; tagContext: string; lookahead: string }[] {
+  const results: { line: number; text: string; tagContext: string; lookahead: string }[] = [];
+  const classAttrRe = /className=(\{`([^`]*)`\}|"([^"]*)")/g;
+  let match: RegExpExecArray | null;
+  while ((match = classAttrRe.exec(content))) {
+    const text = match[2] ?? match[3] ?? '';
+    const line = content.slice(0, match.index).split('\n').length;
+    const tagContext = content.slice(Math.max(0, match.index - 60), match.index);
+    const afterIdx = match.index + match[0].length;
+    const lookahead = content
+      .slice(afterIdx)
+      .split('\n')
+      .slice(0, LOOKAHEAD_LINES)
+      .join('\n');
+    results.push({ line, text, tagContext, lookahead });
+  }
+  return results;
+}
+
+// 자체 base className에 p-4(16px, 4px 돌출분보다 넉넉)를 내장한 캐노니컬 컴포넌트 —
+// 호출부 className은 cn()으로 병합될 뿐 그 기본 패딩을 지우지 않으므로(호출부가 명시적
+// p-*를 주지 않는 한) 안전하다. dialog.tsx DialogPrimitive.Popup 실측(p-4) 확認.
+const SAFE_BASE_COMPONENT_RE = /<DialogContent\b/;
+
+export function findFocusInsetViolations(content: string): FocusInsetViolation[] {
+  const violations: FocusInsetViolation[] = [];
+  for (const { line, text, tagContext, lookahead } of extractClassAttrs(content)) {
+    if (!OVERFLOW_RE.test(text)) continue;
+    if (PADDING_RE.test(text)) continue;
+    if (FOCUS_INSET_RE.test(text)) continue;
+    if (SAFE_BASE_COMPONENT_RE.test(tagContext)) continue;
+    // <pre className="overflow-auto ...">처럼 태그 자신이 표/코드블록인 경우(태그명이
+    // className보다 앞)와, 컨테이너 바로 다음 줄에 <table>이 오는 경우(태그명이 뒤) 둘 다 본다.
+    if (
+      READONLY_CONTENT_LOOKAHEAD_RE.test(text) ||
+      READONLY_CONTENT_LOOKAHEAD_RE.test(lookahead) ||
+      /<(table|pre)\b/.test(tagContext)
+    ) continue;
+    violations.push({ line, snippet: text.trim().slice(0, 120) });
+  }
+  return violations;
+}
+
+const EXT_RE = /\.tsx$/;
+const TEST_RE = /\.test\.tsx$/;
+
+function walk(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walk(full, out);
+    } else if (EXT_RE.test(entry) && !TEST_RE.test(entry)) {
+      out.push(full);
+    }
+  }
+}
+
+// 검사 대상 0건이면 위반 0건과 구분 안 되는 함정(#2057에서 실제로 겪은 사고) — self-assert.
+const MIN_EXPECTED_FILES = 300;
+
+// story #2062 — 의도적으로 미룬 단 하나의 예외. app/dashboard/dashboard-shell.tsx는 앱
+// 전체를 감싸는 최상위 셸이라 `focus-inset`을 붙이면 그 안의 모든 후손 :focus-visible이
+// inset되는데, 그중 solid `bg-primary` 버튼이 전역에 다수 존재해 각각에 `focus-outset`
+// 예외를 달아야 하는 파급 범위를 이 스토리 하나로 판단하기엔 과하다(PO+유나 재검토 필요,
+// 아직 미결). 손으로 관리하는 목록은 뒤처진다는 규율을 알면서도 남기는 단 하나의 예외 —
+// 목록이 자라면(2번째 항목이 생기면) 그 자체가 "이 방식으로는 못 버틴다"는 신호로 읽는다.
+const DEFERRED_FILES = new Set(['app/dashboard/dashboard-shell.tsx']);
+
+function main(): void {
+  const srcRoot = path.resolve(process.cwd(), 'src');
+  const files: string[] = [];
+  walk(srcRoot, files);
+
+  if (files.length < MIN_EXPECTED_FILES) {
+    console.error(
+      `FAIL: 검사 대상 파일이 ${files.length}개뿐 — 경로/실행 위치가 틀렸을 가능성. 가드가 헛돌고 있다.`,
+    );
+    console.error(`  srcRoot=${srcRoot} (기대 최소 ${MIN_EXPECTED_FILES}개)`);
+    process.exit(1);
+  }
+
+  const allViolations: { file: string; line: number; snippet: string }[] = [];
+  for (const abs of files) {
+    const rel = path.relative(srcRoot, abs).split(path.sep).join('/');
+    if (DEFERRED_FILES.has(rel)) continue;
+    const content = readFileSync(abs, 'utf8');
+    for (const v of findFocusInsetViolations(content)) {
+      allViolations.push({ file: rel, ...v });
+    }
+  }
+
+  if (allViolations.length > 0) {
+    console.error('FAIL: 패딩도 focus-inset도 없는 스크롤 컨테이너 발견(story #2062 회귀):');
+    for (const v of allViolations) console.error(`  - ${v.file}:${v.line}  ${v.snippet}`);
+    console.error(
+      '\n`overflow-*-auto|scroll` 컨테이너는 패딩(p-*)을 주거나 `focus-inset`(@/app/globals.css,' +
+        ' story #2062)을 붙여 포커스 링 클리핑을 막는다. 컨테이너 안에 solid `bg-primary` 버튼이' +
+        ' 있으면 그 버튼에 `focus-outset`도 같이 붙인다(inset이면 링=배경 대비 1.00으로 안 보임).',
+    );
+    process.exit(1);
+  }
+
+  console.log(`OK: focus-inset 커버리지 회귀 0건 (검사 파일 ${files.length}개)`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
@@ -290,7 +290,7 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* Desktop sidebar — hidden on mobile */}
         {!sidebarCollapsed && (
-          <aside className="relative hidden w-[236px] flex-shrink-0 flex-col overflow-y-auto border-r border-border/80 bg-background lg:flex">
+          <aside className="focus-inset relative hidden w-[236px] flex-shrink-0 flex-col overflow-y-auto border-r border-border/80 bg-background lg:flex">
             <button
               type="button"
               onClick={handleToggleSidebar}
@@ -364,7 +364,7 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
             <span className="text-sm font-medium text-foreground">{t('title')}</span>
             <button type="button" onClick={closeDrawer} className="rounded p-1 text-muted-foreground hover:text-foreground" aria-label="닫기"><X className="size-4" /></button>
           </div>
-          <div className="flex-1 overflow-y-auto">{sidebarContent}</div>
+          <div className="focus-inset flex-1 overflow-y-auto">{sidebarContent}</div>
         </div>
       </div>
 

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-shell-client.tsx
@@ -741,7 +741,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
                   <X className="size-4" />
                 </button>
               </div>
-              <div className="flex-1 overflow-y-auto">
+              <div className="focus-inset flex-1 overflow-y-auto">
                 {sidebarContent}
               </div>
             </div>

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
@@ -820,7 +820,7 @@ function CreateModal({ projectId, orgId, onCreated, onClose }: CreateModalProps)
         </div>
         {/* Scrollable body — long forms (outcome 추가 등) overflow the viewport otherwise;
             internal scroll keeps every field + the submit button reachable (S5). */}
-        <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-6">
+        <div className="focus-inset min-h-0 flex-1 overflow-y-auto px-6 pb-6">
           <GoalCreateForm
             projectId={projectId}
             orgId={orgId}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/steer-dispatch-modal.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/steer-dispatch-modal.tsx
@@ -122,7 +122,7 @@ export function SteerDispatchModal({ projectId, items, onClose, onDispatched }: 
           <DialogDescription>{t('steerCommitDesc')}</DialogDescription>
         </DialogHeader>
 
-        <div className="max-h-64 overflow-y-auto py-1">
+        <div className="focus-inset max-h-64 overflow-y-auto py-1">
           {agents === null ? (
             <p className="py-4 text-center text-sm text-muted-foreground">{t('loading')}</p>
           ) : agents.length === 0 ? (

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx
@@ -626,7 +626,7 @@ export default function RetroSessionPage() {
         }
       />
 
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <div className="focus-inset flex min-h-0 flex-1 flex-col overflow-y-auto">
         {/* E-SPRINT-LOOP FE(5feac498) — 셸(stepper 프레임)은 항상 렌더(핸드오프 §4①). session
             도착 전엔 중립 skeleton 칩(어느 단계인지 아직 모름)·도착 후 실제 상태로 hydrate. */}
         {session && currentStage ? (

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/page.tsx
@@ -149,7 +149,7 @@ export default function RetroPage() {
         }
       />
 
-      <div className="flex min-h-0 flex-1 flex-col gap-0 overflow-y-auto">
+      <div className="focus-inset flex min-h-0 flex-1 flex-col gap-0 overflow-y-auto">
         {/* Create new session — toggle via TopBar button */}
         {showCreateForm && (
           <div className="flex-shrink-0 border-b border-border/80 px-6 py-4">

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/standup/standup-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/standup/standup-client.tsx
@@ -452,7 +452,7 @@ export default function StandupPage({ projectId }: StandupClientProps) {
         {dateNavControls}
       </div>
 
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <div className="focus-inset flex min-h-0 flex-1 flex-col overflow-y-auto">
         {headerBadges.length > 0 ? (
           <div className="flex flex-wrap items-center gap-2 border-b border-border/80 px-6 py-3">
             {headerBadges.map((badge) => (
@@ -712,7 +712,7 @@ export default function StandupPage({ projectId }: StandupClientProps) {
                                 </div>
                               ) : null}
                               {storyPickerStories.length > 0 ? (
-                                <div className="max-h-40 space-y-1.5 overflow-y-auto">
+                                <div className="focus-inset max-h-40 space-y-1.5 overflow-y-auto">
                                   {storyPickerStories.map((story) => {
                                     const checked = planStoryIds.includes(story.id);
                                     return (

--- a/apps/web/src/app/(authenticated)/inbox/page.tsx
+++ b/apps/web/src/app/(authenticated)/inbox/page.tsx
@@ -444,7 +444,7 @@ export default function InboxPage() {
             caused a 768-1023 tablet seam where the mobile bottom-tab shell and this master-detail
             split disagreed on what "mobile" means. */}
         <div className={`flex w-full min-w-[320px] flex-col border-r border-border/80 lg:max-w-[420px] max-lg:min-w-0 ${selectedId ? 'max-lg:hidden' : ''}`}>
-          <div className="flex-1 overflow-y-auto py-2">
+          <div className="focus-inset flex-1 overflow-y-auto py-2">
             {loading ? (
               <div className="space-y-2 px-3 pt-2">
                 {[1, 2, 3, 4, 5].map((i) => (
@@ -570,7 +570,7 @@ export default function InboxPage() {
 
         {/* Right: detail panel. max-lg: hidden when nothing selected (the list owns the
             screen); full-screen with a back button when an item is tapped (efcb3840 ⓑ, #1986). */}
-        <div className={`flex min-w-0 flex-1 flex-col overflow-y-auto ${!selectedId ? 'max-lg:hidden' : ''}`}>
+        <div className={`focus-inset flex min-w-0 flex-1 flex-col overflow-y-auto ${!selectedId ? 'max-lg:hidden' : ''}`}>
           {selectedNotification ? (
             <button
               type="button"

--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
@@ -653,7 +653,7 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
                   </div>
                   {/* 다음 버튼이 긴 리스트 하단에 묻히지 않도록 리스트 자체를 bounded-height 스크롤로 격리 —
                       버튼은 이 영역 밖(항상 보임)에 위치. */}
-                  <div className="max-h-[55vh] space-y-4 overflow-y-auto pr-0.5">
+                  <div className="focus-inset max-h-[55vh] space-y-4 overflow-y-auto pr-0.5">
                     {roleGroups.length === 0 ? (
                       <p className="py-6 text-center text-sm text-muted-foreground">{t('roleSearchEmpty')}</p>
                     ) : roleGroups.map((group) => (
@@ -771,7 +771,7 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
                     {[0, 1].map((i) => <Skeleton key={i} className="h-14 rounded-md" />)}
                   </div>
                 ) : scopeMode === 'projects' ? (
-                  <div className="grid max-h-56 gap-3 overflow-y-auto sm:grid-cols-2">
+                  <div className="focus-inset grid max-h-56 gap-3 overflow-y-auto sm:grid-cols-2">
                     {(orgProjects ?? []).map((project) => {
                       const selected = scopeProjectIds.includes(project.id);
                       return (

--- a/apps/web/src/app/(authenticated)/rewards/page.tsx
+++ b/apps/web/src/app/(authenticated)/rewards/page.tsx
@@ -105,7 +105,7 @@ export default function RewardsPage() {
     <>
       <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
 
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <div className="focus-inset flex min-h-0 flex-1 flex-col overflow-y-auto">
         <div className="mx-auto w-full max-w-3xl space-y-5 p-6">
 
           {/* 리더보드 */}

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -681,7 +681,7 @@ export default function SettingsPage() {
         </div>
 
         {/* Right content */}
-        <div className="flex-1 min-w-0 overflow-y-auto">
+        <div className="focus-inset flex-1 min-w-0 overflow-y-auto">
           {/* Mobile toggle button */}
           <div className="lg:hidden flex items-center gap-2 border-b px-4 py-2">
             <SidebarTrigger className="mr-1" />

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -498,6 +498,19 @@
   *::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 3px; }
   *::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); }
 
+  /* story #2062(유나 규격): #2057의 outline-offset:2px(바깥 4px 돌출)가 패딩 0인
+     overflow-*-auto 스크롤 컨테이너에서 클리핑된다 — 링이 컨테이너 밖으로 못 새어나가
+     잘린다. 컨테이너에 `.focus-inset`을 붙이면 그 안의 포커스 링이 요소 안쪽으로 그려져
+     클리핑을 원천 회피한다(레이아웃은 안 건드림 — #2062 AC2 대안 중 유나 실측 채택).
+     단, primary 배경 버튼은 링 색=배경색이라 inset이면 대비 1.00(안 보임) — 그런 버튼에는
+     `.focus-outset`을 같이 붙여 바깥 링으로 되돌린다. */
+  .focus-inset :focus-visible {
+    outline-offset: -2px;
+  }
+  .focus-inset .focus-outset:focus-visible {
+    outline-offset: 2px;
+  }
+
   html {
     @apply font-sans;
     text-autospace: ideograph-alpha ideograph-numeric;

--- a/apps/web/src/components/agents/access-matrix-tab.tsx
+++ b/apps/web/src/components/agents/access-matrix-tab.tsx
@@ -172,7 +172,7 @@ export function AccessMatrixTab() {
               <p className="text-sm text-muted-foreground">{ta('matrixEmpty')}</p>
             </div>
           ) : (
-            <div className="overflow-x-auto rounded-md border border-border">
+            <div className="focus-inset overflow-x-auto rounded-md border border-border">
               <table className="w-full border-collapse text-sm">
                 <thead>
                   <tr className="border-b border-border bg-muted/30">

--- a/apps/web/src/components/canvas/story-picker-dialog.tsx
+++ b/apps/web/src/components/canvas/story-picker-dialog.tsx
@@ -73,7 +73,7 @@ export function StoryPickerDialog({ open, onOpenChange, projectId, onSelect }: S
           placeholder={t('storyPickerSearchPlaceholder')}
         />
 
-        <div className="max-h-64 space-y-1 overflow-y-auto">
+        <div className="focus-inset max-h-64 space-y-1 overflow-y-auto">
           {loading ? (
             <p className="px-1 py-2 text-xs text-muted-foreground">{t('storyPickerLoading')}</p>
           ) : stories.length === 0 ? (

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -502,7 +502,7 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
       <div className="relative flex items-end gap-2">
         {/* Command dropdown (선생님 B·mockup #3) — mention/entity 셸·키보드 nav 동일·command 활성=info 신호 토큰 */}
         {commandCandidates.length > 0 && (
-          <ul role="listbox" aria-label="커맨드 후보" className="absolute bottom-full left-8 z-50 mb-1 max-h-48 w-72 overflow-y-auto rounded-md border border-border bg-popover shadow-md">
+          <ul role="listbox" aria-label="커맨드 후보" className="focus-inset absolute bottom-full left-8 z-50 mb-1 max-h-48 w-72 overflow-y-auto rounded-md border border-border bg-popover shadow-md">
             {commandCandidates.map((cmd, idx) => (
               <li key={cmd.name}>
                 <button
@@ -524,7 +524,7 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
 
         {/* Mention dropdown */}
         {mentionMembers.length > 0 && (
-          <ul role="listbox" aria-label="멘션 후보" className="absolute bottom-full left-8 z-50 mb-1 max-h-48 w-56 overflow-y-auto rounded-md border border-border bg-popover shadow-md">
+          <ul role="listbox" aria-label="멘션 후보" className="focus-inset absolute bottom-full left-8 z-50 mb-1 max-h-48 w-56 overflow-y-auto rounded-md border border-border bg-popover shadow-md">
             {mentionMembers.map((member, idx) => (
               <li key={member.id}>
                 <button
@@ -545,7 +545,7 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
 
         {/* Entity dropdown */}
         {entityResults.length > 0 && (
-          <ul role="listbox" aria-label="엔티티 후보" className="absolute bottom-full left-8 z-50 mb-1 max-h-48 w-72 overflow-y-auto rounded-md border border-border bg-popover shadow-md">
+          <ul role="listbox" aria-label="엔티티 후보" className="focus-inset absolute bottom-full left-8 z-50 mb-1 max-h-48 w-72 overflow-y-auto rounded-md border border-border bg-popover shadow-md">
             {entityResults.map((entity, idx) => {
               const EntityIcon = ENTITY_ICONS[entity.entity_type] ?? Hash;
               return (

--- a/apps/web/src/components/docs/doc-breadcrumb.tsx
+++ b/apps/web/src/components/docs/doc-breadcrumb.tsx
@@ -31,7 +31,7 @@ export function DocBreadcrumb({ currentDocId, tree, onExpandFolder, ariaLabel }:
   if (path.length <= 1) return null;
 
   return (
-    <nav aria-label={ariaLabel} className="flex min-w-0 items-center gap-0.5 overflow-x-auto pb-0.5 text-[11px] text-muted-foreground">
+    <nav aria-label={ariaLabel} className="focus-inset flex min-w-0 items-center gap-0.5 overflow-x-auto pb-0.5 text-[11px] text-muted-foreground">
       {path.map((doc, idx) => {
         const isCurrent = idx === path.length - 1;
         return (

--- a/apps/web/src/components/docs/doc-toc.tsx
+++ b/apps/web/src/components/docs/doc-toc.tsx
@@ -63,7 +63,7 @@ export function DocToc({ headings, onHeadingClick, className }: DocTocProps) {
               <X className="size-3.5" />
             </button>
           </div>
-          <nav className="max-h-72 overflow-y-auto py-1.5">
+          <nav className="focus-inset max-h-72 overflow-y-auto py-1.5">
             {headings.map((heading) => (
               <button
                 key={heading.id}

--- a/apps/web/src/components/docs/docs-shell.tsx
+++ b/apps/web/src/components/docs/docs-shell.tsx
@@ -12,7 +12,7 @@ export function DocsShell({
 }) {
   return (
     <div className={cn('flex h-full flex-row overflow-hidden', className)}>
-      <aside className="flex w-[236px] flex-shrink-0 flex-col border-r border-border/80 bg-background overflow-y-auto">
+      <aside className="focus-inset flex w-[236px] flex-shrink-0 flex-col border-r border-border/80 bg-background overflow-y-auto">
         {sidebar}
       </aside>
       <section className="flex min-w-0 flex-1 flex-col bg-background overflow-hidden">

--- a/apps/web/src/components/docs/extensions/code-block-copy.tsx
+++ b/apps/web/src/components/docs/extensions/code-block-copy.tsx
@@ -164,7 +164,7 @@ function ShikiBlockView({ node, editor, selected }: ReactNodeViewProps) {
               {isEditable && <ChevronDown className="size-3" />}
             </button>
             {showLangMenu && (
-              <div className="absolute left-0 top-full z-50 mt-1 max-h-52 w-36 overflow-y-auto rounded-xl border border-border bg-popover py-1">
+              <div className="focus-inset absolute left-0 top-full z-50 mt-1 max-h-52 w-36 overflow-y-auto rounded-xl border border-border bg-popover py-1">
                 {SUPPORTED_LANGUAGES.map((lang) => (
                   <button
                     key={lang}

--- a/apps/web/src/components/epics/hypothesis-declaration-card.tsx
+++ b/apps/web/src/components/epics/hypothesis-declaration-card.tsx
@@ -279,7 +279,7 @@ export function HypothesisDeclarationCard({
           ) : filteredLinkable.length === 0 ? (
             <p className="py-2 text-center text-xs text-muted-foreground">{th('pickerEmpty')}</p>
           ) : (
-            <div className="max-h-32 space-y-1 overflow-y-auto">
+            <div className="focus-inset max-h-32 space-y-1 overflow-y-auto">
               {filteredLinkable.map((h) => (
                 <button
                   key={h.id}

--- a/apps/web/src/components/glance/roadmap-flow.tsx
+++ b/apps/web/src/components/glance/roadmap-flow.tsx
@@ -49,7 +49,7 @@ export function RoadmapFlow({ epics, totalEpicCount, className }: RoadmapFlowPro
           높이 잠식) 대신 가로스크롤. 보강③ 양끝 페이드로 "더 있음" 스크롤 발견성 신호(relative
           wrapper + pointer-events-none 그라데이션 오버레이, from-background로 페이지 배경과 합성). */}
       <div className="relative">
-        <div className="flex items-start overflow-x-auto">
+        <div className="focus-inset flex items-start overflow-x-auto">
           {epics.map((e, i) => (
             <div key={e.id} className="flex items-start">
               <Link

--- a/apps/web/src/components/hypotheses/story-hypotheses-section.tsx
+++ b/apps/web/src/components/hypotheses/story-hypotheses-section.tsx
@@ -213,7 +213,7 @@ export function StoryHypothesesSection({
           ) : filteredCandidates.length === 0 ? (
             <p className="px-1 py-2 text-xs text-muted-foreground">{t('pickerEmpty')}</p>
           ) : (
-            <ul className="max-h-48 space-y-1 overflow-y-auto">
+            <ul className="focus-inset max-h-48 space-y-1 overflow-y-auto">
               {filteredCandidates.map((h) => (
                 <li key={h.id}>
                   <button

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -947,7 +947,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
                 />
               </div>
               <DropdownMenuSeparator />
-              <div className="max-h-[50vh] overflow-y-auto">
+              <div className="focus-inset max-h-[50vh] overflow-y-auto">
                 <DropdownMenuGroup>
                   <DropdownMenuItem onClick={() => updateFilter('sprint_id', '')}>
                     <span className="flex-1">{t('allSprints')}</span>
@@ -1007,7 +1007,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
                 />
               </div>
               <DropdownMenuSeparator />
-              <div className="max-h-[50vh] overflow-y-auto">
+              <div className="focus-inset max-h-[50vh] overflow-y-auto">
                 <DropdownMenuGroup>
                   <DropdownMenuItem onClick={() => updateFilter('epic_id', '')}>
                     <span className="flex-1">{t('allEpics')}</span>
@@ -1067,7 +1067,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
                 />
               </div>
               <DropdownMenuSeparator />
-              <div className="max-h-[50vh] overflow-y-auto">
+              <div className="focus-inset max-h-[50vh] overflow-y-auto">
                 <DropdownMenuGroup>
                   <DropdownMenuItem onClick={() => updateFilter('assignee_id', '')}>
                     <span className="flex-1">{t('allAssignees')}</span>
@@ -1147,7 +1147,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
                   />
                 </div>
                 <DropdownMenuSeparator />
-                <div className="max-h-[50vh] overflow-y-auto">
+                <div className="focus-inset max-h-[50vh] overflow-y-auto">
                   <DropdownMenuGroup>
                     <DropdownMenuItem onClick={() => setSelectedLabelIds([])}>
                       <span className="flex-1">{t('allLabels')}</span>
@@ -1256,7 +1256,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
         ) : null}
         <div className="min-h-0 flex-1 overflow-hidden">
         {viewMode === 'list' ? (
-          <div className="h-full overflow-y-auto">
+          <div className="focus-inset h-full overflow-y-auto">
             <KanbanListView
               stories={filteredStories}
               epicMap={epicMap}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -1376,7 +1376,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                     className="w-full rounded border border-border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-primary"
                   />
                   {depQueryResults.length > 0 && (
-                    <ul className="max-h-32 overflow-y-auto rounded border border-border bg-background">
+                    <ul className="focus-inset max-h-32 overflow-y-auto rounded border border-border bg-background">
                       {depQueryResults.map((s) => (
                         <li key={s.id}>
                           <button

--- a/apps/web/src/components/loops/loop-create-dialog.tsx
+++ b/apps/web/src/components/loops/loop-create-dialog.tsx
@@ -466,7 +466,7 @@ export function LoopCreateDialog({
                 ) : filteredHypotheses.length === 0 ? (
                   <p className="py-2 text-center text-xs text-muted-foreground">{t('createLoopLinkEmpty')}</p>
                 ) : (
-                  <div className="max-h-40 space-y-1 overflow-y-auto">
+                  <div className="focus-inset max-h-40 space-y-1 overflow-y-auto">
                     {filteredHypotheses.map((h) => (
                       <button
                         key={h.id}

--- a/apps/web/src/components/nav/notification-bell.tsx
+++ b/apps/web/src/components/nav/notification-bell.tsx
@@ -184,7 +184,7 @@ function NotificationPanel({
       </div>
 
       {/* 필터 탭 */}
-      <div className="flex shrink-0 overflow-x-auto border-b">
+      <div className="focus-inset flex shrink-0 overflow-x-auto border-b">
         {FILTER_TABS.map((tab) => (
           <button
             key={tab.value}
@@ -205,7 +205,9 @@ function NotificationPanel({
             type="button"
             onClick={() => setShowUnreadOnly((v) => !v)}
             className={cn(
-              'rounded-full px-2.5 py-0.5 text-[11px] font-medium transition',
+              // story #2062: showUnreadOnly=true면 bg-primary(링색과 동일) — focus-inset 컨테이너
+              // 안에서는 inset 링이 안 보이므로 focus-outset으로 바깥 링을 되돌린다(유나 규격).
+              'focus-outset rounded-full px-2.5 py-0.5 text-[11px] font-medium transition',
               showUnreadOnly
                 ? 'bg-primary text-primary-foreground'
                 : 'bg-muted text-muted-foreground hover:text-foreground',
@@ -217,7 +219,7 @@ function NotificationPanel({
       </div>
 
       {/* 목록 */}
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="focus-inset min-h-0 flex-1 overflow-y-auto">
         {loading ? (
           <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
             {tCommon('loading')}

--- a/apps/web/src/components/presence/team-presence-panel.tsx
+++ b/apps/web/src/components/presence/team-presence-panel.tsx
@@ -107,7 +107,7 @@ export function TeamPresencePanel({
         ) : null}
       </header>
 
-      <div className="min-h-0 flex-1 overflow-y-auto py-2">
+      <div className="focus-inset min-h-0 flex-1 overflow-y-auto py-2">
         {groups.length === 0 ? (
           <p className="px-4 py-6 text-center text-sm text-muted-foreground">{t('empty')}</p>
         ) : (

--- a/apps/web/src/components/settings/agent-project-access-section.tsx
+++ b/apps/web/src/components/settings/agent-project-access-section.tsx
@@ -163,7 +163,7 @@ export function AgentProjectAccessSection({ agentMemberId, projects, canEdit }: 
             접근 가능한 프로젝트가 없습니다.
           </p>
         ) : (
-          <div className="max-h-72 divide-y divide-border overflow-y-auto overflow-x-hidden rounded-md border border-border">
+          <div className="focus-inset max-h-72 divide-y divide-border overflow-y-auto overflow-x-hidden rounded-md border border-border">
             {projects.map((project) => {
               const errored = errorIds.has(project.id);
               const readDenied = readDeniedIds.has(project.id);

--- a/apps/web/src/components/sprints/hypothesis-declaration-card.tsx
+++ b/apps/web/src/components/sprints/hypothesis-declaration-card.tsx
@@ -281,7 +281,7 @@ export function HypothesisDeclarationCard({
           ) : filteredLinkable.length === 0 ? (
             <p className="py-2 text-center text-xs text-muted-foreground">{th('pickerEmpty')}</p>
           ) : (
-            <div className="max-h-32 space-y-1 overflow-y-auto">
+            <div className="focus-inset max-h-32 space-y-1 overflow-y-auto">
               {filteredLinkable.map((h) => (
                 <button
                   key={h.id}

--- a/apps/web/src/components/standup/board-bridge-modal.tsx
+++ b/apps/web/src/components/standup/board-bridge-modal.tsx
@@ -105,7 +105,7 @@ export function BoardBridgeModal({ open, onOpenChange, boards, alreadySelectedId
               ) : stories.length === 0 ? (
                 <p className="text-sm text-muted-foreground">{t('bridgeNoStories')}</p>
               ) : (
-                <div className="max-h-64 space-y-1.5 overflow-y-auto">
+                <div className="focus-inset max-h-64 space-y-1.5 overflow-y-auto">
                   {stories.map((story) => {
                     const alreadyAdded = alreadySelectedIds.includes(story.id);
                     return (

--- a/apps/web/src/components/storage/storage-asset-list.tsx
+++ b/apps/web/src/components/storage/storage-asset-list.tsx
@@ -130,7 +130,7 @@ export function StorageAssetList({
       </div>
 
       {/* body */}
-      <div className="min-h-0 flex-1 overflow-auto">
+      <div className="focus-inset min-h-0 flex-1 overflow-auto">
         {loading ? (
           <div className="space-y-0">
             {Array.from({ length: 8 }).map((_, i) => (

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -409,7 +409,9 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
-        "no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        // story #2062: 앱 전역 사이드바 nav — 포커스 링(#2057) 클리핑 회귀 방지, 유나 규격
+        // focus-inset(inset 링, 레이아웃 불변). primary 배경 요소 없음(grep 확認) — 예외 불요.
+        "focus-inset no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
         className
       )}
       {...props}


### PR DESCRIPTION
칸반 카드 3면 클리핑(#2346, p-1.5)의 AC3: "다른 스크롤 컨테이너에도 같은 자리가 있는지 훑는다." 126개 스크롤 컨테이너 전수 감사 → 33곳(까심 정적조사 29곳보다 더 잡힘) AT_RISK 확認.

## 디자인 판단 — 유나 홀름
① 33곳 개별 패딩 vs ② 전역 inset-ring 두 방향을 저울질했으나, 유나가 카드·버튼·텍스트 링크 세 종류를 실물로 그려본 결과 **전역 inset은 불가**로 판정됐다 — primary 버튼은 링 색=배경색이 같아 inset이면 대비 1.00(완전히 안 보임, #2057이 고치려던 상태로 정확히 회귀). 텍스트 링크는 inset이 글자 획을 관통.

⇒ **컨테이너 단위 `.focus-inset` 유틸리티**로 절충(globals.css): `outline-offset:-2px`로 링을 요소 안쪽에 그려 스크롤 클리핑을 원천 회피하되, 레이아웃(패딩)은 안 건드려 개별 패딩 방식의 회귀 면적을 피한다. 전역 `outline-ring`은 그대로 유지.

컨테이너 안에 solid `bg-primary` 버튼이 있으면(notification-bell.tsx 안읽음 토글) `.focus-outset`을 붙여 바깥 링으로 되돌린다. `components/ui/sidebar.tsx`는 grep 확認 결과 primary 배경 요소가 없어 예외 불요.

## 적용 — 44곳
Explore(읽기전용 서브에이전트)로 1차 분류 후 직접 재검증·구현. 신규 가드가 32곳 1차 목록에 없던 12곳을 추가로 잡아냈다(docs 사이드바 래퍼·retro/standup/rewards/settings 페이지 셸·access-matrix 테이블·story-picker-dialog·kanban-board 리스트뷰 등).

## 재발 가드 — verify-focus-inset-coverage.ts
`overflow-*-auto|scroll` + 패딩 없음 + `focus-inset` 없음 = 위반. ① 검사 대상 0건이면 실패(self-assert) ② `DialogContent`(자체 p-4)·`<table>`/`<pre>`/KaTeX(읽기전용) 오탐 배제. 신규 테스트 8개.

### 의도적 미결 — dashboard-shell.tsx
앱 전체를 감싸는 최상위 셸이라 `.focus-inset`을 붙이면 전역 primary 버튼 다수에 예외를 달아야 하는 파급이 이 스토리 하나로 판단하기 과하다고 봤다. 가드에 근거를 남긴 단일 예외로 두고 PO+유나 재검토 대상으로 넘긴다.

## 검증
type-check/lint(0 errors)/build(EXIT 0)/vitest 전체(286파일·1971개 — 1회 관측된 실패는 격리+전체 재실행 둘 다 클린으로 일시적 플레이크 확認) 전부 green.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>