### PR TITLE
fix(#2215): report-done agent_id 검증이 owner-floor 휴먼을 거절하던 것

### DIFF
--- a/backend/app/routers/workflow_report.py
+++ b/backend/app/routers/workflow_report.py
@@ -15,6 +15,7 @@ from app.models.gate import Gate
 from app.models.pm import Story
 from app.models.team import TeamMember
 from app.repositories.story import StoryRepository
+from app.services.member_resolver import filter_org_member_ids
 from app.services.merge_verdict_gate import (
     AUTO_MERGE,
     BLOCK,
@@ -158,12 +159,18 @@ async def report_done(
 
     # S20 finding #12(sibling): body.agent_id도 검증 없이 gate/line 평가의 actor로 그대로
     # 쓰였다 — 임의 agent_id로 actor 스푸핑 가능했던 갭. caller org 소속 member인지 확인.
-    agent_check = await session.execute(
-        select(TeamMember.id).where(
-            TeamMember.id == body.agent_id, TeamMember.org_id == org_id,
-        ).limit(1)
-    )
-    if agent_check.scalar_one_or_none() is None:
+    # #2215: TeamMember 단독 조회였을 때는 team_members 뷰(members ⋈ project_access INNER
+    # JOIN)에 명시 grant가 없는 owner-floor 휴먼(org owner/admin — has_project_access의
+    # admin_branch로 접근권을 얻지 project_access 행을 갖지 않음)이 이 뷰에 원천적으로
+    # 안 잡혀 "agent_id not found"로 오탐 차단됐다 — 1인 창업자가 자기 스토리를
+    # report-done으로 보고하면 자기 조직 팀원이 아니라고 거절당하는 유입 손실이었다.
+    # 처방: 뷰 자체는 안 건드리고(공용 자산·폭발 반경 큼) **검증 쪽의 판정을 넓힌다** —
+    # filter_org_member_ids(member_resolver.py)가 이미 TeamMember ∪ OrgMember(grant-only
+    # 포함)로 "org 소속인가"를 판정하는 SSOT다(멘션/포크 cross-org 차단에 기존 사용 중,
+    # 재구현 0). 스푸핑 방지라는 이 체크의 원래 목적은 그대로 — org 밖/미소속 agent_id는
+    # 여전히 차단(TeamMember도 OrgMember도 없으면 교집합 0).
+    valid_ids = await filter_org_member_ids({body.agent_id}, org_id, session)
+    if body.agent_id not in valid_ids:
         raise HTTPException(status_code=400, detail="agent_id not found in this organization")
 
     transition = _TRANSITIONS[body.stage]

--- a/backend/tests/test_2215_report_done_owner_floor_agent_id_realdb.py
+++ b/backend/tests/test_2215_report_done_owner_floor_agent_id_realdb.py
@@ -1,0 +1,207 @@
+"""story #2215(AC6 완주 중 발견·오르테가군 확定): `POST /workflow/report-done`의 agent_id
+스푸핑 방지 체크(S20 finding #12 sibling)가 `team_members` VIEW(members ⋈ project_access
+**INNER JOIN**)만 조회했다 — org owner/admin은 명시 project_access grant 없이 owner-floor
+(`has_project_access`의 admin_branch)로 접근권을 얻으므로 이 뷰에 행이 없다. 결과: **1인
+창업자가 자기 스토리를 자기 이름으로 report-done 보고하면 "agent_id not found in this
+organization"(400)으로 거절**됐다(#2166과 동형의 OSS 유입 손실).
+
+처방: 뷰는 무접촉(공용 자산·폭발 반경 큼) — 검증 쪽을 `filter_org_member_ids`(member_resolver.py,
+TeamMember ∪ OrgMember, story #1994 계열 SSOT — 멘션/포크 cross-org 차단에 기존 사용 중)로
+교체. 새 규칙 발명 0.
+
+⛔이 파일은 오르테가군이 명시한 가드 3종을 전부 고정한다 — 양성(owner 통과)만 재고 닫지 않는다:
+  ① owner-floor만 가진 owner → 통과(결함이 있던 조건 그대로)
+  ② 조직 밖 agent_id → 여전히 400(스푸핑 방어가 안 헐거워졌는가)
+  ③ 정상 agent(project grant 有) → 여전히 통과(되던 것이 되는가)
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from starlette.responses import Response
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("d2215000-0000-0000-0000-000000000010")
+OTHER_ORG = uuid.UUID("d2215000-0000-0000-0000-0000000000a1")
+OWNER_USER = uuid.UUID("d2215000-0000-0000-0000-000000000011")
+OUTSIDER_USER = uuid.UUID("d2215000-0000-0000-0000-0000000000a2")
+PROJ = uuid.UUID("d2215000-0000-0000-0000-000000000012")
+AGENT_PROJ = uuid.UUID("d2215000-0000-0000-0000-000000000013")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth(user_id: uuid.UUID, org_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(user_id), email=None, claims={}, org_id=str(org_id))
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _clean(s):
+    for sql in [
+        f"DELETE FROM participation WHERE org_id IN ('{ORG}','{OTHER_ORG}')",
+        f"DELETE FROM participation_role WHERE org_id IN ('{ORG}','{OTHER_ORG}')",
+        f"DELETE FROM stories WHERE org_id IN ('{ORG}','{OTHER_ORG}')",
+        f"DELETE FROM team_members WHERE org_id IN ('{ORG}','{OTHER_ORG}')",
+        f"DELETE FROM project_access WHERE project_id IN "
+        f"(SELECT id FROM projects WHERE org_id IN ('{ORG}','{OTHER_ORG}'))",
+        f"DELETE FROM projects WHERE org_id IN ('{ORG}','{OTHER_ORG}')",
+        f"DELETE FROM org_members WHERE org_id IN ('{ORG}','{OTHER_ORG}')",
+        f"DELETE FROM users WHERE id IN ('{OWNER_USER}','{OUTSIDER_USER}')",
+        f"DELETE FROM organizations WHERE id IN ('{ORG}','{OTHER_ORG}')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _seed(s) -> tuple[uuid.UUID, uuid.UUID]:
+    """ORG(owner-floor만 가진 owner) + OTHER_ORG(무관 사용자, 스푸핑 후보). agent_om_id는
+    project grant 있는 정상 agent(③용). owner_om_id 반환."""
+    await _clean(s)
+    for sql in [
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES "
+        f"('{ORG}','O','d2215-org','free'),('{OTHER_ORG}','X','d2215-other','free')",
+        f"INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{OWNER_USER}','owner@d2215.test','x','Owner',true,true,0,false,0),"
+        f"('{OUTSIDER_USER}','outsider@d2215.test','x','Outsider',true,true,0,false,0)",
+        f"INSERT INTO projects (id,org_id,name,slug,violation_level) VALUES "
+        f"('{PROJ}','{ORG}','P','d2215-proj','warn'),"
+        f"('{AGENT_PROJ}','{ORG}','AP','d2215-agent-proj','warn')",
+    ]:
+        await s.execute(text(sql))
+    owner_row = (await s.execute(text(
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES "
+        f"(gen_random_uuid(),'{ORG}','{OWNER_USER}','owner') RETURNING id"
+    ))).one()
+    owner_om_id = owner_row[0]
+    outsider_row = (await s.execute(text(
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES "
+        f"(gen_random_uuid(),'{OTHER_ORG}','{OUTSIDER_USER}','owner') RETURNING id"
+    ))).one()
+    outsider_om_id = outsider_row[0]
+    # ⚠️owner_om_id는 의도적으로 team_members/project_access 어디에도 안 넣는다(owner-floor만).
+    await s.commit()
+    return owner_om_id, outsider_om_id
+
+
+async def _seed_agent_with_grant(s) -> uuid.UUID:
+    """③용 — project_access grant 有 정상 agent(team_members 뷰에 자연히 잡힘)."""
+    from app.models.team import TeamMember
+    agent = TeamMember(
+        id=uuid.uuid4(), org_id=ORG, project_id=AGENT_PROJ, type="agent", name="Agent",
+        is_active=True,
+    )
+    s.add(agent)
+    await s.flush()
+    await s.execute(text(
+        f"INSERT INTO project_access (id,project_id,member_id,permission) VALUES "
+        f"(gen_random_uuid(),'{AGENT_PROJ}','{agent.id}','granted')"
+    ))
+    await s.commit()
+    return agent.id
+
+
+async def _seed_story_with_participation(s, member_id: uuid.UUID, project_id: uuid.UUID) -> uuid.UUID:
+    from app.models.participation import Participation, ParticipationRole
+    story_id = uuid.uuid4()
+    await s.execute(text(
+        f"INSERT INTO stories (id,org_id,project_id,title,status,story_number,priority) VALUES "
+        f"('{story_id}','{ORG}','{project_id}','S','in-progress',"
+        f"(SELECT COALESCE(MAX(story_number),0)+1 FROM stories WHERE org_id='{ORG}'),'medium')"
+    ))
+    role_id = uuid.uuid4()
+    s.add(ParticipationRole(id=role_id, org_id=ORG, key="implementation", label="구현", is_default=True))
+    await s.flush()
+    s.add(Participation(id=uuid.uuid4(), org_id=ORG, story_id=story_id, member_id=member_id, role_id=role_id))
+    await s.commit()
+    return story_id
+
+
+@pytest.mark.anyio
+async def test_owner_floor_only_owner_can_report_done():
+    """① 결함이 있던 조건 그대로 — owner-floor만 가진 owner가 자기 이름으로 report-done 성공."""
+    from app.routers.workflow_report import ReportDoneRequest, report_done
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            owner_om_id, _ = await _seed(s)
+            story_id = await _seed_story_with_participation(s, owner_om_id, PROJ)
+        async with Session() as s:
+            body = ReportDoneRequest(
+                story_id=story_id, stage="merge", agent_id=owner_om_id,
+                context={"pr_number": 1, "repo": "x/y", "ci_result": "pass", "pr_result": "pass"},
+            )
+            resp = await report_done(
+                body=body, background_tasks=None, response=Response(),
+                session=s, org_id=ORG, auth=_auth(OWNER_USER, ORG),
+            )
+        # 핵심 단언: agent_id 검증에서 400이 안 났다(=owner-floor가 더 이상 거절되지 않음).
+        # h1_merge_gate_enabled 는 이 테스트 프로세스 기본값 False라 gate_decision 자체는
+        # None일 수 있음(그 축은 별개 관심사 — #2215가 겨냥한 건 agent_id 스푸핑 체크뿐).
+        assert resp.completed_stage == "merge"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_id_outside_org_still_400():
+    """② 스푸핑 방어 안 헐거워짐 — 다른 org 소속 member_id를 agent_id로 넣으면 여전히 400."""
+    from app.routers.workflow_report import ReportDoneRequest, report_done
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            owner_om_id, outsider_om_id = await _seed(s)
+            story_id = await _seed_story_with_participation(s, owner_om_id, PROJ)
+        async with Session() as s:
+            body = ReportDoneRequest(
+                story_id=story_id, stage="kickoff", agent_id=outsider_om_id,
+            )
+            with pytest.raises(HTTPException) as ei:
+                await report_done(
+                    body=body, background_tasks=None, response=Response(),
+                    session=s, org_id=ORG, auth=_auth(OWNER_USER, ORG),
+                )
+        assert ei.value.status_code == 400
+        assert "agent_id not found" in str(ei.value.detail)
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_normal_agent_with_grant_still_works():
+    """③ 되던 것이 계속 됨 — project_access grant 있는 정상 agent는 회귀 없이 통과."""
+    from app.routers.workflow_report import ReportDoneRequest, report_done
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            owner_om_id, _ = await _seed(s)
+            agent_id = await _seed_agent_with_grant(s)
+            story_id = await _seed_story_with_participation(s, agent_id, AGENT_PROJ)
+        async with Session() as s:
+            body = ReportDoneRequest(story_id=story_id, stage="kickoff", agent_id=agent_id)
+            resp = await report_done(
+                body=body, background_tasks=None, response=Response(),
+                session=s, org_id=ORG, auth=_auth(OWNER_USER, ORG),
+            )
+        assert resp.completed_stage == "kickoff"
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_2215_report_done_owner_floor_agent_id_realdb.py
+++ b/backend/tests/test_2215_report_done_owner_floor_agent_id_realdb.py
@@ -60,9 +60,9 @@ async def _clean(s):
         f"DELETE FROM participation WHERE org_id IN ('{ORG}','{OTHER_ORG}')",
         f"DELETE FROM participation_role WHERE org_id IN ('{ORG}','{OTHER_ORG}')",
         f"DELETE FROM stories WHERE org_id IN ('{ORG}','{OTHER_ORG}')",
-        f"DELETE FROM team_members WHERE org_id IN ('{ORG}','{OTHER_ORG}')",
         f"DELETE FROM project_access WHERE project_id IN "
         f"(SELECT id FROM projects WHERE org_id IN ('{ORG}','{OTHER_ORG}'))",
+        f"DELETE FROM members WHERE org_id IN ('{ORG}','{OTHER_ORG}')",
         f"DELETE FROM projects WHERE org_id IN ('{ORG}','{OTHER_ORG}')",
         f"DELETE FROM org_members WHERE org_id IN ('{ORG}','{OTHER_ORG}')",
         f"DELETE FROM users WHERE id IN ('{OWNER_USER}','{OUTSIDER_USER}')",
@@ -104,20 +104,21 @@ async def _seed(s) -> tuple[uuid.UUID, uuid.UUID]:
 
 
 async def _seed_agent_with_grant(s) -> uuid.UUID:
-    """③용 — project_access grant 有 정상 agent(team_members 뷰에 자연히 잡힘)."""
-    from app.models.team import TeamMember
-    agent = TeamMember(
-        id=uuid.uuid4(), org_id=ORG, project_id=AGENT_PROJ, type="agent", name="Agent",
-        is_active=True,
-    )
-    s.add(agent)
-    await s.flush()
+    """③용 — project_access grant 有 정상 agent. ⚠️team_members는 실 배포 스키마에서
+    UNION 뷰(members ⋈ project_access)라 직접 INSERT/DELETE 불가 — 실 base 테이블인
+    members + project_access(member_id 경유)에 심으면 뷰가 자연히 반영한다(#2206/#2515
+    계열 test_doc_mutation_project_scope_idor_realdb.py와 동일 관례)."""
+    agent_id = uuid.uuid4()
+    await s.execute(text(
+        f"INSERT INTO members (id,org_id,type,name,is_active) VALUES "
+        f"('{agent_id}','{ORG}','agent','Agent',true)"
+    ))
     await s.execute(text(
         f"INSERT INTO project_access (id,project_id,member_id,permission) VALUES "
-        f"(gen_random_uuid(),'{AGENT_PROJ}','{agent.id}','granted')"
+        f"(gen_random_uuid(),'{AGENT_PROJ}','{agent_id}','granted')"
     ))
     await s.commit()
-    return agent.id
+    return agent_id
 
 
 async def _seed_story_with_participation(s, member_id: uuid.UUID, project_id: uuid.UUID) -> uuid.UUID:

--- a/backend/tests/test_h1_s4_merge_gate_wiring.py
+++ b/backend/tests/test_h1_s4_merge_gate_wiring.py
@@ -46,6 +46,10 @@ async def _client():
     session = AsyncMock()
     result = MagicMock()
     result.scalar_one_or_none.return_value = _mock_story()
+    # #2215: agent_id 검증이 filter_org_member_ids(TeamMember ∪ OrgMember)로 바뀌어
+    # session.execute(...).scalars().all() 경로도 탄다 — 기존 단일 result 캐스케이드가
+    # 그 축도 만족하도록 AGENT_ID를 포함시킨다(story 조회용 scalar_one_or_none과 공존).
+    result.scalars.return_value.all.return_value = [AGENT_ID]
     session.execute = AsyncMock(return_value=result)
 
     async def override_db():

--- a/backend/tests/test_no_team_members_view_dml_in_tests.py
+++ b/backend/tests/test_no_team_members_view_dml_in_tests.py
@@ -1,0 +1,70 @@
+"""오르테가군 지시(2026-07-27, #2215 CI 2연속 재발 후): `team_members`는 실 배포 스키마에서
+`members ⋈ project_access` UNION 뷰다(baseline schema.sql) — UNION 뷰는 Postgres에서
+자동 갱신 불가라 DML(INSERT/UPDATE/DELETE)이 전부 실패한다. 로컬 `Base.metadata.create_all()`
+throwaway DB는 `TeamMember` 모델을 진짜 테이블로 만들어 이 DML이 로컬에서는 통과하지만, CI의
+공유 alembic-migrated DB(`pytest -m "not destructive_schema"` 스위트, ci.yml)에서는 항상
+깨진다 — 오늘 #2516과 #2215에서 각각 독립적으로 재현된 동일 결함 클래스.
+
+⛔"채팅에 교훈을 남기는 것"과 "다음 사람이 그 자리에 서 있는 것"은 다르다 — 이 파일은 후자를
+강제한다. 정적 grep 가드: `pytest.mark.destructive_schema`가 **아닌** 파일(=공유 baseline DB를
+쓰는 84개 파일) 안에서 `team_members`에 대한 DML(SQL 문자열) 또는 `TeamMember(...)` ORM
+생성자를 통한 삽입 시도가 하나도 없어야 한다. 대체 경로: 휴먼은 org_members(+선택적 members),
+에이전트는 members+project_access(member_id 경유) 직접 seed —
+`test_doc_mutation_project_scope_idor_realdb.py` 선례. `select(TeamMember...)`(읽기)는 허용.
+
+destructive_schema 마커 파일(story 8236bbc3)은 **자기 전용 격리 create_all DB**
+(`sprintable_test_iso`, ci.yml)를 쓰므로 거기서는 TeamMember가 진짜 쓰기 가능한 테이블이다 —
+이 가드가 잡으면 안 되는 정당한 축이라 명시 제외한다."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_TESTS_DIR = Path(__file__).parent
+
+# 이 가드 자신의 docstring/주석에 "team_members"·"TeamMember(" 문자열이 등장하므로 자기 자신은
+# 스캔에서 제외한다(설명 텍스트를 결함으로 오탐하는 것 방지).
+_SELF = Path(__file__)
+
+# ── 정당한 예외(이유 필수) ────────────────────────────────────────────────────
+# 문자열 리터럴이 "이 안티패턴이 코드에 없어야 한다"를 검증하는 대상이지, 실행되는 DML이
+# 아니다(라인-단위 정적 스캔이 문자열의 실행 여부를 못 가르는 한계 — 반대 방향 오탐).
+_ASSERTS_ABSENCE_ALLOWLIST = {
+    "test_auth_fallback_fix.py",
+    "test_e_entity_cleanup_s5_human_cleanup.py",
+}
+# story 8236bbc3: CI에서 의도적으로 전량 제외(자기 파일 docstring에 명시) — legacy cutover
+# parity 테스트, 이미 obsolete. 실행 자체가 안 되니 이 가드의 대상이 아니다.
+_CI_EXCLUDED_ALLOWLIST = {
+    "test_member_ssot_parity_realdb.py",
+}
+
+_SQL_DML_PATTERN = re.compile(
+    r"(?i)\b(INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+team_members\b"
+)
+# ORM 삽입: s.add(TeamMember(...)) / session.add(TeamMember(...)) — select(TeamMember...)는
+# 정상 읽기라 별개 패턴(add( 뒤에 바로 TeamMember( 가 와야만 매치).
+_ORM_INSERT_PATTERN = re.compile(r"\.add\(\s*TeamMember\(")
+_DESTRUCTIVE_SCHEMA_MARKER = re.compile(r"pytest\.mark\.destructive_schema")
+
+
+def test_no_team_members_view_dml_in_tests():
+    violations = []
+    for path in _TESTS_DIR.glob("*.py"):
+        if path == _SELF or path.name in _ASSERTS_ABSENCE_ALLOWLIST | _CI_EXCLUDED_ALLOWLIST:
+            continue
+        text = path.read_text()
+        if _DESTRUCTIVE_SCHEMA_MARKER.search(text):
+            continue  # 자기 전용 격리 create_all DB — TeamMember가 진짜 테이블.
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if _SQL_DML_PATTERN.search(line) or _ORM_INSERT_PATTERN.search(line):
+                violations.append(f"{path.name}:{lineno}: {line.strip()}")
+    assert not violations, (
+        "공유 baseline DB(non-destructive_schema)를 쓰는 파일에서 team_members DML 발견 — "
+        "team_members는 실 배포 스키마에서 UNION 뷰(members ⋈ project_access)라 "
+        "INSERT/UPDATE/DELETE가 전부 실패한다(로컬 create_all throwaway DB에서만 통과하고 "
+        "CI 실 스키마에서는 깨짐 — #2516·#2215 2연속 재발). "
+        "휴먼은 org_members(+members)를, 에이전트는 members+project_access(member_id 경유)를 "
+        "직접 seed할 것(destructive_schema 마커를 붙여 자기 전용 create_all DB로 격리하는 "
+        "것도 대안이나 원래 목적이 공유 DB 검증이면 그건 회피가 아니라 우회):\n" + "\n".join(violations)
+    )

--- a/backend/tests/test_no_team_members_view_dml_in_tests.py
+++ b/backend/tests/test_no_team_members_view_dml_in_tests.py
@@ -14,7 +14,16 @@ throwaway DB는 `TeamMember` 모델을 진짜 테이블로 만들어 이 DML이 
 
 destructive_schema 마커 파일(story 8236bbc3)은 **자기 전용 격리 create_all DB**
 (`sprintable_test_iso`, ci.yml)를 쓰므로 거기서는 TeamMember가 진짜 쓰기 가능한 테이블이다 —
-이 가드가 잡으면 안 되는 정당한 축이라 명시 제외한다."""
+이 가드가 잡으면 안 되는 정당한 축이라 명시 제외한다.
+
+⚠️이 가드가 못 잡는 것(오르테가군 지적, 2026-07-27): destructive_schema 파일의 `s.add(
+TeamMember(...))` 픽스처를 **그대로 복사**해 non-destructive 파일에 붙여넣으면, 붙여넣은
+그 순간엔 이 가드가 새 위반으로 즉시 잡는다 — 그런데 만약 그 복사가 파일 자체를
+`destructive_schema`로 마킹하면서 이뤄지면(마커까지 함께 복사) 가드는 그 파일을 통째로
+스캔 대상에서 제외해버려 **못 잡는다**. 오늘 #2515/#2519 재발이 정확히 이 경로였다 — "어딘가
+(다른 realdb 파일)에서 되던 패턴"을 그대로 옮겨 쓴 것. 마커 자체가 파일의 실제 DB 대상과
+일치하는지(정말 자기 전용 create_all이 필요한 테스트인지, 아니면 그냥 team_members를 건드리고
+싶어서 마커를 붙인 것인지)는 이 정적 스캔으로 판별 불가 — 코드 리뷰가 여전히 필요한 지점."""
 from __future__ import annotations
 
 import re

--- a/backend/tests/test_workflow_report.py
+++ b/backend/tests/test_workflow_report.py
@@ -100,6 +100,10 @@ async def test_kickoff_to_dev():
         story = _mock_story(status="ready-for-dev")
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = story
+        # #2215: agent_id 검증이 filter_org_member_ids(TeamMember ∪ OrgMember)로 바뀌어
+        # session.execute(...).scalars().all() 경로도 탄다 — 기존 단일 mock_result 캐스케이드가
+        # 그 축도 만족하도록 AGENT_ID를 포함시킨다(story 조회용 scalar_one_or_none과 공존).
+        mock_result.scalars.return_value.all.return_value = [AGENT_ID]
         session.execute = AsyncMock(return_value=mock_result)
 
         with patch("app.repositories.story.StoryRepository.update", new_callable=AsyncMock) as mock_update:
@@ -133,6 +137,10 @@ async def test_s20_line_active_blocks_non_merge_transition():
         story = _mock_story(status="ready-for-dev")
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = story
+        # #2215: agent_id 검증이 filter_org_member_ids(TeamMember ∪ OrgMember)로 바뀌어
+        # session.execute(...).scalars().all() 경로도 탄다 — 기존 단일 mock_result 캐스케이드가
+        # 그 축도 만족하도록 AGENT_ID를 포함시킨다(story 조회용 scalar_one_or_none과 공존).
+        mock_result.scalars.return_value.all.return_value = [AGENT_ID]
         session.execute = AsyncMock(return_value=mock_result)
         blocked = LineDecision(mode="blocked_by_policy", status_to_apply=None,
                                blocking_reason="workflow line blocks", http_status=409)
@@ -155,6 +163,10 @@ async def test_dev_to_review():
         story = _mock_story(status="in-progress")
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = story
+        # #2215: agent_id 검증이 filter_org_member_ids(TeamMember ∪ OrgMember)로 바뀌어
+        # session.execute(...).scalars().all() 경로도 탄다 — 기존 단일 mock_result 캐스케이드가
+        # 그 축도 만족하도록 AGENT_ID를 포함시킨다(story 조회용 scalar_one_or_none과 공존).
+        mock_result.scalars.return_value.all.return_value = [AGENT_ID]
         session.execute = AsyncMock(return_value=mock_result)
 
         with patch("app.repositories.story.StoryRepository.update", new_callable=AsyncMock) as mock_update:
@@ -187,6 +199,10 @@ async def test_merge_to_done():
         story = _mock_story(status="in-review")
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = story
+        # #2215: agent_id 검증이 filter_org_member_ids(TeamMember ∪ OrgMember)로 바뀌어
+        # session.execute(...).scalars().all() 경로도 탄다 — 기존 단일 mock_result 캐스케이드가
+        # 그 축도 만족하도록 AGENT_ID를 포함시킨다(story 조회용 scalar_one_or_none과 공존).
+        mock_result.scalars.return_value.all.return_value = [AGENT_ID]
         session.execute = AsyncMock(return_value=mock_result)
 
         auto = MergeGateDecision(
@@ -223,6 +239,10 @@ async def test_context_field_accepted():
         story = _mock_story()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = story
+        # #2215: agent_id 검증이 filter_org_member_ids(TeamMember ∪ OrgMember)로 바뀌어
+        # session.execute(...).scalars().all() 경로도 탄다 — 기존 단일 mock_result 캐스케이드가
+        # 그 축도 만족하도록 AGENT_ID를 포함시킨다(story 조회용 scalar_one_or_none과 공존).
+        mock_result.scalars.return_value.all.return_value = [AGENT_ID]
         session.execute = AsyncMock(return_value=mock_result)
 
         with patch("app.repositories.story.StoryRepository.update", new_callable=AsyncMock, return_value=story):
@@ -255,6 +275,10 @@ async def test_all_valid_stages():
             story = _mock_story()
             mock_result = MagicMock()
             mock_result.scalar_one_or_none.return_value = story
+            # #2215: agent_id 검증이 filter_org_member_ids(TeamMember ∪ OrgMember)로 바뀌어
+            # session.execute(...).scalars().all() 경로도 탄다 — 기존 단일 mock_result 캐스케이드가
+            # 그 축도 만족하도록 AGENT_ID를 포함시킨다(story 조회용 scalar_one_or_none과 공존).
+            mock_result.scalars.return_value.all.return_value = [AGENT_ID]
             session.execute = AsyncMock(return_value=mock_result)
 
             with patch("app.repositories.story.StoryRepository.update", new_callable=AsyncMock, return_value=story), \


### PR DESCRIPTION
## Summary
- story #2215(AC6 완주 중 발견·오르테가군 확定): `POST /workflow/report-done`의 agent_id 스푸핑 방지 체크(S20 finding #12 sibling)가 `team_members` VIEW(members ⋈ project_access **INNER JOIN**)만 조회 — org owner/admin은 명시 grant 없이 owner-floor(`has_project_access`의 admin_branch)로 접근하므로 이 뷰에 행이 없음
- 결과: **1인 창업자가 자기 스토리를 자기 이름으로 report-done 보고하면 "agent_id not found in this organization"(400)** — #2166과 동형의 OSS 온보딩 유입 손실
- 처방: 뷰는 무접촉(공용 자산·폭발 반경 큼) — 검증 쪽을 `filter_org_member_ids`(member_resolver.py, TeamMember ∪ OrgMember — 멘션/포크 cross-org 차단에 기존 사용 중인 SSOT)로 교체. 새 규칙 발명 0

## Test plan
- [x] realdb 가드 3종(`test_2215_report_done_owner_floor_agent_id_realdb.py`): ① owner-floor 통과(결함 조건 그대로) ② org 밖 agent_id 여전히 400(스푸핑 방어 유지) ③ project grant 있는 정상 agent 여전히 통과(회귀 없음)
- [x] 뮤테이션 자가검증: 옛 TeamMember 단독 체크로 되돌리면 ①만 정확히 예측한 400으로 RED, ②③은 그대로 GREEN(비-공허 확인) 후 복원
- [x] 기존 `test_workflow_report.py` 12건 전부 회귀 없음(mock 캐스케이드에 `.scalars().all()` 축 보강)
- [x] `test_authz_project_scope_coverage.py` 9건 회귀 없음

## 전수 스윕(오르테가군 지시 — 등재만, 이 PR 스코프 밖)
같은 클래스(`TeamMember` 직접 쿼리로 "조직 구성원인가" 판정)의 다른 콜사이트 확인:
- `app/routers/agent_runs.py:102` — `type=="agent"` 필터로 좁혀져 있어 무관(에이전트는 항상 grant 有)
- `app/routers/docs.py:285`,`342` — project-scoped 멤버십 체크(caller 자신), owner-floor caller가 동일 클래스로 403 받을 가능성 있는 **의심 자리** — 별도 확인 필요, 이 PR에서 손 안 댐
- `app/routers/sprints.py:424`, `app/services/workflow_fallback_notify.py:54` — 벌크 알림 대상 목록(TeamMember.type=='human')이라 owner-floor 휴먼이 알림 수신자 목록에서 누락될 수 있음(차단이 아닌 전달 누락 — 다른 성격의 갭), 이 PR에서 손 안 댐

🤖 Generated with [Claude Code](https://claude.com/claude-code)