### PR TITLE
[SID:2032] 채팅 입력 연속성 — 자동 포커스·임시저장·ESC 뒤로가기

### DIFF
--- a/apps/web/src/components/chat/chat-input.test.tsx
+++ b/apps/web/src/components/chat/chat-input.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+//
+// story #2032 — 채팅 입력 연속성(자동 포커스·대화별 임시저장·ESC 뒤로가기) 회귀가드.
+// 순수 헬퍼(멘션/엔티티 파싱)는 기존 chat-input.test.ts가 이미 덮는다 — 이 파일은 그 위에
+// 새로 얹은 상호작용(effect·localStorage·keydown 우선순위)을 실 렌더로 검증한다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { ChatInput } from './chat-input';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function withIntl(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+function stubMatchMedia(coarse: boolean) {
+  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: coarse } as MediaQueryList));
+}
+
+// story #2059(kanban-board.test.tsx)와 동일 패턴 — jsdom/Node의 네이티브 localStorage가
+// 이 실행 환경에서 온전치 않아(--localstorage-file 미설정 시 .clear() 등이 없는 스텁으로
+// 대체됨) Map 기반 페이크로 통째로 교체한다.
+let store: Map<string, string>;
+function stubLocalStorage() {
+  store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => { store.set(k, v); },
+    removeItem: (k: string) => { store.delete(k); },
+    clear: () => { store.clear(); },
+  });
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  stubLocalStorage();
+  stubMatchMedia(false); // 기본은 데스크톱(포인터 정밀) — AC1 대상
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function textarea(): HTMLTextAreaElement {
+  return container.querySelector('textarea') as HTMLTextAreaElement;
+}
+
+describe('ChatInput — 진입 시 자동 포커스(story #2032 AC1)', () => {
+  it('데스크톱(pointer:fine)이면 마운트 직후 textarea에 포커스가 잡힌다', async () => {
+    await act(async () => {
+      root.render(withIntl(<ChatInput threadId="c1" onSend={vi.fn()} />));
+    });
+    expect(document.activeElement).toBe(textarea());
+  });
+
+  it('터치 기기(pointer:coarse)면 자동 포커스하지 않는다(소프트 키보드가 화면을 덮는 것 방지)', async () => {
+    stubMatchMedia(true);
+    await act(async () => {
+      root.render(withIntl(<ChatInput threadId="c1" onSend={vi.fn()} />));
+    });
+    expect(document.activeElement).not.toBe(textarea());
+  });
+});
+
+describe('ChatInput — 대화별 임시저장(story #2032 AC2/AC3/AC6)', () => {
+  it('마운트 시 그 대화의 저장된 초안을 복원한다(AC2)', async () => {
+    window.localStorage.setItem('sprintable:chat-draft:c1', '쓰던 내용');
+    await act(async () => {
+      root.render(withIntl(<ChatInput threadId="c1" onSend={vi.fn()} />));
+    });
+    expect(textarea().value).toBe('쓰던 내용');
+  });
+
+  it('타이핑하면 그 대화 슬롯에 자동저장된다(AC2)', async () => {
+    await act(async () => {
+      root.render(withIntl(<ChatInput threadId="c1" onSend={vi.fn()} />));
+    });
+    await act(async () => {
+      const el = textarea();
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+      setter.call(el, '작성 중');
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(window.localStorage.getItem('sprintable:chat-draft:c1')).toBe('작성 중');
+  });
+
+  it('대화별로 분리된다 — A 대화 초안이 B 대화에 나타나지 않는다(AC3)', async () => {
+    window.localStorage.setItem('sprintable:chat-draft:conv-A', 'A 대화 초안');
+    await act(async () => {
+      root.render(withIntl(<ChatInput threadId="conv-B" onSend={vi.fn()} />));
+    });
+    expect(textarea().value).toBe(''); // B에는 A의 초안이 안 보임
+    expect(window.localStorage.getItem('sprintable:chat-draft:conv-A')).toBe('A 대화 초안'); // A 것은 그대로 보존
+  });
+
+  it('메시지를 전송하면 그 대화의 임시저장이 비워진다(AC6)', async () => {
+    window.localStorage.setItem('sprintable:chat-draft:c1', '보낼 내용');
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    await act(async () => {
+      root.render(withIntl(<ChatInput threadId="c1" onSend={onSend} />));
+    });
+    const sendButton = Array.from(container.querySelectorAll('button')).find((b) => b.querySelector('svg') && !b.hasAttribute('aria-haspopup'));
+    await act(async () => {
+      sendButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(onSend).toHaveBeenCalledWith('보낼 내용', undefined, undefined);
+    expect(window.localStorage.getItem('sprintable:chat-draft:c1')).toBeNull();
+  });
+});
+
+describe('ChatInput — ESC 우선순위(story #2032 AC4/AC5)', () => {
+  it('아무 오버레이도 안 열려 있으면 ESC가 onEscape를 부른다(AC4)', async () => {
+    const onEscape = vi.fn();
+    await act(async () => {
+      root.render(withIntl(<ChatInput threadId="c1" onSend={vi.fn()} onEscape={onEscape} />));
+    });
+    await act(async () => {
+      textarea().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+    expect(onEscape).toHaveBeenCalledTimes(1);
+  });
+
+  it('멘션 후보가 열려 있으면 ESC는 그 후보를 먼저 닫고 onEscape는 안 부른다(AC5)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      data: [{ id: 'm1', name: '오르테가' }],
+    }), { status: 200, headers: { 'content-type': 'application/json' } })));
+    const onEscape = vi.fn();
+    await act(async () => {
+      root.render(withIntl(<ChatInput threadId="c1" onSend={vi.fn()} onEscape={onEscape} />));
+    });
+    const el = textarea();
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(el, '@오');
+      el.selectionStart = 2;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    // 멘션 fetch가 resolve될 시간을 준다.
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(container.querySelector('[role="listbox"]')).not.toBeNull(); // 후보가 실제로 떠 있음(전제 확認)
+
+    await act(async () => {
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+
+    expect(onEscape).not.toHaveBeenCalled(); // 후보 우선 — 대화 밖으로 안 나감
+  });
+});

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -120,6 +120,33 @@ interface EntityResult {
   status: string | null;
 }
 
+// story #2032 — 대화별 임시저장(localStorage). 대화 전환은 ChatView가 key={conversation_id}로
+// ChatInput을 통째로 리마운트시키므로(page.tsx), threadId가 이 컴포넌트 수명 중에 바뀌는
+// 경우 자체가 없다 — 마운트 시 lazy initializer로 그 대화의 초안을 1회 읽으면 AC3(대화별
+// 분리)가 별도 분기 없이 성립한다.
+function draftStorageKey(threadId: string): string {
+  return `sprintable:chat-draft:${threadId}`;
+}
+
+function loadDraft(threadId: string): string {
+  if (typeof window === 'undefined') return '';
+  try {
+    return window.localStorage.getItem(draftStorageKey(threadId)) ?? '';
+  } catch {
+    return ''; // localStorage 접근 불가(프라이빗 모드 등) — 초안 없이 시작(무해 폴백).
+  }
+}
+
+function saveDraft(threadId: string, text: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (text) window.localStorage.setItem(draftStorageKey(threadId), text);
+    else window.localStorage.removeItem(draftStorageKey(threadId)); // AC6: 빈 초안을 남기지 않음
+  } catch {
+    // 쓰기 실패(용량 초과 등) — 조용히 무시, 전송 자체는 막지 않는다.
+  }
+}
+
 interface ChatInputProps {
   onSend: (content: string, mentionedIds?: string[], attachments?: SendAttachment[]) => Promise<void>;
   onUploadFile?: (file: File) => Promise<SendAttachment>;
@@ -128,16 +155,22 @@ interface ChatInputProps {
   projectId?: string;
   onMentionIdsChange?: (ids: string[]) => void;
   commandTargets?: CommandTarget[];
+  // story #2032: 대화별 초안 스코프 키 + ESC 뒤로가기 위임(모달/팝오버/커맨드팔레트가 없을 때만
+  // — 이 컴포넌트 내부 mention/entity/command picker 자체의 Escape가 이미 우선 처리되므로,
+  // 그 셋 중 아무것도 안 열려 있을 때만 이 콜백까지 내려온다).
+  threadId: string;
+  onEscape?: () => void;
 }
 
-export function ChatInput({ onSend, onUploadFile, disabled, placeholder, projectId, onMentionIdsChange, commandTargets }: ChatInputProps) {
+export function ChatInput({ onSend, onUploadFile, disabled, placeholder, projectId, onMentionIdsChange, commandTargets, threadId, onEscape }: ChatInputProps) {
   const t = useTranslations('chats');
   // story 1946(PO 실기기 발견): 터치(가상 키보드)엔 Cmd/Shift 조합이 없어 Enter=발송이면 장문
   // 지시 중 오발송이 잦다. 뷰포트가 아니라 입력 capability로 분기(물리 키보드 연결 태블릿은
   // 데스크톱 거동이 자연스러움) — artifact-stage.tsx와 동형 패턴(`(pointer: coarse)` 1회 판정,
   // SSR 안전 lazy initializer, 하이브리드 기기 중간 전환은 희귀 엣지케이스라 리스너 미부착).
   const [isTouchDevice] = useState(() => typeof window !== 'undefined' && typeof window.matchMedia === 'function' && window.matchMedia('(pointer: coarse)').matches);
-  const [text, setText] = useState('');
+  // story #2032 AC2/AC3: 대화별 초안 복원(lazy initializer — 마운트 시 1회, 리마운트당 재평가).
+  const [text, setText] = useState(() => loadDraft(threadId));
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
   const [uploadFailed, setUploadFailed] = useState(false);
   const [sendFailed, setSendFailed] = useState(false);
@@ -206,6 +239,30 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
     el.style.height = 'auto';
     el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
   };
+
+  // story #2032 AC1: 진입 시 자동 포커스 — 터치 기기는 제외한다(소프트 키보드가 화면 절반을
+  // 덮는 것을 막기 위해, chat-view.tsx 진입 직후 클릭 없이 타이핑 가능해야 한다는 요구는
+  // 데스크톱(포인터 정밀)에만 적용). isTouchDevice는 위에서 이미 판정된 값(#2242와 동일 근거)을
+  // 그대로 재사용 — 새 판정축을 만들지 않는다. 마운트 1회만(대화 전환은 리마운트라 자동으로 재실행).
+  useEffect(() => {
+    if (isTouchDevice) return;
+    textareaRef.current?.focus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // story #2032 AC2: 초안을 복원한 첫 렌더 直後 textarea 높이를 내용에 맞게 1회 보정한다 —
+  // adjustHeight는 지금까지 onChange에서만 불렸는데, lazy initializer로 값이 들어온 이번
+  // 마운트에는 onChange가 안 일어나 여러 줄 초안이 1줄 높이로 잘려 보이는 것을 막는다.
+  useEffect(() => {
+    adjustHeight();
+  }, []);
+
+  // story #2032 AC2/AC6: 대화별 초안 자동저장 — text가 바뀔 때마다 그 대화의 슬롯에 쓴다.
+  // 전송 성공 시 handleSend가 setText('')를 부르면 이 effect가 뒤이어 빈 문자열을 써서
+  // saveDraft 내부 분기가 자동으로 항목을 지운다(AC6, 별도 clearDraft 호출 불요).
+  useEffect(() => {
+    saveDraft(threadId, text);
+  }, [threadId, text]);
 
   const handleTextChange = (nextValue: string, cursorPos: number) => {
     setText(nextValue);
@@ -362,6 +419,14 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
     if (e.key === 'Enter' && !e.shiftKey && !isTouchDevice) {
       e.preventDefault();
       void handleSend();
+    }
+    // story #2032 AC4/AC5: ESC 뒤로가기 — 위 세 분기(command/entity/mention picker) 중 아무것도
+    // 안 열려 있을 때만 여기 도달한다. 그 셋은 이미 각자 Escape에서 return 하므로, 이 지점은
+    // "이 컴포넌트 안에는 닫을 오버레이가 없다"는 뜻이라 우선순위가 구조적으로 보장된다(별도
+    // z-index/포커스트랩 조율 불필요). 텍스트는 지우지 않는다 — 초안 자동저장 effect가 이미
+    // 최신 text를 들고 있으므로 나가기 前 별도 저장 호출도 불요.
+    if (e.key === 'Escape' && onEscape) {
+      onEscape();
     }
   };
 

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -19,6 +19,10 @@ interface ChatViewProps {
   currentTeamMemberId: string;
   projectId?: string;
   apiPrefix?: string;
+  // story #2032 AC4: ESC로 나갈 목적지. router.replace()로 이동한다(router.back()/
+  // window.history.back() 직접호출 금지 — [[feedback-history-back-nextjs]] 하우스룰,
+  // #2266이 이미 이 페이지의 헤더 백버튼에 적용한 것과 동일 패턴).
+  backHref?: string;
   // S8 #2: pre-send capability 경고 대상(에이전트 participant runtime). 빈 배열이면 경고 미표시(graceful).
   commandTargets?: CommandTarget[];
   // 1aeecdde P2: 에이전트 member_id → presence_status(연결축 dot). 없으면 dot 미표시(graceful).
@@ -51,7 +55,7 @@ function groupByDate(messages: ChatMessage[]): MessageGroup[] {
   return Object.entries(groups).map(([date, msgs]) => ({ date, messages: msgs }));
 }
 
-export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix = '/api/chats', commandTargets, presenceById, scrollToMessageId, initialLastReadAt }: ChatViewProps) {
+export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix = '/api/chats', backHref = '/chats', commandTargets, presenceById, scrollToMessageId, initialLastReadAt }: ChatViewProps) {
   const router = useRouter();
   const pathname = usePathname();
   const t = useTranslations('chats');
@@ -663,11 +667,13 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
 
           {/* Input */}
           <ChatInput
+            threadId={threadId}
             onSend={handleSend}
             onUploadFile={handleUploadFile}
             projectId={projectId}
             commandTargets={commandTargets}
             placeholder={isMobile ? t('inputPlaceholderMobile') : t('inputPlaceholderFull')}
+            onEscape={() => router.replace(backHref)}
           />
         </div>
 

--- a/apps/web/src/components/chat/thread-panel.tsx
+++ b/apps/web/src/components/chat/thread-panel.tsx
@@ -149,9 +149,16 @@ export function ThreadPanel({
 
       {/* Input */}
       <ChatInput
+        // story #2032: 스레드 답글 초안은 부모 대화의 본문 초안과 같은 슬롯을 쓰면 서로
+        // 덮어써 사고가 난다(AC3, "A 대화 초안이 B 대화에 나타나면 사고"와 같은 클래스) —
+        // conversationId만이 아니라 parentMessage.id까지 합성해 스레드별로도 분리한다.
+        threadId={`${conversationId}:thread:${parentMessage.id}`}
         onSend={handleSend}
         projectId={projectId}
         placeholder="답글을 입력하세요… (Enter 전송 / Shift+Enter 줄바꿈)"
+        // story #2032 AC5류 우선순위 — 스레드 패널이 열린 상태에서 ESC는 대화 전체를 나가는
+        // 것이 아니라 이 패널을 먼저 닫는다(중첩 오버레이는 안쪽부터 닫히는 것과 동형).
+        onEscape={onClose}
       />
     </div>
   );


### PR DESCRIPTION
## 배경 (선생님 실사용 지시 2026-07-20)
"입력 흐름이 끊기지 않는 것" — 대화 진입마다 클릭해야 하고, 작성 중 이동하면 글이 사라지던 불편 해소.

## AC별 구현
- **AC1(자동 포커스)**: 데스크톱만. 터치는 소프트 키보드가 화면을 덮으므로 제외 — `isTouchDevice`(기존 `#2242` Enter=개행 분기와 동일 판정, 새 축 안 만듦) 재사용.
- **AC2/AC3(대화별 임시저장)**: `localStorage` 키 `sprintable:chat-draft:{threadId}`. `ChatView`가 이미 `key={conversation_id}`로 `ChatInput`을 통째로 리마운트시키므로(기존 아키텍처), threadId가 컴포넌트 수명 중 바뀌는 경우 자체가 없어 대화별 분리가 별도 분기 없이 성립. 새로고침·재접속 후에도 유지.
- **AC4/AC5(ESC 뒤로가기 + 우선순위)**: `router.replace(backHref)` — **`router.back()`/`window.history.back()` 직접호출은 하우스룰로 금지**([[feedback-history-back-nextjs]], `#2266`이 헤더 백버튼에 이미 적용한 것과 동일 패턴). 우선순위는 기존 command/entity/mention picker의 Escape 분기 **뒤**에 배치 — 그 셋이 이미 자기 Escape에서 `return`하므로 이 지점 도달 자체가 "닫을 오버레이가 없다"는 뜻(별도 z-index/포커스트랩 조율 불요, 구조적 보장).
- **AC6(전송 시 초안 비움)**: 별도 clear 호출 없음 — `handleSend`가 `setText('')`하면 기존 자동저장 effect가 빈 문자열을 써서 `saveDraft` 내부 분기가 자동으로 지운다.
- **스레드 답글도 동일 컴포넌트 재사용**(`thread-panel.tsx`) — draft 키를 `{conversationId}:thread:{parentMessageId}`로 합성해 본문 초안과 충돌 차단(AC3와 같은 클래스 사고를 스레드 축에서도 선제 방지). ESC는 스레드 패널을 먼저 닫음(중첩 오버레이는 안쪽부터).

## 회귀테스트 + 뮤테이션 셀프체크
`chat-input.test.tsx` 신규 8건(자동포커스 2·임시저장 4·ESC우선순위 2) — 실 렌더(`NextIntlClientProvider` + `localStorage` Map 페이크, 기존 `kanban-board.test.tsx`와 동형 패턴)로 상호작용 직접 확認. 기존 순수함수 테스트(`chat-input.test.ts`) 14건과 별도 파일로 공존.

**뮤테이션 셀프체크 5건**: 자동포커스 끄기 / 초안복원 끄기 / 자동저장 끄기 / ESC 콜백 끄기 / **ESC 우선순위를 최상단으로 옮기기**(마지막 것이 특히 값어치 — "기능이 있다"가 아니라 "순서가 맞다"를 직접 검증) — 전부 대응 테스트가 정확히 RED로 떨어지는 것 확認 후 복구.

## 검증
- type-check·lint·build 통과, vitest 299 files 전건 PASS(2회차 클린 — 1회차 `kanban-board.test.tsx` 15건은 오늘 반복 관측된 기존 격리성 플레이키니스, 이 diff는 kanban-board 접촉 0).

## ⛔ AC7 — 배포 後 라이브 검증 필요
포커스/키보드 이벤트/`localStorage` 상호작용은 실 브라우저 세션이 있어야 정확히 재현 가능한 자리라 **유닛 테스트만으로 닫지 않는다.** 배포 착지 후 데스크톱+모바일 폭 각각 실 왕복 확認 예정.

## Test plan
- [x] 회귀테스트 8건 + 뮤테이션 셀프체크 5건
- [ ] 배포 후 실 브라우저 데스크톱+모바일 폭 왕복 증빙(AC7, 스토리 최종 done-gate)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>