### PR TITLE
[SID:2229] #2214 편집기 뷰 절반 실패 — CSS Cascade Layers 패배 수정

### DIFF
--- a/apps/web/src/app/globals-scrollbar.test.ts
+++ b/apps/web/src/app/globals-scrollbar.test.ts
@@ -66,6 +66,32 @@ describe('문서 코드블럭이 실제로 "굴러갈 수 있다" — .ProseMirr
     // selector 문자열 자체에 prose(p)나 blockquote·table 태그가 안 섞여 있어야 한다.
     expect(css).not.toMatch(/\.ProseMirror \.scrollbar-visible[^{]*[,\s](p|blockquote|table)[,\s{]/);
   });
+
+  // story #2229(라이브 실측, 2026-07-27) — #2214가 편집기 뷰(실 ProseMirror 런타임)에서
+  // 절반만 먹혔다. 이 규칙이 @layer base **안**에 있었기 때문 — prosemirror-view가 런타임에
+  // 주입하는 `.ProseMirror pre { white-space: pre-wrap }`은 레포 어디에도 소스가 없는(런타임
+  // <style> 직접 주입) **레이어 밖(unlayered)** 규칙이라, CSS Cascade Layers 스펙상 특이도와
+  // 무관하게 레이어 안 규칙을 항상 이긴다. #2203(.tableWrapper)이 같은 @layer base 안에서도
+  // 먹혔던 건 그저 경쟁 규칙이 없었기 때문일 뿐 — "레이어 안에서도 이긴다"는 증거가 아니었다.
+  // ⛔이 테스트는 "CSS 문자열이 있는가"만 볼 수 있고 "실제로 이겼는가"(computed style)는
+  // jsdom이 CSS 레이아웃을 안 돌려 원리적으로 못 잡는다 — 그 축은 라이브/실브라우저 렌더로만
+  // 확인 가능(#2229에서 정적 HTML 재현으로 검증 완료, 라이브 배포 확認은 별도).
+  it('⛔.ProseMirror .scrollbar-visible 규칙은 @layer base 안에 있지 않다(레이어 밖이어야 라이브러리 런타임 주입 스타일을 이긴다)', () => {
+    const layerBaseStart = css.indexOf('@layer base {');
+    expect(layerBaseStart).toBeGreaterThan(-1);
+    let depth = 0;
+    let layerBaseEnd = -1;
+    for (let i = layerBaseStart; i < css.length; i++) {
+      if (css[i] === '{') depth++;
+      if (css[i] === '}') {
+        depth--;
+        if (depth === 0) { layerBaseEnd = i; break; }
+      }
+    }
+    expect(layerBaseEnd).toBeGreaterThan(-1);
+    const layerBaseBlock = css.slice(layerBaseStart, layerBaseEnd);
+    expect(layerBaseBlock).not.toContain('.ProseMirror .scrollbar-visible');
+  });
 });
 
 describe('실제 스크롤 요소(shiki가 만드는 <pre> 자신)에도 scrollbar-visible 예외가 있다 (#2214 후속, 라이브 실측 발견)', () => {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -517,44 +517,6 @@
     overflow-x: auto;
   }
 
-  /* story #2214(유나 판정, 2026-07-27) — "굴린다. 코드블럭만." TipTap/ProseMirror base CSS
-     (.ProseMirror { overflow-wrap: break-word } · .ProseMirror pre { white-space: pre-wrap })가
-     모든 <pre>를 강제로 접어, #2165가 코드블럭에 준 .scrollbar-visible 예외가 애초에 발동할
-     조건(가로 오버플로) 자체를 못 만들고 있었다(#2214 조사 — "스크롤바가 안 보인다"가 아니라
-     "스크롤할 일이 생길 수 없다"). code-block-copy.tsx가 코드블럭에만 부착하는
-     `.scrollbar-visible` 래퍼를 `.ProseMirror` 조상과 함께 잡아 특이도를 올려 라이브러리 base
-     규칙을 덮는다 — 산문·인용·inline code·표(#2203에서 이미 별도 처리)는 이 selector에
-     걸리지 않아 무접촉.
-     ⛔순서 필수: max-width:100%+min-width:0(레이아웃 안전장치, #2035류 body 밀림 방지)을
-     white-space:pre(본체, 실제로 굴러가게 하는 것)보다 먼저 건다 — 안 그러면 굴러가긴 하는데
-     컨테이너를 못 벗어나는 게 아니라 body 전체를 밀어내는 상태를 한 번 만들고 고치게 된다. */
-  .ProseMirror .scrollbar-visible {
-    max-width: 100%;
-    min-width: 0;
-  }
-  .ProseMirror .scrollbar-visible pre {
-    white-space: pre;
-    overflow-wrap: normal;
-  }
-
-  /* story #2214 후속(라이브 실측으로 발견, 2026-07-27) — 실제로 스크롤되는 요소는
-     `.scrollbar-visible` 래퍼 div가 아니라 그 안의 `<pre class="shiki ...">` 그 자신이었다.
-     shiki가 생성하는 pre 자체에 이미 `overflow-x: auto`가 붙어 있어(라이브러리 산출물), 내용이
-     그 pre 안에서 스스로 스크롤되며 바깥 wrapper의 scrollWidth에는 반영되지 않는다(wrapper는
-     scrollWidth===clientWidth로 남는다 — 실측 확認). 그런데 위 `.scrollbar-visible,
-     .doc-renderer pre, .tableWrapper` 예외 목록은 그 **바깥 wrapper**에만 scrollbar-width:thin을
-     주고 있어서, 실제로 스크롤되는 이 pre 자신은 여전히 전역 `* { scrollbar-width: none }`을
-     그대로 물려받는다 — scrollLeft는 실제로 움직이는데(굴러가는 것 자체는 성립) 스크롤바만
-     안 보이는 반쪽 상태였다. `.ProseMirror .scrollbar-visible pre`에도 같은 예외를 준다. */
-  .ProseMirror .scrollbar-visible pre {
-    scrollbar-width: thin;
-    scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
-  }
-  .ProseMirror .scrollbar-visible pre::-webkit-scrollbar { display: block; width: 6px; height: 6px; }
-  .ProseMirror .scrollbar-visible pre::-webkit-scrollbar-track { background: var(--scrollbar-track); }
-  .ProseMirror .scrollbar-visible pre::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 3px; }
-  .ProseMirror .scrollbar-visible pre::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); }
-
   .scrollbar-visible,
   .doc-renderer pre,
   .tableWrapper {
@@ -600,6 +562,36 @@
     @apply transition-colors;
   }
 }
+
+/* story #2229(라이브 실측으로 발견, 2026-07-27) — #2214가 편집기 뷰에서 절반만 먹고 있었다.
+   원인은 CSS Cascade Layers: 이 규칙(과거 @layer base 안)이 특이도로 이겨야 할 상대는
+   `.ProseMirror pre { white-space: pre-wrap }`인데, 이 상대는 **레포 어디에도 소스가 없다**
+   (grep 0건) — prosemirror-view가 런타임에 <style> 태그로 직접 주입하는 라이브러리 base
+   스타일이다. 런타임 주입 <style>은 어떤 @layer로도 안 감싸여 있어 **레이어 밖(unlayered)**
+   이고, Cascade Layers 스펙상 레이어 밖 선언은 **특이도와 무관하게** 레이어 안 선언을 항상
+   이긴다 — 그래서 @layer base 안에 있던 우리 규칙(특이도로는 이길 수 있었는데도)이 매번
+   졌다. #2203(.tableWrapper)이 같은 @layer base 블록에서도 먹혔던 이유는 그저 **경쟁 규칙이
+   없었기** 때문이었을 뿐, "레이어 안에서도 이긴다"는 증거가 아니었다.
+   ⛔이 규칙을 @layer base 밖(=여기, 파일의 다른 unlayered 규칙과 같은 층위)으로 옮기는 것이
+   유일한 원칙적 처방이다 — !important는 쓰지 않는다(원인이 레이어인데 힘으로 누르면 "왜
+   이겼는지"가 다음 사람에게 안 읽힌다). 정적 HTML 재현(레이어 안 vs 밖, prosemirror-view 실
+   런타임 없이도 재현 가능)으로 가설 확認 후 이 위치로 옮김. */
+.ProseMirror .scrollbar-visible {
+  max-width: 100%;
+  min-width: 0;
+}
+.ProseMirror .scrollbar-visible pre {
+  white-space: pre;
+  overflow-wrap: normal;
+}
+.ProseMirror .scrollbar-visible pre {
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+}
+.ProseMirror .scrollbar-visible pre::-webkit-scrollbar { display: block; width: 6px; height: 6px; }
+.ProseMirror .scrollbar-visible pre::-webkit-scrollbar-track { background: var(--scrollbar-track); }
+.ProseMirror .scrollbar-visible pre::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 3px; }
+.ProseMirror .scrollbar-visible pre::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); }
 
 /* ─── Tiptap rich editor ─── */
 .tiptap-content .tiptap {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -575,7 +575,26 @@
    ⛔이 규칙을 @layer base 밖(=여기, 파일의 다른 unlayered 규칙과 같은 층위)으로 옮기는 것이
    유일한 원칙적 처방이다 — !important는 쓰지 않는다(원인이 레이어인데 힘으로 누르면 "왜
    이겼는지"가 다음 사람에게 안 읽힌다). 정적 HTML 재현(레이어 안 vs 밖, prosemirror-view 실
-   런타임 없이도 재현 가능)으로 가설 확認 후 이 위치로 옮김. */
+   런타임 없이도 재현 가능)으로 가설 확認 후 이 위치로 옮김.
+
+   ⛔순서 필수(#2214 원 규율, 옮기면서도 유지) — max-width:100%+min-width:0(레이아웃 안전장치,
+   #2035류 body 밀림 방지)을 white-space:pre(본체, 실제로 굴러가게 하는 것)보다 먼저 건다 —
+   안 그러면 굴러가긴 하는데 컨테이너를 못 벗어나는 게 아니라 body 전체를 밀어내는 상태를
+   한 번 만들고 고치게 된다. 이 두 블록이 나뉘어 있는 이유가 바로 이 순서다 — 정리한다고
+   하나로 합치지 말 것.
+
+   ⚠️shiki 발견(#2214 후속, 라이브 실측) — 실제로 스크롤되는 요소는 `.scrollbar-visible`
+   래퍼 div가 아니라 그 안의 `<pre class="shiki ...">` 그 자신이다(shiki 산출물 자체에
+   overflow-x:auto가 이미 붙어 있어 내용이 pre 안에서 스스로 스크롤되고, 바깥 wrapper의
+   scrollWidth에는 반영 안 됨 — wrapper는 scrollWidth===clientWidth로 남는다). 그래서
+   scrollbar-width 예외도 wrapper가 아니라 pre 자신에게 준다 — 다음 사람이 "wrapper만 재고
+   안 넘친다"로 오판하지 않도록.
+
+   ⛔경합 경고 — 이 파일 뒤쪽 `.tiptap-content .tiptap pre`(Tiptap 섹션)가 이 규칙과 특이도가
+   똑같고(둘 다 0,2,1) 이 규칙보다 더 뒤에 온다. 지금은 그쪽이 white-space/overflow-wrap을
+   안 걸어서 안 부딪히지만, 누가 그쪽에 그 두 속성을 추가하면 소스 순서(later wins at equal
+   specificity)로 이 규칙을 이기게 된다 — `.tiptap-content .tiptap pre`에는 white-space나
+   overflow-wrap을 넣지 말 것. */
 .ProseMirror .scrollbar-visible {
   max-width: 100%;
   min-width: 0;
@@ -605,6 +624,9 @@
 .tiptap-content .tiptap h2 { font-size: 20px; font-weight: 600; margin: 0.8em 0 0.4em; }
 .tiptap-content .tiptap h3 { font-size: 16px; font-weight: 600; margin: 0.6em 0 0.3em; }
 .tiptap-content .tiptap code { background: var(--tiptap-code-bg); color: oklch(0.9 0 0); padding: 2px 6px; border-radius: 4px; font-size: 13px; font-family: var(--font-mono, monospace); }
+/* ⛔#2229 경합 경고 — 이 selector는 위쪽 `.ProseMirror .scrollbar-visible pre`(#2214/#2229)와
+   특이도가 똑같고(0,2,1) 이 규칙이 소스에서 더 뒤에 온다. white-space나 overflow-wrap을
+   여기 추가하면 동일 특이도 타이브레이크(소스 순서)로 그 규칙을 이겨 #2214를 재발시킨다. */
 .tiptap-content .tiptap pre { background: var(--tiptap-pre-bg); color: oklch(0.9 0 0); padding: 16px; border-radius: 8px; overflow-x: auto; font-size: 13px; line-height: 1.6; }
 .tiptap-content .tiptap pre code { background: none; color: inherit; padding: 0; border-radius: 0; font-size: inherit; }
 .tiptap-content .tiptap blockquote { border-left: 3px solid var(--tiptap-blockquote-border); padding: 12px 16px; margin: 12px 0; border-radius: 0 6px 6px 0; background: var(--tiptap-blockquote-bg); }


### PR DESCRIPTION
## 요약
#2214("굴린다. 코드블럭만.")가 읽기전용 `/view`에서는 먹혔지만 **편집기 뷰**에서는 안 먹혔다(computed white-space가 "pre-wrap"으로 남음) — 문서를 실제로 쓰는 사람이 머무는 화면이라 이게 진짜 절반.

## 원인 (정적 HTML 재현으로 확認 — 배포/로그인 불필요)
`.ProseMirror pre { white-space: pre-wrap }`는 레포 소스에 없다(grep 0건) — prosemirror-view가 런타임에 `<style>` 태그로 직접 주입하는 라이브러리 스타일이다. 런타임 주입 스타일은 **레이어 밖(unlayered)**이고, CSS Cascade Layers 스펙상 레이어 밖 선언은 **특이도와 무관하게** 레이어 안 선언을 항상 이긴다. 우리 규칙이 `@layer base` 안에 있는 한 특이도를 아무리 올려도(#2214가 시도한 방법) 못 이긴다.

`#2203`(`.tableWrapper`)이 같은 `@layer base` 블록에서도 먹혔던 건 경쟁 규칙 자체가 없었기 때문 — "레이어 안에서도 이긴다"는 증거가 아니었다.

## 가설 확認 (file:// 로컬 재현, 실 globals.css 전체 링크)
- 레이어 안 규칙 vs 레이어 밖 `pre-wrap` → computed `pre-wrap`(재현)
- 같은 선언을 레이어 밖으로 옮기면 → computed `pre`로 뒤집힘(확定)
- 실 globals.css 링크 재현에서도 나머지 속성(scrollbar-width:thin·max-width:100% 등) 정상 유지 확認

## 처방
`.ProseMirror .scrollbar-visible` 관련 규칙을 `@layer base` 밖(Tiptap 섹션 앞, 파일의 다른 unlayered 규칙과 같은 층위)으로 이동. `!important` 미사용(원인이 레이어인데 힘으로 누르면 다음 사람이 못 읽음).

## 가드 보강
`globals-scrollbar.test.ts`에 "이 규칙이 `@layer base` 안에 있지 않다" 불변식 신설 — 기존 가드는 "문자열이 있는가"만 봐서 "있는데 안 먹는다"를 못 잡았다.

## 테스트
mutation 확인: 규칙을 일시적으로 `@layer base` 안으로 되돌리면 새 가드가 정확히 RED, 복구 후 GREEN. 전체 vitest 316 files/2107 passed. build/lint clean.

## Test plan
- [ ] 배포 후 편집기 뷰에서 긴 코드 한 줄이 실제로 가로 스크롤되는지 라이브 확인(세션 재로그인 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)