### PR TITLE
[SID:2076][근본재구현] 컨텍스트 칩 표시 allowlist — 기본 숨김

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/board/board-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/board/board-client.tsx
@@ -18,7 +18,7 @@ export default function BoardPageClient({ projectId, wsSlug, projSlug }: BoardPa
 
   return (
     <>
-      <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
+      <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} showContextChip />
       <KanbanBoard projectId={projectId} wsSlug={wsSlug} projSlug={projSlug} />
     </>
   );

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
@@ -281,12 +281,13 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
 
   return (
     <DocsLayoutContext.Provider value={{ wsSlug, projSlug, projectId, tree, setTree, handleNewDoc, fetchTree, pendingDocUpdate, clearPendingDocUpdate, expandFolder, openTreeDrawer: openDrawer }}>
-      {/* 긴급 fix(2076 회귀) — 문서 상세(currentSlug 있음)는 유나양 규격상 상세 화면으로
-          칩 억제 대상. 리스트뷰는 title이 정적 "문서" 헤딩이라 루트 화면과 동일 취급(칩 유지). */}
+      {/* 근본 재구현(2076 회귀 후속, 유나양 규격) — currentSlug 없음(목록)=켬, 있음(문서 하나)=
+          끔. 이 shell은 단일 문서가 화면을 꽉 채우는 구조(목록+본문 동시 2단 아님)라 이 분기가
+          맞다(2단 shell이었다면 항상 켜야 함 — 유나양 규격 예외 조항). */}
       <TopBarSlot
         title={topBarTitle}
         actions={topBarActions}
-        hideContextChip={!!currentSlug}
+        showContextChip={!currentSlug}
       />
 
       {/* Unified: children rendered exactly once — sidebar responsive via breakpoint classes */}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx
@@ -282,7 +282,6 @@ export default function EpicDetailPage() {
             <span className="text-sm font-medium truncate max-w-[200px]">{epic.title}</span>
           </div>
         }
-        hideContextChip
       />
 
       <div className="mx-auto max-w-3xl px-4 py-6 space-y-8">

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
@@ -967,7 +967,7 @@ export function GoalsClient({ projectId, orgId }: GoalsClientProps) {
   if (loading) {
     return (
       <>
-        <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
+        <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} showContextChip />
         <div className="flex h-64 items-center justify-center">
           <p className="text-sm text-muted-foreground">{t('loading')}</p>
         </div>
@@ -1097,6 +1097,7 @@ export function GoalsClient({ projectId, orgId }: GoalsClientProps) {
             {t('newGoal')}
           </Button>
         }
+        showContextChip
       />
 
       {/* Desktop layout: list + slide-in detail panel */}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/loops/[id]/loop-detail-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/loops/[id]/loop-detail-client.tsx
@@ -112,7 +112,7 @@ export function LoopDetailClient({ loopId, wsSlug, projSlug }: { loopId: string;
   if (loading) {
     return (
       <>
-        <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} hideContextChip />
+        <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
         <div className="flex h-64 items-center justify-center">
           <p className="text-sm text-muted-foreground">{t('loading')}</p>
         </div>
@@ -123,7 +123,7 @@ export function LoopDetailClient({ loopId, wsSlug, projSlug }: { loopId: string;
   if (notFound || !loop) {
     return (
       <>
-        <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} hideContextChip />
+        <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
         <div className="flex h-64 flex-col items-center justify-center gap-3">
           <p className="text-sm text-muted-foreground">{t('notFound')}</p>
           {/* story #1990: replace — 뒤로가기 재진입 트랩 방지(§3.2). */}
@@ -155,7 +155,6 @@ export function LoopDetailClient({ loopId, wsSlug, projSlug }: { loopId: string;
             {t('backToList')}
           </button>
         }
-        hideContextChip
       />
       <div className="mx-auto max-w-3xl space-y-5 overflow-y-auto p-5">
         {/* Header */}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/loops/loops-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/loops/loops-client.tsx
@@ -130,7 +130,7 @@ export function LoopsClient({ projectId, wsSlug, projSlug }: { projectId: string
   if (loading) {
     return (
       <>
-        <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
+        <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} showContextChip />
         <div className="flex h-64 items-center justify-center">
           <p className="text-sm text-muted-foreground">{t('loading')}</p>
         </div>
@@ -148,6 +148,7 @@ export function LoopsClient({ projectId, wsSlug, projSlug }: { projectId: string
             {t('createLoopCta')}
           </Button>
         }
+        showContextChip
       />
       <LoopCreateDialog
         projectId={projectId}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/mockups/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/mockups/[id]/page.tsx
@@ -115,7 +115,6 @@ export default function MockupViewerPage() {
             <Badge variant="info">v{mockup.version}</Badge>
           </div>
         }
-        hideContextChip
       />
 
       <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/mockups/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/mockups/page.tsx
@@ -73,6 +73,7 @@ export default function MockupsPage() {
             {t('newMockup')}
           </Button>
         }
+        showContextChip
       />
 
       {showCreate ? (

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx
@@ -624,7 +624,6 @@ export default function RetroSessionPage() {
             </div>
           ) : null
         }
-        hideContextChip
       />
 
       <div className="focus-inset flex min-h-0 flex-1 flex-col overflow-y-auto">

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/page.tsx
@@ -126,7 +126,7 @@ export default function RetroPage() {
   if (!projectId) {
     return (
       <>
-        <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
+        <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} showContextChip />
         <div className="flex h-64 items-center justify-center p-6">
           <EmptyState title={shellT('projectSelectPrompt')} description={shellT('projectSelectDescription')} />
         </div>
@@ -147,6 +147,7 @@ export default function RetroPage() {
             )}
           </Button>
         }
+        showContextChip
       />
 
       <div className="focus-inset flex min-h-0 flex-1 flex-col gap-0 overflow-y-auto">

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx
@@ -628,6 +628,7 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
             <span className="hidden sm:inline">{t('newSprint')}</span>
           </Button>
         }
+        showContextChip
       />
       <div className="flex min-h-0 flex-1 overflow-hidden">
       {/* Sprint list */}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/standup/standup-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/standup/standup-client.tsx
@@ -445,6 +445,7 @@ export default function StandupPage({ projectId }: StandupClientProps) {
         actions={
           <div className="hidden flex-wrap items-center gap-1.5 lg:flex">{dateNavControls}</div>
         }
+        showContextChip
       />
 
       {/* S4: mobile date nav as its own full-width row (keeps the header title readable). */}

--- a/apps/web/src/app/(authenticated)/channel/page.tsx
+++ b/apps/web/src/app/(authenticated)/channel/page.tsx
@@ -169,6 +169,7 @@ export default function ChannelPage() {
             <span className={`h-2 w-2 rounded-full ${statusDot}`} title={wsStatus} />
           </div>
         }
+        showContextChip
       />
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">

--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
@@ -239,7 +239,6 @@ export default function ConversationPage() {
             </div>
           )
         }
-        hideContextChip
       />
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
         <ChatView

--- a/apps/web/src/app/(authenticated)/chats/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/page.tsx
@@ -32,6 +32,7 @@ export default function ChatsPage() {
             {t('newConversation')}
           </Button>
         }
+        showContextChip
       />
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <ChatListView

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -130,7 +130,6 @@ export default function GateDetailPage() {
             {t('gateDetailBackToInbox')}
           </button>
         }
-        hideContextChip
       />
       <div className="mx-auto flex min-h-full w-full max-w-2xl flex-1 flex-col gap-5 px-4 py-5">
         {loading ? (

--- a/apps/web/src/app/(authenticated)/inbox/page.tsx
+++ b/apps/web/src/app/(authenticated)/inbox/page.tsx
@@ -373,6 +373,7 @@ export default function InboxPage() {
             {t('markAllRead')}
           </Button>
         }
+        showContextChip
       />
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">

--- a/apps/web/src/app/(authenticated)/more/page.tsx
+++ b/apps/web/src/app/(authenticated)/more/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
+import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import {
   FolderKanban,
   CalendarRange,
@@ -43,7 +44,10 @@ export default function MorePage() {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-4">
-      <h1 className="mb-1 text-lg font-semibold text-foreground">{tMore('more')}</h1>
+      {/* 근본 재구현(2076 회귀 후속, 유나양 규격) — 이 4탭 루트는 TopBarSlot을 아예 안 써서
+          allowlist(showContextChip)로 켤 자리가 없었다. "슬롯 없으면 자동 켬"은 fail-open이라
+          금지(유나양) — 슬롯을 명시적으로 쓰게 해서 켠다. */}
+      <TopBarSlot title={<h1 className="text-sm font-medium">{tMore('more')}</h1>} showContextChip />
       <p className="mb-4 text-xs text-muted-foreground">{tMore('moreTempNotice')}</p>
       <ul className="divide-y divide-border rounded-xl border border-border">
         {ITEMS.map(({ href, icon: Icon, labelKey }) => (

--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
@@ -607,7 +607,7 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
   return (
     <div className="mx-auto flex max-w-2xl flex-1 flex-col gap-4 p-4">
       {showTopBar ? (
-        <TopBarSlot title={<h1 className="flex items-center gap-2 text-sm font-medium"><IdCard className="h-4 w-4" aria-hidden />{t('title')}</h1>} />
+        <TopBarSlot title={<h1 className="flex items-center gap-2 text-sm font-medium"><IdCard className="h-4 w-4" aria-hidden />{t('title')}</h1>} showContextChip />
       ) : null}
       {onExit ? (
         <button

--- a/apps/web/src/app/(authenticated)/rewards/page.tsx
+++ b/apps/web/src/app/(authenticated)/rewards/page.tsx
@@ -93,7 +93,7 @@ export default function RewardsPage() {
   if (!projectId) {
     return (
       <>
-        <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
+        <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} showContextChip />
         <div className="flex h-64 items-center justify-center p-6">
           <EmptyState title={shellT('projectSelectPrompt')} description={shellT('projectSelectDescription')} />
         </div>
@@ -103,7 +103,7 @@ export default function RewardsPage() {
 
   return (
     <>
-      <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
+      <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} showContextChip />
 
       <div className="focus-inset flex min-h-0 flex-1 flex-col overflow-y-auto">
         <div className="mx-auto w-full max-w-3xl space-y-5 p-6">

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -28,7 +28,7 @@ export default async function DashboardPage() {
     return (
       <div className="min-h-full p-4 lg:p-6">
         <div className="mx-auto max-w-7xl space-y-5">
-          <TopBarSlot title={<h1 className="text-sm font-medium">{t('commandCenter')}</h1>} />
+          <TopBarSlot title={<h1 className="text-sm font-medium">{t('commandCenter')}</h1>} showContextChip />
           <EmptyState
             title={t('noProjectTitle')}
             description={t('noProjectDescription')}
@@ -46,7 +46,7 @@ export default async function DashboardPage() {
   return (
     <div className="min-h-full p-4 lg:p-6">
       <div className="mx-auto max-w-7xl space-y-5">
-        <TopBarSlot title={<h1 className="text-sm font-medium">{t('commandCenter')}</h1>} />
+        <TopBarSlot title={<h1 className="text-sm font-medium">{t('commandCenter')}</h1>} showContextChip />
         <CommandCenter projectName={me.project_name} />
       </div>
     </div>

--- a/apps/web/src/components/activity/activity-log-view.tsx
+++ b/apps/web/src/components/activity/activity-log-view.tsx
@@ -199,7 +199,7 @@ export function ActivityLogView({ projectId }: ActivityLogViewProps) {
 
   return (
     <>
-      <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
+      <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} showContextChip />
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {/* Filters */}

--- a/apps/web/src/components/activity/team-activity-view.tsx
+++ b/apps/web/src/components/activity/team-activity-view.tsx
@@ -299,7 +299,7 @@ export function TeamActivityView({ projectId }: { projectId: string }) {
 
   return (
     <>
-      <TopBarSlot title={<h1 className="text-sm font-medium">{t('tabTeamActivity')}</h1>} />
+      <TopBarSlot title={<h1 className="text-sm font-medium">{t('tabTeamActivity')}</h1>} showContextChip />
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {/* 정규화됨 pill + 캡션 바 (팀활동 탭만 — 시각/의미 차별화 생명선) */}

--- a/apps/web/src/components/agents/agent-hitl-requests-list.tsx
+++ b/apps/web/src/components/agents/agent-hitl-requests-list.tsx
@@ -108,6 +108,7 @@ export function AgentHitlRequestsList() {
             </Link>
           </div>
         }
+        showContextChip
       />
 
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-6 space-y-5">

--- a/apps/web/src/components/agents/agent-runs-list.tsx
+++ b/apps/web/src/components/agents/agent-runs-list.tsx
@@ -183,7 +183,7 @@ export function AgentRunsList() {
 
   return (
     <>
-      <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
+      <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} showContextChip />
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {/* Filters */}

--- a/apps/web/src/components/agents/agents-dashboard.tsx
+++ b/apps/web/src/components/agents/agents-dashboard.tsx
@@ -325,6 +325,7 @@ export function AgentsDashboard({ deployments: initialDeployments, hideTopBar = 
                 </Link>
               ) : null
             }
+            showContextChip
           />
       )}
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-6">

--- a/apps/web/src/components/agents/agents-page-tabs.tsx
+++ b/apps/web/src/components/agents/agents-page-tabs.tsx
@@ -57,7 +57,7 @@ export function AgentsPageTabs() {
 
   return (
     <>
-      <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
+      <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} showContextChip />
       <Tabs value={effectiveTab} onValueChange={(v) => setActiveTab(v as AgentsTab)}>
         <div className="border-b border-border px-6">
           <TabsList variant="line">

--- a/apps/web/src/components/nav/top-bar-context.test.tsx
+++ b/apps/web/src/components/nav/top-bar-context.test.tsx
@@ -1,8 +1,10 @@
 // @vitest-environment jsdom
 //
-// 긴급 fix(2076 회귀) — 2뎁스+ 상세 화면(자체 뒤로가기 보유)이 TopBarSlot에 hideContextChip을
-// 선언하면 TopBar가 실제로 컨텍스트 칩을 뺀다는 것을 회귀가드로 고정한다. RED였던 증상:
-// 채팅 상세에서 칩+뒤로가기+제목+액션+아이콘 클러스터가 <1024에서 공간 부족으로 뭉개짐.
+// 근본 재구현(2076 회귀 후속, 유나양 규격) — 기본 숨김·표시할 루트 화면만 TopBarSlot에
+// showContextChip을 선언해 켠다는 것을 회귀가드로 고정한다. 원래 "숨길 화면을 명시
+// (hideContextChip)" 방식은 fail-open이었다 — docs·mockups·retro가 뒤로가기 아이콘 부재로
+// grep 기반 탐색에서 3차례 누락되며(2026-07-21) 실측으로 구조적 약점이 증명됐다. "표시할
+// 것만 명시·기본 숨김"이면 새 상세 화면이 생겨도 구조적으로 안 샌다.
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { act } from 'react';
@@ -16,8 +18,8 @@ let container: HTMLDivElement;
 let root: Root;
 
 function Probe() {
-  const { hideContextChip } = useTopBar();
-  return <span data-testid="probe">{String(hideContextChip)}</span>;
+  const { showContextChip } = useTopBar();
+  return <span data-testid="probe">{String(showContextChip)}</span>;
 }
 
 beforeEach(() => {
@@ -31,8 +33,8 @@ afterEach(async () => {
   container.remove();
 });
 
-describe('TopBarSlot hideContextChip — 2076 긴급 fix 회귀가드', () => {
-  it('hideContextChip을 안 주면(기본) false — 기존 화면은 칩이 그대로 보인다', async () => {
+describe('TopBarSlot showContextChip — allowlist 재구현(2076 회귀 후속)', () => {
+  it('showContextChip을 안 주면(기본) false — 새 화면은 기본적으로 칩이 안 뜬다(fail-closed)', async () => {
     await act(async () => {
       root.render(
         <TopBarProvider>
@@ -44,11 +46,11 @@ describe('TopBarSlot hideContextChip — 2076 긴급 fix 회귀가드', () => {
     expect(container.querySelector('[data-testid="probe"]')?.textContent).toBe('false');
   });
 
-  it('hideContextChip을 주면 true로 전파된다 — 상세 화면이 칩을 뺀다', async () => {
+  it('showContextChip을 주면 true로 전파된다 — 루트 화면이 명시적으로 칩을 켠다', async () => {
     await act(async () => {
       root.render(
         <TopBarProvider>
-          <TopBarSlot title={<span>채팅 상세</span>} hideContextChip />
+          <TopBarSlot title={<span>보드</span>} showContextChip />
           <Probe />
         </TopBarProvider>,
       );
@@ -56,29 +58,29 @@ describe('TopBarSlot hideContextChip — 2076 긴급 fix 회귀가드', () => {
     expect(container.querySelector('[data-testid="probe"]')?.textContent).toBe('true');
   });
 
-  it('상세→목록으로 props가 바뀌면 hideContextChip도 그에 맞춰 갱신된다', async () => {
-    function Wrapper({ showDetail }: { showDetail: boolean }) {
+  it('루트→상세로 props가 바뀌면 showContextChip도 그에 맞춰 갱신된다', async () => {
+    function Wrapper({ isRoot }: { isRoot: boolean }) {
       return (
         <TopBarProvider>
-          {showDetail
-            ? <TopBarSlot title={<span>상세</span>} hideContextChip />
-            : <TopBarSlot title={<span>목록</span>} />}
+          {isRoot
+            ? <TopBarSlot title={<span>목록</span>} showContextChip />
+            : <TopBarSlot title={<span>상세</span>} />}
           <Probe />
         </TopBarProvider>
       );
     }
-    await act(async () => { root.render(<Wrapper showDetail />); });
+    await act(async () => { root.render(<Wrapper isRoot />); });
     expect(container.querySelector('[data-testid="probe"]')?.textContent).toBe('true');
 
-    await act(async () => { root.render(<Wrapper showDetail={false} />); });
+    await act(async () => { root.render(<Wrapper isRoot={false} />); });
     expect(container.querySelector('[data-testid="probe"]')?.textContent).toBe('false');
   });
 
-  it('TopBarSlot이 언마운트되면(clearSlot) hideContextChip도 false로 초기화된다', async () => {
+  it('TopBarSlot이 언마운트되면(clearSlot) showContextChip도 false로 초기화된다', async () => {
     function Wrapper({ mounted }: { mounted: boolean }) {
       return (
         <TopBarProvider>
-          {mounted && <TopBarSlot title={<span>상세</span>} hideContextChip />}
+          {mounted && <TopBarSlot title={<span>보드</span>} showContextChip />}
           <Probe />
         </TopBarProvider>
       );

--- a/apps/web/src/components/nav/top-bar-context.tsx
+++ b/apps/web/src/components/nav/top-bar-context.tsx
@@ -5,16 +5,15 @@ import { createContext, useContext, useState, type ReactNode } from 'react';
 interface TopBarState {
   title: ReactNode | null;
   actions: ReactNode | null;
-  // 긴급 fix(2076 회귀) — 2뎁스+ 상세 화면(채팅 상세·목표 상세·게이트 상세·루프 상세 등)은
-  // title 슬롯 자체에 이미 뒤로가기가 있어, 그 위에 컨텍스트 칩까지 얹으면 <1024에서 공간이
-  // 부족해 뭉개진다(선생님 실기기 리포트). "전환은 최상위에서" — 상세 화면은 이미 맥락이
-  // 있으므로 칩이 불필요하다는 판단(오르테가군). 페이지가 명시적으로 선언한다(라우트 깊이
-  // 추론은 board/goals/standup 등 depth-2지만 root-tab인 화면과 구분이 안 돼 신뢰 불가).
-  hideContextChip: boolean;
+  // 근본 재구현(2076 회귀 후속, 유나양 규격) — 애초 "숨길 화면을 명시(hideContextChip)"가
+  // fail-open 구조였다(docs·mockups·retro가 뒤로가기 신호 부재로 grep에서 3차례 누락되며
+  // 실측으로 증명됨). "표시할 루트만 명시·기본 숨김"으로 뒤집는다 — 새 상세 화면이 생겨도
+  // 기본이 "칩 없음"이라 구조적으로 안 샌다. 화면이 명시적으로 켜야 보인다.
+  showContextChip: boolean;
 }
 
 interface TopBarStore extends TopBarState {
-  setSlot: (slot: Pick<TopBarState, 'title' | 'actions'> & Partial<Pick<TopBarState, 'hideContextChip'>>) => void;
+  setSlot: (slot: Pick<TopBarState, 'title' | 'actions'> & Partial<Pick<TopBarState, 'showContextChip'>>) => void;
   clearSlot: () => void;
   hidden: boolean;
   setHidden: (h: boolean) => void;
@@ -25,13 +24,13 @@ interface TopBarStore extends TopBarState {
 const TopBarCtx = createContext<TopBarStore | null>(null);
 
 export function TopBarProvider({ children }: { children: ReactNode }) {
-  const [state, setState] = useState<TopBarState>({ title: null, actions: null, hideContextChip: false });
+  const [state, setState] = useState<TopBarState>({ title: null, actions: null, showContextChip: false });
   const [hidden, setHidden] = useState(false);
   const [scrollContainer, setScrollContainer] = useState<HTMLElement | null>(null);
   const value: TopBarStore = {
     ...state,
-    setSlot: (slot) => setState({ hideContextChip: false, ...slot }),
-    clearSlot: () => setState({ title: null, actions: null, hideContextChip: false }),
+    setSlot: (slot) => setState({ showContextChip: false, ...slot }),
+    clearSlot: () => setState({ title: null, actions: null, showContextChip: false }),
     hidden,
     setHidden,
     scrollContainer,

--- a/apps/web/src/components/nav/top-bar-slot.tsx
+++ b/apps/web/src/components/nav/top-bar-slot.tsx
@@ -6,17 +6,19 @@ import { useTopBar } from './top-bar-context';
 interface TopBarSlotProps {
   title: ReactNode;
   actions?: ReactNode;
-  /** 긴급 fix(2076 회귀) — 이 화면의 title이 이미 자체 뒤로가기를 갖는 상세 화면이면 true로
-   * 컨텍스트 칩을 뺀다(<1024에서 공간 부족으로 뭉개지는 문제). */
-  hideContextChip?: boolean;
+  /** 근본 재구현(2076 회귀 후속) — 기본 false(칩 숨김). 이 화면이 조직/프로젝트 컨텍스트를
+   * "훑는" 루트 화면(보드·목표목록·독립 리스트 등)이면 true로 명시해 칩을 켠다. 상세/단일
+   * 항목 화면은 아무것도 안 해도(기본값) 칩이 안 뜬다 — hideContextChip 방식(숨길 것 명시)의
+   * fail-open 구조적 약점(새 상세 화면마다 빠뜨리기 쉬움, 유나양 규격)을 뒤집은 것. */
+  showContextChip?: boolean;
 }
 
-export function TopBarSlot({ title, actions = null, hideContextChip = false }: TopBarSlotProps) {
+export function TopBarSlot({ title, actions = null, showContextChip = false }: TopBarSlotProps) {
   const { setSlot, clearSlot } = useTopBar();
   useEffect(() => {
-    setSlot({ title, actions, hideContextChip });
+    setSlot({ title, actions, showContextChip });
     return clearSlot;
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [title, actions, hideContextChip]);
+  }, [title, actions, showContextChip]);
   return null;
 }

--- a/apps/web/src/components/nav/top-bar.tsx
+++ b/apps/web/src/components/nav/top-bar.tsx
@@ -20,7 +20,7 @@ interface TopBarProps {
 }
 
 export function TopBar({ className, orgId, orgMemberships = [], projectId, projectMemberships = [] }: TopBarProps) {
-  const { title, actions, hidden, hideContextChip } = useTopBar();
+  const { title, actions, hidden, showContextChip } = useTopBar();
   return (
     <div
       className={cn(
@@ -37,9 +37,10 @@ export function TopBar({ className, orgId, orgMemberships = [], projectId, proje
           story #2076: 그 자리에 컨텍스트 칩을 추가한다 — 탭바는 화면 이동, 칩은 컨텍스트(조직/
           프로젝트) 전환으로 관심사가 다르다. title보다 먼저 두어 "지금 어디에 있는지"가 화면
           제목보다 앞서 보이게 한다.
-          긴급 fix(2076 회귀): 2뎁스+ 상세 화면(자체 뒤로가기 보유)은 hideContextChip으로
-          칩을 뺀다 — "전환은 최상위에서" 이미 맥락이 있는 화면엔 칩이 불필요·공간도 부족. */}
-      {!hideContextChip && (
+          근본 재구현(2076 회귀 후속, 유나양 규격): 기본 숨김·표시할 루트 화면만 showContextChip
+          으로 명시 — "숨길 것 명시" 방식이 새 상세 화면마다 빠뜨리는 fail-open이었던 것을
+          "표시할 것만 명시·기본 숨김"으로 뒤집었다(상세 화면은 이미 뒤로가기로 맥락이 있다). */}
+      {showContextChip && (
         <ContextSwitcherChip
           orgs={orgMemberships}
           currentOrgId={orgId}

--- a/apps/web/src/components/storage/storage-view.tsx
+++ b/apps/web/src/components/storage/storage-view.tsx
@@ -282,7 +282,7 @@ export function StorageView({ projectId }: { projectId: string }) {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <TopBarSlot title={topBarTitle} />
+      <TopBarSlot title={topBarTitle} showContextChip />
 
       <div className="px-4 pt-3 empty:hidden">
         <StorageCapacityBanner />


### PR DESCRIPTION
"숨길 화면을 명시(hideContextChip)"이 fail-open 구조였다 — #2354 도입부터 #2359 회귀까지, #2359 자체도 docs·mockups·retro 3곳을 뒤로가기 아이콘 부재 때문에 두 차례 더 놓쳤다. "뒤로가기 유무"라는 간접 신호로는 상세 화면을 구조적으로 못 가른다는 게 유나양 전수조사로 확定됐다.

## 뒤집힌 방향(유나양 규격)
`TopBarSlot`의 `hideContextChip?: boolean`(기본 false=보임) → `showContextChip?: boolean`(기본 false=숨김)으로 전면 교체. 화면이 "나는 칩을 켠다"를 명시해야만 보인다 — 새 상세 화면이 생겨도 기본이 숨김이라 구조적으로 안 샌다.

## 켠 곳(20곳, 유나양 전수조사)
- `[ws]/[proj]`: board·goals·loops·sprints·standup·mockups(목록)·retro(목록)
- 앱 레벨: inbox·chats(목록)·channel·rewards·dashboard·recruiter-client
- 컴포넌트(루트 화면에 마운트): activity-log-view·team-activity-view·agents-dashboard·agents-page-tabs·agent-runs-list·agent-hitl-requests-list·storage-view
- (`kanban-board.tsx`는 `board-client.tsx` 안에서만 마운트돼 자체 TopBarSlot이 없어 제외 — 부모 슬롯이 이미 커버)

## docs — currentSlug로 분기
목록(currentSlug 없음)=켬 / 문서 하나(있음)=끔. 목록+본문 동시 노출 2단 레이아웃이 아니라 이 분기가 맞다.

## /more — 슬롯이 아예 없던 문제
TopBarSlot을 새로 추가해 showContextChip을 켰다("슬롯 없으면 자동 켬"은 다시 fail-open이라 금지).

## 뺀 곳(6곳)
chats/[conversation_id]·goals/[id]·gates/[id]·loops/[id]·mockups/[id]·retro/[id] — `hideContextChip` prop 제거만으로 충분.

## 검증
`top-bar-context.test.tsx` 4케이스 새 API로 재작성 전부 통과. type-check/lint(0 errors)/build(EXIT 0)/vitest 전체(289파일·1989개) green.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>