### PR TITLE
feat(E-ARCH 0단계): story #2078 — SSE 멀티플렉서 dev 플래그 GO

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -78,6 +78,10 @@ jobs:
             # prod가 Redis 연결을 갖추는 승격 시점에 산티아고군이 실측값으로 override할 것.
             echo "redis_url=" >> "$GITHUB_OUTPUT"
             echo "backend_redis_dual_publish_enabled=false" >> "$GITHUB_OUTPUT"
+            # story #2078(E-ARCH 0단계, 오르테가군 판정 2026-07-21): dev 실측 GREEN 확認 전
+            # prod에 얹지 않는다 — develop→main 48커밋 일괄승격에 검증 안 된 롤백 플래그를
+            # 섞으면 문제 발생 시 원인 격리가 안 된다. dev 실측 후 별도 판단.
+            echo "sse_multiplex_enabled=false" >> "$GITHUB_OUTPUT"
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
@@ -128,6 +132,11 @@ jobs:
             # deploy-realtime 스텝이 이미 dev 전용 가드 안에서 직접 명시(변수 아님).
             echo "redis_url=redis://10.164.120.243:6379" >> "$GITHUB_OUTPUT"
             echo "backend_redis_dual_publish_enabled=true" >> "$GITHUB_OUTPUT"
+            # story #2078(E-ARCH 0단계, 오르테가군 GO 2026-07-21): dev만 켠다 — 게이트(devtools
+            # 탭당 EventSource 1개·정상 채널 이벤트 도착·롤백 왕복) 실측 통과가 prod 승격의
+            # 전제. 3개 소비 훅(use-sse-notifications·use-chat-sse·use-team-presence)이 이
+            # 값 하나로 공유 커넥션 vs 독립 커넥션을 가른다(realtime-provider.tsx).
+            echo "sse_multiplex_enabled=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Submit Cloud Build
@@ -135,6 +144,6 @@ jobs:
           gcloud builds submit \
             --config=cloudbuild.yaml \
             --project="${{ secrets.GCP_PROJECT_ID }}" \
-            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}",_BACKEND_MIN_INSTANCES="${{ steps.env.outputs.backend_min_instances }}",_BACKEND_MAX_INSTANCES="${{ steps.env.outputs.backend_max_instances }}",_BACKEND_TIMEOUT="${{ steps.env.outputs.backend_timeout }}",_GA4_MEASUREMENT_ID="${{ steps.env.outputs.ga4_measurement_id }}",_REALTIME_MIN_INSTANCES="${{ steps.env.outputs.realtime_min_instances }}",_REALTIME_MAX_INSTANCES="${{ steps.env.outputs.realtime_max_instances }}",_REALTIME_TIMEOUT="${{ steps.env.outputs.realtime_timeout }}",_REALTIME_URL="${{ steps.env.outputs.realtime_url }}",_BACKEND_PG_LISTEN_ENABLED="${{ steps.env.outputs.backend_pg_listen_enabled }}",_BACKEND_REDIS_CONSUME_ENABLED="${{ steps.env.outputs.backend_redis_consume_enabled }}",_REDIS_URL="${{ steps.env.outputs.redis_url }}",_BACKEND_REDIS_DUAL_PUBLISH_ENABLED="${{ steps.env.outputs.backend_redis_dual_publish_enabled }}" \
+            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}",_BACKEND_MIN_INSTANCES="${{ steps.env.outputs.backend_min_instances }}",_BACKEND_MAX_INSTANCES="${{ steps.env.outputs.backend_max_instances }}",_BACKEND_TIMEOUT="${{ steps.env.outputs.backend_timeout }}",_GA4_MEASUREMENT_ID="${{ steps.env.outputs.ga4_measurement_id }}",_REALTIME_MIN_INSTANCES="${{ steps.env.outputs.realtime_min_instances }}",_REALTIME_MAX_INSTANCES="${{ steps.env.outputs.realtime_max_instances }}",_REALTIME_TIMEOUT="${{ steps.env.outputs.realtime_timeout }}",_REALTIME_URL="${{ steps.env.outputs.realtime_url }}",_BACKEND_PG_LISTEN_ENABLED="${{ steps.env.outputs.backend_pg_listen_enabled }}",_BACKEND_REDIS_CONSUME_ENABLED="${{ steps.env.outputs.backend_redis_consume_enabled }}",_REDIS_URL="${{ steps.env.outputs.redis_url }}",_BACKEND_REDIS_DUAL_PUBLISH_ENABLED="${{ steps.env.outputs.backend_redis_dual_publish_enabled }}",_SSE_MULTIPLEX_ENABLED="${{ steps.env.outputs.sse_multiplex_enabled }}" \
             --suppress-logs \
             .

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -33,6 +33,11 @@ ARG NEXT_PUBLIC_OAUTH_ENABLED
 ENV NEXT_PUBLIC_OAUTH_ENABLED=${NEXT_PUBLIC_OAUTH_ENABLED}
 ARG NEXT_PUBLIC_GA4_MEASUREMENT_ID
 ENV NEXT_PUBLIC_GA4_MEASUREMENT_ID=${NEXT_PUBLIC_GA4_MEASUREMENT_ID}
+# story #2078(E-ARCH 0단계) — SSE 멀티플렉서 롤백 플래그. dev만 GO(오르테가군 판정,
+# 2026-07-21) — prod는 develop→main 48커밋 일괄승격에 얹으면 문제 발생 시 원인 격리가
+# 안 돼 별도 판단으로 미룬다. 기본값 false(미설정 시 dev-safe fallback).
+ARG NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED=false
+ENV NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED=${NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED}
 RUN pnpm build
 
 # ─── 런타임 ──────────────────────────────────────────────────────────────────

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,6 +23,11 @@ substitutions:
   #    폐기 이력 있음. 트래픽↑ 時 아키텍처 재검토(#2074) 필요.)
   _BACKEND_MAX_INSTANCES: '1'
   _GA4_MEASUREMENT_ID: ""  # dev 기본값 빈 문자열 — prod 트리거에서 G-RYHFE7XM3X 주입
+  # story #2078(E-ARCH 0단계) — SSE 멀티플렉서 롤백 플래그. dev-safe 기본값 'false'(수동
+  # `gcloud builds submit` override 없을 때 안전). GHA가 dev 브랜치에서만 'true' 주입 —
+  # prod는 develop→main 일괄승격에 검증 안 된 플래그를 얹지 않는다(오르테가군 판정,
+  # 2026-07-21 — 문제 생기면 48커밋 중 원인 격리 불가라 별도 판단으로 미룸).
+  _SSE_MULTIPLEX_ENABLED: "false"
   # story #2005(Phase B P1-c, E-A2A-PROTO 리라이어빌리티): Cloud Run 요청 타임아웃이
   # `deploy-backend` 스텝에 `--timeout` 플래그로 명시된 적이 한 번도 없어(grep 확認) 인프라
   # 기본값에 암묵 의존 중이었다(A2A `/rpc` 특히 `SendStreamingMessage` SSE가 사실상 무기한
@@ -96,6 +101,8 @@ steps:
       - NEXT_PUBLIC_OAUTH_ENABLED=true
       - --build-arg
       - NEXT_PUBLIC_GA4_MEASUREMENT_ID=${_GA4_MEASUREMENT_ID}
+      - --build-arg
+      - NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED=${_SSE_MULTIPLEX_ENABLED}
       - .
     env:
       - DOCKER_BUILDKIT=1


### PR DESCRIPTION
오전에 구현·머지된 `sse-multiplexer.ts` + 3개 소비 훅(#2357)이 `NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED` 롤백 플래그 뒤에서 대기 중이었다 — 빌드/배포 파이프라인 어디에도 이 값이 배선 안 돼 있어 dev/prod 둘 다 기본값 false(비활성)였다.

`NEXT_PUBLIC_*`는 Next.js가 빌드타임에 클라이언트 번들로 정적 인라인한다 — 기존 FASTAPI_URL/GA4 패턴과 동일하게 Dockerfile ARG/ENV + cloudbuild.yaml `--build-arg` + GHA 브랜치별 output 3단 배선이 필요했다.

## 배선
- `Dockerfile`: ARG/ENV 추가(기본값 false)
- `cloudbuild.yaml`: `_SSE_MULTIPLEX_ENABLED` substitution 신설(dev-safe 기본 'false') + `build-frontend` `--build-arg` 연결
- GHA `cloud-build.yml`: dev 브랜치만 'true' 출력, prod는 명시적으로 'false' — develop→main 48커밋 일괄승격에 검증 안 된 플래그를 얹지 않는다(오르테가군 판정, 2026-07-21). dev 실측 GREEN 확認 후 prod는 별도 판단.

actionlint 검증(pre-existing SC2140 스타일노트만 비례 증가·신규 에러 0). type-check/lint(0 errors) green — 앱 소스코드 변경 없음(순수 빌드/배포 인프라).

## 다음
배포 완료되면 devtools 네트워크로 게이트 실측(탭당 EventSource 1개·`story.status_changed`·`conversation.message_created` 정상 도착·롤백 왕복) — `story.assignee_changed`는 별도 알려진 결함(디디군 수정 중)이라 이번 게이트에서 제외.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>