### PR TITLE
feat(i18n): story #2084 1순위 — invite·login·reset-password 하드코딩 배선

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1893,7 +1893,7 @@
     "authFailed": "Authentication failed. Please try again.",
     "backToLogin": "Go to login →",
     "joinedOrg": "You've joined {org}",
-    "joinHeadingLine2": "Join this organization",
+    "joinHeading": "Join <b>{org}</b>",
     "invitedByPerson": "{name} invited you",
     "invitedByOrgFallback": "Invited by {org}",
     "namePlaceholder": "Name",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1890,7 +1890,31 @@
     "invalidToken": "Invalid invitation link.",
     "acceptFailed": "Failed to accept invitation.",
     "accepting": "Accepting invitation...",
-    "authFailed": "Authentication failed. Please try again."
+    "authFailed": "Authentication failed. Please try again.",
+    "backToLogin": "Go to login →",
+    "joinedOrg": "You've joined {org}",
+    "joinHeadingLine2": "Join this organization",
+    "invitedByPerson": "{name} invited you",
+    "invitedByOrgFallback": "Invited by {org}",
+    "namePlaceholder": "Name",
+    "tosAgreement": "I agree to the Terms of Service and Privacy Policy",
+    "joining": "Joining…",
+    "submit": "Join",
+    "invitedByOrg": "Invited by {org}.",
+    "signupEmail": "You'll sign up with {email}.",
+    "decline": "Decline (for now)"
+  },
+  "resetPassword": {
+    "title": "Set a new password",
+    "placeholder": "New password",
+    "submit": "Change password",
+    "submitting": "Changing…",
+    "done": "Your password has been changed.",
+    "mfaReenroll": "Please set up two-factor authentication again.",
+    "invalidLink": "This link has expired or is invalid.",
+    "strengthHint": "At least 3 of: uppercase, lowercase, number, symbol ({met}/3)",
+    "lengthHint": "At least 8 characters",
+    "submitFailed": "Couldn't change the password. Please try again in a moment."
   },
   "mockup": {
     "title": "Mockups",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1893,7 +1893,7 @@
     "authFailed": "인증에 실패했습니다. 다시 시도해주세요.",
     "backToLogin": "로그인 페이지로 →",
     "joinedOrg": "{org}에 합류했어요",
-    "joinHeadingLine2": "에 합류하세요",
+    "joinHeading": "<b>{org}</b>에 합류하세요",
     "invitedByPerson": "{name}님이 초대했어요",
     "invitedByOrgFallback": "{org}에서 초대했어요",
     "namePlaceholder": "이름",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1890,7 +1890,31 @@
     "invalidToken": "유효하지 않은 초대 링크입니다.",
     "acceptFailed": "초대 수락에 실패했습니다.",
     "accepting": "수락 중...",
-    "authFailed": "인증에 실패했습니다. 다시 시도해주세요."
+    "authFailed": "인증에 실패했습니다. 다시 시도해주세요.",
+    "backToLogin": "로그인 페이지로 →",
+    "joinedOrg": "{org}에 합류했어요",
+    "joinHeadingLine2": "에 합류하세요",
+    "invitedByPerson": "{name}님이 초대했어요",
+    "invitedByOrgFallback": "{org}에서 초대했어요",
+    "namePlaceholder": "이름",
+    "tosAgreement": "이용약관 및 개인정보처리방침에 동의합니다",
+    "joining": "합류 중…",
+    "submit": "합류하기",
+    "invitedByOrg": "{org}에서 초대했습니다.",
+    "signupEmail": "{email} 계정으로 가입됩니다.",
+    "decline": "거절 (나중에)"
+  },
+  "resetPassword": {
+    "title": "새 비밀번호 설정",
+    "placeholder": "새 비밀번호",
+    "submit": "비밀번호 변경",
+    "submitting": "변경 중…",
+    "done": "비밀번호가 변경되었습니다.",
+    "mfaReenroll": "2단계 인증을 다시 등록해 주세요.",
+    "invalidLink": "링크가 만료되었거나 유효하지 않습니다.",
+    "strengthHint": "대문자·소문자·숫자·특수문자 중 3가지 이상 ({met}/3)",
+    "lengthHint": "8자 이상",
+    "submitFailed": "비밀번호를 변경하지 못했습니다. 잠시 후 다시 시도해 주세요."
   },
   "mockup": {
     "title": "목업",

--- a/apps/web/src/app/invite/accept/invite-accept-client.tsx
+++ b/apps/web/src/app/invite/accept/invite-accept-client.tsx
@@ -14,6 +14,7 @@ interface InviteAcceptClientProps {
 
 export function InviteAcceptClient({ token, orgName, role, email, projects }: InviteAcceptClientProps) {
   const t = useTranslations('settings');
+  const tInvite = useTranslations('invite');
   const [accepting, setAccepting] = useState(false);
   const [result, setResult] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
@@ -32,9 +33,9 @@ export function InviteAcceptClient({ token, orgName, role, email, projects }: In
       const res = await fetch(`/api/invites/${token}/accept`, { method: 'POST' });
       const json = await res.json() as { error?: { message?: string } };
       if (!res.ok) {
-        setResult({ type: 'error', text: json.error?.message ?? '초대 수락에 실패했습니다.' });
+        setResult({ type: 'error', text: json.error?.message ?? tInvite('acceptFailed') });
       } else {
-        setResult({ type: 'success', text: '초대를 수락했습니다. Dashboard로 이동합니다.' });
+        setResult({ type: 'success', text: `${tInvite('success')} ${tInvite('redirecting')}` });
         setTimeout(() => { window.location.href = '/dashboard'; }, 1500);
       }
     } finally {
@@ -46,11 +47,11 @@ export function InviteAcceptClient({ token, orgName, role, email, projects }: In
     <div className="flex min-h-screen items-center justify-center bg-muted">
       <div className="w-full max-w-sm rounded-2xl bg-background p-8 shadow-lg space-y-6">
         <div className="text-center space-y-2">
-          <h1 className="text-2xl font-bold text-foreground">Organization 초대</h1>
+          <h1 className="text-2xl font-bold text-foreground">{tInvite('title')}</h1>
           <p className="text-sm text-muted-foreground">
-            <span className="font-semibold text-foreground/85">{orgName}</span>에서 초대했습니다.
+            {tInvite('invitedByOrg', { org: orgName })}
           </p>
-          {email && <p className="text-xs text-muted-foreground/60">{email} 계정으로 가입됩니다.</p>}
+          {email && <p className="text-xs text-muted-foreground/60">{tInvite('signupEmail', { email })}</p>}
         </div>
 
         <div className="rounded-lg border border-border bg-muted px-4 py-3">
@@ -59,7 +60,7 @@ export function InviteAcceptClient({ token, orgName, role, email, projects }: In
             <span className="font-medium text-foreground/85">{orgName}</span>
           </div>
           <div className="mt-2 flex items-center justify-between text-sm">
-            <span className="text-muted-foreground">역할</span>
+            <span className="text-muted-foreground">{t('profileRole')}</span>
             <span className="font-medium text-foreground/85 capitalize">{role}</span>
           </div>
           <div className="mt-2 flex items-center justify-between gap-4 text-sm">
@@ -88,7 +89,7 @@ export function InviteAcceptClient({ token, orgName, role, email, projects }: In
               onClick={() => void handleAccept()}
               disabled={accepting}
             >
-              {accepting ? '수락 중…' : '초대 수락'}
+              {accepting ? tInvite('accepting') : tInvite('accept')}
             </Button>
             {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- story a539c649 S2:
                 app/(authenticated)/[ws]/[proj]/ 도입 후 이 규칙이 무관 파일에 오탐(2단 중첩
@@ -98,7 +99,7 @@ export function InviteAcceptClient({ token, orgName, role, email, projects }: In
               href="/dashboard"
               className="block text-center text-sm text-muted-foreground hover:text-foreground/70"
             >
-              거절 (나중에)
+              {tInvite('decline')}
             </a>
           </div>
         )}

--- a/apps/web/src/app/invite/page.test.tsx
+++ b/apps/web/src/app/invite/page.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+//
+// story #2084(i18n 1순위) — joinHeading을 t.rich()로 바꾸면서 PO가 명시한 위험: 태그 이름이
+// 안 맞거나 함수가 빠지면 화면에 "<b>" 문자가 그대로 찍히거나 빈 문자열이 나오는데
+// type-check로는 안 잡힌다. ko/en 양쪽에서 조직명이 <b> 태그 없이 강조 span으로 렌더되고,
+// 문장이 한 줄로 정확히 나오는지 실제 DOM으로 고정한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import InvitePage from './page';
+import koMessages from '../../../messages/ko.json';
+import enMessages from '../../../messages/en.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams('token=tok-1'),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(locale: 'ko' | 'en', node: React.ReactNode) {
+  const messages = locale === 'ko' ? koMessages : enMessages;
+  return (
+    <NextIntlClientProvider locale={locale} messages={messages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+const PREVIEW = { org_name: '뭉클랩', role: 'member' as const, expires_at: '2099-01-01', email: 'a@b.com' };
+
+function stubSuccessFlow() {
+  // preview fetch → /api/me(미인증, auth 화면으로) — success 상태는 직접 auth 성공 경로로 유도.
+  vi.stubGlobal('fetch', vi.fn(async (url: string, opts?: RequestInit) => {
+    if (url.includes('/api/invites/tok-1') && !url.includes('accept')) {
+      return { ok: true, json: async () => ({ data: PREVIEW }) };
+    }
+    if (url === '/api/me') return { ok: false } as Response;
+    if (url === '/api/auth/login' && opts?.method === 'POST') {
+      return { ok: true, json: async () => ({}) };
+    }
+    if (url.includes('/accept')) {
+      return { ok: true, json: async () => ({}) };
+    }
+    throw new Error('unexpected fetch: ' + url);
+  }));
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe('InvitePage — joinHeading t.rich() 렌더 (story #2084)', () => {
+  it('ko: 조직명이 <b> 리터럴 없이 강조 span으로 렌더되고 문장이 정확하다', async () => {
+    stubSuccessFlow();
+    await act(async () => { root.render(wrap('ko', <InvitePage />)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    const h1 = container.querySelector('h1');
+    expect(h1?.textContent).toBe('뭉클랩에 합류하세요');
+    expect(h1?.innerHTML).not.toContain('<b>');
+    expect(h1?.innerHTML).not.toContain('&lt;b&gt;');
+    const emphasized = h1?.querySelector('span.font-semibold');
+    expect(emphasized?.textContent).toBe('뭉클랩');
+  });
+
+  it('en: 조직명이 <b> 리터럴 없이 강조 span으로 렌더되고 문장이 정확하다', async () => {
+    stubSuccessFlow();
+    await act(async () => { root.render(wrap('en', <InvitePage />)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    const h1 = container.querySelector('h1');
+    expect(h1?.textContent).toBe('Join 뭉클랩');
+    expect(h1?.innerHTML).not.toContain('<b>');
+    const emphasized = h1?.querySelector('span.font-semibold');
+    expect(emphasized?.textContent).toBe('뭉클랩');
+  });
+});

--- a/apps/web/src/app/invite/page.tsx
+++ b/apps/web/src/app/invite/page.tsx
@@ -182,11 +182,11 @@ export default function InvitePage() {
       {preview && (
         <div className="space-y-6">
           <div className="space-y-3 text-center animate-in fade-in slide-in-from-bottom-2 duration-500 delay-100 fill-mode-backwards">
-            <h1 className="text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
-              <span className="block">{preview.org_name}</span>
-              <span className="block text-base font-normal text-muted-foreground mt-1">
-                {t('joinHeadingLine2')}
-              </span>
+            <h1 className="text-2xl font-normal tracking-tight text-foreground sm:text-3xl">
+              {t.rich('joinHeading', {
+                org: preview.org_name,
+                b: (chunks) => <span className="font-semibold text-foreground">{chunks}</span>,
+              })}
             </h1>
           </div>
 

--- a/apps/web/src/app/invite/page.tsx
+++ b/apps/web/src/app/invite/page.tsx
@@ -24,6 +24,7 @@ type PageState = 'preview-loading' | 'preview-error' | 'auth' | 'accepting' | 's
 
 export default function InvitePage() {
   const t = useTranslations('invite');
+  const t2 = useTranslations('login');
   const searchParams = useSearchParams();
   const router = useRouter();
   const token = searchParams.get('token');
@@ -145,7 +146,7 @@ export default function InvitePage() {
           <p className="text-sm text-destructive">{errorMsg}</p>
           {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- story a539c649 S2 오탐, invite-accept-client.tsx 주석 참고 */}
           <a href="/login" className="text-sm font-medium text-brand hover:text-brand/80">
-            로그인 페이지로 →
+            {t('backToLogin')}
           </a>
         </div>
       </Frame>
@@ -164,7 +165,7 @@ export default function InvitePage() {
           {pageState === 'success' && preview ? (
             <>
               <p className="text-lg font-semibold tracking-tight text-foreground">
-                {preview.org_name}에 합류했어요
+                {t('joinedOrg', { org: preview.org_name })}
               </p>
               <p className="text-sm text-muted-foreground">{t('redirecting')}</p>
             </>
@@ -184,7 +185,7 @@ export default function InvitePage() {
             <h1 className="text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
               <span className="block">{preview.org_name}</span>
               <span className="block text-base font-normal text-muted-foreground mt-1">
-                에 합류하세요
+                {t('joinHeadingLine2')}
               </span>
             </h1>
           </div>
@@ -195,7 +196,7 @@ export default function InvitePage() {
                 {preview.inviter_name ? (
                   <>
                     <div className="truncate font-medium text-foreground">
-                      {preview.inviter_name}님이 초대했어요
+                      {t('invitedByPerson', { name: preview.inviter_name })}
                     </div>
                     {preview.inviter_email && (
                       <div className="truncate text-xs text-muted-foreground">{preview.inviter_email}</div>
@@ -203,7 +204,7 @@ export default function InvitePage() {
                   </>
                 ) : (
                   <div className="truncate font-medium text-foreground">
-                    {preview.org_name}에서 초대했어요
+                    {t('invitedByOrgFallback', { org: preview.org_name })}
                   </div>
                 )}
               </div>
@@ -227,7 +228,7 @@ export default function InvitePage() {
                       : 'text-muted-foreground hover:text-foreground/80',
                   )}
                 >
-                  {mode === 'signup' ? '가입' : '로그인'}
+                  {mode === 'signup' ? t2('signUp') : t2('signIn')}
                   {authMode === mode && (
                     <span className="absolute inset-x-0 -bottom-px h-0.5 bg-foreground" />
                   )}
@@ -239,7 +240,7 @@ export default function InvitePage() {
               {authMode === 'signup' && (
                 <input
                   type="text"
-                  placeholder="이름"
+                  placeholder={t('namePlaceholder')}
                   autoComplete="name"
                   className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-brand"
                   value={displayName}
@@ -249,7 +250,7 @@ export default function InvitePage() {
               )}
               <input
                 type="email"
-                placeholder="이메일"
+                placeholder={t2('email')}
                 autoComplete="email"
                 className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-brand"
                 value={email}
@@ -258,7 +259,7 @@ export default function InvitePage() {
               />
               <input
                 type="password"
-                placeholder="비밀번호"
+                placeholder={t2('password')}
                 autoComplete={authMode === 'signup' ? 'new-password' : 'current-password'}
                 className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-brand"
                 value={password}
@@ -276,7 +277,7 @@ export default function InvitePage() {
                     disabled={submitting}
                   />
                   <span className="text-xs text-muted-foreground">
-                    이용약관 + 개인정보처리방침에 동의합니다
+                    {t('tosAgreement')}
                   </span>
                 </label>
               )}
@@ -295,14 +296,14 @@ export default function InvitePage() {
               className="flex w-full min-h-[44px] items-center justify-center gap-2 rounded-lg bg-brand px-4 py-3 text-sm font-medium text-brand-foreground transition hover:bg-brand/90 disabled:opacity-50"
             >
               {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-              {submitting ? '...' : '합류하기'}
+              {submitting ? t('joining') : t('submit')}
             </button>
           </div>
 
           <div className="space-y-3 animate-in fade-in slide-in-from-bottom-2 duration-500 delay-400 fill-mode-backwards">
             <div className="relative flex items-center">
               <div className="flex-grow border-t border-border/50" />
-              <span className="mx-3 flex-shrink text-xs text-muted-foreground/60">또는</span>
+              <span className="mx-3 flex-shrink text-xs text-muted-foreground/60">{t2('orContinueWith')}</span>
               <div className="flex-grow border-t border-border/50" />
             </div>
             <a
@@ -310,14 +311,14 @@ export default function InvitePage() {
               className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-border bg-background px-4 py-3 text-sm font-medium text-foreground/80 transition hover:bg-muted/50"
             >
               <GoogleIcon />
-              Google로 계속
+              {t2('google')}
             </a>
             <a
               href={`/auth/login?provider=github&invite_token=${encodeURIComponent(token!)}&tos_accepted=true`}
               className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-border bg-foreground px-4 py-3 text-sm font-medium text-background transition hover:bg-foreground/90"
             >
               <GitHubIcon />
-              GitHub로 계속
+              {t2('github')}
             </a>
           </div>
         </div>

--- a/apps/web/src/app/reset-password/page.tsx
+++ b/apps/web/src/app/reset-password/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
 import { FIREBASE_AUTH_ENABLED } from '@/lib/auth/firebase-client';
 import { shouldPromptTotpReenroll } from '@/lib/auth/totp-reenroll';
@@ -18,6 +19,8 @@ function checkPasswordRules(pw: string) {
 }
 
 export default function ResetPasswordPage() {
+  const t = useTranslations('resetPassword');
+  const t2 = useTranslations('login');
   const router = useRouter();
   const searchParams = useSearchParams();
   const token = searchParams.get('token') ?? '';
@@ -51,13 +54,13 @@ export default function ResetPasswordPage() {
       });
       const json = await res.json() as { data?: { message: string; totp_enabled?: boolean }; error?: { message: string } };
       if (!res.ok) {
-        setError(json.error?.message ?? 'Failed to reset password');
+        setError(json.error?.message ?? t('submitFailed'));
         return;
       }
       setTotpReenrollNeeded(shouldPromptTotpReenroll(FIREBASE_AUTH_ENABLED, json.data?.totp_enabled));
       setDone(true);
     } catch {
-      setError('Failed to reset password. Please try again.');
+      setError(t('submitFailed'));
     } finally {
       setLoading(false);
     }
@@ -67,8 +70,8 @@ export default function ResetPasswordPage() {
     return (
       <div className="flex min-h-screen items-center justify-center bg-muted">
         <div className="text-center space-y-4">
-          <p className="text-sm text-destructive">유효하지 않은 링크입니다.</p>
-          <Link href="/forgot-password" className="text-sm text-brand hover:text-brand/80">비밀번호 찾기</Link>
+          <p className="text-sm text-destructive">{t('invalidLink')}</p>
+          <Link href="/forgot-password" className="text-sm text-brand hover:text-brand/80">{t2('forgotPassword')}</Link>
         </div>
       </div>
     );
@@ -79,27 +82,27 @@ export default function ResetPasswordPage() {
       <div className="w-full max-w-sm space-y-6 rounded-2xl bg-background p-4 shadow-lg sm:p-8">
         <div className="flex flex-col items-center gap-3 text-center">
           <SprintableLogo variant="stacked" className="text-foreground" markClassName="h-14" wordmarkClassName="h-5" />
-          <h1 className="text-lg font-semibold text-foreground">새 비밀번호 설정</h1>
+          <h1 className="text-lg font-semibold text-foreground">{t('title')}</h1>
         </div>
 
         {done ? (
           <div className="space-y-4 text-center">
-            <p className="text-sm text-muted-foreground">비밀번호가 변경되었습니다.</p>
+            <p className="text-sm text-muted-foreground">{t('done')}</p>
             {totpReenrollNeeded && (
-              <p className="text-sm text-muted-foreground">2단계 인증을 다시 등록해 주세요.</p>
+              <p className="text-sm text-muted-foreground">{t('mfaReenroll')}</p>
             )}
             <button
               onClick={() => router.push('/login')}
               className="flex w-full min-h-[44px] items-center justify-center rounded-lg bg-brand px-4 py-3 text-sm font-medium text-brand-foreground transition hover:bg-brand/90"
             >
-              로그인
+              {t2('signIn')}
             </button>
           </div>
         ) : (
           <div className="space-y-3">
             <input
               type="password"
-              placeholder="새 비밀번호"
+              placeholder={t('placeholder')}
               autoComplete="new-password"
               className={`w-full rounded-lg border px-4 py-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-brand ${
                 touched && !isValid ? 'border-destructive' : 'border-border'
@@ -112,10 +115,10 @@ export default function ResetPasswordPage() {
             {touched && password.length > 0 && (
               <ul className="space-y-1 text-xs">
                 <li className={rules.length ? 'text-success' : 'text-muted-foreground/60'}>
-                  {rules.length ? '✓' : '○'} 8자 이상
+                  {rules.length ? '✓' : '○'} {t('lengthHint')}
                 </li>
                 <li className={categoriesMet >= 3 ? 'text-success' : 'text-muted-foreground/60'}>
-                  {categoriesMet >= 3 ? '✓' : '○'} 대문자/소문자/숫자/특수문자 중 3가지 이상 ({categoriesMet}/3)
+                  {categoriesMet >= 3 ? '✓' : '○'} {t('strengthHint', { met: categoriesMet })}
                 </li>
               </ul>
             )}
@@ -125,7 +128,7 @@ export default function ResetPasswordPage() {
               disabled={loading || !password}
               className="flex w-full min-h-[44px] items-center justify-center rounded-lg bg-brand px-4 py-3 text-sm font-medium text-brand-foreground transition hover:bg-brand/90 disabled:opacity-50"
             >
-              {loading ? '변경 중...' : '비밀번호 변경'}
+              {loading ? t('submitting') : t('submit')}
             </button>
           </div>
         )}


### PR DESCRIPTION
유나양 규격(doc `i18n-copy-spec-2084`) 반영. 진단은 "번역 누락"이 아니라 "t() 미호출" — ko/en 3613키 완전 대칭 확認됨. 미인증 사용자가 보는 유일한 표면(1순위 근거)이라 못 읽으면 제품에 아예 못 들어온다.

## invite/page.tsx
기존 invite 키 배선은 이미 돼 있었고, 나머지 하드코딩(뒤로가기 링크·합류완료 메시지·헤딩·초대자/조직 안내·탭 라벨·placeholder 3종·약관동의·제출버튼·구분선·소셜버튼 2종)을 invite/login 네임스페이스로 전수 배선. login 기존 키 재사용, invite에 신규 9개.

## invite/accept/invite-accept-client.tsx
Yuna 규격 그대로 기존 키(title·success·redirecting·acceptFailed·accepting·accept) 배선. "역할" 라벨은 이미 임포트돼 있던 settings.profileRole 재사용(신규 불요). 거절 링크는 신규 invite.decline.

## reset-password/page.tsx — next-intl 신규 도입
`resetPassword` 네임스페이스 신설, Yuna 규격 8키 그대로 값 채택 — invalidLink는 원칙(화면이 분간 못 하는 사실을 단정하지 않음)에 따라 정확도 교정. 스코프 내 추가 발견 2건(길이 힌트·submitFailed 폴백)도 같은 톤으로 신설.

## 스코프 준수
console.*·주석 미터치, 기존 정상 동작 문구는 불일치해도 이번 스코프에서 안 건드림.

type-check/lint(0 errors)/build(EXIT 0)/vitest 전체(290파일·1994개) green.

## Done-gate 미완 — 라이브
ko/en 양쪽 로케일로 실제 화면 렌더 확認은 배포 후 대상.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>