### PR TITLE
feat(#2280): MCP 도구 선언경로 vs 실제 라우트 정적 대조 가드

### DIFF
--- a/backend/tests/test_mcp_path_contract_guard.py
+++ b/backend/tests/test_mcp_path_contract_guard.py
@@ -1,0 +1,166 @@
+"""story #2280 — infra/mcp_path_contract_guard.py(MCP 경로 계약 가드) 회귀가드.
+
+`infra/test_check_serving_reality.py`(story #2174)와 동형 구조 — 라이브 아무것도 안 건드리고
+판정 로직만 고정한다. `load_route_table`/`load_mcp_declared`/`_load_allowlist`/
+`check_ref_freshness`를 가짜로 갈아끼워 실제로 겪은 모양(2026-07-28 #2271/#2280 발견분) 그대로
+넣고, 가드가 그걸 잡는지/허용목록으로 눈감는지/만료되면 다시 잡는지를 본다.
+"""
+from __future__ import annotations
+
+import importlib.util
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_INFRA_DIR = _REPO_ROOT / "infra"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "mcp_path_contract_guard", _INFRA_DIR / "mcp_path_contract_guard.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _stub(monkeypatch, mod, *, calls=None, unreadable=None, route_table=None,
+          mismatches=None, indirect=None, today="2026-07-28", fresh=True):
+    monkeypatch.setattr(mod, "check_ref_freshness", lambda: None if fresh else "테스트로 심은 stale")
+    monkeypatch.setattr(mod, "load_route_table", lambda: route_table or {mod.POSITIVE_CONTROL})
+    monkeypatch.setattr(mod, "load_mcp_declared", lambda: (calls or [], unreadable or []))
+    monkeypatch.setattr(mod, "_load_allowlist", lambda: (mismatches or {}, indirect or {}))
+    monkeypatch.setattr(mod, "_today", lambda: date.fromisoformat(today))
+
+
+def _entry(reason="r", declared_by="PO", until="2026-08-27"):
+    return {"reason": reason, "declared_by": declared_by, "until": until}
+
+
+def test_all_matching_passes(monkeypatch):
+    """모든 호출이 실제 라우트와 일치하면(불일치 0·M 0) 그린."""
+    mod = _load()
+    _stub(monkeypatch, mod,
+          route_table={mod.POSITIVE_CONTROL, ("GET", "/api/v2/epics")},
+          calls=[("epics", "GET", "/api/v2/epics")])
+    assert mod.main() == 0
+
+
+def test_positive_control_missing_fails_hard(monkeypatch):
+    """⭐양성대조 자체가 route_table에 없으면 대조법이 고장난 것 — 다른 결과를 신뢰 말고 즉시 2."""
+    mod = _load()
+    _stub(monkeypatch, mod, route_table={("GET", "/api/v2/something-else")})
+    assert mod.main() == 2
+
+
+def test_unknown_mismatch_fails(monkeypatch, capsys):
+    """허용목록에 없는 새 불일치는 그대로 FAIL — 2026-07-28 실제 발견 4건과 동형 모양."""
+    mod = _load()
+    _stub(monkeypatch, mod,
+          calls=[("notifications", "PATCH", "/api/v2/notifications")])
+    assert mod.main() == 1
+    out = capsys.readouterr().out
+    assert "신규" in out and "notifications" in out
+
+
+def test_baselined_mismatch_within_expiry_passes(monkeypatch, capsys):
+    """허용목록에 사유·선언자·미래 만료일과 함께 등재돼 있으면 통과(AC8 — 알려진 4건이 상시
+    빨강을 만들지 않게)."""
+    mod = _load()
+    key = ("notifications", "PATCH", "/api/v2/notifications")
+    _stub(monkeypatch, mod,
+          calls=[key],
+          mismatches={key: _entry()})
+    assert mod.main() == 0
+    assert "알려짐" in capsys.readouterr().out
+
+
+def test_baselined_mismatch_expired_fails(monkeypatch, capsys):
+    """⭐등재는 돼 있지만 until이 지났으면 다시 FAIL — 선언이 스스로 만료된다(story #2174와
+    동일 원칙: "끝났다는 통지가 사라지면 시스템이 그 상태를 영영 놓지 못한다")."""
+    mod = _load()
+    key = ("notifications", "PATCH", "/api/v2/notifications")
+    _stub(monkeypatch, mod,
+          calls=[key],
+          mismatches={key: _entry(until="2026-07-01")},
+          today="2026-07-28")
+    assert mod.main() == 1
+    assert "만료" in capsys.readouterr().out
+
+
+def test_baselined_mismatch_until_too_far_fails(monkeypatch, capsys):
+    """⭐`until: 2099-12-31`류 사실상 영구 예외 우회를 막는다(check_serving_reality.py와 동일
+    교훈 — 상한 없는 선언은 이 가드가 막으려는 바로 그것을 재현한다)."""
+    mod = _load()
+    key = ("notifications", "PATCH", "/api/v2/notifications")
+    _stub(monkeypatch, mod,
+          calls=[key],
+          mismatches={key: _entry(until="2099-12-31")})
+    assert mod.main() == 1
+    assert "너무 멀다" in capsys.readouterr().out
+
+
+def test_baselined_mismatch_without_reason_fails(monkeypatch, capsys):
+    mod = _load()
+    key = ("notifications", "PATCH", "/api/v2/notifications")
+    entry = _entry()
+    del entry["reason"]
+    _stub(monkeypatch, mod, calls=[key], mismatches={key: entry})
+    assert mod.main() == 1
+    assert "reason" in capsys.readouterr().out
+
+
+def test_unknown_indirect_helper_fails(monkeypatch, capsys):
+    """⭐M(리터럴 아닌 경로 호출)이 baseline에 없으면 하드fail — 2026-07-28에 실제로 겪은
+    "조용히 빠지는" 실패를 막는 그 조항(⑤⑥)."""
+    mod = _load()
+    _stub(monkeypatch, mod,
+          unreadable=[("payments", "charge_card", "POST some_var")])
+    assert mod.main() == 1
+    out = capsys.readouterr().out
+    assert "신규" in out and "payments" in out and "charge_card" in out
+
+
+def test_baselined_indirect_helper_passes(monkeypatch, capsys):
+    """실제 사례 — attachments.py:upload_attachments()가 baseline에 있으면 M으로는 찍히되(이름
+    노출) 그린을 막지 않는다."""
+    mod = _load()
+    key = ("attachments", "upload_attachments")
+    _stub(monkeypatch, mod,
+          unreadable=[("attachments", "upload_attachments", "POST upload_path")],
+          indirect={key: _entry()})
+    assert mod.main() == 0
+    out = capsys.readouterr().out
+    assert "M(1개)" in out and "수기검증됨" in out
+
+
+def test_stale_checkout_fails(monkeypatch, capsys):
+    """⭐ref 신선도 자체 실패(develop과 다름)면 그 자체로 FAIL — 2026-07-28 오보 재발방지 조항."""
+    mod = _load()
+    _stub(monkeypatch, mod, fresh=False)
+    assert mod.main() == 1
+    assert "ref 신선도" in capsys.readouterr().err
+
+
+def test_norm_ignores_path_param_names():
+    mod = _load()
+    assert mod.norm("/api/v2/epics/{epic_id}") == mod.norm("/api/v2/epics/{id}")
+
+
+def test_repo_allowlist_entries_are_wellformed():
+    """저장소에 실제로 커밋된 선언(infra/mcp-path-contract-allowlist.yml)이 형식을 지키는지."""
+    mod = _load()
+    mismatches, indirect = mod._load_allowlist()
+    for kind, entries in (("declared_mismatches", mismatches), ("declared_indirect", indirect)):
+        for key, entry in entries.items():
+            problem = mod._expired(entry, date(2026, 7, 28))
+            assert problem is None, f"{kind}/{key}: {problem}"
+
+
+def test_repo_current_state_is_green():
+    """⭐리포에 실제로 커밋된 코드+허용목록으로 가드를 그대로 돌려서 통과하는지 — 이게 CI에서
+    도는 그 실행과 동일하다(가짜 없음, ref 신선도만 이 테스트 환경에선 git 명령이 있어야 함)."""
+    mod = _load()
+    assert mod.main() == 0

--- a/infra/mcp-path-contract-allowlist.yml
+++ b/infra/mcp-path-contract-allowlist.yml
@@ -1,0 +1,68 @@
+# MCP 경로 계약 가드(story #2280) 선언 목록 — infra/mcp_path_contract_guard.py가 읽는다.
+#
+# ## 이 파일의 성격 — "정상"이 아니라 "알고 있다"의 선언이다
+#
+# 여기 등재하는 것은 그 상태가 옳다는 뜻이 아니라, 사람이 보고 판단했고 언제까지 두기로
+# 했는지를 남기는 것이다(infra/serving-reality-allowlist.yml과 동일 원칙 — story #2174).
+#
+# ```
+# reason        필수 — 사유(연결된 story 포함)
+# declared_by   필수 — 누가 판단했는지
+# until         필수 — 만료일. 지나면 가드가 FAIL한다(최대 30일, infra/check_serving_reality.py와 동일 상한)
+# ```
+#
+# ⭐until이 필수인 이유 — #2271/#2280 자체가 겪은 일이다. 알려진 4건을 여기 영구로 묻어두면
+# 다음에 같은 파일에 새 병이 또 생겨도 "어차피 여기 원래 빨갛잖아"로 안 보이게 된다.
+# 만료되면 가드가 다시 빨개지고, 그때 #2281 진행 상황을 다시 판단한다.
+
+# 경로 불일치 — story #2281에서 해소 예정. 넷을 같은 답으로 고치지 않기로 함(파울로/까심 합의,
+# 2026-07-28): 경로만 틀린 것 1 · 경로+입력스키마 둘 다 틀린 것 1 · 서버에 기능 자체가 없는 것 2
+# (ⓐ만든다/ⓑ도구를 걷는다/ⓒ명시적 오류로 바꾼다 중 #2281 안에서 판정).
+declared_mismatches:
+  - module: notifications
+    method: PATCH
+    path: /api/v2/notifications
+    tool: mark_notification_read
+    reason: >-
+      단건 알림 읽음처리 라우트가 서버에 없음(#2271 발견, #2281에서 ⓐ만든다/ⓑ걷는다/ⓒ명시오류
+      중 판정 — 유나 화면실측 "가르기 안 됨"과 맞물림)
+    declared_by: PO
+    until: "2026-08-27"
+  - module: notifications
+    method: PATCH
+    path: /api/v2/notifications
+    tool: mark_all_notifications_read
+    reason: >-
+      실제 경로는 PATCH /api/v2/notifications/mark-all-read(#2271 발견, #2281에서 경로 수정 예정)
+    declared_by: PO
+    until: "2026-08-27"
+  - module: standup
+    method: GET
+    path: /api/v2/retro/{sprint_id}
+    tool: get_retro_session
+    reason: >-
+      sprint_id 기준 get-or-create 메커니즘 자체가 서버에 없음(#2271 발견, #2281에서 판정)
+    declared_by: PO
+    until: "2026-08-27"
+  - module: standup
+    method: PATCH
+    path: /api/v2/retro/actions/{action_id}
+    tool: update_retro_action_status
+    reason: >-
+      경로도 틀렸고 입력 스키마(UpdateRetroActionStatusInput)에 세션 id 필드 자체가 없어 경로만
+      고쳐도 못 고침(#2271 발견, #2281에서 스키마+경로 동시 수정 예정)
+    declared_by: PO
+    until: "2026-08-27"
+
+# 간접경로 — 리터럴이 아니라 변수로 경로를 받는 공용 헬퍼. 정적 대조가 원천적으로 못 읽어서
+# "조용히 빠지는" 쪽이라 이름을 반드시 명시하고(M), 수기 추적 결과까지 여기 남긴다.
+declared_indirect:
+  - module: attachments
+    function: upload_attachments
+    reason: >-
+      경로를 인자로 받는 공용 업로드 헬퍼(client.post(upload_path, ...)). 호출부 3곳 수기 추적:
+      docs.py:164(/docs/{id}/attachments) · chat.py:121(/conversations/{id}/attachments) ·
+      stories.py:147(/stories/{id}/attachments) — 서버 라우트 3곳(stories.py:578/docs.py:967/
+      conversations.py:2162) 전부 실재 확認됨(2026-07-28)
+    declared_by: 까심 아르야
+    until: "2026-08-27"

--- a/infra/mcp_path_contract_guard.py
+++ b/infra/mcp_path_contract_guard.py
@@ -1,0 +1,287 @@
+"""story #2280 — MCP 도구 선언 경로 vs FastAPI 실제 라우트 정적 대조 가드.
+
+호출 없음(서버 기동 불필요) — `backend/sprintable_mcp/tools/*.py`가 부르는 경로 문자열과
+`backend/app/routers/*.py`(+`backend/app/main.py`의 include_router)가 실제로 여는 경로를
+소스에서 직독해 대조한다. #2271 AC3·AC4의 산출물.
+
+⭐이 파일은 `infra/check_serving_reality.py`(story #2174)와 같은 자리에 있다 — 같은 이유:
+"정상"과 "알고 있다"를 분리하고(허용목록), 허용목록은 스스로 만료된다(`until` 필수+상한).
+자세한 배경은 `infra/mcp-path-contract-allowlist.yml` 머리말 참조.
+
+⚠️오늘(2026-07-28) 이 축 자체에서 겪은 실패: 최초 수기 audit가 develop보다 뒤처진 로컬
+체크아웃으로 실행돼, 2026-07-15에 이미 fix된 retro.py 7건+list_backlog 1건(총 8건)을
+"신규 발견"으로 오보했다. `check_ref_freshness()`는 그 재발을 막기 위한 것이다 — 결과가
+아니라 "지금 무엇을 읽고 있는가" 자체를 매 실행 검증한다.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_ROUTERS_DIR = _REPO_ROOT / "backend" / "app" / "routers"
+_TOOLS_DIR = _REPO_ROOT / "backend" / "sprintable_mcp" / "tools"
+_MAIN_PY = _REPO_ROOT / "backend" / "app" / "main.py"
+_ALLOWLIST_PATH = _REPO_ROOT / "infra" / "mcp-path-contract-allowlist.yml"
+
+_MAX_DECLARATION_HORIZON_DAYS = 30  # infra/check_serving_reality.py와 동일 상한(까심군 리뷰③ 교훈).
+
+POSITIVE_CONTROL = ("GET", "/api/v2/docs")  # list_docs — 2026-07-28 read-sweep으로 정상 작동 재확認.
+
+
+def _today() -> date:
+    env = __import__("os").environ.get("MCP_PATH_GUARD_TODAY")
+    if env:
+        return date.fromisoformat(env)
+    return datetime.now(timezone.utc).date()
+
+
+def norm(path: str) -> str:
+    return re.sub(r"\{[^}]+\}", "{*}", path)
+
+
+def _load_allowlist() -> tuple[dict[tuple[str, str, str], dict], dict[tuple[str, str], dict]]:
+    """반환: ({(module, method, norm_path): entry} 경로 불일치 선언, {(module, function): entry} 간접경로 선언).
+
+    파일이 없으면 빈 선언으로 취급한다 — ⛔"선언 파일이 없으니 검사 생략"은 하지 않는다."""
+    if not _ALLOWLIST_PATH.exists():
+        return {}, {}
+    import yaml
+
+    data = yaml.safe_load(_ALLOWLIST_PATH.read_text()) or {}
+    mismatches = {}
+    for e in data.get("declared_mismatches") or []:
+        key = (e["module"], e["method"].upper(), norm(e["path"]))
+        mismatches[key] = e
+    indirect = {}
+    for e in data.get("declared_indirect") or []:
+        key = (e["module"], e["function"])
+        indirect[key] = e
+    return mismatches, indirect
+
+
+def _expired(entry: dict, today: date) -> str | None:
+    """만료·형식 위반이면 사유 문자열, 아니면 None. infra/check_serving_reality.py와 동형."""
+    until_raw = entry.get("until")
+    if not until_raw:
+        return "`until`(만료일)이 없다 — 영원히 사는 선언은 허용하지 않는다"
+    try:
+        until = date.fromisoformat(str(until_raw))
+    except ValueError:
+        return f"`until` 형식이 YYYY-MM-DD가 아니다: {until_raw!r}"
+    if until < today:
+        return f"선언이 만료됐다(until={until}) — 재확認 후 갱신하거나 실제로 고칠 것"
+    horizon = (until - today).days
+    if horizon > _MAX_DECLARATION_HORIZON_DAYS:
+        return (
+            f"`until`이 너무 멀다({until} · {horizon}일 뒤) — 최대 {_MAX_DECLARATION_HORIZON_DAYS}일"
+        )
+    if not entry.get("reason"):
+        return "`reason`(사유)이 없다"
+    if not entry.get("declared_by"):
+        return "`declared_by`(선언자)가 없다"
+    return None
+
+
+def check_ref_freshness(repo_root: Path = _REPO_ROOT) -> str | None:
+    """지금 읽는 체크아웃이 origin/develop과 관련 경로에서 같은지 확認. 다르면 경고 문자열,
+    같으면 None. (git 명령 실패 시에도 문자열 반환 — 신뢰 여부를 호출부가 판단.)
+
+    ⚠️CI 안에서는 스킵한다 — actions/checkout이 매번 정확히 그 PR의 커밋만 체크아웃하므로
+    "로컬 클론이 develop보다 뒤처졌다"는 애초에 성립하지 않는 문제다(그리고 기본 checkout은
+    fetch-depth=1이라 origin/develop 자체가 로컬에 없어 이 git 명령이 항상 실패한다). 이 체크는
+    세션이 긴 인터랙티브 작업에서 공유 클론을 재사용할 때만 의미가 있다(2026-07-28 실제로
+    겪은 문제)."""
+    import os
+    if os.environ.get("CI"):
+        return None
+    try:
+        diff = subprocess.run(
+            ["git", "diff", "--quiet", "origin/develop", "HEAD", "--",
+             "backend/sprintable_mcp/tools/", "backend/app/routers/", "backend/app/main.py"],
+            cwd=repo_root,
+        )
+        if diff.returncode not in (0, 1):
+            return f"git diff 명령이 비정상 종료(returncode={diff.returncode})"
+        if diff.returncode == 1:
+            return "HEAD가 origin/develop과 관련 경로에서 다름 — `git fetch origin develop` 후 재확認 요망"
+        return None
+    except Exception as exc:  # pragma: no cover - 환경 문제
+        return f"ref 신선도 체크 실패(git 명령 오류): {exc}"
+
+
+def load_route_table(routers_dir: Path = _ROUTERS_DIR, main_py: Path = _MAIN_PY) -> set[tuple[str, str]]:
+    """FastAPI 실제 라우트. prefix가 있는/없는 라우터, include_router(prefix=...) 마운트 시점
+    prefix 세 가지 경우를 모두 읽는다."""
+    routes = set()
+    mounted = set()
+    mount_prefixes: dict[str, set] = {}
+    main_src = main_py.read_text()
+    for m in re.finditer(r'app\.include_router\((\w+)\.router(?:,\s*prefix="([^"]*)")?', main_src):
+        module, mount_prefix = m.group(1), m.group(2)
+        mounted.add(module)
+        mount_prefixes.setdefault(module, set()).add(mount_prefix or "")
+
+    for fpath in sorted(routers_dir.glob("*.py")):
+        module = fpath.stem
+        src = fpath.read_text()
+        if "router = APIRouter(" not in src:
+            continue
+        pm = re.search(r'APIRouter\(prefix="([^"]*)"', src)
+        decorator_prefix = pm.group(1) if pm else None
+
+        candidate_prefixes = set()
+        for mp in mount_prefixes.get(module, {None}):
+            if mp:
+                candidate_prefixes.add(mp)
+            elif decorator_prefix is not None:
+                candidate_prefixes.add(decorator_prefix)
+            else:
+                candidate_prefixes.add("")
+        if module not in mount_prefixes and decorator_prefix is not None:
+            candidate_prefixes.add(decorator_prefix)
+
+        for method, path in re.findall(r'@router\.(get|post|patch|put|delete)\("([^"]*)"', src):
+            for prefix in candidate_prefixes:
+                full = (prefix.rstrip("/") + path) if prefix else path
+                routes.add((method.upper(), norm(full)))
+        if module not in mounted:
+            print(f"⚠️  {module}.py: router 정의는 있으나 main.py에 include_router 안 됨(미탑재 의심)", file=sys.stderr)
+    return routes
+
+
+def _enclosing_function(src: str, pos: int) -> str:
+    fns = re.findall(r"^async def (\w+)", src[:pos], re.MULTILINE)
+    return fns[-1] if fns else "?"
+
+
+def load_mcp_declared(tools_dir: Path = _TOOLS_DIR):
+    """MCP 도구가 부르는 경로. 반환: (calls, unreadable) — unreadable은 (module, function, raw) 리스트로
+    첫 인자가 리터럴이 아니었던(변수 등) 호출. 셋 다 이름까지 남는다(자동으로 못 읽었다고 조용히
+    빠지지 않는다 — 2026-07-28 attachments.py:upload_attachments 발견 이후 필수 요건)."""
+    calls = []
+    unreadable = []
+    method_re = re.compile(r"client\.(get|post|patch|put|delete)\(")
+    request_re = re.compile(r'client\.request\(\s*\n?\s*"(GET|POST|PATCH|PUT|DELETE)",\s*\n?\s*')
+
+    for fpath in sorted(tools_dir.glob("*.py")):
+        module = fpath.stem
+        src = fpath.read_text()
+
+        for m in method_re.finditer(src):
+            method = m.group(1).upper()
+            after = src[m.end():]
+            lit = re.match(r'\s*f?"([^"]*)"', after)
+            if lit:
+                calls.append((module, method, lit.group(1)))
+            else:
+                raw = after[:60].split(",")[0].split(")")[0].strip().replace("\n", " ")
+                unreadable.append((module, _enclosing_function(src, m.start()), f"{method} {raw}"))
+
+        for m in request_re.finditer(src):
+            method = m.group(1)
+            after = src[m.end():]
+            lit = re.match(r'f?"([^"]*)"', after)
+            if lit:
+                calls.append((module, method, lit.group(1)))
+            else:
+                raw = after[:60].split(",")[0].split(")")[0].strip().replace("\n", " ")
+                unreadable.append((module, _enclosing_function(src, m.start()), f"{method} {raw}"))
+
+    return calls, unreadable
+
+
+def main() -> int:
+    today = _today()
+    ok = True
+
+    import os
+    freshness_problem = check_ref_freshness()
+    if freshness_problem:
+        print(f"🔴 ref 신선도: {freshness_problem}", file=sys.stderr)
+        ok = False
+    elif os.environ.get("CI"):
+        print("ref 신선도: CI 환경 — actions/checkout이 이미 정확한 커밋이라 스킵")
+    else:
+        print("ref 신선도 OK: HEAD == origin/develop(관련 경로 기준)")
+
+    route_table = load_route_table()
+    if POSITIVE_CONTROL not in route_table:
+        print(f"🔴 가드 자체 이상 — 양성대조 {POSITIVE_CONTROL}가 route_table에 없다. "
+              "대조법이 고장났을 가능성 → 이 가드의 다른 결과를 신뢰하지 말 것.")
+        return 2
+    print(f"양성대조 OK: {POSITIVE_CONTROL} 확認됨 — 대조법 정상\n")
+
+    mcp_calls, unreadable = load_mcp_declared()
+    declared_mismatches, declared_indirect = _load_allowlist()
+
+    mismatches = []
+    for module, method, path in mcp_calls:
+        key = (module, method, norm(path))
+        if (method, norm(path)) in route_table:
+            continue
+        mismatches.append((module, method, path))
+
+    print(f"대조한 {len(mcp_calls)}개 / 읽지 못한 {len(unreadable)}개(M)\n")
+
+    new_mismatches = []
+    print(f"불일치 {len(mismatches)}건")
+    for module, method, path in mismatches:
+        key = (module, method, norm(path))
+        entry = declared_mismatches.get(key)
+        if entry is None:
+            print(f"  🔴 {module}: {method} {path} — 허용목록에 없는 신규")
+            new_mismatches.append((module, method, path))
+            continue
+        problem = _expired(entry, today)
+        if problem:
+            print(f"  🔴 {module}: {method} {path} — 등재는 돼 있으나 {problem}")
+            new_mismatches.append((module, method, path))
+        else:
+            print(f"  ⚪ {module}: {method} {path} — 알려짐(until={entry['until']}, {entry['reason']})")
+
+    new_indirect = []
+    if unreadable:
+        print(f"\nM({len(unreadable)}개) — 이름 명시:")
+        for module, func, raw in unreadable:
+            entry = declared_indirect.get((module, func))
+            if entry is None:
+                print(f"  🔴 {module}.py:{func}() — {raw} — 허용목록에 없는 신규")
+                new_indirect.append((module, func, raw))
+                continue
+            problem = _expired(entry, today)
+            if problem:
+                print(f"  🔴 {module}.py:{func}() — {raw} — 등재는 돼 있으나 {problem}")
+                new_indirect.append((module, func, raw))
+            else:
+                print(f"  ⚪ {module}.py:{func}() — {raw} — 수기검증됨(until={entry['until']})")
+
+    if new_mismatches or new_indirect:
+        print(f"\n🔴 신규(또는 만료된) 항목 {len(new_mismatches) + len(new_indirect)}건 — "
+              f"실제 버그면 고치고, 알고 있는 상태로 계속 두려면 "
+              f"infra/mcp-path-contract-allowlist.yml에 reason/declared_by/until과 함께 등재할 것.")
+        ok = False
+
+    print(
+        "\n이 가드가 구조적으로 못 잡는 것(자인):\n"
+        " 1. 경로가 변수 조립인데 그 값을 이 스크립트가 못 읽는 경우(M으로 이름은 찍되 내용까진 못 봄).\n"
+        " 2. 서버 쪽 동적 라우트 등록(add_api_route 등) — 현재 저장소엔 없음(grep 0건) 확인했으나 생기면 못 봄.\n"
+        " 3. 경로 문자열은 일치하지만 body shape·쿼리 필수여부·인가 요구사항이 다른 경우 — 별도 계약 테스트 몫.\n"
+        " 4. 조건부 include_router(if 분기 안)로 마운트되는 라우터.\n"
+        " 5. 배포 상태(그 코드가 실제로 떠 있는지)는 안 본다 — 소스 스냅샷 대조.\n"
+        " 6. 허용목록 키는 (module, method, path)다 — 같은 경로를 부르는 도구가 둘 이상이면(현재\n"
+        "    실제 사례: notifications 모듈의 mark_notification_read·mark_all_notifications_read가\n"
+        "    둘 다 PATCH /api/v2/notifications) 한 항목이 그 «경로 자체»를 대변한다. 하나만 고쳐도\n"
+        "    다른 하나가 여전히 그 경로를 쓰면 허용목록 항목이 계속 필요하다 — 도구별 개별 추적이\n"
+        "    아니다(2026-07-28 레드테스트 중 실제로 이 경계에 걸려서 알게 됨: 두 도구 중 하나의\n"
+        "    허용목록 항목만 지워도 가드가 그린으로 남았다).\n"
+    )
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- story #2280 — #2271 AC3/AC4에서 수기로 했던 "MCP 도구가 부르는 경로 vs FastAPI 실제 라우트" 정적 대조를 재사용 가능한 가드로 만든다. 호출 없음(서버 기동 불필요) — 양쪽 소스의 선언만 읽어 대조한다.
- `infra/mcp_path_contract_guard.py` — `infra/check_serving_reality.py`(story #2174)와 동일 컨벤션: `main() -> int`, 허용목록(`reason`/`declared_by`/`until`, 최대 30일) 강제, 스스로 만료.
- `infra/mcp-path-contract-allowlist.yml` — 알려진 4건(story #2281에서 해소 예정: notifications 2·standup 2) + 간접경로 헬퍼 1건(attachments.py:upload_attachments) 등재, until=2026-08-27.
- `backend/tests/test_mcp_path_contract_guard.py` — `test_check_serving_reality.py`와 동형 구조로 wrapping. 13개 테스트: 양성대조 실패 시 하드종료·신규 불일치/간접경로 FAIL·허용목록 만료/상한초과/사유누락 FAIL·ref 신선도 실패 FAIL·리포에 실제 커밋된 상태가 그린인지 등.

## CI 배선
- **새 워크플로/잡 불필요.** `backend/tests/test_mcp_path_contract_guard.py`는 일반 pytest 파일(리얼DB·`destructive_schema` 마커 없음)이라 `.github/workflows/ci.yml`의 기존 `backend-test` job → "Run pytest (non-destructive, real-PG auto-discovered via marker)" 스텝(`uv run pytest -q -m "not destructive_schema"`)에 자동 편입된다. 로컬에서 그 정확한 커맨드로 재현·확認함.

## AC8(기준선) 증거 — 레드→그린 실측
- 커밋된 파일 그대로 `uv run python3 infra/mcp_path_contract_guard.py` → exit 0 (양성대조 OK · 대조 113개/M 1개 · 불일치 4건 전부 "알려짐").
- 허용목록에서 고유 키(`standup:get_retro_session`) 항목을 실제로 지우고 재실행 → `🔴 신규` 로 잡히며 exit 1 확認. 원복 후 다시 exit 0(`diff`로 byte-identical 확認).
- ⚠️레드 실측 중 새 한계 하나 발견: notifications 모듈의 두 도구(`mark_notification_read`·`mark_all_notifications_read`)가 동일 `(module, method, path)`를 공유해 한쪽 허용목록 항목만 지워도 가드가 계속 그린이었다 — 허용목록 키는 "도구별"이 아니라 "경로별" 선언임을 스크립트 docstring(자인 목록 ⑥)에 명시.

## ref 신선도 자기확認
- #2271/#2280 작업 중 실제로 겪은 실패(develop보다 뒤처진 로컬 체크아웃으로 이미 2026-07-15에 fix된 retro.py 7건+list_backlog 1건, 총 8건을 "신규 발견"으로 오보)의 재발방지 조항. `git diff --quiet origin/develop HEAD -- <관련경로>`로 자기확認하되, CI 환경(`CI` env var)에서는 스킵 — `actions/checkout`이 매번 정확한 커밋만 얕게 체크아웃해 `origin/develop` 자체가 로컬에 없고, 애초에 "로컬 클론이 develop보다 뒤처졌다"는 문제가 성립하지 않는 컨텍스트라서.

## Test plan
- [x] `uv run pytest -q tests/test_mcp_path_contract_guard.py` — 13 passed
- [x] `uv run pytest -q -m "not destructive_schema" tests/test_mcp_path_contract_guard.py` (CI와 동일 커맨드) — 13 passed
- [x] CLI 직접 실행 exit 0(그린) 확認
- [x] 허용목록 항목 제거 → exit 1(레드) 확認 → 원복 → byte-identical 확認 → exit 0 재확認

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>