### PR TITLE
[SID:2139] presence refetch 디바운스·in-flight·레이스 가드

### DIFF
--- a/apps/web/src/components/presence/use-team-presence.test.tsx
+++ b/apps/web/src/components/presence/use-team-presence.test.tsx
@@ -5,7 +5,7 @@
 // isReconnect() 판정이 정확히 작동하는지 고정한다 — onerror를 안 걸면 hadPriorError가 영원히
 // false라 재연결 refetch가 죽은 코드가 되는 함정이 있어(직접 확認), 그 회귀를 막는다.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { act } from 'react';
+import { act, useEffect } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { useTeamPresence } from './use-team-presence';
 
@@ -95,7 +95,7 @@ describe('useTeamPresence — 독립 연결 폴백의 재연결 refetch(#2139)',
     expect(fetchMock).toHaveBeenCalledTimes(2); // 재연결 refetch 발화
   });
 
-  it('presence 이벤트 자체도 여전히 refetch를 유발한다(기존 동작 무회귀)', async () => {
+  it('presence 이벤트 자체도 여전히 refetch를 유발한다(디바운스 창을 넘기면·기존 동작 무회귀)', async () => {
     await act(async () => {
       root.render(<Harness active memberId="m1" />);
       await Promise.resolve();
@@ -104,9 +104,109 @@ describe('useTeamPresence — 독립 연결 폴백의 재연결 refetch(#2139)',
     const es = FakeEventSource.instances[0]!;
     await act(async () => {
       es.emit('presence');
+      await new Promise((r) => setTimeout(r, 320)); // story #2139 — 300ms 디바운스 창을 넘긴다
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+// story #2139 — presence 이벤트가 재접속 60초 주기로 몰려 올 때(M명 접속 시 분당 최대 M건)의
+// 세 가드: ①디바운스(중복 요청 접기) ②in-flight 가드(진행 중엔 새로 안 쏘되 놓치지 않음)
+// ③레이스 가드(늦게 온 stale 응답이 최신 화면을 덮어쓰지 못함 — 셋 중 제일 중요).
+describe('useTeamPresence — presence 폭주 가드(#2139)', () => {
+  it('①짧은 창에 presence 이벤트가 여러 건 몰려도 refetch는 한 번만 나간다', async () => {
+    await act(async () => {
+      root.render(<Harness active memberId="m1" />);
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1); // 초기 스냅샷
+    const es = FakeEventSource.instances[0]!;
+    await act(async () => {
+      es.emit('presence');
+      es.emit('presence');
+      es.emit('presence');
+      await new Promise((r) => setTimeout(r, 320));
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2); // 초기 1 + 디바운스로 접힌 refetch 1
+  });
+
+  it('②fetch 진행 중에 새 트리거가 오면 새로 쏘지 않되, 끝난 뒤 1회 더 실행해 놓치지 않는다', async () => {
+    let resolveFirst!: (v: { ok: boolean; json: () => Promise<{ data: never[] }> }) => void;
+    fetchMock.mockImplementationOnce(() => new Promise((r) => { resolveFirst = r; }));
+
+    await act(async () => {
+      root.render(<Harness active memberId="m1" />);
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1); // 초기 스냅샷 — 아직 in-flight(응답 대기 중)
+
+    const es = FakeEventSource.instances[0]!;
+    await act(async () => {
+      es.emit('presence'); // in-flight 중 도착 — 디바운스 타이머는 걸리지만
+      await new Promise((r) => setTimeout(r, 320)); // 디바운스가 풀려도 in-flight라 pendingRef만 표시
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1); // 새로 쏘지 않음(in-flight 가드)
+
+    await act(async () => {
+      resolveFirst({ ok: true, json: async () => ({ data: [] }) }); // 첫 요청 종료
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2); // 종료 직후 "한 번 더" 자동 실행 — 놓치지 않음
+  });
+
+  // ⚠️in-flight 가드(②)가 이미 동시요청 자체를 직렬화하므로(요청이 진행 중이면 새로 안 쏘고
+  // 끝난 뒤 큐잉된 한 번만 이어 쏨), "두 요청이 동시에 떠 있다가 늦은 응답이 최신을 덮어쓰는"
+  // 시나리오는 이 설계에서 실제로 재현되지 않는다 — 레이스 가드(seq 비교)는 그 전제가 깨질
+  // 미래 변경에 대비한 방어선이다. 여기서는 그 대신, in-flight 큐잉으로 이어진 "한 번 더"
+  // 요청의 결과가 최종 state로 정확히 반영되는 것(오래된 응답이 아니라 실제로 나간 마지막
+  // 요청의 값)을 확認해 같은 결론(화면은 항상 가장 최근에 나간 요청의 결과를 보여준다)을 고정한다.
+  it('③in-flight 큐잉으로 이어진 두 번째 요청의 응답이 최종 state로 정확히 반영된다', async () => {
+    const first = { data: [{ member_id: 'first' }] };
+    const second = { data: [{ member_id: 'second' }] };
+    let resolveFirst!: (v: unknown) => void;
+    let resolveSecond!: (v: unknown) => void;
+    fetchMock
+      .mockImplementationOnce(() => new Promise((r) => { resolveFirst = r; }))
+      .mockImplementationOnce(() => new Promise((r) => { resolveSecond = r; }));
+
+    const renderedItemsRef: { current: Array<{ member_id: string }> } = { current: [] };
+    function Consumer() {
+      const items = useTeamPresence(true, 'm1');
+      useEffect(() => {
+        renderedItemsRef.current = items as unknown as Array<{ member_id: string }>;
+      });
+      return null;
+    }
+
+    await act(async () => {
+      root.render(<Consumer />);
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1); // 초기 요청 — 아직 in-flight
+
+    const es = FakeEventSource.instances[0]!;
+    await act(async () => {
+      es.onerror?.();
+      es.onopen?.(); // 재연결 refetch — in-flight라 새로 안 쏘고 pendingRef만 표시
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFirst({ ok: true, json: async () => first }); // 첫 요청 종료 → 큐잉된 두 번째 즉시 발사
+      await Promise.resolve();
       await Promise.resolve();
     });
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(renderedItemsRef.current).toEqual(first.data); // 이 시점엔 첫 응답이 아직 최신(두 번째는 진행 중)
+
+    await act(async () => {
+      resolveSecond({ ok: true, json: async () => second });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(renderedItemsRef.current).toEqual(second.data); // 마지막으로 나간 요청의 응답이 최종 반영됨
   });
 });
 

--- a/apps/web/src/components/presence/use-team-presence.ts
+++ b/apps/web/src/components/presence/use-team-presence.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { PresenceStatus } from '@/components/chat/presence-dot';
 import { useSseMultiplexerContext } from '@/components/realtime-provider';
 import { createReconnectBackoffState } from '@/lib/realtime/sse-reconnect-backoff';
@@ -35,38 +35,84 @@ export interface TeamPresenceItem {
  * 백스톱처럼도 작동한다). ⚠️남는 리스크: **연결은 살아있는데 특정 named 이벤트만 안 오는
  * 경우**는 이 폴백으로 못 잡는다(#2139가 정확히 이 형태 — heartbeat·연결 전부 정상인데
  * presence만 0건 관측됨). 그건 폴백이 아니라 배달 경로 자체를 일원화하는 것(#2132)이 답이다.
+ *
+ * ⚠️2026-07-23 — #2132가 오늘 배달 경로를 살리면서(BE PR#2448) presence가 "처음으로 실제로
+ * 오기 시작"한다. PO 실측: 프론트 Cloud Run이 60s마다 강제로 연결을 끊어 전 접속자가 60초
+ * 주기로 재연결하고, 재연결 1건마다 BE가 emit_presence 1건을 org 전원에게 push한다 — 즉 접속자
+ * M명이면 클라이언트 1개가 분당 최대 M건의 'presence' 이벤트를 받을 수 있다(M명이 각자 60초
+ * 주기로 재연결하며 그 각각이 전원에게 push되므로). 아래 세 가드가 이걸 감당한다:
+ * ① 디바운스(300ms) — presence 이벤트는 payload 없는 경량 트리거라(trigger({})) 여러 건을
+ *   한 번의 refetch로 접어도 정보 손실이 0이다. 300ms는 근접 도착한 이벤트를 한 틱으로 묶기엔
+ *   충분하고, 사람이 체감하기엔 여전히 즉시로 느껴지는 값(NN/g 기준 "0.1~1s는 지연 안 느껴짐"
+ *   범위 내 — 실제 변경이 뜨는 데 최대 0.3초 더 걸리는 것뿐이라 UX 저하가 아니다).
+ * ② in-flight 가드 — 요청이 이미 진행 중이면 새로 안 쏘고, 끝난 뒤 "한 번 더" 필요했는지만
+ *   표시해 요청 종료 즉시 재실행한다(그냥 무시하면 그 사이 도착한 최신 변경을 놓친다).
+ * ③ 레이스 가드(제일 중요) — 요청마다 단조증가 시퀀스를 붙여, 응답이 왔을 때 그 요청이 여전히
+ *   최신 요청인지 확認 후에만 state에 반영한다. 없으면 늦게 도착한 stale 응답이 최신 스냅샷을
+ *   덮어써 **틀린 화면을 그리는** 사고가 난다(①②는 비용 문제, ③은 정확성 문제라 성격이 다르다).
  */
+const PRESENCE_EVENT_DEBOUNCE_MS = 300;
+
 export function useTeamPresence(active: boolean, memberId?: string): TeamPresenceItem[] {
   const [items, setItems] = useState<TeamPresenceItem[]>([]);
   const mux = useSseMultiplexerContext();
 
+  const seqRef = useRef(0);
+  const inFlightRef = useRef(false);
+  const pendingRef = useRef(false);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // story #2139 — in-flight 가드(②) + 레이스 가드(③). 실제 네트워크 호출은 여기서만 한다.
   const fetchPresence = useCallback(async () => {
     if (typeof document !== 'undefined' && document.hidden) return;
+    if (inFlightRef.current) { pendingRef.current = true; return; }
+    inFlightRef.current = true;
+    const mySeq = ++seqRef.current;
     try {
       const res = await fetch('/api/team-presence');
       if (!res.ok) return;
       const json = (await res.json()) as TeamPresenceItem[] | { data?: TeamPresenceItem[] };
-      setItems(Array.isArray(json) ? json : (json.data ?? []));
+      // 이 응답을 보낸 뒤에 더 최신 요청이 나갔다면(seqRef가 더 커졌다면) stale이므로 버린다.
+      if (seqRef.current === mySeq) {
+        setItems(Array.isArray(json) ? json : (json.data ?? []));
+      }
     } catch {
       /* non-critical */
+    } finally {
+      inFlightRef.current = false;
+      if (pendingRef.current) {
+        pendingRef.current = false;
+        void fetchPresence();
+      }
     }
   }, []);
 
+  // story #2139 — 디바운스(①). 'presence' 이벤트가 짧은 창에 몰려 도착해도 refetch는 한 번만
+  // 나가게 접는다. 마운트/탭복귀/재연결 트리거는 각자 단발성 신호라 디바운스 없이 즉시 부른다 —
+  // in-flight·레이스 가드는 fetchPresence 내부에서 호출자와 무관하게 항상 적용된다.
+  const scheduleFetchPresence = useCallback(() => {
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    debounceTimerRef.current = setTimeout(() => {
+      debounceTimerRef.current = null;
+      void fetchPresence();
+    }, PRESENCE_EVENT_DEBOUNCE_MS);
+  }, [fetchPresence]);
+
   useEffect(() => {
     if (!active || typeof window === 'undefined') return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     void fetchPresence(); // 초기 스냅샷
     const onVisible = () => { if (!document.hidden) void fetchPresence(); }; // hidden 중 누락 보정
     document.addEventListener('visibilitychange', onVisible);
 
     if (mux) {
-      const unsubPresence = mux.subscribe('presence', () => { void fetchPresence(); });
+      const unsubPresence = mux.subscribe('presence', () => { scheduleFetchPresence(); });
       // story #2139 — 공유 커넥션이 끊겼다 재연결되면 그 구간에 놓쳤을 변경을 강제 refetch로 흡수.
       const unsubReconnect = mux.subscribeReconnect(() => { void fetchPresence(); });
       return () => {
         unsubPresence();
         unsubReconnect();
         document.removeEventListener('visibilitychange', onVisible);
+        if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
       };
     }
 
@@ -88,9 +134,13 @@ export function useTeamPresence(active: boolean, memberId?: string): TeamPresenc
     // 걸지 않고 브라우저 native auto-reconnect에 맡기지만, onError를 호출해두지 않으면
     // isReconnect()가 영원히 false로 남아 위 onopen의 refetch가 절대 안 켜진다.
     es.onerror = () => { backoff.onError(); };
-    es.addEventListener('presence', () => { void fetchPresence(); }); // 변경 시 push → refetch
-    return () => { es.close(); document.removeEventListener('visibilitychange', onVisible); };
-  }, [active, fetchPresence, memberId, mux]);
+    es.addEventListener('presence', () => { scheduleFetchPresence(); }); // 변경 시 push → 디바운스 후 refetch
+    return () => {
+      es.close();
+      document.removeEventListener('visibilitychange', onVisible);
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    };
+  }, [active, fetchPresence, scheduleFetchPresence, memberId, mux]);
 
   return items;
 }


### PR DESCRIPTION
## Summary
- Story #2139 — BE(#2132/PR#2448)가 오늘 presence 배달 경로를 살리면서 `presence` SSE 이벤트가 처음으로 실제 도달하기 시작한다. PO 실측: Cloud Run이 60s마다 연결을 끊어 전 접속자가 60초 주기로 재연결하고, 재연결마다 BE가 전원에게 push하므로 접속자 M명이면 클라이언트 1개가 분당 최대 M건의 `presence` 이벤트를 받을 수 있다.
- 기존 구독은 디바운스·in-flight 가드·레이스 가드가 전부 0이었다 — 이벤트가 몰릴 때 요청 폭주 + 늦은 응답이 최신 스냅샷을 덮어쓸 위험. **"지금까지 문제 없었다"는 이 경로가 죽어 있어 이벤트가 한 번도 안 왔기 때문**이라 근거가 안 된다.

## 3중 가드
- **① 디바운스(300ms)** — presence는 payload 없는 경량 트리거라 여러 건을 한 번의 refetch로 접어도 정보 손실 0. `presence` 이벤트 구독에만 적용(마운트/탭복귀/재연결은 단발 신호라 즉시 호출).
- **② in-flight 가드** — 진행 중이면 새로 안 쏘고, 종료 직후 1회 더 실행해 변경을 놓치지 않음.
- **③ 레이스 가드(제일 중요)** — 요청마다 단조증가 시퀀스, 응답 시 자신이 최신 요청인지 확인 후에만 반영. ①②는 비용 문제, ③은 정확성 문제(늦은 응답이 화면을 틀리게 그림)라 성격이 다름.

각 값의 근거는 훅 docblock에 남김.

## last_event_id 별도 확인 (PO 요청)
mux 경로는 재연결마다 URL을 새로 빌드하며 `last_event_id`를 항상 포함(수동 close+재생성 구조라 서버 재개 지원이 무용지물이 될 위험 없음). `use-team-presence.ts`의 독립 EventSource 폴백 경로는 추적 안 함 — presence는 payload 없는 트리거라 #2419의 재연결-강제refetch가 갭을 메꿔 기능적 영향 없음(정합성 지적사항으로만 기록).

## Test coverage
3케이스 추가(디바운스 접힘·in-flight 큐잉·최종 state가 마지막 요청 결과로 정확히 반영). **RED→GREEN 검증 완료**(가드 되돌리면 신규 3케이스 실패 확인 후 복원, 8/8 통과).

⚠️설계 노트: in-flight 가드가 이미 요청을 직렬화해 "동시 요청 중 늦은 응답이 최신을 덮어쓰는" 시나리오는 이 구현에서 실제 재현되지 않는다 — 레이스 가드는 그 전제가 깨질 미래 변경 대비 방어선. 테스트는 in-flight 큐잉으로 이어진 마지막 요청의 결과가 최종 반영됨을 확인해 같은 결론을 고정.

## Gate 결과 (worktree root)
- `pnpm --filter web type-check` — **0 errors**
- `pnpm --filter web lint` — **0 errors**, 5 pre-existing warnings 무관 파일
- `pnpm test` — **306 test files passed, 2097 tests passed, 2 skipped, 0 failed**
- `pnpm --filter web build` — **EXIT 0**

## Test plan
- [x] type-check clean
- [x] lint clean
- [x] full vitest suite green
- [x] production build succeeds
- [ ] QA(까심) review — 승인 없이 머지 금지

🤖 Generated with [Claude Code](https://claude.com/claude-code)