### PR TITLE
[SID:2139] use-team-presence 폴백 정책 — 재연결 시 강제 refetch

### DIFF
--- a/apps/web/src/components/presence/use-team-presence.test.tsx
+++ b/apps/web/src/components/presence/use-team-presence.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+//
+// story #2139 — 폴백 정책 결정(PO): 주기 폴링은 재도입하지 않고(#2074 인스턴스 기아 교훈),
+// 재연결 시 1회 강제 refetch만 추가한다. 이 테스트는 독립 EventSource 폴백 경로(mux 없음)에서
+// isReconnect() 판정이 정확히 작동하는지 고정한다 — onerror를 안 걸면 hadPriorError가 영원히
+// false라 재연결 refetch가 죽은 코드가 되는 함정이 있어(직접 확認), 그 회귀를 막는다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useTeamPresence } from './use-team-presence';
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  listeners: Record<string, Array<() => void>> = {};
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+  constructor(public url: string, _opts?: unknown) {
+    FakeEventSource.instances.push(this);
+  }
+  addEventListener(type: string, cb: () => void) {
+    (this.listeners[type] ??= []).push(cb);
+  }
+  close() { this.closed = true; }
+  emit(type: string) {
+    for (const cb of this.listeners[type] ?? []) cb();
+  }
+}
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  FakeEventSource.instances = [];
+  (globalThis as unknown as { EventSource: typeof FakeEventSource }).EventSource = FakeEventSource;
+  fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({ data: [] }) }));
+  vi.stubGlobal('fetch', fetchMock);
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function Harness({ active, memberId }: { active: boolean; memberId?: string }) {
+  useTeamPresence(active, memberId);
+  return null;
+}
+
+describe('useTeamPresence — 독립 연결 폴백의 재연결 refetch(#2139)', () => {
+  it('최초 open은 refetch를 유발하지 않는다(초기 스냅샷 fetch 1회만)', async () => {
+    await act(async () => {
+      root.render(<Harness active memberId="m1" />);
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1); // 초기 스냅샷
+    const es = FakeEventSource.instances[0]!;
+    await act(async () => {
+      es.onopen?.(); // 최초 open — isReconnect()는 아직 false
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1); // 늘지 않음
+  });
+
+  it('error 후 재open되면 강제 refetch가 1회 추가된다', async () => {
+    await act(async () => {
+      root.render(<Harness active memberId="m1" />);
+      await Promise.resolve();
+    });
+    const es = FakeEventSource.instances[0]!;
+    await act(async () => {
+      es.onopen?.(); // 최초 open
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      es.onerror?.(); // 끊김 — backoff가 hadPriorError=true로 기록
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1); // error 자체는 fetch 유발 안 함
+
+    await act(async () => {
+      es.onopen?.(); // 재연결(native auto-reconnect가 다시 연 것으로 시뮬레이션)
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2); // 재연결 refetch 발화
+  });
+
+  it('presence 이벤트 자체도 여전히 refetch를 유발한다(기존 동작 무회귀)', async () => {
+    await act(async () => {
+      root.render(<Harness active memberId="m1" />);
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const es = FakeEventSource.instances[0]!;
+    await act(async () => {
+      es.emit('presence');
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/components/presence/use-team-presence.ts
+++ b/apps/web/src/components/presence/use-team-presence.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { PresenceStatus } from '@/components/chat/presence-dot';
 import { useSseMultiplexerContext } from '@/components/realtime-provider';
+import { createReconnectBackoffState } from '@/lib/realtime/sse-reconnect-backoff';
 
 // 2505d27d: #1356 `GET /api/v2/team-presence` 응답 계약(검증 완료·mismatch 0).
 export interface TeamPresenceItem {
@@ -23,7 +24,17 @@ export interface TeamPresenceItem {
  * 스냅샷은 refetch 로 확보(BE 계약). `document.hidden` 이면 fetch 0(낭비 가드 유지).
  *
  * story #2078 — 플래그 ON이면 RealtimeProvider의 공유 커넥션에 'presence' 이벤트만 구독한다
- * (독립 EventSource를 안 연다). 플래그 OFF/Provider 밖이면 기존과 동일하게 자체 연결.
+ * (독립 EventSource를 안 여는). 플래그 OFF/Provider 밖이면 기존과 동일하게 자체 연결.
+ *
+ * story #2139 — 폴백 정책 결정(PO): 주기 폴링은 재도입하지 않는다(#2074 인스턴스 기아 교훈 —
+ * 그래서 애초에 걷어낸 것). 대신 **재연결 시 1회 강제 refetch**를 추가한다 — 새 메커니즘이
+ * 아니라 `use-chat-sse.ts`가 이미 쓰는 `subscribeReconnect`/`isReconnect` 패턴의 재사용이고,
+ * "실시간이 죽으면 조용히 낡는" 구멍의 대부분이 연결이 끊겼다 재연결되는 구간이라 비용 대비
+ * 효과가 크다(참고: `sse-reconnect-backoff.ts` 문서 — Cloud Run 60s 요청 타임아웃 때문에
+ * 이 재연결 자체가 정상 운영 중 계속 반복되는 예정된 이벤트라, 부수적으로 수십초~1분 단위
+ * 백스톱처럼도 작동한다). ⚠️남는 리스크: **연결은 살아있는데 특정 named 이벤트만 안 오는
+ * 경우**는 이 폴백으로 못 잡는다(#2139가 정확히 이 형태 — heartbeat·연결 전부 정상인데
+ * presence만 0건 관측됨). 그건 폴백이 아니라 배달 경로 자체를 일원화하는 것(#2132)이 답이다.
  */
 export function useTeamPresence(active: boolean, memberId?: string): TeamPresenceItem[] {
   const [items, setItems] = useState<TeamPresenceItem[]>([]);
@@ -49,17 +60,34 @@ export function useTeamPresence(active: boolean, memberId?: string): TeamPresenc
     document.addEventListener('visibilitychange', onVisible);
 
     if (mux) {
-      const unsub = mux.subscribe('presence', () => { void fetchPresence(); });
-      return () => { unsub(); document.removeEventListener('visibilitychange', onVisible); };
+      const unsubPresence = mux.subscribe('presence', () => { void fetchPresence(); });
+      // story #2139 — 공유 커넥션이 끊겼다 재연결되면 그 구간에 놓쳤을 변경을 강제 refetch로 흡수.
+      const unsubReconnect = mux.subscribeReconnect(() => { void fetchPresence(); });
+      return () => {
+        unsubPresence();
+        unsubReconnect();
+        document.removeEventListener('visibilitychange', onVisible);
+      };
     }
 
-    // 독립 연결 폴백(플래그 OFF 또는 Provider 밖) — story #2078 이전과 완전히 동일한 코드.
+    // 독립 연결 폴백(플래그 OFF 또는 Provider 밖) — story #2078 이전과 완전히 동일한 코드
+    // + story #2139의 재연결 refetch(use-chat-sse.ts와 동일한 backoff.isReconnect() 패턴).
     if (typeof EventSource === 'undefined') {
       return () => document.removeEventListener('visibilitychange', onVisible);
     }
+    const backoff = createReconnectBackoffState();
     const url = new URL('/api/event-stream', window.location.origin);
     if (memberId) url.searchParams.set('member_id', memberId);
     const es = new EventSource(url.toString(), { withCredentials: true });
+    es.onopen = () => {
+      const isReconnect = backoff.isReconnect();
+      backoff.onOpen();
+      if (isReconnect) void fetchPresence();
+    };
+    // 재연결 여부는 hadPriorError(직전 error 발생 이력)로 판정된다 — 이 훅은 수동 재시도를
+    // 걸지 않고 브라우저 native auto-reconnect에 맡기지만, onError를 호출해두지 않으면
+    // isReconnect()가 영원히 false로 남아 위 onopen의 refetch가 절대 안 켜진다.
+    es.onerror = () => { backoff.onError(); };
     es.addEventListener('presence', () => { void fetchPresence(); }); // 변경 시 push → refetch
     return () => { es.close(); document.removeEventListener('visibilitychange', onVisible); };
   }, [active, fetchPresence, memberId, mux]);


### PR DESCRIPTION
## 배경
#2139(BE) 라이브 판정: `presence`·`conversation.working`은 연결·heartbeat가 멀쩡한데도 프레임이 240초간 0건 — `emit_presence()`/`emit_conversation_working()`이 dead org fanout(`publish_event`의 `_subscribers[org_id]`, `.add()` 호출 0곳)만 타서다. `use-team-presence`는 R2에서 이 실시간을 믿고 3s 폴링을 걷어냈던 자리라, 배달이 죽으면 화면이 조용히 낡는다.

## PO 결정(그대로 코드 주석에 반영)
- 주기 폴링 재도입 안 함 — `#2074`(인스턴스 기아) 교훈으로 R2에서 걷어낸 것.
- 대신 **재연결 시 1회 강제 refetch** — `use-chat-sse.ts`가 이미 쓰는 `subscribeReconnect`/`isReconnect` 패턴 재사용(새 메커니즘 도입 아님, 비용 거의 0).
- ⚠️남는 리스크 명시: **연결은 살아있는데 특정 named 이벤트만 안 오는 경우**(#2139가 정확히 이 형태)는 이 폴백으로 못 잡는다 — 그건 배달 경로 일원화(#2132)가 답.
- `visibilitychange` 캐치업은 그대로 유지.

## 구현
- mux 공유 커넥션 경로: `mux.subscribeReconnect(() => fetchPresence())` 추가.
- 독립 EventSource 폴백 경로: `createReconnectBackoffState()`로 `use-chat-sse.ts`와 동일한 `onopen`에서 `isReconnect()` 판정 → refetch.

**함정 발견 및 수정**: `isReconnect()`는 `hadPriorError`(직전 `onError()` 호출 이력)로 판정되는데, 이 훅은 수동 재시도를 안 걸고 브라우저 native auto-reconnect에 맡긴다. `es.onerror`를 안 걸면 `hadPriorError`가 영원히 `false`로 남아 재연결 refetch가 **죽은 코드**가 된다 — 직접 짜다가 잡아서 `es.onerror = () => backoff.onError()`를 추가했다. 회귀 테스트로 고정(아래).

## 검증
- 신규 테스트 3건(`use-team-presence.test.tsx`, 독립 EventSource 경로): 최초 open은 refetch 안 함 / error 후 재open은 refetch 1회 추가 / 기존 `presence` 이벤트 refetch는 무회귀 — **`es.onerror` 배선을 임시로 빼서 RED 확認 후 복원해 GREEN 재확認**(sanity check).
- `pnpm vitest run` — 3/3 PASS
- `pnpm exec eslint`(변경 2파일) — 0
- `pnpm exec tsc --noEmit` — 0
- `pnpm build` — EXIT 0

## 참고 — 수신자 스코프 확認(오르테가 질의 응답, 코드 변경 아님)
`useTeamPresence`의 유일한 소비처는 `dashboard-shell.tsx`(전역 ScrollShell — FAB working-count 배지 + 상시 팀 presence 패널)이고, `/api/team-presence` → BE `/api/v2/team-presence`는 주석에 "org 전 에이전트"로 명시돼 있다. 프로젝트 필터링 코드 없음 → **org 전체가 맞음**(오르테가 기본 가정 "프로젝트 멤버"와 다름). BE 설계 시 반영 필요.

## 스코프
`conversation.working`(chat-view.tsx)은 이 PR 대상 아님 — 오르테가 지시가 `use-team-presence` 한정이었고, typing indicator는 TTL 기반 ephemeral이라 staleness 성격이 다름. 필요하면 별도로 판단.