### PR TITLE
fix(#2230): 스토리 댓글 「더보기」 — 직렬로 겹친 결함 세 겹 해소

### DIFF
--- a/apps/web/src/app/api/stories/[id]/comments/route.ts
+++ b/apps/web/src/app/api/stories/[id]/comments/route.ts
@@ -1,5 +1,5 @@
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { apiSuccess, ApiErrors, type ApiMeta } from '@/lib/api-response';
 import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
@@ -14,7 +14,11 @@ export async function GET(request: Request, { params }: RouteParams) {
 
     const _r = await proxyToFastapiWithParams(request, '/api/v2/stories/[id]/comments', { id });
     if (!_r.ok) return _r;
-    return apiSuccess(await _r.json());
+    // story #2230: BE가 {data,meta}(#2231 규약 A)를 낸다 — 그대로 apiSuccess(json)에 넘기면
+    // 통째로 다시 data 필드에 얹혀 이중포장된다(오늘 mockups에서 본 것과 동형). data/meta를
+    // 풀어서 넘긴다.
+    const beJson = await _r.json() as { data?: unknown; meta?: ApiMeta };
+    return apiSuccess(beJson.data ?? beJson, beJson.meta);
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -606,7 +606,9 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
         if (res.ok) {
           const json = await res.json();
           setComments(json.data ?? []);
-          setNextCommentsCursor(json.meta?.nextCursor ?? null);
+          // story #2230: BE meta 필드는 snake_case(next_cursor) — camelCase 로 읽어 항상
+          // undefined였던 것이 커서가 죽어 보이던 세 번째 원인(BE 미반영·프록시 이중포장과 직렬).
+          setNextCommentsCursor(json.meta?.next_cursor ?? null);
         }
       } catch {
         setComments([]);
@@ -683,7 +685,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
       if (res.ok) {
         const json = await res.json();
         setComments((prev) => [...prev, ...(json.data ?? [])]);
-        setNextCommentsCursor(json.meta?.nextCursor ?? null);
+        setNextCommentsCursor(json.meta?.next_cursor ?? null);
       }
     } finally {
       setLoadingMoreComments(false);

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -1328,7 +1328,7 @@ class ActivityResponse(BaseModel):
 
 # ─── Comments ─────────────────────────────────────────────────────────────────
 
-@router.get("/{id}/comments", response_model=list[CommentResponse])
+@router.get("/{id}/comments")
 async def list_comments(
     id: uuid.UUID,
     limit: int = Query(default=20, le=100),
@@ -1336,7 +1336,12 @@ async def list_comments(
     db: AsyncSession = Depends(get_db),
     repo: StoryRepository = Depends(_get_repo),
     auth: AuthContext = Depends(get_current_user),
-) -> list[CommentResponse]:
+) -> dict:
+    """story #2230: cursor 파라미터가 시그니처에만 있고 쿼리에 안 물려 있었다(선언-미사용
+    죽은 파라미터) — FE(story-detail-panel.tsx)는 이미 이 파라미터로 「더보기」를 완결해
+    두고 기다리고 있었다. #2231 정본 규약 A(limit+1 오버페치 + has_more/next_cursor body
+    meta, 참조 구현: conversations.py::list_messages)로 실제 동작하게 한다.
+    """
     # SEC(story #2206, 까심 인가 전수 스윕 A급): 쿼리 술어가 StoryComment.story_id == id 뿐이라
     # org_id 조건 자체가 없었다(project-only 누락이 아니라 org 조건 부재 — 같은 파일 다른
     # 엔드포인트들의 project-only 누락 갭과 다른 형태). 어느 org 멤버든 story UUID만 알면 다른
@@ -1346,11 +1351,23 @@ async def list_comments(
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")
     await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
-    q = select(StoryComment).where(
-        StoryComment.story_id == id,
-    ).order_by(StoryComment.created_at.desc()).limit(limit)
+    q = select(StoryComment).where(StoryComment.story_id == id)
+    if cursor:
+        try:
+            cursor_dt = datetime.fromisoformat(cursor)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid cursor format")
+        q = q.where(StoryComment.created_at < cursor_dt)
+    q = q.order_by(StoryComment.created_at.desc()).limit(limit + 1)
     result = await db.execute(q)
-    return [CommentResponse.model_validate(r) for r in result.scalars()]
+    rows = list(result.scalars())
+    has_more = len(rows) > limit
+    page = rows[:limit]
+    next_cursor = page[-1].created_at.isoformat() if has_more and page else None
+    return {
+        "data": [CommentResponse.model_validate(r) for r in page],
+        "meta": {"has_more": has_more, "next_cursor": next_cursor},
+    }
 
 
 async def _resolve_team_member_id(auth: AuthContext, org_id: uuid.UUID, db: AsyncSession) -> uuid.UUID:

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -1352,7 +1352,10 @@ async def list_comments(
         raise HTTPException(status_code=404, detail="Story not found")
     await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
     q = select(StoryComment).where(StoryComment.story_id == id)
-    if cursor:
+    # #2540 CI 교훈(오르테가군): "값이 있는지"만 보면 안 되고 "그 값이 문자열인지"까지 봐야
+    # 한다 — 이 함수를 FastAPI DI 없이 직접 호출하며 cursor= 를 누락하면 파이썬 기본값인
+    # Query(...) 센티넬 객체(truthy) 가 그대로 들어온다. 문자열이 아니면 커서 없음으로 취급.
+    if isinstance(cursor, str) and cursor:
         try:
             cursor_dt = datetime.fromisoformat(cursor)
         except ValueError:

--- a/backend/tests/test_2206_story_comments_activities_org_scope_realdb.py
+++ b/backend/tests/test_2206_story_comments_activities_org_scope_realdb.py
@@ -153,7 +153,8 @@ async def test_list_comments_same_org_project_member_still_works():
             repo = StoryRepository(s, VICTIM_ORG)
             auth = AuthContext(user_id=str(VICTIM_MEMBER), email=None, claims={}, org_id=str(VICTIM_ORG))
             out = await list_comments(id=STORY, limit=20, cursor=None, db=s, repo=repo, auth=auth)
-        assert len(out) == 1
-        assert out[0].content == "타org 에 새면 안 되는 댓글"
+        # story #2230: 응답이 bare list → {data,meta}(#2231 규약 A)로 바뀜.
+        assert len(out["data"]) == 1
+        assert out["data"][0].content == "타org 에 새면 안 되는 댓글"
     finally:
         await eng.dispose()

--- a/backend/tests/test_2230_story_comments_cursor_pagination_realdb.py
+++ b/backend/tests/test_2230_story_comments_cursor_pagination_realdb.py
@@ -1,0 +1,153 @@
+"""story #2230 — GET /api/v2/stories/{id}/comments 의 cursor 파라미터가 시그니처에만
+있고 쿼리에 안 물려 있었다(선언-미사용 죽은 파라미터). FE(story-detail-panel.tsx)는 이미
+이 파라미터로 「더보기」를 완결해 두고 기다리고 있었다 — cursor 가 죽어 있어 한 번도
+실제로 다음 페이지를 받아본 적이 없다. #2231 정본 규약 A(limit+1 오버페치 +
+has_more/next_cursor body meta)를 적용해 실제로 동작하게 한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("d2230000-0000-0000-0000-000000000010")
+PROJ = uuid.UUID("d2230000-0000-0000-0000-000000000011")
+STORY = uuid.UUID("d2230000-0000-0000-0000-000000000012")
+AUTHOR_USER = uuid.UUID("d2230000-0000-0000-0000-000000000013")
+AUTHOR_MEMBER = uuid.UUID("d2230000-0000-0000-0000-000000000014")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(AUTHOR_USER), email=None,
+        claims={"app_metadata": {"org_id": str(ORG)}},
+        org_id=str(ORG),
+    )
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _clean(s):
+    for sql in [
+        f"DELETE FROM story_comments WHERE org_id='{ORG}'",
+        f"DELETE FROM stories WHERE id='{STORY}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE id='{PROJ}'",
+        f"DELETE FROM users WHERE id='{AUTHOR_USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _seed(s, n: int) -> list[uuid.UUID]:
+    await _clean(s)
+    await s.execute(text(f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','O','d2230-org','free')"))
+    await s.execute(text(
+        f"INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{AUTHOR_USER}','d2230@d2230.test','x','D2230',true,true,0,false,0)"
+    ))
+    await s.execute(text(f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ}','{ORG}','P2230')"))
+    await s.execute(text(
+        f"INSERT INTO members (id,org_id,user_id,type,name,is_active) VALUES "
+        f"('{AUTHOR_MEMBER}','{ORG}','{AUTHOR_USER}','human','D2230',true)"
+    ))
+    await s.execute(text(
+        f"INSERT INTO project_access (id,project_id,member_id,role,permission) VALUES "
+        f"(gen_random_uuid(),'{PROJ}','{AUTHOR_MEMBER}','member','granted')"
+    ))
+    await s.execute(text(
+        f"INSERT INTO stories (id,org_id,project_id,title,status) VALUES "
+        f"('{STORY}','{ORG}','{PROJ}','S','backlog')"
+    ))
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    ids = []
+    for i in range(n):
+        cid = uuid.uuid4()
+        ids.append(cid)
+        created_at = base + timedelta(seconds=i)
+        await s.execute(text(
+            f"INSERT INTO story_comments (id,org_id,story_id,project_id,content,created_by,created_at) VALUES "
+            f"('{cid}','{ORG}','{STORY}','{PROJ}','comment-{i}','{AUTHOR_MEMBER}','{created_at.isoformat()}')"
+        ))
+    await s.commit()
+    return list(reversed(ids))  # newest-first, matches server ORDER BY created_at DESC
+
+
+@pytest.mark.anyio
+async def test_second_page_returns_different_rows_realdb():
+    from app.routers.stories import list_comments
+    from app.repositories.story import StoryRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            newest_first = await _seed(s, n=5)
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            page1 = await list_comments(id=STORY, limit=2, cursor=None, db=s, repo=repo, auth=_auth())
+        assert [c.id for c in page1["data"]] == newest_first[0:2]
+        assert page1["meta"]["has_more"] is True
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            page2 = await list_comments(
+                id=STORY, limit=2, cursor=page1["meta"]["next_cursor"], db=s, repo=repo, auth=_auth(),
+            )
+        page2_ids = [c.id for c in page2["data"]]
+        assert page2_ids == newest_first[2:4], "page2가 page1과 다른 행을 반환해야 한다(#2230 본체)"
+        assert not (set(page2_ids) & {c.id for c in page1["data"]})
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            page3 = await list_comments(
+                id=STORY, limit=2, cursor=page2["meta"]["next_cursor"], db=s, repo=repo, auth=_auth(),
+            )
+        assert [c.id for c in page3["data"]] == newest_first[4:5]
+        assert page3["meta"]["has_more"] is False
+        assert page3["meta"]["next_cursor"] is None
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_cursor_under_limit_has_more_false_realdb():
+    from app.routers.stories import list_comments
+    from app.repositories.story import StoryRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, n=3)
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            page = await list_comments(id=STORY, limit=20, cursor=None, db=s, repo=repo, auth=_auth())
+        assert [c.id for c in page["data"]] == seeded
+        assert page["meta"]["has_more"] is False
+        assert page["meta"]["next_cursor"] is None
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_2230_story_comments_cursor_pagination_realdb.py
+++ b/backend/tests/test_2230_story_comments_cursor_pagination_realdb.py
@@ -151,3 +151,31 @@ async def test_no_cursor_under_limit_has_more_false_realdb():
         assert page["meta"]["next_cursor"] is None
     finally:
         await eng.dispose()
+
+
+class _FakeQuerySentinel:
+    """#2540 CI 재현(오르테가군) — FastAPI Query(...) 객체처럼 str이 아니면서 truthy인 것을
+    흉내낸다. list_comments를 FastAPI DI 없이 직접 호출하며 cursor= 를 누락하면 실제로
+    이런 모양의 객체(파이썬 함수 기본값)가 들어온다."""
+    default = None
+
+
+@pytest.mark.anyio
+async def test_non_string_truthy_cursor_treated_as_no_cursor_not_crash_realdb():
+    from app.routers.stories import list_comments
+    from app.repositories.story import StoryRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, n=3)
+
+        fake_sentinel = _FakeQuerySentinel()
+        assert bool(fake_sentinel) is True  # 전제 확인 — truthy임
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            page = await list_comments(id=STORY, limit=20, cursor=fake_sentinel, db=s, repo=repo, auth=_auth())
+        assert [c.id for c in page["data"]] == seeded, "커서 없음으로 취급돼 전체가 나와야 한다(크래시 아님)"
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## Summary
원 신고는 "BE cursor 파라미터가 죽어 있다"였지만, 착수 전 화면(story-detail-panel.tsx)부터 열어 보니 FE 「더보기」 UI는 이미 완결돼 있었고 **직렬로 겹친 결함 셋** 중 하나였다 — 하나만 고쳐도 사용자 체감은 "여전히 안 됨"으로 동일했을 자리:

```
① BE list_comments      — cursor 시그니처에만 있고 쿼리 미반영(원 신고)
② FE 프록시 route.ts     — apiSuccess(await _r.json())가 BE의 {data,meta}를 통째로
                           다시 자기 data 필드에 얹어 이중포장
③ FE 컴포넌트 casing     — json.meta?.nextCursor(camelCase) 읽음. 확立된 규약
                           (chat-view.tsx가 conversations.py를 읽는 실제 코드로 확認)은
                           snake_case next_cursor
```

## ⚠️ Lane 예외 — 왜 이 PR에 FE 파일이 포함됐는가
BE lane 규율(BE는 FE 코드를 안 건드림)의 목적은 (a) 동시 편집 충돌 방지 (b) 리뷰 흐림 방지. 이번 건은 둘 다 해당 없음 — 미르코군은 지금 이 두 파일을 안 건드리고 있음(open PR 검색으로 확認, 겹침 없음), 변경 규모도 각 파일 한 곳(프록시 unwrap 한 줄·필드명 두 자리)이라 리뷰가 흐려지지 않음. 셋이 직렬이라 쪼개면 "반쪽 처방"이 되는 것이 예외를 연 이유(PO 판단, 2026-07-27).

## Changes
- `backend/app/routers/stories.py`: `list_comments`에 #2231 정본 규약 A(limit+1 오버페치 + has_more/next_cursor body meta) 적용. `response_model=list[CommentResponse]` → `dict`.
- `apps/web/src/app/api/stories/[id]/comments/route.ts` (GET만): BE 응답의 `data`/`meta`를 풀어 `apiSuccess(data, meta)`로 전달(이중포장 제거).
- `apps/web/src/components/kanban/story-detail-panel.tsx`: `fetchComments`·`handleLoadMoreComments` 두 자리 `nextCursor` → `next_cursor`.

## ⚠️ 부수 발견 (이 PR 스코프 밖, 별건 보고 예정)
`handleLoadMoreActivities()`도 완전히 동일한 패턴으로 `/api/stories/{id}/activities`를 호출하는데 그쪽 BE(`list_activities`)는 cursor 파라미터 자체가 없음(#2231 스윕의 CAPPED-NO-NEXT-PAGE 항목) — 죽은 정도만 다르지 같은 병. 이 PR에 안 담음(스코프 확장은 별도 판단 대기).

## Test plan
- [x] 신규 realdb 테스트: 5건을 `limit=2`로 3페이지 완주 — 겹침 0·합집합 정확히 일치. 음성대조(총량≤limit → has_more=False) 포함.
- [x] 뮤테이션 셀프체크: cursor 필터 제거 시 정확히 예측한 자리(page2==page1 아님, 실제로는 다음 커서 미전진) RED. 복구 후 재확認 GREEN.
- [x] 기존 `test_2206_story_comments_activities_org_scope_realdb.py`(IDOR 가드) 응답shape 갱신(`out["data"]`) 후 재확認 GREEN. `stories.py` 전체 회귀 스윕 116 passed.
- [x] FE 타입체크: node_modules 있는 별도 체크아웃에 두 파일만 임시 반영해 `tsc --noEmit` 스코프 확認 — 두 파일 자체 에러 0. ⚠️단 그 체크아웃이 `develop`이 아닌 구브랜치(`promo/2160-20260724`)라 완전한 보증은 아님 — **미르코군이 실 브랜치에서 타입체크·렌더 확認 필요**(머지 전 조건).
- [ ] **머지 전 미르코군 확認 필요**: 위 FE 2개 파일 리뷰 + 가능하면 dev에서 실제 "더보기" 클릭 왕복 확認.

🤖 Generated with [Claude Code](https://claude.com/claude-code)