### PR TITLE
fix(#2237): 형제 비대칭 인가 구멍 11건 봉인 — project-scope 가드 통일

### DIFF
--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -616,10 +616,10 @@ async def get_doc_share(
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
 ) -> ShareStatusResponse:
-    doc = await repo.get(id)
-    if doc is None:
-        raise HTTPException(status_code=404, detail="Doc not found")
-    await _resolve_doc_member_id(auth, repo.org_id, db)  # 멤버십 게이트(비멤버 차단)
+    # #2237: 형제(enable/regenerate/disable_doc_share)와 동일한 project 접근권 가드로 통일 —
+    # 기존엔 org 멤버십(_resolve_doc_member_id)만 확認하고 project 접근권은 안 봤다.
+    # _require_doc_project_access가 org-scope 존재검증(404)+project 접근권(403)을 함께 처리한다.
+    await _require_doc_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
     from app.services import doc_share
     return _share_resp(await doc_share.get_status(db, repo.org_id, id))
 
@@ -683,13 +683,13 @@ async def list_doc_comments(
     limit: int = Query(default=20, le=100),
     db: AsyncSession = Depends(get_db),
     repo: DocRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[DocCommentResponse]:
     # ⚠️S28 보안(까심 RC twin·revisions 동형 IDOR): doc 이 caller org 소속인지 org-scoped repo 로 검증.
     # ⭐comments 는 revisions(S28 전 잠복)와 달리 이미 populated 라 active cross-org 노출이었다(pre-
     # existing·revisions 고치며 surface sweep 서 적출·같이 봉인). org_id 가드(방어 심층).
-    doc = await repo.get(id)
-    if doc is None:
-        raise HTTPException(status_code=404, detail="Doc not found")
+    # #2237: 형제(add_doc_comment)와 동일한 project 접근권 가드 추가(기존엔 org-scope만 봤다).
+    doc = await _require_doc_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
     q = select(DocComment).where(
         DocComment.doc_id == id,
         DocComment.org_id == repo.org_id,
@@ -731,13 +731,13 @@ async def list_doc_revisions(
     limit: int = Query(default=50, le=100),
     db: AsyncSession = Depends(get_db),
     repo: DocRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[DocRevisionResponse]:
     # ⚠️S28 보안(까심 RC·cross-org IDOR): doc 이 caller org 소속인지 org-scoped repo 로 먼저 검증.
     # 안 하면 다른 org 가 doc UUID 추측만으로 revision content 를 읽는다(S28 전엔 revision 미배선이라
     # 빈 응답 잠복·재상신 스냅샷 배선으로 활성화). revision 쿼리에도 org_id 가드(방어 심층).
-    doc = await repo.get(id)
-    if doc is None:
-        raise HTTPException(status_code=404, detail="Doc not found")
+    # #2237: 형제(PATCH/DELETE /{id})와 동일한 project 접근권 가드 추가(기존엔 org-scope만 봤다).
+    doc = await _require_doc_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
     q = select(DocRevision).where(
         DocRevision.doc_id == id,
         DocRevision.org_id == repo.org_id,

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -213,6 +213,13 @@ async def create_gate_endpoint(
     project_id = await resolve_work_item_project_id(
         session, org_id, body.work_item_type, body.work_item_id,
     )
+    # #2237: resolve_work_item_project_id는 조회 전용(gate_service.py) — caller 접근권은 여기서
+    # 별도 강제해야 한다(형제 get_gate_endpoint와 동일 SSOT·동일 404 관례로 존재 비노출).
+    # project_id가 None이면(project-무관 work_item) 경계가 없으므로 org 멤버십만으로 충분.
+    if project_id is not None and not await has_project_access(
+        session, uuid.UUID(_auth.user_id), project_id, org_id
+    ):
+        raise HTTPException(status_code=404, detail="Project not found")
     gate = await create_gate(
         session=session,
         org_id=org_id,

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -24,6 +24,7 @@ from app.services.gate_service import (
     derive_risk_grade,
     get_org_posture,
     hold_gate,
+    is_project_scoped_work_item_type,
     resolve_work_item_project_id,
     transition_gate,
     unhold_gate,
@@ -215,10 +216,13 @@ async def create_gate_endpoint(
     )
     # #2237: resolve_work_item_project_id는 조회 전용(gate_service.py) — caller 접근권은 여기서
     # 별도 강제해야 한다(형제 get_gate_endpoint와 동일 SSOT·동일 404 관례로 존재 비노출).
-    # project_id가 None이면(project-무관 work_item) 경계가 없으므로 org 멤버십만으로 충분.
-    if project_id is not None and not await has_project_access(
-        session, uuid.UUID(_auth.user_id), project_id, org_id
-    ):
+    # ⛔project_id가 None인 이유를 가른다(오르테가 PO 판정, 2026-07-27 라이브 실측 발견) —
+    # 「project-무관 타입이라 None」과 「project-scoped 타입인데 해소 실패(타 org·부재)라 None」이
+    # 같은 값으로 뭉개져 있으면 후자가 검사를 skip해 버린다(실측: 타 org story로 gate 201 생성됨).
+    if project_id is not None:
+        if not await has_project_access(session, uuid.UUID(_auth.user_id), project_id, org_id):
+            raise HTTPException(status_code=404, detail="Project not found")
+    elif is_project_scoped_work_item_type(body.work_item_type):
         raise HTTPException(status_code=404, detail="Project not found")
     gate = await create_gate(
         session=session,
@@ -725,9 +729,14 @@ async def get_gate_endpoint(
     project_id = await resolve_work_item_project_id(
         session, org_id, gate.work_item_type, gate.work_item_id,
     )
-    if project_id is not None and not await has_project_access(
-        session, uuid.UUID(auth.user_id), project_id, org_id
-    ):
+    # #2237: project_id가 None인 이유를 가른다(오르테가 PO 판정, 2026-07-27) — 「project-무관
+    # 타입이라 None」과 「project-scoped 타입인데 해소 실패(work_item이 이 org에 없음)라 None」이
+    # 같은 값으로 뭉개져 있으면 후자가 검사를 skip해 버린다. gate.work_item_id가 org_id 스코프
+    # 안에서 해소 안 되는 것은 이 gate 자체가 가리키는 대상이 이 org에 없다는 뜻이라 거부.
+    if project_id is not None:
+        if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
+            raise HTTPException(status_code=404, detail="Gate not found")
+    elif is_project_scoped_work_item_type(gate.work_item_type):
         raise HTTPException(status_code=404, detail="Gate not found")
 
     resp = GateResponse.model_validate(gate)

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -24,7 +24,7 @@ from app.services.gate_service import (
     derive_risk_grade,
     get_org_posture,
     hold_gate,
-    is_project_scoped_work_item_type,
+    is_known_project_agnostic_work_item_type,
     resolve_work_item_project_id,
     transition_gate,
     unhold_gate,
@@ -219,10 +219,12 @@ async def create_gate_endpoint(
     # ⛔project_id가 None인 이유를 가른다(오르테가 PO 판정, 2026-07-27 라이브 실측 발견) —
     # 「project-무관 타입이라 None」과 「project-scoped 타입인데 해소 실패(타 org·부재)라 None」이
     # 같은 값으로 뭉개져 있으면 후자가 검사를 skip해 버린다(실측: 타 org story로 gate 201 생성됨).
+    # fail-closed(②): 통과는 KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES(명시 allowlist)에 있을 때만 —
+    # PROJECT_SCOPED_WORK_ITEM_TYPES에도 그 목록에도 없는 미분류 타입은 기본값이 거부다.
     if project_id is not None:
         if not await has_project_access(session, uuid.UUID(_auth.user_id), project_id, org_id):
             raise HTTPException(status_code=404, detail="Project not found")
-    elif is_project_scoped_work_item_type(body.work_item_type):
+    elif not is_known_project_agnostic_work_item_type(body.work_item_type):
         raise HTTPException(status_code=404, detail="Project not found")
     gate = await create_gate(
         session=session,
@@ -733,10 +735,11 @@ async def get_gate_endpoint(
     # 타입이라 None」과 「project-scoped 타입인데 해소 실패(work_item이 이 org에 없음)라 None」이
     # 같은 값으로 뭉개져 있으면 후자가 검사를 skip해 버린다. gate.work_item_id가 org_id 스코프
     # 안에서 해소 안 되는 것은 이 gate 자체가 가리키는 대상이 이 org에 없다는 뜻이라 거부.
+    # fail-closed(②): 통과는 KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES 명시 allowlist에 있을 때만.
     if project_id is not None:
         if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
             raise HTTPException(status_code=404, detail="Gate not found")
-    elif is_project_scoped_work_item_type(gate.work_item_type):
+    elif not is_known_project_agnostic_work_item_type(gate.work_item_type):
         raise HTTPException(status_code=404, detail="Gate not found")
 
     resp = GateResponse.model_validate(gate)

--- a/backend/app/routers/goals.py
+++ b/backend/app/routers/goals.py
@@ -137,9 +137,13 @@ async def create_goal(
 async def get_goal(
     id: uuid.UUID,
     repo: GoalRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> GoalResponse:
     goal = await repo.get(id)
     if goal is None:
+        raise HTTPException(status_code=404, detail="Goal not found")
+    # #2237: 형제(update_goal)와 동일한 project 접근권 가드 추가(기존엔 org-scope만 봤다).
+    if not await has_project_access(repo.session, uuid.UUID(auth.user_id), goal.project_id, repo.org_id):
         raise HTTPException(status_code=404, detail="Goal not found")
     return GoalResponse.model_validate(goal)
 
@@ -382,9 +386,13 @@ async def delete_goal(
 async def get_goal_progress(
     id: uuid.UUID,
     repo: GoalRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> GoalProgressResponse:
     goal = await repo.get(id)
     if goal is None:
+        raise HTTPException(status_code=404, detail="Goal not found")
+    # #2237: 형제(update_goal)와 동일한 project 접근권 가드 추가(기존엔 org-scope만 봤다).
+    if not await has_project_access(repo.session, uuid.UUID(auth.user_id), goal.project_id, repo.org_id):
         raise HTTPException(status_code=404, detail="Goal not found")
     return await repo.get_progress(id)
 

--- a/backend/app/routers/hypotheses.py
+++ b/backend/app/routers/hypotheses.py
@@ -160,8 +160,12 @@ async def create_hypothesis(
 async def get_hypothesis(
     hypothesis_id: uuid.UUID,
     session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> HypothesisResponse:
+    # #2237: 형제(update_hypothesis)와 동일한 project 접근권 가드 추가(기존엔 org-scope만 봤다·
+    # auth 파라미터 자체가 없었다).
+    await _assert_hypothesis_project_access(session, uuid.UUID(auth.user_id), org_id, hypothesis_id)
     try:
         return await svc.get_hypothesis(session, org_id, hypothesis_id)
     except svc.HypothesisServiceError as err:

--- a/backend/app/routers/hypotheses.py
+++ b/backend/app/routers/hypotheses.py
@@ -192,6 +192,11 @@ async def transition_hypothesis(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> HypothesisResponse:
+    # #2237: 형제(update_hypothesis/unlink/archive)와 동일한 project 접근권 가드를 status 값과
+    # 무관하게 전 전이에 적용(기존엔 status=="active" 분기 안에만 있던 hyp 조회가 owner/admin
+    # role 체크로만 쓰였을 뿐, project 접근권 자체는 어떤 status 로도 검증되지 않았다 — #2198과
+    # 동형 「타입 분기 안에 갇힌 검사」. 同org 비-project 멤버도 kill/verify/falsify/archive 가능하던 갭).
+    await _assert_hypothesis_project_access(session, uuid.UUID(auth.user_id), org_id, hypothesis_id)
     caller = await resolve_member(auth, org_id, session)
     # §3.1.7 active 전이 권한은 라우터에서 보강(owner 휴먼 또는 org admin/owner).
     if body.status == "active":
@@ -214,8 +219,13 @@ async def link_hypothesis(
     hypothesis_id: uuid.UUID,
     body: HypothesisLinkRequest,
     session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> HypothesisResponse:
+    # #2237: 형제(unlink_hypothesis)와 동일하게 caller 의 hypothesis project 접근권 사전검증
+    # (기존엔 service 의 _assert_targets_same_project 가 "링크 대상들이 서로 같은 project인가"만
+    # 봤을 뿐 caller 접근권은 전혀 안 봤다 — 同org 비-project 멤버도 링크 주입 가능하던 갭).
+    await _assert_hypothesis_project_access(session, uuid.UUID(auth.user_id), org_id, hypothesis_id)
     # §3.7.2 cross-project 링크 금지 + 존재 검증은 service(link_hypothesis)가 단일 처리.
     try:
         return await svc.link_hypothesis(session, org_id, hypothesis_id, body)

--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -276,7 +276,12 @@ async def get_missing_standups(
     project_id: uuid.UUID = Query(...),
     date_filter: date = Query(..., alias="date"),
     repo: StandupEntryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[uuid.UUID]:
+    # #2237: 형제(list_standup_history)와 동일한 project_id 쿼리파라미터 접근권 가드 추가 —
+    # 기존엔 auth 파라미터 자체가 없어 project_id를 caller 접근권 검증 없이 그대로 썼다.
+    if not await has_project_access(repo.session, uuid.UUID(auth.user_id), project_id, repo.org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
     return await repo.get_missing(project_id, date_filter)
 
 
@@ -285,8 +290,13 @@ async def list_feedback(
     project_id: uuid.UUID = Query(...),
     date_filter: date = Query(..., alias="date"),
     db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> list[FeedbackResponse]:
+    # #2237: 형제(list_standups/list_standup_history)와 동일한 project_id 접근권 가드 추가 —
+    # 기존엔 auth 파라미터 자체가 없어 project_id를 caller 접근권 검증 없이 쿼리 필터로만 썼다.
+    if not await has_project_access(db, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
     q = (
         select(StandupFeedback)
         .join(StandupEntry, StandupFeedback.standup_entry_id == StandupEntry.id)

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -27,7 +27,9 @@ from sqlalchemy.orm import aliased
 from app.models.doc import Doc
 from app.models.gate import Gate, is_valid_transition
 from app.models.hitl_config import OrgGatePolicy
-from app.models.pm import Story, Task
+from app.models.hypothesis import Hypothesis
+from app.models.loop import LoopRun
+from app.models.pm import Goal, Sprint, Story, Task
 from app.models.visual_artifact import VisualArtifact
 from app.models.workflow_line import (
     WorkflowLineStepApproval,
@@ -179,12 +181,19 @@ _DISPOSITION_TO_STATUS: dict[str, str] = {
     "deny": "rejected",
 }
 
-# #2237: resolve_work_item_project_id가 다루는 4개 타입은 전부 project_id NOT NULL(위 docstring)
-# — 즉 구조적으로 project-scoped다. 이 집합에 없는 work_item_type(workflow_line_config의
-# wf_line_version 등)만 진짜 project-무관이다. 호출부가 None 하나로 뭉뚱그려 받으면 "project-무관
-# 타입이라 None"과 "project-scoped 타입인데 해소 실패(타 org·부재)"를 구분 못 해 후자가 검사를
-# 그냥 skip해 버린다(create_gate_endpoint가 실제로 겪었다 — 타 org story로 gate가 생성됨).
-PROJECT_SCOPED_WORK_ITEM_TYPES: frozenset[str] = frozenset({"story", "task", "doc", "visual_artifact"})
+# #2237(오르테가 PO 판정 2026-07-27, ①→②): create_gate() 실 호출부 6곳을 전부 읽어 만든 「전량」 —
+# DB에도 Pydantic에도 work_item_type 정본이 없다(gate_type만 GATE_TYPES로 검증됨, 비대칭 — 그 갭은
+# 별도 스토리로 오르테가군이 등재). 아래 8개는 각 모델의 project_id 컬럼을 기계적으로 확認해 project-
+# scoped로 분류한 것(새 규칙 발명 0 — 그냥 「project_id가 NOT NULL FK로 있는가」를 본 것):
+#   story·task·doc·visual_artifact(원래 4개) + loop(LoopRun.project_id)·hypothesis(Hypothesis.
+#   project_id)·epic(Goal.project_id — B1 rename 前 이름 그대로 남은 work_item_type 리터럴, 실체는
+#   Goal)·sprint(Sprint.project_id) — 전부 NOT NULL FK(app/models/{loop,hypothesis,pm}.py 확認).
+# 진짜 project-무관은 workflow_line_config의 'wf_line_version' 뿐(version.project_id가 nullable —
+# 구조적으로 project 경계가 없을 수 있음, 그 호출부가 이미 로드된 엔티티의 project_id를 직접 넘김).
+PROJECT_SCOPED_WORK_ITEM_TYPES: frozenset[str] = frozenset(
+    {"story", "task", "doc", "visual_artifact", "loop", "hypothesis", "epic", "sprint"}
+)
+KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES: frozenset[str] = frozenset({"wf_line_version"})
 
 
 def is_project_scoped_work_item_type(work_item_type: str) -> bool:
@@ -192,6 +201,14 @@ def is_project_scoped_work_item_type(work_item_type: str) -> bool:
     «project-scoped 타입인데 해소 실패라 거부» 로 갈라 판단할 때 쓴다. 새 타입 발명이 아니라
     resolve_work_item_project_id가 이미 아는 분기를 그대로 드러낸 것(SSOT 재사용)."""
     return work_item_type in PROJECT_SCOPED_WORK_ITEM_TYPES
+
+
+def is_known_project_agnostic_work_item_type(work_item_type: str) -> bool:
+    """#2237(②, fail-closed 전환): resolve_work_item_project_id()가 None을 반환했을 때 «통과»는
+    이 명시적 allowlist에 있는 타입에만 허용한다 — PROJECT_SCOPED_WORK_ITEM_TYPES에도 이 집합에도
+    없는 미분류 타입(오타·미래에 추가될 새 타입)은 기본값이 «거부»다(과거엔 기본값이 «통과»라
+    fail-open이었다 — 새 work_item_type이 조용히 다시 뚫리는 재발 클래스였다)."""
+    return work_item_type in KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES
 
 
 async def resolve_work_item_project_id(
@@ -206,16 +223,24 @@ async def resolve_work_item_project_id(
     (routers/gates.py 제네릭 생성 엔드포인트·merge_verdict_gate.py evaluate_merge_gate)과
     override_gate()의 sr(step_run)=None 폴백용.
 
-    Story/Doc/VisualArtifact.project_id는 NOT NULL이라 row가 있으면 항상 값이 있다. Task는
-    project_id 컬럼이 없어 story JOIN. 미지원/미인식 work_item_type(예: workflow_line_config의
+    PROJECT_SCOPED_WORK_ITEM_TYPES 8종은 project_id가 NOT NULL이라 row가 있으면 항상 값이 있다.
+    Task는 project_id 컬럼이 없어 story JOIN. 미지원/미인식 work_item_type(예: workflow_line_config의
     org-level 'wf_line_version' — 실제로 project-무관일 수 있음)은 None(best-effort — silent
-    실패가 아니라 구조적으로 project-scoped가 아닐 수 있다는 정직한 신호).
+    실패가 아니라 구조적으로 project-scoped가 아닐 수 있다는 정직한 신호). #2237: 호출부는 이 None을
+    그대로 "통과"로 읽지 말고 is_known_project_agnostic_work_item_type()으로 한 번 더 갈라야 한다
+    (project-scoped 타입의 해소 실패=거부, 진짜 무관 타입=통과 — 같은 None을 뭉개면 전자가 새는 것을
+    #2237이 create_gate_endpoint에서 실측으로 확認했다).
 
     story #2082: visual_artifact 분기는 이 함수 신설 시(story #1968) 누락돼 있었다 —
     artifact_canonicalize 게이트(work_item_type="visual_artifact")의 project_id가 항상
     None으로 해소돼 assigned_to_me=true 인박스에서 project-level owner/admin에게 안 보이는
     (org owner/admin에게만 노출되는) 회귀였다. VisualArtifact.project_id는 NOT NULL이라
-    Story/Doc과 동형으로 항상 해소 가능."""
+    Story/Doc과 동형으로 항상 해소 가능.
+
+    #2237: loop(workflow_parallel_approval.py 병렬승인·loop.py 자체 결정 게이트)·hypothesis/epic/
+    sprint(workflow_parallel_approval.py가 WorkflowLineStepRun.entity_type을 work_item_type으로
+    그대로 넘긴다 — app/models/workflow_line.py ENTITY_TYPES={story,doc,hypothesis,epic,sprint})
+    4종 신규 — 전부 project_id NOT NULL FK 확認 후 추가(기계적 확認, 새 규칙 아님)."""
     if work_item_type == "story":
         return (await session.execute(
             select(Story.project_id).where(Story.id == work_item_id, Story.org_id == org_id)
@@ -235,6 +260,24 @@ async def resolve_work_item_project_id(
             select(VisualArtifact.project_id).where(
                 VisualArtifact.id == work_item_id, VisualArtifact.org_id == org_id,
             )
+        )).scalar_one_or_none()
+    if work_item_type == "loop":
+        return (await session.execute(
+            select(LoopRun.project_id).where(LoopRun.id == work_item_id, LoopRun.org_id == org_id)
+        )).scalar_one_or_none()
+    if work_item_type == "hypothesis":
+        return (await session.execute(
+            select(Hypothesis.project_id).where(
+                Hypothesis.id == work_item_id, Hypothesis.org_id == org_id,
+            )
+        )).scalar_one_or_none()
+    if work_item_type == "epic":  # 실체=Goal(B1 rename 前 work_item_type 리터럴이 그대로 남음).
+        return (await session.execute(
+            select(Goal.project_id).where(Goal.id == work_item_id, Goal.org_id == org_id)
+        )).scalar_one_or_none()
+    if work_item_type == "sprint":
+        return (await session.execute(
+            select(Sprint.project_id).where(Sprint.id == work_item_id, Sprint.org_id == org_id)
         )).scalar_one_or_none()
     return None
 

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -179,6 +179,21 @@ _DISPOSITION_TO_STATUS: dict[str, str] = {
     "deny": "rejected",
 }
 
+# #2237: resolve_work_item_project_id가 다루는 4개 타입은 전부 project_id NOT NULL(위 docstring)
+# — 즉 구조적으로 project-scoped다. 이 집합에 없는 work_item_type(workflow_line_config의
+# wf_line_version 등)만 진짜 project-무관이다. 호출부가 None 하나로 뭉뚱그려 받으면 "project-무관
+# 타입이라 None"과 "project-scoped 타입인데 해소 실패(타 org·부재)"를 구분 못 해 후자가 검사를
+# 그냥 skip해 버린다(create_gate_endpoint가 실제로 겪었다 — 타 org story로 gate가 생성됨).
+PROJECT_SCOPED_WORK_ITEM_TYPES: frozenset[str] = frozenset({"story", "task", "doc", "visual_artifact"})
+
+
+def is_project_scoped_work_item_type(work_item_type: str) -> bool:
+    """호출부가 resolve_work_item_project_id()의 None을 «project-무관 타입이라 통과»와
+    «project-scoped 타입인데 해소 실패라 거부» 로 갈라 판단할 때 쓴다. 새 타입 발명이 아니라
+    resolve_work_item_project_id가 이미 아는 분기를 그대로 드러낸 것(SSOT 재사용)."""
+    return work_item_type in PROJECT_SCOPED_WORK_ITEM_TYPES
+
+
 async def resolve_work_item_project_id(
     session: AsyncSession, org_id: uuid.UUID, work_item_type: str, work_item_id: uuid.UUID,
 ) -> uuid.UUID | None:

--- a/backend/tests/test_1968_gate_project_id_threading.py
+++ b/backend/tests/test_1968_gate_project_id_threading.py
@@ -140,8 +140,9 @@ async def test_generic_gate_endpoint_threads_resolved_project_id():
 
 
 @pytest.mark.anyio
-async def test_generic_gate_endpoint_unresolvable_type_passes_none():
-    """미인식 work_item_type이면 project_id=None 그대로 넘어간다(크래시 아님 — best-effort)."""
+async def test_generic_gate_endpoint_known_agnostic_type_passes_none():
+    """#2237(②): KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES 명시 allowlist(예: wf_line_version)에
+    있는 타입만 project_id=None 그대로 통과한다(진짜 project-무관 타입 — 크래시 아님)."""
     from app.routers import gates as gates_mod
     from app.routers.gates import GateCreateRequest, create_gate_endpoint
 
@@ -150,7 +151,7 @@ async def test_generic_gate_endpoint_unresolvable_type_passes_none():
     session.commit = AsyncMock()
     gate = SimpleNamespace(id=uuid.uuid4(), status="pending")
     body = GateCreateRequest(
-        work_item_id=work_item_id, work_item_type="mystery_type", gate_type="qa",
+        work_item_id=work_item_id, work_item_type="wf_line_version", gate_type="qa",
         member_id=uuid.uuid4(), role_id=uuid.uuid4(),
     )
 
@@ -161,6 +162,31 @@ async def test_generic_gate_endpoint_unresolvable_type_passes_none():
         await create_gate_endpoint(body=body, session=session, org_id=org_id, _auth=SimpleNamespace())
 
     assert create_spy.await_args.kwargs["project_id"] is None
+
+
+@pytest.mark.anyio
+async def test_generic_gate_endpoint_unclassified_type_rejected_fail_closed():
+    """#2237(②, fail-closed 전환): PROJECT_SCOPED_WORK_ITEM_TYPES에도
+    KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES에도 없는 미분류 타입은 이제 기본값이 거부다(과거엔
+    통과였다 — 새 work_item_type이 조용히 다시 뚫리는 재발 클래스를 막는다)."""
+    from fastapi import HTTPException
+    from app.routers import gates as gates_mod
+    from app.routers.gates import GateCreateRequest, create_gate_endpoint
+
+    org_id, work_item_id = uuid.uuid4(), uuid.uuid4()
+    session = AsyncMock()
+    body = GateCreateRequest(
+        work_item_id=work_item_id, work_item_type="mystery_type", gate_type="qa",
+        member_id=uuid.uuid4(), role_id=uuid.uuid4(),
+    )
+
+    with patch.object(gates_mod, "resolve_work_item_project_id", AsyncMock(return_value=None)):
+        with pytest.raises(HTTPException) as ei:
+            await create_gate_endpoint(
+                body=body, session=session, org_id=org_id,
+                _auth=SimpleNamespace(user_id=str(uuid.uuid4())),
+            )
+    assert ei.value.status_code == 404
 
 
 # ── merge_verdict_gate.py evaluate_merge_gate ────────────────────────────────

--- a/backend/tests/test_1968_gate_project_id_threading.py
+++ b/backend/tests/test_1968_gate_project_id_threading.py
@@ -124,12 +124,16 @@ async def test_generic_gate_endpoint_threads_resolved_project_id():
         work_item_id=work_item_id, work_item_type="story", gate_type="merge",
         member_id=uuid.uuid4(), role_id=uuid.uuid4(),
     )
+    # #2237: create_gate_endpoint가 project_id 해소 後 caller 접근권을 강제하게 됐다 — 이 테스트는
+    # threading(①resolve→②create로 넘김) 자체만 검증하므로 has_project_access는 True로 통과시킨다.
+    auth = SimpleNamespace(user_id=str(uuid.uuid4()))
 
     with patch.object(gates_mod, "resolve_work_item_project_id",
                        AsyncMock(return_value=project_id)) as resolve_spy, \
+         patch.object(gates_mod, "has_project_access", AsyncMock(return_value=True)), \
          patch.object(gates_mod, "create_gate", AsyncMock(return_value=gate)) as create_spy, \
          patch.object(gates_mod.GateResponse, "model_validate", lambda g: "OK"):
-        await create_gate_endpoint(body=body, session=session, org_id=org_id, _auth=SimpleNamespace())
+        await create_gate_endpoint(body=body, session=session, org_id=org_id, _auth=auth)
 
     resolve_spy.assert_awaited_once_with(session, org_id, "story", work_item_id)
     assert create_spy.await_args.kwargs["project_id"] == project_id

--- a/backend/tests/test_2038_hypothesis_outcome_result_enforce.py
+++ b/backend/tests/test_2038_hypothesis_outcome_result_enforce.py
@@ -88,9 +88,15 @@ async def _setup_app(app, Session, org_id, user_id):
 
 
 async def _seed_common(session):
-    """org + project + caller(human org member)."""
+    """org + project + caller(human org member, project_access grant).
+
+    #2237(PR #2546 CI 적발): transition_hypothesis가 status=="active" 밖에서도 project 접근권을
+    강제하게 되면서 — 이 fixture가 caller를 org member로만 만들고 project_access grant를 준 적이
+    없던 것(이전엔 그 검사 자체가 없어 안 드러났다)이 실제로 거부(404)로 드러났다. 가드가 옳고
+    fixture가 낡았던 케이스(②) — caller에게 project_access를 명시로 세워 준다."""
     from app.models.organization import Organization
     from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
     from app.models.user import User
 
     org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
@@ -106,6 +112,10 @@ async def _seed_common(session):
     await session.commit()
     caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller.id, role="member")
     session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=caller_om.id, permission="granted", role="member",
+    ))
     await session.commit()
 
     return {"org_id": org.id, "project_id": project.id, "caller_id": caller_om.id, "caller_user_id": caller.id}

--- a/backend/tests/test_2237_gate_create_project_scope_realdb.py
+++ b/backend/tests/test_2237_gate_create_project_scope_realdb.py
@@ -1,0 +1,130 @@
+"""#2237(WRITE②) — POST /api/v2/gates(create_gate_endpoint) project-scope IDOR, 실 PG.
+
+갭: create_gate_endpoint 는 resolve_work_item_project_id() 로 project_id 를 조회만 할 뿐(gate_service.py),
+caller 가 그 project 에 접근권이 있는지는 전혀 검증하지 않았다 — 형제 get_gate_endpoint(GET /{id})는
+동일 project_id 에 has_project_access 를 강제하는데(story #1970) create 경로만 빠져 있었다(#2200 A급
+전수 적출). 同org 비-project 멤버가 접근권 없는 project 의 story/doc/task 를 work_item 으로 임의
+gate_type(doc_approval 제외) 게이트를 생성할 수 있었다.
+
+처방: 형제(get_gate_endpoint)가 쓰는 것과 동일한 has_project_access, 동일 404 관례("Project not found").
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("d2237000-0000-0000-0000-000000000001")
+CALLER_USER = uuid.UUID("d2237000-0000-0000-0000-0000000000a1")  # project_access: PROJ_A 만
+CALLER_OM = uuid.UUID("d2237000-0000-0000-0000-0000000000b1")
+PROJ_A = uuid.UUID("d2237000-0000-0000-0000-0000000000c1")  # caller 접근권 有
+PROJ_B = uuid.UUID("d2237000-0000-0000-0000-0000000000c2")  # caller 접근권 無
+STORY_A = uuid.UUID("d2237000-0000-0000-0000-0000000000d1")
+STORY_B = uuid.UUID("d2237000-0000-0000-0000-0000000000d2")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(CALLER_USER), email=None, claims={}, org_id=str(ORG))
+
+
+async def _seed(s):
+    """ORG · PROJ_A(caller grant)·PROJ_B(caller 무접근) · 각 project 에 story 1건."""
+    for sql in [
+        f"DELETE FROM gate WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id IN ('{PROJ_A}','{PROJ_B}')",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM stories WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{CALLER_USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','D2237','d2237-org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{CALLER_USER}','caller@d2237.test','x','Caller',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{CALLER_OM}','{ORG}','{CALLER_USER}','member')",
+        f"INSERT INTO projects (id,org_id,name,slug) VALUES "
+        f"('{PROJ_A}','{ORG}','A','proj-a-2237'),('{PROJ_B}','{ORG}','B','proj-b-2237')",
+        # caller는 PROJ_A에만 grant — PROJ_B에는 project_access 행 자체가 없다.
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission,role) VALUES "
+        f"(gen_random_uuid(),'{PROJ_A}','{CALLER_OM}','granted','member')",
+        f"INSERT INTO stories (id,org_id,project_id,title,status) VALUES "
+        f"('{STORY_A}','{ORG}','{PROJ_A}','Story A','backlog'),"
+        f"('{STORY_B}','{ORG}','{PROJ_B}','Story B','backlog')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _gate_count(Session, work_item_id):
+    async with Session() as s:
+        return (await s.execute(
+            text("SELECT count(*) FROM gate WHERE work_item_id = :w"), {"w": work_item_id}
+        )).scalar_one()
+
+
+@pytest.mark.anyio
+async def test_create_gate_own_project_200():
+    """회귀0: PROJ_A grant caller가 PROJ_A story를 work_item으로 qa 게이트 생성 → 성공."""
+    from app.routers.gates import GateCreateRequest, create_gate_endpoint
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            resp = await create_gate_endpoint(
+                body=GateCreateRequest(
+                    work_item_id=STORY_A, work_item_type="story", gate_type="qa",
+                    member_id=uuid.uuid4(), role_id=uuid.uuid4(),
+                ),
+                session=s, org_id=ORG, _auth=_auth(),
+            )
+        assert resp.work_item_id == STORY_A
+        assert await _gate_count(Session, STORY_A) == 1
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_gate_cross_project_blocked_404_not_created():
+    """봉인: 접근권 없는 PROJ_B story를 work_item으로 게이트 생성 시도 → 404 + **생성 0건**
+    (직전 재조회로 뮤테이션 실증). 수정 前엔 project_id 조회만 하고 접근권 검증이 없어 201로 통과했다."""
+    from app.routers.gates import GateCreateRequest, create_gate_endpoint
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await create_gate_endpoint(
+                    body=GateCreateRequest(
+                        work_item_id=STORY_B, work_item_type="story", gate_type="qa",
+                        member_id=uuid.uuid4(), role_id=uuid.uuid4(),
+                    ),
+                    session=s, org_id=ORG, _auth=_auth(),
+                )
+            assert ei.value.status_code == 404
+        assert await _gate_count(Session, STORY_B) == 0, "cross-project 게이트가 생성됨(IDOR)"
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_2237_goals_get_progress_project_scope_realdb.py
+++ b/backend/tests/test_2237_goals_get_progress_project_scope_realdb.py
@@ -1,0 +1,192 @@
+"""#2237(READ) — GET /{id}·GET /{id}/progress(goals.py get_goal·get_goal_progress) project-scope
+IDOR, 실 PG.
+
+갭: 두 라우트 모두 goal을 id로 잡되 repo.get()이 org-scope만이라 project 접근권 검증이 없었다
+(#2200 A급 전수 적출). 형제 update_goal(PATCH)은 has_project_access를 이미 쓰고 있었다. 처방:
+형제와 동일한 has_project_access(동일 404 "Goal not found" 관례 — 존재 비노출) 재사용.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a[caller grant]·project_b[무접근]) + goal_a(project_a)·goal_b(project_b)."""
+    from app.models.organization import Organization
+    from app.models.pm import Goal
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+    goal_a = Goal(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Goal A", status="active")
+    goal_b = Goal(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Goal B SECRET", status="active")
+    session.add_all([goal_a, goal_b])
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=caller_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "goal_a_id": goal_a.id, "goal_b_id": goal_b.id, "caller_id": caller_id}
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_get_goal_own_project_200():
+    """회귀0: project_a grant caller가 project_a goal 조회 → 200."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/goals/{seeded['goal_a_id']}")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["title"] == "Goal A"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_goal_cross_project_blocked_404():
+    """봉인: 접근권 없는 project_b goal 조회 시도 → 404(수정 前엔 200으로 통과해 title/전략 노출)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/goals/{seeded['goal_b_id']}")
+            assert resp.status_code == 404, resp.text
+            assert "SECRET" not in resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_goal_progress_own_project_200():
+    """회귀0: project_a grant caller가 project_a goal의 progress 조회 → 200."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/goals/{seeded['goal_a_id']}/progress")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_goal_progress_cross_project_blocked_404():
+    """봉인: 접근권 없는 project_b goal의 progress 조회 시도 → 404(수정 前엔 200으로 통과)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/goals/{seeded['goal_b_id']}/progress")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_2237_standups_missing_feedback_project_scope_realdb.py
+++ b/backend/tests/test_2237_standups_missing_feedback_project_scope_realdb.py
@@ -1,0 +1,219 @@
+"""#2237(READ) — GET /missing·GET /feedback(standups.py get_missing_standups·list_feedback)
+project-scope IDOR, 실 PG.
+
+갭: 둘 다 project_id를 쿼리파라미터로 받되 caller 접근권 검증이 없었다(#2200 A급 전수 적출) —
+`auth` 파라미터 자체가 없어 caller 식별조차 안 했다(가장 노골적인 형태). 바로 옆 형제
+list_standups/list_standup_history는 이미 has_project_access(ratchet round5, #2050)를 쓰고
+있었다. 처방: 그 형제와 동일한 has_project_access + 동일 404 "Project not found" 관례.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a[caller grant]·project_b[무접근]) + project_b standup entry(SECRET blockers)
+    + project_b에 링크된 feedback(SECRET note)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.standup import StandupEntry, StandupEntryProject, StandupFeedback
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    the_date = date(2026, 7, 11)
+    entry_b = StandupEntry(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, sprint_id=None,
+        author_id=uuid.uuid4(), date=the_date,
+        done="x", plan="y", blockers="SECRET BLOCKER PROJECT B",
+    )
+    session.add(entry_b)
+    await session.commit()
+    session.add(StandupEntryProject(id=uuid.uuid4(), org_id=org.id, entry_id=entry_b.id, project_id=project_b.id))
+    await session.commit()
+    feedback_b = StandupFeedback(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, standup_entry_id=entry_b.id,
+        feedback_by_id=uuid.uuid4(), review_type="comment", feedback_text="SECRET FEEDBACK PROJECT B",
+    )
+    session.add(feedback_b)
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=caller_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "the_date": the_date, "caller_id": caller_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_get_missing_standups_own_project_200():
+    """회귀0: project_a grant caller가 project_a missing 조회 → 200."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/standups/missing?project_id={seeded['project_a_id']}&date={seeded['the_date'].isoformat()}"
+            )
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_missing_standups_cross_project_blocked_404():
+    """봉인: 접근권 없는 project_b missing 조회 시도 → 404(수정 前엔 auth 파라미터도 없어 200 통과)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/standups/missing?project_id={seeded['project_b_id']}&date={seeded['the_date'].isoformat()}"
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_feedback_own_project_200():
+    """회귀0: project_a grant caller가 project_a feedback 조회(빈 결과여도 200)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/standups/feedback?project_id={seeded['project_a_id']}&date={seeded['the_date'].isoformat()}"
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json() == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_feedback_cross_project_blocked_404_no_leak():
+    """봉인: 접근권 없는 project_b feedback(SECRET FEEDBACK) 조회 시도 → 404 + 내용 무노출
+    (수정 前엔 auth 파라미터도 없어 project_id 필터만으로 200 + SECRET 노출)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/standups/feedback?project_id={seeded['project_b_id']}&date={seeded['the_date'].isoformat()}"
+            )
+            assert resp.status_code == 404, resp.text
+            assert "SECRET FEEDBACK PROJECT B" not in resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_2237_work_item_type_classification_exhaustive.py
+++ b/backend/tests/test_2237_work_item_type_classification_exhaustive.py
@@ -1,0 +1,73 @@
+"""#2237(③): PROJECT_SCOPED_WORK_ITEM_TYPES/KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES 분류가
+「전량」을 커버하는지 고정한다.
+
+⚠️이 테스트가 못 잡는 것 한 줄(오르테가 PO 요청, i18n 가드 #2228 선례와 동형): work_item_type은
+DB CHECK도 Pydantic 검증기도 없는 varchar(20) 자유값이라(gate_type=GATE_TYPES와 비대칭 — 그 갭은
+별도 스토리) 진짜 exhaustive 보장은 이 리포의 모든 create_gate() 호출부를 AST로 스캔해야 한다
+(story #1808 PATH_ID axis 스캐너와 동형 무게). 이 테스트는 그 정도가 아니라 — 2026-07-27 기준
+create_gate() 실 호출부 6곳을 손으로 읽어 나온 리터럴 목록을 고정한 것이다. 새 create_gate() 호출부가
+새 work_item_type으로 생기면 이 테스트는 «못 잡는다»(수동 목록의 한계) — 그건 gate_service.py의
+PROJECT_SCOPED_WORK_ITEM_TYPES/KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES 자체가 손으로 갱신해야 하는
+한계이지 이 테스트의 몫이 아니다. 이 테스트가 잡는 것은 「이미 알려진 8+1개 타입 중 하나가 실수로
+분류에서 빠지는 것」뿐이다.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# 2026-07-27 기준 create_gate() 실 호출부 6곳에서 나온 work_item_type 리터럴 전량(손으로 읽음):
+#   app/services/doc.py                       "doc"              (DOC_GATE_WORK_ITEM_TYPE)
+#   app/routers/visual_artifacts.py            "visual_artifact"
+#   app/services/merge_verdict_gate.py         "story"
+#   app/services/loop.py                       "loop"
+#   app/services/workflow_line_config.py       "wf_line_version"  (WORKFLOW_LINE_VERSION_WORK_ITEM_TYPE)
+#   app/services/workflow_parallel_approval.py step_run.entity_type — 정의역(app/models/workflow_line.py
+#                                               ENTITY_TYPES) = {story, doc, hypothesis, epic, sprint}
+#   app/routers/gates.py 제네릭 create_gate_endpoint — task 포함(resolve_work_item_project_id가
+#                                               지원하는 타입 중 "task"는 story #1968이 이미 project-
+#                                               scoped로 분류해 뒀음. 실 create_gate() 호출부는 없지만
+#                                               resolve_work_item_project_id/get_gate_endpoint가
+#                                               다뤄야 하므로 이 전량에 포함한다.)
+_KNOWN_PROJECT_SCOPED = frozenset(
+    {"story", "task", "doc", "visual_artifact", "loop", "hypothesis", "epic", "sprint"}
+)
+_KNOWN_PROJECT_AGNOSTIC = frozenset({"wf_line_version"})
+
+
+def test_project_scoped_set_matches_hand_audited_inventory():
+    """gate_service.PROJECT_SCOPED_WORK_ITEM_TYPES가 위 손-감사 목록과 정확히 일치하는지 고정.
+    누가 이 집합에서 하나를 실수로 빼면(또는 오분류로 KNOWN_PROJECT_AGNOSTIC에 넣으면) 이 테스트가
+    즉시 빨개진다 — #2237이 기계적으로 확認한 project_id NOT NULL FK 근거가 조용히 사라지는 것을 막는다."""
+    from app.services.gate_service import PROJECT_SCOPED_WORK_ITEM_TYPES
+    assert PROJECT_SCOPED_WORK_ITEM_TYPES == _KNOWN_PROJECT_SCOPED
+
+
+def test_project_agnostic_set_matches_hand_audited_inventory():
+    from app.services.gate_service import KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES
+    assert KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES == _KNOWN_PROJECT_AGNOSTIC
+
+
+def test_the_two_sets_do_not_overlap():
+    """한 타입이 «project를 가진다」와 «project가 없다」로 동시에 분류되면 그 자체가 모순."""
+    from app.services.gate_service import (
+        KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES,
+        PROJECT_SCOPED_WORK_ITEM_TYPES,
+    )
+    assert PROJECT_SCOPED_WORK_ITEM_TYPES & KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES == frozenset()
+
+
+@pytest.mark.parametrize("work_item_type", sorted(_KNOWN_PROJECT_SCOPED))
+def test_resolve_work_item_project_id_has_explicit_branch_for_every_scoped_type(work_item_type):
+    """PROJECT_SCOPED_WORK_ITEM_TYPES의 모든 타입은 resolve_work_item_project_id()가 실제 분기를
+    가져야 한다 — 분류표엔 있는데 resolver가 여전히 모르면(폴백 None) fail-closed가 «항상 거부」로
+    떨어져 그 타입 게이트 생성/조회가 통째로 죽는다(살아있는 기능을 죽이는 회귀 — ③이 이걸 막는다).
+    소스를 읽어 `if work_item_type == "<타입>"` 리터럴 분기가 있는지 정적으로 확認한다(신규 쿼리 없음)."""
+    import inspect
+    from app.services.gate_service import resolve_work_item_project_id
+    src = inspect.getsource(resolve_work_item_project_id)
+    assert f'work_item_type == "{work_item_type}"' in src, (
+        f"resolve_work_item_project_id에 {work_item_type!r} 분기가 없다 — "
+        "PROJECT_SCOPED_WORK_ITEM_TYPES엔 있는데 resolver가 모르면 fail-closed가 그 타입을 "
+        "항상 거부한다(생성/조회 전부 깨짐)."
+    )

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -230,12 +230,17 @@ async def test_list_docs_with_parent_id_200():
 
 @pytest.mark.anyio
 async def test_list_doc_revisions_cross_org_404():
-    """⚠️S28 보안(까심 RC·cross-org IDOR): 다른 org doc 의 revisions 요청 → org-scoped repo.get None →
-    404. revision content 무노출(S28 스냅샷 배선으로 활성화된 누출 봉인)."""
+    """⚠️S28 보안(까심 RC·cross-org IDOR): 다른 org doc 의 revisions 요청 → 404. revision content
+    무노출(S28 스냅샷 배선으로 활성화된 누출 봉인). #2237: org-scope에 project-scope도 더해져
+    _require_doc_project_access(형제 add_doc_comment/enable_doc_share와 동일 SSOT)가 이 검증을
+    맡는다 — doc 미존재/타org 둘 다 404로 흡수(존재 비노출)."""
+    from fastapi import HTTPException
     client, session, app = await _client()
     try:
-        # org-scoped repo.get 이 None(이 org 소속 아님) → 404·revision 쿼리 미실행.
-        with patch("app.repositories.base.BaseRepository.get", AsyncMock(return_value=None)):
+        with patch(
+            "app.routers.docs._require_doc_project_access",
+            AsyncMock(side_effect=HTTPException(status_code=404, detail="Doc not found")),
+        ):
             async with client as c:
                 resp = await c.get(f"/api/v2/docs/{DOC_ID}/revisions")
         assert resp.status_code == 404
@@ -245,7 +250,7 @@ async def test_list_doc_revisions_cross_org_404():
 
 @pytest.mark.anyio
 async def test_list_doc_revisions_in_org_200():
-    """org 소속 doc 은 revisions 정상 반환(org_id 가드 통과)."""
+    """org+project 접근권 보유 caller는 revisions 정상 반환(형제 가드 통과)."""
     client, session, app = await _client()
     try:
         rev = MagicMock()
@@ -259,7 +264,7 @@ async def test_list_doc_revisions_in_org_200():
         rev_result = MagicMock()
         rev_result.scalars.return_value = [rev]
         session.execute = AsyncMock(return_value=rev_result)
-        with patch("app.repositories.base.BaseRepository.get", AsyncMock(return_value=_mock_doc())):
+        with patch("app.routers.docs._require_doc_project_access", AsyncMock(return_value=_mock_doc())):
             async with client as c:
                 resp = await c.get(f"/api/v2/docs/{DOC_ID}/revisions")
         assert resp.status_code == 200
@@ -270,13 +275,76 @@ async def test_list_doc_revisions_in_org_200():
 
 @pytest.mark.anyio
 async def test_list_doc_comments_cross_org_404():
-    """⚠️S28 보안(까심 RC twin): 다른 org doc 의 comments 요청 → org-scoped repo.get None → 404.
-    revisions 와 동형 IDOR(comments 는 이미 populated 라 active 노출이었음·같이 봉인)."""
+    """⚠️S28 보안(까심 RC twin): 다른 org doc 의 comments 요청 → 404. revisions 와 동형 IDOR(comments
+    는 이미 populated 라 active 노출이었음·같이 봉인). #2237: _require_doc_project_access로 project-
+    scope도 함께 검증(형제 add_doc_comment와 동일 SSOT)."""
+    from fastapi import HTTPException
     client, session, app = await _client()
     try:
-        with patch("app.repositories.base.BaseRepository.get", AsyncMock(return_value=None)):
+        with patch(
+            "app.routers.docs._require_doc_project_access",
+            AsyncMock(side_effect=HTTPException(status_code=404, detail="Doc not found")),
+        ):
             async with client as c:
                 resp = await c.get(f"/api/v2/docs/{DOC_ID}/comments")
         assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_doc_comments_in_org_200():
+    """org+project 접근권 보유 caller는 comments 정상 반환(형제 가드 통과)."""
+    client, session, app = await _client()
+    try:
+        cmt = MagicMock()
+        cmt.id = uuid.uuid4()
+        cmt.doc_id = DOC_ID
+        cmt.org_id = ORG_ID
+        cmt.project_id = PROJECT_ID
+        cmt.content = "nice doc"
+        cmt.created_by = uuid.uuid4()
+        cmt.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+        cmt_result = MagicMock()
+        cmt_result.scalars.return_value = [cmt]
+        session.execute = AsyncMock(return_value=cmt_result)
+        with patch("app.routers.docs._require_doc_project_access", AsyncMock(return_value=_mock_doc())):
+            async with client as c:
+                resp = await c.get(f"/api/v2/docs/{DOC_ID}/comments")
+        assert resp.status_code == 200
+        assert resp.json()[0]["content"] == "nice doc"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_doc_share_cross_project_404():
+    """#2237 봉인: 형제(enable/regenerate/disable_doc_share)와 동일하게 project 접근권 없으면 404
+    (기존엔 org 멤버십만 확認하고 project 접근권은 안 봤다)."""
+    from fastapi import HTTPException
+    client, session, app = await _client()
+    try:
+        with patch(
+            "app.routers.docs._require_doc_project_access",
+            AsyncMock(side_effect=HTTPException(status_code=403, detail="해당 문서의 프로젝트 접근 권한이 없습니다")),
+        ):
+            async with client as c:
+                resp = await c.get(f"/api/v2/docs/{DOC_ID}/share")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_doc_share_in_project_200():
+    """project 접근권 보유 caller는 share 상태 정상 반환(형제 가드 통과)."""
+    client, session, app = await _client()
+    try:
+        with patch("app.routers.docs._require_doc_project_access", AsyncMock(return_value=_mock_doc())), \
+             patch("app.services.doc_share.get_status", AsyncMock(return_value=None)):
+            async with client as c:
+                resp = await c.get(f"/api/v2/docs/{DOC_ID}/share")
+        assert resp.status_code == 200
+        assert resp.json()["enabled"] is False
     finally:
         app.dependency_overrides.clear()

--- a/backend/tests/test_e_sec_hypotheses_project_scope_realdb.py
+++ b/backend/tests/test_e_sec_hypotheses_project_scope_realdb.py
@@ -219,3 +219,106 @@ async def test_unlink_hypothesis_cross_project_blocked_404():
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+# ── #2237 WRITE① — POST /{hypothesis_id}/links (link_hypothesis) ───────────────
+# 착수 前: 이 라우터는 caller 접근권을 전혀 안 봤다(service의 _assert_targets_same_project는
+# 링크 대상들의 상호 project 정합성만 검증) — 형제 unlink_hypothesis(위 테스트)와 정확히 같은
+# 모양으로 봉인한다(_assert_hypothesis_project_access 재사용).
+
+@pytest.mark.anyio
+async def test_link_hypothesis_own_project_200():
+    """회귀0: project_a grant caller가 project_a hyp에 링크(빈 페이로드) → 200."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/hypotheses/{seeded['hyp_a_id']}/links",
+                json={"epic_ids": [], "story_ids": []},
+            )
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_link_hypothesis_cross_project_blocked_404():
+    """봉인: 접근권 없는 project_b hyp에 링크 주입 시도 → 404(가드가 service 前 차단·기존엔 200으로 통과했다)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/hypotheses/{seeded['hyp_b_id']}/links",
+                json={"epic_ids": [], "story_ids": []},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── #2237 WRITE③ — POST /{hypothesis_id}/transition (transition_hypothesis) ────
+# 착수 前: project 접근권 검사가 status=="active" 분기 안에서 owner/admin role 체크로만 쓰였을 뿐,
+# proposed→killed 같은 non-active 전이는 project 검사가 라우터·서비스 어디에도 없었다(#2198과
+# 동형 「타입 분기 안에 갇힌 검사」). _assert_hypothesis_project_access를 분기 밖으로 꺼내 봉인.
+
+@pytest.mark.anyio
+async def test_transition_hypothesis_own_project_200():
+    """회귀0: project_a grant caller가 project_a hyp를 proposed→killed 전이 → 200."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/hypotheses/{seeded['hyp_a_id']}/transition", json={"status": "killed"},
+            )
+            assert resp.status_code == 200, resp.text
+            assert await _hyp_col(Session, seeded["hyp_a_id"], "status") == "killed"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_transition_hypothesis_cross_project_blocked_404_not_transitioned():
+    """봉인: 접근권 없는 project_b hyp를 proposed→killed 전이 시도(non-active 경로) → 404 +
+    **미전이 직조회**(status='proposed' 유지). 수정 前엔 이 경로에 project 검사가 없어 200으로 통과했다."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/hypotheses/{seeded['hyp_b_id']}/transition", json={"status": "killed"},
+            )
+            assert resp.status_code == 404, resp.text
+            assert await _hyp_col(Session, seeded["hyp_b_id"], "status") == "proposed", "cross-project hyp 전이됨(IDOR)"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_sec_hypotheses_project_scope_realdb.py
+++ b/backend/tests/test_e_sec_hypotheses_project_scope_realdb.py
@@ -131,6 +131,52 @@ async def _hyp_col(Session, hyp_id, col):
         )).scalar_one()
 
 
+# ── #2237 READ — GET /{hypothesis_id} (get_hypothesis) ─────────────────────────
+# 착수 前: auth 파라미터 자체가 없었고 project 접근권 검사도 없었다(org-scope repo.get()뿐).
+# 형제 update_hypothesis와 동일한 _assert_hypothesis_project_access로 봉인.
+
+@pytest.mark.anyio
+async def test_get_hypothesis_own_project_200():
+    """회귀0: project_a grant caller가 project_a hyp 조회 → 200."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/hypotheses/{seeded['hyp_a_id']}")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["statement"] == "Hyp A"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_hypothesis_cross_project_blocked_404():
+    """봉인: 접근권 없는 project_b hyp 조회 시도 → 404(수정 前엔 200으로 통과해 statement 노출)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/hypotheses/{seeded['hyp_b_id']}")
+            assert resp.status_code == 404, resp.text
+            assert "Hyp B orig" not in resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
 @pytest.mark.anyio
 async def test_update_hypothesis_own_project_200():
     """회귀0: project_a grant caller가 project_a hyp statement 수정 → 200 + 반영."""

--- a/backend/tests/test_hypotheses_router.py
+++ b/backend/tests/test_hypotheses_router.py
@@ -244,7 +244,11 @@ async def test_create_endpoint_service_error_maps_dict_detail(app_with_overrides
 async def test_get_endpoint_not_found_404(app_with_overrides):
     from httpx import ASGITransport, AsyncClient
     err = HypothesisServiceError("HYPOTHESIS_NOT_FOUND", "없음")
-    with patch.object(r.svc, "get_hypothesis", AsyncMock(side_effect=err)):
+    # #2237: get_hypothesis가 이제 svc.get_hypothesis 전에 _assert_hypothesis_project_access를
+    # 거친다(형제 update_hypothesis와 동일 SSOT) — 이 테스트는 mock_session이 실 쿼리를 못 받는
+    # 자리라(get_db override가 iter([...])라 session.execute까지 안 감) 그 가드도 함께 patch한다.
+    with patch.object(r, "_assert_hypothesis_project_access", AsyncMock(return_value=None)), \
+         patch.object(r.svc, "get_hypothesis", AsyncMock(side_effect=err)):
         async with AsyncClient(transport=ASGITransport(app=app_with_overrides), base_url="http://t") as c:
             resp = await c.get(f"/api/v2/hypotheses/{HYP_ID}")
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary

#2200 전수(A급10+B급2)가 찾아낸 **형제 비대칭 인가 구멍 11건**을 봉인. 각 파일의 형제 엔드포인트(PATCH/POST/DELETE)가 이미 쓰는 project-scope 가드를 그대로 재사용 — 새 헬퍼 발명 0.

```
✅확定  전부 「인증·org 검증은 통과」한 뒤의 문제다. 인증 없이 열리는 자리가 아니다.
✅확定  빠진 것은 「이 org 멤버가 그 프로젝트에 접근권이 있는가」 한 겹이다.
⇒ 실 노출면 = 같은 org 안에서, 접근권 없는 프로젝트의 것을 읽거나(9건) 쓰는(2건) 것.
⛔cross-org 아님 — org 스코프는 살아 있었다.
```

## 봉인 대상 11건

| # | 파일:함수 | 축 | 처방(형제가 쓰는 것 그대로) |
|---|---|---|---|
| 1 | docs.py list_doc_comments | 형제비대칭 | `_require_doc_project_access`(add_doc_comment와 동일) |
| 2 | docs.py list_doc_revisions | 형제비대칭 | 〃(PATCH/DELETE `/{id}`와 동일) |
| 3 | docs.py get_doc_share | 형제비대칭 | 〃(POST/DELETE `/{id}/share`와 동일) |
| 4 | goals.py get_goal | 형제비대칭 | `has_project_access`(update_goal과 동일) |
| 5 | goals.py get_goal_progress | 형제비대칭 | 〃 |
| 6 | hypotheses.py get_hypothesis | 형제비대칭 | `_assert_hypothesis_project_access`(update와 동일) |
| 7 | hypotheses.py link_hypothesis(POST /links) | 형제비대칭+WRITE | 〃(unlink와 동일) |
| 8 | standups.py get_missing_standups | 형제비대칭 | `has_project_access`(list_standup_history=ratchet round5와 동일) |
| 9 | standups.py list_feedback | 형제비대칭 | 〃 |
| 10 | gates.py create_gate_endpoint(POST "") | 형제비대칭+WRITE | 〃(get_gate_endpoint와 동일) |
| 11 | hypotheses.py transition_hypothesis | 타입분기(B급) | 가드를 `status=="active"` 분기 밖으로 — 전 전이(kill/verify/falsify/archive)에 적용 |

## 부수 발견 — gates cross-org fail-open (PO 지시로 같은 PR에 흡수)

WRITE②(create_gate_endpoint) 작업 중 `resolve_work_item_project_id`가 「project-무관 타입이라 None」과 「project-scoped 타입인데 해소 실패(타 org·부재)라 None」을 구분 못 해, 후자가 접근권 검사를 skip하는 것을 발견(실측: 타 org story로 gate 201 생성 확認). 측정 결과 **데이터 오염(고아 gate 레코드)이지 cross-org 데이터 열람/유출은 아님**(`_resolve_work_item_summary`가 독립적으로 org-scope돼 있어 제목/상태가 재노출되지 않음 — 실측 확認).

처방(PO 판정): `resolve_work_item_project_id`에 실제로 project_id NOT NULL FK를 가진 4개 타입(loop·hypothesis·epic·sprint) 분기를 추가(PROJECT_SCOPED_WORK_ITEM_TYPES 4→8개, 기계적 확認 — 새 규칙 발명 0) + `work_item_type` 미분류 시 fail-closed로 전환(`KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES` 명시 allowlist에 있을 때만 통과).

## ⚠️ 이 PR이 못 잡는 것
`work_item_type`은 `gate_type`(GATE_TYPES로 검증됨)과 달리 DB CHECK도 Pydantic 검증기도 없는 자유 varchar(20)라, 진짜 exhaustive 보장은 전체 `create_gate()` 호출부 AST 스캔이 필요합니다(story #1808 PATH_ID axis 스캐너급 무게). 이번 PR의 8+1개 분류는 2026-07-27 기준 손-감사 인벤토리 고정이며, `tests/test_2237_work_item_type_classification_exhaustive.py`가 그 인벤토리 이탈만 잡습니다. 그 검증기 비대칭 자체는 **#2240**으로 별도 등재됨.

## Test plan
- [x] RED→GREEN 실증 — 11건 전부 git stash로 가드 제거 후 실제 통과(200)를 재현 → 복원 후 거부(404/403) 확認
- [x] standups는 실제로 `SECRET FEEDBACK PROJECT B` 콘텐츠가 200으로 노출되는 것까지 재현 후 봉인 확認
- [x] gates cross-org 우회도 실측(타 org story→201 생성 확認) 후 봉인 확認
- [x] 회귀 0 — 관련 스위트 400+ 건(hypotheses/gates/docs/goals/standups/authz-coverage-ratchet) 전부 green
- [x] `test_authz_project_scope_coverage.py`(#1808 PATH_ID axis 스캐너) baseline 무변동 확認

## 연결
- #2200 — 1차 스윕(전수·세는 스토리, 이 PR의 입력)
- #2198 / #2168 — 같은 계열의 먼저 나온 두 사례
- #2240 — work_item_type 정본 부재(별도 스토리, 이 PR 범위 밖)

🤖 Generated with [Claude Code](https://claude.com/claude-code)