### PR TITLE
feat(infra): drift guard ②값 대조 축 구현 (story #2098)

### DIFF
--- a/backend/scripts/deploy_frontend.sh
+++ b/backend/scripts/deploy_frontend.sh
@@ -81,10 +81,18 @@ if [[ -n "${FASTAPI_URL_OVERRIDE}" ]]; then
 else
     # FastAPI Cloud Run 서비스 URL 조회(동적 discovery — prod는 아직 CF-fronted 도메인이 없어
     # raw *.run.app 이 곧 정답값).
+    # ⚠️story #2098 정정(2026-07-22, 드리프트 가드 ②값 대조가 실측 중 발견): `status.url`은
+    # hash 포맷(`sprintable-backend-prod-57iommnikq-du.a.run.app`)을 반환하는데 라이브
+    # NEXT_PUBLIC_FASTAPI_URL은 project-number 포맷(`sprintable-backend-prod-787818285179.
+    # asia-northeast3.run.app`)이다 — 둘 다 유효한 별칭(`metadata.annotations['run.googleapis.
+    # com/urls']`에 둘 다 등재돼 있음, curl 200 각각 확認)이지만 재배포 시 표기가 바뀌는
+    # 드리프트였다. `skip`으로 눈 감는 대신 라이브와 같은 포맷(그 annotation의 첫 번째
+    # 원소)을 명시적으로 골라 스크립트가 라이브와 일치하는 값을 계산하게 고쳤다.
     FASTAPI_URL=$(gcloud run services describe "${FASTAPI_SERVICE}" \
         --region="${GCP_REGION}" \
         --project="${GCP_PROJECT}" \
-        --format="value(status.url)" 2>/dev/null || echo "")
+        --format="value(metadata.annotations['run.googleapis.com/urls'])" 2>/dev/null \
+        | sed -E 's/^\["([^"]*)".*/\1/' || echo "")
 fi
 
 if [[ -z "${FASTAPI_URL}" ]]; then

--- a/backend/scripts/deploy_frontend.sh
+++ b/backend/scripts/deploy_frontend.sh
@@ -15,6 +15,10 @@
 #   GCP_REGION    (기본: asia-northeast3)
 #   COMMIT_SHA    [필수] 배포할 이미지 태그
 #   ENV           dev|prod (또는 첫 번째 인자)
+#   DRY_RUN       1이면 실 배포(gcloud run deploy) 없이 resolved config만 stdout 출력
+#                 (story #2098, 드리프트 가드 ②값 대조 축용 — deploy_backend.sh와 동형).
+#                 prod의 NEXT_PUBLIC_FASTAPI_URL 동적 discovery(아래) 자체는 read-only
+#                 gcloud describe라 DRY_RUN에서도 그대로 수행(실 배포만 스킵).
 
 set -euo pipefail
 
@@ -22,7 +26,13 @@ GCP_PROJECT="${GCP_PROJECT:-sprintable-494803}"
 GCP_REGION="${GCP_REGION:-asia-northeast3}"
 AR_REPO="${AR_REPO:-sprintable}"
 ENV="${1:-${ENV:-dev}}"
-COMMIT_SHA="${COMMIT_SHA:?COMMIT_SHA is required}"
+DRY_RUN="${DRY_RUN:-0}"
+# DRY_RUN(검증 전용)에서는 실제 이미지 태그가 필요 없으므로 COMMIT_SHA를 강제하지 않는다.
+if [ "${DRY_RUN}" = "1" ]; then
+    COMMIT_SHA="${COMMIT_SHA:-dry-run-placeholder}"
+else
+    COMMIT_SHA="${COMMIT_SHA:?COMMIT_SHA is required}"
+fi
 
 IMAGE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${AR_REPO}/frontend:${COMMIT_SHA}"
 
@@ -81,6 +91,23 @@ if [[ -z "${FASTAPI_URL}" ]]; then
     log "WARNING: FastAPI service '${FASTAPI_SERVICE}' not found. NEXT_PUBLIC_FASTAPI_URL will be empty."
 fi
 
+ENV_VARS_SPEC="NODE_ENV=production,NEXT_TELEMETRY_DISABLED=1,NEXT_PUBLIC_FASTAPI_URL=${FASTAPI_URL}"
+SECRETS_SPEC="NEXT_PUBLIC_SUPABASE_URL=NEXT_PUBLIC_SUPABASE_URL:latest,NEXT_PUBLIC_SUPABASE_ANON_KEY=NEXT_PUBLIC_SUPABASE_ANON_KEY:latest,JWT_SECRET=JWT_SECRET:latest${COOKIE_DOMAIN_SECRET_SPEC}"
+
+if [ "${DRY_RUN}" = "1" ]; then
+    cat <<EOF
+ENV=${ENV}
+SERVICE_NAME=${SERVICE_NAME}
+IMAGE=${IMAGE}
+RUNTIME_SA=${RUNTIME_SA}
+MIN_INSTANCES=${MIN_INSTANCES}
+MAX_INSTANCES=${MAX_INSTANCES}
+ENV_VARS_SPEC=${ENV_VARS_SPEC}
+SECRETS_SPEC=${SECRETS_SPEC}
+EOF
+    exit 0
+fi
+
 # ⛔story cd10e123 계열 긴급수정(2026-07-21, durable-wiring 전수 스윕 ⓐ): deploy_backend.sh와
 # 동형 결함 — --set-env-vars/--set-secrets(전체교체)로 재실행되면 cloudbuild.yaml deploy-frontend
 # 스텝이 additive로 쌓아온 REALTIME_URL 등이 소실된다. --update-*(additive)로 교정.
@@ -98,11 +125,8 @@ gcloud run deploy "${SERVICE_NAME}" \
     --max-instances="${MAX_INSTANCES}" \
     --concurrency=80 \
     --timeout=60 \
-    --update-env-vars="NODE_ENV=production,NEXT_TELEMETRY_DISABLED=1,NEXT_PUBLIC_FASTAPI_URL=${FASTAPI_URL}" \
-    --update-secrets="\
-NEXT_PUBLIC_SUPABASE_URL=NEXT_PUBLIC_SUPABASE_URL:latest,\
-NEXT_PUBLIC_SUPABASE_ANON_KEY=NEXT_PUBLIC_SUPABASE_ANON_KEY:latest,\
-JWT_SECRET=JWT_SECRET:latest${COOKIE_DOMAIN_SECRET_SPEC}" \
+    --update-env-vars="${ENV_VARS_SPEC}" \
+    --update-secrets="${SECRETS_SPEC}" \
     --cpu-boost
 
 SERVICE_URL=$(gcloud run services describe "${SERVICE_NAME}" \

--- a/backend/scripts/deploy_frontend.sh
+++ b/backend/scripts/deploy_frontend.sh
@@ -88,6 +88,10 @@ else
     # com/urls']`에 둘 다 등재돼 있음, curl 200 각각 확認)이지만 재배포 시 표기가 바뀌는
     # 드리프트였다. `skip`으로 눈 감는 대신 라이브와 같은 포맷(그 annotation의 첫 번째
     # 원소)을 명시적으로 골라 스크립트가 라이브와 일치하는 값을 계산하게 고쳤다.
+    # ⚠️ 전제(오르테가군 지적): 아래는 `run.googleapis.com/urls`의 첫 원소가 project-number
+    # 포맷이라는 GCP 쪽 현재 동작에 의존한다 — 이 순서 보장을 우리가 정할 수 없다. GCP가
+    # 순서를 바꾸면 이 대조가 다시 어긋난다 — 그때는 순서 의존을 걷어내고 두 포맷을 모두
+    # 허용하는 쪽으로 판단할 것(지금 당장 그렇게 만들라는 건 아님 — 전제만 기록).
     FASTAPI_URL=$(gcloud run services describe "${FASTAPI_SERVICE}" \
         --region="${GCP_REGION}" \
         --project="${GCP_PROJECT}" \

--- a/infra/check_env_drift.py
+++ b/infra/check_env_drift.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
-"""ⓒ 라이브 env 드리프트 가드 — ①키집합 대조 + ③평문 시크릿 형태 검출.
+"""ⓒ 라이브 env 드리프트 가드 — ①키집합 대조 + ②값 대조(story #2098) + ③평문 시크릿 형태 검출.
 
 라이브 Cloud Run 서비스의 env var 키 이름 전체가 (IaC 선언 키 ∪ manual-env-allowlist.yml)
 안에 있는지 확認한다(①). 서비스 목록은 `gcloud run services list`로 매 실행 동적 열거 —
 하드코딩하지 않는다(mcp-dev 키 유출 사건이 "아무도 안 본 서비스"에서 났다는 교훈).
+
+②(값 대조)는 DRY_RUN을 지원하는 deploy_backend.sh/deploy_frontend.sh 대상(backend-dev/prod,
+frontend-dev/prod)만 커버한다 — #2381이 잡은 APP_ENV/FRONTEND_URL/COOKIE_DOMAIN류 버그가
+정확히 이 두 스크립트의 계산값 클래스였다. realtime-dev(cloudbuild.yaml 단일 소스)·
+mcp-dev/prod(항상 `--set-env-vars` 전체교체라 additive-drift 리스크 자체가 낮음)는 이번
+스코프 밖 — 후속으로 넓힐 수 있음(못 잡는 것을 못 잡는다고 적어두는 것).
 
 ⛔ ③(평문 시크릿 형태 검출)은 excluded_services 여부와 무관하게 **전 서비스**에 적용한다 —
 ①②축은 "이 repo의 IaC로 대조 불가"라는 이유로 뺄 수 있지만, ③은 라이브 env value만 보면
@@ -19,6 +25,8 @@ exit code: 0=드리프트 없음, 1=드리프트 발견(FAIL 상세를 stdout에
 """
 from __future__ import annotations
 
+import json
+import os
 import re
 import subprocess
 import sys
@@ -40,6 +48,14 @@ _SERVICE_SCRIPT_MAP: dict[str, list[str]] = {
     "sprintable-frontend-prod": ["backend/scripts/deploy_frontend.sh"],
     "sprintable-mcp-dev": ["backend/scripts/deploy_mcp_dev.sh"],
     "sprintable-mcp-prod": ["backend/scripts/deploy_mcp_prod.sh"],
+}
+
+# ② 값 대조 대상 — DRY_RUN=1로 ENV_VARS_SPEC을 stdout에 뽑아낼 수 있는 스크립트만.
+_SERVICE_DRY_RUN_MAP: dict[str, tuple[str, str]] = {
+    "sprintable-backend-dev": ("backend/scripts/deploy_backend.sh", "dev"),
+    "sprintable-backend-prod": ("backend/scripts/deploy_backend.sh", "prod"),
+    "sprintable-frontend-dev": ("backend/scripts/deploy_frontend.sh", "dev"),
+    "sprintable-frontend-prod": ("backend/scripts/deploy_frontend.sh", "prod"),
 }
 
 _KEY_RE = re.compile(r"([A-Z][A-Z0-9_]*)=")
@@ -82,24 +98,8 @@ def _list_live_services() -> list[str]:
     return [line.strip() for line in out.splitlines() if line.strip()]
 
 
-def _live_env_keys(service: str) -> set[str]:
-    out = _run([
-        "gcloud", "run", "services", "describe", service,
-        f"--region={_REGION}",
-        "--format=value(spec.template.spec.containers[0].env[].name)",
-    ])
-    if not out:
-        return set()
-    return {k.strip() for k in out.split(";") if k.strip()}
-
-
-def _plain_secret_shaped_keys(service: str) -> list[str]:
-    """③ — plain(비-secretKeyRef) env value가 알려진 시크릿 형태와 일치하는 키 이름만 반환.
-
-    값 자체는 이 함수 밖으로 절대 나가지 않는다(정규식 매치 결과 bool만 사용) — 호출부는
-    반환된 키 이름과 서비스만 로그에 남긴다."""
-    import json as _json
-
+def _live_env_entries(service: str) -> list[dict]:
+    """서비스의 raw env 리스트(name + value 또는 valueFrom) — ②③이 공유."""
     out = _run([
         "gcloud", "run", "services", "describe", service,
         f"--region={_REGION}",
@@ -107,17 +107,64 @@ def _plain_secret_shaped_keys(service: str) -> list[str]:
     ])
     if not out:
         return []
-    data = _json.loads(out)
-    envs = (
+    data = json.loads(out)
+    return (
         data.get("spec", {}).get("template", {}).get("spec", {})
         .get("containers", [{}])[0].get("env", [])
     )
+
+
+def _plain_secret_shaped_keys(envs: list[dict]) -> list[str]:
+    """③ — plain(비-secretKeyRef) env value가 알려진 시크릿 형태와 일치하는 키 이름만 반환.
+
+    값 자체는 이 함수 밖으로 절대 나가지 않는다(정규식 매치 결과 bool만 사용) — 호출부는
+    반환된 키 이름과 서비스만 로그에 남긴다."""
     hits = []
     for entry in envs:
         value = entry.get("value")
         if value is not None and _SECRET_SHAPE_RE.search(value):
             hits.append(entry["name"])
     return hits
+
+
+def _live_plain_env_values(envs: list[dict]) -> dict[str, str]:
+    """② 대조용 — plain(비-secretKeyRef) env만 key→value. secretKeyRef는 값이 안 보이니
+    비교 대상이 아니다(① 키집합 대조가 그 존재 자체는 이미 커버)."""
+    return {e["name"]: e["value"] for e in envs if e.get("value") is not None}
+
+
+def _parse_key_value_spec(spec: str) -> dict[str, str]:
+    """`KEY1=val1,KEY2=val2` 또는 `^@^KEY1=val1@KEY2=val2` 류 구분자 무관 파싱.
+
+    `_extract_keys_from_text`와 동일 전제(`[A-Z][A-Z0-9_]*=` 위치 기준) — 각 키 매치의
+    시작~다음 키 매치 시작 사이를 값으로 보고, 끝에 남은 구분자 문자(,·@·#·^)만 벗겨낸다.
+    """
+    matches = list(_KEY_RE.finditer(spec))
+    result: dict[str, str] = {}
+    for i, m in enumerate(matches):
+        key = m.group(1)
+        val_start = m.end()
+        val_end = matches[i + 1].start() if i + 1 < len(matches) else len(spec)
+        result[key] = spec[val_start:val_end].rstrip(",@#^")
+    return result
+
+
+def _dry_run_env_vars_spec(script_rel: str, env_arg: str) -> dict[str, str]:
+    """deploy_backend.sh/deploy_frontend.sh를 DRY_RUN=1로 돌려 ENV_VARS_SPEC 계산값을 얻는다.
+
+    실 배포(gcloud run deploy)는 스킵되고 resolved config만 stdout으로 나온다(스크립트
+    자체의 DRY_RUN 계약) — network 부작용 없음(단, prod frontend의 FASTAPI_URL 동적
+    discovery 자체는 read-only gcloud describe 1콜을 그대로 수행)."""
+    script_path = _REPO_ROOT / script_rel
+    result = subprocess.run(
+        ["bash", str(script_path), env_arg],
+        capture_output=True, text=True, check=True,
+        env={**os.environ, "DRY_RUN": "1", "COMMIT_SHA": "dry-run-placeholder", "ENV": env_arg},
+    )
+    for line in result.stdout.splitlines():
+        if line.startswith("ENV_VARS_SPEC="):
+            return _parse_key_value_spec(line[len("ENV_VARS_SPEC="):])
+    return {}
 
 
 def _extract_keys_from_text(text: str) -> set[str]:
@@ -150,15 +197,36 @@ def main() -> int:
 
     live_services = _list_live_services()
     key_set_failures: list[str] = []
+    value_check_failures: list[str] = []
     secret_shape_failures: list[str] = []
     unmapped: list[str] = []
 
     checked = 0
+    value_checked = 0
     for service in live_services:
+        envs = _live_env_entries(service)
+
         # ③ 평문 시크릿 형태 검출 — excluded_services 여부와 무관하게 전 서비스에 적용.
-        secret_hits = _plain_secret_shaped_keys(service)
+        secret_hits = _plain_secret_shaped_keys(envs)
         if secret_hits:
             secret_shape_failures.append(f"{service}: {', '.join(sorted(secret_hits))}")
+
+        # ② 값 대조 — DRY_RUN 지원 스크립트 매핑이 있는 서비스만.
+        if service in _SERVICE_DRY_RUN_MAP:
+            skip_keys = {
+                entry["key"] for entry in allowlist_services.get(service, {}).get("keys", [])
+                if entry.get("value_check") == "skip"
+            }
+            script_rel, env_arg = _SERVICE_DRY_RUN_MAP[service]
+            expected = _dry_run_env_vars_spec(script_rel, env_arg)
+            live_plain = _live_plain_env_values(envs)
+            value_checked += 1
+            mismatched = sorted(
+                key for key, exp_val in expected.items()
+                if key not in skip_keys and key in live_plain and live_plain[key] != exp_val
+            )
+            if mismatched:
+                value_check_failures.append(f"{service}: {', '.join(mismatched)}")
 
         # ①키집합 대조 — 축별 제외(key_set) 대상이면 스킵.
         if "key_set" in excluded_axes.get(service, set()):
@@ -168,7 +236,7 @@ def main() -> int:
             continue
 
         checked += 1
-        live_keys = _live_env_keys(service)
+        live_keys = {e["name"] for e in envs}
         allowed_keys = {
             entry["key"] for entry in allowlist_services.get(service, {}).get("keys", [])
         }
@@ -184,11 +252,15 @@ def main() -> int:
             + ", ".join(unmapped)
         )
 
-    if key_set_failures or secret_shape_failures:
+    if key_set_failures or value_check_failures or secret_shape_failures:
         print("❌ env 드리프트 발견:")
         if key_set_failures:
             print("  ①키집합 대조:")
             for line in key_set_failures:
+                print(f"    - {line}")
+        if value_check_failures:
+            print("  ②값 대조(⛔ 값은 출력하지 않음 — 키 이름만, 스크립트 계산값 ≠ 라이브):")
+            for line in value_check_failures:
                 print(f"    - {line}")
         if secret_shape_failures:
             print("  ③평문 시크릿 형태 검출(⛔ 값은 출력하지 않음 — 키 이름만):")
@@ -197,13 +269,16 @@ def main() -> int:
         print(
             "\n→ ①은 파이프라인(cloudbuild.yaml/deploy_*.sh)에 편입하거나 "
             "infra/manual-env-allowlist.yml에 사유와 함께 등재. "
+            "②는 스크립트 재실행 시 라이브 값을 되돌릴 위험 — 스크립트를 라이브에 맞게 "
+            "고치거나 의도적이면 allowlist에 `value_check: skip`+사유로 등재. "
             "③은 즉시 Secret Manager secretKeyRef로 전환 바라는(평문 유지 시 재확定 시마다 재발)."
         )
         return 1
 
     print(
-        f"✅ 드리프트 없음 — ①{checked}개 서비스 키집합 확認"
+        f"✅ 드리프트 없음 — ①{checked}개 서비스 키집합"
         f"(제외 {sum(1 for a in excluded_axes.values() if 'key_set' in a)}개), "
+        f"②{value_checked}개 서비스 값 대조, "
         f"③{len(live_services)}개 서비스 전체 평문시크릿 스캔 완료(제외 없음)."
     )
     return 0

--- a/infra/manual-env-allowlist.yml
+++ b/infra/manual-env-allowlist.yml
@@ -355,6 +355,18 @@ services:
       - key: SUPABASE_SERVICE_ROLE_KEY
         reason: Supabase 서비스 롤 키 — 부트스트랩 스크립트 미편입, prod-only.
         owner: TBD
+      - key: NEXT_PUBLIC_FASTAPI_URL
+        value_check: skip
+        reason: >-
+          story #2098 구현 중 실측(2026-07-22)으로 발견 — deploy_frontend.sh prod의
+          동적 discovery(`gcloud run services describe backend-prod --format=value(status.url)`)가
+          현재 hash 포맷 URL(`sprintable-backend-prod-57iommnikq-du.a.run.app`)을 반환하는데,
+          라이브 값은 project-number 포맷(`sprintable-backend-prod-787818285179.
+          asia-northeast3.run.app`)이다. 둘 다 curl 200 확認(같은 서비스의 유효한 별칭
+          URL 두 형태) — 재배포해도 기능상 무해하나 표기가 바뀌는 것뿐이라 `skip`.
+          이 키 자체가 스코프 밖인 게 아니라(①은 이미 IaC-covered라 entry 불필요),
+          ②값 대조 축에서만 의도적 예외.
+        owner: TBD
 
   # sprintable-mcp-dev / sprintable-mcp-prod: 실측 결과 라이브 키 전부(MCP_TRANSPORT·
   # SPRINTABLE_API_URL·AGENT_API_KEY·[prod만]MCP_ALLOWED_HOSTS) deploy_mcp_dev.sh/

--- a/infra/manual-env-allowlist.yml
+++ b/infra/manual-env-allowlist.yml
@@ -355,17 +355,6 @@ services:
       - key: SUPABASE_SERVICE_ROLE_KEY
         reason: Supabase 서비스 롤 키 — 부트스트랩 스크립트 미편입, prod-only.
         owner: TBD
-      - key: NEXT_PUBLIC_FASTAPI_URL
-        value_check: skip
-        reason: >-
-          story #2098 구현 중 실측(2026-07-22)으로 발견 — deploy_frontend.sh prod의
-          동적 discovery(`gcloud run services describe backend-prod --format=value(status.url)`)가
-          현재 hash 포맷 URL(`sprintable-backend-prod-57iommnikq-du.a.run.app`)을 반환하는데,
-          라이브 값은 project-number 포맷(`sprintable-backend-prod-787818285179.
-          asia-northeast3.run.app`)이다. 둘 다 curl 200 확認(같은 서비스의 유효한 별칭
-          URL 두 형태) — 재배포해도 기능상 무해하나 표기가 바뀌는 것뿐이라 `skip`.
-          이 키 자체가 스코프 밖인 게 아니라(①은 이미 IaC-covered라 entry 불필요),
-          ②값 대조 축에서만 의도적 예외.
         owner: TBD
 
   # sprintable-mcp-dev / sprintable-mcp-prod: 실측 결과 라이브 키 전부(MCP_TRANSPORT·


### PR DESCRIPTION
## Summary
- story #2098 — env-drift-guard-design 설계의 ②값 대조 축 구현. deploy_backend.sh/deploy_frontend.sh를 `DRY_RUN=1`로 돌려 계산되는 ENV_VARS_SPEC과 라이브 plain env value를 키별로 비교 — #2381이 잡은 APP_ENV/FRONTEND_URL/COOKIE_DOMAIN류("적힌 키의 값 자체가 낡음" 클래스, 스크립트 재실행 시 라이브 값을 조용히 되돌리는 리스크) 재발을 상시 감시
- `deploy_frontend.sh`에 `DRY_RUN` 지원 신설(`deploy_backend.sh`와 동형) — 실 배포 없이 resolved config만 stdout 출력. 실 배포 호출부도 새 `ENV_VARS_SPEC`/`SECRETS_SPEC` 변수를 그대로 재사용하도록 리팩터해 DRY_RUN 출력과 실 배포가 구조적으로 갈라질 수 없게 함
- `check_env_drift.py`: `_dry_run_env_vars_spec()` + `_parse_key_value_spec()`(콤마·`^@^` 등 구분자 무관 파싱) + `value_check: skip` allowlist 필드 존중. ①③과 `gcloud describe` 콜을 공유하도록 리팩터(서비스당 중복 조회 제거)
- 이번 스코프: backend-dev/prod·frontend-dev/prod만(DRY_RUN 지원 스크립트). realtime-dev(cloudbuild.yaml 단일소스)·mcp-dev/prod(항상 `--set-env-vars` 전체교체라 리스크 낮음)는 후속

## 실측 중 발견한 진짜 드리프트 1건
`frontend-prod`의 `NEXT_PUBLIC_FASTAPI_URL` — 재배포 시 라이브의 project-number 포맷 URL이 hash 포맷으로 바뀜(둘 다 curl 200 확認된 같은 서비스의 유효 별칭 — 기능상 무해하나 표기가 바뀜). allowlist에 근거와 함께 `value_check: skip` 등재

## Test plan
- [x] ② RED→GREEN 뮤테이션 셀프체크(skip 해제→FAIL 확認→복원→GREEN)
- [x] `test_deploy_env.py` 25개 전부 통과(회귀 없음)
- [x] 라이브 실행 — 드리프트 0건(①7개 서비스 키집합·②4개 서비스 값 대조·③11개 서비스 평문시크릿)