### PR TITLE
fix(#2216): owner-floor 휴먼이 프로젝트를 「고를」 수 없던 두 겹 결함

### DIFF
--- a/backend/app/routers/current_project.py
+++ b/backend/app/routers/current_project.py
@@ -10,6 +10,7 @@ from app.models.project import Project
 from app.models.team import TeamMember
 from app.schemas.current_project import CurrentProjectResponse, SetCurrentProject
 from app.services.member_resolver import assert_caller_is_member
+from app.services.project_auth import has_project_access
 
 router = APIRouter(prefix="/api/v2/current-project", tags=["current-project", "Organization"])
 
@@ -56,17 +57,17 @@ async def set_current_project(
 ) -> CurrentProjectResponse:
     """S20(산티아고 재확인 대상 — S19 Phase C서 no-op으로 skip 판단했던 그 오라클을 authz-coverage
     스캐너가 재발견): member_id가 caller 본인인지 검증 없이 임의 member의 project 전환 결과
-    (project_name/org_id)를 열람할 수 있었다. self-scope 추가."""
+    (project_name/org_id)를 열람할 수 있었다. self-scope 추가.
+
+    #2216: 프로젝트 접근권 체크를 TeamMember(=team_members뷰, members ⋈ project_access
+    INNER JOIN) 단독 조회로 했더니 owner-floor 휴먼(명시 grant 없이 has_project_access의
+    admin_branch로만 접근하는 org owner/admin)이 자기 프로젝트를 "고르는" 이 엔드포인트에서
+    영구히 403을 맞았다 — #2212가 "프로젝트 못 정하면 org-briefing으로 보내 고르게 한다"고
+    고친 그 「고르는」 동작 자체가 벽이었다. has_project_access(project_auth.py, admin_branch
+    포함 4-branch SSOT)로 교체 — 새 규칙 발명 0, project_access.py/analytics.py 등 기존
+    project-scope 가드와 동일 판정."""
     await assert_caller_is_member(member_id, auth, session, org_id)
-    tm_r = await session.execute(
-        select(TeamMember.org_id).where(
-            TeamMember.id == member_id,
-            TeamMember.project_id == body.project_id,
-            TeamMember.is_active.is_(True),
-        )
-    )
-    org_id = tm_r.scalar_one_or_none()
-    if org_id is None:
+    if not await has_project_access(session, uuid.UUID(auth.user_id), body.project_id, org_id):
         raise HTTPException(status_code=403, detail="Project membership not found")
 
     proj_r = await session.execute(

--- a/backend/app/services/member_resolver.py
+++ b/backend/app/services/member_resolver.py
@@ -413,7 +413,23 @@ async def is_caller_member(
         ).limit(1)
     )
     row = result.first()
-    return row is not None and row[0] == caller_id
+    if row is not None:
+        return row[0] == caller_id
+    # #2216: team_members뷰(members ⋈ project_access INNER JOIN)는 owner-floor 휴먼
+    # (project_access grant 없이 has_project_access의 admin_branch로만 접근하는 org
+    # owner/admin)을 원천적으로 못 담는다 — 그 축은 TeamMember 조회가 항상 빈 채로
+    # 오는데, 그걸 곧장 "본인 아님"으로 오판하면 owner-floor 본인이 자기 자신을 대상으로
+    # 한 self-scope 호출(예: current-project 전환)에서 영구히 403을 맞는다. org_members
+    # SSOT(filter_org_member_ids와 동일 축 — member_id.py:508의 폴백과 동형)로 마지막
+    # 확인한다: member_id가 org_member.id이고 그 user_id가 caller 본인인가.
+    om_result = await session.execute(
+        select(OrgMember.user_id).where(
+            OrgMember.id == member_id, OrgMember.org_id == org_id,
+            OrgMember.deleted_at.is_(None),
+        ).limit(1)
+    )
+    om_row = om_result.first()
+    return om_row is not None and om_row[0] == caller_id
 
 
 async def assert_caller_is_member(

--- a/backend/tests/test_2216_current_project_owner_floor_realdb.py
+++ b/backend/tests/test_2216_current_project_owner_floor_realdb.py
@@ -1,0 +1,173 @@
+"""story #2216(#2215 AC 항목3 전수 스윕 중 발견·오르테가군 확定): `POST /current-project`
+(project 선택 — #2212의 "org-briefing으로 보내 고르게 한다" 처방이 최종적으로 기대는 그
+동작)이 owner-floor 휴먼(명시 project_access grant 없이 `has_project_access`의 admin_branch
+로만 접근하는 org owner/admin)을 **자기 자신조차 아니라고** 거절했다 — 두 겹의 결함:
+
+  ① `is_caller_member`(member_resolver.py, JWT 휴먼 분기)가 `team_members`뷰(members ⋈
+     project_access INNER JOIN)만 조회 — owner-floor는 이 뷰에 행이 없어 self-scope 체크
+     자체에서 먼저 403("Cannot act as another member")
+  ② ①을 통과해도 `set_current_project`의 project-membership 체크가 동일하게 TeamMember만
+     조회 — 403("Project membership not found")
+
+①은 assert_caller_is_member/is_caller_member 공용 함수라 current-project 외에도 광범위
+콜사이트가 있다(claim/heartbeat/lock류, 자기 docstring 언급) — 여기서 fix하면 그 축 전체가
+같이 풀린다. ②는 current_project.py 국소 — has_project_access(project_auth.py, admin_branch
+포함 4-branch SSOT)로 교체. 새 규칙 발명 0.
+
+⛔가드 3종 — 양성만 재고 닫지 않는다:
+  ① owner-floor 본인이 project 전환 성공(결함 있던 조건 그대로)
+  ② 타인의 member_id를 사칭하면 여전히 403(self-scope 방어 안 헐거워짐)
+  ③ 기존 team_member 기반(project-scoped) 휴먼은 여전히 정상 동작(회귀 없음)
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("d2216000-0000-0000-0000-000000000010")
+OWNER_USER = uuid.UUID("d2216000-0000-0000-0000-000000000011")
+OTHER_MEMBER_USER = uuid.UUID("d2216000-0000-0000-0000-000000000012")
+TM_HUMAN_USER = uuid.UUID("d2216000-0000-0000-0000-000000000013")
+PROJ = uuid.UUID("d2216000-0000-0000-0000-000000000014")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth(user_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(user_id), email=None, claims={}, org_id=str(ORG))
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _clean(s):
+    for sql in [
+        f"DELETE FROM project_access WHERE project_id IN "
+        f"(SELECT id FROM projects WHERE org_id='{ORG}')",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id IN ('{OWNER_USER}','{OTHER_MEMBER_USER}','{TM_HUMAN_USER}')",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _seed(s) -> dict[str, uuid.UUID]:
+    """owner-floor owner(①②용) + team_member 기반 정상 휴먼(③용, project grant 有)."""
+    await _clean(s)
+    for sql in [
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','O','d2216-org','free')",
+        f"INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{OWNER_USER}','owner@d2216.test','x','Owner',true,true,0,false,0),"
+        f"('{OTHER_MEMBER_USER}','other@d2216.test','x','Other',true,true,0,false,0),"
+        f"('{TM_HUMAN_USER}','tm@d2216.test','x','TM',true,true,0,false,0)",
+        f"INSERT INTO projects (id,org_id,name,slug,violation_level) VALUES "
+        f"('{PROJ}','{ORG}','P','d2216-proj','warn')",
+    ]:
+        await s.execute(text(sql))
+    owner_row = (await s.execute(text(
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES "
+        f"(gen_random_uuid(),'{ORG}','{OWNER_USER}','owner') RETURNING id"
+    ))).one()
+    owner_om_id = owner_row[0]
+    other_row = (await s.execute(text(
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES "
+        f"(gen_random_uuid(),'{ORG}','{OTHER_MEMBER_USER}','member') RETURNING id"
+    ))).one()
+    other_om_id = other_row[0]
+    # ③용 — 실 team_member(project grant 有) 휴먼. members + project_access(member_id 경유).
+    tm_member_id = uuid.uuid4()
+    await s.execute(text(
+        f"INSERT INTO members (id,org_id,user_id,type,name,is_active) VALUES "
+        f"('{tm_member_id}','{ORG}','{TM_HUMAN_USER}','human','TM',true)"
+    ))
+    await s.execute(text(
+        f"INSERT INTO project_access (id,project_id,member_id,permission) VALUES "
+        f"(gen_random_uuid(),'{PROJ}','{tm_member_id}','granted')"
+    ))
+    # ⚠️owner_om_id/other_om_id는 의도적으로 members/project_access 어디에도 안 넣는다
+    # (owner-floor만 — project_access grant 없이 접근).
+    await s.commit()
+    return {"owner_om": owner_om_id, "other_om": other_om_id, "tm_member": tm_member_id}
+
+
+@pytest.mark.anyio
+async def test_owner_floor_can_switch_to_own_project():
+    """① 결함이 있던 조건 그대로 — owner-floor 본인이 project 전환 성공."""
+    from app.routers.current_project import set_current_project
+    from app.schemas.current_project import SetCurrentProject
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            ids = await _seed(s)
+        async with Session() as s:
+            resp = await set_current_project(
+                body=SetCurrentProject(project_id=PROJ),
+                member_id=ids["owner_om"], session=s, org_id=ORG, auth=_auth(OWNER_USER),
+            )
+        assert resp.project_id == PROJ
+        assert resp.org_id == ORG
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_impersonating_another_members_id_still_403():
+    """② self-scope 방어 안 헐거워짐 — 타인의 member_id로 호출하면 여전히 403."""
+    from app.routers.current_project import set_current_project
+    from app.schemas.current_project import SetCurrentProject
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            ids = await _seed(s)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await set_current_project(
+                    body=SetCurrentProject(project_id=PROJ),
+                    # OWNER_USER가 other_om(타인)의 member_id를 사칭.
+                    member_id=ids["other_om"], session=s, org_id=ORG, auth=_auth(OWNER_USER),
+                )
+        assert ei.value.status_code == 403
+        assert "Cannot act as another member" in str(ei.value.detail)
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_team_member_based_human_still_works():
+    """③ 되던 것이 계속 됨 — project grant 있는 정상 team_member 휴먼은 회귀 없이 통과."""
+    from app.routers.current_project import set_current_project
+    from app.schemas.current_project import SetCurrentProject
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            ids = await _seed(s)
+        async with Session() as s:
+            resp = await set_current_project(
+                body=SetCurrentProject(project_id=PROJ),
+                member_id=ids["tm_member"], session=s, org_id=ORG, auth=_auth(TM_HUMAN_USER),
+            )
+        assert resp.project_id == PROJ
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_sweep_multiproject_teammember_services.py
+++ b/backend/tests/test_sweep_multiproject_teammember_services.py
@@ -11,8 +11,18 @@ CRASH → .limit(1)(전 행 동형 컬럼 소비):
   - ownership.assert_agent_owner                               (created_by ownership guard)
 
 SAFE(project_id == 필터로 1행 확정·무변경):
-  - current_project.set_current_project / reward.create_reward
-"""
+  - reward.create_reward
+
+ELIMINATED(#2216, 2026-07-27 재분류 — 지우지 않고 옮김): current_project.set_current_project는
+더 이상 이 카탈로그의 대상이 아니다. 원래 "SAFE" 분류는 "TeamMember를 쓰되 project_id==필터로
+1행 확정해서 안전"이었는데, #2216이 owner-floor 휴먼(명시 project_access grant 없이
+has_project_access의 admin_branch로만 접근 — team_members뷰엔 행 자체가 없음)을 이 필터가
+"멤버 아님"으로 오판하는 걸 발견해 TeamMember 조회 자체를 has_project_access 호출로 교체했다.
+multi-project 행이 여러 개 잡힐 위험은 "필터로 좁혀서" 없앤 게 아니라 "그 조회 자체가 없어져서"
+구조적으로 성립하지 않는다 — 옛 SAFE보다 강한 상태(TeamMember 스캔 대상에서 아예 이탈).
+⚠️이 재분류가 못 보는 것: has_project_access로 갈아탄 자리는 이 스윕이 더는 감시하지 않는다 —
+그쪽 판정(project_auth.py 4-branch)이 나중에 틀리면 이 가드는 침묵한다(별도 축 —
+test_authz_project_scope_coverage.py가 그 축을 감시)."""
 from __future__ import annotations
 
 import inspect
@@ -48,7 +58,6 @@ def test_teammember_scalar_site_has_limit(name: str):
 
 
 @pytest.mark.parametrize("module,fn,expr", [
-    ("app.routers.current_project", "set_current_project", "TeamMember.project_id == body.project_id"),
     ("app.repositories.reward", None, "TeamMember.project_id == project_id"),
 ])
 def test_safe_sites_disambiguated_by_project_filter(module: str, fn: str, expr: str):
@@ -58,3 +67,20 @@ def test_safe_sites_disambiguated_by_project_filter(module: str, fn: str, expr: 
     mod = importlib.import_module(module)
     src = inspect.getsource(mod)
     assert expr in src, f"{module}: '{expr}' disambig 필터 사라짐 — 재분류 필요(이제 crash-prone)"
+
+
+def test_current_project_set_current_project_no_longer_queries_team_member():
+    """#2216 재분류 확인축 — set_current_project가 TeamMember를 아예 안 쓰는지 양성 확인.
+    이게 다시 TeamMember 쿼리를 쓰게 되면(예: 누가 "일관성" 명목으로 되돌리면) multi-project
+    disambig 위험이 재도입되므로 이 테스트가 잡아야 한다 — has_project_access 사용도 함께 고정."""
+    from app.routers import current_project
+
+    src = inspect.getsource(current_project.set_current_project)
+    # select(TeamMember...) 실행 쿼리 부재만 본다 — docstring/주석의 "TeamMember" 단어 언급은
+    # 오탐(#2216 재분류 사유를 설명하는 텍스트 그 자체가 "TeamMember"를 담고 있음).
+    assert "select(TeamMember" not in src, (
+        "set_current_project가 다시 TeamMember를 쿼리한다 — #2216 재분류 전제(TeamMember 조회 "
+        "자체 이탈)가 깨졌다. multi-project disambig 위험이 재도입됐을 수 있으니 owner-floor "
+        "가드(test_2216_current_project_owner_floor_realdb.py)까지 함께 재확인할 것."
+    )
+    assert "has_project_access" in src


### PR DESCRIPTION
## Summary
- #2212가 "프로젝트 못 정하면 org-briefing으로 보내 고르게 한다"고 고친 그 「고르는」 동작(`POST /current-project`) 자체가 owner-floor 휴먼(명시 `project_access` grant 없이 `has_project_access`의 admin_branch로만 접근하는 org owner/admin)에게 벽이었음 — 안내를 따라가도 또 막히는, 404보다 나쁠 수 있는 자리
- 두 겹 결함, AC5(#2212 미확인 후보 ⓑ "쿠키가 한 번도 SET된 적 없는 계정")와 직결:
  1. `is_caller_member`(member_resolver.py, JWT 휴먼 분기)가 `team_members`뷰(members ⋈ project_access **INNER JOIN**)만 조회 — owner-floor는 이 뷰에 행이 없어 self-scope 체크 자체에서 먼저 403("Cannot act as another member"). `org_members` SSOT 폴백 추가(`filter_org_member_ids`와 동일 축) — claim/heartbeat/lock류 등 이 공용 함수의 다른 콜사이트도 함께 풀림
  2. ①을 통과해도 `set_current_project`의 project-membership 체크가 동일하게 TeamMember만 조회 — 403("Project membership not found"). `has_project_access`(admin_branch 포함 4-branch SSOT)로 교체

## Test plan
- [x] realdb 가드 3종(`test_2216_current_project_owner_floor_realdb.py`): ① owner-floor 본인 전환 성공(결함 조건 그대로) ② 타인 member_id 사칭 여전히 403(self-scope 방어 유지) ③ 기존 team_member 기반 휴먼 여전히 정상(회귀 없음)
- [x] 두 레이어 각각 독립 뮤테이션 자가검증 — 예측한 정확한 실패로 RED 확인 후 복원
- [x] `bootstrap.py`(alembic upgrade heads)로 세운 실 baseline 스키마(뷰 포함) DB에서 검증(create_all throwaway와 실 스키마 드리프트를 이번엔 처음부터 배제)
- [x] `is_caller_member`/`assert_caller_is_member` 광범위 소비자(rewards/eventbus/claim/heartbeat/trust-score 등 11개 파일, 164 테스트) 회귀 없음
- [x] `test_authz_project_scope_coverage.py` 9건 회귀 없음(`has_project_access`는 기존 인식 어휘라 확장 불요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)