### PR TITLE
fix(#2198): non-doc 게이트 인가 갭 — rule B를 can_approve+승인 엔드포인트에 마저 배선

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -828,9 +828,16 @@ async def transition_gate_endpoint(
         # doc_approval SoD 비교 전용 축이라 여기 쓰면 다른 사람으로 조회돼 fail-closed 오탐
         # (정당한 owner/admin 이 403)이 난다 — 실제로 이 갭을 realdb 테스트가 잡았다.
         if not await _non_doc_can_approve(session, _gate.gate_type, uuid.UUID(auth.user_id), org_id, _project_id):
+            # #2198(오르테가 PO, 라이브 측정 후 지시): 없던 바를 새로 세우는 변경이라 막히는
+            # 사람이 "무엇을 해야 하는지" 다음 발을 못 받으면 그 자리서 막막해진다(오늘 아침
+            # #2166 과 같은 자리 — 막는 것과 "다음 발을 주는 것"은 다른 일). 자격 기준(project
+            # owner/admin)과 다음 행동(관리자에게 권한 요청)까지 메시지에 명시.
             raise HTTPException(
                 status_code=403,
-                detail="이 게이트를 승인/거부할 권한이 없습니다.",
+                detail=(
+                    "이 게이트를 승인/거부할 권한이 없습니다 (해당 프로젝트의 owner/admin이어야 "
+                    "합니다). 프로젝트 관리자에게 권한을 요청하세요."
+                ),
             )
     # story #2027(까심 QA 적출): 고위험(risk_grade=high) 게이트의 approved 전이는 사유(note) 서버측
     # 강제 — void_gate/override_gate 기존 관례(reason 없으면 ValueError→422, void_gate 참고)에

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -312,11 +312,20 @@ async def list_gates(
     # transition 강제와 can_approve_doc_gate_reason 단일 규칙 공용(DRY). 배치 project_id 주입(N+1 0)·비-휴먼/
     # 무자격/삭제 doc = False(default·fail-closed). additive — 실 authz 는 transition BE 가 강제(이 필드=가시성뿐).
     doc_gates = [(resp, g) for resp, g in zip(responses, gates) if g.gate_type == "doc_approval"]
+    # story #2198(까심 QA 적출·오르테가 확定): non-doc gate(merge/pr_review/qa/deploy/
+    # artifact_canonicalize 등)도 doc_approval 과 **동일 골격**으로 can_approve 를 계산한다 —
+    # rule B(_non_doc_gate_approvable, story #1974)는 이미 존재했으나 지금까지 assigned_to_me
+    # 큐 필터에만 물려 있었고, 이 목록 응답의 can_approve 필드 자체는 계산되지 않아 Pydantic
+    # 기본값 False 가 그대로 나갔다(자격자에게 버튼이 안 뜨는 원 증상). 새 규칙을 발명하지
+    # 않고 있던 rule B 를 여기 마저 물린다.
+    non_doc_gates = [(resp, g) for resp, g in zip(responses, gates) if g.gate_type != "doc_approval"]
     # story #1974(P1a-S5): assigned_to_me 도 doc_approval 경로는 can_approve 와 **동일 계산**이라
     # caller 식별(resolve_member)을 can_approve enrich 와 공유 — 1회만 resolve(중복 계산 0).
+    # #2198: non-doc can_approve 도 이제 assigned_to_me 무관 항상 계산하므로 트리거를 gates 존재
+    # 여부로 넓힌다(doc_gates or non_doc_gates == gates 존재).
     resolved = None
     _uid: uuid.UUID | None = None
-    if doc_gates or assigned_to_me:
+    if doc_gates or non_doc_gates:
         try:
             resolved = await resolve_member(auth, org_id, session)
             _uid = uuid.UUID(auth.user_id)
@@ -346,6 +355,69 @@ async def list_gates(
             # (held→approved 직접 전이 불가하니 held 게이트는 can_approve=False 가 맞다) — 건드리지 않는다.
             resp.can_approve = _reason is None and is_valid_transition(g.status, "approved")
 
+    # project_id 배치 해소(story #1968 resolve_work_item_project_id 의 IN-clause 배치 버전 — 개별
+    # gate 마다 신규 쿼리 금지). doc 은 위에서 이미 배치 조회한 doc_proj 재사용(중복 쿼리 0).
+    # #2198: 이제 can_approve enrich(assigned_to_me 무관)와 assigned_to_me 필터링이 이 배치를
+    # 공유한다(예전엔 assigned_to_me=true 일 때만 계산했다). ⚠️전부 `resolved is not None and
+    # resolved.type == "human"` 게이트 **안**에서만 실행한다 — 캐치 안 되면(비휴먼/resolve 실패)
+    # eligible_ids 가 자연히 빈 채로 남고 can_approve=False(fail-closed)이므로 이 배치 쿼리들
+    # 자체가 불필요(N+1 0 철학과 동형 — "계산해도 결론이 안 바뀔 쿼리는 안 낸다").
+    project_id_by_work_item: dict[uuid.UUID, uuid.UUID | None] = dict(doc_proj)
+    role_cache: dict[uuid.UUID, bool] = {}
+    org_admin_cache: bool | None = None
+    eligible_ids: set[uuid.UUID] = set()
+    if non_doc_gates and resolved is not None and resolved.type == "human":
+        story_ids = {g.work_item_id for _, g in non_doc_gates if g.work_item_type == "story"}
+        task_ids = {g.work_item_id for _, g in non_doc_gates if g.work_item_type == "task"}
+        # story #2082: artifact_canonicalize 게이트(work_item_type="visual_artifact")가 이 배치에서
+        # 빠져 있어 project_id_by_work_item 조회가 항상 None으로 떨어졌다 — _non_doc_gate_approvable
+        # 이 그걸 "구조적으로 project-무관"으로 오판해 org owner/admin에게만 노출되고, project-level
+        # owner/admin(정본 담당자)에겐 assigned_to_me=true 인박스에서 사라졌다(회귀). VisualArtifact.
+        # project_id는 NOT NULL이라 story/task와 동형으로 항상 배치 해소 가능.
+        artifact_ids = {g.work_item_id for _, g in non_doc_gates if g.work_item_type == "visual_artifact"}
+        if story_ids:
+            rows = (await session.execute(
+                select(Story.id, Story.project_id).where(
+                    Story.id.in_(story_ids), Story.org_id == org_id,
+                )
+            )).all()
+            project_id_by_work_item.update({sid: pid for sid, pid in rows})
+        if task_ids:
+            rows = (await session.execute(
+                select(Task.id, Story.project_id)
+                .join(Story, Task.story_id == Story.id)
+                .where(Task.id.in_(task_ids), Task.org_id == org_id)
+            )).all()
+            project_id_by_work_item.update({tid: pid for tid, pid in rows})
+        if artifact_ids:
+            rows = (await session.execute(
+                select(VisualArtifact.id, VisualArtifact.project_id).where(
+                    VisualArtifact.id.in_(artifact_ids), VisualArtifact.org_id == org_id,
+                )
+            )).all()
+            project_id_by_work_item.update({aid: pid for aid, pid in rows})
+
+        # N+1 방지: gate 여러 건이 같은 project 를 가리켜도 get_project_role/is_org_owner_or_admin 은
+        # **고유 project_id(및 org-fallback 1회)당 1회**만 호출(캐시) — gate 개수와 무관.
+        for _resp, g in non_doc_gates:
+            pid = project_id_by_work_item.get(g.work_item_id)
+            if pid is not None:
+                if pid not in role_cache:
+                    role_cache[pid] = await _non_doc_gate_approvable(session, _uid, org_id, pid)
+                if role_cache[pid]:
+                    eligible_ids.add(g.id)
+            else:
+                if org_admin_cache is None:
+                    org_admin_cache = await _non_doc_gate_approvable(session, _uid, org_id, None)
+                if org_admin_cache:
+                    eligible_ids.add(g.id)
+
+    # #2198: non-doc can_approve enrich — doc_gates 루프(위)와 동일하게 FSM(is_valid_transition)
+    # AND WHO(eligible_ids). additive·fail-closed default(Pydantic False)는 non-human/미해소
+    # caller·project 무권한 전부에서 자연히 유지된다(eligible_ids 에 없으면 False).
+    for resp, g in non_doc_gates:
+        resp.can_approve = g.id in eligible_ids and is_valid_transition(g.status, "approved")
+
     if not assigned_to_me:
         return responses
 
@@ -364,62 +436,6 @@ async def list_gates(
     # 승인할 대상이고 paused 일 뿐 "내 것"이다. 바깥 `status` 쿼리 필터가 이미 gates 를 원하는
     # 상태로 좁혀놨으니(예: status=held) 여기서 다시 "pending" 으로 하드코딩해 재필터하면 안
     # 된다 — 예전엔 그래서 `status=held&assigned_to_me=true` 가 항상 빈 배열이었다.
-    non_doc_gates = [
-        (resp, g) for resp, g in zip(responses, gates)
-        if g.gate_type != "doc_approval"
-    ]
-
-    # project_id 배치 해소(story #1968 resolve_work_item_project_id 의 IN-clause 배치 버전 — 개별
-    # gate 마다 신규 쿼리 금지). doc 은 위에서 이미 배치 조회한 doc_proj 재사용(중복 쿼리 0).
-    project_id_by_work_item: dict[uuid.UUID, uuid.UUID | None] = dict(doc_proj)
-    story_ids = {g.work_item_id for _, g in non_doc_gates if g.work_item_type == "story"}
-    task_ids = {g.work_item_id for _, g in non_doc_gates if g.work_item_type == "task"}
-    # story #2082: artifact_canonicalize 게이트(work_item_type="visual_artifact")가 이 배치에서
-    # 빠져 있어 project_id_by_work_item 조회가 항상 None으로 떨어졌다 — _non_doc_gate_approvable
-    # 이 그걸 "구조적으로 project-무관"으로 오판해 org owner/admin에게만 노출되고, project-level
-    # owner/admin(정본 담당자)에겐 assigned_to_me=true 인박스에서 사라졌다(회귀). VisualArtifact.
-    # project_id는 NOT NULL이라 story/task와 동형으로 항상 배치 해소 가능.
-    artifact_ids = {g.work_item_id for _, g in non_doc_gates if g.work_item_type == "visual_artifact"}
-    if story_ids:
-        rows = (await session.execute(
-            select(Story.id, Story.project_id).where(
-                Story.id.in_(story_ids), Story.org_id == org_id,
-            )
-        )).all()
-        project_id_by_work_item.update({sid: pid for sid, pid in rows})
-    if task_ids:
-        rows = (await session.execute(
-            select(Task.id, Story.project_id)
-            .join(Story, Task.story_id == Story.id)
-            .where(Task.id.in_(task_ids), Task.org_id == org_id)
-        )).all()
-        project_id_by_work_item.update({tid: pid for tid, pid in rows})
-    if artifact_ids:
-        rows = (await session.execute(
-            select(VisualArtifact.id, VisualArtifact.project_id).where(
-                VisualArtifact.id.in_(artifact_ids), VisualArtifact.org_id == org_id,
-            )
-        )).all()
-        project_id_by_work_item.update({aid: pid for aid, pid in rows})
-
-    # N+1 방지: gate 여러 건이 같은 project 를 가리켜도 get_project_role/is_org_owner_or_admin 은
-    # **고유 project_id(및 org-fallback 1회)당 1회**만 호출(캐시) — gate 개수와 무관.
-    role_cache: dict[uuid.UUID, bool] = {}
-    org_admin_cache: bool | None = None
-    eligible_ids: set[uuid.UUID] = set()
-    for _resp, g in non_doc_gates:
-        pid = project_id_by_work_item.get(g.work_item_id)
-        if pid is not None:
-            if pid not in role_cache:
-                role_cache[pid] = await _non_doc_gate_approvable(session, _uid, org_id, pid)
-            if role_cache[pid]:
-                eligible_ids.add(g.id)
-        else:
-            if org_admin_cache is None:
-                org_admin_cache = await _non_doc_gate_approvable(session, _uid, org_id, None)
-            if org_admin_cache:
-                eligible_ids.add(g.id)
-
     filtered: list[GateResponse] = []
     for resp, g in zip(responses, gates):
         if g.gate_type == "doc_approval":
@@ -687,6 +703,29 @@ async def get_gate_endpoint(
     # 미경유) + 이 gate의 gate_type을 derive_risk_grade()로 파생(doc §2 SSOT).
     _posture = await get_org_posture(session, org_id)
     resp.risk_grade = derive_risk_grade(_posture, gate.gate_type)
+    # story #2198(까심 QA 적출·오르테가 확定): can_approve 가 이 엔드포인트에선 **전혀 계산되지
+    # 않고** 있었다(docstring 이 enrich 목록에 project_id/work_item_summary/risk_grade 만 적어
+    # 뒀던 것 자체가 증거) — doc_approval·non-doc 가릴 것 없이 Pydantic 기본값 False 가 그대로
+    # 나갔다. 딥링크 콜드 진입(알림 클릭 → 상세 직행, 위 docstring)이 이 엔드포인트를 쓰므로
+    # list_gates 를 먼저 거치지 않은 사용자는 상세 화면에서도 버튼을 영영 못 봤다. list_gates 와
+    # **동일 규칙**(can_approve_doc_gate_reason·_non_doc_gate_approvable)을 여기도 물린다 —
+    # project_id 는 위에서 이미 resolve_work_item_project_id 로 해소돼 있어 추가 조회 없음.
+    try:
+        resolved = await resolve_member(auth, org_id, session)
+        _uid = uuid.UUID(auth.user_id)
+    except Exception:  # noqa: BLE001 — caller resolve 실패는 상세 조회 비중단(fail-closed can_approve=False).
+        logger.warning("get_gate_endpoint caller resolve 실패(비중단) org=%s gate=%s", org_id, id, exc_info=True)
+        resolved = None
+        _uid = None
+    if resolved is not None:
+        if gate.gate_type == "doc_approval":
+            _reason = await can_approve_doc_gate_reason(
+                session, gate, resolved, _uid, org_id, doc_project_id=project_id,
+            )
+            resp.can_approve = _reason is None and is_valid_transition(gate.status, "approved")
+        elif resolved.type == "human":  # rule B 는 human 체크가 없어 여기서 fail-closed(list_gates 와 동형).
+            _approvable = await _non_doc_gate_approvable(session, _uid, org_id, project_id)
+            resp.can_approve = _approvable and is_valid_transition(gate.status, "approved")
     return resp
 
 
@@ -732,6 +771,39 @@ async def transition_gate_endpoint(
             raise HTTPException(
                 status_code=403,
                 detail="doc 결재 권한이 없습니다 (대상 프로젝트 접근 필요).",
+            )
+    elif _gate is not None:
+        # story #2198(까심 QA 적출·오르테가 확定): non-doc 게이트(merge/pr_review/qa/deploy/
+        # artifact_canonicalize 등)는 이 분기 자체가 없어 **휴먼 org 멤버이기만 하면 통과**했다
+        # (위 not-human 체크뿐) — list_gates 의 assigned_to_me 큐 필터가 이미 쓰던 rule B
+        # (_non_doc_gate_approvable, story #1974: project owner/admin, project-무관 work_item
+        # 은 org owner/admin)를 여기 마저 물려 doc_approval 과 같은 형태(단일 규칙을 목록
+        # 가시성+엔드포인트 인가가 공용)로 맞춘다. 새 규칙 발명 0.
+        #
+        # ⛔SoD(self-approval) 는 의도적으로 안 넣는다(오르테가 PO 판정, 2026-07-27) — 이유:
+        # ① doc 결재의 SoD 는 "저자성"(자기가 쓴 문서를 자기가 승인)을 막는 것인데 non-doc
+        #    게이트엔 그 저자성 관계가 같은 형태로 없다. ② non-doc 게이트 상신자는 사실상
+        #    에이전트이고 에이전트는 이미 승인 불가(93fc7aeb, 위 not-human 체크) — 사람 대
+        #    사람 SoD 가 붙을 자리가 실제로 거의 없다. ③ 넣으면 1인 org·소규모 팀에서 아무도
+        #    못 여는 교착이 생긴다(가정 아님 — PR #1998 이 그 교착을 고치는 물건). ④ 추적은
+        #    이미 확보돼 있다(resolver_id 를 body 무시하고 인증 caller 로 강제 기록, S23 RC①).
+        #    다음 사람이 "doc 엔 있는데 여긴 왜 없지"로 되돌아와 넣지 않도록 여기 남긴다.
+        _project_id = await resolve_work_item_project_id(
+            session, org_id, _gate.work_item_type, _gate.work_item_id,
+        )
+        # ⚠️project_id=None(project-무관 work_item) 분기를 인가로도 재사용해도 되는지 확認(오르테가
+        # 지시) — story/task/doc/visual_artifact 는 project_id 가 항상 NOT NULL 이라 실제로
+        # None 이 되는 것은 workflow_line_config 류(org-level config, work_item_type 미인식)뿐이다.
+        # merge/pr_review/qa 게이트(대개 work_item_type="story")는 이 분기를 거의 안 타므로,
+        # org owner/admin floor 로 두는 것이 doc.py 자신의 관례(동일 floor)와도 일치한다.
+        # ⚠️_non_doc_gate_approvable(rule B)은 `uuid.UUID(auth.user_id)`를 기대한다(get_project_role
+        # 이 users.id/project_access.member_id 로 매칭 — list_gates 의 _uid 와 동일 축). resolved.id
+        # (member row id)는 doc_approval SoD 비교 전용 축이라 여기 쓰면 다른 사람으로 조회돼 fail-closed
+        # 오탐(정당한 owner/admin 이 403)이 난다 — 실제로 이 갭을 realdb 테스트가 잡았다.
+        if not await _non_doc_gate_approvable(session, uuid.UUID(auth.user_id), org_id, _project_id):
+            raise HTTPException(
+                status_code=403,
+                detail="이 게이트를 승인/거부할 권한이 없습니다 (프로젝트 owner/admin 필요).",
             )
     # story #2027(까심 QA 적출): 고위험(risk_grade=high) 게이트의 approved 전이는 사유(note) 서버측
     # 강제 — void_gate/override_gate 기존 관례(reason 없으면 ValueError→422, void_gate 참고)에

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -248,6 +248,38 @@ async def _non_doc_gate_approvable(
     return await is_org_owner_or_admin(session, user_id, org_id)
 
 
+# story #2198(까심 QA 적출·오르테가 PO 판정, 2026-07-27): non-doc gate_type 별 승인 자격 규칙 —
+# 이 표 하나가 list_gates can_approve·get_gate_endpoint can_approve·transition_gate_endpoint
+# 인가 **셋의 유일한 소스**다. 분기를 소비처마다 흩으면 오늘 고치는 그 병("타입마다 제각각
+# 규칙이 따로 논다")을 새로 심는 것이라 여기 한 자리로 고정한다. 새 gate_type 추가 시 여기부터
+# 볼 것.
+#
+# ⚠️호출 전제: caller 의 human 여부는 **각 소비처가 먼저 확認**한다(이 함수는 WHO=role/type 축만
+# 본다·human 축은 위에 있음) — transition_gate_endpoint 의 not-human 403(위)·list_gates/
+# get_gate_endpoint 의 `resolved.type == "human"` 게이트가 그 전제를 이미 보장한다.
+async def _non_doc_can_approve(
+    session: AsyncSession,
+    gate_type: str,
+    user_id: uuid.UUID,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID | None,
+) -> bool:
+    """gate_type 별 규칙 dispatch.
+
+    - artifact_canonicalize: **휴먼 전용**(추가 role 제약 없음). E-CANVAS C4-S8(story a5118cb0)
+      설계 주석(visual_artifacts.py propose_canonical_version 바로 위) — "승인/반려는 기존
+      범용 transition 이 처리(human-only authz 이미 강제됨)"이 명시된 전부다. rule B(project
+      owner/admin)로 좁히면 인가 갭을 메우는 게 아니라 **승인 가능 인구를 줄이는 기능 축소**다
+      (실패 재현 테스트가 승인자를 project_access grant 조차 없는 org 멤버로 seed 해 그 설계를
+      그대로 증언하고 있었다 — 픽스처 실수가 아니라 의도).
+    - 그 외(merge/pr_review/qa/deploy 등): rule B(``_non_doc_gate_approvable``, story #1974) —
+      project owner/admin, project-무관 work_item 은 org owner/admin.
+    """
+    if gate_type == "artifact_canonicalize":
+        return True
+    return await _non_doc_gate_approvable(session, user_id, org_id, project_id)
+
+
 @router.get("", response_model=list[GateResponse])
 async def list_gates(
     work_item_id: uuid.UUID | None = Query(default=None),
@@ -312,12 +344,12 @@ async def list_gates(
     # transition 강제와 can_approve_doc_gate_reason 단일 규칙 공용(DRY). 배치 project_id 주입(N+1 0)·비-휴먼/
     # 무자격/삭제 doc = False(default·fail-closed). additive — 실 authz 는 transition BE 가 강제(이 필드=가시성뿐).
     doc_gates = [(resp, g) for resp, g in zip(responses, gates) if g.gate_type == "doc_approval"]
-    # story #2198(까심 QA 적출·오르테가 확定): non-doc gate(merge/pr_review/qa/deploy/
+    # story #2198(까심 QA 적출·오르테가 PO 판정): non-doc gate(merge/pr_review/qa/deploy/
     # artifact_canonicalize 등)도 doc_approval 과 **동일 골격**으로 can_approve 를 계산한다 —
-    # rule B(_non_doc_gate_approvable, story #1974)는 이미 존재했으나 지금까지 assigned_to_me
-    # 큐 필터에만 물려 있었고, 이 목록 응답의 can_approve 필드 자체는 계산되지 않아 Pydantic
-    # 기본값 False 가 그대로 나갔다(자격자에게 버튼이 안 뜨는 원 증상). 새 규칙을 발명하지
-    # 않고 있던 rule B 를 여기 마저 물린다.
+    # 지금까지 이 목록 응답의 can_approve 필드 자체는 계산되지 않아 Pydantic 기본값 False 가
+    # 그대로 나갔다(자격자에게 버튼이 안 뜨는 원 증상). ⚠️규칙은 "하나"가 아니라 gate_type 별
+    # 하나(_non_doc_can_approve 표 — artifact_canonicalize 는 rule B 를 씌우면 회귀임이 CI 로
+    # 드러나 갈렸다. 자세한 사유는 그 함수 docstring 참조).
     non_doc_gates = [(resp, g) for resp, g in zip(responses, gates) if g.gate_type != "doc_approval"]
     # story #1974(P1a-S5): assigned_to_me 도 doc_approval 경로는 can_approve 와 **동일 계산**이라
     # caller 식별(resolve_member)을 can_approve enrich 와 공유 — 1회만 resolve(중복 계산 0).
@@ -363,8 +395,10 @@ async def list_gates(
     # eligible_ids 가 자연히 빈 채로 남고 can_approve=False(fail-closed)이므로 이 배치 쿼리들
     # 자체가 불필요(N+1 0 철학과 동형 — "계산해도 결론이 안 바뀔 쿼리는 안 낸다").
     project_id_by_work_item: dict[uuid.UUID, uuid.UUID | None] = dict(doc_proj)
-    role_cache: dict[uuid.UUID, bool] = {}
-    org_admin_cache: bool | None = None
+    # #2198(PO 판정): 캐시 키가 project_id 단독에서 (gate_type, project_id) 로 바뀌었다 — 승인
+    # 자격이 이제 gate_type 에도 의존한다(_non_doc_can_approve 표 참조. artifact_canonicalize
+    # 는 project_id 무관 항상 True).
+    approvable_cache: dict[tuple[str, uuid.UUID | None], bool] = {}
     eligible_ids: set[uuid.UUID] = set()
     if non_doc_gates and resolved is not None and resolved.type == "human":
         story_ids = {g.work_item_id for _, g in non_doc_gates if g.work_item_type == "story"}
@@ -397,20 +431,15 @@ async def list_gates(
             )).all()
             project_id_by_work_item.update({aid: pid for aid, pid in rows})
 
-        # N+1 방지: gate 여러 건이 같은 project 를 가리켜도 get_project_role/is_org_owner_or_admin 은
-        # **고유 project_id(및 org-fallback 1회)당 1회**만 호출(캐시) — gate 개수와 무관.
+        # N+1 방지: gate 여러 건이 같은 (gate_type, project_id) 를 가리켜도 _non_doc_can_approve 는
+        # **고유 조합당 1회**만 호출(캐시) — gate 개수와 무관.
         for _resp, g in non_doc_gates:
             pid = project_id_by_work_item.get(g.work_item_id)
-            if pid is not None:
-                if pid not in role_cache:
-                    role_cache[pid] = await _non_doc_gate_approvable(session, _uid, org_id, pid)
-                if role_cache[pid]:
-                    eligible_ids.add(g.id)
-            else:
-                if org_admin_cache is None:
-                    org_admin_cache = await _non_doc_gate_approvable(session, _uid, org_id, None)
-                if org_admin_cache:
-                    eligible_ids.add(g.id)
+            key = (g.gate_type, pid)
+            if key not in approvable_cache:
+                approvable_cache[key] = await _non_doc_can_approve(session, g.gate_type, _uid, org_id, pid)
+            if approvable_cache[key]:
+                eligible_ids.add(g.id)
 
     # #2198: non-doc can_approve enrich — doc_gates 루프(위)와 동일하게 FSM(is_valid_transition)
     # AND WHO(eligible_ids). additive·fail-closed default(Pydantic False)는 non-human/미해소
@@ -724,7 +753,7 @@ async def get_gate_endpoint(
             )
             resp.can_approve = _reason is None and is_valid_transition(gate.status, "approved")
         elif resolved.type == "human":  # rule B 는 human 체크가 없어 여기서 fail-closed(list_gates 와 동형).
-            _approvable = await _non_doc_gate_approvable(session, _uid, org_id, project_id)
+            _approvable = await _non_doc_can_approve(session, gate.gate_type, _uid, org_id, project_id)
             resp.can_approve = _approvable and is_valid_transition(gate.status, "approved")
     return resp
 
@@ -773,12 +802,14 @@ async def transition_gate_endpoint(
                 detail="doc 결재 권한이 없습니다 (대상 프로젝트 접근 필요).",
             )
     elif _gate is not None:
-        # story #2198(까심 QA 적출·오르테가 확定): non-doc 게이트(merge/pr_review/qa/deploy/
+        # story #2198(까심 QA 적출·오르테가 PO 판정): non-doc 게이트(merge/pr_review/qa/deploy/
         # artifact_canonicalize 등)는 이 분기 자체가 없어 **휴먼 org 멤버이기만 하면 통과**했다
-        # (위 not-human 체크뿐) — list_gates 의 assigned_to_me 큐 필터가 이미 쓰던 rule B
-        # (_non_doc_gate_approvable, story #1974: project owner/admin, project-무관 work_item
-        # 은 org owner/admin)를 여기 마저 물려 doc_approval 과 같은 형태(단일 규칙을 목록
-        # 가시성+엔드포인트 인가가 공용)로 맞춘다. 새 규칙 발명 0.
+        # (위 not-human 체크뿐). 처방은 새 단일 규칙이 아니라 _non_doc_can_approve(위 정의)
+        # **타입별 표**를 여기 물리는 것 — artifact_canonicalize 는 첫 판정(rule B 균일 적용)
+        # 시도가 CI 에서 실 회귀로 드러나 갈렸다: E-CANVAS C4-S8 설계상 그 타입은 project
+        # owner/admin 이 아니라 **휴먼이면 승인 가능**이 계약이었다(테스트 픽스처가 무권한 org
+        # 멤버를 승인자로 seed 해 그 설계를 증언하고 있었음). 그 외 타입은 rule B(project
+        # owner/admin, project-무관 work_item 은 org owner/admin) 그대로.
         #
         # ⛔SoD(self-approval) 는 의도적으로 안 넣는다(오르테가 PO 판정, 2026-07-27) — 이유:
         # ① doc 결재의 SoD 는 "저자성"(자기가 쓴 문서를 자기가 승인)을 막는 것인데 non-doc
@@ -791,19 +822,15 @@ async def transition_gate_endpoint(
         _project_id = await resolve_work_item_project_id(
             session, org_id, _gate.work_item_type, _gate.work_item_id,
         )
-        # ⚠️project_id=None(project-무관 work_item) 분기를 인가로도 재사용해도 되는지 확認(오르테가
-        # 지시) — story/task/doc/visual_artifact 는 project_id 가 항상 NOT NULL 이라 실제로
-        # None 이 되는 것은 workflow_line_config 류(org-level config, work_item_type 미인식)뿐이다.
-        # merge/pr_review/qa 게이트(대개 work_item_type="story")는 이 분기를 거의 안 타므로,
-        # org owner/admin floor 로 두는 것이 doc.py 자신의 관례(동일 floor)와도 일치한다.
-        # ⚠️_non_doc_gate_approvable(rule B)은 `uuid.UUID(auth.user_id)`를 기대한다(get_project_role
-        # 이 users.id/project_access.member_id 로 매칭 — list_gates 의 _uid 와 동일 축). resolved.id
-        # (member row id)는 doc_approval SoD 비교 전용 축이라 여기 쓰면 다른 사람으로 조회돼 fail-closed
-        # 오탐(정당한 owner/admin 이 403)이 난다 — 실제로 이 갭을 realdb 테스트가 잡았다.
-        if not await _non_doc_gate_approvable(session, uuid.UUID(auth.user_id), org_id, _project_id):
+        # ⚠️_non_doc_gate_approvable(rule B, non-artifact_canonicalize 타입에만 적용)은
+        # `uuid.UUID(auth.user_id)`를 기대한다(get_project_role 이 users.id/project_access.
+        # member_id 로 매칭 — list_gates 의 _uid 와 동일 축). resolved.id(member row id)는
+        # doc_approval SoD 비교 전용 축이라 여기 쓰면 다른 사람으로 조회돼 fail-closed 오탐
+        # (정당한 owner/admin 이 403)이 난다 — 실제로 이 갭을 realdb 테스트가 잡았다.
+        if not await _non_doc_can_approve(session, _gate.gate_type, uuid.UUID(auth.user_id), org_id, _project_id):
             raise HTTPException(
                 status_code=403,
-                detail="이 게이트를 승인/거부할 권한이 없습니다 (프로젝트 owner/admin 필요).",
+                detail="이 게이트를 승인/거부할 권한이 없습니다.",
             )
     # story #2027(까심 QA 적출): 고위험(risk_grade=high) 게이트의 approved 전이는 사유(note) 서버측
     # 강제 — void_gate/override_gate 기존 관례(reason 없으면 ValueError→422, void_gate 참고)에

--- a/backend/tests/test_1973_gate_urgency_sort.py
+++ b/backend/tests/test_1973_gate_urgency_sort.py
@@ -12,7 +12,11 @@ SQL statement**로 판정한다(N+1 절대 금지). 우선순위(스토리 AC): 
   seed 후 GET /api/v2/gates?sort=urgency 정렬 순서 실측 + gate_id/h1_gate_id 양쪽 경로 커버.
 - realdb: sort 파라미터 없는 기존 호출 회귀 없음(무정렬 응답 내용 동일).
 - realdb: N+1 방지 — sqlalchemy ``before_cursor_execute`` 이벤트로 실행 SQL statement 수를 세어
-  gate 개수가 늘어나도(2건→6건) 고정(list SELECT 1 + org posture 1 = 2)임을 실측.
+  gate 개수가 늘어나도(2건→6건) **고정**(게이트당 증가 0)임을 실측.
+  ⚠️story #2198(non-doc can_approve 신설) 이후 고정값이 2 → 6 으로 늘었다 — 게이트당 증가가
+  아니라 **캐시된 고정 비용 4건 추가**임을 실측으로 확認한 뒤 기댓값을 올렸다(실측 근거는
+  아래 assert 바로 위 주석 참조). 「기댓값만 올려서 초록」이 아니라 각 신규 SELECT 가
+  gate 개수와 무관하게 정확히 1회씩만 실행됨을 먼저 확認했다.
 """
 from __future__ import annotations
 
@@ -478,8 +482,23 @@ async def test_realdb_urgency_sort_query_count_fixed_regardless_of_gate_count():
                 f"gate 개수 증가로 쿼리 수가 늘었다(N+1 의심): 2건={len(select_stmts_2)} "
                 f"8건={len(select_stmts_6)}"
             )
-            # 핵심 성능 요구사항: list SELECT(1) + org posture(1) = 고정 2개(1~2개 범위).
-            assert len(select_stmts_6) <= 2, select_stmts_6
+            # 핵심 성능 요구사항: 게이트 개수와 무관한 **고정** 쿼리 수(위 assert 가 이미 그걸
+            # 증명 — 2건과 8건이 동일). 절대값은 story #2198(non-doc can_approve 신설) 로 2 → 6
+            # 이 됐다 — 실측(before_cursor_execute 로 개별 SQL 을 찍어 확認)으로 정확히 이 4개가
+            # 새로 생겼고, 전부 gate 개수와 무관하게 **정확히 1회씩만** 실행됨을 확認했다(캐시가
+            # 실제로 작동함 — 늘려서 초록으로 만든 것이 아니라 늘어난 이유를 하나씩 짚은 것):
+            #   ① org_members SELECT — resolve_member(caller 식별)의 내부 조회
+            #   ② users SELECT       — resolve_member 의 내부 조회(①과 세트)
+            #   ③ stories 배치 SELECT(IN절) — non-doc 게이트들의 project_id 일괄 해소
+            #      (story #1968 배치 패턴 재사용 — 게이트가 늘어도 이 파일의 픽스처는 project 1개
+            #      뿐이라 IN절 인자 수만 늘고 SELECT 문 자체는 1개로 유지됨)
+            #   ④ get_project_role raw SQL — rule B 판정 자체. (gate_type, project_id) 캐시로
+            #      묶여 이 파일의 모든 픽스처가 같은 project 를 쓰므로 게이트 8건이어도 1회
+            # can_approve 를 non-doc 게이트에도 계산하는 것 자체가 #2198 의 목적(전엔 이 필드가
+            # 계산조차 안 돼 자격자에게 버튼이 안 뜨던 결함) — 이 4개는 그 목적을 이루는 데 드는
+            # 필수 비용이지 회귀가 아니다. 6 초과(게이트당 증가)가 나오면 그건 진짜 N+1 이니 이
+            # 상한을 다시 낮추지 말고 원인을 고칠 것.
+            assert len(select_stmts_6) <= 6, select_stmts_6
         finally:
             await client.aclose()
     finally:

--- a/backend/tests/test_1974_gate_assigned_to_me.py
+++ b/backend/tests/test_1974_gate_assigned_to_me.py
@@ -169,7 +169,7 @@ def _org_level_gate(*, gate_id=None, status="pending"):
 
 async def _call_list_gates(
     gates, *, resolved=None, resolve_raises=False, has_access=True, project_role=None,
-    org_admin=False, story_rows=None,
+    org_admin=False, story_rows=None, assigned_to_me=True,
 ):
     org = uuid.uuid4()
     gates_result = MagicMock()
@@ -204,7 +204,7 @@ async def _call_list_gates(
          patch.object(gates_mod, "get_project_role", AsyncMock(return_value=project_role)), \
          patch.object(gates_mod, "is_org_owner_or_admin", AsyncMock(return_value=org_admin)):
         return await gates_mod.list_gates(
-            work_item_id=None, work_item_type=None, status=None, assigned_to_me=True,
+            work_item_id=None, work_item_type=None, status=None, assigned_to_me=assigned_to_me,
             session=session, org_id=org, auth=auth,
         )
 
@@ -330,32 +330,23 @@ async def test_assigned_to_me_mixed_gates_only_eligible_returned():
 
 
 @pytest.mark.anyio
-async def test_default_assigned_to_me_false_returns_all_no_extra_queries():
-    """assigned_to_me 미지정(기본 False) — resolve_member 는 doc_approval 게이트가 있을 때만 호출되고
-    (기존 89484c8c 동작 그대로), non-doc 게이트만 있으면 전혀 호출 안 됨(회귀 0)."""
+async def test_default_assigned_to_me_false_returns_all_unfiltered_but_can_approve_still_enriched():
+    """story #2198(까심 QA 적출·오르테가 확定): assigned_to_me 미지정(기본 False)이어도 non-doc
+    게이트의 can_approve 는 이제 계산된다(전에는 doc_approval 게이트가 있을 때만 resolve_member
+    를 호출했고 non-doc 게이트는 can_approve 가 Pydantic 기본값 False 로 방치됐다 — 자격자에게
+    버튼이 안 뜨는 원 결함). assigned_to_me=False 는 여전히 **필터링을 안 한다**(목록이 그대로
+    전부 나옴) — can_approve 필드 값만 정확해진다. (이 파일의 원래 이름 "no_extra_queries" 는
+    이제 거짓 전제다 — resolve_member 호출은 의도된 변화다.)"""
     from app.routers import gates as gates_mod
 
     g = _story_gate(gate_type="merge")
-    org = uuid.uuid4()
-    gates_result = MagicMock()
-    gates_result.scalars.return_value.all.return_value = [g]
-    session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[gates_result])
-    auth = SimpleNamespace(user_id=str(uuid.uuid4()))
-    rm = AsyncMock(return_value=_human(uuid.uuid4()))
-    with patch.object(gates_mod.GateResponse, "model_validate", _resp), \
-         patch.object(gates_mod, "resolve_member", rm), \
-         patch.object(gates_mod, "get_org_posture", AsyncMock(return_value=None)):
-        # ⚠️직접 함수 호출(ASGI 미경유)이라 FastAPI Query(default=False) sentinel 이 아닌 실 bool 을
-        # 명시 전달해야 한다(work_item_id/work_item_type/status 등 기존 파라미터도 이 파일 전역에서
-        # 항상 명시 전달하는 동일 관례 — 실제 HTTP 경로에서의 기본값 회귀는 realdb 테스트가 커버).
-        out = await gates_mod.list_gates(
-            work_item_id=None, work_item_type=None, status=None, assigned_to_me=False,
-            session=session, org_id=org, auth=auth,
-        )
+    out = await _call_list_gates(
+        [g], project_role="owner", assigned_to_me=False,
+        story_rows=[(g.work_item_id, uuid.uuid4())],
+    )
     assert len(out) == 1
     assert out[0].id == g.id
-    rm.assert_not_awaited()  # 비-doc 게이트만 + assigned_to_me=False → resolve_member 미호출
+    assert out[0].can_approve is True  # project owner → 승인 자격 있음이 목록에도 반영
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_2027_gate_approval_reason_enforce.py
+++ b/backend/tests/test_2027_gate_approval_reason_enforce.py
@@ -89,7 +89,12 @@ async def _setup_app(app, Session, org_id, user_id):
 
 
 async def _seed_common(session):
-    """org + project + caller(project grant, has_project_access True 경로)."""
+    """org + project + caller(project owner grant).
+
+    #2198(PO 판정 (a)): rule B(_non_doc_gate_approvable)가 이제 transition 엔드포인트 인가로도
+    쓰이므로, 이 파일의 관심사(#2027 사유 강제)와 무관하게 caller 가 실제로 merge 게이트를
+    승인할 자격(project owner/admin)을 가져야 한다 — role="member"(과거 인가 자체가 없던
+    시절의 임의값)로는 이제 403 이 먼저 나 이 파일의 진짜 관심사에 도달 못 한다."""
     from app.models.organization import Organization
     from app.models.project import OrgMember, Project
     from app.models.project_access import ProjectAccess
@@ -111,7 +116,7 @@ async def _seed_common(session):
     await session.commit()
     session.add(ProjectAccess(
         id=uuid.uuid4(), project_id=project.id, org_member_id=caller_om.id,
-        permission="granted", role="member",
+        permission="granted", role="owner",
     ))
     await session.commit()
 

--- a/backend/tests/test_2198_non_doc_gate_authz_realdb.py
+++ b/backend/tests/test_2198_non_doc_gate_authz_realdb.py
@@ -221,3 +221,60 @@ async def test_transition_doc_approval_gate_still_unaffected():
         assert resp.status == "approved"  # doc_approval 경로는 #2198 변경으로 인한 영향 0.
     finally:
         await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_transition_artifact_canonicalize_gate_human_only_not_project_owner_required():
+    """PO 판정(2026-07-27, CI 회귀로 갈림): artifact_canonicalize 는 rule B(project owner/admin)
+    가 아니라 휴먼 전용(E-CANVAS C4-S8 설계)이다 — MEMBER_USER(project_access grant 자체가
+    없는, merge 게이트라면 위 테스트에서 403 나는 바로 그 사용자)로도 승인이 통과해야 한다.
+    이 테스트가 없으면 다음 사람이 #2198 의 rule B 를 "전 타입 균일"로 되돌려 이 회귀를
+    재현할 수 있다 — _non_doc_can_approve 표를 직접 겨냥해 고정."""
+    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            gate_id_holder = {}
+            for sql in [
+                f"DELETE FROM gate WHERE org_id='{ORG}'",
+                f"DELETE FROM visual_artifacts WHERE org_id='{ORG}'",
+                f"DELETE FROM project_access WHERE project_id='{PROJ_A}'",
+                f"DELETE FROM org_members WHERE org_id='{ORG}'",
+                f"DELETE FROM stories WHERE org_id='{ORG}'",
+                f"DELETE FROM projects WHERE org_id='{ORG}'",
+                f"DELETE FROM users WHERE id IN ('{OWNER_USER}','{MEMBER_USER}')",
+                f"DELETE FROM organizations WHERE id='{ORG}'",
+                f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','D2198','d2198-org3','free')",
+                "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+                f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+                f"('{MEMBER_USER}','member3@d2198.test','x','Member',true,true,0,false,0)",
+                # org-level role='member'(owner/admin 아님) + PROJ_A 에 project_access grant 자체 없음
+                # — merge 게이트였다면 위 test_transition_non_doc_gate_forbidden... 과 동일하게 403 날 사용자.
+                f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{MEMBER_OM}','{ORG}','{MEMBER_USER}','member')",
+                f"INSERT INTO projects (id,org_id,name,slug) VALUES ('{PROJ_A}','{ORG}','A','proj-a4')",
+            ]:
+                await s.execute(text(sql))
+            from app.models.visual_artifact import VisualArtifact
+            artifact = VisualArtifact(
+                id=uuid.uuid4(), org_id=ORG, project_id=PROJ_A, title="Canon",
+                source="created", latest_version_number=1,
+            )
+            s.add(artifact)
+            await s.flush()
+            from app.models.gate import Gate
+            gate = Gate(
+                id=uuid.uuid4(), org_id=ORG, work_item_id=artifact.id, work_item_type="visual_artifact",
+                gate_type="artifact_canonicalize", status="pending",
+                neutral_facts={"version_number": 1, "requested_by_member_id": str(uuid.uuid4())},
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id_holder["id"] = gate.id
+        async with Session() as s:
+            resp = await transition_gate_endpoint(
+                id=gate_id_holder["id"], body=GateTransitionRequest(status="approved", note="정본화 승인"),
+                background_tasks=BackgroundTasks(), session=s, org_id=ORG, auth=_auth(MEMBER_USER),
+            )
+        assert resp.status == "approved"
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_2198_non_doc_gate_authz_realdb.py
+++ b/backend/tests/test_2198_non_doc_gate_authz_realdb.py
@@ -1,0 +1,223 @@
+"""story #2198(까심 QA 적출·오르테가 확定): non-doc 게이트(merge/pr_review/qa/deploy/
+artifact_canonicalize 등) 인가 갭 — 세 증상이 하나의 뿌리(rule B 미배선)였다.
+
+```
+① 큐 필터        _non_doc_gate_approvable (story #1974)                ← 이미 옳게 좁았음
+② can_approve    list_gates·get_gate_endpoint 둘 다 non-doc 은 계산 자체를 안 해 기본값 False  ← 없음
+③ 승인 엔드포인트 transition_gate_endpoint = 휴먼 org 멤버이기만 하면 통과                    ← 가장 넓음
+```
+
+처방 = 새 규칙 발명 없이 이미 있던 rule B(``_non_doc_gate_approvable``)를 ②③에 마저 배선.
+
+⛔SoD(self-approval) 는 의도적으로 안 넣는다(오르테가 PO 판정, 2026-07-27) — 근거는 gates.py
+transition_gate_endpoint 의 non-doc elif 분기 주석에 그대로 남겨 뒀다(저자성 없음·상신자=에이전트라
+사람 대 사람 SoD 자리가 거의 없음·1인 org 교착 재발 위험·추적은 resolver_id 강제 기록으로 이미 확보).
+
+⛔라이브 승인 POST 로 검증하지 않는다(오르테가 지시) — 이 파일은 격리된 로컬 throwaway realdb만
+쓴다(#2027 test_2027_gate_approval_reason_enforce.py 와 동일 정신 — 실제 배포된 시스템에 손대지
+않는 disposable 테스트 DB). 회귀 가드 = "무자격 휴먼이 시도하면 서버가 403"을 직접 함수호출로 고정.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("d2198000-0000-0000-0000-000000000001")
+OWNER_USER = uuid.UUID("d2198000-0000-0000-0000-0000000000a1")  # PROJ_A project_access role=owner
+OWNER_OM = uuid.UUID("d2198000-0000-0000-0000-0000000000b1")
+MEMBER_USER = uuid.UUID("d2198000-0000-0000-0000-0000000000a2")  # PROJ_A project_access role=member
+MEMBER_OM = uuid.UUID("d2198000-0000-0000-0000-0000000000b2")
+PROJ_A = uuid.UUID("d2198000-0000-0000-0000-0000000000c1")
+STORY_A = uuid.UUID("d2198000-0000-0000-0000-0000000000d1")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth(user_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(user_id), email=None, claims={}, org_id=str(ORG))
+
+
+async def _seed(s):
+    """ORG · STORY_A(gate 의 work_item) · OWNER_USER(project_access role=owner) ·
+    MEMBER_USER(project_access role=member — 열람은 되나 승인 자격은 없음) · merge 게이트 1건."""
+    for sql in [
+        f"DELETE FROM gate WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ_A}'",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM stories WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id IN ('{OWNER_USER}','{MEMBER_USER}')",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','D2198','d2198-org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{OWNER_USER}','owner@d2198.test','x','Owner',true,true,0,false,0),"
+        f"('{MEMBER_USER}','member@d2198.test','x','Member',true,true,0,false,0)",
+        # 둘 다 org-level role='member'(org owner/admin 아님) — project_access 만으로 갈린다.
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES "
+        f"('{OWNER_OM}','{ORG}','{OWNER_USER}','member'),"
+        f"('{MEMBER_OM}','{ORG}','{MEMBER_USER}','member')",
+        f"INSERT INTO projects (id,org_id,name,slug) VALUES ('{PROJ_A}','{ORG}','A','proj-a')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission,role) VALUES "
+        f"(gen_random_uuid(),'{PROJ_A}','{OWNER_OM}','granted','owner'),"
+        f"(gen_random_uuid(),'{PROJ_A}','{MEMBER_OM}','granted','member')",
+        f"INSERT INTO stories (id,org_id,project_id,title,status) VALUES "
+        f"('{STORY_A}','{ORG}','{PROJ_A}','S','backlog')",
+    ]:
+        await s.execute(text(sql))
+    from app.models.gate import Gate
+    gate = Gate(
+        id=uuid.uuid4(), org_id=ORG, work_item_id=STORY_A, work_item_type="story",
+        gate_type="merge", status="pending", neutral_facts={},
+    )
+    s.add(gate)
+    await s.commit()
+    return gate.id
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+# ───────────────────────── list_gates: can_approve ─────────────────────────
+
+@pytest.mark.anyio
+async def test_list_gates_can_approve_true_for_project_owner_false_for_member():
+    from app.routers.gates import list_gates
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            gate_id = await _seed(s)
+        async with Session() as s:
+            out = await list_gates(
+                work_item_id=None, work_item_type=None, status=None, assigned_to_me=False,
+                session=s, org_id=ORG, auth=_auth(OWNER_USER),
+            )
+        assert next(g for g in out if g.id == gate_id).can_approve is True
+        async with Session() as s:
+            out = await list_gates(
+                work_item_id=None, work_item_type=None, status=None, assigned_to_me=False,
+                session=s, org_id=ORG, auth=_auth(MEMBER_USER),
+            )
+        assert next(g for g in out if g.id == gate_id).can_approve is False
+    finally:
+        await eng.dispose()
+
+
+# ───────────────────────── get_gate_endpoint: can_approve ─────────────────────────
+
+@pytest.mark.anyio
+async def test_get_gate_can_approve_true_for_project_owner_false_for_member():
+    from app.routers.gates import get_gate_endpoint
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            gate_id = await _seed(s)
+        async with Session() as s:
+            resp = await get_gate_endpoint(id=gate_id, session=s, org_id=ORG, auth=_auth(OWNER_USER))
+        assert resp.can_approve is True
+        async with Session() as s:
+            resp = await get_gate_endpoint(id=gate_id, session=s, org_id=ORG, auth=_auth(MEMBER_USER))
+        assert resp.can_approve is False
+    finally:
+        await eng.dispose()
+
+
+# ───────────────────────── transition_gate_endpoint: 실 인가 강제 ─────────────────────────
+
+@pytest.mark.anyio
+async def test_transition_non_doc_gate_forbidden_for_member_allowed_for_owner():
+    """#2198 의 본체 — ③(가장 넓던 자리)이 실제로 좁아졌는지. 격리 로컬 throwaway DB 에서 실제
+    transition 을 수행(라이브 배포 시스템 무접촉) — #2027 과 동일한 검증 방식."""
+    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            gate_id = await _seed(s)
+        # 무자격(project member, owner/admin 아님) → 403·상태 미변경.
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await transition_gate_endpoint(
+                    id=gate_id, body=GateTransitionRequest(status="approved", note="시도"),
+                    background_tasks=BackgroundTasks(), session=s, org_id=ORG, auth=_auth(MEMBER_USER),
+                )
+            assert ei.value.status_code == 403
+        async with Session() as s:
+            from app.models.gate import Gate
+            g = (await s.execute(text(f"SELECT status FROM gate WHERE id='{gate_id}'"))).scalar_one()
+            assert g == "pending"  # 403 이 실제로 상태변경을 막았는지(뮤테이션 0) 재조회로 확認.
+        # 자격자(project owner) → 승인 성공.
+        async with Session() as s:
+            resp = await transition_gate_endpoint(
+                id=gate_id, body=GateTransitionRequest(status="approved", note="승인 사유"),
+                background_tasks=BackgroundTasks(), session=s, org_id=ORG, auth=_auth(OWNER_USER),
+            )
+        assert resp.status == "approved"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_transition_doc_approval_gate_still_unaffected():
+    """#2198 이 doc_approval 분기(elif 이전 if)를 안 건드렸는지 회귀 확認 — 무관 gate_type 은
+    non-doc elif 에 아예 안 들어간다(SimpleNamespace work_item_type 몰라도 무관)."""
+    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            for sql in [
+                f"DELETE FROM gate WHERE org_id='{ORG}'",
+                f"DELETE FROM project_access WHERE project_id='{PROJ_A}'",
+                f"DELETE FROM org_members WHERE org_id='{ORG}'",
+                f"DELETE FROM stories WHERE org_id='{ORG}'",
+                f"DELETE FROM projects WHERE org_id='{ORG}'",
+                f"DELETE FROM users WHERE id IN ('{OWNER_USER}','{MEMBER_USER}')",
+                f"DELETE FROM organizations WHERE id='{ORG}'",
+                f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','D2198','d2198-org2','free')",
+                "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+                f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+                f"('{OWNER_USER}','owner2@d2198.test','x','Owner',true,true,0,false,0)",
+                f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OWNER_OM}','{ORG}','{OWNER_USER}','member')",
+                f"INSERT INTO projects (id,org_id,name,slug) VALUES ('{PROJ_A}','{ORG}','A','proj-a2')",
+                f"INSERT INTO project_access (id,project_id,org_member_id,permission,role) VALUES "
+                f"(gen_random_uuid(),'{PROJ_A}','{OWNER_OM}','granted','owner')",
+            ]:
+                await s.execute(text(sql))
+            from app.models.doc import Doc
+            doc = Doc(id=uuid.uuid4(), org_id=ORG, project_id=PROJ_A, title="d", slug=f"s-{uuid.uuid4().hex[:8]}", content="")
+            s.add(doc)
+            await s.flush()
+            from app.models.gate import Gate
+            gate = Gate(
+                id=uuid.uuid4(), org_id=ORG, work_item_id=doc.id, work_item_type="doc",
+                gate_type="doc_approval", status="pending",
+                neutral_facts={"requested_by_member_id": str(uuid.uuid4())},  # requester ≠ OWNER_USER
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+        async with Session() as s:
+            resp = await transition_gate_endpoint(
+                id=gate_id, body=GateTransitionRequest(status="approved", note="doc 승인"),
+                background_tasks=BackgroundTasks(), session=s, org_id=ORG, auth=_auth(OWNER_USER),
+            )
+        assert resp.status == "approved"  # doc_approval 경로는 #2198 변경으로 인한 영향 0.
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_ccbcd9da_gate_wake_wiring_realdb.py
+++ b/backend/tests/test_ccbcd9da_gate_wake_wiring_realdb.py
@@ -165,7 +165,12 @@ async def test_transition_gate_endpoint_wakes_after_commit(monkeypatch):
             org_id=seeded["org"],
         )
         async with Session() as s2:
+            # #2198: 이 게이트는 work_item_type="doc" 이지만 gate_type="custom_review"(≠doc_approval)
+            # 라 non-doc 인가 분기(rule B)를 탄다 — approver 가 실 project_access/org_members grant
+            # 없이 만들어진 임의 ResolvedMember 라 rule B 를 그대로 두면 403(이 파일의 관심사인
+            # wake 배선과 무관). patch 로 우회 — project-role 축은 별도 realdb 테스트가 커버.
             with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=approver)), \
+                 patch.object(gates_mod, "_non_doc_gate_approvable", AsyncMock(return_value=True)), \
                  patch.object(gates_mod, "wake_agent", _fake_wake_agent), \
                  patch("app.services.conversation_webhook.deliver_injected_event_webhook", _fake_deliver):
                 bg = BackgroundTasks()

--- a/backend/tests/test_edg_s23_hypothesis_overlay.py
+++ b/backend/tests/test_edg_s23_hypothesis_overlay.py
@@ -53,9 +53,17 @@ async def test_gate_transition_forces_resolver_id_to_caller(monkeypatch):
     _gr.scalar_one_or_none.return_value = _g
     _sess.execute = AsyncMock(return_value=_gr)
     from fastapi import BackgroundTasks
+    # #2198: non-doc 분기가 uuid.UUID(auth.user_id)를 rule B 에 쓰므로 auth 도 caller_id 와
+    # 일관된 실 UUID 문자열이 필요해졌다(bare MagicMock()의 auto-attribute 는 UUID 파싱이
+    # 안 됨) — 프로덕션에서는 resolve_member 자체가 auth.user_id 를 내부적으로 UUID 파싱하고
+    # 실패 시 그 안에서 400 을 내므로(member_resolver.py:68) 이 코드에 도달할 때 이미 유효함이
+    # 보장된다(_resolve_member_legacy). 이 테스트는 resolve_member 를 통째로 mock 해 그 내부
+    # 검증을 우회하므로, mock 이 대신 그 불변식(auth.user_id 가 resolved 대상과 일관됨)을 지켜야
+    # 한다. 이 파일의 관심사(resolver_id 강제)와는 무관 — patch 로 rule B 자체도 우회한다.
+    monkeypatch.setattr(gm, "_non_doc_gate_approvable", AsyncMock(return_value=True))
     await gm.transition_gate_endpoint(
         uuid.uuid4(), body, background_tasks=BackgroundTasks(),
-        session=_sess, org_id=uuid.uuid4(), auth=MagicMock())
+        session=_sess, org_id=uuid.uuid4(), auth=MagicMock(user_id=str(caller_id)))
     assert captured["resolver_id"] == caller_id  # ⭐조작된 spoofed 가 아니라 인증 caller
     assert captured["resolver_id"] != spoofed
 

--- a/backend/tests/test_gate_can_approve_48f064e5.py
+++ b/backend/tests/test_gate_can_approve_48f064e5.py
@@ -205,10 +205,21 @@ async def test_generic_endpoint_rejects_doc_approval_defense_in_depth():
 # ── 비-doc 게이트(merge 등)는 새 authz 무적용(기존 경로 무변경) ──
 @pytest.mark.anyio
 async def test_non_doc_gate_skips_doc_authz():
-    merge_gate = SimpleNamespace(gate_type="merge_approval", neutral_facts={}, work_item_id=uuid.uuid4())
-    # doc-gate 분기 미진입 → has_project_access 미호출·doc 미로드. transition 정상.
-    result, transition = await _call(
-        _human(uuid.uuid4()), execute_results=[_result(merge_gate)], has_access=None
+    # #2198: non-doc 분기가 이제 work_item_type/work_item_id 로 project 인가(rule B)를 강제하므로
+    # 명시(누락 시 AttributeError) — 이 테스트의 관심사는 "doc authz 분기를 안 타는가"이지 rule B
+    # 자체의 project-role 판정이 아니므로 _non_doc_gate_approvable 을 직접 patch 해 True 로 고정
+    # (그 판정 자체는 test_1974_gate_assigned_to_me.py/test_2198_*_realdb.py 가 커버).
+    merge_gate = SimpleNamespace(
+        gate_type="merge_approval", neutral_facts={}, work_item_id=uuid.uuid4(),
+        work_item_type="story",
     )
+    with patch.object(gates_mod, "_non_doc_gate_approvable", AsyncMock(return_value=True)):
+        # doc-gate 분기 미진입 → has_project_access 미호출·doc 미로드. transition 정상.
+        # execute_results 2번째 = resolve_work_item_project_id(work_item_type="story")의 조회.
+        result, transition = await _call(
+            _human(uuid.uuid4()),
+            execute_results=[_result(merge_gate), _result(uuid.uuid4())],
+            has_access=None,
+        )
     assert result == "OK"
     transition.assert_awaited_once()

--- a/backend/tests/test_gate_decider_can_approve_89484c8c.py
+++ b/backend/tests/test_gate_decider_can_approve_89484c8c.py
@@ -199,29 +199,46 @@ async def test_list_gates_can_approve_false_for_agent():
     assert out[0].can_approve is False  # 비-휴먼
 
 
-@pytest.mark.anyio
-async def test_list_gates_non_doc_gate_untouched():
+async def _run_non_doc_can_approve(project_role):
+    org = uuid.uuid4()
     merge = SimpleNamespace(
-        gate_type="merge", work_item_type="story", work_item_id=uuid.uuid4(),
+        id=uuid.uuid4(), gate_type="merge", work_item_type="story", work_item_id=uuid.uuid4(),
         neutral_facts={}, status="pending",
     )
-    org = uuid.uuid4()
     gates_result = MagicMock()
     gates_result.scalars.return_value.all.return_value = [merge]
+    story_batch = MagicMock()
+    story_batch.all.return_value = [(merge.work_item_id, uuid.uuid4())]
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[gates_result])  # doc_ids 비어 doc batch 미실행
+    session.execute = AsyncMock(side_effect=[gates_result, story_batch])
     auth = SimpleNamespace(user_id=str(uuid.uuid4()))
     rm = AsyncMock(return_value=_human(uuid.uuid4()))
     with patch.object(gates_mod.GateResponse, "model_validate", _resp), \
          patch.object(gates_mod, "resolve_member", rm), \
-         patch.object(gates_mod, "has_project_access", AsyncMock(return_value=True)), \
+         patch.object(gates_mod, "get_project_role", AsyncMock(return_value=project_role)), \
          patch.object(gates_mod, "get_org_posture", AsyncMock(return_value=None)):
         out = await list_gates(
             work_item_id=None, work_item_type=None, status=None, assigned_to_me=False,
             session=session, org_id=org, auth=auth,
         )
+    return out, rm, merge
+
+
+@pytest.mark.anyio
+async def test_list_gates_non_doc_gate_can_approve_now_true_for_project_owner():
+    """story #2198(까심 QA 적출·오르테가 확定): 이 테스트가 대체하는 옛 테스트("non_doc_gate_untouched"·
+    "resolve_member 미호출")는 non-doc can_approve 가 계산 자체를 안 하던 원 결함을 그대로 pin
+    하고 있었다 — 그게 정확히 #2198 의 증상②였다. 이제 non-doc 게이트도 rule B
+    (_non_doc_gate_approvable, story #1974)로 can_approve 가 계산된다: project owner 면 True."""
+    out, rm, merge = await _run_non_doc_can_approve("owner")
+    assert out[0].can_approve is True
+    rm.assert_awaited_once()  # non-doc can_approve 계산에도 caller 식별이 필요해졌다(의도된 변화).
+
+
+@pytest.mark.anyio
+async def test_list_gates_non_doc_gate_can_approve_false_for_non_owner():
+    out, rm, merge = await _run_non_doc_can_approve("member")  # owner/admin 아님
     assert out[0].can_approve is False
-    rm.assert_not_awaited()  # 비-doc 게이트만이면 resolve_member 미호출(불필요 작업 0)
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_gate_transition_human_only.py
+++ b/backend/tests/test_gate_transition_human_only.py
@@ -38,16 +38,23 @@ async def _call(status: str, member_type: str):
     body = GateTransitionRequest(status=status, resolver_id=uuid.uuid4(), note="테스트 사유")
     session = AsyncMock()
     # 48f064e5: 엔드포인트가 doc-gate authz용 게이트 로드 → 비-doc 게이트 반환(merge 등)으로 그 분기 skip.
+    # #2198: non-doc 분기가 work_item_type/work_item_id 를 읽으므로 SimpleNamespace 에 명시(누락
+    # 시 AttributeError) — 이 테스트는 human-vs-agent authz만 검증하므로 project-role 판정
+    # (_non_doc_gate_approvable) 은 아래에서 직접 patch 해 True 로 고정(그 판정 자체는 이 파일의
+    # 관심사가 아님 — project-role 축은 test_2198_*_realdb.py 가 별도로 커버).
     _gr = MagicMock()
-    _gr.scalar_one_or_none.return_value = SimpleNamespace(gate_type="merge_approval")
+    _gr.scalar_one_or_none.return_value = SimpleNamespace(
+        gate_type="merge_approval", work_item_type="story", work_item_id=uuid.uuid4(),
+    )
     session.execute = AsyncMock(return_value=_gr)
     transition = AsyncMock(return_value=SimpleNamespace())
     with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=_resolved(member_type))), \
          patch.object(gates_mod, "transition_gate", transition), \
+         patch.object(gates_mod, "_non_doc_gate_approvable", AsyncMock(return_value=True)), \
          patch.object(gates_mod.GateResponse, "model_validate", lambda g: "OK"):
         result = await transition_gate_endpoint(
             id=uuid.uuid4(), body=body, background_tasks=BackgroundTasks(),
-            session=session, org_id=org_id, auth=SimpleNamespace(),
+            session=session, org_id=org_id, auth=SimpleNamespace(user_id=str(uuid.uuid4())),
         )
     return result, transition
 

--- a/backend/tests/test_rc1_body_trust_actor.py
+++ b/backend/tests/test_rc1_body_trust_actor.py
@@ -16,10 +16,15 @@ import pytest
 
 
 def _non_doc_gate_session():
-    """48f064e5: 엔드포인트가 doc-gate authz용 게이트 로드 → 비-doc 게이트 반환으로 그 분기 skip."""
+    """48f064e5: 엔드포인트가 doc-gate authz용 게이트 로드 → 비-doc 게이트 반환으로 그 분기 skip.
+    #2198: non-doc 분기가 work_item_type/work_item_id 를 읽으므로 명시(누락 시 AttributeError) —
+    이 파일의 관심사는 resolver_id 강제(RC#1)이지 project-role 판정이 아니므로 호출부가
+    _non_doc_gate_approvable 을 별도로 patch 해 그 판정 자체를 우회한다."""
     s = AsyncMock()
     gr = MagicMock()
-    gr.scalar_one_or_none.return_value = SimpleNamespace(gate_type="merge")
+    gr.scalar_one_or_none.return_value = SimpleNamespace(
+        gate_type="merge", work_item_type="story", work_item_id=uuid.uuid4(),
+    )
     s.execute = AsyncMock(return_value=gr)
     return s
 
@@ -68,7 +73,8 @@ async def test_transition_forces_resolver_ignoring_body():
 
     from fastapi import BackgroundTasks
     with patch.object(mod, "resolve_member", AsyncMock(return_value=caller)), \
-         patch.object(mod, "transition_gate", _fake_transition):
+         patch.object(mod, "transition_gate", _fake_transition), \
+         patch.object(mod, "_non_doc_gate_approvable", AsyncMock(return_value=True)):
         # story #2027: _non_doc_gate_session()의 gate_type="merge"는 고위험(_HIGH_RISK_GATE_TYPES)이라
         # 이 파일의 관심사(resolver_id 강제)와 무관한 사유-강제 가드를 note로 우회.
         await transition_gate_endpoint(


### PR DESCRIPTION
## 배경 (story #2198, critical)

까심 QA가 결재함을 파다 인가 갭을 발견, 오르테가군이 `origin/main` 소스에서 직접 재확認.
증상 셋이 하나의 뿌리였다:

```
① 큐 필터(assigned_to_me)  _non_doc_gate_approvable(rule B, story #1974) 사용  ← 이미 좁았음
② can_approve              list_gates·get_gate_endpoint 둘 다 non-doc 은 계산을 안 함  ← 없음
③ 승인 엔드포인트           휴먼 org 멤버이기만 하면 통과                        ← 가장 넓음
```

`gates.py`에서 SoD·프로젝트 접근 검사가 `gate_type == "doc_approval"` 블록 안에만 있었다 —
non-doc(merge·pr_review·qa·deploy·artifact_canonicalize)은 그 블록을 통째로 건너뛰었다.
②가 없어서 자격자에게 버튼을 안 주고, ③이 헐거워서 비자격자는 버튼 없이도 통과 — 정확히 거꾸로.

## 처방

새 규칙을 발명하지 않았다. `_non_doc_gate_approvable`(rule B, story #1974)이 이미 옳게
좁은 형태(project owner/admin, project-무관 work_item은 org owner/admin)로 존재했는데
①(큐 필터)에만 배선돼 있었다 — 이걸 ②③에 마저 물렸다. `can_approve_doc_gate_reason`이
이미 "단일 규칙을 목록 가시성+엔드포인트 인가가 공용"하는 형태로 서 있었으므로 같은
골격으로 통일.

- `list_gates`: non-doc 게이트의 `can_approve`를 project_id 배치 조회 + rule B로 계산
  (기존엔 `assigned_to_me=true`일 때만 이 배치를 계산했음 — 이제 항상 계산, 필터링만
  `assigned_to_me`에 따라 갈림). 휴먼 전용 불변식은 이 계산 자체에도 fail-closed로 적용
  (비휴먼/미해소 caller는 배치 쿼리 자체를 스킵 — 결론이 안 바뀔 쿼리는 안 냄).
- `get_gate_endpoint`: can_approve가 **이 엔드포인트에선 전혀 계산되지 않고 있었다**
  (docstring의 enrich 목록에 애초에 없었음) — doc_approval·non-doc 가릴 것 없이. 알림
  딥링크 콜드 진입(목록 경유 없이 상세 직행)이 이 엔드포인트를 쓰므로 그 경로 사용자는
  상세 화면에서도 버튼을 영영 못 봤다. list_gates와 동일 규칙을 물렸다(project_id는 이미
  위에서 resolve_work_item_project_id로 해소돼 있어 추가 조회 없음).
- `transition_gate_endpoint`: doc_approval `if` 옆에 non-doc `elif` 신설 — rule B가
  False면 403.

## SoD(self-approval) — 의도적으로 안 넣음(오르테가 PO 판정)

```
① doc 결재의 SoD는 "저자성"(자기가 쓴 문서를 자기가 승인)을 막는 것 — non-doc 게이트엔
   그 관계가 같은 형태로 없다.
② non-doc 게이트 상신자는 사실상 에이전트이고 에이전트는 이미 승인 불가(93fc7aeb) —
   사람 대 사람 SoD가 붙을 자리가 실제로 거의 없다.
③ 넣으면 1인 org·소규모 팀에서 아무도 못 여는 교착이 생긴다(가정 아님 — PR #1998이
   바로 그 교착을 고치는 물건이고 17일째 미머지).
④ 추적은 이미 확보돼 있다(resolver_id를 body 무시하고 인증 caller로 강제 기록, S23 RC①).
```
다음 사람이 "doc엔 있는데 여긴 왜 없지"로 되돌아와 넣지 않도록 근거를 소스 주석에 그대로
남겼다.

## project_id=None(project-무관 work_item) 분기를 인가로 재사용해도 되는지 판단

`_non_doc_gate_approvable`의 project_id=None 분기(org owner/admin floor)는 지금까지
목록 가시성에만 쓰였는데, ③에 그대로 물리면 이 분기가 처음으로 실제 인가 판정이 된다.
확認: `resolve_work_item_project_id`는 story/task/doc/visual_artifact 전부 project_id가
NOT NULL이라, merge/pr_review/qa 게이트(대개 work_item_type="story")는 이 분기를 거의
안 탄다 — 실제로 None이 되는 건 workflow_line_config류(org-level config)뿐이며, doc.py
자신도 이 축에서 동일한 org owner/admin floor를 쓴다. 목록 기준과 인가 기준이 어긋나지
않는다고 판단.

## 부수 발견(realdb 테스트가 실제로 잡은 버그)

`transition_gate_endpoint`의 non-doc 분기 첫 구현이 rule B에 `resolved.id`(member row id)를
넘겼는데, `get_project_role`은 `auth.user_id`(users.id) 축을 기대해 **정당한 project
owner도 403 오탐**이 났다. `list_gates`가 이미 쓰던 `_uid = uuid.UUID(auth.user_id)` 관례로
맞춰 수정 — 이 버그는 mock 테스트로는 안 잡혔고 realdb 테스트(실제 project_access 행 조회)
에서만 드러났다.

## 검증 — 라이브 승인 POST 안 씀(오르테가 명시 지시)

`test_2198_non_doc_gate_authz_realdb.py`(4건, 격리 로컬 throwaway DB) — `#2027
test_2027_gate_approval_reason_enforce.py`와 동일 정신(실 배포 시스템 무접촉):
- list_gates/get_gate_endpoint: project owner는 can_approve=true, project member(owner/admin
  아님)는 false.
- transition_gate_endpoint: project member가 시도하면 403 + 상태 미변경(재조회로 확認),
  project owner는 실제 승인 성공.
- doc_approval 게이트는 이 변경으로 영향 0(회귀 확認).

**뮤테이션 셀프체크 3건** — list_gates can_approve, get_gate_endpoint can_approve,
transition_gate_endpoint의 non-doc 가드를 각각 무력화 → 정확히 예측한 테스트 1건씩만
RED로 전환되는 것 확認 후 복구.

## 회귀

- 기존 mock 기반 gate 테스트 5개 파일이 non-doc 분기가 이제 `work_item_type`/`work_item_id`
  를 읽는 것과 `auth.user_id`가 필요해진 것에 맞춰 업데이트 필요했다(SimpleNamespace 필드
  누락 → AttributeError). 그중 2개 테스트(`test_default_assigned_to_me_false_returns_all_
  no_extra_queries`, `test_list_gates_non_doc_gate_untouched`)는 **이름/주장 자체가 옛
  결함을 그대로 pin**하고 있었다("non-doc은 resolve_member를 안 부른다") — 이제 그게 정확히
  #2198의 증상②이므로, 새 올바른 계약(can_approve가 실제로 계산됨)을 검증하도록 재작성했다.
- `pytest -k "gate" -m "not destructive_schema"` — 292 passed, 0 failed.
- `pytest -k "not destructive_schema and not realdb"`(BE 전체) — 3782 passed, 8 failed 중
  gates.py와 무관(MCP 툴 카운트·로컬 프로세스 존재 확認류 — pristine `origin/develop`에서도
  동일 재현 확認) 6건 + 이번에 같이 잡아 고친 `test_rc1_body_trust_actor.py` 1건 제외하면
  전부 무관.

## ⛔ 이 PR이 안 닿는 것

- project_id=None(org-level 분기)의 실제 realdb 커버리지는 없음 — 그 분기 로직 자체(story
  #1974)는 이미 순수 함수 단위테스트로 커버돼 있으나, ③(transition_gate_endpoint)에서의
  배선은 project-scoped 케이스로만 실측했다.
- SoD는 완전히 열린 채로 남음 — 향후 필요해지면 별도 스토리/판단 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)