### PR TITLE
fix(#2142): stop comma-value truncation + mirror APP_ENV/NEXT_PUBLIC_APP_URL onto prod

### DIFF
--- a/backend/scripts/deploy_realtime_gce.sh
+++ b/backend/scripts/deploy_realtime_gce.sh
@@ -178,6 +178,26 @@ log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [$ENV] $*" >&2; }
 # Cloud Run 쪽 카테고리 C와 별개로 여기서도 전량 명시(두 배포 표면이 다르므로 각자 SSOT).
 PLAIN_ENV_SPEC="EVENTBUS_ENABLED=true"
 PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},APP_URL=${APP_URL}"
+# ⛔story #2142(2026-07-23, 오르테가 전수 3방향 diff 적발 — GCE 플랜 vs 라이브 backend-prod
+# env, "prod에 있는데 GCE엔 없는" 축) — APP_ENV/CORS_ORIGINS/NEXT_PUBLIC_APP_URL 셋 다
+# backend-dev에도 backend-prod에도 이 스크립트 작성 당시엔 없었는데, backend-prod는 그 후
+# 별도로 이 값들을 받았다(describe 대조 확認) — dev는 지금도 없음. 즉 이번 건은 "dev값이
+# 분기 밖에 남은" 이전 3건과 반대 방향: **prod가 나중에 추가로 받은 값을 이 스크립트가
+# 못 따라간 것**. 특히 APP_ENV는 `config.py::is_really_local`(story #2071 — `K_SERVICE`
+# 부재로 로컬 판정, GCE엔 K_SERVICE가 원천적으로 없어 그 프로퍼티 자체는 이 값과 무관하게
+# 계속 True로 나옴, 이건 별도 코드 결함으로 등재)와는 별개로 `app_env` 문자열을 직접 보는
+# 코드 경로를 위해 필요 — 지금 당장 시크릿 fail-open 구멍은 아니지만(CRON_SECRET_PROD·
+# FIREBASE_BFF_INTERNAL_SECRET 둘 다 바인딩돼 있어 그 경로는 안전) 미러링 원칙 그대로 적용.
+if [ "${ENV}" = "prod" ]; then
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},APP_ENV=prod"
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},NEXT_PUBLIC_APP_URL=${APP_URL}"
+    # ⚠️CORS_ORIGINS는 여기 안 넣는다 — PLAIN_ENV_SPEC은 아래(line ~410 부근)에서
+    # `IFS=',' read -ra` 로 콤마 분해해 docker run -e 인자로 바꾸는데, CORS_ORIGINS 값
+    # 자체가 콤마 구분 origin 목록(http://localhost:3000,http://localhost:3108,
+    # https://app.sprintable.ai)이라 이 메커니즘에 실으면 조각나 깨진 -e 인자가 된다.
+    # config.py의 cors_origins 기본값이 이 prod 라이브 값과 문자열까지 완전히 동일함을
+    # 확認했으므로(2026-07-23) 안 넣어도 결과가 같다 — 안전한 쪽(생략)을 택한다.
+fi
 PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},MEMBER_SSOT_RESOLVER_SHADOW=true"
 PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},MEMBER_SSOT_APIKEY_CUT=true"
 # ⛔story #2142(2026-07-23, 오르테가 DRY_RUN 검수 3번째 적발 — 같은 뿌리: dev 라이브에서
@@ -197,7 +217,12 @@ fi
 PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},H1_MERGE_GATE_ENABLED=true"
 PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},H1_MERGE_GATE_ORG_ALLOWLIST=${H1_MERGE_GATE_ORG_ALLOWLIST_VALUE}"
 PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},H1_MERGE_GATE_ADVISORY=true"
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},BUILD_APP_METADATA_DEFALLBACK=true"
+# ⛔story #2142(2026-07-23, 오르테가 전수 3방향 diff 적발, 4번째 묶음) — 같은 뿌리(dev
+# 라이브 리터럴이 env 분기 밖에 남음). BUILD_APP_METADATA_DEFALLBACK은 backend-prod에
+# 키 자체가 없다(describe 대조 확認) — dev 전용으로 되돌림.
+if [ "${ENV}" = "dev" ]; then
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},BUILD_APP_METADATA_DEFALLBACK=true"
+fi
 if [ "${GATE_CONFIG_ENFORCE_ENABLED_LINE}" = "true" ]; then
     PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},GATE_CONFIG_ENFORCE_ENABLED=true"
     PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},GATE_CONFIG_ENFORCE_ORG_ALLOWLIST=03970fbf-2db6-434b-a7b1-cb74f9547059"
@@ -221,6 +246,13 @@ PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},DB_MAX_OVERFLOW=1"
 # story #2115(S6): 앱 per-instance SSE 소프트캡(events.py MAX_SSE_CONNECTIONS·기본 100)을 상향.
 # GCE는 Cloud Run concurrency 제약이 없어 실질 상한은 노드 fd/mem이고, 이 캡은 그 전에 걸리는
 # 앱 자체 소프트캡이라 env로 무료 확장 가능. 500으로 올려 ceiling이 실제 확장됨을 실증(3노드=1500 이론).
+# ⛔story #2142(2026-07-23, 오르테가 전수 3방향 diff 검수 시 확認 요청) — backend-prod는
+# 이 값이 코드 기본값(100)인데, 이 GCE 노드가 그보다 높은 500을 쓰는 건 **dev값이 새어든
+# 것이 아니라 이 스택 자체의 설계 의도**다: realtime-gateway는 SSE 전용 노드라 요청당
+# 다른 부하(REST·DB write 등)와 경쟁하지 않고, Cloud Run concurrency 상한도 없어 노드
+# fd/mem이 진짜 상한이 되므로 캡을 올려도 안전 — backend-prod가 이 값을 안 올린 이유는
+# backend-prod는 SSE 전용이 아니라 REST 트래픽과 캡을 공유하기 때문(다른 성격의 노드).
+# dev/prod 둘 다 이 GCE 스택에서는 500 그대로 유지 — env 분기 대상 아님.
 PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},MAX_SSE_CONNECTIONS=500"
 # #2120(E-ARCH 근본): chat_presence working → Redis 공유 롤아웃 게이트. 실측용으로 env 로 flip
 # (기본 false=현 in-memory 무회귀). OFF 실측=false, ON 실측=true. 라이브 실측 후 durable 값 확定.
@@ -235,11 +267,17 @@ PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},SSE_LEASE_REDIS_ENABLED=${SSE_LEASE_REDIS_ENAB
 # env 로 flip(기본 false=pg_notify 직행 무회귀). #2122 라이브 재측정 배포=true(GCE PG_LISTEN=false라 wake
 # 가 Redis 백플레인 타야 타노드 도달 — 미설정 시 cross-node wake 0/2 재현). REALTIME_BACKPLANE 는 별개(cutover).
 PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},FANOUT_WAKE_REDIS_ENABLED=${FANOUT_WAKE_REDIS_ENABLED:-false}"
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},LLM_GEMINI_MODEL=gemini-3.1-pro-preview"
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},LLM_GEMINI_LOCATION=global"
+# ⛔story #2142(2026-07-23, 오르테가 전수 3방향 diff 적발, 4번째 묶음) — 같은 뿌리.
+# LLM_GEMINI_MODEL/_LOCATION·FIREBASE_OAUTH_HANDOFF_ENABLED 전부 backend-prod에 키
+# 자체가 없다(describe 대조 확認) — FIREBASE_OAUTH_HANDOFF_ENABLED=1은 특히 firebase
+# 내부 경로를 **켜는** 값이라 더 신중해야 하는 자리였다. dev 전용으로 되돌림.
+if [ "${ENV}" = "dev" ]; then
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},LLM_GEMINI_MODEL=gemini-3.1-pro-preview"
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},LLM_GEMINI_LOCATION=global"
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},FIREBASE_OAUTH_HANDOFF_ENABLED=1"
+fi
 PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},MCP_PUBLIC_URL=${MCP_PUBLIC_URL}"
 PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},LICENSE_CONSENT=agreed"
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},FIREBASE_OAUTH_HANDOFF_ENABLED=1"
 # realtime 고유값(backend/api와 다름 — cloudbuild.yaml deploy-realtime 스텝과 동일 컨벤션):
 PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},PG_LISTEN_ENABLED=false"
 # story #2135(2026-07-23, #2123 실측 적발): 키 이름이 여태 `REDIS_CONSUME_ENABLED`였다 —

--- a/backend/scripts/deploy_realtime_gce.sh
+++ b/backend/scripts/deploy_realtime_gce.sh
@@ -176,8 +176,16 @@ log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [$ENV] $*" >&2; }
 # ── 라이브 실측 그대로 이관(2026-07-22, gcloud run services describe 전량 대조) ──
 # 평문 35개 + 시크릿 15개 = 50개, drift-guard(infra/manual-env-allowlist.yml)가 감시 중인
 # Cloud Run 쪽 카테고리 C와 별개로 여기서도 전량 명시(두 배포 표면이 다르므로 각자 SSOT).
+# ⛔story #2142(2026-07-23, 오르테가 지적 — 자기 지시가 만든 결함 자인) — PLAIN_ENV_SPEC을
+# 예전엔 콤마로 join하고 소비부에서 `IFS=',' read -ra`로 무조건 콤마 분해했다. 값 자체에
+# 콤마가 들어 있으면(H1_MERGE_GATE_ORG_ALLOWLIST의 2-org 콤마리스트 등) 그 값이 조각나
+# VM에는 절반만 실리는 조용한 절단이 났다 — cloudbuild.yaml이 CORS_ORIGINS로 이미 겪고
+# 커스텀 구분자('^@^')로 고쳐둔 바로 그 함정을 이 스크립트가 다시 밟은 것. 값에 절대
+# 나타나지 않는 ASCII Unit Separator(0x1F)를 join 구분자로 써서 이 클래스 전체를 원천
+# 차단한다 — 어떤 미래 값이 콤마를 포함해도 더 이상 쪼개지지 않는다.
+_PLAIN_SEP=$'\x1f'
 PLAIN_ENV_SPEC="EVENTBUS_ENABLED=true"
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},APP_URL=${APP_URL}"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}APP_URL=${APP_URL}"
 # ⛔story #2142(2026-07-23, 오르테가 전수 3방향 diff 적발 — GCE 플랜 vs 라이브 backend-prod
 # env, "prod에 있는데 GCE엔 없는" 축) — APP_ENV/CORS_ORIGINS/NEXT_PUBLIC_APP_URL 셋 다
 # backend-dev에도 backend-prod에도 이 스크립트 작성 당시엔 없었는데, backend-prod는 그 후
@@ -189,17 +197,17 @@ PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},APP_URL=${APP_URL}"
 # 코드 경로를 위해 필요 — 지금 당장 시크릿 fail-open 구멍은 아니지만(CRON_SECRET_PROD·
 # FIREBASE_BFF_INTERNAL_SECRET 둘 다 바인딩돼 있어 그 경로는 안전) 미러링 원칙 그대로 적용.
 if [ "${ENV}" = "prod" ]; then
-    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},APP_ENV=prod"
-    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},NEXT_PUBLIC_APP_URL=${APP_URL}"
-    # ⚠️CORS_ORIGINS는 여기 안 넣는다 — PLAIN_ENV_SPEC은 아래(line ~410 부근)에서
-    # `IFS=',' read -ra` 로 콤마 분해해 docker run -e 인자로 바꾸는데, CORS_ORIGINS 값
-    # 자체가 콤마 구분 origin 목록(http://localhost:3000,http://localhost:3108,
-    # https://app.sprintable.ai)이라 이 메커니즘에 실으면 조각나 깨진 -e 인자가 된다.
-    # config.py의 cors_origins 기본값이 이 prod 라이브 값과 문자열까지 완전히 동일함을
-    # 확認했으므로(2026-07-23) 안 넣어도 결과가 같다 — 안전한 쪽(생략)을 택한다.
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}APP_ENV=prod"
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}NEXT_PUBLIC_APP_URL=${APP_URL}"
+    # story #2142(2026-07-23) — CORS_ORIGINS는 처음엔 콤마 분해 함정 때문에 생략했으나(옛
+    # `IFS=',' read -ra` 소비부가 이 값 자체의 콤마에서 쪼개짐), 그 소비부 자체를 _PLAIN_SEP
+    # (0x1F) 기반으로 고친 뒤(위 참조)에는 값에 콤마가 있어도 안전하다 — 이제 넣는다.
+    # config.py의 cors_origins 기본값과 문자열까지 완전히 동일(2026-07-23 확認)하므로 이
+    # 값 자체는 무회귀이며, 명시로 durable화하는 것뿐이다.
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}CORS_ORIGINS=http://localhost:3000,http://localhost:3108,https://app.sprintable.ai"
 fi
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},MEMBER_SSOT_RESOLVER_SHADOW=true"
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},MEMBER_SSOT_APIKEY_CUT=true"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}MEMBER_SSOT_RESOLVER_SHADOW=true"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}MEMBER_SSOT_APIKEY_CUT=true"
 # ⛔story #2142(2026-07-23, 오르테가 DRY_RUN 검수 3번째 적발 — 같은 뿌리: dev 라이브에서
 # 관측한 사실을 env 분기 없이 prod에 적용) — L2_TRIGGER_*/GATE_CONFIG_ENFORCE_*/
 # DECISION_GATE_LINE_*는 backend-prod에 키 자체가 없다(그 기능이 prod에서 한 번도 켜진 적
@@ -207,42 +215,42 @@ PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},MEMBER_SSOT_APIKEY_CUT=true"
 # lifespan 워커가 그대로 뜬다 — "SSE 전용이라 안 탈 것"이라는 추론 대신 backend-prod를
 # 그대로 미러링한다(오르테가 판정). prod 분기에서 이 3그룹은 아예 붙이지 않는다.
 if [ "${L2_TRIGGER_ENABLED_LINE}" = "true" ]; then
-    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},L2_TRIGGER_ENABLED=true"
-    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},L2_TRIGGER_ADVISORY_LOCK=true"
-    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},L2_TRIGGER_ORG_ALLOWLIST=54bac162-5c0d-49fa-8e49-85977063a091"
-    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},L2_TRIGGER_MAX_WAKES_PER_ORG_PER_HOUR=5"
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}L2_TRIGGER_ENABLED=true"
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}L2_TRIGGER_ADVISORY_LOCK=true"
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}L2_TRIGGER_ORG_ALLOWLIST=54bac162-5c0d-49fa-8e49-85977063a091"
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}L2_TRIGGER_MAX_WAKES_PER_ORG_PER_HOUR=5"
 fi
 # H1_MERGE_GATE는 backend-prod에도 실재(ENABLED/ADVISORY=true/true, dev와 동일) — 허용목록만
 # env별로 다르다(H1_MERGE_GATE_ORG_ALLOWLIST_VALUE, case 분기에서 라이브 실측값으로 설정).
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},H1_MERGE_GATE_ENABLED=true"
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},H1_MERGE_GATE_ORG_ALLOWLIST=${H1_MERGE_GATE_ORG_ALLOWLIST_VALUE}"
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},H1_MERGE_GATE_ADVISORY=true"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}H1_MERGE_GATE_ENABLED=true"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}H1_MERGE_GATE_ORG_ALLOWLIST=${H1_MERGE_GATE_ORG_ALLOWLIST_VALUE}"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}H1_MERGE_GATE_ADVISORY=true"
 # ⛔story #2142(2026-07-23, 오르테가 전수 3방향 diff 적발, 4번째 묶음) — 같은 뿌리(dev
 # 라이브 리터럴이 env 분기 밖에 남음). BUILD_APP_METADATA_DEFALLBACK은 backend-prod에
 # 키 자체가 없다(describe 대조 확認) — dev 전용으로 되돌림.
 if [ "${ENV}" = "dev" ]; then
-    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},BUILD_APP_METADATA_DEFALLBACK=true"
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}BUILD_APP_METADATA_DEFALLBACK=true"
 fi
 if [ "${GATE_CONFIG_ENFORCE_ENABLED_LINE}" = "true" ]; then
-    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},GATE_CONFIG_ENFORCE_ENABLED=true"
-    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},GATE_CONFIG_ENFORCE_ORG_ALLOWLIST=03970fbf-2db6-434b-a7b1-cb74f9547059"
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}GATE_CONFIG_ENFORCE_ENABLED=true"
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}GATE_CONFIG_ENFORCE_ORG_ALLOWLIST=03970fbf-2db6-434b-a7b1-cb74f9547059"
 fi
 if [ "${DECISION_GATE_LINE_ENABLED_LINE}" = "true" ]; then
-    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},DECISION_GATE_LINE_ENABLED=true"
-    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},DECISION_GATE_LINE_ORG_ALLOWLIST=54bac162-5c0d-49fa-8e49-85977063a091"
-    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},DECISION_GATE_LINE_MODE=shadow"
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}DECISION_GATE_LINE_ENABLED=true"
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}DECISION_GATE_LINE_ORG_ALLOWLIST=54bac162-5c0d-49fa-8e49-85977063a091"
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}DECISION_GATE_LINE_MODE=shadow"
 fi
 # ⛔story #2142(2026-07-23, 오르테가 DRY_RUN 검수 적발) 정정 — 이 세 값이 env 분기 밖의
 # 리터럴(dev App 값)이라 prod 플랜에도 그대로 실려, prod 시크릿(github-app-*-prod)과 dev App의
 # ID/CLIENT_ID가 섞이는 조합이 될 뻔했다. ${GITHUB_APP_ID}/${GITHUB_APP_CLIENT_ID}/
 # ${GITHUB_APP_SLUG}(case 분기, 위 참조 — dev/prod 각각 라이브 실측값)로 정정.
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},GITHUB_APP_ID=${GITHUB_APP_ID}"
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},GITHUB_APP_CLIENT_ID=${GITHUB_APP_CLIENT_ID}"
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},GITHUB_APP_SLUG=${GITHUB_APP_SLUG}"
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},FASTAPI_URL=${FASTAPI_URL}"
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},STORAGE_PROVIDER=gcs"
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},DB_POOL_SIZE=3"
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},DB_MAX_OVERFLOW=1"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}GITHUB_APP_ID=${GITHUB_APP_ID}"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}GITHUB_APP_CLIENT_ID=${GITHUB_APP_CLIENT_ID}"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}GITHUB_APP_SLUG=${GITHUB_APP_SLUG}"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}FASTAPI_URL=${FASTAPI_URL}"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}STORAGE_PROVIDER=gcs"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}DB_POOL_SIZE=3"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}DB_MAX_OVERFLOW=1"
 # story #2115(S6): 앱 per-instance SSE 소프트캡(events.py MAX_SSE_CONNECTIONS·기본 100)을 상향.
 # GCE는 Cloud Run concurrency 제약이 없어 실질 상한은 노드 fd/mem이고, 이 캡은 그 전에 걸리는
 # 앱 자체 소프트캡이라 env로 무료 확장 가능. 500으로 올려 ceiling이 실제 확장됨을 실증(3노드=1500 이론).
@@ -253,40 +261,40 @@ PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},DB_MAX_OVERFLOW=1"
 # fd/mem이 진짜 상한이 되므로 캡을 올려도 안전 — backend-prod가 이 값을 안 올린 이유는
 # backend-prod는 SSE 전용이 아니라 REST 트래픽과 캡을 공유하기 때문(다른 성격의 노드).
 # dev/prod 둘 다 이 GCE 스택에서는 500 그대로 유지 — env 분기 대상 아님.
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},MAX_SSE_CONNECTIONS=500"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}MAX_SSE_CONNECTIONS=500"
 # #2120(E-ARCH 근본): chat_presence working → Redis 공유 롤아웃 게이트. 실측용으로 env 로 flip
 # (기본 false=현 in-memory 무회귀). OFF 실측=false, ON 실측=true. 라이브 실측 후 durable 값 확定.
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},PRESENCE_REDIS_ENABLED=${PRESENCE_REDIS_ENABLED:-false}"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}PRESENCE_REDIS_ENABLED=${PRESENCE_REDIS_ENABLED:-false}"
 # #2120 AC2: online liveness Redis 롤아웃 게이트(§2 working 과 독립 flag). env 로 flip(기본 false).
 # AC2 실측 배포=true. Redis-down fail-open 실측 땐 REDIS_URL 오배선(공유 Memorystore 무접촉)로 시뮬.
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},PRESENCE_ONLINE_REDIS_ENABLED=${PRESENCE_ONLINE_REDIS_ENABLED:-false}"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}PRESENCE_ONLINE_REDIS_ENABLED=${PRESENCE_ONLINE_REDIS_ENABLED:-false}"
 # #2121(E-ARCH 근본): SSE 연결 카운터(429/503) → Redis ZSET lease 롤아웃 게이트(presence 와 독립 flag).
 # env 로 flip(기본 false=in-process 무회귀). AC5 실측 배포=true(GCE 3노드 필수·멀티노드 합산 대조).
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},SSE_LEASE_REDIS_ENABLED=${SSE_LEASE_REDIS_ENABLED:-false}"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}SSE_LEASE_REDIS_ENABLED=${SSE_LEASE_REDIS_ENABLED:-false}"
 # #2122(E-ARCH 근본): fanout(wake_agent) → Redis 백플레인 롤아웃 게이트(presence/lease 와 독립 flag).
 # env 로 flip(기본 false=pg_notify 직행 무회귀). #2122 라이브 재측정 배포=true(GCE PG_LISTEN=false라 wake
 # 가 Redis 백플레인 타야 타노드 도달 — 미설정 시 cross-node wake 0/2 재현). REALTIME_BACKPLANE 는 별개(cutover).
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},FANOUT_WAKE_REDIS_ENABLED=${FANOUT_WAKE_REDIS_ENABLED:-false}"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}FANOUT_WAKE_REDIS_ENABLED=${FANOUT_WAKE_REDIS_ENABLED:-false}"
 # ⛔story #2142(2026-07-23, 오르테가 전수 3방향 diff 적발, 4번째 묶음) — 같은 뿌리.
 # LLM_GEMINI_MODEL/_LOCATION·FIREBASE_OAUTH_HANDOFF_ENABLED 전부 backend-prod에 키
 # 자체가 없다(describe 대조 확認) — FIREBASE_OAUTH_HANDOFF_ENABLED=1은 특히 firebase
 # 내부 경로를 **켜는** 값이라 더 신중해야 하는 자리였다. dev 전용으로 되돌림.
 if [ "${ENV}" = "dev" ]; then
-    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},LLM_GEMINI_MODEL=gemini-3.1-pro-preview"
-    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},LLM_GEMINI_LOCATION=global"
-    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},FIREBASE_OAUTH_HANDOFF_ENABLED=1"
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}LLM_GEMINI_MODEL=gemini-3.1-pro-preview"
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}LLM_GEMINI_LOCATION=global"
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}FIREBASE_OAUTH_HANDOFF_ENABLED=1"
 fi
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},MCP_PUBLIC_URL=${MCP_PUBLIC_URL}"
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},LICENSE_CONSENT=agreed"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}MCP_PUBLIC_URL=${MCP_PUBLIC_URL}"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}LICENSE_CONSENT=agreed"
 # realtime 고유값(backend/api와 다름 — cloudbuild.yaml deploy-realtime 스텝과 동일 컨벤션):
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},PG_LISTEN_ENABLED=false"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}PG_LISTEN_ENABLED=false"
 # story #2135(2026-07-23, #2123 실측 적발): 키 이름이 여태 `REDIS_CONSUME_ENABLED`였다 —
 # Settings 필드(`event_broker_redis_consume_enabled`)와 안 맞아 pydantic-settings가 조용히
 # 무시했다(GCE는 필드 기본값이 우연히 True라 결과만 의도와 같았음). 실제 필드가 요구하는
 # 키로 정정.
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},EVENT_BROKER_REDIS_CONSUME_ENABLED=true"
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=true"
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},EVENT_BROKER_REDIS_DISPATCH_ENABLED=true"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}EVENT_BROKER_REDIS_CONSUME_ENABLED=true"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=true"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}EVENT_BROKER_REDIS_DISPATCH_ENABLED=true"
 # ⛔story #2142(2026-07-23, 오르테가 리뷰 적발 — 실행 前 발견) 정정: REDIS_URL이 여태 env
 # 분기 없이 PLAIN_ENV_SPEC(평문·인스턴스 메타데이터에 그대로 박힘)에 얹혀 있었다. 두 가지가
 # 동시에 걸리는 자리였다 — ①prod Redis는 AUTH 활성이라 URL이 비밀번호를 품는데, 그게 평문
@@ -301,7 +309,7 @@ else
     # dev: Memorystore가 AUTH 없는 plain 인스턴스 — VPC 내부 IP(10.164.120.243)라 평문이어도
     # 시크릿이 아니다. env로 override 가능하게 기존 그대로 유지(재실측 없이 하드코딩 안 함).
     REDIS_URL_VALUE="${REDIS_URL:-redis://10.164.120.243:6379}"
-    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC},REDIS_URL=${REDIS_URL_VALUE}"
+    PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}REDIS_URL=${REDIS_URL_VALUE}"
     SECRET_PAIRS_REDIS=""
 fi
 # DB_POOL_SIZE/DB_MAX_OVERFLOW는 위에서 이미 3/1로 명시(Cloud Run realtime과 동일).
@@ -417,6 +425,20 @@ trap 'rm -f "${STARTUP_SCRIPT_FILE}"' EXIT
     echo "_AR_TOKEN=\$(docker run --rm gcr.io/google.com/cloudsdktool/cloud-sdk:slim gcloud auth print-access-token)"
     echo "echo \"\${_AR_TOKEN}\" | docker login -u oauth2accesstoken --password-stdin https://${_AR_HOST}"
     echo ''
+    # ⛔story #2142(2026-07-23, 오르테가 지적 — 자기 지시가 만든 결함 자인) — 이전엔 여기서
+    # PLAIN_ENV_SPEC을 `IFS=',' read -ra`로 무조건 콤마 분해해 개별 `-e KEY=VALUE \` 인자로
+    # 만들었다. 값 자체에 콤마가 있으면(H1_MERGE_GATE_ORG_ALLOWLIST의 2-org 리스트 등) 그
+    # 값이 조각나 VM에는 절반만 실리는 조용한 절단이 났었다 — 위 _PLAIN_SEP(0x1F join)로
+    # 그 클래스 자체는 이미 막았지만, 여기서도 `docker --env-file`로 전환해 ⭐구분자 싸움을
+    # 아예 끝낸다(오르테가 권고) — 부수 이득으로 PLAIN 값들이 더 이상 프로세스 인자
+    # (`docker run -e ...`, `ps` 등으로 노출 가능)에 안 실리고 파일로만 전달된다.
+    echo 'cat > /tmp/realtime-gateway-plain.env <<'"'"'PLAIN_ENV_EOF'"'"''
+    IFS="${_PLAIN_SEP}" read -ra _plain_pairs <<< "${PLAIN_ENV_SPEC}"
+    for kv in "${_plain_pairs[@]}"; do
+        printf '%s\n' "${kv}"
+    done
+    echo 'PLAIN_ENV_EOF'
+    echo ''
     echo 'docker rm -f realtime-gateway 2>/dev/null || true'
     echo 'docker run -d --name realtime-gateway --restart=always \'
     echo '  -p 8000:8000 \'
@@ -425,11 +447,7 @@ trap 'rm -f "${STARTUP_SCRIPT_FILE}"' EXIT
         env_name="${pair##*:}"
         echo "  -e ${env_name}=\"\${${env_name}}\" \\"
     done
-    # PLAIN_ENV_SPEC은 콤마 구분 KEY=VAL 목록 — docker run -e 인자로 한 줄씩 분해.
-    IFS=',' read -ra _plain_pairs <<< "${PLAIN_ENV_SPEC}"
-    for kv in "${_plain_pairs[@]}"; do
-        echo "  -e ${kv} \\"
-    done
+    echo '  --env-file=/tmp/realtime-gateway-plain.env \'
     echo "  ${IMAGE} \\"
     echo '  uvicorn app.main:app --host 0.0.0.0 --port 8000 --timeout-graceful-shutdown 30'
     echo ''
@@ -457,6 +475,14 @@ log "Machine type: ${MACHINE_TYPE}, target size: ${TARGET_SIZE}"
 log "Cloud SQL: ${SQL_INSTANCE_CONN}"
 
 if [ "${DRY_RUN}" = "1" ]; then
+    # ⛔story #2142(2026-07-23, 오르테가 지적) — 이전 DRY_RUN 출력은 PLAIN_ENV_SPEC "요약
+    # 문자열"만 보여줬다. 그 요약은 join 구분자가 무엇이든 항상 올바르게 보였을 것이라
+    # (부분 문자열 검사만 하니) H1_MERGE_GATE_ORG_ALLOWLIST의 콤마-절단 결함을 회귀 테스트가
+    # 전혀 못 잡았던 근본 원인이다 — 검증 대상(요약 문자열)과 실제 배포되는 것(생성된
+    # startup-script의 env-file)이 달랐다. 실제 생성된 env-file 내용을 그대로 노출해
+    # 테스트가 "진짜 배포될 것"을 검증하게 한다(base64 — 줄바꿈을 한 줄 KEY=VALUE 출력
+    # 포맷 안에 안전하게 실어야 해서).
+    _GENERATED_PLAIN_ENV_FILE_B64="$(sed -n '/^cat > \/tmp\/realtime-gateway-plain\.env/,/^PLAIN_ENV_EOF$/p' "${STARTUP_SCRIPT_FILE}" | sed '1d;$d' | base64 | tr -d '\n')"
     cat <<EOF
 ENV=${ENV}
 MIG_NAME=${MIG_NAME}
@@ -469,6 +495,7 @@ SQL_INSTANCE_CONN=${SQL_INSTANCE_CONN}
 RUNTIME_SA=${RUNTIME_SA}
 PLAIN_ENV_SPEC=${PLAIN_ENV_SPEC}
 SECRET_PAIRS=${SECRET_PAIRS}
+GENERATED_PLAIN_ENV_FILE_B64=${_GENERATED_PLAIN_ENV_FILE_B64}
 EOF
     exit 0
 fi

--- a/backend/tests/test_deploy_realtime_gce_env.py
+++ b/backend/tests/test_deploy_realtime_gce_env.py
@@ -217,6 +217,66 @@ def test_deploy_gce_prod_redis_url_env_override_ignored_for_secret_routing():
     assert "leaked" not in cfg["PLAIN_ENV_SPEC"]
 
 
+def test_deploy_gce_prod_app_env_and_next_public_app_url_match_live_binding():
+    """story #2142(오르테가 전수 3방향 diff 적발, 2026-07-23) — GCE 플랜과 라이브
+    backend-prod env를 3방향 diff("GCE에만 있음"/"값 다름"/"prod에만 있음")했을 때
+    세 번째 축("prod에 있는데 GCE엔 없음")에서 나온 것. APP_ENV/NEXT_PUBLIC_APP_URL은
+    backend-prod엔 실재하지만 이 스크립트 작성 당시 dev에도 없어 분기 자체가 없었다 —
+    이전 3건(dev값이 분기 밖에 남음)과 반대 방향(prod가 나중에 받은 값을 못 따라감).
+    NEXT_PUBLIC_APP_URL은 auth.py/docs.py/discord_webhook.py 등 실제 backend 런타임
+    코드 경로가 읽는다(repo grep 확認) — 장식이 아니다."""
+    prod = _resolve(_DEPLOY_GCE, "prod")
+    assert "APP_ENV=prod" in prod["PLAIN_ENV_SPEC"]
+    assert "NEXT_PUBLIC_APP_URL=https://app.sprintable.ai" in prod["PLAIN_ENV_SPEC"]
+
+
+def test_deploy_gce_dev_has_no_app_env_or_next_public_app_url():
+    """dev는 지금도 이 두 값이 라이브에 없다(describe 대조 확認) — 무회귀."""
+    dev = _resolve(_DEPLOY_GCE, "dev")
+    assert "APP_ENV=" not in dev["PLAIN_ENV_SPEC"]
+    assert "NEXT_PUBLIC_APP_URL=" not in dev["PLAIN_ENV_SPEC"]
+
+
+def test_deploy_gce_prod_excludes_cors_origins():
+    """CORS_ORIGINS는 의도적으로 prod 플랜에서도 생략한다 — PLAIN_ENV_SPEC은 스크립트
+    자신이 `IFS=','`로 콤마 분해해 docker run -e 인자로 바꾸는데, CORS_ORIGINS 값 자체가
+    콤마 구분 origin 목록이라 이 메커니즘에 실으면 깨진다. config.py 기본값이 prod
+    라이브 값과 문자열까지 동일해 생략해도 결과가 같다."""
+    prod = _resolve(_DEPLOY_GCE, "prod")
+    assert "CORS_ORIGINS" not in prod["PLAIN_ENV_SPEC"]
+
+
+def test_deploy_gce_prod_dev_only_flags_absent():
+    """story #2142(오르테가 전수 3방향 diff 적발, 2026-07-23, 4번째 묶음) — 같은 뿌리
+    (dev 라이브 리터럴이 env 분기 밖에 남음). BUILD_APP_METADATA_DEFALLBACK·
+    LLM_GEMINI_MODEL/_LOCATION·FIREBASE_OAUTH_HANDOFF_ENABLED 전부 backend-prod에
+    키 자체가 없다(describe 대조 확認) — FIREBASE_OAUTH_HANDOFF_ENABLED=1은 firebase
+    내부 경로를 켜는 값이라 더 위험한 자리였다."""
+    prod = _resolve(_DEPLOY_GCE, "prod")
+    for key in ("BUILD_APP_METADATA_DEFALLBACK", "LLM_GEMINI_MODEL", "LLM_GEMINI_LOCATION",
+                "FIREBASE_OAUTH_HANDOFF_ENABLED"):
+        assert key not in prod["PLAIN_ENV_SPEC"], f"{key}가 prod 플랜에 실리면 안 됨"
+
+
+def test_deploy_gce_dev_only_flags_unchanged():
+    """dev는 이 4개 값 전부 현행 유지 — 무회귀(순서는 바뀔 수 있으나 값 자체는 그대로)."""
+    dev = _resolve(_DEPLOY_GCE, "dev")
+    assert "BUILD_APP_METADATA_DEFALLBACK=true" in dev["PLAIN_ENV_SPEC"]
+    assert "LLM_GEMINI_MODEL=gemini-3.1-pro-preview" in dev["PLAIN_ENV_SPEC"]
+    assert "LLM_GEMINI_LOCATION=global" in dev["PLAIN_ENV_SPEC"]
+    assert "FIREBASE_OAUTH_HANDOFF_ENABLED=1" in dev["PLAIN_ENV_SPEC"]
+
+
+def test_deploy_gce_max_sse_connections_intentional_both_envs():
+    """MAX_SSE_CONNECTIONS=500는 dev/prod 둘 다 동일 — dev값이 새어든 것이 아니라 이
+    SSE 전용 GCE 스택 자체의 설계 의도(backend-prod는 REST와 캡을 공유하는 다른 성격의
+    노드라 코드 기본값 100을 그대로 씀 — 그건 정상이고, 이 GCE 스택이 다른 것)."""
+    dev = _resolve(_DEPLOY_GCE, "dev")
+    prod = _resolve(_DEPLOY_GCE, "prod")
+    assert "MAX_SSE_CONNECTIONS=500" in dev["PLAIN_ENV_SPEC"]
+    assert "MAX_SSE_CONNECTIONS=500" in prod["PLAIN_ENV_SPEC"]
+
+
 def test_deploy_gce_invalid_env_rejected():
     proc = subprocess.run(
         ["bash", _DEPLOY_GCE, "staging"],

--- a/backend/tests/test_deploy_realtime_gce_env.py
+++ b/backend/tests/test_deploy_realtime_gce_env.py
@@ -2,9 +2,19 @@
 
 test_deploy_env.py(deploy_backend.sh 등)와 동일 패턴 — DRY_RUN=1 resolved config를
 파싱해 dev/prod 경로를 검증한다.
+
+⛔story #2142 배포 함정 핫픽스(2026-07-23, 오르테가 자인) — 이 파일의 기존 테스트는 전부
+`PLAIN_ENV_SPEC` "요약 문자열"의 부분 문자열만 검사했다. 그 요약은 실제 배포되는 것과 다른
+층이라(요약은 파이썬 쪽에서 그냥 이어붙인 문자열, 실제 배포는 스크립트 자신의 셸 소비
+로직을 거친 결과), `H1_MERGE_GATE_ORG_ALLOWLIST`의 2-org 콤마 값이 옛 `IFS=',' read -ra`
+소비부에서 조각나 VM에는 절반만 실리는 결함을 전혀 못 잡았다 — 요약 문자열엔 원본 그대로
+있었으니 부분 문자열 검사는 항상 통과했을 것이다. `test_deploy_gce_*_no_comma_value_truncation`
+이 그 갭을 닫는다 — 요약이 아니라 스크립트가 실제로 생성하는 env-file 내용(`GENERATED_
+PLAIN_ENV_FILE_B64`)을 디코드해 검증한다.
 """
 from __future__ import annotations
 
+import base64
 import os
 import subprocess
 
@@ -28,6 +38,14 @@ def _resolve(script: str, env: str, extra: dict | None = None) -> dict[str, str]
             k, _, v = line.partition("=")
             cfg[k.strip()] = v.strip()
     return cfg
+
+
+def _resolve_generated_env_lines(env: str) -> list[str]:
+    """실제 VM에 실릴 env-file 내용을 그대로 디코드해 줄 목록으로 반환 — `_resolve()`의
+    요약 문자열이 아니라 스크립트가 진짜로 생성하는 산출물을 검증 대상으로 삼는다."""
+    cfg = _resolve(_DEPLOY_GCE, env)
+    b64 = cfg["GENERATED_PLAIN_ENV_FILE_B64"]
+    return base64.b64decode(b64).decode().splitlines()
 
 
 # ── deploy_realtime_gce.sh ───────────────────────────────────────────────────
@@ -237,13 +255,58 @@ def test_deploy_gce_dev_has_no_app_env_or_next_public_app_url():
     assert "NEXT_PUBLIC_APP_URL=" not in dev["PLAIN_ENV_SPEC"]
 
 
-def test_deploy_gce_prod_excludes_cors_origins():
-    """CORS_ORIGINS는 의도적으로 prod 플랜에서도 생략한다 — PLAIN_ENV_SPEC은 스크립트
-    자신이 `IFS=','`로 콤마 분해해 docker run -e 인자로 바꾸는데, CORS_ORIGINS 값 자체가
-    콤마 구분 origin 목록이라 이 메커니즘에 실으면 깨진다. config.py 기본값이 prod
-    라이브 값과 문자열까지 동일해 생략해도 결과가 같다."""
-    prod = _resolve(_DEPLOY_GCE, "prod")
-    assert "CORS_ORIGINS" not in prod["PLAIN_ENV_SPEC"]
+def test_deploy_gce_prod_includes_cors_origins_intact():
+    """story #2142 핫픽스(2026-07-23) — CORS_ORIGINS는 최초엔 콤마 분해 함정 때문에
+    생략했으나, 그 소비부 자체를 _PLAIN_SEP(0x1F join) 기반 + `docker --env-file`로
+    고친 뒤에는 값에 콤마가 있어도 안전하다. 요약 문자열이 아니라 **실제 생성되는
+    env-file**에서 이 값이 하나의 온전한 줄로 나가는지 확認한다(부분 문자열 검사는
+    콤마 절단 여부를 구분 못 함 — 원본이 3조각으로 쪼개져도 이어붙이면 부분 문자열
+    검사는 통과해버린다)."""
+    lines = _resolve_generated_env_lines("prod")
+    assert (
+        "CORS_ORIGINS=http://localhost:3000,http://localhost:3108,https://app.sprintable.ai"
+        in lines
+    ), "CORS_ORIGINS가 온전한 한 줄로 안 나갔음(콤마에서 쪼개졌을 가능성)"
+    # 콤마 절단이 났다면 이런 조각난 줄들이 별도로 나타난다 — 존재하면 안 됨.
+    assert "http://localhost:3108" not in lines
+    assert "https://app.sprintable.ai" not in lines
+
+
+def test_deploy_gce_prod_h1_merge_gate_allowlist_survives_env_file_generation():
+    """story #2142 배포 함정 핫픽스(2026-07-23, 오르테가 자인) — 이 저장소가 실제로
+    겪은 사고의 재발 방지 테스트. H1_MERGE_GATE_ORG_ALLOWLIST의 2-org 콤마 값이 옛
+    `IFS=',' read -ra` 소비부에서 조각나 VM에는 `54bac162-...`(org 하나)만 실리고
+    `588186bf-...`는 `=` 없는 쓰레기 인자가 되는 결함이 실제로 있었다(#2431 머지 後
+    발견). PLAIN_ENV_SPEC 요약 문자열 검사(`test_deploy_gce_prod_h1_merge_gate_
+    matches_live_two_org_allowlist`)는 이 결함을 못 잡았다 — 요약은 원본을 그대로
+    이어붙인 것이라 부분 문자열은 항상 있었기 때문. 이 테스트는 **실제 생성된
+    env-file**을 검증해 그 갭을 닫는다."""
+    lines = _resolve_generated_env_lines("prod")
+    assert (
+        "H1_MERGE_GATE_ORG_ALLOWLIST=54bac162-5c0d-49fa-8e49-85977063a091,"
+        "588186bf-1558-48a3-b3a0-fe3759a925fc"
+    ) in lines, "2-org 허용목록이 온전한 한 줄로 안 나갔음(콤마 절단 재발)"
+    # 절단됐다면 두 번째 org가 "=" 없는 독립 줄(쓰레기 -e 인자)로 나타난다.
+    assert "588186bf-1558-48a3-b3a0-fe3759a925fc" not in lines
+    # 절단됐다면 첫 org만 있는 반쪽짜리 줄도 별도로 존재하게 된다.
+    assert "H1_MERGE_GATE_ORG_ALLOWLIST=54bac162-5c0d-49fa-8e49-85977063a091" not in lines
+
+
+def test_deploy_gce_dev_env_file_generation_no_truncation():
+    """dev도 같은 소비부를 타므로 무회귀 확認 — dev는 콤마 든 값이 없지만(현재), 생성된
+    env-file의 줄 수가 PLAIN_ENV_SPEC의 엔트리 수와 정확히 일치해야 한다(하나라도
+    쪼개지거나 합쳐지면 줄 수가 달라짐)."""
+    lines = _resolve_generated_env_lines("dev")
+    cfg = _resolve(_DEPLOY_GCE, "dev")
+    expected_count = cfg["PLAIN_ENV_SPEC"].count("\x1f") + 1 if "\x1f" in cfg["PLAIN_ENV_SPEC"] else None
+    # DRY_RUN 요약 출력 자체가 \x1f를 그대로 담고 있으므로(줄바꿈이 아니라 필드 값 문자로
+    # 실림) 그 문자로 직접 개수를 셀 수 있다 — 있으면 그걸로, 없으면(구분자 표시가 안
+    # 보이는 환경) 최소 27개 이상만 느슨히 확認.
+    if expected_count is not None:
+        assert len(lines) == expected_count
+    else:
+        assert len(lines) >= 27
+    assert all("=" in line for line in lines), "쓰레기(= 없는) 줄이 섞여 있음 — 절단 의심"
 
 
 def test_deploy_gce_prod_dev_only_flags_absent():


### PR DESCRIPTION
## Summary — two parts, the second is critical

### Part 1: round-4 mirroring (original scope of this PR)
Fourth round found by a full 3-way diff of the GCE prod plan against live backend-prod env (keys only in the plan / differing values / keys only in the live service).

- **`APP_ENV=prod`** and **`NEXT_PUBLIC_APP_URL=<APP_URL>`** added to prod (live on backend-prod, was in neither dev nor this script; `NEXT_PUBLIC_APP_URL` has real backend runtime consumers — `auth.py`, `docs.py`, `discord_webhook.py`, `org_invite_email.py`, confirmed via grep).
- **`BUILD_APP_METADATA_DEFALLBACK`, `LLM_GEMINI_MODEL`, `LLM_GEMINI_LOCATION`, `FIREBASE_OAUTH_HANDOFF_ENABLED`** dropped to dev-only (absent from backend-prod's live env, confirmed via `describe`).
- `MAX_SSE_CONNECTIONS=500` comment strengthened — confirmed intentional GCE-stack-wide (not a leaked dev value).
- Follow-up filed separately: story #2151, `config.py::is_really_local`'s `K_SERVICE`-based check is blind to GCE (always returns `True` there) — not currently exploitable (the fail-open paths it guards also require a missing secret, all bound here) but a latent gap now that GCE is real infra.

### Part 2: comma-value truncation (critical, found reviewing why CORS_ORIGINS was excluded)
While reviewing whether to add `CORS_ORIGINS` for part 1, found that **the H1_MERGE_GATE_ORG_ALLOWLIST two-org value added in #2431 (already merged) was being silently corrupted in the real deployment artifact.**

The consumption site built `docker run -e` arguments via `IFS=',' read -ra` on `PLAIN_ENV_SPEC` — a blind split on every comma. Any value containing a comma fragments: the VM would have received `H1_MERGE_GATE_ORG_ALLOWLIST=54bac162-...` (one org, second silently dropped) plus a garbage `=`-less argument for the second org. This repo had already hit and fixed the identical bug class in `cloudbuild.yaml` (`CORS_ORIGINS`, custom `^@^` delimiter) — this script independently re-walked into it.

**Root fix:** switched `PLAIN_ENV_SPEC`'s join character from a literal comma to ASCII Unit Separator (`0x1F`, never appears in any config value) — closes the entire delimiter-collision class, not just this instance. Mechanically applied across all 40 accumulation sites via a scripted find-replace. Also switched the docker invocation from individual `-e` args to `docker --env-file` (ends the delimiter question permanently; side benefit — plain values no longer appear in `docker run`'s process arguments).

With the encoding fixed, `CORS_ORIGINS` (also comma-containing) is now safely included in the prod plan.

**Testing gap also closed:** every existing test in this file checked substrings of the `PLAIN_ENV_SPEC` *summary string* — pure Python-side string concatenation, never exercised through the actual shell consumption logic. That's why 28 passing tests never caught an already-merged, real bug. Added `GENERATED_PLAIN_ENV_FILE_B64` to `DRY_RUN` output (base64 of the actual generated env-file content — the startup-script always builds this regardless of `DRY_RUN`) so tests verify the real artifact, not a parallel summary.

## Test plan
- [x] `bash -n` syntax check passes
- [x] `DRY_RUN=1 ... dev` / `... prod` — decoded the real generated env-file content directly, confirmed all values (including the 2-org allowlist and `CORS_ORIGINS`) land as single intact lines
- [x] **Negative control**: reverted the consumption site to the old comma-split logic in a scratch copy, confirmed it reproduces the exact truncation described above, confirmed the new tests fail against it and the *old* summary-string assertion still passes against it (proving the gap this closes)
- [x] 30 tests total (2 new, 1 rewritten from the now-obsolete CORS_ORIGINS-exclusion test) — `uv run pytest backend/tests/test_deploy_realtime_gce_env.py`, 30/30 pass on the fixed version

🤖 Generated with [Claude Code](https://claude.com/claude-code)