### PR TITLE
fix(#2206): story comments/activities — org 조건 자체가 없던 cross-org 유출 차단

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -1334,8 +1334,18 @@ async def list_comments(
     limit: int = Query(default=20, le=100),
     cursor: str | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
-    _repo: StoryRepository = Depends(_get_repo),
+    repo: StoryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[CommentResponse]:
+    # SEC(story #2206, 까심 인가 전수 스윕 A급): 쿼리 술어가 StoryComment.story_id == id 뿐이라
+    # org_id 조건 자체가 없었다(project-only 누락이 아니라 org 조건 부재 — 같은 파일 다른
+    # 엔드포인트들의 project-only 누락 갭과 다른 형태). 어느 org 멤버든 story UUID만 알면 다른
+    # org 의 댓글을 읽을 수 있었다. GET /{id}(524) 의 형제 가드(_assert_story_project_access)
+    # 를 그대로 재사용 — 새 규칙 발명 0.
+    story = await repo.get(id)
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+    await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
     q = select(StoryComment).where(
         StoryComment.story_id == id,
     ).order_by(StoryComment.created_at.desc()).limit(limit)
@@ -1430,8 +1440,14 @@ async def list_activities(
     id: uuid.UUID,
     limit: int = Query(default=20, le=100),
     db: AsyncSession = Depends(get_db),
-    _repo: StoryRepository = Depends(_get_repo),
+    repo: StoryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[ActivityResponse]:
+    # SEC(story #2206) — list_comments(1339)와 동형 갭·동형 처방. 자세한 사유는 그쪽 주석 참조.
+    story = await repo.get(id)
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+    await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
     q = select(StoryActivity).where(
         StoryActivity.story_id == id,
     ).order_by(StoryActivity.created_at.desc()).limit(limit)

--- a/backend/tests/test_2206_story_comments_activities_org_scope_realdb.py
+++ b/backend/tests/test_2206_story_comments_activities_org_scope_realdb.py
@@ -1,0 +1,159 @@
+"""story #2206(까심 인가 전수 스윕 A급·오르테가 확定): `GET /stories/{id}/comments`·
+`GET /stories/{id}/activities` 가 org_id 조건 자체 없이 `StoryComment.story_id == id`
+/`StoryActivity.story_id == id` 뿐이었다 — `_repo: StoryRepository = Depends(_get_repo)`
+가 주입만 되고 쿼리엔 안 쓰이는 함정(호출자의 org 멤버십은 검증되지만, "그 story 가 실제로
+그 org 소속인지"는 전혀 검증 안 됨). 어느 org 멤버든 story UUID 만 알면 다른 org 의
+댓글·활동이 읽혔다.
+
+처방 = GET /stories/{id}(get_story) 의 형제 가드(``repo.get(id)`` org-scope 404 +
+``_assert_story_project_access`` project-scope 403)를 그대로 재사용. 새 규칙 발명 0.
+
+⛔이 파일은 **결함이 있던 조건**(다른 org 의 human 이 그 story UUID 를 안다)으로 걸어야
+하는 회귀 가드다 — 같은 org 픽스처만으로는 이 결함을 못 잡는다. 라이브 실행(실제 배포
+시스템의 남의 org 데이터 조회)으로 갭을 확認하지 않는다 — 격리된 로컬 throwaway realdb에서
+라우터 함수를 직접 호출한다(StoryRepository 를 attacker 의 org_id 로 수동 구성 — FastAPI
+의존성 주입 경유 없이 `_get_repo` 가 만드는 것과 동일한 객체를 재현).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+VICTIM_ORG = uuid.UUID("d2206000-0000-0000-0000-000000000001")
+VICTIM_PROJ = uuid.UUID("d2206000-0000-0000-0000-000000000002")
+STORY = uuid.UUID("d2206000-0000-0000-0000-000000000003")
+
+ATTACKER_ORG = uuid.UUID("d2206000-0000-0000-0000-0000000000a1")
+ATTACKER_USER = uuid.UUID("d2206000-0000-0000-0000-0000000000a2")
+
+VICTIM_MEMBER = uuid.UUID("d2206000-0000-0000-0000-000000000004")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _attacker_auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(ATTACKER_USER), email=None, claims={}, org_id=str(ATTACKER_ORG))
+
+
+async def _seed(s):
+    """VICTIM_ORG 에 story 1건 + 댓글 1건 + 활동 1건. ATTACKER_ORG 는 완전히 별개
+    (VICTIM 과 아무 관계도 없음 — project_access·team_member 어느 것도 안 만든다·바로
+    이게 #2206 이 막아야 하는 축)."""
+    from app.models.pm import Story, StoryActivity, StoryComment
+
+    for sql in [
+        f"DELETE FROM story_comments WHERE org_id='{VICTIM_ORG}'",
+        f"DELETE FROM story_activities WHERE org_id='{VICTIM_ORG}'",
+        f"DELETE FROM stories WHERE org_id IN ('{VICTIM_ORG}','{ATTACKER_ORG}')",
+        f"DELETE FROM projects WHERE org_id IN ('{VICTIM_ORG}','{ATTACKER_ORG}')",
+        # org_members·users 는 organizations DELETE 로 cascade 안 됨 — 여러 테스트가 같은
+        # VICTIM_MEMBER id 로 재시딩하므로 명시 정리(테스트 순서·재실행 무관하게 항상 clean-slate).
+        f"DELETE FROM org_members WHERE org_id='{VICTIM_ORG}'",
+        f"DELETE FROM users WHERE id='{VICTIM_MEMBER}'",
+        f"DELETE FROM organizations WHERE id IN ('{VICTIM_ORG}','{ATTACKER_ORG}')",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES "
+        f"('{VICTIM_ORG}','Victim','d2206-victim','free'),"
+        f"('{ATTACKER_ORG}','Attacker','d2206-attacker','free')",
+        f"INSERT INTO projects (id,org_id,name,slug) VALUES ('{VICTIM_PROJ}','{VICTIM_ORG}','P','proj-victim')",
+    ]:
+        await s.execute(text(sql))
+    story = Story(id=STORY, org_id=VICTIM_ORG, project_id=VICTIM_PROJ, title="비밀 스토리", status="backlog")
+    s.add(story)
+    await s.flush()
+    s.add(StoryComment(
+        id=uuid.uuid4(), org_id=VICTIM_ORG, story_id=STORY, project_id=VICTIM_PROJ,
+        content="타org 에 새면 안 되는 댓글", created_by=VICTIM_MEMBER,
+    ))
+    s.add(StoryActivity(
+        id=uuid.uuid4(), org_id=VICTIM_ORG, story_id=STORY, project_id=VICTIM_PROJ,
+        activity_type="status_changed", created_by=VICTIM_MEMBER,
+    ))
+    await s.commit()
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+@pytest.mark.anyio
+async def test_list_comments_cross_org_404_not_leaked():
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import list_comments
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            # _get_repo 가 만드는 것과 동일한 객체를 attacker 의 org_id 로 수동 구성 —
+            # FastAPI Depends 경유 없이 라우터 함수를 직접 호출(라이브 HTTP 무접촉).
+            attacker_repo = StoryRepository(s, ATTACKER_ORG)
+            with pytest.raises(HTTPException) as ei:
+                await list_comments(
+                    id=STORY, limit=20, cursor=None, db=s, repo=attacker_repo, auth=_attacker_auth(),
+                )
+            assert ei.value.status_code == 404
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_activities_cross_org_404_not_leaked():
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import list_activities
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            attacker_repo = StoryRepository(s, ATTACKER_ORG)
+            with pytest.raises(HTTPException) as ei:
+                await list_activities(id=STORY, limit=20, db=s, repo=attacker_repo, auth=_attacker_auth())
+            assert ei.value.status_code == 404
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_comments_same_org_project_member_still_works():
+    """회귀 없음 확認 — 정당한(같은 org, project 접근 O) 휴먼은 그대로 조회된다."""
+    from app.repositories.story import StoryRepository
+    from app.dependencies.auth import AuthContext
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            for sql in [
+                f"INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+                f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+                f"('{VICTIM_MEMBER}','viewer@d2206.test','x','V',true,true,0,false,0)",
+                f"INSERT INTO org_members (id,org_id,user_id,role) VALUES "
+                f"(gen_random_uuid(),'{VICTIM_ORG}','{VICTIM_MEMBER}','owner')",
+            ]:
+                await s.execute(text(sql))
+            await s.commit()
+        async with Session() as s:
+            from app.routers.stories import list_comments
+            repo = StoryRepository(s, VICTIM_ORG)
+            auth = AuthContext(user_id=str(VICTIM_MEMBER), email=None, claims={}, org_id=str(VICTIM_ORG))
+            out = await list_comments(id=STORY, limit=20, cursor=None, db=s, repo=repo, auth=auth)
+        assert len(out) == 1
+        assert out[0].content == "타org 에 새면 안 되는 댓글"
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## 배경 (story #2206, critical — 까심 인가 전수 스윕 A급)

A급 12건 중 이 둘(`GET /stories/{id}/comments`, `GET /stories/{id}/activities`)만 성격이
달랐다. 나머지는 org 스코프는 서 있고 project 검증만 빠진 것인데, 이 둘은 **org 조건
자체가 쿼리에 없었다**:

```python
q = select(StoryComment).where(StoryComment.story_id == id)   # ⛔ 이 술어 하나뿐
_repo: StoryRepository = Depends(_get_repo)                    # 주입은 되는데 쿼리가 안 씀
```

`_repo`가 파라미터에 있어 스코프가 걸린 것처럼 읽히지만, 실제로는 호출자가 어느 org
멤버인지만 검증하고(`_get_repo`의 `get_project_scoped_org_id` 의존) **쿼리 자체는 그
org로 안 좁힌다**. 같은 파일의 다른 엔드포인트들은 `_repo`/`repo`를 실제로 써서(`repo.get(id)`,
`has_project_access` 등) 좁히므로 눈으로 훑으면 다 비슷해 보이는 함정이었다.

⇒ 어느 org 멤버든 story UUID만 알면(채팅·문서·PR 본문에 작업 번호와 함께 흔히 돌아다니는
식별자) 다른 조직의 댓글·활동을 읽을 수 있었다.

## 처방

새 규칙을 발명하지 않았다. `GET /stories/{id}`(`get_story`)의 형제 가드를 그대로 재사용:

```python
story = await repo.get(id)                # org-scope — 다른 org면 None → 404
if story is None:
    raise HTTPException(status_code=404, detail="Story not found")
await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)  # project-scope 403
```

`_repo`(밑줄 접두 = "미사용" 관례)를 `repo`로 바꾸고 `auth: AuthContext = Depends(get_current_user)`
파라미터를 추가했다.

## 같은 파일 전수 훑음(지시 4번)

`stories.py`의 다른 모든 `_repo`/`repo: StoryRepository = Depends(_get_repo)` 주입 지점
(list_stories의 ids 분기·workflow-line status/metrics·get_story·workflow-line fallback-notify/
withdraw·bulk_update·update_story·delete_story·update_story_status)을 전수 확認 — 전부
`repo.get()`으로 실제 스코핑하거나 `has_project_access`/`_assert_story_project_access`를
쓰고 있어 이 두 엔드포인트만 예외였다. 추가 등재 없음(전수 스윕 자체는 #2200이 별도로 함).

## 검증

**⛔먼저 결함이 있던 조건으로 실제로 걸었다** — 격리된 로컬 throwaway DB에서 취약한(수정
전) 코드를 직접 호출해 다른 org의 댓글 content가 실제로 반환되는 것을 확認한 뒤 고쳤다
(라이브 배포 시스템은 무접촉 — 남의 org 데이터를 실제로 읽어보는 방식이 아니라 로컬
disposable DB에서만).

realdb 회귀 가드 3건(`test_2206_story_comments_activities_org_scope_realdb.py`):
- cross-org 시도 → 404(유출 0) — comments·activities 각각
- 같은 org·project 접근권 있는 정당한 사용자는 그대로 조회(회귀 없음)

**뮤테이션 셀프체크** — 가드(`repo.get`+`_assert_story_project_access`)를 제거 → 정확히
cross-org 테스트 1건만 "DID NOT RAISE HTTPException"으로 RED → 복구. 테스트 재실행
안정성(동일 세션 3연속 그린)도 확認.

회귀: `pytest -k "stories or story" -m "not destructive_schema"` 170 passed, 0 failed.

## ⛔ 이 PR이 안 닿는 것

- `stories.py` 밖의 다른 라우터들의 같은 패턴(A급 12건 중 나머지 10건)은 스코프 밖 —
  #2200(전수 스윕)이 별도로 다룬다.
- `_repo` 주입-but-미사용 패턴 자체를 정적으로 잡는 lint/CI 가드는 만들지 않았음(이번은
  발견된 두 자리의 수정에 집중).

🤖 Generated with [Claude Code](https://claude.com/claude-code)