### PR TITLE
fix(inbox): story #2103 P0 — HITL 인라인 승인/반려 버튼이 에이전트 계정에도 열려 있던 결함

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3599,6 +3599,7 @@
     "gateReadonlyBlock": "Auto-blocked · read-only",
     "gateReadonlyAuto": "Auto-passed · no action needed",
     "gateReadonlyNoVerdict": "No verdict recorded · nothing to review",
+    "gateReadonlyNotAuthorized": "You don't have permission to approve this gate",
     "mergeGateTitle": "Merge gate",
     "outcomeTrustLabel": "Outcome trust",
     "outcomeSummary": "{hit} hit · {resolved} resolved · last {days}d",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3599,6 +3599,7 @@
     "gateReadonlyBlock": "자동 차단 · 읽기 전용",
     "gateReadonlyAuto": "자동 통과 · 액션 불필요",
     "gateReadonlyNoVerdict": "판정 미거침 · 표시할 액션 없음",
+    "gateReadonlyNotAuthorized": "본인은 이 게이트를 승인할 권한이 없습니다",
     "mergeGateTitle": "머지 게이트",
     "outcomeTrustLabel": "가설 적중",
     "outcomeSummary": "적중 {hit} · 판정 {resolved} · 최근 {days}일",

--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -12,6 +12,12 @@ interface MemberContext {
   project_name: string;
   name: string;
   role?: string;
+  // story #2103 — BE가 여러 write action(게이트/HITL 승인·거부, 각종 삭제)을 "휴먼 멤버만
+  // 가능"으로 명시적으로 403 거부한다. FE가 이 판정을 미리 반영하지 않고 버튼을 무조건
+  // 노출한 자리(HITL 인라인 승인/반려, approvals-queue.tsx)가 #2091(게이트 상세)과 같은
+  // 버그클래스로 확인됐다 — 계정의 human/agent 여부를 앱 전역에서 재사용 가능하게
+  // DashboardContext로 흘려보낸다(신규 fetch 0, 이미 매 요청 fetch하던 /api/v2/me 재사용).
+  type?: 'human' | 'agent';
 }
 
 interface OrgMembership {
@@ -116,6 +122,7 @@ export default async function AuthenticatedLayout({
       currentProjectSlug={currentProjectSlug}
       userName={me?.name}
       role={me?.role}
+      currentMemberType={me?.type}
       projectMemberships={projectMemberships}
       orgMemberships={orgMemberships}
       pathOrgId={pathOrgId}

--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -41,6 +41,10 @@ interface DashboardContext {
   currentProjectSlug?: string;
   userName?: string;
   role?: string;
+  // story #2103 — BE가 여러 write action을 "휴먼 멤버만 가능"으로 명시 거부한다(게이트/HITL
+  // 승인·거부, 각종 삭제 등). URL과 무관한 순수 계정 속성이라 #2093의 pathOrgId류와 달리
+  // 별도 override가 필요 없다 — 항상 서버 me.type 그대로.
+  currentMemberType?: 'human' | 'agent';
   projectMemberships: DashboardProjectOption[];
   orgMemberships: OrgSwitcherItem[];
 }
@@ -203,6 +207,7 @@ export function DashboardShell({
   currentProjectSlug,
   userName,
   role,
+  currentMemberType,
   projectMemberships,
   orgMemberships,
   pathOrgId,
@@ -231,7 +236,7 @@ export function DashboardShell({
   const chatUnreadTotal = useChatUnreadTotal(currentTeamMemberId);
 
   return (
-    <DashboardCtx.Provider value={{ currentTeamMemberId, orgId: effectiveOrgId, projectId: effectiveProjectId, projectName: effectiveProjectName, currentProjectSlug, userName, role, projectMemberships, orgMemberships }}>
+    <DashboardCtx.Provider value={{ currentTeamMemberId, orgId: effectiveOrgId, projectId: effectiveProjectId, projectName: effectiveProjectName, currentProjectSlug, userName, role, currentMemberType, projectMemberships, orgMemberships }}>
       <RefreshProvider>
       <RealtimeProvider currentTeamMemberId={currentTeamMemberId}>
         <TopBarProvider>

--- a/apps/web/src/components/inbox/approvals-queue.test.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.test.tsx
@@ -79,9 +79,12 @@ beforeEach(() => {
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
+  // story #2103 — 기본값은 human(기존 스위트 전부가 "승인/반려 버튼이 보인다"를 전제하므로).
+  // agent 게이팅 자체를 검증하는 케이스만 개별로 override한다.
   useDashboardContextMock.mockReturnValue({
     orgMemberships: [{ orgId: 'org-1', orgName: '뭉클랩' }],
     projectMemberships: [],
+    currentMemberType: 'human',
   });
 });
 
@@ -236,5 +239,42 @@ describe('ApprovalsQueue', () => {
     await act(async () => { gateButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     expect(pushMock).toHaveBeenCalledWith('/gates/g-mixed');
     expect(pushMock).not.toHaveBeenCalledWith(expect.stringContaining('h-mixed'));
+  });
+
+  // story #2103(P0) — BE `PATCH /api/v1/hitl-requests/{id}`가 human-only 불변식(hitl.py:131,
+  // "gates.py transition_gate_endpoint와 같은"). #2091(게이트 상세)과 같은 버그클래스: 이 큐가
+  // 그 판정을 미리 안 보고 에이전트 계정에도 승인/반려 버튼을 무조건 열었다. 양방향(human→노출·
+  // agent→비노출+사유문구) 다 고정한다 — 한쪽만 보면 "항상 노출" 회귀도 통과한다.
+  it('agent 계정이면 hitl 승인/반려 버튼이 안 뜨고 권한없음 문구가 뜬다', async () => {
+    useDashboardContextMock.mockReturnValue({
+      orgMemberships: [{ orgId: 'org-1', orgName: '뭉클랩' }],
+      projectMemberships: [],
+      currentMemberType: 'agent',
+    });
+    mockFetches([hitl({ id: 'h-agent', title: 'agent가 보는 승인요청' })], []);
+    await mount();
+    const buttons = [...container.querySelectorAll('button')].map((b) => b.textContent);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.gateApprove))).toBe(false);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.gateReject))).toBe(false);
+    expect(container.textContent).toContain(koMessages.cage.gateReadonlyNotAuthorized);
+  });
+
+  it('currentMemberType이 응답에 없으면(구버전/누락) undefined→false로 안전하게 폴백해 버튼을 안 연다(fail-closed)', async () => {
+    useDashboardContextMock.mockReturnValue({
+      orgMemberships: [{ orgId: 'org-1', orgName: '뭉클랩' }],
+      projectMemberships: [],
+    });
+    mockFetches([hitl({ id: 'h-unknown' })], []);
+    await mount();
+    const buttons = [...container.querySelectorAll('button')].map((b) => b.textContent);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.gateApprove))).toBe(false);
+  });
+
+  it('human 계정이면 hitl 승인/반려 버튼이 뜬다(회귀 확認)', async () => {
+    mockFetches([hitl({ id: 'h-human' })], []);
+    await mount();
+    const buttons = [...container.querySelectorAll('button')].map((b) => b.textContent);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.gateApprove))).toBe(true);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.gateReject))).toBe(true);
   });
 });

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -58,7 +58,13 @@ function formatAge(createdAt: string, t: ReturnType<typeof useTranslations>): st
 export function ApprovalsQueue() {
   const t = useTranslations('cage');
   const router = useRouter();
-  const { orgMemberships } = useDashboardContext();
+  // story #2103 — BE `PATCH /api/v1/hitl-requests/{id}`가 human-only 불변식이다(gates.py
+  // transition_gate_endpoint와 동형, resolved.type != "human" → 403). #2091(게이트 상세)과
+  // 같은 버그클래스: 이 큐는 그 판정을 미리 안 보고 에이전트 계정에도 승인/반려 버튼을
+  // 무조건 열었다. Gate와 달리 HitlInboxItem엔 per-item can_approve 필드가 없어(BE 응답
+  // shape 차이) 계정 자체의 type(human/agent, DashboardContext #2103 신규)으로 게이팅한다.
+  const { orgMemberships, currentMemberType } = useDashboardContext();
+  const canResolveHitl = currentMemberType === 'human';
   const [items, setItems] = useState<GateInboxItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [resolving, setResolving] = useState<string | null>(null);
@@ -112,28 +118,32 @@ export function ApprovalsQueue() {
               </div>
               <p className="text-sm text-foreground">{item.title}</p>
               <p className="line-clamp-2 text-[11px] text-muted-foreground">{item.prompt}</p>
-              <div className="mt-1 flex justify-end gap-1.5">
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-7 gap-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-                  disabled={resolving === item.id}
-                  onClick={() => void resolveHitl(item.id, 'rejected')}
-                >
-                  <XCircle className="size-3.5" />
-                  {t('gateReject')}
-                </Button>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-7 gap-1 text-success hover:bg-success-tint hover:text-success"
-                  disabled={resolving === item.id}
-                  onClick={() => void resolveHitl(item.id, 'approved')}
-                >
-                  <CheckCircle className="size-3.5" />
-                  {t('gateApprove')}
-                </Button>
-              </div>
+              {canResolveHitl ? (
+                <div className="mt-1 flex justify-end gap-1.5">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 gap-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                    disabled={resolving === item.id}
+                    onClick={() => void resolveHitl(item.id, 'rejected')}
+                  >
+                    <XCircle className="size-3.5" />
+                    {t('gateReject')}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 gap-1 text-success hover:bg-success-tint hover:text-success"
+                    disabled={resolving === item.id}
+                    onClick={() => void resolveHitl(item.id, 'approved')}
+                  >
+                    <CheckCircle className="size-3.5" />
+                    {t('gateApprove')}
+                  </Button>
+                </div>
+              ) : (
+                <p className="mt-1 text-right text-[11px] text-muted-foreground">{t('gateReadonlyNotAuthorized')}</p>
+              )}
             </div>
           );
         }


### PR DESCRIPTION
## 근본원인
#2091(게이트 상세)과 같은 버그클래스. BE `PATCH /api/v1/hitl-requests/{id}`가 human-only 불변식이다(hitl.py:131). 결재함 큐의 HITL 인라인 승인/반려 버튼이 이 판정을 미리 안 보고 무조건 노출했다.

Gate와 달리 HitlInboxItem엔 per-item can_approve 필드가 없어(BE 응답 shape 차이) 계정 자체의 human/agent 여부로 게이팅한다. `/api/v2/me`가 이미 `type` 필드를 반환하는데(`loops/[id]/loop-detail-client.tsx`가 이미 같은 패턴을 올바르게 씀) layout이 여태 DashboardContext로 안 흘려보내고 있었다 — 신규 fetch 0, `currentMemberType`으로 앱 전역 재사용 가능하게 노출.

## 수정
`canResolveHitl = currentMemberType === 'human'`. false면 버튼 대신 사유 문구(#2091이 만든 `gateReadonlyNotAuthorized` 재사용).

## 테스트
3케이스 추가(human→노출·agent→비노출+문구·필드누락→fail-closed), 기존 13케이스 mock에 `currentMemberType: 'human'` 명시. RED→GREEN 확認.

type-check/lint/vitest(1836)/build 전부 green.

## AC5 전수 훑기 — 별도 발견 4건, 스코프 안 넣음
```
docs/[slug]/page.tsx:380-382       Doc 삭제 — BE docs.py:471 human-only
goals/goals-client.tsx:584,932-937 Goal 삭제 — BE goals.py:352 human-only
sprints/sprints-client.tsx:565     Sprint 삭제 — BE sprints.py:351 human-only
retro/[id]/page.tsx:291            다음가설 채택 — BE retros.py:373 human-only
```
`loops/[id]/loop-detail-client.tsx`가 이미 올바른 참조 패턴을 갖고 있어 같은 방식으로 고칠 수 있어 보인다. 미확인 5건(meeting/task/project 삭제·story 삭제·goal decision transition)도 있음. 스코프 판단 필요.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>