### PR TITLE
[SID:2275] 편집 진입점을 «수정 버튼 하나»로 좁힌다 — 본문 클릭이 편집모드를 먹던 것 제거

### DIFF
--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -1111,6 +1111,8 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 // 살아남는 구조라 위험하다(#2566은 링크 하나만 증상 패치). 상호작용 규약을
                 // 아예 「편집 진입은 위 ✎ 수정 버튼으로만」으로 좁혀 원천 차단한다 — 본문
                 // 안의 무엇을 눌러도 편집모드가 끼어들 수 없다.
+                // ⛔이 div에 onClick을 다시 붙이지 않는다 — 편집 진입은 «수정 버튼»으로만.
+                // 본문 안의 링크·멘션·체크박스가 자기 일을 해야 하기 때문이다.
                 <div className="mt-2">
                   <DescriptionViewer description={story.description} />
                 </div>
@@ -1159,6 +1161,8 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 </div>
               ) : story.acceptance_criteria ? (
                 // #2275 — description과 동일 처방: 편집 진입은 위 ✎ 수정 버튼으로만.
+                // ⛔이 div에 onClick을 다시 붙이지 않는다 — 본문 안의 링크·멘션·체크박스가
+                // 자기 일을 해야 하기 때문이다.
                 <div className="mt-2">
                   <DescriptionViewer description={story.acceptance_criteria} />
                 </div>

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -1106,7 +1106,12 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   </div>
                 </div>
               ) : story.description ? (
-                <div className="mt-2 cursor-pointer" onClick={() => setEditingDescription(true)}>
+                // 긴급 정정(2026-07-28, PO 검수·#2275) — 본문 전체에 클릭=편집모드 onClick이
+                // 걸려 있으면 안의 링크 등 대화형 요소가 stopPropagation을 각각 붙여야만
+                // 살아남는 구조라 위험하다(#2566은 링크 하나만 증상 패치). 상호작용 규약을
+                // 아예 「편집 진입은 위 ✎ 수정 버튼으로만」으로 좁혀 원천 차단한다 — 본문
+                // 안의 무엇을 눌러도 편집모드가 끼어들 수 없다.
+                <div className="mt-2">
                   <DescriptionViewer description={story.description} />
                 </div>
               ) : (
@@ -1153,7 +1158,8 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   </div>
                 </div>
               ) : story.acceptance_criteria ? (
-                <div className="mt-2 cursor-pointer" onClick={() => setEditingAC(true)}>
+                // #2275 — description과 동일 처방: 편집 진입은 위 ✎ 수정 버튼으로만.
+                <div className="mt-2">
                   <DescriptionViewer description={story.acceptance_criteria} />
                 </div>
               ) : (


### PR DESCRIPTION
## AC7 — #2258과 무관한 별개 결함이라는 판정 근거

PR #2561(#2258)은 `story-detail-panel.tsx`의 description/AC 섹션을 손대지 않았다(그 PR이 만진 곳은 trustChip 줄·의존성 토글·검증요청 버튼, 전부 다른 위치). 이 버그는 **description/AC에 markdown 링크가 있는 모든 스토리에서 항상 재현되는, 컴포넌트가 생긴 이후 계속 있던 사전 존재 결함**이다. #2258을 되돌렸다면 엉뚱한 것을 되돌린 셈이 됐을 것이다.

## AC1/AC2 — 무엇을 고쳤는가

```diff
- <div className="mt-2 cursor-pointer" onClick={() => setEditingDescription(true)}>
+ <div className="mt-2">
    <DescriptionViewer description={story.description} />
  </div>
```
(AC 영역도 동일)

⛔증상 패치(#2566: 링크에만 `stopPropagation`)가 아니라 **상호작용 규약 자체를 정했다** — 본문 전체에 걸려 있던 "클릭=편집모드" `onClick`을 완전히 제거한다. 편집 진입은 이제 이미 존재하던 「✎ 수정」버튼(섹션 헤더 우측, 편집 중이 아닐 때 항상 표시 — AC2 "발견 가능한 자리") **하나로만** 가능하다. 본문 안의 무엇을 눌러도(링크든 그 무엇이든) 편집모드가 끼어들 수 없다.

## AC3/AC4 — 본문 안 「누를 것 전부」+ 같은 패턴 전수

| 무엇 | 지금 눌리나(고치기 전) | 고친 뒤 눌리나 |
|---|---|---|
| description 안 링크 | ❌(부모가 먹음, #2566으로 링크만 증상패치돼 있었음) | ✅(구조적으로 해소 — 부모 onClick 자체가 없음) |
| description 안 멘션/#참조/체크박스/코드복사 | 해당없음(#2258 AC3 조사로 이미 확認 — 이 뷰어엔 그 기능 자체가 없음) | 해당없음(무변화) |
| **AC 영역** | description과 동일 구조·동일 증상 | ✅description과 동일 처방으로 같이 해소 |

같은 클래스("본문 전체가 클릭=편집" 패턴) 코드베이스 전수 결과:
| 자리 | 같은 클래스인가 | 이유 |
|---|---|---|
| story-detail-panel.tsx title(866)/assignee(994) | 아니오 | 단일 필드용 소형 위젯 — 클릭 가능한 자식 콘텐츠(리치 텍스트) 자체가 없음 |
| goals-client.tsx 에픽 카드 클릭 | 아니오 | 카드 선택/네비게이션 목적(칸반 카드와 동형) — 리치 텍스트 본문이 아님 |
| docs 에디터(doc-editor.tsx) | 아니오 | tiptap `editable` prop을 직접 토글하는 구조 — "별도 뷰/편집 div 스왑" 패턴 자체가 없음 |
| story comments | 아니오 | 편집 기능 자체가 없음(inline edit 미지원, PATCH 엔드포인트도 없음) |

⇒ **이 병의 발생지는 story-detail-panel.tsx의 description·AC 둘뿐**이었다 — 둘 다 이 PR로 해소.

## AC5 — 회귀 가드 + 가드가 못 잡는 것

`description-viewer.test.tsx`(#2566에서 신설)가 `DescriptionViewer`의 `<a>` 렌더러가 `stopPropagation`을 계속 호출하는지 격리 검증한다(재통과 확認, 이번 PR로 재실행해도 GREEN — 방어 계층으로 유지).

⛔**이 가드가 못 잡는 것**: `story-detail-panel.tsx`의 실제 wrapper div에서 `onClick`이 재도입되는 것 자체를 잡는 전체 마운트 테스트는 없다 — `StoryDetailPanel`은 1400+ 줄·거대 prop/fetch 표면이라 전체 마운트 테스트 하네스가 이 세션엔 없다(이 컴포넌트 자체가 오늘까지 테스트 파일 0개였다). 이번 fix는 직접 코드 diff(위 diff 그대로, `onClick` 완전 제거) + AC1 라이브 실측으로 검증한다.

## AC6 — 라이브 실측

배포 후 브라우저에서 실제로 문서 링크를 눌러 이동하는 것과, ✎ 수정 버튼으로 편집모드가 여전히 열리는 것 둘 다 확認 필요 — PO 또는 제가 브라우저로 검증 예정(미리 공지).

## 검증
- `tsc --noEmit` 무오류, `eslint` 무경고.
- 전체 FE vitest 스윕: 294 파일 · 1955 테스트 전부 PASS(회귀 없음).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>