### PR TITLE
fix(#2246): serving-reality guard distinguishes deploying-from-stalled

### DIFF
--- a/backend/tests/test_check_serving_reality.py
+++ b/backend/tests/test_check_serving_reality.py
@@ -37,11 +37,25 @@ def _load():
     return module
 
 
-def _stub(monkeypatch, mod, statuses: dict[str, dict], pins=None, stalls=None):
+def _stub(monkeypatch, mod, statuses: dict[str, dict], pins=None, stalls=None, revision_ages=None):
+    """revision_ages: {revision_name: datetime}(creationTimestamp) — 기본은 «훨씬 옛날»(1시간
+    前)이라, 지정 안 하면 축B 정체가 유예 없이 즉시 FAIL(story #2246 이전 동작과 동일 — 기존
+    표본 B 류 테스트가 별도 수정 없이 그대로 통과하게)."""
+    from datetime import datetime, timedelta, timezone
+
     monkeypatch.setattr(mod, "_list_live_services", lambda: list(statuses))
     monkeypatch.setattr(mod, "_serving_status", lambda s: statuses[s])
     monkeypatch.setattr(mod, "_load_allowlist", lambda: (pins or {}, stalls or {}))
     monkeypatch.setenv("SERVING_REALITY_TODAY", "2026-07-25")
+
+    _ages = revision_ages or {}
+
+    def _fake_created_at(revision_name: str) -> datetime:
+        if revision_name in _ages:
+            return _ages[revision_name]
+        return datetime.now(timezone.utc) - timedelta(hours=1)
+
+    monkeypatch.setattr(mod, "_revision_created_at", _fake_created_at)
 
 
 def _healthy(rev: str = "svc-00010-aaa") -> dict:
@@ -89,6 +103,74 @@ def test_sample_b_undeclared_stall_is_caught(monkeypatch, capsys):
     assert mod.main() == 1
     out = capsys.readouterr().out
     assert "축B" in out and "00015-bn6" in out
+
+
+def test_stall_within_grace_is_deferred_not_failed(monkeypatch, capsys):
+    """story #2246 본체 — 리비전이 생성된 지 얼마 안 됐으면(유예 안) 정체가 아니라
+    "아직 배포 중"이다. FAIL 이 아니라 판정 보류로 넘어가고, 다음 실행에서 다시 본다."""
+    from datetime import datetime, timedelta, timezone
+    mod = _load()
+    just_created = datetime.now(timezone.utc) - timedelta(seconds=5)
+    _stub(
+        monkeypatch, mod,
+        {"sprintable-realtime-dev": {
+            "traffic": [{
+                "revisionName": "sprintable-realtime-dev-00183-h45",
+                "percent": 100, "latestRevision": True,
+            }],
+            "latest_ready": "sprintable-realtime-dev-00183-h45",
+            "latest_created": "sprintable-realtime-dev-00184-bmv",
+        }},
+        revision_ages={"sprintable-realtime-dev-00184-bmv": just_created},
+    )
+    assert mod.main() == 0
+    out = capsys.readouterr().out
+    assert "판정 보류" in out and "00184-bmv" in out
+    assert "⛔ 배포 실효 가드 FAIL" not in out  # FAIL 로 안 떨어졌어야 한다
+    assert "축B 선언 없는 롤아웃 정체" not in out  # undeclared_stalls 헤딩엔 안 잡혔어야 한다
+
+
+def test_stall_beyond_grace_still_fails(monkeypatch, capsys):
+    """⭐양성대조(AC5) — 유예를 넣었다고 진짜 정체를 눈감으면 안 된다. 나이가 유예를
+    넘긴(90초 초과) 정체는 여전히 FAIL 해야 한다."""
+    from datetime import datetime, timedelta, timezone
+    mod = _load()
+    long_ago = datetime.now(timezone.utc) - timedelta(minutes=10)
+    _stub(
+        monkeypatch, mod,
+        {"sprintable-internal-api-dev": {
+            "traffic": [{
+                "revisionName": "sprintable-internal-api-dev-00014-bwq",
+                "percent": 100, "latestRevision": True,
+            }],
+            "latest_ready": "sprintable-internal-api-dev-00014-bwq",
+            "latest_created": "sprintable-internal-api-dev-00015-bn6",
+        }},
+        revision_ages={"sprintable-internal-api-dev-00015-bn6": long_ago},
+    )
+    assert mod.main() == 1
+    out = capsys.readouterr().out
+    assert "축B" in out and "00015-bn6" in out
+    assert "분 경과했는데" in out  # AC4 — 나이를 말하는 문구
+
+
+def test_stall_age_lookup_failure_fails_immediately(monkeypatch, capsys):
+    """나이를 못 재면(gcloud 실패 등) 유예를 줄 근거가 없다 — 안전 쪽(즉시 FAIL)으로 떨어진다."""
+    mod = _load()
+
+    def _boom(revision_name):
+        raise RuntimeError("gcloud transient error")
+
+    _stub(monkeypatch, mod, {
+        "svc-x": {
+            "traffic": [{"revisionName": "x-1", "percent": 100, "latestRevision": True}],
+            "latest_ready": "x-1", "latest_created": "x-2",
+        },
+    })
+    monkeypatch.setattr(mod, "_revision_created_at", _boom)
+    assert mod.main() == 1
+    out = capsys.readouterr().out
+    assert "축B" in out and "생성 시각을 확認 못 했는데" in out
 
 
 def test_declared_stall_within_expiry_passes(monkeypatch):

--- a/infra/check_serving_reality.py
+++ b/infra/check_serving_reality.py
@@ -48,9 +48,14 @@
 4. 리비전이 Ready 인 것과 **실제로 요청을 정상 처리하는 것**은 다르다 — 헬스체크는 이 가드 밖.
 5. 고정을 **누가** 했는지는 안 본다(공용 자격증명이라 감사로그로도 못 가른다 — 표본 A 에서
    실제로 못 갈랐다). 이 가드는 "누가"가 아니라 "선언됐는가"만 묻는다.
-6. 정상 배포 중 몇 초간 나타나는 `latestReady != latestCreated` **과도기**가 하필 크론
-   타이밍과 겹치면 오탐이 난다(확률은 낮다 — 6시간 주기 × 수십초 창). 오탐 시 다음
-   사이클에서 자연히 사라지므로 선언하지 말고 다음 실행을 볼 것.
+6. ✅story #2246(2026-07-28)로 해소 — 예전엔 정상 배포 중 몇 초간 나타나는
+   `latestReady != latestCreated` **과도기**가 크론/온디맨드 실행과 겹치면 축B 오탐이 났다
+   (실측: 리비전 생성 1.3초 뒤 판정 → FAIL, 18.79초 뒤 실제 Ready). 지금은 `_STALL_GRACE_
+   SECONDS`(90s, 관측 최대 18.8s 대비 여유) 안이면 FAIL 대신 "판정 보류"로 넘어간다.
+   ⛔axis A(트래픽 고정) 쪽은 같은 레이스가 구조적으로 없다 — Cloud Run 은 새 리비전이
+   Ready 가 되기 前까지 트래픽을 옮기지 않으므로(latestRevision:true 태그가 옛 리비전에
+   계속 남아 있음), `_is_pinned`가 잡는 "100% 미만" 상태 자체가 배포 진행 중에는 발생하지
+   않는다(2026-07-28 확認, 이번 스토리에서 axis A 는 손대지 않음).
 7. **같은 문제를 몇 번 알렸는지 세지 않는다** — 아래 "알림 반복" 참조.
 ```
 
@@ -124,6 +129,34 @@ def _serving_status(service: str) -> dict:
         "latest_ready": status.get("latestReadyRevisionName"),
         "latest_created": status.get("latestCreatedRevisionName"),
     }
+
+
+# story #2246 — 축B 오탐 수정: 「Ready 에 도달 못 했다」와 「아직 도달 안 했다」를 나이로 가른다.
+# 근거(2026-07-28 실측, 11개 서비스의 «갓 배포된» 최신 리비전 created→Ready 델타 표본):
+#   18.7 · 17.7 · 7.9 · 9.4 · 18.8 · 11.2 · 7.9 · 6.2 · 5.6 · 12.9 · 12.7 (초) — 최대 18.8초.
+# ⛔이 값들은 `status.conditions[Ready].lastTransitionTime`이 **아니라**
+# `metadata.creationTimestamp` 대비로만 유효하다 — lastTransitionTime 은 그 리비전이 나중에
+# 스케일링/재시작 등으로 조건이 다시 평가되면 갱신되므로, 오래된 리비전에서 같은 계산을 하면
+# 수천~수십만 초가 나온다(실측으로 확認 — 원래 데이터를 오염시킬 뻔했다). 그래서 age 판정도
+# creationTimestamp 만 쓴다(아래 `_revision_created_at`).
+# 유예값 = 관측 최대(18.8s) 대비 넉넉한 여유(~4.8배) — #2128 이 60s(프론트 컷)+30s 여유로
+# 90s 를 정한 것과 같은 근거 스타일. 6시간 주기 가드라 90s 유예를 더 줘도 감시력 손실은
+# 사실상 0(진짜 정체는 다음 실행에서도 나이가 계속 크게 나와 반드시 잡힌다).
+_STALL_GRACE_SECONDS = 90.0
+
+
+def _revision_created_at(revision_name: str) -> datetime:
+    """리비전 metadata.creationTimestamp — 「나이」 판정 축(story #2246).
+
+    ⛔`status.conditions[].lastTransitionTime`은 쓰지 않는다 — 그건 "마지막 상태 전환
+    시각"이라 스케일링·재시작 등으로 나중에 갱신될 수 있어, 오래 살아있는 리비전에서는
+    "생성 시각"과 전혀 무관해진다(2026-07-28 실측 — 이 값으로 유예 판정을 했으면 몇 시간
+    전 리비전도 "방금 생겼다"로 잘못 읽었을 것)."""
+    out = _run([
+        "gcloud", "run", "revisions", "describe", revision_name,
+        f"--region={_REGION}", "--format=value(metadata.creationTimestamp)",
+    ])
+    return datetime.fromisoformat(out.replace("Z", "+00:00"))
 
 
 def _load_allowlist() -> tuple[dict[str, dict], dict[str, dict]]:
@@ -211,6 +244,7 @@ def main() -> int:
 
     undeclared_pins: list[str] = []
     undeclared_stalls: list[str] = []
+    deferred_stalls: list[str] = []
     bad_declarations: list[str] = []
     unreadable: list[str] = []
     live_pinned: set[str] = set()
@@ -256,11 +290,32 @@ def main() -> int:
         if stalled:
             live_stalled.add(service)
             if service not in declared_stalls:
-                undeclared_stalls.append(
-                    f"{service}: 최신 리비전이 Ready 에 도달 못 했다 — "
-                    f"latestCreated={st['latest_created']} · "
-                    f"실제 서빙 가능한 최신={st['latest_ready']}"
-                )
+                # story #2246 — 「도달 못 했다」와 「아직 도달 안 했다」를 나이로 가른다.
+                # 나이를 못 재도(gcloud 실패 등) 유예를 못 주는 쪽(=즉시 FAIL)이 안전하다 —
+                # 유예는 «봐주는 것»이 아니라 «판정에 필요한 근거(나이)가 있을 때만» 쓴다.
+                age_seconds: float | None = None
+                try:
+                    created_at = _revision_created_at(st["latest_created"])
+                    age_seconds = (datetime.now(timezone.utc) - created_at).total_seconds()
+                except Exception:  # noqa: BLE001 — 나이 조회 실패는 유예 불가로만 처리(배치는 계속)
+                    age_seconds = None
+
+                if age_seconds is not None and 0 <= age_seconds <= _STALL_GRACE_SECONDS:
+                    deferred_stalls.append(
+                        f"{service}: 생성 후 {age_seconds:.0f}초 경과 — 아직 유예 기간"
+                        f"({_STALL_GRACE_SECONDS:.0f}초) 내라 판정 보류(다음 실행에서 다시 본다). "
+                        f"latestCreated={st['latest_created']} · latestReady={st['latest_ready']}"
+                    )
+                else:
+                    age_desc = (
+                        f"생성 후 {age_seconds / 60:.1f}분 경과했는데"
+                        if age_seconds is not None else "생성 시각을 확認 못 했는데"
+                    )
+                    undeclared_stalls.append(
+                        f"{service}: {age_desc} Ready 가 아니다 — "
+                        f"latestCreated={st['latest_created']} · "
+                        f"실제 서빙 가능한 최신={st['latest_ready']}"
+                    )
 
     # 선언 자체의 건강 — 만료·사유누락·사실과 어긋남.
     for kind, declared, live in (
@@ -295,6 +350,10 @@ def main() -> int:
             print("  ⚠️상태를 못 읽은 서비스(감시 공백 — 조용히 넘기지 않는다):")
             for line in unreadable:
                 print(f"    - {line}")
+        if deferred_stalls:
+            print("  ⏳ 판정 보류(배포 직후로 보임 — 이건 FAIL 사유가 아니다):")
+            for line in deferred_stalls:
+                print(f"    - {line}")
         print(
             f"\n검사한 서비스 {len(services) - len(unreadable)}/{len(services)}개.\n"
             "→ **이 알림을 멈추는 방법은 둘뿐이다: 상태를 고치거나, 선언하거나.** "
@@ -308,9 +367,20 @@ def main() -> int:
         )
         return 1
 
+    # story #2246 — 판정 보류는 "통과"가 아니다. FAIL 을 안 울려도(de-dup 없이 알림 반복하는
+    # 규율을 이 축까지 넓히지 않는다 — 배포 직후 정상 진행 중인 것까지 시끄러우면 그게 새 노이즈)
+    # 조용히 삼키지도 않는다 — 다음 실행에서 같은 리비전을 다시 재고, 그때도 Ready 가 아니면
+    # 나이가 유예를 넘겨 반드시 FAIL 로 넘어간다(상태를 따로 기억할 필요가 없다).
+    if deferred_stalls:
+        print("⏳ 판정 보류 — 배포 직후로 보인다(정체 아님, 다음 실행에서 다시 본다):")
+        for line in deferred_stalls:
+            print(f"    - {line}")
+        print()
+
     print(
         f"✅ 배포 실효 이상 없음 — {len(services)}개 Cloud Run 서비스 전부 검사 "
-        f"(축A 트래픽 고정/분할 0건·축B 롤아웃 정체 0건·선언 문제 0건·조회 실패 0건). "
+        f"(축A 트래픽 고정/분할 0건·축B 롤아웃 정체 0건·선언 문제 0건·조회 실패 0건"
+        f"{'·판정 보류 ' + str(len(deferred_stalls)) + '건' if deferred_stalls else ''}). "
         f"⚠️GCE MIG·'최신 머지가 서빙되는가'는 이 가드 밖(모듈 docstring 참조)."
     )
     return 0


### PR DESCRIPTION
## 요약
배포 실효 가드(`infra/check_serving_reality.py`, story #2174)의 축B(롤아웃 정체) 판정이 리비전 생성 직후 실행되면 "아직 Ready 도달 전"을 "정체"로 오판했다. PR #2551 배포 中 실측(PO):

```
00:52:07.506  리비전 00184-bmv 생성
00:52:08.835  가드가 "Ready 에 도달 못 했다"로 FAIL 판정     ← 생성 1.3초 뒤
00:52:26.299  Ready=True ("succeeded in 18.79s")
```

## 처방 — 어휘 확장(무조건 통과 아님)
- `_revision_created_at()`: `metadata.creationTimestamp` 기준. ⛔`status.conditions[Ready].lastTransitionTime`은 안 쓴다 — 스케일링/재시작으로 나중에 갱신돼 오래된 리비전에선 생성 시각과 무관해진다(실측으로 확認 — 원래 이 값으로 재려다 수천~수십만 초짜리 데이터를 얻고 원인을 찾았다).
- `_STALL_GRACE_SECONDS=90`: 11개 서비스의 "갓 배포된" 최신 리비전 created→Ready 델타 실측 분포(2026-07-28, 5.6~18.8초) 대비 여유(#2128이 60s+30s로 90s를 정한 것과 같은 근거 스타일).
- 유예 안이면 **FAIL이 아니라 "판정 보류"**로 분리 출력 — 조용히 "통과"로 세지 않는다(exit code 0이지만 출력엔 남는다). 다음 실행(6시간 주기)에서 같은 리비전을 다시 재므로 별도 상태 기억이 필요 없다 — 진짜 정체면 나이가 계속 커져 반드시 FAIL로 넘어간다.
- 나이 조회 자체가 실패하면 유예를 줄 근거가 없다 — 안전 쪽(즉시 FAIL)으로 떨어진다.
- 메시지 문구를 "Ready 도달 못 했다"에서 "생성 후 N분 경과했는데 Ready가 아니다"로 바꿔, 읽는 사람이 경주(race)인지 정체(stall)인지 바로 판단할 수 있게 했다.

## 양성대조 (AC5)
나이가 유예(90초)를 넘긴 정체는 **여전히 FAIL**한다 — 테스트로 고정(`test_stall_beyond_grace_still_fails`). 유예를 넣었다고 진짜 결함을 눈감지 않는다는 것을 확認.

## axis A(트래픽 고정) 조사 (AC6)
같은 레이스는 **없다** — Cloud Run은 새 리비전이 Ready가 되기 前까지 트래픽을 옮기지 않는다(`latestRevision:true` 태그가 옛 리비전에 그대로 남아 있음). `_is_pinned`가 잡는 "100% 미만" 상태 자체가 배포 진행 中에는 구조적으로 발생하지 않는다. 이번 PR에서 axis A는 손대지 않았다.

## allowlist 는 안 건드렸다 (AC7)
이건 선언 대상(의도적 고정/카나리)이 아니라 가드 자체의 결함이다.

## Test plan
- [x] 신규 3건: 유예 안 판정보류(`test_stall_within_grace_is_deferred_not_failed`) · 유예 초과 여전히 FAIL(`test_stall_beyond_grace_still_fails`, 양성대조) · 나이 조회 실패 시 즉시 FAIL(`test_stall_age_lookup_failure_fails_immediately`)
- [x] 기존 20건 전부 그대로 통과(무회귀) — 표본 A/B·선언 만료/낡음·까심군 적대적 리뷰 회귀가드 포함, 총 23/23 PASS
- [x] `python -c "import importlib.util; ..."` 로 스크립트 자체 import 성공 확認
- [x] 라이브 실측: 현재 11개 서비스 전부 `check_serving_reality.py` 직접 실행 → 정상 초록(판정 보류 0건, 전부 이미 Ready 상태이므로)

## 못 잡는 것
docstring의 기존 "못 잡는 것" 목록(GCE MIG·최신 머지 여부·타 리전·헬스체크·고정 주체·알림 반복 미카운트)은 그대로 유효 — 이번 PR은 항목 6(과도기 오탐)만 해소했다.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>