### PR TITLE
fix: 스토리 description/AC 본문 링크 클릭 시 편집모드 동시 진입 정정

### DIFF
--- a/apps/web/src/components/kanban/description-viewer.test.tsx
+++ b/apps/web/src/components/kanban/description-viewer.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+//
+// 긴급 정정(2026-07-28, PO 검수 실패) — story-detail-panel.tsx의 description/AC 뷰어는
+// 부모 div에 「클릭=편집모드 진입」 onClick이 걸려 있다. 그 안의 markdown 링크가
+// stopPropagation 없이 렌더돼 링크 클릭이 부모까지 버블링, 새 탭이 열리는 동시에
+// 편집모드까지 열리던 결함(#2258과 무관 — 컴포넌트 레벨 사전 존재 결함). DescriptionViewer는
+// StoryDetailPanel 전체 마운트 없이 격리 테스트 가능하도록 export됐다.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { DescriptionViewer } from './story-detail-panel';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+describe('DescriptionViewer — 본문 링크 클릭이 부모(편집모드 진입) onClick으로 안 새는지', () => {
+  it('링크를 클릭해도 부모 wrapper의 onClick(편집모드 진입)이 발화하지 않는다', async () => {
+    let parentClicked = false;
+    await act(async () => {
+      root.render(
+        // story-detail-panel.tsx:1093/1140과 동일한 실제 wrapper 패턴 재현.
+        <div onClick={() => { parentClicked = true; }}>
+          <DescriptionViewer description="문서 보기: [연결된 doc](https://sprintable.example/docs/some-doc)" />
+        </div>,
+      );
+    });
+
+    const link = container.querySelector('a') as HTMLAnchorElement;
+    expect(link).toBeTruthy();
+    expect(link.getAttribute('href')).toBe('https://sprintable.example/docs/some-doc');
+
+    // jsdom에서 실제 새 탭 네비게이션은 일어나지 않지만, React 합성이벤트 버블링 여부는 검증 가능.
+    await act(async () => {
+      link.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+
+    expect(parentClicked).toBe(false);
+  });
+
+  it('(양성대조) 링크가 아닌 본문 텍스트를 클릭하면 부모 onClick은 정상적으로 발화한다', async () => {
+    let parentClicked = false;
+    await act(async () => {
+      root.render(
+        <div onClick={() => { parentClicked = true; }}>
+          <DescriptionViewer description="그냥 본문 텍스트입니다." />
+        </div>,
+      );
+    });
+
+    const p = container.querySelector('p') as HTMLParagraphElement;
+    await act(async () => {
+      p.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+
+    expect(parentClicked).toBe(true);
+  });
+});

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -108,13 +108,29 @@ const descriptionViewerComponents = {
   pre: ({ children }: { children?: React.ReactNode }) => <pre className="mb-2 overflow-x-auto scrollbar-visible rounded-lg bg-muted p-3 text-[13px] text-foreground">{children}</pre>,
   code: ({ children }: { children?: React.ReactNode }) => <code className="rounded bg-muted px-1 py-0.5 font-mono text-[13px] text-foreground">{children}</code>,
   blockquote: ({ children }: { children?: React.ReactNode }) => <blockquote className="mb-2 border-l-2 border-border pl-3 text-muted-foreground">{children}</blockquote>,
-  a: ({ href, children }: { href?: string; children?: React.ReactNode }) => <a href={href} target="_blank" rel="noopener noreferrer" className="text-primary underline underline-offset-2">{children}</a>,
+  // 긴급 정정(2026-07-28, PO 검수): description/AC 뷰어는 부모 div에 클릭=편집모드 진입
+  // onClick이 걸려 있다(1093·1140줄) — 링크가 stopPropagation 없이 렌더돼 클릭이 그대로
+  // 버블링, 링크가 새 탭으로 열리는 동시에 편집모드까지 열렸다. 링크 클릭은 여기서 끊는다.
+  a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-primary underline underline-offset-2"
+      onClick={(e) => e.stopPropagation()}
+    >
+      {children}
+    </a>
+  ),
   strong: ({ children }: { children?: React.ReactNode }) => <strong className="font-semibold text-foreground">{children}</strong>,
   em: ({ children }: { children?: React.ReactNode }) => <em className="italic text-muted-foreground">{children}</em>,
   hr: () => <hr className="my-2 border-border" />,
 };
 
-function DescriptionViewer({ description }: { description: string }) {
+// export: 회귀 테스트(부모 클릭=편집모드 진입 wrapper 안에서 링크 클릭이 전파를 끊는지)를
+// StoryDetailPanel 전체 마운트 없이 격리 검증하기 위함(story-detail-panel.tsx는 huge prop
+// surface라 전체 마운트 테스트가 비실용적) — 동작 변경 없는 순수 export 추가.
+export function DescriptionViewer({ description }: { description: string }) {
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}


### PR DESCRIPTION
## 발견 경위

PO가 `#2258` 검수 중 "description에서 연결된 doc을 누르면 description 편집이 열려서 AC 충족 안 되는" 것을 발견. `#2258`의 AC(증거연결)인지 별개 결함인지부터 갈랐다.

## ㉠/㉡ 판정 — ㉡ 별개 결함, #2258과 무관

`#2258`(PR #2561) diff는 `story-detail-panel.tsx`의 description/AC 섹션을 손대지 않았다(그 PR이 만진 곳은 trustChip 줄·의존성 토글·검증요청 버튼, 전부 다른 위치). 이 버그는 **description/AC에 markdown 링크가 있는 모든 스토리에서 항상 재현되는 컴포넌트 레벨 결함**이다.

## 원인

```
story-detail-panel.tsx:1093  <div className="cursor-pointer" onClick={() => setEditingDescription(true)}>
                                <DescriptionViewer description={story.description} />
story-detail-panel.tsx:1140  <div className="cursor-pointer" onClick={() => setEditingAC(true)}>  (AC — 동일 패턴)
story-detail-panel.tsx:111   a: (...) => <a href={href} target="_blank" ...>{children}</a>  ← stopPropagation 없음
```

부모 div에 "클릭=편집모드 진입" `onClick`이 걸려 있는데, 그 안의 링크(`descriptionViewerComponents.a`)가 `stopPropagation` 없이 렌더돼 클릭이 그대로 버블링 — 링크가 새 탭으로 열리는 동시에 편집모드까지 열렸다.

## 같은 클래스가 본문 안에 몇 개인지

`descriptionViewerComponents`(description·AC 뷰어 공용 렌더맵)에서 클릭 가능한 커스텀 컴포넌트는 **`a` 하나뿐**이다(멘션·체크박스 등 별도 인터랙티브 렌더러 없음 — story 본문은 순수 react-markdown이고, 문서 에디터의 wiki-link/체크박스 확장과는 무관). 이 `a`가 description(1093)·AC(1140) **두 자리**에서 재사용되며 둘 다 같은 증상 — 한 곳만 고치면 둘 다 해소된다.

## 수정

`a` 렌더러에 `onClick={(e) => e.stopPropagation()}` 추가. 새 패턴 발명 없이 최소 변경.

## 검증

- `DescriptionViewer`를 export해 `StoryDetailPanel` 전체 마운트 없이 격리 회귀테스트 2케이스(링크 클릭 시 부모 미발화 / 양성대조로 일반 텍스트 클릭 시 부모 정상 발화).
- mutation-verified: `stopPropagation` 제거 → 테스트가 정확히 이 버그를 재현하며 RED → 원복 → GREEN.
- `tsc --noEmit` 무오류, `eslint` 무경고.
- 전체 FE vitest 스윕: 293 파일 · 1947 테스트 전부 PASS(회귀 없음).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>