### PR TITLE
[SID:2148] 삼항조건부 인라인 에러 라이브리전 PR-B — agent-project-access-section 재시도 버튼

### DIFF
--- a/apps/web/src/components/settings/agent-project-access-section.tsx
+++ b/apps/web/src/components/settings/agent-project-access-section.tsx
@@ -184,6 +184,9 @@ export function AgentProjectAccessSection({ agentMemberId, projects, canEdit }: 
                       type="button"
                       onClick={() => void loadGrants()}
                       className="inline-flex shrink-0 items-center gap-1 text-xs text-destructive hover:underline"
+                      role="alert"
+                      aria-live="assertive"
+                      aria-atomic="true"
                     >
                       로드 실패 · 재시도
                     </button>


### PR DESCRIPTION
## Summary
- Story #2148 PR-B — `agent-project-access-section.tsx`의 행별 "로드 실패 · 재시도" 버튼(텍스트 알림이 아닌 버튼-전환형)에 role/aria-live 부여.
- PR-A(#2433, 17파일 20곳 텍스트-알림형)와 수정 형태가 달라 PO 지시로 분리.

## 변경 내용
프로젝트별 접근권한 로드 실패 시 토글 버튼 자리가 "로드 실패 · 재시도" 버튼으로 전환되는 자리에 `role="alert" aria-live="assertive" aria-atomic="true"` 부여. 새 버튼이 나타나는 시점 자체가 조건부 렌더 요소의 신규 삽입이라, `#2400`의 "load-failure-with-retry 배너는 alert" 선례(예: `recruiter-client.tsx`의 `roleError`/`runtimeCapabilitiesError` 배너)와 동일 분류.

## Test coverage
기존 jsdom mount 테스트 스캐폴딩 없음 — `#2400` 컨벤션대로 코드리뷰로 검증, 새 heavyweight 인프라는 만들지 않음.

## Gate 결과
- `pnpm --filter web type-check` — **0 errors**
- `pnpm --filter web lint` — **0 errors**, 5 pre-existing warnings 무관 파일
- `pnpm test` — **304 test files passed, 2088 tests passed, 2 skipped, 0 failed**
- `pnpm --filter web build` — **EXIT 0**

## Test plan
- [x] type-check clean
- [x] lint clean
- [x] full vitest suite green
- [x] production build succeeds
- [ ] QA(까심) review — 승인 없이 머지 금지

🤖 Generated with [Claude Code](https://claude.com/claude-code)