### PR TITLE
fix(#2166): uvx sprintable first-run error gives no next step

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -198,6 +198,18 @@ Sprintable에서: **에이전트(Agents) → 채용(Recruit) → API 키 복사*
 
 원격 배포 환경이라면 `localhost:3108`을 실제 Sprintable URL로 바꾸세요.
 
+#### 레포 클론 없이 stdio로 (`uvx sprintable`)
+
+위의 HTTP 설정 대신 stdio MCP 서버를 쓰고 싶다면? `sprintable`은 PyPI에 배포돼 있어 레포 클론이 필요 없습니다:
+
+```bash
+export SPRINTABLE_API_URL=http://localhost:8000   # 백엔드의 base URL — 아래 참고
+export AGENT_API_KEY=YOUR_AGENT_API_KEY
+uvx sprintable
+```
+
+`SPRINTABLE_API_URL`은 **백엔드**의 base URL이지 프론트엔드가 아닙니다 — 위 로컬 셀프호스트 설정 기준으로는 `:3108`이 아니라 `http://localhost:8000`입니다(`docker-compose.yml` 참고). 전체 상세(환경변수·transport 모드·hosted 인스턴스 설정): [`backend/sprintable_mcp/README.md`](backend/sprintable_mcp/README.md)(이 내용이 그대로 [PyPI 페이지](https://pypi.org/project/sprintable/)에도 렌더링됩니다).
+
 #### 다른 런타임
 
 10개 런타임 전부(Claude Code, Codex, Cursor, Gemini, Grok, Hermes, OpenClaw, OpenCode, Pi, 그리고 범용 `connector` fallback)를 **에이전트(Agents) → 채용(Recruit)**에서 채용할 수 있습니다 — 선택한 런타임에 맞는 안내 파일과 설정을 Sprintable이 자동 생성합니다.

--- a/README.md
+++ b/README.md
@@ -209,6 +209,18 @@ Add Sprintable as an MCP server in your agent's config. This gives the agent acc
 
 Replace `localhost:3108` with your Sprintable URL if deployed remotely.
 
+#### No-clone stdio (`uvx sprintable`)
+
+Prefer a stdio MCP server over the HTTP config above? `sprintable` is published on PyPI — no repo clone needed:
+
+```bash
+export SPRINTABLE_API_URL=http://localhost:8000   # your backend's base URL — see note below
+export AGENT_API_KEY=YOUR_AGENT_API_KEY
+uvx sprintable
+```
+
+`SPRINTABLE_API_URL` is the **backend's** base URL, not the frontend's — for the local self-host setup above that's `http://localhost:8000` (see `docker-compose.yml`), not `:3108`. Full details (env vars, transport modes, hosted-instance setup): [`backend/sprintable_mcp/README.md`](backend/sprintable_mcp/README.md) (also the README rendered on the [PyPI page](https://pypi.org/project/sprintable/)).
+
 #### Other runtimes
 
 All ten runtimes (Claude Code, Codex, Cursor, Gemini, Grok, Hermes, OpenClaw, OpenCode, Pi, plus a generic `connector` fallback) are recruitable from **Agents → Recruit** — Sprintable generates the right instruction file and config for whichever one you pick.

--- a/backend/sprintable_mcp/__main__.py
+++ b/backend/sprintable_mcp/__main__.py
@@ -26,7 +26,18 @@ async def _setup() -> list[str] | None:
 
 def main() -> None:
     if not settings.sprintable_api_url:
-        print("Error: SPRINTABLE_API_URL environment variable required", file=sys.stderr)
+        # story #2166(2026-07-25, 까심 QA): 이전엔 "required"만 찍고 값이 무엇인지·어디서
+        # 얻는지 0였다 — OSS 사용자의 첫 명령이 안내 없이 죽는 첫인상 결함이었다. self-host
+        # 예시(docker-compose 기본 backend 포트 8000)만 값으로 박는다 — prod URL을 여기
+        # 하드코딩하면 self-host 사용자를 조용히 우리 백엔드로 연결시키는 더 나쁜 결함이 된다
+        # (①을 기본값으로도 채택 안 한 이유와 동일 근거).
+        print(
+            "Error: SPRINTABLE_API_URL environment variable required "
+            "(the base URL of your Sprintable backend).\n"
+            "  Self-hosting (docker compose up)? Try: export SPRINTABLE_API_URL=http://localhost:8000\n"
+            "  Using a hosted Sprintable instance? See https://pypi.org/project/sprintable/ for the URL to use.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     # E-MCP-HTTP S1: transport 분기. http=외부/Poke(per-request bearer·startup env-key auth/filter 없음·

--- a/backend/tests/test_2166_sprintable_mcp_missing_api_url_message.py
+++ b/backend/tests/test_2166_sprintable_mcp_missing_api_url_message.py
@@ -1,0 +1,52 @@
+"""story #2166(2026-07-25, 까심 QA) — `uvx sprintable` 첫 실행 시 SPRINTABLE_API_URL 미설정
+에러 메시지가 "무엇을 설정해야 하는지·어디서 얻는지"를 실제로 알려주는지 고정한다.
+
+이전엔 "환경변수가 필요하다"까지만 말하고 값·출처는 침묵해 OSS 사용자의 첫 명령이 안내 없이
+죽었다(유입손실). self-host 예시값만 메시지에 박고 prod URL은 절대 하드코딩하지 않는다 —
+그러면 self-host 사용자를 조용히 다른 백엔드로 연결시키는 더 나쁜 결함이 된다(story 본문 ①
+기각 근거와 동일).
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+def test_missing_api_url_message_gives_next_step(monkeypatch, capsys):
+    from sprintable_mcp import __main__ as main_mod
+    from sprintable_mcp.config import settings
+
+    monkeypatch.setattr(settings, "sprintable_api_url", "")
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_mod.main()
+
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    # 값이 무엇인지(백엔드 base URL)를 설명해야
+    assert "base URL" in err or "backend" in err
+    # self-host 예시를 그 자리에서 바로 복붙 가능한 형태로 줘야
+    assert "SPRINTABLE_API_URL=http://localhost:8000" in err
+    # hosted 사용자는 어디를 보라는 안내가 있어야
+    assert "pypi.org/project/sprintable" in err
+    # ⛔prod 백엔드 URL을 메시지에 하드코딩하지 않는다(① 기각 근거 — self-host 사용자를
+    # 조용히 다른 백엔드로 연결시키는 더 나쁜 결함 방지).
+    assert "run.app" not in err
+    assert "sprintable-backend-prod" not in err
+
+
+def test_missing_api_url_exits_before_agent_key_check(monkeypatch, capsys):
+    """SPRINTABLE_API_URL 체크가 AGENT_API_KEY 체크보다 먼저라 두 값 다 없어도 URL 메시지만
+    나와야(한 번에 하나씩 안내 — 무회귀 고정)."""
+    from sprintable_mcp import __main__ as main_mod
+    from sprintable_mcp.config import settings
+
+    monkeypatch.setattr(settings, "sprintable_api_url", "")
+    monkeypatch.setattr(settings, "agent_api_key", "")
+
+    with pytest.raises(SystemExit):
+        main_mod.main()
+
+    err = capsys.readouterr().err
+    assert "AGENT_API_KEY" not in err


### PR DESCRIPTION
## Summary
`uvx sprintable` crashed on first run with just "SPRINTABLE_API_URL environment variable required" — no hint of what value or where to get it. First command a new OSS user runs, dying without guidance, is signup loss rather than a feature bug.

## Root cause disambiguation (① / ② / ③)
Ruled out a hardcoded SaaS default (①): this repo's primary onboarding path is self-host (git clone + docker compose), and no confirmed public self-serve SaaS signup exists — defaulting to our prod backend would silently connect self-hosters to someone else's backend, a worse failure than the current explicit error.

Verdict: ②+③. The value is legitimately environment-specific (must be set explicitly), and the real gap was that the correct docs (`backend/sprintable_mcp/README.md`, which is also literally the PyPI page via `readme = "README.md"` in its `pyproject.toml`) don't reach the user at the moment of failure — plus the top-level README never mentioned `uvx sprintable` as an onboarding option at all, a discoverability gap for anyone arriving via GitHub rather than PyPI.

## Changes
- `backend/sprintable_mcp/__main__.py`: error message now names what the value is, gives a copy-pasteable self-host example (`http://localhost:8000`, matching `docker-compose.yml`'s backend port — not `:3108`, which is the frontend), and points hosted users at the PyPI README. Does **not** hardcode the prod URL in the message (same reasoning as the ① rejection above — don't silently route self-hosters elsewhere).
- `README.md` / `README.ko.md`: added a "No-clone stdio (`uvx sprintable`)" section so the path is discoverable from the GitHub landing page, not just PyPI.
- `backend/tests/test_2166_sprintable_mcp_missing_api_url_message.py`: regression test pinning the message content and asserting the prod URL is never hardcoded into it.

## Test plan
- [x] Reproduced in a genuinely clean environment first: `env -i HOME="$HOME" PATH="$PATH" uvx sprintable` → real PyPI install (30 packages, not cached) → same crash as reported.
- [x] New unit tests (2) pass: message contains the base-URL explanation, the self-host example, and the PyPI pointer; does not contain `run.app` or the prod backend hostname; SPRINTABLE_API_URL check fires before the AGENT_API_KEY check.
- [x] End-to-end re-verified post-fix in the same clean-env style (`env -i ... python -m sprintable_mcp`) — new message confirmed printed, exit code 1 preserved (no behavior change beyond the message).

## Explicitly out of scope (per PO)
- `npx sprintable connect` (separate npm package, already decided "abandoned" per #1937) — not touched here; the discoverability gap found in its own README will be filed as a separate story.
- Whether a public self-serve SaaS signup should exist at all — product-level question, PO is following up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)