### PR TITLE
[SID:2212] 세션 만료 재로그인 직후 bare 레거시 링크(/board 등) 404 dead-end

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -339,6 +339,7 @@
   "orgBriefing": {
     "title": "Org Briefing",
     "subtitle": "What's come to you, what we're learning, and who's on what — at a glance.",
+    "projectRequiredBanner": "The page you were headed to needs a project. Pick one above and you'll be taken there.",
     "greeting": "Hi {name}, here's your org today",
     "nowHeroBadge": "Now",
     "nowTitle": "Requests",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -339,6 +339,7 @@
   "orgBriefing": {
     "title": "조직 브리핑",
     "subtitle": "내게 온 요청, 우리가 배우는 것, 누가 무엇을 맡고 있는지 — 한눈에.",
+    "projectRequiredBanner": "이동하려던 페이지에 프로젝트가 필요해요. 위에서 프로젝트를 선택하면 그 페이지로 이동합니다.",
     "greeting": "{name}님, 오늘 조직의 지금이에요",
     "nowHeroBadge": "지금",
     "nowTitle": "받은 요청",

--- a/apps/web/src/components/org-briefing/org-briefing-shell.test.tsx
+++ b/apps/web/src/components/org-briefing/org-briefing-shell.test.tsx
@@ -17,6 +17,12 @@ vi.mock('@/app/dashboard/dashboard-shell', () => ({
   useDashboardContext: () => useDashboardContextMock(),
 }));
 
+// story #2212 — OrgBriefingShell이 이제 useSearchParams(?next= 배너용)를 쓴다. 이 테스트는
+// Next 라우터 컨텍스트 밖(createRoot 직접 렌더)이라 목이 없으면 null이 되어 크래시한다.
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 let container: HTMLDivElement;

--- a/apps/web/src/components/org-briefing/org-briefing-shell.tsx
+++ b/apps/web/src/components/org-briefing/org-briefing-shell.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
+import { useSearchParams } from 'next/navigation';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { NowFace } from './now-face';
 import { LoopFace } from './loop-face';
@@ -39,9 +40,19 @@ function FaceSkeletonPanel({ title, subject }: { title: string; subject: string 
 export function OrgBriefingShell() {
   const t = useTranslations('orgBriefing');
   const { projectId, userName } = useDashboardContext();
+  // story #2212 — proxy.ts가 "프로젝트 미확定" 404 대신 여기로 next=<원 목적지>를 들고 보낸
+  // 경우, 위 프로젝트 스위처(사이드바/탑바 칩)로 프로젝트를 고르라는 안내를 보여준다. 실제
+  // 복귀는 use-unified-switcher.ts의 switchProject/switchOrgAndProject가 이 next를 읽어 처리.
+  const searchParams = useSearchParams();
+  const nextTarget = searchParams.get('next');
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 p-4 lg:p-6">
+      {nextTarget && (
+        <div className="rounded-xl border border-border bg-muted/40 px-4 py-3 text-sm text-foreground" role="status">
+          {t('projectRequiredBanner')}
+        </div>
+      )}
       <div>
         <h1 className="text-lg font-semibold tracking-tight text-foreground">
           {userName ? t('greeting', { name: userName }) : t('title')}

--- a/apps/web/src/hooks/use-unified-switcher.test.tsx
+++ b/apps/web/src/hooks/use-unified-switcher.test.tsx
@@ -12,10 +12,17 @@ import { useUnifiedSwitcher, type OrgSwitcherItem, type ProjectSwitcherItem } fr
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
+// story #2212 — routerPushMock/searchParamsValue를 테스트별로 갈아끼워 next-복귀·open-redirect
+// 가드를 검증한다(기존 테스트는 빈 URLSearchParams로 그대로 동작 — 회귀 없음).
+const { routerPushMock, searchParamsValueRef } = vi.hoisted(() => ({
+  routerPushMock: vi.fn(),
+  searchParamsValueRef: { current: '' as string },
+}));
+
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  useRouter: () => ({ push: routerPushMock, refresh: vi.fn() }),
   usePathname: () => '/moonklabs/sprintable/board',
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => new URLSearchParams(searchParamsValueRef.current),
 }));
 
 let container: HTMLDivElement;
@@ -43,6 +50,8 @@ beforeEach(() => {
   document.body.appendChild(container);
   root = createRoot(container);
   result = null;
+  routerPushMock.mockClear();
+  searchParamsValueRef.current = '';
 });
 
 afterEach(async () => {
@@ -88,5 +97,35 @@ describe('useUnifiedSwitcher — currentOrgProjects (story #2093 후속)', () =>
     await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
 
     expect(result?.currentOrgProjects).toEqual([]);
+  });
+});
+
+describe('useUnifiedSwitcher — switchProject의 ?next= 복귀 (story #2212)', () => {
+  it('?next=이 안전한 내부경로면 프로젝트 선택 직후 그리로 router.push한다(원 목적지로 복귀)', async () => {
+    searchParamsValueRef.current = 'next=%2Fboard';
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: { ok: true } }) })));
+    await act(async () => { root.render(<TestComp />); });
+    await act(async () => { await result?.switchProject('proj-sprintable'); });
+    expect(routerPushMock).toHaveBeenCalledWith('/board');
+    expect(routerPushMock).toHaveBeenCalledTimes(1); // switchedPath 계산 등 다른 push 없이 next로 한 번만
+  });
+
+  it.each([
+    ['//evil.com', 'protocol-relative'],
+    ['https://evil.com', '절대 URL'],
+    ['/\\evil.com', '백슬래시 트릭'],
+  ])('?next=%s(%s)는 신뢰하지 않고 무시한다(open-redirect 방지, story #2212)', async (malicious) => {
+    searchParamsValueRef.current = `next=${encodeURIComponent(malicious)}`;
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: { ok: true } }) })));
+    await act(async () => { root.render(<TestComp />); });
+    await act(async () => { await result?.switchProject('proj-sprintable'); });
+    // next를 안 믿으면 기존 경로(pathname 유지 + ?p= 갱신)로 떨어진다 — 외부 도메인으로 직접
+    // 이동(router.push의 목적지 자체가 malicious)하는 일은 절대 없어야 한다. malicious 값이
+    // 그 fallback URL의 ?next= 쿼리 "값"으로 그대로 남는 것 자체는 안전(어디로도 이동 안 시킴).
+    expect(routerPushMock).not.toHaveBeenCalledWith(malicious);
+    for (const call of routerPushMock.mock.calls) {
+      const dest = String(call[0]);
+      expect(dest.startsWith('/moonklabs/sprintable/board')).toBe(true); // 목적지 자체는 항상 내부 경로
+    }
   });
 });

--- a/apps/web/src/hooks/use-unified-switcher.ts
+++ b/apps/web/src/hooks/use-unified-switcher.ts
@@ -30,6 +30,16 @@ async function fetchProjectSlug(projectId: string): Promise<string | null> {
     .catch(() => null);
 }
 
+// story #2212(오르테가 지적, open-redirect 방어) — `?next=`는 사용자가 URL로 조작 가능한
+// 값이다(예: 남이 보낸 링크의 쿼리스트링). 여기가 실제 소비·router.push 지점이라 이 가드가
+// 없으면 로그인 상태로 외부 사이트로 튕겨 보내는 open-redirect가 된다(`//evil.com`,
+// `https://evil.com`, `/\evil.com` 등). proxy.ts의 redirectToProjectPicker에도 같은 형태의
+// 가드가 있지만(생성 쪽 방어는 originalPathname이 항상 안전해 이론상 불필요에 가깝다), 진짜
+// 열린 문은 여기다 — 방어는 양쪽 다.
+function isSafeInternalNext(value: string | null): value is string {
+  return !!value && value.startsWith('/') && !value.startsWith('//') && !value.includes('\\');
+}
+
 // story #2039 AC4 — 라이브 재현 확認(2026-07-20): switchProject/switchOrgAndProject가 URL 경로는
 // 그대로 두고 `?p=`만 갈아끼워서 ①목록이 안 바뀐 것처럼 보이고 ②사이드바를 누르는 순간에야 새
 // 프로젝트 slug로 이동해 그 slug가 미정규화(한글 등)면 404가 터진다(#2039 본체와 결합해 증폭).
@@ -167,6 +177,16 @@ export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjec
         body: JSON.stringify({ project_id: projectId }),
       }).catch(() => null);
       if (typeof window !== 'undefined') window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, projectId);
+      // story #2212 — proxy.ts가 "프로젝트 미확定" 404 대신 /org-briefing?next=<원 목적지>로
+      // 보낸 경우, 여기서 그 next를 읽어 프로젝트 선택 "직후" 원래 가려던 곳으로 돌려보낸다
+      // ("고르면 여기로 돌아온다"). CURRENT_PROJECT_COOKIE는 위 switch-project 응답이 이미
+      // Set-Cookie로 반영했으므로 이 시점에 next로 이동하면 그 목적지는 정상 해소된다.
+      const nextRaw = searchParams.get('next');
+      const nextTarget = isSafeInternalNext(nextRaw) ? nextRaw : null;
+      if (nextTarget) {
+        router.push(nextTarget);
+        return;
+      }
       const sp = new URLSearchParams(Array.from(searchParams.entries()));
       sp.set('p', projectId);
       const newOrgSlug = orgs.find((o) => o.orgId === nextOrgId)?.orgSlug;
@@ -184,6 +204,20 @@ export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjec
     setPending(true);
     try {
       if (typeof window !== 'undefined') window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, nextProjectId);
+      // story #2212 — next 목적지는 middleware가 CURRENT_PROJECT_COOKIE를 보고 판정하므로,
+      // 기존 경로(낙관적 push 먼저·fetch 나중)와 달리 여기선 push 전에 반드시 fetch가 반영돼야
+      // 한다(안 그러면 next로 이동해도 쿠키가 아직 안 실려 다시 같은 처방으로 튕긴다).
+      const nextRaw = searchParams.get('next');
+      const nextTarget = isSafeInternalNext(nextRaw) ? nextRaw : null;
+      if (nextTarget) {
+        await fetch('/api/switch-project', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ project_id: nextProjectId }),
+        }).catch(() => null);
+        router.push(nextTarget);
+        return;
+      }
       const sp = new URLSearchParams(Array.from(searchParams.entries()));
       sp.set('p', nextProjectId);
       const orgSlug = currentOrg?.orgSlug;

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -241,6 +241,54 @@ describe('proxy', () => {
     const response = await middleware(req);
     expect(response.status).toBe(403);
   });
+
+  // story #2212 근본원인 — curl로 라이브 재현해 확定한 결함: sp_at이 없거나 무효라 refresh를
+  // 타는 두 분기가, 새 토큰을 받고도 원 pathname을 그냥 NextResponse.next()로 통과시켰다.
+  // bare 레거시 링크(/board 등)는 그 pathname에 대응하는 페이지가 없어(오직 /{ws}/{proj}/board만
+  // 존재) Next 라우터가 즉시 404 — 토큰 자체는 정상으로 새로 발급됐는데도(다음 요청은 정상 301)
+  // 이 요청은 구제 안 됐다("재로그인 직후 첫 진입만 404, 재진입은 정상"과 정확히 일치). 이 두
+  // 테스트가 그 회귀가드 — refresh 성공 후에도 legacy-resource-redirect가 반드시 실행돼야 한다.
+  it('sp_at이 무효(만료 등)라 refresh를 타도, 그 새 토큰으로 legacy 리소스 경로가 여전히 301 해소된다(story #2212)', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const newAt = await makeAccessToken({ exp: now + 900, orgId: 'org-1', projectId: 'proj-1' });
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/api/v2/auth/refresh')) {
+        return Promise.resolve({ ok: true, json: async () => ({ data: { access_token: newAt, refresh_token: 'new-rt' } }) });
+      }
+      if (url.includes('/api/v2/organizations/org-1')) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'org-1', slug: 'moonklabs' }) });
+      }
+      if (url.includes('/api/v2/projects/proj-1')) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'proj-1', slug: 'sprintable' }) });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+    // sp_at은 서명 자체가 무효(claims 검증 실패) — verifyAccessToken이 null을 반환하는 경로.
+    const response = await middleware(makeRequest('/board', { sp_at: 'not.a.valid.jwt', sp_rt: 'old-rt' }));
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/sprintable/board');
+    expect(response.headers.get('set-cookie')).toContain('sp_at=');
+  });
+
+  it('sp_at 쿠키 자체가 없어(만료 후 삭제 등) refresh를 타도, 그 새 토큰으로 legacy 리소스 경로가 여전히 301 해소된다(story #2212)', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const newAt = await makeAccessToken({ exp: now + 900, orgId: 'org-1', projectId: 'proj-1' });
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/api/v2/auth/refresh')) {
+        return Promise.resolve({ ok: true, json: async () => ({ data: { access_token: newAt, refresh_token: 'new-rt' } }) });
+      }
+      if (url.includes('/api/v2/organizations/org-1')) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'org-1', slug: 'moonklabs' }) });
+      }
+      if (url.includes('/api/v2/projects/proj-1')) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'proj-1', slug: 'sprintable' }) });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+    const response = await middleware(makeRequest('/board', { sp_rt: 'valid-rt' }));
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/sprintable/board');
+  });
 });
 
 describe('proxy — resolve (story a539c649 S-route-project S1)', () => {
@@ -407,20 +455,36 @@ describe('proxy — legacy /docs bare-URL redirect (story a539c649 S2)', () => {
     expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/sprintable/docs');
   });
 
-  it('current-project 쿠키 없으면 개입 없이 통과 — Next 자체 404로 정직하게 실패(과잉확장 아님)', async () => {
+  // story #2212 — 이 두 케이스는 예전엔 "개입 없이 통과"(→ Next 자체 404)가 정답이라고
+  // 봤으나, 그 자체가 dead-end 결함이었다(AC3/AC4). 프로젝트를 못 정했거나(쿠키+JWT 둘 다 없음)
+  // BE 해소 자체가 실패해도, org는 확定돼 있으니 org-briefing(프로젝트 불필요 페이지)으로
+  // next=원 목적지를 들고 보낸다 — "고르면 여기로 돌아온다"(use-unified-switcher.ts가 소비).
+  it('current-project 쿠키도 JWT project_id도 없으면 404 대신 /org-briefing?next=<원경로+되돌이방지마커>로 302(story #2212)', async () => {
     const token = await makeAccessToken({ orgId: 'org-1' });
     const response = await middleware(makeRequest('/docs/my-doc', { sp_at: token }));
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(302);
+    // _prRetry=1 — 프로젝트를 골라도 또 실패하면(아래 되돌이 방지 테스트) 다시 안 튕기기 위한 내부 마커.
+    expect(response.headers.get('location')).toBe('https://app.example.com/org-briefing?next=%2Fdocs%2Fmy-doc%3F_prRetry%3D1');
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('org/project 단건 조회 실패(예: 삭제됨) 시 개입 없이 통과', async () => {
+  it('org/project는 확定됐는데 BE 단건 조회만 실패(예: 삭제됨)해도 404 대신 /org-briefing?next=<원경로+되돌이방지마커>로 302(story #2212)', async () => {
     const token = await makeAccessToken({ orgId: 'org-1' });
     mockFetch.mockResolvedValue({ ok: false, status: 404 });
     const response = await middleware(makeRequest('/docs/my-doc', {
       sp_at: token, sprintable_current_project_id: 'proj-1',
     }));
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('https://app.example.com/org-briefing?next=%2Fdocs%2Fmy-doc%3F_prRetry%3D1');
+  });
+
+  // story #2212(오르테가 지적, 되돌이 방지) — 프로젝트를 골라 next로 돌아왔는데도(=이 요청 자체가
+  // _prRetry=1을 달고 옴) 여전히 해소가 실패하면, 다시 /org-briefing으로 튕기지 않고 정직하게
+  // 멈춘다(Next 자체 404) — 무한 왕복 대신 "여기서 안 된다"는 신호.
+  it('되돌이 방지 — _prRetry=1을 달고 왔는데도 또 실패하면 다시 org-briefing으로 안 튕기고 개입 없이 통과(404)한다', async () => {
+    const token = await makeAccessToken({ orgId: 'org-1' });
+    const response = await middleware(makeRequest('/docs/my-doc?_prRetry=1', { sp_at: token }));
+    expect(response.status).toBe(200); // 개입 없이 통과 — Next 라우터가 이 pathname에 404를 렌더
   });
 });
 

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -152,16 +152,62 @@ async function redirectLegacyResourcePath(
   // story #1998: 쿠키 우선(명시 switch-project 결과) — 없으면 JWT app_metadata.project_id로 fallback.
   const projectId = request.cookies.get(CURRENT_PROJECT_COOKIE)?.value
     ?? await getProjectIdFromAccessToken(accessToken);
-  if (!orgId || !projectId) return null;
+  // orgId조차 없으면(토큰 자체가 org_id를 못 실은 예외적 경우) 개입할 근거가 없어 그대로 통과
+  // (Next 자체 404) — verifyAccessToken 통과 후 이론상 가능하나 실사용 재현 없음, story #2212
+  // 스코프 밖(그 경우엔 org조차 모르니 org-briefing으로도 못 보낸다).
+  if (!orgId) return null;
+  // story #2212 — 여기서 그냥 null(→ Next 404)을 주던 것이 결함이었다. "프로젝트를 못 정했다"는
+  // 사고가 아니라 코드 주석에 그대로 선언된 설계였지만("해소 불가면 null"), 그 선택 자체가
+  // dead-end라 처방 대상이다. org는 확定됐으니 org-briefing(프로젝트 불필요 페이지)으로 보내고
+  // 원래 목적지를 ?next=로 보존 — use-unified-switcher.ts의 switchProject/switchOrgAndProject가
+  // 이 next를 읽어 프로젝트 선택 직후 그리로 돌려보낸다("고르면 여기로 돌아온다").
+  // ⛔되돌이 방지(오르테가 지적) — 이미 이 왕복을 한 번 거쳐온 요청(RESOLVE_RETRY_PARAM 존재)이
+  // 또 실패하면 다시 org-briefing으로 튕기지 않는다 — 프로젝트를 골라도 안 되는 것이면 무한
+  // 왕복 대신 정직하게 멈춘다(Next 자체 404).
+  if (!projectId) {
+    if (request.nextUrl.searchParams.has(RESOLVE_RETRY_PARAM)) return null;
+    return redirectToProjectPicker(request, pathname);
+  }
 
   const fastapiUrl = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
   const slugs = await resolveLegacyResourcePath(fastapiUrl, orgId, projectId, accessToken);
-  if (!slugs) return null;
+  // org/project는 둘 다 확定됐는데 BE 해소만 실패한 경우(예: 그 project가 삭제/접근철회)도
+  // 같은 안내로 보낸다(AC4: "404가 맞는 경우에도 다음 발이 붙는다") — 단, 이것도 되돌이 방지 적용.
+  if (!slugs) {
+    if (request.nextUrl.searchParams.has(RESOLVE_RETRY_PARAM)) return null;
+    return redirectToProjectPicker(request, pathname);
+  }
 
   const rest = pathname.slice(`/${resourceName}`.length); // '' | '/{sub}' | '/{sub}/{sub2}'
   const url = request.nextUrl.clone();
   url.pathname = `/${slugs.orgSlug}/${slugs.projectSlug}/${resourceName}${rest}`;
+  url.searchParams.delete(RESOLVE_RETRY_PARAM); // 성공 착지 URL에 내부 마커가 새지 않게
   return NextResponse.redirect(url, 301);
+}
+
+// story #2212 — org-briefing 왕복이 한 번 더 실패했을 때 무한 왕복을 막기 위한 내부 마커(오르테가
+// 지적). redirectToProjectPicker가 next 목적지에 심고, redirectLegacyResourcePath가 "이미 한 번
+// 튕겼던 요청인가"를 판별하는 데만 쓴다 — 사용자에게 노출될 일 없는(성공 시 delete) 순수 내부 신호.
+const RESOLVE_RETRY_PARAM = '_prRetry';
+
+// story #2212(오르테가 지적, open-redirect 방어) — next로 실어 보내는 값은 반드시 내부 경로여야
+// 한다. 여기(생성 쪽)의 originalPathname은 항상 request.nextUrl.pathname에서 유도돼 구조적으로
+// 안전하지만, 진짜 위험한 소비 지점은 use-unified-switcher.ts(그쪽은 사용자가 URL로 조작 가능한
+// ?next=를 읽어 router.push한다) — 방어는 그쪽에도 동일하게 있어야 한다(양쪽 다, 한쪽만으론 뚫림).
+function isSafeInternalPath(value: string): boolean {
+  return value.startsWith('/') && !value.startsWith('//') && !value.includes('\\');
+}
+
+function redirectToProjectPicker(request: NextRequest, originalPathname: string): NextResponse {
+  const url = request.nextUrl.clone();
+  url.pathname = '/org-briefing';
+  const targetSearch = new URLSearchParams(request.nextUrl.search);
+  targetSearch.set(RESOLVE_RETRY_PARAM, '1');
+  const targetQuery = targetSearch.toString();
+  const next = originalPathname + (targetQuery ? `?${targetQuery}` : '');
+  url.search = '';
+  if (isSafeInternalPath(next)) url.searchParams.set('next', next);
+  return NextResponse.redirect(url, 302); // 302 — 이 목적지는 계정 상태(현재 프로젝트)에 의존, 영구 아님
 }
 
 /**
@@ -308,65 +354,49 @@ function handleUnauthenticated(request: NextRequest, isApiPath: boolean, refresh
   return response;
 }
 
-export async function proxy(request: NextRequest) {
-  const pathname = request.nextUrl.pathname;
+// story #2212 — 근본원인(curl 재현으로 확定, 2026-07-27): accessToken이 없거나(만료 등) 무효라
+// refresh를 타는 두 분기가, refresh 성공 후 **바로 `NextResponse.next()`로 원 pathname을 그대로
+// 통과**시켰다. bare flat 링크(`/board` 등)는 그 pathname 자체엔 대응하는 페이지가 없어(오직
+// `/{ws}/{proj}/board`만 존재) redirectLegacyResourcePath를 거치지 못한 채 Next 라우터가 즉시
+// 404 — 새로 발급된 토큰은 org_id/project_id 둘 다 정상인데도(다음 요청은 정상 301) 이 요청
+// 자체는 구제되지 않았다. "세션 만료 후 재로그인 직후 첫 진입만 404, 재진입은 정상"이라는 선생님
+// 재현과 정확히 일치(curl: corrupt sp_at+valid sp_rt → 새 토큰 발급되지만 응답은 404 · 그 새
+// 토큰으로 재요청 → 301 정상). 고침: refresh 성공 시에도 그 새 토큰으로 이 요청 자체를
+// resolveAndRespond까지 마저 태운다(API 경로는 라우트 핸들러가 직접 인증하므로 제외 — 기존 그대로).
+async function respondWithRefreshedToken(
+  request: NextRequest,
+  pathname: string,
+  tokens: { accessToken: string; refreshToken: string },
+  isApiPath: boolean,
+): Promise<NextResponse> {
+  const headers = buildRefreshedHeaders(request, tokens);
+  const response = isApiPath
+    ? NextResponse.next({ request: { headers } })
+    : await (async () => {
+        const freshClaims = await verifyAccessToken(tokens.accessToken);
+        return freshClaims
+          ? resolveAndRespond(request, pathname, tokens.accessToken, freshClaims, headers)
+          : NextResponse.next({ request: { headers } });
+      })();
+  applyTokenCookies(response, tokens.accessToken, tokens.refreshToken);
+  return response;
+}
 
-  const isPublicPath =
-    PUBLIC_EXACT.includes(pathname) ||
-    PUBLIC_PREFIX.some((prefix) => pathname.startsWith(prefix));
-
-  if (isPublicPath) {
-    return NextResponse.next({ request });
-  }
-
-  // Authenticated API routes — try token refresh but never redirect to /login
-  const isApiPath = pathname.startsWith('/api/');
-
-  // Agent API keys are for MCP/HTTP API only — block UI route access
-  const authHeader = request.headers.get('Authorization');
-  if (!isApiPath && authHeader?.startsWith('Bearer ')) {
-    return new NextResponse(
-      JSON.stringify({ error: { code: 'FORBIDDEN', message: 'Agent API keys cannot access UI routes' } }),
-      { status: 403, headers: { 'Content-Type': 'application/json' } },
-    );
-  }
-
-  const accessToken = request.cookies.get(SP_AT_COOKIE)?.value;
-
-  if (!accessToken) {
-    const tokens = await tryRefreshViaFastapi(request);
-    if (!tokens) return handleUnauthenticated(request, isApiPath, true);
-    // RC2: stale refresh(다른 계정)면 적용 안 함 — 잘못된 계정으로 복귀 방지(쿠키는 유지).
-    if (!(await refreshMatchesActive(request, tokens.accessToken))) {
-      return handleUnauthenticated(request, isApiPath, false);
-    }
-    const headers = buildRefreshedHeaders(request, tokens);
-    const response = NextResponse.next({ request: { headers } });
-    applyTokenCookies(response, tokens.accessToken, tokens.refreshToken);
-    return response;
-  }
-
-  const claims = await verifyAccessToken(accessToken);
-
-  if (!claims) {
-    // access token invalid/expired — try refresh
-    const tokens = await tryRefreshViaFastapi(request);
-    if (!tokens) return handleUnauthenticated(request, isApiPath, true);
-    // RC2: stale refresh(다른 계정)면 적용 안 함 — 잘못된 계정으로 복귀 방지(쿠키는 유지).
-    if (!(await refreshMatchesActive(request, tokens.accessToken))) {
-      return handleUnauthenticated(request, isApiPath, false);
-    }
-    const headers = buildRefreshedHeaders(request, tokens);
-    const response = NextResponse.next({ request: { headers } });
-    applyTokenCookies(response, tokens.accessToken, tokens.refreshToken);
-    return response;
-  }
-
+// story a539c649/8fc51517/#2212 — 유효한 accessToken이 있을 때(원 요청이든, 방금 refresh로
+// 받은 것이든) 실제로 응답을 만드는 본체. 두 호출부(정상 경로·refresh-직후 경로)가 완전히
+// 같은 해소 순서를 타야 #2212 같은 우회가 다시 안 생긴다 — 로직을 여기 하나로 모은다.
+async function resolveAndRespond(
+  request: NextRequest,
+  pathname: string,
+  accessToken: string,
+  claims: { exp?: number },
+  baseHeaders: Headers,
+): Promise<NextResponse> {
   // Proactive refresh if expiring within 5 minutes.
   // AC3: x-pathname 주입 — (authenticated)/layout 이 /me 401 시 next 보존 redirect 에 사용(server component
   // 는 현재 경로를 직접 못 읽음).
   const now = Math.floor(Date.now() / 1000);
-  const fwdHeaders = new Headers(request.headers);
+  const fwdHeaders = new Headers(baseHeaders);
   fwdHeaders.set('x-pathname', pathname + request.nextUrl.search);
 
   // story a539c649(S2 최초·S3 일반화) — 이관 완료된 리소스(MIGRATED_RESOURCES)의 옛 flat
@@ -408,6 +438,57 @@ export async function proxy(request: NextRequest) {
   }
 
   return response;
+}
+
+export async function proxy(request: NextRequest) {
+  const pathname = request.nextUrl.pathname;
+
+  const isPublicPath =
+    PUBLIC_EXACT.includes(pathname) ||
+    PUBLIC_PREFIX.some((prefix) => pathname.startsWith(prefix));
+
+  if (isPublicPath) {
+    return NextResponse.next({ request });
+  }
+
+  // Authenticated API routes — try token refresh but never redirect to /login
+  const isApiPath = pathname.startsWith('/api/');
+
+  // Agent API keys are for MCP/HTTP API only — block UI route access
+  const authHeader = request.headers.get('Authorization');
+  if (!isApiPath && authHeader?.startsWith('Bearer ')) {
+    return new NextResponse(
+      JSON.stringify({ error: { code: 'FORBIDDEN', message: 'Agent API keys cannot access UI routes' } }),
+      { status: 403, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  const accessToken = request.cookies.get(SP_AT_COOKIE)?.value;
+
+  if (!accessToken) {
+    const tokens = await tryRefreshViaFastapi(request);
+    if (!tokens) return handleUnauthenticated(request, isApiPath, true);
+    // RC2: stale refresh(다른 계정)면 적용 안 함 — 잘못된 계정으로 복귀 방지(쿠키는 유지).
+    if (!(await refreshMatchesActive(request, tokens.accessToken))) {
+      return handleUnauthenticated(request, isApiPath, false);
+    }
+    return respondWithRefreshedToken(request, pathname, tokens, isApiPath);
+  }
+
+  const claims = await verifyAccessToken(accessToken);
+
+  if (!claims) {
+    // access token invalid/expired — try refresh
+    const tokens = await tryRefreshViaFastapi(request);
+    if (!tokens) return handleUnauthenticated(request, isApiPath, true);
+    // RC2: stale refresh(다른 계정)면 적용 안 함 — 잘못된 계정으로 복귀 방지(쿠키는 유지).
+    if (!(await refreshMatchesActive(request, tokens.accessToken))) {
+      return handleUnauthenticated(request, isApiPath, false);
+    }
+    return respondWithRefreshedToken(request, pathname, tokens, isApiPath);
+  }
+
+  return resolveAndRespond(request, pathname, accessToken, claims, request.headers);
 }
 
 type ResolveWiringResult =


### PR DESCRIPTION
## 요약
- 근본원인(curl로 dev 백엔드 직접 재현해 확定): `proxy.ts`에서 sp_at이 없거나 무효라 refresh를 타는 두 분기가, 새 토큰을 정상 발급받고도 **원 pathname을 그냥 통과**시켰다. bare 레거시 링크(`/board` 등)는 그 pathname에 대응 페이지가 없어(오직 `/{ws}/{proj}/board`) Next 라우터가 즉시 404 — 다음 요청부턴 sp_at이 유효해 정상 경로를 타므로 "재로그인 직후 첫 진입만 404, 재진입은 정상"이었다.
- `resolveAndRespond()`로 해소 로직(legacy-redirect/rename-redirect/workspace-resolve)을 하나로 모아, 정상 경로와 refresh-직후 경로 **둘 다** 동일하게 타도록 리팩터.
- AC3(본체): 프로젝트를 못 정했을 때(`!projectId`)나 BE 단건조회 실패(`!slugs`)도 404 대신 `/org-briefing?next=<원경로>`로 302 — org는 확定됐으니 프로젝트 불필요 페이지로 보내고 원 목적지를 보존("고르면 여기로 돌아온다").
- `use-unified-switcher.ts`가 `?next=`을 읽어 프로젝트 선택 직후 원래 목적지로 복귀.
- open-redirect 방지(생성 쪽 proxy.ts + 소비 쪽 switcher 양쪽) + 되돌이 방지 마커(`_prRetry`)로, next로 복귀해도 다시 실패하면 무한 왕복 대신 정직하게 멈춤(Next 404).

## 재현 (dev 백엔드, curl)
```
① sp_at 고의 손상(서명무효)+sp_rt 유효 → bare GET /board → 404 (새 sp_at은 org/project 다 정상으로 발급됨)
② 그 새 sp_at으로 같은 bare /board 재요청 → 301 정상
```
선생님 재현("같은 브라우저·같은 탭, 로그인 풀린 채 재로그인하면 첫 진입만 404, 재진입은 정상")과 일치.

## 테스트
- `proxy.test.ts`: 회귀가드 4건 신설(토큰-refresh-우회 2건 + dead-end→302 전환 2건 + 되돌이 방지 1건) — mutation 확認(되돌리면 RED).
- `use-unified-switcher.test.tsx`: next-복귀 1건 + open-redirect 방지 3건(protocol-relative/절대URL/백슬래시).
- `org-briefing-shell.test.tsx`: 기존 테스트에 `next/navigation` mock 보강(회귀 없음).
- 전체 vitest: 312 files / 2079 passed.
- `pnpm build`: 성공(exit 0).

## Test plan
- [ ] dev 배포 후 라이브 puppeteer로 동일 curl 시나리오 재현 확認(첫 진입 301/무배너, 프로젝트 미확定 시 org-briefing 배너+스위처로 복귀)
- [ ] 모바일 폭에서도 org-briefing 배너 확認

🤖 Generated with [Claude Code](https://claude.com/claude-code)