### PR TITLE
fix(E-ARCH 0단계): story #2078 — useChatUnreadTotal이 RealtimeProvider 밖에서 호출돼 SSE mux를 못 타던 결함

### DIFF
--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -74,6 +74,57 @@ function isTabRootPage(pathname: string): boolean {
   return TAB_ROOT_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`));
 }
 
+// story #2078(E-ARCH 0단계) 결함수정 — AppSidebar/ScrollShell이 필요로 하는 chatUnreadTotal을
+// 예전엔 DashboardShell 함수 바디 최상단(<RealtimeProvider> JSX 인스턴스화 *이전*)에서
+// useChatUnreadTotal()로 계산했다. 그 훅이 내부에서 useChatSse → useSseMultiplexerContext()를
+// 부르는데, React Context는 실제 렌더 트리상 Provider의 자식에게만 전파된다 — 이 호출은
+// Provider의 형제/조상 위치에서 실행되므로 mux가 항상 null이 되어, 플래그 값과 무관하게
+// 이 경로만 영구히 독립 EventSource 폴백을 탔다(민군 실측: 탭당 2연결, 그중 하나가 이 경로).
+// AppSidebar·ScrollShell은 이미 <RealtimeProvider> 자식이므로, 이 래퍼를 그 안에 두고
+// 훅 호출도 함께 옮기면 mux 컨텍스트를 정상적으로 받는다(chat-list-view.tsx·chat-view.tsx의
+// useChatSse 호출과 동일한 위치 조건이 된다).
+function ShellBody({
+  currentTeamMemberId, showTopBar, tabletCentered, orgId, orgMemberships, projectId, projectMemberships,
+  currentProjectSlug, userName, children,
+}: {
+  currentTeamMemberId?: string;
+  showTopBar: boolean;
+  tabletCentered: boolean;
+  orgId?: string;
+  orgMemberships: OrgSwitcherItem[];
+  projectId?: string;
+  projectMemberships: DashboardProjectOption[];
+  currentProjectSlug?: string;
+  userName?: string;
+  children: React.ReactNode;
+}) {
+  const chatUnreadTotal = useChatUnreadTotal(currentTeamMemberId);
+  return (
+    <>
+      <AppSidebar
+        projectId={projectId}
+        currentProjectSlug={currentProjectSlug}
+        projectMemberships={projectMemberships}
+        orgId={orgId}
+        orgMemberships={orgMemberships}
+        userName={userName}
+        chatUnreadTotal={chatUnreadTotal}
+      />
+      <ScrollShell
+        showTopBar={showTopBar}
+        tabletCentered={tabletCentered}
+        chatUnreadTotal={chatUnreadTotal}
+        orgId={orgId}
+        orgMemberships={orgMemberships}
+        projectId={projectId}
+        projectMemberships={projectMemberships}
+      >
+        {children}
+      </ScrollShell>
+    </>
+  );
+}
+
 function ScrollShell({
   showTopBar, tabletCentered, chatUnreadTotal, orgId, orgMemberships, projectId, projectMemberships, children,
 }: {
@@ -229,11 +280,9 @@ export function DashboardShell({
   // 리다이렉트 안전망이 받는다). 완전 동기화는 이 슬라이스 스코프 밖(over-engineering).
 
   // story #2007(perf·서버부하): GNB 채팅 unread 총합을 AppSidebar+MobileTabBar가 각자
-  // useChatUnreadTotal()을 호출해 SSE(EventSource) 연결을 독립적으로 2개 열던 것을 여기 한
-  // 곳에서만 계산해 두 표면에 값만 prop으로 내려준다 — 동일 유저 event-stream 동시 연결
-  // 4개(presence·notifications·GNB×2) 중 2개를 1개로 줄인다(배지 값은 뷰포트 무관 동일해야
-  // 하므로 공유가 정확도 손실 없이 순수 절감).
-  const chatUnreadTotal = useChatUnreadTotal(currentTeamMemberId);
+  // useChatUnreadTotal()을 호출해 SSE(EventSource) 연결을 독립적으로 2개 열던 것을 한
+  // 곳에서만 계산해 두 표면에 값만 prop으로 내려준다. story #2078 결함수정(위 ShellBody 주석
+  // 참고) — 이 훅 호출은 <RealtimeProvider> 자식 위치(ShellBody 안)로 옮겨졌다.
 
   return (
     <DashboardCtx.Provider value={{ currentTeamMemberId, orgId: effectiveOrgId, projectId: effectiveProjectId, projectName: effectiveProjectName, currentProjectSlug, userName, role, currentMemberType, projectMemberships, orgMemberships }}>
@@ -241,26 +290,19 @@ export function DashboardShell({
       <RealtimeProvider currentTeamMemberId={currentTeamMemberId}>
         <TopBarProvider>
           <SidebarProvider className="h-svh">
-            <AppSidebar
-              projectId={effectiveProjectId}
-              currentProjectSlug={currentProjectSlug}
-              projectMemberships={projectMemberships}
-              orgId={effectiveOrgId}
-              orgMemberships={orgMemberships}
-              userName={userName}
-              chatUnreadTotal={chatUnreadTotal}
-            />
-            <ScrollShell
+            <ShellBody
+              currentTeamMemberId={currentTeamMemberId}
               showTopBar={showTopBar}
               tabletCentered={tabletCentered}
-              chatUnreadTotal={chatUnreadTotal}
               orgId={effectiveOrgId}
               orgMemberships={orgMemberships}
               projectId={effectiveProjectId}
               projectMemberships={projectMemberships}
+              currentProjectSlug={currentProjectSlug}
+              userName={userName}
             >
               {children}
-            </ScrollShell>
+            </ShellBody>
           </SidebarProvider>
         </TopBarProvider>
         <SessionExpiredDialog />

--- a/apps/web/src/hooks/use-chat-unread-total.test.tsx
+++ b/apps/web/src/hooks/use-chat-unread-total.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+//
+// story #2078(E-ARCH 0단계) 결함수정 회귀가드 — 민군 실측: 탭당 EventSource가 1개가 아니라
+// 2개 열렸다(mux 1 + 독립 폴백 1). 근본은 useChatUnreadTotal이 예전엔 dashboard-shell.tsx의
+// <RealtimeProvider> JSX 인스턴스화 *이전*(함수 바디 최상단)에서 호출됐다는 것 — React
+// Context는 Provider의 자식에게만 전파되므로, 그 위치의 호출은 useSseMultiplexerContext()가
+// 항상 null을 받아 플래그 값과 무관하게 영구히 독립 EventSource 폴백을 탔다.
+//
+// 이 테스트는 정확히 그 계약을 고정한다: useChatUnreadTotal이 <RealtimeProvider> 자식으로
+// 렌더되면(수정 후 dashboard-shell.tsx의 ShellBody와 동일 조건) mux 공유 커넥션 하나만 열리고,
+// 독립 EventSource는 생기지 않는다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+type SseListener = (e: { data: string; lastEventId?: string }) => void;
+
+interface FakeInstance {
+  url: string;
+  listeners: Record<string, SseListener[]>;
+  onopen: (() => void) | null;
+  onmessage: SseListener | null;
+  onerror: (() => void) | null;
+  closed: boolean;
+}
+
+let instances: FakeInstance[] = [];
+
+function stubEventSource() {
+  class FakeEventSource {
+    handle: FakeInstance;
+    constructor(url: string) {
+      this.handle = { url, listeners: {}, onopen: null, onmessage: null, onerror: null, closed: false };
+      instances.push(this.handle);
+    }
+    set onopen(cb: (() => void) | null) { this.handle.onopen = cb; }
+    get onopen() { return this.handle.onopen; }
+    set onmessage(cb: SseListener | null) { this.handle.onmessage = cb; }
+    get onmessage() { return this.handle.onmessage; }
+    set onerror(cb: (() => void) | null) { this.handle.onerror = cb; }
+    get onerror() { return this.handle.onerror; }
+    addEventListener(_name: string, _cb: SseListener) { /* not needed for this test */ }
+    close() { this.handle.closed = true; }
+  }
+  vi.stubGlobal('EventSource', FakeEventSource);
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  instances = [];
+  stubEventSource();
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ count: 0 }) })) as unknown as typeof fetch);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+describe('useChatUnreadTotal — story #2078 결함수정(Provider 자식 위치 고정)', () => {
+  it('<RealtimeProvider>(mux ON) 자식으로 렌더되면 독립 EventSource를 열지 않고 mux 커넥션 1개만 공유한다', async () => {
+    vi.resetModules();
+    vi.stubEnv('NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED', 'true');
+    const { RealtimeProvider } = await import('@/components/realtime-provider');
+    const { useChatUnreadTotal } = await import('./use-chat-unread-total');
+
+    function Consumer() {
+      useChatUnreadTotal('member-1');
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        <RealtimeProvider currentTeamMemberId="member-1">
+          <Consumer />
+        </RealtimeProvider>,
+      );
+    });
+
+    // RealtimeProvider 자신의 mux 커넥션 1개만 존재해야 한다 — Consumer(=useChatUnreadTotal)가
+    // 별도로 독립 EventSource를 열면 이 회귀가 재현된 것(수정 전 상태).
+    expect(instances).toHaveLength(1);
+  });
+
+  it('Provider 밖(컨텍스트 기본값 null)에서 렌더되면 독립 EventSource로 폴백한다 — 폴백 경로 자체는 유효', async () => {
+    vi.resetModules();
+    vi.stubEnv('NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED', 'true');
+    const { useChatUnreadTotal } = await import('./use-chat-unread-total');
+
+    function StandaloneConsumer() {
+      useChatUnreadTotal('member-1');
+      return null;
+    }
+
+    await act(async () => {
+      root.render(<StandaloneConsumer />);
+    });
+
+    // Provider 밖이므로 mux 컨텍스트가 없다 — 이 경우엔 독립 연결이 "의도된" 폴백이다
+    // (플래그 OFF와 동일하게 취급). 즉 결함은 "폴백이 존재한다"가 아니라 "정상 위치에서도
+    // 폴백을 탄다"였다 — 위 첫 테스트가 그 축을 고정한다.
+    expect(instances).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- 민군 실측(dev-app, mux ON): 탭당 EventSource **2개**(기대 1), StrictMode 배제, 서로 다른 코드경로(`r@chunk37551:1941` · `e@chunk37551:4879`). PO 빌드시각 확인(bundle 01756-26b > PR#2382 머지)으로 "재배포 안 됨"은 배제됨.
- **근본**: `dashboard-shell.tsx`의 `const chatUnreadTotal = useChatUnreadTotal(currentTeamMemberId);`가 `<RealtimeProvider>` JSX 인스턴스화 *이전*(DashboardShell 함수 바디 최상단)에서 실행되고 있었다. `useChatUnreadTotal` → `useChatSse` → `useSseMultiplexerContext()` 순으로 mux를 읽는데, React Context는 실제 렌더 트리상 Provider의 **자식**에게만 전파된다 — 이 호출 위치는 Provider의 형제/조상이라 `mux`가 항상 `null`, 플래그 값과 무관하게 영구히 독립 EventSource 폴백을 탔다.
- 같은 `useChatSse`가 `chat-list-view.tsx`·`chat-view.tsx`에서도 불리지만 그건 `{children}`(Provider 자식) 안이라 정상 동작 — **이 한 자리만** 구조결함이었다. `useChatSse`·`useSseNotifications`·`useTeamPresence` 전체 호출처를 grep해 다른 Provider-밖 호출이 없음을 확인(민군 관측 "2개"와 정확히 일치 — 고치면 1개가 되어야 함).

## Fix
- `chatUnreadTotal` 계산(useChatUnreadTotal 호출)을 `<RealtimeProvider>` 자식 위치로 옮긴 내부 래퍼(`ShellBody`)를 신설. `AppSidebar`·`ScrollShell`도 함께 그 안으로 이동 — 두 컴포넌트에 넘기던 다른 prop은 그대로 pass-through만 (최소변경, 정공법).

## Test
- `apps/web/src/hooks/use-chat-unread-total.test.tsx`(신규): `useChatUnreadTotal`이 `<RealtimeProvider>` 자식으로 렌더되면 mux 커넥션 1개만 공유(독립 EventSource 안 엶), Provider 밖에서는 의도된 독립 폴백을 확인.
- 기존 `sse-multiplexer.test.tsx`(story #2078 phase1)와 함께 회귀 없음 확인.

## Gates (worktree root, fresh `pnpm install`)
- `pnpm type-check` — 0 errors
- `pnpm lint` — 0 errors, 5 pre-existing warnings (이 PR 미터치 파일)
- `pnpm vitest run` (관련 파일) — 10 passed
- `pnpm build` — exit 0

## Verification plan
- 코드 리뷰는 PO(오르테가)가 진단·설계 단계에서 이미 확인(승인 GO).
- dev 배포 후 **민군이 EventSource 개수 재측정(2→1)**으로 최종 close.

Story #2078.