### PR TITLE
fix(destructive-actions): story #2104 P0 — 파괴적/결정 조작 6곳이 에이전트 계정에도 열려 있던 결함

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3599,6 +3599,7 @@
     "gateReadonlyBlock": "Auto-blocked · read-only",
     "gateReadonlyAuto": "Auto-passed · no action needed",
     "gateReadonlyNoVerdict": "No verdict recorded · nothing to review",
+    "gateReadonlyNotAuthorized": "You don't have permission to approve this gate",
     "mergeGateTitle": "Merge gate",
     "outcomeTrustLabel": "Outcome trust",
     "outcomeSummary": "{hit} hit · {resolved} resolved · last {days}d",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3599,6 +3599,7 @@
     "gateReadonlyBlock": "자동 차단 · 읽기 전용",
     "gateReadonlyAuto": "자동 통과 · 액션 불필요",
     "gateReadonlyNoVerdict": "판정 미거침 · 표시할 액션 없음",
+    "gateReadonlyNotAuthorized": "본인은 이 게이트를 승인할 권한이 없습니다",
     "mergeGateTitle": "머지 게이트",
     "outcomeTrustLabel": "가설 적중",
     "outcomeSummary": "적중 {hit} · 판정 {resolved} · 최근 {days}일",

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/page.tsx
@@ -26,6 +26,7 @@ import { useDocsLayout } from '../docs-context';
 import { DocAssigneeControl } from '@/components/docs/doc-assignee-control';
 import { DocBreadcrumb } from '@/components/docs/doc-breadcrumb';
 import { useSyntheticParentTabHistory } from '@/hooks/use-synthetic-parent-tab-history';
+import { HumanOnlyAction } from '@/components/ui/human-only-action';
 
 interface DocDetail {
   id: string;
@@ -377,10 +378,16 @@ export default function DocSlugPage() {
                 {t('editUrl')}
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={handleDelete} className="text-destructive focus:text-destructive">
-                <Trash2 className="mr-2 h-4 w-4" />
-                {t('deleteDoc')}
-              </DropdownMenuItem>
+              {/* story #2104 — BE docs.py:471이 human-only로 삭제를 403 거부한다(delete는 사람만
+                  가능, 되돌릴 수 없는 조작). 에이전트 계정에도 이 항목을 열어두면 "내가 지울 수
+                  있다"고 믿게 만드는 #2091/#2103과 같은 결함이라 미리 숨긴다(메뉴 공간 제약상
+                  사유 문구 대신 항목 자체를 생략 — edit-url 등 남은 항목은 그대로 유지). */}
+              <HumanOnlyAction>
+                <DropdownMenuItem onClick={handleDelete} className="text-destructive focus:text-destructive">
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  {t('deleteDoc')}
+                </DropdownMenuItem>
+              </HumanOnlyAction>
             </>
           )}
         </DropdownMenuContent>

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.test.tsx
@@ -24,6 +24,14 @@ vi.mock('@/components/nav/top-bar-slot', () => ({
   ),
 }));
 
+// story #2104 — HumanOnlyAction(에픽 삭제 트리거를 감싼다)이 useDashboardContext를 읽는다.
+// 기본은 human(기존 스위트가 전부 "리스트가 정상 렌더된다"만 확認하므로 무관). agent 게이팅
+// 자체를 보는 케이스만 개별 override.
+const { useDashboardContextMock } = vi.hoisted(() => ({ useDashboardContextMock: vi.fn() }));
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => useDashboardContextMock(),
+}));
+
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 let container: HTMLDivElement;
@@ -50,6 +58,7 @@ beforeEach(() => {
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
+  useDashboardContextMock.mockReturnValue({ currentMemberType: 'human' });
 });
 
 afterEach(async () => {
@@ -97,5 +106,21 @@ describe('GoalsClient — 목표 first-touch 정체성', () => {
     const html = container.innerHTML;
     expect(html).toContain('E-CANVAS');
     expect(html).not.toContain('아직 목표가 없어요');
+  });
+
+  // story #2104 — BE goals.py:352(human-only 삭제 403)를 FE가 미리 안 보고 에이전트 계정에도
+  // 삭제 트리거를 무조건 열었다(#2091/#2103과 같은 결함). 양방향 고정 — human까지 잠그면
+  // 정당한 삭제가 봉쇄되는 더 큰 사고다.
+  it('human이면 에픽 삭제 트리거가 렌더된다(정당한 사용자는 막히면 안 됨)', async () => {
+    stubFetch([{ id: 'e1', title: 'E-CANVAS', status: 'active', story_count: 3, is_ai_generated: false }]);
+    await mount();
+    expect(container.querySelector('button[aria-label="목표 삭제"]')).not.toBeNull();
+  });
+
+  it('agent면 에픽 삭제 트리거가 안 뜬다', async () => {
+    useDashboardContextMock.mockReturnValue({ currentMemberType: 'agent' });
+    stubFetch([{ id: 'e1', title: 'E-CANVAS', status: 'active', story_count: 3, is_ai_generated: false }]);
+    await mount();
+    expect(container.querySelector('button[aria-label="목표 삭제"]')).toBeNull();
   });
 });

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
@@ -39,6 +39,7 @@ import { EpicHypothesisDeclarationSection } from '@/components/epics/hypothesis-
 import type { HypothesisDeclarationValue } from '@/services/hypothesis-declaration';
 import { toEpicHypothesisCreatePayload, toEpicHypothesisLink } from '@/services/hypothesis-declaration-epic';
 import { SteerDispatchModal } from './steer-dispatch-modal';
+import { HumanOnlyAction } from '@/components/ui/human-only-action';
 
 // ─── Drag sensor ──────────────────────────────────────────────────────────────
 
@@ -582,14 +583,19 @@ function GoalRow({ epic, isSelected, onClick, onDeleteRequest, sortable }: GoalR
             ) : null}
             <Badge variant={statusBadgeVariant(epic.status)}>{statusLabel[epic.status]}</Badge>
             <Badge variant={priorityBadgeVariant(epic.priority)}>{priorityLabel[epic.priority]}</Badge>
-            <button
-              type="button"
-              aria-label={t('deleteGoal')}
-              onClick={(e) => { e.stopPropagation(); onDeleteRequest(epic.id); }}
-              className="hidden group-hover:flex items-center justify-center rounded-md p-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-            </button>
+            {/* story #2104 — BE goals.py:352가 human-only로 삭제를 403 거부한다(되돌릴 수 없는
+                조작). 에이전트 계정에도 트리거를 열어두면 #2091/#2103과 같은 결함이라 미리
+                숨긴다. */}
+            <HumanOnlyAction>
+              <button
+                type="button"
+                aria-label={t('deleteGoal')}
+                onClick={(e) => { e.stopPropagation(); onDeleteRequest(epic.id); }}
+                className="hidden group-hover:flex items-center justify-center rounded-md p-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            </HumanOnlyAction>
           </div>
         </div>
 

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx
@@ -35,6 +35,7 @@ import {
 import { HypothesisDeclarationSection } from '@/components/sprints/hypothesis-declaration-section';
 import { OpenLoopCockpit } from '@/components/sprints/open-loop-cockpit';
 import type { RetroHypothesisResult } from '@/services/retro-session';
+import { HumanOnlyAction } from '@/components/ui/human-only-action';
 
 // 8a2bbda2: 기간 표시는 start_date~end_date(진실)에서 계산한다. BE `duration` 필드(예 14)가
 // 날짜 범위와 불일치하는 케이스가 있어 신뢰하지 않고, inclusive 일수(end−start+1)를 직접 산출한다.
@@ -694,16 +695,21 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
           <Badge variant={statusVariant(selected.status)} className="mt-1">{selected.status}</Badge>
         </div>
         <div className="flex shrink-0 items-center gap-1">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => { setDeleteError(null); setShowDeleteConfirm(true); }}
-            aria-label={t('delete')}
-            title={t('delete')}
-            className="text-muted-foreground hover:text-destructive"
-          >
-            <Trash2 className="size-4" />
-          </Button>
+          {/* story #2104 — BE sprints.py:351이 human-only로 삭제를 403 거부한다(되돌릴 수 없는
+              조작). 에이전트 계정에도 트리거를 열어두면 #2091/#2103과 같은 결함이라 미리
+              숨긴다. */}
+          <HumanOnlyAction>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => { setDeleteError(null); setShowDeleteConfirm(true); }}
+              aria-label={t('delete')}
+              title={t('delete')}
+              className="text-muted-foreground hover:text-destructive"
+            >
+              <Trash2 className="size-4" />
+            </Button>
+          </HumanOnlyAction>
           <Button variant="ghost" size="sm" onClick={() => setSelected(null)} aria-label={t('cancel')}>
             <X className="size-4" />
           </Button>

--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -12,6 +12,12 @@ interface MemberContext {
   project_name: string;
   name: string;
   role?: string;
+  // story #2103 — BE가 여러 write action(게이트/HITL 승인·거부, 각종 삭제)을 "휴먼 멤버만
+  // 가능"으로 명시적으로 403 거부한다. FE가 이 판정을 미리 반영하지 않고 버튼을 무조건
+  // 노출한 자리(HITL 인라인 승인/반려, approvals-queue.tsx)가 #2091(게이트 상세)과 같은
+  // 버그클래스로 확인됐다 — 계정의 human/agent 여부를 앱 전역에서 재사용 가능하게
+  // DashboardContext로 흘려보낸다(신규 fetch 0, 이미 매 요청 fetch하던 /api/v2/me 재사용).
+  type?: 'human' | 'agent';
 }
 
 interface OrgMembership {
@@ -116,6 +122,7 @@ export default async function AuthenticatedLayout({
       currentProjectSlug={currentProjectSlug}
       userName={me?.name}
       role={me?.role}
+      currentMemberType={me?.type}
       projectMemberships={projectMemberships}
       orgMemberships={orgMemberships}
       pathOrgId={pathOrgId}

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -37,6 +37,7 @@ import { SidebarTrigger } from '@/components/ui/sidebar';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { NOTIFICATION_TYPES } from '@/lib/notification-types';
 import { isEEEnabled } from '@/lib/ee';
+import { HumanOnlyAction } from '@/components/ui/human-only-action';
 import dynamic from 'next/dynamic';
 
 // TypeScript 정적 해석을 위해 unconditional import — 조건부 렌더링은 JSX isEEEnabled() 체크로 처리
@@ -1036,15 +1037,23 @@ export default function SettingsPage() {
                                     >
                                       {tc('edit')}
                                     </Button>
-                                    <Button
-                                      variant="ghost"
-                                      size="sm"
-                                      className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-                                      onClick={() => setDeleteProjectConfirmId(project.id)}
-                                      disabled={deletingProjectId === project.id}
-                                    >
-                                      {deletingProjectId === project.id ? '...' : t('deleteProject')}
-                                    </Button>
+                                    {/* story #2104 — BE projects.py:213이 human-only로 삭제를
+                                        403 거부한다(되돌릴 수 없는 조작). 이 버튼은 이미
+                                        isAdmin(org owner/admin)으로 감싸져 있으나, 에이전트도
+                                        구조상 owner/admin 권한을 가질 수 있어 human 여부는
+                                        별도 확認이 필요하다(#2091/#2103과 같은 결함). edit
+                                        버튼은 BE에 human-only 가드가 없어 그대로 둔다. */}
+                                    <HumanOnlyAction>
+                                      <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                                        onClick={() => setDeleteProjectConfirmId(project.id)}
+                                        disabled={deletingProjectId === project.id}
+                                      >
+                                        {deletingProjectId === project.id ? '...' : t('deleteProject')}
+                                      </Button>
+                                    </HumanOnlyAction>
                                   </>
                                 ) : null}
                               </div>

--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -41,6 +41,10 @@ interface DashboardContext {
   currentProjectSlug?: string;
   userName?: string;
   role?: string;
+  // story #2103 — BE가 여러 write action을 "휴먼 멤버만 가능"으로 명시 거부한다(게이트/HITL
+  // 승인·거부, 각종 삭제 등). URL과 무관한 순수 계정 속성이라 #2093의 pathOrgId류와 달리
+  // 별도 override가 필요 없다 — 항상 서버 me.type 그대로.
+  currentMemberType?: 'human' | 'agent';
   projectMemberships: DashboardProjectOption[];
   orgMemberships: OrgSwitcherItem[];
 }
@@ -203,6 +207,7 @@ export function DashboardShell({
   currentProjectSlug,
   userName,
   role,
+  currentMemberType,
   projectMemberships,
   orgMemberships,
   pathOrgId,
@@ -231,7 +236,7 @@ export function DashboardShell({
   const chatUnreadTotal = useChatUnreadTotal(currentTeamMemberId);
 
   return (
-    <DashboardCtx.Provider value={{ currentTeamMemberId, orgId: effectiveOrgId, projectId: effectiveProjectId, projectName: effectiveProjectName, currentProjectSlug, userName, role, projectMemberships, orgMemberships }}>
+    <DashboardCtx.Provider value={{ currentTeamMemberId, orgId: effectiveOrgId, projectId: effectiveProjectId, projectName: effectiveProjectName, currentProjectSlug, userName, role, currentMemberType, projectMemberships, orgMemberships }}>
       <RefreshProvider>
       <RealtimeProvider currentTeamMemberId={currentTeamMemberId}>
         <TopBarProvider>

--- a/apps/web/src/components/inbox/approvals-queue.test.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.test.tsx
@@ -79,9 +79,12 @@ beforeEach(() => {
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
+  // story #2103 — 기본값은 human(기존 스위트 전부가 "승인/반려 버튼이 보인다"를 전제하므로).
+  // agent 게이팅 자체를 검증하는 케이스만 개별로 override한다.
   useDashboardContextMock.mockReturnValue({
     orgMemberships: [{ orgId: 'org-1', orgName: '뭉클랩' }],
     projectMemberships: [],
+    currentMemberType: 'human',
   });
 });
 
@@ -236,5 +239,42 @@ describe('ApprovalsQueue', () => {
     await act(async () => { gateButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     expect(pushMock).toHaveBeenCalledWith('/gates/g-mixed');
     expect(pushMock).not.toHaveBeenCalledWith(expect.stringContaining('h-mixed'));
+  });
+
+  // story #2103(P0) — BE `PATCH /api/v1/hitl-requests/{id}`가 human-only 불변식(hitl.py:131,
+  // "gates.py transition_gate_endpoint와 같은"). #2091(게이트 상세)과 같은 버그클래스: 이 큐가
+  // 그 판정을 미리 안 보고 에이전트 계정에도 승인/반려 버튼을 무조건 열었다. 양방향(human→노출·
+  // agent→비노출+사유문구) 다 고정한다 — 한쪽만 보면 "항상 노출" 회귀도 통과한다.
+  it('agent 계정이면 hitl 승인/반려 버튼이 안 뜨고 권한없음 문구가 뜬다', async () => {
+    useDashboardContextMock.mockReturnValue({
+      orgMemberships: [{ orgId: 'org-1', orgName: '뭉클랩' }],
+      projectMemberships: [],
+      currentMemberType: 'agent',
+    });
+    mockFetches([hitl({ id: 'h-agent', title: 'agent가 보는 승인요청' })], []);
+    await mount();
+    const buttons = [...container.querySelectorAll('button')].map((b) => b.textContent);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.gateApprove))).toBe(false);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.gateReject))).toBe(false);
+    expect(container.textContent).toContain(koMessages.cage.gateReadonlyNotAuthorized);
+  });
+
+  it('currentMemberType이 응답에 없으면(구버전/누락) undefined→false로 안전하게 폴백해 버튼을 안 연다(fail-closed)', async () => {
+    useDashboardContextMock.mockReturnValue({
+      orgMemberships: [{ orgId: 'org-1', orgName: '뭉클랩' }],
+      projectMemberships: [],
+    });
+    mockFetches([hitl({ id: 'h-unknown' })], []);
+    await mount();
+    const buttons = [...container.querySelectorAll('button')].map((b) => b.textContent);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.gateApprove))).toBe(false);
+  });
+
+  it('human 계정이면 hitl 승인/반려 버튼이 뜬다(회귀 확認)', async () => {
+    mockFetches([hitl({ id: 'h-human' })], []);
+    await mount();
+    const buttons = [...container.querySelectorAll('button')].map((b) => b.textContent);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.gateApprove))).toBe(true);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.gateReject))).toBe(true);
   });
 });

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -58,7 +58,13 @@ function formatAge(createdAt: string, t: ReturnType<typeof useTranslations>): st
 export function ApprovalsQueue() {
   const t = useTranslations('cage');
   const router = useRouter();
-  const { orgMemberships } = useDashboardContext();
+  // story #2103 — BE `PATCH /api/v1/hitl-requests/{id}`가 human-only 불변식이다(gates.py
+  // transition_gate_endpoint와 동형, resolved.type != "human" → 403). #2091(게이트 상세)과
+  // 같은 버그클래스: 이 큐는 그 판정을 미리 안 보고 에이전트 계정에도 승인/반려 버튼을
+  // 무조건 열었다. Gate와 달리 HitlInboxItem엔 per-item can_approve 필드가 없어(BE 응답
+  // shape 차이) 계정 자체의 type(human/agent, DashboardContext #2103 신규)으로 게이팅한다.
+  const { orgMemberships, currentMemberType } = useDashboardContext();
+  const canResolveHitl = currentMemberType === 'human';
   const [items, setItems] = useState<GateInboxItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [resolving, setResolving] = useState<string | null>(null);
@@ -112,28 +118,32 @@ export function ApprovalsQueue() {
               </div>
               <p className="text-sm text-foreground">{item.title}</p>
               <p className="line-clamp-2 text-[11px] text-muted-foreground">{item.prompt}</p>
-              <div className="mt-1 flex justify-end gap-1.5">
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-7 gap-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-                  disabled={resolving === item.id}
-                  onClick={() => void resolveHitl(item.id, 'rejected')}
-                >
-                  <XCircle className="size-3.5" />
-                  {t('gateReject')}
-                </Button>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-7 gap-1 text-success hover:bg-success-tint hover:text-success"
-                  disabled={resolving === item.id}
-                  onClick={() => void resolveHitl(item.id, 'approved')}
-                >
-                  <CheckCircle className="size-3.5" />
-                  {t('gateApprove')}
-                </Button>
-              </div>
+              {canResolveHitl ? (
+                <div className="mt-1 flex justify-end gap-1.5">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 gap-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                    disabled={resolving === item.id}
+                    onClick={() => void resolveHitl(item.id, 'rejected')}
+                  >
+                    <XCircle className="size-3.5" />
+                    {t('gateReject')}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 gap-1 text-success hover:bg-success-tint hover:text-success"
+                    disabled={resolving === item.id}
+                    onClick={() => void resolveHitl(item.id, 'approved')}
+                  >
+                    <CheckCircle className="size-3.5" />
+                    {t('gateApprove')}
+                  </Button>
+                </div>
+              ) : (
+                <p className="mt-1 text-right text-[11px] text-muted-foreground">{t('gateReadonlyNotAuthorized')}</p>
+              )}
             </div>
           );
         }

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -38,6 +38,7 @@ import {
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { useSyntheticParentTabHistory } from '@/hooks/use-synthetic-parent-tab-history';
 import { useFocusTrap } from '@/hooks/use-focus-trap';
+import { HumanOnlyAction } from '@/components/ui/human-only-action';
 
 interface Task {
   id: string;
@@ -850,14 +851,19 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
             />
           </div>
           <div className="flex shrink-0 items-center gap-2">
-            <button
-              type="button"
-              onClick={() => setShowDeleteConfirm(true)}
-              className="flex items-center gap-1 rounded-md border border-destructive/40 px-2.5 py-1.5 text-xs text-destructive transition hover:bg-destructive/10"
-              aria-label={t('deleteStory')}
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-            </button>
+            {/* story #2104 — BE stories.py:1056이 human-only로 hard-delete를 403 거부한다(되돌릴
+                수 없는 조작). 에이전트 계정에도 트리거를 열어두면 #2091/#2103과 같은 결함이라
+                미리 숨긴다. */}
+            <HumanOnlyAction>
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(true)}
+                className="flex items-center gap-1 rounded-md border border-destructive/40 px-2.5 py-1.5 text-xs text-destructive transition hover:bg-destructive/10"
+                aria-label={t('deleteStory')}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            </HumanOnlyAction>
             <button type="button" onClick={onClose} className="rounded-md border border-border px-3 py-2 text-muted-foreground transition hover:text-foreground hover:bg-muted/50">✕</button>
           </div>
         </div>

--- a/apps/web/src/components/retro/sprint-close-cockpit.test.tsx
+++ b/apps/web/src/components/retro/sprint-close-cockpit.test.tsx
@@ -6,6 +6,14 @@ import { createHeuristicStepSchedule, SprintCloseCockpit } from './sprint-close-
 import { EvidenceStrip } from './evidence-strip';
 import type { RetroHypothesisResult, RetroNextHypothesis, RetroSynthesis } from '@/services/retro-session';
 
+// story #2104 — HumanOnlyAction(다음가설 채택 버튼을 감싼다)이 useDashboardContext를 읽는다.
+// 기본은 human(기존 스위트가 전부 "채택 버튼이 보인다"를 전제하므로). agent 게이팅 자체를
+// 보는 케이스만 개별 override.
+const { useDashboardContextMock } = vi.hoisted(() => ({ useDashboardContextMock: vi.fn(() => ({ currentMemberType: 'human' })) }));
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => useDashboardContextMock(),
+}));
+
 function wrap(node: React.ReactNode) {
   return (
     <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
@@ -132,6 +140,32 @@ describe('SprintCloseCockpit (E-SPRINT-LOOP 1b9f4ecb)', () => {
     expect(markup).toContain('채택');
     expect(markup).toContain('추천일 뿐이다');
     expect(markup).toContain('중'); // 0.55 → mid bucket
+  });
+
+  // story #2104 — BE retros.py:373(ADOPTION_REQUIRES_HUMAN, "채택=인간 게이트")를 FE가 미리
+  // 안 보고 에이전트 계정에도 채택 버튼을 무조건 열었다(#2091/#2103과 같은 결함). 양방향
+  // 고정 — human까지 잠그면 정당한 채택이 봉쇄되는 더 큰 사고다.
+  it('agent 계정이면 채택 버튼이 안 뜬다(위 human 케이스와 대구 — story #2104)', () => {
+    useDashboardContextMock.mockReturnValue({ currentMemberType: 'agent' });
+    const synthesis: RetroSynthesis = { learned: [{ text: '학습' }], generated_at: '2026-07-02T00:00:00Z', source: 'ai_draft' };
+    const rec: RetroNextHypothesis = {
+      statement: '온보딩 첫 화면에 가이드를 넣으면 리텐션이 오를 것이다',
+      metric_definition: { metric: 'D1 리텐션', target: 32, direction: 'up' },
+      measure_after: '2026-07-16T00:00:00Z',
+      confidence: 0.55,
+      rationale: '가설 2 반증에서 — 레버는 첫 경험',
+      requires_confirmation: true,
+    };
+    const markup = renderToStaticMarkup(wrap(
+      <SprintCloseCockpit hypotheses={[VERIFIED]} synthesis={synthesis} nextHypotheses={[rec]} onGenerateSynthesis={noop} onAdoptRecommendation={noop} />,
+    ));
+    // 추천 카드 자체(문구·근거)는 그대로 보여야 한다 — 숨겨지는 건 액션 버튼뿐. 하단 안내문
+    // "채택하면 다음 스프린트..."는 "채택" 부분 문자열을 포함하므로(무관한 문구) 버튼
+    // 정확 경계(>채택</button>)로만 단언한다.
+    expect(markup).toContain('온보딩 첫 화면에 가이드를 넣으면 리텐션이 오를 것이다');
+    expect(markup).not.toContain('>채택</button>');
+    expect(markup).toContain('추천일 뿐이다'); // 안내문 자체는 그대로 남아있어야 함(무관 텍스트 보존 확認)
+    useDashboardContextMock.mockReturnValue({ currentMemberType: 'human' });
   });
 
   it('does not crash when a recommendation is missing metric_definition (까심 QA 적출 회귀 가드)', () => {

--- a/apps/web/src/components/retro/sprint-close-cockpit.tsx
+++ b/apps/web/src/components/retro/sprint-close-cockpit.tsx
@@ -9,6 +9,7 @@ import { OperatorTextarea } from '@/components/ui/operator-control';
 import { cn } from '@/lib/utils';
 import { DeltaTrack, fmt } from '@/components/outcome/outcome-result-card';
 import { AiGenerationLoading, type AiGenerationLoadingStep } from '@/components/ai/ai-generation-loading';
+import { HumanOnlyAction } from '@/components/ui/human-only-action';
 import type {
   RetroHypothesisResult,
   RetroNextHypothesis,
@@ -325,9 +326,14 @@ function RecommendationCard({
         <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={() => setEditing((v) => !v)}>
           {editing ? t('recEditDone') : t('recEdit')}
         </Button>
-        <Button variant="hero" size="sm" className="h-6 px-2.5 text-xs" onClick={() => onAdopt(statement)} disabled={adopting}>
-          {adopting ? t('recAdopting') : t('recAdopt')}
-        </Button>
+        {/* story #2104 — BE retros.py:373(ADOPTION_REQUIRES_HUMAN)이 human-only로 채택을 403
+            거부한다("채택=인간 게이트", SOUL-LOCK 유나 §6). 에이전트 계정에도 버튼을 열어두면
+            #2091/#2103과 같은 결함이라 미리 숨긴다. */}
+        <HumanOnlyAction>
+          <Button variant="hero" size="sm" className="h-6 px-2.5 text-xs" onClick={() => onAdopt(statement)} disabled={adopting}>
+            {adopting ? t('recAdopting') : t('recAdopt')}
+          </Button>
+        </HumanOnlyAction>
       </div>
     </div>
   );

--- a/apps/web/src/components/ui/human-only-action.test.tsx
+++ b/apps/web/src/components/ui/human-only-action.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+//
+// story #2104(AC6) — #2091(게이트 승인)·#2103(HITL 인라인)에서 반복된 결함(BE가 human-only로
+// 403 거부하는 파괴적/결정 조작에 FE가 버튼을 무조건 열어 "내가 할 수 있다"고 믿게 만든 것)을
+// 막는 공용 wrapper. HOC(디디군이 오늘 lint에 막힘)가 아니라 children을 받는 평범한
+// 컴포넌트라는 것 자체가 이 테스트의 전제 — 렌더 시점 게이팅만 검증한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { HumanOnlyAction } from './human-only-action';
+
+const { useDashboardContextMock } = vi.hoisted(() => ({ useDashboardContextMock: vi.fn() }));
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => useDashboardContextMock(),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+async function render(currentMemberType: 'human' | 'agent' | undefined) {
+  useDashboardContextMock.mockReturnValue({ currentMemberType });
+  await act(async () => {
+    root.render(
+      <HumanOnlyAction fallback={<p>권한없음</p>}>
+        <button type="button">삭제</button>
+      </HumanOnlyAction>,
+    );
+  });
+}
+
+describe('HumanOnlyAction (story #2104)', () => {
+  it('human이면 children(액션 버튼)이 렌더된다 — 정당한 사용자까지 잠그면 더 큰 사고인', async () => {
+    await render('human');
+    expect(container.querySelector('button')?.textContent).toBe('삭제');
+    expect(container.textContent).not.toContain('권한없음');
+  });
+
+  it('agent면 children 대신 fallback이 렌더된다', async () => {
+    await render('agent');
+    expect(container.querySelector('button')).toBeNull();
+    expect(container.textContent).toBe('권한없음');
+  });
+
+  it('currentMemberType이 없으면(구버전/누락) fallback으로 fail-closed된다', async () => {
+    await render(undefined);
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('fallback을 안 넘기면 아무것도 안 그린다(기본값)', async () => {
+    useDashboardContextMock.mockReturnValue({ currentMemberType: 'agent' });
+    await act(async () => {
+      root.render(<HumanOnlyAction><button type="button">삭제</button></HumanOnlyAction>);
+    });
+    expect(container.textContent).toBe('');
+  });
+});

--- a/apps/web/src/components/ui/human-only-action.tsx
+++ b/apps/web/src/components/ui/human-only-action.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+
+interface HumanOnlyActionProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+/**
+ * story #2104(AC6) — 삭제·채택 등 BE가 human-only로 명시 거부하는 파괴적/결정 조작 버튼을
+ * 감싸는 wrapper. #2091(게이트 승인)·#2103(HITL 인라인)에서 반복된 결함(BE가 caller.type을
+ * 근거로 403을 정확히 판단하는데 FE가 그 판정을 미리 안 보고 버튼을 무조건 열어 "내가 할 수
+ * 있다"고 믿게 만든 것)을 재발시키지 않기 위한 공용 게이트다.
+ *
+ * HOC(함수가 컴포넌트를 받아 새 컴포넌트를 반환)가 아니라 children을 받는 평범한 컴포넌트다 —
+ * 오늘 팀이 겪은 HOC lint 차단(클로저를 함수 인자로 넘기는 패턴)과 구조가 다르다.
+ *
+ * `currentMemberType === 'human'`으로 명시 비교한다 — `if (currentMemberType)`로 쓰면 필드가
+ * 없을 때 우연히 닫히는 것(운)이 되고, 지금은 필드 부재 시 닫힌다는 것이 코드에 적혀 있다
+ * (fail-closed, #2091/#2103과 동일 원칙).
+ */
+export function HumanOnlyAction({ children, fallback = null }: HumanOnlyActionProps) {
+  const { currentMemberType } = useDashboardContext();
+  if (currentMemberType === 'human') return <>{children}</>;
+  return <>{fallback}</>;
+}


### PR DESCRIPTION
## 근본원인
#2091·#2103과 같은 버그클래스. BE human-only 403 가드를 17곳 전수 대조(원본=서버 가드) — 4곳 이미 게이팅됨(#2091·#2103 포함), 6곳 미게이팅(전부 파괴적/결정 조작), 2곳 대응 화면 없음, 1곳 대상 아님.

## 수정 — 6곳
```
docs.py:471    Doc 삭제 드롭다운
goals.py:352   Goal(Epic) 삭제
sprints.py:351 Sprint 삭제
retros.py:373  다음가설 채택(ADOPTION_REQUIRES_HUMAN)
stories.py:1056 Story 영구삭제(hard-delete)
projects.py:213 Project 삭제(edit 버튼은 human-only 가드 없어 미터치)
```

## AC6(재발 방지) — `<HumanOnlyAction>` wrapper 신설
HOC(디디군이 오늘 lint에 막힘)가 아니라 children을 받는 평범한 컴포넌트 — 렌더 시점 게이팅에만 쓸 수 있고, handler 내부 판정(SSE dedup 등)에는 못 쓴다(감쌀 JSX가 없으므로). `currentMemberType === 'human'`로 명시 비교(fail-closed), #2103이 만든 DashboardContext 필드 재사용(신규 fetch 0).

## 테스트
`human-only-action.test.tsx`(wrapper 자체 4케이스) + `goals-client.test.tsx`·`sprint-close-cockpit.test.tsx` 각 2케이스. RED→GREEN 확認. 나머지 4곳(docs·sprints·story-detail-panel·settings)은 코드 검토로 배선 확認, 전체 마운트 테스트는 기존 인프라 부재로 비용 대비 낮다고 판단 — 배포 후 실화면 검증으로 보강.

type-check/lint/vitest(1843)/build 전부 green.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>