### PR TITLE
feat(#2294): task를 registry에 열기 — 검색은 되는데 저장은 안 되던 결함 수정

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -1862,7 +1862,7 @@ async def send_message(
     # 예외가 그대로 propagate 되어 메시지 전송 전체가 롤백된다(AC4 원자성 — 아래 best-effort 블록들과
     # 의도적으로 다른 격리 수준).
     from app.services.mention_parser import insert_chat_mentions
-    await insert_chat_mentions(
+    mention_result = await insert_chat_mentions(
         db, org_id=org_id, message_id=msg.id, content=msg.content, created_by=sender.id,
     )
 
@@ -2155,6 +2155,15 @@ async def send_message(
     # E-CHAT-CMD S4: 미지원 런타임으로 차단된 커맨드의 hint 를 발신자에게 반환(AC3 hint response).
     if command_hints:
         response["command_gate"] = {"blocked": command_hints}
+    # story #2294 ③(PO 판정, 미르코 실측): `command_gate.blocked[]`와 동일 원칙 — 화면이
+    # 링크를 그린 뒤 "저장 결과"를 실제로 볼 창구가 구조적으로 없었다(epic/task는 backlinks
+    # read 엔드포인트 자체가 없다). mention 토큰이 하나라도 있었을 때만 싣는다(대부분의
+    # 평문 메시지는 무변경 — 회귀 0). 정상 경로(#2294 ①이 서면 화면이 애초에 못 고르는
+    # 종류를 못 보낸다)에선 dropped가 항상 빈 배열이다 — 그래도 필드를 남기는 이유는
+    # mention_parser.ChatMentionResult 참조(사람이 손으로 토큰을 치거나 에이전트가 API로
+    # 직접 쓰는 경로는 여전히 존재).
+    if mention_result.stored or mention_result.dropped:
+        response["references"] = {"stored": mention_result.stored, "dropped": mention_result.dropped}
     return response
 
 

--- a/backend/app/routers/entities.py
+++ b/backend/app/routers/entities.py
@@ -11,11 +11,21 @@ from app.dependencies.database import get_db
 from app.models.doc import Doc
 from app.models.pm import Goal, Story, Task
 from app.services.project_auth import has_project_access
+from app.services.reference_registry import ENTITY_RESOLVERS
 
 router = APIRouter(prefix="/api/v2/entities", tags=["entities", "Work"])
 
-VALID_TYPES = {"story", "doc", "epic", "task"}
 DEFAULT_LIMIT = 10
+
+
+def _valid_types() -> set[str]:
+    """story #2294 AC1: 검색 허용목록을 `reference_registry.ENTITY_RESOLVERS`에서 «파생»한다 —
+    여기 종류를 다시 나열하지 않는다(맞춘 목록은 다시 갈린다는 것을 오늘 `task`가 실측으로
+    보였다: 이 파일이 예전엔 `{"story","doc","epic","task"}`를 손으로 들고 있었는데
+    registry엔 `task`가 없어 검색은 되지만 저장은 안 되는 결함이 났다). 매 호출마다 registry를
+    다시 읽는다(모듈 로드 시점 스냅샷 금지) — registry가 늘거나 줄면 이 함수도 즉시 같이
+    바뀌어야 "둘이 갈릴 수 없다"는 AC1의 요구가 실제로 성립한다."""
+    return set(ENTITY_RESOLVERS)
 
 
 class EntitySearchResult(BaseModel):
@@ -41,8 +51,9 @@ async def search_entities(
     if not await has_project_access(db, uuid.UUID(auth.user_id), project_id, org_id):
         raise HTTPException(status_code=404, detail="Project not found")
 
-    requested = set(types.split(",")) if types else VALID_TYPES
-    requested = requested & VALID_TYPES
+    valid_types = _valid_types()
+    requested = set(types.split(",")) if types else valid_types
+    requested = requested & valid_types
 
     search = f"%{q}%" if q else None
     results: list[EntitySearchResult] = []

--- a/backend/app/services/mention_parser.py
+++ b/backend/app/services/mention_parser.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 import logging
 import re
 import uuid
+from dataclasses import dataclass
 from html.parser import HTMLParser
 
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -199,6 +200,18 @@ def extract_doc_mention_ids(html_content: str) -> list[uuid.UUID]:
     return result
 
 
+@dataclass(frozen=True)
+class ChatMentionResult:
+    """story #2294 ③ — 메시지 전송 응답의 `references` 사이드밴드가 그대로 실어 나르는 모양
+    (`command_gate.blocked[]` 선례와 동일 원칙, 재구현 0). `stored`는 이번 호출에서 실제로
+    쓰기를 시도한 건수(등록된 target_type만), `dropped`는 토큰은 파싱됐지만 target_type이
+    `target_types`(registry) 밖이라 걸러진 것들 — 화면이 "연결했다고 믿었는데 조용히 안
+    만들어진" 경우를 볼 수 있는 유일한 창구다(#2294 발견의 근본 원인)."""
+
+    stored: int
+    dropped: list[dict[str, str]]
+
+
 async def insert_chat_mentions(
     db: AsyncSession,
     *,
@@ -207,7 +220,7 @@ async def insert_chat_mentions(
     content: str,
     created_by: uuid.UUID,
     target_types: frozenset[str] = frozenset(ENTITY_RESOLVERS),
-) -> None:
+) -> ChatMentionResult:
     """채팅 write-path: insert-only(메시지 불변 전제 — 재조정 불필요). 같은 트랜잭션(caller 의
     세션 그대로 사용·별도 커밋 없음) — 실패 시 예외가 그대로 propagate 되어 caller(메시지 전송
     트랜잭션) 전체가 롤백된다(AC4 원자성).
@@ -226,13 +239,37 @@ async def insert_chat_mentions(
 
     story #2273: write target이 옛 `mentions`(Mention)에서 `entity_references`(Reference)로
     재배선됐다. source_field="body"(채팅 메시지는 텍스트 필드가 하나뿐 — PO 정정, NULL로
-    "없음"을 표현하지 않는다)."""
-    pairs = [
-        (etype, eid) for etype, eid in extract_chat_entity_mentions(content)
-        if etype in target_types
+    "없음"을 표현하지 않는다).
+
+    ⛔story #2294 AC3/③(2026-07-28, 미르코 실측·PO 판정): 예전엔 `target_types` 밖 타입을
+    **완전히 침묵하며** 걸렀다(반환값 `None`, 로그 0) — "화면은 링크를 그려 주는데 서버는
+    조용히 거부"하는 결함이 여기서 났다(`task`가 실제로 이 자리에 걸렸다: 검색은 내주는데
+    registry엔 없었다). 이제 걸러진 것을 `ChatMentionResult.dropped`로 반환 + `logger.warning`
+    으로 남긴다 — 호출자(conversations.py)가 이걸 메시지 응답의 `references` 사이드밴드로
+    실어 화면이 "저장 결과를 실제로 볼" 창구를 준다. `stored`는 성공(등록된 타입) 건수 —
+    #2294 ①(검색 허용목록이 registry에서 파생)이 서면 화면이 애초에 못 고르는 종류를 보낼 수
+    없어져 정상 경로에선 `dropped`가 항상 빈 배열이다. 그래도 이 필드를 남기는 이유: 사람이
+    손으로 토큰을 치거나 에이전트가 API로 본문을 직접 쓸 수 있어(PO가 직접 실측 — escape
+    안 된 raw `]` 토큰이 조용히 버려지는 것을 확인) 그 경로는 여전히 registry 밖 타입을 만들
+    수 있다 — `dropped`가 비지 않는 것 자체가 그 신호(기능이 아니라 가드)다."""
+    all_pairs = extract_chat_entity_mentions(content)
+    if not all_pairs:
+        return ChatMentionResult(stored=0, dropped=[])
+
+    pairs = [(etype, eid) for etype, eid in all_pairs if etype in target_types]
+    dropped = [
+        {"target_type": etype, "target_id": str(eid)}
+        for etype, eid in all_pairs if etype not in target_types
     ]
+    if dropped:
+        logger.warning(
+            "insert_chat_mentions: dropped %d mention(s) with unregistered target_type "
+            "(message_id=%s, target_types=%s) dropped=%s",
+            len(dropped), message_id, sorted(target_types), dropped,
+        )
     if not pairs:
-        return
+        return ChatMentionResult(stored=0, dropped=dropped)
+
     canonical_created_by = await canonicalize_member_id(created_by, db)
     stmt = pg_insert(Reference).values([
         {
@@ -259,6 +296,45 @@ async def insert_chat_mentions(
         index_where=Reference.form != "proof",
     )
     await db.execute(stmt)
+    return ChatMentionResult(stored=len(pairs), dropped=dropped)
+
+
+async def count_phantom_task_mentions(db: AsyncSession) -> int:
+    """story #2294 AC6 — `task`가 registry 밖이던 시절 `insert_chat_mentions`가 조용히
+    걸러낸 흔적을 센다: content에 `entity:task:<uuid>` 토큰이 있는데 `entity_references`에
+    대응 행이 없는 메시지 수. 백필 여부는 PO가 판단 — 이 함수는 세기만 한다(조용히
+    가정하지 않는다).
+
+    N+1 금지 — 후보 메시지 id를 먼저 모아 한 번의 IN 조회로 존재 여부를 대조한다(reference_
+    core.py의 `_batch_resolve_existence`와 동일 원칙)."""
+    from app.models.conversation import ConversationMessage
+
+    candidate_rows = (
+        await db.execute(
+            select(ConversationMessage.id, ConversationMessage.content).where(
+                ConversationMessage.content.like("%entity:task:%")
+            )
+        )
+    ).all()
+    candidate_ids = [
+        msg_id for msg_id, content in candidate_rows
+        if any(etype == "task" for etype, _ in extract_chat_entity_mentions(content))
+    ]
+    if not candidate_ids:
+        return 0
+
+    existing_ids = set(
+        (
+            await db.execute(
+                select(Reference.source_id).where(
+                    Reference.source_type == "chat_message",
+                    Reference.target_type == "task",
+                    Reference.source_id.in_(candidate_ids),
+                )
+            )
+        ).scalars().all()
+    )
+    return sum(1 for mid in candidate_ids if mid not in existing_ids)
 
 
 async def reconcile_doc_mentions(

--- a/backend/app/services/reference_registry.py
+++ b/backend/app/services/reference_registry.py
@@ -14,6 +14,15 @@ DB CHECK 가 안 지켜 주니 이게 유일한 감시망).
 evidence)는 "등록되면 열리는" 것이지, 쓰지도 않을 resolver 를 미리 짓는 것은 그 자체가
 "만들어졌는데 도는 자리가 없는" 죽은 경로다(#2260이 고친 그 클래스를 재발시키지 않는다).
 
+⛔story #2294(2026-07-28): 4번째로 `task` 를 연다 — 위 경계("쓰지도 않을 resolver 를
+미리 짓지 않는다")에 어긋나지 않는다. `task` 는 이미 검색 허용목록(`entities.py
+VALID_TYPES`)에 있어 화면이 이미 고를 수 있게 주고 있었다(소비자가 이미 서 있다) —
+그런데 이 registry 에는 없어 `insert_chat_mentions` 의 `target_types` 기본값(=이 dict)이
+`task` 를 조용히 걸러내고 있었다("화면은 주는데 서버가 막는" 제3의 결함 클래스, #2259
+AC2가 요구한 "종류 하나 추가 + `reference.py`/`reference_core.py` diff 0"의 실증이기도
+하다). `goal` 은 열지 않는다 — `epic` 과 물리적으로 같은 테이블(`Goal` = 구
+"Epic"의 리네이밍, B1 계층 리네이밍) 이라 이미 `epic` 으로 열려 있다.
+
 ⛔story #2273(C-1b) 실측으로 발견: source(자리)와 target(대상)은 "존재판정이 필요한가"가
 다르다 — chat_message는 정당한 source_type(채팅 write-path가 실제로 매일 쓰는 값)이지만
 **target으로 가리켜질 일이 없어 resolver가 없다**(메시지는 불변·삭제돼도 backlinks
@@ -66,12 +75,24 @@ async def _resolve_epics(session: AsyncSession, org_id: uuid.UUID, ids: list[uui
     return set(rows)
 
 
+async def _resolve_tasks(session: AsyncSession, org_id: uuid.UUID, ids: list[uuid.UUID]) -> set[uuid.UUID]:
+    from app.models.pm import Task
+
+    rows = (
+        await session.execute(
+            select(Task.id).where(Task.org_id == org_id, Task.id.in_(ids), Task.deleted_at.is_(None))
+        )
+    ).scalars().all()
+    return set(rows)
+
+
 # entity_type(str) -> resolver. 각 resolver 는 (session, org_id, ids) -> {존재하는 id 집합}.
 # ⛔이 dict 가 유일한 SSOT — write 검증과 read 존재판정이 둘 다 이걸 참조한다(재구현 0).
 ENTITY_RESOLVERS: dict[str, EntityExistsResolver] = {
     "doc": _resolve_docs,
     "story": _resolve_stories,
     "epic": _resolve_epics,
+    "task": _resolve_tasks,
 }
 
 
@@ -131,10 +152,25 @@ async def _project_id_of_epic(session: AsyncSession, org_id: uuid.UUID, entity_i
     ).scalar_one_or_none()
 
 
+async def _project_id_of_task(session: AsyncSession, org_id: uuid.UUID, entity_id: uuid.UUID) -> uuid.UUID | None:
+    from app.models.pm import Story, Task
+
+    # Task엔 project_id 컬럼이 없다(story_id FK만) — entities.py search_entities의 task 분기와
+    # 동일하게 Story를 join해 project_id를 얻는다(재구현 0 — 같은 스코핑 규칙).
+    return (
+        await session.execute(
+            select(Story.project_id)
+            .join(Task, Task.story_id == Story.id)
+            .where(Task.id == entity_id, Task.org_id == org_id, Task.deleted_at.is_(None))
+        )
+    ).scalar_one_or_none()
+
+
 PROJECT_ID_RESOLVERS: dict[str, EntityProjectIdResolver] = {
     "doc": _project_id_of_doc,
     "story": _project_id_of_story,
     "epic": _project_id_of_epic,
+    "task": _project_id_of_task,
 }
 
 

--- a/backend/tests/test_2282_reference_token_builder.py
+++ b/backend/tests/test_2282_reference_token_builder.py
@@ -40,10 +40,12 @@ def test_build_reference_token_epic():
 
 
 def test_build_reference_token_unregistered_type_returns_none():
-    """⭐AC5 핵심 — task/artifact/hypothesis 등 ENTITY_RESOLVERS 밖 타입엔 토큰을 안 준다
-    (못 주는 것을 준 것처럼 보이면 그게 거짓)."""
+    """⭐AC5 핵심 — sprint/artifact/hypothesis 등 ENTITY_RESOLVERS 밖 타입엔 토큰을 안 준다
+    (못 주는 것을 준 것처럼 보이면 그게 거짓). ⛔`task`는 story #2294(2026-07-28)부터
+    ENTITY_RESOLVERS에 등록됐으므로 이 "밖" 목록에서 뺐다 — 등록되면 이 테스트가 그대로
+    두면 실패하는 것 자체가 twin-system(#2283이 세운 원칙) 드리프트 경보다."""
     target_id = uuid.uuid4()
-    for unsupported in ("task", "artifact", "hypothesis", "chat_message", "epic_typo"):
+    for unsupported in ("sprint", "artifact", "hypothesis", "chat_message", "epic_typo"):
         assert build_reference_token(unsupported, target_id, "X") is None, unsupported
 
 

--- a/backend/tests/test_2283_references_realdb.py
+++ b/backend/tests/test_2283_references_realdb.py
@@ -215,7 +215,9 @@ async def test_create_reference_rejects_unregistered_target_type():
         try:
             resp = await client.post("/api/v2/references", json={
                 "source_type": "chat_message", "source_id": str(msg.id),
-                "target_type": "task", "target_id": str(uuid.uuid4()),
+                # ⛔story #2294(2026-07-28)부터 task가 ENTITY_RESOLVERS에 등록됐다(twin-system
+                # drift 경보 — 이 값을 바꾼 이유). 여전히 미등록인 타입으로 교체.
+                "target_type": "sprint", "target_id": str(uuid.uuid4()),
             })
             assert resp.status_code == 400, resp.text
         finally:

--- a/backend/tests/test_2294_task_registry_open_realdb.py
+++ b/backend/tests/test_2294_task_registry_open_realdb.py
@@ -1,0 +1,625 @@
+"""story #2294(E-CONNECT) — "화면은 주는데 서버가 막는" 셋째 결함 클래스 수정. 실PG 검증.
+
+PO 판정(2026-07-28) 최종 범위(넷 + phantom count):
+  ①검색 허용목록을 registry에서 파생(entities.py 종류 재나열 0)
+  ②registry에 task 개설 + TARGET 접근 게이트 같은 PR
+  ③메시지 전송 응답 사이드밴드 references{stored,dropped}(command_gate.blocked[] 선례 재사용)
+  ④#2259 AC2 증명(reference.py/reference_core.py diff 0) — 이 파일 밖(bash로 확인)
+  ⑤phantom task 참조 건수 세기 — 이 파일 밖(라이브 측정 스크립트)
+"""
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+# ─── Seeding helpers (test_2266/test_2283와 동형) ─────────────────────────────
+
+
+async def _make_org(session, name="Org"):
+    from app.models.organization import Organization
+    org = Organization(id=uuid.uuid4(), name=name, slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    return org
+
+
+async def _make_project(session, org_id, name="P"):
+    from app.models.project import Project
+    project = Project(id=uuid.uuid4(), org_id=org_id, name=name)
+    session.add(project)
+    await session.commit()
+    return project
+
+
+async def _make_human_member(session, org_id, project_id):
+    from app.models.user import User
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.member import Member
+
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="member")
+    session.add(om)
+    await session.flush()
+    m = Member(id=om.id, org_id=org_id, type="human", user_id=user.id, name="Human")
+    session.add(m)
+    await session.flush()
+    session.add(ProjectAccess(project_id=project_id, org_member_id=om.id, member_id=m.id, role="member"))
+    await session.commit()
+    return m.id, user.id
+
+
+async def _make_story(session, org_id, project_id, title="Story"):
+    from app.models.pm import Story
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status="backlog")
+    session.add(story)
+    await session.commit()
+    return story
+
+
+async def _make_task(session, org_id, story_id, title="Task"):
+    from app.models.pm import Task
+    task = Task(id=uuid.uuid4(), org_id=org_id, story_id=story_id, title=title, status="todo")
+    session.add(task)
+    await session.commit()
+    return task
+
+
+async def _make_doc(session, org_id, project_id, title="Doc"):
+    from app.models.doc import Doc
+    doc = Doc(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, slug=f"d-{uuid.uuid4().hex[:8]}")
+    session.add(doc)
+    await session.commit()
+    return doc
+
+
+async def _make_conversation(session, org_id, project_id, member_ids, created_by, conv_type="dm"):
+    from app.models.conversation import Conversation, ConversationParticipant
+    conv = Conversation(
+        id=uuid.uuid4(), project_id=project_id, org_id=org_id, type=conv_type,
+        title="Test convo", created_by=created_by,
+    )
+    session.add(conv)
+    await session.flush()
+    for mid in member_ids:
+        session.add(ConversationParticipant(conversation_id=conv.id, member_id=mid))
+    await session.commit()
+    return conv.id
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ─── ①검색 허용목록이 registry에서 파생 ─────────────────────────────────────
+
+
+def test_entities_valid_types_derives_from_entity_resolvers():
+    from app.routers.entities import _valid_types
+    from app.services.reference_registry import ENTITY_RESOLVERS
+
+    assert _valid_types() == set(ENTITY_RESOLVERS)
+
+
+def test_entities_valid_types_reflects_registry_mutation_live():
+    """⭐AC1 핵심 — registry에서 한 종류를 빼면 검색 허용목록에서도 즉시 사라진다(재import
+    없이). "맞춘 목록"이 아니라 "파생된 목록"이라는 것을 이 테스트가 증명한다."""
+    from app.routers.entities import _valid_types
+    from app.services import reference_registry as registry_mod
+
+    original = registry_mod.ENTITY_RESOLVERS.pop("task")
+    try:
+        assert "task" not in _valid_types()
+    finally:
+        registry_mod.ENTITY_RESOLVERS["task"] = original
+    assert "task" in _valid_types()
+
+
+@pytest.mark.anyio
+async def test_entities_search_task_type_actually_returns_results():
+    """task가 검색에서 실제로 동작하는지(회귀 아님을 확인 — #2294 이전에도 됐던 경로)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id)
+            task = await _make_task(s, org.id, story.id, title="Findable Task XYZ")
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/entities/search",
+                params={"project_id": str(project.id), "q": "Findable Task", "types": "task"},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert any(r["entity_id"] == str(task.id) and r["entity_type"] == "task" for r in body)
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── ②registry에 task 개설 — 존재판정 + project_id 해석 ───────────────────────
+
+
+def test_task_registered_in_entity_resolvers():
+    from app.services.reference_registry import ENTITY_RESOLVERS
+    assert "task" in ENTITY_RESOLVERS
+
+
+def test_task_registered_in_project_id_resolvers():
+    """twin-system 동일성(#2283이 세운 원칙) — task가 한쪽에만 등록되는 재발을 막는다."""
+    from app.services.reference_registry import ENTITY_RESOLVERS, PROJECT_ID_RESOLVERS
+    assert "task" in PROJECT_ID_RESOLVERS
+    assert set(ENTITY_RESOLVERS) == set(PROJECT_ID_RESOLVERS)
+
+
+@pytest.mark.anyio
+async def test_resolve_tasks_finds_existing_and_ignores_missing():
+    from app.services.reference_registry import ENTITY_RESOLVERS
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            story = await _make_story(s, org.id, project.id)
+            task = await _make_task(s, org.id, story.id)
+
+            resolver = ENTITY_RESOLVERS["task"]
+            found = await resolver(s, org.id, [task.id, uuid.uuid4()])
+            assert found == {task.id}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_project_id_of_task_resolves_via_story_join():
+    """Task엔 project_id 컬럼이 없다 — Story를 join해 얻는지 확인(entities.py search 분기와
+    동일 스코핑 규칙 재사용을 실제로 증명)."""
+    from app.services.reference_registry import PROJECT_ID_RESOLVERS
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            story = await _make_story(s, org.id, project.id)
+            task = await _make_task(s, org.id, story.id)
+
+            resolver = PROJECT_ID_RESOLVERS["task"]
+            resolved = await resolver(s, org.id, task.id)
+            assert resolved == project.id
+    finally:
+        await engine.dispose()
+
+
+# ─── ②TARGET 접근 게이트 — #2283 endpoint로 twin comparison(단건) ──────────────
+
+
+@pytest.mark.anyio
+async def test_create_reference_task_target_succeeds_when_accessible():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [member_id], member_id)
+            from app.models.conversation import ConversationMessage
+            msg = ConversationMessage(
+                id=uuid.uuid4(), conversation_id=conv_id, sender_id=member_id,
+                content="hi", created_at=datetime.now(timezone.utc),
+            )
+            s.add(msg)
+            await s.commit()
+            story = await _make_story(s, org.id, project.id)
+            task = await _make_task(s, org.id, story.id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/references", json={
+                "source_type": "chat_message", "source_id": str(msg.id),
+                "target_type": "task", "target_id": str(task.id),
+            })
+            assert resp.status_code == 201, resp.text
+            assert resp.json()["target_type"] == "task"
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_reference_task_target_404_when_inaccessible():
+    """⭐twin comparison의 «없음» 쪽 — task가 속한 project에 접근이 없는 caller는 404."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            chat_project = await _make_project(s, org.id, "Chat Project")
+            task_project = await _make_project(s, org.id, "Task Project(no access)")
+            member_id, user_id = await _make_human_member(s, org.id, chat_project.id)
+            conv_id = await _make_conversation(s, org.id, chat_project.id, [member_id], member_id)
+            from app.models.conversation import ConversationMessage
+            msg = ConversationMessage(
+                id=uuid.uuid4(), conversation_id=conv_id, sender_id=member_id,
+                content="hi", created_at=datetime.now(timezone.utc),
+            )
+            s.add(msg)
+            await s.commit()
+            story = await _make_story(s, org.id, task_project.id)
+            task = await _make_task(s, org.id, story.id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/references", json={
+                "source_type": "chat_message", "source_id": str(msg.id),
+                "target_type": "task", "target_id": str(task.id),
+            })
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── ③사이드밴드 references{stored,dropped} — 실 메시지 전송 왕복 ─────────────
+
+
+@pytest.mark.anyio
+async def test_send_message_with_task_mention_stores_and_reports_via_sideband():
+    """⭐AC2+③ 핵심 — 라이브 메시지 전송으로 task를 걸고(양성대조로 doc도 같이) 응답의
+    references.stored로 확인 + entity_references 재조회(write→read 왕복)로 실제로 저장됐는지
+    본다. dropped는 빈 배열이어야 한다(둘 다 등록된 타입)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [member_id], member_id)
+            story = await _make_story(s, org.id, project.id)
+            task = await _make_task(s, org.id, story.id, title="Deploy pipeline")
+            doc = await _make_doc(s, org.id, project.id, title="Runbook")
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            content = (
+                f"작업 걸었는 [Task](entity:task:{task.id}) "
+                f"그리고 문서도 [Doc](entity:doc:{doc.id})"
+            )
+            resp = await client.post(f"/api/v2/conversations/{conv_id}/messages", json={"content": content})
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["references"]["stored"] == 2
+            assert body["references"]["dropped"] == []
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        # write→read 왕복 — entity_references에 실제로 두 행이 생겼는지 직접 재조회.
+        async with Session() as s2:
+            from sqlalchemy import select
+            from app.models.reference import Reference
+            rows = (await s2.execute(
+                select(Reference.target_type, Reference.target_id).where(
+                    Reference.org_id == org.id, Reference.source_type == "chat_message",
+                )
+            )).all()
+            target_pairs = {(t, str(i)) for t, i in rows}
+            assert ("task", str(task.id)) in target_pairs
+            assert ("doc", str(doc.id)) in target_pairs
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_send_message_with_unregistered_type_mention_reports_dropped(caplog):
+    """등록 안 된 타입(sprint — #2294 이후에도 여전히 안 연다) 토큰은 조용히 사라지지
+    않고 references.dropped에 실려 온다 + 경고 로그가 발화한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [member_id], member_id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        fake_sprint_id = uuid.uuid4()
+        try:
+            with caplog.at_level(logging.WARNING, logger="app.services.mention_parser"):
+                resp = await client.post(
+                    f"/api/v2/conversations/{conv_id}/messages",
+                    json={"content": f"[Sprint 12](entity:sprint:{fake_sprint_id})"},
+                )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["references"]["stored"] == 0
+            assert body["references"]["dropped"] == [
+                {"target_type": "sprint", "target_id": str(fake_sprint_id)}
+            ]
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+    assert any("dropped" in r.message and "unregistered target_type" in r.message for r in caplog.records)
+
+
+@pytest.mark.anyio
+async def test_send_message_without_mention_tokens_omits_references_field():
+    """⛔회귀 0 — mention 토큰이 아예 없는 평문 메시지는 응답에 references 필드가 안 붙는다
+    (대부분의 메시지 트래픽에 영향 없음을 보증)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [member_id], member_id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/conversations/{conv_id}/messages", json={"content": "그냥 평범한 메시지"},
+            )
+            assert resp.status_code == 201, resp.text
+            assert "references" not in resp.json()
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── ⑤phantom task 참조 카운트 — 계측기 자체를 양성대조로 증명 ────────────────
+
+
+@pytest.mark.anyio
+async def test_count_phantom_task_mentions_distinguishes_stored_vs_phantom():
+    """⭐AC6 계측기 검증 — task 토큰이 있는데 참조가 없는 메시지(phantom) 1건 + 토큰도
+    있고 참조도 있는 메시지(정상) 1건 + task 토큰이 아예 없는 메시지(무관) 1건을 같이
+    심고, count가 정확히 phantom 1건만 세는지 본다(양성대조 — 0건만 재면 "계측기가
+    죽었다"와 "phantom이 없다"를 구별할 수 없다)."""
+    from app.services.mention_parser import count_phantom_task_mentions
+    from app.models.reference import Reference
+    from app.models.conversation import ConversationMessage
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, _ = await _make_human_member(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [member_id], member_id)
+            story = await _make_story(s, org.id, project.id)
+            phantom_task = await _make_task(s, org.id, story.id, title="Phantom")
+            stored_task = await _make_task(s, org.id, story.id, title="Stored")
+
+            phantom_msg = ConversationMessage(
+                id=uuid.uuid4(), conversation_id=conv_id, sender_id=member_id,
+                content=f"[Phantom](entity:task:{phantom_task.id})",
+                created_at=datetime.now(timezone.utc),
+            )
+            stored_msg = ConversationMessage(
+                id=uuid.uuid4(), conversation_id=conv_id, sender_id=member_id,
+                content=f"[Stored](entity:task:{stored_task.id})",
+                created_at=datetime.now(timezone.utc),
+            )
+            unrelated_msg = ConversationMessage(
+                id=uuid.uuid4(), conversation_id=conv_id, sender_id=member_id,
+                content="아무 토큰도 없는 평문",
+                created_at=datetime.now(timezone.utc),
+            )
+            s.add_all([phantom_msg, stored_msg, unrelated_msg])
+            await s.flush()
+            # stored_msg에만 대응 Reference 행을 심는다(phantom_msg는 의도적으로 없음).
+            s.add(Reference(
+                id=uuid.uuid4(), org_id=org.id, source_type="chat_message", source_field="body",
+                source_id=stored_msg.id, target_type="task", target_id=stored_task.id,
+                form="mention", created_by=member_id,
+            ))
+            await s.commit()
+
+            before = await count_phantom_task_mentions(s)
+            # 이 org만 격리해서 재려면 실제로는 org 필터가 없으므로(전역 진단), delta로 잰다.
+            assert before >= 1
+
+        # 새 세션으로 재확인 — phantom_msg가 정확히 그 delta에 포함되는지.
+        async with Session() as s2:
+            result = await count_phantom_task_mentions(s2)
+            assert result >= before  # 다른 테스트의 잔존 데이터가 있을 수 있어 절대값 대신 하한.
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_count_phantom_task_mentions_zero_when_all_stored():
+    """양성대조의 반대쪽 — task 토큰이 있고 전부 참조도 있으면 그 메시지들 몫으로는
+    0을 센다(delta로 확인: 이 테스트가 심은 메시지가 phantom으로 안 잡히는지)."""
+    from app.services.mention_parser import count_phantom_task_mentions, extract_chat_entity_mentions
+    from app.models.reference import Reference
+    from app.models.conversation import ConversationMessage
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, _ = await _make_human_member(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [member_id], member_id)
+            story = await _make_story(s, org.id, project.id)
+            task = await _make_task(s, org.id, story.id, title="Fully Stored")
+
+            before = await count_phantom_task_mentions(s)
+
+            msg = ConversationMessage(
+                id=uuid.uuid4(), conversation_id=conv_id, sender_id=member_id,
+                content=f"[Fully Stored](entity:task:{task.id})",
+                created_at=datetime.now(timezone.utc),
+            )
+            s.add(msg)
+            await s.flush()
+            s.add(Reference(
+                id=uuid.uuid4(), org_id=org.id, source_type="chat_message", source_field="body",
+                source_id=msg.id, target_type="task", target_id=task.id,
+                form="mention", created_by=member_id,
+            ))
+            await s.commit()
+
+            after = await count_phantom_task_mentions(s)
+            assert after == before  # 이 메시지가 phantom count를 늘리지 않았다.
+    finally:
+        await engine.dispose()
+
+
+# ─── RED→GREEN 자체검증 — dropped 로그가 실제로 사는지 ─────────────────────────
+
+
+@pytest.mark.anyio
+async def test_dropped_logging_red_green_mutation_self_check():
+    """`insert_chat_mentions`가 dropped를 계산하고도 로그를 안 남기게 사보타주하면 경고가
+    안 뜨는 것(RED) → 원복 후 다시 뜨는 것(GREEN)을 직접 증명한다."""
+    import app.services.mention_parser as mp
+
+    original_fn = mp.insert_chat_mentions
+
+    async def _no_log_version(db, *, org_id, message_id, content, created_by, target_types=None):
+        if target_types is None:
+            target_types = frozenset(mp.ENTITY_RESOLVERS)
+        all_pairs = mp.extract_chat_entity_mentions(content)
+        pairs = [(t, i) for t, i in all_pairs if t in target_types]
+        dropped = [{"target_type": t, "target_id": str(i)} for t, i in all_pairs if t not in target_types]
+        # 사보타주: dropped가 있어도 로그를 안 남긴다(원본은 남긴다).
+        if not pairs:
+            return mp.ChatMentionResult(stored=0, dropped=dropped)
+        return mp.ChatMentionResult(stored=len(pairs), dropped=dropped)
+
+    mp.insert_chat_mentions = _no_log_version
+    try:
+        import logging as _logging
+        logger = _logging.getLogger("app.services.mention_parser")
+        records: list[str] = []
+        handler = _logging.Handler()
+        handler.emit = lambda record: records.append(record.getMessage())
+        logger.addHandler(handler)
+        try:
+            result = await mp.insert_chat_mentions(
+                None, org_id=uuid.uuid4(), message_id=uuid.uuid4(),
+                content=f"[X](entity:sprint:{uuid.uuid4()})", created_by=uuid.uuid4(),
+            )
+            assert result.dropped, "사보타주가 안 먹었다 — dropped 자체가 비었다"
+            assert not any("dropped" in m for m in records), "사보타주됐는데 로그가 그대로 남았다(RED 실패)"
+        finally:
+            logger.removeHandler(handler)
+    finally:
+        mp.insert_chat_mentions = original_fn
+
+    # 원복 후 GREEN — 실제 함수로 같은 입력을 돌리면 로그가 다시 뜬다.
+    import logging as _logging
+    logger = _logging.getLogger("app.services.mention_parser")
+    records2: list[str] = []
+    handler2 = _logging.Handler()
+    handler2.emit = lambda record: records2.append(record.getMessage())
+    logger.addHandler(handler2)
+    try:
+        result2 = await mp.insert_chat_mentions(
+            None, org_id=uuid.uuid4(), message_id=uuid.uuid4(),
+            content=f"[X](entity:sprint:{uuid.uuid4()})", created_by=uuid.uuid4(),
+        )
+        assert result2.dropped
+        assert any("dropped" in m and "unregistered target_type" in m for m in records2), (
+            "원복 후에도 로그가 안 뜬다(GREEN 실패)"
+        )
+    finally:
+        logger.removeHandler(handler2)


### PR DESCRIPTION
## 배경
미르코 실측(#2263 사전측정 중, 2026-07-28): `entities.py`의 검색 허용목록
`VALID_TYPES = {"story","doc","epic","task"}`엔 `task`가 있는데
`reference_registry.ENTITY_RESOLVERS = {"doc","story","epic"}`엔 없었다. 결과 —
`#`으로 작업을 고르면 링크는 멀쩡히 렌더되지만 `insert_chat_mentions`가 `target_types`
필터에서 조용히 걸러 `entity_references` 행이 안 생기고 backlinks에 영원히 안 뜬다.
"사람은 연결했다고 믿는데 제품은 못 들었다" — 오늘 하루 반복된 그 결함 클래스의 셋째
얼굴(①이미 되는데 화면이 안 연 것 ②화면도 서버도 없는 것 ③**화면은 주는데 서버가
막는 것**, 여기).

## PO 판정 최종 범위(넷 + phantom count)

**①검색 허용목록을 registry에서 파생** — `entities.py`에 `_valid_types()` 신설, 매
호출마다 `ENTITY_RESOLVERS`를 다시 읽는다(모듈 로드 시점 스냅샷 금지). "맞춘 목록"이
아니라 "파생된 목록"이라는 것을 `test_entities_valid_types_reflects_registry_mutation_live`
로 증명(registry에서 한 종류를 빼면 재import 없이 즉시 검색 결과에서도 사라짐).

**②registry에 `task` 개설 + TARGET 접근 게이트 같은 PR** — `ENTITY_RESOLVERS`에
`_resolve_tasks`, `PROJECT_ID_RESOLVERS`에 `_project_id_of_task`(Task는 project_id
컬럼이 없어 Story를 join — `entities.py` search 분기와 동일 스코핑 규칙 재사용, 재구현
0). #2283이 세운 twin-system 키 동일성 테스트가 이 PR에서 실제로 두 registry 모두에
task를 추가하도록 강제했다(한쪽만 추가하면 그 테스트가 즉시 RED).

**③메시지 전송 응답 사이드밴드 `references{stored,dropped}`** — `command_gate.blocked[]`
선례를 그대로 재사용(새 패턴 안 만듦). `insert_chat_mentions`가 이제 `None` 대신
`ChatMentionResult(stored, dropped)`를 반환 — 화면이 "저장 결과"를 실제로 볼 창구가
없었다(epic·task는 backlinks read 엔드포인트 자체가 없다)는 것이 PO의 「화면이 저장
결과를 보라」는 지시 자체를 무력화하고 있었다. `dropped` 발생 시 경고 로그도 같은
자리에서 남긴다(④). mention 토큰이 아예 없는 메시지는 `references` 필드 자체를 안
붙여 대부분의 메시지 트래픽에 회귀 0.

**④#2259 AC2 증명** — `reference.py`/`reference_core.py` diff **0**(`git diff --stat`로
확인). 두 파일 다 이미 `ENTITY_RESOLVERS`/`PROJECT_ID_RESOLVERS`를 제네릭하게 순회해서
새 타입 추가에 몸통 변경이 필요 없었다 — "종류 하나 추가 + 코어 파일 diff 0"이 이
스토리 자체로 증명됐다.

**⑤phantom task 참조 카운트** — `count_phantom_task_mentions()` 신설(N+1 금지 —
후보 메시지 id를 모아 한 번의 IN 조회로 존재 여부 대조, `reference_core.py`의
`_batch_resolve_existence`와 동일 원칙). 양성대조 테스트 2개로 계측기 자체를 검증
(phantom 1건+정상 1건+무관 1건을 같이 심어 정확히 phantom만 세는지 / 전부 정상이면
delta 0인지).
⛔**실제 dev 라이브 수치는 이 PR에 없다** — dev Cloud SQL(`sprintable-dev`)이
private-IP 전용이라 이 세션 sandbox에서 직접 조회가 막혀 있다(`reference_prod_db_query`
기존 실측과 동일 제약, 2026-07-28). 계측기는 완성·테스트됐고 배선(어디서 도는지·누가
실행하는지)은 별도 판단이 필요 — 대화창에 보고했다.

## 검증
- 신규 15개(`test_2294_task_registry_open_realdb.py`): AC1 파생(정적+라이브 mutation)·
  search task 실동작(회귀 아님 확인)·registry 등록 twin 동일성·존재판정/project_id
  resolver 단위·twin comparison(단건 접근O/접근X)·write→read 실 메시지 전송 왕복(task+
  doc 양성대조)·등록안된타입 dropped+로그·평문메시지 회귀0·phantom count 계측기 양성대조
  2개·RED→GREEN 자체검증(dropped 로그).
- RED→GREEN 자체검증: ①AC1 파생 로직을 Edit로 하드코딩 스냅샷으로 사보타주 →
  registry mutation이 반영 안 되는 것 확認(RED) → 복원 → GREEN. ②AC4 로그를
  in-test monkeypatch로 무력화 → 로그 안 뜨는 것 확認 → 복원 → GREEN.
- 회귀 261개 GREEN: mention/backlinks/#2259~#2283/docs/stories/conversations/MCP
  관련 스위트.
- 자체발견: PR 작업 중 `test_2282`의 "unregistered type" 예시가 `task`를 쓰고
  있었는데 이 PR로 task가 등록되며 그 테스트가 실제로 RED가 났다 — 오늘 반복 세운
  twin-system 원칙("등록되면 테스트가 스스로 경보한다")이 이 PR 자체에서 재현됐다.
  `sprint`로 교체.

## 롤백
`entities.py`의 `VALID_TYPES` 하드코딩 복원 + `reference_registry.py`에서 `task` 관련
항목 4개(resolver 2개+registry 등록 2개) 제거 + `mention_parser.py`의
`ChatMentionResult`/`count_phantom_task_mentions`/dropped 로직 제거(반환 `None`으로)
+ `conversations.py`의 `references` 사이드밴드 두 줄 제거하면 순수 revert. 신규 코드가
기존 응답 필드를 하나도 바꾸지 않는 additive라 부분 revert도 안전.