### PR TITLE
fix(applink): dev 모바일 패키지 assetlinks.json 항목 추가 (재발행)

### DIFF
--- a/apps/web/public/.well-known/assetlinks.json
+++ b/apps/web/public/.well-known/assetlinks.json
@@ -8,5 +8,15 @@
         "F5:D0:7A:92:EA:A1:BB:71:F6:AF:71:9C:EC:E7:34:65:E5:83:FA:CF:C1:90:EE:CA:A0:E1:F0:F1:02:9C:59:99"
       ]
     }
+  },
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.moonklabs.sprintable.dev",
+      "sha256_cert_fingerprints": [
+        "F5:D0:7A:92:EA:A1:BB:71:F6:AF:71:9C:EC:E7:34:65:E5:83:FA:CF:C1:90:EE:CA:A0:E1:F0:F1:02:9C:59:99"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
`#2568`을 대체 — 그 PR은 main 기반 브랜치라 base를 develop으로 바꾸자 develop에 없는 커밋 99개(billing/pricing 마이그레이션·워크플로 변경 등)가 diff에 딸려왔다. 이 PR은 **origin/develop에서 새로 딴 브랜치**이고 파일 1개·커밋 1개다.

## 무엇

`sprintable-mobile`에서 dev/prod 앱 한 기기 공존을 위해 dev만 `applicationId`를 `com.moonklabs.sprintable.dev`로 분리했다(prod는 정본 ID라 유지). App Link는 이 파일의 `package_name`+`sha256_cert_fingerprints`로 OS가 앱을 가로챌지 정하는데 `.dev`가 없어서, OAuth 복귀(`dev-app.sprintable.ai/native/oauth-return`, 네이티브 전용 경로·실페이지 없음)를 앱이 못 잡고 서버가 404를 냈다(선생님 실기기 실측).

## 고친 것

`.dev` 패키지 항목 **추가**(기존 prod 항목 그대로). SHA256은 기존과 동일 — 같은 서명키(dev APK를 `check-assetlinks.js`로 직접 서명 인증서 파싱해서 확認).

## 배포 필요

정적 파일이라 develop 머지 → 배포까지 가야 반영된다. 배포 후 선생님 dev 앱 재로그인으로 재확認 필요(별개로 `EXPO_PUBLIC_OAUTH_HANDOFF`/`FIREBASE_OAUTH_HANDOFF_ENABLED` 짝 롤아웃도 필요 — 별도 트랙).

🤖 Generated with [Claude Code](https://claude.com/claude-code)