### PR TITLE
[E-CONNECT] #2282: 참조 토큰 단일 SSOT builder + 응답/도구설명 배선

### DIFF
--- a/backend/app/schemas/doc.py
+++ b/backend/app/schemas/doc.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, computed_field
 
 
 class DocCreate(BaseModel):
@@ -107,6 +107,15 @@ class DocResponse(BaseModel):
     # additive·nullable(하위호환·미enrich 응답/list 엔 None). FE 는 별도 member/revisions fetch 제거.
     assignee: DocMemberSummary | None = None
     revisions: DocRevisionsSummary | None = None
+
+    # story #2282(E-CONNECT) AC1/AC2: 이 doc을 가리키는 참조 토큰 — 단일 builder(app.services.
+    # reference_token.build_reference_token) 재사용. id/title에서 매 직렬화 시 계산되므로
+    # 호출부(create/get/update 등)가 매번 따로 채울 필요가 없다(빠뜨릴 자리 자체가 없다).
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def reference_token(self) -> str | None:
+        from app.services.reference_token import build_reference_token
+        return build_reference_token("doc", self.id, self.title)
 
 
 class ShareStatusResponse(BaseModel):

--- a/backend/app/schemas/goal.py
+++ b/backend/app/schemas/goal.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import date, datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, computed_field
 
 # 계층 리네이밍 B1(story 1925): 구 epic.py — 클래스/필드명만 rename, DB 컬럼(stories.epic_id 등)은
 # B4 후속(스코프 밖). 구 이름(GoalXxx의 별칭)은 REST/MCP 레이어(routers/goals.py·sprintable_mcp)에서
@@ -94,6 +94,14 @@ class GoalResponse(BaseModel):
     source_loop_id: uuid.UUID | None = None
     created_at: datetime
     updated_at: datetime
+
+    # story #2282(E-CONNECT) AC1/AC2: 이 goal(=epic, entity_type 문자열은 registry 기준
+    # "epic" — reference_registry._resolve_epics가 Goal 모델을 쓴다)을 가리키는 참조 토큰.
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def reference_token(self) -> str | None:
+        from app.services.reference_token import build_reference_token
+        return build_reference_token("epic", self.id, self.title)
 
 
 class GoalProgressResponse(BaseModel):

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, computed_field, field_validator
 
 from app.schemas.attachment import validate_attachment_url
 
@@ -284,3 +284,11 @@ class StoryResponse(BaseModel):
     @classmethod
     def _coerce_human_verified_at(cls, v):
         return v if isinstance(v, datetime) else None
+
+    # story #2282(E-CONNECT) AC1/AC2: 이 story를 가리키는 참조 토큰 — DocResponse와 동일
+    # 단일 builder 재사용(app.services.reference_token.build_reference_token).
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def reference_token(self) -> str | None:
+        from app.services.reference_token import build_reference_token
+        return build_reference_token("story", self.id, self.title)

--- a/backend/app/services/mention_parser.py
+++ b/backend/app/services/mention_parser.py
@@ -43,6 +43,7 @@ design-org-knowledge-mentions-backlinks §2.
 """
 from __future__ import annotations
 
+import logging
 import re
 import uuid
 from html.parser import HTMLParser
@@ -55,13 +56,24 @@ from app.models.reference import Reference
 from app.services.member_resolver import canonicalize_member_id
 from app.services.reference_registry import ENTITY_RESOLVERS
 
+logger = logging.getLogger(__name__)
+
 _UUID_RE = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
 
 # FE `applyEntity`(chat-input.tsx) 가 만드는 정확한 토큰: `[title](entity:<type>:<id>) `.
-# title 은 `[...]` 안에 임의 텍스트(escape 없음 — applyEntity 는 asset 경로만 이스케이프한다) ·
 # id 는 UUID. type 그룹을 남겨 향후 story/epic 확장 시 재사용 가능하게 하되, 이번엔 doc 만 필터.
+#
+# ⛔story #2282(PO critical, 2026-07-28): title 안의 `[^\]]*`(그냥 "]가 아닌 문자 반복")는
+# escape 를 전혀 모른다 — title 에 `]`가 들어가면(이 조직의 실제 명명 관례 `[TAG] 제목`이
+# 정확히 이 경우다) **어디서 escape 했든 안 했든** 그 `]`에서 무조건 멈추고, 그 뒤에
+# `(entity:...)`가 바로 안 오면(제목이 이어지므로 안 온다) **매치 자체가 통째로 실패**한다
+# (조용히 0건 추출 — AC4 왕복 실증 중 직접 재현). `(?:[^\]\\]|\\.)*`로 교체: "]나 \가 아닌
+# 문자" 또는 "\+아무문자(escape 시퀀스)"의 반복 — escape된 `\]`는 멈추지 않고 진짜(escape
+# 안 된) `]`에서만 멈춘다. `build_reference_token`(reference_token.py)이 title을
+# backslash-escape하는 것과 **짝**이다 — 한쪽만 고치면(escape만 하고 파서는 그대로) 여전히
+# 안 열린다는 것을 실측으로 확인했다.
 _CHAT_TOKEN_RE = re.compile(
-    r"\[[^\]]*\]\(entity:(?P<type>[a-z]+):(?P<id>" + _UUID_RE + r")\)"
+    r"\[(?:[^\]\\]|\\.)*\]\(entity:(?P<type>[a-z]+):(?P<id>" + _UUID_RE + r")\)"
 )
 
 
@@ -73,7 +85,16 @@ def extract_chat_entity_mentions(content: str) -> list[tuple[str, uuid.UUID]]:
     write-path 호출부가 target_types 로 내린다(추출/저장의 경계를 함수 시그니처로 옮김).
     이 함수를 다시 열어 타입별 분기를 추가하는 일은 이제 없다(그러면 죽은 경로가 재발한다).
 
-    malformed(정규식 미매치·잘못된 UUID)는 자연히 스킵된다."""
+    malformed(정규식 미매치·잘못된 UUID)는 자연히 스킵된다.
+
+    ⛔story #2282(PO 판정, 2026-07-28): "매치 실패가 조용했던 것" 자체가 사고였다 — 예전
+    `_CHAT_TOKEN_RE`가 escape를 몰라 `[TAG] 제목`류(이 조직의 실제 명명 관례)에서 매치가
+    통째로 실패했는데도 아무 신호가 없었다(사람은 picker로 골랐고 화면엔 링크처럼 보이는데
+    데이터엔 아무것도 안 남는 — "실패가 성공처럼 보이는" 최악의 판). 그래서 이 함수는 이제
+    "토큰 모양"(`](entity:`)이 본문에 있는데 실제 추출 건수가 그보다 적으면 경고 로그를
+    남긴다 — 재발해도 조용히 안 넘어가게 하는 최소 감시망(완벽한 검출은 아니다 — 우연히
+    `](entity:`를 포함한 무관한 텍스트가 오탐을 낼 수 있다는 것도 안다, 그래도 "0신호"보다
+    낫다)."""
     if not content:
         return []
     seen: set[tuple[str, uuid.UUID]] = set()
@@ -88,6 +109,13 @@ def extract_chat_entity_mentions(content: str) -> list[tuple[str, uuid.UUID]]:
         if key not in seen:
             seen.add(key)
             result.append(key)
+    shape_count = content.count("](entity:")
+    if len(result) < shape_count:
+        logger.warning(
+            "mention_parser: token-shaped substring count(%d) exceeds extracted count(%d) — "
+            "possible silent parse failure. content_snippet=%r",
+            shape_count, len(result), content[:200],
+        )
     return result
 
 

--- a/backend/app/services/reference_token.py
+++ b/backend/app/services/reference_token.py
@@ -6,14 +6,19 @@ JS/Python 두 군데에 따로 있으면 한쪽이 조용히 뒤처진다(이 �
 동형: 빌드 프로필 플래그·MCP 경로 선언·브랜치 기반·알림 두 소스). 그래서 응답 필드(각 response
 schema의 `reference_token` computed field)와 MCP 도구 설명(AC6) 둘 다 이 함수 하나만 부른다.
 
-⛔AC3 실측(2026-07-28, origin/develop): FE `applyEntity`는 title을 **전혀 escape하지
-않는다** — `` `[${title}](entity:${entityType}:${entityId}) ` `` 리터럴 삽입 그대로다.
-형제 함수 `applyAsset`(파일명 삽입)은 `[ ] ( ) \\`와 개행을 escape하는데(그 함수 자신의
-코멘트: "markdown-link 토큰 구조를 변조 → phishing 링크 렌더 차단") `applyEntity`에는 그
-escape가 없다 — 즉 doc/story/epic **제목에 `]`나 `)`가 들어가면 토큰 구조가 깨질 수 있는
-실제 취약점**이다. 이 함수는 그 부재를 "있는 척" 하지 않고 FE와 **동일하게 escape 없이**
-만든다(AC3이 요구하는 건 parity 검증이지 새 escape 규칙을 여기서 발명하는 게 아니다 — FE도
-같이 고쳐야 하는 별건이라 PO에게 별도 보고했다).
+⛔⭐PO 판정(2026-07-28, critical) — AC3 실측이 «보안 결함»이었다: FE `applyEntity`는 title을
+전혀 escape하지 않는데, 형제 함수 `applyAsset`(파일명 삽입)은 `[ ] ( ) \\`와 개행을
+escape한다(그 함수 자신의 코멘트: "markdown-link 토큰 구조를 변조 → phishing 링크 렌더
+차단"). **한쪽은 위험을 알고 막았는데 다른 쪽은 안 막은 것**이라 — 그 주석 자체가 "이게
+위험하다"는 선언이니 "몰랐다"로 볼 수 없는 자리다. 그리고 실측(2026-07-28): `[TAG] 제목`류
+접두사가 이 조직의 실제 명명 관례라(`[E-ARCH]`·`[E-CONNECT]`·`[C-8]` 등, entities/search
+쿼리 4개가 전부 캡(10건)까지 찬 것으로 확인) — escape 없이 나갔으면 그런 제목 거의 전부가
+첫 배포부터 깨진 토큰을 냈을 것이다.
+
+⇒ 이 함수는 **`applyAsset`과 같은 규칙**으로 title을 escape한다(두 FE 함수끼리도 규칙이
+갈리면 그게 또 다른 비대칭이 되므로, 새 규칙을 발명하지 않고 이미 있는 안전한 규칙을 그대로
+가져온다). FE `applyEntity` 자체의 수정은 별도 스토리(critical, 미르코군 담당)로 분리했다 —
+이 함수(BE 응답이 실제로 내보내는 토큰)는 이 PR에서 즉시 안전해진다.
 
 ⛔FE의 trailing space(`) `)는 텍스트에어리어 삽입 편의(캐럿을 스페이스 뒤에 두는 것)이지
 토큰 자체의 일부가 아니다 — 이 함수가 반환하는 토큰 문자열엔 trailing space가 없다. parity
@@ -21,9 +26,19 @@ escape가 없다 — 즉 doc/story/epic **제목에 `]`나 `)`가 들어가면 �
 """
 from __future__ import annotations
 
+import re
 import uuid
 
 from app.services.reference_registry import is_registered_entity_type
+
+# FE `applyAsset`(chat-input.tsx)과 동일 규칙: `\ [ ] ( )`를 backslash-escape.
+_UNSAFE_CHARS_RE = re.compile(r"[\\\[\]()]")
+_NEWLINE_RUN_RE = re.compile(r"[\r\n]+")
+
+
+def _escape_title(title: str) -> str:
+    escaped = _UNSAFE_CHARS_RE.sub(lambda m: "\\" + m.group(0), title)
+    return _NEWLINE_RUN_RE.sub(" ", escaped)
 
 
 def build_reference_token(entity_type: str, entity_id: uuid.UUID, title: str) -> str | None:
@@ -35,4 +50,4 @@ def build_reference_token(entity_type: str, entity_id: uuid.UUID, title: str) ->
     null — 필드 자체는 항상 존재하되 "지원 안 함"이 값으로 드러난다)."""
     if not is_registered_entity_type(entity_type):
         return None
-    return f"[{title}](entity:{entity_type}:{entity_id})"
+    return f"[{_escape_title(title)}](entity:{entity_type}:{entity_id})"

--- a/backend/app/services/reference_token.py
+++ b/backend/app/services/reference_token.py
@@ -1,0 +1,38 @@
+"""story #2282(E-CONNECT) — 참조 토큰 빌더. 단일 SSOT(AC2).
+
+⛔이 문자열 포맷은 FE `apps/web/src/components/chat/chat-input.tsx`의 `applyEntity`가
+`#`-검색 picker로 엔티티를 선택할 때 만드는 것과 **정확히 같은 것**이어야 한다 — 같은 규칙이
+JS/Python 두 군데에 따로 있으면 한쪽이 조용히 뒤처진다(이 세션 내내 잡은 "쌍둥이 체계" 함정과
+동형: 빌드 프로필 플래그·MCP 경로 선언·브랜치 기반·알림 두 소스). 그래서 응답 필드(각 response
+schema의 `reference_token` computed field)와 MCP 도구 설명(AC6) 둘 다 이 함수 하나만 부른다.
+
+⛔AC3 실측(2026-07-28, origin/develop): FE `applyEntity`는 title을 **전혀 escape하지
+않는다** — `` `[${title}](entity:${entityType}:${entityId}) ` `` 리터럴 삽입 그대로다.
+형제 함수 `applyAsset`(파일명 삽입)은 `[ ] ( ) \\`와 개행을 escape하는데(그 함수 자신의
+코멘트: "markdown-link 토큰 구조를 변조 → phishing 링크 렌더 차단") `applyEntity`에는 그
+escape가 없다 — 즉 doc/story/epic **제목에 `]`나 `)`가 들어가면 토큰 구조가 깨질 수 있는
+실제 취약점**이다. 이 함수는 그 부재를 "있는 척" 하지 않고 FE와 **동일하게 escape 없이**
+만든다(AC3이 요구하는 건 parity 검증이지 새 escape 규칙을 여기서 발명하는 게 아니다 — FE도
+같이 고쳐야 하는 별건이라 PO에게 별도 보고했다).
+
+⛔FE의 trailing space(`) `)는 텍스트에어리어 삽입 편의(캐럿을 스페이스 뒤에 두는 것)이지
+토큰 자체의 일부가 아니다 — 이 함수가 반환하는 토큰 문자열엔 trailing space가 없다. parity
+검증(AC3)은 `[title](entity:type:id)` 몸통에 대해서만 한다.
+"""
+from __future__ import annotations
+
+import uuid
+
+from app.services.reference_registry import is_registered_entity_type
+
+
+def build_reference_token(entity_type: str, entity_id: uuid.UUID, title: str) -> str | None:
+    """이 엔티티를 가리키는 참조 토큰을 만든다.
+
+    AC5: `entity_type`이 `ENTITY_RESOLVERS`(존재판정 가능·현재 doc/story/epic)에 없으면
+    `None`을 반환한다 — 줄 수 없는 것을 준 것처럼 보이면 그게 거짓이다. 호출부(각 response
+    schema의 computed field)는 `None`이면 필드를 그대로 `None`으로 낸다(생략이 아니라 명시적
+    null — 필드 자체는 항상 존재하되 "지원 안 함"이 값으로 드러난다)."""
+    if not is_registered_entity_type(entity_type):
+        return None
+    return f"[{title}](entity:{entity_type}:{entity_id})"

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -318,16 +318,19 @@ async def ping() -> list[TextContent]:
 _TOOL_DEFS: list[tuple] = [
     # Stories (8)
     ("sprintable_list_stories",
-     "[일감] 프로젝트 스토리 목록 조회. project_id/org_id context 자동 주입.",
+     "[일감] 프로젝트 스토리 목록 조회. project_id/org_id context 자동 주입."
+     " 각 항목의 reference_token 필드가 그 스토리를 가리키는 참조 토큰"
+     "([제목](entity:story:id))을 준다 — 채팅 등에 그대로 쓰면 참조가 생긴다(story #2282).",
      ListStoriesInput, list_stories),
     ("sprintable_list_backlog",
      "[일감] 백로그 스토리 목록 (스프린트 미배정).",
      SprintableInput, list_backlog),
     ("sprintable_add_story",
-     "[일감] 스토리 생성.",
+     "[일감] 스토리 생성. 응답 reference_token 필드가 이 스토리를 가리키는 참조 토큰"
+     "([제목](entity:story:id))을 준다 — 채팅 등에 그대로 쓰면 참조가 생긴다(story #2282).",
      AddStoryInput, add_story),
     ("sprintable_update_story",
-     "[일감] 스토리 수정.",
+     "[일감] 스토리 수정. 응답 reference_token은 sprintable_add_story와 동일.",
      UpdateStoryInput, update_story),
     # E-SECURITY SEC-S1: sprintable_delete_story 의도적 제거(에이전트 hard-delete 차단).
     ("sprintable_assign_story_to_sprint",
@@ -363,13 +366,15 @@ _TOOL_DEFS: list[tuple] = [
     # 함수**를 참조하는 deprecated 별칭(hierarchy-rename-alias-mechanism-design §1 — 로직 복제
     # 0, 드리프트 불가). 별칭 유지 기간 동안 무중단 서빙.
     ("sprintable_list_goals",
-     "[일감] 목표 목록 조회.",
+     "[일감] 목표 목록 조회. 각 항목의 reference_token 필드가 그 목표를 가리키는 참조 토큰"
+     "([제목](entity:epic:id))을 준다 — 채팅 등에 그대로 쓰면 참조가 생긴다(story #2282).",
      ListGoalsInput, list_goals),
     ("sprintable_add_goal",
-     "[일감] 목표 생성.",
+     "[일감] 목표 생성. 응답 reference_token 필드가 이 목표를 가리키는 참조 토큰"
+     "([제목](entity:epic:id))을 준다 — 채팅 등에 그대로 쓰면 참조가 생긴다(story #2282).",
      AddGoalInput, add_goal),
     ("sprintable_update_goal",
-     "[일감] 목표 수정.",
+     "[일감] 목표 수정. 응답 reference_token은 sprintable_add_goal과 동일.",
      UpdateGoalInput, update_goal),
     # story #2010: 목표 lifecycle 전이 전용 도구(rename B1 이후 신설이라 구 _epic 별칭 없음 —
     # update_goal의 status 필드는 백엔드가 422로 거부해 이 도구만이 유일한 전이 경로).
@@ -440,19 +445,23 @@ _TOOL_DEFS: list[tuple] = [
      UpdateSprintInput, update_sprint),
     # Docs (5) — E-SECURITY SEC-S1 확장: delete_doc 제거(에이전트 삭제 차단)
     ("sprintable_list_docs",
-     "[지식] 문서 목록 조회 (tree 또는 tag 필터).",
+     "[지식] 문서 목록 조회 (tree 또는 tag 필터). 각 항목의 reference_token 필드가 그 문서를"
+     " 가리키는 참조 토큰([제목](entity:doc:id))을 준다 — 채팅 등에 그대로 쓰면 참조가"
+     " 생긴다(story #2282).",
      ListDocsInput, list_docs),
     ("sprintable_get_doc",
-     "[지식] slug로 문서 단건 조회.",
+     "[지식] slug로 문서 단건 조회. 응답 reference_token 필드가 이 문서를 가리키는 참조 토큰"
+     "([제목](entity:doc:id))을 준다 — 채팅 등에 그대로 쓰면 참조가 생긴다(story #2282).",
      GetDocInput, get_doc),
     ("sprintable_search_docs",
      "[지식] 문서 제목/본문 검색.",
      SearchDocsInput, search_docs),
     ("sprintable_create_doc",
-     "[지식] 문서 생성.",
+     "[지식] 문서 생성. 응답 reference_token 필드가 이 문서를 가리키는 참조 토큰"
+     "([제목](entity:doc:id))을 준다 — 채팅 등에 그대로 쓰면 참조가 생긴다(story #2282).",
      CreateDocInput, create_doc),
     ("sprintable_update_doc",
-     "[지식] 문서 수정.",
+     "[지식] 문서 수정. 응답 reference_token은 sprintable_create_doc과 동일.",
      UpdateDocInput, update_doc),
     # Analytics (11)
     ("sprintable_get_project_overview",

--- a/backend/tests/test_1993_mention_parser.py
+++ b/backend/tests/test_1993_mention_parser.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import uuid
 
+import pytest
+
 from app.services.mention_parser import (
     extract_chat_doc_mention_ids,
     extract_doc_mention_ids,
@@ -72,9 +74,11 @@ def test_extract_chat_requires_title_brackets():
 
 
 def test_extract_chat_title_with_escaped_bracket_still_matches():
-    """⭐핵심 회귀 가드 — `[TAG] 제목`류(이 조직의 실제 명명 관례)가 escape된 채로 와도
-    파싱이 성공해야 한다. 예전 정규식(`[^\\]]*`)은 escape를 몰라 이 케이스에서 통째로
-    매치 실패했다(#2282 발견·재현)."""
+    """⭐핵심 회귀 가드 — 제목에 escape된 `]`가 있어도 파싱이 성공해야 한다(요건은 특정
+    조직의 명명 관례를 받는 게 아니라 "어떤 제목이든 안 깨진다"는 것 — PO 재정정,
+    2026-07-28). 예전 정규식(`[^\\]]*`)은 escape를 몰라 이 케이스에서 통째로 매치
+    실패했다(#2282 발견·재현). `[TAG] 제목`(이 조직에서 실제로 쓰는 형태 하나)은 그
+    일반 요건이 실물에 적용된 사례일 뿐이다."""
     from app.services.mention_parser import extract_chat_entity_mentions
 
     story_id = uuid.uuid4()
@@ -90,6 +94,29 @@ def test_extract_chat_title_with_escaped_paren_and_backslash_still_matches():
     title = r"Report\]\(https://evil.example\)\[Click"
     content = f"[{title}](entity:doc:{doc_id})"
     assert extract_chat_entity_mentions(content) == [("doc", doc_id)]
+
+
+@pytest.mark.parametrize("raw_title", [
+    "🚀 Launch Plan [Q3] 🎯",
+    "Say \"Hello\" and 'Bye'",
+    "日本語のタイトル [テスト] 中文标题 한국어 عربي",
+    "C:\\Users\\test[1]",
+    "[[deep]] nesting ]] test",
+    "제목 — 부제(2024)",
+    "Report](https://evil.example)[Click here",  # `](` 가 제목 «안»에 literal로 등장
+])
+def test_extract_chat_arbitrary_special_char_title_roundtrips(raw_title):
+    """⭐⭐PO 판정(2026-07-28, 선생님 재정정) — 요건은 "우리 조직 관례를 받는다"가 아니라
+    "어떤 제목이든 안 깨진다"다. `build_reference_token`이 만든 escape된 토큰이 이
+    파서로 정확히 다시 파싱되는지 임의 특수문자 조합으로 확認한다(생성-파싱 왕복을
+    파서 쪽에서 직접, 빌더 쪽 테스트와 별도로 재검증)."""
+    from app.services.mention_parser import extract_chat_entity_mentions
+    from app.services.reference_token import build_reference_token
+
+    doc_id = uuid.uuid4()
+    token = build_reference_token("doc", doc_id, raw_title)
+    content = f"메시지: {token} 끝"
+    assert extract_chat_entity_mentions(content) == [("doc", doc_id)], f"title={raw_title!r}"
 
 
 def test_extract_chat_plain_title_without_escapes_still_matches_backward_compat():

--- a/backend/tests/test_1993_mention_parser.py
+++ b/backend/tests/test_1993_mention_parser.py
@@ -68,6 +68,69 @@ def test_extract_chat_requires_title_brackets():
     assert extract_chat_doc_mention_ids(content) == []
 
 
+# ─── story #2282(PO critical) — escape-aware 정규식 (제목 안 `]`가 조기종료 안 함) ────
+
+
+def test_extract_chat_title_with_escaped_bracket_still_matches():
+    """⭐핵심 회귀 가드 — `[TAG] 제목`류(이 조직의 실제 명명 관례)가 escape된 채로 와도
+    파싱이 성공해야 한다. 예전 정규식(`[^\\]]*`)은 escape를 몰라 이 케이스에서 통째로
+    매치 실패했다(#2282 발견·재현)."""
+    from app.services.mention_parser import extract_chat_entity_mentions
+
+    story_id = uuid.uuid4()
+    title = r"\[E-CONNECT\] 참조 토큰을 «만드는 법»을 응답이 알려 준다"
+    content = f"[{title}](entity:story:{story_id})"
+    assert extract_chat_entity_mentions(content) == [("story", story_id)]
+
+
+def test_extract_chat_title_with_escaped_paren_and_backslash_still_matches():
+    from app.services.mention_parser import extract_chat_entity_mentions
+
+    doc_id = uuid.uuid4()
+    title = r"Report\]\(https://evil.example\)\[Click"
+    content = f"[{title}](entity:doc:{doc_id})"
+    assert extract_chat_entity_mentions(content) == [("doc", doc_id)]
+
+
+def test_extract_chat_plain_title_without_escapes_still_matches_backward_compat():
+    """escape-aware로 바꿔도 escape 없는 기존 토큰(대다수 실 데이터)은 그대로 매치돼야
+    한다 — 회귀 0."""
+    doc_id = uuid.uuid4()
+    content = f"[Pricing Policy](entity:doc:{doc_id})"
+    assert extract_chat_doc_mention_ids(content) == [doc_id]
+
+
+# ─── story #2282(PO 판정) — 매치 실패를 조용히 넘기지 않는다(감시망) ──────────
+
+
+def test_extract_chat_warns_on_unparsed_token_shape(caplog):
+    """⭐토큰 «모양»(`](entity:`)이 있는데 실제 추출이 그보다 적으면 경고를 남긴다 — "실패가
+    성공처럼 보이는" 것을 막는 최소 감시망. 일부러 다시 escape-unaware 패턴을 흉내내
+    (실제 매치 실패를 유발할 순 없으니 문자열 자체에 `](entity:`를 여러 번 심어 카운트를
+    올린다) 경고가 뜨는지 확認한다."""
+    import logging
+    from app.services.mention_parser import extract_chat_entity_mentions
+
+    caplog.set_level(logging.WARNING, logger="app.services.mention_parser")
+    doc_id = uuid.uuid4()
+    # 진짜 토큰 1개 + "](entity:" 모양만 흉내낸 잡음 1개 → shape_count(2) > extracted(1).
+    content = f"[Real](entity:doc:{doc_id}) 그리고 이상한 텍스트 ](entity: 어쩌고"
+    result = extract_chat_entity_mentions(content)
+    assert result == [("doc", doc_id)]
+    assert any("possible silent parse failure" in r.message for r in caplog.records)
+
+
+def test_extract_chat_no_warning_when_shapes_all_parsed(caplog):
+    import logging
+    from app.services.mention_parser import extract_chat_entity_mentions
+
+    caplog.set_level(logging.WARNING, logger="app.services.mention_parser")
+    doc_id = uuid.uuid4()
+    content = f"[Real](entity:doc:{doc_id})"
+    extract_chat_entity_mentions(content)
+    assert not any("possible silent parse failure" in r.message for r in caplog.records)
+
+
 # ─── extract_doc_mention_ids (HTMLParser — wikiLink/pageEmbed data-doc-id) ────
 
 

--- a/backend/tests/test_2282_reference_token_builder.py
+++ b/backend/tests/test_2282_reference_token_builder.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
+import pytest
+
 from app.services.reference_token import build_reference_token
 
 
@@ -60,10 +62,14 @@ def test_build_reference_token_matches_fe_applyEntity_format_no_trailing_space()
 def test_build_reference_token_escapes_brackets_matching_fe_applyAsset_rule():
     """⭐PO critical 판정(2026-07-28) — FE `applyEntity`가 title을 escape 안 하는 게 실제
     보안 결함으로 확정됐다(형제 `applyAsset`은 `[ ] ( ) \\`+개행을 escape — 그 코멘트가
-    "phishing 링크 렌더 차단"이라고 명시). 게다가 `[TAG] 제목`류가 이 조직의 실제 명명
-    관례라 예외 입력이 아니라 기본 입력이었다(실측: entities/search 쿼리 4개가 전부 캡까지
-    참). 이 함수는 이제 **applyAsset과 같은 규칙**으로 escape한다 — BE가 만드는 토큰은
-    무조건 안전해진다."""
+    "phishing 링크 렌더 차단"이라고 명시). 이 함수는 이제 **applyAsset과 같은 규칙**으로
+    escape한다 — BE가 만드는 토큰은 무조건 안전해진다.
+
+    ⛔PO 재정정(2026-07-28): "이 조직의 명명 관례가 흔하다"는 «급한 이유»일 뿐 «요건»이
+    아니다 — 요건은 "우리 관례를 받는다"가 아니라 **"어떤 제목이든 안 깨진다"**다. 제목에
+    특정 문자를 쓰지 말라고 하는 것은 제품이 질 일을 사람에게 미루는 것이라 안 하는 길이다.
+    아래 `test_build_reference_token_handles_arbitrary_special_characters`가 그 일반
+    요건을 다룬다 — 이 테스트는 그중 "링크 위장" 시나리오 하나만 남긴다."""
     doc_id = uuid.uuid4()
     dangerous_title = "Report](https://evil.example)[Click"
     token = build_reference_token("doc", doc_id, dangerous_title)
@@ -72,8 +78,9 @@ def test_build_reference_token_escapes_brackets_matching_fe_applyAsset_rule():
 
 
 def test_build_reference_token_escapes_realistic_org_tag_prefix_title():
-    """⭐실측 회귀 가드 — 이 조직의 실제 명명 관례(`[TAG] 제목`, 예: 오늘 만든 #2266/#2284/
-    #2282 스토리 자신도 이 패턴)가 안전한 토큰을 낸다는 것을 실물 사례로 고정한다."""
+    """실측 회귀 가드(참고 사례 하나) — 이 조직에서 실제로 쓰이는 `[TAG] 제목` 형태가
+    안전한 토큰을 낸다는 것을 실물 사례로 고정한다. ⛔단 이건 "이 형태만 지원한다"는
+    뜻이 아니다 — 일반 요건은 아래 파라미터화 테스트가 다룬다."""
     story_id = uuid.uuid4()
     title = "[E-CONNECT] 참조 토큰을 «만드는 법»을 응답이 알려 준다"
     token = build_reference_token("story", story_id, title)
@@ -81,6 +88,32 @@ def test_build_reference_token_escapes_realistic_org_tag_prefix_title():
     # 안쪽 대괄호가 escape됐으니 바깥 [...] 몸통이 첫 `]`에서 조기 종료되지 않는다.
     body_end = token.index("](entity:")
     assert token[1:body_end] == r"\[E-CONNECT\] 참조 토큰을 «만드는 법»을 응답이 알려 준다"
+
+
+@pytest.mark.parametrize("title", [
+    "🚀 Launch Plan [Q3] 🎯",
+    "Say \"Hello\" and 'Bye'",
+    "日本語のタイトル [テスト] 中文标题 한국어 عربي",
+    "C:\\Users\\test[1]",  # title 자체에 이미 backslash가 있는 경우(이중 escape 견고성)
+    "[[deep]] nesting ]] test",
+    "🔥 [TAG] \"quoted\" 日本語 (paren) \\ end — 모든 축 동시",
+    "제목 — 부제(2024)",
+    "Emoji only 😀😃😄",
+])
+def test_build_reference_token_handles_arbitrary_special_characters(title):
+    """⭐⭐PO 판정(2026-07-28, 선생님 지적) — 요건은 «우리 조직 명명 관례를 받는다»가
+    아니라 **«어떤 제목이든 안 깨진다»**다. 다른 조직은 `(2024)`·`제목 — 부제`·이모지·
+    다국어 — 무엇이든 쓴다. 「이 문자는 못 씁니다」가 어디에도 뜨지 않아야 하는 것이
+    요건이지, 특정 조직의 관례를 지원하는 게 요건이 아니다. 이 테스트는 임의의 특수문자
+    조합이 항상 안전하게 escape되고(생성) 항상 다시 파싱되는지(왕복, 파서 쪽은
+    test_1993_mention_parser.py에서 별도로도 재검증) 확認한다."""
+    from app.services.mention_parser import extract_chat_entity_mentions
+
+    entity_id = uuid.uuid4()
+    token = build_reference_token("doc", entity_id, title)
+    assert token is not None
+    parsed = extract_chat_entity_mentions(f"메시지 본문: {token} 뒤에 텍스트")
+    assert parsed == [("doc", entity_id)], f"title={title!r} token={token!r}"
 
 
 def test_build_reference_token_escapes_backslash_and_collapses_newlines():

--- a/backend/tests/test_2282_reference_token_builder.py
+++ b/backend/tests/test_2282_reference_token_builder.py
@@ -2,8 +2,8 @@
 
 AC2(단일 SSOT) — DocResponse/StoryResponse/GoalResponse가 전부 같은
 `build_reference_token`을 재사용하는지, AC5(해석 불가 타입엔 안 줌), AC3(FE `applyEntity`와의
-parity — 이스케이핑 부재까지 그대로 pin)를 다룬다. AC4(왕복 실증)는 realdb 테스트
-(`test_2282_reference_token_roundtrip_realdb.py`) 몫.
+포맷 parity + escape — PO critical 판정으로 `applyAsset`과 동일 escape 규칙을 적용)를
+다룬다. AC4(왕복 실증)는 realdb 테스트(`test_2282_reference_token_roundtrip_realdb.py`) 몫.
 """
 from __future__ import annotations
 
@@ -57,18 +57,39 @@ def test_build_reference_token_matches_fe_applyEntity_format_no_trailing_space()
     assert not token.endswith(" ")
 
 
-def test_build_reference_token_does_not_escape_brackets_matching_fe_gap():
-    """⛔AC3 실측 pin — FE `applyEntity`는 title을 escape하지 않는다(형제 `applyAsset`은
-    한다). 이 함수도 **동일하게 escape 안 함**(있는 척 안 함, parity가 목적) — 제목에
-    `]`가 들어가면 토큰 구조가 깨진다는 것을 이 테스트가 고정한다. ⚠️이건 알려진 gap이지
-    이 함수의 버그가 아니다(#2282 보고 참조 — FE도 같이 고쳐야 하는 별건)."""
+def test_build_reference_token_escapes_brackets_matching_fe_applyAsset_rule():
+    """⭐PO critical 판정(2026-07-28) — FE `applyEntity`가 title을 escape 안 하는 게 실제
+    보안 결함으로 확정됐다(형제 `applyAsset`은 `[ ] ( ) \\`+개행을 escape — 그 코멘트가
+    "phishing 링크 렌더 차단"이라고 명시). 게다가 `[TAG] 제목`류가 이 조직의 실제 명명
+    관례라 예외 입력이 아니라 기본 입력이었다(실측: entities/search 쿼리 4개가 전부 캡까지
+    참). 이 함수는 이제 **applyAsset과 같은 규칙**으로 escape한다 — BE가 만드는 토큰은
+    무조건 안전해진다."""
     doc_id = uuid.uuid4()
     dangerous_title = "Report](https://evil.example)[Click"
     token = build_reference_token("doc", doc_id, dangerous_title)
-    # escape 안 됐다는 것 자체를 pin(문자 그대로 들어감 — \\[ \\] 변환 없음).
-    assert token == f"[{dangerous_title}](entity:doc:{doc_id})"
-    assert "\\]" not in token
-    assert "\\)" not in token
+    expected_escaped = r"Report\]\(https://evil.example\)\[Click"
+    assert token == f"[{expected_escaped}](entity:doc:{doc_id})"
+
+
+def test_build_reference_token_escapes_realistic_org_tag_prefix_title():
+    """⭐실측 회귀 가드 — 이 조직의 실제 명명 관례(`[TAG] 제목`, 예: 오늘 만든 #2266/#2284/
+    #2282 스토리 자신도 이 패턴)가 안전한 토큰을 낸다는 것을 실물 사례로 고정한다."""
+    story_id = uuid.uuid4()
+    title = "[E-CONNECT] 참조 토큰을 «만드는 법»을 응답이 알려 준다"
+    token = build_reference_token("story", story_id, title)
+    assert token == f"[\\[E-CONNECT\\] 참조 토큰을 «만드는 법»을 응답이 알려 준다](entity:story:{story_id})"
+    # 안쪽 대괄호가 escape됐으니 바깥 [...] 몸통이 첫 `]`에서 조기 종료되지 않는다.
+    body_end = token.index("](entity:")
+    assert token[1:body_end] == r"\[E-CONNECT\] 참조 토큰을 «만드는 법»을 응답이 알려 준다"
+
+
+def test_build_reference_token_escapes_backslash_and_collapses_newlines():
+    doc_id = uuid.uuid4()
+    title = "Path\\to\\file\nSecond line\r\nThird"
+    token = build_reference_token("doc", doc_id, title)
+    assert "\\\\" in token  # backslash escaped
+    assert "\n" not in token and "\r" not in token
+    assert token == f"[Path\\\\to\\\\file Second line Third](entity:doc:{doc_id})"
 
 
 # ─── DocResponse/StoryResponse/GoalResponse computed_field — AC1/AC2 ────────

--- a/backend/tests/test_2282_reference_token_builder.py
+++ b/backend/tests/test_2282_reference_token_builder.py
@@ -1,0 +1,152 @@
+"""story #2282(E-CONNECT) — 참조 토큰 builder + response computed_field 순수 단위 테스트.
+
+AC2(단일 SSOT) — DocResponse/StoryResponse/GoalResponse가 전부 같은
+`build_reference_token`을 재사용하는지, AC5(해석 불가 타입엔 안 줌), AC3(FE `applyEntity`와의
+parity — 이스케이핑 부재까지 그대로 pin)를 다룬다. AC4(왕복 실증)는 realdb 테스트
+(`test_2282_reference_token_roundtrip_realdb.py`) 몫.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from app.services.reference_token import build_reference_token
+
+
+# ─── build_reference_token — AC2/AC5 ────────────────────────────────────────
+
+
+def test_build_reference_token_doc():
+    doc_id = uuid.uuid4()
+    assert build_reference_token("doc", doc_id, "Pricing Policy") == (
+        f"[Pricing Policy](entity:doc:{doc_id})"
+    )
+
+
+def test_build_reference_token_story():
+    story_id = uuid.uuid4()
+    assert build_reference_token("story", story_id, "Fix login bug") == (
+        f"[Fix login bug](entity:story:{story_id})"
+    )
+
+
+def test_build_reference_token_epic():
+    epic_id = uuid.uuid4()
+    assert build_reference_token("epic", epic_id, "E-CONNECT") == (
+        f"[E-CONNECT](entity:epic:{epic_id})"
+    )
+
+
+def test_build_reference_token_unregistered_type_returns_none():
+    """⭐AC5 핵심 — task/artifact/hypothesis 등 ENTITY_RESOLVERS 밖 타입엔 토큰을 안 준다
+    (못 주는 것을 준 것처럼 보이면 그게 거짓)."""
+    target_id = uuid.uuid4()
+    for unsupported in ("task", "artifact", "hypothesis", "chat_message", "epic_typo"):
+        assert build_reference_token(unsupported, target_id, "X") is None, unsupported
+
+
+# ─── AC3 — FE applyEntity와의 parity(+이스케이핑 부재를 있는 그대로 pin) ────────
+
+
+def test_build_reference_token_matches_fe_applyEntity_format_no_trailing_space():
+    """FE `chat-input.tsx applyEntity`: `` `[${title}](entity:${type}:${id}) ` `` — trailing
+    space는 textarea 삽입 편의(이 함수의 반환값엔 없다, 모듈 docstring 참조)."""
+    doc_id = uuid.uuid4()
+    token = build_reference_token("doc", doc_id, "X")
+    assert token == f"[X](entity:doc:{doc_id})"
+    assert not token.endswith(" ")
+
+
+def test_build_reference_token_does_not_escape_brackets_matching_fe_gap():
+    """⛔AC3 실측 pin — FE `applyEntity`는 title을 escape하지 않는다(형제 `applyAsset`은
+    한다). 이 함수도 **동일하게 escape 안 함**(있는 척 안 함, parity가 목적) — 제목에
+    `]`가 들어가면 토큰 구조가 깨진다는 것을 이 테스트가 고정한다. ⚠️이건 알려진 gap이지
+    이 함수의 버그가 아니다(#2282 보고 참조 — FE도 같이 고쳐야 하는 별건)."""
+    doc_id = uuid.uuid4()
+    dangerous_title = "Report](https://evil.example)[Click"
+    token = build_reference_token("doc", doc_id, dangerous_title)
+    # escape 안 됐다는 것 자체를 pin(문자 그대로 들어감 — \\[ \\] 변환 없음).
+    assert token == f"[{dangerous_title}](entity:doc:{doc_id})"
+    assert "\\]" not in token
+    assert "\\)" not in token
+
+
+# ─── DocResponse/StoryResponse/GoalResponse computed_field — AC1/AC2 ────────
+
+
+def _doc_kwargs(**overrides):
+    base = dict(
+        id=uuid.uuid4(), project_id=uuid.uuid4(), org_id=uuid.uuid4(), parent_id=None,
+        created_by=None, assignee_id=None, status="draft", superseded_by=None,
+        title="Doc Title", slug="doc-title", canonical_slug="doc-title", slug_locked=False,
+        content="", icon=None, sort_order=0, doc_type="page", content_format="markdown",
+        tags=[], created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
+    )
+    base.update(overrides)
+    return base
+
+
+def test_doc_response_reference_token_computed():
+    from app.schemas.doc import DocResponse
+    kwargs = _doc_kwargs()
+    resp = DocResponse(**kwargs)
+    assert resp.reference_token == f"[Doc Title](entity:doc:{kwargs['id']})"
+
+
+def _story_kwargs(**overrides):
+    base = dict(
+        id=uuid.uuid4(), story_number=1, project_id=uuid.uuid4(), org_id=uuid.uuid4(),
+        title="Story Title", status="backlog", priority="medium",
+        created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
+    )
+    base.update(overrides)
+    return base
+
+
+def test_story_response_reference_token_computed():
+    from app.schemas.story import StoryResponse
+    kwargs = _story_kwargs()
+    resp = StoryResponse(**kwargs)
+    assert resp.reference_token == f"[Story Title](entity:story:{kwargs['id']})"
+
+
+def _goal_kwargs(**overrides):
+    base = dict(
+        id=uuid.uuid4(), project_id=uuid.uuid4(), org_id=uuid.uuid4(), title="Goal Title",
+        status="draft", priority="medium",
+        created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
+    )
+    base.update(overrides)
+    return base
+
+
+def test_goal_response_reference_token_computed_uses_epic_type():
+    """⛔Goal 모델이지만 entity_type 문자열은 registry 기준 "epic"이어야 한다(모델명≠타입
+    리터럴 — reference_registry._resolve_epics가 Goal을 쓰는 것과 동형)."""
+    from app.schemas.goal import GoalResponse
+    kwargs = _goal_kwargs()
+    resp = GoalResponse(**kwargs)
+    assert resp.reference_token == f"[Goal Title](entity:epic:{kwargs['id']})"
+
+
+# ─── AC6 — MCP 도구 설명에 문법이 들어가는지(정적 스캔) ──────────────────────
+
+
+def test_mcp_tool_descriptions_mention_reference_token_syntax():
+    """⭐AC6 pin — create_doc·get_doc·add_story·list_stories(스토리 본문이 명시한 넷) 도구
+    설명에 `entity:` 토큰 문법 언급이 실제로 있는지 소스를 정적으로 훑어 확認한다."""
+    import inspect
+    import sprintable_mcp.server as server_module
+
+    source = inspect.getsource(server_module)
+    # _TOOL_DEFS 리터럴 블록만 보면 충분 — 전체 소스에서 각 도구 이름 뒤 description에
+    # "entity:" 문법이 붙어 있는지를 대략적으로 확인(정확한 파싱보다 정적 포함 여부로 pin).
+    required_tools = [
+        "sprintable_create_doc", "sprintable_get_doc",
+        "sprintable_add_story", "sprintable_list_stories",
+    ]
+    for tool_name in required_tools:
+        idx = source.index(f'"{tool_name}"')
+        # 그 도구 이름 등장 지점부터 다음 500자 안에 문법 힌트가 있는지(느슨하지만 정적 스캔).
+        window = source[idx: idx + 500]
+        assert "entity:" in window, f"{tool_name} 설명에 참조 토큰 문법이 없다"

--- a/backend/tests/test_2282_reference_token_roundtrip_realdb.py
+++ b/backend/tests/test_2282_reference_token_roundtrip_realdb.py
@@ -1,0 +1,194 @@
+"""story #2282(E-CONNECT) AC4 — 왕복 실증: 응답이 준 reference_token을 그대로 채팅에 보내면
+entity_references에 행이 생기고 백링크에 뜬다. "문자열이 그럴듯하다"로 끝내지 않는다(AC4
+자체 문구) — 실제 파서(extract_chat_entity_mentions)로 다시 파싱되는 것까지 증명한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project_member(session):
+    """⛔#2266/#2273의 동명 helper와 달리 write-path 단독 테스트가 아니라 read-path
+    (list_doc_backlinks) authz까지 재는지라 ProjectAccess도 명시 부여한다(test_1994의
+    `_make_human_member`와 동형 — 없으면 캐ller가 project 접근이 없어 backlinks에서
+    조용히 걸러진다, 이번 파일 작성 중 직접 걸린 자리)."""
+    from app.models.organization import Organization
+    from app.models.project import Project, OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+    from app.models.member import Member
+
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.flush()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.flush()
+    om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=user.id, role="member")
+    session.add(om)
+    await session.flush()
+    member = Member(id=om.id, org_id=org.id, type="human", user_id=user.id, name="Test Human")
+    session.add(member)
+    await session.flush()
+    session.add(ProjectAccess(project_id=project.id, org_member_id=om.id, member_id=member.id, role="member"))
+    await session.commit()
+    return org, project, member
+
+
+async def _make_conversation(session, org_id, project_id, member_ids, created_by, conv_type="dm"):
+    from app.models.conversation import Conversation, ConversationParticipant
+    conv = Conversation(
+        id=uuid.uuid4(), project_id=project_id, org_id=org_id, type=conv_type,
+        title="Test convo", created_by=created_by,
+    )
+    session.add(conv)
+    await session.flush()
+    for mid in member_ids:
+        session.add(ConversationParticipant(conversation_id=conv.id, member_id=mid))
+    await session.commit()
+    return conv.id
+
+
+async def _add_message(session, conv_id, sender_id, content):
+    from app.models.conversation import ConversationMessage
+    msg = ConversationMessage(id=uuid.uuid4(), conversation_id=conv_id, sender_id=sender_id, content=content)
+    session.add(msg)
+    await session.commit()
+    return msg
+
+
+@pytest.mark.anyio
+async def test_doc_response_reference_token_roundtrips_through_chat_into_entity_references():
+    """⭐AC4 핵심 — 실 doc의 DocResponse.reference_token을 채팅 content로 그대로 보내면
+    entity_references에 doc-target 행이 생기고, GET /docs/{id}/backlinks에 뜬다."""
+    from app.models.doc import Doc
+    from app.models.reference import Reference
+    from app.schemas.doc import DocResponse
+    from app.services.mention_parser import insert_chat_mentions
+    from sqlalchemy import select
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            other_member = (await _seed_org_project_member(session))[2]
+            doc = Doc(
+                id=uuid.uuid4(), org_id=org.id, project_id=project.id,
+                title="Pricing Policy v2.1", slug=f"pricing-{uuid.uuid4().hex[:8]}", content="",
+            )
+            session.add(doc)
+            await session.commit()
+
+            # 응답이 실제로 주는 값 그대로(모델 검증 우회 없음).
+            doc_response = DocResponse.model_validate(doc)
+            token = doc_response.reference_token
+            assert token == f"[Pricing Policy v2.1](entity:doc:{doc.id})"
+
+            conv_id = await _make_conversation(
+                session, org.id, project.id, [member.id, other_member.id], member.id,
+            )
+            msg = await _add_message(session, conv_id, member.id, f"참고: {token}")
+            await insert_chat_mentions(
+                session, org_id=org.id, message_id=msg.id, content=msg.content,
+                created_by=member.id,
+            )
+            await session.commit()
+
+            rows = (await session.execute(
+                select(Reference).where(Reference.source_id == msg.id)
+            )).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].target_type == "doc"
+            assert rows[0].target_id == doc.id
+            assert rows[0].form == "mention"
+
+            from app.services.backlinks import list_doc_backlinks
+            from app.dependencies.auth import AuthContext
+            auth = AuthContext(user_id=str(member.user_id), email="human@test", claims={})
+            result = await list_doc_backlinks(
+                session, org_id=org.id, doc_id=doc.id, auth=auth, limit=30, cursor=None,
+            )
+            assert any(item["source_id"] == str(msg.id) for item in result["data"])
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_story_response_reference_token_roundtrips_through_chat():
+    """AC4 story 반쪽 — story의 reference_token도 왕복이 실제로 되는지(#2266 story-backlinks
+    경로까지)."""
+    from app.models.pm import Story
+    from app.models.reference import Reference
+    from app.schemas.story import StoryResponse
+    from app.services.mention_parser import insert_chat_mentions
+    from sqlalchemy import select
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            story = Story(
+                id=uuid.uuid4(), org_id=org.id, project_id=project.id,
+                title="Fix login bug", status="backlog",
+            )
+            session.add(story)
+            await session.commit()
+
+            story_response = StoryResponse.model_validate(story)
+            token = story_response.reference_token
+            assert token == f"[Fix login bug](entity:story:{story.id})"
+
+            message_id = uuid.uuid4()
+            await insert_chat_mentions(
+                session, org_id=org.id, message_id=message_id, content=f"보는 중: {token}",
+                created_by=member.id,
+            )
+            await session.commit()
+
+            rows = (await session.execute(
+                select(Reference).where(Reference.source_id == message_id)
+            )).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].target_type == "story"
+            assert rows[0].target_id == story.id
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2282_reference_token_roundtrip_realdb.py
+++ b/backend/tests/test_2282_reference_token_roundtrip_realdb.py
@@ -192,3 +192,52 @@ async def test_story_response_reference_token_roundtrips_through_chat():
             assert rows[0].target_id == story.id
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_bracket_prefixed_title_reference_token_roundtrips_through_chat():
+    """⭐⭐이 세션의 핵심 발견 — 「[TAG] 제목」류(이 조직의 실제 명명 관례, 오늘 만든
+    #2266/#2284/#2282 스토리 자신도 이 패턴)가 실제로 채팅을 왕복해 entity_references에
+    등록되는지 실증한다. 이 테스트가 예전 `_CHAT_TOKEN_RE`(escape-unaware)였다면 RED였을
+    것 — PARSED: []로 재현된 그 버그를 직접 잡는 회귀 가드."""
+    from app.models.pm import Story
+    from app.models.reference import Reference
+    from app.schemas.story import StoryResponse
+    from app.services.mention_parser import insert_chat_mentions
+    from sqlalchemy import select
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            story = Story(
+                id=uuid.uuid4(), org_id=org.id, project_id=project.id,
+                title="[E-CONNECT] 참조 토큰을 «만드는 법»을 응답이 알려 준다"
+                " — ⛔포맷이 FE에 하나뿐이라 BE가 따로 만들면 쌍둥이가 된다",
+                status="backlog",
+            )
+            session.add(story)
+            await session.commit()
+
+            story_response = StoryResponse.model_validate(story)
+            token = story_response.reference_token
+            assert token is not None
+            assert "\\[E-CONNECT\\]" in token  # escape 확인
+
+            message_id = uuid.uuid4()
+            await insert_chat_mentions(
+                session, org_id=org.id, message_id=message_id, content=f"참고: {token}",
+                created_by=member.id,
+            )
+            await session.commit()
+
+            rows = (await session.execute(
+                select(Reference).where(Reference.source_id == message_id)
+            )).scalars().all()
+            assert len(rows) == 1, (
+                f"[TAG] 제목 토큰이 왕복하지 않았다(#2282 발견 버그 회귀) — rows={rows}"
+            )
+            assert rows[0].target_type == "story"
+            assert rows[0].target_id == story.id
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 배경
PO가 오늘 이 결손에 두 번 걸렸다: ①슬러그를 채팅에 타이핑 → 안 잡힘(정상, `#`는 picker
트리거일 뿐) ②완성 토큰(`[title](entity:doc:uuid)`)을 API로 직접 박음 → **정상 작동**(디디·
유나가 각각 backlinks로 확認). 기능은 처음부터 됐다 — **문법을 배울 자리가 어디에도 없었을
뿐**(MCP 도구 설명 0·응답 0·문서 0). 이 제품의 전제는 "읽는 쪽에도 쓰는 쪽에도 에이전트가
있다"인데 연결을 만드는 문법이 사실상 사람(화면 picker) 전용이었다.

## 진짜 무게 — 「어디서 만드느냐」
포맷 문자열(`f"[{title}](entity:{type}:{id})"`)은 기계적으로 한 줄이지만, 지금 FE
(`chat-input.tsx applyEntity`)에 **단 하나만** 존재한다. BE가 각 응답 serializer마다 따로
만들면 같은 규칙이 JS/Python 두 군데에 중복돼 한쪽이 조용히 뒤처진다 — 이 세션 내내 잡은
"쌍둥이 체계" 함정과 동형.

## 구현
- `app/services/reference_token.py::build_reference_token(entity_type, id, title)` 신설
  (AC2 단일 SSOT). `ENTITY_RESOLVERS`(doc/story/epic) 밖 타입은 `None`(AC5 — 못 주는 걸
  준 것처럼 안 보임).
- `DocResponse`/`StoryResponse`/`GoalResponse`에 `reference_token`을 `@computed_field`로
  추가 — id/title에서 매 직렬화 시 자동 계산되므로 create/get/update 등 어느 호출부도
  빠뜨릴 수 없다(AC2를 스키마 레벨에서 강제).
- MCP 도구 설명(create_doc/get_doc/update_doc/list_docs, add_story/update_story/
  list_stories, add_goal/update_goal/list_goals)에 토큰 문법 명시(AC6).

## ⛔⛔자체 발견 — 실제 보안+기능 결함(PO critical 판정) — «에픽 전제를 흔드는» 재정의 포함

**①escape 부재 = 실제 취약점.** FE `applyEntity`는 title을 전혀 escape하지 않는다. 형제
함수 `applyAsset`(파일명 삽입)은 `[ ] ( ) \`와 개행을 escape하는데(그 함수 자신의 코멘트:
"markdown-link 토큰 구조를 변조 → phishing 링크 렌더 차단") `applyEntity`엔 그 escape가
없다 — 한쪽은 위험을 알고 막았는데 다른 쪽은 안 막은 형제 비대칭. 그 주석 자체가 "이게
위험하다"는 선언이라 "몰랐다"로 볼 수 없는 자리다. `build_reference_token`은 이제
`applyAsset`과 **같은 규칙**으로 title을 escape한다(두 규칙이 갈리면 그게 또 다른 비대칭이
되므로 새 규칙을 발명하지 않았다). FE `applyEntity` 자체의 수정은 별도(critical) 스토리로
PO가 미르코군에게 분리 배정했다.

**②escape만으로는 AC4(왕복 파싱)가 안 채워졌다 — 더 큰 발견.** `mention_parser.py`의
`_CHAT_TOKEN_RE`가 `[^\]]*`(escape를 전혀 모르는 패턴)라, escape를 하든 안 하든 title의
첫 `]`에서 무조건 멈추고 그 뒤에 `(entity:...)`가 바로 안 오면(제목이 이어지므로 안 온다)
**매치가 통째로 실패**했다(재현: `PARSED: []`). `(?:[^\]\\]|\\.)*`로 교체(escape된 `\]`는
안 멈추고 진짜 `]`에서만 멈춤) — 실물 `[E-CONNECT] 제목`으로 재검증해 정상 왕복 확認.

**③⭐재정의 — 이건 #2282가 만든 버그가 아니라 #1993(원 채팅 멘션 기능)부터 있던 기존
버그다.** `[TAG] 제목`류(이 조직의 실제 명명 관례 — `entities/search` 실측: `]`·`(`·`)`·`[`
쿼리 4개가 전부 캡(10건)까지 참, 오늘 만든 #2266/#2284/#2282 스토리 자신도 이 패턴)는
escape 여부와 무관하게 **처음부터 파서에 안 잡혔다** — #2282가 escape를 넣으려다 우연히
처음 드러낸 것뿐이다. 즉 **오늘까지 화면 picker로 그런 제목의 엔티티를 골라도 조용히
참조가 안 생기고 있었다.**

⛔단 **"얼마나가 그 탓인지"는 못 잰다** — 조용히 실패했으므로 시도한 기록 자체가 없다.
"전부 버그 탓"도 "전부 습관 탓"도 말할 수 없다. 말할 수 있는 것은 "관례 제목은 골라도
안 됐다" 하나뿐이다. 넘겨짚지 않는다 — 대신 ④의 경고 로그가 지금부터 실측을 쌓는다.

**④매치 실패를 조용히 넘기지 않는 감시망.** `extract_chat_entity_mentions`가 토큰 "모양"
(`](entity:`)이 본문에 있는데 실제 추출이 그보다 적으면 경고 로그를 남긴다 — RED(사보타주)
상태에서 이 경고가 실제로 발화하는 것까지 확認했다(감시망을 만들고 그 감시망이 사는지도
쟀다).

**⑤⭐요건 재정정(선생님 지적) — "우리 조직 관례"는 급한 이유였을 뿐 요건이 아니었다.**
처음엔 "`[TAG] 제목`이 이 조직의 실제 명명 관례라 급하다"로 근거를 댔는데, 그 논리를
따라가면 다음 발이 "관례를 바꾸자"가 될 뻔했다. 요건은 "우리 관례를 받는다"가 아니라
**"어떤 제목이든 안 깨진다"**다 — 다른 조직은 `(2024)`·`제목 — 부제`·이모지·다국어 등
무엇이든 쓴다. "이 문자는 못 씁니다"로 가는 것은 제품이 질 일을 사람에게 미루는 것이라
그 길은 안 갔다. 코드는 이미 일반적이었다(조직별 특수 처리 없음) — 테스트만 좁았어서
넓혔다: 이모지·따옴표·다국어(한/중/일/아랍)·기존 backslash가 title에 있는 경우(이중
escape 견고성)·중첩 대괄호·`](` 가 title **안**에 literal로 등장(미르코군이 실 데이터
0건 확인한 케이스, 원리적으로는 여전히 다뤄야 함) 등 15종을 파라미터화 테스트로 추가.

## 검증
- pure-unit 20개: builder(doc/story/epic/미등록타입 None)·FE parity·applyAsset과 동일
  escape 규칙·escape-aware 정규식·경고 로그 발화 여부·**임의 특수문자 8종 파라미터화**·
  3개 response schema의 computed_field·MCP 도구 설명 정적 스캔(AC6).
- 파서 쪽 별도 35개(`test_1993_mention_parser.py`): 위와 같은 특수문자 집합을 파서에서
  직접 재검증(생성-파싱 왕복, 빌더 테스트와 독립).
- realdb 5개(AC4 왕복 실증, 그중 1개는 실물 `[E-CONNECT] 제목`): 실제 Doc/Story의
  `*Response.reference_token`을 그대로 채팅 content로 보내 `entity_references` 행 생성 +
  `list_doc_backlinks` 노출까지 확인("문자열이 그럴듯하다"로 끝내지 않음).
- RED→GREEN 자체검증 2건: AC5 게이트(미등록 타입 → None) + escape-aware 정규식(원복 시
  실물 제목 테스트 RED + 경고 로그 발화 확認).
- 회귀: doc/story/goal/backlinks/mention/MCP 카탈로그 관련 스위트 157개 GREEN.

## 롤백
`app/services/reference_token.py` 삭제 + 3개 schema 파일의 `reference_token` computed_field
제거 + `sprintable_mcp/server.py`의 설명 문자열 원복 + `mention_parser.py`의 `_CHAT_TOKEN_RE`
정규식만 되돌리면(escape 인식 제거) #1993 이후 원래 동작으로 복귀. 신규 코드가 순수
additive(기존 응답 필드 변경 없음)라 부분 revert도 안전.
