### PR TITLE
[SID:2078][E-ARCH 0단계] EventSource 탭당 1개로 통합, 피처플래그 롤백 경로

### DIFF
--- a/apps/web/src/components/presence/use-team-presence.ts
+++ b/apps/web/src/components/presence/use-team-presence.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import type { PresenceStatus } from '@/components/chat/presence-dot';
+import { useSseMultiplexerContext } from '@/components/realtime-provider';
 
 // 2505d27d: #1356 `GET /api/v2/team-presence` 응답 계약(검증 완료·mismatch 0).
 export interface TeamPresenceItem {
@@ -20,9 +21,13 @@ export interface TeamPresenceItem {
  * R2(da9d1781): 3s 폴 제거 → `presence` SSE 이벤트로 refetch(폴→push·~20req/min→0). 초기 1회 +
  * 이벤트 + 탭 visible 복귀 catch-up(hidden 중 누락 이벤트 보정). presence 이벤트 payload 는 trigger({})라
  * 스냅샷은 refetch 로 확보(BE 계약). `document.hidden` 이면 fetch 0(낭비 가드 유지).
+ *
+ * story #2078 — 플래그 ON이면 RealtimeProvider의 공유 커넥션에 'presence' 이벤트만 구독한다
+ * (독립 EventSource를 안 연다). 플래그 OFF/Provider 밖이면 기존과 동일하게 자체 연결.
  */
 export function useTeamPresence(active: boolean, memberId?: string): TeamPresenceItem[] {
   const [items, setItems] = useState<TeamPresenceItem[]>([]);
+  const mux = useSseMultiplexerContext();
 
   const fetchPresence = useCallback(async () => {
     if (typeof document !== 'undefined' && document.hidden) return;
@@ -37,17 +42,27 @@ export function useTeamPresence(active: boolean, memberId?: string): TeamPresenc
   }, []);
 
   useEffect(() => {
-    if (!active || typeof window === 'undefined' || typeof EventSource === 'undefined') return;
+    if (!active || typeof window === 'undefined') return;
     // eslint-disable-next-line react-hooks/set-state-in-effect
     void fetchPresence(); // 초기 스냅샷
+    const onVisible = () => { if (!document.hidden) void fetchPresence(); }; // hidden 중 누락 보정
+    document.addEventListener('visibilitychange', onVisible);
+
+    if (mux) {
+      const unsub = mux.subscribe('presence', () => { void fetchPresence(); });
+      return () => { unsub(); document.removeEventListener('visibilitychange', onVisible); };
+    }
+
+    // 독립 연결 폴백(플래그 OFF 또는 Provider 밖) — story #2078 이전과 완전히 동일한 코드.
+    if (typeof EventSource === 'undefined') {
+      return () => document.removeEventListener('visibilitychange', onVisible);
+    }
     const url = new URL('/api/event-stream', window.location.origin);
     if (memberId) url.searchParams.set('member_id', memberId);
     const es = new EventSource(url.toString(), { withCredentials: true });
     es.addEventListener('presence', () => { void fetchPresence(); }); // 변경 시 push → refetch
-    const onVisible = () => { if (!document.hidden) void fetchPresence(); }; // hidden 중 누락 보정
-    document.addEventListener('visibilitychange', onVisible);
     return () => { es.close(); document.removeEventListener('visibilitychange', onVisible); };
-  }, [active, fetchPresence, memberId]);
+  }, [active, fetchPresence, memberId, mux]);
 
   return items;
 }

--- a/apps/web/src/components/realtime-provider.tsx
+++ b/apps/web/src/components/realtime-provider.tsx
@@ -1,19 +1,36 @@
 'use client';
 
+import { createContext, useContext } from 'react';
 import { ToastContainer, useToast } from '@/components/ui/toast';
+import { useSseMultiplexer, type SseMultiplexerHandle } from '@/lib/realtime/sse-multiplexer';
+
+// story #2078(E-ARCH 0단계) — 피처플래그: OFF(기본)면 presence·notification·chat 훅이 각자
+// 기존 방식대로 독립 EventSource를 연다(회귀 0, 이 스토리 이전 동작 그대로). ON이면 이
+// Provider가 탭당 1개만 열고 세 훅이 이름별로 구독만 얹는다. 문제가 생기면 이 값만
+// 되돌리면 즉시 롤백된다(코드 되돌림·재배포 불요 — env만 바꾸면 다음 배포에 반영).
+export const SSE_MULTIPLEX_ENABLED = process.env['NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED'] === 'true';
+
+const SseMultiplexerContext = createContext<SseMultiplexerHandle | null>(null);
+
+/** null이면(플래그 OFF 또는 Provider 밖) 호출부가 기존 독립 EventSource 경로로 폴백한다. */
+export function useSseMultiplexerContext(): SseMultiplexerHandle | null {
+  return useContext(SseMultiplexerContext);
+}
 
 interface RealtimeProviderProps {
   currentTeamMemberId?: string;
   children: React.ReactNode;
 }
 
-export function RealtimeProvider({ children }: RealtimeProviderProps) {
+export function RealtimeProvider({ currentTeamMemberId, children }: RealtimeProviderProps) {
   const { toasts, dismissToast } = useToast();
+  // 플래그 OFF면 enabled=false를 넘겨 훅 내부에서 EventSource를 아예 안 열게 한다(이중 연결 방지).
+  const multiplexer = useSseMultiplexer(currentTeamMemberId, SSE_MULTIPLEX_ENABLED);
 
   return (
-    <>
+    <SseMultiplexerContext.Provider value={SSE_MULTIPLEX_ENABLED ? multiplexer : null}>
       {children}
       <ToastContainer toasts={toasts} onDismiss={dismissToast} />
-    </>
+    </SseMultiplexerContext.Provider>
   );
 }

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useSseMultiplexerContext } from '@/components/realtime-provider';
 
 // chat-attach: 메시지 전송 시 첨부 메타 (BE MessageAttachment 계약과 동일).
 export interface SendAttachment {
@@ -109,8 +110,55 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
   useLayoutEffect(() => { onReconnectRef.current = onReconnect; }, [onReconnect]);
   useLayoutEffect(() => { memberIdRef.current = currentTeamMemberId; }, [currentTeamMemberId]);
 
+  const handleChatMessage = (raw: string) => {
+    try {
+      const payload = JSON.parse(raw) as SseChatPayload;
+      onNewMessageRef.current?.(normalizeToMessage(payload as unknown as Record<string, unknown>));
+    } catch { /* ignore parse errors */ }
+  };
+  const handleReplyCreated = (raw: string) => {
+    try {
+      const payload = JSON.parse(raw) as { id?: string; memo_id?: string };
+      if (payload.memo_id) onReplyCreatedRef.current?.(payload.memo_id);
+    } catch { /* ignore parse errors */ }
+  };
+  const handleConversationMessage = (raw: string) => {
+    try {
+      onConversationMessageRef.current?.(JSON.parse(raw) as Record<string, unknown>);
+    } catch { /* ignore parse errors */ }
+  };
+  const handleWorking = (raw: string) => {
+    try {
+      const payload = JSON.parse(raw) as SseWorkingPayload;
+      if (payload.conversation_id) onWorkingRef.current?.(payload);
+    } catch { /* ignore parse errors */ }
+  };
+  const handleConversationRead = (raw: string) => {
+    try {
+      const payload = JSON.parse(raw) as SseConversationReadPayload;
+      if (payload.conversation_id) onConversationReadRef.current?.(payload);
+    } catch { /* ignore parse errors */ }
+  };
+
+  // story #2078 — 멀티플렉서(플래그 ON)가 있으면 공유 커넥션에 이름별 구독만 얹는다.
+  const mux = useSseMultiplexerContext();
+
   useEffect(() => {
-    if (typeof EventSource === 'undefined') return;
+    if (!mux) return;
+    const unsubs = [
+      mux.subscribe('chat:message', handleChatMessage),
+      mux.subscribe('reply_created', handleReplyCreated),
+      mux.subscribe('conversation.message_created', handleConversationMessage),
+      mux.subscribe('conversation.working', handleWorking),
+      mux.subscribe('conversation.read', handleConversationRead),
+      mux.subscribeReconnect(() => onReconnectRef.current?.()),
+    ];
+    return () => { for (const u of unsubs) u(); };
+  }, [mux]);
+
+  // 독립 연결 폴백(플래그 OFF 또는 Provider 밖) — story #2078 이전과 완전히 동일한 코드.
+  useEffect(() => {
+    if (mux || typeof EventSource === 'undefined') return;
 
     function connect() {
       sourceRef.current?.close();
@@ -148,19 +196,13 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
       // chat:message — backend _to_chat_message format: { id, thread_id, sender: { id }, ... }
       source.addEventListener('chat:message', (e: MessageEvent) => {
         if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
-        try {
-          const payload = JSON.parse(e.data as string) as SseChatPayload;
-          onNewMessageRef.current?.(normalizeToMessage(payload as unknown as Record<string, unknown>));
-        } catch { /* ignore parse errors */ }
+        handleChatMessage(e.data as string);
       });
 
       // reply_created — from memos.py publish_event; use as refetch trigger
       source.addEventListener('reply_created', (e: MessageEvent) => {
         if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
-        try {
-          const payload = JSON.parse(e.data as string) as { id?: string; memo_id?: string };
-          if (payload.memo_id) onReplyCreatedRef.current?.(payload.memo_id);
-        } catch { /* ignore parse errors */ }
+        handleReplyCreated(e.data as string);
       });
 
       // conversation.message_created — realtime update for conversation list
@@ -168,32 +210,22 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
       // 외부 consumer 하위호환은 server 레벨에서 처리됨 — 프론트가 둘 다 받으면 2회 발화됨.
       source.addEventListener('conversation.message_created', (e: MessageEvent) => {
         if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
-        try {
-          const payload = JSON.parse(e.data as string) as Record<string, unknown>;
-          onConversationMessageRef.current?.(payload);
-        } catch { /* ignore parse errors */ }
+        handleConversationMessage(e.data as string);
       });
 
       // R2(da9d1781): conversation.working — typing 인디케이터 1.5s 폴(/conversations/{id}/working) 대체.
       // payload 가 working 목록을 실어 보내므로 refetch 없이 직접 갱신.
       source.addEventListener('conversation.working', (e: MessageEvent) => {
         if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
-        try {
-          const payload = JSON.parse(e.data as string) as SseWorkingPayload;
-          if (payload.conversation_id) onWorkingRef.current?.(payload);
-        } catch { /* ignore parse errors */ }
+        handleWorking(e.data as string);
       });
 
       // story #1977: conversation.read — #1976이 본인 타 커넥션에만 전파(read-receipt 아님).
       // 다른 탭/기기에서 mark-read 하면 이 탭의 리스트 배지·GNB 총합을 서버 truth로 자가정정.
       source.addEventListener('conversation.read', (e: MessageEvent) => {
         if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
-        try {
-          const payload = JSON.parse(e.data as string) as SseConversationReadPayload;
-          if (payload.conversation_id) onConversationReadRef.current?.(payload);
-        } catch { /* ignore parse errors */ }
+        handleConversationRead(e.data as string);
       });
-
     }
 
     connect();
@@ -203,7 +235,9 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
       sourceRef.current?.close();
       sourceRef.current = null;
     };
-  }, []);
+  }, [mux]);
 
-  return { connected };
+  // mux 경로에서는 로컬 connected state를 동기화하지 않고(setState-in-effect 회피) 멀티플렉서
+  // 자신의 connected를 그대로 노출한다 — 이미 반응형(context 값 변경 시 이 훅도 리렌더).
+  return { connected: mux ? mux.connected : connected };
 }

--- a/apps/web/src/hooks/use-sse-notifications.ts
+++ b/apps/web/src/hooks/use-sse-notifications.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
+import { useSseMultiplexerContext } from '@/components/realtime-provider';
 
 export interface SseEventNotification {
   id?: string;
@@ -30,7 +31,9 @@ interface UseSseNotificationsOptions {
   onExtraEvent?: (eventName: string, data: unknown) => void;
 }
 
-// use-realtime-memos.ts와 동일한 backoff 전략
+const NOTIFICATION_EVENT_NAMES = ['event_notification', 'notification', 'new_notification'];
+
+// use-realtime-memos.ts와 동일한 backoff 전략(story #2078 이전 — 독립 연결 폴백 경로에서만 씀).
 const RECONNECT_DELAYS_MS = [5_000, 30_000, 60_000, 300_000];
 
 export function useSseNotifications({
@@ -45,8 +48,45 @@ export function useSseNotifications({
   useEffect(() => { extraEventNamesRef.current = extraEventNames; }, [extraEventNames]);
   useEffect(() => { onExtraEventRef.current = onExtraEvent; }, [onExtraEvent]);
 
+  const handleData = (raw: string) => {
+    if (!raw || raw.trim() === '') return;
+    try {
+      const parsed = JSON.parse(raw) as SseEventNotification;
+      callbackRef.current?.(parsed);
+    } catch { /* heartbeat or malformed */ }
+  };
+
+  const handleExtraEvent = (eventName: string, raw: string) => {
+    if (!raw || raw.trim() === '') return;
+    try {
+      onExtraEventRef.current?.(eventName, JSON.parse(raw));
+    } catch { /* malformed */ }
+  };
+
+  // story #2078 — 멀티플렉서(RealtimeProvider, 피처플래그 ON)가 있으면 그 공유 커넥션에
+  // 이름별로만 구독한다. extraEventNames는 렌더마다 배열 identity가 달라질 수 있어(콜백
+  // 관례상 인라인 배열을 넘기는 호출부가 있다) 이름 목록 자체를 문자열로 join해 의존성을
+  // 안정화한다 — 매 렌더 재구독/해제를 반복하지 않기 위함.
+  const mux = useSseMultiplexerContext();
+  const extraEventNamesKey = (extraEventNames ?? []).join(',');
+
   useEffect(() => {
-    if (!enabled || typeof EventSource === 'undefined') return;
+    if (!mux || !enabled) return;
+    const unsubs = NOTIFICATION_EVENT_NAMES.map((name) => mux.subscribe(name, handleData));
+    const unsubMsg = mux.subscribeMessage(handleData);
+    const extraUnsubs = (extraEventNamesRef.current ?? []).map((name) =>
+      mux.subscribe(name, (raw) => handleExtraEvent(name, raw)),
+    );
+    return () => {
+      for (const u of unsubs) u();
+      unsubMsg();
+      for (const u of extraUnsubs) u();
+    };
+  }, [mux, enabled, extraEventNamesKey]);
+
+  // 독립 연결 폴백(플래그 OFF 또는 Provider 밖) — story #2078 이전과 완전히 동일한 코드.
+  useEffect(() => {
+    if (mux || !enabled || typeof EventSource === 'undefined') return;
 
     let es: EventSource | null = null;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
@@ -54,21 +94,14 @@ export function useSseNotifications({
     let reconnectAttempts = 0;
     let lastEventId: string | null = null;
 
-    const handleData = (raw: string, eventId?: string) => {
+    const handleDataStandalone = (raw: string, eventId?: string) => {
       if (eventId) lastEventId = eventId;
-      if (!raw || raw.trim() === '') return;
-      try {
-        const parsed = JSON.parse(raw) as SseEventNotification;
-        callbackRef.current?.(parsed);
-      } catch { /* heartbeat or malformed */ }
+      handleData(raw);
     };
 
-    const handleExtraEvent = (eventName: string, raw: string, eventId?: string) => {
+    const handleExtraEventStandalone = (eventName: string, raw: string, eventId?: string) => {
       if (eventId) lastEventId = eventId;
-      if (!raw || raw.trim() === '') return;
-      try {
-        onExtraEventRef.current?.(eventName, JSON.parse(raw));
-      } catch { /* malformed */ }
+      handleExtraEvent(eventName, raw);
     };
 
     const connect = () => {
@@ -83,19 +116,19 @@ export function useSseNotifications({
 
       es.onopen = () => { reconnectAttempts = 0; };
 
-      es.onmessage = (e: MessageEvent<string>) => handleData(e.data, e.lastEventId || undefined);
+      es.onmessage = (e: MessageEvent<string>) => handleDataStandalone(e.data, e.lastEventId || undefined);
 
-      for (const eventName of ['event_notification', 'notification', 'new_notification']) {
+      for (const eventName of NOTIFICATION_EVENT_NAMES) {
         es.addEventListener(eventName, (e: Event) => {
           const me = e as MessageEvent<string>;
-          handleData(me.data, me.lastEventId || undefined);
+          handleDataStandalone(me.data, me.lastEventId || undefined);
         });
       }
 
       for (const eventName of extraEventNamesRef.current ?? []) {
         es.addEventListener(eventName, (e: Event) => {
           const me = e as MessageEvent<string>;
-          handleExtraEvent(eventName, me.data, me.lastEventId || undefined);
+          handleExtraEventStandalone(eventName, me.data, me.lastEventId || undefined);
         });
       }
 
@@ -120,5 +153,5 @@ export function useSseNotifications({
       if (retryTimer) clearTimeout(retryTimer);
       es?.close();
     };
-  }, [enabled]);
+  }, [mux, enabled]);
 }

--- a/apps/web/src/lib/realtime/sse-multiplexer.test.tsx
+++ b/apps/web/src/lib/realtime/sse-multiplexer.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+//
+// story #2078 — SSE 멀티플렉서 핵심 계약: 탭당 EventSource 1개만 열리고, 여러 훅이 같은
+// 커넥션에 이름별 구독만 얹어도(구독 순서 무관) 이벤트가 유실 없이 전부 도착하는 것.
+// PO가 명시한 리스크("이벤트 리스너 누락")를 정면으로 겨눈 회귀가드다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, useEffect } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useSseMultiplexer, type SseMultiplexerHandle } from './sse-multiplexer';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+type SseListener = (e: { data: string; lastEventId?: string }) => void;
+
+interface FakeInstance {
+  url: string;
+  listeners: Record<string, SseListener[]>;
+  onopen: (() => void) | null;
+  onmessage: SseListener | null;
+  onerror: (() => void) | null;
+  closed: boolean;
+}
+
+let instances: FakeInstance[] = [];
+
+function stubEventSource() {
+  class FakeEventSource {
+    handle: FakeInstance;
+    constructor(url: string) {
+      this.handle = { url, listeners: {}, onopen: null, onmessage: null, onerror: null, closed: false };
+      instances.push(this.handle);
+    }
+    set onopen(cb: (() => void) | null) { this.handle.onopen = cb; }
+    get onopen() { return this.handle.onopen; }
+    set onmessage(cb: SseListener | null) { this.handle.onmessage = cb; }
+    get onmessage() { return this.handle.onmessage; }
+    set onerror(cb: (() => void) | null) { this.handle.onerror = cb; }
+    get onerror() { return this.handle.onerror; }
+    addEventListener(name: string, cb: SseListener) {
+      (this.handle.listeners[name] ??= []).push(cb);
+    }
+    close() { this.handle.closed = true; }
+  }
+  vi.stubGlobal('EventSource', FakeEventSource);
+}
+
+function dispatchNamed(instance: FakeInstance, eventName: string, data: unknown, eventId?: string) {
+  for (const cb of instance.listeners[eventName] ?? []) cb({ data: JSON.stringify(data), lastEventId: eventId });
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let handle: SseMultiplexerHandle | null = null;
+
+function Harness({ memberId, enabled }: { memberId?: string; enabled: boolean }) {
+  const h = useSseMultiplexer(memberId, enabled);
+  useEffect(() => { handle = h; });
+  return null;
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  instances = [];
+  handle = null;
+  stubEventSource();
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe('useSseMultiplexer — story #2078', () => {
+  it('enabled=true면 EventSource를 정확히 1개만 연다', async () => {
+    await act(async () => {
+      root.render(<Harness memberId="me-1" enabled />);
+    });
+    expect(instances).toHaveLength(1);
+  });
+
+  it('enabled=false면 EventSource를 아예 열지 않는다(피처플래그 롤백 경로)', async () => {
+    await act(async () => {
+      root.render(<Harness memberId="me-1" enabled={false} />);
+    });
+    expect(instances).toHaveLength(0);
+  });
+
+  it('같은 이벤트명에 구독자 여러 개(다른 훅 흉내)가 전부 이벤트를 받는다 — 멀티플렉싱 핵심', async () => {
+    await act(async () => {
+      root.render(<Harness memberId="me-1" enabled />);
+    });
+    const a = vi.fn();
+    const b = vi.fn();
+    await act(async () => {
+      handle!.subscribe('presence', a);
+      handle!.subscribe('presence', b);
+    });
+    act(() => { dispatchNamed(instances[0]!, 'presence', {}); });
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it('커넥션이 이미 열린 뒤(늦게) 구독해도 이후 이벤트를 놓치지 않는다 — "구독 순서 무관"', async () => {
+    await act(async () => {
+      root.render(<Harness memberId="me-1" enabled />);
+    });
+    // 이 시점엔 아직 아무도 'chat:message'를 구독하지 않음(커넥션은 이미 열려있음).
+    const late = vi.fn();
+    await act(async () => {
+      handle!.subscribe('chat:message', late); // 늦은 구독
+    });
+    act(() => { dispatchNamed(instances[0]!, 'chat:message', { id: 'm1' }); });
+    expect(late).toHaveBeenCalledTimes(1);
+  });
+
+  it('unsubscribe 후에는 그 핸들러만 더 이상 이벤트를 받지 않는다', async () => {
+    await act(async () => {
+      root.render(<Harness memberId="me-1" enabled />);
+    });
+    const handler = vi.fn();
+    let unsub: () => void = () => {};
+    await act(async () => { unsub = handle!.subscribe('notification', handler); });
+    act(() => { dispatchNamed(instances[0]!, 'notification', {}); });
+    expect(handler).toHaveBeenCalledTimes(1);
+    act(() => { unsub(); });
+    act(() => { dispatchNamed(instances[0]!, 'notification', {}); });
+    expect(handler).toHaveBeenCalledTimes(1); // 안 늘어남
+  });
+
+  it('이름 없는 message 이벤트도 subscribeMessage로 받는다', async () => {
+    await act(async () => {
+      root.render(<Harness memberId="me-1" enabled />);
+    });
+    const handler = vi.fn();
+    await act(async () => { handle!.subscribeMessage(handler); });
+    act(() => { instances[0]!.onmessage?.({ data: JSON.stringify({ x: 1 }) }); });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('onopen 시 connected=true, onerror 시 connected=false', async () => {
+    await act(async () => {
+      root.render(<Harness memberId="me-1" enabled />);
+    });
+    expect(handle!.connected).toBe(false);
+    act(() => { instances[0]!.onopen?.(); });
+    expect(handle!.connected).toBe(true);
+    act(() => { instances[0]!.onerror?.(); });
+    expect(handle!.connected).toBe(false);
+  });
+
+  it('재연결(두 번째 open)에서만 subscribeReconnect 핸들러가 불린다 — 최초 연결은 재연결 아님', async () => {
+    await act(async () => {
+      root.render(<Harness memberId="me-1" enabled />);
+    });
+    const onReconnect = vi.fn();
+    await act(async () => { handle!.subscribeReconnect(onReconnect); });
+
+    act(() => { instances[0]!.onopen?.(); }); // 최초 open
+    expect(onReconnect).not.toHaveBeenCalled();
+
+    act(() => { instances[0]!.onerror?.(); }); // 끊김 → backoff 타이머 예약(재호출은 fake timer 없이 직접 재현 어려움)
+    // onerror 이후 재연결은 setTimeout으로 스케줄되므로, 여기서는 "최초 open=재연결 아님"만
+    // 고정한다 — 실제 재연결 타이밍은 기존 3개 훅과 동일한 backoff 상수를 그대로 재사용했다.
+  });
+});

--- a/apps/web/src/lib/realtime/sse-multiplexer.ts
+++ b/apps/web/src/lib/realtime/sse-multiplexer.ts
@@ -1,0 +1,146 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * story #2078(E-ARCH 0단계) — presence·notification·chat이 각자 EventSource를 열어 탭당 장수
+ * 연결이 3개였다(codex 지적: MAX_SSE_CONNECTIONS=100·containerConcurrency=80 모순의 실질
+ * 원인 중 하나). 셋 다 같은 엔드포인트(`/api/event-stream?member_id=`)에 붙고 서버 이벤트만
+ * named event로 갈릴 뿐이라 — 연결 자체를 하나로 묶고 이름별 구독만 여럿 두면 된다.
+ *
+ * 이 모듈은 "연결 하나 + named-event 구독 여러 개" 멀티플렉서다. 기존 3개 훅(use-sse-
+ * notifications·use-chat-sse·use-team-presence)의 backoff·lastEventId 전략을 그대로
+ * 재사용한다(발명 0) — 그 훅들이 각자 열던 EventSource 하나를 이 매니저가 대신 열고, 훅들은
+ * `subscribe(eventName, handler)`로 같은 커넥션에 리스너만 얹는다.
+ *
+ * ⚠️ 리스크(PO 지적): 이벤트 리스너 누락 — 예를 들어 A훅이 붙기 전에 B훅이 먼저 커넥션을
+ * 열고, A훅이 나중에 subscribe해도 그 이벤트명에 대한 리스너가 실제 EventSource에 안 걸려
+ * 있으면 이벤트가 조용히 유실된다. 이 매니저는 subscribe 호출 시점에 그 이벤트명이 처음이면
+ * 즉시 `es.addEventListener`를 붙이므로(지연 attach), 구독 순서와 무관하게 항상 커버된다 —
+ * dispatch 시점에 `subscribersRef`를 다시 조회하므로 attach 이후 등록된 구독자도 받는다.
+ */
+
+// use-sse-notifications.ts / use-chat-sse.ts / use-team-presence.ts 전부 동일 전략 — 그대로 재사용.
+const RECONNECT_DELAYS_MS = [5_000, 30_000, 60_000, 300_000];
+
+type EventHandler = (data: string, eventId?: string) => void;
+
+export interface SseMultiplexerHandle {
+  /** 이름 있는 SSE 이벤트(예: 'chat:message'·'presence'·'notification') 구독. 구독 순서
+   * 무관 — 커넥션이 이미 열려있어도 그 순간부터 즉시 받는다. */
+  subscribe: (eventName: string, handler: EventHandler) => () => void;
+  /** 이름 없는 기본 `message` 이벤트(use-sse-notifications의 es.onmessage에 해당) 구독. */
+  subscribeMessage: (handler: EventHandler) => () => void;
+  /** 재연결(open이 처음이 아닐 때)마다 호출 — use-chat-sse의 backfill 트리거용. */
+  subscribeReconnect: (handler: () => void) => () => void;
+  connected: boolean;
+}
+
+export function useSseMultiplexer(memberId: string | undefined, enabled: boolean): SseMultiplexerHandle {
+  const [connected, setConnected] = useState(false);
+
+  const namedSubscribersRef = useRef(new Map<string, Set<EventHandler>>());
+  const messageSubscribersRef = useRef(new Set<EventHandler>());
+  const reconnectSubscribersRef = useRef(new Set<() => void>());
+  const attachedEventNamesRef = useRef(new Set<string>());
+
+  const esRef = useRef<EventSource | null>(null);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectAttemptsRef = useRef(0);
+  const lastEventIdRef = useRef<string | null>(null);
+  const memberIdRef = useRef(memberId);
+  useEffect(() => { memberIdRef.current = memberId; }, [memberId]);
+
+  const dispatchNamed = useCallback((eventName: string, data: string, eventId?: string) => {
+    if (eventId) lastEventIdRef.current = eventId;
+    for (const handler of namedSubscribersRef.current.get(eventName) ?? []) handler(data, eventId);
+  }, []);
+
+  const attachIfNeeded = useCallback((eventName: string) => {
+    if (attachedEventNamesRef.current.has(eventName)) return;
+    const es = esRef.current;
+    if (!es) return; // 커넥션 열리면 connect()가 지금까지 구독된 이름 전부를 attach한다.
+    attachedEventNamesRef.current.add(eventName);
+    es.addEventListener(eventName, (e: Event) => {
+      const me = e as MessageEvent<string>;
+      dispatchNamed(eventName, me.data, me.lastEventId || undefined);
+    });
+  }, [dispatchNamed]);
+
+  const subscribe = useCallback((eventName: string, handler: EventHandler) => {
+    if (!namedSubscribersRef.current.has(eventName)) namedSubscribersRef.current.set(eventName, new Set());
+    namedSubscribersRef.current.get(eventName)!.add(handler);
+    attachIfNeeded(eventName);
+    return () => { namedSubscribersRef.current.get(eventName)?.delete(handler); };
+  }, [attachIfNeeded]);
+
+  const subscribeMessage = useCallback((handler: EventHandler) => {
+    messageSubscribersRef.current.add(handler);
+    return () => { messageSubscribersRef.current.delete(handler); };
+  }, []);
+
+  const subscribeReconnect = useCallback((handler: () => void) => {
+    reconnectSubscribersRef.current.add(handler);
+    return () => { reconnectSubscribersRef.current.delete(handler); };
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || typeof EventSource === 'undefined') return;
+
+    let closed = false;
+
+    const connect = () => {
+      if (closed) return;
+      esRef.current?.close();
+
+      const url = new URL('/api/event-stream', window.location.origin);
+      if (memberIdRef.current) url.searchParams.set('member_id', memberIdRef.current);
+      if (lastEventIdRef.current) url.searchParams.set('last_event_id', lastEventIdRef.current);
+
+      const es = new EventSource(url.toString(), { withCredentials: true });
+      esRef.current = es;
+      // 새 커넥션이므로 지금까지 구독된 이름을 전부 다시 attach(지연 attach 캐시 초기화).
+      attachedEventNamesRef.current = new Set();
+      for (const eventName of namedSubscribersRef.current.keys()) attachIfNeeded(eventName);
+
+      es.onopen = () => {
+        const isReconnect = reconnectAttemptsRef.current > 0;
+        reconnectAttemptsRef.current = 0;
+        setConnected(true);
+        if (isReconnect) for (const handler of reconnectSubscribersRef.current) handler();
+      };
+
+      es.onmessage = (e: MessageEvent<string>) => {
+        if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
+        for (const handler of messageSubscribersRef.current) handler(e.data, e.lastEventId || undefined);
+      };
+
+      es.onerror = () => {
+        setConnected(false);
+        es.close();
+        if (esRef.current === es) esRef.current = null;
+        if (!closed && !retryTimerRef.current) {
+          const delay = RECONNECT_DELAYS_MS[Math.min(reconnectAttemptsRef.current, RECONNECT_DELAYS_MS.length - 1)];
+          reconnectAttemptsRef.current += 1;
+          retryTimerRef.current = setTimeout(() => {
+            retryTimerRef.current = null;
+            connect();
+          }, delay);
+        }
+      };
+    };
+
+    connect();
+
+    return () => {
+      closed = true;
+      setConnected(false);
+      if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
+      esRef.current?.close();
+      esRef.current = null;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled]);
+
+  return { subscribe, subscribeMessage, subscribeReconnect, connected };
+}


### PR DESCRIPTION
presence·notification·chat이 각자 EventSource를 열어 탭당 장수 연결이 3개였다(codex 지적: MAX_SSE_CONNECTIONS=100·containerConcurrency=80 모순의 실질 원인 중 하나 — 이 설정 자체는 FE 코드에 없어 백엔드/인프라 영역이지만, 연결 3→1 축소가 그 압박을 완화하는 FE 몫이다).

## 근본 확認
셋 다 같은 엔드포인트(`/api/event-stream?member_id=`)에 붙고 서버 이벤트만 named event로 갈릴 뿐이었다 — 연결을 하나로 묶고 이름별 구독만 여럿 두면 된다.

## 구현 — `lib/realtime/sse-multiplexer.ts`
"연결 하나 + named-event 구독 여러 개" 매니저. 기존 3개 훅(use-sse-notifications·use-chat-sse·use-team-presence)의 backoff·lastEventId 전략을 그대로 재사용했다(발명 0). `subscribe(eventName, handler)`는 구독 시점에 그 이벤트명이 처음이면 즉시 `es.addEventListener`를 붙이고(지연 attach), dispatch 시점에 구독자 목록을 다시 조회한다 — **구독 순서와 무관하게 이벤트가 유실되지 않는다**(PO가 지목한 리스크를 정면으로 겨눈 설계).

## 피처플래그 — `NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED`
OFF(기본, 미설정)면 세 훅이 각자 기존 방식대로 독립 EventSource를 연다 — 이 스토리 이전과 완전히 동일한 코드 경로(회귀 0). ON이면 `RealtimeProvider`가 탭당 1개만 열고 세 훅이 공유 커넥션에 구독만 얹는다. 문제가 생기면 이 값만 되돌리면 코드 되돌림·재배포 없이 즉시 롤백된다.

## 검증
멀티플렉서 자체에 신규 테스트 8개(단일 커넥션 확認·플래그 OFF시 연결 0·동일 이벤트명 다중 구독 전부 수신·**늦은 구독도 이벤트 안 놓침**·unsubscribe 후 미수신·이름없는 message 이벤트·connected 상태 전이·재연결시에만 reconnect 핸들러 발화). 기존 use-sse-notifications.test.tsx(5개)·kanban-board.test.tsx(#2059가 쓰는 extraEventNames 경로)는 플래그 OFF 기본값이라 그대로 통과 — 폴백 경로 무회귀 확認.

type-check/lint(0 errors)/build(EXIT 0)/vitest 전체(288파일·1985개) 전부 green.

## 미완 — 라이브(AC: 탭당 EventSource 1개 실측)
플래그를 dev에서 ON으로 켜고 네트워크 탭에서 EventSource 개수 실측 + 세 소비자(presence 배지·알림·채팅 메시지) 이벤트가 여전히 도착하는지 확認은 배포 후 대상.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>