### PR TITLE
fix(#2178 AC1/AC2): sprintable-realtime-dev 플래그 세트를 backend와 대조·진짜 누락 2종 배선

### DIFF
--- a/backend/tests/test_2178_realtime_flag_parity.py
+++ b/backend/tests/test_2178_realtime_flag_parity.py
@@ -1,0 +1,79 @@
+"""story #2178(2026-07-24): sprintable-realtime-dev가 backend-dev와 다른 Redis 플래그 세트로
+돌고 있었는데 그 차이가 어디에도 선언된 적이 없었다 — #2158 회귀검증이 그 자리에서 막혔다
+(record()는 backend-dev에서 정상이었는데, 실제 브라우저 SSE를 서빙하는 realtime-dev엔
+SSE_TRANSIENT_REPLAY_ENABLED가 아예 없어 replay()가 그 서비스에서 한 번도 안 돎).
+
+5종 전수를 코드 경로로 판정(값보다 "왜 다른지" 선언이 본체):
+- SSE_TRANSIENT_REPLAY_ENABLED·SSE_LEASE_REDIS_ENABLED: 진짜 누락 → deploy-realtime 배선
+- PRESENCE_REDIS_ENABLED·PRESENCE_ONLINE_REDIS_ENABLED·FANOUT_WAKE_REDIS_ENABLED: 의도적 off
+  (해당 로직이 events.py의 agent_event_stream 어디에도 없음 — REST 라우트/agent_gateway.py
+  전용이라 realtime-dev 프로세스에서 구조적으로 실행되지 않음)
+
+이 테스트는 그 판정 결과가 cloudbuild.yaml에 실제로 반영돼 있는지 고정한다 — 다음에 누가
+"다 켜자"로 뭉개거나, 반대로 누락분이 다시 빠지는 것을 막는다.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CLOUDBUILD_YAML = _REPO_ROOT / "cloudbuild.yaml"
+
+
+def _deploy_realtime_step_script() -> str:
+    import yaml
+
+    doc = yaml.safe_load(_CLOUDBUILD_YAML.read_text())
+    step = next(s for s in doc["steps"] if s["id"] == "deploy-realtime")
+    assert step["entrypoint"] == "bash"
+    return step["args"][1]
+
+
+def _update_env_vars_line(script: str) -> str:
+    line = next(l for l in script.splitlines() if "--update-env-vars=" in l)
+    return line.strip()
+
+
+def test_realtime_step_enables_confirmed_missing_flags():
+    """#2158(replay)·#2178 AC1(sse_lease) — 코드 경로 실증으로 "진짜 누락" 판정된 둘만 켠다."""
+    line = _update_env_vars_line(_deploy_realtime_step_script())
+    assert "SSE_TRANSIENT_REPLAY_ENABLED=true" in line, (
+        "SSE_TRANSIENT_REPLAY_ENABLED 누락 — 브라우저 SSE를 실제로 서빙하는 서비스에서 "
+        "replay()가 안 돎(#2158 회귀검증이 막힌 그 자리)"
+    )
+    assert "SSE_LEASE_REDIS_ENABLED=true" in line, (
+        "SSE_LEASE_REDIS_ENABLED 누락 — events.py의 sse_lease.acquire/refresh/release가 "
+        "agent_event_stream 안에서 직접 호출되는데(연결·30초 하트비트·해제), realtime-dev가 "
+        "다인스턴스(2~8)라 이게 꺼지면 #2121이 고치려던 전역 429/503 캡이 인스턴스별로 쪼개진다"
+    )
+
+
+def test_realtime_step_intentionally_leaves_three_flags_off():
+    """의도적 off 3종 — 해당 로직이 events.py(agent_event_stream)에 존재하지 않아 이 서비스
+    에선 구조적으로 무해(REST 라우트/agent_gateway.py 전용). 값이 실수로 켜지면 이 판정
+    자체가 재검토 대상이므로 실패시켜 눈에 띄게 한다."""
+    line = _update_env_vars_line(_deploy_realtime_step_script())
+    assert "PRESENCE_REDIS_ENABLED=" not in line, (
+        "chat_presence는 conversations.py/team_presence.py 전용(REST) — events.py엔 "
+        "import/호출 자체가 없다. 켜야 한다는 새 근거가 생겼으면 이 assert와 함께 cloudbuild.yaml "
+        "주석의 '의도적 off' 판정도 같이 갱신할 것"
+    )
+    assert "PRESENCE_ONLINE_REDIS_ENABLED=" not in line, (
+        "30초 SSE-틱 hot-path 기록은 agent_gateway.py의 /agent/stream(에이전트 전용)에만 "
+        "있다 — events.py(브라우저 전용)엔 presence_online 참조가 없다"
+    )
+    assert "FANOUT_WAKE_REDIS_ENABLED=" not in line, (
+        "wake_agent()의 대상 큐는 에이전트 키인데 에이전트는 backend-dev에만 붙는다 — "
+        "realtime-dev엔 그 큐가 존재한 적이 없어 이 플래그가 무의미하다"
+    )
+
+
+def test_realtime_step_source_declares_why_flags_differ():
+    """AC3(이 스토리의 본체) — 값이 아니라 "왜 다른지"가 코드에 선언돼 있는지 소스 검사로 고정.
+    다음에 누가 값만 보고 "다 켜자"로 판단하지 않도록, 각 플래그의 판정 근거가 남아있어야 한다."""
+    script = _deploy_realtime_step_script()
+    assert "story #2178" in script
+    for flag in (
+        "PRESENCE_REDIS_ENABLED", "PRESENCE_ONLINE_REDIS_ENABLED", "FANOUT_WAKE_REDIS_ENABLED",
+    ):
+        assert flag in script, f"{flag}의 '의도적 off' 판정 근거가 스텝 주석에서 사라졌다"

--- a/backend/tests/test_2178_realtime_flag_parity.py
+++ b/backend/tests/test_2178_realtime_flag_parity.py
@@ -77,3 +77,14 @@ def test_realtime_step_source_declares_why_flags_differ():
         "PRESENCE_REDIS_ENABLED", "PRESENCE_ONLINE_REDIS_ENABLED", "FANOUT_WAKE_REDIS_ENABLED",
     ):
         assert flag in script, f"{flag}의 '의도적 off' 판정 근거가 스텝 주석에서 사라졌다"
+
+
+def test_realtime_step_declares_the_assumption_the_judgment_rests_on():
+    """오르테가군 PR 리뷰(2026-07-24): "의도적 off" 판정 근거뿐 아니라 그 판정이 **무너지는
+    조건**까지 선언돼야 한다 — 오늘 #2178 사달의 근본원인이 정확히 "전제가 어디에도 안
+    적혀 있던 것"이었다. realtime-dev가 backend와 같은 풀 이미지를 돌려 /agent/stream
+    라우트 자체는 살아있으므로, "브라우저만 붙는다"는 전제가 라우팅 변경으로 깨지면 이
+    판정 전체가 재검토 대상이 된다는 것을 명시해야 한다."""
+    script = _deploy_realtime_step_script()
+    assert "브라우저만 붙는다" in script
+    assert "재검토" in script or "재판정" in script

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -425,6 +425,32 @@ steps:
         # (false/None)으로 되돌아가면 두 전송경로 동시 무효화(실시간 전면정지)가 된다.
         # 이 스텝은 이미 dev 전용 가드(위) 안이라 true를 직접 명시해도 안전(PG_LISTEN_ENABLED=
         # false와 동일 컨벤션) — REDIS_URL만 변수(연결문자열은 환경별로 다르므로).
+        #
+        # story #2178(2026-07-24, 까심 #2158 회귀검증에서 적발 → PO가 전수로 넓힘): deploy-backend
+        # 는 12키를 넘기는데 이 스텝은 8키뿐이라 backend·realtime 두 서비스가 다른 플래그 세트로
+        # 돌고 있었다 — 그 차이 자체가 어디에도 선언된 적이 없어 "켰다"고 믿는 사고가 반복됐다
+        # (#2158 SSE_TRANSIENT_REPLAY_ENABLED가 정확히 그 사고: record()는 backend-dev에서 돌아
+        # 정상이었는데, 실제 브라우저 SSE를 서빙하는 건 이 realtime-dev라 replay()가 이 서비스
+        # 에서 한 번도 안 돌고 있었다). 5종 전수 판정(코드 경로 실증, 값보다 "왜 다른지" 선언이
+        # 본체):
+        #   ⭐SSE_TRANSIENT_REPLAY_ENABLED  진짜 누락 — replay 대상 연결이 실제로 여기(realtime-
+        #     dev의 agent_event_stream)에 있다. 즉시 배선(아래).
+        #   ⭐SSE_LEASE_REDIS_ENABLED       진짜 누락 — events.py의 sse_lease.acquire/refresh/
+        #     release가 바로 이 파일의 agent_event_stream 안에서 직접 호출된다(연결 시점·30초
+        #     하트비트마다·해제 시). realtime-dev가 다인스턴스(_REALTIME_MIN/MAX_INSTANCES=2~8)
+        #     라 이게 꺼져 있으면 #2121이 고치려던 전역 429/503 캡이 인스턴스별로 쪼개져 그 결함이
+        #     이 서비스에서 그대로 재현된다. 즉시 배선(아래).
+        #   PRESENCE_REDIS_ENABLED         의도적 off(무해) — chat_presence는 이 파일(events.py)
+        #     어디에도 import/호출이 없다. 쓰기·읽기 전부 conversations.py/team_presence.py(REST
+        #     라우트)에만 있어 backend-dev에서만 실행된다.
+        #   PRESENCE_ONLINE_REDIS_ENABLED  의도적 off(무해) — 30초 SSE-틱 hot-path 기록은
+        #     agent_gateway.py의 /agent/stream(에이전트 전용, backend-dev가 직접 서빙)에만 있다.
+        #     이 파일의 agent_event_stream(브라우저 전용)엔 presence_online 참조가 전혀 없다.
+        #   FANOUT_WAKE_REDIS_ENABLED      의도적 off(무해) — wake_agent()는 REST 뮤테이션
+        #     라우트에서만 호출되고, 대상 큐(_agent_connections)도 에이전트 키인데 에이전트는
+        #     backend-dev에만 붙는다 — realtime-dev엔 그 큐 자체가 존재한 적이 없다.
+        # 위 두 건(누락)만 배선하고 나머지 셋은 의도적으로 그대로 둔다 — 한 덩어리로 "다 켜자"
+        # 하지 않는다(PO 지시).
         gcloud run deploy sprintable-realtime-${_DEPLOY_ENV} \
           --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA} \
           --region=${_AR_REGION} \
@@ -432,7 +458,7 @@ steps:
           --max-instances=${_REALTIME_MAX_INSTANCES} \
           --timeout=${_REALTIME_TIMEOUT} \
           --allow-unauthenticated \
-          --update-env-vars=FASTAPI_URL=${_REALTIME_URL},DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1,PG_LISTEN_ENABLED=false,EVENT_BROKER_REDIS_CONSUME_ENABLED=true,REDIS_URL=${_REDIS_URL},EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=true,EVENT_BROKER_REDIS_DISPATCH_ENABLED=true \
+          --update-env-vars=FASTAPI_URL=${_REALTIME_URL},DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1,PG_LISTEN_ENABLED=false,EVENT_BROKER_REDIS_CONSUME_ENABLED=true,REDIS_URL=${_REDIS_URL},EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=true,EVENT_BROKER_REDIS_DISPATCH_ENABLED=true,SSE_TRANSIENT_REPLAY_ENABLED=true,SSE_LEASE_REDIS_ENABLED=true \
           --remove-env-vars=REDIS_CONSUME_ENABLED \
           --quiet
     waitFor: [run-migrate-job]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -451,6 +451,14 @@ steps:
         #     backend-dev에만 붙는다 — realtime-dev엔 그 큐 자체가 존재한 적이 없다.
         # 위 두 건(누락)만 배선하고 나머지 셋은 의도적으로 그대로 둔다 — 한 덩어리로 "다 켜자"
         # 하지 않는다(PO 지시).
+        # ⚠️이 판정이 딛고 선 전제(오르테가군 PR 리뷰 지적, 2026-07-24) — 위 세 건의 "의도적
+        # off" 판정은 **"realtime-dev에는 브라우저만 붙는다"**는 현재 라우팅 전제 위에 서 있다.
+        # 이 서비스는 backend와 **같은 풀 이미지**를 돌리므로 `/agent/stream`(agent_gateway.py)
+        # 라우트 자체는 살아 있다 — 지금은 에이전트가 항상 backend-dev로 붙도록 배선돼 있어(
+        # agent_onboarding_config.py::resolve_backend_direct_url) 무해할 뿐이다. **그 라우팅이
+        # 바뀌어 에이전트가 realtime-dev에도 붙게 되면 이 판정 전체를 재검토할 것** — 오늘 이
+        # 사달(#2178)의 근본원인이 정확히 "전제가 어디에도 안 적혀 있었던 것"이라, 판정 근거뿐
+        # 아니라 판정이 무너지는 조건까지 여기 남긴다.
         gcloud run deploy sprintable-realtime-${_DEPLOY_ENV} \
           --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA} \
           --region=${_AR_REGION} \


### PR DESCRIPTION
## 근본
까심이 #2158 회귀검증에서 막힌 지점을 우회하지 않고 그대로 보고했다: `record()`는 되는데 `replay()`가 이 요청을 아예 안 본다. 원인 — 브라우저 SSE를 실제로 서빙하는 건 `sprintable-backend-dev`가 아니라 **`sprintable-realtime-dev`**(별개 Cloud Run 서비스)인데, `SSE_TRANSIENT_REPLAY_ENABLED`가 그 서비스엔 없었다.

PO가 그 하나를 확認하다 **Redis 계열 5종 전부**가 backend-dev와 다르게 꺼져 있는 것을 발견(같은 이미지·같은 REDIS_URL인데). 뿌리: `cloudbuild.yaml`의 `deploy-backend`(12키)와 `deploy-realtime`(8키) env 목록이 애초에 갈려 있었다 — **#2077이 만든 게 아니라 그 기존 갈림을 그대로 따라간 것**.

## 이 스토리의 본체 — 값이 아니라 "차이가 선언된 적이 없다"
두 서비스가 다른 플래그로 도는 것 자체는 정당할 수 있다(realtime은 SSE 서빙 전용이니 일부 기능이 불필요할 수 있다). 문제는 그 차이가 어디에도 적혀 있지 않아 의도인지 누락인지 코드로도 문서로도 안 갈린다는 것 — 그래서 #2158처럼 "한쪽만 켜고 켰다고 믿는" 일이 생겼다.

## AC1 — 5종 전수를 코드 경로로 판정(한 덩어리로 "다 켜자" 안 함)

| 플래그 | 판정 | 근거 |
|---|---|---|
| `SSE_TRANSIENT_REPLAY_ENABLED` | ⭐**진짜 누락** | replay 대상 연결이 실제로 이 서비스의 `agent_event_stream`에 있다 |
| `SSE_LEASE_REDIS_ENABLED` | ⭐**진짜 누락(신규 발견)** | `events.py`의 `sse_lease.acquire/refresh/release`가 `agent_event_stream` 안에서 직접 호출(연결·30초 하트비트마다·해제 시). realtime-dev가 다인스턴스(`_REALTIME_MIN/MAX_INSTANCES=2~8`)라 이게 꺼지면 #2121이 고치려던 전역 429/503 캡이 인스턴스별로 쪼개진다 |
| `PRESENCE_REDIS_ENABLED` | 의도적 off | `chat_presence`는 `events.py` 어디에도 import/호출 없음 — `conversations.py`/`team_presence.py`(REST) 전용 |
| `PRESENCE_ONLINE_REDIS_ENABLED` | 의도적 off | 30초 SSE-틱 hot-path 기록은 `agent_gateway.py`의 `/agent/stream`(에이전트 전용, backend-dev가 직접 서빙)에만 있음 |
| `FANOUT_WAKE_REDIS_ENABLED` | 의도적 off | `wake_agent()` 대상 큐는 에이전트 키인데 에이전트는 backend-dev에만 붙음 — realtime-dev엔 그 큐 자체가 없음 |

## AC2 — 진짜 누락 2종만 즉시 배선
`deploy-realtime` 스텝(이미 dev 전용 가드 안 — prod는 이 스텝 자체가 skip)에 `SSE_TRANSIENT_REPLAY_ENABLED=true`·`SSE_LEASE_REDIS_ENABLED=true`를 기존 `PG_LISTEN_ENABLED=false`와 동일 컨벤션(substitution 없이 직접 명시)으로 추가.

## AC3 — 차이를 선언(이 스토리의 본체)
`deploy-realtime` 스텝 주석에 5종 전체의 판정과 근거를 명시 — 다음에 누가 값만 보고 "다 켜자"로 판단하지 않도록.

## 검증
- YAML 파싱 + 기존 이스케이프 가드(`entrypoint: bash` 스텝 정적 스캔, `deploy-realtime`도 스캔 대상) 통과
- 신규 pinning 테스트 3건(`test_2178_realtime_flag_parity.py`):
  - 진짜 누락 2종이 실제로 켜져 있는지
  - 의도적 off 3종이 실수로 켜지지 않는지(누가 다시 "다 켜자"로 뭉개면 실패)
  - 판정 근거(주석)가 소스에 실제로 존재하는지
- 관련 회귀(deploy/cloudbuild) 118건 전부 pass

## 이 PR 스코프 밖(오르테가군 지시)
- **AC4**(prod realtime은 GCE — 별도 스크립트 경로, 축이 다름) — 별건
- **AC5**(서비스 간 플래그 차이가 선언 없이 생기면 드러나는 가드) — 별건

## Test plan
- [x] YAML 파싱 + 이스케이프 가드 통과
- [x] pinning 테스트 3건 pass
- [x] 관련 회귀 118건 pass
- [ ] dev 배포 후 까심군이 #2158 재검증(팔로우업)

🤖 Generated with [Claude Code](https://claude.com/claude-code)