### PR TITLE
fix(story #2075): org owner/admin이 명시 project_access 없이도 SSE push 수신

### DIFF
--- a/backend/app/services/project_auth.py
+++ b/backend/app/services/project_auth.py
@@ -617,10 +617,18 @@ async def project_accessible_member_ids(
     (project 고정 → 접근 가능 member_id 집합). `team_members`(VIEW, human+agent grant를 이미
     member_id 공간으로 통합)만 조회 — 단일 쿼리 배치(N+1 없음).
 
-    ⚠️ org owner/admin의 암묵 org-wide 접근 분기(has_project_access 3번째 조건)는 **의도적으로
-    제외**한다 — 이 함수는 실시간 SSE push 수신자 해소 전용이라, 명시 project 소속이 없는 admin에게
-    안 밀리는 쪽(false negative)이 잘못 밀리는 쪽(false positive·cross-project 누설)보다 안전.
-    write 인가(has_project_access)는 이 함수를 쓰지 않는다 — 그쪽은 기존 3-branch 그대로."""
+    story #2075(2026-07-21, 촬영 재현+선생님 실사용 케이스로 확定): org owner/admin의 암묵
+    org-wide 접근 분기를 "의도적으로 제외"했던 이전 판단(9ef0f914)을 뒤집는다 — 그 판단은
+    write 인가(`has_project_access`)와 read 인가(SSE push 수신)가 서로 다른 판정을 내리는
+    자기모순이었다: owner는 보드를 **볼 권한**은 있는데(`has_project_access` 3번째 조건)
+    그 화면이 실시간으로 갱신될 **권한**은 없는 상태 — "권한 완화"가 아니라 "같은 사실에
+    다른 답을 내는 두 판정을 일치"시키는 것이다(오늘 반복된 트윈 패턴과 동형).
+
+    owner/admin의 SSE 등록 키는 `org_members.id`다(`resolve_member_identity`의 TeamMember→
+    OrgMember fallback과 동형 — grant-only 휴먼은 team_members 뷰에 project_access 행이 없어
+    project-scoped 브랜치에 안 걸리고 org_member.id로 신원 해소된다). `Project.org_id ==
+    OrgMember.org_id`로 스코프를 맞춰(`_project_access_predicate.admin_branch`와 동일 기준)
+    **다른 org의 owner에게는 여전히 안 새게** 한다 — cross-project(cross-org) 누설 0."""
     rows = await session.execute(
         text(
             """
@@ -629,6 +637,12 @@ async def project_accessible_member_ids(
             WHERE tm.project_id = :project_id
               AND tm.org_id = :org_id
               AND tm.is_active = true
+            UNION
+            SELECT om.id
+            FROM org_members om
+            WHERE om.org_id = :org_id
+              AND om.role IN ('owner', 'admin')
+              AND om.deleted_at IS NULL
             """
         ),
         {"project_id": project_id, "org_id": org_id},

--- a/backend/tests/test_2075_owner_sse_push_parity.py
+++ b/backend/tests/test_2075_owner_sse_push_parity.py
@@ -1,0 +1,117 @@
+"""story #2075(2026-07-21) — org owner/admin이 명시 project_access 없이도 SSE push 수신자
+집합에 포함되는지 실측(까심 아르야 코드 발견 + 댄 어윈 촬영 재현 + 선생님 실사용 케이스로 확定).
+
+`project_accessible_member_ids`(SSE push 수신자 해소)가 `has_project_access`(보드 조회 인가)와
+다른 판정을 내리던 자기모순을 닫는다 — owner는 볼 수 있는데 실시간 갱신은 안 오던 상태.
+직접 함수 호출로 검증(gate approve 등 전체 파이프라인을 안 타서 story #2059/#2067 재검증에서
+겪은 이중 이벤트 얽힘과 무관 — 순수 SQL 함수 단위 테스트)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org + project_a/project_b + owner(project_access 없음, org_members.role=owner) +
+    member_a(project_a에 명시 project_access) + 다른 org의 owner_other(누설 대조군)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    other_org = Organization(id=uuid.uuid4(), name="OtherOrg", slug=f"other-{uuid.uuid4().hex[:8]}")
+    session.add_all([org, other_org])
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="A")
+    session.add(project_a)
+    await session.commit()
+
+    owner_user = User(id=uuid.uuid4(), email=f"owner-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    other_owner_user = User(id=uuid.uuid4(), email=f"other-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add_all([owner_user, other_owner_user])
+    await session.commit()
+
+    # owner는 members 행 자체가 없어도 된다(grant-only 휴먼) — org_members만으로 신원 해소되는
+    # 케이스를 그대로 재현(story #2075가 닫으려는 정확히 그 시나리오).
+    owner_org_member = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=owner_user.id, role="owner")
+    other_owner_org_member = OrgMember(
+        id=uuid.uuid4(), org_id=other_org.id, user_id=other_owner_user.id, role="owner",
+    )
+    session.add_all([owner_org_member, other_owner_org_member])
+    await session.commit()
+
+    member_a = Member(id=uuid.uuid4(), org_id=org.id, type="human", name="Member A")
+    session.add(member_a)
+    await session.commit()
+    session.add(ProjectAccess(id=uuid.uuid4(), project_id=project_a.id, member_id=member_a.id, permission="granted"))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a": project_a.id,
+        "owner_org_member_id": owner_org_member.id,
+        "other_owner_org_member_id": other_owner_org_member.id,
+        "member_a": member_a.id,
+    }
+
+
+@pytest.mark.anyio
+async def test_owner_without_explicit_project_access_is_included():
+    """story #2075 핵심 — project_access 행이 아예 없는 org owner도 수신자 집합에 포함된다."""
+    from app.services.project_auth import project_accessible_member_ids
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            result = await project_accessible_member_ids(s, seeded["org_id"], seeded["project_a"])
+        assert seeded["owner_org_member_id"] in result, "org owner가 push 수신자 집합에서 빠짐(#2075 회귀)"
+        assert seeded["member_a"] in result, "명시 project_access 멤버는 계속 포함돼야 함(무회귀)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_other_org_owner_not_leaked_hard_gate():
+    """하드 게이트 — 다른 org의 owner는 여전히 절대 포함되지 않는다(cross-org 누설 0)."""
+    from app.services.project_auth import project_accessible_member_ids
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            result = await project_accessible_member_ids(s, seeded["org_id"], seeded["project_a"])
+        assert seeded["other_owner_org_member_id"] not in result, "다른 org owner에게 누설됨(#2075 회귀)"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 요약
story #2075(high, 촬영 P2·P7 차단) — 까심 아르야 코드 발견 + 댄 어윈 촬영 재현 + 선생님 실사용 케이스로 확定. `project_accessible_member_ids`(SSE push 수신자 해소)가 `has_project_access`(보드 조회 인가)와 다른 판정을 내리던 자기모순 — org owner는 보드를 **볼 권한**은 있는데 그 화면이 **실시간 갱신될 권한**은 없었다(9ef0f914에서 "의도적으로 제외"한 설계 — write 인가와 read 인가가 어긋나는 트윈 패턴, 오늘 반복된 것과 동형).

## 재현 (오르테가군 종합)
1. 까심 아르야 코드: org owner가 명시 project_access 없으면 push 수신자에서 빠짐(`project_accessible_member_ids`).
2. 댄 어윈 촬영 재현: sellerking으로 보드 열고 실제 `/status` PATCH+이벤트 3건 발화 — 14초간 화면 무갱신.
3. 선생님 실사용 케이스: 뭉클랩 owner라 본인 보드도 실시간 안 올 수 있음.

## 근본
owner/admin의 SSE 등록 키는 `org_members.id`다(`resolve_member_identity`의 TeamMember→OrgMember fallback과 동형 — grant-only 휴먼은 `team_members` 뷰에 project_access 행이 없어 project-scoped 브랜치에 안 걸리고 `org_member.id`로 신원 해소된다). 기존 쿼리는 `team_members`만 조회해 이 케이스를 놓쳤다.

## 변경사항
`project_accessible_member_ids`에 owner/admin UNION 브랜치 추가 — `Project.org_id == OrgMember.org_id`로 스코프를 맞춰(`_project_access_predicate.admin_branch`와 동일 기준) **cross-org 누설은 그대로 차단**한다. "권한 완화"가 아니라 두 판정(write 인가 vs read 인가) 일치가 목표.

## 검증
- `uv run pytest tests/test_2075_owner_sse_push_parity.py` — 신규 realdb 2종(project_access 없는 owner 포함·다른 org owner 하드게이트), skip(로컬 PG 없음) 확認.
- `uv run pytest tests/test_emit_story_status_changed_isolation.py tests/test_h1_s4_merge_gate_wiring.py tests/test_workflow_report.py` — 21 passed, 무회귀.
- `uv run pytest tests/ -k "project_auth or has_project_access or trust_pipeline"` — 21 passed, 9 skipped(realdb), 무회귀.
- 단일 UNION 쿼리(N+1 없음) — 기존 `test_batch_member_resolution_single_query`(단일쿼리 검증) 영향 없음.
- app import 검증 완료(490 routes).

## 배포 후 확認 필요(오르테가군, 까심군)
- 라이브 재검증 — 까심군 방법(별도 액터+raw SSE), 이번엔 **owner 관찰자**로.
- 댄 어윈 촬영 P2·P7 재개.

🤖 Generated with [Claude Code](https://claude.com/claude-code)