### PR TITLE
fix(invite): 초대 프리뷰 GET이 미인증 신규 사용자를 401로 막던 결함

### DIFF
--- a/apps/web/src/app/api/invites/[token]/route.test.ts
+++ b/apps/web/src/app/api/invites/[token]/route.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// 라이브 재현(2026-07-21, story #2383 배포검수 중 발견) — 이 라우트가 public 옵션 없이
+// proxyToFastapi를 호출해 "아직 계정이 없는 신규 사용자"가 보는 초대 프리뷰를 무조건 401로
+// 막고 있었다. GET /api/invites/[token]은 반드시 { public: true }로 위임해야 한다.
+const { proxyToFastapiWithParams } = vi.hoisted(() => ({ proxyToFastapiWithParams: vi.fn() }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
+
+import { GET } from './route';
+
+const PATH = '/api/v2/invites/[token]';
+const okRes = (b: unknown = { ok: 1 }) =>
+  new Response(JSON.stringify(b), { status: 200, headers: { 'content-type': 'application/json' } });
+const req = () => new Request('http://localhost/api/invites/tok-1');
+const params = () => Promise.resolve({ token: 'tok-1' });
+
+describe('GET /api/invites/[token] (초대 프리뷰 — 미인증 사용자용, public 위임 필수)', () => {
+  beforeEach(() => proxyToFastapiWithParams.mockReset());
+
+  it('미인증 사용자도 접근 가능하도록 { public: true }로 위임한다', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(okRes({ org_name: '뭉클랩' }));
+    const res = await GET(req(), { params: params() });
+    expect(res.status).toBe(200);
+    expect(proxyToFastapiWithParams).toHaveBeenCalledWith(
+      expect.anything(), PATH, { token: 'tok-1' }, { public: true },
+    );
+    expect((await res.json()).data).toMatchObject({ org_name: '뭉클랩' });
+  });
+
+  it('passes through proxy errors', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(new Response('e', { status: 404 }));
+    expect((await GET(req(), { params: params() })).status).toBe(404);
+  });
+});

--- a/apps/web/src/app/api/invites/[token]/route.ts
+++ b/apps/web/src/app/api/invites/[token]/route.ts
@@ -5,7 +5,12 @@ type RouteParams = { params: Promise<{ token: string }> };
 
 export async function GET(request: Request, { params }: RouteParams) {
   const { token } = await params;
-  const _r = await proxyToFastapiWithParams(request, '/api/v2/invites/[token]', { token });
+  // 라이브 재현(2026-07-21, story #2383 배포검수 중 발견) — 이 라우트가 public 옵션 없이
+  // proxyToFastapi를 호출해 미인증 요청을 무조건 401로 막고 있었다(fastapi-proxy.ts:92-94).
+  // 초대 프리뷰는 정의상 "아직 계정이 없는 신규 사용자"가 보는 화면이라 미인증이 기본 상태다
+  // — 이 라우트 신설(#857) 이후 한 번도 고쳐진 적 없는 원 결함(git log 단일 커밋 확認).
+  // POST .../accept는 로그인/가입 완료 후에만 호출되므로 인증 유지가 맞다(그대로 둠).
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/invites/[token]', { token }, { public: true });
   if (!_r.ok) return _r;
   if (_r.status === 204) return apiSuccess({ ok: true });
   return apiSuccess(await _r.json());


### PR DESCRIPTION
story #2383(i18n) 배포검수 중 라이브 재현으로 발견 — joinHeading `t.rich()` 강조를 실제 미인증 화면에서 확認하려다 "Unauthorized"만 뜨는 것을 보고 조사했다.

## 근본원인
`/api/invites/[token]/route.ts`가 `proxyToFastapiWithParams`를 public 옵션 없이 호출해 미인증 요청을 401로 막는다. git log 확認 결과 이 라우트 신설(#857) 이후 한 번도 고쳐진 적 없는 원 결함 — 오늘 도입된 회귀가 아니다.

초대 프리뷰는 정의상 **아직 계정이 없는 신규 사용자**가 처음 보는 화면이다. 실측: 로그아웃 상태(`/api/me` 401 확認) + 유효 토큰으로 `/invite?token=...` 접속 시 "Unauthorized"만 뜨고 프리뷰 정보를 전혀 못 봤다 — 링크를 받은 신규 사용자 전원이 이 화면에서 막혔을 것으로 보인다.

`POST .../accept/route.ts`는 로그인 후에만 호출되는 게 맞아 그대로 둔다 — 동일 클래스(`/api/public/docs/[token]/route.ts`)에 이미 있는 `{ public: true }` 패턴을 GET 프리뷰에만 적용했다.

## 테스트
`route.test.ts` 신설, RED→GREEN 확認. type-check/lint/vitest(1830)/build 전부 green.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>