### PR TITLE
[SID:2231] AC4 커서 페이지네이션 봉투를 타입으로 고정 + AC5 CI 가드

### DIFF
--- a/apps/web/src/components/agents/agent-runs-list.tsx
+++ b/apps/web/src/components/agents/agent-runs-list.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
+import { parseCursorMeta } from '@/lib/pagination';
 import {
   ALL_RUN_STATUS_FILTER,
   DEFAULT_RUN_STATUS_FILTER,
@@ -127,9 +128,13 @@ export function AgentRunsList() {
     const res = await fetch(`/api/v1/agent-runs?${params}`);
     if (!res.ok) return { items: [], nextCursor: null };
     const json = await res.json();
+    // story #2231 AC4: 이 프록시는 apiSuccess(await _r.json())로 BE의 {data,meta} 전체를
+    // 다시 자기 data 필드에 얹는다(comments가 #2230 전에 그랬던 것과 동형 이중포장) — 바깥
+    // meta는 항상 null이라 「더 보기」가 지금 구조적으로 죽어 있다. 공용 파서로 그 사실을
+    // 조용히 삼키지 않고 드러낸다(프록시 자체 fix는 #2231 AC2 스코프, 별도 처리).
     return {
       items: (json.data ?? []) as AgentRun[],
-      nextCursor: json.meta?.nextCursor ?? null,
+      nextCursor: parseCursorMeta(json.meta, 'agent-runs-list').nextCursor,
     };
   }, [statusFilter, fromDate, toDate]);
 

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -11,6 +11,7 @@ import { normalizeAssigneePatch } from './types';
 import type { SendAttachment } from '@/hooks/use-chat-sse';
 import { getFileIcon } from '@/lib/file-icon';
 import { imageFilesFromClipboard } from '@/lib/clipboard-image';
+import { parseCursorMeta } from '@/lib/pagination';
 import { AttachmentImage } from '@/components/chat/attachment-image';
 import { AttachmentFile } from '@/components/chat/attachment-file';
 import { LabelChip, LABEL_PRESET_COLORS, type LabelData } from '@/components/ui/label-chip';
@@ -608,7 +609,8 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
           setComments(json.data ?? []);
           // story #2230: BE meta 필드는 snake_case(next_cursor) — camelCase 로 읽어 항상
           // undefined였던 것이 커서가 죽어 보이던 세 번째 원인(BE 미반영·프록시 이중포장과 직렬).
-          setNextCommentsCursor(json.meta?.next_cursor ?? null);
+          // story #2231 AC4: 그 casing 판단을 여기서 다시 하지 않는다 — 공용 파서로 위임.
+          setNextCommentsCursor(parseCursorMeta(json.meta, 'story-detail-panel:comments').nextCursor);
         }
       } catch {
         setComments([]);
@@ -628,7 +630,10 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
         if (res.ok) {
           const json = await res.json();
           setActivities(json.data ?? []);
-          setNextActivitiesCursor(json.meta?.nextCursor ?? null);
+          // story #2231 AC4: BE list_activities는 아직 cursor를 안 낸다(CAPPED-NO-NEXT-PAGE) —
+          // 지금은 meta가 없어 "더 없음"으로 낙하하는 게 맞지만, 조용히가 아니라 console.error로
+          // 드러나야 다음에 BE가 cursor를 추가했을 때 이 자리가 계속 죽어 있는 걸 놓치지 않는다.
+          setNextActivitiesCursor(parseCursorMeta(json.meta, 'story-detail-panel:activities').nextCursor);
         }
       } catch {
         setActivities([]);
@@ -685,7 +690,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
       if (res.ok) {
         const json = await res.json();
         setComments((prev) => [...prev, ...(json.data ?? [])]);
-        setNextCommentsCursor(json.meta?.next_cursor ?? null);
+        setNextCommentsCursor(parseCursorMeta(json.meta, 'story-detail-panel:comments:loadMore').nextCursor);
       }
     } finally {
       setLoadingMoreComments(false);
@@ -701,7 +706,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
       if (res.ok) {
         const json = await res.json();
         setActivities((prev) => [...prev, ...(json.data ?? [])]);
-        setNextActivitiesCursor(json.meta?.nextCursor ?? null);
+        setNextActivitiesCursor(parseCursorMeta(json.meta, 'story-detail-panel:activities:loadMore').nextCursor);
       }
     } finally {
       setLoadingMoreActivities(false);

--- a/apps/web/src/lib/pagination-envelope-consumers.test.ts
+++ b/apps/web/src/lib/pagination-envelope-consumers.test.ts
@@ -1,0 +1,121 @@
+// story #2231 AC5 — 커서 페이지네이션 meta(hasMore/has_more/nextCursor/next_cursor)를
+// 직접(옵셔널 체이닝으로) 읽는 자리가 새로 생기면 CI가 빨개진다. 새 자리는 두 선택지뿐이다:
+//   ① `parseCursorMeta()`(#2231 AC4, lib/pagination.ts)로 위임 — 규약 밖 응답이면 조용히
+//      삼키지 않고 console.error로 드러난다.
+//   ② 이 파일 하단 ALLOWLIST에 "왜 안전한지" 근거와 함께 추가 — 리뷰 없이 조용히 늘지 않는다.
+//
+// ⛔이 가드가 못 잡는 것(고의로 남겨둔 한계 — i18n-key-coverage.test.ts와 같은 규율):
+//   ① ALLOWLIST 항목의 **런타임 정확성**은 못 잡는다 — 이 시점(2026-07-27)에 각 항목이
+//      실제로 소비하는 프록시 라우트의 응답 형태를 1:1로 대조해 「맞다」로 확認한 것뿐이다.
+//      그 프록시가 나중에 형태를 바꾸는데 이 클라이언트 파일이 안 바뀌면, 이 가드는
+//      여전히 초록이지만 실제로는 깨진다(정적 스캔의 근본 한계 — 실측은 라이브 QA 몫).
+//   ② hasMore/nextCursor 외의 이름으로 같은 개념을 나르는 새 규약(D)이 생기면 이 정규식
+//      자체가 못 본다 — 그 경우는 새 정규식이 필요하다.
+//   ③ 주석 스트립은 근사치다(i18n-key-coverage.test.ts와 동일 방식·동일 한계).
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SRC_ROOT = path.resolve(__dirname, '..');
+
+function stripComments(text: string): string {
+  let out = text.replace(/\/\*[\s\S]*?\*\//g, '');
+  out = out
+    .split('\n')
+    .map((line) => {
+      const idx = line.indexOf('//');
+      if (idx === -1) return line;
+      const before = line.slice(0, idx);
+      const quotes = (before.match(/"/g) || []).length
+        + (before.match(/'/g) || []).length
+        + (before.match(/`/g) || []).length;
+      return quotes % 2 === 0 ? before : line;
+    })
+    .join('\n');
+  return out;
+}
+
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...collectSourceFiles(full));
+    } else if (/\.(ts|tsx)$/.test(entry.name) && !entry.name.endsWith('.d.ts') && !/\.test\.tsx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// 「meta」 또는 「json.meta」/「beJson.meta」 등에 옵셔널 체이닝으로 곧장 hasMore/has_more/
+// nextCursor/next_cursor를 읽는 자리 — parseCursorMeta()를 거치지 않고 casing을 직접 가정하는 자리.
+const RAW_ACCESS_RE = /\bmeta\??\.(hasMore|has_more|nextCursor|next_cursor)\b/;
+
+// 2026-07-27 감사 완료 — 각 항목이 실제로 부르는 프록시의 응답 형태와 1:1 대조해 정합 확認.
+const ALLOWLIST = new Map<string, string>([
+  ['app/(authenticated)/inbox/page.tsx',
+    '/api/notifications 소비 — 이 라우트는 FastAPI 프록시가 아니라 repo.list()가 직접 camelCase{hasMore,nextCursor}를 반환(내부 TS, casing 불일치 불가)'],
+  ['app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx',
+    '/api/stories(buildCursorPageMeta)·/api/stories/backlog(수동 camelCase 구성) 둘 다 camelCase — 정합'],
+  ['app/(authenticated)/[ws]/[proj]/standup/standup-client.tsx',
+    '/api/stories(buildCursorPageMeta) 소비 — camelCase 정합'],
+  ['app/(authenticated)/[ws]/[proj]/docs/docs-shell-client.tsx',
+    '/api/docs(buildCursorPageMeta) 소비 — camelCase 정합'],
+  ['app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx',
+    '/api/docs(buildCursorPageMeta) 소비 — camelCase 정합'],
+  ['app/api/stories/backlog/route.ts',
+    'PRODUCER — X-Next-Cursor/X-Total-Count 헤더를 읽어 camelCase{limit,hasMore,nextCursor}를 직접 구성해 내보냄(#2190). 이 파일이 그 구성 지점이라 스스로는 parseCursorMeta를 쓰지 않음'],
+  ['components/chat/chat-view.tsx',
+    'conversations 메시지 엔드포인트(#2231 규약 A의 원본 레퍼런스 구현) 직접 소비 — BE 네이티브 snake_case{next_cursor,has_more} 그대로 정합'],
+  ['components/kanban/kanban-board.tsx',
+    '/api/stories(buildCursorPageMeta) 소비 — camelCase 정합'],
+  ['components/nav/notification-bell.tsx',
+    '/api/event-notifications 소비 — 커서 아닌 offset+limit 방식(변형 C 계열)이라 hasMore만 있고 nextCursor 자체가 없음. 프록시가 camelCase{hasMore}를 직접 구성 — 정합. 이 가드의 스코프(커서 규약 A) 밖'],
+]);
+
+describe('pagination meta 직접 접근 전수 — 새 자리는 parseCursorMeta 또는 승인된 allowlist뿐 (#2231 AC5)', () => {
+  it('ALLOWLIST 밖에서 hasMore/has_more/nextCursor/next_cursor를 옵셔널 체이닝으로 직접 읽지 않는다', () => {
+    const files = collectSourceFiles(SRC_ROOT);
+    const unexpected: string[] = [];
+
+    for (const file of files) {
+      const rel = path.relative(SRC_ROOT, file).split(path.sep).join('/');
+      if (rel === 'lib/pagination.ts') continue; // 정의부 자신
+      const stripped = stripComments(fs.readFileSync(file, 'utf-8'));
+      if (RAW_ACCESS_RE.test(stripped) && !ALLOWLIST.has(rel)) {
+        unexpected.push(rel);
+      }
+    }
+
+    if (unexpected.length > 0) {
+      throw new Error(
+        `커서 페이지네이션 meta를 parseCursorMeta() 없이 직접 읽는 새 자리 ${unexpected.length}곳:\n` +
+        unexpected.map((f) => `  ${f}`).join('\n') +
+        '\n\n→ parseCursorMeta(json.meta, "출처")로 감싸거나, 정말 안전하면 ' +
+        'pagination-envelope-consumers.test.ts의 ALLOWLIST에 근거와 함께 추가할 것.',
+      );
+    }
+    expect(unexpected).toEqual([]);
+  });
+
+  it('⛔양성대조 — 탐지 로직 자체가 실제로 위반을 잡고 안전한 것은 통과시키는지(합성 케이스)', () => {
+    const violation = `
+      const json = await res.json();
+      setNextCursor(json.meta?.nextCursor ?? null); // parseCursorMeta 없이 직접 casing 가정
+    `;
+    const viaParser = `
+      const json = await res.json();
+      setNextCursor(parseCursorMeta(json.meta, 'x').nextCursor); // 안전 — 위임
+    `;
+    const inComment = `
+      // 예전엔 json.meta?.nextCursor 로 읽었었다(지금은 parseCursorMeta로 교체됨)
+      setNextCursor(parseCursorMeta(json.meta, 'x').nextCursor);
+    `;
+
+    expect(RAW_ACCESS_RE.test(stripComments(violation))).toBe(true);
+    expect(RAW_ACCESS_RE.test(stripComments(viaParser))).toBe(false);
+    expect(RAW_ACCESS_RE.test(stripComments(inComment))).toBe(false); // 주석 스트립이 실제로 동작
+  });
+});

--- a/apps/web/src/lib/pagination-envelope-consumers.test.ts
+++ b/apps/web/src/lib/pagination-envelope-consumers.test.ts
@@ -12,6 +12,12 @@
 //   ② hasMore/nextCursor 외의 이름으로 같은 개념을 나르는 새 규약(D)이 생기면 이 정규식
 //      자체가 못 본다 — 그 경우는 새 정규식이 필요하다.
 //   ③ 주석 스트립은 근사치다(i18n-key-coverage.test.ts와 동일 방식·동일 한계).
+//   ④ ⭐**producer 쪽 이중포장은 이 가드의 스코프 밖이다** — 이 가드는 "소비자가 봉투를
+//      제대로 읽는가"만 본다. "프록시가 봉투 자체를 망가뜨리는가"(예: agent-runs-list가
+//      소비하는 /api/v1/agent-runs가 `apiSuccess(await _r.json())`로 BE의 {data,meta}
+//      전체를 다시 자기 data에 얹어 바깥 meta가 항상 null인 경우, #2230 이전 comments와
+//      동형·2026-07-27 재발견으로 3번째 사례가 됨 — 전수 필요)는 별도 가드/스토리가
+//      필요하다(story #2231 본문 참고, 이번 PR 스코프 밖).
 import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';

--- a/apps/web/src/lib/pagination.test.ts
+++ b/apps/web/src/lib/pagination.test.ts
@@ -1,5 +1,57 @@
-import { describe, expect, it } from 'vitest';
-import { buildCursorPageMeta, paginateInMemory, parseCursorPageInput } from './pagination';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildCursorPageMeta, paginateInMemory, parseCursorMeta, parseCursorPageInput } from './pagination';
+
+describe('parseCursorMeta (#2231 AC4 — 규약 A 하나만 전제, 규약 밖이면 조용히 삼키지 않는다)', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('camelCase(hasMore/nextCursor) — FE가 buildCursorPageMeta로 직접 지은 응답', () => {
+    const meta = parseCursorMeta({ limit: 20, hasMore: true, nextCursor: 'abc' }, 'test:camel');
+    expect(meta).toEqual({ limit: 20, hasMore: true, nextCursor: 'abc' });
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('snake_case(has_more/next_cursor) — BE가 직접 내는 규약 A 응답(예: comments)', () => {
+    const meta = parseCursorMeta({ limit: 20, has_more: true, next_cursor: 'xyz' }, 'test:snake');
+    expect(meta).toEqual({ limit: 20, hasMore: true, nextCursor: 'xyz', has_more: true, next_cursor: 'xyz' });
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('마지막 페이지(hasMore:false) — nextCursor는 문자열이 아니어도(null) 조용히 통과', () => {
+    const meta = parseCursorMeta({ limit: 20, has_more: false, next_cursor: null }, 'test:last-page');
+    expect(meta).toEqual({ limit: 20, hasMore: false, nextCursor: null, has_more: false, next_cursor: null });
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('⛔양성대조 — meta가 아예 없으면(undefined) 조용히 hasMore:false로 낙하하지 않고 console.error로 드러낸다', () => {
+    const meta = parseCursorMeta(undefined, 'test:missing-meta');
+    expect(meta).toEqual({ limit: 0, hasMore: false, nextCursor: null });
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0]?.[0]).toContain('test:missing-meta');
+  });
+
+  it('⛔양성대조 — 오늘 실제로 걸린 자리(agent-runs 이중포장): meta가 이중포장된 전체 봉투이면(hasMore/has_more 둘 다 없음) 드러난다', () => {
+    // apiSuccess(await _r.json())가 BE의 {data,error,meta}를 통째로 다시 data에 얹으면
+    // 바깥 meta는 항상 null이다 — 이 경우를 재현.
+    const meta = parseCursorMeta(null, 'test:double-wrapped');
+    expect(meta.hasMore).toBe(false);
+    expect(meta.nextCursor).toBeNull();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('규약 밖 형태(예: offset+limit 래퍼, 규약 C)도 드러난다', () => {
+    const meta = parseCursorMeta({ items: [], total: 5, offset: 0, limit: 20 }, 'test:convention-c');
+    expect(meta.hasMore).toBe(false);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe('pagination helpers', () => {
   it('clamps limit and normalizes cursor input', () => {

--- a/apps/web/src/lib/pagination.ts
+++ b/apps/web/src/lib/pagination.ts
@@ -30,16 +30,31 @@ export function parseCursorPageInput(input?: CursorPageInput, defaults?: { defau
 /**
  * story #2231 AC4 — 클라이언트가 커서 페이지네이션 meta를 읽는 공용 진입점.
  *
- * 규약 A(#2231)는 두 가지 합법적인 표기로 온다: BE가 직접 내는 응답은 snake_case
- * (has_more/next_cursor, 예: comments — #2230 이후), FE 프록시가 buildCursorPageMeta로
- * 직접 지어내는 응답은 camelCase(hasMore/nextCursor, 예: docs/goals/stories/tasks). 둘 다
- * "규약 A 안"이라 정상 — 이 함수가 어느 쪽이든 받아 하나로 정규화한다.
+ * 규약 A(#2231)는 두 가지 합법적인 표기로 온다 — **방어적으로 아무거나 받는 것이 아니라,
+ * "누가 meta를 짓는가"에 따라 기계적으로 갈리는 유한한 목록**이다(2026-07-27 실측,
+ * 오르테가군 확認 요청에 대한 답):
+ *
+ *   camelCase(hasMore/nextCursor) — FE 프록시가 buildCursorPageMeta로 **직접 지어내는** 응답
+ *     (FE가 유일한 작성자라 JS 관용 casing을 씀): /api/docs · /api/goals · /api/stories ·
+ *     /api/tasks · /api/stories/backlog(BE 헤더 X-Next-Cursor/X-Total-Count를 읽어 수동 구성)
+ *
+ *   snake_case(has_more/next_cursor) — BE가 직접 낸 meta를 FE가 **그대로 전달**하는 응답
+ *     (FE가 작성자가 아니므로 BE의 원 casing을 보존): /api/stories/[id]/comments(#2230) ·
+ *     /api/v1/agent-deployments(현재 라이브 소비자 없음 — #2235에서 화면 삭제) ·
+ *     /api/conversations/[conversation_id]/messages(proxyToFastapi 순수 passthrough,
+ *     apiSuccess조차 안 거침 — 규약 A의 원본 레퍼런스 구현)
  *
  * ⛔진짜 문제는 **둘 다 없는 경우**(meta 자체가 없거나, 다른 규약(B/C)이거나, #2230 이전의
  * 이중포장처럼 meta가 통째로 유실된 경우)를 `json.meta?.nextCursor ?? null` 같은 옵셔널
  * 체이닝이 "다음 페이지 없음"과 구분 없이 조용히 삼켰다는 것 — 오늘 그 병의 정확한 모양이다.
  * 이 함수는 그 경우를 삼키지 않는다: 화면은 "더 보기 없음"으로 안전하게 낙하시키되(부분실패로
  * 전면 에러를 만들지 않는 house style 유지), console.error로 시끄럽게 드러낸다.
+ *
+ * ⛔이 함수가 못 잡는 것 — **producer 쪽 이중포장**(예: agent-runs-list가 소비하는
+ * `/api/v1/agent-runs`가 `apiSuccess(await _r.json())`로 BE의 {data,meta} 전체를 다시
+ * 자기 data에 얹어 바깥 meta가 항상 null인 경우, #2230 이전 comments와 동형·2026-07-27
+ * 재발견): 이 함수는 **소비자가 봉투를 정확히 읽는가**만 본다. **프록시가 봉투 자체를
+ * 망가뜨리는가**는 이 함수의 검증 범위 밖이다(별도 스토리 필요 — story #2231 본문 참고).
  */
 export function parseCursorMeta(meta: unknown, source: string): CursorPageMeta {
   if (meta && typeof meta === 'object') {

--- a/apps/web/src/lib/pagination.ts
+++ b/apps/web/src/lib/pagination.ts
@@ -27,6 +27,41 @@ export function parseCursorPageInput(input?: CursorPageInput, defaults?: { defau
   };
 }
 
+/**
+ * story #2231 AC4 — 클라이언트가 커서 페이지네이션 meta를 읽는 공용 진입점.
+ *
+ * 규약 A(#2231)는 두 가지 합법적인 표기로 온다: BE가 직접 내는 응답은 snake_case
+ * (has_more/next_cursor, 예: comments — #2230 이후), FE 프록시가 buildCursorPageMeta로
+ * 직접 지어내는 응답은 camelCase(hasMore/nextCursor, 예: docs/goals/stories/tasks). 둘 다
+ * "규약 A 안"이라 정상 — 이 함수가 어느 쪽이든 받아 하나로 정규화한다.
+ *
+ * ⛔진짜 문제는 **둘 다 없는 경우**(meta 자체가 없거나, 다른 규약(B/C)이거나, #2230 이전의
+ * 이중포장처럼 meta가 통째로 유실된 경우)를 `json.meta?.nextCursor ?? null` 같은 옵셔널
+ * 체이닝이 "다음 페이지 없음"과 구분 없이 조용히 삼켰다는 것 — 오늘 그 병의 정확한 모양이다.
+ * 이 함수는 그 경우를 삼키지 않는다: 화면은 "더 보기 없음"으로 안전하게 낙하시키되(부분실패로
+ * 전면 에러를 만들지 않는 house style 유지), console.error로 시끄럽게 드러낸다.
+ */
+export function parseCursorMeta(meta: unknown, source: string): CursorPageMeta {
+  if (meta && typeof meta === 'object') {
+    const m = meta as Record<string, unknown>;
+    const hasCamel = typeof m['hasMore'] === 'boolean';
+    const hasSnake = typeof m['has_more'] === 'boolean';
+    if (hasCamel || hasSnake) {
+      const hasMore = (hasCamel ? m['hasMore'] : m['has_more']) as boolean;
+      const nextCursorRaw = hasCamel ? m['nextCursor'] : m['next_cursor'];
+      const nextCursor = typeof nextCursorRaw === 'string' ? nextCursorRaw : null;
+      const limit = typeof m['limit'] === 'number' ? m['limit'] : 0;
+      return { ...m, limit, hasMore, nextCursor };
+    }
+  }
+  console.error(
+    `[pagination] ${source}: cursor page meta가 규약 A(hasMore/has_more) 형태가 아니다 — ` +
+    `"더 보기 없음"으로 낙하하지만 실제로는 더 있을 수 있다(story #2231 AC4). meta=`,
+    meta,
+  );
+  return { limit: 0, hasMore: false, nextCursor: null };
+}
+
 export function buildCursorPageMeta<T extends object, K extends keyof T & string>(
   rows: T[] | null | undefined,
   limit: number,


### PR DESCRIPTION
## 요약
story #2231(목록 페이지네이션 규약 전수)의 **AC4·AC5만** 처리. AC2(개별 엔드포인트 적용)는 스코프 밖 — PO 지시.

## AC4 — `parseCursorMeta()` 신설 (봉투를 타입으로 고정)
규약 A(has_more/next_cursor)는 두 가지 합법적 표기로 온다:
- BE 네이티브 응답: snake_case(`has_more`/`next_cursor`, 예: comments — #2230 이후)
- FE가 `buildCursorPageMeta`로 직접 짓는 응답: camelCase(`hasMore`/`nextCursor`, 예: docs/goals/stories/tasks)

문제는 **둘 다 없는 경우**(meta 자체가 없거나, 다른 규약이거나, 이중포장으로 meta가 유실된 경우)를 `json.meta?.nextCursor ?? null` 같은 옵셔널 체이닝이 "다음 페이지 없음"과 구분 없이 조용히 삼켰다는 것 — 오늘 `story-detail-panel.tsx`의 casing 어긋남(#2230)이 정확히 이 모양이었다.

`lib/pagination.ts`에 `parseCursorMeta(meta, source)` 신설: 두 casing 모두 인식해 정규화하고, 둘 다 없으면 화면은 안전하게 "더 보기 없음"으로 낙하시키되(house style — 부분실패로 전면 에러를 만들지 않음) `console.error`로 드러낸다. **"깨져서 고친다"가 아니라 "같은 보안/정합 불변식을 더 정확히 잰다"** — 약화가 아니라 강화.

적용: `story-detail-panel.tsx`(댓글 2곳 + 활동 2곳) · `agent-runs-list.tsx`.

## ⭐부수 발견 — agent-runs-list.tsx, 살아있는 동형 버그
`/api/v1/agent-runs` 프록시가 `apiSuccess(await _r.json())`로 BE의 `{data,meta}`를 통째로 다시 자기 `data`에 얹는 **이중포장**(#2230 이전 comments와 동형) — 바깥 `meta`가 항상 `null`이라 이 화면의 「더 보기」가 **지금 구조적으로 죽어 있다**. 이번 PR은 이 사실을 console.error로 드러내기만 하고, 프록시 자체 수정은 **#2231 AC2(개별 엔드포인트) 스코프로 넘긴다** — 지시받은 범위(AC4·AC5)를 지킴. PO/오르테가군 판단 대기.

## AC5 — CI 가드
`pagination-envelope-consumers.test.ts` 신설: apps/web/src 전체를 스캔해 `hasMore`/`has_more`/`nextCursor`/`next_cursor`를 `parseCursorMeta()` 없이 직접 읽는 새 자리가 생기면 CI가 빨개진다. 현재 9개 파일(각각 실제 소비 중인 프록시 응답 형태와 1:1 대조해 정합 확認 완료)은 근거와 함께 allowlist에 등재.

`i18n-key-coverage.test.ts`와 동일 규율로 **이 가드가 못 잡는 것 3가지**를 주석으로 선언(allowlist 항목의 런타임 정확성 불가·새 규약 D 불가·주석 스트립 근사치).

**양성대조**: allowlist에서 `chat-view.tsx`를 임시로 빼고 전체 스캔이 정확히 그 파일 하나를 지목하며 RED로 떨어지는 것을 실측 후 복구.

## 게이트 실측
- `pnpm run type-check`: EXIT 0
- `pnpm run lint`: 0 errors (무관 파일 warning 5개는 기존 그대로)
- `pnpm run build`: EXIT 0, Compiled successfully
- `npx vitest run`(apps/web 전체): 289 test files / 1929 tests all pass (기존 1921 + 신규 8)

## Test plan
- [x] type-check GREEN
- [x] lint 0 errors
- [x] build GREEN
- [x] vitest 전체 GREEN
- [x] AC5 가드 양성대조(allowlist 항목 제거 → RED 확認 → 복구)
- [ ] dev 배포 후 라이브 QA(story-detail-panel 댓글/활동 더보기 정상 동작 확認)

story #2231