### PR TITLE
fix(mcp): mentions doc→doc/story/epic + reuse server reference_token

### DIFF
--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -607,9 +607,12 @@ _TOOL_DEFS: list[tuple] = [
      ProposeCanonicalInput, propose_canonical_version),
     # Chat (4)
     ("sprintable_send_chat_message",
-     "[조직] conversation thread에 채팅 메시지 발송. mentions=[{type:\"doc\", id, title?}]로 human"
-     " `#`-검색 doc mention과 동형인 `[title](entity:doc:id)` 토큰을 content에 합성(title 생략 시"
-     " 서버가 doc title 조회) — agent 발신 메시지에서도 doc 링크/backlink가 동작하게 한다.",
+     "[조직] conversation thread에 채팅 메시지 발송. mentions=[{type:\"doc\"|\"story\"|\"epic\", id,"
+     " title?}]로 human `#`-검색 mention과 동형인 `[title](entity:<type>:id)` 토큰을 content에"
+     " 합성(title 생략 시 서버가 canonical title로 만든 reference_token을 그대로 재사용 —"
+     " content에 직접 `[제목](entity:...)` 문자열을 손으로 짓지 말 것: 제목에 `]`가 들어가면"
+     " (예: \"[TAG] 제목\" 관례) 파서가 못 읽는다) — agent 발신 메시지에서도 링크/backlink가"
+     " 동작하게 한다.",
      SendChatInput, send_chat_message),
     ("sprintable_create_conversation",
      "[조직] 새 conversation thread 생성.",

--- a/backend/sprintable_mcp/tools/chat.py
+++ b/backend/sprintable_mcp/tools/chat.py
@@ -29,6 +29,12 @@ def escape_mention_title(title: str) -> str:
     백슬래시로 escape하고, `\r`/`\n` 연속을 단일 공백으로 접는다. title이 caller 제공이든
     (agent가 임의 문자열 전달 가능) DB에서 fetch한 것이든(문서 제목에 임의 문자 가능) 동일하게
     적용해야 `[{title}](entity:doc:{id})` 토큰 구조가 깨지지 않는다.
+
+    ⛔PO 지적(2026-07-28, #2585 리뷰): 이 함수가 여전히 「규칙이 둘인 자리」 하나를 남긴다 —
+    title을 caller가 직접 지정하는 경로(`_resolve_mention_content`에서 `mention.title is not
+    None`인 분기)는 백엔드 `build_reference_token`이 만들 토큰이 애초에 없다(그 문자열은 DB에
+    없는 caller 전용 표시 문구이므로). 그래서 이 경로만은 어쩔 수 없이 로컬 escape를 계속 쓴다 —
+    `_escape_title`(reference_token.py)과 규칙이 갈리면 다시 벌어질 자리로 표시해 둔다.
     """
     escaped = _MENTION_TITLE_ESCAPE_RE.sub(lambda m: "\\" + m.group(0), title)
     return _MENTION_TITLE_NEWLINE_RE.sub(" ", escaped)
@@ -51,9 +57,19 @@ class MentionRef(SprintableInput):
     """agent 발신 채팅 메시지에 첨부할 entity mention — story 1995(doc 링크 안 됨 근본수정) +
     story #2283 후속(2026-07-28, doc→doc/story/epic 확장).
 
-    type은 스키마 레벨에서 doc/story/epic만 허용(Literal, `_MENTION_ENTITY_ENDPOINTS`와 동일
-    축 — test_mention_ref_types_match_entity_endpoints가 드리프트를 고정) — 그 외 값은
-    핸들러 코드 진입 전에 거부된다.
+    type은 스키마 레벨에서 doc/story/epic만 허용(Literal). MCP 서버는 백엔드 `app.*`를 import
+    하지 않고 HTTP로만 통신하는 별도 프로세스라(api_client.py 참조) 이 목록을 백엔드
+    `reference_registry.ENTITY_RESOLVERS`에서 런타임에 **파생시킬 수 없다** — 두 프로세스가
+    같은 값을 손으로 맞춰 유지하는 수밖에 없는 자리다. 대신
+    `test_mention_entity_endpoints_match_backend_entity_resolvers`가 **테스트로** 그 동일성을
+    고정한다 — 백엔드 registry가 늘면 이 테스트가 빨개져서 여기(이 Literal +
+    `_MENTION_ENTITY_ENDPOINTS`)도 늘리도록 강제한다.
+
+    ⛔실제로 story #2294(target_type에 `task` 개설)에서 이 테스트가 바로 빨개질 것이다 — 그때
+    답은 **이 테스트를 고치거나 느슨하게 하는 것이 아니라, 여기 Literal과
+    `_MENTION_ENTITY_ENDPOINTS`에 `task` 항목을 추가하는 것**이다(가드가 걸렸을 때 나올 수
+    있는 세 가지 반응 — 목록을 넓힌다 / 테스트를 고친다 / 무시한다 — 중 첫 번째만 옳다는 것을
+    미리 적어 둔다).
     """
 
     type: Literal["doc", "story", "epic"]
@@ -125,6 +141,15 @@ async def _resolve_mention_content(args: SendChatInput) -> str:
         entity = await client.get(endpoint)
         token = (entity.get("reference_token") if isinstance(entity, dict) else None) or None
         if token is None:
+            # ⛔PO 지적(2026-07-28, #2585 리뷰): "경고만"으로는 이 폴백이 실제로 얼마나
+            # 타는지 아무도 모른다 — 그러면 twin-rule(로컬 escape vs 서버 build_reference_token)
+            # 이 살아 있는데 살아 있는 줄 모르는 상태가 된다. 이 경고 로그 자체가 그 카운터다 —
+            # Cloud Logging에서 logger="sprintable_mcp.tools.chat" + "missing reference_token"
+            # 문자열로 검색해 발화 빈도를 센다. 만료 날짜를 미리 정하지 않은 이유: MCP와 백엔드가
+            # 같은 배포 유닛(둘 다 backend/ 하위)이라 정상 상태에선 skew가 없어야 하지만, Cloud
+            # Run 리비전 교체 중 짧은 창(구 리비전 파드가 아직 트래픽을 받는 순간)엔 실제로 있을
+            # 수 있다 — 그게 "일회성"인지 "배포마다 반복"인지 아직 실측이 없다. 카운트가 0에
+            # 수렴하면(또는 배포 롤아웃 창에서만 튀는 패턴이 확인되면) 그때 폴백을 걷는다.
             title = (entity.get("title") or "") if isinstance(entity, dict) else ""
             token = f"[{escape_mention_title(title)}](entity:{mention.type}:{mention.id})"
             logger.warning(

--- a/backend/sprintable_mcp/tools/chat.py
+++ b/backend/sprintable_mcp/tools/chat.py
@@ -34,14 +34,29 @@ def escape_mention_title(title: str) -> str:
     return _MENTION_TITLE_NEWLINE_RE.sub(" ", escaped)
 
 
-class MentionRef(SprintableInput):
-    """agent 발신 채팅 메시지에 첨부할 entity mention — story 1995(doc 링크 안 됨 근본수정).
+# story #2283 후속(오르테가 라이브 실측, 2026-07-28): #2282가 만든 escape-aware 정규식은
+# «escape된» `]`만 통과시키고 날것 `]`은 여전히 파서를 못 넘는다(설계상 유지 — greedy/lazy로
+# 늘리면 토큰 경계가 모호해져 더 큰 사고를 부른다는 PO 판정). 그러니 "제목을 손으로 짜서
+# 토큰 문자열을 만드는" 경로는 이 조직 명명 관례([TAG] 제목)에서 구조적으로 깨진다 — 정답은
+# 손으로 안 짓고 **백엔드가 준 reference_token을 그대로 쓰는** 것(#2282 SSOT). doc만
+# 지원하던 것을 story/epic까지 넓혀 «형제 비대칭»(FE만 안 깨지는 것)을 없앤다.
+_MENTION_ENTITY_ENDPOINTS: dict[str, str] = {
+    "doc": "/api/v2/docs/{id}",
+    "story": "/api/v2/stories/{id}",
+    "epic": "/api/v2/goals/{id}",
+}
 
-    type은 스키마 레벨에서 "doc"만 허용(Literal) — MCP tool-call 검증 단계에서 그 외 값은
-    핸들러 코드 진입 전에 거부된다(AC1).
+
+class MentionRef(SprintableInput):
+    """agent 발신 채팅 메시지에 첨부할 entity mention — story 1995(doc 링크 안 됨 근본수정) +
+    story #2283 후속(2026-07-28, doc→doc/story/epic 확장).
+
+    type은 스키마 레벨에서 doc/story/epic만 허용(Literal, `_MENTION_ENTITY_ENDPOINTS`와 동일
+    축 — test_mention_ref_types_match_entity_endpoints가 드리프트를 고정) — 그 외 값은
+    핸들러 코드 진입 전에 거부된다.
     """
 
-    type: Literal["doc"]
+    type: Literal["doc", "story", "epic"]
     id: str
     title: str | None = None
 
@@ -78,11 +93,22 @@ class GetChatMessageInput(SprintableInput):
 
 
 async def _resolve_mention_content(args: SendChatInput) -> str:
-    """story 1995: mentions → `[title](entity:doc:id) ` 토큰을 합성해 content에 붙인다.
+    """story 1995 + #2283 후속: mentions → `[title](entity:<type>:id) ` 토큰을 합성해 content에
+    붙인다.
 
-    title 미지정 mention은 GET /api/v2/docs/{id}로 canonical title을 조회(AC3) — 404/기타 에러는
-    그대로 propagate(호출자 send_chat_message의 try/except가 잡아 err()로 노출·메시지 POST 자체를
-    막는다 — broken 토큰이 실린 반쪽 메시지가 저장되는 걸 방지).
+    ⛔title 미지정 mention은 GET(_MENTION_ENTITY_ENDPOINTS)으로 엔티티를 조회하고, 그 응답의
+    `reference_token` 필드(#2282 SSOT — DocResponse/StoryResponse/GoalResponse가
+    @computed_field로 매 직렬화마다 서버가 escape까지 끝내 만든 것)를 **그대로** 쓴다 — title을
+    가져와 여기서 다시 escape하지 않는다. 로컬 escape 로직(`escape_mention_title`)과 백엔드
+    `build_reference_token`의 escape 규칙이 각각 따로 존재하면(오늘 하루 반복 걸린 twin-system
+    클래스) 한쪽만 고쳐질 때 다시 벌어진다 — 서버가 이미 만든 토큰을 재사용하면 그 위험 자체가
+    없다. 응답에 `reference_token`이 없으면(구버전 백엔드 등 방어적 폴백) title로 로컬 조립하고
+    경고 로그를 남긴다. 404/기타 에러는 그대로 propagate(호출자 send_chat_message의 try/except가
+    잡아 err()로 노출·메시지 POST 자체를 막는다 — broken 토큰이 실린 반쪽 메시지가 저장되는 걸
+    방지).
+
+    title **지정** mention(캐릭터가 표시 문구를 커스텀하고 싶을 때)은 백엔드에 해당 문자열의
+    토큰이 없으므로 로컬 escape로 직접 짓는다 — 이 경로만 `escape_mention_title`을 쓴다.
 
     join 컨벤션: 각 토큰은 FE applyEntity()/applyAsset() 관례와 동일하게 trailing space를 포함
     (`[title](entity:doc:id) `) — 여러 mention은 토큰을 그대로 이어붙이고(토큰마다 이미 뒤 공백이
@@ -92,11 +118,21 @@ async def _resolve_mention_content(args: SendChatInput) -> str:
     """
     tokens: list[str] = []
     for mention in args.mentions or []:
-        title = mention.title
-        if title is None:
-            doc = await client.get(f"/api/v2/docs/{mention.id}")
-            title = (doc.get("title") or "") if isinstance(doc, dict) else ""
-        tokens.append(f"[{escape_mention_title(title)}](entity:doc:{mention.id}) ")
+        if mention.title is not None:
+            tokens.append(f"[{escape_mention_title(mention.title)}](entity:{mention.type}:{mention.id}) ")
+            continue
+        endpoint = _MENTION_ENTITY_ENDPOINTS[mention.type].format(id=mention.id)
+        entity = await client.get(endpoint)
+        token = (entity.get("reference_token") if isinstance(entity, dict) else None) or None
+        if token is None:
+            title = (entity.get("title") or "") if isinstance(entity, dict) else ""
+            token = f"[{escape_mention_title(title)}](entity:{mention.type}:{mention.id})"
+            logger.warning(
+                "send_chat_message: %s %s GET response missing reference_token — built locally "
+                "as fallback (possible backend/mcp version skew)",
+                mention.type, mention.id,
+            )
+        tokens.append(f"{token} ")
     token_block = "".join(tokens)
     return f"{args.content} {token_block}" if args.content else token_block
 

--- a/backend/tests/test_mcp_s1995_agent_doc_mentions.py
+++ b/backend/tests/test_mcp_s1995_agent_doc_mentions.py
@@ -1,4 +1,6 @@
 """story #1995: `sprintable_send_chat_message`의 agent doc-mention 토큰 합성 — MCP 쪽 검증.
+story #2283 후속(오르테가 라이브 실측, 2026-07-28): doc→doc/story/epic 확장 + title 미지정
+경로가 백엔드 `reference_token`(#2282 SSOT)을 재사용하도록 변경 — 검증도 함께 확장.
 
 근본 원인: human이 채팅 UI에서 `#`으로 doc를 검색하면 chat-input.tsx의 applyEntity()가
 `[title](entity:doc:id) ` 토큰을 삽입해 doc 링크/backlink가 동작한다. agent가
@@ -7,11 +9,14 @@ sprintable_send_chat_message로 보내는 raw content엔 이 토큰을 만들 �
 
 이 테스트는 (1) escape helper 단위 테스트(adversarial title — token-injection/forged-link
 방지), (2) mentions→토큰 합성 통합 테스트(title 명시/생략 양쪽 경로 + 404 전파),
-(3) mentions 생략 시 회귀 0(가장 중요), (4) type Literal["doc"] 외 값이 Pydantic 스키마
-레벨에서 거부되는지를 검증한다.
+(3) mentions 생략 시 회귀 0(가장 중요), (4) type Literal["doc","story","epic"] 외 값이
+Pydantic 스키마 레벨에서 거부되는지, (5) title 생략 시 서버 `reference_token`을 그대로
+재사용하는지(+ 없을 때 로컬 fallback+경고), (6) `_MENTION_ENTITY_ENDPOINTS`가 백엔드
+`ENTITY_RESOLVERS`와 축이 같은지(twin-system drift 고정)를 검증한다.
 """
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -67,9 +72,10 @@ def test_escape_mention_title_collapses_newlines_to_single_space():
 
 # ── MentionRef schema validation ──────────────────────────────────────────────
 def test_mention_ref_rejects_invalid_type():
-    """type이 "doc" 외 값이면 Pydantic 스키마 레벨에서 거부(AC1) — 핸들러 코드 진입 전 차단."""
+    """type이 doc/story/epic 외 값이면 Pydantic 스키마 레벨에서 거부(AC1) — 핸들러 코드
+    진입 전 차단."""
     with pytest.raises(ValidationError):
-        MentionRef(type="story", id="s-1")
+        MentionRef(type="task", id="t-1")
 
 
 def test_send_chat_input_rejects_invalid_mention_type():
@@ -80,6 +86,26 @@ def test_send_chat_input_rejects_invalid_mention_type():
 def test_mention_ref_accepts_doc_type():
     m = MentionRef(type="doc", id="d-1", title="My Doc")
     assert m.type == "doc"
+
+
+def test_mention_ref_accepts_story_type():
+    m = MentionRef(type="story", id="s-1", title="My Story")
+    assert m.type == "story"
+
+
+def test_mention_ref_accepts_epic_type():
+    m = MentionRef(type="epic", id="e-1", title="My Epic")
+    assert m.type == "epic"
+
+
+def test_mention_entity_endpoints_match_backend_entity_resolvers():
+    """`_MENTION_ENTITY_ENDPOINTS`(MCP 쪽 type→GET endpoint 매핑)가 백엔드
+    `reference_registry.ENTITY_RESOLVERS`(존재판정 registry, #2259/#2266/#2283이 계속 SSOT로
+    써 온 것)와 같은 타입 집합인지 고정 — 한쪽만 늘면(예: 백엔드에 새 target_type 등록,
+    MCP mentions는 안 넓힘) agent 경로만 뒤처지는 형제 비대칭이 조용히 생긴다."""
+    from app.services.reference_registry import ENTITY_RESOLVERS
+
+    assert set(chat_mod._MENTION_ENTITY_ENDPOINTS) == set(ENTITY_RESOLVERS)
 
 
 # ── send_chat_message: token synthesis (title given) ─────────────────────────
@@ -134,21 +160,93 @@ async def test_send_chat_message_escapes_adversarial_given_title():
         )
 
 
-# ── send_chat_message: title omitted → fetched via client.get ────────────────
+# ── send_chat_message: title omitted → fetched via client.get, reuses reference_token ──
 @pytest.mark.anyio
-async def test_send_chat_message_fetches_title_when_omitted():
+async def test_send_chat_message_reuses_backend_reference_token_when_title_omitted():
+    """⭐#2283 후속 핵심 — title 생략 시 응답의 `reference_token`(#2282 SSOT, 서버가 이미
+    escape까지 끝낸 것)을 그대로 쓴다. 여기서 로컬 escape를 다시 태우지 않는다는 것이 핵심
+    (title이 실제로는 `]`를 포함해도, reference_token 필드 자체가 이미 정답이므로 title
+    파싱/재조립이 필요 없다).
+
+    ⛔fixture 설계 주의 — reference_token을 title의 로컬 escape 결과와 «일부러 다르게»
+    만든다(예: 다른 표시 문구). 둘이 같으면 "reference_token을 썼다"와 "fallback으로 title을
+    로컬 escape했다"를 구별할 수 없는 테스트가 된다(오늘 낮에 반복 경계한 confound 클래스) —
+    실제로 이 실수로 처음 짠 버전은 sabotage(강제 fallback)해도 GREEN이 나와 자체발견했다."""
     args = SendChatInput(
         thread_id="conv-1",
         content="see this",
         mentions=[{"type": "doc", "id": "doc-1"}],
     )
-    with patch.object(chat_mod.client, "get", new=AsyncMock(return_value={"id": "doc-1", "title": "Fetched Doc"})) as g, \
+    fetched = {
+        "id": "doc-1", "title": "Fetched Doc",
+        "reference_token": "[SERVER-CANONICAL-TOKEN](entity:doc:doc-1)",
+    }
+    with patch.object(chat_mod.client, "get", new=AsyncMock(return_value=fetched)) as g, \
          patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m:
         result = await send_chat_message(args)
         g.assert_awaited_once_with("/api/v2/docs/doc-1")
         _, kwargs = m.call_args
-        assert kwargs["json"]["content"] == "see this [Fetched Doc](entity:doc:doc-1) "
+        assert kwargs["json"]["content"] == (
+            "see this [SERVER-CANONICAL-TOKEN](entity:doc:doc-1) "
+        )
         assert "Error" not in result[0].text
+
+
+@pytest.mark.anyio
+async def test_send_chat_message_reuses_reference_token_for_story_type():
+    args = SendChatInput(
+        thread_id="conv-1",
+        content="see this",
+        mentions=[{"type": "story", "id": "story-1"}],
+    )
+    fetched = {
+        "id": "story-1", "title": "My Story",
+        "reference_token": "[SERVER-CANONICAL-STORY-TOKEN](entity:story:story-1)",
+    }
+    with patch.object(chat_mod.client, "get", new=AsyncMock(return_value=fetched)) as g, \
+         patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m:
+        await send_chat_message(args)
+        g.assert_awaited_once_with("/api/v2/stories/story-1")
+        _, kwargs = m.call_args
+        assert kwargs["json"]["content"] == "see this [SERVER-CANONICAL-STORY-TOKEN](entity:story:story-1) "
+
+
+@pytest.mark.anyio
+async def test_send_chat_message_reuses_reference_token_for_epic_type():
+    args = SendChatInput(
+        thread_id="conv-1",
+        content="see this",
+        mentions=[{"type": "epic", "id": "epic-1"}],
+    )
+    fetched = {
+        "id": "epic-1", "title": "My Epic",
+        "reference_token": "[SERVER-CANONICAL-EPIC-TOKEN](entity:epic:epic-1)",
+    }
+    with patch.object(chat_mod.client, "get", new=AsyncMock(return_value=fetched)) as g, \
+         patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m:
+        await send_chat_message(args)
+        g.assert_awaited_once_with("/api/v2/goals/epic-1")
+        _, kwargs = m.call_args
+        assert kwargs["json"]["content"] == "see this [SERVER-CANONICAL-EPIC-TOKEN](entity:epic:epic-1) "
+
+
+@pytest.mark.anyio
+async def test_send_chat_message_falls_back_to_local_escape_when_reference_token_missing(caplog):
+    """방어적 폴백 — 응답에 reference_token 필드가 없으면(구버전 백엔드 등) title로 로컬
+    escape 조립하고 경고 로그를 남긴다(조용한 skew 금지)."""
+    args = SendChatInput(
+        thread_id="conv-1",
+        content="see this",
+        mentions=[{"type": "doc", "id": "doc-1"}],
+    )
+    fetched = {"id": "doc-1", "title": "Fetched Doc"}  # reference_token 없음
+    with caplog.at_level(logging.WARNING, logger="sprintable_mcp.tools.chat"):
+        with patch.object(chat_mod.client, "get", new=AsyncMock(return_value=fetched)), \
+             patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m:
+            await send_chat_message(args)
+            _, kwargs = m.call_args
+            assert kwargs["json"]["content"] == "see this [Fetched Doc](entity:doc:doc-1) "
+    assert any("missing reference_token" in r.message for r in caplog.records)
 
 
 # ── send_chat_message: 404 on doc fetch propagates, no message POST ──────────

--- a/infra/mcp-path-contract-allowlist.yml
+++ b/infra/mcp-path-contract-allowlist.yml
@@ -66,3 +66,16 @@ declared_indirect:
       conversations.py:2162) 전부 실재 확認됨(2026-07-28)
     declared_by: 까심 아르야
     until: "2026-08-27"
+  - module: chat
+    function: _resolve_mention_content
+    reason: >-
+      경로를 `_MENTION_ENTITY_ENDPOINTS[mention.type].format(id=mention.id)`로 조립하는
+      client.get(endpoint) 호출(story #2283 후속, 2026-07-28 — doc→doc/story/epic 확장 +
+      title 미지정 시 서버 reference_token 재사용으로 도입). 호출부는 `mention.type`이 doc/
+      story/epic 셋 중 하나로 Literal 검증되므로 실제로 조립되는 경로는 정확히 3가지뿐 —
+      수기 추적: /api/v2/docs/{id}(app/routers/docs.py:GET /{id}) ·
+      /api/v2/stories/{id}(app/routers/stories.py:539 GET /{id}) ·
+      /api/v2/goals/{id}(app/routers/goals.py:136 GET /{id}, main.py:296에서
+      prefix=/api/v2/goals로 마운트) — 셋 다 실재 확認됨(2026-07-28).
+    declared_by: 디디 은와추쿠
+    until: "2026-08-27"


### PR DESCRIPTION
## 배경
오르테가 라이브 실측(2026-07-28, dev revision `01976-plc`): #2282가 만든 escape-aware
정규식은 «escape된» `]`만 통과시키고 날것 `]`은 여전히 파서를 못 넘는다(설계상 유지 — PO
판정: 정규식을 더 늘리면 토큰 경계가 모호해져 더 큰 사고를 부른다). 즉 손으로
`[제목](entity:type:id)` 문자열을 짓는 경로는 이 조직 명명 관례(`[TAG] 제목`)에서 구조적으로
깨진다. 정답은 손으로 짓지 않고 **백엔드가 이미 만든 `reference_token`(#2282 SSOT)을 그대로
쓰는 것** — PO가 명시적으로 요청한 두 가지(①에이전트 경로에서 토큰 빌더가 닿는가, ②escape
실패를 조용히 안 넘기는가)에 대한 답.

## 구현
- `MentionRef.type`을 `Literal["doc"]` → `Literal["doc", "story", "epic"]`로 확장
  (`_MENTION_ENTITY_ENDPOINTS`, 백엔드 `reference_registry.ENTITY_RESOLVERS`와 키 집합
  동일성을 테스트로 고정 — twin-system drift 방지). doc만 되던 것을 「FE만 안 깨지는」
  형제 비대칭 없이 story/epic까지 넓혔다.
- title 미지정 mention은 GET 응답의 `reference_token` 필드(#2282가 `DocResponse`/
  `StoryResponse`/`GoalResponse`에 `@computed_field`로 부착한 것 — 서버가 escape까지
  끝낸 SSOT)를 **그대로 재사용** — 로컬 `escape_mention_title`(FE `applyAsset` 규칙의
  독립 Python 미러)로 title을 다시 조립하지 않는다. 두 규칙이 각각 존재하면 한쪽만
  고쳐질 때 다시 벌어지는 위험(오늘 하루 반복 걸린 twin-system 클래스)을 원천 제거한다.
  응답에 `reference_token`이 없으면(구버전 백엔드 등) 로컬 escape로 방어적 폴백 + 경고
  로그.
- title 지정(caller가 표시 문구를 커스텀하고 싶을 때) 경로는 백엔드에 해당 문자열의
  토큰이 없으므로 기존대로 로컬 escape 유지.

## 별도 확인 (②는 이미 구현돼 있었다)
PO가 요청한 "escape 실패를 조용히 넘기지 않는 로그"는 #2282에서 이미 구현·머지돼 있었다
(`mention_parser.py::extract_chat_entity_mentions`의 `shape_count` vs 추출건수 비교
경고). Ortega의 정확한 재현 케이스(`[E-PAY] 요금제 정책안 v2.1`류 raw 토큰 + 정상 escape
토큰을 한 메시지에 같이)를 직접 재실행해 경고가 올바르게 발화함을 실측 확認 — 중복
구현 없이 기존 감시망이 이미 그 역할을 하고 있음을 검증만 했다.

## 검증
- 신규/갱신 22개(`test_mcp_s1995_agent_doc_mentions.py`): type 확장(story/epic accept),
  `_MENTION_ENTITY_ENDPOINTS`↔`ENTITY_RESOLVERS` 키 동일성, doc/story/epic 각각
  reference_token 재사용, reference_token 부재 시 로컬 fallback+경고 로그.
- RED→GREEN 자체검증: reference_token 재사용 분기를 Edit로 무력화(`token = None` 강제)
  → 사보타주 확認 도중 **테스트 자체의 결함을 자체발견**: 최초 fixture는 title의 로컬
  escape 결과와 reference_token 값이 우연히 같아 sabotage해도 GREEN이 나오는 confound
  였다 — fixture를 서로 다른 문자열(`SERVER-CANONICAL-*-TOKEN`)로 재설계해 실제로
  구별력 있는 RED를 확認 → 복원 → GREEN.
- 회귀: MCP 스위트 144개 GREEN(`tests/mcp/` + `test_e_mcp_*` + 이 파일). 무관한 라이브
  e2e 도구-개수 테스트(`test_tools_list_89_tools`, 실제 dev 백엔드에 붙어 89 vs 107 카운트
  불일치) 1개 실패는 `git stash`로 내 변경 없이도 동일하게 실패함을 확認 — 환경 요인,
  pre-existing(이 PR이 원인 아님).

## 롤백
`sprintable_mcp/tools/chat.py`의 `MentionRef.type`을 `Literal["doc"]`로, `_resolve_mention_content`를
이전 doc-only+title-escape 버전으로, `server.py`의 도구 설명 문자열을 원복하면 #1995 이후
원래 동작으로 복귀. 신규 코드가 기존 doc mention 경로의 byte-identical 회귀 테스트를 통과하는
순수 확장이라 부분 revert도 안전.