### PR TITLE
hotfix: 규약A 이중포장 두 인스턴스 정정 — story-detail 열 때 크래시(prod)

### DIFF
--- a/apps/web/src/app/api/evidence/route.ts
+++ b/apps/web/src/app/api/evidence/route.ts
@@ -14,13 +14,15 @@ export async function GET(request: Request) {
   } catch (err: unknown) { return handleApiError(err); }
 }
 
-/** story #2258 — 증거연결: BE는 이미 있었는데 FE가 부르지 않던 경로. */
+/** story #2258 — 증거연결: BE는 이미 있었는데 FE가 부르지 않던 경로.
+ * 긴급 정정(2026-07-28, prod 크래시): BE create_evidence는 단건 객체를 그대로 반환하는데
+ * (list 아님, response_model=EvidenceResponse) apiSuccess로 한 번 더 감싸 소비부(evidence-
+ * section.tsx)가 실제로는 {data,error,meta}를 받으면서 `as EvidenceItem`으로 거짓 단언했다.
+ * 형제(request-verification route)처럼 그대로 돌려준다 — raw passthrough, 새 규칙 발명 0. */
 export async function POST(request: Request) {
   try {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
-    const _r = await proxyToFastapi(request, '/api/v2/evidence');
-    if (!_r.ok) return _r;
-    return apiSuccess(await _r.json());
+    return await proxyToFastapi(request, '/api/v2/evidence');
   } catch (err: unknown) { return handleApiError(err); }
 }

--- a/apps/web/src/app/api/stories/[id]/activities/route.test.ts
+++ b/apps/web/src/app/api/stories/[id]/activities/route.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// 긴급 정정(2026-07-28, prod 크래시): #2247이 BE list_activities에 convention-A({data,meta})를
+// 적용했는데 이 프록시가 apiSuccess(json)에 그대로 넘겨 이중포장했다 — story-detail-panel.tsx의
+// activities.map()이 「activities.map is not a function」으로 터지던 실제 원인.
+const h = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(),
+  proxyToFastapiWithParams: vi.fn(),
+}));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext: h.getOrgProjectAuthContext }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams: h.proxyToFastapiWithParams }));
+
+import { GET } from './route';
+
+const ctx = () => ({ params: Promise.resolve({ id: 'story-1' }) });
+const req = () => new Request('http://localhost/api/stories/story-1/activities?limit=20');
+const me = () => ({ id: 'a', org_id: 'org-1', project_id: 'p1', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
+
+describe('GET /api/stories/[id]/activities — 이중포장 회귀 방지', () => {
+  beforeEach(() => {
+    h.getOrgProjectAuthContext.mockReset();
+    h.proxyToFastapiWithParams.mockReset();
+    h.getOrgProjectAuthContext.mockResolvedValue(me());
+  });
+
+  it('BE가 이미 {data,meta}를 내면(convention-A) data 배열이 최상위 data로 그대로 나온다(이중포장 없음)', async () => {
+    h.proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ id: 'act-1', activity_type: 'status_changed' }], meta: { has_more: false, next_cursor: null } }), { status: 200 }),
+    );
+    const res = await GET(req(), ctx());
+    const json = await res.json() as { data: unknown; meta: unknown };
+    expect(Array.isArray(json.data)).toBe(true);
+    expect(json.data).toEqual([{ id: 'act-1', activity_type: 'status_changed' }]);
+    expect(json.meta).toEqual({ has_more: false, next_cursor: null });
+  });
+
+  it('BE 응답이 예외적으로 봉투 없이 온다면(과거 형상) 그 값 전체를 data로 감싼다(폴백)', async () => {
+    h.proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify([{ id: 'act-1' }]), { status: 200 }),
+    );
+    const res = await GET(req(), ctx());
+    const json = await res.json() as { data: unknown };
+    expect(json.data).toEqual([{ id: 'act-1' }]);
+  });
+});

--- a/apps/web/src/app/api/stories/[id]/activities/route.ts
+++ b/apps/web/src/app/api/stories/[id]/activities/route.ts
@@ -1,5 +1,5 @@
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { apiSuccess, ApiErrors, type ApiMeta } from '@/lib/api-response';
 import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
@@ -14,7 +14,12 @@ export async function GET(request: Request, { params }: RouteParams) {
 
     const _r = await proxyToFastapiWithParams(request, '/api/v2/stories/[id]/activities', { id });
     if (!_r.ok) return _r;
-    return apiSuccess(await _r.json());
+    // 긴급 정정(2026-07-28, prod 크래시): #2247이 BE list_activities에 convention-A({data,meta})를
+    // 적용했는데 이 프록시가 그대로 apiSuccess(json)에 넘겨 이중포장했다(형제 comments/route.ts는
+    // 이미 이 처방이 돼 있었음). 이중포장되면 소비부(story-detail-panel.tsx)의 `json.data ?? []`가
+    // `json.data`(={data,meta} 객체·truthy)를 그대로 state에 넣어 `.map()`이 터진다.
+    const beJson = await _r.json() as { data?: unknown; meta?: ApiMeta };
+    return apiSuccess(beJson.data ?? beJson, beJson.meta);
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/components/verify/evidence-section.test.tsx
+++ b/apps/web/src/components/verify/evidence-section.test.tsx
@@ -1,8 +1,13 @@
+// @vitest-environment jsdom
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
 import { EvidenceSection, isLinkableRef } from './evidence-section';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 function wrap(node: React.ReactNode) {
   return (
@@ -98,5 +103,98 @@ describe('EvidenceSection (SSR snapshot — §7 상태 매트릭스 + P0-04 Clai
     );
     expect(markup).toContain('deadbe');
     expect(markup).not.toContain('undefined');
+  });
+});
+
+describe('EvidenceSection — 증거 연결 POST(긴급 정정 2026-07-28: 봉투 이중포장 회귀 방지)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => { root.unmount(); });
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  async function renderExpanded() {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/evidence?')) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      return new Response('{}', { status: 200 });
+    }));
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+          <EvidenceSection workItemId="s1" workItemType="story" selfReported={true} humanVerified={null} humanVerifiedBy={null} humanVerifiedAt={null} />
+        </NextIntlClientProvider>,
+      );
+    });
+    // 근거 보기 클릭 → 펼침 + 증거 연결 폼 노출
+    const toggleBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('근거 보기'));
+    await act(async () => { toggleBtn!.click(); await Promise.resolve(); await Promise.resolve(); });
+  }
+
+  it('POST 응답이 raw 단건 객체(봉투 없음)면 정상적으로 목록에 반영된다(회귀 방지 본체)', async () => {
+    await renderExpanded();
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        // BE create_evidence 실제 응답 — 봉투 없는 raw 단건 객체(오늘 curl로 실측한 형상).
+        return new Response(JSON.stringify({
+          id: 'ev-1', org_id: 'org-1', work_item_id: 's1', work_item_type: 'story',
+          type: 'url', ref: 'https://example.com/proof', source: null, note: null,
+          created_by: 'member-1', created_at: '2026-07-28T00:00:00Z',
+        }), { status: 201, headers: { 'content-type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }));
+
+    const findEvidenceAddBtn = () => Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '증거 연결');
+    await act(async () => { findEvidenceAddBtn()!.click(); }); // 폼 펼침(토글 버튼 → 폼으로 치환)
+    const refInput = container.querySelector('input[placeholder="URL 또는 참조"]') as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(refInput, 'https://example.com/proof');
+      refInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => { findEvidenceAddBtn()!.click(); await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).toContain('https://example.com/proof');
+    expect(container.textContent).not.toContain('증거 연결 실패');
+  });
+
+  it('POST 응답이 봉투({data,error,meta})로 이중포장되면 실패로 처리한다(과거 회귀 재현 — 반드시 통과해야 함)', async () => {
+    await renderExpanded();
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        // 과거 버그 재현: apiSuccess가 한 번 더 감싼 형상.
+        return new Response(JSON.stringify({
+          data: { id: 'ev-1', type: 'url', ref: 'https://example.com/proof' },
+          error: null, meta: null,
+        }), { status: 201, headers: { 'content-type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }));
+
+    const findEvidenceAddBtn = () => Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '증거 연결');
+    await act(async () => { findEvidenceAddBtn()!.click(); }); // 폼 펼침
+    const refInput = container.querySelector('input[placeholder="URL 또는 참조"]') as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(refInput, 'https://example.com/proof');
+      refInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => { findEvidenceAddBtn()!.click(); await Promise.resolve(); await Promise.resolve(); });
+
+    // 형상 가드가 봉투({data,error,meta}에는 최상위 'type'/'ref'가 없음)를 거부해야 한다 —
+    // 거부하지 못하면 items에 깨진 객체가 들어가 렌더가 이상해진다(과거 실제 회귀).
+    expect(container.textContent).toContain('증거 연결 실패');
   });
 });

--- a/apps/web/src/components/verify/evidence-section.tsx
+++ b/apps/web/src/components/verify/evidence-section.tsx
@@ -116,7 +116,13 @@ export function EvidenceSection({
         }),
       });
       if (!res.ok) { setAddError(true); return; }
-      const created = (await res.json()) as EvidenceItem;
+      // 긴급 정정(2026-07-28): `as EvidenceItem` 단언이 봉투 이중포장을 조용히 통과시켰다
+      // (build/typecheck 둘 다 못 잡음) — 최소 형상 가드로 대체. 없으면 실패로 취급한다.
+      const raw: unknown = await res.json();
+      const created = (raw && typeof raw === 'object' && 'id' in raw && 'type' in raw && 'ref' in raw)
+        ? (raw as EvidenceItem)
+        : null;
+      if (!created) { setAddError(true); return; }
       // AC1: 붙인 뒤 다시 읽어서 붙어 있는 것 — 서버 응답(실제로 저장된 값)을 그대로 리스트에 반영.
       setItems((prev) => [created, ...(prev ?? [])]);
       setAddRef('');

--- a/apps/web/src/lib/convention-a-double-wrap-guard.test.ts
+++ b/apps/web/src/lib/convention-a-double-wrap-guard.test.ts
@@ -1,0 +1,65 @@
+/**
+ * CI 가드(2026-07-28, prod 크래시 사후) — 오늘 이 병이 세 번 났다(activities·evidence·오늘 아침
+ * 디디군 스캔의 comments). 축: **BE가 이미 규약A({data,meta})를 내는데 FE 프록시가 apiSuccess로
+ * 또 감싸는 자리**. 완벽한 정적분석이 아니다 — 지금 아는 「규약A로 확認된 엔드포인트 + 그
+ * 프록시」 조합만 잡는다. 새 규약A 엔드포인트를 추가하면 이 목록에도 추가해야 한다(자동 탐지 아님).
+ *
+ * ⛔이 파일이 covers 하지 않는 것(전수 시 확認, 훑은 범위/못 훑은 범위):
+ * - conversations.py(list_messages/list_message_replies): FE 프록시가 raw passthrough라
+ *   해당 안 됨(이중포장 자체가 구조적으로 불가) — 스킵.
+ * - docs.py(list_docs)·notifications.py(list_notifications): FE가 이 BE 엔드포인트를 아예
+ *   안 쓰고 별도 내부 서비스/레포지토리를 쓴다(다른 아키텍처) — 이 클래스의 위험군이 아님, 스킵.
+ * - docs.py(get_doc_backlinks): FE 프록시 자체가 아직 없음(story #2263 별건, 배선 자체가 안 됨).
+ * - 미래에 새로 생기는 규약A 엔드포인트는 이 가드가 자동으로 못 잡는다 — 만들 때 이 파일에
+ *   케이스를 추가하는 것이 유일한 방어선이다.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(async () => ({
+    id: 'me', org_id: 'org-1', project_id: 'p1',
+    rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0,
+  })),
+  proxyToFastapi: vi.fn(),
+  proxyToFastapiWithParams: vi.fn(),
+}));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext: h.getOrgProjectAuthContext }));
+vi.mock('@/lib/fastapi-proxy', () => ({
+  proxyToFastapi: h.proxyToFastapi,
+  proxyToFastapiWithParams: h.proxyToFastapiWithParams,
+}));
+
+const BE_ENVELOPE = { data: [{ id: 'x1' }], meta: { has_more: false, next_cursor: null } };
+
+function stubBeResponse() {
+  const r = new Response(JSON.stringify(BE_ENVELOPE), { status: 200 });
+  h.proxyToFastapi.mockResolvedValue(r.clone());
+  h.proxyToFastapiWithParams.mockResolvedValue(r.clone());
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function assertNoDoubleWrap(GET: (req: Request, ctx?: any) => Promise<Response>, ctx?: unknown) {
+  stubBeResponse();
+  const res = await GET(new Request('http://localhost/x'), ctx);
+  const json = await res.json() as { data: unknown; meta: unknown };
+  expect(Array.isArray(json.data)).toBe(true);
+  expect(json.data).toEqual(BE_ENVELOPE.data);
+  expect(json.meta).toEqual(BE_ENVELOPE.meta);
+}
+
+describe('규약A 엔드포인트 FE 프록시 — 이중포장 없음 가드', () => {
+  it('stories/[id]/activities — #2247 이후 잔존 회귀(오늘 실제 crash) 재발 방지', async () => {
+    const { GET } = await import('@/app/api/stories/[id]/activities/route');
+    await assertNoDoubleWrap(GET, { params: Promise.resolve({ id: 's1' }) });
+  });
+
+  it('stories/[id]/comments — #2230/#2231 처방 유지 확認', async () => {
+    const { GET } = await import('@/app/api/stories/[id]/comments/route');
+    await assertNoDoubleWrap(GET, { params: Promise.resolve({ id: 's1' }) });
+  });
+
+  it('standup/history — #2248 처방 유지 확認', async () => {
+    const { GET } = await import('@/app/api/standup/history/route');
+    await assertNoDoubleWrap(GET);
+  });
+});


### PR DESCRIPTION
## 🔴 원인 사슬 (다음 사람이 다시 안 파도 되게)

1. `#2247`이 BE `stories.py::list_activities`에 규약A(`{data, meta}`)를 적용했다.
2. FE 프록시(`activities/route.ts`)는 이 변경 당시 갱신되지 않아 `apiSuccess(await _r.json())`로 BE의 `{data,meta}`를 **한 번 더 감쌌다** — 형제 `comments/route.ts`(같은 시기 `#2230`/`#2231`)는 이미 이 처방이 돼 있었는데 activities만 빠졌다.
3. `story-detail-panel.tsx`의 `setActivities(json.data ?? [])`에서 `json.data`가 이제 `{data:[...], meta:{...}}`(객체, truthy)라 `??`가 안 걸리고 그대로 state에 들어간다.
4. `activities.length === 0`이 `undefined === 0`(false)로 새서 `activities.map(...)`까지 도달 → **`activities.map is not a function`으로 크래시**(story 상세를 열 때마다, 새로고침해도, 네트워크 에러 0 — 실제 증상과 100% 일치).

## 같은 클래스의 두 번째 인스턴스

`/api/evidence` POST도 BE(`create_evidence`, 단건 객체 반환)를 `apiSuccess`로 또 감쌌는데, 소비부(`evidence-section.tsx`)가 `(await res.json()) as EvidenceItem`으로 **거짓 단언**해 봉투를 그대로 목록에 밀어넣고 있었다(증거를 "추가"할 때만 발생 — 오늘 아침 `#2258`에서 새로 추가된 코드).

## 무엇을 고쳤는가

- `activities/route.ts`: 형제 `comments/route.ts`와 **동일한 처방**(`beJson.data ?? beJson`으로 해제) — 새 방식 발명 0.
- `evidence/route.ts` POST: 형제(`request-verification`)와 동일하게 **raw passthrough**로 전환.
- `evidence-section.tsx`: `as EvidenceItem` 단언을 최소 형상 가드(`'id' in raw && 'type' in raw && 'ref' in raw`)로 대체 — 형상이 안 맞으면 실패로 처리(조용히 통과 금지).
- **CI 가드 신설**(`convention-a-double-wrap-guard.test.ts`): 알려진 규약A 엔드포인트(activities/comments/standup-history) 프록시가 재감싸지 않는지 확認. ⚠️완전한 정적분석이 아니다 — 커버 범위(및 커버하지 않는 것: conversations/docs/notifications, 미래의 신규 규약A 엔드포인트)를 파일 상단 주석에 명시했다.

## 전수 (규약A 엔드포인트 전량)

BE에서 `has_more` 키를 쓰는 규약A 엔드포인트 6개를 전부 확認:
| 소스 | FE 소비 경로 | 상태 |
|---|---|---|
| `conversations.py` list_messages/list_message_replies | raw passthrough + 소비부 방어적(`Array.isArray` 가드) | ✅ 안전 |
| `docs.py` list_docs | FE가 이 BE 엔드포인트 자체를 안 씀(별도 내부 서비스) | 해당없음 |
| `notifications.py` list_notifications | FE가 이 BE 엔드포인트 자체를 안 씀(별도 내부 레포지토리) | 해당없음 |
| `standups.py` list_standup_history | 이미 처방됨(#2248) | ✅ 안전 |
| `stories.py` list_comments | 이미 처방됨(#2230/#2231) | ✅ 안전 |
| `stories.py` list_activities | **이중포장(실제 회귀)** | ✅ 이번 PR로 수정 |

## 검증
- 두 버그 다 mutation-verified(고친 코드를 일부러 원복 → 테스트 RED 확認 → 재적용 → GREEN).
- 신규/변경 테스트 14케이스 GREEN(activities route 2 + evidence-section 4(신규 2건 포함) + double-wrap 가드 3 + 관련 기존 8).
- 전체 FE vitest 스윕: 292 파일 · 1945 테스트 전부 PASS(회귀 없음).
- `tsc --noEmit` 무오류, `eslint` 무경고.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>