### PR TITLE
fix(#2181): 모델↔실 DB drift 감사(agent_runs 전수 + 117테이블 표본) + 발견 즉시 수정 2건

### DIFF
--- a/backend/alembic/versions/0209_mockup_pages_viewport_default.py
+++ b/backend/alembic/versions/0209_mockup_pages_viewport_default.py
@@ -1,0 +1,32 @@
+"""story #2181(모델↔DB drift 감사, 2026-07-24) — mockup_pages.viewport DEFAULT 신설.
+
+Revision ID: 0209
+Revises: 0208
+Create Date: 2026-07-24
+
+drift 감사(script/model_db_drift_audit.py) 발견 — 실 DB의 `viewport`는 이미 NOT NULL인데
+모델은 `str | None`(선택)이라 선언돼 있었고, `CreateMockupRequest.viewport`도 optional(기본
+None)이다. FE(mockups/page.tsx)는 항상 명시적으로 보내지만(자체 기본값 'desktop'), FE를
+거치지 않는 다른 호출부(MCP·직접 API 호출)가 생략하면 `POST /mockups`가 실 DB에서
+NotNullViolation → 500이었다(라이브 확認: viewport 생략 INSERT 재현).
+
+DEFAULT 'desktop' — FE 자체 초기 상태값과 동일(mockups/page.tsx의 `useState<'desktop'|'mobile'>
+('desktop')`)라 창작이 아니라 이미 존재하는 관례를 DB에도 반영하는 것. 백필 불요(기존 행은
+전부 이미 NOT NULL 통과한 값이 있음, 컬럼 자체는 그대로 두고 DEFAULT만 추가하는 순수 확장).
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0209"
+down_revision = "0208"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE mockup_pages ALTER COLUMN viewport SET DEFAULT 'desktop'")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE mockup_pages ALTER COLUMN viewport DROP DEFAULT")

--- a/backend/alembic/versions/0210_agent_runs_duration_ms_bigint.py
+++ b/backend/alembic/versions/0210_agent_runs_duration_ms_bigint.py
@@ -1,0 +1,64 @@
+"""story #2161/#2181(2026-07-24, 오르테가군 라이브 발견) — agent_runs.duration_ms int32 overflow.
+
+Revision ID: 0210
+Revises: 0209
+Create Date: 2026-07-24
+
+리퍼(app/services/agent_run_lifecycle.py, story #2161) 등록 전 오르테가군이 직접 호출해보다
+발견 — 오래 stuck된 running run을 abandoned로 전이하며 finished_at을 쓰는 순간
+`duration_ms`(GENERATED, `integer` 32bit)가 계산되는데, `started_at`이 오래된(#2161 0208
+백필로 `created_at`이 들어간 레거시 run 포함) run은 `(finished_at - started_at)`이 ~24.83일
+(2,147,483,647ms = INT32_MAX)을 넘으면 `asyncpg.NumericValueOutOfRangeError: integer out of
+range`로 UPDATE 자체가 실패한다. 스케줄 등록 前 라이브 호출로 잡음 — 등록됐으면 10분마다
+조용히 500 나며 아무 run도 안 걷혔을 것(#2181과 같은 가족: GENERATED 컬럼 제약이 코드
+어디에도 안 보이던 자리, 4번째 사례).
+
+**처방 판단(오르테가군 요청 — 근거 명시)**:
+- ⛔"전이 시 finished_at 안 쓰기"는 배제 — #2161이 고치던 "사망시각 기록 없음" 병을 다시
+  불러오는 것이라(반대 방향 회귀).
+- ⛔"계산식을 INT32 상한으로 clamp"도 배제 — 오래 stuck된 run의 실제 지속시간을 거짓값으로
+  위장하는 것이라 오늘 하루 지켜온 "완료로 위장 금지"와 같은 원칙 위반(진실을 안 잃는 쪽).
+- ✅**타입 확장(bigint)** — 유일하게 진실을 안 잃는 선택. bigint 상한(~9.2×10^18ms ≈ 2.9억년)은
+  현실적인 어떤 run 지속시간도 넘지 않는다.
+
+⚠️`ALTER COLUMN ... TYPE bigint`만으로는 부족함을 로컬 실PG로 직접 확認했다 — GENERATED
+표현식 내부의 `::integer` 캐스팅이 여전히 원본 그대로 남아 같은 자리에서 오버플로된다(외부
+컬럼 타입만 넓히고 내부 캐스팅은 안 바뀜). DROP COLUMN + 재-ADD로 표현식 자체의 캐스팅을
+`::bigint`로 교체해야 한다(Postgres는 GENERATED 표현식을 in-place ALTER 못 함).
+`duration_ms_legacy`(백필-only, 여전히 32bit)도 CASE 분기에서 `::bigint`로 캐스팅.
+
+백필 불요(GENERATED STORED 컬럼 재-ADD 시 Postgres가 기존 행 전부를 자동 재계산).
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0210"
+down_revision = "0209"
+branch_labels = None
+depends_on = None
+
+_NEW_EXPR = """
+CASE
+    WHEN ((finished_at IS NOT NULL) AND (started_at IS NOT NULL)) THEN GREATEST(((EXTRACT(epoch FROM (finished_at - started_at)) * (1000)::numeric))::bigint, (0)::bigint)
+    WHEN (duration_ms_legacy IS NOT NULL) THEN (duration_ms_legacy)::bigint
+    ELSE NULL::bigint
+END
+""".strip()
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE agent_runs DROP COLUMN duration_ms")
+    op.execute(f"ALTER TABLE agent_runs ADD COLUMN duration_ms bigint GENERATED ALWAYS AS ({_NEW_EXPR}) STORED")
+
+
+def downgrade() -> None:
+    _OLD_EXPR = """
+CASE
+    WHEN ((finished_at IS NOT NULL) AND (started_at IS NOT NULL)) THEN GREATEST(((EXTRACT(epoch FROM (finished_at - started_at)) * (1000)::numeric))::integer, 0)
+    WHEN (duration_ms_legacy IS NOT NULL) THEN duration_ms_legacy
+    ELSE NULL::integer
+END
+""".strip()
+    op.execute("ALTER TABLE agent_runs DROP COLUMN duration_ms")
+    op.execute(f"ALTER TABLE agent_runs ADD COLUMN duration_ms integer GENERATED ALWAYS AS ({_OLD_EXPR}) STORED")

--- a/backend/app/models/agent_run.py
+++ b/backend/app/models/agent_run.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Computed, DateTime, ForeignKey, Integer, Numeric, Text, func
+from sqlalchemy import BigInteger, Computed, DateTime, ForeignKey, Integer, Numeric, Text, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -50,15 +50,21 @@ class AgentRun(Base):
     # duration_ms_legacy 폴백에서 파생)인데 모델이 plain writable Integer로 매핑해 SQLAlchemy가
     # INSERT/UPDATE에 이 컬럼을 항상 emit → GeneratedAlwaysError로 agent_runs 생성 전건 실패했다.
     # Computed(persisted=True)로 read-only 선언 → DML서 제외(모델↔DB 드리프트 해소·create_all
-    # DDL도 prod와 동형 generated 컬럼 생성). 표현식은 baseline schema.sql과 byte-정합.
+    # DDL도 prod와 동형 generated 컬럼 생성).
+    #
+    # story #2161/#2181(2026-07-24, 오르테가군 라이브 발견, migration 0210): 32bit integer는
+    # ~24.83일(2,147,483,647ms)이 상한이라 오래 stuck된 run을 리퍼가 abandoned 전이(finished_at
+    # 기록)하는 순간 NumericValueOutOfRangeError. bigint로 확장(진실을 잃지 않는 유일한 선택 —
+    # "전이 시 finished_at 안 쓰기"는 사망시각 재상실이라 배제, "상한 clamp"는 지속시간 위장이라
+    # 배제, 근거는 0210 migration 참조).
     duration_ms: Mapped[int | None] = mapped_column(
-        Integer,
+        BigInteger,
         Computed(
             "CASE "
             "WHEN ((finished_at IS NOT NULL) AND (started_at IS NOT NULL)) "
-            "THEN GREATEST(((EXTRACT(epoch FROM (finished_at - started_at)) * (1000)::numeric))::integer, 0) "
-            "WHEN (duration_ms_legacy IS NOT NULL) THEN duration_ms_legacy "
-            "ELSE NULL::integer "
+            "THEN GREATEST(((EXTRACT(epoch FROM (finished_at - started_at)) * (1000)::numeric))::bigint, (0)::bigint) "
+            "WHEN (duration_ms_legacy IS NOT NULL) THEN (duration_ms_legacy)::bigint "
+            "ELSE NULL::bigint "
             "END",
             persisted=True,
         ),

--- a/backend/app/models/mockup.py
+++ b/backend/app/models/mockup.py
@@ -17,7 +17,9 @@ class MockupPage(Base):
     slug: Mapped[str] = mapped_column(Text, nullable=False)
     title: Mapped[str] = mapped_column(Text, nullable=False)
     category: Mapped[str | None] = mapped_column(Text, nullable=True)
-    viewport: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # story #2181(모델↔DB drift 감사): 실 DB는 NOT NULL(모델은 nullable=True로 잘못 선언돼 있었음
+    # — router가 body.viewport 그대로 넘기면 생략 호출 시 NotNullViolation 500이던 자리, 같이 fix).
+    viewport: Mapped[str] = mapped_column(Text, nullable=False, server_default="desktop")
     version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
@@ -30,7 +32,13 @@ class MockupComponent(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     page_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
-    type: Mapped[str] = mapped_column(Text, nullable=False)
+    # story #2181(모델↔DB drift 감사, 2026-07-24): 실 DB 컬럼명은 `component_type`(모델은
+    # `type`이라 선언 — 처음부터 한 번도 일치한 적 없었던 자리, mockup_components를 건드리는
+    # 모든 select(MockupComponent)가 실 migrated DB에서 UndefinedColumnError였을 것). API
+    # 계약(MockupComponentOut.type)·라우터 kwarg(`type=`)는 그대로 두고 DB 컬럼명만 명시
+    # 매핑(app/models/agent_run.py의 run_metadata↔"metadata"와 동형 패턴) — 파이썬 쪽 이름은
+    # 안 건드려 회귀 0.
+    type: Mapped[str] = mapped_column("component_type", Text, nullable=False)
     props: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
     sort_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     parent_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)

--- a/backend/app/routers/mockups.py
+++ b/backend/app/routers/mockups.py
@@ -92,7 +92,10 @@ async def create_mockup(
     page = MockupPage(
         org_id=org_id, project_id=project_id,
         slug=body.slug, title=body.title,
-        category=body.category, viewport=body.viewport,
+        category=body.category,
+        # story #2181: 실 DB viewport는 NOT NULL(FE 자체 기본값 'desktop'과 통일) — body.viewport
+        # 생략(None) 호출부(MCP 등, FE는 항상 명시)가 NotNullViolation 500이던 자리.
+        viewport=body.viewport or "desktop",
         created_by=auth.user_id, created_at=now, updated_at=now,
     )
     session.add(page)

--- a/backend/scripts/model_db_drift_audit.py
+++ b/backend/scripts/model_db_drift_audit.py
@@ -1,0 +1,122 @@
+"""story #2181(2026-07-24) — 모델↔실 DB drift 감사 도구.
+
+sqlalchemy.inspect()로 **실 migrated Postgres**를 직접 조회해 SQLAlchemy 모델 메타데이터와
+대조한다(baseline schema.sql 텍스트 대조가 아님 — #2161에서 baseline.sql 자체가 일부 테이블에
+대해 stale함을 이미 확認했다, 예: a2a_tasks가 통째로 없음). AC1(agent_runs 전수) + AC4(표본
+규모 측정) 양쪽에 재사용.
+
+사용: ALEMBIC_DATABASE_URL(psycopg2 URL, 이미 head까지 migrated)로 실행.
+    ALEMBIC_DATABASE_URL=postgresql://... uv run python scripts/model_db_drift_audit.py [table1 table2 ...]
+인자 없으면 모델에 매핑된 전 테이블을 대상(전수 — AC4 표본 단계에선 명시적으로 테이블명을 넘길 것).
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import sqlalchemy as sa
+
+import app.models  # noqa: F401 — 전 모델 등록
+from app.core.database import Base
+
+
+def _sync_url() -> str:
+    url = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("DATABASE_URL", "")
+    for prefix in ("postgresql+asyncpg://",):
+        if url.startswith(prefix):
+            return "postgresql+psycopg2://" + url[len(prefix):]
+    return url
+
+
+def audit_table(insp: sa.Inspector, table: sa.Table, view_names: set[str]) -> dict:
+    name = table.name
+    result = {"table": name, "issues": []}
+    is_view = name in view_names
+
+    if not is_view and not insp.has_table(name):
+        result["issues"].append("MISSING_TABLE — 모델엔 있으나 실 DB에 테이블 자체가 없음")
+        return result
+
+    db_cols = {c["name"]: c for c in insp.get_columns(name)}
+    model_cols = {c.name: c for c in table.columns}
+
+    # ⓐ 컬럼 존재 여부(양방향)
+    for col_name in db_cols:
+        if col_name not in model_cols:
+            result["issues"].append(f"DB_ONLY_COLUMN: {col_name}(모델 미매핑)")
+    for col_name in model_cols:
+        if col_name not in db_cols:
+            result["issues"].append(f"MODEL_ONLY_COLUMN: {col_name}(DB에 없음 — 마이그 누락 가능성)")
+
+    # ⓑ NOT NULL / DEFAULT 정합(둘 다 있는 컬럼만, 실 테이블만 — VIEW는 Postgres reflection이
+    # 원본 테이블의 NOT NULL/DEFAULT를 안 물려준다(모든 결과 컬럼을 nullable=True로 봄)라
+    # 대조가 구조적으로 노이즈뿐이라 스킵. team_members 뷰로 확認, story #2181).
+    for col_name in ([] if is_view else (set(db_cols) & set(model_cols))):
+        db_c, model_c = db_cols[col_name], model_cols[col_name]
+        db_nullable = db_c["nullable"]
+        model_nullable = model_c.nullable
+        if db_nullable != model_nullable:
+            result["issues"].append(
+                f"NULLABLE_MISMATCH: {col_name} DB={db_nullable} model={model_nullable}"
+            )
+        db_has_default = db_c.get("default") is not None or bool(db_c.get("identity"))
+        # GENERATED ALWAYS(Computed)·IDENTITY 컬럼은 DEFAULT가 아닌 별도 메커니즘 — server_default
+        # 대조 대상에서 제외(duration_ms/activity_seq류 오탐 방지, #2161 started_at과는 다른 성질).
+        is_computed = model_c.computed is not None
+        is_identity = model_c.identity is not None
+        model_declares_server_default = (
+            model_c.server_default is not None and not is_computed and not is_identity
+        )
+        # server_default를 모델이 선언했는데 실 DB엔 없는 경우 — #2161 started_at과 동일 패턴
+        # ("약속했지만 DB에 없음", INSERT가 컬럼 생략 시 DB가 안 채워줌).
+        if model_declares_server_default and not db_has_default:
+            result["issues"].append(
+                f"SERVER_DEFAULT_NOT_ENFORCED: {col_name} — 모델은 server_default 선언, "
+                f"실 DB엔 DEFAULT 없음(약속 미이행 — #2161 started_at과 동일 패턴)"
+            )
+
+    # ⓒ CHECK 제약 — 모델 레벨엔 보통 선언 안 하므로 DB에 있는 CHECK 목록을 그대로 정보성 노출
+    # (수동 판단 필요 — 새 enum값 추가 시 이 목록 대조해야 하는 [[feedback_baseline_check_ci_sqlite_blindspot]]).
+    try:
+        checks = insp.get_check_constraints(name)
+        if checks:
+            result["issues"].append(
+                f"DB_CHECK_CONSTRAINTS(정보성, 모델엔 선언 없음): "
+                + ", ".join(c["name"] for c in checks)
+            )
+    except NotImplementedError:
+        pass
+
+    return result
+
+
+def main() -> None:
+    engine = sa.create_engine(_sync_url())
+    insp = sa.inspect(engine)
+    view_names = set(insp.get_view_names())
+
+    target_names = sys.argv[1:]
+    tables = (
+        [Base.metadata.tables[n] for n in target_names if n in Base.metadata.tables]
+        if target_names else list(Base.metadata.tables.values())
+    )
+    missing = [n for n in target_names if n not in Base.metadata.tables]
+    if missing:
+        print(f"⚠️ 모델에 없는 테이블명(무시): {missing}")
+
+    total_with_issues = 0
+    for table in sorted(tables, key=lambda t: t.name):
+        r = audit_table(insp, table, view_names)
+        if r["issues"]:
+            total_with_issues += 1
+            view_tag = " [VIEW]" if table.name in view_names else ""
+            print(f"\n=== {r['table']}{view_tag} ({len(r['issues'])}건) ===")
+            for issue in r["issues"]:
+                print(f"  - {issue}")
+
+    print(f"\n{'='*60}")
+    print(f"대상 테이블 {len(tables)}개 중 drift 있는 테이블 {total_with_issues}개")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_2161_agent_run_reaper.py
+++ b/backend/tests/test_2161_agent_run_reaper.py
@@ -107,6 +107,50 @@ async def test_sweeper_abandons_expired_running_run_with_explicit_deadline():
 
 
 @pytest.mark.anyio
+async def test_sweeper_abandons_genuinely_old_run_without_int32_overflow():
+    """오르테가군 라이브 발견(migration 0210) 회귀가드 — 스케줄 등록 前 실호출로 잡힌 버그:
+    90일 전에 시작된 run(0208 백필 시나리오처럼 매우 오래된 stuck run)을 리퍼가 abandoned로
+    전이하며 finished_at을 쓰면 duration_ms(GENERATED)가 계산되는데, 그 값이 32bit integer
+    상한(~24.83일)을 넘어 `asyncpg.NumericValueOutOfRangeError: integer out of range`로 UPDATE
+    자체가 실패했다 — CI는 짧은 시간차 데이터만 써서 통과했고 라이브에서만 터졌다("단순
+    유닛으로 안 닫힘", 오르테가군 지적). bigint 확장(0210) 후 실제로 90일치 run이 정상
+    abandoned 전이되고 duration_ms가 정확한 값(~90일 in ms, INT32_MAX 훨씬 초과)을 갖는지
+    실PG로 직접 검증 — 반드시 짧은 시간차가 아닌 진짜 오래된 값으로."""
+    from app.services.agent_run_lifecycle import sweep_expired_agent_runs
+    from app.models.agent_run import AgentRun
+    from sqlalchemy import select
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            very_old_started_at = datetime.now(timezone.utc) - timedelta(days=90)
+            run = await _make_run(
+                s, org_id, project_id, deadline_at=None, started_at=very_old_started_at,
+            )
+
+            result = await sweep_expired_agent_runs(s)
+            assert result["swept_count"] == 1
+            assert str(run.id) in result["run_ids"]
+
+            reloaded = (await s.execute(select(AgentRun).where(AgentRun.id == run.id))).scalar_one()
+            assert reloaded.status == "abandoned"
+            assert reloaded.finished_at is not None
+            # INT32_MAX(2,147,483,647ms ≈ 24.83일)를 훨씬 초과하는 실제 값 — bigint 확장이
+            # 실제로 먹혔는지의 직접 증거(단순히 에러 없음만으론 부족, 값 자체를 확認).
+            assert reloaded.duration_ms is not None
+            assert reloaded.duration_ms > 2_147_483_647, (
+                f"duration_ms가 INT32_MAX를 안 넘음 — 90일치 run인데 값이 이상함: {reloaded.duration_ms}"
+            )
+            expected_ms = 90 * 24 * 3600 * 1000
+            assert abs(reloaded.duration_ms - expected_ms) < 60_000, (
+                f"90일 근방이어야 — 실제 {reloaded.duration_ms}ms"
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_sweeper_leaves_not_yet_expired_run_running():
     from app.services.agent_run_lifecycle import sweep_expired_agent_runs
     from app.models.agent_run import AgentRun

--- a/backend/tests/test_2181_mockup_model_db_drift.py
+++ b/backend/tests/test_2181_mockup_model_db_drift.py
@@ -1,0 +1,187 @@
+"""story #2181(모델↔DB drift 감사, 2026-07-24) — mockups 실PG 회귀 가드.
+
+`model_db_drift_audit.py`(AC1/AC4)가 실 migrated DB 대조로 발견한 두 결함:
+ⓐ `MockupComponent.type`이 DB엔 `component_type`으로 존재 — 모델·DB가 처음부터 한 번도
+   일치한 적 없었음(create_all 기반 기존 테스트는 이 드리프트를 구조적으로 못 잡음, 모델
+   자체로 테이블을 만드니까). select(MockupComponent)가 실 DB에서 UndefinedColumnError.
+ⓑ `mockup_pages.viewport`가 실 DB엔 NOT NULL인데 모델은 Optional — `POST /mockups`가
+   viewport 생략(클라 기본 None) 시 NotNullViolation 500.
+
+이 테스트는 create_all이 아니라 **alembic 마이그레이션으로 프로비저닝된 실 PG**를 써서
+(모델이 아니라 진짜 DB 스키마 대상) 두 결함이 실제로 재발하지 않는지 HTTP 왕복으로 검증한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _migrated_sync_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+asyncpg://",):
+        if url.startswith(prefix):
+            return "postgresql+psycopg2://" + url[len(prefix):]
+    if url.startswith("postgresql://"):
+        return "postgresql+psycopg2://" + url[len("postgresql://"):]
+    return url
+
+
+def _run_migrations_to_head() -> None:
+    """create_all이 아니라 **실제 alembic 마이그레이션**을 적용 — 이 테스트의 존재 이유
+    자체가 "모델이 만드는 스키마"가 아니라 "마이그가 만드는 실 스키마"를 검증하는 것이라
+    create_all을 쓰면 애초에 재현이 안 된다([[reference_local_migration_verify]])."""
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    result = subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", "head"],
+        cwd=str(Path(__file__).resolve().parents[1]),
+        env={**os.environ, "ALEMBIC_DATABASE_URL": _migrated_sync_url()},
+        capture_output=True, text=True, timeout=120,
+    )
+    assert result.returncode == 0, f"alembic upgrade head 실패: {result.stdout}\n{result.stderr}"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix) if prefix != "postgresql://" else len("postgresql://"):]
+            break
+    engine = create_async_engine(url)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, project_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(uuid.uuid4()), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_realdb_create_mockup_without_viewport_does_not_500():
+    """ⓑ 회귀가드 — viewport 생략 POST가 실 DB NotNullViolation 500 없이 성공하고, FE 자체
+    기본값('desktop')과 통일된 값으로 채워지는지."""
+    from app.main import app
+
+    _run_migrations_to_head()
+    engine, Session = await _session()
+    try:
+        org_id, project_id = uuid.uuid4(), uuid.uuid4()
+        async with Session() as s:
+            from sqlalchemy import text
+            await s.execute(text(
+                "INSERT INTO organizations (id, name, slug, plan) VALUES (:id, 'O', :slug, 'free')"
+            ), {"id": org_id, "slug": f"org-2181-{uuid.uuid4().hex[:8]}"})
+            await s.execute(text(
+                "INSERT INTO projects (id, org_id, name, violation_level) VALUES (:id, :org_id, 'P', 'warn')"
+            ), {"id": project_id, "org_id": org_id})
+            await s.commit()
+
+        await _setup_app(app, Session, org_id, project_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/mockups", json={"slug": "no-viewport", "title": "T"})
+            assert resp.status_code == 201, resp.text
+            body = resp.json()["data"]
+            assert body["viewport"] == "desktop", f"FE 기본값과 통일돼야 — 실제 {body['viewport']!r}"
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_realdb_update_mockup_components_type_roundtrips():
+    """ⓐ 회귀가드 — components(type 포함) PUT이 실 DB에서 UndefinedColumnError 없이 성공하고,
+    저장된 type이 그대로 조회되는지(모델 컬럼명 `type` ↔ 실 DB `component_type` 매핑 확認)."""
+    from app.main import app
+
+    _run_migrations_to_head()
+    engine, Session = await _session()
+    try:
+        org_id, project_id = uuid.uuid4(), uuid.uuid4()
+        async with Session() as s:
+            from sqlalchemy import text
+            await s.execute(text(
+                "INSERT INTO organizations (id, name, slug, plan) VALUES (:id, 'O', :slug, 'free')"
+            ), {"id": org_id, "slug": f"org-2181b-{uuid.uuid4().hex[:8]}"})
+            await s.execute(text(
+                "INSERT INTO projects (id, org_id, name, violation_level) VALUES (:id, :org_id, 'P', 'warn')"
+            ), {"id": project_id, "org_id": org_id})
+            await s.commit()
+
+        await _setup_app(app, Session, org_id, project_id)
+        client = _client_for(app)
+        try:
+            create_resp = await client.post(
+                "/api/v2/mockups", json={"slug": "with-components", "title": "T", "viewport": "mobile"},
+            )
+            assert create_resp.status_code == 201, create_resp.text
+            page_id = create_resp.json()["data"]["id"]
+
+            put_resp = await client.put(
+                f"/api/v2/mockups/{page_id}",
+                json={"components": [{"type": "button", "props": {"label": "OK"}, "sort_order": 0}]},
+            )
+            assert put_resp.status_code == 200, (
+                f"UndefinedColumnError(모델 `type` ↔ 실 DB `component_type` 미매핑) 재발 의심: {put_resp.text}"
+            )
+
+            get_resp = await client.get(f"/api/v2/mockups/{page_id}")
+            assert get_resp.status_code == 200, get_resp.text
+            comps = get_resp.json()["data"]["components"]
+            assert len(comps) == 1
+            assert comps[0]["type"] == "button", f"type 왕복 실패 — 실제 {comps[0]}"
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary

**AC1 — agent_runs 전수 대조**: `sqlalchemy.inspect()`로 실 migrated Postgres를 직접 조회(baseline schema.sql 텍스트 대조가 아님 — #2161서 baseline.sql 자체가 일부 테이블에 stale함을 이미 확認). 결과: 컬럼 14개 모델 미매핑(`session_id` 등)·CHECK 4개 모델 미선언(정보성). `SERVER_DEFAULT_NOT_ENFORCED`/`NULLABLE_MISMATCH` 0건 — #2161이 이미 닫음.

**AC4 — 표본으로 규모 먼저 측정**: 자동 대조 도구(`scripts/model_db_drift_audit.py`) 작성. 20개 표본으로 시작했으나 스크립트 자체가 저비용이라 전 117테이블로 확장 실행(수동 개별조사가 아니라 자동 스캔이라 "표본→전수"가 사실상 공짜).

### 결과(117개 중 49개 어떤 형태로든 signal — 위험도 구분이 핵심)
| 분류 | 건수 | 위험도 |
|---|---|---|
| DB_CHECK_CONSTRAINTS(모델 미선언, 정보성) | 44 | 낮음 — 기존 관례(`feedback_baseline_check_ci_sqlite_blindspot`)로 이미 커버 |
| DB_ONLY_COLUMN(모델 미매핑) | 35 | 낮음 — 대부분 미사용 컬럼(`deleted_at`류 반복 패턴, 앱 코드가 안 건드림) |
| NULLABLE_MISMATCH | 5 | 방향별 분리: 모델이 DB보다 엄격=저위험 3건 / DB가 모델보다 엄격=위험 2건(1건은 dead code 확認, 1건=아래 fix) |
| MODEL_ONLY_COLUMN | 0 | 이번 fix로 0 도달(아래) |
| SERVER_DEFAULT_NOT_ENFORCED | 0 | 이번 fix로 0 도달(아래) |

**스크립트 자기교정 2회**: `Computed()`(duration_ms)·`Identity()`(activity_seq) 컬럼을 `SERVER_DEFAULT_NOT_ENFORCED`로 오탐했던 것을 실 DB 직접 확認(`\d` psql) 후 제외 처리 — 최종 리포트엔 반영 안 됨.

## 발견 즉시 수정(2건, 라이브 재현 확認 후 — [[feedback_fix_on_sight]])

1. **`MockupComponent.type`**: 실 DB 컬럼명은 `component_type`(모델은 애초 한 번도 일치한 적 없음). `select(MockupComponent)`가 전부 실 migrated DB에서 `UndefinedColumnError`. **재현 확認**: fix를 `git stash`로 임시 되돌려 정확히 그 에러로 재현시킨 뒤 복원. API 계약(`MockupComponentOut.type`)·라우터 kwarg(`type=`)는 안 건드리고 컬럼명만 명시 매핑(`agent_run.py`의 `run_metadata↔"metadata"`와 동형 패턴).
2. **`mockup_pages.viewport`**: 실 DB NOT NULL인데 모델 Optional·`CreateMockupRequest.viewport`도 optional(기본 None). FE(`mockups/page.tsx`)는 항상 명시(자체 기본값 `'desktop'`)하나 그 외 호출부(MCP 등)는 생략 시 500. migration 0209로 DB `DEFAULT='desktop'`(FE 관례 그대로 재사용, 창작 아님) + 라우터 coalesce(`body.viewport or "desktop"`) + 모델 정정(`nullable=False`).

## Test plan
- [x] `test_2181_mockup_model_db_drift.py`(신규, 2): 실 alembic-migrated PG(create_all 아님 — 이 버그의 재현 조건 자체가 "마이그된 실 스키마"라 create_all로는 재현 불가) HTTP 왕복 — viewport 생략 POST 201+기본값·components(type 포함) PUT/GET 왕복
- [x] fix 되돌려 정확한 실패 재현(`UndefinedColumnError: column mockup_components.type does not exist`) 확認 후 복원
- [x] 기존 `test_s48.py`(mockups CRUD, 8건) 회귀 0
- [x] 전체 non-destructive 백엔드 스위트: `3736 passed`, 잔여 7건은 오늘 종일 재현되던 로컬 MCP stdio 환경 이슈와 동일(무관)

## 스코프 판단(AC4 요청 — 범위는 오르테가군 판단 요청)
나머지 3건(NULLABLE_MISMATCH 위험방향)은 라이브 콜사이트 0건(dead code) 확認 — 이번 PR엔 미포함. 35건 DB_ONLY_COLUMN도 대부분 미사용이라 즉시 조치 불요로 판단했으나, 전 범위 확대 여부는 별도 판단 요청.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>