### PR TITLE
[SID:2076][긴급회귀 후속] 컨텍스트 칩 max-width 55vw→120px

### DIFF
--- a/apps/web/src/components/nav/context-switcher-chip.test.tsx
+++ b/apps/web/src/components/nav/context-switcher-chip.test.tsx
@@ -71,6 +71,20 @@ describe('ContextSwitcherChip — story #2076', () => {
     expect(trigger?.className).toContain('lg:hidden');
   });
 
+  it('긴급 fix(채팅 리스트 재현) — max-w가 뷰포트 비례(vw)가 아닌 고정 px 캡이다', async () => {
+    // max-w-[55vw]는 title+actions 있는 allowlist 화면(채팅·목표 등)에서 아이콘 클러스터와
+    // 합쳐 <1024 뷰포트를 82px 초과했다(실측, 2076 회귀 후속) — 고정 px 캡으로 되돌아가는
+    // 회귀를 막는다.
+    await act(async () => {
+      root.render(wrap(
+        <ContextSwitcherChip orgs={ORGS} currentOrgId="org-1" projects={PROJECTS} currentProjectId="proj-1" />,
+      ));
+    });
+    const trigger = container.querySelector('button');
+    expect(trigger?.className).not.toMatch(/max-w-\[\d+vw\]/);
+    expect(trigger?.className).toMatch(/max-w-\[\d+px\]/);
+  });
+
   it('칩을 탭하기 전에는 프로젝트 목록(바텀시트 내용)이 안 보인다', async () => {
     await act(async () => {
       root.render(wrap(

--- a/apps/web/src/components/nav/context-switcher-chip.tsx
+++ b/apps/web/src/components/nav/context-switcher-chip.tsx
@@ -61,7 +61,13 @@ export function ContextSwitcherChip({ orgs, currentOrgId, projects, currentProje
           type="button"
           onClick={() => s.setOpen(true)}
           disabled={s.pending}
-          className="flex min-w-0 max-w-[55vw] shrink-0 items-center gap-1.5 rounded-full border border-border bg-muted/40 py-1 pl-1.5 pr-2 text-left transition hover:bg-muted disabled:opacity-60 lg:hidden"
+          // 긴급 fix(2076 회귀 후속, 채팅 리스트 재현) — max-w-[55vw]가 title/actions 있는
+          // allowlist 화면(채팅·목표 등)에서 여전히 과도했다. 실측(390px 기준): chip(55vw=
+          // 214px)+actions버튼(~90px)+아이콘클러스터(~110px)+padding/gap(~48px)=472px로
+          // 뷰포트를 82px 초과한다(title이 min-w-0로 0까지 줄어도 나머지가 이미 초과) —
+          // "칩이 다른 UI를 뭉갠다"는 실측 그 자체. 120px 고정 캡으로 최악 시나리오를
+          // 378px까지 낮춘다(390px 뷰포트 기준 여유 확보, iPhone SE 375px도 안전).
+          className="flex min-w-0 max-w-[120px] shrink-0 items-center gap-1.5 rounded-full border border-border bg-muted/40 py-1 pl-1.5 pr-2 text-left transition hover:bg-muted disabled:opacity-60 lg:hidden"
           aria-label={t('switcherMobileTriggerAria')}
         >
           <OrgInitial name={s.displayOrg} />


### PR DESCRIPTION
#2362(상세 화면 칩 숨김) 배포 후에도 채팅 리스트(chats/page.tsx)에서 UI가 여전히 뭉개짐. #2362는 "숨길지 켤지"만 다뤘고, "켜졌을 때 칩 자체의 폭"은 #2354부터 한 번도 고쳐진 적이 없었다 — 이번이 그 근본.

## 실측(390px 뷰포트 기준)
```
chip(max-w-55vw)        최대 214px
actions 버튼("새 대화")   ~90px
아이콘 클러스터(3개)      ~110px
padding+gap              ~48px
합계                      ~462px  ← 390px 뷰포트를 72px+ 초과
```
title은 `min-w-0 flex-1`라 0까지 줄어들지만 나머지만으로 이미 초과 — actions 버튼이 있는 allowlist 화면(채팅·목표·스프린트·모업·회고 등 다수) 전반이 구조적으로 같은 위험을 안고 있었다. board-client.tsx처럼 actions 없는 화면은 그만큼 여유가 있어 안 뭉갰을 뿐.

## 수정
`max-w-[55vw]` → `max-w-[120px]`(뷰포트 비례 → 고정 캡). 최악 시나리오를 378px까지 낮춰 390px(iPhone SE 375px 포함)에서 여유 확보. 라벨은 이미 `truncate` 처리돼 있어 짧아져도 말줄임표로 축약된다.

## 검증
`context-switcher-chip.test.tsx` 신규 케이스(고정 px 캡·vw 회귀 방지) + 기존 4케이스 통과. type-check/lint(0 errors)/build(EXIT 0)/vitest 전체(290파일·1994개) green.

## 미완 — 라이브
배포되면 채팅 리스트가 더 이상 안 뭉개지는지 확認 대상.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>