### PR TITLE
feat(E-CONNECT B단계): registry에 sprint/artifact/hypothesis/evidence 열기

### DIFF
--- a/backend/app/services/reference_registry.py
+++ b/backend/app/services/reference_registry.py
@@ -23,6 +23,18 @@ AC2가 요구한 "종류 하나 추가 + `reference.py`/`reference_core.py` diff
 하다). `goal` 은 열지 않는다 — `epic` 과 물리적으로 같은 테이블(`Goal` = 구
 "Epic"의 리네이밍, B1 계층 리네이밍) 이라 이미 `epic` 으로 열려 있다.
 
+⛔B단계(2026-07-29, PO 판정 — "선생님 원문 «어떤 엔티티든지»를 채우는 것"): sprint·
+artifact(VisualArtifact)·hypothesis·evidence 4종을 더 연다 — doc·story·epic·task가
+이미 세운 "resolver + project_id resolver + TARGET 게이트" 절차를 그대로 반복한다.
+  · sprint·hypothesis — Goal(epic)과 동형: SoftDeleteMixin 없음(하드 삭제) — row 존재
+    자체가 존재판정. Hypothesis의 `archived_at`은 삭제 마커가 아니라 라이프사이클
+    상태(§3.10 "archive=soft, hard delete는 정책 확定 전까지 금지" — 즉 archived여도
+    row는 여전히 "존재"하고 참조 가능해야 한다)라 필터하지 않는다.
+  · artifact(VisualArtifact) — doc과 동형: `deleted_at` soft-delete 필터.
+  · evidence — project_id 컬럼이 없다(work_item_id/work_item_type로 story/task를
+    폴리모픽 참조). project_id 해석은 work_item_type으로 분기해 Story 또는
+    Task→Story join으로 간접 해소한다(task의 project_id resolver와 동일 join 패턴).
+
 ⛔story #2273(C-1b) 실측으로 발견: source(자리)와 target(대상)은 "존재판정이 필요한가"가
 다르다 — chat_message는 정당한 source_type(채팅 write-path가 실제로 매일 쓰는 값)이지만
 **target으로 가리켜질 일이 없어 resolver가 없다**(메시지는 불변·삭제돼도 backlinks
@@ -86,6 +98,50 @@ async def _resolve_tasks(session: AsyncSession, org_id: uuid.UUID, ids: list[uui
     return set(rows)
 
 
+async def _resolve_sprints(session: AsyncSession, org_id: uuid.UUID, ids: list[uuid.UUID]) -> set[uuid.UUID]:
+    from app.models.pm import Sprint
+
+    # Sprint엔 SoftDeleteMixin이 없다(하드 삭제) — row 존재 자체가 존재판정(epic과 동형).
+    rows = (
+        await session.execute(select(Sprint.id).where(Sprint.org_id == org_id, Sprint.id.in_(ids)))
+    ).scalars().all()
+    return set(rows)
+
+
+async def _resolve_artifacts(session: AsyncSession, org_id: uuid.UUID, ids: list[uuid.UUID]) -> set[uuid.UUID]:
+    from app.models.visual_artifact import VisualArtifact
+
+    rows = (
+        await session.execute(
+            select(VisualArtifact.id).where(
+                VisualArtifact.org_id == org_id, VisualArtifact.id.in_(ids),
+                VisualArtifact.deleted_at.is_(None),
+            )
+        )
+    ).scalars().all()
+    return set(rows)
+
+
+async def _resolve_hypotheses(session: AsyncSession, org_id: uuid.UUID, ids: list[uuid.UUID]) -> set[uuid.UUID]:
+    from app.models.hypothesis import Hypothesis
+
+    # archived_at은 삭제 마커가 아니라 라이프사이클 상태(하드 삭제 정책 확定 전까지 금지) —
+    # 필터하지 않는다. row 존재 자체가 존재판정(epic·sprint와 동형).
+    rows = (
+        await session.execute(select(Hypothesis.id).where(Hypothesis.org_id == org_id, Hypothesis.id.in_(ids)))
+    ).scalars().all()
+    return set(rows)
+
+
+async def _resolve_evidence(session: AsyncSession, org_id: uuid.UUID, ids: list[uuid.UUID]) -> set[uuid.UUID]:
+    from app.models.evidence import Evidence
+
+    rows = (
+        await session.execute(select(Evidence.id).where(Evidence.org_id == org_id, Evidence.id.in_(ids)))
+    ).scalars().all()
+    return set(rows)
+
+
 # entity_type(str) -> resolver. 각 resolver 는 (session, org_id, ids) -> {존재하는 id 집합}.
 # ⛔이 dict 가 유일한 SSOT — write 검증과 read 존재판정이 둘 다 이걸 참조한다(재구현 0).
 ENTITY_RESOLVERS: dict[str, EntityExistsResolver] = {
@@ -93,6 +149,10 @@ ENTITY_RESOLVERS: dict[str, EntityExistsResolver] = {
     "story": _resolve_stories,
     "epic": _resolve_epics,
     "task": _resolve_tasks,
+    "sprint": _resolve_sprints,
+    "artifact": _resolve_artifacts,
+    "hypothesis": _resolve_hypotheses,
+    "evidence": _resolve_evidence,
 }
 
 
@@ -166,11 +226,85 @@ async def _project_id_of_task(session: AsyncSession, org_id: uuid.UUID, entity_i
     ).scalar_one_or_none()
 
 
+async def _project_id_of_sprint(session: AsyncSession, org_id: uuid.UUID, entity_id: uuid.UUID) -> uuid.UUID | None:
+    from app.models.pm import Sprint
+
+    return (
+        await session.execute(
+            select(Sprint.project_id).where(Sprint.id == entity_id, Sprint.org_id == org_id)
+        )
+    ).scalar_one_or_none()
+
+
+async def _project_id_of_artifact(session: AsyncSession, org_id: uuid.UUID, entity_id: uuid.UUID) -> uuid.UUID | None:
+    from app.models.visual_artifact import VisualArtifact
+
+    return (
+        await session.execute(
+            select(VisualArtifact.project_id).where(
+                VisualArtifact.id == entity_id, VisualArtifact.org_id == org_id,
+                VisualArtifact.deleted_at.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+
+
+async def _project_id_of_hypothesis(session: AsyncSession, org_id: uuid.UUID, entity_id: uuid.UUID) -> uuid.UUID | None:
+    from app.models.hypothesis import Hypothesis
+
+    return (
+        await session.execute(
+            select(Hypothesis.project_id).where(Hypothesis.id == entity_id, Hypothesis.org_id == org_id)
+        )
+    ).scalar_one_or_none()
+
+
+async def _project_id_of_evidence(session: AsyncSession, org_id: uuid.UUID, entity_id: uuid.UUID) -> uuid.UUID | None:
+    from app.models.evidence import Evidence
+    from app.models.pm import Story, Task
+
+    # Evidence엔 project_id가 없다 — work_item_id/work_item_type(story|task 폴리모픽)을
+    # 통해 간접 해소한다. task 케이스는 task의 project_id resolver와 동일한 Story join.
+    row = (
+        await session.execute(
+            select(Evidence.work_item_id, Evidence.work_item_type).where(
+                Evidence.id == entity_id, Evidence.org_id == org_id,
+            )
+        )
+    ).first()
+    if row is None:
+        return None
+    work_item_id, work_item_type = row
+    if work_item_type == "story":
+        return (
+            await session.execute(
+                select(Story.project_id).where(
+                    Story.id == work_item_id, Story.org_id == org_id, Story.deleted_at.is_(None),
+                )
+            )
+        ).scalar_one_or_none()
+    if work_item_type == "task":
+        return (
+            await session.execute(
+                select(Story.project_id)
+                .join(Task, Task.story_id == Story.id)
+                .where(Task.id == work_item_id, Task.org_id == org_id, Task.deleted_at.is_(None))
+            )
+        ).scalar_one_or_none()
+    # work_item_type이 알려진 두 값(story·task) 밖이면 project_id를 모른다 — has_project_access
+    # 호출부가 None을 404로 번역한다(조용히 통과 금지).
+    return None
+
+
 PROJECT_ID_RESOLVERS: dict[str, EntityProjectIdResolver] = {
     "doc": _project_id_of_doc,
     "story": _project_id_of_story,
     "epic": _project_id_of_epic,
     "task": _project_id_of_task,
+    "sprint": _project_id_of_sprint,
+    "artifact": _project_id_of_artifact,
+    "hypothesis": _project_id_of_hypothesis,
+    "evidence": _project_id_of_evidence,
 }
 
 

--- a/backend/sprintable_mcp/tools/chat.py
+++ b/backend/sprintable_mcp/tools/chat.py
@@ -46,33 +46,47 @@ def escape_mention_title(title: str) -> str:
 # 토큰 문자열을 만드는" 경로는 이 조직 명명 관례([TAG] 제목)에서 구조적으로 깨진다 — 정답은
 # 손으로 안 짓고 **백엔드가 준 reference_token을 그대로 쓰는** 것(#2282 SSOT). doc만
 # 지원하던 것을 story/epic까지 넓혀 «형제 비대칭»(FE만 안 깨지는 것)을 없앤다.
+#
+# ⛔story #2294(2026-07-28, 실제로 걸린 드리프트): task가 백엔드 ENTITY_RESOLVERS에 열렸는데
+# 이 dict는 안 늘어 test_mention_entity_endpoints_match_backend_entity_resolvers가 develop
+# HEAD에서 RED였다 — 서로 다른 두 PR이 각각은 옳은 변경이었는데 합쳐지며 이 축이 깨진
+# "merge-order로만 드러나는" 드리프트였다(#2585는 #2294보다 먼저 작성돼 task를 몰랐다).
+# ⛔B단계(2026-07-29): sprint·artifact·hypothesis도 같이 연다(GET /{id} 단건조회 엔드포인트가
+# 실재해 title 미지정 mention의 auto-fetch가 가능함을 확認). `evidence`는 **의도적으로 뺀다**
+# — GET /api/v2/evidence/{id}(단건조회) 라우트 자체가 없다(list만 work_item_id로 필터링해서
+# 있음). 이 비대칭은 test_mcp_s1995의 `_MENTION_ENDPOINT_KNOWN_GAP`이 명시 선언한다(조용히
+# 빠진 것과 일부러 뺀 것은 처방이 다르다).
 _MENTION_ENTITY_ENDPOINTS: dict[str, str] = {
     "doc": "/api/v2/docs/{id}",
     "story": "/api/v2/stories/{id}",
     "epic": "/api/v2/goals/{id}",
+    "task": "/api/v2/tasks/{id}",
+    "sprint": "/api/v2/sprints/{id}",
+    "artifact": "/api/v2/visual-artifacts/{id}",
+    "hypothesis": "/api/v2/hypotheses/{id}",
 }
 
 
 class MentionRef(SprintableInput):
     """agent 발신 채팅 메시지에 첨부할 entity mention — story 1995(doc 링크 안 됨 근본수정) +
-    story #2283 후속(2026-07-28, doc→doc/story/epic 확장).
+    story #2283/#2294 후속(2026-07-28~29, doc→doc/story/epic/task/sprint/artifact/
+    hypothesis 확장 — evidence는 GET /{id} 단건조회가 없어 의도적으로 제외, 아래
+    `_MENTION_ENTITY_ENDPOINTS` 주석 참조).
 
-    type은 스키마 레벨에서 doc/story/epic만 허용(Literal). MCP 서버는 백엔드 `app.*`를 import
-    하지 않고 HTTP로만 통신하는 별도 프로세스라(api_client.py 참조) 이 목록을 백엔드
+    type은 스키마 레벨에서 이 목록만 허용(Literal). MCP 서버는 백엔드 `app.*`를 import 하지
+    않고 HTTP로만 통신하는 별도 프로세스라(api_client.py 참조) 이 목록을 백엔드
     `reference_registry.ENTITY_RESOLVERS`에서 런타임에 **파생시킬 수 없다** — 두 프로세스가
     같은 값을 손으로 맞춰 유지하는 수밖에 없는 자리다. 대신
     `test_mention_entity_endpoints_match_backend_entity_resolvers`가 **테스트로** 그 동일성을
-    고정한다 — 백엔드 registry가 늘면 이 테스트가 빨개져서 여기(이 Literal +
-    `_MENTION_ENTITY_ENDPOINTS`)도 늘리도록 강제한다.
+    (알려진 gap인 evidence를 뺀 나머지에 대해) 고정한다 — 백엔드 registry가 더 늘면 이 테스트가
+    빨개져서 여기(이 Literal + `_MENTION_ENTITY_ENDPOINTS`)도 늘리도록 강제한다.
 
-    ⛔실제로 story #2294(target_type에 `task` 개설)에서 이 테스트가 바로 빨개질 것이다 — 그때
-    답은 **이 테스트를 고치거나 느슨하게 하는 것이 아니라, 여기 Literal과
-    `_MENTION_ENTITY_ENDPOINTS`에 `task` 항목을 추가하는 것**이다(가드가 걸렸을 때 나올 수
-    있는 세 가지 반응 — 목록을 넓힌다 / 테스트를 고친다 / 무시한다 — 중 첫 번째만 옳다는 것을
-    미리 적어 둔다).
+    ⛔가드가 걸렸을 때 나올 수 있는 세 가지 반응 — 목록을 넓힌다 / 테스트를 고친다(또는
+    느슨하게 한다) / 무시한다 — 중 첫 번째만 옳다. GET /{id}가 아예 없는 타입(evidence류)만
+    예외로, 이유와 함께 명시 등재한다(조용히 빼지 않는다).
     """
 
-    type: Literal["doc", "story", "epic"]
+    type: Literal["doc", "story", "epic", "task", "sprint", "artifact", "hypothesis"]
     id: str
     title: str | None = None
 

--- a/backend/tests/test_2282_reference_token_builder.py
+++ b/backend/tests/test_2282_reference_token_builder.py
@@ -40,12 +40,13 @@ def test_build_reference_token_epic():
 
 
 def test_build_reference_token_unregistered_type_returns_none():
-    """⭐AC5 핵심 — sprint/artifact/hypothesis 등 ENTITY_RESOLVERS 밖 타입엔 토큰을 안 준다
-    (못 주는 것을 준 것처럼 보이면 그게 거짓). ⛔`task`는 story #2294(2026-07-28)부터
-    ENTITY_RESOLVERS에 등록됐으므로 이 "밖" 목록에서 뺐다 — 등록되면 이 테스트가 그대로
-    두면 실패하는 것 자체가 twin-system(#2283이 세운 원칙) 드리프트 경보다."""
+    """⭐AC5 핵심 — ENTITY_RESOLVERS 밖 타입엔 토큰을 안 준다(못 주는 것을 준 것처럼 보이면
+    그게 거짓). ⛔`task`(#2294)·`sprint`/`artifact`/`hypothesis`/`evidence`(#2294 B단계,
+    2026-07-29)는 이후 ENTITY_RESOLVERS에 등록됐으므로 이 "밖" 목록에서 뺐다 — 등록되면 이
+    테스트가 그대로 두면 실패하는 것 자체가 twin-system(#2283이 세운 원칙) 드리프트 경보다.
+    `goal`은 epic과 같은 테이블이라 앞으로도 절대 안 열리는 안전한 예시."""
     target_id = uuid.uuid4()
-    for unsupported in ("sprint", "artifact", "hypothesis", "chat_message", "epic_typo"):
+    for unsupported in ("goal", "chat_message", "epic_typo"):
         assert build_reference_token(unsupported, target_id, "X") is None, unsupported
 
 

--- a/backend/tests/test_2283_references_realdb.py
+++ b/backend/tests/test_2283_references_realdb.py
@@ -215,9 +215,10 @@ async def test_create_reference_rejects_unregistered_target_type():
         try:
             resp = await client.post("/api/v2/references", json={
                 "source_type": "chat_message", "source_id": str(msg.id),
-                # ⛔story #2294(2026-07-28)부터 task가 ENTITY_RESOLVERS에 등록됐다(twin-system
-                # drift 경보 — 이 값을 바꾼 이유). 여전히 미등록인 타입으로 교체.
-                "target_type": "sprint", "target_id": str(uuid.uuid4()),
+                # ⛔story #2294(2026-07-28)부터 task가, B단계(2026-07-29)부터 sprint도
+                # ENTITY_RESOLVERS에 등록됐다(twin-system drift 경보 — 이 값을 바꾼 이유).
+                # goal은 epic과 같은 테이블이라 앞으로도 절대 안 열리는 안전한 예시.
+                "target_type": "goal", "target_id": str(uuid.uuid4()),
             })
             assert resp.status_code == 400, resp.text
         finally:

--- a/backend/tests/test_2294_task_registry_open_realdb.py
+++ b/backend/tests/test_2294_task_registry_open_realdb.py
@@ -398,8 +398,10 @@ async def test_send_message_with_task_mention_stores_and_reports_via_sideband():
 
 @pytest.mark.anyio
 async def test_send_message_with_unregistered_type_mention_reports_dropped(caplog):
-    """등록 안 된 타입(sprint — #2294 이후에도 여전히 안 연다) 토큰은 조용히 사라지지
-    않고 references.dropped에 실려 온다 + 경고 로그가 발화한다."""
+    """등록 안 된 타입(goal — epic과 같은 테이블이라 앞으로도 절대 안 연다) 토큰은 조용히
+    사라지지 않고 references.dropped에 실려 온다 + 경고 로그가 발화한다.
+    ⛔`sprint`는 #2294 B단계(2026-07-29)부터 ENTITY_RESOLVERS에 등록됐다(twin-system
+    drift 경보 — 이 값을 goal로 바꾼 이유)."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -412,18 +414,18 @@ async def test_send_message_with_unregistered_type_mention_reports_dropped(caplo
 
         await _setup_app_human(app, Session, user_id, org.id)
         client = _client_for(app)
-        fake_sprint_id = uuid.uuid4()
+        fake_goal_id = uuid.uuid4()
         try:
             with caplog.at_level(logging.WARNING, logger="app.services.mention_parser"):
                 resp = await client.post(
                     f"/api/v2/conversations/{conv_id}/messages",
-                    json={"content": f"[Sprint 12](entity:sprint:{fake_sprint_id})"},
+                    json={"content": f"[Goal X](entity:goal:{fake_goal_id})"},
                 )
             assert resp.status_code == 201, resp.text
             body = resp.json()
             assert body["references"]["stored"] == 0
             assert body["references"]["dropped"] == [
-                {"target_type": "sprint", "target_id": str(fake_sprint_id)}
+                {"target_type": "goal", "target_id": str(fake_goal_id)}
             ]
         finally:
             await client.aclose()
@@ -596,7 +598,7 @@ async def test_dropped_logging_red_green_mutation_self_check():
         try:
             result = await mp.insert_chat_mentions(
                 None, org_id=uuid.uuid4(), message_id=uuid.uuid4(),
-                content=f"[X](entity:sprint:{uuid.uuid4()})", created_by=uuid.uuid4(),
+                content=f"[X](entity:goal:{uuid.uuid4()})", created_by=uuid.uuid4(),
             )
             assert result.dropped, "사보타주가 안 먹었다 — dropped 자체가 비었다"
             assert not any("dropped" in m for m in records), "사보타주됐는데 로그가 그대로 남았다(RED 실패)"
@@ -615,7 +617,7 @@ async def test_dropped_logging_red_green_mutation_self_check():
     try:
         result2 = await mp.insert_chat_mentions(
             None, org_id=uuid.uuid4(), message_id=uuid.uuid4(),
-            content=f"[X](entity:sprint:{uuid.uuid4()})", created_by=uuid.uuid4(),
+            content=f"[X](entity:goal:{uuid.uuid4()})", created_by=uuid.uuid4(),
         )
         assert result2.dropped
         assert any("dropped" in m and "unregistered target_type" in m for m in records2), (

--- a/backend/tests/test_2294b_open_4_types_realdb.py
+++ b/backend/tests/test_2294b_open_4_types_realdb.py
@@ -1,0 +1,470 @@
+"""story #2294 B단계(E-CONNECT, 2026-07-29) — registry에 sprint·artifact(VisualArtifact)·
+hypothesis·evidence 4종을 더 연다. doc·story·epic·task가 세운 절차(resolver + project_id
+resolver + TARGET 게이트)를 그대로 반복 — `goal`은 epic과 같은 테이블이라 열지 않는다.
+
+PO 요구: "종류마다 게이트가 실제로 서는지는 «각각» 보이는 것" — 4종을 한 루프로 뭉개지 않고
+타입별로 독립 twin-comparison(접근 있음 vs 없음)을 각각 둔다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+# ─── Seeding helpers (test_2266/test_2283/test_2294와 동형) ──────────────────
+
+
+async def _make_org(session, name="Org"):
+    from app.models.organization import Organization
+    org = Organization(id=uuid.uuid4(), name=name, slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    return org
+
+
+async def _make_project(session, org_id, name="P"):
+    from app.models.project import Project
+    project = Project(id=uuid.uuid4(), org_id=org_id, name=name)
+    session.add(project)
+    await session.commit()
+    return project
+
+
+async def _make_human_member(session, org_id, project_id):
+    from app.models.user import User
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.member import Member
+
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="member")
+    session.add(om)
+    await session.flush()
+    m = Member(id=om.id, org_id=org_id, type="human", user_id=user.id, name="Human")
+    session.add(m)
+    await session.flush()
+    session.add(ProjectAccess(project_id=project_id, org_member_id=om.id, member_id=m.id, role="member"))
+    await session.commit()
+    return m.id, user.id
+
+
+async def _make_story(session, org_id, project_id, title="Story"):
+    from app.models.pm import Story
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status="backlog")
+    session.add(story)
+    await session.commit()
+    return story
+
+
+async def _make_task(session, org_id, story_id, title="Task"):
+    from app.models.pm import Task
+    task = Task(id=uuid.uuid4(), org_id=org_id, story_id=story_id, title=title, status="todo")
+    session.add(task)
+    await session.commit()
+    return task
+
+
+async def _make_sprint(session, org_id, project_id, title="Sprint"):
+    from app.models.pm import Sprint
+    sprint = Sprint(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(sprint)
+    await session.commit()
+    return sprint
+
+
+async def _make_artifact(session, org_id, project_id, title="Artifact"):
+    from app.models.visual_artifact import VisualArtifact
+    artifact = VisualArtifact(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(artifact)
+    await session.commit()
+    return artifact
+
+
+async def _make_hypothesis(session, org_id, project_id, owner_member_id, statement="H"):
+    from app.models.hypothesis import Hypothesis
+    hyp = Hypothesis(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, owner_member_id=owner_member_id,
+        statement=statement, metric_definition={}, measure_after=datetime.now(timezone.utc),
+    )
+    session.add(hyp)
+    await session.commit()
+    return hyp
+
+
+async def _make_evidence(session, org_id, work_item_id, work_item_type, created_by, ev_type="url"):
+    from app.models.evidence import Evidence
+    ev = Evidence(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=work_item_id, work_item_type=work_item_type,
+        type=ev_type, ref="https://example.com", created_by=created_by,
+    )
+    session.add(ev)
+    await session.commit()
+    return ev
+
+
+async def _make_conversation(session, org_id, project_id, member_ids, created_by, conv_type="dm"):
+    from app.models.conversation import Conversation, ConversationParticipant
+    conv = Conversation(
+        id=uuid.uuid4(), project_id=project_id, org_id=org_id, type=conv_type,
+        title="Test convo", created_by=created_by,
+    )
+    session.add(conv)
+    await session.flush()
+    for mid in member_ids:
+        session.add(ConversationParticipant(conversation_id=conv.id, member_id=mid))
+    await session.commit()
+    return conv.id
+
+
+async def _make_message(session, conv_id, sender_id, content="hi"):
+    from app.models.conversation import ConversationMessage
+    msg = ConversationMessage(
+        id=uuid.uuid4(), conversation_id=conv_id, sender_id=sender_id,
+        content=content, created_at=datetime.now(timezone.utc),
+    )
+    session.add(msg)
+    await session.commit()
+    return msg
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ─── registry 등록 + twin-system 동일성 ────────────────────────────────────────
+
+
+def test_all_four_registered_in_entity_resolvers():
+    from app.services.reference_registry import ENTITY_RESOLVERS
+    for t in ("sprint", "artifact", "hypothesis", "evidence"):
+        assert t in ENTITY_RESOLVERS, t
+    assert "goal" not in ENTITY_RESOLVERS  # epic과 동일 테이블이라 안 연다
+
+
+def test_all_four_registered_in_project_id_resolvers_and_keys_match():
+    from app.services.reference_registry import ENTITY_RESOLVERS, PROJECT_ID_RESOLVERS
+    for t in ("sprint", "artifact", "hypothesis", "evidence"):
+        assert t in PROJECT_ID_RESOLVERS, t
+    assert set(ENTITY_RESOLVERS) == set(PROJECT_ID_RESOLVERS)
+
+
+# ─── ㉠존재판정 resolver 단위 ───────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_resolve_sprints_finds_existing_and_ignores_missing():
+    from app.services.reference_registry import ENTITY_RESOLVERS
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            sprint = await _make_sprint(s, org.id, project.id)
+            found = await ENTITY_RESOLVERS["sprint"](s, org.id, [sprint.id, uuid.uuid4()])
+            assert found == {sprint.id}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_resolve_artifacts_excludes_soft_deleted():
+    from app.services.reference_registry import ENTITY_RESOLVERS
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            artifact = await _make_artifact(s, org.id, project.id)
+            found_before = await ENTITY_RESOLVERS["artifact"](s, org.id, [artifact.id])
+            assert found_before == {artifact.id}
+
+            artifact.deleted_at = datetime.now(timezone.utc)
+            await s.commit()
+            found_after = await ENTITY_RESOLVERS["artifact"](s, org.id, [artifact.id])
+            assert found_after == set()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_resolve_hypotheses_archived_still_exists():
+    """archived_at은 삭제 마커가 아니라 라이프사이클 상태 — 아카이브해도 존재판정은 True."""
+    from app.services.reference_registry import ENTITY_RESOLVERS
+    from app.models.hypothesis import Hypothesis
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, _ = await _make_human_member(s, org.id, project.id)
+            hyp = await _make_hypothesis(s, org.id, project.id, member_id)
+
+            found_before = await ENTITY_RESOLVERS["hypothesis"](s, org.id, [hyp.id])
+            assert found_before == {hyp.id}
+
+            hyp.archived_at = datetime.now(timezone.utc)
+            await s.commit()
+            found_after = await ENTITY_RESOLVERS["hypothesis"](s, org.id, [hyp.id])
+            assert found_after == {hyp.id}  # 여전히 존재
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_resolve_evidence_finds_existing():
+    from app.services.reference_registry import ENTITY_RESOLVERS
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, _ = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id)
+            ev = await _make_evidence(s, org.id, story.id, "story", member_id)
+            found = await ENTITY_RESOLVERS["evidence"](s, org.id, [ev.id, uuid.uuid4()])
+            assert found == {ev.id}
+    finally:
+        await engine.dispose()
+
+
+# ─── project_id resolver 단위(evidence는 폴리모픽 분기 둘 다) ─────────────────
+
+
+@pytest.mark.anyio
+async def test_project_id_of_sprint():
+    from app.services.reference_registry import PROJECT_ID_RESOLVERS
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            sprint = await _make_sprint(s, org.id, project.id)
+            resolved = await PROJECT_ID_RESOLVERS["sprint"](s, org.id, sprint.id)
+            assert resolved == project.id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_project_id_of_artifact():
+    from app.services.reference_registry import PROJECT_ID_RESOLVERS
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            artifact = await _make_artifact(s, org.id, project.id)
+            resolved = await PROJECT_ID_RESOLVERS["artifact"](s, org.id, artifact.id)
+            assert resolved == project.id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_project_id_of_hypothesis():
+    from app.services.reference_registry import PROJECT_ID_RESOLVERS
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, _ = await _make_human_member(s, org.id, project.id)
+            hyp = await _make_hypothesis(s, org.id, project.id, member_id)
+            resolved = await PROJECT_ID_RESOLVERS["hypothesis"](s, org.id, hyp.id)
+            assert resolved == project.id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_project_id_of_evidence_via_story_work_item():
+    from app.services.reference_registry import PROJECT_ID_RESOLVERS
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, _ = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id)
+            ev = await _make_evidence(s, org.id, story.id, "story", member_id)
+            resolved = await PROJECT_ID_RESOLVERS["evidence"](s, org.id, ev.id)
+            assert resolved == project.id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_project_id_of_evidence_via_task_work_item():
+    """evidence의 work_item_type="task"인 경우 — task→story join으로 project_id 해소."""
+    from app.services.reference_registry import PROJECT_ID_RESOLVERS
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, _ = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id)
+            task = await _make_task(s, org.id, story.id)
+            ev = await _make_evidence(s, org.id, task.id, "task", member_id)
+            resolved = await PROJECT_ID_RESOLVERS["evidence"](s, org.id, ev.id)
+            assert resolved == project.id
+    finally:
+        await engine.dispose()
+
+
+# ─── ㉡TARGET 게이트 — #2283 endpoint로 타입별 독립 twin comparison ────────────
+
+
+async def _twin_comparison_for_type(target_type, make_target_coro):
+    """공용 뼈대 — source(chat_message)는 항상 접근 가능하게 하고, target 접근 유무만
+    가른다. 각 타입은 자기 seed 함수(make_target_coro)로 target을 만든다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            chat_project = await _make_project(s, org.id, "Chat Project")
+            target_project_ok = await _make_project(s, org.id, "Target Project(access)")
+            target_project_bad = await _make_project(s, org.id, "Target Project(no access)")
+
+            member_id, user_id = await _make_human_member(s, org.id, chat_project.id)
+            # user도 target_project_ok에 접근권을 갖게 한다(twin의 "있음" 쪽) — 같은 member_id로
+            # 두 번째 project에 grant만 추가(별도 human을 또 만들 필요 없음, member_id==org_member.id).
+            from sqlalchemy import select
+            from app.models.project import OrgMember
+            from app.models.project_access import ProjectAccess
+            om = (await s.execute(select(OrgMember).where(OrgMember.id == member_id))).scalar_one()
+            s.add(ProjectAccess(project_id=target_project_ok.id, org_member_id=om.id, member_id=member_id, role="member"))
+            await s.commit()
+
+            conv_id = await _make_conversation(s, org.id, chat_project.id, [member_id], member_id)
+            msg = await _make_message(s, conv_id, member_id)
+
+            target_ok = await make_target_coro(s, org.id, target_project_ok.id, member_id)
+            target_bad = await make_target_coro(s, org.id, target_project_bad.id, member_id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp_ok = await client.post("/api/v2/references", json={
+                "source_type": "chat_message", "source_id": str(msg.id),
+                "target_type": target_type, "target_id": str(target_ok),
+            })
+            resp_bad = await client.post("/api/v2/references", json={
+                "source_type": "chat_message", "source_id": str(msg.id),
+                "target_type": target_type, "target_id": str(target_bad),
+            })
+            return resp_ok, resp_bad
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_reference_sprint_target_gate_twin_comparison():
+    async def make(s, org_id, project_id, member_id):
+        sprint = await _make_sprint(s, org_id, project_id)
+        return sprint.id
+
+    resp_ok, resp_bad = await _twin_comparison_for_type("sprint", make)
+    assert resp_ok.status_code == 201, resp_ok.text
+    assert resp_bad.status_code == 404, resp_bad.text
+
+
+@pytest.mark.anyio
+async def test_create_reference_artifact_target_gate_twin_comparison():
+    async def make(s, org_id, project_id, member_id):
+        artifact = await _make_artifact(s, org_id, project_id)
+        return artifact.id
+
+    resp_ok, resp_bad = await _twin_comparison_for_type("artifact", make)
+    assert resp_ok.status_code == 201, resp_ok.text
+    assert resp_bad.status_code == 404, resp_bad.text
+
+
+@pytest.mark.anyio
+async def test_create_reference_hypothesis_target_gate_twin_comparison():
+    async def make(s, org_id, project_id, member_id):
+        hyp = await _make_hypothesis(s, org_id, project_id, member_id)
+        return hyp.id
+
+    resp_ok, resp_bad = await _twin_comparison_for_type("hypothesis", make)
+    assert resp_ok.status_code == 201, resp_ok.text
+    assert resp_bad.status_code == 404, resp_bad.text
+
+
+@pytest.mark.anyio
+async def test_create_reference_evidence_target_gate_twin_comparison():
+    async def make(s, org_id, project_id, member_id):
+        story = await _make_story(s, org_id, project_id)
+        ev = await _make_evidence(s, org_id, story.id, "story", member_id)
+        return ev.id
+
+    resp_ok, resp_bad = await _twin_comparison_for_type("evidence", make)
+    assert resp_ok.status_code == 201, resp_ok.text
+    assert resp_bad.status_code == 404, resp_bad.text

--- a/backend/tests/test_mcp_s1995_agent_doc_mentions.py
+++ b/backend/tests/test_mcp_s1995_agent_doc_mentions.py
@@ -72,15 +72,24 @@ def test_escape_mention_title_collapses_newlines_to_single_space():
 
 # ── MentionRef schema validation ──────────────────────────────────────────────
 def test_mention_ref_rejects_invalid_type():
-    """type이 doc/story/epic 외 값이면 Pydantic 스키마 레벨에서 거부(AC1) — 핸들러 코드
-    진입 전 차단."""
+    """type이 허용 목록 외 값이면 Pydantic 스키마 레벨에서 거부(AC1) — 핸들러 코드 진입
+    전 차단. `goal`은 절대 안 열리는 값(epic과 물리적으로 같은 테이블)이라 진짜 "미등록"
+    예시로 안전하다."""
     with pytest.raises(ValidationError):
-        MentionRef(type="task", id="t-1")
+        MentionRef(type="goal", id="t-1")
 
 
 def test_send_chat_input_rejects_invalid_mention_type():
     with pytest.raises(ValidationError):
-        SendChatInput(thread_id="conv-1", content="hi", mentions=[{"type": "task", "id": "t-1"}])
+        SendChatInput(thread_id="conv-1", content="hi", mentions=[{"type": "goal", "id": "t-1"}])
+
+
+def test_mention_ref_rejects_evidence_type_intentional_gap():
+    """`evidence`는 백엔드 ENTITY_RESOLVERS엔 있지만(#2294 B단계) MCP mentions Literal엔
+    없다 — GET /api/v2/evidence/{id} 단건조회 라우트가 없어서다(의도적 gap,
+    `_MENTION_ENDPOINT_KNOWN_GAP` 참조). 그 gap이 스키마 레벨에서 실제로 거부로 이어지는지."""
+    with pytest.raises(ValidationError):
+        MentionRef(type="evidence", id="ev-1")
 
 
 def test_mention_ref_accepts_doc_type():
@@ -98,14 +107,46 @@ def test_mention_ref_accepts_epic_type():
     assert m.type == "epic"
 
 
+def test_mention_ref_accepts_task_type():
+    m = MentionRef(type="task", id="t-1", title="My Task")
+    assert m.type == "task"
+
+
+def test_mention_ref_accepts_sprint_type():
+    m = MentionRef(type="sprint", id="sp-1", title="Sprint 12")
+    assert m.type == "sprint"
+
+
+def test_mention_ref_accepts_artifact_type():
+    m = MentionRef(type="artifact", id="a-1", title="My Artifact")
+    assert m.type == "artifact"
+
+
+def test_mention_ref_accepts_hypothesis_type():
+    m = MentionRef(type="hypothesis", id="h-1", title="My Hypothesis")
+    assert m.type == "hypothesis"
+
+
+# story #2294 B단계(2026-07-29): evidence는 백엔드 registry에 있지만 GET /{id} 단건조회
+# 라우트가 없어(list만 있음) MCP mentions에서 의도적으로 뺀다 — 조용히 빠진 것과 일부러
+# 뺀 것은 처방이 다르므로 이유를 명시 등재한다(infra/mcp-path-contract-allowlist.yml의
+# "알고 있다"는 선언 관례와 동형).
+_MENTION_ENDPOINT_KNOWN_GAP: frozenset[str] = frozenset({"evidence"})
+
+
 def test_mention_entity_endpoints_match_backend_entity_resolvers():
     """`_MENTION_ENTITY_ENDPOINTS`(MCP 쪽 type→GET endpoint 매핑)가 백엔드
     `reference_registry.ENTITY_RESOLVERS`(존재판정 registry, #2259/#2266/#2283이 계속 SSOT로
-    써 온 것)와 같은 타입 집합인지 고정 — 한쪽만 늘면(예: 백엔드에 새 target_type 등록,
-    MCP mentions는 안 넓힘) agent 경로만 뒤처지는 형제 비대칭이 조용히 생긴다."""
+    써 온 것)와 같은 타입 집합인지 고정(알려진 gap `_MENTION_ENDPOINT_KNOWN_GAP` 제외) —
+    한쪽만 늘면(예: 백엔드에 새 target_type 등록, MCP mentions는 안 넓힘) agent 경로만
+    뒤처지는 형제 비대칭이 조용히 생긴다. ⛔story #2294에서 이 테스트가 실제로 RED였다
+    (task가 백엔드에만 열리고 여기 안 넓혀진 채 develop에 머지됨 — merge-order 드리프트)."""
     from app.services.reference_registry import ENTITY_RESOLVERS
 
-    assert set(chat_mod._MENTION_ENTITY_ENDPOINTS) == set(ENTITY_RESOLVERS)
+    assert set(chat_mod._MENTION_ENTITY_ENDPOINTS) == set(ENTITY_RESOLVERS) - _MENTION_ENDPOINT_KNOWN_GAP
+    # gap 자체가 정말 gap인지도 고정 — evidence가 실수로 뚫려도(둘 다에 존재) 이 assert가 잡는다.
+    assert _MENTION_ENDPOINT_KNOWN_GAP <= set(ENTITY_RESOLVERS)
+    assert _MENTION_ENDPOINT_KNOWN_GAP.isdisjoint(chat_mod._MENTION_ENTITY_ENDPOINTS)
 
 
 # ── send_chat_message: token synthesis (title given) ─────────────────────────

--- a/infra/mcp-path-contract-allowlist.yml
+++ b/infra/mcp-path-contract-allowlist.yml
@@ -43,12 +43,16 @@ declared_indirect:
     function: _resolve_mention_content
     reason: >-
       경로를 `_MENTION_ENTITY_ENDPOINTS[mention.type].format(id=mention.id)`로 조립하는
-      client.get(endpoint) 호출(story #2283 후속, 2026-07-28 — doc→doc/story/epic 확장 +
-      title 미지정 시 서버 reference_token 재사용으로 도입). 호출부는 `mention.type`이 doc/
-      story/epic 셋 중 하나로 Literal 검증되므로 실제로 조립되는 경로는 정확히 3가지뿐 —
-      수기 추적: /api/v2/docs/{id}(app/routers/docs.py:GET /{id}) ·
-      /api/v2/stories/{id}(app/routers/stories.py:539 GET /{id}) ·
-      /api/v2/goals/{id}(app/routers/goals.py:136 GET /{id}, main.py:296에서
-      prefix=/api/v2/goals로 마운트) — 셋 다 실재 확認됨(2026-07-28).
+      client.get(endpoint) 호출(story #2283 후속 2026-07-28 doc→doc/story/epic 확장,
+      story #2294 B단계 2026-07-29 task/sprint/artifact/hypothesis 추가 — evidence는
+      GET /{id} 라우트 자체가 없어 의도적 제외, backend/tests/test_mcp_s1995_agent_doc_
+      mentions.py의 `_MENTION_ENDPOINT_KNOWN_GAP` 참조). 호출부는 `mention.type`이 Literal로
+      검증되므로 실제로 조립되는 경로는 정확히 7가지 — 수기 추적: /api/v2/docs/{id}
+      (docs.py GET /{id}) · /api/v2/stories/{id}(stories.py:539 GET /{id}) ·
+      /api/v2/goals/{id}(goals.py:136 GET /{id}, main.py:296 prefix=/api/v2/goals 마운트) ·
+      /api/v2/tasks/{id}(tasks.py:127 GET /{id}) · /api/v2/sprints/{id}(sprints.py:163
+      GET /{id}) · /api/v2/visual-artifacts/{id}(visual_artifacts.py:214 GET /{id}) ·
+      /api/v2/hypotheses/{id}(hypotheses.py:159 GET /{hypothesis_id}) — 일곱 다 실재
+      확認됨(2026-07-29).
     declared_by: 디디 은와추쿠
     until: "2026-08-27"


### PR DESCRIPTION
## 배경
PO 판정(2026-07-29): #2294(A단계 — task)가 "resolver + project_id resolver + TARGET 게이트"
절차를 확립했다. B단계는 선생님 원문 "어떤 엔티티든지"를 마저 채우는 것 — registry를
doc/story/epic/task(넷) → sprint/artifact/hypothesis/evidence까지 더해 **여덟**으로 넓힌다.
`goal`은 epic과 물리적으로 같은 테이블(B1 계층 리네이밍)이라 열지 않는다.

## 구현
- **sprint·hypothesis** — epic과 동형: `SoftDeleteMixin` 없음(하드 삭제) — row 존재 자체가
  존재판정. `Hypothesis.archived_at`은 삭제 마커가 아니라 라이프사이클 상태(모델 코멘트
  §3.10 "hard delete는 정책 확定 전까지 금지")라 필터하지 않는다 — 아카이브된 가설도 여전히
  참조 가능해야 한다는 것을 realdb 테스트로 확인(`test_resolve_hypotheses_archived_still_exists`).
- **artifact(VisualArtifact)** — doc과 동형: `deleted_at` soft-delete 필터.
- **evidence** — `project_id` 컬럼이 없다(`work_item_id`/`work_item_type`로 story/task를
  폴리모픽 참조). `work_item_type`으로 분기해 Story 직접 또는 Task→Story join으로 간접
  해소(task의 project_id resolver와 동일 join 패턴, 재구현 0).
- `reference.py`·`reference_core.py` diff **0**(`git diff --stat`로 확인) — 두 파일 다 이미
  registry를 제네릭하게 순회해 4종 추가에 몸통 변경이 필요 없었다.

## 부수 발견 — merge-order 드리프트를 직접 겪고 고쳤다
작업 시작 전 `develop` HEAD가 **이미 RED**였다:
`test_mention_entity_endpoints_match_backend_entity_resolvers`가 실패 중이었다 — #2585
(MCP mentions doc/story/epic 확장)가 #2294(task 개설)보다 먼저 작성돼 task를 몰랐고, 두
PR이 각각은 옳았지만 develop에 합쳐지며 그 축이 깨졌다(어느 한 PR의 CI도 혼자서는 못 잡는
클래스 — 두 정확한 변경의 조합이 만드는 결함). `_MENTION_ENTITY_ENDPOINTS`+`MentionRef.type`
에 task/sprint/artifact/hypothesis를 추가해 고쳤다. `evidence`는 `GET /api/v2/evidence/{id}`
단건조회 라우트 자체가 없어서(list만 `work_item_id`로 필터링해 존재) MCP mentions에서는
**의도적으로 제외** — `_MENTION_ENDPOINT_KNOWN_GAP`로 명시 선언했다(조용히 빠진 것과 일부러
뺀 것은 처방이 다르다 — `infra/mcp-path-contract-allowlist.yml`의 "알고 있다" 선언 관례와
동형). 그 allowlist 파일의 `declared_indirect` 엔트리도 7개 엔드포인트 전부 수기 추적해
갱신했다.

## twin-system drift 재발 — 이번 PR 자체에서 (오늘) 네 번째
`sprint`가 이제 등록되며 `#2282`/`#2283`/`#2294`의 기존 테스트 3개가 "sprint=미등록 예시"로
쓰고 있던 자리가 RED가 됐다 — `goal`(epic과 같은 테이블이라 절대 안 열림)로 교체했다.
등록되면 테스트가 스스로 경보한다는 것이 이 PR 자체에서 다시 한 번 증명됐다.

## 검증
- 신규 15개(`test_2294b_open_4_types_realdb.py`): registry 등록+twin-system 키 동일성 ·
  존재판정 resolver 단위(sprint/artifact soft-delete/hypothesis archived-still-exists/
  evidence) · project_id resolver 단위(evidence는 story·task 폴리모픽 분기 둘 다) ·
  타입별 **독립** twin comparison(#2283 endpoint, 접근 있음 201 / 없음 404) — PO 요구
  "종류마다 게이트가 실제로 서는지는 각각 보이는 것"대로 4개 타입을 한 루프로 뭉개지 않고
  각각 별도 테스트.
- MCP mentions 갱신 27개(`test_mcp_s1995_agent_doc_mentions.py`) + 경로 계약 가드 13개
  (`test_mcp_path_contract_guard.py`, CI=1로 재현).
- RED→GREEN 자체검증: `PROJECT_ID_RESOLVERS`에서 `"evidence"` 항목을 Edit로 제거 →
  `#2283`/`#2294B` 두 parity 테스트 모두 RED 확認(twin-system 가드가 실제로 작동하는 것
  실증) → 복원 → GREEN.
- 회귀 360개 GREEN(mention/backlinks/#2259~#2294/docs/stories/conversations/evidence/
  sprints/hypotheses 관련 스위트).

## 롤백
`reference_registry.py`에서 4종(각 resolver+project_id resolver 2개씩=8개 함수·registry
등록 4×2=8개 항목) 제거 + `chat.py`의 `MentionRef.type`/`_MENTION_ENTITY_ENDPOINTS`에서
task/sprint/artifact/hypothesis 4개 제거하면 순수 revert. 신규 코드가 기존 응답 필드를
하나도 바꾸지 않는 additive라 부분 revert도 안전.