### PR TITLE
fix(auth): story cd10e123(P0) — FE proxy.ts in-memory refresh dedup 제거

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -234,36 +234,15 @@ async function tryRefreshViaFastapi(request: NextRequest): Promise<{ accessToken
   }
 }
 
-// AC1(551bbbee): single-flight refresh. refresh 는 single-use rotation(첫 건이 RT revoke)이라, 대시보드
-// 동시요청이 같은 RT 로 각자 refresh 하면 첫 건만 통과·나머지 401 → 강제 로그아웃("세션 너무 짧음")이던
-// 레이스를 제거. RT 기준 in-flight 1개로 dedupe(나머지는 그 promise 를 await/재사용) — 실제 refresh 호출은
-// 1회라 single-use 보안 유지.
-//   - **pending 동안은 시간 무관하게 그 promise 재사용**(refresh 가 10s 걸려도 1개만 — 시작-기준 grace 면
-//     느린 refresh 가 grace 넘겨 pending 중 신규 refresh 시작=레이스 재발, RC HIGH 봉합).
-//   - 해소(settled) 후엔 **해소 시각 기준 grace** 동안만 결과 재사용 — cookie 갱신 전 도착한 burst 꼬리
-//     요청도 옛 RT 로 새 refresh 안 함.
-// setTimeout 미사용(edge 런타임 post-response 실행 불확실)·size-cap lazy prune(무한증가 방지).
-const REFRESH_GRACE_MS = 5_000;
-type RefreshEntry = { p: Promise<{ accessToken: string; refreshToken: string } | null>; settledAt: number | null };
-const inflightRefresh = new Map<string, RefreshEntry>();
-
-function singleFlightRefresh(request: NextRequest): Promise<{ accessToken: string; refreshToken: string } | null> {
-  const rt = request.cookies.get(SP_RT_COOKIE)?.value;
-  if (!rt) return Promise.resolve(null);
-  const now = Date.now();
-  const existing = inflightRefresh.get(rt);
-  // pending(settledAt===null) → 시간 무관 재사용 / settled → 해소 시각 + grace 내에서만 재사용.
-  if (existing && (existing.settledAt === null || existing.settledAt + REFRESH_GRACE_MS > now)) {
-    return existing.p;
-  }
-  const entry: RefreshEntry = { p: tryRefreshViaFastapi(request), settledAt: null };
-  inflightRefresh.set(rt, entry);
-  void entry.p.finally(() => { entry.settledAt = Date.now(); }); // 해소 시각 기록 → grace 시작점
-  if (inflightRefresh.size > 64) { // settled + grace 지난 항목 lazy prune(pending 은 유지)
-    for (const [k, v] of inflightRefresh) if (v.settledAt !== null && v.settledAt + REFRESH_GRACE_MS <= now) inflightRefresh.delete(k);
-  }
-  return entry.p;
-}
+// story cd10e123(P0) 근본 수정 — AC1(551bbbee)이 만든 single-flight in-memory dedupe(아래 옛
+// singleFlightRefresh)는 Cloud Run 멀티인스턴스(prod maxScale=10)에서 인스턴스 간 공유가 안 돼
+// 무의미했다: 하드리프레시의 병렬 인증요청이 다른 인스턴스로 라우팅되면 각자 독립 Map으로
+// 같은 refresh_token을 rotate 시도 → 원자적 single-use rotation(e5225c0a)에 의해 두 번째
+// 인스턴스는 TOKEN_REVOKED 401 → clearAuthCookies() → 세션 살아있는데 강제 로그아웃.
+//
+// 근본 fix는 BE로 옮겼다 — `/api/v2/auth/refresh`가 이제 grace-window(기본 5s) 내 재사용된
+// 토큰에 한해 하드 401 대신 독립적인 새 rotation을 fork 발급한다(PR #2377). dedupe가 인스턴스
+// 경계와 무관하게 필요 없어진 것 — FE는 그냥 매 요청마다 직접 refresh를 호출하면 된다(아래).
 
 function applyTokenCookies(
   response: NextResponse,
@@ -320,7 +299,7 @@ function loginRedirect(request: NextRequest): NextResponse {
 }
 
 // story e5225c0a(P0): refresh 시도 후 세션을 못 살렸을 때의 공통 응답. `refreshFailed`=true
-// (singleFlightRefresh 자체가 null — BE 401/rotation 실패)일 때만 clearAuthCookies 호출.
+// (tryRefreshViaFastapi 자체가 null — BE 401/rotation 실패)일 때만 clearAuthCookies 호출.
 // refreshMatchesActive=false(RC2, superseded 계정의 늦은 refresh)는 refresh 자체는 성공이므로
 // 쿠키를 그대로 둔다 — 두 실패 사유를 여기서 한 번만 구분해 양쪽 호출부의 분기를 통일한다.
 function handleUnauthenticated(request: NextRequest, isApiPath: boolean, refreshFailed: boolean): NextResponse {
@@ -355,7 +334,7 @@ export async function proxy(request: NextRequest) {
   const accessToken = request.cookies.get(SP_AT_COOKIE)?.value;
 
   if (!accessToken) {
-    const tokens = await singleFlightRefresh(request);
+    const tokens = await tryRefreshViaFastapi(request);
     if (!tokens) return handleUnauthenticated(request, isApiPath, true);
     // RC2: stale refresh(다른 계정)면 적용 안 함 — 잘못된 계정으로 복귀 방지(쿠키는 유지).
     if (!(await refreshMatchesActive(request, tokens.accessToken))) {
@@ -371,7 +350,7 @@ export async function proxy(request: NextRequest) {
 
   if (!claims) {
     // access token invalid/expired — try refresh
-    const tokens = await singleFlightRefresh(request);
+    const tokens = await tryRefreshViaFastapi(request);
     if (!tokens) return handleUnauthenticated(request, isApiPath, true);
     // RC2: stale refresh(다른 계정)면 적용 안 함 — 잘못된 계정으로 복귀 방지(쿠키는 유지).
     if (!(await refreshMatchesActive(request, tokens.accessToken))) {
@@ -415,7 +394,7 @@ export async function proxy(request: NextRequest) {
   }
 
   if (claims.exp !== undefined && claims.exp - now < 300) {
-    const tokens = await singleFlightRefresh(request);
+    const tokens = await tryRefreshViaFastapi(request);
     // RC2: stale refresh(다른 계정)면 적용 안 함 — 현 active 세션 유지.
     if (tokens && (await refreshMatchesActive(request, tokens.accessToken))) {
       applyTokenCookies(response, tokens.accessToken, tokens.refreshToken);


### PR DESCRIPTION
BE(#2377)가 grace-window(5s) 내 재사용된 refresh_token에 대해 하드 401 대신 독립 rotation을 fork 발급하도록 바뀌면서, FE의 `singleFlightRefresh`(story 551bbbee AC1)가 막던 문제 자체가 BE 공유소스에서 원천 해소됐다.

`singleFlightRefresh`는 애초에 Cloud Run 멀티인스턴스(prod maxScale=10)에서 인스턴스 간 공유가 안 되는 모듈 레벨 in-memory Map이었다 — 하드리프레시의 병렬 요청이 다른 인스턴스로 라우팅되면 각자 독립 Map으로 같은 RT를 rotate 시도해 두 번째 요청이 TOKEN_REVOKED 401 → 강제 로그아웃되던 게 이번 P0(story cd10e123)의 근본. B안(Redis로 FE Map 공유)은 `proxy.ts`가 edge 런타임이라 edge-호환 클라 전환 등 과한 인프라라 배제하고, A안(BE idempotent)으로 3-lane(오르테가·디디·미르코) 합의 — dedupe 자체가 인스턴스 경계와 무관하게 불필요해지는 방향.

`inflightRefresh` Map·`singleFlightRefresh`·`REFRESH_GRACE_MS`·`RefreshEntry` 전부 제거, 3개 호출부를 `tryRefreshViaFastapi(request)` 직접 호출로 교체 — FE는 이제 그냥 매 요청마다 refresh를 호출하고, idempotency는 BE가 보장한다.

## 검증
`proxy.test.ts` 47개 전부 통과(블랙박스 동작 테스트라 내부 헬퍼명 변경 무관). type-check/lint(0 errors)/build(EXIT 0)/vitest 전체(290파일·1994개) green.

## 미완 — 라이브
prod에서 하드리프레시 반복 재현(선생님 실기기, 만료 시점 근처) 후 인증 안 풀리는지 확認 필요.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>