### PR TITLE
[SID:2104] 파괴적조작 authz — sprints-client·story-detail-panel 양방향 mount 테스트 추가

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.test.tsx
@@ -20,6 +20,13 @@ vi.mock('@/components/nav/top-bar-slot', () => ({
   ),
 }));
 
+// story #2104 — HumanOnlyAction(스프린트 삭제 트리거를 감싼다)이 useDashboardContext를 읽는다.
+// 기본은 human(기존 first-touch 스위트는 게이팅과 무관). agent 케이스만 개별 override.
+const { useDashboardContextMock } = vi.hoisted(() => ({ useDashboardContextMock: vi.fn() }));
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => useDashboardContextMock(),
+}));
+
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 let container: HTMLDivElement;
@@ -46,6 +53,7 @@ beforeEach(() => {
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
+  useDashboardContextMock.mockReturnValue({ currentMemberType: 'human' });
 });
 
 afterEach(async () => {
@@ -92,5 +100,27 @@ describe('SprintsClient — 스프린트 first-touch 정체성', () => {
     expect(html).toContain('Sprint 1');
     expect(html).not.toContain('아직 시작한 스프린트가 없어요');
     expect(html).not.toContain('첫 스프린트 시작하기');
+  });
+
+  // story #2104 — BE sprints.py:351(human-only 삭제 403)를 FE가 미리 안 보고 에이전트 계정에도
+  // 삭제 트리거를 무조건 열었다(#2091/#2103과 같은 결함). 양방향 고정 — human까지 잠그면
+  // 정당한 삭제가 봉쇄되는 더 큰 사고다(승격 위험목록의 잔여 미검증 칸 해소).
+  it('human이면 스프린트 삭제 트리거가 렌더된다(정당한 사용자는 막히면 안 됨)', async () => {
+    stubFetch([{ id: 's1', title: 'Sprint 1', status: 'planning', start_date: '2026-07-01', end_date: '2026-07-14' }]);
+    await mount();
+    const row = [...container.querySelectorAll('li')].find((li) => li.textContent?.includes('Sprint 1'));
+    expect(row).not.toBeUndefined();
+    await act(async () => { row!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(container.querySelector('button[aria-label="스프린트 삭제"]')).not.toBeNull();
+  });
+
+  it('agent면 스프린트 삭제 트리거가 안 뜬다', async () => {
+    useDashboardContextMock.mockReturnValue({ currentMemberType: 'agent' });
+    stubFetch([{ id: 's1', title: 'Sprint 1', status: 'planning', start_date: '2026-07-01', end_date: '2026-07-14' }]);
+    await mount();
+    const row = [...container.querySelectorAll('li')].find((li) => li.textContent?.includes('Sprint 1'));
+    expect(row).not.toBeUndefined();
+    await act(async () => { row!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(container.querySelector('button[aria-label="스프린트 삭제"]')).toBeNull();
   });
 });

--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -99,7 +99,7 @@ beforeEach(() => {
   root = createRoot(container);
   stubLocalStorage();
   stubEventSource();
-  useDashboardContextMock.mockReturnValue({ currentTeamMemberId: 'me-1', projectMemberships: [], orgMemberships: [] });
+  useDashboardContextMock.mockReturnValue({ currentTeamMemberId: 'me-1', projectMemberships: [], orgMemberships: [], currentMemberType: 'human' });
 });
 
 afterEach(async () => {
@@ -335,5 +335,35 @@ describe('KanbanBoard — 실시간(SSE) 상세 패널 동기화(#2137)', () => 
     // story-detail-panel.tsx: useEffect(() => setLocalStatus(story.status), [story.status]) 가
     // selectedStory prop 갱신을 따라가는지 — StatusBadge 라벨 텍스트로 확認.
     expect(dialog!.textContent).toContain('개발 대기');
+  });
+});
+
+// story #2104 — BE stories.py:1056(human-only 영구삭제 403)를 FE가 미리 안 보고 에이전트
+// 계정에도 삭제 트리거를 무조건 열었다(#2091/#2103과 같은 결함). 양방향 고정 — human까지
+// 잠그면 정당한 삭제가 봉쇄되는 더 큰 사고다(승격 위험목록의 잔여 미검증 칸 해소).
+describe('StoryDetailPanel — 영구삭제 트리거 authz(story #2104)', () => {
+  async function openPanel(title: string) {
+    const card = container.querySelector(`[title="${title}"]`) as HTMLElement | null;
+    expect(card).not.toBeNull();
+    await act(async () => {
+      card!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it('human이면 스토리 영구삭제 트리거가 렌더된다(정당한 사용자는 막히면 안 됨)', async () => {
+    stubFetch([{ id: 's1', title: 'S1', status: 'backlog', priority: 'medium' }]);
+    await mount();
+    await openPanel('S1');
+    expect(container.querySelector('[role="dialog"] button[aria-label="스토리 삭제"]')).not.toBeNull();
+  });
+
+  it('agent면 스토리 영구삭제 트리거가 안 뜬다', async () => {
+    useDashboardContextMock.mockReturnValue({ currentTeamMemberId: 'me-1', projectMemberships: [], orgMemberships: [], currentMemberType: 'agent' });
+    stubFetch([{ id: 's1', title: 'S1', status: 'backlog', priority: 'medium' }]);
+    await mount();
+    await openPanel('S1');
+    expect(container.querySelector('[role="dialog"] button[aria-label="스토리 삭제"]')).toBeNull();
   });
 });


### PR DESCRIPTION
## 배경
prod 승격(PR #2426) FE 위험면 검토 중 발견한 잔여 미검증 칸을 닫는다. #2104(`<HumanOnlyAction>` wrapper, 파괴적조작 6곳)의 원 PR(#2397)은 `wrapper 자체(4케이스)` + `goals-client`·`sprint-close-cockpit`(각 2케이스) mount 테스트만 있었고, 나머지 4곳(docs·sprints·story-detail-panel·settings)은 코드리뷰로만 배선을 확認했다("기존 테스트 인프라 부재로 비용 대비 낮음"이 원 PR의 판단).

이 PR은 그 4곳 중 **mount 테스트 인프라가 이미 있던 2곳**(sprints-client — first-touch 스위트 존재, story-detail-panel — kanban-board.test.tsx의 #2137 `openPanel` 헬퍼 재사용 가능)을 닫는다.

## 변경
**⭐양방향 필수(PO 강조)** — agent에 열려있는 건 prod 현행이라 최악이 현상유지지만, human이 잘못 막히면 **되던 일이 안 되는 회귀**다. 그게 이 클래스의 유일한 실질 위험.

- `sprints-client.test.tsx`: 스프린트 삭제 트리거(`aria-label="스프린트 삭제"`) — human→노출 / agent→비노출 2케이스 추가.
- `kanban-board.test.tsx`: 스토리 영구삭제 트리거(story-detail-panel, `aria-label="스토리 삭제"`) — human→노출 / agent→비노출 2케이스 추가. 기존 `useDashboardContextMock` 기본값에 `currentMemberType: 'human'` 추가(기존 13+ 케이스는 게이팅과 무관해 무영향).

## 검증
**RED→GREEN 확認**: 두 파일 모두 `<HumanOnlyAction>` wrapper를 임시로 제거해 agent 케이스가 실제로 실패하는 것(버튼이 열려버림)을 확認한 뒤 복원해 GREEN 재확認했다.
- `pnpm vitest run`(변경 2파일) — 20/20 PASS
- `pnpm exec eslint`(변경 2파일) — 0
- `pnpm exec tsc --noEmit` — 0
- `pnpm build` — EXIT 0

## 스코프 밖 — 후속 스토리로 분리
남은 2곳(`docs/[slug]/page.tsx`·`settings/page.tsx`)은 삭제 트리거가 base-ui `DropdownMenu`(포탈 렌더) 안에 있고 `useDocsLayout`/`useDocSync` 등 무거운 Provider·훅 의존이 있어 마운트 인프라가 진짜 0인 채로 새로 만드는 비용이 크다. 코드리뷰(`<HumanOnlyAction>` 사용 자체는 grep 재확認 — RED는 안 났음, "실패"가 아니라 "못 잰 칸")로 정리하고 별도 후속 스토리로 등재한다.