### PR TITLE
feat(#2165): hide scrollbars product-wide, keep them on code blocks + tables

### DIFF
--- a/apps/web/src/app/globals-scrollbar.test.ts
+++ b/apps/web/src/app/globals-scrollbar.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// story #2165(2026-07-25, 까심 QA): 제품 전역 스크롤바 숨김 + 코드블럭/표 예외. CSS는 jsdom으로
+// 렌더 검증이 안 돼(실제 스크롤바 렌더는 브라우저 전용) 소스 문자열 불변식으로 고정한다:
+// ① 전역 숨김 규칙이 존재 ② .scrollbar-visible 예외 클래스가 그것을 되살림 ③ 스크롤 "기능"
+// 자체를 막는 overflow:hidden으로 되어있지 않음(숨기는 것과 못 굴리게 하는 것은 다르다).
+describe('전역 스크롤바 숨김 CSS 불변식 (#2165)', () => {
+  const css = fs.readFileSync(
+    path.resolve(__dirname, 'globals.css'),
+    'utf8',
+  );
+
+  it('전역 * 규칙이 scrollbar-width:none + webkit scrollbar display:none 이다', () => {
+    expect(css).toMatch(/\*\s*\{\s*scrollbar-width:\s*none;\s*\}/);
+    expect(css).toContain('*::-webkit-scrollbar { display: none; }');
+  });
+
+  it('.scrollbar-visible 이 scrollbar-width:thin으로 되살리고 overflow는 건드리지 않는다', () => {
+    expect(css).toMatch(/\.scrollbar-visible[^{]*\{[^}]*scrollbar-width:\s*thin/);
+    expect(css).not.toMatch(/\.scrollbar-visible[^{]*\{[^}]*overflow:\s*hidden/);
+  });
+
+  it('.doc-renderer pre 후손 선택자도 같은 예외를 받는다(raw HTML 주입 경로라 클래스 직접 부착 불가)', () => {
+    expect(css).toMatch(/\.doc-renderer pre[^{]*\{[^}]*scrollbar-width:\s*thin|\.scrollbar-visible,\s*\n?\s*\.doc-renderer pre/);
+  });
+});
+
+describe('코드블럭/표 wrapper가 scrollbar-visible을 잃지 않았다 (#2165)', () => {
+  const files = [
+    'docs/extensions/code-block-copy.tsx',
+    'docs/doc-content-renderer.tsx',
+    'chat/chat-bubble.tsx',
+    'chat/embed-card.tsx',
+    'kanban/story-detail-panel.tsx',
+    'agents/access-matrix-tab.tsx',
+    'settings/workflow-execution-history-section.tsx',
+  ];
+
+  for (const file of files) {
+    it(`components/${file} 안에 scrollbar-visible 클래스가 존재한다`, () => {
+      const content = fs.readFileSync(
+        path.resolve(__dirname, '../components', file),
+        'utf8',
+      );
+      expect(content).toContain('scrollbar-visible');
+    });
+  }
+});

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -490,13 +490,33 @@
     @apply border-border outline-ring;
     outline-width: 2px;
     outline-offset: 2px;
+  }
+
+  /* story #2165(2026-07-25, 까심 규격): 제품 전역 스크롤바 숨김(가로·세로 모두) — 스크롤
+     "기능"은 유지, 시각적 바만 없앤다. 대부분의 표면에서 스크롤바는 잡음이지만, 콘텐츠가
+     가로로 잘려 있다는 사실 자체를 알려야 하는 표면(코드블럭·표 — 잘린 열/줄이 안 보이면
+     사용자가 존재를 모른다)은 `.scrollbar-visible`로 개별 옵트인한다. */
+  * {
+    scrollbar-width: none;
+  }
+  *::-webkit-scrollbar { display: none; }
+
+  /* .doc-renderer pre: doc-content-renderer.tsx의 legacy html-format 경로가 raw HTML 문자열을
+     그대로 주입해(dangerouslySetInnerHTML) 내부 <pre>에 클래스를 직접 못 붙인다 — 조상
+     .doc-renderer(항상 존재하는 컨테이너 클래스)를 거쳐 후손 선택자로 동일 예외를 적용한다. */
+  .scrollbar-visible,
+  .doc-renderer pre {
     scrollbar-width: thin;
     scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
   }
-  *::-webkit-scrollbar { width: 6px; height: 6px; }
-  *::-webkit-scrollbar-track { background: var(--scrollbar-track); }
-  *::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 3px; }
-  *::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); }
+  .scrollbar-visible::-webkit-scrollbar,
+  .doc-renderer pre::-webkit-scrollbar { display: block; width: 6px; height: 6px; }
+  .scrollbar-visible::-webkit-scrollbar-track,
+  .doc-renderer pre::-webkit-scrollbar-track { background: var(--scrollbar-track); }
+  .scrollbar-visible::-webkit-scrollbar-thumb,
+  .doc-renderer pre::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 3px; }
+  .scrollbar-visible::-webkit-scrollbar-thumb:hover,
+  .doc-renderer pre::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); }
 
   /* story #2062(유나 규격): #2057의 outline-offset:2px(바깥 4px 돌출)가 패딩 0인
      overflow-*-auto 스크롤 컨테이너에서 클리핑된다 — 링이 컨테이너 밖으로 못 새어나가

--- a/apps/web/src/components/agents/access-matrix-tab.tsx
+++ b/apps/web/src/components/agents/access-matrix-tab.tsx
@@ -190,7 +190,8 @@ export function AccessMatrixTab() {
               <p className="text-sm text-muted-foreground">{ta('matrixEmpty')}</p>
             </div>
           ) : (
-            <div className="focus-inset overflow-x-auto rounded-md border border-border">
+            // story #2165: 표는 전역 스크롤바 숨김 예외 — 가로로 잘린 열이 있다는 것을 알려야 한다.
+            <div className="focus-inset overflow-x-auto scrollbar-visible rounded-md border border-border">
               <table className="w-full border-collapse text-sm">
                 <thead>
                   <tr className="border-b border-border bg-muted/30">

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -126,13 +126,15 @@ function ChatMarkdown({ content, isMine }: { content: string; isMine: boolean })
         />
       );
     },
-    pre: ({ children }: { children?: React.ReactNode }) => <pre className={`mb-1.5 overflow-x-auto rounded-lg p-2.5 text-xs ${codeBg}`}>{children}</pre>,
+    // story #2165: 코드블럭은 전역 스크롤바 숨김 예외 — 가로로 잘린 줄이 있다는 것을 알려야 한다.
+    pre: ({ children }: { children?: React.ReactNode }) => <pre className={`mb-1.5 overflow-x-auto scrollbar-visible rounded-lg p-2.5 text-xs ${codeBg}`}>{children}</pre>,
     // story #2035 AC2 — 표는 자기 컨테이너 안에서만 가로 스크롤(doc-content-renderer.tsx의
     // 검증된 not-prose overflow-x-auto 패턴 재사용). whitespace-nowrap 없으면 브라우저가
     // 열 텍스트를 좁은 말풍선 폭에 맞춰 줄바꿈/축약해버려 "열 삭제·축약 금지" 위반이 됨 —
     // nowrap으로 열 폭을 원문 그대로 유지하고 넘치는 만큼 래퍼가 스크롤하게 한다.
+    // story #2165: 표도 코드블럭과 같은 성격 — 스크롤바 숨김 예외.
     table: ({ children }: { children?: React.ReactNode }) => (
-      <div className={`mb-1.5 overflow-x-auto rounded-lg border ${border}`}>
+      <div className={`mb-1.5 overflow-x-auto scrollbar-visible rounded-lg border ${border}`}>
         <table className="whitespace-nowrap text-xs">{children}</table>
       </div>
     ),

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -76,7 +76,8 @@ const mdBodyComponents = {
   ul: ({ children }: { children?: React.ReactNode }) => <ul className="mb-2 ml-4 list-disc space-y-0.5">{children}</ul>,
   ol: ({ children }: { children?: React.ReactNode }) => <ol className="mb-2 ml-4 list-decimal space-y-0.5">{children}</ol>,
   li: ({ children }: { children?: React.ReactNode }) => <li className="text-sm leading-6">{children}</li>,
-  pre: ({ children }: { children?: React.ReactNode }) => <pre className="mb-2 overflow-x-auto rounded-lg p-3 text-[13px] bg-muted">{children}</pre>,
+  // story #2165: 코드블럭은 전역 스크롤바 숨김 예외.
+  pre: ({ children }: { children?: React.ReactNode }) => <pre className="mb-2 overflow-x-auto scrollbar-visible rounded-lg p-3 text-[13px] bg-muted">{children}</pre>,
   code: ({ children }: { children?: React.ReactNode }) => <code className="rounded px-1 py-0.5 font-mono text-[13px] bg-muted">{children}</code>,
   blockquote: ({ children }: { children?: React.ReactNode }) => <blockquote className="mb-2 border-l-2 pl-3 border-border text-muted-foreground">{children}</blockquote>,
   strong: ({ children }: { children?: React.ReactNode }) => <strong className="font-semibold">{children}</strong>,

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -204,7 +204,8 @@ export function DocContentRenderer({
           });
           const wrapper = document.createElement('div');
           wrapper.innerHTML = highlighted;
-          wrapper.className = '[&_pre]:!bg-transparent [&_pre]:!m-0 [&_pre]:p-4 [&_pre]:text-xs [&_pre]:leading-6 [&_code]:!bg-transparent overflow-x-auto';
+          // story #2165: 코드블럭은 전역 스크롤바 숨김 예외 — 가로로 잘린 줄을 알려야 한다.
+          wrapper.className = '[&_pre]:!bg-transparent [&_pre]:!m-0 [&_pre]:p-4 [&_pre]:text-xs [&_pre]:leading-6 [&_code]:!bg-transparent overflow-x-auto scrollbar-visible';
           if (pre.parentElement) pre.replaceWith(wrapper);
         }).catch(() => { /* fallback: keep original pre */ });
       });
@@ -295,7 +296,8 @@ export function DocContentRenderer({
         if (error) {
           block.innerHTML = `<div class="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive font-mono">${escapeHtmlText(error)}</div>`;
         } else {
-          block.innerHTML = `<div class="flex justify-center overflow-x-auto py-3 [&_.katex]:text-foreground">${katexHtml}</div>`;
+          // story #2165: 긴 수식도 코드와 같은 성격(가로로 잘리면 사용자가 잘린 줄 모름) — 예외.
+          block.innerHTML = `<div class="flex justify-center overflow-x-auto scrollbar-visible py-3 [&_.katex]:text-foreground">${katexHtml}</div>`;
         }
       });
     });
@@ -531,7 +533,8 @@ export function DocContentRenderer({
       return <NextImage src={hasSrc ? (src as string) : ''} alt={alt ?? ''} width={800} height={600} style={{ maxWidth: '100%', height: 'auto' }} unoptimized />;
     },
     table: ({ children }: { children?: ReactNode }) => (
-      <div className="not-prose overflow-x-auto rounded-xl border border-border">
+      // story #2165: 표도 코드블럭과 같은 성격 — 가로로 잘린 열이 있다는 것을 알려야 한다.
+      <div className="not-prose overflow-x-auto scrollbar-visible rounded-xl border border-border">
         <table>{children}</table>
       </div>
     ),
@@ -702,10 +705,10 @@ function ShikiCodeBlock({
       {html ? (
         <div
           dangerouslySetInnerHTML={{ __html: html }}
-          className="overflow-x-auto [&_pre]:!m-0 [&_pre]:!bg-transparent [&_pre]:p-4 [&_pre]:text-xs [&_pre]:leading-6 [&_code]:!bg-transparent"
+          className="overflow-x-auto scrollbar-visible [&_pre]:!m-0 [&_pre]:!bg-transparent [&_pre]:p-4 [&_pre]:text-xs [&_pre]:leading-6 [&_code]:!bg-transparent"
         />
       ) : (
-        <pre className="overflow-x-auto p-4 text-xs leading-6 text-foreground">
+        <pre className="overflow-x-auto scrollbar-visible p-4 text-xs leading-6 text-foreground">
           <code>{code}</code>
         </pre>
       )}
@@ -734,7 +737,7 @@ function decorateHtmlContent(content: string, headings: ReturnType<typeof extrac
   });
 
   const withTableShells = withHeadingIds.replace(/<table\b[\s\S]*?<\/table>/gi, (tableMarkup) => {
-    return `<div class="not-prose overflow-x-auto rounded-xl border border-border">${tableMarkup}</div>`;
+    return `<div class="not-prose overflow-x-auto scrollbar-visible rounded-xl border border-border">${tableMarkup}</div>`;
   });
 
   return withTableShells.replace(/<pre>([\s\S]*?)<\/pre>/gi, (_match, inner) => {

--- a/apps/web/src/components/docs/extensions/code-block-copy.tsx
+++ b/apps/web/src/components/docs/extensions/code-block-copy.tsx
@@ -198,7 +198,9 @@ function ShikiBlockView({ node, editor, selected }: ReactNodeViewProps) {
         </div>
 
         {/* Code area */}
-        <div className="overflow-x-auto px-4 pb-4">
+        {/* story #2165: 코드블럭은 전역 스크롤바 숨김의 예외 — 가로로 잘린 줄이 있다는 것을
+            스크롤바로 알려야 한다. */}
+        <div className="scrollbar-visible overflow-x-auto px-4 pb-4">
           {/* Editing mode: show plain NodeViewContent */}
           <pre
             className={`text-xs leading-6 text-foreground ${isEditing || !highlightedHtml ? '' : 'hidden'}`}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -103,7 +103,8 @@ const descriptionViewerComponents = {
   ul: ({ children }: { children?: React.ReactNode }) => <ul className="mb-2 ml-4 list-disc space-y-0.5 text-muted-foreground">{children}</ul>,
   ol: ({ children }: { children?: React.ReactNode }) => <ol className="mb-2 ml-4 list-decimal space-y-0.5 text-muted-foreground">{children}</ol>,
   li: ({ children }: { children?: React.ReactNode }) => <li className="text-sm leading-6">{children}</li>,
-  pre: ({ children }: { children?: React.ReactNode }) => <pre className="mb-2 overflow-x-auto rounded-lg bg-muted p-3 text-[13px] text-foreground">{children}</pre>,
+  // story #2165: 코드블럭은 전역 스크롤바 숨김 예외.
+  pre: ({ children }: { children?: React.ReactNode }) => <pre className="mb-2 overflow-x-auto scrollbar-visible rounded-lg bg-muted p-3 text-[13px] text-foreground">{children}</pre>,
   code: ({ children }: { children?: React.ReactNode }) => <code className="rounded bg-muted px-1 py-0.5 font-mono text-[13px] text-foreground">{children}</code>,
   blockquote: ({ children }: { children?: React.ReactNode }) => <blockquote className="mb-2 border-l-2 border-border pl-3 text-muted-foreground">{children}</blockquote>,
   a: ({ href, children }: { href?: string; children?: React.ReactNode }) => <a href={href} target="_blank" rel="noopener noreferrer" className="text-primary underline underline-offset-2">{children}</a>,

--- a/apps/web/src/components/settings/workflow-execution-history-section.tsx
+++ b/apps/web/src/components/settings/workflow-execution-history-section.tsx
@@ -84,7 +84,8 @@ export function WorkflowExecutionHistorySection({ projectId }: { projectId: stri
           </div>
         ) : (
           <>
-            <div className="overflow-x-auto">
+            {/* story #2165: 표는 전역 스크롤바 숨김 예외. */}
+            <div className="overflow-x-auto scrollbar-visible">
               <table className="w-full text-xs">
                 <thead>
                   <tr className="border-b border-border text-left text-muted-foreground">

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -411,7 +411,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
       className={cn(
         // story #2062: 앱 전역 사이드바 nav — 포커스 링(#2057) 클리핑 회귀 방지, 유나 규격
         // focus-inset(inset 링, 레이아웃 불변). primary 배경 요소 없음(grep 확認) — 예외 불요.
-        "focus-inset no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "focus-inset flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
         className
       )}
       {...props}


### PR DESCRIPTION
## Original ask (정신병 리스트 2026-07-24 · 기타 2)

> 프로덕트 전체에 대상으로 스크롤바 hidden 줘야 하는 (가로 세로 스크롤바 모두 해당). 유일하게
> 스크롤바를 명시적 노출해줘야 하는 컴포넌트가 바로 코드블럭인.

## Design axis (per PO): how does "코드블럭만 예외" get decided at each site?

Went with **global hide + opt-in class** over component-level or per-instance exceptions —
it's the only one of the three where a brand-new code block or table automatically stays
hidden by default (correct default) and only surfaces the bar if someone explicitly opts in,
rather than requiring every new scrollable surface to remember to add a "hide" class.

`globals.css`:
```css
* { scrollbar-width: none; }
*::-webkit-scrollbar { display: none; }

.scrollbar-visible { scrollbar-width: thin; scrollbar-color: ...; }
.scrollbar-visible::-webkit-scrollbar { display: block; width: 6px; height: 6px; }
/* ...track/thumb reuse the existing --scrollbar-* tokens, unchanged colors */
```

⛔ **Scroll function is untouched** — only `scrollbar-width`/`::-webkit-scrollbar` change, no
`overflow: hidden` anywhere. Verified with Playwright: dispatching a `scrollLeft` change on a
hidden-scrollbar element, a `.scrollbar-visible` element, and a `.doc-renderer pre` element all
still scroll (mouse-wheel/trackpad/touch/keyboard scrolling go through the same `overflow-x:
auto`, untouched).

## AC3 — swept for other truncation-risk surfaces beyond code blocks

Repo-wide grep found ~85 files using `overflow-x-auto`/`overflow-y-auto`/`overflow-auto`.
Narrowed to genuine truncation risk by asking: **does hiding this scrollbar hide the fact that
information exists off-screen, with no other visual cue?**

**Got the exception** (code + literal `<table>` wrappers — content is columnar/linear data,
cut off silently with no other affordance):
- `docs/extensions/code-block-copy.tsx` — Tiptap doc editor code block
- `docs/doc-content-renderer.tsx` — 6 spots: legacy raw-HTML code wrapper
  (`wrapper.className`), KaTeX math block (long equations have the same truncation risk as
  code), markdown `table` override, Shiki code block + its plain-`<pre>` fallback, legacy
  raw-HTML table shell (`withTableShells`)
- `chat/chat-bubble.tsx` — markdown `pre` + `table` overrides
- `chat/embed-card.tsx` — markdown `pre` override
- `kanban/story-detail-panel.tsx` — markdown `pre` override (story description)
- `agents/access-matrix-tab.tsx` — agent×project access matrix `<table>`
- `settings/workflow-execution-history-section.tsx` — execution log `<table>`

**Explicitly did NOT get the exception** (checked, decided no, recording why):
- **Kanban board horizontal scroll** (`kanban-board.tsx`) — card-based, not columnar data;
  the column-edge cutoff and drag interaction are the discoverability cue, not a scrollbar.
- **Canvas node-tree** (`edit-canvas.tsx`, `data-canvas-scrollable`) — spatial/pan-style
  browsing, not linear data; canvas UIs conventionally don't show scrollbars. Also: most of
  the canvas viewer stack (`artifact-stage.tsx` etc.) already moved off native scroll to
  pan/zoom in a prior rewrite, so the global rule barely touches it anyway.
- **Everything else** (~75 remaining files: modals, dropdowns, sidebars, chat lists, doc
  TOC, breadcrumbs, generic card/list panels) — these are navigational/browsing surfaces
  where the scrollbar was pure chrome, not a truncation signal. This is exactly the bulk of
  what "전역 숨김" is *for* — no per-file change needed, the global rule already hides them.

One raw-HTML-injection wrinkle: `doc-content-renderer.tsx`'s legacy `contentFormat==='html'`
path builds `<pre>` tags as literal strings (`dangerouslySetInnerHTML`), so there's no JSX
class to attach. Added a `.doc-renderer pre` descendant rule in `globals.css` instead — the
ancestor `.doc-renderer` class is always present on that render path's container.

Also removed the `no-scrollbar` class reference in `components/ui/sidebar.tsx` — grepped the
whole repo, no CSS definition for it exists anywhere (dead/no-op class), and it's redundant
now regardless since hidden is the new default.

## AC4 — cross-browser / desktop app

- `scrollbar-width: none` (Firefox) + `::-webkit-scrollbar{display:none}` (Chromium/Safari/
  Edge) is the standard pairing for this — both are long-established (Firefox 64+, all
  WebKit/Blink browsers).
- ⚠️ **Firefox not live-verified** — no Firefox binary available in this sandbox
  (`playwright install` would be needed). Chromium verified live (see AC5). Flagging this
  honestly rather than claiming full cross-browser coverage.
- **Desktop app (Electron/Tauri): confirmed does not exist in this repo** — checked
  `apps/`, all `package.json` files, no `electron`/`@tauri-apps` dependency anywhere. AC4's
  "데스크톱 앱 포함" is moot; not skipped, genuinely not applicable.

## AC5 — live verification

Full app UI walkthrough wasn't done (would need a running local stack against this branch).
Instead verified the actual compiled CSS mechanism directly:
1. Compiled `globals.css` through the real `@tailwindcss/postcss` pipeline (same one the app
   build uses) — no errors, confirmed generated CSS contains the global hide rule + both
   exception selectors.
2. Loaded that compiled CSS in a real Chromium page (Playwright) against a generic hidden
   div, a `.scrollbar-visible` div, and a `.doc-renderer pre` — `getComputedStyle().
   scrollbarWidth` reads `none` / `thin` / `thin` respectively, matching intent exactly.
3. Functional check: `scrollLeft` mutation on all three still moves the scroll position —
   confirms hiding the bar didn't disable scrolling.

This is a targeted verification of the CSS mechanism itself, not a full-app visual sweep —
noting that distinction rather than implying broader coverage than what was actually run.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `eslint` on changed files — clean
- [x] New `globals-scrollbar.test.ts` — 10/10 pass (CSS invariants + all 7 wrapper files
      still carry `.scrollbar-visible`)
- [x] CSS compiles cleanly through the real Tailwind v4 postcss pipeline
- [x] Chromium: computed `scrollbar-width` correct on all 3 cases + scroll still functions
- [ ] Firefox live visual check (no binary in this sandbox)
- [ ] Full-app visual walkthrough on dev after deploy (kanban board, chat with code+table,
      doc viewer with code+table+math, access matrix, execution history)