### PR TITLE
chore(#2166): sprintable-mcp 0.1.0 → 0.1.1 — PyPI 릴리즈가 빠져 사용자가 계속 옛 에러를 보던 것

### DIFF
--- a/backend/sprintable_mcp/pyproject.toml
+++ b/backend/sprintable_mcp/pyproject.toml
@@ -6,7 +6,10 @@ build-backend = "hatchling.build"
 # OB-PUBLISH(f5e1742d): distribution name = "sprintable" (선생님 PyPI project 등록값·uvx sprintable
 # 한 줄 정합). 내부 모듈명은 sprintable_mcp 그대로(dist명≠모듈명 — hatch sources remap 아래 유지).
 name = "sprintable"
-version = "0.1.0"
+# 0.1.1 (2026-07-27): story #2166 — `uvx sprintable` 첫 실행이 SPRINTABLE_API_URL 필수 에러로
+# 바로 죽으면서 다음 발을 안 주던 것 수정(메시지 + README). 코드는 2026-07-25 에 착지했으나
+# PyPI 는 0.1.0(07-07) 그대로여서 **실사용자는 계속 옛 에러를 보고 있었다** — 릴리즈가 빠진 칸이었다.
+version = "0.1.1"
 description = "Sprintable MCP server — BYO agent toolset over the Sprintable API (stdio). No repo clone required."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## 왜

story #2166 의 수정(`uvx sprintable` 첫 실행 에러에 **다음 발**을 주는 메시지 + README)은 2026-07-25 에 develop·main 양쪽에 착지했다. 그런데 **PyPI 는 여전히 0.1.0(2026-07-07 업로드)** 이라, 실사용자가 `uvx sprintable` 을 치면 **수정 前 판이 내려와 옛 에러를 그대로 본다.**

⇒ 코드와 사용자 사이에 **「릴리즈」라는 미실행 단계**가 남아 있었다. 머지 ≠ 사용자 도달.

## 실측 근거

```
PyPI JSON API      sprintable 최신 = 0.1.0 · upload_time 2026-07-07T09:28:02
픽스 커밋          e1d333e8 (2026-07-25) — origin/main 에 포함됨(merge-base 확認 rc=0)
패키지 코드 동일성  backend/sprintable_mcp : origin/main vs origin/develop **diff 0**
                  ⇒ main 에서 내보내도 develop 과 같은 코드가 나간다
```

## 무엇을 바꾸나

버전 한 줄(`0.1.0` → `0.1.1`). 코드 변경 0.
`publish-mcp.yml` 에 **릴리즈 태그와 pyproject 버전이 일치해야 하는 가드**가 있어(태그 `sprintable-mcp-v0.1.1`), 버전을 먼저 올려야 태그를 달 수 있다. 또 PyPI 는 같은 버전 재업로드를 거부하므로 어차피 필수다.

## 착지 뒤 순서

1. 이 PR 머지(main)
2. 릴리즈 `sprintable-mcp-v0.1.1` 발행 → `publish-mcp.yml` 이 OIDC 로 PyPI 업로드
3. ⛔**확認**: PyPI 최신이 0.1.1 로 바뀌는가 + 깨끗한 환경에서 `uvx sprintable` 이 **새 메시지**를 내는가
   (배포 성공 ≠ 사용자 도달 — 오늘 하루 종일 본 그 축)
4. 같은 버전 bump 를 develop 에도 반영(브랜치 드리프트 방지)

선생님 승인 하에 진행(2026-07-27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)