### PR TITLE
fix(gates): story #2091 P0 — 승인 권한 없는 계정에도 승인/반려 버튼이 열려 있던 결함

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3599,6 +3599,7 @@
     "gateReadonlyBlock": "Auto-blocked · read-only",
     "gateReadonlyAuto": "Auto-passed · no action needed",
     "gateReadonlyNoVerdict": "No verdict recorded · nothing to review",
+    "gateReadonlyNotAuthorized": "You don't have permission to approve this gate",
     "mergeGateTitle": "Merge gate",
     "outcomeTrustLabel": "Outcome trust",
     "outcomeSummary": "{hit} hit · {resolved} resolved · last {days}d",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3599,6 +3599,7 @@
     "gateReadonlyBlock": "자동 차단 · 읽기 전용",
     "gateReadonlyAuto": "자동 통과 · 액션 불필요",
     "gateReadonlyNoVerdict": "판정 미거침 · 표시할 액션 없음",
+    "gateReadonlyNotAuthorized": "본인은 이 게이트를 승인할 권한이 없습니다",
     "mergeGateTitle": "머지 게이트",
     "outcomeTrustLabel": "가설 적중",
     "outcomeSummary": "적중 {hit} · 판정 {resolved} · 최근 {days}일",

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+//
+// story #2091(P0) — 오르테가군이 라이브에서 직접 재현: gate.can_approve=false(에이전트 계정,
+// BE per-caller 판정)인데도 화면이 승인/반려 버튼을 열어 클릭 시 서버가 403으로 거부했다.
+// "API가 틀렸나 화면이 틀렸나"의 답은 화면 — needsAction(게이트 자체가 사람 판단이 필요한가)과
+// can_approve(이 caller가 승인 권한이 있는가)를 섞어서 버튼을 열었다. AC②(권한 없는 계정에서
+// 버튼이 안 열리는 것도 반드시 같이 본다 — 한쪽만 보면 "항상 true" 수정도 통과한다)에 따라
+// can_approve=true/false 양쪽 다 고정한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../../../messages/ko.json';
+import type { GateItem } from '@/components/kanban/types';
+
+const { useDashboardContextMock, replaceMock } = vi.hoisted(() => ({
+  useDashboardContextMock: vi.fn(),
+  replaceMock: vi.fn(),
+}));
+
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => useDashboardContextMock(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: replaceMock, push: vi.fn() }),
+  useParams: () => ({ id: 'gate-1' }),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode, Provider: React.ComponentType<{ children: React.ReactNode }>) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      <Provider>{node}</Provider>
+    </NextIntlClientProvider>
+  );
+}
+
+function gate(overrides: Partial<GateItem>): GateItem {
+  return {
+    id: 'gate-1',
+    org_id: 'org-1',
+    work_item_id: 'w-1',
+    work_item_type: 'story',
+    gate_type: 'merge_gate',
+    status: 'pending',
+    resolver_id: null,
+    resolved_at: null,
+    resolution_note: null,
+    neutral_facts: null,
+    requires_human: true,
+    // usesSignatureFlow(riskLevel!=='low')는 'unknown'/'high'에서 GateSignatureApproval(다른
+    // 버튼 라벨·sigApproveAndSign/sigRequestChanges)로 분기한다 — can_approve 게이팅 자체를
+    // 테스트하는 이 스위트는 그 분기 디테일과 무관하므로 'low'로 고정해 단순 버튼 경로를 탄다.
+    risk_grade: 'low',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  useDashboardContextMock.mockReturnValue({ orgMemberships: [], projectMemberships: [] });
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+  replaceMock.mockReset();
+});
+
+async function mount(gateFixture: GateItem) {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (url === '/api/gates/gate-1') return { ok: true, status: 200, json: async () => ({ data: gateFixture }) };
+    return { ok: true, json: async () => ({ data: [] }) };
+  }));
+  const { default: GateDetailPage } = await import('./page');
+  const { TopBarProvider } = await import('@/components/nav/top-bar-context');
+  await act(async () => { root.render(wrap(<GateDetailPage />, TopBarProvider)); });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('GateDetailPage — can_approve 게이팅 (story #2091)', () => {
+  it('can_approve=true면 승인/반려 버튼이 렌더된다', async () => {
+    await mount(gate({ can_approve: true }));
+    const buttons = [...container.querySelectorAll('button')].map((b) => b.textContent);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.gateApprove))).toBe(true);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.gateReject))).toBe(true);
+  });
+
+  it('can_approve=false면(에이전트 계정 등) 승인/반려 버튼이 렌더되지 않고 권한없음 문구가 뜬다', async () => {
+    await mount(gate({ can_approve: false }));
+    const buttons = [...container.querySelectorAll('button')].map((b) => b.textContent);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.gateApprove))).toBe(false);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.gateReject))).toBe(false);
+    expect(container.textContent).toContain(koMessages.cage.gateReadonlyNotAuthorized);
+  });
+
+  it('can_approve가 응답에 없으면(구버전/누락) undefined→false로 안전하게 폴백해 버튼을 안 연다(fail-closed)', async () => {
+    const g = gate({});
+    delete (g as { can_approve?: boolean }).can_approve;
+    await mount(g);
+    const buttons = [...container.querySelectorAll('button')].map((b) => b.textContent);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.gateApprove))).toBe(false);
+  });
+
+  it('needsAction 자체가 false(예: block 판정)면 can_approve=true여도 버튼이 없다(게이트가 액션을 요구하지 않음)', async () => {
+    await mount(gate({ can_approve: true, auto_decision_reason: 'block' }));
+    const buttons = [...container.querySelectorAll('button')].map((b) => b.textContent);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.gateApprove))).toBe(false);
+  });
+});

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -88,6 +88,16 @@ export default function GateDetailPage() {
   const isDocGate = gate?.work_item_type === 'doc' || gate?.gate_type === 'doc_approval';
   const isCanonicalizeGate = gate?.gate_type === 'artifact_canonicalize';
   const needsAction = !!gate && gate.status === 'pending' && (gateNeedsAction(gate) || isDocGate || isCanonicalizeGate);
+  // story #2091(P0) — needsAction은 "이 게이트가 사람의 판단을 필요로 하는가"만 답한다(gate 자체의
+  // 속성). "이 화면을 보는 나(caller)에게 승인 권한이 있는가"는 별개 질문인데 여태 이 둘을 섞어서
+  // needsAction=true이면 무조건 버튼을 열었다 — 오르테가군이 라이브에서 직접 재현(까심군이 잡은
+  // can_approve:false ↔ 버튼 노출 불일치의 근본): 에이전트 계정이 이 화면에 들어오면 BE는
+  // `POST .../transition`을 403으로 정확히 거부하는데(휴먼 전용, rule A) 화면은 버튼을 계속
+  // 보여줬다 — "눌렀는데 실패"가 아니라 "내가 승인할 수 있다고 믿게 되는" 더 나쁜 형태(유나양
+  // §1-1). 서버가 준 gate.can_approve(BE per-caller 판정)를 근거로만 버튼을 열고 닫는다 — 화면이
+  // 독자 판정으로 서버를 덮지 않는다(AC2). needsAction=true인데 can_approve=false면(권한 없는
+  // 뷰어) 아래에서 읽기전용 사유 문구로 분기한다(무권한 상태에서 액션 버튼 자체를 렌더하지 않음).
+  const canAct = needsAction && gate?.can_approve === true;
 
   const transition = useCallback(async (status: 'approved' | 'rejected', note?: string) => {
     if (!gate) return;
@@ -181,6 +191,15 @@ export default function GateDetailPage() {
                     : gateDecision(gate) === 'auto_merge' ? t('gateReadonlyAuto')
                     : t('gateReadonlyNoVerdict')}
                 </p>
+              </div>
+            ) : !canAct ? (
+              // story #2091(P0) — needsAction=true(게이트 자체는 사람 판단이 필요)이지만
+              // gate.can_approve=false(이 caller는 승인 권한 없음, BE per-caller 판정). 액션
+              // 버튼을 렌더하지 않고 왜 못 누르는지를 정직하게 알린다 — "이미 처리됨"과는
+              // 다른 사유이므로 별개 문구(gateReadonlyNotAuthorized)를 쓴다.
+              <div className="space-y-3">
+                <GateEvidence gate={gate} />
+                <p className="text-[11px] text-muted-foreground">{t('gateReadonlyNotAuthorized')}</p>
               </div>
             ) : usesSignatureFlow(deriveRiskLevel(gate)) ? (
               <GateSignatureApproval


### PR DESCRIPTION
## 근본원인(오르테가군 라이브 재현으로 확定)
`needsAction`(게이트 자체가 사람 판단을 필요로 하는가)과 `can_approve`(이 caller가 승인 권한이 있는가)를 섞어서, needsAction=true면 무조건 버튼을 열었다. 에이전트 계정이 게이트 상세에 들어가면 BE는 `POST .../transition`을 403으로 정확히 거부하는데(휴먼 전용) 화면은 계속 승인/반려 버튼을 보여줬다.

## 수정(AC2)
`canAct = needsAction && gate.can_approve === true`. `gate.can_approve`는 BE per-caller 판정을 이미 동봉하고 있었다(`doc-gate-section.tsx`가 이미 올바르게 쓰던 패턴) — 이 상세 페이지만 안 보고 있었다. 권한 없는 뷰어는 버튼 대신 읽기전용 사유 문구로 분기한다.

## 테스트(AC4 — 양방향)
`page.test.tsx` 4케이스: can_approve=true→버튼 노출 / false→버튼 없음+사유문구 / 필드 누락→fail-closed / needsAction=false면 can_approve=true여도 버튼 없음. RED→GREEN 확認.

AC5(API 직접 호출 시 서버 거부)는 오르테가군이 이미 403으로 실증 완료.

## 별건 발견 — 스코프 안 넣음
`approvals-queue.tsx`의 HITL 인라인 버튼도 같은 클래스로 보이나 `HitlInboxItem`엔 can_approve 동급 필드가 없어 여기서 같이 못 고쳤다. 별도 보고.

type-check/lint/vitest(1837)/build 전부 green.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>