### PR TITLE
[SID:2203] .tableWrapper 가로 스크롤 안 되던 것 fix — overflow-x:visible이라 스크롤 컨테이너 자체가 아니었음

### DIFF
--- a/apps/web/src/app/globals-scrollbar.test.ts
+++ b/apps/web/src/app/globals-scrollbar.test.ts
@@ -6,12 +6,12 @@ import path from 'node:path';
 // 렌더 검증이 안 돼(실제 스크롤바 렌더는 브라우저 전용) 소스 문자열 불변식으로 고정한다:
 // ① 전역 숨김 규칙이 존재 ② .scrollbar-visible 예외 클래스가 그것을 되살림 ③ 스크롤 "기능"
 // 자체를 막는 overflow:hidden으로 되어있지 않음(숨기는 것과 못 굴리게 하는 것은 다르다).
-describe('전역 스크롤바 숨김 CSS 불변식 (#2165)', () => {
-  const css = fs.readFileSync(
-    path.resolve(__dirname, 'globals.css'),
-    'utf8',
-  );
+const css = fs.readFileSync(
+  path.resolve(__dirname, 'globals.css'),
+  'utf8',
+);
 
+describe('전역 스크롤바 숨김 CSS 불변식 (#2165)', () => {
   it('전역 * 규칙이 scrollbar-width:none + webkit scrollbar display:none 이다', () => {
     expect(css).toMatch(/\*\s*\{\s*scrollbar-width:\s*none;\s*\}/);
     expect(css).toContain('*::-webkit-scrollbar { display: none; }');
@@ -24,6 +24,20 @@ describe('전역 스크롤바 숨김 CSS 불변식 (#2165)', () => {
 
   it('.doc-renderer pre 후손 선택자도 같은 예외를 받는다(raw HTML 주입 경로라 클래스 직접 부착 불가)', () => {
     expect(css).toMatch(/\.doc-renderer pre[^{]*\{[^}]*scrollbar-width:\s*thin|\.scrollbar-visible,\s*\n?\s*\.doc-renderer pre/);
+  });
+});
+
+describe('.tableWrapper(TipTap 테이블 노드뷰 기본 클래스)가 실제로 가로 스크롤 가능하다 (#2203)', () => {
+  it('overflow-x:auto가 있다 — 이게 본체(스크롤바 노출만으로는 여전히 안 굴러간다)', () => {
+    expect(css).toMatch(/\.tableWrapper\s*\{[^}]*overflow-x:\s*auto/);
+  });
+
+  it('overflow-x:visible이나 overflow-x:hidden으로 되어있지 않다(#2203 원 결함 재발 방지)', () => {
+    expect(css).not.toMatch(/\.tableWrapper\s*\{[^}]*overflow-x:\s*(visible|hidden)/);
+  });
+
+  it('scrollbar-visible과 같은 예외(scrollbar-width:thin)를 받는다', () => {
+    expect(css).toMatch(/\.tableWrapper[^{]*\{[^}]*scrollbar-width:\s*thin|\.scrollbar-visible,[\s\S]*?\.tableWrapper\s*\{/);
   });
 });
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -503,20 +503,37 @@
 
   /* .doc-renderer pre: doc-content-renderer.tsx의 legacy html-format 경로가 raw HTML 문자열을
      그대로 주입해(dangerouslySetInnerHTML) 내부 <pre>에 클래스를 직접 못 붙인다 — 조상
-     .doc-renderer(항상 존재하는 컨테이너 클래스)를 거쳐 후손 선택자로 동일 예외를 적용한다. */
+     .doc-renderer(항상 존재하는 컨테이너 클래스)를 거쳐 후손 선택자로 동일 예외를 적용한다.
+
+     story #2203 — .tableWrapper는 @tiptap/extension-table(doc-editor.tsx의 Table.configure)이
+     테이블을 감쌀 때 항상 붙이는 자체 클래스다(이 프로젝트 코드가 아니라 라이브러리 기본
+     node view라 className prop을 못 건다 — .doc-renderer pre와 같은 이유로 후손 선택자를
+     못 쓰고 클래스명 자체로 잡는다). 이 클래스에 애초에 overflow-x 규칙이 하나도 없어서
+     scrollbar-width:none(위 전역 숨김)만 먹고 스크롤 자체가 안 되고 있었다(#2165가 스크롤바
+     "숨김"만 예외 처리했지, 이 컨테이너는 애초에 스크롤 "가능"조차 아니었다 — 별개 결함).
+     overflow-x:auto가 본체이고, scrollbar-visible 예외는 그 다음이다(순서가 바뀌면 막대만
+     생기고 여전히 안 굴러간다). */
+  .tableWrapper {
+    overflow-x: auto;
+  }
   .scrollbar-visible,
-  .doc-renderer pre {
+  .doc-renderer pre,
+  .tableWrapper {
     scrollbar-width: thin;
     scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
   }
   .scrollbar-visible::-webkit-scrollbar,
-  .doc-renderer pre::-webkit-scrollbar { display: block; width: 6px; height: 6px; }
+  .doc-renderer pre::-webkit-scrollbar,
+  .tableWrapper::-webkit-scrollbar { display: block; width: 6px; height: 6px; }
   .scrollbar-visible::-webkit-scrollbar-track,
-  .doc-renderer pre::-webkit-scrollbar-track { background: var(--scrollbar-track); }
+  .doc-renderer pre::-webkit-scrollbar-track,
+  .tableWrapper::-webkit-scrollbar-track { background: var(--scrollbar-track); }
   .scrollbar-visible::-webkit-scrollbar-thumb,
-  .doc-renderer pre::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 3px; }
+  .doc-renderer pre::-webkit-scrollbar-thumb,
+  .tableWrapper::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 3px; }
   .scrollbar-visible::-webkit-scrollbar-thumb:hover,
-  .doc-renderer pre::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); }
+  .doc-renderer pre::-webkit-scrollbar-thumb:hover,
+  .tableWrapper::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); }
 
   /* story #2062(유나 규격): #2057의 outline-offset:2px(바깥 4px 돌출)가 패딩 0인
      overflow-*-auto 스크롤 컨테이너에서 클리핑된다 — 링이 컨테이너 밖으로 못 새어나가


### PR DESCRIPTION
## 요약
- `@tiptap/extension-table`이 테이블에 항상 씌우는 자체 클래스 `.tableWrapper`에 `overflow-x` 규칙이 아예 없어(라이브러리 기본값), 전역 스크롤바 숨김(#2165, `scrollbar-width:none`)만 먹고 스크롤 가능성 자체가 없는 상태였다.
- 실측(까심 QA): `scrollWidth 922 > clientWidth 842`(실제로 넘침)인데 `scrollLeft`를 강제로 옮겨도 이동 안 함(`moved=false`) — 막대가 안 보이는 게 아니라 애초에 안 굴러가는 것.
- `#2165`와는 원인이 다름 — `#2165`는 자기 스코프대로 정상 동작했고, 이 결함은 그보다 이전부터 있던 스크롤 가능성 자체의 부재.

## 처방 순서 (스토리 요구사항)
1. `overflow-x: auto`(본체) — 이게 없으면 스크롤바를 노출해도 여전히 안 굴러감.
2. `scrollbar-visible`과 동일한 노출 예외를 `.tableWrapper`에도 적용.
3. `.doc-renderer pre`와 같은 이유로 후손 선택자 대신 클래스명 자체를 직접 잡음 — TipTap 노드뷰가 생성하는 wrapper라 className prop을 못 건다.

## 테스트
- `globals-scrollbar.test.ts`에 3건 추가(소스 문자열 불변식 — jsdom은 실제 overflow/scroll 렌더를 못 하므로 이 파일의 기존 관례 그대로 따름): `overflow-x:auto` 존재 확인, `visible`/`hidden` 부재 확인, `scrollbar-visible`과 동일 예외 확인.
- 뮤테이션 셀프체크: `overflow-x`를 `visible`로 되돌려 재실행 — 정확히 RED(2건). 복구 후 재확인(13건 전부 PASS).
- `pnpm exec tsc --noEmit`(clean) / `pnpm exec eslint`(0 경고) / `pnpm exec vitest run`(308 files·2054 tests, 전부 pass) / `pnpm build`(exit 0).

## 라이브 기능 검증 — 배포 후 진행 예정
- 까심이 만든 임시 문서(`qa-2165-overflow-probe-temp`, 9열 표)로 데스크톱/모바일(≤430px) 양쪽에서 `scrollLeft` 강제 이동 테스트 예정(computed style만으로 닫지 않음 — 이 결함이 바로 그 차이에서 나왔다).

## Test plan
- [ ] CI green
- [ ] 배포 후 qa-2165-overflow-probe-temp 문서에서 데스크톱 폭 `scrollLeft` 기능 시험(`moved === true`)
- [ ] 배포 후 모바일 폭(≤430px)에서 동일 시험