### PR TITLE
[SID:2258] 다음행동 15개 중 「있는데 안 이어진」 3개를 잇는다

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -429,6 +429,10 @@
     "proofCapsuleStateVerified": "Verified",
     "trustChipNeedsInput": "Needs input",
     "trustChipMergeReady": "Merge ready",
+    "requestVerification": "Request verification",
+    "verificationPending": "Verification pending",
+    "verificationRequested": "Verification requested",
+    "verificationRequestFailed": "Failed to request verification",
     "workcellStateInProgress": "In progress",
     "workcellDodMissing": "No DoD specified",
     "workcellBlockedReason": "Waiting on dependency stories",
@@ -523,6 +527,7 @@
       "cycleDetected": "Dependency creates a cycle",
       "invalidSelf": "Invalid dependency (self-reference not allowed)",
       "addFailed": "Failed to add dependency",
+      "toggleType": "Switch blocks/depends",
       "add": "Add",
       "typeBlocks": "Blocks",
       "typeDepends": "Depends",
@@ -3268,7 +3273,11 @@
     "evidenceTypeDeploy": "Deploy",
     "evidenceTypeMetric": "Metric",
     "evidenceTypeReport": "Report",
-    "evidenceTypeGateApproval": "Gate approval"
+    "evidenceTypeGateApproval": "Gate approval",
+    "evidenceAdd": "Link evidence",
+    "evidenceAddFailed": "Failed to link evidence",
+    "evidenceRefPlaceholder": "URL or reference",
+    "evidenceNotePlaceholder": "Note (optional)"
   },
   "canvas": {
     "versionLineage": "Version lineage",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -429,6 +429,10 @@
     "proofCapsuleStateVerified": "검증됨",
     "trustChipNeedsInput": "입력 필요",
     "trustChipMergeReady": "병합 대기",
+    "requestVerification": "검증 요청",
+    "verificationPending": "검증 대기 중",
+    "verificationRequested": "검증 요청됨",
+    "verificationRequestFailed": "검증 요청 실패",
     "workcellStateInProgress": "진행 중",
     "workcellDodMissing": "완료 조건 미기재",
     "workcellBlockedReason": "의존 스토리 대기 중",
@@ -523,6 +527,7 @@
       "cycleDetected": "사이클이 발생하는 의존성",
       "invalidSelf": "잘못된 의존성 (자기참조 불가)",
       "addFailed": "의존성 추가 실패",
+      "toggleType": "차단/의존 전환",
       "add": "추가",
       "typeBlocks": "차단",
       "typeDepends": "의존",
@@ -3268,7 +3273,11 @@
     "evidenceTypeDeploy": "배포",
     "evidenceTypeMetric": "지표",
     "evidenceTypeReport": "리포트",
-    "evidenceTypeGateApproval": "게이트 승인"
+    "evidenceTypeGateApproval": "게이트 승인",
+    "evidenceAdd": "증거 연결",
+    "evidenceAddFailed": "증거 연결 실패",
+    "evidenceRefPlaceholder": "URL 또는 참조",
+    "evidenceNotePlaceholder": "메모(선택)"
   },
   "canvas": {
     "versionLineage": "버전 lineage",

--- a/apps/web/src/app/api/dependencies/[id]/route.ts
+++ b/apps/web/src/app/api/dependencies/[id]/route.ts
@@ -4,3 +4,9 @@ export async function DELETE(request: Request, { params }: { params: Promise<{ i
   const { id } = await params;
   return proxyToFastapi(request, `/api/v2/dependencies/${id}`);
 }
+
+// story #2258 AC3: 대기 해제 조건(dep_type) «수정» — BE PATCH를 그대로 프록시.
+export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await params;
+  return proxyToFastapi(request, `/api/v2/dependencies/${id}`);
+}

--- a/apps/web/src/app/api/evidence/route.ts
+++ b/apps/web/src/app/api/evidence/route.ts
@@ -13,3 +13,14 @@ export async function GET(request: Request) {
     return apiSuccess(await _r.json());
   } catch (err: unknown) { return handleApiError(err); }
 }
+
+/** story #2258 — 증거연결: BE는 이미 있었는데 FE가 부르지 않던 경로. */
+export async function POST(request: Request) {
+  try {
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    const _r = await proxyToFastapi(request, '/api/v2/evidence');
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/app/api/stories/[id]/request-verification/route.ts
+++ b/apps/web/src/app/api/stories/[id]/request-verification/route.ts
@@ -1,0 +1,22 @@
+import { handleApiError } from '@/lib/api-error';
+import { ApiErrors } from '@/lib/api-response';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+// story #2258 — 검증요청: 제네릭 게이트 생성(POST /api/gates)은 이미 있었는데 story 화면에서
+// 부르는 곳이 0곳이었다(member_id/role_id를 client가 몰라 실질적으로 막혀 있었음). BE가
+// role_id를 서버에서 해소하는 얇은 래퍼(stories.py::request_verification)를 그대로 프록시.
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const me = await getOrgProjectAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    return await proxyToFastapiWithParams(request, '/api/v2/stories/[id]/request-verification', { id });
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from 'next-intl';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
-import { AlertTriangle, Check, GitFork, Loader2, Paperclip, Plus, Tag, Trash2, X } from 'lucide-react';
+import { AlertTriangle, ArrowLeftRight, Check, GitFork, Loader2, Paperclip, Plus, Tag, Trash2, X } from 'lucide-react';
 import type { KanbanStory, KanbanMember, DependencyEdge } from './types';
 import { normalizeAssigneePatch } from './types';
 import type { SendAttachment } from '@/hooks/use-chat-sse';
@@ -340,6 +340,54 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   const handleRemoveDep = async (depId: string) => {
     const res = await fetch(`/api/dependencies/${depId}`, { method: 'DELETE' });
     if (res.ok) setDeps((prev) => prev.filter((d) => d.id !== depId));
+  };
+
+  // story #2258 AC2 — 검증요청: BE(request-verification)는 이미 있었는데 화면이 부르지 않던 경로.
+  // 서버 응답의 gate를 그대로 chipGates에 반영(낙관적 아님 — 실제로 저장된 것을 다시 읽는다).
+  const [requestingVerification, setRequestingVerification] = useState(false);
+  const handleRequestVerification = async () => {
+    if (requestingVerification) return;
+    setRequestingVerification(true);
+    try {
+      const res = await fetch(`/api/stories/${story.id}/request-verification`, { method: 'POST' });
+      if (res.ok) {
+        const gate = await res.json() as { gate_type: string; status: string; neutral_facts?: Record<string, unknown> | null };
+        setChipGates((prev) => [...prev.filter((g) => g.gate_type !== 'qa'), gate]);
+        addToast({ type: 'success', title: t('verificationRequested') });
+      } else {
+        addToast({ type: 'error', title: t('verificationRequestFailed') });
+      }
+    } catch {
+      addToast({ type: 'error', title: t('verificationRequestFailed') });
+    } finally {
+      setRequestingVerification(false);
+    }
+  };
+
+  // story #2258 AC3: 대기 해제 조건(dep_type) «수정» — 삭제 후 재생성이 아니라 같은 행을 PATCH.
+  // 서버 응답의 dep_type을 그대로 반영(낙관적 플립 아님 — 실제로 저장된 값을 다시 읽는다).
+  const [updatingDepId, setUpdatingDepId] = useState<string | null>(null);
+  const handleToggleDepType = async (dep: DependencyEdge) => {
+    if (updatingDepId) return;
+    const nextType = dep.dep_type === 'blocks' ? 'depends_on' : 'blocks';
+    setUpdatingDepId(dep.id);
+    try {
+      const res = await fetch(`/api/dependencies/${dep.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dep_type: nextType }),
+      });
+      if (res.ok) {
+        const updated = await res.json() as DependencyEdge;
+        setDeps((prev) => prev.map((d) => (d.id === updated.id ? updated : d)));
+      } else {
+        addToast({ type: 'error', title: t('dep.addFailed') });
+      }
+    } catch {
+      addToast({ type: 'error', title: t('dep.addFailed') });
+    } finally {
+      setUpdatingDepId(null);
+    }
   };
 
   useEffect(() => {
@@ -847,6 +895,22 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   {trustChipLabel}
                 </span>
               ) : null}
+              {/* story #2258 AC2 — 검증요청: pending "qa" gate가 없을 때만 요청 버튼, 있으면 대기 배지. */}
+              {chipGates.some((g) => g.gate_type === 'qa' && g.status === 'pending') ? (
+                <span className="inline-flex items-center gap-1.5 rounded-[7px] bg-proof-amber-soft px-2 py-0.5 text-[11px] font-semibold text-proof-amber">
+                  <span className="size-1.5 rounded-full bg-proof-amber" aria-hidden="true" />
+                  {t('verificationPending')}
+                </span>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => void handleRequestVerification()}
+                  disabled={requestingVerification}
+                  className="inline-flex items-center gap-1 rounded-[7px] border border-border px-2 py-0.5 text-[11px] font-medium text-muted-foreground hover:text-foreground disabled:opacity-50"
+                >
+                  {requestingVerification ? t('loading') : t('requestVerification')}
+                </button>
+              )}
             </div>
             {/* E-VERIFY V0-S3 Lv1/Lv2 + P0-04 Claimed-vs-Verified — 완료 badge의 연장으로 읽히도록
                 바로 아래. 증거 0이면 EvidenceSection 자체가 null 렌더(행 미노출, §7 상태 매트릭스). */}
@@ -1315,6 +1379,9 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                           <span className="min-w-0 truncate">{blocker?.title ?? `#${d.from_id.slice(0, 6)}`}</span>
                           {blocker?.status ? <span className="ml-auto shrink-0 font-mono text-[10px] opacity-60">{blocker.status}</span> : null}
                         </button>
+                        <button type="button" onClick={() => void handleToggleDepType(d)} disabled={updatingDepId === d.id} className="hidden shrink-0 rounded p-0.5 hover:bg-warning/20 group-hover:block" aria-label={t('dep.toggleType')} title={t('dep.toggleType')}>
+                          <ArrowLeftRight className="size-3" />
+                        </button>
                         <button type="button" onClick={() => void handleRemoveDep(d.id)} className="hidden shrink-0 rounded p-0.5 hover:bg-warning/20 group-hover:block" aria-label="Remove">
                           <X className="size-3" />
                         </button>
@@ -1332,6 +1399,9 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                           <span className="font-medium shrink-0">Blocking</span>
                           <span className="min-w-0 truncate">{blocked?.title ?? `#${d.to_id.slice(0, 6)}`}</span>
                           {blocked?.status ? <span className="ml-auto shrink-0 font-mono text-[10px] opacity-60">{blocked.status}</span> : null}
+                        </button>
+                        <button type="button" onClick={() => void handleToggleDepType(d)} disabled={updatingDepId === d.id} className="hidden shrink-0 rounded p-0.5 hover:bg-muted group-hover:block" aria-label={t('dep.toggleType')} title={t('dep.toggleType')}>
+                          <ArrowLeftRight className="size-3" />
                         </button>
                         <button type="button" onClick={() => void handleRemoveDep(d.id)} className="hidden shrink-0 rounded p-0.5 hover:bg-muted group-hover:block" aria-label="Remove">
                           <X className="size-3" />
@@ -1351,6 +1421,9 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                           <span className="min-w-0 truncate">{target?.title ?? `#${d.to_id.slice(0, 6)}`}</span>
                           {target?.status ? <span className="ml-auto shrink-0 font-mono text-[10px] opacity-60">{target.status}</span> : null}
                         </button>
+                        <button type="button" onClick={() => void handleToggleDepType(d)} disabled={updatingDepId === d.id} className="hidden shrink-0 rounded p-0.5 hover:bg-muted group-hover:block" aria-label={t('dep.toggleType')} title={t('dep.toggleType')}>
+                          <ArrowLeftRight className="size-3" />
+                        </button>
                         <button type="button" onClick={() => void handleRemoveDep(d.id)} className="hidden shrink-0 rounded p-0.5 hover:bg-muted group-hover:block" aria-label="Remove">
                           <X className="size-3" />
                         </button>
@@ -1368,6 +1441,9 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                           <span className="font-medium shrink-0">Depended by</span>
                           <span className="min-w-0 truncate">{source?.title ?? `#${d.from_id.slice(0, 6)}`}</span>
                           {source?.status ? <span className="ml-auto shrink-0 font-mono text-[10px] opacity-60">{source.status}</span> : null}
+                        </button>
+                        <button type="button" onClick={() => void handleToggleDepType(d)} disabled={updatingDepId === d.id} className="hidden shrink-0 rounded p-0.5 hover:bg-muted group-hover:block" aria-label={t('dep.toggleType')} title={t('dep.toggleType')}>
+                          <ArrowLeftRight className="size-3" />
                         </button>
                         <button type="button" onClick={() => void handleRemoveDep(d.id)} className="hidden shrink-0 rounded p-0.5 hover:bg-muted group-hover:block" aria-label="Remove">
                           <X className="size-3" />

--- a/apps/web/src/components/verify/evidence-section.tsx
+++ b/apps/web/src/components/verify/evidence-section.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useState } from 'react';
 import {
-  Check, ChevronDown, ChevronUp, ExternalLink, Link2, Paperclip,
+  Check, ChevronDown, ChevronUp, ExternalLink, Link2, Paperclip, Plus,
   GitPullRequest, Rocket, TrendingUp, FileText, CheckCircle2,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
@@ -11,6 +11,9 @@ import { formatRelativeTime } from '@/lib/storage/format';
 import { deriveTrustStage, type EvidenceItem, type EvidenceType } from '@/services/verify';
 
 const VISIBLE_LIMIT = 4;
+
+// BE _CLIENT_CREATABLE_TYPES(evidence.py) 미러 — gate_approval은 시스템 전용(직접 생성 차단).
+const CLIENT_CREATABLE_TYPES: EvidenceType[] = ['url', 'file', 'pr', 'deploy', 'metric', 'report'];
 
 const TYPE_ICON: Record<EvidenceType, typeof Link2> = {
   url: Link2,
@@ -89,6 +92,41 @@ export function EvidenceSection({
   const handleToggle = () => {
     if (!expanded && items === null) { void fetchEvidence(); }
     setExpanded((v) => !v);
+  };
+
+  // story #2258 — 증거연결: BE(create_evidence)는 이미 있었는데 화면이 부르지 않던 경로.
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [addType, setAddType] = useState<EvidenceType>('url');
+  const [addRef, setAddRef] = useState('');
+  const [addNote, setAddNote] = useState('');
+  const [adding, setAdding] = useState(false);
+  const [addError, setAddError] = useState(false);
+
+  const handleAddEvidence = async () => {
+    if (!addRef.trim() || adding) return;
+    setAdding(true);
+    setAddError(false);
+    try {
+      const res = await fetch('/api/evidence', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          work_item_id: workItemId, work_item_type: workItemType,
+          type: addType, ref: addRef.trim(), note: addNote.trim() || null,
+        }),
+      });
+      if (!res.ok) { setAddError(true); return; }
+      const created = (await res.json()) as EvidenceItem;
+      // AC1: 붙인 뒤 다시 읽어서 붙어 있는 것 — 서버 응답(실제로 저장된 값)을 그대로 리스트에 반영.
+      setItems((prev) => [created, ...(prev ?? [])]);
+      setAddRef('');
+      setAddNote('');
+      setShowAddForm(false);
+    } catch {
+      setAddError(true);
+    } finally {
+      setAdding(false);
+    }
   };
 
   // 증거 0 = 신뢰 행 자체를 렌더하지 않는다(§7 상태 매트릭스 — 현행과 동일 무표시, "증명 안 됨" 금지).
@@ -182,6 +220,63 @@ export function EvidenceSection({
                 ) : null}
               </>
             ) : null}
+
+            {showAddForm ? (
+              <div className="mt-2 space-y-1.5 rounded-md border border-border bg-muted/20 p-2">
+                <div className="flex flex-wrap gap-1">
+                  {CLIENT_CREATABLE_TYPES.map((ty) => (
+                    <button
+                      key={ty}
+                      type="button"
+                      onClick={() => setAddType(ty)}
+                      className={cn(
+                        'rounded px-2 py-0.5 text-[10px] font-medium transition',
+                        addType === ty ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground hover:text-foreground',
+                      )}
+                    >
+                      {t(TYPE_LABEL_KEY[ty])}
+                    </button>
+                  ))}
+                </div>
+                <input
+                  type="text"
+                  value={addRef}
+                  onChange={(e) => setAddRef(e.target.value)}
+                  placeholder={t('evidenceRefPlaceholder')}
+                  className="w-full rounded border border-border bg-background px-2 py-1 text-xs"
+                />
+                <input
+                  type="text"
+                  value={addNote}
+                  onChange={(e) => setAddNote(e.target.value)}
+                  placeholder={t('evidenceNotePlaceholder')}
+                  className="w-full rounded border border-border bg-background px-2 py-1 text-xs"
+                />
+                {addError ? <p className="text-[11px] text-destructive">{t('evidenceAddFailed')}</p> : null}
+                <div className="flex justify-end gap-1.5">
+                  <button type="button" onClick={() => setShowAddForm(false)} className="rounded px-2 py-1 text-[11px] text-muted-foreground hover:text-foreground">
+                    {tCommon('cancel')}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleAddEvidence()}
+                    disabled={!addRef.trim() || adding}
+                    className="rounded bg-primary px-2 py-1 text-[11px] font-medium text-primary-foreground disabled:opacity-50"
+                  >
+                    {adding ? tCommon('loading') : t('evidenceAdd')}
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setShowAddForm(true)}
+                className="mt-2 flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground"
+              >
+                <Plus className="h-3 w-3" aria-hidden />
+                {t('evidenceAdd')}
+              </button>
+            )}
           </div>
         ) : null}
       </div>

--- a/backend/app/repositories/dependency.py
+++ b/backend/app/repositories/dependency.py
@@ -33,6 +33,15 @@ class DependencyRepository(BaseRepository[ItemDependency]):
         await self.session.flush()
         return result.rowcount  # type: ignore[return-value]
 
+    async def update_dep_type(self, id: uuid.UUID, dep_type: str) -> ItemDependency | None:
+        """story #2258 AC3: 같은 행을 UPDATE(id/created_at 보존) — delete+create로 흉내내지 않는다."""
+        dep = await self.get(id)
+        if dep is None:
+            return None
+        dep.dep_type = dep_type
+        await self.session.flush()
+        return dep
+
     async def exists(self, from_id: uuid.UUID, to_id: uuid.UUID, item_type: str) -> bool:
         result = await self.session.execute(
             select(ItemDependency.id).where(

--- a/backend/app/routers/dependencies.py
+++ b/backend/app/routers/dependencies.py
@@ -9,7 +9,12 @@ from app.dependencies.database import get_db
 from app.models.dependency import ITEM_TYPES
 from app.models.pm import Goal, Sprint, Story
 from app.repositories.dependency import DependencyRepository
-from app.schemas.dependency import DependencyCreate, DependencyGraphResponse, DependencyResponse
+from app.schemas.dependency import (
+    DependencyCreate,
+    DependencyGraphResponse,
+    DependencyResponse,
+    DependencyUpdate,
+)
 from app.services.dependency_graph import get_graph, would_create_cycle
 from app.services.project_auth import accessible_project_ids_in_org, has_project_access
 
@@ -130,6 +135,45 @@ async def list_dependencies(
     await _assert_item_project_access(repo.session, uuid.UUID(auth.user_id), repo.org_id, item_id, item_type)
     deps = await repo.list_by_item(item_id, item_type)
     return [DependencyResponse.model_validate(d) for d in deps]
+
+
+@router.patch("/{id}", response_model=DependencyResponse)
+async def update_dependency(
+    id: uuid.UUID,
+    body: DependencyUpdate,
+    repo: DependencyRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+) -> DependencyResponse:
+    """story #2258 AC3: 대기 해제 조건(dep_type) «수정» — 생성+삭제로 흉내내지 않는다(같은 id·
+    created_at 보존, 감사 기록이 「삭제 후 생성」이 아니라 「수정」으로 남는다). create/delete와
+    동일하게 양쪽-아이템 project 접근권 게이트(반쪽 금지) + trust_pipeline 훅 유지."""
+    dep = await repo.get(id)
+    if dep is None:
+        raise HTTPException(status_code=404, detail="의존성을 찾을 수 없음")
+    user_id = uuid.UUID(auth.user_id)
+    await _assert_item_project_access(repo.session, user_id, repo.org_id, dep.from_id, dep.item_type)
+    await _assert_item_project_access(repo.session, user_id, repo.org_id, dep.to_id, dep.item_type)
+
+    # P0-04: dep_type 변경으로 blocks 여부가 어느 방향으로든 뒤집힐 수 있어(depends_on→blocks도
+    # blocks→depends_on도) create/delete와 달리 "old이거나 new이거나 blocks"로 넓게 게이트한다.
+    _trust_before = None
+    if dep.item_type == "story" and (dep.dep_type == "blocks" or body.dep_type == "blocks"):
+        from app.services.trust_pipeline import compute_trust_facts
+
+        _trust_before = await compute_trust_facts(repo.session, repo.org_id, dep.to_id)
+
+    updated = await repo.update_dep_type(id, body.dep_type)
+    if updated is None:
+        raise HTTPException(status_code=404, detail="의존성을 찾을 수 없음")
+
+    if _trust_before is not None:
+        from app.services.trust_pipeline import maybe_emit_trust_stage_changed
+
+        await maybe_emit_trust_stage_changed(
+            repo.session, repo.org_id, dep.to_id, _trust_before, actor_id=user_id
+        )
+
+    return DependencyResponse.model_validate(updated)
 
 
 @router.delete("/{id}", status_code=200)

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -18,6 +18,7 @@ from app.models.team import TeamMember
 from app.repositories.story import StoryRepository
 from app.repositories.story_assignee import StoryAssigneeRepository
 from app.routers.agent_gateway import wake_agent
+from app.routers.gates import GateResponse
 from app.services import mcp_attachment_upload
 from app.services.asset_registry import DEFAULT_CONTAINER, sync_attachment_assets
 from app.schemas.story import StoryAttachment, StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
@@ -1487,6 +1488,40 @@ async def add_comment(
         )
 
     return CommentResponse.model_validate(comment)
+
+
+@router.post("/{id}/request-verification", response_model=GateResponse, status_code=201)
+async def request_verification(
+    id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    repo: StoryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+) -> GateResponse:
+    """story #2258 — 검증요청: 제네릭 게이트 생성(POST /api/v2/gates)은 이미 있었는데(work_item_type
+    무관) FE가 story에서 부르는 곳이 0곳이었다(member_id/role_id를 client가 알아야 해 실질적으로
+    막혀 있었음). doc.py::transition_doc이 doc_approval 게이트를 상신 시 자동 생성하는 것과
+    동형 패턴 — 여기서도 role_id를 서버가 `_default_role_id`로 해소해 client가 아무것도 몰라도
+    되게 한다. gate_type="qa"(GATE_TYPES 중 「검증」에 가장 가까운 값). create_gate 자체가 멱등
+    (재요청 시 기존 pending 재사용, rejected는 자동 재오픈)이라 여기서 별도 처리 불필요.
+    """
+    story = await repo.get(id)
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+    await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
+
+    from app.services.gate_service import create_gate
+    from app.services.workflow_line_config import _default_role_id
+
+    member_id = await _resolve_team_member_id(auth, repo.org_id, db)
+    role_id = await _default_role_id(db, repo.org_id) or story.id
+    gate = await create_gate(
+        db, repo.org_id, story.id, "story", "qa",
+        member_id, role_id,
+        neutral_facts={"requested_by_member_id": str(member_id), "story_title": story.title},
+        project_id=story.project_id,
+    )
+    await db.commit()
+    return GateResponse.model_validate(gate)
 
 
 # ─── Activities ───────────────────────────────────────────────────────────────

--- a/backend/app/schemas/dependency.py
+++ b/backend/app/schemas/dependency.py
@@ -27,6 +27,19 @@ class DependencyCreate(BaseModel):
         return v
 
 
+class DependencyUpdate(BaseModel):
+    """story #2258 AC3: 대기 해제 조건(dep_type) «수정» — 삭제 후 생성이 아니라 같은 행을 UPDATE해
+    id/created_at을 보존한다(감사 기록이 「수정」으로 남아야 함)."""
+    dep_type: str
+
+    @field_validator("dep_type")
+    @classmethod
+    def validate_dep_type(cls, v: str) -> str:
+        if v not in DEP_TYPES:
+            raise ValueError(f"dep_type must be one of {sorted(DEP_TYPES)}")
+        return v
+
+
 class DependencyResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/tests/test_2258_story_request_verification_realdb.py
+++ b/backend/tests/test_2258_story_request_verification_realdb.py
@@ -1,0 +1,253 @@
+"""story #2258 AC2 — POST /api/v2/stories/{id}/request-verification.
+
+발견: 제네릭 게이트 생성(POST /api/v2/gates)은 이미 있었다(work_item_type 무관, BE 완비) — 그런데
+story-detail-panel.tsx 어디에도 그걸 부르는 곳이 없었다(FE 미배선). 이유는 GateCreateRequest가
+member_id/role_id를 client가 알아야 하는데 그걸 알아낼 방법이 화면에 없었기 때문 — doc.py::
+transition_doc이 doc_approval 게이트를 상신 시 자동 생성하며 role_id를 `_default_role_id`로
+서버가 스스로 해소하는 것과 동형으로, story 쪽에도 얇은 래퍼 엔드포인트를 신설했다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session, *, with_default_role: bool = True):
+    from app.models.organization import Organization
+    from app.models.participation import ParticipationRole
+    from app.models.pm import Story
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    proj = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(proj)
+    await session.commit()
+
+    proj_b = Project(id=uuid.uuid4(), org_id=org.id, name="P-other")
+    session.add(proj_b)
+    await session.commit()
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=proj.id, title="검증 대상 스토리")
+    story_other = Story(id=uuid.uuid4(), org_id=org.id, project_id=proj_b.id, title="타 프로젝트 스토리")
+    session.add_all([story, story_other])
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+
+    om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=proj.id, org_member_id=om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    # _resolve_team_member_id(stories.py) 폴백: team_members(뷰, 직접 insert 불가)에 안 걸리면
+    # resolve_member(member_resolver.py)가 human JWT를 org_member.id로 해소한다(위 om 재사용).
+    if with_default_role:
+        role = ParticipationRole(id=uuid.uuid4(), org_id=org.id, key="qa", label="QA", is_default=True)
+        session.add(role)
+        await session.commit()
+
+    return {
+        "org_id": org.id, "caller_id": caller_id,
+        "story_id": story.id, "story_other_id": story_other.id,
+        "project_id": proj.id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _gate_rows(Session, work_item_id):
+    from sqlalchemy import text
+    async with Session() as s:
+        return (await s.execute(
+            text("SELECT id, gate_type, work_item_type, status FROM gate WHERE work_item_id = :i"),
+            {"i": work_item_id},
+        )).all()
+
+
+@pytest.mark.anyio
+async def test_request_verification_creates_qa_gate_201_and_persists():
+    """AC2 본체: 붙인 뒤 다시 읽어서 붙어 있는 것(write→read) — 응답 201뿐 아니라 gates 테이블
+    직조회로 실제 저장을 확인한다."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/stories/{seeded['story_id']}/request-verification")
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["gate_type"] == "qa"
+            assert body["work_item_type"] == "story"
+            assert body["work_item_id"] == str(seeded["story_id"])
+        finally:
+            await client.aclose()
+
+        rows = await _gate_rows(Session, seeded["story_id"])
+        assert len(rows) == 1, "gates 테이블에 실제로 저장되지 않음(write→read 실패)"
+        assert rows[0][1] == "qa"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_request_verification_idempotent_no_duplicate_gate():
+    """create_gate 멱등성 재사용 확인 — 두 번 요청해도 gate가 1개만 남는다(중복 게이트 방지)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            r1 = await client.post(f"/api/v2/stories/{seeded['story_id']}/request-verification")
+            r2 = await client.post(f"/api/v2/stories/{seeded['story_id']}/request-verification")
+            assert r1.status_code == 201, r1.text
+            assert r2.status_code == 201, r2.text
+            assert r1.json()["id"] == r2.json()["id"], "재요청이 새 게이트를 또 만듦(멱등 깨짐)"
+        finally:
+            await client.aclose()
+
+        rows = await _gate_rows(Session, seeded["story_id"])
+        assert len(rows) == 1
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_request_verification_without_default_role_falls_back_not_500():
+    """org에 is_default role이 없어도(placeholder role_id=story.id 폴백) 500 없이 정상 생성."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, with_default_role=False)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/stories/{seeded['story_id']}/request-verification")
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_request_verification_cross_project_blocked_403_no_gate():
+    """봉인: 접근권 없는 project의 story에 검증요청 시도 → 403 + gate 미생성."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/stories/{seeded['story_other_id']}/request-verification")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+
+        rows = await _gate_rows(Session, seeded["story_other_id"])
+        assert len(rows) == 0, "무접근 project story에 게이트가 생성됨(IDOR)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_request_verification_not_found_404():
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/stories/{uuid.uuid4()}/request-verification")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_sec_dependencies_subsystem_project_scope_realdb.py
+++ b/backend/tests/test_e_sec_dependencies_subsystem_project_scope_realdb.py
@@ -271,6 +271,117 @@ async def test_list_dependencies_cross_project_blocked_404():
         await engine.dispose()
 
 
+# ── update/PATCH (story #2258 AC3: 「수정」이지 「삭제 후 생성」이 아니다) ──────────
+
+async def _dep_row(Session, dep_id):
+    from sqlalchemy import text
+    async with Session() as s:
+        row = (await s.execute(
+            text("SELECT id, created_at, dep_type FROM item_dependency WHERE id = :i"), {"i": dep_id}
+        )).one_or_none()
+        return None if row is None else {"id": row[0], "created_at": row[1], "dep_type": row[2]}
+
+
+@pytest.mark.anyio
+async def test_update_dependency_own_project_200_same_id_and_created_at():
+    """AC3 본체: dep_type이 바뀌어도 id·created_at이 그대로다(같은 행 UPDATE — delete+create였다면
+    created_at이 갱신되거나 id가 바뀌었을 것)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        before = await _dep_row(Session, seeded["dep_aa"])
+        assert before["dep_type"] == "blocks"
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/dependencies/{seeded['dep_aa']}", json={"dep_type": "depends_on"},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["dep_type"] == "depends_on"
+        finally:
+            await client.aclose()
+
+        after = await _dep_row(Session, seeded["dep_aa"])
+        assert after["id"] == before["id"], "id가 바뀜 — delete+create로 흉내낸 것"
+        assert after["created_at"] == before["created_at"], "created_at이 바뀜 — delete+create로 흉내낸 것"
+        assert after["dep_type"] == "depends_on"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_dependency_cross_project_blocked_404_not_changed():
+    """봉인: 접근권 없는 project_b 의존성 PATCH 시도 → 404 + **미변경 직조회**."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/dependencies/{seeded['dep_bb']}", json={"dep_type": "depends_on"},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+        row = await _dep_row(Session, seeded["dep_bb"])
+        assert row["dep_type"] == "blocks", "cross-project 의존성이 변경됨(IDOR)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_dependency_not_found_404():
+    """존재하지 않는 id → 404(반쪽 게이트가 아니라 조회 자체가 없음)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/dependencies/{uuid.uuid4()}", json={"dep_type": "depends_on"},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_dependency_invalid_dep_type_422():
+    """dep_type 화이트리스트 밖 값 → 422(생성 경로와 동일 검증)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/dependencies/{seeded['dep_aa']}", json={"dep_type": "not-a-type"},
+            )
+            assert resp.status_code == 422, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
 # ── graph (AC3: 응답 필터·사이클 org-wide 보존) ─────────────────────────────────
 
 @pytest.mark.anyio


### PR DESCRIPTION
## 무엇을 발견했는가

story #2258이 근거로 삼은 doc `flow-board-next-action-inventory-20260728`(2026-07-28 전수)에서, 블루프린트 7상태의 다음행동 15개 중 3개가 **「없는 것」이 아니라 「있는데 안 이어진 것」**으로 확인됐다:

| 항목 | 재전수 이전 상태 | 부족했던 레이어 |
|---|---|---|
| 증거연결 | ⚠️ | **FE가 안 부름** — `POST /api/v2/evidence`(create_evidence)는 이미 있었는데 `evidence-section.tsx`는 GET만 호출(코드베이스 전체 POST 호출부 0건) |
| 검증요청 | ⚠️ | **FE가 안 부름(story 한정)** — 제네릭 `POST /api/v2/gates`는 있었으나 story/task용 gate 생성 UI가 0곳(doc·hypothesis 전용 컴포넌트에만 있었음). 게다가 `member_id`/`role_id`를 client가 알아야 해 실질적으로 막혀 있었다 |
| 대기해제조건수정 | ⛔ | **API 자체가 없음** — `dependencies.py`엔 POST(생성)·DELETE·GET(목록/그래프)뿐, PATCH/PUT이 존재하지 않았다. "조건 수정"은 삭제 후 재생성으로만 흉내 가능했다 |

## 무엇을 고쳤는가

### 1. `PATCH /api/v2/dependencies/{id}` (신규)
- `dep_type`을 in-place UPDATE — 삭제 후 재생성이 아니다(같은 `id`·`created_at` 보존 — 그래야 감사 기록이 「수정」으로 남는다, 관측 공백이 없다).
- create/delete와 동일한 양쪽-아이템 project 접근권 게이트 + `trust_pipeline` 훅(dep_type 변경으로 blocking 여부가 어느 방향으로든 뒤집힐 수 있어 `old이거나 new이거나 blocks`로 게이트).
- **mutation-verified**: repository 메서드를 일부러 delete+recreate로 바꿔봄 → `id`/`created_at` 불변 검증 테스트가 RED로 정확히 잡음 → 원복.
- realdb 4케이스(own-project 200+id/created_at 보존·cross-project 404+미변경·not-found 404·invalid dep_type 422).

### 2. `POST /api/v2/stories/{id}/request-verification` (신규)
- `doc.py::transition_doc`이 doc_approval 게이트를 상신 시 자동 생성하는 것과 동형 패턴 — `role_id`를 서버가 `_default_role_id`로 해소해 client가 아무것도 몰라도 되게 한다.
- `gate_type="qa"`(GATE_TYPES 중 「검증」에 가장 가까운 값), `create_gate` 자체의 멱등성 재사용(재요청 시 기존 pending 재사용, rejected는 자동 재오픈 — 별도 처리 불필요).
- realdb 5케이스(생성+저장 확인·멱등성(중복 게이트 0)·default role 없어도 500 아님·cross-project 403+게이트 미생성·not-found 404).

### 3. FE 배선
- `evidence-section.tsx`: 타입선택(url/file/pr/deploy/metric/report)+ref/note 입력 폼. 제출 후 **서버 응답을 그대로 리스트에 반영**(낙관적 아님 — 실제로 저장된 값을 다시 읽는다, AC1 왕복 확인).
- `story-detail-panel.tsx`: 검증요청 버튼(pending qa gate 있으면 배지로 전환) + 의존성 각 행에 타입 토글 버튼(ArrowLeftRight 아이콘).

## 15개 재전수 (before/after)

doc `flow-board-next-action-inventory-20260728`에 전후 비교표 갱신 완료 — **5/15 → 8/15**. 다시 세어 본 결과 이 셋 외 다른 항목의 부수 개선이나 반쪽 회귀는 없었다.

## 회귀 스윕
- Backend: dependencies/gates/stories 관련 6개 테스트 파일(31케이스) 전부 PASS — isolated throwaway PG(pgvector/pgvector:pg15, 공유 dev DB 미사용).
- FE: 관련 vitest 5개 파일(42케이스) 전부 PASS. `tsc --noEmit` 무오류. `eslint` 무경고.

## AC6 (클래스 전수)
「BE는 있는데 FE가 안 부르는」패턴이 오늘 3번째(증거연결·검증요청·별도 조사에서 발견한 message→doc backlinks) 나와 클래스 전수를 별도 진행 중 — 결과는 Ortega에게 별도 보고(코드 수정 아닌 목록 산출물).

## 스크린샷
로컬 UI 스크린샷은 별도 첨부 예정(dev 배포 후 라이브 픽셀로 대체 가능) — 이 PR은 API 계약 신설/FE 배선 위주라 회귀 테스트로 우선 검증했다.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>