### PR TITLE
feat(#2139): enable backplane in prod too — presence/presence_online/sse_lease

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -112,12 +112,13 @@ jobs:
             # prod에 얹지 않는다 — develop→main 48커밋 일괄승격에 검증 안 된 롤백 플래그를
             # 섞으면 문제 발생 시 원인 격리가 안 된다. dev 실측 후 별도 판단.
             echo "sse_multiplex_enabled=false" >> "$GITHUB_OUTPUT"
-            # story #2139/#2143 후속(2026-07-23, 오르테가군 판정) — 백플레인 켜기 3종은 prod가
-            # 실시간 GCE 3노드 쪽도 함께 켜야 하는 별도 단계라 dev 게이트 통과 전엔 얹지 않는다
-            # (#2120/#2121/#2122와 동일 원칙 — 위 sse_multiplex_enabled와 나란히).
-            echo "backend_presence_redis_enabled=false" >> "$GITHUB_OUTPUT"
-            echo "backend_presence_online_redis_enabled=false" >> "$GITHUB_OUTPUT"
-            echo "backend_sse_lease_redis_enabled=false" >> "$GITHUB_OUTPUT"
+            # story #2139/#2143 후속(2026-07-23, 오르테가군 판정 — dev 게이트 GREEN 확認 後
+            # 같은 날 prod 승격, "절반만 고치는 것" 방지 교정): backend 쪽을 GCE 실시간 3노드와
+            # 같은 흐름에서 켠다(한쪽만 켜고 멈추면 오늘의 #2448 인시던트와 동형 반쪽 상태가
+            # prod에 남는다). deploy_realtime_gce.sh의 prod 분기 기본값도 이 커밋과 짝으로 true.
+            echo "backend_presence_redis_enabled=true" >> "$GITHUB_OUTPUT"
+            echo "backend_presence_online_redis_enabled=true" >> "$GITHUB_OUTPUT"
+            echo "backend_sse_lease_redis_enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"

--- a/backend/scripts/deploy_realtime_gce.sh
+++ b/backend/scripts/deploy_realtime_gce.sh
@@ -263,16 +263,13 @@ PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}DB_MAX_OVERFLOW=1"
 # backend-prod는 SSE 전용이 아니라 REST 트래픽과 캡을 공유하기 때문(다른 성격의 노드).
 # dev/prod 둘 다 이 GCE 스택에서는 500 그대로 유지 — env 분기 대상 아님.
 PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}MAX_SSE_CONNECTIONS=500"
-# story #2139/#2143 후속(2026-07-23, 오르테가군 판정) — "백플레인 켜기" durable화. dev만
-# true — prod는 backend(cloudbuild.yaml _BACKEND_PRESENCE_*/_BACKEND_SSE_LEASE_*)와 함께
-# 켜야 하는 별도 단계(#2120/#2121/#2122와 동일 원칙, dev 게이트 통과 전엔 얹지 않는다).
+# story #2139/#2143 후속(2026-07-23, 오르테가군 판정 — dev 게이트 GREEN 확認 後 같은 날
+# prod 승격, "절반만 고치는 것" 방지 교정): dev/prod 둘 다 true. backend(cloudbuild.yaml
+# _BACKEND_PRESENCE_*/_BACKEND_SSE_LEASE_*)와 같은 흐름에서 켠다 — 한쪽만 켜고 멈추면
+# backend는 Redis 공유·GCE는 로컬인 반쪽 상태가 prod에 남는다(오늘 #2448 인시던트와 동형).
 # 손 env override(PRESENCE_REDIS_ENABLED=true bash ... prod 식)는 여기 SSOT 기본값을 다음
 # 배포가 덮으므로 durable 값 자체를 여기 못박는다.
-if [ "${ENV}" = "dev" ]; then
-    _BACKPLANE_DEFAULT=true
-else
-    _BACKPLANE_DEFAULT=false
-fi
+_BACKPLANE_DEFAULT=true
 # #2120(E-ARCH 근본): chat_presence working → Redis 공유 롤아웃 게이트(프로세스-로컬 dict라
 # GCE 멀티노드에서 노드마다 다르게 보이는 실제 결함 — 미르코의 working 판정이 여기 걸림).
 PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}PRESENCE_REDIS_ENABLED=${PRESENCE_REDIS_ENABLED:-${_BACKPLANE_DEFAULT}}"


### PR DESCRIPTION
## Summary
Stacked on #2454 (dev-only enable) — prepared in parallel per Ortega's explicit correction: staging dev/prod as separate steps left prod in a half-fixed state for an unbounded time, the same defect class as merging #2448 human-only for several hours today ("half-fixes" pattern flagged twice in one day).

Flips prod to `true` for all three backplane flags, in the same rollout as the GCE realtime 3-node side:
- `cloud-build.yml` prod branch: `backend_presence_redis_enabled` / `backend_presence_online_redis_enabled` / `backend_sse_lease_redis_enabled` → `true`.
- `deploy_realtime_gce.sh`: `_BACKPLANE_DEFAULT` is now unconditional `true` (was `ENV`-branched dev-only) — backend alone sharing via Redis while GCE stays process-local would be a more confusing half-on state than fully off.

**Merge gate**: do not merge until the dev verification completes green (backend-dev auto-deploy + GCE dev rolling-update + Mirko's working check + Kasim's node-variance check). This PR is prepared now so it can land the moment that gate passes, not built from scratch afterward.

Note: since this branch stacks on #2454, its diff currently includes #2454's commit too — it'll shrink to just the 2-file prod delta once #2454 merges.

## Test plan
- [x] `bash -n` + YAML syntax valid.
- [x] `test_deploy_env.py` / `test_deploy_realtime_gce_env.py` / `test_cloudbuild_migrate_wiring.py` / `test_deploy_backend_redis_secret_conflict.py` — 66 passed together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)