### PR TITLE
fix(#2185): dev REALTIME_URL 을 배포 SSOT 로 옮긴다 — 손 gcloud 값이 다음 배포에 덮였다

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -179,7 +179,21 @@ jobs:
             echo "realtime_min_instances=2" >> "$GITHUB_OUTPUT"
             echo "realtime_max_instances=8" >> "$GITHUB_OUTPUT"
             echo "realtime_timeout=3600" >> "$GITHUB_OUTPUT"
-            echo "realtime_url=https://sprintable-realtime-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
+            # ⭐story #2185(2026-07-25) — dev 를 prod 와 같은 스택으로 맞춘다.
+            # prod 프론트는 이미 GCE 로드밸런서(realtime.sprintable.ai)를 보고 있고 실 트래픽
+            # 353건/48h 을 받는데, dev 만 옛 Cloud Run 을 보고 있었다 ⇒ **GCE 축을 dev 에서
+            # 검증할 수 없었다**(#2180 을 GCLB 로그로 우회 측정해야 했던 것이 그 비용).
+            # ⛔PO 가 2026-07-25 `gcloud run services update` 로 손 플립했다가 **다음 배포가
+            #   그대로 덮었다**(리비전 01836→01838 에서 옛 URL 복귀) — 바로 아래 줄에 적힌
+            #   「손 gcloud 값은 다음 배포가 덮으니 여기 durable 로 못박는다」를 PO 가 어긴 것이다.
+            #   그래서 값을 여기(배포 SSOT)로 옮긴다.
+            # 전환 前 확認(실측): dev GCE LB /api/v2/ping·health 200 · 백엔드 3대 전부 HEALTHY.
+            # 전환 後 확認(실측): GCLB 에 /api/v2/events/stream 200 다건 · 점유 55~87초(p50 60)
+            #   ⇒ Cloud Run 시절 112~121초(전부 서버 캡에 걸림)와 달리 **캡 前에 스스로 종료**.
+            # ⚠️무너지는 조건: dev GCE 스택(realtime-gateway-dev MIG·GCLB)이 내려가면 이 값도
+            #   되돌려야 한다. 롤백은 이 줄을 옛 Cloud Run URL 로 되돌리고 재배포하면 즉시 복귀
+            #   (route.ts 는 REALTIME_URL 이 비면 FASTAPI_URL 로 폴백하는 설계 그대로).
+            echo "realtime_url=https://dev-realtime.sprintable.ai" >> "$GITHUB_OUTPUT"
             # story #2078(E-ARCH 1단계 durable화, 2026-07-21 PO 손 플립 확認 후): api는 SSE/LISTEN
             # 을 realtime-dev로 넘겼다(까심군 raw SSE 검증 PASS). 손 gcloud 값은 다음 배포가
             # 덮으니(오늘 규율) 여기 durable로 못박는다 — 다음 api 배포에서도 false 유지.


### PR DESCRIPTION
## 무엇이 있었나

PO 가 오늘 `gcloud run services update` 로 dev 프론트의 `REALTIME_URL` 을 GCE LB 로 손 플립했고, **다음 배포가 그대로 덮었다.**

```
설정  REALTIME_URL = https://dev-realtime.sprintable.ai   (리비전 01836-bb6)
이후  REALTIME_URL = 옛 Cloud Run URL                      (리비전 01838-gj8)
관측  GCLB 에 SSE 0건(스캐너 404 만) · 프론트는 200 서빙 ⇒ **트래픽이 GCE 로 안 감**
```

⛔**바로 아래 줄에 그 규율이 이미 적혀 있었다** — *"손 gcloud 값은 다음 배포가 덮으니(오늘 규율) 여기 durable 로 못박는다"*(story #2078 주석). **PO 가 알고도 어긴 것이다.** 그래서 값을 배포 SSOT 로 옮긴다.

## 왜 GCE 를 가리켜야 하나

prod 프론트는 이미 GCE LB(`realtime.sprintable.ai`)를 보고 **실 트래픽 353건/48h** 를 받는데 dev 만 옛 Cloud Run 을 보고 있었다.

⇒ **GCE 축을 dev 에서 검증할 수 없었다.** 그 비용이 오늘 실제로 났다 — #2180(GCE fanout 플래그)을 dev 에서 못 보고 GCLB 로그로 우회 측정해야 했다.

## 실측 근거

| 시점 | 관측 |
|---|---|
| 전환 前 | dev GCE LB `/api/v2/ping`·`/api/v2/health` **200** · 백엔드 **3대 전부 HEALTHY** |
| 전환 後 | GCLB 에 `/api/v2/events/stream` **200 다건** · 점유 **55.4~87.2초**(p50 60.1) · 503 **0** |

⭐**Cloud Run 시절엔 112~121초로 전부 서버 캡(90+jitter+heartbeat)에 걸려 끝났는데, GCE 에서는 캡 前에 스스로 종료한다.** 같은 코드·같은 프론트·같은 클라이언트에서 런타임만 바뀐 결과다.

## 범위

- **dev 만.** prod 는 `realtime_url` output 자체를 안 내보내고 `deploy-realtime` 스텝도 `_DEPLOY_ENV` 가드로 스킵된다 — 파일 내 `realtime_url=` 은 **이 한 줄뿐**(grep 확認).
- ⚠️**무너지는 조건**과 **롤백 경로**를 주석에 명시했다: dev GCE 스택이 내려가면 이 값도 되돌린다. 롤백은 이 줄을 옛 Cloud Run URL 로 되돌려 재배포하면 즉시 복귀(`route.ts` 는 `REALTIME_URL` 이 비면 `FASTAPI_URL` 로 폴백하는 설계 그대로).

## 검증

```
YAML 파싱 OK (jobs=['cloud-build'])
realtime_url= 선언 위치 1곳뿐 — prod 무영향 확認
```

## 착지 後 확認할 것 (PO)

배포 뒤 **frontend-dev 의 라이브 env 가 실제로 GCE LB 인지**와 **GCLB 에 SSE 가 다시 흐르는지**를 실측한다. ⛔"배포 성공"으로 닫지 않는다 — 이 PR 자체가 그 교훈에서 나온 것이다.

연결: #2185 · #2180 · #2078 · #2089(이 전환이 그 선행조건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)