### PR TITLE
fix(story #2078): Settings.redis_url 중복 선언 제거 — 필드 shadowing 핫픽스

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -95,7 +95,7 @@ class Settings(BaseSettings):
     # gateway의 shadow-consume 비교용(지연·중복률 측정)이라 유실돼도 정합성 영향 0
     # (agent_gateway.py의 acked_seq DB 재조회 패턴과 동형 근거 — 오늘 세션 교차검증 완료).
     event_broker_redis_dual_publish_enabled: bool = False
-    redis_url: str | None = None  # Memorystore 연결 문자열. flag on인데 None이면 경고 로그만(fail-safe).
+    redis_url: str | None = None  # Memorystore 연결 문자열(공유 — event_broker + RedisRateLimiter). flag on인데 None이면 경고 로그만(fail-safe).
 
     # E-L2 휴리스틱 트리거 워커. default-off — 명시 활성화 전엔 lifespan task 미생성(무동작).
     # advisory_lock=on이면 멀티인스턴스 중 pg_try_advisory_lock holder 1개만 poll/evaluate.
@@ -171,7 +171,15 @@ class Settings(BaseSettings):
 
     # Rate limiting (E-OA1:S5)
     rate_limit_backend: str = "memory"  # "memory" | "redis"
-    redis_url: str = "redis://localhost:6379/0"
+    # ⚠️ story #2078 핫픽스(2026-07-21, Memorystore 배선 직전 PO가 발견): 이 필드가 원래 여기
+    # `str = "redis://localhost:6379/0"`로 별도 선언돼 있었다 — event_broker용 `redis_url`
+    # (위 line 98, `str | None = None`)과 이름이 같아 파이썬 클래스 바디에서 나중 선언이 이겼다
+    # (Pydantic 필드 shadowing). 실제 `settings.redis_url` 기본값은 이 truthy localhost
+    # 문자열이었고, event_broker.py의 "None이면 fail-safe skip" 체크가 여기 가려져 한 번도
+    # 안 걸렸다(PR #2363에서 신설한 필드가 죽어있던 상태). 단일 필드로 통합 — event_broker와
+    # RedisRateLimiter가 같은 Memorystore 인스턴스 하나를 봐야 맞고, rate_limit_backend="redis"
+    # 인데 redis_url이 None이면 aioredis.from_url(None)이 명시적으로 실패하는 게 조용한
+    # localhost 오접속보다 낫다.
 
     # E-AUTH-REBUILD M2 Phase 1(story b07ad526·doc firebase-auth-identity-platform-migration-poc
     # §10.1): Firebase Auth/Identity Platform 이행 플래그. 전부 default off — Phase 1 스키마+검증기

--- a/backend/tests/test_2078_no_duplicate_settings_fields.py
+++ b/backend/tests/test_2078_no_duplicate_settings_fields.py
@@ -1,0 +1,32 @@
+"""story #2078 핫픽스 회귀 가드: `Settings` 클래스에 같은 필드명이 두 번 선언되면 파이썬
+클래스 바디에서 나중 선언이 조용히 이긴다(필드 shadowing) — `redis_url`이 정확히 이 패턴으로
+`event_broker`용 `None` 기본값이 `RedisRateLimiter`용 `"redis://localhost:6379/0"`에 가려져,
+Memorystore 배선 전까지 아무도 못 알아챘다. 정적 grep으로 재발을 원천 차단한다.
+"""
+from __future__ import annotations
+
+import ast
+from collections import Counter
+from pathlib import Path
+
+_CONFIG_PATH = Path(__file__).parent.parent / "app" / "core" / "config.py"
+
+
+def _settings_field_names() -> list[str]:
+    tree = ast.parse(_CONFIG_PATH.read_text())
+    names = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "Settings":
+            for stmt in node.body:
+                if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                    names.append(stmt.target.id)
+    return names
+
+
+def test_settings_has_no_duplicate_field_declarations():
+    names = _settings_field_names()
+    assert names, "Settings 클래스에서 필드를 하나도 못 찾았다 — 파서/경로 확인 필요"
+    dupes = {name: count for name, count in Counter(names).items() if count > 1}
+    assert not dupes, (
+        f"Settings에 중복 선언된 필드 발견 — 나중 선언이 조용히 앞 선언을 가린다(story #2078 재발): {dupes}"
+    )


### PR DESCRIPTION
## Summary
- PR #2363에서 신설한 `event_broker`용 `redis_url`(`str | None = None`)이, 이미 존재하던 `RedisRateLimiter`용 `redis_url`(`str = "redis://localhost:6379/0"`)과 이름이 겹쳐 파이썬 클래스 바디 필드 shadowing으로 조용히 가려졌다.
- 실제 `settings.redis_url` 기본값은 truthy `"redis://localhost:6379/0"`였다 — `event_broker.py`의 "redis_url 없으면 fail-safe skip" 체크가 한 번도 안 걸렸을 상태.
- Memorystore 배선 착수 직전 PO가 `config.py`를 다시 확인하다 두 곳 다른 default를 보고 질문 → 실물 대조로 확정.

## Fix
- 단일 `redis_url: str | None = None` 필드로 통합(line 98 유지, line 174 중복 제거).
- `event_broker`와 `RedisRateLimiter`가 같은 Memorystore 인스턴스 하나를 공유(별도 Redis 두 개 배선할 이유 없음).
- 재발 방지: `Settings` 클래스 필드 중복 선언을 AST로 정적 검사하는 회귀 가드 추가(`test_2078_no_duplicate_settings_fields.py`) — 사전 상태로 되돌려 실제로 fail하는 것 확인.

## Test plan
- [x] `Settings()` 인스턴스화 → `redis_url is None` 확인
- [x] 신규 가드 테스트가 버그 재현 시 fail, 수정 후 pass 확인(왕복 검증)
- [x] `test_2078_event_broker.py` 11건 전부 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)