### PR TITLE
fix(E-ARCH #2141): prod Redis 시크릿 바인딩 준비 — deploy-backend env/secret 충돌 제거

### DIFF
--- a/backend/tests/test_deploy_backend_redis_secret_conflict.py
+++ b/backend/tests/test_deploy_backend_redis_secret_conflict.py
@@ -1,0 +1,88 @@
+"""story #2141(E-ARCH, 2026-07-23): cloudbuild.yaml deploy-backend REDIS_URL env/secret 충돌 방지.
+
+Cloud Build 스텝은 DRY_RUN 모드가 없어(gcloud CLI 스크립트와 다름) deploy_realtime_gce.sh류
+DRY_RUN 검증을 그대로 못 쓴다 — 대신 ENV_VARS 조립 로직을 cloudbuild.yaml에서 그대로 추출해
+독립 실행하고 dev/prod의 REDIS_URL 포함 여부를 검증한다(오르테가 확定 산출물).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CLOUDBUILD_YAML = _REPO_ROOT / "cloudbuild.yaml"
+
+
+def _extract_deploy_backend_script() -> str:
+    """cloudbuild.yaml의 deploy-backend 스텝 bash 스크립트 본문을 그대로 추출."""
+    doc = yaml.safe_load(_CLOUDBUILD_YAML.read_text())
+    step = next(s for s in doc["steps"] if s["id"] == "deploy-backend")
+    assert step["entrypoint"] == "bash", "deploy-backend가 더 이상 bash entrypoint가 아님 — 이 테스트 갱신 필요"
+    # args: ["-c", "<script>"]
+    return step["args"][1]
+
+
+def _run_env_vars_assembly(deploy_env: str, redis_url: str) -> str:
+    """실제 gcloud 호출부만 잘라내고 ENV_VARS 조립 로직까지만 실행 — 실제 배포 없이 결과 문자열만 얻는다."""
+    script = _extract_deploy_backend_script()
+    # 실제 gcloud run deploy 호출 라인 이후는 잘라내고 ENV_VARS를 echo하도록 붙인다.
+    # ⚠️"gcloud run deploy"만으로 찾으면 그 문구를 언급하는 주석(설명 문장)에 먼저 매치된다 —
+    # 실제 호출부에만 있는 서비스명까지 포함해 정확히 그 라인을 찾는다.
+    marker = "gcloud run deploy sprintable-backend"
+    idx = script.index(marker)
+    assembly_only = script[:idx] + '\necho "RESULT_ENV_VARS=${ENV_VARS}"\n'
+
+    env = {
+        **os.environ,
+        "_DEPLOY_ENV": deploy_env,
+        "_FASTAPI_URL": "https://example.run.app",
+        "_BACKEND_PG_LISTEN_ENABLED": "true",
+        "_BACKEND_REDIS_CONSUME_ENABLED": "false",
+        "_BACKEND_REDIS_DISPATCH_ENABLED": "false",
+        "_BACKEND_REDIS_DUAL_PUBLISH_ENABLED": "false",
+        "_BACKEND_FANOUT_WAKE_REDIS_ENABLED": "false",
+        "_REDIS_URL": redis_url,
+    }
+    proc = subprocess.run(
+        ["bash", "-c", assembly_only],
+        capture_output=True, text=True, env=env, check=True,
+    )
+    for line in proc.stdout.splitlines():
+        if line.startswith("RESULT_ENV_VARS="):
+            return line[len("RESULT_ENV_VARS="):]
+    raise AssertionError(f"ENV_VARS not found in output: {proc.stdout!r}")
+
+
+def test_deploy_backend_is_bash_entrypoint():
+    """story #2141 정정 — env 조건분기를 위해 gcloud 단순 args에서 bash로 전환됐다."""
+    doc = yaml.safe_load(_CLOUDBUILD_YAML.read_text())
+    step = next(s for s in doc["steps"] if s["id"] == "deploy-backend")
+    assert step["entrypoint"] == "bash"
+    assert "set -euo pipefail" in step["args"][1], "실패 시 배포가 조용히 반쪽 되지 않도록 하는 안전장치 누락"
+
+
+def test_deploy_backend_dev_includes_plain_redis_url():
+    """dev: AUTH 없는 plain Memorystore — 시크릿 바인딩이 없으므로 기존처럼 plain env로 넘긴다."""
+    result = _run_env_vars_assembly("dev", "redis://10.164.120.243:6379")
+    assert "REDIS_URL=redis://10.164.120.243:6379" in result
+
+
+def test_deploy_backend_prod_excludes_plain_redis_url():
+    """⭐#2141 핵심 AC — prod는 REDIS_URL을 절대 plain env로 안 넘긴다(Secret Manager 바인딩과
+    동명 충돌 방지, 값의 유무와 무관하게 키 자체가 없어야 한다)."""
+    result = _run_env_vars_assembly("prod", "")
+    assert "REDIS_URL" not in result
+
+
+def test_deploy_backend_dev_env_vars_unchanged_by_prod_branch():
+    """dev 경로 무회귀 — prod 분기 추가가 dev의 다른 필드에 영향을 주지 않는다."""
+    result = _run_env_vars_assembly("dev", "redis://10.164.120.243:6379")
+    assert result == (
+        "FASTAPI_URL=https://example.run.app,DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1,"
+        "PG_LISTEN_ENABLED=true,EVENT_BROKER_REDIS_CONSUME_ENABLED=false,"
+        "EVENT_BROKER_REDIS_DISPATCH_ENABLED=false,EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=false,"
+        "FANOUT_WAKE_REDIS_ENABLED=false,REDIS_URL=redis://10.164.120.243:6379"
+    )

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -252,44 +252,51 @@ steps:
 
   - id: deploy-backend
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    entrypoint: gcloud
+    entrypoint: bash
     args:
-      - run
-      - deploy
-      - sprintable-backend-${_DEPLOY_ENV}
-      - --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA}
-      - --region=${_AR_REGION}
-      - --min-instances=${_BACKEND_MIN_INSTANCES}
-      - --max-instances=${_BACKEND_MAX_INSTANCES}
-      # story #2005: 요청 타임아웃 명시화(위 `_BACKEND_TIMEOUT` 주석 참조) — 이전엔 이 플래그
-      # 자체가 없어 Cloud Run 인프라 기본값에 암묵 의존했다.
-      - --timeout=${_BACKEND_TIMEOUT}
-      # ⭐frontend 가 NEXT_PUBLIC_FASTAPI_URL 로 backend 를 직접 호출(public 필수). 플래그 없으면
-      # gcloud run deploy 가 기존 IAM 을 preserve(non-deterministic) → 신규/리셋 시 allUsers invoker
-      # 유실로 403(2026-06-21 prod promotion 사건). 명시적·멱등 설정으로 매 배포 public 보장(dev/prod 공통).
-      - --allow-unauthenticated
-      # OB-1: 에이전트 onboarding generator 가 읽는 backend-direct URL 을 런타임 env 로 주입.
-      # ⚠️ 반드시 --update-env-vars(additive·기존 backend env[DATABASE_URL 등] 보존). --set-env-vars 금지
-      # (전체 wipe). _FASTAPI_URL 은 dev/prod 각 backend-direct run.app(프론트 NEXT_PUBLIC_FASTAPI_URL 과 동일 값).
-      # DB_POOL_SIZE=3/DB_MAX_OVERFLOW=1: config.py 기본과 동일하나 **명시 주입으로 durable**(과거 수동 설정·
-      # lingering env 가 config 기본을 덮는 것 방지). rollout 산식: 2×maxScale×(pool+overflow+pg_pubsub raw 1)
-      # ≤ DB max_conn (dev maxScale 8: 2×8×5=80 · prod maxScale 5: 2×5×5=50+admin). 변경 시 cloud-build.yml
-      # maxScale 와 짝으로 검토. (PO rev 01256 dev 429 right-size durable 화.)
-      # E-ARCH 1단계(story #2078): PG_LISTEN_ENABLED durable화 — 위 _BACKEND_PG_LISTEN_ENABLED
-      # 주석 참조(dev=false·prod=true 유지, GHA per-env 배선).
-      # ⛔E-ARCH S2 정리(story #2078) 정정(#2123, 2026-07-23): EVENT_BROKER_REDIS_CONSUME_
-      # ENABLED/_DISPATCH_ENABLED durable화 — 위 _BACKEND_REDIS_CONSUME_ENABLED/_DISPATCH_
-      # ENABLED 주석 참조. "api는 SSE 미서빙" 전제가 틀렸음이 드러나 값을 true로 정정(에이전트
-      # SSE가 agent_onboarding_config.py 설계상 backend-dev를 직접 서빙). 키 이름 자체도 story
-      # #2135(2026-07-23)에서 정정(구 `REDIS_CONSUME_ENABLED`는 Settings 필드와 안 맞아 무시되던
-      # 키) — 구 키는 아래 --remove-env-vars로 명시 제거(안 지우면 두 키 공존, additive 함정).
-      # ⛔story cd10e123 긴급수정(2026-07-21, codex 리서치 검증 중 적발): REDIS_URL·
-      # EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED durable화 — 위 _REDIS_URL 주석 참조.
-      # story #2123 S0-b(2026-07-23): FANOUT_WAKE_REDIS_ENABLED — 위 _BACKEND_FANOUT_WAKE_
-      # REDIS_ENABLED 주석 참조(dev만 true, prod는 손대지 않음).
-      - --update-env-vars=FASTAPI_URL=${_FASTAPI_URL},DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1,PG_LISTEN_ENABLED=${_BACKEND_PG_LISTEN_ENABLED},EVENT_BROKER_REDIS_CONSUME_ENABLED=${_BACKEND_REDIS_CONSUME_ENABLED},EVENT_BROKER_REDIS_DISPATCH_ENABLED=${_BACKEND_REDIS_DISPATCH_ENABLED},REDIS_URL=${_REDIS_URL},EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=${_BACKEND_REDIS_DUAL_PUBLISH_ENABLED},FANOUT_WAKE_REDIS_ENABLED=${_BACKEND_FANOUT_WAKE_REDIS_ENABLED}
-      - --remove-env-vars=REDIS_CONSUME_ENABLED
-      - --quiet
+      - -c
+      - |
+        set -euo pipefail
+        # story #2005: 요청 타임아웃 명시화(_BACKEND_TIMEOUT) — 이전엔 이 플래그 자체가 없어
+        # Cloud Run 인프라 기본값에 암묵 의존했다.
+        # ⭐frontend 가 NEXT_PUBLIC_FASTAPI_URL 로 backend 를 직접 호출(public 필수). --allow-
+        # unauthenticated 없으면 gcloud run deploy 가 기존 IAM 을 preserve(non-deterministic)
+        # → 신규/리셋 시 allUsers invoker 유실로 403(2026-06-21 prod promotion 사건).
+        # OB-1: 에이전트 onboarding generator 가 읽는 backend-direct URL 을 런타임 env 로 주입.
+        # ⚠️ 반드시 --update-env-vars(additive·기존 backend env[DATABASE_URL 등] 보존).
+        # --set-env-vars 금지(전체 wipe). DB_POOL_SIZE=3/DB_MAX_OVERFLOW=1: config.py 기본과
+        # 동일하나 명시 주입으로 durable(과거 수동 설정·lingering env 가 기본을 덮는 것 방지).
+        # rollout 산식: 2×maxScale×(pool+overflow+pg_pubsub raw 1) ≤ DB max_conn (dev maxScale 8:
+        # 2×8×5=80 · prod maxScale 5: 2×5×5=50+admin). 변경 시 cloud-build.yml maxScale 와 짝으로
+        # 검토(PO rev 01256 dev 429 right-size durable 화).
+        # E-ARCH 1단계(story #2078): PG_LISTEN_ENABLED durable화(dev=false·prod=true, GHA per-env).
+        # ⛔E-ARCH S2 정리(story #2078) 정정(#2123): EVENT_BROKER_REDIS_CONSUME_ENABLED/_DISPATCH_
+        # ENABLED durable화 — "api는 SSE 미서빙" 전제가 틀렸음이 드러나 값을 true로 정정(에이전트
+        # SSE가 agent_onboarding_config.py 설계상 backend-dev를 직접 서빙). 키 이름도 story #2135
+        # 에서 정정(구 `REDIS_CONSUME_ENABLED`는 Settings 필드와 안 맞아 무시되던 키) — 구 키는
+        # --remove-env-vars로 명시 제거(안 지우면 두 키 공존, additive 함정).
+        # story #2123 S0-b: FANOUT_WAKE_REDIS_ENABLED(dev만 true, prod는 손대지 않음).
+        ENV_VARS="FASTAPI_URL=${_FASTAPI_URL},DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1,PG_LISTEN_ENABLED=${_BACKEND_PG_LISTEN_ENABLED},EVENT_BROKER_REDIS_CONSUME_ENABLED=${_BACKEND_REDIS_CONSUME_ENABLED},EVENT_BROKER_REDIS_DISPATCH_ENABLED=${_BACKEND_REDIS_DISPATCH_ENABLED},EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=${_BACKEND_REDIS_DUAL_PUBLISH_ENABLED},FANOUT_WAKE_REDIS_ENABLED=${_BACKEND_FANOUT_WAKE_REDIS_ENABLED}"
+        # ⛔story #2141(2026-07-23, prod Redis Memorystore 전환): REDIS_URL을 여기서 이 스텝이
+        # 예전엔 dev/prod 공용으로 plain env 넘겼다 — prod는 Secret Manager 바인딩(REDIS_URL_PROD,
+        # AUTH 필요)으로 전환하는데, 같은 배포에 plain REDIS_URL 키까지 넘기면 Cloud Run이
+        # "env와 secret이 동명 키"로 배포 자체를 거부한다(값 유무 무관 — 키 존재 자체가 충돌).
+        # dev는 AUTH 없는 plain Memorystore라 시크릿 바인딩 자체가 없으므로 기존처럼 plain으로 넘긴다.
+        # prod는 여기서 REDIS_URL을 절대 안 넘김 — 시크릿 바인딩(별도 1회 gcloud, PO lane)이
+        # --set-secrets 없는 이 스텝에 preserve된다(DATABASE_URL_PROD 등 기존 15개와 동일 컨벤션).
+        if [ "${_DEPLOY_ENV}" != "prod" ]; then
+          ENV_VARS="${ENV_VARS},REDIS_URL=${_REDIS_URL}"
+        fi
+        gcloud run deploy sprintable-backend-${_DEPLOY_ENV} \
+          --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA} \
+          --region=${_AR_REGION} \
+          --min-instances=${_BACKEND_MIN_INSTANCES} \
+          --max-instances=${_BACKEND_MAX_INSTANCES} \
+          --timeout=${_BACKEND_TIMEOUT} \
+          --allow-unauthenticated \
+          --update-env-vars="${ENV_VARS}" \
+          --remove-env-vars=REDIS_CONSUME_ENABLED \
+          --quiet
     # story dbda0baf: push-backend → run-migrate-job(위) 로 변경 — 신규 코드가 마이그 안 된
     # 스키마를 상대로 뜨는 걸 막는다(migrate 실패 시 이 스텝 자체가 안 돎).
     waitFor: [run-migrate-job]


### PR DESCRIPTION
## 배경

prod Memorystore(`sprintable-redis-prod`, STANDARD_HA·1GB·AUTH 활성) READY. Secret Manager에
`REDIS_URL_PROD` 생성 + `cloudrun-runtime-prod@` secretAccessor 부여까지 완료(PO). 이 PR은 그
시크릿을 `backend-prod` Cloud Run에 바인딩하기 **前** cloudbuild.yaml 쪽 근본 충돌을 먼저 제거한다.

⚠️AUTH 문자열/REDIS_URL 전문은 이 PR 어디에도 없음 — 시크릿 **이름**(`REDIS_URL_PROD`)만 참조.

## 문제

`deploy-backend` 스텝이 dev/prod 공용으로 `REDIS_URL`을 plain env(`--update-env-vars`)로 넘기고
있었다. prod에 같은 키를 Secret Manager 바인딩으로 붙이면 **Cloud Run이 "env와 secret 동명 키
충돌"로 배포 자체를 거부**한다(값의 유무 무관 — 키 존재 자체가 충돌).

기존 `DATABASE_URL_PROD` 등 15개 시크릿이 무사한 이유: cloudbuild.yaml이 그 키들을 애초에
`--update-env-vars`에 한 번도 안 넣기 때문(`--set-secrets` 없는 `gcloud run deploy` 컨벤션 —
기존 바인딩 preserve). `REDIS_URL`만 예외적으로 plain 슬롯이 이미 점유돼 있어 이 함정이 생긴다.

## 변경 내용

- `deploy-backend` 스텝을 `entrypoint: gcloud`(정적 args) → `entrypoint: bash`로 전환.
- `ENV_VARS` 문자열을 `_DEPLOY_ENV != prod`일 때만 `REDIS_URL=${_REDIS_URL}`을 포함하도록 조건 조립.
  - **dev**: 기존과 동일(AUTH 없는 plain Memorystore, 시크릿 바인딩 자체가 없음) — 무회귀.
  - **prod**: `REDIS_URL`을 여기서 전혀 안 넘김 — 별도 1회 `gcloud`(PO lane)로 붙는 Secret Manager
    바인딩이 `--set-secrets` 없는 이 스텝에 preserve됨(기존 15개 시크릿과 동일 컨벤션).

## 순서(중요 — 뒤집으면 안 됨)

```
1. 이 PR이 develop에 먼저 머지된다
2. 그 다음 PO가 backend-prod에 REDIS_URL=REDIS_URL_PROD:latest 시크릿 바인딩을 1회 gcloud로 붙인다
3. 그 다음 브로커 플래그(dual_publish → consume → dispatch) 단계별 배선(별 커밋, 매 단계 배포 後 실측)
```
순서를 뒤집으면(바인딩을 먼저 붙인 상태에서 develop→main 승격이 돌면) 그 배포가 여전히 plain
REDIS_URL을 넘기는 옛 cloudbuild.yaml을 써서 같은 충돌이 재현되는 창이 생긴다.

## 알려진 인접 갭 (이 PR 스코프 아님, 문서화만)

`deploy-realtime` 스텝도 동일 패턴(REDIS_URL 공용 plain env)이나, 지금은 `_DEPLOY_ENV != dev`
가드로 prod가 스킵돼 안 걸린다. **prod GCE realtime 신설(#2142) 시점에 반드시 같은 수정이 필요**
— 그때 별도 PR로 처리(오르테가 지적).

## Test plan

- [x] `bash -n` 문법 검증 없음(YAML 내 스크립트라 `yaml.safe_load` 파싱 + `set -euo pipefail` 유지 확認)
- [x] Cloud Build 스텝은 DRY_RUN이 없어, `ENV_VARS` 조립 로직을 cloudbuild.yaml에서 그대로 추출해
      독립 실행 — dev/prod 결과 대조:
```
dev:  ...,REDIS_URL=redis://10.164.120.243:6379   (포함)
prod: ...,FANOUT_WAKE_REDIS_ENABLED=false          (REDIS_URL 없음)
```
- [x] 신규 회귀 테스트 4건(`test_deploy_backend_redis_secret_conflict.py`) — dev 포함/prod 제외/
      dev 무회귀(문자열 완전 동일)/`set -euo pipefail` 유지, 전부 통과(`uv run pytest` 29 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)