### PR TITLE
fix(gce-deploy): rolling-action max-surge hardcoded 1 rejected on prod, failure was swallowed

### DIFF
--- a/backend/scripts/deploy_realtime_gce.sh
+++ b/backend/scripts/deploy_realtime_gce.sh
@@ -46,6 +46,29 @@ else
     COMMIT_SHA="${COMMIT_SHA:?COMMIT_SHA is required}"
 fi
 
+# ⛔prod GCE 재배포 사고(2026-07-24, 오르테가 자인) — 실행자의 로컬 체크아웃이 낮의
+# codex-스캔용 오래된 커밋(d0acf749)에 멈춰 있는 채로 이 스크립트를 돌렸다. COMMIT_SHA는
+# 도커 이미지 태그만 바꿨을 뿐 **스크립트 파일 자체**는 그 stale 체크아웃 그대로 실행돼,
+# `_BACKPLANE_DEFAULT` 도입 이전 버전(백플레인 항상 false)으로 첫 prod 배포가 조용히
+# 나갔다 — 오늘 rc=0 삼킴과 같은 계열(스크립트가 옳아도 옛 버전을 돌리면 무의미). 이 스크립트
+# 자신이 실행 중인 로컬 git checkout의 HEAD를 못박아 눈에 띄게 만든다(git 정보 없으면
+# "unknown"으로 표시만 하고 계속 진행 — 이 가드가 배포 자체를 막을 만큼 확실하진 않다).
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_LOCAL_HEAD="$(git -C "${_SCRIPT_DIR}" rev-parse HEAD 2>/dev/null || echo "unknown")"
+# log()는 이 시점에 아직 정의 전(스크립트 뒤쪽에서 정의)이라 echo로 직접 씀.
+echo "Running from local checkout HEAD=${_LOCAL_HEAD} (deploying COMMIT_SHA=${COMMIT_SHA} image tag)" >&2
+if [ "${_LOCAL_HEAD}" != "unknown" ] && [ "${DRY_RUN}" != "1" ]; then
+    case "${_LOCAL_HEAD}" in
+        "${COMMIT_SHA}"*) : ;;  # 접두 일치 — 정상(로컬 체크아웃 = 배포 대상 커밋).
+        *)
+            echo "⚠️  WARNING: local checkout HEAD(${_LOCAL_HEAD})가 COMMIT_SHA(${COMMIT_SHA})와" >&2
+            echo "   다르다 — 이 스크립트 파일 자체가 오래된 체크아웃에서 실행 중일 수 있다." >&2
+            echo "   (오늘 실측 사고: d0acf749 stale checkout으로 백플레인 false 템플릿이 나감)" >&2
+            echo "   'git pull'/'git checkout develop' 후 재실행을 확인할 것." >&2
+            ;;
+    esac
+fi
+
 case "${ENV}" in
     dev)
         MIG_NAME="sprintable-realtime-gateway-dev"

--- a/backend/scripts/deploy_realtime_gce.sh
+++ b/backend/scripts/deploy_realtime_gce.sh
@@ -596,18 +596,39 @@ if gcloud compute instance-groups managed describe "${MIG_NAME}" \
         # 안전했다(아무 것도 건드리기 전에 멈춤 — backends/named-ports/https 200 전부 무영향,
         # fail-fast) — 그래도 실행 없이는 코드리뷰/CI로 못 잡는 gcloud API 제약이었다.
         #
-        # 수정: `--max-unavailable=0`(항상 유효한 값) + `--max-surge=1`. 이 스택의 존재
-        # 이유가 SSE 장수명 연결(설계 doc)이라, 기존 노드를 먼저 빼는 대신 **새 인스턴스를
-        # 먼저 띄우고** 헬스체크 통과 後 옮기는 쪽을 우선한다(오르테가 명시 선호). surge=1로
-        # 제한해 3대 e2-small이 일시 4대까지만 늘어나게(전체 3대 동시 서지=6대는 비용·쿼터
-        # 여유가 불확실해 배제).
-        log "Rolling-updating ${MIG_NAME} to template ${TEMPLATE_NAME} (MIG 객체 보존 — backend-service 부착·named-ports 무영향)"
-        gcloud compute instance-groups managed rolling-action start-update "${MIG_NAME}" \
+        # ⛔prod 재배포 핫픽스(2026-07-24, 오르테가 실 재배포 실측 — 오늘 이 파일 세 번째 같은
+        # 결함류: delete+recreate·maxUnavailable·이번 maxSurge, 전부 "실행은 됐는데 실효는
+        # 없는" 형태) — `--max-surge=1`도 같은 regional MIG 제약에 걸린다: "Fixed
+        # updatePolicy.maxSurge for regional managed instance group has to be either 0 or at
+        # least equal to the number of zones". dev(당시 실측 zone 구성)에선 우연히 통과했지만
+        # prod(3존)에선 거부됐다 — "1"을 하드코딩하지 않고 **이 MIG가 실제로 걸쳐 있는 존
+        # 개수를 조회**해 그 값을 쓴다(하드코딩 "3"도 안 쓴다 — 스크립트가 아는 값과 라이브
+        # 존 구성이 어긋나면 오늘 반복된 "코드는 맞는데 실측과 다르다" 함정이 그대로 재현된다).
+        # max-unavailable=0 유지(항상 유효값·SSE 무중단 우선 — 새 인스턴스 먼저 띄우고
+        # 헬스체크 통과 後 옮기는 설계 의도는 그대로).
+        # json(...) 서브셋으로 좁혀 zones 리스트만 뽑은 뒤 "zone" 키 등장 횟수로 카운트 —
+        # gcloud value()의 리스트 join 구분자를 가정하지 않는 가장 안전한 방식. ⚠️grep -c는
+        # "매치된 줄 수"를 세지 총 매치 횟수가 아니다 — gcloud json 출력이 한 줄로 나오면
+        # (pretty-print 보장 없음) zone이 몇 개든 항상 1로 잡히는 실측 버그를 mock-gcloud
+        # 테스트로 직접 재현·확認했다. grep -o | wc -l로 줄 구조와 무관하게 총 출현 횟수를 센다.
+        _ZONE_COUNT=$(gcloud compute instance-groups managed describe "${MIG_NAME}" \
+            --project="${GCP_PROJECT}" --region="${GCP_REGION}" \
+            --format='json(distributionPolicy.zones)' | grep -o '"zone":' | wc -l | tr -d ' ')
+        log "Rolling-updating ${MIG_NAME} to template ${TEMPLATE_NAME} (MIG 객체 보존 — backend-service 부착·named-ports 무영향, max-surge=${_ZONE_COUNT} zone 수 실측)"
+        # ⛔같은 실측(2026-07-24) — rolling-action 실패가 파이프라인/래퍼를 거치면 rc=0으로
+        # 보일 수 있다(캡처 방식에 따라 exit code가 가려짐). `if ! CMD; then`로 이 명령
+        # **자체의** 종료코드를 명시 확인해 실패를 실패로 드러낸다(암묵적 set -e 전파에만
+        # 의존하지 않는다 — 이 파일 상단 `_REALTIME_URL` 빈값 가드와 동일한 명시-실패 컨벤션).
+        if ! gcloud compute instance-groups managed rolling-action start-update "${MIG_NAME}" \
             --project="${GCP_PROJECT}" \
             --region="${GCP_REGION}" \
             --version=template="${TEMPLATE_NAME}" \
             --max-unavailable=0 \
-            --max-surge=1
+            --max-surge="${_ZONE_COUNT}"; then
+            echo "FAIL: rolling-action start-update 실패(${MIG_NAME}) — MIG는 이전 템플릿에 그대로 남아있다."
+            echo "      위 gcloud 에러 메시지를 확인할 것(예: maxSurge/maxUnavailable 제약)."
+            exit 1
+        fi
     fi
 else
     log "Creating MIG ${MIG_NAME} (size ${TARGET_SIZE}, zones ${ZONES}, no autoscaling)"

--- a/backend/tests/test_deploy_gce_rolling_update_maxsurge_failfast.py
+++ b/backend/tests/test_deploy_gce_rolling_update_maxsurge_failfast.py
@@ -65,7 +65,7 @@ def _mock_gcloud_script(*, rolling_action_exit: int, zone_count: int) -> str:
         """)
 
 
-def _run_script(tmp_path, *, rolling_action_exit: int, zone_count: int):
+def _run_script(tmp_path, *, rolling_action_exit: int, zone_count: int, commit_sha: str = "deadbeef"):
     mock_bin_dir = tmp_path / "mockbin"
     mock_bin_dir.mkdir()
     gcloud_path = mock_bin_dir / "gcloud"
@@ -83,7 +83,7 @@ def _run_script(tmp_path, *, rolling_action_exit: int, zone_count: int):
         **os.environ,
         "PATH": f"{mock_bin_dir}:{os.environ['PATH']}",
         "DRY_RUN": "0",
-        "COMMIT_SHA": "deadbeef",
+        "COMMIT_SHA": commit_sha,
         # dev 분기의 하드코딩 MIG_NAME(스크립트 내부 변수) — mock gcloud는 별도 프로세스라
         # 스크립트 내부 변수를 못 보므로, backend-services describe mock 응답에 같은 이름을
         # 실어주기 위해 여기서도 명시(스크립트 값과 반드시 동일해야 함).
@@ -134,3 +134,26 @@ def test_rolling_action_success_reaches_end_of_script(tmp_path):
     assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
     # log()는 stderr로 쓴다(이 스크립트 전체 컨벤션 — DRY_RUN의 stdout KEY=VALUE 출력과 분리).
     assert "Deployment submitted" in proc.stderr
+
+
+# ── 로컬 체크아웃 버전 가드(2026-07-24, 오르테가 실 사고 — stale d0acf749 체크아웃으로 첫
+# prod 배포가 백플레인 false 템플릿을 조용히 만들어냈다) ─────────────────────────────────
+
+def _real_repo_head() -> str:
+    import subprocess as _sp
+    return _sp.run(
+        ["git", "rev-parse", "HEAD"], cwd=os.path.dirname(_SCRIPT), capture_output=True, text=True,
+    ).stdout.strip()
+
+
+def test_version_guard_warns_when_commit_sha_does_not_match_local_checkout(tmp_path):
+    """⭐로컬 체크아웃(스크립트 파일 자체)이 COMMIT_SHA와 다른 커밋에 멈춰 있으면 경고 —
+    오늘 사고(옛 스크립트가 실행돼 백플레인 false 템플릿을 조용히 생성)의 재발 방지."""
+    proc, _ = _run_script(tmp_path, rolling_action_exit=0, zone_count=3, commit_sha="not-the-real-sha")
+    assert "WARNING" in proc.stderr and "local checkout" in proc.stderr, f"stderr={proc.stderr!r}"
+
+
+def test_version_guard_silent_when_commit_sha_matches_local_checkout(tmp_path):
+    """무회귀 대조군 — 정상 케이스(로컬 체크아웃 = 배포 대상 커밋)에서는 경고가 안 뜬다."""
+    proc, _ = _run_script(tmp_path, rolling_action_exit=0, zone_count=3, commit_sha=_real_repo_head())
+    assert "WARNING" not in proc.stderr, f"stderr={proc.stderr!r}"

--- a/backend/tests/test_deploy_gce_rolling_update_maxsurge_failfast.py
+++ b/backend/tests/test_deploy_gce_rolling_update_maxsurge_failfast.py
@@ -1,0 +1,136 @@
+"""GCE prod 재배포 핫픽스(2026-07-24, 오르테가 실 재배포 실측) — deploy_realtime_gce.sh
+rolling-action 관련 두 결함의 실행 기반(mock gcloud) 회귀가드.
+
+배경: prod 재배포에서 `--max-surge=1`이 regional MIG 제약("0 또는 zone 수 이상")에 걸려
+거부됐는데, 그 실패가 "deploy rc=0"으로 보였다 — MIG는 옛 템플릿에 남아있는 채로 성공
+처럼 보고된 것. 오늘 이 파일이 걸린 세 번째 같은 클래스 결함(delete+recreate·
+maxUnavailable에 이어)이라 "실행 없이는 gcloud API 제약을 코드리뷰로 못 잡는다"는 교훈이
+반복됐다 — 이 테스트는 실 GCP 접근 없이도(mock gcloud 함수) 그 실행 층 자체를 고정한다.
+
+⚠️DRY_RUN=1은 이 로직 자체를 건너뛴다(라인 486의 exit 0 — 실 gcloud 호출부 진입 前). 그래서
+기존 test_deploy_realtime_gce_env.py의 DRY_RUN 패턴으로는 이 결함을 원천적으로 못 잡는다.
+이 파일은 DRY_RUN=0으로 스크립트를 실제로 끝까지 돌리되, PATH에 mock gcloud 함수를 얹어
+실 GCP 호출 없이 그 실행 경로를 그대로 태운다.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+
+_SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "deploy_realtime_gce.sh")
+
+
+def _mock_gcloud_script(*, rolling_action_exit: int, zone_count: int) -> str:
+    """실행 경로를 그대로 태우기 위한 최소 mock — dev 시나리오(템플릿·MIG 둘 다 이미 존재
+    → rolling-update 분기)만 커버한다. 인자 패턴 매칭으로 각 서브커맨드에 필요한 최소
+    응답만 돌려준다(실 gcloud 응답 그대로 흉내낼 필요 없음 — 이 스크립트의 소비 로직만
+    검증 대상)."""
+    zones_json = ", ".join(f'{{"zone": "z{i}"}}' for i in range(zone_count))
+    return textwrap.dedent(f"""\
+        #!/usr/bin/env bash
+        set -euo pipefail
+        args="$*"
+        echo "MOCK_GCLOUD_CALL: $args" >> "${{MOCK_GCLOUD_LOG}}"
+
+        case "$args" in
+            *"instance-templates describe"*)
+                exit 0  # 템플릿 이미 존재 — create 스킵.
+                ;;
+            *"instance-groups managed describe"*"format=json(distributionPolicy.zones)"*)
+                echo '{{"distributionPolicy": {{"zones": [{zones_json}]}}}}'
+                exit 0
+                ;;
+            *"instance-groups managed describe"*)
+                exit 0  # MIG 이미 존재 — rolling-update 분기 진입.
+                ;;
+            *"rolling-action start-update"*)
+                echo "$args" >> "${{MOCK_ROLLING_ACTION_ARGS_FILE}}"
+                if [ "{rolling_action_exit}" != "0" ]; then
+                    echo "ERROR: Invalid value for 'updatePolicy.maxSurge.fixed'" >&2
+                fi
+                exit {rolling_action_exit}
+                ;;
+            *"set-named-ports"*)
+                exit 0
+                ;;
+            *"backend-services describe"*)
+                echo "https://.../instanceGroups/${{MIG_NAME:-mig}}"
+                exit 0
+                ;;
+            *)
+                exit 0
+                ;;
+        esac
+        """)
+
+
+def _run_script(tmp_path, *, rolling_action_exit: int, zone_count: int):
+    mock_bin_dir = tmp_path / "mockbin"
+    mock_bin_dir.mkdir()
+    gcloud_path = mock_bin_dir / "gcloud"
+    gcloud_path.write_text(
+        _mock_gcloud_script(rolling_action_exit=rolling_action_exit, zone_count=zone_count)
+    )
+    gcloud_path.chmod(0o755)
+
+    log_file = tmp_path / "mock_calls.log"
+    rolling_args_file = tmp_path / "rolling_action_args.txt"
+    log_file.write_text("")
+    rolling_args_file.write_text("")
+
+    env = {
+        **os.environ,
+        "PATH": f"{mock_bin_dir}:{os.environ['PATH']}",
+        "DRY_RUN": "0",
+        "COMMIT_SHA": "deadbeef",
+        # dev 분기의 하드코딩 MIG_NAME(스크립트 내부 변수) — mock gcloud는 별도 프로세스라
+        # 스크립트 내부 변수를 못 보므로, backend-services describe mock 응답에 같은 이름을
+        # 실어주기 위해 여기서도 명시(스크립트 값과 반드시 동일해야 함).
+        "MIG_NAME": "sprintable-realtime-gateway-dev",
+        "MOCK_GCLOUD_LOG": str(log_file),
+        "MOCK_ROLLING_ACTION_ARGS_FILE": str(rolling_args_file),
+    }
+    proc = subprocess.run(
+        ["bash", _SCRIPT, "dev"],
+        capture_output=True, text=True, env=env,
+    )
+    rolling_args = rolling_args_file.read_text().strip()
+    return proc, rolling_args
+
+
+def test_rolling_action_failure_is_surfaced_not_swallowed(tmp_path):
+    """⭐핵심 회귀가드 — rolling-action이 비-0 종료해도 스크립트가 조용히 rc=0으로 넘어가지
+    않는다(오늘 실측된 결함 그대로). 명시 FAIL: 마커 + 최종 종료코드 != 0 둘 다 확인."""
+    proc, _ = _run_script(tmp_path, rolling_action_exit=1, zone_count=3)
+    assert proc.returncode != 0, (
+        f"rolling-action 실패인데도 스크립트가 rc=0으로 종료됨(오늘 실측된 바로 그 결함) — "
+        f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    )
+    assert "FAIL:" in proc.stdout, f"명시 실패 마커 없음 — stdout={proc.stdout!r}"
+
+
+def test_rolling_action_max_surge_uses_live_zone_count_not_hardcoded_1(tmp_path):
+    """⭐prod 재배포에서 거부된 --max-surge=1 하드코딩을 회귀 방지 — 실 zone 수(mock=3)를
+    그대로 반영해 호출하는지 확인. 하드코딩 "3"도 아니고(dev/prod 어느 쪽이든) MIG가
+    실제로 걸친 zone 수를 그대로 쓰는지가 핵심(다른 zone 수로도 검증)."""
+    _, rolling_args = _run_script(tmp_path, rolling_action_exit=0, zone_count=3)
+    assert "--max-surge=3" in rolling_args, f"got: {rolling_args!r}"
+    assert "--max-surge=1" not in rolling_args, "구 하드코딩 값(1)이 여전히 쓰이고 있음"
+
+
+def test_rolling_action_max_surge_tracks_different_zone_count(tmp_path):
+    """zone 수가 3이 아닌 경우(예: 5)에도 그 실측값을 그대로 따라가는지 — 이번엔 "3"으로
+    하드코딩을 바꿔치기하는 회귀까지 잡는다(1→3 치환만으로는 다음에 zone 수가 또 바뀌면
+    똑같이 재발한다)."""
+    _, rolling_args = _run_script(tmp_path, rolling_action_exit=0, zone_count=5)
+    assert "--max-surge=5" in rolling_args, f"got: {rolling_args!r}"
+
+
+def test_rolling_action_success_reaches_end_of_script(tmp_path):
+    """정상 종료 시(rolling-action 성공) 스크립트가 끝까지 도달해 rc=0으로 마친다 — 위
+    실패 케이스와의 대조군(무회귀 확인)."""
+    proc, _ = _run_script(tmp_path, rolling_action_exit=0, zone_count=3)
+    assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    # log()는 stderr로 쓴다(이 스크립트 전체 컨벤션 — DRY_RUN의 stdout KEY=VALUE 출력과 분리).
+    assert "Deployment submitted" in proc.stderr


### PR DESCRIPTION
## Summary
Third defect of this same class in this file today (delete+recreate, then maxUnavailable, now maxSurge) — each time the script "ran successfully" but did nothing real. This time: `--max-surge=1` hit the same regional-MIG constraint as the earlier `maxUnavailable` fix ("must be 0 or >= zone count"), rejected on prod's 3-zone MIG. The failure didn't surface — Ortega observed `deploy rc=0` while the MIG stayed on the old template with all three nodes still on the old flags.

Not urgent (Ortega already unblocked prod live with a direct `--max-surge=3` override) — this is the SSOT fix so it doesn't recur.

Two independent fixes, both because "ran" != "worked" for gcloud calls:

1. **Stop hardcoding `max-surge=1`** — query the MIG's actual live zone count via `gcloud ... describe --format='json(distributionPolicy.zones)'` and use that (not a hardcoded `3` either — that would just be the same class of bug with a different constant). Caught and fixed a real bug in my first attempt at this along the way: `grep -c` counts matching *lines*, not total occurrences — gcloud's JSON output isn't guaranteed one-zone-per-line, so `grep -c` silently returned `1` regardless of the real zone count. Found this via the mock-gcloud test below, not by inspection. Switched to `grep -o | wc -l`.
2. **Explicitly check the rolling-action command's own exit status** (`if ! gcloud ...; then echo "FAIL: ..."; exit 1; fi`) instead of relying solely on implicit `set -e` propagation, which is fragile depending on how the script gets invoked/piped by its caller. Matches this file's own existing explicit fail-fast convention (the `_REALTIME_URL` empty-check a few lines up).

## Test plan
- [x] New test file uses a mock `gcloud` shim (a fake executable prepended to `PATH`) to run the real script end-to-end without live GCP access — `DRY_RUN=1` exits before this code path entirely, so the existing DRY_RUN-based test file structurally cannot exercise it.
- [x] Mutation-checked: 3 of 4 new tests fail against the pre-fix script, reproducing the exact live symptoms (`--max-surge=1` hardcoded regardless of real zone count, rolling-action failure not surfaced).
- [x] `bash -n` + all 4 new tests + existing deploy-config test files (70 total) pass together.
- [x] Full non-realdb suite: 3931 passed (only the same 7 pre-existing local-env-only failures that self-skip in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)