### PR TITLE
fix(E-ARCH S2): 긴급 — realtime PG_LISTEN_ENABLED 하드코딩 제거 + consume 역할 분리

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -69,6 +69,9 @@ jobs:
             # 중). false로 먼저 못박으면 prod에 LISTEN 하는 서비스가 0개가 돼 실시간이
             # 완전히 죽는다. prod가 realtime 배선을 마치는 승격 시점에 이 값을 false로 뒤집을 것.
             echo "backend_pg_listen_enabled=true" >> "$GITHUB_OUTPUT"
+            # story #2078(E-ARCH S2 정리): api는 SSE 미서빙 — Redis 구독(consume) 불필요.
+            # dual_publish(발행)는 안 건드림. prod도 dev와 동일 이유로 false.
+            echo "backend_redis_consume_enabled=false" >> "$GITHUB_OUTPUT"
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
@@ -108,6 +111,10 @@ jobs:
             # 을 realtime-dev로 넘겼다(까심군 raw SSE 검증 PASS). 손 gcloud 값은 다음 배포가
             # 덮으니(오늘 규율) 여기 durable로 못박는다 — 다음 api 배포에서도 false 유지.
             echo "backend_pg_listen_enabled=false" >> "$GITHUB_OUTPUT"
+            # story #2078(E-ARCH S2 정리): api는 SSE 미서빙(realtime-dev로 완전 이관) —
+            # Redis 구독(consume) 불필요. dual_publish(발행)는 안 건드림 — cross-instance
+            # relay 소스가 되어야 하므로.
+            echo "backend_redis_consume_enabled=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Submit Cloud Build
@@ -115,6 +122,6 @@ jobs:
           gcloud builds submit \
             --config=cloudbuild.yaml \
             --project="${{ secrets.GCP_PROJECT_ID }}" \
-            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}",_BACKEND_MIN_INSTANCES="${{ steps.env.outputs.backend_min_instances }}",_BACKEND_MAX_INSTANCES="${{ steps.env.outputs.backend_max_instances }}",_BACKEND_TIMEOUT="${{ steps.env.outputs.backend_timeout }}",_GA4_MEASUREMENT_ID="${{ steps.env.outputs.ga4_measurement_id }}",_REALTIME_MIN_INSTANCES="${{ steps.env.outputs.realtime_min_instances }}",_REALTIME_MAX_INSTANCES="${{ steps.env.outputs.realtime_max_instances }}",_REALTIME_TIMEOUT="${{ steps.env.outputs.realtime_timeout }}",_REALTIME_URL="${{ steps.env.outputs.realtime_url }}",_BACKEND_PG_LISTEN_ENABLED="${{ steps.env.outputs.backend_pg_listen_enabled }}" \
+            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}",_BACKEND_MIN_INSTANCES="${{ steps.env.outputs.backend_min_instances }}",_BACKEND_MAX_INSTANCES="${{ steps.env.outputs.backend_max_instances }}",_BACKEND_TIMEOUT="${{ steps.env.outputs.backend_timeout }}",_GA4_MEASUREMENT_ID="${{ steps.env.outputs.ga4_measurement_id }}",_REALTIME_MIN_INSTANCES="${{ steps.env.outputs.realtime_min_instances }}",_REALTIME_MAX_INSTANCES="${{ steps.env.outputs.realtime_max_instances }}",_REALTIME_TIMEOUT="${{ steps.env.outputs.realtime_timeout }}",_REALTIME_URL="${{ steps.env.outputs.realtime_url }}",_BACKEND_PG_LISTEN_ENABLED="${{ steps.env.outputs.backend_pg_listen_enabled }}",_BACKEND_REDIS_CONSUME_ENABLED="${{ steps.env.outputs.backend_redis_consume_enabled }}" \
             --suppress-logs \
             .

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -107,6 +107,16 @@ class Settings(BaseSettings):
     # instance_id가 없어 self-skip이 안 돼 중복 dispatch 위험(3b에서 해소 예정).
     event_broker_redis_dispatch_enabled: bool = False
 
+    # E-ARCH S2 정리(2026-07-21, LISTEN 제거 완료 후 발견): redis_consume_loop task 생성이
+    # event_broker_redis_dual_publish_enabled 하나로만 게이트돼 있었다 — dual_publish(발행,
+    # 모든 인스턴스가 필요)와 consume(구독+dispatch, SSE를 실제로 서빙하는 서비스만 필요)
+    # 역할이 뒤섞여, api(SSE 미서빙)도 불필요하게 Redis 구독을 유지했다(낭비 + shadow 비교
+    # 로그 노이즈 — api는 LISTEN이 없어 PG 도착 기준점이 영원히 0이라 항상 "redis-only"로
+    # 오독될 수 있는 상태였다). default=True(무회귀) — realtime이 이미 이 loop로 실 dispatch
+    # 중이라 default를 False로 하면 재배포 시 실시간이 끊긴다. api 쪽만 GHA per-env override로
+    # false 배선(story #2078 PG_LISTEN_ENABLED durable 분리·PR #2364와 동일 패턴).
+    event_broker_redis_consume_enabled: bool = True
+
     # E-ARCH S3(story #2078) 3a단계: `event_outbox` row insert를 EventBroker.publish()에 추가로
     # 얹는다(호출 타이밍은 안 바뀜 — 여전히 caller commit 이후, 별도 짧은 트랜잭션이라 아직 진짜
     # atomic outbox는 아님). default=False(무회귀) — 켜지기 전엔 OutboxEventBroker가 inner

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,16 +48,17 @@ async def lifespan(app: FastAPI):
         from app.services.l2_trigger_worker import L2TriggerWorker
 
         l2_task = asyncio.create_task(L2TriggerWorker().run())
-    # E-ARCH S2/S3(story #2078): redis_consume_loop은 event_broker_redis_dual_publish_enabled
-    # (default False)일 때만 task 생성 — Memorystore 미배선 상태(redis_url=None)에서도 이
-    # 브랜치 자체가 안 돌아 무해. ⚠️이 loop은 두 가지 일을 한다 — (1) 항상: PG 도착 기록과
-    # 대조해 지연Δ 로그(관측) (2) event_broker_redis_dispatch_enabled(default False, 별개
-    # 게이트)도 켜지면 publish_event()/_push_to_agent()를 실제로 호출해 SSE로 전달(실
-    # dispatch). dispatch_enabled가 꺼진 동안은 (1)뿐이라 무회귀 — PG LISTEN이 여전히 유일한
-    # 실 dispatch 경로. dispatch_enabled를 켜야 비로소 PG_LISTEN_ENABLED=false(LISTEN 제거)가
-    # 안전해진다(순서 중요 — 착수 전 확認 2026-07-21).
+    # E-ARCH S2/S3(story #2078): redis_consume_loop은 dual_publish_enabled AND
+    # redis_consume_enabled 둘 다 켜져야 task 생성 — Memorystore 미배선 상태(redis_url=None)
+    # 에서도 이 브랜치 자체가 안 돌아 무해. consume_enabled는 "이 서비스가 Redis를 구독해
+    # dispatch하는 역할인가"(SSE를 실제로 서빙하는 realtime만 True — api는 발행만 하고 구독은
+    # 불필요, GHA per-env override로 false 배선) — dual_publish_enabled(발행, 모든 인스턴스
+    # 필요)와 독립적인 축이다(2026-07-21 정리, PG_LISTEN_ENABLED durable 분리와 동일 패턴).
+    # ⚠️이 loop은 두 가지 일을 한다 — (1) 항상: PG 도착 기록과 대조해 지연Δ 로그(관측)
+    # (2) event_broker_redis_dispatch_enabled(default False, 별개 게이트)도 켜지면
+    # publish_event()/_push_to_agent()를 실제로 호출해 SSE로 전달(실 dispatch).
     redis_shadow_task = None
-    if settings.event_broker_redis_dual_publish_enabled:
+    if settings.event_broker_redis_dual_publish_enabled and settings.event_broker_redis_consume_enabled:
         from app.services.event_broker import redis_consume_loop
 
         redis_shadow_task = asyncio.create_task(redis_consume_loop())

--- a/backend/tests/test_lifespan_engine_dispose_33e0c681.py
+++ b/backend/tests/test_lifespan_engine_dispose_33e0c681.py
@@ -214,3 +214,56 @@ async def test_lifespan_starts_redis_shadow_task_when_enabled(monkeypatch):
         await asyncio.wait_for(started.wait(), timeout=1)
 
     fake_engine.dispose.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_lifespan_skips_redis_consume_task_when_consume_disabled_even_if_dual_publish_on(monkeypatch):
+    """story #2078 정리(2026-07-21): dual_publish=True인데 redis_consume_enabled=False(api용
+    durable 배선)면 task를 안 만들어야 — 발행(publish) 역할과 구독(consume) 역할을 분리하는
+    신규 게이트. api는 SSE를 안 서빙하니 구독이 불필요(로그 노이즈 + 낭비였던 것을 여기서 막는다)."""
+    from app.main import lifespan
+
+    fake_engine = _patch_engine(monkeypatch)
+    monkeypatch.setattr("app.main.settings.event_broker_redis_dual_publish_enabled", True)
+    monkeypatch.setattr("app.main.settings.event_broker_redis_consume_enabled", False)
+
+    started = asyncio.Event()
+
+    async def fake_consume():
+        started.set()  # 호출되면 안 됨.
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr("app.services.event_broker.redis_consume_loop", fake_consume)
+
+    async with lifespan(MagicMock()):
+        await asyncio.sleep(0.05)
+        assert not started.is_set(), "consume_enabled=False인데 redis_consume_loop가 시작됨"
+
+    fake_engine.dispose.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_lifespan_starts_redis_consume_task_when_both_flags_on(monkeypatch):
+    """dual_publish=True AND consume_enabled=True(둘 다 필요) — realtime용 배선(default True라
+    명시 안 해도 되지만, 회귀 가드로 명시 조합을 직접 검증)."""
+    from app.main import lifespan
+
+    fake_engine = _patch_engine(monkeypatch)
+    monkeypatch.setattr("app.main.settings.event_broker_redis_dual_publish_enabled", True)
+    monkeypatch.setattr("app.main.settings.event_broker_redis_consume_enabled", True)
+
+    started = asyncio.Event()
+
+    async def fake_consume():
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            return
+
+    monkeypatch.setattr("app.services.event_broker.redis_consume_loop", fake_consume)
+
+    async with lifespan(MagicMock()):
+        await asyncio.wait_for(started.wait(), timeout=1)
+
+    fake_engine.dispose.assert_awaited_once()

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -61,6 +61,12 @@ substitutions:
   # sprintable-realtime-prod 배선을 마치는 승격 시점에 GHA prod 분기에도 false를 명시할 것.
   _BACKEND_PG_LISTEN_ENABLED: 'true'
 
+  # E-ARCH S2 정리(story #2078, 2026-07-21): api는 SSE를 서빙하지 않으니(realtime으로 이관
+  # 완료) Redis 구독(consume) 자체가 불필요 — dual_publish(발행)는 여전히 필요(cross-instance
+  # relay 소스가 되어야 하므로 안 건드림). 기본값 'false'(api 전용 durable 값) — 이 값은
+  # deploy-backend에서만 쓰이고 deploy-realtime은 항상 true를 직접 명시(아래, 변수 아님).
+  _BACKEND_REDIS_CONSUME_ENABLED: 'false'
+
 steps:
   # ─── Frontend (Next.js standalone) ────────────────────────────────────────
   - id: build-frontend
@@ -197,7 +203,9 @@ steps:
       # maxScale 와 짝으로 검토. (PO rev 01256 dev 429 right-size durable 화.)
       # E-ARCH 1단계(story #2078): PG_LISTEN_ENABLED durable화 — 위 _BACKEND_PG_LISTEN_ENABLED
       # 주석 참조(dev=false·prod=true 유지, GHA per-env 배선).
-      - --update-env-vars=FASTAPI_URL=${_FASTAPI_URL},DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1,PG_LISTEN_ENABLED=${_BACKEND_PG_LISTEN_ENABLED}
+      # E-ARCH S2 정리(story #2078): REDIS_CONSUME_ENABLED durable화 — 위 _BACKEND_REDIS_
+      # CONSUME_ENABLED 주석 참조(api는 SSE 미서빙이라 구독 불필요, dual_publish는 유지).
+      - --update-env-vars=FASTAPI_URL=${_FASTAPI_URL},DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1,PG_LISTEN_ENABLED=${_BACKEND_PG_LISTEN_ENABLED},REDIS_CONSUME_ENABLED=${_BACKEND_REDIS_CONSUME_ENABLED}
       - --quiet
     # story dbda0baf: push-backend → run-migrate-job(위) 로 변경 — 신규 코드가 마이그 안 된
     # 스키마를 상대로 뜨는 걸 막는다(migrate 실패 시 이 스텝 자체가 안 돎).
@@ -219,6 +227,13 @@ steps:
           echo "skip deploy-realtime: prod gate pending (E-ARCH 1단계 dev 검증 후 오픈)"
           exit 0
         fi
+        # ⚠️story #2078 긴급수정(2026-07-21): PG_LISTEN_ENABLED가 여기 true로 하드코딩돼
+        # 있었다 — PO가 라이브에서 손으로 false로 전환(LISTEN 제거·Redis 단독 dispatch 확認
+        # 완료)했는데, 이 스텝이 명시적으로 true를 다시 밀어넣어 **다음 배포마다 LISTEN이
+        # 부활**하는 시한폭탄이었다("손 값은 배포가 덮는다" 규율의 역방향 재발 — 이번엔 배포가
+        # 고침을 지우는 쪽). realtime은 이제 LISTEN이 구조적으로 불필요(Redis가 authoritative
+        # dispatch) — false로 durable 고정. REDIS_CONSUME_ENABLED=true도 명시(이 서비스가
+        # Redis를 구독+dispatch하는 유일한 서비스라는 것을 코드에 못박음 — api는 false).
         gcloud run deploy sprintable-realtime-${_DEPLOY_ENV} \
           --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA} \
           --region=${_AR_REGION} \
@@ -226,7 +241,7 @@ steps:
           --max-instances=${_REALTIME_MAX_INSTANCES} \
           --timeout=${_REALTIME_TIMEOUT} \
           --allow-unauthenticated \
-          --update-env-vars=FASTAPI_URL=${_REALTIME_URL},DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1,PG_LISTEN_ENABLED=true \
+          --update-env-vars=FASTAPI_URL=${_REALTIME_URL},DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1,PG_LISTEN_ENABLED=false,REDIS_CONSUME_ENABLED=true \
           --quiet
     waitFor: [run-migrate-job]
 


### PR DESCRIPTION
## Summary — 긴급
PO가 라이브에서 손으로 `sprintable-realtime-dev`의 `PG_LISTEN_ENABLED`를 `false`로 전환(LISTEN 제거·오늘 진단한 이중 dispatch 버그 해소 확인)했는데, `cloudbuild.yaml`의 `deploy-realtime` 스텝이 `PG_LISTEN_ENABLED=true`를 **하드코딩**하고 있어 다음 develop 배포(어떤 PR이든)에서 이 손 값이 되돌려지는 시한폭탄이었다. **false로 durable 고정.**

## 역할 분리 정리
`main.py`가 `redis_consume_loop` task 생성을 `event_broker_redis_dual_publish_enabled` 하나로만 게이트하고 있어, publish(발행, 모든 인스턴스 필요)와 consume(구독+dispatch, SSE 서빙하는 realtime만 필요) 역할이 뒤섞여 있었다 — api도 불필요하게 Redis 구독을 유지해 낭비 + shadow 비교 로그 노이즈(api는 LISTEN이 없어 PG 도착 기준점이 항상 0이라 "redis-only"로 계속 오독될 수 있는 상태).

- `event_broker_redis_consume_enabled`(신규 flag) 추가 — default=**True**(realtime이 이미 이 loop로 실 dispatch 중이라 default False는 재배포 시 실시간 정지 위험)
- api만 GHA per-env override로 `false` 배선(`_BACKEND_REDIS_CONSUME_ENABLED`, `PG_LISTEN_ENABLED` durable 분리·#2364와 동일 패턴)
- realtime은 `REDIS_CONSUME_ENABLED=true`를 명시(혼동 방지)

## Test plan
- [x] `event_broker_redis_consume_enabled=False`가 `dual_publish=True`와 무관하게 task 생성을 막는지 신규 테스트
- [x] 둘 다 True일 때 task가 뜨는지 신규 테스트
- [x] `Settings()` 기본값 `True` 확인
- [x] 기존 lifespan/event_broker 회귀 26건 전부 pass
- [x] YAML 파싱 검증(js-yaml) 양쪽 파일
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)