### PR TITLE
fix(story #2082): artifact_canonicalize 게이트가 project-owner 인박스에서 누락

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -15,6 +15,7 @@ from app.models.doc import Doc
 from app.models.gate import Gate, is_valid_transition
 from app.models.hitl import HitlRequest
 from app.models.pm import Story, Task
+from app.models.visual_artifact import VisualArtifact
 from app.routers.agent_gateway import wake_agent
 from app.services.gate_service import (
     RiskGrade,
@@ -373,6 +374,12 @@ async def list_gates(
     project_id_by_work_item: dict[uuid.UUID, uuid.UUID | None] = dict(doc_proj)
     story_ids = {g.work_item_id for _, g in non_doc_gates if g.work_item_type == "story"}
     task_ids = {g.work_item_id for _, g in non_doc_gates if g.work_item_type == "task"}
+    # story #2082: artifact_canonicalize 게이트(work_item_type="visual_artifact")가 이 배치에서
+    # 빠져 있어 project_id_by_work_item 조회가 항상 None으로 떨어졌다 — _non_doc_gate_approvable
+    # 이 그걸 "구조적으로 project-무관"으로 오판해 org owner/admin에게만 노출되고, project-level
+    # owner/admin(정본 담당자)에겐 assigned_to_me=true 인박스에서 사라졌다(회귀). VisualArtifact.
+    # project_id는 NOT NULL이라 story/task와 동형으로 항상 배치 해소 가능.
+    artifact_ids = {g.work_item_id for _, g in non_doc_gates if g.work_item_type == "visual_artifact"}
     if story_ids:
         rows = (await session.execute(
             select(Story.id, Story.project_id).where(
@@ -387,6 +394,13 @@ async def list_gates(
             .where(Task.id.in_(task_ids), Task.org_id == org_id)
         )).all()
         project_id_by_work_item.update({tid: pid for tid, pid in rows})
+    if artifact_ids:
+        rows = (await session.execute(
+            select(VisualArtifact.id, VisualArtifact.project_id).where(
+                VisualArtifact.id.in_(artifact_ids), VisualArtifact.org_id == org_id,
+            )
+        )).all()
+        project_id_by_work_item.update({aid: pid for aid, pid in rows})
 
     # N+1 방지: gate 여러 건이 같은 project 를 가리켜도 get_project_role/is_org_owner_or_admin 은
     # **고유 project_id(및 org-fallback 1회)당 1회**만 호출(캐시) — gate 개수와 무관.

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -28,6 +28,7 @@ from app.models.doc import Doc
 from app.models.gate import Gate, is_valid_transition
 from app.models.hitl_config import OrgGatePolicy
 from app.models.pm import Story, Task
+from app.models.visual_artifact import VisualArtifact
 from app.models.workflow_line import (
     WorkflowLineStepApproval,
     WorkflowLineStepRun,
@@ -190,10 +191,16 @@ async def resolve_work_item_project_id(
     (routers/gates.py 제네릭 생성 엔드포인트·merge_verdict_gate.py evaluate_merge_gate)과
     override_gate()의 sr(step_run)=None 폴백용.
 
-    Story/Doc.project_id는 NOT NULL이라 row가 있으면 항상 값이 있다. Task는 project_id 컬럼이
-    없어 story JOIN. 미지원/미인식 work_item_type(예: workflow_line_config의 org-level
-    'wf_line_version' — 실제로 project-무관일 수 있음)은 None(best-effort — silent 실패가
-    아니라 구조적으로 project-scoped가 아닐 수 있다는 정직한 신호)."""
+    Story/Doc/VisualArtifact.project_id는 NOT NULL이라 row가 있으면 항상 값이 있다. Task는
+    project_id 컬럼이 없어 story JOIN. 미지원/미인식 work_item_type(예: workflow_line_config의
+    org-level 'wf_line_version' — 실제로 project-무관일 수 있음)은 None(best-effort — silent
+    실패가 아니라 구조적으로 project-scoped가 아닐 수 있다는 정직한 신호).
+
+    story #2082: visual_artifact 분기는 이 함수 신설 시(story #1968) 누락돼 있었다 —
+    artifact_canonicalize 게이트(work_item_type="visual_artifact")의 project_id가 항상
+    None으로 해소돼 assigned_to_me=true 인박스에서 project-level owner/admin에게 안 보이는
+    (org owner/admin에게만 노출되는) 회귀였다. VisualArtifact.project_id는 NOT NULL이라
+    Story/Doc과 동형으로 항상 해소 가능."""
     if work_item_type == "story":
         return (await session.execute(
             select(Story.project_id).where(Story.id == work_item_id, Story.org_id == org_id)
@@ -207,6 +214,12 @@ async def resolve_work_item_project_id(
     if work_item_type == "doc":
         return (await session.execute(
             select(Doc.project_id).where(Doc.id == work_item_id, Doc.org_id == org_id)
+        )).scalar_one_or_none()
+    if work_item_type == "visual_artifact":
+        return (await session.execute(
+            select(VisualArtifact.project_id).where(
+                VisualArtifact.id == work_item_id, VisualArtifact.org_id == org_id,
+            )
         )).scalar_one_or_none()
     return None
 

--- a/backend/tests/test_2082_artifact_canonicalize_gate_inbox.py
+++ b/backend/tests/test_2082_artifact_canonicalize_gate_inbox.py
@@ -1,0 +1,251 @@
+"""story #2082(선생님 실사용 발견 — 결재함에서 artifact_canonicalize 게이트가 안 보임/못 닿음).
+
+근본: `resolve_work_item_project_id`(gate_service.py, story #1968 SSOT)와 `list_gates`의
+assigned_to_me 배치 project_id 해소(gates.py) 둘 다 `work_item_type == "visual_artifact"`를
+처음부터 커버하지 않았다 — `VisualArtifact.project_id`가 NOT NULL임에도 story/task/doc만
+커버해 canonicalize 게이트의 project_id가 항상 None으로 떨어졌다. 그 결과
+`_non_doc_gate_approvable`이 "구조적으로 project-무관"으로 오판해 org owner/admin에게만
+노출하고, project-level owner/admin(정본 담당자)에겐 assigned_to_me=true 인박스에서
+canonicalize 게이트가 사라졌다(딥링크할 항목 자체가 없어 "결재함에 버튼도 없다"로 보임).
+
+AC(오르테가군 명시): "서버가 그 결재를 목록에 실제로 뱉고·승인/거절이 서버 처리되는지"
+라이브(화면상태 아님) — 아래 realdb 테스트가 정확히 이걸 실 HTTP 왕복으로 캡처한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# realdb 섹션이 Base.metadata.create_all을 호출한다 — conftest.py AST 가드(story 8236bbc3) 대응.
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ═══════════════ resolve_work_item_project_id: visual_artifact 분기(mocked) ═══════════════
+
+
+@pytest.mark.anyio
+async def test_resolve_work_item_project_id_visual_artifact_returns_project_id():
+    from app.services.gate_service import resolve_work_item_project_id
+
+    session = AsyncMock()
+    result_mock = AsyncMock()
+    result_mock.scalar_one_or_none = lambda: uuid.UUID(int=1)
+    session.execute = AsyncMock(return_value=result_mock)
+
+    out = await resolve_work_item_project_id(
+        session, uuid.uuid4(), "visual_artifact", uuid.uuid4()
+    )
+    assert out == uuid.UUID(int=1)
+
+
+@pytest.mark.anyio
+async def test_resolve_work_item_project_id_unrecognized_type_still_returns_none():
+    """회귀 없음 — visual_artifact 분기 추가가 다른 미지원 타입의 None 폴백을 안 건드림."""
+    from app.services.gate_service import resolve_work_item_project_id
+
+    out = await resolve_work_item_project_id(
+        AsyncMock(), uuid.uuid4(), "wf_line_version", uuid.uuid4()
+    )
+    assert out is None
+
+
+# ═══════════════════════ realdb: HTTP 왕복 — 인박스 노출 + 승인 처리 ═══════════════════════
+
+_REAL_DB_SKIP = pytest.mark.skipif(
+    not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"
+)
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    import app.models  # noqa: F401 — 전 모델 메타데이터 로드
+    from app.core.database import Base
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, user_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {}})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _seed_org_project_artifact_and_owner(session):
+    """org + project + project-owner(A, org-level은 plain member) + visual_artifact 1건.
+
+    A는 project owner grant만 있고 org owner/admin은 **아니다** — 회귀 재현의 핵심 조건
+    (org-level fallback으로 우연히 통과하면 실측 의미가 없다)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+    from app.models.visual_artifact import VisualArtifact
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    user_a = User(id=uuid.uuid4(), email=f"a-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add(user_a)
+    await session.commit()
+
+    om_a = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=user_a.id, role="member")  # org-level=member
+    session.add(om_a)
+    await session.commit()
+
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=om_a.id,
+        permission="granted", role="owner",  # project-level=owner
+    ))
+    await session.commit()
+
+    artifact = VisualArtifact(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="mock-1")
+    session.add(artifact)
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "artifact_id": artifact.id,
+        "user_a_id": user_a.id,
+    }
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_artifact_canonicalize_gate_visible_to_project_owner_not_org_admin():
+    """근본 회귀 실측 — project-level owner(org-level은 plain member)가
+    `/api/v2/gates/inbox?status=pending&assigned_to_me=true`로 canonicalize 게이트를 본다."""
+    from app.main import app
+    from app.models.gate import Gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_artifact_and_owner(s)
+            org_id, artifact_id, a_id = seeded["org_id"], seeded["artifact_id"], seeded["user_a_id"]
+
+            gate = Gate(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=artifact_id,
+                work_item_type="visual_artifact", gate_type="artifact_canonicalize",
+                status="pending",
+            )
+            s.add(gate)
+            await s.commit()
+
+        await _setup_app(app, Session, org_id, a_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/gates/inbox", params={"status": "pending", "assigned_to_me": "true"},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            print("\n=== realdb #2082 artifact_canonicalize inbox capture (A=project-owner, org=member) ===")
+            for row in body:
+                print(f"  id={row.get('id')} gate_type={row.get('gate_type')} work_item_type={row.get('work_item_type')}")
+            ids = {row["id"] for row in body if "id" in row}
+            assert str(gate.id) in ids, (
+                "artifact_canonicalize 게이트가 project-owner의 assigned_to_me=true 인박스에서 "
+                "빠짐 — visual_artifact project_id 배치 해소 회귀 재발(story #2082)"
+            )
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_artifact_canonicalize_gate_approve_processes_server_side():
+    """AC: 목록 노출뿐 아니라 승인 액션 자체가 서버에서 실제로 처리되는지(화면상태 아님)."""
+    from app.main import app
+    from app.models.gate import Gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_artifact_and_owner(s)
+            org_id, artifact_id, a_id = seeded["org_id"], seeded["artifact_id"], seeded["user_a_id"]
+
+            gate = Gate(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=artifact_id,
+                work_item_type="visual_artifact", gate_type="artifact_canonicalize",
+                status="pending",
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+
+        await _setup_app(app, Session, org_id, a_id)
+        client = _client_for(app)
+        try:
+            with patch(
+                "app.routers.gates.wake_agent", AsyncMock(return_value=None)
+            ):
+                resp = await client.post(
+                    f"/api/v2/gates/{gate_id}/transition",
+                    # note는 risk_grade=high 게이트 타입의 approve 서버측 강제 사유(story #2027)를
+                    # 무해하게 만족시키기 위함 — 이 테스트의 검증 대상(project_id 배치 해소 회귀)과
+                    # 무관한 별개 정책이라 우회하지 않고 그냥 채운다.
+                    json={"status": "approved", "note": "test approve"},
+                )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["status"] == "approved"
+
+            async with Session() as s2:
+                refreshed = await s2.get(Gate, gate_id)
+                assert refreshed.status == "approved", "서버 DB에 approved가 실제로 반영 안 됨"
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- 선생님 실사용 발견 — 결재함에서 artifact_canonicalize(캔버스 정본화) 게이트에 접근이 안 됨. 미르코군 FE 조사로 액션/딥링크는 코드에 다 있음을 확인 → BE 목록 쿼리 조사(오르테가군 지시) → 근본 확정.
- **근본**: SSOT `resolve_work_item_project_id`(story #1968)가 story/task/doc만 커버하고 `visual_artifact`를 빠뜨렸다. `VisualArtifact.project_id`는 NOT NULL(항상 해소 가능)인데도 None을 반환 → `list_gates`의 `assigned_to_me` 배치 project_id 해소가 같은 갭을 상속 → `artifact_canonicalize` 게이트가 "구조적으로 project-무관"으로 오판돼 **org owner/admin에게만** 노출(project-level owner/admin은 인박스에서 못 봄).

## Fix
- `resolve_work_item_project_id`(gate_service.py)에 `visual_artifact` 분기 추가 — story/doc과 동형(단일 SELECT)
- `list_gates`(gates.py)의 배치 `project_id_by_work_item`에 `visual_artifact_ids` 배치 조회 추가 — `story_ids`/`task_ids`와 동일 패턴(N+1 없음)

## Test plan
- [x] 신규 realdb 테스트 4건(`test_2082_artifact_canonicalize_gate_inbox.py`) — **왕복 검증**: 픽스를 stash로 되돌려 RED 확인(정확히 2건만 실패, 증상과 동일한 빈 배열 `set()` 재현) → 픽스 복원해 GREEN
- [x] project-owner(org-level은 plain member)가 인박스에서 게이트를 실제로 보고, `POST /transition`으로 승인 처리까지(서버 DB `status=approved` 반영) HTTP 왕복으로 확인 — AC(오르테가군 명시): 화면상태 아니라 서버 처리 자체
- [x] 기존 gates 회귀 스위트 124건(assigned_to_me/urgency-sort/risk-grade/inbox-enrich/decider-can-approve 등) 전부 pass
- [x] `resolve_work_item_project_id`의 다른 콜사이트(`merge_verdict_gate.py` 등) 회귀 스위트 44건 전부 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)