### PR TITLE
fix(hardening): notifications 커서 truthy 검사 닫음 — #2540 CI 클래스 선제 대응

### DIFF
--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -95,7 +95,10 @@ async def list_notifications(
     user_id = await _resolve_notification_user_id(auth, db)
     resolved_is_read = (not unread) if unread is not None else is_read
     before_dt: datetime | None = None
-    if before:
+    # #2540 CI 교훈(오르테가군, 2026-07-27): "값이 있는지"만 보면 안 되고 "그 값이
+    # 문자열인지"까지 봐야 한다 — 이 함수를 FastAPI DI 없이 직접 호출하며 before= 를
+    # 누락하면 파이썬 기본값인 Query(...) 센티넬 객체(truthy)가 그대로 들어온다.
+    if isinstance(before, str) and before:
         try:
             before_dt = datetime.fromisoformat(before)
         except ValueError:

--- a/backend/tests/test_2195_notifications_cursor_pagination_realdb.py
+++ b/backend/tests/test_2195_notifications_cursor_pagination_realdb.py
@@ -155,3 +155,34 @@ async def test_no_cursor_first_page_unaffected_when_under_limit_realdb():
         assert page["meta"]["next_cursor"] is None
     finally:
         await eng.dispose()
+
+
+class _FakeQuerySentinel:
+    """#2540 CI 재현(오르테가군, 2026-07-27) — FastAPI Query(...) 객체처럼 str이 아니면서
+    truthy인 것을 흉내낸다. list_notifications를 FastAPI DI 없이 직접 호출하며 before= 를
+    누락하면 실제로 이런 모양의 객체(파이썬 함수 기본값)가 들어온다."""
+    default = None
+
+
+@pytest.mark.anyio
+async def test_non_string_truthy_before_treated_as_no_cursor_not_crash_realdb():
+    from app.routers.notifications import list_notifications
+    from app.repositories.notification import NotificationRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, n=3)
+
+        fake_sentinel = _FakeQuerySentinel()
+        assert bool(fake_sentinel) is True  # 전제 확인 — truthy임
+
+        async with Session() as s:
+            repo = NotificationRepository(s, ORG)
+            page = await list_notifications(
+                unread=None, is_read=None, limit=50, before=fake_sentinel,
+                db=s, auth=_auth(), repo=repo,
+            )
+        assert [n.id for n in page["data"]] == seeded, "커서 없음으로 취급돼 전체가 나와야 한다(크래시 아님)"
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## Summary
#2540 CI가 잡은 결함 클래스(오르테가군, 2026-07-27) — 커서 파싱이 "값이 있는지"만 보고 "그 값이 문자열인지"는 안 보면, FastAPI DI 없이 직접 호출하며 인자를 누락했을 때 파이썬 기본값인 `Query(...)` 센티넬 객체(truthy)가 그대로 들어와 크래시한다. `#2538`(merge됨, `notifications.py`)에도 동일 패턴이 있어 선제로 닫는다 — `docs.py`(#2540)와 같은 뿌리, `stories.py`(#2542)에도 동시 적용 중.

## Changes
- `app/routers/notifications.py::list_notifications`: `if before:` → `if isinstance(before, str) and before:`.

## Test plan
- [x] 신규 테스트: `Query(...)`처럼 str이 아니면서 truthy인 더미 객체를 `before=`로 직접 호출 — 크래시 없이 "커서 없음"으로 정규화됨을 확認.
- [x] 뮤테이션 셀프체크: 가드 제거 시 정확히 예측한 `TypeError: fromisoformat: argument must be str`로 RED. 복구 후 재확認 GREEN.
- [x] `test_notifications.py`/`test_integration.py`/MCP shape 테스트 회귀 56 passed 이상 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)