### PR TITLE
fix(E-ARCH S2): Redis 소비 경로를 실 dispatch로 승격 — 근본 정정

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -97,6 +97,16 @@ class Settings(BaseSettings):
     event_broker_redis_dual_publish_enabled: bool = False
     redis_url: str | None = None  # Memorystore 연결 문자열(공유 — event_broker + RedisRateLimiter). flag on인데 None이면 경고 로그만(fail-safe).
 
+    # E-ARCH S2 근본 정정(2026-07-21, 착수 전 확認 — shadow-consume은 "도달" 관측이지 "전달"이
+    # 아니었다): 원래 redis_consume_loop(구 redis_shadow_consume_loop)은 로그만 남기고
+    # publish_event()/_push_to_agent()를 호출 안 했다 — 그 상태에서 PG_LISTEN_ENABLED=false로
+    # LISTEN을 걷으면 Redis 발행은 되는데 아무도 안 받아 실시간이 전면 정지했을 것. 이 플래그가
+    # 켜지면 그 loop이 실제로 SSE 큐까지 전달한다(self-skip 포함, pg_pubsub._dispatch_received
+    # 와 동형). default=False — event_broker_redis_dual_publish_enabled만으로는 여전히 관측만
+    # (무회귀). ⚠️event_broker_outbox_enabled와 동시에 켜지 말 것 — outbox 발행분은
+    # instance_id가 없어 self-skip이 안 돼 중복 dispatch 위험(3b에서 해소 예정).
+    event_broker_redis_dispatch_enabled: bool = False
+
     # E-ARCH S3(story #2078) 3a단계: `event_outbox` row insert를 EventBroker.publish()에 추가로
     # 얹는다(호출 타이밍은 안 바뀜 — 여전히 caller commit 이후, 별도 짧은 트랜잭션이라 아직 진짜
     # atomic outbox는 아님). default=False(무회귀) — 켜지기 전엔 OutboxEventBroker가 inner

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,14 +48,19 @@ async def lifespan(app: FastAPI):
         from app.services.l2_trigger_worker import L2TriggerWorker
 
         l2_task = asyncio.create_task(L2TriggerWorker().run())
-    # E-ARCH S2(story #2078): shadow-consume은 event_broker_redis_dual_publish_enabled(default
-    # False)일 때만 task 생성 — Memorystore 미배선 상태(redis_url=None)에서도 이 브랜치 자체가
-    # 안 돌아 무해(플래그가 꺼져 있으면 event_broker.py의 redis_url 가드에도 안 닿는다).
+    # E-ARCH S2/S3(story #2078): redis_consume_loop은 event_broker_redis_dual_publish_enabled
+    # (default False)일 때만 task 생성 — Memorystore 미배선 상태(redis_url=None)에서도 이
+    # 브랜치 자체가 안 돌아 무해. ⚠️이 loop은 두 가지 일을 한다 — (1) 항상: PG 도착 기록과
+    # 대조해 지연Δ 로그(관측) (2) event_broker_redis_dispatch_enabled(default False, 별개
+    # 게이트)도 켜지면 publish_event()/_push_to_agent()를 실제로 호출해 SSE로 전달(실
+    # dispatch). dispatch_enabled가 꺼진 동안은 (1)뿐이라 무회귀 — PG LISTEN이 여전히 유일한
+    # 실 dispatch 경로. dispatch_enabled를 켜야 비로소 PG_LISTEN_ENABLED=false(LISTEN 제거)가
+    # 안전해진다(순서 중요 — 착수 전 확認 2026-07-21).
     redis_shadow_task = None
     if settings.event_broker_redis_dual_publish_enabled:
-        from app.services.event_broker import redis_shadow_consume_loop
+        from app.services.event_broker import redis_consume_loop
 
-        redis_shadow_task = asyncio.create_task(redis_shadow_consume_loop())
+        redis_shadow_task = asyncio.create_task(redis_consume_loop())
     # E-ARCH S3(story #2078) 3a단계: outbox dispatcher는 event_broker_outbox_enabled(default
     # False)일 때만 task 생성 — 꺼져 있으면 event_outbox row 자체가 안 쌓이니(OutboxEventBroker
     # 가 insert를 스킵) 폴링할 게 없다. redis_shadow_task와 별개 게이트(outbox insert가 켜졌다고

--- a/backend/app/services/event_broker.py
+++ b/backend/app/services/event_broker.py
@@ -1,15 +1,24 @@
-"""E-ARCH S2(story #2078): EventBroker — PG NOTIFY(authoritative) + Redis(shadow dual-publish).
+"""E-ARCH S2/S3(story #2078): EventBroker — PG NOTIFY(authoritative) + Redis dual-publish,
+단계적으로 Redis를 실 dispatch 경로로 승격.
 
 설계(오르테가군 판정 2026-07-21): 2단계는 dual-publish, 3단계에서 Redis-only 구현체로 교체 가능
 하도록 `EventBroker`를 인터페이스로 분리한다 — 콜사이트(events.py)는 어느 구현체가 도는지 모른다.
 
-Redis 경로는 `event_broker_redis_dual_publish_enabled`(default False)로 게이트 — 꺼져 있으면
-이 모듈은 `pg_notify()` 호출 외 아무것도 안 한다(무회귀, #2358 PG_LISTEN_ENABLED와 동일 컨벤션).
+Redis 발행 경로는 `event_broker_redis_dual_publish_enabled`(default False)로 게이트 — 꺼져
+있으면 이 모듈은 `pg_notify()` 호출 외 아무것도 안 한다(무회귀, #2358 PG_LISTEN_ENABLED와 동일
+컨벤션).
 
-Redis가 이 단계에서 100% 유실돼도 정합성 영향 0 — Redis는 realtime gateway의 shadow-consume
-비교(지연·중복률 측정)용일 뿐 dispatch에 쓰이지 않는다. dispatch는 여전히 PG LISTEN
-(pg_pubsub.listen_loop) 경로만 탄다. 근거: agent_gateway.py의 acked_seq DB 재조회 패턴과 동형
-— wake 신호 유실은 다음 재조회가 흡수한다(2026-07-21 세션 코드 교차검증 완료).
+⚠️근본 정정(2026-07-21, 착수 전 확認): 처음엔 Redis 수신이 "shadow"(관측 전용 — PG 대비 도달률/
+지연만 로그, 실제 SSE 전달은 안 함)이었다. 그 상태로 PG LISTEN을 걷으면 Redis는 발행되는데
+아무도 안 받아 실시간이 전면 정지했을 것 — "도달 확認"과 "전달 확認"은 다른 것이었다.
+`event_broker_redis_dispatch_enabled`(default False, 별개 게이트)가 켜져야 `redis_consume_loop`
+가 `publish_event()`/`_push_to_agent()`를 실제로 호출해 SSE로 전달한다(self-skip 포함,
+pg_pubsub._dispatch_received와 동형) — 이게 켜져야 비로소 PG_LISTEN_ENABLED=false(LISTEN
+제거)가 안전해진다. dual_publish만 켜진 상태(dispatch 꺼짐)는 여전히 순수 관측이라 무회귀 —
+PG LISTEN이 유일한 실 dispatch 경로. 근거(관측 유실 허용 근거는 유지): agent_gateway.py의
+acked_seq DB 재조회 패턴과 동형 — wake 신호 유실은 다음 재조회가 흡수한다(2026-07-21 세션
+코드 교차검증 완료). 단 이 근거는 "dispatch가 이미 이뤄지는데 신호만 놓쳐도 안전하다"는
+것이지 "dispatch 자체가 없어도 안전하다"는 뜻이 아니다 — 이번 정정이 그 구분을 명확히 한다.
 """
 from __future__ import annotations
 
@@ -71,18 +80,30 @@ def _get_redis_client():
 async def _redis_publish(
     target: Literal["org", "agent"], target_id: str, event_type: str, data: dict, event_id: str
 ) -> None:
-    """Redis 발행 — 실패 시 경고 로그만(pg_notify와 동형 철학: shadow 경로라 예외 전파 금지)."""
+    """Redis 발행 — 실패 시 경고 로그만(pg_notify와 동형 철학: shadow 경로라 예외 전파 금지).
+
+    payload는 pg_notify()와 동형 envelope(instance_id/target/target_id/event_type/data 분리) —
+    자기발행 self-skip(story #2078 실 dispatch 승격)과 수신측 파싱을 pg_pubsub._dispatch_received()
+    와 대칭으로 유지한다. instance_id는 pg_pubsub.INSTANCE_ID 재사용(같은 프로세스=같은 값).
+    """
     import json
 
     from app.core.config import settings
+    from app.services.pg_pubsub import INSTANCE_ID
 
     if not settings.redis_url:
         logger.warning("event_broker redis publish skipped: redis_url not configured")
         return
 
-    payload = _slim_org_payload(data) if target == "org" else dict(data)
-    payload["event_type"] = event_type
-    payload["_broker_event_id"] = event_id
+    inner = _slim_org_payload(data) if target == "org" else dict(data)
+    payload = {
+        "instance_id": INSTANCE_ID,
+        "target": target,
+        "target_id": target_id,
+        "event_type": event_type,
+        "_broker_event_id": event_id,
+        "data": inner,
+    }
 
     try:
         client = _get_redis_client()
@@ -228,22 +249,36 @@ def record_pg_arrival(event_id: str) -> None:
     _pg_arrivals[event_id] = time.monotonic()
 
 
-async def redis_shadow_consume_loop() -> None:
-    """Redis 구독 → PG 경로 도착 기록과 대조해 지연Δ·중복률을 로그.
+async def redis_consume_loop() -> None:
+    """Redis 구독 → (a) PG 경로 도착 기록과 대조해 지연Δ·중복률 로그(항상) (b)
+    `event_broker_redis_dispatch_enabled`(default False)가 켜지면 실제로
+    `publish_event()`/`_push_to_agent()`를 호출해 SSE로 전달(실 dispatch 승격).
 
-    dispatch에는 절대 안 씀(PG가 여전히 authoritative) — 비교 관측 전용.
+    ⚠️ story #2078 근본 정정(2026-07-21, 착수 전 확認): 원래 "shadow-consume"이라는 이름대로
+    관측만 했다 — Redis가 PG만큼 "도달"하는지는 쟀지만 그 도달이 실제로 SSE 큐까지 "전달"되는
+    지는 재지 않았다(publish_event/_push_to_agent 호출 자체가 코드에 없었다). 그 상태에서 PG
+    LISTEN을 걷으면 Redis 발행은 되는데 아무도 안 받아 실시간이 전면 정지했을 것 — 이 함수가
+    바로 그 갭을 닫는다. dispatch_enabled=False인 동안은 순수 관측(무회귀, 기존 이름의 "shadow"
+    의미 그대로 유지) — 켜지면 pg_pubsub._dispatch_received()와 동형으로 실 전달까지 한다.
+
+    self-skip: payload.instance_id(자기 자신이 발행한 이벤트)면 skip — PG NOTIFY의 동일 로직과
+    대칭(_dispatch_received). ⚠️outbox_dispatcher_loop 발행분은 instance_id=None이라 self-skip
+    신호가 없다 — event_broker_outbox_enabled와 dispatch_enabled를 동시에 켜면 중복 dispatch
+    위험(3b에서 해소 예정, 그 전까지 둘을 동시에 켜지 말 것).
+
     listen_loop()(pg_pubsub.py)과 동형 재연결 구조(1s→2s→4s→max 30s backoff).
     """
     import json
 
     from app.core.config import settings
+    from app.services.pg_pubsub import INSTANCE_ID
 
     if not settings.redis_url:
-        logger.warning("event_broker redis shadow consume skipped: redis_url not configured")
+        logger.warning("event_broker redis consume skipped: redis_url not configured")
         return
 
     delay = 1.0
-    logger.info("event_broker redis shadow consume starting")
+    logger.info("event_broker redis consume starting (dispatch_enabled=%s)", settings.event_broker_redis_dispatch_enabled)
 
     while True:
         pubsub = None
@@ -252,7 +287,7 @@ async def redis_shadow_consume_loop() -> None:
             pubsub = client.pubsub()
             await pubsub.psubscribe("org:*:invalidation", "agent:*")
             delay = 1.0
-            logger.info("event_broker redis shadow consume connected")
+            logger.info("event_broker redis consume connected")
             async for message in pubsub.listen():
                 if message.get("type") not in ("pmessage", "message"):
                     continue
@@ -260,27 +295,46 @@ async def redis_shadow_consume_loop() -> None:
                     payload = json.loads(message["data"])
                 except (TypeError, ValueError):
                     continue
+
                 event_id = payload.get("_broker_event_id")
-                if not event_id:
+                if event_id:
+                    received_at = time.monotonic()
+                    pg_arrived_at = _pg_arrivals.get(event_id)
+                    if pg_arrived_at is not None:
+                        logger.info(
+                            "event_broker shadow: redis+pg both delivered event_id=%s latency_delta=%.3fs",
+                            event_id, received_at - pg_arrived_at,
+                        )
+                    else:
+                        logger.info(
+                            "event_broker shadow: redis-only delivery event_id=%s (pg 미도착/유실 가능)",
+                            event_id,
+                        )
+
+                if not settings.event_broker_redis_dispatch_enabled:
                     continue
-                received_at = time.monotonic()
-                pg_arrived_at = _pg_arrivals.get(event_id)
-                if pg_arrived_at is not None:
-                    logger.info(
-                        "event_broker shadow: redis+pg both delivered event_id=%s latency_delta=%.3fs",
-                        event_id, received_at - pg_arrived_at,
-                    )
-                else:
-                    logger.info(
-                        "event_broker shadow: redis-only delivery event_id=%s (pg 미도착/유실 가능)",
-                        event_id,
-                    )
+
+                if payload.get("instance_id") == INSTANCE_ID:
+                    continue  # 자기 자신이 발행한 이벤트 skip(_dispatch_received 동형)
+
+                target = payload.get("target")
+                target_id = str(payload.get("target_id", ""))
+                event_type = str(payload.get("event_type", ""))
+                data = payload.get("data") or {}
+                try:
+                    from app.routers.events import _push_to_agent, publish_event
+                    if target == "org":
+                        publish_event(target_id, event_type, data, _from_listener=True)
+                    elif target == "agent":
+                        _push_to_agent(target_id, data, _from_listener=True)
+                except Exception as exc:
+                    logger.warning("event_broker redis dispatch failed target=%s: %s", target, exc)
         except asyncio.CancelledError:
-            logger.info("event_broker redis shadow consume cancelled — shutting down")
+            logger.info("event_broker redis consume cancelled — shutting down")
             break
         except Exception as exc:
             logger.warning(
-                "event_broker redis shadow consume error: %s — reconnecting in %.1fs", exc, delay
+                "event_broker redis consume error: %s — reconnecting in %.1fs", exc, delay
             )
             await asyncio.sleep(delay)
             delay = min(delay * 2, 30)
@@ -302,7 +356,7 @@ async def outbox_dispatcher_loop() -> None:
     """`event_outbox`의 미발행 row를 폴링해 Redis로 발행 — 3a단계 dispatcher.
 
     `FOR UPDATE SKIP LOCKED`로 멀티인스턴스 동시 폴링 시 중복발행을 방지한다(표준 outbox
-    패턴). listen_loop()/redis_shadow_consume_loop()와 동형 에러 backoff(1s→2s→...→30s) —
+    패턴). listen_loop()/redis_consume_loop()와 동형 에러 backoff(1s→2s→...→30s) —
     정상 시엔 고정 폴링 간격(`_OUTBOX_POLL_INTERVAL`)으로 반복한다.
 
     ⚠️ `event_broker_redis_dual_publish_enabled`와 `event_broker_outbox_enabled`를 동시에
@@ -349,9 +403,21 @@ async def outbox_dispatcher_loop() -> None:
                 client = _get_redis_client()
                 now = datetime.now(timezone.utc)
                 for row in rows:
-                    payload = _slim_org_payload(row.payload) if row.target == "org" else dict(row.payload)
-                    payload["event_type"] = row.event_type
-                    payload["_broker_event_id"] = str(row.id)
+                    inner = _slim_org_payload(row.payload) if row.target == "org" else dict(row.payload)
+                    # pg_notify()/_redis_publish()와 동형 envelope(파싱 대칭) — instance_id는
+                    # 의도적으로 None: outbox row는 폴링한 인스턴스가 원발행 인스턴스와 다를 수
+                    # 있어(dispatcher가 어느 인스턴스에서 돌든 같은 DB row를 픽업) 신뢰 가능한
+                    # self-skip 신호가 없다. ⚠️알려진 갭(3b에서 해소 예정) — 이 경로가 아직 실
+                    # dispatch로 승격 안 된 이유이기도 하다(event_broker_redis_dispatch_enabled
+                    # 를 outbox_enabled와 함께 켜면 self-skip 누락으로 인한 중복 dispatch 위험).
+                    payload = {
+                        "instance_id": None,
+                        "target": row.target,
+                        "target_id": str(row.target_id),
+                        "event_type": row.event_type,
+                        "_broker_event_id": str(row.id),
+                        "data": inner,
+                    }
                     try:
                         await client.publish(
                             _redis_channel(row.target, str(row.target_id)),

--- a/backend/tests/test_2078_event_broker.py
+++ b/backend/tests/test_2078_event_broker.py
@@ -136,10 +136,213 @@ def test_record_pg_arrival_ignores_empty_id():
 
 
 @pytest.mark.anyio
-async def test_shadow_consume_loop_returns_immediately_without_redis_url(monkeypatch):
+async def test_redis_consume_loop_returns_immediately_without_redis_url(monkeypatch):
     """redis_url 없으면 무한루프에 안 들어가고 바로 return해야(테스트가 hang 안 함 자체가 증거)."""
     monkeypatch.setattr("app.core.config.settings.redis_url", None)
-    await eb.redis_shadow_consume_loop()  # 타임아웃 없이 즉시 끝나야
+    await eb.redis_consume_loop()  # 타임아웃 없이 즉시 끝나야
+
+
+class _FakePubSub:
+    """redis-py PubSub 최소 mock — psubscribe 무시, listen()이 고정 메시지 시퀀스를 방출.
+
+    ⚠️매 yield/재연결 사이 `asyncio.sleep(0)`으로 이벤트루프에 제어를 넘긴다 — 실 redis-py는
+    네트워크 I/O라 자연히 이벤트루프에 양보하지만, 이 mock은 순수 동기 for라 양보점이 없으면
+    redis_consume_loop의 `while True` 재연결 루프가 이 테스트 프로세스를 독점해 폴링 중인
+    테스트 코루틴이 영원히 스케줄 안 되는(= pytest-timeout 30s로 hang) 버그를 낳는다."""
+
+    def __init__(self, messages):
+        self._messages = messages
+
+    async def psubscribe(self, *patterns):
+        await asyncio.sleep(0)
+
+    async def listen(self):
+        for m in self._messages:
+            yield m
+            await asyncio.sleep(0)
+
+    async def close(self):
+        pass
+
+
+def _redis_message(payload: dict) -> dict:
+    import json
+    return {"type": "pmessage", "data": json.dumps(payload)}
+
+
+async def _run_loop_until(monkeypatch, messages, condition, timeout_s=1.0):
+    """redis_consume_loop을 백그라운드에서 돌리고 condition()이 참이 될 때까지 폴링 후 취소.
+
+    fake pubsub의 listen()이 소진되면 while True가 재연결을 시도(_get_redis_client가 같은
+    fake client를 반환하니 무해 — psubscribe도 매번 no-op) — 그래도 메시지 시퀀스는 1회만
+    방출되니 condition이 첫 순회에서 안 만족되면 이 헬퍼가 timeout으로 실패한다(의도적).
+    """
+    class _FakeClient:
+        def pubsub(self):
+            return _FakePubSub(messages)
+
+    monkeypatch.setattr(eb, "_get_redis_client", lambda: _FakeClient())
+    monkeypatch.setattr("app.core.config.settings.redis_url", "redis://fake:6379/0")
+
+    task = asyncio.create_task(eb.redis_consume_loop())
+    elapsed = 0.0
+    step = 0.01
+    while elapsed < timeout_s:
+        if condition():
+            break
+        await asyncio.sleep(step)
+        elapsed += step
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    assert condition(), "redis_consume_loop이 기대한 상태에 도달 못 함(timeout)"
+
+
+@pytest.mark.anyio
+async def test_redis_consume_loop_dispatch_disabled_only_logs_no_dispatch_call(monkeypatch):
+    """event_broker_redis_dispatch_enabled=False(default) — publish_event/_push_to_agent 안 불려야
+    (이 회귀 가드가 없으면 3단계 전 실수로 실 dispatch가 켜져도 아무도 못 잡는다)."""
+    monkeypatch.setattr("app.core.config.settings.event_broker_redis_dispatch_enabled", False)
+    monkeypatch.setattr("app.core.config.settings.redis_url", "redis://fake:6379/0")
+    dispatch_calls = []
+    monkeypatch.setattr(
+        "app.routers.events.publish_event",
+        lambda *a, **kw: dispatch_calls.append(("publish_event", a, kw)),
+    )
+    monkeypatch.setattr(
+        "app.routers.events._push_to_agent",
+        lambda *a, **kw: dispatch_calls.append(("_push_to_agent", a, kw)),
+    )
+
+    msg = _redis_message({
+        "instance_id": "other-instance", "target": "org", "target_id": "org-1",
+        "event_type": "x", "_broker_event_id": "evt-1", "data": {"foo": "bar"},
+    })
+
+    class _FakeClient:
+        def pubsub(self):
+            return _FakePubSub([msg])
+
+    monkeypatch.setattr(eb, "_get_redis_client", lambda: _FakeClient())
+
+    # 음성 결과(아무것도 dispatch 안 됨) 검증 — 긍정 condition이 없으니 고정 시간만 대기.
+    task = asyncio.create_task(eb.redis_consume_loop())
+    await asyncio.sleep(0.2)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    assert dispatch_calls == []
+    # 그래도 shadow 관측(로그 기준점)은 여전히 동작해야 — dispatch=off가 관측까지 죽이면 안 됨.
+    assert "evt-1" not in eb._pg_arrivals  # PG 도착이 없었으니 당연히 비교 기준점도 없음(정상)
+
+
+@pytest.mark.anyio
+async def test_redis_consume_loop_dispatch_enabled_calls_publish_event_for_org_target(monkeypatch):
+    monkeypatch.setattr("app.core.config.settings.event_broker_redis_dispatch_enabled", True)
+    dispatch_calls = []
+    monkeypatch.setattr(
+        "app.routers.events.publish_event",
+        lambda *a, **kw: dispatch_calls.append((a, kw)),
+    )
+    monkeypatch.setattr("app.routers.events._push_to_agent", lambda *a, **kw: None)
+
+    msg = _redis_message({
+        "instance_id": "other-instance", "target": "org", "target_id": "org-1",
+        "event_type": "story.status_changed", "_broker_event_id": "evt-2",
+        "data": {"entity_id": "s1"},
+    })
+    await _run_loop_until(monkeypatch, [msg], lambda: len(dispatch_calls) > 0)
+
+    args, kwargs = dispatch_calls[0]
+    assert args[0] == "org-1"
+    assert args[1] == "story.status_changed"
+    assert args[2] == {"entity_id": "s1"}
+    assert kwargs.get("_from_listener") is True  # 재발행 무한루프 차단 플래그 필수
+
+
+@pytest.mark.anyio
+async def test_redis_consume_loop_dispatch_enabled_calls_push_to_agent_for_agent_target(monkeypatch):
+    monkeypatch.setattr("app.core.config.settings.event_broker_redis_dispatch_enabled", True)
+    dispatch_calls = []
+    monkeypatch.setattr("app.routers.events.publish_event", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        "app.routers.events._push_to_agent",
+        lambda *a, **kw: dispatch_calls.append((a, kw)),
+    )
+
+    msg = _redis_message({
+        "instance_id": "other-instance", "target": "agent", "target_id": "member-1",
+        "event_type": "task.assigned", "_broker_event_id": "evt-3",
+        "data": {"task_id": "t1"},
+    })
+    await _run_loop_until(monkeypatch, [msg], lambda: len(dispatch_calls) > 0)
+
+    args, kwargs = dispatch_calls[0]
+    assert args[0] == "member-1"
+    assert args[1] == {"task_id": "t1"}
+    assert kwargs.get("_from_listener") is True
+
+
+@pytest.mark.anyio
+async def test_redis_consume_loop_dispatch_enabled_skips_self_published_event(monkeypatch):
+    """자기 인스턴스가 발행한 이벤트(instance_id 일치)는 dispatch 안 해야 — 중복 전달 방지."""
+    from app.services.pg_pubsub import INSTANCE_ID
+
+    monkeypatch.setattr("app.core.config.settings.event_broker_redis_dispatch_enabled", True)
+    dispatch_calls = []
+    monkeypatch.setattr(
+        "app.routers.events.publish_event",
+        lambda *a, **kw: dispatch_calls.append(a),
+    )
+    monkeypatch.setattr("app.routers.events._push_to_agent", lambda *a, **kw: None)
+
+    msg = _redis_message({
+        "instance_id": INSTANCE_ID, "target": "org", "target_id": "org-1",
+        "event_type": "x", "_broker_event_id": "evt-4", "data": {},
+    })
+    # self-skip이니 dispatch_calls는 영원히 빈 채 — 고정 시간만 대기 후 확認(음성 결과 검증).
+    task = asyncio.create_task(eb.redis_consume_loop())
+    await asyncio.sleep(0.2)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    assert dispatch_calls == []
+
+
+@pytest.mark.anyio
+async def test_redis_publish_payload_includes_instance_id_and_nested_data(monkeypatch):
+    """envelope 형태가 pg_notify()와 동형(instance_id/target/target_id/event_type/data 분리)인지
+    — redis_consume_loop의 파싱 대칭성 전제."""
+    import json
+
+    from app.services.pg_pubsub import INSTANCE_ID
+
+    monkeypatch.setattr("app.core.config.settings.redis_url", "redis://fake:6379/0")
+    published = []
+
+    class _FakeClient:
+        async def publish(self, channel, message):
+            published.append((channel, json.loads(message)))
+
+    monkeypatch.setattr(eb, "_get_redis_client", lambda: _FakeClient())
+
+    await eb._redis_publish("agent", "member-1", "task.assigned", {"task_id": "t1"}, "evt-5")
+
+    assert len(published) == 1
+    channel, payload = published[0]
+    assert channel == "agent:member-1"
+    assert payload["instance_id"] == INSTANCE_ID
+    assert payload["target"] == "agent"
+    assert payload["target_id"] == "member-1"
+    assert payload["event_type"] == "task.assigned"
+    assert payload["_broker_event_id"] == "evt-5"
+    assert payload["data"] == {"task_id": "t1"}
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_lifespan_engine_dispose_33e0c681.py
+++ b/backend/tests/test_lifespan_engine_dispose_33e0c681.py
@@ -170,7 +170,7 @@ async def test_lifespan_skips_check_listen_config_when_pg_listen_disabled(monkey
 @pytest.mark.anyio
 async def test_lifespan_skips_redis_shadow_task_by_default(monkeypatch):
     """E-ARCH S2(story #2078): event_broker_redis_dual_publish_enabled default=False —
-    redis_shadow_consume_loop task 자체를 안 만든다(Memorystore 미배선 상태에서도 무해)."""
+    redis_consume_loop task 자체를 안 만든다(Memorystore 미배선 상태에서도 무해)."""
     from app.main import lifespan
 
     fake_engine = _patch_engine(monkeypatch)
@@ -182,18 +182,18 @@ async def test_lifespan_skips_redis_shadow_task_by_default(monkeypatch):
         started.set()  # 호출되면 안 됨.
         await asyncio.Event().wait()
 
-    monkeypatch.setattr("app.services.event_broker.redis_shadow_consume_loop", fake_shadow_consume)
+    monkeypatch.setattr("app.services.event_broker.redis_consume_loop", fake_shadow_consume)
 
     async with lifespan(MagicMock()):
         await asyncio.sleep(0.05)
-        assert not started.is_set(), "flag off인데 redis_shadow_consume_loop가 시작됨"
+        assert not started.is_set(), "flag off인데 redis_consume_loop가 시작됨"
 
     fake_engine.dispose.assert_awaited_once()
 
 
 @pytest.mark.anyio
 async def test_lifespan_starts_redis_shadow_task_when_enabled(monkeypatch):
-    """flag on이면 redis_shadow_consume_loop task가 뜨고, shutdown 시 정상 cancel→dispose."""
+    """flag on이면 redis_consume_loop task가 뜨고, shutdown 시 정상 cancel→dispose."""
     from app.main import lifespan
 
     fake_engine = _patch_engine(monkeypatch)
@@ -208,7 +208,7 @@ async def test_lifespan_starts_redis_shadow_task_when_enabled(monkeypatch):
         except asyncio.CancelledError:
             return
 
-    monkeypatch.setattr("app.services.event_broker.redis_shadow_consume_loop", fake_shadow_consume)
+    monkeypatch.setattr("app.services.event_broker.redis_consume_loop", fake_shadow_consume)
 
     async with lifespan(MagicMock()):
         await asyncio.wait_for(started.wait(), timeout=1)


### PR DESCRIPTION
## Summary
착수 전 확認(2026-07-21, outbox flag on 지시 직전 차단) — `redis_shadow_consume_loop`은 "도달"(PG 대비 지연·중복률)만 관측했지 "전달"(SSE 큐 적재)은 안 했다. 그 상태로 PG LISTEN을 걷으면 Redis는 발행되는데 아무도 안 받아 실시간이 전면 정지했을 것.

## Fix
- `redis_shadow_consume_loop` → `redis_consume_loop`로 개명. `event_broker_redis_dispatch_enabled`(신규 flag, default **False**)가 켜지면 수신 시 실제로 `publish_event()`/`_push_to_agent()`를 호출(`_from_listener=True`, `pg_pubsub._dispatch_received`와 동형) — 꺼진 동안은 기존 관측만(무회귀)
- `_redis_publish()`/`outbox_dispatcher_loop()` 발행 payload를 `pg_notify()`와 동형 envelope(`instance_id`/`target`/`target_id`/`event_type`/`data` 분리)로 재구성 — self-skip(자기 발행 이벤트 재수신 시 중복 dispatch 방지)의 전제
- ⚠️`outbox_dispatcher_loop` 발행분은 `instance_id=None`(원발행 인스턴스 미상) — self-skip 불가라 `event_broker_outbox_enabled`와 `dispatch_enabled` 동시 활성은 중복 dispatch 위험(3b에서 콜사이트 이관과 함께 해소 예정, 코드 주석으로 문서화)

## 배선 순서(참고 — 배포는 오르테가군 lane)
1. 이 PR 머지 → dev에 배포(flag 둘 다 off라 무회귀)
2. `event_broker_redis_dispatch_enabled=true` 플립(dual_publish는 이미 on) → 라이브로 "Redis만으로 SSE가 실제로 뜨는지" 검증
3. 검증되면 `PG_LISTEN_ENABLED=false`(realtime) 전환 — 이제 안전
4. `event_broker_outbox_enabled`는 3b(콜사이트 이관) 전까지 dispatch_enabled와 별도로 켜지 말 것

## Test plan
- [x] 신규 6건(`test_2078_event_broker.py`) — dispatch off 무회귀·org/agent target 실 dispatch 호출 인자 검증·self-skip·envelope payload 형태(instance_id/nested data)
- [x] 테스트 fixture 버그 하나 자체 발견·수정 — fake pubsub가 실 이벤트루프 yield 없이 tight loop를 만들어 폴링 테스트를 30s pytest-timeout으로 hang시킴(`asyncio.sleep(0)` 체크포인트 추가로 해결)
- [x] 기존 event_broker/outbox/lifespan/fire_and_forget 회귀 36건 전부 pass(로컬 PG)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)