### PR TITLE
[SID:2089] realtime_main.py에 health.router 추가 — GCLB 헬스체크 계약 fix

### DIFF
--- a/backend/app/realtime_main.py
+++ b/backend/app/realtime_main.py
@@ -114,10 +114,18 @@ async def realtime_lifespan(app: FastAPI):
         await engine.dispose()
 
 
-# story #2089 핵심 — 여기서 딱 두 라우터만 import한다. app.main.py:147의 90+ 모듈
+# story #2089 핵심 — SSE router 둘 + health 하나만 import한다. app.main.py:147의 90+ 모듈
 # 일괄 import(alembic·ee·mcp 게이트를 함께 끌고 오는 그 배선)를 반복하지 않는 것이
 # 이 entrypoint의 전체 목적이다.
-from app.routers import agent_gateway, events  # noqa: E402
+#
+# ⚠️ health.router는 REST를 안 서빙하는 이 서비스가 왜 예외로 갖고 있는지 이유를 남긴다
+# (2026-07-25, 오르테가군 3-a 라이브 배포 실패 후 발견 — 지우면 안 됨): GCLB 백엔드
+# 헬스체크(provision_realtime_gclb.sh) 대상이 `/api/v2/ping`이다. 이 라우트가 없으면
+# GCLB가 이 서비스를 영구 UNHEALTHY로 보고 502를 낸다 — "REST를 안 서빙한다"는 이유로
+# 이 라우터까지 빼면 부팅은 되지만 로드밸런서 뒤에서 트래픽을 못 받는다. `/api/v2/health`
+# (DB 조회 포함)도 같은 라우터에 있지만 GCLB는 `/ping`(DB 미조회)만 쓴다 — 그래도 분리해서
+# 뺄 이유가 없어(같은 파일·같은 위험 0) 함께 마운트한다.
+from app.routers import agent_gateway, events, health  # noqa: E402
 
 app = FastAPI(
     title="Sprintable Realtime Gateway (stage2 측정용 시제품)",
@@ -172,3 +180,4 @@ app.add_middleware(
 
 app.include_router(events.router)
 app.include_router(agent_gateway.router)
+app.include_router(health.router)

--- a/backend/tests/test_realtime_main_external_contracts.py
+++ b/backend/tests/test_realtime_main_external_contracts.py
@@ -1,0 +1,51 @@
+"""story #2089(2026-07-25, 오르테가군 지적) — 3-a 라이브 배포가 GCLB 헬스체크 실패(502)로
+롤백된 뒤 세운 회귀가드.
+
+2단계(«실제 로드된 모듈 목록» 측정)는 **의존**은 잡았지만 **이 서비스에 외부가 요구하는
+계약**은 못 잡았다 — 로컬 TestClient 기동은 헬스체크를 안 태우므로 그 갭이 로컬에서는
+안 보였다. `/api/v2/ping`이 빠진 채로 배포돼 GCLB가 영구 UNHEALTHY로 보고 502를 냈다.
+
+이 파일은 realtime_main.py가 실제로 서비스해야 하는 외부 계약을 하나씩 명시하고 pin한다
+(지금 아는 것은 GCLB 헬스체크 하나 — provision_realtime_gclb.sh 대조 확認. 더 있으면
+이 파일에 추가할 것).
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_gclb_health_check_path_responds_200():
+    """provision_realtime_gclb.sh:112 --request-path=/api/v2/ping 과 대조 — 이 경로가
+    없으면 GCLB가 이 서비스를 영구 UNHEALTHY로 판정해 502를 낸다(2026-07-25 실제 배포
+    실패로 확認된 실패 모드)."""
+    import app.realtime_main as rm
+
+    with TestClient(rm.app) as client:
+        response = client.get("/api/v2/ping")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_gclb_health_check_path_matches_provision_script():
+    """provision_realtime_gclb.sh의 --request-path 값 자체가 바뀌면 이 pin도 같이 갱신돼야
+    한다 — 두 파일이 서로 다른 경로를 말하게 되는 드리프트를 잡는다."""
+    import pathlib
+
+    script = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "scripts" / "provision_realtime_gclb.sh"
+    )
+    assert script.exists()
+    source = script.read_text()
+    assert "--request-path=/api/v2/ping" in source, (
+        "provision_realtime_gclb.sh의 헬스체크 경로가 바뀌었다 — "
+        "realtime_main.py가 그 경로를 여전히 서빙하는지 재확認 필요"
+    )


### PR DESCRIPTION
## Summary
⚠️ #2495(stage 3-a 초안·fire-and-forget 허용목록 fix)는 이미 스쿼시 머지됨(브랜치 삭제됨). 이 PR은 그 이후 발견된 후속 fix 하나만 담는다 — 새 브랜치로 다시 연다.

## 배경 — 3-a 라이브 배포 실패
GCLB 백엔드 헬스체크 대상이 `/api/v2/ping`(`provision_realtime_gclb.sh:112`)인데 `realtime_main.py`는 `events.router`+`agent_gateway.router` 둘만 마운트해 그 경로가 없었다. MIG는 RUNNING이었으나 GCLB가 영구 UNHEALTHY로 판정 → 502. 즉시 롤백(트래픽 영향 0 — 옛 진입점으로 안전 복구, GCE 전환 순서 판단이 맞았음이 증명됨).

stage 2의 `sys.modules` 측정은 "무엇을 import하는가"(의존)는 정확히 잡았지만 "외부가 이 서비스에 요구하는 계약"(GCLB 헬스체크 경로)은 로컬 `TestClient` 기동으로는 안 보이는 축이었다(로컬 실행은 헬스체크를 안 태움).

## 처방
- `health.router` 마운트 + "REST를 안 서빙하는 서비스가 왜 이 라우터만 예외로 갖는가" 이유를 소스에 명시.
- 신규 회귀 테스트 2건: `/api/v2/ping` 200 응답 확認 · `provision_realtime_gclb.sh`의 `--request-path` 값과 코드 일치 여부 드리프트 가드(외부 계약이 코드 밖 스크립트에 있던 것을 테스트로 묶음 — 이번 실패의 근본을 원천 차단).

## Test plan
- [x] `app/realtime_main.py` 정적 import 확認(risky 모듈 0건 유지)
- [x] 신규 2건 + 기존 관련 42건 전부 그린(44건)
- [x] 뮤테이션 셀프체크: `health.router` 마운트 주석 처리 → `/api/v2/ping` 정확히 404(실제 배포 실패와 같은 실패 모드) → 복구 확認

🤖 Generated with [Claude Code](https://claude.com/claude-code)