### PR TITLE
[SID:2089] stage 3-a — realtime GCE dev entrypoint를 app.realtime_main:app으로 전환

### DIFF
--- a/backend/app/realtime_main.py
+++ b/backend/app/realtime_main.py
@@ -11,12 +11,10 @@
 include_router)는 아예 옮기지 않는다 — realtime은 그 라우트를 서빙할 이유가 없으므로
 "빼는" 게 아니라 "처음부터 안 부르는" 것(오르테가군 판단 그대로).
 
-⚠️ 미해결 — a2a.router(JSON-RPC SendStreamingMessage, 자체 SSE형 무기한 스트림)를 여기
-포함해야 하는지 판단 보류. 이 세션에서 "SSE router"로 계속 지칭해 온 것은 events.py/
-agent_gateway.py 둘뿐이라(오늘 _SSE_LIFESPAN_SEC/_AGENT_SSE_LIFESPAN_SEC로 다룬 그 둘) 이
-둘만 마운트했다 — a2a는 별도 판단이 필요하면 그때 추가.
-
-a2a.router 판단 확定(2026-07-25, 오르테가군 실측) — 제외:
+a2a.router 판단 확定(2026-07-25, 오르테가군 실측) — 제외. 이 세션에서 "SSE router"로
+계속 지칭해 온 것은 events.py/agent_gateway.py 둘뿐이라(오늘 _SSE_LIFESPAN_SEC/
+_AGENT_SSE_LIFESPAN_SEC로 다룬 그 둘) a2a는 처음부터 별도 판단 대상으로 비워 뒀었고,
+아래 실측으로 그 판단이 내려졌다:
   ① 24시간 a2a 트래픽 실측: 50건 전부 backend-dev · realtime-dev 0건 — a2a는 지금
      backend에서만 서빙되고 realtime으로 라우팅되지 않는다.
   ② a2a는 이미 자체 _A2A_RPC_TIMEOUT_SECONDS=280s 상한을 갖고 있다 — 오늘 고친 SSE

--- a/backend/app/realtime_main.py
+++ b/backend/app/realtime_main.py
@@ -1,0 +1,176 @@
+"""story #2089(2026-07-25) — realtime 전용 entrypoint, stage 2 시제품.
+
+⛔ 이 파일은 기존 app/main.py를 대체하지 않는다(무터치). 목적은 «SSE router + 그 의존만
+마운트한 별도 앱을 실제로 띄워서 진짜 필요한 모듈이 뭔지 측정하는 것»이다(오르테가군 지시
+2026-07-25) — 정적 import 그래프만으로는 app/main.py:368의 `is_ee_enabled` 게이트처럼
+"조건부지만 지금 실제로 실행되는" 배선을 놓친다는 것이 오늘 실물로 드러났다.
+
+전략 — "처음엔 넉넉히 잡고 측정 결과로 깎는다": app.main.lifespan()의 로직 중 realtime의
+실제 역할(cross-node event 수신 → SSE로 fan-out)에 관련된 부분은 그대로 가져오고, 다른
+89개 REST 라우터는 마운트하지 않는다. ee 게이트(app.main:368의 billing/push_devices
+include_router)는 아예 옮기지 않는다 — realtime은 그 라우트를 서빙할 이유가 없으므로
+"빼는" 게 아니라 "처음부터 안 부르는" 것(오르테가군 판단 그대로).
+
+⚠️ 미해결 — a2a.router(JSON-RPC SendStreamingMessage, 자체 SSE형 무기한 스트림)를 여기
+포함해야 하는지 판단 보류. 이 세션에서 "SSE router"로 계속 지칭해 온 것은 events.py/
+agent_gateway.py 둘뿐이라(오늘 _SSE_LIFESPAN_SEC/_AGENT_SSE_LIFESPAN_SEC로 다룬 그 둘) 이
+둘만 마운트했다 — a2a는 별도 판단이 필요하면 그때 추가.
+
+a2a.router 판단 확定(2026-07-25, 오르테가군 실측) — 제외:
+  ① 24시간 a2a 트래픽 실측: 50건 전부 backend-dev · realtime-dev 0건 — a2a는 지금
+     backend에서만 서빙되고 realtime으로 라우팅되지 않는다.
+  ② a2a는 이미 자체 _A2A_RPC_TIMEOUT_SECONDS=280s 상한을 갖고 있다 — 오늘 고친 SSE
+     wall-clock 캡 결함군(감지 실패로 인한 무기한 점유)이 아니다.
+  넣으면 "라우팅이 없는 것을 이미지에만 얹는" 것이라 표면만 늘어난다.
+  무너지는 조건: a2a 스트리밍을 realtime으로 라우팅하기로 결정하면 그때 이 entrypoint에
+  편입한다 — ①(라우팅이 backend로 감) 또는 ②(자체 280s 상한이 이 결함군과 무관함) 중
+  하나라도 바뀌면 재검토.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from slowapi.errors import RateLimitExceeded
+
+from app.core.config import settings
+from app.core.logging_config import configure_logging
+from app.core.rate_limit import limiter
+
+configure_logging(json_logs=os.getenv("APP_ENV", "development") != "development")
+_logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def realtime_lifespan(app: FastAPI):
+    """app.main.lifespan()의 부분집합 — realtime이 실제로 쓰는 축만.
+
+    제외한 것과 이유(넉넉히 잡되 명백히 무관한 것만 뺌):
+    - check_internal_secret_config/check_cron_secret_config/check_mobile_app_check_config:
+      auth_firebase_internal(웹뷰 핸드오프)·cron(REST 엔드포인트)·mobile app check(REST 인증) —
+      전부 realtime이 서빙 안 하는 REST 표면의 설정 가드. 측정 단계에서 굳이 끌고 오지 않음.
+    - warn_if_webhook_secret_misconfigured: 웹훅 발송은 dispatch.router(REST) 쪽 관심사.
+    포함한 것:
+    - shutdown_event 리셋 — events.py/agent_gateway.py 둘 다 이 신호를 구독해 정상 종료함(필수).
+    - backplane 해석 + PG LISTEN 또는 Redis consume 루프 — realtime의 존재 이유(cross-node
+      event 수신) 그 자체.
+    - #2138 outbox+dual_publish 동시활성화 fail-closed 가드 — 부팅 안전성 가드라 값이 쌈.
+    - outbox_dispatcher_loop — event_broker_outbox_enabled 조합에서 realtime도 관련될 수 있어
+      우선 포함(측정 결과로 불필요하면 뺀다).
+    - engine.dispose() — 좀비 커넥션 방지, 다른 서비스와 동형으로 필수.
+    """
+    from app.core import shutdown as shutdown_module
+    from app.core.database import engine
+    from app.services.event_broker import (
+        check_outbox_dual_publish_config,
+        outbox_dispatcher_loop,
+        redis_consume_loop,
+        resolve_backplane,
+    )
+    from app.services.pg_pubsub import check_listen_config, listen_loop
+
+    shutdown_module.reset_shutdown_event()
+    check_outbox_dual_publish_config()
+
+    backplane = resolve_backplane(log_conflict=True)
+    if backplane == "redis" and not (
+        settings.event_broker_redis_dual_publish_enabled
+        and settings.event_broker_redis_consume_enabled
+    ):
+        _logger.error(
+            "REALTIME_BACKPLANE=redis(또는 dispatch_enabled)인데 consume loop 미기동"
+            "(dual_publish/consume off) = dispatcher 0. PG listen 으로 폴백. (#2122 정합성 가드)"
+        )
+        backplane = "pg"
+    if backplane == "pg":
+        check_listen_config()
+
+    listen_task = asyncio.create_task(listen_loop()) if backplane == "pg" else None
+
+    redis_shadow_task = None
+    if settings.event_broker_redis_dual_publish_enabled and settings.event_broker_redis_consume_enabled:
+        redis_shadow_task = asyncio.create_task(redis_consume_loop())
+
+    outbox_dispatcher_task = None
+    if settings.event_broker_outbox_enabled:
+        outbox_dispatcher_task = asyncio.create_task(outbox_dispatcher_loop())
+
+    try:
+        yield
+    finally:
+        shutdown_module.shutdown_event.set()
+        for t in (listen_task, redis_shadow_task, outbox_dispatcher_task):
+            if t is not None:
+                t.cancel()
+        for t in (listen_task, redis_shadow_task, outbox_dispatcher_task):
+            if t is not None:
+                try:
+                    await t
+                except asyncio.CancelledError:
+                    pass
+        await engine.dispose()
+
+
+# story #2089 핵심 — 여기서 딱 두 라우터만 import한다. app.main.py:147의 90+ 모듈
+# 일괄 import(alembic·ee·mcp 게이트를 함께 끌고 오는 그 배선)를 반복하지 않는 것이
+# 이 entrypoint의 전체 목적이다.
+from app.routers import agent_gateway, events  # noqa: E402
+
+app = FastAPI(
+    title="Sprintable Realtime Gateway (stage2 측정용 시제품)",
+    description="SSE router만 서빙 — app.main과 별개 entrypoint(#2089)",
+    version="0.1.0-stage2",
+    docs_url=None,
+    redoc_url=None,
+    lifespan=realtime_lifespan,
+)
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    mapped = {
+        400: "BAD_REQUEST", 401: "UNAUTHORIZED", 403: "FORBIDDEN", 404: "NOT_FOUND",
+        409: "CONFLICT", 422: "UNPROCESSABLE_ENTITY", 429: "RATE_LIMITED",
+    }.get(exc.status_code, f"HTTP_{exc.status_code}")
+    detail = exc.detail
+    if isinstance(detail, dict):
+        error = {"code": detail.get("code", mapped), "message": detail.get("message", "")}
+        for k, v in detail.items():
+            if k not in ("code", "message"):
+                error[k] = v
+    else:
+        error = {"code": mapped, "message": str(detail)}
+    return JSONResponse(status_code=exc.status_code, content={"data": None, "error": error, "meta": None}, headers=exc.headers)
+
+
+@app.exception_handler(RateLimitExceeded)
+async def rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
+    resp = JSONResponse(status_code=429, content={"data": None, "error": {"code": "RATE_LIMITED", "message": "Too many requests"}, "meta": None})
+    resp.headers["Retry-After"] = str(getattr(exc, "retry_after", 60))
+    return resp
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    _logger.exception("Unhandled exception on %s %s: %s", request.method, request.url.path, exc)
+    detail = str(exc) if settings.debug else "Internal server error"
+    return JSONResponse(status_code=500, content={"data": None, "error": {"code": "INTERNAL_ERROR", "message": detail}, "meta": None})
+
+
+app.state.limiter = limiter
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[o.strip() for o in settings.cors_origins.split(",") if o.strip()],
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type", "X-Org-Id", "X-Project-Id", "X-Request-ID"],
+)
+
+app.include_router(events.router)
+app.include_router(agent_gateway.router)

--- a/backend/scripts/deploy_realtime_gce.sh
+++ b/backend/scripts/deploy_realtime_gce.sh
@@ -135,6 +135,12 @@ case "${ENV}" in
         # 최종적으로 GCLB 프론트 URL로 바뀌어야 하는지는 provision_realtime_gclb.sh 완료 후
         # 별도 재확認 필요(TODO — 현재는 라이브 값 그대로 이관해 드리프트 0으로 시작).
         FASTAPI_URL="https://sprintable-realtime-dev-787818285179.asia-northeast3.run.app"
+        # story #2089 stage 3-a(2026-07-25, 오르테가군 지시) — «변수를 하나씩 움직인다»:
+        # 이미지는 그대로 두고 entrypoint만 app.realtime_main:app(SSE router 둘만 마운트,
+        # main.py:147의 90+ 라우터 일괄 import·ee 게이트를 안 거침)으로 교체해 dev GCE에서만
+        # 먼저 검증한다. prod는 이번 단계에서 손대지 않는다(아래 prod 분기가 기존
+        # app.main:app을 그대로 유지 — 이 값이 바로 그 분리 지점).
+        UVICORN_APP_MODULE="app.realtime_main:app"
         ;;
     prod)
         # story #2142(2026-07-23, 선생님 GCE prod 전환 승인): dev와 동일 구조, 리소스명·Cloud
@@ -199,6 +205,9 @@ case "${ENV}" in
         # 잠정값으로 둔다 — provision_realtime_gclb.sh 완료 후 GCLB 프론트 IP/도메인으로
         # 바꿔야 하는지는 별도 재확認 대상(이 PR은 스크립트가 prod를 받게만 하는 스코프).
         FASTAPI_URL="https://sprintable-backend-prod-787818285179.asia-northeast3.run.app"
+        # story #2089 stage 3-a — prod는 이번 단계에서 안 건드린다. 기존 app.main:app 그대로
+        # (dev만 app.realtime_main:app으로 바뀌는 것과 대비되는 지점 — 위 dev 분기 주석 참조).
+        UVICORN_APP_MODULE="app.main:app"
         ;;
     *)
         echo "Usage: $0 [dev|prod]" >&2
@@ -534,7 +543,7 @@ trap 'rm -f "${STARTUP_SCRIPT_FILE}"' EXIT
     done
     echo '  --env-file=/tmp/realtime-gateway-plain.env \'
     echo "  ${IMAGE} \\"
-    echo '  uvicorn app.main:app --host 0.0.0.0 --port 8000 --timeout-graceful-shutdown 30'
+    echo "  uvicorn ${UVICORN_APP_MODULE} --host 0.0.0.0 --port 8000 --timeout-graceful-shutdown 30"
     echo ''
     echo '# ── 부팅 진단(시리얼 콘솔로) — COS는 SSH/Cloud Logging 접근이 제한적이라, 컨테이너'
     echo '#    상태·소켓·프록시/앱 로그를 startup-script stdout(=시리얼)로 남겨 원격 진단 가능케 한다.'
@@ -568,6 +577,10 @@ if [ "${DRY_RUN}" = "1" ]; then
     # 테스트가 "진짜 배포될 것"을 검증하게 한다(base64 — 줄바꿈을 한 줄 KEY=VALUE 출력
     # 포맷 안에 안전하게 실어야 해서).
     _GENERATED_PLAIN_ENV_FILE_B64="$(sed -n '/^cat > \/tmp\/realtime-gateway-plain\.env/,/^PLAIN_ENV_EOF$/p' "${STARTUP_SCRIPT_FILE}" | sed '1d;$d' | base64 | tr -d '\n')"
+    # story #2089 stage 3-a — #2142와 동일 관례: 요약 변수(UVICORN_APP_MODULE)가 아니라
+    # startup-script에 실제로 적힌 uvicorn 커맨드 그 줄 자체를 노출해, 변수→실제 산출물
+    # 배선이 끊기지 않았는지 테스트가 직접 대조할 수 있게 한다.
+    _GENERATED_UVICORN_CMD_LINE="$(grep '^  uvicorn ' "${STARTUP_SCRIPT_FILE}")"
     cat <<EOF
 ENV=${ENV}
 MIG_NAME=${MIG_NAME}
@@ -581,6 +594,8 @@ RUNTIME_SA=${RUNTIME_SA}
 PLAIN_ENV_SPEC=${PLAIN_ENV_SPEC}
 SECRET_PAIRS=${SECRET_PAIRS}
 GENERATED_PLAIN_ENV_FILE_B64=${_GENERATED_PLAIN_ENV_FILE_B64}
+UVICORN_APP_MODULE=${UVICORN_APP_MODULE}
+GENERATED_UVICORN_CMD_LINE=${_GENERATED_UVICORN_CMD_LINE}
 EOF
     exit 0
 fi

--- a/backend/tests/test_deploy_realtime_gce_env.py
+++ b/backend/tests/test_deploy_realtime_gce_env.py
@@ -481,3 +481,40 @@ def test_provision_gclb_invalid_env_rejected():
     )
     assert proc.returncode != 0
     assert "[dev|prod]" in proc.stderr
+
+
+# ── story #2089 stage 3-a(2026-07-25, 오르테가군 지시): dev만 entrypoint 교체 ────────
+
+def test_deploy_gce_dev_uses_realtime_main_entrypoint():
+    """dev는 app.realtime_main:app(SSE router 둘만 마운트)으로 뜬다."""
+    cfg = _resolve(_DEPLOY_GCE, "dev")
+    assert cfg["UVICORN_APP_MODULE"] == "app.realtime_main:app"
+
+
+def test_deploy_gce_prod_entrypoint_unchanged():
+    """⭐핵심 AC — prod는 이번 단계에서 손대지 않는다. 기존 app.main:app 그대로인지
+    명시 검증(변수 분리 리팩터 자체가 prod 값을 조용히 바꾸지 않았는지가 이 테스트의 목적)."""
+    cfg = _resolve(_DEPLOY_GCE, "prod")
+    assert cfg["UVICORN_APP_MODULE"] == "app.main:app"
+
+
+def test_deploy_gce_dev_and_prod_entrypoints_differ():
+    dev = _resolve(_DEPLOY_GCE, "dev")
+    prod = _resolve(_DEPLOY_GCE, "prod")
+    assert dev["UVICORN_APP_MODULE"] != prod["UVICORN_APP_MODULE"]
+
+
+def test_deploy_gce_dev_startup_script_actually_invokes_realtime_main():
+    """요약 변수(UVICORN_APP_MODULE)뿐 아니라 실제 생성되는 startup-script의 docker run
+    커맨드 라인 자체에 반영되는지 — #2142가 세운 관례(요약 문자열과 실제 산출물이 다를 수
+    있다는 것)를 따라 startup-script 원문(GENERATED_UVICORN_CMD_LINE)에서 직접 확認한다."""
+    cfg = _resolve(_DEPLOY_GCE, "dev")
+    assert "uvicorn app.realtime_main:app" in cfg["GENERATED_UVICORN_CMD_LINE"]
+    assert "--host 0.0.0.0" in cfg["GENERATED_UVICORN_CMD_LINE"]
+
+
+def test_deploy_gce_prod_startup_script_still_invokes_main():
+    """prod의 실제 startup-script 산출물도 기존 app.main:app 그대로인지 원문으로 확認."""
+    cfg = _resolve(_DEPLOY_GCE, "prod")
+    assert "uvicorn app.main:app" in cfg["GENERATED_UVICORN_CMD_LINE"]
+    assert "realtime_main" not in cfg["GENERATED_UVICORN_CMD_LINE"]

--- a/backend/tests/test_no_unreferenced_fire_and_forget.py
+++ b/backend/tests/test_no_unreferenced_fire_and_forget.py
@@ -19,12 +19,20 @@ _APP_DIR = Path(__file__).parent.parent / "app"
 # events.py/agent_gateway.py: story c4c72eb1 PR-A — get_task/shutdown_wait_task 모두 지역 변수에
 # 참조 보관 후 asyncio.wait()로 즉시 경합·완료 대기하고 각 finally에서 cancel() — fire-and-forget
 # 아닌 표준 "동시 대기" 패턴(#1970류 GC 조기수거 리스크 없음).
+# realtime_main.py: story #2089(2026-07-25) — main.py lifespan의 부분집합. listen_task/
+# redis_shadow_task/outbox_dispatcher_task 전부 지역변수 보관 + lifespan finally에서
+# cancel()+await로 명시 추적 — main.py가 허용된 바로 그 패턴과 코드 대조로 동일함을 확認
+# (fire_and_forget()으로 전환하면 Task를 안 돌려줘 명시적 cancel을 잃는다 — lifespan이
+# engine.dispose() 前에 백그라운드 루프를 반드시 먼저 멈춰야 하는 순서를 못 지키게 되는
+# 퇴행이라 전환하지 않았다). 이 안전성이 유지되는지는
+# test_realtime_main_lifespan_shutdown_order.py가 실행으로 계속 지킨다.
 _ALLOWED_FILES = {
     _APP_DIR / "main.py",
     _APP_DIR / "services" / "pg_pubsub.py",
     _APP_DIR / "services" / "l2_trigger_worker.py",
     _APP_DIR / "routers" / "events.py",
     _APP_DIR / "routers" / "agent_gateway.py",
+    _APP_DIR / "realtime_main.py",
 }
 _PATTERN = re.compile(r"\.create_task\(|\bensure_future\(")
 

--- a/backend/tests/test_realtime_main_lifespan_shutdown_order.py
+++ b/backend/tests/test_realtime_main_lifespan_shutdown_order.py
@@ -1,0 +1,107 @@
+"""story #2089(2026-07-25, 오르테가군 지시) — `app/realtime_main.py`가
+`test_no_unreferenced_fire_and_forget.py`의 허용목록에 들어간 근거(main.py와 동일한
+"로컬변수 보관 + lifespan finally에서 cancel()+await로 명시 추적" 패턴)가 **지금도 참인지**
+실행으로 지킨다.
+
+허용목록은 "그때 사람이 코드를 봤다"는 선언일 뿐이라, 이 파일이 나중에 바뀌면 그 선언이
+조용히 거짓이 될 수 있다(#2174가 "until 만료"로 지키는 것과 같은 필요 — 여기서는 "패턴이
+유지되는가"를 실행으로 지킨다). 검증 대상: 백그라운드 루프 태스크의 취소가 반드시
+`engine.dispose()` **前에** 일어나는 것(오늘 하루 세운 순서 — cancel→await→dispose. 순서가
+깨지면 아직 도는 루프가 이미 dispose된 엔진의 커넥션을 쓰려는 레이스가 생긴다).
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class _FakeEngine:
+    """AsyncEngine.dispose는 슬롯 속성이라 개별 메서드 patch가 안 됨(AttributeError:
+    read-only) — 엔진 객체 전체를 대체한다."""
+
+    def __init__(self, on_dispose=None):
+        self._on_dispose = on_dispose
+
+    async def dispose(self):
+        if self._on_dispose is not None:
+            await self._on_dispose()
+
+
+async def test_listen_loop_cancelled_before_engine_dispose():
+    """listen_loop()의 취소(cancellation)가 engine.dispose() 호출보다 먼저 관측돼야 한다."""
+    import app.realtime_main as rm
+
+    call_order: list[str] = []
+
+    async def _fake_listen_loop():
+        try:
+            await asyncio.Event().wait()  # 영원히 대기 — 취소돼야만 빠져나감
+        except asyncio.CancelledError:
+            call_order.append("listen_loop_cancelled")
+            raise
+
+    async def _fake_dispose():
+        call_order.append("engine_dispose")
+
+    with patch("app.services.event_broker.resolve_backplane", return_value="pg"), \
+         patch("app.services.pg_pubsub.check_listen_config", return_value=None), \
+         patch("app.services.pg_pubsub.listen_loop", side_effect=_fake_listen_loop), \
+         patch("app.services.event_broker.check_outbox_dual_publish_config", return_value=None), \
+         patch("app.core.database.engine", new=_FakeEngine(_fake_dispose)):
+        async with rm.realtime_lifespan(rm.app):
+            # startup 완료 — listen_task가 실제로 생성돼 _fake_listen_loop에서 대기 중이어야 함.
+            await asyncio.sleep(0)
+        # realtime_lifespan의 __aexit__(= finally 블록)이 여기서 이미 실행 완료됨.
+
+    assert "listen_loop_cancelled" in call_order, (
+        "listen_loop가 취소되지 않았다 — lifespan finally가 태스크 참조를 잃었을 가능성"
+    )
+    assert "engine_dispose" in call_order
+    assert call_order.index("listen_loop_cancelled") < call_order.index("engine_dispose"), (
+        f"순서 위반 — engine.dispose()가 listen_loop 취소보다 먼저(또는 동시에) 일어남: {call_order}. "
+        "아직 도는 루프가 이미 dispose된 엔진의 커넥션을 쓰려는 레이스 위험."
+    )
+
+
+async def test_all_three_background_tasks_are_referenced_and_awaited():
+    """listen_task/redis_shadow_task/outbox_dispatcher_task 셋 다 실제로 취소·await되는지
+    (백그라운드 루프가 셋 다 켜진 조합에서) — 하나라도 참조를 잃으면 그 루프만 GC 조기수거
+    위험에 노출된다."""
+    import app.realtime_main as rm
+
+    cancelled: set[str] = set()
+
+    def _tracked_loop(name: str):
+        async def _loop():
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancelled.add(name)
+                raise
+        return _loop
+
+    with patch("app.services.event_broker.resolve_backplane", return_value="pg"), \
+         patch("app.services.pg_pubsub.check_listen_config", return_value=None), \
+         patch("app.services.pg_pubsub.listen_loop", side_effect=_tracked_loop("listen")), \
+         patch("app.services.event_broker.check_outbox_dual_publish_config", return_value=None), \
+         patch("app.core.config.settings.event_broker_redis_dual_publish_enabled", True), \
+         patch("app.core.config.settings.event_broker_redis_consume_enabled", True), \
+         patch("app.services.event_broker.redis_consume_loop", side_effect=_tracked_loop("redis_shadow")), \
+         patch("app.core.config.settings.event_broker_outbox_enabled", True), \
+         patch("app.services.event_broker.outbox_dispatcher_loop", side_effect=_tracked_loop("outbox")), \
+         patch("app.core.database.engine", new=_FakeEngine()):
+        async with rm.realtime_lifespan(rm.app):
+            await asyncio.sleep(0)
+
+    assert cancelled == {"listen", "redis_shadow", "outbox"}, (
+        f"일부 백그라운드 루프가 취소되지 않음(GC 조기수거 위험) — cancelled={cancelled}"
+    )


### PR DESCRIPTION
## Summary — draft, dev 검증 전
story #2089(realtime 이미지 분리) stage 3-a. "변수를 하나씩 움직인다"(스토리 본문 원칙) — 이미지는 그대로 두고 **entrypoint만 교체**해 dev GCE에서 먼저 검증한다. **prod는 이번 단계에서 손대지 않는다.**

## 구성
- `app/realtime_main.py`(신규, `app/main.py` 무터치) — `events.router`+`agent_gateway.router` 둘만 마운트하는 별도 FastAPI 앱. lifespan은 `app.main.lifespan()`의 부분집합(shutdown_event·backplane 해석+listen_loop/redis_consume_loop·#2138 outbox 가드·engine.dispose()만).
- `deploy_realtime_gce.sh` — `UVICORN_APP_MODULE`을 dev/prod case 분기에서 각각 결정(dev=`app.realtime_main:app` · prod=`app.main:app`, 기존 하드코드 값 그대로). 공유 uvicorn 커맨드 라인에서 이 변수를 소비.

## 왜 이 형태인가 — ee 랜드마인 발견(stage 1)
`app/main.py:368`의 `if settings.is_ee_enabled: from ee.routers import billing ...`가 realtime GCE 배포(`LICENSE_CONSENT=agreed`, `deploy_realtime_gce.sh:320`)에서 **실제로 실행 중**임을 확認 — `ee/`를 파일에서 빼는 접근이었다면 이 줄에서 부팅이 깨졌을 자리. entrypoint를 분리하면 이 코드 자체를 안 거쳐 문제가 원천적으로 사라진다.

## stage 2 측정 — 실행으로 증명
- 정적 import(`sys.modules` diff): 936개 신규 모듈, exclude 후보(ee/alembic/sprintable_mcp/scripts.jobs) **0개**
- 실제 lifespan 기동(`TestClient` startup→shutdown 왕복): 996개 중 risky **0개**

## a2a.router 제외 — 실측 근거
- 24시간 a2a 트래픽 50건 전부 backend-dev, realtime-dev **0건**(라우팅이 안 옴)
- a2a는 이미 자체 `_A2A_RPC_TIMEOUT_SECONDS=280s` 상한 보유 — 오늘 고친 SSE wall-clock 캡 결함군과 무관
- 무너지는 조건 명시: a2a를 realtime으로 라우팅하기로 결정하면 재검토

## Test plan
- [x] `test_deploy_realtime_gce_env.py` 신규 5건 — 요약 변수(`UVICORN_APP_MODULE`)와 실제 startup-script 원문(`GENERATED_UVICORN_CMD_LINE`) 양쪽 검증(#2142 관례 재사용: 요약≠실제 산출물일 수 있다)
- [x] 기존 39건 전체 그린(prod 분기 무영향 확認 포함)
- [x] 뮤테이션 셀프체크: 스크립트 변경 stash → 5건 전부 예측대로 RED(KeyError 포함) → 복구
- [x] `app/realtime_main.py` 정적 import + 실제 lifespan 기동 양쪽 로컬 확認(stage 2)
- [ ] **dev GCE 배포 후 라이브 판정**(draft 사유 — 아직 안 함): SSE 정상 · 점유시간 90~135초 유지(#2128 캡과 정합) · 503 0 · presence 동작
- [ ] 롤백 경로 확認: entrypoint를 `app.main:app`으로 되돌리는 커밋 1개로 재배포 가능함을 실제로 시연

⛔ **아직 dev에 배포 안 함 — PO/오르테가군 승인 후 진행.** prod는 이번 스토리 전체에서 미배포.

🤖 Generated with [Claude Code](https://claude.com/claude-code)