### PR TITLE
[SID:2278][진단] OAuth 콜백 csrf 실패 — 쿠키없음/값불일치 분기 로그

### DIFF
--- a/apps/web/src/app/api/auth/callback/[provider]/route.test.ts
+++ b/apps/web/src/app/api/auth/callback/[provider]/route.test.ts
@@ -155,3 +155,72 @@ describe('GET /api/auth/callback/[provider] — native OAuth-handoff branch', ()
     expect(h.cookiesDeleteMock).toHaveBeenCalledWith('oauth_native_challenge_google');
   });
 });
+
+describe('GET /api/auth/callback/[provider] — state 검증 분기 로그(2026-07-28 진단, 가드는 무변화)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    h.cookiesGetMock.mockReset();
+    h.cookiesDeleteMock.mockReset();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  function stubCookies(overrides: Record<string, string> = {}) {
+    h.cookiesGetMock.mockImplementation((name: string) =>
+      name in overrides ? { value: overrides[name] } : undefined,
+    );
+  }
+
+  it('ⓐ 쿠키가 아예 없으면 missing_cookie로 로그되고, 검증 결과는 원래와 동일하게 csrf_mismatch로 리다이렉트한다', async () => {
+    stubCookies(); // oauth_state_google 자체가 없음
+    const res = await GET(
+      makeRequest({ code: 'c', state: 'some-state-value-from-attacker-or-replay' }),
+      routeParams(),
+    );
+    expect(res.headers.get('location')).toBe('http://localhost:3108/login?error=csrf_mismatch');
+    expect(mockFetch).not.toHaveBeenCalled(); // FastAPI까지 안 감(검증이 여전히 앞단에서 막음)
+
+    const logLine = warnSpy.mock.calls.map((c) => String(c[0])).find((l) => l.includes('state_check'));
+    expect(logLine).toContain('outcome=missing_cookie');
+    expect(logLine).toContain('stored_state_len=null');
+  });
+
+  it('ⓑ 쿠키는 있는데 값이 다르면 state_mismatch로 로그되고, 검증 결과는 원래와 동일하게 csrf_mismatch로 리다이렉트한다', async () => {
+    stubCookies({ oauth_state_google: 'stored-value-aaa' });
+    const res = await GET(makeRequest({ code: 'c', state: 'incoming-value-bbb' }), routeParams());
+    expect(res.headers.get('location')).toBe('http://localhost:3108/login?error=csrf_mismatch');
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    const logLine = warnSpy.mock.calls.map((c) => String(c[0])).find((l) => l.includes('state_check'));
+    expect(logLine).toContain('outcome=state_mismatch');
+    expect(logLine).not.toContain('stored_state_len=null'); // 존재는 했다
+  });
+
+  it('양성대조 — 통과 경로(dev 포함)에도 outcome=ok 로그가 남는다(미도달과 무로그를 구분)', async () => {
+    stubCookies({ oauth_state_google: 'matching-state' });
+    mockFetch.mockResolvedValueOnce({
+      ok: true, json: async () => ({ data: { access_token: 'at', refresh_token: 'rt' } }),
+    });
+    await GET(makeRequest({ code: 'c', state: 'matching-state' }), routeParams());
+
+    const logLine = warnSpy.mock.calls.map((c) => String(c[0])).find((l) => l.includes('state_check'));
+    expect(logLine).toContain('outcome=ok');
+  });
+
+  it('⛔state 값·쿠키 값을 로그에 절대 안 찍는다(길이/존재 여부만) — 세 분기 모두', async () => {
+    const secretState = 'THIS-MUST-NEVER-APPEAR-IN-LOGS-abc123';
+    const secretStored = 'THIS-STORED-VALUE-MUST-NEVER-APPEAR-xyz789';
+
+    stubCookies({ oauth_state_google: secretStored });
+    await GET(makeRequest({ code: 'c', state: secretState }), routeParams());
+
+    const allLoggedText = warnSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(allLoggedText).not.toContain(secretState);
+    expect(allLoggedText).not.toContain(secretStored);
+  });
+});

--- a/apps/web/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/web/src/app/api/auth/callback/[provider]/route.ts
@@ -10,6 +10,27 @@ const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://loca
 // association이 분리되므로(§10.2) env로 주입 — PO/인프라 lane이 prod 값 설정 책임.
 const APP_LINK_ORIGIN = () => process.env['MOBILE_APP_LINK_ORIGIN'] ?? 'https://dev-app.sprintable.ai';
 
+// 진단(2026-07-28, 모바일 구글 로그인 prod security_check_failed) — ⛔가드를 푸는 것이 아니다,
+// 통과 조건은 글자 하나도 안 바뀐다. state 검증 실패가 「쿠키가 아예 안 옴(ⓐ)」과 「쿠키는
+// 왔는데 값이 다름(ⓑ)」 두 서로 다른 사고로 뭉쳐 있어 처방 방향이 갈리는데 지금은 구분이
+// 안 된다 — 서버 로그에만 분기해 남긴다(사용자 화면 문구는 csrf_mismatch로 동일 유지).
+// ⛔state 값·쿠키 값·인증 코드는 절대 안 찍는다(길이/존재 여부만). dev의 통과 경로에도
+// 성공 로그를 남겨야 "안 찍힘=미도달"과 "안 찍힘=로그 자체가 없음"이 갈린다(양성대조).
+function logOauthStateCheck(
+  outcome: 'missing_cookie' | 'state_mismatch' | 'ok',
+  request: Request,
+  provider: string,
+  nativeChallenge: string | null,
+  stateLen: number,
+  storedStateLen: number | null,
+): void {
+  console.warn(
+    `auth.oauth.callback.state_check outcome=${outcome} provider=${provider} ` +
+    `native=${Boolean(nativeChallenge)} state_len=${stateLen} stored_state_len=${storedStateLen ?? 'null'} ` +
+    `referer=${request.headers.get('referer') ?? 'null'} ua=${request.headers.get('user-agent') ?? 'null'}`,
+  );
+}
+
 function cookieBase() {
   const domain = process.env['NEXT_PUBLIC_COOKIE_DOMAIN'];
   return { httpOnly: true, secure: process.env.NODE_ENV === 'production', sameSite: 'lax' as const, path: '/', ...(domain ? { domain } : {}) };
@@ -61,9 +82,17 @@ export async function GET(request: Request, { params }: RouteParams) {
   cookieStore.delete(`oauth_next_${provider}`);
   cookieStore.delete(`oauth_native_challenge_${provider}`);
 
-  if (!storedState || storedState !== state) {
+  // ⛔통과 조건은 원래와 동일(storedState 존재 AND 일치) — 분기는 로그용일 뿐, 검증 자체는
+  // 안 바뀐다. 두 실패 분기 다 사용자에게는 동일한 csrf_mismatch로 리다이렉트한다.
+  if (!storedState) {
+    logOauthStateCheck('missing_cookie', request, provider, nativeChallenge, state.length, null);
     return NextResponse.redirect(`${origin}/login?error=csrf_mismatch`);
   }
+  if (storedState !== state) {
+    logOauthStateCheck('state_mismatch', request, provider, nativeChallenge, state.length, storedState.length);
+    return NextResponse.redirect(`${origin}/login?error=csrf_mismatch`);
+  }
+  logOauthStateCheck('ok', request, provider, nativeChallenge, state.length, storedState.length);
 
   // FastAPI OAuth callback
   const fastapiRes = await fetch(`${FASTAPI_URL()}/api/v2/auth/oauth/callback`, {


### PR DESCRIPTION
## 배경

~~모바일 구글 로그인이 prod에서 `security check failed`로 실패~~ — **착수 후 원인이 다른 경로(민 조사)로 먼저 밝혀졌다**: 앱 빌드 프로필에 `EXPO_PUBLIC_OAUTH_HANDOFF` 플래그가 없어 네이티브 핸드오프 자체가 시작 안 됨 → 웹뷰가 일반 웹 로그인을 탐 → 쿠키는 웹뷰가 먹고 구글 콜백은 Chrome이 받음 → 쿠키 없음 → csrf_mismatch. **웹 서버 쪽 결함이 아니었다.**

그래도 이 PR은 폐기하지 않는다 — "다음에 또 csrf가 나면 ⓐ(쿠키 없음)/ⓑ(값 불일치)를 갈라야 하는" 판별력 자체는 여전히 유효한 값이라 PO가 유지 지시했다(priority high→medium 하향, 급하지 않게).

## 무엇을 고쳤는가

```js
if (!storedState || storedState !== state)   // 완전히 다른 두 사고가 한 조건에 묶여 있었다
```

⛔**검증 로직은 글자 하나도 안 바뀐다** — 통과 조건(`storedState && storedState === state`)은 동일, if 분기만 재배열했다. 사용자 화면 문구도 `csrf_mismatch`로 동일 유지 — 갈리는 것은 서버 로그(`console.warn`)뿐.

- 로그 필드: `outcome`(missing_cookie|state_mismatch|ok) · `provider` · `native` 여부 · `Referer`/`User-Agent`.
- ⛔state 값·쿠키 값·인증 코드는 **절대 원문을 안 찍는다** — 길이(`state_len`/`stored_state_len`)와 존재 여부까지만.
- 통과 경로(`ok`)에도 로그를 남긴다 — "안 찍힘=미도달"과 "로그 자체가 없음"을 가르는 양성대조(AC5).

## 검증

- mutation-verified: 분기를 원래의 단일 조건으로 되돌림 → 신규 테스트 3개가 정확히 RED → 재적용 → GREEN.
- 신규 테스트 4케이스(ⓐ/ⓑ 분기 로그·양성대조 성공 로그·민감값 비노출 검증) + 기존 native-handoff 회귀가드 9케이스 전부 GREEN(검증 로직 불변의 증거).
- 전체 FE vitest 스윕: 294 파일 · 1955 테스트 전부 PASS.
- `tsc --noEmit` 무오류, `eslint` 무경고.

## AC7(dev·prod 배포 후 로그 관측)에 대해

원인이 이미 다른 경로로 밝혀졌으므로 이번엔 실제 재현·로그 관측이 필요 없다 — PO 승인 하에 "판별력 자체는 남기고 급하지 않게 마무리"로 처리.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>