### PR TITLE
chore(#2293): 샤드 가중치 스냅샷 재측정 기준 문서화 + 자동경고

### DIFF
--- a/backend/scripts/shard_destructive_tests.py
+++ b/backend/scripts/shard_destructive_tests.py
@@ -51,6 +51,28 @@ def load_weights(weights_path: Path = WEIGHTS_PATH) -> dict[str, float]:
     return {e["file"]: float(e["sec"]) for e in data.get("files", [])}
 
 
+def check_staleness(discovered_count: int, weights_path: Path = WEIGHTS_PATH) -> str | None:
+    """story #2293 후속(파울로군 지적, 2026-07-28) — 이 스냅샷은 실시간 측정이 아니다.
+    스위트가 자라면 조용히 낡는다. 재측정 기준(a)만 여기서 자동 확인한다(파일 수 +20% —
+    weights_path의 `_snapshot_policy`에 (b)(c) 수동 기준도 적혀 있다: 샤드 간 벽시계가
+    1.5배 이상 벌어지거나 25분 천장 대비 여유가 다시 좁아지면 재측정)."""
+    if not weights_path.exists():
+        return None
+    data = json.loads(weights_path.read_text())
+    snapshot_total = data.get("total_files")
+    if not snapshot_total:
+        return None
+    growth = (discovered_count - snapshot_total) / snapshot_total
+    if growth >= 0.20:
+        return (
+            f"가중치 스냅샷({weights_path.name}, {data.get('measured_at', '?')} · "
+            f"{snapshot_total}개) 대비 discover가 {discovered_count}개 — "
+            f"+{growth * 100:.0f}% 증가. 재측정 권장(무거운 새 파일이 '평균 가중치'로만 "
+            f"잡혀 한 샤드에 쏠릴 수 있다)."
+        )
+    return None
+
+
 def partition(files: list[str], weights: dict[str, float], shard_count: int) -> tuple[list[list[str]], list[float]]:
     """greedy LPT — 무거운 순으로 정렬해 매번 «지금 가장 가벼운 샤드」에 넣는다.
     ⭐이 함수는 무손실이다(모든 파일이 정확히 하나의 샤드에 들어간다) —
@@ -81,6 +103,10 @@ def main() -> int:
     files = discover_files()
     weights = load_weights()
     shards, totals = partition(files, weights, args.shard_count)
+
+    staleness = check_staleness(len(files))
+    if staleness:
+        print(f"⚠️ {staleness}", file=sys.stderr)
 
     if args.print_summary:
         print(f"discovered {len(files)} destructive_schema files total (discover가 SSOT)", file=sys.stderr)

--- a/backend/tests/test_shard_destructive_tests.py
+++ b/backend/tests/test_shard_destructive_tests.py
@@ -92,3 +92,30 @@ def test_shard_index_out_of_range_is_rejected():
     mod = _load()
     with pytest.raises(ValueError):
         mod.partition(["a"], {}, shard_count=0)
+
+
+def test_check_staleness_flags_20pct_file_growth(tmp_path):
+    mod = _load()
+    weights_path = tmp_path / "weights.json"
+    weights_path.write_text(json.dumps({
+        "measured_at": "2026-01-01", "total_files": 100, "total_sec": 500.0,
+        "files": [{"file": "tests/test_a.py", "sec": 5.0}],
+    }))
+    assert mod.check_staleness(119, weights_path) is None, "19% 증가는 아직 경고 아님"
+    warning = mod.check_staleness(120, weights_path)
+    assert warning is not None and "+20%" in warning
+
+
+def test_check_staleness_silent_when_stable(tmp_path):
+    mod = _load()
+    weights_path = tmp_path / "weights.json"
+    weights_path.write_text(json.dumps({
+        "measured_at": "2026-01-01", "total_files": 94, "total_sec": 534.7, "files": [],
+    }))
+    assert mod.check_staleness(94, weights_path) is None
+    assert mod.check_staleness(80, weights_path) is None, "줄어든 것은 경고 대상 아님"
+
+
+def test_check_staleness_missing_file_is_silent(tmp_path):
+    mod = _load()
+    assert mod.check_staleness(94, tmp_path / "nope.json") is None

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1,4 +1,5 @@
 {
+  "_snapshot_policy": "story #2293(2026-07-28) — 이건 그 시점의 스냅샷이지 실시간 측정이 아니다. backend/scripts/shard_destructive_tests.py의 partition()이 이 가중치로 샤드 4개를 균형배분한다 — 스위트가 자라거나(새 destructive_schema 파일 추가) 특정 파일이 눈에 띄게 느려지면 이 스냅샷은 조용히 낡고 샤드 균형도 조용히 무너진다(discover 자체는 항상 최신이라 파일이 빠지진 않지만, 무거운 새 파일이 '평균 가중치'로만 잡혀 한 샤드에 쏠릴 수 있다). 재측정 시점 기준: (a) destructive_schema 파일 수가 이 스냅샷 대비 +20% 이상 늘었을 때, (b) 어느 한 샤드의 CI 벽시계가 다른 샤드 대비 눈에 띄게(체감상 1.5배 이상) 벌어질 때, (c) 25분 천장 대비 여유가 다시 좁아지는 게 느껴질 때. 재측정 방법: PR run의 'Backend destructive-schema (shard)' 각 job 로그에서 파일별 pytest 실행시간을 다시 뽑아 이 files 배열과 total_files/total_sec/measured_at을 갱신.",
   "source_run": 30360717358,
   "measured_at": "2026-07-28",
   "total_files": 94,


### PR DESCRIPTION
## Summary
- #2581(story #2293) 머지 후 파울로군 후속 지적: `infra/destructive-schema-shard-weights.json`이 2026-07-28 스냅샷일 뿐 실시간 측정이 아니라는 사실이 코드/문서 어디에도 안 남아 있었다 — "반년 뒤 아무도 그게 스냅샷인 줄 모른다."
- weights.json에 `_snapshot_policy` 필드로 재측정 기준 3가지(파일수 +20%·샤드간 벽시계 1.5배 이상 벌어짐·25분 천장 대비 여유 재축소)와 재측정 방법을 명문화.
- `check_staleness()` — 그중 자동으로 확인 가능한 기준(a, 파일수 +20%)은 매 실행마다 discover 결과와 스냅샷을 대조해 stderr 경고. 하드fail은 아님(사람 판단 몫으로 남김 — 파일 몇 개 늘었다고 CI를 막을 일은 아니라서).

## Test plan
- [x] `uv run pytest -q tests/test_shard_destructive_tests.py` — 14 passed(신규 3건 포함: 19%/20% 경계·감소는 무경고·스냅샷 부재는 무경고)
- [x] 실제 저장소 상태(94개)로 로컬 실행 — 경고 없음(false positive 0) 확인

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>