### PR TITLE
fix(#2139/#2132): eliminate dead publish_event() path, revive presence/working delivery

### DIFF
--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -160,7 +160,7 @@ async def _mark_agent_disconnected(
             # SSE 발행(FE 폴링 대체·best-effort). working 비운 대화에 push 안 하면 "...typing" 영구 stale(QA HIGH).
             if remaining is None and org_id:
                 from app.services.presence_events import emit_conversation_working, emit_presence
-                emit_presence(org_id)
+                await emit_presence(org_id)
                 for _conv in _cleared_convs:
                     await emit_conversation_working(org_id, _conv)
     except Exception:
@@ -449,7 +449,7 @@ async def agent_stream(
             await presence_online.mark_online(agent_id)
             # R2(da9d1781): 연결 online 진입 → presence SSE 발행(FE 3s 폴링 대체·best-effort).
             from app.services.presence_events import emit_presence
-            emit_presence(org_id_str)
+            await emit_presence(org_id_str)
 
             yield "event: heartbeat\ndata: {}\n\n"
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1501,18 +1501,11 @@ async def set_default_project(
     if member is None:
         raise HTTPException(status_code=404, detail="Member not found")
 
-    old_default = member.default_project_id
     member.default_project_id = body.project_id
     await db.flush()
-
-    from app.routers.events import publish_event
-    publish_event(str(org_id), "member.default_project_changed", {
-        "member_id": str(member_id),
-        "org_id": str(org_id),
-        "old_default_project_id": str(old_default) if old_default else None,
-        "new_default_project_id": str(body.project_id),
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-    })
+    # story #2132(2026-07-23): member.default_project_changed의 publish_event() 호출 제거 —
+    # FE 소비처 0(설계 doc `story-2139-2132-publish-event-unification-design` §1) + 그
+    # 죽은 org-level fanout(`_subscribers`) 자체가 삭제됨. 복구 대상 아님(신기능 스코프 밖).
     await db.commit()
 
     resolved, ambiguous, accessible_ids = await _resolve_project_default(db, member_id, org_id)

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -22,7 +22,7 @@ from app.models.project import OrgMember
 from app.models.team import AgentMessageAllowlist, TeamMember
 from app.models.agent_deployment import AgentAuditLog
 from app.models.webhook_config import WebhookConfig
-from app.routers.events import _push_to_agent, publish_event
+from app.routers.events import _push_to_agent
 from app.schemas.attachment import validate_attachment_url
 from app.services import chat_presence
 from app.services.agent_runtime import supports_deterministic_command
@@ -492,7 +492,7 @@ async def _dispatch_conversation_event(
     if _set_working_any:
         from app.services.presence_events import emit_conversation_working, emit_presence
         await emit_conversation_working(org_id, conversation.id)
-        emit_presence(org_id)
+        await emit_presence(org_id)
     # per-recipient dense seq 발급 (agent recipient만)
     for pid_str, event in events_to_push:
         if member_type_map.get(event.recipient_id, "human") == "agent":
@@ -1658,7 +1658,7 @@ async def send_message(
     # R2(da9d1781): working clear → conversation.working + presence SSE 발행(폴링 대체·best-effort).
     from app.services.presence_events import emit_conversation_working, emit_presence
     await emit_conversation_working(org_id, conversation_id)
-    emit_presence(org_id)
+    await emit_presence(org_id)
 
     # cross-org 차단: mentioned_ids를 현재 org 소속 member로 일괄 필터링 (QA B1).
     # E-MEMBER-SSOT Phase 0: 저장·DM포크·group 멘션 발송 모든 경로에 org 필터를 한 번 적용.
@@ -1972,19 +1972,20 @@ async def send_message(
     # commit 완료 후 SSE push — Event가 DB에 커밋된 상태에서 push해야 race condition 없음
     for pid_str, sse_payload in pending_sse_pushes:
         _push_to_agent(pid_str, sse_payload)
-    # story #2090 정정(2026-07-22, 까심 발견 — 2026-07-21 PR #2375의 착오 정정): publish_event()의
-    # org _subscribers fanout은 영구 죽은 레지스트리(story #2059/#2067과 동일 근본)라 실제
-    # SSE 전달 경로가 아니다 — canonical event_type 기록용(L1 activity_events 캡처)으로만 유지.
-    # 실 전달은 위 pending_sse_pushes push 루프(commit 후, 1982행 부근)가 이미 담당한다:
-    # `_dispatch_conversation_event`가 conversation participant 전원에게, `_dispatch_mention_
-    # events`가 멘션 대상(참가자 여부 무관) 전원에게 각각 event_type을 정확히 나눠(message_created
-    # vs conversation:mention) push하므로 별도 함수로 다시 push할 필요가 없다 — PR #2375가 이
-    # 사실을 놓치고 `_push_conversation_message_created()`로 동일 pid에 conversation.message_created를
+    # story #2090 정정(2026-07-22, 까심 발견 — 2026-07-21 PR #2375의 착오 정정) + #2132(2026-07-23
+    # 근본수정): publish_event()의 org _subscribers fanout은 영구 죽은 레지스트리(story #2059/
+    # #2067과 동일 근본)라 실제 SSE 전달 경로가 아니었다 — 그 함수 자체를 삭제했다. L1
+    # activity_events 캡처는 이 함수 호출과 무관하게 위쪽 `Event(...)` DB row 생성(:474/:477,
+    # event_type="conversation.message_created")으로 이미 이뤄지므로 무영향. 실 전달은 위
+    # pending_sse_pushes push 루프(commit 후)가 담당한다: `_dispatch_conversation_event`가
+    # conversation participant 전원에게, `_dispatch_mention_events`가 멘션 대상(참가자 여부
+    # 무관) 전원에게 각각 event_type을 정확히 나눠(message_created vs conversation:mention)
+    # push하므로 별도 함수로 다시 push할 필요가 없다 — PR #2375가 이 사실을 놓치고
+    # `_push_conversation_message_created()`로 동일 pid에 conversation.message_created를
     # 중복 발송했고(참가자 기준 순수 중복), 게다가 pending_sse_pushes 전체를 pid 기준 dedup하면서
     # 멘션-only 비참가자에게도 message_created를 함께 보내 use-chat-unread-total.ts의 "SSE는 실
     # 참여자에게만 전달되므로 +1 정확" 전제를 깨는 phantom unread 증분 부작용까지 냈다(비참가자는
     # /api/conversations/unread-count 서버 truth엔 안 잡히므로 배지만 어긋남). 그 함수 자체를 삭제.
-    publish_event(str(org_id), "conversation.message_created", _msg_payload(msg, sender))  # canonical (S-COMM-12) — L1 activity_events 캡처용 유지
 
     # ws_chat WebSocket 브로드캐스트 — agent 참가자 room에 실시간 전달 (conv.type/title 무관)
     try:

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -35,48 +35,6 @@ from app.services.member_resolver import assert_caller_is_member, resolve_member
 
 router = APIRouter(prefix="/api/v2/events", tags=["events", "Organization"])
 
-# ─── In-process event bus (C-S6: memo SSE) ────────────────────────────────────
-# org_id → set of queues (one per connected SSE client)
-_subscribers: dict[str, set[asyncio.Queue[dict]]] = defaultdict(set)
-
-
-def publish_event(org_id: str, event_type: str, data: dict, _from_listener: bool = False) -> None:
-    """다른 라우터에서 이벤트를 발행할 때 호출.
-
-    _from_listener=True: LISTEN 수신기에서 호출 시 pg_notify 재발행 금지 (무한 루프 차단).
-
-    ⚠️story #2059/#2067(까심군 라이브 실측 확定, 2026-07-21): 이 함수가 쓰는 `_subscribers[org_id]`
-    레지스트리에 `.add()`하는 코드가 저장소 전체 0곳이다 — 즉 **이 org-level fanout은 실제로
-    아무 브라우저/에이전트 연결에도 닿지 않는 영구 죽은 코드다**(pg_notify 크로스 인스턴스 릴레이도
-    결국 이 함수를 다시 부를 뿐이라 동일하게 죽어 있다). FE/에이전트가 실제로 붙는 경로는
-    `_agent_connections[member_id]`(`_push_to_agent()`로만 채워짐)뿐이다. 이 함수를 호출하는 것만으로
-    "실시간 전달했다"고 가정하지 마라 — 실시간 SSE 전달이 실제로 필요하면 `_push_to_agent()`를
-    직접 호출해야 한다(선례: `trust_pipeline._maybe_emit`·`story_status_events.emit_story_status_changed`
-    — `project_accessible_member_ids()`로 수신자 해소 후 개별 push). 이 함수 자체를 항상-fanout으로
-    바꾸지 않은 이유: 호출부마다 올바른 수신자 스코프가 다르다(project-scoped story/goal 이벤트 vs
-    conversation 참가자 vs org-wide presence) — 제네릭하게 못 바꾸고 호출부별 개별 판단이 필요하다.
-    """
-    payload = {"type": event_type, **data}
-    dead: list[asyncio.Queue] = []
-    for q in _subscribers.get(org_id, set()):
-        try:
-            q.put_nowait(dict(payload))  # copy per subscriber — shared dict mutation 방지
-        except asyncio.QueueFull:
-            dead.append(q)
-    for q in dead:
-        _subscribers[org_id].discard(q)
-    if not _from_listener:
-        # prod 커넥션 누수 근본fix(2026-07-08): 참조 미보관 create_task는 GC가 pg_notify()의
-        # async with async_session_factory() 도중 태스크를 조기수거할 수 있다(공식 문서 경고) —
-        # fire_and_forget이 강한 참조를 보관해 이를 막는다.
-        # E-ARCH S2(story #2078): pg_notify() 직접 호출 → event_broker.publish()로 — PG NOTIFY는
-        # 그대로(내부에서 동일 호출) + event_broker_redis_dual_publish_enabled 시 Redis shadow
-        # 추가 발행(기본 off, 무회귀). fire_and_forget 감싸는 방식은 무변경.
-        from app.services.event_broker import event_broker
-        from app.services.pg_pubsub import fire_and_forget
-        fire_and_forget(event_broker.publish("org", org_id, event_type, data))
-
-
 # ─── Agent connection registry (S2/S3: 에이전트별 SSE) ───────────────────────
 # member_id (str) → set[Queue] — 다중 연결 지원, 해제 시 해당 queue만 제거
 _agent_connections: dict[str, set[asyncio.Queue[dict]]] = defaultdict(set)
@@ -162,12 +120,48 @@ def _push_to_agent(member_id: str, payload: dict, _from_listener: bool = False) 
         for q in dead:
             queues.discard(q)
     if not _from_listener:
-        # prod 커넥션 누수 근본fix(2026-07-08) — publish_event()와 동형(fire_and_forget 참조 보관).
-        # E-ARCH S2(story #2078): pg_notify() 직접 호출 → event_broker.publish()로(publish_event()와 동형 치환).
+        # prod 커넥션 누수 근본fix(2026-07-08) — 참조 미보관 create_task는 GC가 pg_notify()의
+        # async with async_session_factory() 도중 태스크를 조기수거할 수 있다(공식 문서 경고) —
+        # fire_and_forget이 강한 참조를 보관해 이를 막는다.
+        # E-ARCH S2(story #2078): pg_notify() 직접 호출 → event_broker.publish()로 — PG NOTIFY는
+        # 그대로(내부에서 동일 호출) + event_broker_redis_dual_publish_enabled 시 Redis shadow
+        # 추가 발행(기본 off, 무회귀).
         from app.services.event_broker import event_broker
         from app.services.pg_pubsub import fire_and_forget
         fire_and_forget(event_broker.publish("agent", member_id, payload.get("event_type", ""), payload))
     return pushed
+
+
+async def push_to_org_members(
+    org_id: str, event_type: str, data: dict, *, member_ids: set[str] | None = None,
+) -> None:
+    """story #2139/#2132 근본수정 — 예전 `publish_event()`의 org-level fanout은 아무도
+    구독하지 않는 영구 죽은 레지스트리였다(_subscribers.add() 호출처 저장소 전체 0곳,
+    story #2059/#2067/#2132 실측). 실제 브라우저/에이전트 배달 경로는 `_push_to_agent()`
+    (`_agent_connections[member_id]`)뿐이라, org 단위 발행도 결국 이 경로로 개별 push해야
+    실제로 도달한다.
+
+    `member_ids` 미지정(None) 시 org 전체 활성 멤버(`org_members`, human+agent 전부)에게
+    보낸다 — presence 전용(#2139 §3, 오르테가 확定: project로 좁히지 않는다. 호출부 4곳이
+    애초에 project_id를 안 들고 있고, 에이전트는 multi-project·DM은 project 자체가 없어
+    데이터가 org 단위다). `member_ids` 지정 시 그 집합에게만 — conversation.working 전용
+    (참가자만, org 전체 아님 — payload가 conversation 단위라 org로 보내면 새는 것).
+
+    best-effort — caller가 감싼 try/except 전제(presence_events.py 관례)로 자체 예외 전파.
+    자기 세션을 열고 닫아(member_ids=None일 때만) caller의 세션 상태와 무관하게 동작."""
+    ids = member_ids
+    if ids is None:
+        from sqlalchemy import text as _text
+
+        from app.core.database import async_session_factory
+        async with async_session_factory() as session:
+            rows = await session.execute(
+                _text("SELECT id FROM org_members WHERE org_id = :org_id AND deleted_at IS NULL"),
+                {"org_id": org_id},
+            )
+            ids = {str(r[0]) for r in rows.all()}
+    for mid in ids:
+        _push_to_agent(mid, {"event_type": event_type, **data})
 
 
 def _event_to_payload(event: "Event") -> dict:

--- a/backend/app/routers/file_locks.py
+++ b/backend/app/routers/file_locks.py
@@ -15,7 +15,6 @@ from app.dependencies.auth import AuthContext, get_current_user, get_verified_or
 from app.dependencies.database import get_db
 from app.models.file_lock import FileLock
 from app.models.team import TeamMember
-from app.routers.events import publish_event
 from app.services.member_resolver import assert_caller_is_member
 from app.services.webhook_dispatch import fire_webhooks
 
@@ -162,10 +161,9 @@ async def _publish_conflict_event(
         "member_id": str(member_id),
         "conflicts": [c.model_dump(mode="json") for c in conflicts],
     }
-    try:
-        publish_event(str(org_id), "file_conflict", event_data)
-    except Exception:
-        pass
+    # story #2132(2026-07-23): file_conflict의 publish_event() 호출 제거 — FE 소비처 0
+    # (설계 doc §1) + 그 죽은 org-level fanout(`_subscribers`) 자체가 삭제됨. Discord
+    # 웹훅(fire_webhooks, 아래)은 별개 채널이라 무관·그대로 유지.
     try:
         await fire_webhooks(session, org_id, "file_conflict", event_data)
     except Exception:

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -18,7 +18,6 @@ from app.models.team import TeamMember
 from app.repositories.story import StoryRepository
 from app.repositories.story_assignee import StoryAssigneeRepository
 from app.routers.agent_gateway import wake_agent
-from app.routers.events import publish_event
 from app.services.event_seq import assign_recipient_seq
 from app.services import mcp_attachment_upload
 from app.services.asset_registry import DEFAULT_CONTAINER, sync_attachment_assets
@@ -744,12 +743,10 @@ async def bulk_update_stories(
 
     await db.commit()
 
-    # workflow_violation 발화(commit 後·기존 이벤트 타입이라 additive·기존 컨슈머 무영향). 실패는 비차단.
+    # workflow_violation 발화(commit 後). story #2132(2026-07-23): publish_event() 호출 제거 —
+    # FE 소비처 0(설계 doc §1) + 그 죽은 org-level fanout(`_subscribers`) 자체가 삭제됨.
+    # webhook(fire_webhooks, 아래)은 별개 채널이라 무관·그대로 유지.
     for _ev, _notify in violation_dispatch:
-        try:
-            publish_event(str(repo.org_id), "workflow_violation", _ev)
-        except Exception:  # noqa: BLE001
-            pass
         try:
             await fire_webhooks(
                 db, repo.org_id, "workflow_violation", _ev, recipient_member_ids=_notify,
@@ -905,11 +902,11 @@ async def update_story(
         _assignee_notify_ids = {
             m for m in (story.assignee_id, old_assignee_id, actor_id) if m is not None
         }
-        # story #2086(2026-07-21, 까심군 라이브 실측 확定): publish_event()의 org _subscribers
-        # fanout은 .add() 호출이 저장소 전체 0곳인 영구 죽은 레지스트리(story #2059/#2067과
-        # 동일 근본) — "org-wide 의도 유지" 주석은 실제로 아무 SSE 연결에도 안 닿는 상태였다.
+        # story #2086(2026-07-21, 까심군 라이브 실측 확定) + #2132(2026-07-23 근본수정):
+        # publish_event()의 org _subscribers fanout은 .add() 호출이 저장소 전체 0곳인 영구
+        # 죽은 레지스트리였다(story #2059/#2067과 동일 근본) — 이제 그 함수 자체를 삭제했다.
         # story.status_changed(story_status_events.py)와 동형으로 project_accessible_member_ids
-        # 로 수신자 해소 후 _push_to_agent 개별 push — 이게 실제로 SSE 큐에 들어가는 유일 경로.
+        # 로 수신자 해소 후 _push_to_agent 개별 push만이 실제로 SSE 큐에 들어가는 유일 경로.
         #
         # story #2106(2026-07-22, 까심군 #2101 QA 후속): 이 push는 의도적으로 Event row를 안
         # 만드는 순수 transient SSE(#2101의 last_event_id 백필 대상이 아님) — "왜 여기만
@@ -920,7 +917,6 @@ async def update_story(
         # dispatch_notification(human)이 별도로 지고 있다 — 그쪽은 Event-backed(또는 동등한
         # 영속 알림함) 라 배정받은 사람이 그 순간 연결이 끊겨 있어도 놓치지 않는다. 즉 상태축
         # (재조회로 복원)과 알림축(영속 전달 필요)이 분리돼 있고, 이 줄은 전자만 담당한다.
-        publish_event(str(org_id), "story.assignee_changed", event_data)
         try:
             from app.routers.events import _push_to_agent
             from app.services.project_auth import project_accessible_member_ids
@@ -931,7 +927,7 @@ async def update_story(
                 _push_to_agent(str(member_id), dict(sse_payload))
         except Exception:
             logger.warning(
-                "assignee_changed SSE 포워딩 실패(story=%s project=%s) — org publish는 이미 발행됨",
+                "assignee_changed SSE 포워딩 실패(story=%s project=%s)",
                 story.id, story.project_id, exc_info=True,
             )
         try:
@@ -1029,24 +1025,6 @@ async def update_story(
                 await db.flush()
             except Exception:
                 pass
-
-    # P0-05 후속(doc scope-violation-signal-design §1 확定): declared_scope_paths 변경(설정/해제)
-    # 감사 이벤트 — 선언 주체 제한 없음(자기신고 허용)이라 도중 축소/해제의 회피 억지력.
-    if "declared_scope_paths" in data and _story_for_access.declared_scope_paths != story.declared_scope_paths:
-        publish_event(str(repo.org_id), "story.declared_scope_changed", {
-            "story_id": str(id),
-            "project_id": str(story.project_id),
-            "org_id": str(repo.org_id),
-            "old_declared_scope_paths": (
-                json.dumps(_story_for_access.declared_scope_paths)
-                if _story_for_access.declared_scope_paths else None
-            ),
-            "new_declared_scope_paths": (
-                json.dumps(story.declared_scope_paths) if story.declared_scope_paths else None
-            ),
-            "actor_id": str(actor_id) if actor_id else None,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-        })
 
     # S-C2: story_updated — actor가 agent인 경우 기록 (AC2, AC6)
     if actor_id:
@@ -1277,14 +1255,11 @@ async def update_story_status(
                 severity="warn",
             )
             # AC4(동일 패턴): workflow_violation webhook도 관련자(행위자+담당자)만 — 동일 org-wide fan-out
-            # 박멸. publish_event(UI 활동피드)는 org-wide 유지.
+            # 박멸. story #2132(2026-07-23): publish_event() 호출 제거 — FE 소비처 0(설계 doc §1) +
+            # 그 죽은 org-level fanout(`_subscribers`) 자체가 삭제됨.
             _violation_notify_ids = {
                 m for m in (actor_id, story.assignee_id) if m is not None
             }
-            try:
-                publish_event(str(org_id), "workflow_violation", _v_event)
-            except Exception:
-                pass
             try:
                 await fire_webhooks(
                     db, org_id, "workflow_violation", _v_event,

--- a/backend/app/services/event_broker.py
+++ b/backend/app/services/event_broker.py
@@ -432,9 +432,18 @@ async def redis_consume_loop() -> None:
                 event_type = str(payload.get("event_type", ""))
                 data = payload.get("data") or {}
                 try:
-                    from app.routers.events import _push_to_agent, publish_event
+                    from app.routers.events import _push_to_agent
                     if target == "org":
-                        publish_event(target_id, event_type, data, _from_listener=True)
+                        # story #2139/#2132 근본수정: publish_event()/_subscribers 삭제 —
+                        # target="org" 발행 자체가 이제 코드 어디에도 없다(발행 측이 전부
+                        # push_to_org_members()로 개별 "agent" target push로 바뀜). 이 분기가
+                        # 실제로 도달하면 어딘가 옛 발행 경로가 남아있다는 신호라 조용히
+                        # 넘기지 않고 경고로 남긴다.
+                        logger.warning(
+                            "event_broker redis dispatch: unexpected target=org event_type=%s "
+                            "(publish_event was removed in #2139/#2132 — this should be unreachable)",
+                            event_type,
+                        )
                     elif target == "agent":
                         _push_to_agent(target_id, data, _from_listener=True)
                 except Exception as exc:

--- a/backend/app/services/goal_events.py
+++ b/backend/app/services/goal_events.py
@@ -10,10 +10,12 @@ PO/선생님 대조 필요 사항으로 별도 보고.
 
 Story의 5-effect(publish_event·fire_webhooks·process_event·dispatch_notification·
 StoryActivity) 전부를 복제하지 않는다 — 근거(BE design doc §2.2): 이 이벤트의 1차 소비자는
-오르테가(웹훅)이지 특정 assignee 알림이 아니다. v1 스코프 = 3-effect:
-publish_event(항상)·fire_webhooks(오르테가 구독 채널)·dispatch_notification(assignee 있을
-때만, 선택적). process_event(workflow_pipeline 에이전트 라우팅 룰 트리거)는 로드맵 이벤트가
-자동으로 에이전트 워크플로 룰을 발화해야 할 근거가 아직 없어 v1 제외(§2.2)."""
+오르테가(웹훅)이지 특정 assignee 알림이 아니다. v1 스코프 = 2-effect:
+fire_webhooks(오르테가 구독 채널)·dispatch_notification(assignee 있을 때만, 선택적).
+process_event(workflow_pipeline 에이전트 라우팅 룰 트리거)는 로드맵 이벤트가 자동으로
+에이전트 워크플로 룰을 발화해야 할 근거가 아직 없어 v1 제외(§2.2). ⚠️story #2132(2026-07-23):
+publish_event는 그 자체가 삭제됐다(org-level fanout이 영구 죽은 코드였음) — 원래 3-effect
+중 하나가 빠진 것은 이 v1 스코프 축소와 무관, #2132 근본수정의 결과다."""
 from __future__ import annotations
 
 import uuid
@@ -49,14 +51,17 @@ async def _emit(
     없음 — preserve_broadcast로 구제될 여지도 없음). notify_member_id가 None(assignee
     없음 — epic.reordered/removed는 항상 이 케이스)이면 반드시 recipient_member_ids=None
     (게이팅 미적용)으로 넘겨야 오르테가 같은 org-wide 구독 웹훅이 실제로 수신한다.
-    `{notify_member_id} if notify_member_id else set()`(빈 집합)이 이 버그의 근본이었다."""
-    from app.routers.events import publish_event
+    `{notify_member_id} if notify_member_id else set()`(빈 집합)이 이 버그의 근본이었다.
+
+    story #2132(2026-07-23): publish_event() 호출 제거 — 이 함수가 발화하는 epic.* 이벤트는
+    FE 소비처 0(설계 doc `story-2139-2132-publish-event-unification-design` §1) + 그 죽은
+    org-level fanout(`_subscribers`) 자체가 삭제됨. fire_webhooks(오르테가 구독 채널)는
+    별개 채널이라 무관·그대로 유지."""
     from app.services.notification_dispatch import dispatch_notification
     from app.services.webhook_dispatch import fire_webhooks
 
     notify_ids: set[uuid.UUID] | None = {notify_member_id} if notify_member_id else None
 
-    publish_event(str(org_id), event_type, event_data)
     try:
         await fire_webhooks(db, org_id, event_type, event_data, recipient_member_ids=notify_ids)
     except Exception:
@@ -122,7 +127,6 @@ async def emit_goal_reordered(
     """
     if not items:
         return
-    from app.routers.events import publish_event
     from app.services.webhook_dispatch import fire_webhooks
 
     representative = items[0]
@@ -138,9 +142,10 @@ async def emit_goal_reordered(
         }
         for it in items
     ]
-    # publish_event(SSE/감사·항상) + 게이팅된 webhook(지정 수신자만). recipient_member_ids가
-    # 빈 집합이면(해소된 relay-owner 없음) member-bound webhook 전부 drop = 0 배달(no-fiction).
-    publish_event(str(org_id), "epic.reordered", event_data)
+    # story #2132(2026-07-23): publish_event() 호출 제거 — FE 소비처 0(설계 doc §1) + 그 죽은
+    # org-level fanout(`_subscribers`) 자체가 삭제됨. 게이팅된 webhook(지정 수신자만)은 그대로
+    # 유지 — recipient_member_ids가 빈 집합이면(해소된 relay-owner 없음) member-bound webhook
+    # 전부 drop = 0 배달(no-fiction).
     try:
         await fire_webhooks(
             db, org_id, "epic.reordered", event_data,

--- a/backend/app/services/pg_pubsub.py
+++ b/backend/app/services/pg_pubsub.py
@@ -137,9 +137,17 @@ async def _dispatch_received(payload_str: str) -> None:
             pass
 
     try:
-        from app.routers.events import publish_event, _push_to_agent
+        from app.routers.events import _push_to_agent
         if target == "org":
-            publish_event(target_id, event_type, data, _from_listener=True)
+            # story #2139/#2132 근본수정: publish_event()/_subscribers 삭제 — target="org"
+            # 발행 자체가 이제 코드 어디에도 없다(발행 측이 전부 push_to_org_members()로
+            # 개별 "agent" target push로 바뀜). 이 분기가 실제로 도달하면 어딘가 옛 발행
+            # 경로가 남아있다는 신호라 조용히 넘기지 않고 경고로 남긴다.
+            logger.warning(
+                "pg_listen dispatch: unexpected target=org event_type=%s "
+                "(publish_event was removed in #2139/#2132 — this should be unreachable)",
+                event_type,
+            )
         elif target == "agent":
             _push_to_agent(target_id, data, _from_listener=True)
     except Exception as exc:

--- a/backend/app/services/presence_events.py
+++ b/backend/app/services/presence_events.py
@@ -1,11 +1,16 @@
 """R2(da9d1781): 실시간 presence/working SSE 이벤트 발행 — 폴링 대체.
 
-기존 event-stream(events.publish_event·pg_pubsub 멀티인스턴스 backplane) 위에 **이벤트 타입만 추가**:
+기존 event-stream 위에 이벤트 타입만 추가:
 - `conversation.working` — 채팅 typing 인디케이터(FE 1.5s 폴링 `/conversations/{id}/working` 대체)
 - `presence` — 팀 presence 변경 트리거(FE 3s 폴링 `/team-presence` 대체)
 
+story #2139/#2132(2026-07-23) 근본수정: 예전엔 `events.publish_event()`(org-level `_subscribers`
+fanout)만 호출했는데, 그 레지스트리는 아무도 구독하지 않는 영구 죽은 코드였다(`_subscribers.add()`
+호출처 저장소 전체 0곳 — 계측 건강 확認 후 양성대조(story.assignee_changed 14~30ms 도달)와
+대조해 240초간 0건 확認, 관측 실패 아니라 진짜 죽은 경로). 지금은 `events.push_to_org_members()`
+(`_push_to_agent()` 개별 push로 귀결 — 실제 배달 경로, cross-instance 포함)로 교체됐다.
+
 best-effort: 발행 실패가 caller(메시지 dispatch·reply·SSE 연결 lifecycle)를 절대 깨지 않는다(try/except).
-publish_event 는 sync — 동기 발행점(chat_presence transition 등)에서도 호출 가능.
 """
 from __future__ import annotations
 
@@ -15,34 +20,56 @@ logger = logging.getLogger(__name__)
 
 
 async def emit_conversation_working(org_id, conversation_id) -> None:
-    """해당 conversation 의 현재 working member 목록을 push(채팅 typing). FE 가 폴링 없이 이벤트로 갱신.
+    """해당 conversation의 현재 working member 목록을 push(채팅 typing). FE가 폴링 없이 이벤트로 갱신.
 
-    #2120: chat_presence.list_working 이 async(Redis 공유)로 전환돼 이 함수도 async — 호출부는 await.
+    수신자 스코프(#2139 §3, 오르테가 확定): **참가자만** — payload가 conversation 단위라
+    org 전체로 보내면 참가자가 아닌 사람에게도 새는 것이라 conversation.working과
+    presence(org 전체)는 서로 다른 스코프를 각각 지켜야 한다.
+
+    #2120: chat_presence.list_working이 async(Redis 공유)로 전환돼 이 함수도 async — 호출부는 await.
     """
     try:
-        from app.routers.events import publish_event
+        from app.models.conversation import ConversationParticipant
+        from app.routers.events import push_to_org_members
         from app.services import chat_presence
 
-        publish_event(
+        from app.core.database import async_session_factory
+        from sqlalchemy import select
+
+        async with async_session_factory() as session:
+            rows = await session.execute(
+                select(ConversationParticipant.member_id).where(
+                    ConversationParticipant.conversation_id == conversation_id,
+                )
+            )
+            participant_ids = {str(r[0]) for r in rows.all()}
+
+        await push_to_org_members(
             str(org_id),
             "conversation.working",
             {
                 "conversation_id": str(conversation_id),
                 "working": await chat_presence.list_working(str(conversation_id)),
             },
+            member_ids=participant_ids,
         )
     except Exception:
         logger.warning("emit conversation.working failed conv=%s", conversation_id, exc_info=True)
 
 
-def emit_presence(org_id) -> None:
-    """팀 presence(online/idle/working) 변경 트리거. FE 가 /team-presence 를 1회 refetch(폴링 대체).
+async def emit_presence(org_id) -> None:
+    """팀 presence(online/idle/working) 변경 트리거. FE가 /team-presence를 1회 refetch(폴링 대체).
 
-    경량 트리거(스냅샷 미포함) — presence 집계는 DB 조회라 sync 발행점에서 산출하지 않고 FE refetch 에 위임.
+    수신자 스코프(#2139 §3, 오르테가 확定): **org 전체** — 호출부(agent_gateway.py 커넥트/
+    디스커넥트, conversations.py working 변경) 전부 project_id를 애초에 안 들고 있다(에이전트는
+    multi-project를 걸치고 DM 대화는 project 자체가 없음 — 데이터가 원래 org 단위). 좁히려면
+    호출부의 project_id 조달이 선행돼야 하므로 이 스토리(버그수정) 스코프 밖 — 별도 스토리.
+
+    경량 트리거(스냅샷 미포함) — presence 집계는 DB 조회라 sync 발행점에서 산출하지 않고 FE refetch에 위임.
     """
     try:
-        from app.routers.events import publish_event
+        from app.routers.events import push_to_org_members
 
-        publish_event(str(org_id), "presence", {})
+        await push_to_org_members(str(org_id), "presence", {})
     except Exception:
         logger.warning("emit presence failed org=%s", org_id, exc_info=True)

--- a/backend/app/services/story_status_events.py
+++ b/backend/app/services/story_status_events.py
@@ -105,17 +105,23 @@ async def emit_story_status_changed(
     actor_role: str | None = None,
     actor_type: str | None = None,
 ) -> None:
-    """story status_changed의 side-effects 5종을 발화. old==new면 no-op.
+    """story status_changed의 side-effects를 발화. old==new면 no-op.
 
     호출자가 story.status를 이미 새 값으로 설정한 뒤 호출한다. 각 side-effect는 best-effort(실패
-    격리)로 status 전이 자체를 깨지 않는다. publish_event는 eventbus→L1 activity_events 캡처의
-    진입점이므로 gate-driven done도 이걸 타야 활동그래프(=verdict 증거원)에 잡힌다.
-    """
+    격리)로 status 전이 자체를 깨지 않는다.
+
+    ⚠️story #2132(2026-07-23) 정정 — 이 docstring이 예전에 "publish_event는 eventbus→L1
+    activity_events 캡처의 진입점"이라 주장했으나 **사실이 아니었다**: L1 capture(
+    `extract_activities_best_effort`)는 전부 `Event(...)` DB row 생성 직후 명시 호출로만
+    이뤄지고(events.py/stories.py:story_assigned/conversations.py/agent_dispatch.py/
+    notification_dispatch.py), story.status_changed는 그 어디에도 안 걸려 있었다 — publish_event()
+    (org-level in-process fanout, `_subscribers` 영구 죽은 레지스트리)를 지금 삭제해도 이 사실엔
+    아무 영향이 없다(원래도 L1에 안 잡히고 있었다). status_changed를 L1에 새로 잡을지는 이
+    스토리(#2132) 스코프 밖 — 별도 판단 필요."""
     if old_status == story.status:
         return
     # lazy import — service→router/pipeline 순환 회피.
     from app.models.pm import StoryActivity
-    from app.routers.events import publish_event
     from app.services.member_resolver import canonicalize_member_id
     from app.services.notification_dispatch import dispatch_notification
     from app.services.rule_evaluator import EventContext
@@ -155,15 +161,14 @@ async def emit_story_status_changed(
     if actor_id and actor_id != story.assignee_id:
         notify_ids.add(actor_id)
 
-    publish_event(str(org_id), "story.status_changed", event_data)
-
     # story #2059/#2067(까심군 라이브 실측 확定 — 별도 액터 PATCH+브라우저 raw SSE 로깅, 25초
-    # 무수신): 위 publish_event()의 org-level fanout은 `_subscribers[org_id]`로 가는데 이 레지스트리에
-    # `.add()`하는 코드가 저장소 전체 0곳이라 영구 빈 집합 — FE가 실제로 붙는 경로는
-    # `_agent_connections[member_id]`(`_push_to_agent()`로만 채워짐)뿐이다. 선례(story
-    # 9ef0f914·trust_pipeline.py `_maybe_emit`)와 동일하게 "레지스트리 통합"이 아니라 project
-    # 인가 필터를 낀 수동 포워딩으로 그 갭을 메운다 — 순수 transient push(Event row 생성 0,
-    # 연결 안 된 멤버는 `_push_to_agent` 자체가 조용히 no-op).
+    # 무수신) + #2132(2026-07-23 근본수정): 구 `publish_event()`의 org-level fanout은
+    # `_subscribers[org_id]`로 가는데 이 레지스트리에 `.add()`하는 코드가 저장소 전체 0곳이라
+    # 영구 빈 집합이었다 — 그 함수 자체를 삭제했다. FE가 실제로 붙는 경로는
+    # `_agent_connections[member_id]`(`_push_to_agent()`로만 채워짐)뿐이라, 선례(story
+    # 9ef0f914·trust_pipeline.py `_maybe_emit`)와 동일하게 project 인가 필터를 낀 수동
+    # 포워딩만 남긴다 — 순수 transient push(Event row 생성 0, 연결 안 된 멤버는
+    # `_push_to_agent` 자체가 조용히 no-op).
     try:
         from app.routers.events import _push_to_agent
         from app.services.project_auth import project_accessible_member_ids
@@ -174,7 +179,7 @@ async def emit_story_status_changed(
             _push_to_agent(str(member_id), dict(sse_payload))
     except Exception:
         logger.warning(
-            "status_changed SSE 포워딩 실패(story=%s project=%s) — org publish는 이미 발행됨",
+            "status_changed SSE 포워딩 실패(story=%s project=%s)",
             story.id, story.project_id, exc_info=True,
         )
 

--- a/backend/app/services/trust_pipeline.py
+++ b/backend/app/services/trust_pipeline.py
@@ -215,7 +215,6 @@ async def _maybe_emit(
     new_signals = derive_exception_signals(after)
     if old_stage == new_stage and old_signals == new_signals:
         return  # 변경 없음 — 이벤트 폭주 방지(doc §4).
-    from app.routers.events import publish_event  # lazy import — service→router 순환 회피.
 
     event_data = {
         "story_id": str(story_id),
@@ -227,11 +226,11 @@ async def _maybe_emit(
         "actor_id": str(actor_id) if actor_id else None,
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
-    publish_event(str(org_id), "story.trust_stage_changed", event_data)
 
-    # E-UI-DAEGBYEON P0-04 후속(story 9ef0f914): org publish는 `_subscribers[org_id]`(구독
-    # 엔드포인트 없음 — 실측 확인)로만 가고 FE가 실제로 붙는 `_agent_connections[member_id]`에는
-    # 안 닿는다 — "레지스트리 통합"이 아니라 project 인가 필터를 낀 포워딩으로 그 갭을 메운다.
+    # E-UI-DAEGBYEON P0-04 후속(story 9ef0f914) + #2132(2026-07-23 근본수정): org publish(구
+    # `publish_event`)는 `_subscribers[org_id]`(구독 엔드포인트 없음 — 실측 확인)로만 가고 FE가
+    # 실제로 붙는 `_agent_connections[member_id]`에는 안 닿았다 — 그 함수 자체를 삭제하고,
+    # project 인가 필터를 낀 포워딩만 남긴다(이게 원래도 유일한 실 배달 경로였다).
     # 순수 transient push(Event row 생성 0 — 오프라인 백필 불필요·PO 가드레일)·연결 안 된 멤버는
     # _push_to_agent 자체가 조용히 no-op.
     try:
@@ -244,7 +243,7 @@ async def _maybe_emit(
             _push_to_agent(str(member_id), dict(sse_payload))
     except Exception:
         logger.warning(
-            "trust_stage_changed SSE 포워딩 실패(story=%s project=%s) — org publish는 이미 발행됨",
+            "trust_stage_changed SSE 포워딩 실패(story=%s project=%s)",
             story_id, after.project_id, exc_info=True,
         )
 

--- a/backend/tests/test_2078_event_broker.py
+++ b/backend/tests/test_2078_event_broker.py
@@ -208,10 +208,6 @@ async def test_redis_consume_loop_dispatch_disabled_only_logs_no_dispatch_call(m
     monkeypatch.setattr("app.core.config.settings.redis_url", "redis://fake:6379/0")
     dispatch_calls = []
     monkeypatch.setattr(
-        "app.routers.events.publish_event",
-        lambda *a, **kw: dispatch_calls.append(("publish_event", a, kw)),
-    )
-    monkeypatch.setattr(
         "app.routers.events._push_to_agent",
         lambda *a, **kw: dispatch_calls.append(("_push_to_agent", a, kw)),
     )
@@ -241,34 +237,46 @@ async def test_redis_consume_loop_dispatch_disabled_only_logs_no_dispatch_call(m
 
 
 @pytest.mark.anyio
-async def test_redis_consume_loop_dispatch_enabled_calls_publish_event_for_org_target(monkeypatch):
+async def test_redis_consume_loop_dispatch_enabled_org_target_logs_warning_not_dispatched(monkeypatch, caplog):
+    """story #2139/#2132(2026-07-23) 근본수정: publish_event()가 삭제돼 target="org" 메시지는
+    이제 아무 곳으로도 배달되지 않는다(발행 측이 전부 push_to_org_members로 바뀌어 target="org"
+    자체가 다시는 발행되지 않을 것이므로 구조적으로 도달 불가능해야 정상) — 도달하면 경고만
+    남기고 조용히 넘어간다(연다 대신 "왜 여기 도달했나"를 로그로 남겨 재발견 가능하게)."""
     monkeypatch.setattr("app.core.config.settings.event_broker_redis_dispatch_enabled", True)
-    dispatch_calls = []
-    monkeypatch.setattr(
-        "app.routers.events.publish_event",
-        lambda *a, **kw: dispatch_calls.append((a, kw)),
-    )
-    monkeypatch.setattr("app.routers.events._push_to_agent", lambda *a, **kw: None)
+    monkeypatch.setattr("app.core.config.settings.redis_url", "redis://fake:6379/0")
+    push_calls = []
+    monkeypatch.setattr("app.routers.events._push_to_agent", lambda *a, **kw: push_calls.append((a, kw)))
 
     msg = _redis_message({
         "instance_id": "other-instance", "target": "org", "target_id": "org-1",
         "event_type": "story.status_changed", "_broker_event_id": "evt-2",
         "data": {"entity_id": "s1"},
     })
-    await _run_loop_until(monkeypatch, [msg], lambda: len(dispatch_calls) > 0)
 
-    args, kwargs = dispatch_calls[0]
-    assert args[0] == "org-1"
-    assert args[1] == "story.status_changed"
-    assert args[2] == {"entity_id": "s1"}
-    assert kwargs.get("_from_listener") is True  # 재발행 무한루프 차단 플래그 필수
+    class _FakeClient:
+        def pubsub(self):
+            return _FakePubSub([msg])
+
+    monkeypatch.setattr(eb, "_get_redis_client", lambda: _FakeClient())
+
+    import logging
+    with caplog.at_level(logging.WARNING):
+        task = asyncio.create_task(eb.redis_consume_loop())
+        await asyncio.sleep(0.2)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    assert push_calls == []  # org target은 _push_to_agent를 절대 안 부른다
+    assert any("unexpected target=org" in r.message for r in caplog.records)
 
 
 @pytest.mark.anyio
 async def test_redis_consume_loop_dispatch_enabled_calls_push_to_agent_for_agent_target(monkeypatch):
     monkeypatch.setattr("app.core.config.settings.event_broker_redis_dispatch_enabled", True)
     dispatch_calls = []
-    monkeypatch.setattr("app.routers.events.publish_event", lambda *a, **kw: None)
     monkeypatch.setattr(
         "app.routers.events._push_to_agent",
         lambda *a, **kw: dispatch_calls.append((a, kw)),
@@ -295,10 +303,9 @@ async def test_redis_consume_loop_dispatch_enabled_skips_self_published_event(mo
     monkeypatch.setattr("app.core.config.settings.event_broker_redis_dispatch_enabled", True)
     dispatch_calls = []
     monkeypatch.setattr(
-        "app.routers.events.publish_event",
+        "app.routers.events._push_to_agent",
         lambda *a, **kw: dispatch_calls.append(a),
     )
-    monkeypatch.setattr("app.routers.events._push_to_agent", lambda *a, **kw: None)
 
     msg = _redis_message({
         "instance_id": INSTANCE_ID, "target": "org", "target_id": "org-1",
@@ -353,12 +360,8 @@ async def test_dispatch_received_records_pg_arrival_for_broker_event(monkeypatch
     recorded = []
     monkeypatch.setattr(eb, "record_pg_arrival", lambda eid: recorded.append(eid))
 
-    async def _noop_publish_event(*a, **kw):
-        pass
-
     import json
 
-    monkeypatch.setattr("app.routers.events.publish_event", lambda *a, **kw: None)
     monkeypatch.setattr("app.routers.events._push_to_agent", lambda *a, **kw: True)
 
     payload = {

--- a/backend/tests/test_2086_assignee_changed_sse.py
+++ b/backend/tests/test_2086_assignee_changed_sse.py
@@ -171,11 +171,10 @@ async def test_realdb_assignee_changed_pushes_sse_to_accessible_members():
 
 @pytest.mark.anyio
 async def test_assignee_changed_sse_forward_failure_does_not_break_response(monkeypatch):
-    """project_accessible_member_ids가 raise해도 publish_event는 이미 나갔고 응답은 안 깨져야
-    (기존 emit_story_status_changed의 격리 패턴과 동형 — best-effort)."""
+    """project_accessible_member_ids가 raise해도 응답은 안 깨져야(기존 emit_story_status_changed의
+    격리 패턴과 동형 — best-effort). story #2132(2026-07-23): publish_event() 자체가 삭제됐다 —
+    "이미 나갔다"고 기댈 별도 발행 경로가 더 이상 없다, _push_to_agent 포워딩이 유일 경로다."""
     from types import SimpleNamespace
-
-    from app.routers import stories as stories_mod
 
     story = SimpleNamespace(
         id=uuid.uuid4(), title="S", priority="low", epic_id=None,
@@ -185,8 +184,7 @@ async def test_assignee_changed_sse_forward_failure_does_not_break_response(monk
     old_assignee_id = None
     actor_id = uuid.uuid4()
 
-    with patch.object(stories_mod, "publish_event", lambda *a, **kw: None), \
-         patch(
+    with patch(
              "app.services.project_auth.project_accessible_member_ids",
              AsyncMock(side_effect=RuntimeError("boom")),
          ):

--- a/backend/tests/test_2139_2132_push_to_org_members.py
+++ b/backend/tests/test_2139_2132_push_to_org_members.py
@@ -1,0 +1,99 @@
+"""story #2139/#2132(2026-07-23) 근본수정 — `events.push_to_org_members()`가 실제로
+`_agent_connections`(실 SSE 배달 레지스트리)에 도착하는 것을 실 큐로 고정한다(mock 없이).
+
+배경: 구 `publish_event()`는 `_subscribers[org_id]`(아무도 `.add()`하지 않는 영구 죽은
+레지스트리)에만 넣었다 — 실 배달 경로는 항상 `_agent_connections[member_id]`
+(`_push_to_agent()`로만 채워짐)뿐이었다. `push_to_org_members()`는 이 실 경로로 개별
+push하므로, "실제로 큐에 들어가는가"를 이 파일이 직접 고정한다."""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.routers.events import _agent_connections, push_to_org_members
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _clean_agent_connections():
+    _agent_connections.clear()
+    yield
+    _agent_connections.clear()
+
+
+@pytest.mark.anyio
+async def test_push_to_org_members_with_explicit_ids_delivers_only_to_those():
+    """conversation.working 경로(참가자만) — member_ids 명시 시 그 집합에게만 실제로 도착한다."""
+    participant = str(uuid.uuid4())
+    non_participant = str(uuid.uuid4())
+    q_participant: asyncio.Queue = asyncio.Queue()
+    q_non_participant: asyncio.Queue = asyncio.Queue()
+    _agent_connections[participant].add(q_participant)
+    _agent_connections[non_participant].add(q_non_participant)
+
+    with patch("app.services.event_broker.event_broker.publish", new=AsyncMock()):
+        await push_to_org_members(
+            str(uuid.uuid4()), "conversation.working", {"conversation_id": "c1"},
+            member_ids={participant},
+        )
+
+    assert q_participant.get_nowait()["event_type"] == "conversation.working"
+    assert q_non_participant.empty()  # 참가자가 아닌 사람에겐 새지 않는다 — 핵심 회귀가드.
+
+
+@pytest.mark.anyio
+async def test_push_to_org_members_none_resolves_org_wide():
+    """presence 경로(org 전체) — member_ids 미지정 시 org_members 전체를 스스로 해소해 보낸다."""
+    org_id = uuid.uuid4()
+    member_a = str(uuid.uuid4())
+    member_b = str(uuid.uuid4())
+    q_a: asyncio.Queue = asyncio.Queue()
+    q_b: asyncio.Queue = asyncio.Queue()
+    _agent_connections[member_a].add(q_a)
+    _agent_connections[member_b].add(q_b)
+
+    result = type("R", (), {"all": lambda self: [(member_a,), (member_b,)]})()
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=result)
+
+    import contextlib
+
+    @contextlib.asynccontextmanager
+    async def _fake_factory():
+        yield session
+
+    with patch("app.core.database.async_session_factory", lambda: _fake_factory()), \
+         patch("app.services.event_broker.event_broker.publish", new=AsyncMock()):
+        await push_to_org_members(str(org_id), "presence", {})
+
+    assert q_a.get_nowait()["event_type"] == "presence"
+    assert q_b.get_nowait()["event_type"] == "presence"
+
+
+@pytest.mark.anyio
+async def test_push_to_org_members_empty_member_ids_delivers_to_nobody():
+    """member_ids={}(빈 집합, None 아님)이면 org 전체 해소로 폴백하지 않고 정말 아무에게도
+    안 간다 — conversation.working의 참가자가 실제로 0명인 엣지케이스(예: 참가자 전원 이탈)."""
+    someone = str(uuid.uuid4())
+    q = asyncio.Queue()
+    _agent_connections[someone].add(q)
+
+    with patch("app.services.event_broker.event_broker.publish", new=AsyncMock()):
+        await push_to_org_members(str(uuid.uuid4()), "conversation.working", {}, member_ids=set())
+
+    assert q.empty()
+
+
+def test_publish_event_and_subscribers_no_longer_exist():
+    """회귀가드 — 구 publish_event()/_subscribers가 정말로 삭제됐는지(부활/재도입 감지)."""
+    import app.routers.events as events_mod
+
+    assert not hasattr(events_mod, "publish_event")
+    assert not hasattr(events_mod, "_subscribers")

--- a/backend/tests/test_e_glance_epic_events_unit.py
+++ b/backend/tests/test_e_glance_epic_events_unit.py
@@ -1,15 +1,20 @@
 """E-GLANCE wedge #2(story 96b19bc3) — app/services/epic_events.py 단위 테스트.
 
 emit_story_status_changed 격리 테스트(test_emit_story_status_changed_isolation.py)와 동형
-패턴: publish_event/fire_webhooks/dispatch_notification을 mock해 (1) 각 이벤트타입의
-정확한 event_type+payload shape, (2) side-effect 실패가 전파되지 않음(best-effort 격리),
-(3) status_changed의 old==new no-op 가드를 검증한다."""
+패턴: fire_webhooks/dispatch_notification을 mock해 (1) 각 이벤트타입의 정확한 event_type+
+payload shape, (2) side-effect 실패가 전파되지 않음(best-effort 격리), (3) status_changed의
+old==new no-op 가드를 검증한다.
+
+story #2132(2026-07-23) 근본수정: `publish_event()` 호출이 삭제됐다(FE 소비처 0 + 죽은
+org-level fanout 자체 삭제) — payload shape 검증은 이제 fire_webhooks에 전달되는 동일
+event_data(4번째 positional arg)로 확認한다(webhook도 같은 event_data를 받으므로 shape
+검증 대상으로 동등)."""
 from __future__ import annotations
 
 import uuid
 from contextlib import ExitStack
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -33,8 +38,7 @@ def _epic(status: str = "active", assignee_id: uuid.UUID | None = None):
     )
 
 
-def _base_patches(stack: ExitStack, *, publish=None, webhook=None, notif=None):
-    stack.enter_context(patch("app.routers.events.publish_event", publish or MagicMock()))
+def _base_patches(stack: ExitStack, *, webhook=None, notif=None):
     stack.enter_context(patch(
         "app.services.webhook_dispatch.fire_webhooks", webhook or AsyncMock(),
     ))
@@ -44,23 +48,18 @@ def _base_patches(stack: ExitStack, *, publish=None, webhook=None, notif=None):
 
 
 @pytest.mark.anyio
-async def test_emit_goal_created_fires_publish_and_webhook_with_correct_shape():
+async def test_emit_goal_created_fires_webhook_with_correct_shape():
     epic = _epic()
-    publish = MagicMock()
     webhook = AsyncMock()
     with ExitStack() as stack:
-        _base_patches(stack, publish=publish, webhook=webhook)
+        _base_patches(stack, webhook=webhook)
         await emit_goal_created(AsyncMock(), uuid.uuid4(), epic, actor_id=uuid.uuid4())
-
-    publish.assert_called_once()
-    args = publish.call_args[0]
-    assert args[1] == "epic.created"
-    assert args[2]["epic_id"] == str(epic.id)
-    assert args[2]["epic_title"] == "Epic X"
 
     webhook.assert_awaited_once()
     wh_args = webhook.call_args[0]
     assert wh_args[2] == "epic.created"
+    assert wh_args[3]["epic_id"] == str(epic.id)
+    assert wh_args[3]["epic_title"] == "Epic X"
     # 까심 QA(#2076 REQUEST_CHANGES) 회귀가드: assignee 없으면 recipient_member_ids는 반드시
     # None(게이팅 미적용)이어야 한다 — 빈 집합이면 fire_webhooks가 member-bound 웹훅(오르테가
     # 포함)을 전부 drop한다(WebhookConfig.member_id nullable=False, broadcast 개념 없음).
@@ -82,29 +81,27 @@ async def test_emit_goal_created_with_assignee_gates_to_that_member_not_empty_se
 
 @pytest.mark.anyio
 async def test_emit_goal_status_changed_no_op_when_old_equals_new():
-    """old_status == epic.status면 완전 no-op(publish_event조차 호출 안 됨) —
+    """old_status == epic.status면 완전 no-op(webhook조차 호출 안 됨) —
     emit_story_status_changed와 동형 규율."""
     epic = _epic(status="active")
-    publish = MagicMock()
     webhook = AsyncMock()
     with ExitStack() as stack:
-        _base_patches(stack, publish=publish, webhook=webhook)
+        _base_patches(stack, webhook=webhook)
         await emit_goal_status_changed(AsyncMock(), uuid.uuid4(), epic, "active")
 
-    publish.assert_not_called()
     webhook.assert_not_awaited()
 
 
 @pytest.mark.anyio
 async def test_emit_goal_status_changed_fires_with_old_and_new_status():
     epic = _epic(status="done")
-    publish = MagicMock()
+    webhook = AsyncMock()
     with ExitStack() as stack:
-        _base_patches(stack, publish=publish)
+        _base_patches(stack, webhook=webhook)
         await emit_goal_status_changed(AsyncMock(), uuid.uuid4(), epic, "active")
 
-    publish.assert_called_once()
-    payload = publish.call_args[0][2]
+    webhook.assert_awaited_once()
+    payload = webhook.call_args[0][3]
     assert payload["old_status"] == "active"
     assert payload["status"] == "done"
 
@@ -112,15 +109,14 @@ async def test_emit_goal_status_changed_fires_with_old_and_new_status():
 @pytest.mark.anyio
 async def test_emit_goal_removed_uses_pre_captured_title_not_epic_object():
     """삭제 後엔 epic 객체 조회 불가 — 호출자가 넘긴 title/project_id로만 payload 구성."""
-    publish = MagicMock()
     webhook = AsyncMock()
     epic_id = uuid.uuid4()
     project_id = uuid.uuid4()
     with ExitStack() as stack:
-        _base_patches(stack, publish=publish, webhook=webhook)
+        _base_patches(stack, webhook=webhook)
         await emit_goal_removed(AsyncMock(), uuid.uuid4(), epic_id, "Deleted Epic", project_id)
 
-    payload = publish.call_args[0][2]
+    payload = webhook.call_args[0][3]
     assert payload["epic_id"] == str(epic_id)
     assert payload["epic_title"] == "Deleted Epic"
     assert payload["project_id"] == str(project_id)
@@ -139,15 +135,13 @@ async def test_emit_goal_reordered_fires_once_for_batch_gated_to_recipients():
         {"id": uuid.uuid4(), "title": "B", "project_id": uuid.uuid4(), "position": 2, "old_position": 5},
     ]
     recipients = {uuid.uuid4()}
-    publish = MagicMock()
     webhook = AsyncMock()
     with ExitStack() as stack:
-        _base_patches(stack, publish=publish, webhook=webhook)
+        _base_patches(stack, webhook=webhook)
         await emit_goal_reordered(AsyncMock(), uuid.uuid4(), items, recipients)
 
-    publish.assert_called_once()
     webhook.assert_awaited_once()
-    payload = publish.call_args[0][2]
+    payload = webhook.call_args[0][3]
     assert len(payload["items"]) == 2
     assert payload["items"][1]["old_position"] == 5
     # 커밋 모델: 지정 수신자로 게이팅(None 브로드캐스트 폐지)·activity-feed 브로드캐스트도 억제.
@@ -157,11 +151,11 @@ async def test_emit_goal_reordered_fires_once_for_batch_gated_to_recipients():
 
 @pytest.mark.anyio
 async def test_emit_goal_reordered_empty_items_is_noop():
-    publish = MagicMock()
+    webhook = AsyncMock()
     with ExitStack() as stack:
-        _base_patches(stack, publish=publish)
+        _base_patches(stack, webhook=webhook)
         await emit_goal_reordered(AsyncMock(), uuid.uuid4(), [], set())
-    publish.assert_not_called()
+    webhook.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_e_mcp_opt_ff6cb90d_multiproject_scoping_realdb.py
+++ b/backend/tests/test_e_mcp_opt_ff6cb90d_multiproject_scoping_realdb.py
@@ -264,10 +264,14 @@ async def test_set_default_project_rejects_inaccessible_project_403():
 
 
 @pytest.mark.anyio
-async def test_default_project_changed_event_emitted():
-    """set_default_project 성공 시 member.default_project_changed(old/new) emit — 감사 가능성 실증."""
-    from unittest.mock import MagicMock, patch as mock_patch
+async def test_default_project_changed_succeeds_without_dead_publish_event():
+    """set_default_project 성공 시 실제로 default_project_id가 바뀐다.
 
+    story #2132(2026-07-23) 근본수정: 이 엔드포인트가 발행하던 `member.default_project_changed`
+    `publish_event()` 호출은 FE 소비처 0(설계 doc §1 실측)이라 삭제됐다 — 그 org-level fanout
+    자체가 아무도 구독 안 하는 영구 죽은 코드였다. 이 테스트는 원래 "emit 여부"를 검증했으나,
+    이제는 그 반대(호출 제거 後에도 실제 기능 — default project 변경 자체 — 는 무회귀임)를
+    검증한다."""
     from app.main import app
     from app.dependencies.database import get_db
 
@@ -288,19 +292,11 @@ async def test_default_project_changed_event_emitted():
         app.dependency_overrides[get_db] = _db
         client = _client_with_key(app, seeded["raw_key"])
         try:
-            publish = MagicMock()
-            with mock_patch("app.routers.events.publish_event", publish):
-                resp = await client.patch(
-                    "/api/v2/auth/me/default-project", json={"project_id": str(target)},
-                )
-                assert resp.status_code == 200, resp.text
-            publish.assert_called_once()
-            args, _ = publish.call_args
-            assert args[1] == "member.default_project_changed"
-            payload = args[2]
-            assert payload["member_id"] == str(seeded["member_id"])
-            assert payload["old_default_project_id"] is None
-            assert payload["new_default_project_id"] == str(target)
+            resp = await client.patch(
+                "/api/v2/auth/me/default-project", json={"project_id": str(target)},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["resolved_default_project_id"] == str(target)
         finally:
             await client.aclose()
     finally:

--- a/backend/tests/test_e_ui_daegbyeon_p0_04_trust_pipeline_realdb.py
+++ b/backend/tests/test_e_ui_daegbyeon_p0_04_trust_pipeline_realdb.py
@@ -3,13 +3,14 @@
 1) /glance/attention merge_ready 엄격화(human_verified+무블로커+무검증실패) + needs_input/verify_fail
    신규 kind 노출.
 2) SSE 훅 3곳(gate 전이·dependency create/delete·story status 변경) — old/new 비교 후 변경시에만
-   story.trust_stage_changed emit(publish_event mock으로 실측). item_type≠story는 무배선 확인.
+   story.trust_stage_changed emit(story #2132 근본수정 後 _push_to_agent mock으로 실측 —
+   publish_event()는 org-level fanout이 영구 죽은 코드라 삭제됐다). item_type≠story는 무배선 확인.
 """
 from __future__ import annotations
 
 import os
 import uuid
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -76,6 +77,15 @@ async def _setup_app(app, Session, user_id, org_id):
 
 
 async def _base_org_project_caller(session):
+    """⚠️story #2132(2026-07-23) 후속 정정 — 이 헬퍼가 원래 `ProjectAccess.org_member_id`만
+    채우고 E-MEMBER-SSOT 앵커(members 테이블 자체 + `ProjectAccess.member_id`)를 안 채웠다.
+    `team_members` VIEW(마이그 0110)는 `pa.member_id = m.id`로 조인하므로(구 org_member_id
+    아님), 이 헬퍼로 만든 caller는 뷰에 전혀 안 잡혀 `project_accessible_member_ids`가 항상
+    빈 집합을 반환했다 — publish_event() 삭제 前엔 수신자 해소 자체가 불필요해 안 보이던 결함.
+    test_1994_backlink_api_realdb.py `_make_human_member`의 검증된 anchor 패턴을 그대로
+    재현한다(`ProjectAccess` 양쪽 컬럼 다 세팅 — 하나만 세팅하면 다른 authz 경로가 조용히
+    403/빈배열)."""
+    from app.models.member import Member
     from app.models.organization import Organization
     from app.models.project import OrgMember, Project
     from app.models.project_access import ProjectAccess
@@ -91,11 +101,16 @@ async def _base_org_project_caller(session):
     caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
     session.add(caller)
     await session.commit()
+    # 휴먼은 members.id == org_members.id(0075 ID-보존 불변식) — 같은 id로 신원 앵커.
     om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
     session.add(om)
     await session.commit()
+    m = Member(id=om.id, org_id=org.id, type="human", user_id=caller_id, name=f"Caller-{caller_id.hex[:6]}")
+    session.add(m)
+    await session.commit()
     session.add(ProjectAccess(
-        id=uuid.uuid4(), project_id=project.id, org_member_id=om.id, permission="granted", role="member",
+        id=uuid.uuid4(), project_id=project.id, org_member_id=om.id, member_id=m.id,
+        permission="granted", role="member",
     ))
     await session.commit()
     return org.id, project.id, caller_id
@@ -188,9 +203,12 @@ async def test_attention_merge_ready_strict_and_new_kinds():
 # ── ② SSE 훅: gate 전이 ──────────────────────────────────────────────────────
 
 def _trust_stage_calls(mock, story_id):
+    """mock=`_push_to_agent`(story #2132 근본수정 — publish_event() 삭제 後의 실 배달 경로).
+    두 번째 위치인자(payload dict)에서 event_type/story_id로 필터한다."""
     return [
         c for c in mock.call_args_list
-        if c.args[1] == "story.trust_stage_changed" and c.args[2]["story_id"] == str(story_id)
+        if c.args[1].get("event_type") == "story.trust_stage_changed"
+        and c.args[1].get("story_id") == str(story_id)
     ]
 
 
@@ -219,14 +237,17 @@ async def test_gate_transition_emits_trust_stage_changed_on_stage_change():
             s.add(gate)
             await s.commit()
 
-            publish = MagicMock()
-            with patch("app.routers.events.publish_event", publish):
+            push = MagicMock()
+            with patch(
+                "app.services.project_auth.project_accessible_member_ids",
+                AsyncMock(return_value={resolver.id}),
+            ), patch("app.routers.events._push_to_agent", push):
                 await transition_gate(s, org_id, gate.id, "approved", resolver_id=resolver.id)
                 await s.commit()
 
-            calls = _trust_stage_calls(publish, story.id)
+            calls = _trust_stage_calls(push, story.id)
             assert len(calls) == 1, calls
-            payload = calls[0].args[2]
+            payload = calls[0].args[1]
             assert payload["old_stage"] == "needs_input"
             assert payload["new_stage"] == "running"
     finally:
@@ -259,14 +280,17 @@ async def test_gate_transition_dedupes_when_status_also_advances():
             s.add(gate)
             await s.commit()
 
-            publish = MagicMock()
-            with patch("app.routers.events.publish_event", publish):
+            push = MagicMock()
+            with patch(
+                "app.services.project_auth.project_accessible_member_ids",
+                AsyncMock(return_value={resolver.id}),
+            ), patch("app.routers.events._push_to_agent", push):
                 await transition_gate(s, org_id, gate.id, "approved", resolver_id=resolver.id)
                 await s.commit()
 
-            calls = _trust_stage_calls(publish, story.id)
+            calls = _trust_stage_calls(push, story.id)
             assert len(calls) == 1, calls  # 훅①·③ 둘 다 발화 가능한 상황이나 정확히 1회만.
-            payload = calls[0].args[2]
+            payload = calls[0].args[1]
             assert payload["old_stage"] == "claimed_done"
             assert payload["new_stage"] is None  # done = 파이프라인 스코프 밖.
     finally:
@@ -275,7 +299,7 @@ async def test_gate_transition_dedupes_when_status_also_advances():
 
 @pytest.mark.anyio
 async def test_gate_transition_noop_for_non_story_work_item():
-    """work_item_type != story(예: doc)는 trust_stage 훅 자체가 무배선 — publish_event 미호출."""
+    """work_item_type != story(예: doc)는 trust_stage 훅 자체가 무배선 — _push_to_agent 미호출."""
     from app.models.gate import Gate
     from app.models.member import Member
     from app.services.gate_service import transition_gate
@@ -294,12 +318,15 @@ async def test_gate_transition_noop_for_non_story_work_item():
             s.add(gate)
             await s.commit()
 
-            publish = MagicMock()
-            with patch("app.routers.events.publish_event", publish):
+            push = MagicMock()
+            with patch(
+                "app.services.project_auth.project_accessible_member_ids",
+                AsyncMock(return_value={resolver.id}),
+            ), patch("app.routers.events._push_to_agent", push):
                 await transition_gate(s, org_id, gate.id, "approved", resolver_id=resolver.id)
                 await s.commit()
 
-            publish.assert_not_called()
+            push.assert_not_called()
     finally:
         await engine.dispose()
 
@@ -323,8 +350,12 @@ async def test_dependency_create_and_delete_emit_trust_stage_changed_for_blocked
         await _setup_app(app, Session, caller_id, org_id)
         client = _client_for(app)
         try:
-            publish = MagicMock()
-            with patch("app.routers.events.publish_event", publish):
+            # story #2132(2026-07-23) 근본수정: publish_event() 삭제 — 실 배달은
+            # project_accessible_member_ids로 수신자 해소 後 _push_to_agent 개별 push뿐이다.
+            # caller가 _base_org_project_caller에서 이미 실 ProjectAccess를 받았으므로 수신자
+            # 해소는 그대로 실행시키고(mock 안 함), _push_to_agent만 캡처한다.
+            push = MagicMock()
+            with patch("app.routers.events._push_to_agent", push):
                 resp = await client.post("/api/v2/dependencies", json={
                     "from_id": str(blocker_id), "to_id": str(blocked_id),
                     "dep_type": "blocks", "item_type": "story",
@@ -334,20 +365,20 @@ async def test_dependency_create_and_delete_emit_trust_stage_changed_for_blocked
 
             # running(무블로커) → running(블로킹 있음. 단, "running" 자체는 exception overlay 변화라
             # stage명은 동일하되 blocked 신호 True로 바뀌므로 emit돼야 함).
-            publish.assert_called_once()
-            args, _ = publish.call_args
-            assert args[1] == "story.trust_stage_changed"
-            assert args[2]["story_id"] == str(blocked_id)
-            assert args[2]["exception_signals"]["blocked"] is True
+            calls = _trust_stage_calls(push, blocked_id)
+            assert len(calls) == 1, calls
+            payload = calls[0].args[1]
+            assert payload["story_id"] == str(blocked_id)
+            assert payload["exception_signals"]["blocked"] is True
 
-            publish2 = MagicMock()
-            with patch("app.routers.events.publish_event", publish2):
+            push2 = MagicMock()
+            with patch("app.routers.events._push_to_agent", push2):
                 del_resp = await client.delete(f"/api/v2/dependencies/{dep_id}")
                 assert del_resp.status_code == 200, del_resp.text
 
-            publish2.assert_called_once()
-            args2, _ = publish2.call_args
-            assert args2[2]["exception_signals"]["blocked"] is False
+            calls2 = _trust_stage_calls(push2, blocked_id)
+            assert len(calls2) == 1, calls2
+            assert calls2[0].args[1]["exception_signals"]["blocked"] is False
         finally:
             await client.aclose()
     finally:
@@ -375,14 +406,14 @@ async def test_dependency_create_noop_for_non_story_item_type():
         await _setup_app(app, Session, caller_id, org_id)
         client = _client_for(app)
         try:
-            publish = MagicMock()
-            with patch("app.routers.events.publish_event", publish):
+            push = MagicMock()
+            with patch("app.routers.events._push_to_agent", push):
                 resp = await client.post("/api/v2/dependencies", json={
                     "from_id": str(epic_a_id), "to_id": str(epic_b_id),
                     "dep_type": "blocks", "item_type": "epic",
                 })
                 assert resp.status_code == 201, resp.text
-            publish.assert_not_called()
+            push.assert_not_called()
         finally:
             await client.aclose()
     finally:

--- a/backend/tests/test_emit_story_status_changed_isolation.py
+++ b/backend/tests/test_emit_story_status_changed_isolation.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import uuid
 from contextlib import ExitStack
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -28,7 +28,6 @@ def _story():
 
 
 def _base_patches(stack: ExitStack, *, notif=None, webhook=None, l2=None):
-    stack.enter_context(patch("app.routers.events.publish_event", MagicMock()))
     stack.enter_context(patch("app.services.webhook_dispatch.fire_webhooks",
                               webhook or AsyncMock()))
     stack.enter_context(patch("app.services.workflow_pipeline.process_event",

--- a/backend/tests/test_event1config_message_gating.py
+++ b/backend/tests/test_event1config_message_gating.py
@@ -70,7 +70,10 @@ def _patches():
         patch.object(conv, "assign_recipient_seq", _assign_seq),
         patch("app.services.activity_stream.extract_activities_best_effort", AsyncMock()),
         patch("app.services.presence_events.emit_conversation_working", new=AsyncMock(return_value=None)),
-        patch("app.services.presence_events.emit_presence", lambda *_a, **_k: None),
+        # story #2139(2026-07-23): emit_presence가 push_to_org_members(await 필요)를 호출하도록
+        # async로 전환됐다 — 호출부(conversations.py)도 `await emit_presence(...)`로 바뀌었으므로
+        # mock도 awaitable이어야 한다(평범한 lambda는 None을 반환해 TypeError: can't await None).
+        patch("app.services.presence_events.emit_presence", new=AsyncMock(return_value=None)),
     ]
 
 

--- a/backend/tests/test_ho_gate_done_side_effects.py
+++ b/backend/tests/test_ho_gate_done_side_effects.py
@@ -1,15 +1,20 @@
 """41a6e294: gate-driven done이 정상 status-change side-effects를 발화.
 
 merge approve→done이 status만 직접 set하던 갭을 닫고, 정상 board 경로와 동일 helper
-(emit_story_status_changed)로 events(story.status_changed→L1 진입점)·StoryActivity를 발화하는지
-실DB로 검증. publish_event는 eventbus→L1 activity_events 캡처의 진입점이다.
+(emit_story_status_changed)로 events(story.status_changed)·StoryActivity를 발화하는지
+실DB로 검증.
+
+⚠️story #2132(2026-07-23) 정정 — 이 파일이 검증하던 `publish_event("story.status_changed")`는
+삭제됐다(org-level fanout, `_subscribers` 영구 죽은 레지스트리·구독자 0). 실 배달은
+`project_accessible_member_ids`로 프로젝트 인가 필터를 거친 뒤 `_push_to_agent` 개별 push뿐이라
+(story_status_events.py 참고), 이 테스트도 그 실 경로로 재조준한다.
 """
 from __future__ import annotations
 
 import os
 import uuid
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -63,8 +68,10 @@ async def test_gate_driven_done_emits_status_changed_side_effects():
             gate_type="merge", work_item_type="story", work_item_id=story_id,
             org_id=org, resolver_id=resolver,
         )
-        spy = MagicMock()
-        with patch("app.routers.events.publish_event", spy):
+        push_spy = MagicMock()
+        with patch("app.services.project_auth.project_accessible_member_ids",
+                   AsyncMock(return_value={resolver})), \
+             patch("app.routers.events._push_to_agent", push_spy):
             async with Session() as s:
                 await s.execute(_text("SET session_replication_role = replica"))
                 await _advance_story_on_merge_approve(s, gate, "approved")
@@ -80,9 +87,9 @@ async def test_gate_driven_done_emits_status_changed_side_effects():
                       "WHERE story_id=:i"), {"i": story_id}
             )).all()
         assert status == "done"
-        # ② publish_event("story.status_changed") 발화 = L1 activity_events 캡처 진입점.
-        assert spy.called
-        evt_types = [c.args[1] for c in spy.call_args_list if len(c.args) >= 2]
+        # ② _push_to_agent("story.status_changed") 발화 = 실 SSE 배달 경로(story #2132 이후).
+        assert push_spy.called
+        evt_types = [c.args[1].get("event_type") for c in push_spy.call_args_list if len(c.args) >= 2]
         assert "story.status_changed" in evt_types
         # ③ StoryActivity status_changed 행(in-review→done) — 정상 경로와 parity.
         assert any(a.activity_type == "status_changed" and a.old_value == "in-review"

--- a/backend/tests/test_presence_events_r2.py
+++ b/backend/tests/test_presence_events_r2.py
@@ -1,61 +1,114 @@
-"""R2(da9d1781): presence/working SSE 발행 헬퍼 — shape + best-effort(실패 swallow)."""
+"""R2(da9d1781): presence/working SSE 발행 헬퍼 — shape + best-effort(실패 swallow).
+
+story #2139/#2132(2026-07-23) 근본수정 반영: 구 `events.publish_event()`(org-level
+`_subscribers` fanout — 아무도 구독 안 하는 영구 죽은 코드)를 삭제하고
+`events.push_to_org_members()`(`_push_to_agent()` 개별 push로 귀결 — 실제 배달 경로)로
+교체됐다. 수신자 스코프가 이벤트별로 다르다(presence=org 전체, conversation.working=참가자만)
+— 그 스코프 차이가 이 테스트의 핵심 축이다."""
 from __future__ import annotations
 
+import contextlib
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 
+def _patch_session_factory(participant_ids: list[str]):
+    """async_session_factory()를 mock async context manager로 대체 — ConversationParticipant
+    조회 결과로 participant_ids를 반환하게 한다(test_agent_gateway.py의 헬퍼와 동형)."""
+    db = MagicMock()
+    result = MagicMock()
+    result.all.return_value = [(uuid.UUID(pid) if _looks_like_uuid(pid) else pid,) for pid in participant_ids]
+    db.execute = AsyncMock(return_value=result)
+
+    def _factory():
+        @contextlib.asynccontextmanager
+        async def _cm():
+            yield db
+        return _cm()
+
+    return _factory, db
+
+
+def _looks_like_uuid(s: str) -> bool:
+    try:
+        uuid.UUID(s)
+        return True
+    except ValueError:
+        return False
+
+
+@pytest.mark.anyio
 async def test_emit_conversation_working_publishes_shape():
+    """conversation.working은 **참가자만**에게 간다(org 전체 아님) — #2139 §3 확定."""
     from app.services import presence_events
 
     org = uuid.uuid4()
     conv = uuid.uuid4()
-    with patch("app.routers.events.publish_event") as pub, patch(
-        "app.services.chat_presence.list_working", new=AsyncMock(return_value=[{"member_id": "m1"}])
-    ):
+    participant_id = str(uuid.uuid4())
+    factory, _db = _patch_session_factory([participant_id])
+
+    with patch("app.core.database.async_session_factory", factory), \
+         patch("app.services.chat_presence.list_working", new=AsyncMock(return_value=[{"member_id": "m1"}])), \
+         patch("app.routers.events.push_to_org_members", new=AsyncMock()) as pub:
         await presence_events.emit_conversation_working(org, conv)
-    pub.assert_called_once()
-    args = pub.call_args.args
+
+    pub.assert_awaited_once()
+    args, kwargs = pub.await_args
     assert args[0] == str(org)
     assert args[1] == "conversation.working"
     assert args[2]["conversation_id"] == str(conv)
     assert args[2]["working"] == [{"member_id": "m1"}]
+    # ⭐핵심 회귀가드 — member_ids가 명시(참가자만)이지 None(org 전체)이 아니어야 한다.
+    assert kwargs["member_ids"] == {participant_id}
 
 
-def test_emit_presence_publishes_trigger():
+@pytest.mark.anyio
+async def test_emit_presence_publishes_trigger():
+    """presence는 **org 전체**에게 간다 — member_ids를 명시하지 않아 push_to_org_members가
+    org_members 전체를 자체 해소하게 한다(#2139 §3 확定)."""
     from app.services import presence_events
 
     org = uuid.uuid4()
-    with patch("app.routers.events.publish_event") as pub:
-        presence_events.emit_presence(org)
-    pub.assert_called_once()
-    args = pub.call_args.args
+    with patch("app.routers.events.push_to_org_members", new=AsyncMock()) as pub:
+        await presence_events.emit_presence(org)
+
+    pub.assert_awaited_once()
+    args, kwargs = pub.await_args
     assert args[0] == str(org)
     assert args[1] == "presence"
     assert args[2] == {}
+    # ⭐핵심 회귀가드 — member_ids를 넘기지 않아야 org 전체로 해소된다(참가자만으로 좁히면 안 됨).
+    assert kwargs.get("member_ids") is None
 
 
+@pytest.mark.anyio
 async def test_emit_best_effort_swallows_publish_failure():
     """발행 실패가 caller 흐름을 깨면 안 됨(메시지 dispatch/reply 보호) — 예외 swallow."""
     from app.services import presence_events
 
-    with patch("app.routers.events.publish_event", side_effect=RuntimeError("bus down")):
-        # 예외 전파 없이 정상 반환해야 한다.
-        presence_events.emit_presence(uuid.uuid4())
-        await presence_events.emit_conversation_working(uuid.uuid4(), uuid.uuid4())
+    with patch("app.routers.events.push_to_org_members", new=AsyncMock(side_effect=RuntimeError("bus down"))):
+        await presence_events.emit_presence(uuid.uuid4())  # no raise
 
-
-async def test_emit_working_swallows_list_working_failure():
-    from app.services import presence_events
-
-    with patch("app.routers.events.publish_event"), patch(
-        "app.services.chat_presence.list_working", new=AsyncMock(side_effect=RuntimeError("boom"))
-    ):
+    factory, _db = _patch_session_factory([])
+    with patch("app.core.database.async_session_factory", factory), \
+         patch("app.routers.events.push_to_org_members", new=AsyncMock(side_effect=RuntimeError("bus down"))):
         await presence_events.emit_conversation_working(uuid.uuid4(), uuid.uuid4())  # no raise
 
 
+@pytest.mark.anyio
+async def test_emit_working_swallows_list_working_failure():
+    from app.services import presence_events
+
+    factory, _db = _patch_session_factory([])
+    with patch("app.core.database.async_session_factory", factory), \
+         patch("app.routers.events.push_to_org_members", new=AsyncMock()), \
+         patch("app.services.chat_presence.list_working", new=AsyncMock(side_effect=RuntimeError("boom"))):
+        await presence_events.emit_conversation_working(uuid.uuid4(), uuid.uuid4())  # no raise
+
+
+@pytest.mark.anyio
 async def test_clear_member_returns_affected_conversations():
     """QA HIGH(#1570): disconnect 시 working 비운 대화 목록 반환 → caller 가 conversation.working 발행."""
     from app.services import chat_presence

--- a/backend/tests/test_s4_1_file_conflict.py
+++ b/backend/tests/test_s4_1_file_conflict.py
@@ -257,8 +257,7 @@ async def test_file_lock_with_conflict_warning():
         session.flush = AsyncMock()
         session.add = MagicMock()
 
-        with patch("app.routers.file_locks.publish_event"), \
-             patch("app.routers.file_locks.fire_webhooks", new_callable=AsyncMock), \
+        with patch("app.routers.file_locks.fire_webhooks", new_callable=AsyncMock), \
              patch("app.routers.file_locks.assert_caller_is_member", new_callable=AsyncMock,
                    return_value=None):
             async with client as c:

--- a/backend/tests/test_stories_bulk_body_contract.py
+++ b/backend/tests/test_stories_bulk_body_contract.py
@@ -93,8 +93,7 @@ async def test_bulk_nonsequential_jump_flags_violation_but_allows(monkeypatch):
 
     monkeypatch.setattr(stories_mod, "_attach_assignee_ids", AsyncMock())
     monkeypatch.setattr(stories_mod, "_resolve_team_member_id", AsyncMock(return_value=None))
-    _pub = MagicMock(); _fire = AsyncMock()
-    monkeypatch.setattr(stories_mod, "publish_event", _pub)
+    _fire = AsyncMock()
     monkeypatch.setattr(stories_mod, "fire_webhooks", _fire)
 
     payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": "in-progress"}])
@@ -105,10 +104,10 @@ async def test_bulk_nonsequential_jump_flags_violation_but_allows(monkeypatch):
         "level": "warn", "from": "backlog", "to": "in-progress", "skipped": 1,
     }
     db.commit.assert_awaited_once()
-    # workflow_violation 가시화 — 기존 이벤트 타입(additive)·commit 後 발화.
-    _pub.assert_called_once()
-    assert _pub.call_args[0][1] == "workflow_violation"
+    # workflow_violation 가시화 — commit 後 발화. story #2132(2026-07-23): publish_event()
+    # 호출은 삭제됐다(FE 소비처 0) — webhook만 남은 실 배달 경로.
     _fire.assert_awaited_once()
+    assert _fire.call_args[0][2] == "workflow_violation"
 
 
 @pytest.mark.anyio
@@ -125,7 +124,6 @@ async def test_bulk_adjacent_and_reopen_no_violation(monkeypatch):
         monkeypatch.setattr(stories_mod, "_attach_assignee_ids", AsyncMock())
         monkeypatch.setattr(stories_mod, "_resolve_team_member_id", AsyncMock(return_value=None))
         _fire = AsyncMock(); monkeypatch.setattr(stories_mod, "fire_webhooks", _fire)
-        monkeypatch.setattr(stories_mod, "publish_event", MagicMock())
 
         payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": new}])
         result = await bulk_update_stories(payload, db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))

--- a/backend/tests/test_trust_pipeline_unit.py
+++ b/backend/tests/test_trust_pipeline_unit.py
@@ -128,10 +128,24 @@ def test_scope_violation_true_passthrough():
 
 
 # ── _maybe_emit: 변경시에만 emit(이벤트 폭주 방지·doc §4) ───────────────────
+#
+# story #2132(2026-07-23) 근본수정: publish_event()가 삭제됐다(org-level fanout이 영구 죽은
+# 코드였음) — 실 배달은 project_accessible_member_ids로 수신자 해소 後 _push_to_agent 개별
+# push뿐이라, 이제 이 두 지점을 mock해 검증한다.
 
 @pytest.fixture
 def anyio_backend():
     return "asyncio"
+
+
+def _patch_forward(member_ids=None):
+    return [
+        patch(
+            "app.services.project_auth.project_accessible_member_ids",
+            AsyncMock(return_value=member_ids if member_ids is not None else set()),
+        ),
+        patch("app.routers.events._push_to_agent", MagicMock()),
+    ]
 
 
 @pytest.mark.anyio
@@ -139,10 +153,13 @@ async def test_maybe_emit_noop_when_stage_and_signals_unchanged():
     story_id = uuid.uuid4()
     org_id = uuid.uuid4()
     facts = _facts("in-review", human_verified=True)
-    publish = MagicMock()
-    with patch("app.routers.events.publish_event", publish):
+    import contextlib
+    with contextlib.ExitStack() as stack:
+        member_patch, push_patch = _patch_forward()
+        stack.enter_context(member_patch)
+        push_mock = stack.enter_context(push_patch)
         await _maybe_emit(AsyncMock(), org_id, story_id, facts, facts)
-    publish.assert_not_called()
+    push_mock.assert_not_called()
 
 
 @pytest.mark.anyio
@@ -152,14 +169,18 @@ async def test_maybe_emit_fires_on_stage_change():
     project_id = uuid.uuid4()
     before = _facts("in-progress", project_id=project_id)
     after = _facts("in-review", human_verified=False, project_id=project_id)
-    publish = MagicMock()
-    with patch("app.routers.events.publish_event", publish):
+    member_id = uuid.uuid4()
+    import contextlib
+    with contextlib.ExitStack() as stack:
+        member_patch, push_patch = _patch_forward({member_id})
+        stack.enter_context(member_patch)
+        push_mock = stack.enter_context(push_patch)
         await _maybe_emit(AsyncMock(), org_id, story_id, before, after)
-    publish.assert_called_once()
-    args, _ = publish.call_args
-    assert args[0] == str(org_id)
-    assert args[1] == "story.trust_stage_changed"
-    payload = args[2]
+    push_mock.assert_called_once()
+    args, _ = push_mock.call_args
+    assert args[0] == str(member_id)
+    payload = args[1]
+    assert payload["event_type"] == "story.trust_stage_changed"
     assert payload["story_id"] == str(story_id)
     assert payload["project_id"] == str(project_id)
     assert payload["old_stage"] == "running"
@@ -175,10 +196,13 @@ async def test_maybe_emit_fires_on_signal_change_without_stage_change():
     after = _facts("in-progress", has_pending_human_gate=True)
     assert derive_trust_stage(before) == "running"
     assert derive_trust_stage(after) == "needs_input"  # (참고: 이 케이스는 실제로 stage도 바뀜)
-    publish = MagicMock()
-    with patch("app.routers.events.publish_event", publish):
+    import contextlib
+    with contextlib.ExitStack() as stack:
+        member_patch, push_patch = _patch_forward({uuid.uuid4()})
+        stack.enter_context(member_patch)
+        push_mock = stack.enter_context(push_patch)
         await _maybe_emit(AsyncMock(), org_id, story_id, before, after)
-    publish.assert_called_once()
+    push_mock.assert_called_once()
 
 
 @pytest.mark.anyio
@@ -189,7 +213,10 @@ async def test_maybe_emit_noop_when_both_outside_pipeline_scope():
     org_id = uuid.uuid4()
     before = _facts("done", human_verified=True)
     after = _facts("done", human_verified=True)
-    publish = MagicMock()
-    with patch("app.routers.events.publish_event", publish):
+    import contextlib
+    with contextlib.ExitStack() as stack:
+        member_patch, push_patch = _patch_forward()
+        stack.enter_context(member_patch)
+        push_mock = stack.enter_context(push_patch)
         await _maybe_emit(AsyncMock(), org_id, story_id, before, after)
-    publish.assert_not_called()
+    push_mock.assert_not_called()


### PR DESCRIPTION
## Summary
설계 doc `story-2139-2132-publish-event-unification-design`(오르테가 사전 승인 02:35/02:38) 그대로 구현. 재현→고침→그 경로로 확認 3단만(신규 설계문서 없음).

**라이브 진단(이미 완료, 재확認)**: 계측 건강 확認 後 양성대조(`story.assignee_changed` 14~30ms 도달) 대비 `presence`/`conversation.working`이 240초간 0건 — 관측실패 아니라 진짜 죽은 경로. 근본: 둘 다 `publish_event()`만 호출했고, 그 함수가 쓰는 `_subscribers[org_id]`에 `.add()`하는 코드가 저장소 전체 0곳(실 배달은 `_agent_connections[member_id]` ← `_push_to_agent()`뿐).

## 변경
- `events.py`: `publish_event()`/`_subscribers` **삭제**. `push_to_org_members(org_id, event_type, data, *, member_ids=None)` 신설 — `member_ids=None`이면 org 전체(`org_members`) 해소, 지정 시 그 집합에게만.
- `presence_events.py`: **①presence(org 전체) ②conversation.working(참가자만)** — 스코프가 서로 다른 것이 이 수정의 핵심 축(둘을 같은 함수로 부활시키면 참가자 아닌 사람에게 새는 자리). `emit_presence`가 async로 전환 — 4개 호출부(agent_gateway.py x2, conversations.py x2) 전부 `await` 추가.
- 나머지 7곳(workflow_violation x2·declared_scope_changed·file_conflict·epic.reordered·epic.\* 공용 헬퍼·member.default_project_changed) — FE 소비처 0(설계 doc §1 실측) → **호출 제거만**, 배달 신설 안 함(신기능 스코프 밖). 인접 fire_webhooks/dispatch_notification(별개 채널)은 무변경.
- 크로스인스턴스 relay dispatch 2곳(event_broker.py `redis_consume_loop`, pg_pubsub.py `_dispatch_received`)도 고침 — `target="org"`를 이제 아무도 발행 안 하므로, 삭제된 이름을 참조하는 대신 경고 로그로 대체(도달 시 재발견 가능하게).
- `story_status_events.py`의 stale docstring 정정 — "publish_event가 L1 activity_events 캡처 진입점"이라던 주장이 애초에 사실이 아니었음을 grep으로 확認(L1은 `extract_activities_best_effort`를 실 `Event(...)` row 생성 직후 명시 호출하는 곳에서만 동작·story.status_changed는 원래 그 어디에도 안 걸려 있었음).

## 스코프 밖(FE, 안 건드림) — 확認했으나 손 안 댐
`kanban-board.tsx:254`가 여전히 "publish_event가 org 전체 브로드캐스트" 낡은 주석을 갖고 있음 — 함수 자체가 이제 없어졌으니 더 틀린 상태. 미르코 몫으로 넘김.

## Test plan
- [x] 기존 실패 테스트 9개 파일 수정(mock 대상이 사라진 publish_event를 겨냥) — 전부 재통과
- [x] 신규 `test_2139_2132_push_to_org_members.py` — **mock 없이 실 `_agent_connections` 큐로 배달 고정**(member_ids 명시 시 그 집합에게만, None이면 org 전체, publish_event/_subscribers 부활 감지 회귀가드)
- [x] `test_presence_events_r2.py`에 스코프 회귀가드 추가 — presence는 `member_ids=None`, conversation.working은 항상 명시 `set`(이 수정에서 가장 틀리기 쉬운 자리)
- [x] 전체 스위트(`-k "not realdb"`) — 3922 passed, pre-existing 무관 실패 7건(MCP tooling) 그대로