### PR TITLE
docs(#2173): 단건/bulk status-emit 실패처리 차이 — 결함 아님, 근거 남기고 닫음

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -788,6 +788,11 @@ async def bulk_update_stories(
                 # 오르테가군 PR 리뷰(2026-07-24): warning은 찾을 때 안 보이는 자리 — 오늘
                 # #2128/#2160/#2161 전부 "조용한 실패"였다. 나가야 할 실시간 프레임이 안 나간
                 # 것 자체가 이 스토리가 고치는 병이라 ERROR로 올린다.
+                #
+                # story #2173: 이 try/except는 emit_story_status_changed 자체의 신뢰성을 못
+                # 믿어서가 아니다(그쪽은 이미 완전 내부 격리 — update_story_status의 단건
+                # 콜사이트 주석 참조) — **다건성**(이 item이 실패해도 for 루프의 나머지 item은
+                # 계속 처리돼야 함) 때문. 단건 경로엔 "나머지 item"이 없어 이 이유가 적용 안 된다.
                 logger.error(
                     "bulk status_changed emit 실패(story=%s)", s.id, exc_info=True,
                 )
@@ -1230,6 +1235,17 @@ async def update_story_status(
                 pass
         # 41a6e294: status_changed side-effects(events→L1·webhook·L2·notif·activity)는 공유 helper로
         # 발화 — gate-driven done(gate_service)과 동일 경로(parity·드리프트 0).
+        #
+        # story #2173(2026-07-24, 오르테가군 판정 — «결함인지 아닌지 가르기») 판정: 여기 try/except가
+        # 없는 것과 아래 bulk_update_stories의 item별 try/except는 **우연히 갈린 게 아니라 이제는
+        # 근거가 붙은 의도적 차이**다 — emit_story_status_changed() 자체가 이미 모든 side-effect를
+        # 개별 try/except로 감싸 내부적으로 완전 격리돼 있어(SSE·webhook·L2·notification·
+        # StoryActivity·trust_pipeline 전부, tests/test_emit_story_status_changed_isolation.py로
+        # 고정) 이 콜사이트에서 밖으로 던질 경로가 구조적으로 없다(라이브 로그 근거도 0건).
+        # bulk의 try/except는 emit 자체의 신뢰성 문제가 아니라 **다건성**(한 item의 실패가 나머지
+        # item을 막으면 안 됨) 때문 — 단건은 애초에 "나머지 item"이 없어 그 이유가 적용 안 된다.
+        # 무너지는 조건: emit_story_status_changed에 나중에 개별 try/except 없는 새 side-effect가
+        # 추가되면 이 판정이 깨진다 — 그 경우 추가하는 사람이 여기도 다시 감쌀지 판단해야 한다.
         await emit_story_status_changed(
             db, org_id, story, old_status,
             actor_id=actor_id, actor_name=actor_name, actor_role=actor_role, actor_type=actor_type,

--- a/backend/app/services/story_status_events.py
+++ b/backend/app/services/story_status_events.py
@@ -112,6 +112,15 @@ async def emit_story_status_changed(
     호출자가 story.status를 이미 새 값으로 설정한 뒤 호출한다. 각 side-effect는 best-effort(실패
     격리)로 status 전이 자체를 깨지 않는다.
 
+    ⚠️계약(story #2173, 2026-07-24 — «결함인지 아닌지 가르기» 판정): 이 함수는 **호출자에게
+    예외를 전파하지 않는다** — SSE·webhook·L2·notification·StoryActivity·trust_pipeline 전부
+    개별 try/except로 감싸져 있다(tests/test_emit_story_status_changed_isolation.py로 고정).
+    이 계약 덕에 `update_story_status`(단건 PATCH)는 이 호출을 try/except로 안 감싸도 안전하고,
+    `bulk_update_stories`의 item별 try/except는 emit 신뢰성이 아니라 순수 다건성(한 item 실패가
+    나머지를 막으면 안 됨) 때문이다 — 두 콜사이트의 차이는 우연이 아니라 이 계약에서 파생된다.
+    무너지는 조건: 나중에 이 함수에 개별 try/except 없는 새 side-effect가 추가되면 이 계약이
+    깨진다 — 추가하는 사람이 그 자리도 감싸야 한다(또는 두 콜사이트 재검토).
+
     `request_received_at`(#2176 AC1, 2026-07-24): 미르코 실측 — 칸반 상태변경이 액터 호출부터
     화면 도착까지 10초(전달 4.7초+렌더 5.0초)였는데, "액터 호출 시작"이 MCP 발신 시각이라 그
     안에 BE 처리·발행이 전부 섞여 있어 #2158의 순수 SSE 전송 400ms대와 기준선이 다르다는

--- a/backend/tests/test_emit_story_status_changed_isolation.py
+++ b/backend/tests/test_emit_story_status_changed_isolation.py
@@ -76,3 +76,48 @@ async def test_noop_when_status_unchanged():
             AsyncMock(), uuid.uuid4(), story, story.status, actor_id=uuid.uuid4(),
         )
     notif.assert_not_awaited()
+
+
+# ── story #2173(2026-07-24) — 나머지 두 side-effect(SSE push·trust_pipeline)도 격리되는지
+#    커버리지 보강. 이 파일 전체가 story_status_events.py 상단 docstring이 선언한 "예외
+#    전파 0" 계약의 pin — update_story_status(단건)가 emit을 try/except 없이 부르는 것과
+#    bulk_update_stories의 item별 try/except가 (emit 신뢰성이 아니라 다건성 때문에) 우연이
+#    아니라는 근거가 이 계약이다(app/routers/stories.py 두 콜사이트 주석 참조). ──────────
+@pytest.mark.anyio
+async def test_sse_push_raise_does_not_propagate():
+    with ExitStack() as stack:
+        _base_patches(stack)
+        stack.enter_context(patch(
+            "app.services.project_auth.project_accessible_member_ids",
+            AsyncMock(side_effect=RuntimeError("sse down")),
+        ))
+        await emit_story_status_changed(
+            AsyncMock(), uuid.uuid4(), _story(), "in-review",
+            actor_id=uuid.uuid4(), actor_type="human",
+        )  # 예외 없이 반환.
+
+
+@pytest.mark.anyio
+async def test_trust_pipeline_raise_does_not_propagate():
+    with ExitStack() as stack:
+        _base_patches(stack)
+        stack.enter_context(patch(
+            "app.services.trust_pipeline.emit_on_story_status_change",
+            AsyncMock(side_effect=RuntimeError("trust pipeline down")),
+        ))
+        await emit_story_status_changed(
+            AsyncMock(), uuid.uuid4(), _story(), "in-review",
+            actor_id=uuid.uuid4(), actor_type="human",
+        )  # 예외 없이 반환.
+
+
+def test_single_item_callsite_intentionally_unwrapped_source_pin():
+    """단건 콜사이트(update_story_status)가 emit_story_status_changed를 try/except 없이
+    부르는 것이 실수로 안 감싸진 게 아니라 #2173 판정에 근거한 의도적 상태임을 소스에 고정
+    — 다음에 누가 "왜 여기만 안 감쌌지"로 다시 파지 않도록."""
+    import inspect
+    from app.routers import stories as stories_mod
+
+    source = inspect.getsource(stories_mod.update_story_status)
+    assert "#2173" in source
+    assert "await emit_story_status_changed(" in source


### PR DESCRIPTION
## Summary
low priority — "결함 고치기"가 아니라 "결함인지 아닌지 가르기". `#2131` 리뷰 중 발견된 관측(같은 `emit_story_status_changed` helper를 공유하면서 단건은 try/except 없이, bulk는 item별 try/except로 감싸는 차이)을 가정 없이 코드로 확認했다.

## ①②③ 확認 결과 (코드 트레이스, 가정 없음)

**① emit이 실제로 던지는 경로가 있는가** — 없다. `emit_story_status_changed`는 이미 6개 side-effect(SSE push·webhook·L2·notification·StoryActivity·trust_pipeline) 전부가 개별 try/except로 감싸져 완전 내부 격리돼 있다. 기존 테스트가 webhook/L2/notification raise를 커버했고, 이번에 **SSE push·trust_pipeline raise 커버리지를 추가**해 6개 전부 확認 완료(`test_emit_story_status_changed_isolation.py`).

**② 재시도 시 부수효과가 두 번 도는가** — 아니다. 코드 트레이스: 재시도 시 `story_before`가 이미 커밋된 새 상태를 재조회 → `old_status == story.status` → 라우트의 `if old_status != story.status` 가드에 걸려 **emit 자체가 호출 안 됨**. "두 번 돈다"가 아니라 재시도 시 emit이 스킵된다(기존 `test_status_same_status_idempotent_200`과 정합).

**③ 라이브에서 실제로 밟힌 적 있는가** — 근거 0건(오르테가군 확認).

## 결론 — 결함 아님

`bulk_update_stories`의 try/except는 emit 신뢰성 문제가 아니라 **다건성**(한 item 실패가 나머지 item을 막으면 안 됨) 때문이다. 단건 경로엔 "나머지 item"이 없어 그 이유가 적용 안 된다. 두 콜사이트의 차이는 **우연이 아니라 이제 근거가 붙은 의도적 차이**다.

**동작 변경 없음** — #2176에서 데인 대로 "없는 결함을 고치는 것이 더 나쁘다"는 판단 그대로. 판정을 소스 주석(양쪽 콜사이트 + `emit_story_status_changed` docstring 계약)과 pinning 테스트로 고정했다.

## Test plan
- [x] `test_emit_story_status_changed_isolation.py`(+3): SSE push raise 격리 · trust_pipeline raise 격리 · 단건 콜사이트가 의도적으로 안 감싸졌음을 소스 고정(`#2173` 마커)
- [x] 기존 `test_stories.py`(idempotent 재시도 포함)·`test_2131_bulk_status_changed_emit.py` 32건 회귀 0
- [x] 전체 non-destructive 백엔드 스위트: `3742 passed`, 잔여 7건은 오늘 종일 재현되던 로컬 MCP stdio 환경 이슈와 동일(무관)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>