### PR TITLE
fix(#2172): bulk assignee_id / 단건 position 이벤트 계약 정합

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -13,13 +13,11 @@ from app.core.config import settings
 from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user, get_project_scoped_org_id, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.deletion_audit import DeletionAuditLog
-from app.models.event import Event
 from app.models.pm import Goal, Story, StoryActivity, StoryComment
 from app.models.team import TeamMember
 from app.repositories.story import StoryRepository
 from app.repositories.story_assignee import StoryAssigneeRepository
 from app.routers.agent_gateway import wake_agent
-from app.services.event_seq import assign_recipient_seq
 from app.services import mcp_attachment_upload
 from app.services.asset_registry import DEFAULT_CONTAINER, sync_attachment_assets
 from app.schemas.story import StoryAttachment, StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
@@ -32,6 +30,7 @@ from app.services.merge_verdict_gate import (
 )
 from app.services.verdict_capture import resolve_implementation_participation
 from app.services.notification_dispatch import dispatch_notification
+from app.services.story_assignee_events import emit_story_assignee_changed
 from app.services.story_status_events import emit_story_status_changed
 from app.services.webhook_dispatch import fire_webhooks
 from app.services.workflow_line_status import (
@@ -40,8 +39,6 @@ from app.services.workflow_line_status import (
     build_workflow_line_status,
     build_workflow_line_status_batch,
 )
-from app.services.workflow_pipeline import process_event
-from app.services.rule_evaluator import EventContext
 from app.services.workflow_violation import (
     build_violation_event,
     build_violation_flag,
@@ -668,6 +665,7 @@ class BulkUpdateRequest(BaseModel):
 @router.patch("/bulk", response_model=list[StoryResponse])
 async def bulk_update_stories(
     payload: BulkUpdateRequest,
+    background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
     repo: StoryRepository = Depends(_get_repo),
     auth: AuthContext = Depends(get_current_user),
@@ -689,6 +687,10 @@ async def bulk_update_stories(
 
     updated: list[Story] = []
     old_status_by_id: dict[uuid.UUID, str] = {}
+    # story #2172 AC1: assignee_id도 status와 동형으로 전이 前 old값 포착(setattr 前). None은
+    # "미배정→배정"의 유효한 old값이라 .get() 대신 멤버십(`in`)으로 "실제 변경 있었음"을 판정한다
+    # (status_by_id는 status가 None일 수 없어 .get()만으로 충분했던 것과 다른 지점).
+    old_assignee_by_id: dict[uuid.UUID, uuid.UUID | None] = {}
     for item in payload.items:
         # E-SECURITY SEC-S8(story 83ea3d6a) W(까심 QA, CRITICAL·실HTTP 확定): 이 raw 쿼리가
         # org_id 필터 자체가 없어(정상 repo.get()은 self._org_filter() 명시·RLS도 0002서 off)
@@ -710,6 +712,8 @@ async def bulk_update_stories(
         # status 변경이면 전이 前 old_status 포착(violation 판정용·setattr 前).
         if "status" in update_data and update_data["status"] != story.status:
             old_status_by_id[story.id] = story.status
+        if "assignee_id" in update_data and update_data["assignee_id"] != story.assignee_id:
+            old_assignee_by_id[story.id] = story.assignee_id
         for k, v in update_data.items():
             setattr(story, k, v)
         # E-BOARD S5: 단일 assignee_id 변경 시 join 미러(단일↔복수 공존 정합)
@@ -765,8 +769,11 @@ async def bulk_update_stories(
     # 그대로 재사용 — 발행 지점을 갈라놓지 않는다(AC3, #2122/#2132와 동일 성질: 두 경로가
     # 갈라지면 다음 결함이 또 한쪽에서만 재발). old_status_by_id는 위에서 이미 "실제로 바뀐
     # item만" 채워둔 것을 그대로 재사용(중복 판정 없음).
-    if old_status_by_id:
+    actor_name = actor_role = actor_type = None
+    if old_status_by_id or old_assignee_by_id:
         actor_name, actor_role, actor_type = await _resolve_actor_info(db, actor_id)
+
+    if old_status_by_id:
         for s in updated:
             old = old_status_by_id.get(s.id)
             if old is None:
@@ -783,6 +790,27 @@ async def bulk_update_stories(
                 # 것 자체가 이 스토리가 고치는 병이라 ERROR로 올린다.
                 logger.error(
                     "bulk status_changed emit 실패(story=%s)", s.id, exc_info=True,
+                )
+
+    # story #2172 AC1: assignee_id도 status와 동형 — bulk가 assignee_id를 실제로 바꾸면서도
+    # 이 helper를 호출하지 않아 PATCH /{id}는 story.assignee_changed를 내는데 /bulk은 안 내는
+    # 계약 불일치가 있었다(현재 FE 라이브 콜러 0 — kanban-board.tsx는 assignee_id를 bulk로 안
+    # 보낸다. "지금 아무도 안 밟지만 계약은 깨져 있는" 자리를 여기서 닫는다). old_assignee_by_id는
+    # 멤버십으로 "실제 변경"만 담아뒀으므로 그대로 재사용(중복 판정 없음, status와 동형).
+    if old_assignee_by_id:
+        for s in updated:
+            if s.id not in old_assignee_by_id:
+                continue
+            old = old_assignee_by_id[s.id]
+            try:
+                await emit_story_assignee_changed(
+                    db, repo.org_id, s, old,
+                    background_tasks=background_tasks,
+                    actor_id=actor_id, actor_name=actor_name, actor_role=actor_role, actor_type=actor_type,
+                )
+            except Exception:  # noqa: BLE001 — 한 item의 emit 실패가 나머지 item을 막지 않음.
+                logger.error(
+                    "bulk assignee_changed emit 실패(story=%s)", s.id, exc_info=True,
                 )
     return results
 
@@ -824,11 +852,14 @@ async def update_story(
     if assignee_ids_in is not None and "assignee_id" not in data:
         data["assignee_id"] = assignee_ids_in[0] if assignee_ids_in else None
     old_assignee_id: uuid.UUID | None = None
+    old_position: int | None = None
     story_before = None
-    if "assignee_id" in data:
+    # story #2172 AC2: position 변경도 old-value 대조가 필요해 assignee_id와 같은 사전조회를 공유.
+    if "assignee_id" in data or "position" in data:
         story_before = await repo.get(id)
         if story_before:
             old_assignee_id = story_before.assignee_id
+            old_position = story_before.position
     # H1-S5: PATCH /{id} 로 status=done 전이 시도도 board 경로와 동일하게 preflight 게이트(AC②).
     if data.get("status") == "done":
         gate_story = story_before or await repo.get(id)
@@ -905,157 +936,53 @@ async def update_story(
         pass
 
     if "assignee_id" in data and old_assignee_id != story.assignee_id:
-        org_id = repo.org_id
-        epic_title: str | None = None
-        try:
-            epic_title = await _resolve_epic_title(db, story.epic_id)
-        except Exception:
-            pass
-        event_data = {
-            "story_id": str(id),
-            "story_title": story.title,
-            "story_priority": story.priority,
-            "epic_id": str(story.epic_id) if story.epic_id else None,
-            "epic_title": epic_title,
-            "assignee_id": str(story.assignee_id) if story.assignee_id else None,
-            "old_assignee_id": str(old_assignee_id) if old_assignee_id else None,
-            "project_id": str(story.project_id),
-            "org_id": str(org_id),
-            "actor_id": str(actor_id) if actor_id else None,
-            "actor_name": actor_name,
-            "actor_role": actor_role,
-            "source_agent_id": str(actor_id) if (actor_id and actor_type == "agent") else None,
-            "assignees": [str(story.assignee_id)] if story.assignee_id else [],
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-        }
-        # AC1(c60dd33c 미러): assignee_changed webhook은 관련자만 — 담당자(신/구)+행위자. member-bound
-        # webhook이 무관 에이전트에 fan-out되던 갭 차단. member_id=null 브로드캐스트는 보존(preserve_broadcast).
-        _assignee_notify_ids = {
-            m for m in (story.assignee_id, old_assignee_id, actor_id) if m is not None
-        }
-        # story #2086(2026-07-21, 까심군 라이브 실측 확定) + #2132(2026-07-23 근본수정):
-        # publish_event()의 org _subscribers fanout은 .add() 호출이 저장소 전체 0곳인 영구
-        # 죽은 레지스트리였다(story #2059/#2067과 동일 근본) — 이제 그 함수 자체를 삭제했다.
-        # story.status_changed(story_status_events.py)와 동형으로 project_accessible_member_ids
-        # 로 수신자 해소 후 _push_to_agent 개별 push만이 실제로 SSE 큐에 들어가는 유일 경로.
-        #
-        # story #2106(2026-07-22, 까심군 #2101 QA 후속): 이 push는 의도적으로 Event row를 안
-        # 만드는 순수 transient SSE(#2101의 last_event_id 백필 대상이 아님) — "왜 여기만
-        # 영속화 안 하지"로 다시 파지 않도록 이유를 명시한다. assignee_changed는 보드/상세
-        # 화면의 "지금 담당자가 누구인지" 실시간 동기화 신호일 뿐이고, 그 값 자체는 항상
-        # story 테이블의 assignee_id가 SSOT라 재조회(새로고침·재연결)하면 그대로 복원된다.
-        # "너에게 배정됐다"는 실제 알림 책임은 몇 줄 아래 story_assigned Event(agent)/
-        # dispatch_notification(human)이 별도로 지고 있다 — 그쪽은 Event-backed(또는 동등한
-        # 영속 알림함) 라 배정받은 사람이 그 순간 연결이 끊겨 있어도 놓치지 않는다. 즉 상태축
-        # (재조회로 복원)과 알림축(영속 전달 필요)이 분리돼 있고, 이 줄은 전자만 담당한다.
+        # story #2172 근본수정(AC1): 이 side-effects를 PATCH /bulk과 공유하는 단일 helper로
+        # 추출 — 두 라우트가 발행 지점을 갈라 갖던 #2131류 결함 재발을 막는다.
+        await emit_story_assignee_changed(
+            db, repo.org_id, story, old_assignee_id,
+            background_tasks=background_tasks,
+            actor_id=actor_id, actor_name=actor_name, actor_role=actor_role, actor_type=actor_type,
+        )
+
+    # story #2172 AC2 판정(오르테가군 지시 — "재정렬 전용 이벤트가 필요한지, 기존 것으로
+    # 되는지 판단하고 근거 남길 것"): 신규 전용 event_type(`story.position_changed`)을 쓰되,
+    # 발행 메커니즘 자체는 assignee_changed와 동일한 기존 패턴(project_accessible_member_ids
+    # + _push_to_agent 개별 push, Event row 미생성)을 그대로 재사용한다. `story.status_changed`나
+    # `story.assignee_changed`를 재사용하지 않은 이유: FE 컨슈머가 event_type으로 분기하는데
+    # (kanban-board.tsx의 `payload.status`/`assignee_id` 필드 체크), 의미가 다른 필드 변경을
+    # 기존 타입에 얹으면 다음에 그 타입 소비처가 무관 필드를 오인 처리할 여지가 생긴다(오늘
+    # 세운 "동작은 한 곳에서만 선언" 원칙과 동형 — event_type과 payload 의미의 1:1을 지킨다).
+    # webhook/notification/StoryActivity를 안 붙인 이유: assignee_changed helper(story_assignee_events.py)
+    # 주석과 동일 논리 — position 값 자체는 story.position이 SSOT라 재조회로 복원되는 순수
+    # 상태축 신호일 뿐, "누가 언제 재배치했는지" 감사가 필요해지면(현재 AC엔 없음) StoryActivity를
+    # 추가해야 한다는 것이 이 판정이 무너지는 조건이다. FE 리스너는 story #2172 시점엔 아직
+    # 없다(kanban-board.tsx가 position PATCH 응답만 낙관적 반영·SSE 구독 X) — 이 이벤트는
+    # 계약(서버가 실제로 emit함)을 갖추는 것이 목적이고 FE 소비는 별도 스코프.
+    if "position" in data and old_position != story.position:
         try:
             from app.routers.events import _push_to_agent
             from app.services.project_auth import project_accessible_member_ids
 
-            member_ids = await project_accessible_member_ids(db, org_id, story.project_id)
-            sse_payload = {"event_type": "story.assignee_changed", **event_data}
-            for member_id in member_ids:
-                _push_to_agent(str(member_id), dict(sse_payload))
+            _pos_member_ids = await project_accessible_member_ids(db, repo.org_id, story.project_id)
+            _pos_payload = {
+                "event_type": "story.position_changed",
+                "story_id": str(id),
+                "story_title": story.title,
+                "position": story.position,
+                "old_position": old_position,
+                "status": story.status,
+                "project_id": str(story.project_id),
+                "org_id": str(repo.org_id),
+                "actor_id": str(actor_id) if actor_id else None,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+            for member_id in _pos_member_ids:
+                _push_to_agent(str(member_id), dict(_pos_payload))
         except Exception:
             logger.warning(
-                "assignee_changed SSE 포워딩 실패(story=%s project=%s)",
+                "position_changed SSE 포워딩 실패(story=%s project=%s)",
                 story.id, story.project_id, exc_info=True,
             )
-        try:
-            await fire_webhooks(
-                db, org_id, "story.assignee_changed", event_data,
-                recipient_member_ids=_assignee_notify_ids,
-            )
-        except Exception:
-            pass
-        try:
-            await process_event(db, org_id, story.project_id, EventContext(
-                event_type="story.assignee_changed",
-                trigger_type_slug="assignee_changed",
-                actor_id=str(actor_id) if actor_id else None,
-                metadata=event_data,
-            ))
-        except Exception:
-            pass
-        # E-EVENTBUS P3 S9 / E-EVENT-INJECT S3: story_assigned 알림 + agent assignment-wake
-        if story.assignee_id and story.assignee_id != old_assignee_id:
-            # assignee 멤버 타입 resolve (agent vs human)
-            assignee_type = (await db.execute(
-                select(TeamMember.type).where(TeamMember.id == story.assignee_id).limit(1)
-            )).scalar_one_or_none()
-
-            if assignee_type == "agent":
-                # E-EVENT-INJECT S3: agent에 배정만 해도 work-turn 시작.
-                # dispatch.py 미러 — content 실린 story_assigned Event + seq + commit BEFORE wake.
-                # (기존 dispatch_notification은 content 없는 dispatched라 connector가 드롭 → 깨우지 못함)
-                _detail = (story.description or "").strip()
-                _content = f"[story] {story.title}" + (f" — {_detail[:200]}" if _detail else "")
-                sa_event = Event(
-                    project_id=story.project_id,
-                    org_id=org_id,
-                    event_type="story_assigned",  # EventType enum 미존재 → literal (connector allow-list 포함)
-                    source_entity_type="story",
-                    source_entity_id=story.id,
-                    sender_id=actor_id,
-                    recipient_id=story.assignee_id,
-                    recipient_type="agent",
-                    payload={
-                        "story_id": str(story.id),
-                        "story_title": story.title,
-                        "content": _content,
-                        "event_type": "story_assigned",
-                    },
-                    status="pending",
-                )
-                db.add(sa_event)
-                await db.flush()
-                await assign_recipient_seq(db, sa_event)  # per-recipient dense seq
-                # L1 BE-3: story assignment → activity_events 1행(best-effort·commit 前·순서 불변).
-                from app.services.activity_stream import extract_activities_best_effort
-                await extract_activities_best_effort(db, [sa_event.id])
-                await db.commit()  # commit BEFORE wake — seq 확정, 이중전달 방지
-                if sa_event.recipient_seq is not None:
-                    wake_agent(str(story.assignee_id), sa_event.recipient_seq)
-                # 1f01c1ad: wake_agent(SSE)는 CC 세션 미도달 → member webhook(CC 릴레이)으로도 주입.
-                # dispatch.py 동형 — INJECTABLE 이벤트의 단일 CC 주입 경로(member webhook)로 일관 전달.
-                from app.services.conversation_webhook import deliver_injected_event_webhook
-                background_tasks.add_task(
-                    deliver_injected_event_webhook,
-                    org_id=org_id,
-                    recipient_id=story.assignee_id,
-                    content=_content,
-                    event_type="story_assigned",
-                    source_entity_type="story",
-                    source_entity_id=story.id,
-                )
-            else:
-                # human: 기존 dispatch_notification 유지 (변경 0)
-                await dispatch_notification(
-                    db,
-                    org_id=org_id,
-                    event_type="story_assigned",
-                    target_member_ids=[story.assignee_id],
-                    title=f"스토리 담당자로 지정됨: {story.title}",
-                    body=None,
-                    reference_type="story",
-                    reference_id=story.id,
-                    # story #1953: story.project_id NOT NULL — 신규 조회 없이 그대로 실음.
-                    source_project_id=story.project_id,
-                )
-        if actor_id:
-            try:
-                db.add(StoryActivity(
-                    story_id=id,
-                    org_id=org_id,
-                    project_id=story.project_id,
-                    activity_type="assignee_changed",
-                    old_value=str(old_assignee_id) if old_assignee_id else None,
-                    new_value=str(story.assignee_id) if story.assignee_id else None,
-                    created_by=(await canonicalize_member_id(actor_id, db)),  # AC3-2d(1b) canonical
-                ))
-                await db.flush()
-            except Exception:
-                pass
 
     # S-C2: story_updated — actor가 agent인 경우 기록 (AC2, AC6)
     if actor_id:

--- a/backend/app/services/story_assignee_events.py
+++ b/backend/app/services/story_assignee_events.py
@@ -1,0 +1,207 @@
+"""스토리 assignee_changed side-effects 공유 발화 (story #2172, 2026-07-24).
+
+근본(AC1): 이 side-effects는 원래 PATCH /{id}(update_story) 안에만 인라인으로 있었다 — bulk가
+assignee_id를 실제로 바꿔도 이 발화 자체가 호출되지 않아 단건/bulk이 서로 다른 계약을 갖고
+있었다(#2131이 status_changed에서 고친 것과 동일 근본). story_status_events.py의
+emit_story_status_changed와 동형으로 단일 helper로 추출해, PATCH /{id}와 PATCH /bulk이 **같은
+발행 지점**을 공유한다 — 두 벌로 갈라놓지 않는다.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import BackgroundTasks
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.event import Event
+from app.models.pm import StoryActivity
+from app.models.team import TeamMember
+
+logger = logging.getLogger(__name__)
+
+
+async def _epic_title(db: AsyncSession, epic_id: uuid.UUID | None) -> str | None:
+    if not epic_id:
+        return None
+    from app.models.pm import Goal
+
+    result = await db.execute(select(Goal).where(Goal.id == epic_id).limit(1))
+    epic = result.scalar_one_or_none()
+    return epic.title if epic else None
+
+
+async def emit_story_assignee_changed(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    story,
+    old_assignee_id: uuid.UUID | None,
+    *,
+    background_tasks: BackgroundTasks,
+    actor_id: uuid.UUID | None = None,
+    actor_name: str | None = None,
+    actor_role: str | None = None,
+    actor_type: str | None = None,
+) -> None:
+    """story assignee_changed의 side-effects를 발화. old==new면 no-op.
+
+    호출자가 story.assignee_id를 이미 새 값으로 설정한 뒤 호출한다. 각 side-effect는
+    best-effort(실패 격리)로 assignee 전이 자체를 깨지 않는다. `background_tasks`는 필수 —
+    agent 배정 시 CC 릴레이(`deliver_injected_event_webhook`)를 fire-and-forget으로 큐잉하는 데
+    쓰인다(PATCH /{id}는 라우트 의존성으로, PATCH /bulk는 이 story #2172에서 새로 받는다).
+    """
+    if old_assignee_id == story.assignee_id:
+        return
+    # lazy import — service→router/pipeline 순환 회피(story_status_events.py와 동형).
+    from app.services.activity_stream import extract_activities_best_effort
+    from app.services.conversation_webhook import deliver_injected_event_webhook
+    from app.services.event_seq import assign_recipient_seq
+    from app.services.member_resolver import canonicalize_member_id
+    from app.services.notification_dispatch import dispatch_notification
+    from app.services.rule_evaluator import EventContext
+    from app.services.webhook_dispatch import fire_webhooks
+    from app.services.workflow_pipeline import process_event
+
+    epic_title: str | None = None
+    try:
+        epic_title = await _epic_title(db, story.epic_id)
+    except Exception:
+        pass
+
+    event_data = {
+        "story_id": str(story.id),
+        "story_title": story.title,
+        "story_priority": story.priority,
+        "epic_id": str(story.epic_id) if story.epic_id else None,
+        "epic_title": epic_title,
+        "assignee_id": str(story.assignee_id) if story.assignee_id else None,
+        "old_assignee_id": str(old_assignee_id) if old_assignee_id else None,
+        "project_id": str(story.project_id),
+        "org_id": str(org_id),
+        "actor_id": str(actor_id) if actor_id else None,
+        "actor_name": actor_name,
+        "actor_role": actor_role,
+        "source_agent_id": str(actor_id) if (actor_id and actor_type == "agent") else None,
+        "assignees": [str(story.assignee_id)] if story.assignee_id else [],
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+    # AC1(c60dd33c 미러): assignee_changed webhook은 관련자만 — 담당자(신/구)+행위자. member-bound
+    # webhook이 무관 에이전트에 fan-out되던 갭 차단. member_id=null 브로드캐스트는 보존(preserve_broadcast).
+    notify_ids = {m for m in (story.assignee_id, old_assignee_id, actor_id) if m is not None}
+
+    # story #2086(2026-07-21, 까심군 라이브 실측 확定) + #2132(2026-07-23 근본수정): 구
+    # publish_event()의 org _subscribers fanout은 영구 죽은 레지스트리였다(이제 삭제됨) —
+    # project 인가 필터를 낀 _push_to_agent 개별 push만이 실제로 SSE 큐에 들어가는 유일 경로.
+    #
+    # story #2106(2026-07-22, 까심군 #2101 QA 후속): 이 push는 의도적으로 Event row를 안
+    # 만드는 순수 transient SSE(#2101의 last_event_id 백필 대상이 아님) — assignee_changed는
+    # "지금 담당자가 누구인지" 실시간 동기화 신호일 뿐이고 값 자체는 항상 story.assignee_id가
+    # SSOT라 재조회하면 복원된다. "너에게 배정됐다"는 실제 알림 책임은 아래 story_assigned
+    # Event(agent)/dispatch_notification(human)이 별도로 진다(상태축과 알림축 분리).
+    try:
+        from app.routers.events import _push_to_agent
+        from app.services.project_auth import project_accessible_member_ids
+
+        member_ids = await project_accessible_member_ids(db, org_id, story.project_id)
+        sse_payload = {"event_type": "story.assignee_changed", **event_data}
+        for member_id in member_ids:
+            _push_to_agent(str(member_id), dict(sse_payload))
+    except Exception:
+        logger.warning(
+            "assignee_changed SSE 포워딩 실패(story=%s project=%s)",
+            story.id, story.project_id, exc_info=True,
+        )
+    try:
+        await fire_webhooks(
+            db, org_id, "story.assignee_changed", event_data,
+            recipient_member_ids=notify_ids,
+        )
+    except Exception:
+        pass
+    try:
+        await process_event(db, org_id, story.project_id, EventContext(
+            event_type="story.assignee_changed",
+            trigger_type_slug="assignee_changed",
+            actor_id=str(actor_id) if actor_id else None,
+            metadata=event_data,
+        ))
+    except Exception:
+        pass
+
+    # E-EVENTBUS P3 S9 / E-EVENT-INJECT S3: story_assigned 알림 + agent assignment-wake
+    if story.assignee_id and story.assignee_id != old_assignee_id:
+        assignee_type = (await db.execute(
+            select(TeamMember.type).where(TeamMember.id == story.assignee_id).limit(1)
+        )).scalar_one_or_none()
+
+        if assignee_type == "agent":
+            # E-EVENT-INJECT S3: agent에 배정만 해도 work-turn 시작.
+            # dispatch.py 미러 — content 실린 story_assigned Event + seq + commit BEFORE wake.
+            _detail = (story.description or "").strip()
+            _content = f"[story] {story.title}" + (f" — {_detail[:200]}" if _detail else "")
+            sa_event = Event(
+                project_id=story.project_id,
+                org_id=org_id,
+                event_type="story_assigned",  # EventType enum 미존재 → literal (connector allow-list 포함)
+                source_entity_type="story",
+                source_entity_id=story.id,
+                sender_id=actor_id,
+                recipient_id=story.assignee_id,
+                recipient_type="agent",
+                payload={
+                    "story_id": str(story.id),
+                    "story_title": story.title,
+                    "content": _content,
+                    "event_type": "story_assigned",
+                },
+                status="pending",
+            )
+            db.add(sa_event)
+            await db.flush()
+            await assign_recipient_seq(db, sa_event)  # per-recipient dense seq
+            # L1 BE-3: story assignment → activity_events 1행(best-effort·commit 前·순서 불변).
+            await extract_activities_best_effort(db, [sa_event.id])
+            await db.commit()  # commit BEFORE wake — seq 확정, 이중전달 방지
+            if sa_event.recipient_seq is not None:
+                from app.routers.agent_gateway import wake_agent
+                wake_agent(str(story.assignee_id), sa_event.recipient_seq)
+            # 1f01c1ad: wake_agent(SSE)는 CC 세션 미도달 → member webhook(CC 릴레이)으로도 주입.
+            background_tasks.add_task(
+                deliver_injected_event_webhook,
+                org_id=org_id,
+                recipient_id=story.assignee_id,
+                content=_content,
+                event_type="story_assigned",
+                source_entity_type="story",
+                source_entity_id=story.id,
+            )
+        else:
+            # human: 기존 dispatch_notification 유지
+            await dispatch_notification(
+                db,
+                org_id=org_id,
+                event_type="story_assigned",
+                target_member_ids=[story.assignee_id],
+                title=f"스토리 담당자로 지정됨: {story.title}",
+                body=None,
+                reference_type="story",
+                reference_id=story.id,
+                source_project_id=story.project_id,
+            )
+    if actor_id:
+        try:
+            db.add(StoryActivity(
+                story_id=story.id,
+                org_id=org_id,
+                project_id=story.project_id,
+                activity_type="assignee_changed",
+                old_value=str(old_assignee_id) if old_assignee_id else None,
+                new_value=str(story.assignee_id) if story.assignee_id else None,
+                created_by=(await canonicalize_member_id(actor_id, db)),  # AC3-2d(1b) canonical
+            ))
+            await db.flush()
+        except Exception:
+            pass

--- a/backend/tests/test_2131_bulk_status_changed_emit.py
+++ b/backend/tests/test_2131_bulk_status_changed_emit.py
@@ -72,7 +72,7 @@ async def test_bulk_status_change_calls_emit_story_status_changed(monkeypatch):
     monkeypatch.setattr(stories_mod, "emit_story_status_changed", spy)
 
     payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": "in-progress"}])
-    await bulk_update_stories(payload, db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
+    await bulk_update_stories(payload, MagicMock(), db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
 
     spy.assert_awaited_once()
     args, kwargs = spy.call_args
@@ -98,7 +98,7 @@ async def test_bulk_no_status_change_does_not_call_emit(monkeypatch):
     monkeypatch.setattr(stories_mod, "emit_story_status_changed", spy)
 
     payload = BulkUpdateRequest(items=[{"id": str(story.id), "priority": "high"}])
-    await bulk_update_stories(payload, db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
+    await bulk_update_stories(payload, MagicMock(), db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
 
     spy.assert_not_awaited()
 
@@ -120,7 +120,7 @@ async def test_bulk_status_unchanged_value_does_not_call_emit(monkeypatch):
     monkeypatch.setattr(stories_mod, "emit_story_status_changed", spy)
 
     payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": "todo"}])
-    await bulk_update_stories(payload, db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
+    await bulk_update_stories(payload, MagicMock(), db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
 
     spy.assert_not_awaited()
 
@@ -143,7 +143,7 @@ async def test_bulk_emit_failure_isolated_per_item(monkeypatch):
     )
 
     payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": "in-progress"}])
-    result = await bulk_update_stories(payload, db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
+    result = await bulk_update_stories(payload, MagicMock(), db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
 
     assert len(result) == 1 and result[0].status == "in-progress"
 

--- a/backend/tests/test_2172_assignee_position_events.py
+++ b/backend/tests/test_2172_assignee_position_events.py
@@ -1,0 +1,498 @@
+"""story #2172(2026-07-24, 오르테가군 킥오프): #2131이 status_changed에서 닫은 "bulk과 단건이
+서로 다른 이벤트 계약을 갖는" 결함이 assignee_id/position에도 있었다.
+
+AC1: PATCH /stories/bulk이 assignee_id를 실제로 바꾸면 PATCH /{id}와 **같은** story.assignee_changed
+     를 낸다 — 발행 지점은 emit_story_assignee_changed(story_assignee_events.py) 하나뿐(#2131의
+     helper-공유 방식 재사용).
+AC2: PATCH /{id}가 position을 실제로 바꾸면 story.position_changed를 낸다(단건 경로 한정 — FE가
+     position을 bulk으로 보내는 경로 자체가 없다, kanban-board.tsx 확認).
+AC3: 해당 필드가 실제로 안 바뀐 호출은 두 이벤트 모두 0건.
+
+⚠️ 오르테가군 킥오프 명시 — low 우선순위인 이유: assignee_id는 bulk 라이브 콜러가 0(FE가 bulk로
+안 보냄), position은 실측 271건 중 3건만 채워져 있어(사람이 순서를 사실상 안 씀) "계약은 깨져
+있으나 지금 아무도 안 밟는" 자리. 그래도 계약 자체는 맞춰둔다(다음에 누가 이 경로를 밟을 때
+또 #2131류 결함으로 재발하지 않도록).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.routers import stories as stories_mod
+from app.routers.stories import BulkUpdateRequest, bulk_update_stories
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+_REAL_DB_SKIP = pytest.mark.skipif(
+    not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── A. mock 단위 — bulk_update_stories가 assignee_id 변경 시 emit_story_assignee_changed를
+#    #2131의 status와 동일한 판정 논리(실제 변경만·값 동일이면 스킵·실패 격리)로 호출하는지 ──
+def _story(assignee_id=None, position=None, **overrides):
+    now = datetime(2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc)
+    base = dict(
+        id=uuid.uuid4(), project_id=uuid.uuid4(), org_id=uuid.uuid4(), epic_id=None,
+        sprint_id=None, assignee_id=assignee_id, assignee_ids=[], attachments=[], meeting_id=None,
+        title="t", status="todo", priority="medium", story_points=None, description=None,
+        acceptance_criteria=None, position=position, success_hypothesis=None, metric_definition=None,
+        measure_after=None, outcome_status="n_a", outcome_result=None, is_excluded=False,
+        created_at=now, updated_at=now,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _mock_db(story_by_id: dict):
+    async def _execute(stmt, *a, **kw):
+        m = MagicMock()
+        m.scalar_one_or_none = MagicMock(return_value=next(iter(story_by_id.values())))
+        return m
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=_execute)
+    db.flush = AsyncMock()
+    db.refresh = AsyncMock()
+    db.commit = AsyncMock()
+    db.add = MagicMock()
+    return db
+
+
+def _patch_common(monkeypatch):
+    monkeypatch.setattr(stories_mod, "_attach_assignee_ids", AsyncMock())
+    monkeypatch.setattr(stories_mod, "_resolve_team_member_id", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        "app.services.project_auth.has_project_access", AsyncMock(return_value=True)
+    )
+    monkeypatch.setattr(
+        "app.repositories.story_assignee.StoryAssigneeRepository.set_for_story", AsyncMock()
+    )
+
+
+@pytest.mark.anyio
+async def test_bulk_assignee_change_calls_emit_story_assignee_changed(monkeypatch):
+    story = _story(assignee_id=None)
+    db = _mock_db({story.id: story})
+    repo = MagicMock()
+    repo.org_id = story.org_id
+
+    _patch_common(monkeypatch)
+    spy = AsyncMock()
+    monkeypatch.setattr(stories_mod, "emit_story_assignee_changed", spy)
+
+    new_assignee = uuid.uuid4()
+    payload = BulkUpdateRequest(items=[{"id": str(story.id), "assignee_id": str(new_assignee)}])
+    await bulk_update_stories(
+        payload, MagicMock(), db, repo, auth=MagicMock(user_id=str(uuid.uuid4())),
+    )
+
+    spy.assert_awaited_once()
+    args, kwargs = spy.call_args
+    assert args[1] == repo.org_id
+    assert args[2] is story
+    assert args[3] is None  # old_assignee_id
+    assert "background_tasks" in kwargs
+
+
+@pytest.mark.anyio
+async def test_bulk_no_assignee_field_does_not_call_emit(monkeypatch):
+    """AC3 — priority만 바뀌는 item은 assignee emit 호출 자체가 없어야."""
+    story = _story(assignee_id=None, priority="low")
+    db = _mock_db({story.id: story})
+    repo = MagicMock()
+    repo.org_id = story.org_id
+
+    _patch_common(monkeypatch)
+    spy = AsyncMock()
+    monkeypatch.setattr(stories_mod, "emit_story_assignee_changed", spy)
+
+    payload = BulkUpdateRequest(items=[{"id": str(story.id), "priority": "high"}])
+    await bulk_update_stories(
+        payload, MagicMock(), db, repo, auth=MagicMock(user_id=str(uuid.uuid4())),
+    )
+
+    spy.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_bulk_assignee_unchanged_value_does_not_call_emit(monkeypatch):
+    """AC3 — 같은 값으로 PATCH(assignee_id 그대로)는 old_assignee_by_id에 안 잡히므로 emit도 안 함."""
+    same_id = uuid.uuid4()
+    story = _story(assignee_id=same_id)
+    db = _mock_db({story.id: story})
+    repo = MagicMock()
+    repo.org_id = story.org_id
+
+    _patch_common(monkeypatch)
+    spy = AsyncMock()
+    monkeypatch.setattr(stories_mod, "emit_story_assignee_changed", spy)
+
+    payload = BulkUpdateRequest(items=[{"id": str(story.id), "assignee_id": str(same_id)}])
+    await bulk_update_stories(
+        payload, MagicMock(), db, repo, auth=MagicMock(user_id=str(uuid.uuid4())),
+    )
+
+    spy.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_bulk_assignee_unassign_to_none_is_not_representable(monkeypatch):
+    """기존 bulk 한계(#2172 스코프 밖) 문서화 — BulkUpdateItem.model_dump(exclude_none=True)는
+    assignee_id=None(명시적 미배정)을 항상 드롭한다. 이 테스트는 그 한계를 고정해 다음 사람이
+    "왜 bulk 미배정이 안 먹지"로 새로 헤매지 않게 한다 — 고치는 게 아니라 기록."""
+    same_id = uuid.uuid4()
+    story = _story(assignee_id=same_id)
+    db = _mock_db({story.id: story})
+    repo = MagicMock()
+    repo.org_id = story.org_id
+
+    _patch_common(monkeypatch)
+    spy = AsyncMock()
+    monkeypatch.setattr(stories_mod, "emit_story_assignee_changed", spy)
+
+    payload = BulkUpdateRequest(items=[{"id": str(story.id), "assignee_id": None}])
+    await bulk_update_stories(
+        payload, MagicMock(), db, repo, auth=MagicMock(user_id=str(uuid.uuid4())),
+    )
+
+    spy.assert_not_awaited()  # exclude_none이 assignee_id 키 자체를 지워 변경으로 안 잡힘
+
+
+@pytest.mark.anyio
+async def test_bulk_assignee_emit_failure_isolated_per_item(monkeypatch):
+    story = _story(assignee_id=None)
+    db = _mock_db({story.id: story})
+    repo = MagicMock()
+    repo.org_id = story.org_id
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(
+        stories_mod, "emit_story_assignee_changed", AsyncMock(side_effect=RuntimeError("boom"))
+    )
+
+    payload = BulkUpdateRequest(items=[{"id": str(story.id), "assignee_id": str(uuid.uuid4())}])
+    result = await bulk_update_stories(
+        payload, MagicMock(), db, repo, auth=MagicMock(user_id=str(uuid.uuid4())),
+    )
+
+    assert len(result) == 1
+
+
+def test_bulk_and_single_share_the_one_assignee_emit_helper():
+    """소스 검사(AC1) — PATCH /{id}·PATCH /bulk 둘 다 emit_story_assignee_changed를 정확히
+    1회씩만 호출. 새 파생 함수를 만들거나 발행 로직을 인라인으로 복제하지 않았는지 회귀 고정
+    (오늘 확立된 "발행 지점을 두 벌로 만들지 말 것" 관례, #2131과 동형)."""
+    import inspect
+
+    bulk_source = inspect.getsource(stories_mod.bulk_update_stories)
+    assert bulk_source.count("await emit_story_assignee_changed(") == 1
+
+    single_source = inspect.getsource(stories_mod.update_story)
+    assert single_source.count("await emit_story_assignee_changed(") == 1
+    # 예전 인라인 블록의 흔적(story_assigned Event 직접 생성)이 update_story 안에 남아있으면
+    # 발행 지점이 갈라진 것 — 완전히 helper로 이관됐는지 고정.
+    assert "sa_event = Event(" not in single_source
+
+
+def test_position_changed_event_type_and_judgment_documented():
+    """소스 검사(AC2) — position 변경 시 story.position_changed를 낸다는 계약 + 오르테가군이
+    요청한 "판정 근거·무너지는 조건" 선언이 소스에 남아있는지 고정(오늘 팀 관례로 채택된
+    "선언은 comment가 아니라 pinning test로" 그대로 적용)."""
+    import inspect
+
+    single_source = inspect.getsource(stories_mod.update_story)
+    assert '"event_type": "story.position_changed"' in single_source
+    assert "판정이 무너지는 조건" in single_source
+
+
+# ── B. 실PG+실HTTP — #2131이 확立한 _agent_connections 실 큐 관찰 패턴 재사용(mock 아닌
+#    실제 서버 push 관찰) ──────────────────────────────────────────────────────────────
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    import app.models  # noqa: F401
+    from app.core.database import Base
+
+    def _async_url() -> str:
+        url = _REAL_DB_URL
+        for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+            if url.startswith(prefix):
+                return "postgresql+asyncpg://" + url[len(prefix):]
+        return url
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import Project
+    from app.models.team import TeamMember
+
+    org = Organization(id=uuid.uuid4(), name="Org2172", slug=f"org2172-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    # actor(human, grant 불요·has_project_access team_member_branch) — #2131 패턴 재사용.
+    # watcher(agent) — "남의 화면" 관찰 대상. new_assignee(human) — 재배정 대상 실존 멤버(
+    # dispatch_notification이 실 member 대상으로 정상 동작하게).
+    actor_id, watcher_id, assignee_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    session.add_all([
+        TeamMember(id=actor_id, org_id=org.id, project_id=project.id, type="human", name="actor"),
+        TeamMember(id=watcher_id, org_id=org.id, project_id=project.id, type="agent", name="watcher"),
+        TeamMember(id=assignee_id, org_id=org.id, project_id=project.id, type="human", name="assignee"),
+    ])
+    await session.commit()
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="S", status="todo")
+    session.add(story)
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "actor_id": actor_id,
+        "watcher_id": watcher_id, "assignee_id": assignee_id, "story_id": story.id,
+    }
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, actor_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(actor_id), email="actor@test",
+            claims={"app_metadata": {"org_id": str(org_id), "api_key_id": "test-key"}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_bulk_assignee_change_pushes_same_event_as_single():
+    """⭐본체 AC1 — PATCH /stories/bulk이 assignee_id를 바꾸면 PATCH /{id}와 동일한
+    story.assignee_changed가 실제로 프로젝트 워처에게 도착한다."""
+    from app.main import app
+    from app.routers import events as events_mod
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["actor_id"], seeded["org_id"])
+
+        watcher_id = str(seeded["watcher_id"])
+        q: asyncio.Queue = asyncio.Queue(maxsize=50)
+        events_mod._agent_connections[watcher_id].add(q)
+        try:
+            client = _client_for(app)
+            try:
+                resp = await client.patch(
+                    "/api/v2/stories/bulk",
+                    json={"items": [{
+                        "id": str(seeded["story_id"]), "assignee_id": str(seeded["assignee_id"]),
+                    }]},
+                )
+                assert resp.status_code == 200, resp.text
+            finally:
+                await client.aclose()
+
+            await asyncio.sleep(0.1)
+
+            received = []
+            while not q.empty():
+                received.append(q.get_nowait())
+
+            assignee_changed = [e for e in received if e.get("event_type") == "story.assignee_changed"]
+            assert len(assignee_changed) == 1, (
+                f"워처가 assignee_changed를 정확히 1건 받아야(bulk 경로) — 실제 "
+                f"{len(assignee_changed)}건. 전체 수신: {received}"
+            )
+            evt = assignee_changed[0]
+            assert evt["assignee_id"] == str(seeded["assignee_id"])
+            assert evt["old_assignee_id"] is None
+            assert evt["story_id"] == str(seeded["story_id"])
+        finally:
+            events_mod._agent_connections[watcher_id].discard(q)
+            events_mod._agent_connections.pop(watcher_id, None)
+    finally:
+        app.dependency_overrides.clear()
+        from app.core.database import engine as _global_engine
+        await _global_engine.dispose()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_bulk_no_assignee_field_pushes_zero():
+    """AC3 — assignee_id 필드 자체를 안 보내는 bulk 호출(priority만)은 assignee_changed 0건."""
+    from app.main import app
+    from app.routers import events as events_mod
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["actor_id"], seeded["org_id"])
+
+        watcher_id = str(seeded["watcher_id"])
+        q: asyncio.Queue = asyncio.Queue(maxsize=50)
+        events_mod._agent_connections[watcher_id].add(q)
+        try:
+            client = _client_for(app)
+            try:
+                resp = await client.patch(
+                    "/api/v2/stories/bulk",
+                    json={"items": [{"id": str(seeded["story_id"]), "priority": "high"}]},
+                )
+                assert resp.status_code == 200, resp.text
+            finally:
+                await client.aclose()
+
+            await asyncio.sleep(0.1)
+
+            received = []
+            while not q.empty():
+                received.append(q.get_nowait())
+            assert not any(e.get("event_type") == "story.assignee_changed" for e in received)
+        finally:
+            events_mod._agent_connections[watcher_id].discard(q)
+            events_mod._agent_connections.pop(watcher_id, None)
+    finally:
+        app.dependency_overrides.clear()
+        from app.core.database import engine as _global_engine
+        await _global_engine.dispose()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_single_position_change_pushes_position_changed():
+    """⭐본체 AC2 — PATCH /{id}가 position을 바꾸면 story.position_changed가 프로젝트 워처에게
+    실제로 도착한다(FE dnd 같은 컬럼 내 재정렬 경로 — kanban-board.tsx 확認)."""
+    from app.main import app
+    from app.routers import events as events_mod
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["actor_id"], seeded["org_id"])
+
+        watcher_id = str(seeded["watcher_id"])
+        q: asyncio.Queue = asyncio.Queue(maxsize=50)
+        events_mod._agent_connections[watcher_id].add(q)
+        try:
+            client = _client_for(app)
+            try:
+                resp = await client.patch(
+                    f"/api/v2/stories/{seeded['story_id']}", json={"position": 2000},
+                )
+                assert resp.status_code == 200, resp.text
+            finally:
+                await client.aclose()
+
+            await asyncio.sleep(0.1)
+
+            received = []
+            while not q.empty():
+                received.append(q.get_nowait())
+
+            position_changed = [e for e in received if e.get("event_type") == "story.position_changed"]
+            assert len(position_changed) == 1, (
+                f"워처가 position_changed를 정확히 1건 받아야 — 실제 {len(position_changed)}건. "
+                f"전체 수신: {received}"
+            )
+            evt = position_changed[0]
+            assert evt["position"] == 2000
+            assert evt["old_position"] is None
+            assert evt["story_id"] == str(seeded["story_id"])
+        finally:
+            events_mod._agent_connections[watcher_id].discard(q)
+            events_mod._agent_connections.pop(watcher_id, None)
+    finally:
+        app.dependency_overrides.clear()
+        from app.core.database import engine as _global_engine
+        await _global_engine.dispose()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_single_position_unchanged_pushes_zero():
+    """AC3 — position 필드 자체를 안 보내는 단건 PATCH(title만)는 position_changed 0건."""
+    from app.main import app
+    from app.routers import events as events_mod
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["actor_id"], seeded["org_id"])
+
+        watcher_id = str(seeded["watcher_id"])
+        q: asyncio.Queue = asyncio.Queue(maxsize=50)
+        events_mod._agent_connections[watcher_id].add(q)
+        try:
+            client = _client_for(app)
+            try:
+                resp = await client.patch(
+                    f"/api/v2/stories/{seeded['story_id']}", json={"title": "renamed"},
+                )
+                assert resp.status_code == 200, resp.text
+            finally:
+                await client.aclose()
+
+            await asyncio.sleep(0.1)
+
+            received = []
+            while not q.empty():
+                received.append(q.get_nowait())
+            assert not any(e.get("event_type") == "story.position_changed" for e in received)
+        finally:
+            events_mod._agent_connections[watcher_id].discard(q)
+            events_mod._agent_connections.pop(watcher_id, None)
+    finally:
+        app.dependency_overrides.clear()
+        from app.core.database import engine as _global_engine
+        await _global_engine.dispose()
+        await engine.dispose()

--- a/backend/tests/test_assignee_changed_fanout_21496392.py
+++ b/backend/tests/test_assignee_changed_fanout_21496392.py
@@ -10,18 +10,24 @@ org-wide 의도 유지(per-agent 미전파)라 미스코핑"이라 적어뒀었�
 실제로는 SSE가 **아예 아무에게도 안 갔다**(까심군 라이브 실측으로 발견). story.status_changed와
 동형으로 `project_accessible_member_ids` + `_push_to_agent` 개별 push를 추가해 실 SSE 전달을
 복구했다 — 자세한 realdb 회귀는 `test_2086_assignee_changed_sse.py` 참조.
+
+⚠️story #2172(2026-07-24) 정정: assignee_changed의 발행 로직(webhook 게이팅 포함)이 stories.py
+인라인에서 `app/services/story_assignee_events.py`의 `emit_story_assignee_changed()`로
+이관됐다(PATCH /{id}·PATCH /bulk 공유). 게이팅 자체(관련자만 recipient_member_ids)는 그대로
+보존됐고, 검사 대상 소스만 그 신규 모듈로 옮겨간다.
 """
 from __future__ import annotations
 
 import inspect
 
 from app.routers import stories
+from app.services import story_assignee_events
 
 
 def test_assignee_changed_fire_webhooks_gated_to_relevant():
-    src = inspect.getsource(stories)
+    src = inspect.getsource(story_assignee_events)
     # assignee_changed: recipient_member_ids = 담당자(신/구)+행위자
-    assert "recipient_member_ids=_assignee_notify_ids" in src
+    assert "recipient_member_ids=notify_ids" in src
     assert "story.assignee_id, old_assignee_id, actor_id" in src
 
 

--- a/backend/tests/test_e_event_inject_s3_assignment_wake.py
+++ b/backend/tests/test_e_event_inject_s3_assignment_wake.py
@@ -96,9 +96,11 @@ async def _run_patch(assignee_type: str):
              patch("app.routers.stories._resolve_actor_info", new_callable=AsyncMock, return_value=(None, None, None)), \
              patch("app.routers.stories._upsert_assignee_participation", new_callable=AsyncMock), \
              patch("app.repositories.story_assignee.StoryAssigneeRepository.set_for_story", new_callable=AsyncMock, return_value=[ASSIGNEE_ID]), \
-             patch("app.routers.stories.assign_recipient_seq", side_effect=_seq), \
-             patch("app.routers.stories.wake_agent") as mock_wake, \
-             patch("app.routers.stories.dispatch_notification", new_callable=AsyncMock) as mock_dispatch:
+             patch("app.services.activity_stream.extract_activities_best_effort", new_callable=AsyncMock), \
+             patch("app.services.conversation_webhook.deliver_injected_event_webhook", new_callable=AsyncMock), \
+             patch("app.services.event_seq.assign_recipient_seq", side_effect=_seq), \
+             patch("app.routers.agent_gateway.wake_agent") as mock_wake, \
+             patch("app.services.notification_dispatch.dispatch_notification", new_callable=AsyncMock) as mock_dispatch:
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as c:
                 resp = await c.patch(f"/api/v2/stories/{STORY_ID}", json={"assignee_id": str(ASSIGNEE_ID)})

--- a/backend/tests/test_stories_bulk_body_contract.py
+++ b/backend/tests/test_stories_bulk_body_contract.py
@@ -68,7 +68,7 @@ async def test_bulk_handler_refreshes_and_serializes(monkeypatch):
     # ⚠️ model_validate 는 모킹하지 않는다 — 실 직렬화를 태워야 P0 3차류를 잡는다.
 
     payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": "done"}])
-    result = await bulk_update_stories(payload, db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
+    result = await bulk_update_stories(payload, MagicMock(), db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
 
     assert story.status == "done"  # setattr 적용
     db.refresh.assert_awaited_once_with(story)  # MissingGreenlet fix 가드(refresh 누락 시 실패)
@@ -97,7 +97,7 @@ async def test_bulk_nonsequential_jump_flags_violation_but_allows(monkeypatch):
     monkeypatch.setattr(stories_mod, "fire_webhooks", _fire)
 
     payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": "in-progress"}])
-    result = await bulk_update_stories(payload, db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
+    result = await bulk_update_stories(payload, MagicMock(), db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
 
     assert story.status == "in-progress"  # allow(차단 X)
     assert result[0].violation == {
@@ -126,7 +126,7 @@ async def test_bulk_adjacent_and_reopen_no_violation(monkeypatch):
         _fire = AsyncMock(); monkeypatch.setattr(stories_mod, "fire_webhooks", _fire)
 
         payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": new}])
-        result = await bulk_update_stories(payload, db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
+        result = await bulk_update_stories(payload, MagicMock(), db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
 
         assert story.status == new  # allow
         assert result[0].violation is None, f"{old}->{new} should be no-violation"


### PR DESCRIPTION
## Summary
- **AC1**: `PATCH /stories/bulk`이 `assignee_id`를 실제로 바꾸면 `PATCH /{id}`와 **같은** `story.assignee_changed`를 낸다. 인라인이던 assignee_changed side-effects(SSE push·webhook·process_event·story_assigned Event/wake·StoryActivity)를 `app/services/story_assignee_events.py::emit_story_assignee_changed()`로 추출해 두 라우트가 공유한다 — 발행 지점을 두 벌로 만들지 않는다(#2131이 status_changed에서 세운 패턴 재사용).
- **AC2**: `PATCH /{id}`가 `position`을 실제로 바꾸면 `story.position_changed`를 낸다(단건 경로 한정 — FE가 position을 bulk으로 보내는 경로 자체가 없음, `kanban-board.tsx` 확認). 신규 event_type을 쓰되 발행 메커니즘(`project_accessible_member_ids` + `_push_to_agent`, Event row 미생성)은 assignee_changed와 동일 패턴 재사용. `status_changed`/`assignee_changed`를 재사용하지 않은 이유와, webhook/notification/StoryActivity를 안 붙인 이유를 소스에 판정 근거+무너지는 조건으로 선언하고 pinning 테스트로 고정.
- **AC3**: 해당 필드가 실제로 안 바뀐 호출은 두 이벤트 모두 0건 — mock 단위 테스트 + 실PG `_agent_connections` 라이브 큐 관찰 양쪽으로 검증.

### low 우선순위 컨텍스트(오르테가군 킥오프)
assignee_id는 bulk 라이브 콜러가 0(FE가 bulk로 안 보냄), position은 실측 271건 중 3건만 채워져 있음(사람이 순서를 사실상 안 씀) — "계약은 깨져 있으나 지금 아무도 안 밟는" 자리를 닫는 작업. 미르코군의 AC5(화면 증명)가 이 PR 머지를 기다리고 있음.

## 부수 변경
- `bulk_update_stories`가 `background_tasks: BackgroundTasks`를 새로 받음(agent 배정 시 CC 릴레이 큐잉에 필요) — 기존 3개 테스트 파일의 직접 함수호출 call site를 새 시그니처에 맞춰 갱신.
- `test_assignee_changed_fanout_21496392.py`의 source-pin 검사 대상을 `stories.py` → `story_assignee_events.py`로 이동(로직 이관 반영).

## Test plan
- [x] `test_2172_assignee_position_events.py`(신규, 11): mock 단위(bulk assignee 변경/무변경/실패격리/소스공유) + 실PG `_agent_connections` 큐 관찰(bulk assignee AC1·position AC2·양쪽 AC3 negative control)
- [x] 기존 `test_2086_assignee_changed_sse.py`·`test_assignee_changed_fanout_21496392.py`·`test_e_event_inject_s3_assignment_wake.py`·`test_s_comm_07.py` 등 assignee_changed 관련 전 스위트 grep+재실행 — 회귀 0(patch target 3곳만 새 모듈 위치로 갱신)
- [x] 전체 non-destructive 백엔드 스위트: `3736 passed`, 실패 7건은 오늘 하루 종일 재현된 로컬 MCP stdio 환경 이슈(코드 변경과 무관, 기존 확인된 목록과 동일)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>