### PR TITLE
fix(ci): destructive-schema 94개 4-way 샤딩 + alembic-fresh-db 중복 제거 (#2293)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,22 @@ jobs:
     # #2372(미르코군, FE only — ko/en.json+goals tsx, 마이그레이션 파일 0개)까지 20m13s에
     # 걸려 "재시도로 넘김"이 마이그레이션 무관 PR에도 세금이 되는 게 실측됐다 — 응급으로
     # 25분 상향(근본 스위트 분할은 #2081 AC2/AC3 후속).
+    #
+    # ⭐story #2293(2026-07-28) — 왜 이 job이 pytest를 안 도는지(AC1):
+    # 이 job은 한때 `backend-test`(아래)와 **byte-identical한 pytest 3스텝**(alembic upgrade
+    # heads + non-destructive real-DB pytest + destructive-schema 94개 파일 격리순회)을
+    # 중복으로 돌리고 있었다 — story #1982/8236bbc3(2026-07-17)가 backend-test의 realDB
+    # 커버리지 갭을 닫으며 이 job의 2단계 구조를 "재사용"했는데, 그 뒤 이 job 쪽 pytest
+    # 스텝을 접는 후속 정리가 없었다. 직접 대조(까심군, 2026-07-28) 결과 커맨드 문자열까지
+    # 동일 — "create_all vs migration" 같은 스키마 구성 방식의 분기는 애초에 없었다(둘 다
+    # `alembic upgrade heads`). PR #2576이 이 job에서 destructive 94개 중 77개까지 pass하고
+    # 25분 천장에 cancelled된 사고(#2293)를 계기로, 아래 4스텝(마이그레이션 경로 자체의
+    # 무결성 검증 — baseline parity·dual-head 수렴·existing-DB no-op)만 남기고 pytest 실행은
+    # **`backend-test`가 유일한 실행처**가 되도록 걷어냈다. destructive-schema 94개는 이제
+    # backend-test 쪽에서 샤딩(`backend-test-destructive`, 4-way)으로 처리한다.
+    # ⛔이 job 이름(`Alembic upgrade head (fresh DB)`)은 develop 필수 상태 체크 문자열이라
+    # **바꾸지 않았다** — 바꿨으면 branch protection이 이름 매칭 실패로 조용히 안 걸렸을
+    # 것(파울로군 실측·경고, 2026-07-28).
     timeout-minutes: 25
 
     services:
@@ -90,16 +106,6 @@ jobs:
           test "$(P "SELECT count(*) FROM pg_constraint WHERE conname='ck_asset_links_source_type'")" = "1"
           echo "baseline parity OK: team_members=VIEW, org_member_id nullable, seed present, 0097 applied, asset registry present, REVISION=0096"
 
-      # story 8236bbc3: 기존 "account resolve/switch"(1개 파일)·"asset registry"(13개 파일)
-      # 하드코딩 리스트 2스텝을 흡수 — real-DB 게이팅(ALEMBIC_DATABASE_URL/PARITY_TEST_DATABASE_URL)
-      # 전체(파일명 무관, destructive_schema 마커 제외 84개 파일)가 자기 skipif로 자동 활성화된다.
-      # 신규 real-DB 테스트 파일은 이 스텝에 아무것도 안 해도 자동 편입(누락 원천차단).
-      # test_member_ssot_parity_realdb.py는 파일 자체 무조건 skip(post-cutover 불일치 — 파일
-      # 상단 주석·design-ci-realdb-gap-8236bbc3 §1 참고).
-      - name: Real-DB tests (non-destructive, auto-discovered via marker)
-        working-directory: backend
-        run: uv run pytest -q -m "not destructive_schema"
-
       # story bda4beac: dual-head(core+ee_pricing) checkout에서 "current == 단일 head" 비교는
       # 항상 실패한다(current가 2행이라 head=1건과 부분일치 안 됨) — 두 head 집합이 정확히
       # 일치하는지(comm -3, 차집합 0행) 비교로 교체. 단일-head 컨텍스트(main)에서도 그대로
@@ -126,44 +132,6 @@ jobs:
             echo "FAIL: migrations re-ran on a DB already at heads (existing-DB path not a no-op)"; exit 1
           fi
           echo "OK: existing-DB upgrade heads is a no-op"
-
-      # story 8236bbc3: destructive_schema 마커 파일(Base.metadata.create_all/drop_all로 자체
-      # 스키마 직접 관리)은 위 alembic-migrated 공유 DB(sprintable_test)에서 절대 실행하지
-      # 않는다 — 실측(design doc §1-C): 단 1개 파일의 drop_all()이 DROP TABLE
-      # agent_project_profiles→ForeignKeyViolationError로 DB를 오염시키고 같은 세션 후속
-      # 테스트 전부가 연쇄 실패(116건). 파일마다 독립 throwaway DB(sprintable_test_iso)로
-      # 완전 격리 — sprintable_test는 절대 건드리지 않는다.
-      - name: Real-DB tests (destructive schema — isolated fresh DB per file)
-        working-directory: backend
-        run: |
-          set -uo pipefail
-          # ⭐set -e를 여기선 안 쓴다(로컬 e2e 시뮬레이션 실측 교훈, 2026-07-03) — 파일별
-          # 루프에서 첫 실패 파일이 스크립트를 즉시 죽이면 나머지 파일은 전혀 실행되지 않고
-          # 조용히 스킵된 것과 동일한 결과가 된다(이 스토리가 막으려는 바로 그 실패 유형).
-          # 전체 파일을 끝까지 돌리고 실패를 누적, 마지막에 하나라도 있으면 exit 1.
-          mapfile -t files < <(
-            uv run pytest -q -m destructive_schema --collect-only \
-              | grep -oE '^tests/[a-zA-Z0-9_]+\.py' | sort -u
-          )
-          echo "destructive files: ${#files[@]}"
-          failed_files=()
-          for f in "${files[@]}"; do
-            echo "::group::isolated $f"
-            PGPASSWORD=sprintable dropdb -h localhost -U sprintable --if-exists sprintable_test_iso
-            PGPASSWORD=sprintable createdb -h localhost -U sprintable sprintable_test_iso
-            PGPASSWORD=sprintable psql -h localhost -U sprintable -d sprintable_test_iso \
-              -c 'CREATE EXTENSION IF NOT EXISTS vector;'
-            ALEMBIC_DATABASE_URL=postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test_iso \
-            PARITY_TEST_DATABASE_URL=postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test_iso \
-            DATABASE_URL=postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test_iso \
-            uv run pytest -q "$f" || failed_files+=("$f")
-            echo "::endgroup::"
-          done
-          if [ "${#failed_files[@]}" -gt 0 ]; then
-            echo "FAILED files: ${failed_files[*]}"
-            exit 1
-          fi
-          echo "OK: all ${#files[@]} isolated destructive-schema files passed"
 
   # story bda4beac: alembic-fresh-db(위)는 checkout된 브랜치(develop/PR)의 파일셋 기준이라
   # main이 develop과 다른 파일셋(ee_pricing 0146/0147 부재)일 때의 그래프 단절을 원천적으로
@@ -238,29 +206,32 @@ jobs:
         working-directory: backend
         run: uv run alembic upgrade heads
 
-  backend-test:
-    name: Backend pytest
+  # story #2293(2026-07-28) — destructive_schema 94개 파일 순차 격리 루프(파일마다 fresh
+  # throwaway DB 생성/드롭)가 25분 천장에 붙었다(PR #2576 conclusion=cancelled, 77/94까지
+  # 전부 pass하고 시간만 모자라 잘림 — 빨간 것은 0건). 개별 테스트는 안 느리다(2026-07-28
+  # 실측 최대 16.24초, `infra/destructive-schema-shard-weights.json`) — 파일마다 붙는
+  # dropdb/createdb/CREATE EXTENSION 오버헤드가 94번 누적된 것이 벽시계 대부분이었다.
+  # `backend/scripts/shard_destructive_tests.py`가 그 오버헤드를 4-way로 병렬화한다
+  # (`test_shard_destructive_tests.py::test_partition_is_lossless_for_any_input`이 무손실을
+  # 고정 — 파일이 조용히 안 도는 샤드 경계 실패를 막는다).
+  #
+  # ⛔이 job은 develop 필수 상태 체크가 아니다(파울로군 실측, 2026-07-28: 필수 체크는
+  # "Backend pytest"·"Lint, Type Check, Test, Build"·"Alembic upgrade head (fresh DB)" 셋
+  # 뿐). 그래서 `backend-test`(아래, 필수)가 `needs:`로 이 job에 의존하고, 이 job의 샤드가
+  # 하나라도 실패하면 `backend-test`가 그 사실을 스스로 감지해 명시적으로 fail한다(GitHub의
+  # 기본 skip 전파에 기대지 않는다 — "유일한 실행처가 조용히 안 돌면 아무도 모른다"는
+  # 지적에 대한 답).
+  backend-test-destructive:
+    name: Backend destructive-schema (shard)
     runs-on: ubuntu-latest
-    # story #1982(2026-07-17): postgres service + real-PG env 배선. 이 갭은 story #1472
-    # (2026-06-21)에서 이미 발견됐고, story 8236bbc3(#1619, 2026-07-03)이 "backend-test job
-    # 무변경(회귀0 최대보수)"으로 의도적으로 유보했던 트레이드오프다 — 그 결과 `_REAL_DB_SKIP`
-    # 마커 테스트(예: test_1974_gate_assigned_to_me.py의 realdb 3건)가 이 job에서 조용히 skip
-    # 되어 CI green이 realPG 왕복 거동을 실제로 보증하지 못했다. 여기서 alembic-fresh-db job과
-    # 동일 자격증명·동일 2단계 구조(non-destructive 공유 DB + destructive_schema 격리 순회)를
-    # 재사용해 닫는다. destructive_schema 마커 테스트를 이 postgres 위에서 격리 없이 평면
-    # `pytest`로 돌리면 파일마다 붙는 autouse 스키마-리셋 fixture(tests/conftest.py:84,
-    # DROP SCHEMA public CASCADE)가 공유 alembic-migrated 스키마를 오염시켜 story 8236bbc3가
-    # 문서화한 116건 연쇄 실패를 이 job에서도 재현하므로, 단일 평면 실행이 아니라 반드시
-    # 동일한 2단계 분리 구조가 필요하다(217초 실측 + 격리 순회 버퍼 — alembic-fresh-db와 동일
-    # timeout-minutes: 20으로 상향).
-    # ⚠️story #2081 응급 상향(2026-07-21): alembic-fresh-db와 동일 destructive_schema 스위트를
-    # 도는 job이라 같은 20m 캡 위험을 공유한다 — 대칭으로 25분 상향(근본은 #2081 AC2/AC3 후속).
     timeout-minutes: 25
+    strategy:
+      fail-fast: false  # 한 샤드 실패가 다른 샤드를 취소하면 "어디까지 진짜 돌았는지"가 흐려진다
+      matrix:
+        shard: [0, 1, 2, 3]
 
     services:
       postgres:
-        # pgvector image: the baseline schema declares `CREATE EXTENSION vector` (embeddings),
-        # which the stock postgres:16 image lacks. Cloud SQL (dev/prod) has pgvector available.
         image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: sprintable
@@ -290,32 +261,27 @@ jobs:
         with:
           version: 'latest'
 
-      # non-destructive real-PG 테스트(84개 파일, destructive_schema 마커 제외)는 alembic-migrated
-      # 스키마(view·nullable·seed 포함 baseline)에 의존한다 — alembic-fresh-db job과 동일하게
-      # fresh DB를 먼저 heads까지 올린다(그렇지 않으면 테이블 부재로 realdb 테스트가 실패한다).
-      - name: alembic upgrade heads (fresh DB → baseline)
+      - name: Determine this shard's file list
         working-directory: backend
-        run: uv run alembic upgrade heads
+        run: |
+          uv run python scripts/shard_destructive_tests.py \
+            --shard-index ${{ matrix.shard }} --shard-count 4 --print-summary \
+            > /tmp/shard_files.txt
+          echo "이 샤드(${{ matrix.shard }}) 파일 수: $(wc -l < /tmp/shard_files.txt)"
 
-      - name: Run pytest (non-destructive, real-PG auto-discovered via marker)
-        working-directory: backend
-        run: uv run pytest -q -m "not destructive_schema"
-
-      # destructive_schema 마커 파일(Base.metadata.create_all/drop_all로 자체 스키마 직접 관리)은
-      # 위 alembic-migrated 공유 DB(sprintable_test)에서 절대 실행하지 않는다 — story 8236bbc3
-      # 실측대로 drop_all()이 DB를 오염시켜 같은 세션 후속 테스트 전부를 연쇄 실패시킬 수 있다.
-      # 파일마다 독립 throwaway DB(sprintable_test_iso)로 완전 격리한다.
-      - name: Run pytest (destructive schema — isolated fresh DB per file)
+      # story 8236bbc3: destructive_schema 마커 파일(Base.metadata.create_all/drop_all로 자체
+      # 스키마 직접 관리)은 alembic-migrated 공유 DB에서 절대 실행하지 않는다 — 실측대로
+      # drop_all()이 DB를 오염시켜 같은 세션 후속 테스트 전부를 연쇄 실패시킬 수 있다.
+      # 파일마다 독립 throwaway DB(sprintable_test_iso)로 완전 격리한다(샤딩 전과 동일 원칙 —
+      # 바뀐 것은 «몇 개를 도는가»이지 «어떻게 격리하는가»가 아니다).
+      - name: Run pytest (destructive schema — isolated fresh DB per file, this shard)
         working-directory: backend
         run: |
           set -uo pipefail
-          # set -e를 여기선 안 쓴다(alembic-fresh-db job과 동일 이유) — 첫 실패 파일이 스크립트를
-          # 즉시 죽이면 나머지 파일은 조용히 미실행된 것과 동일한 결과가 된다.
-          mapfile -t files < <(
-            uv run pytest -q -m destructive_schema --collect-only \
-              | grep -oE '^tests/[a-zA-Z0-9_]+\.py' | sort -u
-          )
-          echo "destructive files: ${#files[@]}"
+          # set -e를 여기선 안 쓴다 — 첫 실패 파일이 스크립트를 즉시 죽이면 이 샤드의 나머지
+          # 파일은 조용히 미실행된 것과 동일한 결과가 된다(#2293이 막으려는 바로 그 실패 유형).
+          mapfile -t files < /tmp/shard_files.txt
+          echo "destructive files (shard ${{ matrix.shard }}): ${#files[@]}"
           failed_files=()
           for f in "${files[@]}"; do
             echo "::group::isolated $f"
@@ -333,7 +299,78 @@ jobs:
             echo "FAILED files: ${failed_files[*]}"
             exit 1
           fi
-          echo "OK: all ${#files[@]} isolated destructive-schema files passed"
+          echo "OK: all ${#files[@]} isolated destructive-schema files passed (shard ${{ matrix.shard }})"
+
+  backend-test:
+    name: Backend pytest
+    runs-on: ubuntu-latest
+    needs: [backend-test-destructive]
+    if: always()
+    # story #1982(2026-07-17): postgres service + real-PG env 배선. 이 갭은 story #1472
+    # (2026-06-21)에서 이미 발견됐고, story 8236bbc3(#1619, 2026-07-03)이 "backend-test job
+    # 무변경(회귀0 최대보수)"으로 의도적으로 유보했던 트레이드오프다 — 그 결과 `_REAL_DB_SKIP`
+    # 마커 테스트(예: test_1974_gate_assigned_to_me.py의 realdb 3건)가 이 job에서 조용히 skip
+    # 되어 CI green이 realPG 왕복 거동을 실제로 보증하지 못했다. non-destructive real-DB
+    # 커버리지는 이 job이 직접 돈다(공유 alembic-migrated 스키마 위 — 격리 불요).
+    #
+    # ⭐story #2293(2026-07-28): destructive_schema 94개는 더는 이 job이 직접 돌지 않는다
+    # (AC1 — alembic-fresh-db와 byte-identical 중복이었다·아래 backend-test-destructive로
+    # 이관). 이 job은 develop 필수 상태 체크(이름 "Backend pytest")라 **이름을 바꾸지
+    # 않았다** — `needs: [backend-test-destructive]` + `if: always()` + 아래 첫 스텝의 명시적
+    # exit 1로, 94개 중 하나라도 실패/샤드가 안 돌면 이 필수 체크 자체가 빨개지게 만든다
+    # (GitHub의 기본 `needs`-실패-시-skip에만 기대면 "필수 체크가 skipped로 조용히 안
+    # 걸리는" 위험이 있다 — 파울로군 지적).
+    timeout-minutes: 25
+
+    services:
+      postgres:
+        # pgvector image: the baseline schema declares `CREATE EXTENSION vector` (embeddings),
+        # which the stock postgres:16 image lacks. Cloud SQL (dev/prod) has pgvector available.
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: sprintable
+          POSTGRES_PASSWORD: sprintable
+          POSTGRES_DB: sprintable_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      ALEMBIC_DATABASE_URL: postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test
+      PARITY_TEST_DATABASE_URL: postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test
+      DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
+      JWT_SECRET: ci-test-secret-at-least-32-chars-long
+      SECRET_KEY: ci-test-secret-at-least-32-chars-long
+
+    steps:
+      - name: Require all destructive-schema shards to have succeeded
+        if: needs.backend-test-destructive.result != 'success'
+        run: |
+          echo "backend-test-destructive result=${{ needs.backend-test-destructive.result }} — destructive-schema 94개의 유일한 실행처가 실패했거나 안 돎"
+          exit 1
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: 'latest'
+
+      # non-destructive real-PG 테스트(84개 파일, destructive_schema 마커 제외)는 alembic-migrated
+      # 스키마(view·nullable·seed 포함 baseline)에 의존한다 — fresh DB를 먼저 heads까지 올린다
+      # (그렇지 않으면 테이블 부재로 realdb 테스트가 실패한다).
+      - name: alembic upgrade heads (fresh DB → baseline)
+        working-directory: backend
+        run: uv run alembic upgrade heads
+
+      - name: Run pytest (non-destructive, real-PG auto-discovered via marker)
+        working-directory: backend
+        run: uv run pytest -q -m "not destructive_schema"
 
   ci:
     name: Lint, Type Check, Test, Build

--- a/backend/scripts/shard_destructive_tests.py
+++ b/backend/scripts/shard_destructive_tests.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""story #2293 — destructive_schema 94개 파일을 CI 매트릭스 샤드로 나눈다.
+
+왜: 순차 94개(파일마다 독립 fresh DB 생성/드롭 — story 8236bbc3)가 25분 천장에 붙었다
+(PR #2576 conclusion=cancelled, 77/94까지 진행하고 잘림 — 실패는 0건, 시간만 모자랐다).
+개별 테스트는 안 느리다(2026-07-28 실측 최대 16.24초, `infra/destructive-schema-shard-
+weights.json` 참고) — 파일마다 붙는 dropdb/createdb/CREATE EXTENSION 오버헤드가 94번
+누적된 것이 벽시계의 대부분이다. 샤딩은 그 오버헤드를 병렬로 나눈다.
+
+`infra/destructive-schema-shard-weights.json`(2026-07-28 스냅샷, 파일별 pytest 실행초)을
+greedy LPT(Longest Processing Time first)로 읽어 균형 배분한다. 스냅샷에 없는 새 파일은
+평균 가중치를 받는다 — ⛔discover(`pytest --collect-only`)가 항상 SSOT다. 스냅샷은 가중치
+힌트일 뿐이라 새 파일이 스냅샷에 없다는 이유로 빠지는 일은 없다(파일 목록은 매번 실제
+컬렉션에서 뽑고, 가중치만 스냅샷+평균값으로 보강한다).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_DIR = REPO_ROOT / "backend"
+WEIGHTS_PATH = REPO_ROOT / "infra" / "destructive-schema-shard-weights.json"
+
+_FILE_RE = re.compile(r"^tests/[a-zA-Z0-9_]+\.py")
+
+
+def discover_files(backend_dir: Path = BACKEND_DIR) -> list[str]:
+    """⚠️`--collect-only` 출력은 `tests/test_x.py::test_name` 형태(테스트 노드 단위)다 —
+    ci.yml의 기존 bash 루프와 동일하게 파일 경로만 앞에서 추출한다(전체 라인이 파일명과
+    같아야 한다는 순진한 가정을 했다가 처음엔 0건으로 깨졌다 — 실측 후 정정)."""
+    out = subprocess.run(
+        ["uv", "run", "pytest", "-q", "-m", "destructive_schema", "--collect-only"],
+        cwd=backend_dir, capture_output=True, text=True, check=True,
+    ).stdout
+    files = sorted({
+        m.group(0) for line in out.splitlines()
+        if (m := _FILE_RE.match(line.strip()))
+    })
+    return files
+
+
+def load_weights(weights_path: Path = WEIGHTS_PATH) -> dict[str, float]:
+    if not weights_path.exists():
+        return {}
+    data = json.loads(weights_path.read_text())
+    return {e["file"]: float(e["sec"]) for e in data.get("files", [])}
+
+
+def partition(files: list[str], weights: dict[str, float], shard_count: int) -> tuple[list[list[str]], list[float]]:
+    """greedy LPT — 무거운 순으로 정렬해 매번 «지금 가장 가벼운 샤드」에 넣는다.
+    ⭐이 함수는 무손실이다(모든 파일이 정확히 하나의 샤드에 들어간다) —
+    test_shard_destructive_tests.py::test_partition_is_lossless_for_any_input이 이걸 고정한다."""
+    if shard_count < 1:
+        raise ValueError("shard_count must be >= 1")
+    avg = (sum(weights.values()) / len(weights)) if weights else 1.0
+    ordered = sorted(files, key=lambda f: weights.get(f, avg), reverse=True)
+    shards: list[list[str]] = [[] for _ in range(shard_count)]
+    totals = [0.0] * shard_count
+    for f in ordered:
+        i = totals.index(min(totals))
+        shards[i].append(f)
+        totals[i] += weights.get(f, avg)
+    return shards, totals
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--shard-index", type=int, required=True)
+    ap.add_argument("--shard-count", type=int, required=True)
+    ap.add_argument("--print-summary", action="store_true", help="전체 샤드 분배를 stderr에 찍는다")
+    args = ap.parse_args()
+    if not (0 <= args.shard_index < args.shard_count):
+        print(f"shard-index {args.shard_index}가 shard-count {args.shard_count} 범위 밖", file=sys.stderr)
+        return 2
+
+    files = discover_files()
+    weights = load_weights()
+    shards, totals = partition(files, weights, args.shard_count)
+
+    if args.print_summary:
+        print(f"discovered {len(files)} destructive_schema files total (discover가 SSOT)", file=sys.stderr)
+        for i, (s, t) in enumerate(zip(shards, totals)):
+            print(f"  shard {i}: {len(s)} files, ~{t:.1f}s(weighted estimate)", file=sys.stderr)
+        assigned = sum(len(s) for s in shards)
+        print(f"  합계: {assigned}/{len(files)} 배정(무손실 확인)", file=sys.stderr)
+
+    for f in shards[args.shard_index]:
+        print(f)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_shard_destructive_tests.py
+++ b/backend/tests/test_shard_destructive_tests.py
@@ -1,0 +1,94 @@
+"""story #2293 — backend/scripts/shard_destructive_tests.py 회귀가드.
+
+핵심 불변식: partition()은 «무손실»이어야 한다 — 입력으로 준 파일 전체가 정확히 하나의
+샤드에 들어가야 한다(누락도 중복도 없이). 이게 깨지면 어떤 파일은 CI에서 «한 번도 안 도는»
+상태가 되는데, 94개 순차 루프와 달리 매트릭스 샤드 사이에는 사람이 눈으로 훑을 로그가
+하나로 안 모이므로 조용히 새는 실패가 훨씬 위험하다.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = _REPO_ROOT / "backend" / "scripts" / "shard_destructive_tests.py"
+_WEIGHTS_PATH = _REPO_ROOT / "infra" / "destructive-schema-shard-weights.json"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("shard_destructive_tests", _SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fake_files(n: int) -> list[str]:
+    return [f"tests/test_fake_{i:03d}.py" for i in range(n)]
+
+
+@pytest.mark.parametrize("n_files,n_shards", [
+    (94, 4),   # 실제 규모
+    (1, 1),
+    (1, 4),    # 샤드 수가 파일 수보다 많음 — 빈 샤드가 생겨도 손실은 없어야 한다
+    (5, 3),    # 안 나누어떨어지는 흔한 경우
+    (0, 4),    # 파일이 0개(향후 destructive_schema 마커가 전부 없어지는 극단)
+])
+def test_partition_is_lossless_for_any_input(n_files, n_shards):
+    mod = _load()
+    files = _fake_files(n_files)
+    shards, totals = mod.partition(files, weights={}, shard_count=n_shards)
+    assert len(shards) == n_shards
+    assert len(totals) == n_shards
+    union = [f for s in shards for f in s]
+    assert sorted(union) == sorted(files), "샤드 합집합이 원본 파일 목록과 정확히 같아야 한다"
+    assert len(union) == len(set(union)), "같은 파일이 두 샤드에 중복 배정되면 안 된다"
+
+
+def test_unknown_files_get_average_weight_not_dropped():
+    """가중치 스냅샷에 없는 새 파일도 discover만 되면 반드시 어딘가의 샤드에 들어간다."""
+    mod = _load()
+    files = ["tests/test_known_heavy.py", "tests/test_brand_new_unweighted.py"]
+    weights = {"tests/test_known_heavy.py": 20.0}
+    shards, totals = mod.partition(files, weights, shard_count=2)
+    union = [f for s in shards for f in s]
+    assert "tests/test_brand_new_unweighted.py" in union
+
+
+def test_partition_balances_heavy_files_across_shards():
+    """무거운 파일 여러 개가 한 샤드에 몰리지 않고 갈라져야 한다(그래야 병렬화 값이 있다)."""
+    mod = _load()
+    files = [f"tests/test_heavy_{i}.py" for i in range(4)]
+    weights = {f: 100.0 for f in files}  # 전부 동일하게 무거움
+    shards, totals = mod.partition(files, weights, shard_count=4)
+    assert all(len(s) == 1 for s in shards), "동일 가중치 4개·샤드 4개면 1:1로 갈려야 한다"
+
+
+def test_load_weights_missing_file_returns_empty(tmp_path):
+    mod = _load()
+    missing = tmp_path / "nope.json"
+    assert mod.load_weights(missing) == {}
+
+
+def test_load_weights_reads_repo_snapshot_shape():
+    mod = _load()
+    weights = mod.load_weights(_WEIGHTS_PATH)
+    assert len(weights) > 0
+    assert all(isinstance(v, float) for v in weights.values())
+
+
+def test_repo_weights_file_is_wellformed():
+    """저장소에 실제로 커밋된 스냅샷(infra/destructive-schema-shard-weights.json)이 형식을
+    지키는지 — total_files/total_sec가 files 배열과 실제로 맞아떨어지는지."""
+    data = json.loads(_WEIGHTS_PATH.read_text())
+    assert data["total_files"] == len(data["files"])
+    assert abs(data["total_sec"] - sum(e["sec"] for e in data["files"])) < 0.5
+    assert len(data["files"]) == len({e["file"] for e in data["files"]}), "중복 파일 항목 없어야 함"
+
+
+def test_shard_index_out_of_range_is_rejected():
+    mod = _load()
+    with pytest.raises(ValueError):
+        mod.partition(["a"], {}, shard_count=0)

--- a/backend/tests/test_zzz_2293_intentional_red_demo.py
+++ b/backend/tests/test_zzz_2293_intentional_red_demo.py
@@ -1,8 +1,0 @@
-"""story #2293 AC4 실증용 — 일부러 실패하는 destructive_schema 테스트.
-⛔이 파일은 CI 레드 증거를 남긴 뒤 즉시 삭제한다(영구 파일 아님)."""
-import pytest
-
-
-@pytest.mark.destructive_schema
-def test_intentional_failure_for_2293_ac4_demo():
-    assert False, "story #2293 AC4 — 일부러 심은 실패, 곧 원복함"

--- a/backend/tests/test_zzz_2293_intentional_red_demo.py
+++ b/backend/tests/test_zzz_2293_intentional_red_demo.py
@@ -1,0 +1,8 @@
+"""story #2293 AC4 실증용 — 일부러 실패하는 destructive_schema 테스트.
+⛔이 파일은 CI 레드 증거를 남긴 뒤 즉시 삭제한다(영구 파일 아님)."""
+import pytest
+
+
+@pytest.mark.destructive_schema
+def test_intentional_failure_for_2293_ac4_demo():
+    assert False, "story #2293 AC4 — 일부러 심은 실패, 곧 원복함"

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1,0 +1,384 @@
+{
+  "source_run": 30360717358,
+  "measured_at": "2026-07-28",
+  "total_files": 94,
+  "total_sec": 534.7,
+  "files": [
+    {
+      "file": "tests/test_2161_agent_run_reaper.py",
+      "sec": 16.24
+    },
+    {
+      "file": "tests/test_edg_s9_parallel_quorum.py",
+      "sec": 13.1
+    },
+    {
+      "file": "tests/test_edg_s18_runtime_mode.py",
+      "sec": 11.19
+    },
+    {
+      "file": "tests/test_2054_gate_inbox.py",
+      "sec": 10.72
+    },
+    {
+      "file": "tests/test_2043_ac3_hitl_reason_enforce.py",
+      "sec": 10.7
+    },
+    {
+      "file": "tests/test_a2a_sa3_link_gate_to_task_realdb.py",
+      "sec": 10.61
+    },
+    {
+      "file": "tests/test_e_recruit_s5_connection_artifact_realdb.py",
+      "sec": 10.6
+    },
+    {
+      "file": "tests/test_edg_s14_role_resolver.py",
+      "sec": 10.49
+    },
+    {
+      "file": "tests/test_1970_gate_single_get.py",
+      "sec": 10.24
+    },
+    {
+      "file": "tests/test_1972_gate_risk_grade.py",
+      "sec": 10.14
+    },
+    {
+      "file": "tests/test_2172_assignee_position_events.py",
+      "sec": 9.82
+    },
+    {
+      "file": "tests/test_a2a_sa5_auth_required_realdb.py",
+      "sec": 9.73
+    },
+    {
+      "file": "tests/test_2038_hypothesis_outcome_result_enforce.py",
+      "sec": 9.62
+    },
+    {
+      "file": "tests/test_2181_mockup_model_db_drift.py",
+      "sec": 9.55
+    },
+    {
+      "file": "tests/test_project_relay_owner.py",
+      "sec": 9.32
+    },
+    {
+      "file": "tests/test_e_recruit_s3_recruit_service_realdb.py",
+      "sec": 8.7
+    },
+    {
+      "file": "tests/test_1974_gate_assigned_to_me.py",
+      "sec": 8.59
+    },
+    {
+      "file": "tests/test_2131_bulk_status_changed_sse_realdb.py",
+      "sec": 8.49
+    },
+    {
+      "file": "tests/test_a2a_sa1_deadline_sweeper_realdb.py",
+      "sec": 8.28
+    },
+    {
+      "file": "tests/test_1973_gate_urgency_sort.py",
+      "sec": 7.89
+    },
+    {
+      "file": "tests/test_2027_gate_approval_reason_enforce.py",
+      "sec": 7.76
+    },
+    {
+      "file": "tests/test_e_loop_ledger_s26_context_pack_synthesis.py",
+      "sec": 7.64
+    },
+    {
+      "file": "tests/test_2039_project_slug_ascii.py",
+      "sec": 7.24
+    },
+    {
+      "file": "tests/test_edg_s13_sla_processor.py",
+      "sec": 7.11
+    },
+    {
+      "file": "tests/test_edg_s32_reassign.py",
+      "sec": 7.02
+    },
+    {
+      "file": "tests/test_edg_s7_handoff_relay.py",
+      "sec": 6.78
+    },
+    {
+      "file": "tests/test_2201_sse_backfill_degraded_signal_realdb.py",
+      "sec": 6.75
+    },
+    {
+      "file": "tests/test_edg_s3_engine.py",
+      "sec": 6.68
+    },
+    {
+      "file": "tests/test_edg_s4_resolver.py",
+      "sec": 6.66
+    },
+    {
+      "file": "tests/test_2082_artifact_canonicalize_gate_inbox.py",
+      "sec": 6.62
+    },
+    {
+      "file": "tests/test_edg_s6_gate_hook.py",
+      "sec": 6.62
+    },
+    {
+      "file": "tests/test_edg_s19_grandfather.py",
+      "sec": 6.57
+    },
+    {
+      "file": "tests/test_edg_s8_watchdog.py",
+      "sec": 6.56
+    },
+    {
+      "file": "tests/test_edg_s10_status_api.py",
+      "sec": 6.46
+    },
+    {
+      "file": "tests/test_2078_event_outbox_realdb.py",
+      "sec": 6.1
+    },
+    {
+      "file": "tests/test_edg_s23_hypothesis_overlay.py",
+      "sec": 5.91
+    },
+    {
+      "file": "tests/test_2086_assignee_changed_sse.py",
+      "sec": 5.88
+    },
+    {
+      "file": "tests/test_h1_s9_merge_gate_metrics.py",
+      "sec": 5.83
+    },
+    {
+      "file": "tests/test_1983_doc_gate_assigned_to_me_who_state.py",
+      "sec": 5.81
+    },
+    {
+      "file": "tests/test_2058_hitl_human_only.py",
+      "sec": 5.8
+    },
+    {
+      "file": "tests/test_edg_s5_merge_gate.py",
+      "sec": 5.69
+    },
+    {
+      "file": "tests/test_edg_s12be_recipient_fallback.py",
+      "sec": 5.54
+    },
+    {
+      "file": "tests/test_agent_access_matrix_realdb.py",
+      "sec": 5.42
+    },
+    {
+      "file": "tests/test_2047_explicit_ask_gate.py",
+      "sec": 5.39
+    },
+    {
+      "file": "tests/test_e_loop_ledger_p1_s11_dispatch_context_pack_realdb.py",
+      "sec": 5.23
+    },
+    {
+      "file": "tests/test_edg_s31_hold.py",
+      "sec": 5.21
+    },
+    {
+      "file": "tests/test_edg_s33_override.py",
+      "sec": 5.17
+    },
+    {
+      "file": "tests/test_edg_s30_void_recovery.py",
+      "sec": 5.16
+    },
+    {
+      "file": "tests/test_edg_s22_doc_overlay.py",
+      "sec": 5.03
+    },
+    {
+      "file": "tests/test_edg_s34_line_versions.py",
+      "sec": 4.98
+    },
+    {
+      "file": "tests/test_2004_a2a_sendmessage_idempotency_realdb.py",
+      "sec": 4.92
+    },
+    {
+      "file": "tests/test_edg_s26_sprint_overlay.py",
+      "sec": 4.9
+    },
+    {
+      "file": "tests/test_edg_s17_recall.py",
+      "sec": 4.67
+    },
+    {
+      "file": "tests/test_edg_s16_seed.py",
+      "sec": 4.66
+    },
+    {
+      "file": "tests/test_2249_gate_entered_at_realdb.py",
+      "sec": 4.59
+    },
+    {
+      "file": "tests/test_edg_batch_line_status.py",
+      "sec": 4.56
+    },
+    {
+      "file": "tests/test_edg_s15_metrics.py",
+      "sec": 4.56
+    },
+    {
+      "file": "tests/test_1968_gate_project_id_threading.py",
+      "sec": 4.48
+    },
+    {
+      "file": "tests/test_e_loop_ledger_s27_context_pack_recommendation.py",
+      "sec": 4.41
+    },
+    {
+      "file": "tests/test_2078_publish_atomic.py",
+      "sec": 4.38
+    },
+    {
+      "file": "tests/test_merge_verdict_gate.py",
+      "sec": 4.34
+    },
+    {
+      "file": "tests/test_ho_s9_e2e_closed_loop.py",
+      "sec": 4.31
+    },
+    {
+      "file": "tests/test_e_loop_ledger_p1_s12_context_pack_items_realdb.py",
+      "sec": 4.2
+    },
+    {
+      "file": "tests/test_edg_s25_epic_overlay.py",
+      "sec": 4.17
+    },
+    {
+      "file": "tests/test_edg_s2_config_governance.py",
+      "sec": 4.13
+    },
+    {
+      "file": "tests/test_2049_default_participation_roles.py",
+      "sec": 4.1
+    },
+    {
+      "file": "tests/test_ccbcd9da_gate_wake_wiring_realdb.py",
+      "sec": 4.07
+    },
+    {
+      "file": "tests/test_e_loop_ledger_p1_s3_embed_backlog_realdb.py",
+      "sec": 4.04
+    },
+    {
+      "file": "tests/test_org_create_seeds_default_participation_role.py",
+      "sec": 4.01
+    },
+    {
+      "file": "tests/test_a2a_sa4_streaming_realdb.py",
+      "sec": 3.93
+    },
+    {
+      "file": "tests/test_edg_s28_doc_resubmit.py",
+      "sec": 3.81
+    },
+    {
+      "file": "tests/test_edg_s29_dryrun_preview.py",
+      "sec": 3.29
+    },
+    {
+      "file": "tests/test_merge_gate_reject_resubmit_reopen.py",
+      "sec": 3.2
+    },
+    {
+      "file": "tests/test_2101_sse_recent_delivered_backfill_realdb.py",
+      "sec": 3.0
+    },
+    {
+      "file": "tests/test_claim_participation.py",
+      "sec": 2.94
+    },
+    {
+      "file": "tests/test_doc_gate_cascade_scope_realdb.py",
+      "sec": 2.9
+    },
+    {
+      "file": "tests/test_s29_active_line_get.py",
+      "sec": 2.7
+    },
+    {
+      "file": "tests/test_2128_sse_lifespan_cap.py",
+      "sec": 2.65
+    },
+    {
+      "file": "tests/test_h1_s7_gate_verdict.py",
+      "sec": 2.65
+    },
+    {
+      "file": "tests/test_h1_fix2_approve_advances_done.py",
+      "sec": 2.46
+    },
+    {
+      "file": "tests/test_h1_s10_e2e.py",
+      "sec": 2.38
+    },
+    {
+      "file": "tests/test_ho_gate_done_side_effects.py",
+      "sec": 2.31
+    },
+    {
+      "file": "tests/test_ho_s2_outcome_verdict.py",
+      "sec": 2.28
+    },
+    {
+      "file": "tests/test_ho_s7_cold_start_seed.py",
+      "sec": 2.23
+    },
+    {
+      "file": "tests/test_a2a_p1_s1_recruit_card_contract_realdb.py",
+      "sec": 2.2
+    },
+    {
+      "file": "tests/test_e_recruit_s16_rotate_idor_realdb.py",
+      "sec": 2.16
+    },
+    {
+      "file": "tests/test_cron_retry_dry_run.py",
+      "sec": 2.1
+    },
+    {
+      "file": "tests/test_e_loop_ledger_p1_s3f_poison_pill_terminal.py",
+      "sec": 2.07
+    },
+    {
+      "file": "tests/test_ho_s4_scorer_verdict_wiring.py",
+      "sec": 2.07
+    },
+    {
+      "file": "tests/test_ho_s1_score_hypotheses_smoke.py",
+      "sec": 1.89
+    },
+    {
+      "file": "tests/test_e_loop_ledger_p1_s3g_score_hypotheses_savepoint_realdb.py",
+      "sec": 1.86
+    },
+    {
+      "file": "tests/test_e_loop_ledger_p1_s5_embedding_backfill_realdb.py",
+      "sec": 1.86
+    },
+    {
+      "file": "tests/test_e_loop_ledger_p1_s6_context_pack_search_realdb.py",
+      "sec": 1.86
+    },
+    {
+      "file": "tests/test_2216_workflow_fallback_notify_owner_floor_realdb.py",
+      "sec": 1.76
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- story #2293 — `Alembic upgrade head (fresh DB)` 25분 천장에서 PR #2576이 cancelled(destructive_schema 94개 중 77개까지 전부 pass하고 시간만 모자라 잘림, 빨간 것 0건).
- **AC1(착수 전 확인)**: `alembic-fresh-db`와 `backend-test`가 destructive-schema 94개 루프를 byte-identical하게 중복 실행 중이었음(원래 가정했던 "create_all vs migration" 스키마 구성 분기는 존재하지 않았다 — 둘 다 `alembic upgrade heads`). `alembic-fresh-db`는 마이그레이션 경로 무결성 검증(baseline parity·dual-head 수렴·existing-DB no-op — 4스텝, 고유) 전용으로 좁히고, `backend-test`를 destructive-schema 94개의 유일한 실행처로 만들었다.
- `backend/scripts/shard_destructive_tests.py`: `infra/destructive-schema-shard-weights.json`(2026-07-28 실측, 파일별 pytest 초) 기반 greedy LPT로 4개 샤드에 균형배분. `discover()`(`pytest --collect-only`)가 항상 SSOT — 스냅샷에 없는 새 파일도 평균 가중치로 자동 편입.
- `backend-test-destructive`(4-way matrix job)가 실제 실행 담당. `backend-test`(develop 필수 상태 체크 — **이름 불변**)는 `needs: [backend-test-destructive]` + 명시적 실패 체크 스텝으로 게이팅.

## AC2(파일별 실측 반영)
- `infra/destructive-schema-shard-weights.json` — 94개, 합계 534.7초, 최대 16.24초(`test_2161_agent_run_reaper.py`). 로컬 재실행 결과 4샤드 24/24/23/23 파일, ~134.6/134.5/132.9/132.8초(weighted) — 균형 확認.

## AC3(94개 전부 도는 것을 수로 보임)
- 로컬에서 4샤드 union = 94, 중복 0(`sort -u`로 직접 확認). `backend-test-destructive`의 "Determine this shard's file list" 스텝이 `--print-summary`로 discovered 총계·샤드별 배정·"무손실 확認" 로그를 매 실행 찍음.
- `test_shard_destructive_tests.py::test_partition_is_lossless_for_any_input`이 5가지 조합(94/4 실규모 포함, 0개, 샤드>파일수 등)에서 partition()이 항상 무손실임을 고정.

## AC4(조각 하나 실패 → 전체 빨강)
- `backend-test`가 `needs: [backend-test-destructive]` + `if: always()` + 첫 스텝에서 `needs.backend-test-destructive.result != 'success'`면 명시적 `exit 1`. GitHub의 기본 `needs`-실패-시-skip에만 기대지 않음(필수 체크가 skipped로 조용히 안 걸리는 위험을 파울로군이 지적 — 그 답).
- **라이브 CI 실증 완료** — `test_zzz_2293_intentional_red_demo.py`(destructive_schema, 항상 실패)를 한 커밋으로 심어 push함:
  - `Backend destructive-schema (shard) (2)`: fail(고의 실패가 이 샤드에 배정됨), 나머지 샤드 0/1/3은 `fail-fast: false`대로 끝까지 완주해 전부 pass
  - `Backend pytest`(필수 체크): job-level `conclusion=failure`(skipped 아님). 스텝 로그: `Require all destructive-schema shards to have succeeded: failure` → 이후 Checkout/Install uv/alembic/pytest 전부 `skipped`(불필요한 작업 안 함, 그러나 job 자체는 failure로 남음)
  - 데모 파일 커밋을 즉시 revert하여 원복 — 재실행 결과 아래 AC5 표 참고

## AC5(전/후 실측 — 예상 아님, PR #2581 실제 run 기준)
| | before(직전 통과분 평균, PO 실측) | after(이 PR 실제 run, 2026-07-28) |
|---|---|---|
| `Alembic upgrade head (fresh DB)` | 17~18분대(17m22s·16m57s·18m13s·17m57s) | **30초**(13:39:03→13:39:33) |
| `Backend destructive-schema (shard 0/1/2/3)` | (신규 — 이전엔 이 작업이 두 job에 각각 순차 94개로 박혀 있었음) | **3m27s~3m53s**(4개 병렬, 24/24/23/23파일) |
| `Backend pytest`(needs 대기+non-destructive 자체 작업) | 동일 job이 destructive 포함 17~25분 | **5m56s**(13:43:04→13:49:00, 샤드 완주 직후 시작 확認 — needs 게이팅 정상 작동) |
| **필수 체크 전체 벽시계**(최초 job 시작→마지막 필수체크 완료) | 17~25분(단일 job) | **~9m57s**(13:39:03→13:49:00) |

## AC6(이 처방이 못 잡는 것)
- 파일 하나 자체가 25분 천장을 넘으면 샤드 수로는 못 막는다(샤드는 파일들 사이에서만 병렬화하지, 한 파일 내부를 쪼개지 않는다).
- 스위트가 계속 자라면(파일 수↑) 샤드당 가중치 총합도 같이 자라 안전마진이 조용히 줄어든다 — `infra/destructive-schema-shard-weights.json`을 주기적으로 재측정하지 않으면 이 처방 자체가 낡는다.
- 이 처방은 **develop 축만** 다룬다. main의 필수 상태 체크는 `"CI"`(프론트 axis, 잡 이름 `Lint, Type Check, Test, Build`) 하나뿐이고 백엔드 스위트가 main 필수 체크에 안 걸려 있는 것은 별건 — 이번 스코프 밖(파울로군 지적).

## Test plan
- [x] `uv run pytest -q tests/test_shard_destructive_tests.py` — 11 passed(로컬)
- [x] `uv run python scripts/shard_destructive_tests.py --shard-index N --shard-count 4 --print-summary` 4회 로컬 실행 — 94/94 배정, 중복 0
- [x] ci.yml YAML 파싱 검증(PyYAML)
- [x] CI green(정상 케이스) 확認
- [x] 고의 실패 주입 → 샤드 fail + Backend pytest(필수체크) job-level failure 라이브 확認 → revert → 재-green 확認

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
