### PR TITLE
[SID:2144] SSE 멀티플렉서 context 값 참조 안정화(useMemo+connected getter)

### DIFF
--- a/apps/web/src/components/presence/use-team-presence.test.tsx
+++ b/apps/web/src/components/presence/use-team-presence.test.tsx
@@ -109,3 +109,73 @@ describe('useTeamPresence — 독립 연결 폴백의 재연결 refetch(#2139)',
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });
+
+// story #2144 — mux 공유 커넥션 경로(RealtimeProvider 자식)에서 connected 토글이 더 이상
+// 구독 재생성(=중복 fetchPresence)을 유발하지 않는 것을 실제 Provider로 고정한다.
+// use-chat-unread-total.test.tsx와 동일한 vi.stubEnv+resetModules+동적 import 패턴 재사용.
+describe('useTeamPresence — mux 공유 커넥션 경로의 connected 참조 안정성(#2144)', () => {
+  afterEach(() => { vi.resetModules(); });
+
+  it('최초 connected flip(false→true)은 추가 fetchPresence를 유발하지 않는다', async () => {
+    vi.resetModules();
+    vi.stubEnv('NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED', 'true');
+    const { RealtimeProvider } = await import('@/components/realtime-provider');
+    const { useTeamPresence: useTeamPresenceFresh } = await import('./use-team-presence');
+
+    function Consumer() {
+      useTeamPresenceFresh(true, 'member-1');
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        <RealtimeProvider currentTeamMemberId="member-1">
+          <Consumer />
+        </RealtimeProvider>,
+      );
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1); // 초기 스냅샷만
+
+    const es = FakeEventSource.instances[0]!;
+    await act(async () => {
+      es.onopen?.(); // mux 커넥션의 최초 open — connected: false → true
+      await Promise.resolve();
+    });
+    // #2144 이전엔 mux 참조가 바뀌어 useTeamPresence effect가 재실행 → fetchPresence 2회.
+    // 고친 뒤엔 핸들 참조가 안정적이라 재실행 자체가 없다.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('실제 재연결(error→open)에서는 #2139의 subscribeReconnect refetch가 정확히 1회만 더 붙는다', async () => {
+    vi.resetModules();
+    vi.stubEnv('NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED', 'true');
+    const { RealtimeProvider } = await import('@/components/realtime-provider');
+    const { useTeamPresence: useTeamPresenceFresh } = await import('./use-team-presence');
+
+    function Consumer() {
+      useTeamPresenceFresh(true, 'member-1');
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        <RealtimeProvider currentTeamMemberId="member-1">
+          <Consumer />
+        </RealtimeProvider>,
+      );
+      await Promise.resolve();
+    });
+    const es = FakeEventSource.instances[0]!;
+    await act(async () => { es.onopen?.(); await Promise.resolve(); }); // 최초 open
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => { es.onerror?.(); await Promise.resolve(); }); // 끊김
+    expect(fetchMock).toHaveBeenCalledTimes(1); // error 자체는 fetch 유발 안 함
+
+    await act(async () => { es.onopen?.(); await Promise.resolve(); }); // 재연결
+    // mux의 subscribeReconnect 경로로 정확히 1회만 늘어난다 — 구독 재생성으로 인한
+    // 중복(effect 재실행발 fetchPresence)이 얹혀 2회 이상이 되면 이 테스트가 잡는다.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/lib/realtime/sse-multiplexer.test.tsx
+++ b/apps/web/src/lib/realtime/sse-multiplexer.test.tsx
@@ -166,4 +166,32 @@ describe('useSseMultiplexer — story #2078', () => {
     // onerror 이후 재연결은 setTimeout으로 스케줄되므로, 여기서는 "최초 open=재연결 아님"만
     // 고정한다 — 실제 재연결 타이밍은 기존 3개 훅과 동일한 backoff 상수를 그대로 재사용했다.
   });
+
+  // story #2144 — 반환 핸들 객체가 connected 토글에도 참조 안정적인지 고정한다. 이게
+  // 깨지면(예: connected를 다시 useMemo deps에 넣으면) mux를 effect deps에 둔 모든
+  // 소비처(presence·chat·notifications)가 재연결마다 구독을 해지·재구독하게 된다.
+  it('connected가 false→true→false로 토글돼도 반환 핸들의 참조는 그대로다', async () => {
+    await act(async () => {
+      root.render(<Harness memberId="me-1" enabled />);
+    });
+    const initial = handle;
+    expect(initial).not.toBeNull();
+
+    act(() => { instances[0]!.onopen?.(); }); // connected: false → true
+    expect(handle).toBe(initial); // 참조 그대로
+    expect(handle!.connected).toBe(true); // 값은 최신
+
+    act(() => { instances[0]!.onerror?.(); }); // connected: true → false
+    expect(handle).toBe(initial); // 여전히 그대로
+    expect(handle!.connected).toBe(false);
+  });
+
+  it('구독 함수 자체도 connected 토글 전후로 동일 참조다(consumer useEffect deps 안정성의 실질)', async () => {
+    await act(async () => {
+      root.render(<Harness memberId="me-1" enabled />);
+    });
+    const subscribeBefore = handle!.subscribe;
+    act(() => { instances[0]!.onopen?.(); });
+    expect(handle!.subscribe).toBe(subscribeBefore);
+  });
 });

--- a/apps/web/src/lib/realtime/sse-multiplexer.ts
+++ b/apps/web/src/lib/realtime/sse-multiplexer.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createReconnectBackoffState } from './sse-reconnect-backoff';
 
 /**
@@ -34,6 +34,15 @@ export interface SseMultiplexerHandle {
   subscribeMessage: (handler: EventHandler) => () => void;
   /** 재연결(open이 처음이 아닐 때)마다 호출 — use-chat-sse의 backfill 트리거용. */
   subscribeReconnect: (handler: () => void) => () => void;
+  /** story #2144 — 접근자(getter)로 노출한다. `connected`가 평범한 boolean 필드면 그 값이
+   * 바뀔 때마다(재연결 사이클마다) 이 핸들 객체 자체가 새로 만들어져야 하고, 그러면 이
+   * 핸들을 effect deps에 둔 모든 소비처(presence·chat·notifications)가 재연결 때마다
+   * 구독을 해지→재구독한다 — 그 사이 창에 도착한 이벤트가 유실될 수 있다(#2144 근본).
+   * getter는 핸들 자체의 참조를 subscribe 함수들처럼 영구 안정적으로 유지하면서도 `.connected`
+   * 접근 시점의 최신값은 그대로 읽게 한다 — 소비처 코드(`mux.connected`)는 무변경. 단
+   * getter는 리액티브하지 않다(값이 바뀌어도 리렌더를 유발하지 않음) — 연결 상태 변화에
+   * 반응해야 하는 소비처는 이 필드를 폴링하지 말고 `subscribeReconnect`를 쓴다.
+   */
   connected: boolean;
 }
 
@@ -142,5 +151,20 @@ export function useSseMultiplexer(memberId: string | undefined, enabled: boolean
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled]);
 
-  return { subscribe, subscribeMessage, subscribeReconnect, connected };
+  // story #2144 — connectedRef는 매 렌더 최신 connected를 반영(렌더 중 ref 대입은 다음
+  // 커밋 전에 끝나 안전 — React 규칙상 자기 자신이 렌더링 중인 컴포넌트의 ref를 렌더 중
+  // 쓰는 것만 문제고, 이건 그냥 최신값 미러링).
+  const connectedRef = useRef(connected);
+  connectedRef.current = connected;
+
+  // 핸들 자체의 참조는 subscribe/subscribeMessage/subscribeReconnect가 이미 영구
+  // 안정적이므로(useCallback, 의존성 불변) 이 useMemo도 최초 1회 이후 재계산되지 않는다 —
+  // `connected`가 몇 번을 토글해도 핸들 참조는 그대로라, 이 핸들을 effect deps에 둔
+  // 소비처가 재연결마다 구독을 해지·재구독하는 일이 없다.
+  return useMemo(() => ({
+    subscribe,
+    subscribeMessage,
+    subscribeReconnect,
+    get connected() { return connectedRef.current; },
+  }), [subscribe, subscribeMessage, subscribeReconnect]);
 }


### PR DESCRIPTION
## 배경
까심이 #2419 관측 중 페이지 로드 시 `/api/team-presence`가 3발 연속 호출되는 것을 곁다리로 잡았고(미르코 원인 확定 → #2144 등재), 착수 전 까심이 판정 숫자를 코드로 재확認했다:

```
connected state가 토글되면 Provider가 2회 리렌더(disconnect 1 + reconnect 1)
→ 그때마다 mux 참조가 바뀌어 소비처 effect가 cleanup+재실행 2회
→ 매 재실행 상단의 fetchPresence()가 무조건 재호출
⇒ "배포 前 baseline 2회"는 의도된 게 아니라 이 버그의 부산물이었다
⇒ "배포 後 3회" = 버그 2 + #2139의 정당한 refetch 1
```

## 근본
`useSseMultiplexer`(`sse-multiplexer.ts`)의 반환이 `useMemo` 없는 매 렌더 신규 객체였다:
```ts
return { subscribe, subscribeMessage, subscribeReconnect, connected };
```
`subscribe` 등은 `useCallback`으로 안정적이지만 **감싸는 객체 자체가 아니었다**. `RealtimeProvider`가 이 객체를 그대로 context value로 전달하는데, `connected`는 연결이 끊겼다 붙을 때마다(재연결 사이클마다) 토글돼 리렌더를 유발하고, 그때마다 참조가 다른 새 `mux` 객체가 context에 주입된다. `mux`를 effect deps에 둔 소비처(presence·chat·notifications — kanban-board의 `story.status_changed`/`assignee_changed` 포함, #2137이 방금 고친 그 경로)는 매번 구독을 해지→재구독한다. **그 해지-재구독 창에 도착한 이벤트는 아무도 안 듣는다.**

## AC4 — mux 소비처 전수(사전 조사, PR 반영)
`useSseMultiplexerContext()` 직접 호출 = 3개 훅, 전부 `mux`가 effect deps에 있어 이번 수정의 수혜 범위:
| 훅 | 최종 소비 UI |
|---|---|
| `use-team-presence.ts` | 전역 FAB working-count 배지 + 상시 팀 presence 패널 |
| `use-sse-notifications.ts` | 알림 벨, **kanban-board 실시간(status/assignee)**, attention-queue(trust_stage) |
| `use-chat-sse.ts` | 열린 채팅방, 대화 목록 |

## 처방
`subscribe`/`subscribeMessage`/`subscribeReconnect`(전부 불변)만 의존성으로 하는 `useMemo`로 핸들을 감싸 참조를 영구 안정화했다. `connected`는 **getter**로 유지(`get connected() { return connectedRef.current; }`) — 소비처 코드(`mux.connected`)는 완전히 무변경, ref에서 항상 최신값을 읽되 핸들 identity에는 관여하지 않는다.

## ⚠️가장 위험한 실패모드(오르테가 사전경고 — 코드로 직접 검증)
`useMemo`로 참조를 얼리면서 `#2139`의 `subscribeReconnect` 발화 경로까지 같이 얼려버리는 것 — 그러면 재연결 시 재조회가 **0회**가 되는 회귀(방금 넣은 폴백이 죽는 것)가 가장 위험하다고 지적받았다. `reconnectSubscribersRef`는 ref 기반 Set이라 handle identity와 완전히 무관하게 독립 동작한다는 것을 회귀 테스트로 직접 고정했다 — 재연결 시 **정확히 1회만** 늘어남(0도 3도 아님) 확認.

## 검증
- 신규 회귀 테스트 5건:
  - `sse-multiplexer.test.tsx`(2건): `connected` 토글 전후 핸들 참조 동일성 / `subscribe` 함수 참조 동일성.
  - `use-team-presence.test.tsx`(2건, `RealtimeProvider` 실장 사용 — `use-chat-unread-total.test.tsx`와 동일한 `vi.stubEnv`+`resetModules` 패턴): 최초 connected flip이 추가 fetch 안 함 / 실제 재연결에서 정확히 1회만 추가.
  - **fix를 임시로 되돌려 3건 전부 RED 확認 후 복원해 GREEN 재확認**(sanity check).
- `pnpm vitest run`(hooks+realtime+presence+kanban-board+nav) — 14 files/92 tests PASS
- `pnpm exec eslint`(변경 3파일) — 0
- `pnpm exec tsc --noEmit` — 0
- `pnpm build` — EXIT 0

## 판정 기준(오르테가 사전등록)
```
현재      3회/사이클
수정 後   1회/사이클 기대  ← 버그성 2회 소멸 + #2139 refetch 1회만 남음
1회 ⇒ PASS · 3회 ⇒ 수정 안 먹음 · 2회 ⇒ 절반만 잡힘 · 0회 ⇒ 회귀(재연결 refetch까지 죽음)
```
dev 배포 후 까심의 사이클 카운트 재관측이 최종 게이트.

## 스코프
`connected`를 소비하는 곳은 `use-chat-sse.ts` 반환값 하나뿐이고(`mux ? mux.connected : connected`), 그 반환값 자체를 실제로 렌더에 쓰는 컴포넌트는 현재 0곳(`chat-view.tsx`/`chat-list-view.tsx` 둘 다 반환값 미사용, grep 확認) — getter 전환이 기존 동작을 바꾸지 않는다.