### PR TITLE
[SID:2039] P0 AC3 — 구 한글 slug 링크 호환 (형식게이트 제거 + 이중 인코딩 수정)

### DIFF
--- a/apps/web/src/lib/route-resolve.test.ts
+++ b/apps/web/src/lib/route-resolve.test.ts
@@ -36,14 +36,21 @@ describe('looksLikeWorkspaceSegment', () => {
     expect(looksLikeWorkspaceSegment('acme-corp')).toBe(true);
   });
 
-  it('rejects empty/undefined/malformed segments', () => {
+  it('rejects only empty/undefined segments — no segment at all', () => {
     expect(looksLikeWorkspaceSegment(undefined)).toBe(false);
     expect(looksLikeWorkspaceSegment(null)).toBe(false);
     expect(looksLikeWorkspaceSegment('')).toBe(false);
-    expect(looksLikeWorkspaceSegment('Has-Upper')).toBe(false);
-    expect(looksLikeWorkspaceSegment('snake_case')).toBe(false);
-    expect(looksLikeWorkspaceSegment('-leading-hyphen')).toBe(false);
-    expect(looksLikeWorkspaceSegment('trailing-hyphen-')).toBe(false);
+  });
+
+  // story #2039 AC3 — 예전엔 여기서 kebab·ASCII 형식까지 걸러 구 한글 slug(`장사왕`)가
+  // resolve fetch 이전에 탈락했다(레거시 링크가 canonical로 안내받지 못하고 그냥 404).
+  // RESERVED_FIRST_SEGMENTS만 가드로 남기고, 형식이 이상해도 resolve가 최종 판정하게 한다.
+  it('더 이상 형식(kebab/ASCII)으로 거르지 않는다 — 구 slug 후보는 resolve가 판정한다', () => {
+    expect(looksLikeWorkspaceSegment('장사왕')).toBe(true);
+    expect(looksLikeWorkspaceSegment('Has-Upper')).toBe(true);
+    expect(looksLikeWorkspaceSegment('snake_case')).toBe(true);
+    expect(looksLikeWorkspaceSegment('-leading-hyphen')).toBe(true);
+    expect(looksLikeWorkspaceSegment('trailing-hyphen-')).toBe(true);
   });
 });
 

--- a/apps/web/src/lib/route-resolve.ts
+++ b/apps/web/src/lib/route-resolve.ts
@@ -32,13 +32,18 @@ export const RESERVED_FIRST_SEGMENTS = new Set([
   'verify-email',
 ]);
 
-/** BE entity_slug 규칙과 동형(kebab·lowercase·영숫자+하이픈) — 형식부터 안 맞으면 fetch 자체 생략. */
-const SLUG_FORMAT = /^[a-z0-9]+(-[a-z0-9]+)*$/;
-
+/**
+ * story #2039 AC3 — 예전엔 여기서 kebab·ASCII 형식(SLUG_FORMAT)까지 검사해 형식이 안 맞으면
+ * resolve fetch 자체를 생략했다. 그런데 **구 한글 slug(예: `장사왕`)가 정확히 그 형식에서
+ * 탈락**한다 — resolve의 목적이 "이 세그먼트가 구 slug일 수 있으니 canonical로 안내"인데,
+ * 형식 검사가 그 대상을 fetch 이전에 걸러버려 정작 필요한 자리에서 무력했다(원 결함 —
+ * "주소는 영문일 것"이라는 가정 — 이 호환 경로에 그대로 남아있던 것). RESERVED_FIRST_SEGMENTS
+ * 회피 목적(flat 라우트 오인 방지)만 남기고 형식 검사는 제거한다 — 형식이 이상해도 resolve가
+ * 최종 판정한다(not_found면 그대로 통과, Next 자체 404로 정직하게 실패).
+ */
 export function looksLikeWorkspaceSegment(segment: string | undefined | null): segment is string {
   if (!segment) return false;
-  if (RESERVED_FIRST_SEGMENTS.has(segment)) return false;
-  return SLUG_FORMAT.test(segment);
+  return !RESERVED_FIRST_SEGMENTS.has(segment);
 }
 
 export interface ResolvedContext {

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -297,6 +297,35 @@ describe('proxy — resolve (story a539c649 S-route-project S1)', () => {
     expect(response.headers.get('location')).toBe('https://app.example.com/new-moonklabs/board');
   });
 
+  it('story #2039 AC3 — 구 한글 project slug(예: /moonklabs/장사왕/board)도 형식 탈락 없이 resolve해 canonical로 301한다', async () => {
+    // PO 실재현 경로 그대로: workspace는 이미 ASCII('moonklabs')라 문제가 없고, **project
+    // 세그먼트가 구 한글 slug('장사왕')**인 자리 — 딱 이 자리가 원 버그다.
+    //
+    // 회귀 재현 ①: SLUG_FORMAT(kebab·ASCII) 검사가 남아있던 시절엔 '장사왕'이 그 형식에서
+    // 탈락해 looksLikeWorkspaceSegment(segments[1])가 false를 반환 → projSlug가 undefined로
+    // 떨어져 resolve가 project 파라미터 없이(workspace만) 호출됐다 — 즉 project 조회 자체가
+    // 시도되지 않았다.
+    //
+    // 회귀 재현 ②(2차 발견, 형식게이트 하나만으론 안 풀림): `pathname`은 비ASCII 세그먼트를
+    // 항상 percent-encoded로 준다. 그 문자열을 디코드 없이 그대로 URLSearchParams에 넣으면
+    // `%`가 `%25`로 재인코딩돼 이중 인코딩된 쿼리스트링이 나가고, 백엔드가 한 번만 디코드하므로
+    // DB의 raw 한글 slug와 매칭되지 않는다. 아래 단언은 fetch가 **단일 인코딩**된 쿼리스트링
+    // (`project=%EC%9E%A5%EC%82%AC%EC%99%95`, decodeURIComponent 한 번으로 '장사왕' 복원)
+    // 으로 호출됐는지까지 정확히 검증한다.
+    const token = await makeAccessToken();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ org_id: 'org-1', org_slug: 'moonklabs', org_role: 'admin', project_id: 'proj-1', redirect: { project: 'project-307152f3' } }),
+    });
+    const response = await middleware(makeRequest('/moonklabs/%EC%9E%A5%EC%82%AC%EC%99%95/board', { sp_at: token }));
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:8000/api/v2/resolve?workspace=moonklabs&project=%EC%9E%A5%EC%82%AC%EC%99%95',
+      expect.any(Object),
+    );
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/project-307152f3/board');
+  });
+
   it('캐시 hit(유효 sp_resolve_cache 쿠키+동일 slug) → resolve fetch 생략', async () => {
     const token = await makeAccessToken();
     const cacheToken = await new SignJWT({

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -451,7 +451,23 @@ async function resolveWorkspaceProject(
   accessToken: string,
   fwdHeaders: Headers,
 ): Promise<ResolveWiringResult> {
-  const segments = pathname.split('/').filter(Boolean);
+  // story #2039 AC3 (2차 발견) — `pathname`은 WHATWG URL 표준대로 비ASCII 세그먼트를 항상
+  // percent-encoded로 준다(`장사왕` → `%EC%9E%A5%EC%82%AC%EC%99%95`, 원문 유니코드로 넣어도
+  // 동일). 그 인코딩된 문자열을 그대로 fetchResolve에 넘기면 URLSearchParams가 `%`를 다시
+  // `%25`로 인코딩해 **이중 인코딩**된 쿼리스트링이 나간다 — 백엔드가 한 번만 디코드하므로
+  // 여전히 `%EC%9E%A5...` 문자열로 남아 DB의 raw 한글 slug(`장사왕`)와 매칭되지 않는다(형식
+  // 게이트를 없앤 이후에도 남아있던 두 번째 결함, resolve 자체는 불렸지만 조회가 실패했을
+  // 것 — 원 재현 로그의 "구 링크 여전히 404"가 형식게이트 하나만으로는 완전히 안 풀렸을
+  // 자리). 디코드는 세그먼트 단위로 한다(경로 구분자 `/`가 디코드로 새로 생기지 않게).
+  const decodeSegment = (segment: string | undefined): string | undefined => {
+    if (!segment) return segment;
+    try {
+      return decodeURIComponent(segment);
+    } catch {
+      return segment; // 잘못된 percent-sequence — 원문 그대로(fail-safe, resolve가 not_found로 정직히 실패)
+    }
+  };
+  const segments = pathname.split('/').filter(Boolean).map(decodeSegment) as string[];
   const wsSlug = segments[0];
   if (!looksLikeWorkspaceSegment(wsSlug)) return { kind: 'skip' };
   const projSlug = looksLikeWorkspaceSegment(segments[1]) ? segments[1] : undefined;


### PR DESCRIPTION
#2039(P0 한글 slug 404)는 AC1·AC2·AC4·AC5·AC7이 이미 dev/prod 실측 PASS였고 AC3(구 링크 호환)만 남아 있었다. PO 코드 확認으로 근본원인까지 문서화돼 있었다.

## 근본
`route-resolve.ts:36`의 SLUG_FORMAT(kebab·ASCII) 검사가 경로 세그먼트를 resolve fetch 이전에 형식으로 거르는데, **구 한글 slug(`장사왕`)가 정확히 그 형식에서 탈락**한다 — resolve의 목적 자체가 "이 세그먼트가 구 slug일 수 있으니 canonical로 안내"인데, 형식 검사가 그 대상을 fetch 이전에 걸러 정작 필요한 자리에서 무력했다.

## 수정 ① — 형식게이트 제거
`looksLikeWorkspaceSegment`에서 SLUG_FORMAT 검사를 제거했다. RESERVED_FIRST_SEGMENTS(flat 라우트 오인 방지) 가드만 남기고, 형식이 이상해도 resolve가 최종 판정한다(not_found면 개입 없이 통과, 회귀 없음).

## 수정 ② — 이중 percent-encoding (구현 중 자체 발견, 형식게이트만으론 AC3가 안 풀림)
`pathname`은 비ASCII 세그먼트를 항상 percent-encoded로 준다. 그 문자열을 디코드 없이 그대로 `URLSearchParams`에 넣으면 `%`가 `%25`로 재인코딩돼 이중 인코딩된 쿼리스트링이 나가고, 백엔드는 표준 디코드를 한 번만 하므로 DB의 raw 한글 slug와 매칭되지 않는다. `decodeURIComponent`(fail-safe)를 추가했다.

## 검증
RED→GREEN: 두 수정 모두 stash 후 재실행 → 신규 테스트 2개(PO의 실재현 경로 `/moonklabs/장사왕/board` 그대로) 정확히 실패, 복원 후 전체 60개 pass. proxy.test.ts 신규 테스트는 fetch 호출 쿼리스트링을 정확히 단일 인코딩으로 검증해 이중 인코딩 회귀까지 잠근다.

type-check/lint(0 errors)/build(EXIT 0)/vitest 전체(286파일·1973개) 전부 green.

## 확認 게이트(AC3 원문)
`/moonklabs/장사왕/board`를 열어 canonical 주소로 301된 뒤 보드가 뜨는 것 — 배포 후 라이브 확認 대상.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>