### PR TITLE
[SID:2214] 코드블럭 스크롤바 노출 후속 — 실제 스크롤 요소(pre 자신)에 예외 누락

### DIFF
--- a/apps/web/src/app/globals-scrollbar.test.ts
+++ b/apps/web/src/app/globals-scrollbar.test.ts
@@ -68,6 +68,22 @@ describe('문서 코드블럭이 실제로 "굴러갈 수 있다" — .ProseMirr
   });
 });
 
+describe('실제 스크롤 요소(shiki가 만드는 <pre> 자신)에도 scrollbar-visible 예외가 있다 (#2214 후속, 라이브 실측 발견)', () => {
+  // 라이브 실측(2026-07-27): 바깥 `.scrollbar-visible` wrapper div가 아니라 그 안의
+  // `<pre class="shiki ...">` 자신이 실제로 scrollLeft가 움직이는 요소였다(shiki 산출물 자체에
+  // overflow-x:auto가 붙어 내용이 pre 안에서 스스로 스크롤되고 바깥 wrapper의 scrollWidth에는
+  // 반영 안 됨 — wrapper는 scrollWidth===clientWidth로 남는다). 그 pre 자신에 scrollbar-width
+  // 예외가 없으면 "굴러가긴 하는데 스크롤바만 안 보이는" 반쪽 상태가 된다.
+  it('.ProseMirror .scrollbar-visible pre에 scrollbar-width:thin 예외가 있다', () => {
+    expect(css).toMatch(/\.ProseMirror \.scrollbar-visible pre\s*\{[^}]*scrollbar-width:\s*thin/);
+  });
+
+  it('webkit 스크롤바 규칙(track·thumb·hover)도 같은 selector로 붙어 있다', () => {
+    expect(css).toMatch(/\.ProseMirror \.scrollbar-visible pre::-webkit-scrollbar\s*\{[^}]*display:\s*block/);
+    expect(css).toMatch(/\.ProseMirror \.scrollbar-visible pre::-webkit-scrollbar-thumb\s*\{/);
+  });
+});
+
 describe('코드블럭/표 wrapper가 scrollbar-visible을 잃지 않았다 (#2165)', () => {
   const files = [
     'docs/extensions/code-block-copy.tsx',

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -537,6 +537,24 @@
     overflow-wrap: normal;
   }
 
+  /* story #2214 후속(라이브 실측으로 발견, 2026-07-27) — 실제로 스크롤되는 요소는
+     `.scrollbar-visible` 래퍼 div가 아니라 그 안의 `<pre class="shiki ...">` 그 자신이었다.
+     shiki가 생성하는 pre 자체에 이미 `overflow-x: auto`가 붙어 있어(라이브러리 산출물), 내용이
+     그 pre 안에서 스스로 스크롤되며 바깥 wrapper의 scrollWidth에는 반영되지 않는다(wrapper는
+     scrollWidth===clientWidth로 남는다 — 실측 확認). 그런데 위 `.scrollbar-visible,
+     .doc-renderer pre, .tableWrapper` 예외 목록은 그 **바깥 wrapper**에만 scrollbar-width:thin을
+     주고 있어서, 실제로 스크롤되는 이 pre 자신은 여전히 전역 `* { scrollbar-width: none }`을
+     그대로 물려받는다 — scrollLeft는 실제로 움직이는데(굴러가는 것 자체는 성립) 스크롤바만
+     안 보이는 반쪽 상태였다. `.ProseMirror .scrollbar-visible pre`에도 같은 예외를 준다. */
+  .ProseMirror .scrollbar-visible pre {
+    scrollbar-width: thin;
+    scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+  }
+  .ProseMirror .scrollbar-visible pre::-webkit-scrollbar { display: block; width: 6px; height: 6px; }
+  .ProseMirror .scrollbar-visible pre::-webkit-scrollbar-track { background: var(--scrollbar-track); }
+  .ProseMirror .scrollbar-visible pre::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 3px; }
+  .ProseMirror .scrollbar-visible pre::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); }
+
   .scrollbar-visible,
   .doc-renderer pre,
   .tableWrapper {


### PR DESCRIPTION
## 요약
#2214("굴린다. 코드블럭만.") 라이브 검증 중 실측으로 발견한 후속 결함.

`.scrollbar-visible` 바깥 wrapper div가 아니라 그 안의 `<pre class="shiki ...">` **자신**이 실제로 `scrollLeft`가 움직이는 요소였다 — shiki 산출물 자체에 이미 `overflow-x: auto`가 붙어 있어 내용이 pre 안에서 스스로 스크롤되고, 바깥 wrapper의 `scrollWidth`에는 반영되지 않는다(wrapper는 `scrollWidth === clientWidth`로 남는 것을 실측 확인).

기존 scrollbar-visible 예외 목록(`.scrollbar-visible, .doc-renderer pre, .tableWrapper`)은 그 **바깥 wrapper**에만 `scrollbar-width: thin`을 주고 있어서, 실제로 스크롤되는 **pre 자신**은 여전히 전역 `* { scrollbar-width: none }`을 그대로 물려받았다 — "굴러가긴 하는데 스크롤바만 안 보이는" 반쪽 상태였다.

## 처방
```css
.ProseMirror .scrollbar-visible pre {
  scrollbar-width: thin;
  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
}
/* + 대응 webkit ::-webkit-scrollbar 계열 */
```

## 테스트
회귀가드 2건 신설(mutation 확認 완료 — 되돌리면 각각 RED). 전체 vitest 314 files/2096 passed. build/lint clean.

## Test plan
- [ ] develop 배포 후 라이브: 긴 코드 한 줄이 있는 문서에서 스크롤바가 실제 눈에 보이는지(데스크톱)

🤖 Generated with [Claude Code](https://claude.com/claude-code)