### PR TITLE
[SID:2292][보안·critical] applyEntity가 제목을 escape 안 하던 것 정정 — 형제 applyAsset과 규칙 통일

### DIFF
--- a/apps/web/src/components/chat/chat-input.entity-token-escape.test.ts
+++ b/apps/web/src/components/chat/chat-input.entity-token-escape.test.ts
@@ -1,0 +1,73 @@
+/**
+ * story #2292(보안·critical) — `applyEntity`가 title을 escape 안 해 형제 `applyAsset`과
+ * 어긋나 있던 것(phishing 링크 렌더 결함). 두 함수가 같은 escape 규칙(`escapeMarkdownLinkText`)
+ * 하나를 공유하는지, 그리고 escape가 실제로 위험 문자를 막는지를 고정한다.
+ */
+import { describe, expect, it } from 'vitest';
+import { applyAsset, applyEntity, escapeMarkdownLinkText } from './chat-input';
+
+describe('escapeMarkdownLinkText — AC2: 깨지는 입력 고정', () => {
+  it('] ) [ ( \\ 를 백슬래시로 escape한다', () => {
+    expect(escapeMarkdownLinkText('a]b)c[d(e\\f')).toBe('a\\]b\\)c\\[d\\(e\\\\f');
+  });
+
+  it('개행을 공백으로 바꾼다', () => {
+    expect(escapeMarkdownLinkText('line1\nline2\r\nline3')).toBe('line1 line2 line3');
+  });
+
+  it('위험 문자가 없는 일반 제목은 그대로 둔다', () => {
+    expect(escapeMarkdownLinkText('평범한 스토리 제목')).toBe('평범한 스토리 제목');
+  });
+});
+
+describe('applyEntity — AC1: applyAsset과 같은 규칙을 쓴다(형제 비대칭 해소)', () => {
+  it('⛔phishing 재현 입력 — 제목에 ](url)[ 을 심어도 링크 구조가 안 깨진다', () => {
+    // 이 입력이 escape 없이 그대로 조립됐다면: `[x](https://phish.example)[y](entity:story:id) `
+    // 처럼 렌더되어 «전혀 다른 외부 링크»가 본문에 심겼을 것이다(스토리 본문 그대로 재현).
+    const malicious = 'x](https://phish.example)[y';
+    const { text } = applyEntity('#', 1, malicious, 'story', '11111111-1111-1111-1111-111111111111');
+    expect(text).toBe(
+      '[x\\]\\(https://phish.example\\)\\[y](entity:story:11111111-1111-1111-1111-111111111111) ',
+    );
+    // escape된 결과에는 "](https://phish.example)[" 가 이스케이프 안 된 형태로 존재하지 않는다.
+    expect(text).not.toContain('x](https://phish.example)[y');
+  });
+
+  it('applyAsset과 완전히 같은 escape 결과를 낸다(공유 규칙 — 형제 비대칭 없음)', () => {
+    const dangerousName = 'a]b)c[d(e\\f\ng';
+    const entityResult = applyEntity('#', 1, dangerousName, 'doc', '22222222-2222-2222-2222-222222222222');
+    const assetResult = applyAsset('', 0, dangerousName, '33333333-3333-3333-3333-333333333333');
+    const entityTitle = entityResult.text.match(/^\[(.*?)\]\(entity:doc:/)?.[1];
+    const assetTitle = assetResult.text.match(/^\[(.*?)\]\(entity:asset:/)?.[1];
+    expect(entityTitle).toBe(assetTitle);
+  });
+
+  it('일반 제목(위험 문자 없음)은 기존과 동일하게 동작한다(회귀 없음)', () => {
+    const { text, caretPos } = applyEntity('#', 1, '평범한 제목', 'story', '11111111-1111-1111-1111-111111111111');
+    expect(text).toBe('[평범한 제목](entity:story:11111111-1111-1111-1111-111111111111) ');
+    expect(caretPos).toBe(text.length);
+  });
+});
+
+describe('AC5: escape 뒤에도 토큰이 다시 파싱된다(왕복 확認 — 막느라 못 쓰게 만들지 않는다)', () => {
+  it('escape된 토큰에서 href(entity:type:id)를 그대로 추출할 수 있다(chat-bubble.tsx 파서와 동일 정규식)', () => {
+    const malicious = 'x](evil)[y';
+    const { text } = applyEntity('#', 1, malicious, 'story', '11111111-1111-1111-1111-111111111111');
+    // chat-bubble.tsx의 실제 href 추출 정규식(entity:(\w+):(uuid)) 그대로 재사용해 검증.
+    const hrefMatch = text.match(/\(entity:(\w+):([0-9a-f-]{36})\)/i);
+    expect(hrefMatch?.[1]).toBe('story');
+    expect(hrefMatch?.[2]).toBe('11111111-1111-1111-1111-111111111111');
+  });
+
+  it('markdown 링크 문법 자체가 정확히 하나의 [text](url) 쌍으로 닫힌다(구문 안 끊김)', () => {
+    const malicious = 'a](b)[c(d)e\\f';
+    const { text } = applyEntity('#', 1, malicious, 'epic', '44444444-4444-4444-4444-444444444444');
+    // 정확히 하나의 최상위 markdown 링크만 존재해야 한다 — remark가 이걸 여러 링크로 쪼개면
+    // escape가 실패한 것이다. 링크 전체를 감싸는 대괄호/괄호 짝이 이스케이프되지 않은 채
+    // 남아있지 않은지 확인(즉 unescaped ] 또는 ) 가 href 앞에 나타나지 않아야 한다).
+    const beforeHref = text.slice(0, text.indexOf('](entity:'));
+    // beforeHref 안의 모든 ] 와 ( 와 ) 는 반드시 백슬래시가 앞에 붙어 있어야 한다(이스케이프됨).
+    const unescapedBracket = /(?<!\\)[\])]/.test(beforeHref.slice(1)); // 맨 앞 '[' 제외하고 검사
+    expect(unescapedBracket).toBe(false);
+  });
+});

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -51,7 +51,15 @@ function getEntityQuery(value: string, cursorPos: number): string | null {
   return m ? m[1] : null;
 }
 
-function applyEntity(
+// story #2292(보안·critical) — 링크 텍스트(markdown `[text](url)`의 text 부분) escape.
+// `[ ] ( ) \` 와 개행이 markdown-link 토큰 구조를 변조(예 `x](https://phish)[y` → 외부
+// phishing 링크 렌더)하는 걸 차단한다. ⛔형제 함수(applyEntity·applyAsset)가 이 상수 하나를
+// 공유해야 한다 — 각자 자기 정규식을 들고 있으면 그게 바로 오늘 반복된 「형제 비대칭」이다.
+export function escapeMarkdownLinkText(text: string): string {
+  return text.replace(/[\\[\]()]/g, '\\$&').replace(/[\r\n]+/g, ' ');
+}
+
+export function applyEntity(
   value: string,
   cursorPos: number,
   title: string,
@@ -62,21 +70,23 @@ function applyEntity(
   const m = before.match(/#([\w가-힣]*)$/);
   if (!m) return { text: value, caretPos: cursorPos };
   const start = cursorPos - m[0].length;
-  const replacement = `[${title}](entity:${entityType}:${entityId}) `;
+  // story #2292: title은 story/doc/epic/task 검색결과 — 자유 텍스트라 escape 필수(형제
+  // applyAsset은 이미 하고 있었다. 여기만 빠져 있던 것이 발견된 결함).
+  const safeTitle = escapeMarkdownLinkText(title);
+  const replacement = `[${safeTitle}](entity:${entityType}:${entityId}) `;
   return { text: value.slice(0, start) + replacement + value.slice(cursorPos), caretPos: start + replacement.length };
 }
 
 
 // S6: 스토리지 자산 선택 → 토큰 삽입. applyEntity 미러(트리거 문자 없이 caret 위치에 삽입).
 // 토큰 형식 정확히 `[${name}](entity:asset:${id}) ` (chat-bubble 의 entity:asset 렌더 경로와 정합).
-function applyAsset(
+export function applyAsset(
   value: string,
   cursorPos: number,
   name: string,
   assetId: string,
 ): { text: string; caretPos: number } {
-  // 파일명 escape — `[ ] ( ) \` 와 개행이 markdown-link 토큰 구조를 변조(예 `x](https://phish)[y` → 외부 phishing 링크 렌더)하는 걸 차단.
-  const safeName = name.replace(/[\\[\]()]/g, '\\$&').replace(/[\r\n]+/g, ' ');
+  const safeName = escapeMarkdownLinkText(name);
   const replacement = `[${safeName}](entity:asset:${assetId}) `;
   return { text: value.slice(0, cursorPos) + replacement + value.slice(cursorPos), caretPos: cursorPos + replacement.length };
 }


### PR DESCRIPTION
## 발견 (디디, #2282 작업 중)

참조 토큰(`[제목](entity:종류:uuid)`)을 조립하는 FE 함수가 둘 있었는데 한쪽만 escape했다:

- `applyAsset` → `[ ] ( ) \` + 개행을 escape. 주석에 **"phishing 링크 렌더 차단"**이라고 이유까지 명시.
- `applyEntity` → 아무것도 안 함.

한쪽은 위험을 알고 막았는데 다른 쪽은 안 막았다 — 그 주석이 곧 "이것이 위험하다"는 선언이라 "몰랐다"로 볼 수 없는 자리다. story/doc/epic/task 제목(자유 텍스트)에 `]`나 `)`가 있으면 마크다운 링크 구문이 끊기고 뒤 텍스트가 다른 링크로 렌더될 수 있다 — **제목을 짓는 것만으로 본문에 임의 링크를 심을 수 있는** 결함.

## AC1 — 무엇을 고쳤는가

```diff
+ function escapeMarkdownLinkText(text: string): string {
+   return text.replace(/[\\[\]()]/g, '\\$&').replace(/[\r\n]+/g, ' ');
+ }

  function applyEntity(...) {
-   const replacement = `[${title}](entity:${entityType}:${entityId}) `;
+   const safeTitle = escapeMarkdownLinkText(title);
+   const replacement = `[${safeTitle}](entity:${entityType}:${entityId}) `;
  }

  function applyAsset(...) {
-   const safeName = name.replace(/[\\[\]()]/g, '\\$&').replace(/[\r\n]+/g, ' ');
+   const safeName = escapeMarkdownLinkText(name);
  }
```

두 함수가 **같은 함수 하나**를 공유한다 — 규칙이 갈리면 그게 또 형제 비대칭이라 각자 정규식을 두지 않았다.

## AC2 — mutation-verified

`escapeMarkdownLinkText` 호출을 제거하고 3개 테스트가 정확히 RED가 되는 것을 확認 → 재적용 → GREEN. phishing 재현 입력(`x](https://phish.example)[y`)으로 실제 결함을 그대로 재현하는 테스트를 포함한다.

## AC3 — 전수(census)

⚠️ org 전체 DB에 직접 접근할 수 없어(Cloud SQL private-IP, 로컬에서 VPC 도달 불가 확認) API 샘플링으로 대체:

| 대상 | 샘플 크기 | `]`·`)` 단독 포함 | 실제 구문파괴 `](` 포함 | 제목 내 URL 포함 |
|---|---|---|---|---|
| story | 1000건(list_backlog 상한) | 650건(주로 팀 `[TAG]` 표기 관례) | **0건** | **0건** |
| doc | 500건 | — | **0건** | **0건** |
| epic | 226건 | — | **0건** | **0건** |

⇒ 취약점은 실재했으나(위 phishing 재현 테스트가 증명) **이 샘플(총 1726건)에서 실제 악용 흔적은 없다.**

⚠️**이 결과는 우리 조직(moonklabs) 표본에 한정된다** — 「지금 이 데이터에 없다」와 「(다른 조직 포함) 앞으로도 없다」를 섞지 않는다. 다른 조직은 제목 관례가 다를 수 있고, 이 취약점은 조직·데이터와 무관하게 코드 자체의 결함이었다(그래서 애초에 데이터 유무와 상관없이 고쳤다) — 위 census는 「이번 사고의 실제 피해 규모」를 추정하기 위한 것이지 「고칠 필요가 있었는지」의 근거가 아니다. ⛔**그러면 앞으로 생기는지는 누가 아는가** — 직접 확認했다: `StoryCreate`/`DocCreate` 스키마(`backend/app/schemas/story.py`·`doc.py`)의 `title` 필드엔 길이 제한도 문자 검증도 `field_validator`도 없다. **거부도 안 하고 로그도 안 남는다 — 지금은 새로 생겨도 아무도 모른다.** 이건 이 PR의 범위가 아니라 별도 스토리 감이다(제목 생성 시점 감시/거부 여부는 기획 판단 필요).

## AC5 — 왕복 확認(막느라 못 쓰게 만들지 않음)

`chat-bubble.tsx`가 실제로 쓰는 href 추출 정규식(`entity:(\w+):([0-9a-f-]{36})`)을 그대로 재사용해, escape된 토큰에서도 entity type/id가 정확히 재추출되는 것을 확認했다.

## AC6 — 같은 클래스 스윕

`chat-input.tsx`의 토큰 조립 함수 4개(`applyMention`·`applyEntity`·`applyAsset`·`applyCommand`) 전수:
- `applyMention`: 입력 자체가 `getMentionQuery`의 정규식(`[\w가-힣]*`)으로 제한돼 위험 문자를 원천적으로 못 받는다 — 안전.
- `applyCommand`: 큐레이션된 고정 목록(`COMMAND_SUGGESTIONS`)만 받는다 — 사용자 자유 입력이 아니다 — 안전.
- `applyAsset`: 이미 escape하고 있었다.
- `applyEntity`: **유일하게 자유 텍스트(title)를 받으면서 escape가 빠져 있던 자리.**

## AC4에 대해

BE `build_reference_token`은 #2282(디디)에서 escape가 착지된다 — 지금은 대조 대상 자체가 없어 그 PR 머지 후 별도로 대조한다.

## 검증
- 신규 8케이스 전부 GREEN, mutation-verified.
- 전체 FE vitest 스윕: 295 파일 · 1963 테스트 전부 PASS(회귀 없음).
- `tsc --noEmit` 무오류, `eslint` 무경고.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

