### PR TITLE
[SID:2136] BE emit 매치가 0인 죽은 SSE 구독 정리

### DIFF
--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -221,17 +221,6 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
     }
   }, [isNearBottom, clearTyping, markRead]);
 
-  const handleNewMessage = useCallback((msg: ChatMessage) => {
-    if (msg.memo_id !== threadId) return;
-    addMessage(msg);
-  }, [threadId, addMessage]);
-
-  const handleReplyCreated = useCallback((memoId: string) => {
-    if (memoId !== threadId) return;
-    // reply_created SSE: refetch to pick up messages not delivered via chat:message
-    fetchMessages();
-  }, [threadId, fetchMessages]);
-
   // HIGH-2: conversation:message SSE — payload uses conversation_id (normalizeToMessage maps it to memo_id)
   const handleConversationMessage = useCallback((payload: Record<string, unknown>) => {
     const conversationId = (payload.conversation_id ?? payload.id) as string | undefined;
@@ -286,8 +275,6 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
 
   useChatSse({
     currentTeamMemberId,
-    onNewMessage: handleNewMessage,
-    onReplyCreated: handleReplyCreated,
     onConversationMessage: handleConversationMessage,
     onWorking: handleWorking,
     onReconnect: handleReconnect,

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -50,16 +50,6 @@ export function normalizeToMessage(raw: Record<string, unknown>): ChatMessage {
   };
 }
 
-// Backend SSE chat:message payload format (_to_chat_message)
-interface SseChatPayload {
-  id: string;
-  thread_id: string;
-  content: string;
-  sender: { id: string; name?: string; type?: string };
-  attachments: unknown[];
-  created_at: string;
-}
-
 /** R2(da9d1781): conversation.working SSE payload — `chat_presence.list_working` 목록. */
 export interface SseWorkingPayload {
   conversation_id: string;
@@ -76,8 +66,6 @@ export interface SseConversationReadPayload {
 
 interface UseChatSseOptions {
   currentTeamMemberId?: string;
-  onNewMessage?: (message: ChatMessage) => void;
-  onReplyCreated?: (memoId: string) => void;
   onConversationMessage?: (payload: Record<string, unknown>) => void;
   // R2: 채팅 working/typing — 1.5s 폴(/conversations/{id}/working) 대체.
   onWorking?: (payload: SseWorkingPayload) => void;
@@ -89,15 +77,13 @@ interface UseChatSseOptions {
 // story #2095 — 재연결 backoff는 sse-reconnect-backoff.ts(공용, sse-multiplexer.ts와
 // 동일 모듈 재사용)로 뽑았다.
 
-export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, onConversationMessage, onWorking, onConversationRead, onReconnect }: UseChatSseOptions) {
+export function useChatSse({ currentTeamMemberId, onConversationMessage, onWorking, onConversationRead, onReconnect }: UseChatSseOptions) {
   const [connected, setConnected] = useState(false);
   const sourceRef = useRef<EventSource | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // react-hooks/refs: 렌더 중 ref.current 조건부 대입 금지라 지연초기화는 useState(초기화 함수)로.
   const [backoff] = useState<ReconnectBackoffState>(() => createReconnectBackoffState());
   const lastEventIdRef = useRef<string | null>(null);
-  const onNewMessageRef = useRef(onNewMessage);
-  const onReplyCreatedRef = useRef(onReplyCreated);
   const onConversationMessageRef = useRef(onConversationMessage);
   const onWorkingRef = useRef(onWorking);
   const onConversationReadRef = useRef(onConversationRead);
@@ -106,28 +92,12 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
 
   // useLayoutEffect: DOM commit 후 동기 실행 — useEffect(비동기)보다 먼저 실행되어
   // SSE 이벤트 도달 전에 ref가 항상 최신 콜백을 가리킴 (stale closure 방지)
-  useLayoutEffect(() => { onNewMessageRef.current = onNewMessage; }, [onNewMessage]);
-  useLayoutEffect(() => { onReplyCreatedRef.current = onReplyCreated; }, [onReplyCreated]);
   useLayoutEffect(() => { onConversationMessageRef.current = onConversationMessage; }, [onConversationMessage]);
   useLayoutEffect(() => { onWorkingRef.current = onWorking; }, [onWorking]);
   useLayoutEffect(() => { onConversationReadRef.current = onConversationRead; }, [onConversationRead]);
   useLayoutEffect(() => { onReconnectRef.current = onReconnect; }, [onReconnect]);
   useLayoutEffect(() => { memberIdRef.current = currentTeamMemberId; }, [currentTeamMemberId]);
 
-  const handleChatMessage = (raw: string) => {
-    if (shouldSuppressDuplicateSseEvent(raw)) return;
-    try {
-      const payload = JSON.parse(raw) as SseChatPayload;
-      onNewMessageRef.current?.(normalizeToMessage(payload as unknown as Record<string, unknown>));
-    } catch { /* ignore parse errors */ }
-  };
-  const handleReplyCreated = (raw: string) => {
-    if (shouldSuppressDuplicateSseEvent(raw)) return;
-    try {
-      const payload = JSON.parse(raw) as { id?: string; memo_id?: string };
-      if (payload.memo_id) onReplyCreatedRef.current?.(payload.memo_id);
-    } catch { /* ignore parse errors */ }
-  };
   const handleConversationMessage = (raw: string) => {
     if (shouldSuppressDuplicateSseEvent(raw)) return;
     try {
@@ -150,13 +120,17 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
   };
 
   // story #2078 — 멀티플렉서(플래그 ON)가 있으면 공유 커넥션에 이름별 구독만 얹는다.
+  //
+  // story #2136 — `chat:message`·`reply_created` 구독을 제거했다. 둘 다 BE emit 문자열과
+  // 매치가 0(grep 확認, `reply_created`가 참조하던 `memos.py`는 backend에 아예 없음)이라
+  // 실제로는 한 번도 fire된 적 없는 죽은 자리였고, 두 이벤트가 하려던 일(신규 메시지 반영)은
+  // 이미 살아있는 canonical 경로 `conversation.message_created`(S-COMM-12, 아래
+  // handleConversationMessage)가 전부 커버한다 — 별도 기능 손실 없이 제거.
   const mux = useSseMultiplexerContext();
 
   useEffect(() => {
     if (!mux) return;
     const unsubs = [
-      mux.subscribe('chat:message', handleChatMessage),
-      mux.subscribe('reply_created', handleReplyCreated),
       mux.subscribe('conversation.message_created', handleConversationMessage),
       mux.subscribe('conversation.working', handleWorking),
       mux.subscribe('conversation.read', handleConversationRead),
@@ -200,18 +174,6 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
           }, delay);
         }
       };
-
-      // chat:message — backend _to_chat_message format: { id, thread_id, sender: { id }, ... }
-      source.addEventListener('chat:message', (e: MessageEvent) => {
-        if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
-        handleChatMessage(e.data as string);
-      });
-
-      // reply_created — from memos.py publish_event; use as refetch trigger
-      source.addEventListener('reply_created', (e: MessageEvent) => {
-        if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
-        handleReplyCreated(e.data as string);
-      });
 
       // conversation.message_created — realtime update for conversation list
       // S-COMM-12: canonical 이름만 리슨. server가 legacy(conversation:message)도 병행 emit하므로

--- a/apps/web/src/hooks/use-sse-notifications.ts
+++ b/apps/web/src/hooks/use-sse-notifications.ts
@@ -33,6 +33,14 @@ interface UseSseNotificationsOptions {
   onExtraEvent?: (eventName: string, data: unknown) => void;
 }
 
+// story #2136 — 이 3개 literal 이름은 BE emit 문자열과 매치가 0이다(grep 확認: `publish_event(...)`도
+// `Event(event_type=...)`도 이 문자열들을 쓰는 자리가 저장소 전체 0곳). 즉 지금은 named 이벤트로는
+// 절대 안 온다. 그런데도 지운 게 아니라 **남긴 이유**: 유일한 소비처 `notification-bell.tsx`가 이
+// 채널을 30s 폴 fallback과 병행 사용 중이라(`useSseNotifications({ onNotification, ... })`), 이
+// 배열을 비워도 관측 가능한 동작 변화는 0(bell은 폴링만으로 이미 정확) — "고쳤다"는 착시가 나기
+// 쉬운 자리다. 실 알림 전달은 named 이벤트가 아니라 `subscribeMessage`/`onmessage`(기본 unnamed
+// SSE 메시지) 경로로 도는 것으로 보이며, 이 3개 이름이 실제로 쓰일 미래 BE 계약을 의도한 자리인지
+// 완전한 죽은 코드인지는 이 스토리 스코프 밖(BE 판단 필요) — 그래서 제거 대신 주석으로 박아둔다.
 const NOTIFICATION_EVENT_NAMES = ['event_notification', 'notification', 'new_notification'];
 
 // story #2095 — 재연결 backoff는 sse-reconnect-backoff.ts(공용)로 뽑았다(독립 연결 폴백

--- a/apps/web/src/hooks/use-sse-notifications.ts
+++ b/apps/web/src/hooks/use-sse-notifications.ts
@@ -40,7 +40,8 @@ interface UseSseNotificationsOptions {
 // 배열을 비워도 관측 가능한 동작 변화는 0(bell은 폴링만으로 이미 정확) — "고쳤다"는 착시가 나기
 // 쉬운 자리다. 실 알림 전달은 named 이벤트가 아니라 `subscribeMessage`/`onmessage`(기본 unnamed
 // SSE 메시지) 경로로 도는 것으로 보이며, 이 3개 이름이 실제로 쓰일 미래 BE 계약을 의도한 자리인지
-// 완전한 죽은 코드인지는 이 스토리 스코프 밖(BE 판단 필요) — 그래서 제거 대신 주석으로 박아둔다.
+// 완전한 죽은 코드인지는 FE 혼자 판단할 문제가 아니라 이 스토리 스코프 밖에 둔다.
+// ⚠️BE 확認 후 정리 대상 — BE가 이 이름들로 emit할 계획이 없다고 확定되면 그때 지운다.
 const NOTIFICATION_EVENT_NAMES = ['event_notification', 'notification', 'new_notification'];
 
 // story #2095 — 재연결 backoff는 sse-reconnect-backoff.ts(공용)로 뽑았다(독립 연결 폴백


### PR DESCRIPTION
## 배경 (#2132 판정자료에서 분리)
FE가 구독 중인 SSE 이벤트 이름 중 **BE가 실제로 발행하는 문자열과 매치가 0인 것**이 있었다(grep, 근거는 #2132 조사).
```
chat:message            → BE emit 매치 0
reply_created           → BE emit 매치 0. 코드 주석은 "memos.py 의 publish_event"를 참조하는데
                          memos.py 자체가 지금 backend 에 없다(find 결과 0) — 죽은 참조
event_notification / notification / new_notification (기본 3종 그룹)
                          → publish_event 도, Event(event_type=) 도 전무
```

기능 영향은 0(애초에 안 오던 이벤트라 화면은 항상 정상이었음). 문제는 **읽는 사람이 "이건 실시간으로 온다"고 믿게 되는 것** — 오늘 하루 이 오해가 반복 결함을 만들었다(#2384·#2130·#2137이 전부 "패치가 도착 안 한다/한쪽만 간다"는 변주였고, 죽은 구독이 진단을 흐렸다).

## 처방
**① `chat:message`·`reply_created` — 제거** (`use-chat-sse.ts` + `chat-view.tsx`)
- `reply_created`가 참조하던 `memos.py`가 backend에 없음(죽은 참조 확定).
- 두 이벤트가 하려던 일(신규 메시지를 스레드에 반영)은 이미 살아있는 canonical 경로 `conversation.message_created`(S-COMM-12, `handleConversationMessage`)가 전부 커버 — 기능 손실 없음.
- `chat-view.tsx`의 대응 콜백(`handleNewMessage`/`handleReplyCreated`)도 같이 제거(다른 소비처 0곳, grep 확認).

**② `event_notification`/`notification`/`new_notification`(기본 3종) — 제거 대신 주석**
- 유일한 소비처 `notification-bell.tsx`가 이 채널 + 30s 폴 fallback을 병행 — 배열을 비워도 관측 가능한 동작 변화 0.
- 실 알림 전달은 named 이벤트가 아니라 `subscribeMessage`/`onmessage`(기본 unnamed SSE) 경로로 도는 것으로 보임. 이 3개 이름이 향후 BE 계약을 의도한 자리인지 완전 죽은 코드인지는 BE 판단이 필요해 이 스토리 스코프 밖 — 임의 제거 대신 근거를 주석으로 박아 "왜 남아있는지" 다음 사람이 다시 안 파도 되게 했다.

**대상 아님**: `presence`·`conversation.working` — 이름은 BE와 일치하고 전달경로만 dead 의혹인 별개 건(#2139, 라이브 확定됨). 이 스토리와 메커니즘이 다르다.

## AC 대조
1. ✅ `chat:message`·`reply_created`는 제거, 기본 3종은 주석으로 사유 명시 — 말없이 방치한 자리 없음.
2. ✅ 판단 근거 전부 BE emit 문자열 기준(grep 원문 위 참조).
3. ✅ 무회귀 — 제거된 두 이벤트는 애초에 fire된 적이 없어(0 BE match) 화면 동작 자체가 자명하게 그대로다. 공유 커넥션 훅(`mux.subscribe`/`addEventListener` 배열)에서 각 이름은 독립 등록이라 다른 구독(`conversation.message_created`/`conversation.working`/`conversation.read`)에는 손도 안 댐 — vitest/eslint/tsc/build 전부 그린으로 교차확認.
4. ✅ `presence`/`conversation.working`은 이 스토리 대상 아님(코드 무변경).

## 검증
- `pnpm vitest run`(`sse-multiplexer.test.tsx` + `src/hooks/**`) — 6 files/30 tests PASS
- `pnpm exec eslint`(변경 3파일) — 0
- `pnpm exec tsc --noEmit` — 0
- `pnpm build` — EXIT 0

## 스코프
새 컴포넌트·새 상태 신설 없음. `presence`/`conversation.working` 무변경(별건).