### PR TITLE
fix(a11y): story #2105 2차 — 나머지 24개 화면 인라인 에러/성공 피드백 스크린리더 낭독

### DIFF
--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
@@ -632,7 +632,9 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
               <p className="text-sm font-semibold text-foreground">{t('roleQuestion')}</p>
 
               {roleError ? (
-                <div className="flex items-center gap-2">
+                // story #2105 2차 — 로드 실패도 결과다(#2096/#2105 1차와 동일 원칙). fetchRoleTemplates가
+                // 재시도 전 setRoleError(false)를 먼저 호출해 매 시도마다 언마운트→리마운트된다.
+                <div role="alert" aria-live="assertive" aria-atomic="true" className="flex items-center gap-2">
                   <p className="text-sm text-destructive">{t('roleLoadError')}</p>
                   <Button variant="ghost" size="sm" onClick={() => void fetchRoleTemplates()}>{t('retry')}</Button>
                 </div>
@@ -828,7 +830,7 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
                       <option value="admin">{tSettings('agentRoleAdmin')}</option>
                     </select>
                   </div>
-                  {equipError && <p className="text-xs text-destructive">{equipError}</p>}
+                  {equipError && <p role="alert" aria-live="assertive" aria-atomic="true" className="text-xs text-destructive">{equipError}</p>}
                 </div>
               ) : null}
 
@@ -868,7 +870,9 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
                     </div>
                   </div>
                 ) : runtimeCapabilitiesError ? (
-                  <div className="space-y-2 rounded-xl border border-border bg-muted/30 p-3">
+                  // story #2105 2차 — fetchRuntimeCapabilities가 재시도 전 setRuntimeCapabilitiesError(false)를
+                  // 먼저 호출해(위 정의) 매 시도마다 언마운트→리마운트된다.
+                  <div role="alert" aria-live="assertive" aria-atomic="true" className="space-y-2 rounded-xl border border-border bg-muted/30 p-3">
                     <p className="text-sm font-medium text-foreground">{t('runtimeLoadError')}</p>
                     <p className="text-xs text-muted-foreground">{t('runtimeLoadErrorNote')}</p>
                     <Button variant="ghost" size="sm" onClick={() => void fetchRuntimeCapabilities()}>{t('retry')}</Button>
@@ -977,7 +981,7 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
                 </div>
               </div>
 
-              {recruitError && <p className="text-sm text-destructive">{recruitError}</p>}
+              {recruitError && <p role="alert" aria-live="assertive" aria-atomic="true" className="text-sm text-destructive">{recruitError}</p>}
 
               <div className="flex justify-between gap-2 pt-2">
                 <Button variant="ghost" onClick={() => setStep(2)}><ChevronLeft className="h-4 w-4" />{t('back')}</Button>
@@ -991,7 +995,9 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
           {/* ── equip-skip 결과(story d82c1092·STEP3 재사용) — AddAgentForm 2-phase 결과 UX 그대로 ── */}
           {step === 3 && equipSkip && equipResult && (
             <div className="space-y-4">
-              <div className="space-y-3 rounded-md border border-success-border bg-success-tint p-4">
+              {/* story #2105 2차 — 생성 성공도 결과다(#2096/#2105 1차와 동일 원칙). equipResult는 이
+                  가드에서 최초 1회만 non-null이 되므로 polite 낭독으로 충분(흐름 차단 아님). */}
+              <div role="status" aria-live="polite" aria-atomic="true" className="space-y-3 rounded-md border border-success-border bg-success-tint p-4">
                 <p className="text-sm font-semibold text-success">{t('equipCreatedTitle', { name: equipResult.name })}</p>
                 {equipResult.fakechat_port ? (
                   <div className="flex flex-wrap items-center gap-2 text-xs">
@@ -1126,7 +1132,7 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
                   <div className="space-y-2 rounded-md border border-warning-border bg-warning-tint p-3">
                     <p className="text-xs font-semibold text-foreground">{t('rotateConfirmTitle')}</p>
                     <p className="text-xs leading-relaxed text-muted-foreground"><b className="text-foreground">{t('rotateConfirmBold')}</b> {t('rotateConfirmBody')}</p>
-                    {rotateError && <p className="text-xs text-destructive">{rotateError}</p>}
+                    {rotateError && <p role="alert" aria-live="assertive" aria-atomic="true" className="text-xs text-destructive">{rotateError}</p>}
                     <div className="flex justify-end gap-2">
                       <Button variant="ghost" size="sm" onClick={() => setShowRotateConfirm(false)} disabled={rotating}>{t('cancel')}</Button>
                       <Button size="sm" className="bg-warning text-foreground hover:bg-warning/90" disabled={rotating} onClick={() => void handleRotateConfirmed()}>

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -909,7 +909,7 @@ export default function SettingsPage() {
                           ) : (
                             <p className="rounded-md border border-input bg-muted/30 px-3 py-2 text-sm text-foreground">{orgInfo.name}</p>
                           )}
-                          {orgNameError && <p className="text-xs text-destructive">{orgNameError}</p>}
+                          {orgNameError && <p role="alert" aria-live="assertive" aria-atomic="true" className="text-xs text-destructive">{orgNameError}</p>}
                         </div>
 
                         <div className="space-y-1.5">
@@ -1069,7 +1069,14 @@ export default function SettingsPage() {
                   </div>
 
                   {projectActionMessage ? (
-                    <Alert variant={projectActionMessage.type === 'success' ? 'success' : 'destructive'}>
+                    // story #2105 2차 — 성공/실패 결과 모두 아직 시각 전용이었다(#2096/#2105 1차와 동일
+                    // 결함클래스). 에러=alert/assertive, 성공=status/polite.
+                    <Alert
+                      variant={projectActionMessage.type === 'success' ? 'success' : 'destructive'}
+                      role={projectActionMessage.type === 'success' ? 'status' : 'alert'}
+                      aria-live={projectActionMessage.type === 'success' ? 'polite' : 'assertive'}
+                      aria-atomic="true"
+                    >
                       <AlertDescription>{projectActionMessage.text}</AlertDescription>
                     </Alert>
                   ) : null}
@@ -1162,7 +1169,7 @@ export default function SettingsPage() {
                                   {webhookSaving === member.id ? '...' : tc('save')}
                                 </Button>
                               </div>
-                              {err ? <p className="mt-1 text-xs text-destructive">{err}</p> : null}
+                              {err ? <p role="alert" aria-live="assertive" aria-atomic="true" className="mt-1 text-xs text-destructive">{err}</p> : null}
                             </div>
                           );
                         })}

--- a/apps/web/src/app/invite/page.test.tsx
+++ b/apps/web/src/app/invite/page.test.tsx
@@ -89,3 +89,62 @@ describe('InvitePage — joinHeading t.rich() 렌더 (story #2084)', () => {
     expect(emphasized?.textContent).toBe('뭉클랩');
   });
 });
+
+// story #2105 2차 — 초대 프리뷰 실패/가입 성공 결과가 role/aria-live로 스크린리더에 낭독되는지.
+// 'preview-loading'/'accepting'에서 비동기로 전이되는 상태라(reset-password의 정적 초기렌더
+// invalidLink와 달리) aria-live 대상이다.
+describe('InvitePage — 결과 피드백 접근성(story #2105 2차)', () => {
+  it('프리뷰 로드 실패 시 role="alert" aria-live="assertive"로 사유가 렌더된다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/invites/tok-1') && !url.includes('accept')) {
+        return { ok: false, json: async () => ({ error: { message: '초대가 만료되었습니다.' } }) };
+      }
+      throw new Error('unexpected fetch: ' + url);
+    }));
+    await act(async () => { root.render(wrap('ko', <InvitePage />)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl).not.toBeNull();
+    expect(alertEl?.textContent).toContain('초대가 만료되었습니다.');
+    expect(alertEl?.getAttribute('aria-live')).toBe('assertive');
+  });
+
+  it('가입 성공 시 role="status" aria-live="polite"로 결과가 렌더된다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string, opts?: RequestInit) => {
+      if (url.includes('/api/invites/tok-1') && !url.includes('accept')) {
+        return { ok: true, json: async () => ({ data: PREVIEW }) };
+      }
+      if (url === '/api/me') return { ok: false } as Response;
+      if (url === '/api/auth/register' && opts?.method === 'POST') {
+        return { ok: true, json: async () => ({}) };
+      }
+      throw new Error('unexpected fetch: ' + url);
+    }));
+    await act(async () => { root.render(wrap('ko', <InvitePage />)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
+    const passwordInput = container.querySelector('input[type="password"]') as HTMLInputElement;
+    const tosCheckbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(nameInput, '홍길동');
+      nameInput.dispatchEvent(new Event('input', { bubbles: true }));
+      setter.call(passwordInput, 'password123!');
+      passwordInput.dispatchEvent(new Event('input', { bubbles: true }));
+      tosCheckbox.click();
+    });
+    const submitBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '합류하기');
+    await act(async () => {
+      submitBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const statusEl = container.querySelector('[role="status"]');
+    expect(statusEl).not.toBeNull();
+    expect(statusEl?.getAttribute('aria-live')).toBe('polite');
+    expect(statusEl?.textContent).toContain('뭉클랩');
+  });
+});

--- a/apps/web/src/app/invite/page.tsx
+++ b/apps/web/src/app/invite/page.tsx
@@ -141,7 +141,9 @@ export default function InvitePage() {
   if (pageState === 'preview-error') {
     return (
       <Frame>
-        <div className="space-y-3 py-8 text-center">
+        {/* story #2105 2차 — 'preview-loading'에서 비동기로 전이되는 결과다(reset-password의
+            정적 초기렌더 invalidLink와 달리 마운트 후 상태변화라 aria-live 대상). */}
+        <div role="alert" aria-live="assertive" aria-atomic="true" className="space-y-3 py-8 text-center">
           <div className="text-3xl">✕</div>
           <p className="text-sm text-destructive">{errorMsg}</p>
           {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- story a539c649 S2 오탐, invite-accept-client.tsx 주석 참고 */}
@@ -163,12 +165,13 @@ export default function InvitePage() {
             pageState === 'success' && 'text-success',
           )} />
           {pageState === 'success' && preview ? (
-            <>
+            // story #2105 2차 — 성공 결과(가입 완료)도 polite로 낭독(#2096/#2105 1차와 동일 원칙).
+            <div role="status" aria-live="polite" aria-atomic="true">
               <p className="text-lg font-semibold tracking-tight text-foreground">
                 {t('joinedOrg', { org: preview.org_name })}
               </p>
               <p className="text-sm text-muted-foreground">{t('redirecting')}</p>
-            </>
+            </div>
           ) : (
             <p className="text-sm text-muted-foreground">{t('accepting')}</p>
           )}
@@ -284,7 +287,9 @@ export default function InvitePage() {
             </div>
 
             {errorMsg && (
-              <p className="text-sm text-destructive">{errorMsg}</p>
+              // story #2105 2차 — handleSubmit이 재시도 전 setErrorMsg('')를 먼저 호출해(위 정의)
+              // 매 시도마다 언마운트→리마운트된다.
+              <p role="alert" aria-live="assertive" aria-atomic="true" className="text-sm text-destructive">{errorMsg}</p>
             )}
 
             <button

--- a/apps/web/src/app/mfa/page.tsx
+++ b/apps/web/src/app/mfa/page.tsx
@@ -53,7 +53,9 @@ export default function MfaPage() {
             onKeyDown={(e) => e.key === 'Enter' && handleVerify()}
             autoFocus
           />
-          {error && <p className="text-sm text-destructive">{error}</p>}
+          {/* story #2105 2차 — handleVerify가 재시도 전 setError(null)을 먼저 호출해(위 정의)
+              매 시도마다 언마운트→리마운트된다(#2096/#2105 1차와 동일 원칙). */}
+          {error && <p role="alert" aria-live="assertive" aria-atomic="true" className="text-sm text-destructive">{error}</p>}
           <button
             onClick={handleVerify}
             disabled={loading || code.length !== 6}

--- a/apps/web/src/app/onboarding/connect-step.tsx
+++ b/apps/web/src/app/onboarding/connect-step.tsx
@@ -414,7 +414,8 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
           </p>
         )}
         {verified && (
-          <div className="rounded-md border border-success/20 bg-success/10 px-3 py-2.5 text-sm text-success">
+          // story #2105 2차 — 검증 성공 결과도 polite로 낭독(#2096/#2105 1차와 동일 원칙).
+          <div role="status" aria-live="polite" aria-atomic="true" className="rounded-md border border-success/20 bg-success/10 px-3 py-2.5 text-sm text-success">
             {t('verifiedBanner')}
           </div>
         )}

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -237,7 +237,9 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
         </div>
 
         {error && (
-          <div className="rounded-lg border border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive">
+          // story #2105 2차 — handleCreateOrg/handleCreateProject/handleCreateAgent 모두 재시도 전
+          // setError('')를 먼저 호출해(위 정의) 매 시도마다 언마운트→리마운트된다.
+          <div role="alert" aria-live="assertive" aria-atomic="true" className="rounded-lg border border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive">
             {error}
           </div>
         )}

--- a/apps/web/src/components/agents/agent-run-detail.tsx
+++ b/apps/web/src/components/agents/agent-run-detail.tsx
@@ -245,7 +245,9 @@ export function AgentRunDetail({
 
   if (loadError) {
     return (
-      <div className="flex flex-col items-center gap-3 py-20 text-center text-muted-foreground">
+      // story #2105 2차 — load()가 재시도 전 setLoadError(false)를 먼저 호출해(위 정의) 매
+      // retryKey 변경마다 언마운트→리마운트된다.
+      <div role="alert" aria-live="assertive" aria-atomic="true" className="flex flex-col items-center gap-3 py-20 text-center text-muted-foreground">
         <p>{tc('error')}</p>
         <p className="text-xs">{tc('errorDescription')}</p>
         <Button size="sm" variant="outline" onClick={() => setRetryKey((k) => k + 1)}>

--- a/apps/web/src/components/chat/add-participant-modal.tsx
+++ b/apps/web/src/components/chat/add-participant-modal.tsx
@@ -117,7 +117,9 @@ export function AddParticipantModal({
             </ul>
           )}
 
-          {error && <p className="mt-2 text-xs text-destructive">{error}</p>}
+          {/* story #2105 2차 — handleAdd이 재시도 전 setError(null)을 먼저 호출해(위 정의) 매
+              시도마다 언마운트→리마운트된다. */}
+          {error && <p role="alert" aria-live="assertive" aria-atomic="true" className="mt-2 text-xs text-destructive">{error}</p>}
         </div>
 
         {/* Footer */}

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -443,11 +443,13 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
           })}
         </div>
       )}
+      {/* story #2105 2차 — handleSend가 재시도 전 두 상태 모두 false로 리셋해(위 정의) 매
+          시도마다 언마운트→리마운트된다. */}
       {uploadFailed && (
-        <p className="mb-1 text-xs text-destructive">첨부 업로드에 실패했습니다. 다시 시도해 주세요.</p>
+        <p role="alert" aria-live="assertive" aria-atomic="true" className="mb-1 text-xs text-destructive">첨부 업로드에 실패했습니다. 다시 시도해 주세요.</p>
       )}
       {sendFailed && (
-        <p className="mb-1 text-xs text-destructive">{t('sendFailed')}</p>
+        <p role="alert" aria-live="assertive" aria-atomic="true" className="mb-1 text-xs text-destructive">{t('sendFailed')}</p>
       )}
       {atMaxAttachments && (
         <p className="mb-1 text-xs text-muted-foreground">첨부는 최대 {MAX_ATTACHMENTS}개까지 가능합니다.</p>

--- a/apps/web/src/components/chat/new-conversation-modal.tsx
+++ b/apps/web/src/components/chat/new-conversation-modal.tsx
@@ -124,7 +124,9 @@ export function NewConversationModal({ projectId, onClose, onCreated }: NewConve
             </div>
           )}
 
-          {error && <p className="mt-2 text-xs text-destructive">{error}</p>}
+          {/* story #2105 2차 — handleCreate가 재시도 전 setError(null)을 먼저 호출해(위 정의) 매
+              시도마다 언마운트→리마운트된다. */}
+          {error && <p role="alert" aria-live="assertive" aria-atomic="true" className="mt-2 text-xs text-destructive">{error}</p>}
         </div>
 
         {/* Footer */}

--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -148,6 +148,23 @@ describe('KanbanBoard — 보드 first-touch 절제된 배너', () => {
 // story #2105 2차 — 스토리 생성 실패 배너(transitionError)가 role="alert" aria-live="assertive"로
 // 스크린리더에 낭독되는지. stubFetch는 GET /api/stories?... 만 매칭하고 POST(쿼리 없음)는
 // 캐치올(ok:false)로 떨어지므로 실패 경로를 그대로 재현한다.
+//
+// ⚠️리베이스 후 전수 검증(story #2105 2차) 중 발견: 원래 이 테스트는 Enter 디스패치 뒤
+// `await Promise.resolve()` 2회로 고정 대기했다 — 실제 체인(onKeyDown→submitCompose
+// [fire-and-forget]→await onCreateStory→await fetch(mock)→!res.ok 분기→submitCompose의
+// await 재개→setDraftTitle/setComposing)은 마이크로태스크 홉이 2회보다 많을 수 있어, 파일
+// 단독 실행(부하 적음)에서는 우연히 통과하고 287파일 전체 스위트(부하 큼·이벤트루프 지터
+// 증가)에서만 간헐적으로 실패하는 결과 불안정을 냈다(직접 확認 — 전체 스위트 3회 중 2회
+// 실패, 파일 단독은 항상 통과). 고정 틱 대신 실제 DOM 조건이 나타날 때까지 짧게 폴링한다.
+async function waitForAlert(): Promise<Element | null> {
+  for (let i = 0; i < 20; i++) {
+    const el = container.querySelector('[role="alert"]');
+    if (el) return el;
+    await act(async () => { await Promise.resolve(); });
+  }
+  return null;
+}
+
 describe('KanbanBoard — 스토리 생성 실패 접근성(story #2105 2차)', () => {
   it('생성 실패 시 role="alert" aria-live="assertive"로 배너가 렌더된다', async () => {
     stubFetch([]);
@@ -163,10 +180,8 @@ describe('KanbanBoard — 스토리 생성 실패 접근성(story #2105 2차)', 
     });
     await act(async () => {
       titleInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
-      await Promise.resolve();
-      await Promise.resolve();
     });
-    const alertEl = container.querySelector('[role="alert"]');
+    const alertEl = await waitForAlert();
     expect(alertEl).not.toBeNull();
     expect(alertEl?.textContent).toContain('스토리 추가에 실패했습니다');
     expect(alertEl?.getAttribute('aria-live')).toBe('assertive');

--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -145,6 +145,34 @@ describe('KanbanBoard — 보드 first-touch 절제된 배너', () => {
   });
 });
 
+// story #2105 2차 — 스토리 생성 실패 배너(transitionError)가 role="alert" aria-live="assertive"로
+// 스크린리더에 낭독되는지. stubFetch는 GET /api/stories?... 만 매칭하고 POST(쿼리 없음)는
+// 캐치올(ok:false)로 떨어지므로 실패 경로를 그대로 재현한다.
+describe('KanbanBoard — 스토리 생성 실패 접근성(story #2105 2차)', () => {
+  it('생성 실패 시 role="alert" aria-live="assertive"로 배너가 렌더된다', async () => {
+    stubFetch([]);
+    await mount();
+    const ctaButton = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('첫 스토리 만들기'));
+    await act(async () => { ctaButton!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const titleInput = container.querySelector('input') as HTMLInputElement;
+    expect(titleInput).not.toBeNull();
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+      setter.call(titleInput, '새 스토리');
+      titleInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => {
+      titleInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl).not.toBeNull();
+    expect(alertEl?.textContent).toContain('스토리 추가에 실패했습니다');
+    expect(alertEl?.getAttribute('aria-live')).toBe('assertive');
+  });
+});
+
 // story #2059 — 보드 실시간 반영. 새 EventSource를 여는 대신 기존 useSseNotifications의
 // extraEventNames를 구독해 story.status_changed/assignee_changed를 받는다(AC2). 이미 로드된
 // 카드만 in-place 패치하고(AC3, 전체 재fetch 없음) 누가 바꿨는지 토스트로 드러낸다(AC4).

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -899,7 +899,11 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
     <div className="flex h-full flex-col overflow-hidden">
       <ToastContainer toasts={toasts} onDismiss={dismissToast} />
       {transitionError && (
-        <div className="fixed bottom-4 right-4 z-50 rounded-md border border-destructive bg-destructive px-4 py-3 text-sm text-destructive-foreground shadow-md">
+        // story #2105 2차 — 이 배너는 4초 후 자동 setTransitionError(null)로만 해소되고, 재시도
+        // 직전에 명시적으로 null 리셋하지 않는다(handleDragEnd/handleChangeStatus/handleCreateStory
+        // 3곳 모두). 4초 내 동일 사유가 재발하면 텍스트가 안 바뀌어 재낭독이 안 될 수 있다 — 별도
+        // 잠재 결함으로 기록(이 스토리에서 상태머신을 재구성하지 않음).
+        <div role="alert" aria-live="assertive" aria-atomic="true" className="fixed bottom-4 right-4 z-50 rounded-md border border-destructive bg-destructive px-4 py-3 text-sm text-destructive-foreground shadow-md">
           ⚠️ {transitionError}
         </div>
       )}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -1142,8 +1142,10 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   <Loader2 className="size-3.5 animate-spin" /> {t('loading')}
                 </div>
               )}
+              {/* story #2105 2차 — handleAttachFiles가 재시도 전 setAttachError(false)를 먼저
+                  호출해(위 정의) 매 시도마다 언마운트→리마운트된다. */}
               {attachError && (
-                <p className="mt-1 text-xs text-destructive">첨부 업로드에 실패했습니다. 다시 시도해 주세요.</p>
+                <p role="alert" aria-live="assertive" aria-atomic="true" className="mt-1 text-xs text-destructive">첨부 업로드에 실패했습니다. 다시 시도해 주세요.</p>
               )}
             </div>
 

--- a/apps/web/src/components/meetings/ai-summarize-button.tsx
+++ b/apps/web/src/components/meetings/ai-summarize-button.tsx
@@ -55,9 +55,10 @@ export function AiSummarizeButton({ meetingId, hasTranscript, guardedFetch, onRe
         )}
       </div>
 
-      {/* AC6: 에러 표시 (AC9: i18n) */}
+      {/* AC6: 에러 표시 (AC9: i18n) — story #2105 2차: useAiSummarize.summarize()가 재시도 전
+          setError(null)을 먼저 호출해 매 시도마다 언마운트→리마운트된다. */}
       {error && (
-        <p className="text-xs text-destructive">
+        <p role="alert" aria-live="assertive" aria-atomic="true" className="text-xs text-destructive">
           {error.includes('NO_API_KEY') ? t('aiKeyRequired')
             : error.includes('NO_TRANSCRIPT') ? t('transcriptRequired')
             : error.includes('Monthly') || error.includes('monthly') ? t('aiMonthlyLimit')

--- a/apps/web/src/components/meetings/audio-recorder.tsx
+++ b/apps/web/src/components/meetings/audio-recorder.tsx
@@ -300,10 +300,14 @@ export function AudioRecorder({
 
   return (
     <div className="rounded-lg border bg-background p-4">
-      {/* 에러 표시 */}
-      {errorCode && <p className="mb-2 text-xs text-destructive">{t(ERROR_I18N_MAP[errorCode])}</p>}
-      {sttError && <p className="mb-2 text-xs text-warning">{sttError}</p>}
-      {fileError && <p className="mb-2 text-xs text-destructive">{fileError}</p>}
+      {/* 에러 표시 — story #2105 2차. sttError/fileError는 handleStart/handleFileUpload가 재시도 전
+          null 리셋을 먼저 호출해(위 정의) 매 시도마다 언마운트→리마운트된다. errorCode(useAudioRecorder
+          훅)는 성공적으로 마이크를 획득한 뒤에만 null로 리셋되고(catch 분기는 직접 세팅), 연속 동일
+          실패(예: micDenied 반복)에서는 null 경유 없이 같은 문자열이 재설정될 수 있다 — 별도 잠재
+          결함으로 기록(훅 내부 상태머신은 이 스토리에서 재구성하지 않음). */}
+      {errorCode && <p role="alert" aria-live="assertive" aria-atomic="true" className="mb-2 text-xs text-destructive">{t(ERROR_I18N_MAP[errorCode])}</p>}
+      {sttError && <p role="alert" aria-live="assertive" aria-atomic="true" className="mb-2 text-xs text-warning">{sttError}</p>}
+      {fileError && <p role="alert" aria-live="assertive" aria-atomic="true" className="mb-2 text-xs text-destructive">{fileError}</p>}
 
       {/* 녹음 상태 (AC2 + AC11 모바일 반응형) */}
       <div className="mb-3 flex flex-wrap items-center gap-2 sm:gap-3">

--- a/apps/web/src/components/nav/create-organization-dialog.tsx
+++ b/apps/web/src/components/nav/create-organization-dialog.tsx
@@ -109,7 +109,10 @@ export function CreateOrganizationDialog({
         </DialogHeader>
         <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
           {planLimitHit && (
-            <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-3 text-sm space-y-1">
+            // story #2105 2차 — handleSubmit이 재시도 전 setPlanLimitHit(false)를 리셋하지 않는다
+            // (setError만 리셋). 같은 402 사유로 재시도해도 텍스트가 안 바뀌어 재낭독이 안 될 수
+            // 있다 — 별도 잠재 결함으로 기록(상태머신은 이 스토리에서 재구성하지 않음).
+            <div role="alert" aria-live="assertive" aria-atomic="true" className="rounded-md border border-amber-200 bg-amber-50 px-3 py-3 text-sm space-y-1">
               <p className="font-medium text-amber-800">Free 플랜 Organization 한도 초과</p>
               <p className="text-amber-700">Free 플랜은 Organization 1개까지만 생성할 수 있습니다.</p>
               {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- story a539c649 S2 오탐, invite-accept-client.tsx 주석 참고 */}
@@ -122,7 +125,9 @@ export function CreateOrganizationDialog({
             </div>
           )}
           {error && (
-            <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            // story #2105 2차 — handleSubmit이 재시도 전 setError('')를 먼저 호출해(위 정의) 매
+            // 시도마다 언마운트→리마운트된다.
+            <div role="alert" aria-live="assertive" aria-atomic="true" className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
               {error}
             </div>
           )}

--- a/apps/web/src/components/nav/profile-menu.tsx
+++ b/apps/web/src/components/nav/profile-menu.tsx
@@ -196,7 +196,9 @@ export function ProfileMenu({ name, avatarUrl }: ProfileMenuProps) {
             );
           })}
         </DropdownMenuGroup>
-        {error && <p className="px-2 py-1 text-xs text-destructive">{error}</p>}
+        {/* story #2105 2차 — handleSwitch/handleAdd이 재시도 전 setError(null)을 먼저 호출해(위
+            정의) 매 시도마다 언마운트→리마운트된다. */}
+        {error && <p role="alert" aria-live="assertive" aria-atomic="true" className="px-2 py-1 text-xs text-destructive">{error}</p>}
         <DropdownMenuSeparator />
         <DropdownMenuItem
           disabled={atCap || busy !== null}

--- a/apps/web/src/components/settings/agent-project-access-section.tsx
+++ b/apps/web/src/components/settings/agent-project-access-section.tsx
@@ -144,7 +144,14 @@ export function AgentProjectAccessSection({ agentMemberId, projects, canEdit }: 
       </SectionCardHeader>
       <SectionCardBody className="space-y-3">
         {message && (
-          <Alert variant={message.type === 'success' ? 'success' : 'destructive'}>
+          // story #2105 2차 — handleToggle이 재시도 전 setMessage(null)을 먼저 호출해(위 정의) 매
+          // 시도마다 언마운트→리마운트된다. 에러=alert/assertive, 성공=status/polite.
+          <Alert
+            variant={message.type === 'success' ? 'success' : 'destructive'}
+            role={message.type === 'success' ? 'status' : 'alert'}
+            aria-live={message.type === 'success' ? 'polite' : 'assertive'}
+            aria-atomic="true"
+          >
             <AlertDescription>{message.text}</AlertDescription>
           </Alert>
         )}

--- a/apps/web/src/components/settings/ai-settings.tsx
+++ b/apps/web/src/components/settings/ai-settings.tsx
@@ -243,8 +243,12 @@ export function AiSettingsSection({ projectId }: { projectId: string }) {
           </div>
         </div>
 
-        {error && <p className="text-xs text-destructive">{error}</p>}
-        {saved && <p className="text-xs text-success">{t('aiSettingsSaved')}</p>}
+        {/* story #2105 2차 — handleSave가 재시도 전 setError(null)/setSaved(false)를 리셋한다.
+            단, requiresNewApiKey 검증 조기-return 경로(위 handleSave 상단)는 그 리셋 前에 바로
+            setError를 호출해 동일 사유 연속 실패 시 재낭독이 안 될 수 있다 — 별도 잠재 결함으로
+            기록(상태머신은 이 스토리에서 재구성하지 않음). */}
+        {error && <p role="alert" aria-live="assertive" aria-atomic="true" className="text-xs text-destructive">{error}</p>}
+        {saved && <p role="status" aria-live="polite" aria-atomic="true" className="text-xs text-success">{t('aiSettingsSaved')}</p>}
 
         <button
           onClick={handleSave}

--- a/apps/web/src/components/settings/gate-level-matrix.tsx
+++ b/apps/web/src/components/settings/gate-level-matrix.tsx
@@ -175,7 +175,14 @@ export function GateLevelMatrix({ surface, projectId, orgId, canEdit }: GateLeve
       </SectionCardHeader>
       <SectionCardBody className="space-y-4">
         {message && (
-          <Alert variant={message.type === 'success' ? 'success' : 'destructive'}>
+          // story #2105 2차 — handleSet/handleRevert가 재시도 전 setMessage(null)을 먼저 호출해(위
+          // 정의) 매 시도마다 언마운트→리마운트된다. 에러=alert/assertive, 성공=status/polite.
+          <Alert
+            variant={message.type === 'success' ? 'success' : 'destructive'}
+            role={message.type === 'success' ? 'status' : 'alert'}
+            aria-live={message.type === 'success' ? 'polite' : 'assertive'}
+            aria-atomic="true"
+          >
             <AlertDescription>{message.text}</AlertDescription>
           </Alert>
         )}

--- a/apps/web/src/components/settings/my-profile-section.tsx
+++ b/apps/web/src/components/settings/my-profile-section.tsx
@@ -94,7 +94,9 @@ export function MyProfileSection() {
               </div>
             )}
           </div>
-          {error && <p className="text-xs text-destructive">{error}</p>}
+          {/* story #2105 2차 — handleSave가 재시도 전 setError(null)을 먼저 호출해(위 정의) 매
+              시도마다 언마운트→리마운트된다. */}
+          {error && <p role="alert" aria-live="assertive" aria-atomic="true" className="text-xs text-destructive">{error}</p>}
           <div className="flex items-center gap-4 py-2.5">
             <span className="w-20 shrink-0 text-muted-foreground">{t('profileEmail')}</span>
             <span className="text-muted-foreground">{profile.email ?? '—'}</span>

--- a/apps/web/src/components/settings/org-members-section.tsx
+++ b/apps/web/src/components/settings/org-members-section.tsx
@@ -264,7 +264,14 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
             </div>
 
             {inviteResult && (
-              <Alert variant={inviteResult.type === 'success' ? 'success' : 'destructive'}>
+              // story #2105 2차 — handleInvite가 재시도 전 setInviteResult(null)을 먼저 호출해(위
+              // 정의) 매 시도마다 언마운트→리마운트된다. 에러=alert/assertive, 성공=status/polite.
+              <Alert
+                variant={inviteResult.type === 'success' ? 'success' : 'destructive'}
+                role={inviteResult.type === 'success' ? 'status' : 'alert'}
+                aria-live={inviteResult.type === 'success' ? 'polite' : 'assertive'}
+                aria-atomic="true"
+              >
                 <AlertDescription className="break-all">{inviteResult.text}</AlertDescription>
               </Alert>
             )}
@@ -272,9 +279,18 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
         </SectionCard>
       )}
 
-      {/* 액션 메시지 */}
+      {/* 액션 메시지 — story #2105 2차. handleChangeRole/handleRemove는 재시도 전
+          setActionMessage(null)을 리셋하지만, handleCopyInviteLink의 catch 경로는 리셋 없이 바로
+          세팅한다 — 연속 동일 실패(예: 클립보드 반복 실패) 시 재낭독이 안 될 수 있다. 별도 잠재
+          결함으로 기록(상태머신은 이 스토리에서 재구성하지 않음). 에러=alert/assertive,
+          성공=status/polite. */}
       {actionMessage && (
-        <Alert variant={actionMessage.type === 'success' ? 'success' : 'destructive'}>
+        <Alert
+          variant={actionMessage.type === 'success' ? 'success' : 'destructive'}
+          role={actionMessage.type === 'success' ? 'status' : 'alert'}
+          aria-live={actionMessage.type === 'success' ? 'polite' : 'assertive'}
+          aria-atomic="true"
+        >
           <AlertDescription>{actionMessage.text}</AlertDescription>
         </Alert>
       )}

--- a/apps/web/src/components/settings/project-access-section.tsx
+++ b/apps/web/src/components/settings/project-access-section.tsx
@@ -144,7 +144,14 @@ export function ProjectAccessSection({ projectId, currentRole }: ProjectAccessSe
       </SectionCardHeader>
       <SectionCardBody className="space-y-3">
         {message && (
-          <Alert variant={message.type === 'success' ? 'success' : 'destructive'}>
+          // story #2105 2차 — handleToggle이 재시도 전 setMessage(null)을 먼저 호출해(위 정의) 매
+          // 시도마다 언마운트→리마운트된다. 에러=alert/assertive, 성공=status/polite.
+          <Alert
+            variant={message.type === 'success' ? 'success' : 'destructive'}
+            role={message.type === 'success' ? 'status' : 'alert'}
+            aria-live={message.type === 'success' ? 'polite' : 'assertive'}
+            aria-atomic="true"
+          >
             <AlertDescription>{message.text}</AlertDescription>
           </Alert>
         )}

--- a/apps/web/src/components/settings/set-password-section.tsx
+++ b/apps/web/src/components/settings/set-password-section.tsx
@@ -80,7 +80,14 @@ export function SetPasswordSection() {
       </SectionCardHeader>
       <SectionCardBody className="space-y-4">
         {message && (
-          <p className={`text-sm ${message.type === 'success' ? 'text-success' : 'text-destructive'}`}>
+          // story #2105 2차 — handleSubmit이 재시도 전 setMessage(null)을 먼저 호출해(위 정의) 매
+          // 시도마다 언마운트→리마운트된다. 에러=alert/assertive, 성공=status/polite.
+          <p
+            role={message.type === 'success' ? 'status' : 'alert'}
+            aria-live={message.type === 'success' ? 'polite' : 'assertive'}
+            aria-atomic="true"
+            className={`text-sm ${message.type === 'success' ? 'text-success' : 'text-destructive'}`}
+          >
             {message.text}
           </p>
         )}

--- a/apps/web/src/components/settings/two-factor-section.tsx
+++ b/apps/web/src/components/settings/two-factor-section.tsx
@@ -105,7 +105,15 @@ export function TwoFactorSection() {
       </SectionCardHeader>
       <SectionCardBody className="space-y-4">
         {message && (
-          <p className={`text-sm ${message.type === 'success' ? 'text-success' : 'text-destructive'}`}>{message.text}</p>
+          // story #2105 2차 — handleSetup/handleVerify/handleDisable이 재시도 전 setMessage(null)을
+          // 먼저 호출해(위 정의) 매 시도마다 언마운트→리마운트된다. 에러=alert/assertive,
+          // 성공=status/polite.
+          <p
+            role={message.type === 'success' ? 'status' : 'alert'}
+            aria-live={message.type === 'success' ? 'polite' : 'assertive'}
+            aria-atomic="true"
+            className={`text-sm ${message.type === 'success' ? 'text-success' : 'text-destructive'}`}
+          >{message.text}</p>
         )}
 
         {state === 'disabled' && (


### PR DESCRIPTION
## Summary
- Story #2105 phase 2 (follow-up to #2399, phase 1: login/register/reset-password auth screens).
- Reuses the phase-1 pattern exactly: error feedback gets `role="alert" aria-live="assertive" aria-atomic="true"`, success/info feedback gets `role="status" aria-live="polite" aria-atomic="true"`, applied directly to the conditionally-rendered element (not an always-mounted wrapper) so screen readers reliably re-announce.
- 24 of the 26 listed files changed. `agents-dashboard.tsx` is a genuine false positive (see below) — 0 changes.
- The 26th file: the task's listed paths only enumerated 25 distinct files (recount included), so "24 fixed + 1 false positive = 25 reviewed" fully accounts for the list as given. Flagging this count discrepancy for the PO/story author in case a 26th path was meant to be included but got dropped from the list.

## Files changed (24, by area)
- `recruiter-client.tsx`: `equipError`/`recruitError`/`rotateError` (alert), `roleError`/`runtimeCapabilitiesError` load-failure banners with retry (alert), `equipCreatedTitle` success block (status).
- `settings/page.tsx`: `orgNameError` (alert), `projectActionMessage` union (dynamic role by `type`), per-member `webhookErrors` (alert).
- `invite/page.tsx`: `preview-error` state (alert — genuine post-mount async transition, unlike reset-password's static `invalidLink`), `success` state (status), inline auth-form `errorMsg` (alert).
- `mfa/page.tsx`, `onboarding-form.tsx`, `ai-summarize-button.tsx`, `add-participant-modal.tsx`, `new-conversation-modal.tsx`, `my-profile-section.tsx`, `profile-menu.tsx`: standard single `error` (alert).
- `connect-step.tsx`: only the `verified` success banner (status) — the artifact pending/error skeleton was judged NOT a clean match (see false-positive-adjacent notes below).
- `agent-run-detail.tsx`: `loadError` full-screen fallback (alert) — the `run.status === 'failed'` `Alert` was excluded (historical run record, not feedback for a just-taken action).
- `chat-input.tsx`: `uploadFailed`/`sendFailed` (alert) — `atMaxAttachments` and the unsupported-runtime warning excluded (persistent hints, not operation results).
- `kanban-board.tsx`: `transitionError` (alert). `story-detail-panel.tsx`: `attachError` (alert).
- `audio-recorder.tsx`: `errorCode`/`sttError`/`fileError` (alert).
- `create-organization-dialog.tsx`: `error` (alert) + `planLimitHit` (alert).
- `settings/{agent-project-access,ai-settings,gate-level-matrix,org-members,project-access,set-password,two-factor}-section.tsx`: union `message` (dynamic role) or static `error`/`saved`.

## Skipped as false positive
- `agents-dashboard.tsx`: was in the original grep match set, but every genuine operation-result message here routes through the shared `Toast` component (already covered by story #2096 / PR #2398). The remaining conditional blocks (`latestFailure`, `recoveryCues`) are historical/log displays ("last failure was X") and persistent status cards, not feedback for something the user just did — matches the explicit false-positive carve-out in the story brief. Zero changes.

## Latent gaps found (not fixed — flagged per story instructions, not silently restructured)
Several files set the error/message state directly on failure without a `setX(null)` reset immediately before the *specific* retry path that can hit the same failure twice in a row, meaning two consecutive identical messages might not force a DOM mutation and thus might not re-announce:
- `kanban-board.tsx` `transitionError`: only auto-clears via a 4s `setTimeout`, no explicit reset-before-retry in `handleDragEnd`/`handleChangeStatus`/`handleCreateStory`.
- `audio-recorder.tsx` `errorCode` (in `useAudioRecorder` hook): the `getUserMedia` failure branch sets the error code directly without a null reset first.
- `create-organization-dialog.tsx` `planLimitHit`: `handleSubmit` resets `error` but not this flag before retrying.
- `ai-settings.tsx`: the `requiresNewApiKey` early-return validation path sets `error` before the `setError(null)` reset that follows it.
- `org-members-section.tsx` `actionMessage`: `handleCopyInviteLink`'s catch path sets the message without a prior reset.

## Test coverage
- **Added test cases** (2 files that already had jsdom component-mount scaffolding):
  - `invite/page.test.tsx`: new `preview-error` (role="alert") and signup-success (role="status") cases.
  - `kanban-board.test.tsx`: new story-create-failure banner (role="alert") case.
- **Not covered** (22 files): none had existing jsdom component-mount test scaffolding — several `.test.tsx` files that exist for some of these components (e.g. `recruiter-client.test.tsx`, `connect-step.test.tsx`, `chat-input.test.ts`) only test extracted pure functions, not the rendered component. Per the story's test-coverage convention, did not build new heavyweight mount infrastructure (Provider stacks, dnd-kit, modals, multi-fetch mocks) for these — verified the `setX(null/false)`-before-retry remount invariant by code review instead, and the attributes were applied following the exact same pattern already covered by the phase-1 (`login/page.test.tsx`) and the two new test cases in this PR.

## Rebase-gate (2026-07-23, 30h stale — PO 지시로 develop 위 재검증)
CI was originally green against a 07-21 base; that green was not trusted after ~30h of unrelated develop churn (per repo discipline: stale-base green ≠ current green).

- **Rebase**: onto `origin/develop`(`11a19c83`) — clean, no conflicts.
- **File-overlap check with today's FE work** (#2413 kanban SSE · #2417 panel SSE sync · #2422 mux stability · #2428 authz mount tests) that also touched `kanban-board.tsx`/`story-detail-panel.tsx`/`kanban-board.test.tsx`: diffed each overlapping file's changes individually before rebasing — this PR's changes are isolated, additive attribute/role changes in unrelated line ranges (e.g. the `transitionError` banner div, the `attachError` paragraph) with zero collision with today's SSE-handler/state-patch logic.
- **⚠️Found and fixed a genuine flaky test** (not present in original 07-21 CI, only reproduces under full-suite parallel load): the new `kanban-board.test.tsx` "생성 실패 시 role=alert" case waited a fixed `await Promise.resolve()` × 2 after dispatching the create-failure keyboard event. That fixed tick count is marginal for the real microtask chain (`onKeyDown → submitCompose[fire-and-forget] → await onCreateStory → await fetch → submitCompose resume`) — passes reliably when the file runs alone, but failed intermittently (2/3 runs) when the full 287-file suite runs under parallel-worker CPU contention. Replaced the fixed wait with a bounded DOM-condition poll. **Verified: full suite run 7× consecutively after the fix, 7/7 pass** (vs. 2/3 fail before). Root-cause note: initially suspected an orphaned `setTimeout` (this component has real 4s timers elsewhere), but `handleCreateStory`'s failure path doesn't use `setTimeout` at all — the actual cause was the fixed-tick race, confirmed by reproducing and fixing it directly.

## Story #2105 AC5/AC6 — checked against this PR's actual delivery (PO request, not just "24 screens fixed ⇒ auto-closed")
- **AC5** ("2차 범위를 목록으로 남기고 우선순위를 기록") — largely pre-satisfied by the story description itself (the "숫자 정정" section already splits scope into this story's 26 items vs. #2109's ambiguous set) before this PR existed. This PR's own count discrepancy (26 listed vs. 25 distinct paths reviewed, flagged above) is the one open loose end under AC5 — not resolved by this PR, just surfaced.
- **AC6** ("검색 기준을 갱신 — text-destructive로 못 잡는 표면이 있으면 더 나은 기준으로 다시 훑거나, 없으면 '이 기준으로 이만큼'이라고 명시") — **not addressed anywhere in this PR** (verified: zero mentions of search-criteria/methodology update in the PR body). This is a genuine gap, not just an omission in the write-up — the PR never revisits or discusses the `text-destructive`-based grep's known blind spots (differently-styled errors, success/info messages outside that pattern). Flagging for PO — may need a follow-up story or an explicit "criterion unchanged, documented limitation stands" closing note before #2105 itself is marked done.

## Gate results (from worktree root)
- `pnpm --filter web type-check` — **0 errors**
- `pnpm --filter web lint` — **0 errors, 5 pre-existing warnings in unrelated files never touched by this PR** (`e2e/retro-detailed.spec.ts`, `docs/[slug]/page.tsx`, `lib/storage/format.ts`)
- `pnpm test` (root vitest, full repo) — **299 test files passed, 2043 tests passed, 2 skipped, 0 failed**
- `pnpm --filter web build` — **EXIT 0**

## Test plan
- [x] type-check clean
- [x] lint clean (no new warnings)
- [x] full vitest suite green
- [x] production build succeeds
- [ ] QA (까심) review — do not merge without QA sign-off per repo convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
