### PR TITLE
fix(#2195): GET /api/v2/notifications 커서 페이지네이션 — 인박스 기본 탭 50건 절단 해소

### DIFF
--- a/backend/app/repositories/notification.py
+++ b/backend/app/repositories/notification.py
@@ -15,13 +15,21 @@ class NotificationRepository(BaseRepository[Notification]):
     def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
         super().__init__(Notification, session, org_id)
 
-    async def list(self, user_id: uuid.UUID, is_read: bool | None = None, limit: int = 200) -> list[Notification]:  # type: ignore[override]
+    async def list(
+        self,
+        user_id: uuid.UUID,
+        is_read: bool | None = None,
+        limit: int = 200,
+        before: datetime | None = None,
+    ) -> list[Notification]:  # type: ignore[override]
         q = select(Notification).where(
             self._org_filter(),
             Notification.user_id == user_id,
         )
         if is_read is not None:
             q = q.where(Notification.is_read == is_read)
+        if before is not None:
+            q = q.where(Notification.created_at < before)
         q = q.order_by(Notification.created_at.desc()).limit(limit)
         result = await self.session.execute(q)
         return list(result.scalars().all())

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
@@ -74,23 +75,39 @@ def _inbox_repo(
     return InboxRepository(session, org_id)
 
 
-@router.get("/notifications", response_model=list[NotificationResponse])
+@router.get("/notifications")
 async def list_notifications(
     unread: bool | None = Query(default=None, description="True=읽지 않은 것만, False=읽은 것만"),
     is_read: bool | None = Query(default=None, description="직접 is_read 지정 (unread 우선)"),
     limit: int = Query(default=200, le=200),
+    before: str | None = Query(default=None, description="ISO datetime cursor — 이 시각 이전 항목(내림차순 다음 페이지)"),
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     repo: NotificationRepository = Depends(_notif_repo),
-) -> list[NotificationResponse]:
+) -> dict:
     """GET /api/v2/notifications — auth context에서 user_id 자동 파생.
 
+    story #2195: #2231 정본 규약 A(limit+1 오버페치 + has_more/next_cursor body meta) 적용.
+    인박스 페이지 기본 탭이 FE 고정 limit=50·커서 없음이라 51번째부터 조용히 잘렸었다
+    (참조 구현: conversations.py::list_messages — 동일 오버페치+cursor 패턴).
     MCP check_notifications 호환: unread=true → is_read=False 변환.
     """
     user_id = await _resolve_notification_user_id(auth, db)
     resolved_is_read = (not unread) if unread is not None else is_read
-    items = await repo.list(user_id=user_id, is_read=resolved_is_read, limit=limit)
-    return [NotificationResponse.model_validate(n) for n in items]
+    before_dt: datetime | None = None
+    if before:
+        try:
+            before_dt = datetime.fromisoformat(before)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid cursor format")
+    rows = await repo.list(user_id=user_id, is_read=resolved_is_read, limit=limit + 1, before=before_dt)
+    has_more = len(rows) > limit
+    page = rows[:limit]
+    next_cursor = page[-1].created_at.isoformat() if has_more and page else None
+    return {
+        "data": [NotificationResponse.model_validate(n) for n in page],
+        "meta": {"has_more": has_more, "next_cursor": next_cursor},
+    }
 
 
 @router.get("/notifications/count")

--- a/backend/sprintable_mcp/tools/notifications.py
+++ b/backend/sprintable_mcp/tools/notifications.py
@@ -33,7 +33,11 @@ async def check_notifications(args: CheckNotificationsInput) -> list[TextContent
     if args.limit:
         params["limit"] = str(args.limit)
     try:
-        return ok(await client.get("/api/v2/notifications", params=params))
+        result = await client.get("/api/v2/notifications", params=params)
+        # story #2195: BE 응답이 bare array → {data, meta}(#2231 정본 규약 A)로 바뀜.
+        # 이 MCP 툴의 계약(호출 에이전트가 보는 모양)은 유지한다 — data만 꺼내 돌려준다.
+        items = result.get("data", result) if isinstance(result, dict) else result
+        return ok(items)
     except Exception as exc:
         return err(str(exc))
 

--- a/backend/sprintable_mcp/tools/notifications.py
+++ b/backend/sprintable_mcp/tools/notifications.py
@@ -12,6 +12,7 @@ class CheckNotificationsInput(SprintableInput):
     unread: bool | None = None
     type: str | None = None
     limit: int | None = None
+    before: str | None = None  # #2195: 이전 호출의 meta.next_cursor 값을 그대로 넘기면 다음 페이지
 
 
 class MarkNotificationReadInput(SprintableInput):
@@ -24,7 +25,7 @@ class MarkAllNotificationsReadInput(SprintableInput):
 
 
 async def check_notifications(args: CheckNotificationsInput) -> list[TextContent]:
-    """알림 목록 조회."""
+    """알림 목록 조회. 더 있으면(has_more) 다음 페이지 안내가 별도 텍스트 블록으로 붙는다."""
     params: dict = {}
     if args.unread:
         params["unread"] = "true"
@@ -32,12 +33,31 @@ async def check_notifications(args: CheckNotificationsInput) -> list[TextContent
         params["type"] = args.type
     if args.limit:
         params["limit"] = str(args.limit)
+    if args.before:
+        params["before"] = args.before
     try:
         result = await client.get("/api/v2/notifications", params=params)
-        # story #2195: BE 응답이 bare array → {data, meta}(#2231 정본 규약 A)로 바뀜.
-        # 이 MCP 툴의 계약(호출 에이전트가 보는 모양)은 유지한다 — data만 꺼내 돌려준다.
-        items = result.get("data", result) if isinstance(result, dict) else result
-        return ok(items)
+        # story #2195 후속(오르테가군 지적): BE 응답이 bare array → {data,meta}(#2231 규약 A)로
+        # 바뀐 뒤 그냥 배열만 언랩해 돌려주면, 사람 화면에서 고친 "목록이 조용히 끝난 척한다"
+        # 병을 에이전트 표면에 그대로 남기게 된다. 1차 블록(배열)은 기존 툴 계약대로 유지하되,
+        # has_more일 때 다음 페이지 안내를 2차 텍스트 블록으로 덧붙여 에이전트가 "전량을 못
+        # 봤다"를 알고 before 커서로 이어 받을 수 있게 한다.
+        if isinstance(result, dict) and "data" in result:
+            items = result["data"]
+            meta = result.get("meta") or {}
+        else:
+            items = result
+            meta = {}
+        blocks = ok(items)
+        if meta.get("has_more"):
+            blocks.append(TextContent(
+                type="text",
+                text=(
+                    f"※ 더 있음 — 이 응답은 {len(items)}건까지만 포함(전량 아님). "
+                    f'다음 페이지: check_notifications를 before="{meta.get("next_cursor")}"로 다시 호출.'
+                ),
+            ))
+        return blocks
     except Exception as exc:
         return err(str(exc))
 

--- a/backend/tests/test_2195_notifications_cursor_pagination_realdb.py
+++ b/backend/tests/test_2195_notifications_cursor_pagination_realdb.py
@@ -1,0 +1,157 @@
+"""story #2195 — GET /api/v2/notifications(인박스 페이지 기본 탭)가 하드코딩 limit=50 +
+커서 없음으로 51번째부터 조용히 잘렸다. #2231 정본 규약 A(limit+1 오버페치 +
+has_more/next_cursor body meta, 참조 구현: conversations.py::list_messages)를 적용한다.
+
+이 테스트는 "두 번째 페이지가 첫 페이지와 다른 행을 반환하는 것"을 실 PG로 증명한다
+(#2231 AC3 · #2195 AC2 요구사항 — 200 응답만으로 갈음 금지). 5건을 심어 limit=2로
+3페이지를 다 넘겨 합집합이 원본 5건과 정확히 일치하는 것(누락도 중복도 없음)까지 본다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("d2195000-0000-0000-0000-000000000010")
+USER = uuid.UUID("d2195000-0000-0000-0000-000000000011")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(USER), email=None,
+        claims={"app_metadata": {"org_id": str(ORG)}},
+        org_id=str(ORG),
+    )
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _clean(s):
+    for sql in [
+        f"DELETE FROM notifications WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _seed(s, n: int) -> list[uuid.UUID]:
+    """org_id·user_id 하나에 n건의 Notification을 1초 간격(오래된 것부터)으로 심는다.
+    반환값은 «최신순(내림차순)» — 서버가 실제로 정렬하는 순서와 같은 순서로 검증하기 위함."""
+    await _clean(s)
+    await s.execute(text(
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','O','d2195-org','free')"
+    ))
+    await s.execute(text(
+        f"INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{USER}','d2195@d2195.test','x','D2195',true,true,0,false,0)"
+    ))
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    ids = []
+    for i in range(n):
+        nid = uuid.uuid4()
+        ids.append(nid)
+        created_at = base + timedelta(seconds=i)
+        await s.execute(text(
+            f"INSERT INTO notifications (id,org_id,user_id,type,title,is_read,created_at) VALUES "
+            f"('{nid}','{ORG}','{USER}','probe_event','notif-{i}',false,'{created_at.isoformat()}')"
+        ))
+    await s.commit()
+    return list(reversed(ids))  # newest-first, matches server ORDER BY created_at DESC
+
+
+@pytest.mark.anyio
+async def test_second_page_returns_different_rows_than_first_realdb():
+    """AC2/AC3 핵심 — page1과 page2가 겹치지 않고, 합쳐서 원본과 정확히 일치한다."""
+    from app.routers.notifications import list_notifications
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            newest_first = await _seed(s, n=5)
+
+        async with Session() as s:
+            from app.repositories.notification import NotificationRepository
+            repo = NotificationRepository(s, ORG)
+            page1 = await list_notifications(
+                unread=None, is_read=None, limit=2, before=None,
+                db=s, auth=_auth(), repo=repo,
+            )
+        assert [n.id for n in page1["data"]] == newest_first[0:2]
+        assert page1["meta"]["has_more"] is True
+        assert page1["meta"]["next_cursor"] is not None
+
+        async with Session() as s:
+            from app.repositories.notification import NotificationRepository
+            repo = NotificationRepository(s, ORG)
+            page2 = await list_notifications(
+                unread=None, is_read=None, limit=2, before=page1["meta"]["next_cursor"],
+                db=s, auth=_auth(), repo=repo,
+            )
+        page2_ids = [n.id for n in page2["data"]]
+        assert page2_ids == newest_first[2:4], "page2가 page1과 다른 행을 반환해야 한다(#2195 AC2)"
+        assert not (set(page2_ids) & {n.id for n in page1["data"]}), "page1·page2 겹침 — 커서가 안 전진함"
+        assert page2["meta"]["has_more"] is True
+
+        async with Session() as s:
+            from app.repositories.notification import NotificationRepository
+            repo = NotificationRepository(s, ORG)
+            page3 = await list_notifications(
+                unread=None, is_read=None, limit=2, before=page2["meta"]["next_cursor"],
+                db=s, auth=_auth(), repo=repo,
+            )
+        page3_ids = [n.id for n in page3["data"]]
+        assert page3_ids == newest_first[4:5]
+        assert page3["meta"]["has_more"] is False
+        assert page3["meta"]["next_cursor"] is None
+
+        all_ids = [n.id for n in page1["data"]] + page2_ids + page3_ids
+        assert all_ids == newest_first, "3페이지 합집합이 원본 5건과 순서까지 정확히 일치해야 한다(누락·중복 0)"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_cursor_first_page_unaffected_when_under_limit_realdb():
+    """음성대조 — 총량이 limit 이하면 has_more=False·next_cursor=None(과잉 페이지네이션 아님)."""
+    from app.routers.notifications import list_notifications
+    from app.repositories.notification import NotificationRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, n=3)
+
+        async with Session() as s:
+            repo = NotificationRepository(s, ORG)
+            page = await list_notifications(
+                unread=None, is_read=None, limit=50, before=None,
+                db=s, auth=_auth(), repo=repo,
+            )
+        assert [n.id for n in page["data"]] == seeded
+        assert page["meta"]["has_more"] is False
+        assert page["meta"]["next_cursor"] is None
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -176,7 +176,7 @@ async def test_notifications_list_via_conftest(test_client, mock_session):
 
     resp = await test_client.get(f"/api/v2/notifications?user_id={member_id}")
     assert resp.status_code == 200
-    assert resp.json() == []
+    assert resp.json()["data"] == []
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_mcp_check_notifications_2195_shape.py
+++ b/backend/tests/test_mcp_check_notifications_2195_shape.py
@@ -1,0 +1,51 @@
+"""story #2195 후속: GET /api/v2/notifications 응답이 bare array → {data, meta}(#2231 규약 A)로
+바뀌었다. sprintable_mcp/tools/notifications.py::check_notifications는 client.get()의 raw
+passthrough라 그대로 두면 호출 에이전트가 어느 날 배열 대신 {data,meta} 객체를 받게 된다
+(sprintable PyPI 0.1.1 — 외부 uvx 사용자도 영향권). 이 MCP 툴의 계약(에이전트가 보는 모양=
+배열)은 유지한다 — data만 꺼내 돌려주는 것을 이 테스트로 고정한다.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_check_notifications_unwraps_new_data_meta_shape():
+    from sprintable_mcp.tools.notifications import CheckNotificationsInput, check_notifications
+
+    new_shape_response = {
+        "data": [{"id": "n1", "title": "hello", "is_read": False}],
+        "meta": {"has_more": True, "next_cursor": "2026-01-01T00:00:00+00:00"},
+    }
+
+    with patch("sprintable_mcp.tools.notifications.client") as mock_client:
+        mock_client.get = AsyncMock(return_value=new_shape_response)
+        out = await check_notifications(CheckNotificationsInput())
+
+    parsed = json.loads(out[0].text)
+    # 툴 계약 유지 — 에이전트는 여전히 «배열»을 받는다(meta 봉투가 새 값이 아니다).
+    assert isinstance(parsed, list)
+    assert parsed == new_shape_response["data"]
+
+
+@pytest.mark.anyio
+async def test_check_notifications_tolerates_bare_array_response():
+    """구 BE(아직 안 갱신됐거나 롤백된 경우) — bare array 그대로 오면 그대로 통과시킨다."""
+    from sprintable_mcp.tools.notifications import CheckNotificationsInput, check_notifications
+
+    old_shape_response = [{"id": "n1", "title": "hello", "is_read": False}]
+
+    with patch("sprintable_mcp.tools.notifications.client") as mock_client:
+        mock_client.get = AsyncMock(return_value=old_shape_response)
+        out = await check_notifications(CheckNotificationsInput())
+
+    parsed = json.loads(out[0].text)
+    assert parsed == old_shape_response

--- a/backend/tests/test_mcp_check_notifications_2195_shape.py
+++ b/backend/tests/test_mcp_check_notifications_2195_shape.py
@@ -1,8 +1,13 @@
 """story #2195 후속: GET /api/v2/notifications 응답이 bare array → {data, meta}(#2231 규약 A)로
 바뀌었다. sprintable_mcp/tools/notifications.py::check_notifications는 client.get()의 raw
 passthrough라 그대로 두면 호출 에이전트가 어느 날 배열 대신 {data,meta} 객체를 받게 된다
-(sprintable PyPI 0.1.1 — 외부 uvx 사용자도 영향권). 이 MCP 툴의 계약(에이전트가 보는 모양=
-배열)은 유지한다 — data만 꺼내 돌려주는 것을 이 테스트로 고정한다.
+(sprintable PyPI 0.1.1 — 외부 uvx 사용자도 영향권). 이 MCP 툴의 계약(1차 블록=에이전트가
+보는 배열)은 유지한다 — data만 꺼내 돌려주는 것을 이 테스트로 고정한다.
+
+오르테가군 후속 지적: 배열만 언랩해 돌려주면 "목록이 조용히 끝난 척한다" 병(사람 화면에서
+방금 고친 그 병)이 에이전트 표면엔 그대로 남는다. has_more일 때 2차 텍스트 블록으로
+다음 페이지 안내(next_cursor)를 덧붙이고, before 파라미터로 실제로 다음 페이지를 받을 수
+있는 것까지 이 파일에서 고정한다.
 """
 from __future__ import annotations
 
@@ -23,17 +28,19 @@ async def test_check_notifications_unwraps_new_data_meta_shape():
 
     new_shape_response = {
         "data": [{"id": "n1", "title": "hello", "is_read": False}],
-        "meta": {"has_more": True, "next_cursor": "2026-01-01T00:00:00+00:00"},
+        "meta": {"has_more": False, "next_cursor": None},
     }
 
     with patch("sprintable_mcp.tools.notifications.client") as mock_client:
         mock_client.get = AsyncMock(return_value=new_shape_response)
         out = await check_notifications(CheckNotificationsInput())
 
+    # 툴 계약 유지 — 에이전트는 여전히 1차 블록으로 «배열»을 받는다(meta 봉투가 새 값이 아니다).
     parsed = json.loads(out[0].text)
-    # 툴 계약 유지 — 에이전트는 여전히 «배열»을 받는다(meta 봉투가 새 값이 아니다).
     assert isinstance(parsed, list)
     assert parsed == new_shape_response["data"]
+    # has_more=False면 다음 페이지 안내 블록을 안 붙인다(과잉 신호 금지).
+    assert len(out) == 1
 
 
 @pytest.mark.anyio
@@ -49,3 +56,40 @@ async def test_check_notifications_tolerates_bare_array_response():
 
     parsed = json.loads(out[0].text)
     assert parsed == old_shape_response
+    assert len(out) == 1
+
+
+@pytest.mark.anyio
+async def test_check_notifications_signals_has_more_with_next_page_hint():
+    """AC(오르테가군 지적) 핵심 — «더 있다»가 에이전트 표면에서 안 사라진다."""
+    from sprintable_mcp.tools.notifications import CheckNotificationsInput, check_notifications
+
+    new_shape_response = {
+        "data": [{"id": "n1", "title": "hello", "is_read": False}],
+        "meta": {"has_more": True, "next_cursor": "2026-01-01T00:00:00+00:00"},
+    }
+
+    with patch("sprintable_mcp.tools.notifications.client") as mock_client:
+        mock_client.get = AsyncMock(return_value=new_shape_response)
+        out = await check_notifications(CheckNotificationsInput())
+
+    # 1차 블록은 여전히 순수 배열(데이터 오염 없음 — 안내가 배열 안에 섞이지 않는다).
+    parsed = json.loads(out[0].text)
+    assert parsed == new_shape_response["data"]
+    # 2차 블록에 다음 페이지 커서가 실제로 실려 있다.
+    assert len(out) == 2
+    assert "2026-01-01T00:00:00+00:00" in out[1].text
+    assert "더 있음" in out[1].text
+
+
+@pytest.mark.anyio
+async def test_check_notifications_passes_before_cursor_through():
+    """before 인자를 넘기면 실제로 BE 쿼리파라미터로 전달돼 다음 페이지를 받을 수 있다."""
+    from sprintable_mcp.tools.notifications import CheckNotificationsInput, check_notifications
+
+    with patch("sprintable_mcp.tools.notifications.client") as mock_client:
+        mock_client.get = AsyncMock(return_value={"data": [], "meta": {"has_more": False, "next_cursor": None}})
+        await check_notifications(CheckNotificationsInput(before="2026-01-01T00:00:00+00:00"))
+
+    _, kwargs = mock_client.get.call_args
+    assert kwargs["params"]["before"] == "2026-01-01T00:00:00+00:00"

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -120,8 +120,12 @@ async def test_list_notifications_200():
                 resp = await c.get(f"/api/v2/notifications?user_id={MEMBER_ID}")
 
         assert resp.status_code == 200
-        assert len(resp.json()) == 1
-        assert resp.json()[0]["is_read"] is False
+        body = resp.json()
+        assert len(body["data"]) == 1
+        assert body["data"][0]["is_read"] is False
+        # story #2195: #2231 정본 규약 A — body meta 로 has_more/next_cursor 를 낸다.
+        assert body["meta"]["has_more"] is False
+        assert body["meta"]["next_cursor"] is None
     finally:
         app.dependency_overrides.clear()
 
@@ -137,7 +141,7 @@ async def test_list_notifications_is_read_filter_200():
                 resp = await c.get(f"/api/v2/notifications?user_id={MEMBER_ID}&is_read=true")
 
         assert resp.status_code == 200
-        assert resp.json() == []
+        assert resp.json()["data"] == []
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary
- 원 신고 그대로 확定(오르테가군, 2026-07-27): 인박스 페이지 기본 탭(`?tab=notifications`)이 `GET /api/notifications`(FE 하드코딩 `limit:50`, 커서 없음)로 51번째부터 조용히 잘림. 사이드바 뱃지(`inboxUnreadCount`)는 같은 `Notification` 테이블 미읽음 **전량**을 세므로 뱃지-목록 불일치로 체감됨.
- #2231에서 확定된 정본 규약 **A**(limit+1 오버페치 + `has_more`/`next_cursor` body meta, 참조 구현: `conversations.py::list_messages`)를 이 엔드포인트에 적용.

## Changes (BE only — 이 PR 범위)
- `app/repositories/notification.py`: `NotificationRepository.list()`에 `before: datetime | None` 커서 파라미터 추가.
- `app/routers/notifications.py`: `GET /api/v2/notifications` — `before`(ISO datetime) 쿼리 파라미터 추가, `limit+1` 오버페치, 응답을 `list[NotificationResponse]` → `{"data": [...], "meta": {"has_more": bool, "next_cursor": str|null}}`로 변경.

## ⚠️ Breaking change — 알려진 소비자 2곳, 별도 페어링으로 후속 갱신 필요
```
apps/web/src/app/api/notifications/route.ts  — FE 프록시. 새 {data,meta} 응답을 소비하도록
  갱신 필요(현재는 bare array 기대). 오르테가군이 미르코군과의 페어링 자리를 잡아 줄 예정.
sprintable_mcp/tools/notifications.py check_notifications — raw passthrough(ok(await client.get(...)))
  라 코드 자체는 안 깨짐. 다만 호출 에이전트가 보는 JSON 모양이 바뀜(배열 → {data,meta}).
```
이 PR은 BE만 포함 — FE `route.ts`/`page.tsx`는 손대지 않음(오르테가군 지시대로 BE 선행).

## Test plan
- [x] 신규 realdb 테스트(`test_2195_notifications_cursor_pagination_realdb.py`): 5건 심어 limit=2로 3페이지 완주 — page1/page2/page3가 서로 안 겹치고 합집합이 원본 5건과 순서까지 정확히 일치. 음성대조(총량≤limit이면 has_more=False) 포함.
- [x] 뮤테이션 셀프체크: `before` 파라미터를 쿼리에서 미반영시키면 page2==page1로 정확히 예측한 자리에서 RED, 복구 후 재확認 GREEN.
- [x] 기존 `test_notifications.py`/`test_integration.py`(응답 shape 변경으로 2건 assertion 갱신 — bare array → `["data"]`) 포함 52 passed, 1 xfailed(무관) 회귀 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)