### PR TITLE
obs(#2124): auth.refresh 로그에 user_id 추가 — 「누가 하드401 루프에 빠졌는지」 못 쫓던 것

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -793,8 +793,18 @@ async def refresh_token(
             )
         )).scalar_one_or_none()
         if revoked_user_id is None:
+            # #2124(관측성 보강 — 오르테가군 요청 2026-07-27): 하드 401은 지금까지 계정 상관이
+            # 0이라 "누가 이 루프에 빠졌는지" 못 쫓았다(prod 실측: 같은 key가 ~20초 간격으로
+            # 수십 회 반복 — "가끔 풀린다"가 아니라 "빠지면 못 나온다"). row 자체(만료/폐기든)가
+            # 있으면 user_id를 읽기만(best-effort, 인가 판정에 영향 0 — 이미 위에서 거부 확定
+            # 後의 순수 로깅 조회) 해 로그에 싣는다. 새 규칙 발명 0 — grace_reuse가 이미 로깅하는
+            # user_id 축을 실패 로그에도 동일하게 확장하는 것뿐.
+            _diag_user_id = (await session.execute(
+                select(RefreshToken.user_id).where(RefreshToken.token_hash == token_hash)
+            )).scalar_one_or_none()
             logger.warning(
-                "auth.refresh 실패 reason=token_not_found_or_revoked_or_expired key=%s", correlation_key,
+                "auth.refresh 실패 reason=token_not_found_or_revoked_or_expired key=%s user_id=%s",
+                correlation_key, _diag_user_id,
             )
             return _err("TOKEN_REVOKED", "Refresh token revoked or expired", 401)
         logger.info(
@@ -815,6 +825,15 @@ async def refresh_token(
     tokens = create_tokens(str(user.id), email=user.email, app_metadata=_md)
     _, refresh_exp = create_refresh_token(str(user.id), expires_delta=timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS))
     await _store_refresh_token(session, user, tokens["refresh_token"], refresh_exp)
+    # #2124(관측성 보강): 성공 회전도 old_key→new_key로 로깅 — 지금까지 성공 경로엔 로그가
+    # 아예 없어(까심발견류 '침묵이 결함을 오래 살린다'와 동형) "회전은 성공했는데 클라가 새
+    # 토큰을 저장 못 했는가(㉮)"를 훗날 old_key의 하드 401과 new_key의 미사용 여부로 대조
+    # 가능하게 한다. ⛔이 로그만으론 ㉮/㉯/㉰을 이 순간 즉시 못 가른다 — 다음 요청과의 대조가
+    # 필요(추가 조사 축이지 이 changeset의 판정은 아님).
+    new_correlation_key = hash_token(tokens["refresh_token"])[:12]
+    logger.info(
+        "auth.refresh rotated old_key=%s new_key=%s user_id=%s", correlation_key, new_correlation_key, user.id,
+    )
 
     return _ok(tokens)
 

--- a/backend/tests/test_e5225c0a_refresh_atomic_realdb.py
+++ b/backend/tests/test_e5225c0a_refresh_atomic_realdb.py
@@ -30,6 +30,14 @@ pytestmark = [
     pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
 ]
 
+# #2124: app.main import(모듈 최초 1회)이 app.core.logging_config.configure_logging()을 태워
+# root.handlers.clear()를 실행한다 — 이 파일을 단독 실행(다른 파일이 먼저 app.main을 안 당겨온
+# 상태)하면 그 clear가 caplog의 propagate 핸들러까지 지워 이 파일의 caplog 기반 관측성 테스트가
+# 거짓양성(assert 대상이 빈 리스트인데도 다른 이유로 통과)/거짓음성을 낼 수 있다. 모듈 최상단에서
+# 미리 당겨와 "이 파일 안에서" clear가 일어나는 시점을 각 테스트의 caplog fixture 설정 前으로
+# 고정 — 전체 스위트에서 이미 우연히 성립하던 순서를 이 파일 단독 실행에서도 보장한다.
+import app.main  # noqa: E402,F401
+
 
 @pytest.fixture
 def anyio_backend():
@@ -234,11 +242,53 @@ async def test_refresh_failure_logs_reason_and_correlation_key_realdb(caplog):
                 second = await client.post(
                     "/api/v2/auth/refresh", json={"refresh_token": seeded["raw_refresh"]},
                 )
-            assert second.status_code == 401
+                assert second.status_code == 401
+                failure_records = [
+                    r for r in caplog.records
+                    if "reason=token_not_found_or_revoked_or_expired" in r.message
+                ]
+                assert failure_records, f"관측성 로그 누락: {[r.message for r in caplog.records]}"
+                assert all("key=" in r.message for r in failure_records)
+                # #2124(오르테가군 요청 2026-07-27): 하드 401 loop 실측(prod 259건, 동일 key 반복)에서
+                # "누가 겪는지" 계정 상관이 0이라 못 쫓았다 — user_id가 **바로 이 실패 로그 레코드
+                # 자체**에 실렸는지 실증(다른 레코드(예: 이전 성공 rotation의 INFO 로그)에 우연히
+                # user_id가 있어 통과하는 거짓양성을 피하려 failure_records만 검사).
+                assert all(
+                    f"user_id={seeded['user_id']}" in r.message for r in failure_records
+                ), f"user_id 관측성 로그 누락: {[r.message for r in failure_records]}"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_refresh_success_logs_rotation_old_new_key_realdb(caplog):
+    """#2124(오르테가군 요청 2026-07-27): 성공 rotation에도 로그가 없어(침묵) old_key의 훗날
+    하드 401과 new_key의 미사용 여부를 대조할 방법이 없었다 — old_key→new_key→user_id 로깅 실증."""
+    import logging
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_user_with_refresh_token(s)
+
+        await _setup_app(app, Session)
+        client = _client_for(app)
+        try:
+            with caplog.at_level(logging.INFO, logger="app.routers.auth"):
+                resp = await client.post(
+                    "/api/v2/auth/refresh", json={"refresh_token": seeded["raw_refresh"]},
+                )
+            assert resp.status_code == 200
             assert any(
-                "reason=token_not_found_or_revoked_or_expired" in r.message and "key=" in r.message
+                "auth.refresh rotated old_key=" in r.message
+                and "new_key=" in r.message
+                and f"user_id={seeded['user_id']}" in r.message
                 for r in caplog.records
-            ), f"관측성 로그 누락: {[r.message for r in caplog.records]}"
+            ), f"rotation 관측성 로그 누락: {[r.message for r in caplog.records]}"
         finally:
             await client.aclose()
     finally:


### PR DESCRIPTION
## Summary
- prod 실측(오르테가군, 2026-07-27): 14일 259건 하드401 전부 `token_not_found_or_revoked_or_expired`, 오늘 55건이 동일 correlation key로 06:39~06:44 5분 사이 ~20초 간격 반복 — "가끔 실패"가 아니라 "한 번 빠지면 재로그인 없인 못 나오는 루프".
- 그런데 이 실패 로그엔 계정 상관키가 없어(`token_hash[:12]`는 역산 불가) prod에서 "누가 겪는지"를 못 쫓았음.
- 두 지점 추가(둘 다 순수 로깅 — 인가 판정 변경 0):
  - 하드 401 직전 best-effort SELECT로 user_id 조회해 로그에 실음(이미 거부 확定 後의 읽기 전용 조회).
  - 성공 rotation에도 로그가 0이었음 — old_key→new_key→user_id 추가(훗날 "회전 성공했는데 new_key 미사용"(㉮ 후보) 대조 가능하게).

## 부수 발견
- caplog 기반 관측성 테스트가 이 파일 단독 실행 시 거짓양성 낼 수 있는 pre-existing 갭 발견: `app.main` import(1회성)가 `configure_logging()`의 `root.handlers.clear()`를 태워 pytest caplog 핸들러를 지운다. 전체 스위트에선 다른 파일이 먼저 `app.main`을 당겨와 우연히 안 겪던 것 — 모듈 최상단 명시 import로 고정.

## Test plan
- [x] 신규 테스트 2개(하드401 user_id 실증 + 성공 rotation old_key/new_key/user_id 실증), 기존 테스트 확장(false-positive 회피용 `failure_records`로 특정 레코드만 검사하도록 재작성).
- [x] 뮤테이션 자가검증 둘 다 완료: user_id enrichment 되돌리면 해당 테스트만 정확히 예측한 실패로 RED, 다른 테스트는 GREEN 그대로.
- [x] 기존 `test_e5225c0a_refresh_atomic_realdb.py`(6건) + `test_auth_11.py`/`test_auth_switch_project.py`/`test_bea25062_auth_cutover_service.py`(22건) 전체 28건 회귀 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)