### PR TITLE
[SID:2183] wall-clock 상한 추가 — request.signal 단독 실패 확認됨

### DIFF
--- a/apps/web/src/app/api/event-stream/route.test.ts
+++ b/apps/web/src/app/api/event-stream/route.test.ts
@@ -137,3 +137,64 @@ describe('/api/event-stream — request.signal 전파(story #2183, 좀비 upstre
     expect(text).toBe('data: hello\n\n'); // 스트림이 잘리지 않고 끝까지 통과함
   });
 });
+
+// story #2183 후속(2026-07-25) — request.signal 단독으로는 Cloud Run의 강제 종료를 못 잡는다는
+// 것이 라이브 실측으로 확認됐다(착지 前 n=300 전부 3601.0s → 착지 後에도 617~658s, ~60s가
+// 나왔어야 했다). wall-clock 캡을 본체로 얹은 회귀가드 — AbortSignal.timeout은 vitest fake
+// timer로 제어가 안 되므로(Node 내부 타이머라 실측 확認됨) AbortSignal.timeout 자체를 스파이/
+// 교체해 "캡이 걸렸을 때"의 배선과 거동을 실시간 대기 없이 검증한다.
+describe('/api/event-stream — wall-clock 상한(story #2183 후속, signal 단독 실패의 회귀가드)', () => {
+  beforeEach(() => {
+    h.getServerSession.mockReset();
+    h.getServerSession.mockResolvedValue({ access_token: 'tok' });
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('AbortSignal.timeout(55000)으로 wall-clock 캡을 건다 — 상수값 고정', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 200 })));
+
+    await GET(new Request('http://localhost/api/event-stream') as unknown as Parameters<typeof GET>[0]);
+
+    expect(timeoutSpy).toHaveBeenCalledWith(55_000);
+  });
+
+  it('wall-clock 캡이 fire되면(request.signal은 안 fire된 채로도) 499로 조용히 정리한다', async () => {
+    // AbortSignal.timeout을 이미 abort된 신호로 교체 — "캡 도달" 시점을 실시간 대기 없이 재현.
+    const timeoutController = new AbortController();
+    const timeoutError = Object.assign(new Error('The operation was aborted due to timeout'), { name: 'TimeoutError' });
+    timeoutController.abort(timeoutError);
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal);
+
+    vi.stubGlobal('fetch', vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.signal?.aborted) throw init.signal.reason;
+      return new Response('', { status: 200 });
+    }));
+    const controller = new AbortController(); // request.signal 자체는 살아있음(클라 안 끊음)
+    const req = new Request('http://localhost/api/event-stream', { signal: controller.signal });
+
+    const res = await GET(req as unknown as Parameters<typeof GET>[0]);
+
+    expect(res.status).toBe(499);
+    expect(controller.signal.aborted).toBe(false); // 클라는 안 끊었다 — 캡이 본체로 작동한 것
+  });
+
+  it('request.signal 배선도 여전히 살아있다(캡과 별개 경로) — #2183 원래 회귀가드 유지', async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => new Response('', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const controller = new AbortController();
+    const req = new Request('http://localhost/api/event-stream', { signal: controller.signal });
+
+    await GET(req as unknown as Parameters<typeof GET>[0]);
+
+    const passedSignal = fetchMock.mock.calls[0]?.[1]?.signal;
+    expect(passedSignal?.aborted).toBe(false);
+    controller.abort();
+    expect(passedSignal?.aborted).toBe(true);
+  });
+});

--- a/apps/web/src/app/api/event-stream/route.ts
+++ b/apps/web/src/app/api/event-stream/route.ts
@@ -8,6 +8,22 @@ const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://loca
 // "되돌리면 원복"(env 값을 비우면 코드 변경·재배포 없이 즉시 원래 경로로 복귀).
 const EVENT_STREAM_UPSTREAM_URL = () => process.env['REALTIME_URL'] || FASTAPI_URL();
 
+// story #2183 후속(2026-07-25) — request.signal 단독으로는 안 잡힌다는 것이 배포 후 라이브
+// 실측으로 확認됐다(착지 前 점유 n=300 전부 정확히 3601.0s → 착지 後에도 617~658s, ~60s가
+// 나왔어야 했다). Cloud Run이 다운스트림(이 라우트 자신에 대한 요청)을 강제로 끊어도 Next
+// 런타임이 그 종료를 항상 request.signal로 전파해 주지는 않는 것으로 판정 — "생명 판정 신호는
+// 판정 대상이 스스로 갱신할 수 없는 것이어야 한다"(#2128과 동일 원리)에 따라 signal 대신
+// wall-clock을 본체로 삼는다. request.signal 배선은 지우지 않는다(틀린 코드는 아님 — 런타임이
+// 나중에 고쳐지면 그때부터 더 빨리 반응한다) — 이 라우트 자신에 대한 다운스트림 요청이 어차피
+// 프론트 Cloud Run 서비스 자신의 timeoutSeconds(dev 확認값: 60s)로 강제 종료되므로, upstream은
+// 그보다 반드시 먼저 닫혀야 한다(≡ "프록시의 upstream은 프록시 자신의 수명보다 오래 살 수
+// 없다"). 55s = 60s − 5s: getServerSession()·URL 구성 등 fetch 호출 前 처리비용만큼 타이머
+// 시작이 다운스트림 요청 시작보다 늦으므로 그 지연을 흡수하는 안전마진.
+// ⚠️무너지는 조건: 프론트 Cloud Run 서비스의 timeoutSeconds가 60s가 아니게 되면 이 상수도
+// 같이 바뀌어야 한다 — 값이 코드(여기)와 인프라 설정(Cloud Run 서비스 config) 두 곳에
+// 살게 되는 것 — 단일 소스로 묶는 것은 인프라 축이라 이 스토리 스코프 밖으로 남긴다.
+const UPSTREAM_HARD_TIMEOUT_MS = 55_000;
+
 export async function GET(request: NextRequest): Promise<Response> {
   const session = await getServerSession();
   if (!session?.access_token) {
@@ -28,17 +44,19 @@ export async function GET(request: NextRequest): Promise<Response> {
   const upstreamHeaders: Record<string, string> = { Authorization: `Bearer ${session.access_token}` };
   if (lastEventId) upstreamHeaders['Last-Event-ID'] = lastEventId;
 
-  // story #2183 — signal이 없으면 이 요청(클라 연결 종료·프론트 자신의 Cloud Run 요청이 60초로
-  // 잘리는 것 포함)이 끝나도 upstream(realtime-gateway) 커넥션은 안 끊긴다. 프론트가 60초마다
-  // 클라 쪽만 끊고 재연결하는 사이클이라, 재연결 1회마다 좀비 upstream 커넥션이 하나씩 쌓여
-  // realtime 타임아웃(3600s) 상한까지 살아있는다 — 탭 1개당 누적 최대 ~60개. request.signal을
-  // 넘겨 다운스트림이 끝나면 upstream fetch도 즉시 abort되게 한다.
+  // story #2183 — signal이 없으면 이 요청(클라 연결 종료 포함)이 끝나도 upstream(realtime-
+  // gateway) 커넥션은 안 끊긴다. request.signal을 넘겨 다운스트림이 끝나면 upstream fetch도
+  // abort되게 한다 — 다만 이것만으로는 부족하다는 것이 라이브로 확認됐다(위 상수 주석 참고).
+  // wall-clock 캡을 같이 걸어 본체로 삼고, signal은 부수 경로로 유지한다(#2128과 동형 2층 구조).
+  const upstreamSignal = AbortSignal.any([request.signal, AbortSignal.timeout(UPSTREAM_HARD_TIMEOUT_MS)]);
+
   let upstream: Response;
   try {
-    upstream = await fetch(upstreamUrl.toString(), { headers: upstreamHeaders, signal: request.signal });
+    upstream = await fetch(upstreamUrl.toString(), { headers: upstreamHeaders, signal: upstreamSignal });
   } catch (err) {
-    if (err instanceof Error && err.name === 'AbortError') {
-      // 클라가 이미 연결을 끊은 뒤라 응답을 볼 대상이 없다 — 조용히 빈 응답으로 정리.
+    // AbortError = request.signal(클라 종료) · TimeoutError = wall-clock 캡(본체) — 실측 확認됨,
+    // 둘 다 "클라가 이미 없거나 이 요청의 최대 수명을 넘겼다"는 뜻이라 응답 볼 대상이 없다.
+    if (err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')) {
       return new Response(null, { status: 499 });
     }
     throw err;


### PR DESCRIPTION
## 배경 — #2183(PR#2481) 배포 후 라이브 실측
```
기준선(착지 前)  n=300  min=p50=p90=max = 3601.0   ← 편차 0
착지 後           n=5    min=617.1  p50=619.9  max=658.5
```
숫자는 내려갔지만 이건 #2128(수명 상한 600s+jitter)이 잡은 것 — #2183이 들었으면 ~60초가 나왔어야 함. 트리거(프론트 dev timeoutSeconds=60 확認)·경로(호출자 userAgent=node, 올바른 프록시 URL)·배포시점(연결 시작이 #2183 착지 後) 전부 배제한 뒤 **Next 런타임이 Cloud Run의 강제 종료를 항상 `request.signal`로 전파해주지는 않는다**로 판정 — 사전선언한 실패모드 A("조용한 무효화") 그대로.

## 원리 — #2128과 동형
> 생명 판정 신호는 판정 대상이 스스로 갱신할 수 없는 것이어야 한다.

`request.signal`은 안 왔고 시계(wall-clock)가 잡았다 — #2128이 disconnect 감지 대신 wall-clock을 택한 것과 같은 판단으로, 프록시도 같은 축으로 간다: **프록시의 upstream은 프록시 자신의 수명보다 오래 살 수 없다**를 시계로 직접 강제한다.

## 변경
- `UPSTREAM_HARD_TIMEOUT_MS = 55_000`(60s − 5s 안전마진) 도입 — 값 근거·무너지는 조건 소스에 명시:
  - 근거: 프론트 자신의 Cloud Run 서비스 timeoutSeconds가 다운스트림을 60s에 강제 종료(dev 확認값). 5s는 getServerSession()·URL 구성 등 fetch 호출 前 처리비용 흡수용 안전마진.
  - 무너지는 조건: 이 timeoutSeconds가 60s가 아니게 되면 이 상수도 같이 바뀌어야 함 — 코드와 인프라 설정 두 곳에 사는 값(단일 소스 통합은 인프라 축, 스코프 밖으로 명시).
- `AbortSignal.any([request.signal, AbortSignal.timeout(55_000)])`로 결합 — wall-clock이 본체, `request.signal`은 부수 경로(지우지 않음 — 틀린 코드 아님, 런타임이 나중에 고쳐지면 더 빨리 반응).
- catch 분기에 `TimeoutError` 추가 — `AbortSignal.timeout()`의 abort reason이 `AbortError`가 아니라 `TimeoutError`임을 로컬 실측(`err.name`)으로 확認 후 반영. 둘 다 499로 조용히 정리.

## 회귀테스트 (3건 신규)
`AbortSignal.timeout()`은 vitest fake timer로 제어되지 않는다는 것을 실측 확認(Node 내부 타이머라 `vi.advanceTimersByTimeAsync`가 안 먹힘) — 그래서 `AbortSignal.timeout` 자체를 spy/교체해 "캡 도달" 시점을 실시간 대기 없이 재현:
1. `AbortSignal.timeout(55000)` 정확한 상수값으로 호출되는지
2. 캡이 fire되면(`request.signal`은 안 끊긴 채로도) 499로 정리되는지
3. `request.signal` 배선 자체도 캡과 별개로 여전히 살아있는지(#2183 원 회귀가드 유지)

**뮤테이션 셀프체크**: wall-clock 캡 결합을 일시 제거(`request.signal`만 남김) → 신규 2건이 정확히 RED로 떨어지는 것 확認 → 복구 후 GREEN.

## 검증
- type-check PASS / lint 0 / build EXIT 0 / vitest 297 files 전건 PASS(신규 3건 포함, 이번엔 kanban-board 플레이키도 없이 첫 시도 클린)

## ⛔ done-gate — #2183 자체와 동형, 유닛으로 안 닫음
배포 후 SSE 점유시간이 ~55~60s대로 내려가는지가 판정. 617~658s가 그대로면 이번 것도 안 듣는 것 — 그때는 Next/Cloud Run 조합 자체의 더 깊은 문제로 다시 원인 규명이 필요.

## Test plan
- [x] 회귀테스트 3건 + 뮤테이션 셀프체크(RED 확認 후 복구)
- [ ] 배포 후 라이브 SSE 점유시간 재측정(스토리 done-gate)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>