### PR TITLE
feat(#2259/C-1): entity_references — first-class polymorphic reference

### DIFF
--- a/backend/alembic/versions/0213_entity_references.py
+++ b/backend/alembic/versions/0213_entity_references.py
@@ -1,0 +1,52 @@
+"""story #2259(C-1, E-CONNECT) — entity_references: 참조를 1급 개념으로.
+
+순수 additive — 신규 테이블 생성뿐, 기존 테이블/데이터 손상 0(prod 적용 전제, 되돌릴 수
+없는 데이터손실형 아님). 옛 `mentions` 테이블은 이 마이그레이션에서 건드리지 않는다 —
+백필은 별도 애플리케이션 코드로, 스키마와 데이터 이관을 한 트랜잭션에 묶지 않는다.
+
+Revision ID: 0213
+Revises: 0212
+Create Date: 2026-07-28
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0213"
+down_revision = "0212"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "entity_references",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("source_type", sa.Text(), nullable=False),
+        sa.Column("source_field", sa.Text(), nullable=True),
+        sa.Column("source_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("target_type", sa.Text(), nullable=False),
+        sa.Column("target_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("form", sa.Text(), nullable=False),
+        sa.Column("proof_payload", postgresql.JSONB(), nullable=True),
+        sa.Column("created_by", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint("form IN ('mention', 'embed', 'proof')", name="ck_entity_references_form"),
+        sa.UniqueConstraint(
+            "source_type", "source_id", "target_type", "target_id", "form",
+            name="uq_entity_references_source_target_form",
+        ),
+    )
+    op.create_index(
+        "ix_entity_references_source", "entity_references", ["org_id", "source_type", "source_id"],
+    )
+    op.create_index(
+        "ix_entity_references_target", "entity_references", ["org_id", "target_type", "target_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_entity_references_target", table_name="entity_references")
+    op.drop_index("ix_entity_references_source", table_name="entity_references")
+    op.drop_table("entity_references")

--- a/backend/alembic/versions/0213_entity_references.py
+++ b/backend/alembic/versions/0213_entity_references.py
@@ -33,10 +33,6 @@ def upgrade() -> None:
         sa.Column("created_by", postgresql.UUID(as_uuid=True), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
         sa.CheckConstraint("form IN ('mention', 'embed', 'proof')", name="ck_entity_references_form"),
-        sa.UniqueConstraint(
-            "source_type", "source_id", "target_type", "target_id", "form",
-            name="uq_entity_references_source_target_form",
-        ),
     )
     op.create_index(
         "ix_entity_references_source", "entity_references", ["org_id", "source_type", "source_id"],
@@ -44,9 +40,23 @@ def upgrade() -> None:
     op.create_index(
         "ix_entity_references_target", "entity_references", ["org_id", "target_type", "target_id"],
     )
+    # 부분 유니크(PO 판정 2026-07-28): proof 는 뺀다(같은 자리·같은 대상을 다른 범위로 여러 번
+    # 인용하는 게 정상 쓰임 — proof_payload 가 정해지기 전까진 그 축으로 유일성을 못 세운다,
+    # #2265 몫). COALESCE로 source_field(nullable)의 NULL 비교 함정을 접는다(NULL<>NULL이라
+    # 그대로 두면 이 인덱스가 아무것도 안 잡는다).
+    op.execute(
+        """
+        CREATE UNIQUE INDEX uq_entity_references_non_proof
+        ON entity_references (
+            source_type, COALESCE(source_field, ''), source_id, target_type, target_id, form
+        )
+        WHERE form <> 'proof'
+        """
+    )
 
 
 def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS uq_entity_references_non_proof")
     op.drop_index("ix_entity_references_target", table_name="entity_references")
     op.drop_index("ix_entity_references_source", table_name="entity_references")
     op.drop_table("entity_references")

--- a/backend/alembic/versions/0213_entity_references.py
+++ b/backend/alembic/versions/0213_entity_references.py
@@ -24,7 +24,10 @@ def upgrade() -> None:
         sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
         sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("source_type", sa.Text(), nullable=False),
-        sa.Column("source_field", sa.Text(), nullable=True),
+        # PO 정정(2026-07-28): NOT NULL — 자리가 없는 게 아니라 "본문"이 그 자리다(단일-필드
+        # source_type도 "body"를 실제로 적는다). NULL이면 유니크 인덱스에서 NULL<>NULL이라
+        # 중복이 안 잡히는 함정(오늘 세션 두 번째 재발) — NOT NULL로 근본에서 막는다.
+        sa.Column("source_field", sa.Text(), nullable=False),
         sa.Column("source_id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("target_type", sa.Text(), nullable=False),
         sa.Column("target_id", postgresql.UUID(as_uuid=True), nullable=False),
@@ -42,14 +45,11 @@ def upgrade() -> None:
     )
     # 부분 유니크(PO 판정 2026-07-28): proof 는 뺀다(같은 자리·같은 대상을 다른 범위로 여러 번
     # 인용하는 게 정상 쓰임 — proof_payload 가 정해지기 전까진 그 축으로 유일성을 못 세운다,
-    # #2265 몫). COALESCE로 source_field(nullable)의 NULL 비교 함정을 접는다(NULL<>NULL이라
-    # 그대로 두면 이 인덱스가 아무것도 안 잡는다).
+    # #2265 몫). source_field가 NOT NULL이라 COALESCE 없이도 그대로 유니크가 성립한다.
     op.execute(
         """
         CREATE UNIQUE INDEX uq_entity_references_non_proof
-        ON entity_references (
-            source_type, COALESCE(source_field, ''), source_id, target_type, target_id, form
-        )
+        ON entity_references (source_type, source_field, source_id, target_type, target_id, form)
         WHERE form <> 'proof'
         """
     )

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -33,6 +33,7 @@ from app.models.webhook_config import WebhookConfig
 from app.models.push_device import PushDevice
 from app.models.doc import Doc, DocShareToken, DocSlugAlias
 from app.models.mention import Mention
+from app.models.reference import Reference
 from app.models.meeting import Meeting
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.conversation_webhook_delivery import ConversationWebhookDelivery
@@ -126,6 +127,7 @@ __all__ = [
     "ItemDependency",
     "EntitySlugHistory",
     "Mention",
+    "Reference",
     "MockupComponent",
     "MockupPage",
     "MockupScenario",

--- a/backend/app/models/reference.py
+++ b/backend/app/models/reference.py
@@ -5,8 +5,14 @@
 
 축 정리(오르테가군 2026-07-28 판정):
   자리(source_type, source_field, source_id)  — source_field 는 같은 엔티티 안 여러 텍스트
-    필드(예: story description vs acceptance_criteria)를 가르는 서브 위치. 텍스트 필드가
-    하나뿐인 소스(chat_message 등)는 None.
+    필드(예: story description vs acceptance_criteria)를 가르는 서브 위치. **NOT NULL** —
+    텍스트 필드가 하나뿐인 소스(chat_message 등)도 "없음"이 아니라 "본문 하나뿐"이 사실이라
+    `"body"`를 실제로 적는다(PO 정정: 모르는 것을 NULL로 두지 않고 아는 것을 적는다 —
+    "자리가 없다"가 아니라 "자리가 본문이다"가 참).
+    ⛔유니크 축에 nullable 컬럼을 넣으면 NULL 행끼리는 "다른 값"으로 취급돼 유니크가 안
+    걸린다(Postgres 표준 동작) — source_field를 NOT NULL로 만든 이유가 이것. 오늘 세션에
+    같은 병이 두 번 나왔다(uq_stories_project_id_story_number → 여기) — **유니크 축의
+    컬럼은 NOT NULL 이거나, NULL 이 진짜 "값"으로 의미가 있어야 한다.**
   대상(target_type, target_id)                — source 와 동일 폴리모픽 원칙.
   형태(form)   — mention(인라인)·embed(카드)·proof(범위 스냅샷) **3값 CHECK로 닫는다**
     (유한하고 안 늘어나는 축 — entity type 과 다른 성격이라 여기만 CHECK).
@@ -33,7 +39,7 @@ write-path(`insert_chat_mentions`/`reconcile_doc_mentions`)는 저장 타깃만 
 import uuid
 from datetime import datetime
 
-from sqlalchemy import CheckConstraint, DateTime, Index, Text, column, func, text
+from sqlalchemy import CheckConstraint, DateTime, Index, Text, func, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -56,16 +62,11 @@ class Reference(Base, OrgScopedMixin):
         # 유일성 축이 다르다. proof 의 진짜 유일성은 proof_payload(어느 범위인가)까지 있어야
         # 서는데, 그 모양은 #2265(유나 lane) 몫이라 아직 모른다 — 지금 굳히면 그때 마이그를
         # 또 파야 하니 **모르는 것을 지금 단정하지 않는다**(부분 유니크로 proof만 열어 둠).
-        # source_field 도 키에 포함 — 같은 스토리의 description/acceptance_criteria 는 다른
-        # "자리"라 같은 대상을 각각 멘션해도 별개 사실이다(합치면 안 됨).
-        # ⛔source_field 는 nullable — Postgres UNIQUE/부분 유니크 인덱스는 NULL 을 서로
-        # 다른 값으로 취급해(story #2249 세션에서 이미 겪은 그 함정과 동형 — uq_stories_
-        # project_id_story_number 참조) source_field=NULL 인 행끼리는 **비교가 항상 거짓이라
-        # 중복이 안 잡힌다**. COALESCE로 NULL을 빈 문자열로 접어 비교 가능하게 만든다.
+        # source_field 는 NOT NULL(위 모듈 docstring 참조) — COALESCE 없이도 그대로 유니크
+        # 비교가 성립한다(기억에 의존하는 가드를 만들지 않는다).
         Index(
             "uq_entity_references_non_proof",
-            "source_type", func.coalesce(column("source_field"), text("''")), "source_id",
-            "target_type", "target_id", "form",
+            "source_type", "source_field", "source_id", "target_type", "target_id", "form",
             unique=True,
             postgresql_where=text("form <> 'proof'"),
         ),
@@ -74,8 +75,9 @@ class Reference(Base, OrgScopedMixin):
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     source_type: Mapped[str] = mapped_column(Text, nullable=False)
     # story #2259: 같은 엔티티 안 복수 텍스트 필드를 가르는 서브 위치(예: "description" vs
-    # "acceptance_criteria") — 필드가 하나뿐인 source_type 은 None.
-    source_field: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # "acceptance_criteria") — 필드가 하나뿐인 source_type 도 "body"를 적는다(모듈 docstring
+    # 참조 — NOT NULL, NULL로 "없음"을 표현하지 않는다).
+    source_field: Mapped[str] = mapped_column(Text, nullable=False)
     source_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
     target_type: Mapped[str] = mapped_column(Text, nullable=False)
     target_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)

--- a/backend/app/models/reference.py
+++ b/backend/app/models/reference.py
@@ -33,7 +33,7 @@ write-path(`insert_chat_mentions`/`reconcile_doc_mentions`)는 저장 타깃만 
 import uuid
 from datetime import datetime
 
-from sqlalchemy import CheckConstraint, DateTime, Index, Text, UniqueConstraint, func
+from sqlalchemy import CheckConstraint, DateTime, Index, Text, column, func, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -49,12 +49,25 @@ class Reference(Base, OrgScopedMixin):
         Index("ix_entity_references_source", "org_id", "source_type", "source_id"),
         Index("ix_entity_references_target", "org_id", "target_type", "target_id"),
         CheckConstraint("form IN ('mention', 'embed', 'proof')", name="ck_entity_references_form"),
-        # mentions 테이블의 uq_mentions_source_target 과 동일 SSOT 원칙(같은 이유: insert-only
-        # write-path 의 ON CONFLICT DO NOTHING 방어 + 백필 재실행 시 idempotent 보장).
-        # ⛔form 도 키에 포함 — 같은 (source,target) 쌍이라도 mention/embed 는 다른 사실.
-        UniqueConstraint(
-            "source_type", "source_id", "target_type", "target_id", "form",
-            name="uq_entity_references_source_target_form",
+        # mentions 테이블의 uq_mentions_source_target 과 동일 SSOT 원칙(insert-only write-path의
+        # ON CONFLICT DO NOTHING 방어 + 백필 재실행 시 idempotent 보장).
+        # ⛔PO 판정(2026-07-28): proof 는 이 제약에서 뺀다 — proof 는 "대화의 다른 범위"를
+        # 각각 박는 정상 쓰임이 있어(같은 자리·같은 대상을 두 조각으로 인용) mention/embed 와
+        # 유일성 축이 다르다. proof 의 진짜 유일성은 proof_payload(어느 범위인가)까지 있어야
+        # 서는데, 그 모양은 #2265(유나 lane) 몫이라 아직 모른다 — 지금 굳히면 그때 마이그를
+        # 또 파야 하니 **모르는 것을 지금 단정하지 않는다**(부분 유니크로 proof만 열어 둠).
+        # source_field 도 키에 포함 — 같은 스토리의 description/acceptance_criteria 는 다른
+        # "자리"라 같은 대상을 각각 멘션해도 별개 사실이다(합치면 안 됨).
+        # ⛔source_field 는 nullable — Postgres UNIQUE/부분 유니크 인덱스는 NULL 을 서로
+        # 다른 값으로 취급해(story #2249 세션에서 이미 겪은 그 함정과 동형 — uq_stories_
+        # project_id_story_number 참조) source_field=NULL 인 행끼리는 **비교가 항상 거짓이라
+        # 중복이 안 잡힌다**. COALESCE로 NULL을 빈 문자열로 접어 비교 가능하게 만든다.
+        Index(
+            "uq_entity_references_non_proof",
+            "source_type", func.coalesce(column("source_field"), text("''")), "source_id",
+            "target_type", "target_id", "form",
+            unique=True,
+            postgresql_where=text("form <> 'proof'"),
         ),
     )
 

--- a/backend/app/models/reference.py
+++ b/backend/app/models/reference.py
@@ -1,0 +1,75 @@
+"""story #2259(C-1, E-CONNECT) — 참조를 1급 개념으로. 근본 설계 doc `flow-map-blueprint-v1` §2/§6.
+
+⛔이 파일이 만드는 것은 「가리켰다」는 사실뿐이다(블루프린트 3층: 참조=관찰됨 / 의미 후보=
+추정됨 / 실행 관계=선언됨) — 의미(잇따름·필요함 등)를 여기서 저장·판정하지 않는다.
+
+축 정리(오르테가군 2026-07-28 판정):
+  자리(source_type, source_field, source_id)  — source_field 는 같은 엔티티 안 여러 텍스트
+    필드(예: story description vs acceptance_criteria)를 가르는 서브 위치. 텍스트 필드가
+    하나뿐인 소스(chat_message 등)는 None.
+  대상(target_type, target_id)                — source 와 동일 폴리모픽 원칙.
+  형태(form)   — mention(인라인)·embed(카드)·proof(범위 스냅샷) **3값 CHECK로 닫는다**
+    (유한하고 안 늘어나는 축 — entity type 과 다른 성격이라 여기만 CHECK).
+    ⛔proof 의 저장 모양(무엇을 잘랐는지)은 #2265(유나 lane, 범위 선택 설계 미확定) 몫 —
+    여기선 `proof_payload` nullable 칸만 남기고 굳히지 않는다.
+
+⛔entity type(source_type/target_type)은 CHECK로 나열하지 않는다(#2260과 같은 원칙 —
+0-diff 확장) — 대신 `app.services.reference_registry`의 resolver registry 가 열어 준
+타입만 write-time 에 허용한다(등록 안 된 타입은 조용히 통과 아니라 거부, registry.py 참조).
+⛔"나열 안 한다"가 "아무거나 받는다"는 아니다 — write 헬퍼가 registry 검증을 강제한다.
+
+양방향 조회: 같은 표에서 축만 바꿔 조회한다(`backlinks.py`의 기존 패턴 재사용 — 재발명 0).
+
+끊어진 참조: PO 판정(b) — 삭제 시점 훅이 아니라 **읽는 시점에 대상 존재를 판정**한다(콜사이트가
+없어 "하나 빠뜨려 조용히 안 남는" 실패모드가 구조적으로 없다 — 늦게 아는 것과 영영 모르는
+것은 다르다). 순서 불변식: 권한 필터(C-3, #2261) → 존재 판정(이 순서를 뒤집으면 "못 보는 것"과
+"끊어진 것"이 섞인다). N+1 금지 — 존재 판정은 target_type 별로 묶어 한 번씩(reference_core.py
+참조).
+
+기존 `mentions`(story #1993) 테이블은 이 스토리에서 지우지 않는다 — 백필로 이 표에 옮기고,
+write-path(`insert_chat_mentions`/`reconcile_doc_mentions`)는 저장 타깃만 재배선한다(추출층은
+#2260에서 이미 범용화돼 손대지 않는다). 옛 표 삭제는 새 표가 라이브로 도는 것을 본 뒤 별건.
+"""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, DateTime, Index, Text, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+from app.models.base import OrgScopedMixin
+
+FORMS = frozenset({"mention", "embed", "proof"})
+
+
+class Reference(Base, OrgScopedMixin):
+    __tablename__ = "entity_references"
+    __table_args__ = (
+        Index("ix_entity_references_source", "org_id", "source_type", "source_id"),
+        Index("ix_entity_references_target", "org_id", "target_type", "target_id"),
+        CheckConstraint("form IN ('mention', 'embed', 'proof')", name="ck_entity_references_form"),
+        # mentions 테이블의 uq_mentions_source_target 과 동일 SSOT 원칙(같은 이유: insert-only
+        # write-path 의 ON CONFLICT DO NOTHING 방어 + 백필 재실행 시 idempotent 보장).
+        # ⛔form 도 키에 포함 — 같은 (source,target) 쌍이라도 mention/embed 는 다른 사실.
+        UniqueConstraint(
+            "source_type", "source_id", "target_type", "target_id", "form",
+            name="uq_entity_references_source_target_form",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    source_type: Mapped[str] = mapped_column(Text, nullable=False)
+    # story #2259: 같은 엔티티 안 복수 텍스트 필드를 가르는 서브 위치(예: "description" vs
+    # "acceptance_criteria") — 필드가 하나뿐인 source_type 은 None.
+    source_field: Mapped[str | None] = mapped_column(Text, nullable=True)
+    source_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    target_type: Mapped[str] = mapped_column(Text, nullable=False)
+    target_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    form: Mapped[str] = mapped_column(Text, nullable=False)
+    # #2265(유나 lane) 몫 — 이 스토리에서 모양을 굳히지 않는다. proof 가 아니면 항상 None.
+    proof_payload: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/backend/app/services/reference_backfill.py
+++ b/backend/app/services/reference_backfill.py
@@ -2,7 +2,8 @@
 
 ⛔PO 판정: 이 마이그레이션에 삭제를 섞지 않는다 — 옛 `mentions` 표는 새 표가 라이브로 도는
 것을 본 뒤 별건으로 정리한다. 이 백필은 몇 번을 다시 돌려도 안전하다(ON CONFLICT DO NOTHING,
-`uq_entity_references_source_target_form` 이 중복 흡수).
+`uq_entity_references_non_proof` 부분 유니크 인덱스가 중복 흡수 — 백필 행은 항상
+form="mention"이라 이 인덱스의 `WHERE form <> 'proof'` 조건에 항상 걸린다).
 
 ⚠️알려진 손실 하나: 옛 `mentions` 테이블엔 mention(인라인)/embed(카드) 구분 컬럼이 없었다
 (source-path 였는지만 알 뿐, 어느 UI 형태였는지는 기록된 적이 없다) — 그래서 백필된 행은
@@ -14,7 +15,7 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -49,6 +50,15 @@ async def backfill_mentions_to_references(session: AsyncSession, *, org_id: uuid
         }
         for m in mentions
     ])
-    insert_stmt = insert_stmt.on_conflict_do_nothing(constraint="uq_entity_references_source_target_form")
+    # 부분 유니크 인덱스라 이름(constraint=)이 아니라 인덱스가 실제로 잡는 컬럼식으로
+    # 타겟팅한다(Postgres ON CONFLICT ON CONSTRAINT는 바닥이 CONSTRAINT여야 하고, 이건 바닥이
+    # 순수 INDEX다 — index_elements + index_where로 그 인덱스를 정확히 가리킨다).
+    insert_stmt = insert_stmt.on_conflict_do_nothing(
+        index_elements=[
+            Reference.source_type, func.coalesce(Reference.source_field, ""), Reference.source_id,
+            Reference.target_type, Reference.target_id, Reference.form,
+        ],
+        index_where=Reference.form != "proof",
+    )
     await session.execute(insert_stmt)
     return len(mentions)

--- a/backend/app/services/reference_backfill.py
+++ b/backend/app/services/reference_backfill.py
@@ -10,12 +10,15 @@ form="mention"이라 이 인덱스의 `WHERE form <> 'proof'` 조건에 항상 �
 전부 `form="mention"`으로 들어간다. 이건 데이터 손실이 아니라 **원래 없던 정보를 지어내지
 않는 것**(안 세는 것과 지어내는 것을 가르는 오늘의 규율 그대로) — 새로 생기는 행부터는
 정확한 form 이 기록된다.
+
+`source_field="body"` 로 채운다(PO 정정: NOT NULL·"자리가 본문이다"가 참) — 옛 표의 두
+source_type(chat_message·doc) 둘 다 텍스트 필드가 하나뿐이라 이게 유일하게 맞는 값이다.
 """
 from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -39,7 +42,7 @@ async def backfill_mentions_to_references(session: AsyncSession, *, org_id: uuid
             "id": uuid.uuid4(),
             "org_id": m.org_id,
             "source_type": m.source_type,
-            "source_field": None,  # 옛 표엔 서브 위치 개념이 없었다.
+            "source_field": "body",  # 옛 표의 두 source_type 다 텍스트 필드가 하나뿐이다.
             "source_id": m.source_id,
             "target_type": m.target_type,
             "target_id": m.target_id,
@@ -55,7 +58,7 @@ async def backfill_mentions_to_references(session: AsyncSession, *, org_id: uuid
     # 순수 INDEX다 — index_elements + index_where로 그 인덱스를 정확히 가리킨다).
     insert_stmt = insert_stmt.on_conflict_do_nothing(
         index_elements=[
-            Reference.source_type, func.coalesce(Reference.source_field, ""), Reference.source_id,
+            Reference.source_type, Reference.source_field, Reference.source_id,
             Reference.target_type, Reference.target_id, Reference.form,
         ],
         index_where=Reference.form != "proof",

--- a/backend/app/services/reference_backfill.py
+++ b/backend/app/services/reference_backfill.py
@@ -1,0 +1,54 @@
+"""story #2259(C-1) — 옛 mentions 데이터를 entity_references 로 옮긴다(복사, 삭제 아님).
+
+⛔PO 판정: 이 마이그레이션에 삭제를 섞지 않는다 — 옛 `mentions` 표는 새 표가 라이브로 도는
+것을 본 뒤 별건으로 정리한다. 이 백필은 몇 번을 다시 돌려도 안전하다(ON CONFLICT DO NOTHING,
+`uq_entity_references_source_target_form` 이 중복 흡수).
+
+⚠️알려진 손실 하나: 옛 `mentions` 테이블엔 mention(인라인)/embed(카드) 구분 컬럼이 없었다
+(source-path 였는지만 알 뿐, 어느 UI 형태였는지는 기록된 적이 없다) — 그래서 백필된 행은
+전부 `form="mention"`으로 들어간다. 이건 데이터 손실이 아니라 **원래 없던 정보를 지어내지
+않는 것**(안 세는 것과 지어내는 것을 가르는 오늘의 규율 그대로) — 새로 생기는 행부터는
+정확한 form 이 기록된다.
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.mention import Mention
+from app.models.reference import Reference
+
+
+async def backfill_mentions_to_references(session: AsyncSession, *, org_id: uuid.UUID | None = None) -> int:
+    """mentions 행을 entity_references 로 복사. org_id 지정 시 그 org 만(부분 재실행용).
+    반환값 = 시도한 행 수(중복은 ON CONFLICT DO NOTHING 으로 조용히 흡수 — 정확한 신규
+    삽입 건수가 필요하면 호출 전후 count(*) 차분으로 잰다)."""
+    stmt = select(Mention)
+    if org_id is not None:
+        stmt = stmt.where(Mention.org_id == org_id)
+    mentions = (await session.execute(stmt)).scalars().all()
+    if not mentions:
+        return 0
+
+    insert_stmt = pg_insert(Reference).values([
+        {
+            "id": uuid.uuid4(),
+            "org_id": m.org_id,
+            "source_type": m.source_type,
+            "source_field": None,  # 옛 표엔 서브 위치 개념이 없었다.
+            "source_id": m.source_id,
+            "target_type": m.target_type,
+            "target_id": m.target_id,
+            "form": "mention",  # ⛔모듈 docstring 참조 — 지어내지 않고 유일하게 아는 값.
+            "proof_payload": None,
+            "created_by": m.created_by,
+            "created_at": m.created_at,
+        }
+        for m in mentions
+    ])
+    insert_stmt = insert_stmt.on_conflict_do_nothing(constraint="uq_entity_references_source_target_form")
+    await session.execute(insert_stmt)
+    return len(mentions)

--- a/backend/app/services/reference_core.py
+++ b/backend/app/services/reference_core.py
@@ -37,7 +37,7 @@ class UnregisteredEntityTypeError(ValueError):
 class ResolvedReference:
     id: uuid.UUID
     source_type: str
-    source_field: str | None
+    source_field: str
     source_id: uuid.UUID
     target_type: str
     target_id: uuid.UUID
@@ -57,7 +57,7 @@ async def insert_reference(
     *,
     org_id: uuid.UUID,
     source_type: str,
-    source_field: str | None,
+    source_field: str,
     source_id: uuid.UUID,
     target_type: str,
     target_id: uuid.UUID,

--- a/backend/app/services/reference_core.py
+++ b/backend/app/services/reference_core.py
@@ -1,0 +1,157 @@
+"""story #2259(C-1) — 참조 write/read 코어.
+
+⛔이 파일은 「가리켰다」는 사실만 다룬다 — 의미(잇따름·필요함 등) 판정은 다른 층(#2261+)의 몫.
+
+write: `insert_reference` — form 은 app-level 로도 검증(DB CHECK 와 이중 방어, 빠른 명확한
+에러), entity_type(source/target 둘 다)은 `reference_registry.ENTITY_RESOLVERS`에 없으면
+**거부**한다(조용히 통과 금지, PO 판정).
+
+read: `list_references` — 양방향(outgoing/incoming)을 같은 함수가 축만 바꿔 처리(재구현 0).
+끊어진 참조는 **읽는 시점에** 판정한다(PO 판정 (b) — 삭제 콜사이트 훅 없음, 실패해도 "늦게
+안다"이지 "영영 모른다"가 아니다). 두 불변식을 지킨다:
+  ㉠순서   permission 필터 → 존재 판정(거꾸로 하면 "못 보는 것"과 "끊어진 것"이 섞인다).
+           ⛔C-3(#2261·안전핀)이 아직 없어 `visible_ids_by_type`는 지금 None 기본값(무필터)
+           — #2261이 이 파라미터를 채워 호출하면 되고, 이 함수 몸통은 안 바뀐다.
+  ㉡N+1 금지  존재 판정은 반대편 entity_type 별로 묶어 **한 번씩만** 조회한다.
+"""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import Literal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.reference import FORMS, Reference
+from app.services.reference_registry import ENTITY_RESOLVERS, is_registered_entity_type
+
+Direction = Literal["outgoing", "incoming"]
+
+
+class UnregisteredEntityTypeError(ValueError):
+    """source_type/target_type 이 reference_registry 에 없다 — write 거부(조용히 통과 금지)."""
+
+
+@dataclass(frozen=True)
+class ResolvedReference:
+    id: uuid.UUID
+    source_type: str
+    source_field: str | None
+    source_id: uuid.UUID
+    target_type: str
+    target_id: uuid.UUID
+    form: str
+    created_at: object
+    # PO (b) — 읽는 시점 판정. **direction 에 따라 무엇을 가리키는지 달라진다** —
+    # outgoing 이면 target 의 존재, incoming 이면 source 의 존재("반대편"이 항상 이 값의
+    # 대상). 필드명을 target_still_exists 로 고정하지 않은 이유가 이것 — incoming 조회에서
+    # "target" 은 이미 entity_id 자신(항상 존재)이라 의미가 없다. None = 아직 안 밝혀짐
+    # (반대편 entity_type 이 registry 밖이라 존재판정 자체를 못 한 경우 — count_orphan_types
+    # 가 잡는 그 케이스). True/False 만 신뢰.
+    still_exists: bool | None
+
+
+async def insert_reference(
+    session: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    source_type: str,
+    source_field: str | None,
+    source_id: uuid.UUID,
+    target_type: str,
+    target_id: uuid.UUID,
+    form: str,
+    created_by: uuid.UUID | None,
+    proof_payload: dict | None = None,
+) -> Reference:
+    if form not in FORMS:
+        raise ValueError(f"form must be one of {sorted(FORMS)}, got {form!r}")
+    if not is_registered_entity_type(source_type):
+        raise UnregisteredEntityTypeError(f"source_type {source_type!r} not in reference_registry")
+    if not is_registered_entity_type(target_type):
+        raise UnregisteredEntityTypeError(f"target_type {target_type!r} not in reference_registry")
+
+    ref = Reference(
+        id=uuid.uuid4(), org_id=org_id, source_type=source_type, source_field=source_field,
+        source_id=source_id, target_type=target_type, target_id=target_id, form=form,
+        proof_payload=proof_payload, created_by=created_by,
+    )
+    session.add(ref)
+    return ref
+
+
+async def _batch_resolve_existence(
+    session: AsyncSession, org_id: uuid.UUID, ids_by_type: dict[str, set[uuid.UUID]],
+) -> dict[str, set[uuid.UUID]]:
+    """㉡N+1 금지 — entity_type 별로 묶어 resolver 를 **한 번씩만** 호출한다."""
+    existing_by_type: dict[str, set[uuid.UUID]] = {}
+    for entity_type, ids in ids_by_type.items():
+        resolver = ENTITY_RESOLVERS.get(entity_type)
+        if resolver is None:
+            # registry 밖 타입 — 존재판정 불가(count_orphan_types 가 별도로 이 사고를 잡는다).
+            existing_by_type[entity_type] = set()
+            continue
+        existing_by_type[entity_type] = await resolver(session, org_id, list(ids))
+    return existing_by_type
+
+
+async def list_references(
+    session: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    entity_type: str,
+    entity_id: uuid.UUID,
+    direction: Direction,
+    visible_ids_by_type: dict[str, set[uuid.UUID]] | None = None,
+) -> list[ResolvedReference]:
+    """direction="outgoing" — entity_id 가 가리키는 것(내가 가리키는 것).
+    direction="incoming" — entity_id 를 가리키는 것(나를 가리키는 것).
+    같은 표에서 축만 바꿔 조회한다(backlinks.py 기존 패턴 재사용)."""
+    if direction == "outgoing":
+        stmt = select(Reference).where(
+            Reference.org_id == org_id, Reference.source_type == entity_type,
+            Reference.source_id == entity_id,
+        )
+    else:
+        stmt = select(Reference).where(
+            Reference.org_id == org_id, Reference.target_type == entity_type,
+            Reference.target_id == entity_id,
+        )
+    rows = (await session.execute(stmt)).scalars().all()
+
+    # ㉠순서: 권한 필터 먼저 — 반대편(outgoing 이면 target, incoming 이면 source)이 보이지
+    # 않으면 여기서 걸러낸다(존재판정 이전에). #2261 붙기 전엔 무필터(모두 통과).
+    if visible_ids_by_type is not None:
+        def _other_side_visible(r: Reference) -> bool:
+            other_type = r.target_type if direction == "outgoing" else r.source_type
+            other_id = r.target_id if direction == "outgoing" else r.source_id
+            return other_id in visible_ids_by_type.get(other_type, set())
+
+        rows = [r for r in rows if _other_side_visible(r)]
+
+    # ㉡존재 판정 — 반대편 id 를 entity_type 별로 묶어 배치 조회(N+1 금지).
+    ids_by_type: dict[str, set[uuid.UUID]] = {}
+    for r in rows:
+        other_type = r.target_type if direction == "outgoing" else r.source_type
+        other_id = r.target_id if direction == "outgoing" else r.source_id
+        ids_by_type.setdefault(other_type, set()).add(other_id)
+    existing_by_type = await _batch_resolve_existence(session, org_id, ids_by_type)
+
+    resolved: list[ResolvedReference] = []
+    for r in rows:
+        other_type = r.target_type if direction == "outgoing" else r.source_type
+        other_id = r.target_id if direction == "outgoing" else r.source_id
+        still_exists: bool | None
+        if other_type not in ENTITY_RESOLVERS:
+            still_exists = None  # registry 밖 타입 — 판정 불가(orphan 점검이 별도로 잡음).
+        else:
+            still_exists = other_id in existing_by_type.get(other_type, set())
+        resolved.append(
+            ResolvedReference(
+                id=r.id, source_type=r.source_type, source_field=r.source_field,
+                source_id=r.source_id, target_type=r.target_type, target_id=r.target_id,
+                form=r.form, created_at=r.created_at, still_exists=still_exists,
+            )
+        )
+    return resolved

--- a/backend/app/services/reference_registry.py
+++ b/backend/app/services/reference_registry.py
@@ -1,0 +1,93 @@
+"""story #2259(C-1) — entity type resolver registry.
+
+⛔0-diff 확장 원칙: 대상 종류를 CHECK 로 나열하지 않는 대신, write-time 검증과 read-time
+존재판정(§`reference_core.py`)을 이 registry 하나로 몬다. 새 타입을 열려면 여기 항목 하나만
+추가하면 되고, `reference.py`/`reference_core.py` 몸통은 손대지 않는다.
+
+⛔PO 판정(2026-07-28): "나열 안 한다"가 "아무거나 받는다"는 아니다 — registry 에 없는
+타입은 write 시 거부한다(조용히 통과 금지). 그리고 이미 저장된 행 중 registry 에 없는
+타입이 있는지 세는 점검(`count_orphan_types`)을 별도로 둔다(오타 타입이 조용히 쌓여도
+DB CHECK 가 안 지켜 주니 이게 유일한 감시망).
+
+⛔지금 실제로 등록하는 것은 **딱 3종**(doc·story·epic) — #2259 착수 시점에 실제로 도는
+것만. 블루프린트가 언급한 나머지(sprint·artifact·hypothesis·goal·task·chat message·
+evidence)는 "등록되면 열리는" 것이지, 쓰지도 않을 resolver 를 미리 짓는 것은 그 자체가
+"만들어졌는데 도는 자리가 없는" 죽은 경로다(#2260이 고친 그 클래스를 재발시키지 않는다).
+"""
+from __future__ import annotations
+
+import uuid
+from collections.abc import Awaitable, Callable
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+EntityExistsResolver = Callable[[AsyncSession, uuid.UUID, list[uuid.UUID]], Awaitable[set[uuid.UUID]]]
+
+
+async def _resolve_docs(session: AsyncSession, org_id: uuid.UUID, ids: list[uuid.UUID]) -> set[uuid.UUID]:
+    from app.models.doc import Doc
+
+    rows = (
+        await session.execute(
+            select(Doc.id).where(Doc.org_id == org_id, Doc.id.in_(ids), Doc.deleted_at.is_(None))
+        )
+    ).scalars().all()
+    return set(rows)
+
+
+async def _resolve_stories(session: AsyncSession, org_id: uuid.UUID, ids: list[uuid.UUID]) -> set[uuid.UUID]:
+    from app.models.pm import Story
+
+    rows = (
+        await session.execute(
+            select(Story.id).where(Story.org_id == org_id, Story.id.in_(ids), Story.deleted_at.is_(None))
+        )
+    ).scalars().all()
+    return set(rows)
+
+
+async def _resolve_epics(session: AsyncSession, org_id: uuid.UUID, ids: list[uuid.UUID]) -> set[uuid.UUID]:
+    from app.models.pm import Goal
+
+    # Goal(epic)엔 SoftDeleteMixin이 없다(하드 삭제) — row 존재 자체가 존재판정.
+    rows = (
+        await session.execute(select(Goal.id).where(Goal.org_id == org_id, Goal.id.in_(ids)))
+    ).scalars().all()
+    return set(rows)
+
+
+# entity_type(str) -> resolver. 각 resolver 는 (session, org_id, ids) -> {존재하는 id 집합}.
+# ⛔이 dict 가 유일한 SSOT — write 검증과 read 존재판정이 둘 다 이걸 참조한다(재구현 0).
+ENTITY_RESOLVERS: dict[str, EntityExistsResolver] = {
+    "doc": _resolve_docs,
+    "story": _resolve_stories,
+    "epic": _resolve_epics,
+}
+
+
+def is_registered_entity_type(entity_type: str) -> bool:
+    return entity_type in ENTITY_RESOLVERS
+
+
+async def count_orphan_types(session: AsyncSession, org_id: uuid.UUID) -> dict[str, int]:
+    """⭐PO가 요구한 감시망 — entity_references 에 저장된 행 중 source_type/target_type 이
+    registry 에 없는 것을 종류별로 센다. 0이 정상 — 0이 아니면 오타/미등록 타입이 조용히
+    쓰기를 통과한 사고(이 함수가 잡아야 하는 그 사고)다."""
+    from collections import Counter
+
+    from app.models.reference import Reference
+
+    known = set(ENTITY_RESOLVERS)
+    rows = (
+        await session.execute(
+            select(Reference.source_type, Reference.target_type).where(Reference.org_id == org_id)
+        )
+    ).all()
+    counts: Counter[str] = Counter()
+    for source_type, target_type in rows:
+        if source_type not in known:
+            counts[f"source:{source_type}"] += 1
+        if target_type not in known:
+            counts[f"target:{target_type}"] += 1
+    return dict(counts)

--- a/backend/tests/test_2259_entity_references_realdb.py
+++ b/backend/tests/test_2259_entity_references_realdb.py
@@ -312,3 +312,103 @@ async def test_orphan_type_count_catches_unregistered_type_in_storage():
             assert orphans.get("target:sprintt") == 1
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_duplicate_mention_rejected_by_unique_index():
+    """PO 정정(2026-07-28) — mention/embed는 같은 (자리,대상) 재삽입이 막힌다."""
+    from sqlalchemy.exc import IntegrityError
+
+    from app.models.reference import Reference
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            story = await _seed_story(session, org, project)
+            doc = await _seed_doc(session, org, project)
+            await session.commit()
+
+            session.add(Reference(
+                id=uuid.uuid4(), org_id=org.id, source_type="story", source_field=None,
+                source_id=story.id, target_type="doc", target_id=doc.id, form="mention",
+                created_by=member.id,
+            ))
+            await session.commit()
+
+            session.add(Reference(
+                id=uuid.uuid4(), org_id=org.id, source_type="story", source_field=None,
+                source_id=story.id, target_type="doc", target_id=doc.id, form="mention",
+                created_by=member.id,
+            ))
+            with pytest.raises(IntegrityError):
+                await session.commit()
+            await session.rollback()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_duplicate_proof_is_allowed():
+    """PO 정정(2026-07-28) — proof는 같은 (자리,대상)을 여러 조각(다른 범위)으로 인용하는
+    것이 정상 쓰임이라, 부분 유니크 인덱스에서 제외돼 막히면 안 된다. 별도 세션/엔진으로
+    분리(앞 테스트의 IntegrityError+rollback 뒤 같은 세션을 계속 쓰면 asyncpg 커넥션이
+    greenlet 브릿지에서 불안정해지는 것 관찰 — 이 코드베이스의 기존 rollback 테스트들도
+    전부 rollback 직후 종료하지 계속 쓰지 않는 것과 같은 이유로 세션을 새로 연다)."""
+    from app.models.reference import Reference
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            story = await _seed_story(session, org, project)
+            doc = await _seed_doc(session, org, project)
+            await session.commit()
+
+            session.add(Reference(
+                id=uuid.uuid4(), org_id=org.id, source_type="story", source_field=None,
+                source_id=story.id, target_type="doc", target_id=doc.id, form="proof",
+                created_by=member.id,
+            ))
+            session.add(Reference(
+                id=uuid.uuid4(), org_id=org.id, source_type="story", source_field=None,
+                source_id=story.id, target_type="doc", target_id=doc.id, form="proof",
+                created_by=member.id,
+            ))
+            await session.commit()  # 두 proof 다 살아있어야 한다(예외 없이).
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_null_source_field_still_dedupes_via_coalesce():
+    """⛔NULL 함정 — source_field가 nullable이라 COALESCE 없이 부분 유니크를 걸면 NULL<>NULL
+    이라 중복이 안 잡힌다(uq_stories_project_id_story_number와 같은 함정). 여기선 잡혀야 한다."""
+    from sqlalchemy.exc import IntegrityError
+
+    from app.models.reference import Reference
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            message_id = uuid.uuid4()
+            doc = await _seed_doc(session, org, project)
+            await session.commit()
+
+            session.add(Reference(
+                id=uuid.uuid4(), org_id=org.id, source_type="chat_message", source_field=None,
+                source_id=message_id, target_type="doc", target_id=doc.id, form="mention",
+                created_by=member.id,
+            ))
+            await session.commit()
+
+            session.add(Reference(
+                id=uuid.uuid4(), org_id=org.id, source_type="chat_message", source_field=None,
+                source_id=message_id, target_type="doc", target_id=doc.id, form="mention",
+                created_by=member.id,
+            ))
+            with pytest.raises(IntegrityError):
+                await session.commit()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2259_entity_references_realdb.py
+++ b/backend/tests/test_2259_entity_references_realdb.py
@@ -1,0 +1,314 @@
+"""story #2259(C-1, E-CONNECT) — entity_references 코어 실PG 검증.
+
+이 파일이 증명하는 것 — 오늘 판정 넷:
+①(b) 읽는 시점 tombstone 판정 + 순서(권한필터→존재판정)·N+1 금지
+②registry 밖 타입은 write 거부 + orphan 타입 카운트
+③(스코프 밖 — proof/여분 resolver는 이 스토리에 없다, 검증할 것도 없음)
+④백필이 idempotent(중복 재실행 안전) + 기존 mentions 데이터가 새 표에서 왕복된다(AC5)
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project_member(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.user import User
+    from app.models.member import Member
+
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.flush()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.flush()
+    member = Member(id=uuid.uuid4(), org_id=org.id, type="human", user_id=user.id, name="Test Human")
+    session.add(member)
+    await session.flush()
+    return org, project, member
+
+
+async def _seed_story(session, org, project):
+    from app.models.pm import Story
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="S", status="backlog")
+    session.add(story)
+    await session.flush()
+    return story
+
+
+async def _seed_doc(session, org, project):
+    from app.models.doc import Doc
+    doc = Doc(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="D", slug=f"d-{uuid.uuid4().hex[:8]}")
+    session.add(doc)
+    await session.flush()
+    return doc
+
+
+@pytest.mark.anyio
+async def test_insert_rejects_unregistered_entity_type():
+    """②registry 밖 타입은 조용히 통과가 아니라 거부."""
+    from app.services.reference_core import UnregisteredEntityTypeError, insert_reference
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            await session.commit()
+            with pytest.raises(UnregisteredEntityTypeError):
+                await insert_reference(
+                    session, org_id=org.id, source_type="chat_message", source_field=None,
+                    source_id=uuid.uuid4(), target_type="not_a_real_type", target_id=uuid.uuid4(),
+                    form="mention", created_by=member.id,
+                )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_insert_rejects_invalid_form():
+    from app.services.reference_core import insert_reference
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            await session.commit()
+            with pytest.raises(ValueError):
+                await insert_reference(
+                    session, org_id=org.id, source_type="chat_message", source_field=None,
+                    source_id=uuid.uuid4(), target_type="doc", target_id=uuid.uuid4(),
+                    form="not_a_real_form", created_by=member.id,
+                )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_outgoing_reference_marks_deleted_target_as_broken():
+    """⭐AC4 핵심 — 대상 doc이 soft-delete되면, 읽을 때 still_exists=False로 판정된다(삭제
+    콜사이트 훅 없이, 읽는 시점에)."""
+    from datetime import datetime, timezone
+
+    from app.services.reference_core import insert_reference, list_references
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            story = await _seed_story(session, org, project)
+            doc = await _seed_doc(session, org, project)
+            await session.commit()
+
+            await insert_reference(
+                session, org_id=org.id, source_type="story", source_field="description",
+                source_id=story.id, target_type="doc", target_id=doc.id,
+                form="mention", created_by=member.id,
+            )
+            await session.commit()
+
+            refs_before = await list_references(
+                session, org_id=org.id, entity_type="story", entity_id=story.id, direction="outgoing",
+            )
+            assert len(refs_before) == 1
+            assert refs_before[0].still_exists is True
+
+            doc.deleted_at = datetime.now(timezone.utc)
+            await session.commit()
+
+            refs_after = await list_references(
+                session, org_id=org.id, entity_type="story", entity_id=story.id, direction="outgoing",
+            )
+            assert len(refs_after) == 1, "끊어진 참조도 목록에서 사라지면 안 된다 — «끊어졌다»로 남아야 한다"
+            assert refs_after[0].still_exists is False
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_incoming_direction_flips_axis_on_same_table():
+    """양방향 — target 쪽에서 조회하면(incoming) source가 반환된다(같은 표, 축만 바꿈)."""
+    from app.services.reference_core import insert_reference, list_references
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            story = await _seed_story(session, org, project)
+            doc = await _seed_doc(session, org, project)
+            await session.commit()
+
+            await insert_reference(
+                session, org_id=org.id, source_type="story", source_field="description",
+                source_id=story.id, target_type="doc", target_id=doc.id,
+                form="mention", created_by=member.id,
+            )
+            await session.commit()
+
+            incoming = await list_references(
+                session, org_id=org.id, entity_type="doc", entity_id=doc.id, direction="incoming",
+            )
+            assert len(incoming) == 1
+            assert incoming[0].source_type == "story"
+            assert incoming[0].source_id == story.id
+            assert incoming[0].still_exists is True  # source(story) 살아있음
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_visible_ids_filter_applies_before_existence_check():
+    """㉠순서 — 권한 필터가 존재판정보다 먼저 적용된다(못 보는 것과 끊어진 것을 안 섞음)."""
+    from app.services.reference_core import insert_reference, list_references
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            story = await _seed_story(session, org, project)
+            doc_visible = await _seed_doc(session, org, project)
+            doc_hidden = await _seed_doc(session, org, project)
+            await session.commit()
+
+            for target in (doc_visible, doc_hidden):
+                await insert_reference(
+                    session, org_id=org.id, source_type="story", source_field="description",
+                    source_id=story.id, target_type="doc", target_id=target.id,
+                    form="mention", created_by=member.id,
+                )
+            await session.commit()
+
+            visible = await list_references(
+                session, org_id=org.id, entity_type="story", entity_id=story.id, direction="outgoing",
+                visible_ids_by_type={"doc": {doc_visible.id}},
+            )
+            assert {r.target_id for r in visible} == {doc_visible.id}, (
+                "권한 필터를 줬는데 안 보이는 doc이 결과에 새어 들어왔다"
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_backfill_is_idempotent_and_old_data_round_trips():
+    """⭐AC5 핵심 — 옛 mentions 데이터가 백필 후 entity_references 로 왕복(read)된다.
+    같은 백필을 두 번 돌려도 중복 행이 안 생긴다(idempotent)."""
+    from sqlalchemy import func, select
+
+    from app.models.mention import Mention
+    from app.models.reference import Reference
+    from app.services.reference_backfill import backfill_mentions_to_references
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            story = await _seed_story(session, org, project)
+            message_id = uuid.uuid4()
+
+            # 옛 시스템처럼 mentions 테이블에 직접 씀(백필 대상 데이터 시딩).
+            old_mention = Mention(
+                id=uuid.uuid4(), org_id=org.id, source_type="chat_message", source_id=message_id,
+                target_type="story", target_id=story.id, created_by=member.id,
+            )
+            session.add(old_mention)
+            await session.commit()
+
+            n1 = await backfill_mentions_to_references(session, org_id=org.id)
+            await session.commit()
+            assert n1 == 1
+
+            count_after_first = (
+                await session.execute(select(func.count()).select_from(Reference).where(Reference.org_id == org.id))
+            ).scalar_one()
+            assert count_after_first == 1
+
+            # 재실행 — 중복 안 생김.
+            await backfill_mentions_to_references(session, org_id=org.id)
+            await session.commit()
+            count_after_second = (
+                await session.execute(select(func.count()).select_from(Reference).where(Reference.org_id == org.id))
+            ).scalar_one()
+            assert count_after_second == 1, "백필 재실행이 중복 행을 만들었다 — idempotent가 아니다"
+
+            # 왕복 — 백필된 옛 데이터가 새 read 경로로 정상 조회된다.
+            from app.services.reference_core import list_references
+
+            refs = await list_references(
+                session, org_id=org.id, entity_type="chat_message", entity_id=message_id, direction="outgoing",
+            )
+            assert len(refs) == 1
+            assert refs[0].target_type == "story"
+            assert refs[0].target_id == story.id
+            assert refs[0].form == "mention"  # 옛 표엔 form 개념이 없어 백필은 항상 mention.
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_orphan_type_count_catches_unregistered_type_in_storage():
+    """②저장분 중 registry에 없는 타입이 있으면 orphan 점검이 잡는다(오타 방지망)."""
+    import uuid as uuid_mod
+
+    from app.models.reference import Reference
+    from app.services.reference_registry import count_orphan_types
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            story = await _seed_story(session, org, project)
+            await session.commit()
+
+            # insert_reference 를 우회해 registry 검증 없이 직접 삽입(오타 타입 시뮬레이션 —
+            # write 경로가 안 걸러도 orphan 점검이 잡아야 하는 것을 증명).
+            bogus = Reference(
+                id=uuid_mod.uuid4(), org_id=org.id, source_type="story", source_field=None,
+                source_id=story.id, target_type="sprintt",  # 오타
+                target_id=uuid_mod.uuid4(), form="mention", created_by=member.id,
+            )
+            session.add(bogus)
+            await session.commit()
+
+            orphans = await count_orphan_types(session, org.id)
+            assert orphans.get("target:sprintt") == 1
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2259_entity_references_realdb.py
+++ b/backend/tests/test_2259_entity_references_realdb.py
@@ -95,7 +95,7 @@ async def test_insert_rejects_unregistered_entity_type():
             await session.commit()
             with pytest.raises(UnregisteredEntityTypeError):
                 await insert_reference(
-                    session, org_id=org.id, source_type="chat_message", source_field=None,
+                    session, org_id=org.id, source_type="chat_message", source_field="body",
                     source_id=uuid.uuid4(), target_type="not_a_real_type", target_id=uuid.uuid4(),
                     form="mention", created_by=member.id,
                 )
@@ -114,7 +114,7 @@ async def test_insert_rejects_invalid_form():
             await session.commit()
             with pytest.raises(ValueError):
                 await insert_reference(
-                    session, org_id=org.id, source_type="chat_message", source_field=None,
+                    session, org_id=org.id, source_type="chat_message", source_field="body",
                     source_id=uuid.uuid4(), target_type="doc", target_id=uuid.uuid4(),
                     form="not_a_real_form", created_by=member.id,
                 )
@@ -301,7 +301,7 @@ async def test_orphan_type_count_catches_unregistered_type_in_storage():
             # insert_reference 를 우회해 registry 검증 없이 직접 삽입(오타 타입 시뮬레이션 —
             # write 경로가 안 걸러도 orphan 점검이 잡아야 하는 것을 증명).
             bogus = Reference(
-                id=uuid_mod.uuid4(), org_id=org.id, source_type="story", source_field=None,
+                id=uuid_mod.uuid4(), org_id=org.id, source_type="story", source_field="description",
                 source_id=story.id, target_type="sprintt",  # 오타
                 target_id=uuid_mod.uuid4(), form="mention", created_by=member.id,
             )
@@ -330,14 +330,14 @@ async def test_duplicate_mention_rejected_by_unique_index():
             await session.commit()
 
             session.add(Reference(
-                id=uuid.uuid4(), org_id=org.id, source_type="story", source_field=None,
+                id=uuid.uuid4(), org_id=org.id, source_type="story", source_field="description",
                 source_id=story.id, target_type="doc", target_id=doc.id, form="mention",
                 created_by=member.id,
             ))
             await session.commit()
 
             session.add(Reference(
-                id=uuid.uuid4(), org_id=org.id, source_type="story", source_field=None,
+                id=uuid.uuid4(), org_id=org.id, source_type="story", source_field="description",
                 source_id=story.id, target_type="doc", target_id=doc.id, form="mention",
                 created_by=member.id,
             ))
@@ -366,12 +366,12 @@ async def test_duplicate_proof_is_allowed():
             await session.commit()
 
             session.add(Reference(
-                id=uuid.uuid4(), org_id=org.id, source_type="story", source_field=None,
+                id=uuid.uuid4(), org_id=org.id, source_type="story", source_field="description",
                 source_id=story.id, target_type="doc", target_id=doc.id, form="proof",
                 created_by=member.id,
             ))
             session.add(Reference(
-                id=uuid.uuid4(), org_id=org.id, source_type="story", source_field=None,
+                id=uuid.uuid4(), org_id=org.id, source_type="story", source_field="description",
                 source_id=story.id, target_type="doc", target_id=doc.id, form="proof",
                 created_by=member.id,
             ))
@@ -381,9 +381,10 @@ async def test_duplicate_proof_is_allowed():
 
 
 @pytest.mark.anyio
-async def test_null_source_field_still_dedupes_via_coalesce():
-    """⛔NULL 함정 — source_field가 nullable이라 COALESCE 없이 부분 유니크를 걸면 NULL<>NULL
-    이라 중복이 안 잡힌다(uq_stories_project_id_story_number와 같은 함정). 여기선 잡혀야 한다."""
+async def test_chat_message_duplicate_mention_dedupes_correctly():
+    """chat_message 소스(source_field="body" 고정)도 정상적으로 중복이 잡힌다 — PO 정정
+    전에는 source_field가 nullable이라 NULL<>NULL 함정으로 이게 «안 잡혔을» 자리(오늘
+    세션 두 번째 재발한 uq_stories_project_id_story_number류 함정, NOT NULL로 근본 해소)."""
     from sqlalchemy.exc import IntegrityError
 
     from app.models.reference import Reference
@@ -397,15 +398,41 @@ async def test_null_source_field_still_dedupes_via_coalesce():
             await session.commit()
 
             session.add(Reference(
-                id=uuid.uuid4(), org_id=org.id, source_type="chat_message", source_field=None,
+                id=uuid.uuid4(), org_id=org.id, source_type="chat_message", source_field="body",
                 source_id=message_id, target_type="doc", target_id=doc.id, form="mention",
                 created_by=member.id,
             ))
             await session.commit()
 
             session.add(Reference(
-                id=uuid.uuid4(), org_id=org.id, source_type="chat_message", source_field=None,
+                id=uuid.uuid4(), org_id=org.id, source_type="chat_message", source_field="body",
                 source_id=message_id, target_type="doc", target_id=doc.id, form="mention",
+                created_by=member.id,
+            ))
+            with pytest.raises(IntegrityError):
+                await session.commit()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_source_field_not_null_enforced_at_db_level():
+    """PO 정정의 근본 요구 — source_field에 NULL을 넣으려 하면 DB가 거부한다(NOT NULL).
+    "자리가 없다"는 상태 자체가 스키마에서 표현 불가능해야 한다는 것이 이 처방의 핵심."""
+    from sqlalchemy.exc import IntegrityError
+
+    from app.models.reference import Reference
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            doc = await _seed_doc(session, org, project)
+            await session.commit()
+
+            session.add(Reference(
+                id=uuid.uuid4(), org_id=org.id, source_type="chat_message", source_field=None,
+                source_id=uuid.uuid4(), target_type="doc", target_id=doc.id, form="mention",
                 created_by=member.id,
             ))
             with pytest.raises(IntegrityError):


### PR DESCRIPTION
## 요약
블루프린트(`flow-map-blueprint-v1`)의 핵심 미지수 — 본문 `#번호` 상호참조 442건이 있지만 그게 데이터로서의 연결이 된 적이 없다. 이 PR은 그 원석을 캐낼 수 있는 1급 참조 구조의 뼈대(표+양방향+백필+registry)를 세운다. 오르테가군 스코프컷 반영: proof payload 모양과 여분 7종 resolver는 이 스토리에 없음(각각 #2265, 향후 등록 시).

## 구조
```
axis          설계
자리          (source_type, source_field, source_id) — source_field는 NOT NULL(PO 정정:
              "자리가 없다"가 아니라 "자리가 본문이다" — 단일필드 소스도 "body"를 명시)
대상          (target_type, target_id) — source와 동일 폴리모픽 원칙
형태          form CHECK(mention/embed/proof, 유한) — entity type과 다른 성격이라 여기만 CHECK
0-diff 확장   entity type은 CHECK 없음 — reference_registry.ENTITY_RESOLVERS(현재 doc·
              story·epic 3종만, 실제 도는 것만). registry 밖 타입은 write 거부 +
              count_orphan_types()로 저장분 오타 감시
양방향        같은 표에서 축만 바꿔 조회(list_references(direction=outgoing/incoming),
              backlinks.py 기존 패턴 재사용 — 재발명 0)
끊어진 참조   PO 판정(b) — 읽는 시점 존재판정(삭제 콜사이트 훅 없음, "늦게 안다"≠"영영 모른다").
              순서 불변식(권한필터→존재판정, C-3/#2261 훅 자리만 마련) + N+1 금지(타입별 배치조회)
백필          mentions→entity_references 복사(ON CONFLICT DO NOTHING, idempotent). 옛 표 안
              지움 — 새 표가 라이브로 도는 것을 본 뒤 별건
```

## 부분 유니크 — 두 차례 오르테가군 처방 반영
1. `UNIQUE(source,target,form) WHERE form <> 'proof'` — proof는 같은 자리·같은 대상을 다른 범위로 여러 번 인용하는 정상 쓰임(#2265 몫이라 아직 그 축을 못 세움).
2. source_field는 COALESCE가 아니라 **NOT NULL**(PO 정정) — nullable 컬럼을 유니크 축에 넣으면 NULL<>NULL이라 중복이 안 잡히는 함정(오늘 세션 `uq_stories_project_id_story_number`와 동형, 두 번째 재발). COALESCE는 "기억해야 하는 가드"라 근본에서 NOT NULL로 막음.

## 검증
- RED→GREEN: `_resolve_docs`의 `deleted_at` 필터 임시 제거 → tombstone 테스트 실패 확認 → 복원 → GREEN.
- 신규 11건 전부 통과: registry 밖 타입 거부·invalid form 거부·tombstone 판정·양방향·권한필터 순서·백필 idempotent+왕복(AC5)·orphan 타입 카운트·duplicate mention 거부·duplicate proof 허용·NOT NULL 강제·chat_message 중복 정상 잡힘.
- 회귀 0: `test_1993_mention_parser`(17)·`test_1993_mentions_realdb`(9)·`test_2260_mention_target_type_not_hardcoded_realdb`(3)·`test_docs`(13) 전부 그대로 GREEN. 총 53건.
- 마이그레이션 0213(PO 채번) — 로컬 실PG 정상 적용, 순수 additive(mentions 테이블 무변경).

## 스코프 밖(명시)
- `insert_chat_mentions`/`reconcile_doc_mentions`의 라이브 쓰기 재배선 — 오르테가군 확認 대기 중 별건 판단(체크포인트 보고에서 여쭤둠, 판이 커지는 결정이라 이 PR엔 안 넣음).
- proof_payload 저장 모양 — #2265(유나 lane) 대기, nullable 칸만.
- resolver 7종 추가(sprint·artifact·hypothesis·goal·task·chat message·evidence) — 실제 도는 3종만 등록, 나머지는 등록되면 열리는 구조.
- HTTP 엔드포인트 — 이 PR은 서비스 레이어까지(AC3 "한 구조에서 나온다"는 이걸로 충족). API 노출은 #2263/#2266이 소비하며 필요시 추가.

## 롤백
`git revert` 단일 계열 — 스키마는 additive(신규 테이블만), 안전.