### PR TITLE
fix(sse): story c4c72eb1 PR-A — shutdown-aware SSE 종료 + /ping 헬스체크 재사용

### DIFF
--- a/backend/app/core/shutdown.py
+++ b/backend/app/core/shutdown.py
@@ -1,0 +1,28 @@
+"""story c4c72eb1(E-ARCH, GCE realtime-gateway 이전) PR-A: 프로세스 전역 셧다운 신호.
+
+SSE 생성기(events.py/agent_gateway.py)가 이 이벤트를 구독해 SIGTERM 시 강제
+`CancelledError`를 기다리지 않고 스스로 정상 종료(clean stream end)한다 —
+`EventSource` 표준 클라이언트가 즉시 재연결하도록 유도(GCLB 드레이닝과 결합
+시 건강한 인스턴스로 자동 이동). main.py의 lifespan `finally` 진입 즉시 set한다.
+
+⚠️`asyncio.Event`는 생성자 자체는 loop-agnostic(3.10+)이지만 `.wait()`/`.set()`이
+내부 Future를 처음 만들 때 **그 시점의 실행 중 루프에 바인딩**된다 — 이 코드베이스는
+TestClient(app)로 lifespan을 여러 번(서로 다른 이벤트루프로) 태우는 테스트 관례가
+있어(story bea25062 주석 참조), 모듈 전역 단일 인스턴스를 `.clear()`만 하면 이전
+루프에 바인딩된 채로 새 루프에서 `RuntimeError: bound to a different event loop`가
+난다(뮤테이션 셀프체크로 직접 재현). 그래서 startup마다 **객체 자체를 재생성**한다 —
+호출부는 반드시 `from app.core import shutdown`(모듈 자체)으로 임포트해
+`shutdown.shutdown_event`를 매번 속성 접근으로 읽어야 한다(`from ... import
+shutdown_event`로 이름을 정적 바인딩하면 재생성 이후에도 옛 객체를 계속 참조한다).
+"""
+from __future__ import annotations
+
+import asyncio
+
+shutdown_event: asyncio.Event = asyncio.Event()
+
+
+def reset_shutdown_event() -> None:
+    """lifespan startup마다 호출 — 현재 실행 중인 루프에 바인딩된 새 Event로 교체."""
+    global shutdown_event
+    shutdown_event = asyncio.Event()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,6 +18,7 @@ _logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    from app.core import shutdown as shutdown_module
     from app.core.database import engine
     from app.routers.auth_firebase_internal import check_internal_secret_config
     from app.routers.cron import check_cron_secret_config
@@ -25,6 +26,13 @@ async def lifespan(app: FastAPI):
     from app.services.firebase_verifier import check_mobile_app_check_config
     from app.services.pg_pubsub import check_listen_config, listen_loop
 
+    # story c4c72eb1(E-ARCH GCE 이전) PR-A: asyncio.Event는 최초 .wait()/.set() 시점의 실행
+    # 루프에 바인딩된다 — 테스트가 TestClient(app)로 lifespan을 여러 번(서로 다른 루프로) 태우는
+    # 이 코드베이스 관례(story bea25062 주석 참조) 아래에서 단순 `.clear()`는 이전 루프에 바인딩된
+    # 채로 남아 다음 루프에서 RuntimeError를 낸다(뮤테이션 셀프체크로 직접 재현). startup마다
+    # 객체 자체를 재생성(shutdown.py의 reset_shutdown_event 참조 — 모듈 속성 접근으로 최신
+    # 객체를 읽어야 하므로 아래도 `shutdown_module.shutdown_event`로 접근, 정적 import 금지).
+    shutdown_module.reset_shutdown_event()
     warn_if_webhook_secret_misconfigured()  # Bot-M.2 P3: 웹훅 secret misconfig 를 트래픽 前 경고.
     # E-ARCH S1: PG_LISTEN_ENABLED=false인 서비스(api)는 이 검증 자체가 무의미 — LISTEN을 절대
     # 안 켜므로 DB_PGBOUNCER/DATABASE_URL_DIRECT 정합을 강제할 이유가 없다(무해·불필요 fail 방지).
@@ -74,6 +82,10 @@ async def lifespan(app: FastAPI):
     try:
         yield
     finally:
+        # story c4c72eb1(E-ARCH GCE 이전) PR-A: SSE 생성기(events.py/agent_gateway.py)가
+        # 이 신호를 구독해 강제 CancelledError를 기다리지 않고 스스로 정상 종료한다 — 다른
+        # 정리 작업(태스크 cancel 등)보다 먼저 set해 SSE 스트림이 최대한 빨리 반응하게 한다.
+        shutdown_module.shutdown_event.set()
         if task is not None:
             task.cancel()
         if l2_task is not None:

--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_current_user_streaming
 from app.core.database import async_session_factory
+from app.core import shutdown as _shutdown_module
 from app.dependencies.database import get_db
 from app.models.agent_gateway import AgentEventCursor, AgentGatewaySession
 from app.models.event import Event
@@ -402,13 +403,31 @@ async def agent_stream(
             # heartbeat가 안 떠도(매번 wait_for가 일찍 반환) last_seen이 stale → 거짓 offline 되므로,
             # 매 iteration 경과를 체크해 _PRESENCE_TICK_INTERVAL마다 throttle write(busy/idle 무관 갱신 보장).
             last_presence_tick = datetime.now(timezone.utc)
+            # story c4c72eb1(E-ARCH GCE 이전) PR-A: events.py와 동형 shutdown-aware 종료.
             while not await request.is_disconnected():
                 _now = datetime.now(timezone.utc)
                 if (_now - last_presence_tick).total_seconds() >= _PRESENCE_TICK_INTERVAL:
                     await _mark_agent_online(agent_id, session_id)
                     last_presence_tick = _now
+                get_task = asyncio.create_task(queue.get())
+                shutdown_task = asyncio.create_task(_shutdown_module.shutdown_event.wait())
                 try:
-                    signal = await asyncio.wait_for(queue.get(), timeout=_SSE_HEARTBEAT)
+                    done, pending = await asyncio.wait(
+                        {get_task, shutdown_task},
+                        timeout=_SSE_HEARTBEAT,
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    for p in pending:
+                        p.cancel()
+                    if shutdown_task in done:
+                        yield "event: shutdown_reconnect\ndata: {}\n\n"
+                        return
+                    if get_task not in done:
+                        yield "event: heartbeat\ndata: {}\n\n"
+                        if await request.is_disconnected():
+                            break
+                        continue
+                    signal = get_task.result()
                     if signal.get("__wake__"):
                         # ìµì  acked_seq ì¡°í (í´ë¼ì´ì¸í¸ê° ACK ë³´ëì ì ìì)
                         async with async_session_factory() as db:
@@ -433,10 +452,10 @@ async def agent_stream(
                         _live_id = signal.get("event_id") or str(uuid.uuid4())
                         _sse = json.dumps({**signal, "is_backfill": False})
                         yield f"event: {event_type}\nid: {_live_id}\ndata: {_sse}\n\n"
-                except asyncio.TimeoutError:
-                    yield "event: heartbeat\ndata: {}\n\n"
-                    if await request.is_disconnected():
-                        break
+                finally:
+                    for t in (get_task, shutdown_task):
+                        if not t.done():
+                            t.cancel()
         except (asyncio.CancelledError, GeneratorExit):
             pass
         finally:

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -27,6 +27,7 @@ from app.dependencies.auth import (
     get_verified_org_id,
     get_verified_org_id_streaming,
 )
+from app.core import shutdown as _shutdown_module
 from app.dependencies.database import get_db
 from app.dependencies.ownership import _is_org_admin
 from app.models.event import Event
@@ -342,53 +343,80 @@ async def agent_event_stream(
                     await db.commit()
 
             # 신규 이벤트 리슨 — 대기 구간에서 커넥션 미점유, 이벤트마다 개별 세션
-            while not await request.is_disconnected():
-                try:
-                    event_data = await asyncio.wait_for(queue.get(), timeout=_SSE_HEARTBEAT_TIMEOUT)
-                    event_type = event_data.get("event_type", "message")
-                    # 1c22da3e fix: yield 전엔 pending 여부만 확인(skip 판정, 마킹 X),
-                    # delivered 마킹은 yield 성공 후로 미룬다 → yield 실패 시 영구 누락 방지.
-                    eid = event_data.get("event_id")
-                    if eid:
-                        try:
-                            async with async_session_factory() as db:
-                                r = await db.execute(
-                                    select(Event.status).where(
-                                        Event.id == uuid.UUID(eid),
-                                        Event.org_id == org_id,
+            # story c4c72eb1(E-ARCH GCE 이전) PR-A: 전역 shutdown_event를 queue.get()과 경합
+            # 시켜(asyncio.wait FIRST_COMPLETED) 셧다운 신호에 하트비트 주기(최대 30초)를
+            # 기다리지 않고 즉시 반응한다 — 강제 CancelledError 대신 정상 return으로 스트림을
+            # 깔끔히 끝내 EventSource가 즉시 재연결하도록 유도(GCLB 드레이닝과 결합 시 자동으로
+            # 건강한 인스턴스로 이동). shutdown 대기 태스크는 연결 생애주기 동안 단 1개만
+            # 생성한다(루프마다 재생성하면 테스트 타이밍이 흔들려 test_s20 케이스가 불안정해짐 —
+            # 뮤테이션 셀프체크로 확認됨, 매 iteration 재생성 버전은 실패).
+            shutdown_wait_task = asyncio.create_task(_shutdown_module.shutdown_event.wait())
+            try:
+                while not await request.is_disconnected():
+                    get_task = asyncio.create_task(queue.get())
+                    try:
+                        done, _pending = await asyncio.wait(
+                            {get_task, shutdown_wait_task},
+                            timeout=_SSE_HEARTBEAT_TIMEOUT,
+                            return_when=asyncio.FIRST_COMPLETED,
+                        )
+                        if shutdown_wait_task in done:
+                            get_task.cancel()
+                            yield "event: shutdown_reconnect\ndata: {}\n\n"
+                            return
+                        if get_task not in done:
+                            # 타임아웃 — 기존 heartbeat 분기
+                            get_task.cancel()
+                            yield "event: heartbeat\ndata: {}\n\n"
+                            if await request.is_disconnected():
+                                break
+                            continue
+                        event_data = get_task.result()
+                        event_type = event_data.get("event_type", "message")
+                        # 1c22da3e fix: yield 전엔 pending 여부만 확인(skip 판정, 마킹 X),
+                        # delivered 마킹은 yield 성공 후로 미룬다 → yield 실패 시 영구 누락 방지.
+                        eid = event_data.get("event_id")
+                        if eid:
+                            try:
+                                async with async_session_factory() as db:
+                                    r = await db.execute(
+                                        select(Event.status).where(
+                                            Event.id == uuid.UUID(eid),
+                                            Event.org_id == org_id,
+                                        )
                                     )
-                                )
-                                _status = r.scalar_one_or_none()
-                                if _status is not None and _status != "pending":
-                                    # 이미 백필/타 연결에서 delivered → 중복 skip
-                                    continue
-                        except Exception:
-                            pass
-                    # event_id 없는 경로(chats direct push 등)도 id: 보장 — 재연결 추적 약화 방지
-                    # is_backfill: False 명시 + event_id 동기화 — SeenIdsCache dedup 및 relay 필터 정합성
-                    _live_id = eid or str(uuid.uuid4())
-                    _sse_data = json.dumps({**event_data, 'event_id': _live_id, 'is_backfill': False})
-                    # S-COMM-12: canonical 이벤트 시 legacy alias도 병행 yield (HTTP SSE 하위호환)
-                    if event_type == "conversation.message_created":
-                        yield f"event: conversation:message\nid: {_live_id}\ndata: {_sse_data}\n\n"
-                    yield f"event: {event_type}\nid: {_live_id}\ndata: {_sse_data}\n\n"
-                    # yield 성공 후 delivered 마킹 (1c22da3e: 손실 방지, dup은 클라 dedup)
-                    if eid:
-                        try:
-                            async with async_session_factory() as db:
-                                await db.execute(
-                                    update(Event)
-                                    .where(Event.id == uuid.UUID(eid), Event.status == "pending")
-                                    .values(status="delivered", delivered_at=datetime.now(timezone.utc))
-                                )
-                                await db.commit()
-                        except Exception:
-                            pass
-                except asyncio.TimeoutError:
-                    # S20: heartbeat 후 즉시 disconnect 체크 — dead connection 조기 정리
-                    yield "event: heartbeat\ndata: {}\n\n"
-                    if await request.is_disconnected():
-                        break
+                                    _status = r.scalar_one_or_none()
+                                    if _status is not None and _status != "pending":
+                                        # 이미 백필/타 연결에서 delivered → 중복 skip
+                                        continue
+                            except Exception:
+                                pass
+                        # event_id 없는 경로(chats direct push 등)도 id: 보장 — 재연결 추적 약화 방지
+                        # is_backfill: False 명시 + event_id 동기화 — SeenIdsCache dedup 및 relay 필터 정합성
+                        _live_id = eid or str(uuid.uuid4())
+                        _sse_data = json.dumps({**event_data, 'event_id': _live_id, 'is_backfill': False})
+                        # S-COMM-12: canonical 이벤트 시 legacy alias도 병행 yield (HTTP SSE 하위호환)
+                        if event_type == "conversation.message_created":
+                            yield f"event: conversation:message\nid: {_live_id}\ndata: {_sse_data}\n\n"
+                        yield f"event: {event_type}\nid: {_live_id}\ndata: {_sse_data}\n\n"
+                        # yield 성공 후 delivered 마킹 (1c22da3e: 손실 방지, dup은 클라 dedup)
+                        if eid:
+                            try:
+                                async with async_session_factory() as db:
+                                    await db.execute(
+                                        update(Event)
+                                        .where(Event.id == uuid.UUID(eid), Event.status == "pending")
+                                        .values(status="delivered", delivered_at=datetime.now(timezone.utc))
+                                    )
+                                    await db.commit()
+                            except Exception:
+                                pass
+                    finally:
+                        if not get_task.done():
+                            get_task.cancel()
+            finally:
+                if not shutdown_wait_task.done():
+                    shutdown_wait_task.cancel()
         except (asyncio.CancelledError, GeneratorExit):
             pass
         finally:

--- a/backend/tests/test_c4c72eb1_sse_shutdown_aware.py
+++ b/backend/tests/test_c4c72eb1_sse_shutdown_aware.py
@@ -1,0 +1,146 @@
+"""story c4c72eb1(E-ARCH GCE realtime-gateway 이전) PR-A: shutdown-aware SSE 종료.
+
+이전에는 SIGTERM → graceful-shutdown 타이머 만료 → 강제 CancelledError로 SSE가
+비정상 종료됐다. 이제는 전역 shutdown_event를 구독해 하트비트 주기(최대 30초)를
+기다리지 않고 즉시 반응, 정리 이벤트(`shutdown_reconnect`)를 yield하고 **정상
+return**한다 — EventSource가 깔끔한 스트림 종료로 인지해 즉시 재연결하도록.
+
+PR-A 검증 범위: Cloud Run은 terminationGracePeriodSeconds=10 캡이 있어 graceful
+timeout 확장 자체의 효과(오래 버티기)는 GCE(PR-B)에서만 열린다. 여기서 검증하는
+건 "셧다운 신호에 즉시 반응해 정상 종료하는가"이지 "얼마나 오래 버티는가"가 아니다.
+
+⚠️ shutdown_event.set()은 asyncio.Event라 스레드 세이프하지 않다 — 테스트에서 별도
+threading.Thread로 트리거하면 TestClient의 내부 이벤트루프와 다른 스레드에서 건드리게
+돼 신호가 전달되지 않는다(뮤테이션 셀프체크로 확認: 첫 시도는 이렇게 짜서 타임아웃
+났다). AsyncClient + asyncio.create_task로 **같은 이벤트루프 안에서** 트리거한다.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _make_mock_session():
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    session.execute = AsyncMock()
+    return session
+
+
+def _membership_ok(member_id: uuid.UUID) -> MagicMock:
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = member_id
+    return r
+
+
+def _pending_empty() -> MagicMock:
+    scalars = MagicMock()
+    scalars.all.return_value = []
+    r = MagicMock()
+    r.scalars.return_value = scalars
+    return r
+
+
+def test_reset_shutdown_event_creates_new_object_each_call():
+    """asyncio.Event는 최초 wait()/set() 시점의 실행 루프에 바인딩되므로, lifespan startup마다
+    객체 자체를 교체해야 한다(단순 .clear()는 이전 루프 바인딩이 남아 다른 루프에서
+    RuntimeError — 뮤테이션 셀프체크로 재현됨). reset_shutdown_event()가 진짜 새 객체를
+    만드는지(같은 객체를 재사용하며 clear만 하는 게 아닌지) 직접 확認."""
+    from app.core import shutdown as shutdown_module
+
+    first = shutdown_module.shutdown_event
+    shutdown_module.reset_shutdown_event()
+    second = shutdown_module.shutdown_event
+    assert first is not second, "reset_shutdown_event가 객체를 재생성하지 않음(동일 인스턴스 재사용)"
+    assert not second.is_set()
+
+
+@pytest.mark.anyio
+async def test_sse_stream_reacts_to_shutdown_signal_immediately_and_closes_cleanly():
+    """전역 shutdown_event.set() 시 SSE가 하트비트 타임아웃(길게 설정)을 기다리지 않고
+    즉시 shutdown_reconnect 이벤트를 내보내고 스트림을 정상 종료하는지 실측.
+
+    ASGITransport/TestClient를 거치면 라이브러리 내부 스케줄링과 얽혀 트리거 태스크가
+    굶는 현상이 있었다(뮤테이션 셀프체크로 확認) — 라우트 함수를 직접 호출해 반환된
+    StreamingResponse의 body_iterator를 이 테스트 코루틴에서 직접 펌프하는 방식으로
+    ASGI 계층을 완전히 우회한다(검증 대상인 generate() 로직 자체는 동일).
+    """
+    from app.core import shutdown as shutdown_module
+    import app.routers.events as ev_module
+
+    member_id = uuid.uuid4()
+    org = uuid.uuid4()
+
+    mock_sess = _make_mock_session()
+    mock_sess.execute.side_effect = [_membership_ok(member_id), _pending_empty()]
+
+    @asynccontextmanager
+    async def _factory():
+        yield mock_sess
+
+    class _FakeRequest:
+        headers: dict = {}
+
+        async def is_disconnected(self) -> bool:
+            return False
+
+    auth_ctx = MagicMock()
+    auth_ctx.user_id = str(member_id)
+    auth_ctx.claims = {"app_metadata": {"api_key_id": "test-key", "org_id": str(org)}}
+
+    count_before = ev_module._sse_connection_count
+    saw_shutdown_event = False
+    elapsed = None
+    try:
+        with patch("app.core.database.async_session_factory", _factory):
+            with patch.object(ev_module, "_SSE_HEARTBEAT_TIMEOUT", 30.0):
+                response = await ev_module.agent_event_stream(
+                    request=_FakeRequest(),
+                    member_id=None,
+                    auth=auth_ctx,
+                    org_id=org,
+                    since_timestamp=None,
+                    last_event_id=None,
+                )
+                assert ev_module._sse_connection_count == count_before + 1
+
+                async def _trigger_shutdown():
+                    await asyncio.sleep(0.1)
+                    shutdown_module.shutdown_event.set()
+
+                trigger_task = asyncio.create_task(_trigger_shutdown())
+                started = time.monotonic()
+
+                # break 없이 끝까지 소진 — generate()가 shutdown_reconnect yield 후 스스로
+                # return(정상 종료)해 StopAsyncIteration으로 자연 종료돼야 finally(카운터
+                # 정리)가 실행된다. 중간에 break하면 아직 return에 안 닿아 정리가 안 된다.
+                async for chunk in response.body_iterator:
+                    if "shutdown_reconnect" in chunk:
+                        saw_shutdown_event = True
+                elapsed = time.monotonic() - started
+                await trigger_task
+
+        assert saw_shutdown_event, "shutdown_reconnect 이벤트가 스트림에 안 실림"
+        # 하트비트 타임아웃(30초)을 기다리지 않고 즉시(수 초 내) 반응했는지 — PR-A의 핵심 주장.
+        assert elapsed is not None and elapsed < 5.0, (
+            f"shutdown 신호 반응이 너무 느림({elapsed}s) — 즉시 반응이어야 함"
+        )
+        await asyncio.sleep(0.1)
+        assert ev_module._sse_connection_count == count_before, "shutdown 후 카운터 정리 안 됨"
+    finally:
+        ev_module._agent_connections.pop(str(member_id), None)
+        ev_module._sse_connection_count = count_before
+        shutdown_module.reset_shutdown_event()

--- a/backend/tests/test_no_unreferenced_fire_and_forget.py
+++ b/backend/tests/test_no_unreferenced_fire_and_forget.py
@@ -16,10 +16,15 @@ _APP_DIR = Path(__file__).parent.parent / "app"
 # main.py: task/l2_task 변수에 참조 보관 + lifespan finally에서 cancel()+await로 명시 추적(안전).
 # pg_pubsub.py: fire_and_forget() 자체의 정석 구현(강한 참조 set 보관) + 그걸 설명하는 docstring.
 # l2_trigger_worker.py: 실 호출 없음 — docstring이 "asyncio.create_task(...)" 문자열을 언급할 뿐.
+# events.py/agent_gateway.py: story c4c72eb1 PR-A — get_task/shutdown_wait_task 모두 지역 변수에
+# 참조 보관 후 asyncio.wait()로 즉시 경합·완료 대기하고 각 finally에서 cancel() — fire-and-forget
+# 아닌 표준 "동시 대기" 패턴(#1970류 GC 조기수거 리스크 없음).
 _ALLOWED_FILES = {
     _APP_DIR / "main.py",
     _APP_DIR / "services" / "pg_pubsub.py",
     _APP_DIR / "services" / "l2_trigger_worker.py",
+    _APP_DIR / "routers" / "events.py",
+    _APP_DIR / "routers" / "agent_gateway.py",
 }
 _PATTERN = re.compile(r"\.create_task\(|\bensure_future\(")
 


### PR DESCRIPTION
## Summary
- GCE realtime-gateway 이전(story c4c72eb1) PR-A — 앱 코드 부분만(인프라 PR-B는 별도). Cloud Run에서 지금 바로 검증 가능한 부분만 먼저 착지.
- **shutdown-aware SSE**: 기존엔 SSE 생성기가 셧다운 신호를 능동 구독하지 않아 SIGTERM → graceful-shutdown 타이머(5초) 만료 → 강제 `CancelledError`로 비정상 종료됐음(코드 리딩으로 확認). 전역 `shutdown_event`를 `queue.get()`과 `asyncio.wait(FIRST_COMPLETED)`로 경합시켜 즉시 반응하도록 변경 — `event: shutdown_reconnect` yield 후 정상 return, `EventSource`가 깔끔한 종료로 인지해 즉시 재연결.
- **헬스체크**: 신규 `/healthz` 대신 이미 존재하는 `/api/v2/ping`(DB 미조회) 재사용 — 중복 라우트 회피.
- **버그 발견+수정**: `asyncio.Event`가 최초 사용 시점의 루프에 바인딩되는 특성 때문에, 여러 이벤트루프로 lifespan을 태우는 이 코드베이스의 테스트 관례상 단순 `.clear()`로는 부족 — `reset_shutdown_event()`로 startup마다 객체를 재생성하도록 수정.

## Test plan
- [x] 뮤테이션 셀프체크: RED(신규 테스트 2개 — ImportError) → GREEN
- [x] `shutdown_reconnect`가 30초 하트비트 타임아웃을 기다리지 않고 5초 이내 도착 실증(직접 라우트 함수 호출로 ASGI 계층 우회)
- [x] 기존 SSE 관련 테스트 250개 전부 GREEN(회귀 없음)
- [ ] PR-B(GCE) 단계에서 실제 60분 연결 유지·재배포 drain 재검증 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)