### PR TITLE
fix(nav): story #2093 P0 — top-bar 컨텍스트 칩이 URL과 다른 프로젝트를 그리던 결함

### DIFF
--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -81,32 +81,30 @@ export default async function AuthenticatedLayout({
 
   // story #2093 — /me/memberships 는 JWT의 "현재 org" 클레임으로 스코프된다(BE
   // app/routers/me.py get_my_memberships). URL 경로가 계정 상태와 다른 org를 가리키면(cross-org
-  // 딥링크·계정 상태가 stale한 경우) pathProjectId가 이 목록에 없어 표시용 이름을 못 찾는다 —
-  // 단건 조회로 보강한다(전환 목록에 넣으려는 게 아니라 표시 이름 확보 목적, 실패해도 무해 —
-  // top-bar 칩이 계정 상태 이름으로 폴백할 뿐 페이지 자체는 이미 경로 기준으로 정상 렌더된다).
-  const pathProjectKnown = pathProjectId ? projectMemberships.some((m) => m.projectId === pathProjectId) : true;
-  if (pathProjectId && !pathProjectKnown) {
-    const resolvedName = await fetch(`${fastapiUrl}/api/v2/projects/${pathProjectId}`, { headers: authHeader, cache: 'no-store' })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((json: { name?: string } | null) => json?.name ?? undefined)
-      .catch(() => undefined);
-    if (resolvedName) {
-      projectMemberships = [...projectMemberships, { projectId: pathProjectId, projectName: resolvedName }];
-    }
-  }
-
-  // story a539c649 S2: 사이드바/⌘K "문서" 바로가기가 /{ws}/{proj}/docs 직접 path를 만들려면
-  // 현재 project의 slug가 필요 — /me/memberships는 slug를 안 실어 보내(BE 스코프 밖, FE 단독
-  // 수정 범위 유지 위해 이미 존재하는 단건 조회를 재사용). 실패해도 sidebar/cmd-palette는
-  // bare `/docs`로 폴백해 미들웨어 리다이렉트 안전망을 타므로 무해.
-  // story #2093: pathProjectId(경로 정본) 우선 — 계정 상태가 다른 project를 가리키면 이
-  // 바로가기도 화면이 실제로 보고 있는 project가 아니라 계정 상태 project로 잘못 향했다.
-  const slugTargetProjectId = pathProjectId ?? me?.project_id;
-  const currentProjectSlug = slugTargetProjectId
-    ? await fetch(`${fastapiUrl}/api/v2/projects/${slugTargetProjectId}`, { headers: authHeader, cache: 'no-store' })
+  // 딥링크·계정 상태가 stale한 경우) pathProjectId가 이 목록에 없어 표시용 이름을 못 찾는다.
+  // 단건 조회(name+slug 동시)로 보강한다 — 사이드바/⌘K "문서" 바로가기 slug(story a539c649 S2)
+  // 와 표시 이름이 같은 project를 가리키므로 PO 리뷰(§확認②) 지적대로 fetch 하나로 합쳤다.
+  // pathProjectId가 없으면(flat 라우트) 계정 상태 project 기준으로 조회한다(기존 동작 유지).
+  const projectInfoTargetId = pathProjectId ?? me?.project_id;
+  const projectInfo = projectInfoTargetId
+    ? await fetch(`${fastapiUrl}/api/v2/projects/${projectInfoTargetId}`, { headers: authHeader, cache: 'no-store' })
         .then((r) => (r.ok ? r.json() : null))
-        .then((json: { slug?: string | null } | null) => json?.slug ?? undefined)
-        .catch(() => undefined)
+        .then((json: { name?: string; slug?: string | null } | null) => json)
+        .catch(() => null)
+    : null;
+  const currentProjectSlug = projectInfo?.slug ?? undefined;
+
+  const pathProjectKnown = pathProjectId ? projectMemberships.some((m) => m.projectId === pathProjectId) : true;
+  if (pathProjectId && !pathProjectKnown && projectInfo?.name) {
+    projectMemberships = [...projectMemberships, { projectId: pathProjectId, projectName: projectInfo.name }];
+  }
+  // PO 리뷰(§확認①) — 위 조회가 실패하면(네트워크·403 등) projectMemberships에 pathProjectId가
+  // 안 들어간다. dashboard-shell.tsx가 이 경우 계정 상태의 옛 project_name으로 조용히
+  // 폴백하지 않도록 `projectName` prop 자체를 pathProjectId 미스매치 시 넘기지 않는다 —
+  // 틀린 이름을 보여주느니 이름을 비워 칩이 org만 보여주게 한다(유나양 §1-1: 모르면
+  // 단정하지 않는다).
+  const projectNameForDisplay = (!pathProjectId || pathProjectId === me?.project_id)
+    ? (me?.project_name ?? undefined)
     : undefined;
 
   return (
@@ -114,7 +112,7 @@ export default async function AuthenticatedLayout({
       currentTeamMemberId={me?.id}
       orgId={me?.org_id}
       projectId={me?.project_id}
-      projectName={me?.project_name ?? undefined}
+      projectName={projectNameForDisplay}
       currentProjectSlug={currentProjectSlug}
       userName={me?.name}
       role={me?.role}

--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -27,7 +27,14 @@ export default async function AuthenticatedLayout({
   children: React.ReactNode;
 }) {
   // AC3: proxy 가 주입한 x-pathname 으로 next 보존(server component 는 현재 경로 직접 못 읽음).
-  const currentPath = (await headers()).get('x-pathname') ?? '';
+  const hdrs = await headers();
+  const currentPath = hdrs.get('x-pathname') ?? '';
+  // story #2093 — proxy.ts(route-resolve.ts `setResolvedHeaders`)가 `[ws]/[proj]` 경로를
+  // 서버측에서 이미 resolve해 실어보낸 값. 계정 상태(me.org_id/project_id)는 URL에 org/project
+  // 세그먼트가 없는 flat 라우트(/glance 등)에서만 신뢰하고, 경로가 있으면 이 값이 정본이다
+  // ("화면이 그리는 컨텍스트의 정본은 URL" — 유나양 규격 §2093).
+  const pathOrgId = hdrs.get('x-resolved-org-id') ?? undefined;
+  const pathProjectId = hdrs.get('x-resolved-project-id') ?? undefined;
 
   const session = await getServerSession();
   if (!session) redirect(buildLoginRedirect(currentPath));
@@ -60,7 +67,7 @@ export default async function AuthenticatedLayout({
   if (!me?.org_id) redirect('/onboarding');
   const memberships: { projectId: string; projectName: string }[] =
     membershipsRes?.ok ? ((await membershipsRes.json()) as { projectId: string; projectName: string }[]) : [];
-  const projectMemberships = memberships.length > 0
+  let projectMemberships = memberships.length > 0
     ? memberships
     : me ? [{ projectId: me.project_id, projectName: me.project_name }] : [];
 
@@ -72,12 +79,31 @@ export default async function AuthenticatedLayout({
     role: o.role,
   }));
 
+  // story #2093 — /me/memberships 는 JWT의 "현재 org" 클레임으로 스코프된다(BE
+  // app/routers/me.py get_my_memberships). URL 경로가 계정 상태와 다른 org를 가리키면(cross-org
+  // 딥링크·계정 상태가 stale한 경우) pathProjectId가 이 목록에 없어 표시용 이름을 못 찾는다 —
+  // 단건 조회로 보강한다(전환 목록에 넣으려는 게 아니라 표시 이름 확보 목적, 실패해도 무해 —
+  // top-bar 칩이 계정 상태 이름으로 폴백할 뿐 페이지 자체는 이미 경로 기준으로 정상 렌더된다).
+  const pathProjectKnown = pathProjectId ? projectMemberships.some((m) => m.projectId === pathProjectId) : true;
+  if (pathProjectId && !pathProjectKnown) {
+    const resolvedName = await fetch(`${fastapiUrl}/api/v2/projects/${pathProjectId}`, { headers: authHeader, cache: 'no-store' })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json: { name?: string } | null) => json?.name ?? undefined)
+      .catch(() => undefined);
+    if (resolvedName) {
+      projectMemberships = [...projectMemberships, { projectId: pathProjectId, projectName: resolvedName }];
+    }
+  }
+
   // story a539c649 S2: 사이드바/⌘K "문서" 바로가기가 /{ws}/{proj}/docs 직접 path를 만들려면
   // 현재 project의 slug가 필요 — /me/memberships는 slug를 안 실어 보내(BE 스코프 밖, FE 단독
   // 수정 범위 유지 위해 이미 존재하는 단건 조회를 재사용). 실패해도 sidebar/cmd-palette는
   // bare `/docs`로 폴백해 미들웨어 리다이렉트 안전망을 타므로 무해.
-  const currentProjectSlug = me?.project_id
-    ? await fetch(`${fastapiUrl}/api/v2/projects/${me.project_id}`, { headers: authHeader, cache: 'no-store' })
+  // story #2093: pathProjectId(경로 정본) 우선 — 계정 상태가 다른 project를 가리키면 이
+  // 바로가기도 화면이 실제로 보고 있는 project가 아니라 계정 상태 project로 잘못 향했다.
+  const slugTargetProjectId = pathProjectId ?? me?.project_id;
+  const currentProjectSlug = slugTargetProjectId
+    ? await fetch(`${fastapiUrl}/api/v2/projects/${slugTargetProjectId}`, { headers: authHeader, cache: 'no-store' })
         .then((r) => (r.ok ? r.json() : null))
         .then((json: { slug?: string | null } | null) => json?.slug ?? undefined)
         .catch(() => undefined)
@@ -94,6 +120,8 @@ export default async function AuthenticatedLayout({
       role={me?.role}
       projectMemberships={projectMemberships}
       orgMemberships={orgMemberships}
+      pathOrgId={pathOrgId}
+      pathProjectId={pathProjectId}
     >
       <StorageCapacityToastProvider>{children}</StorageCapacityToastProvider>
     </DashboardShell>

--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -52,6 +52,12 @@ export function useDashboardContext() {
 }
 
 interface DashboardShellProps extends DashboardContext {
+  // story #2093 — proxy.ts가 `[ws]/[proj]` 경로를 서버측에서 resolve한 결과(x-resolved-*
+  // 헤더 유래). 계정 상태(orgId/projectId, 위 DashboardContext 필드)는 "다음에 어디로 갈지"의
+  // 기본값이고, 이 둘은 "지금 이 URL이 실제로 가리키는 것"이다 — 화면 표시(top-bar 칩 등)는
+  // 이 값을 우선한다. 경로 세그먼트가 없는 flat 라우트(/glance 등)에선 undefined.
+  pathOrgId?: string;
+  pathProjectId?: string;
   children: React.ReactNode;
 }
 
@@ -143,7 +149,11 @@ function ScrollShell({
  * `useDashboardContext().projectId` 소비부가 이 값으로 자동 URL-aware 가 된다. fetch 인터셉터가
  * 같은 값을 `X-Project-Id` 헤더로 실어 mutation 을 탭의 URL 프로젝트에 바인딩(BE 가 멤버십 검증).
  */
-function useProjectSsot(serverProjectId: string | undefined, memberships: DashboardProjectOption[]): string | undefined {
+function useProjectSsot(
+  serverProjectId: string | undefined,
+  memberships: DashboardProjectOption[],
+  pathProjectId: string | undefined,
+): string | undefined {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -160,7 +170,9 @@ function useProjectSsot(serverProjectId: string | undefined, memberships: Dashbo
   const [hydrated, setHydrated] = useState(false);
   useEffect(() => { startTransition(() => setHydrated(true)); }, []);
 
-  const effectiveProjectId = resolveEffectiveProjectId(urlProjectId, serverProjectId, accessibleIds, hydrated);
+  // story #2093 — pathProjectId(경로 `[ws]/[proj]` 서버측 resolve 결과)가 최우선. `?p=`는
+  // 경로 세그먼트가 없는 flat 라우트에서만 실질적인 SSOT로 남는다(project-context-client.ts 참고).
+  const effectiveProjectId = resolveEffectiveProjectId(urlProjectId, serverProjectId, accessibleIds, hydrated, pathProjectId);
 
   // ref 동기화 + 인터셉터 설치를 **렌더 단계**에서 — effect(자식→부모 순)에 두면 부모(DashboardShell)
   // 설치 effect 가 자식(app-sidebar·use-team-presence·kanban-board) 초기 fetch *후* 실행돼 첫 로드
@@ -193,14 +205,19 @@ export function DashboardShell({
   role,
   projectMemberships,
   orgMemberships,
+  pathOrgId,
+  pathProjectId,
   children,
 }: DashboardShellProps) {
   const pathname = usePathname();
   const showTopBar = !pathname.startsWith('/settings');
   const tabletCentered = isTabRootPage(pathname);
 
-  // R2: URL `?p=` = 탭별 SSOT. 서버 prop 대신 effective 를 컨텍스트/사이드바에 공급.
-  const effectiveProjectId = useProjectSsot(projectId, projectMemberships);
+  // story #2093 — 경로(`[ws]/[proj]`) resolve 결과가 최우선(화면이 실제로 그리는 것의 정본).
+  // 계정 상태(orgId, server prop)는 flat 라우트(경로에 org/project가 없는 화면)에서만 쓰인다.
+  const effectiveOrgId = pathOrgId ?? orgId;
+  // R2: URL `?p=` = flat 라우트의 탭별 SSOT. pathProjectId(경로 resolve)가 있으면 그게 최우선.
+  const effectiveProjectId = useProjectSsot(projectId, projectMemberships, pathProjectId);
   const effectiveProjectName = projectMemberships.find((m) => m.projectId === effectiveProjectId)?.projectName ?? projectName;
   // currentProjectSlug 는 server prop(me.project_id) 기준 — effectiveProjectId 가 탭 SSOT로
   // 갈렸으면 살짝 stale 할 수 있으나, "문서로 가기" 바로가기 링크 용도라 무해(틀려도 미들웨어
@@ -214,7 +231,7 @@ export function DashboardShell({
   const chatUnreadTotal = useChatUnreadTotal(currentTeamMemberId);
 
   return (
-    <DashboardCtx.Provider value={{ currentTeamMemberId, orgId, projectId: effectiveProjectId, projectName: effectiveProjectName, currentProjectSlug, userName, role, projectMemberships, orgMemberships }}>
+    <DashboardCtx.Provider value={{ currentTeamMemberId, orgId: effectiveOrgId, projectId: effectiveProjectId, projectName: effectiveProjectName, currentProjectSlug, userName, role, projectMemberships, orgMemberships }}>
       <RefreshProvider>
       <RealtimeProvider currentTeamMemberId={currentTeamMemberId}>
         <TopBarProvider>
@@ -223,7 +240,7 @@ export function DashboardShell({
               projectId={effectiveProjectId}
               currentProjectSlug={currentProjectSlug}
               projectMemberships={projectMemberships}
-              orgId={orgId}
+              orgId={effectiveOrgId}
               orgMemberships={orgMemberships}
               userName={userName}
               chatUnreadTotal={chatUnreadTotal}
@@ -232,7 +249,7 @@ export function DashboardShell({
               showTopBar={showTopBar}
               tabletCentered={tabletCentered}
               chatUnreadTotal={chatUnreadTotal}
-              orgId={orgId}
+              orgId={effectiveOrgId}
               orgMemberships={orgMemberships}
               projectId={effectiveProjectId}
               projectMemberships={projectMemberships}

--- a/apps/web/src/lib/project-context-client.test.ts
+++ b/apps/web/src/lib/project-context-client.test.ts
@@ -45,3 +45,33 @@ describe('resolveEffectiveProjectId (hydrated 게이팅 — SSR/첫 CSR 렌더 d
     expect(resolveEffectiveProjectId(null, 'server-id', accessible, true)).toBe('server-id');
   });
 });
+
+describe('resolveEffectiveProjectId — pathProjectId 최우선 (story #2093, 직접 URL 진입 시 top-bar 칩이 계정 상태의 다른 프로젝트를 그리던 회귀)', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+  afterEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('직접 URL 진입(?p= 없음) — pathProjectId가 계정 상태(serverProjectId)보다 우선한다', () => {
+    const accessible = new Set(['server-id']); // 계정 멤버십엔 path-project가 없을 수 있다(cross-org)
+    expect(resolveEffectiveProjectId(null, 'server-id', accessible, true, 'path-id')).toBe('path-id');
+  });
+
+  it('pathProjectId는 accessibleIds 체크를 받지 않는다(proxy.ts가 이미 서버측에서 resolve로 검증한 값)', () => {
+    const accessible = new Set(['server-id']); // path-id가 이 집합에 없어도(cross-org) 채택돼야 한다
+    expect(resolveEffectiveProjectId(null, 'server-id', accessible, false, 'path-id')).toBe('path-id');
+  });
+
+  it('pathProjectId가 ?p=/sessionStorage보다도 우선한다(경로가 유일한 정본)', () => {
+    window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, 'stored-id');
+    const accessible = new Set(['stored-id', 'url-id', 'path-id']);
+    expect(resolveEffectiveProjectId('url-id', 'server-id', accessible, true, 'path-id')).toBe('path-id');
+  });
+
+  it('pathProjectId가 없는(flat 라우트) 경우엔 기존 ?p= 우선순위 체인이 그대로 동작한다', () => {
+    const accessible = new Set(['url-id', 'server-id']);
+    expect(resolveEffectiveProjectId('url-id', 'server-id', accessible, true, undefined)).toBe('url-id');
+  });
+});

--- a/apps/web/src/lib/project-context-client.ts
+++ b/apps/web/src/lib/project-context-client.ts
@@ -61,21 +61,38 @@ export function installProjectHeaderInterceptor(): void {
 }
 
 /**
- * 탭 effective project 해소 — 우선순위: URL `?p=` → sessionStorage backstop → 서버 prop(쿠키 유래).
- * 후보가 accessible(`accessibleIds`)일 때만 채택(UX/intent 필터, 보안 아님). 무효면 다음 우선순위.
+ * 탭 effective project 해소 — 우선순위: **경로(`[ws]/[proj]`) resolve 결과** → URL `?p=` →
+ * sessionStorage backstop → 서버 prop(쿠키 유래). 후보가 accessible(`accessibleIds`)일 때만
+ * 채택(UX/intent 필터, 보안 아님) — 단 `pathProjectId`는 예외(아래 참고). 무효면 다음 우선순위.
+ *
+ * story #2093 — `?p=`는 원래 "탭별 SSOT"였으나 `/{ws}/{proj}/...` 경로 세그먼트도 탭마다
+ * 다른 값이라 같은 일을 하는 두 번째 축이었다. 두 축이 갈리는 자리(북마크·딥링크 등 `?p=` 없이
+ * 경로로 직접 진입)에서 화면 본문은 경로를 따르는데 이 함수는 계정 상태로 폴백해 top-bar 칩이
+ * 다른 프로젝트를 그렸다(라이브 재현). `pathProjectId`(proxy.ts가 URL 경로를 서버측에서 resolve해
+ * `x-resolved-project-id` 헤더로 실어보낸 값)를 최우선으로 승격해 두 축을 하나로 합친다.
+ * `?p=`는 경로 세그먼트가 없는 flat 라우트(`/glance`·`/inbox` 등, TAB_ROOT_PREFIXES)에서 여전히
+ * 유일한 탭별 SSOT라 유지한다 — 그 라우트들은 애초에 `pathProjectId`가 없다(resolve 미대상).
+ *
+ * `pathProjectId`는 accessibleIds 체크를 안 받는다 — `?p=`/sessionStorage는 클라이언트가 임의로
+ * 들고 있을 수 있는 값이라 멤버십 재확인이 필요하지만, `pathProjectId`는 proxy.ts가 같은
+ * accessToken으로 BE resolve(`/api/v2/resolve`)를 이미 통과시킨 서버측 검증 결과라 재검증이
+ * 중복이다(그리고 cross-org 진입 시 `accessibleIds`가 계정의 "현재 org" 멤버십에만 스코프돼
+ * 있어 오탈락할 수 있다 — 그 경우 이 우선순위가 없으면 정확한 값도 걸러진다).
  *
  * `hydrated`(기본 true, 명시적으로 false를 넘길 때만 sessionStorage 무시) — 라이브 재현(2026-07-11)
  * 대응: sessionStorage는 브라우저 전용이라 SSR(`window` 없음)에선 원천적으로 못 읽는다. 이 함수
  * 호출부(`useProjectSsot`)가 하이드레이션 완료 전엔 `hydrated=false`를 넘겨, 첫 클라이언트 렌더가
- * 서버 렌더와 동일한 값(URL/serverProjectId 기준)을 내도록 강제한다 — 안 그러면 SSR과 첫 CSR
- * 사이에 값이 갈려 하이드레이션 직후 예상 밖 URL 정규화(router.replace)가 발동할 수 있다.
+ * 서버 렌더와 동일한 값(경로/URL/serverProjectId 기준)을 내도록 강제한다 — 안 그러면 SSR과 첫
+ * CSR 사이에 값이 갈려 하이드레이션 직후 예상 밖 URL 정규화(router.replace)가 발동할 수 있다.
  */
 export function resolveEffectiveProjectId(
   urlProjectId: string | null,
   serverProjectId: string | undefined,
   accessibleIds: ReadonlySet<string>,
   hydrated = true,
+  pathProjectId?: string,
 ): string | undefined {
+  if (pathProjectId) return pathProjectId;
   if (urlProjectId && accessibleIds.has(urlProjectId)) return urlProjectId;
   if (hydrated && typeof window !== 'undefined') {
     const stored = window.sessionStorage.getItem(TAB_PROJECT_STORAGE_KEY);


### PR DESCRIPTION
## 근본원인
top-bar 칩이 화면이 실제로 그리는 컨텍스트가 아니라 계정의 "현재 프로젝트/조직" 상태(`me.org_id`/`me.project_id`, 입력값)를 표시해왔다. 이미 "SSOT"라는 이름의 설계(`useProjectSsot`, R2)가 있었지만 그 URL 소스가 `[ws]/[proj]` 경로 세그먼트가 아니라 `?p=` 쿼리파라미터였다 — 전환 시엔 둘 다 같이 갱신돼 안 갈렸지만, `?p=` 없이 `/{ws}/{proj}/board`로 직접 진입(북마크·딥링크·브라우저 뒤로가기)하면 계정 상태로 폴백해 칩이 다른 프로젝트를 그렸다.

`proxy.ts`가 이미 URL을 서버측에서 resolve해 `x-resolved-org-id`/`x-resolved-project-id` 헤더로 downstream에 실어보내고 있었으나 `(authenticated)/layout.tsx`가 이 헤더를 전혀 읽지 않고 있었다.

## 규격(유나양 확定)
화면이 그리는 컨텍스트의 정본은 URL(경로 세그먼트)이다. 계정의 "현재 프로젝트"는 다음에 어디로 갈지를 정할 때만 쓴다.

## 수정
- `project-context-client.ts`: `resolveEffectiveProjectId`에 `pathProjectId` 최우선 파라미터 신설(accessibleIds 재검증 없음 — proxy.ts가 이미 서버측에서 검증).
- `dashboard-shell.tsx`: `useProjectSsot`에 스레딩, `orgId`도 `pathOrgId ?? orgId`로 승격.
- `(authenticated)/layout.tsx`: 헤더 읽어 전달, cross-org 진입 시 projectMemberships 표시이름 보강, 문서 바로가기 슬러그도 정정.

`?p=`는 flat 라우트(`/glance`·`/inbox` 등, 경로에 project 세그먼트 자체가 없음)에서 대체 불가능해 유지.

## 테스트
`project-context-client.test.ts` 4건 신설, RED→GREEN 확認. type-check/lint/vitest(1826)/build 전부 green.

## 미완 — 배포 후 게이트
①URL 직접 진입 ②전환 직후 ③브라우저 뒤로가기 3경로 실측은 배포 후. 칩 노출폭(<1024) 회귀는 현재 dev 1024/1440px에서 직접 확認 결과 정상 — 리포트가 #2365 배포 전 시점이었을 가능성.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>