### PR TITLE
[SID:2195] 인박스 기본 탭 커서 페이지네이션 — 51번째부터 조용히 잘리던 것 (FE, BE #2538과 짝)

### DIFF
--- a/apps/web/src/app/(authenticated)/inbox/inbox-pagination.test.tsx
+++ b/apps/web/src/app/(authenticated)/inbox/inbox-pagination.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+//
+// story #2195 — 인박스 기본(notifications) 탭이 서버 하드코딩 limit=50 + 커서 없음으로
+// 51번째부터 조용히 잘렸다. BE(#2538, 규약 A)가 has_more/next_cursor를 body meta로 낸다 —
+// FE가 "더 보기"를 세우고, 눌렀을 때 실제로 next_cursor를 다음 요청에 실어 붙이는지,
+// 그리고 서버가 hasMore=false면 그 버튼이 서 있지 않는지가 이 스위트의 본체다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { TopBarProvider } from '@/components/nav/top-bar-context';
+import koMessages from '../../../../messages/ko.json';
+
+const { useDashboardContextMock, pushMock, replaceMock } = vi.hoisted(() => ({
+  useDashboardContextMock: vi.fn(),
+  pushMock: vi.fn(),
+  replaceMock: vi.fn(),
+}));
+
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => useDashboardContextMock(),
+}));
+vi.mock('../../dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => useDashboardContextMock(),
+}));
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+vi.mock('@/components/inbox/decisions-waiting', () => ({ DecisionsWaiting: () => null }));
+vi.mock('@/components/inbox/approvals-queue', () => ({ ApprovalsQueue: () => null }));
+vi.mock('@/components/attention-queue/attention-queue-view', () => ({ AttentionQueueView: () => null }));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      <TopBarProvider>{node}</TopBarProvider>
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  pushMock.mockClear();
+  replaceMock.mockClear();
+  useDashboardContextMock.mockReturnValue({ currentTeamMemberId: 'me-1', projectId: 'proj-1' });
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+const NOTIF = (id: string) => ({
+  id, org_id: 'o1', user_id: 'u1', type: 'x', title: `notif-${id}`, body: null,
+  is_read: false, reference_type: null, reference_id: null, created_at: '2026-01-01T00:00:00+00:00',
+});
+
+function stubFetch(pages: { hasMore: boolean; nextCursor: string | null; items: unknown[] }[]) {
+  let call = 0;
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (typeof url === 'string' && url.includes('/api/workflow-executions')) {
+      return { ok: true, json: async () => ({ items: [] }) };
+    }
+    if (typeof url === 'string' && url.includes('/api/notifications')) {
+      const page = pages[Math.min(call, pages.length - 1)];
+      call += 1;
+      return {
+        ok: true,
+        json: async () => ({ data: page!.items, meta: { unreadCount: page!.items.length, hasMore: page!.hasMore, nextCursor: page!.nextCursor } }),
+      };
+    }
+    return { ok: false, status: 404, json: async () => null };
+  }));
+}
+
+async function mount(Page: React.ComponentType) {
+  await act(async () => {
+    root.render(wrap(<Page />));
+  });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('인박스 기본 탭 커서 페이지네이션 (story #2195)', () => {
+  it('hasMore=true면 "더 보기" 버튼이 뜬다', async () => {
+    stubFetch([{ hasMore: true, nextCursor: '2025-12-01T00:00:00+00:00', items: [NOTIF('1'), NOTIF('2')] }]);
+    const { default: InboxPage } = await import('./page');
+    await mount(InboxPage);
+
+    const loadMoreBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '더 보기');
+    expect(loadMoreBtn).toBeTruthy();
+  });
+
+  it('hasMore=false면 "더 보기" 버튼이 서 있지 않는다(서버가 못 줄 때 안 보이게)', async () => {
+    stubFetch([{ hasMore: false, nextCursor: null, items: [NOTIF('1')] }]);
+    const { default: InboxPage } = await import('./page');
+    await mount(InboxPage);
+
+    const loadMoreBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '더 보기');
+    expect(loadMoreBtn).toBeFalsy();
+  });
+
+  it('"더 보기" 클릭 시 nextCursor를 실어 다음 페이지를 요청하고, 결과를 기존 목록에 이어 붙인다', async () => {
+    stubFetch([
+      { hasMore: true, nextCursor: '2025-12-01T00:00:00+00:00', items: [NOTIF('1'), NOTIF('2')] },
+      { hasMore: false, nextCursor: null, items: [NOTIF('3')] },
+    ]);
+    const { default: InboxPage } = await import('./page');
+    await mount(InboxPage);
+
+    expect(container.textContent).toContain('notif-1');
+    expect(container.textContent).not.toContain('notif-3');
+
+    const loadMoreBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '더 보기')!;
+    await act(async () => { loadMoreBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    const fetchMock = vi.mocked(fetch);
+    const secondCallUrl = fetchMock.mock.calls.find(([u]) =>
+      typeof u === 'string' && u.includes('/api/notifications') && u.includes('cursor='),
+    )?.[0] as string | undefined;
+    expect(secondCallUrl).toContain(`cursor=${encodeURIComponent('2025-12-01T00:00:00+00:00')}`);
+
+    // 이어 붙임 — 기존 항목이 사라지지 않고 새 항목이 추가된다.
+    expect(container.textContent).toContain('notif-1');
+    expect(container.textContent).toContain('notif-3');
+    // 2페이지째는 hasMore:false라 버튼이 사라진다.
+    expect([...container.querySelectorAll('button')].find((b) => b.textContent === '더 보기')).toBeFalsy();
+  });
+});

--- a/apps/web/src/app/(authenticated)/inbox/page.tsx
+++ b/apps/web/src/app/(authenticated)/inbox/page.tsx
@@ -156,9 +156,13 @@ function AgentJoinedDetailPanel({
   );
 }
 
-async function fetchInboxNotifications(typeFilter: string) {
+// story #2195 — 기본(notifications) 탭이 서버 하드코딩 limit=50 + 커서 없음으로 51번째부터
+// 조용히 잘렸다. BE(#2538, 규약 A)가 이제 has_more/next_cursor를 body meta로 낸다 —
+// cursor를 실어 보내고 그 meta를 그대로 다음 요청에 이어 붙인다.
+async function fetchInboxNotifications(typeFilter: string, cursor?: string | null) {
   const params = new URLSearchParams();
   if (typeFilter) params.set('type', typeFilter);
+  if (cursor) params.set('cursor', cursor);
 
   const res = await fetch(`/api/notifications?${params}`);
   if (!res.ok) return null;
@@ -167,6 +171,8 @@ async function fetchInboxNotifications(typeFilter: string) {
   return {
     notifications: (json.data ?? []) as Notification[],
     unreadCount: (json.meta?.unreadCount ?? 0) as number,
+    hasMore: (json.meta?.hasMore ?? false) as boolean,
+    nextCursor: (json.meta?.nextCursor ?? null) as string | null,
   };
 }
 
@@ -193,17 +199,40 @@ export default function InboxPage() {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [hasMore, setHasMore] = useState(false);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  // story #2195 — 사용자가 "더 보기"로 두 번째 페이지 이상을 이미 펼친 뒤, 15초 폴링
+  // 리프레시가 그 상태를 조용히 1페이지로 되돌리면 안 된다(펼친 걸 다시 접는 것으로 읽힌다).
+  // 더 보기를 누른 적이 있으면 그 뒤로는 자동 폴링을 건너뛴다.
+  const [pagedBeyondFirst, setPagedBeyondFirst] = useState(false);
   const [workflowExecs, setWorkflowExecs] = useState<WorkflowExecItem[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const { toasts, addToast, dismissToast } = useToast();
 
   const refreshNotifications = useCallback(async () => {
+    if (pagedBeyondFirst) return;
     const result = await fetchInboxNotifications('');
     if (!result) return;
 
     setNotifications(result.notifications);
     setUnreadCount(result.unreadCount);
-  }, []);
+    setHasMore(result.hasMore);
+    setNextCursor(result.nextCursor);
+  }, [pagedBeyondFirst]);
+
+  const loadMoreNotifications = useCallback(async () => {
+    if (!nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    const result = await fetchInboxNotifications('', nextCursor);
+    if (result) {
+      setNotifications((prev) => [...prev, ...result.notifications]);
+      setHasMore(result.hasMore);
+      setNextCursor(result.nextCursor);
+      setPagedBeyondFirst(true);
+    }
+    setLoadingMore(false);
+  }, [nextCursor, loadingMore]);
 
   useEffect(() => {
     let cancelled = false;
@@ -214,6 +243,8 @@ export default function InboxPage() {
       if (!cancelled && result) {
         setNotifications(result.notifications);
         setUnreadCount(result.unreadCount);
+        setHasMore(result.hasMore);
+        setNextCursor(result.nextCursor);
       }
       if (!cancelled) setLoading(false);
     }
@@ -575,6 +606,20 @@ export default function InboxPage() {
                 </div>
               ))
             )}
+            {/* story #2195 — hasMore가 참일 때만 노출(서버가 못 줄 때 서 있지 않게). */}
+            {!loading && hasMore ? (
+              <div className="px-3 py-3">
+                <Button
+                  variant="glass"
+                  size="sm"
+                  className="w-full"
+                  disabled={loadingMore}
+                  onClick={() => void loadMoreNotifications()}
+                >
+                  {tCommon('loadMore')}
+                </Button>
+              </div>
+            ) : null}
           </div>
         </div>
 

--- a/apps/web/src/app/api/notifications/route.test.ts
+++ b/apps/web/src/app/api/notifications/route.test.ts
@@ -31,13 +31,41 @@ describe('/api/notifications (직접 repo)', () => {
     expect((await GET(new Request('http://localhost/api/notifications'))).status).toBe(401);
   });
   it('GET: lists via repo + attachHrefs + unreadCount meta', async () => {
-    h.list.mockResolvedValue([{ id: 'n1', is_read: false, type: 'x' }, { id: 'n2', is_read: true, type: 'x' }]);
+    h.list.mockResolvedValue({
+      items: [{ id: 'n1', is_read: false, type: 'x' }, { id: 'n2', is_read: true, type: 'x' }],
+      hasMore: false,
+      nextCursor: null,
+    });
     const res = await GET(new Request('http://localhost/api/notifications'));
     expect(res.status).toBe(200);
     expect(h.list).toHaveBeenCalledWith(expect.objectContaining({ user_id: 'mem-1' }));
     const body = await res.json();
     expect(body.data).toHaveLength(2);
     expect(body.meta.unreadCount).toBe(1);
+  });
+
+  // story #2195 — 규약 A: cursor를 받아 repo.list에 그대로 실어 보내고, hasMore/nextCursor를
+  // meta로 그대로 전달한다(서버가 못 줄 때 "더 보기"가 서 있으면 안 된다 — 그 판단은 hasMore).
+  it('GET: cursor 쿼리를 repo.list로 전달하고 hasMore/nextCursor를 meta로 반환한다', async () => {
+    h.list.mockResolvedValue({
+      items: [{ id: 'n3', is_read: false, type: 'x' }],
+      hasMore: true,
+      nextCursor: '2026-01-01T00:00:00+00:00',
+    });
+    const res = await GET(new Request('http://localhost/api/notifications?cursor=2025-12-31T00:00:00%2B00:00'));
+    expect(res.status).toBe(200);
+    expect(h.list).toHaveBeenCalledWith(expect.objectContaining({ cursor: '2025-12-31T00:00:00+00:00' }));
+    const body = await res.json();
+    expect(body.meta.hasMore).toBe(true);
+    expect(body.meta.nextCursor).toBe('2026-01-01T00:00:00+00:00');
+  });
+
+  it('GET: hasMore=false면 nextCursor도 null로 전달된다("더 보기"가 서 있지 않게)', async () => {
+    h.list.mockResolvedValue({ items: [], hasMore: false, nextCursor: null });
+    const res = await GET(new Request('http://localhost/api/notifications'));
+    const body = await res.json();
+    expect(body.meta.hasMore).toBe(false);
+    expect(body.meta.nextCursor).toBeNull();
   });
 
   it('PATCH: invalid body → parseBody 400', async () => {

--- a/apps/web/src/app/api/notifications/route.ts
+++ b/apps/web/src/app/api/notifications/route.ts
@@ -15,17 +15,25 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
     const typeFilter = searchParams.get('type');
     const unreadOnly = searchParams.get('unread') === 'true';
+    // story #2195(#2231 규약 A) — 하드코딩 limit=50 + 커서 없음으로 51번째부터 조용히
+    // 잘리던 자리. BE(#2538)가 before 커서 + has_more/next_cursor를 지원한다.
+    const cursor = searchParams.get('cursor');
 
     const repo = await createNotificationRepository();
-    const notifications = await repo.list({
+    const { items, hasMore, nextCursor } = await repo.list({
       user_id: me.id,
       is_read: unreadOnly ? false : undefined,
       limit: 50,
+      cursor,
     });
-    const filtered = typeFilter ? notifications.filter((n) => n.type === typeFilter) : notifications;
+    // ⛔type 필터는 서버 커서 페이지 이후 클라이언트 측 후처리다 — 이 필터를 쓰는 유일한
+    // 호출자(now-face.tsx)는 페이지네이션 없이 단발 조회만 하므로 hasMore/nextCursor와
+    // 어긋나지 않는다(#2195 스코프 확認). 페이지네이션 UI(inbox 기본 탭)는 typeFilter를
+    // 안 쓴다.
+    const filtered = typeFilter ? items.filter((n) => n.type === typeFilter) : items;
     const withHrefs = await attachNotificationHrefs(undefined, filtered);
     const unreadCount = filtered.filter((n) => !n.is_read).length;
-    return apiSuccess(withHrefs, { unreadCount });
+    return apiSuccess(withHrefs, { unreadCount, hasMore, nextCursor });
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/lib/i18n-template-key-coverage.test.ts
+++ b/apps/web/src/lib/i18n-template-key-coverage.test.ts
@@ -36,6 +36,10 @@ function hasKey(messages: unknown, dotted: string): boolean {
 
 // [prefix, values[], sourceOfTruth] — sourceOfTruth는 그 값 집합을 어디서 실제로 확인했는지
 // (다음 사람이 재검증할 때 다시 읽을 자리).
+// ⛔이 표는 손으로 갱신해야 한다(PO 리뷰, 2026-07-27) — 정적 스캔이 아니라 하드코딩이라,
+// 새 템플릿 조합 키(`t(\`prefix_${var}\`)` 형태)를 만들면 이 표가 조용히 낡는다. 그 상태로는
+// 가드가 계속 초록인데 새 키만 화면에 그대로 뜬다 — 새 조합 키를 추가할 때 반드시 여기 항목을
+// 같이 추가할 것.
 const TEMPLATE_KEY_TABLE: Array<[string, string[], string]> = [
   ['proofCapsule.risk.', ['low', 'medium', 'high'], 'proof-capsule.tsx RISK_KEY 값 타입'],
   ['settings.mcpConnections.status.', ['active', 'error', 'pending_oauth', 'disconnected'], 'mcp-connection-settings.tsx McpConnectionSummary.status'],

--- a/packages/core-storage/src/index.ts
+++ b/packages/core-storage/src/index.ts
@@ -75,6 +75,7 @@ export type {
   Notification,
   CreateNotificationInput,
   NotificationListFilters,
+  NotificationListResult,
 } from './interfaces/INotificationRepository';
 
 export type {

--- a/packages/core-storage/src/interfaces/INotificationRepository.ts
+++ b/packages/core-storage/src/interfaces/INotificationRepository.ts
@@ -28,9 +28,17 @@ export interface NotificationListFilters extends PaginationOptions {
   is_read?: boolean;
 }
 
+// story #2195(#2231 규약 A) — BE가 has_more/next_cursor를 body meta로 직접 계산해 낸다
+// (limit+1 오버페치는 BE 내부에서 이미 끝남 — FE가 buildCursorPageMeta로 재추론하지 않는다).
+export interface NotificationListResult {
+  items: Notification[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
 export interface INotificationRepository {
   create(input: CreateNotificationInput): Promise<Notification>;
-  list(filters: NotificationListFilters): Promise<Notification[]>;
+  list(filters: NotificationListFilters): Promise<NotificationListResult>;
   markRead(id: string, userId: string): Promise<Notification>;
   markAllRead(userId: string): Promise<number>;
   // story #2194 — list(limit:200).length는 200건 넘는 계정에서 실제 unread 수를 거짓으로

--- a/packages/storage-api/src/ApiNotificationRepository.test.ts
+++ b/packages/storage-api/src/ApiNotificationRepository.test.ts
@@ -1,0 +1,48 @@
+// story #2195(#2231 규약 A) — BE(#2538)가 GET /api/v2/notifications 응답을 배열에서
+// {data, meta:{has_more, next_cursor}}로 바꿨다. FE가 cursor(before로 매핑)를 실제
+// 요청 URL에 실어 보내는지, 그리고 새 응답 형태를 {items, hasMore, nextCursor}로 정확히
+// 풀어내는지가 이 스위트의 본체다 — 이걸 놓치면 인박스 "더 보기"가 아무 것도 안 붙는다.
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { ApiNotificationRepository } from './ApiNotificationRepository';
+
+describe('ApiNotificationRepository.list — cursor 전달 + {data,meta} 응답 언랩 (#2195)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [{ id: 'n1', org_id: 'o1', user_id: 'u1', type: 'x', title: 't', body: null, is_read: false, reference_type: null, reference_id: null, created_at: '2026-01-01T00:00:00+00:00' }],
+        meta: { has_more: true, next_cursor: '2026-01-01T00:00:00+00:00' },
+      }),
+    })) as unknown as ReturnType<typeof vi.fn>;
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  it('cursor가 있으면 요청 URL에 before로 실린다', async () => {
+    const repo = new ApiNotificationRepository('token');
+    await repo.list({ user_id: 'u1', limit: 50, cursor: '2025-12-31T00:00:00+00:00' });
+
+    const requestedUrl = (fetchMock.mock.calls[0]![0] as URL | string).toString();
+    expect(requestedUrl).toContain(`before=${encodeURIComponent('2025-12-31T00:00:00+00:00')}`);
+  });
+
+  it('cursor가 없으면 before가 요청 URL에 안 실린다(기존 무커서 호출 회귀 0)', async () => {
+    const repo = new ApiNotificationRepository('token');
+    await repo.list({ user_id: 'u1', limit: 50 });
+
+    const requestedUrl = (fetchMock.mock.calls[0]![0] as URL | string).toString();
+    expect(requestedUrl).not.toContain('before=');
+  });
+
+  it('{data,meta} 응답을 {items,hasMore,nextCursor}로 정확히 언랩한다', async () => {
+    const repo = new ApiNotificationRepository('token');
+    const result = await repo.list({ user_id: 'u1', limit: 50 });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]!.id).toBe('n1');
+    expect(result.hasMore).toBe(true);
+    expect(result.nextCursor).toBe('2026-01-01T00:00:00+00:00');
+  });
+});

--- a/packages/storage-api/src/ApiNotificationRepository.ts
+++ b/packages/storage-api/src/ApiNotificationRepository.ts
@@ -1,5 +1,10 @@
-import type { INotificationRepository, Notification, CreateNotificationInput, NotificationListFilters } from '@sprintable/core-storage';
+import type { INotificationRepository, Notification, CreateNotificationInput, NotificationListFilters, NotificationListResult } from '@sprintable/core-storage';
 import { fastapiCall } from './utils';
+
+interface RawNotificationListResponse {
+  data: Notification[];
+  meta: { has_more: boolean; next_cursor: string | null };
+}
 
 export class ApiNotificationRepository implements INotificationRepository {
   constructor(private readonly accessToken: string = '') {}
@@ -8,8 +13,19 @@ export class ApiNotificationRepository implements INotificationRepository {
     return fastapiCall<Notification>('POST', '/api/v2/notifications', this.accessToken, { body: input });
   }
 
-  async list(filters: NotificationListFilters): Promise<Notification[]> {
-    return fastapiCall<Notification[]>('GET', '/api/v2/notifications', this.accessToken, { query: { user_id: filters.user_id, is_read: filters.is_read != null ? String(filters.is_read) : undefined, limit: filters.limit } });
+  // story #2195(#2231 규약 A) — BE가 {data, meta:{has_more, next_cursor}}로 응답한다(#2538).
+  // cursor는 BE 쿼리 파라미터명 `before`로 매핑한다(FE 공통 필드명은 cursor로 유지 — 다른
+  // 저장소들과 인터페이스 일관성).
+  async list(filters: NotificationListFilters): Promise<NotificationListResult> {
+    const res = await fastapiCall<RawNotificationListResponse>('GET', '/api/v2/notifications', this.accessToken, {
+      query: {
+        user_id: filters.user_id,
+        is_read: filters.is_read != null ? String(filters.is_read) : undefined,
+        limit: filters.limit,
+        before: filters.cursor ?? undefined,
+      },
+    });
+    return { items: res.data, hasMore: res.meta.has_more, nextCursor: res.meta.next_cursor };
   }
 
   async markRead(id: string, _userId: string): Promise<Notification> {


### PR DESCRIPTION
## 요약
⛔**BE #2538과 짝으로 나가야 하는 PR** — BE 단독 머지 시 인박스 화면이 즉시 깨진다(PO가 #2538을 잡아 두고 이 PR과 함께 미는 것으로 결정. 순서: 이 PR CI 초록 → #2538(BE) 머지 → 이 PR(FE) 머지 → 배포).

## 원인
`apps/web/src/app/api/notifications/route.ts`가 `limit=50` 하드코딩 + 커서 자체가 없어 51번째 알림부터 목록에 영원히 안 보였다. BE #2538이 `GET /api/v2/notifications` 응답을 배열 → `{data, meta:{has_more, next_cursor}}`로 바꾸고 `NotificationRepository.list()`에 `before`(datetime) 커서 + limit+1 오버페치를 추가한다(#2231 규약 A, 참조 구현: `conversations.py::list_messages`).

## 변경
- **packages/core-storage**: `INotificationRepository.list()`가 `Notification[]` 대신 `{items, hasMore, nextCursor}`를 반환(유일한 소비처라 안전한 변경).
- **packages/storage-api**: `ApiNotificationRepository.list()`가 새 `{data,meta}` 응답을 언랩, `filters.cursor` → BE 쿼리 파라미터 `before`로 매핑.
- **apps/web/src/app/api/notifications/route.ts**: `cursor` 쿼리를 받아 repo에 전달, `hasMore`/`nextCursor`를 meta로 반환. type 필터(`now-face.tsx` 전용, 단발 조회)와 안 겹침 확인(inbox 기본 탭은 typeFilter 안 씀).
- **inbox/page.tsx**: "더 보기" 버튼(hasMore일 때만 노출) — 누르면 `nextCursor`로 다음 페이지를 가져와 이어 붙임. 15초 폴링 리프레시가 "더 보기"로 펼친 상태를 조용히 1페이지로 되돌리지 않도록 가드 추가.

`buildCursorPageMeta`와는 안 겹침 확인 — 이 경로는 그 함수를 애초에 안 쓰고(4곳 전수에 안 들어감), BE가 이미 `has_more`/`next_cursor`를 직접 계산해 내는 규약 A를 그대로 따른다.

## 테스트
mutation 확인 완료(3곳 — repo `before` 매핑, route cursor 전달, page 버튼 게이팅 — 되돌리면 정확히 그 자리 RED). 2페이지 전환(hasMore:true→false) 단위테스트로 51번째 경계 재현. 전체 vitest 331 files/2272 passed. type-check(core-storage·storage-api) clean. build/lint clean.

## 겸사 — i18n 가드 후속 (PR#2536 PO 리뷰 코멘트)
`i18n-template-key-coverage.test.ts`에 "이 표는 손으로 갱신해야 한다" 주석 추가(CI 재실행 아끼려고 다음 FE PR에 묻히는 것으로 합의됨).

## Test plan
- [ ] BE #2538 머지 후 이 PR 머지 → 배포 → 51개 넘는 알림 계정에서 "더 보기"가 실제로 다음 페이지를 붙이는지 라이브 확인(까심군)

🤖 Generated with [Claude Code](https://claude.com/claude-code)