### PR TITLE
chore(#2071/#2072): deploy_backend.sh에 FIREBASE_BFF_INTERNAL_SECRET 배선 준비

### DIFF
--- a/backend/scripts/deploy_backend.sh
+++ b/backend/scripts/deploy_backend.sh
@@ -118,6 +118,13 @@ SECRETS_SPEC="${SECRETS_SPEC},GITHUB_CLIENT_ID=GITHUB_CLIENT_ID_${GITHUB_SECRET_
 SECRETS_SPEC="${SECRETS_SPEC},GITHUB_CLIENT_SECRET=GITHUB_CLIENT_SECRET_${GITHUB_SECRET_SUFFIX}:latest"
 SECRETS_SPEC="${SECRETS_SPEC},RESEND_API_KEY=RESEND_API_KEY:latest"
 SECRETS_SPEC="${SECRETS_SPEC},EMAIL_FROM=EMAIL_FROM:latest"
+# story #2071/#2072(critical, 2026-07-21): 이 시크릿이 dev/prod 어디에도 배선 안 돼 있어
+# _require_internal_secret의 fail-open이 노출된 dev에 그대로 적용되던 결함의 근본원인이었다
+# (K_SERVICE 기반 판정으로 좁힌 #2347이 배포될 때 이 시크릿 부재로 startup에서 죽었다 — 그
+# revert PR #2350 참고). Secret Manager에 값 생성 후(setup_secret_manager.sh D-S3와 동형
+# create_secret 패턴) 이 줄로 배선한다. FE(apps/web, sprintable-frontend-{dev,prod})에도
+# 반드시 같은 값을 넣어야 한다 — BE만 넣으면 FE가 헤더를 못 보내 handoff가 401로 막힌다.
+SECRETS_SPEC="${SECRETS_SPEC},FIREBASE_BFF_INTERNAL_SECRET=FIREBASE_BFF_INTERNAL_SECRET:latest"
 
 # ── 결함④ fix: 평문 env. CORS_ORIGINS 값에 콤마가 있어 기본(콤마) 구분자로는 env가 쪼개진다 →
 #   gcloud 커스텀 구분자 '^@^'로 '@' 구분. NEXT_PUBLIC_APP_URL도 세팅(verify-link 환경정합·#1236 finding). ──


### PR DESCRIPTION
## 요약
선행조건 b(오르테가군 지정 순서: a.Secret Manager 생성 → **b.이 배선** → c.FE 배선 → #2347/#2349 재적용). 값이 아직 없어도 스크립트 자체는 안전(수동 실행 스크립트, `cloudbuild.yaml` 자동 파이프라인은 이 스크립트를 안 부름 — 머지돼도 즉시 실행/배포 트리거 없음).

## 변경사항
- `deploy_backend.sh` SECRETS_SPEC에 `FIREBASE_BFF_INTERNAL_SECRET=FIREBASE_BFF_INTERNAL_SECRET:latest` 추가.

## 검증
- `bash -n` 문법 확認.
- `DRY_RUN=1 bash backend/scripts/deploy_backend.sh dev` — SECRETS_SPEC에 새 항목 정확히 조립됨 확認.

🤖 Generated with [Claude Code](https://claude.com/claude-code)