### PR TITLE
fix(dispatch): 까심군 QA 회귀 — envelope unwrap 누락 + assignee_ids 미동기화

### DIFF
--- a/apps/web/src/components/dispatch/entity-dispatch-panel.test.tsx
+++ b/apps/web/src/components/dispatch/entity-dispatch-panel.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+//
+// 까심군 QA 회귀(2026-07-21) — /api/dispatch가 apiSuccess()로 {data:{dispatched,...}}를
+// 감싸는데 패널이 flat({dispatched})으로 읽어 서버가 200 성공을 반환해도 매번 "담당자
+// 미지정" 토스트가 떴다(4/4 재현, dispatched는 항상 undefined). RED→GREEN으로 고정한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { EntityDispatchPanel } from './entity-dispatch-panel';
+import koMessages from '../../../messages/ko.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+const MEMBERS = [{ id: 'm1', name: '홍길동', type: 'human' as const, is_active: true }];
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe('EntityDispatchPanel — 까심군 QA 회귀 (envelope unwrap)', () => {
+  it('/api/dispatch가 {data:{dispatched:true}}로 응답하면 성공 토스트가 뜬다(담당자 미지정 오탐 아님)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/members')) return { ok: true, json: async () => ({ data: MEMBERS }) };
+      if (url === '/api/stories/s1') return { ok: true, json: async () => ({ data: {} }) };
+      if (url === '/api/dispatch') {
+        // 실제 서버 계약 — apiSuccess()가 감싼 shape 그대로.
+        return { ok: true, json: async () => ({ data: { dispatched: true, assignee_id: 'm1', reason: 'ok' } }) };
+      }
+      throw new Error('unexpected fetch: ' + url);
+    }));
+
+    await act(async () => {
+      root.render(wrap(
+        <EntityDispatchPanel entityType="story" entityId="s1" projectId="p1" currentAssigneeId="m1" />,
+      ));
+    });
+    // 담당자 select가 members fetch 이후 채워질 때까지 한 틱 더.
+    await act(async () => { await Promise.resolve(); });
+
+    const dispatchBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('전달'));
+    await act(async () => {
+      dispatchBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(document.body.textContent).not.toContain('담당자가 지정되지 않았습니다');
+    expect(document.body.textContent).toContain('전달했습니다');
+  });
+
+  it('/api/dispatch가 {data:{dispatched:false}}면(진짜 담당자 미지정) 안내 토스트가 뜬다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/members')) return { ok: true, json: async () => ({ data: MEMBERS }) };
+      if (url === '/api/stories/s1') return { ok: true, json: async () => ({ data: {} }) };
+      if (url === '/api/dispatch') {
+        return { ok: true, json: async () => ({ data: { dispatched: false, reason: 'no_assignee' } }) };
+      }
+      throw new Error('unexpected fetch: ' + url);
+    }));
+
+    await act(async () => {
+      root.render(wrap(
+        <EntityDispatchPanel entityType="story" entityId="s1" projectId="p1" currentAssigneeId="m1" />,
+      ));
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    const dispatchBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('전달'));
+    await act(async () => {
+      dispatchBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(document.body.textContent).toContain('담당자가 지정되지 않았습니다');
+  });
+});

--- a/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
+++ b/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
@@ -101,7 +101,12 @@ export function EntityDispatchPanel({
         addToast({ type: 'error', title: t('dispatchFailedTitle'), body: t('dispatchFailedBody') });
         return;
       }
-      const dispatchData = await dispatchRes.json().catch(() => ({})) as { dispatched?: boolean };
+      // 까심군 QA 회귀(2026-07-21) — /api/dispatch(route.ts)가 apiSuccess()로 응답을
+      // {data:{dispatched,...}} 로 감싸는데 여기서 flat({dispatched})으로 읽고 있었다
+      // ("fastapi-proxy envelope 경계" 버그클래스). 실제로는 항상 dispatched=undefined라
+      // 서버가 200 성공을 반환해도 매번 "담당자 미지정" 토스트가 떴다(4/4 재현).
+      const dispatchJson = await dispatchRes.json().catch(() => ({})) as { data?: { dispatched?: boolean } };
+      const dispatchData = dispatchJson.data ?? {};
       if (!dispatchData.dispatched) {
         // 담당자가 지정되지 않아 전달 대상이 없는 경우 — 오류가 아니라 안내(info)로 처리한다.
         addToast({ type: 'info', title: t('assigneeNotSetTitle'), body: t('assigneeNotSetBody') });

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -954,7 +954,15 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   entityId={story.id}
                   projectId={projectId}
                   currentAssigneeId={localAssigneeIds.length > 1 ? undefined : (localAssigneeIds[0] ?? story.assignee_id)}
-                  onAssigneePatched={(aid) => onStoryUpdate?.({ ...story, assignee_id: aid })}
+                  // 까심군 QA 회귀(2026-07-21) — assignee_id만 갱신하면 표시 로직(L478-480)이
+                  // 우선 읽는 assignee_ids 배열이 stale로 남아 새로고침 전까지 옛 담당자가
+                  // 보였다(L505의 정상 경로는 둘 다 갱신·이 경로만 누락). dispatch는 단일
+                  // 담당자 지정이라 assignee_ids를 [aid]로 교체해 정합을 맞춘다.
+                  onAssigneePatched={(aid) => {
+                    assigneeIdsRef.current = [aid];
+                    setLocalAssigneeIds([aid]);
+                    onStoryUpdate?.({ ...story, assignee_id: aid, assignee_ids: [aid] });
+                  }}
                 />
               </div>
             )}


### PR DESCRIPTION
## ① EntityDispatchPanel — apiSuccess envelope 미언랩
`/api/dispatch/route.ts`가 `apiSuccess()`로 `{data:{dispatched,...}}`를 감싸는데 패널이 flat(`dispatchData.dispatched`)으로 읽어 `dispatched`가 항상 `undefined` → 서버가 200 성공(`dispatched:true`)을 반환해도 매번 "담당자가 지정되지 않았습니다" 오탐(4/4 재현). 예외를 안 던지고 falsy로 조용히 흘러가 에러 로그로도 안 잡히는 유형("fastapi-proxy envelope 경계" 버그클래스). git blame으로 오늘 #2376 변경 이전부터 있던 결함임을 확認(토스트 텍스트만 바꿨고 파싱 로직은 안 건드림) — 다만 손댄 파일이니 지금 고침.

`entity-dispatch-panel.test.tsx` 신설, RED(수정 전, stash로 재현)→GREEN(수정 후) 확認.

## ② story-detail-panel.tsx — dispatch 후 assignee_ids 미갱신
`onAssigneePatched` 콜백이 `assignee_id`만 갱신하고 `assignee_ids`(복수 담당자 배열)는 그대로 뒀는데, 표시 로직(L478-480)이 `assignee_ids`를 우선 읽는 구조라 배열이 stale로 남아 새로고침 전까지 옛 담당자가 계속 보임(같은 파일의 정상 경로 L505는 둘 다 갱신). dispatch는 단일 담당자 지정이므로 `assignee_ids`를 `[aid]`로 교체해 정합을 맞춤.

컴포넌트가 1598줄에 하위섹션 다수 의존이라 전체 마운트 테스트는 과잉 판단 — 변경은 3줄 스코프의 명확한 콜백 보정. 실사용 검증은 배포 후 실제 왕복 클릭(토스트+필드 즉시갱신)으로 확認 예정.

## apiSuccess envelope 버그클래스 전수 스윕
fork로 병행(145→18건 방법론), dispatch 건 외 확실한 추가 인스턴스 없음(한계: `await ...json() as {}` 리터럴 패턴 의존, `.then()` 체인·헬퍼 래핑 파싱은 커버 안 됨).

type-check/lint(0 errors)/vitest 전체(275파일·1822개)/build(EXIT 0) green.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>