### PR TITLE
fix(#2245): seal 2 sibling-asymmetry project-access gaps (workflow-line)

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -490,6 +490,7 @@ async def create_story(
 async def get_workflow_line_status_batch(
     ids: str = Query(..., description="comma-separated story ids"),
     repo: StoryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[LineStatusSummary]:
     try:
         story_ids = [uuid.UUID(x) for x in ids.split(",") if x.strip()]
@@ -499,7 +500,24 @@ async def get_workflow_line_status_batch(
         return []
     if len(story_ids) > 200:  # 보드 페이지 단위 방어(과대 IN 금지)
         raise HTTPException(status_code=422, detail="too many ids (max 200)")
-    return await build_workflow_line_status_batch(repo.session, repo.org_id, story_ids)
+    # story #2245(형제 비대칭 — 배치판): 단건(get_workflow_line_status)과 같은 구멍이 여기 있었다
+    # (org-scope만, 항목별 project 접근권 검사 0) — 200개까지 한 번에 새는 자리라 단건보다 값이 큼.
+    # ⛔has_project_access를 id마다 부르지 않는다(쿼리 200회) — 접근 가능한 project 집합을
+    # 한 번에 구해(accessible_project_ids_in_org) 조회 前에 story_ids를 거른다(+1~2 쿼리로 끝남).
+    project_by_id = dict((await repo.session.execute(
+        select(Story.id, Story.project_id).where(
+            Story.org_id == repo.org_id, Story.id.in_(story_ids),
+        )
+    )).all())
+    from app.services.project_auth import accessible_project_ids_in_org
+    accessible = set(
+        await accessible_project_ids_in_org(repo.session, uuid.UUID(auth.user_id), repo.org_id)
+    )
+    # ⛔접근권 없는 id는 조용히 빼고 나머지만 준다(부분 성공) — 몇 개가 빠졌는지도 알리지 않는다.
+    # "빠졌다"는 말 자체가 그 id의 존재를 누설한다 — 없는 id와 못 보는 id를 구분하지 않는다
+    # (404/403을 안 가르는 것과 같은 이유).
+    filtered_ids = [sid for sid in story_ids if project_by_id.get(sid) in accessible]
+    return await build_workflow_line_status_batch(repo.session, repo.org_id, filtered_ids)
 
 
 # E-DG S15(P1-6): line metric 집계(org-scoped·read-only·default-off org=no-op). ⚠️ /{id} 보다 먼저.

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -623,17 +623,21 @@ class FallbackNotifyRequest(BaseModel):
     step_run_id: uuid.UUID
 
 
-# E-DG S12 Gap2: stuck handoff fallback human notification. 기존 _get_repo org-scoped auth·없는
-# story 404·dispatch_notification 재사용·idempotent(run당 1회·already_notified)·status rollback 0.
+# E-DG S12 Gap2: stuck handoff fallback human notification. 없는 story 404·dispatch_notification
+# 재사용·idempotent(run당 1회·already_notified)·status rollback 0.
+# story #2245(형제 비대칭 — 쓰기): _get_repo가 org-scope만 걸어 project 접근권 검사가 없었다.
+# 형제 get_story/get_workflow_line_status와 동일 가드(_assert_story_project_access) 재사용.
 @router.post("/{id}/workflow-line/fallback-notify")
 async def workflow_line_fallback_notify(
     id: uuid.UUID,
     body: FallbackNotifyRequest,
     repo: StoryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
     story = await repo.get(id)
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")
+    await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
     from app.services.workflow_fallback_notify import fallback_notify
     result = await fallback_notify(repo.session, repo.org_id, id, body.step_run_id)
     if result.get("status") == "not_found":
@@ -648,6 +652,10 @@ class WithdrawRequest(BaseModel):
 
 # E-DG S17: author/owner pending gate run 철회(withdraw). requester/owner/admin 만·idempotent·
 # Gate enum 미확장(run/approval status 로만)·entity 미전이.
+# story #2245(형제 비대칭 — 쓰기): _get_repo가 org-scope만 걸어 project 접근권 검사가 없었다.
+# 형제 get_story/get_workflow_line_status와 동일 가드(_assert_story_project_access) 재사용 —
+# requester/owner/admin(아래 withdraw_pending_run 내부 판정)보다 먼저, project 접근권 자체가
+# 없으면 그 판정에 도달하지도 못하게 한다.
 @router.post("/{id}/workflow-line/withdraw")
 async def workflow_line_withdraw(
     id: uuid.UUID,
@@ -659,6 +667,7 @@ async def workflow_line_withdraw(
     story = await repo.get(id)
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")
+    await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
     actor_id = await _resolve_team_member_id(auth, repo.org_id, db)
     from app.services.workflow_recall import withdraw_pending_run
     result = await withdraw_pending_run(repo.session, repo.org_id, id, body.step_run_id, actor_id, body.reason)

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -602,16 +602,20 @@ async def upload_story_attachment(
 
 
 # E-DG S10(P1-4 observability): workflow-line 상태 read API — "왜 막혔나·어디로 relay 됐나"를
-# 채팅 없이 board/API 서 안다(FE S11 데이터 소스). 기존 story read auth(_get_repo·org-scoped)
-# 재사용·없는 story 404·active 없으면 terminal 5개 history·engine_degraded/grandfathered 명시.
+# 채팅 없이 board/API 서 안다(FE S11 데이터 소스). 없는 story 404·active 없으면 terminal 5개
+# history·engine_degraded/grandfathered 명시.
+# story #2245(형제 비대칭): org-scope만으론 불충분하다 — 바로 위 get_story가 이미 그걸 알고
+# _assert_story_project_access를 추가로 부른다. 이 엔드포인트만 org-scope에서 멈춰 있었다.
 @router.get("/{id}/workflow-line/status", response_model=WorkflowLineStatusResponse)
 async def get_workflow_line_status(
     id: uuid.UUID,
     repo: StoryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> WorkflowLineStatusResponse:
-    story = await repo.get(id)  # org/project-scoped read auth(AC⑤)·scope 밖/없으면 None→404
+    story = await repo.get(id)  # org-scoped·scope 밖/없으면 None→404
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")
+    await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
     return await build_workflow_line_status(repo.session, repo.org_id, id)
 
 

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -521,6 +521,11 @@ async def get_workflow_line_status_batch(
 
 
 # E-DG S15(P1-6): line metric 집계(org-scoped·read-only·default-off org=no-op). ⚠️ /{id} 보다 먼저.
+# story #2245 경계 기록(스냅샷·판정 아님, 2026-07-28) — 개별 story 식별·내용 없이 org 전체
+# COUNT/SUM뿐이라 이번 병(항목별 project 접근권 누락)의 대상이 아니라고 보고 이 스토리 스코프
+# 밖에 남긴다. ⛔완전히 무해하다는 뜻은 아니다 — 집계는 "내가 못 보는 프로젝트의 일이 몇
+# 건인가"를 알려 준다. 개별 식별은 불가하고 org 내부라 지금은 열어 두지만, project 격리를
+# 엄히 요구하는 고객이 생기면 다음에 손댈 자리가 여기다.
 @router.get("/workflow-line/metrics")
 async def get_workflow_line_metrics(
     window_days: int = Query(default=14, ge=1, le=90),

--- a/backend/app/routers/workflow_line_config.py
+++ b/backend/app/routers/workflow_line_config.py
@@ -160,14 +160,18 @@ async def list_versions_endpoint(
     return [VersionResponse.model_validate(v) for v in rows]
 
 
+# story #2245(형제 비대칭): org-scope만으론 불충분하다 — 바로 아래 update_draft_version(PATCH)이
+# 이미 로드 後 _require_draft_author를 부른다. 이 GET만 org-scope에서 멈춰 있었다.
 @router.get("/versions/{version_id}", response_model=VersionResponse)
 async def get_version(
     version_id: uuid.UUID,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> VersionResponse:
-    return VersionResponse.model_validate(await _load_version(session, org_id, version_id))
+    version = await _load_version(session, org_id, version_id)
+    await _require_draft_author(session, uuid.UUID(auth.user_id), org_id, version.project_id)
+    return VersionResponse.model_validate(version)
 
 
 class PatchDraftRequest(BaseModel):

--- a/backend/tests/test_2245_stories_workflow_line_status_batch_project_scope_realdb.py
+++ b/backend/tests/test_2245_stories_workflow_line_status_batch_project_scope_realdb.py
@@ -1,0 +1,183 @@
+"""#2245(형제 비대칭 — 배치판) — GET /workflow-line/status?ids=(stories.py
+get_workflow_line_status_batch) project-scope IDOR, 실 PG.
+
+갭: build_workflow_line_status_batch가 org_id + entity_id.in_(ids)로만 필터하고 항목별 project
+접근권 검사가 없었다(#2245 PR 리뷰 中 오르테가 지적) — 단건(get_workflow_line_status)과 같은
+구멍이나 ids=로 최대 200개를 한 번에 새는 자리라 봉인 값이 더 크다.
+
+처방: has_project_access를 id마다 부르지 않는다(쿼리 200회) — accessible_project_ids_in_org로
+접근 가능한 project 집합을 한 번에 구해 조회 前에 story_ids를 거른다. 접근권 없는 id는 조용히
+빠지고(부분 성공) 몇 개가 빠졌는지도 알리지 않는다(없는 id와 못 보는 id를 구분하지 않는다).
+
+이 테스트가 오늘 봉인 전체의 대표 증거다 — "섞어 넣어도 남의 것은 안 나온다"가 인가의 본질.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a[caller grant, story 2개]·project_b[무접근, story 2개])."""
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    mine_1 = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Mine 1", status="backlog")
+    mine_2 = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Mine 2", status="backlog")
+    theirs_1 = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Theirs 1", status="backlog")
+    theirs_2 = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Theirs 2", status="backlog")
+    session.add_all([mine_1, mine_2, theirs_1, theirs_2])
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=caller_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "caller_id": caller_id,
+        "mine_ids": [mine_1.id, mine_2.id], "theirs_ids": [theirs_1.id, theirs_2.id],
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_batch_mixed_ids_returns_only_accessible_no_trace_of_others():
+    """본체(대표 증거): 내 project story 2개 + 접근권 없는 project story 2개를 함께 넣으면
+    200이면서 내 것만 돌아온다 — 남의 것은 403이 아니라 흔적도 없이 조용히 빠진다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            all_ids = seeded["mine_ids"] + seeded["theirs_ids"]
+            resp = await client.get(
+                "/api/v2/stories/workflow-line/status",
+                params={"ids": ",".join(str(i) for i in all_ids)},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            returned_story_ids = {row["story_id"] for row in body}
+            assert returned_story_ids == {str(i) for i in seeded["mine_ids"]}
+            for theirs_id in seeded["theirs_ids"]:
+                assert str(theirs_id) not in resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_batch_only_accessible_ids_unaffected():
+    """회귀 0: 전부 접근권 있는 id만 넣으면 필터링이 아무것도 안 건드리고 그대로 통과."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/stories/workflow-line/status",
+                params={"ids": ",".join(str(i) for i in seeded["mine_ids"])},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert {row["story_id"] for row in body} == {str(i) for i in seeded["mine_ids"]}
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_2245_stories_workflow_line_status_project_scope_realdb.py
+++ b/backend/tests/test_2245_stories_workflow_line_status_project_scope_realdb.py
@@ -1,0 +1,156 @@
+"""#2245(형제 비대칭) — GET /{id}/workflow-line/status(stories.py get_workflow_line_status)
+project-scope IDOR, 실 PG.
+
+갭: repo.get(id)가 org-scope만이라 project 접근권 검증이 없었다(#2238 2차 스윕 적출). 바로 위
+형제 get_story(GET /{id})는 repo.get(id) 後 _assert_story_project_access를 이미 추가로 부른다.
+처방: 형제와 동일한 _assert_story_project_access(동일 403 관례) 재사용.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a[caller grant]·project_b[무접근]) + story_a(project_a)·story_b(project_b)."""
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+    story_a = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Story A", status="backlog")
+    story_b = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Story B SECRET", status="backlog")
+    session.add_all([story_a, story_b])
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=caller_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "story_a_id": story_a.id, "story_b_id": story_b.id, "caller_id": caller_id}
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_get_workflow_line_status_own_project_200():
+    """회귀 0: project 접근권 있는 caller는 여전히 200."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{seeded['story_a_id']}/workflow-line/status")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_workflow_line_status_no_project_access_blocked_403():
+    """본체: 같은 org 이지만 project 접근권 없는 caller는 거부(기존엔 org-scope만이라 200)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{seeded['story_b_id']}/workflow-line/status")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_2245_stories_workflow_line_writes_project_scope_realdb.py
+++ b/backend/tests/test_2245_stories_workflow_line_writes_project_scope_realdb.py
@@ -1,0 +1,222 @@
+"""#2245(형제 비대칭 — 쓰기 2건) — POST /{id}/workflow-line/fallback-notify ·
+POST /{id}/workflow-line/withdraw(stories.py) project-scope IDOR, 실 PG.
+
+갭: 둘 다 repo.get(id)가 org-scope만 걸고 project 접근권 검사가 없었다(#2238 2차 스윕 적출 →
+오르테가 판정으로 #2245에 흡수 — get_workflow_line_status(읽기)만 막고 이 둘(쓰기)을 열어두면
+오늘 아침 11건과 같은 형제 비대칭을 우리가 새로 만드는 것이므로 함께 봉인).
+withdraw는 pending gate run을 실제로 철회하는 쓰기라 더 아픈 자리 — 접근권 없는 caller가
+step_run_id를 몰라도 이 가드에서 먼저 막혀야 한다(서비스 레이어까지 안 감).
+
+처방: 형제(get_story·get_workflow_line_status)와 동일한 _assert_story_project_access 재사용.
+step_run이 실재하지 않아도 가드가 먼저 걸려야 하므로, step_run_id는 임의 UUID로 충분 —
+접근권 있는 caller는 가드를 통과해 서비스 레이어의 "not_found"(404)에 도달하는 것으로,
+접근권 없는 caller는 가드에서 403으로 막히는 것으로 구분한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a[caller grant]·project_b[무접근]) + story_a(project_a)·story_b(project_b)."""
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+    story_a = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Story A", status="backlog")
+    story_b = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Story B", status="backlog")
+    session.add_all([story_a, story_b])
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=caller_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "story_a_id": story_a.id, "story_b_id": story_b.id, "caller_id": caller_id}
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_fallback_notify_own_project_passes_guard_404_step_run():
+    """회귀 0: project 접근권 있는 caller는 가드를 통과 — step_run이 없으니 404(가드 통과 증거)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{seeded['story_a_id']}/workflow-line/fallback-notify",
+                json={"step_run_id": str(uuid.uuid4())},
+            )
+            assert resp.status_code == 404, resp.text
+            assert "step_run" in resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_fallback_notify_no_project_access_blocked_403():
+    """본체: 같은 org 이지만 project 접근권 없는 caller는 서비스 레이어 도달 前 403으로 거부."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{seeded['story_b_id']}/workflow-line/fallback-notify",
+                json={"step_run_id": str(uuid.uuid4())},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_withdraw_own_project_passes_guard_404_step_run():
+    """회귀 0: project 접근권 있는 caller는 가드를 통과 — step_run이 없으니 404(가드 통과 증거)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{seeded['story_a_id']}/workflow-line/withdraw",
+                json={"step_run_id": str(uuid.uuid4())},
+            )
+            assert resp.status_code == 404, resp.text
+            assert "step_run" in resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_withdraw_no_project_access_blocked_403():
+    """본체(가장 아픈 자리 — 쓰기): 같은 org 이지만 project 접근권 없는 caller는 pending gate
+    run 철회 서비스에 도달하지도 못하고 403으로 거부."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{seeded['story_b_id']}/workflow-line/withdraw",
+                json={"step_run_id": str(uuid.uuid4())},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_2245_workflow_line_config_get_version_project_scope_realdb.py
+++ b/backend/tests/test_2245_workflow_line_config_get_version_project_scope_realdb.py
@@ -1,0 +1,171 @@
+"""#2245(형제 비대칭) — GET /versions/{version_id}(workflow_line_config.py get_version)
+project-scope IDOR, 실 PG.
+
+갭: _load_version이 org-scope만이라 project 접근권(draft-author) 검증이 없었다(#2238 2차 스윕
+적출). 바로 아래 형제 update_draft_version(PATCH)은 로드 後 _require_draft_author를 이미 부른다.
+처방: 형제와 동일한 _require_draft_author(동일 403 관례) 재사용.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a[caller=project admin grant]·project_b[무접근]) + version_a(project_a)·
+    version_b(project_b, caller 접근권 없음)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+    from app.models.workflow_line import WorkflowLineDefinitionVersion
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    version_a = WorkflowLineDefinitionVersion(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, entity_type="story", version=1,
+        status="draft", config={}, config_hash="a", lint_status="not_run", lint_errors=[],
+        created_by_member_id=uuid.uuid4(),
+    )
+    version_b = WorkflowLineDefinitionVersion(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, entity_type="story", version=1,
+        status="draft", config={"secret": "B"}, config_hash="b", lint_status="not_run", lint_errors=[],
+        created_by_member_id=uuid.uuid4(),
+    )
+    session.add_all([version_a, version_b])
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    # org role=member(org owner/admin 아님) — project_a 에만 명시 admin grant.
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=caller_om.id, permission="granted", role="admin",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "version_a_id": version_a.id, "version_b_id": version_b.id,
+        "caller_id": caller_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_get_version_own_project_admin_200():
+    """회귀 0: project admin grant 있는 caller는 여전히 200."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/workflow-line-config/versions/{seeded['version_a_id']}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_version_no_project_access_blocked_403():
+    """본체: 같은 org 이지만 해당 project 의 draft-author 자격 없는 caller는 거부
+    (기존엔 org-scope만이라 200)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/workflow-line-config/versions/{seeded['version_b_id']}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## 요약
#2238(2차 스윕)이 찾은 형제 비대칭 2건 + PO 판정으로 흡수한 인접 4건(쓰기 2 + 배치 1), 총 5건을 오늘 아침 #2237과 같은 처방(옆 엔드포인트가 이미 쓰는 가드를 그대로 옮긴다·새 헬퍼 발명 0)으로 봉인한다.

## 착수 전 대조
`git show origin/develop:<파일>`로 HEAD 실물을 먼저 확認했다(오늘 이걸로 다섯 번째 발견 — #2244는 이미 해소돼 있었고, 이번 건들은 #2238이 인용한 그대로 실물과 일치했다).

## ① `stories.py::get_workflow_line_status` — `GET /{id}/workflow-line/status`
형제 `get_story`(`GET /{id}`)의 `_assert_story_project_access` 재사용.

## ② `workflow_line_config.py::get_version` — `GET /versions/{version_id}`
형제 `update_draft_version`(PATCH)의 `_require_draft_author` 재사용.

## ③④ 인접 발견 → PO 판정으로 흡수: 쓰기 2건
같은 파일·같은 형제 무리·같은 처방인데 읽기(①)만 막고 쓰기를 열어두면 오늘 아침 봉인한 11건과 같은 형제 비대칭을 새로 만드는 것이라는 PO 판정으로 흡수했다.
- `workflow_line_fallback_notify`(`POST /{id}/workflow-line/fallback-notify`)
- `workflow_line_withdraw`(`POST /{id}/workflow-line/withdraw`) — pending gate run을 실제로 철회하는 **쓰기**라 더 아픈 자리. 서비스 레이어(`workflow_recall.py`)에도 project_access 검사가 없어(grep 0건) "라우터에서 빠뜨린 것"이 아니라 "그 경로 전체에 그 개념이 없는" 것이었다 — 형제가 붙인 자리(라우터 레벨) 그대로 따라 새 층을 발명하지 않았다.

## ⑤ 배치 — PO 판정으로 흡수: 가장 큰 노출면
`get_workflow_line_status_batch`(`GET /workflow-line/status?ids=`)도 같은 구멍(org-scope만, 항목별 project 접근권 검사 0)이었다. `ids=`로 최대 200개를 한 번에 새는 자리라 단건보다 봉인 값이 크다.

**처방(PO가 모양을 직접 자름)** — `has_project_access`를 id마다 부르지 않는다(쿼리 200회, 화면 하나 그리는 데 못 쓴다):
1. 요청된 `story_ids`의 `Story.project_id`를 한 번에 조회
2. `accessible_project_ids_in_org`(기존 SSOT — `list_projects`가 쓰는 것과 동일)로 접근 가능한 project 집합을 한 번에 구함
3. 그 집합에 속한 project의 story만 남기고 기존 배치 쿼리를 그 부분집합으로 돌림
⇒ 쿼리 수는 +2로 끝난다.

**응답 모양(PO가 자름)**: 접근권 없는 id는 조용히 빠지고 부분 성공으로 200을 준다 — 전체를 403으로 실패시키지 않고, 몇 개가 빠졌는지도 알리지 않는다("빠졌다"는 말 자체가 그 id의 존재를 누설한다 — 없는 id와 못 보는 id를 구분하지 않는다. 404/403을 안 가르는 것과 같은 이유).

**경계 확認**: `git show origin/develop:backend/app/routers/stories.py | grep "workflow-line"` — `{id}`-scoped 무리는 정확히 셋(status/fallback-notify/withdraw)이고 배치가 그 넷째 형태. metrics(`/workflow-line/metrics`)는 개별 story 식별자·내용 없이 org 전체 COUNT/SUM 집계뿐이라 이번 병(항목별 접근권 누락)과는 다른 종류의 물음으로 판단해 이 PR 스코프 밖으로 남겼다(story 단위 유출이 아님).

## 심각도
인증·org 검증은 통과한 뒤의 문제다(cross-org 아님) — 실 노출면은 **같은 org 안에서 접근권 없는 프로젝트**의 workflow-line 상태/config 읽기(단건+배치) 및 pending gate run 조작.

## realdb RED→GREEN (5건 전부)
- ①②: `git stash`로 가드를 뺀 상태에서 "접근권 없는 같은 org 멤버" 케이스가 실제로 200(응답 body에 project B의 workflow-line 상태/config가 그대로 노출 — `secret:"B"` 포함 확認)으로 통과하는 것 확認 → `stash pop` 後 403으로 거부되는 것 확認.
- ③④: 가드를 뺀 상태에서 접근권 없는 caller가 가드를 건너뛰고 서비스 레이어까지 도달(존재하지 않는 `step_run_id`로도 `"not_found"` 404를 받음 = 가드가 없어 통과했다는 증거)하는 것 확認 → 가드 복원 後 403으로 막히는 것 확認.
- ⑤: 내 project story 2개 + 접근권 없는 project story 2개를 섞어 `ids=`에 넣었을 때, 가드 前 4개 전부 200 반환(누설 확認) → 가드 後 내 것 2개만 200 반환·남의 것 2개는 응답 body 어디에도 흔적 없음(story_id 문자열 자체가 안 나타나는 것까지 확認).
- 접근권 있는 caller는 5건 전부 가드를 통과(무회귀).

## Test plan
- [x] `test_2245_stories_workflow_line_status_project_scope_realdb.py` — 2 tests
- [x] `test_2245_workflow_line_config_get_version_project_scope_realdb.py` — 2 tests
- [x] `test_2245_stories_workflow_line_writes_project_scope_realdb.py` — 4 tests
- [x] `test_2245_stories_workflow_line_status_batch_project_scope_realdb.py` — 2 tests(섞어넣기 대표 증거 포함)
- [x] RED→GREEN 5건 전부(위 참조), 전부 실 PG
- [x] 회귀: 기존 형제 SEC-S8-M realdb 테스트 3건 + `test_stories.py`·bulk 계열 32건 그대로 통과

## 못 잡는 것
`/workflow-line/metrics`는 이 PR 스코프 밖(story 단위 유출 아닌 org 집계 — 별개 판단 대상). cron·conversations 축은 각각 다른 스토리에서 답했다.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>