### PR TITLE
docs(sse/chat): #2106+#2127 — assignee_changed transient 이유 + mention auto-promotion 의도 주석

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -1860,6 +1860,13 @@ async def send_message(
         raise HTTPException(status_code=500, detail="event dispatch failed") from _dispatch_err
 
     # AC1: 멘션 대상에게 conversation:mention SSE 발송 (participant 여부 무관)
+    #
+    # story #2127(2026-07-22, 까심군 #2090 QA 후속): "participant 여부 무관"은 group
+    # conversation 기준이다 — DM은 위 CB-S2 fork 분기(conversation_id/conv가 이미 재대입돼
+    # 있음)가 비참여자 멘션을 그룹으로 자동승격 + 참가자 편입시키므로, 이 지점에 도달할 때는
+    # DM에서 온 멘션 대상도 이미 참가자다(git log -S "CB-S2: DM" 확認, [CB-S2] PR#747, 의도된
+    # 기능·버그 아님). 즉 "진짜 비참가자에게 message_created 없이 mention만 감"이 실제로
+    # 일어나는 건 group conversation에서 기존 비참가자를 멘션하는 경우뿐이다.
     if msg.mentioned_ids:
         mention_targets = set(msg.mentioned_ids) - {sender.id} - discord_exclude_ids - blocked_agent_ids
         if mention_targets:

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -910,6 +910,16 @@ async def update_story(
         # 동일 근본) — "org-wide 의도 유지" 주석은 실제로 아무 SSE 연결에도 안 닿는 상태였다.
         # story.status_changed(story_status_events.py)와 동형으로 project_accessible_member_ids
         # 로 수신자 해소 후 _push_to_agent 개별 push — 이게 실제로 SSE 큐에 들어가는 유일 경로.
+        #
+        # story #2106(2026-07-22, 까심군 #2101 QA 후속): 이 push는 의도적으로 Event row를 안
+        # 만드는 순수 transient SSE(#2101의 last_event_id 백필 대상이 아님) — "왜 여기만
+        # 영속화 안 하지"로 다시 파지 않도록 이유를 명시한다. assignee_changed는 보드/상세
+        # 화면의 "지금 담당자가 누구인지" 실시간 동기화 신호일 뿐이고, 그 값 자체는 항상
+        # story 테이블의 assignee_id가 SSOT라 재조회(새로고침·재연결)하면 그대로 복원된다.
+        # "너에게 배정됐다"는 실제 알림 책임은 몇 줄 아래 story_assigned Event(agent)/
+        # dispatch_notification(human)이 별도로 지고 있다 — 그쪽은 Event-backed(또는 동등한
+        # 영속 알림함) 라 배정받은 사람이 그 순간 연결이 끊겨 있어도 놓치지 않는다. 즉 상태축
+        # (재조회로 복원)과 알림축(영속 전달 필요)이 분리돼 있고, 이 줄은 전자만 담당한다.
         publish_event(str(org_id), "story.assignee_changed", event_data)
         try:
             from app.routers.events import _push_to_agent


### PR DESCRIPTION
## Summary
- #2106: `story.assignee_changed`가 Event row를 생성하지 않는 이유(순수 transient push)를 명시. 상태는 `story.assignee_id`가 SSOT라 재조회로 복원되고, "배정됐다"는 실제 알림 책임은 `story_assigned`(agent, Event-backed)/`dispatch_notification`(human)이 별도로 진다는 상태축/알림축 분리를 주석으로 남김.
- #2127: 멘션 시 비참여자를 그룹으로 자동승격하는 동작(`CB-S2`)이 의도된 기능(PR#747)임을 git log로 확定. `_dispatch_mention_events`의 "participant 여부 무관" 주석이 group conversation 기준이며 DM은 이미 CB-S2가 참가자로 편입시킨 뒤라는 걸 명시.

로직 변경 0 — 주석 전용.

## Test plan
- [x] `python3 -c "import ast; ast.parse(...)"` — 두 파일 문법 확認
- [x] 주석 전용 diff, 로직/동작 변경 없음 확認(`git diff --stat` 17 insertions, 0 deletions)
- [ ] CI green 확認

🤖 Generated with [Claude Code](https://claude.com/claude-code)