### PR TITLE
chore(#2155): remove dead GITHUB_CLIENT_ID/_SECRET wiring from deploy_backend.sh

### DIFF
--- a/backend/scripts/deploy_backend.sh
+++ b/backend/scripts/deploy_backend.sh
@@ -104,9 +104,6 @@ CORS_ORIGINS="http://localhost:3000,http://localhost:3108,${FRONTEND_URL}"
 EVENTBUS_ENABLED="${EVENTBUS_ENABLED:-true}"
 MEMBER_SSOT_RESOLVER_SHADOW="${MEMBER_SSOT_RESOLVER_SHADOW:-true}"
 MEMBER_SSOT_APIKEY_CUT="${MEMBER_SSOT_APIKEY_CUT:-true}"
-# ⚠️ GitHub OAuth는 현재 _DEV 앱만 존재(prod 앱 미생성) → dev/prod 모두 _DEV 시크릿 참조.
-#   prod GitHub 앱 생성 시 GITHUB_SECRET_SUFFIX=PROD로 override.
-GITHUB_SECRET_SUFFIX="${GITHUB_SECRET_SUFFIX:-DEV}"
 
 # ── 결함③ fix: full env. Secret Manager 시크릿 (값에 콤마 없어 콤마 구분 OK). ──
 SECRETS_SPEC="DATABASE_URL=${DB_SECRET_NAME}:latest"
@@ -114,8 +111,9 @@ SECRETS_SPEC="${SECRETS_SPEC},JWT_SECRET=JWT_SECRET:latest"
 # ⚠️ SUPABASE 시크릿은 dead(backend/app 0 functional refs·JWT_SECRET 우선) → 미주입(S1 결정 유지).
 SECRETS_SPEC="${SECRETS_SPEC},GOOGLE_CLIENT_ID=GOOGLE_CLIENT_ID:latest"
 SECRETS_SPEC="${SECRETS_SPEC},GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest"
-SECRETS_SPEC="${SECRETS_SPEC},GITHUB_CLIENT_ID=GITHUB_CLIENT_ID_${GITHUB_SECRET_SUFFIX}:latest"
-SECRETS_SPEC="${SECRETS_SPEC},GITHUB_CLIENT_SECRET=GITHUB_CLIENT_SECRET_${GITHUB_SECRET_SUFFIX}:latest"
+# story #2155(2026-07-23): GitHub 로그인 제거로 GITHUB_CLIENT_ID/_SECRET(+GITHUB_SECRET_SUFFIX)
+# 배선 삭제 — settings.github_client_id/github_client_secret 자체가 코드에 더 이상 없다(#2436).
+# 라이브 바인딩 제거는 이 스크립트 편집과 무관하게 별도 gcloud --remove-secrets 필요(#2145).
 SECRETS_SPEC="${SECRETS_SPEC},RESEND_API_KEY=RESEND_API_KEY:latest"
 SECRETS_SPEC="${SECRETS_SPEC},EMAIL_FROM=EMAIL_FROM:latest"
 # story #2071/#2072(critical, 2026-07-21): 이 시크릿이 dev/prod 어디에도 배선 안 돼 있어

--- a/backend/tests/test_deploy_env.py
+++ b/backend/tests/test_deploy_env.py
@@ -158,11 +158,17 @@ def test_dockerfile_uv_sync_uses_frozen():
 # ── deploy_backend.sh 4결함 fix (cutover 첫 prod 실행서 노출) ────────────────────
 
 def test_deploy_full_env_secrets():
-    """결함③: full env — DATABASE_URL/JWT 외 GOOGLE/GITHUB/RESEND/EMAIL 시크릿 포함."""
+    """결함③: full env — DATABASE_URL/JWT 외 GOOGLE/RESEND/EMAIL 시크릿 포함.
+
+    story #2155(2026-07-23): GitHub 로그인 제거로 GITHUB_CLIENT_ID/_SECRET 배선도 함께
+    삭제됐다(settings.github_client_id/github_client_secret 자체가 코드에 없음, #2436) —
+    더 이상 이 목록에 있으면 안 된다(회귀가드로 부재를 고정)."""
     s = _resolve(_DEPLOY, "dev")["SECRETS_SPEC"]
     for name in ("DATABASE_URL=", "JWT_SECRET=", "GOOGLE_CLIENT_ID=", "GOOGLE_CLIENT_SECRET=",
-                 "GITHUB_CLIENT_ID=", "RESEND_API_KEY=", "EMAIL_FROM="):
+                 "RESEND_API_KEY=", "EMAIL_FROM="):
         assert name in s, f"{name} 누락 (결함③ full env 미충족)"
+    assert "GITHUB_CLIENT_ID=" not in s, "GitHub 로그인 제거(#2155) 후에도 배선이 남아있음"
+    assert "GITHUB_CLIENT_SECRET=" not in s, "GitHub 로그인 제거(#2155) 후에도 배선이 남아있음"
 
 
 def test_deploy_cors_custom_delimiter_preserves_commas():


### PR DESCRIPTION
## Summary
- story #2155 잔여(오르테가 라이브 실측): prod backend-00235에 `GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET`가 여전히 바인딩돼 있음(← `GITHUB_CLIENT_ID_DEV`/`GITHUB_CLIENT_SECRET_DEV`) — #2436이 그 값을 읽는 코드는 지웠지만 배선은 그대로였다.
- `deploy_backend.sh:117-118` 두 줄 + 이제 완전히 미사용이 된 `GITHUB_SECRET_SUFFIX`(108-109행) 제거. 그 변수의 유일한 소비처가 이 두 줄뿐인 것 grep으로 확認.
- ⚠️**이 PR만으로 live 바인딩이 사라지지 않는다** — `cloudbuild.yaml`은 `--set-secrets`를 안 써서 기존 바인딩을 그대로 물려주고(299·328행 주석 명시), `deploy_backend.sh` 자체는 GitHub Actions/cloudbuild 어디서도 호출 안 되는 **수동 전용 스크립트**다. 실제 제거는 `gcloud run services update --remove-secrets=GITHUB_CLIENT_ID,GITHUB_CLIENT_SECRET`(dev/prod 둘 다) — 오르테가 gcloud 몫, 순서상 이 PR 다음 단계.
- 순서: ① (이 PR) 수동 경로 배선 정리 → ② 오르테가 `--remove-secrets` 실제 제거 + 리비전 실측 → ③ Secret Manager `GITHUB_CLIENT_ID/_SECRET(+_DEV)` 4종 삭제 → #2145 종결.

## Test plan
- [x] `bash -n backend/scripts/deploy_backend.sh` + `DRY_RUN=1 ... bash deploy_backend.sh dev` — SECRETS_SPEC에서 GITHUB_CLIENT_* 완전히 사라진 것 확認
- [x] `pytest tests/test_deploy_env.py tests/test_deploy_backend_redis_secret_conflict.py tests/test_cloudbuild_migrate_wiring.py` — 36 passed. `test_deploy_full_env_secrets`를 부재-회귀가드로 갱신(이전엔 존재를 assert, 이제 부재를 assert)