### PR TITLE
fix(story #2072, high): cron.py CRON_SECRET fail-open을 근본 판정으로 좁힘

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -204,5 +204,18 @@ class Settings(BaseSettings):
     def is_ee_enabled(self) -> bool:
         return self.license_consent.lower() == "agreed"
 
+    @property
+    def is_really_local(self) -> bool:
+        """story #2071(critical, 2026-07-21) 근본수정 — `app_env=="development"`만으로는
+        "개발자 랩탑"과 "인터넷에 노출된 dev Cloud Run 배포"를 구분 못 한다(둘 다 동일
+        APP_ENV=development). Cloud Run은 `K_SERVICE`를 항상 자동 주입한다(설정 불필요 —
+        `app/core/database.py`의 커넥션 태깅과 동일 SSOT, 신규 발명 아님). 이게 없으면(로컬
+        uvicorn/pytest) 진짜 로컬, 있으면(dev든 prod든) Cloud Run 위라 fail-open 대상이 아니다.
+        내부 secret 게이트(auth_firebase_internal.py·cron.py 등)가 "시크릿 미설정=로컬이니
+        허용" 판정을 내릴 때 이 프로퍼티로 좁혀야 한다 — `app_env` 문자열만 보면 노출된 dev가
+        그대로 열린다(#2071이 이 클래스의 첫 사례)."""
+        import os
+        return not os.environ.get("K_SERVICE")
+
 
 settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,6 +20,7 @@ _logger = logging.getLogger(__name__)
 async def lifespan(app: FastAPI):
     from app.core.database import engine
     from app.routers.auth_firebase_internal import check_internal_secret_config
+    from app.routers.cron import check_cron_secret_config
     from app.routers.verdict_capture import warn_if_webhook_secret_misconfigured
     from app.services.firebase_verifier import check_mobile_app_check_config
     from app.services.pg_pubsub import check_listen_config, listen_loop
@@ -27,6 +28,7 @@ async def lifespan(app: FastAPI):
     warn_if_webhook_secret_misconfigured()  # Bot-M.2 P3: 웹훅 secret misconfig 를 트래픽 前 경고.
     check_listen_config()  # ee7794eb ③ fail-closed: DB_PGBOUNCER on + DATABASE_URL_DIRECT 없으면 startup raise.
     check_internal_secret_config()  # 산티아고 §9 finding 4: non-local + 시크릿 미설정 fail-closed.
+    check_cron_secret_config()  # story #2072: non-local + CRON_SECRET 미설정 fail-closed.
     check_mobile_app_check_config()  # 산티아고 §9 finding 1: mobile 발급 on + App Check 미필수 fail-closed.
     # story bea25062: cutover 존재-캐시는 의도적으로 startup에서 warm 안 함(자체 발견 —
     # TestClient(app)로 lifespan을 태우는 기존 SSE 테스트들이 라우트 전용으로 짜둔 유한한

--- a/backend/app/routers/auth_firebase_internal.py
+++ b/backend/app/routers/auth_firebase_internal.py
@@ -18,7 +18,6 @@ import base64
 import binascii
 import hashlib
 import logging
-import os
 import uuid
 from datetime import datetime, timezone
 
@@ -83,27 +82,14 @@ class FirebaseSessionMintResponse(BaseModel):
 _LOCAL_ENVS = {"development"}
 
 
-def _really_local() -> bool:
-    """story #2071(critical, 2026-07-21) 근본수정 — `app_env=="development"`는 "진짜 로컬"과
-    "인터넷에 노출된 dev Cloud Run 배포"를 구분 못 한다(둘 다 APP_ENV=development로 배포됨).
-    산티아고 #2202(07-15)의 완화("Firebase 기능 default-off면 시크릿 startup 요구 면제")가
-    이 구분 부재와 겹쳐 노출된 dev를 그대로 열어버렸다 — `FIREBASE_BFF_INTERNAL_SECRET`이
-    dev에 안 배선된 채 이 fail-open이 dev에도 적용됨(민군 발견·오르테가군 실측 확定).
-
-    Cloud Run은 `K_SERVICE`를 항상 자동 주입한다(설정 불필요 — `app/core/database.py`의
-    커넥션 태깅과 동일 SSOT, 신규 발명 아님). 이게 없으면(로컬 `uvicorn`/pytest) 진짜 로컬,
-    있으면(dev든 prod든) Cloud Run 위 — 인터넷에 닿을 수 있으니 fail-open 대상이 아니다."""
-    return not os.environ.get("K_SERVICE")
-
-
 def _require_internal_secret(authorization: str | None) -> None:
     secret = settings.firebase_bff_internal_secret
     if not secret:
-        if settings.app_env in _LOCAL_ENVS and _really_local():
-            return  # 진짜 로컬 개발 전용 예외(Cloud Run 위가 아님)
+        if settings.app_env in _LOCAL_ENVS and settings.is_really_local:
+            return  # 진짜 로컬 개발 전용 예외(Cloud Run 위가 아님 — story #2071)
         logger.warning(
             "auth.firebase.internal_secret_missing_in_non_local_env app_env=%s on_cloud_run=%s",
-            settings.app_env, not _really_local(),
+            settings.app_env, not settings.is_really_local,
         )
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Service misconfigured")
     if authorization != f"Bearer {secret}":
@@ -123,16 +109,17 @@ def check_internal_secret_config(s=None) -> None:
     켜져 있을 때만 시크릿을 요구한다.
 
     story #2071(critical) 근본수정: `app_env not in _LOCAL_ENVS`만으로는 노출된 dev
-    Cloud Run(APP_ENV=development)을 놓친다 — `_really_local()`(K_SERVICE 부재) 아니면
-    시크릿을 요구한다. dev에 Firebase 기능이 켜지고 이 startup 가드가 살아 있으면, 시크릿
-    없이는 이제 배포 자체가 실패한다(런타임 503 fail-closed보다 먼저 잡힘 — 배포 시점에
-    시끄럽게 실패하는 쪽이 더 안전, check_listen_config()와 동형)."""
+    Cloud Run(APP_ENV=development)을 놓친다 — `s.is_really_local`(K_SERVICE 부재 판정,
+    `app/core/config.py` SSOT) 아니면 시크릿을 요구한다. dev에 Firebase 기능이 켜지고 이
+    startup 가드가 살아 있으면, 시크릿 없이는 이제 배포 자체가 실패한다(런타임 503
+    fail-closed보다 먼저 잡힘 — 배포 시점에 시끄럽게 실패하는 쪽이 더 안전,
+    check_listen_config()와 동형)."""
     if s is None:
         from app.core.config import settings as s
     firebase_internal_enabled = (
         s.firebase_auth_issue_session or s.firebase_auth_mobile_issue or s.firebase_oauth_handoff_enabled
     )
-    _not_local = s.app_env not in _LOCAL_ENVS or not _really_local()
+    _not_local = s.app_env not in _LOCAL_ENVS or not s.is_really_local
     if firebase_internal_enabled and _not_local and not s.firebase_bff_internal_secret:
         raise RuntimeError(
             f"APP_ENV={s.app_env}인데 FIREBASE_BFF_INTERNAL_SECRET 미설정 — 내부 세션 mint/"

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -14,6 +14,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy import func, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.dependencies.database import get_db
 from app.models.agent_run import AgentRun
 from app.models.agent_session import AgentSession
@@ -41,12 +42,47 @@ def _err(code: str, message: str, status: int = 400) -> JSONResponse:
     return JSONResponse({"data": None, "error": {"code": code, "message": message}, "meta": None}, status_code=status)
 
 
+_LOCAL_ENVS = {"development"}
+
+
 def verify_cron(request: Request) -> None:
+    """story #2072(high, 2026-07-21) 근본수정 — 기존엔 `if not CRON_SECRET: return`(환경
+    무관 무조건 허용)이라 `_require_internal_secret`(#2071)보다도 더 넓게 열려 있었다(둘 다
+    "시크릿 없으면 연다"는 같은 안티패턴 — agent_inbox.py `_verify_signature`가 유일한 정답
+    형태: "secret 미설정 시 open ingestion 차단"). 지금은 dev/prod 둘 다 `CRON_SECRET`이
+    secretRef로 배선돼 있어 무인증은 아니지만(오르테가군 실측), 배선이 한 번이라도 비면
+    (배포 실수·로테이션·env 누락) 전 cron이 열리는 구조적 위험이었다.
+
+    `_require_internal_secret`(#2071)과 동일 기준으로 좁힌다 — `app_env=="development"`
+    문자열만으로는 "진짜 로컬"과 "인터넷에 노출된 dev Cloud Run"을 구분 못 하므로
+    `settings.is_really_local`(K_SERVICE 부재 판정, `app/core/config.py` SSOT)도 같이
+    요구한다."""
     if not CRON_SECRET:
-        return  # CRON_SECRET 미설정 시 로컬 개발 허용
+        if settings.app_env in _LOCAL_ENVS and settings.is_really_local:
+            return  # 진짜 로컬 개발 전용 예외(Cloud Run 위가 아님)
+        logger.warning(
+            "cron.secret_missing_in_non_local_env app_env=%s on_cloud_run=%s",
+            settings.app_env, not settings.is_really_local,
+        )
+        raise HTTPException(status_code=503, detail="Service misconfigured")
     auth = request.headers.get("authorization", "")
     if auth != f"Bearer {CRON_SECRET}":
         raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+def check_cron_secret_config(s=None) -> None:
+    """fail-closed startup 가드(story #2072) — `check_internal_secret_config`(#2071)와
+    동형(check_listen_config()와 동일 패턴, main lifespan이 호출 대상). non-local(진짜
+    로컬이 아닌)인데 `CRON_SECRET` 미설정이면 배포 자체를 막는다 — 런타임 503보다 먼저,
+    더 시끄럽게 잡는 쪽이 안전하다."""
+    if s is None:
+        from app.core.config import settings as s
+    _not_local = s.app_env not in _LOCAL_ENVS or not s.is_really_local
+    if _not_local and not CRON_SECRET:
+        raise RuntimeError(
+            f"APP_ENV={s.app_env}인데 CRON_SECRET 미설정 — 내부 cron 엔드포인트가 인증 없이 "
+            "공개된다(fail-closed·story #2072)."
+        )
 
 
 # ─── GET /api/v2/internal/cron/agent-session-recovery ─────────────────────────

--- a/backend/tests/test_2072_cron_secret_failopen.py
+++ b/backend/tests/test_2072_cron_secret_failopen.py
@@ -1,0 +1,75 @@
+"""story #2072(high, 2026-07-21) — cron.py의 CRON_SECRET 게이트가 `_require_internal_secret`
+(story #2071)보다도 넓게 열려 있던 결함(환경 체크 자체가 없었음). 같은 K_SERVICE 기반 판정으로
+좁힌다 — check_internal_secret_config 회귀 테스트(test_e_auth_rebuild_phase1_s5_startup_guards.py)
+와 동형 구조."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _s(**overrides):
+    base = {"app_env": "development", "is_really_local": True}
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_check_cron_secret_config_ok_when_local_and_empty():
+    from app.routers.cron import check_cron_secret_config
+    check_cron_secret_config(_s(app_env="development", is_really_local=True))
+
+
+def test_check_cron_secret_config_raises_when_prod():
+    from app.routers.cron import check_cron_secret_config
+    with pytest.raises(RuntimeError, match="CRON_SECRET"):
+        check_cron_secret_config(_s(app_env="production", is_really_local=False))
+
+
+def test_check_cron_secret_config_raises_when_dev_appenv_but_on_cloud_run():
+    """story #2072 근본: APP_ENV=development여도 K_SERVICE가 있으면(노출된 dev) fail-closed."""
+    from app.routers.cron import check_cron_secret_config
+    with pytest.raises(RuntimeError, match="CRON_SECRET"):
+        check_cron_secret_config(_s(app_env="development", is_really_local=False))
+
+
+def test_verify_cron_raises_503_when_dev_appenv_but_on_cloud_run(monkeypatch):
+    """런타임 게이트 — 노출된 dev에서 CRON_SECRET 미설정이면 이전엔 무조건 통과(fail-open)
+    했다. 이제 503(fail-closed). is_really_local은 @property(setter 없음)라 K_SERVICE
+    env var를 직접 조작 — 실제 판정 경로 그대로 태운다."""
+    monkeypatch.setenv("K_SERVICE", "sprintable-backend-dev")
+    monkeypatch.setattr("app.routers.cron.CRON_SECRET", None)
+    monkeypatch.setattr("app.routers.cron.settings.app_env", "development")
+    from fastapi import HTTPException
+
+    from app.routers.cron import verify_cron
+    request = MagicMock()
+    with pytest.raises(HTTPException) as exc_info:
+        verify_cron(request)
+    assert exc_info.value.status_code == 503
+
+
+def test_verify_cron_ok_when_truly_local(monkeypatch):
+    monkeypatch.delenv("K_SERVICE", raising=False)
+    monkeypatch.setattr("app.routers.cron.CRON_SECRET", None)
+    monkeypatch.setattr("app.routers.cron.settings.app_env", "development")
+    from app.routers.cron import verify_cron
+    request = MagicMock()
+    verify_cron(request)  # raise 없이 통과해야 함.
+
+
+def test_verify_cron_still_requires_correct_secret_when_configured(monkeypatch):
+    """무회귀 — CRON_SECRET이 설정된 기존 케이스는 그대로 헤더 검증."""
+    monkeypatch.setattr("app.routers.cron.CRON_SECRET", "real-secret")
+    from fastapi import HTTPException
+
+    from app.routers.cron import verify_cron
+    request = MagicMock()
+    request.headers.get.return_value = "Bearer wrong"
+    with pytest.raises(HTTPException) as exc_info:
+        verify_cron(request)
+    assert exc_info.value.status_code == 401
+
+    request.headers.get.return_value = "Bearer real-secret"
+    verify_cron(request)  # 정확한 시크릿이면 통과.

--- a/backend/tests/test_e_auth_rebuild_phase1_s5_startup_guards.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s5_startup_guards.py
@@ -15,6 +15,9 @@ def _s(**overrides):
         "firebase_auth_mobile_issue": False,
         "firebase_oauth_handoff_enabled": False,
         "firebase_auth_mobile_app_check_required": False,
+        # story #2071: 기본값=진짜 로컬(테스트 러너는 Cloud Run이 아님). on-Cloud-Run
+        # 시나리오를 검증하는 테스트만 is_really_local=False로 override.
+        "is_really_local": True,
     }
     base.update(overrides)
     return SimpleNamespace(**base)
@@ -91,25 +94,25 @@ def test_internal_secret_config_raises_when_prod_and_empty_and_oauth_handoff_on(
         ))
 
 
-def test_internal_secret_config_raises_when_dev_appenv_but_on_cloud_run(monkeypatch):
+def test_internal_secret_config_raises_when_dev_appenv_but_on_cloud_run():
     """story #2071(critical, 2026-07-21): APP_ENV=development인데 실제로는 Cloud Run
     위(K_SERVICE 존재 — 노출된 dev 배포)면 "로컬" 예외가 더 이상 적용되면 안 된다. 이게
     민군/오르테가군이 실측 확定한 결함의 근본원인 — app_env 문자열만으로 "로컬"을 판정해서
     노출된 dev가 fail-open을 그대로 탔다."""
-    monkeypatch.setenv("K_SERVICE", "sprintable-backend-dev")
     from app.routers.auth_firebase_internal import check_internal_secret_config
     with pytest.raises(RuntimeError, match="FIREBASE_BFF_INTERNAL_SECRET"):
         check_internal_secret_config(_s(
             app_env="development", firebase_bff_internal_secret="", firebase_auth_issue_session=True,
+            is_really_local=False,
         ))
 
 
-def test_internal_secret_config_ok_when_dev_appenv_and_truly_local(monkeypatch):
+def test_internal_secret_config_ok_when_dev_appenv_and_truly_local():
     """대조군 — K_SERVICE가 없는 진짜 로컬(uvicorn/pytest)은 여전히 예외 대상."""
-    monkeypatch.delenv("K_SERVICE", raising=False)
     from app.routers.auth_firebase_internal import check_internal_secret_config
     check_internal_secret_config(_s(
         app_env="development", firebase_bff_internal_secret="", firebase_auth_issue_session=True,
+        is_really_local=True,
     ))
 
 


### PR DESCRIPTION
## 요약
story #2072(high) — #2071 AC2 감사 중 발견. `app/routers/cron.py`의 `verify_cron()`이 `_require_internal_secret`(#2071)보다도 넓게 열려 있었다: 환경 체크 자체가 없이 `if not CRON_SECRET: return`(시크릿 미설정=무조건 허용, 어느 환경이든).

## 안티패턴 시리즈(오르테가군 전수)
```
verify_cron              secret 없으면 return (env 체크 0)          ❌ 이 스토리
_require_internal_secret secret 없고 app_env==development면 return   ❌ #2071(이미 수정)
agent_inbox._verify_signature  secret 없으면 False(차단)             ✅ 정답 형태
```
"시크릿 없으면 연다"는 잘못된 기본값이 두 곳에 복사된 것 — 정답 형태(agent_inbox.py)로 통일한다.

## 현재 노출도(오르테가군 실측)
dev·prod 둘 다 `CRON_SECRET`이 secretRef로 배선돼 있어 지금은 인증을 요구한다(급성 유출 아님). 다만 시크릿이 한 번이라도 비면(배포 실수·로테이션·env 누락) prod 전 cron이 열리는 **구조적 위험**이었다.

## 변경사항
- `Settings.is_really_local` 프로퍼티 신규(`app/core/config.py`) — K_SERVICE(Cloud Run 자동 주입) 부재로 "진짜 로컬"을 판정(#2071의 로컬 함수를 SSOT로 추출, `auth_firebase_internal.py`도 이걸 쓰도록 리팩터 — 중복 제거).
- `cron.py::verify_cron()`: `app_env=="development"` **and** `is_really_local`일 때만 시크릿 미설정 예외 허용, 아니면 503.
- `cron.py::check_cron_secret_config()` 신규 — `check_internal_secret_config`(#2071)와 동형 startup fail-closed 가드, `main.py` lifespan에 배선.

## 검증
- `uv run pytest tests/test_2072_cron_secret_failopen.py tests/test_e_auth_rebuild_phase1_s5_startup_guards.py` — 21 passed.
- `uv run pytest tests/ -k "cron or startup_guard"` — 27 passed, 4 skipped(realdb), 무회귀.
- app import 검증 완료(490 routes).

⚠️ startup 가드가 dev/prod 배포를 막을 수 있음(secret 미설정 시) — 오르테가군이 이미 실측 확認한 대로 현재 둘 다 배선돼 있어 안전할 것으로 보이나, 머지 전 재확認 권장(산티아고 #2202 배포 회귀 선례와 같은 리스크 축).

🤖 Generated with [Claude Code](https://claude.com/claude-code)