### PR TITLE
fix(auth): story cd10e123(P0) — refresh 멀티인스턴스 race grace-window fork

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -224,6 +224,16 @@ class Settings(BaseSettings):
     legacy_auth_issue: bool = True               # 기존 self-issued JWT 로그인/refresh 발급
     legacy_auth_verify: bool = True              # 기존 self-issued JWT 검증(proxy.ts·FastAPI)
 
+    # ⛔P0(신 클래스, #1887과 별개) — proxy.ts singleFlightRefresh는 Cloud Run 인스턴스-로컬
+    # in-memory Map이라 멀티인스턴스(session affinity 꺼짐, gcloud 실측 dev max=3) 간 dedupe가
+    # 안 된다. 하드리프레시의 병렬 인증요청이 인스턴스 분산되면 같은 refresh_token으로 동시
+    # rotate 경합 → 진 쪽은 원자 single-use rotation에 의해 TOKEN_REVOKED 401 → FE가
+    # clearAuthCookies() 실행 → 세션은 살아있는데 강제 로그아웃. FE 그레이스 재사용 패턴
+    # (REFRESH_GRACE_MS=5000, proxy.ts)을 BE로 옮겨 인스턴스 개수/라우팅과 무관하게 만든다
+    # (오르테가·미르코 판단: Redis로 FE 상태공유는 proxy.ts가 edge 런타임이라 과한 인프라 —
+    # 배제. DB-only fork-rotation이 근본이면서 인프라 안 키우는 정공법).
+    auth_refresh_grace_seconds: int = 5
+
     firebase_project_id: str = ""  # Firebase/Identity Platform GCP 프로젝트 ID(dev/prod 분리)
 
     # story 132e7204(Phase1-S4): Next.js BFF↔FastAPI 세션쿠키 발급 내부 호출 공유시크릿.

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -773,10 +773,32 @@ async def refresh_token(
         .returning(RefreshToken.user_id)
     )).scalar_one_or_none()
     if revoked_user_id is None:
-        logger.warning(
-            "auth.refresh 실패 reason=token_not_found_or_revoked_or_expired key=%s", correlation_key,
+        # ⛔P0 신 클래스(#1887 쿠키-Domain no-op과 별개 — config.py auth_refresh_grace_seconds
+        # 주석 참조): proxy.ts 의 FE 인스턴스-로컬 single-flight dedupe 는 Cloud Run 멀티인스턴스
+        # 간 공유가 안 돼, 하드리프레시의 병렬 인증요청이 인스턴스 분산되면 같은 RT 로 동시
+        # rotate 경합이 남는다 — 진 쪽은 방금(grace window 내) 이미 소비된 RT 를 만난 것뿐,
+        # 진짜 stale/탈취 replay 가 아니다. grace window 내 revoke 된 토큰이면 하드 401 로 FE
+        # clearAuthCookies()(강제 로그아웃)를 유발하는 대신 독립적인 새 rotation 을 한 번 더
+        # 발급(fork)한다 — 이미 소비된 old RT 를 재사용하는 게 아니라 그 자신만의 새 RT 를
+        # 새로 발급받을 뿐이라 원자 single-use 불변식 자체는 안 깨진다.
+        grace_cutoff = datetime.now(timezone.utc) - timedelta(seconds=settings.auth_refresh_grace_seconds)
+        revoked_user_id = (await session.execute(
+            select(RefreshToken.user_id).where(
+                RefreshToken.token_hash == token_hash,
+                RefreshToken.revoked_at.is_not(None),
+                RefreshToken.revoked_at > grace_cutoff,
+                RefreshToken.expires_at > datetime.now(timezone.utc),
+            )
+        )).scalar_one_or_none()
+        if revoked_user_id is None:
+            logger.warning(
+                "auth.refresh 실패 reason=token_not_found_or_revoked_or_expired key=%s", correlation_key,
+            )
+            return _err("TOKEN_REVOKED", "Refresh token revoked or expired", 401)
+        logger.info(
+            "auth.refresh grace_reuse key=%s user_id=%s reason=multi_instance_race_loser_fork_rotation",
+            correlation_key, revoked_user_id,
         )
-        return _err("TOKEN_REVOKED", "Refresh token revoked or expired", 401)
 
     user = await _get_user_by_id(session, revoked_user_id)
     if not user:

--- a/backend/tests/test_e5225c0a_refresh_atomic_realdb.py
+++ b/backend/tests/test_e5225c0a_refresh_atomic_realdb.py
@@ -2,8 +2,18 @@
 
 산티아고 실측: SELECT→UPDATE 비원자 rotation이 Cloud Run 멀티 인스턴스 간 race를 유발해
 /auth/refresh 239건 중 230건 401(30일 sp_rt 쿠키가 실패를 무한 재생산). 이 테스트는 동일
-refresh_token으로 동시 2요청을 쏴 정확히 1건만 성공(switch_account 선례와 동형 single-use
-원자 rotation)함을 라이브 PG로 실증한다.
+refresh_token으로 동시 2요청을 쏴 원자 single-use rotation(switch_account 선례와 동형)이
+정확히 1건만 실제로 revoke함을 라이브 PG로 실증한다.
+
+⛔story cd10e123(P0, e5225c0a와 별개 신 클래스) 갱신: 원자 rotation 자체는 여전히
+single-use(위 불변식 유지)이나, "진 쪽에게 무엇을 응답하는지"가 바뀌었다 — 예전엔 하드
+401(TOKEN_REVOKED)로 FE가 clearAuthCookies() 실행해 강제 로그아웃됐다(멀티인스턴스 in-memory
+dedup 미공유 때문에 이게 진짜 race의 정상 경로로 발생). 이제는 grace window(config.py
+auth_refresh_grace_seconds, 기본 5s) 내 revoke된 토큰이면 진짜 stale/replay가 아니라 race
+패자로 판정해 독립적인 새 rotation(fork)을 발급, 200으로 응답한다 — 그래서 아래
+`test_concurrent_refresh_same_token_exactly_one_succeeds_realdb`는 [200,401]이 아니라
+[200,200](양쪽 다 독립적으로 유효한, 그러나 서로 다른 토큰)을 기대하도록 갱신됐다.
+grace window 밖(진짜 stale)은 여전히 401 — 아래 `_after_grace` 테스트가 그 경계를 증명한다.
 """
 from __future__ import annotations
 
@@ -91,7 +101,9 @@ async def _setup_app(app, Session):
 
 @pytest.mark.anyio
 async def test_concurrent_refresh_same_token_exactly_one_succeeds_realdb():
-    """까심 race 재현: 동일 refresh_token으로 동시 2요청 → 정확히 1건 200, 1건 401(TOKEN_REVOKED)."""
+    """까심 race 재현 — 갱신(story cd10e123): 동일 refresh_token 동시 2요청 → 이제 둘 다 200
+    (grace-window fork). 원자성 불변식은 "둘이 서로 다른 독립 토큰을 받는지"로 증명한다 —
+    같은 토큰을 공유해 받으면 그건 그것대로 버그(양쪽이 같은 세션을 오인)."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -107,12 +119,13 @@ async def test_concurrent_refresh_same_token_exactly_one_succeeds_realdb():
                 client.post("/api/v2/auth/refresh", json={"refresh_token": seeded["raw_refresh"]}),
             )
             statuses = sorted(r.status_code for r in results)
-            assert statuses == [200, 401], (
-                f"원자성 실패 — 동시 2요청 결과가 [200,401]이 아님: {statuses} "
-                f"(둘 다 200이면 double-spend race 재발)"
+            assert statuses == [200, 200], (
+                f"grace-window fork 실패 — 동시 2요청 결과가 [200,200]이 아님: {statuses} "
+                f"(1건이라도 401이면 멀티인스턴스 race 강제로그아웃 재발)"
             )
-            failed = next(r for r in results if r.status_code == 401)
-            assert failed.json()["error"]["code"] == "TOKEN_REVOKED"
+            rt_a = results[0].json()["data"]["refresh_token"]
+            rt_b = results[1].json()["data"]["refresh_token"]
+            assert rt_a != rt_b, "두 race 요청이 같은 refresh_token을 받음 — double-spend/세션 혼선"
         finally:
             await client.aclose()
     finally:
@@ -121,8 +134,9 @@ async def test_concurrent_refresh_same_token_exactly_one_succeeds_realdb():
 
 
 @pytest.mark.anyio
-async def test_refresh_already_revoked_token_401_realdb():
-    """회귀 0: 이미 사용된(revoked) 토큰 재사용 → 401(단발성 rotation 유지 확인)."""
+async def test_refresh_replay_within_grace_window_forks_new_session_realdb():
+    """story cd10e123: grace window(기본 5s) 내 순차 재사용 → 200(fork) — race 패자가 강제
+    로그아웃되지 않고 독립적인 새 세션을 받는다는 게 이 신 클래스 fix의 핵심 계약."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -136,6 +150,46 @@ async def test_refresh_already_revoked_token_401_realdb():
             first = await client.post("/api/v2/auth/refresh", json={"refresh_token": seeded["raw_refresh"]})
             assert first.status_code == 200, first.text
             second = await client.post("/api/v2/auth/refresh", json={"refresh_token": seeded["raw_refresh"]})
+            assert second.status_code == 200, second.text
+            assert first.json()["data"]["refresh_token"] != second.json()["data"]["refresh_token"]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_refresh_replay_after_grace_window_still_401_realdb():
+    """회귀 0(갱신): grace window *밖*의 진짜 stale replay는 여전히 401 — grace가 무기한
+    재사용을 허용하는 게 아님을 경계값으로 증명(revoked_at을 grace+1s 과거로 직접 backdate)."""
+    from app.main import app
+    from app.core.config import settings
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_user_with_refresh_token(s)
+
+        await _setup_app(app, Session)
+        client = _client_for(app)
+        try:
+            first = await client.post("/api/v2/auth/refresh", json={"refresh_token": seeded["raw_refresh"]})
+            assert first.status_code == 200, first.text
+
+            from app.core.security import hash_token
+            from app.models.user import RefreshToken
+            from sqlalchemy import update as sa_update
+            stale_at = datetime.now(timezone.utc) - timedelta(seconds=settings.auth_refresh_grace_seconds + 1)
+            async with Session() as s:
+                await s.execute(
+                    sa_update(RefreshToken)
+                    .where(RefreshToken.token_hash == hash_token(seeded["raw_refresh"]))
+                    .values(revoked_at=stale_at)
+                )
+                await s.commit()
+
+            second = await client.post("/api/v2/auth/refresh", json={"refresh_token": seeded["raw_refresh"]})
             assert second.status_code == 401
             assert second.json()["error"]["code"] == "TOKEN_REVOKED"
         finally:
@@ -147,9 +201,11 @@ async def test_refresh_already_revoked_token_401_realdb():
 
 @pytest.mark.anyio
 async def test_refresh_failure_logs_reason_and_correlation_key_realdb(caplog):
-    """산티아고 관측성 요구(item 3): 실패 시 reason+상관키가 로그에 남는지 실증."""
+    """산티아고 관측성 요구(item 3): grace window 밖 실패 시 reason+상관키가 로그에 남는지 실증
+    (story cd10e123 갱신: grace 안쪽은 이제 성공이라 이 테스트는 grace 밖 시나리오로 검증)."""
     import logging
     from app.main import app
+    from app.core.config import settings
 
     engine, Session = await _session_factory()
     try:
@@ -161,6 +217,18 @@ async def test_refresh_failure_logs_reason_and_correlation_key_realdb(caplog):
         try:
             first = await client.post("/api/v2/auth/refresh", json={"refresh_token": seeded["raw_refresh"]})
             assert first.status_code == 200
+
+            from app.core.security import hash_token
+            from app.models.user import RefreshToken
+            from sqlalchemy import update as sa_update
+            stale_at = datetime.now(timezone.utc) - timedelta(seconds=settings.auth_refresh_grace_seconds + 1)
+            async with Session() as s:
+                await s.execute(
+                    sa_update(RefreshToken)
+                    .where(RefreshToken.token_hash == hash_token(seeded["raw_refresh"]))
+                    .values(revoked_at=stale_at)
+                )
+                await s.commit()
 
             with caplog.at_level(logging.WARNING, logger="app.routers.auth"):
                 second = await client.post(


### PR DESCRIPTION
## Summary
- ⛔P0 신 클래스(#1887 쿠키-Domain no-op과 별개, 오르테가·미르코 판단 합의): `proxy.ts`의 `singleFlightRefresh`가 Cloud Run 인스턴스-로컬 in-memory Map이라 멀티인스턴스(gcloud 실측 dev `minScale=1/maxScale=3`·session affinity 꺼짐) 간 dedupe가 안 됨. 하드리프레시의 병렬 인증요청이 인스턴스 분산되면 같은 refresh_token으로 동시 rotate 경합 → 원자 single-use rotation(story e5225c0a)에 의해 진 쪽은 `TOKEN_REVOKED` 401 → FE `clearAuthCookies()` → 세션은 살아있는데 강제 로그아웃.
- fix: FE 그레이스 재사용 패턴(`REFRESH_GRACE_MS=5s`)을 BE 공유소스로 이관 — `auth_refresh_grace_seconds`(기본 5s) 내 이미 revoke된 토큰이면 하드 401 대신 독립적인 새 rotation(fork) 발급. 원자 single-use 불변식은 유지(이미 소비된 토큰 재사용 아님 — 그 자신만의 새 RT 발급).
- 채택 근거: B안(Redis로 FE dedup Map 공유화)은 `proxy.ts`가 edge 런타임이라 edge-호환 클라/Node 전환 필요 → 과한 인프라로 배제. DB-only가 근본이면서 인프라 안 키우는 정공법.

## Test plan
- [x] 뮤테이션 셀프체크: fix stash → RED(4개 실패, 신규 grace 테스트+field 미존재) 확認 → restore → GREEN(5/5)
- [x] `test_concurrent_refresh_same_token_exactly_one_succeeds_realdb` 갱신 — 동시 2요청이 이제 `[200,200]`(서로 다른 독립 토큰) 기대
- [x] `test_refresh_replay_within_grace_window_forks_new_session_realdb`(신규) — grace 내 순차 재사용 → 200
- [x] `test_refresh_replay_after_grace_window_still_401_realdb`(신규) — `revoked_at`을 grace+1s backdate해 경계값으로 여전히 401 실증
- [x] `test_refresh_failure_logs_reason_and_correlation_key_realdb` 갱신 — grace 밖 실패 로그 관측성 유지 확認
- [x] `test_2078_no_duplicate_settings_fields` 통과 확認(신규 필드 중복선언 없음)
- [x] 관련 auth/refresh 전체 스위트 313 passed(9개 무관 pre-existing 실패는 clean develop baseline에서도 동일 재현 확認 — 내 변경과 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)