### PR TITLE
feat(E-ARCH S2): EventBroker — PG NOTIFY + Redis dual-publish shadow

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -88,6 +88,15 @@ class Settings(BaseSettings):
     # default=True(무회귀) — 명시적으로 끄지 않는 한 기존 단일서비스 배포와 동일 동작.
     pg_listen_enabled: bool = True
 
+    # E-ARCH S2(story #2078·설계 오르테가군 판정 2026-07-21): PG NOTIFY 옆에 Redis(Memorystore)
+    # dual-publish를 shadow로 추가하는 단계. default=False(무회귀) — Memorystore 인스턴스가 아직
+    # 없어도(PO lane·1단계 abort-0 실측 확認 후 배선 예정) 이 PR 자체는 아무 동작도 안 바꾼다.
+    # 켜져도 PG NOTIFY가 여전히 authoritative(dispatch는 PG 경로만 사용) — Redis는 realtime
+    # gateway의 shadow-consume 비교용(지연·중복률 측정)이라 유실돼도 정합성 영향 0
+    # (agent_gateway.py의 acked_seq DB 재조회 패턴과 동형 근거 — 오늘 세션 교차검증 완료).
+    event_broker_redis_dual_publish_enabled: bool = False
+    redis_url: str | None = None  # Memorystore 연결 문자열. flag on인데 None이면 경고 로그만(fail-safe).
+
     # E-L2 휴리스틱 트리거 워커. default-off — 명시 활성화 전엔 lifespan task 미생성(무동작).
     # advisory_lock=on이면 멀티인스턴스 중 pg_try_advisory_lock holder 1개만 poll/evaluate.
     l2_trigger_enabled: bool = False

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,6 +48,14 @@ async def lifespan(app: FastAPI):
         from app.services.l2_trigger_worker import L2TriggerWorker
 
         l2_task = asyncio.create_task(L2TriggerWorker().run())
+    # E-ARCH S2(story #2078): shadow-consume은 event_broker_redis_dual_publish_enabled(default
+    # False)일 때만 task 생성 — Memorystore 미배선 상태(redis_url=None)에서도 이 브랜치 자체가
+    # 안 돌아 무해(플래그가 꺼져 있으면 event_broker.py의 redis_url 가드에도 안 닿는다).
+    redis_shadow_task = None
+    if settings.event_broker_redis_dual_publish_enabled:
+        from app.services.event_broker import redis_shadow_consume_loop
+
+        redis_shadow_task = asyncio.create_task(redis_shadow_consume_loop())
     try:
         yield
     finally:
@@ -55,6 +63,8 @@ async def lifespan(app: FastAPI):
             task.cancel()
         if l2_task is not None:
             l2_task.cancel()
+        if redis_shadow_task is not None:
+            redis_shadow_task.cancel()
         try:
             if task is not None:
                 try:
@@ -64,6 +74,11 @@ async def lifespan(app: FastAPI):
             if l2_task is not None:
                 try:
                     await l2_task
+                except asyncio.CancelledError:
+                    pass
+            if redis_shadow_task is not None:
+                try:
+                    await redis_shadow_task
                 except asyncio.CancelledError:
                     pass
         finally:

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -68,8 +68,12 @@ def publish_event(org_id: str, event_type: str, data: dict, _from_listener: bool
         # prod 커넥션 누수 근본fix(2026-07-08): 참조 미보관 create_task는 GC가 pg_notify()의
         # async with async_session_factory() 도중 태스크를 조기수거할 수 있다(공식 문서 경고) —
         # fire_and_forget이 강한 참조를 보관해 이를 막는다.
-        from app.services.pg_pubsub import fire_and_forget, pg_notify
-        fire_and_forget(pg_notify("org", org_id, event_type, data))
+        # E-ARCH S2(story #2078): pg_notify() 직접 호출 → event_broker.publish()로 — PG NOTIFY는
+        # 그대로(내부에서 동일 호출) + event_broker_redis_dual_publish_enabled 시 Redis shadow
+        # 추가 발행(기본 off, 무회귀). fire_and_forget 감싸는 방식은 무변경.
+        from app.services.event_broker import event_broker
+        from app.services.pg_pubsub import fire_and_forget
+        fire_and_forget(event_broker.publish("org", org_id, event_type, data))
 
 
 # ─── Agent connection registry (S2/S3: 에이전트별 SSE) ───────────────────────
@@ -129,8 +133,10 @@ def _push_to_agent(member_id: str, payload: dict, _from_listener: bool = False) 
             queues.discard(q)
     if not _from_listener:
         # prod 커넥션 누수 근본fix(2026-07-08) — publish_event()와 동형(fire_and_forget 참조 보관).
-        from app.services.pg_pubsub import fire_and_forget, pg_notify
-        fire_and_forget(pg_notify("agent", member_id, payload.get("event_type", ""), payload))
+        # E-ARCH S2(story #2078): pg_notify() 직접 호출 → event_broker.publish()로(publish_event()와 동형 치환).
+        from app.services.event_broker import event_broker
+        from app.services.pg_pubsub import fire_and_forget
+        fire_and_forget(event_broker.publish("agent", member_id, payload.get("event_type", ""), payload))
     return pushed
 
 

--- a/backend/app/services/event_broker.py
+++ b/backend/app/services/event_broker.py
@@ -1,0 +1,189 @@
+"""E-ARCH S2(story #2078): EventBroker — PG NOTIFY(authoritative) + Redis(shadow dual-publish).
+
+설계(오르테가군 판정 2026-07-21): 2단계는 dual-publish, 3단계에서 Redis-only 구현체로 교체 가능
+하도록 `EventBroker`를 인터페이스로 분리한다 — 콜사이트(events.py)는 어느 구현체가 도는지 모른다.
+
+Redis 경로는 `event_broker_redis_dual_publish_enabled`(default False)로 게이트 — 꺼져 있으면
+이 모듈은 `pg_notify()` 호출 외 아무것도 안 한다(무회귀, #2358 PG_LISTEN_ENABLED와 동일 컨벤션).
+
+Redis가 이 단계에서 100% 유실돼도 정합성 영향 0 — Redis는 realtime gateway의 shadow-consume
+비교(지연·중복률 측정)용일 뿐 dispatch에 쓰이지 않는다. dispatch는 여전히 PG LISTEN
+(pg_pubsub.listen_loop) 경로만 탄다. 근거: agent_gateway.py의 acked_seq DB 재조회 패턴과 동형
+— wake 신호 유실은 다음 재조회가 흡수한다(2026-07-21 세션 코드 교차검증 완료).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from typing import Literal, Protocol
+
+logger = logging.getLogger(__name__)
+
+_REDIS_CHANNEL_PREFIX_ORG = "org"
+_REDIS_CHANNEL_PREFIX_AGENT = "agent"
+
+# shadow-consume 비교용 — PG 경로로 도착한 event_id → 도착 시각(monotonic). 크기 상한으로
+# 무한증가 방지(정밀 LRU 불필요 — shadow 비교는 근사치 지표면 충분, 비교 실패해도 dispatch 무영향).
+_SHADOW_MAX_TRACKED = 2000
+_pg_arrivals: dict[str, float] = {}
+
+_redis_client = None  # lazy singleton — redis_url 미설정 시(Memorystore 없음) 절대 생성 안 함
+
+
+class EventBroker(Protocol):
+    async def publish(
+        self, target: Literal["org", "agent"], target_id: str, event_type: str, data: dict
+    ) -> None: ...
+
+
+def _slim_org_payload(data: dict) -> dict:
+    """org-wide invalidation 전용 슬림 payload — 민감 content 방송 금지(FE가 권한검증 REST 재조회).
+
+    ⚠️ 이 슬림화는 신규 Redis 경로에만 적용된다 — 기존 PG NOTIFY org 채널 payload(및
+    `publish_event()`의 `_subscribers` 로컬 in-process fanout)는 안 건드림(기존 컨슈머 무영향).
+    """
+    return {
+        "entity_type": data.get("entity_type"),
+        "entity_id": data.get("entity_id"),
+        "version": data.get("version"),
+    }
+
+
+def _redis_channel(target: Literal["org", "agent"], target_id: str) -> str:
+    if target == "org":
+        return f"{_REDIS_CHANNEL_PREFIX_ORG}:{target_id}:invalidation"
+    return f"{_REDIS_CHANNEL_PREFIX_AGENT}:{target_id}"
+
+
+def _get_redis_client():
+    global _redis_client
+    if _redis_client is None:
+        import redis.asyncio as aioredis
+
+        from app.core.config import settings
+
+        _redis_client = aioredis.from_url(settings.redis_url, decode_responses=True)
+    return _redis_client
+
+
+async def _redis_publish(
+    target: Literal["org", "agent"], target_id: str, event_type: str, data: dict, event_id: str
+) -> None:
+    """Redis 발행 — 실패 시 경고 로그만(pg_notify와 동형 철학: shadow 경로라 예외 전파 금지)."""
+    import json
+
+    from app.core.config import settings
+
+    if not settings.redis_url:
+        logger.warning("event_broker redis publish skipped: redis_url not configured")
+        return
+
+    payload = _slim_org_payload(data) if target == "org" else dict(data)
+    payload["event_type"] = event_type
+    payload["_broker_event_id"] = event_id
+
+    try:
+        client = _get_redis_client()
+        await client.publish(_redis_channel(target, target_id), json.dumps(payload, default=str))
+    except Exception as exc:
+        logger.warning(
+            "event_broker redis publish failed target=%s target_id=%s: %s", target, target_id, exc
+        )
+
+
+class DualPublishEventBroker:
+    """E-ARCH S2 구현체 — PG NOTIFY(authoritative, 무변경) + Redis(shadow, best-effort)."""
+
+    async def publish(
+        self, target: Literal["org", "agent"], target_id: str, event_type: str, data: dict
+    ) -> None:
+        from app.core.config import settings
+        from app.services.pg_pubsub import fire_and_forget, pg_notify
+
+        event_id = str(uuid.uuid4())
+        # 기존 pg_notify 호출 그대로 — _broker_event_id만 추가(상관관계 ID, shadow 비교용).
+        await pg_notify(target, target_id, event_type, {**data, "_broker_event_id": event_id})
+
+        if settings.event_broker_redis_dual_publish_enabled:
+            fire_and_forget(_redis_publish(target, target_id, event_type, data, event_id))
+
+
+event_broker: EventBroker = DualPublishEventBroker()
+
+
+# ─── Shadow-consume 비교 (realtime gateway 전용) ──────────────────────────────
+
+def record_pg_arrival(event_id: str) -> None:
+    """pg_pubsub._dispatch_received()가 PG 경로로 이벤트 도착 시 호출 — shadow 비교 기준점."""
+    if not event_id:
+        return
+    if len(_pg_arrivals) >= _SHADOW_MAX_TRACKED:
+        for key in list(_pg_arrivals)[: _SHADOW_MAX_TRACKED // 2]:
+            _pg_arrivals.pop(key, None)
+    _pg_arrivals[event_id] = time.monotonic()
+
+
+async def redis_shadow_consume_loop() -> None:
+    """Redis 구독 → PG 경로 도착 기록과 대조해 지연Δ·중복률을 로그.
+
+    dispatch에는 절대 안 씀(PG가 여전히 authoritative) — 비교 관측 전용.
+    listen_loop()(pg_pubsub.py)과 동형 재연결 구조(1s→2s→4s→max 30s backoff).
+    """
+    import json
+
+    from app.core.config import settings
+
+    if not settings.redis_url:
+        logger.warning("event_broker redis shadow consume skipped: redis_url not configured")
+        return
+
+    delay = 1.0
+    logger.info("event_broker redis shadow consume starting")
+
+    while True:
+        pubsub = None
+        try:
+            client = _get_redis_client()
+            pubsub = client.pubsub()
+            await pubsub.psubscribe("org:*:invalidation", "agent:*")
+            delay = 1.0
+            logger.info("event_broker redis shadow consume connected")
+            async for message in pubsub.listen():
+                if message.get("type") not in ("pmessage", "message"):
+                    continue
+                try:
+                    payload = json.loads(message["data"])
+                except (TypeError, ValueError):
+                    continue
+                event_id = payload.get("_broker_event_id")
+                if not event_id:
+                    continue
+                received_at = time.monotonic()
+                pg_arrived_at = _pg_arrivals.get(event_id)
+                if pg_arrived_at is not None:
+                    logger.info(
+                        "event_broker shadow: redis+pg both delivered event_id=%s latency_delta=%.3fs",
+                        event_id, received_at - pg_arrived_at,
+                    )
+                else:
+                    logger.info(
+                        "event_broker shadow: redis-only delivery event_id=%s (pg 미도착/유실 가능)",
+                        event_id,
+                    )
+        except asyncio.CancelledError:
+            logger.info("event_broker redis shadow consume cancelled — shutting down")
+            break
+        except Exception as exc:
+            logger.warning(
+                "event_broker redis shadow consume error: %s — reconnecting in %.1fs", exc, delay
+            )
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, 30)
+        finally:
+            if pubsub is not None:
+                try:
+                    await pubsub.close()
+                except Exception:
+                    pass

--- a/backend/app/services/pg_pubsub.py
+++ b/backend/app/services/pg_pubsub.py
@@ -124,6 +124,18 @@ async def _dispatch_received(payload_str: str) -> None:
     event_type = str(payload.get("event_type", ""))
     data = payload.get("data") or {}
 
+    # E-ARCH S2(story #2078): shadow-consume 비교 기준점 — 이 인스턴스가 LISTEN으로 받은
+    # 이벤트(=다른 인스턴스가 발행)의 도착 시각을 기록. ⚠️ 자기 자신이 발행한 이벤트는 위
+    # instance_id 체크로 이 지점 전에 return돼 기록되지 않는다 — shadow 비교에서 항상
+    # "redis-only"로 보일 수 있는 known 비대칭(관측용 근사치라 정합성 영향 없음, 의도적 축소범위).
+    broker_event_id = data.get("_broker_event_id")
+    if broker_event_id:
+        try:
+            from app.services.event_broker import record_pg_arrival
+            record_pg_arrival(broker_event_id)
+        except Exception:
+            pass
+
     try:
         from app.routers.events import publish_event, _push_to_agent
         if target == "org":

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -45,6 +45,11 @@ dependencies = [
     # 이어질 수 있어 검증된 라이브러리 사용.
     "cbor2>=5.6.0",
     "imagesize>=2.0.0",
+    # E-ARCH S2(story #2078): EventBroker dual-publish shadow(Redis/Memorystore, event_broker_redis_
+    # dual_publish_enabled default-off). rate_limiter.py의 RedisRateLimiter가 이미 `redis.asyncio`를
+    # lazy-import하고 있었는데 이 패키지가 선언돼 있지 않았다(rate_limit_backend가 항상 "memory"라
+    # 한 번도 실행 경로를 안 타 드러나지 않은 잠재 ImportError) — 이 선언이 그 갭도 같이 닫는다.
+    "redis>=5.0.0",
 ]
 
 [dependency-groups]

--- a/backend/tests/test_2078_event_broker.py
+++ b/backend/tests/test_2078_event_broker.py
@@ -1,0 +1,191 @@
+"""E-ARCH S2(story #2078): EventBroker dual-publish 회귀 가드.
+
+무회귀 우선순위 — `event_broker_redis_dual_publish_enabled`(default False) 상태에서 기존
+pg_notify 경로가 그대로 도는지, 켰을 때만 Redis 발행이 추가되는지를 검증한다. Memorystore가
+없어도 CI가 돌게 redis 클라이언트는 전부 mock — 실 Redis 연결은 만들지 않는다.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.services import event_broker as eb
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _reset_shadow_state():
+    eb._pg_arrivals.clear()
+    yield
+    eb._pg_arrivals.clear()
+
+
+def test_slim_org_payload_drops_content():
+    data = {
+        "entity_type": "story",
+        "entity_id": "s1",
+        "version": 3,
+        "content": "민감한 본문 — Redis org 채널엔 절대 안 나가야",
+    }
+    slim = eb._slim_org_payload(data)
+    assert slim == {"entity_type": "story", "entity_id": "s1", "version": 3}
+    assert "content" not in slim
+
+
+def test_redis_channel_naming():
+    assert eb._redis_channel("org", "org-1") == "org:org-1:invalidation"
+    assert eb._redis_channel("agent", "member-1") == "agent:member-1"
+
+
+@pytest.mark.anyio
+async def test_dual_publish_flag_off_only_calls_pg_notify(monkeypatch):
+    """default(off) — pg_notify만 불리고 redis publish는 아예 안 스케줄돼야."""
+    calls = []
+
+    async def _fake_pg_notify(target, target_id, event_type, data):
+        calls.append((target, target_id, event_type, data))
+
+    redis_calls = []
+
+    async def _fake_redis_publish(*args, **kwargs):
+        redis_calls.append((args, kwargs))
+
+    monkeypatch.setattr("app.services.pg_pubsub.pg_notify", _fake_pg_notify)
+    monkeypatch.setattr("app.services.event_broker._redis_publish", _fake_redis_publish)
+    monkeypatch.setattr(
+        "app.core.config.settings.event_broker_redis_dual_publish_enabled", False
+    )
+
+    broker = eb.DualPublishEventBroker()
+    await broker.publish("org", "org-1", "story.status_changed", {"foo": "bar"})
+
+    assert len(calls) == 1
+    assert calls[0][0] == "org"
+    assert calls[0][3]["_broker_event_id"]  # correlation id는 flag 무관 항상 부여
+    await asyncio.sleep(0)  # fire_and_forget 예약분(있다면) flush
+    assert redis_calls == []
+
+
+@pytest.mark.anyio
+async def test_dual_publish_flag_on_also_fires_redis(monkeypatch):
+    """켜져 있으면 pg_notify + redis publish(fire-and-forget) 둘 다 스케줄돼야."""
+    pg_calls = []
+    redis_calls = []
+
+    async def _fake_pg_notify(target, target_id, event_type, data):
+        pg_calls.append((target, target_id, event_type, data))
+
+    async def _fake_redis_publish(target, target_id, event_type, data, event_id):
+        redis_calls.append((target, target_id, event_type, data, event_id))
+
+    monkeypatch.setattr("app.services.pg_pubsub.pg_notify", _fake_pg_notify)
+    monkeypatch.setattr("app.services.event_broker._redis_publish", _fake_redis_publish)
+    monkeypatch.setattr(
+        "app.core.config.settings.event_broker_redis_dual_publish_enabled", True
+    )
+
+    broker = eb.DualPublishEventBroker()
+    await broker.publish("agent", "member-1", "task.assigned", {"task_id": "t1"})
+    await asyncio.sleep(0)  # fire_and_forget이 스케줄한 task 실행 대기
+
+    assert len(pg_calls) == 1
+    assert len(redis_calls) == 1
+    # 두 경로가 같은 event_id로 상관관계를 맺어야(shadow 비교의 전제조건)
+    pg_event_id = pg_calls[0][3]["_broker_event_id"]
+    redis_event_id = redis_calls[0][4]
+    assert pg_event_id == redis_event_id
+
+
+@pytest.mark.anyio
+async def test_redis_publish_skips_when_url_not_configured(monkeypatch, caplog):
+    """redis_url 미설정 — 예외 없이 경고 로그만(fail-safe, shadow 경로라 절대 안 죽어야)."""
+    monkeypatch.setattr("app.core.config.settings.redis_url", None)
+    with caplog.at_level("WARNING"):
+        await eb._redis_publish("org", "org-1", "x", {}, "evt-1")
+    assert "redis_url not configured" in caplog.text
+
+
+@pytest.mark.anyio
+async def test_redis_publish_failure_does_not_raise(monkeypatch):
+    """Redis client.publish가 던져도 shadow 경로는 예외를 삼켜야(pg_notify와 동형 철학)."""
+    monkeypatch.setattr("app.core.config.settings.redis_url", "redis://fake:6379/0")
+
+    class _BoomClient:
+        async def publish(self, *a, **kw):
+            raise ConnectionError("no memorystore")
+
+    monkeypatch.setattr(eb, "_get_redis_client", lambda: _BoomClient())
+    await eb._redis_publish("org", "org-1", "x", {"entity_type": "story"}, "evt-1")  # raise 안 해야
+
+
+def test_record_pg_arrival_bounds_memory():
+    """무한증가 방지 — 상한 도달 시 절반 정리."""
+    for i in range(eb._SHADOW_MAX_TRACKED + 100):
+        eb.record_pg_arrival(f"evt-{i}")
+    assert len(eb._pg_arrivals) <= eb._SHADOW_MAX_TRACKED
+
+
+def test_record_pg_arrival_ignores_empty_id():
+    eb.record_pg_arrival("")
+    assert eb._pg_arrivals == {}
+
+
+@pytest.mark.anyio
+async def test_shadow_consume_loop_returns_immediately_without_redis_url(monkeypatch):
+    """redis_url 없으면 무한루프에 안 들어가고 바로 return해야(테스트가 hang 안 함 자체가 증거)."""
+    monkeypatch.setattr("app.core.config.settings.redis_url", None)
+    await eb.redis_shadow_consume_loop()  # 타임아웃 없이 즉시 끝나야
+
+
+@pytest.mark.anyio
+async def test_dispatch_received_records_pg_arrival_for_broker_event(monkeypatch):
+    """pg_pubsub._dispatch_received가 _broker_event_id를 뽑아 record_pg_arrival을 호출해야."""
+    from app.services import pg_pubsub
+
+    recorded = []
+    monkeypatch.setattr(eb, "record_pg_arrival", lambda eid: recorded.append(eid))
+
+    async def _noop_publish_event(*a, **kw):
+        pass
+
+    import json
+
+    monkeypatch.setattr("app.routers.events.publish_event", lambda *a, **kw: None)
+    monkeypatch.setattr("app.routers.events._push_to_agent", lambda *a, **kw: True)
+
+    payload = {
+        "instance_id": "other-instance",
+        "target": "org",
+        "target_id": "org-1",
+        "event_type": "story.status_changed",
+        "data": {"_broker_event_id": "evt-xyz"},
+    }
+    await pg_pubsub._dispatch_received(json.dumps(payload))
+    assert recorded == ["evt-xyz"]
+
+
+@pytest.mark.anyio
+async def test_dispatch_received_skips_self_published_event(monkeypatch):
+    """자기 인스턴스가 발행한 이벤트는 instance_id 체크로 조기 return — record_pg_arrival 안 불려야
+    (known 비대칭 — docstring에 명시된 그대로 실증)."""
+    from app.services import pg_pubsub
+
+    recorded = []
+    monkeypatch.setattr(eb, "record_pg_arrival", lambda eid: recorded.append(eid))
+
+    import json
+
+    payload = {
+        "instance_id": pg_pubsub.INSTANCE_ID,
+        "target": "org",
+        "target_id": "org-1",
+        "event_type": "x",
+        "data": {"_broker_event_id": "evt-self"},
+    }
+    await pg_pubsub._dispatch_received(json.dumps(payload))
+    assert recorded == []

--- a/backend/tests/test_lifespan_engine_dispose_33e0c681.py
+++ b/backend/tests/test_lifespan_engine_dispose_33e0c681.py
@@ -165,3 +165,52 @@ async def test_lifespan_skips_check_listen_config_when_pg_listen_disabled(monkey
         await asyncio.sleep(0.05)
 
     assert called["n"] == 0, "PG_LISTEN_ENABLED=false인데 check_listen_config가 호출됨"
+
+
+@pytest.mark.anyio
+async def test_lifespan_skips_redis_shadow_task_by_default(monkeypatch):
+    """E-ARCH S2(story #2078): event_broker_redis_dual_publish_enabled default=False —
+    redis_shadow_consume_loop task 자체를 안 만든다(Memorystore 미배선 상태에서도 무해)."""
+    from app.main import lifespan
+
+    fake_engine = _patch_engine(monkeypatch)
+    monkeypatch.setattr("app.main.settings.event_broker_redis_dual_publish_enabled", False)
+
+    started = asyncio.Event()
+
+    async def fake_shadow_consume():
+        started.set()  # 호출되면 안 됨.
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr("app.services.event_broker.redis_shadow_consume_loop", fake_shadow_consume)
+
+    async with lifespan(MagicMock()):
+        await asyncio.sleep(0.05)
+        assert not started.is_set(), "flag off인데 redis_shadow_consume_loop가 시작됨"
+
+    fake_engine.dispose.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_lifespan_starts_redis_shadow_task_when_enabled(monkeypatch):
+    """flag on이면 redis_shadow_consume_loop task가 뜨고, shutdown 시 정상 cancel→dispose."""
+    from app.main import lifespan
+
+    fake_engine = _patch_engine(monkeypatch)
+    monkeypatch.setattr("app.main.settings.event_broker_redis_dual_publish_enabled", True)
+
+    started = asyncio.Event()
+
+    async def fake_shadow_consume():
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            return
+
+    monkeypatch.setattr("app.services.event_broker.redis_shadow_consume_loop", fake_shadow_consume)
+
+    async with lifespan(MagicMock()):
+        await asyncio.wait_for(started.wait(), timeout=1)
+
+    fake_engine.dispose.assert_awaited_once()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1648,6 +1648,15 @@ wheels = [
 ]
 
 [[package]]
+name = "redis"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c3/928b290c2c0ca99ab96eea5b4ff8f30be8112b075301a7d3ba214a3c8c12/redis-8.0.1.tar.gz", hash = "sha256:afc5a7a2f5a084f5b1880dec548dd45be17db7e43c82a30d84f952aefb05cfb0", size = 5114170, upload-time = "2026-06-23T14:52:37.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/0a/c2345ebf1ebe70840ce3f6c6ee612f8fa749cfbd1b03069c53bf0c62aaad/redis-8.0.1-py3-none-any.whl", hash = "sha256:47daa35a058c23468d6437f17a8c76882cb316b838ef763036af99b96cedd743", size = 502406, upload-time = "2026-06-23T14:52:36.137Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1852,6 +1861,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
+    { name = "redis" },
     { name = "resend" },
     { name = "slowapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -1893,6 +1903,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },
+    { name = "redis", specifier = ">=5.0.0" },
     { name = "resend", specifier = ">=2.0.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary
story #2078 — 오르테가군이 판정한 2단계 EventBroker 설계를 코드화. `EventBroker`(Protocol) 인터페이스 + `DualPublishEventBroker` 구현체로, 3단계에서 Redis-only 구현체로 교체 가능하도록 콜사이트(`events.py`)와 전송 계층을 분리했다.

## Details
- `events.py`의 `publish_event()`/`_push_to_agent()`에서 `pg_notify()` 직접 호출 → `event_broker.publish()`로 치환. `fire_and_forget` 래핑 방식은 무변경(GC 조기수거 방지 패턴 그대로 재사용)
- `event_broker_redis_dual_publish_enabled`(default **False**) — 꺼져 있으면 `pg_notify()` 호출 외 아무 동작도 안 함(무회귀, #2358 `PG_LISTEN_ENABLED`와 동일 컨벤션)
- **PG NOTIFY가 여전히 authoritative**(dispatch 유일 경로) — Redis는 realtime gateway의 shadow-consume 비교(지연Δ·중복률)용일 뿐, 유실돼도 정합성 영향 0. 근거: `agent_gateway.py`의 acked_seq DB 재조회 패턴과 동형(2026-07-21 세션 코드 교차검증 완료)
- org-wide Redis 채널(`org:{org_id}:invalidation`)은 처음부터 슬림 payload(`entity_type`/`entity_id`/`version`)만 — 민감 content 미포함(FE가 권한검증 REST로 재조회). 기존 PG NOTIFY 컨슈머는 안 건드림
- direct-agent Redis 채널(`agent:{member_id}`)은 기존 pg_notify agent target과 payload parity
- `redis` 패키지를 `pyproject.toml`에 명시 선언 — `rate_limiter.py`의 `RedisRateLimiter`가 이미 `redis.asyncio`를 lazy-import 중이었는데 미선언 상태였던 잠재 ImportError 갭도 같이 닫힘

## Out of scope (다음 조각)
- Memorystore 인스턴스 생성·`redis_url` 배선 — PO lane, E-ARCH 1단계 abort-0 실측 확인 후 진행
- PG NOTIFY 제거(3단계) — 안 건드림
- 기존 PG NOTIFY 컨슈머 payload 슬림화 — 안 건드림(Redis 신규 경로만 좁게)

## Test plan
- [x] 신규 `test_2078_event_broker.py`(11 tests) — flag on/off dual-publish 분기, redis_url 미설정 fail-safe, shadow 비교 event_id 상관관계, 메모리 상한, `_dispatch_received` self-skip 비대칭 실증
- [x] `test_lifespan_engine_dispose_33e0c681.py`에 shadow-consume task 게이팅 테스트 2건 추가(default off/on)
- [x] 로컬 `uv run pytest tests/ -m "not destructive_schema"` — 3557 passed, 7 failed(전부 라이브 dev MCP/로컬 config 의존·기존 실패, 이번 diff와 무관 확인)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)