### PR TITLE
feat(E-ARCH S1): PG_LISTEN_ENABLED 플래그 — REST/실시간 서비스 분리 1단계

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -80,6 +80,14 @@ class Settings(BaseSettings):
     # E-EVENTBUS: dev=true, prod=false (기존 웹훅 병행 운영)
     eventbus_enabled: bool = False
 
+    # E-ARCH S1(2026-07-21, 선생님 "가자" 승인 — 채팅 5초 지연/#2074 근본): REST(api)와
+    # 실시간(SSE/LISTEN)이 같은 Cloud Run 서비스에 있어 인스턴스 기아(콜드스타트 경합)로
+    # 서로를 굶기던 구조를 분리하는 1단계. 이 플래그를 끄면 이 인스턴스는 pg_pubsub LISTEN을
+    # 전혀 시작 안 함(RAW_LISTEN 커넥션 소비 0) — api 서비스에 false, 신규
+    # sprintable-realtime-{env} 서비스에 true로 배선한다(같은 이미지, env만 다름).
+    # default=True(무회귀) — 명시적으로 끄지 않는 한 기존 단일서비스 배포와 동일 동작.
+    pg_listen_enabled: bool = True
+
     # E-L2 휴리스틱 트리거 워커. default-off — 명시 활성화 전엔 lifespan task 미생성(무동작).
     # advisory_lock=on이면 멀티인스턴스 중 pg_try_advisory_lock holder 1개만 poll/evaluate.
     l2_trigger_enabled: bool = False

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,7 +26,10 @@ async def lifespan(app: FastAPI):
     from app.services.pg_pubsub import check_listen_config, listen_loop
 
     warn_if_webhook_secret_misconfigured()  # Bot-M.2 P3: 웹훅 secret misconfig 를 트래픽 前 경고.
-    check_listen_config()  # ee7794eb ③ fail-closed: DB_PGBOUNCER on + DATABASE_URL_DIRECT 없으면 startup raise.
+    # E-ARCH S1: PG_LISTEN_ENABLED=false인 서비스(api)는 이 검증 자체가 무의미 — LISTEN을 절대
+    # 안 켜므로 DB_PGBOUNCER/DATABASE_URL_DIRECT 정합을 강제할 이유가 없다(무해·불필요 fail 방지).
+    if settings.pg_listen_enabled:
+        check_listen_config()  # ee7794eb ③ fail-closed: DB_PGBOUNCER on + DATABASE_URL_DIRECT 없으면 startup raise.
     check_internal_secret_config()  # 산티아고 §9 finding 4: non-local + 시크릿 미설정 fail-closed.
     check_cron_secret_config()  # story #2072: non-local + CRON_SECRET 미설정 fail-closed.
     check_mobile_app_check_config()  # 산티아고 §9 finding 1: mobile 발급 on + App Check 미필수 fail-closed.
@@ -35,7 +38,10 @@ async def lifespan(app: FastAPI):
     # mock db.execute() 순서-큐를 startup 시점의 이 캐시 조회가 몰래 하나 소비해 실패시켰다).
     # 지연 초기화(첫 실 요청에서 채워짐)만으로 충분 — check_any_cutover_epoch_exists() 자체가
     # DB 접속 불가/미준비 시에도 fail-safe라 startup에서 먼저 확인해둘 실익이 크지 않다.
-    task = asyncio.create_task(listen_loop())
+    # E-ARCH S1(2026-07-21, #2074 근본 — REST/실시간 서비스 분리 1단계): default=True(무회귀) —
+    # api 서비스에 PG_LISTEN_ENABLED=false를 배선하면 이 인스턴스는 RAW_LISTEN 커넥션을 전혀
+    # 안 잡는다(커넥션 예산 산식에서 이 항이 빠짐). realtime 서비스만 true로 유지.
+    task = asyncio.create_task(listen_loop()) if settings.pg_listen_enabled else None
     # E-L2 S5: 휴리스틱 트리거 워커는 default-off — 명시 활성화 시에만 task 생성(AC①).
     l2_task = None
     if settings.l2_trigger_enabled:
@@ -45,14 +51,16 @@ async def lifespan(app: FastAPI):
     try:
         yield
     finally:
-        task.cancel()
+        if task is not None:
+            task.cancel()
         if l2_task is not None:
             l2_task.cancel()
         try:
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
+            if task is not None:
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
             if l2_task is not None:
                 try:
                     await l2_task

--- a/backend/tests/test_lifespan_engine_dispose_33e0c681.py
+++ b/backend/tests/test_lifespan_engine_dispose_33e0c681.py
@@ -113,3 +113,55 @@ async def test_lifespan_disposes_even_if_pubsub_task_raises(monkeypatch):
             await asyncio.sleep(0)  # task 가 예외로 완전히 종료되게 양보
 
     fake_engine.dispose.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_lifespan_skips_pubsub_task_when_pg_listen_disabled(monkeypatch):
+    """E-ARCH S1(story #2074/#2077): PG_LISTEN_ENABLED=false(api 서비스)면 listen_loop
+    task 자체를 안 만든다 — RAW_LISTEN 커넥션 소비 0. dispose는 여전히 정상 실행(무회귀)."""
+    from app.main import lifespan
+
+    fake_engine = _patch_engine(monkeypatch)
+    monkeypatch.setattr("app.main.settings.pg_listen_enabled", False)
+
+    started = asyncio.Event()
+
+    async def fake_listen():
+        started.set()  # 호출되면 안 됨 — 아래서 미호출 확認.
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr("app.services.pg_pubsub.listen_loop", fake_listen)
+
+    async with lifespan(MagicMock()):
+        await asyncio.sleep(0.05)
+        assert not started.is_set(), "PG_LISTEN_ENABLED=false인데 listen_loop가 시작됨"
+
+    fake_engine.dispose.assert_awaited_once()  # task가 없어도 dispose는 정상 실행.
+
+
+@pytest.mark.anyio
+async def test_lifespan_skips_check_listen_config_when_pg_listen_disabled(monkeypatch):
+    """PG_LISTEN_ENABLED=false면 check_listen_config()(DB_PGBOUNCER/DATABASE_URL_DIRECT
+    정합 fail-closed 가드)도 안 부른다 — LISTEN을 아예 안 켜는 서비스엔 무의미한 강제라
+    불필요한 startup 실패를 막는다."""
+    from app.main import lifespan
+
+    _patch_engine(monkeypatch)
+    monkeypatch.setattr("app.main.settings.pg_listen_enabled", False)
+
+    called = {"n": 0}
+
+    def fake_check():
+        called["n"] += 1
+
+    monkeypatch.setattr("app.services.pg_pubsub.check_listen_config", fake_check)
+
+    async def fake_listen():
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr("app.services.pg_pubsub.listen_loop", fake_listen)
+
+    async with lifespan(MagicMock()):
+        await asyncio.sleep(0.05)
+
+    assert called["n"] == 0, "PG_LISTEN_ENABLED=false인데 check_listen_config가 호출됨"


### PR DESCRIPTION
## 요약
E-ARCH 에픽(선생님 "가자" 승인) 1단계 — REST(api)와 실시간(SSE/LISTEN)이 같은 Cloud Run 서비스에 있어 인스턴스 기아(콜드스타트 경합)로 서로를 굶기던 구조(#2074 근본원인: "no available instance" abort, 채팅 5초 지연·목표화면 Loading·촬영 막힘)를 분리한다.

## codex 아키텍처 제안 코드 교차검증 결과 (별도 채팅 보고 요약)
- **agent_gateway recipient_seq 패턴**: 개념(신호=가벼움·DB=정본, wake 유실돼도 재연결 시 DB 재조회로 따라잡음)은 재사용 가능하지만 구현(AgentEventCursor는 agent 1명당 1개, 1:1 전용)은 board 같은 1:다 브로드캐스트에 직접 재사용 불가 — 이 PR 스코프 아님, 향후 project-scoped 커서로 별도 설계 필요.
- **transactional outbox**: 오늘 고친 #2059 emit 경로(수동 팬아웃)를 정확히 흡수하나 구현 규모가 커서(publish_event 호출부 12곳 마이그레이션) 이 PR 스코프 아님, 2-3단계.
- **Redis**: 도입 시 "정본"이 아니라 "wake 신호 릴레이"로만 스코프를 좁혀야 안전(장애 시 유실이 아니라 지연으로 격하) — 이 PR 스코프 아님.

## 변경사항
- `Settings.pg_listen_enabled: bool = True`(무회귀 기본값) 신규.
- `main.py` lifespan: `PG_LISTEN_ENABLED=false`면 `listen_loop` task 생성 안 함(RAW_LISTEN 커넥션 소비 0) + `check_listen_config()`(DB_PGBOUNCER 정합 fail-closed 가드)도 호출 안 함(LISTEN 자체를 안 켜는 서비스엔 무의미한 강제). `L2TriggerWorker`의 기존 default-off 패턴과 동일 — 신규 발명 아님.

## 배선 계획 (인프라, 오르테가군 lane — 이 PR엔 미포함)
1. 신규 Cloud Run 서비스 `sprintable-realtime-{env}`(같은 이미지) — `PG_LISTEN_ENABLED=true`, 작게 고정(minScale=maxScale, 2~3 정도).
2. 기존 `sprintable-backend-{env}`(api)엔 `PG_LISTEN_ENABLED=false`.
3. FE(`apps/web/src/app/api/event-stream/route.ts`) — 현재 `NEXT_PUBLIC_FASTAPI_URL` 단일 소스를 `REALTIME_URL`(신규, 미설정 시 기존값 폴백해 무중단) 우선으로 전환 — **FE lane 조율 필요**(미르코군), 다른 SSE 소비처(`use-chat-sse.ts`/`use-sse-notifications.ts`/`use-team-presence.ts`)도 이 프록시 공유 여부 확인 필요.

## 검증
- `uv run pytest tests/test_lifespan_engine_dispose_33e0c681.py` — 5 passed(기존 3 + 신규 2: listen_loop 미생성·check_listen_config 미호출).
- `uv run pytest tests/ -k "lifespan or startup_guard or pg_pubsub or listen"` — 32 passed, 무회귀.
- app import 검증 완료(490 routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)