### PR TITLE
[SID:2160] 세션 종료 탭의 401 무한 재폴링 fix — 재로그인 안내

### DIFF
--- a/apps/web/src/components/auth/session-expired-dialog.test.tsx
+++ b/apps/web/src/components/auth/session-expired-dialog.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+//
+// story #2160 — 오르테가 리뷰(PR#2467) 회귀가드: resetSessionExpired()의 프로덕션 호출처가
+// 0건이라, 이 모달을 ESC/바깥클릭으로 닫으면 signaled=true인 채 fetchWithAuth가 영구 단락돼
+// "앱이 되살아날 길 없이 조용히 죽는" 것 — #2160이 고치려던 증상 그대로다. 유일한 출구가
+// 재로그인 CTA(하드 내비게이션) 하나뿐인지를 고정한다.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { SessionExpiredDialog } from './session-expired-dialog';
+import { resetSessionExpired, signalSessionExpired } from '@/lib/auth/session-expired-signal';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const EXPIRED_TITLE = koMessages.session.expiredTitle;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  resetSessionExpired();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  resetSessionExpired();
+});
+
+function renderDialog() {
+  return act(async () => {
+    root.render(
+      <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+        <SessionExpiredDialog />
+      </NextIntlClientProvider>,
+    );
+  });
+}
+
+describe('SessionExpiredDialog — 유일한 출구는 재로그인 CTA다(#2160)', () => {
+  it('signalSessionExpired 후 모달이 뜬다', async () => {
+    await renderDialog();
+    await act(async () => { signalSessionExpired(); });
+    expect(document.body.textContent).toContain(EXPIRED_TITLE);
+  });
+
+  it('ESC 키를 눌러도 모달이 닫히지 않는다 — 안 그러면 signaled=true인 채 fetchWithAuth가 영구 단락된다', async () => {
+    await renderDialog();
+    await act(async () => { signalSessionExpired(); });
+    expect(document.body.textContent).toContain(EXPIRED_TITLE);
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+    });
+    expect(document.body.textContent).toContain(EXPIRED_TITLE); // 여전히 열려있음
+  });
+
+  it('바깥(backdrop) 클릭으로도 닫히지 않는다', async () => {
+    await renderDialog();
+    await act(async () => { signalSessionExpired(); });
+    expect(document.body.textContent).toContain(EXPIRED_TITLE);
+
+    await act(async () => {
+      document.body.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, cancelable: true }));
+      document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+      document.body.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true }));
+      document.body.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+    expect(document.body.textContent).toContain(EXPIRED_TITLE); // 여전히 열려있음
+  });
+
+  it('닫기(X) 버튼이 렌더되지 않는다 — 유일한 출구는 재로그인 CTA뿐이어야 한다', async () => {
+    await renderDialog();
+    await act(async () => { signalSessionExpired(); });
+    expect(document.body.textContent).toContain(EXPIRED_TITLE);
+    expect(document.body.querySelector('[data-slot="dialog-close"]')).toBeNull();
+  });
+});

--- a/apps/web/src/components/auth/session-expired-dialog.tsx
+++ b/apps/web/src/components/auth/session-expired-dialog.tsx
@@ -11,6 +11,13 @@ import { buildLoginRedirect } from '@/lib/auth/session-redirect';
  * AC3(af8d3641): 세션 만료 모달. fetchWithAuth 의 refresh 최종 실패 신호(session-expired-signal)를 받아
  * hard redirect 대신 graceful 안내 — "다시 로그인" 시 현재 경로를 next 로 보존해 §A 계약 redirect.
  * (authenticated) 트리 전역(DashboardShell)에 1회 마운트. 신규 토큰 0(Dialog/Button 재사용).
+ *
+ * story #2160 — 오르테가 리뷰(PR#2467): `resetSessionExpired()`는 프로덕션 호출처가 0건이라,
+ * 이 모달을 ESC/바깥클릭/X로 닫으면 `signaled=true`인 채로 남는다. #2160이 fetchWithAuth에
+ * "signaled면 네트워크 자체를 안 탄다"를 얹었기 때문에, 그 상태에서는 앱 전체가 **되살아날 길 없이**
+ * 조용히 죽는다 — #2160이 고치려던 증상 그대로다. 그래서 출구를 재로그인 CTA(하드 내비게이션 —
+ * 새 페이지 컨텍스트에서 signaled가 자연 초기화됨) 하나로 좁힌다: onOpenChange를 no-op으로 두어
+ * ESC/바깥클릭/포커스아웃 등 어떤 이유로도 내부적으로 닫히지 않게 하고, 닫기 X 버튼도 없앤다.
  */
 export function SessionExpiredDialog() {
   const t = useTranslations('session');
@@ -24,8 +31,8 @@ export function SessionExpiredDialog() {
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent>
+    <Dialog open={open} onOpenChange={() => {}} disablePointerDismissal>
+      <DialogContent showCloseButton={false}>
         <DialogHeader>
           <DialogTitle>{t('expiredTitle')}</DialogTitle>
           <DialogDescription>{t('expiredBody')}</DialogDescription>

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -34,6 +34,7 @@ import { ThemeToggle } from '@/components/nav/theme-toggle';
 import { CommandPalette } from '@/components/command-palette/command-palette';
 import { ProfileMenu } from '@/components/nav/profile-menu';
 import { UnifiedSwitcher, type OrgSwitcherItem } from '@/components/nav/unified-switcher';
+import { fetchWithAuth } from '@/lib/db/client';
 import {
   Sidebar,
   SidebarContent,
@@ -140,7 +141,8 @@ export function AppSidebar({
     let cancelled = false;
     const fetchUnread = async () => {
       try {
-        const res = await fetch('/api/notifications/count');
+        // story #2160 — 30초 폴링이 401을 조용히 삼키던 자리(fetchWithAuth로 전환).
+        const res = await fetchWithAuth('/api/notifications/count');
         if (!res.ok || cancelled) return;
         const json = await res.json() as { data?: { memoUnreadCount?: number; inboxUnreadCount?: number } };
         if (!cancelled) {

--- a/apps/web/src/components/nav/notification-bell.tsx
+++ b/apps/web/src/components/nav/notification-bell.tsx
@@ -13,6 +13,7 @@ import {
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+import { fetchWithAuth } from '@/lib/db/client';
 import { useSseNotifications, type SseEventNotification } from '@/hooks/use-sse-notifications';
 import { useFocusTrap } from '@/hooks/use-focus-trap';
 import { useMediaQuery } from '@/lib/use-media-query';
@@ -95,7 +96,8 @@ function timeAgo(dateStr: string, t: ReturnType<typeof useTranslations>): string
 async function fetchNotifications(projectId?: string): Promise<EventNotification[]> {
   const params = new URLSearchParams({ limit: '30' });
   if (projectId) params.set('project_id', projectId);
-  const res = await fetch(`/api/event-notifications?${params.toString()}`);
+  // story #2160 — 401을 조용히 삼키던 폴링을 fetchWithAuth로 전환(세션만료 인지+재로그인 유도).
+  const res = await fetchWithAuth(`/api/event-notifications?${params.toString()}`);
   if (!res.ok) return [];
   const json = (await res.json()) as unknown;
   if (Array.isArray(json)) return json as EventNotification[];
@@ -109,7 +111,8 @@ async function fetchNotifications(projectId?: string): Promise<EventNotification
 
 async function fetchUnreadCount(projectId?: string): Promise<number> {
   const params = projectId ? `?project_id=${projectId}` : '';
-  const res = await fetch(`/api/event-notifications/unread-count${params}`);
+  // story #2160 — 30초 폴링이 401을 조용히 삼키던 자리(fetchWithAuth로 전환).
+  const res = await fetchWithAuth(`/api/event-notifications/unread-count${params}`);
   if (!res.ok) return 0;
   const json = (await res.json()) as unknown;
   if (json && typeof json === 'object') {

--- a/apps/web/src/components/presence/use-team-presence.test.tsx
+++ b/apps/web/src/components/presence/use-team-presence.test.tsx
@@ -11,10 +11,17 @@ import { useTeamPresence } from './use-team-presence';
 
 class FakeEventSource {
   static instances: FakeEventSource[] = [];
+  // story #2160 — 실 EventSource의 readyState 상수. 이 테스트가 시뮬레이션하는 error→open은
+  // "native auto-reconnect가 다시 연 것"(정상 순단, docstring 참고)이라 CONNECTING이 맞는 기본값
+  // — CLOSED(fatal)였다면 #2160의 세션-확認 분기를 타 fetchMock 호출수가 달라진다.
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
   listeners: Record<string, Array<() => void>> = {};
   onopen: (() => void) | null = null;
   onerror: (() => void) | null = null;
   closed = false;
+  readyState = 0;
   constructor(public url: string, _opts?: unknown) {
     FakeEventSource.instances.push(this);
   }

--- a/apps/web/src/components/presence/use-team-presence.ts
+++ b/apps/web/src/components/presence/use-team-presence.ts
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { PresenceStatus } from '@/components/chat/presence-dot';
 import { useSseMultiplexerContext } from '@/components/realtime-provider';
 import { createReconnectBackoffState } from '@/lib/realtime/sse-reconnect-backoff';
+import { isSessionAlive } from '@/lib/realtime/sse-session-guard';
+import { fetchWithAuth } from '@/lib/db/client';
 
 // 2505d27d: #1356 `GET /api/v2/team-presence` 응답 계약(검증 완료·mismatch 0).
 export interface TeamPresenceItem {
@@ -69,7 +71,7 @@ export function useTeamPresence(active: boolean, memberId?: string): TeamPresenc
     inFlightRef.current = true;
     const mySeq = ++seqRef.current;
     try {
-      const res = await fetch('/api/team-presence');
+      const res = await fetchWithAuth('/api/team-presence');
       if (!res.ok) return;
       const json = (await res.json()) as TeamPresenceItem[] | { data?: TeamPresenceItem[] };
       // 이 응답을 보낸 뒤에 더 최신 요청이 나갔다면(seqRef가 더 커졌다면) stale이므로 버린다.
@@ -133,7 +135,12 @@ export function useTeamPresence(active: boolean, memberId?: string): TeamPresenc
     // 재연결 여부는 hadPriorError(직전 error 발생 이력)로 판정된다 — 이 훅은 수동 재시도를
     // 걸지 않고 브라우저 native auto-reconnect에 맡기지만, onError를 호출해두지 않으면
     // isReconnect()가 영원히 false로 남아 위 onopen의 refetch가 절대 안 켜진다.
-    es.onerror = () => { backoff.onError(); };
+    es.onerror = () => {
+      backoff.onError();
+      // story #2160 — CLOSED면 브라우저가 자동재연결을 이미 포기한 것(non-2xx 등). 조용히
+      // 방치하지 않고 세션 상태를 확認해, 죽었으면 SessionExpiredDialog로 사용자에게 알린다.
+      if (es.readyState === EventSource.CLOSED) void isSessionAlive();
+    };
     es.addEventListener('presence', () => { scheduleFetchPresence(); }); // 변경 시 push → 디바운스 후 refetch
     return () => {
       es.close();

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -4,6 +4,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useSseMultiplexerContext } from '@/components/realtime-provider';
 import { shouldSuppressDuplicateSseEvent } from '@/lib/realtime/sse-event-dedup';
 import { createReconnectBackoffState, type ReconnectBackoffState } from '@/lib/realtime/sse-reconnect-backoff';
+import { isSessionAlive } from '@/lib/realtime/sse-session-guard';
 
 // chat-attach: 메시지 전송 시 첨부 메타 (BE MessageAttachment 계약과 동일).
 export interface SendAttachment {
@@ -164,15 +165,23 @@ export function useChatSse({ currentTeamMemberId, onConversationMessage, onWorki
 
       source.onerror = () => {
         setConnected(false);
+        // story #2160 — CLOSED는 브라우저가 이미 "복구 불가"로 판정한 것(자동재연결 없음).
+        const wasFatal = source.readyState === EventSource.CLOSED;
         source.close();
         sourceRef.current = null;
-        if (!reconnectTimerRef.current) {
+        const scheduleRetry = () => {
+          if (reconnectTimerRef.current) return;
           const delay = backoff.onError();
           reconnectTimerRef.current = setTimeout(() => {
             reconnectTimerRef.current = null;
             connect();
           }, delay);
+        };
+        if (wasFatal) {
+          void isSessionAlive().then((alive) => { if (alive) scheduleRetry(); });
+          return;
         }
+        scheduleRetry();
       };
 
       // conversation.message_created — realtime update for conversation list

--- a/apps/web/src/hooks/use-chat-unread-total.ts
+++ b/apps/web/src/hooks/use-chat-unread-total.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { useChatSse } from './use-chat-sse';
+import { fetchWithAuth } from '@/lib/db/client';
 
 /**
  * story #1977(트랙B) — GNB 채팅 unread 총합(3번째 표면: 데스크톱 사이드바 채팅 항목 +
@@ -23,7 +24,8 @@ export function useChatUnreadTotal(currentTeamMemberId?: string): number {
     let cancelled = false;
     async function fetchTotal() {
       try {
-        const res = await fetch('/api/conversations/unread-count');
+        // story #2160 — 401을 조용히 삼키던 자리(fetchWithAuth로 전환).
+        const res = await fetchWithAuth('/api/conversations/unread-count');
         if (!res.ok || cancelled) return;
         const json = (await res.json()) as { count?: number };
         if (!cancelled) setTotal(json.count ?? 0);

--- a/apps/web/src/hooks/use-sse-notifications.ts
+++ b/apps/web/src/hooks/use-sse-notifications.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react';
 import { useSseMultiplexerContext } from '@/components/realtime-provider';
 import { shouldSuppressDuplicateSseEvent } from '@/lib/realtime/sse-event-dedup';
 import { createReconnectBackoffState } from '@/lib/realtime/sse-reconnect-backoff';
+import { isSessionAlive } from '@/lib/realtime/sse-session-guard';
 
 export interface SseEventNotification {
   id?: string;
@@ -146,15 +147,23 @@ export function useSseNotifications({
       }
 
       es.onerror = () => {
+        // story #2160 — CLOSED는 브라우저가 이미 "복구 불가"로 판정한 것(자동재연결 없음).
+        const wasFatal = es?.readyState === EventSource.CLOSED;
         es?.close();
         es = null;
-        if (!closed && !retryTimer) {
+        const scheduleRetry = () => {
+          if (closed || retryTimer) return;
           const delay = backoff.onError();
           retryTimer = setTimeout(() => {
             retryTimer = null;
             connect();
           }, delay);
+        };
+        if (wasFatal) {
+          void isSessionAlive().then((alive) => { if (alive) scheduleRetry(); });
+          return;
         }
+        scheduleRetry();
       };
     };
 

--- a/apps/web/src/lib/auth/session-expired-signal.ts
+++ b/apps/web/src/lib/auth/session-expired-signal.ts
@@ -24,3 +24,8 @@ export function signalSessionExpired(): void {
 export function resetSessionExpired(): void {
   signaled = false;
 }
+
+/** story #2160 — 세션이 이미 죽었다고 확定된 상태인지(fetchWithAuth가 재시도 전에 조회). */
+export function isSessionExpiredSignaled(): boolean {
+  return signaled;
+}

--- a/apps/web/src/lib/db/client.test.ts
+++ b/apps/web/src/lib/db/client.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+//
+// story #2160 — fetchWithAuth가 signalSessionExpired 이후엔 네트워크를 타지 않는지 고정한다.
+// 이게 없으면 401 폴링/SSE 재연결 루프가 세션이 죽은 뒤에도 매 tick마다 refresh를 재시도해
+// "401에는 재시도하지 않는다"는 처방이 무력화된다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithAuth } from './client';
+import { resetSessionExpired, signalSessionExpired } from '@/lib/auth/session-expired-signal';
+
+beforeEach(() => {
+  resetSessionExpired();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetSessionExpired();
+});
+
+describe('fetchWithAuth — 세션만료 신호 후 단락(#2160)', () => {
+  it('signalSessionExpired 이전에는 평범하게 fetch한다', async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const res = await fetchWithAuth('/api/me');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(200);
+  });
+
+  it('signalSessionExpired 이후에는 fetch를 아예 타지 않고 즉시 401을 반환한다', async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    signalSessionExpired();
+    const res = await fetchWithAuth('/api/me');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/web/src/lib/db/client.ts
+++ b/apps/web/src/lib/db/client.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { signalSessionExpired } from '@/lib/auth/session-expired-signal';
+import { isSessionExpiredSignaled, signalSessionExpired } from '@/lib/auth/session-expired-signal';
 
 // ─── FastAPI Auth Utilities ───────────────────────────────────────────────────
 
@@ -57,6 +57,12 @@ export async function refreshAuthTokens(): Promise<AuthResult> {
 let _refreshing: Promise<AuthResult> | null = null;
 
 export async function fetchWithAuth(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  // story #2160 — 세션이 이미 죽었다고 확定된 뒤(SessionExpiredDialog 노출 중)엔 네트워크를
+  // 아예 타지 않는다. 안 그러면 401 폴링/재연결 루프가 매 tick마다 refresh를 다시 시도해
+  // "401에는 재시도하지 않는다"는 처방이 무력화된다.
+  if (typeof window !== 'undefined' && isSessionExpiredSignaled()) {
+    return new Response(null, { status: 401 });
+  }
   const res = await fetch(input, init);
   if (res.status !== 401) return res;
 

--- a/apps/web/src/lib/realtime/sse-multiplexer.test.tsx
+++ b/apps/web/src/lib/realtime/sse-multiplexer.test.tsx
@@ -8,6 +8,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, useEffect } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { useSseMultiplexer, type SseMultiplexerHandle } from './sse-multiplexer';
+import { fetchWithAuth } from '@/lib/db/client';
+
+vi.mock('@/lib/db/client', () => ({ fetchWithAuth: vi.fn() }));
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -20,15 +23,21 @@ interface FakeInstance {
   onmessage: SseListener | null;
   onerror: (() => void) | null;
   closed: boolean;
+  readyState: number;
 }
 
 let instances: FakeInstance[] = [];
 
 function stubEventSource() {
   class FakeEventSource {
+    // story #2160 — 실 EventSource readyState 상수. onerror 발생 시점의 readyState로
+    // "fatal(CLOSED, 자동재연결 없음)"과 "transient(그 외)"를 가른다.
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSED = 2;
     handle: FakeInstance;
     constructor(url: string) {
-      this.handle = { url, listeners: {}, onopen: null, onmessage: null, onerror: null, closed: false };
+      this.handle = { url, listeners: {}, onopen: null, onmessage: null, onerror: null, closed: false, readyState: 0 };
       instances.push(this.handle);
     }
     set onopen(cb: (() => void) | null) { this.handle.onopen = cb; }
@@ -37,6 +46,8 @@ function stubEventSource() {
     get onmessage() { return this.handle.onmessage; }
     set onerror(cb: (() => void) | null) { this.handle.onerror = cb; }
     get onerror() { return this.handle.onerror; }
+    get readyState() { return this.handle.readyState; }
+    set readyState(v: number) { this.handle.readyState = v; }
     addEventListener(name: string, cb: SseListener) {
       (this.handle.listeners[name] ??= []).push(cb);
     }
@@ -66,6 +77,7 @@ beforeEach(() => {
   instances = [];
   handle = null;
   stubEventSource();
+  vi.mocked(fetchWithAuth).mockReset();
 });
 
 afterEach(async () => {
@@ -193,5 +205,58 @@ describe('useSseMultiplexer — story #2078', () => {
     const subscribeBefore = handle!.subscribe;
     act(() => { instances[0]!.onopen?.(); });
     expect(handle!.subscribe).toBe(subscribeBefore);
+  });
+
+  // story #2160 — 세션이 죽었는데 탭이 401을 영원히 재폴링하던 결함의 회귀가드.
+  describe('CLOSED(fatal) onerror — 세션 확認 후에만 재연결한다(#2160)', () => {
+    it('세션이 죽었으면(fetchWithAuth 401) 재연결하지 않는다', async () => {
+      vi.useFakeTimers();
+      vi.mocked(fetchWithAuth).mockResolvedValue({ ok: false } as Response);
+      await act(async () => {
+        root.render(<Harness memberId="me-1" enabled />);
+      });
+      expect(instances).toHaveLength(1);
+      await act(async () => {
+        instances[0]!.readyState = 2; // EventSource.CLOSED
+        instances[0]!.onerror?.();
+        await Promise.resolve(); // isSessionAlive() 마이크로태스크 해소
+      });
+      expect(fetchWithAuth).toHaveBeenCalledWith('/api/me');
+      await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
+      expect(instances).toHaveLength(1); // 새 EventSource 없음 — 재시도 안 함
+      vi.useRealTimers();
+    });
+
+    it('세션이 살아있으면(fetchWithAuth 200) 재연결한다', async () => {
+      vi.useFakeTimers();
+      vi.mocked(fetchWithAuth).mockResolvedValue({ ok: true } as Response);
+      await act(async () => {
+        root.render(<Harness memberId="me-1" enabled />);
+      });
+      await act(async () => {
+        instances[0]!.readyState = 2; // EventSource.CLOSED
+        instances[0]!.onerror?.();
+        await Promise.resolve();
+      });
+      await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
+      expect(instances.length).toBeGreaterThan(1); // 백오프 지연 후 재연결됨
+      vi.useRealTimers();
+    });
+
+    it('CONNECTING(transient) onerror는 세션 확認 없이 곧장 백오프 재시도한다', async () => {
+      vi.useFakeTimers();
+      await act(async () => {
+        root.render(<Harness memberId="me-1" enabled />);
+      });
+      await act(async () => {
+        instances[0]!.readyState = 0; // EventSource.CONNECTING — 정상 순단
+        instances[0]!.onerror?.();
+        await Promise.resolve();
+      });
+      expect(fetchWithAuth).not.toHaveBeenCalled();
+      await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
+      expect(instances.length).toBeGreaterThan(1);
+      vi.useRealTimers();
+    });
   });
 });

--- a/apps/web/src/lib/realtime/sse-multiplexer.ts
+++ b/apps/web/src/lib/realtime/sse-multiplexer.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createReconnectBackoffState } from './sse-reconnect-backoff';
+import { isSessionAlive } from './sse-session-guard';
 
 /**
  * story #2078(E-ARCH 0단계) — presence·notification·chat이 각자 EventSource를 열어 탭당 장수
@@ -127,15 +128,26 @@ export function useSseMultiplexer(memberId: string | undefined, enabled: boolean
 
       es.onerror = () => {
         setConnected(false);
+        // story #2160 — CLOSED는 브라우저가 이미 "복구 불가"로 판정한 것(non-2xx 등, 자동재연결
+        // 없음). 세션이 죽은 것인지 업스트림 일시 오류인지 여기선 못 가르므로 세션부터 확認한다.
+        const wasFatal = es.readyState === EventSource.CLOSED;
         es.close();
         if (esRef.current === es) esRef.current = null;
-        if (!closed && !retryTimerRef.current) {
+        if (closed) return;
+        const scheduleRetry = () => {
+          if (retryTimerRef.current) return;
           const delay = backoff.onError();
           retryTimerRef.current = setTimeout(() => {
             retryTimerRef.current = null;
             connect();
           }, delay);
+        };
+        if (wasFatal) {
+          // 세션이 죽었으면 재시도하지 않는다(fetchWithAuth가 SessionExpiredDialog를 이미 띄웠다).
+          void isSessionAlive().then((alive) => { if (alive) scheduleRetry(); });
+          return;
         }
+        scheduleRetry();
       };
     };
 

--- a/apps/web/src/lib/realtime/sse-session-guard.test.ts
+++ b/apps/web/src/lib/realtime/sse-session-guard.test.ts
@@ -1,0 +1,33 @@
+// story #2160 — isSessionAlive 계약 고정: fetchWithAuth('/api/me')의 ok 여부를 그대로 반영하고,
+// 네트워크 자체 예외는 세션 문제로 오판하지 않고 true(기존 백오프에 맡김)로 접는다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithAuth } from '@/lib/db/client';
+import { isSessionAlive } from './sse-session-guard';
+
+vi.mock('@/lib/db/client', () => ({ fetchWithAuth: vi.fn() }));
+
+beforeEach(() => {
+  vi.mocked(fetchWithAuth).mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('isSessionAlive — #2160', () => {
+  it('fetchWithAuth가 ok:true면 true를 반환한다', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({ ok: true } as Response);
+    await expect(isSessionAlive()).resolves.toBe(true);
+    expect(fetchWithAuth).toHaveBeenCalledWith('/api/me');
+  });
+
+  it('fetchWithAuth가 ok:false(세션 죽음, 이미 signalSessionExpired 발화됨)면 false를 반환한다', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({ ok: false } as Response);
+    await expect(isSessionAlive()).resolves.toBe(false);
+  });
+
+  it('fetchWithAuth 자체가 던지면(네트워크 예외) 세션 문제로 오판하지 않고 true를 반환한다', async () => {
+    vi.mocked(fetchWithAuth).mockRejectedValue(new Error('offline'));
+    await expect(isSessionAlive()).resolves.toBe(true);
+  });
+});

--- a/apps/web/src/lib/realtime/sse-session-guard.ts
+++ b/apps/web/src/lib/realtime/sse-session-guard.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { fetchWithAuth } from '@/lib/db/client';
+
+/**
+ * story #2160 — EventSource가 readyState=CLOSED(2)로 error를 내는 것은 스펙상 "복구 불가"
+ * 판정이다(non-2xx 응답이거나 content-type 불일치면 브라우저가 자동재연결을 포기하고 CLOSED로
+ * 고정한다 — 실측: 401 응답 시 Chromium이 error 이벤트 정확히 1회만 내고 재연결하지 않음).
+ * 그런데 EventSource는 실패 사유(상태코드)를 노출하지 않아, 이 신호만으로는 "세션이 죽었다"와
+ * "업스트림이 한 번 삐끗했다"를 못 가른다. fetchWithAuth('/api/me')로 실제 세션 상태를 물어
+ * 가른다 — 401→refresh 시도→(실패 시)signalSessionExpired 가 이미 내장돼 있다(발명 0).
+ */
+export async function isSessionAlive(): Promise<boolean> {
+  try {
+    return (await fetchWithAuth('/api/me')).ok;
+  } catch {
+    // 네트워크 자체 문제(오프라인 등)는 세션 문제로 오판하지 않고 기존 백오프 재시도에 맡긴다.
+    return true;
+  }
+}


### PR DESCRIPTION
## 배경
prod 로그(오르테가 실측)에서 세션이 끝난 브라우저 3개가 `/api/event-stream` 등에 401을 창 전체(최대 1h43m/893건, 최대 1694회/3시간+) 지속 반복하면서도 화면은 아무 안내가 없었다. 정상 세션 2개(200)와 대조해 라우트 결함이 아니라 세션 단위 문제로 이미 갈라져 있었다(#1887 재발 아님, refresh는 건강).

## AC1 재현 (코드읽기로 닫지 않음)
로컬 dev 서버(`/api/event-stream`이 세션 없으면 401 반환)에 실 브라우저(puppeteer)로 `new EventSource(...)`를 직접 열어 확認:
- 401 응답 시 Chromium이 **`error` 이벤트를 정확히 1회만** 내고 `readyState`가 **CLOSED(2)로 고정**됨(spec대로 자동재연결 포기).
- 그런데 현재 앱의 4개 재연결 루프(`sse-multiplexer.ts`, `use-chat-sse.ts`/`use-sse-notifications.ts`/`use-team-presence.ts`의 독립 폴백 경로)는 이 신호를 무시하고 무조건 새 `EventSource`를 열어 백오프를 영원히 반복함(재현: 6초간 6회 재연결 확認, 무한 지속).

## 처방 (③ 없으면 반려 조건 충족)
- ① **세션 무효 인지**: `readyState===CLOSED`(fatal)일 때만 `fetchWithAuth('/api/me')`로 세션 생사 확認(발명 0 — 기존 401→refresh→실패 시 `signalSessionExpired` 파이프라인 재사용).
- ② **401엔 재시도 안 함**: 세션이 죽은 게 확定되면 재연결을 스케줄하지 않음. 또한 `fetchWithAuth` 자체가 `signalSessionExpired` 이후엔 네트워크를 아예 타지 않고 즉시 401을 반환하도록 단락 — 폴링이 매 tick마다 refresh를 재시도하지 못하게 함.
- ③ **사용자에게 보이는 것**: 이미 구현돼 있던 `SessionExpiredDialog`(재로그인 CTA)가 위 경로를 타면서 자연히 뜨게 됨(신규 UI 0 — 기존에 있었으나 SSE/폴링 경로가 안 태우던 것을 연결).
- 부수: 같은 창에서 401이 관측된 3개 폴링(`/api/notifications/count`, `/api/event-notifications/unread-count`, `/api/conversations/unread-count`)도 raw `fetch` → `fetchWithAuth`로 전환해 같은 파이프라인에 태움.

## 변경 파일
- 신규: `lib/realtime/sse-session-guard.ts`(+test), `lib/db/client.test.ts`
- 수정: `sse-multiplexer.ts`(+test), `use-chat-sse.ts`, `use-sse-notifications.ts`, `use-team-presence.ts`(+test), `notification-bell.tsx`, `app-sidebar.tsx`, `use-chat-unread-total.ts`, `lib/db/client.ts`, `lib/auth/session-expired-signal.ts`

## #2158과의 경계
섞지 않음 — 이건 "아예 못 붙는"(세션 종료) 케이스, #2158은 "붙었다 끊기는"(60초 컷) 케이스로 원인·처방 모두 별개.

## 검증
- `pnpm type-check` PASS / `pnpm lint`(대상 파일) 경고 0 / `pnpm build` EXIT 0
- `pnpm vitest run` 전체 293 files / 1937 tests PASS (신규 8건 포함, 회귀 0)
- 라이브 done-gate(401 지속 루프 0, prod 로그 재측정)는 머지→dev 배포 후 오르테가군 확認 필요(로컬 FE는 dev BE JWT_SECRET 불일치로 실 세션 발급 불가 — 배포 dev FE에서 세션 만료를 의도적으로 재현하는 양성대조 포함 재검증 예정).

## Test plan
- [x] 유닛 테스트(신규 8건: CLOSED+세션죽음→재연결안함, CLOSED+세션살아있음→재연결, CONNECTING→즉시백오프, fetchWithAuth 단락)
- [x] 기존 회귀 스위트 전체 그린
- [ ] dev 배포 후 라이브 세션만료 양성대조 + prod 401 루프 재측정 (오르테가군)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>