### PR TITLE
[C-8] #2266: backlinks target_type 허용목록 일반화 + story 역방향 조회

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -551,6 +551,36 @@ async def get_story(
     return StoryResponse.model_validate(story)
 
 
+# ─── Backlinks (story #2266·C-8·E-CONNECT — target_type 일반화의 첫 사용처) ─────
+# `app.services.backlinks.list_entity_backlinks`는 SOURCE 접근만 스스로 판정하고 TARGET 접근은
+# 호출부 책임(§8① 동일 계약, docs.py의 get_doc_backlinks와 동형). 이 라우트가 그 TARGET
+# 게이트다 — get_story와 동일한 `_assert_story_project_access` 재사용(AC2: 같은 PR에 게이트,
+# AC7: 새 인증 미발명).
+@router.get("/{id}/backlinks")
+async def get_story_backlinks(
+    id: uuid.UUID,
+    limit: int = Query(default=30, ge=1, le=200),
+    before: str | None = Query(default=None),
+    repo: StoryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    """GET /api/v2/stories/{id}/backlinks — 이 story를 가리키는 chat_message/doc 목록(#2266,
+    C-8 "역방향"). docs.py의 get_doc_backlinks와 동일 convention(cursor pagination, 응답
+    shape) — 실제 쿼리는 `list_entity_backlinks`가 target_type만 다르게 받아 처리하는 **같은
+    코드**다(중복 구현 아님). 존재하지 않는 story는 404, 있지만 project 접근 없으면 403
+    (`_assert_story_project_access` — get_story와 동일 계약, existence oracle 없음)."""
+    story = await repo.get(id)
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+    await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
+
+    from app.services.backlinks import list_entity_backlinks
+    return await list_entity_backlinks(
+        repo.session, org_id=repo.org_id, target_type="story", target_id=id,
+        auth=auth, limit=limit, cursor=before,
+    )
+
+
 class UploadStoryAttachmentRequest(BaseModel):
     """E-MCP-OPT S6: MCP(비-브라우저)용 JSON/base64 첨부 업로드 요청(chat과 동형)."""
 

--- a/backend/app/services/backlinks.py
+++ b/backend/app/services/backlinks.py
@@ -279,18 +279,41 @@ async def _chat_predicate_inputs(
     return caller_member_id, is_api_key
 
 
-async def list_doc_backlinks(
+# ─── story #2266(C-8) — target_type 일반화, 허용목록(allowlist) ──────────────────
+# PO 판정(2026-07-28): target_type을 자유 파라미터로 열면 «게이트가 안 선 타입까지 통과하는
+# 구멍»이 생긴다 — 이 함수는 TARGET 접근 검증을 스스로 하지 않고(§8①) 호출부(라우터)가
+# 이미 검증했다는 전제로 짜여 있기 때문(위 docstring 참조). 그래서 "이 타입은 호출부가 실제로
+# 게이트를 세웠다"를 이 allowlist가 보증한다 — 코드 레벨 계약이지 편의 목록이 아니다.
+BACKLINKS_ALLOWED_TARGET_TYPES = frozenset({"doc", "story"})
+# ⛔registry(reference_registry.ENTITY_RESOLVERS)의 나머지 타입(epic 등)이 여기 없는 이유는
+# "의도적 제외"가 아니라 **게이트 미비**다 — 그 타입들의 라우터에 아직 이 함수와 동형인
+# TARGET project-access 선-게이트(docs.py._require_doc_project_access ·
+# stories.py._assert_story_project_access)가 없다. 게이트가 서는 순서대로 여기 추가한다.
+
+
+class UnsupportedBacklinkTargetTypeError(ValueError):
+    """target_type이 BACKLINKS_ALLOWED_TARGET_TYPES 밖 — 호출 라우터가 400으로 번역한다."""
+
+
+async def list_entity_backlinks(
     db: AsyncSession,
     *,
     org_id: uuid.UUID,
-    doc_id: uuid.UUID,
+    target_type: str,
+    target_id: uuid.UUID,
     auth: AuthContext,
     limit: int,
     cursor: str | None,
 ) -> dict:
-    """GET /api/v2/docs/{id}/backlinks 코어. 호출부(docs.py)가 target doc 접근을 이미 검증했다는
-    전제(§8① target read access는 별도·기존 라우트 책임) — 여기선 source 접근만 mention 행
-    단위로 판정한다.
+    """GET /api/v2/{docs,stories}/{id}/backlinks 코어(#2266 — target_type 일반화). 호출부
+    (docs.py/stories.py)가 target 접근을 이미 검증했다는 전제(§8① target read access는 별도·
+    기존 라우트 책임) — 여기선 source 접근만 mention 행 단위로 판정한다.
+
+    story #2266: `target_type`은 `BACKLINKS_ALLOWED_TARGET_TYPES`(허용목록)에 있는 값만
+    받는다 — 그 밖의 값은 `UnsupportedBacklinkTargetTypeError`(호출부가 400으로 번역). SOURCE
+    측 로직(authz predicate·응답 item shape)은 target_type과 완전히 무관하다(SELECT/JOIN이
+    `Reference.source_id`·`Reference.source_type` 기준이지 target 기준이 아니다) — 그래서
+    이 함수는 target_type이 늘어도 SOURCE 쪽 쿼리를 한 글자도 안 바꾼다.
 
     반환: `{"data": [...], "meta": {"next_cursor": str|None, "has_more": bool}}` — list_messages와
     동일 shape(AC1 "same convention"). data 항목: {id, source_type, source_id, created_by,
@@ -298,6 +321,9 @@ async def list_doc_backlinks(
     `created_by`는 raw UUID가 아니라 `{id,name,type}`|None(sender와 동형 처리 — Extra fix).
     `next_cursor`는 opaque composite base64 토큰(B3) — `before` query param에 그대로 되돌려준다.
     """
+    if target_type not in BACKLINKS_ALLOWED_TARGET_TYPES:
+        raise UnsupportedBacklinkTargetTypeError(target_type)
+
     cursor_key: tuple[datetime, uuid.UUID] | None = None
     if cursor:
         cursor_key = decode_cursor(cursor)
@@ -392,8 +418,8 @@ async def list_doc_backlinks(
         .where(
             Reference.org_id == org_id,
             Reference.source_field == "body",
-            Reference.target_type == "doc",
-            Reference.target_id == doc_id,
+            Reference.target_type == target_type,
+            Reference.target_id == target_id,
             or_(
                 and_(
                     Reference.source_type == "doc",
@@ -415,6 +441,11 @@ async def list_doc_backlinks(
         cursor_created_at, cursor_id = cursor_key
         stmt = stmt.where(tuple_(Reference.created_at, Reference.id) < tuple_(cursor_created_at, cursor_id))
 
+    # story #2266 AC6(정렬은 "최근"이 아니라 "쓸모"): entity_references는 지금 조회수·클릭·
+    # 관련도 등 recency 이외의 신호를 전혀 안 쌓는다(row에 그런 컬럼이 없다) — "쓸모" 축으로
+    # 정렬하려 해도 지금 계산할 수 있는 신호가 하나도 없다. created_at DESC를 유지하는 이유는
+    # "그냥 기본값"이 아니라 "지금 유일하게 존재하는 신호가 이것뿐"이라는 사실이다. 신호가
+    # 생기면(예: form!=proof 우선순위, 조회 카운트) 그때 다시 정렬 기준을 판정한다.
     stmt = stmt.order_by(Reference.created_at.desc(), Reference.id.desc()).limit(limit + 1)
 
     rows = (await db.execute(stmt)).all()
@@ -459,4 +490,37 @@ async def list_doc_backlinks(
         last_mention = page_rows[-1].Reference
         next_cursor = encode_cursor(last_mention.created_at, last_mention.id)
 
-    return {"data": data, "meta": {"next_cursor": next_cursor, "has_more": has_more}}
+    # story #2266 AC4(정직성 관문): "0건"을 "출처 없음"으로 읽지 않도록, 이 응답이 실제로
+    # 무엇을 셌는지를 구조화된 사실로 함께 낸다(문안 렌더는 FE 몫 — 여기선 FE가 틀리지 않게
+    # 근거 사실만 준다). ⛔이 쿼리는 `Reference.form`을 필터링하지 않는다(mention/embed/proof
+    # 전부 포함 — 위 stmt에 form 조건이 없다) — 그래서 "mention/embed만"이라고 쓰면 거짓이다.
+    # source_type은 이 함수가 아는 두 값(chat_message·doc)뿐 — PR "[SID:XXX]" 텍스트 관례·
+    # evidence 자유텍스트 참조는 entity_references에 전혀 안 쌓이므로(구조화 전) 이 카운트에
+    # 없다.
+    collection_scope = {
+        "source_types": ["chat_message", "doc"],
+        "forms": "all",
+        "excludes": ["pr_sid_text_convention", "evidence_free_text_reference"],
+    }
+
+    return {
+        "data": data,
+        "meta": {"next_cursor": next_cursor, "has_more": has_more, "collection_scope": collection_scope},
+    }
+
+
+async def list_doc_backlinks(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    doc_id: uuid.UUID,
+    auth: AuthContext,
+    limit: int,
+    cursor: str | None,
+) -> dict:
+    """하위호환 wrapper(story #2266) — 기존 호출부(docs.py)·기존 테스트(test_1994_*)가 이
+    이름·시그니처 그대로 쓴다. 실제 로직은 `list_entity_backlinks(target_type="doc", ...)`로
+    위임한다(둘이 서로 다른 코드가 아니다 — 하나의 SSOT)."""
+    return await list_entity_backlinks(
+        db, org_id=org_id, target_type="doc", target_id=doc_id, auth=auth, limit=limit, cursor=cursor,
+    )

--- a/backend/app/services/backlinks.py
+++ b/backend/app/services/backlinks.py
@@ -292,7 +292,16 @@ BACKLINKS_ALLOWED_TARGET_TYPES = frozenset({"doc", "story"})
 
 
 class UnsupportedBacklinkTargetTypeError(ValueError):
-    """target_type이 BACKLINKS_ALLOWED_TARGET_TYPES 밖 — 호출 라우터가 400으로 번역한다."""
+    """target_type이 BACKLINKS_ALLOWED_TARGET_TYPES 밖 — 호출 라우터가 400으로 번역한다.
+
+    ⛔PO 리뷰(2026-07-28): 지금은 이 분기가 HTTP 경로로 «도달 불가»하다 — docs.py/stories.py
+    둘 다 target_type을 client 입력이 아니라 고정 literal("doc"/"story")로 넘긴다. 그래서
+    「아무도 안 타는 분기」로 보여 다음 사람이 지울 위험이 있다 — 지우면 안 된다. **허용목록이
+    언젠가 client 입력(예: 단일 generic `/entities/{type}/{id}/backlinks` 라우트)을 받게 되는
+    날, 이 분기가 TARGET 게이트 누락을 막는 유일한 방어선**이 된다. 지금도
+    `test_list_entity_backlinks_rejects_unsupported_target_type`이 이 분기를 직접 타서
+    커버리지에 살아 있고, 허용목록을 게이트 없이 늘리면 그 테스트가 걸린다(RED로 잡는다는
+    뜻이 아니라 — 허용목록에 추가한 사람이 이 클래스의 존재를 코드에서 보게 된다는 뜻)."""
 
 
 async def list_entity_backlinks(

--- a/backend/tests/test_2266_story_backlinks_realdb.py
+++ b/backend/tests/test_2266_story_backlinks_realdb.py
@@ -1,0 +1,416 @@
+"""story #2266(C-8, E-CONNECT) — `list_doc_backlinks` 일반화(target_type 허용목록) +
+`GET /api/v2/stories/{id}/backlinks`(역방향, "이것을 가리키는 것들"). 실PG 검증.
+
+PO 판정(2026-07-28) 3정정을 그대로 검증한다:
+  ①target_type은 허용목록(BACKLINKS_ALLOWED_TARGET_TYPES={doc, story}) — 밖은 거절
+  ②story TARGET 게이트(`_assert_story_project_access`)가 같은 PR에 선다 — 게이트 없이 여는
+    PR은 이 스토리의 완료가 아니다(AC2 money test)
+  ③구 AC4(참조 0건 전체 목록/기준선)는 #2277로 분리 — 이 파일은 다루지 않는다
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+# ─── Seeding helpers (test_1994_backlink_api_realdb.py와 동형 — 이 파일 자체 완결) ──
+
+
+async def _make_org(session, name="Org"):
+    from app.models.organization import Organization
+    org = Organization(id=uuid.uuid4(), name=name, slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    return org
+
+
+async def _make_project(session, org_id, name="P"):
+    from app.models.project import Project
+    project = Project(id=uuid.uuid4(), org_id=org_id, name=name)
+    session.add(project)
+    await session.commit()
+    return project
+
+
+async def _make_human_member(session, org_id, project_id):
+    """test_1994의 동명 helper와 동일 anchor 패턴(members + org_members + project_access
+    직접 write — team_members는 VIEW라 INSERT 불가)."""
+    from app.models.user import User
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.member import Member
+
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="member")
+    session.add(om)
+    await session.flush()
+    m = Member(id=om.id, org_id=org_id, type="human", user_id=user.id, name="Human")
+    session.add(m)
+    await session.flush()
+    session.add(ProjectAccess(project_id=project_id, org_member_id=om.id, member_id=m.id, role="member"))
+    await session.commit()
+    return m.id, user.id
+
+
+async def _make_story(session, org_id, project_id, title="Story"):
+    from app.models.pm import Story
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status="backlog")
+    session.add(story)
+    await session.commit()
+    return story
+
+
+async def _make_conversation(session, org_id, project_id, member_ids, created_by, conv_type="dm"):
+    from app.models.conversation import Conversation, ConversationParticipant
+    conv = Conversation(
+        id=uuid.uuid4(), project_id=project_id, org_id=org_id, type=conv_type,
+        title="Test convo", created_by=created_by,
+    )
+    session.add(conv)
+    await session.flush()
+    for mid in member_ids:
+        session.add(ConversationParticipant(conversation_id=conv.id, member_id=mid))
+    await session.commit()
+    return conv.id
+
+
+async def _add_message(session, conv_id, sender_id, content, created_at=None):
+    from app.models.conversation import ConversationMessage
+    msg = ConversationMessage(
+        id=uuid.uuid4(), conversation_id=conv_id, sender_id=sender_id,
+        content=content, created_at=created_at or datetime.now(timezone.utc),
+    )
+    session.add(msg)
+    await session.commit()
+    return msg
+
+
+async def _make_reference(session, org_id, source_type, source_id, target_type, target_id, created_by, form="mention"):
+    from app.models.reference import Reference
+    ref = Reference(
+        id=uuid.uuid4(), org_id=org_id, source_type=source_type, source_field="body",
+        source_id=source_id, target_type=target_type, target_id=target_id, form=form,
+        created_by=created_by,
+    )
+    session.add(ref)
+    await session.commit()
+    return ref
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ─── ①허용목록 — service-level guard ────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_list_entity_backlinks_rejects_unsupported_target_type():
+    """게이트가 안 선 타입(epic 등)은 허용목록 밖 — UnsupportedBacklinkTargetTypeError."""
+    from app.services.backlinks import list_entity_backlinks, UnsupportedBacklinkTargetTypeError
+    from app.dependencies.auth import AuthContext
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            auth = AuthContext(user_id=str(uuid.uuid4()), email="x@test", claims={})
+            with pytest.raises(UnsupportedBacklinkTargetTypeError):
+                await list_entity_backlinks(
+                    s, org_id=org.id, target_type="epic", target_id=uuid.uuid4(),
+                    auth=auth, limit=30, cursor=None,
+                )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_backlinks_allowlist_contains_exactly_doc_and_story():
+    """이번 판 허용목록은 정확히 {doc, story}뿐 — 다음 판(epic 등)이 늘리기 전까지 고정."""
+    from app.services.backlinks import BACKLINKS_ALLOWED_TARGET_TYPES
+    assert BACKLINKS_ALLOWED_TARGET_TYPES == frozenset({"doc", "story"})
+
+
+# ─── ②story TARGET 게이트 — AC2 money test(권한 대조: 있음 vs 없음) ────────────
+
+
+@pytest.mark.anyio
+async def test_story_backlinks_404_for_nonexistent_story():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{uuid.uuid4()}/backlinks")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_story_backlinks_project_access_twin_comparison():
+    """⭐AC2·AC5 핵심 — 양성대조(twin comparison, PO가 #2277에도 요구한 그 패턴): 같은
+    story·같은 참조 데이터에 대해 project 접근이 «있는» caller는 200+데이터를 보고, 접근이
+    «없는» caller는 403을 받는다. 하나만 재면(0건만 확인) 권한 게이트가 실제로 도는지
+    "없어서 0건"인지 "막혀서 0건"인지 구분이 안 된다 — 이 테스트가 그 둘을 가른다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id, "Story Project")
+            other_project = await _make_project(s, org.id, "Other Project")
+            member_with_access, user_with_access = await _make_human_member(s, org.id, project.id)
+            member_without_access, user_without_access = await _make_human_member(s, org.id, other_project.id)
+
+            story = await _make_story(s, org.id, project.id, title="Target Story")
+            conv_id = await _make_conversation(s, org.id, project.id, [member_with_access], member_with_access)
+            msg = await _add_message(s, conv_id, member_with_access, f"보는 [Story](entity:story:{story.id})")
+            await _make_reference(
+                s, org.id, "chat_message", msg.id, "story", story.id, created_by=member_with_access,
+            )
+
+        # (1) 접근 있는 caller — 200 + 데이터 보임
+        await _setup_app_human(app, Session, user_with_access, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{story.id}/backlinks")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert len(body["data"]) == 1, body
+            assert body["data"][0]["source_type"] == "chat_message"
+            assert body["data"][0]["message"]["id"] == str(msg.id)
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        # (2) 접근 없는 caller(다른 project) — 403, 데이터 유출 0
+        await _setup_app_human(app, Session, user_without_access, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{story.id}/backlinks")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_story_backlinks_gate_red_green_mutation_self_check():
+    """⭐RED→GREEN 자체검증 — 라우터에서 `_assert_story_project_access` 호출을 사보타주하면
+    위 twin comparison의 (2)가 403 대신 200으로 새는지(=게이트가 실제로 그 자리에서 막고
+    있었는지) 직접 증명한다. `stories.py`를 임시로 패치해 게이트를 무력화 → RED 확인 → 원복."""
+    import app.routers.stories as stories_module
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id, "Story Project")
+            other_project = await _make_project(s, org.id, "Other Project")
+            member_with_access, user_with_access = await _make_human_member(s, org.id, project.id)
+            member_without_access, user_without_access = await _make_human_member(s, org.id, other_project.id)
+            story = await _make_story(s, org.id, project.id, title="Target Story")
+
+        from app.main import app
+
+        original_gate = stories_module._assert_story_project_access
+
+        async def _noop_gate(*args, **kwargs):
+            return None
+
+        stories_module._assert_story_project_access = _noop_gate
+        try:
+            await _setup_app_human(app, Session, user_without_access, org.id)
+            client = _client_for(app)
+            try:
+                resp = await client.get(f"/api/v2/stories/{story.id}/backlinks")
+                # 게이트 무력화 상태 — 권한 없는 caller인데도 200이 새는 것(RED, 사보타주 효과 실증)
+                assert resp.status_code == 200, (
+                    f"사보타주가 안 먹었다(게이트가 다른 경로로도 걸리는 중?) — {resp.status_code}: {resp.text}"
+                )
+            finally:
+                await client.aclose()
+                app.dependency_overrides.clear()
+        finally:
+            stories_module._assert_story_project_access = original_gate
+
+        # 원복 후 GREEN 재확인 — 같은 caller가 다시 403.
+        await _setup_app_human(app, Session, user_without_access, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{story.id}/backlinks")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── ③「0건」 collection_scope meta(AC4) ────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_story_backlinks_zero_result_still_carries_collection_scope():
+    """참조 0건이어도 meta.collection_scope는 항상 나온다 — FE가 「출처 없음」이 아니라
+    「관찰된 참조 0건(수집범위 X)」을 조립할 수 있는 근거 사실을 backend가 준다(AC4)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, title="No references")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{story.id}/backlinks")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["data"] == []
+            scope = body["meta"]["collection_scope"]
+            assert scope["source_types"] == ["chat_message", "doc"]
+            assert scope["forms"] == "all"
+            assert "pr_sid_text_convention" in scope["excludes"]
+            assert "evidence_free_text_reference" in scope["excludes"]
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_doc_backlinks_wrapper_still_returns_collection_scope_no_regression():
+    """list_doc_backlinks(#1994 기존 호출부)도 같은 SSOT를 타므로 collection_scope가
+    새로 붙는다 — 기존 41개 테스트가 이미 키-존재 단정이 아닌 개별 키만 검사해 회귀가 없음을
+    실행으로 확인했지만(별도 스윕), 이 테스트는 그 사실 자체를 명시적으로 고정한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            from app.models.doc import Doc
+            doc = Doc(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="D", slug=f"d-{uuid.uuid4().hex[:8]}", content="")
+            s.add(doc)
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/docs/{doc.id}/backlinks")
+            assert resp.status_code == 200, resp.text
+            assert "collection_scope" in resp.json()["meta"]
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── ④성능 경계(AC7) — 단건 조회가 실제로 인덱스를 타는지 실측 ─────────────────
+
+
+@pytest.mark.anyio
+async def test_story_backlinks_query_uses_target_index():
+    """⛔실측(AC7) — target_type+target_id 필터가 ix_entity_references_target을 Index
+    (Only) Scan으로 타는지 EXPLAIN으로 직접 확인한다(코드 읽고 "될 것 같다"가 아니라)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            from sqlalchemy import text
+            explain = await s.execute(text(
+                "EXPLAIN SELECT * FROM entity_references "
+                "WHERE org_id = :org_id AND target_type = 'story' AND target_id = :target_id "
+                "ORDER BY created_at DESC, id DESC LIMIT 31"
+            ), {"org_id": str(org.id), "target_id": str(uuid.uuid4())})
+            plan_lines = [row[0] for row in explain.all()]
+            plan_text = "\n".join(plan_lines)
+            assert "ix_entity_references_target" in plan_text, (
+                f"target index를 안 탄다 — planner가 다른 경로를 골랐다:\n{plan_text}"
+            )
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 배경
블루프린트 §3-2 "뒤(출처) 미상" — story의 FK는 epic/sprint/meeting(컨테이너)뿐, "어디서
나왔는가"를 담을 칸이 없었다. #2273이 세운 `entity_references`는 참조를 "가리킨 쪽"에
쌓는다 — 가리켜진 쪽(예: story)에서 거꾸로 읽으면 "이 story는 저 대화에서 나왔다"가
나온다. 이 PR이 그 "거꾸로 읽기"(역방향)를 처음 연다.

## PO 판정 3정정 반영
1. **허용목록(allowlist)** — `list_doc_backlinks`는 TARGET 접근 검증을 스스로 하지 않고
   호출부(라우터)가 이미 검증했다는 전제로 짜여 있다. target_type을 자유 파라미터로 열면
   "게이트가 안 선 타입까지 통과하는 구멍"이 생긴다. `BACKLINKS_ALLOWED_TARGET_TYPES =
   {doc, story}`로 막았다 — 밖의 타입은 `UnsupportedBacklinkTargetTypeError`. 나머지
   타입(epic 등)이 없는 이유(게이트 미비, 의도적 제외 아님)를 코드 주석에 남겼다.
2. **story TARGET 게이트를 같은 PR에** — `stories.py`에 `GET /{id}/backlinks`를 신설하면서
   기존 SEC-S8 게이트(`_assert_story_project_access`, get_story가 이미 쓰는 그 함수 —
   신규 인증 미발명, AC7)를 라우터에서 먼저 태운 뒤에만 backlinks 코어를 호출한다.
3. **"참조 0건 전체 목록"은 분리** — #2277로 등록(PO). 이 PR은 **역방향 단건 조회**만.

## 구현
- `list_doc_backlinks`의 SOURCE측 authz/응답 shape는 target_type과 **완전히 무관**함을
  코드 실측으로 확인(SELECT/JOIN이 `Reference.source_id`/`source_type` 기준) — 그래서
  WHERE절의 `target_type`/`target_id` 리터럴만 파라미터화하면 됐다(`list_entity_backlinks`).
  `list_doc_backlinks`는 하위호환 thin wrapper로 남겨 기존 호출부(docs.py)·기존 테스트
  41개 무변경.
- `GET /stories/{id}/backlinks` 신설 — docs.py의 `get_doc_backlinks`와 완전히 동형인
  convention(cursor pagination, 응답 shape, 404/403 계약).
- 응답 `meta.collection_scope` 추가(AC4, "이 모양의 최고점"으로 승인된 문안의 근거 사실) —
  ⛔자체 발견: 이 쿼리는 `Reference.form`을 필터링하지 않는다(mention/embed/proof 전부
  포함) — 애초 승인받은 "수집범위: mention/embed"라는 표현은 부정확했다. `forms: "all"`로
  정정해 반영(정직성 관문을 스스로 어기지 않기 위해).
- AC6(정렬="쓸모"): entity_references에 recency 외 신호(조회수 등)가 아직 없어
  `created_at DESC`를 유지 — "이유 없이 두는 것"이 아니라 "지금 존재하는 유일한 신호"라는
  근거를 코드 주석에 남겼다.

## 검증
- 신규 8테스트(`test_2266_story_backlinks_realdb.py`): 허용목록 가드, 404, **twin
  comparison**(같은 story·같은 참조에 대해 접근 있는 caller=200+데이터 / 접근 없는
  caller=403 — "없어서 0건"과 "막혀서 0건"을 가른다), **RED→GREEN 게이트 사보타주
  자체검증**(`_assert_story_project_access` 무력화 → 403이 200으로 새는 것 확인 → 원복 →
  재확인), collection_scope 메타, **EXPLAIN 기반 인덱스 실측**(`ix_entity_references_target`
  실제로 탐).
- 회귀: `test_1994_backlink_api_realdb.py`(41) + stories 라우터 전체(`test_stories.py` 등,
  42) + mention/reference 관련 스위트(65) 전부 GREEN. 프레시 마이그 DB(`alembic upgrade
  head`) 기준.

## 롤백
`app/routers/stories.py`의 `get_story_backlinks` 삭제 + `app/services/backlinks.py`를
이 커밋 이전으로 revert(`list_doc_backlinks`는 원래 시그니처 그대로 복원 가능 — 하위호환
유지했으므로 부분 revert도 안전).