### PR TITLE
fix(mcp): story cd10e123 계열 긴급 — deploy_mcp_dev.sh AGENT_API_KEY ambient 상속 제거

### DIFF
--- a/backend/scripts/deploy_mcp_dev.sh
+++ b/backend/scripts/deploy_mcp_dev.sh
@@ -16,8 +16,14 @@ PROJECT="sprintable-494803"
 AR="${REGION}-docker.pkg.dev/${PROJECT}/sprintable/backend"
 SHA="${COMMIT_SHA:-latest-dev}"
 DEV_BACKEND_URL="https://sprintable-backend-dev-787818285179.${REGION}.run.app"
-# AGENT_API_KEY 는 http 모드 never-hit fallback(per-request bearer 가 실키)·placeholder 안전.
-ENV_KEY="${AGENT_API_KEY:-_http_per_request_bearer_only_}"
+# ⛔story cd10e123 계열 긴급수정(2026-07-21, 오르테가군 발견+디디 독립재현): AGENT_API_KEY 는
+# http 모드 never-hit fallback(per-request bearer 가 실키)이라 원래도 어떤 실값도 필요 없다 —
+# 그런데 예전엔 이 값을 호출자 쉘의 ambient `AGENT_API_KEY`에서 상속받았다. oscar 런처가 모든
+# 에이전트 런타임 쉘에 자신의 실 `AGENT_API_KEY`를 상시 export하므로, 에이전트가 이 스크립트를
+# 자기 쉘에서 실행하면 그 실 키가 그대로 Cloud Run 평문 env로 구워지는 게 구조적으로 100%
+# 재현됐다(실제 사건 발생·17일간 노출 확認). override가 필요한 시나리오 자체가 없으므로(실인증은
+# per-request Bearer) 호출자 env를 아예 참조하지 않는다 — 리터럴 고정.
+readonly MCP_DEV_PLACEHOLDER_AGENT_KEY="_http_per_request_bearer_only_"
 
 echo ">>> deploy sprintable-mcp-dev (image=backend:${SHA})"
 gcloud run deploy sprintable-mcp-dev \
@@ -25,7 +31,7 @@ gcloud run deploy sprintable-mcp-dev \
   --region="${REGION}" \
   --command="python" \
   --args="-m,sprintable_mcp" \
-  --set-env-vars="MCP_TRANSPORT=http,SPRINTABLE_API_URL=${DEV_BACKEND_URL},AGENT_API_KEY=${ENV_KEY}" \
+  --set-env-vars="MCP_TRANSPORT=http,SPRINTABLE_API_URL=${DEV_BACKEND_URL},AGENT_API_KEY=${MCP_DEV_PLACEHOLDER_AGENT_KEY}" \
   --allow-unauthenticated \
   --min-instances=0 \
   --max-instances=2 \


### PR DESCRIPTION
## Summary
- 오르테가군 발견 + 디디 독립재현: `deploy_mcp_dev.sh`가 호출자 쉘의 ambient `AGENT_API_KEY`를 상속받아 그대로 Cloud Run 평문 env로 굽고 있었음.
- oscar 런처가 모든 에이전트 런타임 쉘에 실 `AGENT_API_KEY`를 상시 export하므로(디디 자신의 쉘에서도 확認 — presence만, 값은 미확인), **에이전트가 이 스크립트를 자기 쉘에서 실행하면 100% 재현**되는 구조적 결함이었음(어제 실사건: 17일간 노출).
- fix: 호출자 env를 아예 참조하지 않도록 리터럴 상수로 고정. 이 값은 애초에 never-hit fallback(http 모드는 per-request Bearer가 실인증)이라 override 시나리오 자체가 없음.

## 병행 스캔 (오르테가군 지시 ②)
`backend/scripts/` 내 전 deploy/provision 스크립트의 `${VAR:-default}` 패턴 전수 확認:
- `GCP_PROJECT`/`GCP_REGION`/`AR_REPO`/`ENV`/`COMMIT_SHA`/`*_SQL_INSTANCE` 류는 비-시크릿 식별자(ambient 상속돼도 최악이 잘못된 프로젝트/리전 문자열이지 시크릿 유출 아님) — 안 건드림.
- `deploy_mcp_prod.sh`의 `AGENT_API_KEY_SECRET`은 시크릿 **이름** 참조일 뿐(값 아님), PO 전담 실행 문서화됨, 에이전트 쉘에 ambient로도 안 잡혀있음(확認 완료) — 낮은 리스크, 이번엔 안 건드림.
- 이 스캔 범위에서 "리터럴 시크릿 값 + 실제 에이전트-ambient" 조합은 `AGENT_API_KEY`(`deploy_mcp_dev.sh`) 단 1건.

## Test plan
- [x] `bash -n`으로 문법 검증
- [ ] 다음 실 배포 시 mcp-dev env에 안전 placeholder만 들어가는지 확認(코드 리뷰로 충분 — 이 스크립트는 CI 미경유·수동 실행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)