### PR TITLE
chore(E-ARCH S1): api PG_LISTEN_ENABLED=false 배포 파이프라인 durable화

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -64,6 +64,11 @@ jobs:
             # prod에서 이 output으로 override, `backend_max_instances`와 동일 배선 패턴).
             echo "backend_timeout=300" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=G-RYHFE7XM3X" >> "$GITHUB_OUTPUT"
+            # story #2078(E-ARCH 1단계 durable화): prod api는 아직 true 유지 — prod는
+            # sprintable-realtime-prod가 없다(deploy-realtime 스텝이 prod에서 여전히 스킵
+            # 중). false로 먼저 못박으면 prod에 LISTEN 하는 서비스가 0개가 돼 실시간이
+            # 완전히 죽는다. prod가 realtime 배선을 마치는 승격 시점에 이 값을 false로 뒤집을 것.
+            echo "backend_pg_listen_enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
@@ -99,6 +104,10 @@ jobs:
             echo "realtime_max_instances=8" >> "$GITHUB_OUTPUT"
             echo "realtime_timeout=3600" >> "$GITHUB_OUTPUT"
             echo "realtime_url=https://sprintable-realtime-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
+            # story #2078(E-ARCH 1단계 durable화, 2026-07-21 PO 손 플립 확認 후): api는 SSE/LISTEN
+            # 을 realtime-dev로 넘겼다(까심군 raw SSE 검증 PASS). 손 gcloud 값은 다음 배포가
+            # 덮으니(오늘 규율) 여기 durable로 못박는다 — 다음 api 배포에서도 false 유지.
+            echo "backend_pg_listen_enabled=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Submit Cloud Build
@@ -106,6 +115,6 @@ jobs:
           gcloud builds submit \
             --config=cloudbuild.yaml \
             --project="${{ secrets.GCP_PROJECT_ID }}" \
-            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}",_BACKEND_MIN_INSTANCES="${{ steps.env.outputs.backend_min_instances }}",_BACKEND_MAX_INSTANCES="${{ steps.env.outputs.backend_max_instances }}",_BACKEND_TIMEOUT="${{ steps.env.outputs.backend_timeout }}",_GA4_MEASUREMENT_ID="${{ steps.env.outputs.ga4_measurement_id }}",_REALTIME_MIN_INSTANCES="${{ steps.env.outputs.realtime_min_instances }}",_REALTIME_MAX_INSTANCES="${{ steps.env.outputs.realtime_max_instances }}",_REALTIME_TIMEOUT="${{ steps.env.outputs.realtime_timeout }}",_REALTIME_URL="${{ steps.env.outputs.realtime_url }}" \
+            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}",_BACKEND_MIN_INSTANCES="${{ steps.env.outputs.backend_min_instances }}",_BACKEND_MAX_INSTANCES="${{ steps.env.outputs.backend_max_instances }}",_BACKEND_TIMEOUT="${{ steps.env.outputs.backend_timeout }}",_GA4_MEASUREMENT_ID="${{ steps.env.outputs.ga4_measurement_id }}",_REALTIME_MIN_INSTANCES="${{ steps.env.outputs.realtime_min_instances }}",_REALTIME_MAX_INSTANCES="${{ steps.env.outputs.realtime_max_instances }}",_REALTIME_TIMEOUT="${{ steps.env.outputs.realtime_timeout }}",_REALTIME_URL="${{ steps.env.outputs.realtime_url }}",_BACKEND_PG_LISTEN_ENABLED="${{ steps.env.outputs.backend_pg_listen_enabled }}" \
             --suppress-logs \
             .

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -52,6 +52,15 @@ substitutions:
   _REALTIME_TIMEOUT: '3600'
   _REALTIME_URL: https://sprintable-realtime-dev-787818285179.asia-northeast3.run.app
 
+  # E-ARCH 1단계 durable화 마지막 조각(story #2078, 2026-07-21 PO 손 플립 확認 후): api
+  # (sprintable-backend-*)의 PG_LISTEN_ENABLED. ⚠️ 기본값 'true' — prod는 아직
+  # sprintable-realtime-prod가 없다(deploy-realtime 스텝이 prod에서 스킵 중, PO 검증 전).
+  # prod api를 false로 먼저 못박으면 prod 승격 시점에 LISTEN 하는 서비스가 하나도 없어
+  # 실시간이 완전히 죽는 landmine이 된다 — 그래서 dev만 GHA에서 명시 override(false)하고
+  # prod는 이 fallback(true)을 그대로 상속해 오늘 이전과 동일 동작을 유지한다. prod가
+  # sprintable-realtime-prod 배선을 마치는 승격 시점에 GHA prod 분기에도 false를 명시할 것.
+  _BACKEND_PG_LISTEN_ENABLED: 'true'
+
 steps:
   # ─── Frontend (Next.js standalone) ────────────────────────────────────────
   - id: build-frontend
@@ -186,7 +195,9 @@ steps:
       # lingering env 가 config 기본을 덮는 것 방지). rollout 산식: 2×maxScale×(pool+overflow+pg_pubsub raw 1)
       # ≤ DB max_conn (dev maxScale 8: 2×8×5=80 · prod maxScale 5: 2×5×5=50+admin). 변경 시 cloud-build.yml
       # maxScale 와 짝으로 검토. (PO rev 01256 dev 429 right-size durable 화.)
-      - --update-env-vars=FASTAPI_URL=${_FASTAPI_URL},DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1
+      # E-ARCH 1단계(story #2078): PG_LISTEN_ENABLED durable화 — 위 _BACKEND_PG_LISTEN_ENABLED
+      # 주석 참조(dev=false·prod=true 유지, GHA per-env 배선).
+      - --update-env-vars=FASTAPI_URL=${_FASTAPI_URL},DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1,PG_LISTEN_ENABLED=${_BACKEND_PG_LISTEN_ENABLED}
       - --quiet
     # story dbda0baf: push-backend → run-migrate-job(위) 로 변경 — 신규 코드가 마이그 안 된
     # 스키마를 상대로 뜨는 걸 막는다(migrate 실패 시 이 스텝 자체가 안 돎).


### PR DESCRIPTION
## Summary
- story #2078 — PO가 까심군 raw SSE 검증 PASS 후 api(`sprintable-backend-dev`)에 `PG_LISTEN=false`를 손 gcloud로 건 것을 durable config로 편입. realtime durable(#2360)의 api판.
- 손 값은 다음 자동배포가 덮는다 — 이 PR 없이는 다음 develop 배포에서 api가 다시 LISTEN을 켜 커넥션 예산·SSE 이중화가 재발함.

## ⚠️ prod 안전장치
- prod api는 **여전히 `true` 유지** — prod는 `sprintable-realtime-prod`가 아직 없음(`deploy-realtime` 스텝이 prod에서 `_DEPLOY_ENV` 가드로 스킵 중, PO 검증 전).
- prod api를 먼저 `false`로 못박으면 prod 승격 시점에 LISTEN 하는 서비스가 0개가 돼 실시간이 완전히 죽는 landmine이 됨 — 그래서 `_BACKEND_MIN_INSTANCES`와 동일한 GHA per-env override 패턴(`_BACKEND_PG_LISTEN_ENABLED`)으로 dev만 `false`, prod는 fallback(`true`) 유지.
- prod가 `sprintable-realtime-prod` 배선을 마치는 승격 시점에 GHA prod 분기의 값을 `false`로 뒤집을 것(코드에 명시 주석).

## Test plan
- [x] `cloudbuild.yaml`, `.github/workflows/cloud-build.yml` YAML 파싱 검증(js-yaml)
- [x] dev/prod 분기 값 대조(dev=false·prod=true) — prod가 실시간 완전 정지되는 회귀 없음을 코드 리뷰로 확인
- [ ] CI green
- [ ] develop 머지 후 다음 dev 배포에서 api가 `PG_LISTEN_ENABLED=false`로 재현되는지 확인(PO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)