### PR TITLE
feat(#2120 AC2): online liveness to Redis TTL key (last_seen_at injection)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -112,6 +112,11 @@ class Settings(BaseSettings):
     # redis_url None/Redis 다운 시 in-memory 로 fail-open(presence=non-critical UI degrade). 롤백=off.
     presence_redis_enabled: bool = False
 
+    # #2120 AC2(2026-07-22): online liveness(30s SSE-틱 hot-path DB write)를 Redis TTL 키로.
+    # §2 presence_redis_enabled 와 **독립** kill switch — AC2 롤백이 검증완료 §2(working)를 끄지
+    # 않게. AC2는 disconnect 판정·reachability(메시지 배달 경로)까지 건드리므로 격리 필수. 기본 off.
+    presence_online_redis_enabled: bool = False
+
     # E-ARCH S2 정리(2026-07-21, LISTEN 제거 완료 후 발견): redis_consume_loop task 생성이
     # event_broker_redis_dual_publish_enabled 하나로만 게이트돼 있었다 — dual_publish(발행,
     # 모든 인스턴스가 필요)와 consume(구독+dispatch, SSE를 실제로 서빙하는 서비스만 필요)

--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -84,31 +84,61 @@ async def _mark_agent_disconnected(
     (schema 단락). MCP heartbeat·재연결 시 online 복귀(self-heal). finally 호출이라 예외 비전파.
     """
     now = datetime.now(timezone.utc)
-    fresh_cutoff = now - timedelta(seconds=_SESSION_FRESH_TTL)
+    from app.core.config import settings as _settings
+    _ac2 = bool(_settings.presence_online_redis_enabled) and bool(_settings.redis_url)
     try:
         async with async_session_factory() as db:
-            # 이 세션 + 같은 에이전트의 좀비 세션(크래시로 finally 미실행 → last_seen stale) 정리.
-            # 멀티인스턴스서 테이블 무한증식 방지 + 아래 "잔여 활성" 판정을 신뢰 가능하게.
-            await db.execute(
-                delete(AgentGatewaySession).where(
-                    (AgentGatewaySession.id == session_id)
-                    | (
-                        (AgentGatewaySession.agent_id == agent_id)
-                        & (AgentGatewaySession.last_seen_at < fresh_cutoff)
+            if _ac2:
+                # #2120 AC2: 30s틱 제거로 session.last_seen_at freshness가 무의미해짐 → liveness를 Redis
+                # online 키로 판정(freshness 소비처 #1 좀비GC·#2 remaining 회귀 방지).
+                from app.services import presence_online
+                await db.execute(
+                    delete(AgentGatewaySession).where(AgentGatewaySession.id == session_id)
+                )
+                online = await presence_online.is_online(agent_id)  # True/False/None
+                if online is False:
+                    # Redis: 이 agent 라이브 연결 0 → 남은 세션 행은 leaked(크래시 잔재) → 정리 + 강등.
+                    await db.execute(
+                        delete(AgentGatewaySession).where(AgentGatewaySession.agent_id == agent_id)
+                    )
+                    remaining = None
+                elif online is True:
+                    remaining = True  # 라이브 형제 연결(틱 중) 있음 → offline 강등/clear 안 함(#2 회귀 방지)
+                else:
+                    # Redis 다운(None) → 세션-row **존재**(freshness 아님)로 폴백=fail-open. 좀비 GC skip(row 보존).
+                    remaining = (await db.execute(
+                        select(AgentGatewaySession.id).where(
+                            AgentGatewaySession.agent_id == agent_id,
+                            AgentGatewaySession.id != session_id,
+                        ).limit(1)
+                    )).scalar_one_or_none()
+            else:
+                # 기존 freshness 경로(30s틱 유지·flag off·무회귀).
+                fresh_cutoff = now - timedelta(seconds=_SESSION_FRESH_TTL)
+                await db.execute(
+                    delete(AgentGatewaySession).where(
+                        (AgentGatewaySession.id == session_id)
+                        | (
+                            (AgentGatewaySession.agent_id == agent_id)
+                            & (AgentGatewaySession.last_seen_at < fresh_cutoff)
+                        )
                     )
                 )
-            )
-            remaining = (await db.execute(
-                select(AgentGatewaySession.id).where(
-                    AgentGatewaySession.agent_id == agent_id,
-                    AgentGatewaySession.last_seen_at >= fresh_cutoff,
-                ).limit(1)
-            )).scalar_one_or_none()
+                remaining = (await db.execute(
+                    select(AgentGatewaySession.id).where(
+                        AgentGatewaySession.agent_id == agent_id,
+                        AgentGatewaySession.last_seen_at >= fresh_cutoff,
+                    ).limit(1)
+                )).scalar_one_or_none()
             if remaining is None:
                 from app.services.agent_anchor_sync import sync_agent_profile_presence
                 await sync_agent_profile_presence(
                     db, agent_id, last_seen_at=None, agent_status="offline"
                 )
+                if _ac2:
+                    # AC2: online 키 DEL(90s 잔존 방지·즉시 offline 규약 유지). flag off면 no-op.
+                    from app.services import presence_online
+                    await presence_online.clear_online(agent_id)
                 # d5de8e08 안전망: 연결 완전 종료 → 이 에이전트의 chat working 신호도 즉시 정리
                 # (offline 인데 "...typing" 잔존 방지·TTL backstop 기다리지 않음).
                 from app.services import chat_presence
@@ -379,6 +409,10 @@ async def agent_stream(
                 )
                 await _pdb.commit()
             _presence_wired = True
+            # #2120 AC2: 연결 즉시 online 키 SET(타노드 GET서 즉시 online 가시). flag off면 no-op.
+            # connect DB write(위 세션 INSERT + profile online)는 내구/폴백용으로 유지.
+            from app.services import presence_online
+            await presence_online.mark_online(agent_id)
             # R2(da9d1781): 연결 online 진입 → presence SSE 발행(FE 3s 폴링 대체·best-effort).
             from app.services.presence_events import emit_presence
             emit_presence(org_id_str)
@@ -407,7 +441,13 @@ async def agent_stream(
             while not await request.is_disconnected():
                 _now = datetime.now(timezone.utc)
                 if (_now - last_presence_tick).total_seconds() >= _PRESENCE_TICK_INTERVAL:
-                    await _mark_agent_online(agent_id, session_id)
+                    from app.core.config import settings as _settings
+                    if _settings.presence_online_redis_enabled and _settings.redis_url:
+                        # #2120 AC2: online liveness를 Redis 키로 — hot-path DB write 0.
+                        from app.services import presence_online
+                        await presence_online.mark_online(agent_id)
+                    else:
+                        await _mark_agent_online(agent_id, session_id)  # 기존 DB 틱(flag off·무회귀)
                     last_presence_tick = _now
                 get_task = asyncio.create_task(queue.get())
                 shutdown_task = asyncio.create_task(_shutdown_module.shutdown_event.wait())

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -31,10 +31,33 @@ class ClaimBody(BaseModel):
     project_id: uuid.UUID | None = None
 
 
+def _override_online(resp: TeamMemberResponse, ts: "str | None") -> TeamMemberResponse:
+    """#2120 AC2: Redis online 키 ts 있으면 last_seen_at 을 그 값으로 override → computed_field
+    presence_status 가 online 을 도출(status 를 직접 주입하지 않아 3상태·AC7 로직 무변경). ts 없음/
+    파싱실패 → 원본(DB last_seen_at 폴백·flag off/Redis 다운 시 자연 폴백)."""
+    if not ts:
+        return resp
+    try:
+        return resp.model_copy(update={"last_seen_at": datetime.fromisoformat(ts)})
+    except (ValueError, TypeError):
+        return resp
+
+
+async def _inject_online_single(resp: TeamMemberResponse, member_id) -> TeamMemberResponse:
+    """단건 응답용 #2120 AC2 online 주입(목록/단건 presence 불일치 방지)."""
+    from app.services import presence_online
+
+    om = await presence_online.get_online_map([member_id])
+    return _override_online(resp, om.get(str(member_id)))
+
+
 async def _inject_active_stories(
     members: list, session: AsyncSession
 ) -> list[TeamMemberResponse]:
-    """AC6: active_story_id → stories batch 조회 후 inject."""
+    """AC6: active_story_id → stories batch 조회 후 inject.
+
+    #2120 AC2: online 키 배치조회(MGET 1회) → 있으면 last_seen_at override → computed_field online.
+    """
     ids = {m.active_story_id for m in members if m.active_story_id}
     stories: dict[uuid.UUID, Story] = {}
     if ids:
@@ -42,9 +65,13 @@ async def _inject_active_stories(
         for s in result.scalars().all():
             stories[s.id] = s
 
+    from app.services import presence_online
+    online_map = await presence_online.get_online_map([m.id for m in members])
+
     out = []
     for m in members:
         resp = TeamMemberResponse.model_validate(m)
+        resp = _override_online(resp, online_map.get(str(m.id)))
         if m.active_story_id and m.active_story_id in stories:
             s = stories[m.active_story_id]
             resp = resp.model_copy(update={
@@ -374,7 +401,7 @@ async def get_team_member(
     member = await repo.get(id)
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
-    return TeamMemberResponse.model_validate(member)
+    return await _inject_online_single(TeamMemberResponse.model_validate(member), member.id)
 
 
 _SELF_EDITABLE_HUMAN_FIELDS: frozenset[str] = frozenset({"name", "avatar_url", "color"})
@@ -436,7 +463,8 @@ async def update_team_member(
     await repo.apply_anchor_update(member, data)
     session.expire(member)
     updated = await repo.get(id)
-    return TeamMemberResponse.model_validate(updated or member)
+    _m = updated or member
+    return await _inject_online_single(TeamMemberResponse.model_validate(_m), _m.id)
 
 
 @router.patch("/{id}/heartbeat")

--- a/backend/app/services/agent_verify.py
+++ b/backend/app/services/agent_verify.py
@@ -105,7 +105,29 @@ async def start_verification(
 
 
 async def _has_fresh_session(db: AsyncSession, agent_id: uuid.UUID) -> bool:
-    """에이전트가 현재 /agent/stream 연결 중인지(= mcp_reachable). 게이트웨이의 동일 freshness TTL 사용."""
+    """에이전트가 현재 /agent/stream 연결 중인지(= mcp_reachable).
+
+    #2120 AC2: flag on 이면 30s 틱이 세션 last_seen_at 을 안 갱신하므로 freshness 가 무의미 →
+    Redis online 키(틱이 SET)로 판정. Redis 불가(None)면 세션-row **존재**로 폴백=fail-open
+    (도달성=메시지 배달 경로라 Redis 다운서도 연결중이면 reachable 유지·freshness 폴백은 fail-closed라 금지).
+    flag off 면 기존 freshness(틱 유지·무회귀).
+    """
+    from app.core.config import settings
+
+    if settings.presence_online_redis_enabled and settings.redis_url:
+        from app.services import presence_online
+
+        online = await presence_online.is_online(agent_id)
+        if online is not None:
+            return online
+        # Redis 다운 → 세션-row 존재(freshness 아님) 폴백
+        row = (await db.execute(
+            select(AgentGatewaySession.id).where(
+                AgentGatewaySession.agent_id == agent_id,
+            ).limit(1)
+        )).first()
+        return row is not None
+
     from app.routers.agent_gateway import _SESSION_FRESH_TTL  # lazy: 순환 import 회피
 
     cutoff = datetime.now(timezone.utc) - timedelta(seconds=_SESSION_FRESH_TTL)

--- a/backend/app/services/presence_online.py
+++ b/backend/app/services/presence_online.py
@@ -1,0 +1,89 @@
+"""#2120 AC2: online liveness를 Redis 키로 — 30s SSE-틱 hot-path DB write 제거.
+
+per-member online 키(값=마지막 틱 ISO ts·EX 90s). 세 소비자:
+- 라우터(team_members/team_presence): effective_last_seen 주입(Redis ts ?? DB last_seen_at) — computed_field 무변경.
+- reachability(agent_verify._has_fresh_session): 도달성 판정(키 존재)·Redis 불가 시 세션-row 존재로 폴백(fail-open).
+- 좀비 GC: Redis 부재 기반으로 게이트(live long-connection row 오삭제 방지).
+
+flag `presence_online_redis_enabled`(§2 presence_redis_enabled 와 **독립** kill switch — AC2 롤백이 검증완료
+§2 를 끄지 않게). off = 현 DB-틱 경로 그대로(무회귀). on 이라도 connect/disconnect DB write 는 유지(내구+폴백).
+"""
+from __future__ import annotations
+
+import datetime
+import logging
+import os
+
+from app.core.config import settings
+from app.services import redis_shared
+
+logger = logging.getLogger(__name__)
+
+_DOMAIN = "presence"
+# SSE 30s 틱 × 3 = 90s(2회 누락 허용·기존 _SESSION_FRESH_TTL 과 동일 근거).
+_TTL_SEC = int(os.getenv("SSE_HEARTBEAT_TIMEOUT", "30")) * 3
+
+
+def _enabled() -> bool:
+    return bool(getattr(settings, "presence_online_redis_enabled", False)) and bool(settings.redis_url)
+
+
+def _key(member_id: str) -> str:
+    return redis_shared.key(_DOMAIN, "online", str(member_id))
+
+
+async def mark_online(member_id: str) -> None:
+    """연결 라이브니스 갱신 — online 키 SET(now ISO, EX 90). off/Redis 다운 → no-op(연결/해제 DB가 폴백)."""
+    if not _enabled():
+        return
+    ts = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+    async def _op(client) -> None:
+        await client.set(_key(member_id), ts, ex=_TTL_SEC)
+
+    await redis_shared.with_fallback(_op, lambda: None)
+
+
+async def clear_online(member_id: str) -> None:
+    """마지막 disconnect — online 키 DEL(즉시 offline·90s 잔존 방지). off/다운 → no-op."""
+    if not _enabled():
+        return
+
+    async def _op(client) -> None:
+        await client.delete(_key(member_id))
+
+    await redis_shared.with_fallback(_op, lambda: None)
+
+
+async def get_online_map(member_ids) -> dict[str, str]:
+    """member_ids 중 online 키가 살아있는 것 → {member_id: ts}. 라우터 last_seen_at 주입용.
+
+    off/Redis 다운/키 부재 → 해당 member 미포함(라우터가 DB last_seen_at 로 폴백). 배치 MGET(1 라운드트립).
+    """
+    ids = [str(m) for m in member_ids]
+    if not _enabled() or not ids:
+        return {}
+
+    async def _op(client) -> dict[str, str]:
+        vals = await client.mget([_key(m) for m in ids])
+        return {m: v for m, v in zip(ids, vals) if v}
+
+    return await redis_shared.with_fallback(_op, lambda: {})
+
+
+async def is_online(member_id: str) -> "bool | None":
+    """reachability 판정 — online 키 존재 여부. True/False = Redis 판정.
+
+    **None = Redis 불가(off/다운/에러)** → 호출부가 세션-row **존재 여부**(freshness 아님)로 폴백해야 함
+    (fail-open: 도달성=메시지 배달 경로라 Redis 다운서도 연결중이면 배달 유지).
+    """
+    if not _enabled():
+        return None
+    client = redis_shared.get_client()
+    if client is None:
+        return None
+    try:
+        return bool(await client.exists(_key(member_id)))
+    except Exception:
+        logger.warning("presence_online.is_online failed → caller session-row fallback", exc_info=True)
+        return None

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -60,6 +60,7 @@ dev = [
     "httpx>=0.27.0",
     "anyio>=4.13.0",
     "pytest-anyio>=0.0.0",
+    "fakeredis>=2.20.0",
 ]
 
 [tool.pytest.ini_options]

--- a/backend/tests/test_ac2_presence_online.py
+++ b/backend/tests/test_ac2_presence_online.py
@@ -1,0 +1,103 @@
+"""#2120 AC2: presence_online (online liveness Redis 키) 단위 테스트.
+
+flag off = no-op(무회귀) · flag on = fakeredis 로 mark/get/is_online/clear 왕복 + last_seen_at 주입.
+"""
+from __future__ import annotations
+
+import datetime
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from app.services import presence_online
+
+
+@pytest.fixture
+def _flag_off():
+    with patch.object(presence_online.settings, "presence_online_redis_enabled", False):
+        yield
+
+
+@pytest.fixture
+def _flag_on_fakeredis():
+    """flag on + redis_shared.get_client → fakeredis(공유 서버)."""
+    import fakeredis.aioredis
+
+    server = fakeredis.aioredis.FakeServer()
+    client = fakeredis.aioredis.FakeRedis(server=server, decode_responses=True)
+    with patch.object(presence_online.settings, "presence_online_redis_enabled", True), \
+         patch.object(presence_online.settings, "redis_url", "redis://fake"), \
+         patch("app.services.redis_shared.get_client", return_value=client):
+        yield client
+
+
+# ── flag off = 무회귀 no-op ────────────────────────────────────────────────────
+async def test_flag_off_mark_is_noop(_flag_off):
+    await presence_online.mark_online("m1")  # 예외 없이 no-op
+
+
+async def test_flag_off_get_online_map_empty(_flag_off):
+    assert await presence_online.get_online_map(["m1", "m2"]) == {}
+
+
+async def test_flag_off_is_online_returns_none(_flag_off):
+    # None = 호출부가 세션-row 존재 폴백 신호
+    assert await presence_online.is_online("m1") is None
+
+
+# ── flag on = Redis 왕복 ───────────────────────────────────────────────────────
+async def test_mark_then_get_and_is_online(_flag_on_fakeredis):
+    m = str(uuid.uuid4())
+    await presence_online.mark_online(m)
+    om = await presence_online.get_online_map([m])
+    assert m in om
+    # 값은 ISO ts (last_seen_at 주입용)
+    datetime.datetime.fromisoformat(om[m])
+    assert await presence_online.is_online(m) is True
+
+
+async def test_clear_online_removes(_flag_on_fakeredis):
+    m = str(uuid.uuid4())
+    await presence_online.mark_online(m)
+    await presence_online.clear_online(m)
+    assert await presence_online.get_online_map([m]) == {}
+    assert await presence_online.is_online(m) is False
+
+
+async def test_get_online_map_only_present(_flag_on_fakeredis):
+    a, b = str(uuid.uuid4()), str(uuid.uuid4())
+    await presence_online.mark_online(a)  # b 는 mark 안 함
+    om = await presence_online.get_online_map([a, b])
+    assert a in om and b not in om
+
+
+# ── read 주입: _override_online ────────────────────────────────────────────────
+def _agent_resp(last_seen_at):
+    from app.schemas.team_member import TeamMemberResponse
+
+    _now = datetime.datetime.now(datetime.timezone.utc)
+    return TeamMemberResponse(
+        id=uuid.uuid4(), project_id=uuid.uuid4(), org_id=uuid.uuid4(),
+        type="agent", name="agent", role="member", is_active=True, color="#000000",
+        created_at=_now, updated_at=_now,
+        last_seen_at=last_seen_at, active_story_id=None,
+    )
+
+
+def test_override_online_injects_last_seen_at():
+    from app.routers.team_members import _override_online
+
+    old = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)  # 옛날 → offline
+    resp = _agent_resp(old)
+    assert resp.presence_status == "offline"
+    ts = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    injected = _override_online(resp, ts)
+    assert injected.presence_status == "online"  # 주입된 fresh ts → computed_field online
+
+
+def test_override_online_none_preserves_db():
+    from app.routers.team_members import _override_online
+
+    resp = _agent_resp(datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc))
+    assert _override_online(resp, None).presence_status == "offline"  # 폴백=DB 그대로

--- a/backend/tests/test_ac2_presence_online.py
+++ b/backend/tests/test_ac2_presence_online.py
@@ -106,3 +106,10 @@ def test_override_online_none_preserves_db():
 
     resp = _agent_resp(datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc))
     assert _override_online(resp, None).presence_status == "offline"  # 폴백=DB 그대로
+
+
+def test_fakeredis_is_available():
+    """가드(silent-skip 문 닫기): fakeredis dev dep 가 빠지면 위 fixture 의 importorskip 이 Redis 왕복
+    테스트를 **조용히 skip** 해 CI green인데 커버리지 0(=vacuous)이 되는 문이 열린다. 이 테스트는
+    importorskip 아니라 **plain import** 라 dep 이 빠지면 여기서 FAIL → CI red 로 즉시 드러난다."""
+    import fakeredis  # noqa: F401

--- a/backend/tests/test_ac2_presence_online.py
+++ b/backend/tests/test_ac2_presence_online.py
@@ -21,11 +21,16 @@ def _flag_off():
 
 @pytest.fixture
 def _flag_on_fakeredis():
-    """flag on + redis_shared.get_client → fakeredis(공유 서버)."""
-    import fakeredis.aioredis
+    """flag on + redis_shared.get_client → fakeredis(공유 서버).
 
-    server = fakeredis.aioredis.FakeServer()
-    client = fakeredis.aioredis.FakeRedis(server=server, decode_responses=True)
+    fakeredis 는 dev-only 테스트 의존이라 CI 이미지에 없을 수 있어 importorskip — 없으면 이 fixture 를
+    쓰는 Redis 왕복 테스트만 skip(무해). Redis 경로는 라이브 실측이 결정적으로 커버. flag-off·_override_online
+    테스트는 fakeredis 무관하게 항상 실행.
+    """
+    aioredis = pytest.importorskip("fakeredis.aioredis")
+
+    server = aioredis.FakeServer()
+    client = aioredis.FakeRedis(server=server, decode_responses=True)
     with patch.object(presence_online.settings, "presence_online_redis_enabled", True), \
          patch.object(presence_online.settings, "redis_url", "redis://fake"), \
          patch("app.services.redis_shared.get_client", return_value=client):

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -525,6 +525,19 @@ wheels = [
 ]
 
 [[package]]
+name = "fakeredis"
+version = "2.36.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/ed/86ed74d8829c3bc565025c1c9efaf8518c9165fbf8c9cc2c026c8ed21bd9/fakeredis-2.36.2.tar.gz", hash = "sha256:c37a0b307fae3f27ec7c19e59519e57b8c52782e00303df9075361b5ba441be6", size = 213336, upload-time = "2026-06-17T13:25:38.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/4d/e6e40f93031adbf654d34e542bd396e9f3bc1c6209b40c920d58c9e1317a/fakeredis-2.36.2-py3-none-any.whl", hash = "sha256:84cbb9c74ca8946c0d2499daadf3a5d0bfe3cfbac71e3398316d1a1eab3421c4", size = 141039, upload-time = "2026-06-17T13:25:36.638Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1834,6 +1847,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
 name = "sprintable-backend"
 version = "0.1.0"
 source = { virtual = "." }
@@ -1871,6 +1893,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "anyio" },
+    { name = "fakeredis" },
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-anyio" },
@@ -1913,6 +1936,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "anyio", specifier = ">=4.13.0" },
+    { name = "fakeredis", specifier = ">=2.20.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-anyio", specifier = ">=0.0.0" },


### PR DESCRIPTION
## #2120 AC2 ⓐ — online liveness Redis化 (30s hot-path DB write 제거)

E-ARCH Wave2. The 30s SSE-tick DB write (`_mark_agent_online`: 2 writes + commit per connection per tick) → Redis `SET online:{member}=<ts> EX 90`. Read layer injects `effective_last_seen = Redis ts ?? DB last_seen_at` at the router before serialization, so the `presence_status` computed_field derives all **3 states + AC7 unchanged** (last_seen_at injection, not status — no logic duplication/drift).

### Design-first (PO-reviewed, doc: e2120-ac2-online-liveness-redis-design)
Removing the tick breaks **every** last_seen_at freshness consumer — exhaustive 2-axis audit (comparison + reader):
- **#1 zombie GC** → gated on Redis online-key absence (not freshness); skipped when Redis down (fail-safe) so live long-connection rows aren't wrongly deleted.
- **#2 remaining check** → session-row **existence** (+ Redis), not freshness → multi-session agent not demoted offline while a sibling connection is live.
- **#3 `agent_verify._has_fresh_session`** → Redis `is_online` primary, session-row **existence** fallback when Redis down (**fail-open**; freshness fallback would be fail-closed on the delivery path).
- **#4 `_has_fresh_heartbeat`** (http rail) — heartbeat-written, SSE-tick-independent → untouched.
- Reader-axis: no presence-display consumer outside the injection point (computed_field via `_inject_active_stories` + single-fetch; command_center=agent_status; anchor_sync=write-sync).

Disconnect also DELs the online key (immediate offline, no 90s residual); last-disconnect keeps `last_seen_at=None`.

### No-regression / rollback
- **Independent** kill switch `presence_online_redis_enabled` (default **off**, isolated from the verified §2 `presence_redis_enabled` — AC2 rollback doesn't kill §2). Off = current DB-tick path unchanged.
- New `app/services/presence_online.py` reuses the §2 `redis_shared` foundation.

### Live 실측 (pending, required to close #2120)
§2-형 cross-node online visibility (serverIp node-separation) + reachability trio (connected delivers / disconnected not-reachable / **Redis-down delivers = fail-open**) + **multi-session regression** (2 conns → drop 1 → stays online, presence preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)