### PR TITLE
chore(E-ARCH S1): sprintable-realtime-dev 배포 파이프라인 durable화

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -91,6 +91,14 @@ jobs:
             # 굴러가지만, `backend_max_instances`와 대칭 배선을 위해 dev도 명시.
             echo "backend_timeout=3600" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=" >> "$GITHUB_OUTPUT"
+            # story #2078(E-ARCH 1단계): sprintable-realtime-dev durable화. cloudbuild.yaml
+            # 의 dev-safe fallback 기본값과 동일값 — PO가 2026-07-21 손으로 생성·검증한 실측
+            # (minScale 2 · timeout 3600 · maxScale 8, describe 대조 완료). prod는 cloudbuild.yaml
+            # 의 deploy-realtime 스텝 자체가 _DEPLOY_ENV 가드로 스킵되니 여기서는 미배선.
+            echo "realtime_min_instances=2" >> "$GITHUB_OUTPUT"
+            echo "realtime_max_instances=8" >> "$GITHUB_OUTPUT"
+            echo "realtime_timeout=3600" >> "$GITHUB_OUTPUT"
+            echo "realtime_url=https://sprintable-realtime-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Submit Cloud Build
@@ -98,6 +106,6 @@ jobs:
           gcloud builds submit \
             --config=cloudbuild.yaml \
             --project="${{ secrets.GCP_PROJECT_ID }}" \
-            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}",_BACKEND_MIN_INSTANCES="${{ steps.env.outputs.backend_min_instances }}",_BACKEND_MAX_INSTANCES="${{ steps.env.outputs.backend_max_instances }}",_BACKEND_TIMEOUT="${{ steps.env.outputs.backend_timeout }}",_GA4_MEASUREMENT_ID="${{ steps.env.outputs.ga4_measurement_id }}" \
+            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}",_BACKEND_MIN_INSTANCES="${{ steps.env.outputs.backend_min_instances }}",_BACKEND_MAX_INSTANCES="${{ steps.env.outputs.backend_max_instances }}",_BACKEND_TIMEOUT="${{ steps.env.outputs.backend_timeout }}",_GA4_MEASUREMENT_ID="${{ steps.env.outputs.ga4_measurement_id }}",_REALTIME_MIN_INSTANCES="${{ steps.env.outputs.realtime_min_instances }}",_REALTIME_MAX_INSTANCES="${{ steps.env.outputs.realtime_max_instances }}",_REALTIME_TIMEOUT="${{ steps.env.outputs.realtime_timeout }}",_REALTIME_URL="${{ steps.env.outputs.realtime_url }}" \
             --suppress-logs \
             .

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -39,6 +39,19 @@ substitutions:
   # override는 존재하지 않음 — 확認 후 아래 GHA 워크플로우도 함께 배선함).
   _BACKEND_TIMEOUT: '3600'
 
+  # E-ARCH 1단계(story #2078·PR #2358 PG_LISTEN_ENABLED 배선): SSE/LISTEN 전용
+  # `sprintable-realtime-${_DEPLOY_ENV}` 서비스 — REST(`sprintable-backend-*`)와 같은 이미지,
+  # PG_LISTEN_ENABLED만 다르다(realtime=true·api는 FE 전환 후 PO가 별도로 false 배선 예정,
+  # 이 파일은 아직 손대지 않는다 — 순서 뒤바뀌면 FE 전환 전에 api LISTEN이 꺼져 실시간이 죽는다).
+  # 아래 기본값은 PO가 2026-07-21 dev에 손으로 생성·검증한 실측값을 그대로 옮긴 것
+  # (`gcloud run services describe sprintable-realtime-dev` 대조 완료) — "손 값은 다음
+  # 배포가 덮는다" 규율대로 이 파일에 명시해 durable화한다. 장수 SSE 연결이 콜드스타트에
+  # 끊기지 않도록 minScale 2(backend는 3) · timeout 3600(요청 타임아웃 상한).
+  _REALTIME_MIN_INSTANCES: '2'
+  _REALTIME_MAX_INSTANCES: '8'
+  _REALTIME_TIMEOUT: '3600'
+  _REALTIME_URL: https://sprintable-realtime-dev-787818285179.asia-northeast3.run.app
+
 steps:
   # ─── Frontend (Next.js standalone) ────────────────────────────────────────
   - id: build-frontend
@@ -173,6 +186,33 @@ steps:
       - --quiet
     # story dbda0baf: push-backend → run-migrate-job(위) 로 변경 — 신규 코드가 마이그 안 된
     # 스키마를 상대로 뜨는 걸 막는다(migrate 실패 시 이 스텝 자체가 안 돎).
+    waitFor: [run-migrate-job]
+
+  # E-ARCH 1단계(story #2078): sprintable-realtime-${_DEPLOY_ENV} — SSE/LISTEN 전용 서비스,
+  # deploy-backend와 동일 이미지·동일 시크릿 상속(--set-secrets 없는 gcloud run deploy
+  # 컨벤션 그대로 — 기존 바인딩 preserve). ⚠️ prod는 PO 검증 전이라 게이트: _DEPLOY_ENV가
+  # dev가 아니면 스킵(서비스 미존재 상태에서 이 스텝이 자동 생성해버리는 것 방지 — 프로덕션
+  # 승격 시점에 이 가드를 열고 _REALTIME_* 값을 prod로 배선).
+  - id: deploy-realtime
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -euo pipefail
+        if [ "${_DEPLOY_ENV}" != "dev" ]; then
+          echo "skip deploy-realtime: prod gate pending (E-ARCH 1단계 dev 검증 후 오픈)"
+          exit 0
+        fi
+        gcloud run deploy sprintable-realtime-${_DEPLOY_ENV} \
+          --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA} \
+          --region=${_AR_REGION} \
+          --min-instances=${_REALTIME_MIN_INSTANCES} \
+          --max-instances=${_REALTIME_MAX_INSTANCES} \
+          --timeout=${_REALTIME_TIMEOUT} \
+          --allow-unauthenticated \
+          --update-env-vars=FASTAPI_URL=${_REALTIME_URL},DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1,PG_LISTEN_ENABLED=true \
+          --quiet
     waitFor: [run-migrate-job]
 
 options:


### PR DESCRIPTION
## Summary
- story #2078 — PO가 2026-07-21 gcloud로 손 생성·검증한 `sprintable-realtime-dev`(SSE/LISTEN 전용, E-ARCH 1단계)를 `cloudbuild.yaml`에 `deploy-realtime` 스텝으로 편입해 durable화
- 손 값은 다음 자동배포가 덮는다(오늘 배운 규율) — 이 PR 없이는 다음 develop 배포에서 realtime 서비스만 이미지가 안 갱신돼 api와 드리프트가 쌓임

## Details
- `deploy-backend`와 동일 이미지·시크릿 상속 컨벤션(`--set-secrets` 없는 `gcloud run deploy`가 기존 바인딩 preserve)
- minScale 2 · timeout 3600(장수 SSE) · maxScale 8 — `gcloud run services describe sprintable-realtime-dev` 실측 대조 완료, 그대로 이식
- prod는 `_DEPLOY_ENV` 가드로 `deploy-realtime` 스텝 자체를 스킵 — main push 시 서비스가 자동 생성돼버리는 것 방지(PO 명시: prod는 dev 검증 후)
- **이 PR은 api(`sprintable-backend-*`)의 `PG_LISTEN_ENABLED`를 건드리지 않음** — FE가 realtime URL로 전환하기 전에 api LISTEN이 꺼지면 실시간이 죽으므로, 그 플립은 FE 전환 후 별도 조치(PO lane)

## Test plan
- [x] `cloudbuild.yaml`, `.github/workflows/cloud-build.yml` YAML 파싱 검증(js-yaml)
- [x] 새 substitution 값을 실 서비스(`gcloud run services describe sprintable-realtime-dev`) 실측과 1:1 대조
- [ ] CI green
- [ ] develop 머지 후 다음 배포에서 `deploy-realtime` 스텝이 dev에서 실행되고 prod push 시 스킵되는지 확인(PO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)