### PR TITLE
fix(a11y): story #2096 — 토스트에 role·aria-live·닫기 aria-label 부재로 스크린리더가 안 읽던 결함

### DIFF
--- a/apps/web/src/components/ui/toast.test.tsx
+++ b/apps/web/src/components/ui/toast.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+//
+// story #2096 — 토스트가 role·aria-live 없이 렌더돼 스크린리더가 아예 안 읽었다(까심군이
+// #2384 검수 때 토스트를 자동으로 못 잡아 스크린샷으로만 확認한 원인). 토스트는 조작 결과를
+// 알리는 유일한 수단인 경우가 많아(담당자 지정 성공 등) 접근성 결함이 곧 기능 결함이다.
+//
+// AC4 — data-testid로 우회하지 않는다: 여기서 쓰는 셀렉터는 [role="alert"]/[role="status"]
+// 자체다. 접근성 속성이 곧 셀렉터라는 것을 테스트 스스로 증명한다.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { ToastContainer, type ToastItem } from './toast';
+import koMessages from '../../../messages/ko.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+function toast(overrides: Partial<ToastItem>): ToastItem {
+  return { id: 't1', title: '제목', ...overrides };
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+describe('Toast 접근성 (story #2096)', () => {
+  // AC2 — success/info/warning은 흐름을 끊지 않는 polite, error만 즉시 끼어드는 assertive.
+  it.each([
+    ['success', 'status', 'polite'],
+    ['info', 'status', 'polite'],
+    ['warning', 'status', 'polite'],
+    [undefined, 'status', 'polite'],
+    ['error', 'alert', 'assertive'],
+  ] as const)('type=%s → role=%s, aria-live=%s', async (type, expectedRole, expectedLive) => {
+    await act(async () => {
+      root.render(wrap(
+        <ToastContainer toasts={[toast({ type })]} onDismiss={() => {}} />,
+      ));
+    });
+    const el = container.querySelector(`[role="${expectedRole}"]`);
+    expect(el).not.toBeNull();
+    expect(el?.getAttribute('aria-live')).toBe(expectedLive);
+    expect(el?.getAttribute('aria-atomic')).toBe('true');
+  });
+
+  it('error 토스트는 status가 아니라 alert로만 잡힌다(둘 다 걸리면 이중 낭독)', async () => {
+    await act(async () => {
+      root.render(wrap(<ToastContainer toasts={[toast({ type: 'error' })]} onDismiss={() => {}} />));
+    });
+    expect(container.querySelector('[role="alert"]')).not.toBeNull();
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+
+  it('닫기 버튼에 접근 가능한 이름(aria-label)이 있다 — "✕" 문자만으론 스크린리더가 못 읽는다', async () => {
+    await act(async () => {
+      root.render(wrap(<ToastContainer toasts={[toast({})]} onDismiss={() => {}} />));
+    });
+    const dismissBtn = container.querySelector('button[aria-label]');
+    expect(dismissBtn).not.toBeNull();
+    expect(dismissBtn?.getAttribute('aria-label')).toBe(koMessages.common.close);
+  });
+
+  it('여러 토스트가 섞여도 각자 올바른 role로 각각 잡힌다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ToastContainer
+          toasts={[toast({ id: 't1', type: 'success' }), toast({ id: 't2', type: 'error' })]}
+          onDismiss={() => {}}
+        />,
+      ));
+    });
+    expect(container.querySelectorAll('[role="status"]').length).toBe(1);
+    expect(container.querySelectorAll('[role="alert"]').length).toBe(1);
+  });
+});

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
+import { useTranslations } from 'next-intl';
 
 export interface ToastItem {
   id: string;
@@ -16,6 +17,7 @@ interface ToastProps {
 }
 
 function Toast({ item, onDismiss }: ToastProps) {
+  const t = useTranslations('common');
   useEffect(() => {
     const timer = setTimeout(() => onDismiss(item.id), 5000);
     return () => clearTimeout(timer);
@@ -33,8 +35,23 @@ function Toast({ item, onDismiss }: ToastProps) {
             ? 'border-l-4 border-l-info'
             : 'border-l-4 border-l-border';
 
+  // story #2096 — 토스트는 조작 결과(담당자 지정 성공 등)를 알리는 유일한 수단인 경우가
+  // 많은데 role·aria-live가 없어 스크린리더가 아예 안 읽었다(까심군이 #2384 검수 때 자동으로
+  // 못 잡고 스크린샷으로만 확認한 원인). AC2 — error는 사용자가 지금 막힌 상태이므로 다른
+  // 작업을 끊고서라도 즉시 알려야 한다(role="alert" → 암묵적 aria-live="assertive"). 나머지
+  // (success/info/warning)는 결과 보고일 뿐 흐름을 끊을 만큼 급하지 않다(role="status" →
+  // 암묵적 aria-live="polite", 진행 중이던 스크린리더 낭독이 끝난 뒤 자연스럽게 이어 읽는다).
+  // aria-live/aria-atomic은 role의 암묵값과 같은 값을 명시로 중복 기술한다 — role의 암묵
+  // 라이브리전 매핑을 지원 안 하는 스크린리더/자동화 도구 대비.
+  const isUrgent = item.type === 'error';
+
   return (
-    <div className={`animate-slide-in rounded-lg border border-border bg-popover p-4 shadow-lg ${borderColor}`}>
+    <div
+      role={isUrgent ? 'alert' : 'status'}
+      aria-live={isUrgent ? 'assertive' : 'polite'}
+      aria-atomic="true"
+      className={`animate-slide-in rounded-lg border border-border bg-popover p-4 shadow-lg ${borderColor}`}
+    >
       <div className="flex items-start justify-between">
         <div>
           <p className="text-sm font-semibold text-popover-foreground">{item.title}</p>
@@ -44,6 +61,7 @@ function Toast({ item, onDismiss }: ToastProps) {
         </div>
         <button
           onClick={() => onDismiss(item.id)}
+          aria-label={t('close')}
           className="ml-3 text-muted-foreground hover:text-foreground"
         >
           ✕


### PR DESCRIPTION
## 근본원인
`toast.tsx`(sonner 아님, 자체 구현)가 role·aria-live 없이 순수 시각 요소로만 렌더됐다. 까심군이 #2384 검수 때 토스트를 자동으로 못 잡아 스크린샷으로만 확認한 원인이 이 접근성 결함이었다.

토스트가 조작 결과를 알리는 유일한 수단인 화면이 많다 — 안 들리는 사용자는 자기 조작이 됐는지 모른다. 눈으로 하는 검수로는 절대 안 잡히는 자리(유나양의 removeAttachment aria-label 건과 정반대 방향).

## 수정
**AC2**: `type==='error'`만 `role="alert"`(assertive — 다른 낭독을 끊고서라도 즉시), 나머지는 `role="status"`(polite — 흐름을 안 끊음). aria-live·aria-atomic도 명시로 중복 기술(role 암묵매핑 미지원 대비). 닫기 버튼에 `aria-label`(common.close 재사용, 신규 키 0).

**AC4**: data-testid 우회 없음 — 테스트 셀렉터가 `[role="alert"]`/`[role="status"]` 자체.

## 테스트
8케이스, RED→GREEN 확認. type-check/lint/vitest(1864)/build 전부 green.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>