### PR TITLE
[SID:2214] 문서 코드블럭 가로 스크롤 — TipTap base pre-wrap 코드블럭만 덮기

### DIFF
--- a/apps/web/src/app/globals-scrollbar.test.ts
+++ b/apps/web/src/app/globals-scrollbar.test.ts
@@ -41,6 +41,33 @@ describe('.tableWrapper(TipTap 테이블 노드뷰 기본 클래스)가 실제�
   });
 });
 
+describe('문서 코드블럭이 실제로 "굴러갈 수 있다" — .ProseMirror pre-wrap을 코드블럭만 덮는다 (#2214)', () => {
+  it('.ProseMirror .scrollbar-visible pre가 white-space:pre로 덮는다(라이브러리 base pre-wrap 무력화)', () => {
+    expect(css).toMatch(/\.ProseMirror \.scrollbar-visible pre\s*\{[^}]*white-space:\s*pre[^-]/);
+  });
+
+  it('overflow-wrap도 normal로 되돌린다(조상 .ProseMirror의 break-word 상속 차단)', () => {
+    expect(css).toMatch(/\.ProseMirror \.scrollbar-visible pre\s*\{[^}]*overflow-wrap:\s*normal/);
+  });
+
+  it('⛔안전장치 — max-width:100%+min-width:0이 white-space:pre보다 먼저 나온다(#2035류 body 밀림 방지)', () => {
+    const safetyIdx = css.indexOf('.ProseMirror .scrollbar-visible {');
+    const bodyIdx = css.indexOf('.ProseMirror .scrollbar-visible pre {');
+    expect(safetyIdx).toBeGreaterThan(-1);
+    expect(bodyIdx).toBeGreaterThan(-1);
+    expect(safetyIdx).toBeLessThan(bodyIdx);
+    const safetyBlock = css.slice(safetyIdx, bodyIdx);
+    expect(safetyBlock).toMatch(/max-width:\s*100%/);
+    expect(safetyBlock).toMatch(/min-width:\s*0/);
+  });
+
+  it('산문·인용·표 selector는 이 규칙에 안 걸린다(코드블럭 scrollbar-visible 래퍼만 특이도를 올림)', () => {
+    // .ProseMirror .scrollbar-visible 자체가 code-block-copy.tsx 전용 클래스 조합이라, 이
+    // selector 문자열 자체에 prose(p)나 blockquote·table 태그가 안 섞여 있어야 한다.
+    expect(css).not.toMatch(/\.ProseMirror \.scrollbar-visible[^{]*[,\s](p|blockquote|table)[,\s{]/);
+  });
+});
+
 describe('코드블럭/표 wrapper가 scrollbar-visible을 잃지 않았다 (#2165)', () => {
   const files = [
     'docs/extensions/code-block-copy.tsx',

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -516,6 +516,27 @@
   .tableWrapper {
     overflow-x: auto;
   }
+
+  /* story #2214(유나 판정, 2026-07-27) — "굴린다. 코드블럭만." TipTap/ProseMirror base CSS
+     (.ProseMirror { overflow-wrap: break-word } · .ProseMirror pre { white-space: pre-wrap })가
+     모든 <pre>를 강제로 접어, #2165가 코드블럭에 준 .scrollbar-visible 예외가 애초에 발동할
+     조건(가로 오버플로) 자체를 못 만들고 있었다(#2214 조사 — "스크롤바가 안 보인다"가 아니라
+     "스크롤할 일이 생길 수 없다"). code-block-copy.tsx가 코드블럭에만 부착하는
+     `.scrollbar-visible` 래퍼를 `.ProseMirror` 조상과 함께 잡아 특이도를 올려 라이브러리 base
+     규칙을 덮는다 — 산문·인용·inline code·표(#2203에서 이미 별도 처리)는 이 selector에
+     걸리지 않아 무접촉.
+     ⛔순서 필수: max-width:100%+min-width:0(레이아웃 안전장치, #2035류 body 밀림 방지)을
+     white-space:pre(본체, 실제로 굴러가게 하는 것)보다 먼저 건다 — 안 그러면 굴러가긴 하는데
+     컨테이너를 못 벗어나는 게 아니라 body 전체를 밀어내는 상태를 한 번 만들고 고치게 된다. */
+  .ProseMirror .scrollbar-visible {
+    max-width: 100%;
+    min-width: 0;
+  }
+  .ProseMirror .scrollbar-visible pre {
+    white-space: pre;
+    overflow-wrap: normal;
+  }
+
   .scrollbar-visible,
   .doc-renderer pre,
   .tableWrapper {


### PR DESCRIPTION
## 요약
유나 판정(2026-07-27, 확定): **접지 않고 굴린다 — 코드블럭만.** 근거: 코드는 형태가 곧 의미(들여쓰기 무너지면 안 됨), #2165 선생님 원문이 이걸 전제, GitHub/IDE 관례.

## 근본원인
`.ProseMirror pre { white-space: pre-wrap }` + `.ProseMirror { overflow-wrap: break-word }` — TipTap/ProseMirror **라이브러리 base CSS**(우리 소스 grep 0건)가 모든 `<pre>`를 넘치기 전에 강제로 접어, #2165가 코드블럭에 준 `.scrollbar-visible` 예외가 발동할 조건(가로 오버플로) 자체를 못 만들고 있었다.

## 처방
```css
.ProseMirror .scrollbar-visible {
  max-width: 100%;
  min-width: 0;
}
.ProseMirror .scrollbar-visible pre {
  white-space: pre;
  overflow-wrap: normal;
}
```
`.ProseMirror .scrollbar-visible`(code-block-copy.tsx가 코드블럭에만 부착하는 조합)로 특이도를 올려 라이브러리 base 규칙만 정확히 덮는다 — 산문·인용·inline code·표(#2203에서 이미 별도 처리)는 이 selector에 안 걸려 무접촉. 유나 안전장치 순서 준수: `max-width:100%`+`min-width:0`(레이아웃, #2035류 body 밀림 방지)을 `white-space:pre`(본체)보다 먼저.

## AC5 — 다른 렌더러 서베이
채팅(`chat-bubble.tsx`)은 이미 `whitespace-pre-wrap`+`overflow-wrap:anywhere`로 "접기"를 **의도적으로 선택한 기존 설계**(코드가 wrap되는 걸 전제로 pre에 overflow-x-auto를 belt-and-suspenders로 둔 것, 코드 주석에 명시돼 있음) — docs와는 다른 결정이 이미 서 있어 이 스토리에서 손대지 않음. 채팅도 "굴린다"로 통일할지는 별도 판단 필요하면 알려주기 바람.

## 테스트
`globals-scrollbar.test.ts`에 4건 신설(mutation 확認 완료 — 되돌리면 각각 RED): white-space:pre 존재·overflow-wrap:normal 존재·안전장치 선순위·prose/table 미접촉. 전체 vitest 314 files/2094 passed. build/lint clean.

## Test plan
- [ ] develop 배포 후 라이브: 긴 코드 한 줄이 실제로 가로 스크롤되고 스크롤바가 보이는지(#2203에서 못 세웠던 축) — `qa-2165-overflow-probe-temp` 문서 재사용
- [ ] 모바일 390px에서 body가 안 밀리는지(#2035 재발 확인)
- [ ] 산문/인용/표는 무회귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)