### PR TITLE
[SID:2191] 사이드바 문서 트리 커서 페이지네이션 (FE, BE #2540과 짝)

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
@@ -156,9 +156,11 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
   const fetchTree = useCallback(async (tags?: string[], cursor?: string | null) => {
     if (!projectId) return;
     try {
+      // story #2191 — "view=tree"는 죽은 파라미터였다(/api/docs가 그 값을 아예 안 읽어
+      // 항상 무커서 일반 목록 분기로 떨어졌다). #2540 이후 BE/FE 둘 다 커서를 실제로
+      // 지원하므로 이 파라미터를 지운다 — tags 유무와 무관하게 같은 커서 경로를 탄다.
       const fetchParams = new URLSearchParams({ project_id: projectId, limit: '20' });
       if (tags?.length) fetchParams.set('tags', tags.join(','));
-      else fetchParams.set('view', 'tree');
       if (cursor) fetchParams.set('cursor', cursor);
       const res = await fetch(`/api/docs?${fetchParams.toString()}`);
       if (!res.ok) throw new Error('Failed to fetch tree');

--- a/apps/web/src/app/api/docs/route.test.ts
+++ b/apps/web/src/app/api/docs/route.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+// story #2191(#2231 규약 A) — getTree()를 소거하고 list()/search()로 통합했다. BE가
+// has_more/next_cursor를 직접 계산해 body meta로 낸다(#2540) — 이 route는 그 값을 그대로
+// 믿고 전달한다(buildCursorPageMeta 재추론 없음).
 const { createDbServerClient, createAdminClient, getAuthContext } = vi.hoisted(() => ({
   createDbServerClient: vi.fn(),
   createAdminClient: vi.fn(),
   getAuthContext: vi.fn(),
 }));
-const getTreeMock = vi.fn();
 const listMock = vi.fn();
 const searchMock = vi.fn();
 const getDocMock = vi.fn();
@@ -13,7 +15,7 @@ const getDocMock = vi.fn();
 vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
 vi.mock('@/lib/db/admin', () => ({ createAdminClient }));
 vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
-vi.mock('@/services/docs', () => ({ DocsService: class { getTree = getTreeMock; list = listMock; search = searchMock; getDoc = getDocMock; } }));
+vi.mock('@/services/docs', () => ({ DocsService: class { list = listMock; search = searchMock; getDoc = getDocMock; } }));
 
 import { GET } from './route';
 
@@ -31,7 +33,6 @@ describe('GET /api/docs', () => {
     createDbServerClient.mockReset();
     createAdminClient.mockReset();
     getAuthContext.mockReset();
-    getTreeMock.mockReset();
     listMock.mockReset();
     searchMock.mockReset();
     getDocMock.mockReset();
@@ -40,33 +41,77 @@ describe('GET /api/docs', () => {
     getAuthContext.mockResolvedValue(mockAuth);
   });
 
-  it('returns hierarchy-preserving tree data when view=tree is requested', async () => {
-    getTreeMock.mockResolvedValue([
-      { id: 'folder-1', parent_id: null, sort_order: 0 },
-      { id: 'doc-1', parent_id: 'folder-1', sort_order: 1 },
-    ]);
+  it('view=tree 파라미터는 이제 죽은 값이다 — 태그 없이도 list()가 커서와 함께 호출된다(#2191)', async () => {
+    listMock.mockResolvedValue({
+      items: [
+        { id: 'folder-1', parent_id: null, sort_order: 0 },
+        { id: 'doc-1', parent_id: 'folder-1', sort_order: 1 },
+      ],
+      hasMore: true,
+      nextCursor: '1:doc-1',
+    });
 
-    const response = await GET(new Request('http://localhost/api/docs?project_id=project-1&view=tree'));
+    const response = await GET(new Request('http://localhost/api/docs?project_id=project-1&view=tree&limit=20'));
     const body = await response.json();
 
-    expect(getTreeMock).toHaveBeenCalledWith('project-1');
-    expect(listMock).not.toHaveBeenCalled();
-    expect(body.meta).toEqual(expect.objectContaining({ mode: 'tree', exception: 'hierarchy_preserving_tree_browse' }));
+    expect(listMock).toHaveBeenCalledWith('project-1', expect.objectContaining({ limit: 20, tags: undefined }));
+    expect(body.data).toHaveLength(2);
+    expect(body.meta).toEqual(expect.objectContaining({ hasMore: true, nextCursor: '1:doc-1' }));
   });
 
-  it('paginates search results with updated_at cursor metadata', async () => {
-    searchMock.mockResolvedValue([
-      { id: 'doc-3', updated_at: '2026-04-13T03:00:00.000Z' },
-      { id: 'doc-2', updated_at: '2026-04-13T02:00:00.000Z' },
-      { id: 'doc-1', updated_at: '2026-04-13T01:00:00.000Z' },
-    ]);
+  it('50건 넘는 트리에서도(가짜 재현) hasMore=true·nextCursor가 그대로 전달된다 — BE 값 재추론 없음', async () => {
+    listMock.mockResolvedValue({ items: Array.from({ length: 20 }, (_, i) => ({ id: `doc-${i}` })), hasMore: true, nextCursor: '0:doc-19' });
+
+    const response = await GET(new Request('http://localhost/api/docs?project_id=project-1&limit=20'));
+    const body = await response.json();
+
+    expect(body.data).toHaveLength(20);
+    expect(body.meta.hasMore).toBe(true);
+    expect(body.meta.nextCursor).toBe('0:doc-19');
+  });
+
+  it('음성대조 — hasMore=false면 nextCursor도 null로 전달된다("더 보기"가 안 서게)', async () => {
+    listMock.mockResolvedValue({ items: [{ id: 'doc-1' }], hasMore: false, nextCursor: null });
+
+    const response = await GET(new Request('http://localhost/api/docs?project_id=project-1'));
+    const body = await response.json();
+
+    expect(body.meta.hasMore).toBe(false);
+    expect(body.meta.nextCursor).toBeNull();
+  });
+
+  it('tags 필터가 있으면 list()에 그대로 전달된다', async () => {
+    listMock.mockResolvedValue({ items: [], hasMore: false, nextCursor: null });
+
+    await GET(new Request('http://localhost/api/docs?project_id=project-1&tags=policy,handbook'));
+
+    expect(listMock).toHaveBeenCalledWith('project-1', expect.objectContaining({ tags: ['policy', 'handbook'] }));
+  });
+
+  it('검색(q)은 search()를 타고, BE가 낸 hasMore/nextCursor를 그대로 반환한다', async () => {
+    searchMock.mockResolvedValue({
+      items: [{ id: 'doc-3', updated_at: '2026-04-13T03:00:00.000Z' }, { id: 'doc-2', updated_at: '2026-04-13T02:00:00.000Z' }],
+      hasMore: false,
+      nextCursor: null,
+    });
 
     const response = await GET(new Request('http://localhost/api/docs?project_id=project-1&q=policy&limit=2'));
     const body = await response.json();
 
     expect(searchMock).toHaveBeenCalledWith('project-1', 'policy', expect.objectContaining({ limit: 2, cursor: null }));
     expect(body.data).toHaveLength(2);
-    expect(body.meta).toEqual(expect.objectContaining({ hasMore: true, nextCursor: '2026-04-13T02:00:00.000Z' }));
+    expect(body.meta).toEqual(expect.objectContaining({ hasMore: false, nextCursor: null }));
+  });
+
+  it('slug 단건 조회는 getDoc()을 탄다(list/search 안 거침)', async () => {
+    getDocMock.mockResolvedValue({ id: 'doc-1', slug: 'my-doc' });
+
+    const response = await GET(new Request('http://localhost/api/docs?project_id=project-1&slug=my-doc'));
+    const body = await response.json();
+
+    expect(getDocMock).toHaveBeenCalledWith('project-1', 'my-doc');
+    expect(listMock).not.toHaveBeenCalled();
+    expect(body.data).toEqual({ id: 'doc-1', slug: 'my-doc' });
   });
 
   it('returns 401 when not authenticated', async () => {

--- a/apps/web/src/app/api/docs/route.ts
+++ b/apps/web/src/app/api/docs/route.ts
@@ -3,7 +3,7 @@ import { DocsService } from '@/services/docs';
 import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
-import { buildCursorPageMeta, parseCursorPageInput } from '@/lib/pagination';
+import { parseCursorPageInput } from '@/lib/pagination';
 import { checkResourceLimit } from '@/lib/check-feature';
 import { createDocRepository } from '@/lib/storage/factory';
 
@@ -21,13 +21,11 @@ export async function GET(request: Request) {
     const slug = searchParams.get('slug');
     if (slug) return apiSuccess(await service.getDoc(projectId, slug));
 
-    if (searchParams.get('view') === 'tree') {
-      return apiSuccess(await service.getTree(projectId), {
-        mode: 'tree',
-        exception: 'hierarchy_preserving_tree_browse',
-      });
-    }
-
+    // story #2191(#2231 규약 A) — "view=tree" 전용 무커서 경로를 소거했다. BE 라우터는
+    // parent_id 유무로만 tree/list를 가르는데 이 route는 project_id만 보내 애초에 항상
+    // 일반 list() 분기로 떨어지고 있었다("tree 분기"는 실재하지 않았다) — 사이드바 문서
+    // 트리(기본 진입)도 태그 필터와 완전히 같은 커서 경로를 탄다. limit='20' 죽은
+    // 파라미터도 여기서 함께 정리(BE가 이제 실제로 cursor/limit을 받는다).
     const pageInput = parseCursorPageInput({
       limit: searchParams.get('limit') ? Number(searchParams.get('limit')) : undefined,
       cursor: searchParams.get('cursor'),
@@ -35,12 +33,13 @@ export async function GET(request: Request) {
     const query = searchParams.get('q');
     const tagsParam = searchParams.get('tags');
     const tags = tagsParam ? tagsParam.split(',').map((t) => t.trim()).filter(Boolean) : undefined;
-    const rows = query
+    const result = query
       ? await service.search(projectId, query, { ...pageInput, tags })
       : await service.list(projectId, { ...pageInput, tags });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { page, meta } = buildCursorPageMeta(rows as any[], pageInput.limit, 'updated_at');
-    return apiSuccess(page, meta);
+    // ⛔BE가 has_more/next_cursor를 직접 계산해 낸다(#2540) — FE는 그 값을 그대로 믿는다.
+    // buildCursorPageMeta로 재추론하지 않는다(재추론은 오늘 여러 번 확認한 "같은 것을
+    // 두 곳에서 계산하는" 병의 근원).
+    return apiSuccess(result.items, { hasMore: result.hasMore, nextCursor: result.nextCursor });
   } catch (err: unknown) { return handleApiError(err); }
 }
 

--- a/apps/web/src/services/docs.ts
+++ b/apps/web/src/services/docs.ts
@@ -19,10 +19,6 @@ export class DocsService {
     return this.repo.list({ project_id: projectId, limit: input?.limit, cursor: input?.cursor ?? undefined, tags: input?.tags });
   }
 
-  async getTree(projectId: string) {
-    return this.repo.getTree(projectId);
-  }
-
   async getDoc(projectId: string, slug: string) {
     return this.repo.getBySlug(projectId, slug);
   }

--- a/packages/core-storage/src/index.ts
+++ b/packages/core-storage/src/index.ts
@@ -52,6 +52,7 @@ export type {
   CreateDocInput,
   UpdateDocInput,
   DocListFilters,
+  DocPageResult,
 } from './interfaces/IDocRepository';
 
 export type {

--- a/packages/core-storage/src/interfaces/IDocRepository.ts
+++ b/packages/core-storage/src/interfaces/IDocRepository.ts
@@ -64,9 +64,19 @@ export interface DocListFilters extends PaginationOptions {
   q?: string;
 }
 
+// story #2191(#2231 규약 A) — BE가 has_more/next_cursor를 body meta로 직접 계산해 낸다
+// (limit+1 오버페치는 BE 내부에서 이미 끝남 — FE가 buildCursorPageMeta로 재추론하지 않는다).
+// getTree()는 이 스토리에서 소거됨 — BE 라우터는 parent_id 유무로만 tree/list 분기하는데
+// FE는 애초에 parent_id를 안 보내(project_id만) 항상 일반 list() 분기로 떨어지고 있었다
+// ("tree 분기"라는 별도 경로가 실제로는 없었다) — list()로 완전히 통합한다.
+export interface DocPageResult {
+  items: DocSummary[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
 export interface IDocRepository {
-  list(filters: DocListFilters): Promise<DocSummary[]>;
-  getTree(projectId: string): Promise<DocSummary[]>;
+  list(filters: DocListFilters): Promise<DocPageResult>;
   getBySlug(projectId: string, slug: string): Promise<Doc>;
   getById(id: string, scope?: RepositoryScopeContext): Promise<Doc>;
   create(input: CreateDocInput): Promise<Doc>;

--- a/packages/storage-api/src/ApiDocRepository.test.ts
+++ b/packages/storage-api/src/ApiDocRepository.test.ts
@@ -1,0 +1,79 @@
+// story #2191(#2231 규약 A) — BE(#2540)가 GET /api/v2/docs 응답을 배열에서
+// {data, meta:{has_more, next_cursor}}로 바꿨다(list/getBySlug 둘 다). FE가 cursor를
+// 그대로 왕복시키는지, {data,meta}를 {items,hasMore,nextCursor}로 정확히 언랩하는지가
+// 이 스위트의 본체다 — 놓치면 사이드바 문서 트리 "더 보기"가 아무 것도 안 붙는다.
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { ApiDocRepository } from './ApiDocRepository';
+
+describe('ApiDocRepository.list — cursor 전달 + {data,meta} 응답 언랩 (#2191)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [{ id: 'doc-1', parent_id: null, title: 't', slug: 's', icon: null, tags: null, sort_order: 0, is_folder: false, updated_at: '2026-01-01T00:00:00+00:00' }],
+        meta: { has_more: true, next_cursor: '0:doc-1' },
+      }),
+    })) as unknown as ReturnType<typeof vi.fn>;
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  it('cursor가 있으면 요청 URL에 그대로 실린다(불투명 문자열 — 파싱 없이 왕복)', async () => {
+    const repo = new ApiDocRepository('token');
+    await repo.list({ project_id: 'proj-1', limit: 20, cursor: '5:doc-0' });
+
+    const requestedUrl = (fetchMock.mock.calls[0]![0] as URL | string).toString();
+    expect(requestedUrl).toContain(`cursor=${encodeURIComponent('5:doc-0')}`);
+  });
+
+  it('cursor가 없으면 요청 URL에 안 실린다(기존 무커서 호출 회귀 0)', async () => {
+    const repo = new ApiDocRepository('token');
+    await repo.list({ project_id: 'proj-1', limit: 20 });
+
+    const requestedUrl = (fetchMock.mock.calls[0]![0] as URL | string).toString();
+    expect(requestedUrl).not.toContain('cursor=');
+  });
+
+  it('{data,meta} 응답을 {items,hasMore,nextCursor}로 정확히 언랩한다', async () => {
+    const repo = new ApiDocRepository('token');
+    const result = await repo.list({ project_id: 'proj-1' });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]!.id).toBe('doc-1');
+    expect(result.hasMore).toBe(true);
+    expect(result.nextCursor).toBe('0:doc-1');
+  });
+});
+
+describe('ApiDocRepository.getBySlug — 단건 조회도 {data,meta} 봉투를 언랩한다 (#2191)', () => {
+  it('data[0]에서 첫 문서를 찾아 단건 조회로 이어간다', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true, status: 200,
+        json: async () => ({ data: [{ id: 'doc-1', slug: 'my-doc' }], meta: { has_more: false, next_cursor: null } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true, status: 200,
+        json: async () => ({ id: 'doc-1', slug: 'my-doc', content: '본문' }),
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const repo = new ApiDocRepository('token');
+    const doc = await repo.getBySlug('proj-1', 'my-doc');
+
+    expect(doc.content).toBe('본문');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('data가 빈 배열이면 Doc not found를 던진다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true, status: 200,
+      json: async () => ({ data: [], meta: { has_more: false, next_cursor: null } }),
+    })));
+
+    const repo = new ApiDocRepository('token');
+    await expect(repo.getBySlug('proj-1', 'missing')).rejects.toThrow('Doc not found: missing');
+  });
+});

--- a/packages/storage-api/src/ApiDocRepository.ts
+++ b/packages/storage-api/src/ApiDocRepository.ts
@@ -1,11 +1,18 @@
-import type { IDocRepository, Doc, DocSummary, CreateDocInput, UpdateDocInput, DocListFilters, RepositoryScopeContext } from '@sprintable/core-storage';
+import type { IDocRepository, Doc, DocSummary, CreateDocInput, UpdateDocInput, DocListFilters, DocPageResult, RepositoryScopeContext } from '@sprintable/core-storage';
 import { fastapiCall } from './utils';
+
+interface RawDocPageResponse {
+  data: DocSummary[];
+  meta: { has_more: boolean; next_cursor: string | null };
+}
 
 export class ApiDocRepository implements IDocRepository {
   constructor(private readonly accessToken: string = '') {}
 
-  async list(filters: DocListFilters): Promise<DocSummary[]> {
-    return fastapiCall<DocSummary[]>('GET', '/api/v2/docs', this.accessToken, {
+  // story #2191(#2231 규약 A) — BE가 {data, meta:{has_more, next_cursor}}로 응답한다(#2540).
+  // 커서는 (sort_order, id) 복합 불투명 문자열("5:uuid") — 그대로 왕복만 시킨다(파싱 금지).
+  async list(filters: DocListFilters): Promise<DocPageResult> {
+    const res = await fastapiCall<RawDocPageResponse>('GET', '/api/v2/docs', this.accessToken, {
       query: {
         project_id: filters.project_id,
         limit: filters.limit,
@@ -14,17 +21,16 @@ export class ApiDocRepository implements IDocRepository {
         q: filters.q,
       },
     });
+    return { items: res.data, hasMore: res.meta.has_more, nextCursor: res.meta.next_cursor };
   }
 
-  async getTree(projectId: string): Promise<DocSummary[]> {
-    return fastapiCall<DocSummary[]>('GET', '/api/v2/docs', this.accessToken, { query: { project_id: projectId } });
-  }
-
+  // story #2191: 단건 slug 조회도 BE에서 이제 {data,meta} 봉투로 온다(has_more는 구조적으로
+  // 항상 false — 단건 lookup이라 페이지네이션 대상이 아님, #2540 주석 참고).
   async getBySlug(projectId: string, slug: string): Promise<Doc> {
-    const summaries = await fastapiCall<DocSummary[]>('GET', '/api/v2/docs', this.accessToken, {
+    const res = await fastapiCall<RawDocPageResponse>('GET', '/api/v2/docs', this.accessToken, {
       query: { project_id: projectId, slug },
     });
-    const first = summaries[0];
+    const first = res.data[0];
     if (!first) throw new Error(`Doc not found: ${slug}`);
     return fastapiCall<Doc>('GET', `/api/v2/docs/${first.id}`, this.accessToken);
   }


### PR DESCRIPTION
## 요약
⛔**BE #2540과 짝으로 나가야 하는 PR** — BE 단독 머지 시 문서 트리 화면이 즉시 깨진다.

## 원인 재확인 — "tree 분기/일반 분기 둘 다 결함"이 아니라 애초에 같은 분기였다
디디군이 앞선 보고를 정정: FE `getTree()`는 `project_id`만 보내(parent_id 없음) BE 라우터의 `list_tree` 분기(`parent_id is not None` 조건)를 건너뛰고 항상 일반 `list()` 분기로 떨어지고 있었다 — "tree 분기"라는 별도 경로가 실재하지 않았다. `docs-client-layout.tsx`의 `fetchTree()`는 이미 cursor/limit/hasMore/nextCursor를 완결해 두고 기다리고 있었으나(`view=tree`+`limit='20'` 죽은 파라미터), FE 프록시(`/api/docs`)가 `view=tree`를 보면 그 파라미터를 전부 무시하고 `service.getTree(projectId)`만 부르던 것이 진짜 병목이었다.

## 변경
- **packages/core-storage**: `IDocRepository.list()`가 `DocSummary[]` 대신 `{items, hasMore, nextCursor}`(`DocPageResult`)를 반환. `getTree()` 완전 소거(유일 호출자였던 route.ts에서 그 호출 자체가 사라짐).
- **packages/storage-api**: `ApiDocRepository.list()`가 BE `{data,meta}`(#2540, `has_more`/`next_cursor`)를 언랩. `getBySlug()`도 같은 봉투를 언랩. 커서는 (sort_order,id) 복합 불투명 문자열 — 파싱 없이 그대로 왕복.
- **apps/web/src/app/api/docs/route.ts**: `view==='tree'` 특수분기 완전 제거 — 태그 유무와 무관하게 항상 같은 커서 경로(`list()`/`search()`)를 탄다. `buildCursorPageMeta` 재추론 제거 — BE가 계산한 `hasMore`/`nextCursor`를 그대로 믿는다(#2195와 동일 원칙).
- **docs-client-layout.tsx**: 죽은 `view=tree` 파라미터 제거(`limit='20'`은 이제 실제로 동작하므로 그대로 둠).

## 테스트
mutation 확인 완료(2곳 — repo cursor 전달, route meta 전달 — 되돌리면 정확히 그 자리 RED, 음성대조 포함). 전체 vitest 332 files/2281 passed. type-check(core-storage·storage-api·apps/web) clean. build/lint clean.

## Test plan
- [ ] BE #2540 머지 후 이 PR 머지 → 배포 → 21개 넘는 프로젝트에서 사이드바 문서 트리 "더 보기"가 실제로 다음 페이지를 붙이는지 라이브 확인(까심군)

🤖 Generated with [Claude Code](https://claude.com/claude-code)