### PR TITLE
fix(a11y): story #2105 1차 — 인증 화면 인라인 에러가 스크린리더에 안 들리던 결함

### DIFF
--- a/apps/web/src/app/login/page.test.tsx
+++ b/apps/web/src/app/login/page.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+//
+// story #2105 1차 — 로그인은 계정 없는 사람이 제품에서 처음 만나는 화면 중 하나인데 실패
+// 사유가 role·aria-live 없이 순수 시각 요소로만 렌더됐다(#2096과 같은 결함클래스). 재시도마다
+// setError(null)이 먼저 실행돼 이 단락이 매번 언마운트→리마운트되므로, 동일한 실패 사유가
+// 연속으로 떠도 새 DOM 노드로 안착해 스크린리더가 놓치지 않는다 — 그 왕복까지 검증한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+
+const { loginWithPasswordMock } = vi.hoisted(() => ({ loginWithPasswordMock: vi.fn() }));
+vi.mock('@/lib/db/client', () => ({ loginWithPassword: loginWithPasswordMock }));
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  loginWithPasswordMock.mockReset();
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.resetModules();
+});
+
+async function mount() {
+  const { default: LoginPage } = await import('./page');
+  await act(async () => { root.render(wrap(<LoginPage />)); });
+}
+
+function setNativeValue(el: HTMLInputElement, value: string) {
+  // React controlled input을 jsdom에서 신뢰성 있게 채우는 표준 우회 — 네이티브 value setter를
+  // 직접 호출해야 React의 내부 값 추적(valueTracker)이 실제 변경으로 인식한다(단순
+  // `el.value = ...` + dispatchEvent만으로는 종종 무시된다).
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+  setter.call(el, value);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+async function submit() {
+  const emailInput = container.querySelector('input[type="email"]') as HTMLInputElement;
+  const passwordInput = container.querySelector('input[type="password"]') as HTMLInputElement;
+  await act(async () => {
+    setNativeValue(emailInput, 'a@b.com');
+    setNativeValue(passwordInput, 'wrong');
+  });
+  const signInBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.login.signIn);
+  await act(async () => {
+    signInBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('LoginPage — 실패 사유 접근성 (story #2105 1차)', () => {
+  it('로그인 실패 시 role="alert" aria-live="assertive"로 사유가 렌더된다', async () => {
+    loginWithPasswordMock.mockResolvedValue({ error: { code: 'INVALID_CREDENTIALS', message: '이메일 또는 비밀번호가 올바르지 않습니다.' } });
+    await mount();
+    await submit();
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl).not.toBeNull();
+    expect(alertEl?.textContent).toBe('이메일 또는 비밀번호가 올바르지 않습니다.');
+    expect(alertEl?.getAttribute('aria-live')).toBe('assertive');
+  });
+
+  it('동일한 실패 사유가 연속으로 떠도 매번 새 DOM 노드로 안착한다(setError(null) 선-리셋 확認)', async () => {
+    loginWithPasswordMock.mockResolvedValue({ error: { code: 'INVALID_CREDENTIALS', message: '이메일 또는 비밀번호가 올바르지 않습니다.' } });
+    await mount();
+    await submit();
+    const first = container.querySelector('[role="alert"]');
+    expect(first).not.toBeNull();
+
+    await submit();
+    const second = container.querySelector('[role="alert"]');
+    expect(second).not.toBeNull();
+    // 서로 다른 DOM 노드여야 한다 — 같은 노드가 재사용되면 텍스트가 안 바뀌어 스크린리더가
+    // 못 알아챌 수 있다. 언마운트→리마운트를 거쳤다면 두 참조는 동일 객체가 아니다.
+    expect(first).not.toBe(second);
+  });
+});

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -140,7 +140,12 @@ export default function LoginPage() {
               disabled={loading}
             />
           )}
-          {error && <p className="text-sm text-destructive">{error}</p>}
+          {/* story #2105 1차 — 계정 없는 사람이 제품에서 처음 만나는 화면(들어오는 경로)인데
+              role·aria-live가 없어 스크린리더가 실패 사유를 안 읽었다(#2096과 같은 결함클래스).
+              handleLogin/handleFirebaseLogin이 재시도 시 setError(null)을 먼저 호출해 이
+              단락이 매 시도마다 언마운트→리마운트되므로(토스트의 "나타남"과 동형), 동일한
+              실패 사유가 연속으로 떠도 매번 새 DOM 노드로 안착해 안정적으로 낭독된다. */}
+          {error && <p role="alert" aria-live="assertive" aria-atomic="true" className="text-sm text-destructive">{error}</p>}
           <button
             onClick={handleLogin}
             disabled={loading || !email.trim() || !password.trim()}

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -142,7 +142,11 @@ export default function RegisterPage() {
             </span>
           </label>
 
-          {error && <p className="text-sm text-destructive">{error}</p>}
+          {/* story #2105 1차 — #2096과 같은 결함클래스(계정 없는 사람이 처음 만나는 화면인데
+              실패 사유가 스크린리더에 안 읽힘). setError(null)이 재시도마다 먼저 실행돼(위
+              handleRegister) 이 단락이 매번 언마운트→리마운트되므로 동일 사유가 반복돼도
+              안정적으로 낭독된다. */}
+          {error && <p role="alert" aria-live="assertive" aria-atomic="true" className="text-sm text-destructive">{error}</p>}
           <button
             onClick={handleRegister}
             disabled={loading || !displayName.trim() || !email.trim() || !password.trim() || !tosAccepted}

--- a/apps/web/src/app/reset-password/page.tsx
+++ b/apps/web/src/app/reset-password/page.tsx
@@ -86,7 +86,9 @@ export default function ResetPasswordPage() {
         </div>
 
         {done ? (
-          <div className="space-y-4 text-center">
+          // story #2105 1차(AC2) — 성공 결과도 결과다. error와 달리 사용자가 막힌 상태가
+          // 아니므로 흐름을 끊는 assertive가 아니라 polite로 알린다(#2096과 동일 원칙).
+          <div role="status" aria-live="polite" aria-atomic="true" className="space-y-4 text-center">
             <p className="text-sm text-muted-foreground">{t('done')}</p>
             {totpReenrollNeeded && (
               <p className="text-sm text-muted-foreground">{t('mfaReenroll')}</p>
@@ -122,7 +124,12 @@ export default function ResetPasswordPage() {
                 </li>
               </ul>
             )}
-            {error && <p className="text-sm text-destructive">{error}</p>}
+            {/* story #2105 1차 — #2096과 같은 결함클래스. setError(null)이 재시도마다 먼저
+                실행돼(위 handleSubmit) 이 단락이 매번 언마운트→리마운트되므로 동일 사유가
+                반복돼도 안정적으로 낭독된다. line 73(invalidLink)은 페이지 최초 렌더의
+                정적 콘텐츠라(사후에 나타나는 결과가 아님) 이 대상이 아니다 — 스크린리더가
+                일반 문서 읽기로 이미 커버한다. */}
+            {error && <p role="alert" aria-live="assertive" aria-atomic="true" className="text-sm text-destructive">{error}</p>}
             <button
               onClick={handleSubmit}
               disabled={loading || !password}


### PR DESCRIPTION
## 근본원인
#2096(토스트)과 같은 결함클래스를 전수 훑어 33개 파일에서 발견 — role·aria-live 있는 파일 0개. 인증 화면(login·register·reset-password)이 가장 급해 1차로 분리 — 계정 없는 사람이 처음 만나는 화면이자 대안이 없는 들어오는 경로. 오늘 #2389로 초대 링크 진입 막힘을 고쳤는데 그 다음 화면(로그인/가입)에서 실패 이유를 못 듣는 상태였다.

## 수정
- login/register: 실패 사유에 `role="alert" aria-live="assertive"`(AC2 — 즉시 알림).
- reset-password: 위와 동일 + 성공 상태엔 `role="status" aria-live="polite"`. `invalidLink`는 정적 초기 콘텐츠라 제외.

## AC3(라이브 리전 오작동 방지)
동일 실패 사유 연속 시 텍스트 무변화로 재낭독 안 될 위험 — 세 화면 모두 `setError(null)` 선-리셋 구조라 매 시도마다 언마운트→리마운트됨을 확認, 테스트로 고정.

## 테스트
`login/page.test.tsx` 2케이스, RED→GREEN. register/reset-password는 동일 패턴 코드 검토로 확認.

type-check/lint/vitest(1858)/build 전부 green.

## 남은 스코프 — 2차
나머지 30개 파일, 별도 PR.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>