### PR TITLE
fix(#2179): JSON 로그 판정 축을 APP_ENV 문자열에서 is_really_local(실행 위치)로 교체

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import os
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
@@ -12,7 +11,31 @@ from app.core.config import settings
 from app.core.logging_config import configure_logging
 from app.core.rate_limit import limiter
 
-configure_logging(json_logs=os.getenv("APP_ENV", "development") != "development")
+# story #2179(2026-07-24, 오르테가군 판정) 근본수정 — 예전엔 `APP_ENV` 문자열 비교로 JSON
+# 로그 여부를 갈랐다("development"가 아니면 JSON). 그런데 JSON 로그가 필요한 진짜 조건은
+# "어느 환경인가"가 아니라 "Cloud Logging으로 나가는가" = "Cloud Run/GCE에서 도는가"다 —
+# 환경 이름 컨벤션이 갈리면(dev/development·prod/production 등, #2179 조사에서 실제로 이미
+# 코드베이스 전역에서 일관성이 깨져 있는 것 확認됨) 그 판정이 조용히 틀어진다(dev Cloud Run이
+# APP_ENV 미설정으로 기본값 "development"를 상속해 텍스트 포매터를 타면서, story
+# #2176(emit 구간 계측)·P1-S8(RAG 검색 계측)·llm_client(LLM 비용/토큰 계측)의 구조화 필드가
+# 전부 조용히 버려지고 있었다 — 메시지 텍스트만 남고 값이 없었음).
+#
+# `is_really_local`(story #2071→#2152, `app/core/config.py`)이 이미 "이 프로세스가 진짜
+# 로컬인가"를 이름이 아니라 실행 위치 신호로 판정한다(K_SERVICE 존재=Cloud Run 확定·
+# PYTEST_CURRENT_TEST=테스트·SPRINTABLE_LOCAL_DEV=로컬 docker-compose 명시). 이 신호를
+# 뒤집어 json_logs 축으로 재사용하면 환경 이름을 하나도 안 건드리고 dev·prod·GCE·MCP가
+# 전부 자동으로 맞는다(GCE도 K_SERVICE가 없지만 SPRINTABLE_LOCAL_DEV가 없어 is_really_local
+# =False로 정확히 판정됨 — #2152가 이미 해결). 로컬 개발(README 공식 경로인
+# `docker compose up`이 SPRINTABLE_LOCAL_DEV=1을 심음)과 pytest 실행은 그대로 텍스트 로그를
+# 받는다(무회귀).
+# ⚠️판단 하나 남긴다(오르테가군 지적 — 판정 근거뿐 아니라 무너지는 조건까지) — bare
+# `uvicorn` 직접 실행(docker-compose 없이, `SPRINTABLE_LOCAL_DEV` 미설정)은 이 변경으로
+# **텍스트→JSON으로 바뀐다.** README 공식 로컬 개발 경로가 아니라는 이유로 의도적으로 이
+# 영향권에 남겨뒀다 — 다음에 bare uvicorn을 쓰다 "왜 갑자기 JSON이 찍히지" 하고 헤매면
+# `SPRINTABLE_LOCAL_DEV=1`을 직접 설정하거나(docker-compose.yml과 동일 신호) `docker compose
+# up`으로 전환할 것. 이 경로까지 텍스트로 지켜야 한다는 요구가 생기면 그건 새 판단이 필요한
+# 것이지 이 커밋의 누락이 아니다.
+configure_logging(json_logs=not settings.is_really_local)
 _logger = logging.getLogger(__name__)
 
 

--- a/backend/scripts/deploy_realtime_gce.sh
+++ b/backend/scripts/deploy_realtime_gce.sh
@@ -216,10 +216,17 @@ PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}APP_URL=${APP_URL}"
 # 별도로 이 값들을 받았다(describe 대조 확認) — dev는 지금도 없음. 즉 이번 건은 "dev값이
 # 분기 밖에 남은" 이전 3건과 반대 방향: **prod가 나중에 추가로 받은 값을 이 스크립트가
 # 못 따라간 것**. 특히 APP_ENV는 `config.py::is_really_local`(story #2071 — `K_SERVICE`
-# 부재로 로컬 판정, GCE엔 K_SERVICE가 원천적으로 없어 그 프로퍼티 자체는 이 값과 무관하게
-# 계속 True로 나옴, 이건 별도 코드 결함으로 등재)와는 별개로 `app_env` 문자열을 직접 보는
-# 코드 경로를 위해 필요 — 지금 당장 시크릿 fail-open 구멍은 아니지만(CRON_SECRET_PROD·
-# FIREBASE_BFF_INTERNAL_SECRET 둘 다 바인딩돼 있어 그 경로는 안전) 미러링 원칙 그대로 적용.
+# 부재로 로컬 판정)와는 별개로 `app_env` 문자열을 직접 보는 코드 경로를 위해 필요 — 지금
+# 당장 시크릿 fail-open 구멍은 아니지만(CRON_SECRET_PROD·FIREBASE_BFF_INTERNAL_SECRET 둘 다
+# 바인딩돼 있어 그 경로는 안전) 미러링 원칙 그대로 적용.
+# ⚠️정정(story #2179, 2026-07-24) — 위 "GCE엔 K_SERVICE가 없어 is_really_local이 계속
+# True로 나온다"는 서술은 **#2152(2026-07-23) 이전** 상태를 가리키던 것이라 지금은 사실이
+# 아니다. #2152가 `is_really_local`을 "K_SERVICE 부재=로컬"에서 "긍정 신호(PYTEST_CURRENT_
+# TEST 또는 SPRINTABLE_LOCAL_DEV) 없으면 로컬 아님"으로 근본수정했고, GCE 배포 경로(이
+# 스크립트·Dockerfile) 어디에도 `SPRINTABLE_LOCAL_DEV`가 없어 GCE는 지금 정확히 False(로컬
+# 아님)로 떨어진다 — `test_2152_runtime_local_detection.py::test_gce_is_not_local`이 이 값을
+# 고정해두고 있다. 이 정정 자체가 story #2179의 근거였다(json_logs 판정 축을 APP_ENV 문자열
+# 대신 `is_really_local`로 교체해도 GCE가 반쪽으로 남지 않는다는 확認).
 if [ "${ENV}" = "prod" ]; then
     PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}APP_ENV=prod"
     PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}NEXT_PUBLIC_APP_URL=${APP_URL}"

--- a/backend/tests/test_2179_logging_axis_by_runtime_location.py
+++ b/backend/tests/test_2179_logging_axis_by_runtime_location.py
@@ -1,0 +1,147 @@
+"""story #2179(2026-07-24, 오르테가군 근본 판정) — JSON 로그 여부의 판정 축을 "환경 이름"
+(`APP_ENV` 문자열 비교)에서 "실행 위치"(`settings.is_really_local`, story #2071→#2152)로
+교체한다.
+
+## 근본
+예전: `configure_logging(json_logs=os.getenv("APP_ENV","development") != "development")`.
+JSON 로그가 필요한 진짜 조건은 "어느 환경인가"가 아니라 "Cloud Logging으로 나가는가" =
+"Cloud Run/GCE에서 도는가"다. 그런데 환경 **이름**으로 그걸 판정하고 있어서, 이름 컨벤션이
+흔들리면(dev Cloud Run에 `APP_ENV`가 아예 안 박혀 기본값 "development"를 상속) 판정이
+조용히 틀어졌다 — dev에서 `logger.info(..., extra={"structured": {...}})`(story #2176 emit
+계측·P1-S8 RAG 검색 계측·llm_client 비용/토큰 계측 전부)가 텍스트 포매터를 타면서 값이 통째로
+버려지고 있었다(메시지 텍스트만 남음).
+
+## 근본수정
+`is_really_local`은 이미 "진짜 로컬인가"를 이름이 아니라 실행 위치 신호(K_SERVICE 존재=Cloud
+Run 확定·PYTEST_CURRENT_TEST=테스트·SPRINTABLE_LOCAL_DEV=로컬 docker-compose 명시)로
+판정한다(story #2152가 GCE 오판까지 이미 닫아둠 — `test_2152_runtime_local_detection.py`
+참조). 이 신호를 뒤집어 재사용하면 환경 이름을 하나도 안 건드리고 dev·prod·GCE·MCP가 전부
+자동으로 맞는다 — `APP_ENV` 배선도, 그로 인한 Redis 키 네임스페이스 부작용(AC3)도 불요.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+import logging
+from io import StringIO
+
+from app.core.config import settings
+from app.core.logging_config import JsonFormatter, configure_logging
+
+
+def _clear_runtime_signals(monkeypatch):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("K_SERVICE", raising=False)
+    monkeypatch.delenv("SPRINTABLE_LOCAL_DEV", raising=False)
+
+
+# ── 소스 고정 — 회귀 가드(오늘 세운 "선언은 pinning 테스트로" 관례 그대로) ────────────
+def test_main_wires_json_logs_from_is_really_local_not_app_env():
+    import app.main as main_mod
+
+    source = inspect.getsource(main_mod)
+    assert "configure_logging(json_logs=not settings.is_really_local)" in source, (
+        "json_logs 판정이 실행 위치 축(is_really_local)을 쓰는지 소스 고정 — 이게 없으면 "
+        "다음에 누가 다시 APP_ENV 문자열 비교로 되돌려도 아무도 모른다"
+    )
+    assert 'os.getenv("APP_ENV"' not in source, (
+        "옛 환경-이름 축(APP_ENV 문자열 비교)이 되살아나면 실패 — #2179가 고친 그 자리"
+    )
+
+
+def test_main_declares_bare_uvicorn_is_a_deliberate_tradeoff():
+    """오르테가군 지적 — "판정 근거뿐 아니라 무너지는 조건까지" 선언할 것. bare uvicorn(
+    docker-compose 없이)이 텍스트→JSON으로 바뀌는 게 실수가 아니라 의도된 판단이라는 것이
+    소스에서 사라지면 실패 — 사라지면 다음 사람이 "왜 갑자기 JSON이지"로 헤맨다."""
+    import app.main as main_mod
+
+    source = inspect.getsource(main_mod)
+    assert "bare" in source and "uvicorn" in source
+    assert "SPRINTABLE_LOCAL_DEV" in source
+
+
+def test_gce_stale_comment_correction_exists():
+    """오르테가군 지적 — deploy_realtime_gce.sh의 "#2071이라 GCE에서 is_really_local
+    계속 True" 서술이 #2152 이후로는 사실이 아닌데 정정이 안 남아있으면 다음 사람이 그
+    낡은 주석만 읽고 속는다. 정정 문장 존재를 고정."""
+    from pathlib import Path
+
+    script = (Path(__file__).resolve().parents[1] / "scripts" / "deploy_realtime_gce.sh").read_text()
+    assert "정정(story #2179" in script
+    assert "test_gce_is_not_local" in script
+
+
+# ── 위치별 판정이 실제로 옳은 json_logs 값을 내는지(is_really_local 자체는 #2152가 이미
+#    전수 검증했으므로, 여기선 "그 값을 뒤집어 json_logs로 쓴다"는 #2179 고유의 계약만 확認) ──
+def test_cloud_run_gets_json_logs(monkeypatch):
+    _clear_runtime_signals(monkeypatch)
+    monkeypatch.setenv("K_SERVICE", "sprintable-backend-dev")
+    assert (not settings.is_really_local) is True
+
+
+def test_gce_gets_json_logs(monkeypatch):
+    """#2152 핵심 — GCE는 K_SERVICE가 없지만 SPRINTABLE_LOCAL_DEV도 없어 is_really_local
+    =False로 정확히 떨어진다(과거 #2071 판정은 여기서 True로 오판했었음). #2179가 그 정확한
+    신호를 그대로 재사용하므로 GCE realtime도 자동으로 JSON 로그를 받는다."""
+    _clear_runtime_signals(monkeypatch)
+    assert (not settings.is_really_local) is True
+
+
+def test_docker_compose_local_dev_keeps_text_logs(monkeypatch):
+    """README 공식 로컬 개발 경로(`docker compose up`)는 SPRINTABLE_LOCAL_DEV=1을 심는다 —
+    무회귀로 텍스트 로그를 유지해야(오르테가군 명시 확認 요청)."""
+    _clear_runtime_signals(monkeypatch)
+    monkeypatch.setenv("SPRINTABLE_LOCAL_DEV", "1")
+    assert (not settings.is_really_local) is False
+
+
+def test_pytest_run_keeps_text_logs(monkeypatch):
+    """pytest 실행 자체가 PYTEST_CURRENT_TEST로 자동 '로컬' 판정 — 테스트 로그도 무회귀."""
+    monkeypatch.delenv("K_SERVICE", raising=False)
+    monkeypatch.delenv("SPRINTABLE_LOCAL_DEV", raising=False)
+    assert (not settings.is_really_local) is False
+
+
+# ── configure_logging() 자체가 그 값을 받아 실제로 JSON/텍스트를 가르는지 + structured
+#    필드가 JSON 경로에서 실제로 살아남는지(#2179가 고치려던 원 증상의 직접 회귀가드) ──
+def _capture_one_log_line(json_logs: bool, structured: dict) -> str:
+    configure_logging(json_logs=json_logs)
+    root = logging.getLogger()
+    stream = StringIO()
+    # StreamHandler(sys.stdout) 대신 캡처용 스트림으로 교체 — configure_logging이 세운
+    # 핸들러의 포매터만 재사용(같은 포매터 클래스가 실제로 쓰이는지가 검증 대상).
+    root.handlers[0].stream = stream
+    logging.getLogger("test_2179").info("probe message", extra={"structured": structured})
+    return stream.getvalue().strip()
+
+
+def test_json_logs_true_preserves_structured_fields(monkeypatch):
+    """#2179 원 증상의 직접 회귀가드 — json_logs=True(Cloud Run/GCE 경로)면 구조화 필드가
+    실제로 로그 라인에 살아남는다(전에는 여기가 통째로 버려졌다)."""
+    line = _capture_one_log_line(True, {"server_processing_ms": 20.9, "recipient_count": 2})
+    payload = json.loads(line)
+    assert payload["server_processing_ms"] == 20.9
+    assert payload["recipient_count"] == 2
+    assert payload["message"] == "probe message"
+
+
+def test_json_logs_false_drops_structured_fields_but_keeps_message():
+    """대조군 — json_logs=False(로컬)면 메시지는 남되 구조화 필드는 텍스트 포매터가 모른다
+    (#2179가 dev에서 실제로 겪은 정확한 증상 — 오탐 방지를 위해 이 대조도 같이 고정)."""
+    line = _capture_one_log_line(False, {"server_processing_ms": 20.9})
+    assert "probe message" in line
+    assert "20.9" not in line
+    assert "server_processing_ms" not in line
+
+
+def test_json_formatter_is_the_class_used_when_json_logs_true():
+    configure_logging(json_logs=True)
+    root = logging.getLogger()
+    assert isinstance(root.handlers[0].formatter, JsonFormatter)
+
+
+def test_plain_formatter_is_used_when_json_logs_false():
+    configure_logging(json_logs=False)
+    root = logging.getLogger()
+    assert not isinstance(root.handlers[0].formatter, JsonFormatter)
+    assert isinstance(root.handlers[0].formatter, logging.Formatter)


### PR DESCRIPTION
## 근본
```python
configure_logging(json_logs=os.getenv("APP_ENV","development") != "development")
```
JSON 로그가 필요한 진짜 조건은 **"어느 환경인가"가 아니라 "Cloud Logging으로 나가는가" = "Cloud Run/GCE에서 도는가"**다. 그런데 환경 **이름**으로 그걸 판정하고 있어서, 이름 컨벤션이 갈리면 판정이 조용히 틀어진다.

**실제로 그랬다** — dev Cloud Run은 `APP_ENV`가 아예 안 박혀 있어 `config.py` 기본값(`"development"`)을 상속했고, `"development" != "development"` = False → 텍스트 포매터를 타면서 `logger.info(..., extra={"structured": {...}})`를 쓰는 세 계측이 전부 조용히 죽어 있었다(메시지 텍스트만 남고 값 0):
- `story_status_events.py` — #2176(칸반 status_changed emit 구간 계측)
- `context_pack.py` — P1-S8(RAG 검색 latency/result_count, 이 패턴의 원조)
- `llm_client.py` — ⭐LLM 비용/토큰 추적(model·latency·prompt/candidates/thoughts/total_token_count·finish_reason) — "크레딧 내 비용 추적용"인데 dev에서 한 번도 안 찍혔다

## 근본수정 — 판정 축을 이름에서 실행 위치로
`is_really_local`(story #2071→#2152, `app/core/config.py`)이 이미 "진짜 로컬인가"를 이름이 아니라 실행 위치 신호로 정확히 판정한다(K_SERVICE 존재=Cloud Run 확定·PYTEST_CURRENT_TEST=테스트·SPRINTABLE_LOCAL_DEV=로컬 docker-compose 명시). 이 신호를 뒤집어 재사용:
```python
configure_logging(json_logs=not settings.is_really_local)
```
환경 이름을 하나도 안 건드리고 **dev·prod·GCE·MCP가 전부 자동으로 맞는다** — `APP_ENV` 배선도, 그로 인한 Redis 키 네임스페이스 부작용(당초 계획했던 AC3)도 **불요**.

### GCE 검증 — 낡은 주석 정정 포함
당초 우려: GCE는 `K_SERVICE`가 없어 `is_really_local`이 오판될 수 있다는 것. 확認 결과:
- `deploy_realtime_gce.sh`에 "#2071이라 GCE에서 `is_really_local` 계속 True"라는 주석이 있었으나, 이건 **#2152(2026-07-23) 이전** 서술이 낡게 남은 것이었다.
- GCE 배포 경로(스크립트·Dockerfile) 어디에도 `SPRINTABLE_LOCAL_DEV`가 없는 것 grep 확認.
- `test_2152_runtime_local_detection.py::test_gce_is_not_local`이 이미 GCE=False(로컬 아님)를 고정해두고 있는 것 확認.
- ⇒ GCE는 현재 정확히 `is_really_local=False`로 떨어져 JSON 로그를 받는다. 낡은 주석은 이 PR에서 정정.

### 무회귀 확認
- **README 공식 로컬 개발 경로**(`docker compose up`) — `SPRINTABLE_LOCAL_DEV=1`이 이미 심어져 있어 텍스트 로그 유지.
- **pytest 실행** — `PYTEST_CURRENT_TEST` 자동 주입으로 텍스트 로그 유지.
- **bare `uvicorn` 직접 실행**(docker-compose 없이) — 텍스트→JSON으로 바뀐다. 공식 로컬 개발 경로가 아니라는 **의도적 판단**으로 영향권에 남겨두고, 그 판단 자체를 소스에 선언(오늘 세운 관례 — 판정 근거뿐 아니라 무너지는 조건까지).

## 조사 중 발견한 부수 이슈(이 PR 스코프 밖 — 오르테가군이 별건으로 세울 예정)
1. `llm_client.py`의 LLM 비용/토큰 추적이 살아나면 "그래서 얼마 쓰고 있나"를 실제로 봐야 함
2. 환경 문자열 컨벤션 자체의 전역 불일치(`github_app.py`의 `app_env != "production"` vs 실값 `"prod"` 등) — 이미 `infra/manual-env-allowlist.yml:107`에 추적 중
3. `logging_config.py`의 `record.request_id`/`httpRequest.requestId` — setter가 코드 어디에도 없는 별개 원인의 죽은 계측
4. `sprintable-mcp-dev/-prod` — backend와 동일 이미지라 같은 병이 있었을 것으로 예상되나, 이 축 교체로 자동 해결(별도 조치 불요)

## 검증
- pinning 테스트 11건(`test_2179_logging_axis_by_runtime_location.py`):
  - 축 소스 고정 2건(새 축 존재 + 옛 축 부재)
  - 위치별 판정 4건(Cloud Run·GCE·docker-compose 로컬·pytest)
  - **JSON/텍스트 실동작 대조 3건** — structured 필드가 JSON 경로에선 실제로 살아남고 텍스트 경로에선 정확히 버려지는 것을 직접 검증(오늘 겪은 "로그는 찍혔는데 값만 없더라" 그 자리를 테스트가 지키게 됨)
  - bare uvicorn 판단 선언 고정 1건 + GCE 주석 정정 고정 1건
- 관련 회귀(2152·2072·2176·auth_rebuild) 45건 pass
- 전체 스위트 로컬 백그라운드 구동 중(CI와 어긋날 때만 보고)

## Test plan
- [x] pinning 테스트 11건 pass
- [x] 관련 회귀 45건 pass
- [ ] dev 배포 후 실제 Cloud Logging에서 structured 필드 확認(#2158/#2176/#2178 재측정과 함께, 팔로우업)

🤖 Generated with [Claude Code](https://claude.com/claude-code)