### PR TITLE
fix(#2155): remove GitHub OAuth login (BE) — App/bot integration untouched

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -66,11 +66,9 @@ class Settings(BaseSettings):
     app_env: str = "development"
     debug: bool = False
 
-    # OAuth — Google / GitHub
+    # OAuth — Google (story #2155: GitHub 로그인 제거 — GitHub App/봇 연동과는 무관, :209 참조)
     google_client_id: str = ""
     google_client_secret: str = ""
-    github_client_id: str = ""
-    github_client_secret: str = ""
     # Next.js 프론트엔드 URL (OAuth redirect_uri 조합용)
     app_url: str = "http://localhost:3000"
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -26,6 +26,11 @@ class User(Base):
     totp_locked_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     display_name: Mapped[str | None] = mapped_column(Text, nullable=True)
     google_id: Mapped[str | None] = mapped_column(Text, nullable=True, unique=True, index=True)
+    # story #2155(2026-07-23): GitHub 로그인 자체를 제거했다(app/routers/auth.py — provider
+    # dispatch에서 "github" 삭제). 이 컬럼은 로그인 외 용도가 0곳(PO grep 확認 — 커밋 귀속·
+    # PR 매핑 어디에도 미사용)이라 지금 당장은 죽은 컬럼이지만, 컬럼 드롭은 되돌릴 수 없고
+    # prod 실측상 이 값이 채워진 사용자가 이미 0명이라 급하지도 않다 — 드롭은 별도 정리로
+    # 미룬다(의도적 보존, 누락 아님).
     github_id: Mapped[str | None] = mapped_column(Text, nullable=True, unique=True, index=True)
     last_project_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="SET NULL"), nullable=True

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -949,6 +949,13 @@ async def totp_verify(
 
 # ─── OAuth ────────────────────────────────────────────────────────────────────
 
+# story #2155(2026-07-23, 선생님 지시): GitHub 로그인 제거 — 첫 화면 로그인 버튼이
+# "개발자 도구" 포지셔닝을 말하지 않게 하기 위함(GitHub App/봇 연동 `github_app.py`는
+# 완전히 별개 물건이라 무관 — config.py:209 주석 참조). 제거 전 prod 실측(디디, 읽기전용
+# 1회 잡): github_id는 있으나 다른 로그인 수단이 없는 사용자 0명 — 이관 경로 불요.
+# `_OAUTH_CONFIGS`가 provider 등록 자체를 게이트하므로("google" 하나만 등록) 아래
+# `_client_id`/`_client_secret`/oauth_callback의 provider 분기는 전부 "google 하나뿐"이
+# 확정된 상태에서 남은 스캐폴딩이다 — 향후 다른 provider가 추가되면 그때 다시 분기한다.
 _OAUTH_CONFIGS: dict[str, dict] = {
     "google": {
         "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
@@ -956,14 +963,6 @@ _OAUTH_CONFIGS: dict[str, dict] = {
         "userinfo_url": "https://www.googleapis.com/oauth2/v3/userinfo",
         "scope": "openid email profile",
         "id_field": "sub",
-        "email_field": "email",
-    },
-    "github": {
-        "authorize_url": "https://github.com/login/oauth/authorize",
-        "token_url": "https://github.com/login/oauth/access_token",
-        "userinfo_url": "https://api.github.com/user",
-        "scope": "read:user user:email",
-        "id_field": "id",
         "email_field": "email",
     },
 }
@@ -974,11 +973,11 @@ def _redirect_uri(provider: str) -> str:
 
 
 def _client_id(provider: str) -> str:
-    return settings.google_client_id if provider == "google" else settings.github_client_id
+    return settings.google_client_id
 
 
 def _client_secret(provider: str) -> str:
-    return settings.google_client_secret if provider == "google" else settings.github_client_secret
+    return settings.google_client_secret
 
 
 class OAuthCallbackRequest(BaseModel):
@@ -1054,18 +1053,6 @@ async def oauth_callback(
             return _err("OAUTH_USERINFO_FAILED", "Failed to fetch user info", 400)
         userinfo = userinfo_resp.json()
 
-        # GitHub email이 null인 경우 /user/emails로 추가 조회
-        if provider == "github" and not userinfo.get("email"):
-            emails_resp = await client.get(
-                "https://api.github.com/user/emails",
-                headers={"Authorization": f"Bearer {access_token}"},
-            )
-            if emails_resp.status_code == 200:
-                emails = emails_resp.json()
-                primary = next((e["email"] for e in emails if e.get("primary") and e.get("verified")), None)
-                if primary:
-                    userinfo["email"] = primary
-
     oauth_id = str(userinfo.get(cfg["id_field"], ""))
     email = (userinfo.get(cfg["email_field"]) or "").lower().strip()
 
@@ -1073,7 +1060,7 @@ async def oauth_callback(
         return _err("OAUTH_MISSING_INFO", "Missing id or email from provider", 400)
 
     # 3. 기존 유저 조회 (oauth_id 기준 → email 기준 순)
-    id_col = User.google_id if provider == "google" else User.github_id
+    id_col = User.google_id
     result = await session.execute(select(User).where(id_col == oauth_id, User.is_active.is_(True)))
     user = result.scalar_one_or_none()
 

--- a/backend/tests/test_2155_github_login_removed.py
+++ b/backend/tests/test_2155_github_login_removed.py
@@ -1,0 +1,64 @@
+"""story #2155(high, 2026-07-23, 선생님 지시): GitHub 로그인 제거 — GitHub App/봇 연동
+(`app/services/github_app.py`, `GITHUB_APP_*`)과는 완전히 별개(config.py:209 참조). prod
+실측(디디, 읽기전용 1회 잡): github_id는 있으나 다른 로그인 수단이 없는 사용자 0명 —
+이관 경로 불요, 즉시 제거."""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+from app.main import app
+
+
+def test_github_no_longer_a_registered_oauth_provider():
+    from app.routers.auth import _OAUTH_CONFIGS
+    assert "github" not in _OAUTH_CONFIGS
+    assert "google" in _OAUTH_CONFIGS  # 대조군 — google은 무회귀
+
+
+def test_oauth_authorize_github_returns_invalid_provider():
+    with TestClient(app) as c:
+        resp = c.get("/api/v2/auth/oauth/github/authorize")
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["error"]["code"] == "INVALID_PROVIDER"
+
+
+def test_oauth_authorize_google_still_works():
+    """무회귀 — google 로그인은 이 스토리로 영향받지 않는다."""
+    with TestClient(app) as c:
+        resp = c.get("/api/v2/auth/oauth/google/authorize")
+        assert resp.status_code == 200
+        assert "accounts.google.com" in resp.json()["data"]["url"]
+
+
+def test_settings_has_no_github_client_credentials():
+    assert not hasattr(settings, "github_client_id")
+    assert not hasattr(settings, "github_client_secret")
+
+
+def test_settings_still_has_google_client_credentials():
+    assert hasattr(settings, "google_client_id")
+    assert hasattr(settings, "google_client_secret")
+
+
+def test_client_id_and_secret_helpers_ignore_provider_arg():
+    from app.routers.auth import _client_id, _client_secret
+    assert _client_id("google") == settings.google_client_id
+    assert _client_secret("google") == settings.google_client_secret
+
+
+def test_github_app_bot_integration_untouched():
+    """AC1 회귀가드 — 이름이 비슷한 GitHub App(봇) 연동은 이 스토리로 전혀 건드리지
+    않았다(github_app.py는 무수정, GITHUB_APP_* 필드는 config.py에 그대로 존재)."""
+    from app.services import github_app  # noqa: F401 — import 성공 자체가 무회귀 증거
+    assert hasattr(settings, "github_app_id")
+    assert hasattr(settings, "github_app_client_id")
+    assert hasattr(settings, "github_app_slug")
+
+
+def test_user_github_id_column_preserved_but_documented_dead():
+    """AC5 — 컬럼은 이번에 안 지운다(되돌릴 수 없고, prod 실측상 0명이라 급하지 않음).
+    모델 필드 자체는 여전히 존재해야 한다(드롭 안 함의 증거)."""
+    from app.models.user import User
+    assert hasattr(User, "github_id")


### PR DESCRIPTION
## Summary
- story #2155 (선생님 지시): 첫 화면 로그인이 "개발자 도구"를 말하지 않도록 GitHub 로그인 제거.
- `auth.py`의 provider dispatch에서 `"github"` 제거(`_OAUTH_CONFIGS`/`_client_id`/`_client_secret`/callback의 GitHub 이메일 보조조회·id_col 분기 삭제) — `google`은 무회귀.
- `settings.github_client_id`/`github_client_secret` 필드 제거.
- ⛔ GitHub App/봇 연동(`github_app.py`, `GITHUB_APP_*`)은 완전히 별개 물건 — 전혀 미수정(회귀 테스트로 고정).
- `User.github_id` 컬럼은 이번엔 안 지운다 — 되돌릴 수 없고 prod 실측상 0행이라 급하지 않음(컬럼 코멘트로 근거 기록, story #2155에도 기록).
- prod 실측(PO 실행, 디디 설계 — 오늘 alembic 확認과 동일한 read-only 1회 진단 잡): `github_linked=0 github_only_trapped=0 active_total=20 all_total=20` — 이관 경로 불요.
- 후속으로 닫히는 것: story #2145(prod가 dev GitHub OAuth 자격증명을 쓰던 미결) — 원인 자체가 사라짐.

## Scope note
FE(로그인 화면 버튼/i18n)는 미르코가 별도 브랜치(`fix/2155-remove-github-login`)에서 담당 — 서로 안 기다리게 독립 진행.

## Test plan
- [x] `pytest tests/test_2155_github_login_removed.py` — provider 제거·google 무회귀·github_app 미수정·github_id 컬럼 보존 확認
- [x] `pytest tests/test_bot_l1_pr_story_link.py tests/test_auth_security.py` — GitHub App/bot 통합 무회귀
- [x] 전체 스위트(`-k "not realdb"`) — 3903 passed, 7 pre-existing 무관 실패(MCP tooling, 이 diff 무접촉)