### PR TITLE
[SID:2183] /api/event-stream 프록시 request.signal 배선 — 좀비 upstream 커넥션 방지

### DIFF
--- a/apps/web/src/app/api/event-stream/route.test.ts
+++ b/apps/web/src/app/api/event-stream/route.test.ts
@@ -66,3 +66,74 @@ describe('/api/event-stream — REALTIME_URL 전환(story #2078)', () => {
     );
   });
 });
+
+// story #2183 — request.signal이 upstream fetch로 안 넘어가 다운스트림(클라 연결·프론트 자신의
+// 60초 요청컷)이 끝나도 upstream(realtime-gateway) 커넥션이 안 끊기던 결함. 재연결 1회마다
+// 좀비 upstream 커넥션이 하나씩 쌓여 realtime 타임아웃(3600s) 상한까지 살아있었다(탭 1개당
+// 누적 최대 ~60개 — 프론트가 60초마다 클라 쪽만 끊고 재연결하는 사이클과 정확히 맞아떨어짐).
+describe('/api/event-stream — request.signal 전파(story #2183, 좀비 upstream 커넥션 방지)', () => {
+  beforeEach(() => {
+    h.getServerSession.mockReset();
+    h.getServerSession.mockResolvedValue({ access_token: 'tok' });
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.unstubAllGlobals();
+  });
+
+  it('upstream fetch에 request.signal이 실제로 배선된다(실패 케이스 실증 — 이게 없으면 좀비가 남는다)', async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => new Response('', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const controller = new AbortController();
+    const req = new Request('http://localhost/api/event-stream', { signal: controller.signal });
+
+    await GET(req as unknown as Parameters<typeof GET>[0]);
+
+    const passedInit = fetchMock.mock.calls[0]?.[1];
+    // ⚠️Node의 Request는 signal을 그대로 참조 전달하지 않고 내부적으로 "따라가는" 별도
+    // AbortSignal을 노출한다(실측 — .toBe() 참조동일성이 깨짐) — 그래서 객체 동일성이 아니라
+    // "컨트롤러를 abort하면 실제로 전파되는지"(기능 동일성)로 검증한다.
+    expect(passedInit?.signal).toBeInstanceOf(AbortSignal);
+    expect(passedInit?.signal?.aborted).toBe(false);
+    controller.abort();
+    expect(passedInit?.signal?.aborted).toBe(true);
+  });
+
+  it('다운스트림이 이미 abort된 채로 들어오면(fetch가 AbortError로 거절) 499로 조용히 정리한다(예외 전파 없음)', async () => {
+    const abortError = Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+    vi.stubGlobal('fetch', vi.fn(async () => { throw abortError; }));
+    const controller = new AbortController();
+    controller.abort();
+    const req = new Request('http://localhost/api/event-stream', { signal: controller.signal });
+
+    const res = await GET(req as unknown as Parameters<typeof GET>[0]);
+
+    expect(res.status).toBe(499);
+  });
+
+  it('AbortError가 아닌 다른 fetch 실패는 그대로 던진다(오탐 방지 — 진짜 네트워크 오류를 499로 감추지 않음)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('ECONNREFUSED'); }));
+    const req = new Request('http://localhost/api/event-stream');
+
+    await expect(GET(req as unknown as Parameters<typeof GET>[0])).rejects.toThrow('ECONNREFUSED');
+  });
+
+  it('정상 스트림(abort 없음)은 signal 배선 후에도 그대로 200으로 통과한다(AC4 — 조기종료 회귀 없음)', async () => {
+    const upstreamBody = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('data: hello\n\n'));
+        controller.close();
+      },
+    });
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(upstreamBody, { status: 200 })));
+    const req = new Request('http://localhost/api/event-stream');
+
+    const res = await GET(req as unknown as Parameters<typeof GET>[0]);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream');
+    const text = await res.text();
+    expect(text).toBe('data: hello\n\n'); // 스트림이 잘리지 않고 끝까지 통과함
+  });
+});

--- a/apps/web/src/app/api/event-stream/route.ts
+++ b/apps/web/src/app/api/event-stream/route.ts
@@ -28,7 +28,21 @@ export async function GET(request: NextRequest): Promise<Response> {
   const upstreamHeaders: Record<string, string> = { Authorization: `Bearer ${session.access_token}` };
   if (lastEventId) upstreamHeaders['Last-Event-ID'] = lastEventId;
 
-  const upstream = await fetch(upstreamUrl.toString(), { headers: upstreamHeaders });
+  // story #2183 — signal이 없으면 이 요청(클라 연결 종료·프론트 자신의 Cloud Run 요청이 60초로
+  // 잘리는 것 포함)이 끝나도 upstream(realtime-gateway) 커넥션은 안 끊긴다. 프론트가 60초마다
+  // 클라 쪽만 끊고 재연결하는 사이클이라, 재연결 1회마다 좀비 upstream 커넥션이 하나씩 쌓여
+  // realtime 타임아웃(3600s) 상한까지 살아있는다 — 탭 1개당 누적 최대 ~60개. request.signal을
+  // 넘겨 다운스트림이 끝나면 upstream fetch도 즉시 abort되게 한다.
+  let upstream: Response;
+  try {
+    upstream = await fetch(upstreamUrl.toString(), { headers: upstreamHeaders, signal: request.signal });
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      // 클라가 이미 연결을 끊은 뒤라 응답을 볼 대상이 없다 — 조용히 빈 응답으로 정리.
+      return new Response(null, { status: 499 });
+    }
+    throw err;
+  }
 
   if (!upstream.ok) {
     return NextResponse.json(


### PR DESCRIPTION
## 배경
디디군이 #2128 설계 중 발견, 오르테가군이 코드로 확認: `apps/web/src/app/api/event-stream/route.ts`의 upstream `fetch()`에 `request.signal`을 넘기는 배선이 0건이었다. 다운스트림(브라우저 연결 종료, 또는 프론트 자신의 Cloud Run 요청이 60초로 잘리는 것)이 끝나도 upstream(realtime-gateway) 커넥션은 안 끊긴다.

**숫자 정합**: 프론트가 60초마다 클라 쪽만 끊고 재연결하는 사이클 → 재연결 1회마다 좀비 upstream 커넥션이 하나씩 남음 → realtime 타임아웃(3600s) 상한까지 살아있음 → 탭 1개당 누적 최대 ~60개. 실측: realtime-dev SSE 점유 중앙값 3601s(=타임아웃 상한), 최근 SSE 연결 100%가 503으로 거절.

## 변경
`fetch(upstreamUrl, { headers, signal: request.signal })` — 다운스트림이 끝나면 upstream fetch도 즉시 abort. AbortError는 499로 조용히 정리(클라가 이미 끊긴 뒤라 응답 볼 대상 없음), 그 외 fetch 실패는 그대로 throw(진짜 네트워크 오류를 499로 감추지 않음 — 오탐 방지).

## 회귀테스트 (4건 신규)
1. **signal 실제 배선** — upstream fetch에 signal이 넘어가는지, controller.abort() 시 실제로 전파되는지(기능 동일성 — Node의 `Request`가 signal을 참조 그대로 안 넘기고 별도 추종 `AbortSignal`을 노출하는 것을 실측으로 확認한 뒤 테스트를 그에 맞게 작성함, `.toBe()` 참조동일성이 아니라 `.aborted` 상태 전파로 검증)
2. abort된 채로 fetch가 거절되면 **499**로 조용히 정리(예외 전파 없음)
3. AbortError가 **아닌** fetch 실패는 그대로 throw(오탐 방지 검증)
4. **AC4 — 정상 스트림 조기종료 없음**: signal 배선 후에도 정상 스트림은 끝까지(청크 전부) 통과

**뮤테이션 셀프체크**: signal 배선을 일시적으로 제거 → 테스트①이 정확히 RED로 떨어지는 것 확認 → 복구 후 GREEN.

## 검증
- type-check PASS / lint(대상 파일) 0 / build EXIT 0
- vitest 295 files / 1959 tests PASS (신규 4건 포함). ⚠️풀스위트 1회차에서 `kanban-board.test.tsx` 15건이 실패했으나 해당 파일 단독 실행(21/21 PASS)·풀스위트 2회차 재실행(295/295 PASS) 둘 다 정상이라 **기존에 있던 격리성 플레이키니스**로 판단(이 PR의 변경과 무관 — event-stream 라우트만 건드림, kanban-board 관련 코드 접촉 0).

## done-gate (스토리 명시 — 여기서 안 재는 것)
⛔ **슬롯 probe로 재지 않는다** — probe 자체가 슬롯을 먹어 재기만 해도 새 좀비를 심는다(까심군이 자진발견). 판정은 **서버 로그의 SSE 점유시간 분포**로 — 머지→배포 후 같은 축으로 재측정해 중앙값이 3601s에서 내려가는 것을 보이는 것이 done-gate(오르테가군 축).

## Test plan
- [x] 회귀테스트 4건 + 뮤테이션 셀프체크(RED 확認 후 복구)
- [ ] 배포 후 realtime-dev SSE 점유시간 분포 재측정(PO 축 — 원인이었는지의 최종 판정)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>