### PR TITLE
fix(#2180): GCE FANOUT_WAKE_REDIS_ENABLED 를 배포 SSOT 의 durable 기본값으로 승격

### DIFF
--- a/backend/scripts/deploy_realtime_gce.sh
+++ b/backend/scripts/deploy_realtime_gce.sh
@@ -311,9 +311,32 @@ PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}PRESENCE_ONLINE_REDIS_ENABLED=${PR
 # 여기 걸림, GCE 3노드 필수·멀티노드 합산 대조).
 PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}SSE_LEASE_REDIS_ENABLED=${SSE_LEASE_REDIS_ENABLED:-${_BACKPLANE_DEFAULT}}"
 # #2122(E-ARCH 근본): fanout(wake_agent) → Redis 백플레인 롤아웃 게이트(presence/lease 와 독립 flag).
-# env 로 flip(기본 false=pg_notify 직행 무회귀). #2122 라이브 재측정 배포=true(GCE PG_LISTEN=false라 wake
-# 가 Redis 백플레인 타야 타노드 도달 — 미설정 시 cross-node wake 0/2 재현). REALTIME_BACKPLANE 는 별개(cutover).
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}FANOUT_WAKE_REDIS_ENABLED=${FANOUT_WAKE_REDIS_ENABLED:-false}"
+# REALTIME_BACKPLANE 는 별개(cutover).
+#
+# story #2180(2026-07-25, 오르테가군 판정 — 기본값을 false 에서 durable true 로 승격):
+# 여태 `:-false` 라서 dev 라이브의 true 는 **SSOT 밖의 손 값**이었다(#2122 라이브 재측정 때
+# 손으로 넣은 것). 즉 다음 배포가 조용히 false 로 덮는 지뢰였다 — #2077(프론트 minScale 이
+# 코드 밖에 떠 있던 것)과 동형. 위 세 형제(presence/online/lease)는 이미 _BACKPLANE_DEFAULT
+# 로 못박혀 있는데 이것만 남아 있었다.
+#
+# 왜 true 가 맞는가:
+#   이 스택은 PG_LISTEN_ENABLED=false 다(아래 참조). ⇒ false 로 두면 wake 가 pg_notify 로만
+#   나가는데 **듣는 프로세스가 전 층에 0개**라 크로스노드 wake 가 조용히 사라진다
+#   (#2122 라이브에서 cross-node wake 0/2 재현됨). true 여야 Redis 백플레인을 타 타노드에 닿는다.
+#
+# 왜 «지금 아프지 않은데» 고치는가 (까심군 측정, 2026-07-25 · #2157 갈림길):
+#   GCLB access log 전수(관측 07-23 13:53Z~) — GCE 3노드에 wake_agent 콜사이트 라우트군
+#   (/api/v2/stories PATCH · /api/v2/gates POST · /api/v2/agents · /api/v2/a2a) 도달 **0건**.
+#   양성대조로 backend-prod 에서는 같은 쿼리에 다건 잡힘 ⇒ 계측기는 커밋을 볼 수 있다.
+#   ⇒ 현재 GCE 는 이벤트를 커밋하지 않는다 = **지금 켜도 라이브 동작 변화 0**(그래서 안전)
+#   ⇒ 동시에 «안 아픈 이유»가 구조적 보장이 아니라 **현 라우팅의 우연**이다 = 방치하면 라우팅이
+#      바뀌는 순간 조용히 깨진다. 안전하게 고칠 수 있는 지금 못박는다.
+#
+# 무너지는 조건: GCE 노드가 이벤트를 커밋하기 시작하는데 Redis 백플레인이 죽어 있으면, 이제는
+#   pg_notify 폴백조차 안 타므로 wake 가 통째로 유실된다(false 였을 때와 같은 결과). Redis
+#   가용성이 이 값의 전제다 — 위 형제 플래그 셋과 같은 전제라 새로 생기는 의존은 아니다.
+# ⚠️손 override 는 계속 가능하나(위 형제와 동일 규약), durable 값은 여기 한 곳이다.
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}FANOUT_WAKE_REDIS_ENABLED=${FANOUT_WAKE_REDIS_ENABLED:-${_BACKPLANE_DEFAULT}}"
 # ⛔story #2142(2026-07-23, 오르테가 전수 3방향 diff 적발, 4번째 묶음) — 같은 뿌리.
 # LLM_GEMINI_MODEL/_LOCATION·FIREBASE_OAUTH_HANDOFF_ENABLED 전부 backend-prod에 키
 # 자체가 없다(describe 대조 확認) — FIREBASE_OAUTH_HANDOFF_ENABLED=1은 특히 firebase

--- a/backend/tests/test_deploy_realtime_gce_env.py
+++ b/backend/tests/test_deploy_realtime_gce_env.py
@@ -40,12 +40,34 @@ def _resolve(script: str, env: str, extra: dict | None = None) -> dict[str, str]
     return cfg
 
 
-def _resolve_generated_env_lines(env: str) -> list[str]:
+def _resolve_generated_env_lines(env: str, extra: dict | None = None) -> list[str]:
     """실제 VM에 실릴 env-file 내용을 그대로 디코드해 줄 목록으로 반환 — `_resolve()`의
     요약 문자열이 아니라 스크립트가 진짜로 생성하는 산출물을 검증 대상으로 삼는다."""
-    cfg = _resolve(_DEPLOY_GCE, env)
+    cfg = _resolve(_DEPLOY_GCE, env, extra)
     b64 = cfg["GENERATED_PLAIN_ENV_FILE_B64"]
     return base64.b64decode(b64).decode().splitlines()
+
+
+def _resolve_generated_env_lines_without(env: str, *unset_keys: str) -> list[str]:
+    """story #2180 — **caller env 를 비운 상태**의 산출물을 반환한다.
+
+    `_resolve()` 는 `os.environ` 을 상속하므로, `${FOO:-기본값}` 형태의 «기본값»을 재려면
+    그 키를 명시적으로 지워야 한다. 안 지우면 실행 환경에 우연히 그 변수가 있을 때 통과해
+    버려 «SSOT 밖 손 값» 결함을 그대로 놓친다 — 이 스토리가 잡으려는 것이 정확히 그것이다.
+    """
+    environ = {**os.environ, "DRY_RUN": "1"}
+    for k in unset_keys:
+        environ.pop(k, None)
+    proc = subprocess.run(
+        ["bash", _DEPLOY_GCE, env],
+        capture_output=True, text=True, env=environ, check=True,
+    )
+    cfg: dict[str, str] = {}
+    for line in proc.stdout.strip().splitlines():
+        if "=" in line:
+            k, _, v = line.partition("=")
+            cfg[k.strip()] = v.strip()
+    return base64.b64decode(cfg["GENERATED_PLAIN_ENV_FILE_B64"]).decode().splitlines()
 
 
 # ── deploy_realtime_gce.sh ───────────────────────────────────────────────────
@@ -347,6 +369,55 @@ def test_deploy_gce_invalid_env_rejected():
     )
     assert proc.returncode != 0
     assert "[dev|prod]" in proc.stderr
+
+
+# ── story #2180: FANOUT_WAKE_REDIS_ENABLED 가 SSOT 밖 손 값이 아니어야 한다 ──────
+
+def test_deploy_gce_fanout_wake_redis_is_durable_true_without_caller_env():
+    """story #2180(2026-07-25) — 이 저장소가 실제로 겪은 함정의 재발 방지.
+
+    여태 `${FANOUT_WAKE_REDIS_ENABLED:-false}` 라서, dev 라이브의 `true` 는 #2122 라이브
+    재측정 때 손으로 넣은 **caller env 값**이었다. 즉 스크립트를 그냥 돌리면 `false` 가
+    나가므로 **다음 배포가 조용히 원복시키는** 상태였다(#2077 프론트 minScale 과 동형 —
+    「라이브에 있는데 코드엔 없다」).
+
+    이 테스트는 **caller env 를 비운 상태**로 스크립트를 돌려 durable 기본값을 검증한다 —
+    `_resolve()` 가 `os.environ` 을 상속하므로, 명시적으로 지워야 「기본값」을 재는 것이 된다.
+    (안 지우면 실행 환경에 그 변수가 우연히 있을 때 통과해버려 판별력이 0이 된다.)
+    """
+    for env_name in ("dev", "prod"):
+        lines = _resolve_generated_env_lines_without(env_name, "FANOUT_WAKE_REDIS_ENABLED")
+        assert "FANOUT_WAKE_REDIS_ENABLED=true" in lines, (
+            f"[{env_name}] durable 기본값이 true 가 아니다 — caller env 없이 배포하면 "
+            "크로스노드 wake 가 pg_notify 로만 나가는데 이 스택은 PG_LISTEN_ENABLED=false 라 "
+            "듣는 프로세스가 0개다(#2122 에서 cross-node wake 0/2 재현)."
+        )
+        assert "FANOUT_WAKE_REDIS_ENABLED=false" not in lines
+
+
+def test_deploy_gce_fanout_wake_assumption_pg_listen_is_still_false():
+    """⚠️#2180 판단이 무너지는 조건을 고정한다.
+
+    「true 여야 한다」는 근거는 **이 스택에서 PG LISTEN 을 아무도 안 듣는다**는 사실 하나에
+    걸려 있다. PG_LISTEN_ENABLED 가 true 로 바뀌면 pg_notify 경로가 되살아나므로 그 근거가
+    사라지고 #2180 을 **재판정**해야 한다. 그때 이 테스트가 실패해서 알려주는 것이 목적이다
+    (#2178 에서 세운 「전제를 소스에 박고 pinning 으로 지킨다」와 같은 형태).
+    """
+    for env_name in ("dev", "prod"):
+        lines = _resolve_generated_env_lines(env_name)
+        assert "PG_LISTEN_ENABLED=false" in lines, (
+            f"[{env_name}] PG_LISTEN_ENABLED 전제가 바뀌었다 — story #2180 의 "
+            "FANOUT_WAKE_REDIS_ENABLED=true 판단을 재판정할 것."
+        )
+
+
+def test_deploy_gce_fanout_wake_caller_override_still_works():
+    """durable 기본값을 못박되 **손 override 통로는 막지 않는다** — 위 형제 플래그
+    (PRESENCE_*/SSE_LEASE_*)와 동일 규약. 롤백·실험 때 이 통로가 필요하다."""
+    lines = _resolve_generated_env_lines(
+        "dev", extra={"FANOUT_WAKE_REDIS_ENABLED": "false"}
+    )
+    assert "FANOUT_WAKE_REDIS_ENABLED=false" in lines
 
 
 # ── provision_realtime_gclb.sh ───────────────────────────────────────────────


### PR DESCRIPTION
## 무엇이 문제였나

`deploy_realtime_gce.sh` 의 `FANOUT_WAKE_REDIS_ENABLED` 만 `${...:-false}` 로 남아 있어, **dev 라이브의 `true` 는 배포 SSOT 밖의 손 값**이었다(#2122 라이브 재측정 때 손으로 넣은 것). 즉 **다음 GCE 배포가 조용히 `false` 로 덮는 지뢰**였다.

- #2077(프론트 minScale/maxScale 이 코드 밖에 떠 있던 것)과 **동형**이다.
- 같은 블록의 형제 셋(`PRESENCE_REDIS_ENABLED`·`PRESENCE_ONLINE_REDIS_ENABLED`·`SSE_LEASE_REDIS_ENABLED`)은 이미 `_BACKPLANE_DEFAULT` 로 못박혀 있는데 **이것만 남아 있었다.**

## 왜 `true` 가 맞는가

이 스택은 `PG_LISTEN_ENABLED=false` 다. `false` 로 두면 wake 가 `pg_notify` 로만 나가는데 **듣는 프로세스가 전 층에 0개**라 크로스노드 wake 가 조용히 사라진다(#2122 라이브에서 cross-node wake **0/2** 재현). `true` 여야 Redis 백플레인을 타 타노드에 닿는다.

## 왜 «지금 아프지 않은데» 고치는가

까심군 측정(2026-07-25 · #2157 갈림길) — GCLB access log 전수(관측 07-23 13:53Z~):

| | wake_agent 콜사이트 라우트군 도달 |
|---|---|
| GCE 3노드 | **0건** |
| backend-prod (양성대조) | 다건 — `/api/v2/stories` PATCH · `/api/v2/gates` POST · `/api/v2/agents` |

⇒ 계측기가 커밋을 **볼 수 있다는 것**이 양성대조로 확認됐고, 그 계측기로 GCE 는 0건이다.

```
지금 켜도 라이브 동작 변화 0        ⇒ 안전하게 고칠 수 있는 타이밍
"안 아픈 이유"가 구조적 보장이 아니라 현 라우팅의 우연 ⇒ 방치하면 라우팅이 바뀌는 순간 조용히 깨진다
```

## pinning 3건

1. **`test_deploy_gce_fanout_wake_redis_is_durable_true_without_caller_env`** — caller env 를 **명시적으로 비운 상태**로 스크립트를 돌려 durable 기본값을 검증한다. `_resolve()` 가 `os.environ` 을 상속하므로 안 지우면 실행 환경에 그 변수가 우연히 있을 때 통과해버려 **판별력이 0**이 된다 — 이 스토리가 잡으려는 결함이 정확히 그것이라 헬퍼를 따로 뒀다.
   - ⭐**판별력 확認**: 수정 前 코드(`:-false`)로 되돌려 실행해 **이 테스트만** 실패하는 것을 확認했다(나머지 둘은 다른 축이라 통과 — 의도대로).
2. **`test_deploy_gce_fanout_wake_assumption_pg_listen_is_still_false`** — 이 판단의 전제(`PG_LISTEN_ENABLED=false`)가 바뀌면 실패해서 **재판정을 요구**한다. #2178 에서 세운 «전제를 소스에 박고 pinning 으로 지킨다»와 같은 형태.
3. **`test_deploy_gce_fanout_wake_caller_override_still_works`** — durable 기본값을 못박되 **손 override 통로는 막지 않는다**(롤백·실험용 · 형제 플래그와 동일 규약).

## 검증

```
tests/test_deploy_realtime_gce_env.py                        33 passed
tests/test_deploy_gce_rolling_update_maxsurge_failfast.py  ┐
tests/test_2179_logging_axis_by_runtime_location.py        ├ 22 passed
tests/test_deploy_backend_redis_secret_conflict.py         ┘
bash -n deploy_realtime_gce.sh                               OK
```

## ⚠️ 배포 관련 주의

GCE 스택은 **수동 배포**(`deploy_realtime_gce.sh`)라 이 머지만으로는 라이브가 안 바뀐다. 다음 GCE 배포 시점에 적용되며, 위 측정대로 **적용돼도 현 라이브 동작 변화는 0**이다.

## 연결

#2122(이 플래그가 켜려던 것) · #2157(까심군 갈림길 측정 = 이 결정의 근거) · #2077(동형 결함) · #2178(전제 선언 형태) · #2135(가드가 서비스 간 차이를 못 본다는 기록)

🤖 Generated with [Claude Code](https://claude.com/claude-code)