### PR TITLE
test(#2120 AC2): unit-validate ⑤/③/④/② (live blocked by #2128)

### DIFF
--- a/backend/tests/test_ac2_presence_online.py
+++ b/backend/tests/test_ac2_presence_online.py
@@ -51,6 +51,20 @@ async def test_flag_off_is_online_returns_none(_flag_off):
     assert await presence_online.is_online("m1") is None
 
 
+# ── ② Redis-down fail-open (유닛) ──────────────────────────────────────────────
+async def test_redis_down_failopen():
+    """②(유닛): flag on이나 Redis 클라이언트 None(다운) → is_online=None(호출부 세션-row 존재 폴백)·
+    get_online_map={}(라우터가 DB last_seen_at 폴백)·mark/clear no-op(예외 0). fail-open by construction.
+    (라이브 REDIS_URL 오배선 재측정은 §2 working 동반 degrade까지 보너스 관측·별도.)"""
+    with patch.object(presence_online.settings, "presence_online_redis_enabled", True), \
+         patch.object(presence_online.settings, "redis_url", "redis://x"), \
+         patch("app.services.redis_shared.get_client", return_value=None):
+        assert await presence_online.is_online("m1") is None       # 호출부 폴백 신호
+        assert await presence_online.get_online_map(["m1"]) == {}   # 라우터 DB 폴백
+        await presence_online.mark_online("m1")                     # no-op·예외 0
+        await presence_online.clear_online("m1")
+
+
 # ── flag on = Redis 왕복 ───────────────────────────────────────────────────────
 async def test_mark_then_get_and_is_online(_flag_on_fakeredis):
     m = str(uuid.uuid4())
@@ -106,6 +120,33 @@ def test_override_online_none_preserves_db():
 
     resp = _agent_resp(datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc))
     assert _override_online(resp, None).presence_status == "offline"  # 폴백=DB 그대로
+
+
+def test_three_state_idle_from_db_fallback():
+    """④(유닛): Redis 주입 없음(None)·DB last_seen_at 10분 전 → computed_field idle(3상태 보존·online 아님)."""
+    from app.routers.team_members import _override_online
+
+    ten_min = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=10)
+    resp = _agent_resp(ten_min)
+    assert resp.presence_status == "idle"                          # DB 그대로 idle
+    assert _override_online(resp, None).presence_status == "idle"  # 주입 None → 폴백 idle 보존
+
+
+def test_three_state_ac7_active_story_stays_idle():
+    """④ AC7(유닛): active_story_id 있으면 offline-time이어도 idle 유지(claim중 강등방지)·AC2 주입 後에도 보존."""
+    from app.routers.team_members import _override_online
+    from app.schemas.team_member import TeamMemberResponse
+
+    _now = datetime.datetime.now(datetime.timezone.utc)
+    old = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)  # >30분 → 원래 offline-time
+    resp = TeamMemberResponse(
+        id=uuid.uuid4(), project_id=uuid.uuid4(), org_id=uuid.uuid4(),
+        type="agent", name="a", role="member", is_active=True, color="#000000",
+        created_at=_now, updated_at=_now, last_seen_at=old,
+        active_story_id=uuid.uuid4(),  # claim 중
+    )
+    assert resp.presence_status == "idle"                          # AC7: offline 아니라 idle
+    assert _override_online(resp, None).presence_status == "idle"  # 주입 None → AC7 보존
 
 
 def test_fakeredis_is_available():

--- a/backend/tests/test_agent_gateway.py
+++ b/backend/tests/test_agent_gateway.py
@@ -436,6 +436,72 @@ async def test_mark_agent_disconnected_keeps_online_when_other_session_active():
     db.commit.assert_awaited_once()
 
 
+# ── #2120 AC2(flag on) disconnect 로직 유닛 검증 ────────────────────────────────
+# ⚠️ ⑤즉시offline·③멀티세션의 **라이브** 측정은 #2128(SSE 클라 disconnect 미감지·좀비) 때문에 불가.
+#    핸들러 로직(remaining=세션-row 존재 primary + is_online 가속)은 아래 유닛으로 결정적 검증한다.
+def _ac2_settings_patches():
+    from app.core.config import settings
+    return (patch.object(settings, "presence_online_redis_enabled", True),
+            patch.object(settings, "redis_url", "redis://x"))
+
+
+@pytest.mark.anyio
+async def test_ac2_disconnect_single_demotes_offline_immediate():
+    """⑤(유닛): flag on·마지막 연결 → remaining=세션-row 없음 → 즉시 offline + online 키 DEL.
+    is_online=True(끊는 연결 자신의 틱)여도 remaining None이면 강등 = 원버그 재발 0."""
+    s1, s2 = _ac2_settings_patches()
+    no_remaining = MagicMock(); no_remaining.scalar_one_or_none.return_value = None
+    factory, db = _patch_session_factory([MagicMock(), no_remaining])
+    with s1, s2, \
+         patch("app.routers.agent_gateway.async_session_factory", factory), \
+         patch("app.services.agent_anchor_sync.sync_agent_profile_presence", new=AsyncMock()) as mock_sync, \
+         patch("app.services.presence_online.is_online", new=AsyncMock(return_value=True)), \
+         patch("app.services.presence_online.clear_online", new=AsyncMock()) as mock_clear_online, \
+         patch("app.services.chat_presence.clear_member", new=AsyncMock(return_value=[])):
+        await _mark_agent_disconnected(AGENT_ID, uuid.uuid4())
+    mock_sync.assert_awaited_once()
+    _, kw = mock_sync.await_args
+    assert kw["agent_status"] == "offline" and kw["last_seen_at"] is None
+    mock_clear_online.assert_awaited_once()  # 마지막 연결 → 키 DEL
+
+
+@pytest.mark.anyio
+async def test_ac2_disconnect_multi_keeps_online_no_false_demote():
+    """③(유닛): flag on·2연결 중 1 종료 → remaining=형제 row 존재 → 강등/DEL 안 함(오강등 0)."""
+    s1, s2 = _ac2_settings_patches()
+    remaining = MagicMock(); remaining.scalar_one_or_none.return_value = uuid.uuid4()
+    factory, db = _patch_session_factory([MagicMock(), remaining])
+    with s1, s2, \
+         patch("app.routers.agent_gateway.async_session_factory", factory), \
+         patch("app.services.agent_anchor_sync.sync_agent_profile_presence", new=AsyncMock()) as mock_sync, \
+         patch("app.services.presence_online.is_online", new=AsyncMock(return_value=True)), \
+         patch("app.services.presence_online.clear_online", new=AsyncMock()) as mock_clear_online, \
+         patch("app.services.chat_presence.clear_member", new=AsyncMock(return_value=[])):
+        await _mark_agent_disconnected(AGENT_ID, uuid.uuid4())
+    mock_sync.assert_not_awaited()        # 형제 live → 강등 없음
+    mock_clear_online.assert_not_awaited()  # 키 DEL 없음
+
+
+@pytest.mark.anyio
+async def test_ac2_disconnect_crash_accel_demotes_via_is_online_false():
+    """크래시 가속(유닛): flag on·remaining=좀비 row 존재여도 is_online False(Redis 정상+키 없음=전부 좀비)
+    → 강등(monotonic 가속·row 규칙 위에). 크래시 수렴 3900s→~90s."""
+    s1, s2 = _ac2_settings_patches()
+    remaining = MagicMock(); remaining.scalar_one_or_none.return_value = uuid.uuid4()
+    factory, db = _patch_session_factory([MagicMock(), remaining])
+    with s1, s2, \
+         patch("app.routers.agent_gateway.async_session_factory", factory), \
+         patch("app.services.agent_anchor_sync.sync_agent_profile_presence", new=AsyncMock()) as mock_sync, \
+         patch("app.services.presence_online.is_online", new=AsyncMock(return_value=False)), \
+         patch("app.services.presence_online.clear_online", new=AsyncMock()) as mock_clear_online, \
+         patch("app.services.chat_presence.clear_member", new=AsyncMock(return_value=[])):
+        await _mark_agent_disconnected(AGENT_ID, uuid.uuid4())
+    mock_sync.assert_awaited_once()       # is_online False → remaining 강제 None → 강등
+    _, kw = mock_sync.await_args
+    assert kw["agent_status"] == "offline"
+    mock_clear_online.assert_awaited_once()
+
+
 def test_presence_tick_interval_below_online_threshold():
     """tick 주기 < online 임계(5분) — 연결 유지 중 last_seen이 online 윈도우 안에 머무름 보장."""
     from app.schemas.team_member import _ONLINE_THRESHOLD


### PR DESCRIPTION
## #2120 AC2 closure — unit validation

Per PO decision: the live ⑤/③ disconnect scenarios can't be measured on the GCE stack because SSE client-disconnect isn't surfaced to the backend (pre-existing defect, tracked separately in **#2128** — the disconnect handler never runs live). AC1(share)/AC3(cross-node) and the AC2 online read-path were **live-verified** (§2 75/75; 5-min-hold 30/30); ⑤/③ are **unit-validated** here and live-promote once #2128 is resolved.

**Disconnect handler (test_agent_gateway.py):**
- ⑤ last-disconnect → session-row-none → demote offline + DEL key (is_online True irrelevant → original bug can't recur)
- ③ multi-session → sibling row exists → no demote/no DEL (no false-demote)
- crash accel → is_online False forces demote despite a lingering row (monotonic, ~90s convergence)

**Service (test_ac2_presence_online.py):**
- ② Redis-down fail-open → is_online None + empty map + no-op (fallback to DB by construction)
- ④ 3-state + AC7 preserved through the last_seen_at injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)