### PR TITLE
fix(#2168 PR-①): 임베드 doc 링크가 자신의 project를 실어 나르게 한다

### DIFF
--- a/apps/web/src/app/api/docs/preview/route.ts
+++ b/apps/web/src/app/api/docs/preview/route.ts
@@ -19,13 +19,20 @@ export async function GET(request: Request) {
 
     const _r = await proxyToFastapi(request, '/api/v2/docs/preview');
     if (!_r.ok) return _r;
-    const data = await _r.json() as { id: string; title: string; icon: string | null; slug: string; embed_chain?: string[] };
+    const data = await _r.json() as {
+      id: string; title: string; icon: string | null; slug: string; embed_chain?: string[];
+      // #2168 PR-①: 링크가 자기 project 를 실어 나르기 위한 3필드(additive).
+      project_id: string; org_slug: string; project_slug: string | null;
+    };
     return apiSuccess({
       id: data.id,
       title: data.title,
       icon: data.icon ?? null,
       slug: data.slug,
       embedChain: data.embed_chain ?? [],
+      projectId: data.project_id,
+      orgSlug: data.org_slug,
+      projectSlug: data.project_slug ?? null,
     });
   } catch (err: unknown) {
     return handleApiError(err);

--- a/apps/web/src/components/chat/embed-card.test.tsx
+++ b/apps/web/src/components/chat/embed-card.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+//
+// story #2168 PR-① — 채팅에 임베드된 doc이 "현재 프로젝트"와 다른 project 소속일 때 못 열리던
+// 원 결함(조사 로그: embed-card.tsx의 handleDocClick이 project 없는 bare `/docs/{slug}/view`로
+// 이동 → middleware가 CURRENT_PROJECT_COOKIE로 project를 추측 → 다른 project 문서면 못 찾음).
+// 처방 = /api/docs/preview 가 이제 내려주는 doc 자신의 project(orgSlug/projectSlug)로 직행.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { EmbedCard } from './embed-card';
+
+const pushMock = vi.hoisted(() => vi.fn());
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+function stubFetch(impl: (url: string) => Promise<{ ok: boolean; json: () => Promise<unknown> }>) {
+  vi.stubGlobal('fetch', vi.fn((url: string) => impl(url)));
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  pushMock.mockClear();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+async function clickMainDocButton() {
+  const btn = container.querySelector('button');
+  await act(async () => {
+    btn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('EmbedCard doc — story #2168 PR-①', () => {
+  it('크로스프로젝트 doc(다른 project 소속)을 클릭하면 그 project 경로로 직행한다', async () => {
+    stubFetch(async () => ({
+      ok: true,
+      json: async () => ({
+        data: { slug: 'other-doc', orgSlug: 'acme', projectSlug: 'content', projectId: 'p-2' },
+      }),
+    }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="doc" entity_id="doc-1" title="T" status={null} />);
+    });
+    await clickMainDocButton();
+    expect(pushMock).toHaveBeenCalledWith('/acme/content/docs/other-doc/view');
+  });
+
+  it('project_slug 가 없으면(옛 미백필 프로젝트) bare 링크로 우아하게 폴백한다(회귀 아님)', async () => {
+    stubFetch(async () => ({
+      ok: true,
+      json: async () => ({
+        data: { slug: 'legacy-doc', orgSlug: 'acme', projectSlug: null, projectId: 'p-3' },
+      }),
+    }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="doc" entity_id="doc-2" title="T" status={null} />);
+    });
+    await clickMainDocButton();
+    expect(pushMock).toHaveBeenCalledWith('/docs/legacy-doc/view');
+  });
+
+  it('preview fetch 실패 시 이동하지 않고 navigating 스피너를 해제한다', async () => {
+    stubFetch(async () => ({ ok: false, json: async () => ({}) }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="doc" entity_id="doc-3" title="T" status={null} />);
+    });
+    await clickMainDocButton();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -6,8 +6,8 @@ import { useRouter } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { ExternalLink, X, FileText, File, Layers, CheckSquare, Hash, Eye, type LucideIcon } from 'lucide-react';
-import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { docViewUrl } from '@/components/docs/lib/doc-project-url';
 
 // 글리프(📋📄🎯✅) → lucide. 타입 식별=아이콘·색은 신호 토큰만(다크 무파손).
 export const ENTITY_ICONS: Record<string, LucideIcon> = {
@@ -152,9 +152,14 @@ function EntityPreviewModal({
 }) {
   const [detail, setDetail] = useState<Record<string, unknown> | null>(null);
   const [loading, setLoading] = useState(entityType !== 'task');
-  // story #1996: doc 본문 조회는 project_id+slug 조합 엔드포인트(getDoc)라 project_id가
-  // 필요 — doc 뷰 페이지([slug]/view/page.tsx)와 동일 소스(useDashboardContext).
-  const { projectId } = useDashboardContext();
+  // #2168 PR-①: docPreview 가 이 doc이 실제로 속한 project(project_id)+경로 세그먼트
+  // (org_slug/project_slug)를 함께 내려준다 — "현재 프로젝트"(useDashboardContext)를 더는
+  // 추측에 쓰지 않는다. 크로스프로젝트 임베드(다른 project 문서가 채팅에 임베드된 경우)는
+  // 현재 프로젝트로 조회하면 project_id AND 필터에 안 걸려 항상 실패했던 것이 원 결함
+  // (조사 로그: story #2168 참조) — 링크가 스스로 자기 project 를 실어 나르는 것이 처방.
+  const [docPreview, setDocPreview] = useState<{
+    slug: string; projectId: string; orgSlug: string; projectSlug: string | null;
+  } | null>(null);
 
   // story #2061: 손수 구현 Escape 핸들러 제거 — 공용 Dialog(base-ui)가 Escape/backdrop-click/
   // 포커스 트랩/반환을 전부 내장한다(중복 핸들러 방지).
@@ -163,18 +168,28 @@ function EntityPreviewModal({
     let cancelled = false;
 
     if (entityType === 'doc') {
-      // story #1996: doc은 2단계 — ①/api/docs/preview?q=(slug-or-uuid)로 entityId(uuid)를
-      // slug로 해소 ②project_id+slug로 본문 조회(getDoc, 다른 doc 뷰 표면과 동일 SSOT 패턴).
-      // /api/docs/{id}(lightweight timestamp-only)를 "풀 doc 조회"로 오인했던 게 원 결함.
-      if (!projectId) { setLoading(false); return; }
+      // #2168 PR-①: doc은 2단계 — ①/api/docs/preview?q=(slug-or-uuid)로 entityId(uuid)를
+      // slug+**실제 project_id/org_slug/project_slug**로 해소 ②그 project_id(현재 프로젝트가
+      // 아니라 doc 자신의 project)로 본문 조회(getDoc, 다른 doc 뷰 표면과 동일 SSOT 패턴).
+      // /api/docs/{id}(lightweight timestamp-only)를 "풀 doc 조회"로 오인했던 게 원 결함(#1996).
       void (async () => {
         try {
           const previewRes = await fetch(`/api/docs/preview?q=${encodeURIComponent(entityId)}`);
           if (!previewRes.ok) throw new Error();
-          const previewJson = (await previewRes.json()) as { data?: { slug?: string } };
+          const previewJson = (await previewRes.json()) as {
+            data?: { slug?: string; projectId?: string; orgSlug?: string; projectSlug?: string | null };
+          };
           const slug = previewJson.data?.slug;
-          if (!slug) throw new Error();
-          const docRes = await fetch(`/api/docs?project_id=${projectId}&slug=${encodeURIComponent(slug)}`);
+          const docProjectId = previewJson.data?.projectId;
+          if (!slug || !docProjectId) throw new Error();
+          if (!cancelled) {
+            setDocPreview({
+              slug, projectId: docProjectId,
+              orgSlug: previewJson.data?.orgSlug ?? '',
+              projectSlug: previewJson.data?.projectSlug ?? null,
+            });
+          }
+          const docRes = await fetch(`/api/docs?project_id=${docProjectId}&slug=${encodeURIComponent(slug)}`);
           if (!docRes.ok) throw new Error();
           const docJson = (await docRes.json()) as { data?: Record<string, unknown> };
           if (!cancelled) setDetail(docJson.data ?? null);
@@ -195,17 +210,23 @@ function EntityPreviewModal({
       .catch(() => { /* fetch 실패 시 fallback만 표시 */ })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, [entityType, entityId, projectId]);
+  }, [entityType, entityId]);
 
   const Icon = ENTITY_ICONS[entityType] ?? Hash;
   const colorClass = ENTITY_COLORS[entityType] ?? 'border-border bg-muted text-foreground';
   const label = title ?? entityId;
-  // story #1996: getEntityHref('doc', id)의 `/docs?id=` 는 어느 라우트도 소비하지 않는 죽은
-  // 패턴(grep 0건) — 실 라우트는 slug 기반(`/docs/{slug}/view`, embed-card의 handleDocClick과
-  // 동형). doc 상세 fetch(위 useEffect)가 이미 slug를 포함해 내려주므로 로드 후 그걸로 override —
-  // "미리보기 살리기"가 이 죽은 링크를 처음으로 실사용 도달 가능하게 만드는 지점이라 같이 고친다.
-  const docSlug = entityType === 'doc' ? (detail as { slug?: string } | null)?.slug : undefined;
-  const resolvedHref = entityType === 'doc' ? (docSlug ? `/docs/${docSlug}/view` : null) : href;
+  // #2168 PR-①: org_slug+project_slug 가 있으면 `/{ws}/{proj}/docs/{slug}/view`로 직행 —
+  // CURRENT_PROJECT_COOKIE 기반 middleware 추측(proxy.ts redirectLegacyResourcePath, "현재
+  // 프로젝트"만 봄)을 거치지 않아 크로스프로젝트에서도 항상 맞는 project 로 착지한다.
+  // project_slug 가 없으면(옛 미백필 프로젝트, Project.slug nullable) 예전 bare 링크로 우아하게
+  // 폴백 — 그 경우는 기존과 동일하게 middleware 추측에 의존(회귀 아님, 기존 동작 유지).
+  const resolvedHref = entityType === 'doc'
+    ? (docPreview
+        ? (docPreview.orgSlug && docPreview.projectSlug
+            ? docViewUrl(docPreview.orgSlug, docPreview.projectSlug, docPreview.slug)
+            : `/docs/${docPreview.slug}/view`)
+        : null)
+    : href;
 
   return (
     <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
@@ -274,10 +295,21 @@ export function EmbedCard({ entity_type, entity_id, title, status }: EmbedCardDa
       // story #1996: /api/docs/{id}는 lightweight timestamp-only 엔드포인트(`{updated_at}`만
       // 반환) — 이 컴포넌트가 실측 이전엔 `data.slug`를 기대해왔으나 실제로 항상 undefined였다
       // (`/docs/undefined/view`로 404). /api/docs/preview?q=가 id→slug 해소 전용 엔드포인트.
+      //
+      // #2168 PR-①: 이 카드가 채팅에 임베드된 doc이 "현재 프로젝트"와 다를 때(크로스프로젝트
+      // 링크)의 바로 그 원 결함 지점 — bare `/docs/{slug}/view`는 middleware(proxy.ts)가
+      // CURRENT_PROJECT_COOKIE로 project를 추측해 다른 project의 doc이면 못 찾았다(조사 로그:
+      // story #2168 참조). preview 응답의 org_slug/project_slug(doc 자신의 실제 project)로
+      // 직행하면 이 추측 자체가 필요 없어진다 — project_slug 없으면(옛 미백필) bare 링크로 폴백.
       const res = await fetch(`/api/docs/preview?q=${encodeURIComponent(entity_id)}`);
       if (!res.ok) throw new Error();
-      const { data } = await res.json() as { data: { slug: string } };
-      router.push(`/docs/${data.slug}/view`);
+      const { data } = await res.json() as {
+        data: { slug: string; orgSlug?: string; projectSlug?: string | null };
+      };
+      const target = (data.orgSlug && data.projectSlug)
+        ? docViewUrl(data.orgSlug, data.projectSlug, data.slug)
+        : `/docs/${data.slug}/view`;
+      router.push(target);
     } catch {
       setNavigating(false);
     }

--- a/apps/web/src/components/docs/lib/doc-project-url.ts
+++ b/apps/web/src/components/docs/lib/doc-project-url.ts
@@ -17,3 +17,9 @@ export function docUrl(wsSlug: string, projSlug: string, slug: string): string {
 export function docsListUrl(wsSlug: string, projSlug: string): string {
   return `/${wsSlug}/${projSlug}/docs`;
 }
+
+/** #2168 PR-①: 읽기전용 뷰 라우트(`[slug]/view`) — 편집기(docUrl)와 다른 목적지. 채팅 임베드
+ * 미리보기(embed-card.tsx)가 doc 자신의 실제 project 로 직행할 때 쓴다. */
+export function docViewUrl(wsSlug: string, projSlug: string, slug: string): string {
+  return `/${wsSlug}/${projSlug}/docs/${slug}/view`;
+}

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -229,6 +229,14 @@ class DocPreviewResponse(BaseModel):
     icon: str | None = None
     slug: str
     embed_chain: list[str] = []
+    # #2168 PR-①: 크로스프로젝트 doc 링크가 "링크 자신이 속한 project 를 실어 나르는" 처방이라
+    # 받는 쪽(FE embed-card)이 "현재 프로젝트"를 추측하지 않고 이 doc 의 실제 project 로 직행할
+    # 수 있어야 한다 — project_id(2차 조회 스코프용) + org_slug/project_slug(경로 세그먼트,
+    # `/{ws}/{proj}/docs/{slug}/view` 조립용). additive·project_slug 는 nullable(Project.slug
+    # 가 nullable — 옛 미백필 프로젝트는 None, FE 가 bare 링크로 우아하게 폴백).
+    project_id: uuid.UUID
+    org_slug: str
+    project_slug: str | None = None
 
 
 # ─── Preview (must be before /{id} to avoid routing conflict) ─────────────────
@@ -241,6 +249,8 @@ async def get_doc_preview(
     repo: DocRepository = Depends(_get_repo),
 ) -> DocPreviewResponse:
     from app.models.doc import Doc
+    from app.models.organization import Organization
+    from app.models.project import Project
 
     try:
         doc_uuid = uuid.UUID(q)
@@ -251,8 +261,16 @@ async def get_doc_preview(
     result = await db.execute(stmt.limit(1))
     doc = result.scalar_one_or_none()
 
+    if doc is not None:
+        # #2168 PR-①: get_doc 과 동형 갭 — org-scope happy path 가 project 인가 없이 즉시
+        # 반환하던 것을 canonical 가드로 통일(같은 이유: 링크가 project 를 실어 나르기 시작하며
+        # 이 경로의 실사용 빈도가 올라간다).
+        from app.services.project_auth import has_project_access
+        if not await has_project_access(db, uuid.UUID(auth.user_id), doc.project_id, repo.org_id):
+            raise HTTPException(status_code=403, detail="해당 문서의 프로젝트 접근 권한이 없습니다")
+
     if doc is None:
-        # cross-org fallback: slug/uuid 기반 전체 org 조회 후 membership 검증
+        # cross-org fallback: slug/uuid 기반 전체 org 조회 후 membership 검증 (기존, 무변경)
         try:
             doc_uuid2 = uuid.UUID(q)
             fallback_stmt = select(Doc).where(Doc.id == doc_uuid2, Doc.deleted_at.is_(None))
@@ -273,12 +291,22 @@ async def get_doc_preview(
         if member.scalar_one_or_none() is None:
             raise HTTPException(status_code=403, detail="해당 프로젝트의 멤버가 아닌")
 
+    org_slug = (await db.execute(
+        select(Organization.slug).where(Organization.id == doc.org_id)
+    )).scalar_one()
+    project_slug = (await db.execute(
+        select(Project.slug).where(Project.id == doc.project_id)
+    )).scalar_one_or_none()
+
     return DocPreviewResponse(
         id=doc.id,
         title=doc.title,
         icon=doc.icon,
         slug=doc.slug,
         embed_chain=[],
+        project_id=doc.project_id,
+        org_slug=org_slug,
+        project_slug=project_slug,
     )
 
 
@@ -292,8 +320,16 @@ async def get_doc(
     repo: DocRepository = Depends(_get_repo),
 ) -> DocResponse:
     doc = await repo.get(id)
+    if doc is not None:
+        # #2168 PR-①: 크로스프로젝트 doc 링크가 정상 동선이 되며 이 org-scope happy path의
+        # project 인가 누락(patch/delete 는 f69fcd91 로 이미 고쳐졌으나 GET 은 방치돼 있었음 —
+        # 同org 비-project caller 가 id만 알면 무제한 열람 가능하던 갭)이 실사용 IDOR 표면으로
+        # 커진다. canonical 가드(has_project_access)로 patch/delete 와 통일.
+        from app.services.project_auth import has_project_access
+        if not await has_project_access(session, uuid.UUID(auth.user_id), doc.project_id, repo.org_id):
+            raise HTTPException(status_code=403, detail="해당 문서의 프로젝트 접근 권한이 없습니다")
     if doc is None:
-        # cross-org fallback: project_id query param 없이 단일 id로 접근한 경우
+        # cross-org fallback: project_id query param 없이 단일 id로 접근한 경우 (기존, 무변경)
         from app.models.doc import Doc
         result = await session.execute(
             select(Doc).where(Doc.id == id, Doc.deleted_at.is_(None))

--- a/backend/tests/test_2168_doc_preview_cross_project_link_realdb.py
+++ b/backend/tests/test_2168_doc_preview_cross_project_link_realdb.py
@@ -1,0 +1,166 @@
+"""story #2168 PR-①: 임베드 링크가 doc 자신의 project 를 실어 나르게 하는 처방의 BE 절반.
+
+DocPreviewResponse 에 project_id/org_slug/project_slug 를 additive 로 추가(FE embed-card.tsx
+가 "현재 프로젝트"를 더는 추측하지 않고 이 필드로 doc 이 실제로 속한 project 로 직행하기 위함).
+그리고 get_doc/get_doc_preview 의 org-scope happy path 가 project 인가 없이 즉시 반환하던 갭
+(patch/delete 는 f69fcd91 로 이미 고쳐졌으나 GET 은 방치돼 있었음)을 canonical 가드로 통일한다.
+
+realdb 필수 — has_project_access SSOT(team_member∪grant∪owner/admin) 실측 + Project/Organization
+slug 컬럼 실조회.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("d2168000-0000-0000-0000-000000000001")
+USER = uuid.UUID("d2168000-0000-0000-0000-0000000000a1")
+OM = uuid.UUID("d2168000-0000-0000-0000-0000000000b1")
+PROJ_A = uuid.UUID("d2168000-0000-0000-0000-0000000000c1")  # USER grant(접근 O)
+PROJ_B = uuid.UUID("d2168000-0000-0000-0000-0000000000c2")  # USER 접근 X(cross-project 축)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+
+
+async def _seed(s):
+    """ORG(slug='d2168-org')·PROJ_A(slug='proj-a', grant O)·PROJ_B(slug='proj-b', grant X) + 양쪽 doc."""
+    from app.models.doc import Doc
+    for sql in [
+        f"DELETE FROM docs WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id IN ('{PROJ_A}','{PROJ_B}')",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','D2168','d2168-org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@d2168.test','x','U',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
+        f"INSERT INTO projects (id,org_id,name,slug) VALUES ('{PROJ_A}','{ORG}','A','proj-a')",
+        f"INSERT INTO projects (id,org_id,name,slug) VALUES ('{PROJ_B}','{ORG}','B','proj-b')",
+        # USER 는 PROJ_A 에만 grant(PROJ_B 접근 없음 — cross-project 테스트축).
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ_A}','{OM}','granted')",
+    ]:
+        await s.execute(text(sql))
+    docs = {}
+    for key, pid in [("a", PROJ_A), ("b", PROJ_B)]:
+        d = Doc(id=uuid.uuid4(), org_id=ORG, project_id=pid, title=f"doc-{key}",
+                slug=f"s-{key}-{uuid.uuid4().hex[:8]}", content="")
+        s.add(d)
+        docs[key] = d
+    await s.commit()
+    return docs
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+@pytest.mark.anyio
+async def test_preview_same_project_returns_project_id_and_slugs():
+    from app.repositories.doc import DocRepository
+    from app.routers.docs import get_doc_preview
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            docs = await _seed(s)
+            doc_a = docs["a"]
+        async with Session() as s:
+            resp = await get_doc_preview(
+                q=str(doc_a.id), db=s, auth=_auth(), repo=DocRepository(s, ORG)
+            )
+        assert resp.project_id == PROJ_A
+        assert resp.org_slug == "d2168-org"
+        assert resp.project_slug == "proj-a"
+        assert resp.slug == doc_a.slug
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_preview_cross_project_forbidden():
+    """#2168 조사 로그의 실제 결함: 링크가 project 없이 도착하면 receiver가 "현재 프로젝트"로
+    추측했다 — 그 갭을 막는 canonical 인가가 preview 에도 걸려야 한다(get_doc 과 동형 가드)."""
+    from app.repositories.doc import DocRepository
+    from app.routers.docs import get_doc_preview
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            docs = await _seed(s)
+            doc_b = docs["b"]
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await get_doc_preview(
+                    q=str(doc_b.id), db=s, auth=_auth(), repo=DocRepository(s, ORG)
+                )
+            assert ei.value.status_code == 403
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_doc_cross_project_forbidden_same_project_ok():
+    """get_doc(GET /{id}) org-scope happy path 가 project 인가 없이 즉시 반환하던 갭 — fix 검증.
+    fix 前(has_project_access 가드 제거)엔 이 테스트가 RED(200 반환)로 exploitability 실증."""
+    from app.repositories.doc import DocRepository
+    from app.routers.docs import get_doc
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            docs = await _seed(s)
+            doc_a, doc_b = docs["a"], docs["b"]
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await get_doc(id=doc_b.id, session=s, auth=_auth(), repo=DocRepository(s, ORG))
+            assert ei.value.status_code == 403
+        async with Session() as s:
+            out = await get_doc(id=doc_a.id, session=s, auth=_auth(), repo=DocRepository(s, ORG))
+            assert out.id == doc_a.id
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_preview_legacy_project_without_slug_returns_none_not_error():
+    """Project.slug 는 nullable(옛 미백필) — preview 가 project_slug=None 을 내려주면 FE 가
+    bare 링크로 우아하게 폴백한다(회귀 아님). preview 가 여기서 예외를 던지지 않는지 고정."""
+    from app.repositories.doc import DocRepository
+    from app.routers.docs import get_doc_preview
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            docs = await _seed(s)
+            doc_a = docs["a"]
+            await s.execute(text(f"UPDATE projects SET slug=NULL WHERE id='{PROJ_A}'"))
+            await s.commit()
+        async with Session() as s:
+            resp = await get_doc_preview(
+                q=str(doc_a.id), db=s, auth=_auth(), repo=DocRepository(s, ORG)
+            )
+        assert resp.project_slug is None
+        assert resp.project_id == PROJ_A
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## 배경 (story #2168)

선생님이 채팅에서 다른 프로젝트 문서 임베드를 클릭했을 때 못 열리던 "태정신병" — 조사
결과(스토리 본문 조사 로그 참조) 서버 인가 문제가 아니라 링크가 project 정보 없이 도착해
receiver가 "현재 프로젝트"로 추측하다 실패하는 것으로 확定(BE `GET /docs/{id}`는 org-scope
로 오히려 관대, FE 조회는 `project_id` AND 필터라 다른 프로젝트 문서면 항상 미스).

⚠️1차 처방("조회를 org로 넓히자")은 `docs_project_slug_active UNIQUE(project_id, slug)`
스키마 확인으로 기각됨 — 같은 org 다른 project가 같은 slug를 가질 수 있어 "org 안에서
slug로 찾기"는 어느 것인지 못 고른다. 최종 처방은 **링크가 doc 자신의 project를 실어
나르는 것**.

## 변경

**BE — `DocPreviewResponse`에 `project_id`/`org_slug`/`project_slug` 추가(additive)**
- `get_doc_preview`가 이제 doc이 실제로 속한 project의 org_slug/project_slug를 함께
  반환 — FE가 `/{ws}/{proj}/docs/{slug}/view`로 직행할 수 있게 한다.
- `project_slug`는 nullable(Project.slug 자체가 nullable — 옛 미백필 프로젝트는 None,
  FE가 bare 링크로 우아하게 폴백).

**FE — `embed-card.tsx`의 두 경로 모두 수정**
- `handleDocClick`(카드 본체 클릭 = 주 이동 경로, 조사 로그가 지목한 실제 결함 지점)과
  `EntityPreviewModal`(👁 미리보기 경로) 둘 다 preview 응답의 project 정보로
  `/{ws}/{proj}/docs/{slug}/view` 직행 — `CURRENT_PROJECT_COOKIE` 기반 middleware
  추측을 거치지 않는다.
- `project_slug` 없으면 기존 bare `/docs/{slug}/view`로 폴백(회귀 아님, 기존 동작 유지).
- `doc-project-url.ts`에 `docViewUrl` 헬퍼 추가(기존 `docUrl`/`newDocUrl` 컨벤션과 통일).

**부수 발견 — get_doc/get_doc_preview의 project 인가 갭 (같이 고침, 스코프 내)**

`get_doc`(`GET /{id}`)과 `get_doc_preview`의 org-scope happy path가 project 인가 없이
즉시 반환하고 있었다 — patch/delete/update 등은 `f69fcd91`로 이미
`_require_doc_project_access`/`has_project_access` 가드가 걸렸으나 GET 경로만 방치돼
있었다. AC2("권한 없는 프로젝트 문서 링크를 밟으면 서버가 거부한다")가 이 PR의 명시
요구사항이고, 크로스프로젝트 doc 링크를 정상 동선으로 만드는 이 PR 자체가 이 갭의
실사용 빈도를 올리므로 같은 PR에서 canonical 가드로 통일했다. 기존 cross-org fallback
분기(다른 org 소속 doc도 project membership만으로 허용하는 로직)는 **건드리지
않음** — #2168의 스코프는 same-org cross-project이고, cross-org 의미론은 별개의 더 큰
질문이라 판단.

## 착지 판정 기준 대조(오르테가군 확定, 스토리 AC 참조)

- AC0(클릭만으로 열림) — `handleDocClick`/모달 둘 다 project-scoped href로 직행하므로 충족.
- AC1(현재 프로젝트 전역 상태 불변) — 이 PR은 CURRENT_PROJECT_COOKIE를 건드리지 않음(읽기만
  하던 middleware 경로 자체를 우회하므로 변경 계기가 없음). 다만 이 부분은 라이브 확認이
  필요하다고 조사 로그에 명시해 뒀다(아래 "안 닿는 것" 참조).
- AC2(권한 없는 프로젝트는 서버가 거부) — 이번 IDOR 픽스로 충족, realdb 테스트로 고정.
- AC3(선생님 원 동선 재현) — 배포 후 라이브 확認 필요(아래 참조).

## 검증

- BE: `test_2168_doc_preview_cross_project_link_realdb.py`(realdb, 4건) — preview가 project
  정보를 정확히 내려주는지, cross-project는 403인지(get_doc/get_doc_preview 둘 다), legacy
  project(slug=None)는 우아하게 폴백하는지. **뮤테이션 셀프체크 통과** — 가드를 각각 주석
  처리해 정확히 예측한 테스트만 RED로 전환되는 것 확認 후 복구.
- FE: `embed-card.test.tsx`(3건) — 크로스프로젝트 doc 클릭 시 정확한 project 경로로 push,
  legacy(project_slug 없음) 폴백, preview 실패 시 미이동. **뮤테이션 셀프체크 통과.**
- BE 회귀: `pytest -k "doc and not realdb"` 207 passed(회귀 0). realdb 전체 doc 스윕에서
  38건의 **기존 실패**를 발견했으나 pristine `origin/develop`과 동일 checkout에서 동일하게
  재현 확認(내 변경과 무관) — 대부분 `projects.violation_level` NOT NULL 위반류로, 이
  세션에서 이미 문서화된 "일부 realdb 테스트가 `Base.metadata.drop_all()`로 공유 스캐치
  DB 스키마를 오염시키는" 알려진 인프라 갭과 일치하는 서명(내 테스트도 그 오염된 상태에서
  격리 실행 시엔 4/4 그린, DB 재구축 후에도 4/4 그린 재확認). 내가 만들거나 악화시킨 문제
  아님.
- FE 회귀: `vitest run apps/web/src/components/chat apps/web/src/components/docs
  apps/web/src/app/api/docs` 232 passed. `tsc --noEmit` clean. `eslint` clean(변경 파일).

## ⛔ 이 PR이 안 닿는 것 (명시)

- AC1의 "다른 프로젝트 문서를 연 뒤 CURRENT_PROJECT_COOKIE가 조용히 바뀌지 않는지"는 코드
  정독으로 결론 못 냈다(`docs-context.tsx` 주석은 URL-로컬 해석을 시사하나 직접 증명 지점을
  못 찾음) — 라이브에서 실제로 확認 필요.
- AC3(선생님 원 동선 그대로 재현)은 배포 후 라이브 확認 대상 — 로컬에서는 단위/realdb
  테스트로만 검증했다.
- PR-②(대화 목록에 프로젝트 밖 최근 대화 노출)는 이 PR의 스코프 밖 — 오르테가군 지시대로
  구조만 별도로 준비 중(하나씩 착지시키기 위해 의도적으로 분리).
- cross-org fallback 분기(다른 org 소속 doc을 project membership만으로 허용하는 기존 로직)
  의 의미론은 이 PR에서 검토하지 않음 — #2168 스코프(same-org cross-project) 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)