### PR TITLE
fix(#2124 ㉯): clearAuthCookies가 진짜 401과 일시 장애를 구분 안 하던 것 — 방아쇠 자체를 막음

### DIFF
--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -75,7 +75,7 @@ describe('proxy', () => {
   it('does not accidentally widen the guard to all of /auth/* — /auth/reset-required stays protected', async () => {
     // 스코프 정확성 회귀가드 — "/auth/native만 열고 /auth/ 전체는 열지 않는다"는 명시 요구를
     // 실제로 지켰는지 확인. /auth/reset-required는 보호 라우트로 남아있어야 함.
-    mockFetch.mockResolvedValue({ ok: false, json: async () => ({ error: { code: 'TOKEN_REVOKED' } }) });
+    mockFetch.mockResolvedValue({ ok: false, status: 401, json: async () => ({ error: { code: 'TOKEN_REVOKED' } }) });
     const response = await middleware(makeRequest('/auth/reset-required'));
     expect(response.status).toBe(307);
   });
@@ -111,7 +111,7 @@ describe('proxy', () => {
   });
 
   it('redirects to login when no sp_at cookie and refresh fails', async () => {
-    mockFetch.mockResolvedValue({ ok: false, json: async () => ({ error: { code: 'TOKEN_REVOKED' } }) });
+    mockFetch.mockResolvedValue({ ok: false, status: 401, json: async () => ({ error: { code: 'TOKEN_REVOKED' } }) });
     const response = await middleware(makeRequest('/dashboard'));
     expect(response.status).toBe(307);
     // AC3(551bbbee): hard /login 대신 next 보존 + reason 배너 계약. graceful 세션 만료 UX.
@@ -134,7 +134,7 @@ describe('proxy', () => {
   it('clears sp_at/sp_rt cookies on definitive refresh failure — UI path (story e5225c0a P0)', async () => {
     // 산티아고 실측: refresh 실패 시 쿠키를 안 지워 30일 sp_rt 가 401 무한 재생산. 이 테스트는
     // 그 정확한 실패 모드를 재현하고 수정을 고정한다.
-    mockFetch.mockResolvedValue({ ok: false, json: async () => ({ error: { code: 'TOKEN_REVOKED' } }) });
+    mockFetch.mockResolvedValue({ ok: false, status: 401, json: async () => ({ error: { code: 'TOKEN_REVOKED' } }) });
     const response = await middleware(makeRequest('/dashboard', { sp_rt: 'stale-rt-ui' }));
     expect(response.status).toBe(307);
     const setCookie = response.headers.get('set-cookie') ?? '';
@@ -143,7 +143,7 @@ describe('proxy', () => {
   });
 
   it('clears sp_at/sp_rt cookies on definitive refresh failure — API path (story e5225c0a P0)', async () => {
-    mockFetch.mockResolvedValue({ ok: false, json: async () => ({ error: { code: 'TOKEN_REVOKED' } }) });
+    mockFetch.mockResolvedValue({ ok: false, status: 401, json: async () => ({ error: { code: 'TOKEN_REVOKED' } }) });
     const response = await middleware(makeRequest('/api/notifications', { sp_rt: 'stale-rt-api' }));
     expect(response.status).toBe(200); // handler 가 401 반환하도록 통과
     const setCookie = response.headers.get('set-cookie') ?? '';
@@ -159,7 +159,7 @@ describe('proxy', () => {
     process.env['NEXT_PUBLIC_APP_URL'] = 'https://app.sprintable.ai';
     process.env['NEXT_PUBLIC_COOKIE_DOMAIN'] = 'app.sprintable.ai';
     try {
-      mockFetch.mockResolvedValue({ ok: false, json: async () => ({ error: { code: 'TOKEN_REVOKED' } }) });
+      mockFetch.mockResolvedValue({ ok: false, status: 401, json: async () => ({ error: { code: 'TOKEN_REVOKED' } }) });
       const response = await middleware(makeRequest('/dashboard', { sp_rt: 'stale-rt-domain' }));
       expect(response.status).toBe(307);
       const setCookie = response.headers.get('set-cookie') ?? '';
@@ -174,23 +174,32 @@ describe('proxy', () => {
     }
   });
 
-  // #2124(오르테가군·선생님 실측 2026-07-27): "매일 방문해도 늘 로그아웃" 인과사슬의 «방아쇠» 확認.
-  // tryRefreshViaFastapi()는 `if (!res.ok) return null`/`catch { return null }` — 진짜 401
-  // (TOKEN_REVOKED)과 일시 장애(429/5xx/네트워크에러/타임아웃)를 구분하지 않는다. 둘 다 동일하게
-  // refreshFailed=true → clearAuthCookies() 호출로 이어진다. 아래 두 테스트는 그 도달 경로가
-  // 실제로 존재함을(status를 401이 아닌 값으로 명시·네트워크 throw로) 실증한다.
-  it('clears sp_at/sp_rt even when backend returns a transient 503(rate-limit이나 콜드스타트 등) — NOT a genuine 401(story #2124 트리거 확認)', async () => {
+  // #2124 ㉯(오르테가군·선생님 실측 2026-07-27) — 기대값 뒤집힘(오르테가군 지시: 새로 짜지 말고
+  // 그 자리 뒤집는 것 — "결함을 증명하는 테스트"에서 "결함이 돌아오면 잡는 가드"로). 예전엔
+  // status를 안 가리고(401도 429도 5xx도 네트워크에러도) 전부 clearAuthCookies로 이어졌다 —
+  // 이제 status===401(진짜 TOKEN_REVOKED)만 지우고, 나머지(transient — 죽었는지 확인 못 함)는
+  // 쿠키를 보존해 다음 방문에 재시도할 여지를 남긴다.
+  it('일시 장애(503 — rate-limit이나 콜드스타트 등)에서는 sp_at/sp_rt를 지우지 않는다 — 진짜 401이 아니므로(story #2124 ㉯)', async () => {
     mockFetch.mockResolvedValue({ ok: false, status: 503, json: async () => ({ error: { code: 'SERVICE_UNAVAILABLE' } }) });
     const response = await middleware(makeRequest('/dashboard', { sp_rt: 'still-valid-rt-503' }));
-    expect(response.status).toBe(307);
+    expect(response.status).toBe(307); // 이 요청 자체는 여전히 미인증 처리(로그인으로) — 다만 쿠키는 살아남는다
     const setCookie = response.headers.get('set-cookie') ?? '';
-    expect(setCookie).toContain('sp_rt=;');
-    expect(setCookie).toContain('sp_at=;');
+    expect(setCookie).not.toContain('sp_rt=;');
+    expect(setCookie).not.toContain('sp_at=;');
   });
 
-  it('clears sp_at/sp_rt on a network-level throw(fetch reject — 타임아웃/DNS 등) — 토큰 자체는 무관(story #2124 트리거 확認)', async () => {
+  it('네트워크 레벨 throw(fetch reject — 타임아웃/DNS 등)에서도 sp_at/sp_rt를 지우지 않는다 — 토큰 자체는 무관하므로(story #2124 ㉯)', async () => {
     mockFetch.mockRejectedValue(new Error('fetch failed: network error'));
     const response = await middleware(makeRequest('/dashboard', { sp_rt: 'still-valid-rt-network-error' }));
+    expect(response.status).toBe(307);
+    const setCookie = response.headers.get('set-cookie') ?? '';
+    expect(setCookie).not.toContain('sp_rt=;');
+    expect(setCookie).not.toContain('sp_at=;');
+  });
+
+  it('진짜 401(TOKEN_REVOKED)일 때는 여전히 sp_at/sp_rt를 지운다 — ㉯가 clearAuthCookies를 아예 없앤 게 아니라 조건만 좁힌 것임을 확認(story #2124 ㉯ 회귀가드)', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 401, json: async () => ({ error: { code: 'TOKEN_REVOKED' } }) });
+    const response = await middleware(makeRequest('/dashboard', { sp_rt: 'genuinely-dead-rt' }));
     expect(response.status).toBe(307);
     const setCookie = response.headers.get('set-cookie') ?? '';
     expect(setCookie).toContain('sp_rt=;');

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -262,7 +262,19 @@ async function refreshMatchesActive(request: NextRequest, accessToken: string): 
   return true;
 }
 
-async function refreshWithToken(rt: string): Promise<{ accessToken: string; refreshToken: string } | null> {
+// #2124 ㉯(선생님 실측·오르테가군 판정 2026-07-27): 지우는 것은 "이 토큰은 진짜 죽었다"(백엔드가
+// 명시 401로 거부)일 때만이어야 한다 — 5xx/네트워크에러/타임아웃은 "확인 못 했다"이지 "죽었다"가
+// 아니다. 예전엔 `!res.ok`(401도 429도 503도 전부 동일) + `catch`(네트워크에러도 동일)를 구분
+// 없이 전부 "실패"로 뭉쳐 clearAuthCookies로 이어졌다 — 일시 장애 한 번에 멀쩡한 30일 세션이
+// 영구 삭제되는 근본(㉢, dev vitest로 트리거 도달 실증·proxy.test.ts). status==401만 "invalid"
+// (backend가 실제로 검사해 거부한 것 — TOKEN_REVOKED/INVALID_TOKEN/USER_NOT_FOUND 전부 401로
+// 통일돼 있음, backend/app/routers/auth.py 실측)로 좁히고 나머지는 전부 "transient"로 분리한다.
+type RefreshOutcome =
+  | { kind: 'ok'; accessToken: string; refreshToken: string }
+  | { kind: 'invalid' } // 백엔드가 401로 명시 거부 — 이 토큰은 진짜 죽음, 지워도 안전
+  | { kind: 'transient' }; // 5xx·429·네트워크에러·타임아웃·응답 파싱 실패 — 죽었는지 모름, 지우면 안 됨
+
+async function refreshWithToken(rt: string): Promise<RefreshOutcome> {
   const fastapiUrl = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
   try {
     const res = await fetch(`${fastapiUrl}/api/v2/auth/refresh`, {
@@ -270,39 +282,49 @@ async function refreshWithToken(rt: string): Promise<{ accessToken: string; refr
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ refresh_token: rt }),
     });
-    if (!res.ok) return null;
+    if (res.status === 401) return { kind: 'invalid' };
+    if (!res.ok) return { kind: 'transient' };
     const json = await res.json() as { data?: { access_token: string; refresh_token: string } };
     const tokens = json.data;
-    if (!tokens?.access_token || !tokens?.refresh_token) return null;
-    return { accessToken: tokens.access_token, refreshToken: tokens.refresh_token };
+    // 200인데 payload가 기대 shape가 아닌 것도 "토큰이 죽었다"는 신호가 아니다(예: 응답 파싱
+    // 실패·백엔드 계약 드리프트) — transient로 취급해 재시도 여지를 남긴다.
+    if (!tokens?.access_token || !tokens?.refresh_token) return { kind: 'transient' };
+    return { kind: 'ok', accessToken: tokens.access_token, refreshToken: tokens.refresh_token };
   } catch {
-    return null;
+    return { kind: 'transient' };
   }
 }
 
-async function tryRefreshViaFastapi(request: NextRequest): Promise<{ accessToken: string; refreshToken: string } | null> {
+async function tryRefreshViaFastapi(request: NextRequest): Promise<RefreshOutcome> {
   const rt = request.cookies.get(SP_RT_COOKIE)?.value;
+  let primaryOutcome: RefreshOutcome = { kind: 'invalid' }; // sp_rt 자체가 없음 = 시도할 것도 없음
   if (rt) {
-    const result = await refreshWithToken(rt);
-    if (result) return result;
+    primaryOutcome = await refreshWithToken(rt);
+    if (primaryOutcome.kind === 'ok') return primaryOutcome;
   }
 
-  // #2124(선생님 실측 2026-07-27): 멀티계정 switch/add-account 後 clearAuthCookies가 sp_at/sp_rt만
-  // 지우고 금고(sp_acct_rt_*)·sp_active_account는 안 건드리는 결함(㉢, 별도 fix 대상)과 맞물려,
-  // sp_rt가 없거나 죽어도 **활성 계정의 금고 토큰은 여전히 살아있는** 상태가 남는다 — 그런데 여기가
-  // 지금까지 그 금고의 존재 자체를 몰랐다(proxy.ts 전체 grep 0건이었던 자리). "매일 방문해도 늘
-  // 로그아웃"의 근본 — 이미 그 상태에 빠진 사용자를 여기서 꺼낸다.
+  // #2124 ㉮(선생님 실측 2026-07-27): 멀티계정 switch/add-account 後 clearAuthCookies가 sp_at/sp_rt만
+  // 지우고 금고(sp_acct_rt_*)·sp_active_account는 안 건드리는 ㉢과 맞물려, sp_rt가 없거나 죽어도
+  // **활성 계정의 금고 토큰은 여전히 살아있는** 상태가 남는다 — 그런데 여기가 지금까지 그 금고의
+  // 존재 자체를 몰랐다(proxy.ts 전체 grep 0건이었던 자리). "매일 방문해도 늘 로그아웃"의 근본 —
+  // 이미 그 상태에 빠진 사용자를 여기서 꺼낸다.
   // ⛔경계(오르테가군 지시, 표면 확장 금지):
   //   · sp_active_account가 가리키는 **그 계정의** 금고 항목만 본다(금고에 있는 아무 토큰이나 X).
   //   · 쿠키 값을 그대로 신뢰하지 않는다 — refreshWithToken이 백엔드 검증을 그대로 거친다(추가
   //     신뢰 경계 확장 0, 기존 rotate 경로 재사용).
   //   · sp_active_account가 가리키는 계정이 금고에 없으면 조용히 다른 걸로 넘어가지 않고 기존
-  //     null 그대로(폴백의 폴백 없음).
+  //     동작(폴백의 폴백 없음 — primaryOutcome 그대로 반환).
   const activeAccountId = request.cookies.get(ACTIVE_ACCOUNT_COOKIE)?.value;
-  if (!activeAccountId) return null;
+  if (!activeAccountId) return primaryOutcome;
   const vaultRt = request.cookies.get(`${VAULT_PREFIX}${activeAccountId}`)?.value;
-  if (!vaultRt) return null;
-  return refreshWithToken(vaultRt);
+  if (!vaultRt) return primaryOutcome;
+  const vaultOutcome = await refreshWithToken(vaultRt);
+  if (vaultOutcome.kind === 'ok') return vaultOutcome;
+  // 둘 다 실패 — 어느 한쪽이라도 transient(확인 못 함)면 안전 쪽(transient)으로 합산한다.
+  // 예: sp_rt는 진짜 죽었지만(invalid) 금고 시도가 마침 네트워크 에러(transient)면, 그 금고
+  // 토큰이 사실 살아있었을 수도 있으므로 지우면 안 된다 — "덜 확信한 쪽"을 최종 판정으로.
+  if (primaryOutcome.kind === 'transient' || vaultOutcome.kind === 'transient') return { kind: 'transient' };
+  return { kind: 'invalid' };
 }
 
 // story cd10e123(P0) 근본 수정 — AC1(551bbbee)이 만든 single-flight in-memory dedupe(아래 옛
@@ -369,13 +391,15 @@ function loginRedirect(request: NextRequest): NextResponse {
   return NextResponse.redirect(url);
 }
 
-// story e5225c0a(P0): refresh 시도 후 세션을 못 살렸을 때의 공통 응답. `refreshFailed`=true
-// (tryRefreshViaFastapi 자체가 null — BE 401/rotation 실패)일 때만 clearAuthCookies 호출.
-// refreshMatchesActive=false(RC2, superseded 계정의 늦은 refresh)는 refresh 자체는 성공이므로
-// 쿠키를 그대로 둔다 — 두 실패 사유를 여기서 한 번만 구분해 양쪽 호출부의 분기를 통일한다.
-function handleUnauthenticated(request: NextRequest, isApiPath: boolean, refreshFailed: boolean): NextResponse {
+// story e5225c0a(P0)+#2124 ㉯: refresh 시도 후 세션을 못 살렸을 때의 공통 응답. `clearCookies`=true
+// (RefreshOutcome.kind === 'invalid' — 백엔드가 401로 명시 거부한 경우만)일 때만 clearAuthCookies
+// 호출. 'transient'(5xx·네트워크에러 등, 죽었는지 확인 못 함)는 쿠키를 보존해 다음 방문에 다시
+// 시도할 여지를 남긴다(㉢ 수정 — 일시 장애로 멀쩡한 세션이 영구 삭제되던 것). refreshMatchesActive
+// =false(RC2, superseded 계정의 늦은 refresh)는 refresh 자체는 성공이므로 쿠키를 그대로 둔다 —
+// 이 세 실패 사유를 여기서 한 번만 구분해 양쪽 호출부의 분기를 통일한다.
+function handleUnauthenticated(request: NextRequest, isApiPath: boolean, clearCookies: boolean): NextResponse {
   const response = isApiPath ? NextResponse.next({ request }) : loginRedirect(request);
-  if (refreshFailed) clearAuthCookies(response);
+  if (clearCookies) clearAuthCookies(response);
   return response;
 }
 
@@ -449,10 +473,12 @@ async function resolveAndRespond(
   }
 
   if (claims.exp !== undefined && claims.exp - now < 300) {
-    const tokens = await tryRefreshViaFastapi(request);
-    // RC2: stale refresh(다른 계정)면 적용 안 함 — 현 active 세션 유지.
-    if (tokens && (await refreshMatchesActive(request, tokens.accessToken))) {
-      applyTokenCookies(response, tokens.accessToken, tokens.refreshToken);
+    const outcome = await tryRefreshViaFastapi(request);
+    // RC2: stale refresh(다른 계정)면 적용 안 함 — 현 active 세션 유지. transient/invalid는
+    // 이 프로액티브 갱신에서 아무것도 안 함(기존 access token이 아직 유효해 이 요청 자체는
+    // 문제 없음 — 실패해도 clearAuthCookies 대상 아님, 다음 요청이 다시 시도).
+    if (outcome.kind === 'ok' && (await refreshMatchesActive(request, outcome.accessToken))) {
+      applyTokenCookies(response, outcome.accessToken, outcome.refreshToken);
     }
   }
 
@@ -491,26 +517,26 @@ export async function proxy(request: NextRequest) {
   const accessToken = request.cookies.get(SP_AT_COOKIE)?.value;
 
   if (!accessToken) {
-    const tokens = await tryRefreshViaFastapi(request);
-    if (!tokens) return handleUnauthenticated(request, isApiPath, true);
+    const outcome = await tryRefreshViaFastapi(request);
+    if (outcome.kind !== 'ok') return handleUnauthenticated(request, isApiPath, outcome.kind === 'invalid');
     // RC2: stale refresh(다른 계정)면 적용 안 함 — 잘못된 계정으로 복귀 방지(쿠키는 유지).
-    if (!(await refreshMatchesActive(request, tokens.accessToken))) {
+    if (!(await refreshMatchesActive(request, outcome.accessToken))) {
       return handleUnauthenticated(request, isApiPath, false);
     }
-    return respondWithRefreshedToken(request, pathname, tokens, isApiPath);
+    return respondWithRefreshedToken(request, pathname, outcome, isApiPath);
   }
 
   const claims = await verifyAccessToken(accessToken);
 
   if (!claims) {
     // access token invalid/expired — try refresh
-    const tokens = await tryRefreshViaFastapi(request);
-    if (!tokens) return handleUnauthenticated(request, isApiPath, true);
+    const outcome = await tryRefreshViaFastapi(request);
+    if (outcome.kind !== 'ok') return handleUnauthenticated(request, isApiPath, outcome.kind === 'invalid');
     // RC2: stale refresh(다른 계정)면 적용 안 함 — 잘못된 계정으로 복귀 방지(쿠키는 유지).
-    if (!(await refreshMatchesActive(request, tokens.accessToken))) {
+    if (!(await refreshMatchesActive(request, outcome.accessToken))) {
       return handleUnauthenticated(request, isApiPath, false);
     }
-    return respondWithRefreshedToken(request, pathname, tokens, isApiPath);
+    return respondWithRefreshedToken(request, pathname, outcome, isApiPath);
   }
 
   return resolveAndRespond(request, pathname, accessToken, claims, request.headers);


### PR DESCRIPTION
## Summary
㉮(vault 폴백, #2532)는 이미 그 상태에 빠진 사용자를 꺼내는 처방이었다. 이건 애초에 그 상태로 떨어지는 **방아쇠**를 막는 것 — `tryRefreshViaFastapi`가 `!res.ok`(401도 429도 5xx도 동일)와 `catch`(네트워크에러·타임아웃도 동일)를 구분 없이 전부 "실패"로 뭉쳐 `clearAuthCookies`로 이어졌다. 일시 장애 한 번에 멀쩡한 30일 세션이 영구 삭제되는 근본(㉢) — 재배포 콜드스타트·rate limit·네트워크 블립이 하필 방문 타이밍과 겹치면 발생.

## 처방
`refreshWithToken`이 판정 3분기 반환:
- `'ok'`(성공)
- `'invalid'`(status===401, 백엔드가 명시 거부 — 지워도 안전)
- `'transient'`(그 외 전부 — 죽었는지 확인 못 함, 지우면 안 됨)

`clearAuthCookies`는 `'invalid'`일 때만 호출. ㉮의 vault 폴백도 동일 판정을 타되, primary/vault 둘 다 실패 시 어느 한쪽이라도 transient면 안전 쪽(transient)으로 합산 — "덜 확信한 쪽"을 최종 판정으로 삼는다.

## Test plan
- [x] 기존 재현 테스트 2개(503/네트워크throw → 삭제됨을 실증하던 것)를 새로 안 짜고 그 자리서 기대값만 뒤집었다("삭제 안 됨"으로) — 결함-재현 테스트가 결함-회귀-가드로 전환
- [x] 진짜 401 케이스가 여전히 지워지는 것도 신규 회귀가드로 고정(㉯가 clearAuthCookies를 아예 없앤 게 아니라 조건만 좁힌 것 확認)
- [x] 기존 e5225c0a 테스트 3개는 mock에 `status: 401` 명시(원래 의도한 "진짜 TOKEN_REVOKED"를 정확히 표현 — 이전엔 status 없이 `ok:false`만 있어 새 판정 기준으로는 transient로 잘못 분류될 뻔했다)
- [x] 뮤테이션 자가검증: 401 판별 조건 제거 시 503 테스트만 정확히 예측한 실패로 RED, 네트워크-throw 테스트(별도 catch 블록 — 이 뮤테이션과 무관)는 GREEN 그대로 — 두 테스트가 서로 다른 코드 경로를 잰다는 것도 같이 증명됨
- [x] `apps/web` 전체(311 files, 2090 tests) + tsc --noEmit 회귀 없음

## 스코프 밖(후속)
재시도 상한("㉯ 뒤에 남는 물음", 오르테가군 지적) — 지금은 무제한 조용한 재시도(다음 방문마다)가 가능한 상태. #2124 스토리에 후속 항목으로 등재 예정, 이 PR엔 안 넣음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)