### PR TITLE
Reapply #2347 — dev secret 배선 완료 후 재적용

### DIFF
--- a/backend/app/routers/auth_firebase_internal.py
+++ b/backend/app/routers/auth_firebase_internal.py
@@ -18,6 +18,7 @@ import base64
 import binascii
 import hashlib
 import logging
+import os
 import uuid
 from datetime import datetime, timezone
 
@@ -82,12 +83,28 @@ class FirebaseSessionMintResponse(BaseModel):
 _LOCAL_ENVS = {"development"}
 
 
+def _really_local() -> bool:
+    """story #2071(critical, 2026-07-21) 근본수정 — `app_env=="development"`는 "진짜 로컬"과
+    "인터넷에 노출된 dev Cloud Run 배포"를 구분 못 한다(둘 다 APP_ENV=development로 배포됨).
+    산티아고 #2202(07-15)의 완화("Firebase 기능 default-off면 시크릿 startup 요구 면제")가
+    이 구분 부재와 겹쳐 노출된 dev를 그대로 열어버렸다 — `FIREBASE_BFF_INTERNAL_SECRET`이
+    dev에 안 배선된 채 이 fail-open이 dev에도 적용됨(민군 발견·오르테가군 실측 확定).
+
+    Cloud Run은 `K_SERVICE`를 항상 자동 주입한다(설정 불필요 — `app/core/database.py`의
+    커넥션 태깅과 동일 SSOT, 신규 발명 아님). 이게 없으면(로컬 `uvicorn`/pytest) 진짜 로컬,
+    있으면(dev든 prod든) Cloud Run 위 — 인터넷에 닿을 수 있으니 fail-open 대상이 아니다."""
+    return not os.environ.get("K_SERVICE")
+
+
 def _require_internal_secret(authorization: str | None) -> None:
     secret = settings.firebase_bff_internal_secret
     if not secret:
-        if settings.app_env in _LOCAL_ENVS:
-            return  # 로컬 개발 전용 예외
-        logger.warning("auth.firebase.internal_secret_missing_in_non_local_env app_env=%s", settings.app_env)
+        if settings.app_env in _LOCAL_ENVS and _really_local():
+            return  # 진짜 로컬 개발 전용 예외(Cloud Run 위가 아님)
+        logger.warning(
+            "auth.firebase.internal_secret_missing_in_non_local_env app_env=%s on_cloud_run=%s",
+            settings.app_env, not _really_local(),
+        )
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Service misconfigured")
     if authorization != f"Bearer {secret}":
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid internal credential")
@@ -103,16 +120,24 @@ def check_internal_secret_config(s=None) -> None:
     `FIREBASE_BFF_INTERNAL_SECRET`을 SECRETS_SPEC에 배선하지 않음) backend 전체가
     startup에서 죽는 회귀였다(직접 probe: prod_features_off_missing_secret_startup_
     allowed=False). 이 내부 엔드포인트를 실제로 쓰는 기능(세션 발급/모바일 부트스트랩)이
-    켜져 있을 때만 시크릿을 요구한다."""
+    켜져 있을 때만 시크릿을 요구한다.
+
+    story #2071(critical) 근본수정: `app_env not in _LOCAL_ENVS`만으로는 노출된 dev
+    Cloud Run(APP_ENV=development)을 놓친다 — `_really_local()`(K_SERVICE 부재) 아니면
+    시크릿을 요구한다. dev에 Firebase 기능이 켜지고 이 startup 가드가 살아 있으면, 시크릿
+    없이는 이제 배포 자체가 실패한다(런타임 503 fail-closed보다 먼저 잡힘 — 배포 시점에
+    시끄럽게 실패하는 쪽이 더 안전, check_listen_config()와 동형)."""
     if s is None:
         from app.core.config import settings as s
     firebase_internal_enabled = (
         s.firebase_auth_issue_session or s.firebase_auth_mobile_issue or s.firebase_oauth_handoff_enabled
     )
-    if firebase_internal_enabled and s.app_env not in _LOCAL_ENVS and not s.firebase_bff_internal_secret:
+    _not_local = s.app_env not in _LOCAL_ENVS or not _really_local()
+    if firebase_internal_enabled and _not_local and not s.firebase_bff_internal_secret:
         raise RuntimeError(
             f"APP_ENV={s.app_env}인데 FIREBASE_BFF_INTERNAL_SECRET 미설정 — 내부 세션 mint/"
-            "consume 엔드포인트가 인증 없이 공개된다(fail-closed·산티아고 §9 finding 4)."
+            "consume 엔드포인트가 인증 없이 공개된다(fail-closed·산티아고 §9 finding 4·"
+            "story #2071 K_SERVICE 판정 포함)."
         )
 
 

--- a/backend/tests/test_e_auth_rebuild_phase1_s5_startup_guards.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s5_startup_guards.py
@@ -91,6 +91,49 @@ def test_internal_secret_config_raises_when_prod_and_empty_and_oauth_handoff_on(
         ))
 
 
+def test_internal_secret_config_raises_when_dev_appenv_but_on_cloud_run(monkeypatch):
+    """story #2071(critical, 2026-07-21): APP_ENV=development인데 실제로는 Cloud Run
+    위(K_SERVICE 존재 — 노출된 dev 배포)면 "로컬" 예외가 더 이상 적용되면 안 된다. 이게
+    민군/오르테가군이 실측 확定한 결함의 근본원인 — app_env 문자열만으로 "로컬"을 판정해서
+    노출된 dev가 fail-open을 그대로 탔다."""
+    monkeypatch.setenv("K_SERVICE", "sprintable-backend-dev")
+    from app.routers.auth_firebase_internal import check_internal_secret_config
+    with pytest.raises(RuntimeError, match="FIREBASE_BFF_INTERNAL_SECRET"):
+        check_internal_secret_config(_s(
+            app_env="development", firebase_bff_internal_secret="", firebase_auth_issue_session=True,
+        ))
+
+
+def test_internal_secret_config_ok_when_dev_appenv_and_truly_local(monkeypatch):
+    """대조군 — K_SERVICE가 없는 진짜 로컬(uvicorn/pytest)은 여전히 예외 대상."""
+    monkeypatch.delenv("K_SERVICE", raising=False)
+    from app.routers.auth_firebase_internal import check_internal_secret_config
+    check_internal_secret_config(_s(
+        app_env="development", firebase_bff_internal_secret="", firebase_auth_issue_session=True,
+    ))
+
+
+def test_require_internal_secret_raises_503_when_dev_appenv_but_on_cloud_run(monkeypatch):
+    """story #2071: 런타임 게이트(_require_internal_secret) 쪽도 동일 — 노출된 dev에서
+    시크릿 미설정이면 인증 없이 통과(fail-open)하던 것을 503(fail-closed)으로 닫는다."""
+    monkeypatch.setenv("K_SERVICE", "sprintable-backend-dev")
+    monkeypatch.setattr("app.routers.auth_firebase_internal.settings.app_env", "development")
+    monkeypatch.setattr("app.routers.auth_firebase_internal.settings.firebase_bff_internal_secret", "")
+    from app.routers.auth_firebase_internal import _require_internal_secret
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc_info:
+        _require_internal_secret(None)
+    assert exc_info.value.status_code == 503
+
+
+def test_require_internal_secret_ok_when_truly_local(monkeypatch):
+    monkeypatch.delenv("K_SERVICE", raising=False)
+    monkeypatch.setattr("app.routers.auth_firebase_internal.settings.app_env", "development")
+    monkeypatch.setattr("app.routers.auth_firebase_internal.settings.firebase_bff_internal_secret", "")
+    from app.routers.auth_firebase_internal import _require_internal_secret
+    _require_internal_secret(None)  # raise 없이 통과해야 함(진짜 로컬).
+
+
 def test_mobile_app_check_config_ok_when_mobile_issue_off():
     from app.services.firebase_verifier import check_mobile_app_check_config
     check_mobile_app_check_config(_s(firebase_auth_mobile_issue=False, firebase_auth_mobile_app_check_required=False))


### PR DESCRIPTION
## 요약
#2350(revert)으로 잠시 되돌렸던 #2071(critical) 근본수정을 재적용한다. dev/prod Secret Manager에 `FIREBASE_BFF_INTERNAL_SECRET` 배선이 완료됐다(오르테가군, `--update-secrets` additive — 기존 시크릿 보존, BE·FE 동일 secret 공유라 값 자동 일치). 트래픽 100% 전환 후 `Invalid internal credential`(fail-closed 정상 동작) 실측 확認됨.

## 확認된 것
- 실 배포 경로(`cloudbuild.yaml`의 `deploy-backend`/`deploy-frontend` step)는 `--set-secrets`/`--update-secrets` 플래그가 아예 없어 secret 바인딩을 안 건드림 — 즉 방금 배선한 시크릿은 앞으로의 모든 자동배포에서 보존된다.
- 코드는 revert 전 #2347과 완전히 동일(revert-the-revert).

## 검증
- `uv run pytest tests/test_e_auth_rebuild_phase1_s5_startup_guards.py` — 15 passed.
- app import 검증 완료.
- dev 배선 실효 실측 완료(오르테가군) — secret 리비전에 트래픽 100% 전환 후 인증 없는 요청이 `Invalid internal credential`로 정확히 막힘.

## ⚠️ prod 승격 체크리스트 필수 항목
**prod는 아직 `FIREBASE_BFF_INTERNAL_SECRET`이 배선 안 됨(승격 전이라 의도적으로 안 건드림).** main 승격 시 **prod Secret Manager 생성 + prod BE·FE `--update-secrets` 배선을 먼저 완료하지 않으면 prod backend가 오늘 dev에서 겪은 것과 동일한 startup 부팅 실패를 겪는다.** 승격 PR/체크리스트에 이 항목을 반드시 포함할 것.

## 배포 후 확認 필요(오르테가군)
- dev backend 신규 리비전 Ready=True·health 200. (죽었던 01759 자리가 이번엔 성공적으로 서는 것이 이 건의 최종 증거.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)