### PR TITLE
[SID:2201] SSE backfill 강등 신호(sync_status) FE 소비 — notification-bell 배너

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1712,7 +1712,8 @@
     "emptyStory": "No story notifications",
     "emptySystem": "No system notifications",
     "daysAgo": "d ago",
-    "bellAriaLabelCount": "{count} notifications"
+    "bellAriaLabelCount": "{count} notifications",
+    "syncDegradedBanner": "Some older notifications may be missing"
   },
   "invite": {
     "title": "Organization Invitation",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1713,7 +1713,7 @@
     "emptySystem": "No system notifications",
     "daysAgo": "d ago",
     "bellAriaLabelCount": "{count} notifications",
-    "syncDegradedBanner": "Some older notifications may be missing"
+    "syncDegradedBanner": "Some older notifications may be missing — check the list below"
   },
   "invite": {
     "title": "Organization Invitation",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1713,7 +1713,7 @@
     "emptySystem": "시스템 알림이 없습니다",
     "daysAgo": "일 전",
     "bellAriaLabelCount": "알림 {count}개",
-    "syncDegradedBanner": "일부 지난 알림은 표시되지 않았습니다"
+    "syncDegradedBanner": "일부 지난 알림은 표시되지 않았습니다 — 아래 목록에서 확인할 수 있습니다"
   },
   "invite": {
     "title": "조직 초대",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1712,7 +1712,8 @@
     "emptyStory": "스토리 알림이 없습니다",
     "emptySystem": "시스템 알림이 없습니다",
     "daysAgo": "일 전",
-    "bellAriaLabelCount": "알림 {count}개"
+    "bellAriaLabelCount": "알림 {count}개",
+    "syncDegradedBanner": "일부 지난 알림은 표시되지 않았습니다"
   },
   "invite": {
     "title": "조직 초대",

--- a/apps/web/src/components/nav/notification-bell.test.tsx
+++ b/apps/web/src/components/nav/notification-bell.test.tsx
@@ -170,3 +170,70 @@ describe('NotificationBell — 더 보기(story #2192 AC3/AC4)', () => {
     expect(desktopPanel.querySelectorAll('ul li')).toHaveLength(36); // 30(API) + 1(SSE) + 5(API 2페이지)
   });
 });
+
+// story #2201 — BE(PR #2554)가 emit하는 `sync_status` 프레임을 받아 배너를 띄우는지 검증.
+// AC5(회귀 가드): 커서가 무효/캡에 걸린 상태(complete:false, reason≠no_cursor)를 재현했을 때만
+// 배너가 뜨는 것 — 정상 커서로만 도는 테스트는 이 결함을 못 잡는다(AC5 명시 요구사항).
+describe('NotificationBell — sync_status 배너(story #2201)', () => {
+  function emitSyncStatus(data: { complete: boolean; reason: string | null; returned: number }) {
+    const es = FakeEventSource.instances[0]!;
+    return act(async () => { es.emit('sync_status', data); });
+  }
+
+  it('강등(cursor_stale)이면 배너가 뜬다', async () => {
+    FakeEventSource.instances = [];
+    vi.stubGlobal('EventSource', FakeEventSource);
+    stubFetchSequenceByOffset({ 0: { items: [], hasMore: false } });
+    await openBell();
+
+    await emitSyncStatus({ complete: false, reason: 'cursor_stale', returned: 5 });
+
+    expect(container.textContent).toContain('일부 지난 알림은 표시되지 않았습니다');
+  });
+
+  it('강등(cursor_not_found)이면 배너가 뜬다', async () => {
+    FakeEventSource.instances = [];
+    vi.stubGlobal('EventSource', FakeEventSource);
+    stubFetchSequenceByOffset({ 0: { items: [], hasMore: false } });
+    await openBell();
+
+    await emitSyncStatus({ complete: false, reason: 'cursor_not_found', returned: 50 });
+
+    expect(container.textContent).toContain('일부 지난 알림은 표시되지 않았습니다');
+  });
+
+  it('음성대조 — no_cursor(최초 연결)는 배너가 안 뜬다(오르테가군 확定: 강등이 아니라 정상 최초상태)', async () => {
+    FakeEventSource.instances = [];
+    vi.stubGlobal('EventSource', FakeEventSource);
+    stubFetchSequenceByOffset({ 0: { items: [], hasMore: false } });
+    await openBell();
+
+    await emitSyncStatus({ complete: false, reason: 'no_cursor', returned: 0 });
+
+    expect(container.textContent).not.toContain('일부 지난 알림은 표시되지 않았습니다');
+  });
+
+  it('음성대조 — complete:true(정상 완결)면 배너가 안 뜬다', async () => {
+    FakeEventSource.instances = [];
+    vi.stubGlobal('EventSource', FakeEventSource);
+    stubFetchSequenceByOffset({ 0: { items: [], hasMore: false } });
+    await openBell();
+
+    await emitSyncStatus({ complete: true, reason: null, returned: 12 });
+
+    expect(container.textContent).not.toContain('일부 지난 알림은 표시되지 않았습니다');
+  });
+
+  it('강등 배너가 뜬 뒤 재연결로 정상 sync_status가 오면 자동으로 걷힌다(별도 dismiss 없음, 스펙 그대로)', async () => {
+    FakeEventSource.instances = [];
+    vi.stubGlobal('EventSource', FakeEventSource);
+    stubFetchSequenceByOffset({ 0: { items: [], hasMore: false } });
+    await openBell();
+
+    await emitSyncStatus({ complete: false, reason: 'cursor_stale', returned: 5 });
+    expect(container.textContent).toContain('일부 지난 알림은 표시되지 않았습니다');
+
+    await emitSyncStatus({ complete: true, reason: null, returned: 8 });
+    expect(container.textContent).not.toContain('일부 지난 알림은 표시되지 않았습니다');
+  });
+});

--- a/apps/web/src/components/nav/notification-bell.tsx
+++ b/apps/web/src/components/nav/notification-bell.tsx
@@ -123,6 +123,21 @@ async function fetchNotifications(projectId?: string, offset = 0): Promise<Notif
   return { items: [], hasMore: false };
 }
 
+// story #2201 — PR #2554(BE) 계약. `returned`는 캡이 아니라 실제 전송 건수(디디군이 테스트로
+// 못박음) — 이 훅은 판정에 안 쓴다(complete/reason만으로 충분). no_cursor는 "최초 연결"이라
+// 강등이 아니다 — 제외한다(오르테가군 확定).
+interface SseSyncStatus {
+  complete: boolean;
+  reason: 'no_cursor' | 'cursor_not_found' | 'cursor_stale' | null;
+  returned: number;
+}
+
+function isSyncDegraded(data: SseSyncStatus): boolean {
+  return !data.complete && data.reason !== null && data.reason !== 'no_cursor';
+}
+
+const SYNC_STATUS_EVENT_NAMES = ['sync_status'];
+
 async function fetchUnreadCount(projectId?: string): Promise<number> {
   const params = projectId ? `?project_id=${projectId}` : '';
   // story #2160 — 30초 폴링이 401을 조용히 삼키던 자리(fetchWithAuth로 전환).
@@ -150,6 +165,8 @@ interface NotificationPanelProps {
   hasMore: boolean;
   loadingMore: boolean;
   onLoadMore: () => void;
+  // story #2201 — SSE backfill이 커서 무효/캡으로 강등됐을 때만 true(no_cursor는 제외).
+  syncDegraded: boolean;
 }
 
 function NotificationPanel({
@@ -160,6 +177,7 @@ function NotificationPanel({
   hasMore,
   loadingMore,
   onLoadMore,
+  syncDegraded,
 }: NotificationPanelProps) {
   const t = useTranslations('inbox');
   const tCommon = useTranslations('common');
@@ -206,6 +224,14 @@ function NotificationPanel({
           </button>
         </div>
       </div>
+
+      {/* story #2201 — SSE backfill이 강등된 연결에서만 뜨는 옅은 회색 한 줄. no_cursor(최초
+          연결)는 제외 — "일부 유실"이 아니라 "아직 아무것도 안 받은 정상 상태"이기 때문. */}
+      {syncDegraded && (
+        <div className="shrink-0 border-b bg-muted/50 px-4 py-1.5 text-xs text-muted-foreground">
+          {t('syncDegradedBanner')}
+        </div>
+      )}
 
       {/* 필터 탭 */}
       <div className="focus-inset flex shrink-0 overflow-x-auto border-b">
@@ -334,6 +360,9 @@ export function NotificationBell() {
   // prepend가 "더 보기" 다음 페이지 경계를 밀려나게 만들어 중복/누락이 생긴다).
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
+  // story #2201 — SSE backfill이 강등된 채로 도착했을 때만 true. 재연결로 sync_status가
+  // 다시 오면(complete:true거나 no_cursor) 자동으로 걷힌다 — 별도 dismiss 없음(스펙 그대로).
+  const [syncDegraded, setSyncDegraded] = useState(false);
   const offsetRef = useRef(0);
   const containerRef = useRef<HTMLDivElement>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -371,7 +400,21 @@ export function NotificationBell() {
     }
   }, [t]);
 
-  useSseNotifications({ onNotification: handleSseNotification, memberId: currentTeamMemberId });
+  // story #2201 — sync_status는 SseEventNotification 계약과 무관한 별도 이벤트라
+  // extraEventNames/onExtraEvent로 구독한다(핸들러 파이프라인을 안 건드림).
+  const handleSyncStatus = useCallback((eventName: string, data: unknown) => {
+    if (eventName !== 'sync_status') return;
+    const parsed = data as Partial<SseSyncStatus>;
+    if (typeof parsed.complete !== 'boolean') return;
+    setSyncDegraded(isSyncDegraded(parsed as SseSyncStatus));
+  }, []);
+
+  useSseNotifications({
+    onNotification: handleSseNotification,
+    memberId: currentTeamMemberId,
+    extraEventNames: SYNC_STATUS_EVENT_NAMES,
+    onExtraEvent: handleSyncStatus,
+  });
 
   // unread count 폴링 (30초 — SSE 실패 보완)
   useEffect(() => {
@@ -512,6 +555,7 @@ export function NotificationBell() {
             hasMore={hasMore}
             loadingMore={loadingMore}
             onLoadMore={() => void handleLoadMore()}
+            syncDegraded={syncDegraded}
           />
         </div>
       )}
@@ -534,6 +578,7 @@ export function NotificationBell() {
             hasMore={hasMore}
             loadingMore={loadingMore}
             onLoadMore={() => void handleLoadMore()}
+            syncDegraded={syncDegraded}
           />
         </div>
       )}


### PR DESCRIPTION
## 요약
- BE(PR #2554)가 emit하는 `sync_status` 프레임(`{complete, reason, returned}`)을 `notification-bell.tsx`에서 구독
- 커서가 무효(`cursor_not_found`)이거나 캡(`cursor_stale`)에 걸려 backfill이 불완전할 때만 패널 최상단에 옅은 회색 한 줄 배너 표시
- 문안: "일부 지난 알림은 표시되지 않았습니다 — 아래 목록에서 확인할 수 있습니다"(en: "Some older notifications may be missing — check the list below")
- `no_cursor`(최초 연결)는 강등이 아니라 정상 최초상태라 제외(오르테가군 확定)

## ⭐제품 물음에 대한 코드 근거 답변 — "이 문안이 다음 발을 주는가"
오르테가군 질문: 이 문안을 읽은 사용자가 그 지난 알림을 실제로 볼 방법이 있는가?

**코드 확認 결과: ㉠(있다) — 같은 패널 안에서.**
- `event_notifications.py`(BE, `/api/v2/event-notifications` 목록)와 `events.py`(BE, SSE `sync_status`가 나오는 backfill 스트림) **둘 다 같은 `Event` 테이블**을 조회한다(`select(Event)` — grep 확認)
- SSE backfill만 5/50/100 캡이 있고, 패널 자신의 REST 목록 fetch(`fetchNotifications`, 패널 open마다 실행)는 그 캡과 무관하게 페이지네이션으로 전량 접근 가능(#2192/#2231에서 이미 완결된 "더 보기" 경로 재사용)
- ⇒ 인박스(`/api/notifications`, 별개의 `Notification` 테이블)로 보낼 필요가 없다 — 오히려 그쪽은 다른 원천이라 틀린 안내가 됐을 것. **정정된 문안은 "아래 목록"(=같은 패널)을 가리킨다.**

## 라이브 픽셀 검증 절차 (배포 後, 디디군과 함께)
```
① 유발 방법 — 실제 사용자가 겪는 경로: 탭을 300초 넘게 백그라운드/절전에 둬 SSE가 끊기게
   한 뒤 포그라운드 복귀로 재연결(cursor_stale 유도). 인위적으로 오래된 last_event_id를
   꾸며 붙이는 방식이 아니라 이쪽을 우선 시도.
② 확인 위치 — 배너는 패널 내부(NotificationPanel)에만 있다. 종 아이콘 자체엔 안 뜬다 —
   반드시 벨을 클릭해 패널을 열어야 보인다.
③ 통과선 — 둘 다 봐야 통과:
   · cursor_stale/cursor_not_found로 재연결 시 배너가 뜨는 것
   · no_cursor(최초 연결, 새 탭/시크릿)로 재연결 시 배너가 안 뜨는 것
   ⛔뜨는 것만 확인하면 "항상 뜨는" 것과 구분이 안 된다 — 반드시 두 케이스 다 확인.
④ ⭐관찰 항목(오르테가군 지적, 지금 고치지 않음) — 배너 잔존 시간
   코드 확認: `syncDegraded` state는 NotificationBell(부모) 레벨에 있고 패널 open/close로
   리셋되지 않는다(다음 sync_status 프레임이 와야만 바뀜) — 즉 패널을 닫았다 다시 열어도
   배너가 그대로 남을 것으로 예측된다. 이때 목록 자체는 이미 REST로 완전히 새로 받은
   상태(③에서 확認)라 "일부 표시되지 않았습니다"가 실시간 경로 기준으로는 맞는 말이지만
   "지금 이 목록" 기준으로는 낡은 말처럼 보일 수 있다. 라이브에서 이 잔존 시간을 눈으로
   보고 판단(코드 수정 여부는 이번 PR 스코프 밖, 관찰만).
```

## 구현
- `useSseNotifications`의 기존 `extraEventNames`/`onExtraEvent` 확장 지점 재사용 — 신규 SSE 배선 없음(mux 경로/standalone 폴백 경로 둘 다 자동 커버)
- `isSyncDegraded(data)` 순수함수로 판정 로직 분리
- 재연결로 정상 `sync_status`(complete:true 또는 no_cursor)가 오면 배너 자동 해제 — 별도 dismiss 버튼 없음(스펙 그대로)

## AC 대조
1. 조용한 강등 제거 — 배너로 사용자에게 노출 + 다음 발(같은 패널에서 확인 가능) 명시 ✅
2. 신호+소비 동시 배선 — 이 PR이 소비 쪽(BE #2554가 신호 쪽) ✅
3. 캡 숫자 미변경 — FE만 작업, BE 로직 무변경 ✅
4. 세 경로(정상/캡/무효커서) 각각 테스트 — 5건 회귀가드로 커버 ✅
5. 회귀 가드(무효 커서 재현 테스트) — 있음, 뮤테이션 자가검증까지 완료(아래) ✅
6. #2197과 동시 작업 금지 — #2197은 이미 done 상태 확認 후 착수 ✅
7. 못 잡는 것 명시 — 이미 GC된 이벤트 구간은 이 스토리가 복구 못함(BE 스토리 경계, FE도 동일 한계 상속)

## 테스트
- 신규 5건: 강등 2종(cursor_not_found·cursor_stale) 표시 / 정상 2종(no_cursor·complete:true) 음성대조 / 재연결 시 자동 해제
- **뮤테이션 자가검증**: `isSyncDegraded`에서 `no_cursor` 제외 조건을 일부러 제거 → 해당 음성대조 테스트가 RED로 떨어지는 것 확認 → 원복 → 전체 GREEN 재확認

## 게이트
- `pnpm run type-check` EXIT 0
- `pnpm run lint` — 0 errors (기존 무관 warning 5건만, 본 PR 파일 무관)
- `pnpm run build` EXIT 0
- `pnpm exec vitest run` — 289 files / 1934 tests 전부 PASS

## 머지 순서
⛔#2554(BE) → #2555(FE) 순. #2554는 까심군이 hang 하나를 조사 중이라 대기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
