### PR TITLE
fix(#2077): prod minScale 1→3 을 main 배포 SSOT 에 못박기 (최소 cherry-pick)

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -49,7 +49,15 @@ jobs:
           if [[ "${{ github.ref_name }}" == "main" ]]; then
             echo "target=prod" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-prod-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
-            echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
+            # ⚠️ minScale 1→3 (story #2077·prod 콜드스타트 durable, 오르테가군 PO 2026-07-23 cherry-pick):
+            # dev #2074 응급대응이 dev 만 3으로 올리고 prod 는 1로 남아 2026-07-22 아침 prod 콜드스타트가
+            # 재발했다. 그때 PO 가 `gcloud run services update` 로 prod minScale=3 을 라이브 적용(승인된
+            # 조치)했고, 그 값은 지금도 라이브다(07-23 PO 실측 확認). 그러나 이 SSOT 는 1 로 남아 있어
+            # **다음 main push 가 prod 를 1 로 되돌리는** 상태였다 — "손 값은 다음 배포가 덮는다" 교훈이
+            # 정작 prod 쪽에 반영되지 않았던 것. develop 에는 #2409 로 이미 들어가 있으나 승격이 80커밋
+            # 규모라, 라이브와 SSOT 를 일치시키는 이 한 줄만 먼저 main 에 못박는다(동작 변화 0).
+            # conn-safe: min 3 × per-instance 5 = 15 ≤ 200(maxScale 5·rollout 70 예산 불변).
+            echo "backend_min_instances=3" >> "$GITHUB_OUTPUT"
             # ⚠️ maxScale 5 (ee7794eb ③·선생님 right-size): prod g1-small max_conn 100. per-instance 5(pool
             # 3/1=4 + pg_pubsub raw 1). rollout(old+new 2×): 2×5×5+20(admin)=70 ≤ 100 ✓ (여유 30).
             # (PgBouncer 풀러 불필요 — Cloud Run raw TCP 미지원으로 중앙 PgBouncer 불가·관리형 풀링은 Enterprise Plus


### PR DESCRIPTION
## 왜 지금 main 인가

- **prod 라이브 = minScale 3** (2026-07-22 콜드스타트 재발 시 PO 가 `gcloud run services update` 로 적용한 승인된 조치. 07-23 PO 재실측으로 현재도 3 확認)
- **origin/main 배포 SSOT = 1** ← 그대로였음
- ⇒ **다음 main push 가 도는 순간 prod minScale 이 1 로 원복**되어 콜드스타트가 되살아나는 조합. 지금 안 터진 유일한 이유는 07-20 이후 prod 배포가 없었기 때문.

develop 에는 #2409 로 이미 반영돼 있으나 `main↔develop` 격차가 **80커밋**이라 승격을 기다리면 그 사이 main push 가 곧 사고가 된다. 그래서 **이 한 줄만** 최소 cherry-pick 한다. (선생님 결재 2026-07-23)

## 변경

`.github/workflows/cloud-build.yml` prod 분기 1줄 + 근거 주석:

```
- echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
+ echo "backend_min_instances=3" >> "$GITHUB_OUTPUT"
```

## 실동작 영향

**0** — 지금 prod 에 떠 있는 값(3)과 SSOT 를 일치시키는 것뿐. 배포가 돌아도 minScale 은 현재와 동일하게 3.

## conn-safe 검산

`min 3 × per-instance 5(pool 3/1=4 + pg_pubsub raw 1) = 15 ≤ 200` (max_connections 200 · maxScale 5 rollout 예산 70 불변)

## 확認 방법

머지 후 prod 배포 완료 시 `gcloud run services describe sprintable-backend-prod --format="value(spec.template.metadata.annotations)"` 로 `minScale=3` 유지 확認 (PO 가 배포 직후 실측한다).

🤖 Generated with [Claude Code](https://claude.com/claude-code)