### PR TITLE
fix(#2074): dev minScale 1→3 durable 배선 — 0단계 응급 봉합

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -50,10 +50,12 @@ jobs:
             echo "target=prod" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-prod-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
             echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
-            # ⚠️ maxScale 5 (ee7794eb ③·선생님 right-size): prod g1-small max_conn 100. per-instance 5(pool
-            # 3/1=4 + pg_pubsub raw 1). rollout(old+new 2×): 2×5×5+20(admin)=70 ≤ 100 ✓ (여유 30).
-            # (PgBouncer 풀러 불필요 — Cloud Run raw TCP 미지원으로 중앙 PgBouncer 불가·관리형 풀링은 Enterprise Plus
-            # 전용. maxScale 10 은 2×10×5+20=120>100 이라 폐기. 향후 트래픽↑ 시 tier업 동반해야 maxScale 상향.)
+            # ⚠️ maxScale 5 (ee7794eb ③·선생님 right-size): prod g1-small. per-instance 5(pool
+            # 3/1=4 + pg_pubsub raw 1). rollout(old+new 2×): 2×5×5+20(admin)=70.
+            # ⚠️ story #2040(2026-07-20) PO gcloud 실측 갱신 — max_connections=**200**(과거 100 가정 낡음,
+            # codex #2074 조사가 재적발). 70 ≤ 200(여유 65%). SSOT는 `docs/db-connection-budget.md`.
+            # (PgBouncer 풀러 불필요/불가 — Cloud Run raw TCP 미지원으로 중앙 PgBouncer 불가·관리형 풀링은
+            # Enterprise Plus 전용(#1779 폐기 이력). 트래픽↑ 시 아키텍처 재검토(#2074) 필요.)
             echo "backend_max_instances=5" >> "$GITHUB_OUTPUT"
             # story #2005: PO 라이브 gcloud 실측(2026-07-17) — backend-prod 현재 유효 Cloud Run
             # 요청 타임아웃=300s. 지금까지 `cloudbuild.yaml`에 `--timeout` 플래그가 없어 이
@@ -75,10 +77,13 @@ jobs:
             echo "backend_min_instances=3" >> "$GITHUB_OUTPUT"
             # ⚠️ maxScale 8 (PO rev 01256-w9r right-size·durable): dev 429 근본 = Cloud Run "no available
             # instance"(maxScale 1 이 fleet 폴링 압도·3h 1345건). per-instance = pool(3/1=4·#1773) +
-            # pg_pubsub raw 1 = 5. rollout(old+new 2×): 2×8×5=80 ≤ 100(PO 실측 dev DB max_conn). 이전
-            # maxScale 1 은 conn-safe였으나 인스턴스 기아로 429 → load+conn 양립값. DB_POOL_SIZE=3/
-            # DB_MAX_OVERFLOW=1 은 cloudbuild.yaml --update-env-vars 로 durable(lingering env 덮어씀).
-            # (⚠️ dev/prod 공유 DB라면 prod(2×5×5+admin)와 합산 점검 필요 — PO 토폴로지 확認.)
+            # pg_pubsub raw 1 = 5. rollout(old+new 2×): 2×8×5=80.
+            # ⚠️ story #2040(2026-07-20) PO gcloud 실측 갱신 — max_connections=**200**(100→200 그날
+            # 사고대응 상향, 과거 100 가정 낡음 — codex #2074 조사가 재적발). 80 ≤ 200(여유 60%). SSOT는
+            # `docs/db-connection-budget.md`. 이전 maxScale 1 은 conn-safe였으나 인스턴스 기아로 429 →
+            # load+conn 양립값. DB_POOL_SIZE=3/DB_MAX_OVERFLOW=1 은 cloudbuild.yaml --update-env-vars
+            # 로 durable(lingering env 덮어씀).
+            # (dev/prod는 별도 Cloud SQL 인스턴스로 확認됨(story #2040 PO gcloud 재확認) — 합산 불필요.)
             echo "backend_max_instances=8" >> "$GITHUB_OUTPUT"
             # story #2005: PO 라이브 gcloud 실측(2026-07-17) — backend-dev 현재 유효 Cloud Run
             # 요청 타임아웃=3600s(Cloud Run 요청 타임아웃 상한). cloudbuild.yaml의

--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -65,7 +65,14 @@ jobs:
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
-            echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
+            # ⚠️ minScale 1→3 (#2074 응급대응, 오르테가군 PO 2026-07-21): gcloud 로그 실측 —
+            # "The request was aborted because there was no available instance"(04:38 다수)가
+            # 채팅 5초 지연·목표화면 Loading·촬영 막힘의 원인이었다. minScale 1은 콜드스타트
+            # 대기를 만들어 트래픽이 몰리면 인스턴스 부족으로 요청이 abort된다. 손으로
+            # gcloud run services update한 값은 다음 자동배포(이 워크플로우)가 덮어써
+            # 원복되므로(어제 교훈 — "손 값은 배포가 덮는다") 여기 durable로 못박는다.
+            # 근본(커넥션 풀링/아키텍처 재검토)은 별도 진행 중 — 이건 0단계 응급 봉합.
+            echo "backend_min_instances=3" >> "$GITHUB_OUTPUT"
             # ⚠️ maxScale 8 (PO rev 01256-w9r right-size·durable): dev 429 근본 = Cloud Run "no available
             # instance"(maxScale 1 이 fleet 폴링 압도·3h 1345건). per-instance = pool(3/1=4·#1773) +
             # pg_pubsub raw 1 = 5. rollout(old+new 2×): 2×8×5=80 ≤ 100(PO 실측 dev DB max_conn). 이전

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,12 +12,15 @@ substitutions:
   _FASTAPI_URL: https://sprintable-backend-dev-787818285179.asia-northeast3.run.app
   _BACKEND_MIN_INSTANCES: '1'
   # ⚠️ default '1'(아래) = _DEPLOY_ENV:dev default 와 정합한 **dev-safe fallback**(수동 `gcloud builds submit`
-  #    override 없을 때 maxScale 10 trap=2×10×5+5=105>25 재현 차단). GHA cloud-build.yml 이 per-env override(prod=5·dev=1).
+  #    override 없을 때 무리한 maxScale 재현 차단). GHA cloud-build.yml 이 per-env override(prod=5·dev=8, #2074 응급).
   #    rollout-safe 산식(ee7794eb·dev TooManyConnections 인시던트): **2 × maxScale × (pool+overflow + raw) +
   #    headroom ≤ max_conn**. per-instance = pool(3/1=4) + pg_pubsub raw(1) = 5.
-  #    prod(g1-small 100): maxScale **5** → 2×5×5+20=70 ≤ 100 ✓(선생님 right-size·여유 30). 10 은 120>100 폐기.
-  #    dev(f1-micro 25): maxScale 1 → 2×1×5+5=15 ≤ 25 ✓. (PgBouncer 풀러: Cloud Run raw TCP 미지원으로 중앙
-  #    불가·관리형 풀링 Enterprise Plus 전용 → 채택 안 함. 트래픽↑ 時 tier업 동반해야 maxScale 상향.)
+  #    ⚠️ story #2040(2026-07-20) PO gcloud 실측 갱신 — max_connections이 dev/prod 둘 다 **200**이다
+  #    (dev는 100→200 그날 사고대응으로 상향). 이 주석이 한동안 100 가정으로 낡아 있었다(codex #2074
+  #    조사가 재적발) — SSOT는 `docs/db-connection-budget.md`, 값 바뀌면 그 문서와 여기를 같이 갱신할 것.
+  #    prod: maxScale 5 → 2×5×5+20=70 ≤ 200(여유 65%). dev: maxScale 8 → 2×8×5=80 ≤ 200(여유 60%).
+  #    (PgBouncer 풀러: Cloud Run raw TCP 미지원으로 중앙 불가·관리형 풀링 Enterprise Plus 전용 → #1779
+  #    폐기 이력 있음. 트래픽↑ 時 아키텍처 재검토(#2074) 필요.)
   _BACKEND_MAX_INSTANCES: '1'
   _GA4_MEASUREMENT_ID: ""  # dev 기본값 빈 문자열 — prod 트리거에서 G-RYHFE7XM3X 주입
   # story #2005(Phase B P1-c, E-A2A-PROTO 리라이어빌리티): Cloud Run 요청 타임아웃이


### PR DESCRIPTION
## 요약
#2074(채팅 5초 지연) 0단계 응급 대응 두 가지:
1. 오르테가군 PO가 gcloud로 응급 상향한 dev minScale(1→3)을 배포파일에 durable로 못박음.
2. codex의 #2074 아키텍처 조사가 재적발한 드리프트 — 배포파일 주석의 max_connections 가정(100)이 story #2040(2026-07-20) 실측값(200)과 안 맞던 것 갱신.

## 근거 ①
오르테가군 gcloud 로그 실측: `"The request was aborted because there was no available instance"`(04:38 다수). minScale 1의 콜드스타트 대기가 트래픽 몰릴 때 인스턴스 부족→요청 abort를 만들며, 이게 채팅 5초 지연·목표화면 Loading·촬영 막힘의 실제 원인으로 확定됨.

## 근거 ②
`docs/db-connection-budget.md`(오늘 아침 #2040 AC4/AC5 작업물)에는 이미 dev/prod max_connections=200이 실측 기록돼 있는데, `cloudbuild.yaml`/`.github/workflows/cloud-build.yml`의 인라인 주석은 여전히 100 가정으로 남아있었다. 값 자체(maxScale/pool 설정)는 이미 200 기준으로 안전하게 잡혀 있었으므로 **동작 변경 없음** — 주석만 실측과 정합시킴.

## 스코프
이건 0단계(응급 봉합 + 문서 정합)뿐. 커넥션 풀링/아키텍처 재검토(근본)는 별도 진행 중 — PgBouncer는 이미 3주 전(#1779) Cloud Run 제약으로 폐기 이력이 확인됐고, 지금 아키텍처 옵션(하이브리드/GKE/실시간 외부화)을 codex 교차검증과 함께 별도로 보는 중.

## 검증
- YAML 문법 확認(`yaml.safe_load`, 두 파일 모두).
- 코드 로직 변경 없음(GHA workflow 문자열 값 + 주석만).

🤖 Generated with [Claude Code](https://claude.com/claude-code)