### PR TITLE
fix(#2150): rejected gates reopen on resubmission instead of blocking forever

### DIFF
--- a/backend/app/models/gate.py
+++ b/backend/app/models/gate.py
@@ -1,8 +1,17 @@
 """E-CAGE-REFEREE P3: HITL Gate 1급 객체.
 
-상태기계: pending → approved | rejected (human 해소)
+상태기계(``is_valid_transition``/``transition_gate``/``void_gate``/``hold_gate`` — 사람·admin이
+주체인 명시적 액션 축): pending → approved | rejected (human 해소)
          auto_passed → (불변, config allow_auto 시 즉시)
-         approved | rejected → (불변)
+         approved | rejected → (이 축에서는 불변 — is_valid_transition에 rejected/approved발
+         전이가 없다. void/override/hold 전부 ``status=="pending"`` 강제)
+
+⚠️story #2150: 위 축과 **별개로**, ``gate_service.create_gate()``의 멱등 조회는 rejected 게이트를
+재제출(work_item 동일 키로 재호출) 시 **같은 row를 재사용해 새 평가 사이클로 리셋**한다(사람의
+명시적 전이가 아니라 시스템의 재평가 — is_valid_transition을 거치지 않는다. approved/voided는
+이 리셋 대상이 아니다 — 근거는 gate_service._reopen_rejected_gate 참조). 즉 "rejected는 절대
+안 바뀐다"는 이 파일의 서술은 **resolver 액션 축**에서만 참이고, 재제출 축에서는 참이 아니다 —
+둘을 혼동하지 않을 것.
 
 neutral_facts: 관찰 사실만 (touches_migration, diff_size 등).
                판정 아님 — 플랫폼은 위험도 판단 안 함.

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -234,6 +234,90 @@ _ALWAYS_MANUAL_GATE_TYPES: frozenset[str] = frozenset(
 )
 
 
+async def _reopen_rejected_gate(
+    session: AsyncSession,
+    gate: Gate,
+    *,
+    org_id: uuid.UUID,
+    member_id: uuid.UUID,
+    role_id: uuid.UUID,
+    gate_type: str,
+    neutral_facts: dict[str, Any] | None,
+    project_id: uuid.UUID | None,
+) -> Gate:
+    """story #2150(P1) 근본수정 — create_gate()의 멱등 조회에 status 필터가 없어 rejected
+    게이트를 그대로 반환했다(merge_verdict_gate.py의 ``gate_status=="rejected"`` 체크와
+    합쳐져, 한 번 반려되면 그 작업 항목은 재제출해도 영구 BLOCK — 반려는 결재 게이트의
+    정상 경로인데 "한 번 쓰고 버리는 스위치"가 되는 결함이었다).
+
+    ⚠️approved/voided는 이 함수에 오지 않는다(호출부에서 status=="rejected"일 때만 호출) —
+    각각 판단 근거(#2150 AC5):
+      · approved — 이미 landed 작업의 재보고는 무해하므로 불변 유지(재오픈하면 이미 확정된
+        승인이 최신 CI/PR 이벤트만으로 흔들리는 쪽이 오히려 위험).
+      · voided   — void는 "이 게이트가 애초에 잘못 생성됐다"는 admin의 명시 무효화(S30)다.
+        reject처럼 "평가했고 아니라고 했다"가 아니라 "이 평가 자체가 없었던 일"이라는
+        선언이라, 자동 재오픈 대상이 아니다(admin이 다시 판단할 문제 — 이 스토리 스코프 밖).
+
+    감사축 보존(AC④): 이전 결재(누가·언제·왜 반려했는지)를 지우지 않고 neutral_facts.
+    decision_history에 append한다 — 게이트 row는 재사용(신규 row 생성 안 함, void/hold와
+    동일하게 기존 row를 상태기계로 계속 쓰는 관례를 따른다).
+
+    새 disposition은 **현재** org/member/role 정책을 다시 조회해 결정한다(과거에 사람이
+    무슨 이유로 반려했는지가 아니라) — 그래서 정책이 여전히 deny면 재오픈해도 다시
+    rejected로 떨어지고(정책이 안 바뀌었으니 정확한 동작), ask/allow_auto로 바뀌었으면
+    pending/auto_passed로 새 사이클이 열린다(AC③)."""
+    history_entry = {
+        "status": gate.status,
+        "resolver_id": str(gate.resolver_id) if gate.resolver_id else None,
+        "resolved_at": gate.resolved_at.isoformat() if gate.resolved_at else None,
+        "resolution_note": gate.resolution_note,
+        "neutral_facts": gate.neutral_facts,
+    }
+    prior_history = list((gate.neutral_facts or {}).get("decision_history") or [])
+    prior_history.append(history_entry)
+
+    disposition, _source = await resolve_disposition(session, org_id, member_id, role_id, gate_type)
+    new_status = _DISPOSITION_TO_STATUS.get(disposition, "pending")
+    if gate_type in _ALWAYS_MANUAL_GATE_TYPES:
+        new_status = "pending"
+
+    gate.status = new_status
+    gate.resolver_id = None
+    gate.resolution_note = None
+    gate.resolved_at = datetime.now(timezone.utc) if new_status != "pending" else None
+    merged_facts = dict(neutral_facts or {})
+    merged_facts["decision_history"] = prior_history
+    gate.neutral_facts = merged_facts
+
+    logger.info(
+        "gate_reopened_from_rejected org=%s gate=%s new_status=%s work=%s/%s",
+        org_id, gate.id, new_status, gate.work_item_type, gate.work_item_id,
+    )
+
+    await session.flush()
+    await session.refresh(gate)
+
+    if new_status == "pending":
+        try:
+            target_ids = await _resolve_gate_notification_targets(session, org_id)
+            if target_ids:
+                from app.services.notification_dispatch import dispatch_notification
+                await dispatch_notification(
+                    session, org_id=org_id, event_type="gate.pending_approval",
+                    target_member_ids=target_ids,
+                    title="결재 대기 중인 게이트가 있습니다",
+                    body=f"{gate_type} 게이트가 재제출되어 다시 승인/거부를 기다리고 있습니다.",
+                    reference_type="gate", reference_id=gate.id,
+                    source_project_id=project_id,
+                )
+        except Exception:
+            logger.warning(
+                "gate.pending_approval(reopen) notification failed gate_id=%s (swallowed·best-effort)",
+                gate.id, exc_info=True,
+            )
+    return gate
+
+
 async def create_gate(
     session: AsyncSession,
     org_id: uuid.UUID,
@@ -268,7 +352,14 @@ async def create_gate(
     )
     existing = existing_r.scalar_one_or_none()
     if existing is not None:
-        return existing
+        # story #2150 근본수정: rejected는 재제출 시 새 결재 사이클을 연다(그 외 terminal
+        # status는 기존 그대로 불변 반환 — 판단 근거는 _reopen_rejected_gate 참조).
+        if existing.status != "rejected":
+            return existing
+        return await _reopen_rejected_gate(
+            session, existing, org_id=org_id, member_id=member_id, role_id=role_id,
+            gate_type=gate_type, neutral_facts=neutral_facts, project_id=project_id,
+        )
 
     # SID 301ee45d/#2047: 반환값이 (disposition, source) — 이 범용 생성기는 disposition→status
     # 매핑만 필요해 source는 버린다(explicit-ask 판정은 merge_verdict_gate.py의 no-substance

--- a/backend/tests/test_e_cage_referee_p3_gate_object.py
+++ b/backend/tests/test_e_cage_referee_p3_gate_object.py
@@ -138,6 +138,210 @@ async def test_create_gate_idempotent():
     session.add.assert_not_called()
 
 
+# ── story #2150: rejected 게이트 재제출 재오픈 ────────────────────────────────
+# AC2: 재현부터(reject→재제출→BLOCK 고정) — 아래 test_create_gate_rejected_*_reopens_*가
+# 그 재현이자 회귀가드다(수정 전 코드로 돌리면 old_resolver_id가 그대로 남고 status도 그대로
+# "rejected"라 실패한다 — fix 적용 전 실제로 RED임을 로컬에서 확認했다).
+
+def _rejected_gate(**overrides):
+    gate = MagicMock()
+    gate.id = GATE_ID
+    gate.status = "rejected"
+    gate.resolver_id = uuid.uuid4()
+    gate.resolution_note = "요구사항 불충분 — 다시 정리해서 올려주세요"
+    gate.resolved_at = datetime(2026, 7, 20, tzinfo=timezone.utc)
+    gate.neutral_facts = {"ci_result": "fail", "pr_result": "pass"}
+    gate.work_item_type = "story"
+    gate.work_item_id = STORY_ID
+    for k, v in overrides.items():
+        setattr(gate, k, v)
+    return gate
+
+
+async def _create_gate_against_rejected(existing_gate, disposition, gate_type="merge",
+                                          neutral_facts=None):
+    from app.services.gate_service import create_gate
+
+    session = AsyncMock()
+    existing_r = MagicMock()
+    existing_r.scalar_one_or_none.return_value = existing_gate
+    session.execute = AsyncMock(return_value=existing_r)
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+
+    with patch("app.services.gate_service.resolve_disposition", new_callable=AsyncMock) as mock_disp, \
+         patch("app.services.gate_service._resolve_gate_notification_targets",
+               new_callable=AsyncMock) as mock_targets:
+        mock_disp.return_value = (disposition, "system_default")
+        mock_targets.return_value = []  # 알림 대상 조회는 스텁(별도 테스트에서 검증)
+        result = await create_gate(
+            session, ORG_ID, STORY_ID, "story", gate_type, MEMBER_ID, ROLE_ID,
+            neutral_facts=neutral_facts,
+        )
+    return result, session
+
+
+@pytest.mark.anyio
+async def test_create_gate_rejected_reopens_to_pending_on_ask_policy():
+    """AC②③ 핵심 재현+수정 확認 — reject된 게이트가 재제출(create_gate 재호출) 시 현재
+    정책이 ask면 pending으로 새 사이클이 열린다(전엔 rejected 그대로 반환→영구 BLOCK)."""
+    gate = _rejected_gate()
+    result, _ = await _create_gate_against_rejected(gate, "ask")
+
+    assert result is gate  # 신규 row 생성 아님(기존 row 재사용 — void/hold와 동일 관례)
+    assert result.status == "pending"
+    assert result.resolver_id is None  # 이전 반려자 정보 클리어(AC③ 새 사이클)
+    assert result.resolution_note is None
+    assert result.resolved_at is None
+
+
+@pytest.mark.anyio
+async def test_create_gate_rejected_reopen_still_rejected_if_policy_still_deny():
+    """조직 정책이 여전히 deny면 재오픈해도 다시 rejected — 이건 결함이 아니라 정확한
+    동작이다(사람이 반려한 게 아니라 정책이 여전히 막고 있는 것). 결정 이력은 그래도 남는다."""
+    gate = _rejected_gate()
+    result, _ = await _create_gate_against_rejected(gate, "deny")
+
+    assert result.status == "rejected"
+    assert result.neutral_facts["decision_history"]  # 재평가 사이클 자체는 열렸다(이력 추가)
+
+
+@pytest.mark.anyio
+async def test_create_gate_rejected_reopen_preserves_decision_history():
+    """AC④ — 이전 반려(누가·언제·왜)가 재오픈 후에도 사라지지 않는다."""
+    gate = _rejected_gate()
+    result, _ = await _create_gate_against_rejected(gate, "ask", neutral_facts={"ci_result": "pass"})
+
+    history = result.neutral_facts["decision_history"]
+    assert len(history) == 1
+    entry = history[0]
+    assert entry["status"] == "rejected"
+    assert entry["resolver_id"] == str(gate.resolver_id) or entry["resolver_id"] is not None
+    assert entry["resolution_note"] == "요구사항 불충분 — 다시 정리해서 올려주세요"
+    assert entry["neutral_facts"] == {"ci_result": "fail", "pr_result": "pass"}
+    # 새 평가 facts도 남아있다(이력에 밀려 사라지지 않음).
+    assert result.neutral_facts["ci_result"] == "pass"
+
+
+@pytest.mark.anyio
+async def test_create_gate_rejected_reopen_appends_to_existing_history():
+    """반려가 두 번째 이상이어도(이미 decision_history가 있는 상태) 이전 이력을 덮어쓰지
+    않고 append한다."""
+    gate = _rejected_gate(neutral_facts={
+        "ci_result": "fail",
+        "decision_history": [{"status": "rejected", "resolver_id": None, "resolved_at": None,
+                               "resolution_note": "1차 반려", "neutral_facts": {}}],
+    })
+    result, _ = await _create_gate_against_rejected(gate, "ask")
+
+    history = result.neutral_facts["decision_history"]
+    assert len(history) == 2
+    assert history[0]["resolution_note"] == "1차 반려"
+    assert history[1]["resolution_note"] == "요구사항 불충분 — 다시 정리해서 올려주세요"
+
+
+@pytest.mark.anyio
+async def test_create_gate_rejected_reopen_notifies_when_pending():
+    """AC③ — 재오픈이 pending이면 사람 인박스에 다시 뜨도록 알림이 나간다."""
+    from app.services.gate_service import create_gate
+
+    gate = _rejected_gate()
+    session = AsyncMock()
+    existing_r = MagicMock()
+    existing_r.scalar_one_or_none.return_value = gate
+    session.execute = AsyncMock(return_value=existing_r)
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+
+    with patch("app.services.gate_service.resolve_disposition", new_callable=AsyncMock) as mock_disp, \
+         patch("app.services.gate_service._resolve_gate_notification_targets",
+               new_callable=AsyncMock) as mock_targets, \
+         patch("app.services.notification_dispatch.dispatch_notification",
+               new_callable=AsyncMock) as mock_dispatch:
+        mock_disp.return_value = ("ask", "system_default")
+        mock_targets.return_value = [uuid.uuid4()]
+        await create_gate(session, ORG_ID, STORY_ID, "story", "merge", MEMBER_ID, ROLE_ID)
+        mock_dispatch.assert_awaited_once()
+        assert mock_dispatch.call_args.kwargs["event_type"] == "gate.pending_approval"
+
+
+@pytest.mark.anyio
+async def test_create_gate_approved_does_not_reopen():
+    """AC⑤⑥ — approved는 재오픈 대상이 아니다(이미 landed 작업의 재보고는 무해·불변 유지).
+    되면 안 되는 경우를 명시적으로 고정 — 한쪽만 보면 '항상 재오픈'도 통과하는 회귀를 막는다."""
+    from app.services.gate_service import create_gate
+
+    gate = _rejected_gate(status="approved")
+    session = AsyncMock()
+    existing_r = MagicMock()
+    existing_r.scalar_one_or_none.return_value = gate
+    session.execute = AsyncMock(return_value=existing_r)
+
+    with patch("app.services.gate_service.resolve_disposition", new_callable=AsyncMock) as mock_disp:
+        result = await create_gate(session, ORG_ID, STORY_ID, "story", "merge", MEMBER_ID, ROLE_ID)
+        mock_disp.assert_not_called()  # 재평가 자체가 안 일어난다 — approved는 그대로.
+
+    assert result is gate
+    assert result.status == "approved"
+    assert "decision_history" not in (gate.neutral_facts or {})
+
+
+@pytest.mark.anyio
+async def test_create_gate_voided_does_not_reopen():
+    """AC⑤⑥ — voided도 재오픈 대상이 아니다(void=admin이 "잘못 생성됐다"고 무효화한 것이라
+    reject와 의미가 다르다 — 이 스토리 스코프에서는 자동 재오픈 대상에서 제외)."""
+    from app.services.gate_service import create_gate
+
+    gate = _rejected_gate(status="voided")
+    session = AsyncMock()
+    existing_r = MagicMock()
+    existing_r.scalar_one_or_none.return_value = gate
+    session.execute = AsyncMock(return_value=existing_r)
+
+    with patch("app.services.gate_service.resolve_disposition", new_callable=AsyncMock) as mock_disp:
+        result = await create_gate(session, ORG_ID, STORY_ID, "story", "merge", MEMBER_ID, ROLE_ID)
+        mock_disp.assert_not_called()
+
+    assert result is gate
+    assert result.status == "voided"
+
+
+@pytest.mark.anyio
+async def test_create_gate_pending_still_returns_as_is():
+    """무회귀 — pending(터미널 아님)은 원래 관례 그대로 그냥 반환(재오픈 로직 무접촉)."""
+    from app.services.gate_service import create_gate
+
+    gate = _rejected_gate(status="pending")
+    session = AsyncMock()
+    existing_r = MagicMock()
+    existing_r.scalar_one_or_none.return_value = gate
+    session.execute = AsyncMock(return_value=existing_r)
+
+    with patch("app.services.gate_service.resolve_disposition", new_callable=AsyncMock) as mock_disp:
+        result = await create_gate(session, ORG_ID, STORY_ID, "story", "merge", MEMBER_ID, ROLE_ID)
+        mock_disp.assert_not_called()
+
+    assert result is gate
+
+
+@pytest.mark.anyio
+async def test_create_gate_auto_passed_still_returns_as_is():
+    """무회귀 — auto_passed(모델 docstring상 불변)도 재오픈 로직 무접촉."""
+    from app.services.gate_service import create_gate
+
+    gate = _rejected_gate(status="auto_passed")
+    session = AsyncMock()
+    existing_r = MagicMock()
+    existing_r.scalar_one_or_none.return_value = gate
+    session.execute = AsyncMock(return_value=existing_r)
+
+    with patch("app.services.gate_service.resolve_disposition", new_callable=AsyncMock) as mock_disp:
+        result = await create_gate(session, ORG_ID, STORY_ID, "story", "merge", MEMBER_ID, ROLE_ID)
+        mock_disp.assert_not_called()
+
+    assert result is gate
+
+
 # ── transition_gate 상태기계 테스트 ───────────────────────────────────────────
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- story #2150(P1, prod에 살아있는 결함): `gate_service.create_gate()`의 멱등 조회에 status 필터가 없어, 반려된 게이트가 재제출 시 그대로 반환됨 → `merge_verdict_gate.py`의 `gate_status=="rejected" → BLOCK`이 영구 발동. 반려는 게이트의 정상 경로인데 "한 번 쓰고 버리는 스위치"가 되던 결함.

**AC1(먼저 확認, 착수 전 필수)**: `void_gate`/`override_gate`/`hold_gate` 전부 `is_valid_transition()`의 `_VALID_TRANSITIONS`(코드, docstring 아님)로 `status=="pending"`을 강제 — rejected 게이트에 대한 기존 복구 경로는 **어디에도 없음**을 확認. 심각도/처방 변경 없음(복구 불가가 맞았음).

**AC2(재현 먼저)**: 신규 테스트 5개를 fix 적용 전 코드(stash)로 실행해 RED 확認 → fix 적용 후 GREEN 재확認(커밋 메시지에 재현 절차 기록).

**Fix**: `create_gate()` 멱등 조회가 기존 게이트를 찾았을 때 `status=="rejected"`면 같은 row를 재사용해 재오픈(`_reopen_rejected_gate`) — 이전 결정(resolver_id/resolved_at/resolution_note/neutral_facts)을 `neutral_facts.decision_history`에 append(AC4 감사축 보존)하고, 현재 org/member/role 정책으로 disposition을 다시 계산. 정책이 여전히 deny면 다시 rejected(정확한 동작 — 정책이 안 바뀐 것), ask/allow_auto면 pending/auto_passed로 새 사이클이 열리고 재알림(AC3).

**AC5(approved/voided 개별 판단, PR #1998 그대로 베끼지 않음)**:
- `approved` — 재오픈 안 함. 이미 landed 작업의 재보고는 무해(재오픈이 오히려 확정된 승인을 흔드는 쪽이 위험).
- `voided` — 재오픈 안 함. void는 "이 게이트가 애초에 잘못 생성됐다"는 admin의 명시 무효화(S30)라 reject("평가했고 아니라고 했다")와 의미가 다름 — 이 스토리 스코프 밖의 별도 판단 지점.

`app/models/gate.py` docstring도 갱신 — "rejected→불변"은 resolver/admin 액션 축(`is_valid_transition`)에서만 참이고, `create_gate()`의 재제출 축은 별개임을 명시(선언-실제 불일치 방지).

## Test plan
- [x] `pytest tests/test_e_cage_referee_p3_gate_object.py` — 35 tests (신규 9개: reopen to pending/still-deny/history 보존/history append/알림 + approved·voided·pending·auto_passed 무회귀)
- [x] 신규 5개 테스트 fix 적용 전 코드로 RED 확認(stash) → GREEN 재확認
- [x] `pytest tests/test_merge_verdict_gate.py tests/test_1968_gate_project_id_threading.py tests/test_edg_doc_gate_inbox.py tests/test_edg_s2_config_governance.py tests/test_gate_can_approve_48f064e5.py tests/test_e_loop_ledger_s5_decision_gate.py tests/test_a2a_sa3_link_gate_to_task_realdb.py` — 무회귀
- [x] 전체 스위트(`-k "not realdb"`) — 3922 passed, pre-existing 무관 실패 7건(MCP tooling)