### PR TITLE
feat(#2176 AC1): status_changed emit 서버측 구간 계측 — 요청수신→emit착수→fan-out완료

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 import uuid
 from datetime import datetime, timezone
 
@@ -671,6 +672,10 @@ async def bulk_update_stories(
     repo: StoryRepository = Depends(_get_repo),
     auth: AuthContext = Depends(get_current_user),
 ) -> list[StoryResponse]:
+    # #2176 AC1: 요청 수신 시각 — emit_story_status_changed에 그대로 넘겨 "요청 수신→emit 착수"
+    # 구간을 잰다(칸반 드래그/컬럼메뉴가 이 라우트를 타므로 미르코 실측 4,754ms의 서버측 성분을
+    # 여기서 갈라낸다). 순수 time.time() 캡처라 무부하.
+    _request_received_at = time.time()
     # 정공법 A(c1cd484b): /bulk 도 /status 와 동일 — status 변경을 항상 allow 하되 비순차 전진 점프는
     # violation flag(응답)+workflow_violation 이벤트로 가시화(차단 X). dnd 양경로(드래그·메뉴) 공통 SSOT.
     # violation 웹훅 수신자 필터용 actor 1회 해소(org-wide fan-out 박멸·/status 와 동형).
@@ -770,6 +775,7 @@ async def bulk_update_stories(
                 await emit_story_status_changed(
                     db, repo.org_id, s, old,
                     actor_id=actor_id, actor_name=actor_name, actor_role=actor_role, actor_type=actor_type,
+                    request_received_at=_request_received_at,
                 )
             except Exception:  # noqa: BLE001 — 한 item의 emit 실패가 나머지 item을 막지 않음.
                 # 오르테가군 PR 리뷰(2026-07-24): warning은 찾을 때 안 보이는 자리 — 오늘
@@ -1129,6 +1135,9 @@ async def update_story_status(
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
 ) -> StoryResponse:
+    # #2176 AC1: 요청 수신 시각(다른 어떤 DB/인가 작업보다도 먼저) — emit_story_status_changed에
+    # 그대로 넘겨 "요청 수신→emit 착수" 구간을 잰다. 순수 time.time() 캡처라 무부하.
+    _request_received_at = time.time()
     story_before = await repo.get(id)
     if story_before is not None:
         await _assert_story_project_access(db, auth, repo.org_id, story_before.project_id)
@@ -1297,6 +1306,7 @@ async def update_story_status(
         await emit_story_status_changed(
             db, org_id, story, old_status,
             actor_id=actor_id, actor_name=actor_name, actor_role=actor_role, actor_type=actor_type,
+            request_received_at=_request_received_at,
         )
 
     # S-C2: story_updated — actor가 agent인 경우 기록 (AC2, AC6)

--- a/backend/app/services/story_status_events.py
+++ b/backend/app/services/story_status_events.py
@@ -8,6 +8,7 @@ done이 게이트 증거에 안 잡힘)을 닫고, 정상 경로와 parity(드�
 from __future__ import annotations
 
 import logging
+import time
 import uuid
 from datetime import datetime, timezone
 
@@ -104,11 +105,20 @@ async def emit_story_status_changed(
     actor_name: str | None = None,
     actor_role: str | None = None,
     actor_type: str | None = None,
+    request_received_at: float | None = None,
 ) -> None:
     """story status_changed의 side-effects를 발화. old==new면 no-op.
 
     호출자가 story.status를 이미 새 값으로 설정한 뒤 호출한다. 각 side-effect는 best-effort(실패
     격리)로 status 전이 자체를 깨지 않는다.
+
+    `request_received_at`(#2176 AC1, 2026-07-24): 미르코 실측 — 칸반 상태변경이 액터 호출부터
+    화면 도착까지 10초(전달 4.7초+렌더 5.0초)였는데, "액터 호출 시작"이 MCP 발신 시각이라 그
+    안에 BE 처리·발행이 전부 섞여 있어 #2158의 순수 SSE 전송 400ms대와 기준선이 다르다는
+    caveat이 있었다 — 쪼개지 않고 "전달이 느리다"로 가면 엉뚱한 곳을 파게 된다. 호출자(route
+    handler)가 요청 수신 직후 `time.time()`을 넘기면, 이 함수가 "요청 수신→emit 착수" 구간과
+    "emit 착수→fan-out 완료"(recipient 수·#2157 팬아웃 겹침 여부 판단용) 구간을 로그 한 줄로
+    가른다. 순수 logging(DB/Redis 호출 0)이라 #2123이 비운 hot-path에 부하를 다시 안 얹는다.
 
     ⚠️story #2132(2026-07-23) 정정 — 이 docstring이 예전에 "publish_event는 eventbus→L1
     activity_events 캡처의 진입점"이라 주장했으나 **사실이 아니었다**: L1 capture(
@@ -169,6 +179,7 @@ async def emit_story_status_changed(
     # 9ef0f914·trust_pipeline.py `_maybe_emit`)와 동일하게 project 인가 필터를 낀 수동
     # 포워딩만 남긴다 — 순수 transient push(Event row 생성 0, 연결 안 된 멤버는
     # `_push_to_agent` 자체가 조용히 no-op).
+    _emit_started_at = time.time()
     try:
         from app.routers.events import _push_to_agent
         from app.services.project_auth import project_accessible_member_ids
@@ -182,6 +193,34 @@ async def emit_story_status_changed(
             "status_changed SSE 포워딩 실패(story=%s project=%s)",
             story.id, story.project_id, exc_info=True,
         )
+    finally:
+        # #2176 AC1: 구간 계측 로그(순수 logging, DB/Redis 호출 0 — hot-path 무부하).
+        # request_received_at 미전달 콜사이트(advance_story_to_done 등)는 그 구간을 None으로
+        # 남긴다 — 이 함수 자체는 그 값의 유무를 몰라도 되게 설계(호출자 계약 확장 없음).
+        try:
+            _emit_completed_at = time.time()
+            _server_processing_ms = (
+                round((_emit_started_at - request_received_at) * 1000, 1)
+                if request_received_at is not None else None
+            )
+            logger.info(
+                "story status_changed emit timing",
+                extra={"structured": {
+                    "story_id": str(story.id),
+                    "old_status": old_status,
+                    "new_status": story.status,
+                    "request_received_at": request_received_at,
+                    "emit_started_at": _emit_started_at,
+                    "emit_completed_at": _emit_completed_at,
+                    "recipient_count": len(member_ids) if "member_ids" in locals() else None,
+                    # 요청 수신 → emit 착수(처리+commit 구간, AC1 핵심)
+                    "server_processing_ms": _server_processing_ms,
+                    # emit 착수 → fan-out 완료(recipient 순회 자체가 느린지, #2157 팬아웃 겹침 여부용, AC5)
+                    "emit_fanout_ms": round((_emit_completed_at - _emit_started_at) * 1000, 2),
+                }},
+            )
+        except Exception:  # noqa: BLE001 — 계측 실패가 이미 발화된 side-effect를 되돌리면 안 됨.
+            pass
 
     try:
         # AC2: story.status_changed 의 member-bound webhook 은 관련자(notify_ids)만 수신 → org-wide

--- a/backend/app/services/story_status_events.py
+++ b/backend/app/services/story_status_events.py
@@ -179,6 +179,11 @@ async def emit_story_status_changed(
     # 9ef0f914·trust_pipeline.py `_maybe_emit`)와 동일하게 project 인가 필터를 낀 수동
     # 포워딩만 남긴다 — 순수 transient push(Event row 생성 0, 연결 안 된 멤버는
     # `_push_to_agent` 자체가 조용히 no-op).
+    # #2176 AC1(오르테가군 PR 리뷰 지적): 여기 `time.monotonic()`이 아니라 `time.time()`이
+    # 맞는 선택이다 — 이 값은 duration 계산에만 쓰이는 게 아니라 **절대 시각으로 로그에
+    # 찍혀** 미르코군의 클라측 `Date.now()` 타임스탬프와 맞대볼 수 있어야 한다.
+    # monotonic은 프로세스-로컬 기준점이라 절대 의미가 없어 그 크로스-프로세스 대조가
+    # 안 된다 — "정석은 monotonic 아닌가"로 나중에 고치면 이 대조 능력이 깨진다.
     _emit_started_at = time.time()
     try:
         from app.routers.events import _push_to_agent

--- a/backend/tests/test_2176_emit_timing_instrumentation.py
+++ b/backend/tests/test_2176_emit_timing_instrumentation.py
@@ -1,0 +1,155 @@
+"""#2176 AC1: emit_story_status_changed의 서버측 구간 계측(요청 수신→emit 착수→fan-out 완료).
+
+미르코 실측(2026-07-24) — 칸반 상태변경이 액터 호출부터 화면 도착까지 10초(전달 4.7초+렌더
+5.0초)였는데 "액터 호출 시작"이 MCP 발신 시각이라 BE 처리·발행이 섞여 있어 #2158의 순수 SSE
+전송 400ms대와 기준선이 다르다는 caveat — 쪼개지 않고 처방부터 고르면 엉뚱한 데를 판다. 이
+계측은 순수 logging(DB/Redis 호출 0)이라 #2123이 비운 hot-path에 부하를 다시 안 얹는다.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services import story_status_events as sse_mod
+from app.services.story_status_events import emit_story_status_changed
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _story(**overrides):
+    now = datetime(2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc)
+    base = dict(
+        id=uuid.uuid4(), project_id=uuid.uuid4(), epic_id=None,
+        title="t", status="in-progress", priority="medium", assignee_id=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class _TimingCapture(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self.records: list[dict] = []
+
+    def emit(self, record):
+        if "emit timing" in record.getMessage():
+            self.records.append(getattr(record, "structured", None))
+
+
+@pytest.fixture
+def _capture():
+    h = _TimingCapture()
+    logger = logging.getLogger("app.services.story_status_events")
+    logger.addHandler(h)
+    logger.setLevel(logging.INFO)
+    yield h
+    logger.removeHandler(h)
+
+
+def _mock_db():
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=MagicMock())
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    return db
+
+
+@pytest.mark.anyio
+async def test_timing_log_includes_all_ac1_segments_when_request_received_at_given(monkeypatch, _capture):
+    monkeypatch.setattr(sse_mod, "project_accessible_member_ids", AsyncMock(return_value=set()), raising=False)
+    monkeypatch.setattr("app.services.project_auth.project_accessible_member_ids", AsyncMock(return_value=set()))
+    monkeypatch.setattr("app.services.webhook_dispatch.fire_webhooks", AsyncMock())
+    monkeypatch.setattr("app.services.workflow_pipeline.process_event", AsyncMock())
+    monkeypatch.setattr("app.services.trust_pipeline.emit_on_story_status_change", AsyncMock())
+
+    story = _story(status="in-progress")
+    db = _mock_db()
+    import time as _time
+    t0 = _time.time()
+
+    await emit_story_status_changed(db, uuid.uuid4(), story, "todo", request_received_at=t0)
+
+    assert len(_capture.records) == 1
+    rec = _capture.records[0]
+    assert rec["story_id"] == str(story.id)
+    assert rec["old_status"] == "todo"
+    assert rec["new_status"] == "in-progress"
+    assert rec["request_received_at"] == t0
+    assert rec["emit_started_at"] >= t0
+    assert rec["emit_completed_at"] >= rec["emit_started_at"]
+    assert rec["server_processing_ms"] is not None and rec["server_processing_ms"] >= 0
+    assert rec["emit_fanout_ms"] is not None and rec["emit_fanout_ms"] >= 0
+    assert rec["recipient_count"] == 0
+
+
+@pytest.mark.anyio
+async def test_timing_log_server_processing_ms_none_without_request_received_at(monkeypatch, _capture):
+    """advance_story_to_done류 콜사이트는 request_received_at을 안 넘긴다 — 계약 확장 없이
+    그 구간만 None으로 빠지고 나머지(emit_fanout_ms)는 여전히 채워져야."""
+    monkeypatch.setattr("app.services.project_auth.project_accessible_member_ids", AsyncMock(return_value=set()))
+    monkeypatch.setattr("app.services.webhook_dispatch.fire_webhooks", AsyncMock())
+    monkeypatch.setattr("app.services.workflow_pipeline.process_event", AsyncMock())
+    monkeypatch.setattr("app.services.trust_pipeline.emit_on_story_status_change", AsyncMock())
+
+    story = _story(status="done")
+    db = _mock_db()
+
+    await emit_story_status_changed(db, uuid.uuid4(), story, "in-progress")
+
+    assert len(_capture.records) == 1
+    rec = _capture.records[0]
+    assert rec["request_received_at"] is None
+    assert rec["server_processing_ms"] is None
+    assert rec["emit_fanout_ms"] is not None  # 이 구간은 request_received_at과 무관하게 항상 채워짐
+
+
+@pytest.mark.anyio
+async def test_no_timing_log_when_status_unchanged(_capture):
+    story = _story(status="todo")
+    db = _mock_db()
+
+    await emit_story_status_changed(db, uuid.uuid4(), story, "todo")
+
+    assert _capture.records == []
+
+
+@pytest.mark.anyio
+async def test_timing_log_failure_does_not_break_emit(monkeypatch, _capture):
+    """계측 로깅 자체가 실패해도(예: 로그 핸들러 고장) 이미 발화된 side-effect가 깨지면 안
+    된다 — best-effort. `time.time()`은 CPython에서 사실상 무결함이라(다른 계측 콜사이트인
+    context_pack.py도 방어 안 함) 그건 시뮬레이션 안 함 — 현실적 실패 지점인 logger.info를 문제
+    삼는다."""
+    monkeypatch.setattr("app.services.project_auth.project_accessible_member_ids", AsyncMock(return_value=set()))
+    monkeypatch.setattr("app.services.webhook_dispatch.fire_webhooks", AsyncMock())
+    monkeypatch.setattr("app.services.workflow_pipeline.process_event", AsyncMock())
+    monkeypatch.setattr("app.services.trust_pipeline.emit_on_story_status_change", AsyncMock())
+    monkeypatch.setattr(sse_mod.logger, "info", MagicMock(side_effect=RuntimeError("boom")))
+
+    story = _story(status="in-progress")
+    db = _mock_db()
+
+    # 예외 전파 없이 정상 반환해야(계측 실패가 함수 전체를 깨면 안 됨).
+    await emit_story_status_changed(db, uuid.uuid4(), story, "todo")
+
+
+def test_route_handlers_capture_and_pass_request_received_at():
+    """소스 검사 — 두 실 콜사이트(bulk/단건)가 요청 수신 시각을 캡처해 넘기는지 회귀 고정."""
+    import inspect
+
+    from app.routers import stories as stories_mod
+
+    bulk_src = inspect.getsource(stories_mod.bulk_update_stories)
+    assert "_request_received_at = time.time()" in bulk_src
+    assert "request_received_at=_request_received_at" in bulk_src
+
+    status_src = inspect.getsource(stories_mod.update_story_status)
+    assert "_request_received_at = time.time()" in status_src
+    assert "request_received_at=_request_received_at" in status_src


### PR DESCRIPTION
## 배경
미르코 실측(2026-07-24, dev `c9ac0a9a` 실브라우저, #2131 화면증명 3회차): 칸반 상태변경이 액터 호출부터 화면 도착까지 **10초**(전달 4.7초+렌더 5.0초)였다.

```
액터 호출 시작(MCP 발신)              +0ms
SSE story.status_changed 프레임 도착   +4,754ms   ← 워처 브라우저 EventSource 수신
DOM: 백로그 이탈 관측                  +4,759ms   (프레임 도착과 5ms 차 — 반응은 즉시)
DOM: 진행중 착지(최종 렌더)            +9,771ms
```

**미르코 자진 caveat(이 스토리 AC1의 출발점)**: "액터 호출 시작"은 MCP 발신 시각이라 그 안에 BE 처리·이벤트 발행이 전부 섞여 있어 #2158의 순수 SSE 전송 400ms대와 **동일 기준선이 아니다**. 4,754ms를 쪼개지 않고 "전달이 느리다"로 가면 엉뚱한 데를 판다.

## 처방 — AC1: 4,754ms를 쪼갠다
`emit_story_status_changed`에 `request_received_at`(선택 인자, 기존 콜사이트 계약 확장 없음)을 추가. route handler가 요청 수신 직후 캡처한 시각을 넘기면, 이 함수가 구조화 로그 한 줄로 두 구간을 가른다:

- **요청 수신 → emit 착수**(`server_processing_ms`) — 처리+commit 구간, AC1 핵심
- **emit 착수 → fan-out 완료**(`emit_fanout_ms`) — recipient 순회 자체가 느린지, **#2157(팬아웃 N배) 겹침 여부 판단용(AC5)**

호출부 2곳(`PATCH /{id}/status`·`PATCH /bulk` — 칸반 드래그/컬럼메뉴가 타는 라우트) 모두에서 요청 수신 시각을 캡처해 전달.

## hot-path 무부하(Ortega 명시 요구)
순수 `logging`(DB/Redis 호출 0)이라 #2123이 비운 hot-path에 부하를 다시 얹지 않는다. 계측 자체도 best-effort로 감싸(이미 발화된 side-effect가 계측 실패로 깨지지 않게) — `logger.info` 자체가 실패하는 현실적 시나리오로 테스트.

## 검증
- 유닛 5건(`test_2176_emit_timing_instrumentation.py`) — 구조화 로그 필드 전체 확認, `request_received_at` 없는 콜사이트(gate-driven done류)는 `server_processing_ms`만 None으로 빠지고 나머지는 정상, status 불변 시 로그 자체 없음, 계측 실패 격리, 두 route handler 소스 고정
- **라이브 실증(로컬 real Postgres)**: 실제 구조화 로그 1건을 직접 캡처해 필드값 확認 —
  ```json
  {"server_processing_ms": 20.9, "emit_fanout_ms": 0.81, "recipient_count": 2}
  ```
  값 자체가 합리적임을 fixture 아닌 실제 실행으로 확認.
- 관련 회귀(story/bulk/emit/2131/2158/2176) 214건 전부 pass, `test_emit_story_status_changed_isolation.py`(기존 격리 가드) 무회귀

## 이 PR 스코프 밖(다음 담당)
- **AC2**(렌더 5,017ms 원인 규명 — "프레임 도착 후 목록 refetch+재배치" 가설 검증, FE/미르코)
- **AC3**(사용자가 "실시간"으로 느끼는 목표 상한 선언 — 값 보기 전 결정, PO)
- **AC4**(수정 후 같은 계측 설계로 재측정 — EventSource 수신+MutationObserver)
- **AC5 최종 판정**(#2157 팬아웃과 겹치는지) — 이 PR의 `emit_fanout_ms`가 그 판단 재료를 제공하지만, 실 dev 트래픽에서 recipient_count가 큰 프로젝트로 재측정해야 최종 결론

## Test plan
- [x] 유닛 5건 pass
- [x] 로컬 real Postgres 라이브 실증 — 구조화 로그 필드 직접 캡처
- [x] 관련 회귀 214건 pass, 기존 isolation 가드 무회귀
- [ ] dev 배포 후 Cloud Logging에서 실제 필드 확認(팔로우업)

🤖 Generated with [Claude Code](https://claude.com/claude-code)