### PR TITLE
feat(push): 발송 실패 로그에 사유도 남긴다 (#2289 후속)

### DIFF
--- a/backend/ee/services/expo_push.py
+++ b/backend/ee/services/expo_push.py
@@ -163,6 +163,7 @@ async def deliver_expo_push(
         dead_tokens: list[str] = []
         ok_count = 0
         error_count = 0
+        error_reasons: dict[str, int] = {}
         for i in range(0, len(messages), _EXPO_MAX_BATCH):
             chunk = messages[i : i + _EXPO_MAX_BATCH]
             chunk_devices = devices[i : i + _EXPO_MAX_BATCH]
@@ -171,7 +172,8 @@ async def deliver_expo_push(
             for dev, ticket in zip(chunk_devices, tickets):
                 if isinstance(ticket, dict) and ticket.get("status") == "error":
                     error_count += 1
-                    err = (ticket.get("details") or {}).get("error")
+                    err = (ticket.get("details") or {}).get("error") or ticket.get("message") or "unknown"
+                    error_reasons[err] = error_reasons.get(err, 0) + 1
                     if err == "DeviceNotRegistered":
                         dead_tokens.append(dev.expo_push_token)
                 elif isinstance(ticket, dict) and ticket.get("status") == "ok":
@@ -179,9 +181,11 @@ async def deliver_expo_push(
 
         # 2026-07-28(#2289): 성공 티켓은 이전까지 어디에도 안 남아 "서버가 쐈는데 실패" vs
         # "서버가 아예 안 쐈다"를 로그만으로 못 갈랐다(둘 다 조용함) — 매 발송마다 요약을 남긴다.
+        # error_reasons는 Expo의 고정 에러 코드(DeviceNotRegistered·InvalidCredentials 등)만
+        # 담는다 — 토큰 값은 절대 안 남긴다(시크릿에 준하는 취급).
         logger.info(
-            "expo push: sent org=%s event=%s devices=%d ok=%d error=%d",
-            org_id, event_type, len(devices), ok_count, error_count,
+            "expo push: sent org=%s event=%s devices=%d ok=%d error=%d reasons=%s",
+            org_id, event_type, len(devices), ok_count, error_count, error_reasons or None,
         )
 
         if dead_tokens:


### PR DESCRIPTION
## 무엇
#2578(발송 성공/실패 요약 로그)의 후속 — error ticket의 `details.error`(Expo 고정 에러 코드:
DeviceNotRegistered·InvalidCredentials 등)를 집계해 요약 로그에 같이 남긴다.

## 왜
`ok=/error=` 카운트만으로는 "몇 건 실패했는지"까지만 알 수 있고 "왜 실패했는지"는 몰랐다.
PO 지적: ok=0 error=N일 때 자격 문제(InvalidCredentials)인지 죽은 토큰(DeviceNotRegistered)인지
갈라야 다음 판(receipt/FCM 층 vs 자격 재점검)이 정해진다.

## 고침
`error_reasons: dict[str, int]`로 에러 코드별 건수를 집계, 요약 로그 끝에 `reasons=` 필드로 추가.
토큰 값은 여전히 로그에 안 남는다.

## 검증
`python3 -m ast` 문법 확認. 순수 로깅 추가라 동작 변경 없음.