### PR TITLE
fix(#2135): axis 4 crashed live — env-drift-guard.yml has no backend deps installed

### DIFF
--- a/backend/tests/test_check_env_drift_settings_coverage.py
+++ b/backend/tests/test_check_env_drift_settings_coverage.py
@@ -122,3 +122,24 @@ def test_axis4_pass_is_visible_even_when_another_axis_fails(monkeypatch, capsys)
     assert "④Settings 커버리지" in out and "이상 없음" in out, (
         f"축①만 FAIL이고 축④는 통과인데 그 통과가 출력에 안 보임 — stdout:\n{out}"
     )
+
+
+def test_settings_field_env_keys_works_without_pydantic_settings_importable(monkeypatch):
+    """⭐라이브 실증(2026-07-24) 재현 — env-drift-guard.yml 워크플로는 backend 의존성
+    (pydantic_settings 등)을 설치하지 않는다. `import app.core.config`를 실제로 태우면
+    `ModuleNotFoundError`로 매일 00:00 크래시하는 가드가 나간다(실측된 그대로). static
+    파싱은 이 import 자체를 안 하므로, `pydantic_settings`가 애초에 설치 안 돼 있어도
+    (sys.modules에서 강제로 못 찾게 만들어 재현) 정상 동작해야 한다."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _blocking_import(name, *args, **kwargs):
+        if name == "pydantic_settings" or name.startswith("pydantic_settings."):
+            raise ModuleNotFoundError(f"No module named '{name}'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocking_import)
+    mod = _load_check_env_drift()  # 모듈 자체 로드도 이 차단 안에서(위 실측과 동일 조건).
+    keys = mod._settings_field_env_keys()
+    assert "PRESENCE_REDIS_ENABLED" in keys and len(keys) == 82

--- a/infra/check_env_drift.py
+++ b/infra/check_env_drift.py
@@ -54,13 +54,27 @@ _SETTINGS_CONSUMING_SERVICES = {
 }
 
 
+_SETTINGS_CONFIG_PATH = _REPO_ROOT / "backend" / "app" / "core" / "config.py"
+# `    field_name: type = default` 형태의 클래스 필드 선언만 잡는다(4칸 들여쓰기 — Settings
+# 클래스 본문 레벨). config.py가 오늘 순수 선언형(82필드 전부 이 형태)이라 정확히 맞는다.
+_SETTINGS_FIELD_RE = re.compile(r"^    ([a-z_][a-zA-Z0-9_]*)\s*:\s*[^=\n]+=", re.MULTILINE)
+
+
 def _settings_field_env_keys() -> set[str]:
-    """app.core.config.Settings의 필드명을 env var 키 이름으로 변환(env_prefix 없음 ⇒
-    필드명 대문자 == env 키, 이 클래스에 alias가 하나도 없음을 전제로 한다 — 전제가 깨지면
-    이 함수도 갱신 필요)."""
-    sys.path.insert(0, str(_REPO_ROOT / "backend"))
-    from app.core.config import Settings
-    return {name.upper() for name in Settings.model_fields}
+    """app/core/config.py를 **static 파싱**해 Settings 필드명을 env var 키로 변환(env_prefix
+    없음 ⇒ 필드명 대문자 == env 키, alias 0개 전제 — 전제가 깨지면 이 함수도 갱신 필요).
+
+    ⛔story #2135 라이브 실증(2026-07-24, 오르테가 재트리거) — 원래는 `from app.core.config
+    import Settings`로 실제 import했으나, env-drift-guard.yml 워크플로는 gcloud+파싱만
+    하는 가벼운 CI라 backend 의존성(pydantic_settings 등)이 설치돼 있지 않다.
+    `ModuleNotFoundError: No module named 'pydantic_settings'`로 매일 00:00 크래시하는
+    가드를 배포할 뻔했다 — fixture(pytest, backend 의존성 있는 환경) 통과가 라이브 동작을
+    보증하지 않는다는 것을 이 사건 자체가 실증한다. **infra 도구가 앱 런타임을 import하면
+    안 된다**가 근본 — static 파싱으로 층을 분리한다(import 0·의존성 0).
+    ⚠️한계: config.py가 동적으로 필드를 생성하면(현재는 순수 선언형 82필드 전부 이 형태라
+    해당 없음) 이 파싱이 놓친다."""
+    text = _SETTINGS_CONFIG_PATH.read_text()
+    return {name.upper() for name in _SETTINGS_FIELD_RE.findall(text)}
 
 
 def _load_settings_exempt() -> dict[str, str]:


### PR DESCRIPTION
## Summary
Live run (2026-07-24, second real trigger, this time correctly targeting `develop` after the first run accidentally hit pre-#2459 `main`) hit:
```
ModuleNotFoundError: No module named 'pydantic_settings'
```

`_settings_field_env_keys()` imported `app.core.config.Settings` directly. That works fine under pytest (backend's own test env has the dependency), but `env-drift-guard.yml` is a lightweight gcloud+parsing workflow that never installs backend dependencies — this would have crashed every single 00:00 UTC scheduled run. Fixture-green CI had nothing to say about it; only the actual live trigger caught it, which is exactly what AC3 (live verification) exists for.

Root cause: an infra tool importing application runtime code couples its dependency footprint to the app's, defeating the reason a separate lightweight drift-guard workflow exists.

Fix: parse `app/core/config.py`'s field declarations with a regex instead of importing `pydantic_settings` at all (`^    field_name: type = ...`, matching the same static approach used during the manual triage earlier). Verified identical field count (82) to the previous import-based version.

## Test plan
- [x] Confirmed running under bare system `python3` (no venv, no backend dependencies installed at all) — same environment shape as the actual CI runner — produces the correct 82-field set.
- [x] New regression test blocks `pydantic_settings` from being importable and confirms the static parse still works.
- [x] Mutation self-check: reverting to the import-based version makes the new test fail with the exact live `ModuleNotFoundError`.
- [x] Full non-realdb suite: 3939 passed (only the same 7 pre-existing local-env-only failures that self-skip in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)