### PR TITLE
[SID:2162] SSE 재개 커서 B계열 오염 방지 게이팅

### DIFF
--- a/apps/web/src/hooks/use-chat-sse.test.tsx
+++ b/apps/web/src/hooks/use-chat-sse.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+//
+// story #2162 — useChatSse의 standalone-fallback(mux OFF/Provider 밖) 경로 재개 커서
+// 오염 방지 회귀가드. Provider 없이 렌더하면 useSseMultiplexerContext()가 null을 반환해
+// 독립 EventSource 폴백 분기를 타는 것을 이용한다(SseMultiplexerContext 기본값 null).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useChatSse } from './use-chat-sse';
+
+class FakeEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+  static instances: FakeEventSource[] = [];
+  listeners: Record<string, Array<(e: { data: string; lastEventId?: string }) => void>> = {};
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+  readyState = 0;
+  constructor(public url: string) {
+    FakeEventSource.instances.push(this);
+  }
+  addEventListener(type: string, cb: (e: { data: string; lastEventId?: string }) => void) {
+    (this.listeners[type] ??= []).push(cb);
+  }
+  close() { this.closed = true; }
+  emit(type: string, data: unknown, lastEventId?: string) {
+    for (const cb of this.listeners[type] ?? []) cb({ data: JSON.stringify(data), lastEventId });
+  }
+}
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  FakeEventSource.instances = [];
+  (globalThis as unknown as { EventSource: typeof FakeEventSource }).EventSource = FakeEventSource;
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+function Harness(props: Parameters<typeof useChatSse>[0]) {
+  useChatSse(props);
+  return null;
+}
+
+async function triggerTransientReconnect() {
+  const es = FakeEventSource.instances[FakeEventSource.instances.length - 1]!;
+  await act(async () => {
+    es.readyState = FakeEventSource.CONNECTING; // 정상 순단(#2160 세션 확認 경로 안 탐)
+    es.onerror?.();
+    await Promise.resolve();
+  });
+  await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
+}
+
+function lastReconnectUrl() {
+  return new URL(FakeEventSource.instances[FakeEventSource.instances.length - 1]!.url);
+}
+
+describe('useChatSse — 재개 커서 B계열 오염 방지(#2162, standalone-fallback)', () => {
+  it('conversation.working(B계열) id는 커서로 승격되지 않는다', async () => {
+    await act(async () => { root.render(<Harness currentTeamMemberId="m1" />); });
+    const es = FakeEventSource.instances[0]!;
+    act(() => { es.emit('conversation.working', { conversation_id: 'c1', working: [] }, 'transient-uuid-1'); });
+
+    await triggerTransientReconnect();
+
+    expect(lastReconnectUrl().searchParams.get('last_event_id')).toBeNull();
+  });
+
+  it('conversation.message_created(A계열) id는 커서로 승격된다', async () => {
+    await act(async () => { root.render(<Harness currentTeamMemberId="m1" />); });
+    const es = FakeEventSource.instances[0]!;
+    act(() => { es.emit('conversation.message_created', { id: 'msg-1' }, 'db-event-id-1'); });
+
+    await triggerTransientReconnect();
+
+    expect(lastReconnectUrl().searchParams.get('last_event_id')).toBe('db-event-id-1');
+  });
+
+  it('conversation.read(A계열) id는 커서로 승격된다', async () => {
+    await act(async () => { root.render(<Harness currentTeamMemberId="m1" />); });
+    const es = FakeEventSource.instances[0]!;
+    act(() => {
+      es.emit('conversation.read', { conversation_id: 'c1', member_id: 'm2', last_read_at: '2026-07-25T00:00:00Z', unread_count: 0 }, 'db-event-id-2');
+    });
+
+    await triggerTransientReconnect();
+
+    expect(lastReconnectUrl().searchParams.get('last_event_id')).toBe('db-event-id-2');
+  });
+
+  it('핵심 시나리오 — A계열 수신 뒤 B계열이 마지막으로 와도 커서는 A계열 id를 유지한다', async () => {
+    await act(async () => { root.render(<Harness currentTeamMemberId="m1" />); });
+    const es = FakeEventSource.instances[0]!;
+    act(() => { es.emit('conversation.message_created', { id: 'msg-1' }, 'a-series-id'); });
+    act(() => { es.emit('conversation.working', { conversation_id: 'c1', working: [] }, 'b-series-id'); });
+
+    await triggerTransientReconnect();
+
+    expect(lastReconnectUrl().searchParams.get('last_event_id')).toBe('a-series-id');
+  });
+});

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -5,6 +5,7 @@ import { useSseMultiplexerContext } from '@/components/realtime-provider';
 import { shouldSuppressDuplicateSseEvent } from '@/lib/realtime/sse-event-dedup';
 import { createReconnectBackoffState, type ReconnectBackoffState } from '@/lib/realtime/sse-reconnect-backoff';
 import { isSessionAlive } from '@/lib/realtime/sse-session-guard';
+import { isCursorEligibleEventName } from '@/lib/realtime/sse-cursor-eligibility';
 
 // chat-attach: 메시지 전송 시 첨부 메타 (BE MessageAttachment 계약과 동일).
 export interface SendAttachment {
@@ -188,21 +189,24 @@ export function useChatSse({ currentTeamMemberId, onConversationMessage, onWorki
       // S-COMM-12: canonical 이름만 리슨. server가 legacy(conversation:message)도 병행 emit하므로
       // 외부 consumer 하위호환은 server 레벨에서 처리됨 — 프론트가 둘 다 받으면 2회 발화됨.
       source.addEventListener('conversation.message_created', (e: MessageEvent) => {
-        if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
+        // story #2162 — B계열(presence·conversation.working)만 커서 승격 금지, 이 이벤트는 대상 아님.
+        if (e.lastEventId && isCursorEligibleEventName('conversation.message_created')) lastEventIdRef.current = e.lastEventId;
         handleConversationMessage(e.data as string);
       });
 
       // R2(da9d1781): conversation.working — typing 인디케이터 1.5s 폴(/conversations/{id}/working) 대체.
       // payload 가 working 목록을 실어 보내므로 refetch 없이 직접 갱신.
       source.addEventListener('conversation.working', (e: MessageEvent) => {
-        if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
+        // story #2162 — DB Event 행이 없는 B계열이라 재개 커서로 승격하지 않는다(근본 원인 자리).
+        if (e.lastEventId && isCursorEligibleEventName('conversation.working')) lastEventIdRef.current = e.lastEventId;
         handleWorking(e.data as string);
       });
 
       // story #1977: conversation.read — #1976이 본인 타 커넥션에만 전파(read-receipt 아님).
       // 다른 탭/기기에서 mark-read 하면 이 탭의 리스트 배지·GNB 총합을 서버 truth로 자가정정.
       source.addEventListener('conversation.read', (e: MessageEvent) => {
-        if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
+        // story #2162 — B계열만 커서 승격 금지, 이 이벤트는 대상 아님.
+        if (e.lastEventId && isCursorEligibleEventName('conversation.read')) lastEventIdRef.current = e.lastEventId;
         handleConversationRead(e.data as string);
       });
     }

--- a/apps/web/src/hooks/use-sse-notifications.test.tsx
+++ b/apps/web/src/hooks/use-sse-notifications.test.tsx
@@ -9,12 +9,16 @@ import { createRoot, type Root } from 'react-dom/client';
 import { useSseNotifications, type SseEventNotification } from './use-sse-notifications';
 
 class FakeEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
   static instances: FakeEventSource[] = [];
   listeners: Record<string, Array<(e: { data: string; lastEventId?: string }) => void>> = {};
   onopen: (() => void) | null = null;
   onmessage: ((e: { data: string; lastEventId?: string }) => void) | null = null;
   onerror: (() => void) | null = null;
   closed = false;
+  readyState = 0;
   constructor(public url: string, _opts?: unknown) {
     FakeEventSource.instances.push(this);
   }
@@ -22,8 +26,8 @@ class FakeEventSource {
     (this.listeners[type] ??= []).push(cb);
   }
   close() { this.closed = true; }
-  emit(type: string, data: string) {
-    for (const cb of this.listeners[type] ?? []) cb({ data });
+  emit(type: string, data: string, lastEventId?: string) {
+    for (const cb of this.listeners[type] ?? []) cb({ data, lastEventId });
   }
 }
 
@@ -111,5 +115,51 @@ describe('useSseNotifications — extraEventNames/onExtraEvent (additive, 9ef0f9
     const es = FakeEventSource.instances[0]!;
     // 기존 알림 채널도 여전히 안전하게(콜백 없어도 크래시 0).
     expect(() => act(() => { es.emit('notification', JSON.stringify({})); })).not.toThrow();
+  });
+});
+
+// story #2162 — 재개 커서(last_event_id) B계열 오염 방지의 standalone-fallback 경로 회귀가드.
+describe('useSseNotifications — 재개 커서 B계열 오염 방지(#2162)', () => {
+  async function triggerTransientReconnect() {
+    const es = FakeEventSource.instances[FakeEventSource.instances.length - 1]!;
+    await act(async () => {
+      es.readyState = FakeEventSource.CONNECTING; // 정상 순단(#2160 세션 확認 경로 안 탐)
+      es.onerror?.();
+      await Promise.resolve();
+    });
+    await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
+  }
+
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('extraEventNames로 받은 B계열(conversation.working) id는 커서로 승격되지 않는다', async () => {
+    await act(async () => {
+      root.render(
+        <Harness memberId="m1" extraEventNames={['conversation.working']} onExtraEvent={vi.fn()} />,
+      );
+    });
+    const es = FakeEventSource.instances[0]!;
+    act(() => { es.emit('conversation.working', JSON.stringify({}), 'transient-uuid-1'); });
+
+    await triggerTransientReconnect();
+
+    const reconnectUrl = new URL(FakeEventSource.instances[FakeEventSource.instances.length - 1]!.url);
+    expect(reconnectUrl.searchParams.get('last_event_id')).toBeNull();
+  });
+
+  it('extraEventNames로 받은 A계열(story.trust_stage_changed) id는 커서로 승격된다', async () => {
+    await act(async () => {
+      root.render(
+        <Harness memberId="m1" extraEventNames={['story.trust_stage_changed']} onExtraEvent={vi.fn()} />,
+      );
+    });
+    const es = FakeEventSource.instances[0]!;
+    act(() => { es.emit('story.trust_stage_changed', JSON.stringify(TRUST_STAGE_PAYLOAD), 'db-event-id-1'); });
+
+    await triggerTransientReconnect();
+
+    const reconnectUrl = new URL(FakeEventSource.instances[FakeEventSource.instances.length - 1]!.url);
+    expect(reconnectUrl.searchParams.get('last_event_id')).toBe('db-event-id-1');
   });
 });

--- a/apps/web/src/hooks/use-sse-notifications.ts
+++ b/apps/web/src/hooks/use-sse-notifications.ts
@@ -5,6 +5,7 @@ import { useSseMultiplexerContext } from '@/components/realtime-provider';
 import { shouldSuppressDuplicateSseEvent } from '@/lib/realtime/sse-event-dedup';
 import { createReconnectBackoffState } from '@/lib/realtime/sse-reconnect-backoff';
 import { isSessionAlive } from '@/lib/realtime/sse-session-guard';
+import { isCursorEligibleEventName } from '@/lib/realtime/sse-cursor-eligibility';
 
 export interface SseEventNotification {
   id?: string;
@@ -114,7 +115,8 @@ export function useSseNotifications({
     };
 
     const handleExtraEventStandalone = (eventName: string, raw: string, eventId?: string) => {
-      if (eventId) lastEventId = eventId;
+      // story #2162 — B계열(presence·conversation.working)만 커서 승격 금지.
+      if (eventId && isCursorEligibleEventName(eventName)) lastEventId = eventId;
       handleExtraEvent(eventName, raw);
     };
 

--- a/apps/web/src/lib/realtime/sse-cursor-eligibility.test.ts
+++ b/apps/web/src/lib/realtime/sse-cursor-eligibility.test.ts
@@ -1,0 +1,25 @@
+// story #2162 — 재개 커서 오염 방지의 판정 함수. 알려진 B계열(presence·conversation.working)만
+// 커서 승격을 막고, 그 외(이름 없는 채널 포함)는 과거 동작 그대로 승격 허용(무회귀).
+import { describe, expect, it } from 'vitest';
+import { isCursorEligibleEventName } from './sse-cursor-eligibility';
+
+describe('isCursorEligibleEventName', () => {
+  it('알려진 B계열(presence)은 커서 승격 불가', () => {
+    expect(isCursorEligibleEventName('presence')).toBe(false);
+  });
+
+  it('알려진 B계열(conversation.working)은 커서 승격 불가', () => {
+    expect(isCursorEligibleEventName('conversation.working')).toBe(false);
+  });
+
+  it('그 외 named 이벤트(예: story.status_changed)는 승격 가능', () => {
+    expect(isCursorEligibleEventName('story.status_changed')).toBe(true);
+    expect(isCursorEligibleEventName('story.assignee_changed')).toBe(true);
+    expect(isCursorEligibleEventName('conversation.message_created')).toBe(true);
+    expect(isCursorEligibleEventName('conversation.read')).toBe(true);
+  });
+
+  it('이름 없는 채널(undefined)은 과거 동작 그대로 승격 가능(무회귀)', () => {
+    expect(isCursorEligibleEventName(undefined)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/realtime/sse-cursor-eligibility.ts
+++ b/apps/web/src/lib/realtime/sse-cursor-eligibility.ts
@@ -1,0 +1,32 @@
+/**
+ * story #2162 — 재개 커서(`last_event_id`) 오염 방지.
+ *
+ * `presence`·`conversation.working`처럼 DB `Event` 행이 없는 transient push(서버가 `uuid4()`를
+ * SSE 프레임 native id로 붙여 내보내는 것 — dedup이 보는 payload의 `event_id` 필드와는 별개
+ * 개념, 그건 sse-event-dedup.ts)는 재연결 시 `last_event_id`로 그대로 실려나가도 서버가 그
+ * id를 `Event` 행으로 못 풀어 시간 기준점이 None이 된다. 그런데 "값은 있으니 초기연결이
+ * 아니다"로 판정돼 INITIAL 상한도 안 걸리는 채로 시간 필터 자체가 안 붙어 최근 50건이
+ * 통째로 재전송된다(#2162 근본 — B계열은 원래도 이랬으나 #2158로 재생 대상이 되며 실제
+ * 하중을 받기 시작함).
+ *
+ * ⇒ 마지막 수신 이벤트가 B계열이면 그 프레임의 native id(`e.lastEventId`)를 커서로 승격하지
+ * 않는다 — B계열이 오기 전 마지막으로 승격된(A계열) id가 그대로 유지되어, 다음 재연결도
+ * 해소 가능한 커서로 나간다.
+ *
+ * ⚠️ 알려진 B계열만 명시한다(추측 금지 — story #2162 조사에서 실제로 확認된 두 이름뿐이다).
+ * 새로운 transient(DB-row 없는) named 이벤트를 추가할 땐 **반드시 여기에도 추가할 것** —
+ * 안 그러면 목록에 없는 이름은 전부 "커서 승격 가능"으로 취급돼 이 버그가 조용히 재발한다.
+ */
+const TRANSIENT_EVENT_NAMES = new Set(['presence', 'conversation.working']);
+
+/**
+ * true면 이 이벤트의 네이티브 SSE id를 재개 커서로 승격해도 안전(DB로 해소 가능하다고 알려짐
+ * 또는 미분류). false면 승격 금지(알려진 B계열).
+ *
+ * eventName이 없는 경우(이름 없는 기본 `message` 채널)는 과거 동작 그대로 승격 허용 —
+ * 지금까지 그 경로에서 문제가 보고된 적이 없어 무회귀를 우선한다.
+ */
+export function isCursorEligibleEventName(eventName: string | undefined): boolean {
+  if (!eventName) return true;
+  return !TRANSIENT_EVENT_NAMES.has(eventName);
+}

--- a/apps/web/src/lib/realtime/sse-multiplexer.test.tsx
+++ b/apps/web/src/lib/realtime/sse-multiplexer.test.tsx
@@ -259,4 +259,64 @@ describe('useSseMultiplexer — story #2078', () => {
       vi.useRealTimers();
     });
   });
+
+  // story #2162 — 마지막 수신이 B계열(presence·conversation.working, DB Event 행 없는 transient
+  // push)이면 재개 커서(last_event_id)로 승격되면 안 된다 — 안 그러면 서버가 그 id를 해소 못 해
+  // 시간 기준점을 잃고 재연결마다 최근 50건을 통째로 재전송한다(#2162 근본).
+  describe('재개 커서 B계열 오염 방지(#2162)', () => {
+    async function triggerTransientReconnect() {
+      await act(async () => {
+        instances[instances.length - 1]!.readyState = 0; // CONNECTING — 정상 순단(세션 확認 불필요)
+        instances[instances.length - 1]!.onerror?.();
+        await Promise.resolve();
+      });
+      await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
+    }
+
+    it('B계열(presence) id는 커서로 승격되지 않는다 — 재연결 URL에 안 실린다', async () => {
+      vi.useFakeTimers();
+      await act(async () => { root.render(<Harness memberId="me-1" enabled />); });
+      // attachIfNeeded는 subscribe 시점에만 fake EventSource.addEventListener를 실제로 건다 —
+      // subscribe 없이 dispatchNamed(fake)만 부르면 리스너가 없어 아무 일도 안 일어나는(공허한
+      // 통과) 자리라, 먼저 구독해서 진짜 훅의 dispatchNamed 경로를 태운다.
+      await act(async () => { handle!.subscribe('presence', vi.fn()); });
+      act(() => { dispatchNamed(instances[0]!, 'presence', {}, 'transient-uuid-1'); });
+
+      await triggerTransientReconnect();
+
+      const reconnectUrl = new URL(instances[instances.length - 1]!.url, 'http://localhost');
+      expect(reconnectUrl.searchParams.get('last_event_id')).toBeNull();
+      vi.useRealTimers();
+    });
+
+    it('A계열(story.status_changed) id는 커서로 승격된다 — 재연결 URL에 실린다', async () => {
+      vi.useFakeTimers();
+      await act(async () => { root.render(<Harness memberId="me-1" enabled />); });
+      await act(async () => { handle!.subscribe('story.status_changed', vi.fn()); });
+      act(() => { dispatchNamed(instances[0]!, 'story.status_changed', {}, 'db-event-id-1'); });
+
+      await triggerTransientReconnect();
+
+      const reconnectUrl = new URL(instances[instances.length - 1]!.url, 'http://localhost');
+      expect(reconnectUrl.searchParams.get('last_event_id')).toBe('db-event-id-1');
+      vi.useRealTimers();
+    });
+
+    it('핵심 시나리오 — A계열 수신 뒤 B계열이 마지막으로 와도 커서는 A계열 id를 유지한다', async () => {
+      vi.useFakeTimers();
+      await act(async () => { root.render(<Harness memberId="me-1" enabled />); });
+      await act(async () => {
+        handle!.subscribe('story.status_changed', vi.fn());
+        handle!.subscribe('presence', vi.fn());
+      });
+      act(() => { dispatchNamed(instances[0]!, 'story.status_changed', {}, 'a-series-id'); });
+      act(() => { dispatchNamed(instances[0]!, 'presence', {}, 'b-series-id'); }); // 마지막 수신 = B계열
+
+      await triggerTransientReconnect();
+
+      const reconnectUrl = new URL(instances[instances.length - 1]!.url, 'http://localhost');
+      expect(reconnectUrl.searchParams.get('last_event_id')).toBe('a-series-id'); // B계열에 안 덮임
+      vi.useRealTimers();
+    });
+  });
 });

--- a/apps/web/src/lib/realtime/sse-multiplexer.ts
+++ b/apps/web/src/lib/realtime/sse-multiplexer.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createReconnectBackoffState } from './sse-reconnect-backoff';
 import { isSessionAlive } from './sse-session-guard';
+import { isCursorEligibleEventName } from './sse-cursor-eligibility';
 
 /**
  * story #2078(E-ARCH 0단계) — presence·notification·chat이 각자 EventSource를 열어 탭당 장수
@@ -62,7 +63,9 @@ export function useSseMultiplexer(memberId: string | undefined, enabled: boolean
   useEffect(() => { memberIdRef.current = memberId; }, [memberId]);
 
   const dispatchNamed = useCallback((eventName: string, data: string, eventId?: string) => {
-    if (eventId) lastEventIdRef.current = eventId;
+    // story #2162 — presence·conversation.working처럼 DB Event 행이 없는 B계열은 재개 커서로
+    // 승격하지 않는다(안 그러면 재연결마다 서버가 시간기준점을 못 잡아 최근 50건을 통째로 재전송).
+    if (eventId && isCursorEligibleEventName(eventName)) lastEventIdRef.current = eventId;
     for (const handler of namedSubscribersRef.current.get(eventName) ?? []) handler(data, eventId);
   }, []);
 


### PR DESCRIPTION
## 배경
재연결 시 서버에 실어보내는 재개 커서(`last_event_id`)가 `presence`/`conversation.working`처럼 DB `Event` 행이 없는 transient push의 id로 갱신되면, 서버가 그 id를 시간기준점으로 해소하지 못해 재연결마다 최근 50건을 통째로 재전송하던 결함.

**그라운딩(구현 前 확認)**: dedup(`sse-event-dedup.ts`)의 `event_id`(JSON payload 필드)와 재개 커서를 만드는 native SSE `id:`(`MessageEvent.lastEventId`)는 서로 다른 개념 — dedup은 이 결함과 무관, 커서 갱신 지점만 정확히 손봐야 함을 코드로 확認.

## 변경
- `sse-cursor-eligibility.ts` 신설 — `isCursorEligibleEventName()`. denylist는 **확인된 것만**(`presence`, `conversation.working`) — `story.status_changed`/`assignee_changed`/`position_changed` 등은 transient임이 확인 안 됐으므로 추측 확장하지 않음.
- 적용 지점 3곳(저장소 전수 grep으로 확認, 총 4개 소비 파일 중 3곳에 적용 대상 존재):
  - `sse-multiplexer.ts` `dispatchNamed`
  - `use-chat-sse.ts` named `addEventListener` 3개(`conversation.message_created`/`working`/`read`)
  - `use-sse-notifications.ts` `handleExtraEventStandalone`
  - `use-team-presence.ts`는 `last_event_id` 추적 자체가 없어 변경 불필요(grep 확認, 별도 손 안 댐)
- unnamed `message` 채널(`es.onmessage`/`handleDataStandalone`)은 이벤트명 컨텍스트가 없어 기존 동작 그대로 유지(무회귀 — 지금까지 문제 관측 없는 자리는 안 건드림).

## 회귀테스트 + 뮤테이션 셀프체크
3개 컨슈머 파일 전부에 B계열/A계열/혼합(A계열 뒤 B계열이 마지막으로 와도 커서 유지) 시나리오 신규 — 재연결 시 구성된 URL의 `last_event_id`로 검증:
- `sse-cursor-eligibility.test.ts`(순수 함수 5케이스)
- `sse-multiplexer.test.tsx` +3
- `use-chat-sse.test.tsx`(신규 파일, +4 — 이 훅은 기존 테스트 자체가 없었음)
- `use-sse-notifications.test.tsx` +2

**뮤테이션 셀프체크**: 3개 파일(`sse-multiplexer.ts`/`use-chat-sse.ts`/`use-sse-notifications.ts`) 전부 게이트를 일시 제거 → 관련 테스트가 정확히 RED로 떨어지는 것 확認 → 복구 후 GREEN.

## 검증
- type-check PASS / lint(대상 파일 전체) 0 / build EXIT 0
- vitest 297 files 전건 PASS(신규 14건 포함). ⚠️풀스위트 1회차에서 `kanban-board.test.tsx` 15건이 실패했으나 단독 실행·2회차 재실행 둘 다 정상 — PR#2481에서도 동일하게 관측된 **이 PR과 무관한 기존 격리성 플레이키니스**(diff는 realtime 관련 4개 파일만 건드림, kanban-board 접촉 0).

## ⛔ done-gate — 유닛 초록으로 안 닫음
스토리 AC 명시대로, 이 수정의 실효은 **라이브 "재연결 1회당 재전송 건수"** before/after 비교로만 판정됩니다. 배포 전이라 after 측정이 아직 불가 — 머지·배포 후 라이브 측정을 이어서 하겠습니다(이전 대화에서 캡처해 둔 "before" 기준선 재사용 여부는 오르테가군 확認 필요 — #2183 배포로 재연결 동역학 자체가 바뀌었을 수 있어 재측정이 더 안전할 수 있음).

## Test plan
- [x] 회귀테스트 14건 + 뮤테이션 셀프체크(3파일 전부 RED 확認 후 복구)
- [ ] 배포 후 라이브 재연결 재전송 건수 before/after 비교(스토리 done-gate)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>