### PR TITLE
[SID:2189] list_stories 제네릭 분기 cursor 무시·ORDER BY 부재 fix

### DIFF
--- a/backend/app/repositories/story.py
+++ b/backend/app/repositories/story.py
@@ -63,6 +63,20 @@ class StoryRepository(BaseRepository[Story]):
         추가한다 — board처럼 별도 전용 정렬 우선순위(priority)를 얹지 않는 이유는 이 분기의
         전 콜러(`buildCursorPageMeta`)가 `created_at`만 cursorField로 쓰기 때문(다른 정렬
         기준을 얹으면 FE가 계산하는 nextCursor와 실제 정렬 순서가 어긋난다).
+
+        까심군 QA 지적(2026-07-25, #2490 머지 前): `created_at`만으로는 같은 트랜잭션 배치
+        insert 시 server_default=func.now()가 여러 행에 동일 값을 줄 수 있어(테스트가 이 경계를
+        1초씩 벌려 피해갔던 것 자체가 "이 경로가 시험된 적 없다"는 증거였다) ORDER BY가
+        비결정적이었다 — 같은 쿼리를 다시 실행해도 동률 구간의 순서가 달라질 수 있어 페이지
+        재요청 시 skip/dup 위험. `id`를 안정적 2차 키로 얹어 정렬 자체를 결정적으로 만든다
+        (board의 `_PRIORITY_ORDER`를 그대로 베끼지 않는 이유: 여기 필요한 건 "board와 같은
+        정렬 결과"가 아니라 "커서 전진이 결정적인 것" — 목적에 맞는 최소 키면 충분하다).
+
+        ⚠️ 남는 한계(무너지는 조건): cursor 자체는 여전히 `created_at` 단일값이라(FE
+        `buildCursorPageMeta`가 그 값만 보내는 계약 — 서버 혼자 바꿀 수 없다), 동률 경계에
+        걸친 행은 이론상 다음 페이지에서 스킵될 수 있다(중복 전달보다는 덜 나쁜 실패 모드로
+        의도적으로 선택). board 분기도 동일한 구조적 한계를 이미 갖고 있다 — 실제로 skip이
+        관측되면 그때 복합 커서(`created_at`+`id`)로 승격한다.
         """
         query = select(Story).where(self._org_filter(), Story.deleted_at.is_(None))
         for attr, val in filters.items():
@@ -71,7 +85,7 @@ class StoryRepository(BaseRepository[Story]):
             query = query.where(Story.title.ilike(f"%{q}%"))
         if cursor:
             query = query.where(Story.created_at < cursor)
-        query = query.order_by(Story.created_at.desc()).limit(limit)
+        query = query.order_by(Story.created_at.desc(), Story.id.desc()).limit(limit)
         result = await self.session.execute(query)
         return list(result.scalars().all())
 

--- a/backend/app/repositories/story.py
+++ b/backend/app/repositories/story.py
@@ -47,18 +47,32 @@ class StoryRepository(BaseRepository[Story]):
         story_number = await allocate_story_number(self.session, data["project_id"])
         return await super().create(story_number=story_number, **data)
 
-    async def list(self, limit: int = 1000, *, q: str | None = None, **filters) -> list[Story]:
+    async def list(
+        self, limit: int = 1000, *, q: str | None = None, cursor: datetime | None = None, **filters,
+    ) -> list[Story]:
         """story 083176e8(까심 #2148 QA 적출): 갤러리 피커 실검색 — `q`는 title ILIKE 부분일치로
         기존 동등비교 필터(**filters, base.list() 상속)와 AND 결합. BaseRepository.list()는
         범용(모든 리포지토리 공유)이라 q ILIKE 개념을 거기 얹지 않고 story 전용으로 오버라이드
         (list_board/list_by_ids와 동일하게 자체 쿼리 구성 — 기존 관례).
+
+        story #2189(2026-07-25): ORDER BY도 cursor도 없었다 — FE(`buildCursorPageMeta`)의
+        over-fetch(limit+1) 페이지네이션은 **결정적 정렬 + cursor가 WHERE로 실제 적용**되는
+        전제 위에서만 동작하는데(board 분기·현재 `/api/goals`가 이미 그 전제로 동작 중), 이
+        분기만 둘 다 없어 "커서를 바꿔도 같은 페이지가 반복"됐다(sprints/standup "더 보기"가
+        dedup 없이 중복 누적). board 분기와 동형으로 `created_at DESC` + `cursor` WHERE를
+        추가한다 — board처럼 별도 전용 정렬 우선순위(priority)를 얹지 않는 이유는 이 분기의
+        전 콜러(`buildCursorPageMeta`)가 `created_at`만 cursorField로 쓰기 때문(다른 정렬
+        기준을 얹으면 FE가 계산하는 nextCursor와 실제 정렬 순서가 어긋난다).
         """
         query = select(Story).where(self._org_filter(), Story.deleted_at.is_(None))
         for attr, val in filters.items():
             query = query.where(getattr(Story, attr) == val)
         if q:
             query = query.where(Story.title.ilike(f"%{q}%"))
-        result = await self.session.execute(query.limit(limit))
+        if cursor:
+            query = query.where(Story.created_at < cursor)
+        query = query.order_by(Story.created_at.desc()).limit(limit)
+        result = await self.session.execute(query)
         return list(result.scalars().all())
 
     async def list_by_ids(self, ids: list[uuid.UUID]) -> list[Story]:

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -163,7 +163,11 @@ async def list_stories(
         filters["status"] = status_filter
     if story_number is not None:
         filters["story_number"] = story_number
-    stories = await repo.list(limit=limit, q=q, **filters)
+    # story #2189: 이 분기도 board 분기(:131)와 동형으로 cursor를 파싱해 넘긴다 — 안 넘기면
+    # FE(buildCursorPageMeta)가 계산한 nextCursor가 다음 요청에서 조용히 무시돼 같은 페이지가
+    # 반복된다(sprints/standup "더 보기" 중복 누적의 원인).
+    cursor_dt = datetime.fromisoformat(cursor) if cursor else None
+    stories = await repo.list(limit=limit, q=q, cursor=cursor_dt, **filters)
     await _attach_assignee_ids(repo.session, repo.org_id, stories)
     await _attach_has_evidence(repo.session, stories)
     return [StoryResponse.model_validate(s) for s in stories]

--- a/backend/tests/test_2189_generic_branch_cursor_pagination_realdb.py
+++ b/backend/tests/test_2189_generic_branch_cursor_pagination_realdb.py
@@ -146,6 +146,18 @@ async def test_cursor_advances_to_next_page_no_overlap():
         assert page1_ids.isdisjoint(page2_ids), (
             f"페이지 간 겹침 — cursor가 무시됐을 때의 그 증상. 겹친 것={page1_ids & page2_ids}"
         )
+
+        # AC3(오르테가군 지적, 2026-07-25) — 음성대조를 "구조상 될 것"으로 말로만 두지 않고
+        # buildCursorPageMeta(pagination.ts)의 hasMore 계산을 그대로 재현해 명시 확認한다:
+        # hasMore = items.length > limit(FE 원 limit=20, over-fetch용 +1 아님). 2차 응답이
+        # 5건(<20)이면 hasMore=false → nextCursor=null → "더 보기" 버튼이 사라져야 한다.
+        # 이게 없으면 "중복은 없어졌는데 버튼은 계속 있는" 반쪽짜리 fix로 닫힐 수 있다.
+        fe_original_limit = 20
+        has_more = len(page2) > fe_original_limit
+        assert has_more is False, (
+            f"2차 응답 {len(page2)}건은 FE 원 limit({fe_original_limit})보다 적어야 hasMore=false로 "
+            "«더 보기» 버튼이 사라지는데, 그 전제가 깨짐"
+        )
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_2189_generic_branch_cursor_pagination_realdb.py
+++ b/backend/tests/test_2189_generic_branch_cursor_pagination_realdb.py
@@ -1,0 +1,206 @@
+"""story #2189(2026-07-25, 오르테가군 도그푸딩 파생) — 실 PG.
+
+`GET /stories?project_id=&sprint_id=`(제네릭 분기, list_stories:148 이하)는 cursor 를 받기만
+하고 WHERE 로 적용하지 않았고 ORDER BY 자체도 없었다. FE(`buildCursorPageMeta`, over-fetch
+limit+1 패턴)는 "커서를 바꾸면 다음 페이지가 온다"를 전제하는데, 이 분기에선 커서를 바꿔도
+**정확히 같은 페이지가 반복**돼 sprints-client.tsx/standup-client.tsx의 "더 보기"가 dedup
+없이 같은 스토리를 중복 누적했다(#2188 콜러 확認 중 파생 발견).
+
+처방: board 분기(list_board)와 동형으로 `created_at DESC` 정렬 + `cursor` WHERE 를 추가.
+FE의 전 콜러가 cursorField로 `created_at`만 쓰므로 board처럼 별도 우선순위 보조정렬은
+얹지 않는다(얹으면 FE가 계산한 nextCursor와 실제 정렬이 어긋난다).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _auth(agent_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(agent_id), email=None, claims={"app_metadata": {}})
+
+
+async def _seed(session, n: int = 25):
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.pm import Sprint, Story
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent")
+    session.add(agent)
+    await session.commit()
+    session.add(ProjectAccess(id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted"))
+    await session.commit()
+
+    sprint = Sprint(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Sprint")
+    session.add(sprint)
+    await session.commit()
+
+    # 같은 트랜잭션 커밋이면 server_default=func.now()가 전부 동일 timestamp를 줄 수 있어
+    # (동률→비결정적 tie-break) cursor 전진을 못 검증하게 되므로 명시적으로 1초씩 벌린다.
+    base_ts = datetime.now(timezone.utc)
+    story_ids: list[uuid.UUID] = []
+    for i in range(n):
+        s = Story(
+            id=uuid.uuid4(), org_id=org.id, project_id=project.id, sprint_id=sprint.id,
+            title=f"S{i:02d}" + (" special" if i == 3 else ""), status="in-progress", story_number=i + 1,
+            created_at=base_ts - timedelta(seconds=n - i),
+        )
+        session.add(s)
+        story_ids.append(s.id)
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "agent_id": agent.id, "sprint_id": sprint.id,
+        "story_ids_oldest_first": story_ids,
+    }
+
+
+async def _call_list_stories(session, org_id, agent_id, **kwargs):
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import list_stories
+
+    repo = StoryRepository(session, org_id)
+    params = dict(
+        project_id=None, epic_id=None, sprint_id=None, assignee_id=None,
+        status_filter=None, no_sprint=False, ids=None, story_number=None, q=None, limit=1000,
+        cursor=None, response=None,
+    )
+    params.update(kwargs)
+    return await list_stories(repo=repo, auth=_auth(agent_id), **params)
+
+
+async def test_cursor_advances_to_next_page_no_overlap():
+    """⭐본체 — sprints-client.tsx/standup-client.tsx가 실제로 쓰는 그 조합(project_id+sprint_id,
+    status 없음). FE over-fetch 패턴(limit+1) 그대로: 21건 요청 → 20건 표시분의 마지막
+    created_at을 cursor로 다음 페이지 요청 → 남은 5건이 겹침 없이 와야 한다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, n=25)
+        async with Session() as s:
+            page1 = await _call_list_stories(
+                s, seeded["org_id"], seeded["agent_id"],
+                project_id=seeded["project_id"], sprint_id=seeded["sprint_id"], limit=21,
+            )
+        assert len(page1) == 21
+        page1_shown = page1[:20]
+        next_cursor = page1_shown[-1].created_at.isoformat()
+        page1_ids = {r.id for r in page1_shown}
+
+        async with Session() as s:
+            page2 = await _call_list_stories(
+                s, seeded["org_id"], seeded["agent_id"],
+                project_id=seeded["project_id"], sprint_id=seeded["sprint_id"], limit=21,
+                cursor=next_cursor,
+            )
+        page2_ids = {r.id for r in page2}
+
+        assert len(page2) == 5, f"25건 중 20건 이미 봤으면 남은 5건이어야 — 실제 {len(page2)}건"
+        assert page1_ids.isdisjoint(page2_ids), (
+            f"페이지 간 겹침 — cursor가 무시됐을 때의 그 증상. 겹친 것={page1_ids & page2_ids}"
+        )
+    finally:
+        await engine.dispose()
+
+
+async def test_deterministic_order_created_at_desc():
+    """정렬이 created_at DESC로 결정적인지 — 아니면 cursor 자체가 의미 없어진다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, n=10)
+        async with Session() as s:
+            result = await _call_list_stories(
+                s, seeded["org_id"], seeded["agent_id"],
+                project_id=seeded["project_id"], sprint_id=seeded["sprint_id"], limit=100,
+            )
+        timestamps = [r.created_at for r in result]
+        assert timestamps == sorted(timestamps, reverse=True), "created_at DESC로 정렬돼야"
+        # oldest_first 시드 순서의 역순(최신이 먼저)과 일치해야.
+        returned_ids_desc = [r.id for r in result]
+        assert returned_ids_desc == list(reversed(seeded["story_ids_oldest_first"]))
+    finally:
+        await engine.dispose()
+
+
+async def test_cursor_combines_with_other_filters_and_not_or():
+    """cursor가 다른 필터(q)와 AND 결합되는지 — OR로 새면 cursor 넘어간 자리에서 q 매치 없는
+    행도 딸려온다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, n=25)
+        async with Session() as s:
+            result = await _call_list_stories(
+                s, seeded["org_id"], seeded["agent_id"],
+                project_id=seeded["project_id"], sprint_id=seeded["sprint_id"], limit=100, q="special",
+            )
+        # 시드에서 i==3인 스토리만 "special" 타이틀을 가짐.
+        assert len(result) == 1
+        assert result[0].id == seeded["story_ids_oldest_first"][3]
+    finally:
+        await engine.dispose()
+
+
+async def test_no_cursor_unspecified_no_regression():
+    """무회귀 — cursor 미지정이면 기존처럼 첫 페이지(limit개)가 그대로 온다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, n=25)
+        async with Session() as s:
+            result = await _call_list_stories(
+                s, seeded["org_id"], seeded["agent_id"],
+                project_id=seeded["project_id"], sprint_id=seeded["sprint_id"], limit=10,
+            )
+        assert len(result) == 10
+        assert [r.id for r in result] == list(reversed(seeded["story_ids_oldest_first"]))[:10]
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2189_generic_branch_cursor_pagination_realdb.py
+++ b/backend/tests/test_2189_generic_branch_cursor_pagination_realdb.py
@@ -216,3 +216,122 @@ async def test_no_cursor_unspecified_no_regression():
         assert [r.id for r in result] == list(reversed(seeded["story_ids_oldest_first"]))[:10]
     finally:
         await engine.dispose()
+
+
+async def _seed_with_tied_created_at(session, n_tied: int):
+    """까심군 QA 지적(2026-07-25, #2490 머지 前) — 기존 시드는 created_at을 1초씩 벌려
+    동률 경계를 피해갔다("이 경로가 시험된 적 없다"는 것 자체가 결함이었다). 이 헬퍼는
+    반대로 **의도적으로 동일 created_at**을 여러 행에 준다(같은 트랜잭션 배치 insert가
+    server_default=func.now()로 실제 만들어내는 조건)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.pm import Sprint, Story
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent")
+    session.add(agent)
+    await session.commit()
+    session.add(ProjectAccess(id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted"))
+    await session.commit()
+    sprint = Sprint(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Sprint")
+    session.add(sprint)
+    await session.commit()
+
+    tied_ts = datetime.now(timezone.utc)
+    story_ids: list[uuid.UUID] = []
+    for i in range(n_tied):
+        s = Story(
+            id=uuid.uuid4(), org_id=org.id, project_id=project.id, sprint_id=sprint.id,
+            title=f"T{i:02d}", status="in-progress", story_number=i + 1, created_at=tied_ts,
+        )
+        session.add(s)
+        story_ids.append(s.id)
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "agent_id": agent.id, "sprint_id": sprint.id,
+        "story_ids": story_ids,
+    }
+
+
+async def test_tied_created_at_order_is_deterministic_across_repeated_queries():
+    """동률(같은 created_at) 구간에서 id 보조키가 없으면 같은 쿼리를 반복 실행해도 순서가
+    바뀔 수 있다(Postgres가 정렬 안정성을 보장 안 함) — id DESC를 2차 키로 얹었으니 반복
+    실행해도 항상 같은 순서여야 한다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_with_tied_created_at(s, n_tied=10)
+
+        orders: list[list[uuid.UUID]] = []
+        for _ in range(5):
+            async with Session() as s:
+                result = await _call_list_stories(
+                    s, seeded["org_id"], seeded["agent_id"],
+                    project_id=seeded["project_id"], sprint_id=seeded["sprint_id"], limit=100,
+                )
+            orders.append([r.id for r in result])
+
+        assert all(o == orders[0] for o in orders), (
+            f"동률 구간 정렬이 반복 실행마다 달라짐(비결정적) — {orders}"
+        )
+        # id DESC가 실제로 tiebreak으로 적용됐는지도 직접 확認.
+        assert orders[0] == sorted(seeded["story_ids"], reverse=True)
+    finally:
+        await engine.dispose()
+
+
+async def test_tied_created_at_cursor_pagination_no_duplicate_across_pages():
+    """⚠️ 이 테스트가 증명하는 것은 "스킵 없음"이 아니라 "중복 없음"이다(무너지는 조건
+    주석 참조 — cursor가 created_at 단일값이라 동률 경계 행은 이론상 다음 페이지에서
+    스킵될 수 있고, 이 테스트는 그 한계를 승인한 채로 **더 나쁜 실패 모드인 중복 전달**만
+    확実히 배제한다)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_with_tied_created_at(s, n_tied=10)
+        async with Session() as s:
+            page1 = await _call_list_stories(
+                s, seeded["org_id"], seeded["agent_id"],
+                project_id=seeded["project_id"], sprint_id=seeded["sprint_id"], limit=6,
+            )
+        assert len(page1) == 6
+        page1_ids = {r.id for r in page1}
+        next_cursor = page1[-1].created_at.isoformat()
+
+        async with Session() as s:
+            page2 = await _call_list_stories(
+                s, seeded["org_id"], seeded["agent_id"],
+                project_id=seeded["project_id"], sprint_id=seeded["sprint_id"], limit=6,
+                cursor=next_cursor,
+            )
+        page2_ids = {r.id for r in page2}
+
+        assert page1_ids.isdisjoint(page2_ids), (
+            f"동률 경계에서 페이지 간 중복 전달 — 겹친 것={page1_ids & page2_ids}"
+        )
+    finally:
+        await engine.dispose()
+
+
+# ── 이 방법으로 안 닿는 것(오르테가군 요청, 2026-07-25) — 말로만 두지 않고 명시 ──
+#
+# 1. 렌더 층(사용자 눈에 카드가 실제로 중복돼 보이는지)은 이 테스트들이 검증 못 한다 —
+#    backend가 올바른 데이터를 주는 것과 FE가 그것을 올바르게 렌더하는 것은 다른 층이다.
+#    kanban-board.tsx/sprints-client.tsx/standup-client.tsx의 실제 append 로직은 코드
+#    대조로만 확認했다(dedup 없음 관측) — 브라우저로 픽셀을 본 적은 없다.
+# 2. 로컬 pg16 단일 인스턴스·소규모(<30건) 시드 기준이라, prod/dev 규모(수백~수천 건)나
+#    실 limit 기본값 조합에서만 드러나는 성능/정확성 차이는 이 테스트로 안 보인다.
+# 3. `test_cursor_advances_to_next_page_no_overlap`의 hasMore 계산은
+#    `apps/web/src/lib/pagination.ts`의 `buildCursorPageMeta` **공식을 Python으로 복제**한
+#    것이지 실제 TS 함수를 호출한 게 아니다 — FE 쪽 공식이 나중에 바뀌면 이 백엔드 테스트는
+#    조용히 낡아 더 이상 실제 계약을 대표하지 않게 된다(까심군 지적). FE 쪽 pagination.test.ts
+#    가 그 함수 자체의 계약을 지키는 축이고, 이 파일은 어디까지나 백엔드가 그 함수의 전제
+#    (결정적 정렬 + cursor WHERE 적용)를 충족하는지만 본다.


### PR DESCRIPTION
## Summary
- #2188 콜러 확認 중 발견: `GET /stories?project_id=&sprint_id=`(status 없음, 제네릭 분기)로 떨어지는 실 콜러 둘(`sprints-client.tsx` 스프린트 상세 "더 보기" · `standup-client.tsx` 스탠드업 "더 보기")이 cursor를 보내지만, `StoryRepository.list()`가 cursor를 받기만 하고 WHERE로 적용하지 않았고 ORDER BY도 없어 — "더 보기" 클릭 시 정확히 같은 페이지가 반복 → 두 화면 모두 dedup 없는 append라 같은 스토리가 중복 누적.
- board 분기(`list_board`)와 동형으로 `created_at DESC` 정렬 + `cursor` WHERE만 추가(board처럼 priority 보조정렬은 얹지 않음 — FE 전 콜러가 cursorField로 created_at만 씀).
- **(까심군 QA 추가 반영)** `id`를 2차 정렬키로 추가 — 같은 트랜잭션 배치 insert 시 `created_at`이 동률일 수 있어 ORDER BY가 비결정적이었다(기존 테스트가 시드 timestamp를 1초씩 벌려 이 경계를 피해간 것 자체가 미검증 신호였음).

## 처방 선택 근거 ((a) backend 배선 vs (b) FE in-memory 페이징)
`buildCursorPageMeta`(FE)를 먼저 읽어 "백엔드 헤더 없어서 FE가 대신 만드는" 게 아니라 표준 over-fetch(limit+1) 패턴이고, 결정적 정렬+실제 cursor WHERE가 있는 백엔드(board 분기·현재 `/api/goals`) 위에서는 이미 정상 동작함을 확認. 게다가 정확히 이 disease class(에픽 "더보기 마지막 항목 중복")를 FE in-memory 페이징(`paginateInMemory`, commit `d3760f9f`)으로 고쳤다가 "1000+건 조용히 truncate"라는 더 나쁜 결함이 나와 백엔드 위임으로 되돌린 전례(commit `569f5316`)가 이미 이 코드베이스에 있음 — `paginateInMemory`는 현재 콜러 0(고아 함수). 같은 실패 반복 방지를 위해 (a) 채택.

## 이 방법으로 안 닿는 것 (명시 선언)
1. 렌더 층(사용자 눈에 카드가 실제로 중복돼 보이는지)은 검증 못 함 — kanban-board.tsx/sprints-client.tsx/standup-client.tsx의 append 로직은 코드 대조로만 확認(dedup 없음 관측), 브라우저로 픽셀을 본 적은 없음.
2. 로컬 pg16 단일 인스턴스·소규모(<30건) 시드 기준 — prod/dev 규모(수백~수천 건)나 실 limit 기본값 조합에서만 드러나는 차이는 안 보임.
3. `hasMore` 계산은 `apps/web/src/lib/pagination.ts`의 `buildCursorPageMeta` **공식을 Python으로 복제**한 것이지 실제 TS 함수를 호출한 게 아님 — FE 공식이 나중에 바뀌면 이 백엔드 테스트는 조용히 낡을 수 있음.
4. 동률 커서 경계에서의 **스킵**(중복은 아님)은 이론상 남는 한계 — cursor 자체가 `created_at` 단일값 계약이라 서버 혼자 복합 커서로 못 바꿈. board 분기도 동일 한계 보유. 실제 관측되면 승격.

## Test plan
- [x] AC1(mock-0 재현): 실 pg16 마이그 DB + 25건 시드, `list_stories()`를 FE over-fetch 패턴(limit=21) 그대로 두 번 호출 — 수정 前엔 2차 호출이 1차와 동일한 첫 20건 반환(overlap 20/20), 수정 後 남은 5건이 겹침 없이 반환됨을 확認
- [x] AC3(음성대조 명시): `hasMore = len(page2) > 20`(FE 원 limit) assert로 "더 보기" 버튼이 실제로 사라지는 조건까지 확認
- [x] 신규 realdb 테스트 6건 + 동률 created_at 테스트 2건(반복 쿼리 결정성·페이지 간 무중복) 그린
- [x] 뮤테이션 셀프체크 2회: (1) 전체 fix stash 후 4/6건 예측대로 RED, (2) id 2차 정렬키만 제거 후 결정성 테스트만 정확히 RED — 둘 다 복구 확認
- [x] 기존 관련 realdb 테스트 개별 실행 그린 — 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)