### PR TITLE
[E-ARCH 1단계][SID:2078] /api/event-stream을 realtime-gateway로 전환

### DIFF
--- a/apps/web/src/app/api/event-stream/route.test.ts
+++ b/apps/web/src/app/api/event-stream/route.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// E-ARCH 1단계(story #2078) — /api/event-stream 프록시 업스트림 선택 회귀가드.
+// REALTIME_URL이 설정돼 있으면 그쪽으로, 없으면 기존 NEXT_PUBLIC_FASTAPI_URL로 폴백 —
+// "되돌리면 원복"(env 값을 비우면 코드 변경 없이 즉시 원래 경로로 복귀)을 고정한다.
+
+const h = vi.hoisted(() => ({ getServerSession: vi.fn() }));
+vi.mock('@/lib/db/server', () => ({ getServerSession: h.getServerSession }));
+
+import { GET } from './route';
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe('/api/event-stream — REALTIME_URL 전환(story #2078)', () => {
+  beforeEach(() => {
+    h.getServerSession.mockReset();
+    h.getServerSession.mockResolvedValue({ access_token: 'tok' });
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 200 })));
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.unstubAllGlobals();
+  });
+
+  it('인증 없으면 401 — 업스트림 호출 자체를 안 한다', async () => {
+    h.getServerSession.mockResolvedValue(null);
+    const res = await GET(new Request('http://localhost/api/event-stream') as unknown as Parameters<typeof GET>[0]);
+    expect(res.status).toBe(401);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('REALTIME_URL이 설정돼 있으면 그쪽 /api/v2/events/stream으로 프록시한다', async () => {
+    process.env['REALTIME_URL'] = 'https://sprintable-realtime-dev-787818285179.asia-northeast3.run.app';
+    process.env['NEXT_PUBLIC_FASTAPI_URL'] = 'https://sprintable-backend-dev-787818285179.asia-northeast3.run.app';
+
+    await GET(new Request('http://localhost/api/event-stream?member_id=m1') as unknown as Parameters<typeof GET>[0]);
+
+    const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+    expect(calledUrl).toBe(
+      'https://sprintable-realtime-dev-787818285179.asia-northeast3.run.app/api/v2/events/stream?member_id=m1',
+    );
+  });
+
+  it('REALTIME_URL이 없으면(원복) 기존 NEXT_PUBLIC_FASTAPI_URL로 폴백한다', async () => {
+    delete process.env['REALTIME_URL'];
+    process.env['NEXT_PUBLIC_FASTAPI_URL'] = 'https://sprintable-backend-dev-787818285179.asia-northeast3.run.app';
+
+    await GET(new Request('http://localhost/api/event-stream?member_id=m1') as unknown as Parameters<typeof GET>[0]);
+
+    const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+    expect(calledUrl).toBe(
+      'https://sprintable-backend-dev-787818285179.asia-northeast3.run.app/api/v2/events/stream?member_id=m1',
+    );
+  });
+
+  it('REALTIME_URL이 빈 문자열이면(원복 케이스) 폴백한다 — falsy 취급', async () => {
+    process.env['REALTIME_URL'] = '';
+    process.env['NEXT_PUBLIC_FASTAPI_URL'] = 'https://sprintable-backend-dev-787818285179.asia-northeast3.run.app';
+
+    await GET(new Request('http://localhost/api/event-stream') as unknown as Parameters<typeof GET>[0]);
+
+    const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+    expect(calledUrl).toBe(
+      'https://sprintable-backend-dev-787818285179.asia-northeast3.run.app/api/v2/events/stream',
+    );
+  });
+});

--- a/apps/web/src/app/api/event-stream/route.ts
+++ b/apps/web/src/app/api/event-stream/route.ts
@@ -3,6 +3,11 @@ import { getServerSession } from '@/lib/db/server';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
+// E-ARCH 1단계(story #2078) — SSE/LISTEN 전용 realtime-gateway(REALTIME_URL)로 이 라우트만
+// 전환한다. REALTIME_URL이 설정돼 있으면 그쪽으로, 없으면 기존 FASTAPI_URL로 폴백 —
+// "되돌리면 원복"(env 값을 비우면 코드 변경·재배포 없이 즉시 원래 경로로 복귀).
+const EVENT_STREAM_UPSTREAM_URL = () => process.env['REALTIME_URL'] || FASTAPI_URL();
+
 export async function GET(request: NextRequest): Promise<Response> {
   const session = await getServerSession();
   if (!session?.access_token) {
@@ -16,7 +21,7 @@ export async function GET(request: NextRequest): Promise<Response> {
   const memberId = searchParams.get('member_id');
   const lastEventId = searchParams.get('last_event_id') ?? request.headers.get('Last-Event-ID');
 
-  const upstreamUrl = new URL(`${FASTAPI_URL()}/api/v2/events/stream`);
+  const upstreamUrl = new URL(`${EVENT_STREAM_UPSTREAM_URL()}/api/v2/events/stream`);
   if (memberId) upstreamUrl.searchParams.set('member_id', memberId);
   if (lastEventId) upstreamUrl.searchParams.set('last_event_id', lastEventId);
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -154,6 +154,10 @@ steps:
       - sprintable-frontend-${_DEPLOY_ENV}
       - --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/frontend:${COMMIT_SHA}
       - --region=${_AR_REGION}
+      # E-ARCH 1단계(story #2078) — /api/event-stream 프록시 라우트가 REALTIME_URL을 읽어
+      # SSE/LISTEN 전용 realtime-gateway로 향한다(REALTIME_URL 없으면 기존 FASTAPI_URL로
+      # 폴백 — 이 값을 비우면 코드 변경·재배포 없이 즉시 원복). --update-env-vars(additive).
+      - --update-env-vars=REALTIME_URL=${_REALTIME_URL}
       - --quiet
     waitFor: [push-frontend]
 


### PR DESCRIPTION
deploy-realtime(#2360)이 SSE/LISTEN 전용 `sprintable-realtime-${_DEPLOY_ENV}` 서비스를 띄웠으니, FE의 유일한 SSE 프록시 라우트(`/api/event-stream`)를 그쪽으로 돌린다. 이걸 해야 PO가 api(`sprintable-backend-*`)의 `PG_LISTEN_ENABLED=false` 전환(가설 67757463 abort 실측)을 안전하게 진행할 수 있다 — 순서가 FE 전환 → api LISTEN 끄기다.

## 구현
`REALTIME_URL` env가 설정돼 있으면 그쪽 `/api/v2/events/stream`으로, 없으면 기존 `NEXT_PUBLIC_FASTAPI_URL`로 폴백(빈 문자열도 falsy로 취급) — "되돌리면 원복".

`cloudbuild.yaml` `deploy-frontend`에 `--update-env-vars=REALTIME_URL=${_REALTIME_URL}` 추가(additive, 기존 substitution 재사용). GHA `cloud-build.yml`에서 dev만 실제 URL을 채우고 prod는 미설정(빈 문자열)이라, prod 프론트는 자동으로 기존 경로를 유지한다(prod realtime 게이트 미개방 — 안전).

## 검증
`route.test.ts` 신규 4케이스(미인증 401·REALTIME_URL 우선·미설정시 폴백·빈문자열도 폴백) 통과. type-check/lint(0 errors)/build(EXIT 0)/vitest 전체(290파일·1993개) green.

## 미완 — 라이브
배포되면 dev에서 EventSource가 sprintable-realtime-dev로 붙는지 + presence·알림·채팅 이벤트가 여전히 도착하는지는 배포 후 실측 대상.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>