### PR TITLE
fix(#2122): route agent wake to Redis backplane (cross-node delivery)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -122,6 +122,17 @@ class Settings(BaseSettings):
     # off/Redis 다운 → 기존 in-process 카운트로 폴백(fail-open·연결 거부 안 함).
     sse_lease_redis_enabled: bool = False
 
+    # #2122(E-ARCH, 2026-07-22): fanout(특히 wake_agent)을 Redis 백플레인에 태워 크로스-인스턴스 배달.
+    # 현재 wake_agent 는 pg_notify 직접(event_broker 우회)이라 GCE(PG_LISTEN=false)서 타노드 미도달 +
+    # __wake__ 마커가 event_type 에만 있어 브리지(_push_to_agent=data만 큐잉)서 유실 = 크로스노드 wake 이중 파손.
+    # fix = event_broker.publish + __wake__ 를 data 에. 독립 flag(#2120/#2121 교훈·롤백 격리). 기본 off=현 동작.
+    fanout_wake_redis_enabled: bool = False
+
+    # #2122 cutover 셀렉터: 크로스-인스턴스 dispatch 백플레인을 하나로 강제(중복배달 차단). PG listen 과
+    # Redis consume 브리지는 구조 동일 — 둘 다 dispatch 하면 같은 이벤트 2회 배달. ""(미설정)=기존 플래그서
+    # 파생(충돌 시 redis 우선+ERROR)·"pg"|"redis"=명시 강제. "잘못된 상태를 표현 불가능하게"(불린 2개 대신 enum).
+    realtime_backplane: str = ""
+
     # E-ARCH S2 정리(2026-07-21, LISTEN 제거 완료 후 발견): redis_consume_loop task 생성이
     # event_broker_redis_dual_publish_enabled 하나로만 게이트돼 있었다 — dual_publish(발행,
     # 모든 인스턴스가 필요)와 consume(구독+dispatch, SSE를 실제로 서빙하는 서비스만 필요)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -40,7 +40,7 @@ async def lifespan(app: FastAPI):
     # 직접 대신 resolver 로 게이팅 — PG_LISTEN + Redis dispatch 동시 활성이면 redis 우선(+ERROR). 미설정 시
     # 기존 플래그서 파생(무회귀). realtime=redis / api=pg 로 자연 갈림.
     from app.services.event_broker import resolve_backplane as _resolve_backplane
-    _backplane = _resolve_backplane()
+    _backplane = _resolve_backplane(log_conflict=True)  # 충돌 ERROR 는 startup 1회만
     if _backplane == "pg":
         check_listen_config()  # ee7794eb ③ fail-closed: DB_PGBOUNCER on + DATABASE_URL_DIRECT 없으면 startup raise.
     check_internal_secret_config()  # 산티아고 §9 finding 4: non-local + 시크릿 미설정 fail-closed.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -36,7 +36,12 @@ async def lifespan(app: FastAPI):
     warn_if_webhook_secret_misconfigured()  # Bot-M.2 P3: 웹훅 secret misconfig 를 트래픽 前 경고.
     # E-ARCH S1: PG_LISTEN_ENABLED=false인 서비스(api)는 이 검증 자체가 무의미 — LISTEN을 절대
     # 안 켜므로 DB_PGBOUNCER/DATABASE_URL_DIRECT 정합을 강제할 이유가 없다(무해·불필요 fail 방지).
-    if settings.pg_listen_enabled:
+    # #2122 cutover: 크로스-인스턴스 dispatch 백플레인을 단일 결정(pg|redis)해 중복배달 차단. pg_listen_enabled
+    # 직접 대신 resolver 로 게이팅 — PG_LISTEN + Redis dispatch 동시 활성이면 redis 우선(+ERROR). 미설정 시
+    # 기존 플래그서 파생(무회귀). realtime=redis / api=pg 로 자연 갈림.
+    from app.services.event_broker import resolve_backplane as _resolve_backplane
+    _backplane = _resolve_backplane()
+    if _backplane == "pg":
         check_listen_config()  # ee7794eb ③ fail-closed: DB_PGBOUNCER on + DATABASE_URL_DIRECT 없으면 startup raise.
     check_internal_secret_config()  # 산티아고 §9 finding 4: non-local + 시크릿 미설정 fail-closed.
     check_cron_secret_config()  # story #2072: non-local + CRON_SECRET 미설정 fail-closed.
@@ -49,7 +54,7 @@ async def lifespan(app: FastAPI):
     # E-ARCH S1(2026-07-21, #2074 근본 — REST/실시간 서비스 분리 1단계): default=True(무회귀) —
     # api 서비스에 PG_LISTEN_ENABLED=false를 배선하면 이 인스턴스는 RAW_LISTEN 커넥션을 전혀
     # 안 잡는다(커넥션 예산 산식에서 이 항이 빠짐). realtime 서비스만 true로 유지.
-    task = asyncio.create_task(listen_loop()) if settings.pg_listen_enabled else None
+    task = asyncio.create_task(listen_loop()) if _backplane == "pg" else None  # #2122: resolver 게이팅
     # E-L2 S5: 휴리스틱 트리거 워커는 default-off — 명시 활성화 시에만 task 생성(AC①).
     l2_task = None
     if settings.l2_trigger_enabled:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -41,6 +41,20 @@ async def lifespan(app: FastAPI):
     # 기존 플래그서 파생(무회귀). realtime=redis / api=pg 로 자연 갈림.
     from app.services.event_broker import resolve_backplane as _resolve_backplane
     _backplane = _resolve_backplane(log_conflict=True)  # 충돌 ERROR 는 startup 1회만
+    # #2122 정합성 가드(mirror-risk·오르테가 2026-07-22): backplane=redis 인데 consume loop 이 안 도는 조합
+    # (dual_publish/consume off 인데 dispatch on)이면 dispatcher 0 = 백플레인은 정해졌는데 **수신자 없는**
+    # "조용한 사망"(오늘 #2122 가 정확히 그 모양이었다). dispatch 와 consume 은 독립 env 라 어긋날 수 있어
+    # startup 서 감지 → loud ERROR + pg 폴백(strictly-better: redis consume loop 이 어차피 안 뜨니 중복배달
+    # 없고, pg 가 뜨면 dispatcher 확보·안 떠도 최소한 침묵 아닌 로그로 관측 가능).
+    if _backplane == "redis" and not (
+        settings.event_broker_redis_dual_publish_enabled
+        and settings.event_broker_redis_consume_enabled
+    ):
+        _logger.error(
+            "REALTIME_BACKPLANE=redis(또는 dispatch_enabled)인데 consume loop 미기동"
+            "(dual_publish/consume off) = dispatcher 0. PG listen 으로 폴백. (#2122 정합성 가드)"
+        )
+        _backplane = "pg"
     if _backplane == "pg":
         check_listen_config()  # ee7794eb ③ fail-closed: DB_PGBOUNCER on + DATABASE_URL_DIRECT 없으면 startup raise.
     check_internal_secret_config()  # 산티아고 §9 finding 4: non-local + 시크릿 미설정 fail-closed.

--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -207,10 +207,21 @@ def wake_agent(agent_id: str, seq: int, _from_listener: bool = False) -> None:
         for q in dead:
             queues.discard(q)
     if not _from_listener:
-        # prod 커넥션 누수 근본fix(2026-07-08) — events.py publish_event()/_push_to_agent()와
-        # 동형(fire_and_forget 참조 보관, GC 조기수거로 인한 non-checked-in connection 방지).
-        from app.services.pg_pubsub import fire_and_forget, pg_notify
-        fire_and_forget(pg_notify("agent", agent_id, "__wake__", {"seq": seq}))
+        from app.services.pg_pubsub import fire_and_forget
+        from app.core.config import settings as _settings
+        if _settings.fanout_wake_redis_enabled:
+            # #2122: wake 를 Redis 백플레인에(event_broker.publish → pg_notify + Redis dual-publish 동시).
+            # ⭐__wake__ 마커를 **data 에** 실어야 타노드 브리지(_push_to_agent 는 data 만 큐잉·event_type 무시)가
+            #   보존 → 타노드 consumer 가 signal.get("__wake__") 감지 → DB 재조회. (기존 {"seq":seq} 는 마커가
+            #   event_type 에만 있어 크로스노드서 유실 → wake 아닌 "message"로 오인 = 크로스노드 wake 파손의 근본.)
+            from app.services.event_broker import event_broker
+            fire_and_forget(
+                event_broker.publish("agent", agent_id, "__wake__", {"__wake__": True, "seq": seq})
+            )
+        else:
+            # 기존 경로(flag off·무회귀) — prod 커넥션 누수 근본fix(2026-07-08)와 동형(fire_and_forget 참조 보관).
+            from app.services.pg_pubsub import pg_notify
+            fire_and_forget(pg_notify("agent", agent_id, "__wake__", {"seq": seq}))
 
 
 

--- a/backend/app/services/event_broker.py
+++ b/backend/app/services/event_broker.py
@@ -326,30 +326,30 @@ def record_pg_arrival(event_id: str) -> None:
     _pg_arrivals[event_id] = time.monotonic()
 
 
-def resolve_backplane() -> str:
+def resolve_backplane(log_conflict: bool = False) -> str:
     """#2122 cutover: 크로스-인스턴스 dispatch 백플레인을 **하나로** 결정(중복배달 차단).
 
     pg_pubsub._dispatch_received 와 redis_consume_loop 는 구조 동일 브리지 — 둘 다 dispatch 하면
     같은 이벤트가 2회 배달된다. 반환 "pg"|"redis"|"none" 중 하나만 dispatch 하도록 게이팅한다.
     · REALTIME_BACKPLANE 명시("pg"|"redis") → 그대로(잘못된 상태를 표현 불가능하게).
-    · 미설정 → 기존 플래그서 파생. PG_LISTEN 과 Redis dispatch 가 **동시에 가능**하면 **redis 우선 + ERROR**
-      (기동거부 아님 — config 오타로 realtime 전체 다운 방지). 하나만 가능하면 그것.
+    · 미설정 → 기존 불린서 파생(무회귀). "redis dispatch 함"의 신호 = `event_broker_redis_dispatch_enabled`
+      (그 플래그 이름이 곧 이 의미 — dual_publish/consume 은 발행·loop 기동 전제라 dispatch 결정과 별개).
+      PG_LISTEN 과 Redis dispatch 가 **동시 활성**이면 **redis 우선**(+ERROR·기동거부 아님 — config 오타로
+      realtime 전체 다운 방지). ⚠️`log_conflict`=True 는 **startup 1회만**(main.py) — dispatch 루프서
+      매 메시지 호출 시엔 False 로 로그 스팸 방지.
     """
     from app.core.config import settings  # 이 모듈은 settings 를 함수-로컬 import(순환 회피)
     sel = (settings.realtime_backplane or "").strip().lower()
     if sel in ("pg", "redis"):
         return sel
     pg = settings.pg_listen_enabled
-    redis = (
-        settings.event_broker_redis_dual_publish_enabled
-        and settings.event_broker_redis_consume_enabled
-        and settings.event_broker_redis_dispatch_enabled
-    )
+    redis = settings.event_broker_redis_dispatch_enabled  # "redis 가 dispatch 하는가"의 직접 신호
     if pg and redis:
-        logger.error(
-            "REALTIME_BACKPLANE 미설정인데 PG_LISTEN + Redis dispatch 동시 활성 = 중복배달 위험. "
-            "redis 우선으로 진행 — REALTIME_BACKPLANE=redis|pg 명시 권장. (#2122 cutover)"
-        )
+        if log_conflict:
+            logger.error(
+                "REALTIME_BACKPLANE 미설정인데 PG_LISTEN + Redis dispatch 동시 활성 = 중복배달 위험. "
+                "redis 우선으로 진행 — REALTIME_BACKPLANE=redis|pg 명시 권장. (#2122 cutover)"
+            )
         return "redis"
     if redis:
         return "redis"

--- a/backend/app/services/event_broker.py
+++ b/backend/app/services/event_broker.py
@@ -326,6 +326,37 @@ def record_pg_arrival(event_id: str) -> None:
     _pg_arrivals[event_id] = time.monotonic()
 
 
+def resolve_backplane() -> str:
+    """#2122 cutover: 크로스-인스턴스 dispatch 백플레인을 **하나로** 결정(중복배달 차단).
+
+    pg_pubsub._dispatch_received 와 redis_consume_loop 는 구조 동일 브리지 — 둘 다 dispatch 하면
+    같은 이벤트가 2회 배달된다. 반환 "pg"|"redis"|"none" 중 하나만 dispatch 하도록 게이팅한다.
+    · REALTIME_BACKPLANE 명시("pg"|"redis") → 그대로(잘못된 상태를 표현 불가능하게).
+    · 미설정 → 기존 플래그서 파생. PG_LISTEN 과 Redis dispatch 가 **동시에 가능**하면 **redis 우선 + ERROR**
+      (기동거부 아님 — config 오타로 realtime 전체 다운 방지). 하나만 가능하면 그것.
+    """
+    sel = (settings.realtime_backplane or "").strip().lower()
+    if sel in ("pg", "redis"):
+        return sel
+    pg = settings.pg_listen_enabled
+    redis = (
+        settings.event_broker_redis_dual_publish_enabled
+        and settings.event_broker_redis_consume_enabled
+        and settings.event_broker_redis_dispatch_enabled
+    )
+    if pg and redis:
+        logger.error(
+            "REALTIME_BACKPLANE 미설정인데 PG_LISTEN + Redis dispatch 동시 활성 = 중복배달 위험. "
+            "redis 우선으로 진행 — REALTIME_BACKPLANE=redis|pg 명시 권장. (#2122 cutover)"
+        )
+        return "redis"
+    if redis:
+        return "redis"
+    if pg:
+        return "pg"
+    return "none"
+
+
 async def redis_consume_loop() -> None:
     """Redis 구독 → (a) PG 경로 도착 기록과 대조해 지연Δ·중복률 로그(항상) (b)
     `event_broker_redis_dispatch_enabled`(default False)가 켜지면 실제로
@@ -388,7 +419,8 @@ async def redis_consume_loop() -> None:
                             event_id,
                         )
 
-                if not settings.event_broker_redis_dispatch_enabled:
+                # #2122 cutover: 이 백플레인이 dispatch 담당일 때만 실제 전달(아니면 관측만). 중복배달 차단.
+                if resolve_backplane() != "redis":
                     continue
 
                 if payload.get("instance_id") == INSTANCE_ID:

--- a/backend/app/services/event_broker.py
+++ b/backend/app/services/event_broker.py
@@ -335,6 +335,7 @@ def resolve_backplane() -> str:
     · 미설정 → 기존 플래그서 파생. PG_LISTEN 과 Redis dispatch 가 **동시에 가능**하면 **redis 우선 + ERROR**
       (기동거부 아님 — config 오타로 realtime 전체 다운 방지). 하나만 가능하면 그것.
     """
+    from app.core.config import settings  # 이 모듈은 settings 를 함수-로컬 import(순환 회피)
     sel = (settings.realtime_backplane or "").strip().lower()
     if sel in ("pg", "redis"):
         return sel

--- a/backend/tests/test_fanout_redis_backplane.py
+++ b/backend/tests/test_fanout_redis_backplane.py
@@ -13,41 +13,42 @@ from unittest.mock import patch
 
 import pytest
 
-from app.services import event_broker
+from app.core.config import settings as _cfg_settings  # 싱글턴 — event_broker 는 settings 를 함수-로컬 import
+from app.services import event_broker  # noqa: F401 (resolve_backplane 소속 모듈)
 from app.services.event_broker import resolve_backplane
 
 
 # ── cutover resolver (redis 우선 + 셀렉터) ──────────────────────────────────────
 def test_resolve_explicit_selector_wins():
-    with patch.object(event_broker.settings, "realtime_backplane", "redis"):
+    with patch.object(_cfg_settings, "realtime_backplane", "redis"):
         assert resolve_backplane() == "redis"
-    with patch.object(event_broker.settings, "realtime_backplane", "pg"):
+    with patch.object(_cfg_settings, "realtime_backplane", "pg"):
         assert resolve_backplane() == "pg"
 
 
 def test_resolve_derives_redis_when_only_redis():
-    with patch.object(event_broker.settings, "realtime_backplane", ""), \
-         patch.object(event_broker.settings, "pg_listen_enabled", False), \
-         patch.object(event_broker.settings, "event_broker_redis_dual_publish_enabled", True), \
-         patch.object(event_broker.settings, "event_broker_redis_consume_enabled", True), \
-         patch.object(event_broker.settings, "event_broker_redis_dispatch_enabled", True):
+    with patch.object(_cfg_settings, "realtime_backplane", ""), \
+         patch.object(_cfg_settings, "pg_listen_enabled", False), \
+         patch.object(_cfg_settings, "event_broker_redis_dual_publish_enabled", True), \
+         patch.object(_cfg_settings, "event_broker_redis_consume_enabled", True), \
+         patch.object(_cfg_settings, "event_broker_redis_dispatch_enabled", True):
         assert resolve_backplane() == "redis"
 
 
 def test_resolve_pg_when_only_pg():
-    with patch.object(event_broker.settings, "realtime_backplane", ""), \
-         patch.object(event_broker.settings, "pg_listen_enabled", True), \
-         patch.object(event_broker.settings, "event_broker_redis_dispatch_enabled", False):
+    with patch.object(_cfg_settings, "realtime_backplane", ""), \
+         patch.object(_cfg_settings, "pg_listen_enabled", True), \
+         patch.object(_cfg_settings, "event_broker_redis_dispatch_enabled", False):
         assert resolve_backplane() == "pg"
 
 
 def test_resolve_conflict_redis_wins_with_error(caplog):
     """PG_LISTEN + Redis dispatch 동시 활성(미설정) → redis 우선 + ERROR 로그(기동거부 아님)."""
-    with patch.object(event_broker.settings, "realtime_backplane", ""), \
-         patch.object(event_broker.settings, "pg_listen_enabled", True), \
-         patch.object(event_broker.settings, "event_broker_redis_dual_publish_enabled", True), \
-         patch.object(event_broker.settings, "event_broker_redis_consume_enabled", True), \
-         patch.object(event_broker.settings, "event_broker_redis_dispatch_enabled", True):
+    with patch.object(_cfg_settings, "realtime_backplane", ""), \
+         patch.object(_cfg_settings, "pg_listen_enabled", True), \
+         patch.object(_cfg_settings, "event_broker_redis_dual_publish_enabled", True), \
+         patch.object(_cfg_settings, "event_broker_redis_consume_enabled", True), \
+         patch.object(_cfg_settings, "event_broker_redis_dispatch_enabled", True):
         with caplog.at_level(logging.ERROR):
             assert resolve_backplane() == "redis"
         assert any("REALTIME_BACKPLANE" in r.message for r in caplog.records)  # ERROR 로그 확認
@@ -92,7 +93,7 @@ def test_wake_agent_flag_on_puts_marker_in_data():
         except Exception:
             pass
 
-    with patch.object(event_broker.settings, "fanout_wake_redis_enabled", True), \
+    with patch.object(_cfg_settings, "fanout_wake_redis_enabled", True), \
          patch("app.services.event_broker.event_broker.publish", new=AsyncMock()) as mock_pub, \
          patch("app.services.pg_pubsub.fire_and_forget", new=MagicMock(side_effect=_swallow)):
         agent_gateway.wake_agent(str(uuid.uuid4()), 5)

--- a/backend/tests/test_fanout_redis_backplane.py
+++ b/backend/tests/test_fanout_redis_backplane.py
@@ -42,16 +42,24 @@ def test_resolve_pg_when_only_pg():
         assert resolve_backplane() == "pg"
 
 
-def test_resolve_conflict_redis_wins_with_error(caplog):
-    """PG_LISTEN + Redis dispatch 동시 활성(미설정) → redis 우선 + ERROR 로그(기동거부 아님)."""
+def test_resolve_conflict_redis_wins_startup_logs(caplog):
+    """PG_LISTEN + Redis dispatch 동시 활성(미설정) → redis 우선. startup(log_conflict=True)만 ERROR 로그."""
     with patch.object(_cfg_settings, "realtime_backplane", ""), \
          patch.object(_cfg_settings, "pg_listen_enabled", True), \
-         patch.object(_cfg_settings, "event_broker_redis_dual_publish_enabled", True), \
-         patch.object(_cfg_settings, "event_broker_redis_consume_enabled", True), \
+         patch.object(_cfg_settings, "event_broker_redis_dispatch_enabled", True):
+        with caplog.at_level(logging.ERROR):
+            assert resolve_backplane(log_conflict=True) == "redis"   # startup 경로 → 로그
+        assert any("REALTIME_BACKPLANE" in r.message for r in caplog.records)
+
+
+def test_resolve_conflict_loop_path_no_log_spam(caplog):
+    """dispatch 루프 경로(log_conflict 기본 False)는 redis 우선이되 매-메시지 로그 스팸 안 함."""
+    with patch.object(_cfg_settings, "realtime_backplane", ""), \
+         patch.object(_cfg_settings, "pg_listen_enabled", True), \
          patch.object(_cfg_settings, "event_broker_redis_dispatch_enabled", True):
         with caplog.at_level(logging.ERROR):
             assert resolve_backplane() == "redis"
-        assert any("REALTIME_BACKPLANE" in r.message for r in caplog.records)  # ERROR 로그 확認
+        assert not any("REALTIME_BACKPLANE" in r.message for r in caplog.records)  # 로그 억제 확認
 
 
 # ── ⭐ __wake__ 전구간(마커 보존) ─────────────────────────────────────────────

--- a/backend/tests/test_fanout_redis_backplane.py
+++ b/backend/tests/test_fanout_redis_backplane.py
@@ -1,0 +1,126 @@
+"""#2122: fanout Redis 백플레인(wake_agent → event_broker.publish) + cutover resolver 유닛.
+
+⭐핵심 = __wake__ 마커가 **전 구간**(producer data → 브리지 → 큐 → consumer 감지) 보존되는지 못박기.
+크로스노드 wake 파손의 근본은 마커가 event_type 에만 있어 브리지(_push_to_agent=data만 큐잉)서 유실된 것.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from app.services import event_broker
+from app.services.event_broker import resolve_backplane
+
+
+# ── cutover resolver (redis 우선 + 셀렉터) ──────────────────────────────────────
+def test_resolve_explicit_selector_wins():
+    with patch.object(event_broker.settings, "realtime_backplane", "redis"):
+        assert resolve_backplane() == "redis"
+    with patch.object(event_broker.settings, "realtime_backplane", "pg"):
+        assert resolve_backplane() == "pg"
+
+
+def test_resolve_derives_redis_when_only_redis():
+    with patch.object(event_broker.settings, "realtime_backplane", ""), \
+         patch.object(event_broker.settings, "pg_listen_enabled", False), \
+         patch.object(event_broker.settings, "event_broker_redis_dual_publish_enabled", True), \
+         patch.object(event_broker.settings, "event_broker_redis_consume_enabled", True), \
+         patch.object(event_broker.settings, "event_broker_redis_dispatch_enabled", True):
+        assert resolve_backplane() == "redis"
+
+
+def test_resolve_pg_when_only_pg():
+    with patch.object(event_broker.settings, "realtime_backplane", ""), \
+         patch.object(event_broker.settings, "pg_listen_enabled", True), \
+         patch.object(event_broker.settings, "event_broker_redis_dispatch_enabled", False):
+        assert resolve_backplane() == "pg"
+
+
+def test_resolve_conflict_redis_wins_with_error(caplog):
+    """PG_LISTEN + Redis dispatch 동시 활성(미설정) → redis 우선 + ERROR 로그(기동거부 아님)."""
+    with patch.object(event_broker.settings, "realtime_backplane", ""), \
+         patch.object(event_broker.settings, "pg_listen_enabled", True), \
+         patch.object(event_broker.settings, "event_broker_redis_dual_publish_enabled", True), \
+         patch.object(event_broker.settings, "event_broker_redis_consume_enabled", True), \
+         patch.object(event_broker.settings, "event_broker_redis_dispatch_enabled", True):
+        with caplog.at_level(logging.ERROR):
+            assert resolve_backplane() == "redis"
+        assert any("REALTIME_BACKPLANE" in r.message for r in caplog.records)  # ERROR 로그 확認
+
+
+# ── ⭐ __wake__ 전구간(마커 보존) ─────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_wake_marker_survives_bridge_to_queue():
+    """PO 필수: __wake__ 를 **data 에** 실은 envelope 가 브리지(_dispatch_received)→_push_to_agent→큐에
+    마커 보존된 채 도착 → consumer 의 signal.get('__wake__') 감지 성립. (#2122 fix 가 확립하는 패리티.)"""
+    from app.routers import events as events_mod
+    from app.services import pg_pubsub
+
+    agent_id = str(uuid.uuid4())
+    q: asyncio.Queue = asyncio.Queue(maxsize=200)
+    events_mod._agent_connections[agent_id].add(q)
+    try:
+        # wake_agent(flag on) 가 발행하는 것과 동형인, 타노드에서 수신되는 envelope
+        envelope = json.dumps({
+            "instance_id": "OTHER_NODE", "target": "agent", "target_id": agent_id,
+            "event_type": "__wake__", "data": {"__wake__": True, "seq": 7},
+        })
+        await pg_pubsub._dispatch_received(envelope)
+        assert not q.empty()
+        signal = q.get_nowait()
+        assert signal.get("__wake__") is True   # ⭐ 마커 보존 = agent_gateway generate 의 wake 분기 성립
+        assert signal.get("seq") == 7
+    finally:
+        events_mod._agent_connections[agent_id].discard(q)
+        events_mod._agent_connections.pop(agent_id, None)
+
+
+def test_wake_agent_flag_on_puts_marker_in_data():
+    """producer 측(전구간 시작점): flag on → wake_agent 가 event_broker.publish 로 __wake__ 를 **data 에** 실어
+    발행(Redis 백플레인 경유). flag off 는 기존 pg_notify(마커 event_type-only) 유지 = 무회귀."""
+    from unittest.mock import AsyncMock, MagicMock
+    from app.routers import agent_gateway
+
+    def _swallow(coro):
+        try:
+            coro.close()
+        except Exception:
+            pass
+
+    with patch.object(event_broker.settings, "fanout_wake_redis_enabled", True), \
+         patch("app.services.event_broker.event_broker.publish", new=AsyncMock()) as mock_pub, \
+         patch("app.services.pg_pubsub.fire_and_forget", new=MagicMock(side_effect=_swallow)):
+        agent_gateway.wake_agent(str(uuid.uuid4()), 5)
+
+    mock_pub.assert_called_once()
+    a = mock_pub.call_args.args
+    assert a[0] == "agent" and a[2] == "__wake__"
+    assert a[3] == {"__wake__": True, "seq": 5}   # ⭐ 마커가 data 에(event_type-only 아님)
+
+
+@pytest.mark.anyio
+async def test_wake_marker_lost_when_only_in_event_type():
+    """회귀방지 대조: 마커가 event_type 에만 있고 data 에 없으면 브리지서 유실 → consumer 미감지.
+    = 크로스노드 wake 파손의 근본 재현(fix 前 legacy pg_notify {"seq":seq} 동형)."""
+    from app.routers import events as events_mod
+    from app.services import pg_pubsub
+
+    agent_id = str(uuid.uuid4())
+    q: asyncio.Queue = asyncio.Queue(maxsize=200)
+    events_mod._agent_connections[agent_id].add(q)
+    try:
+        envelope = json.dumps({
+            "instance_id": "OTHER_NODE", "target": "agent", "target_id": agent_id,
+            "event_type": "__wake__", "data": {"seq": 7},   # data 에 마커 없음(기존 파손)
+        })
+        await pg_pubsub._dispatch_received(envelope)
+        signal = q.get_nowait()
+        assert signal.get("__wake__") is None   # ⭐ 유실 — wake 미감지("message"로 오인됐던 근본
+    finally:
+        events_mod._agent_connections[agent_id].discard(q)
+        events_mod._agent_connections.pop(agent_id, None)


### PR DESCRIPTION
## Live defect: agent wake dead cross-node on GCE

**Measured (민군):** same trigger/connection/moment, path the only variable — Redis-path event **2/2** delivered, pg_notify wake **0/2**. On GCE, writes land on backend-dev (Cloud Run) but SSE is served by the GCE MIG with `PG_LISTEN_ENABLED=false`; wake_agent published via pg_notify directly → nobody listens → cross-node wakes never arrive (no data loss; recipient_seq recovers on reconnect, but real-time dies).

**Root cause was DOUBLE:** (1) wake off the Redis backplane, and (2) the `__wake__` marker lived only in the event_type **arg**, but the bridge (`_dispatch_received`/`redis_consume_loop`) drops event_type for the 'agent' target and queues only `data` — so even a delivered wake was misread as a 'message' (consumer checks the `__wake__` **key** in data). An exhaustive audit confirmed **wake_agent is the only member of this class**.

## Fix (behind independent flag `fanout_wake_redis_enabled`, default off)
- **wake_agent → event_broker.publish('agent', id, '__wake__', {'__wake__': True, 'seq': seq})** — marker in DATA, byte-identical to the local queued dict. (A bridge-merge of event_type would NOT fix it — the consumer keys on `__wake__`, not event_type.)
- **cutover:** `resolve_backplane()` picks one dispatcher. `REALTIME_BACKPLANE` selector authoritative; else derived; both-active → ERROR log + redis-wins (no startup-refusal). Gates main.py listen_loop and redis_consume dispatch.
- **fail-open:** Redis down → local delivery still happens; only cross-node lost.

## Tests
Full-chain `__wake__` marker survival (producer→bridge→queue→consumer) + regression-contrast (event_type-only → lost) + resolver (selector/derive/redis-wins+ERROR).

Deploy **after** the #2121 AC5 measurement (flag-isolated; don't mix variables). E-GCE-RT verdict gets a follow-up correction (S6 'fanout 4/4' was a single-node confound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)