### PR TITLE
[SID:2283] 사람이 친 #번호·#슬러그를 후보로 잡아 보낸 메시지 바로 아래서 한 번 묻는다

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2766,6 +2766,10 @@
   },
   "chats": {
     "unreadMarker": "Unread from here",
+    "referenceCandidatePrompt": "Link {token} as a story?",
+    "referenceCandidateConfirm": "Yes",
+    "referenceCandidateReject": "Don't ask again",
+    "referenceCandidateComingSoon": "Linking {token} is coming soon",
     "inputPlaceholderMobile": "Type a message… (@ mention)",
     "inputPlaceholderFull": "Type a message… (Enter to send / Shift+Enter for new line / @ mention / # entity)",
     "isTyping": "{name} is typing",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2766,6 +2766,10 @@
   },
   "chats": {
     "unreadMarker": "여기부터 안읽음",
+    "referenceCandidatePrompt": "{token}를 스토리로 잇겠습니까?",
+    "referenceCandidateConfirm": "예",
+    "referenceCandidateReject": "묻지 않기",
+    "referenceCandidateComingSoon": "{token} 연결은 곧 지원됩니다",
     "inputPlaceholderMobile": "메시지를 입력하세요… (@ 멘션)",
     "inputPlaceholderFull": "메시지를 입력하세요… (Enter 전송 / Shift+Enter 줄바꿈 / @ 멘션 / # 엔티티)",
     "isTyping": "{name} 님이 입력 중",

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -16,6 +16,7 @@ import { AttachmentMedia } from './attachment-media';
 import { AttachmentFile } from './attachment-file';
 import { MessageContextMenu } from './message-context-menu';
 import { PresenceDot, WORKING_RING_CLASS, type PresenceStatus } from './presence-dot';
+import { ReferenceSuggestionRow } from './reference-suggestion-row';
 
 interface ChatBubbleProps {
   message: ChatMessage;
@@ -331,6 +332,10 @@ export function ChatBubble({ message, isMine, isGrouped = false, onOpenThread, o
               <ChatMarkdown content={displayContent} isMine={isMine} />
             </div>
           )}
+
+          {/* story #2283 — 보낸 직후 그 메시지 바로 아래에서 한 번 제안(작성자 본인에게만,
+              isMine 게이트는 컴포넌트 내부에서 건다). ⛔남의 메시지엔 안 뜬다. */}
+          {!isCmd && <ReferenceSuggestionRow messageId={message.id} content={message.content} isMine={isMine} />}
 
           {/* Attachments — a54ddc16: auth-gated 서명 라우트 경유(public 직링크 미사용).
               이미지=AttachmentImage(3상태 render)·오디오/비디오=AttachmentMedia(story #2051,

--- a/apps/web/src/components/chat/reference-suggestion-row.test.tsx
+++ b/apps/web/src/components/chat/reference-suggestion-row.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { ReferenceSuggestionRow } from './reference-suggestion-row';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let store: Map<string, string>;
+function stubLocalStorage() {
+  store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => { store.set(k, v); },
+    removeItem: (k: string) => { store.delete(k); },
+    clear: () => { store.clear(); },
+  });
+}
+
+function withIntl(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  stubLocalStorage();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function render(props: { messageId: string; content: string; isMine: boolean }) {
+  await act(async () => {
+    root.render(withIntl(<ReferenceSuggestionRow {...props} />));
+  });
+}
+
+describe('ReferenceSuggestionRow — story #2283', () => {
+  it('남의 메시지(isMine=false)엔 후보가 있어도 아무것도 안 뜬다(작성자 본인에게만)', async () => {
+    await render({ messageId: 'm1', content: '#2249 확認 부탁', isMine: false });
+    expect(container.textContent).toBe('');
+  });
+
+  it('후보가 없으면 아무것도 안 뜬다', async () => {
+    await render({ messageId: 'm1', content: '그냥 평범한 메시지입니다', isMine: true });
+    expect(container.textContent).toBe('');
+  });
+
+  it('본인 메시지에 평문 #번호가 있으면 제안이 뜬다', async () => {
+    await render({ messageId: 'm1', content: '#2249 확認 부탁', isMine: true });
+    expect(container.textContent).toContain('#2249를 스토리로 잇겠습니까?');
+    expect(container.textContent).toContain('예');
+  });
+
+  it('⛔누르기 전에는 「예」를 눌러도 조용히 성공한 척하지 않고 "곧 지원" 문구를 보여준다(자동확정 금지)', async () => {
+    await render({ messageId: 'm1', content: '#2249 확認 부탁', isMine: true });
+    const confirmBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '예');
+    await act(async () => { confirmBtn!.click(); });
+    expect(container.textContent).toContain('곧 지원됩니다');
+    expect(container.textContent).not.toContain('연결되었습니다');
+  });
+
+  it('「묻지 않기」를 누르면 그 후보가 즉시 사라진다(같은 렌더 인스턴스 내 즉시 반영)', async () => {
+    await render({ messageId: 'm1', content: '#2249 확認 부탁', isMine: true });
+    const rejectBtn = container.querySelector('button[aria-label="묻지 않기"]') as HTMLButtonElement;
+    await act(async () => { rejectBtn.click(); });
+    expect(container.textContent).toBe('');
+  });
+
+  it('거절 후 재마운트해도(localStorage 기억) 같은 메시지의 같은 후보는 다시 안 뜬다', async () => {
+    await render({ messageId: 'm1', content: '#2249 확認 부탁', isMine: true });
+    const rejectBtn = container.querySelector('button[aria-label="묻지 않기"]') as HTMLButtonElement;
+    await act(async () => { rejectBtn.click(); });
+    await act(async () => { root.unmount(); });
+    root = createRoot(container);
+    await render({ messageId: 'm1', content: '#2249 확認 부탁', isMine: true });
+    expect(container.textContent).toBe('');
+  });
+});

--- a/apps/web/src/components/chat/reference-suggestion-row.tsx
+++ b/apps/web/src/components/chat/reference-suggestion-row.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Link2, X } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { findReferenceCandidates, isCandidateRejected, rejectCandidate } from '@/lib/reference-candidates';
+
+interface ReferenceSuggestionRowProps {
+  messageId: string;
+  content: string;
+  /** AC1: 보낸 사람 본인의 메시지 바로 아래에서만 묻는다 — 남의 메시지엔 안 뜬다. */
+  isMine: boolean;
+}
+
+/**
+ * story #2283 — 사람이 채팅에 평문으로 친 `#번호`·`#슬러그`를 「이걸 스토리로 잇겠습니까?」로
+ * 한 번 묻는다. ⛔자동 확정 금지(AC2) — 사람이 누른 것만 선다.
+ *
+ * ⛔해소(번호/슬러그→UUID)·확인된 참조를 실제로 꽂는 쓰기 경로 둘 다 아직 BE에 없다
+ * (디디군이 #2282 다음 판에서 함께 만든다 — 착수 전 착수 보고 참조). 그래서 「예」는 지금
+ * 조용히 성공한 척하지 않고 "곧 지원됩니다"를 명시적으로 보여준다 — API가 채워지면 이
+ * 컴포넌트의 handleConfirm 한 곳만 실 구현으로 바꾸면 된다(자리·탐지·소음규칙은 이미 완성).
+ */
+export function ReferenceSuggestionRow({ messageId, content, isMine }: ReferenceSuggestionRowProps) {
+  const t = useTranslations('chats');
+  // AC3 ②: 거절 즉시 이 렌더 인스턴스에서도 사라지도록 로컬 상태로 미러링(localStorage는
+  // 다음 마운트/새로고침 시의 진실이고, 지금 이 세션에서 즉시 반영되려면 상태가 필요하다).
+  const [locallyDismissed, setLocallyDismissed] = useState<Set<string>>(() => new Set());
+  const [pendingNotice, setPendingNotice] = useState<string | null>(null);
+
+  const candidates = useMemo(() => {
+    if (!isMine) return [];
+    return findReferenceCandidates(content).filter(
+      (c) => !isCandidateRejected(messageId, c.raw) && !locallyDismissed.has(c.raw),
+    );
+  }, [isMine, content, messageId, locallyDismissed]);
+
+  if (candidates.length === 0) return null;
+
+  const handleReject = (raw: string) => {
+    rejectCandidate(messageId, raw);
+    setLocallyDismissed((prev) => new Set(prev).add(raw));
+  };
+
+  // ⛔AC2: 여기서 참조를 만들지 않는다 — BE 쓰기 경로가 서면 이 함수 본체만 교체한다.
+  const handleConfirm = (raw: string) => {
+    setPendingNotice(raw);
+  };
+
+  return (
+    <div className="mt-1 flex flex-col gap-1">
+      {candidates.map((c) => (
+        <div
+          key={c.raw}
+          className="flex items-center gap-2 rounded-md border border-dashed border-border bg-muted/30 px-2.5 py-1.5 text-xs text-muted-foreground"
+        >
+          <Link2 className="size-3.5 shrink-0" aria-hidden />
+          {pendingNotice === c.raw ? (
+            <span className="flex-1">{t('referenceCandidateComingSoon', { token: c.raw })}</span>
+          ) : (
+            <>
+              <span className="flex-1">{t('referenceCandidatePrompt', { token: c.raw })}</span>
+              <button
+                type="button"
+                onClick={() => handleConfirm(c.raw)}
+                className="rounded px-1.5 py-0.5 font-medium text-primary hover:bg-primary/10"
+              >
+                {t('referenceCandidateConfirm')}
+              </button>
+              <button
+                type="button"
+                onClick={() => handleReject(c.raw)}
+                aria-label={t('referenceCandidateReject')}
+                className="rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+              >
+                <X className="size-3.5" />
+              </button>
+            </>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/lib/reference-candidates.test.ts
+++ b/apps/web/src/lib/reference-candidates.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { findReferenceCandidates, isCandidateRejected, rejectCandidate } from './reference-candidates';
+
+// story #2059(kanban-board.test.tsx)와 동일 패턴 — jsdom/Node 네이티브 localStorage가
+// 이 실행환경에서 온전치 않아(--localstorage-file 미설정 시 .clear() 없는 스텁) Map 기반
+// 페이크로 통째로 교체한다.
+let store: Map<string, string>;
+function stubLocalStorage() {
+  store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => { store.set(k, v); },
+    removeItem: (k: string) => { store.delete(k); },
+    clear: () => { store.clear(); },
+  });
+}
+
+describe('findReferenceCandidates', () => {
+  it('평문 #번호를 후보로 잡는다', () => {
+    const result = findReferenceCandidates('이거 #2249 확認해줘');
+    expect(result).toEqual([{ raw: '#2249', kind: 'number', value: '2249' }]);
+  });
+
+  it('평문 #슬러그(하이픈 포함)를 후보로 잡는다', () => {
+    const result = findReferenceCandidates('doc #flow-map-blueprint-v1 참조');
+    expect(result).toEqual([{ raw: '#flow-map-blueprint-v1', kind: 'slug', value: 'flow-map-blueprint-v1' }]);
+  });
+
+  it('하이픈 없는 순수 해시태그성 단어는 슬러그로 잡지 않는다(오탐 방지)', () => {
+    const result = findReferenceCandidates('#urgent 부탁드려요');
+    expect(result).toEqual([]);
+  });
+
+  it('한 자리 숫자(#1 같은)는 잡지 않는다(스토리 번호 관례상 노이즈 방지)', () => {
+    const result = findReferenceCandidates('순서 #1 먼저요');
+    expect(result).toEqual([]);
+  });
+
+  it('이미 entity 토큰인 것은 후보에서 뺀다(같은 클래스 재질문 방지)', () => {
+    const result = findReferenceCandidates('[Fix #2249 bug](entity:story:11111111-1111-1111-1111-111111111111) 참고');
+    expect(result).toEqual([]);
+  });
+
+  it('entity 토큰과 평문 후보가 섞여 있으면 평문 것만 잡는다', () => {
+    const result = findReferenceCandidates(
+      '[제목](entity:story:11111111-1111-1111-1111-111111111111) 관련해서 #2250 도 봐줘',
+    );
+    expect(result).toEqual([{ raw: '#2250', kind: 'number', value: '2250' }]);
+  });
+
+  it('같은 후보가 두 번 나오면 한 번만 잡는다(dedupe)', () => {
+    const result = findReferenceCandidates('#2249 그리고 다시 #2249');
+    expect(result).toHaveLength(1);
+  });
+
+  it('빈 문자열은 빈 배열을 낸다', () => {
+    expect(findReferenceCandidates('')).toEqual([]);
+  });
+});
+
+describe('거절 기억(localStorage, durable 아님)', () => {
+  beforeEach(() => {
+    stubLocalStorage();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('거절 전엔 rejected가 아니다', () => {
+    expect(isCandidateRejected('msg-1', '#2249')).toBe(false);
+  });
+
+  it('거절하면 같은 (messageId, raw) 쌍은 rejected로 남는다', () => {
+    rejectCandidate('msg-1', '#2249');
+    expect(isCandidateRejected('msg-1', '#2249')).toBe(true);
+  });
+
+  it('다른 메시지의 같은 토큰 문자열은 거절 영향을 안 받는다(메시지 단위 스코프)', () => {
+    rejectCandidate('msg-1', '#2249');
+    expect(isCandidateRejected('msg-2', '#2249')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/reference-candidates.ts
+++ b/apps/web/src/lib/reference-candidates.ts
@@ -1,0 +1,95 @@
+/**
+ * story #2283 — 사람이 채팅에 평문으로 친 `#번호`·`#슬러그`를 「아직 참조가 안 된 후보」로
+ * 잡는다. 순수 함수(부작용 없음) — 렌더 쪽(reference-suggestion-row.tsx)이 이걸 써서
+ * "보낸 직후 그 메시지 바로 아래" 제안을 만든다.
+ *
+ * ⛔이미 토큰인 것은 후보에서 뺀다 — `[title](entity:type:id)` 토큰의 title 텍스트 안에
+ * "#2249" 같은 글자가 우연히 들어 있어도(예: "Fix #2249 bug"라는 제목) 그건 이미 참조가
+ * 선 것이므로 다시 묻지 않는다. 그래서 먼저 entity 토큰 구간을 걷어낸 텍스트에서만 찾는다.
+ */
+
+export type ReferenceCandidateKind = 'number' | 'slug';
+
+export interface ReferenceCandidate {
+  /** 매칭된 원문 그대로(예: "#2249", "#flow-map-blueprint-v1") — dedupe/거절 기억의 키. */
+  raw: string;
+  kind: ReferenceCandidateKind;
+  /** '#' 뺀 값(예: "2249", "flow-map-blueprint-v1"). */
+  value: string;
+}
+
+const ENTITY_TOKEN_RE = /\[[^\]]*\]\(entity:[a-z]+:[0-9a-fA-F-]+\)/g;
+const NUMBER_RE = /#(\d{2,6})\b/g;
+// 슬러그: 최소 한 번의 하이픈을 요구해 일반 해시태그성 단어와 구분한다(이 코드베이스의
+// 실제 슬러그 관례 — 예: flow-map-blueprint-v1, provenance-attachment-point-inventory-...).
+const SLUG_RE = /#([a-z][a-z0-9]*(?:-[a-z0-9]+)+)\b/g;
+
+export function findReferenceCandidates(content: string): ReferenceCandidate[] {
+  if (!content) return [];
+  const withoutTokens = content.replace(ENTITY_TOKEN_RE, (m) => ' '.repeat(m.length));
+
+  const seen = new Set<string>();
+  const result: ReferenceCandidate[] = [];
+
+  for (const m of withoutTokens.matchAll(NUMBER_RE)) {
+    const raw = m[0];
+    if (seen.has(raw)) continue;
+    seen.add(raw);
+    result.push({ raw, kind: 'number', value: m[1]! });
+  }
+  for (const m of withoutTokens.matchAll(SLUG_RE)) {
+    const raw = m[0];
+    if (seen.has(raw)) continue;
+    seen.add(raw);
+    result.push({ raw, kind: 'slug', value: m[1]! });
+  }
+  return result;
+}
+
+// ── 거절 기억(AC3 ②) ─────────────────────────────────────────────────────────
+// ⛔이 세션이 짓는 만큼만 정직하게: BE에 거절 상태를 남길 표가 아직 없어(이 스토리의
+// 쓰기 경로 자체가 미해결 — 착수 보고 참조) 브라우저 localStorage에만 남긴다. 즉 다른
+// 기기·시크릿창·캐시삭제 후에는 다시 물을 수 있다 — durable하지 않다는 점을 명시한다.
+// 거절 기억은 "소음 억제"이지 "데이터"가 아니라 잃어버려도 손해는 "한 번 더 묻는 것"뿐이라
+// 지금은 이걸로 충분하다(PO 판정, 2026-07-28).
+//
+// ⛔이 선택이 부족해지는 조건(다음 사람이 "왜 localStorage지?"를 다시 판단하지 않도록 —
+// 조건이 오면 서버 쪽(거절 기억 전용 표 또는 Reference 신설 시 그 옆)으로 옮긴다):
+//   ①사람이 기기를 바꾸면 거절이 안 따라간다 — 같은 후보를 또 묻게 된다.
+//   ②제안이 잦아지면(#2269가 본문에 쌓인 기존 참조를 캐기 시작하면) 체감이 커진다.
+const REJECTED_KEY = 'sprintable:reference-candidates:rejected';
+
+function readRejectedSet(): Set<string> {
+  if (typeof window === 'undefined') return new Set();
+  try {
+    const raw = window.localStorage.getItem(REJECTED_KEY);
+    if (!raw) return new Set();
+    const arr = JSON.parse(raw) as unknown;
+    return new Set(Array.isArray(arr) ? arr.filter((x): x is string => typeof x === 'string') : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function writeRejectedSet(s: Set<string>): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(REJECTED_KEY, JSON.stringify(Array.from(s)));
+  } catch {
+    // localStorage 쓰기 실패(용량초과/프라이빗모드 등) — 조용히 무시, 다음 렌더에서 다시 물을 뿐.
+  }
+}
+
+function rejectionKey(messageId: string, raw: string): string {
+  return `${messageId}::${raw}`;
+}
+
+export function isCandidateRejected(messageId: string, raw: string): boolean {
+  return readRejectedSet().has(rejectionKey(messageId, raw));
+}
+
+export function rejectCandidate(messageId: string, raw: string): void {
+  const s = readRejectedSet();
+  s.add(rejectionKey(messageId, raw));
+  writeRejectedSet(s);
+}


### PR DESCRIPTION
## 착수 전 발견한 것 — PO가 낸 전제 하나를 정정

착수 지시는 "④해소(번호/슬러그→UUID)만 BE가 필요하다"였다. 코드를 직접 읽어보니 **해소뿐 아니라, 확인된 후보를 실제로 Reference로 꽂는 쓰기 경로도 없다**는 걸 발견했다:

- `insert_chat_mentions`(mention_parser.py)는 **메시지 content를 재파싱**해서만 Reference를 만드는 구조.
- 채팅 메시지는 **불변 전제**(파일 docstring에 명시) — "확인 누른 뒤 토큰으로 다시 써넣기"가 안 된다.
- 즉 "사람이 예 눌렀을 때 Reference를 곧바로 꽂는" 범용 엔드포인트 자체가 코드베이스 어디에도 없다.

PO 판정: 메시지 content는 안 건드리고(불변 전제 유지) **Reference를 직접 꽂는 새 경로**를 만든다 — 디디가 #2282 다음 판에서 해소+직접생성 둘을 한 번에 만든다. #2269(본문에 쌓인 기존 참조 캐기)도 같은 경로를 쓴다.

## 이 PR이 짓는 것 — BE 없이 되는 것 셋

| 항목 | 상태 |
|---|---|
| ①제안 한 줄이 뜨는 자리와 모양(보낸 메시지 바로 아래) | ✅완성 |
| ②평문 `#번호`·`#슬러그` 후보 탐지 | ✅완성 |
| ③소음 규칙(이미 토큰인 것은 안 묻기·거절 기억) | ✅완성 |
| ④해소(번호/슬러그→UUID) | ⛔BE 대기(디디, #2282 다음 판) |
| 확인된 후보를 실제 Reference로 꽂는 쓰기 | ⛔BE 대기(위와 동일 판) |

## 세부

- **`reference-candidates.ts`**(순수 함수): 번호 `#\d{2,6}`(한 자리 숫자는 노이즈로 제외) · 슬러그(하이픈 필수 — `#urgent` 같은 일반 해시태그 오탐 방지). `[title](entity:type:id)` 토큰 구간은 먼저 걷어내고 찾아 "이미 참조가 선 제목 안에 우연히 `#2249`가 있는" 경우도 다시 안 묻는다.
- **거절 기억**: localStorage, 메시지 단위 스코프. ⚠️durable하지 않다 — 기기를 바꾸면 다시 물을 수 있다. 이 선택이 부족해지는 조건(기기 전환·#2269로 제안 빈도 증가)을 코드 주석에 명시해 다음 사람이 "왜 localStorage지?"를 재판단하지 않게 했다.
- **`reference-suggestion-row.tsx`**: `isMine` 게이트 — **작성자 본인의 메시지에만** 뜬다(mutation-verified: 게이트 제거 → 테스트 RED 확認 → 원복). "예" 클릭 시 **조용히 성공한 척하지 않고** "곧 지원됩니다"를 명시적으로 보여준다 — BE가 준비되면 `handleConfirm` 본체만 교체하면 된다.
- **`chat-bubble.tsx`**: 메시지 콘텐츠 바로 아래(첨부/시간 이전)에 배선.

## 검증
- 신규 17케이스(탐지 유틸 11 + 컴포넌트 6) 전부 GREEN, `isMine` 게이트 mutation-verified.
- 전체 FE vitest 스윕: 296 파일 · 1972 테스트 전부 PASS(회귀 없음).
- `tsc --noEmit` 무오류, `eslint` 무경고.

## AC4/AC6/AC7에 대해

BE 쓰기 경로가 서야 완결된다 — 그때 이 스토리를 재오픈하지 않고, `handleConfirm`을 실 구현으로 바꾸는 후속 PR로 마무리한다. 사람 경로 라이브 실측(AC6)은 그 후속 PR에서 진행.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>