### PR TITLE
feat(#2283 BE): 참조 직접생성 POST/DELETE /api/v2/references

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -169,7 +169,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import a2a, account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, deeplink_manifest, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, device_installations, dispatch, docs, entities, goals, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, project_access, project_settings, projects, public_docs, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import a2a, account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, deeplink_manifest, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, device_installations, dispatch, docs, entities, goals, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, project_access, project_settings, projects, public_docs, references, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 # 도메인 축 B(org-1st-class-surface-ia-design-b §3): OpenAPI 태그 조직-우선 위계.
 # 개별 라우터는 기존 세부 tag(예 "stories")를 그대로 유지하고 이 4축 태그를 추가로 보유(다중
@@ -330,6 +330,7 @@ app.include_router(standups.router)
 app.include_router(retros.router)
 app.include_router(role_templates.router)
 app.include_router(entities.router)
+app.include_router(references.router)
 app.include_router(event_notifications.router)
 app.include_router(notifications.router)
 app.include_router(deeplink_manifest.router)  # story #1951: 딥링크 계약 매니페스트 v1 서빙

--- a/backend/app/routers/references.py
+++ b/backend/app/routers/references.py
@@ -1,0 +1,188 @@
+"""story #2283(BE) — 참조 직접생성 엔드포인트. 계약 doc `reference-direct-create-contract-20260728`
+(PO 확정) 그대로 구현 — 미르코군의 FE 절반(#2283, PR #2575 merged)과 미래 #2269("본문 원석 3단계
+승격")이 공유하는 write 경로.
+
+⛔target_type/source_type 을 CHECK 로 나열하지 않는다 — 아래 두 dict(각각 target/source 게이트)가
+SSOT 다. registry 에 없는 값은 400(등록 안 됨) — "나열 안 함"이 "아무거나 받음"은 아니다(#2259/#2266
+과 동일 원칙).
+
+⛔form 은 요청 바디에 없다 — 서버가 항상 "mention"으로 stamp 한다(계약서 그대로, proof 는 별도 write
+경로 몫 — reference.py 모듈 docstring 참조).
+
+⛔양쪽-아이템 게이트(404, 존재 비노출 오라클 — dependencies.py/evidence.py/gates.py 의 기존 관례와
+동일) — source 접근과 target 접근을 **독립적으로** 검증한다("반쪽 금지").
+
+⛔멱등 = 같은 (source_type, source_field, source_id, target_type, target_id, form) 튜플이면 200 +
+기존 행 재반환(409 아님) — `insert_chat_mentions`(mention_parser.py)가 이미 쓰는 ON CONFLICT DO
+NOTHING + 재조회 패턴을 그대로 재사용한다(재구현 0).
+
+⛔DELETE(디디 판단, 계약서가 명시 요구) — 만든다. "확인" 오클릭 직후 되돌릴 길이 없으면 그 자체가
+결손이라는 계약서 근거를 그대로 따른다. 삭제도 같은 양쪽-아이템 게이트(404)를 요구한다.
+"""
+from __future__ import annotations
+
+import uuid
+from collections.abc import Awaitable, Callable
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.models.reference import Reference
+from app.services.member_resolver import canonicalize_member_id
+from app.services.project_auth import has_project_access
+from app.services.reference_registry import PROJECT_ID_RESOLVERS
+
+router = APIRouter(prefix="/api/v2/references", tags=["references", "Work"])
+
+
+async def _chat_message_source_access(
+    session: AsyncSession, source_id: uuid.UUID, org_id: uuid.UUID, auth: AuthContext
+) -> bool:
+    from app.models.conversation import ConversationMessage
+
+    msg = (
+        await session.execute(select(ConversationMessage).where(ConversationMessage.id == source_id))
+    ).scalar_one_or_none()
+    if msg is None:
+        return False
+    from app.routers.conversations import _can_read_conversation
+
+    return await _can_read_conversation(msg.conversation_id, session, auth, org_id)
+
+
+SourceAccessGate = Callable[[AsyncSession, uuid.UUID, uuid.UUID, AuthContext], Awaitable[bool]]
+
+# ⛔지금 실제로 게이트가 서 있는 source_type만 여기 등록한다(#2266 BACKLINKS_ALLOWED_TARGET_TYPES
+# 와 동형 원칙 — "허용목록=게이트가 실제로 선 것"). is_valid_source_type(reference_registry.py) 는
+# doc/story/epic 도 source-capable 로 인정하지만, 그 접근 게이트는 아직 안 지었다(#2269 몫으로
+# 계약서에 이미 예정) — 여기서 미리 짓지 않는다(#2260 이 고친 "도는 자리 없는 죽은 코드" 클래스
+# 재발 금지). 등록 안 된 source_type 은 400(미지원)으로 정직하게 거부 — 조용히 통과 금지.
+_SOURCE_ACCESS_GATES: dict[str, SourceAccessGate] = {
+    "chat_message": _chat_message_source_access,
+}
+
+
+class CreateReferenceRequest(BaseModel):
+    source_type: str
+    source_id: uuid.UUID
+    source_field: str
+    target_type: str
+    target_id: uuid.UUID
+
+
+class ReferenceResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    source_type: str
+    source_id: uuid.UUID
+    target_type: str
+    target_id: uuid.UUID
+    form: str
+    created_at: datetime
+
+
+@router.post("", response_model=ReferenceResponse, status_code=201)
+async def create_reference(
+    body: CreateReferenceRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> ReferenceResponse:
+    source_gate = _SOURCE_ACCESS_GATES.get(body.source_type)
+    if source_gate is None:
+        raise HTTPException(status_code=400, detail=f"Unsupported source_type: {body.source_type}")
+
+    target_resolver = PROJECT_ID_RESOLVERS.get(body.target_type)
+    if target_resolver is None:
+        raise HTTPException(status_code=400, detail=f"Unsupported target_type: {body.target_type}")
+
+    # 양쪽-아이템 게이트 — source/target 독립 검증("반쪽 금지"). 둘 다 404(존재 비노출).
+    if not await source_gate(session, body.source_id, org_id, auth):
+        raise HTTPException(status_code=404, detail="Source not found")
+
+    target_project_id = await target_resolver(session, org_id, body.target_id)
+    if target_project_id is None:
+        raise HTTPException(status_code=404, detail="Target not found")
+    if not await has_project_access(session, uuid.UUID(auth.user_id), target_project_id, org_id):
+        raise HTTPException(status_code=404, detail="Target not found")
+
+    from app.routers.conversations import _resolve_member
+
+    sender = await _resolve_member(auth, org_id, session, project_id=None)
+    canonical_created_by = await canonicalize_member_id(sender.id, session)
+
+    new_id = uuid.uuid4()
+    stmt = pg_insert(Reference).values(
+        id=new_id,
+        org_id=org_id,
+        source_type=body.source_type,
+        source_field=body.source_field,
+        source_id=body.source_id,
+        target_type=body.target_type,
+        target_id=body.target_id,
+        form="mention",
+        created_by=canonical_created_by,
+    )
+    stmt = stmt.on_conflict_do_nothing(
+        index_elements=[
+            Reference.source_type, Reference.source_field, Reference.source_id,
+            Reference.target_type, Reference.target_id, Reference.form,
+        ],
+        index_where=Reference.form != "proof",
+    )
+    await session.execute(stmt)
+    await session.commit()
+
+    # 멱등 — insert 가 conflict 로 no-op 이었어도 기존 행을 그대로 재반환한다(계약: 재호출은
+    # 409 가 아니라 200/201 + 기존 데이터).
+    row = (
+        await session.execute(
+            select(Reference).where(
+                Reference.org_id == org_id,
+                Reference.source_type == body.source_type,
+                Reference.source_field == body.source_field,
+                Reference.source_id == body.source_id,
+                Reference.target_type == body.target_type,
+                Reference.target_id == body.target_id,
+                Reference.form == "mention",
+            )
+        )
+    ).scalar_one()
+    return ReferenceResponse.model_validate(row)
+
+
+@router.delete("/{reference_id}", status_code=204)
+async def delete_reference(
+    reference_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> None:
+    row = (
+        await session.execute(select(Reference).where(Reference.id == reference_id, Reference.org_id == org_id))
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Reference not found")
+
+    # 삭제도 생성과 동일한 양쪽-아이템 게이트를 요구한다 — 생성 이후 권한이 사라졌는데도
+    # 지울 수 있으면 그 자체가 구멍이다(row 존재만으로 삭제를 허용하지 않는다).
+    source_gate = _SOURCE_ACCESS_GATES.get(row.source_type)
+    if source_gate is None or not await source_gate(session, row.source_id, org_id, auth):
+        raise HTTPException(status_code=404, detail="Reference not found")
+
+    target_resolver = PROJECT_ID_RESOLVERS.get(row.target_type)
+    target_project_id = await target_resolver(session, org_id, row.target_id) if target_resolver else None
+    if target_project_id is None or not await has_project_access(
+        session, uuid.UUID(auth.user_id), target_project_id, org_id
+    ):
+        raise HTTPException(status_code=404, detail="Reference not found")
+
+    await session.delete(row)
+    await session.commit()

--- a/backend/app/routers/references.py
+++ b/backend/app/routers/references.py
@@ -9,12 +9,22 @@ SSOT 다. registry 에 없는 값은 400(등록 안 됨) — "나열 안 함"이
 ⛔form 은 요청 바디에 없다 — 서버가 항상 "mention"으로 stamp 한다(계약서 그대로, proof 는 별도 write
 경로 몫 — reference.py 모듈 docstring 참조).
 
+⛔source_field 도 요청 바디에 없다(PO 판정, 2026-07-28 PR #2582 리뷰) — 멱등 유니크
+(uq_entity_references_non_proof)가 source_field 를 키에 포함하므로, 클라이언트가
+`"body"`/`"Body"`처럼 대소문자만 다르게 보내면 **같은 연결이 두 행으로 쪼개진다**(form 을
+서버가 stamp 하는 것과 동일한 이유 — 멱등 키는 클라이언트 손에 두지 않는다). source_type 마다
+"어느 칸에서 왔는가"가 갈리는 날(#2269 — story description vs acceptance_criteria) 이 매핑을
+registry 로 옮긴다. 그전까지는 `_SOURCE_TYPE_CONFIG` 가 고정값으로 정한다.
+
 ⛔양쪽-아이템 게이트(404, 존재 비노출 오라클 — dependencies.py/evidence.py/gates.py 의 기존 관례와
 동일) — source 접근과 target 접근을 **독립적으로** 검증한다("반쪽 금지").
 
-⛔멱등 = 같은 (source_type, source_field, source_id, target_type, target_id, form) 튜플이면 200 +
-기존 행 재반환(409 아님) — `insert_chat_mentions`(mention_parser.py)가 이미 쓰는 ON CONFLICT DO
-NOTHING + 재조회 패턴을 그대로 재사용한다(재구현 0).
+⛔멱등 = 같은 (source_type, source_field, source_id, target_type, target_id, form) 튜플이면
+**200**(이미 있던 것) 또는 **201**(방금 생김) — 둘 다 데이터는 같지만 상태 코드로 "새로 생겼는지"를
+구별한다(PO 판정 — FE 가 "N개 연결됨"을 셀 때 연타가 부풀리면 안 된다). `ON CONFLICT DO NOTHING
+.returning(...)` 으로 "내 insert 가 실제로 꽂혔는가"를 직접 판정한다 — 방금 insert 시도 직후의
+무조건 select(과거 초안의 실수)는 우리 conflict 가 아닌 다른 이유로 no-op 났을 때 0행을 만나
+`scalar_one()` 이 500 을 던질 수 있어(PO 지적) 쓰지 않는다.
 
 ⛔DELETE(디디 판단, 계약서가 명시 요구) — 만든다. "확인" 오클릭 직후 되돌릴 길이 없으면 그 자체가
 결손이라는 계약서 근거를 그대로 따른다. 삭제도 같은 양쪽-아이템 게이트(404)를 요구한다.
@@ -24,8 +34,9 @@ from __future__ import annotations
 import uuid
 from collections.abc import Awaitable, Callable
 from datetime import datetime
+from typing import NamedTuple
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -58,20 +69,28 @@ async def _chat_message_source_access(
 
 SourceAccessGate = Callable[[AsyncSession, uuid.UUID, uuid.UUID, AuthContext], Awaitable[bool]]
 
+
+class SourceTypeConfig(NamedTuple):
+    source_field: str
+    access_gate: SourceAccessGate
+
+
 # ⛔지금 실제로 게이트가 서 있는 source_type만 여기 등록한다(#2266 BACKLINKS_ALLOWED_TARGET_TYPES
 # 와 동형 원칙 — "허용목록=게이트가 실제로 선 것"). is_valid_source_type(reference_registry.py) 는
 # doc/story/epic 도 source-capable 로 인정하지만, 그 접근 게이트는 아직 안 지었다(#2269 몫으로
 # 계약서에 이미 예정) — 여기서 미리 짓지 않는다(#2260 이 고친 "도는 자리 없는 죽은 코드" 클래스
 # 재발 금지). 등록 안 된 source_type 은 400(미지원)으로 정직하게 거부 — 조용히 통과 금지.
-_SOURCE_ACCESS_GATES: dict[str, SourceAccessGate] = {
-    "chat_message": _chat_message_source_access,
+# ⛔source_field 를 access_gate 와 «같은 dict»에 묶은 것은 의도적 — 따로 두면 새 source_type을
+# 열 때 한쪽만(예: 게이트만) 추가하고 field 매핑은 깜빡할 수 있다(오늘 PROJECT_ID_RESOLVERS 에
+# 적용한 것과 동일한 twin-system drift 방지 원칙).
+_SOURCE_TYPE_CONFIG: dict[str, SourceTypeConfig] = {
+    "chat_message": SourceTypeConfig("body", _chat_message_source_access),
 }
 
 
 class CreateReferenceRequest(BaseModel):
     source_type: str
     source_id: uuid.UUID
-    source_field: str
     target_type: str
     target_id: uuid.UUID
 
@@ -82,6 +101,7 @@ class ReferenceResponse(BaseModel):
     id: uuid.UUID
     source_type: str
     source_id: uuid.UUID
+    source_field: str
     target_type: str
     target_id: uuid.UUID
     form: str
@@ -91,12 +111,13 @@ class ReferenceResponse(BaseModel):
 @router.post("", response_model=ReferenceResponse, status_code=201)
 async def create_reference(
     body: CreateReferenceRequest,
+    response: Response,
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> ReferenceResponse:
-    source_gate = _SOURCE_ACCESS_GATES.get(body.source_type)
-    if source_gate is None:
+    config = _SOURCE_TYPE_CONFIG.get(body.source_type)
+    if config is None:
         raise HTTPException(status_code=400, detail=f"Unsupported source_type: {body.source_type}")
 
     target_resolver = PROJECT_ID_RESOLVERS.get(body.target_type)
@@ -104,7 +125,7 @@ async def create_reference(
         raise HTTPException(status_code=400, detail=f"Unsupported target_type: {body.target_type}")
 
     # 양쪽-아이템 게이트 — source/target 독립 검증("반쪽 금지"). 둘 다 404(존재 비노출).
-    if not await source_gate(session, body.source_id, org_id, auth):
+    if not await config.access_gate(session, body.source_id, org_id, auth):
         raise HTTPException(status_code=404, detail="Source not found")
 
     target_project_id = await target_resolver(session, org_id, body.target_id)
@@ -123,7 +144,7 @@ async def create_reference(
         id=new_id,
         org_id=org_id,
         source_type=body.source_type,
-        source_field=body.source_field,
+        source_field=config.source_field,
         source_id=body.source_id,
         target_type=body.target_type,
         target_id=body.target_id,
@@ -136,25 +157,38 @@ async def create_reference(
             Reference.target_type, Reference.target_id, Reference.form,
         ],
         index_where=Reference.form != "proof",
-    )
-    await session.execute(stmt)
+    ).returning(Reference.id)
+    inserted_id = (await session.execute(stmt)).scalar_one_or_none()
     await session.commit()
 
-    # 멱등 — insert 가 conflict 로 no-op 이었어도 기존 행을 그대로 재반환한다(계약: 재호출은
-    # 409 가 아니라 200/201 + 기존 데이터).
-    row = (
-        await session.execute(
-            select(Reference).where(
-                Reference.org_id == org_id,
-                Reference.source_type == body.source_type,
-                Reference.source_field == body.source_field,
-                Reference.source_id == body.source_id,
-                Reference.target_type == body.target_type,
-                Reference.target_id == body.target_id,
-                Reference.form == "mention",
+    if inserted_id is not None:
+        # 내 insert 가 실제로 꽂혔다 — 방금 생긴 것(201, 라우트 기본값 그대로).
+        row_id = inserted_id
+    else:
+        # 멱등 충돌 — 이미 있던 것(200). 재조회는 우리가 겨냥한 그 튜플로만 좁혀서(다른 이유로
+        # 0행이면 501 대신 명시적 500 — "있어야 하는데 없다"를 조용히 넘기지 않는다).
+        response.status_code = 200
+        existing_id = (
+            await session.execute(
+                select(Reference.id).where(
+                    Reference.org_id == org_id,
+                    Reference.source_type == body.source_type,
+                    Reference.source_field == config.source_field,
+                    Reference.source_id == body.source_id,
+                    Reference.target_type == body.target_type,
+                    Reference.target_id == body.target_id,
+                    Reference.form == "mention",
+                )
             )
-        )
-    ).scalar_one()
+        ).scalar_one_or_none()
+        if existing_id is None:
+            raise HTTPException(
+                status_code=500,
+                detail="Insert conflicted but no matching reference row found — unexpected state",
+            )
+        row_id = existing_id
+
+    row = (await session.execute(select(Reference).where(Reference.id == row_id))).scalar_one()
     return ReferenceResponse.model_validate(row)
 
 
@@ -173,8 +207,8 @@ async def delete_reference(
 
     # 삭제도 생성과 동일한 양쪽-아이템 게이트를 요구한다 — 생성 이후 권한이 사라졌는데도
     # 지울 수 있으면 그 자체가 구멍이다(row 존재만으로 삭제를 허용하지 않는다).
-    source_gate = _SOURCE_ACCESS_GATES.get(row.source_type)
-    if source_gate is None or not await source_gate(session, row.source_id, org_id, auth):
+    config = _SOURCE_TYPE_CONFIG.get(row.source_type)
+    if config is None or not await config.access_gate(session, row.source_id, org_id, auth):
         raise HTTPException(status_code=404, detail="Reference not found")
 
     target_resolver = PROJECT_ID_RESOLVERS.get(row.target_type)

--- a/backend/app/services/reference_registry.py
+++ b/backend/app/services/reference_registry.py
@@ -91,6 +91,53 @@ def is_valid_source_type(entity_type: str) -> bool:
     return entity_type in ENTITY_RESOLVERS or entity_type in SOURCE_ONLY_TYPES
 
 
+# ─── story #2283 — target TARGET 접근 게이트(project_id 조회) ────────────────
+# ⛔ENTITY_RESOLVERS(존재판정)와 별개 축이다: "이 id가 존재하는가"와 "그 엔티티의 project_id는
+# 무엇인가"는 다른 질문이다(has_project_access가 project_id를 요구한다). 같은 3개 타입에
+# 대해 각각 별도 함수가 필요하지만(테이블이 다르므로 구조적으로 불가피), registry 자체는
+# ENTITY_RESOLVERS와 **동형 dict**로 둔다 — 새 타입을 열 때 두 registry에 항목을 "같이"
+# 추가하게 강제하려면 dict가 갈라져 있어야 한다(합치면 "존재판정만 있고 project_id 조회는
+# 없는" 조용한 누락이 가능해진다). 두 registry의 key 집합이 같은지는 테스트로 고정한다
+# (test_2283_references_realdb.py) — twin-system drift 방지.
+
+EntityProjectIdResolver = Callable[[AsyncSession, uuid.UUID, uuid.UUID], Awaitable["uuid.UUID | None"]]
+
+
+async def _project_id_of_doc(session: AsyncSession, org_id: uuid.UUID, entity_id: uuid.UUID) -> uuid.UUID | None:
+    from app.models.doc import Doc
+
+    return (
+        await session.execute(
+            select(Doc.project_id).where(Doc.id == entity_id, Doc.org_id == org_id, Doc.deleted_at.is_(None))
+        )
+    ).scalar_one_or_none()
+
+
+async def _project_id_of_story(session: AsyncSession, org_id: uuid.UUID, entity_id: uuid.UUID) -> uuid.UUID | None:
+    from app.models.pm import Story
+
+    return (
+        await session.execute(
+            select(Story.project_id).where(Story.id == entity_id, Story.org_id == org_id, Story.deleted_at.is_(None))
+        )
+    ).scalar_one_or_none()
+
+
+async def _project_id_of_epic(session: AsyncSession, org_id: uuid.UUID, entity_id: uuid.UUID) -> uuid.UUID | None:
+    from app.models.pm import Goal
+
+    return (
+        await session.execute(select(Goal.project_id).where(Goal.id == entity_id, Goal.org_id == org_id))
+    ).scalar_one_or_none()
+
+
+PROJECT_ID_RESOLVERS: dict[str, EntityProjectIdResolver] = {
+    "doc": _project_id_of_doc,
+    "story": _project_id_of_story,
+    "epic": _project_id_of_epic,
+}
+
+
 async def count_orphan_types(session: AsyncSession, org_id: uuid.UUID | None = None) -> dict[str, int]:
     """⭐PO가 요구한 감시망 — entity_references 에 저장된 행 중 source_type/target_type 이
     registry(+source-only 허용목록)에 없는 것을 종류별로 센다. 0이 정상 — 0이 아니면

--- a/backend/tests/test_2283_references_realdb.py
+++ b/backend/tests/test_2283_references_realdb.py
@@ -1,0 +1,531 @@
+"""story #2283(BE) — `POST /api/v2/references`(직접생성) + `DELETE /api/v2/references/{id}`.
+계약 doc `reference-direct-create-contract-20260728`(PO 확정) 그대로 실PG 검증.
+
+검증 축:
+  ①registry 밖 source_type/target_type — 400(등록 안 됨, 조용히 통과 금지)
+  ②멱등 — 같은 (source, target) 튜플 재호출은 409가 아니라 200 + 기존 id 재반환
+  ③양쪽-아이템 게이트(404, 존재 비노출) — source 접근·target 접근을 twin comparison(있음
+    vs 없음)으로 «독립적으로» 증명한다("반쪽 금지" — 한쪽만 막고 한쪽은 새는 회귀를 잡는다)
+  ④DELETE도 동일 게이트 — 삭제 권한이 생성 권한과 독립적으로 재확인되는지
+  ⑤PROJECT_ID_RESOLVERS와 ENTITY_RESOLVERS 키 집합 동일(twin-system drift 방지, 테스트로 pin)
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+# ─── Seeding helpers (test_2266_story_backlinks_realdb.py와 동형) ─────────────
+
+
+async def _make_org(session, name="Org"):
+    from app.models.organization import Organization
+    org = Organization(id=uuid.uuid4(), name=name, slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    return org
+
+
+async def _make_project(session, org_id, name="P"):
+    from app.models.project import Project
+    project = Project(id=uuid.uuid4(), org_id=org_id, name=name)
+    session.add(project)
+    await session.commit()
+    return project
+
+
+async def _make_human_member(session, org_id, project_id):
+    from app.models.user import User
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.member import Member
+
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="member")
+    session.add(om)
+    await session.flush()
+    m = Member(id=om.id, org_id=org_id, type="human", user_id=user.id, name="Human")
+    session.add(m)
+    await session.flush()
+    session.add(ProjectAccess(project_id=project_id, org_member_id=om.id, member_id=m.id, role="member"))
+    await session.commit()
+    return m.id, user.id
+
+
+async def _make_story(session, org_id, project_id, title="Story"):
+    from app.models.pm import Story
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status="backlog")
+    session.add(story)
+    await session.commit()
+    return story
+
+
+async def _make_doc(session, org_id, project_id, title="Doc"):
+    from app.models.doc import Doc
+    doc = Doc(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, slug=f"d-{uuid.uuid4().hex[:8]}")
+    session.add(doc)
+    await session.commit()
+    return doc
+
+
+async def _make_conversation(session, org_id, project_id, member_ids, created_by, conv_type="dm"):
+    from app.models.conversation import Conversation, ConversationParticipant
+    conv = Conversation(
+        id=uuid.uuid4(), project_id=project_id, org_id=org_id, type=conv_type,
+        title="Test convo", created_by=created_by,
+    )
+    session.add(conv)
+    await session.flush()
+    for mid in member_ids:
+        session.add(ConversationParticipant(conversation_id=conv.id, member_id=mid))
+    await session.commit()
+    return conv.id
+
+
+async def _add_message(session, conv_id, sender_id, content, created_at=None):
+    from app.models.conversation import ConversationMessage
+    msg = ConversationMessage(
+        id=uuid.uuid4(), conversation_id=conv_id, sender_id=sender_id,
+        content=content, created_at=created_at or datetime.now(timezone.utc),
+    )
+    session.add(msg)
+    await session.commit()
+    return msg
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ─── ⑤twin-system drift 방지 ──────────────────────────────────────────────
+
+
+def test_project_id_resolvers_keys_match_entity_resolvers():
+    from app.services.reference_registry import ENTITY_RESOLVERS, PROJECT_ID_RESOLVERS
+    assert set(PROJECT_ID_RESOLVERS) == set(ENTITY_RESOLVERS)
+
+
+# ─── ①registry 밖 타입 — 400 ───────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_create_reference_rejects_unregistered_source_type():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/references", json={
+                "source_type": "task", "source_id": str(uuid.uuid4()), "source_field": "body",
+                "target_type": "story", "target_id": str(story.id),
+            })
+            assert resp.status_code == 400, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_reference_rejects_unregistered_target_type():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [member_id], member_id)
+            msg = await _add_message(s, conv_id, member_id, "hi")
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/references", json={
+                "source_type": "chat_message", "source_id": str(msg.id), "source_field": "body",
+                "target_type": "task", "target_id": str(uuid.uuid4()),
+            })
+            assert resp.status_code == 400, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── ③양쪽-아이템 게이트 — twin comparison(독립 검증) ─────────────────────────
+
+
+@pytest.mark.anyio
+async def test_create_reference_404_when_source_inaccessible():
+    """caller가 target(story)엔 접근하지만 source(chat_message가 속한 conversation)엔
+    참여하지 않는 경우 — source 게이트 단독으로 404가 걸리는지(target 접근권만으로 새지
+    않는지)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            owner_id, _ = await _make_human_member(s, org.id, project.id)
+            outsider_id, outsider_user_id = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [owner_id], owner_id)
+            msg = await _add_message(s, conv_id, owner_id, "private convo")
+
+        # outsider는 project 접근은 있지만 conversation 참가자가 아니다.
+        await _setup_app_human(app, Session, outsider_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/references", json={
+                "source_type": "chat_message", "source_id": str(msg.id), "source_field": "body",
+                "target_type": "story", "target_id": str(story.id),
+            })
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_reference_404_when_target_inaccessible():
+    """caller가 source(chat_message)엔 참여하지만 target(story)이 속한 project엔 접근이
+    없는 경우 — target 게이트 단독으로 404가 걸리는지(source 접근권만으로 새지 않는지)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            chat_project = await _make_project(s, org.id, "Chat Project")
+            story_project = await _make_project(s, org.id, "Story Project(no access)")
+            member_id, user_id = await _make_human_member(s, org.id, chat_project.id)
+            conv_id = await _make_conversation(s, org.id, chat_project.id, [member_id], member_id)
+            msg = await _add_message(s, conv_id, member_id, "hi")
+            story = await _make_story(s, org.id, story_project.id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/references", json={
+                "source_type": "chat_message", "source_id": str(msg.id), "source_field": "body",
+                "target_type": "story", "target_id": str(story.id),
+            })
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_reference_succeeds_when_both_accessible():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [member_id], member_id)
+            msg = await _add_message(s, conv_id, member_id, "hi")
+            doc = await _make_doc(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/references", json={
+                "source_type": "chat_message", "source_id": str(msg.id), "source_field": "body",
+                "target_type": "doc", "target_id": str(doc.id),
+            })
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["source_type"] == "chat_message"
+            assert body["source_id"] == str(msg.id)
+            assert body["target_type"] == "doc"
+            assert body["target_id"] == str(doc.id)
+            assert body["form"] == "mention"
+            assert "id" in body and "created_at" in body
+            return body["id"], msg.id, doc.id, org.id, user_id
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── ②멱등 ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_create_reference_idempotent_same_tuple_returns_existing():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [member_id], member_id)
+            msg = await _add_message(s, conv_id, member_id, "hi")
+            doc = await _make_doc(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            payload = {
+                "source_type": "chat_message", "source_id": str(msg.id), "source_field": "body",
+                "target_type": "doc", "target_id": str(doc.id),
+            }
+            resp1 = await client.post("/api/v2/references", json=payload)
+            assert resp1.status_code == 201, resp1.text
+            resp2 = await client.post("/api/v2/references", json=payload)
+            # ⛔계약: 재호출은 409가 아니라 200/201 + 기존 행 재반환.
+            assert resp2.status_code in (200, 201), resp2.text
+            assert resp1.json()["id"] == resp2.json()["id"]
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── ④DELETE — 동일 게이트 ─────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_delete_reference_404_for_nonexistent():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/references/{uuid.uuid4()}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_delete_reference_404_when_caller_lost_target_access():
+    """생성 당시엔 접근이 있었지만(다른 caller가 만든 행), 지우려는 caller는 target
+    project 접근이 없는 경우 — row 존재만으로 삭제가 새지 않는지."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            chat_project = await _make_project(s, org.id, "Chat Project")
+            story_project = await _make_project(s, org.id, "Story Project(no access)")
+            member_id, creator_user_id = await _make_human_member(s, org.id, chat_project.id)
+            conv_id = await _make_conversation(s, org.id, chat_project.id, [member_id], member_id)
+            msg = await _add_message(s, conv_id, member_id, "hi")
+            story = await _make_story(s, org.id, story_project.id)
+            # creator도 story_project에 접근이 없으므로 API를 통해 만들 수 없다 — 직접 행 삽입.
+            from app.models.reference import Reference
+            ref = Reference(
+                id=uuid.uuid4(), org_id=org.id, source_type="chat_message", source_field="body",
+                source_id=msg.id, target_type="story", target_id=story.id, form="mention",
+                created_by=member_id,
+            )
+            s.add(ref)
+            await s.commit()
+            ref_id = ref.id
+
+        await _setup_app_human(app, Session, creator_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/references/{ref_id}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_delete_reference_succeeds_when_both_accessible():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [member_id], member_id)
+            msg = await _add_message(s, conv_id, member_id, "hi")
+            doc = await _make_doc(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/references", json={
+                "source_type": "chat_message", "source_id": str(msg.id), "source_field": "body",
+                "target_type": "doc", "target_id": str(doc.id),
+            })
+            ref_id = create_resp.json()["id"]
+            del_resp = await client.delete(f"/api/v2/references/{ref_id}")
+            assert del_resp.status_code == 204, del_resp.text
+
+            # 재조회하면 이미 없음(404) — 실제로 지워졌는지 확인(응답코드만 믿지 않는다).
+            del_resp2 = await client.delete(f"/api/v2/references/{ref_id}")
+            assert del_resp2.status_code == 404, del_resp2.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── RED→GREEN 자체검증 — source 게이트 무력화 시 실제로 새는지 ────────────────
+
+
+@pytest.mark.anyio
+async def test_source_gate_red_green_mutation_self_check():
+    """`_SOURCE_ACCESS_GATES["chat_message"]`를 임시로 no-op화하면 위
+    test_create_reference_404_when_source_inaccessible의 outsider가 404 대신 201로
+    새는지(=게이트가 실제로 막고 있었는지) 직접 증명한다."""
+    import app.routers.references as references_module
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            owner_id, _ = await _make_human_member(s, org.id, project.id)
+            outsider_id, outsider_user_id = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [owner_id], owner_id)
+            msg = await _add_message(s, conv_id, owner_id, "private convo")
+
+        from app.main import app
+
+        original_gates = dict(references_module._SOURCE_ACCESS_GATES)
+
+        async def _noop_true(*args, **kwargs):
+            return True
+
+        references_module._SOURCE_ACCESS_GATES["chat_message"] = _noop_true
+        try:
+            await _setup_app_human(app, Session, outsider_user_id, org.id)
+            client = _client_for(app)
+            try:
+                resp = await client.post("/api/v2/references", json={
+                    "source_type": "chat_message", "source_id": str(msg.id), "source_field": "body",
+                    "target_type": "story", "target_id": str(story.id),
+                })
+                assert resp.status_code == 201, (
+                    f"사보타주가 안 먹었다(게이트가 다른 경로로도 걸리는 중?) — {resp.status_code}: {resp.text}"
+                )
+            finally:
+                await client.aclose()
+                app.dependency_overrides.clear()
+        finally:
+            references_module._SOURCE_ACCESS_GATES.clear()
+            references_module._SOURCE_ACCESS_GATES.update(original_gates)
+
+        # 원복 후 GREEN 재확인.
+        await _setup_app_human(app, Session, outsider_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/references", json={
+                "source_type": "chat_message", "source_id": str(msg.id), "source_field": "body",
+                "target_type": "story", "target_id": str(story.id),
+            })
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2283_references_realdb.py
+++ b/backend/tests/test_2283_references_realdb.py
@@ -186,7 +186,7 @@ async def test_create_reference_rejects_unregistered_source_type():
         client = _client_for(app)
         try:
             resp = await client.post("/api/v2/references", json={
-                "source_type": "task", "source_id": str(uuid.uuid4()), "source_field": "body",
+                "source_type": "task", "source_id": str(uuid.uuid4()),
                 "target_type": "story", "target_id": str(story.id),
             })
             assert resp.status_code == 400, resp.text
@@ -214,7 +214,7 @@ async def test_create_reference_rejects_unregistered_target_type():
         client = _client_for(app)
         try:
             resp = await client.post("/api/v2/references", json={
-                "source_type": "chat_message", "source_id": str(msg.id), "source_field": "body",
+                "source_type": "chat_message", "source_id": str(msg.id),
                 "target_type": "task", "target_id": str(uuid.uuid4()),
             })
             assert resp.status_code == 400, resp.text
@@ -251,7 +251,7 @@ async def test_create_reference_404_when_source_inaccessible():
         client = _client_for(app)
         try:
             resp = await client.post("/api/v2/references", json={
-                "source_type": "chat_message", "source_id": str(msg.id), "source_field": "body",
+                "source_type": "chat_message", "source_id": str(msg.id),
                 "target_type": "story", "target_id": str(story.id),
             })
             assert resp.status_code == 404, resp.text
@@ -283,7 +283,7 @@ async def test_create_reference_404_when_target_inaccessible():
         client = _client_for(app)
         try:
             resp = await client.post("/api/v2/references", json={
-                "source_type": "chat_message", "source_id": str(msg.id), "source_field": "body",
+                "source_type": "chat_message", "source_id": str(msg.id),
                 "target_type": "story", "target_id": str(story.id),
             })
             assert resp.status_code == 404, resp.text
@@ -312,13 +312,14 @@ async def test_create_reference_succeeds_when_both_accessible():
         client = _client_for(app)
         try:
             resp = await client.post("/api/v2/references", json={
-                "source_type": "chat_message", "source_id": str(msg.id), "source_field": "body",
+                "source_type": "chat_message", "source_id": str(msg.id),
                 "target_type": "doc", "target_id": str(doc.id),
             })
             assert resp.status_code == 201, resp.text
             body = resp.json()
             assert body["source_type"] == "chat_message"
             assert body["source_id"] == str(msg.id)
+            assert body["source_field"] == "body"
             assert body["target_type"] == "doc"
             assert body["target_id"] == str(doc.id)
             assert body["form"] == "mention"
@@ -352,15 +353,17 @@ async def test_create_reference_idempotent_same_tuple_returns_existing():
         client = _client_for(app)
         try:
             payload = {
-                "source_type": "chat_message", "source_id": str(msg.id), "source_field": "body",
+                "source_type": "chat_message", "source_id": str(msg.id),
                 "target_type": "doc", "target_id": str(doc.id),
             }
             resp1 = await client.post("/api/v2/references", json=payload)
             assert resp1.status_code == 201, resp1.text
             resp2 = await client.post("/api/v2/references", json=payload)
-            # ⛔계약: 재호출은 409가 아니라 200/201 + 기존 행 재반환.
-            assert resp2.status_code in (200, 201), resp2.text
+            # ⛔계약: 재호출은 409가 아니라 200 + 기존 행 재반환(첫 호출만 201 — PO 판정:
+            # FE가 "새로 생겼는지"를 상태코드로 구별할 수 있어야 연타가 카운트를 안 부풀린다).
+            assert resp2.status_code == 200, resp2.text
             assert resp1.json()["id"] == resp2.json()["id"]
+            assert resp1.json()["source_field"] == resp2.json()["source_field"] == "body"
         finally:
             await client.aclose()
             app.dependency_overrides.clear()
@@ -451,7 +454,7 @@ async def test_delete_reference_succeeds_when_both_accessible():
         client = _client_for(app)
         try:
             create_resp = await client.post("/api/v2/references", json={
-                "source_type": "chat_message", "source_id": str(msg.id), "source_field": "body",
+                "source_type": "chat_message", "source_id": str(msg.id),
                 "target_type": "doc", "target_id": str(doc.id),
             })
             ref_id = create_resp.json()["id"]
@@ -473,7 +476,7 @@ async def test_delete_reference_succeeds_when_both_accessible():
 
 @pytest.mark.anyio
 async def test_source_gate_red_green_mutation_self_check():
-    """`_SOURCE_ACCESS_GATES["chat_message"]`를 임시로 no-op화하면 위
+    """`_SOURCE_TYPE_CONFIG["chat_message"].access_gate`를 임시로 no-op화하면 위
     test_create_reference_404_when_source_inaccessible의 outsider가 404 대신 201로
     새는지(=게이트가 실제로 막고 있었는지) 직접 증명한다."""
     import app.routers.references as references_module
@@ -491,18 +494,20 @@ async def test_source_gate_red_green_mutation_self_check():
 
         from app.main import app
 
-        original_gates = dict(references_module._SOURCE_ACCESS_GATES)
+        original_config = dict(references_module._SOURCE_TYPE_CONFIG)
 
         async def _noop_true(*args, **kwargs):
             return True
 
-        references_module._SOURCE_ACCESS_GATES["chat_message"] = _noop_true
+        references_module._SOURCE_TYPE_CONFIG["chat_message"] = references_module.SourceTypeConfig(
+            "body", _noop_true
+        )
         try:
             await _setup_app_human(app, Session, outsider_user_id, org.id)
             client = _client_for(app)
             try:
                 resp = await client.post("/api/v2/references", json={
-                    "source_type": "chat_message", "source_id": str(msg.id), "source_field": "body",
+                    "source_type": "chat_message", "source_id": str(msg.id),
                     "target_type": "story", "target_id": str(story.id),
                 })
                 assert resp.status_code == 201, (
@@ -512,15 +517,15 @@ async def test_source_gate_red_green_mutation_self_check():
                 await client.aclose()
                 app.dependency_overrides.clear()
         finally:
-            references_module._SOURCE_ACCESS_GATES.clear()
-            references_module._SOURCE_ACCESS_GATES.update(original_gates)
+            references_module._SOURCE_TYPE_CONFIG.clear()
+            references_module._SOURCE_TYPE_CONFIG.update(original_config)
 
         # 원복 후 GREEN 재확인.
         await _setup_app_human(app, Session, outsider_user_id, org.id)
         client = _client_for(app)
         try:
             resp = await client.post("/api/v2/references", json={
-                "source_type": "chat_message", "source_id": str(msg.id), "source_field": "body",
+                "source_type": "chat_message", "source_id": str(msg.id),
                 "target_type": "story", "target_id": str(story.id),
             })
             assert resp.status_code == 404, resp.text


### PR DESCRIPTION
## 배경
미르코군의 FE 절반(#2283, PR #2575 merged)이 사람이 직접 "친" 참조(예: story description
편집 중 링크 삽입)를 즉시 반영할 write path를 필요로 한다. 계약 doc
`reference-direct-create-contract-20260728`(PO 확정)이 명세 — 그대로 구현했다(재량 없음).
같은 경로를 미래 #2269("본문 원석 3단계 승격")도 공유한다.

## 구현
- `POST /api/v2/references` — `{source_type, source_id, source_field, target_type, target_id}`.
  `form`은 요청 바디에 없다(서버가 항상 `"mention"` stamp — 계약서 그대로, proof는 별도
  write 경로 몫).
- registry-based 타입 검증 — source_type은 `_SOURCE_ACCESS_GATES`(references.py 로컬,
  지금은 chat_message 하나), target_type은 신규 `PROJECT_ID_RESOLVERS`(reference_registry.py,
  doc/story/epic). 등록 안 된 값은 400(조용히 통과 금지 — #2259/#2266과 동일 원칙).
- 양쪽-아이템 게이트(404, 존재 비노출 오라클 회피 — dependencies.py/gates.py 기존 관례) —
  source(`_can_read_conversation` 재사용)와 target(`has_project_access` 재사용)을
  **독립적으로** 검증("반쪽 금지"). 두 검증 경로를 twin-comparison으로 각각 별도 테스트.
- 멱등 — 같은 (source_type, source_field, source_id, target_type, target_id, form) 튜플
  재호출은 409가 아니라 200/201 + 기존 행 재반환(`insert_chat_mentions`의 ON CONFLICT DO
  NOTHING + 재조회 패턴 재사용 — 재구현 0).
- `DELETE /api/v2/references/{id}`(디디 판단, 계약서가 명시 요구) — 만들었다. "확인" 오클릭
  직후 되돌릴 길이 없으면 그 자체가 결손이라는 계약서 근거. 삭제도 생성과 동일한 양쪽-아이템
  게이트를 다시 요구한다(row 존재만으로 삭제 허용 안 함 — 생성 이후 권한이 사라졌으면 지울
  수도 없어야 한다).

## twin-system 설계 노트
`PROJECT_ID_RESOLVERS`(신규, project_id 조회)를 기존 `ENTITY_RESOLVERS`(존재판정)와 **의도적으로
분리된 dict**로 뒀다 — 합치면 "새 타입 열 때 존재판정만 추가하고 project_id 조회는 깜빡"하는
조용한 누락이 가능해진다. 대신 키 집합이 항상 같아야 한다는 불변식을
`test_project_id_resolvers_keys_match_entity_resolvers`로 pin — 이 세션 내내 잡은
"쌍둥이 체계 드리프트" 함정을 테스트로 미리 막았다.

## 검증
- 신규 11개(`test_2283_references_realdb.py`, 실PG): registry 밖 타입 400(source/target
  각각) · twin comparison(source만 없음/target만 없음/둘 다 있음 — 3분기 독립 확인) · 멱등
  재호출 · DELETE 404(존재X/게이트 상실) · DELETE 성공 후 재삭제 404(실제로 지워졌는지
  응답코드만 안 믿고 재조회로 확인) · registry 키 동일성 pin.
- RED→GREEN 자체검증 2건: ①source 게이트(in-test monkeypatch로 무력화 → outsider가 201로
  새는 것 확인 → 원복 → 404 재확인) ②target 게이트(Edit로 라우터 코드 자체를 `if False and
  ...`로 사보타주 → 201 누출 확인 → 원복 → 404 재확인, 파일-레벨 사보타주로 실제 게이트가
  그 자리에서 막고 있었음을 증명).
- 회귀: mention/backlinks/#2259~#2274 스위트 + docs/stories/conversations 라우터 168개
  GREEN(rebase 후 재실행).
- `origin/develop` 최신(cd337d0f5, PR #2580까지)으로 rebase — 겹치는 파일 0, 충돌 0.

## 롤백
`app/routers/references.py` 삭제 + `app/main.py`의 import/include_router 두 줄 원복 +
`app/services/reference_registry.py`의 `PROJECT_ID_RESOLVERS` 섹션 제거하면 순수 revert.
신규 라우터가 기존 엔드포인트 응답을 하나도 변경하지 않는 순수 additive라 부분 revert도 안전.