### PR TITLE
fix(#2216): 잔여 두 자리 — ws_chat.py·workflow_executions.py

### DIFF
--- a/backend/app/routers/workflow_executions.py
+++ b/backend/app/routers/workflow_executions.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id, require_admin
 from app.dependencies.database import get_db
 from app.models.agent_routing_rule import AgentRoutingRule
+from app.models.project import OrgMember
 from app.models.team import TeamMember
 from app.models.workflow_execution_log import WorkflowExecutionLog
 
@@ -136,7 +137,24 @@ async def list_executions(
                 or_(TeamMember.user_id == user_uuid, TeamMember.id == user_uuid),
             ).limit(1)
         )
-        if not member_check.scalar_one_or_none():
+        is_self = member_check.scalar_one_or_none() is not None
+        if not is_self:
+            # #2216: team_members뷰(members ⋈ project_access INNER JOIN)는 grant-only/
+            # owner-floor 휴먼(명시 project_access grant를 org_member_id 경유로만 가진
+            # non-admin/owner 멤버 포함)을 이 뷰에 행이 없다는 이유로 못 찾는다 — 자기
+            # 자신의 실행 이력을 조회하려 해도 "본인 아님"으로 오판됐다. org_members
+            # SSOT(filter_org_member_ids와 동일 축)로 폴백 — member_id가 caller 본인의
+            # org_member.id이고 그 user_id가 caller와 일치하는지 확認.
+            om_check = await db.execute(
+                select(OrgMember.id).where(
+                    OrgMember.id == member_id,
+                    OrgMember.org_id == org_id,
+                    OrgMember.user_id == user_uuid,
+                    OrgMember.deleted_at.is_(None),
+                ).limit(1)
+            )
+            is_self = om_check.scalar_one_or_none() is not None
+        if not is_self:
             raise HTTPException(status_code=403, detail="Can only query own executions")
 
     base = (

--- a/backend/app/routers/ws_chat.py
+++ b/backend/app/routers/ws_chat.py
@@ -15,10 +15,13 @@ from sqlalchemy import and_, select
 
 from sqlalchemy.exc import IntegrityError
 
+from dataclasses import dataclass
+
 from app.core.database import async_session_factory
 from app.core.security import JWTError, decode_jwt, hash_token
 from app.models.api_key import ApiKey
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
+from app.models.project import OrgMember
 from app.models.team import TeamMember
 
 logger = logging.getLogger(__name__)
@@ -28,7 +31,16 @@ router = APIRouter(tags=["ws-chat", "Organization"])
 _rooms: dict[str, set[WebSocket]] = defaultdict(set)
 
 
-async def _authenticate(api_key: str | None, token: str | None) -> TeamMember | None:
+@dataclass(frozen=True)
+class _CallerIdentity:
+    """#2216: owner-floor 휴먼(team_members뷰에 행 없음)용 최소 caller 신원 — 이 라우터가
+    실제로 쓰는 필드(.id/.org_id)만 담는다. TeamMember와 duck-type 호환(caller.id/caller.org_id
+    로만 소비됨, 아래 ws_chat_hub 참조)."""
+    id: uuid.UUID
+    org_id: uuid.UUID
+
+
+async def _authenticate(api_key: str | None, token: str | None) -> TeamMember | _CallerIdentity | None:
     """Query param API Key 또는 JWT로 TeamMember 반환. 실패 시 None."""
     now = datetime.now(timezone.utc)
     async with async_session_factory() as db:
@@ -67,11 +79,26 @@ async def _authenticate(api_key: str | None, token: str | None) -> TeamMember | 
                 uid = uuid.UUID(user_id)
             except ValueError:
                 return None
-            return (await db.execute(
+            tm = (await db.execute(
                 select(TeamMember)
                 .where(TeamMember.user_id == uid)
                 .where(TeamMember.is_active.is_(True))
             )).scalars().first()
+            if tm is not None:
+                return tm
+            # #2216: team_members뷰(members ⋈ project_access INNER JOIN)는 owner-floor
+            # 휴먼(명시 project_access grant 없이 has_project_access의 admin_branch로만
+            # 접근하는 org owner/admin)을 이 뷰에 행이 없다는 이유로 못 찾는다 — 그 결과
+            # owner-floor는 WS 채팅에 아예 접속하지 못했다(Unauthorized). org_members
+            # SSOT(filter_org_member_ids와 동일 축)로 폴백 — 이 라우터가 caller에서 실제로
+            # 쓰는 필드(.id/.org_id)만 있으면 되므로 최소 dataclass로 충분(TeamMember 전체
+            # 필드 불필요).
+            om = (await db.execute(
+                select(OrgMember.id, OrgMember.org_id).where(
+                    OrgMember.user_id == uid, OrgMember.deleted_at.is_(None),
+                )
+            )).first()
+            return _CallerIdentity(id=om.id, org_id=om.org_id) if om is not None else None
 
     return None
 

--- a/backend/tests/test_2216_workflow_executions_owner_floor_realdb.py
+++ b/backend/tests/test_2216_workflow_executions_owner_floor_realdb.py
@@ -1,0 +1,164 @@
+"""story #2216(#2215 AC 항목3 전수 스윕 CONFIRMED-SUSPECT): `GET /workflow-executions`의
+self-scope 체크(`role not in ("admin","owner")`일 때 caller가 자기 자신의 member_id로만
+조회하는지 검증)가 `TeamMember`(=team_members뷰, members ⋈ project_access INNER JOIN)
+단독 조회를 썼다 — grant-only 휴먼(명시 project_access grant를 org_member_id 경유로만
+가진, team_members/members 행이 없는 member)이 자기 자신의 실행 이력을 조회하려 해도
+"Can only query own executions"(403)으로 오판됐다.
+
+처방: TeamMember 조회가 빈 채로 오면 org_members SSOT(filter_org_member_ids와 동일 축)로
+폴백 — member_id가 caller 본인의 org_member.id이고 그 user_id가 caller와 일치하는지 확認.
+새 규칙 발명 0.
+
+가드 3종:
+  ① grant-only 휴먼이 자기 member_id로 자기 실행이력 조회 성공(결함이 있던 조건 그대로)
+  ② 타인의 member_id로 조회하면 여전히 403(self-scope 방어 안 헐거워짐)
+  ③ 기존 team_member 기반(project grant 有) 휴먼은 여전히 정상 동작(회귀 없음)
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("d2216d00-0000-0000-0000-000000000010")
+GRANT_ONLY_USER = uuid.UUID("d2216d00-0000-0000-0000-000000000011")
+OTHER_USER = uuid.UUID("d2216d00-0000-0000-0000-000000000012")
+TM_HUMAN_USER = uuid.UUID("d2216d00-0000-0000-0000-000000000013")
+PROJ = uuid.UUID("d2216d00-0000-0000-0000-000000000014")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth(user_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(user_id), email=None,
+        claims={"app_metadata": {"org_id": str(ORG), "role": "member"}},
+        org_id=str(ORG),
+    )
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _clean(s):
+    for sql in [
+        f"DELETE FROM project_access WHERE project_id IN "
+        f"(SELECT id FROM projects WHERE org_id='{ORG}')",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id IN ('{GRANT_ONLY_USER}','{OTHER_USER}','{TM_HUMAN_USER}')",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _seed(s) -> dict[str, uuid.UUID]:
+    await _clean(s)
+    for sql in [
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','O','d2216d-org','free')",
+        f"INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{GRANT_ONLY_USER}','grantonly@d2216d.test','x','GrantOnly',true,true,0,false,0),"
+        f"('{OTHER_USER}','other@d2216d.test','x','Other',true,true,0,false,0),"
+        f"('{TM_HUMAN_USER}','tm@d2216d.test','x','TM',true,true,0,false,0)",
+        f"INSERT INTO projects (id,org_id,name,slug,violation_level) VALUES "
+        f"('{PROJ}','{ORG}','P','d2216d-proj','warn')",
+    ]:
+        await s.execute(text(sql))
+    grant_only_row = (await s.execute(text(
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES "
+        f"(gen_random_uuid(),'{ORG}','{GRANT_ONLY_USER}','member') RETURNING id"
+    ))).one()
+    other_row = (await s.execute(text(
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES "
+        f"(gen_random_uuid(),'{ORG}','{OTHER_USER}','member') RETURNING id"
+    ))).one()
+    tm_member_id = uuid.uuid4()
+    await s.execute(text(
+        f"INSERT INTO members (id,org_id,user_id,type,name,is_active) VALUES "
+        f"('{tm_member_id}','{ORG}','{TM_HUMAN_USER}','human','TM',true)"
+    ))
+    await s.execute(text(
+        f"INSERT INTO project_access (id,project_id,member_id,permission) VALUES "
+        f"(gen_random_uuid(),'{PROJ}','{tm_member_id}','granted')"
+    ))
+    # ⚠️GRANT_ONLY_USER/OTHER_USER: members/team_members 어디에도 안 넣음(team_member 행 없음).
+    await s.commit()
+    return {"grant_only_om": grant_only_row[0], "other_om": other_row[0], "tm_member": tm_member_id}
+
+
+@pytest.mark.anyio
+async def test_grant_only_member_can_query_own_executions():
+    """① grant-only 휴먼이 자기 member_id로 자기 실행이력 조회 성공(결함 있던 조건 그대로)."""
+    from app.routers.workflow_executions import list_executions
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            ids = await _seed(s)
+        async with Session() as s:
+            out = await list_executions(
+                project_id=PROJ, event_type=None, status=None, story_id=None,
+                member_id=ids["grant_only_om"], offset=0, limit=20,
+                db=s, org_id=ORG, auth=_auth(GRANT_ONLY_USER),
+            )
+        assert out.items == []  # 실행 이력은 안 심었음 — 403 안 났다는 것 자체가 이 테스트의 요지.
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_other_member_id_still_403():
+    """② 타인의 member_id로 조회하면 여전히 403(self-scope 방어 안 헐거워짐)."""
+    from app.routers.workflow_executions import list_executions
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            ids = await _seed(s)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await list_executions(
+                    project_id=PROJ, event_type=None, status=None, story_id=None,
+                    member_id=ids["other_om"], offset=0, limit=20,
+                    db=s, org_id=ORG, auth=_auth(GRANT_ONLY_USER),
+                )
+        assert ei.value.status_code == 403
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_team_member_based_human_still_works():
+    """③ 되던 것이 계속 됨 — project grant 있는 정상 team_member 휴먼은 무회귀."""
+    from app.routers.workflow_executions import list_executions
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            ids = await _seed(s)
+        async with Session() as s:
+            out = await list_executions(
+                project_id=PROJ, event_type=None, status=None, story_id=None,
+                member_id=ids["tm_member"], offset=0, limit=20,
+                db=s, org_id=ORG, auth=_auth(TM_HUMAN_USER),
+            )
+        assert out.items == []
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_2216_ws_chat_owner_floor_realdb.py
+++ b/backend/tests/test_2216_ws_chat_owner_floor_realdb.py
@@ -1,0 +1,177 @@
+"""story #2216(#2215 AC 항목3 전수 스윕 CONFIRMED-SUSPECT): `ws_chat.py`의 `_authenticate`
+(WS `/ws/chat/{agent_id}` JWT 휴먼 분기)가 `TeamMember`(=team_members뷰, members ⋈
+project_access INNER JOIN) 단독 조회로 caller 신원을 해소했다 — owner-floor 휴먼(명시
+project_access grant 없이 has_project_access의 admin_branch로만 접근하는 org owner/admin)
+은 이 뷰에 행이 없어 `_authenticate`가 `None`을 반환 → WS 연결 자체가 Unauthorized(4001)로
+거부됐다.
+
+처방: TeamMember 조회가 빈 채로 오면 org_members SSOT(filter_org_member_ids와 동일 축)로
+폴백 — 이 라우터가 caller에서 실제로 쓰는 필드(.id/.org_id)만 담는 최소 dataclass로 반환.
+새 규칙 발명 0.
+
+가드 3종:
+  ① owner-floor 휴먼이 _authenticate로 정상 신원 해소(결함이 있던 조건 그대로)
+  ② 유효하지 않은/미소속 사용자는 여전히 None(방어 안 헐거워짐)
+  ③ 기존 team_member 기반(project grant 有) 휴먼은 여전히 정상 동작(회귀 없음)
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+ORG = uuid.UUID("d2216c00-0000-0000-0000-000000000010")
+OWNER_USER = uuid.UUID("d2216c00-0000-0000-0000-000000000011")
+TM_HUMAN_USER = uuid.UUID("d2216c00-0000-0000-0000-000000000012")
+UNKNOWN_USER = uuid.UUID("d2216c00-0000-0000-0000-000000000013")
+PROJ = uuid.UUID("d2216c00-0000-0000-0000-000000000014")
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _clean(s):
+    for sql in [
+        f"DELETE FROM project_access WHERE project_id IN "
+        f"(SELECT id FROM projects WHERE org_id='{ORG}')",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id IN ('{OWNER_USER}','{TM_HUMAN_USER}')",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _seed(s) -> uuid.UUID:
+    await _clean(s)
+    for sql in [
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','O','d2216c-org','free')",
+        f"INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{OWNER_USER}','owner@d2216c.test','x','Owner',true,true,0,false,0),"
+        f"('{TM_HUMAN_USER}','tm@d2216c.test','x','TM',true,true,0,false,0)",
+        f"INSERT INTO projects (id,org_id,name,slug,violation_level) VALUES "
+        f"('{PROJ}','{ORG}','P','d2216c-proj','warn')",
+    ]:
+        await s.execute(text(sql))
+    owner_row = (await s.execute(text(
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES "
+        f"(gen_random_uuid(),'{ORG}','{OWNER_USER}','owner') RETURNING id"
+    ))).one()
+    owner_om_id = owner_row[0]
+    tm_member_id = uuid.uuid4()
+    await s.execute(text(
+        f"INSERT INTO members (id,org_id,user_id,type,name,is_active) VALUES "
+        f"('{tm_member_id}','{ORG}','{TM_HUMAN_USER}','human','TM',true)"
+    ))
+    await s.execute(text(
+        f"INSERT INTO project_access (id,project_id,member_id,permission) VALUES "
+        f"(gen_random_uuid(),'{PROJ}','{tm_member_id}','granted')"
+    ))
+    # ⚠️OWNER_USER: members/project_access 어디에도 안 넣음(owner-floor만).
+    await s.commit()
+    return owner_om_id
+
+
+@pytest.mark.anyio
+async def test_authenticate_owner_floor_resolves_identity():
+    """① owner-floor 휴먼이 _authenticate로 정상 신원 해소(결함이 있던 조건 그대로)."""
+    from app.core.security import create_access_token
+    from app.routers.ws_chat import _authenticate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            owner_om_id = await _seed(s)
+        token = create_access_token(user_id=str(OWNER_USER))
+        # _authenticate는 app.core.database.async_session_factory(모듈-레벨 전역 engine)를
+        # 직접 쓴다 — pytest-anyio는 테스트마다 새 event loop를 돌려 전역 engine과 루프가
+        # 어긋난다("attached to a different loop"). 이 테스트 자신의 loop에 바인딩된
+        # Session으로 패치(test_2139_presence_recipient_source_realdb.py 선례와 동일 관례).
+        import contextlib
+        import unittest.mock
+
+        @contextlib.asynccontextmanager
+        async def _factory():
+            async with Session() as s2:
+                yield s2
+
+        with unittest.mock.patch("app.routers.ws_chat.async_session_factory", _factory):
+            caller = await _authenticate(api_key=None, token=token)
+        assert caller is not None
+        assert caller.id == owner_om_id
+        assert caller.org_id == ORG
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_authenticate_unknown_user_still_none():
+    """② org에 없는 사용자는 여전히 인증 실패(방어 안 헐거워짐)."""
+    from app.core.security import create_access_token
+    from app.routers.ws_chat import _authenticate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        token = create_access_token(user_id=str(UNKNOWN_USER))
+        import contextlib
+        import unittest.mock
+
+        @contextlib.asynccontextmanager
+        async def _factory():
+            async with Session() as s2:
+                yield s2
+
+        with unittest.mock.patch("app.routers.ws_chat.async_session_factory", _factory):
+            caller = await _authenticate(api_key=None, token=token)
+        assert caller is None
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_authenticate_team_member_still_works():
+    """③ 되던 것이 계속 됨 — project grant 있는 정상 team_member 휴먼은 무회귀."""
+    from app.core.security import create_access_token
+    from app.routers.ws_chat import _authenticate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        token = create_access_token(user_id=str(TM_HUMAN_USER))
+        import contextlib
+        import unittest.mock
+
+        @contextlib.asynccontextmanager
+        async def _factory():
+            async with Session() as s2:
+                yield s2
+
+        with unittest.mock.patch("app.routers.ws_chat.async_session_factory", _factory):
+            caller = await _authenticate(api_key=None, token=token)
+        assert caller is not None
+        assert caller.org_id == ORG
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## Summary
- #2216 전수 스윕 CONFIRMED-SUSPECT 잔여 마감(마지막 두 자리) — `current_project.py`(#2521), `docs.py`(#2523)에 이어
- `ws_chat.py:71` `_authenticate`(WS `/ws/chat/{agent_id}` JWT 휴먼 분기): owner-floor 휴먼은 WS 채팅 자체에 접속 불가(Unauthorized 4001)했음 — org_members SSOT 폴백 + 이 라우터가 실제로 쓰는 필드(.id/.org_id)만 담는 최소 dataclass(`_CallerIdentity`)로 duck-type 호환 유지
- `workflow_executions.py:133` `list_executions`(non-admin/owner self-scope 체크): grant-only 멤버(project_access를 org_member_id 경유로만 가진 non-admin/owner)가 자기 자신의 실행 이력도 못 봄 — org_members 폴백 추가

## Test plan
- [x] realdb 가드 3종씩(ws_chat: `test_2216_ws_chat_owner_floor_realdb.py`, workflow_executions: `test_2216_workflow_executions_owner_floor_realdb.py`) — 양성 통과·타인/미소속 여전히 차단·기존 team_member 무회귀
- [x] 각 자리 독립 뮤테이션 자가검증 — 정확히 예측한 실패로 RED 확인 후 복원
- [x] `bootstrap.py`(alembic upgrade heads) 실 baseline 스키마 DB로 전량 검증
- [x] 기존 `test_ws_chat_true_routing.py`, `test_authz_project_scope_coverage.py` 회귀 없음

## 남은 것(이 PR 스코프 밖 — 판정 축이 다름)
전달-누락 계열(`team_members.py:338`, `sprints.py:424`, `workflow_fallback_notify.py:54`)은 403이 아니라 "알림이 실제로 도착하는가"로 재야 하는 별도 축 — 이 PR에서 손 안 댐.

🤖 Generated with [Claude Code](https://claude.com/claude-code)