### PR TITLE
fix(#2191): GET /api/v2/docs 커서 페이지네이션 — 문서 트리 500건 절단 해소

### DIFF
--- a/backend/app/repositories/doc.py
+++ b/backend/app/repositories/doc.py
@@ -17,13 +17,20 @@ def encode_doc_cursor(doc: Doc) -> str:
     return f"{doc.sort_order}:{doc.id}"
 
 
-def parse_doc_cursor(cursor: str | None) -> tuple[int, uuid.UUID] | None:
-    if not cursor:
+def parse_doc_cursor(cursor: object) -> tuple[int, uuid.UUID] | None:
+    """오르테가군 지적(2026-07-27, #2540 CI): 이 함수는 HTTP(FastAPI 가 Query(...)를
+    리졸브해 진짜 str|None 을 줌)와 직접호출(테스트·내부 — 인자를 명시로 안 넘기면
+    파이썬 기본값인 Query(...) 센티넬 객체 그 자체가 들어옴) 두 경로로 불린다.
+    예전엔 `if not cursor:` 가 "값이 있는지"만 보고 "그 값이 문자열인지"는 안 봐서,
+    Query 객체(truthy)가 그대로 통과해 .split() 에서 터졌다(또는 AttributeError→400
+    으로 변질돼 정상 "커서 없음" 요청을 거절하는 쪽으로 오동작). 문자열이 아니면
+    타입 단계에서 즉시 None(커서 없음) 취급 — 값의 존재가 아니라 값의 종류를 본다."""
+    if not isinstance(cursor, str) or not cursor:
         return None
     try:
         sort_order_str, id_str = cursor.split(":", 1)
         return int(sort_order_str), uuid.UUID(id_str)
-    except (ValueError, AttributeError) as exc:
+    except ValueError as exc:
         from fastapi import HTTPException
         raise HTTPException(status_code=400, detail="Invalid cursor format") from exc
 

--- a/backend/app/repositories/doc.py
+++ b/backend/app/repositories/doc.py
@@ -3,22 +3,45 @@ from __future__ import annotations
 import uuid
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import select, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.doc import Doc
 from app.repositories.base import BaseRepository
 
 
+def encode_doc_cursor(doc: Doc) -> str:
+    """story #2191: (sort_order, id) 복합 커서 — sort_order 는 기본값 0 이 절대다수라
+    단독으로는 동률(tie)이 흔하다(모델 default=0, 수동 재배치 안 한 doc이 대다수).
+    id 를 2차 정렬키로 더해야 페이지 경계에서 행이 누락되거나 중복되지 않는다."""
+    return f"{doc.sort_order}:{doc.id}"
+
+
+def parse_doc_cursor(cursor: str | None) -> tuple[int, uuid.UUID] | None:
+    if not cursor:
+        return None
+    try:
+        sort_order_str, id_str = cursor.split(":", 1)
+        return int(sort_order_str), uuid.UUID(id_str)
+    except (ValueError, AttributeError) as exc:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=400, detail="Invalid cursor format") from exc
+
+
 class DocRepository(BaseRepository[Doc]):
     def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
         super().__init__(Doc, session, org_id)
 
-    async def list(self, limit: int = 500, **filters: Any) -> list[Doc]:  # type: ignore[override]
+    async def list(
+        self, limit: int = 500, cursor: str | None = None, **filters: Any
+    ) -> list[Doc]:  # type: ignore[override]
         q = select(Doc).where(self._org_filter(), Doc.deleted_at.is_(None))
         for attr, val in filters.items():
             q = q.where(getattr(Doc, attr) == val)
-        q = q.order_by(Doc.sort_order).limit(limit)
+        parsed = parse_doc_cursor(cursor)
+        if parsed is not None:
+            q = q.where(tuple_(Doc.sort_order, Doc.id) > tuple_(*parsed))
+        q = q.order_by(Doc.sort_order, Doc.id).limit(limit)
         result = await self.session.execute(q)
         return list(result.scalars().all())
 
@@ -50,7 +73,9 @@ class DocRepository(BaseRepository[Doc]):
         )
         return result.scalar_one_or_none()
 
-    async def list_tree(self, project_id: uuid.UUID, parent_id: uuid.UUID | None = None, limit: int = 500) -> list[Doc]:
+    async def list_tree(
+        self, project_id: uuid.UUID, parent_id: uuid.UUID | None = None, limit: int = 500, cursor: str | None = None,
+    ) -> list[Doc]:
         """project 내 특정 parent 하위 docs 조회 (트리 1레벨)."""
         q = select(Doc).where(
             self._org_filter(),
@@ -61,12 +86,20 @@ class DocRepository(BaseRepository[Doc]):
             q = q.where(Doc.parent_id.is_(None))
         else:
             q = q.where(Doc.parent_id == parent_id)
-        q = q.order_by(Doc.sort_order).limit(limit)
+        parsed = parse_doc_cursor(cursor)
+        if parsed is not None:
+            q = q.where(tuple_(Doc.sort_order, Doc.id) > tuple_(*parsed))
+        q = q.order_by(Doc.sort_order, Doc.id).limit(limit)
         result = await self.session.execute(q)
         return list(result.scalars().all())
 
-    async def search_by_tags(self, project_id: uuid.UUID, tags: list[str], limit: int = 500) -> list[Doc]:
-        """tags 배열이 주어진 태그를 모두 포함하는 docs 조회 (@> 연산자)."""
+    async def search_by_tags(
+        self, project_id: uuid.UUID, tags: list[str], limit: int = 500, cursor: str | None = None,
+    ) -> list[Doc]:
+        """tags 배열이 주어진 태그를 모두 포함하는 docs 조회 (@> 연산자).
+
+        story #2191: 예전엔 ORDER BY 자체가 없어(암묵적 DB 순서, 비결정적) 커서 페이지네이션이
+        애초에 안전하지 않았다 — list()/list_tree()와 같은 (sort_order,id) 규약으로 통일한다."""
         from sqlalchemy import cast
         from sqlalchemy.dialects.postgresql import ARRAY
         from sqlalchemy import Text
@@ -76,14 +109,23 @@ class DocRepository(BaseRepository[Doc]):
             Doc.project_id == project_id,
             Doc.deleted_at.is_(None),
             Doc.tags.contains(cast(tags, ARRAY(Text))),
-        ).limit(limit)
+        )
+        parsed = parse_doc_cursor(cursor)
+        if parsed is not None:
+            q = q.where(tuple_(Doc.sort_order, Doc.id) > tuple_(*parsed))
+        q = q.order_by(Doc.sort_order, Doc.id).limit(limit)
         result = await self.session.execute(q)
         return list(result.scalars().all())
 
     async def search_full_text(
         self, project_id: uuid.UUID, query: str, limit: int = 50
     ) -> list[tuple[Doc, str | None]]:
-        """tsvector 기반 전문 검색. ts_rank 내림차순. snippet 포함."""
+        """tsvector 기반 전문 검색. ts_rank 내림차순. snippet 포함.
+
+        story #2191: 이 분기는 의도적으로 (sort_order,id) 커서 규약을 안 쓴다 — 정렬 기준이
+        관련도(ts_rank)라 위치/시간 커서를 얹으면 페이지마다 순위가 뒤섞인다(오르테가군 판단,
+        2026-07-27). limit=50 상한 안에서만 결과를 낸다 — 그 너머로 스크롤하는 UX는 이 함수의
+        스코프 밖(검색 결과 심층 페이지네이션이 필요해지면 별도 설계로 다룰 것)."""
         from sqlalchemy import func, literal_column
 
         tsquery = func.plainto_tsquery("simple", query)

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -81,7 +81,21 @@ def _get_repo(
     return DocRepository(session, org_id)
 
 
-@router.get("", response_model=list[DocSummaryResponse])
+def _doc_page_envelope(docs: list, limit: int) -> dict:
+    """story #2191: #2231 정본 규약 A(limit+1 오버페치 + has_more/next_cursor body meta).
+    docs 는 이미 limit+1 개까지 조회된 상태로 들어온다(호출부에서 overfetch)."""
+    from app.repositories.doc import encode_doc_cursor
+
+    has_more = len(docs) > limit
+    page = docs[:limit]
+    next_cursor = encode_doc_cursor(page[-1]) if has_more and page else None
+    return {
+        "data": [DocSummaryResponse.model_validate(d) for d in page],
+        "meta": {"has_more": has_more, "next_cursor": next_cursor},
+    }
+
+
+@router.get("")
 async def list_docs(
     project_id: uuid.UUID | None = Query(default=None),
     parent_id: uuid.UUID | None = Query(default=None),
@@ -90,15 +104,19 @@ async def list_docs(
     slug: str | None = Query(default=None),
     q: str | None = Query(default=None, description="전문 검색 — 제목 + 본문"),
     limit: int = Query(default=500, ge=1, le=1000),
+    cursor: str | None = Query(default=None, description="(sort_order,id) 복합 커서 — 이전 페이지 meta.next_cursor 값 그대로"),
     repo: DocRepository = Depends(_get_repo),
-) -> list[DocSummaryResponse]:
+) -> dict:
     # AC1 + AC3: 전문 검색 — project_id 필수
+    # story #2191: 의도적으로 커서 미지원(관련도순 + 위치커서 조합이 결과를 뒤섞음, repo단
+    # search_full_text 주석 참조) — has_more/next_cursor는 항상 False/None으로 봉투만 맞춘다.
     if q and project_id:
         results = await repo.search_full_text(project_id, q.strip(), limit=min(limit, 50))
-        return [
+        data = [
             DocSummaryResponse.model_validate(doc).model_copy(update={"snippet": snippet})
             for doc, snippet in results
         ]
+        return {"data": data, "meta": {"has_more": False, "next_cursor": None}}
 
     if slug and project_id:
         doc = await repo.get_by_slug(project_id, slug)
@@ -107,24 +125,26 @@ async def list_docs(
             doc = await repo.get_by_alias(project_id, slug)
         # slug 단건 경로 = FE 문서 상세 fetchDoc 의 실 경로 → detail 과 동일하게 enrich(담당자/수정이력).
         # 일반 list/tree/search 분기는 enrich 안 함(다건 N+1 회피·페이로드 과확장 금지).
-        return [await _enrich_doc_summary(doc, repo.session)] if doc else []
+        # story #2191: 단건 lookup이라 페이지네이션 대상이 아님 — has_more는 구조적으로 항상 False.
+        data = [await _enrich_doc_summary(doc, repo.session)] if doc else []
+        return {"data": data, "meta": {"has_more": False, "next_cursor": None}}
 
     if tags and project_id:
         tag_list = [t.strip() for t in tags.split(",") if t.strip()]
-        docs = await repo.search_by_tags(project_id, tag_list, limit=limit)
-        return [DocSummaryResponse.model_validate(d) for d in docs]
+        docs = await repo.search_by_tags(project_id, tag_list, limit=limit + 1, cursor=cursor)
+        return _doc_page_envelope(docs, limit)
 
     if project_id and parent_id is not None:
-        docs = await repo.list_tree(project_id, parent_id, limit=limit)
-        return [DocSummaryResponse.model_validate(d) for d in docs]
+        docs = await repo.list_tree(project_id, parent_id, limit=limit + 1, cursor=cursor)
+        return _doc_page_envelope(docs, limit)
 
     filters: dict = {}
     if project_id:
         filters["project_id"] = project_id
     if doc_type:
         filters["doc_type"] = doc_type
-    docs = await repo.list(limit=limit, **filters)
-    return [DocSummaryResponse.model_validate(d) for d in docs]
+    docs = await repo.list(limit=limit + 1, cursor=cursor, **filters)
+    return _doc_page_envelope(docs, limit)
 
 
 async def _assert_doc_parent_in_project(

--- a/backend/sprintable_mcp/tools/docs.py
+++ b/backend/sprintable_mcp/tools/docs.py
@@ -14,6 +14,7 @@ from .attachments import upload_attachments
 
 class ListDocsInput(SprintableInput):
     tags: list[str] | None = None
+    cursor: str | None = None  # #2191: 이전 호출의 meta.next_cursor 값을 그대로 넘기면 다음 페이지
 
 
 class GetDocInput(SprintableInput):
@@ -53,15 +54,38 @@ class UpdateDocInput(SprintableInput):
     attachments: list[dict] | None = None
 
 
+def _unwrap_docs_page(result: object) -> tuple[list, dict]:
+    """story #2191: BE GET /api/v2/docs 가 bare array → {data,meta}(#2231 규약 A)로 바뀜.
+    이 MCP 계층의 소비자들(list_docs·get_doc·search_docs)이 여전히 배열을 기대하므로
+    공통으로 언랩한다. 구 bare-array 응답(롤백/미갱신 BE)도 하위호환으로 통과시킨다."""
+    if isinstance(result, dict) and "data" in result:
+        return result["data"], (result.get("meta") or {})
+    return (result if isinstance(result, list) else []), {}
+
+
 async def list_docs(args: ListDocsInput) -> list[TextContent]:
-    """프로젝트 문서 목록 조회 (tree 또는 tag 필터)."""
+    """프로젝트 문서 목록 조회 (tree 또는 tag 필터). 더 있으면(has_more) 다음 페이지 안내가
+    별도 텍스트 블록으로 붙는다."""
     try:
         params: dict = {"project_id": client.require_project_id()}
         if args.tags:
             params["tags"] = ",".join(args.tags)
         else:
             params["view"] = "tree"
-        return ok(await client.get("/api/v2/docs", params=params))
+        if args.cursor:
+            params["cursor"] = args.cursor
+        result = await client.get("/api/v2/docs", params=params)
+        items, meta = _unwrap_docs_page(result)
+        blocks = ok(items)
+        if meta.get("has_more"):
+            blocks.append(TextContent(
+                type="text",
+                text=(
+                    f"※ 더 있음 — 이 응답은 {len(items)}건까지만 포함(전량 아님). "
+                    f'다음 페이지: list_docs를 cursor="{meta.get("next_cursor")}"로 다시 호출.'
+                ),
+            ))
+        return blocks
     except Exception as exc:
         return err(str(exc))
 
@@ -73,11 +97,15 @@ async def get_doc(args: GetDocInput) -> list[TextContent]:
     반환해 에이전트가 서로의 doc 본문을 못 읽었다. slug→id 해소 후 GET /{id}(DocResponse·content
     보유)를 surface한다. 메타데이터(id·title·slug·tags·updated_at)는 DocResponse에 그대로 있어
     기존 소비자 무영향(content 필드만 추가).
+
+    story #2191: slug 조회 자체는 BE에서도 항상 {data,meta} 봉투로 오므로(단건이라도) 여기서
+    같은 방식으로 언랩한다 — 안 하면 summaries[0]이 dict를 정수 인덱싱하려다 터진다.
     """
     try:
-        summaries = await client.get(
+        result = await client.get(
             "/api/v2/docs", params={"project_id": client.require_project_id(), "slug": args.slug}
         )
+        summaries, _meta = _unwrap_docs_page(result)
         if not summaries:
             return err(f"Doc not found: {args.slug}")
         doc_id = summaries[0]["id"]
@@ -87,12 +115,18 @@ async def get_doc(args: GetDocInput) -> list[TextContent]:
 
 
 async def search_docs(args: SearchDocsInput) -> list[TextContent]:
-    """문서 제목/본문 검색 (tag 필터 선택)."""
+    """문서 제목/본문 검색 (tag 필터 선택).
+
+    story #2191: 이 경로(q+project_id)는 BE에서 관련도(ts_rank)순이라 커서 페이지네이션을
+    의도적으로 지원 안 함(has_more는 항상 false) — 언랩만 하고 다음 페이지 안내는 안 붙인다.
+    """
     try:
         params: dict = {"project_id": client.require_project_id(), "q": args.query}
         if args.tags:
             params["tags"] = ",".join(args.tags)
-        return ok(await client.get("/api/v2/docs", params=params))
+        result = await client.get("/api/v2/docs", params=params)
+        items, _meta = _unwrap_docs_page(result)
+        return ok(items)
     except Exception as exc:
         return err(str(exc))
 

--- a/backend/tests/test_2191_docs_cursor_pagination_realdb.py
+++ b/backend/tests/test_2191_docs_cursor_pagination_realdb.py
@@ -1,0 +1,133 @@
+"""story #2191 — GET /api/v2/docs 일반 분기(list())가 무커서였다. FE는 이미 cursor 를
+보내고 있었으나(ApiDocRepository.list()) BE list_docs 가 그 파라미터를 라우터·리포 어느 층
+에서도 안 받아 조용히 버려졌다(#2230 의 거울상 — 이번엔 서버가 «못 알아듣는» 쪽). #2231
+정본 규약 A(limit+1 오버페치 + has_more/next_cursor body meta, 참조 구현:
+conversations.py::list_messages)를 적용한다.
+
+정렬 기준은 created_at/updated_at 이 아니라 Doc.sort_order(기본값 0, 수동 재배치 안 하면
+전부 동률)다 — sort_order 단독으로는 페이지 경계에서 행이 씹히므로 (sort_order,id) 복합
+커서를 쓴다. 이 테스트는 «전부 sort_order=0인 흔한 실제 상황»에서 두 번째 페이지가 첫
+페이지와 겹치지 않고, 전체를 순회하면 원본과 정확히 일치하는 것을 실 PG로 증명한다
+(#2231 AC3 요구사항 — 200 응답만으로 갈음 금지).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("d2191000-0000-0000-0000-000000000010")
+PROJ = uuid.UUID("d2191000-0000-0000-0000-000000000011")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _clean(s):
+    for sql in [
+        f"DELETE FROM docs WHERE project_id='{PROJ}'",
+        f"DELETE FROM projects WHERE id='{PROJ}'",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _seed_all_sort_order_zero(s, n: int) -> list[uuid.UUID]:
+    """n건 전부 sort_order=0(디폴트, 실제 대다수 케이스) — 동률 상황에서 id 2차키로
+    페이지 경계가 깨지지 않는 것이 이 테스트의 핵심."""
+    await _clean(s)
+    await s.execute(text(
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ}','{ORG}','P2191')"
+    ))
+    ids = []
+    for i in range(n):
+        did = uuid.uuid4()
+        ids.append(did)
+        await s.execute(text(
+            f"INSERT INTO docs (id,org_id,project_id,title,slug,content,sort_order) VALUES "
+            f"('{did}','{ORG}','{PROJ}','doc-{i}','doc-{i}-{did.hex[:8]}','',0)"
+        ))
+    await s.commit()
+    return ids
+
+
+@pytest.mark.anyio
+async def test_second_page_no_overlap_and_full_union_matches_realdb():
+    from app.routers.docs import list_docs
+    from app.repositories.doc import DocRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            seeded_ids = set(await _seed_all_sort_order_zero(s, n=5))
+
+        collected: set[uuid.UUID] = set()
+        cursor = None
+        pages_fetched = 0
+        total_rows_seen = 0
+        async with Session() as s:
+            repo = DocRepository(s, ORG)
+            while True:
+                pages_fetched += 1
+                assert pages_fetched <= 10, "무한루프 방지 — has_more가 계속 True로 나오면 커서 전진 실패"
+                page = await list_docs(
+                    project_id=PROJ, parent_id=None, doc_type=None, tags=None, slug=None, q=None,
+                    limit=2, cursor=cursor, repo=repo,
+                )
+                page_ids = {d.id for d in page["data"]}
+                overlap = page_ids & collected
+                assert not overlap, f"페이지 간 겹침 발생 — 커서가 안 전진함: {overlap}"
+                collected |= page_ids
+                total_rows_seen += len(page["data"])
+                if not page["meta"]["has_more"]:
+                    assert page["meta"]["next_cursor"] is None
+                    break
+                cursor = page["meta"]["next_cursor"]
+                assert cursor is not None
+
+        assert seeded_ids == collected, "전 페이지 합집합이 원본과 정확히 일치해야 한다(누락·중복 0)"
+        assert total_rows_seen == 5
+        assert pages_fetched == 3  # limit=2로 5건 → 2+2+1
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_cursor_under_limit_has_more_false_realdb():
+    """음성대조 — 총량이 limit 이하면 has_more=False·next_cursor=None."""
+    from app.routers.docs import list_docs
+    from app.repositories.doc import DocRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            seeded_ids = await _seed_all_sort_order_zero(s, n=3)
+
+        async with Session() as s:
+            repo = DocRepository(s, ORG)
+            page = await list_docs(
+                project_id=PROJ, parent_id=None, doc_type=None, tags=None, slug=None, q=None,
+                limit=50, cursor=None, repo=repo,
+            )
+        assert {d.id for d in page["data"]} == set(seeded_ids)
+        assert page["meta"]["has_more"] is False
+        assert page["meta"]["next_cursor"] is None
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_2191_parse_doc_cursor_type_guard.py
+++ b/backend/tests/test_2191_parse_doc_cursor_type_guard.py
@@ -1,0 +1,47 @@
+"""story #2191 CI 후속(오르테가군, 2026-07-27) — parse_doc_cursor가 "값이 있는지"만 보고
+"그 값이 문자열인지"는 안 봐서, FastAPI Query(...) 없이 직접 호출되며 cursor= 를 누락하면
+파이썬 기본값(Query 센티넬 객체, truthy)이 그대로 통과해 .split()에서 터지던 것(#2540 CI
+실패의 근본원인, test_2193_doc_summary_created_at_realdb.py에서 실제로 발생).
+
+이 클래스(#2230 죽은 cursor·#2233 위조 total과 같은 가족 — "있어 보이면 통과시키는 검사")를
+닫는다: 문자열이 아닌 것은 타입 단계에서 즉시 None(커서 없음) 취급.
+"""
+from __future__ import annotations
+
+import uuid
+
+from app.repositories.doc import parse_doc_cursor
+
+
+def test_none_returns_none():
+    assert parse_doc_cursor(None) is None
+
+
+def test_empty_string_returns_none():
+    assert parse_doc_cursor("") is None
+
+
+def test_valid_cursor_parses():
+    did = uuid.uuid4()
+    assert parse_doc_cursor(f"3:{did}") == (3, did)
+
+
+def test_malformed_string_raises_400():
+    from fastapi import HTTPException
+    import pytest as _pytest
+    with _pytest.raises(HTTPException) as ei:
+        parse_doc_cursor("not-a-valid-cursor")
+    assert ei.value.status_code == 400
+
+
+def test_non_string_truthy_object_treated_as_no_cursor_not_crash():
+    """#2540 CI 재현 — FastAPI Query(...) 센티넬 객체(str이 아니지만 truthy)를 흉내낸다.
+    예전 코드는 이 자리에서 AttributeError(→400으로 변질)로 터졌다. 이제는 '커서 없음'으로
+    조용히 정규화되어 정상 요청처럼 처리된다."""
+    class _FakeQuerySentinel:
+        """FastAPI Query(...) 객체처럼 str이 아니면서 truthy인 것을 흉내내는 최소 더미."""
+        default = None
+
+    fake_sentinel = _FakeQuerySentinel()
+    assert bool(fake_sentinel) is True  # 이 시나리오의 전제 — truthy임을 먼저 확인
+    assert parse_doc_cursor(fake_sentinel) is None

--- a/backend/tests/test_2193_doc_summary_created_at_realdb.py
+++ b/backend/tests/test_2193_doc_summary_created_at_realdb.py
@@ -81,12 +81,16 @@ async def test_doc_summary_response_exposes_created_at_distinct_from_updated_at(
             from app.routers.docs import list_docs
 
             repo = DocRepository(s, seeded["org_id"])
+            # story #2191: cursor 는 라우터에서 Query(...)로 선언돼 있어, 직접 함수호출 시
+            # 명시로 안 넘기면 FastAPI 가 주입한 값이 아니라 Query 객체 그 자체가 넘어가
+            # parse_doc_cursor 가 그걸 문자열로 착각해 터진다 — 반드시 명시로 넘긴다.
             result = await list_docs(
                 project_id=seeded["project_id"], parent_id=None, doc_type=None,
-                tags=None, slug=None, q=None, limit=500, repo=repo,
+                tags=None, slug=None, q=None, limit=500, cursor=None, repo=repo,
             )
-        assert len(result) == 1
-        summary = result[0]
+        # story #2191: 응답이 bare list → {data,meta}(#2231 규약 A)로 바뀜.
+        assert len(result["data"]) == 1
+        summary = result["data"][0]
         assert hasattr(summary, "created_at"), "DocSummaryResponse에 created_at 필드가 없음"
         assert summary.created_at is not None
         assert summary.created_at != summary.updated_at, (

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -84,7 +84,10 @@ async def test_list_docs_200():
             resp = await c.get(f"/api/v2/docs?project_id={PROJECT_ID}")
 
         assert resp.status_code == 200
-        assert len(resp.json()) == 1
+        # story #2191: #2231 정본 규약 A — bare array → {data,meta} 봉투.
+        body = resp.json()
+        assert len(body["data"]) == 1
+        assert body["meta"]["has_more"] is False
     finally:
         app.dependency_overrides.clear()
 

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -62,7 +62,7 @@ async def test_docs_list_via_conftest(test_client, mock_session, project_id, org
 
     resp = await test_client.get(f"/api/v2/docs?project_id={project_id}")
     assert resp.status_code == 200
-    assert resp.json() == []
+    assert resp.json()["data"] == []
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_mcp_docs_2191_shape.py
+++ b/backend/tests/test_mcp_docs_2191_shape.py
@@ -1,0 +1,119 @@
+"""story #2191 후속: GET /api/v2/docs 응답이 bare array → {data, meta}(#2231 규약 A)로
+바뀌었다. sprintable_mcp/tools/docs.py의 list_docs·get_doc·search_docs 셋 다 이 엔드포인트를
+호출하므로(같은 병 #2195 MCP 대응과 동형) 언랩 + has_more 안내를 고정한다.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_list_docs_unwraps_new_data_meta_shape_no_has_more():
+    from sprintable_mcp.tools.docs import ListDocsInput, list_docs
+
+    new_shape = {
+        "data": [{"id": "d1", "title": "hello", "slug": "hello"}],
+        "meta": {"has_more": False, "next_cursor": None},
+    }
+    with patch("sprintable_mcp.tools.docs.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get = AsyncMock(return_value=new_shape)
+        out = await list_docs(ListDocsInput())
+
+    parsed = json.loads(out[0].text)
+    assert isinstance(parsed, list)
+    assert parsed == new_shape["data"]
+    assert len(out) == 1  # has_more=False면 안내 블록 없음
+
+
+@pytest.mark.anyio
+async def test_list_docs_signals_has_more_with_next_page_hint():
+    from sprintable_mcp.tools.docs import ListDocsInput, list_docs
+
+    new_shape = {
+        "data": [{"id": "d1", "title": "hello", "slug": "hello"}],
+        "meta": {"has_more": True, "next_cursor": "0:11111111-1111-1111-1111-111111111111"},
+    }
+    with patch("sprintable_mcp.tools.docs.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get = AsyncMock(return_value=new_shape)
+        out = await list_docs(ListDocsInput())
+
+    parsed = json.loads(out[0].text)
+    assert parsed == new_shape["data"]
+    assert len(out) == 2
+    assert "0:11111111-1111-1111-1111-111111111111" in out[1].text
+    assert "더 있음" in out[1].text
+
+
+@pytest.mark.anyio
+async def test_list_docs_passes_cursor_through():
+    from sprintable_mcp.tools.docs import ListDocsInput, list_docs
+
+    with patch("sprintable_mcp.tools.docs.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get = AsyncMock(return_value={"data": [], "meta": {"has_more": False, "next_cursor": None}})
+        await list_docs(ListDocsInput(cursor="0:abc"))
+
+    _, kwargs = mock_client.get.call_args
+    assert kwargs["params"]["cursor"] == "0:abc"
+
+
+@pytest.mark.anyio
+async def test_get_doc_unwraps_new_shape_for_slug_lookup():
+    """8a8e881a 회귀 가드 + #2191: {data,meta} 봉투에서도 summaries[0] 인덱싱이 안 터진다."""
+    from sprintable_mcp.tools.docs import GetDocInput, get_doc
+
+    doc_id = "11111111-1111-1111-1111-111111111111"
+    list_shape = {"data": [{"id": doc_id, "title": "Handoff", "slug": "handoff"}], "meta": {"has_more": False, "next_cursor": None}}
+    doc_resp = {"id": doc_id, "title": "Handoff", "slug": "handoff", "content": "FULL BODY"}
+
+    async def fake_get(path, params=None):
+        return list_shape if path == "/api/v2/docs" else doc_resp
+
+    with patch("sprintable_mcp.tools.docs.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get = AsyncMock(side_effect=fake_get)
+        out = await get_doc(GetDocInput(slug="handoff"))
+
+    parsed = json.loads(out[0].text)
+    assert parsed["content"] == "FULL BODY"
+
+
+@pytest.mark.anyio
+async def test_get_doc_not_found_with_new_shape():
+    from sprintable_mcp.tools.docs import GetDocInput, get_doc
+
+    with patch("sprintable_mcp.tools.docs.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get = AsyncMock(return_value={"data": [], "meta": {"has_more": False, "next_cursor": None}})
+        out = await get_doc(GetDocInput(slug="nope"))
+
+    assert "not found" in out[0].text.lower()
+
+
+@pytest.mark.anyio
+async def test_search_docs_unwraps_and_never_signals_has_more():
+    """search_full_text 분기는 의도적으로 커서 미지원 — has_more 안내가 절대 안 붙는다."""
+    from sprintable_mcp.tools.docs import SearchDocsInput, search_docs
+
+    new_shape = {
+        "data": [{"id": "d1", "title": "hello", "snippet": "..."}],
+        "meta": {"has_more": False, "next_cursor": None},
+    }
+    with patch("sprintable_mcp.tools.docs.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get = AsyncMock(return_value=new_shape)
+        out = await search_docs(SearchDocsInput(query="hello"))
+
+    parsed = json.loads(out[0].text)
+    assert parsed == new_shape["data"]
+    assert len(out) == 1


### PR DESCRIPTION
## Summary
- 원 신고: 문서 트리 500/620건 조용한 절단(19% 안 보임). 착수 전 층별 재확認 중 「일반 분기도 결함」(미르코 지적)을 코드로 확定 — FE(`ApiDocRepository.list()`)는 이미 `cursor` 쿼리파라미터를 보내고 있었으나 BE `list_docs`가 라우터·리포 어느 층에도 그 파라미터를 선언하지 않아 조용히 버려지고 있었다(#2230의 거울상). BE가 `limit+1` 오버페치도 안 해 FE `buildCursorPageMeta`의 `hasMore`가 구조적으로 항상 `false`였다.
- PO 판단(scope b): `list_docs` 5개 분기 전부 한 번에 정리 — 정렬 기준이 다른 분기는 규약을 안 씌우고 이유를 명시.

## Changes (BE only — 이 PR 범위, MCP 포함)
- `app/repositories/doc.py`: `(sort_order, id)` 복합 커서(`encode_doc_cursor`/`parse_doc_cursor`) 도입. `list()`/`list_tree()`/`search_by_tags()`에 적용. `search_by_tags()`는 기존 ORDER BY 자체가 없었던 것(비결정적)도 이번에 고침.
- `app/routers/docs.py`: `list_docs`에 `cursor` 쿼리파라미터 추가, `limit+1` 오버페치, 응답을 `list[DocSummaryResponse]` → `{"data": [...], "meta": {"has_more": bool, "next_cursor": string|null}}`로 통일(5개 분기 전부 같은 봉투 — search_full_text/slug 분기도 `has_more` 항상 `false`로 봉투만 맞춤, 코드 주석에 왜 커서를 안 쓰는지 명시).
- `sprintable_mcp/tools/docs.py`: `list_docs`/`get_doc`/`search_docs` 언랩(+`list_docs`는 `has_more` 안내 2차 블록 + `cursor` 입력 추가). `get_doc`은 새 봉투에서 `summaries[0]` 인덱싱이 안 터지게 방지(안 했으면 크래시).

## ⚠️ Breaking change — 소비자 3+3곳, 별도 페어링으로 후속 갱신 필요
```
FE: packages/storage-api/src/ApiDocRepository.ts 의 list()/getTree()/getBySlug() 전부
    이 엔드포인트를 호출하고 DocSummary[] 타입으로 고정돼 있음 — 셋 다 갱신 필요.
    apps/web/src/app/api/docs/route.ts 의 buildCursorPageMeta 재계산도 이제 BE가 직접
    hasMore/nextCursor를 내므로 불필요해짐(설계 단순화 여지, Mirko 판단).
MCP: 이번 PR에 같이 처리 완료.
```
FE `route.ts`/`docs-client-layout.tsx`는 이 PR에서 안 건드림 — #2195와 동일하게 BE 선행, FE 페어링 대기.

## Test plan
- [x] 신규 realdb 테스트(`test_2191_docs_cursor_pagination_realdb.py`): **전부 `sort_order=0`(동률, 실사용 대다수 상황)**인 5건을 `limit=2`로 3페이지 완주 — 겹침 0·합집합 정확히 일치(id 2차 정렬키가 실제로 동률을 깨는 것 증명). 음성대조(총량≤limit → has_more=False) 포함.
- [x] MCP 신규 테스트 6건(`test_mcp_docs_2191_shape.py`): 언랩·has_more 안내·cursor 전달·get_doc 크래시 방지·search 커서 미신호(의도된 예외).
- [x] 뮤테이션 셀프체크 2건 — repo cursor 필터 제거 시 페이지 겹침으로 정확히 예측한 자리 RED; MCP unwrap 로직 제거 시 list_docs 축만 RED(get_doc/search_docs는 별개 축이라 GREEN 유지, 4개 독립 검증).
- [x] 기존 `test_docs.py`/`test_integration.py`(응답 shape 변경 2건 갱신) + docs 전체 회귀 스윕 183 passed 이상 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)