### PR TITLE
fix(#2423): remove unescaped ENV_VARS reference hiding in a comment

### DIFF
--- a/backend/tests/test_deploy_backend_redis_secret_conflict.py
+++ b/backend/tests/test_deploy_backend_redis_secret_conflict.py
@@ -4,14 +4,25 @@ Cloud Build 스텝은 DRY_RUN 모드가 없어(gcloud CLI 스크립트와 다름
 DRY_RUN 검증을 그대로 못 쓴다 — 대신 ENV_VARS 조립 로직을 cloudbuild.yaml에서 그대로 추출해
 독립 실행하고 dev/prod의 REDIS_URL 포함 여부를 검증한다(오르테가 확定 산출물).
 
-⛔story #2421 배포 실패 핫픽스(2026-07-23) — 이 파일의 첫 버전은 추출한 스크립트를 곧바로
-bash로 실행해 통과했지만, 실 Cloud Build에는 여기 없는 층이 하나 더 있다: args 문자열 전체가
-먼저 Cloud Build 자신의 substitution 파서를 거친다. `${ENV_VARS}`처럼 셸 변수를 substitution
-문법과 같은 `${...}`로 참조하면 Cloud Build가 "유효한 substitution이 아니다"로 **build submit
-자체를 거부**한다(bash가 실행되기도 전) — 셸에서 직접 돌리면 정상 동작하는 것과 완전히 다른
-실패 모드라 그 층을 건너뛴 첫 테스트는 이 결함을 못 잡았다. `_apply_cloudbuild_escaping()`이
-그 층을 재현하고, `test_deploy_backend_no_unescaped_shell_vars_in_cloudbuild_substitution_syntax`가
-회귀를 원천 차단한다(추출한 스크립트를 실행하지 않고 정적으로 스캔 — 셸 계층과 무관).
+⛔story #2421/#2423 배포 실패 핫픽스(2026-07-23, 2건 연속) — 1차: 이 파일의 첫 버전은 추출한
+스크립트를 곧바로 bash로 실행해 통과했지만, 실 Cloud Build에는 여기 없는 층이 하나 더 있다:
+args 문자열 전체가 먼저 Cloud Build 자신의 substitution 파서를 거친다. 달러중괄호로 셸 변수를
+참조하면 Cloud Build가 "유효한 substitution이 아니다"로 build submit 자체를 거부한다(bash가
+실행되기도 전) — 셸에서 직접 돌리면 정상 동작하는 것과 완전히 다른 실패 모드라 그 층을 건너뛴
+첫 테스트는 이 결함을 못 잡았다.
+
+2차(더 지독한 재발) — 1차 수정 직후 정적 가드 테스트를 추가했는데, 그 테스트가 "주석 줄은
+스캔에서 제외"라는 규칙을 넣었다(자기 자신의 설명 주석이 예시로 문제의 표기를 언급하는 것까지
+코드로 오인해 실패하는 것을 막으려던 의도). 그런데 실제 Cloud Build 파서는 args 문자열 전체를
+그냥 문자열로 훑을 뿐 bash 주석 여부를 전혀 가리지 않는다 — 그래서 그 사고를 "설명하는" 주석
+문장 자신이 예시로 그 표기를 그대로 써서 실제로 build submit을 다시 거부시켰다(계측기가 실제
+Cloud Build보다 관대했던 것 — 테스트가 모델링한 계층과 실제 계층이 어긋난 전형적인 형태).
+⇒ 주석 제외 규칙을 제거했다 — Cloud Build가 안 가리니 테스트도 안 가려야 한다.
+
+`_apply_cloudbuild_escaping()`이 `$$`→`$` 치환 층을 재현하고,
+`test_deploy_backend_no_unescaped_shell_vars_in_cloudbuild_substitution_syntax`가(주석 포함
+전문 스캔으로) 회귀를 원천 차단한다(추출한 스크립트를 실행하지 않고 정적으로 스캔 — 셸
+계층과 무관).
 """
 from __future__ import annotations
 
@@ -89,26 +100,29 @@ def _run_env_vars_assembly(deploy_env: str, redis_url: str) -> str:
 
 
 def test_deploy_backend_no_unescaped_shell_vars_in_cloudbuild_substitution_syntax():
-    """⭐story #2421 회귀 방지 핵심 AC — Cloud Build가 build submit 자체를 거부하는 층을 정적으로 잡는다.
+    """⭐story #2421/#2423 회귀 방지 핵심 AC — Cloud Build가 build submit 자체를 거부하는 층을 정적으로 잡는다.
 
-    `${...}`/`$...` 형태로 스크립트에 등장하는 이름이 cloudbuild.yaml의 substitutions: 선언
-    또는 GCP 내장 변수 목록에 없다면, 그건 이스케이프(`$$`) 안 된 셸 변수 참조 — 실 Cloud Build가
-    "key ... is not a valid built-in substitution"로 build를 거부한다(부분 배포 없이 막히지만,
-    dev 파이프라인 전체가 멈춘다 — #2421 실 사고).
+    달러중괄호 형태로 스크립트에 등장하는 이름이 cloudbuild.yaml의 substitutions: 선언 또는
+    GCP 내장 변수 목록에 없다면, 그건 이스케이프(달러 두 개) 안 된 셸 변수 참조 — 실 Cloud
+    Build가 "key ... is not a valid built-in substitution"로 build를 거부한다(부분 배포 없이
+    막히지만, dev 파이프라인 전체가 멈춘다 — #2421 실 사고).
+
+    ⛔#2423 재발 교훈 — **주석 줄을 제외하지 않는다.** Cloud Build의 substitution 파서는 args
+    문자열 전체를 그냥 문자열로 훑고 bash 주석 여부를 전혀 가리지 않는다. 이전 버전이 주석을
+    스캔에서 뺐다가 "이 사고를 설명하는 주석 자신이 그 표기를 예시로 써서 사고를 재현"하는
+    것을 놓쳤다 — 그 재발이 이 규칙을 없앤 이유다. 새 주석을 쓸 때도 달러중괄호로 미선언
+    이름을 언급하면(설명 목적이라도) 이 테스트가 실패해야 정상이다.
     """
     script = _extract_deploy_backend_script()
-    # 주석 줄은 스캔 대상에서 제외 — 이 파일 자신의 설명 주석이 예시로 `${ENV_VARS}`를
-    # 언급하는 것까지 코드로 오인해 자기 자신을 실패시키는 것 방지(실제 실행되는 코드만 검사).
-    code_only = "\n".join(
-        line for line in script.splitlines() if not line.strip().startswith("#")
-    )
     # `$$`(이스케이프)로 시작하는 자리는 실제 셸 변수 참조라 스킵 — `$$` 다음 글자부터 다시 스캔.
     # 정규식으로 `$$` 뒤에 오는 참조는 애초에 매치 대상에서 제외(단일 `$`만 substitution 후보).
-    unescaped = re.findall(r"(?<!\$)\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?", code_only)
+    # 주석 포함 스크립트 원문 전체를 스캔한다(주석 제외 금지 — 위 docstring 참조).
+    unescaped = re.findall(r"(?<!\$)\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?", script)
     unknown = sorted(set(unescaped) - _DECLARED_SUBSTITUTIONS)
     assert not unknown, (
-        f"cloudbuild.yaml deploy-backend 스텝에 이스케이프 안 된(`$$` 누락) 셸 변수로 보이는 "
-        f"미선언 substitution 참조 발견: {unknown} — 셸 변수라면 `$${{VAR}}`로 이스케이프할 것."
+        f"cloudbuild.yaml deploy-backend 스텝에 이스케이프 안 된(달러 두 개 누락) 셸 변수로 "
+        f"보이는 미선언 substitution 참조 발견(주석 포함 전문 스캔): {unknown} — 셸 변수라면 "
+        f"달러 두 개로 이스케이프할 것. 설명 주석이라도 달러중괄호로 이 이름들을 언급하지 말 것."
     )
 
 

--- a/backend/tests/test_deploy_backend_redis_secret_conflict.py
+++ b/backend/tests/test_deploy_backend_redis_secret_conflict.py
@@ -50,13 +50,26 @@ _DECLARED_SUBSTITUTIONS = {
 }
 
 
-def _extract_deploy_backend_script() -> str:
-    """cloudbuild.yaml의 deploy-backend 스텝 bash 스크립트 본문을 그대로 추출(원문 그대로 — $$ 이스케이프 미처리)."""
+# Cloud Build의 substitution 파서가 실제로 훑는 대상 = entrypoint: bash 스텝의 args 블록
+# 스칼라 문자열뿐이다(오르테가 실측, 2026-07-23) — YAML 레벨 주석(이 스칼라 밖)은 YAML
+# 파서가 먼저 걷어내 Cloud Build가 아예 보지 못한다. 그래서 가드 스캔 스코프를 파일 전체가
+# 아니라 이 스텝들로 좁힌다 — 넓히면 순수 YAML 주석(예: 다른 스텝을 설명하는 프로즈 안의
+# `${ENV}` 언급)에 오탐이 나서 안전한 주석을 억지로 고치게 만든다. bash entrypoint 스텝이
+# 새로 생기면 이 목록에 추가할 것(오르테가 지시 — deploy-realtime도 같은 함정 자리라 포함).
+_BASH_ENTRYPOINT_STEP_IDS = ("deploy-backend", "deploy-realtime")
+
+
+def _extract_step_script(step_id: str) -> str:
+    """cloudbuild.yaml의 지정 스텝 bash 스크립트 본문을 그대로 추출(원문 그대로 — $$ 이스케이프 미처리)."""
     doc = yaml.safe_load(_CLOUDBUILD_YAML.read_text())
-    step = next(s for s in doc["steps"] if s["id"] == "deploy-backend")
-    assert step["entrypoint"] == "bash", "deploy-backend가 더 이상 bash entrypoint가 아님 — 이 테스트 갱신 필요"
+    step = next(s for s in doc["steps"] if s["id"] == step_id)
+    assert step["entrypoint"] == "bash", f"{step_id}가 더 이상 bash entrypoint가 아님 — 이 테스트 갱신 필요"
     # args: ["-c", "<script>"]
     return step["args"][1]
+
+
+def _extract_deploy_backend_script() -> str:
+    return _extract_step_script("deploy-backend")
 
 
 def _apply_cloudbuild_escaping(script: str) -> str:
@@ -112,18 +125,25 @@ def test_deploy_backend_no_unescaped_shell_vars_in_cloudbuild_substitution_synta
     스캔에서 뺐다가 "이 사고를 설명하는 주석 자신이 그 표기를 예시로 써서 사고를 재현"하는
     것을 놓쳤다 — 그 재발이 이 규칙을 없앤 이유다. 새 주석을 쓸 때도 달러중괄호로 미선언
     이름을 언급하면(설명 목적이라도) 이 테스트가 실패해야 정상이다.
+
+    스캔 범위는 파일 전체가 아니라 `_BASH_ENTRYPOINT_STEP_IDS`의 args 블록 스칼라로 한정한다
+    (오르테가 확認, 2026-07-23) — Cloud Build는 그 스칼라 문자열만 보고, YAML 레벨 주석(스텝
+    args 밖의 프로즈)은 YAML 파서가 먼저 걷어내 Cloud Build가 아예 못 본다. 파일 전체로
+    넓히면 그런 순수 YAML 주석에 오탐이 나서(실측: 다른 스텝을 설명하는 주석이 예시로
+    `${ENV}` 를 언급하는 자리) 안전한 문장을 억지로 고치게 된다.
     """
-    script = _extract_deploy_backend_script()
-    # `$$`(이스케이프)로 시작하는 자리는 실제 셸 변수 참조라 스킵 — `$$` 다음 글자부터 다시 스캔.
-    # 정규식으로 `$$` 뒤에 오는 참조는 애초에 매치 대상에서 제외(단일 `$`만 substitution 후보).
-    # 주석 포함 스크립트 원문 전체를 스캔한다(주석 제외 금지 — 위 docstring 참조).
-    unescaped = re.findall(r"(?<!\$)\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?", script)
-    unknown = sorted(set(unescaped) - _DECLARED_SUBSTITUTIONS)
-    assert not unknown, (
-        f"cloudbuild.yaml deploy-backend 스텝에 이스케이프 안 된(달러 두 개 누락) 셸 변수로 "
-        f"보이는 미선언 substitution 참조 발견(주석 포함 전문 스캔): {unknown} — 셸 변수라면 "
-        f"달러 두 개로 이스케이프할 것. 설명 주석이라도 달러중괄호로 이 이름들을 언급하지 말 것."
-    )
+    for step_id in _BASH_ENTRYPOINT_STEP_IDS:
+        script = _extract_step_script(step_id)
+        # `$$`(이스케이프)로 시작하는 자리는 실제 셸 변수 참조라 스킵 — `$$` 다음 글자부터 다시 스캔.
+        # 정규식으로 `$$` 뒤에 오는 참조는 애초에 매치 대상에서 제외(단일 `$`만 substitution 후보).
+        # 주석 포함 스크립트 원문 전체를 스캔한다(주석 제외 금지 — 위 docstring 참조).
+        unescaped = re.findall(r"(?<!\$)\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?", script)
+        unknown = sorted(set(unescaped) - _DECLARED_SUBSTITUTIONS)
+        assert not unknown, (
+            f"cloudbuild.yaml {step_id} 스텝에 이스케이프 안 된(달러 두 개 누락) 셸 변수로 "
+            f"보이는 미선언 substitution 참조 발견(주석 포함 전문 스캔): {unknown} — 셸 변수라면 "
+            f"달러 두 개로 이스케이프할 것. 설명 주석이라도 달러중괄호로 이 이름들을 언급하지 말 것."
+        )
 
 
 def test_deploy_backend_is_bash_entrypoint():

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -284,12 +284,16 @@ steps:
         # dev는 AUTH 없는 plain Memorystore라 시크릿 바인딩 자체가 없으므로 기존처럼 plain으로 넘긴다.
         # prod는 여기서 REDIS_URL을 절대 안 넘김 — 시크릿 바인딩(별도 1회 gcloud, PO lane)이
         # --set-secrets 없는 이 스텝에 preserve된다(DATABASE_URL_PROD 등 기존 15개와 동일 컨벤션).
-        # ⛔story #2421 배포 실패 핫픽스(2026-07-23, 오르테가군 진단) — Cloud Build는 bash
-        # 스텝 안이라도 args 문자열 전체를 자기 substitution 파서로 먼저 훑는다. `ENV_VARS`는
-        # 유효한 built-in/사용자 substitution이 아니라서 `${ENV_VARS}` 참조가 build submit
-        # 자체를 INVALID_ARGUMENT로 거부시켰다(부분 배포 없이 안전하게 막힘). 셸 변수
-        # 참조는 `$$`로 이스케이프해야 Cloud Build가 문자 그대로 bash에 넘긴다 — 아래
-        # `$${ENV_VARS}`가 그것(진짜 substitution인 `${_DEPLOY_ENV}` 등은 단일 `$` 그대로 유지).
+        # ⛔story #2423 배포 실패 핫픽스(2026-07-23, 오르테가군 진단, 2차) — Cloud Build는 bash
+        # 스텝 안이라도 args 문자열 전체(주석 포함 — bash에겐 주석이지만 Cloud Build 파서는
+        # 주석/코드를 구분하지 않고 그냥 문자열로 훑는다)를 자기 substitution 파서로 먼저
+        # 훑는다. 셸 변수 ENV_VARS는 유효한 built-in/사용자 substitution이 아니라서, 달러중괄호
+        # 표기로 참조하면(이 문장처럼 예시로 적어도 마찬가지) build submit 자체가
+        # INVALID_ARGUMENT로 거부된다(부분 배포 없이 안전하게 막힘 — 1차 사고와 동일 에러,
+        # 이번엔 그 사고를 설명하던 주석 문장 자체가 같은 표기를 그대로 써서 재현했다). 이후
+        # 이 파일 어디서도 ENV_VARS를 달러중괄호로 예시조차 적지 않는다 — 셸 변수 실참조는
+        # 아래처럼 달러 두 개로 이스케이프한 표기만 쓴다(진짜 substitution인 DEPLOY_ENV 등은
+        # 달러 한 개 표기 그대로 유지 — 그건 Cloud Build가 실제로 채워야 하는 값이라 안전하다).
         if [ "${_DEPLOY_ENV}" != "prod" ]; then
           ENV_VARS="$${ENV_VARS},REDIS_URL=${_REDIS_URL}"
         fi


### PR DESCRIPTION
## Summary
- #2423's own fix left one unescaped `\${ENV_VARS}` reference behind — inside a comment (line 289) explaining the original bug. Cloud Build's substitution parser scans the entire step `args` string regardless of bash comment syntax, so that comment reproduced the exact `INVALID_ARGUMENT` error it was describing, breaking the recovery deploy the same way.
- Reworded the comment to avoid `${...}` notation entirely (describes escaping in words rather than showing broken syntax as a literal example).
- Removed the "skip comment lines" rule from the regression guard test added in #2423 — that rule modeled bash's behavior (which ignores comments), not Cloud Build's (which does not), so it let this exact bug through CI. The guard now scans the full script text including comments.

## Test plan
- [x] `uv run pytest backend/tests/test_deploy_backend_redis_secret_conflict.py -v` — 5/5 pass
- [x] Verified the updated (comment-inclusive) guard test catches the exact bug when run against the currently-merged `cloudbuild.yaml` content (`git show HEAD:cloudbuild.yaml`)
- [x] Verified zero unescaped/unknown `${...}` references remain anywhere in the `deploy-backend` step after the fix
- [ ] Real Cloud Build submission succeeds on dev (Ortega to confirm post-merge — he's checking the merged file directly with a live scan before pressing merge this time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)