### PR TITLE
[C-1c] #2274: 테스트 모듈전역 미복원 스윕 + cron orphan-check 재부착

### DIFF
--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -289,6 +289,36 @@ async def seed_default_story_line_cron(
         return _err("INTERNAL_ERROR", "Internal server error", 500)
 
 
+# ─── GET /api/v2/internal/cron/entity-references-orphan-check ─────────────────
+# story #2274(C-1c) AC4: count_orphan_types(#2259가 만든 함수)에 「도는 자리」를 준다 —
+# 안 그러면 그 함수 자체가 「만들어졌는데 도는 자리가 없는」 것이 된다. 정상은 0(registry
+# 밖 타입이 entity_references에 하나도 안 쌓였다는 뜻) — 0이 아니면 write 경로 어딘가
+# (registry 검증을 우회한 직접 INSERT 등)가 오타/미등록 타입을 조용히 통과시킨 것이다.
+# ⛔이 엔드포인트는 데이터를 바꾸지 않는다(read-only 점검) — 결과는 응답 JSON + 로그에
+# 남는다(logger.warning으로 0이 아닌 경우 특히 눈에 띄게).
+# ⛔#2273에서 이 엔드포인트를 처음 붙였을 때 CI가 전역 401로 깨졌다 — 원인은 이 엔드포인트
+# 자체가 아니라, 그때 짠 테스트가 CRON_SECRET을 monkeypatch 없이 직접 대입해 복원을 안 한
+# 것이었다(#2274 AC1, 재현까지 완료). 이 엔드포인트 코드 자체는 다른 cron 엔드포인트와
+# 동일한 verify_cron() 패턴 그대로다(AC7 — 인증을 새로 발명하지 않는다).
+
+@router.get("/entity-references-orphan-check")
+async def entity_references_orphan_check(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    verify_cron(request)
+    try:
+        from app.services.reference_registry import count_orphan_types
+        orphans = await count_orphan_types(session)  # org_id=None → 전체 org
+        total = sum(orphans.values())
+        if total:
+            logger.warning("entity_references orphan types found: %s (total=%d)", orphans, total)
+        return _ok({"orphans": orphans, "total": total})
+    except Exception as exc:
+        logger.exception("cron error: %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)
+
+
 # ─── GET /api/v2/internal/cron/inbox-outbox ────────────────────────────────────
 
 @router.get("/inbox-outbox")

--- a/backend/tests/test_2273_reference_cutover_realdb.py
+++ b/backend/tests/test_2273_reference_cutover_realdb.py
@@ -163,7 +163,7 @@ async def test_count_orphan_types_org_id_none_aggregates_all_orgs():
         await engine.dispose()
 
 
-# ⛔story #2274로 분리(2026-07-28) — cron endpoint(entity_references_orphan_check) 배선이
-# 이 PR의 CI에서 전역 401 회귀를 냈다(원인 미규명 — CRON_SECRET 전역 누수 의심, #2274 AC1이
-# 그 원인부터 밝힌다). count_orphan_types 자체(위 테스트들)는 재배선 본체와 무관해 남기고,
-# cron endpoint를 직접 부르는 테스트만 여기서 뺐다 — 원인 규명 뒤 #2274에서 다시 짠다.
+# ⛔story #2274로 분리됐던 cron endpoint(entity_references_orphan_check) 테스트는 원인
+# 규명(테스트 격리 오염 — CRON_SECRET 전역 미복원, cron 라우터 자체는 무죄) 후
+# tests/test_2274_cron_orphan_check_realdb.py로 다시 짜졌다(monkeypatch.setattr 사용 —
+# 같은 사고 재발 없음). 이 파일은 재배선(#2273) 본체 검증만 남긴다.

--- a/backend/tests/test_2274_cron_orphan_check_realdb.py
+++ b/backend/tests/test_2274_cron_orphan_check_realdb.py
@@ -1,0 +1,173 @@
+"""story #2274(C-1c) — entity-references-orphan-check cron endpoint 실PG 검증.
+
+⛔#2273 때 이 엔드포인트의 첫 버전은 CI를 전역 401로 깼다 — 원인은 엔드포인트가 아니라
+그때 테스트가 `app.routers.cron.CRON_SECRET`을 monkeypatch 없이 직접 대입하고 복원을 안 한
+것(#2274 AC1, 재현까지 완료된 원인 규명). 이 파일은 `monkeypatch.setattr`을 써서 pytest가
+테스트 종료 시 자동으로 원래 값을 복원하게 한다 — 같은 사고가 재발하지 않는 자리.
+"""
+from __future__ import annotations
+
+import json
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project_member(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.user import User
+    from app.models.member import Member
+
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.flush()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.flush()
+    member = Member(id=uuid.uuid4(), org_id=org.id, type="human", user_id=user.id, name="Test Human")
+    session.add(member)
+    await session.flush()
+    return org, project, member
+
+
+@pytest.mark.anyio
+async def test_orphan_check_endpoint_rejects_missing_auth(monkeypatch):
+    """AC7 — 다른 cron 엔드포인트와 같은 verify_cron() 게이트를 그대로 쓴다(새 인증 발명 없음).
+    ⛔monkeypatch.setattr — 이 테스트가 끝나면 pytest가 자동으로 원래 CRON_SECRET을 복원한다
+    (직접 대입+finally 없음 방식이었던 #2273 때의 사고를 구조적으로 재발 불가능하게 만든다)."""
+    import app.routers.cron as cron_module
+    from app.routers.cron import entity_references_orphan_check
+    from fastapi import HTTPException
+    from starlette.requests import Request as StarletteRequest
+
+    monkeypatch.setattr(cron_module, "CRON_SECRET", "the-real-secret")
+
+    request = StarletteRequest(scope={"type": "http", "headers": []})  # 인증 헤더 없음
+    with pytest.raises(HTTPException) as exc_info:
+        await entity_references_orphan_check(request, session=None)
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_orphan_check_endpoint_calls_count_orphan_types(monkeypatch):
+    """⭐AC4 핵심 — cron endpoint가 실제로 count_orphan_types를 호출하는 「도는 자리」임을
+    직접 증명한다(라우터 함수를 직접 호출 — HTTP 계층 우회, story #2554 세션에서 확立한
+    패턴). ⛔DB가 공유돼(로컬 재사용) 절대값 0을 기대하면 다른 테스트의 잔여 데이터에
+    깨지기 쉬우므로, 정상 타입 삽입 **전후 delta**로 증명한다."""
+    import app.routers.cron as cron_module
+    from app.routers.cron import entity_references_orphan_check
+    from app.services.reference_core import insert_reference
+    from starlette.requests import Request as StarletteRequest
+
+    monkeypatch.setattr(cron_module, "CRON_SECRET", "the-real-secret")
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            await session.commit()
+
+            def _request():
+                return StarletteRequest(scope={
+                    "type": "http", "headers": [(b"authorization", b"Bearer the-real-secret")],
+                })
+
+            resp_before = await entity_references_orphan_check(_request(), session=session)
+            total_before = json.loads(resp_before.body)["data"]["total"]
+
+            # registry에 있는 정상 타입만 하나 심는다 — orphan이 아닌 것.
+            await insert_reference(
+                session, org_id=org.id, source_type="story", source_field="description",
+                source_id=uuid.uuid4(), target_type="doc", target_id=uuid.uuid4(),
+                form="mention", created_by=member.id,
+            )
+            await session.commit()
+
+            resp_after = await entity_references_orphan_check(_request(), session=session)
+            body_after = json.loads(resp_after.body)
+            assert body_after["data"]["total"] == total_before, (
+                f"정상 타입 삽입인데 orphan 총계가 늘었다({total_before} → "
+                f"{body_after['data']['total']}) — orphans={body_after['data']['orphans']}"
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_orphan_check_endpoint_flags_real_orphan(monkeypatch):
+    """⭐AC5 기준선 — registry 밖 타입이 실제로 있으면 total이 그만큼 늘어나는 것(정상은
+    0이지만, 0이 아닐 수 있다는 것도 같이 증명 — «항상 0을 반환하는 죽은 코드»가 아님을
+    보인다)."""
+    import app.routers.cron as cron_module
+    from app.routers.cron import entity_references_orphan_check
+    from app.models.reference import Reference
+    from starlette.requests import Request as StarletteRequest
+
+    monkeypatch.setattr(cron_module, "CRON_SECRET", "the-real-secret")
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            await session.commit()
+
+            def _request():
+                return StarletteRequest(scope={
+                    "type": "http", "headers": [(b"authorization", b"Bearer the-real-secret")],
+                })
+
+            resp_before = await entity_references_orphan_check(_request(), session=session)
+            body_before = json.loads(resp_before.body)
+            total_before = body_before["data"]["total"]
+            orphan_key_before = body_before["data"]["orphans"].get("target:definitely_not_registered", 0)
+
+            session.add(Reference(
+                id=uuid.uuid4(), org_id=org.id, source_type="story", source_field="description",
+                source_id=uuid.uuid4(), target_type="definitely_not_registered",
+                target_id=uuid.uuid4(), form="mention", created_by=member.id,
+            ))
+            await session.commit()
+
+            resp_after = await entity_references_orphan_check(_request(), session=session)
+            body_after = json.loads(resp_after.body)
+            assert body_after["data"]["total"] == total_before + 1
+            assert body_after["data"]["orphans"].get("target:definitely_not_registered") == orphan_key_before + 1
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2274_module_global_leak_guard.py
+++ b/backend/tests/test_2274_module_global_leak_guard.py
@@ -1,0 +1,61 @@
+"""story #2274(C-1c) — 「테스트가 모듈 전역을 복원 없이 대입하는」 병의 재발 방지 가드.
+
+⛔완벽하지 않다(오르테가군 지시대로 «못 잡는 것을 선언»한다) — 이 가드가 잡는 것과 못 잡는 것:
+
+잡는 것:
+  `app.routers.cron.CRON_SECRET`(오늘 실제로 사고 난 그 전역)에 monkeypatch를 거치지 않고
+  직접 대입하는 코드가 tests/ 어딘가에 다시 생기면 이 테스트가 RED된다(정적 텍스트 스캔).
+  이 전역을 골라 지킨 이유: verify_cron()이 읽고, cron.py 자신 + verdict_capture.py 둘 다
+  소비하는 것을 오늘 확認했다(#2274 원인 규명) — 지금 아는 것 중 blast radius가 가장 넓다.
+
+못 잡는 것(정직하게 남긴다):
+  ①CRON_SECRET **이외의** 모듈 전역을 복원 없이 대입하는 새 사고 — 이 가드는 그 전역
+    하나만 지킨다. 클래스 전체를 막는 가드가 아니다.
+  ②`from x import y; y = something`처럼 **이름 재바인딩**(모듈 attribute 대입이 아닌) 형태의
+    오염 — 문법적으로 로컬 변수 정의와 구분이 안 돼 정적 스캔으로 못 잡는다.
+  ③런타임에 동적으로 생성된 문자열로 attribute를 대입하는 경우(`setattr(mod, name, val)`) —
+    이 스캔은 `mod.ATTR = ` 리터럴 패턴만 본다.
+  ④이미 monkeypatch로 감쌌지만 monkeypatch 자체를 잘못 쓴 경우(예: 잘못된 대상에 setattr) —
+    이 가드는 "monkeypatch라는 단어가 근처에 있는가"만 보지 그 사용이 맞는지는 안 본다.
+
+전수 스윕 결과(2026-07-28, #2274 AC1) — 훑은 범위: `import app.X as Y` 형태로 alias
+import된 모듈에 대한 `Y.ATTR = ` 직접 대입 전수(34개 alias) + `os.environ[...] = `/`.pop`/
+`.update` 직접 조작 전수 + `settings.attr = ` 직접 대입 전수. 못 훑은 범위: 위 ②③④ 그대로.
+발견: 이 파일이 고친 `test_s0_2_chat_migration.py`(NEXT_PUBLIC_APP_URL, monkeypatch.setenv로
+전환) 1건 제외 전부 이미 올바르게 복원됨(try/finally 또는 patch.dict/monkeypatch) — 오늘의
+CRON_SECRET 건이 유일한 미복원 사례였다.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_TESTS_DIR = Path(__file__).parent
+
+# ⛔이 파일 자신은 스캔 대상에서 제외(가드 코드 자체가 이 패턴을 문서화하려고 언급할 수 있다).
+_SELF = Path(__file__).name
+
+# cron_module.CRON_SECRET = ... 또는 cron.CRON_SECRET = ... 형태(alias 무관, 변수명이
+# "cron"을 포함하고 .CRON_SECRET = 로 끝나는 대입) — monkeypatch.setattr(...) 호출은 별도
+# 문법(함수 호출이라 이 대입 패턴에 안 걸림)이라 오탐하지 않는다.
+_DANGEROUS_PATTERN = re.compile(r"\bcron\w*\.CRON_SECRET\s*=(?!=)")
+
+
+def test_no_unguarded_cron_secret_assignment_in_tests():
+    """cron.CRON_SECRET(오늘 실제 사고 난 전역)을 직접 대입하는 코드가 tests/에 있으면 안
+    된다 — monkeypatch.setattr(cron_module, "CRON_SECRET", ...)를 쓸 것(자동 복원)."""
+    offenders: list[str] = []
+    for path in sorted(_TESTS_DIR.glob("*.py")):
+        if path.name == _SELF:
+            continue
+        text = path.read_text()
+        for m in _DANGEROUS_PATTERN.finditer(text):
+            line_no = text[:m.start()].count("\n") + 1
+            offenders.append(f"{path.name}:{line_no}: {m.group(0)}")
+
+    assert not offenders, (
+        "tests/ 에 cron.CRON_SECRET 직접 대입(monkeypatch 미사용)이 발견됐다 — "
+        "오늘(#2274) 실제로 CI를 전역 401로 깬 그 사고 클래스다. "
+        "monkeypatch.setattr(cron_module, 'CRON_SECRET', ...)로 바꿀 것:\n"
+        + "\n".join(offenders)
+    )

--- a/backend/tests/test_s0_2_chat_migration.py
+++ b/backend/tests/test_s0_2_chat_migration.py
@@ -67,10 +67,12 @@ def test_to_discord_payload_content_fields():
     assert "reply_id:" not in content
 
 
-def test_to_discord_payload_embed_url():
-    """Discord embed URL에 /conversations/{id} 경로 사용."""
-    import os
-    os.environ["NEXT_PUBLIC_APP_URL"] = "https://app.example.com"
+def test_to_discord_payload_embed_url(monkeypatch):
+    """Discord embed URL에 /conversations/{id} 경로 사용.
+    ⛔story #2274: 예전엔 os.environ 직접 대입이라 이 값이 프로세스 끝까지 굳었다(auth.py·
+    docs.py·org_invite_email.py·discord_webhook.py가 이 env를 읽는 소비자라 blast
+    radius가 넓음) — monkeypatch.setenv로 테스트 종료 시 자동 복원되게 고쳤다."""
+    monkeypatch.setenv("NEXT_PUBLIC_APP_URL", "https://app.example.com")
     from app.services.conversation_webhook import _to_discord_payload
 
     payload = {


### PR DESCRIPTION
## 배경
#2273(PR #2565) 첫 시도 때 CI가 3개 무관 파일(`test_e_2040_ac2_application_name.py`,
`test_e_board_schema_s1_epic_outcome.py`, `test_e_cage_referee_p1_review_verdict.py`)에서
전역 401로 깨졌다. 최초 가설("cron 라우터가 전역 인증을 깼다")은 틀렸다 — 근본원인은 그때
새로 짠 테스트(`test_entity_references_orphan_check_cron_endpoint_calls_count_orphan_types`,
이후 삭제)가 `app.routers.cron.CRON_SECRET`(모듈 전역, `verify_cron()`이 읽음)을
monkeypatch 없이 직접 대입하고 복원하지 않아, 같은 pytest 프로세스의 다른 모든 테스트가
오염된 값을 물려받은 것이었다(재현 완료). **cron 라우터 자체는 무죄** — 테스트 격리가
깨진 것.

## AC별 처리
- **①클래스 전수 스윕** — `import X as Y` 형태 alias import된 34개 모듈에 대한
  `Y.ATTR = ` 직접 대입 + `os.environ[...]`/`.pop`/`.update` 직접 조작 + `settings.attr = `
  직접 대입을 tests/ 전수 훑음. 발견: `test_s0_2_chat_migration.py`의
  `NEXT_PUBLIC_APP_URL` 미복원 대입 1건 제외 전부 이미 올바르게 복원됨(try/finally 또는
  patch.dict/monkeypatch). 훑은 범위 밖(이름 재바인딩·동적 setattr 등)은 가드
  테스트 docstring에 명시.
- **②wide-blast-radius 1건만 즉시 수정** — `test_s0_2_chat_migration.py`:
  `os.environ["NEXT_PUBLIC_APP_URL"] = ...`(무복원) → `monkeypatch.setenv(...)`.
  consumer: `auth.py`/`docs.py`/`org_invite_email.py`/`discord_webhook.py`.
- **③재발 방지 가드** — `test_2274_module_global_leak_guard.py`: `cron\w*.CRON_SECRET =`
  패턴 정적 스캔. RED→GREEN 자체검증 완료(사보타주 삽입 시 정확한 file:line 리포트 확인
  후 제거). 못 잡는 범위(다른 전역·이름 재바인딩·동적 setattr·monkeypatch 오용)를
  docstring에 명시.
- **④count_orphan_types에 실 caller** — `entity_references_orphan_check` cron endpoint
  재부착(`app/routers/cron.py`). 다른 cron endpoint와 동일한 `verify_cron()` 패턴
  재사용(⑦, 신규 인증 미발명).
- **⑤baseline 측정** — `test_2274_cron_orphan_check_realdb.py`: 정상 타입 삽입 시
  orphan 총계 불변, registry 밖 타입 삽입 시 total이 정확히 델타만큼 증가함을 확인(절대값
  아닌 delta 비교 — 공유 DB 잔여 데이터에 안전).
- **⑥전역 회귀 0** — 프레시 마이그레이션 DB(`alembic upgrade head`)에서 #2274/#2273/#2260/
  #2259/cron-secret 관련 테스트 파일 9개(86 tests) 전부 GREEN. 원래 CI를 깼던 3개 파일도
  포함해 GREEN. 별도로, `verify_cron()`/`CRON_SECRET`을 소비하는 전 파일(6개, 59 tests)도
  전부 GREEN.
- **⑨(자체) RED→GREEN mutation self-check** — cron endpoint 내부의 `count_orphan_types`
  호출을 임시로 `{}`로 사보타주 → `test_orphan_check_endpoint_flags_real_orphan` RED 확인
  → 원복 → GREEN 재확인. 테스트가 실제로 엔드포인트 정확성을 검증함을 증명.

## 스코프 밖 (참고)
- 대규모(5000+) 전체 테스트 스위프에서 무관한 758개 실패를 발견했으나, 대표 샘플
  3파일(retro/webhook_config/standup)을 `git stash`로 diff 제거 후 재실행해 동일하게
  실패함을 확인 — 이 PR의 diff와 무관한 기존 DB 스키마 드리프트(예: `projects.violation_level`
  NOT NULL)다. 이 PR의 diff는 `app/routers/cron.py` + 4개 test 파일뿐이라 그 실패군과
  교집합이 없음.

## 롤백
`app/routers/cron.py`에서 `entity_references_orphan_check` 함수 삭제(또는 이 PR revert) —
`count_orphan_types` 자체(순수 함수, #2259)는 영향 없음.