### PR TITLE
promo(stage2): prod dual_publish 켜기 — #2425 단일 커밋 체리픽 (1단 검증 완료 後)

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -84,17 +84,29 @@ jobs:
             # false 유지 — dev 게이트(consume+dispatch 동시 on) 통과 후 별도 판단.
             echo "backend_redis_consume_enabled=false" >> "$GITHUB_OUTPUT"
             echo "backend_redis_dispatch_enabled=false" >> "$GITHUB_OUTPUT"
-            # story cd10e123 긴급수정(2026-07-21): prod는 아직 Memorystore 인스턴스/연결이
-            # 확認 안 됐다(오늘 Redis 작업은 dev 한정) — REDIS_URL 빈 문자열(config.py의
-            # "미설정 시 fail-safe" 로직이 그대로 no-op)·dual_publish도 false로 안전 기본.
-            # prod가 Redis 연결을 갖추는 승격 시점에 산티아고군이 실측값으로 override할 것.
+            # story #2141 S-a(E-ARCH, 2026-07-23 오르테가군 확定 순서) — prod Redis 인스턴스
+            # READY(sprintable-redis-prod, AUTH 켬)이고, backend-prod Cloud Run에 REDIS_URL
+            # secretKeyRef=REDIS_URL_PROD 바인딩이 실제로 붙어 있는 것 확認됐다(오르테가
+            # --update-secrets 실행, 리비전 00231-lxm→00232-mmm, env 32→33·시크릿 13→14,
+            # ping 200 — 2026-07-23). ⇒ 이 커밋이 dual_publish=true를 실배포하는 첫 안전한
+            # 시점이다(바인딩 전에 켜면 REDIS_URL 없이 발행을 시도해 깨졌을 자리).
+            # redis_url output은 여기 안 둔다 — prod는 cloudbuild.yaml deploy-backend가
+            # ${_DEPLOY_ENV}==prod일 때 REDIS_URL을 ENV_VARS에 아예 안 실으므로(#2421) plain
+            # substitution 경로 자체가 없다(시크릿 바인딩만 유효 경로).
+            # ⛔S-a는 dual_publish 하나만 켠다 — consume/dispatch는 각각 별 커밋(S-b/S-c,
+            # #2141 §3)이며, PG_LISTEN_ENABLED는 이 단계에서 손대지 않는다(prod의 유일한
+            # 실시간 배차 경로라 Redis 도달 확認 前에 끄면 실시간이 전면 정지한다).
             echo "redis_url=" >> "$GITHUB_OUTPUT"
-            echo "backend_redis_dual_publish_enabled=false" >> "$GITHUB_OUTPUT"
+            echo "backend_redis_dual_publish_enabled=true" >> "$GITHUB_OUTPUT"
             # story #2123 S0-b(2026-07-23, 오르테가군 판정): wake_agent 크로스인스턴스 배달의
-            # 발행측 스위치. prod는 아직 dual_publish/redis_url 자체가 없다(위) — 이 스위치를
-            # 켜봐야 event_broker.publish() 내부에서 여전히 Redis publish는 안 나가고(직전
-            # dual_publish=false) pg_notify만 무조건 나간다(현행 유지). dev 게이트 통과 전
-            # prod에 얹지 않는다(#2120/#2121/#2122와 동일 원칙).
+            # 발행측 스위치.
+            # ⛔#2141 S-a 반영 후 정정 — 이 주석이 여태 "prod는 아직 dual_publish/redis_url
+            # 자체가 없다"를 근거로 들었으나, 위 dual_publish가 이제 true다(그 전제는 낡았다).
+            # 그래도 결론(false 유지)은 그대로 맞다 — 이유가 바뀐 것뿐: consume/dispatch가
+            # 아직 false라 event_broker가 Redis로 publish는 해도(dual_publish) 그걸 구독해서
+            # 실 전달(dispatch)하는 쪽이 꺼져 있다. dispatch 없이 이 스위치만 켜봐야 무의미하고,
+            # S-b/S-c(consume/dispatch)가 dev 게이트를 통과하기 전엔 prod에 얹지 않는다
+            # (#2120/#2121/#2122와 동일 원칙).
             echo "backend_fanout_wake_redis_enabled=false" >> "$GITHUB_OUTPUT"
             # story #2078(E-ARCH 0단계, 오르테가군 판정 2026-07-21): dev 실측 GREEN 확認 전
             # prod에 얹지 않는다 — develop→main 48커밋 일괄승격에 검증 안 된 롤백 플래그를


### PR DESCRIPTION
## 무엇인가 — prod 승격 **2단(동작 전환)**. 한 줄이다.

```
.github/workflows/cloud-build.yml  prod 분기
  backend_redis_dual_publish_enabled   false → true
```

`develop` 의 `11a19c83`(#2425) 을 `-x` 로 체리픽했다. **1단(#2426, `main` `64af78e5`)이 착지·검증 완료된 뒤** 태우는 두 번째 단계다.

### 왜 체리픽인가 — 이번엔 merge 가 아니다

1단은 `develop~1` 을 **머지커밋**으로 올려 ancestry 를 보존했다(그래서 다음 승격 범위가 잘린다). 그러나 지금 `origin/main..origin/develop` 에는 `#2425` 외에 **ee_pricing/billing 계열 변경이 함께 들어 있다**(`backend/ee/routers/billing.py`, `pricing_version.py` 등 17파일). `main` 은 그 경계를 의도적으로 제외해 온 브랜치이므로 **develop→main 재머지는 쓸 수 없다.**

⇒ #2415 와 같은 **단일 커밋 체리픽** 경로를 쓴다. 대가는 다음 전체 승격에서 이 한 파일에 작은 충돌이 한 번 생기는 것이고, 오늘 그 충돌을 실제로 처리해본 자리라 비용이 확認돼 있다(주석만 다른 형태). 이 반복 자체는 별건 **#2146** 으로 등재돼 있다.

## 1단이 실제로 검증된 근거 (이 PR 의 전제)

```
backend-prod-00233-rw4 / frontend-prod-00209-92x
env 33 → 38 · 신규 5키 값 전부 일치 · 사라지는 키 0
시크릿 14 유지 · REDIS_URL secretKeyRef 유지
minScale 3 · maxScale 5 · timeout 300 불변
frontend REALTIME_URL = '' (dev URL 아님)
alembic 0204 → 0205 적용 확認 — 로그(05:49:24.915Z "Running upgrade 0204 -> 0205")
                                + DB 직접 실측(alembic_version=['0205'] · event_outbox 실재)
/api/v2/ping 200
```

**오류율 대조(같은 클래스·같은 서비스, 배포 前後):**

```
00232-mmm  05:20~05:45Z (25분)  ERROR 131건  ≈ 5.2/분
00233-rw4  05:50~06:02Z (12분)  ERROR  37건  ≈ 3.1/분
⇒ 전부 기존 SQLAlchemy 커넥션 풀 GC 계열(pool-gc / terminate). **새 오류 클래스 0** ·
  비율 증가 없음. 5xx 0건. frontend ERROR 0건.
```

⚠️ 이 pool-GC 잡음은 **승격 前부터 있던 것**이며 이 PR 과 무관하다(#2074/#2040 커넥션 축). 여기 적는 이유는 "배포 후 에러가 보인다"를 이 승격 탓으로 오독하지 않게 하기 위함이다.

## 이 PR 이 prod 에서 실제로 바꾸는 것

`event_broker.publish()` 가 기존 `pg_notify()` 에 **더해** Redis 로도 발행하기 시작한다(`_redis_publish`, fire-and-forget).

```
consume  = false  (유지) — 구독해서 실제로 배달하는 쪽은 여전히 꺼져 있다
dispatch = false  (유지)
PG_LISTEN_ENABLED = true (유지) — prod 의 유일한 실 배차 경로는 그대로다
⇒ 배달 경로는 하나도 안 바뀐다. **관측/도달 확認 단계**다
```

**실패 시 동작(코드 확認)**: `_redis_publish` 는 `try/except` 로 감싸 경고 로그만 남기고 예외를 전파하지 않으며, `redis_url` 미설정이면 즉시 skip 한다. `pg_notify()` 는 그 앞에서 이미 무조건 실행된다 ⇒ **Redis 가 불통이어도 실시간이 죽지 않는다.**

## 배포 後 실측 (값 보기 前에 박아둔다)

```
env 38 → 38 (개수 불변 · dual_publish 값만 false→true)
EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED = true
시크릿 14 유지 · minScale 3 · maxScale 5 · timeout 300 불변 · /api/v2/ping 200
⭐ prod 로그 "event_broker redis publish failed" → **0건이어야 한다**
   ⚠️단 0건만으로 성공을 선언하지 않는다 — 발행 자체가 일어난 창인지부터 확認한다
     (활동이 없으면 실패도 0건이다. 양성 대조 없는 0건은 근거가 아니다)
⇒ Memorystore `sprintable-redis-prod` 의 서버측 지표(commands/calls)로 **실제 도달**을 본다
```

## 롤백

이 커밋을 revert 하고 재배포하면 `dual_publish=false` 로 돌아가 `publish()` 가 `pg_notify()` 전용으로 복귀한다 — 다른 prod 상태 변경이 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
