### PR TITLE
[SID:2153] access-matrix-tab message.type 판별자 무시 결함 수정

### DIFF
--- a/apps/web/src/components/agents/access-matrix-tab.test.tsx
+++ b/apps/web/src/components/agents/access-matrix-tab.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+//
+// story #2153 — access-matrix-tab.tsx가 message.type('success'|'error')을 선언해놓고
+// 렌더가 이를 무시해 항상 role="alert"/assertive/destructive(빨강)로만 그렸다. 지금은
+// setter가 'error'만 넣어 무해했지만, 'success'가 들어오는 날 성공 메시지가 빨간 글씨로
+// 뜨고 스크린리더 낭독을 assertive로 끊는 회귀가 된다(#2096 관례 위반, #2149와 동일 클래스
+// 결함의 개별 화면판).
+//
+// 렌더 분기(AccessMatrixMessage)를 분리해 success/error 각각을 직접 고정한다 — 실제
+// setter 코드는 현재 'error'만 만들어 success 경로를 종단(fetch mock) 테스트로 재현할
+// 방법이 없어, 렌더 분기 자체를 단위로 검증한다.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { AccessMatrixMessage } from './access-matrix-tab';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+describe('AccessMatrixMessage 접근성 (story #2153)', () => {
+  it('type=success → role=status, aria-live=polite, text-success 클래스(빨강 아님)', async () => {
+    await act(async () => {
+      root.render(<AccessMatrixMessage message={{ type: 'success', text: '완료' }} />);
+    });
+    const el = container.querySelector('[role="status"]');
+    expect(el).not.toBeNull();
+    expect(el?.getAttribute('aria-live')).toBe('polite');
+    expect(el?.getAttribute('aria-atomic')).toBe('true');
+    expect(el?.className).toContain('text-success');
+    expect(el?.className).not.toContain('text-destructive');
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('type=error → role=alert, aria-live=assertive, text-destructive 클래스(현행 유지)', async () => {
+    await act(async () => {
+      root.render(<AccessMatrixMessage message={{ type: 'error', text: '실패' }} />);
+    });
+    const el = container.querySelector('[role="alert"]');
+    expect(el).not.toBeNull();
+    expect(el?.getAttribute('aria-live')).toBe('assertive');
+    expect(el?.getAttribute('aria-atomic')).toBe('true');
+    expect(el?.className).toContain('text-destructive');
+    expect(el?.className).not.toContain('text-success');
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+
+  it('message가 null이면 아무것도 렌더하지 않는다', async () => {
+    await act(async () => {
+      root.render(<AccessMatrixMessage message={null} />);
+    });
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+});

--- a/apps/web/src/components/agents/access-matrix-tab.tsx
+++ b/apps/web/src/components/agents/access-matrix-tab.tsx
@@ -22,6 +22,24 @@ interface AccessMatrixRow {
   record_id: string;
 }
 
+export type AccessMatrixMessageState = { type: 'success' | 'error'; text: string } | null;
+
+// story #2153: 선언(type: 'success'|'error')과 렌더가 갈라져 있던 결함 — success가 들어와도
+// 항상 destructive/alert였다. 렌더 분기를 별도 컴포넌트로 빼 success 케이스를 직접 테스트한다.
+export function AccessMatrixMessage({ message }: { message: AccessMatrixMessageState }) {
+  if (!message) return null;
+  return (
+    <p
+      className={cn('mb-3 text-xs', message.type === 'success' ? 'text-success' : 'text-destructive')}
+      role={message.type === 'success' ? 'status' : 'alert'}
+      aria-live={message.type === 'success' ? 'polite' : 'assertive'}
+      aria-atomic="true"
+    >
+      {message.text}
+    </p>
+  );
+}
+
 /**
  * story da4c6b2d — org 전체 에이전트(행) × 프로젝트(열) 접근권한 매트릭스.
  * 데이터 = `agent-project-access-section.tsx`(상세 per-agent 토글)와 동일 원천
@@ -41,7 +59,7 @@ export function AccessMatrixTab() {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
   const [togglingKey, setTogglingKey] = useState<string | null>(null);
-  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [message, setMessage] = useState<AccessMatrixMessageState>(null);
 
   const key = (agentId: string, projectId: string) => `${agentId}::${projectId}`;
 
@@ -165,7 +183,7 @@ export function AccessMatrixTab() {
           </div>
         </SectionCardHeader>
         <SectionCardBody>
-          {message ? <p className="mb-3 text-xs text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{message.text}</p> : null}
+          <AccessMatrixMessage message={message} />
 
           {agents.length === 0 || projects.length === 0 ? (
             <div className="rounded-md border border-dashed border-border px-3 py-8 text-center">


### PR DESCRIPTION
## Summary
- Story #2153 — `#2148` PR-A 검수 중 PO가 발견: `access-matrix-tab.tsx`의 `message` state가 `{ type: 'success' | 'error'; text: string }`를 선언해놓고 렌더는 `type`을 무시한 채 항상 `text-destructive`/`role="alert"`/`assertive`였다.
- 현재 setter 2곳이 전부 `type:'error'`만 넣어 오늘까지는 무해했지만, 누군가 `type:'success'`를 넣는 순간 성공 메시지가 빨간 글씨로 뜨고 스크린리더 낭독을 assertive로 끊는 회귀가 되는 구조("선언과 실제가 갈라진 자리" — `#2149`와 동일 클래스의 개별 화면판).

## 변경 내용
- 처방 ⓐ(렌더가 `type`을 실제로 쓴다) 채택 — 이미 다른 13개 사이트가 쓰는 `success→text-success/status/polite`, `error→text-destructive/alert/assertive` 패턴과 동일하게 맞춤.
- 렌더 분기를 `AccessMatrixMessage`로 분리·export — 실제 setter 코드가 `'error'`만 만들어 success 경로를 종단(fetch mock) 테스트로 재현할 방법이 없어, 분기 자체를 단위로 테스트 가능하게 했다.

## AC2 — 같은 패턴 전수 훑기 (이 스토리의 본체)
`{ type: 'success' | 'error'; ... }` 판별자를 선언하는 `useState` **14곳** 전부를 grep해 렌더 사이트를 직접 대조:
```
13곳 정상(이미 .type을 분기해 렌더): settings/page.tsx(projectActionMessage) ·
  agent-project-access-section · set-password-section · mcp-connection-settings ·
  workflow-trigger-types-section · org-members-section(inviteResult+actionMessage, 2곳) ·
  gate-level-matrix · two-factor-section · project-access-section ·
  agent-management-tab · invite/accept/invite-accept-client
1곳만 결함: access-matrix-tab.tsx ← 이 PR로 fix
```
⇒ **"이 기준으로 이만큼 봤고, 새는 곳은 없었다"**로 종결 — 4번째 스토리 안 엶.

## Test coverage
- 신규 `access-matrix-tab.test.tsx`(3케이스): `type=success`→role=status/polite/text-success, `type=error`→role=alert/assertive/text-destructive(현행 유지), `message=null`→미렌더.
- **RED→GREEN**: fix를 stash로 되돌리면 `AccessMatrixMessage` export 자체가 없어져 신규 테스트 3개 전부 실패(모듈 해석 실패) → 복원 후 3/3 통과.

## Gate 결과 (worktree root)
- `pnpm --filter web type-check` — **0 errors**
- `pnpm --filter web lint` — **0 errors**, 5 pre-existing warnings 무관 파일
- `pnpm test` — **305 test files passed, 2091 tests passed, 2 skipped, 0 failed**
- `pnpm --filter web build` — **EXIT 0**

## Test plan
- [x] type-check clean
- [x] lint clean
- [x] full vitest suite green
- [x] production build succeeds
- [ ] QA(까심) review — 승인 없이 머지 금지

🤖 Generated with [Claude Code](https://claude.com/claude-code)