### PR TITLE
feat(#2201): SSE backfill 조용한 강등에 이유 신호(sync_status) 추가

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -71,8 +71,10 @@ from app.models.role_template import RoleTemplate
 # plan_feature·project_api_key·label·onboarding_event·verdict·workflow_execution_log·
 # workflow_line·workflow_template·workflow_trigger_type)는 등재 시 destructive_schema
 # 테스트(101개 파일 × 파일당 create_all/drop_all) 총소요가 CI 예산(25분, 기준선 16~17분)을
-# 넘겨 별도 스토리로 분리(PO 세움) — "등재를 미루는 것"이 아니라 "파일마다 전체 스키마를
-# create_all/drop_all하는 구조 자체를 먼저 손보는 것"이 그 스토리의 실제 과제.
+# 넘겨 별도 스토리로 분리 — "[인프라·CI] 모델 하나 늘 때마다 CI가 몇 분씩 느려진다 — 집합
+# 모듈 누락 10건을 «등재할 수 없는» 상태다"(id 69d7380e-9567-47ed-9194-d9784cbf637a).
+# "등재를 미루는 것"이 아니라 "파일마다 전체 스키마를 create_all/drop_all하는 구조 자체를
+# 먼저 손보는 것"이 그 스토리의 실제 과제.
 from app.models.trust_snapshot import OrgMemberTrustSnapshot
 from app.models.visual_artifact import ArtifactNode, ArtifactVersion, VisualArtifact
 # fix(2026-07-20, #2058 후속 CI 적출): 이 두 모듈이 여기 없어 `import app.models`만으로는

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -15,6 +15,7 @@ from app.models.device_installation import DeviceInstallation, DeviceProofChalle
 from app.models.entity_slug_history import EntitySlugHistory
 from app.models.embedding import Embedding
 from app.models.evidence import Evidence
+from app.models.event import Event
 from app.models.event_outbox import EventOutbox
 from app.models.gate import Gate
 from app.models.github_installation import GithubInstallation, GithubInstallNonce, GithubWebhookDelivery
@@ -23,9 +24,11 @@ from app.models.mockup import MockupComponent, MockupPage, MockupScenario, Mocku
 from app.models.user import RefreshToken, User
 from app.models.workflow_version import WorkflowVersion
 from app.models.api_key import ApiKey
+from app.models.project_api_key import ProjectApiKey
 from app.models.org_subscription import OrgSubscription
 from app.models.pricing_version import PricingVersion
 from app.models.plan_tier_limit import PlanTierLimit
+from app.models.plan_feature import PlanFeature
 from app.models.policy_document import PolicyDocument
 from app.models.audit import AuditLog
 from app.models.webhook_config import WebhookConfig
@@ -60,9 +63,30 @@ from app.models.org_invite import OrgInvite
 from app.models.project_access import ProjectAccess
 from app.models.member import AgentProjectProfile, Member, MemberIdentityAlias
 from app.models.activity_event import ActivityEvent
+from app.models.activity_log import ActivityLog
 from app.models.asset import Asset, AssetFolder, AssetLink
 from app.models.release_note import ReleaseNote
 from app.models.role_template import RoleTemplate
+# fix(2026-07-28, #2201 후속 CI 적출): 아래 11개 모듈이 여기 없어 `import app.models`만으로는
+# Base.metadata에 등록 안 됐다(2026-07-20 hitl_config/participation 건과 동일 클래스 결함 —
+# app/models/*.py 파일 목록 대 이 파일의 import 목록을 전수 대조해 한 번에 찾음). 프로세스에서
+# 그 모델이 어디서도 아직 안 읽힌 채 realdb 테스트의 create_all()이 먼저 돌면 해당 테이블이
+# 통째로 안 생긴다 — "그 테스트가 프로세스의 첫 realdb 테스트일 때만" 조용히 재현돼(#2201
+# `events` 테이블 사례) 원인 특정이 어려운 결함 계열이다.
+from app.models.label import Label, ItemLabel
+from app.models.onboarding_event import OnboardingEvent
+from app.models.verdict import Verdict
+from app.models.workflow_execution_log import WorkflowExecutionLog
+from app.models.workflow_line import (
+    WorkflowLineDefinition,
+    WorkflowLineDefinitionVersion,
+    WorkflowLineStepRun,
+    WorkflowLineStepApproval,
+    WorkflowLineStepRunEvent,
+    WorkflowRoleAssignment,
+)
+from app.models.workflow_template import WorkflowTemplate
+from app.models.workflow_trigger_type import WorkflowTriggerType
 from app.models.trust_snapshot import OrgMemberTrustSnapshot
 from app.models.visual_artifact import ArtifactNode, ArtifactVersion, VisualArtifact
 # fix(2026-07-20, #2058 후속 CI 적출): 이 두 모듈이 여기 없어 `import app.models`만으로는
@@ -166,4 +190,21 @@ __all__ = [
     "RefreshToken",
     "User",
     "WorkflowVersion",
+    "Event",
+    "ActivityLog",
+    "PlanFeature",
+    "ProjectApiKey",
+    "Label",
+    "ItemLabel",
+    "OnboardingEvent",
+    "Verdict",
+    "WorkflowExecutionLog",
+    "WorkflowLineDefinition",
+    "WorkflowLineDefinitionVersion",
+    "WorkflowLineStepRun",
+    "WorkflowLineStepApproval",
+    "WorkflowLineStepRunEvent",
+    "WorkflowRoleAssignment",
+    "WorkflowTemplate",
+    "WorkflowTriggerType",
 ]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -24,11 +24,9 @@ from app.models.mockup import MockupComponent, MockupPage, MockupScenario, Mocku
 from app.models.user import RefreshToken, User
 from app.models.workflow_version import WorkflowVersion
 from app.models.api_key import ApiKey
-from app.models.project_api_key import ProjectApiKey
 from app.models.org_subscription import OrgSubscription
 from app.models.pricing_version import PricingVersion
 from app.models.plan_tier_limit import PlanTierLimit
-from app.models.plan_feature import PlanFeature
 from app.models.policy_document import PolicyDocument
 from app.models.audit import AuditLog
 from app.models.webhook_config import WebhookConfig
@@ -63,30 +61,18 @@ from app.models.org_invite import OrgInvite
 from app.models.project_access import ProjectAccess
 from app.models.member import AgentProjectProfile, Member, MemberIdentityAlias
 from app.models.activity_event import ActivityEvent
-from app.models.activity_log import ActivityLog
 from app.models.asset import Asset, AssetFolder, AssetLink
 from app.models.release_note import ReleaseNote
 from app.models.role_template import RoleTemplate
-# fix(2026-07-28, #2201 후속 CI 적출): 아래 11개 모듈이 여기 없어 `import app.models`만으로는
-# Base.metadata에 등록 안 됐다(2026-07-20 hitl_config/participation 건과 동일 클래스 결함 —
-# app/models/*.py 파일 목록 대 이 파일의 import 목록을 전수 대조해 한 번에 찾음). 프로세스에서
-# 그 모델이 어디서도 아직 안 읽힌 채 realdb 테스트의 create_all()이 먼저 돌면 해당 테이블이
-# 통째로 안 생긴다 — "그 테스트가 프로세스의 첫 realdb 테스트일 때만" 조용히 재현돼(#2201
-# `events` 테이블 사례) 원인 특정이 어려운 결함 계열이다.
-from app.models.label import Label, ItemLabel
-from app.models.onboarding_event import OnboardingEvent
-from app.models.verdict import Verdict
-from app.models.workflow_execution_log import WorkflowExecutionLog
-from app.models.workflow_line import (
-    WorkflowLineDefinition,
-    WorkflowLineDefinitionVersion,
-    WorkflowLineStepRun,
-    WorkflowLineStepApproval,
-    WorkflowLineStepRunEvent,
-    WorkflowRoleAssignment,
-)
-from app.models.workflow_template import WorkflowTemplate
-from app.models.workflow_trigger_type import WorkflowTriggerType
+# fix(2026-07-28, #2201 후속 CI 적출): app/models/*.py 파일 목록 대 이 파일의 import 목록을
+# 전수 대조해, `import app.models`만으로는 Base.metadata에 안 잡히는 모듈 11개를 찾았다
+# (2026-07-20 hitl_config/participation 건과 동일 결함 클래스). 이 PR이 실제로 필요한 것은
+# `event`(Event/"events" 테이블) 하나뿐이라 그것만 여기서 등재한다 — 나머지 10개(activity_log·
+# plan_feature·project_api_key·label·onboarding_event·verdict·workflow_execution_log·
+# workflow_line·workflow_template·workflow_trigger_type)는 등재 시 destructive_schema
+# 테스트(101개 파일 × 파일당 create_all/drop_all) 총소요가 CI 예산(25분, 기준선 16~17분)을
+# 넘겨 별도 스토리로 분리(PO 세움) — "등재를 미루는 것"이 아니라 "파일마다 전체 스키마를
+# create_all/drop_all하는 구조 자체를 먼저 손보는 것"이 그 스토리의 실제 과제.
 from app.models.trust_snapshot import OrgMemberTrustSnapshot
 from app.models.visual_artifact import ArtifactNode, ArtifactVersion, VisualArtifact
 # fix(2026-07-20, #2058 후속 CI 적출): 이 두 모듈이 여기 없어 `import app.models`만으로는
@@ -191,20 +177,4 @@ __all__ = [
     "User",
     "WorkflowVersion",
     "Event",
-    "ActivityLog",
-    "PlanFeature",
-    "ProjectApiKey",
-    "Label",
-    "ItemLabel",
-    "OnboardingEvent",
-    "Verdict",
-    "WorkflowExecutionLog",
-    "WorkflowLineDefinition",
-    "WorkflowLineDefinitionVersion",
-    "WorkflowLineStepRun",
-    "WorkflowLineStepApproval",
-    "WorkflowLineStepRunEvent",
-    "WorkflowRoleAssignment",
-    "WorkflowTemplate",
-    "WorkflowTriggerType",
 ]

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -403,6 +403,30 @@ async def agent_event_stream(
                 # S0-1: 초기 연결(last_event_id=None, since_timestamp=None)은 INITIAL 상한 적용
                 is_initial = last_event_id is None and since_timestamp is None
                 exceed, limit = _compute_backfill_mode(_ref, now, initial=is_initial)
+                # story #2201: 강등 «사실»만이 아니라 «이유»를 클라이언트에 싣는다 — 지금까지는
+                # 캡에 걸려 과거를 못 채워도(exceed=True) 아무 신호 없이 정상 응답처럼 돌아갔다.
+                # ⛔_compute_backfill_mode의 시그니처·반환값(exceed, limit)은 손대지 않는다(동작
+                # 불변 — 50/100/5 캡은 그대로) · reason만 호출부에서 옆에 붙인다(이 세 값 각각을
+                # 판별할 정보는 이미 위에서 계산돼 있다: is_initial · _ref(None이면 커서를
+                # 보냈어도 못 찾은 것 · since_timestamp 폴백도 없었던 것) · exceed).
+                if is_initial:
+                    _backfill_reason: str | None = "no_cursor"
+                elif _ref is None:
+                    _backfill_reason = "cursor_not_found"
+                elif exceed:
+                    _backfill_reason = "cursor_stale"
+                else:
+                    _backfill_reason = None
+                # done-gate(story #2201): "코드 넣었다"로 안 닫는다 — 이 로그가 gcloud logging
+                # read로 실제로 잡히는 것까지 확認해야 완료다. no_cursor(진짜 최초접속)는 정상
+                # 트래픽이라 제외 — 재연결인데 못 따라잡은 두 경우(cursor_not_found·cursor_stale)
+                # 만 센다(강등 «빈도»가 이 신호의 목적이지 최초접속 빈도가 아니다).
+                if _backfill_reason in ("cursor_not_found", "cursor_stale"):
+                    import logging
+                    logging.getLogger(__name__).info(
+                        "sse.backfill_degraded reason=%s org_id=%s member_id=%s",
+                        _backfill_reason, org_id, resolved_member_id,
+                    )
                 # story #2101: pending뿐 아니라 최근 delivered도 포함 — 동일 member의
                 # 다른 연결(탭)이 먼저 받아 delivered로 마킹한 이벤트를, 재연결한 이 연결도
                 # 다시 받게 한다(중복은 클라 dedup이 처리, 영구 유실 0이 목표).
@@ -456,6 +480,16 @@ async def agent_event_stream(
                         .limit(100)
                     )
                     pending_events = result.scalars().all()
+
+                # story #2201: heartbeat 다음, backfill 이벤트 스트리밍 시작 前에 전용 이벤트
+                # 타입으로 보낸다 — 응답 헤더/heartbeat 메타에는 못 싣는다(heartbeat은 위에서
+                # 이 판정 前에 이미 나가 헤더를 flush했다, hang 방지 설계라 이 스토리에서 손대지
+                # 않는다). 미등록 named event는 이 정확히 같은 엔드포인트에서 heartbeat이 매일
+                # 무해함을 실증 중이라 계약 안전은 이미 확認됨(FE·MCP 브리지 둘 다 조용히 무시).
+                yield (
+                    "event: sync_status\n"
+                    f"data: {json.dumps({'complete': _backfill_reason is None, 'reason': _backfill_reason, 'returned': len(pending_events)})}\n\n"
+                )
 
                 for i in range(0, len(pending_events), _SSE_BATCH_SIZE):
                     batch = pending_events[i : i + _SSE_BATCH_SIZE]

--- a/backend/tests/test_2201_sse_backfill_degraded_signal_realdb.py
+++ b/backend/tests/test_2201_sse_backfill_degraded_signal_realdb.py
@@ -81,7 +81,7 @@ async def _seed(Session, *, with_stale_event: bool = False, with_fresh_event: bo
             ))
             await s.commit()
 
-    return {"org_id": org_id, "member_id": member_id, "event_id": event_id}
+    return {"org_id": org_id, "project_id": project_id, "member_id": member_id, "event_id": event_id}
 
 
 async def _setup_app(app, Session, member_id, org_id):
@@ -214,6 +214,54 @@ async def test_cursor_fresh_within_threshold_complete_true():
                 client, f"/api/v2/events/stream?last_event_id={seeded['event_id']}"
             )
             assert frame == {"complete": True, "reason": None, "returned": 0}
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_returned_reflects_actual_count_not_the_cap():
+    """PO 리뷰(2026-07-28) — `returned`가 이름 그대로인지 실증한다: 그 모드의 상한(cursor_
+    not_found → 50건 캡)이 아니라 **실제 쿼리 결과 건수**여야 한다. 오늘 하루 「이름이 실제와
+    다른 것」에 세 번 걸렸다(X-Total-Count=len(items)·next_after_seq가 실은 커서·
+    lastTransitionTime이 나이 아님) — 이번엔 실측으로 미리 가른다.
+
+    시나리오: cursor_not_found(50건 캡 경로)인데 실제 pending 이벤트는 **2건뿐**. `returned`가
+    50이 아니라 2로 나오면 실제 건수를 담고 있다는 뜻 — 왜냐하면 `sync_status`가 heartbeat
+    다음·**개별 백필 이벤트 스트리밍 시작 前**에 나가는 건 맞지만, 그 시점은 이미 DB 쿼리가
+    끝나 `pending_events` 리스트가 메모리에 있는 시점이다(라우터 코드: 쿼리 실행 → `sync_status`
+    yield → 그 리스트를 배치로 스트리밍하는 순서). "스트리밍 시작 前"이지 "쿼리 前"이 아니다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        seeded = await _seed(Session)
+        # cursor_not_found 유도(존재하지 않는 last_event_id) + 실제 pending 이벤트 2건만 시드
+        # (50건 캡보다 훨씬 작게 — 캡값이 그대로 찍히면 바로 드러나도록).
+        async with Session() as s:
+            from app.models.event import Event
+            for _ in range(2):
+                s.add(Event(
+                    id=uuid.uuid4(), project_id=seeded["project_id"], org_id=seeded["org_id"],
+                    event_type="test.event", recipient_id=seeded["member_id"],
+                    recipient_type="agent", payload={}, status="pending",
+                ))
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["member_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            missing_cursor = uuid.uuid4()
+            frame = await _read_sync_status_frame(
+                client, f"/api/v2/events/stream?last_event_id={missing_cursor}"
+            )
+            assert frame["reason"] == "cursor_not_found"
+            assert frame["returned"] == 2, (
+                f"returned={frame['returned']} — 50(캡)이 찍혔으면 «상한»을 담고 있는 것이라 "
+                "이름이 거짓말인 버그. 실제 시드한 2건이 나와야 한다."
+            )
         finally:
             await client.aclose()
     finally:

--- a/backend/tests/test_2201_sse_backfill_degraded_signal_realdb.py
+++ b/backend/tests/test_2201_sse_backfill_degraded_signal_realdb.py
@@ -63,16 +63,9 @@ def _async_url() -> str:
 async def _session_factory():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-    import app.models  # noqa: F401 — 전 모델 메타데이터 로드(⚠️아래 참조 — 이것만으론 부족)
-    # ⛔`app.models`(__init__.py)는 `app.models.event`(Event/"events" 테이블)를 안 끌어온다
-    # (agent_event_seq·event_outbox·activity_event만 임포트 — grep 확認). 이 프로세스에서
-    # `Event`가 아직 어디서도 임포트 안 된 시점에 create_all이 먼저 돌면 "events" 테이블이
-    # 통째로 안 만들어진다 — 그 뒤 `agent_event_stream`(app.routers.events, 모듈 레벨에서
-    # `from app.models.event import Event`)이 처음 임포트되며 뒤늦게 Base.metadata에 등록
-    # 되지만 이미 create_all은 끝난 후라 DB엔 없다(`UndefinedTableError: relation "events"
-    # does not exist`, 이 프로세스의 첫 realdb 테스트에서만 재현 — 그 다음 테스트부터는
-    # Event가 이미 등록돼 있어 무재현. 실측 2026-07-28). create_all **前** 명시 임포트로 봉인.
-    from app.models.event import Event  # noqa: F401
+    import app.models  # noqa: F401 — 전 모델 메타데이터 로드(app/models/__init__.py가 Event 등
+    # 11종을 끌어오도록 봉인됨 — 2026-07-28, #2201 후속. 근본 수정은 app/models/__init__.py에
+    # 있음. 상세 경위는 그 파일 주석 참조).
     from app.core.database import Base
 
     engine = create_async_engine(_async_url())

--- a/backend/tests/test_2201_sse_backfill_degraded_signal_realdb.py
+++ b/backend/tests/test_2201_sse_backfill_degraded_signal_realdb.py
@@ -1,0 +1,251 @@
+"""story #2201 실PG 통합 테스트 — SSE 백필 강등 신호(event: sync_status).
+
+갭: last_event_id가 무효(만료·GC됨)하거나 300초를 넘겨도 클라이언트에게 "못 따라잡았다"는
+신호가 전혀 없었다(events.py 조용한 강등). 처방: heartbeat 다음, backfill 이벤트 스트리밍
+시작 前에 전용 이벤트 타입(event: sync_status)으로 이유(reason)를 싣는다.
+
+⛔동작(50/100/5 캡)은 이 스토리에서 안 바꾼다 — _compute_backfill_mode의 유닛 테스트
+(test_s6_1_sse_backfill.py)가 그대로 통과하는 것으로 무회귀를 확認한다. 이 파일은 신호
+자체(sync_status 프레임 · reason 값 · 로그)만 검증한다.
+"""
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.destructive_schema,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    import app.models  # noqa: F401 — 전 모델 메타데이터 로드
+    from app.core.database import Base
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(Session, *, with_stale_event: bool = False, with_fresh_event: bool = False):
+    from app.models.event import Event
+    from app.models.project import Project
+    from app.models.team import TeamMember
+
+    org_id, project_id, member_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    async with Session() as s:
+        s.add(Project(id=project_id, org_id=org_id, name="test-project"))
+        await s.commit()
+        s.add(TeamMember(id=member_id, org_id=org_id, project_id=project_id, type="agent", name="test-agent"))
+        await s.commit()
+
+        event_id = None
+        if with_stale_event or with_fresh_event:
+            now = datetime.now(timezone.utc)
+            created_at = now - timedelta(seconds=(600 if with_stale_event else 5))
+            event_id = uuid.uuid4()
+            s.add(Event(
+                id=event_id, project_id=project_id, org_id=org_id, event_type="test.event",
+                recipient_id=member_id, recipient_type="agent", payload={}, status="pending",
+                created_at=created_at,
+            ))
+            await s.commit()
+
+    return {"org_id": org_id, "member_id": member_id, "event_id": event_id}
+
+
+async def _setup_app(app, Session, member_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user_streaming, get_verified_org_id_streaming
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(member_id), email="agent@test",
+            claims={"app_metadata": {"api_key_id": str(uuid.uuid4()), "org_id": str(org_id)}},
+        )
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user_streaming] = _auth
+    app.dependency_overrides[get_verified_org_id_streaming] = _org
+
+
+async def _read_sync_status_frame(client, url: str) -> dict:
+    """SSE 스트림에서 heartbeat 다음 sync_status 프레임까지만 읽고 연결을 닫는다
+    (그 뒤는 신규 이벤트 대기 큐라 무한정 블록됨 — 안 읽는다)."""
+    lines: list[str] = []
+    async with client.stream("GET", url, timeout=10.0) as resp:
+        assert resp.status_code == 200, await resp.aread()
+        seen_event_types: list[str] = []
+        async for line in resp.aiter_lines():
+            lines.append(line)
+            if line.startswith("event: "):
+                seen_event_types.append(line[len("event: "):])
+            if line.startswith("data: ") and seen_event_types[-1:] == ["sync_status"]:
+                return json.loads(line[len("data: "):])
+    raise AssertionError(f"sync_status frame not found in stream: {lines}")
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+@pytest.mark.anyio
+async def test_initial_connection_no_cursor():
+    """진짜 최초접속(커서 자체 없음) → reason=no_cursor, complete=False."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        seeded = await _seed(Session)
+        await _setup_app(app, Session, seeded["member_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            frame = await _read_sync_status_frame(client, "/api/v2/events/stream")
+            assert frame == {"complete": False, "reason": "no_cursor", "returned": 0}
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cursor_not_found_reconnect():
+    """커서는 보냈는데 DB에 없음(만료·GC됨) → reason=cursor_not_found(5건 아니라 50건 캡 경로)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        seeded = await _seed(Session)
+        await _setup_app(app, Session, seeded["member_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            missing_cursor = uuid.uuid4()
+            frame = await _read_sync_status_frame(
+                client, f"/api/v2/events/stream?last_event_id={missing_cursor}"
+            )
+            assert frame["reason"] == "cursor_not_found"
+            assert frame["complete"] is False
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cursor_stale_over_threshold():
+    """커서는 유효한데 300초 초과 → reason=cursor_stale."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        seeded = await _seed(Session, with_stale_event=True)
+        await _setup_app(app, Session, seeded["member_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            frame = await _read_sync_status_frame(
+                client, f"/api/v2/events/stream?last_event_id={seeded['event_id']}"
+            )
+            assert frame["reason"] == "cursor_stale"
+            assert frame["complete"] is False
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cursor_fresh_within_threshold_complete_true():
+    """회귀 0: 커서 유효·300초 이내 → complete=True, reason=None(정상 캐치업)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        seeded = await _seed(Session, with_fresh_event=True)
+        await _setup_app(app, Session, seeded["member_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            frame = await _read_sync_status_frame(
+                client, f"/api/v2/events/stream?last_event_id={seeded['event_id']}"
+            )
+            assert frame == {"complete": True, "reason": None, "returned": 0}
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_degraded_reason_logged(caplog):
+    """done-gate: 강등 시(cursor_not_found) 서버 로그가 실제로 찍힌다(gcloud logging read 로
+    셀 수 있게 되는 핵심 산출) — "코드 넣었다"가 아니라 로그가 실제로 나가는 것까지 확認."""
+    import logging
+
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        seeded = await _seed(Session)
+        await _setup_app(app, Session, seeded["member_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            with caplog.at_level(logging.INFO, logger="app.routers.events"):
+                missing_cursor = uuid.uuid4()
+                await _read_sync_status_frame(
+                    client, f"/api/v2/events/stream?last_event_id={missing_cursor}"
+                )
+            assert any(
+                "sse.backfill_degraded" in r.message and "cursor_not_found" in r.message
+                for r in caplog.records
+            ), [r.message for r in caplog.records]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_2201_sse_backfill_degraded_signal_realdb.py
+++ b/backend/tests/test_2201_sse_backfill_degraded_signal_realdb.py
@@ -7,6 +7,18 @@
 ⛔동작(50/100/5 캡)은 이 스토리에서 안 바꾼다 — _compute_backfill_mode의 유닛 테스트
 (test_s6_1_sse_backfill.py)가 그대로 통과하는 것으로 무회귀를 확認한다. 이 파일은 신호
 자체(sync_status 프레임 · reason 값 · 로그)만 검증한다.
+
+⛔읽기 방식(HTTP 계층 우회, 2026-07-28 CI red 조사 후 확定): `httpx.AsyncClient(transport=
+ASGITransport(...))`(같은 이벤트루프) 로 읽으면 서버는 즉시(<10ms) heartbeat·sync_status를
+전부 yield하는데도(계측 실증) 클라이언트가 status조차 못 받고 영구 대기했다 — PR과 무관한
+test-harness 비호환(PR 코드를 pass로 치환해도 동일 hang, 원인은 events.py가 아니라 read
+방식). 대안으로 시도한 `starlette.testclient.TestClient`(스레드+anyio portal, 이 코드베이스의
+기존 검증 패턴 test_s20.py)도 이 파일처럼 **실 asyncpg I/O가 섞인** 스트림에서는
+`AttributeError: 'ByteStream' object has no attribute 'write'`(starlette 1.0.0 + httpx
+0.28.1 조합 비호환)를 냈다. 최종 처방: ASGI/HTTP 트랜스포트 전부 우회 — 라우터 함수
+`agent_event_stream`을 직접 호출해 반환된 StreamingResponse의 `body_iterator`를 테스트
+자신의 이벤트루프에서 직접 순회한다. 스레드·소켓·트랜스포트 계층이 없어 이 비호환 클래스를
+전부 피하면서 실제 프로덕션과 동일한 제너레이터 로직을 그대로 검증한다.
 """
 from __future__ import annotations
 
@@ -32,8 +44,11 @@ def anyio_backend():
 
 @pytest.fixture(autouse=True)
 async def _dispose_global_engine_after_test():
-    yield
+    """`agent_event_stream`이 이 파일의 `get_db` 오버라이드가 안 닿는 앱 전역
+    `async_session_factory`(모듈 싱글턴)를 직접 쓴다. 다음 테스트 파일이 다른 destructive_schema
+    스키마로 재사용할 때 이 풀의 커넥션이 이전 스키마를 들고 있지 않도록 매 테스트 뒤에 폐기한다."""
     from app.core.database import engine as _global_engine
+    yield
     await _global_engine.dispose()
 
 
@@ -48,7 +63,16 @@ def _async_url() -> str:
 async def _session_factory():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-    import app.models  # noqa: F401 — 전 모델 메타데이터 로드
+    import app.models  # noqa: F401 — 전 모델 메타데이터 로드(⚠️아래 참조 — 이것만으론 부족)
+    # ⛔`app.models`(__init__.py)는 `app.models.event`(Event/"events" 테이블)를 안 끌어온다
+    # (agent_event_seq·event_outbox·activity_event만 임포트 — grep 확認). 이 프로세스에서
+    # `Event`가 아직 어디서도 임포트 안 된 시점에 create_all이 먼저 돌면 "events" 테이블이
+    # 통째로 안 만들어진다 — 그 뒤 `agent_event_stream`(app.routers.events, 모듈 레벨에서
+    # `from app.models.event import Event`)이 처음 임포트되며 뒤늦게 Base.metadata에 등록
+    # 되지만 이미 create_all은 끝난 후라 DB엔 없다(`UndefinedTableError: relation "events"
+    # does not exist`, 이 프로세스의 첫 realdb 테스트에서만 재현 — 그 다음 테스트부터는
+    # Event가 이미 등록돼 있어 무재현. 실측 2026-07-28). create_all **前** 명시 임포트로 봉인.
+    from app.models.event import Event  # noqa: F401
     from app.core.database import Base
 
     engine = create_async_engine(_async_url())
@@ -84,140 +108,97 @@ async def _seed(Session, *, with_stale_event: bool = False, with_fresh_event: bo
     return {"org_id": org_id, "project_id": project_id, "member_id": member_id, "event_id": event_id}
 
 
-async def _setup_app(app, Session, member_id, org_id):
-    from app.dependencies.auth import AuthContext, get_current_user_streaming, get_verified_org_id_streaming
-    from app.dependencies.database import get_db
+async def _read_sync_status_frame(
+    *, org_id: uuid.UUID, member_id: uuid.UUID, last_event_id: uuid.UUID | None = None,
+) -> dict:
+    """`agent_event_stream`을 직접 호출해 heartbeat 다음 sync_status 프레임까지만 읽는다
+    (그 뒤는 신규 이벤트 대기 큐라 무한정 블록됨 — 안 읽는다). 모듈 docstring 참조 — HTTP/ASGI
+    트랜스포트를 전부 우회하는 이유."""
+    from app.dependencies.auth import AuthContext
+    from app.routers.events import agent_event_stream
+    from starlette.requests import Request
 
-    async def _db():
-        async with Session() as s:
-            try:
-                yield s
-                await s.commit()
-            except Exception:
-                await s.rollback()
-                raise
+    auth = AuthContext(
+        user_id=str(member_id), email="agent@test",
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4()), "org_id": str(org_id)}},
+    )
+    request = Request(scope={"type": "http", "headers": [], "method": "GET", "path": "/api/v2/events/stream"})
 
-    async def _auth():
-        return AuthContext(
-            user_id=str(member_id), email="agent@test",
-            claims={"app_metadata": {"api_key_id": str(uuid.uuid4()), "org_id": str(org_id)}},
-        )
+    resp = await agent_event_stream(
+        request=request, member_id=None, auth=auth, org_id=org_id,
+        since_timestamp=None, last_event_id=last_event_id,
+    )
+    assert resp.status_code == 200
 
-    async def _org():
-        return org_id
-
-    app.dependency_overrides[get_db] = _db
-    app.dependency_overrides[get_current_user_streaming] = _auth
-    app.dependency_overrides[get_verified_org_id_streaming] = _org
-
-
-async def _read_sync_status_frame(client, url: str) -> dict:
-    """SSE 스트림에서 heartbeat 다음 sync_status 프레임까지만 읽고 연결을 닫는다
-    (그 뒤는 신규 이벤트 대기 큐라 무한정 블록됨 — 안 읽는다)."""
     lines: list[str] = []
-    async with client.stream("GET", url, timeout=10.0) as resp:
-        assert resp.status_code == 200, await resp.aread()
-        seen_event_types: list[str] = []
-        async for line in resp.aiter_lines():
-            lines.append(line)
-            if line.startswith("event: "):
-                seen_event_types.append(line[len("event: "):])
-            if line.startswith("data: ") and seen_event_types[-1:] == ["sync_status"]:
-                return json.loads(line[len("data: "):])
+    seen_event_types: list[str] = []
+    try:
+        async for chunk in resp.body_iterator:
+            for line in chunk.splitlines():
+                lines.append(line)
+                if line.startswith("event: "):
+                    seen_event_types.append(line[len("event: "):])
+                if line.startswith("data: ") and seen_event_types[-1:] == ["sync_status"]:
+                    return json.loads(line[len("data: "):])
+    finally:
+        await resp.body_iterator.aclose()
     raise AssertionError(f"sync_status frame not found in stream: {lines}")
-
-
-def _client_for(app):
-    from httpx import AsyncClient, ASGITransport
-    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
 
 
 @pytest.mark.anyio
 async def test_initial_connection_no_cursor():
     """진짜 최초접속(커서 자체 없음) → reason=no_cursor, complete=False."""
-    from app.main import app
-
     engine, Session = await _session_factory()
     try:
         seeded = await _seed(Session)
-        await _setup_app(app, Session, seeded["member_id"], seeded["org_id"])
-        client = _client_for(app)
-        try:
-            frame = await _read_sync_status_frame(client, "/api/v2/events/stream")
-            assert frame == {"complete": False, "reason": "no_cursor", "returned": 0}
-        finally:
-            await client.aclose()
+        frame = await _read_sync_status_frame(org_id=seeded["org_id"], member_id=seeded["member_id"])
+        assert frame == {"complete": False, "reason": "no_cursor", "returned": 0}
     finally:
-        app.dependency_overrides.clear()
         await engine.dispose()
 
 
 @pytest.mark.anyio
 async def test_cursor_not_found_reconnect():
     """커서는 보냈는데 DB에 없음(만료·GC됨) → reason=cursor_not_found(5건 아니라 50건 캡 경로)."""
-    from app.main import app
-
     engine, Session = await _session_factory()
     try:
         seeded = await _seed(Session)
-        await _setup_app(app, Session, seeded["member_id"], seeded["org_id"])
-        client = _client_for(app)
-        try:
-            missing_cursor = uuid.uuid4()
-            frame = await _read_sync_status_frame(
-                client, f"/api/v2/events/stream?last_event_id={missing_cursor}"
-            )
-            assert frame["reason"] == "cursor_not_found"
-            assert frame["complete"] is False
-        finally:
-            await client.aclose()
+        missing_cursor = uuid.uuid4()
+        frame = await _read_sync_status_frame(
+            org_id=seeded["org_id"], member_id=seeded["member_id"], last_event_id=missing_cursor,
+        )
+        assert frame["reason"] == "cursor_not_found"
+        assert frame["complete"] is False
     finally:
-        app.dependency_overrides.clear()
         await engine.dispose()
 
 
 @pytest.mark.anyio
 async def test_cursor_stale_over_threshold():
     """커서는 유효한데 300초 초과 → reason=cursor_stale."""
-    from app.main import app
-
     engine, Session = await _session_factory()
     try:
         seeded = await _seed(Session, with_stale_event=True)
-        await _setup_app(app, Session, seeded["member_id"], seeded["org_id"])
-        client = _client_for(app)
-        try:
-            frame = await _read_sync_status_frame(
-                client, f"/api/v2/events/stream?last_event_id={seeded['event_id']}"
-            )
-            assert frame["reason"] == "cursor_stale"
-            assert frame["complete"] is False
-        finally:
-            await client.aclose()
+        frame = await _read_sync_status_frame(
+            org_id=seeded["org_id"], member_id=seeded["member_id"], last_event_id=seeded["event_id"],
+        )
+        assert frame["reason"] == "cursor_stale"
+        assert frame["complete"] is False
     finally:
-        app.dependency_overrides.clear()
         await engine.dispose()
 
 
 @pytest.mark.anyio
 async def test_cursor_fresh_within_threshold_complete_true():
     """회귀 0: 커서 유효·300초 이내 → complete=True, reason=None(정상 캐치업)."""
-    from app.main import app
-
     engine, Session = await _session_factory()
     try:
         seeded = await _seed(Session, with_fresh_event=True)
-        await _setup_app(app, Session, seeded["member_id"], seeded["org_id"])
-        client = _client_for(app)
-        try:
-            frame = await _read_sync_status_frame(
-                client, f"/api/v2/events/stream?last_event_id={seeded['event_id']}"
-            )
-            assert frame == {"complete": True, "reason": None, "returned": 0}
-        finally:
-            await client.aclose()
+        frame = await _read_sync_status_frame(
+            org_id=seeded["org_id"], member_id=seeded["member_id"], last_event_id=seeded["event_id"],
+        )
+        assert frame == {"complete": True, "reason": None, "returned": 0}
     finally:
-        app.dependency_overrides.clear()
         await engine.dispose()
 
 
@@ -233,8 +214,6 @@ async def test_returned_reflects_actual_count_not_the_cap():
     다음·**개별 백필 이벤트 스트리밍 시작 前**에 나가는 건 맞지만, 그 시점은 이미 DB 쿼리가
     끝나 `pending_events` 리스트가 메모리에 있는 시점이다(라우터 코드: 쿼리 실행 → `sync_status`
     yield → 그 리스트를 배치로 스트리밍하는 순서). "스트리밍 시작 前"이지 "쿼리 前"이 아니다."""
-    from app.main import app
-
     engine, Session = await _session_factory()
     try:
         seeded = await _seed(Session)
@@ -250,22 +229,16 @@ async def test_returned_reflects_actual_count_not_the_cap():
                 ))
             await s.commit()
 
-        await _setup_app(app, Session, seeded["member_id"], seeded["org_id"])
-        client = _client_for(app)
-        try:
-            missing_cursor = uuid.uuid4()
-            frame = await _read_sync_status_frame(
-                client, f"/api/v2/events/stream?last_event_id={missing_cursor}"
-            )
-            assert frame["reason"] == "cursor_not_found"
-            assert frame["returned"] == 2, (
-                f"returned={frame['returned']} — 50(캡)이 찍혔으면 «상한»을 담고 있는 것이라 "
-                "이름이 거짓말인 버그. 실제 시드한 2건이 나와야 한다."
-            )
-        finally:
-            await client.aclose()
+        missing_cursor = uuid.uuid4()
+        frame = await _read_sync_status_frame(
+            org_id=seeded["org_id"], member_id=seeded["member_id"], last_event_id=missing_cursor,
+        )
+        assert frame["reason"] == "cursor_not_found"
+        assert frame["returned"] == 2, (
+            f"returned={frame['returned']} — 50(캡)이 찍혔으면 «상한»을 담고 있는 것이라 "
+            "이름이 거짓말인 버그. 실제 시드한 2건이 나와야 한다."
+        )
     finally:
-        app.dependency_overrides.clear()
         await engine.dispose()
 
 
@@ -275,25 +248,17 @@ async def test_degraded_reason_logged(caplog):
     셀 수 있게 되는 핵심 산출) — "코드 넣었다"가 아니라 로그가 실제로 나가는 것까지 확認."""
     import logging
 
-    from app.main import app
-
     engine, Session = await _session_factory()
     try:
         seeded = await _seed(Session)
-        await _setup_app(app, Session, seeded["member_id"], seeded["org_id"])
-        client = _client_for(app)
-        try:
-            with caplog.at_level(logging.INFO, logger="app.routers.events"):
-                missing_cursor = uuid.uuid4()
-                await _read_sync_status_frame(
-                    client, f"/api/v2/events/stream?last_event_id={missing_cursor}"
-                )
-            assert any(
-                "sse.backfill_degraded" in r.message and "cursor_not_found" in r.message
-                for r in caplog.records
-            ), [r.message for r in caplog.records]
-        finally:
-            await client.aclose()
+        with caplog.at_level(logging.INFO, logger="app.routers.events"):
+            missing_cursor = uuid.uuid4()
+            await _read_sync_status_frame(
+                org_id=seeded["org_id"], member_id=seeded["member_id"], last_event_id=missing_cursor,
+            )
+        assert any(
+            "sse.backfill_degraded" in r.message and "cursor_not_found" in r.message
+            for r in caplog.records
+        ), [r.message for r in caplog.records]
     finally:
-        app.dependency_overrides.clear()
         await engine.dispose()


### PR DESCRIPTION
## 요약
무효 커서(만료·GC됨)나 300초 초과 재연결이 캡(50/100/5)에 걸려 과거를 못 채워도, 클라이언트에게 "못 따라잡았다"는 신호가 전혀 없었다 — 서버는 정상 응답처럼 조용히 일부만 돌려줬다(story #2201).

신호 설계 자체는 이전 논의에서 이미 확定됐다(전용 이벤트 타입 · reason 3종 · 동작 불변 · 계약 안전 heartbeat 실증). 이 PR은 그 설계의 BE 구현이다.

## 신호
```
event: sync_status
data: {"complete": bool, "reason": "no_cursor"|"cursor_not_found"|"cursor_stale"|null, "returned": N}
```
- heartbeat 다음, backfill 이벤트 스트리밍 시작 前에 보낸다. ⛔헤더/heartbeat 메타엔 못 싣는다 — heartbeat이 이 판정 前에 이미 나가 헤더를 flush한다(hang 방지 설계, 이 스토리에서 손대지 않음).
- reason 3종: `no_cursor`(진짜 최초접속) · `cursor_not_found`(커서는 보냈는데 DB에 없음) · `cursor_stale`(커서는 유효한데 300초 초과). 뒤 두 개가 **같은 50건 캡 경로로 수렴**하는 것을 #2201 조사에서 이미 확認 — 이번 PR은 그 판정 정보를 호출부에서 옆에 붙이기만 한다.

## ⛔동작 불변
`_compute_backfill_mode()`의 시그니처·반환값은 손대지 않았다 — 50/100/5 캡 그대로. `test_s6_1_sse_backfill.py` 26건 그대로 통과로 확認(무회귀).

## done-gate 로그
`cursor_not_found`·`cursor_stale`일 때만 `sse.backfill_degraded` 구조화 로그를 남긴다(gcloud logging read로 카운트 가능). `no_cursor`(정상 최초접속)는 제외 — 강등 "빈도"가 목적이지 최초접속 빈도가 아니다.

## 계약 안전(코드로 확認, 짐작 아님)
같은 엔드포인트가 이미 매초 `event: heartbeat`를 보내는데 FE(`use-chat-sse.ts`)는 "heartbeat" 리스너를 등록하지 않고도 정상 작동 중이다 — grep 0건으로 확認. 미등록 named event가 이 정확히 같은 스트림에서 이미 무해함을 실증하고 있다. MCP 브리지(`sse_bridge.py`)도 `event_type` 분기가 "heartbeat인지 아닌지"뿐이라 새 타입은 같은 일반 경로(dedup·ack 스케줄링 모두 id/recipient_seq 없으면 조용히 스킵)를 탄다.

## Test plan
- [x] `test_2201_sse_backfill_degraded_signal_realdb.py` — 5 tests, 실 PG + httpx 스트리밍 읽기
  - `no_cursor` → `{"complete": false, "reason": "no_cursor", "returned": 0}`
  - `cursor_not_found`(존재하지 않는 UUID) → reason 확認
  - `cursor_stale`(300초 초과 이벤트) → reason 확認
  - `cursor_fresh`(300초 이내) → `{"complete": true, "reason": null}` 회귀 0
  - done-gate 로그(`caplog`)가 `cursor_not_found` 시 실제로 찍히는 것 확認
- [x] `test_s6_1_sse_backfill.py` 26건 그대로 통과(동작 불변 확認)
- [x] `test_2158_sse_transient_replay.py`·`test_2158_transient_replay_gating.py`·`test_backfill_activity_events.py` 30건 그대로 통과(회귀 0)

## ⛔남은 것 — 디디 몫(BE 절반)의 나머지
1회 실측(신호가 실제로 dev에 나가는 것): 이 PR이 dev에 배포된 후, 무효 커서로 라이브 연결 1회 → `sync_status` 프레임 수신 확認 + `gcloud logging read`로 `sse.backfill_degraded` 로그 1건 확認. 화면(FE 소비)은 별도(미르코 lane).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>