### PR TITLE
fix(#2131): 칸반 드래그/컬럼이동(PATCH /stories/bulk)이 status_changed 미발행 — 남의 화면에 영원히 안 보임

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -772,7 +772,10 @@ async def bulk_update_stories(
                     actor_id=actor_id, actor_name=actor_name, actor_role=actor_role, actor_type=actor_type,
                 )
             except Exception:  # noqa: BLE001 — 한 item의 emit 실패가 나머지 item을 막지 않음.
-                logger.warning(
+                # 오르테가군 PR 리뷰(2026-07-24): warning은 찾을 때 안 보이는 자리 — 오늘
+                # #2128/#2160/#2161 전부 "조용한 실패"였다. 나가야 할 실시간 프레임이 안 나간
+                # 것 자체가 이 스토리가 고치는 병이라 ERROR로 올린다.
+                logger.error(
                     "bulk status_changed emit 실패(story=%s)", s.id, exc_info=True,
                 )
     return results

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -753,6 +753,28 @@ async def bulk_update_stories(
             )
         except Exception:  # noqa: BLE001
             pass
+
+    # #2131 근본수정: bulk가 status를 실제로 바꾸면서도 emit_story_status_changed()를 아예
+    # 호출하지 않아 SSE 프레임이 서버에서 출발조차 안 했다(칸반 드래그·컬럼메뉴 둘 다 이 라우트라
+    # 남의 화면에 영원히 안 보이던 근본). PATCH /{id}/status(:1272)와 **같은 공유 helper**를
+    # 그대로 재사용 — 발행 지점을 갈라놓지 않는다(AC3, #2122/#2132와 동일 성질: 두 경로가
+    # 갈라지면 다음 결함이 또 한쪽에서만 재발). old_status_by_id는 위에서 이미 "실제로 바뀐
+    # item만" 채워둔 것을 그대로 재사용(중복 판정 없음).
+    if old_status_by_id:
+        actor_name, actor_role, actor_type = await _resolve_actor_info(db, actor_id)
+        for s in updated:
+            old = old_status_by_id.get(s.id)
+            if old is None:
+                continue
+            try:
+                await emit_story_status_changed(
+                    db, repo.org_id, s, old,
+                    actor_id=actor_id, actor_name=actor_name, actor_role=actor_role, actor_type=actor_type,
+                )
+            except Exception:  # noqa: BLE001 — 한 item의 emit 실패가 나머지 item을 막지 않음.
+                logger.warning(
+                    "bulk status_changed emit 실패(story=%s)", s.id, exc_info=True,
+                )
     return results
 
 

--- a/backend/tests/test_2131_bulk_status_changed_emit.py
+++ b/backend/tests/test_2131_bulk_status_changed_emit.py
@@ -1,0 +1,158 @@
+"""#2131: bulk_update_stories가 status 변경 시 emit_story_status_changed()를 실제로 호출하는지.
+
+근본: 칸반 드래그/컬럼메뉴가 전부 PATCH /stories/bulk를 타는데, 그 라우트는 status를
+setattr+commit만 하고 emit_story_status_changed()를 호출하지 않아 SSE 프레임이 서버에서
+출발조차 안 했다(pushed=False가 아니라 애초에 push 호출 자체가 없음). PATCH /{id}/status가
+이미 쓰는 동일 helper를 재사용해 발행 지점을 하나로 유지한다(AC3).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.routers import stories as stories_mod
+from app.routers.stories import BulkUpdateRequest, bulk_update_stories
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _story(status="todo", **overrides):
+    now = datetime(2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc)
+    base = dict(
+        id=uuid.uuid4(), project_id=uuid.uuid4(), org_id=uuid.uuid4(), epic_id=None,
+        sprint_id=None, assignee_id=None, assignee_ids=[], attachments=[], meeting_id=None,
+        title="t", status=status, priority="medium", story_points=None, description=None,
+        acceptance_criteria=None, position=None, success_hypothesis=None, metric_definition=None,
+        measure_after=None, outcome_status="n_a", outcome_result=None, is_excluded=False,
+        created_at=now, updated_at=now,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _mock_db(story_by_id: dict):
+    """org_id/id로 조회하면 해당 story를 돌려주는 db.execute mock."""
+    async def _execute(stmt, *a, **kw):
+        # bulk_update_stories의 조회는 항상 select(Story).where(Story.id==item.id, ...) 패턴 —
+        # 여기선 조회 순서를 story_by_id 삽입 순서에 맞춰 순차 반환(has_project_access 등
+        # 다른 execute 호출도 섞이므로, id 매칭 대신 단순 큐로 처리하지 않고 항상 요청된 story를
+        # 못 찾을 걱정 없게 첫 story를 fallback으로 둔다 — 테스트는 단일/소수 story라 충분).
+        m = MagicMock()
+        m.scalar_one_or_none = MagicMock(return_value=next(iter(story_by_id.values())))
+        return m
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=_execute)
+    db.flush = AsyncMock()
+    db.refresh = AsyncMock()
+    db.commit = AsyncMock()
+    db.add = MagicMock()
+    return db
+
+
+@pytest.mark.anyio
+async def test_bulk_status_change_calls_emit_story_status_changed(monkeypatch):
+    story = _story(status="todo")
+    db = _mock_db({story.id: story})
+    repo = MagicMock()
+    repo.org_id = story.org_id
+
+    monkeypatch.setattr(stories_mod, "_attach_assignee_ids", AsyncMock())
+    monkeypatch.setattr(stories_mod, "_resolve_team_member_id", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        "app.services.project_auth.has_project_access", AsyncMock(return_value=True)
+    )
+    spy = AsyncMock()
+    monkeypatch.setattr(stories_mod, "emit_story_status_changed", spy)
+
+    payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": "in-progress"}])
+    await bulk_update_stories(payload, db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
+
+    spy.assert_awaited_once()
+    args, kwargs = spy.call_args
+    assert args[1] == repo.org_id
+    assert args[2] is story
+    assert args[3] == "todo"  # old_status
+
+
+@pytest.mark.anyio
+async def test_bulk_no_status_change_does_not_call_emit(monkeypatch):
+    """priority만 바뀌는 item — status 불변이면 emit_story_status_changed 호출 자체가 없어야."""
+    story = _story(status="todo", priority="low")
+    db = _mock_db({story.id: story})
+    repo = MagicMock()
+    repo.org_id = story.org_id
+
+    monkeypatch.setattr(stories_mod, "_attach_assignee_ids", AsyncMock())
+    monkeypatch.setattr(stories_mod, "_resolve_team_member_id", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        "app.services.project_auth.has_project_access", AsyncMock(return_value=True)
+    )
+    spy = AsyncMock()
+    monkeypatch.setattr(stories_mod, "emit_story_status_changed", spy)
+
+    payload = BulkUpdateRequest(items=[{"id": str(story.id), "priority": "high"}])
+    await bulk_update_stories(payload, db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
+
+    spy.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_bulk_status_unchanged_value_does_not_call_emit(monkeypatch):
+    """같은 값으로 PATCH(status=todo→todo) — old_status_by_id에 안 잡히므로 emit도 안 함."""
+    story = _story(status="todo")
+    db = _mock_db({story.id: story})
+    repo = MagicMock()
+    repo.org_id = story.org_id
+
+    monkeypatch.setattr(stories_mod, "_attach_assignee_ids", AsyncMock())
+    monkeypatch.setattr(stories_mod, "_resolve_team_member_id", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        "app.services.project_auth.has_project_access", AsyncMock(return_value=True)
+    )
+    spy = AsyncMock()
+    monkeypatch.setattr(stories_mod, "emit_story_status_changed", spy)
+
+    payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": "todo"}])
+    await bulk_update_stories(payload, db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
+
+    spy.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_bulk_emit_failure_isolated_per_item(monkeypatch):
+    """emit_story_status_changed가 실패해도 bulk 응답 자체는 깨지지 않는다(best-effort)."""
+    story = _story(status="todo")
+    db = _mock_db({story.id: story})
+    repo = MagicMock()
+    repo.org_id = story.org_id
+
+    monkeypatch.setattr(stories_mod, "_attach_assignee_ids", AsyncMock())
+    monkeypatch.setattr(stories_mod, "_resolve_team_member_id", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        "app.services.project_auth.has_project_access", AsyncMock(return_value=True)
+    )
+    monkeypatch.setattr(
+        stories_mod, "emit_story_status_changed", AsyncMock(side_effect=RuntimeError("boom"))
+    )
+
+    payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": "in-progress"}])
+    result = await bulk_update_stories(payload, db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
+
+    assert len(result) == 1 and result[0].status == "in-progress"
+
+
+def test_bulk_source_reuses_shared_emit_helper():
+    """소스 검사 — bulk가 emit_story_status_changed를 PATCH /{id}/status와 동일하게 호출.
+    새 파생 함수를 만들지 않았는지(AC3: 발행 지점 분리 금지) 회귀 고정."""
+    import inspect
+
+    source = inspect.getsource(stories_mod.bulk_update_stories)
+    assert "await emit_story_status_changed(" in source
+    assert source.count("await emit_story_status_changed(") == 1

--- a/backend/tests/test_2131_bulk_status_changed_sse_realdb.py
+++ b/backend/tests/test_2131_bulk_status_changed_sse_realdb.py
@@ -1,0 +1,258 @@
+"""#2131 실DB+실HTTP 통합 — PATCH /stories/bulk가 status_changed SSE를 실제로 큐에 넣는지.
+
+fixture 아님: 실 PG(create_all) + 실 FastAPI 앱(ASGITransport)을 통해 실제 라우트를 태우고,
+`_agent_connections`에 진짜 asyncio.Queue를 꽂아 서버가 실제로 push하는지 확認한다
+(#2158에서 확립한 "라이브 실증, fixture-green 아님" 관례와 동형).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+_REAL_DB_SKIP = pytest.mark.skipif(
+    not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    import app.models  # noqa: F401
+    from app.core.database import Base
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session, *, n_stories: int = 1):
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import Project
+    from app.models.team import TeamMember
+
+    org = Organization(id=uuid.uuid4(), name="Org2131", slug=f"org2131-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    # actor(human) — has_project_access의 team_member_branch가 type=="human"만 grant-없이
+    # 통과시킨다(project_auth.py:226) — agent는 별도 Member+ProjectAccess grant가 필요해 여기선
+    # 불필요한 복잡도. watcher(agent) — 다른 화면의 관찰자 역할(#2131 AC1의 "남의 화면"). watcher는
+    # project_accessible_member_ids의 수신자 쿼리(team_members, type 필터 없음)만 통과하면 되므로
+    # type=agent로 그대로 둬도 무방(오히려 실제 관찰 대상인 agent 클라이언트를 더 잘 대표).
+    actor_id, watcher_id = uuid.uuid4(), uuid.uuid4()
+    session.add_all([
+        TeamMember(id=actor_id, org_id=org.id, project_id=project.id, type="human", name="actor"),
+        TeamMember(id=watcher_id, org_id=org.id, project_id=project.id, type="agent", name="watcher"),
+    ])
+    await session.commit()
+
+    story_ids = []
+    for i in range(n_stories):
+        sid = uuid.uuid4()
+        session.add(Story(id=sid, org_id=org.id, project_id=project.id, title=f"S{i}", status="todo"))
+        story_ids.append(sid)
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id,
+        "actor_id": actor_id, "watcher_id": watcher_id, "story_ids": story_ids,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, actor_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(actor_id), email="actor@test",
+            claims={"app_metadata": {"org_id": str(org_id), "api_key_id": "test-key"}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_bulk_status_patch_pushes_sse_to_project_watcher():
+    """⭐본체: 액터 ≠ 워처. 액터가 카드를 다른 컬럼으로 옮기면(bulk PATCH), 같은 프로젝트의
+    다른 멤버(워처)에게 실제로 story.status_changed SSE 프레임이 도착하는지 — 이게 안 되던 것이 #2131."""
+    from app.main import app
+    from app.routers import events as events_mod
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["actor_id"], seeded["org_id"])
+
+        watcher_id = str(seeded["watcher_id"])
+        q: asyncio.Queue = asyncio.Queue(maxsize=50)
+        events_mod._agent_connections[watcher_id].add(q)
+        try:
+            client = _client_for(app)
+            try:
+                resp = await client.patch(
+                    "/api/v2/stories/bulk",
+                    json={"items": [{"id": str(seeded["story_ids"][0]), "status": "in-progress"}]},
+                )
+                assert resp.status_code == 200, resp.text
+            finally:
+                await client.aclose()
+
+            await asyncio.sleep(0.1)  # fire_and_forget/BackgroundTasks 예약분 flush
+
+            received = []
+            while not q.empty():
+                received.append(q.get_nowait())
+
+            status_changed = [e for e in received if e.get("event_type") == "story.status_changed"]
+            assert len(status_changed) == 1, (
+                f"워처가 status_changed를 정확히 1건 받아야 — 실제 {len(status_changed)}건. "
+                f"전체 수신: {received}"
+            )
+            evt = status_changed[0]
+            assert evt["old_status"] == "todo"
+            assert evt["new_status"] == "in-progress"
+            assert evt["story_id"] == str(seeded["story_ids"][0])
+        finally:
+            events_mod._agent_connections[watcher_id].discard(q)
+            events_mod._agent_connections.pop(watcher_id, None)
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_bulk_no_status_field_does_not_push_status_changed():
+    """회귀 가드: status 필드 자체를 안 보내는 bulk 호출(예: priority만)은 status_changed를 안 낸다."""
+    from app.main import app
+    from app.routers import events as events_mod
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["actor_id"], seeded["org_id"])
+
+        watcher_id = str(seeded["watcher_id"])
+        q: asyncio.Queue = asyncio.Queue(maxsize=50)
+        events_mod._agent_connections[watcher_id].add(q)
+        try:
+            client = _client_for(app)
+            try:
+                resp = await client.patch(
+                    "/api/v2/stories/bulk",
+                    json={"items": [{"id": str(seeded["story_ids"][0]), "priority": "high"}]},
+                )
+                assert resp.status_code == 200, resp.text
+            finally:
+                await client.aclose()
+
+            await asyncio.sleep(0.1)
+
+            received = []
+            while not q.empty():
+                received.append(q.get_nowait())
+            assert not any(e.get("event_type") == "story.status_changed" for e in received)
+        finally:
+            events_mod._agent_connections[watcher_id].discard(q)
+            events_mod._agent_connections.pop(watcher_id, None)
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_bulk_n_item_load_measured():
+    """AC3 부하 실측: N건 동시 status 변경 시 워처 1명당 push 건수 = N(선형, 배수 곱 없음).
+    #2157(presence 18배)류 증폭이 이 경로엔 없음을 직접 잰다."""
+    from app.main import app
+    from app.routers import events as events_mod
+
+    N = 8
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, n_stories=N)
+
+        await _setup_app(app, Session, seeded["actor_id"], seeded["org_id"])
+
+        watcher_id = str(seeded["watcher_id"])
+        q: asyncio.Queue = asyncio.Queue(maxsize=200)
+        events_mod._agent_connections[watcher_id].add(q)
+        try:
+            client = _client_for(app)
+            try:
+                items = [{"id": str(sid), "status": "in-progress"} for sid in seeded["story_ids"]]
+                resp = await client.patch("/api/v2/stories/bulk", json={"items": items})
+                assert resp.status_code == 200, resp.text
+            finally:
+                await client.aclose()
+
+            await asyncio.sleep(0.2)
+
+            received = []
+            while not q.empty():
+                received.append(q.get_nowait())
+            status_changed = [e for e in received if e.get("event_type") == "story.status_changed"]
+            print(f"\n[#2131 부하 실측] {N}건 동시 status 변경 → 워처 1명 push 수신 = {len(status_changed)}건")
+            assert len(status_changed) == N, f"기대 {N}건(선형), 실제 {len(status_changed)}건"
+        finally:
+            events_mod._agent_connections[watcher_id].discard(q)
+            events_mod._agent_connections.pop(watcher_id, None)
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## 근본
칸반 드래그(`kanban-board.tsx:699`)·컬럼 메뉴(`:759`) 둘 다 `PATCH /stories/bulk`를 타는데, 그 라우트(`stories.py:668-756`)는 status를 `setattr`+`commit`만 하고 `emit_story_status_changed()`를 아예 호출하지 않았다 — **SSE 프레임이 서버에서 출발조차 안 함**. 다른 사용자 화면에서 카드가 절대 움직이지 않고, 에러도 없어서(그냥 조용히 안 보냄) 오래 살아남은 결함.

`#2130`(FE 렌더 결함 — 프레임은 도착하는데 안 그려짐)과는 층이 다른 별개 건.

## 처방
`PATCH /{id}/status`가 이미 쓰는 **동일** `emit_story_status_changed()` helper를 bulk에서도 그대로 호출한다 — 발행 지점을 갈라놓지 않는다(AC3, `#2122`/`#2132`와 동일 성질: 갈라지면 다음 결함이 한쪽에서만 재발). 이미 workflow violation 판정용으로 추적 중이던 `old_status_by_id`(실제로 값이 바뀐 item만 채워짐)를 그대로 재사용 — 중복 판정 로직 없음.

### 부하 설계(AC 명시 요구 — "건당 emit이 맞는지 부하까지 재서 판단")
bulk는 N건을 한 번에 바꾸므로, 건당 emit이면 대량 이동 시 N개 프레임이 나간다. 킥오프에서 우려한 시나리오: `presence`가 이미 org 멤버 수(N=18)만큼 곱해지는 구조(`#2157`)라 "카드 10장 = 10×18 = 180 발행"이 될 수 있다는 것.

**라이브 실측으로 직접 반박**: `emit_story_status_changed`의 recipient 해소는 `project_accessible_member_ids`(project-scope, org-wide 아님)이고, 8건 동시 status 변경 시 워처 1명당 push 수신 = **정확히 8건**(선형, 배수 곱 없음) — presence류 증폭이 이 경로엔 없음을 숫자로 확認. 건당 emit이 안전한 선택.

## AC2 — 전수 대조(같은 클래스 전수가 핵심)
```
필드          단건 라우트가 내는 이벤트                         bulk(수정前)   bulk(수정後)
status        PATCH /{id}/status → emit_story_status_changed    없음          emit_story_status_changed ✅
assignee_id   PATCH /{id} → story.assignee_changed(인라인)       없음          없음 ⚠️ 별건
priority      없음(단건도 emit 자체가 없음)                       없음          없음 — bulk 패리티 밖
sprint_id     없음(단건도 emit 자체가 없음)                       없음          없음 — bulk 패리티 밖
position      단건 PATCH /{id}(같은 컬럼 재정렬 전용, bulk 아님) → 없음  N/A     N/A — 별개 결함
```
`kanban-board.tsx` grep(=`/stories/bulk`의 유일 FE 호출처) 결과 드래그·컬럼메뉴 **둘 다 status만** 전송 — assignee_id/priority/sprint_id는 bulk 스키마상 받을 수는 있지만 오늘 라이브 콜러가 0. position은 애초에 bulk가 아니라 단건 PATCH로 나가며, 그쪽도 emit이 없어(PATCH /{id}는 assignee_id 변경 시에만 emit) 재정렬 자체가 별개 결함.

오르테가군과 합의 — 이 PR은 **status만** 닫고, **assignee_id-via-bulk + position 재정렬 미전파**는 "칸반에서 움직였는데 남이 못 본다"는 같은 문장이라 하나의 별건 스토리로 묶어 후속 등재(`#2158→#2162`와 동형 패턴, 실사용 데이터: position은 271건 중 순서변경 3건뿐이라 급하지 않음).

## 검증
- 유닛 5건(spy 기반 — `emit_story_status_changed` 호출/미호출 정확한 인자로 고정, best-effort 격리 확認, 발행 지점 1곳 소스 고정)
- **라이브 실증(로컬 real Postgres + 실 FastAPI ASGI, fixture 아님)** — 액터≠워처(다른 화면 시뮬):
  - 단건 이동: 워처가 `story.status_changed` 정확히 1건 수신(old=todo→new=in-progress)
  - 음성대조: priority만 바뀐 bulk 호출 → status_changed 0건(과다발행 없음)
  - N건 부하: 8건 동시 status 변경 → 워처 1명 push 수신 = 8건(선형 확認)
- 기존 `/stories/bulk` 회귀 전부 pass(SEC-S8 W/W2 cross-org·project-scope IDOR 가드 포함)

## 남은 것 — done-gate는 사람 눈
로컬 real-infra 검증은 **기전 증명**이지 **화면 증명**이 아니다(오르테가군 지적). AC1의 실제 done-gate는 두 브라우저 화면을 띄워놓고 한쪽에서 드래그하면 다른 쪽이 새로고침 없이 움직이는 것 — 이건 사람(또는 dev 배포 후 실 브라우저 라운드트립)이 확認해야 하는 영역이라 이 PR로 자동 충족되지 않는다.

## Test plan
- [x] 유닛(spy) 전체 pass
- [x] 로컬 real Postgres + 실 HTTP 라이브 실증(단건·음성대조·부하) 전부 pass
- [x] 기존 bulk 회귀(보안 IDOR 가드 포함) 전부 pass
- [ ] dev 배포 후 사람 눈으로 두 화면 확認(팔로우업)

🤖 Generated with [Claude Code](https://claude.com/claude-code)