### PR TITLE
fix(#2124 ㉮): 인증 미들웨어가 멀티계정 금고를 못 보던 것 — 「매일 방문해도 늘 로그아웃」 근본

### DIFF
--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -174,6 +174,90 @@ describe('proxy', () => {
     }
   });
 
+  // #2124(오르테가군·선생님 실측 2026-07-27): "매일 방문해도 늘 로그아웃" 인과사슬의 «방아쇠» 확認.
+  // tryRefreshViaFastapi()는 `if (!res.ok) return null`/`catch { return null }` — 진짜 401
+  // (TOKEN_REVOKED)과 일시 장애(429/5xx/네트워크에러/타임아웃)를 구분하지 않는다. 둘 다 동일하게
+  // refreshFailed=true → clearAuthCookies() 호출로 이어진다. 아래 두 테스트는 그 도달 경로가
+  // 실제로 존재함을(status를 401이 아닌 값으로 명시·네트워크 throw로) 실증한다.
+  it('clears sp_at/sp_rt even when backend returns a transient 503(rate-limit이나 콜드스타트 등) — NOT a genuine 401(story #2124 트리거 확認)', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 503, json: async () => ({ error: { code: 'SERVICE_UNAVAILABLE' } }) });
+    const response = await middleware(makeRequest('/dashboard', { sp_rt: 'still-valid-rt-503' }));
+    expect(response.status).toBe(307);
+    const setCookie = response.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain('sp_rt=;');
+    expect(setCookie).toContain('sp_at=;');
+  });
+
+  it('clears sp_at/sp_rt on a network-level throw(fetch reject — 타임아웃/DNS 등) — 토큰 자체는 무관(story #2124 트리거 확認)', async () => {
+    mockFetch.mockRejectedValue(new Error('fetch failed: network error'));
+    const response = await middleware(makeRequest('/dashboard', { sp_rt: 'still-valid-rt-network-error' }));
+    expect(response.status).toBe(307);
+    const setCookie = response.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain('sp_rt=;');
+    expect(setCookie).toContain('sp_at=;');
+  });
+
+  // #2124 사슬 3단계 — ㉮(vault 폴백) 착지 後 기대값 뒤집힘(오르테가군 지시: 새로 짜지 말고 그
+  // 셋의 기대값만 뒤집는 것). 원래는 "금고가 있어도 proxy가 안 봐서 복구 불가"를 증명하는
+  // 결함-재현 테스트였다 — 이제는 "sp_rt가 죽어도 active 계정의 금고 토큰으로 갱신에 성공한다"는
+  // 정상동작 가드다. 결함이 돌아오면(vault 폴백이 다시 사라지면) 이 테스트가 RED로 잡는다.
+  it('sp_rt가 죽어도 sp_active_account가 가리키는 계정의 금고(sp_acct_rt_<id>) 토큰으로 갱신에 성공한다(story #2124 ㉮)', async () => {
+    const activeId = '5dfbd9fc-94c2-4afc-9814-da4b7ad08c28';
+    const now = Math.floor(Date.now() / 1000);
+    const newAt = await new SignJWT({ type: 'access', email: 'test@example.com' })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setSubject(activeId)
+      .setIssuedAt(now)
+      .setExpirationTime(now + 900)
+      .sign(new TextEncoder().encode(JWT_SECRET));
+    mockFetch.mockImplementation((_url: string, init: { body: string }) => {
+      const body = JSON.parse(init.body) as { refresh_token: string };
+      if (body.refresh_token === 'vaulted-active-account-rt') {
+        return Promise.resolve({ ok: true, json: async () => ({ data: { access_token: newAt, refresh_token: 'new-rt-from-vault' } }) });
+      }
+      // sp_rt(죽은 토큰) 경로는 여전히 503 — 그래서 폴백이 실제로 발동해야만 이 테스트가 통과한다.
+      return Promise.resolve({ ok: false, status: 503, json: async () => ({ error: { code: 'SERVICE_UNAVAILABLE' } }) });
+    });
+    const response = await middleware(makeRequest('/dashboard', {
+      sp_rt: 'active-rt-about-to-die',
+      [`sp_acct_rt_${activeId}`]: 'vaulted-active-account-rt',
+      sp_active_account: activeId,
+    }));
+    expect(response.status).toBe(200); // 리다이렉트 안 됨 — 로그인 화면으로 안 튕겨나감
+    const setCookie = response.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain('sp_at=');
+    expect(setCookie).toContain('new-rt-from-vault');
+  });
+
+  // 경계 ①(오르테가군 지시): 금고에 있는 아무 토큰이나 쓰면 안 됨 — active 포인터가 가리키는
+  // 계정 것만. 다른 계정의 금고 항목이 있어도 그건 안 쓰고 기존(null) 동작 그대로.
+  it('active 포인터와 다른 계정의 금고 항목은 쓰지 않는다(story #2124 ㉮ 경계①)', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 503, json: async () => ({ error: { code: 'SERVICE_UNAVAILABLE' } }) });
+    const response = await middleware(makeRequest('/dashboard', {
+      sp_rt: 'active-rt-about-to-die',
+      sp_acct_rt_other_account_id: 'someone-elses-vault-token',
+      sp_active_account: 'this-account-id-has-no-vault-entry',
+    }));
+    expect(response.status).toBe(307); // 폴백 대상이 없으니 기존 그대로 로그인으로
+    // sp_rt 시도 1회만(active 계정 것도 아닌 다른 금고 항목으로 추가 시도 0)
+    const refreshCalls = mockFetch.mock.calls.filter((c: unknown[]) => (c[0] as string).includes('/api/v2/auth/refresh'));
+    expect(refreshCalls.length).toBe(1);
+  });
+
+  // 경계 ②(오르테가군 지시): active 포인터가 가리키는 계정이 금고에 아예 없으면 조용히 다른
+  // 걸로 안 감 — 기존 null 동작 그대로(폴백의 폴백 없음).
+  it('active 포인터가 가리키는 계정이 금고에 없으면 폴백 없이 기존 동작 그대로(story #2124 ㉮ 경계②)', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 503, json: async () => ({ error: { code: 'SERVICE_UNAVAILABLE' } }) });
+    const response = await middleware(makeRequest('/dashboard', {
+      sp_rt: 'active-rt-about-to-die',
+      sp_active_account: 'account-with-no-vault-entry-at-all',
+      // sp_acct_rt_account-with-no-vault-entry-at-all 쿠키 자체가 없음
+    }));
+    expect(response.status).toBe(307);
+    const refreshCalls = mockFetch.mock.calls.filter((c: unknown[]) => (c[0] as string).includes('/api/v2/auth/refresh'));
+    expect(refreshCalls.length).toBe(1);
+  });
+
   it('does NOT clear cookies when refresh succeeds but is suppressed for a different active account (RC2 regression guard)', async () => {
     // refreshMatchesActive=false 는 refresh 자체가 실패한 게 아니라(다른 계정의 늦은 refresh를
     // 의도적으로 무시하는 것) — clearAuthCookies 를 호출하면 안 된다. sp_active_account 포인터를

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -235,6 +235,9 @@ function redirectRenamedResourcePath(request: NextRequest, pathname: string): Ne
 
 // bf305fa0 멀티계정 — active 포인터(switch가 set). 없으면 단일계정(back-compat).
 const ACTIVE_ACCOUNT_COOKIE = 'sp_active_account';
+// account-vault.ts와 동일 값 — 그 모듈은 next/headers(cookies())를 임포트해 middleware/proxy
+// 런타임에서 못 씀(ACTIVE_ACCOUNT_COOKIE와 동일 이유로 이미 로컬 재정의된 관례를 따름).
+const VAULT_PREFIX = 'sp_acct_rt_';
 
 /**
  * RC2(stale Set-Cookie suppression): refresh 결과를 sp_at/sp_rt 에 적용해도 되는지 판정.
@@ -259,10 +262,7 @@ async function refreshMatchesActive(request: NextRequest, accessToken: string): 
   return true;
 }
 
-async function tryRefreshViaFastapi(request: NextRequest): Promise<{ accessToken: string; refreshToken: string } | null> {
-  const rt = request.cookies.get(SP_RT_COOKIE)?.value;
-  if (!rt) return null;
-
+async function refreshWithToken(rt: string): Promise<{ accessToken: string; refreshToken: string } | null> {
   const fastapiUrl = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
   try {
     const res = await fetch(`${fastapiUrl}/api/v2/auth/refresh`, {
@@ -278,6 +278,31 @@ async function tryRefreshViaFastapi(request: NextRequest): Promise<{ accessToken
   } catch {
     return null;
   }
+}
+
+async function tryRefreshViaFastapi(request: NextRequest): Promise<{ accessToken: string; refreshToken: string } | null> {
+  const rt = request.cookies.get(SP_RT_COOKIE)?.value;
+  if (rt) {
+    const result = await refreshWithToken(rt);
+    if (result) return result;
+  }
+
+  // #2124(선생님 실측 2026-07-27): 멀티계정 switch/add-account 後 clearAuthCookies가 sp_at/sp_rt만
+  // 지우고 금고(sp_acct_rt_*)·sp_active_account는 안 건드리는 결함(㉢, 별도 fix 대상)과 맞물려,
+  // sp_rt가 없거나 죽어도 **활성 계정의 금고 토큰은 여전히 살아있는** 상태가 남는다 — 그런데 여기가
+  // 지금까지 그 금고의 존재 자체를 몰랐다(proxy.ts 전체 grep 0건이었던 자리). "매일 방문해도 늘
+  // 로그아웃"의 근본 — 이미 그 상태에 빠진 사용자를 여기서 꺼낸다.
+  // ⛔경계(오르테가군 지시, 표면 확장 금지):
+  //   · sp_active_account가 가리키는 **그 계정의** 금고 항목만 본다(금고에 있는 아무 토큰이나 X).
+  //   · 쿠키 값을 그대로 신뢰하지 않는다 — refreshWithToken이 백엔드 검증을 그대로 거친다(추가
+  //     신뢰 경계 확장 0, 기존 rotate 경로 재사용).
+  //   · sp_active_account가 가리키는 계정이 금고에 없으면 조용히 다른 걸로 넘어가지 않고 기존
+  //     null 그대로(폴백의 폴백 없음).
+  const activeAccountId = request.cookies.get(ACTIVE_ACCOUNT_COOKIE)?.value;
+  if (!activeAccountId) return null;
+  const vaultRt = request.cookies.get(`${VAULT_PREFIX}${activeAccountId}`)?.value;
+  if (!vaultRt) return null;
+  return refreshWithToken(vaultRt);
 }
 
 // story cd10e123(P0) 근본 수정 — AC1(551bbbee)이 만든 single-flight in-memory dedupe(아래 옛


### PR DESCRIPTION
## Summary
선생님 실측(2026-07-27, 6/26 멀티계정 기능 출시 이후 한 달 넘게 지속): 브라우저에 `sp_rt`는 없고 `sp_acct_rt_<id>`(금고)·`sp_active_account`만 있는 상태. 코드로 갈린 인과사슬:

1. 로그인/계정전환 성공 시 `setActiveAccount`가 `sp_rt`를 정상 심음
2. 어느 refresh가 실패(진짜 401이든 일시 장애든, 원인은 별건 #2124 ㉯) → `clearAuthCookies`가 `sp_at`/`sp_rt`만 지움(금고·active 포인터는 안 건드림 — 함수 시그니처 자체가 그 둘뿐)
3. 그 뒤 `tryRefreshViaFastapi`는 `sp_rt`만 보고 없으면 즉시 null(백엔드 호출조차 안 함) → `proxy.ts` 전체에 금고 참조 grep 0건 — 존재 자체를 몰랐음
4. 금고엔 여전히 살아있는 토큰이 있는데 아무도 안 봐 복구 경로가 없음 → 사용자는 매번 재로그인

## 처방(㉮)
`sp_rt` 실패 시 `sp_active_account`가 가리키는 그 계정의 금고 항목으로 한 번 더 refresh 시도. 경계 3개(오르테가군 지시):
1. 아무 금고 토큰이나 쓰지 않음 — active 포인터가 가리키는 것만
2. 쿠키 값을 그대로 신뢰하지 않음 — 기존 `refreshWithToken`(백엔드 rotate 검증) 그대로 재사용, 새 신뢰 경계 0
3. active 포인터가 가리키는 계정이 금고에 없으면 조용히 다른 걸로 넘어가지 않고 기존 null 그대로

㉯(`clearAuthCookies`가 401/일시장애를 구분 안 하는 방아쇠 자체)는 별도 PR — 한 PR에 둘 다 안 넣음.

## Test plan
- [x] 신규 테스트 3개: 금고 폴백 성공 실증, 경계①(타 계정 금고 미사용), 경계②(금고 미존재 시 폴백 없음)
- [x] 기존 2개 재현 테스트(`503`/네트워크 throw → 삭제)는 그대로 유지 — ㉯(별도 PR)를 위해 보존
- [x] 뮤테이션 자가검증: 폴백 로직 제거 시 성공 테스트만 정확히 예측한 실패(200→307)로 RED, 나머지 54건은 GREEN 그대로
- [x] `apps/web` 전체 vitest(311 files, 2087 tests) + tsc --noEmit 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)