### PR TITLE
feat(push): Expo 발송 성공도 로그에 남긴다 (#2289 관측성 갭)

### DIFF
--- a/backend/ee/services/expo_push.py
+++ b/backend/ee/services/expo_push.py
@@ -161,6 +161,8 @@ async def deliver_expo_push(
         ]
 
         dead_tokens: list[str] = []
+        ok_count = 0
+        error_count = 0
         for i in range(0, len(messages), _EXPO_MAX_BATCH):
             chunk = messages[i : i + _EXPO_MAX_BATCH]
             chunk_devices = devices[i : i + _EXPO_MAX_BATCH]
@@ -168,9 +170,19 @@ async def deliver_expo_push(
             # ticket 은 메시지와 동순서. 개수 불일치(부분 응답) 시 zip 이 짧은 쪽 기준(안전).
             for dev, ticket in zip(chunk_devices, tickets):
                 if isinstance(ticket, dict) and ticket.get("status") == "error":
+                    error_count += 1
                     err = (ticket.get("details") or {}).get("error")
                     if err == "DeviceNotRegistered":
                         dead_tokens.append(dev.expo_push_token)
+                elif isinstance(ticket, dict) and ticket.get("status") == "ok":
+                    ok_count += 1
+
+        # 2026-07-28(#2289): 성공 티켓은 이전까지 어디에도 안 남아 "서버가 쐈는데 실패" vs
+        # "서버가 아예 안 쐈다"를 로그만으로 못 갈랐다(둘 다 조용함) — 매 발송마다 요약을 남긴다.
+        logger.info(
+            "expo push: sent org=%s event=%s devices=%d ok=%d error=%d",
+            org_id, event_type, len(devices), ok_count, error_count,
+        )
 
         if dead_tokens:
             await db.execute(


### PR DESCRIPTION
## 무엇
`deliver_expo_push()`가 Expo Push API 성공 티켓(status:"ok")도 요약 로그로 남기게 한다.

## 왜 (#2289 조사 중 발견)
FCM 토큰 발급 실패(GCP API key allowlist 갭 — 별도 PR/조치로 이미 고침)를 조사하며 이 함수를
읽었는데, 성공 경로엔 로그가 **전혀 없었다**. 실패만 `logger.warning`/`logger.info`(dead-token
정리)로 찍힌다. 그래서 사람이 알림을 못 받았을 때 "서버가 쐈는데 전달 단계에서 유실"과
"서버가 애초에 시도조차 안 함"을 로그만으로 구분할 방법이 없었다 — 둘 다 조용하다.

## 고침
배치 루프가 끝날 때마다 `org_id`·`event_type`·대상 device 수·ok/error 수를 `logger.info`로
남긴다. 기존 실패 로그(`logger.warning` 등)와 동선 안에서 최소 추가 — 발송 로직/재시도/
best-effort 스왈로 정책은 전혀 안 건드림.

## 검증
`python3 -m ast` 문법 확認. 이 함수 자체의 단위테스트는 못 찾음(있으면 리뷰에서 알려주면
붙이겠음) — 순수 로깅 추가라 동작 변경 없음.