### PR TITLE
[SID:2137] 상세 패널이 SSE 배정/상태 변경을 반영하지 않던 결함 fix

### DIFF
--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -258,3 +258,82 @@ describe('KanbanBoard — 실시간(SSE) 반영', () => {
     expect(container.textContent).toContain('오르테가님이 S1 담당자를 변경했습니다');
   });
 });
+
+// story #2137 — 카드는 갱신되는데 상세 패널만 옛값에 고정되던 결함(#2384·#2130과 같은 클래스의
+// 3번째 재발). 카드(stories 배열)와 패널(selectedStory)이 별도 state라 SSE 패치가 stories에만
+// 적용되던 게 근본 — patchStoryFromSse가 둘을 같이 갱신하는지 패널 스코프(role=dialog)로 고정한다.
+describe('KanbanBoard — 실시간(SSE) 상세 패널 동기화(#2137)', () => {
+  async function openPanel(title: string) {
+    const card = container.querySelector(`[title="${title}"]`) as HTMLElement | null;
+    expect(card).not.toBeNull();
+    await act(async () => {
+      card!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it('패널이 열려 있을 때 다른 사람이 담당자를 바꾸면 패널도 새 담당자로 갱신된다', async () => {
+    stubFetch(
+      [{ id: 's1', title: 'S1', status: 'backlog', priority: 'medium', assignee_id: 'old-1', assignee_ids: ['old-1'] }],
+      [{ id: 'old-1', name: '올드멤버', type: 'human' }, { id: 'new-1', name: '뉴멤버', type: 'agent' }],
+    );
+    await mount();
+    await openPanel('S1');
+    const dialog = container.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+    expect(dialog!.textContent).toContain('올드멤버');
+
+    await act(async () => {
+      dispatchSse('story.assignee_changed', {
+        story_id: 's1', project_id: 'proj-1', actor_id: 'other-1', actor_name: '까심',
+        assignee_id: 'new-1', old_assignee_id: 'old-1', assignees: ['new-1'],
+      });
+      await Promise.resolve();
+    });
+
+    expect(dialog!.textContent).toContain('뉴멤버');
+    expect(dialog!.textContent).not.toContain('올드멤버');
+  });
+
+  it('패널이 열려 있을 때 다른 사람이 담당자를 해제하면 패널도 미배정으로 갱신된다', async () => {
+    stubFetch(
+      [{ id: 's1', title: 'S1', status: 'backlog', priority: 'medium', assignee_id: 'old-1', assignee_ids: ['old-1'] }],
+      [{ id: 'old-1', name: '올드멤버', type: 'human' }],
+    );
+    await mount();
+    await openPanel('S1');
+    const dialog = container.querySelector('[role="dialog"]');
+    expect(dialog!.textContent).toContain('올드멤버');
+
+    await act(async () => {
+      dispatchSse('story.assignee_changed', {
+        story_id: 's1', project_id: 'proj-1', actor_id: 'other-1', actor_name: '까심',
+        assignee_id: null, old_assignee_id: 'old-1', assignees: [],
+      });
+      await Promise.resolve();
+    });
+
+    expect(dialog!.textContent).not.toContain('올드멤버');
+  });
+
+  it('패널이 열려 있을 때 다른 사람이 상태를 바꾸면 패널도 새 상태로 갱신된다', async () => {
+    stubFetch([{ id: 's1', title: 'S1', status: 'backlog', priority: 'medium' }]);
+    await mount();
+    await openPanel('S1');
+    const dialog = container.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+
+    await act(async () => {
+      dispatchSse('story.status_changed', {
+        story_id: 's1', project_id: 'proj-1', actor_id: 'other-1', actor_name: '댄',
+        status: 'ready-for-dev', old_status: 'backlog',
+      });
+      await Promise.resolve();
+    });
+
+    // story-detail-panel.tsx: useEffect(() => setLocalStatus(story.status), [story.status]) 가
+    // selectedStory prop 갱신을 따라가는지 — StatusBadge 라벨 텍스트로 확認.
+    expect(dialog!.textContent).toContain('개발 대기');
+  });
+});

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -252,6 +252,16 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
   // 아직 로드 안 된 카드(다른 컬럼 페이지네이션 밖)의 신규 진입은 이 스토리 스코프 밖으로 둔다.
   const { currentTeamMemberId } = useDashboardContext();
 
+  // story #2137 — 카드(stories 배열)와 상세 패널(selectedStory)이 별도 state라, SSE 패치를
+  // stories에만 적용하면 패널만 옛값에 고정된다(#2384·#2130과 같은 클래스의 3번째 재발 — 이번엔
+  // "갱신 신호를 아예 안 듣는 표면"). patchStory 하나로 묶어 두 state를 항상 같이 갱신해
+  // "한쪽만 패치" 자체를 구조적으로 불가능하게 만든다 — 이 handler에 새 이벤트 분기가 추가돼도
+  // 자동으로 이 보장을 물려받는다.
+  const patchStoryFromSse = useCallback((storyId: string, patch: Partial<KanbanStory>) => {
+    setStories((prev) => prev.map((s) => (s.id === storyId ? { ...s, ...patch } : s)));
+    setSelectedStory((prev) => (prev && prev.id === storyId ? { ...prev, ...patch } : prev));
+  }, []);
+
   const handleBoardSseEvent = useCallback((eventName: string, data: unknown) => {
     const payload = data as {
       story_id?: string;
@@ -272,16 +282,14 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
     const titleForToast = existing.title;
     if (eventName === 'story.status_changed' && payload.status && payload.status !== existing.status) {
       const newStatus = payload.status;
-      setStories((prev) => prev.map((s) => (s.id === payload.story_id ? { ...s, status: newStatus } : s)));
+      patchStoryFromSse(payload.story_id, { status: newStatus });
       adjustColumnTotal(existing.status, -1);
       adjustColumnTotal(newStatus, +1);
     } else if (eventName === 'story.assignee_changed') {
       // story #2133 — normalizeAssigneePatch가 assignee_id/assignee_ids 정합을 강제한다.
       // 손으로 두 필드를 따로 계산하던 자리(#2130 근본)를 구조로 제거.
       const assigneePatch = normalizeAssigneePatch({ assignee_id: payload.assignee_id, assignee_ids: payload.assignees });
-      setStories((prev) => prev.map((s) => (
-        s.id === payload.story_id ? { ...s, ...assigneePatch } : s
-      )));
+      patchStoryFromSse(payload.story_id, assigneePatch);
     } else {
       return;
     }
@@ -295,7 +303,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
         ? t('realtimeStatusChanged', { actor: actorLabel, title: titleForToast })
         : t('realtimeAssigneeChanged', { actor: actorLabel, title: titleForToast }),
     });
-  }, [projectId, currentTeamMemberId, stories, adjustColumnTotal, addToast, t]);
+  }, [projectId, currentTeamMemberId, stories, adjustColumnTotal, addToast, t, patchStoryFromSse]);
 
   useSseNotifications({
     memberId: currentTeamMemberId,


### PR DESCRIPTION
## 배경 — 까심 라이브 QA(프로브 카드 #2134, dev)
WATCHER=sellerking(칸반 카드+상세 패널 두 표면 동시 오픈) · ACTOR=오르테가(≠워처).

| 케이스 | 카드 | 패널 |
|---|---|---|
| 오르테가→미르코 재배정 | ✅ PASS(즉시 반영) | ❌ FAIL(무반응) |
| 미르코→해제 | ✅ PASS(즉시 반영) | ❌ FAIL(무반응) |

프레임 도달은 카드가 갱신됐다는 사실로 증명됨(같은 순간·같은 페이지). **패널만 그 프레임을 반영하지 않았다.** 패널의 로컬 렌더 자체는 정상(자기 자신에게 Dispatch하면 즉시 반영) — 죽은 건 **SSE 수신 → 패널 상태 반영 경로**.

`#2384`(07-22 오전)·`#2130`(07-23 새벽)에 이어 같은 클래스 3회째. 앞의 둘은 "갱신하는 쪽이 한 필드만 고침"이었고, 이번은 "갱신 신호를 아예 안 듣는 표면"이라 층이 하나 더 깊다.

## 근본
`kanban-board.tsx`에서 카드는 `stories`(배열) state로, 상세 패널은 `selectedStory`(별도 단일 state)로 렌더된다. `handleBoardSseEvent`는 `setStories`만 갱신하고 `selectedStory`는 전혀 건드리지 않았다 — 두 표면이 SSE 패치를 받는 경로 자체가 분리돼 있었다.

`story-detail-panel.tsx` 쪽은 무죄: `story` prop이 바뀌면 `localStatus`(`useEffect(() => setLocalStatus(story.status), [story.status])`)와 assignee 로컬 state(`assigneeSyncKey` effect) 둘 다 이미 정상적으로 재동기화된다. prop 자체가 안 바뀌었을 뿐.

## 처방(AC2 — 구조로 일원화)
`patchStoryFromSse(storyId, patch)` 헬퍼 하나로 `stories`+`selectedStory` 갱신을 항상 함께 묶었다. `story.status_changed`/`story.assignee_changed` 두 분기 모두 이걸 경유하도록 교체 — 앞으로 이 핸들러에 새 분기가 추가돼도 "한쪽만 패치"가 구조적으로 불가능하다.

## AC3 — 다른 필드도 전수 확認
`kanban-board.tsx`가 SSE로 실제 구독 중인 이벤트는 `story.status_changed`·`story.assignee_changed` **2종뿐**(`extraEventNames`로 grep 확인). 이번 fix로 이 2종 모두 카드+패널 동시 반영이 보장된다.

`story.trust_stage_changed`·`story.declared_scope_changed` 등 BE가 emit하는 다른 story 이벤트는 애초에 board/panel 어느 쪽도 구독하지 않는다(별도 서피스인 attention-queue만 trust_stage_changed 구독) — 이 PR로 새로 생긴 갭이 아니라 기존 스코프 밖이며, 새 구독 추가는 #2132 (ii)에서 이미 "신기능이라 이번 라운드 스코프 아님"으로 확定됨. 여기서 같이 끼워 넣지 않았다.

**스코프 명시(오르테가 리뷰 반영)**: 이 보드 핸들러가 구독하는 SSE는 `story.status_changed`·`story.assignee_changed` 둘뿐이므로, "패널이 SSE로 받아야 할 필드"도 지금은 이 둘이 전부다 — "담당자만 고쳤다"가 아니라 **현재 구독 범위 전체(2/2)를 고쳤다**.

## AC4 — 실패 시 무엇이 그려지나
`patchStoryFromSse`가 누락되면(이번 결함) 패널은 조용히 옛값을 유지한다 — 에러도 없고 토스트는 뜨는데(핸들러는 실행됨) 화면만 안 바뀌어 "내 화면이 이상한가"로 사람이 오인하게 만드는 자리였다. 회귀 테스트로 고정.

**편집 중 덮어쓰기 검토(오르테가 리뷰 반영)**: 패널을 열어두고 유저가 편집 중일 때 SSE 패치가 도착하면 `story` prop 변경 → 재동기화 `useEffect`가 로컬 값을 덮어쓰는지 코드로 확認했다.
- `titleDraft`/`descriptionDraft`/`acDraft`(제목·설명·완료조건 편집 버퍼)는 `story` prop과 동기화하는 `useEffect`가 **아예 없다**(`story-detail-panel.tsx` grep) — 애초에 이번 patch(`status`/`assignee_id`/`assignee_ids`만 담음)가 건드리는 필드도 아니라 영향 0.
- `status`/`assignee`는 둘 다 **클릭 즉시 낙관 반영 + PATCH**(드래프트를 모았다 제출하는 구조가 아님) 패턴이라 "입력 중이던 값 유실"이 원천적으로 없다. 경합 시나리오(내가 클릭 직후 PATCH 응답 대기 중에 남의 SSE가 도착)에서는 `useEffect`가 순간적으로 SSE값으로 되돌릴 수 있으나, 내 PATCH가 이어서 resolve되면 `onStoryUpdate`가 내 결과로 다시 덮어써 **최종 상태는 마지막에 resolve된 네트워크 응답으로 수렴**한다(기존 `onStoryUpdate` 재동기화와 동일한 성질 — 이 PR이 새로 만든 경합이 아니라 기존에도 있던 "last response wins" 특성). 순간 깜빡임 가능성은 **알려진 한계로 기록**하되 이번 스코프에서 고치지 않는다.

## 검증
- 신규 테스트 3건(패널 스코프 `role="dialog"`로 고정): 재배정/해제/상태변경 — **fix를 임시로 되돌려 RED 확認 후 복원해 GREEN 재확認**(sanity check).
- `pnpm vitest run` `kanban-board.test.tsx` — 13/13 PASS
- `pnpm exec eslint`(변경 2파일) — 0
- `pnpm exec tsc --noEmit` — 0
- `pnpm build` — EXIT 0

## 스코프
`story-detail-panel.tsx` 무변경. 새 컴포넌트·새 상태 신설 없음(기존 두 state를 한 헬퍼로 묶었을 뿐). dev 배포 후 까심 3케이스(프로브 카드 #2134) 재실행이 AC5(라이브 재확認)의 완결.
