### PR TITLE
[SID:2109] 정적/피드백 혼재 판별 후 조작-결과 알림 13파일 19곳 접근성 부여

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx
@@ -605,7 +605,7 @@ export default function RetroSessionPage() {
         actions={
           session ? (
             <div className="flex items-center gap-2">
-              {advanceError ? <span className="text-xs text-destructive">{advanceError}</span> : null}
+              {advanceError ? <span className="text-xs text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{advanceError}</span> : null}
               {prevStage ? (
                 <Button variant="outline" size="sm" onClick={() => void goToStage(prevStage)} disabled={advancing}>
                   {t('previousPhase')}
@@ -713,7 +713,7 @@ export default function RetroSessionPage() {
               {showItems ? (
                 <div className="space-y-2">
                   {canMerge ? <p className="text-xs text-muted-foreground">{t('mergeHint')}</p> : null}
-                  {groupError ? <p className="text-xs text-destructive">{groupError}</p> : null}
+                  {groupError ? <p className="text-xs text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{groupError}</p> : null}
                   <DndContext sensors={dndSensors} onDragEnd={handleItemDragEnd}>
                     <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
                       {CATEGORIES.map((category) => {
@@ -748,7 +748,7 @@ export default function RetroSessionPage() {
 
                             {canAddItems ? (
                               <div className="space-y-2 border-t border-border/60 pt-3">
-                                {addItemError ? <p className="text-xs text-destructive">{addItemError}</p> : null}
+                                {addItemError ? <p className="text-xs text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{addItemError}</p> : null}
                                 <OperatorTextarea
                                   value={newItemText[category]}
                                   onChange={(e) => setNewItemText((prev) => ({ ...prev, [category]: e.target.value }))}
@@ -837,7 +837,7 @@ export default function RetroSessionPage() {
 
                   {canAddActions ? (
                     <div className="space-y-2 border-t border-border/60 pt-3">
-                      {addActionError ? <p className="text-xs text-destructive">{addActionError}</p> : null}
+                      {addActionError ? <p className="text-xs text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{addActionError}</p> : null}
                       <div className="flex flex-wrap gap-2">
                         <OperatorInput
                           type="text"

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/page.tsx
@@ -177,7 +177,7 @@ export default function RetroPage() {
               </Button>
             </div>
             {createError ? (
-              <p className="mt-2 text-xs text-destructive">{createError}</p>
+              <p className="mt-2 text-xs text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{createError}</p>
             ) : null}
           </div>
         )}

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -213,7 +213,12 @@ export default function GateDetailPage() {
               <div className="space-y-3">
                 <GateEvidence gate={gate} />
                 {transitionError ? (
-                  <p className="rounded-lg border border-destructive/30 bg-destructive/8 px-3 py-2 text-xs text-destructive">
+                  <p
+                    className="rounded-lg border border-destructive/30 bg-destructive/8 px-3 py-2 text-xs text-destructive"
+                    role="alert"
+                    aria-live="assertive"
+                    aria-atomic="true"
+                  >
                     {t('gateTransitionError', { reason: transitionError })}
                   </p>
                 ) : null}

--- a/apps/web/src/app/verify-email/page.tsx
+++ b/apps/web/src/app/verify-email/page.tsx
@@ -54,7 +54,7 @@ export default function VerifyEmailPage() {
 
         {status === 'success' && (
           <div className="space-y-4">
-            <p className="text-sm font-medium text-success">{message}</p>
+            <p className="text-sm font-medium text-success" role="status" aria-live="polite" aria-atomic="true">{message}</p>
             <button
               onClick={() => router.push('/inbox')}
               className="flex w-full min-h-[44px] items-center justify-center rounded-lg bg-brand px-4 py-3 text-sm font-medium text-brand-foreground transition hover:bg-brand/90"
@@ -66,7 +66,7 @@ export default function VerifyEmailPage() {
 
         {status === 'error' && (
           <div className="space-y-4">
-            <p className="text-sm text-destructive">{message}</p>
+            <p className="text-sm text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{message}</p>
             <Link href="/login" className="block text-sm font-medium text-brand hover:text-brand/80">
               로그인으로 돌아가기
             </Link>

--- a/apps/web/src/components/docs/doc-url-dialog.tsx
+++ b/apps/web/src/components/docs/doc-url-dialog.tsx
@@ -140,7 +140,7 @@ function DocUrlDialogForm({
             </button>
           </p>
         ) : invalid ? (
-          <p className="text-xs text-destructive">{labels.slugInvalid}</p>
+          <p className="text-xs text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{labels.slugInvalid}</p>
         ) : hasExistingSlug ? (
           <p className="flex items-center gap-1 text-xs text-muted-foreground">
             <Info className="size-3 shrink-0" />

--- a/apps/web/src/components/docs/extensions/image-node.tsx
+++ b/apps/web/src/components/docs/extensions/image-node.tsx
@@ -186,7 +186,12 @@ function ImageView({ node, updateAttributes, selected }: ReactNodeViewProps) {
     return (
       <NodeViewWrapper as="div" className="relative my-4 inline-block max-w-full not-prose">
         <StateBox tone="error">
-          <div className="flex flex-col items-center gap-2 text-xs text-destructive">
+          <div
+            className="flex flex-col items-center gap-2 text-xs text-destructive"
+            role="alert"
+            aria-live="assertive"
+            aria-atomic="true"
+          >
             <ImageOff className="size-[22px]" aria-hidden />
             <span>{t('attachImageUnavailable')}</span>
             {isRef || (uploadError && uploadId) ? (

--- a/apps/web/src/components/retro/sprint-close-cockpit.tsx
+++ b/apps/web/src/components/retro/sprint-close-cockpit.tsx
@@ -418,7 +418,7 @@ export function SprintCloseCockpit({
         <div className="flex flex-col items-center gap-2.5 rounded-xl border border-dashed border-border bg-muted/20 p-5 text-center">
           <Sparkles className="size-4 text-info" aria-hidden />
           <p className="text-xs text-muted-foreground">{t('synthesisGenerateHint')}</p>
-          {generateError ? <p className="text-xs text-destructive">{t('synthesisGenerateFailed')}</p> : null}
+          {generateError ? <p className="text-xs text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{t('synthesisGenerateFailed')}</p> : null}
           <Button variant="outline" size="sm" onClick={() => void handleGenerate()}>
             {t('synthesisGenerateCta')}
           </Button>
@@ -443,7 +443,7 @@ export function SprintCloseCockpit({
                   onAdopt={(statement) => void handleAdopt(i, rec, statement)}
                   onIgnore={() => setIgnoredIndexes((prev) => new Set([...prev, i]))}
                 />
-                {adoptError === i ? <p className="text-xs text-destructive">{t('recAdoptFailed')}</p> : null}
+                {adoptError === i ? <p className="text-xs text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{t('recAdoptFailed')}</p> : null}
               </div>
             ))}
           </div>

--- a/apps/web/src/components/settings/my-notification-channel-section.tsx
+++ b/apps/web/src/components/settings/my-notification-channel-section.tsx
@@ -389,6 +389,9 @@ export function MyNotificationChannelSection({ projectId, projectName }: MyNotif
                               test.status === 'fail' && 'text-destructive',
                               (test.status === 'sending' || test.status === 'unavailable') && 'text-muted-foreground',
                             )}
+                            role={test.status === 'fail' ? 'alert' : 'status'}
+                            aria-live={test.status === 'fail' ? 'assertive' : 'polite'}
+                            aria-atomic="true"
                           >
                             {test.status === 'ok' && <><Check className="h-3 w-3" />{t('testReached')}{test.ts ? ` · ${formatTs(test.ts)}` : ''}</>}
                             {test.status === 'fail' && <><X className="h-3 w-3" />{t('testFailed')}{test.reason ? ` · ${test.reason}` : ''}</>}

--- a/apps/web/src/components/settings/workflow-template-gallery-section.tsx
+++ b/apps/web/src/components/settings/workflow-template-gallery-section.tsx
@@ -254,7 +254,12 @@ export function WorkflowTemplateGallerySection({
             })}
 
             {applyResult && (
-              <p className={`text-xs ${applyResult.ok ? 'text-success' : 'text-destructive'}`}>
+              <p
+                className={`text-xs ${applyResult.ok ? 'text-success' : 'text-destructive'}`}
+                role={applyResult.ok ? 'status' : 'alert'}
+                aria-live={applyResult.ok ? 'polite' : 'assertive'}
+                aria-atomic="true"
+              >
                 {applyResult.message}
               </p>
             )}

--- a/apps/web/src/components/standup/board-bridge-modal.tsx
+++ b/apps/web/src/components/standup/board-bridge-modal.tsx
@@ -101,7 +101,7 @@ export function BoardBridgeModal({ open, onOpenChange, boards, alreadySelectedId
                   ))}
                 </div>
               ) : loadError ? (
-                <p className="text-sm text-destructive">{loadError}</p>
+                <p className="text-sm text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{loadError}</p>
               ) : stories.length === 0 ? (
                 <p className="text-sm text-muted-foreground">{t('bridgeNoStories')}</p>
               ) : (

--- a/apps/web/src/components/standup/standup-feedback-dialog.tsx
+++ b/apps/web/src/components/standup/standup-feedback-dialog.tsx
@@ -264,7 +264,7 @@ export function StandupFeedbackDialog({
               ) : null}
             </div>
 
-            {actionError ? <p className="text-sm text-destructive">{actionError}</p> : null}
+            {actionError ? <p className="text-sm text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{actionError}</p> : null}
 
             {feedback.length === 0 ? (
               <p className="text-sm text-muted-foreground">{t('noFeedback')}</p>

--- a/apps/web/src/components/storage/storage-folder-tree.tsx
+++ b/apps/web/src/components/storage/storage-folder-tree.tsx
@@ -221,7 +221,7 @@ export function StorageFolderTree({
             disabled={submitting}
             className="w-full min-w-0 rounded-md border border-border bg-background px-2 py-1.5 text-[12px] text-foreground outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-60"
           />
-          {createError ? <p className="text-[11px] text-destructive">{createError}</p> : null}
+          {createError ? <p className="text-[11px] text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{createError}</p> : null}
           <div className="flex items-center justify-end gap-1.5">
             <button
               type="button"

--- a/apps/web/src/ee/components/billing/billing-tab.tsx
+++ b/apps/web/src/ee/components/billing/billing-tab.tsx
@@ -87,7 +87,7 @@ export function BillingTab({ orgId }: { orgId: string }) {
   };
 
   if (loading) return <div className="p-6 text-sm text-muted-foreground flex items-center gap-2"><Loader2 className="h-4 w-4 animate-spin" />Loading...</div>;
-  if (error) return <div className="p-6 text-sm text-destructive">{error}</div>;
+  if (error) return <div className="p-6 text-sm text-destructive" role="alert" aria-live="assertive" aria-atomic="true">{error}</div>;
 
   const currentPlan = [...plans, { id: 'free', name: 'Free', price: 0, billing_cycle: null, features: ['1 project', '5 members', 'Basic AI features'] }].find((p) => p.id === status?.tier);
 


### PR DESCRIPTION
## Summary
- Story #2109 — `text-destructive` 전수(94곳, UI 프리미티브 정의 4개 제외)를 ⓐ상시 정적 라벨 / ⓑ조작-결과 알림(패턴만 다름) / ⓒ삭제·위험 경고 셋으로 판별 후, ⓑ 19곳(13파일)에만 role/aria-live를 부여했다. 일괄 부여 금지 — 상시 라벨에 붙이면 `#2105` AC3(화면이 조용할 때도 계속 announce되면 안 됨)를 위반한다.

## 모집단 계산 (PO 확인 완료)
```
text-destructive 전체(UI 프리미티브 4개 제외)     94곳
  - 공용 <Alert> 사용(#2149로 자동해결)            14곳
  - 이미 role=alert/status 있음(phase1/2/#2148)    33곳
  = 미판별 후보                                    47곳
    - ⓑ 조작-결과 알림(이 PR)                      19곳
    - ⓒ 삭제/위험 경고(판정 결과 손대지 않음)        2곳
    - ⓐ 상시 정적(손대지 않음)                      나머지
```

## 변경 내용 (19곳, 13파일)
- `retro/[id]/page.tsx`: advanceError·groupError·addItemError·addActionError (4곳)
- `gates/[id]/page.tsx`: transitionError — `gate-signature-approval.tsx`와 같은 상태값이지만 "서명 불필요 게이트" 분기(`usesSignatureFlow=false`)라 그쪽 fix(`#2148`)가 안 닿았던 자리
- `verify-email/page.tsx`: 이메일 인증 성공/실패 페어(성공도 `role=status` 필요했음)
- `board-bridge-modal.tsx`: loadError · `standup-feedback-dialog.tsx`: actionError
- `billing-tab.tsx`: error(데이터 로드 실패 풀스크린 폴백)
- `workflow-template-gallery-section.tsx`: applyResult.ok 조건부(성공/실패 페어)
- `doc-url-dialog.tsx`: slugInvalid 검증 메시지
- `storage-folder-tree.tsx`: createError · `retro/page.tsx`: createError
- `sprint-close-cockpit.tsx`: generateError·adoptError (2곳)
- `image-node.tsx`: 이미지 렌더 실패(`code-block-copy.tsx`·`math-node.tsx`와 동일계열 — `StateBox` 래퍼는 색상만 담당, role은 없었음)
- `my-notification-channel-section.tsx`: 채널 테스트 `status==='fail'`(순수 로컬 state, 매 마운트 초기화 — 지속 상태 아님)

## 4건 애매 사례 — PO 판별 기준 적용 결과
PO가 준 기준: **"사용자가 방금 아무것도 안 했는데도 그 문구가 화면에 있을 수 있는가?"** — 있으면 ⓐ정적(손대지 않음), 없으면(조작 직후에만) ⓑ피드백(부여).
```
file-node.tsx uploadError            → ⓐ정적: Tiptap 노드 attr, 문서 재열람만으로도 보임. 손대지 않음.
notification test.status==='fail'    → ⓑ피드백: useState({}) 매 마운트 초기화. 이 PR에 포함.
doc-gate-section docGateDeniedReason → ⓐ정적: state==='denied'인 동안 상시 노출("현재 상태" 표면). 손대지 않음.
storage-delete-dialog 아이콘         → ⓐ정적: 상위 role="dialog"(alertdialog 아님) 확인, 조건부-결과 자체가 아닌 장식 헤더 아이콘. 손대지 않음.
```

## 스코프 제외
`doc-content-renderer.tsx`(innerHTML 문자열 3곳)는 부여 방식이 JSX 속성이 아니라 근본적으로 달라 이번 스코프에서 제외 — 별건으로 기록만.

## AC4류 무회귀(재시도-전-리셋) 코드 확인
19곳 대부분 `setXxx(null/false)` 리셋이 각 재시도 핸들러 진입 시 확인됨.
⚠️**스코프 밖 관측**: `billing-tab.tsx`는 `handleCheckout` 실패 시 `error`가 최상위 `if (error) return <div>...`에 걸려 결제 UI 전체가 사라지고 재시도 버튼 자체가 없음(단순 재시도-전-리셋 부재보다 심각한 아키텍처 이슈) — 이 PR에서 고치지 않고 관측만 기록.

## Gate 결과 (worktree root)
- `pnpm --filter web type-check` — **0 errors**
- `pnpm --filter web lint` — **0 errors**, 5 pre-existing warnings 무관 파일
- `pnpm test` — **304 test files passed, 2088 tests passed, 2 skipped, 0 failed**
- `pnpm --filter web build` — **EXIT 0**

## Test plan
- [x] type-check clean
- [x] lint clean
- [x] full vitest suite green
- [x] production build succeeds
- [ ] QA(까심) review — 승인 없이 머지 금지

🤖 Generated with [Claude Code](https://claude.com/claude-code)