### PR TITLE
[SID:2192] 알림벨 30건 절단 결함 — 프록시 meta + 더 보기

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1881,6 +1881,7 @@
     "eventFallback": "New notification",
     "panelTitle": "Notifications",
     "unreadOnly": "Unread only",
+    "loadMore": "Load more",
     "emptyAll": "No new notifications",
     "emptyStory": "No story notifications",
     "emptySystem": "No system notifications",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1881,6 +1881,7 @@
     "eventFallback": "새 알림",
     "panelTitle": "알림",
     "unreadOnly": "안읽음만",
+    "loadMore": "더 보기",
     "emptyAll": "새 알림이 없습니다",
     "emptyStory": "스토리 알림이 없습니다",
     "emptySystem": "시스템 알림이 없습니다",

--- a/apps/web/src/app/api/event-notifications/route.test.ts
+++ b/apps/web/src/app/api/event-notifications/route.test.ts
@@ -1,0 +1,62 @@
+// story #2192 — 알림벨이 30건에서 조용히 잘리던 결함의 회귀가드. BE(/api/v2/event-notifications)는
+// limit/offset을 이미 정직히 지원하지만(backend/app/routers/event_notifications.py) 응답이
+// 순수 배열이라 "더 있다"는 신호가 없었다 — 프록시가 그 신호(meta.hasMore)를 만드는지 검증한다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({ getServerSession: vi.fn() }));
+vi.mock('@/lib/db/server', () => ({ getServerSession: h.getServerSession }));
+
+import { GET } from './route';
+
+describe('/api/event-notifications — meta 구성(story #2192)', () => {
+  beforeEach(() => {
+    h.getServerSession.mockReset();
+    h.getServerSession.mockResolvedValue({ access_token: 'tok' });
+  });
+
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('꽉 찬 페이지(limit만큼 반환)면 hasMore=true(31번째가 있을 수 있다는 신호)', async () => {
+    const items = Array.from({ length: 30 }, (_, i) => ({ id: `n${i}` }));
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify(items), {
+      status: 200, headers: { 'content-type': 'application/json' },
+    })));
+
+    const req = new Request('http://localhost/api/event-notifications?limit=30&offset=0');
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(json.data).toHaveLength(30);
+    expect(json.meta.hasMore).toBe(true);
+    expect(json.meta.limit).toBe(30);
+    expect(json.meta.offset).toBe(0);
+  });
+
+  it('음성대조 — 30건 이하 계정(limit 미만 반환)이면 hasMore=false', async () => {
+    const items = Array.from({ length: 5 }, (_, i) => ({ id: `n${i}` }));
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify(items), {
+      status: 200, headers: { 'content-type': 'application/json' },
+    })));
+
+    const req = new Request('http://localhost/api/event-notifications?limit=30&offset=0');
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(json.data).toHaveLength(5);
+    expect(json.meta.hasMore).toBe(false);
+  });
+
+  it('offset을 그대로 BE에 전달한다(다음 페이지 요청)', async () => {
+    const fetchMock = vi.fn(async (_url: string) => new Response(JSON.stringify([]), {
+      status: 200, headers: { 'content-type': 'application/json' },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = new Request('http://localhost/api/event-notifications?limit=30&offset=30');
+    await GET(req);
+
+    const calledUrl = fetchMock.mock.calls[0]?.[0] as string;
+    expect(calledUrl).toContain('offset=30');
+    expect(calledUrl).toContain('limit=30');
+  });
+});

--- a/apps/web/src/app/api/event-notifications/route.ts
+++ b/apps/web/src/app/api/event-notifications/route.ts
@@ -1,5 +1,21 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
+// story #2192 — BE(/api/v2/event-notifications)는 limit/offset을 이미 정직히 지원하지만
+// (backend/app/routers/event_notifications.py: limit ge=1,le=100 · offset ge=0) 응답이
+// 순수 배열이라 "더 있다"는 신호가 전혀 없었다 — 그래서 이 프록시는 그동안 raw 배열을
+// 그대로 통과시켰을 뿐 meta를 만들지 않았다(notification-bell.tsx가 limit=30 고정으로만
+// 불러 31번째부터는 조용히 잘림). BE가 limit을 초과해 주지 않으므로(over-fetch 없음)
+// 정확히 limit만큼 돌아왔을 때만 다음 페이지가 있을 수 있다고 본다(#2190과 동일 판단).
 export async function GET(request: Request): Promise<Response> {
-  return proxyToFastapi(request, '/api/v2/event-notifications');
+  const _r = await proxyToFastapi(request, '/api/v2/event-notifications');
+  if (!_r.ok) return _r;
+  const data = await _r.json();
+
+  const url = new URL(request.url);
+  const requestedLimit = Number(url.searchParams.get('limit')) || 20; // BE 기본값과 동일
+  const requestedOffset = Number(url.searchParams.get('offset')) || 0;
+  const hasMore = Array.isArray(data) && data.length === requestedLimit;
+
+  return apiSuccess(data, { limit: requestedLimit, offset: requestedOffset, hasMore });
 }

--- a/apps/web/src/components/nav/notification-bell.test.tsx
+++ b/apps/web/src/components/nav/notification-bell.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+//
+// story #2192 — 알림벨이 30건에서 조용히 잘리던 결함의 회귀가드. 「더 보기」가 hasMore일 때만
+// 뜨고, 누르면 offset을 이어서 다음 페이지를 붙이는지 실 렌더로 검증한다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+const { NotificationBell } = await import('./notification-bell');
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function withIntl(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+function stubMatchMedia() {
+  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
+    matches: true, // 데스크톱 드롭다운 분기(lg+) — 목록 렌더를 그쪽으로 고정해 테스트를 단순화.
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+}
+
+function notif(id: string) {
+  return {
+    id, event_type: 'story_status_changed', source_entity_type: null, source_entity_id: null,
+    payload: { summary: `알림 ${id}` }, read_at: '2026-07-27T00:00:00Z', created_at: '2026-07-27T00:00:00Z',
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  stubMatchMedia();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// offset 쿼리파라미터로 페이지를 서빙한다(호출 횟수 순서가 아니라) — offsetRef 계산이
+// 실제로 틀리면(예: 항상 0을 보내거나 notifications.length를 그대로 씀) 요청한 offset에
+// 해당하는 페이지가 없어 빈 배열이 와서 뮤테이션을 잡아낸다.
+function stubFetchSequenceByOffset(pagesByOffset: Record<number, { items: ReturnType<typeof notif>[]; hasMore: boolean }>) {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (url.includes('/api/event-notifications?')) {
+      const offset = Number(new URL(url, 'http://localhost').searchParams.get('offset') ?? '0');
+      const page = pagesByOffset[offset] ?? { items: [], hasMore: false };
+      return new Response(JSON.stringify({ data: page.items, meta: { hasMore: page.hasMore } }), {
+        status: 200, headers: { 'content-type': 'application/json' },
+      });
+    }
+    // unread-count 폴링 등 그 외 호출 — 무해한 기본 응답.
+    return new Response(JSON.stringify({ count: 0 }), { status: 200, headers: { 'content-type': 'application/json' } });
+  }));
+}
+
+async function openBell() {
+  await act(async () => { root.render(withIntl(<NotificationBell />)); });
+  const bellButton = container.querySelector('button[aria-expanded]') as HTMLButtonElement;
+  await act(async () => { bellButton.click(); });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('NotificationBell — 더 보기(story #2192 AC3/AC4)', () => {
+  it('hasMore=true면 「더 보기」 버튼이 뜬다(AC3)', async () => {
+    stubFetchSequenceByOffset({ 0: { items: Array.from({ length: 30 }, (_, i) => notif(`n${i}`)), hasMore: true } });
+    await openBell();
+
+    const loadMoreBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '더 보기');
+    expect(loadMoreBtn).toBeDefined();
+  });
+
+  it('음성대조 — hasMore=false(30건 이하 계정)면 「더 보기」 버튼이 없다(AC4)', async () => {
+    stubFetchSequenceByOffset({ 0: { items: Array.from({ length: 5 }, (_, i) => notif(`n${i}`)), hasMore: false } });
+    await openBell();
+
+    const loadMoreBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '더 보기');
+    expect(loadMoreBtn).toBeUndefined();
+  });
+
+  it('「더 보기」를 연달아 두 번 누르면 offset=30·60으로 누적 요청해 뒤에 붙인다(누적 오프셋 계산 검증)', async () => {
+    stubFetchSequenceByOffset({
+      0: { items: Array.from({ length: 30 }, (_, i) => notif(`n${i}`)), hasMore: true },
+      30: { items: Array.from({ length: 30 }, (_, i) => notif(`n2-${i}`)), hasMore: true },
+      60: { items: Array.from({ length: 5 }, (_, i) => notif(`n3-${i}`)), hasMore: false },
+    });
+    await openBell();
+
+    // jsdom은 Tailwind의 lg:flex/lg:hidden 반응형 클래스를 실제로 평가하지 않아 데스크톱
+    // 드롭다운·모바일 오버레이 둘 다 DOM에 동시 존재한다 — 데스크톱 컨테이너(.w-80)로 좁혀서 잰다.
+    const desktopPanel = container.querySelector('.w-80')!;
+    expect(desktopPanel.querySelectorAll('ul li')).toHaveLength(30);
+
+    const clickLoadMore = async () => {
+      const btn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '더 보기') as HTMLButtonElement;
+      await act(async () => { btn.click(); await Promise.resolve(); await Promise.resolve(); });
+    };
+
+    await clickLoadMore(); // offset=30 요청 기대
+    expect(desktopPanel.querySelectorAll('ul li')).toHaveLength(60); // 30 + 30 — offsetRef가 30으로 안 갱신됐으면 offset=0 재요청이라 여기서 어긋난다
+
+    await clickLoadMore(); // offset=60 요청 기대(누적)
+    expect(desktopPanel.querySelectorAll('ul li')).toHaveLength(65); // 60 + 5
+    expect(Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '더 보기')).toBeUndefined(); // 3페이지째 hasMore=false
+  });
+});

--- a/apps/web/src/components/nav/notification-bell.test.tsx
+++ b/apps/web/src/components/nav/notification-bell.test.tsx
@@ -73,6 +73,26 @@ function stubFetchSequenceByOffset(pagesByOffset: Record<number, { items: Return
   }));
 }
 
+// story #2192 — "더 보기" 클릭 사이에 SSE로 실시간 알림이 목록 앞에 끼어들어도(prepend)
+// offsetRef(API로 실제 받은 건수만 누적)가 오염되지 않는지 재현한다. 오르테가군이 "이 PR에서
+// 제일 깨지기 쉬운 자리"로 지목한 곳 — notifications.length를 직접 offset으로 썼다면 SSE
+// prepend가 1건 생길 때마다 다음 "더 보기" 요청의 offset이 실제보다 하나씩 밀린다.
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  listeners: Record<string, Array<(e: { data: string; lastEventId?: string }) => void>> = {};
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string; lastEventId?: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  constructor(public url: string) { FakeEventSource.instances.push(this); }
+  addEventListener(type: string, cb: (e: { data: string; lastEventId?: string }) => void) {
+    (this.listeners[type] ??= []).push(cb);
+  }
+  close() { /* no-op */ }
+  emit(type: string, data: unknown) {
+    for (const cb of this.listeners[type] ?? []) cb({ data: JSON.stringify(data) });
+  }
+}
+
 async function openBell() {
   await act(async () => { root.render(withIntl(<NotificationBell />)); });
   const bellButton = container.querySelector('button[aria-expanded]') as HTMLButtonElement;
@@ -121,5 +141,32 @@ describe('NotificationBell — 더 보기(story #2192 AC3/AC4)', () => {
     await clickLoadMore(); // offset=60 요청 기대(누적)
     expect(desktopPanel.querySelectorAll('ul li')).toHaveLength(65); // 60 + 5
     expect(Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '더 보기')).toBeUndefined(); // 3페이지째 hasMore=false
+  });
+
+  it('더 보기 사이에 SSE 실시간 알림이 앞에 끼어들어도 다음 페이지 offset이 안 밀린다(오르테가군 지적 — 제일 깨지기 쉬운 자리)', async () => {
+    FakeEventSource.instances = [];
+    vi.stubGlobal('EventSource', FakeEventSource);
+    stubFetchSequenceByOffset({
+      0: { items: Array.from({ length: 30 }, (_, i) => notif(`n${i}`)), hasMore: true },
+      30: { items: Array.from({ length: 5 }, (_, i) => notif(`n2-${i}`)), hasMore: false },
+    });
+    await openBell();
+
+    const desktopPanel = container.querySelector('.w-80')!;
+    expect(desktopPanel.querySelectorAll('ul li')).toHaveLength(30);
+
+    // SSE로 실시간 알림 1건이 목록 맨 앞에 끼어든다 — API로 받은 게 아니므로 offsetRef는 그대로 30이어야.
+    const es = FakeEventSource.instances[0]!;
+    await act(async () => {
+      es.emit('notification', { id: 'live-1', event_type: 'story_status_changed', source_entity_type: null, source_entity_id: null, payload: {}, read_at: null, created_at: '2026-07-27T01:00:00Z' });
+    });
+    expect(desktopPanel.querySelectorAll('ul li')).toHaveLength(31); // 30(API) + 1(SSE)
+
+    // "더 보기"를 누르면 offsetRef(30)를 그대로 써서 offset=30을 요청해야 한다 — SSE로 31개가
+    // 됐다고 offset=31을 보내면 실제 30번째 API 항목을 건너뛰게 된다(중복/누락의 정확한 형태).
+    const loadMoreBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '더 보기') as HTMLButtonElement;
+    await act(async () => { loadMoreBtn.click(); await Promise.resolve(); await Promise.resolve(); });
+
+    expect(desktopPanel.querySelectorAll('ul li')).toHaveLength(36); // 30(API) + 1(SSE) + 5(API 2페이지)
   });
 });

--- a/apps/web/src/components/nav/notification-bell.tsx
+++ b/apps/web/src/components/nav/notification-bell.tsx
@@ -93,20 +93,34 @@ function timeAgo(dateStr: string, t: ReturnType<typeof useTranslations>): string
   return `${days}${t('daysAgo')}`;
 }
 
-async function fetchNotifications(projectId?: string): Promise<EventNotification[]> {
-  const params = new URLSearchParams({ limit: '30' });
+// story #2192 — 30건에서 조용히 잘리던 결함의 회귀가드. NOTIFICATIONS_PAGE_SIZE만큼 요청해
+// 정확히 그 개수가 돌아오면(BE는 limit을 초과해 주지 않는다 — over-fetch 없음) 다음 페이지가
+// 있을 수 있다고 본다(프록시가 계산한 meta.hasMore를 그대로 신뢰). offset을 넘기면 그 뒤
+// 페이지를 이어서 받는다.
+const NOTIFICATIONS_PAGE_SIZE = 30;
+
+interface NotificationsPage {
+  items: EventNotification[];
+  hasMore: boolean;
+}
+
+async function fetchNotifications(projectId?: string, offset = 0): Promise<NotificationsPage> {
+  const params = new URLSearchParams({ limit: String(NOTIFICATIONS_PAGE_SIZE), offset: String(offset) });
   if (projectId) params.set('project_id', projectId);
   // story #2160 — 401을 조용히 삼키던 폴링을 fetchWithAuth로 전환(세션만료 인지+재로그인 유도).
   const res = await fetchWithAuth(`/api/event-notifications?${params.toString()}`);
-  if (!res.ok) return [];
+  if (!res.ok) return { items: [], hasMore: false };
   const json = (await res.json()) as unknown;
-  if (Array.isArray(json)) return json as EventNotification[];
+  if (Array.isArray(json)) return { items: json as EventNotification[], hasMore: false }; // 옛 raw-array 응답 하위호환
   if (json && typeof json === 'object') {
     const obj = json as Record<string, unknown>;
-    if (Array.isArray(obj['data'])) return obj['data'] as EventNotification[];
-    if (obj['items'] && Array.isArray(obj['items'])) return obj['items'] as EventNotification[];
+    const items = Array.isArray(obj['data'])
+      ? obj['data'] as EventNotification[]
+      : (obj['items'] && Array.isArray(obj['items']) ? obj['items'] as EventNotification[] : []);
+    const meta = obj['meta'] as { hasMore?: boolean } | null | undefined;
+    return { items, hasMore: meta?.hasMore ?? false };
   }
-  return [];
+  return { items: [], hasMore: false };
 }
 
 async function fetchUnreadCount(projectId?: string): Promise<number> {
@@ -132,6 +146,10 @@ interface NotificationPanelProps {
   onMarkAllRead: () => void;
   onNavigate: (notification: EventNotification) => void;
   onClose: () => void;
+  // story #2192 AC3/AC4 — hasMore가 false면 버튼 자체를 안 그린다(음성대조).
+  hasMore: boolean;
+  loadingMore: boolean;
+  onLoadMore: () => void;
 }
 
 function NotificationPanel({
@@ -139,6 +157,9 @@ function NotificationPanel({
   onMarkAllRead,
   onNavigate,
   onClose,
+  hasMore,
+  loadingMore,
+  onLoadMore,
 }: NotificationPanelProps) {
   const t = useTranslations('inbox');
   const tCommon = useTranslations('common');
@@ -233,6 +254,7 @@ function NotificationPanel({
             <span>{emptyMessage}</span>
           </div>
         ) : (
+          <>
           <ul>
             {filtered.map((n) => (
               <li key={n.id}>
@@ -279,6 +301,20 @@ function NotificationPanel({
               </li>
             ))}
           </ul>
+          {/* story #2192 AC3/AC4 — hasMore일 때만 렌더(음성대조: 30건 이하 계정은 버튼 자체가 없음). */}
+          {hasMore && (
+            <div className="flex justify-center py-3">
+              <button
+                type="button"
+                onClick={onLoadMore}
+                disabled={loadingMore}
+                className="text-xs text-muted-foreground hover:text-foreground disabled:opacity-50"
+              >
+                {loadingMore ? tCommon('loading') : t('loadMore')}
+              </button>
+            </div>
+          )}
+          </>
         )}
       </div>
     </div>
@@ -293,6 +329,12 @@ export function NotificationBell() {
   const [unreadCount, setUnreadCount] = useState(0);
   // null = 로딩 중, array = 로드 완료
   const [notifications, setNotifications] = useState<EventNotification[] | null>(null);
+  // story #2192 — "더 보기" 상태. offsetRef는 API로 실제 가져온 건수만 누적한다(SSE로 앞에
+  // 끼워 넣은 실시간 알림은 offset 계산에서 제외 — notifications.length를 그대로 쓰면 SSE
+  // prepend가 "더 보기" 다음 페이지 경계를 밀려나게 만들어 중복/누락이 생긴다).
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const offsetRef = useRef(0);
   const containerRef = useRef<HTMLDivElement>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   // story #2061 — 모바일 풀스크린 오버레이(< lg)만 손수구현 모달이라 포커스 트랩 배선.
@@ -353,8 +395,11 @@ export function NotificationBell() {
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
-    void fetchNotifications(projectId ?? undefined).then((data) => {
-      if (!cancelled) setNotifications(data);
+    void fetchNotifications(projectId ?? undefined, 0).then(({ items, hasMore: more }) => {
+      if (cancelled) return;
+      setNotifications(items);
+      setHasMore(more);
+      offsetRef.current = items.length;
     });
     // 브라우저 Notification 권한 — 최초 패널 오픈 시 요청
     if ('Notification' in window && Notification.permission === 'default') {
@@ -362,6 +407,21 @@ export function NotificationBell() {
     }
     return () => { cancelled = true; };
   }, [open, projectId]);
+
+  // story #2192 AC3 — "더 보기": offsetRef(SSE prepend와 무관하게 API로 실제 가져온 건수)부터
+  // 이어서 받아 뒤에 붙인다.
+  const handleLoadMore = useCallback(async () => {
+    if (!hasMore || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const { items, hasMore: more } = await fetchNotifications(projectId ?? undefined, offsetRef.current);
+      setNotifications((prev) => (prev ? [...prev, ...items] : items));
+      setHasMore(more);
+      offsetRef.current += items.length;
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [hasMore, loadingMore, projectId]);
 
   // 외부 클릭으로 패널 닫기 (데스크톱)
   useEffect(() => {
@@ -443,6 +503,9 @@ export function NotificationBell() {
             onMarkAllRead={handleMarkAllRead}
             onNavigate={handleNavigate}
             onClose={() => setOpen(false)}
+            hasMore={hasMore}
+            loadingMore={loadingMore}
+            onLoadMore={() => void handleLoadMore()}
           />
         </div>
       )}
@@ -462,6 +525,9 @@ export function NotificationBell() {
             onMarkAllRead={handleMarkAllRead}
             onNavigate={handleNavigate}
             onClose={() => setOpen(false)}
+            hasMore={hasMore}
+            loadingMore={loadingMore}
+            onLoadMore={() => void handleLoadMore()}
           />
         </div>
       )}

--- a/apps/web/src/components/nav/notification-bell.tsx
+++ b/apps/web/src/components/nav/notification-bell.tsx
@@ -409,7 +409,13 @@ export function NotificationBell() {
   }, [open, projectId]);
 
   // story #2192 AC3 — "더 보기": offsetRef(SSE prepend와 무관하게 API로 실제 가져온 건수)부터
-  // 이어서 받아 뒤에 붙인다.
+  // 이어서 받아 뒤에 붙인다. 이 콜백은 notifications를 deps에 안 갖는다(의도) — offsetRef로
+  // 추적하므로 불필요하다.
+  // ⚠️여기서 offsetRef.current를 notifications.length(또는 notifications?.length)로 바꾸면
+  // 두 가지가 동시에 깨진다: ① SSE prepend가 offset을 오염시키는 원래 버그가 되돌아오고,
+  // ② 이 콜백이 useCallback으로 메모이즈돼 notifications가 deps에 없어 stale closure로
+  // 조용히 옛 값을 읽는다(뮤테이션 셀프체크 중 실측 — 그 상태로는 회귀테스트도 우연히
+  // 통과해버려서 "테스트가 초록"과 "테스트가 이 결함을 잡는다"가 갈리는 걸 직접 봤다).
   const handleLoadMore = useCallback(async () => {
     if (!hasMore || loadingMore) return;
     setLoadingMore(true);


### PR DESCRIPTION
## 배경 — 3단계 측정법(오늘 페이지네이션 전수 스윕에서 세운 방법)으로 확定
```
PO 계정 실측:  limit=30(실경로) → 30건 · limit=100(스키마 최대) → 100건
              ⇒ 둘 다 상한과 같음 = 절단 신호. 알림 100+건인데 벨은 30건만.
계정 편차:     까심군 계정 5건(절단 없음) vs PO 계정 100+(memo_reply 99)
              ⇒ "내 계정에서 안 보였다"로 닫으면 안 되는 자리
```

## 근본원인 — BE는 이미 offset을 지원, FE가 안 씀 + 신호 없음
`backend/app/routers/event_notifications.py`: `limit: int = Query(ge=1, le=100)` · `offset: int = Query(ge=0)` — **BE는 이미 완전한 offset 페이지네이션을 지원한다.** 문제는:
1. 응답이 순수 배열(`response_model=list[NotificationResponse]`)이라 "더 있다"는 신호가 전혀 없음.
2. `notification-bell.tsx`가 `limit=30` 고정 1회 fetch만 하고 offset을 애초에 한 번도 안 보냄. "더 보기" UI 자체가 없음.

BE가 이미 offset을 지원하므로 **백엔드 코드 변경 없이 FE 프록시 레이어만으로 닫힘**(#2190과 동일 판단 — over-fetch 없이 정확히 limit만큼 돌아왔을 때만 다음 페이지가 있을 수 있다고 판단).

## 변경
- **`event-notifications/route.ts`**: BE의 순수 배열 응답을 감싸 `meta: { limit, offset, hasMore }` 구성. **⛔JSON body meta로만** — 헤더(`X-Total-Count`) 방식은 이번 스윕에서 유일한 사용처인 `goals`조차 그 헤더를 안 읽고 자체 계산하는, **한 번도 이어진 적 없는 죽은 배선**으로 확認됨.
- **`notification-bell.tsx`**: `limit=30` 고정 fetch를 `offset` 파라미터화. `offsetRef`로 **API로 실제 수신한 건수만** 누적 — SSE로 실시간 알림이 목록 앞에 끼어들어도(`handleSseNotification`이 `prepend`) "더 보기" 페이지 경계가 안 밀리게(`notifications.length`를 직접 쓰면 SSE prepend가 offset 계산을 오염시킨다). `hasMore`일 때만 "더 보기" 버튼 렌더(AC4 음성대조).

## 회귀테스트 + 뮤테이션 셀프체크
6건(프록시 meta 구성 3 + 컴포넌트 더보기 3). 컴포넌트 테스트는 **offset 쿼리파라미터로 페이지를 서빙하는 스텁**을 써서 "두 번째 요청이 실제로 맞는 offset을 보내는지"까지 검증 — 처음엔 호출 순서 기반 스텁으로 썼다가, 그러면 오프셋 계산 버그를 놓친다는 것을 뮤테이션 체크로 직접 겪고 offset-aware 스텁 + 연속 두 번 클릭 시나리오로 강화했다.

**뮤테이션 셀프체크 3건**: `hasMore` 계산 끄기 / 버튼 렌더 끄기 / `offsetRef` 누적 끄기 — 마지막 것은 **1회 클릭만 검증하는 최초 테스트로는 안 걸렸다**(offset이 갱신 안 돼도 그 자리에서 한 번은 우연히 통과) → 연달아 두 번 클릭하는 누적 시나리오로 테스트를 강화한 뒤에야 정확히 RED로 잡히는 것 확認. "한 번 통과했다고 충분한 게 아니다"를 셀프체크 과정에서 재확인한 자리.

## 검증
- type-check·lint·build 통과, vitest 303 files 전건 PASS(첫 시도 클린).
- **라이브**(로컬 next dev → 실 dev BE): 내 계정(13건, 30 미만)에서 `hasMore=false` 실측 확認(AC4 음성대조 실증 — 실제로는 0건일 줄 알았는데 오늘 활동으로 13건 쌓여 있어 그대로 좋은 음성대조 표본이 됐다).

## ⛔ AC5 — 최소 두 계정(적은 쪽·많은 쪽) 미완
30건 넘는 "많은 쪽" 계정(PO 계정 등) 실측은 그 계정 접근권이 없어 이 PR에서 완결하지 못했다. 배포 후 PO 계정으로 직접 확認 부탁 — AC1(재현)·AC5(계정 편차) 최종 완결에 필요.

## Test plan
- [x] 회귀테스트 6건 + 뮤테이션 셀프체크 3건
- [x] 라이브 확認(적은 쪽 계정, 13건)
- [ ] 라이브 확認(많은 쪽 계정, 30+건) — 배포 후 PO 계정으로

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>