### PR TITLE
[SID:2133] assignee_id/assignee_ids 이중표현 정규화 함수로 강제

### DIFF
--- a/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
+++ b/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 import { MoreHorizontal, Zap } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ToastContainer, useToast } from '@/components/ui/toast';
+import { normalizeAssigneePatch } from '@/components/kanban/types';
 
 interface TeamMember {
   id: string;
@@ -77,12 +78,14 @@ export function EntityDispatchPanel({
     try {
       // 84f57f97 fix②: dispatch 前 assignee를 전 entity type 영속화(이전엔 story만 스킵→미영속→
       // BE dispatch가 담당자 못 봐 core flow 막힘). story=assignee_ids 배열·doc/epic=assignee_id.
+      // story #2133: 두 필드를 손으로 나눠 쓰지 않고 normalizeAssigneePatch에서 파생.
       const patchPath = entityType === 'doc' ? `/api/docs/${entityId}`
         : entityType === 'epic' ? `/api/goals/${entityId}`
         : `/api/stories/${entityId}`;
+      const assigneePatch = normalizeAssigneePatch({ assignee_id: assigneeId });
       const patchBody = entityType === 'story'
-        ? { assignee_ids: [assigneeId] }
-        : { assignee_id: assigneeId };
+        ? { assignee_ids: assigneePatch.assignee_ids }
+        : { assignee_id: assigneePatch.assignee_id };
       const patchRes = await fetch(patchPath, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -26,7 +26,7 @@ import { KanbanListView } from './kanban-list-view';
 import { KanbanSkeleton } from './kanban-skeleton';
 import { StoryDetailPanel } from './story-detail-panel';
 import { StoryCard } from './story-card';
-import { COLUMNS, type KanbanStory, type KanbanSprint, type KanbanEpic, type KanbanMember, type ColumnId, type DependencyEdge, type GateItem, type LineStatusSummary } from './types';
+import { COLUMNS, normalizeAssigneePatch, type KanbanStory, type KanbanSprint, type KanbanEpic, type KanbanMember, type ColumnId, type DependencyEdge, type GateItem, type LineStatusSummary } from './types';
 import type { LabelData } from '@/components/ui/label-chip';
 
 /**
@@ -276,15 +276,11 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
       adjustColumnTotal(existing.status, -1);
       adjustColumnTotal(newStatus, +1);
     } else if (eventName === 'story.assignee_changed') {
-      // story #2130 — 카드(StoryCard)는 assignees(배열, assignee_ids 유래)를 assignee(단일)보다
-      // 우선해 그린다. assignee_id만 갱신하면 assignee_ids가 stale로 남아 화면이 안 바뀐다
-      // (배열이 이미 비어있지 않으면 옛 담당자가 계속 보이고, 비어있으면 memberMap에 새
-      // 담당자가 없을 때 빈 채로 남는다 — 오늘 #2384(story-detail-panel.tsx)와 같은 클래스).
-      // 서버 payload의 assignees(ID 배열)를 그대로 반영해 화면이 읽는 필드를 전부 맞춘다.
-      const newAssigneeId = payload.assignee_id ?? null;
-      const newAssigneeIds = payload.assignees ?? (newAssigneeId ? [newAssigneeId] : []);
+      // story #2133 — normalizeAssigneePatch가 assignee_id/assignee_ids 정합을 강제한다.
+      // 손으로 두 필드를 따로 계산하던 자리(#2130 근본)를 구조로 제거.
+      const assigneePatch = normalizeAssigneePatch({ assignee_id: payload.assignee_id, assignee_ids: payload.assignees });
       setStories((prev) => prev.map((s) => (
-        s.id === payload.story_id ? { ...s, assignee_id: newAssigneeId, assignee_ids: newAssigneeIds } : s
+        s.id === payload.story_id ? { ...s, ...assigneePatch } : s
       )));
     } else {
       return;

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -7,6 +7,7 @@ import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
 import { AlertTriangle, Check, GitFork, Loader2, Paperclip, Plus, Tag, Trash2, X } from 'lucide-react';
 import type { KanbanStory, KanbanMember, DependencyEdge } from './types';
+import { normalizeAssigneePatch } from './types';
 import type { SendAttachment } from '@/hooks/use-chat-sse';
 import { getFileIcon } from '@/lib/file-icon';
 import { imageFilesFromClipboard } from '@/lib/clipboard-image';
@@ -499,11 +500,12 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     // assignee_ids 전체 배열 교체(서버 last-write-wins) → 연타 시 마지막 로컬과 정합.
     const updated = await patchStory({ assignee_ids: next });
     if (updated) {
-      // BE가 assignee_id(주담당)를 assignee_ids[0]로 동기화 → 응답 우선, 없으면 로컬 계산.
-      const resolved = updated.assignee_ids ?? next;
-      assigneeIdsRef.current = resolved;
-      setLocalAssigneeIds(resolved);
-      onStoryUpdate?.({ ...story, assignee_ids: resolved, assignee_id: updated.assignee_id ?? resolved[0] ?? null });
+      // story #2133 — BE 응답(assignee_ids 우선, 없으면 로컬 next)을 normalizeAssigneePatch로
+      // 통과시켜 assignee_id를 손으로 다시 계산하지 않는다.
+      const assigneePatch = normalizeAssigneePatch({ assignee_ids: updated.assignee_ids ?? next });
+      assigneeIdsRef.current = assigneePatch.assignee_ids;
+      setLocalAssigneeIds(assigneePatch.assignee_ids);
+      onStoryUpdate?.({ ...story, ...assigneePatch });
     } else {
       assigneeIdsRef.current = prev; // PATCH 실패 → 직전 값 롤백
       setLocalAssigneeIds(prev);
@@ -518,7 +520,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     setEditingAssignee(false);
     const updated = await patchStory({ assignee_ids: [] });
     if (updated) {
-      onStoryUpdate?.({ ...story, assignee_ids: [], assignee_id: null });
+      onStoryUpdate?.({ ...story, ...normalizeAssigneePatch({ assignee_ids: [] }) });
     } else {
       assigneeIdsRef.current = prev; // 롤백
       setLocalAssigneeIds(prev);
@@ -960,14 +962,13 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   entityId={story.id}
                   projectId={projectId}
                   currentAssigneeId={localAssigneeIds.length > 1 ? undefined : (localAssigneeIds[0] ?? story.assignee_id)}
-                  // 까심군 QA 회귀(2026-07-21) — assignee_id만 갱신하면 표시 로직(L478-480)이
-                  // 우선 읽는 assignee_ids 배열이 stale로 남아 새로고침 전까지 옛 담당자가
-                  // 보였다(L505의 정상 경로는 둘 다 갱신·이 경로만 누락). dispatch는 단일
-                  // 담당자 지정이라 assignee_ids를 [aid]로 교체해 정합을 맞춘다.
+                  // story #2133 — normalizeAssigneePatch가 assignee_id/assignee_ids 정합을
+                  // 강제해, 이 경로만 한쪽을 빠뜨리는 실수(#2384 근본)가 구조적으로 불가능해진다.
                   onAssigneePatched={(aid) => {
-                    assigneeIdsRef.current = [aid];
-                    setLocalAssigneeIds([aid]);
-                    onStoryUpdate?.({ ...story, assignee_id: aid, assignee_ids: [aid] });
+                    const assigneePatch = normalizeAssigneePatch({ assignee_id: aid });
+                    assigneeIdsRef.current = assigneePatch.assignee_ids;
+                    setLocalAssigneeIds(assigneePatch.assignee_ids);
+                    onStoryUpdate?.({ ...story, ...assigneePatch });
                   }}
                 />
               </div>

--- a/apps/web/src/components/kanban/types.test.ts
+++ b/apps/web/src/components/kanban/types.test.ts
@@ -1,0 +1,62 @@
+// story #2133 — assignee_id(단일)/assignee_ids(배열) 이중표현이 생산처마다 손으로
+// 맞춰지다 하루 2회(#2384·#2130) 동일 클래스로 어긋났다. normalizeAssigneePatch가 항상
+// 정합된 patch를 반환하는지 조합별로 고정한다(회귀 방지의 실질).
+import { describe, expect, it } from 'vitest';
+import { normalizeAssigneePatch } from './types';
+
+describe('normalizeAssigneePatch', () => {
+  it('assignee_id 단일 입력 → assignee_ids로 파생된다', () => {
+    expect(normalizeAssigneePatch({ assignee_id: 'm1' })).toEqual({
+      assignee_id: 'm1',
+      assignee_ids: ['m1'],
+    });
+  });
+
+  it('assignee_ids 배열 입력 → assignee_id는 배열의 첫 원소로 파생된다', () => {
+    expect(normalizeAssigneePatch({ assignee_ids: ['m1', 'm2'] })).toEqual({
+      assignee_id: 'm1',
+      assignee_ids: ['m1', 'm2'],
+    });
+  });
+
+  it('빈 배열 입력 → 둘 다 빈 상태로 정합된다', () => {
+    expect(normalizeAssigneePatch({ assignee_ids: [] })).toEqual({
+      assignee_id: null,
+      assignee_ids: [],
+    });
+  });
+
+  it('assignee_id도 null, assignee_ids도 없는 입력 → 둘 다 빈 상태', () => {
+    expect(normalizeAssigneePatch({ assignee_id: null })).toEqual({
+      assignee_id: null,
+      assignee_ids: [],
+    });
+    expect(normalizeAssigneePatch({})).toEqual({
+      assignee_id: null,
+      assignee_ids: [],
+    });
+  });
+
+  it('assignee_id와 assignee_ids가 함께 오면 assignee_ids(배열)가 SSOT — assignee_id는 무시되고 배열 첫 원소로 재계산된다', () => {
+    // #2130 SSE payload처럼 assignee_id·assignees(배열)가 동시에 오는 경우도, 배열이 있으면
+    // 배열을 기준으로 정합시켜 두 필드가 서로 다른 값을 가리키는 상태를 원천 봉쇄한다.
+    expect(normalizeAssigneePatch({ assignee_id: 'stale', assignee_ids: ['fresh'] })).toEqual({
+      assignee_id: 'fresh',
+      assignee_ids: ['fresh'],
+    });
+  });
+
+  it('미지 멤버(memberMap에 없는 id)도 그대로 정합된 patch를 낸다 — 렌더 실패와 state 정합은 별개', () => {
+    expect(normalizeAssigneePatch({ assignee_ids: ['unknown-member'] })).toEqual({
+      assignee_id: 'unknown-member',
+      assignee_ids: ['unknown-member'],
+    });
+  });
+
+  it('assignee_ids에 falsy 값이 섞여 있어도 걸러낸다', () => {
+    expect(normalizeAssigneePatch({ assignee_ids: ['m1', '', 'm2'] })).toEqual({
+      assignee_id: 'm1',
+      assignee_ids: ['m1', 'm2'],
+    });
+  });
+});

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -241,3 +241,25 @@ export const COLUMNS = [
 ] as const;
 
 export type ColumnId = (typeof COLUMNS)[number]['id'];
+
+// story #2133: assignee_id(단일)/assignee_ids(배열) 이중표현이 생산처마다 손으로
+// 맞춰지다 하루 2회(#2384·#2130) 동일 클래스로 어긋났다. assignee_ids를 단일 SSOT로 두고
+// assignee_id는 항상 그 파생값으로만 존재하게 해 "한쪽만 갱신" 자체를 불가능하게 만든다.
+export interface AssigneePatchInput {
+  assignee_id?: string | null;
+  assignee_ids?: string[] | null;
+}
+
+export interface AssigneePatch {
+  assignee_id: string | null;
+  assignee_ids: string[];
+}
+
+export function normalizeAssigneePatch(payload: AssigneePatchInput): AssigneePatch {
+  if (payload.assignee_ids !== undefined && payload.assignee_ids !== null) {
+    const ids = payload.assignee_ids.filter((id): id is string => Boolean(id));
+    return { assignee_ids: ids, assignee_id: ids[0] ?? null };
+  }
+  const id = payload.assignee_id ?? null;
+  return { assignee_id: id, assignee_ids: id ? [id] : [] };
+}


### PR DESCRIPTION
## 배경
같은 클래스 결함이 하루 2회 났다 — #2384(story-detail-panel), #2130(kanban-board SSE 핸들러). 생산처가 각자 손으로 `assignee_id`/`assignee_ids` 두 필드를 맞추다 한쪽만 갱신해 화면이 stale해지는 패턴.

## 처방
`normalizeAssigneePatch(payload) → { assignee_id, assignee_ids }` 순수 함수 1개(`kanban/types.ts`). `assignee_ids`(배열)를 SSOT로 두고 `assignee_id`는 항상 배열 첫 원소로만 파생 — 두 필드가 서로 다른 값을 가리키는 상태 자체를 불가능하게 만든다.

## 경유 처리 — grep 근거
실측(직접 grep, 아래 재현 가능): 두 필드를 손으로 세팅하던 자리는 **4곳**이었고 전부 정규화 함수를 경유하도록 교체했다.
- `kanban-board.tsx` — `story.assignee_changed` SSE 핸들러
- `story-detail-panel.tsx` — 멀티셀렉트 토글(L500대) / 전체 해제(L520대) / 단일 배정(dispatch 콜백, L960대) 3곳
- `entity-dispatch-panel.tsx` — dispatch 전 assignee 영속

`kanban-column.tsx`·`kanban-list-view.tsx`는 원래 PO 킥오프 메시지가 "생산처"로 지목했으나, 실제로는 `story.assignee_id`/`assignee_ids`를 **읽기만** 하고(카드/리스트 렌더용) 손으로 세팅하는 자리가 **0곳**이었다 — grep 결과 첨부:
```
$ grep -n "assignee_id:\|assignee_ids:" kanban-column.tsx kanban-list-view.tsx
(no output)
```
경유할 쓰기 지점이 없어 손대지 않았다. 소비처(`story-card.tsx`)도 설계대로 무변경.

### AC 대조
1. ✅ 정규화 함수 도입 + 실 생산처 4곳 전부 경유
2. ✅ `grep "assignee_id:\|assignee_ids:"` 로 손수 dual-set 자리 0곳 증명 (PR 본문 상단)
3. ✅ 회귀 테스트 신설(`types.test.ts`) — 단일/배열/빈값/미지 멤버/충돌(assignee_id≠assignee_ids) 조합 전부 고정
4. ✅ #2130 재현 시나리오는 기존 `kanban-board.test.tsx` 회귀가드가 이미 있고, 리팩터 후에도 그대로 green (무회귀 확인)
5. ✅ 타입 강제 — `assignee_ids`가 SSOT이므로 함수를 거치는 한 `assignee_id`를 독립적으로 잘못 세팅할 방법이 없음(런타임 강제)

이 수정이 실패하면(예: 함수 미경유 자리가 남으면) 그 자리에서 다시 `?? old`/`if(새값)` 폴백으로 조용히 옛 상태가 남는다 — grep 0건이 유일한 실질적 방지책.

## 검증
- `pnpm vitest run` (types.test.ts + kanban-board.test.tsx + entity-dispatch-panel.test.tsx) — 19/19 PASS
- `pnpm exec eslint` (변경 5파일) — 경고 0
- `pnpm exec tsc --noEmit` — 에러 0
- `pnpm build` — EXIT 0

## 스코프
새 컴포넌트·새 상태 신설 없음. `story-card.tsx`(소비처) 무변경. `kanban-column.tsx`/`kanban-list-view.tsx`는 경유할 쓰기 지점이 없어 무변경(위 grep 근거).

## 기록(오르테가 AC 검수 中 지적, 변경 요청 아님)
`story-detail-panel.tsx:501` — `patchStory` 응답이 `assignee_ids`를 안 주면 `updated.assignee_ids ?? next`로 **요청값(next)에 폴백**한다. 서버가 요청과 다른 값을 돌려주는 상황이면 화면이 잠깐 요청값을 믿는 형태. 지금 스코프에선 낙관적 업데이트로 자연스럽고 문제 없으나, 나중에 서버가 배정을 조정하는 규칙이 생기면 이 자리가 재검토 1순위.
