### PR TITLE
[SID:2172] story.position_changed FE 소비 배선 (AC5 완결)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -451,6 +451,7 @@
     "loadMore": "Load more",
     "realtimeStatusChanged": "{actor} changed the status of {title}",
     "realtimeAssigneeChanged": "{actor} changed the assignee of {title}",
+    "realtimePositionChanged": "{actor} changed the order of {title}",
     "realtimeUnknownActor": "Someone",
     "editStory": "Edit Story",
     "changeStatus": "Change Status",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -451,6 +451,7 @@
     "loadMore": "더 보기",
     "realtimeStatusChanged": "{actor}님이 {title} 상태를 변경했습니다",
     "realtimeAssigneeChanged": "{actor}님이 {title} 담당자를 변경했습니다",
+    "realtimePositionChanged": "{actor}님이 {title} 순서를 변경했습니다",
     "realtimeUnknownActor": "누군가",
     "editStory": "스토리 수정",
     "changeStatus": "상태 변경",

--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -348,6 +348,76 @@ describe('KanbanBoard — 실시간(SSE) 반영', () => {
     // 의존이라 이 테스트 범위 밖(멤버 목록 자체가 별건).
     expect(container.textContent).toContain('오르테가님이 S1 담당자를 변경했습니다');
   });
+
+  // story #2172 AC5 — BE(#2476)는 이미 story.position_changed를 발행하고 있었으나 FE 구독이
+  // 없어 "프레임은 나가는데 아무도 안 받는" 죽은 경로였다(라이브 실측으로 확認, dev). 컬럼 렌더가
+  // position으로 정렬하므로(storiesByColumn) position만 patch하면 재정렬은 그 정렬 로직이
+  // 그대로 이어받는다 — 이 테스트는 그 재정렬이 실제로 일어나는지 카드 DOM 순서로 고정한다.
+  it('순서 변경 이벤트도 토스트로 드러난다', async () => {
+    stubFetch([{ id: 's1', title: 'S1', status: 'backlog', priority: 'medium', position: 1000 }]);
+    await mount();
+    await act(async () => {
+      dispatchSse('story.position_changed', {
+        story_id: 's1', project_id: 'proj-1', actor_id: 'other-1', actor_name: '유나',
+        position: 500, old_position: 1000,
+      });
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain('유나님이 S1 순서를 변경했습니다');
+  });
+
+  it('순서 변경 시 카드가 같은 컬럼 안에서 실제로 재배치된다(#2172 AC5②)', async () => {
+    // S1이 S2보다 뒤(position 큰 값)로 시작 — 이벤트로 S1이 S2보다 앞서게 만든다.
+    stubFetch([
+      { id: 's1', title: 'S1', status: 'backlog', priority: 'medium', position: 2000 },
+      { id: 's2', title: 'S2', status: 'backlog', priority: 'medium', position: 1000 },
+    ]);
+    await mount();
+    // ⚠️컨테이너 전체 textContent로 순서를 재면 ToastContainer가 담는 토스트 문구(스토리 제목을
+    // 그대로 포함)에 오염된다 — 오늘 라이브 계측에서 한 번 걸린 그 함정과 동형이라, 카드
+    // 자체만(dnd-kit useSortable이 부여하는 aria-roledescription="sortable") 스코프를 좁힌다.
+    function cardOrder(): string[] {
+      return Array.from(container.querySelectorAll('[aria-roledescription="sortable"]'))
+        .map((el) => (el.textContent!.includes('S1') ? 'S1' : el.textContent!.includes('S2') ? 'S2' : '?'));
+    }
+    expect(cardOrder()).toEqual(['S2', 'S1']); // 시작 상태: S2(1000)가 S1(2000)보다 먼저
+
+    await act(async () => {
+      dispatchSse('story.position_changed', {
+        story_id: 's1', project_id: 'proj-1', actor_id: 'other-1', actor_name: '유나',
+        position: 500, old_position: 2000,
+      });
+      await Promise.resolve();
+    });
+
+    expect(cardOrder()).toEqual(['S1', 'S2']); // S1이 500으로 내려와 S2(1000)보다 앞으로 옴
+  });
+
+  it('position 값이 실제로 안 바뀐 순서 이벤트는 무시한다(음성대조 — 과다 patch/토스트 방지)', async () => {
+    stubFetch([{ id: 's1', title: 'S1', status: 'backlog', priority: 'medium', position: 1000 }]);
+    await mount();
+    await act(async () => {
+      dispatchSse('story.position_changed', {
+        story_id: 's1', project_id: 'proj-1', actor_id: 'other-1', actor_name: '유나',
+        position: 1000, old_position: 1000, // 동일값 — 실질 변경 없음
+      });
+      await Promise.resolve();
+    });
+    expect(container.textContent).not.toContain('순서를 변경했습니다');
+  });
+
+  it('내 액션의 echo(actor_id===currentTeamMemberId)는 순서 변경 토스트도 안 띄운다', async () => {
+    stubFetch([{ id: 's1', title: 'S1', status: 'backlog', priority: 'medium', position: 1000 }]);
+    await mount();
+    await act(async () => {
+      dispatchSse('story.position_changed', {
+        story_id: 's1', project_id: 'proj-1', actor_id: 'me-1', actor_name: '나',
+        position: 500, old_position: 1000,
+      });
+      await Promise.resolve();
+    });
+    expect(container.textContent).not.toContain('순서를 변경했습니다');
+  });
 });
 
 // story #2137 — 카드는 갱신되는데 상세 패널만 옛값에 고정되던 결함(#2384·#2130과 같은 클래스의

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -280,6 +280,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
       status?: string;
       assignee_id?: string | null;
       assignees?: string[];
+      position?: number;
     };
     if (!payload.story_id || !payload.project_id || payload.project_id !== projectId) return;
     // 내 액션의 echo는 무시 — 이미 낙관 갱신했으므로 중복 패치·토스트 스팸을 방지한다.
@@ -299,6 +300,12 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
       // 손으로 두 필드를 따로 계산하던 자리(#2130 근본)를 구조로 제거.
       const assigneePatch = normalizeAssigneePatch({ assignee_id: payload.assignee_id, assignee_ids: payload.assignees });
       patchStoryFromSse(payload.story_id, assigneePatch);
+    } else if (eventName === 'story.position_changed' && typeof payload.position === 'number' && payload.position !== existing.position) {
+      // story #2172 AC5 — BE는 이미 발행하고 있었으나(#2476) FE 구독이 없어 "프레임은 나가는데
+      // 아무도 안 받는" 죽은 경로였다(#2131이 고친 "프레임이 출발조차 안 함"의 거울상). 컬럼
+      // 렌더가 이미 position으로 정렬하므로(위 columnStories 계산부) position만 patch하면
+      // 재정렬은 그 정렬 로직이 그대로 이어받는다 — 별도 재배치 코드 불요.
+      patchStoryFromSse(payload.story_id, { position: payload.position });
     } else {
       return;
     }
@@ -310,13 +317,15 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
       type: 'info',
       title: eventName === 'story.status_changed'
         ? t('realtimeStatusChanged', { actor: actorLabel, title: titleForToast })
-        : t('realtimeAssigneeChanged', { actor: actorLabel, title: titleForToast }),
+        : eventName === 'story.assignee_changed'
+          ? t('realtimeAssigneeChanged', { actor: actorLabel, title: titleForToast })
+          : t('realtimePositionChanged', { actor: actorLabel, title: titleForToast }),
     });
   }, [projectId, currentTeamMemberId, stories, adjustColumnTotal, addToast, t, patchStoryFromSse]);
 
   useSseNotifications({
     memberId: currentTeamMemberId,
-    extraEventNames: ['story.status_changed', 'story.assignee_changed'],
+    extraEventNames: ['story.status_changed', 'story.assignee_changed', 'story.position_changed'],
     onExtraEvent: handleBoardSseEvent,
   });
 


### PR DESCRIPTION
## 배경
#2172 BE PR(#2476, 59c1c71e)이 `story.position_changed`를 이미 발행하고 있었으나, PR 자체 주석에 "FE 소비는 별도 스코프"로 명시돼 있어 FE 구독이 없었다. AC5(사람눈 화면증명) 라이브 테스트에서 실제로 확認: DB position 반영·SSE 이벤트 발행 둘 다 정상인데 화면 뮤테이션 0건 — "프레임은 나가는데 아무도 안 받는" 죽은 경로(#2131이 고친 "프레임이 출발조차 안 함"의 거울상, 오르테가군 판정으로 별건 분리 없이 즉시 배선).

## 변경
- `kanban-board.tsx`: `handleBoardSseEvent`에 `story.position_changed` 분기 추가. 컬럼 렌더(`storiesByColumn`)가 이미 position 오름차순 정렬이라 `position` 필드만 patch하면 재정렬은 그 로직이 그대로 이어받음 — 별도 재배치 코드 불요.
- 기존 `status_changed`/`assignee_changed`와 동일한 echo 무시(`actor_id===currentTeamMemberId`)·`project_id` 필터·AC4 토스트 규약 재사용.
- i18n 키 `realtimePositionChanged` 추가(ko/en).

## AC5 라이브 검증 (dev, sha 59c1c71e 배포 확認 후)
액터=제 agent API key로 BE `/api/v2/stories/{id}` 직접 curl(브라우저 밖 경로) · 워처=puppeteer, 관측 스코프는 보드 컬럼 루트로 좁힘(토스트 서브트리 배제 — 오늘 걸린 함정 반영).

- ① 담당자 변경 → PASS(아바타 새로고침 0회 등장)
- ③ 음성대조(priority만 변경) → PASS(뮤테이션 0건)
- ② 순서 변경 → 이 PR 이전엔 DB/이벤트는 정상인데 화면 뮤테이션 0건 확認(배선 전 상태 실측) — 이 PR로 배선

## 회귀테스트 4건 (kanban-board.test.tsx)
1. 순서 변경 이벤트 토스트 노출
2. **실제 재배치** — 카드 DOM 순서가 position 값에 따라 실제로 뒤바뀌는지(`aria-roledescription="sortable"` 스코프로 카드만 추출 — 컨테이너 전체 텍스트로 재면 토스트 문구에 오염됨, 뮤테이션 셀프체크 중 직접 발견해 수정)
3. 음성대조 — position 값이 실제로 안 바뀐 이벤트는 무시(과다 patch/토스트 방지)
4. echo 무시 — 내 액션이면 토스트 안 뜸

**뮤테이션 셀프체크**: position patch를 일시적으로 no-op화 → 재배치 테스트가 RED로 떨어지는 것 확認 → 복구 후 GREEN. 이 과정에서 최초 작성한 테스트가 컨테이너 전체 텍스트로 순서를 재고 있어 토스트 텍스트(스토리 제목 포함)에 오염돼 오탐 없이 통과하던 결함을 발견 — 카드 전용 셀렉터로 스코프를 좁혀 수정.

## 검증
- type-check PASS / lint(대상 파일) 0 / build EXIT 0
- vitest 295 files / 1955 tests 전부 PASS(신규 4건 포함, 회귀 0)

## Test plan
- [x] 신규 회귀테스트 4건 + 뮤테이션 셀프체크(RED 확認 후 복구)
- [x] 라이브 AC5①③ PASS 실측(dev)
- [ ] 머지 後 dev 재배포 확認 → AC5② 라이브 재검증(카드 재배치가 실제로 새로고침 없이 보이는지)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>