### PR TITLE
fix(mcp): 경로↔서버 불일치 남은 4건 — 경로/스키마/신설/명시오류 각각 다르게 (#2281)

### DIFF
--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -26,6 +26,7 @@ from app.schemas.retro import (
     CreateAction,
     CreateItem,
     CreateSession,
+    GetOrCreateBySprint,
     GroupItem,
     ItemResponse,
     PhaseTransition,
@@ -164,6 +165,57 @@ async def create_session(
         created_by=creator.id,
     )
     return SessionListResponse.model_validate(session)
+
+
+@router.post("/by-sprint", response_model=SessionResponse)
+async def get_or_create_session_by_sprint(
+    body: GetOrCreateBySprint,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> SessionResponse:
+    """story #2281 AC3ⓐ — MCP `get_retro_session`(sprint_id 기준 get-or-create)이 부르던
+    메커니즘이 서버에 여태 없었다(#2271에서 처음 발견 — 도구는 등재됐지만 한 번도 정상
+    실행된 적 없었다). project_id는 caller가 안 넘긴다 — sprint 자체가 project를 이미
+    알므로(POST "" 처럼 body.project_id와 body.sprint_id의 정합을 별도 검증할 필요가
+    구조적으로 없다).
+
+    ⚠️여러 세션이 같은 sprint에 있을 수 있는 경우(수동 중복 생성 등) — `created_at DESC`로
+    명시 정렬해 가장 최근 것을 반환한다(BaseRepository.list()는 ORDER BY가 없어 비결정적 —
+    story #2260류 교훈, 여기서 직접 쿼리로 우회)."""
+    sprint = (
+        await db.execute(select(Sprint).where(Sprint.id == body.sprint_id, Sprint.org_id == org_id))
+    ).scalar_one_or_none()
+    if sprint is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    if not await has_project_access(db, uuid.UUID(auth.user_id), sprint.project_id, org_id):
+        raise HTTPException(status_code=403, detail="해당 프로젝트 접근 권한이 없습니다")
+
+    existing = (
+        await db.execute(
+            select(RetroSession)
+            .where(
+                RetroSession.org_id == org_id,
+                RetroSession.sprint_id == body.sprint_id,
+            )
+            .order_by(RetroSession.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+    if existing is not None:
+        session = existing
+    else:
+        creator = await resolve_member(auth, org_id, db, project_id=sprint.project_id)
+        repo = RetroSessionRepository(db, org_id)
+        session = await repo.create(
+            project_id=sprint.project_id,
+            title=body.title or f"{sprint.title} 회고",
+            sprint_id=body.sprint_id,
+            created_by=creator.id,
+        )
+
+    return await _build_session_response(db, session, auth)
 
 
 async def _build_session_response(

--- a/backend/app/schemas/retro.py
+++ b/backend/app/schemas/retro.py
@@ -13,6 +13,13 @@ class CreateSession(BaseModel):
     created_by: uuid.UUID | None = None
 
 
+class GetOrCreateBySprint(BaseModel):
+    """story #2281 AC3ⓐ — sprint_id 기준 get-or-create. project_id는 안 받는다 —
+    sprint 자체가 project를 이미 알아 caller가 넘긴 값과 어긋날 여지가 없다."""
+    sprint_id: uuid.UUID
+    title: str | None = None
+
+
 class ItemResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/sprintable_mcp/tools/notifications.py
+++ b/backend/sprintable_mcp/tools/notifications.py
@@ -63,20 +63,26 @@ async def check_notifications(args: CheckNotificationsInput) -> list[TextContent
 
 
 async def mark_notification_read(args: MarkNotificationReadInput) -> list[TextContent]:
-    """알림 읽음 처리."""
-    body: dict = {"id": args.notification_id, "is_read": args.is_read if args.is_read is not None else True}
-    try:
-        return ok(await client.patch("/api/v2/notifications", json=body))
-    except Exception as exc:
-        return err(str(exc))
+    """알림 읽음 처리 — story #2281 AC3ⓒ: 단건 읽음처리 라우트가 서버에 없다(#2271 발견).
+    ⓐ(서버에 만든다)는 알림 자체의 재설계(#2201·#2279)와 순서가 얽혀 PO가 순서를 잡기로
+    했다 — 그때까지 이 도구는 «조용한 404» 대신 명시적으로 미지원임을 말한다(AC4)."""
+    return err(
+        "단건 알림 읽음처리는 서버에 아직 구현돼 있지 않습니다(story #2281 — "
+        "알림 재설계 #2201/#2279와 순서가 얽혀 보류 중). 전체 읽음처리는 "
+        "mark_all_notifications_read를 쓰세요."
+    )
 
 
 async def mark_all_notifications_read(args: MarkAllNotificationsReadInput) -> list[TextContent]:
-    """전체 알림 읽음 처리."""
-    body: dict = {"markAllRead": True}
+    """전체 알림 읽음 처리 — story #2281 AC1: 경로가 틀렸었다(#2271). 서버는 body를
+    아예 안 받는다(auth로만 전체를 읽음처리) — type 필터는 서버 미지원이라 조용히
+    무시하지 않고 명시 오류로 막는다(AC4)."""
     if args.type:
-        body["type"] = args.type
+        return err(
+            "mark_all_notifications_read의 type 필터는 서버가 아직 지원하지 않습니다"
+            "(무시하고 전체를 읽음처리하면 의도와 다른 결과가 조용히 발생하므로 막습니다)."
+        )
     try:
-        return ok(await client.patch("/api/v2/notifications", json=body))
+        return ok(await client.patch("/api/v2/notifications/mark-all-read"))
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/standup.py
+++ b/backend/sprintable_mcp/tools/standup.py
@@ -35,11 +35,11 @@ class ListStandupEntriesInput(SprintableInput):
 
 class GetRetroSessionInput(SprintableInput):
     sprint_id: str
-    org_id: str | None = None
-    initiator_id: str | None = None
+    title: str | None = None  # 새로 만들어야 할 때만 쓰임(생략 시 서버가 "{스프린트} 회고")
 
 
 class UpdateRetroActionStatusInput(SprintableInput):
+    session_id: str  # story #2281 AC2 — 실제 서버 경로가 세션 id를 요구해 추가(누락이 원 결함)
     action_id: str
     status: str  # open | done
 
@@ -106,22 +106,24 @@ async def list_standup_entries(args: ListStandupEntriesInput) -> list[TextConten
 
 
 async def get_retro_session(args: GetRetroSessionInput) -> list[TextContent]:
-    """스프린트 레트로 세션 조회 (없으면 생성)."""
+    """스프린트 레트로 세션 조회(없으면 생성) — story #2281 AC3ⓐ: 부르던 경로/메커니즘
+    자체가 서버에 없었다(#2271). `POST /api/v2/retros/by-sprint`를 신설해 고쳤다."""
     try:
-        params: dict = {"project_id": client.require_project_id()}
-        if args.org_id:
-            params["org_id"] = args.org_id
-        if args.initiator_id:
-            params["initiator_id"] = args.initiator_id
-        return ok(await client.get(f"/api/v2/retro/{args.sprint_id}", params=params))
+        body: dict = {"sprint_id": args.sprint_id}
+        if args.title:
+            body["title"] = args.title
+        return ok(await client.post("/api/v2/retros/by-sprint", json=body))
     except Exception as exc:
         return err(str(exc))
 
 
 async def update_retro_action_status(args: UpdateRetroActionStatusInput) -> list[TextContent]:
-    """레트로 액션 아이템 상태 변경 (open|done)."""
+    """레트로 액션 아이템 상태 변경 (open|done) — story #2281 AC2: 경로에 세션 id가
+    빠져 있었다(입력 스키마 자체에 필드가 없었음)."""
     try:
-        return ok(await client.patch(f"/api/v2/retro/actions/{args.action_id}", json={"status": args.status}))
+        return ok(await client.patch(
+            f"/api/v2/retros/{args.session_id}/actions/{args.action_id}", json={"status": args.status}
+        ))
     except Exception as exc:
         return err(str(exc))
 

--- a/backend/tests/test_2281_mcp_path_and_schema_fixes.py
+++ b/backend/tests/test_2281_mcp_path_and_schema_fixes.py
@@ -1,0 +1,111 @@
+"""story #2281 — #2271에서 발견된 MCP 도구↔서버 경로 불일치 4건의 회귀가드.
+
+AC6: "고친 도구마다 경로를 고정하는 테스트가 있어야 한다" — retro.py가 「테스트가 전무해
+미검출」이었던 것이 그 병의 뿌리였다. 여기서는 mock client로 각 도구가 실제로 부르는
+경로/메서드/바디를 고정하고, 부재였던 두 건(ⓐ건은 실제 서버 라우트, ⓒ건은 명시적 오류)의
+새 행동을 고정한다.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── AC1 — mark_all_notifications_read: 경로 수정 + body 무의미 문제 해소 ──────────
+
+@pytest.mark.anyio
+async def test_mark_all_notifications_read_calls_correct_path_no_body():
+    from sprintable_mcp.tools.notifications import MarkAllNotificationsReadInput, mark_all_notifications_read
+
+    with patch("sprintable_mcp.tools.notifications.client") as mock_client:
+        mock_client.patch = AsyncMock(return_value={"ok": True})
+        out = await mark_all_notifications_read(MarkAllNotificationsReadInput())
+
+    mock_client.patch.assert_awaited_once_with("/api/v2/notifications/mark-all-read")
+    assert json.loads(out[0].text) == {"ok": True}
+
+
+@pytest.mark.anyio
+async def test_mark_all_notifications_read_type_filter_explicit_error_not_silent_ignore():
+    """서버가 type 필터를 지원 안 하므로, 조용히 무시하지 않고 명시 오류로 막는다(AC4)."""
+    from sprintable_mcp.tools.notifications import MarkAllNotificationsReadInput, mark_all_notifications_read
+
+    with patch("sprintable_mcp.tools.notifications.client") as mock_client:
+        mock_client.patch = AsyncMock()
+        out = await mark_all_notifications_read(MarkAllNotificationsReadInput(type="mention"))
+
+    mock_client.patch.assert_not_awaited()
+    assert out[0].text.startswith("Error:") and "지원하지 않습니다" in out[0].text
+
+
+# ── AC3ⓒ — mark_notification_read: 부재를 명시 오류로(조용한 404 금지, AC4) ──────
+
+@pytest.mark.anyio
+async def test_mark_notification_read_explicit_unsupported_error_not_silent_404():
+    from sprintable_mcp.tools.notifications import MarkNotificationReadInput, mark_notification_read
+
+    with patch("sprintable_mcp.tools.notifications.client") as mock_client:
+        out = await mark_notification_read(MarkNotificationReadInput(notification_id="n1"))
+
+    mock_client.assert_not_called()  # 서버 호출 자체를 안 함 — 없는 기능을 부르지 않는다
+    assert out[0].text.startswith("Error:") and "구현돼 있지 않습니다" in out[0].text
+
+
+# ── AC2 — update_retro_action_status: 경로+입력스키마(session_id) 동시 수정 ────────
+
+@pytest.mark.anyio
+async def test_update_retro_action_status_requires_session_id_in_schema():
+    from sprintable_mcp.tools.standup import UpdateRetroActionStatusInput
+    assert "session_id" in UpdateRetroActionStatusInput.model_fields
+
+
+@pytest.mark.anyio
+async def test_update_retro_action_status_calls_correct_nested_path():
+    from sprintable_mcp.tools.standup import UpdateRetroActionStatusInput, update_retro_action_status
+
+    with patch("sprintable_mcp.tools.standup.client") as mock_client:
+        mock_client.patch = AsyncMock(return_value={"id": "a1", "status": "done"})
+        out = await update_retro_action_status(
+            UpdateRetroActionStatusInput(session_id="s1", action_id="a1", status="done")
+        )
+
+    mock_client.patch.assert_awaited_once_with(
+        "/api/v2/retros/s1/actions/a1", json={"status": "done"}
+    )
+    assert json.loads(out[0].text)["status"] == "done"
+
+
+# ── AC3ⓐ — get_retro_session: 새 서버 라우트(POST /api/v2/retros/by-sprint) 호출 ────
+
+@pytest.mark.anyio
+async def test_get_retro_session_calls_new_by_sprint_route():
+    from sprintable_mcp.tools.standup import GetRetroSessionInput, get_retro_session
+
+    with patch("sprintable_mcp.tools.standup.client") as mock_client:
+        mock_client.post = AsyncMock(return_value={"id": "sess1", "sprint_id": "sp1"})
+        out = await get_retro_session(GetRetroSessionInput(sprint_id="sp1"))
+
+    mock_client.post.assert_awaited_once_with(
+        "/api/v2/retros/by-sprint", json={"sprint_id": "sp1"}
+    )
+    assert json.loads(out[0].text)["id"] == "sess1"
+
+
+@pytest.mark.anyio
+async def test_get_retro_session_passes_title_when_given():
+    from sprintable_mcp.tools.standup import GetRetroSessionInput, get_retro_session
+
+    with patch("sprintable_mcp.tools.standup.client") as mock_client:
+        mock_client.post = AsyncMock(return_value={"id": "sess1"})
+        await get_retro_session(GetRetroSessionInput(sprint_id="sp1", title="스프린트 3 회고"))
+
+    mock_client.post.assert_awaited_once_with(
+        "/api/v2/retros/by-sprint", json={"sprint_id": "sp1", "title": "스프린트 3 회고"}
+    )

--- a/backend/tests/test_2281_retro_get_or_create_by_sprint_realdb.py
+++ b/backend/tests/test_2281_retro_get_or_create_by_sprint_realdb.py
@@ -1,0 +1,190 @@
+"""story #2281 AC3ⓐ·AC5 — POST /api/v2/retros/by-sprint(신설) 실PG 왕복 검증.
+
+MCP `get_retro_session`이 부르던 get-or-create-by-sprint 메커니즘이 서버에 아예 없었다
+(#2271 발견 — 도구는 등재됐지만 한 번도 정상 실행된 적 없었다). 이 라우트를 새로 만들고,
+다음을 실PG로 고정한다: ①없으면 생성 ②있으면 «같은» 세션을 반환(멱등 — 매 호출마다
+새로 안 만듦) ③project 접근권 없는 caller는 403 ④존재하지 않는 sprint_id는 404.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("d2281000-0000-0000-0000-000000000001")
+USER_IN = uuid.UUID("d2281000-0000-0000-0000-0000000000a1")   # PROJ 접근 O
+USER_OUT = uuid.UUID("d2281000-0000-0000-0000-0000000000a2")  # PROJ 접근 X
+OM_IN = uuid.UUID("d2281000-0000-0000-0000-0000000000b1")
+OM_OUT = uuid.UUID("d2281000-0000-0000-0000-0000000000b2")
+PROJ = uuid.UUID("d2281000-0000-0000-0000-000000000c01")
+OTHER_PROJ = uuid.UUID("d2281000-0000-0000-0000-000000000c02")
+SPRINT = uuid.UUID("d2281000-0000-0000-0000-000000000d01")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth(user_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(user_id), email=None, claims={}, org_id=str(ORG))
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _seed(s):
+    for sql in [
+        f"DELETE FROM retro_sessions WHERE org_id='{ORG}'",
+        f"DELETE FROM sprints WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id IN ('{PROJ}','{OTHER_PROJ}')",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id IN ('{USER_IN}','{USER_OUT}')",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','D2281','d2281-org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{USER_IN}','in@d2281.test','x','In',true,true,0,false,0),"
+        f"('{USER_OUT}','out@d2281.test','x','Out',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES "
+        f"('{OM_IN}','{ORG}','{USER_IN}','member'),('{OM_OUT}','{ORG}','{USER_OUT}','member')",
+        f"INSERT INTO members (id,org_id,user_id,type,name,is_active) VALUES "
+        f"('{OM_IN}','{ORG}','{USER_IN}','human','In',true),"
+        f"('{OM_OUT}','{ORG}','{USER_OUT}','human','Out',true)",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ}','{ORG}','P'),('{OTHER_PROJ}','{ORG}','P2')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ}','{OM_IN}','granted')",
+        f"INSERT INTO sprints (id,org_id,project_id,title,status,duration) VALUES "
+        f"('{SPRINT}','{ORG}','{PROJ}','Sprint 1','active',14)",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+@pytest.mark.anyio
+async def test_creates_session_when_none_exists_realdb():
+    from app.routers.retros import get_or_create_session_by_sprint
+    from app.schemas.retro import GetOrCreateBySprint
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            resp = await get_or_create_session_by_sprint(
+                GetOrCreateBySprint(sprint_id=SPRINT), db=s, auth=_auth(USER_IN), org_id=ORG,
+            )
+        assert resp.sprint_id == SPRINT
+        assert resp.project_id == PROJ
+        assert resp.title == "Sprint 1 회고"  # 기본 제목 파생 확認
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_second_call_returns_same_session_not_a_new_one_realdb():
+    """멱등성 — get-or-create의 핵심. 두 번째 호출이 새 세션을 또 만들면 안 된다."""
+    from app.routers.retros import get_or_create_session_by_sprint
+    from app.schemas.retro import GetOrCreateBySprint
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            first = await get_or_create_session_by_sprint(
+                GetOrCreateBySprint(sprint_id=SPRINT), db=s, auth=_auth(USER_IN), org_id=ORG,
+            )
+            await s.commit()  # get_db()의 실 프로덕션 커밋을 흉내(app/core/database.py:77)
+        async with Session() as s:
+            second = await get_or_create_session_by_sprint(
+                GetOrCreateBySprint(sprint_id=SPRINT), db=s, auth=_auth(USER_IN), org_id=ORG,
+            )
+            await s.commit()
+        assert first.id == second.id
+
+        async with Session() as s:
+            count = (await s.execute(
+                text(f"SELECT count(*) FROM retro_sessions WHERE sprint_id='{SPRINT}'")
+            )).scalar_one()
+        assert count == 1, "get-or-create 두 번 불러도 세션이 하나여야 한다"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_custom_title_used_on_create_realdb():
+    from app.routers.retros import get_or_create_session_by_sprint
+    from app.schemas.retro import GetOrCreateBySprint
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            resp = await get_or_create_session_by_sprint(
+                GetOrCreateBySprint(sprint_id=SPRINT, title="커스텀 제목"),
+                db=s, auth=_auth(USER_IN), org_id=ORG,
+            )
+        assert resp.title == "커스텀 제목"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_project_access_is_403_realdb():
+    from app.routers.retros import get_or_create_session_by_sprint
+    from app.schemas.retro import GetOrCreateBySprint
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await get_or_create_session_by_sprint(
+                    GetOrCreateBySprint(sprint_id=SPRINT), db=s, auth=_auth(USER_OUT), org_id=ORG,
+                )
+            assert ei.value.status_code == 403
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_nonexistent_sprint_is_404_realdb():
+    from app.routers.retros import get_or_create_session_by_sprint
+    from app.schemas.retro import GetOrCreateBySprint
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await get_or_create_session_by_sprint(
+                    GetOrCreateBySprint(sprint_id=uuid.uuid4()), db=s, auth=_auth(USER_IN), org_id=ORG,
+                )
+            assert ei.value.status_code == 404
+    finally:
+        await eng.dispose()

--- a/infra/mcp-path-contract-allowlist.yml
+++ b/infra/mcp-path-contract-allowlist.yml
@@ -15,44 +15,17 @@
 # 다음에 같은 파일에 새 병이 또 생겨도 "어차피 여기 원래 빨갛잖아"로 안 보이게 된다.
 # 만료되면 가드가 다시 빨개지고, 그때 #2281 진행 상황을 다시 판단한다.
 
-# 경로 불일치 — story #2281에서 해소 예정. 넷을 같은 답으로 고치지 않기로 함(파울로/까심 합의,
-# 2026-07-28): 경로만 틀린 것 1 · 경로+입력스키마 둘 다 틀린 것 1 · 서버에 기능 자체가 없는 것 2
-# (ⓐ만든다/ⓑ도구를 걷는다/ⓒ명시적 오류로 바꾼다 중 #2281 안에서 판정).
-declared_mismatches:
-  - module: notifications
-    method: PATCH
-    path: /api/v2/notifications
-    tool: mark_notification_read
-    reason: >-
-      단건 알림 읽음처리 라우트가 서버에 없음(#2271 발견, #2281에서 ⓐ만든다/ⓑ걷는다/ⓒ명시오류
-      중 판정 — 유나 화면실측 "가르기 안 됨"과 맞물림)
-    declared_by: PO
-    until: "2026-08-27"
-  - module: notifications
-    method: PATCH
-    path: /api/v2/notifications
-    tool: mark_all_notifications_read
-    reason: >-
-      실제 경로는 PATCH /api/v2/notifications/mark-all-read(#2271 발견, #2281에서 경로 수정 예정)
-    declared_by: PO
-    until: "2026-08-27"
-  - module: standup
-    method: GET
-    path: /api/v2/retro/{sprint_id}
-    tool: get_retro_session
-    reason: >-
-      sprint_id 기준 get-or-create 메커니즘 자체가 서버에 없음(#2271 발견, #2281에서 판정)
-    declared_by: PO
-    until: "2026-08-27"
-  - module: standup
-    method: PATCH
-    path: /api/v2/retro/actions/{action_id}
-    tool: update_retro_action_status
-    reason: >-
-      경로도 틀렸고 입력 스키마(UpdateRetroActionStatusInput)에 세션 id 필드 자체가 없어 경로만
-      고쳐도 못 고침(#2271 발견, #2281에서 스키마+경로 동시 수정 예정)
-    declared_by: PO
-    until: "2026-08-27"
+# story #2281(2026-07-28)에서 4건 전부 해소됨 — declared_mismatches가 빈 배열인 것 자체가
+# 그 증거다(가드가 그린으로 남아 있으면 해소된 것, 다시 불일치가 뜨면 회귀).
+#   · mark_notification_read → ⓒ명시적 오류로 판정(서버측 신설은 알림 재설계 #2201/#2279와
+#     순서가 얽혀 PO가 순서를 잡기로 함 — err() 반환, client 호출 자체를 안 하므로 이 가드
+#     스코프(client.METHOD 호출) 밖으로 자연히 빠짐)
+#   · mark_all_notifications_read → 경로 수정(/mark-all-read) + type 필터 미지원을 명시 오류로
+#   · get_retro_session → ⓐ서버에 신설(POST /api/v2/retros/by-sprint, get-or-create)
+#   · update_retro_action_status → 경로+입력스키마(session_id) 동시 수정
+# 회귀가드: backend/tests/test_2281_mcp_path_and_schema_fixes.py·
+#           test_2281_retro_get_or_create_by_sprint_realdb.py
+declared_mismatches: []
 
 # 간접경로 — 리터럴이 아니라 변수로 경로를 받는 공용 헬퍼. 정적 대조가 원천적으로 못 읽어서
 # "조용히 빠지는" 쪽이라 이름을 반드시 명시하고(M), 수기 추적 결과까지 여기 남긴다.


### PR DESCRIPTION
## Summary
story #2281 — #2271/#2280이 기준선으로 잡고 있던 남은 4건. 성질이 셋으로 갈려 각각 다르게 고쳤다.

## AC1 — mark_all_notifications_read(경로)
- `PATCH /api/v2/notifications` → `/api/v2/notifications/mark-all-read`
- 서버는 body를 아예 안 받음(auth로만 전체 처리). `type` 필터는 서버 미지원 — 조용히 무시하면 "필터링됐다고 믿었는데 사실 전체가 읽음처리된" 사고가 나므로, `type`이 오면 명시 오류로 막는다(AC4).

## AC2 — update_retro_action_status(경로+스키마)
- 입력 스키마에 `session_id`가 없어 경로만 고쳐도 못 고치는 상태였다(서버 라우트가 `/{id}/actions/{action_id}` 2-path-param).
- `session_id` 필드 추가 + `PATCH /api/v2/retros/{session_id}/actions/{action_id}`로 동시 수정.

## AC3 — 「부재」 2건, 각각 근거와 함께 판정
- **get_retro_session → ⓐ서버에 신설**: `POST /api/v2/retros/by-sprint`. sprint_id 기준 get-or-create가 서버에 아예 없었다. `sprint_id`만 받고 `project_id`는 안 받는다(sprint 자체가 project를 안다 — POST `/retros`(body.project_id)와 달리 정합 검증 자체가 불요). realdb로 멱등성(같은 sprint 재호출 시 새 세션 안 만듦) 고정.
- **mark_notification_read → ⓒ명시적 오류로**: 단건 읽음처리 라우트가 서버에 없다. ⓐ(서버 신설)는 유나의 prod 화면 실측("전체 읽음만 가능")과 맞물려 있고 알림 재설계(#2201/#2279)와 순서가 얽혀 있어 PO가 순서를 잡기로 함 — 그때까지 이 도구는 조용한 404 대신 명시 오류를 반환(AC4).

## AC4 — 조용한 404로 안 남김
- 위 4건 모두 명시 오류(err()) 또는 정확한 경로로 고쳐졌다. 어느 경로도 이제 "호출했는데 왜 안 되는지 모르는" 상태가 아니다.

## AC5 — 왕복 실측(realdb)
- `test_2281_retro_get_or_create_by_sprint_realdb.py` — 실제 Postgres(disposable, pgvector/pgvector:pg16)로 5개 시나리오: 신규생성·**멱등성(2회 호출→같은 세션, count=1)**·커스텀 제목·프로젝트 접근권 403·존재하지 않는 sprint 404. 전부 실측 PASS.
  - ⚠️멱등성 테스트에서 첫 구현의 실제 버그(정확히는 테스트가 `get_db()`의 실 프로덕션 커밋을 안 흉내내 두 번째 호출이 새 세션을 만듦)를 잡아 수정한 과정을 커밋 히스토리에 남김.
- `test_2281_mcp_path_and_schema_fixes.py` — mock client로 4개 도구 전부의 정확한 경로/메서드/바디를 고정(AC6).

## AC6 — 회귀 테스트
- 위 두 파일. retro.py가 "테스트 전무"였던 게 원 결함의 뿌리였다(story #2281 본문) — 이번엔 고친 도구마다 경로 고정 테스트가 있다.

## AC7 — #2280 가드 기준선과 일치
- `infra/mcp-path-contract-allowlist.yml`의 `declared_mismatches`를 빈 배열로 비웠다.
- 가드 재실행 결과: **불일치 0건**(허용목록 없이도 그린 — 허용목록으로 가려진 게 아니라 진짜 고쳐졌다는 증거).
  ```
  $ python infra/mcp_path_contract_guard.py
  대조한 112개 / 읽지 못한 1개(M)
  불일치 0건
  ```

## Test plan
- [x] `uv run pytest -q tests/test_2281_mcp_path_and_schema_fixes.py` — 7 passed
- [x] `uv run pytest -q tests/test_2281_retro_get_or_create_by_sprint_realdb.py`(disposable PG) — 5 passed
- [x] 회귀: `test_notifications.py`·`test_retros.py`·`test_retro_mutation_project_scope_idor_realdb.py`·`tests/mcp/test_contract.py`·`test_mcp_path_contract_guard.py` — 135 passed, 0 실패
- [x] `infra/mcp_path_contract_guard.py` 직접 실행 — exit 0, 불일치 0건(빈 허용목록 기준)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>