### PR TITLE
Revert #2347 — dev 파이프라인 응급 복구, 시크릿 배선 완비 후 재적용

### DIFF
--- a/backend/app/routers/auth_firebase_internal.py
+++ b/backend/app/routers/auth_firebase_internal.py
@@ -18,7 +18,6 @@ import base64
 import binascii
 import hashlib
 import logging
-import os
 import uuid
 from datetime import datetime, timezone
 
@@ -83,28 +82,12 @@ class FirebaseSessionMintResponse(BaseModel):
 _LOCAL_ENVS = {"development"}
 
 
-def _really_local() -> bool:
-    """story #2071(critical, 2026-07-21) 근본수정 — `app_env=="development"`는 "진짜 로컬"과
-    "인터넷에 노출된 dev Cloud Run 배포"를 구분 못 한다(둘 다 APP_ENV=development로 배포됨).
-    산티아고 #2202(07-15)의 완화("Firebase 기능 default-off면 시크릿 startup 요구 면제")가
-    이 구분 부재와 겹쳐 노출된 dev를 그대로 열어버렸다 — `FIREBASE_BFF_INTERNAL_SECRET`이
-    dev에 안 배선된 채 이 fail-open이 dev에도 적용됨(민군 발견·오르테가군 실측 확定).
-
-    Cloud Run은 `K_SERVICE`를 항상 자동 주입한다(설정 불필요 — `app/core/database.py`의
-    커넥션 태깅과 동일 SSOT, 신규 발명 아님). 이게 없으면(로컬 `uvicorn`/pytest) 진짜 로컬,
-    있으면(dev든 prod든) Cloud Run 위 — 인터넷에 닿을 수 있으니 fail-open 대상이 아니다."""
-    return not os.environ.get("K_SERVICE")
-
-
 def _require_internal_secret(authorization: str | None) -> None:
     secret = settings.firebase_bff_internal_secret
     if not secret:
-        if settings.app_env in _LOCAL_ENVS and _really_local():
-            return  # 진짜 로컬 개발 전용 예외(Cloud Run 위가 아님)
-        logger.warning(
-            "auth.firebase.internal_secret_missing_in_non_local_env app_env=%s on_cloud_run=%s",
-            settings.app_env, not _really_local(),
-        )
+        if settings.app_env in _LOCAL_ENVS:
+            return  # 로컬 개발 전용 예외
+        logger.warning("auth.firebase.internal_secret_missing_in_non_local_env app_env=%s", settings.app_env)
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Service misconfigured")
     if authorization != f"Bearer {secret}":
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid internal credential")
@@ -120,24 +103,16 @@ def check_internal_secret_config(s=None) -> None:
     `FIREBASE_BFF_INTERNAL_SECRET`을 SECRETS_SPEC에 배선하지 않음) backend 전체가
     startup에서 죽는 회귀였다(직접 probe: prod_features_off_missing_secret_startup_
     allowed=False). 이 내부 엔드포인트를 실제로 쓰는 기능(세션 발급/모바일 부트스트랩)이
-    켜져 있을 때만 시크릿을 요구한다.
-
-    story #2071(critical) 근본수정: `app_env not in _LOCAL_ENVS`만으로는 노출된 dev
-    Cloud Run(APP_ENV=development)을 놓친다 — `_really_local()`(K_SERVICE 부재) 아니면
-    시크릿을 요구한다. dev에 Firebase 기능이 켜지고 이 startup 가드가 살아 있으면, 시크릿
-    없이는 이제 배포 자체가 실패한다(런타임 503 fail-closed보다 먼저 잡힘 — 배포 시점에
-    시끄럽게 실패하는 쪽이 더 안전, check_listen_config()와 동형)."""
+    켜져 있을 때만 시크릿을 요구한다."""
     if s is None:
         from app.core.config import settings as s
     firebase_internal_enabled = (
         s.firebase_auth_issue_session or s.firebase_auth_mobile_issue or s.firebase_oauth_handoff_enabled
     )
-    _not_local = s.app_env not in _LOCAL_ENVS or not _really_local()
-    if firebase_internal_enabled and _not_local and not s.firebase_bff_internal_secret:
+    if firebase_internal_enabled and s.app_env not in _LOCAL_ENVS and not s.firebase_bff_internal_secret:
         raise RuntimeError(
             f"APP_ENV={s.app_env}인데 FIREBASE_BFF_INTERNAL_SECRET 미설정 — 내부 세션 mint/"
-            "consume 엔드포인트가 인증 없이 공개된다(fail-closed·산티아고 §9 finding 4·"
-            "story #2071 K_SERVICE 판정 포함)."
+            "consume 엔드포인트가 인증 없이 공개된다(fail-closed·산티아고 §9 finding 4)."
         )
 
 

--- a/backend/tests/test_e_auth_rebuild_phase1_s5_startup_guards.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s5_startup_guards.py
@@ -91,49 +91,6 @@ def test_internal_secret_config_raises_when_prod_and_empty_and_oauth_handoff_on(
         ))
 
 
-def test_internal_secret_config_raises_when_dev_appenv_but_on_cloud_run(monkeypatch):
-    """story #2071(critical, 2026-07-21): APP_ENV=development인데 실제로는 Cloud Run
-    위(K_SERVICE 존재 — 노출된 dev 배포)면 "로컬" 예외가 더 이상 적용되면 안 된다. 이게
-    민군/오르테가군이 실측 확定한 결함의 근본원인 — app_env 문자열만으로 "로컬"을 판정해서
-    노출된 dev가 fail-open을 그대로 탔다."""
-    monkeypatch.setenv("K_SERVICE", "sprintable-backend-dev")
-    from app.routers.auth_firebase_internal import check_internal_secret_config
-    with pytest.raises(RuntimeError, match="FIREBASE_BFF_INTERNAL_SECRET"):
-        check_internal_secret_config(_s(
-            app_env="development", firebase_bff_internal_secret="", firebase_auth_issue_session=True,
-        ))
-
-
-def test_internal_secret_config_ok_when_dev_appenv_and_truly_local(monkeypatch):
-    """대조군 — K_SERVICE가 없는 진짜 로컬(uvicorn/pytest)은 여전히 예외 대상."""
-    monkeypatch.delenv("K_SERVICE", raising=False)
-    from app.routers.auth_firebase_internal import check_internal_secret_config
-    check_internal_secret_config(_s(
-        app_env="development", firebase_bff_internal_secret="", firebase_auth_issue_session=True,
-    ))
-
-
-def test_require_internal_secret_raises_503_when_dev_appenv_but_on_cloud_run(monkeypatch):
-    """story #2071: 런타임 게이트(_require_internal_secret) 쪽도 동일 — 노출된 dev에서
-    시크릿 미설정이면 인증 없이 통과(fail-open)하던 것을 503(fail-closed)으로 닫는다."""
-    monkeypatch.setenv("K_SERVICE", "sprintable-backend-dev")
-    monkeypatch.setattr("app.routers.auth_firebase_internal.settings.app_env", "development")
-    monkeypatch.setattr("app.routers.auth_firebase_internal.settings.firebase_bff_internal_secret", "")
-    from app.routers.auth_firebase_internal import _require_internal_secret
-    from fastapi import HTTPException
-    with pytest.raises(HTTPException) as exc_info:
-        _require_internal_secret(None)
-    assert exc_info.value.status_code == 503
-
-
-def test_require_internal_secret_ok_when_truly_local(monkeypatch):
-    monkeypatch.delenv("K_SERVICE", raising=False)
-    monkeypatch.setattr("app.routers.auth_firebase_internal.settings.app_env", "development")
-    monkeypatch.setattr("app.routers.auth_firebase_internal.settings.firebase_bff_internal_secret", "")
-    from app.routers.auth_firebase_internal import _require_internal_secret
-    _require_internal_secret(None)  # raise 없이 통과해야 함(진짜 로컬).
-
-
 def test_mobile_app_check_config_ok_when_mobile_issue_off():
     from app.services.firebase_verifier import check_mobile_app_check_config
     check_mobile_app_check_config(_s(firebase_auth_mobile_issue=False, firebase_auth_mobile_app_check_required=False))


### PR DESCRIPTION
## 요약
⛔ 긴급 — #2347(story #2071 critical fix)의 dev 배포가 `FIREBASE_BFF_INTERNAL_SECRET` 미배선으로 startup fail-closed 가드에 걸려 실패했다(deploy-backend step 7 FAILURE, dev backend 신규 리비전 01759 "container failed to start on PORT 8000"). Cloud Run이 Ready 안 된 리비전엔 트래픽을 안 돌려 구 리비전(01758)이 계속 서빙해 라이브 장애는 없었으나, develop 배포 파이프라인 자체가 막혀 후속 머지가 dev에 반영되지 않는 상태였다.

## 이건 폐기가 아니라 순서 조정
#2347 자체는 맞는 근본수정이다(#2071 원 PR에서도 "startup 가드가 dev/prod 배포를 막을 수 있음" 리스크를 명시했었음). 시크릿 배선이 먼저 필요했다:
1. Secret Manager에 `FIREBASE_BFF_INTERNAL_SECRET` 생성(dev·prod)
2. `deploy_backend.sh` SECRETS_SPEC 배선
3. FE(apps/web, `sprintable-frontend-{dev,prod}`)에도 동일 값 배선

세 개가 갖춰지면 #2347/#2349를 재적용한다. revert로 되돌아가는 상태(시크릿 미설정 시 fail-open)는 새 위험이 아니라 이 revert 이전부터 있던 상태다.

## 검증
- `uv run pytest tests/test_e_auth_rebuild_phase1_s5_startup_guards.py` — 11 passed(원래 상태로 복원).
- clean revert, 충돌 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)