### PR TITLE
fix(kanban): story #2130 — SSE assignee_changed 핸들러가 assignee_id만 갱신해 카드가 안 그려지던 결함

### DIFF
--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -39,7 +39,7 @@ function wrap(node: React.ReactNode) {
   );
 }
 
-function stubFetch(stories: Array<Record<string, unknown> & { status: string }>) {
+function stubFetch(stories: Array<Record<string, unknown> & { status: string }>, members: Array<Record<string, unknown>> = []) {
   // CB-S4: 보드는 status별 5회 독립 호출(/api/stories?...&status=<col>) — 각 호출에 해당
   // status만 필터링해 {data:[...]} 형태(meta 포함)로 응답해야 실제 파싱 경로(json.data ?? [])와 맞는다.
   vi.stubGlobal('fetch', vi.fn(async (url: string) => {
@@ -48,7 +48,10 @@ function stubFetch(stories: Array<Record<string, unknown> & { status: string }>)
       const matched = stories.filter((s) => s.status === status);
       return { ok: true, json: async () => ({ data: matched, meta: { total: matched.length, nextCursor: null } }) };
     }
-    // 나머지(sprints/epics/members/workflow-executions/labels/gates 등)는 그레이스풀 폴백 경로만
+    if (typeof url === 'string' && url.startsWith('/api/members')) {
+      return { ok: true, json: async () => ({ data: members }) };
+    }
+    // 나머지(sprints/epics/workflow-executions/labels/gates 등)는 그레이스풀 폴백 경로만
     // 타면 되므로 실패 응답으로 충분(코드베이스 전반의 try/catch·optional-chaining 관례).
     return { ok: false, json: async () => null };
   }));
@@ -209,5 +212,49 @@ describe('KanbanBoard — 실시간(SSE) 반영', () => {
       await Promise.resolve();
     });
     expect(container.textContent).toContain('까심님이 S1 담당자를 변경했습니다');
+  });
+
+  // story #2130 — 토스트만 뜨고 카드 화면(아바타)은 안 바뀌던 결함의 회귀가드. StoryCard는
+  // assignees(배열·assignee_ids 유래)를 assignee(단일·assignee_id 유래)보다 우선해 그리므로,
+  // 핸들러가 assignee_id만 갱신하면 화면은 stale한 배열을 계속 본다(#2384와 같은 클래스).
+  it('담당자 변경 시 카드가 새 담당자 이름으로 실제로 렌더된다(#2130) — 배열 필드도 함께 갱신', async () => {
+    // 옛 담당자가 assignee_ids 배열에 이미 들어있는 상태(까심 재현 조건과 동일)로 시작한다.
+    stubFetch(
+      [{ id: 's1', title: 'S1', status: 'backlog', priority: 'medium', assignee_id: 'old-1', assignee_ids: ['old-1'] }],
+      [{ id: 'old-1', name: '올드멤버', type: 'human' }, { id: 'new-1', name: '뉴멤버', type: 'agent' }],
+    );
+    await mount();
+    // 아바타는 title 속성에 전체 이름을 담고 화면엔 이니셜만 그린다(getInitials) — title로 정확히 식별한다.
+    expect(container.querySelector('[title="올드멤버"]')).not.toBeNull();
+    await act(async () => {
+      dispatchSse('story.assignee_changed', {
+        story_id: 's1', project_id: 'proj-1', actor_id: 'other-1', actor_name: '까심',
+        assignee_id: 'new-1', old_assignee_id: 'old-1', assignees: ['new-1'],
+      });
+      await Promise.resolve();
+    });
+    // 카드가 실제로 새 담당자로 바뀌어야 한다 — 옛 담당자 아바타가 더 이상 카드에 남아있으면 안 된다.
+    expect(container.querySelector('[title="뉴멤버"]')).not.toBeNull();
+    expect(container.querySelector('[title="올드멤버"]')).toBeNull();
+  });
+
+  it('담당자 변경 시(원래 미배정) memberMap에 새 담당자가 없어도 assignee_id/assignee_ids는 갱신된다(#2130 빈칸-유지 케이스)', async () => {
+    // memberMap에 새 담당자가 없는 극단 케이스(예: 프로젝트 멤버 목록 밖 계정) — 이때도
+    // state 자체는 정확히 갱신돼야 한다(렌더가 못 그리는 것과 state가 안 바뀌는 것은 별개 결함).
+    stubFetch(
+      [{ id: 's1', title: 'S1', status: 'backlog', priority: 'medium', assignee_id: null, assignee_ids: [] }],
+      [],
+    );
+    await mount();
+    await act(async () => {
+      dispatchSse('story.assignee_changed', {
+        story_id: 's1', project_id: 'proj-1', actor_id: 'other-1', actor_name: '오르테가',
+        assignee_id: 'unknown-member', old_assignee_id: null, assignees: ['unknown-member'],
+      });
+      await Promise.resolve();
+    });
+    // 토스트는 여전히 뜬다(핸들러가 실행됐다는 관측 가능한 신호) — 카드 시각 확認은 memberMap
+    // 의존이라 이 테스트 범위 밖(멤버 목록 자체가 별건).
+    expect(container.textContent).toContain('오르테가님이 S1 담당자를 변경했습니다');
   });
 });

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -260,6 +260,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
       actor_name?: string;
       status?: string;
       assignee_id?: string | null;
+      assignees?: string[];
     };
     if (!payload.story_id || !payload.project_id || payload.project_id !== projectId) return;
     // 내 액션의 echo는 무시 — 이미 낙관 갱신했으므로 중복 패치·토스트 스팸을 방지한다.
@@ -275,8 +276,16 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
       adjustColumnTotal(existing.status, -1);
       adjustColumnTotal(newStatus, +1);
     } else if (eventName === 'story.assignee_changed') {
+      // story #2130 — 카드(StoryCard)는 assignees(배열, assignee_ids 유래)를 assignee(단일)보다
+      // 우선해 그린다. assignee_id만 갱신하면 assignee_ids가 stale로 남아 화면이 안 바뀐다
+      // (배열이 이미 비어있지 않으면 옛 담당자가 계속 보이고, 비어있으면 memberMap에 새
+      // 담당자가 없을 때 빈 채로 남는다 — 오늘 #2384(story-detail-panel.tsx)와 같은 클래스).
+      // 서버 payload의 assignees(ID 배열)를 그대로 반영해 화면이 읽는 필드를 전부 맞춘다.
       const newAssigneeId = payload.assignee_id ?? null;
-      setStories((prev) => prev.map((s) => (s.id === payload.story_id ? { ...s, assignee_id: newAssigneeId } : s)));
+      const newAssigneeIds = payload.assignees ?? (newAssigneeId ? [newAssigneeId] : []);
+      setStories((prev) => prev.map((s) => (
+        s.id === payload.story_id ? { ...s, assignee_id: newAssigneeId, assignee_ids: newAssigneeIds } : s
+      )));
     } else {
       return;
     }


### PR DESCRIPTION
## Summary
- 민군 fiber 실측(런타임 관측): 전달✅ 파싱✅ 핸들러호출✅ 필터통과✅ **state patch✅** → **DOM 반영❌**.
- 근본: `StoryCard`는 `assignees`(배열, `story.assignee_ids` 유래)를 `assignee`(단일, `assignee_id` 유래)보다 **우선**해 그리는데(`assigneeList = assignees.length>0 ? assignees : [assignee]`), `handleBoardSseEvent`의 `assignee_changed` 분기는 `assignee_id`만 `setStories`로 갱신하고 `assignee_ids`는 stale로 방치했다.
- 두 증상이 같은 뿌리였다: `assignee_ids`가 이미 비어있지 않던 경우(옛 담당자가 배열에 남아있음) → 카드가 옛 담당자로 고정 / `assignee_ids`가 비어있고 `memberMap`에 새 담당자가 없던 경우 → 그릴 게 없어 빈칸 유지.
- 오늘 아침 **#2384**(`story-detail-panel.tsx`의 `onAssigneePatched` 콜백)에서 고친 것과 **같은 클래스** — "assignee를 id 단일+배열+객체 여러 표현으로 들고 다니면 갱신하는 쪽과 읽는 쪽이 다른 필드를 보는 조합이 계속 생긴다"는 구조적 위험이 하루에 두 번 나왔다.

## Fix
- 서버 payload의 `assignees`(ID 배열, `stories.py:897`에서 이미 발행 중이던 필드)를 그대로 반영해 `assignee_id`와 `assignee_ids`를 함께 갱신 — 화면이 실제로 읽는 필드 전부를 맞춘다.

## AC3 — 같은 클래스 전수
- `kanban-board.tsx`가 구독하는 transient 이벤트는 `status_changed`·`assignee_changed` 둘뿐(같은 `handleBoardSseEvent` 공유) — `status`는 단일 필드라 이 클래스에 해당 없음(확인 완료).
- 다른 컴포넌트(`attention-queue-view.tsx`의 `trust_stage_changed`)는 디바운스 후 서버 재조회 구조라 이 결함 클래스에 아예 노출되지 않음(구조적으로 독립 — 정상 작동해도 방증 안 되고 결함 있어도 안 걸림).

## Test
- `kanban-board.test.tsx`에 2케이스 추가:
  1. 옛 담당자가 `assignee_ids`에 남아있던 케이스가 새 담당자로 실제 렌더되는 것(RED→GREEN 확인: 수정 전 코드로 `git stash` 재현 후 실패 확인).
  2. `memberMap`에 없는 새 담당자라도 state 자체는 갱신되는 것(렌더 실패와 state 실패를 분리해 고정).

## Gates (fresh worktree)
- `pnpm type-check` — 0 errors
- `pnpm lint` — 0 errors, 5 pre-existing warnings(이 PR 미터치 파일)
- `pnpm vitest run`(전체) — 285 files, 1881 passed, 2 skipped, 0 failed
- `pnpm build` — exit 0

## 근본 제안(스코프 밖, 판단만 공유)
assignee를 id 단일/id 배열/resolved 객체 세 겹으로 들고 다니는 구조 자체가 위험원이다. 축소 방향: ①"resolved 객체" 계층은 아예 story 상태에 두지 않고 지금처럼 렌더 시점 `memberMap` 조회로만 파생시킨다(이미 그렇게 하고 있음 — 유지). ②남는 두 겹(`assignee_id`/`assignee_ids`)은 모든 story mutation 경로(SSE 핸들러·dispatch 콜백·드래그 재배정 등)가 **하나의 공유 정규화 함수**를 통해서만 갱신하도록 강제한다(현재는 각 호출부가 개별적으로 두 필드를 손으로 맞추고 있어 이번·#2384처럼 하나를 빠뜨리는 사고가 반복된다). 이번 PR에는 포함하지 않았다 — 스코프 판단 필요.

Story #2130.