### PR TITLE
fix(#2138): outbox+dual_publish/dispatch 동시활성화 fail-fast startup 가드

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -46,6 +46,7 @@ async def lifespan(app: FastAPI):
     from app.routers.auth_firebase_internal import check_internal_secret_config
     from app.routers.cron import check_cron_secret_config
     from app.routers.verdict_capture import warn_if_webhook_secret_misconfigured
+    from app.services.event_broker import check_outbox_dual_publish_config
     from app.services.firebase_verifier import check_mobile_app_check_config
     from app.services.pg_pubsub import check_listen_config, listen_loop
 
@@ -82,6 +83,7 @@ async def lifespan(app: FastAPI):
         check_listen_config()  # ee7794eb ③ fail-closed: DB_PGBOUNCER on + DATABASE_URL_DIRECT 없으면 startup raise.
     check_internal_secret_config()  # 산티아고 §9 finding 4: non-local + 시크릿 미설정 fail-closed.
     check_cron_secret_config()  # story #2072: non-local + CRON_SECRET 미설정 fail-closed.
+    check_outbox_dual_publish_config()  # story #2138: outbox + dual_publish/dispatch 동시 fail-closed.
     check_mobile_app_check_config()  # 산티아고 §9 finding 1: mobile 발급 on + App Check 미필수 fail-closed.
     # story bea25062: cutover 존재-캐시는 의도적으로 startup에서 warm 안 함(자체 발견 —
     # TestClient(app)로 lifespan을 태우는 기존 SSE 테스트들이 라우트 전용으로 짜둔 유한한

--- a/backend/app/services/event_broker.py
+++ b/backend/app/services/event_broker.py
@@ -465,6 +465,51 @@ async def redis_consume_loop() -> None:
                     pass
 
 
+def check_outbox_dual_publish_config(s=None) -> None:
+    """fail-closed startup 가드(story #2138, 까심 전수 확認) — `check_cron_secret_config`
+    (#2072)·`check_listen_config`(ee7794eb)와 동형(main lifespan이 호출 대상). 이전엔 이
+    위험 조합을 막는 게 `outbox_dispatcher_loop()`의 docstring 경고문 한 줄뿐이었다
+    (model_validator·startup assertion·런타임 체크 전부 0건 — 까심 전수 확認) — 설정
+    실수가 배포를 통과해 런타임에야 중복배달로 드러나는 구조였다. 런타임 증상보다 먼저,
+    더 시끄럽게 막는 쪽이 안전하다.
+
+    두 위험 조합을 각각 막는다:
+    ① `event_broker_redis_dual_publish_enabled` + `event_broker_outbox_enabled`:
+       같은 논리적 이벤트가 Redis에 두 번(즉시 shadow-publish + 나중 outbox dispatch)
+       발행된다 — 서로 다른 `_broker_event_id`(즉시 경로는 uuid4, outbox 경로는 row.id)를
+       써서 dedup도 안 걸린다(outbox_dispatcher_loop() docstring 참조).
+    ② `event_broker_redis_dispatch_enabled` + `event_broker_outbox_enabled`:
+       outbox로 발행된 이벤트는 `instance_id`가 없어 self-skip이 안 돼 중복 dispatch(실제
+       전달) 위험이 있다(app/core/config.py의 event_broker_redis_dispatch_enabled 주석 참조).
+
+    outbox는 dual-publish/dispatch를 **대체**하는 것이지 병행하는 게 아니다(오르테가군
+    시퀀싱 — dual-publish→shadow-consume→outbox 전환→LISTEN 제거는 순차, 동시 아님).
+
+    ⚠️ 이 어서션은 현재 아무것도 안 막는 상태로 들어간다(까심 전수 확認 — 라이브 어디에도
+    outbox가 켜져 있지 않고, 코드 기본값도 전부 False) = 배포 리스크 0. 그게 지금 넣기 좋은
+    이유이기도 하다 — 나중에 실제로 outbox 전환이 시작될 때는 이미 가드가 있는 채로 시작한다.
+    """
+    if s is None:
+        from app.core.config import settings as s
+    if not s.event_broker_outbox_enabled:
+        return
+    if s.event_broker_redis_dual_publish_enabled:
+        raise RuntimeError(
+            "event_broker_outbox_enabled=true인데 event_broker_redis_dual_publish_enabled도"
+            "=true — 같은 이벤트가 Redis에 두 번(즉시 shadow-publish + 나중 outbox dispatch)"
+            " 발행되고 서로 다른 broker_event_id를 써서 dedup도 안 걸린다(중복배달, story"
+            " #2138). outbox는 dual-publish를 대체하는 것이지 병행하는 게 아니다 — 전환 중이면"
+            " dual_publish를 먼저 끄고 outbox를 켤 것."
+        )
+    if s.event_broker_redis_dispatch_enabled:
+        raise RuntimeError(
+            "event_broker_outbox_enabled=true인데 event_broker_redis_dispatch_enabled도"
+            "=true — outbox로 발행된 이벤트는 instance_id가 없어 self-skip이 안 돼 중복"
+            " dispatch(실 전달) 위험이 있다(story #2138). outbox는 dispatch 경로를 대체하는"
+            " 것이지 병행하는 게 아니다 — 전환 중이면 dispatch를 먼저 끄고 outbox를 켤 것."
+        )
+
+
 # ─── Outbox dispatcher (realtime gateway 전용, event_broker_outbox_enabled 게이트) ────────
 
 _OUTBOX_BATCH_SIZE = 50

--- a/backend/tests/test_2138_outbox_dual_publish_guard.py
+++ b/backend/tests/test_2138_outbox_dual_publish_guard.py
@@ -1,0 +1,88 @@
+"""story #2138(2026-07-24, 까심 전수 확認 근거) — outbox+dual_publish/dispatch 동시 활성화
+fail-closed startup 가드.
+
+이전엔 이 위험 조합을 막는 게 outbox_dispatcher_loop() docstring 경고문 한 줄뿐이었다
+(model_validator·startup assertion·런타임 체크 전부 0건). `check_cron_secret_config`(#2072)·
+`check_listen_config`(ee7794eb)와 동형 — main lifespan이 호출하는 fail-closed startup 가드로
+승격한다.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.event_broker import check_outbox_dual_publish_config
+
+
+def _s(**overrides):
+    base = {
+        "event_broker_outbox_enabled": False,
+        "event_broker_redis_dual_publish_enabled": False,
+        "event_broker_redis_dispatch_enabled": False,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_ok_when_outbox_off_regardless_of_others():
+    # outbox 자체가 꺼져 있으면 다른 플래그가 뭐든 무해(무회귀 — 켜기 전엔 이 가드 자체가 no-op).
+    check_outbox_dual_publish_config(_s(
+        event_broker_outbox_enabled=False,
+        event_broker_redis_dual_publish_enabled=True,
+        event_broker_redis_dispatch_enabled=True,
+    ))
+
+
+def test_ok_when_outbox_alone():
+    check_outbox_dual_publish_config(_s(event_broker_outbox_enabled=True))
+
+
+def test_raises_when_outbox_and_dual_publish_both_on():
+    with pytest.raises(RuntimeError, match="dual_publish"):
+        check_outbox_dual_publish_config(_s(
+            event_broker_outbox_enabled=True,
+            event_broker_redis_dual_publish_enabled=True,
+        ))
+
+
+def test_raises_when_outbox_and_dispatch_both_on():
+    with pytest.raises(RuntimeError, match="dispatch"):
+        check_outbox_dual_publish_config(_s(
+            event_broker_outbox_enabled=True,
+            event_broker_redis_dispatch_enabled=True,
+        ))
+
+
+def test_raises_when_all_three_on():
+    """dual_publish 위반이 dispatch보다 먼저 걸리는지(둘 다 위험하지만 최소 1개는 반드시
+    잡아야 하고, 어느 쪽이든 fail-closed면 충분 — 순서 자체를 계약으로 강제하진 않음)."""
+    with pytest.raises(RuntimeError):
+        check_outbox_dual_publish_config(_s(
+            event_broker_outbox_enabled=True,
+            event_broker_redis_dual_publish_enabled=True,
+            event_broker_redis_dispatch_enabled=True,
+        ))
+
+
+def test_startup_wired_in_main_lifespan():
+    """main.py lifespan이 실제로 이 가드를 부르는지 소스 고정 — #2072/ee7794eb와 같은
+    "만들었는데 안 부름" 패턴 재발 방지."""
+    import inspect
+    import app.main as main_mod
+
+    source = inspect.getsource(main_mod.lifespan)
+    assert "check_outbox_dual_publish_config()" in source
+
+
+def test_error_message_explains_why_not_just_that():
+    """오르테가군 지시 — 어서션 문구에 «무엇을 막는지·왜 위험한지»가 있어야(다음 사람이
+    "왜 못 켜지"만 알고 "왜 위험한지"를 모르면 우회하려 들 것이라는 지적)."""
+    with pytest.raises(RuntimeError) as exc_info:
+        check_outbox_dual_publish_config(_s(
+            event_broker_outbox_enabled=True,
+            event_broker_redis_dual_publish_enabled=True,
+        ))
+    msg = str(exc_info.value)
+    assert "중복배달" in msg or "두 번" in msg  # 왜 위험한지
+    assert "대체" in msg or "먼저 끄고" in msg  # 어떻게 풀지


### PR DESCRIPTION
## Summary
까심 전수 확認: `EVENT_BROKER_OUTBOX_ENABLED`와 dual_publish/dispatch를 동시에 켜면 중복배달인데, 그걸 막는 게 `outbox_dispatcher_loop()` docstring 경고문 한 줄뿐이었다(model_validator·startup assertion·런타임 체크 전부 0건). 설정 실수가 배포를 통과해 런타임에야 중복배달로 드러나는 구조였다.

`check_cron_secret_config`(`#2072`)·`check_listen_config`(`ee7794eb`)와 동형 fail-closed startup 가드로 승격 — main lifespan에서 호출.

## 두 위험 조합 모두 확認 후 가드
그라운딩 중 문서화된 위험 조합이 **하나가 아니라 둘**임을 발견:
1. `event_broker_redis_dual_publish_enabled` + `outbox` — 같은 이벤트가 Redis에 두 번(즉시 shadow-publish + 나중 outbox dispatch) 발행, 서로 다른 `broker_event_id`라 dedup도 안 걸림(`outbox_dispatcher_loop()` docstring).
2. `event_broker_redis_dispatch_enabled` + `outbox` — outbox 발행분은 `instance_id`가 없어 self-skip이 안 돼 중복 dispatch(실 전달) 위험(`config.py`의 `event_broker_redis_dispatch_enabled` 주석에서 발견).

어서션 문구에 "무엇을 막는지·왜 위험한지·어떻게 풀지"를 명시(오르테가군 지시 — "왜 못 켜지"만 알고 "왜 위험한지" 모르면 우회하려 든다).

## 라이브 검증
mock이 아니라 실 `settings` 객체로 직접 호출해 현재 모든 플래그 기본값 False라 no-op임을 확認(까심의 "배포 리스크 0" 판단과 일치) — 지금이 넣기 좋은 이유이기도 하다.

## Test plan
- [x] `test_2138_outbox_dual_publish_guard.py`(신규, 7): outbox off면 무해 · outbox 단독 무해 · dual_publish 조합 raise · dispatch 조합 raise · 셋 다 켜도 raise · main lifespan 배선 소스 고정 · 에러 메시지가 위험 이유+해법을 담는지
- [x] 실 settings 객체로 직접 호출해 no-op 확認(mock 아님)
- [x] 관련 lifespan/event_broker 회귀 테스트(`test_lifespan_engine_dispose_33e0c681`·`test_s20`·`test_2078_publish_atomic`·`test_e_auth_rebuild_phase1_s5_startup_guards`) 38건 회귀 0
- [x] 전체 non-destructive 백엔드 스위트: `3746 passed`, 잔여 7건은 오늘 종일 재현되던 로컬 MCP stdio 환경 이슈와 동일(무관)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>