### PR TITLE
fix(#2260/C-2): stop hardcoding target_type in the chat mention write-path

### DIFF
--- a/backend/app/services/mention_parser.py
+++ b/backend/app/services/mention_parser.py
@@ -1,12 +1,13 @@
 """story #1993(E-KNOWLEDGE-LINK S1) — mentions write-path 파서. 근본 설계 doc
 design-org-knowledge-mentions-backlinks §2.
 
-두 개의 독립된 순수 추출 함수 + 두 개의 DB write 헬퍼로 구성된다:
+순수 추출 함수 + DB write 헬퍼로 구성된다:
 
-  · `extract_chat_doc_mention_ids` — 채팅 메시지 content 에서 `[title](entity:doc:<uuid>)`
+  · `extract_chat_entity_mentions` — 채팅 메시지 content 에서 `[title](entity:<type>:<uuid>)`
     토큰(FE `apps/web/src/components/chat/chat-input.tsx` applyEntity 가 만드는 정확한 포맷 —
-    `#` 트리거 검색 결과 선택 시 삽입)을 정규식으로 추출한다. 채팅 메시지는 수정 불가 전제라
-    파서도 매번 전체를 새로 파싱해 insert-only 로 쓴다(재조정 불필요).
+    `#` 트리거 검색 결과 선택 시 삽입)을 (entity_type, id) 쌍으로 **전부** 추출한다. 채팅
+    메시지는 수정 불가 전제라 파서도 매번 전체를 새로 파싱해 insert-only 로 쓴다(재조정 불필요).
+  · `extract_chat_doc_mention_ids` — 위의 doc-only 하위호환 래퍼(기존 호출부/테스트용).
   · `extract_doc_mention_ids` — doc content(HTML — tiptap `editor.getHTML()` 그대로 저장,
     content_format 무관하게 실제 마크업은 HTML)에서 wikiLink(`<span data-type="wikiLink"
     data-doc-id="...">`) 와 pageEmbed(`<div data-page-embed data-doc-id="...">`) 의
@@ -14,13 +15,16 @@ design-org-knowledge-mentions-backlinks §2.
     attribute 순서가 보장되지 않는다는 게 설계 doc 의 근거(mergeAttributes 가 만드는 순서는
     tiptap 내부 구현에 의존하므로 위치 기반 정규식은 취약).
 
-두 함수 모두 malformed 토큰(파싱 실패·잘못된 UUID)은 **조용히 스킵**한다 — 멘션 파싱 실패로
+추출 함수는 malformed 토큰(파싱 실패·잘못된 UUID)을 **조용히 스킵**한다 — 멘션 파싱 실패로
 본 메시지/문서 저장 전체가 실패하면 안 된다는 원칙(AC와 별개로, 파서 자체의 malformed-tolerance).
-자기참조(target doc == source doc)는 두 write 헬퍼가 공통으로 드롭한다.
+자기참조(target doc == source doc)는 doc write 헬퍼가 드롭한다.
 
-story/epic 멘션은 **파싱하지 않는다**(스키마 CHECK 는 여지를 열어두되 이번 스토리는 doc 만 —
-과확장 금지). 확장 시 `_CHAT_TOKEN_RE`의 `type` 그룹을 소비하는 분기만 추가하면 된다(현재는
-`doc` 타입만 필터링).
+⛔story #2260: **어떤 entity_type 이 지원되는지는 추출 함수의 관심사가 아니다** — 추출은
+`entity:<type>:<id>` 토큰을 있는 그대로 전부 뽑고, "지금 이 write-path 가 뭘 쓰기 허용하는가"는
+`insert_chat_mentions(target_types=...)` 파라미터가 결정한다(기본값 = `app.models.mention.
+TARGET_TYPES`, 스키마 CHECK 와 동일 SSOT). 새 타입을 열려면 스키마 CHECK + 그 기본값만 넓히면
+되고, 추출 함수나 write 헬퍼 몸통에 분기를 추가할 필요가 없다 — «메시지→문서만 되고
+메시지→스토리는 파서가 막는» 죽은 경로가 이 구조에서는 재발하지 않는다.
 
 기존 `mentioned_ids`(ConversationMessage 컬럼·멤버 알림용) 파이프라인은 이 모듈이 전혀
 참조하지 않는다 — 완전히 독립된 병행 경로.
@@ -35,7 +39,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
-from app.models.mention import Mention
+from app.models.mention import TARGET_TYPES, Mention
 from app.services.member_resolver import canonicalize_member_id
 
 _UUID_RE = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
@@ -48,26 +52,37 @@ _CHAT_TOKEN_RE = re.compile(
 )
 
 
-def extract_chat_doc_mention_ids(content: str) -> list[uuid.UUID]:
-    """채팅 메시지 content 에서 `entity:doc:<uuid>` 토큰의 doc id 를 순서 보존 + 중복 제거로 추출.
+def extract_chat_entity_mentions(content: str) -> list[tuple[str, uuid.UUID]]:
+    """채팅 메시지 content 에서 `entity:<type>:<uuid>` 토큰 전부를 (entity_type, id) 쌍으로,
+    순서 보존 + 중복 제거해 추출한다.
 
-    malformed(정규식 미매치·잘못된 UUID)는 자연히 스킵된다. story/epic 등 다른 entity type
-    토큰은 무시(doc 만 스코프)."""
+    ⛔story #2260: 어떤 entity_type 이 "지원되는지"는 이 함수의 관심사가 아니다 — 그 판단은
+    write-path 호출부가 target_types 로 내린다(추출/저장의 경계를 함수 시그니처로 옮김).
+    이 함수를 다시 열어 타입별 분기를 추가하는 일은 이제 없다(그러면 죽은 경로가 재발한다).
+
+    malformed(정규식 미매치·잘못된 UUID)는 자연히 스킵된다."""
     if not content:
         return []
-    seen: set[uuid.UUID] = set()
-    result: list[uuid.UUID] = []
+    seen: set[tuple[str, uuid.UUID]] = set()
+    result: list[tuple[str, uuid.UUID]] = []
     for m in _CHAT_TOKEN_RE.finditer(content):
-        if m.group("type") != "doc":
-            continue
+        entity_type = m.group("type")
         try:
-            doc_id = uuid.UUID(m.group("id"))
+            entity_id = uuid.UUID(m.group("id"))
         except (ValueError, AttributeError):
             continue
-        if doc_id not in seen:
-            seen.add(doc_id)
-            result.append(doc_id)
+        key = (entity_type, entity_id)
+        if key not in seen:
+            seen.add(key)
+            result.append(key)
     return result
+
+
+def extract_chat_doc_mention_ids(content: str) -> list[uuid.UUID]:
+    """`extract_chat_entity_mentions`의 doc-only 하위집합(하위호환 편의 래퍼) — 순서 보존.
+    ⛔새 호출부는 이 함수 대신 `extract_chat_entity_mentions`를 쓸 것(타입 필터링이 이미
+    걸려 있어 story #2260이 고친 문제를 다시 들여올 수 있다)."""
+    return [eid for etype, eid in extract_chat_entity_mentions(content) if etype == "doc"]
 
 
 class _DocMentionHTMLParser(HTMLParser):
@@ -129,13 +144,22 @@ async def insert_chat_mentions(
     message_id: uuid.UUID,
     content: str,
     created_by: uuid.UUID,
+    target_types: frozenset[str] = TARGET_TYPES,
 ) -> None:
-    """채팅 write-path: insert-only(메시지 불변 전제 — 재조정 불필요). 자기참조 개념이 없다
-    (source=chat_message, target=doc — 항상 다른 타입). 같은 트랜잭션(caller 의 세션 그대로
-    사용·별도 커밋 없음) — 실패 시 예외가 그대로 propagate 되어 caller(메시지 전송 트랜잭션)
-    전체가 롤백된다(AC4 원자성)."""
-    target_ids = extract_chat_doc_mention_ids(content)
-    if not target_ids:
+    """채팅 write-path: insert-only(메시지 불변 전제 — 재조정 불필요). 같은 트랜잭션(caller 의
+    세션 그대로 사용·별도 커밋 없음) — 실패 시 예외가 그대로 propagate 되어 caller(메시지 전송
+    트랜잭션) 전체가 롤백된다(AC4 원자성).
+
+    story #2260: target_type 은 본문에서 추출된 값을 그대로 쓴다(내부에서 결정하지 않는다) —
+    이 함수엔 entity type 리터럴이 하나도 없다. `target_types`는 **지금 이 write-path 가
+    실제로 쓰기를 허용하는 타입의 경계**(schema CHECK와 동일 SSOT, app.models.mention.
+    TARGET_TYPES)일 뿐 — 새 타입을 지원하려면 스키마 CHECK + 이 기본값만 넓히면 되고, 이
+    함수 몸통에 분기를 추가할 필요가 없다(대상 종류를 코드에 나열한 곳이 여기 없다는 뜻)."""
+    pairs = [
+        (etype, eid) for etype, eid in extract_chat_entity_mentions(content)
+        if etype in target_types
+    ]
+    if not pairs:
         return
     canonical_created_by = await canonicalize_member_id(created_by, db)
     stmt = pg_insert(Mention).values([
@@ -144,11 +168,11 @@ async def insert_chat_mentions(
             "org_id": org_id,
             "source_type": "chat_message",
             "source_id": message_id,
-            "target_type": "doc",
-            "target_id": target_id,
+            "target_type": entity_type,
+            "target_id": entity_id,
             "created_by": canonical_created_by,
         }
-        for target_id in target_ids
+        for entity_type, entity_id in pairs
     ])
     # UNIQUE(source_type, source_id, target_type, target_id) 방어 — insert-only 전제라 원칙적으로
     # 이 message_id 에 대한 기존 row 는 없지만(신규 메시지), 같은 메시지 안에 동일 doc 을 가리키는

--- a/backend/tests/test_2260_mention_target_type_not_hardcoded_realdb.py
+++ b/backend/tests/test_2260_mention_target_type_not_hardcoded_realdb.py
@@ -1,0 +1,179 @@
+"""story #2260(C-2) — 파서의 «대상 종류 하드코딩» 제거 실PG 검증.
+
+AC1 핵심: 「메시지 → 스토리」임베드가 실제로 만들어진다(죽은 경로였던 것 — 스키마 CHECK는
+이미 story/epic을 허용했지만 mention_parser.py가 doc으로만 필터링했다). 왕복(write→read)으로
+증명한다. AC2(하드코딩 리터럴 제거)는 이 테스트가 story/epic target_type 이 실제로 써지는
+것으로 간접 증명 — insert_chat_mentions 안에 target_type="doc" 리터럴이 남아 있었다면 이
+테스트들은 전부 실패했을 것이다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project_member(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.user import User
+    from app.models.member import Member
+
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.flush()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.flush()
+
+    member = Member(id=uuid.uuid4(), org_id=org.id, type="human", user_id=user.id, name="Test Human")
+    session.add(member)
+    await session.flush()
+
+    return org, project, member
+
+
+@pytest.mark.anyio
+async def test_chat_mention_to_story_round_trips():
+    """⭐AC1 핵심 — 메시지→스토리 임베드가 실제로 만들어지고 다시 읽힌다(죽은 경로 재현/해소)."""
+    from sqlalchemy import select
+
+    from app.models.mention import Mention
+    from app.services.mention_parser import insert_chat_mentions
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            await session.commit()
+
+            target_story_id = uuid.uuid4()
+            message_id = uuid.uuid4()
+            content = f"[관련 스토리](entity:story:{target_story_id})"
+
+            await insert_chat_mentions(
+                session, org_id=org.id, message_id=message_id, content=content,
+                created_by=member.id,
+            )
+            await session.commit()
+
+            rows = (
+                await session.execute(select(Mention).where(Mention.source_id == message_id))
+            ).scalars().all()
+            assert len(rows) == 1, (
+                "메시지→스토리 멘션이 저장되지 않았다 — insert_chat_mentions 안 어딘가에 "
+                "target_type이 다시 하드코딩됐을 가능성"
+            )
+            row = rows[0]
+            assert row.target_type == "story"
+            assert row.target_id == target_story_id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_chat_mention_to_epic_round_trips():
+    """같은 메시지에 doc·story·epic 세 종류가 섞여도 전부 저장된다 — 종류별 분기가 코드에 없다."""
+    from sqlalchemy import select
+
+    from app.models.mention import Mention
+    from app.services.mention_parser import insert_chat_mentions
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            await session.commit()
+
+            doc_id, story_id, epic_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+            message_id = uuid.uuid4()
+            content = (
+                f"[문서](entity:doc:{doc_id}) [스토리](entity:story:{story_id}) "
+                f"[에픽](entity:epic:{epic_id})"
+            )
+
+            await insert_chat_mentions(
+                session, org_id=org.id, message_id=message_id, content=content,
+                created_by=member.id,
+            )
+            await session.commit()
+
+            rows = (
+                await session.execute(select(Mention).where(Mention.source_id == message_id))
+            ).scalars().all()
+            got = {(r.target_type, r.target_id) for r in rows}
+            assert got == {("doc", doc_id), ("story", story_id), ("epic", epic_id)}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_target_types_param_is_the_boundary_not_a_body_branch():
+    """target_types 는 호출부가 내리는 경계값이다 — 좁히면 그 타입만 걸러진다(본문 안 분기가
+    아니라 시그니처 파라미터가 결정한다는 것을 직접 증명)."""
+    from sqlalchemy import select
+
+    from app.models.mention import Mention
+    from app.services.mention_parser import insert_chat_mentions
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            await session.commit()
+
+            doc_id, story_id = uuid.uuid4(), uuid.uuid4()
+            message_id = uuid.uuid4()
+            content = f"[문서](entity:doc:{doc_id}) [스토리](entity:story:{story_id})"
+
+            await insert_chat_mentions(
+                session, org_id=org.id, message_id=message_id, content=content,
+                created_by=member.id, target_types=frozenset({"doc"}),
+            )
+            await session.commit()
+
+            rows = (
+                await session.execute(select(Mention).where(Mention.source_id == message_id))
+            ).scalars().all()
+            got = {(r.target_type, r.target_id) for r in rows}
+            assert got == {("doc", doc_id)}, "target_types 로 좁혔는데 story가 새어 들어왔다"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 요약
「메시지 → 문서」는 되는데 「메시지 → 스토리」는 파서가 대상 종류를 `"doc"`로 하드코딩해서 죽은 경로였다. `Mention` 모델 CHECK 제약은 이미 `target_type IN ('doc','story','epic')`을 허용하는데, 애플리케이션 코드(`mention_parser.py`)가 그중 `doc`만 통과시켰던 것.

## 처방 (PO 지시 반영 — 값을 「경계」로 올림)
- `extract_chat_entity_mentions(content) -> list[(entity_type, id)]` — 타입 필터링 없는 순수 추출 함수 신설(기존 `extract_chat_doc_mention_ids`는 doc-only 하위호환 래퍼로 유지, 기존 호출부/테스트 무변경).
- `insert_chat_mentions(..., target_types: frozenset[str] = Mention.TARGET_TYPES)` — 저장 헬퍼 **몸통 안에 타입 리터럴이 하나도 없다**. 새 타입 지원 시 스키마 CHECK + 이 SSOT 기본값만 넓히면 되고, 분기를 추가할 필요가 없다.
- 이렇게 고치면 #2259(참조 1급 신설)가 저장 몸통을 새 모델로 통째로 갈아 끼워도 이 계약(파서→시그니처 경계)은 그대로 산다 — 저장층 안에서 고쳤다면 #2259 때 다시 손이 가는 코드가 됐을 것.

## 스윕 범위 선언(AC3)
`app/services`·`app/routers` 전체에서 `"target_type": "<literal>"`/`"source_type": "<literal>"` 딕셔너리 리터럴 패턴 grep — `mention_parser.py` 딱 한 파일만 걸림:
- ㉠(대상 종류 박힘): 채팅 경로(`extract_chat_doc_mention_ids`/`insert_chat_mentions`) — **이번에 고침**.
- ㉠(대상 종류 박힘, 남은 것): doc-content 경로(`reconcile_doc_mentions`)도 `target_type="doc"` 하드코딩이나, 이건 FE 위키링크 기능 자체가 지금 doc만 지원해서 생기는 것(백엔드 판단 하드코딩이 아님) — 이번 스코프 밖으로 명시. FE가 story/epic 위키링크를 지원하게 되면 그때 같이 넓힐 자리.
- #2258(증거연결·검증요청)은 "BE 있는데 FE 미배선" — 다른 병 클래스라 이 스윕 대상 아님(별도 스토리, 건드리지 않음).
- 못 훑은 범위: 프론트엔드 코드는 스코프 밖(백엔드 PR).

## 검증
- RED→GREEN(AC4): `git stash`로 이 파일만 되돌려 신규 테스트 3건이 실패하는 것 확認 → 복원 후 재확認 GREEN.
- 실PG 왕복(AC1): `test_chat_mention_to_story_round_trips`/`test_chat_mention_to_epic_round_trips` — 메시지→스토리/에픽 임베드 write→read 왕복 확認.
- 경계 파라미터(신규 처방 검증): `test_target_types_param_is_the_boundary_not_a_body_branch` — `target_types`를 좁히면 실제로 그 타입만 걸러지는 것 확認(본문 분기가 아니라 시그니처가 결정한다는 것을 직접 증명).
- 회귀 0: `test_1993_mention_parser.py`(17)·`test_1993_mentions_realdb.py`(9)·`test_docs.py`(13) 전부 그대로 GREEN.
- 마이그레이션 불필요 — CHECK 제약이 이미 story/epic을 허용.
- ⛔라이브 실측(메시지→스토리가 실제 dev 채팅에서 왕복)은 배포 후 별도 확認 필요(다른 story들과 동일 패턴, PR 병합 전엔 못 함).

## 롤백
`git revert` 단일 커밋 — 스키마 변경 없음, 안전.