### PR TITLE
[SID:2076][긴급회귀] 2뎁스+ 상세 화면 컨텍스트 칩 제거

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
@@ -281,9 +281,12 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
 
   return (
     <DocsLayoutContext.Provider value={{ wsSlug, projSlug, projectId, tree, setTree, handleNewDoc, fetchTree, pendingDocUpdate, clearPendingDocUpdate, expandFolder, openTreeDrawer: openDrawer }}>
+      {/* 긴급 fix(2076 회귀) — 문서 상세(currentSlug 있음)는 유나양 규격상 상세 화면으로
+          칩 억제 대상. 리스트뷰는 title이 정적 "문서" 헤딩이라 루트 화면과 동일 취급(칩 유지). */}
       <TopBarSlot
         title={topBarTitle}
         actions={topBarActions}
+        hideContextChip={!!currentSlug}
       />
 
       {/* Unified: children rendered exactly once — sidebar responsive via breakpoint classes */}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx
@@ -282,6 +282,7 @@ export default function EpicDetailPage() {
             <span className="text-sm font-medium truncate max-w-[200px]">{epic.title}</span>
           </div>
         }
+        hideContextChip
       />
 
       <div className="mx-auto max-w-3xl px-4 py-6 space-y-8">

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/loops/[id]/loop-detail-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/loops/[id]/loop-detail-client.tsx
@@ -112,7 +112,7 @@ export function LoopDetailClient({ loopId, wsSlug, projSlug }: { loopId: string;
   if (loading) {
     return (
       <>
-        <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
+        <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} hideContextChip />
         <div className="flex h-64 items-center justify-center">
           <p className="text-sm text-muted-foreground">{t('loading')}</p>
         </div>
@@ -123,7 +123,7 @@ export function LoopDetailClient({ loopId, wsSlug, projSlug }: { loopId: string;
   if (notFound || !loop) {
     return (
       <>
-        <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
+        <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} hideContextChip />
         <div className="flex h-64 flex-col items-center justify-center gap-3">
           <p className="text-sm text-muted-foreground">{t('notFound')}</p>
           {/* story #1990: replace — 뒤로가기 재진입 트랩 방지(§3.2). */}
@@ -155,6 +155,7 @@ export function LoopDetailClient({ loopId, wsSlug, projSlug }: { loopId: string;
             {t('backToList')}
           </button>
         }
+        hideContextChip
       />
       <div className="mx-auto max-w-3xl space-y-5 overflow-y-auto p-5">
         {/* Header */}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/mockups/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/mockups/[id]/page.tsx
@@ -115,6 +115,7 @@ export default function MockupViewerPage() {
             <Badge variant="info">v{mockup.version}</Badge>
           </div>
         }
+        hideContextChip
       />
 
       <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx
@@ -624,6 +624,7 @@ export default function RetroSessionPage() {
             </div>
           ) : null
         }
+        hideContextChip
       />
 
       <div className="focus-inset flex min-h-0 flex-1 flex-col overflow-y-auto">

--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
@@ -239,6 +239,7 @@ export default function ConversationPage() {
             </div>
           )
         }
+        hideContextChip
       />
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
         <ChatView

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -130,6 +130,7 @@ export default function GateDetailPage() {
             {t('gateDetailBackToInbox')}
           </button>
         }
+        hideContextChip
       />
       <div className="mx-auto flex min-h-full w-full max-w-2xl flex-1 flex-col gap-5 px-4 py-5">
         {loading ? (

--- a/apps/web/src/components/nav/top-bar-context.test.tsx
+++ b/apps/web/src/components/nav/top-bar-context.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+//
+// 긴급 fix(2076 회귀) — 2뎁스+ 상세 화면(자체 뒤로가기 보유)이 TopBarSlot에 hideContextChip을
+// 선언하면 TopBar가 실제로 컨텍스트 칩을 뺀다는 것을 회귀가드로 고정한다. RED였던 증상:
+// 채팅 상세에서 칩+뒤로가기+제목+액션+아이콘 클러스터가 <1024에서 공간 부족으로 뭉개짐.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { TopBarProvider, useTopBar } from './top-bar-context';
+import { TopBarSlot } from './top-bar-slot';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function Probe() {
+  const { hideContextChip } = useTopBar();
+  return <span data-testid="probe">{String(hideContextChip)}</span>;
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+describe('TopBarSlot hideContextChip — 2076 긴급 fix 회귀가드', () => {
+  it('hideContextChip을 안 주면(기본) false — 기존 화면은 칩이 그대로 보인다', async () => {
+    await act(async () => {
+      root.render(
+        <TopBarProvider>
+          <TopBarSlot title={<span>제목</span>} />
+          <Probe />
+        </TopBarProvider>,
+      );
+    });
+    expect(container.querySelector('[data-testid="probe"]')?.textContent).toBe('false');
+  });
+
+  it('hideContextChip을 주면 true로 전파된다 — 상세 화면이 칩을 뺀다', async () => {
+    await act(async () => {
+      root.render(
+        <TopBarProvider>
+          <TopBarSlot title={<span>채팅 상세</span>} hideContextChip />
+          <Probe />
+        </TopBarProvider>,
+      );
+    });
+    expect(container.querySelector('[data-testid="probe"]')?.textContent).toBe('true');
+  });
+
+  it('상세→목록으로 props가 바뀌면 hideContextChip도 그에 맞춰 갱신된다', async () => {
+    function Wrapper({ showDetail }: { showDetail: boolean }) {
+      return (
+        <TopBarProvider>
+          {showDetail
+            ? <TopBarSlot title={<span>상세</span>} hideContextChip />
+            : <TopBarSlot title={<span>목록</span>} />}
+          <Probe />
+        </TopBarProvider>
+      );
+    }
+    await act(async () => { root.render(<Wrapper showDetail />); });
+    expect(container.querySelector('[data-testid="probe"]')?.textContent).toBe('true');
+
+    await act(async () => { root.render(<Wrapper showDetail={false} />); });
+    expect(container.querySelector('[data-testid="probe"]')?.textContent).toBe('false');
+  });
+
+  it('TopBarSlot이 언마운트되면(clearSlot) hideContextChip도 false로 초기화된다', async () => {
+    function Wrapper({ mounted }: { mounted: boolean }) {
+      return (
+        <TopBarProvider>
+          {mounted && <TopBarSlot title={<span>상세</span>} hideContextChip />}
+          <Probe />
+        </TopBarProvider>
+      );
+    }
+    await act(async () => { root.render(<Wrapper mounted />); });
+    expect(container.querySelector('[data-testid="probe"]')?.textContent).toBe('true');
+
+    await act(async () => { root.render(<Wrapper mounted={false} />); });
+    expect(container.querySelector('[data-testid="probe"]')?.textContent).toBe('false');
+  });
+});

--- a/apps/web/src/components/nav/top-bar-context.tsx
+++ b/apps/web/src/components/nav/top-bar-context.tsx
@@ -5,10 +5,16 @@ import { createContext, useContext, useState, type ReactNode } from 'react';
 interface TopBarState {
   title: ReactNode | null;
   actions: ReactNode | null;
+  // 긴급 fix(2076 회귀) — 2뎁스+ 상세 화면(채팅 상세·목표 상세·게이트 상세·루프 상세 등)은
+  // title 슬롯 자체에 이미 뒤로가기가 있어, 그 위에 컨텍스트 칩까지 얹으면 <1024에서 공간이
+  // 부족해 뭉개진다(선생님 실기기 리포트). "전환은 최상위에서" — 상세 화면은 이미 맥락이
+  // 있으므로 칩이 불필요하다는 판단(오르테가군). 페이지가 명시적으로 선언한다(라우트 깊이
+  // 추론은 board/goals/standup 등 depth-2지만 root-tab인 화면과 구분이 안 돼 신뢰 불가).
+  hideContextChip: boolean;
 }
 
 interface TopBarStore extends TopBarState {
-  setSlot: (slot: TopBarState) => void;
+  setSlot: (slot: Pick<TopBarState, 'title' | 'actions'> & Partial<Pick<TopBarState, 'hideContextChip'>>) => void;
   clearSlot: () => void;
   hidden: boolean;
   setHidden: (h: boolean) => void;
@@ -19,13 +25,13 @@ interface TopBarStore extends TopBarState {
 const TopBarCtx = createContext<TopBarStore | null>(null);
 
 export function TopBarProvider({ children }: { children: ReactNode }) {
-  const [state, setState] = useState<TopBarState>({ title: null, actions: null });
+  const [state, setState] = useState<TopBarState>({ title: null, actions: null, hideContextChip: false });
   const [hidden, setHidden] = useState(false);
   const [scrollContainer, setScrollContainer] = useState<HTMLElement | null>(null);
   const value: TopBarStore = {
     ...state,
-    setSlot: (slot) => setState(slot),
-    clearSlot: () => setState({ title: null, actions: null }),
+    setSlot: (slot) => setState({ hideContextChip: false, ...slot }),
+    clearSlot: () => setState({ title: null, actions: null, hideContextChip: false }),
     hidden,
     setHidden,
     scrollContainer,

--- a/apps/web/src/components/nav/top-bar-slot.tsx
+++ b/apps/web/src/components/nav/top-bar-slot.tsx
@@ -6,14 +6,17 @@ import { useTopBar } from './top-bar-context';
 interface TopBarSlotProps {
   title: ReactNode;
   actions?: ReactNode;
+  /** 긴급 fix(2076 회귀) — 이 화면의 title이 이미 자체 뒤로가기를 갖는 상세 화면이면 true로
+   * 컨텍스트 칩을 뺀다(<1024에서 공간 부족으로 뭉개지는 문제). */
+  hideContextChip?: boolean;
 }
 
-export function TopBarSlot({ title, actions = null }: TopBarSlotProps) {
+export function TopBarSlot({ title, actions = null, hideContextChip = false }: TopBarSlotProps) {
   const { setSlot, clearSlot } = useTopBar();
   useEffect(() => {
-    setSlot({ title, actions });
+    setSlot({ title, actions, hideContextChip });
     return clearSlot;
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [title, actions]);
+  }, [title, actions, hideContextChip]);
   return null;
 }

--- a/apps/web/src/components/nav/top-bar.tsx
+++ b/apps/web/src/components/nav/top-bar.tsx
@@ -20,7 +20,7 @@ interface TopBarProps {
 }
 
 export function TopBar({ className, orgId, orgMemberships = [], projectId, projectMemberships = [] }: TopBarProps) {
-  const { title, actions, hidden } = useTopBar();
+  const { title, actions, hidden, hideContextChip } = useTopBar();
   return (
     <div
       className={cn(
@@ -36,13 +36,17 @@ export function TopBar({ className, orgId, orgMemberships = [], projectId, proje
           대신한다(blueprint §3.2 "모바일 사이드바 Sheet/햄버거 폐기" 방향, 오르테가군 확定).
           story #2076: 그 자리에 컨텍스트 칩을 추가한다 — 탭바는 화면 이동, 칩은 컨텍스트(조직/
           프로젝트) 전환으로 관심사가 다르다. title보다 먼저 두어 "지금 어디에 있는지"가 화면
-          제목보다 앞서 보이게 한다. */}
-      <ContextSwitcherChip
-        orgs={orgMemberships}
-        currentOrgId={orgId}
-        projects={projectMemberships}
-        currentProjectId={projectId}
-      />
+          제목보다 앞서 보이게 한다.
+          긴급 fix(2076 회귀): 2뎁스+ 상세 화면(자체 뒤로가기 보유)은 hideContextChip으로
+          칩을 뺀다 — "전환은 최상위에서" 이미 맥락이 있는 화면엔 칩이 불필요·공간도 부족. */}
+      {!hideContextChip && (
+        <ContextSwitcherChip
+          orgs={orgMemberships}
+          currentOrgId={orgId}
+          projects={projectMemberships}
+          currentProjectId={projectId}
+        />
+      )}
       <div className="flex min-w-0 flex-1 items-center gap-2">
         {title}
       </div>


### PR DESCRIPTION
선생님 실기기 리포트: "프로젝트 선택하는 게 상단에 올라온 거 봤는데 다른 UI를 다 뭉개버린".

## 근본
칩(#2354)은 title 슬롯 앞에 상시 렌더된다. 채팅 상세·목표 상세·게이트 상세·루프 상세 등 2뎁스+ 화면은 title 슬롯 자체에 이미 뒤로가기 버튼+제목(+편집/알림 등 액션)이 있어, <1024 top-bar 한 줄에 칩(최대 55vw)까지 더해지면 공간이 부족해 아이콘 클러스터와 충돌한다. 루트 화면(보드·목표목록·스탠드업 등)은 title이 짧은 정적 헤딩이라 문제가 없었다.

## 방향
"전환은 최상위에서" — 상세 화면은 이미 뒤로가기로 맥락이 있으므로 칩 자체가 불필요하다는 판단. 라우트 깊이 자동판정은 board/goals/standup처럼 depth-2 URL이지만 root-tab인 화면과 구분이 안 돼 신뢰할 수 없어, 화면이 명시적으로 선언하는 방식을 택했다.

## 구현
`TopBarSlot`에 `hideContextChip?: boolean` prop 추가 → `TopBarProvider` state 전파 → `TopBar`가 true면 `ContextSwitcherChip` 미렌더. 자체 뒤로가기가 확인된 4개 상세 화면 적용: `chats/[conversation_id]`, `goals/[id]`, `gates/[id]`, `loops/[id]`(loading·notFound·본문 3곳 모두).

## 검증
`top-bar-context.test.tsx` 신규 3케이스(기본 false·전파·언마운트시 clearSlot 복귀) + 기존 `context-switcher-chip.test.tsx` 4케이스 그대로 통과. type-check/lint(0 errors)/build(EXIT 0)/vitest 전체(288파일·1981개) green.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>