### PR TITLE
[SID:2168] 크로스프로젝트 전환 토스트가 네비게이션에 씻겨나가던 것 (라이브 실측 발견)

### DIFF
--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -4,6 +4,7 @@ import { getServerSession } from '@/lib/db/server';
 import { buildLoginRedirect } from '@/lib/auth/session-redirect';
 import { DashboardShell } from '../dashboard/dashboard-shell';
 import { StorageCapacityToastProvider } from '@/components/storage/storage-capacity-toast-provider';
+import { CrossProjectToastProvider } from '@/components/chat/cross-project-toast-provider';
 
 interface MemberContext {
   id: string;
@@ -128,7 +129,9 @@ export default async function AuthenticatedLayout({
       pathOrgId={pathOrgId}
       pathProjectId={pathProjectId}
     >
-      <StorageCapacityToastProvider>{children}</StorageCapacityToastProvider>
+      <StorageCapacityToastProvider>
+        <CrossProjectToastProvider>{children}</CrossProjectToastProvider>
+      </StorageCapacityToastProvider>
     </DashboardShell>
   );
 }

--- a/apps/web/src/components/chat/chat-list-view.test.tsx
+++ b/apps/web/src/components/chat/chat-list-view.test.tsx
@@ -113,4 +113,17 @@ describe('ChatListView — 다른 프로젝트 섹션 (story #2168 PR-②)', () 
     expect(params.get('from')).toBe('proj-current');
     expect(params.get('pn')).toBe('sprintable-content');
   });
+
+  // 라이브 실측으로 발견(2026-07-27) — 클릭 직후 router.push가 이 컴포넌트 자체를 언마운트시켜,
+  // 로컬 useToast()로 띄운 토스트가 화면에 페인트될 새도 없이 사라졌었다. queuePendingToast로
+  // sessionStorage에 넘겨 네비게이션을 넘어 살아남게 한다(cross-project-toast-provider.tsx가 소비).
+  it('클릭 시 로컬 토스트가 아니라 sessionStorage 경유 queuePendingToast로 메시지를 넘긴다(네비게이션 생존)', async () => {
+    stubFetch([OUTSIDE_CONV]);
+    sessionStorage.clear();
+    await mount();
+    const row = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('댄군과의 대화'));
+    await act(async () => { row!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    expect(sessionStorage.getItem('sprintable_pending_toast')).toBe('sprintable-content 프로젝트로 이동');
+  });
 });

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -9,7 +9,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { NewConversationModal } from './new-conversation-modal';
 import { useChatSse, type SseConversationReadPayload } from '@/hooks/use-chat-sse';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
-import { useToast, ToastContainer } from '@/components/ui/toast';
+import { queuePendingToast } from './cross-project-toast-provider';
 
 interface Participant {
   member_id: string;
@@ -279,11 +279,8 @@ export function ChatListView({ projectId, currentTeamMemberId, open, onOpenChang
   const showModal = open !== undefined ? open : internalShowModal;
   const setShowModal = onOpenChange ?? setInternalShowModal;
 
-  // story #2168 PR-② — 프로젝트 밖 최근 대화(최대 5개). 토스트는 이 목록 화면에서만 발생하는
-  // 신호라 여기서 자체 useToast 인스턴스를 든다(전역 토스트 provider 없음 — 이 컴포넌트가
-  // ToastContainer도 직접 렌더).
+  // story #2168 PR-② — 프로젝트 밖 최근 대화(최대 5개).
   const [outsideProjectConvs, setOutsideProjectConvs] = useState<OutsideProjectConversation[]>([]);
-  const { toasts, addToast, dismissToast } = useToast();
 
   const convsRef = useRef(conversations);
   useEffect(() => { convsRef.current = conversations; }, [conversations]);
@@ -344,13 +341,18 @@ export function ChatListView({ projectId, currentTeamMemberId, open, onOpenChang
   // 명시 project_id를 이미 실은 URL이라 R2 우선순위상 accessible 검증만 통과하면 채택된다).
   // `from`(원 프로젝트)은 대화 상세 페이지의 기존 "← 채팅" 뒤로가기 버튼이 그대로 소비해
   // "고르면 여기로 돌아온다"를 완성한다(새 뒤로가기 UI를 만들지 않는다).
+  //
+  // ⚠️토스트는 queuePendingToast로 넘긴다(직접 addToast 아님) — 라이브 실측으로 발견: 이 클릭
+  // 직후 곧장 router.push하면 이 컴포넌트(ChatListView) 자체가 언마운트되며 로컬 토스트도 화면에
+  // 페인트될 새 없이 함께 사라졌다. cross-project-toast-provider.tsx(layout 레벨 상주)가 도착한
+  // 페이지에서 대신 띄운다.
   const handleOutsideProjectClick = useCallback((conv: OutsideProjectConversation) => {
-    addToast({ title: t('movedToProjectToast', { name: conv.project_name }), type: 'info' });
+    queuePendingToast(t('movedToProjectToast', { name: conv.project_name }));
     // `pn`(대상 프로젝트명)은 실패 화면(권한 회수 등)에서 dashboardContext.projectMemberships가
     // 이미 그 프로젝트를 못 가진 상태일 수 있어(바로 그게 실패 사유) 클릭 시점 값을 실어 보낸다.
     const params = new URLSearchParams({ p: conv.project_id, from: projectId, pn: conv.project_name });
     router.push(`/chats/${conv.id}?${params.toString()}`);
-  }, [addToast, t, router, projectId]);
+  }, [t, router, projectId]);
 
   useEffect(() => { void fetchConversations(0, false); }, [fetchConversations]);
 
@@ -524,7 +526,6 @@ export function ChatListView({ projectId, currentTeamMemberId, open, onOpenChang
           onCreated={handleCreated}
         />
       )}
-      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
     </div>
   );
 }

--- a/apps/web/src/components/chat/cross-project-toast-provider.test.tsx
+++ b/apps/web/src/components/chat/cross-project-toast-provider.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+//
+// story #2168 PR-② 후속 — CrossProjectToastProvider가 layout 레벨에 상주해 네비게이션(pathname
+// 변경)을 넘어 대기 중인 토스트를 소비하는지 고정한다. 라이브 실측 발견: ChatListView 자체의
+// 로컬 토스트는 클릭 직후 router.push로 언마운트되며 화면에 페인트될 새 없이 사라졌다 — 이
+// provider가 그 자리를 대신한다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { CrossProjectToastProvider, queuePendingToast } from './cross-project-toast-provider';
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+const { pathnameRef } = vi.hoisted(() => ({ pathnameRef: { current: '/chats' } }));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => pathnameRef.current,
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  sessionStorage.clear();
+  pathnameRef.current = '/chats';
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+async function mount() {
+  await act(async () => {
+    root.render(wrap(<CrossProjectToastProvider><div>content</div></CrossProjectToastProvider>));
+  });
+}
+
+async function rerenderAtPathname(pathname: string) {
+  pathnameRef.current = pathname;
+  await act(async () => {
+    root.render(wrap(<CrossProjectToastProvider><div>content</div></CrossProjectToastProvider>));
+  });
+}
+
+describe('CrossProjectToastProvider — 네비게이션 생존 토스트 (story #2168 PR-② 후속)', () => {
+  it('큐잉된 토스트가 없으면 아무것도 안 뜬다', async () => {
+    await mount();
+    expect(container.textContent).toBe('content');
+  });
+
+  it('pathname이 바뀌면(=도착) 큐잉된 토스트를 소비해 띄우고 sessionStorage를 비운다', async () => {
+    queuePendingToast('sprintable 프로젝트로 이동');
+    await mount(); // 최초 마운트도 pathname 변경으로 취급(useEffect 최초 실행)
+    await act(async () => { await Promise.resolve(); });
+
+    expect(container.textContent).toContain('sprintable 프로젝트로 이동');
+    expect(sessionStorage.getItem('sprintable_pending_toast')).toBeNull();
+  });
+
+  // 참고: consumedRef 가드(React StrictMode의 effect 이중 호출 방어)는 이 테스트 하네스로는
+  // 판별력 있게 재현이 안 된다(mutation 확認 결과 — 가드를 지워도 이 harness의 "같은 pathname
+  // 재렌더"는 애초에 useEffect를 재실행하지 않아 실패하지 않았다·React 자체의 의존성 배열
+  // 메커니즘이 이미 그 경로를 막는다). 그래서 "판별력 없는 초록 테스트"로 남기지 않고 뺐다 —
+  // 가드 자체는 StrictMode 이중 마운트 대비로 구조상 유지한다.
+
+  it('다음 페이지에서 새 토스트가 큐잉되면(pathname 변경) 그건 소비한다', async () => {
+    queuePendingToast('A 프로젝트로 이동');
+    await mount();
+    await act(async () => { await Promise.resolve(); });
+
+    queuePendingToast('B 프로젝트로 이동');
+    await rerenderAtPathname('/chats/conv-2');
+    await act(async () => { await Promise.resolve(); });
+
+    expect(container.textContent).toContain('B 프로젝트로 이동');
+  });
+});

--- a/apps/web/src/components/chat/cross-project-toast-provider.tsx
+++ b/apps/web/src/components/chat/cross-project-toast-provider.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { usePathname } from 'next/navigation';
+import { ToastContainer, useToast } from '@/components/ui/toast';
+
+// story #2168 PR-② 후속(라이브 실측으로 발견) — chat-list-view.tsx가 "다른 프로젝트" 항목
+// 클릭 시 addToast를 호출한 바로 다음 줄에서 router.push로 상세 페이지(다른 라우트)로 이동한다.
+// 그 즉시 ChatListView 자체가 언마운트되며 로컬 useToast()/ToastContainer도 함께 사라져,
+// 토스트가 화면에 페인트될 기회조차 없이 사라졌다 — 클릭 직후 동기 체크(DOM querySelector)로도
+// 토스트 컨테이너가 안 잡혔다. storage-capacity-toast-provider.tsx와 같은 패턴(네비게이션을
+// 넘어 살아남는 (authenticated) layout 레벨 provider)으로 옮긴다 — 새 패턴을 만들지 않고
+// 기존에 이미 검증된 것을 재사용.
+const PENDING_TOAST_KEY = 'sprintable_pending_toast';
+
+/** 네비게이션 직전에 호출 — 도착한 페이지에서 CrossProjectToastProvider가 이 값을 읽어 띄운다. */
+export function queuePendingToast(title: string): void {
+  try {
+    sessionStorage.setItem(PENDING_TOAST_KEY, title);
+  } catch {
+    // sessionStorage 불가 — 토스트 없이 진행(전환 자체는 이미 일어나므로 치명적이지 않음)
+  }
+}
+
+export function CrossProjectToastProvider({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const { toasts, addToast, dismissToast } = useToast();
+  const consumedRef = useRef<string | null>(null);
+
+  // pathname이 바뀔 때마다(=네비게이션 도착마다) 대기 중인 토스트가 있는지 확인한다.
+  // 이 provider 자체는 언마운트되지 않으므로(layout 레벨 상주) 매 도착에서 반드시 체크된다.
+  useEffect(() => {
+    let pending: string | null = null;
+    try {
+      pending = sessionStorage.getItem(PENDING_TOAST_KEY);
+    } catch {
+      // ignore
+    }
+    if (!pending || consumedRef.current === pending) return;
+    consumedRef.current = pending;
+    try {
+      sessionStorage.removeItem(PENDING_TOAST_KEY);
+    } catch {
+      // ignore
+    }
+    addToast({ title: pending, type: 'info' });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname]);
+
+  return (
+    <>
+      {children}
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+    </>
+  );
+}


### PR DESCRIPTION
## 요약
#2520(#2168 PR-②) 라이브 검증 중 실측으로 발견: "다른 프로젝트" 항목 클릭 시 로컬 `addToast()` 호출 직후 곧장 `router.push()`하면 `ChatListView` 자체가 언마운트되며 로컬 `useToast()`/`ToastContainer`도 함께 사라진다 — 토스트가 화면에 페인트될 기회조차 없이 사라졌다(클릭 직후 동기 DOM 체크로도 컨테이너 자체가 안 잡히는 것 확인).

## 처방
`storage-capacity-toast-provider.tsx`와 동일한 기존 패턴(네비게이션을 넘어 살아남는 `(authenticated)` layout 레벨 provider)으로 옮김 — **새 패턴 0**. `queuePendingToast()`로 sessionStorage에 메시지를 넘기고, 도착한 페이지에서 `CrossProjectToastProvider`가 `pathname` 변경을 감지해 소비 + 표시한다.

## 테스트
회귀가드 3건 신설(mutation 확認 완료 — 되돌리면 각각 RED): 빈 상태 무표시·pathname 변경 시 소비+sessionStorage 클리어·다음 페이지에서 새 토스트 소비. 전체 vitest 315 files/2098 passed. build/lint clean.

## Test plan
- [ ] develop 배포 후 라이브: "다른 프로젝트" 항목 클릭 → 도착한 대화 상세 페이지에서 "{project} 프로젝트로 이동" 토스트가 실제로 화면에 보이는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)