### PR TITLE
[SID:2194] 알림 뱃지 카운트가 200건부터 거짓말하던 것 fix

### DIFF
--- a/apps/web/src/app/api/notifications/count/route.test.ts
+++ b/apps/web/src/app/api/notifications/count/route.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// story #2194 — 뱃지 카운트가 list(limit:200).length 자작 계산이 아니라 repo.countUnread()
+// (BE 진짜 unbounded SQL COUNT)를 쓰는지 검증한다.
+const h = vi.hoisted(() => ({
+  getAuthContext: vi.fn(), createNotificationRepository: vi.fn(),
+  countUnread: vi.fn(), list: vi.fn(),
+}));
+vi.mock('@/lib/auth-helpers', () => ({ getAuthContext: h.getAuthContext }));
+vi.mock('@/lib/storage/factory', () => ({ createNotificationRepository: h.createNotificationRepository }));
+
+import { GET } from './route';
+
+const agent = () => ({ id: 'mem-1', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
+
+describe('/api/notifications/count (story #2194)', () => {
+  beforeEach(() => {
+    Object.values(h).forEach((m) => m.mockReset());
+    h.getAuthContext.mockResolvedValue(agent());
+    h.createNotificationRepository.mockResolvedValue({ countUnread: h.countUnread, list: h.list });
+  });
+
+  it('401 when unauthenticated', async () => {
+    h.getAuthContext.mockResolvedValue(null);
+    expect((await GET(new Request('http://localhost/api/notifications/count'))).status).toBe(401);
+  });
+
+  it('repo.countUnread()이 반환하는 값을 그대로 뱃지 수로 쓴다(list는 안 부른다)', async () => {
+    h.countUnread.mockResolvedValue(250);
+    const res = await GET(new Request('http://localhost/api/notifications/count'));
+    const body = await res.json();
+
+    expect(body.data.inboxUnreadCount).toBe(250);
+    expect(h.countUnread).toHaveBeenCalledWith('mem-1');
+    expect(h.list).not.toHaveBeenCalled();
+  });
+
+  it('음성대조 — 200 이하 값도 그대로 통과한다(캡 없음)', async () => {
+    h.countUnread.mockResolvedValue(7);
+    const res = await GET(new Request('http://localhost/api/notifications/count'));
+    const body = await res.json();
+
+    expect(body.data.inboxUnreadCount).toBe(7);
+  });
+});

--- a/apps/web/src/app/api/notifications/count/route.ts
+++ b/apps/web/src/app/api/notifications/count/route.ts
@@ -3,7 +3,14 @@ import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { createNotificationRepository } from '@/lib/storage/factory';
 
-/** GET — 안읽음 뱃지용 COUNT만 반환 (full list 조회 없음) */
+/** GET — 안읽음 뱃지용 COUNT만 반환 (full list 조회 없음)
+ *
+ * story #2194 — 예전엔 repo.list({ limit: 200 }).length로 뱃지 수를 냈다. BE가 이미
+ * 진짜 unbounded SQL COUNT 엔드포인트(countUnread → /api/v2/notifications/count →
+ * select(func.count()))를 제공하므로, list+length로 재구현하지 않고 그걸 그대로 쓴다.
+ * list+length 방식은 200건 넘는 계정에서 실제 unread 수와 무관하게 항상 200을 반환하는
+ * 결함이 있었다(뱃지가 "200건부터 거짓말"하는 자리).
+ */
 export async function GET(request: Request) {
   try {
     const me = await getAuthContext(request);
@@ -11,8 +18,7 @@ export async function GET(request: Request) {
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
     const repo = await createNotificationRepository();
-    const all = await repo.list({ user_id: me.id, is_read: false, limit: 200 });
-    const inboxUnreadCount = all.length;
+    const inboxUnreadCount = await repo.countUnread(me.id);
     return apiSuccess({ inboxUnreadCount });
   } catch (err: unknown) {
     return handleApiError(err);

--- a/packages/core-storage/src/interfaces/INotificationRepository.ts
+++ b/packages/core-storage/src/interfaces/INotificationRepository.ts
@@ -33,4 +33,8 @@ export interface INotificationRepository {
   list(filters: NotificationListFilters): Promise<Notification[]>;
   markRead(id: string, userId: string): Promise<Notification>;
   markAllRead(userId: string): Promise<number>;
+  // story #2194 — list(limit:200).length는 200건 넘는 계정에서 실제 unread 수를 거짓으로
+  // 200에 고정시킨다. BE에 이미 진짜 unbounded SQL COUNT 엔드포인트(/api/v2/notifications/count)가
+  // 있으므로 뱃지는 반드시 이 메서드로 받아야 한다 — list+length로 대체하지 말 것.
+  countUnread(userId: string): Promise<number>;
 }

--- a/packages/storage-api/src/ApiNotificationRepository.ts
+++ b/packages/storage-api/src/ApiNotificationRepository.ts
@@ -20,4 +20,14 @@ export class ApiNotificationRepository implements INotificationRepository {
     const result = await fastapiCall<{ count?: number }>('PATCH', '/api/v2/notifications/mark-all-read', this.accessToken, { query: { user_id: userId } });
     return result?.count ?? 0;
   }
+
+  // story #2194 — BE(/api/v2/notifications/count)가 이미 select(func.count())로 진짜
+  // unbounded 카운트를 낸다. 여기서 list(limit:200) 등으로 재구현하면 200건 초과 계정에서
+  // 항상 200에 고정되는 결함이 재발한다. 이 BE 라우트는 user_id를 쿼리로 안 받고 auth
+  // context에서만 파생한다(notifications.py count_unread) — 그래서 인자로 받는 userId는
+  // 인터페이스 시그니처 일관성을 위해 남기되 쿼리로 넘기지 않는다.
+  async countUnread(_userId: string): Promise<number> {
+    const result = await fastapiCall<{ count?: number }>('GET', '/api/v2/notifications/count', this.accessToken);
+    return result?.count ?? 0;
+  }
 }


### PR DESCRIPTION
## 요약
- 인박스 뱃지(`/api/notifications/count`)가 `repo.list({ limit: 200 }).length`로 카운트를 자작 계산해, 200건 넘는 계정에서 실제 unread 수와 무관하게 항상 200에서 고정되던 결함.
- BE에 이미 진짜 unbounded SQL COUNT 엔드포인트(`GET /api/v2/notifications/count` → `select(func.count())`)가 있어, `INotificationRepository`에 `countUnread()`를 추가하고 FE route가 그걸 직접 쓰도록 교체.

## 배경
#2192(알림벨 절단) 착지 확인 과정에서 발견 — 종 아이콘(벨) 자체는 뱃지/목록이 같은 `event-notifications` 계열이라 이상 없었지만, 별개로 존재하는 사이드바 "인박스" 뱃지 소스(`/api/notifications`)에서 이 결함을 확인했다. #2192/#2504는 그대로 유효(다른 시스템).

## 스코프 밖(별도 스토리 예정)
- 인박스 **목록** 자체도 `limit:50` 하드코딩 + offset/cursor 미지원으로 절단되는 문제가 있음 — 이건 BE에 offset 파라미터가 아예 없어 backend/ 변경이 필요해 이 PR엔 포함하지 않았다.

## 테스트
- `route.test.ts` 신규 3건(401·countUnread 위임 확인·list 미호출 확인·200 초과값 통과 확인).
- 뮤테이션 셀프체크: route를 예전 list+length 방식으로 되돌려 확인 — 정확히 RED.
- `pnpm exec tsc --noEmit`(clean) / `pnpm run lint`(0 errors, 기존 무관 warning 5건만) / `pnpm exec vitest run`(apps/web 306 files·2040 tests + storage-api 1 file·2 tests, 전부 pass) / `pnpm build`(exit 0).

## Test plan
- [ ] CI green
- [ ] 배포 후 200+ unread 테스트 계정으로 뱃지 실측(가능한 계정 있으면)