### PR TITLE
chore(#2166): develop 의 sprintable-mcp 버전을 릴리즈된 0.1.1 로 맞춘다

### DIFF
--- a/backend/sprintable_mcp/pyproject.toml
+++ b/backend/sprintable_mcp/pyproject.toml
@@ -6,7 +6,10 @@ build-backend = "hatchling.build"
 # OB-PUBLISH(f5e1742d): distribution name = "sprintable" (선생님 PyPI project 등록값·uvx sprintable
 # 한 줄 정합). 내부 모듈명은 sprintable_mcp 그대로(dist명≠모듈명 — hatch sources remap 아래 유지).
 name = "sprintable"
-version = "0.1.0"
+# 0.1.1 (2026-07-27): story #2166 픽스가 PyPI 에 안 나가 사용자는 계속 옛 에러를 보고 있었다.
+# main 에서 릴리즈(sprintable-mcp-v0.1.1 · PyPI 05:55:20)했으므로 develop 도 같은 값으로 맞춘다
+# — 브랜치별로 버전이 갈리면 다음 사람이 "지금 나간 게 무엇인지"를 못 읽는다.
+version = "0.1.1"
 description = "Sprintable MCP server — BYO agent toolset over the Sprintable API (stdio). No repo clone required."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
main 에서 `sprintable-mcp-v0.1.1` 을 릴리즈해 PyPI 에 올렸다(2026-07-27T05:55:20 · latest 0.1.1 확認).

`backend/sprintable_mcp` 는 main·develop 이 **완전 동일**(diff 0)이라 나간 코드는 같다. 다만 버전 줄만 develop 에 `0.1.0` 으로 남으면 **「지금 나간 것이 무엇인지」를 브랜치에서 읽을 수 없다.**

코드 변경 0 — 버전 한 줄만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)