### PR TITLE
fix(E-ARCH): story #2095 — SSE 재연결 backoff 상한 300초→20초, 연결지속시간 기반 리셋

### DIFF
--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -3,6 +3,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useSseMultiplexerContext } from '@/components/realtime-provider';
 import { shouldSuppressDuplicateSseEvent } from '@/lib/realtime/sse-event-dedup';
+import { createReconnectBackoffState, type ReconnectBackoffState } from '@/lib/realtime/sse-reconnect-backoff';
 
 // chat-attach: 메시지 전송 시 첨부 메타 (BE MessageAttachment 계약과 동일).
 export interface SendAttachment {
@@ -85,13 +86,15 @@ interface UseChatSseOptions {
   onReconnect?: () => void;
 }
 
-const RECONNECT_DELAYS_MS = [5_000, 30_000, 60_000, 300_000];
+// story #2095 — 재연결 backoff는 sse-reconnect-backoff.ts(공용, sse-multiplexer.ts와
+// 동일 모듈 재사용)로 뽑았다.
 
 export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, onConversationMessage, onWorking, onConversationRead, onReconnect }: UseChatSseOptions) {
   const [connected, setConnected] = useState(false);
   const sourceRef = useRef<EventSource | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const reconnectAttemptsRef = useRef(0);
+  // react-hooks/refs: 렌더 중 ref.current 조건부 대입 금지라 지연초기화는 useState(초기화 함수)로.
+  const [backoff] = useState<ReconnectBackoffState>(() => createReconnectBackoffState());
   const lastEventIdRef = useRef<string | null>(null);
   const onNewMessageRef = useRef(onNewMessage);
   const onReplyCreatedRef = useRef(onReplyCreated);
@@ -178,9 +181,9 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
       sourceRef.current = source;
 
       source.onopen = () => {
-        const isReconnect = reconnectAttemptsRef.current > 0;
+        const isReconnect = backoff.isReconnect();
         setConnected(true);
-        reconnectAttemptsRef.current = 0;
+        backoff.onOpen();
         // AC4: 재연결 시 backfill 트리거
         if (isReconnect) onReconnectRef.current?.();
       };
@@ -190,8 +193,7 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
         source.close();
         sourceRef.current = null;
         if (!reconnectTimerRef.current) {
-          const delay = RECONNECT_DELAYS_MS[Math.min(reconnectAttemptsRef.current, RECONNECT_DELAYS_MS.length - 1)];
-          reconnectAttemptsRef.current += 1;
+          const delay = backoff.onError();
           reconnectTimerRef.current = setTimeout(() => {
             reconnectTimerRef.current = null;
             connect();
@@ -241,7 +243,7 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
       sourceRef.current?.close();
       sourceRef.current = null;
     };
-  }, [mux]);
+  }, [mux, backoff]);
 
   // mux 경로에서는 로컬 connected state를 동기화하지 않고(setState-in-effect 회피) 멀티플렉서
   // 자신의 connected를 그대로 노출한다 — 이미 반응형(context 값 변경 시 이 훅도 리렌더).

--- a/apps/web/src/hooks/use-sse-notifications.ts
+++ b/apps/web/src/hooks/use-sse-notifications.ts
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from 'react';
 import { useSseMultiplexerContext } from '@/components/realtime-provider';
 import { shouldSuppressDuplicateSseEvent } from '@/lib/realtime/sse-event-dedup';
+import { createReconnectBackoffState } from '@/lib/realtime/sse-reconnect-backoff';
 
 export interface SseEventNotification {
   id?: string;
@@ -34,8 +35,8 @@ interface UseSseNotificationsOptions {
 
 const NOTIFICATION_EVENT_NAMES = ['event_notification', 'notification', 'new_notification'];
 
-// use-realtime-memos.ts와 동일한 backoff 전략(story #2078 이전 — 독립 연결 폴백 경로에서만 씀).
-const RECONNECT_DELAYS_MS = [5_000, 30_000, 60_000, 300_000];
+// story #2095 — 재연결 backoff는 sse-reconnect-backoff.ts(공용)로 뽑았다(독립 연결 폴백
+// 경로에서만 씀 — story #2078 이후 mux ON이면 이 경로 자체를 안 탄다).
 
 export function useSseNotifications({
   onNotification, memberId, enabled = true, extraEventNames, onExtraEvent,
@@ -94,8 +95,8 @@ export function useSseNotifications({
     let es: EventSource | null = null;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
     let closed = false;
-    let reconnectAttempts = 0;
     let lastEventId: string | null = null;
+    const backoff = createReconnectBackoffState();
 
     const handleDataStandalone = (raw: string, eventId?: string) => {
       if (eventId) lastEventId = eventId;
@@ -117,7 +118,7 @@ export function useSseNotifications({
 
       es = new EventSource(url.toString(), { withCredentials: true });
 
-      es.onopen = () => { reconnectAttempts = 0; };
+      es.onopen = () => { backoff.onOpen(); };
 
       es.onmessage = (e: MessageEvent<string>) => handleDataStandalone(e.data, e.lastEventId || undefined);
 
@@ -139,8 +140,7 @@ export function useSseNotifications({
         es?.close();
         es = null;
         if (!closed && !retryTimer) {
-          const delay = RECONNECT_DELAYS_MS[Math.min(reconnectAttempts, RECONNECT_DELAYS_MS.length - 1)];
-          reconnectAttempts += 1;
+          const delay = backoff.onError();
           retryTimer = setTimeout(() => {
             retryTimer = null;
             connect();

--- a/apps/web/src/lib/realtime/sse-multiplexer.ts
+++ b/apps/web/src/lib/realtime/sse-multiplexer.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { createReconnectBackoffState } from './sse-reconnect-backoff';
 
 /**
  * story #2078(E-ARCH 0단계) — presence·notification·chat이 각자 EventSource를 열어 탭당 장수
@@ -20,8 +21,8 @@ import { useCallback, useEffect, useRef, useState } from 'react';
  * dispatch 시점에 `subscribersRef`를 다시 조회하므로 attach 이후 등록된 구독자도 받는다.
  */
 
-// use-sse-notifications.ts / use-chat-sse.ts / use-team-presence.ts 전부 동일 전략 — 그대로 재사용.
-const RECONNECT_DELAYS_MS = [5_000, 30_000, 60_000, 300_000];
+// story #2095 — 재연결 backoff는 sse-reconnect-backoff.ts(공용, use-chat-sse.ts·
+// use-sse-notifications.ts 폴백 경로와 동일 모듈 재사용)로 뽑았다.
 
 type EventHandler = (data: string, eventId?: string) => void;
 
@@ -46,7 +47,6 @@ export function useSseMultiplexer(memberId: string | undefined, enabled: boolean
 
   const esRef = useRef<EventSource | null>(null);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const reconnectAttemptsRef = useRef(0);
   const lastEventIdRef = useRef<string | null>(null);
   const memberIdRef = useRef(memberId);
   useEffect(() => { memberIdRef.current = memberId; }, [memberId]);
@@ -88,6 +88,7 @@ export function useSseMultiplexer(memberId: string | undefined, enabled: boolean
     if (!enabled || typeof EventSource === 'undefined') return;
 
     let closed = false;
+    const backoff = createReconnectBackoffState();
 
     const connect = () => {
       if (closed) return;
@@ -104,8 +105,8 @@ export function useSseMultiplexer(memberId: string | undefined, enabled: boolean
       for (const eventName of namedSubscribersRef.current.keys()) attachIfNeeded(eventName);
 
       es.onopen = () => {
-        const isReconnect = reconnectAttemptsRef.current > 0;
-        reconnectAttemptsRef.current = 0;
+        const isReconnect = backoff.isReconnect();
+        backoff.onOpen();
         setConnected(true);
         if (isReconnect) for (const handler of reconnectSubscribersRef.current) handler();
       };
@@ -120,8 +121,7 @@ export function useSseMultiplexer(memberId: string | undefined, enabled: boolean
         es.close();
         if (esRef.current === es) esRef.current = null;
         if (!closed && !retryTimerRef.current) {
-          const delay = RECONNECT_DELAYS_MS[Math.min(reconnectAttemptsRef.current, RECONNECT_DELAYS_MS.length - 1)];
-          reconnectAttemptsRef.current += 1;
+          const delay = backoff.onError();
           retryTimerRef.current = setTimeout(() => {
             retryTimerRef.current = null;
             connect();

--- a/apps/web/src/lib/realtime/sse-reconnect-backoff.test.ts
+++ b/apps/web/src/lib/realtime/sse-reconnect-backoff.test.ts
@@ -1,0 +1,79 @@
+// story #2095 — 실측(30분·71회·60~68초 클러스터, dev-app 프론트 Cloud Run timeout=60초 원인,
+// 의도된 트레이드오프라 유지) 기반 재연결 backoff 계약 고정.
+//
+// 핵심 계약:
+// ① 연결이 HEALTHY_CONNECTION_MS(10초) 이상 붙어 있다가 끊기면 실패 카운트를 즉시 잊는다
+//    (정상 60초 사이클에서 backoff가 절대 안 치솟는다).
+// ② 10초 미만에 끊기면(핸드셰이크 직후 등) 실패 카운트가 유지·증가한다(서버가 진짜
+//    죽었을 때만 벌어지는 시나리오 — 그 경우도 상한 20초로 재시도 폭풍을 막는다).
+// ③ 상한은 300초→20초로 낮아졌다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createReconnectBackoffState, RECONNECT_DELAYS_MS } from './sse-reconnect-backoff';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('createReconnectBackoffState — story #2095', () => {
+  it('최초 연결이 열리기도 전에 에러가 나면(핸드셰이크 실패) 1단계 지연(1s)을 반환한다', () => {
+    const backoff = createReconnectBackoffState();
+    expect(backoff.onError()).toBe(RECONNECT_DELAYS_MS[0]);
+  });
+
+  it('핸드셰이크가 반복 실패하면(open 없이 error만) 지연이 단계적으로 상승하고 상한(20s)에서 멈춘다', () => {
+    const backoff = createReconnectBackoffState();
+    const delays = [backoff.onError(), backoff.onError(), backoff.onError(), backoff.onError(), backoff.onError()];
+    expect(delays).toEqual([1_000, 3_000, 8_000, 20_000, 20_000]);
+  });
+
+  it('연결이 10초 미만으로 붙어있다가 끊기면 — 진짜 불안정으로 보고 카운트가 계속 오른다', () => {
+    const backoff = createReconnectBackoffState();
+    expect(backoff.onError()).toBe(1_000); // 1회차: 핸드셰이크 실패
+    backoff.onOpen();
+    vi.advanceTimersByTime(5_000); // 5초만 붙어있다가 끊김(HEALTHY 10초 미만)
+    expect(backoff.onError()).toBe(3_000); // 리셋 안 되고 2단계로 계속 상승
+  });
+
+  it('연결이 10초 이상 붙어있다가 끊기면 — 정상 사이클로 보고 카운트를 즉시 잊는다', () => {
+    const backoff = createReconnectBackoffState();
+    expect(backoff.onError()).toBe(1_000); // 1회차: 핸드셰이크 실패로 카운트 상승 시작
+    expect(backoff.onError()).toBe(3_000); // 2회차
+    backoff.onOpen();
+    vi.advanceTimersByTime(10_000); // 정확히 경계값(10초) 이상 붙어있었음
+    expect(backoff.onError()).toBe(1_000); // 리셋됨 — 다시 1단계
+  });
+
+  it('60~68초 정상 사이클을 여러 번 반복해도(실측 재현) 지연이 항상 1단계(1s)로 유지된다', () => {
+    const backoff = createReconnectBackoffState();
+    for (let cycle = 0; cycle < 5; cycle++) {
+      backoff.onOpen();
+      vi.advanceTimersByTime(64_000); // 실측 평균 근사(60~68초 클러스터 중앙값)
+      expect(backoff.onError()).toBe(1_000);
+    }
+  });
+
+  it('isReconnect()는 최초 연결(에러 이력 없음)에서는 false, 에러를 한 번이라도 겪은 뒤에는 true다', () => {
+    const backoff = createReconnectBackoffState();
+    expect(backoff.isReconnect()).toBe(false);
+    backoff.onOpen(); // 최초 연결 성공 — 아직 에러 이력 없음
+    expect(backoff.isReconnect()).toBe(false);
+    backoff.onError();
+    expect(backoff.isReconnect()).toBe(true);
+    backoff.onOpen(); // 재연결 성공 — 에러 이력이 있었으므로 true 유지
+    expect(backoff.isReconnect()).toBe(true);
+  });
+
+  it('연결이 정확히 경계값 미만(9.999초)이면 여전히 불안정으로 취급한다', () => {
+    const backoff = createReconnectBackoffState();
+    backoff.onError(); // 1단계로 진입
+    backoff.onOpen();
+    vi.advanceTimersByTime(9_999);
+    expect(backoff.onError()).toBe(3_000); // 리셋 안 됨
+  });
+});

--- a/apps/web/src/lib/realtime/sse-reconnect-backoff.test.ts
+++ b/apps/web/src/lib/realtime/sse-reconnect-backoff.test.ts
@@ -7,9 +7,14 @@
 // ② 10초 미만에 끊기면(핸드셰이크 직후 등) 실패 카운트가 유지·증가한다(서버가 진짜
 //    죽었을 때만 벌어지는 시나리오 — 그 경우도 상한 20초로 재시도 폭풍을 막는다).
 // ③ 상한은 300초→20초로 낮아졌다.
+// ④ PO 리뷰(2026-07-22, E-GCE-RT S6 실측 600연결/CPU 92~97% thundering herd 근거) — 각
+//    지연에 ±20% 지터를 곱해 동시 재시도(herd)를 시간축으로 흩뿌린다.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createReconnectBackoffState, RECONNECT_DELAYS_MS } from './sse-reconnect-backoff';
+
+// 지터를 무력화(배수=1.0)해 기존 정확값 단언을 그대로 쓴다 — 0.5는 (1-0.2)+0.5*(2*0.2)=1.0.
+const NO_JITTER = () => 0.5;
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -22,18 +27,18 @@ afterEach(() => {
 
 describe('createReconnectBackoffState — story #2095', () => {
   it('최초 연결이 열리기도 전에 에러가 나면(핸드셰이크 실패) 1단계 지연(1s)을 반환한다', () => {
-    const backoff = createReconnectBackoffState();
+    const backoff = createReconnectBackoffState(NO_JITTER);
     expect(backoff.onError()).toBe(RECONNECT_DELAYS_MS[0]);
   });
 
   it('핸드셰이크가 반복 실패하면(open 없이 error만) 지연이 단계적으로 상승하고 상한(20s)에서 멈춘다', () => {
-    const backoff = createReconnectBackoffState();
+    const backoff = createReconnectBackoffState(NO_JITTER);
     const delays = [backoff.onError(), backoff.onError(), backoff.onError(), backoff.onError(), backoff.onError()];
     expect(delays).toEqual([1_000, 3_000, 8_000, 20_000, 20_000]);
   });
 
   it('연결이 10초 미만으로 붙어있다가 끊기면 — 진짜 불안정으로 보고 카운트가 계속 오른다', () => {
-    const backoff = createReconnectBackoffState();
+    const backoff = createReconnectBackoffState(NO_JITTER);
     expect(backoff.onError()).toBe(1_000); // 1회차: 핸드셰이크 실패
     backoff.onOpen();
     vi.advanceTimersByTime(5_000); // 5초만 붙어있다가 끊김(HEALTHY 10초 미만)
@@ -41,7 +46,7 @@ describe('createReconnectBackoffState — story #2095', () => {
   });
 
   it('연결이 10초 이상 붙어있다가 끊기면 — 정상 사이클로 보고 카운트를 즉시 잊는다', () => {
-    const backoff = createReconnectBackoffState();
+    const backoff = createReconnectBackoffState(NO_JITTER);
     expect(backoff.onError()).toBe(1_000); // 1회차: 핸드셰이크 실패로 카운트 상승 시작
     expect(backoff.onError()).toBe(3_000); // 2회차
     backoff.onOpen();
@@ -50,7 +55,7 @@ describe('createReconnectBackoffState — story #2095', () => {
   });
 
   it('60~68초 정상 사이클을 여러 번 반복해도(실측 재현) 지연이 항상 1단계(1s)로 유지된다', () => {
-    const backoff = createReconnectBackoffState();
+    const backoff = createReconnectBackoffState(NO_JITTER);
     for (let cycle = 0; cycle < 5; cycle++) {
       backoff.onOpen();
       vi.advanceTimersByTime(64_000); // 실측 평균 근사(60~68초 클러스터 중앙값)
@@ -59,7 +64,7 @@ describe('createReconnectBackoffState — story #2095', () => {
   });
 
   it('isReconnect()는 최초 연결(에러 이력 없음)에서는 false, 에러를 한 번이라도 겪은 뒤에는 true다', () => {
-    const backoff = createReconnectBackoffState();
+    const backoff = createReconnectBackoffState(NO_JITTER);
     expect(backoff.isReconnect()).toBe(false);
     backoff.onOpen(); // 최초 연결 성공 — 아직 에러 이력 없음
     expect(backoff.isReconnect()).toBe(false);
@@ -70,10 +75,38 @@ describe('createReconnectBackoffState — story #2095', () => {
   });
 
   it('연결이 정확히 경계값 미만(9.999초)이면 여전히 불안정으로 취급한다', () => {
-    const backoff = createReconnectBackoffState();
+    const backoff = createReconnectBackoffState(NO_JITTER);
     backoff.onError(); // 1단계로 진입
     backoff.onOpen();
     vi.advanceTimersByTime(9_999);
     expect(backoff.onError()).toBe(3_000); // 리셋 안 됨
+  });
+
+  it('지터 — random()=0(최소)이면 기본값의 80%를 반환한다', () => {
+    const backoff = createReconnectBackoffState(() => 0);
+    expect(backoff.onError()).toBe(Math.round(1_000 * 0.8));
+  });
+
+  it('지터 — random()=1(최대)이면 기본값의 120%를 반환한다', () => {
+    const backoff = createReconnectBackoffState(() => 1);
+    expect(backoff.onError()).toBe(Math.round(1_000 * 1.2));
+  });
+
+  it('지터 — 기본 Math.random()으로도 항상 [base*0.8, base*1.2] 범위 안에 든다(경계 포함, 다회 샘플)', () => {
+    const backoff = createReconnectBackoffState();
+    for (let i = 0; i < 200; i++) {
+      const delay = backoff.onError();
+      expect(delay).toBeGreaterThanOrEqual(Math.round(1_000 * 0.8));
+      expect(delay).toBeLessThanOrEqual(Math.round(1_000 * 1.2));
+      backoff.onOpen();
+      vi.advanceTimersByTime(64_000); // 매번 정상 사이클로 리셋해 항상 1단계에서 샘플링
+    }
+  });
+
+  it('지터가 있어도 동일 클라이언트 안에서 단계 자체(1→2→3→4)는 여전히 상승한다', () => {
+    const backoff = createReconnectBackoffState(NO_JITTER);
+    const delays = [backoff.onError(), backoff.onError(), backoff.onError(), backoff.onError()];
+    // NO_JITTER(배수=1.0)이므로 정확값과 동일 — 지터 로직이 단계 자체를 깨지 않는 것 확인.
+    expect(delays).toEqual([1_000, 3_000, 8_000, 20_000]);
   });
 });

--- a/apps/web/src/lib/realtime/sse-reconnect-backoff.ts
+++ b/apps/web/src/lib/realtime/sse-reconnect-backoff.ts
@@ -26,10 +26,18 @@
  * 진짜 죽어 매번 카운트가 증가)에도 누적 백오프(1+3+8+20=32초)가 정상 사이클 길이보다
  * 짧다 — 재시도 폭풍이 사이클 하나를 도는 동안 물리적으로 발생할 수 없다. 동시에 실시간
  * 공백을 기존 최악 5분에서 최악 20초로 줄인다.
+ *
+ * ⚠️ PO 리뷰(2026-07-22) — 지터(jitter) 필수: 지터 없이 상한만 낮추면 서버 재시작·순단처럼
+ * **다수 클라이언트가 동시에 끊기는** 상황에서 전부 같은 간격으로 동시 재시도해(동기화된
+ * herd) 재시도 폭풍 위험이 오히려 커진다. E-GCE-RT S6 실측(600 연결 동시 접속 시 CPU
+ * 92~97%)으로 thundering herd가 실제 문제임이 확인됐고, 상한을 15배 낮췄으니(300s→20s)
+ * 같은 herd가 15배 자주 온다 — 각 지연에 ±20% 랜덤 지터(`delay * (0.8~1.2)`)를 곱해
+ * 동시 재시도를 시간축으로 흩뿌린다.
  */
 export const RECONNECT_DELAYS_MS = [1_000, 3_000, 8_000, 20_000];
 
 const HEALTHY_CONNECTION_MS = 10_000;
+const JITTER_RATIO = 0.2; // ±20%
 
 export interface ReconnectBackoffState {
   /** EventSource가 open됐을 때 호출 — 이후 onError 판정에 쓸 시작 시각을 기록한다. */
@@ -37,11 +45,12 @@ export interface ReconnectBackoffState {
   /** 지금이 최초 연결이 아니라 재연결(과거 open 이력이 있음)인지 — backfill 트리거용.
    *  onOpen() 호출 *전에* 확인해야 정확하다(과거 이력을 묻는 질문이므로). */
   isReconnect: () => boolean;
-  /** EventSource가 error됐을 때 호출 — 다음 재시도까지 기다릴 지연(ms)을 반환한다. */
+  /** EventSource가 error됐을 때 호출 — 다음 재시도까지 기다릴 지연(ms, ±20% 지터 적용됨)을 반환한다. */
   onError: () => number;
 }
 
-export function createReconnectBackoffState(): ReconnectBackoffState {
+/** 테스트에서 결정적 값을 주입할 수 있도록 난수 소스를 분리(기본 Math.random). */
+export function createReconnectBackoffState(random: () => number = Math.random): ReconnectBackoffState {
   let attempts = 0;
   let openedAt: number | null = null;
   let hadPriorError = false;
@@ -58,9 +67,11 @@ export function createReconnectBackoffState(): ReconnectBackoffState {
       const stayedHealthy = openedAt !== null && Date.now() - openedAt >= HEALTHY_CONNECTION_MS;
       openedAt = null;
       if (stayedHealthy) attempts = 0;
-      const delay = RECONNECT_DELAYS_MS[Math.min(attempts, RECONNECT_DELAYS_MS.length - 1)]!;
+      const baseDelay = RECONNECT_DELAYS_MS[Math.min(attempts, RECONNECT_DELAYS_MS.length - 1)]!;
       attempts += 1;
-      return delay;
+      // (1-JITTER_RATIO) ~ (1+JITTER_RATIO) 범위(0.8~1.2)로 균등분포 — 동시 재시도를 흩뿌린다.
+      const jitterMultiplier = 1 - JITTER_RATIO + random() * (2 * JITTER_RATIO);
+      return Math.round(baseDelay * jitterMultiplier);
     },
   };
 }

--- a/apps/web/src/lib/realtime/sse-reconnect-backoff.ts
+++ b/apps/web/src/lib/realtime/sse-reconnect-backoff.ts
@@ -1,0 +1,66 @@
+'use client';
+
+/**
+ * story #2095 — SSE 재연결 backoff 공용 로직.
+ *
+ * 배경(실측, 2026-07-22 dev-app·gcloud logging read·realtime-gateway 30분 관측):
+ * 멤버 1명 기준 30분간 재연결 71회, 간격 분포가 60~68초 클러스터에 몰려 있다. 원인은
+ * `sprintable-frontend-*`의 Cloud Run 요청 타임아웃이 60초로 고정돼 있어서다(cloudbuild.yaml
+ * `_FRONTEND_TIMEOUT`) — frontend가 짧은 페이지 요청 기준 sizing(maxScale=3·상한 240 슬롯)이라
+ * SSE 장수연결을 오래 붙들면 그 슬롯을 페이지 요청과 다투게 만드는 병목이 생기므로, 값
+ * 인상이 아니라 브라우저→realtime 직결 설계(추후) 전까지는 **의도적으로 유지되는 트레이드
+ * 오프**다(cloudbuild.yaml 주석 참고). 즉 이 60초 주기 컷은 "가끔 있는 이상 상황"이 아니라
+ * **정상 운영 중 항상 반복되는 예정된 이벤트**다.
+ *
+ * 기존 `RECONNECT_DELAYS_MS = [5s, 30s, 60s, 300s]`는 `onopen`이 무조건 실패 카운트를
+ * 리셋해서, 이 정상 60초 사이클에서는 우연히 5분까지 안 치솟는다 — 다만 "오래 붙어있었는지"가
+ * 아니라 "열리기만 했는지"로 판정하고 있어 설계 의도가 불명확했다. 진짜 위험은 **핸드셰이크
+ * 자체가 반복 실패하는(서버가 실제로 죽은) 상황**인데, 그 경우도 5분 상한은 과하다.
+ *
+ * 이 모듈은 "연결이 얼마나 오래 붙어 있었는지"로 리셋 여부를 가른다:
+ * - `HEALTHY_CONNECTION_MS`(10초) 이상 붙어 있다가 끊겼으면 정상 사이클로 보고 실패
+ *   카운트를 즉시 잊는다(다음 재시도는 1단계 지연만).
+ * - 그보다 짧게(핸드셰이크 직후 등) 끊기면 진짜 불안정으로 보고 카운트를 유지·증가시킨다.
+ *
+ * 새 상한(20초, 기존 300초)의 근거: 실측 정상 사이클이 60~68초이므로, 최악의 경우(서버가
+ * 진짜 죽어 매번 카운트가 증가)에도 누적 백오프(1+3+8+20=32초)가 정상 사이클 길이보다
+ * 짧다 — 재시도 폭풍이 사이클 하나를 도는 동안 물리적으로 발생할 수 없다. 동시에 실시간
+ * 공백을 기존 최악 5분에서 최악 20초로 줄인다.
+ */
+export const RECONNECT_DELAYS_MS = [1_000, 3_000, 8_000, 20_000];
+
+const HEALTHY_CONNECTION_MS = 10_000;
+
+export interface ReconnectBackoffState {
+  /** EventSource가 open됐을 때 호출 — 이후 onError 판정에 쓸 시작 시각을 기록한다. */
+  onOpen: () => void;
+  /** 지금이 최초 연결이 아니라 재연결(과거 open 이력이 있음)인지 — backfill 트리거용.
+   *  onOpen() 호출 *전에* 확인해야 정확하다(과거 이력을 묻는 질문이므로). */
+  isReconnect: () => boolean;
+  /** EventSource가 error됐을 때 호출 — 다음 재시도까지 기다릴 지연(ms)을 반환한다. */
+  onError: () => number;
+}
+
+export function createReconnectBackoffState(): ReconnectBackoffState {
+  let attempts = 0;
+  let openedAt: number | null = null;
+  let hadPriorError = false;
+
+  return {
+    onOpen() {
+      openedAt = Date.now();
+    },
+    isReconnect() {
+      return hadPriorError;
+    },
+    onError() {
+      hadPriorError = true;
+      const stayedHealthy = openedAt !== null && Date.now() - openedAt >= HEALTHY_CONNECTION_MS;
+      openedAt = null;
+      if (stayedHealthy) attempts = 0;
+      const delay = RECONNECT_DELAYS_MS[Math.min(attempts, RECONNECT_DELAYS_MS.length - 1)]!;
+      attempts += 1;
+      return delay;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- **실측**(2026-07-22 dev-app, `gcloud logging read`, realtime-gateway 30분 관측): 멤버 1명 기준 재연결 71회, 간격 분포가 **60~68초 클러스터**. 원인은 `sprintable-frontend-*`의 Cloud Run `timeout=60초`(cloudbuild.yaml `_FRONTEND_TIMEOUT`) — frontend는 짧은 페이지 요청 기준 sizing(maxScale=3·상한 240 슬롯)이라 SSE 장수연결을 오래 붙들면 병목이 생기므로, **값 인상이 아니라 브라우저→realtime 직결 설계(추후) 전까지 의도적으로 유지되는 트레이드오프**(PO 확인 — cloudbuild.yaml durable화 불필요, 이 60초 컷 자체는 정상 운영 중 항상 반복되는 예정된 이벤트).
- 기존 `RECONNECT_DELAYS_MS=[5s,30s,60s,300s]`는 `onopen`이 무조건 실패 카운트를 리셋해서 이 정상 60초 사이클에서는 우연히 안 치솟지만, "오래 붙어있었는지"가 아니라 "열리기만 했는지"로 판정해 설계 의도가 불명확했다. 진짜 위험(핸드셰이크 자체가 반복 실패 = 서버가 실제로 죽음) 시나리오에서는 5분 상한이 실시간을 통째로 죽인다.

## Fix
- 연결이 `HEALTHY_CONNECTION_MS`(10초, 실측 정상 사이클 60~68초의 1/6 미만) 이상 붙어 있다가 끊기면 실패 카운트를 즉시 리셋(정상 사이클 컷과 진짜 불안정을 가른다).
- 상한을 300초→**20초**로 낮췄다 — 근거: 누적 백오프(1+3+8+20=32초)가 정상 사이클(60~68초)보다 짧아, 서버가 진짜 죽은 최악의 경우에도 재시도 폭풍이 사이클 하나를 도는 동안 물리적으로 발생할 수 없다.
- `sse-multiplexer.ts`(dev, mux ON)·`use-chat-sse.ts`/`use-sse-notifications.ts`의 독립 폴백(prod, mux OFF) 3곳에 `RECONNECT_DELAYS_MS`+동일 로직이 복붙돼 드리프트 위험이 있어, 공용 모듈 `sse-reconnect-backoff.ts`로 추출해 3곳 전부 재사용(발명 0 — 기존 값/전략 계승, 리셋 조건만 정정).

## Test
- `sse-reconnect-backoff.test.ts`(신규, 7케이스) — 10초 경계값 안팎 거동, 60~68초 실측 사이클 재현(5회 반복해도 항상 1단계 유지), 상한 고정, `isReconnect()` 계약.
- 기존 `sse-multiplexer.test.tsx`(story #2078) 회귀 없음 확인.

## Gates (fresh worktree)
- `pnpm type-check` — 0 errors
- `pnpm lint` — 0 errors, 5 pre-existing warnings(이 PR 미터치 파일)
- `pnpm vitest run`(전체) — 285 files, 1875 passed, 2 skipped, 0 failed
- `pnpm build` — exit 0

Story #2095.