### PR TITLE
[SID:2149] 공용 <Alert> variant 무관 role="alert" 고정 — 성공/안내 메시지 assertive 낭독 오끊김 수정

### DIFF
--- a/apps/web/src/components/ui/alert.test.tsx
+++ b/apps/web/src/components/ui/alert.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+//
+// story #2149 — 공용 <Alert>가 variant와 무관하게 항상 role="alert"(assertive)로 고정돼
+// 있어, variant="success"/"info" 성공·안내 메시지까지 사용자의 스크린리더 낭독을 끊고
+// 들어갔다(#2096이 정한 "에러=assertive/성공-안내=polite" 관례 위반). #2148 판별 중
+// 발견 — Alert 컴포넌트가 최초 생성(2026-05-26)될 때부터 그랬고, #2096 관례는 그로부터
+// 약 2개월 뒤(2026-07-22)에 생겨 소급 반영되지 않았던 순수 누락.
+//
+// 설계 제약(PO 지시) — 실패 방향은 안전한 쪽이어야 한다: variant를 못 읽거나 새
+// variant가 추가돼 매핑에 없으면 assertive로 떨어져야 한다(에러가 조용해지는 것이
+// 성공이 시끄러운 것보다 나쁘다). 즉 success/info만 명시적으로 polite, 그 외 전부
+// assertive다 — 이 테스트는 그 allowlist 방향이 실제로 지켜지는지 고정한다.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { Alert, AlertDescription } from './alert';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+describe('Alert 접근성 (story #2149)', () => {
+  // AC1 — variant별 role/aria-live 고정. success/info만 polite, 나머지(default/warning/
+  // destructive)는 전부 assertive. 새 variant를 추가하는 사람이 이 매핑을 안 건드리면
+  // 여기가 깨져서 잡는다.
+  it.each([
+    ['default', 'alert', 'assertive'],
+    ['warning', 'alert', 'assertive'],
+    ['destructive', 'alert', 'assertive'],
+    [undefined, 'alert', 'assertive'],
+    ['success', 'status', 'polite'],
+    ['info', 'status', 'polite'],
+  ] as const)('variant=%s → role=%s, aria-live=%s', async (variant, expectedRole, expectedLive) => {
+    await act(async () => {
+      root.render(<Alert variant={variant}><AlertDescription>메시지</AlertDescription></Alert>);
+    });
+    const el = container.querySelector(`[role="${expectedRole}"]`);
+    expect(el).not.toBeNull();
+    expect(el?.getAttribute('aria-live')).toBe(expectedLive);
+    expect(el?.getAttribute('aria-atomic')).toBe('true');
+  });
+
+  it('매핑에 없는 미지의 variant는 안전한 방향(assertive)으로 떨어진다', async () => {
+    // 아직 alertVariants에 정의되지 않은 variant를 억지로 통과시켜, "새 variant 추가 시
+    // 매핑을 깜빡해도 조용해지지 않는다"는 설계 제약을 직접 증명한다.
+    const unmappedVariant = 'brand-new-variant' as unknown as React.ComponentProps<typeof Alert>['variant'];
+    await act(async () => {
+      root.render(<Alert variant={unmappedVariant}><AlertDescription>메시지</AlertDescription></Alert>);
+    });
+    const el = container.querySelector('[role="alert"]');
+    expect(el).not.toBeNull();
+    expect(el?.getAttribute('aria-live')).toBe('assertive');
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+
+  it('호출부가 명시적으로 role/aria-live를 넘기면 그 값이 우선한다(기존 doc-sync-banner 오버라이드 패턴 보존)', async () => {
+    await act(async () => {
+      root.render(
+        <Alert variant="success" role="alert" aria-live="assertive">
+          <AlertDescription>강제 오버라이드</AlertDescription>
+        </Alert>,
+      );
+    });
+    const el = container.querySelector('[role="alert"]');
+    expect(el).not.toBeNull();
+    expect(el?.getAttribute('aria-live')).toBe('assertive');
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+
+  it('destructive와 status가 동시에 잡히지 않는다(이중 낭독 방지)', async () => {
+    await act(async () => {
+      root.render(<Alert variant="destructive"><AlertDescription>에러</AlertDescription></Alert>);
+    });
+    expect(container.querySelector('[role="alert"]')).not.toBeNull();
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+});

--- a/apps/web/src/components/ui/alert.tsx
+++ b/apps/web/src/components/ui/alert.tsx
@@ -24,13 +24,28 @@ const alertVariants = cva(
   }
 );
 
+// story #2149: role/aria-live는 variant에서 유도한다. 오직 success/info만 명시적으로
+// polite — 그 외(default/warning/destructive, 그리고 매핑에 없는 미지의 variant)는
+// 전부 assertive로 떨어진다. 에러가 조용해지는 것이 성공이 시끄러운 것보다 나쁘다.
+const POLITE_ALERT_VARIANTS = new Set(['success', 'info']);
+
+function getAlertRole(variant?: string | null): 'alert' | 'status' {
+  return variant && POLITE_ALERT_VARIANTS.has(variant) ? 'status' : 'alert';
+}
+
+function getAlertAriaLive(variant?: string | null): 'assertive' | 'polite' {
+  return variant && POLITE_ALERT_VARIANTS.has(variant) ? 'polite' : 'assertive';
+}
+
 const Alert = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
->(({ className, variant, ...props }, ref) => (
+>(({ className, variant, role, 'aria-live': ariaLive, 'aria-atomic': ariaAtomic, ...props }, ref) => (
   <div
     ref={ref}
-    role="alert"
+    role={role ?? getAlertRole(variant)}
+    aria-live={ariaLive ?? getAlertAriaLive(variant)}
+    aria-atomic={ariaAtomic ?? 'true'}
     className={cn(alertVariants({ variant }), className)}
     {...props}
   />


### PR DESCRIPTION
## Summary
- Story #2149 — `#2148`(story #2105 AC6 재훑, 삼항조건부 23곳 판별) 진행 중 부수 발견.
- 공용 `<Alert>` 컴포넌트(`components/ui/alert.tsx`)가 `variant`(default/success/warning/destructive/info) prop을 받으면서도 `role`은 항상 `"alert"`로 하드코딩돼 있었음 — `variant="success"`/`"info"` 메시지까지 스크린리더 낭독을 assertive로 끊고 들어감(`#2096`이 정한 "에러=assertive, 성공/안내=polite" 관례 위반).
- 개별 화면을 고치는 방식(`#2105`/`#2148`)으로는 해결 불가 — 공용 컴포넌트가 강제하는 값이라 소비 측에서 손 댈 수 없음. 컴포넌트 자체를 고침.

## 의도성 확認 (착수 전 PO 지시 — 등재 조건)
```
컴포넌트 최초 커밋   5b4c8c7d (2026-05-26) "feat(ds): DS-S12 add <Alert> component"
                    → role="alert" 하드코딩이 최초부터 존재. ARIA/variant 분기 언급 0.
통합 커밋           8fad3db3 (PR#995, 같은 날) — 순수 색상→시맨틱 토큰 마이그레이션, role 논의 0.
#2096(관례 확定)    2026-07-22 — Alert 생성일로부터 약 2개월 뒤.
```
근거주석 0·의도적 분기 제외 흔적 0 — **의도된 설계가 아니라, 관례가 나중에 생겼는데 소급 안 된 순수 누락**으로 확定.

## 변경 내용
`apps/web/src/components/ui/alert.tsx`:
- `success`/`info`만 명시적으로 `role="status"` + `aria-live="polite"`, 그 외(`default`/`warning`/`destructive`, **그리고 매핑에 없는 미지의 variant**)는 전부 `role="alert"` + `aria-live="assertive"` — allowlist(폴라이트만 명시) 방향.
- **설계 제약(PO 지시)**: 실패 방향이 안전한 쪽이어야 한다 — variant를 못 읽거나 새 variant가 추가돼 매핑에 없으면 assertive로 떨어져야 함(에러가 조용해지는 것이 성공이 시끄러운 것보다 나쁨). polite를 기본으로 하고 error만 assertive로 짜면 새 variant가 조용해지는 함정이 생기므로, 반대 방향(assertive 기본 + success/info만 예외)으로 구현.
- `aria-atomic="true"` 추가(기존엔 없었음).
- 호출부가 명시적으로 `role`/`aria-live`를 넘기면 그 값이 우선 — 기존 `doc-sync-banner.tsx`의 수동 오버라이드 패턴(`variant={isConflict?'warning':'info'} role={isConflict?'alert':'status'}`)과 완전히 호환. 오히려 그 파일은 이번 변경으로 `aria-atomic`이 자동으로 추가되는 효과도 얻음(부작용 아님 — 개선).

## ⚠️ Toast(#2096) 관례와의 의도적 차이 — 투명히 기록
Toast(`#2096`)는 `warning`도 polite로 분류한다. **이 컴포넌트는 PO 지시에 따라 `warning`을 assertive로 분류** — "success/info만 명시적으로 polite, 나머지 전부 assertive"라는 fail-safe 우선 설계다. Toast와 Alert가 서로 다른 `warning` 정책을 갖게 되는 것은 인지하고 있으며, 의도적 선택(PO 승인)이다.

## variant 사용 분포 실측 (AC2)
```
grep -rhoE '<Alert[^>]*variant="[a-z]+"' apps/web/src --include="*.tsx" | grep -oE 'variant="[a-z]+"' | sort | uniq -c
   1 variant="default"
   4 variant="destructive"
   1 variant="info"
   6 variant="success"
  15 variant="warning"
```
+ 동적 variant(`message.type==='success'?'success':'destructive'` 등) 사용처 다수 — 위 카운트는 정적 리터럴만 집계, 동적 분기는 런타임에 fail-safe 로직이 그대로 적용됨.

## `#2148`과의 관계
`#2148`이 판별 中 이미 `<Alert>` 사용 3곳(`agent-hitl-policy-editor.tsx`·`agent-management-tab.tsx`·`mcp-connection-settings.tsx`)을 "role이 이미 있어 false positive"로 분류했음 — 이 PR이 그 3곳을 포함해 **`<Alert>`를 쓰는 모든 화면**을 한 번에 고침. `#2148`은 이 PR 머지 후 착수(PO 지시, 순서만 바뀐 것 — 판별 결과는 그대로 유효).

## Test coverage
- 신규 `alert.test.tsx` (9 케이스): variant별 role/aria-live 6종 고정 + 미지의 variant가 assertive로 떨어짐 증명 + 명시적 오버라이드 우선 증명 + 이중 role 낭독 방지.
- **RED→GREEN 검증**: fix를 되돌려 신규 테스트 9개 중 7개 실패 확認(2개는 애초에 fix 무관 케이스라 그대로 통과) → 복원 후 9/9 통과.

## Gate 결과 (worktree root)
- `pnpm --filter web type-check` — **0 errors**
- `pnpm --filter web lint` — **0 errors**, 5 pre-existing warnings in unrelated files (e2e/retro-detailed.spec.ts, docs/[slug]/page.tsx, lib/storage/format.ts) — 이 PR과 무관
- `pnpm test` (root vitest, full repo) — **304 test files passed, 2088 tests passed, 2 skipped, 0 failed**
- `pnpm --filter web build` — **EXIT 0**

## Test plan
- [x] type-check clean
- [x] lint clean (no new warnings)
- [x] full vitest suite green
- [x] production build succeeds
- [ ] QA(까심) review — 승인 없이 머지 금지

🤖 Generated with [Claude Code](https://claude.com/claude-code)