### PR TITLE
fix(#2152): is_really_local unknown-runtime default is now safe (not local)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -23,6 +23,11 @@ SUPABASE_URL=https://your-project.supabase.co
 # ─── App ─────────────────────────────────────────────────────────────────────
 APP_ENV=development
 DEBUG=true
+# story #2152: "진짜 로컬 개발"임을 명시적으로 선언 — cron.py/auth_firebase_internal.py의
+# 내부 시크릿 fail-open 게이트가 이 값을 요구한다(K_SERVICE 부재만으로는 더 이상 인정하지
+# 않음 — GCE 등 비-Cloud-Run 배포도 K_SERVICE가 없기 때문). 실제 배포 환경(Cloud Run/GCE)
+# 에서는 이 값을 절대 세팅하지 말 것.
+SPRINTABLE_LOCAL_DEV=1
 
 # ─── EE / SaaS gating ────────────────────────────────────────────────────────
 LICENSE_CONSENT=

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -66,11 +66,9 @@ class Settings(BaseSettings):
     app_env: str = "development"
     debug: bool = False
 
-    # OAuth — Google / GitHub
+    # OAuth — Google (story #2155: GitHub 로그인 제거 — GitHub App/봇 연동과는 무관, :209 참조)
     google_client_id: str = ""
     google_client_secret: str = ""
-    github_client_id: str = ""
-    github_client_secret: str = ""
     # Next.js 프론트엔드 URL (OAuth redirect_uri 조합용)
     app_url: str = "http://localhost:3000"
 
@@ -294,16 +292,45 @@ class Settings(BaseSettings):
 
     @property
     def is_really_local(self) -> bool:
-        """story #2071(critical, 2026-07-21) 근본수정 — `app_env=="development"`만으로는
-        "개발자 랩탑"과 "인터넷에 노출된 dev Cloud Run 배포"를 구분 못 한다(둘 다 동일
-        APP_ENV=development). Cloud Run은 `K_SERVICE`를 항상 자동 주입한다(설정 불필요 —
-        `app/core/database.py`의 커넥션 태깅과 동일 SSOT, 신규 발명 아님). 이게 없으면(로컬
-        uvicorn/pytest) 진짜 로컬, 있으면(dev든 prod든) Cloud Run 위라 fail-open 대상이 아니다.
-        내부 secret 게이트(auth_firebase_internal.py·cron.py 등)가 "시크릿 미설정=로컬이니
-        허용" 판정을 내릴 때 이 프로퍼티로 좁혀야 한다 — `app_env` 문자열만 보면 노출된 dev가
-        그대로 열린다(#2071이 이 클래스의 첫 사례)."""
+        """story #2152(high, 2026-07-23) 근본수정 — story #2071이 도입한 `not K_SERVICE`
+        판정은 "우리는 Cloud Run 위에 있다"는 깨진 전제를 깔고 있었다: GCE(story #2142
+        realtime-gateway)도 `K_SERVICE`가 없으므로 이 판정에선 GCE prod 노드조차 "진짜
+        로컬"이 되어버렸다 — #2071이 막은 구멍이 새 런타임에서 그대로 재현된 것.
+
+        AC2(안전한 실패 방향) 근본수정: "특정 클라우드의 부재 신호"만으로 "로컬"을 추론하는
+        방식(K_SERVICE 없음 = 로컬)은 구조적으로 계속 깨진다 — 모르는 런타임이 새로 생길
+        때마다 그 런타임의 부재 신호를 목록에 추가해야 하고, 빠뜨리면 다시 열린다. `K_SERVICE`
+        존재는 여전히 "Cloud Run 위"라는 확실한 긍정 신호라 그대로 두지만(빠른 경로, 여전히
+        유효 — 틀린 적 없다), **그게 없다고 곧장 "로컬"로 넘어가지 않는다** — 그 경우엔
+        "로컬이다"를 별도로 긍정 확인할 수 있을 때만 True고, 그 외(GCE 포함, 모르는 런타임
+        포함 전부)는 False(로컬 아님 = 게이트 적용)로 떨어뜨린다.
+
+        "로컬이다"의 긍정 신호 둘만 인정한다:
+        ①pytest 실행 중(`PYTEST_CURRENT_TEST`, pytest가 매 테스트마다 자동 주입 — 신규 발명
+          아님) ②`SPRINTABLE_LOCAL_DEV`가 명시적으로 세팅됨(로컬 uvicorn/자체호스팅
+          docker-compose용 — `.env.example`·`docker-compose.yml`에 채워둠, 신규 개발자가
+          별도 조치 없이 그대로 동작).
+
+        ⛔이 판정이 못 잡는 것(AC1 명시): `SPRINTABLE_LOCAL_DEV`를 실수로 세팅한 채 배포된
+        노드는 여전히 "로컬"로 열린다 — 이건 판정 로직이 아니라 배포 설정 리뷰의 몫이다.
+        마찬가지로 자체호스팅 docker-compose를 운영자가 인터넷에 노출하면서도
+        `SPRINTABLE_LOCAL_DEV`를 지우지 않으면 그 인스턴스도 "로컬"로 판정된다 — 이건 #2152
+        도입 이전에도 동일하게 뚫려 있던(K_SERVICE 부재로) 자체호스팅 한정 기존 한계이지,
+        이번 수정이 새로 만든 구멍이 아니다."""
         import os
-        return not os.environ.get("K_SERVICE")
+        if os.environ.get("K_SERVICE"):
+            return False
+        if os.environ.get("PYTEST_CURRENT_TEST"):
+            return True
+        return os.environ.get("SPRINTABLE_LOCAL_DEV", "").strip().lower() in {"1", "true", "yes"}
+
+    @property
+    def is_internal_secret_gate_exempt(self) -> bool:
+        """cron.py/auth_firebase_internal.py의 내부 시크릿 fail-open 게이트가 참조하는
+        단일 진입점(story #2152 AC4) — `is_really_local`을 app_env 체크 없이 단독으로 쓰는
+        호출부가 생기는 것을 코드 구조로 막는다(둘 다 이 프로퍼티 하나만 부르면 되게 만들어,
+        "app_env와 AND로 묶는 것"이 관례가 아니라 강제가 되게 한다)."""
+        return self.app_env == "development" and self.is_really_local
 
 
 settings = Settings()

--- a/backend/app/routers/auth_firebase_internal.py
+++ b/backend/app/routers/auth_firebase_internal.py
@@ -78,15 +78,15 @@ class FirebaseSessionMintResponse(BaseModel):
 # 따라 "시크릿 미설정=허용"이었는데, cron과 달리 이 엔드포인트는 세션쿠키 mint 능력 자체라
 # 환경 무관 fail-open이 위험하다 — 직접 probe로 `app_env=production`+시크릿 미설정 시
 # 내부 consume/mint 엔드포인트가 공개됨을 실증. non-local 환경은 fail-closed(503), 로컬
-# 개발(APP_ENV=development)만 예외 허용.
-_LOCAL_ENVS = {"development"}
+# 개발(APP_ENV=development)만 예외 허용. story #2152 이후로는 `settings.
+# is_internal_secret_gate_exempt`(app/core/config.py SSOT) 단일 프로퍼티로 판정한다.
 
 
 def _require_internal_secret(authorization: str | None) -> None:
     secret = settings.firebase_bff_internal_secret
     if not secret:
-        if settings.app_env in _LOCAL_ENVS and settings.is_really_local:
-            return  # 진짜 로컬 개발 전용 예외(Cloud Run 위가 아님 — story #2071)
+        if settings.is_internal_secret_gate_exempt:
+            return  # 진짜 로컬 개발 전용 예외(Cloud Run/GCE 위가 아님 — story #2071/#2152)
         logger.warning(
             "auth.firebase.internal_secret_missing_in_non_local_env app_env=%s on_cloud_run=%s",
             settings.app_env, not settings.is_really_local,
@@ -108,18 +108,17 @@ def check_internal_secret_config(s=None) -> None:
     allowed=False). 이 내부 엔드포인트를 실제로 쓰는 기능(세션 발급/모바일 부트스트랩)이
     켜져 있을 때만 시크릿을 요구한다.
 
-    story #2071(critical) 근본수정: `app_env not in _LOCAL_ENVS`만으로는 노출된 dev
-    Cloud Run(APP_ENV=development)을 놓친다 — `s.is_really_local`(K_SERVICE 부재 판정,
-    `app/core/config.py` SSOT) 아니면 시크릿을 요구한다. dev에 Firebase 기능이 켜지고 이
-    startup 가드가 살아 있으면, 시크릿 없이는 이제 배포 자체가 실패한다(런타임 503
-    fail-closed보다 먼저 잡힘 — 배포 시점에 시끄럽게 실패하는 쪽이 더 안전,
-    check_listen_config()와 동형)."""
+    story #2071(critical) 근본수정, #2152로 판정 SSOT 통합: `s.is_internal_secret_gate_exempt`
+    (`app/core/config.py`, app_env+is_really_local을 이미 AND로 묶은 단일 프로퍼티) 아니면
+    시크릿을 요구한다. dev에 Firebase 기능이 켜지고 이 startup 가드가 살아 있으면, 시크릿
+    없이는 이제 배포 자체가 실패한다(런타임 503 fail-closed보다 먼저 잡힘 — 배포 시점에
+    시끄럽게 실패하는 쪽이 더 안전, check_listen_config()와 동형)."""
     if s is None:
         from app.core.config import settings as s
     firebase_internal_enabled = (
         s.firebase_auth_issue_session or s.firebase_auth_mobile_issue or s.firebase_oauth_handoff_enabled
     )
-    _not_local = s.app_env not in _LOCAL_ENVS or not s.is_really_local
+    _not_local = not s.is_internal_secret_gate_exempt
     if firebase_internal_enabled and _not_local and not s.firebase_bff_internal_secret:
         raise RuntimeError(
             f"APP_ENV={s.app_env}인데 FIREBASE_BFF_INTERNAL_SECRET 미설정 — 내부 세션 mint/"

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -42,9 +42,6 @@ def _err(code: str, message: str, status: int = 400) -> JSONResponse:
     return JSONResponse({"data": None, "error": {"code": code, "message": message}, "meta": None}, status_code=status)
 
 
-_LOCAL_ENVS = {"development"}
-
-
 def verify_cron(request: Request) -> None:
     """story #2072(high, 2026-07-21) 근본수정 — 기존엔 `if not CRON_SECRET: return`(환경
     무관 무조건 허용)이라 `_require_internal_secret`(#2071)보다도 더 넓게 열려 있었다(둘 다
@@ -53,13 +50,13 @@ def verify_cron(request: Request) -> None:
     secretRef로 배선돼 있어 무인증은 아니지만(오르테가군 실측), 배선이 한 번이라도 비면
     (배포 실수·로테이션·env 누락) 전 cron이 열리는 구조적 위험이었다.
 
-    `_require_internal_secret`(#2071)과 동일 기준으로 좁힌다 — `app_env=="development"`
-    문자열만으로는 "진짜 로컬"과 "인터넷에 노출된 dev Cloud Run"을 구분 못 하므로
-    `settings.is_really_local`(K_SERVICE 부재 판정, `app/core/config.py` SSOT)도 같이
-    요구한다."""
+    `_require_internal_secret`(#2071)과 동일 기준으로 좁힌다 — story #2152 이후로는
+    `settings.is_internal_secret_gate_exempt`(`app/core/config.py` SSOT) 단일 프로퍼티만
+    본다 — app_env 체크를 이 파일에서 직접 반복하지 않는다(#2152 AC4: is_really_local을
+    app_env와 따로 떼어 쓸 여지 자체를 구조로 없앤다)."""
     if not CRON_SECRET:
-        if settings.app_env in _LOCAL_ENVS and settings.is_really_local:
-            return  # 진짜 로컬 개발 전용 예외(Cloud Run 위가 아님)
+        if settings.is_internal_secret_gate_exempt:
+            return  # 진짜 로컬 개발 전용 예외(Cloud Run/GCE 위가 아님)
         logger.warning(
             "cron.secret_missing_in_non_local_env app_env=%s on_cloud_run=%s",
             settings.app_env, not settings.is_really_local,
@@ -77,7 +74,7 @@ def check_cron_secret_config(s=None) -> None:
     더 시끄럽게 잡는 쪽이 안전하다."""
     if s is None:
         from app.core.config import settings as s
-    _not_local = s.app_env not in _LOCAL_ENVS or not s.is_really_local
+    _not_local = not s.is_internal_secret_gate_exempt
     if _not_local and not CRON_SECRET:
         raise RuntimeError(
             f"APP_ENV={s.app_env}인데 CRON_SECRET 미설정 — 내부 cron 엔드포인트가 인증 없이 "

--- a/backend/tests/test_2072_cron_secret_failopen.py
+++ b/backend/tests/test_2072_cron_secret_failopen.py
@@ -13,6 +13,12 @@ import pytest
 def _s(**overrides):
     base = {"app_env": "development", "is_really_local": True}
     base.update(overrides)
+    # story #2152: check_cron_secret_config은 이제 is_internal_secret_gate_exempt 단일
+    # 프로퍼티만 본다 — 목(mock)도 실제 Settings와 동일하게 app_env+is_really_local의 AND로
+    # 계산해서 넣어준다(SimpleNamespace엔 @property가 없어 직접 계산 필요).
+    base["is_internal_secret_gate_exempt"] = (
+        base["app_env"] == "development" and base["is_really_local"]
+    )
     return SimpleNamespace(**base)
 
 

--- a/backend/tests/test_2152_runtime_local_detection.py
+++ b/backend/tests/test_2152_runtime_local_detection.py
@@ -1,0 +1,101 @@
+"""story #2152(high, 2026-07-23) 근본수정 — story #2071이 도입한 `is_really_local = not
+K_SERVICE` 판정은 "Cloud Run만 존재한다"는 전제가 깨지자(story #2142 GCE realtime-gateway)
+그대로 재발했다: GCE도 K_SERVICE가 없으므로 "진짜 로컬"로 오판됐다.
+
+이 파일은 AC2(실패 방향이 안전한 쪽 — 모르면 로컬 아님)·AC5(Cloud Run/GCE/진짜 로컬 세
+시나리오 고정)를 실제 `settings.is_really_local`/`is_internal_secret_gate_exempt` 프로퍼티
+(SimpleNamespace 목이 아니라 진짜 판정 로직)로 검증한다."""
+from __future__ import annotations
+
+from app.core.config import settings
+
+
+def _clear_runtime_signals(monkeypatch):
+    """세 시나리오 전부 이 상태에서 시작 — `PYTEST_CURRENT_TEST`를 지우지 않으면 pytest가
+    실행 중이라는 사실 자체가 항상 '로컬'로 판정돼 Cloud Run/GCE 시나리오를 흉내낼 수 없다
+    (pytest가 매 테스트마다 이 값을 자동 세팅 — 신규 발명 아님)."""
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("K_SERVICE", raising=False)
+    monkeypatch.delenv("SPRINTABLE_LOCAL_DEV", raising=False)
+
+
+def test_cloud_run_is_not_local(monkeypatch):
+    """Cloud Run: K_SERVICE 자동주입 — 로컬 아님(#2071 이래 불변, 회귀가드)."""
+    _clear_runtime_signals(monkeypatch)
+    monkeypatch.setenv("K_SERVICE", "sprintable-backend-dev")
+    assert settings.is_really_local is False
+
+
+def test_gce_is_not_local(monkeypatch):
+    """story #2152 핵심 회귀 — GCE는 K_SERVICE가 없다(Cloud Run 전용 주입). 이전 판정
+    (`not K_SERVICE`)은 여기서 True(로컬)로 오판했다. 새 판정은 SPRINTABLE_LOCAL_DEV도
+    없으므로 안전하게 False(로컬 아님)로 떨어져야 한다."""
+    _clear_runtime_signals(monkeypatch)
+    assert settings.is_really_local is False
+
+
+def test_unknown_future_runtime_defaults_to_not_local(monkeypatch):
+    """AC2 핵심 주장의 일반형 — GCE라는 특정 케이스가 아니어도, 아무 긍정 신호가 없는
+    '모르는 런타임'은 전부 로컬 아님으로 떨어진다(부재 신호를 쌓아가는 방식이 아니라
+    긍정 신호 하나만 보는 설계이므로, 다음에 또 다른 런타임이 나와도 이 결과는 그대로다)."""
+    _clear_runtime_signals(monkeypatch)
+    assert settings.is_really_local is False
+
+
+def test_truly_local_via_pytest_marker_needs_no_extra_setup(monkeypatch):
+    """대조군 — 기존 테스트 스위트 어디에도 SPRINTABLE_LOCAL_DEV가 세팅돼 있지 않지만,
+    pytest 실행 자체가 자동으로 '진짜 로컬' 신호가 된다(PYTEST_CURRENT_TEST를 지우지 않는
+    케이스)."""
+    monkeypatch.delenv("K_SERVICE", raising=False)
+    monkeypatch.delenv("SPRINTABLE_LOCAL_DEV", raising=False)
+    assert settings.is_really_local is True
+
+
+def test_truly_local_via_explicit_marker(monkeypatch):
+    """자체호스팅 docker-compose·bare uvicorn --reload 대조군 — pytest가 아니어도
+    SPRINTABLE_LOCAL_DEV를 명시하면 로컬로 인정된다(.env.example·docker-compose.yml에
+    기본 포함, story #2152)."""
+    _clear_runtime_signals(monkeypatch)
+    monkeypatch.setenv("SPRINTABLE_LOCAL_DEV", "1")
+    assert settings.is_really_local is True
+
+
+def test_local_dev_marker_accepts_true_and_yes(monkeypatch):
+    _clear_runtime_signals(monkeypatch)
+    for value in ("true", "True", "yes", "YES"):
+        monkeypatch.setenv("SPRINTABLE_LOCAL_DEV", value)
+        assert settings.is_really_local is True
+
+
+def test_local_dev_marker_rejects_falsy_values(monkeypatch):
+    _clear_runtime_signals(monkeypatch)
+    for value in ("0", "false", ""):
+        monkeypatch.setenv("SPRINTABLE_LOCAL_DEV", value)
+        assert settings.is_really_local is False
+
+
+def test_gate_exempt_requires_both_dev_appenv_and_really_local(monkeypatch):
+    """AC4 — `is_internal_secret_gate_exempt`는 app_env와 is_really_local을 코드 구조로
+    AND 묶는다(cron.py/auth_firebase_internal.py가 is_really_local을 단독으로 볼 여지를
+    없앤다). is_really_local만 True여도 app_env가 dev가 아니면 여전히 게이트가 걸린다."""
+    _clear_runtime_signals(monkeypatch)
+    monkeypatch.setenv("SPRINTABLE_LOCAL_DEV", "1")
+    monkeypatch.setattr(settings, "app_env", "production")
+    assert settings.is_really_local is True
+    assert settings.is_internal_secret_gate_exempt is False
+
+
+def test_gate_exempt_true_only_when_both_hold(monkeypatch):
+    _clear_runtime_signals(monkeypatch)
+    monkeypatch.setenv("SPRINTABLE_LOCAL_DEV", "1")
+    monkeypatch.setattr(settings, "app_env", "development")
+    assert settings.is_internal_secret_gate_exempt is True
+
+
+def test_gate_exempt_false_when_appenv_missing_defaults_dev_but_runtime_unknown(monkeypatch):
+    """AC6 — APP_ENV 누락(기본값 development)만으로는 더 이상 게이트가 안 열린다.
+    is_really_local이 안전한 새 기본값(False)이라 combined 판정이 이 축 하나만으로도
+    막힌다(배포 스크립트가 APP_ENV를 채우는 것에 의존하지 않는다)."""
+    _clear_runtime_signals(monkeypatch)
+    monkeypatch.setattr(settings, "app_env", "development")  # Settings 클래스 기본값과 동일
+    assert settings.is_internal_secret_gate_exempt is False

--- a/backend/tests/test_e_auth_rebuild_phase1_s5_startup_guards.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s5_startup_guards.py
@@ -20,6 +20,12 @@ def _s(**overrides):
         "is_really_local": True,
     }
     base.update(overrides)
+    # story #2152: check_internal_secret_config은 이제 is_internal_secret_gate_exempt 단일
+    # 프로퍼티만 본다 — 목(mock)도 실제 Settings와 동일하게 app_env+is_really_local의 AND로
+    # 계산해서 넣어준다(SimpleNamespace엔 @property가 없어 직접 계산 필요).
+    base["is_internal_secret_gate_exempt"] = (
+        base["app_env"] == "development" and base["is_really_local"]
+    )
     return SimpleNamespace(**base)
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,11 @@ services:
       H1_MERGE_GATE_ENABLED: "True"
       # Agent chat file uploads (POST /api/v2/channel/upload)
       CHANNEL_FILES_DIR: /app/data/channel_files
+      # story #2152: 자체호스팅 docker-compose는 K_SERVICE가 없으므로(Cloud Run 전용) 이걸
+      # 명시하지 않으면 내부 cron/firebase-internal 시크릿 게이트가 startup에서 fail-closed
+      # 된다(CRON_SECRET 등이 이 compose엔 안 배선돼 있음). 인터넷에 노출해 운영한다면 이
+      # 값을 지우고 해당 시크릿들을 직접 설정할 것.
+      SPRINTABLE_LOCAL_DEV: "1"
     volumes:
       - ./data/channel_files:/app/data/channel_files
     command: >


### PR DESCRIPTION
## Summary
- story #2152: `is_really_local = not K_SERVICE`(#2071)의 전제("Cloud Run만 존재")가 GCE(#2142)로 깨져, K_SERVICE 없는 GCE prod 노드가 "진짜 로컬"로 오판되던 결함.
- **AC1**: 특정 클라우드 부재 신호를 쌓는 방식 폐기 — K_SERVICE 존재는 여전히 유효한 "확실히 not local" 빠른 경로로 남기되, 그 부재가 곧장 "로컬"로 이어지지 않는다. "못 잡는 것"도 프로퍼티 docstring에 명시(SPRINTABLE_LOCAL_DEV 오설정·자체호스팅 인터넷 노출 케이스).
- **AC2**: 모르는 런타임은 기본 False(로컬 아님=게이트 적용). 로컬 판정은 이제 긍정 신호(pytest 실행 중 / `SPRINTABLE_LOCAL_DEV` 명시)가 있을 때만.
- **AC3**: 코드 수정만으로 끝내지 않음 — 실 GCE 노드 실측이 필요하나 이건 infra lane(gcloud 실행권한 없음) — 별도로 핸드오프.
- **AC4**: `cron.py`/`auth_firebase_internal.py`가 각자 `app_env in _LOCAL_ENVS and is_really_local`을 반복하던 것을 `settings.is_internal_secret_gate_exempt` 단일 프로퍼티로 통합 — is_really_local을 앞으로 단독 사용할 여지를 구조로 제거.
- **AC5**: `tests/test_2152_runtime_local_detection.py` — Cloud Run/GCE/진짜 로컬 세 시나리오 + 미래 런타임(unknown) 케이스를 실제 프로퍼티로 고정.
- **AC6**: `is_internal_secret_gate_exempt`가 app_env+is_really_local의 AND라, APP_ENV 누락(기본값 development)만으로는 더 이상 게이트가 안 열림(is_really_local의 새 안전 기본값이 커버) — 테스트로 고정.
- 자체호스팅 `docker-compose.yml`/`.env.example`에 `SPRINTABLE_LOCAL_DEV=1` 추가 — 로컬 uvicorn/자체호스팅 워크플로우 무회귀.

## Test plan
- [x] `pytest tests/test_2152_runtime_local_detection.py` — 9 tests, Cloud Run/GCE/unknown/local 시나리오
- [x] `pytest tests/test_2072_cron_secret_failopen.py tests/test_e_auth_rebuild_phase1_s5_startup_guards.py` — 기존 fail-open 회귀 테스트 무회귀(merged property 반영)
- [x] 전체 스위트(`-k "not realdb"`) — 3905 passed, pre-existing 무관 실패 7건(MCP tooling)
- [ ] AC3 라이브 확認 — 실 GCE 노드에서 `python3 -c "from app.core.config import settings; print(settings.is_really_local, settings.app_env)"` (infra 실행 권한 필요, 별도 핸드오프)