### PR TITLE
fix(promo): _REALTIME_URL empty-default + deploy-realtime fail-fast guard

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -340,6 +340,20 @@ steps:
           echo "skip deploy-realtime: prod gate pending (E-ARCH 1단계 dev 검증 후 오픈)"
           exit 0
         fi
+        # ⛔fail-fast (오르테가군 PO 2026-07-23): `_REALTIME_URL` 기본값을 dev URL 에서 빈
+        # 문자열로 내렸다(위 substitutions 주석 — prod 프론트가 dev realtime 을 가리킬 여지 제거).
+        # frontend 쪽은 빈 값이 곧 "FASTAPI_URL 로 폴백"이라 안전하지만, **여기서는 빈 값이
+        # 안전하지 않다** — 아래 `FASTAPI_URL=${_REALTIME_URL}` 가 빈 문자열로 나가면
+        # realtime-dev 의 self URL 이 지워진다. 조용히 깨지는 대신 여기서 멈춘다.
+        # 자동 경로(GHA dev 분기)는 항상 명시값을 넘기므로 이 가드에 걸릴 일이 없다 —
+        # 걸린다면 substitution 없이 수동 `gcloud builds submit` 한 경우이고, 그건 정말로
+        # 멈춰야 하는 상황이다.
+        if [ -z "${_REALTIME_URL}" ]; then
+          echo "FAIL: _REALTIME_URL 이 비어 있다. deploy-realtime 은 이 값을 realtime 서비스의"
+          echo "      FASTAPI_URL 로 쓰므로 빈 값으로 진행하면 self URL 이 지워진다."
+          echo "      --substitutions 에 _REALTIME_URL=<realtime 서비스 URL> 을 명시할 것."
+          exit 1
+        fi
         # ⚠️story #2078 긴급수정(2026-07-21): PG_LISTEN_ENABLED가 여기 true로 하드코딩돼
         # 있었다 — PO가 라이브에서 손으로 false로 전환(LISTEN 제거·Redis 단독 dispatch 확認
         # 완료)했는데, 이 스텝이 명시적으로 true를 다시 밀어넣어 **다음 배포마다 LISTEN이

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -55,7 +55,20 @@ substitutions:
   _REALTIME_MIN_INSTANCES: '2'
   _REALTIME_MAX_INSTANCES: '8'
   _REALTIME_TIMEOUT: '3600'
-  _REALTIME_URL: https://sprintable-realtime-dev-787818285179.asia-northeast3.run.app
+  # ⛔기본값을 dev URL 에서 빈 문자열로 내린다(오르테가군 PO, 2026-07-23 prod 승격 preflight
+  # 에서 적발). 이 값은 `deploy-frontend` 의 `--update-env-vars=REALTIME_URL=${_REALTIME_URL}`
+  # 로 흘러 FE 의 `/api/event-stream` 프록시 목적지가 된다. 그런데 GHA 워크플로우의 prod 분기는
+  # `realtime_url` output 을 아예 내보내지 않아 `_REALTIME_URL=` (빈 값)이 전달된다 —
+  # **"빈 값으로 전달"이 "기본값으로 폴백"이 되는 순간 prod 프론트가 dev realtime 을 가리킨다.**
+  # 그 동작에 의존해 안전을 주장할 근거가 이 저장소에 없었다(빈 값 override 를 실측한 전례 0건:
+  # `_GA4_MEASUREMENT_ID` 는 기본값도 빈 문자열이라 대조가 안 되고, 나머지는 전부 비어있지 않은
+  # 값을 넘긴다). ⇒ 폴백 자체를 안전한 쪽으로 뒤집는다 — 빈 값이면 FE 가 FASTAPI_URL 로 폴백하는
+  # 것이 이미 설계된 동작이고(deploy-frontend 주석 "이 값을 비우면 즉시 원복"), 그것이 현행 prod
+  # 동작과 정확히 같다. dev 는 워크플로우가 항상 명시값을 넘기므로 무영향(라이브 대조 확認:
+  # sprintable-frontend-dev REALTIME_URL=…realtime-dev…run.app).
+  # ⚠️이 한 줄은 develop 에도 같이 들어가야 한다 — 승격 브랜치에만 남으면 main/develop 이
+  # 또 갈라진다(오늘 0163 에서 겪은 그 부채와 같은 종류). 별 PR 로 동반 반영할 것.
+  _REALTIME_URL: ""
 
   # story c4c72eb1 후속(2026-07-22, GCE 조사 중 발견): `deploy-frontend` 스텝에 `--timeout`
   # 플래그가 한 번도 없었다(story #2005가 backend에서 고친 것과 동형 결함, frontend는


### PR DESCRIPTION
## Summary
Companion PR for the same fix Ortega found and applied directly on the `promo/stage1-earch-20260723` promotion branch (#2426, commits `337ef8b3`/`773877ee`), cherry-picked here unchanged so main and develop don't fork on `cloudbuild.yaml` — same class of debt as today's `0163`/ee_pricing lesson.

**The bug (not visible in any commit diff — an interaction between a default value and an empty override, not a line that says "send prod to dev"):**
- `deploy-frontend` passes `--update-env-vars=REALTIME_URL=${_REALTIME_URL}` to set the FE's `/api/event-stream` proxy target.
- The GHA workflow's prod branch never emits a `realtime_url` output, so `_REALTIME_URL` resolves to cloudbuild.yaml's substitution default — which was the **dev** realtime URL.
- Result: an empty override silently becoming a dev-URL fallback would have pointed prod's frontend at `sprintable-realtime-dev`.

**The fix:** flip the default itself to `""` instead of relying on empirically-unverified "does an empty override actually take effect" behavior (no precedent for that in this repo). Empty string reaching the FE's `process.env['REALTIME_URL'] || FASTAPI_URL()` check falls back exactly like the current live state (verified: prod frontend currently has no `REALTIME_URL` key at all). A companion fail-fast guard was needed because the same default is *also* consumed by `deploy-realtime` as the realtime service's own `FASTAPI_URL` — there, an empty value is NOT safe (it would deploy with no self-URL), so that path errors out instead of silently proceeding.

## Verification (adversarial re-check, independent of the original author)
- Traced every consumer of `_REALTIME_URL`/`REALTIME_URL` repo-wide: only `deploy-frontend` and `deploy-realtime` in `cloudbuild.yaml`, both now handled correctly (fallback vs fail-fast).
- `apps/web/src/app/api/event-stream/route.ts` already has a pre-existing test (`route.test.ts`) explicitly covering the empty-string case — passing before this change, unaffected by it (this PR touches only `cloudbuild.yaml`).
- Live-confirmed via `gcloud run services describe sprintable-frontend-prod`: no `REALTIME_URL` key currently exists on prod frontend, matching the fallback path this default now produces.
- dev path unaffected: GHA's dev branch always emits an explicit `realtime_url` output, so the new fail-fast guard never triggers on the automated path — only on a manual `gcloud builds submit` with no substitutions, which is exactly when it should stop.
- `cloudbuild.yaml` re-validated as well-formed YAML after cherry-pick; clean cherry-pick, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)