### PR TITLE
[SID:2247] stories.list_activities에 규약A 적용 — FE 더보기가 처음으로 도는 자리

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -1491,21 +1491,42 @@ async def add_comment(
 
 # ─── Activities ───────────────────────────────────────────────────────────────
 
-@router.get("/{id}/activities", response_model=list[ActivityResponse])
+@router.get("/{id}/activities")
 async def list_activities(
     id: uuid.UUID,
     limit: int = Query(default=20, le=100),
+    cursor: str | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
     repo: StoryRepository = Depends(_get_repo),
     auth: AuthContext = Depends(get_current_user),
-) -> list[ActivityResponse]:
+) -> dict:
+    """story #2247: FE(story-detail-panel.tsx)의 「더보기」가 이미 완결돼 기다리고 있었는데
+    이 엔드포인트에 cursor 자체가 없어 원천적으로 도달 불가였다(#2231 표 CAPPED-NO-NEXT-PAGE).
+    #2231 정본 규약 A(limit+1 오버페치 + has_more/next_cursor body meta, 참조 구현:
+    stories.py::list_comments — #2230에서 이미 같은 처방을 받은 형제 엔드포인트)로 도달 가능하게 한다.
+    """
     # SEC(story #2206) — list_comments(1339)와 동형 갭·동형 처방. 자세한 사유는 그쪽 주석 참조.
     story = await repo.get(id)
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")
     await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
-    q = select(StoryActivity).where(
-        StoryActivity.story_id == id,
-    ).order_by(StoryActivity.created_at.desc()).limit(limit)
+    q = select(StoryActivity).where(StoryActivity.story_id == id)
+    # #2540 CI 교훈(오르테가군): "값이 있는지"만 보면 안 되고 "그 값이 문자열인지"까지 봐야
+    # 한다 — 이 함수를 FastAPI DI 없이 직접 호출하며 cursor= 를 누락하면 파이썬 기본값인
+    # Query(...) 센티넬 객체(truthy) 가 그대로 들어온다. 문자열이 아니면 커서 없음으로 취급.
+    if isinstance(cursor, str) and cursor:
+        try:
+            cursor_dt = datetime.fromisoformat(cursor)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid cursor format")
+        q = q.where(StoryActivity.created_at < cursor_dt)
+    q = q.order_by(StoryActivity.created_at.desc()).limit(limit + 1)
     result = await db.execute(q)
-    return [ActivityResponse.model_validate(r) for r in result.scalars()]
+    rows = list(result.scalars())
+    has_more = len(rows) > limit
+    page = rows[:limit]
+    next_cursor = page[-1].created_at.isoformat() if has_more and page else None
+    return {
+        "data": [ActivityResponse.model_validate(r) for r in page],
+        "meta": {"has_more": has_more, "next_cursor": next_cursor},
+    }

--- a/backend/tests/test_2247_story_activities_cursor_pagination_realdb.py
+++ b/backend/tests/test_2247_story_activities_cursor_pagination_realdb.py
@@ -1,0 +1,204 @@
+"""story #2247 — GET /api/v2/stories/{id}/activities 에 cursor 파라미터 자체가 없어
+FE(story-detail-panel.tsx)의 「더보기」(핸들러+버튼 전부 이미 완성)가 원천적으로 도달
+불가였다(#2231 표 CAPPED-NO-NEXT-PAGE). #2231 정본 규약 A(limit+1 오버페치 +
+has_more/next_cursor body meta, 참조 구현: stories.py::list_comments — #2230)를
+적용해 실제로 동작하게 한다. #2231 AC3(적용 엔드포인트 realdb 2페이지 «다름» 검증)의
+검증 책임이 이 스토리로 왔다 — 아래 테스트가 그 책임을 진다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("d2247000-0000-0000-0000-000000000010")
+PROJ = uuid.UUID("d2247000-0000-0000-0000-000000000011")
+STORY = uuid.UUID("d2247000-0000-0000-0000-000000000012")
+AUTHOR_USER = uuid.UUID("d2247000-0000-0000-0000-000000000013")
+AUTHOR_MEMBER = uuid.UUID("d2247000-0000-0000-0000-000000000014")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(AUTHOR_USER), email=None,
+        claims={"app_metadata": {"org_id": str(ORG)}},
+        org_id=str(ORG),
+    )
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _clean(s):
+    for sql in [
+        f"DELETE FROM story_activities WHERE org_id='{ORG}'",
+        f"DELETE FROM stories WHERE id='{STORY}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE id='{PROJ}'",
+        f"DELETE FROM users WHERE id='{AUTHOR_USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _seed(s, n: int) -> list[uuid.UUID]:
+    await _clean(s)
+    await s.execute(text(f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','O','d2247-org','free')"))
+    await s.execute(text(
+        f"INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{AUTHOR_USER}','d2247@d2247.test','x','D2247',true,true,0,false,0)"
+    ))
+    await s.execute(text(f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ}','{ORG}','P2247')"))
+    await s.execute(text(
+        f"INSERT INTO members (id,org_id,user_id,type,name,is_active) VALUES "
+        f"('{AUTHOR_MEMBER}','{ORG}','{AUTHOR_USER}','human','D2247',true)"
+    ))
+    await s.execute(text(
+        f"INSERT INTO project_access (id,project_id,member_id,role,permission) VALUES "
+        f"(gen_random_uuid(),'{PROJ}','{AUTHOR_MEMBER}','member','granted')"
+    ))
+    await s.execute(text(
+        f"INSERT INTO stories (id,org_id,project_id,title,status) VALUES "
+        f"('{STORY}','{ORG}','{PROJ}','S','backlog')"
+    ))
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    ids = []
+    for i in range(n):
+        aid = uuid.uuid4()
+        ids.append(aid)
+        created_at = base + timedelta(seconds=i)
+        await s.execute(text(
+            f"INSERT INTO story_activities (id,org_id,story_id,project_id,activity_type,"
+            f"old_value,new_value,created_by,created_at) VALUES "
+            f"('{aid}','{ORG}','{STORY}','{PROJ}','status_changed','backlog','in-progress',"
+            f"'{AUTHOR_MEMBER}','{created_at.isoformat()}')"
+        ))
+    await s.commit()
+    return list(reversed(ids))  # newest-first, matches server ORDER BY created_at DESC
+
+
+@pytest.mark.anyio
+async def test_second_page_returns_different_rows_realdb():
+    from app.routers.stories import list_activities
+    from app.repositories.story import StoryRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            newest_first = await _seed(s, n=5)
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            page1 = await list_activities(id=STORY, limit=2, cursor=None, db=s, repo=repo, auth=_auth())
+        assert [a.id for a in page1["data"]] == newest_first[0:2]
+        assert page1["meta"]["has_more"] is True
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            page2 = await list_activities(
+                id=STORY, limit=2, cursor=page1["meta"]["next_cursor"], db=s, repo=repo, auth=_auth(),
+            )
+        page2_ids = [a.id for a in page2["data"]]
+        assert page2_ids == newest_first[2:4], "page2가 page1과 다른 행을 반환해야 한다(#2231 AC3 본체)"
+        assert not (set(page2_ids) & {a.id for a in page1["data"]})
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            page3 = await list_activities(
+                id=STORY, limit=2, cursor=page2["meta"]["next_cursor"], db=s, repo=repo, auth=_auth(),
+            )
+        assert [a.id for a in page3["data"]] == newest_first[4:5]
+        assert page3["meta"]["has_more"] is False
+        assert page3["meta"]["next_cursor"] is None
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_cursor_under_limit_has_more_false_realdb():
+    from app.routers.stories import list_activities
+    from app.repositories.story import StoryRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, n=3)
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            page = await list_activities(id=STORY, limit=20, cursor=None, db=s, repo=repo, auth=_auth())
+        assert [a.id for a in page["data"]] == seeded
+        assert page["meta"]["has_more"] is False
+        assert page["meta"]["next_cursor"] is None
+    finally:
+        await eng.dispose()
+
+
+class _FakeQuerySentinel:
+    """#2540 CI 재현(오르테가군) — FastAPI Query(...) 객체처럼 str이 아니면서 truthy인 것을
+    흉내낸다. list_activities를 FastAPI DI 없이 직접 호출하며 cursor= 를 누락하면 실제로
+    이런 모양의 객체(파이썬 함수 기본값)가 들어온다."""
+    default = None
+
+
+@pytest.mark.anyio
+async def test_non_string_truthy_cursor_treated_as_no_cursor_not_crash_realdb():
+    from app.routers.stories import list_activities
+    from app.repositories.story import StoryRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, n=3)
+
+        fake_sentinel = _FakeQuerySentinel()
+        assert bool(fake_sentinel) is True  # 전제 확인 — truthy임
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            page = await list_activities(id=STORY, limit=20, cursor=fake_sentinel, db=s, repo=repo, auth=_auth())
+        assert [a.id for a in page["data"]] == seeded, "커서 없음으로 취급돼 전체가 나와야 한다(크래시 아님)"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_invalid_cursor_format_400_realdb():
+    from app.routers.stories import list_activities
+    from app.repositories.story import StoryRepository
+    from fastapi import HTTPException
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s, n=1)
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            with pytest.raises(HTTPException) as ei:
+                await list_activities(id=STORY, limit=20, cursor="not-a-date", db=s, repo=repo, auth=_auth())
+            assert ei.value.status_code == 400
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
⛔**머지 보류 — develop 프리즈 중(승격 delta 확定까지, 오르테가군 지시).** PR만 올림.

## 요약
FE(`story-detail-panel.tsx`)의 "더보기"(핸들러+버튼+`parseCursorMeta` 전부 이미 완성, #2231 AC4)는 있었는데 BE `stories.py::list_activities`에 `cursor` 자체가 없어 원천적으로 도달 불가였다(#2231 표 CAPPED-NO-NEXT-PAGE, ㉯✗). 참조 구현 `stories.py::list_comments`(#2230에서 이미 같은 처방을 받은 형제 엔드포인트, #2231 정본 규약 A)를 그대로 재사용 — 새 모양 발명 0.

## 구현
- `limit+1` 오버페치 + `{"data": [...], "meta": {"has_more", "next_cursor"}}` 봉투
- `#2540` 교훈 반영 — `isinstance(cursor, str) and cursor`로 FastAPI DI 없는 직접호출 시 truthy 센티넬 크래시 방지
- `response_model=list[ActivityResponse]` 제거(응답 형태가 dict로 바뀌므로) — `list_comments`와 동일 패턴
- FE 코드 변경 없음(설계대로) — BE가 규약A를 내는 순간 기존 FE 배선이 그대로 동작

## #2231 AC3 검증 (적용 엔드포인트 realdb 2페이지 «다름» — 200 갈음 금지)
신규 realdb 테스트 4건, 격리된 throwaway Postgres(`pgvector/pgvector:pg15`, `alembic upgrade head`)로 검증:
- `test_second_page_returns_different_rows_realdb` — **본체**. page1/page2/page3가 실제로 다른 행을 반환하는 것 확認
- `test_no_cursor_under_limit_has_more_false_realdb`
- `test_non_string_truthy_cursor_treated_as_no_cursor_not_crash_realdb`(#2540 재현)
- `test_invalid_cursor_format_400_realdb`

**뮤테이션 자가검증**: cursor 필터를 일부러 비활성화 → `test_second_page_returns_different_rows_realdb`가 "page2가 page1과 다른 행을 반환해야 한다(#2231 AC3 본체)" 메시지로 RED 확認 → 원복 → 10건 전부 GREEN 재확認.

## 회귀 확認
`test_2206_story_comments_activities_org_scope_realdb.py`(cross-org 404 가드) + `test_2230_story_comments_cursor_pagination_realdb.py`(형제 엔드포인트) 재실행 — 회귀 0. `-k 'stories or 2247 or 2230 or 2206'` 스윕 76건 전부 PASS.

## 게이트
- realdb pytest: 10/10 PASS(신규 4 + 회귀 6)
- 스윕: 76/76 PASS
- FE 변경 없음 — type-check/lint/build/vitest 대상 아님

## 남은 것
- FE 라이브 픽셀(패널 "더보기" 버튼이 DOM에 처음 뜨는 것 + 클릭 시 추가 활동 로드)은 배포 후 확認(#2231 AC3 FE측 companion, #2201과 동일 패턴)
- `pagination-envelope-consumers.test.ts` allowlist의 이 자리 console.error 소거 확認도 배포 후

🤖 Generated with [Claude Code](https://claude.com/claude-code)