### PR TITLE
[SID:2193] DocSummaryResponse에 created_at 추가 — 문서 트리 시간그룹 블로커

### DIFF
--- a/backend/app/schemas/doc.py
+++ b/backend/app/schemas/doc.py
@@ -55,6 +55,7 @@ class DocSummaryResponse(BaseModel):
     doc_type: str
     is_folder: bool
     tags: list[str]
+    created_at: datetime
     updated_at: datetime
     snippet: str | None = None
     # doc-payload enrich(slug-query 단건 경로): FE 상세 fetchDoc 이 GET /api/docs?slug= 를 쓰므로 이 응답에도

--- a/backend/tests/test_2193_doc_summary_created_at_realdb.py
+++ b/backend/tests/test_2193_doc_summary_created_at_realdb.py
@@ -1,0 +1,96 @@
+"""story #2193(2026-07-27) — GET /api/v2/docs 응답(DocSummaryResponse)에 created_at이
+빠져 있었다(updated_at만 노출) — 문서 트리 시간 그룹의 기준이 생성일이어야 한다는 판단
+(오르테가군: 수정일 기준이면 에이전트가 방금 건드린 문서가 위로 오는 「거짓 최신성」이
+된다). DB 컬럼은 이미 있다(TimestampMixin) — additive로 노출만 한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    from app.models.doc import Doc
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    created_ts = datetime.now(timezone.utc) - timedelta(days=3)
+    updated_ts = datetime.now(timezone.utc)
+    doc = Doc(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="D1",
+        slug="d1", doc_type="page",
+        created_at=created_ts, updated_at=updated_ts,
+    )
+    session.add(doc)
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "doc_id": doc.id, "created_ts": created_ts}
+
+
+async def test_doc_summary_response_exposes_created_at_distinct_from_updated_at():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            from app.repositories.doc import DocRepository
+            from app.routers.docs import list_docs
+
+            repo = DocRepository(s, seeded["org_id"])
+            result = await list_docs(
+                project_id=seeded["project_id"], parent_id=None, doc_type=None,
+                tags=None, slug=None, q=None, limit=500, repo=repo,
+            )
+        assert len(result) == 1
+        summary = result[0]
+        assert hasattr(summary, "created_at"), "DocSummaryResponse에 created_at 필드가 없음"
+        assert summary.created_at is not None
+        assert summary.created_at != summary.updated_at, (
+            "created_at이 updated_at과 같은 값이면 시딩이 의도(3일 전 생성·방금 수정)를 못 나타낸 것"
+        )
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_doc_slug_enrich.py
+++ b/backend/tests/test_doc_slug_enrich.py
@@ -29,7 +29,7 @@ def _doc(assignee_id=None):
     return SimpleNamespace(
         id=uuid.uuid4(), project_id=uuid.uuid4(), org_id=ORG, parent_id=None,
         title="t", slug="s", canonical_slug="s", slug_locked=False, icon=None,
-        sort_order=0, doc_type="page", is_folder=False, tags=[], updated_at=T,
+        sort_order=0, doc_type="page", is_folder=False, tags=[], created_at=T, updated_at=T,
         snippet=None, assignee_id=assignee_id,
     )
 


### PR DESCRIPTION
## Summary
`GET /api/v2/docs`(리스트) 응답이 `updated_at`만 노출하고 `created_at`은 빠져 있었음 — DB 컬럼은 이미 있음(`Doc`이 `TimestampMixin` 상속), additive로 노출만 함. 마이그레이션 불요.

문서 트리 시간 그룹 기준이 수정일이 아니라 **생성일**이어야 하는 이유:
1. 수정일 기준이면 에이전트가 방금 건드린 문서가 위로 오는 "거짓 최신성" — 조직 특성상 에이전트 활동량이 커서 소음이 됨
2. 버킷이 수정마다 바뀌면 "어디 있더라"가 안 됨 — 생성일은 고정
3. "최근 본 것"이 이미 사람 열람 축을 담당 — 수정일까지 넣으면 축이 두 번 겹침

## 블라스트 반경 확認
`DocSummaryResponse`의 유일한 생성 경로는 `app/routers/docs.py`의 `model_validate(doc)` 호출들(list/tree/tags/search/slug-enrich) — 전부 Pydantic `from_attributes`라 ORM 객체가 이미 가진 `created_at`을 그대로 읽음. 라우터 로직 변경 0줄.

## Test plan
- [x] 신규 realdb 테스트 1건 — `created_at`이 노출되고 `updated_at`과 다른 값임을 확認
- [x] 기존 `test_doc_slug_enrich.py`의 mock fixture에 `created_at` 없어 4건 깨졌던 것 동기화 fix
- [x] 뮤테이션 셀프체크: schema 변경 stash → 정확히 "필드 없음"으로 RED → 복구 확認
- [x] 관련 doc 테스트 34건(개별 파일 실행) 그린

## 📌 별건 발견(미수정)
`test_doc_mutation_project_scope_idor_realdb.py`가 pristine `origin/develop`에서도 이미 실패 중(`NotNullViolationError: projects.violation_level`) — 이 PR과 무관함을 무수정 체크아웃 재현으로 확認. 별도 트래킹 필요해 보임.

🤖 Generated with [Claude Code](https://claude.com/claude-code)