### PR TITLE
[SID:2076] AC1 — top-bar 컨텍스트 칩(<1024) 신설, 전환 진입점+현위치 라벨 겸용

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -90,6 +90,8 @@
     "orgTrust": "Trust",
     "orgMemory": "Memory",
     "switcherOrgSettingsAria": "Organization settings",
+    "switcherMobileTriggerAria": "Switch organization or project",
+    "switcherMobileSheetTitle": "Switch",
     "switcherSwitchToOrg": "Switch to this organization",
     "switcherNewProject": "New project",
     "switcherNewOrganization": "Create new organization",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -90,6 +90,8 @@
     "orgTrust": "신뢰",
     "orgMemory": "기억",
     "switcherOrgSettingsAria": "Organization 설정",
+    "switcherMobileTriggerAria": "조직·프로젝트 전환",
+    "switcherMobileSheetTitle": "전환",
     "switcherSwitchToOrg": "이 조직으로 전환",
     "switcherNewProject": "새 프로젝트",
     "switcherNewOrganization": "새 Organization 만들기",

--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -64,7 +64,18 @@ function isTabRootPage(pathname: string): boolean {
   return TAB_ROOT_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`));
 }
 
-function ScrollShell({ showTopBar, tabletCentered, chatUnreadTotal, children }: { showTopBar: boolean; tabletCentered: boolean; chatUnreadTotal: number; children: React.ReactNode }) {
+function ScrollShell({
+  showTopBar, tabletCentered, chatUnreadTotal, orgId, orgMemberships, projectId, projectMemberships, children,
+}: {
+  showTopBar: boolean;
+  tabletCentered: boolean;
+  chatUnreadTotal: number;
+  orgId?: string;
+  orgMemberships: OrgSwitcherItem[];
+  projectId?: string;
+  projectMemberships: DashboardProjectOption[];
+  children: React.ReactNode;
+}) {
   const { setScrollContainer } = useTopBar();
   const setRef = useCallback((el: HTMLDivElement | null) => {
     setScrollContainer(el);
@@ -82,7 +93,14 @@ function ScrollShell({ showTopBar, tabletCentered, chatUnreadTotal, children }: 
     <TeamPresenceToggleProvider value={{ toggle: panel.togglePanel, workingCount, open: panel.inlinePanelOpen || panel.drawerOpen }}>
     <SidebarInset className="relative flex flex-col overflow-hidden">
       <div ref={setRef} className="flex flex-1 min-h-0 flex-col overflow-y-auto">
-        {showTopBar && <TopBar />}
+        {showTopBar && (
+          <TopBar
+            orgId={orgId}
+            orgMemberships={orgMemberships}
+            projectId={projectId}
+            projectMemberships={projectMemberships}
+          />
+        )}
         <ContextualPanelLayout
           renderPanel={({ mode, closePanel }) => (
             <div className={mode === 'inline' ? '2xl:sticky 2xl:top-0 2xl:h-svh 2xl:p-2' : 'h-full'}>
@@ -210,7 +228,15 @@ export function DashboardShell({
               userName={userName}
               chatUnreadTotal={chatUnreadTotal}
             />
-            <ScrollShell showTopBar={showTopBar} tabletCentered={tabletCentered} chatUnreadTotal={chatUnreadTotal}>
+            <ScrollShell
+              showTopBar={showTopBar}
+              tabletCentered={tabletCentered}
+              chatUnreadTotal={chatUnreadTotal}
+              orgId={orgId}
+              orgMemberships={orgMemberships}
+              projectId={effectiveProjectId}
+              projectMemberships={projectMemberships}
+            >
               {children}
             </ScrollShell>
           </SidebarProvider>

--- a/apps/web/src/components/nav/context-switcher-chip.test.tsx
+++ b/apps/web/src/components/nav/context-switcher-chip.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+//
+// story #2076 — top-bar 좌상단 컨텍스트 칩(<1024). 현재 조직/프로젝트를 상시 표시하고 탭하면
+// 전환 바텀시트가 열리는 것, 그리고 프로젝트 선택 시 useUnifiedSwitcher(사이드바와 동일 훅)의
+// switchProject가 정확히 호출되는 것을 실제 DOM(createRoot)으로 검증한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { ContextSwitcherChip } from './context-switcher-chip';
+import koMessages from '../../../messages/ko.json';
+
+const pushMock = vi.fn();
+const refreshMock = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock, refresh: refreshMock }),
+  usePathname: () => '/moonklabs/sprintable/board',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('@/components/nav/create-organization-dialog', () => ({
+  CreateOrganizationDialog: () => null,
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+const ORGS = [{ orgId: 'org-1', orgName: '뭉클랩', orgSlug: 'moonklabs', role: 'admin' }];
+const PROJECTS = [
+  { projectId: 'proj-1', projectName: 'Sprintable' },
+  { projectId: 'proj-2', projectName: 'Landing' },
+];
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  pushMock.mockClear();
+  refreshMock.mockClear();
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: { ok: true } }) })));
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe('ContextSwitcherChip — story #2076', () => {
+  it('현재 조직›프로젝트를 라벨로 표시하고 lg:hidden(≥1024에서 숨김)이다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ContextSwitcherChip orgs={ORGS} currentOrgId="org-1" projects={PROJECTS} currentProjectId="proj-1" />,
+      ));
+    });
+    const trigger = container.querySelector('button');
+    expect(trigger?.textContent).toContain('뭉클랩');
+    expect(trigger?.textContent).toContain('Sprintable');
+    expect(trigger?.className).toContain('lg:hidden');
+  });
+
+  it('칩을 탭하기 전에는 프로젝트 목록(바텀시트 내용)이 안 보인다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ContextSwitcherChip orgs={ORGS} currentOrgId="org-1" projects={PROJECTS} currentProjectId="proj-1" />,
+      ));
+    });
+    expect(document.body.textContent).not.toContain('Landing');
+  });
+
+  it('칩을 탭하면 바텀시트가 열려 프로젝트 목록이 보인다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ContextSwitcherChip orgs={ORGS} currentOrgId="org-1" projects={PROJECTS} currentProjectId="proj-1" />,
+      ));
+    });
+    const trigger = container.querySelector('button');
+    await act(async () => { trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(document.body.textContent).toContain('Landing');
+  });
+
+  it('시트에서 다른 프로젝트를 선택하면 switchProject 경로(fetch /api/switch-project)가 호출된다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ContextSwitcherChip orgs={ORGS} currentOrgId="org-1" projects={PROJECTS} currentProjectId="proj-1" />,
+      ));
+    });
+    const trigger = container.querySelector('button');
+    await act(async () => { trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    const landingButton = [...document.querySelectorAll('button')].find((b) => b.textContent?.includes('Landing'));
+    await act(async () => {
+      landingButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/switch-project',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ project_id: 'proj-2' }) }),
+    );
+  });
+});

--- a/apps/web/src/components/nav/context-switcher-chip.tsx
+++ b/apps/web/src/components/nav/context-switcher-chip.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Check, ChevronDown, Loader2, Plus, Settings } from 'lucide-react';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogClose,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { CreateOrganizationDialog } from '@/components/nav/create-organization-dialog';
+import { useUnifiedSwitcher, type OrgSwitcherItem, type ProjectSwitcherItem } from '@/hooks/use-unified-switcher';
+
+interface ContextSwitcherChipProps {
+  orgs: OrgSwitcherItem[];
+  currentOrgId?: string;
+  projects: ProjectSwitcherItem[];
+  currentProjectId?: string;
+}
+
+function OrgInitial({ name }: { name: string }) {
+  return (
+    <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-sm bg-brand text-[9px] font-semibold text-brand-foreground">
+      {name.charAt(0).toUpperCase()}
+    </span>
+  );
+}
+
+/**
+ * story #2076 — top-bar 좌상단 컨텍스트 칩(<1024 전용, `lg:hidden`). 현재 조직/프로젝트를
+ * 상시 표시("여기가 어디인지" 라벨 겸)하고 탭하면 전환 바텀시트를 연다. 로직은
+ * useUnifiedSwitcher(사이드바 UnifiedSwitcher와 동일 훅) — 전환 자체는 새로 구현하지 않고
+ * 재사용한다(#2039 AC4가 고친 slug-path 보존·optimistic rollback을 그대로 물려받는다).
+ *
+ * ⚠️ PO 순서 지시: 이 칩은 기존 "More → Settings → 구 GNB" 경로와 **공존**한다. 구 경로 제거는
+ * 이 칩이 배포·라이브 확認된 뒤 별도 후속으로 진행한다(둘 다 한 번에 바꾸면 전환 경로가
+ * 잠깐 0이 되는 위험).
+ */
+export function ContextSwitcherChip({ orgs, currentOrgId, projects, currentProjectId }: ContextSwitcherChipProps) {
+  const t = useTranslations('nav');
+  const tCommon = useTranslations('common');
+  const s = useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjectId });
+
+  // 유나 칩 표시 규격 미도착 — PO 폴백 지시: 조직 › 프로젝트 둘 다 표시(선생님이 "어느
+  // 컨텍스트인지 모름"이라 하셨으므로 하나만 보이면 그 결함이 재발한다).
+  const chipLabel = s.displayProject ? `${s.displayOrg} › ${s.displayProject}` : s.displayOrg;
+
+  return (
+    <>
+      <Sheet open={s.open} onOpenChange={s.setOpen}>
+        <button
+          type="button"
+          onClick={() => s.setOpen(true)}
+          disabled={s.pending}
+          className="flex min-w-0 max-w-[55vw] shrink-0 items-center gap-1.5 rounded-full border border-border bg-muted/40 py-1 pl-1.5 pr-2 text-left transition hover:bg-muted disabled:opacity-60 lg:hidden"
+          aria-label={t('switcherMobileTriggerAria')}
+        >
+          <OrgInitial name={s.displayOrg} />
+          <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">{chipLabel}</span>
+          <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
+        </button>
+
+        <SheetContent side="bottom" className="max-h-[80vh] rounded-t-2xl p-0">
+          <SheetHeader className="border-b pb-3">
+            <SheetTitle>{t('switcherMobileSheetTitle')}</SheetTitle>
+          </SheetHeader>
+
+          <div className="focus-inset flex-1 overflow-y-auto px-2 pb-4">
+            {/* 현재 조직 */}
+            <div className="flex items-center justify-between px-2 py-2">
+              <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                <OrgInitial name={s.displayOrg} />
+                {s.displayOrg}
+              </span>
+              <button
+                type="button"
+                onClick={() => { window.location.href = '/settings?tab=organization'; }}
+                className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+                aria-label={t('switcherOrgSettingsAria')}
+              >
+                <Settings className="h-3.5 w-3.5" />
+              </button>
+            </div>
+            {projects.map((project) => (
+              <button
+                key={project.projectId}
+                type="button"
+                disabled={s.pending}
+                onClick={() => void s.switchProject(project.projectId)}
+                className="flex w-full items-center gap-2 rounded-lg px-4 py-2.5 text-left transition hover:bg-accent disabled:opacity-60"
+              >
+                <span className="min-w-0 flex-1 truncate text-sm">{project.projectName}</span>
+                {project.projectId === s.currentProjectId && (
+                  <Check className="h-4 w-4 shrink-0 text-primary" />
+                )}
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={() => s.setCreateProjectOpen(true)}
+              className="flex w-full items-center gap-2 rounded-lg px-4 py-2.5 text-left text-muted-foreground transition hover:bg-accent"
+            >
+              <Plus className="h-4 w-4 shrink-0" />
+              <span className="text-sm">{t('switcherNewProject')}</span>
+            </button>
+
+            {/* 다른 조직들 */}
+            {s.otherOrgs.map((org) => {
+              const orgProjects = s.otherOrgProjects[org.orgId];
+              const isLoading = s.loadingOrgIds.has(org.orgId);
+              return (
+                <div key={org.orgId} className="mt-2 border-t pt-2">
+                  <div className="flex items-center gap-1.5 px-2 py-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    <OrgInitial name={org.orgName} />
+                    {org.orgName}
+                    {org.role && <span className="text-[9px] font-normal capitalize normal-case opacity-60">{org.role}</span>}
+                  </div>
+                  {isLoading ? (
+                    <div className="flex items-center gap-2 px-4 py-2.5 text-sm text-muted-foreground">
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      <span>{tCommon('loading')}</span>
+                    </div>
+                  ) : orgProjects && orgProjects.length > 0 ? (
+                    orgProjects.map((project) => (
+                      <button
+                        key={project.projectId}
+                        type="button"
+                        disabled={s.pending}
+                        onClick={() => void s.switchOrgAndProject(org.orgId, project.projectId)}
+                        className="flex w-full items-center gap-2 rounded-lg px-4 py-2.5 text-left transition hover:bg-accent disabled:opacity-60"
+                      >
+                        <span className="min-w-0 flex-1 truncate text-sm">{project.projectName}</span>
+                      </button>
+                    ))
+                  ) : (
+                    <button
+                      type="button"
+                      disabled={s.pending}
+                      onClick={() => void s.switchOrg(org.orgId)}
+                      className="flex w-full items-center gap-2 rounded-lg px-4 py-2.5 text-left text-muted-foreground transition hover:bg-accent disabled:opacity-60"
+                    >
+                      <span className="text-sm">{t('switcherSwitchToOrg')}</span>
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+
+            <div className="mt-2 border-t pt-2">
+              <button
+                type="button"
+                onClick={() => s.setCreateOrgOpen(true)}
+                className="flex w-full items-center gap-2 rounded-lg px-4 py-2.5 text-left transition hover:bg-accent"
+              >
+                <Plus className="h-4 w-4 shrink-0" />
+                <span className="text-sm">{t('switcherNewOrganization')}</span>
+              </button>
+            </div>
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      <CreateOrganizationDialog
+        open={s.createOrgOpen}
+        onOpenChange={s.setCreateOrgOpen}
+        onCreated={s.handleOrgCreated}
+      />
+
+      <Dialog open={s.createProjectOpen} onOpenChange={s.setCreateProjectOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('switcherNewProjectDialogTitle')}</DialogTitle>
+          </DialogHeader>
+          <form onSubmit={(e) => { e.preventDefault(); void s.createProject(s.newProjectName, s.newProjectDesc); }} className="space-y-3">
+            <div className="space-y-1">
+              <label className="text-sm font-medium" htmlFor="chip-proj-name">
+                {t('switcherProjectNameLabel')} <span className="text-destructive">*</span>
+              </label>
+              <input
+                id="chip-proj-name"
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                placeholder={t('switcherProjectNamePlaceholder')}
+                value={s.newProjectName}
+                onChange={(e) => s.setNewProjectName(e.target.value)}
+                required
+                autoFocus
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium" htmlFor="chip-proj-desc">
+                {t('switcherDescriptionLabel')} <span className="text-muted-foreground text-xs">{t('switcherOptionalLabel')}</span>
+              </label>
+              <textarea
+                id="chip-proj-desc"
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                placeholder={t('switcherProjectDescPlaceholder')}
+                rows={3}
+                value={s.newProjectDesc}
+                onChange={(e) => s.setNewProjectDesc(e.target.value)}
+              />
+            </div>
+            <DialogFooter>
+              <DialogClose render={<Button type="button" variant="ghost" disabled={s.creating}>{tCommon('cancel')}</Button>} />
+              <Button type="submit" disabled={!s.newProjectName.trim() || s.creating}>
+                {s.creating ? t('switcherCreating') : t('switcherCreateButton')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/components/nav/top-bar.tsx
+++ b/apps/web/src/components/nav/top-bar.tsx
@@ -5,12 +5,21 @@ import { NotificationBell } from './notification-bell';
 import { WhatsNewButton } from '@/components/release-notes/whats-new-button';
 import { PresenceToggleButton } from '@/components/presence/team-presence-toggle';
 import { useTopBar } from './top-bar-context';
+import { ContextSwitcherChip } from './context-switcher-chip';
+import type { OrgSwitcherItem } from './unified-switcher';
 
 interface TopBarProps {
   className?: string;
+  // story #2076 — <1024 컨텍스트 칩(조직/프로젝트 전환). AppSidebar와 같은 이유로 훅 대신
+  // props로 받는다(dashboard-shell.tsx가 이 트리 전체의 provider라 그 안에서 useDashboardContext를
+  // 다시 소비하면 파일 간 순환 import가 생긴다 — AppSidebar가 이미 같은 패턴).
+  orgId?: string;
+  orgMemberships?: OrgSwitcherItem[];
+  projectId?: string;
+  projectMemberships?: Array<{ projectId: string; projectName: string }>;
 }
 
-export function TopBar({ className }: TopBarProps) {
+export function TopBar({ className, orgId, orgMemberships = [], projectId, projectMemberships = [] }: TopBarProps) {
   const { title, actions, hidden } = useTopBar();
   return (
     <div
@@ -24,7 +33,16 @@ export function TopBar({ className }: TopBarProps) {
       )}
     >
       {/* story #1958: 모바일 햄버거 트리거 제거 — 하단 탭바(MobileTabBar)가 <1024 내비게이션을
-          대신한다(blueprint §3.2 "모바일 사이드바 Sheet/햄버거 폐기" 방향, 오르테가군 확定). */}
+          대신한다(blueprint §3.2 "모바일 사이드바 Sheet/햄버거 폐기" 방향, 오르테가군 확定).
+          story #2076: 그 자리에 컨텍스트 칩을 추가한다 — 탭바는 화면 이동, 칩은 컨텍스트(조직/
+          프로젝트) 전환으로 관심사가 다르다. title보다 먼저 두어 "지금 어디에 있는지"가 화면
+          제목보다 앞서 보이게 한다. */}
+      <ContextSwitcherChip
+        orgs={orgMemberships}
+        currentOrgId={orgId}
+        projects={projectMemberships}
+        currentProjectId={projectId}
+      />
       <div className="flex min-w-0 flex-1 items-center gap-2">
         {title}
       </div>

--- a/apps/web/src/components/nav/unified-switcher.tsx
+++ b/apps/web/src/components/nav/unified-switcher.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { TAB_PROJECT_STORAGE_KEY } from '@/lib/project-context-client';
 import { Check, ChevronDown, Loader2, Plus, Settings } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
@@ -26,50 +23,18 @@ import {
 import { Button } from '@/components/ui/button';
 import { SidebarMenuButton } from '@/components/ui/sidebar';
 import { CreateOrganizationDialog } from '@/components/nav/create-organization-dialog';
+import { useUnifiedSwitcher, withSwitchedSlugs, type OrgSwitcherItem, type ProjectSwitcherItem } from '@/hooks/use-unified-switcher';
 
-export interface OrgSwitcherItem {
-  orgId: string;
-  orgName: string;
-  orgSlug: string;
-  role?: string;
-}
-
-interface ProjectItem {
-  projectId: string;
-  projectName: string;
-}
-
-// story #2039 AC4 — 라이브 재현 확認(2026-07-20): switchProject/switchOrgAndProject가 URL 경로는
-// 그대로 두고 `?p=`만 갈아끼워서 ①목록이 안 바뀐 것처럼 보이고 ②사이드바를 누르는 순간에야 새
-// 프로젝트 slug로 이동해 그 slug가 미정규화(한글 등)면 404가 터진다(#2039 본체와 결합해 증폭).
-// `/{ws}/{proj}/...` 아래 라우트는 `[ws]` 밑에 `[proj]`만 존재(다른 org-레벨 세그먼트 없음)라
-// pathname 첫 세그먼트가 현재 org slug와 일치하면 그 경로는 반드시 project-scoped이고, 둘째
-// 세그먼트가 project slug다 — 그 둘만 교체하면 나머지(리소스+하위 경로)는 그대로 보존된다.
-// 현재 화면 유지가 컨텍스트 보존에 맞다고 판단(PO 동의) — 기본 화면으로 보내는 대안은 기각.
-export function withSwitchedSlugs(
-  pathname: string,
-  currentOrgSlug: string | undefined,
-  newOrgSlug: string,
-  newProjectSlug: string,
-): string | null {
-  const segments = pathname.split('/').filter(Boolean);
-  if (segments.length < 2 || !currentOrgSlug || segments[0] !== currentOrgSlug) return null;
-  segments[0] = newOrgSlug;
-  segments[1] = newProjectSlug;
-  return `/${segments.join('/')}`;
-}
-
-async function fetchProjectSlug(projectId: string): Promise<string | null> {
-  return fetch(`/api/projects/${projectId}`)
-    .then((r) => (r.ok ? r.json() : null))
-    .then((json: { data?: { slug?: string | null } } | null) => json?.data?.slug ?? null)
-    .catch(() => null);
-}
+// story #2076: 로직(withSwitchedSlugs 포함)이 hooks/use-unified-switcher.ts로 이동했다 —
+// 사이드바(UnifiedSwitcher, ≥1024)와 신규 ContextSwitcherChip(top-bar 칩+바텀시트, <1024)이
+// 같은 훅을 공유한다. 기존 import 경로(`from './unified-switcher'`)를 깨지 않도록 재-export.
+export { withSwitchedSlugs };
+export type { OrgSwitcherItem };
 
 interface UnifiedSwitcherProps {
   orgs: OrgSwitcherItem[];
   currentOrgId?: string;
-  projects: ProjectItem[];
+  projects: ProjectSwitcherItem[];
   currentProjectId?: string;
   className?: string;
 }
@@ -82,6 +47,8 @@ function OrgInitial({ name }: { name: string }) {
   );
 }
 
+// story #2076: 사이드바 트리거(≥1024)용 UI. 로직은 useUnifiedSwitcher 훅 — 신규
+// ContextSwitcherChip(top-bar 칩+바텀시트, <1024)이 같은 훅을 쓰되 컨테이너만 Sheet로 갈아낀다.
 export function UnifiedSwitcher({
   orgs,
   currentOrgId,
@@ -91,199 +58,26 @@ export function UnifiedSwitcher({
 }: UnifiedSwitcherProps) {
   const t = useTranslations('nav');
   const tCommon = useTranslations('common');
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const [pending, setPending] = useState(false);
-  const [open, setOpen] = useState(false);
-  const [createOrgOpen, setCreateOrgOpen] = useState(false);
-  const [createProjectOpen, setCreateProjectOpen] = useState(false);
-  const [newProjectName, setNewProjectName] = useState('');
-  const [newProjectDesc, setNewProjectDesc] = useState('');
-  const [creating, setCreating] = useState(false);
-
-  // 다른 조직의 프로젝트를 lazy fetch
-  const [otherOrgProjects, setOtherOrgProjects] = useState<Record<string, ProjectItem[]>>({});
-  const [loadingOrgIds, setLoadingOrgIds] = useState<Set<string>>(new Set());
-
-  // Optimistic org 상태 — API 성공 즉시 UI에 반영, router.refresh() 완료 후 서버 값과 동기화
-  const [localOrgId, setLocalOrgId] = useState<string | undefined>(currentOrgId);
-
-  // 서버에서 새 currentOrgId가 내려오면 (router.refresh() 완료 후) 로컬 상태 동기화
-  useEffect(() => {
-    setLocalOrgId(currentOrgId);
-  }, [currentOrgId]);
-
-  const currentOrg = orgs.find((o) => o.orgId === localOrgId);
-  const currentProject = projects.find((p) => p.projectId === currentProjectId);
-  const otherOrgs = orgs.filter((o) => o.orgId !== localOrgId);
-
-  const displayOrg = currentOrg?.orgName ?? 'Organization';
-  const displayProject = currentProject?.projectName ?? '';
-
-  // 드롭다운 열릴 때 다른 조직의 프로젝트 fetch
-  useEffect(() => {
-    if (!open) return;
-    for (const org of otherOrgs) {
-      if (otherOrgProjects[org.orgId] !== undefined || loadingOrgIds.has(org.orgId)) continue;
-      setLoadingOrgIds((prev) => new Set([...prev, org.orgId]));
-      fetch(`/api/projects`, { headers: { 'X-Org-Id': org.orgId } })
-        .then((r) => r.ok ? r.json() : null)
-        .then((data: { data?: Array<{ id?: string; projectId?: string; name?: string; projectName?: string }> } | null) => {
-          const mapped = (data?.data ?? []).map((p) => ({
-            projectId: p.id ?? p.projectId ?? '',
-            projectName: p.name ?? p.projectName ?? '',
-          }));
-          setOtherOrgProjects((prev) => ({ ...prev, [org.orgId]: mapped }));
-        })
-        .catch(() => {
-          setOtherOrgProjects((prev) => ({ ...prev, [org.orgId]: [] }));
-        })
-        .finally(() => {
-          setLoadingOrgIds((prev) => { const n = new Set(prev); n.delete(org.orgId); return n; });
-        });
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
-
-  async function switchOrg(nextOrgId: string) {
-    if (!nextOrgId || nextOrgId === localOrgId || pending) return;
-    const prevOrgId = localOrgId;
-    setPending(true);
-    setLocalOrgId(nextOrgId); // optimistic: 즉시 사이드바 org명 갱신
-    try {
-      const res = await fetch('/api/switch-org', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ org_id: nextOrgId }),
-      });
-      // 0746aab9: 200이어도 실제 전환 성공(data.ok) 여부를 확인하고 refresh — 단순 res.ok만 보면
-      // 200-but-실패 케이스가 성공으로 오인돼 전환 깨진 화면이 무에러로 뜬다.
-      const json = await res.json().catch(() => null) as { data?: { ok?: boolean } } | null;
-      if (res.ok && json?.data?.ok) {
-        router.refresh();
-      } else {
-        setLocalOrgId(prevOrgId); // 실패(비-2xx 또는 data.ok 아님) 시 롤백
-      }
-    } finally {
-      setPending(false);
-    }
-  }
-
-  async function switchOrgAndProject(nextOrgId: string, projectId: string) {
-    if (pending) return;
-    const prevOrgId = localOrgId;
-    setPending(true);
-    setLocalOrgId(nextOrgId); // optimistic: 즉시 사이드바 org명 갱신
-    try {
-      const orgRes = await fetch('/api/switch-org', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ org_id: nextOrgId }),
-      });
-      if (!orgRes.ok) {
-        setLocalOrgId(prevOrgId);
-        return;
-      }
-      // org 전환 후 project 전환 (쿠키는 Set-Cookie로 이미 갱신됨)
-      await fetch('/api/switch-project', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ project_id: projectId }),
-      }).catch(() => null);
-      // R2: 랜딩 탭의 per-tab SSOT(sessionStorage + `?p=`)도 새 프로젝트로 동기.
-      if (typeof window !== 'undefined') window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, projectId);
-      const sp = new URLSearchParams(Array.from(searchParams.entries()));
-      sp.set('p', projectId);
-      // story #2039 AC4 — org+project 동시 전환도 경로 세그먼트 둘 다 갱신.
-      const newOrgSlug = orgs.find((o) => o.orgId === nextOrgId)?.orgSlug;
-      const newSlug = newOrgSlug ? await fetchProjectSlug(projectId) : null;
-      const switchedPath = newOrgSlug && newSlug ? withSwitchedSlugs(pathname, currentOrg?.orgSlug, newOrgSlug, newSlug) : null;
-      router.push(`${switchedPath ?? pathname}?${sp.toString()}`);
-      router.refresh();
-    } finally {
-      setPending(false);
-    }
-  }
-
-  async function switchProject(nextProjectId: string) {
-    if (!nextProjectId || nextProjectId === currentProjectId || pending) return;
-    setPending(true);
-    try {
-      // R2 per-tab SSOT: 전역 reload 대신 이 탭의 sessionStorage backstop + URL `?p=` 갱신.
-      // → 탭별 독립(85614dd9) + 화면/컨텍스트 동기(d802da27). 다른 탭은 자기 `?p=`로 안 흔들림.
-      if (typeof window !== 'undefined') window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, nextProjectId);
-      const sp = new URLSearchParams(Array.from(searchParams.entries()));
-      sp.set('p', nextProjectId);
-      // story #2039 AC4 — 경로의 프로젝트 slug 세그먼트를 즉시 새 프로젝트로 교체(같은 org라
-      // org 세그먼트는 유지). 실패(slug 조회 불가 등)하면 안전하게 기존 pathname으로 폴백 —
-      // ?p만 갈아끼우던 원래 동작과 동일하게 degrade, 새 오류를 만들지 않는다.
-      const orgSlug = currentOrg?.orgSlug;
-      const newSlug = orgSlug ? await fetchProjectSlug(nextProjectId) : null;
-      const switchedPath = orgSlug && newSlug ? withSwitchedSlugs(pathname, orgSlug, orgSlug, newSlug) : null;
-      router.push(`${switchedPath ?? pathname}?${sp.toString()}`);
-      // 쿠키/JWT 동기화(이 탭 RSC·첫 렌더용). 공유 쿠키가 덮여도 per-tab 정합은 `?p=`+sessionStorage+
-      // fetch X-Project-Id 헤더가 보장하므로 무해.
-      await fetch('/api/switch-project', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ project_id: nextProjectId }),
-      }).catch(() => null);
-      router.refresh();
-    } finally {
-      setPending(false);
-    }
-  }
-
-  async function createProject(e: React.FormEvent) {
-    e.preventDefault();
-    if (!newProjectName.trim() || creating) return;
-    setCreating(true);
-    try {
-      const res = await fetch('/api/projects', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: newProjectName.trim(),
-          description: newProjectDesc.trim() || null,
-          ...(currentOrgId ? { org_id: currentOrgId } : {}),
-        }),
-      });
-      if (!res.ok) return;
-      const data = await res.json() as { id?: string; data?: { id: string } };
-      const newId = data.id ?? data.data?.id;
-      setCreateProjectOpen(false);
-      setNewProjectName('');
-      setNewProjectDesc('');
-      if (newId) await switchProject(newId);
-      else router.refresh();
-    } finally {
-      setCreating(false);
-    }
-  }
-
-  function handleOrgCreated(orgId: string) {
-    window.location.href = `/onboarding?step=project&orgId=${orgId}`;
-  }
+  const s = useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjectId });
 
   return (
     <>
-      <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenu open={s.open} onOpenChange={s.setOpen}>
         <DropdownMenuTrigger
-          disabled={pending}
+          disabled={s.pending}
           render={
             <SidebarMenuButton className={cn('w-full', className)}>
-              <OrgInitial name={displayOrg} />
+              <OrgInitial name={s.displayOrg} />
               {/* story c4980e70(조직 헤더 1급화): 조직명=primary(굵게)·프로젝트명=secondary로 emphasis 전도 —
                   기존엔 조직명이 10px 보조 라벨이라 "조직명 부재"처럼 읽혔다(doc §1 ①). */}
               <span className="flex min-w-0 flex-1 flex-col truncate text-left">
                 <span className="truncate text-xs font-semibold text-foreground leading-tight">
-                  {displayOrg}
+                  {s.displayOrg}
                 </span>
                 {/* 0746: 전환 중에는 옛 org의 프로젝트명을 숨겨 "새 org + 옛 프로젝트" 깜빡임(leak처럼 보임)을 차단 */}
-                {!pending && displayProject && (
+                {!s.pending && s.displayProject && (
                   <span className="truncate text-[10px] font-medium text-muted-foreground leading-tight">
-                    {displayProject}
+                    {s.displayProject}
                   </span>
                 )}
               </span>
@@ -297,8 +91,8 @@ export function UnifiedSwitcher({
             <div className="flex items-center justify-between px-2 py-1.5">
               <DropdownMenuLabel className="p-0 text-[11px] font-semibold text-muted-foreground uppercase tracking-wide">
                 <span className="flex items-center gap-1.5">
-                  <OrgInitial name={displayOrg} />
-                  {displayOrg}
+                  <OrgInitial name={s.displayOrg} />
+                  {s.displayOrg}
                 </span>
               </DropdownMenuLabel>
               <button
@@ -313,26 +107,26 @@ export function UnifiedSwitcher({
             {projects.map((project) => (
               <DropdownMenuItem
                 key={project.projectId}
-                disabled={pending}
+                disabled={s.pending}
                 className="pl-5"
-                onClick={() => void switchProject(project.projectId)}
+                onClick={() => void s.switchProject(project.projectId)}
               >
                 <span className="flex-1 truncate text-sm">{project.projectName}</span>
-                {project.projectId === currentProjectId && (
+                {project.projectId === s.currentProjectId && (
                   <Check className="h-3.5 w-3.5 shrink-0 text-primary" />
                 )}
               </DropdownMenuItem>
             ))}
-            <DropdownMenuItem className="pl-5 text-muted-foreground" onClick={() => setCreateProjectOpen(true)}>
+            <DropdownMenuItem className="pl-5 text-muted-foreground" onClick={() => s.setCreateProjectOpen(true)}>
               <Plus className="h-3.5 w-3.5" />
               <span className="text-sm">{t('switcherNewProject')}</span>
             </DropdownMenuItem>
           </DropdownMenuGroup>
 
           {/* 다른 조직들 — 각 조직 아래에 프로젝트 표시 */}
-          {otherOrgs.map((org) => {
-            const orgProjects = otherOrgProjects[org.orgId];
-            const isLoading = loadingOrgIds.has(org.orgId);
+          {s.otherOrgs.map((org) => {
+            const orgProjects = s.otherOrgProjects[org.orgId];
+            const isLoading = s.loadingOrgIds.has(org.orgId);
             return (
               <div key={org.orgId}>
                 <DropdownMenuSeparator />
@@ -357,18 +151,18 @@ export function UnifiedSwitcher({
                     orgProjects.map((project) => (
                       <DropdownMenuItem
                         key={project.projectId}
-                        disabled={pending}
+                        disabled={s.pending}
                         className="pl-5"
-                        onClick={() => void switchOrgAndProject(org.orgId, project.projectId)}
+                        onClick={() => void s.switchOrgAndProject(org.orgId, project.projectId)}
                       >
                         <span className="flex-1 truncate text-sm">{project.projectName}</span>
                       </DropdownMenuItem>
                     ))
                   ) : (
                     <DropdownMenuItem
-                      disabled={pending}
+                      disabled={s.pending}
                       className="pl-5 text-muted-foreground"
-                      onClick={() => void switchOrg(org.orgId)}
+                      onClick={() => void s.switchOrg(org.orgId)}
                     >
                       <span className="text-sm">{t('switcherSwitchToOrg')}</span>
                     </DropdownMenuItem>
@@ -379,7 +173,7 @@ export function UnifiedSwitcher({
           })}
 
           <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={() => setCreateOrgOpen(true)}>
+          <DropdownMenuItem onClick={() => s.setCreateOrgOpen(true)}>
             <Plus className="h-3.5 w-3.5" />
             <span className="text-sm">{t('switcherNewOrganization')}</span>
           </DropdownMenuItem>
@@ -387,17 +181,17 @@ export function UnifiedSwitcher({
       </DropdownMenu>
 
       <CreateOrganizationDialog
-        open={createOrgOpen}
-        onOpenChange={setCreateOrgOpen}
-        onCreated={handleOrgCreated}
+        open={s.createOrgOpen}
+        onOpenChange={s.setCreateOrgOpen}
+        onCreated={s.handleOrgCreated}
       />
 
-      <Dialog open={createProjectOpen} onOpenChange={setCreateProjectOpen}>
+      <Dialog open={s.createProjectOpen} onOpenChange={s.setCreateProjectOpen}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>{t('switcherNewProjectDialogTitle')}</DialogTitle>
           </DialogHeader>
-          <form onSubmit={(e) => void createProject(e)} className="space-y-3">
+          <form onSubmit={(e) => { e.preventDefault(); void s.createProject(s.newProjectName, s.newProjectDesc); }} className="space-y-3">
             <div className="space-y-1">
               <label className="text-sm font-medium" htmlFor="unified-proj-name">
                 {t('switcherProjectNameLabel')} <span className="text-destructive">*</span>
@@ -406,8 +200,8 @@ export function UnifiedSwitcher({
                 id="unified-proj-name"
                 className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                 placeholder={t('switcherProjectNamePlaceholder')}
-                value={newProjectName}
-                onChange={(e) => setNewProjectName(e.target.value)}
+                value={s.newProjectName}
+                onChange={(e) => s.setNewProjectName(e.target.value)}
                 required
                 autoFocus
               />
@@ -421,14 +215,14 @@ export function UnifiedSwitcher({
                 className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                 placeholder={t('switcherProjectDescPlaceholder')}
                 rows={3}
-                value={newProjectDesc}
-                onChange={(e) => setNewProjectDesc(e.target.value)}
+                value={s.newProjectDesc}
+                onChange={(e) => s.setNewProjectDesc(e.target.value)}
               />
             </div>
             <DialogFooter>
-              <DialogClose render={<Button type="button" variant="ghost" disabled={creating}>{tCommon('cancel')}</Button>} />
-              <Button type="submit" disabled={!newProjectName.trim() || creating}>
-                {creating ? t('switcherCreating') : t('switcherCreateButton')}
+              <DialogClose render={<Button type="button" variant="ghost" disabled={s.creating}>{tCommon('cancel')}</Button>} />
+              <Button type="submit" disabled={!s.newProjectName.trim() || s.creating}>
+                {s.creating ? t('switcherCreating') : t('switcherCreateButton')}
               </Button>
             </DialogFooter>
           </form>

--- a/apps/web/src/hooks/use-unified-switcher.ts
+++ b/apps/web/src/hooks/use-unified-switcher.ts
@@ -1,0 +1,243 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { TAB_PROJECT_STORAGE_KEY } from '@/lib/project-context-client';
+
+export interface OrgSwitcherItem {
+  orgId: string;
+  orgName: string;
+  orgSlug: string;
+  role?: string;
+}
+
+export interface ProjectSwitcherItem {
+  projectId: string;
+  projectName: string;
+}
+
+export interface UseUnifiedSwitcherArgs {
+  orgs: OrgSwitcherItem[];
+  currentOrgId?: string;
+  projects: ProjectSwitcherItem[];
+  currentProjectId?: string;
+}
+
+async function fetchProjectSlug(projectId: string): Promise<string | null> {
+  return fetch(`/api/projects/${projectId}`)
+    .then((r) => (r.ok ? r.json() : null))
+    .then((json: { data?: { slug?: string | null } } | null) => json?.data?.slug ?? null)
+    .catch(() => null);
+}
+
+// story #2039 AC4 — 라이브 재현 확認(2026-07-20): switchProject/switchOrgAndProject가 URL 경로는
+// 그대로 두고 `?p=`만 갈아끼워서 ①목록이 안 바뀐 것처럼 보이고 ②사이드바를 누르는 순간에야 새
+// 프로젝트 slug로 이동해 그 slug가 미정규화(한글 등)면 404가 터진다(#2039 본체와 결합해 증폭).
+// `/{ws}/{proj}/...` 아래 라우트는 `[ws]` 밑에 `[proj]`만 존재(다른 org-레벨 세그먼트 없음)라
+// pathname 첫 세그먼트가 현재 org slug와 일치하면 그 경로는 반드시 project-scoped이고, 둘째
+// 세그먼트가 project slug다 — 그 둘만 교체하면 나머지(리소스+하위 경로)는 그대로 보존된다.
+// 현재 화면 유지가 컨텍스트 보존에 맞다고 판단(PO 동의) — 기본 화면으로 보내는 대안은 기각.
+export function withSwitchedSlugs(
+  pathname: string,
+  currentOrgSlug: string | undefined,
+  newOrgSlug: string,
+  newProjectSlug: string,
+): string | null {
+  const segments = pathname.split('/').filter(Boolean);
+  if (segments.length < 2 || !currentOrgSlug || segments[0] !== currentOrgSlug) return null;
+  segments[0] = newOrgSlug;
+  segments[1] = newProjectSlug;
+  return `/${segments.join('/')}`;
+}
+
+/**
+ * story #2076 — UnifiedSwitcher(사이드바, ≥1024)와 신규 ContextSwitcherChip(top-bar 칩+
+ * 바텀시트, <1024)가 공유하는 전환 로직. 원래 unified-switcher.tsx에 있던 상태·핸들러를
+ * 그대로 추출했다 — 동작을 재구현하지 않고 "재사용"한 것(#2039 AC4가 이 스위칭 경로에서
+ * 고친 slug-path 보존·optimistic rollback·per-tab sessionStorage 동기 전부를 두 표현이
+ * 똑같이 물려받는다). 컨테이너(DropdownMenu vs Sheet)만 두 곳이 각자 고른다 — `open`은
+ * 훅이 들고 있지만 그 값을 어느 UI 프리미티브의 open/onOpenChange에 묶을지는 호출부 몫이다.
+ */
+export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjectId }: UseUnifiedSwitcherArgs) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [pending, setPending] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [createOrgOpen, setCreateOrgOpen] = useState(false);
+  const [createProjectOpen, setCreateProjectOpen] = useState(false);
+  const [newProjectName, setNewProjectName] = useState('');
+  const [newProjectDesc, setNewProjectDesc] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  const [otherOrgProjects, setOtherOrgProjects] = useState<Record<string, ProjectSwitcherItem[]>>({});
+  const [loadingOrgIds, setLoadingOrgIds] = useState<Set<string>>(new Set());
+
+  const [localOrgId, setLocalOrgId] = useState<string | undefined>(currentOrgId);
+
+  useEffect(() => {
+    setLocalOrgId(currentOrgId);
+  }, [currentOrgId]);
+
+  const currentOrg = orgs.find((o) => o.orgId === localOrgId);
+  const currentProject = projects.find((p) => p.projectId === currentProjectId);
+  const otherOrgs = orgs.filter((o) => o.orgId !== localOrgId);
+
+  const displayOrg = currentOrg?.orgName ?? 'Organization';
+  const displayProject = currentProject?.projectName ?? '';
+
+  useEffect(() => {
+    if (!open) return;
+    for (const org of otherOrgs) {
+      if (otherOrgProjects[org.orgId] !== undefined || loadingOrgIds.has(org.orgId)) continue;
+      setLoadingOrgIds((prev) => new Set([...prev, org.orgId]));
+      fetch(`/api/projects`, { headers: { 'X-Org-Id': org.orgId } })
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data: { data?: Array<{ id?: string; projectId?: string; name?: string; projectName?: string }> } | null) => {
+          const mapped = (data?.data ?? []).map((p) => ({
+            projectId: p.id ?? p.projectId ?? '',
+            projectName: p.name ?? p.projectName ?? '',
+          }));
+          setOtherOrgProjects((prev) => ({ ...prev, [org.orgId]: mapped }));
+        })
+        .catch(() => {
+          setOtherOrgProjects((prev) => ({ ...prev, [org.orgId]: [] }));
+        })
+        .finally(() => {
+          setLoadingOrgIds((prev) => { const n = new Set(prev); n.delete(org.orgId); return n; });
+        });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  async function switchOrg(nextOrgId: string) {
+    if (!nextOrgId || nextOrgId === localOrgId || pending) return;
+    const prevOrgId = localOrgId;
+    setPending(true);
+    setLocalOrgId(nextOrgId);
+    try {
+      const res = await fetch('/api/switch-org', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ org_id: nextOrgId }),
+      });
+      const json = await res.json().catch(() => null) as { data?: { ok?: boolean } } | null;
+      if (res.ok && json?.data?.ok) {
+        router.refresh();
+      } else {
+        setLocalOrgId(prevOrgId);
+      }
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function switchOrgAndProject(nextOrgId: string, projectId: string) {
+    if (pending) return;
+    const prevOrgId = localOrgId;
+    setPending(true);
+    setLocalOrgId(nextOrgId);
+    try {
+      const orgRes = await fetch('/api/switch-org', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ org_id: nextOrgId }),
+      });
+      if (!orgRes.ok) {
+        setLocalOrgId(prevOrgId);
+        return;
+      }
+      await fetch('/api/switch-project', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ project_id: projectId }),
+      }).catch(() => null);
+      if (typeof window !== 'undefined') window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, projectId);
+      const sp = new URLSearchParams(Array.from(searchParams.entries()));
+      sp.set('p', projectId);
+      const newOrgSlug = orgs.find((o) => o.orgId === nextOrgId)?.orgSlug;
+      const newSlug = newOrgSlug ? await fetchProjectSlug(projectId) : null;
+      const switchedPath = newOrgSlug && newSlug ? withSwitchedSlugs(pathname, currentOrg?.orgSlug, newOrgSlug, newSlug) : null;
+      router.push(`${switchedPath ?? pathname}?${sp.toString()}`);
+      router.refresh();
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function switchProject(nextProjectId: string) {
+    if (!nextProjectId || nextProjectId === currentProjectId || pending) return;
+    setPending(true);
+    try {
+      if (typeof window !== 'undefined') window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, nextProjectId);
+      const sp = new URLSearchParams(Array.from(searchParams.entries()));
+      sp.set('p', nextProjectId);
+      const orgSlug = currentOrg?.orgSlug;
+      const newSlug = orgSlug ? await fetchProjectSlug(nextProjectId) : null;
+      const switchedPath = orgSlug && newSlug ? withSwitchedSlugs(pathname, orgSlug, orgSlug, newSlug) : null;
+      router.push(`${switchedPath ?? pathname}?${sp.toString()}`);
+      await fetch('/api/switch-project', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ project_id: nextProjectId }),
+      }).catch(() => null);
+      router.refresh();
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function createProject(name: string, description: string): Promise<boolean> {
+    if (!name.trim() || creating) return false;
+    setCreating(true);
+    try {
+      const res = await fetch('/api/projects', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: name.trim(),
+          description: description.trim() || null,
+          ...(currentOrgId ? { org_id: currentOrgId } : {}),
+        }),
+      });
+      if (!res.ok) return false;
+      const data = await res.json() as { id?: string; data?: { id: string } };
+      const newId = data.id ?? data.data?.id;
+      setCreateProjectOpen(false);
+      setNewProjectName('');
+      setNewProjectDesc('');
+      if (newId) await switchProject(newId);
+      else router.refresh();
+      return true;
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  function handleOrgCreated(orgId: string) {
+    window.location.href = `/onboarding?step=project&orgId=${orgId}`;
+  }
+
+  return {
+    pending,
+    open, setOpen,
+    createOrgOpen, setCreateOrgOpen,
+    createProjectOpen, setCreateProjectOpen,
+    newProjectName, setNewProjectName,
+    newProjectDesc, setNewProjectDesc,
+    creating,
+    otherOrgProjects,
+    loadingOrgIds,
+    currentOrg,
+    currentProject,
+    otherOrgs,
+    displayOrg,
+    displayProject,
+    currentProjectId,
+    switchOrg,
+    switchOrgAndProject,
+    switchProject,
+    createProject,
+    handleOrgCreated,
+  };
+}


### PR DESCRIPTION
선생님 실사용: 프로젝트/계정 전환이 "More → Settings → 구 IA GNB → 전환" 5단계 깊이에만 있었다(작동은 함 — 회귀 아님, 발견성·동선 결함). 유나 홀름 확定 설계에 따라 구현했다.

## 확定 설계
① top-bar 좌상단 컨텍스트 칩 — 현재 조직/프로젝트 상시 표시 + 탭하면 전환
② 바텀시트로 전환(모바일 짧은 선택)
③ 뷰포트별 하나 — ≥1024 사이드바 UnifiedSwitcher 그대로 / <1024 칩
⑤ 순서: ①칩 먼저 배포·확認 → 구 GNB(SidebarTrigger) 제거는 별도 후속

## 구현
전환 로직(switchOrg/switchOrgAndProject/switchProject/createProject 등, #2039 AC4가 고친 slug-path 보존·optimistic rollback·per-tab sessionStorage 동기 전부 포함)을 `hooks/use-unified-switcher.ts`로 추출했다 — 재구현이 아니라 재사용. `UnifiedSwitcher`(사이드바, ≥1024)는 이 훅을 쓰도록 리팩터만 하고 UI/동작은 그대로. 신규 `ContextSwitcherChip`(top-bar, `lg:hidden`)이 같은 훅으로 칩+Sheet(바텀시트) UI를 구성한다.

**칩 라벨**: 유나 칩 표시 규격 문서가 아직 안 와서 PO 폴백 지시대로 "조직 › 프로젝트" 둘 다 표시. 규격 도착하면 후속으로 맞춘다.

## 스코프 — 이 PR에 포함 안 된 것 (PO 순서 지시)
**④ Settings의 구 GNB(SidebarTrigger) 제거는 하지 않았다** — 새 칩과 구 경로가 잠깐이라도 공존해야 "전환 경로가 순간 0이 되는" 위험을 피한다. 이 칩이 배포·라이브 확認된 뒤 별도 후속 PR로 제거한다.

## 검증
RED→GREEN: 신규 컴포넌트 임시 이동 후 재실행 → import 실패로 스위트 fail, 복원 후 4/4 pass. 기존 unified-switcher.test.ts 6개도 리팩터 후 그대로 pass(로직 무회귀 확認).

type-check/lint(0 errors)/build(EXIT 0)/vitest 전체(287파일·1977개) 전부 green.

## 미완 — 라이브(AC5)
실기기 모바일 탭 수 전/후 비교는 배포 후 대상. 유나 칩 표시 규격 도착 시 후속 반영.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>