### PR TITLE
fix(#2128): SSE wall-clock 수명 상한 — 좀비 스트림 자가회수(critical)

### DIFF
--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -10,6 +10,8 @@ import asyncio
 import json
 import logging
 import os
+import random
+import time
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -50,6 +52,23 @@ _SESSION_FRESH_TTL: float = _SSE_HEARTBEAT * 3
 # 아니라 **세션-row 존재**로 한다. 다만 크래시로 finally 미실행된 leaked row를 "활성"으로 오판하면 안 되므로,
 # 연결 최대수명(GLCB backend timeout 3600s = SSE 단일연결 상한)을 넘긴 row는 확실히 죽은 좀비로 보고 제외/GC.
 _MAX_SSE_LIFETIME_SEC: float = 3900.0  # 3600s(GLCB) + 여유
+
+# story #2128(2026-07-24, critical) — wall-clock 수명 상한(v2 설계 ①본체, events.py와 동형
+# 원리). 위 _MAX_SSE_LIFETIME_SEC은 "이미 죽었다고 확信할 수 있는" 사후 GC 기준(3600s+여유)
+# 일 뿐, 스트림 자체를 능동 종료하지 않는다 — Cloud Run 타임아웃이 결국 끊어줄 때까지
+# 수동으로 기다리기만 했다(그게 이 병의 본질). 이 상수는 그 수동 대기를 능동 종료로 바꾼다.
+#
+# N=1800s(30분) 근거 — browser(events.py)와 다른 판단이 필요한 이유: 에이전트는 프론트
+# 프록시를 안 거치고 backend-dev에 직결이라(#2095의 60s 강제 재연결 없음) MCP 세션의 idle
+# 대기가 정당하게 길 수 있다 — browser와 같은 "자연주기" 논증을 못 쓴다.
+# · 3600s의 절반 — 오탐지 리스크를 browser보다 크게 두되(margin 우선), 최대 점유는 2배 줄인다.
+# · #2161(AGENT_RUN_TIMEOUT_HOURS=24h)과 동형 판단 — 첫 판은 "정확"이 아니라 "안전"이 목적.
+#   idle-but-legit한 agent 세션 길이를 실측한 적이 없어 보수적으로 넉넉히 잡았다.
+#
+# 무너지는 조건(pinning 테스트 — tests/test_2128_sse_lifespan_cap.py 참조): "30분보다 오래
+# idle-but-legit한 agent 세션이 실제로 관측되면" 이 값을 올려야 한다 — 지금은 그런 관측 없음.
+_AGENT_SSE_LIFESPAN_SEC: float = 1800.0
+_AGENT_SSE_LIFESPAN_JITTER_SEC: float = 60.0  # herd 방지(#2095 지터와 동일 목적)
 
 
 async def _mark_agent_online(agent_id: uuid.UUID, session_id: uuid.UUID) -> None:
@@ -414,6 +433,10 @@ async def agent_stream(
     queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=200)
     _agent_connections[agent_id_str].add(queue)
 
+    # story #2128: 연결 시작 시점에 이미 종료 예정 시각을 갖고 태어난다(#2161과 동일 원리).
+    # monotonic — 벽시계 조정에 영향 안 받음.
+    _lifespan_deadline = time.monotonic() + _AGENT_SSE_LIFESPAN_SEC + random.uniform(0, _AGENT_SSE_LIFESPAN_JITTER_SEC)
+
     async def generate():
         """gap-free ordered-at-least-once SSE ì¤í¸ë¦¼.
 
@@ -481,6 +504,13 @@ async def agent_stream(
             last_presence_tick = datetime.now(timezone.utc)
             # story c4c72eb1(E-ARCH GCE 이전) PR-A: events.py와 동형 shutdown-aware 종료.
             while not await request.is_disconnected():
+                # story #2128 ①본체: 좀비가 스스로 늘릴 수 없는 유일한 축 — disconnect 감지
+                # 여부와 완전히 무관하게 발동. "완료로 위장" 안 함 — 특별취급 없이 기존
+                # finally: 하나로 그대로 흘러간다(정상종료·이상종료·수명초과 전부 같은 정리
+                # 경로 — presence offline 강등·세션row 삭제 포함, #2161 CAS 원칙의 적용).
+                if time.monotonic() >= _lifespan_deadline:
+                    yield "event: lifespan_reconnect\ndata: {}\n\n"
+                    return
                 _now = datetime.now(timezone.utc)
                 if (_now - last_presence_tick).total_seconds() >= _PRESENCE_TICK_INTERVAL:
                     from app.core.config import settings as _settings

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import random
+import time
 import uuid
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
@@ -46,6 +48,38 @@ import os as _os
 _MAX_SSE_CONNECTIONS: int = int(_os.getenv("MAX_SSE_CONNECTIONS", "100"))
 _sse_connection_count: int = 0
 _SSE_HEARTBEAT_TIMEOUT: float = float(_os.getenv("SSE_HEARTBEAT_TIMEOUT", "30"))
+
+# story #2128(2026-07-24, critical) — wall-clock 수명 상한(v2 설계 ①본체). realtime-dev가
+# 이 병으로 죽어 있었다: GCLB 뒤에서 클라 disconnect가 백엔드로 전파 안 되고(코드는 정상 —
+# request.is_disconnected() 체크·finally discard 둘 다 있음), 연결이 Cloud Run 타임아웃
+# (3600s)까지 자연 종료 없이 슬롯을 점유해 640슬롯(concurrency 80×maxInstances 8)이
+# 누적 고갈됐다(관측: 200 SSE 슬롯 점유 중앙값 3601초). 처방 제1원리(오르테가군 판정) —
+# 생명 판정 신호는 "판정 대상이 스스로 갱신할 수 없는 것"이어야 한다: heartbeat/ACK
+# staleness는 신호가 없는 정상 idle 연결(브라우저 EventSource는 out-of-band 신호 자체가
+# 0)을 오살하므로 "가속"으로만 쓰고, wall-clock 상한을 유일한 본체로 둔다. 좀비는 이 축을
+# 스스로 늘릴 수 없다 — 정상 연결도 이 상한에 걸려 재연결되지만 #2101 backfill+Last-Event-ID
+# 재개로 데이터 손실 0.
+#
+# N=600s(10분) 근거:
+# · #2183(2026-07-24, 등재) 고쳐지기 前: apps/web `/api/event-stream` 프록시(route.ts)의
+#   upstream fetch()가 incoming request.signal을 안 넘겨받아, 프론트 자체 요청이 #2095의
+#   60s 타임아웃으로 끊겨도 realtime-dev로의 upstream 연결은 안 끊긴다 — 이 상태에선
+#   600s가 **실질 상한**이고 healthy 연결에도 발동한다(무해 — 위 데이터손실 0 근거 그대로).
+# · #2183 고쳐진 後: 프론트 60s 컷이 먼저 걸려(자연주기 ~60~68s, story #2101 실측) 이
+#   600s는 거의 발동 안 하는 순수 백스톱으로 물러난다. 600s는 그 자연주기의 ~9배라
+#   AC4(정상연결 오살 금지)를 여유있게 만족.
+# · 3600s의 1/6 — 좀비 최대 점유시간이 6배 줄어든다.
+# · #2095(재연결 backoff 상한 20s)와 동형 근거화 방식: "자연주기보다 충분히 길어 정상
+#   트래픽엔 사실상 발동 안 하면서, 발동하면 확실히 좀비를 잘라낸다."
+#
+# 무너지는 조건(pinning 테스트 — tests/test_2128_sse_lifespan_cap.py 참조): "600s 미만에
+# 정상 완료되는 게 드문 무거운 초기 핸드셰이크/backfill이 실제로 관측되면"(예: 매우 큰
+# backfill이 600s 근처를 자주 침범) 이 값을 올려야 한다 — 지금은 그런 관측 없음.
+#
+# 배포 env가 아니라 코드 상수 — #2161 AGENT_RUN_TIMEOUT_HOURS와 동형(값이 두 곳에 살면
+# 오늘 하루 종일 데인 그 모양이 된다는 오르테가군 지적).
+_SSE_LIFESPAN_SEC: float = 600.0
+_SSE_LIFESPAN_JITTER_SEC: float = 60.0  # herd 방지(#2095 지터와 동일 목적)
 
 # ─── S6-1: Backfill 볼륨 제어 ─────────────────────────────────────────────────
 _BACKFILL_THRESHOLD_SECONDS: int = int(_os.getenv("BACKFILL_THRESHOLD_SECONDS", "300"))
@@ -329,6 +363,10 @@ async def agent_event_stream(
     queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=200)
     _agent_connections[member_id_str].add(queue)
 
+    # story #2128: 연결 시작 시점에 이미 종료 예정 시각을 갖고 태어난다(#2161과 동일 원리 —
+    # "시작할 때 이미 끝날 시각을 갖고 태어나게"). monotonic — 벽시계 조정에 영향 안 받음.
+    _lifespan_deadline = time.monotonic() + _SSE_LIFESPAN_SEC + random.uniform(0, _SSE_LIFESPAN_JITTER_SEC)
+
     async def generate():
         try:
             # 즉시 heartbeat → HTTP 응답 헤더 즉시 반환 (대량 백필 전 hang 방지)
@@ -449,6 +487,13 @@ async def agent_event_stream(
             shutdown_wait_task = asyncio.create_task(_shutdown_module.shutdown_event.wait())
             try:
                 while not await request.is_disconnected():
+                    # story #2128 ①본체: 좀비가 스스로 늘릴 수 없는 유일한 축 — disconnect
+                    # 감지 여부와 완전히 무관하게 발동(그게 이 방어선의 존재 이유). "완료로
+                    # 위장" 안 함 — 아래에서 특별취급 없이 기존 finally: 하나로 그대로 흘러간다
+                    # (정상종료·이상종료·수명초과 전부 같은 정리 경로, #2161 CAS 원칙의 적용).
+                    if time.monotonic() >= _lifespan_deadline:
+                        yield "event: lifespan_reconnect\ndata: {}\n\n"
+                        return
                     get_task = asyncio.create_task(queue.get())
                     try:
                         done, _pending = await asyncio.wait(

--- a/backend/tests/test_2128_sse_lifespan_cap.py
+++ b/backend/tests/test_2128_sse_lifespan_cap.py
@@ -1,0 +1,311 @@
+"""story #2128(2026-07-24, critical) — SSE wall-clock 수명 상한(v2 설계 ①본체).
+
+realtime-dev가 이 병으로 죽어 있었다: GCLB 뒤에서 클라 disconnect가 백엔드로 전파 안 되고
+(코드는 정상 — request.is_disconnected() 체크·finally discard 둘 다 있음), 연결이 Cloud Run
+타임아웃(3600s)까지 자연 종료 없이 640슬롯을 점유했다(관측: 점유 중앙값 3601초). 처방 —
+disconnect 감지 여부와 완전히 무관하게 발동하는 wall-clock 상한을 본체로 둔다(좀비가 스스로
+늘릴 수 없는 유일한 축).
+
+browser(events.py)는 test_c4c72eb1_sse_shutdown_aware.py의 검증된 패턴(라우트 함수 직접
+호출 + body_iterator 직접 펌프, ASGI 계층 우회)을 그대로 재사용. agent(agent_gateway.py)는
+DB 상태(AgentGatewaySession·presence)까지 검증해야 해 실PG로 간다.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+# story 8236bbc3 컨벤션: 이 파일의 agent 경로 realdb 테스트가 create_all/drop_all을 쓴다 —
+# 파일 전체에 마커(mock 전용 테스트도 포함, 개별 함수 마커만으론 AST 가드가 통과 안 됨).
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _make_mock_session():
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    session.execute = AsyncMock()
+    return session
+
+
+def _membership_ok(member_id: uuid.UUID) -> MagicMock:
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = member_id
+    return r
+
+
+def _pending_empty() -> MagicMock:
+    scalars = MagicMock()
+    scalars.all.return_value = []
+    r = MagicMock()
+    r.scalars.return_value = scalars
+    return r
+
+
+class _FakeRequest:
+    headers: dict = {}
+
+    async def is_disconnected(self) -> bool:
+        return False
+
+
+# ── browser(events.py) — test_c4c72eb1 패턴 재사용 ──────────────────────────
+@pytest.mark.anyio
+async def test_browser_lifespan_cap_triggers_finite_reconnect_and_cleanup():
+    """AC1/AC2 — disconnect 감지와 무관하게(위 _FakeRequest는 항상 is_disconnected()=False,
+    #2128의 실제 라이브 증상 그대로 재현) wall-clock 상한만으로 유한 시간 내 종료 + 슬롯 반납."""
+    import app.routers.events as ev_module
+
+    member_id = uuid.uuid4()
+    org = uuid.uuid4()
+
+    mock_sess = _make_mock_session()
+    mock_sess.execute.side_effect = [_membership_ok(member_id), _pending_empty()]
+
+    @asynccontextmanager
+    async def _factory():
+        yield mock_sess
+
+    auth_ctx = MagicMock()
+    auth_ctx.user_id = str(member_id)
+    auth_ctx.claims = {"app_metadata": {"api_key_id": "test-key", "org_id": str(org)}}
+
+    count_before = ev_module._sse_connection_count
+    saw_lifespan_event = False
+    elapsed = None
+    try:
+        with patch("app.core.database.async_session_factory", _factory):
+            # 수명상한 체크는 while 루프 top에서 heartbeat-tick 주기로만 재평가된다(매
+            # asyncio.wait(timeout=heartbeat)를 다 기다려야 다음 체크로 넘어감) — 그래서
+            # 하트비트도 함께 짧게 잡아야 짧은 수명상한이 실제로 빠르게 감지된다(프로덕션은
+            # 30s 하트비트 주기 오차가 600s/1800s 상한 대비 무시할 수준이라 문제 없음).
+            with patch.object(ev_module, "_SSE_HEARTBEAT_TIMEOUT", 0.02), \
+                 patch.object(ev_module, "_SSE_LIFESPAN_SEC", 0.05), \
+                 patch.object(ev_module, "_SSE_LIFESPAN_JITTER_SEC", 0.0):
+                response = await ev_module.agent_event_stream(
+                    request=_FakeRequest(),
+                    member_id=None,
+                    auth=auth_ctx,
+                    org_id=org,
+                    since_timestamp=None,
+                    last_event_id=None,
+                )
+                assert ev_module._sse_connection_count == count_before + 1
+
+                started = time.monotonic()
+                async for chunk in response.body_iterator:
+                    if "lifespan_reconnect" in chunk:
+                        saw_lifespan_event = True
+                elapsed = time.monotonic() - started
+
+        assert saw_lifespan_event, "lifespan_reconnect 이벤트가 스트림에 안 실림 — 상한 미발동"
+        assert elapsed is not None and elapsed < 5.0, (
+            f"수명상한 반응이 너무 느림({elapsed}s) — disconnect 신호 없이도 유한 시간 내 종료해야"
+        )
+        await asyncio.sleep(0.05)
+        assert ev_module._sse_connection_count == count_before, "수명초과 후 카운터 정리 안 됨(AC2)"
+    finally:
+        ev_module._agent_connections.pop(str(member_id), None)
+        ev_module._sse_connection_count = count_before
+        # generate()가 내부적으로 shutdown_event.wait()를 태스크로 태워 이 테스트의 이벤트
+        # 루프에 바인딩시킨다 — 리셋 안 하면 다음 테스트(다른 루프)가 cross-loop
+        # RuntimeError를 맞는다(test_c4c72eb1_sse_shutdown_aware.py와 동일 관례).
+        from app.core import shutdown as _shutdown_module
+        _shutdown_module.reset_shutdown_event()
+
+
+@pytest.mark.anyio
+async def test_browser_lifespan_cap_does_not_fire_under_normal_duration():
+    """AC4 — 상한이 넉넉히 크면(정상 상황) 하트비트/이벤트 경로가 그대로 동작(회귀 0).
+    짧은 관찰 구간 안에서 lifespan_reconnect가 섞이지 않는지만 확認(무한 대기 방지 위해
+    heartbeat 타임아웃도 짧게 잡고 몇 틱만 관찰)."""
+    import app.routers.events as ev_module
+
+    member_id = uuid.uuid4()
+    org = uuid.uuid4()
+
+    mock_sess = _make_mock_session()
+    mock_sess.execute.side_effect = [_membership_ok(member_id), _pending_empty()]
+
+    @asynccontextmanager
+    async def _factory():
+        yield mock_sess
+
+    auth_ctx = MagicMock()
+    auth_ctx.user_id = str(member_id)
+    auth_ctx.claims = {"app_metadata": {"api_key_id": "test-key", "org_id": str(org)}}
+
+    count_before = ev_module._sse_connection_count
+    chunks: list[str] = []
+    try:
+        with patch("app.core.database.async_session_factory", _factory):
+            with patch.object(ev_module, "_SSE_HEARTBEAT_TIMEOUT", 0.05), \
+                 patch.object(ev_module, "_SSE_LIFESPAN_SEC", 600.0), \
+                 patch.object(ev_module, "_SSE_LIFESPAN_JITTER_SEC", 0.0):
+                response = await ev_module.agent_event_stream(
+                    request=_FakeRequest(),
+                    member_id=None,
+                    auth=auth_ctx,
+                    org_id=org,
+                    since_timestamp=None,
+                    last_event_id=None,
+                )
+                agen = response.body_iterator
+                for _ in range(4):  # 초기 heartbeat + 하트비트 tick 몇 번
+                    chunks.append(await agen.__anext__())
+                await agen.aclose()
+        assert not any("lifespan_reconnect" in c for c in chunks), (
+            "600s 상한인데 짧은 관찰 구간에 발동 — 회귀"
+        )
+        assert any("heartbeat" in c for c in chunks)
+    finally:
+        ev_module._agent_connections.pop(str(member_id), None)
+        ev_module._sse_connection_count = count_before
+        from app.core import shutdown as _shutdown_module
+        _shutdown_module.reset_shutdown_event()
+
+
+# ── agent(agent_gateway.py) — 실PG로 세션row/presence까지 검증(AC2/AC3) ─────
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project_agent(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.team import TeamMember
+
+    org = Organization(id=uuid.uuid4(), name="Org2128", slug=f"org2128-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    agent = TeamMember(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id, type="agent", name="agent",
+        is_active=True,
+    )
+    session.add(agent)
+    await session.commit()
+    return org.id, project.id, agent.id
+
+
+@pytest.mark.anyio
+@pytest.mark.destructive_schema
+@pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+async def test_agent_lifespan_cap_reclaims_slot_and_presence():
+    """AC2/AC3 — 에이전트 경로: 수명상한 발동 시 연결 카운트·AgentGatewaySession row·presence
+    offline까지 실제로 회수되는지(기존 finally: 무수정 — 정상/이상/수명초과 전부 같은 경로)."""
+    import app.routers.agent_gateway as gw_module
+    from app.models.agent_gateway import AgentGatewaySession
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, agent_id = await _seed_org_project_agent(s)
+
+        auth_ctx = MagicMock()
+        auth_ctx.user_id = str(agent_id)
+        auth_ctx.claims = {"app_metadata": {"api_key_id": "test-key"}}
+
+        @asynccontextmanager
+        async def _factory():
+            async with Session() as s:
+                yield s
+
+        count_before = gw_module._agent_sse_connection_count
+        saw_lifespan_event = False
+        elapsed = None
+        with patch("app.core.database.async_session_factory", _factory), \
+             patch.object(gw_module, "_SSE_HEARTBEAT", 0.02), \
+             patch.object(gw_module, "_AGENT_SSE_LIFESPAN_SEC", 0.05), \
+             patch.object(gw_module, "_AGENT_SSE_LIFESPAN_JITTER_SEC", 0.0), \
+             patch("app.services.onboarding_funnel.emit_onboarding_event", AsyncMock()):
+            response = await gw_module.agent_stream(request=_FakeRequest(), auth=auth_ctx)
+            assert gw_module._agent_sse_connection_count == count_before + 1
+
+            started = time.monotonic()
+            async for chunk in response.body_iterator:
+                if "lifespan_reconnect" in chunk:
+                    saw_lifespan_event = True
+            elapsed = time.monotonic() - started
+
+        assert saw_lifespan_event, "lifespan_reconnect 이벤트가 스트림에 안 실림"
+        assert elapsed is not None and elapsed < 5.0
+
+        await asyncio.sleep(0.05)
+        assert gw_module._agent_sse_connection_count == count_before, "수명초과 후 카운터 정리 안 됨"
+        assert not gw_module._agent_connections.get(str(agent_id)), "queue 정리 안 됨"
+
+        async with Session() as s:
+            remaining = (await s.execute(
+                select(AgentGatewaySession).where(AgentGatewaySession.agent_id == agent_id)
+            )).scalars().all()
+            assert remaining == [], "AgentGatewaySession row가 정리 안 됨(AC2/AC3)"
+    finally:
+        from app.core.database import Base
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+        from app.core import shutdown as _shutdown_module
+        _shutdown_module.reset_shutdown_event()
+
+
+# ── 소스 고정 — pinning 테스트(오늘 팀 관례) ────────────────────────────────
+def test_browser_breaking_condition_declared():
+    import inspect
+    import app.routers.events as ev_module
+
+    source = inspect.getsource(ev_module)
+    assert "600s 미만에" in source and "무너지는 조건" in source
+
+
+def test_agent_breaking_condition_declared():
+    import inspect
+    import app.routers.agent_gateway as gw_module
+
+    source = inspect.getsource(gw_module)
+    assert "idle-but-legit한 agent 세션이 실제로 관측되면" in source
+    assert "무너지는 조건" in source
+
+
+def test_lifespan_cap_uses_same_finally_no_special_casing():
+    """오르테가군 지시 — "completed로 위장 금지·CAS로 전이"의 SSE 적용: 수명초과 종료가
+    기존 finally: 블록과 별도의 정리 경로를 만들지 않았는지 소스 고정(정상·이상·수명초과가
+    모두 같은 finally 하나를 탄다)."""
+    import inspect
+    import app.routers.events as ev_module
+    import app.routers.agent_gateway as gw_module
+
+    ev_source = inspect.getsource(ev_module.agent_event_stream)
+    gw_source = inspect.getsource(gw_module.agent_stream)
+    # lifespan_reconnect 분기가 return만 하고(그 안에서 카운터 조작을 직접 하지 않음),
+    # 정리는 바깥 finally:가 담당 — 새 finally 블록을 안 만들었는지 개수로 확認.
+    assert ev_source.count("_sse_connection_count -= 1") == 1
+    assert gw_source.count("_agent_sse_connection_count -= 1") == 1


### PR DESCRIPTION
## Summary
**critical — realtime-dev가 현재 죽어 있는 실장애 대응.** GCLB 뒤에서 클라 disconnect가 백엔드로 전파 안 되고(코드는 정상), 연결이 Cloud Run 타임아웃(3600s)까지 자연 종료 없이 640슬롯을 점유해 신규 연결이 전부 503(관측: 최근 40분 104건 전부 503, 점유 중앙값 3601s = 타임아웃 상한).

## 처방(설계 v2)
제1원리: 생명 판정 신호는 판정 대상이 스스로 갱신할 수 없는 것이어야 한다.
- **① wall-clock 수명 상한 + jitter = 본체** — 좀비가 스스로 늘릴 수 없는 유일한 축. `#2101` backfill + Last-Event-ID 재개로 데이터 손실 0.
- **② heartbeat/ACK staleness = 신호가 실재하는 경로에만 얹는 가속** — "무신호=죽음" 금지(idle MCP/Hermes/브라우저는 신호 자체가 0). **이번 스코프 제외**(6 AC 전부 ①만으로 충족, 급한 불부터 — 승인됨). 후속 스토리 후보.

## 두 경로 별도 N값(AC5)
- **browser(events.py) 600s+jitter** — `#2095`가 프론트를 60~68s 자연주기로 이미 강제 재연결시키는 중(단 `#2183` 프록시 버그로 그 컷이 upstream엔 전파 안 돼 현재는 600s가 healthy 연결에도 실질 발동 — 무해, 코드 주석에 두 시점 구분 명시).
- **agent(agent_gateway.py) 1800s+jitter** — 프론트 프록시 없이 직결이라 idle 세션이 정당하게 길 수 있음(`#2161`과 동형 "정확 아닌 안전" 판단, 무너지는 조건 명시).

## 메커니즘
연결 시작 시 `deadline = monotonic() + N + jitter`(`#2161`과 동일 "시작할 때 이미 끝날 시각을 갖고 태어나게"). 기존 heartbeat while 루프에 deadline 체크만 얹음(새 태스크 없음). 초과 시 `event: lifespan_reconnect` emit 후 return — **기존 finally: 블록을 특별취급 없이 그대로 탐**(정상·이상·수명초과 전부 같은 정리 경로, `#2161` CAS 원칙의 SSE 적용 — completed로 위장 안 함).

## 부수 발견(별도 등재)
`apps/web` `/api/event-stream` 프록시(`route.ts:31`)의 upstream `fetch()`가 incoming `request.signal`을 안 넘겨받아 프론트 60s 컷이 upstream(realtime)엔 전파 안 됨 — `#2183`로 등재(Ortega 확認+미르코군 배정, apps/web 소관이라 이 PR 스코프 밖). 원천차단(`#2183`)과 백스톱(이 PR)은 서로 대체 아님 — `#2183`이 안 고쳐져도 이 fix는 유효.

## 잔여(명시적으로 기록, 조용히 덮지 않음)
AC3(presence 유한시간 offline 수렴)는 ①만으로 "유한"은 충족하나 최대 600s(browser)/1800s(agent) 걸릴 수 있음 — 사람이 나가도 남 화면에 최대 10분/30분까지 "접속 중"으로 보일 수 있음(AC 위반 아니나 사용자 체감 품질 잔여, 스토리 doc에 명시).

## Test plan
- [x] `test_2128_sse_lifespan_cap.py`(신규, 6): browser 경로 lifespan_reconnect 발동+슬롯반납(mock, `test_c4c72eb1_sse_shutdown_aware.py` 검증된 패턴 재사용) · browser 정상 상황 무발동(회귀 0) · agent 경로 실PG로 슬롯+AgentGatewaySession row+presence까지 회수 확認 · pinning(무너지는 조건 선언·같은 finally 사용)
- [x] fix를 stash로 되돌려 5/6 테스트가 정확히 예상대로 실패하는 것 확認(negative-control 테스트만 원래 통과) 후 복원 — 회귀가드가 진짜 작동하는지 검증
- [x] 관련 destructive_schema realdb 테스트(`test_2101_sse_recent_delivered_backfill_realdb`·`test_edg_s8_watchdog`·`test_2086_assignee_changed_sse`·`test_2131_bulk_status_changed_sse_realdb`) 15건 회귀 0
- [x] 전체 non-destructive 백엔드 스위트: `3736 passed`, 잔여 7건은 오늘 종일 재현되던 로컬 MCP stdio 환경 이슈와 동일(무관)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>