### PR TITLE
promo(#2142): prod 실시간 트래픽 GCE 전환 — REALTIME_URL 배선 (60분 실측 PASS 後 머지)

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -112,6 +112,13 @@ jobs:
             # prod에 얹지 않는다 — develop→main 48커밋 일괄승격에 검증 안 된 롤백 플래그를
             # 섞으면 문제 발생 시 원인 격리가 안 된다. dev 실측 후 별도 판단.
             echo "sse_multiplex_enabled=false" >> "$GITHUB_OUTPUT"
+            # ⭐story #2142(2026-07-23) — prod 실시간 트래픽을 GCE 스택으로 전환한다.
+            # 이 한 줄이 prod 프론트의 REALTIME_URL 이 되고, `/api/event-stream` 프록시가
+            # 그 주소로 향한다(비우면 FASTAPI_URL 로 폴백 = 즉시 원복, 코드 변경 불요).
+            # 전환 근거(값 보기 前 선언한 기준으로 실측): GCE 3노드 전부 HEALTHY ·
+            # backendService timeout=3600 · 관리형 인증서 ACTIVE · 평문 80 차단 ·
+            # 단일세션 60분 무절단 + heartbeat 규칙성(dev 대조군 동시 측정).
+            echo "realtime_url=https://realtime.sprintable.ai" >> "$GITHUB_OUTPUT"
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
prod 프론트의 `REALTIME_URL` 을 `https://realtime.sprintable.ai` 로 배선한다. 지금은 빈 값이라 기존 Cloud Run 경로로 폴백 중이고, 이 한 줄이 실시간 트래픽을 GCE 스택으로 보낸다.

**원복**: 이 줄을 지우면 즉시 폴백 복귀(코드 변경 불요).

⛔ **draft 인 이유** — 60분 단일세션 실측이 아직 도는 중이다. PASS 확認 後에만 ready 로 바꾸고 머지한다. 선생님 결재 사안이라 그 숫자와 함께 여쭙는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)