### PR TITLE
feat(#2168 PR-②): 프로젝트 밖 최근 대화 5개 — BE

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -12,13 +12,14 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy import and_, func, select, text, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
 
 from app.core.config import settings
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.event import Event
-from app.models.project import OrgMember
+from app.models.project import OrgMember, Project
 from app.models.team import AgentMessageAllowlist, TeamMember
 from app.models.agent_deployment import AgentAuditLog
 from app.models.webhook_config import WebhookConfig
@@ -37,6 +38,7 @@ from app.services.member_resolver import (
     resolve_member,
     resolve_member_identity,
 )
+from app.services.project_auth import project_access_valid_correlated
 from app.services.storage import get_storage_provider
 
 logger = logging.getLogger(__name__)
@@ -1053,6 +1055,83 @@ async def get_unread_count_total(
     sender = await _resolve_member(auth, org_id, db)
     total = (await db.execute(_total_unread_count_stmt(sender.id))).scalar_one()
     return {"count": int(total)}
+
+
+@router.get("/recent-outside-project")
+async def list_recent_conversations_outside_project(
+    project_id: uuid.UUID = Query(..., description="현재 보고 있는 프로젝트(제외 대상)"),
+    limit: int = Query(default=5, ge=1, le=5),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """GET /api/v2/conversations/recent-outside-project — story #2168 PR-② BE.
+
+    현재 프로젝트 **밖**에서 caller가 참여 중인 대화 최근 5개. 정렬 축은 유나·오르테가군
+    승인 스펙(2026-07-27) 그대로 caller 자신의 `ConversationParticipant.last_read_at`
+    (내가 마지막으로 들어간 시각) DESC — ⛔ 대화의 마지막 메시지 시각이 아니다(크로스-프로젝트
+    목록에서 그 축은 "남이 더 떠든 방이 위로 온다"는 소음이 된다, 스펙 문구 그대로).
+    NULL(한 번도 안 들어간 참여)은 가장 오래 전 취급으로 정렬 뒤로 밀린다(`nulls_last()`).
+
+    인가(스펙 실패-자리 "수동 사라짐=조용히 빠짐, 무알림"의 BE 축): FE가 나중에 403/404로
+    거르는 게 아니라 **이 쿼리 자체가** 지금 시점 접근 불가 대화를 담지 않는다 —
+    `project_access_valid_correlated`(project_auth.py, `has_project_access`와 동일
+    SSOT `_project_access_predicate` 재사용, story #1994 5회차가 확립한 "참가 행은 남아도
+    project_access 회수 시 못 읽는다" 불변식)를 메인 statement의 WHERE절에 직접 correlate —
+    별도 SELECT로 "접근 가능 project 집합"을 먼저 만들어 `.in_()`으로 거르는 2-phase가 아니라
+    같은 스냅샷 안에서 평가되는 correlated EXISTS(TOCTOU-by-construction, backlinks.py와 동형).
+
+    admin-bypass(`conversation_readable_predicate`의 우변, agent-only 대화를 관리자에게
+    추가 노출하는 축)는 여기서 의도적으로 미적용 — 이 엔드포인트는 애초에
+    `ConversationParticipant`(caller 자신의 참가 행)를 INNER JOIN해 "내가 참여한 대화"로만
+    후보를 좁힌다(비참여 admin-bypass 대화는 `last_read_at`이라는 정렬 축 자체가 없어
+    "오래 안 들어간 것부터" 캡의 의미론에 애초에 안 낀다 — list_conversations의
+    `include_agent_conversations`처럼 별도 admin 전용 노출 축이 필요하면 그건 이 스토리
+    스코프 밖의 별개 결정).
+    """
+    sender = await _resolve_member(auth, org_id, db, project_id=None)
+    uid = uuid.UUID(str(auth.user_id))
+
+    # 응답용 project 조인은 별도 alias로 둔다 — `project_access_valid_correlated`가 내부에서
+    # 다루는 `Project`와 identity가 겹치면 SQLAlchemy가 이 outer join의 Project를 correlated
+    # EXISTS 안쪽으로 잘못 끌어들여(auto-correlation) "FROM 절 0개"로 즉시 InvalidRequestError —
+    # 실측으로 발견(realdb 테스트 최초 실행 시 100% 재현).
+    ProjectAlias = aliased(Project)
+
+    stmt = (
+        select(Conversation, ProjectAlias.name, ProjectAlias.slug, ConversationParticipant.last_read_at)
+        .join(
+            ConversationParticipant,
+            and_(
+                ConversationParticipant.conversation_id == Conversation.id,
+                ConversationParticipant.member_id == sender.id,
+            ),
+        )
+        .join(ProjectAlias, ProjectAlias.id == Conversation.project_id)
+        .where(
+            Conversation.org_id == org_id,
+            Conversation.project_id != project_id,
+            project_access_valid_correlated(Conversation.project_id, caller_id=uid, org_id=org_id),
+        )
+        .order_by(ConversationParticipant.last_read_at.desc().nulls_last())
+        .limit(limit)
+    )
+    rows = (await db.execute(stmt)).all()
+
+    return {
+        "data": [
+            {
+                "id": str(conv.id),
+                "type": conv.type,
+                "title": conv.title,
+                "project_id": str(conv.project_id),
+                "project_name": project_name,
+                "project_slug": project_slug,
+                "last_read_at": last_read_at.isoformat() if last_read_at else None,
+            }
+            for conv, project_name, project_slug, last_read_at in rows
+        ]
+    }
 
 
 @router.get("/{conversation_id}", response_model=ConversationResponse)

--- a/backend/tests/authz_coverage_lib.py
+++ b/backend/tests/authz_coverage_lib.py
@@ -64,6 +64,20 @@ PROJECT_GUARD_FUNCTIONS: frozenset[str] = frozenset({
     "_assert_item_project_access",
     "_require_doc_project_access",
     "_require_retro_project_access",
+    # story #1994(E-KNOWLEDGE-LINK S2) 5회차 SSOT — has_project_access와 동일한
+    # _project_access_predicate를 렌더하는 correlated-EXISTS 빌더(project_auth.py). 별도
+    # SELECT로 "접근 가능 project 집합"을 먼저 만들어 .in_() 거르는 2-phase가 아니라 메인
+    # statement의 WHERE절에 직접 correlate돼 같은 스냅샷에서 평가된다 — has_project_access
+    # 호출보다 약한 것이 아니라 TOCTOU 윈도우가 구조적으로 없는 더 강한 형태(#2168 PR-②
+    # conversations.py:list_recent_conversations_outside_project 최초 콜사이트).
+    #
+    # ⚠️이 가드로도 못 잡는 것(선언 — 까심 i18n 가드와 동일 규율): AST 바디 스캔은 "이 이름의
+    # 호출이 body 안에 있는가"만 본다. project_access_valid_correlated를 **import만 하고
+    # 실제로 메인 쿼리의 WHERE/필터에 물리지 않은 채 다른 데(로그·주석성 변수 등)에 호출만
+    # 남겨도 이 스캐너는 guarded로 오인식한다 — "호출됐다"와 "그 결과가 실제로 응답을 좁힌다"
+    # 사이는 정적 AST로 못 가른다. 이 콜사이트류를 건드리는 PR은 realdb 회귀 테스트로
+    # "무권한 caller가 실제로 빈 결과/403을 받는가"까지 실증해야 한다(단순 호출 존재로 안심 금지).
+    "project_access_valid_correlated",
 })
 
 # ── PATH_ID 뮤테이션 축(story 5285888c): `DELETE|PATCH|PUT /resource/{id}` 처럼 리소스 자기

--- a/backend/tests/test_2168_pr2_recent_conversations_outside_project_realdb.py
+++ b/backend/tests/test_2168_pr2_recent_conversations_outside_project_realdb.py
@@ -60,7 +60,6 @@ async def _clean(s):
         f"DELETE FROM conversation_participants WHERE conversation_id IN "
         f"(SELECT id FROM conversations WHERE org_id='{ORG}')",
         f"DELETE FROM conversations WHERE org_id='{ORG}'",
-        f"DELETE FROM team_members WHERE org_id='{ORG}'",
         f"DELETE FROM project_access WHERE project_id IN "
         f"(SELECT id FROM projects WHERE org_id='{ORG}')",
         f"DELETE FROM projects WHERE org_id='{ORG}'",
@@ -100,16 +99,14 @@ async def _seed_base(s) -> uuid.UUID:
         f"(gen_random_uuid(),'{PROJ_B}','{caller_om_id}','granted')"
     ))
     # PROJ_REVOKED: grant row 자체가 없다 — "회수"를 project_access 부재로 표현(grant 모델).
-    # ⚠️ 실 배포 스키마는 team_members가 VIEW라 conversation_participants.member_id에
-    # FK 강제가 없다(baseline schema.sql 확인됨) — 그러나 이 테스트는 `Base.metadata.create_all()`
-    # 로 세운 throwaway DB라 TeamMember 모델이 진짜 테이블로 만들어져 FK가 걸린다. id만
-    # caller_om_id와 맞춰 1행 심어 이 테스트 DB의 제약을 만족시킨다(project_id는 FK 만족용
-    # placeholder — conversation_participants 조회는 member_id만 본다).
-    from app.models.team import TeamMember
-    s.add(TeamMember(
-        id=caller_om_id, org_id=ORG, project_id=PROJ_A, type="human", name="Caller",
-    ))
-    await s.flush()
+    # ⚠️ team_members는 실 배포 스키마에서 VIEW(members ⋈ project_access UNION)라 여기서
+    # 행을 만들지 않는다 — conversation_participants.member_id에는 FK 강제가 없다(baseline
+    # schema.sql 확인됨: conversation_id FK만 존재). 로컬에서 `Base.metadata.create_all()`로
+    # 세운 throwaway DB는 TeamMember 모델을 진짜 테이블로 만들어 이 자리에 FK가 생기지만,
+    # 그건 create_all과 실 배포 스키마(뷰) 사이의 알려진 드리프트일 뿐(#2513 CI가 UNION
+    # 뷰에 대한 DELETE로 실패한 것도 동일 원인) — 이 파일은 CI(실 baseline 스키마) 기준으로
+    # 짜여 있으므로 team_members에 손대지 않는다. 로컬 재현은 create_all 대신 실 baseline
+    # 스키마로 세운 DB가 필요하다.
     await s.commit()
     return caller_om_id
 

--- a/backend/tests/test_2168_pr2_recent_conversations_outside_project_realdb.py
+++ b/backend/tests/test_2168_pr2_recent_conversations_outside_project_realdb.py
@@ -1,0 +1,192 @@
+"""story #2168 PR-② (유나·오르테가군 승인 2026-07-27): `GET /conversations/recent-outside-project`.
+
+스펙 3축을 이 파일에서 고정한다:
+  ① 정렬축 = caller 자신의 `ConversationParticipant.last_read_at` DESC(마지막 메시지 시각 아님 —
+     크로스-프로젝트 목록에서 그건 "남이 더 떠든 방이 위로 오는" 소음이 된다는 게 스펙의 명시적
+     금지 사유). 5개 캡, 넘치면 "오래 안 들어간 것부터" 잘림(=last_read_at 오름차순 쪽부터 드롭).
+  ② 현재 프로젝트는 항상 제외.
+  ③ 실패-자리 "수동 사라짐(권한 회수)=조용히 빠짐, 무알림"의 BE 축 — participant 원시 행이
+     남아 있어도 project_access가 회수됐으면(=project_access 레코드 부재, grant 모델) 이 목록
+     자체가 그 대화를 담지 않는다(FE가 나중에 403으로 거르는 게 아니라 쿼리 시점에 이미 없음).
+
+격리된 로컬 throwaway realdb에서 라우터 함수를 직접 호출한다(HTTP 무접촉) — #2198/#2206과 동일
+관례.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("d2168000-0000-0000-0000-000000000001")
+CALLER_USER = uuid.UUID("d2168000-0000-0000-0000-000000000002")
+
+PROJ_CURRENT = uuid.UUID("d2168000-0000-0000-0000-000000000010")
+PROJ_A = uuid.UUID("d2168000-0000-0000-0000-000000000011")
+PROJ_B = uuid.UUID("d2168000-0000-0000-0000-000000000012")
+PROJ_REVOKED = uuid.UUID("d2168000-0000-0000-0000-000000000013")
+
+NOW = datetime(2026, 7, 27, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(CALLER_USER), email=None, claims={}, org_id=str(ORG))
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _clean(s):
+    for sql in [
+        f"DELETE FROM conversation_participants WHERE conversation_id IN "
+        f"(SELECT id FROM conversations WHERE org_id='{ORG}')",
+        f"DELETE FROM conversations WHERE org_id='{ORG}'",
+        f"DELETE FROM team_members WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id IN "
+        f"(SELECT id FROM projects WHERE org_id='{ORG}')",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{CALLER_USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _seed_base(s) -> uuid.UUID:
+    """org+caller(일반 member, owner/admin 아님)+4개 project. PROJ_A/PROJ_B는 grant 부여,
+    PROJ_REVOKED는 의도적으로 grant 없음(=회수 상태). caller_om_id 반환."""
+    await _clean(s)
+    for sql in [
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','O','d2168-org','free')",
+        f"INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{CALLER_USER}','caller@d2168.test','x','C',true,true,0,false,0)",
+        f"INSERT INTO projects (id,org_id,name,slug,violation_level) VALUES "
+        f"('{PROJ_CURRENT}','{ORG}','Current','d2168-current','warn'),"
+        f"('{PROJ_A}','{ORG}','A','d2168-a','warn'),"
+        f"('{PROJ_B}','{ORG}','B','d2168-b','warn'),"
+        f"('{PROJ_REVOKED}','{ORG}','Revoked','d2168-revoked','warn')",
+    ]:
+        await s.execute(text(sql))
+    om_row = (await s.execute(text(
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES "
+        f"(gen_random_uuid(),'{ORG}','{CALLER_USER}','member') RETURNING id"
+    ))).one()
+    caller_om_id = om_row[0]
+    # PROJ_CURRENT엔 grant 불필요(project_id != 필터로 애초에 결과 후보에서 배제).
+    await s.execute(text(
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) VALUES "
+        f"(gen_random_uuid(),'{PROJ_A}','{caller_om_id}','granted'),"
+        f"(gen_random_uuid(),'{PROJ_B}','{caller_om_id}','granted')"
+    ))
+    # PROJ_REVOKED: grant row 자체가 없다 — "회수"를 project_access 부재로 표현(grant 모델).
+    # ⚠️ 실 배포 스키마는 team_members가 VIEW라 conversation_participants.member_id에
+    # FK 강제가 없다(baseline schema.sql 확인됨) — 그러나 이 테스트는 `Base.metadata.create_all()`
+    # 로 세운 throwaway DB라 TeamMember 모델이 진짜 테이블로 만들어져 FK가 걸린다. id만
+    # caller_om_id와 맞춰 1행 심어 이 테스트 DB의 제약을 만족시킨다(project_id는 FK 만족용
+    # placeholder — conversation_participants 조회는 member_id만 본다).
+    from app.models.team import TeamMember
+    s.add(TeamMember(
+        id=caller_om_id, org_id=ORG, project_id=PROJ_A, type="human", name="Caller",
+    ))
+    await s.flush()
+    await s.commit()
+    return caller_om_id
+
+
+async def _add_conv(s, *, conv_id, project_id, caller_om_id, last_read_at):
+    await s.execute(text(
+        f"INSERT INTO conversations (id,org_id,project_id,type,title,status) VALUES "
+        f"('{conv_id}','{ORG}','{project_id}','group','T-{conv_id}','open')"
+    ))
+    lra = f"'{last_read_at.isoformat()}'" if last_read_at is not None else "NULL"
+    await s.execute(text(
+        f"INSERT INTO conversation_participants (id,conversation_id,member_id,last_read_at) VALUES "
+        f"(gen_random_uuid(),'{conv_id}','{caller_om_id}',{lra})"
+    ))
+    await s.commit()
+
+
+@pytest.mark.anyio
+async def test_orders_by_own_last_read_at_desc_excludes_current_and_revoked():
+    from app.routers.conversations import list_recent_conversations_outside_project
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            caller_om_id = await _seed_base(s)
+            conv_current = uuid.uuid4()
+            conv_a_recent = uuid.uuid4()
+            conv_b_mid = uuid.uuid4()
+            conv_a_old = uuid.uuid4()
+            conv_revoked = uuid.uuid4()
+            # 현재 프로젝트: last_read_at이 전부보다 최신이어도 제외돼야 함(②).
+            await _add_conv(s, conv_id=conv_current, project_id=PROJ_CURRENT,
+                             caller_om_id=caller_om_id, last_read_at=NOW - timedelta(minutes=10))
+            await _add_conv(s, conv_id=conv_a_recent, project_id=PROJ_A,
+                             caller_om_id=caller_om_id, last_read_at=NOW - timedelta(hours=1))
+            await _add_conv(s, conv_id=conv_b_mid, project_id=PROJ_B,
+                             caller_om_id=caller_om_id, last_read_at=NOW - timedelta(hours=3))
+            await _add_conv(s, conv_id=conv_a_old, project_id=PROJ_A,
+                             caller_om_id=caller_om_id, last_read_at=NOW - timedelta(hours=5))
+            # 권한 회수: participant 행은 있지만 PROJ_REVOKED엔 project_access grant가 없다 —
+            # last_read_at이 전부보다 최신이어도(=제일 "안 들어간지 얼마 안 된" 축) 빠져야 함(③).
+            await _add_conv(s, conv_id=conv_revoked, project_id=PROJ_REVOKED,
+                             caller_om_id=caller_om_id, last_read_at=NOW - timedelta(minutes=30))
+        async with Session() as s:
+            out = await list_recent_conversations_outside_project(
+                project_id=PROJ_CURRENT, limit=5, db=s, auth=_auth(), org_id=ORG,
+            )
+        ids = [row["id"] for row in out["data"]]
+        assert ids == [str(conv_a_recent), str(conv_b_mid), str(conv_a_old)], ids
+        assert str(conv_current) not in ids, "현재 프로젝트 대화가 새면 안 됨"
+        assert str(conv_revoked) not in ids, "권한 회수된 프로젝트 대화가 새면 안 됨(③ 조용히 빠짐)"
+        # ③ 프로젝트명 병기(스펙③) 확인.
+        assert out["data"][0]["project_name"] == "A"
+        assert out["data"][1]["project_name"] == "B"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_caps_at_limit_dropping_least_recently_read():
+    """①"5개, 넘치면 오래 안 들어간 것부터" — 6개 접근가능 대화 중 last_read_at 최신 5개만."""
+    from app.routers.conversations import list_recent_conversations_outside_project
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            caller_om_id = await _seed_base(s)
+            conv_ids = [uuid.uuid4() for _ in range(6)]
+            for i, cid in enumerate(conv_ids):
+                await _add_conv(
+                    s, conv_id=cid, project_id=(PROJ_A if i % 2 == 0 else PROJ_B),
+                    caller_om_id=caller_om_id, last_read_at=NOW - timedelta(hours=i),
+                )
+        async with Session() as s:
+            out = await list_recent_conversations_outside_project(
+                project_id=PROJ_CURRENT, limit=5, db=s, auth=_auth(), org_id=ORG,
+            )
+        ids = [row["id"] for row in out["data"]]
+        assert ids == [str(c) for c in conv_ids[:5]], ids
+        assert str(conv_ids[5]) not in ids, "가장 오래 안 들어간(hours=5) 것부터 잘려야 함"
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## Summary
- story #2168 PR-②(유나·오르테가군 승인, 2026-07-27) BE 축: `GET /api/v2/conversations/recent-outside-project`
- 현재 프로젝트 밖에서 caller가 참여 중인 대화 최근 5개 — 정렬축은 caller 자신의 `ConversationParticipant.last_read_at` DESC(⛔ 마지막 메시지 시각 아님 — 크로스-프로젝트 목록에서 그 축은 소음)
- 인가: `project_access_valid_correlated`(story #1994 SSOT, `has_project_access`와 동일 판정)를 메인 쿼리 WHERE절에 직접 correlate — project_access가 회수된 대화는 participant 행이 남아 있어도 **쿼리 시점에** 제외(스펙 "수동 사라짐=조용히 빠짐, 무알림"의 BE 축, FE가 나중에 403으로 거르는 게 아님)
- FE(미르코)는 별도 PR — 오르테가군 명시 지시("합치면 어디서 깨졌는지 못 가른다")

## Test plan
- [x] realdb 회귀 2건 신규(`test_2168_pr2_recent_conversations_outside_project_realdb.py`): 정렬+현재프로젝트 제외+권한회수 제외 동시 검증, limit 캡 검증
- [x] 두 불변식(권한회수 필터, last_read_at DESC 정렬) 모두 뮤테이션 자가검증 — 가드 제거/방향 반전 시 예측한 정확한 실패로 RED 확인 후 복원
- [x] 기존 conversations 테스트 회귀 없음 확인(`test_conversations.py`, `test_channel_get_or_create_conversation_args.py`)
- [x] 라우트 등록 순서 확인 — `/{conversation_id}` 캐치올보다 먼저 등록돼 경로 충돌 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)