### PR TITLE
[SID:2163] SSE dedup 전역 싱글턴이 컨슈머 간 서로 굶기던 결함 (①만)

### DIFF
--- a/apps/web/src/hooks/use-chat-sse.test.tsx
+++ b/apps/web/src/hooks/use-chat-sse.test.tsx
@@ -114,3 +114,30 @@ describe('useChatSse — 재개 커서 B계열 오염 방지(#2162, standalone-f
     expect(lastReconnectUrl().searchParams.get('last_event_id')).toBe('a-series-id');
   });
 });
+
+// story #2163 — 「알림은 오는데 화면은 안 바뀐다」 정신병의 근본이었던 그 시나리오를 실 훅
+// 두 인스턴스로 직접 재현한다. dedup tracker가 모듈 전역 싱글턴이던 시절엔 두 번째 인스턴스가
+// 굶었다(먼저 처리한 쪽이 event_id를 "이미 봤다"로 마킹) — ChatView와 GNB 뱃지(useChatUnreadTotal)
+// 가 같은 탭에서 동시에 useChatSse를 부르는 실제 배치와 동형이다.
+describe('useChatSse — 동시 마운트된 두 인스턴스가 같은 이벤트를 각자 받는다(story #2163)', () => {
+  it('ChatView·GNB 뱃지 흉내 — 같은 event_id의 conversation.message_created를 둘 다 받는다', async () => {
+    const onMessageA = vi.fn(); // ChatView 흉내
+    const onMessageB = vi.fn(); // useChatUnreadTotal(GNB 뱃지) 흉내
+    await act(async () => {
+      root.render(
+        <>
+          <Harness currentTeamMemberId="m1" onConversationMessage={onMessageA} />
+          <Harness currentTeamMemberId="m1" onConversationMessage={onMessageB} />
+        </>,
+      );
+    });
+    // mux OFF(Provider 밖)라 인스턴스마다 독립 EventSource — 서버가 둘 다에 같은 프레임을 민다.
+    expect(FakeEventSource.instances).toHaveLength(2);
+    const payload = { id: 'msg-1', event_id: 'shared-event-1' };
+    act(() => { FakeEventSource.instances[0]!.emit('conversation.message_created', payload); });
+    act(() => { FakeEventSource.instances[1]!.emit('conversation.message_created', payload); });
+
+    expect(onMessageA).toHaveBeenCalledTimes(1); // 전역 싱글턴이면 여기가 0이었다(둘 중 하나가 굶음)
+    expect(onMessageB).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useSseMultiplexerContext } from '@/components/realtime-provider';
-import { shouldSuppressDuplicateSseEvent } from '@/lib/realtime/sse-event-dedup';
+import { shouldSuppressDuplicateSseEvent, createSeenIdTracker } from '@/lib/realtime/sse-event-dedup';
 import { createReconnectBackoffState, type ReconnectBackoffState } from '@/lib/realtime/sse-reconnect-backoff';
 import { isSessionAlive } from '@/lib/realtime/sse-session-guard';
 import { isCursorEligibleEventName } from '@/lib/realtime/sse-cursor-eligibility';
@@ -85,6 +85,9 @@ export function useChatSse({ currentTeamMemberId, onConversationMessage, onWorki
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // react-hooks/refs: 렌더 중 ref.current 조건부 대입 금지라 지연초기화는 useState(초기화 함수)로.
   const [backoff] = useState<ReconnectBackoffState>(() => createReconnectBackoffState());
+  // story #2163 — 이 훅 인스턴스 전용 dedup tracker(모듈 전역 아님). 이 컴포넌트가 언마운트되면
+  // 같이 사라진다 — 다른 useChatSse 인스턴스(예: GNB 뱃지의 useChatUnreadTotal)를 굶기지 않는다.
+  const seenIdsRef = useRef(createSeenIdTracker());
   const lastEventIdRef = useRef<string | null>(null);
   const onConversationMessageRef = useRef(onConversationMessage);
   const onWorkingRef = useRef(onWorking);
@@ -101,20 +104,20 @@ export function useChatSse({ currentTeamMemberId, onConversationMessage, onWorki
   useLayoutEffect(() => { memberIdRef.current = currentTeamMemberId; }, [currentTeamMemberId]);
 
   const handleConversationMessage = (raw: string) => {
-    if (shouldSuppressDuplicateSseEvent(raw)) return;
+    if (shouldSuppressDuplicateSseEvent(raw, seenIdsRef.current)) return;
     try {
       onConversationMessageRef.current?.(JSON.parse(raw) as Record<string, unknown>);
     } catch { /* ignore parse errors */ }
   };
   const handleWorking = (raw: string) => {
-    if (shouldSuppressDuplicateSseEvent(raw)) return;
+    if (shouldSuppressDuplicateSseEvent(raw, seenIdsRef.current)) return;
     try {
       const payload = JSON.parse(raw) as SseWorkingPayload;
       if (payload.conversation_id) onWorkingRef.current?.(payload);
     } catch { /* ignore parse errors */ }
   };
   const handleConversationRead = (raw: string) => {
-    if (shouldSuppressDuplicateSseEvent(raw)) return;
+    if (shouldSuppressDuplicateSseEvent(raw, seenIdsRef.current)) return;
     try {
       const payload = JSON.parse(raw) as SseConversationReadPayload;
       if (payload.conversation_id) onConversationReadRef.current?.(payload);

--- a/apps/web/src/hooks/use-sse-notifications.ts
+++ b/apps/web/src/hooks/use-sse-notifications.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import { useSseMultiplexerContext } from '@/components/realtime-provider';
-import { shouldSuppressDuplicateSseEvent } from '@/lib/realtime/sse-event-dedup';
+import { shouldSuppressDuplicateSseEvent, createSeenIdTracker } from '@/lib/realtime/sse-event-dedup';
 import { createReconnectBackoffState } from '@/lib/realtime/sse-reconnect-backoff';
 import { isSessionAlive } from '@/lib/realtime/sse-session-guard';
 import { isCursorEligibleEventName } from '@/lib/realtime/sse-cursor-eligibility';
@@ -56,6 +56,8 @@ export function useSseNotifications({
   const memberIdRef = useRef(memberId);
   const extraEventNamesRef = useRef(extraEventNames);
   const onExtraEventRef = useRef(onExtraEvent);
+  // story #2163 — 이 훅 인스턴스 전용 dedup tracker(모듈 전역 아님, use-chat-sse.ts와 동형).
+  const seenIdsRef = useRef(createSeenIdTracker());
   useEffect(() => { callbackRef.current = onNotification; }, [onNotification]);
   useEffect(() => { memberIdRef.current = memberId; }, [memberId]);
   useEffect(() => { extraEventNamesRef.current = extraEventNames; }, [extraEventNames]);
@@ -63,7 +65,7 @@ export function useSseNotifications({
 
   const handleData = (raw: string) => {
     if (!raw || raw.trim() === '') return;
-    if (shouldSuppressDuplicateSseEvent(raw)) return;
+    if (shouldSuppressDuplicateSseEvent(raw, seenIdsRef.current)) return;
     try {
       const parsed = JSON.parse(raw) as SseEventNotification;
       callbackRef.current?.(parsed);
@@ -72,7 +74,7 @@ export function useSseNotifications({
 
   const handleExtraEvent = (eventName: string, raw: string) => {
     if (!raw || raw.trim() === '') return;
-    if (shouldSuppressDuplicateSseEvent(raw)) return;
+    if (shouldSuppressDuplicateSseEvent(raw, seenIdsRef.current)) return;
     try {
       onExtraEventRef.current?.(eventName, JSON.parse(raw));
     } catch { /* malformed */ }

--- a/apps/web/src/lib/realtime/sse-event-dedup.test.ts
+++ b/apps/web/src/lib/realtime/sse-event-dedup.test.ts
@@ -1,10 +1,12 @@
 // story #2101 — event_id 기반 SSE dedup 유틸 회귀가드. 백엔드 백필 확대(최근 delivered
 // 포함, 다중 탭 영구 유실 방지)가 만드는 중복 배달을 클라가 정확히 한 번으로 좁히는지.
 //
-// shouldSuppressDuplicateSseEvent는 모듈 스코프 싱글턴 tracker를 공유한다(react-hooks/refs
-// lint가 handler를 HOC로 감싸는 패턴 자체를 막아, 각 handler 본문 첫 줄에서 직접 호출하는
-// 관례로 감 — 설계 이력은 sse-event-dedup.ts 상단 주석 참고) — 이 파일의 테스트 케이스들은
-// 서로 다른 event_id를 써서 싱글턴 상태 간섭을 피한다.
+// story #2163 — shouldSuppressDuplicateSseEvent는 더 이상 모듈 스코프 싱글턴을 쓰지 않는다.
+// 호출부가 자기 tracker(createSeenIdTracker())를 만들어 넘긴다 — 전역이었을 때 "같은 탭 안의
+// 서로 다른 useChatSse 컨슈머(ChatView·GNB 뱃지)가 같은 event_id를 두고 서로를 굶기던" 결함의
+// 회귀가드가 아래 "두 컨슈머" 블록이다. #2101의 원 목적(같은 컨슈머가 재연결 백필로 같은
+// 이벤트를 두 번 받는 것 억제)은 "같은 tracker" 블록이 그대로 지킨다 — 이 둘이 쌍으로 있어야
+// "이번 결함을 고치다 #2101을 깼는지"를 가를 수 있다.
 
 import { describe, expect, it } from 'vitest';
 import { createSeenIdTracker, extractSseEventId, shouldSuppressDuplicateSseEvent } from './sse-event-dedup';
@@ -44,25 +46,28 @@ describe('createSeenIdTracker (isolated instances — testability primitive)', (
   });
 });
 
-describe('shouldSuppressDuplicateSseEvent (module-scope singleton — production API)', () => {
+describe('shouldSuppressDuplicateSseEvent — 같은 tracker(story #2101 원 목적, 아직 지켜지는지)', () => {
   it('suppresses the second delivery of a duplicate event_id, passes distinct ones', () => {
+    const tracker = createSeenIdTracker();
     const idA = 'sup-dup-1';
     const idB = 'sup-dup-2';
-    expect(shouldSuppressDuplicateSseEvent(`{"event_id":"${idA}"}`)).toBe(false);
-    expect(shouldSuppressDuplicateSseEvent(`{"event_id":"${idA}"}`)).toBe(true); // 재배달 억제
-    expect(shouldSuppressDuplicateSseEvent(`{"event_id":"${idB}"}`)).toBe(false); // 별개 id는 통과
+    expect(shouldSuppressDuplicateSseEvent(`{"event_id":"${idA}"}`, tracker)).toBe(false);
+    expect(shouldSuppressDuplicateSseEvent(`{"event_id":"${idA}"}`, tracker)).toBe(true); // 재배달 억제
+    expect(shouldSuppressDuplicateSseEvent(`{"event_id":"${idB}"}`, tracker)).toBe(false); // 별개 id는 통과
   });
 
   it('never suppresses when event_id is absent (no regression for legacy payloads)', () => {
+    const tracker = createSeenIdTracker();
     const payload = '{"no_id":"legacy-sup"}';
-    expect(shouldSuppressDuplicateSseEvent(payload)).toBe(false);
-    expect(shouldSuppressDuplicateSseEvent(payload)).toBe(false);
+    expect(shouldSuppressDuplicateSseEvent(payload, tracker)).toBe(false);
+    expect(shouldSuppressDuplicateSseEvent(payload, tracker)).toBe(false);
   });
 
   it('simulates the handler-first-line convention used across use-chat-sse.ts/use-sse-notifications.ts', () => {
+    const tracker = createSeenIdTracker();
     const calls: string[] = [];
     const handle = (raw: string) => {
-      if (shouldSuppressDuplicateSseEvent(raw)) return;
+      if (shouldSuppressDuplicateSseEvent(raw, tracker)) return;
       calls.push(raw);
     };
 
@@ -75,5 +80,32 @@ describe('shouldSuppressDuplicateSseEvent (module-scope singleton — production
     handle(payloadB);
 
     expect(calls).toEqual([payloadA, payloadB]);
+  });
+});
+
+// story #2163 — 이 블록이 이번 결함의 핵심 판별력이다. 전역 싱글턴이었을 때는 아래 첫 테스트가
+// 실패했다(먼저 처리한 컨슈머가 마킹해 버려 두 번째 컨슈머가 자기 입장에서 "처음 보는" 이벤트를
+// 못 받았다) — 뱃지는 +1 되는데 채팅창은 안 바뀌는 증상이 정확히 이것이었다.
+describe('shouldSuppressDuplicateSseEvent — 서로 다른 tracker(컨슈머 간, 이번 결함)', () => {
+  it('두 독립 컨슈머(ChatView·GNB 뱃지 흉내)가 같은 event_id를 각자 받는다 — 굶기지 않는다', () => {
+    const chatViewTracker = createSeenIdTracker();
+    const gnbBadgeTracker = createSeenIdTracker();
+    const raw = '{"event_id":"cross-consumer-1","content":"hi"}';
+
+    // GNB 뱃지가 먼저 처리한다고 가정(트리 상위라 먼저 구독되는 경향 — 실측된 순서).
+    const gnbSuppressed = shouldSuppressDuplicateSseEvent(raw, gnbBadgeTracker);
+    const chatViewSuppressed = shouldSuppressDuplicateSseEvent(raw, chatViewTracker);
+
+    expect(gnbSuppressed).toBe(false); // 뱃지: +1
+    expect(chatViewSuppressed).toBe(false); // 채팅창: 굶지 않고 자기 몫을 받는다(전역이면 여기서 true였다)
+  });
+
+  it('컨슈머가 3개여도 전부 각자 받는다(2개로 우연히 맞은 게 아님을 고정)', () => {
+    const trackers = [createSeenIdTracker(), createSeenIdTracker(), createSeenIdTracker()];
+    const raw = '{"event_id":"cross-consumer-triple","content":"hi"}';
+
+    const results = trackers.map((t) => shouldSuppressDuplicateSseEvent(raw, t));
+
+    expect(results).toEqual([false, false, false]);
   });
 });

--- a/apps/web/src/lib/realtime/sse-event-dedup.ts
+++ b/apps/web/src/lib/realtime/sse-event-dedup.ts
@@ -41,6 +41,19 @@
  * 파일 단위 판정이라 완벽하지 않다(sse-dedup-enforcement.ts 상단 주석의 한계 선언 참고).
  * 게이트 이전에는 컴파일도 테스트도 안 걸리고 unread 뱃지가 조용히 이중 증가하거나 알림
  * 리스트에 중복이 쌓이는 형태로만 드러났다(원인 파악이 어려운 클래스의 버그였다).
+ *
+ * ⚠️ 2026-07-25 정정(story #2163) — seen-id 저장소가 모듈 스코프 **전역 싱글턴**이었던 것이
+ * 새로운 버그 클래스를 낳았다: "이 이벤트를 내가 이미 처리했나"는 **소비자별** 질문인데,
+ * 그 답을 탭 전체가 공유하는 Set 하나가 대신하고 있었다. 같은 탭 안에 `useChatSse`를 각자
+ * 부르는 서로 다른 컨슈머(ChatView 자신 · GNB unread 뱃지의 `useChatUnreadTotal`)가 동시에
+ * 마운트돼 있으면, 같은 `event_id`가 둘 다에 도착했을 때 **먼저 처리한 쪽이 "이미 봤다"로
+ * 마킹**해 버려 **나중 컨슈머는 자기 입장에서는 처음 보는 이벤트인데도 조용히 굶는다** —
+ * 뱃지는 +1 되는데 채팅창은 안 바뀌는 증상(정신병 리스트 #2163)이 이것이었다.
+ * ⇒ seen-id 저장소를 **호출부(각 `useChatSse`/`useSseNotifications` 인스턴스)가 직접
+ * 만들어 들고 있다가 이 함수에 넘기는 방식**으로 바꿨다 — 인스턴스가 언마운트되면 그
+ * Set도 같이 사라진다(전역 수명 잔존 없음). #2101의 원 목적(같은 컨슈머가 재연결 백필로
+ * 같은 이벤트를 두 번 받는 것 억제)은 **그 컨슈머 자신의 tracker 안에서 그대로 유지**된다
+ * — 애초에 그 중복도 "같은 컨슈머가 같은 걸 두 번" 문제였으므로 인스턴스 스코프로 충분하다.
  */
 
 const _MAX_SEEN_IDS = 500; // 무한 증식 방지 — FIFO 경계(재연결 시나리오엔 넉넉한 여유)
@@ -79,18 +92,16 @@ export function extractSseEventId(raw: string): string | null {
   }
 }
 
-/** 앱 전역 SSE 이벤트가 공유하는 단일 seen-id 저장소 — 모듈 스코프(React ref 아님). */
-const _globalSeenIds = createSeenIdTracker();
-
 /**
- * 이미 본 event_id면 true(호출부는 조기 return으로 처리를 건너뛴다) — 전역 싱글턴 기준.
- * 각 SSE handler 본문 **첫 줄**에서 직접 호출하는 것이 관례다(위 설계 이력 참고 — HOC로
- * 감쌀 수 없다).
+ * 이미 본 event_id면 true(호출부는 조기 return으로 처리를 건너뛴다) — `tracker` 기준(story
+ * #2163 — 전역 싱글턴 아님, 호출부가 자기 인스턴스 수명에 맞는 tracker를 직접 들고 있다가
+ * 넘긴다). 각 SSE handler 본문 **첫 줄**에서 직접 호출하는 것이 관례다(위 설계 이력 참고 —
+ * HOC로 감쌀 수 없다).
  */
-export function shouldSuppressDuplicateSseEvent(raw: string): boolean {
+export function shouldSuppressDuplicateSseEvent(raw: string, tracker: SseSeenIdTracker): boolean {
   const eventId = extractSseEventId(raw);
   if (eventId === null) return false;
-  if (_globalSeenIds.hasSeen(eventId)) return true;
-  _globalSeenIds.markSeen(eventId);
+  if (tracker.hasSeen(eventId)) return true;
+  tracker.markSeen(eventId);
   return false;
 }


### PR DESCRIPTION
## 배경 — AC2를 먼저 돌렸다(중복 굴착 방지)
선생님 「정신병 리스트」#2163: "새 메시지 도착 시 알림은 오는데 화면은 안 바뀐다 — 이탈 후 재진입해야 갱신". 오늘 착지한 #2158(재연결 공백 재생버퍼)·#2139(presence backplane)·#2160(세션 죽은 탭)이 이미 고쳤는지 **먼저 확認** — 셋 다 SSE **전달(delivery)** 계층 픽스라, 이 버그(전달은 되는데 **렌더 소비**가 굶는 것)를 안 건드림을 코드로 확定한 뒤 새로 팠다.

## 근본원인
`sse-event-dedup.ts`의 `_globalSeenIds`가 **모듈스코프 전역 싱글턴**이었다. 같은 탭 안에 `useChatSse`를 각자 부르는 서로 다른 컨슈머 — `ChatView`(채팅 화면 자체) · `useChatUnreadTotal`(GNB unread 뱃지, 모든 인증 페이지에 항상 마운트) — 가 동시에 존재하면, 같은 `event_id`(`conversation.message_created`)가 둘 다에 도착했을 때 **먼저 처리한 쪽이 "이미 봤다"로 마킹**해 버려 **나중 컨슈머는 자기 입장에서 처음 보는 이벤트인데도 조용히 스킵**됐다.

⇒ 뱃지는 +1 되는데(먼저 처리) 채팅창은 안 바뀌는(늦게 처리돼 스킵) — 신고된 증상 그 자체. 이탈→재진입하면 `ChatView`가 리마운트되며 REST `fetchMessages()`로 새로 받아오니 "고쳐지는" 것처럼 보였을 뿐.

mux ON/OFF 무관 — OFF(현재 배포 상태)에서도 서버가 두 독립 `EventSource` 커넥션에 같은 프레임을 밀면, 클라이언트 dedup은 탭 전체 공유(모듈 스코프)라 동일하게 발생한다.

## 변경
- `shouldSuppressDuplicateSseEvent(raw)` → `shouldSuppressDuplicateSseEvent(raw, tracker)`로 시그니처 변경, 전역 싱글턴(`_globalSeenIds`) 제거.
- `use-chat-sse.ts`/`use-sse-notifications.ts`: 각 훅 **인스턴스 수명에 붙는 tracker**(`useRef(createSeenIdTracker())`)를 만들어 넘긴다. `useState`가 아니라 `useRef`인 이유: `useState`로 하면 exhaustive-deps가 handler 함수 자체를 effect dep으로 요구해 이 파일의 기존 "ref로 최신 콜백 들고 있기" 관례(stale-closure 방지)와 충돌 — `useRef`로 감으로써 무형(no-op) 확認.
- **#2101의 원 목적**(같은 컨슈머가 재연결 백필로 같은 이벤트를 두 번 받는 것 억제)은 인스턴스 스코프 tracker 안에서 그대로 유지 — 애초에 그 중복도 "같은 컨슈머가 같은 걸 두 번" 문제였으므로 인스턴스 스코프로 충분하다.

## ②(기기 간 불일치)는 별개 — 이 PR 스코프 밖
`_globalSeenIds`는 런타임(탭)별이라 기기 간 공유 자체가 없다 — 이 결함으로 설명 안 됨. 별도 조사·보고 예정.

## 회귀가드 쌍 — 이번 결함의 핵심 판별력
```
① 서로 다른 tracker(컨슈머 간, 이번 결함) — 굶기지 않는다
② 같은 tracker(#2101 원 목적)          — 재연결 중복은 여전히 억제된다
```
①만 걸면 #2101을 깨뜨려도 초록이 되는 자리라 반드시 쌍으로 고정. 추가로 **실 훅 통합테스트**(`use-chat-sse.test.tsx`) — `useChatSse` 두 인스턴스를 동시 마운트(ChatView·GNB 뱃지 실제 배치와 동형)해 같은 `event_id`를 각자 받는지 real hook 코드로 직접 확認.

**뮤테이션 셀프체크** 3건: 전역 싱글턴으로 되돌리기(①이 RED) / 억제 자체 무력화(②가 RED) / 통합테스트용 전역 tracker 재현(통합테스트가 RED) — 전부 확認 후 복구.

## 검증
- type-check·lint·build 통과, vitest 298 files 전건 PASS(2회차 클린). 1회차에서 `kanban-board.test.tsx` 15건 실패는 오늘 하루 반복 관측된 기존 격리성 플레이키니스(이 diff는 kanban-board 접촉 0).

## Test plan
- [x] 회귀가드 쌍 + 실 훅 통합테스트 + 뮤테이션 셀프체크 3건
- [ ] 배포 후 실 브라우저 두 화면(또는 채팅+GNB 뱃지 동시 관찰)으로 라이브 확認 — 이 버그는 순수 클라이언트 JS 로직이라 유닛/통합 테스트로 결정론적 검증이 가능했음을 참고(Cloud Run/AbortSignal류처럼 런타임 자체가 불확실 변수인 경우와 다름)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>