### PR TITLE
fix(story #2086 후속): conversation.message_created가 SSE로 전달 안 됨

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -412,6 +412,22 @@ def _msg_payload(msg: ConversationMessage, sender: "ResolvedMember | TeamMember 
     }
 
 
+def _push_conversation_message_created(
+    pending_sse_pushes: list[tuple[str, dict]], msg_payload: dict,
+) -> None:
+    """story #2086 후속(2026-07-21): `conversation.message_created`(대화 목록 갱신 신호,
+    use-chat-sse.ts)를 `pending_sse_pushes`와 동일 수신자 집합(참가자+멘션 대상, sender/discord/
+    차단 제외 — 이미 `_dispatch_conversation_event`/`_dispatch_mention_events`가 계산)에게
+    dedup 개별 push한다. `chat:message`와 다른 event_type이라 별도 payload로 보낸다."""
+    payload = {"event_type": "conversation.message_created", **msg_payload}
+    pushed: set[str] = set()
+    for pid_str, _ in pending_sse_pushes:
+        if pid_str in pushed:
+            continue
+        pushed.add(pid_str)
+        _push_to_agent(pid_str, dict(payload))
+
+
 async def _dispatch_conversation_event(
     db: AsyncSession,
     conversation: Conversation,
@@ -1965,8 +1981,14 @@ async def send_message(
     # commit 완료 후 SSE push — Event가 DB에 커밋된 상태에서 push해야 race condition 없음
     for pid_str, sse_payload in pending_sse_pushes:
         _push_to_agent(pid_str, sse_payload)
-    # 브라우저 SSE 구독자에게 1회 발행 — pending 유무와 무관하게 commit 후 항상 발행
-    publish_event(str(org_id), "conversation.message_created", _msg_payload(msg, sender))  # canonical (S-COMM-12)
+    # story #2086 후속(2026-07-21, 전수 스윕 발견): publish_event()의 org _subscribers fanout은
+    # 영구 죽은 레지스트리(story #2059/#2067과 동일 근본) — "브라우저 SSE 구독자에게 1회 발행"
+    # 의도와 달리 use-chat-sse.ts의 conversation.message_created 리스너(대화 목록 갱신용)에
+    # 실제로는 아무것도 안 갔다. pending_sse_pushes와 동일 참가자 집합(sender/discord-covered/
+    # 차단 에이전트 제외한 conversation participant + mention target — _dispatch_conversation_
+    # event·_dispatch_mention_events가 이미 계산)에게 개별 push로 복구.
+    publish_event(str(org_id), "conversation.message_created", _msg_payload(msg, sender))  # canonical (S-COMM-12) — L1 activity_events 캡처용 유지
+    _push_conversation_message_created(pending_sse_pushes, _msg_payload(msg, sender))
 
     # ws_chat WebSocket 브로드캐스트 — agent 참가자 room에 실시간 전달 (conv.type/title 무관)
     try:

--- a/backend/tests/test_2087_conversation_message_created_sse.py
+++ b/backend/tests/test_2087_conversation_message_created_sse.py
@@ -1,0 +1,69 @@
+"""story #2086 후속(2026-07-21, 전수 스윕 발견): `conversation.message_created`가 SSE로 안 감 —
+`publish_event()`의 org `_subscribers` fanout은 영구 죽은 레지스트리(story #2059/#2067과 동일
+근본)라 `use-chat-sse.ts`의 `conversation.message_created` 리스너(대화 목록 갱신)에 실제로는
+아무것도 안 갔다. `_push_conversation_message_created()`가 `pending_sse_pushes`와 동일 참가자
+집합(dedup)에게 개별 push하도록 복구한다.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from app.routers.conversations import _push_conversation_message_created
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_pushes_once_per_unique_participant():
+    """참가자 push와 멘션 push가 같은 pid를 중복 포함해도(participant ⊇ mention 겹침 가능)
+    conversation.message_created는 pid당 1회만 나가야."""
+    p1, p2 = str(uuid.uuid4()), str(uuid.uuid4())
+    pending_sse_pushes = [
+        (p1, {"event_type": "chat:message", "id": "m1"}),  # participant push
+        (p2, {"event_type": "chat:message", "id": "m1"}),  # participant push
+        (p1, {"event_type": "conversation:mention", "id": "m1"}),  # p1이 멘션도 됨(중복)
+    ]
+    pushed_calls = []
+    with patch(
+        "app.routers.conversations._push_to_agent",
+        lambda pid, payload: pushed_calls.append((pid, payload)),
+    ):
+        _push_conversation_message_created(pending_sse_pushes, {"id": "m1", "content": "hi"})
+
+    assert len(pushed_calls) == 2  # p1 1회 + p2 1회(dedup) — 3개 입력이 2개 push로
+    pids_pushed = {pid for pid, _ in pushed_calls}
+    assert pids_pushed == {p1, p2}
+    for _, payload in pushed_calls:
+        assert payload["event_type"] == "conversation.message_created"
+        assert payload["content"] == "hi"
+
+
+def test_no_pushes_when_no_recipients():
+    pushed_calls = []
+    with patch(
+        "app.routers.conversations._push_to_agent",
+        lambda pid, payload: pushed_calls.append((pid, payload)),
+    ):
+        _push_conversation_message_created([], {"id": "m1"})
+    assert pushed_calls == []
+
+
+def test_payload_is_copied_per_recipient_not_shared_mutable():
+    """수신자마다 dict 사본이어야(한 명의 로컬 mutation이 다른 수신자 payload에 안 새도록)."""
+    p1, p2 = str(uuid.uuid4()), str(uuid.uuid4())
+    pending_sse_pushes = [(p1, {}), (p2, {})]
+    captured = []
+    with patch(
+        "app.routers.conversations._push_to_agent",
+        lambda pid, payload: captured.append(payload),
+    ):
+        _push_conversation_message_created(pending_sse_pushes, {"id": "m1"})
+
+    assert len(captured) == 2
+    captured[0]["mutated"] = True
+    assert "mutated" not in captured[1]


### PR DESCRIPTION
## Summary
story #2086 전수 스윕에서 발견 — `publish_event()`의 org `_subscribers` fanout은 영구 죽은 레지스트리(story #2059/#2067과 동일 근본)라 `use-chat-sse.ts`의 `conversation.message_created` 리스너(대화 목록 갱신용)에 실제로는 아무것도 안 갔다.

## Fix
`pending_sse_pushes`(`chat:message`용으로 이미 계산된 참가자+멘션 대상 집합 — sender/discord-covered/차단 에이전트 제외)와 동일 수신자에게 `conversation.message_created`를 개별 push하는 `_push_conversation_message_created()` 헬퍼 추가.

- dedup(참가자∩멘션 중복 제거)
- payload는 수신자마다 사본(공유 mutable 방지)
- `publish_event()` 호출은 유지 — L1 `activity_events` 캡처 진입점이라(SSE 전달과는 별개 관심사)

## Test plan
- [x] 신규 3건 — dedup 동작·무수신자 no-op·payload 비공유(mutation 격리)
- [x] 기존 `test_conversations.py` 회귀 18건 전부 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)