### PR TITLE
fix(nav): story #2093 후속 — 스위처 시트가 cross-org 진입 시 다른 org 프로젝트를 목록에 걸던 결함

### DIFF
--- a/apps/web/src/components/nav/context-switcher-chip.test.tsx
+++ b/apps/web/src/components/nav/context-switcher-chip.test.tsx
@@ -49,7 +49,15 @@ beforeEach(() => {
   root = createRoot(container);
   pushMock.mockClear();
   refreshMock.mockClear();
-  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: { ok: true } }) })));
+  // story #2093 후속 — 시트가 열리면 useUnifiedSwitcher가 현재 org도 X-Org-Id로 재조회한다
+  // (JWT 스코프 stale 방지). 이 스위트는 URL org(org-1)=계정 상태 org라 재조회 결과가 그대로
+  // PROJECTS와 같아야 한다 — 아니면 재조회가 목록을 빈 배열로 덮어써 이후 단언이 깨진다.
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (url === '/api/projects') {
+      return { ok: true, json: async () => ({ data: PROJECTS.map((p) => ({ id: p.projectId, name: p.projectName })) }) };
+    }
+    return { ok: true, json: async () => ({ data: { ok: true } }) };
+  }));
 });
 
 afterEach(async () => {

--- a/apps/web/src/components/nav/context-switcher-chip.tsx
+++ b/apps/web/src/components/nav/context-switcher-chip.tsx
@@ -96,7 +96,17 @@ export function ContextSwitcherChip({ orgs, currentOrgId, projects, currentProje
                 <Settings className="h-3.5 w-3.5" />
               </button>
             </div>
-            {projects.map((project) => (
+            {/* story #2093 후속 — s.currentOrgProjects(X-Org-Id로 방금 조회한 정본)를 쓴다.
+                raw projects prop은 서버 /me/memberships가 JWT "현재 org" 클레임 스코프라
+                URL org와 계정 상태 org가 갈리면(cross-org 진입) 다른 org의 프로젝트를
+                이 org 소속인 것처럼 보여줄 수 있다. */}
+            {s.currentOrgLoading && (
+              <div className="flex items-center gap-2 px-4 py-2.5 text-sm text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <span>{tCommon('loading')}</span>
+              </div>
+            )}
+            {s.currentOrgProjects.map((project) => (
               <button
                 key={project.projectId}
                 type="button"

--- a/apps/web/src/components/nav/unified-switcher.tsx
+++ b/apps/web/src/components/nav/unified-switcher.tsx
@@ -104,7 +104,17 @@ export function UnifiedSwitcher({
                 <Settings className="h-3 w-3" />
               </button>
             </div>
-            {projects.map((project) => (
+            {/* story #2093 후속 — s.currentOrgProjects(X-Org-Id로 방금 조회한 정본)를 쓴다.
+                raw projects prop은 서버 /me/memberships가 JWT "현재 org" 클레임 스코프라
+                URL org와 계정 상태 org가 갈리면(cross-org 진입) 다른 org의 프로젝트를
+                이 org 소속인 것처럼 보여줄 수 있다. */}
+            {s.currentOrgLoading && (
+              <div className="flex items-center gap-2 px-5 py-1.5 text-sm text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <span>{tCommon('loading')}</span>
+              </div>
+            )}
+            {s.currentOrgProjects.map((project) => (
               <DropdownMenuItem
                 key={project.projectId}
                 disabled={s.pending}

--- a/apps/web/src/hooks/use-unified-switcher.test.tsx
+++ b/apps/web/src/hooks/use-unified-switcher.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+//
+// story #2093 후속 — 라이브 재현(계정상태=HITL Dogfood, URL=뭉클랩)에서 스위처 시트가
+// "뭉클랩" 헤더 아래 "Dogfood Project"(다른 org 소속)를 그대로 보여주던 결함. 서버 prop
+// `projects`(JWT "현재 org" 클레임 스코프)를 그대로 믿지 않고 X-Org-Id로 현재 org를 다시
+// 조회해 정본으로 교체하는지 RED→GREEN으로 고정한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, useEffect } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useUnifiedSwitcher, type OrgSwitcherItem, type ProjectSwitcherItem } from './use-unified-switcher';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => '/moonklabs/sprintable/board',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+const ORGS: OrgSwitcherItem[] = [
+  { orgId: 'org-moonklabs', orgName: '뭉클랩', orgSlug: 'moonklabs' },
+  { orgId: 'org-dogfood', orgName: 'HITL Dogfood Test', orgSlug: 'hitl-dogfood-test' },
+];
+// 서버 /me/memberships — 계정 상태(JWT "현재 org"=Dogfood)로 스코프된 값. currentOrgId(URL,
+// 뭉클랩)와 갈린다 — 이게 바로 그 stale-scope 결함 재현.
+const STALE_PROJECTS: ProjectSwitcherItem[] = [{ projectId: 'proj-dogfood', projectName: 'Dogfood Project' }];
+const MOONKLABS_PROJECTS = [{ id: 'proj-sprintable', name: 'sprintable' }];
+
+let result: ReturnType<typeof useUnifiedSwitcher> | null = null;
+
+function TestComp() {
+  const hook = useUnifiedSwitcher({ orgs: ORGS, currentOrgId: 'org-moonklabs', projects: STALE_PROJECTS, currentProjectId: undefined });
+  useEffect(() => { result = hook; });
+  return null;
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  result = null;
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe('useUnifiedSwitcher — currentOrgProjects (story #2093 후속)', () => {
+  it('시트가 안 열려 있으면 서버 prop을 그대로 낙관적으로 노출한다(불필요한 fetch 없음)', async () => {
+    vi.stubGlobal('fetch', vi.fn());
+    await act(async () => { root.render(<TestComp />); });
+    expect(result?.currentOrgProjects).toEqual(STALE_PROJECTS);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('시트를 열면 X-Org-Id로 현재 org를 재조회해 stale한 서버 prop을 정본으로 교체한다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (_url: string, init?: RequestInit) => {
+      const orgId = (init?.headers as Record<string, string>)?.['X-Org-Id'];
+      if (orgId === 'org-moonklabs') {
+        return { ok: true, json: async () => ({ data: MOONKLABS_PROJECTS }) };
+      }
+      throw new Error('unexpected org: ' + orgId);
+    }));
+
+    await act(async () => { root.render(<TestComp />); });
+    // stale 값이 즉시 보이는(깜빡임 없음) 것부터 확認.
+    expect(result?.currentOrgProjects).toEqual(STALE_PROJECTS);
+
+    await act(async () => { result?.setOpen(true); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    expect(result?.currentOrgProjects).toEqual([{ projectId: 'proj-sprintable', projectName: 'sprintable' }]);
+    // Dogfood Project(다른 org 소속)가 더 이상 뭉클랩 목록에 안 남아있어야 한다.
+    expect(result?.currentOrgProjects.some((p) => p.projectId === 'proj-dogfood')).toBe(false);
+  });
+
+  it('재조회가 실패하면(네트워크 등) 빈 목록으로 떨어진다 — stale한 다른 org 데이터로 남지 않는다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network down'); }));
+
+    await act(async () => { root.render(<TestComp />); });
+    await act(async () => { result?.setOpen(true); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    expect(result?.currentOrgProjects).toEqual([]);
+  });
+});

--- a/apps/web/src/hooks/use-unified-switcher.ts
+++ b/apps/web/src/hooks/use-unified-switcher.ts
@@ -80,15 +80,29 @@ export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjec
   }, [currentOrgId]);
 
   const currentOrg = orgs.find((o) => o.orgId === localOrgId);
-  const currentProject = projects.find((p) => p.projectId === currentProjectId);
   const otherOrgs = orgs.filter((o) => o.orgId !== localOrgId);
 
   const displayOrg = currentOrg?.orgName ?? 'Organization';
+
+  // story #2093 후속 — `projects`(서버 `/me/memberships`, JWT "현재 org" 클레임 스코프) prop은
+  // localOrgId(=URL 경로 resolve 결과, #2093 이후)와 다른 org를 가리킬 수 있다(cross-org 진입 —
+  // 계정 상태가 stale하거나 초대/딥링크로 다른 org에 들어온 경우). 그 상태에서 `projects`를
+  // 그대로 "현재 조직 섹션"에 그리면 다른 org의 프로젝트가 마치 이 org 소속인 것처럼 보인다
+  // (라이브 재현: 계정상태=HITL Dogfood, URL=뭉클랩일 때 "뭉클랩" 헤더 아래 "Dogfood Project"가
+  // 뜸). "다른 조직"에 이미 있는 X-Org-Id lazy-fetch를 현재 조직에도 똑같이 적용해 스코프
+  // 불일치 자체를 없앤다 — 정본은 항상 방금 그 org로 헤더를 찍어 다시 조회한 응답이다.
+  const currentOrgFetched = localOrgId ? otherOrgProjects[localOrgId] : undefined;
+  const currentOrgLoading = localOrgId ? loadingOrgIds.has(localOrgId) : false;
+  // fetch 전(혹은 org 없음)엔 서버 prop을 낙관적으로 보여준다 — 대부분(같은 org)은 이 값이 곧
+  // fetch 결과와 같아 깜빡임이 없고, 다르면 fetch 완료 즉시 정본으로 교체된다.
+  const currentOrgProjects = currentOrgFetched ?? projects;
+  const currentProject = currentOrgProjects.find((p) => p.projectId === currentProjectId);
   const displayProject = currentProject?.projectName ?? '';
 
   useEffect(() => {
     if (!open) return;
-    for (const org of otherOrgs) {
+    const orgsToFetch = localOrgId ? [{ orgId: localOrgId }, ...otherOrgs] : otherOrgs;
+    for (const org of orgsToFetch) {
       if (otherOrgProjects[org.orgId] !== undefined || loadingOrgIds.has(org.orgId)) continue;
       setLoadingOrgIds((prev) => new Set([...prev, org.orgId]));
       fetch(`/api/projects`, { headers: { 'X-Org-Id': org.orgId } })
@@ -108,7 +122,7 @@ export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjec
         });
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
+  }, [open, localOrgId]);
 
   async function switchOrg(nextOrgId: string) {
     if (!nextOrgId || nextOrgId === localOrgId || pending) return;
@@ -230,6 +244,8 @@ export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjec
     loadingOrgIds,
     currentOrg,
     currentProject,
+    currentOrgProjects,
+    currentOrgLoading: currentOrgLoading && currentOrgFetched === undefined,
     otherOrgs,
     displayOrg,
     displayProject,


### PR DESCRIPTION
## 재현(라이브)
계정 상태(JWT "현재 org"=HITL Dogfood Test)로 stale인 상태에서 URL로 뭉클랩 프로젝트에 직접 진입 → top-bar 칩(#2093 본체가 이미 고침)은 "뭉클랩"을 정확히 그리지만, 칩을 눌러 연 스위처 시트에서 "뭉클랩" 헤더 바로 아래 "Dogfood Project"(다른 org 소속)가 목록에 뜬다.

## 근본원인
서버 `projects` prop(`/me/memberships`, BE가 JWT "현재 org" 클레임으로 스코프)이 URL이 resolve한 org와 다를 수 있는데, 스위처는 그 prop을 "현재 org의 프로젝트 목록"으로 그대로 믿고 렌더했다. 칩 라벨(collapsed)은 옳은데 시트를 펼치면 잘못된 org 밑에 잘못된 프로젝트가 걸려 있는 것으로 드러남 — 칩 라벨 오류보다 나쁜 형태.

## 수정
스위처가 "다른 조직"에 이미 쓰던 X-Org-Id lazy-fetch 패턴을 "현재 조직"에도 동일 적용. 시트가 열리면 현재 org도 다른 org들과 똑같이 재조회해 정본으로 교체 — 서버 prop은 낙관적 표시로만 쓰이고(같은 org인 흔한 경우 깜빡임 없음), 실패 시 빈 배열(다른 org 데이터가 안 남는다). 모바일 시트·사이드바(≥1024) 둘 다 같은 훅 공유라 두 표면 모두 적용.

## 테스트
`use-unified-switcher.test.tsx` 신설, RED→GREEN 확認. 기존 `context-switcher-chip.test.tsx`의 fetch mock 보강(제네릭 mock을 URL 분기로 교체 — 실 코드 결함 아님).

type-check/lint/vitest(1833, 재실행 2회 안정)/build 전부 green.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>