### PR TITLE
[E-CONNECT] #2284: 문서 참조 form을 wikiLink/pageEmbed로 안 뭉갠다

### DIFF
--- a/backend/app/services/mention_parser.py
+++ b/backend/app/services/mention_parser.py
@@ -33,6 +33,13 @@ design-org-knowledge-mentions-backlinks §2.
 
 기존 `mentioned_ids`(ConversationMessage 컬럼·멤버 알림용) 파이프라인은 이 모듈이 전혀
 참조하지 않는다 — 완전히 독립된 병행 경로.
+
+⛔story #2284: 이 모듈이 쓰는 form은 `mention`·`embed` 둘뿐이다. `proof`는 여기서 만들지
+않는다 — 「지원 안 함」이 아니라 「아직 안 만듦」이다: proof는 #2265(대화 일부를 view-only로
+잘라 박는 기능, 별도 write 경로)의 몫으로 설계돼 있고 그 write 경로 자체가 아직 없다(코드
+0줄). doc의 wikiLink→mention·pageEmbed→embed 구분은 파싱 시점에 이미 있던 재료를 저장
+시점에 버리지 않게 고친 것뿐이라 작은 일이었지만, proof는 새 UI 흐름(어느 대화 구간을
+자를지)과 새 write 경로가 통째로 필요해 크기가 다르다.
 """
 from __future__ import annotations
 
@@ -97,26 +104,34 @@ class _DocMentionHTMLParser(HTMLParser):
     tiptap `mergeAttributes`/`renderHTML` 이 만드는 attribute 순서가 보장되지 않아 위치 기반
     정규식은 attribute 순서가 바뀌면 깨진다 — HTMLParser 는 attrs 를 (name, value) 튜플 리스트로
     주므로 dict 화해 이름으로 조회하면 순서 무관.
+
+    story #2284: 어느 태그였는지(wikiLink=인라인 멘션 / pageEmbed=카드 임베드)를 **버리지
+    않고** (doc_id, form) 쌍으로 남긴다 — 파싱 시점엔 이미 있던 구분이 예전엔 저장 시점에
+    뭉개졌다(#2259 이후 form이 리터럴 "mention"으로 하드코딩됐던 자리).
     """
 
     def __init__(self) -> None:
         super().__init__()
-        self.doc_ids: list[str] = []
+        self.doc_refs: list[tuple[str, str]] = []  # (raw_doc_id, form)
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         attr_map = dict(attrs)
         if tag == "span" and attr_map.get("data-type") == "wikiLink":
             doc_id = attr_map.get("data-doc-id")
             if doc_id:
-                self.doc_ids.append(doc_id)
+                self.doc_refs.append((doc_id, "mention"))
         elif tag == "div" and "data-page-embed" in attr_map:
             doc_id = attr_map.get("data-doc-id")
             if doc_id:
-                self.doc_ids.append(doc_id)
+                self.doc_refs.append((doc_id, "embed"))
 
 
-def extract_doc_mention_ids(html_content: str) -> list[uuid.UUID]:
-    """doc content(HTML) 에서 wikiLink/pageEmbed 의 data-doc-id 를 순서 보존 + 중복 제거로 추출.
+def extract_doc_mention_targets(html_content: str) -> list[tuple[uuid.UUID, str]]:
+    """doc content(HTML) 에서 wikiLink/pageEmbed 의 data-doc-id 를 **형태(form)와 함께** 순서
+    보존 + 중복 제거로 추출한다. 반환: `[(target_doc_id, form), ...]` — wikiLink→"mention",
+    pageEmbed→"embed"(story #2284). 같은 doc이 인라인 멘션과 카드 임베드 둘 다로 등장하면
+    서로 다른 (id, form) 쌍이라 둘 다 남는다(entity_references의 partial unique index가
+    form을 키에 포함하므로 공존 가능 — 우연이 아니라 설계).
 
     malformed HTML(HTMLParser 가 못 견디는 조각)·malformed UUID 는 조용히 스킵 — 파서 예외로
     전체 doc 저장이 실패하면 안 된다."""
@@ -130,13 +145,26 @@ def extract_doc_mention_ids(html_content: str) -> list[uuid.UUID]:
         # HTMLParser 는 malformed 마크업에도 대체로 관대(best-effort recovery)하지만, 방어적으로
         # 예외 자체도 삼킨다 — 여기까지 왔으면 이미 파싱된 partial 결과를 그대로 쓴다(전체 실패 금지).
         pass
-    seen: set[uuid.UUID] = set()
-    result: list[uuid.UUID] = []
-    for raw in parser.doc_ids:
+    seen: set[tuple[uuid.UUID, str]] = set()
+    result: list[tuple[uuid.UUID, str]] = []
+    for raw_id, form in parser.doc_refs:
         try:
-            doc_id = uuid.UUID(raw)
+            doc_id = uuid.UUID(raw_id)
         except ValueError:
             continue
+        key = (doc_id, form)
+        if key not in seen:
+            seen.add(key)
+            result.append(key)
+    return result
+
+
+def extract_doc_mention_ids(html_content: str) -> list[uuid.UUID]:
+    """하위호환 편의 래퍼(story #2284) — id만 필요한 호출부용. form 정보가 필요하면
+    `extract_doc_mention_targets`를 직접 쓸 것(reconcile_doc_mentions가 그렇게 한다)."""
+    seen: set[uuid.UUID] = set()
+    result: list[uuid.UUID] = []
+    for doc_id, _form in extract_doc_mention_targets(html_content):
         if doc_id not in seen:
             seen.add(doc_id)
             result.append(doc_id)
@@ -155,6 +183,12 @@ async def insert_chat_mentions(
     """채팅 write-path: insert-only(메시지 불변 전제 — 재조정 불필요). 같은 트랜잭션(caller 의
     세션 그대로 사용·별도 커밋 없음) — 실패 시 예외가 그대로 propagate 되어 caller(메시지 전송
     트랜잭션) 전체가 롤백된다(AC4 원자성).
+
+    ⛔story #2284 AC3: 채팅 쪽엔 **멘션/임베드를 가를 재료가 없다** — `_CHAT_TOKEN_RE`가 아는
+    토큰 문법은 `[title](entity:type:id)` **하나뿐**(doc의 wikiLink/pageEmbed 같은 두 번째
+    문법이 없다). 그래서 채팅은 지금 「없는데 있는 척」이 아니라 **문자 그대로 mention만
+    만든다** — 아래 `"form": "mention"`이 하드코딩이 아니라 지금 있는 유일한 값이다. 채팅에
+    임베드 문법을 추가하는 건 이 스토리 범위 밖(새 문법을 만드는 별건 — #2284 본문 참조).
 
     story #2260: target_type 은 본문에서 추출된 값을 그대로 쓴다(내부에서 결정하지 않는다) —
     이 함수엔 entity type 리터럴이 하나도 없다. `target_types`는 **지금 이 write-path 가
@@ -215,26 +249,42 @@ async def reconcile_doc_mentions(
     전체가 롤백된다(AC4 원자성).
 
     story #2273: write target이 `entity_references`로 재배선됐다. source_field="body"(doc
-    본문은 텍스트 필드가 하나뿐)."""
-    target_ids = {tid for tid in extract_doc_mention_ids(html_content) if tid != doc_id}
+    본문은 텍스트 필드가 하나뿐).
 
-    existing_ids = set(
-        (
-            await db.execute(
-                select(Reference.target_id).where(
-                    Reference.source_type == "doc",
-                    Reference.source_field == "body",
-                    Reference.source_id == doc_id,
-                    Reference.target_type == "doc",
-                    Reference.form == "mention",
-                )
+    story #2284: diff 단위가 target_id 하나였던 것을 **(target_id, form) 쌍**으로 넓혔다 —
+    같은 대상이라도 wikiLink(mention)와 pageEmbed(embed)는 서로 다른 행이라(파서가 이제
+    구분을 보존한다). ⛔이 함수는 mention/embed 두 form만 다룬다 — proof(form)는 이 write
+    경로가 만들지도 지우지도 않는다(#2265 전용 별도 write 경로 몫 — 아직 존재하지 않는다).
+    그래서 존재-조회에 `Reference.form.in_(("mention", "embed"))`로 명시해 proof 행을
+    이 diff의 시야 밖에 둔다(실수로 지우는 사고 원천 차단).
+
+    ⛔AC4(기존 행 소급 재분류 안 함, 별개 판단): 이 함수는 «마이그레이션 스크립트»가 아니라
+    doc이 저장될 때마다 도는 diff다 — 예전에 form="mention"으로 잘못 저장된 pageEmbed
+    참조가 있는 doc을 사용자가 «다시 저장」하면, 그 저장이 새 파서로 다시 diff되어 자연히
+    embed로 갈린다(그 doc이 재저장되지 않는 한 예전 값 그대로 남는다). 이건 소급 일괄
+    재분류(=이 스토리가 안 하는 것)가 아니라 정상적인 reconcile-on-save의 자연스러운 결과다
+    — 그래서 별도 backfill 코드는 없다. 그 doc의 `entity_references` row가 갈린 시점(=이
+    행의 `created_at`)이 그 doc 한정으로는 경계다."""
+    target_refs = {
+        (tid, form) for tid, form in extract_doc_mention_targets(html_content) if tid != doc_id
+    }
+
+    existing_rows = (
+        await db.execute(
+            select(Reference.target_id, Reference.form).where(
+                Reference.source_type == "doc",
+                Reference.source_field == "body",
+                Reference.source_id == doc_id,
+                Reference.target_type == "doc",
+                Reference.form.in_(("mention", "embed")),
             )
-        ).scalars().all()
-    )
+        )
+    ).all()
+    existing_refs = {(row.target_id, row.form) for row in existing_rows}
 
-    stale_ids = existing_ids - target_ids
-    if stale_ids:
-        from sqlalchemy import delete as sa_delete
+    stale_refs = existing_refs - target_refs
+    if stale_refs:
+        from sqlalchemy import delete as sa_delete, tuple_
 
         await db.execute(
             sa_delete(Reference).where(
@@ -242,13 +292,13 @@ async def reconcile_doc_mentions(
                 Reference.source_field == "body",
                 Reference.source_id == doc_id,
                 Reference.target_type == "doc",
-                Reference.form == "mention",
-                Reference.target_id.in_(stale_ids),
+                Reference.form.in_(("mention", "embed")),
+                tuple_(Reference.target_id, Reference.form).in_(stale_refs),
             )
         )
 
-    new_ids = target_ids - existing_ids
-    if new_ids:
+    new_refs = target_refs - existing_refs
+    if new_refs:
         canonical_created_by = await canonicalize_member_id(created_by, db)
         stmt = pg_insert(Reference).values([
             {
@@ -259,10 +309,10 @@ async def reconcile_doc_mentions(
                 "source_id": doc_id,
                 "target_type": "doc",
                 "target_id": target_id,
-                "form": "mention",
+                "form": form,
                 "created_by": canonical_created_by,
             }
-            for target_id in new_ids
+            for target_id, form in new_refs
         ])
         stmt = stmt.on_conflict_do_nothing(
             index_elements=[

--- a/backend/tests/test_1993_mention_parser.py
+++ b/backend/tests/test_1993_mention_parser.py
@@ -10,6 +10,7 @@ import uuid
 from app.services.mention_parser import (
     extract_chat_doc_mention_ids,
     extract_doc_mention_ids,
+    extract_doc_mention_targets,
 )
 
 
@@ -133,3 +134,59 @@ def test_extract_doc_malformed_html_does_not_raise():
     # 예외 없이 리턴되면 충분(잘린 태그라도 이미 열린 span 의 속성은 잡힘).
     result = extract_doc_mention_ids(html)
     assert doc_id in result
+
+
+# ─── extract_doc_mention_targets (story #2284 — form 보존: wikiLink→mention·pageEmbed→embed) ──
+
+
+def test_extract_doc_targets_wikilink_is_mention_form():
+    doc_id = uuid.uuid4()
+    html = f'<span data-type="wikiLink" data-doc-id="{doc_id}">X</span>'
+    assert extract_doc_mention_targets(html) == [(doc_id, "mention")]
+
+
+def test_extract_doc_targets_page_embed_is_embed_form():
+    doc_id = uuid.uuid4()
+    html = f'<div data-page-embed data-doc-id="{doc_id}"></div>'
+    assert extract_doc_mention_targets(html) == [(doc_id, "embed")]
+
+
+def test_extract_doc_targets_mixed_forms_both_kept_distinct():
+    """⭐AC1 핵심 — 파싱 시점에 있던 형태 구분이 저장 직전 단계까지 버려지지 않고 살아남는다."""
+    id1, id2 = uuid.uuid4(), uuid.uuid4()
+    html = (
+        f'<span data-type="wikiLink" data-doc-id="{id1}">A</span>'
+        f'<div data-page-embed data-doc-id="{id2}"></div>'
+    )
+    assert extract_doc_mention_targets(html) == [(id1, "mention"), (id2, "embed")]
+
+
+def test_extract_doc_targets_same_doc_as_both_forms_not_collapsed():
+    """같은 doc이 인라인 멘션과 카드 임베드 둘 다로 등장하면 (id, form)이 달라 둘 다 남는다 —
+    entity_references의 partial unique index가 form을 키에 포함하므로 공존이 설계상 맞다."""
+    doc_id = uuid.uuid4()
+    html = (
+        f'<span data-type="wikiLink" data-doc-id="{doc_id}">A</span>'
+        f'<div data-page-embed data-doc-id="{doc_id}"></div>'
+    )
+    assert extract_doc_mention_targets(html) == [(doc_id, "mention"), (doc_id, "embed")]
+
+
+def test_extract_doc_targets_duplicate_same_form_deduped():
+    doc_id = uuid.uuid4()
+    html = (
+        f'<span data-type="wikiLink" data-doc-id="{doc_id}">A</span>'
+        f'<span data-type="wikiLink" data-doc-id="{doc_id}">A again</span>'
+    )
+    assert extract_doc_mention_targets(html) == [(doc_id, "mention")]
+
+
+def test_extract_doc_mention_ids_wrapper_still_ignores_form():
+    """extract_doc_mention_ids(하위호환 래퍼)는 여전히 id만 반환 — form이 다른 같은 id도
+    한 번만(기존 계약 무변경)."""
+    doc_id = uuid.uuid4()
+    html = (
+        f'<span data-type="wikiLink" data-doc-id="{doc_id}">A</span>'
+        f'<div data-page-embed data-doc-id="{doc_id}"></div>'
+    )
+    assert extract_doc_mention_ids(html) == [doc_id]

--- a/backend/tests/test_1993_mentions_realdb.py
+++ b/backend/tests/test_1993_mentions_realdb.py
@@ -162,6 +162,128 @@ async def test_doc_reconcile_adds_and_removes_stale_mentions():
         await engine.dispose()
 
 
+# ─── story #2284 AC5: 왕복 실측 — 인라인 멘션과 카드 임베드가 서로 다른 form으로 선다 ──
+
+
+async def test_doc_reconcile_wikilink_and_page_embed_land_as_distinct_forms():
+    """⭐AC5 핵심 — 문서 본문에 인라인 멘션 하나와 카드 임베드 하나를 같이 넣으면
+    entity_references에 서로 다른 form(mention/embed)으로 각각 행이 생긴다(예전엔 둘 다
+    "mention"으로 뭉개졌다)."""
+    from app.models.reference import Reference
+    from app.services.mention_parser import reconcile_doc_mentions
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            await session.commit()
+
+            source_doc_id = uuid.uuid4()
+            mention_target = uuid.uuid4()
+            embed_target = uuid.uuid4()
+
+            html = (
+                f'<span data-type="wikiLink" data-doc-id="{mention_target}">M</span>'
+                f'<div data-page-embed data-doc-id="{embed_target}"></div>'
+            )
+            await reconcile_doc_mentions(
+                session, org_id=org.id, doc_id=source_doc_id, html_content=html,
+                created_by=member.id,
+            )
+            await session.commit()
+
+            rows = (await session.execute(
+                select(Reference.target_id, Reference.form).where(
+                    Reference.source_type == "doc", Reference.source_id == source_doc_id,
+                )
+            )).all()
+            by_target = {row.target_id: row.form for row in rows}
+            assert by_target == {mention_target: "mention", embed_target: "embed"}
+    finally:
+        await engine.dispose()
+
+
+async def test_doc_reconcile_switching_page_embed_to_wikilink_swaps_form_not_stacks():
+    """같은 대상이 pageEmbed→wikiLink로 바뀌면(사용자가 카드를 인라인 멘션으로 바꿔 재저장)
+    embed 행이 사라지고 mention 행 하나만 남는다 — 두 form이 동시에 쌓이지 않는다."""
+    from app.models.reference import Reference
+    from app.services.mention_parser import reconcile_doc_mentions
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            await session.commit()
+
+            source_doc_id = uuid.uuid4()
+            target = uuid.uuid4()
+
+            html_v1 = f'<div data-page-embed data-doc-id="{target}"></div>'
+            await reconcile_doc_mentions(
+                session, org_id=org.id, doc_id=source_doc_id, html_content=html_v1,
+                created_by=member.id,
+            )
+            await session.commit()
+
+            html_v2 = f'<span data-type="wikiLink" data-doc-id="{target}">X</span>'
+            await reconcile_doc_mentions(
+                session, org_id=org.id, doc_id=source_doc_id, html_content=html_v2,
+                created_by=member.id,
+            )
+            await session.commit()
+
+            rows = (await session.execute(
+                select(Reference.target_id, Reference.form).where(
+                    Reference.source_type == "doc", Reference.source_id == source_doc_id,
+                )
+            )).all()
+            assert [(row.target_id, row.form) for row in rows] == [(target, "mention")]
+    finally:
+        await engine.dispose()
+
+
+async def test_doc_reconcile_proof_rows_untouched_by_reconcile():
+    """⛔reconcile_doc_mentions는 mention/embed만 다룬다 — 같은 (source_doc, target_doc) 쌍에
+    미리 존재하는 form="proof" 행은 이 함수가 절대 건드리지 않는다(다른 write 경로 소유)."""
+    from app.models.reference import Reference
+    from app.services.mention_parser import reconcile_doc_mentions
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            await session.commit()
+
+            source_doc_id = uuid.uuid4()
+            target = uuid.uuid4()
+
+            proof_row = Reference(
+                id=uuid.uuid4(), org_id=org.id, source_type="doc", source_field="body",
+                source_id=source_doc_id, target_type="doc", target_id=target, form="proof",
+                created_by=member.id,
+            )
+            session.add(proof_row)
+            await session.commit()
+
+            # 본문에 아무 언급도 없음 — reconcile이 "다 지운다"면 proof도 같이 지워질 위험.
+            await reconcile_doc_mentions(
+                session, org_id=org.id, doc_id=source_doc_id, html_content="<p>empty</p>",
+                created_by=member.id,
+            )
+            await session.commit()
+
+            rows = (await session.execute(
+                select(Reference).where(
+                    Reference.source_type == "doc", Reference.source_id == source_doc_id,
+                )
+            )).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].id == proof_row.id
+            assert rows[0].form == "proof"
+    finally:
+        await engine.dispose()
+
+
 # ─── AC4-3: 중복 삽입 → UNIQUE 로 1 row 만 ──────────────────────────────────────
 
 


### PR DESCRIPTION
## 배경
유나 발견 → 디디 확認: `entity_references.form` CHECK={mention,embed,proof}인데 form을 쓰는
코드 4곳이 전부 리터럴 `"mention"`이었다. 문서 쪽은 `_DocMentionHTMLParser`가 wikiLink(인라인
멘션)와 pageEmbed(카드 임베드) 둘 다 파싱하는데(#1993 설계상 원래 다른 모양) `extract_doc_
mention_ids`가 그 구분을 버리고 id 리스트 하나로 뭉갰다 — **파싱 시점에 있던 재료가 저장
시점에 버려지는** 것이었다. 채팅은 문법이 하나(`[title](entity:type:id)`)뿐이라 애초에 가를
재료가 없다(#2265의 proof와도 크기가 다른 별건).

## 스코프 (PO 판정, 유나 경계)
문서 쪽만. 채팅 쪽은 「지금은 mention만 만든다」를 기록하는 데까지(AC3) — 새 문법을 만드는
일은 별건(#2263).

## 구현
- `_DocMentionHTMLParser`: `(doc_id, form)` 쌍으로 보존(wikiLink→mention, pageEmbed→embed).
- `extract_doc_mention_targets` 신설(형태 보존 버전). `extract_doc_mention_ids`는 id만
  필요한 호출부용 하위호환 래퍼로 재정의(외부 호출부 0곳 확인 — 깨질 게 없다).
- `reconcile_doc_mentions`: diff 단위를 `target_id`에서 `(target_id, form)`으로 확장.
  - proof 행은 존재-조회(`Reference.form.in_(("mention","embed"))`)에서 명시적으로 제외 —
    다른 write 경로(#2265, 아직 없음) 소유라 이 함수가 실수로 지우면 안 된다.
  - AC4: 기존 행은 소급 일괄 재분류하지 않는다(별도 backfill 코드 없음). doc이 다음에
    재저장될 때 자연히 새 파서로 다시 diff되어 갈린다 — 이건 정상 reconcile-on-save의
    결과이지 마이그레이션이 아니다(docstring에 명시).
- `insert_chat_mentions`: AC3 — 채팅엔 가를 재료가 없다는 사실을 명시(하드코딩이 아니라
  지금 있는 유일한 값).
- 모듈 docstring: AC6 — proof가 아직 안 만들어지는 이유(#2265 전용 write 경로 자체가
  없음, "지원 안 함"과 "아직 안 만듦"은 다르다).

## 검증
- 신규 pure-unit 6개(`test_1993_mention_parser.py`) — 형태 보존·혼합·중복제거·하위호환 래퍼.
- 신규 realdb 3개(`test_1993_mentions_realdb.py`) — AC5 왕복(mention/embed 서로 다른 행),
  embed→mention 전환 시 겹쳐 쌓이지 않음, **proof 행이 reconcile에 안 건드려짐**(사고 방지
  회귀 가드).
- RED→GREEN 자체검증: form을 다시 하드코딩 사보타주 → 신규 테스트 RED 확인 → 원복 → GREEN.
- 회귀: mention/backlinks/reference/stories 관련 스위트(48+52개) 전부 GREEN.

## 롤백
`app/services/mention_parser.py`를 이 커밋 이전으로 revert — `extract_doc_mention_ids`
하위호환 래퍼가 있어 다른 파일 변경 없이 되돌아간다.