### PR TITLE
[SID:2148] 삼항조건부 인라인 에러 라이브리전 PR-A — 17파일 20곳

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
@@ -343,7 +343,7 @@ function GoalCreateForm({ projectId, orgId, onCreated, onCancel }: GoalCreateFor
         onChange={setDeclarations}
       />
 
-      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+      {error ? <p className="text-xs text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{error}</p> : null}
 
       <div className="flex justify-end gap-2 pt-2">
         <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
@@ -471,7 +471,7 @@ function GoalEditForm({ epic, onSaved, onCancel }: GoalEditFormProps) {
         </div>
       </div>
 
-      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+      {error ? <p className="text-xs text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{error}</p> : null}
 
       <div className="flex justify-end gap-2 pt-2">
         <Button type="button" variant="ghost" size="sm" onClick={onCancel}>

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/steer-dispatch-modal.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/steer-dispatch-modal.tsx
@@ -155,7 +155,7 @@ export function SteerDispatchModal({ projectId, items, onClose, onDispatched }: 
           )}
         </div>
 
-        {error ? <p className="text-xs text-destructive">{error}</p> : null}
+        {error ? <p className="text-xs text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{error}</p> : null}
 
         <DialogFooter>
           <Button variant="ghost" size="sm" onClick={onClose} disabled={sending}>{t('cancel')}</Button>

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx
@@ -274,7 +274,7 @@ function CreateDialog({ projectId, onCreated, onClose }: CreateDialogProps) {
             />
           ) : null}
 
-          {error ? <p className="text-xs text-destructive">{error}</p> : null}
+          {error ? <p className="text-xs text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{error}</p> : null}
           <div className="flex items-center justify-between gap-2 pt-1">
             <span className="text-[11px] text-muted-foreground">
               {declaredCount > 0 ? (
@@ -322,7 +322,7 @@ function DeleteConfirmDialog({ sprintTitle, deleting, error, onConfirm, onClose 
           </div>
         </div>
         <p className="mb-4 text-sm text-muted-foreground">{t('deleteConfirmBody')}</p>
-        {error ? <p className="mb-3 text-xs text-destructive">{error}</p> : null}
+        {error ? <p className="mb-3 text-xs text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{error}</p> : null}
         <div className="flex justify-end gap-2">
           <Button type="button" variant="ghost" size="sm" onClick={onClose} disabled={deleting}>{t('cancel')}</Button>
           <Button type="button" variant="destructive" size="sm" onClick={onConfirm} disabled={deleting}>
@@ -767,7 +767,7 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
           {closing ? '...' : t('close')}
         </Button>
       ) : null}
-      {actionError ? <p className="mb-3 text-xs text-destructive">{actionError}</p> : null}
+      {actionError ? <p className="mb-3 text-xs text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{actionError}</p> : null}
 
       {/* E-SPRINT-LOOP FE(278314e9) §4④ — 활성화 게이트: planning + 생존 가설 0이면 질문 안내(마찰
           아님). 422 HYPOTHESIS_REQUIRED_FOR_ACTIVATION을 맞은 뒤에도 동일 배너로 graceful 흡수. */}

--- a/apps/web/src/app/internal-dogfood/page.tsx
+++ b/apps/web/src/app/internal-dogfood/page.tsx
@@ -52,7 +52,7 @@ export default async function InternalDogfoodPage({ searchParams }: PageProps) {
         {error ? (
           <SectionCard>
             <SectionCardBody>
-              <p className="text-sm text-rose-700">오류: {error}</p>
+              <p className="text-sm text-rose-700" role="alert" aria-live="assertive" aria-atomic="true">오류: {error}</p>
             </SectionCardBody>
           </SectionCard>
         ) : null}

--- a/apps/web/src/components/agents/access-matrix-tab.tsx
+++ b/apps/web/src/components/agents/access-matrix-tab.tsx
@@ -165,7 +165,7 @@ export function AccessMatrixTab() {
           </div>
         </SectionCardHeader>
         <SectionCardBody>
-          {message ? <p className="mb-3 text-xs text-destructive">{message.text}</p> : null}
+          {message ? <p className="mb-3 text-xs text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{message.text}</p> : null}
 
           {agents.length === 0 || projects.length === 0 ? (
             <div className="rounded-md border border-dashed border-border px-3 py-8 text-center">

--- a/apps/web/src/components/agents/agent-persona-composer.tsx
+++ b/apps/web/src/components/agents/agent-persona-composer.tsx
@@ -321,7 +321,12 @@ export function AgentPersonaComposer({
         </div>
 
         {errorMessage ? (
-          <div className="rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          <div
+            className="rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+            role="alert"
+            aria-live="assertive"
+            aria-atomic="true"
+          >
             {errorMessage}
           </div>
         ) : null}

--- a/apps/web/src/components/cage/gate-signature-approval.tsx
+++ b/apps/web/src/components/cage/gate-signature-approval.tsx
@@ -65,7 +65,12 @@ export function GateSignatureApproval({
       </div>
 
       {error ? (
-        <p className="rounded-lg border border-destructive/30 bg-destructive/8 px-3 py-2 text-xs text-destructive">
+        <p
+          className="rounded-lg border border-destructive/30 bg-destructive/8 px-3 py-2 text-xs text-destructive"
+          role="alert"
+          aria-live="assertive"
+          aria-atomic="true"
+        >
           {t('gateTransitionError', { reason: error })}
         </p>
       ) : null}

--- a/apps/web/src/components/canvas/export-dialog.tsx
+++ b/apps/web/src/components/canvas/export-dialog.tsx
@@ -97,7 +97,12 @@ export function ExportDialog({ open, onOpenChange, artifactId, versionNumber, ca
             ) : null}
           </div>
         ) : phase === 'error' ? (
-          <div className="space-y-1 rounded-md bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+          <div
+            className="space-y-1 rounded-md bg-muted/40 px-3 py-2 text-xs text-muted-foreground"
+            role="alert"
+            aria-live="assertive"
+            aria-atomic="true"
+          >
             <p>{t('exportFailedNote')}</p>
             {errorDetail ? (
               <p className="break-words font-mono text-[10px] leading-[13px] text-muted-foreground/70">{errorDetail}</p>

--- a/apps/web/src/components/canvas/pin-authoring-popover.tsx
+++ b/apps/web/src/components/canvas/pin-authoring-popover.tsx
@@ -69,7 +69,7 @@ export function PinAuthoringPopover({ open, onOpenChange, initialDescription, on
           rows={4}
           className="w-full resize-none rounded-md border border-border bg-background px-2 py-1.5 text-[12px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
         />
-        {error ? <p className="mt-1 text-[10px] text-destructive">{t('specPinSaveFailedNote')}</p> : null}
+        {error ? <p className="mt-1 text-[10px] text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{t('specPinSaveFailedNote')}</p> : null}
 
         <DialogFooter className="flex items-center justify-between gap-2 sm:justify-between">
           {onDelete ? (

--- a/apps/web/src/components/docs/extensions/code-block-copy.tsx
+++ b/apps/web/src/components/docs/extensions/code-block-copy.tsx
@@ -68,7 +68,12 @@ function MermaidBlockView({ node, editor, selected }: ReactNodeViewProps) {
             style={{ cursor: isEditable ? 'pointer' : 'default' }}
           >
             {error ? (
-              <div className="rounded-xl border border-destructive-border bg-destructive-tint p-3 text-xs text-destructive">
+              <div
+                className="rounded-xl border border-destructive-border bg-destructive-tint p-3 text-xs text-destructive"
+                role="alert"
+                aria-live="assertive"
+                aria-atomic="true"
+              >
                 {error}
               </div>
             ) : svg ? (

--- a/apps/web/src/components/docs/extensions/math-node.tsx
+++ b/apps/web/src/components/docs/extensions/math-node.tsx
@@ -63,7 +63,14 @@ function MathBlockView({ node, selected }: ReactNodeViewProps) {
         {!showEdit && (
           <div className="px-4 pb-4" contentEditable={false}>
             {error ? (
-              <div className="rounded-lg border border-destructive-border bg-destructive-tint p-3 text-xs text-destructive font-mono">{error}</div>
+              <div
+                className="rounded-lg border border-destructive-border bg-destructive-tint p-3 text-xs text-destructive font-mono"
+                role="alert"
+                aria-live="assertive"
+                aria-atomic="true"
+              >
+                {error}
+              </div>
             ) : html ? (
               <div
                 dangerouslySetInnerHTML={{ __html: html }}

--- a/apps/web/src/components/integrations/pr-link-section.tsx
+++ b/apps/web/src/components/integrations/pr-link-section.tsx
@@ -292,7 +292,12 @@ export function PrLinkSection({ storyId }: { storyId: string }) {
 
       <p className="text-[10px] text-muted-foreground/70">{t('riskHint')}</p>
       {error ? (
-        <p className="inline-flex items-center gap-1 text-[11px] text-destructive">
+        <p
+          className="inline-flex items-center gap-1 text-[11px] text-destructive"
+          role="alert"
+          aria-live="assertive"
+          aria-atomic="true"
+        >
           <AlertTriangle className="size-3 shrink-0" />
           {error}
         </p>

--- a/apps/web/src/components/loops/loop-create-dialog.tsx
+++ b/apps/web/src/components/loops/loop-create-dialog.tsx
@@ -504,7 +504,7 @@ export function LoopCreateDialog({
             />
           </div>
 
-          {error ? <p className="text-xs text-destructive">{error}</p> : null}
+          {error ? <p className="text-xs text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{error}</p> : null}
         </div>
 
         <DialogFooter className="items-center justify-between sm:justify-between">

--- a/apps/web/src/components/loops/variant-gallery.tsx
+++ b/apps/web/src/components/loops/variant-gallery.tsx
@@ -207,7 +207,7 @@ function VariantSlot({
 
       {!decided && canDecide ? (
         <div className="space-y-2 border-t border-border px-4 py-3">
-          {error ? <p className="text-xs text-destructive">{error}</p> : null}
+          {error ? <p className="text-xs text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{error}</p> : null}
           <div className="flex flex-wrap items-center justify-between gap-3">
             <p className="text-[11px] text-muted-foreground">{t('confirmSlotHint')}</p>
             <Button size="sm" disabled={!canSubmit} onClick={() => void handleSubmit()}>

--- a/apps/web/src/components/settings/add-member-modal.tsx
+++ b/apps/web/src/components/settings/add-member-modal.tsx
@@ -113,7 +113,7 @@ export function AddMemberModal({ open, onClose, orgId, projects, onAdded }: AddM
           </div>
         </div>
 
-        {error ? <p className="text-xs text-destructive">{error}</p> : null}
+        {error ? <p className="text-xs text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{error}</p> : null}
 
         <DialogFooter>
           <Button variant="ghost" onClick={close} disabled={submitting}>{tc('cancel')}</Button>

--- a/apps/web/src/components/settings/workflow-line-editor-section.tsx
+++ b/apps/web/src/components/settings/workflow-line-editor-section.tsx
@@ -190,7 +190,7 @@ export function WorkflowLineEditorSection({ projectId }: { projectId?: string | 
         </select>
       </div>
 
-      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      {error ? <p className="text-sm text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{error}</p> : null}
 
       {/* VIEW: S29 active + simulator 재사용 */}
       {mode === 'view' ? (

--- a/apps/web/src/components/settings/workflow-policy-simulator-section.tsx
+++ b/apps/web/src/components/settings/workflow-policy-simulator-section.tsx
@@ -113,7 +113,7 @@ export function WorkflowPolicySimulatorSection() {
         {loading ? t('simRunning') : t('simRun')}
       </Button>
 
-      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      {error ? <p className="text-sm text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{error}</p> : null}
 
       {result ? (
         <div className="space-y-3 rounded-xl border border-border bg-muted/20 p-3">


### PR DESCRIPTION
## Summary
- Story #2148 (원류 `#2105` AC6 재훑 3차 후속) — `&&`-조건부만 잡던 원 grep이 삼항(`? :`) 조건부 인라인 에러 메시지를 전량 놓친 것을 발견, 23개 raw 리스트를 개별 판별(진짜 조작-결과 피드백 vs 정적/이력/이미-커버 오탐)하고 PO 승인받은 결과 중 **텍스트-알림형 17파일 20곳**을 이 PR에서 처리.
- PR-B(`agent-project-access-section.tsx` — 버튼 전환형, 수정 형태가 달라 분리)는 별도 PR.

## 대상 20곳 (17파일)
```
goals-client.tsx:346(생성폼)·474(수정폼)
steer-dispatch-modal.tsx:158
sprints-client.tsx:277(생성)·325(삭제확인)·770(액션에러 — ⭐아래 참조)
internal-dogfood/page.tsx:52 — 인증장애 시 내부 긴급도구, PO 판정으로 포함
access-matrix-tab.tsx:168
agent-persona-composer.tsx:323
cage/gate-signature-approval.tsx:67
canvas/export-dialog.tsx:102 — phase==='error' 3항체인(&&/삼항 외 세 번째 조건부 형태, AC3 부수발견)
canvas/pin-authoring-popover.tsx:72
docs/extensions/code-block-copy.tsx:70 — 다이어그램 렌더 에러
docs/extensions/math-node.tsx:65 — LaTeX 렌더 에러
integrations/pr-link-section.tsx:294
loops/loop-create-dialog.tsx:507
loops/variant-gallery.tsx:210
settings/add-member-modal.tsx:116
settings/workflow-line-editor-section.tsx:193
settings/workflow-policy-simulator-section.tsx:116
```
전부 phase1(`#2399`)/phase2(`#2400`)와 동일 패턴: `role="alert" aria-live="assertive" aria-atomic="true"`(전부 에러류 — 성공/안내 성격 사이트 없음, 시각 클래스 그대로 `text-destructive`).

## ⭐ 계획에 없던 추가 발견 — `sprints-client.tsx:770` `actionError`
당초 판별표엔 `sprints-client.tsx`가 2곳(생성·삭제확인)뿐이었으나, 이 PR 작업 중 같은 파일의 활성화/종료 액션 버튼 바로 아래에 `{actionError ? <p className="...text-destructive">{actionError}</p> : null}`(스프린트 액티베이트/클로즈 실패 피드백)를 추가로 발견했다. **변수명이 `error`/`success`/`message` 접두사가 아니어서(`actionError`) `#2148`의 원 grep(변수명 패턴 기반)에 애초에 안 잡혔던 것** — 이미 같은 파일을 열어 수정하던 중이라 즉시 함께 고쳤다. AC6이 이미 경고한 "기준이 100% 배타적이지 않다"는 한계의 실제 사례다.

## 스코프에서 제외한 것 (판별표 그대로, 근거는 story #2148 본문에 기록)
- `agent-hitl-policy-editor.tsx`·`agent-management-tab.tsx`·`mcp-connection-settings.tsx`: 공용 `<Alert>` 사용 — `#2149`(PR#2430, merged)가 컴포넌트 레벨에서 자동으로 올바른 role/aria-live를 부여해 이미 해결됨.
- `decisions-waiting.tsx`: 이미 `role="alert"` inline로 있어 동작이 이미 옳음 — 3종 세트 추가는 동작 변화 0인 회귀 면적 증가라 손대지 않음.
- `agent-run-detail.tsx`: 툴 감사 이력 표시(방금 조작 결과 아님) — `#2400`이 같은 이유로 제외한 `run.status==='failed'` Alert와 동일 클래스.
- `agent-project-access-section.tsx`: "로드 실패·재시도" 버튼 전환형 — PR-B로 분리.

## Gate 결과 (worktree root)
- `pnpm --filter web type-check` — **0 errors**
- `pnpm --filter web lint` — **0 errors**, 5 pre-existing warnings in unrelated files (e2e/retro-detailed.spec.ts, docs/[slug]/page.tsx, lib/storage/format.ts) — 이 PR과 무관
- `pnpm test` (root vitest, full repo) — **304 test files passed, 2088 tests passed, 2 skipped, 0 failed**
- `pnpm --filter web build` — **EXIT 0**

## Test coverage
- 순수 속성 추가(className/로직 무변경)라 기존 시각 스냅샷/렌더 테스트에 영향 없음 — 전체 vitest 그린으로 무회귀 확認.
- 신규 mount 테스트는 추가하지 않음 — phase2(`#2400`)의 "22개 파일에 기존 jsdom mount 스캐폴딩 없어 코드리뷰로 대체" 컨벤션을 그대로 따름(패턴이 phase1/2와 완전히 동일해 새 인프라 불필요).

## Test plan
- [x] type-check clean
- [x] lint clean (no new warnings)
- [x] full vitest suite green
- [x] production build succeeds
- [ ] QA(까심) review — 승인 없이 머지 금지

🤖 Generated with [Claude Code](https://claude.com/claude-code)