### PR TITLE
fix(agent-runs): BE {data,meta} 이중포장 해소 — 더 보기 복구

### DIFF
--- a/apps/web/src/app/api/v1/agent-runs/route.test.ts
+++ b/apps/web/src/app/api/v1/agent-runs/route.test.ts
@@ -26,4 +26,29 @@ describe('/api/v1/agent-runs (proxy 위임)', () => {
       expect((await fn(req(name))).status).toBe(500);
     });
   }
+
+  // agent-runs-list.tsx의 「더 보기」가 라이브에서 구조적으로 죽어 있던 원인(2026-07-27
+  // 발견, #2230/#2231과 동형) — BE가 규약 A({data,meta})를 내는데 apiSuccess(json)에
+  // 통째로 넘기면 바깥 data에 BE 전체가 다시 얹히고 바깥 meta는 항상 null이 된다.
+  it('GET: BE의 {data,meta}(규약 A) 응답을 이중포장하지 않고 풀어서 넘긴다', async () => {
+    proxyToFastapi.mockResolvedValue(okRes({
+      data: [{ id: 'run-1' }, { id: 'run-2' }],
+      error: null,
+      meta: { hasMore: true, nextCursor: 'run-2' },
+    }));
+    const res = await GET(req('GET'));
+    const json = await res.json();
+
+    // ⛔양성대조 — 고치기 전엔 이 assertion들이 실패했다(json.data가 BE 전체 {data,error,meta}
+    // 봉투 그 자체였고, json.meta는 항상 null이었다). 직접 재현: 이 파일 fix 전 커밋에서 실행하면 RED.
+    expect(json.data).toEqual([{ id: 'run-1' }, { id: 'run-2' }]);
+    expect(json.meta).toEqual({ hasMore: true, nextCursor: 'run-2' });
+  });
+
+  it('POST: 단건 생성 응답도 이중포장하지 않는다(data.data 금지)', async () => {
+    proxyToFastapi.mockResolvedValue(okRes({ data: { id: 'run-new' }, error: null, meta: null }));
+    const res = await POST(req('POST'));
+    const json = await res.json();
+    expect(json.data).toEqual({ id: 'run-new' });
+  });
 });

--- a/apps/web/src/app/api/v1/agent-runs/route.ts
+++ b/apps/web/src/app/api/v1/agent-runs/route.ts
@@ -1,4 +1,4 @@
-import { apiSuccess } from '@/lib/api-response';
+import { apiSuccess, type ApiMeta } from '@/lib/api-response';
 import { handleApiError } from '@/lib/api-error';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
@@ -7,7 +7,11 @@ export async function GET(request: Request) {
     const _r = await proxyToFastapi(request, '/api/v2/agent-runs');
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });
-    return apiSuccess(await _r.json());
+    // #2230/#2231 동형 이중포장 fix: BE가 {data,meta}(규약 A)를 낸다 — 그대로 apiSuccess(json)에
+    // 넘기면 통째로 다시 data 필드에 얹혀 이중포장되고, 바깥 meta는 항상 null이 된다(agent-runs-list.tsx
+    // 「더 보기」가 그래서 구조적으로 죽어 있었다). data/meta를 풀어서 넘긴다.
+    const beJson = await _r.json() as { data?: unknown; meta?: ApiMeta };
+    return apiSuccess(beJson.data ?? beJson, beJson.meta);
   } catch (error) { return handleApiError(error); }
 }
 
@@ -16,6 +20,8 @@ export async function POST(request: Request) {
     const _r = await proxyToFastapi(request, '/api/v2/agent-runs');
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });
-    return apiSuccess(await _r.json());
+    // 단건 생성 응답이라 meta는 없지만, 같은 이중포장 위험(data.data)을 동일하게 막는다.
+    const beJson = await _r.json() as { data?: unknown; meta?: ApiMeta };
+    return apiSuccess(beJson.data ?? beJson, beJson.meta);
   } catch (error) { return handleApiError(error); }
 }


### PR DESCRIPTION
## 요약
story #2231 AC4 리뷰 중 발견(#2549)한 살아있는 이중포장 버그의 개별 처방. #2230(comments)과 완전 동형 — 세 번째 사례로, 전수 스윕은 별도로 진행 중(수 집계 후 보고 예정).

## 문제
`/api/v1/agent-runs` 프록시(GET/POST)가 `apiSuccess(await _r.json())`로 BE의 `{data, error, meta}`(규약 A) 응답 전체를 다시 자기 `data` 필드에 얹었다 — 바깥 `meta`가 항상 `null`이라 `agent-runs-list.tsx`의 "더 보기"가 **라이브에서 구조적으로 죽어 있었다**(nextCursor가 절대 채워지지 않음).

## 처방
`comments/route.ts`(#2230)와 동일 패턴 — BE 응답을 `{data?, meta?}`로 타입 파싱해 `data`/`meta`를 풀어서 넘긴다. GET(목록, meta 유의미)·POST(단건 생성, meta는 없지만 `data.data` 이중포장은 동일하게 막음) 둘 다 적용.

## 양성대조
고치기 전 코드로 되돌려 신규 테스트 2건(GET 규약A 언랩·POST 단건 언랩)이 정확히 RED로 떨어지는 것 확認 후 복구.

## 게이트 실측
- type-check: EXIT 0
- lint: 0 errors
- build: EXIT 0
- vitest 전체: 289 files / 1931 tests all pass

## Test plan
- [x] 양성대조(revert→RED→restore→GREEN)
- [ ] dev 배포 후 agent-runs-list 화면 "더 보기" 실측(51번째 이상 run 있는 계정)

관련: #2230, #2231, PR #2549