### PR TITLE
feat(E-ARCH S3): 트랜잭셔널 아웃박스 3a단계 스캐폴딩

### DIFF
--- a/backend/alembic/versions/0205_event_outbox_table.py
+++ b/backend/alembic/versions/0205_event_outbox_table.py
@@ -1,0 +1,46 @@
+"""E-ARCH S3(story #2078) 3a단계 — 트랜잭셔널 아웃박스 스캐폴딩 테이블. `EventBroker` 콜사이트
+(publish_event()/_push_to_agent(), 10파일 20곳)의 payload를 durable하게 적재해 realtime-gateway의
+outbox_dispatcher_loop()가 Redis로 폴링·발행한다. 이 단계에서는 아직 caller의 commit과 같은
+트랜잭션이 아니다(3b에서 콜사이트별 이관 예정) — 지금은 "재시도 가능한 큐"만 얻는다.
+
+Revision ID: 0205
+Revises: 0204
+Create Date: 2026-07-21
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0205"
+down_revision = "0204"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "event_outbox",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("target", sa.Text(), nullable=False),
+        sa.Column("target_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("event_type", sa.Text(), nullable=False),
+        sa.Column("payload", postgresql.JSONB(), nullable=False, server_default="{}"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("published_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint("target IN ('org', 'agent')", name="ck_event_outbox_target"),
+    )
+    op.create_index("ix_event_outbox_org_id", "event_outbox", ["org_id"])
+    # dispatcher 폴링 축 — published_at IS NULL 부분 인덱스(unpublished row는 항상 소수).
+    op.create_index(
+        "ix_event_outbox_pending", "event_outbox", ["id"],
+        postgresql_where=sa.text("published_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_event_outbox_pending", table_name="event_outbox")
+    op.drop_index("ix_event_outbox_org_id", table_name="event_outbox")
+    op.drop_table("event_outbox")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -97,6 +97,13 @@ class Settings(BaseSettings):
     event_broker_redis_dual_publish_enabled: bool = False
     redis_url: str | None = None  # Memorystore 연결 문자열(공유 — event_broker + RedisRateLimiter). flag on인데 None이면 경고 로그만(fail-safe).
 
+    # E-ARCH S3(story #2078) 3a단계: `event_outbox` row insert를 EventBroker.publish()에 추가로
+    # 얹는다(호출 타이밍은 안 바뀜 — 여전히 caller commit 이후, 별도 짧은 트랜잭션이라 아직 진짜
+    # atomic outbox는 아님). default=False(무회귀) — 켜지기 전엔 OutboxEventBroker가 inner
+    # (DualPublishEventBroker) 동작만 그대로 위임한다. outbox_dispatcher_loop 도 이 플래그로
+    # 게이트(꺼져 있으면 realtime gateway에서 폴링 task 자체를 안 만든다).
+    event_broker_outbox_enabled: bool = False
+
     # E-L2 휴리스틱 트리거 워커. default-off — 명시 활성화 전엔 lifespan task 미생성(무동작).
     # advisory_lock=on이면 멀티인스턴스 중 pg_try_advisory_lock holder 1개만 poll/evaluate.
     l2_trigger_enabled: bool = False

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -56,6 +56,15 @@ async def lifespan(app: FastAPI):
         from app.services.event_broker import redis_shadow_consume_loop
 
         redis_shadow_task = asyncio.create_task(redis_shadow_consume_loop())
+    # E-ARCH S3(story #2078) 3a단계: outbox dispatcher는 event_broker_outbox_enabled(default
+    # False)일 때만 task 생성 — 꺼져 있으면 event_outbox row 자체가 안 쌓이니(OutboxEventBroker
+    # 가 insert를 스킵) 폴링할 게 없다. redis_shadow_task와 별개 게이트(outbox insert가 켜졌다고
+    # 즉시 dual-publish shadow까지 켜지는 건 아니다 — 두 플래그는 독립적으로 rollout 가능).
+    outbox_dispatcher_task = None
+    if settings.event_broker_outbox_enabled:
+        from app.services.event_broker import outbox_dispatcher_loop
+
+        outbox_dispatcher_task = asyncio.create_task(outbox_dispatcher_loop())
     try:
         yield
     finally:
@@ -65,6 +74,8 @@ async def lifespan(app: FastAPI):
             l2_task.cancel()
         if redis_shadow_task is not None:
             redis_shadow_task.cancel()
+        if outbox_dispatcher_task is not None:
+            outbox_dispatcher_task.cancel()
         try:
             if task is not None:
                 try:
@@ -79,6 +90,11 @@ async def lifespan(app: FastAPI):
             if redis_shadow_task is not None:
                 try:
                     await redis_shadow_task
+                except asyncio.CancelledError:
+                    pass
+            if outbox_dispatcher_task is not None:
+                try:
+                    await outbox_dispatcher_task
                 except asyncio.CancelledError:
                     pass
         finally:

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -15,6 +15,7 @@ from app.models.device_installation import DeviceInstallation, DeviceProofChalle
 from app.models.entity_slug_history import EntitySlugHistory
 from app.models.embedding import Embedding
 from app.models.evidence import Evidence
+from app.models.event_outbox import EventOutbox
 from app.models.gate import Gate
 from app.models.github_installation import GithubInstallation, GithubInstallNonce, GithubWebhookDelivery
 from app.models.hitl import HitlPolicy, HitlRequest
@@ -103,6 +104,7 @@ __all__ = [
     "BridgeChannelMapping",
     "BridgeUserMapping",
     "Embedding",
+    "EventOutbox",
     "Gate",
     "GithubInstallation",
     "GithubInstallNonce",

--- a/backend/app/models/event_outbox.py
+++ b/backend/app/models/event_outbox.py
@@ -1,0 +1,38 @@
+"""E-ARCH S3(story #2078): 트랜잭셔널 아웃박스 스캐폴딩.
+
+3a단계(현재) — `EventBroker` 호출부(20곳, 전부 `session.commit()` 이후 fire-and-forget)의
+타이밍은 그대로 두고, `event_outbox` row insert만 얹어 durable·재시도 가능한 큐를 얻는다.
+아직 진짜 atomic outbox는 아니다(insert가 caller의 commit과 별 트랜잭션) — 3b단계에서
+콜사이트를 "커밋 전 insert"로 하나씩 이관해야 진짜 원자성이 선다(설계 문서 참조).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Index, Text, func, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class EventOutbox(Base):
+    __tablename__ = "event_outbox"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    target: Mapped[str] = mapped_column(Text, nullable=False)  # "org" | "agent"
+    target_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    event_type: Mapped[str] = mapped_column(Text, nullable=False)
+    payload: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        # dispatcher 폴링 축 — published_at IS NULL 부분 인덱스(대부분 즉시 pending→published라
+        # 실제 unpublished row는 항상 소수, 부분 인덱스로 스캔 비용 최소화).
+        Index("ix_event_outbox_pending", "id", postgresql_where=text("published_at IS NULL")),
+    )

--- a/backend/app/services/event_broker.py
+++ b/backend/app/services/event_broker.py
@@ -110,7 +110,110 @@ class DualPublishEventBroker:
             fire_and_forget(_redis_publish(target, target_id, event_type, data, event_id))
 
 
-event_broker: EventBroker = DualPublishEventBroker()
+async def _resolve_org_id(target: Literal["org", "agent"], target_id: str, data: dict) -> uuid.UUID | None:
+    """outbox row의 org_id(NOT NULL) 확보 — 우선순위: (1) payload에 이미 있으면 그대로
+    (org-target 대부분이 여기 해당) (2) agent-target은 payload에 org_id가 없는 경우가 많아
+    member 조회 — #2075(story #2075 owner SSE parity)에서 확立된 대로 member_id 축이
+    `team_members.id`뿐 아니라 grant-only 휴먼은 `org_members.id`로도 해소되므로 UNION 조회.
+    둘 다 실패하면 None(호출부가 skip+경고 로그, outbox insert는 best-effort라 예외 전파 금지)."""
+    if target == "org":
+        try:
+            return uuid.UUID(target_id)
+        except ValueError:
+            pass
+
+    raw = data.get("org_id")
+    if raw:
+        try:
+            return uuid.UUID(str(raw))
+        except ValueError:
+            pass
+
+    try:
+        from sqlalchemy import text as _sa_text
+
+        from app.core.database import async_session_factory
+
+        async with async_session_factory() as session:
+            row = (
+                await session.execute(
+                    _sa_text(
+                        "SELECT org_id FROM team_members WHERE id = :tid "
+                        "UNION SELECT org_id FROM org_members WHERE id = :tid LIMIT 1"
+                    ),
+                    {"tid": target_id},
+                )
+            ).first()
+            return row[0] if row else None
+    except Exception as exc:
+        logger.warning("event_broker org_id resolve failed target_id=%s: %s", target_id, exc)
+        return None
+
+
+async def _insert_outbox_row(
+    target: Literal["org", "agent"], target_id: str, event_type: str, data: dict
+) -> None:
+    """event_outbox row insert — best-effort(별도 짧은 트랜잭션, caller의 commit과 atomic 아님).
+
+    3a단계 스코프: 실패해도 예외를 삼킨다(경고 로그만) — outbox가 아직 dispatch의 유일 경로가
+    아니라(PG NOTIFY가 여전히 authoritative) insert 실패가 실시간 전달 자체를 막으면 안 된다.
+    """
+    org_id = await _resolve_org_id(target, target_id, data)
+    if org_id is None:
+        logger.warning(
+            "event_broker outbox insert skipped (org_id unresolved) target=%s target_id=%s event_type=%s",
+            target, target_id, event_type,
+        )
+        return
+
+    try:
+        from app.core.database import async_session_factory
+        from app.models.event_outbox import EventOutbox
+
+        async with async_session_factory() as session:
+            session.add(
+                EventOutbox(
+                    org_id=org_id,
+                    target=target,
+                    target_id=uuid.UUID(target_id),
+                    event_type=event_type,
+                    payload=data,
+                )
+            )
+            await session.commit()
+    except Exception as exc:
+        logger.warning(
+            "event_broker outbox insert failed target=%s target_id=%s: %s", target, target_id, exc
+        )
+
+
+class OutboxEventBroker:
+    """E-ARCH S3 3a단계 구현체 — `DualPublishEventBroker`(PG NOTIFY+Redis shadow) 위에
+    `event_outbox` row insert만 추가한다. 호출 타이밍은 3a에서 바뀌지 않는다(여전히 caller
+    commit 이후) — 3b에서 콜사이트가 db 세션을 넘기게 되면 이 클래스의 publish 시그니처를
+    확장해 진짜 atomic insert로 바꿀 것(지금은 조기 확장 금지).
+
+    `event_broker_outbox_enabled`(default False)로 게이트 — 꺼져 있으면 inner(2단계) 동작만
+    그대로, insert 자체가 아예 시도되지 않는다(무회귀).
+    """
+
+    def __init__(self, inner: EventBroker | None = None):
+        self._inner = inner or DualPublishEventBroker()
+
+    async def publish(
+        self, target: Literal["org", "agent"], target_id: str, event_type: str, data: dict
+    ) -> None:
+        await self._inner.publish(target, target_id, event_type, data)
+
+        from app.core.config import settings
+
+        if settings.event_broker_outbox_enabled:
+            await _insert_outbox_row(target, target_id, event_type, data)
+
+
+# events.py 콜사이트가 참조하는 싱글턴 — OutboxEventBroker가 DualPublishEventBroker(2단계)를
+# 감싸는 형태라 콜사이트 변경 없이 3a가 얹힌다(event_broker_outbox_enabled=False면 완전 무회귀).
+event_broker: EventBroker = OutboxEventBroker()
 
 
 # ─── Shadow-consume 비교 (realtime gateway 전용) ──────────────────────────────
@@ -187,3 +290,88 @@ async def redis_shadow_consume_loop() -> None:
                     await pubsub.close()
                 except Exception:
                     pass
+
+
+# ─── Outbox dispatcher (realtime gateway 전용, event_broker_outbox_enabled 게이트) ────────
+
+_OUTBOX_BATCH_SIZE = 50
+_OUTBOX_POLL_INTERVAL = 1.0
+
+
+async def outbox_dispatcher_loop() -> None:
+    """`event_outbox`의 미발행 row를 폴링해 Redis로 발행 — 3a단계 dispatcher.
+
+    `FOR UPDATE SKIP LOCKED`로 멀티인스턴스 동시 폴링 시 중복발행을 방지한다(표준 outbox
+    패턴). listen_loop()/redis_shadow_consume_loop()와 동형 에러 backoff(1s→2s→...→30s) —
+    정상 시엔 고정 폴링 간격(`_OUTBOX_POLL_INTERVAL`)으로 반복한다.
+
+    ⚠️ `event_broker_redis_dual_publish_enabled`와 `event_broker_outbox_enabled`를 동시에
+    켜면 같은 논리적 이벤트가 Redis에 두 번(즉시 shadow-publish + 나중 outbox dispatch) 발행될
+    수 있다 — 서로 다른 `_broker_event_id`를 쓰기 때문에(즉시 경로는 uuid4, outbox 경로는
+    row.id) dedup도 안 된다. 의도된 설계다: outbox는 dual-publish를 **대체**하는 것이지
+    병행하는 게 아니다(오르테가군 시퀀싱 — dual-publish→shadow-consume→outbox 전환→LISTEN
+    제거는 순차, 동시 아님). 두 플래그를 동시에 켜는 것은 3b 전환 실험 용도가 아니면 피할 것.
+    """
+    import json
+    from datetime import datetime, timezone
+
+    from sqlalchemy import select
+
+    from app.core.config import settings
+    from app.core.database import async_session_factory
+    from app.models.event_outbox import EventOutbox
+
+    if not settings.redis_url:
+        logger.warning("event_broker outbox dispatcher skipped: redis_url not configured")
+        return
+
+    delay = 1.0
+    logger.info("event_broker outbox dispatcher starting")
+
+    while True:
+        try:
+            async with async_session_factory() as session:
+                rows = (
+                    await session.execute(
+                        select(EventOutbox)
+                        .where(EventOutbox.published_at.is_(None))
+                        .order_by(EventOutbox.id)
+                        .limit(_OUTBOX_BATCH_SIZE)
+                        .with_for_update(skip_locked=True)
+                    )
+                ).scalars().all()
+
+                if not rows:
+                    await session.commit()
+                    await asyncio.sleep(_OUTBOX_POLL_INTERVAL)
+                    continue
+
+                client = _get_redis_client()
+                now = datetime.now(timezone.utc)
+                for row in rows:
+                    payload = _slim_org_payload(row.payload) if row.target == "org" else dict(row.payload)
+                    payload["event_type"] = row.event_type
+                    payload["_broker_event_id"] = str(row.id)
+                    try:
+                        await client.publish(
+                            _redis_channel(row.target, str(row.target_id)),
+                            json.dumps(payload, default=str),
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "event_broker outbox dispatch publish failed id=%s: %s", row.id, exc
+                        )
+                        continue  # published_at 미갱신 — 다음 폴링에서 재시도(at-least-once)
+                    row.published_at = now
+
+                await session.commit()
+            delay = 1.0
+        except asyncio.CancelledError:
+            logger.info("event_broker outbox dispatcher cancelled — shutting down")
+            break
+        except Exception as exc:
+            logger.warning(
+                "event_broker outbox dispatcher error: %s — retrying in %.1fs", exc, delay
+            )
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, 30)

--- a/backend/tests/test_2078_event_outbox_realdb.py
+++ b/backend/tests/test_2078_event_outbox_realdb.py
@@ -1,0 +1,231 @@
+"""E-ARCH S3(story #2078) 3a단계 — event_outbox 실DB 통합 테스트.
+
+`_resolve_org_id`(team_members/org_members UNION 조회)·`_insert_outbox_row`·
+`outbox_dispatcher_loop`(FOR UPDATE SKIP LOCKED 폴링→발행→published_at 마킹)은 실 SQL 문법과
+JSONB/UUID 타입에 의존해 SQLite/mock으로는 검증 불가능하다 — 실 PG 필요.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# realdb 섹션이 Base.metadata.create_all을 호출한다 — conftest.py AST 가드(story 8236bbc3) 대응.
+pytestmark = pytest.mark.destructive_schema
+
+_REAL_DB_SKIP = pytest.mark.skipif(
+    not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    import app.models  # noqa: F401 — 전 모델 메타데이터 로드
+    from app.core.database import Base
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_member(Session):
+    """org_members에 휴먼 하나 시드 — grant-only(team_members 행 없음) 케이스를 정확히 재현.
+    org_id/user_id에 FK가 없어(project.py:44-45) Organization/User 시드 불요."""
+    from app.models.project import OrgMember
+
+    org_id = uuid.uuid4()
+    member_id = uuid.uuid4()
+    async with Session() as s:
+        s.add(OrgMember(id=member_id, org_id=org_id, user_id=uuid.uuid4(), role="member"))
+        await s.commit()
+    return org_id, member_id
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_resolve_org_id_org_target_returns_target_id_directly(monkeypatch):
+    from app.services.event_broker import _resolve_org_id
+
+    org_id = uuid.uuid4()
+    resolved = await _resolve_org_id("org", str(org_id), {})
+    assert resolved == org_id
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_resolve_org_id_agent_target_prefers_payload_org_id():
+    from app.services.event_broker import _resolve_org_id
+
+    org_id = uuid.uuid4()
+    resolved = await _resolve_org_id("agent", str(uuid.uuid4()), {"org_id": str(org_id)})
+    assert resolved == org_id
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_resolve_org_id_agent_target_falls_back_to_org_members_lookup(monkeypatch):
+    """#2075(org owner SSE parity)와 동일 근거 — grant-only 휴먼은 team_members 행이 없고
+    org_members.id로만 신원이 해소된다. UNION 조회가 이 케이스를 잡아야 한다."""
+    from app.core.database import Base
+    from app.services import event_broker as eb
+
+    engine, Session = await _session_factory()
+    monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    try:
+        org_id, member_id = await _seed_org_member(Session)
+        resolved = await eb._resolve_org_id("agent", str(member_id), {})
+        assert resolved == org_id
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_resolve_org_id_unresolvable_returns_none(monkeypatch):
+    from app.core.database import Base
+    from app.services import event_broker as eb
+
+    engine, Session = await _session_factory()
+    monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    try:
+        resolved = await eb._resolve_org_id("agent", str(uuid.uuid4()), {})
+        assert resolved is None
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_insert_outbox_row_creates_pending_row(monkeypatch):
+    from sqlalchemy import select
+
+    from app.core.database import Base
+    from app.models.event_outbox import EventOutbox
+    from app.services import event_broker as eb
+
+    engine, Session = await _session_factory()
+    monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    try:
+        org_id = uuid.uuid4()
+        await eb._insert_outbox_row("org", str(org_id), "story.status_changed", {"entity_id": "s1"})
+
+        async with Session() as s:
+            rows = (await s.execute(select(EventOutbox))).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].org_id == org_id
+        assert rows[0].target == "org"
+        assert rows[0].published_at is None
+        assert rows[0].payload == {"entity_id": "s1"}
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_insert_outbox_row_skips_silently_when_org_id_unresolvable(monkeypatch):
+    """best-effort 철학 — org_id 못 찾아도 예외 안 던지고 조용히 skip(경고 로그만)."""
+    from sqlalchemy import select
+
+    from app.core.database import Base
+    from app.models.event_outbox import EventOutbox
+    from app.services import event_broker as eb
+
+    engine, Session = await _session_factory()
+    monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    try:
+        await eb._insert_outbox_row("agent", str(uuid.uuid4()), "x", {})  # raise 안 해야
+        async with Session() as s:
+            rows = (await s.execute(select(EventOutbox))).scalars().all()
+        assert rows == []
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_outbox_dispatcher_publishes_pending_rows_and_marks_published(monkeypatch):
+    """dispatcher가 pending row를 Redis publish하고 published_at을 마킹하는지 — 실 SQL(FOR
+    UPDATE SKIP LOCKED·published_at IS NULL 필터) 검증. 1회전만 돌리고 즉시 취소."""
+    import asyncio
+
+    from sqlalchemy import select
+
+    from app.core.database import Base
+    from app.models.event_outbox import EventOutbox
+    from app.services import event_broker as eb
+
+    engine, Session = await _session_factory()
+    monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    monkeypatch.setattr("app.core.config.settings.redis_url", "redis://fake:6379/0")
+
+    published = []
+    fake_client = AsyncMock()
+
+    async def _fake_publish(channel, payload):
+        published.append((channel, payload))
+
+    fake_client.publish = _fake_publish
+    monkeypatch.setattr(eb, "_get_redis_client", lambda: fake_client)
+
+    org_id = uuid.uuid4()
+    try:
+        async with Session() as s:
+            s.add(EventOutbox(org_id=org_id, target="org", target_id=org_id, event_type="x", payload={}))
+            await s.commit()
+
+        task = asyncio.create_task(eb.outbox_dispatcher_loop())
+        for _ in range(50):  # 최대 ~0.5s 대기 — dispatcher가 첫 배치를 처리할 때까지
+            await asyncio.sleep(0.01)
+            if published:
+                break
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        assert len(published) == 1
+
+        async with Session() as s:
+            rows = (await s.execute(select(EventOutbox))).scalars().all()
+        assert rows[0].published_at is not None
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_outbox_dispatcher_skips_immediately_without_redis_url(monkeypatch):
+    from app.services import event_broker as eb
+
+    monkeypatch.setattr("app.core.config.settings.redis_url", None)
+    await eb.outbox_dispatcher_loop()  # 타임아웃 없이 즉시 끝나야


### PR DESCRIPTION
## Summary
story #2078 — E-ARCH 3단계(transactional outbox + PG LISTEN 제거) 3a단계. `publish_event()`/`_push_to_agent()` 콜사이트(10파일 20곳, 전부 `session.commit()` 이후 fire-and-forget — 실측 완료)를 한 번에 재배선하는 대수술 대신, 안전한 절개선으로 쪼갠 첫 조각.

## Details
- `event_outbox` 테이블 신설(migration 0205) — `id, org_id, target, target_id, event_type, payload, created_at, published_at`
- `OutboxEventBroker`(`EventBroker` 인터페이스 구현체) — `DualPublishEventBroker`(2단계)를 감싸 outbox row insert만 추가. **호출 타이밍은 안 바뀜**(여전히 caller commit 이후, 별도 짧은 트랜잭션) — 아직 진짜 atomic outbox는 아님
- `outbox_dispatcher_loop()` — realtime gateway에서 `FOR UPDATE SKIP LOCKED`로 폴링 → Redis 발행 → `published_at` 마킹(at-least-once, 멀티인스턴스 중복발행 방지)
- `event_broker_outbox_enabled`(default **False**) — 꺼져 있으면 `OutboxEventBroker`가 inner(2단계) 동작만 위임, insert 자체가 시도되지 않는다(무회귀, #2358/#2363과 동일 컨벤션)
- org_id 해소는 **#2075(owner SSE parity)에서 확립된 `team_members`/`org_members` UNION 조회 재사용** — grant-only 휴먼의 member_id가 `org_members.id`로만 해소되는 identity-space 갭을 outbox 쪽에서도 놓치지 않음(agent-target payload는 대부분 org_id를 안 담고 있어 필요)

## ⚠️ 3a는 진짜 atomic이 아님 — 3b가 후속
- insert가 caller의 `commit()`과 별 트랜잭션이라, 그 사이 크래시하면 event 유실 가능성이 남음(오늘 fire-and-forget보다는 훨씬 나음)
- 3b단계: 20개 콜사이트를 `db` 세션 넘겨받아 "커밋 전 insert"로 하나씩 이관(state 변경과 같은 txn) → 전부 이관 확인 후 `pg_pubsub.py`(listen_loop·pg_notify·`PG_LISTEN_ENABLED`) 완전 제거

## Test plan
- [x] realdb 테스트 8건(신규 `test_2078_event_outbox_realdb.py`) — org_id 해소 3분기(org target/agent payload내/agent UNION 조회)·insert 성공/스킵·dispatcher 발행+마킹(1회전 실행→취소)·redis_url 미설정 즉시 skip — 로컬 PG로 검증
- [x] migration 0205 로컬 PG(`alembic upgrade heads`) 왕복 검증 — `\d event_outbox` 구조 대조
- [x] 기존 event_broker/lifespan/fire-and-forget 가드 테스트 전부 pass(28건 합산)
- [x] rebase 후 전체 재검증(config.py 머지 충돌 해소 확인)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)