### PR TITLE
[SID:2263] `#` 엔티티 피커 — 종류별 그룹화·글자 라벨·미등록 종류 정상 렌더(㉠㉡㉢)

### DIFF
--- a/apps/web/src/components/chat/chat-input.entity-picker-grouping.test.ts
+++ b/apps/web/src/components/chat/chat-input.entity-picker-grouping.test.ts
@@ -1,0 +1,66 @@
+/**
+ * story #2263(C-5) ㉠㉡㉢ — `#` 엔티티 피커가 종류로 묶여 보이고, 라벨이 글자로 우선하며,
+ * 화면이 모르는 종류도 "정상 경로"로 그려지는지(조용한 Hash 실패 대신)를 고정한다.
+ */
+import { describe, expect, it } from 'vitest';
+import { entityTypeLabel, groupEntitiesByType } from './chat-input';
+
+interface EntityResult {
+  entity_type: string;
+  entity_id: string;
+  title: string;
+  status: string | null;
+}
+
+function er(entity_type: string, entity_id: string, title = entity_id): EntityResult {
+  return { entity_type, entity_id, title, status: null };
+}
+
+describe('entityTypeLabel — ㉠ 종류를 글자로, ㉢ 모르는 종류도 정상 경로', () => {
+  it('알려진 종류는 한글 라벨을 낸다', () => {
+    expect(entityTypeLabel('story')).toBe('스토리');
+    expect(entityTypeLabel('doc')).toBe('문서');
+    expect(entityTypeLabel('epic')).toBe('에픽');
+    expect(entityTypeLabel('task')).toBe('작업');
+  });
+
+  it('⛔모르는 종류(sprint 등 미래 registry 확장)도 빈 문자열/물음표 없이 원문 그대로 보인다', () => {
+    expect(entityTypeLabel('sprint')).toBe('sprint');
+    expect(entityTypeLabel('hypothesis')).toBe('hypothesis');
+    expect(entityTypeLabel('')).toBe('');
+  });
+});
+
+describe('groupEntitiesByType — ㉡ 종류로 묶되 열은 안 나눈다(단일 순서 배열)', () => {
+  it('뒤섞인 종류를 첫 등장 순서 기준으로 묶어 재배열한다', () => {
+    const mixed = [er('story', 's1'), er('doc', 'd1'), er('story', 's2'), er('doc', 'd2'), er('epic', 'e1')];
+    const grouped = groupEntitiesByType(mixed);
+    expect(grouped.map((r) => `${r.entity_type}:${r.entity_id}`)).toEqual([
+      'story:s1', 'story:s2', 'doc:d1', 'doc:d2', 'epic:e1',
+    ]);
+  });
+
+  it('그룹 내부 순서(관련도/최신순 등 BE가 준 순서)는 보존한다', () => {
+    const mixed = [er('doc', 'd-newest'), er('story', 's1'), er('doc', 'd-older')];
+    const grouped = groupEntitiesByType(mixed);
+    const docIds = grouped.filter((r) => r.entity_type === 'doc').map((r) => r.entity_id);
+    expect(docIds).toEqual(['d-newest', 'd-older']);
+  });
+
+  it('모르는 종류가 섞여도 그대로 하나의 그룹으로 묶인다(하드코딩된 타입 나열에 안 걸림)', () => {
+    const mixed = [er('sprint', 'sp1'), er('story', 's1'), er('sprint', 'sp2')];
+    const grouped = groupEntitiesByType(mixed);
+    expect(grouped.map((r) => `${r.entity_type}:${r.entity_id}`)).toEqual([
+      'sprint:sp1', 'sprint:sp2', 'story:s1',
+    ]);
+  });
+
+  it('빈 배열은 빈 배열을 낸다', () => {
+    expect(groupEntitiesByType([])).toEqual([]);
+  });
+
+  it('종류가 하나뿐이면 원래 순서 그대로다', () => {
+    const single = [er('story', 's1'), er('story', 's2'), er('story', 's3')];
+    expect(groupEntitiesByType(single)).toEqual(single);
+  });
+});

--- a/apps/web/src/components/chat/chat-input.test.tsx
+++ b/apps/web/src/components/chat/chat-input.test.tsx
@@ -163,3 +163,51 @@ describe('ChatInput — ESC 우선순위(story #2032 AC4/AC5)', () => {
     expect(onEscape).not.toHaveBeenCalled(); // 후보 우선 — 대화 밖으로 안 나감
   });
 });
+
+describe('ChatInput — `#` 엔티티 피커 종류별 그룹화(story #2263 ㉠㉡㉢)', () => {
+  it('뒤섞인 종류 응답이 실 렌더에서 종류별 머리글로 묶여 나온다(모르는 종류도 정상 렌더)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/entities/search')) {
+        return new Response(JSON.stringify({
+          // 일부러 인터리빙(doc·story·doc·sprint) — 그룹핑이 실제로 재배열해야만
+          // "문서 둘"이 "스토리 하나"보다 앞으로 옮겨진다(그룹핑 없으면 원본 순서 그대로라
+          // "스토리 하나"가 "문서 둘"보다 앞에 남아 이 assertion이 그 결여를 잡아낸다).
+          data: [
+            { entity_type: 'doc', entity_id: 'd1', title: '문서 하나', status: null },
+            { entity_type: 'story', entity_id: 's1', title: '스토리 하나', status: 'in-progress' },
+            { entity_type: 'doc', entity_id: 'd2', title: '문서 둘', status: null },
+            { entity_type: 'sprint', entity_id: 'sp1', title: '스프린트 하나', status: null },
+          ],
+        }));
+      }
+      return new Response(JSON.stringify({ data: [] }));
+    }));
+
+    await act(async () => {
+      root.render(withIntl(<ChatInput threadId="c1" projectId="p1" onSend={vi.fn()} />));
+    });
+    const el = textarea();
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(el, '#');
+      el.selectionStart = 1;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    // 엔티티 검색은 200ms 디바운스 뒤 fetch — 실 타이머로 흘려보낸다.
+    await act(async () => { await new Promise((r) => setTimeout(r, 260)); });
+
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox).not.toBeNull();
+    const text = listbox!.textContent ?? '';
+    // ㉡: 인터리빙된 응답이 doc 그룹으로 다시 묶인다 — 그룹핑이 없다면 "문서 둘"은
+    // 원본 순서상 "스토리 하나" 뒤에 그대로 남아 이 assertion이 실패한다(mutation-verified).
+    expect(text.indexOf('문서 둘')).toBeLessThan(text.indexOf('스토리 하나'));
+    expect(text.indexOf('문서 하나')).toBeLessThan(text.indexOf('문서 둘'));
+    // ㉠: 종류 라벨이 글자로 보인다.
+    expect(text).toContain('문서');
+    expect(text).toContain('스토리');
+    // ㉢: 모르는 종류(sprint)도 빈 값·물음표 없이 원문 그대로 정상 렌더된다.
+    expect(text).toContain('sprint');
+    expect(text).toContain('스프린트 하나');
+  });
+});

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -130,6 +130,32 @@ interface EntityResult {
   status: string | null;
 }
 
+// story #2263(C-5) ㉠㉢: 종류를 «글자»로 보이는 라벨. ⛔서버가 신규 종류를 주면(registry는
+// 화면이 모르는 채로 늘 수 있다) 목록에 없는 값도 "정상 경로"로 그려야 한다 — 매핑이 없으면
+// 원문 종류 문자열을 그대로 쓴다(공백/대문자 처리 없이도 "sprint"·"hypothesis"처럼 읽을 수
+// 있는 값이라 그 자체로 충분히 "정상"이다. 빈 문자열·물음표·아이콘만 남기는 실패 대신).
+const ENTITY_TYPE_LABELS: Record<string, string> = {
+  story: '스토리', doc: '문서', epic: '에픽', task: '작업',
+};
+export function entityTypeLabel(type: string): string {
+  return ENTITY_TYPE_LABELS[type] ?? type;
+}
+
+// story #2263(C-5) ㉡: 종류로 묶어 보이되 열은 나누지 않는다(키보드 이동이 한 줄기여야 하므로
+// entityResults 자체의 순서를 그룹 순서로 재배열한다 — entityIndex가 이 배열을 그대로
+// 인덱싱하므로 렌더 순서=키보드 이동 순서가 항상 같다, 별도 변환이 렌더 시점에 필요 없다).
+// ⛔BE(entities.py)의 최종 정렬(가나다/최신순)이 종류를 뒤섞을 수 있으므로 첫 등장 순서를
+// 그룹 우선순위로 쓰는 stable regroup(하드코딩된 타입 나열 없음 — 데이터가 순서를 정한다).
+export function groupEntitiesByType(results: EntityResult[]): EntityResult[] {
+  const order: string[] = [];
+  const buckets = new Map<string, EntityResult[]>();
+  for (const r of results) {
+    if (!buckets.has(r.entity_type)) { buckets.set(r.entity_type, []); order.push(r.entity_type); }
+    buckets.get(r.entity_type)!.push(r);
+  }
+  return order.flatMap((type) => buckets.get(type)!);
+}
+
 // story #2032 — 대화별 임시저장(localStorage). 대화 전환은 ChatView가 key={conversation_id}로
 // ChatInput을 통째로 리마운트시키므로(page.tsx), threadId가 이 컴포넌트 수명 중에 바뀌는
 // 경우 자체가 없다 — 마운트 시 lazy initializer로 그 대화의 초안을 1회 읽으면 AC3(대화별
@@ -235,7 +261,7 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
         .then((json: EntityResult[] | { data?: EntityResult[] }) => {
           if (cancelled) return;
           const arr = Array.isArray(json) ? json : (json.data ?? []);
-          setEntityResults(Array.isArray(arr) ? arr : []);
+          setEntityResults(groupEntitiesByType(Array.isArray(arr) ? arr : []));
           setEntityIndex(0);
         })
         .catch(() => {});
@@ -620,13 +646,20 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
           </ul>
         )}
 
-        {/* Entity dropdown */}
+        {/* Entity dropdown — story #2263(C-5) ㉡: 종류별 구역(머리글)으로 묶되 열은 안 나눈다
+            (entityResults가 이미 groupEntitiesByType로 그룹 순서라 렌더 순서=entityIndex 순서). */}
         {entityResults.length > 0 && (
           <ul role="listbox" aria-label="엔티티 후보" className="focus-inset absolute bottom-full left-8 z-50 mb-1 max-h-48 w-72 overflow-y-auto rounded-md border border-border bg-popover shadow-md">
             {entityResults.map((entity, idx) => {
               const EntityIcon = ENTITY_ICONS[entity.entity_type] ?? Hash;
+              const isNewGroup = idx === 0 || entityResults[idx - 1]!.entity_type !== entity.entity_type;
               return (
               <li key={`${entity.entity_type}:${entity.entity_id}`}>
+                {isNewGroup && (
+                  <div className="sticky top-0 bg-popover px-3 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    {entityTypeLabel(entity.entity_type)}
+                  </div>
+                )}
                 <button
                   type="button"
                   id={`entity-opt-${idx}`}
@@ -635,7 +668,8 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
                   onMouseDown={(e) => { e.preventDefault(); selectEntity(entity); }}
                   className={`flex w-full items-center px-3 py-2 text-left text-sm transition ${idx === entityIndex ? 'bg-accent text-foreground font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}`}
                 >
-                  <EntityIcon className="mr-1.5 size-3.5 shrink-0" />
+                  {/* ㉠: 종류는 위 머리글의 «글자»가 1차 신호 — 이 아이콘은 어디까지나 보조. */}
+                  <EntityIcon className="mr-1.5 size-3.5 shrink-0" aria-hidden />
                   <span className="font-medium">{entity.title}</span>
                   {entity.status ? (
                     <span className="ml-2 rounded px-1.5 py-0.5 text-xs bg-muted text-muted-foreground">{entity.status}</span>


### PR DESCRIPTION
## 범위

story #2263(C-5)의 유나 확定 규격(bca74509 v3) 중 **BE 계약이 필요 없는 셋(㉠㉡㉢)**만 이번 판에서 잇는다. ①(종류별 보장 몫)·②(잘림 투명성)는 `entities.py` 응답이 지금 재료(종류별 shown/more count)를 안 줘 화면이 지어내지 않고서는 못 고치는 자리라 BE 계약 착지 후 별건으로 진행한다. ㉣(#2294, 저장결과 확認)도 별도 스토리 — PO가 BE에 `references: {stored, dropped[]}` 사이드밴드를 확定해 디디군에게 넘긴 상태다.

## ㉠ 종류를 글자로, 아이콘은 보조

`entityTypeLabel(type)` — 여덟 종류가 되면 아이콘 변별이 무너진다는 유나 실측을 그대로 반영, 각 그룹 머리글에 한글 라벨을 텍스트로 표시(아이콘은 각 행에 보조로만 남김).

## ㉢ 모르는 종류도 "정상 경로"로 그린다

지금은 `ENTITY_ICONS[type] ?? Hash`로 아이콘만 조용히 대체되고 그 종류의 **이름 자체가 화면 어디에도 안 뜬다** — 아홉째 종류가 등장하면 또 같은 결함이 반복될 자리였다. `entityTypeLabel`은 매핑이 없으면 원문 타입 문자열(`"sprint"`, `"hypothesis"` 등)을 그대로 라벨로 쓴다 — 빈 값·물음표 없이 그 자체로 읽을 수 있는 정상 표시.

## ㉡ 종류로 묶되 열은 안 나눈다

`groupEntitiesByType(results)` — BE(entities.py)의 최종 정렬(가나다/최신순)이 종류를 뒤섞을 수 있어, `entityResults` state 자체를 그룹 순서로 재배열한다(첫 등장 순서를 그룹 우선순위로 — 하드코딩된 타입 나열 없음, 데이터가 순서를 정한다). `entityIndex`가 이 배열을 그대로 인덱싱하므로 키보드 이동 순서=렌더 순서가 항상 일치(열 분리 없이 단일 스트림 유지).

## 검증

- 신규 순수함수 테스트 7건(`entityTypeLabel`/`groupEntitiesByType` 격리 단위) + 실 렌더 통합 테스트 1건(인터리빙된 mock 응답으로 `<ChatInput>`을 실제로 렌더해 그룹 재배열·라벨·미등록 타입 정상 표시를 DOM에서 확인).
- mutation-verified: `groupEntitiesByType` 호출 제거 → 통합 테스트가 정확히 그 결여(재배열 안 됨)를 잡고 RED → 원복 GREEN.
- 전체 FE vitest: 298 파일·1997 테스트 PASS(회귀 0). `tsc --noEmit`/`eslint` 무오류.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>