### PR TITLE
chore(#2146): ee_pricing fork already stable — findings + regression guard (not a recurring debt)

### DIFF
--- a/.github/workflows/ee-pricing-fork-guard.yml
+++ b/.github/workflows/ee-pricing-fork-guard.yml
@@ -1,0 +1,46 @@
+name: ee_pricing Fork Guard
+
+# story #2146: main/develop이 4개 파일(0146/0147/0162/0163)에서 이미 안정적으로 분기해
+# 있다(git 실측 — merge-base 이후 develop 쪽 diff 0, main만 삭제/재부모) — 매 승격마다
+# "수술"이 필요한 부채가 아니라, 이미 해소된 상태다. 이 워크플로우는 그 상태를 "유지"만
+# 감시한다: develop 쪽 PR이 이 4개 파일 중 하나라도 건드리면, 다음 develop→main 승격이
+# 더 이상 clean하게 자동 해소되지 않을 수 있다는 것을 **PR 시점에** 알린다.
+#
+# ADVISORY by design(sid-link-check.yml과 동형) — 모든 경로가 exit 0. required check로
+# 절대 추가하지 않는다. ⛔ 이 가드가 못 잡는 것: develop이 이 4개 파일과 무관한 새 ee_pricing
+# 리비전을 추가하는 경우(그 신규 파일 개별로는 "main엔 없음"이 반복될 뿐 이 가드로 안 잡힘) —
+# backend/scripts/check_ee_pricing_promotion_fork.sh로 승격 착수 시 전체를 별도 확認할 것.
+
+on:
+  pull_request:
+    branches: [develop]
+
+jobs:
+  ee-pricing-fork-guard:
+    name: ee_pricing fork stability — advisory
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for edits to the fork-sensitive files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          WATCHED_FILES=(
+            "backend/alembic/versions/0146_pricing_versions.py"
+            "backend/alembic/versions/0147_pricing_versions_live_seed.py"
+            "backend/alembic/versions/0162_merge_ee_pricing_core_heads.py"
+            "backend/alembic/versions/0163_strip_stale_runtime_note_from_role_behaviors.py"
+          )
+          CHANGED="$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" -- "${WATCHED_FILES[@]}")"
+          if [ -n "${CHANGED}" ]; then
+            echo "::warning title=ee_pricing fork-sensitive file changed::This PR edits a file that main and develop currently keep in a stable, auto-resolving fork (story #2146): $(echo "${CHANGED}" | tr '\n' ' '). Until now, develop->main promotions merge these files cleanly ONLY because develop never touches them since their last resolution — editing one breaks that and the next promotion will likely need manual reconciliation. Run backend/scripts/check_ee_pricing_promotion_fork.sh before the next promotion. (advisory — does not block merge)"
+          else
+            echo "No changes to the ee_pricing fork-sensitive files — promotion fork stability unaffected."
+          fi

--- a/backend/scripts/check_ee_pricing_promotion_fork.sh
+++ b/backend/scripts/check_ee_pricing_promotion_fork.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# story #2146: develop→main 승격 준비를 "시작하는 시점"에 ee_pricing 마이그 포크 상태를
+# 즉시 보여준다 — 지금까지는 CI 실패(Main Alembic preflight)나 `git rm` 실패로 사후에만
+# 드러났다(AC2).
+#
+# 근본 배경(2026-07-23 실측, PR #2426/#2441 두 승격 비교로 확認):
+#   main 은 ee_pricing 전용 마이그 3개(0146/0147/0162)를 갖지 않고, 공유 이름 파일 0163 도
+#   main 쪽이 down_revision 을 0161 로 재부모한 다른 내용이다(story bda4beac). develop 은
+#   이 4개 파일을 계속 그대로 들고 있다.
+#
+#   git 의 3-way merge 는 "merge-base 이후 한쪽만 건드리고 반대쪽은 무변경"인 파일을 충돌
+#   없이 자동 해소한다 — main 쪽만 삭제/재부모했고 develop 쪽이 그 이후 이 4개 파일을 전혀
+#   안 건드렸다면, 다음 승격도 별도 개입 없이 clean 하게 같은 결과로 떨어진다. 이건 "운"이
+#   아니라 git 의 결정적 동작이다 — 단, **develop 이 이 4개 파일 중 하나라도 다시 건드리면
+#   그 즉시 깨진다.** 이 스크립트는 그 조건이 지금 성립하는지를 승격 착수 시점에 확認한다.
+#
+# ⛔ 이 스크립트가 못 잡는 것(AC5):
+#   1. develop 이 이 4개 파일 "자체"는 안 건드리고 0162 뒤에 새 ee_pricing head 커밋(신규
+#      리비전 파일)을 추가하는 경우 — 그 신규 파일은 개별적으로 "main 엔 없음"이 반복될
+#      뿐 이 스크립트로는 안 잡힌다. `git diff --stat <merge-base> <develop> --
+#      backend/alembic/versions/` 전체를 별도로 볼 것.
+#   2. ee_pricing 을 prod(main)로 승격할지 자체는 이 스크립트가 판단하지 않는다 — 그건
+#      정책 결정이고 SSOT 문서에 못박아야 할 사안이다(story #2146 AC1, 아직 미결).
+#
+# Usage: backend/scripts/check_ee_pricing_promotion_fork.sh [main_ref] [develop_ref]
+#   기본값: origin/main / origin/develop
+set -euo pipefail
+
+MAIN_REF="${1:-origin/main}"
+DEVELOP_REF="${2:-origin/develop}"
+
+EE_ONLY_FILES=(
+  "backend/alembic/versions/0146_pricing_versions.py"
+  "backend/alembic/versions/0147_pricing_versions_live_seed.py"
+  "backend/alembic/versions/0162_merge_ee_pricing_core_heads.py"
+)
+SHARED_FORK_FILE="backend/alembic/versions/0163_strip_stale_runtime_note_from_role_behaviors.py"
+
+MB="$(git merge-base "${MAIN_REF}" "${DEVELOP_REF}")"
+
+echo "=== E-ARCH ee_pricing 승격 포크 체크 (story #2146) ==="
+echo "main:        ${MAIN_REF}"
+echo "develop:     ${DEVELOP_REF}"
+echo "merge-base:  ${MB} ($(git log -1 --format='%h %s' "${MB}"))"
+echo
+
+SAFE=1
+
+echo "-- ee 전용 마이그 파일 (0146/0147/0162 — main엔 존재 자체가 없어야 정상) --"
+for f in "${EE_ONLY_FILES[@]}"; do
+  dev_diff="$(git diff --stat "${MB}" "${DEVELOP_REF}" -- "${f}")"
+  if [ -z "${dev_diff}" ]; then
+    echo "  OK   ${f} — develop 무변경(merge-base 이후) → clean 유지 예상"
+  else
+    echo "  ⚠️  ${f} — develop 이 merge-base 이후 이 파일을 건드렸다. clean-merge 보장 깨짐 — 수동 확認 필요"
+    SAFE=0
+  fi
+done
+
+echo
+echo "-- 공유 이름 포크 파일 (0163 — 양쪽 다 존재하되 내용이 다르다) --"
+dev_diff="$(git diff --stat "${MB}" "${DEVELOP_REF}" -- "${SHARED_FORK_FILE}")"
+if [ -z "${dev_diff}" ]; then
+  echo "  OK   ${SHARED_FORK_FILE} — develop 무변경 → main 버전(down_revision=0161) 그대로 clean 유지 예상"
+else
+  echo "  ⚠️  ${SHARED_FORK_FILE} — develop 이 이 파일을 건드렸다. main과 진짜 충돌 가능 — 수동 확認 필요"
+  SAFE=0
+fi
+
+echo
+if [ "${SAFE}" -eq 1 ]; then
+  echo "⇒ 이번 승격은 이 4개 파일 축에서는 안전(clean merge 예상)."
+else
+  echo "⇒ ⛔ 이번 승격은 수동 개입이 필요할 수 있다 — 위 ⚠️ 표시된 파일을 승격 전에 직접 검토할 것."
+fi
+echo "⛔ ee_pricing 자체를 prod로 승격할지는 여전히 미결(story #2146 AC1) — 이 스크립트는 그 판단을 내리지 않는다."


### PR DESCRIPTION
## Summary (정정판 — 오르테가군 재프레임 반영)
원래 story #2146은 "매 승격마다 ee_pricing 마이그 수술을 반복한다"는 전제였다. **AC3 git 실측 결과 그 전제가 틀렸다**: main/develop은 0146/0147/0162(main엔 부재)·0163(down_revision 다름) 4개 파일에서 이미 `story bda4beac`로 한 번 해소된 뒤 계속 안정적으로 유지되는 상태였다 — 반복되는 부채가 아니라, "재발 조건 하나"만 감시하면 되는 상태.

**AC3 git 실측(추정 아님)**:
```
merge-base(origin/main, origin/develop) 기준:
  main:    0146/0147/0162 완전 삭제 + 0163 down_revision 0162→0161 재작성 (diff 존재)
  develop: 이 4개 파일 전부 merge-base 이후 diff 0
```
git 표준 "한쪽만 변경·반대쪽 무변경" 자동해소 — 결정론적. **깨지는 조건은 명확**: develop이 이 4개 파일 중 하나라도 다시 건드리면 그 즉시 재발.

**AC1(재해석) — "자동화할 대상"은 정책 결정이 아니라 재발 감시 가드였다**: `.github/workflows/ee-pricing-fork-guard.yml` 추가 — `sid-link-check.yml`과 동형(advisory, 모든 경로 exit 0, 절대 required check 아님). develop 타깃 PR이 이 4개 파일을 건드리면 PR 시점에 `::warning::`으로 즉시 알림.

**AC2**: `backend/scripts/check_ee_pricing_promotion_fork.sh` — 승격 착수 시점에 수동으로 전체 상태 재확認용(실 refs 검증 완료).

**AC4**: PR #1886(MERGED)은 dev/EE DB 물리상태 stamp 문제로 근본 다름 — 별개 확定.

**AC5**: 가드가 못 잡는 것(develop이 무관한 신규 ee_pricing 리비전을 추가하는 경우) 워크플로우/스크립트 docstring 양쪽에 명시.

스토리 제목·본문도 "부채" 규정을 정정해 갱신함(틀린 이름이 남으면 다음 사람이 없는 문제를 또 판다).

## Test plan
- [x] `sh -n backend/scripts/check_ee_pricing_promotion_fork.sh` + 실 refs 실행 확認(이전 커밋)
- [x] `.github/workflows/ee-pricing-fork-guard.yml` YAML 파싱 확認(pyyaml)
- [x] sid-link-check.yml과 패턴 동형 확認(advisory·non-blocking·no required-check)