### PR TITLE
fix(#2161): agent_runs 'running' 영구정체 방지 — deadline_at + CAS 리퍼

### DIFF
--- a/backend/alembic/baseline/schema.sql
+++ b/backend/alembic/baseline/schema.sql
@@ -421,7 +421,7 @@ END) STORED,
     CONSTRAINT agent_runs_failure_disposition_check CHECK (((failure_disposition = ANY (ARRAY['retry_scheduled'::text, 'retry_launched'::text, 'retry_exhausted'::text, 'non_retryable'::text])) OR (failure_disposition IS NULL))),
     CONSTRAINT agent_runs_llm_provider_check CHECK ((llm_provider = ANY (ARRAY['managed'::text, 'byom'::text]))),
     CONSTRAINT agent_runs_llm_provider_key_check CHECK ((llm_provider_key = ANY (ARRAY['openai'::text, 'anthropic'::text, 'google'::text, 'groq'::text, 'openai-compatible'::text]))),
-    CONSTRAINT agent_runs_status_check CHECK ((status = ANY (ARRAY['queued'::text, 'held'::text, 'running'::text, 'hitl_pending'::text, 'completed'::text, 'failed'::text])))
+    CONSTRAINT agent_runs_status_check CHECK ((status = ANY (ARRAY['queued'::text, 'held'::text, 'running'::text, 'hitl_pending'::text, 'completed'::text, 'failed'::text, 'abandoned'::text])))
 );
 
 

--- a/backend/alembic/versions/0206_agent_runs_deadline_at.py
+++ b/backend/alembic/versions/0206_agent_runs_deadline_at.py
@@ -1,0 +1,37 @@
+"""story #2161(2026-07-24, 오르테가군 판정) — agent_runs.deadline_at 컬럼.
+
+Revision ID: 0206
+Revises: 0205
+Create Date: 2026-07-24
+
+'running' 정체 방지 — POST /agent-runs 와 PATCH /agent-runs/{id} 는 서로 모르는 두 독립 MCP
+호출(sprintable_mcp/tools/agent_runs.py: emit_event/update_run_status)이라, 종료 신호가
+안 오면(에이전트 크래시/kill/timeout) status='running' 이 영원히 안 닫혔다(까심군 AC1 확定).
+`a2a_tasks.deadline_at`(0168, story 2a57dc0f)과 동일 처방 — 생성 시점에 이미 종료 예정 시각을
+기록해, 폴링과 무관한 cron 스위퍼가 능동적으로 판정한다("시작할 때 이미 끝날 시각을 갖고
+태어나게", 오르테가군 지시).
+
+nullable(기존 행 백필 없음, 순수 additive) — 마이그 이전 생성된 레거시 run은 NULL이며, 소비
+코드(app/services/agent_run_lifecycle.py)가 `deadline_at ?? started_at + AGENT_RUN_TIMEOUT_
+HOURS`로 폴백해 무회귀 처리한다(0168과 동형 폴백 — 기존 stuck row도 자동 스위퍼 사정권).
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0206"
+down_revision = "0205"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_runs",
+        sa.Column("deadline_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agent_runs", "deadline_at")

--- a/backend/alembic/versions/0207_agent_runs_status_check_widen.py
+++ b/backend/alembic/versions/0207_agent_runs_status_check_widen.py
@@ -1,0 +1,39 @@
+"""story #2161(2026-07-24) — agent_runs_status_check 를 'abandoned' 포함하게 확장.
+
+Revision ID: 0207
+Revises: 0206
+Create Date: 2026-07-24
+
+리퍼(app/services/agent_run_lifecycle.py)가 기한 초과 'running' run을 'abandoned'으로 전이한다
+— 오르테가군 지시: **'completed'로 위장 금지**(끝났는지 모르는 것을 성공적으로 끝난 것으로
+둔갑시키면 거짓을 없애려던 수정이 더 나쁜 거짓을 만든다). 기존 CHECK
+(queued|held|running|hitl_pending|completed|failed)에 'abandoned'이 없어 실 Postgres에서
+그대로 쓰면 IntegrityError — 0129(sprints_status_check widen)와 동일 패턴으로 ALTER.
+
+⚠️백필 불필요: 기존 행은 전부 기존 6-enum 안에 있어 wider 제약서도 그대로 유효(안전한 확장
+ALTER). baseline schema.sql CHECK 동반 갱신 필수([[feedback_baseline_check_ci_sqlite_blindspot]]
+— CI SQLite/session mock은 이 제약 위반을 못 잡는다, 실 PG에서만 드러남).
+"""
+from alembic import op
+
+revision = "0207"
+down_revision = "0206"
+branch_labels = None
+depends_on = None
+
+_FULL = "('queued', 'held', 'running', 'hitl_pending', 'completed', 'failed', 'abandoned')"
+_OLD = "('queued', 'held', 'running', 'hitl_pending', 'completed', 'failed')"
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE agent_runs DROP CONSTRAINT IF EXISTS agent_runs_status_check")
+    op.execute(
+        f"ALTER TABLE agent_runs ADD CONSTRAINT agent_runs_status_check CHECK (status IN {_FULL})"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE agent_runs DROP CONSTRAINT IF EXISTS agent_runs_status_check")
+    op.execute(
+        f"ALTER TABLE agent_runs ADD CONSTRAINT agent_runs_status_check CHECK (status IN {_OLD})"
+    )

--- a/backend/alembic/versions/0208_agent_runs_started_at_default_backfill.py
+++ b/backend/alembic/versions/0208_agent_runs_started_at_default_backfill.py
@@ -1,0 +1,47 @@
+"""story #2161(2026-07-24) — agent_runs.started_at DEFAULT 복구 + 백필 + NOT NULL.
+
+Revision ID: 0208
+Revises: 0207
+Create Date: 2026-07-24
+
+CI real-PG 스위트(까심 실측, #2478 리뷰)가 잡음: `app/models/agent_run.py`의 `started_at`은
+`server_default=func.now(), nullable=False`라고 선언돼 있었으나, 실 DB(baseline schema.sql)엔
+`started_at timestamp with time zone,`뿐 — DEFAULT도 NOT NULL도 실제로는 없었다. 모델의
+server_default는 "DB가 채워줄 것"이라 믿고 INSERT에서 컬럼 자체를 생략하는데, 그 DB에 정말
+DEFAULT가 없으니 Postgres가 그 자리에 NULL을 넣어왔다 — `POST /agent-runs`로 생성되는 **모든**
+run이 (레거시뿐 아니라 지금 이 순간 만들어지는 것도) started_at=NULL이었다는 뜻이다.
+
+오르테가군 판정(#2478 리뷰) — "DB가 맞다(Optional로 순응)" 대신 "스키마가 맞다, NULL 행이
+왜 생기는지가 진짜 결함"을 먼저 볼 것: "시작 기록이 없는 실행"은 #2161이 다루는 "끝 기록이
+없는 실행"과 같은 병의 다른 얼굴이다. 그래서 응답 스키마를 물러서지 않고 DB 쪽을 모델의
+원래 의도(server_default=now(), NOT NULL)에 맞게 고친다:
+
+1. DEFAULT 복구 — 앞으로 생성되는 모든 run은 실제로 now()를 받는다.
+2. 백필 — 기존 NULL 행은 created_at(row 자체의 진짜 생성 시각, DEFAULT now() NOT NULL로
+   이미 신뢰 가능)으로 채운다. 정확한 순간을 모른다는 사실을 숨기지 않되(창작하지 않되),
+   가진 것 중 가장 근접하고 진짜인 신호를 쓴다 — created_at과 started_at은 현재 코드
+   경로상 사실상 동시 이벤트(같은 POST 호출 안에서 row가 만들어지는 순간).
+3. NOT NULL — 1·2가 전건을 커버하므로 모델의 원래 선언이 마침내 사실이 된다.
+
+⚠️백필은 되돌리지 않음(downgrade는 DEFAULT/NOT NULL만 되돌림 — 0203 backfill 선례와 동형,
+데이터 손실 없는 안전한 되돌림만).
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0208"
+down_revision = "0207"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE agent_runs ALTER COLUMN started_at SET DEFAULT now()")
+    op.execute("UPDATE agent_runs SET started_at = created_at WHERE started_at IS NULL")
+    op.execute("ALTER TABLE agent_runs ALTER COLUMN started_at SET NOT NULL")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE agent_runs ALTER COLUMN started_at DROP NOT NULL")
+    op.execute("ALTER TABLE agent_runs ALTER COLUMN started_at DROP DEFAULT")

--- a/backend/app/models/agent_run.py
+++ b/backend/app/models/agent_run.py
@@ -78,3 +78,6 @@ class AgentRun(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
+    # story #2161(0206): 생성 시점에 기록되는 종료 예정 시각 — app/services/agent_run_lifecycle.py
+    # 의 cron 스위퍼가 이 값을 넘긴 'running' run을 능동적으로 'abandoned' 전이한다.
+    deadline_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routers/agent_runs.py
+++ b/backend/app/routers/agent_runs.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
@@ -11,8 +11,13 @@ from app.models.project import Project
 from app.models.team import TeamMember
 from app.repositories.agent_run import AgentRunRepository
 from app.schemas.agent_run import AgentRunResponse, CreateAgentRun, UpdateAgentRun
+from app.services.agent_run_lifecycle import AGENT_RUN_TIMEOUT_HOURS
 
 router = APIRouter(prefix="/api/v2/agent-runs", tags=["agent-runs", "Work"])
+
+# story #2161: PATCH가 이 세 상태로 전이시키는데 클라가 finished_at을 안 보내면 서버가 채운다
+# (server-authority — MCP는 이미 finished_at을 보낼 수 있지만 항상 보낸다고 신뢰하지 않는다).
+_TERMINAL_STATUSES = {"completed", "failed", "abandoned"}
 
 
 def _get_repo(session: AsyncSession = Depends(get_db)) -> AgentRunRepository:
@@ -102,6 +107,8 @@ async def create_agent_run(
     if member_r.scalar_one_or_none() is None:
         raise HTTPException(status_code=400, detail="agent_id not found or not an agent")
 
+    # story #2161: "시작할 때 이미 끝날 시각을 갖고 태어나게" — deadline_at은 클라 미제공(항상
+    # 서버 계산, A2ATask.deadline_at 선례와 동형·클라가 자기 기한을 임의 연장 못 하게).
     run = await repo.create(
         org_id=org_id,
         agent_id=body.agent_id,
@@ -115,6 +122,7 @@ async def create_agent_run(
         input_tokens=body.input_tokens,
         output_tokens=body.output_tokens,
         cost_usd=body.cost_usd,
+        deadline_at=datetime.now(timezone.utc) + timedelta(hours=AGENT_RUN_TIMEOUT_HOURS),
     )
     return AgentRunResponse.model_validate(run)
 
@@ -139,6 +147,12 @@ async def update_agent_run(
     # 덮어쓸 수 있었다(형제 list/create는 이미 has_project_access 有·불일치 시그널이 지목). 404·body-claimed 금지.
     if not await has_project_access(repo.session, uuid.UUID(auth.user_id), existing.project_id, org_id):
         raise HTTPException(status_code=404, detail="Agent run not found")
+    # story #2161: finished_at 갭 — MCP는 이미 보낼 수 있으나(sprintable_mcp update_run_status)
+    # 항상 보낸다고 신뢰하지 않는다. 종단 상태로 전이인데 클라 미제공이면 서버가 now()로 채운다
+    # (duration_ms GENERATED가 살아나는 유일한 경로 — 안 채우면 정상 종료도 영구 NULL).
+    _finished_at = body.finished_at
+    if _finished_at is None and body.status in _TERMINAL_STATUSES:
+        _finished_at = datetime.now(timezone.utc)
     run = await repo.update(
         id,
         status=body.status,
@@ -147,6 +161,7 @@ async def update_agent_run(
         output_tokens=body.output_tokens,
         cost_usd=body.cost_usd,
         last_error_code=body.last_error_code,
+        finished_at=_finished_at,
     )
     if run is None:
         raise HTTPException(status_code=404, detail="Agent run not found")

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -612,6 +612,26 @@ async def a2a_task_deadline_sweep(
         return _err("INTERNAL_ERROR", "Internal server error", 500)
 
 
+# ─── GET /api/v2/internal/cron/agent-run-timeout-sweep ────────────────────────
+# story #2161(2026-07-24, 오르테가군 판정): agent_runs 'running' 영구정체 방지 —
+# a2a-task-deadline-sweep(위)과 동일 근본·동일 처방(폴링 무관 능동 CAS 전이). deadline_at
+# 폴백(NULL이면 started_at + AGENT_RUN_TIMEOUT_HOURS)이 기존 stuck row도 사정권에 넣는다.
+
+@router.get("/agent-run-timeout-sweep")
+async def agent_run_timeout_sweep(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    verify_cron(request)
+    try:
+        from app.services.agent_run_lifecycle import sweep_expired_agent_runs
+        result = await sweep_expired_agent_runs(session)
+        return _ok(result)
+    except Exception as exc:
+        logger.exception("cron error (agent-run-timeout-sweep): %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)
+
+
 @router.get("/storage-usage-warn")
 async def storage_usage_warn(
     request: Request,

--- a/backend/app/schemas/agent_run.py
+++ b/backend/app/schemas/agent_run.py
@@ -33,6 +33,12 @@ class UpdateAgentRun(BaseModel):
     cost_usd: float | None = None
     # duration_ms: GENERATED ALWAYS라 입력 불가(2a5f21d3) — 제거.
     last_error_code: str | None = None
+    # story #2161: MCP update_run_status는 이미 finished_at을 보낼 준비가 돼 있었으나(
+    # sprintable_mcp/tools/agent_runs.py) 이 스키마에 필드가 없어 조용히 버려지고 있었다 —
+    # 정상 종료조차 duration_ms(GENERATED, started/finished_at 파생)가 영구 NULL이던 근본.
+    # 생략 시 라우터가 status가 종단 상태(completed/failed/abandoned)면 now()로 채운다(server-
+    # authority, 클라 미제공을 신뢰하지 않는 기존 관례 — S7 attachments와 동형).
+    finished_at: datetime | None = None
 
 
 class AgentRunResponse(BaseModel):
@@ -54,4 +60,9 @@ class AgentRunResponse(BaseModel):
     last_error_code: str | None = None
     llm_call_count: int
     run_metadata: dict[str, Any]
+    started_at: datetime
+    # story #2161: 클라 가시성 확보(#1793 "실행 중" 배지가 실제 상태를 렌더링하려면 필요) —
+    # 응답 스키마에 없어 API 소비자가 언제 끝났는지/기한이 언제인지 볼 방법이 없었다.
+    finished_at: datetime | None = None
+    deadline_at: datetime | None = None
     created_at: datetime

--- a/backend/app/services/agent_run_lifecycle.py
+++ b/backend/app/services/agent_run_lifecycle.py
@@ -1,0 +1,100 @@
+"""story #2161(2026-07-24, 오르테가군 판정) — agent_runs 'running' 영구정체 방지.
+
+`POST /agent-runs`와 `PATCH /agent-runs/{id}`는 서로 모르는 두 독립 MCP 호출
+(`sprintable_mcp/tools/agent_runs.py`: emit_event/update_run_status)이라, 종료 신호가 안 오면
+(에이전트 크래시/kill/timeout) status='running'이 영원히 안 닫혔다(까심군 AC1 확定 — 부산물
+증명: llm_call_count=0·tokens/cost/duration_ms 전부 NULL, 프로토콜 자체가 POST↔PATCH를 안 묶음).
+
+`app/services/a2a_task_lifecycle.py`(story 2a57dc0f, A2ATask WORKING 영구정체 방지)와 동일
+근본·동일 처방 — "시작할 때 이미 끝날 시각을 갖고 태어나게" 한다(오르테가군 지시). 까심군이
+그때 QA로 잡았던 레이스(스위퍼가 SELECT 후 Python 뮤테이트→커밋 하는 사이 정상완료 커밋이
+껴서 거짓 전이로 덮어씀, story 2a57dc0f HIGH 블로커 C)를 CAS로 선제 방지한다.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.agent_run import AgentRun
+
+# 오르테가군 지시(2026-07-24) — 비용이 비대칭: 너무 짧으면 살아있는 실행을 죽이는(되돌릴 수
+# 없는) 반대사고, 너무 길면 좀비가 조금 더 오래 남을 뿐(관측된 좀비가 이미 2일 3시간 —
+# 24시간 경계만으로도 "영원히"는 확실히 깨짐). 첫 판은 "정확"이 아니라 "안전"이 목적이라
+# 일부러 헐겁게 잡았다 — finished_at 갭(app/schemas/agent_run.py)이 고쳐져 실측 데이터가
+# 쌓이면 그때 조인다. agent_run의 단위(도구 호출 1회 vs 세션)가 코드상 불명확해(session_id
+# 컬럼 존재는 다건/세션을 시사하나 실측 미확認) 보수적 상한을 우선한다.
+#
+# 무너지는 조건(pinning 테스트 — tests/test_2161_agent_run_reaper.py 참조):
+# "타임아웃보다 오래 걸리는 정상 실행이 실제로 관측되면" 이 설계는 틀어진다 — 그 경우
+# 하트비트 방식(에이전트가 주기적으로 deadline_at을 갱신하는 PATCH 호출)으로 승격 필요.
+# 이번 스코프는 하트비트 없이 간다.
+AGENT_RUN_TIMEOUT_HOURS = 24
+
+
+def effective_deadline(run: AgentRun) -> datetime:
+    """deadline_at(명시 기록, story #2161 신규 컬럼, migration 0206) 우선 — NULL(마이그 이전
+    레거시 run)이면 기존 stuck run도 사정권에 들게 started_at + 고정 타임아웃으로 폴백
+    (a2a_task_lifecycle.effective_deadline과 동형)."""
+    if run.deadline_at is not None:
+        return run.deadline_at
+    return run.started_at + timedelta(hours=AGENT_RUN_TIMEOUT_HOURS)
+
+
+async def abandon_run_if_still_running(session: AsyncSession, run_id: uuid.UUID, reason: str) -> bool:
+    """CAS — status='running'인 경우에만 'abandoned' 전이(조건부 UPDATE). a2a_task_lifecycle.
+    fail_task_if_still_working과 동일 근본수정(까심 QA, story 2a57dc0f HIGH 블로커 C) 선제
+    적용 — 스위퍼가 후보를 SELECT한 뒤 Python에서 판정하는 사이 진짜 완료 PATCH가 먼저
+    커밋되면, 그 완료를 존중하고 스위퍼는 조용히 skip한다(영향행 0). 'completed'로 위장하지
+    않음 — 'abandoned'은 completed/failed와 구분되는 제3의 종단 상태(오르테가군 지시, "위장
+    금지" — 끝났는지 모르는 것을 성공적으로 끝난 것으로 둔갑시키면 거짓을 없애려던 수정이
+    더 나쁜 거짓을 만든다).
+
+    Returns:
+        True면 이 호출이 실제로 abandoned 전이시켰음. False면 영향행 0(이미 다른 경로가 그
+        run을 전이시킴 — 예: PATCH가 그 사이 completed로 커밋) — 그 결과를 존중하고 아무것도
+        안 한다. 호출부는 commit 책임(트랜잭션 경계가 호출부마다 다를 수 있음).
+    """
+    now = datetime.now(timezone.utc)
+    stmt = (
+        update(AgentRun)
+        .where(AgentRun.id == run_id, AgentRun.status == "running")
+        .values(status="abandoned", finished_at=now, error_message=reason)
+    )
+    result = await session.execute(stmt)
+    return result.rowcount > 0
+
+
+async def sweep_expired_agent_runs(session: AsyncSession) -> dict:
+    """story #2161 — cron 진입점(app/routers/cron.py). 폴링과 무관하게 기한 초과 'running'
+    run을 능동적으로 'abandoned'으로 승격한다. SQL 레벨에서 deadline_at NULL(레거시)/non-NULL
+    양쪽을 한 쿼리로 처리(a2a_task_lifecycle.sweep_expired_a2a_tasks와 동형 — 백필 마이그
+    불요, 기존 stuck row도 자동 사정권).
+
+    후보 목록은 SELECT로 뽑되, 실제 전이는 각 run마다 개별 CAS UPDATE로 — 다른 트랜잭션이
+    그 사이 먼저 종결시킨 run은 조용히 skip."""
+    now = datetime.now(timezone.utc)
+    legacy_cutoff = now - timedelta(hours=AGENT_RUN_TIMEOUT_HOURS)
+
+    result = await session.execute(
+        select(AgentRun.id).where(
+            AgentRun.status == "running",
+            (
+                (AgentRun.deadline_at.is_not(None)) & (AgentRun.deadline_at < now)
+            ) | (
+                (AgentRun.deadline_at.is_(None)) & (AgentRun.started_at < legacy_cutoff)
+            ),
+        )
+    )
+    candidate_ids = [row[0] for row in result.all()]
+
+    reason = f"deadline sweep: no completion signal within {AGENT_RUN_TIMEOUT_HOURS}h of run start"
+    swept_ids = []
+    for run_id in candidate_ids:
+        if await abandon_run_if_still_running(session, run_id, reason):
+            swept_ids.append(run_id)
+
+    await session.commit()
+    return {"swept_count": len(swept_ids), "run_ids": [str(r) for r in swept_ids]}

--- a/backend/tests/test_2161_agent_run_reaper.py
+++ b/backend/tests/test_2161_agent_run_reaper.py
@@ -1,0 +1,460 @@
+"""story #2161(2026-07-24, 오르테가군 판정) — agent_runs 'running' 영구정체 방지, 실 Postgres 검증.
+
+핵심 축: ⓐ 능동 스위퍼(폴링 무관)가 기한 초과 'running' run을 'abandoned'으로 승격
+ⓑ 레거시 행(deadline_at NULL)도 started_at 폴백으로 정상 처리 ⓒ CAS가 진짜 완료 레이스를
+보호(까심 QA HIGH C, story 2a57dc0f와 동일 근본 선제방지) ⓓ POST가 deadline_at을 즉시 기록
+ⓔ PATCH가 종단 상태 전이 시 finished_at을 서버가 채움(클라 미제공 시) — duration_ms GENERATED
+가 정상 종료에서도 살아나는지. story 8236bbc3 컨벤션: create_all 자체 스키마 관리."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2161", slug=f"org2161-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _make_run(session, org_id, project_id, *, status="running", deadline_at=None,
+                     started_at=None):
+    from app.models.agent_run import AgentRun
+    from sqlalchemy import update
+
+    run = AgentRun(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, agent_id=uuid.uuid4(),
+        trigger="manual", status=status, deadline_at=deadline_at,
+    )
+    session.add(run)
+    await session.flush()
+    if started_at is not None:
+        # server_default=now()를 과거값으로 덮어써야 레거시-행 시나리오 재현(0168/a2a 동형).
+        await session.execute(update(AgentRun).where(AgentRun.id == run.id).values(started_at=started_at))
+    await session.commit()
+    await session.refresh(run)
+    return run
+
+
+@pytest.mark.anyio
+async def test_sweeper_abandons_expired_running_run_with_explicit_deadline():
+    from app.services.agent_run_lifecycle import sweep_expired_agent_runs
+    from app.models.agent_run import AgentRun
+    from sqlalchemy import select
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            past_deadline = datetime.now(timezone.utc) - timedelta(minutes=1)
+            run = await _make_run(s, org_id, project_id, deadline_at=past_deadline)
+
+            result = await sweep_expired_agent_runs(s)
+            assert result["swept_count"] == 1
+            assert str(run.id) in result["run_ids"]
+
+            reloaded = (await s.execute(select(AgentRun).where(AgentRun.id == run.id))).scalar_one()
+            assert reloaded.status == "abandoned"
+            assert reloaded.finished_at is not None
+            assert reloaded.error_message is not None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sweeper_leaves_not_yet_expired_run_running():
+    from app.services.agent_run_lifecycle import sweep_expired_agent_runs
+    from app.models.agent_run import AgentRun
+    from sqlalchemy import select
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            future_deadline = datetime.now(timezone.utc) + timedelta(hours=1)
+            run = await _make_run(s, org_id, project_id, deadline_at=future_deadline)
+
+            result = await sweep_expired_agent_runs(s)
+            assert result["swept_count"] == 0
+
+            reloaded = (await s.execute(select(AgentRun).where(AgentRun.id == run.id))).scalar_one()
+            assert reloaded.status == "running"
+            assert reloaded.finished_at is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sweeper_falls_back_to_started_at_for_legacy_null_deadline():
+    from app.services.agent_run_lifecycle import sweep_expired_agent_runs, AGENT_RUN_TIMEOUT_HOURS
+    from app.models.agent_run import AgentRun
+    from sqlalchemy import select
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            old_started_at = datetime.now(timezone.utc) - timedelta(hours=AGENT_RUN_TIMEOUT_HOURS + 1)
+            run = await _make_run(s, org_id, project_id, deadline_at=None, started_at=old_started_at)
+
+            result = await sweep_expired_agent_runs(s)
+            assert result["swept_count"] == 1
+
+            reloaded = (await s.execute(select(AgentRun).where(AgentRun.id == run.id))).scalar_one()
+            assert reloaded.status == "abandoned"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sweeper_ignores_non_running_statuses():
+    from app.services.agent_run_lifecycle import sweep_expired_agent_runs
+    from app.models.agent_run import AgentRun
+    from sqlalchemy import select
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            past_deadline = datetime.now(timezone.utc) - timedelta(minutes=1)
+            completed = await _make_run(s, org_id, project_id, status="completed", deadline_at=past_deadline)
+            failed = await _make_run(s, org_id, project_id, status="failed", deadline_at=past_deadline)
+            queued = await _make_run(s, org_id, project_id, status="queued", deadline_at=past_deadline)
+
+            result = await sweep_expired_agent_runs(s)
+            assert result["swept_count"] == 0
+
+            for rid, expected in ((completed.id, "completed"), (failed.id, "failed"), (queued.id, "queued")):
+                reloaded = (await s.execute(select(AgentRun).where(AgentRun.id == rid))).scalar_one()
+                assert reloaded.status == expected
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cas_prevents_sweeper_from_clobbering_concurrently_completed_run():
+    """까심 QA HIGH C 회귀 선제방지(story 2a57dc0f 동일 근본) — 실 PG 2세션 레이스 재현. 스위퍼가
+    후보를 SELECT한 *이후*, 다른 트랜잭션(진짜 PATCH 완료 경로 시뮬레이션)이 먼저 그 run을
+    completed로 커밋하면, 스위퍼의 CAS UPDATE는 `WHERE status='running'`에 걸려 영향행 0 →
+    skip해야 한다. CAS 없이 무조건 덮어쓰면 정상 완료된 run이 가짜 abandoned로 오염된다."""
+    from app.models.agent_run import AgentRun
+    from app.services.agent_run_lifecycle import abandon_run_if_still_running
+    from sqlalchemy import select, update
+
+    engine, Session = await _session()
+    try:
+        past_deadline = datetime.now(timezone.utc) - timedelta(minutes=1)
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            run = await _make_run(s, org_id, project_id, deadline_at=past_deadline)
+            run_id = run.id
+
+        # TxA(스위퍼 시뮬레이션): 후보 SELECT — 이 시점엔 running(TxB 커밋 전).
+        session_a = Session()
+        candidates = [
+            row[0] for row in (await session_a.execute(
+                select(AgentRun.id).where(AgentRun.id == run_id, AgentRun.status == "running")
+            )).all()
+        ]
+        assert run_id in candidates
+
+        # TxB(진짜 PATCH 완료 경로): 독립 세션+독립 커밋 — SELECT~UPDATE 사이 윈도우에서
+        # 진짜로 먼저 completed 커밋(실 레이스 재현, mock 아님).
+        real_finished_at = datetime.now(timezone.utc)
+        async with Session() as session_b:
+            await session_b.execute(
+                update(AgentRun).where(AgentRun.id == run_id).values(
+                    status="completed", finished_at=real_finished_at, result_summary="진짜 완료",
+                )
+            )
+            await session_b.commit()
+
+        # TxA: 이제서야 CAS UPDATE 시도 — WHERE status='running'에 이미 안 걸림.
+        transitioned = await abandon_run_if_still_running(session_a, run_id, "deadline sweep")
+        await session_a.commit()
+        await session_a.close()
+        assert transitioned is False, "CAS가 이미 completed인 run을 덮어씀 — 회귀"
+
+        async with Session() as s:
+            final = (await s.execute(select(AgentRun).where(AgentRun.id == run_id))).scalar_one()
+            assert final.status == "completed"
+            assert final.result_summary == "진짜 완료"  # 진짜 완료 데이터 보존
+    finally:
+        await engine.dispose()
+
+
+# ── HTTP 왕복 — POST가 deadline_at을 기록하는지 + PATCH가 종단 상태에서 finished_at을
+#    서버가 채우는지(duration_ms GENERATED가 정상 종료에서도 살아나는지, #2161 인접결함 fix) ──
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, user_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {}})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _seed_org_project_owner(session):
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.team import TeamMember
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org2161B", slug=f"org2161b-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=user.id, role="owner")
+    session.add(om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=om.id, permission="granted", role="owner",
+    ))
+    agent = TeamMember(id=uuid.uuid4(), org_id=org.id, project_id=project.id, type="agent", name="agent")
+    session.add(agent)
+    await session.commit()
+    return {"org_id": org.id, "project_id": project.id, "user_id": user.id, "agent_id": agent.id}
+
+
+@pytest.mark.anyio
+async def test_realdb_create_agent_run_sets_deadline_at():
+    from app.main import app
+    from app.services.agent_run_lifecycle import AGENT_RUN_TIMEOUT_HOURS
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_owner(s)
+        await _setup_app(app, Session, seeded["org_id"], seeded["user_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/agent-runs", json={
+                "agent_id": str(seeded["agent_id"]), "project_id": str(seeded["project_id"]),
+            })
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["status"] == "running"
+            deadline = datetime.fromisoformat(body["deadline_at"].replace("Z", "+00:00"))
+            expected = datetime.now(timezone.utc) + timedelta(hours=AGENT_RUN_TIMEOUT_HOURS)
+            assert abs((deadline - expected).total_seconds()) < 30, (
+                f"deadline_at이 now+{AGENT_RUN_TIMEOUT_HOURS}h 근방이어야 — 실제 {deadline}"
+            )
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+    finally:
+        from app.core.database import Base
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_realdb_patch_terminal_status_without_finished_at_is_server_filled():
+    """AC — 클라(MCP)가 finished_at을 안 보내도 종단 상태 전이 시 서버가 now()로 채워
+    duration_ms(GENERATED)가 살아난다(#2161 인접결함 fix 핵심 회귀가드)."""
+    from app.main import app
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_owner(s)
+        await _setup_app(app, Session, seeded["org_id"], seeded["user_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/agent-runs", json={
+                "agent_id": str(seeded["agent_id"]), "project_id": str(seeded["project_id"]),
+            })
+            run_id = create_resp.json()["id"]
+
+            patch_resp = await client.patch(
+                f"/api/v2/agent-runs/{run_id}", json={"status": "completed"},
+            )
+            assert patch_resp.status_code == 200, patch_resp.text
+            body = patch_resp.json()
+            assert body["status"] == "completed"
+            assert body["finished_at"] is not None, "종단 상태인데 finished_at이 여전히 NULL — 인접결함 재발"
+            assert body["duration_ms"] is not None, "finished_at이 채워졌으면 duration_ms GENERATED도 살아나야"
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+    finally:
+        from app.core.database import Base
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_realdb_patch_non_terminal_status_does_not_set_finished_at():
+    from app.main import app
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_owner(s)
+        await _setup_app(app, Session, seeded["org_id"], seeded["user_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/agent-runs", json={
+                "agent_id": str(seeded["agent_id"]), "project_id": str(seeded["project_id"]),
+            })
+            run_id = create_resp.json()["id"]
+
+            patch_resp = await client.patch(f"/api/v2/agent-runs/{run_id}", json={"status": "held"})
+            assert patch_resp.status_code == 200, patch_resp.text
+            assert patch_resp.json()["finished_at"] is None
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+    finally:
+        from app.core.database import Base
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_realdb_patch_respects_client_provided_finished_at():
+    """MCP가 이미 finished_at을 보낼 수 있는 경로(sprintable_mcp update_run_status)를 존중 —
+    서버 now()로 덮어쓰지 않는다."""
+    from app.main import app
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_owner(s)
+        await _setup_app(app, Session, seeded["org_id"], seeded["user_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/agent-runs", json={
+                "agent_id": str(seeded["agent_id"]), "project_id": str(seeded["project_id"]),
+            })
+            run_id = create_resp.json()["id"]
+
+            explicit = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+            patch_resp = await client.patch(
+                f"/api/v2/agent-runs/{run_id}", json={"status": "completed", "finished_at": explicit},
+            )
+            assert patch_resp.status_code == 200, patch_resp.text
+            got = datetime.fromisoformat(patch_resp.json()["finished_at"].replace("Z", "+00:00"))
+            expected = datetime.fromisoformat(explicit)
+            assert abs((got - expected).total_seconds()) < 2
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+    finally:
+        from app.core.database import Base
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+# ── 소스 고정 — pinning 테스트(오늘 팀 관례로 채택, 오르테가군 명시 요청) ──────────────
+def test_breaking_condition_declared_and_pinned():
+    """오르테가군 지시 — "타임아웃보다 오래 걸리는 정상 실행이 실제로 관측되면 하트비트로
+    승격" 문장 그대로 소스에 고정. 사라지면 다음 사람이 왜 24시간인지, 언제 재고해야 하는지
+    모른 채 넘어간다."""
+    import inspect
+    import app.services.agent_run_lifecycle as mod
+
+    source = inspect.getsource(mod)
+    assert "타임아웃보다 오래 걸리는 정상 실행이 실제로 관측되면" in source
+    assert "하트비트" in source
+
+
+def test_baseline_schema_check_includes_abandoned():
+    """[[feedback_baseline_check_ci_sqlite_blindspot]] — CI SQLite/create_all은 실 PG CHECK
+    위반을 못 잡는다. 'abandoned'이 baseline schema.sql의 agent_runs_status_check에 실제로
+    반영됐는지 소스 고정(migration 0207과 짝)."""
+    from pathlib import Path
+
+    schema = (Path(__file__).resolve().parents[1] / "alembic" / "baseline" / "schema.sql").read_text()
+    # agent_runs 테이블의 CHECK 라인만 특정 — 다른 테이블의 status CHECK와 혼동 방지.
+    assert "CONSTRAINT agent_runs_status_check CHECK ((status = ANY (ARRAY[" in schema
+    check_line = next(
+        line for line in schema.splitlines() if "agent_runs_status_check" in line
+    )
+    assert "'abandoned'::text" in check_line
+
+
+def test_terminal_statuses_include_abandoned_not_completed_disguise():
+    """가드②(오르테가군 지시, "completed로 위장 금지") — abandon_run_if_still_running이 실제로
+    'abandoned'을 쓰는지, 'completed'를 쓰지 않는지 소스 고정."""
+    import inspect
+    import app.services.agent_run_lifecycle as mod
+
+    source = inspect.getsource(mod.abandon_run_if_still_running)
+    assert 'status="abandoned"' in source
+    assert 'status="completed"' not in source

--- a/backend/tests/test_2161_agent_run_reaper.py
+++ b/backend/tests/test_2161_agent_run_reaper.py
@@ -421,6 +421,107 @@ async def test_realdb_patch_respects_client_provided_finished_at():
         await engine.dispose()
 
 
+def test_migration_0208_backfills_legacy_null_started_at_and_enforces_not_null():
+    """CI real-PG 리뷰(#2478, 2026-07-24) 회귀 재발 방지 — `app/models/agent_run.py`의
+    `started_at`은 원래도 `nullable=False, server_default=func.now()`라고 선언돼 있었지만
+    실 DB(baseline schema.sql)엔 DEFAULT도 NOT NULL도 없었다. 그래서 `POST /agent-runs`로
+    생성되는 모든 run(레거시뿐 아니라)이 started_at=NULL이었고, `AgentRunResponse`가 그
+    필드를 노출하자(story #2161) pydantic ValidationError로 실 CI에서 터졌다.
+
+    [[reference_local_migration_verify]] 패턴(env.py 우회·Operations API로 마이그 함수 직구동,
+    동기 psycopg2) — create_all로 테이블을 만든 뒤 started_at을 raw SQL로 "0208 이전 상태"
+    (NOT NULL/DEFAULT 없음)로 되돌려 레거시 NULL 행을 재현하고, 0208.upgrade()를 실제로
+    호출해 ⓐ 백필 ⓑ NOT NULL 강제 ⓒ DEFAULT 동작을 직접 검증한다."""
+    import importlib.util
+    import sqlalchemy as sa
+    from alembic.runtime.migration import MigrationContext
+    from alembic.operations import Operations
+    from pathlib import Path
+    from sqlalchemy.orm import sessionmaker
+
+    sync_url = _REAL_DB_URL
+    for prefix in ("postgresql+asyncpg://",):
+        if sync_url.startswith(prefix):
+            sync_url = "postgresql+psycopg2://" + sync_url[len(prefix):]
+            break
+    if sync_url.startswith("postgresql://"):
+        sync_url = sync_url.replace("postgresql://", "postgresql+psycopg2://", 1)
+
+    from app.core.database import Base
+    from app.models.agent_run import AgentRun
+    from app.models.organization import Organization
+    from app.models.project import Project
+    import app.models  # noqa: F401
+
+    engine = sa.create_engine(sync_url)
+    Session = sessionmaker(bind=engine)
+    try:
+        Base.metadata.create_all(engine)
+        # 모델은 이미 nullable=False/server_default=func.now()라 create_all이 NOT NULL로 만든다
+        # — 0208 "이전" 상태(레거시)를 재현하려면 그 제약을 되돌려야 한다.
+        with engine.begin() as conn:
+            conn.execute(sa.text("ALTER TABLE agent_runs ALTER COLUMN started_at DROP NOT NULL"))
+            conn.execute(sa.text("ALTER TABLE agent_runs ALTER COLUMN started_at DROP DEFAULT"))
+
+        with Session() as s:
+            org = Organization(name="T", slug=f"org-2161-mig-{uuid.uuid4().hex[:8]}")
+            s.add(org)
+            s.flush()
+            project = Project(org_id=org.id, name="P")
+            s.add(project)
+            s.flush()
+            # ORM은 Python-level에서 nullable을 검증하지 않는다(DB만 강제) — started_at=None을
+            # 명시해 "0208 이전에 만들어진 레거시 run"을 그대로 재현.
+            legacy_run = AgentRun(
+                org_id=org.id, project_id=project.id, agent_id=uuid.uuid4(), status="completed",
+                started_at=None,
+            )
+            s.add(legacy_run)
+            s.commit()
+            legacy_run_id, org_id, project_id = legacy_run.id, org.id, project.id
+
+        spec = importlib.util.spec_from_file_location(
+            "m0208",
+            Path(__file__).resolve().parents[1] / "alembic" / "versions"
+            / "0208_agent_runs_started_at_default_backfill.py",
+        )
+        m0208 = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(m0208)
+
+        with engine.begin() as conn:
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                m0208.upgrade()
+
+        with Session() as s:
+            reloaded = s.get(AgentRun, legacy_run_id)
+            assert reloaded.started_at is not None, "레거시 NULL 행이 백필 안 됨 — 회귀"
+            assert reloaded.started_at == reloaded.created_at, "백필값이 created_at과 달라야 할 이유가 없음"
+
+            # DEFAULT 확認 — started_at 생략(ORM도 이제 Python default로 채우지만, 여기선
+            # DB DEFAULT 자체가 살아있는지가 검증 대상이라 raw INSERT로 컬럼째 생략).
+            new_started_at = s.execute(sa.text(
+                "INSERT INTO agent_runs (id, org_id, project_id, agent_id, trigger, status, "
+                "retry_count, max_retries, llm_call_count, metadata) "
+                "VALUES (gen_random_uuid(), :org_id, :project_id, gen_random_uuid(), 'manual', "
+                "'running', 0, 3, 0, '{}'::jsonb) RETURNING started_at"
+            ), {"org_id": org_id, "project_id": project_id}).scalar_one()
+            assert new_started_at is not None, "DEFAULT가 새 INSERT에 안 먹음 — 회귀"
+            s.commit()
+
+            with pytest.raises(Exception):
+                s.execute(sa.text(
+                    "INSERT INTO agent_runs (id, org_id, project_id, agent_id, trigger, status, "
+                    "retry_count, max_retries, llm_call_count, metadata, started_at) "
+                    "VALUES (gen_random_uuid(), :org_id, :project_id, gen_random_uuid(), 'manual', "
+                    "'running', 0, 3, 0, '{}'::jsonb, NULL)"
+                ), {"org_id": org_id, "project_id": project_id})
+                s.commit()
+    finally:
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
 # ── 소스 고정 — pinning 테스트(오늘 팀 관례로 채택, 오르테가군 명시 요청) ──────────────
 def test_breaking_condition_declared_and_pinned():
     """오르테가군 지시 — "타임아웃보다 오래 걸리는 정상 실행이 실제로 관측되면 하트비트로


### PR DESCRIPTION
## Summary
- **근본**: `POST /agent-runs`와 `PATCH /agent-runs/{id}`는 서로 모르는 두 독립 MCP 호출(`sprintable_mcp/tools/agent_runs.py`)이라, 종료 신호가 안 오면(에이전트 크래시/kill/timeout) `status='running'`이 영원히 안 닫혔다(까심군 AC1 확定 — 프로토콜 자체가 두 호출을 안 묶음).
- **처방**: `A2ATask` WORKING 영구정체 방지(story 2a57dc0f)와 동일 근본·동일 해법 재사용.
  - `AgentRun.deadline_at` 신설(migration 0206) — `POST /agent-runs` 생성 시점에 `now + 24h`로 즉시 기록("시작할 때 이미 끝날 시각을 갖고 태어나게").
  - `app/services/agent_run_lifecycle.py`: CAS 전이(`UPDATE ... WHERE status='running'`) — 까심군이 A2ATask 때 잡았던 정확히 같은 레이스(스위퍼 SELECT~커밋 사이 진짜 완료가 끼어드는 경우)를 선제 방지. 진짜 완료를 존중하고 skip.
  - 종단 상태 = `'abandoned'`(`completed`로 위장 금지). CHECK 제약 확장(migration 0207 + baseline schema.sql 동반 갱신).
  - `deadline_at IS NULL` 폴백(`started_at + 24h`)으로 마이그 이전 기존 stuck row도 자동 사정권(백필 불요).
  - 신규 cron 엔드포인트 `agent-run-timeout-sweep`(`a2a-task-deadline-sweep`과 동일 패턴). **스케줄러 등록은 오르테가군 lane**.
- **인접결함 fix**: `UpdateAgentRun`에 `finished_at` 필드가 없어 정상 종료조차 `duration_ms`(GENERATED)가 영구 NULL이었다. 종단 상태(`completed`/`failed`/`abandoned`) 전이 시 클라 미제공이면 서버가 `now()`로 채운다(server-authority, MCP가 이미 보낼 수 있는 값은 존중).
- `AgentRunResponse`에 `started_at`/`finished_at`/`deadline_at` 노출 추가(#1793 "실행 중" 배지가 실 상태를 렌더링하려면 필요).

## 타임아웃 24시간 판단 근거(오르테가군 지시)
비용이 비대칭 — 너무 짧으면 살아있는 실행을 죽이는 반대사고(되돌릴 수 없음), 너무 길면 좀비가 조금 더 오래 남을 뿐(관측된 좀비가 이미 2일 3시간). 첫 판은 "정확"이 아니라 "안전"이 목적이라 일부러 헐겁게 잡았다 — `finished_at` 갭이 고쳐져 실측 데이터가 쌓이면 조정 전제. `agent_run`의 단위(도구 호출 1회 vs 세션)는 코드상 명확히 확認되지 않았으나(`session_id` 컬럼 존재는 세션당 다건을 시사), 실측 전이라 보수적 상한 우선.

## 무너지는 조건(pinning 테스트로 고정)
"타임아웃보다 오래 걸리는 정상 실행이 실제로 관측되면" 이 설계는 하트비트 방식으로 승격 필요 — 이번 스코프는 하트비트 없이 감.

## Test plan
- [x] `test_2161_agent_run_reaper.py`(신규, 12): CAS 정상 전이·미만료 무시·레거시 NULL 폴백·non-running 상태 무시·**CAS 레이스 방지**(실 PG 2세션)·POST deadline_at 기록·PATCH finished_at 서버채움/클라값 존중·pinning(무너지는 조건·위장금지·baseline CHECK)
- [x] 마이그 0206/0207 로컬 실PG(`alembic upgrade head`) 적용 확認 — 컬럼/CHECK 둘 다 실제 반영 확認
- [x] 기존 agent_runs 관련 테스트(create/patch/pagination/story_id filter) 재실행 — 실패 8건은 스키마 미프로비저닝(create_all 안 씀, 사전 마이그 필요) pre-existing 환경 갭임을 pristine main checkout으로 동일 재현 확認(#2161과 무관)
- [x] 전체 non-destructive 백엔드 스위트: `3736 passed`, 잔여 7건은 오늘 종일 재현되던 로컬 MCP stdio 환경 이슈와 동일(무관)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>