### PR TITLE
feat(infra): env 드리프트 가드 축⑤ 「코드가 읽는데 아무도 안 주는 값」 신설 (#2296)

### DIFF
--- a/backend/scripts/deploy_frontend.sh
+++ b/backend/scripts/deploy_frontend.sh
@@ -66,6 +66,11 @@ case "${ENV}" in
         # 항상 raw *.run.app 로 resolve돼 재실행 시 이 값을 조용히 되돌린다.
         FASTAPI_URL_OVERRIDE="https://dev-api.sprintable.ai"
         COOKIE_DOMAIN_SECRET_SPEC=""
+        # story #2296(2026-07-28) — apps/web/src/app/api/auth/callback/[provider]/route.ts:11의
+        # 하드코딩 폴백('https://dev-app.sprintable.ai')과 정확히 같은 값. 이 스크립트가 그
+        # 값을 명시적으로 공급하지 않아도 dev는 "우연히" 맞았다(사고 원인 그 자체). SSOT에 넣는
+        # 이유는 "지워져서"가 아니라 "아무도 여기 있는 줄 몰라서"다(AC7, PO 자기정정 참고).
+        MOBILE_APP_LINK_ORIGIN="https://dev-app.sprintable.ai"
         ;;
     prod)
         SERVICE_NAME="sprintable-frontend-prod"
@@ -77,6 +82,12 @@ case "${ENV}" in
         RUNTIME_SA="cloudrun-runtime-prod@${GCP_PROJECT}.iam.gserviceaccount.com"
         FASTAPI_URL_OVERRIDE=""
         COOKIE_DOMAIN_SECRET_SPEC=",NEXT_PUBLIC_COOKIE_DOMAIN=NEXT_PUBLIC_COOKIE_DOMAIN:latest"
+        # story #2296(2026-07-28) — 2026-07-28 prod 앱 로그인 장애의 근본원인 두 건 중 하나.
+        # 이 값이 없어 코드의 dev 기본값으로 되돌아갔다(prod가 dev 앱 주소를 가리킴). 저장소
+        # 전체가 이미 app.sprintable.ai를 prod 정본으로 쓴다(deploy_backend.sh:79,81·
+        # setup_dns.sh:44·verify_gcp_migration.sh:22·setup_secret_manager.sh:45의
+        # NEXT_PUBLIC_COOKIE_DOMAIN 등) — 그 관례를 그대로 따른다.
+        MOBILE_APP_LINK_ORIGIN="https://app.sprintable.ai"
         ;;
     *)
         echo "Usage: $0 [dev|prod]"; exit 1 ;;
@@ -113,8 +124,11 @@ if [[ -z "${FASTAPI_URL}" ]]; then
     log "WARNING: FastAPI service '${FASTAPI_SERVICE}' not found. NEXT_PUBLIC_FASTAPI_URL will be empty."
 fi
 
-ENV_VARS_SPEC="NODE_ENV=production,NEXT_TELEMETRY_DISABLED=1,NEXT_PUBLIC_FASTAPI_URL=${FASTAPI_URL}"
-SECRETS_SPEC="NEXT_PUBLIC_SUPABASE_URL=NEXT_PUBLIC_SUPABASE_URL:latest,NEXT_PUBLIC_SUPABASE_ANON_KEY=NEXT_PUBLIC_SUPABASE_ANON_KEY:latest,JWT_SECRET=JWT_SECRET:latest${COOKIE_DOMAIN_SECRET_SPEC}"
+ENV_VARS_SPEC="NODE_ENV=production,NEXT_TELEMETRY_DISABLED=1,NEXT_PUBLIC_FASTAPI_URL=${FASTAPI_URL},MOBILE_APP_LINK_ORIGIN=${MOBILE_APP_LINK_ORIGIN}"
+# FIREBASE_BFF_INTERNAL_SECRET — deploy_backend.sh:125가 이미 같은 Secret Manager 시크릿을
+# 바인딩한다(story #2296 이전에도 존재 — backend는 받고 있었다). frontend가 그동안 이 스크립트로
+# 안 받고 있었던 것이 2026-07-28 사고의 나머지 절반이다. 값은 옮기지 않는다(:latest 참조만).
+SECRETS_SPEC="NEXT_PUBLIC_SUPABASE_URL=NEXT_PUBLIC_SUPABASE_URL:latest,NEXT_PUBLIC_SUPABASE_ANON_KEY=NEXT_PUBLIC_SUPABASE_ANON_KEY:latest,JWT_SECRET=JWT_SECRET:latest,FIREBASE_BFF_INTERNAL_SECRET=FIREBASE_BFF_INTERNAL_SECRET:latest${COOKIE_DOMAIN_SECRET_SPEC}"
 
 if [ "${DRY_RUN}" = "1" ]; then
     cat <<EOF

--- a/backend/tests/test_check_env_drift_code_read_axis.py
+++ b/backend/tests/test_check_env_drift_code_read_axis.py
@@ -1,0 +1,251 @@
+"""story #2296 축⑤ "코드가 읽는데 아무도 안 주는 값" — infra/check_env_drift.py 신규 축 회귀가드.
+
+2026-07-28 prod 앱 로그인 장애 그대로 재현·고정한다: `MOBILE_APP_LINK_ORIGIN`(기본값이
+dev-app.sprintable.ai — ㉡최고위험)·`FIREBASE_BFF_INTERNAL_SECRET`(기본값 없음 — ㉠높음) 둘
+다 IaC(deploy_frontend.sh)에도 라이브(frontend-prod)에도 없었다. gcloud 라이브 접근 없이
+(정적 스캔·allowlist 파싱은 순수 로컬 로직) 실행 가능한 부분만 고정한다.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_INFRA_DIR = _REPO_ROOT / "infra"
+
+
+def _load_check_env_drift():
+    spec = importlib.util.spec_from_file_location(
+        "check_env_drift", _INFRA_DIR / "check_env_drift.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ── AC3 — 위험 등급이 실제로 갈린다 ────────────────────────────────────────────
+
+def test_classify_dev_default_is_highest():
+    mod = _load_check_env_drift()
+    assert mod._classify_code_read_risk(["https://dev-app.sprintable.ai"]) == "highest"
+
+
+def test_classify_localhost_and_test_defaults_are_also_highest():
+    mod = _load_check_env_drift()
+    assert mod._classify_code_read_risk(["http://localhost:8000"]) == "highest"
+    assert mod._classify_code_read_risk(["test-mode"]) == "highest"
+
+
+def test_classify_no_default_is_high_not_highest():
+    """FIREBASE_BFF_INTERNAL_SECRET의 실제 모양 — 기본값 자체가 없다. dev 가리키는 것보다는
+    한 등급 낮다(㉠) — 즉시 undefined로 드러나 쪽이 조용한 오지정보다 상대적으로 덜 insidious."""
+    mod = _load_check_env_drift()
+    assert mod._classify_code_read_risk([None]) == "high"
+
+
+def test_classify_env_agnostic_default_is_low():
+    mod = _load_check_env_drift()
+    assert mod._classify_code_read_risk(["us-east-1"]) == "low"
+    assert mod._classify_code_read_risk([".storage"]) == "low"
+
+
+def test_three_tiers_are_actually_different_not_one_bucket():
+    """AC3 본체 — 세 등급이 «다른 값»으로 나와야 한다(하나로 뭉치면 등급이 아니다)."""
+    mod = _load_check_env_drift()
+    tiers = {
+        mod._classify_code_read_risk(["https://dev-app.sprintable.ai"]),
+        mod._classify_code_read_risk([None]),
+        mod._classify_code_read_risk(["us-east-1"]),
+    }
+    assert tiers == {"highest", "high", "low"}
+
+
+# ── 추출 — 소스 리터럴만 읽는다(라이브 값 없이도 동작) ──────────────────────────
+
+def test_web_env_reads_finds_the_real_incident_file(tmp_path):
+    mod = _load_check_env_drift()
+    src = tmp_path / "route.ts"
+    src.write_text(
+        "const A = () => process.env['MOBILE_APP_LINK_ORIGIN'] ?? 'https://dev-app.sprintable.ai';\n"
+        "const B = () => process.env['FIREBASE_BFF_INTERNAL_SECRET'];\n"
+    )
+    reads = mod._web_env_reads(tmp_path)
+    assert reads["MOBILE_APP_LINK_ORIGIN"][0][1] == "https://dev-app.sprintable.ai"
+    assert reads["FIREBASE_BFF_INTERNAL_SECRET"][0][1] is None
+
+
+def test_web_env_reads_ignores_test_files(tmp_path):
+    mod = _load_check_env_drift()
+    (tmp_path / "route.test.ts").write_text("process.env['SOME_TEST_ONLY_KEY'] = 'x';\n")
+    reads = mod._web_env_reads(tmp_path)
+    assert "SOME_TEST_ONLY_KEY" not in reads
+
+
+def test_web_env_reads_never_touches_live_values():
+    """AC5 — 이 함수의 시그니처 자체가 소스 Path만 받는다(라이브 env 접근 불가능한 구조).
+    함수가 아예 gcloud를 부를 방법이 없다는 것을 소스 검사로 고정."""
+    import inspect
+    mod = _load_check_env_drift()
+    src = inspect.getsource(mod._web_env_reads)
+    assert "gcloud" not in src and "_live_env_entries" not in src
+
+
+# ── AC1 — 오늘의 두 건이 실제로 잡힌다(fixture 재현, 라이브 값은 지금 채워져 있으므로) ──
+
+# AC7에서 이 두 키를 deploy_frontend.sh에 실제로 추가한다 — 그러면 실시간
+# `_iac_covered_keys_for_service()`는 "이미 고쳐진" 상태를 돌려주게 된다. AC1은 "사고 당시"를
+# 재현하는 것이 목적이라 그 두 키만 빼서 사고 시점 상태를 흉내낸다(그 외 실제 IaC 상태는
+# 그대로 써서 NEXT_PUBLIC_FASTAPI_URL 같은 무관한 키가 findings에 섞이지 않게 한다).
+_INCIDENT_KEYS = {"MOBILE_APP_LINK_ORIGIN", "FIREBASE_BFF_INTERNAL_SECRET"}
+
+
+def test_ac1_mobile_app_link_origin_reproduces_as_highest_fail():
+    """실제 리포 소스(오늘 그 파일)를 그대로 스캔 + 실제 per-service IaC 커버리지에서 사고
+    당시 상태(그 두 키만 없음)를 흉내 — highest 등급으로 잡혀야 한다."""
+    mod = _load_check_env_drift()
+    reads = mod._web_env_reads()  # 실제 apps/web/src 스캔 — MOBILE_APP_LINK_ORIGIN 실존 확認
+    assert "MOBILE_APP_LINK_ORIGIN" in reads
+
+    covered = mod._iac_covered_keys_for_service("sprintable-frontend-prod") - _INCIDENT_KEYS
+    highest, high, low = mod._unsupplied_code_read_findings(reads, covered, set())
+    assert any("MOBILE_APP_LINK_ORIGIN" in line for line in highest), (
+        f"highest에 MOBILE_APP_LINK_ORIGIN이 없음 — {highest}"
+    )
+
+
+def test_ac1_firebase_bff_internal_secret_reproduces_as_high():
+    mod = _load_check_env_drift()
+    reads = mod._web_env_reads()
+    assert "FIREBASE_BFF_INTERNAL_SECRET" in reads
+
+    covered = mod._iac_covered_keys_for_service("sprintable-frontend-prod") - _INCIDENT_KEYS
+    highest, high, low = mod._unsupplied_code_read_findings(reads, covered, set())
+    assert any("FIREBASE_BFF_INTERNAL_SECRET" in line for line in high), (
+        f"high에 FIREBASE_BFF_INTERNAL_SECRET이 없음 — {high}"
+    )
+
+
+def test_ac1_full_main_reproduces_frontend_prod_incident_and_fails(monkeypatch, capsys):
+    """⭐AC1 본체 — main()을 통째로 돌려 「가드가 빨개지는 것」을 실제로 본다.
+    frontend-prod 라이브를 사고 당시 그대로(두 키 다 없음) fixture로 흉내낸다."""
+    mod = _load_check_env_drift()
+
+    monkeypatch.setattr(mod, "_list_live_services", lambda: ["sprintable-frontend-prod"])
+    monkeypatch.setattr(
+        mod, "_live_env_entries",
+        lambda service: [{"name": "OTHER_UNRELATED_KEY", "value": "x"}],  # 그 둘은 없음
+    )
+    monkeypatch.setattr(mod, "_load_allowlist", lambda: ({}, {}))
+    monkeypatch.setattr(mod, "_load_code_read_exempt", lambda: set())
+    monkeypatch.setattr(mod, "_iac_covered_keys_for_service", lambda service: set())
+    monkeypatch.setattr(mod, "_iac_covered_keys", lambda: set())
+    # ①②③④축은 이 서비스가 그 매핑들 밖이라 자연히 skip — ⑤만 단독으로 신호를 낸다.
+
+    exit_code = mod.main()
+
+    assert exit_code == 1, "MOBILE_APP_LINK_ORIGIN(highest)이 잡혔어야 하는데 통과함"
+    out = capsys.readouterr().out
+    assert "⑤㉡" in out and "MOBILE_APP_LINK_ORIGIN" in out
+    assert "sprintable-frontend-prod" in out
+
+
+# ── AC2 — 양성대조: 정상 상태에서는 안 걸린다 ──────────────────────────────────
+
+def test_ac2_positive_control_both_keys_covered_does_not_fire():
+    """지금(고쳐진 뒤) 상태를 흉내 — 두 키가 covered_keys에 있으면 findings에 안 나와야
+    한다. 둘 다 걸리면 판별력 0(뭘 넣어도 FAIL)이라 이 테스트가 그 축퇴를 막는다."""
+    mod = _load_check_env_drift()
+    reads = mod._web_env_reads()
+    covered_after_fix = {"MOBILE_APP_LINK_ORIGIN", "FIREBASE_BFF_INTERNAL_SECRET"}
+    highest, high, low = mod._unsupplied_code_read_findings(reads, covered_after_fix, set())
+    assert not any("MOBILE_APP_LINK_ORIGIN" in line for line in highest)
+    assert not any("FIREBASE_BFF_INTERNAL_SECRET" in line for line in high)
+
+
+def test_ac2_positive_control_full_main_passes_when_covered(monkeypatch, capsys):
+    """⛔`_iac_covered_keys_for_service`는 모킹하지 않는다 — 진짜 IaC(현재 리포)를 그대로
+    쓰고, 사고의 그 두 키만 라이브로 "공급된 것처럼" fixture로 얹는다. 나머지 실제 코드베이스
+    findings(highest 대상인 NEXT_PUBLIC_FASTAPI_URL 등)는 실제 IaC가 이미 커버하고 있어
+    자연히 안 걸린다 — 그게 이 테스트가 «진짜 양성대조»인 이유(인위적으로 다 가려서 초록을
+    만든 게 아니다)."""
+    mod = _load_check_env_drift()
+    monkeypatch.setattr(mod, "_list_live_services", lambda: ["sprintable-frontend-prod"])
+    monkeypatch.setattr(
+        mod, "_live_env_entries",
+        lambda service: [
+            {"name": "MOBILE_APP_LINK_ORIGIN", "valueFrom": {}},
+            {"name": "FIREBASE_BFF_INTERNAL_SECRET", "valueFrom": {}},
+        ],
+    )
+    monkeypatch.setattr(mod, "_load_allowlist", lambda: ({}, {}))
+
+    exit_code = mod.main()
+    out = capsys.readouterr().out
+    assert "MOBILE_APP_LINK_ORIGIN" not in out
+    assert "FIREBASE_BFF_INTERNAL_SECRET" not in out
+    # ⛔"⑤㉡" 헤더 자체가 아니라 안내문(항상 찍히는 remediation guidance)에 그 글자가 섞여
+    # 있을 수 있어 헤더 전체 문자열로 정밀하게 확認한다(오탐 방지 — 이 assertion 자체가
+    # 처음엔 너무 넓어 자기 오탐을 냈다).
+    assert "⑤㉡코드가 읽는데" not in out, f"highest 등급 FAIL 섹션이 실제로 찍힘(양성대조 오염) — {out}"
+    assert exit_code == 0
+
+
+# ── AC4 — 오탐 수를 세어 적는다(실 저장소 스캔) ─────────────────────────────────
+
+def test_ac4_real_repo_scan_counts_are_recorded():
+    """2026-07-28 실측(AC7 반영 前 — deploy_frontend.sh에 그 두 키를 추가하기 전 기준) —
+    이 수치가 바뀌면(새 env 추가·exempt 갱신 등) 이 테스트가 알린다. exempt 18건은
+    KMS/Storage/Dogfood 3개 기능-스위치 군으로 코드 확認 후 등재한 것 — 나머지는 정직히
+    미triage 상태로 남긴다(라이브 접근 불가 환경이라 IaC-only 상한선 — 실제 CI는 라이브도
+    더해 이보다 작거나 같은 수를 본다)."""
+    mod = _load_check_env_drift()
+    reads = mod._web_env_reads()
+    exempt = mod._load_code_read_exempt()
+    covered = mod._iac_covered_keys_for_service("sprintable-frontend-prod") - _INCIDENT_KEYS
+
+    highest, high, low = mod._unsupplied_code_read_findings(reads, covered, exempt)
+    total_reads = len(reads)
+    total_findings = len(highest) + len(high) + len(low)
+
+    print(
+        f"\n[AC4] 총 고유 env 키 {total_reads}개 · exempt {len(exempt)}개 · "
+        f"미커버 findings {total_findings}개(highest={len(highest)}, high={len(high)}, low={len(low)})"
+    )
+    # 정확한 숫자 고정(2026-07-28) — 스위트가 실패하면 숫자가 바뀐 것, 원인을 봐야 한다.
+    assert len(highest) == 1, highest
+    assert len(high) == 15, high
+    assert len(low) == 9, low
+    assert len(exempt) == 18
+
+
+# ── AC5 — 값을 안 읽는다 ──────────────────────────────────────────────────────
+
+def test_ac5_findings_never_reference_live_env_values():
+    """라이브 entry가 «value 필드 자체가 없어도»(name만) ⑤ 판정이 정상 동작해야 한다 —
+    이 축이 구조적으로 값을 필요로 하지 않는다는 증거."""
+    mod = _load_check_env_drift()
+    reads = {"SOME_KEY": [("file.ts", None)]}
+    # covered_keys는 이름 집합일 뿐, live entry의 "value"를 담을 여지가 없는 자료형(set[str]).
+    highest, high, low = mod._unsupplied_code_read_findings(reads, {"SOME_KEY"}, set())
+    assert highest == [] and high == [] and low == []
+
+
+# ── ⛔AC6 — 이 축이 여전히 못 잡는 것(코드 검증 아니라 문서화·정직한 선언) ─────────
+#
+# 1. 런타임에 동적으로 조립된 키(`process.env[varName]`, `process.env[\`PREFIX_${x}\`]`)는
+#    정적 정규식(`[A-Z][A-Z0-9_]*` 리터럴)으로 안 보인다.
+# 2. `??`/`||` 폴백이 아니라 `if (!process.env.X) throw` 류 런타임 가드는 "기본값 없음"으로
+#    뭉뚱그려진다 — 그 가드가 실제로 얼마나 엄격한지는 못 가른다.
+# 3. NEXT_PUBLIC_* 접두 키는 Next.js가 빌드타임에 인라인할 수 있어, 그 경우 라이브 Cloud Run
+#    env 유무 자체가 무관해진다 — 이 축은 그 구분을 못 한다(과탐 방향 — 실제로는 괜찮은데
+#    "안 채워졌다"고 보고할 수 있음).
+# 4. IaC 커버리지는 «스크립트에 그 키 리터럴이 있는가»만 본다 — 조건부 분기(`if [ "$ENV" =
+#    "prod" ]`) 안에 있어도 스크립트 전체 텍스트에서 매치되면 "있다"로 잡힌다(과소탐지
+#    방향 — dev 분기에만 있어도 prod가 커버된 것처럼 보일 수 있음).
+def test_ac6_dynamic_key_construction_is_not_detected(tmp_path):
+    """1번 한계를 코드로도 고정 — 동적 키 조립은 진짜로 안 잡힌다는 것을 실증."""
+    mod = _load_check_env_drift()
+    src = tmp_path / "dynamic.ts"
+    src.write_text("const key = 'RUNTIME_' + suffix; const v = process.env[key];\n")
+    reads = mod._web_env_reads(tmp_path)
+    assert reads == {}, "동적 키 조립은 이 축이 원천적으로 못 본다는 전제가 깨짐"

--- a/backend/tests/test_check_env_drift_code_read_axis.py
+++ b/backend/tests/test_check_env_drift_code_read_axis.py
@@ -249,3 +249,102 @@ def test_ac6_dynamic_key_construction_is_not_detected(tmp_path):
     src.write_text("const key = 'RUNTIME_' + suffix; const v = process.env[key];\n")
     reads = mod._web_env_reads(tmp_path)
     assert reads == {}, "동적 키 조립은 이 축이 원천적으로 못 본다는 전제가 깨짐"
+
+
+# ── ⑤㉠ baseline 래칫(파울로군 지시, 2026-07-28) — report-only가 영원히 report-only가
+# 되지 않도록: baseline에 없는 새 ㉠은 FAIL, baseline 안은 count만, self-expiring ──────
+
+
+def _entry(reason="r", declared_by="PO", until="2026-08-27"):
+    return {"reason": reason, "declared_by": declared_by, "until": until}
+
+
+def test_baseline_known_high_is_not_escalated():
+    mod = _load_check_env_drift()
+    baseline = {"KNOWN_KEY": _entry()}
+    ok, escalate = mod._split_high_by_baseline(
+        [("KNOWN_KEY", "KNOWN_KEY (file.ts)")], baseline, mod._today()
+    )
+    assert len(ok) == 1 and escalate == []
+
+
+def test_new_high_not_in_baseline_is_escalated():
+    """AC의 핵심 — baseline에 없는 신규 ㉠은 즉시 FAIL 대상이 된다."""
+    mod = _load_check_env_drift()
+    ok, escalate = mod._split_high_by_baseline(
+        [("BRAND_NEW_KEY", "BRAND_NEW_KEY (file.ts)")], {}, mod._today()
+    )
+    assert ok == [] and len(escalate) == 1
+    assert "BRAND_NEW_KEY" in escalate[0] and "신규" in escalate[0]
+
+
+def test_baseline_entry_expired_is_escalated():
+    """만료된 baseline은 신규와 동일하게 FAIL — 「묻어두는 곳」이 되지 않는다."""
+    from datetime import date
+    mod = _load_check_env_drift()
+    baseline = {"OLD_KEY": _entry(until="2026-01-01")}
+    ok, escalate = mod._split_high_by_baseline(
+        [("OLD_KEY", "OLD_KEY (file.ts)")], baseline, date(2026, 7, 28)
+    )
+    assert ok == [] and len(escalate) == 1 and "만료" in escalate[0]
+
+
+def test_baseline_entry_too_far_in_future_is_escalated():
+    mod = _load_check_env_drift()
+    baseline = {"K": _entry(until="2099-12-31")}
+    ok, escalate = mod._split_high_by_baseline([("K", "K (f.ts)")], baseline, mod._today())
+    assert ok == [] and "너무 멀다" in escalate[0]
+
+
+def test_baseline_entry_without_reason_is_escalated():
+    mod = _load_check_env_drift()
+    entry = _entry()
+    del entry["reason"]
+    baseline = {"K": entry}
+    ok, escalate = mod._split_high_by_baseline([("K", "K (f.ts)")], baseline, mod._today())
+    assert ok == [] and "reason" in escalate[0]
+
+
+def test_repo_code_read_high_baseline_is_wellformed():
+    """저장소에 실제로 커밋된 baseline(14건, 2026-07-28)이 형식을 지키는지."""
+    mod = _load_check_env_drift()
+    baseline = mod._load_code_read_high_baseline()
+    assert len(baseline) == 14
+    for key, entry in baseline.items():
+        problem = mod._baseline_entry_expired(entry, mod._today())
+        assert problem is None, f"{key}: {problem}"
+
+
+def test_ac1_full_main_new_high_key_escalates_to_fail(monkeypatch, capsys):
+    """⭐라이브 재현 — baseline에 없는 새 ㉠ 하나가 실제로 main()을 exit 1로 떨어뜨리는지
+    end-to-end로 본다(AC1이 요구하는 "가드가 빨개지는 것"을 ㉠ 축에서도 만족)."""
+    mod = _load_check_env_drift()
+    monkeypatch.setattr(mod, "_list_live_services", lambda: ["sprintable-frontend-prod"])
+    monkeypatch.setattr(mod, "_live_env_entries", lambda service: [])
+    monkeypatch.setattr(mod, "_load_allowlist", lambda: ({}, {}))
+    monkeypatch.setattr(mod, "_iac_covered_keys_for_service", lambda service: set())
+    monkeypatch.setattr(mod, "_iac_covered_keys", lambda: set())
+    monkeypatch.setattr(
+        mod, "_web_env_reads",
+        lambda: {"BRAND_NEW_UNBASELINED_KEY": [("fake.ts", None)]},  # 기본값 없음 = ㉠
+    )
+    monkeypatch.setattr(mod, "_load_code_read_exempt", lambda: set())
+    monkeypatch.setattr(mod, "_load_code_read_high_baseline", lambda: {})  # baseline 비어있음
+
+    exit_code = mod.main()
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "BRAND_NEW_UNBASELINED_KEY" in out and "신규" in out
+
+
+def test_baseline_count_is_always_printed(monkeypatch, capsys):
+    """③ — baseline 수를 «매번» 찍는다(성공 경로에서도). 안 찍으면 baseline이 줄어드는지
+    아무도 모른다."""
+    mod = _load_check_env_drift()
+    monkeypatch.setattr(mod, "_list_live_services", lambda: [])  # 서비스 0개 — 완전 성공 경로
+    monkeypatch.setattr(mod, "_load_allowlist", lambda: ({}, {}))
+
+    exit_code = mod.main()
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "⑤㉠ baseline" in out

--- a/infra/check_env_drift.py
+++ b/infra/check_env_drift.py
@@ -27,7 +27,21 @@ Settings 클래스 자체를 extra="forbid"로 바꾸는 건 안 함(플랫폼/�
 안정화되기 전엔 FAIL 승격하지 않는다(exit code에 반영 안 함 — stdout 열거만). exempt 목록이
 triage로 정리된 後 별도 커밋에서 fail로 승격할 것.
 
+⑤(story #2296, 2026-07-28) — 코드가 읽는데 아무도 안 주는 값. ①②③④는 전부 "라이브 ↔
+IaC" 두 자리만 본다 — 둘 다 그 값을 모르면(둘 다 안 준다) "드리프트 없음"으로 읽힌다. 오늘
+프론트 prod 로그인이 정확히 그 구멍으로 죽었다(`MOBILE_APP_LINK_ORIGIN`·
+`FIREBASE_BFF_INTERNAL_SECRET` 둘 다 IaC에도 라이브 어디에도 없었다 — dev는 하드코딩
+기본값이 우연히 dev 주소와 같아 "그냥 됐다"). 세 번째 축 "코드가 읽는 이름"을 붙인다 —
+`apps/web/src`를 정적 스캔해 `process.env['X']`/`process.env.X` 읽는 키를 전부 뽑고,
+IaC∪라이브(그 서비스 것) 어디에도 없는 키를 위험 등급별로 보고한다. 백엔드는 이미 ④(Settings
+커버리지)와 pydantic-settings의 필수 필드 검증(기본값 없는 필드는 기동 자체가 실패)이
+같은 역할을 구조적으로 하고 있어 이 축의 신규 대상이 아니다 — Next.js는 `process.env.X`가
+없어도 그냥 `undefined`로 흘러 기동은 되고 런타임에 조용히 깨지는 게 이 사고의 근본이었다.
+
 값 자체는 절대 출력/기록하지 않는다 — 매치 여부(bool)만 사용, stdout엔 키 이름·서비스만.
+⚠️⑤의 "기본값" 판정은 예외다 — 소스 코드에 **리터럴로 박힌** 폴백 문자열(이미 git에
+공개돼 있는 것, 예: `'https://dev-app.sprintable.ai'`)만 읽는다. 라이브 Cloud Run env
+value는 이 축도 절대 안 읽는다(①이 이미 뽑아 둔 키 «이름» 집합만 재사용).
 
 로컬 수동 실행:
     python3 infra/check_env_drift.py
@@ -227,6 +241,26 @@ def _extract_keys_from_text(text: str) -> set[str]:
     return set(_KEY_RE.findall(text))
 
 
+def _iac_covered_keys_for_service(service: str) -> set[str]:
+    """⑤ 전용 — ①의 `_iac_covered_keys()`는 전 서비스 스크립트를 합쳐(global union) 판정한다
+    (v1 실용적 타협, 위 클래스 docstring 참고). 그런데 그 합집합이 정확히 이 축의 두 실사고
+    중 하나(`FIREBASE_BFF_INTERNAL_SECRET`)를 가린다 — 그 키는 deploy_backend.sh에만 있고
+    deploy_frontend.sh엔 없는데, 전역 합집합으로 보면 "IaC 어딘가엔 있다"가 되어 frontend가
+    실제로 그 키를 공급받는지와 무관하게 "커버됨"으로 잘못 판정된다. ⑤는 그래서 «이
+    서비스를 담당하는 스크립트»로만 좁혀 본다(공유 cloudbuild.yaml/cloud-build.yml은
+    여러 서비스가 같은 스텝에서 배선될 수 있어 그대로 포함)."""
+    covered: set[str] = set()
+    for rel in ("cloudbuild.yaml", ".github/workflows/cloud-build.yml"):
+        path = _REPO_ROOT / rel
+        if path.exists():
+            covered |= _extract_keys_from_text(path.read_text())
+    for rel in _SERVICE_SCRIPT_MAP.get(service, []):
+        path = _REPO_ROOT / rel
+        if path.exists():
+            covered |= _extract_keys_from_text(path.read_text())
+    return covered
+
+
 def _iac_covered_keys() -> set[str]:
     covered: set[str] = set()
     for rel in ("cloudbuild.yaml", ".github/workflows/cloud-build.yml"):
@@ -241,23 +275,121 @@ def _iac_covered_keys() -> set[str]:
     return covered
 
 
+# ⑤ 코드가 읽는데 아무도 안 주는 값 — apps/web/src 정적 스캔 대상.
+_WEB_SRC_DIR = _REPO_ROOT / "apps" / "web" / "src"
+_ENV_BRACKET_RE = re.compile(r"process\.env\[\s*['\"]([A-Z][A-Z0-9_]*)['\"]\s*\]")
+_ENV_DOT_RE = re.compile(r"process\.env\.([A-Z][A-Z0-9_]*)")
+# 매치 직후 200자 안에서 `?? '...'`/`|| '...'`(문자열 리터럴 폴백)만 인식한다 — 함수 호출·
+# 변수 등 리터럴이 아닌 폴백은 "기본값 없음"과 동일하게 취급(안전 쪽, ㉠으로 승격).
+_DEFAULT_LITERAL_RE = re.compile(r"""^\s*(?:\?\?|\|\|)\s*['"]([^'"]*)['"]""")
+
+# 플랫폼/빌드가 항상 채우거나 이 축의 판정 대상이 아닌 잘 알려진 키.
+# NEXT_RUNTIME — Next.js가 빌드/런타임에 자동 주입(nodejs/edge 런타임 구분), 사람이 배포
+# 설정으로 "공급"하는 값이 아니다(2026-07-28 실측 확認 — instrumentation.ts가 읽지만 그
+# 값은 배포 SSOT/라이브 env var가 아니라 프레임워크가 실행 컨텍스트에 따라 스스로 세팅).
+_WEB_ENV_IGNORE = {"NODE_ENV", "NEXT_RUNTIME"}
+
+# ⑤가 대상으로 삼는 서비스 — apps/web 코드베이스를 실제로 구동하는 라이브 서비스만.
+_WEB_CODE_SERVICES = {"sprintable-frontend-dev", "sprintable-frontend-prod"}
+
+
+def _web_env_reads(src_dir: Path = _WEB_SRC_DIR) -> dict[str, list[tuple[str, str | None]]]:
+    """반환: {key: [(file_relpath, default_literal_or_None), ...]}. 소스 «리터럴»만 읽는다
+    (git에 이미 공개된 텍스트) — 라이브 env value는 이 함수가 존재를 몰라도 된다."""
+    findings: dict[str, list[tuple[str, str | None]]] = {}
+    if not src_dir.exists():
+        return findings
+    paths = sorted(src_dir.rglob("*.ts")) + sorted(src_dir.rglob("*.tsx"))
+    for path in paths:
+        if ".test." in path.name or ".spec." in path.name:
+            continue
+        text = path.read_text(errors="ignore")
+        try:
+            rel = str(path.relative_to(_REPO_ROOT))
+        except ValueError:
+            rel = str(path)  # src_dir이 repo 밖(테스트의 tmp_path 등)일 때의 폴백
+        for regex in (_ENV_BRACKET_RE, _ENV_DOT_RE):
+            for m in regex.finditer(text):
+                key = m.group(1)
+                if key in _WEB_ENV_IGNORE:
+                    continue
+                tail = text[m.end():m.end() + 200]
+                dmatch = _DEFAULT_LITERAL_RE.match(tail)
+                default = dmatch.group(1) if dmatch else None
+                findings.setdefault(key, []).append((rel, default))
+    return findings
+
+
+def _classify_code_read_risk(defaults: list[str | None]) -> str:
+    """같은 키를 여러 곳에서 읽으면 «가장 위험한» 등급으로 접는다.
+    반환: "highest"(㉡ dev/localhost/test 기본값) · "high"(㉠ 기본값 없음) · "low"(㉢ 무관 상수)."""
+    if any(d is not None and re.search(r"dev|localhost|test", d, re.IGNORECASE) for d in defaults):
+        return "highest"
+    if any(d is None for d in defaults):
+        return "high"
+    return "low"
+
+
+def _unsupplied_code_read_findings(
+    web_reads: dict[str, list[tuple[str, str | None]]],
+    covered_keys: set[str],
+    code_read_exempt: set[str],
+) -> tuple[list[str], list[str], list[str]]:
+    """covered_keys(그 서비스의 IaC∪라이브 키 «이름» 집합)에 없는 키만, 등급별로 3개 리스트로
+    나눠 돌려준다(highest, high, low). exempt는 아예 리스트에서 빠진다(알려진 정상)."""
+    highest, high, low = [], [], []
+    for key in sorted(web_reads):
+        if key in covered_keys or key in code_read_exempt:
+            continue
+        occurrences = web_reads[key]
+        tier = _classify_code_read_risk([d for _, d in occurrences])
+        sample = ", ".join(sorted({f for f, _ in occurrences})[:2])
+        line = f"{key} ({sample})"
+        (highest if tier == "highest" else high if tier == "high" else low).append(line)
+    return highest, high, low
+
+
+def _load_code_read_exempt() -> set[str]:
+    import yaml
+    data = yaml.safe_load(_ALLOWLIST_PATH.read_text())
+    return {entry["key"] for entry in data.get("code_read_exempt", [])}
+
+
 def main() -> int:
     excluded_axes, allowlist_services = _load_allowlist()
     iac_keys = _iac_covered_keys()
     settings_field_keys = _settings_field_env_keys()
     settings_exempt = _load_settings_exempt()
+    web_reads = _web_env_reads()  # ⑤ — repo 정적 스캔, 서비스 루프 밖(반복 파일 IO 방지)
+    code_read_exempt = _load_code_read_exempt()
 
     live_services = _list_live_services()
     key_set_failures: list[str] = []
     value_check_failures: list[str] = []
     secret_shape_failures: list[str] = []
     settings_coverage_report: list[str] = []  # ④ report-only — FAIL 집합에 안 넣음(위 docstring).
+    code_read_highest_failures: list[str] = []  # ⑤㉡ — FAIL 집합에 들어감(오늘 실제 사고 등급).
+    code_read_report: list[str] = []  # ⑤㉠㉢ — report-only(오탐 triage 전까지, ④와 동일 원칙).
     unmapped: list[str] = []
 
     checked = 0
     value_checked = 0
     for service in live_services:
         envs = _live_env_entries(service)
+
+        # ⑤ 코드가 읽는데 아무도 안 주는 값 — apps/web을 구동하는 서비스만.
+        # ⛔전역 iac_keys가 아니라 이 서비스 전용 IaC 커버리지를 쓴다(위 함수 docstring 참고 —
+        # 전역이면 FIREBASE_BFF_INTERNAL_SECRET류가 "backend 스크립트에 있으니 커버됨"으로
+        # 잘못 판정된다).
+        if service in _WEB_CODE_SERVICES:
+            live_keys_for_web = {e["name"] for e in envs}
+            covered = _iac_covered_keys_for_service(service) | live_keys_for_web
+            highest, high, low = _unsupplied_code_read_findings(web_reads, covered, code_read_exempt)
+            if highest:
+                code_read_highest_failures.append(f"{service}: {', '.join(highest)}")
+            for tier_label, items in (("㉠기본값없음", high), ("㉢환경무관", low)):
+                if items:
+                    code_read_report.append(f"{service}[{tier_label}]: {', '.join(items)}")
 
         # ③ 평문 시크릿 형태 검출 — excluded_services 여부와 무관하게 전 서비스에 적용.
         secret_hits = _plain_secret_shaped_keys(envs)
@@ -314,8 +446,18 @@ def main() -> int:
             + ", ".join(unmapped)
         )
 
-    if key_set_failures or value_check_failures or secret_shape_failures or settings_coverage_report:
-        print("❌ env 드리프트 발견:")
+    # ⚠️story #2296 후속 자체 발견 — ④(settings_coverage_report)가 "report-only"라는 docstring과
+    # 달리, 원래 코드는 이 값이 하나라도 있으면 아래 블록에 들어가 무조건 `return 1`로
+    # 떨어지는 latent 버그였다(triage 직후라 지금까지 값이 늘 0이라 안 드러났을 뿐).
+    # ⑤㉠㉢도 같은 성질(report-only)로 설계하는 참이라 그대로 물려받으면 안 됨 — FAIL 판정과
+    # report-only 판정을 여기서 명시적으로 분리한다.
+    has_fail = bool(
+        key_set_failures or value_check_failures or secret_shape_failures or code_read_highest_failures
+    )
+    has_report_only = bool(settings_coverage_report or code_read_report)
+
+    if has_fail or has_report_only:
+        print("❌ env 드리프트 발견:" if has_fail else "⚠️ env 드리프트 report-only 발견(FAIL 아님):")
         if key_set_failures:
             print("  ①키집합 대조:")
             for line in key_set_failures:
@@ -327,6 +469,17 @@ def main() -> int:
         if secret_shape_failures:
             print("  ③평문 시크릿 형태 검출(⛔ 값은 출력하지 않음 — 키 이름만):")
             for line in secret_shape_failures:
+                print(f"    - {line}")
+        if code_read_highest_failures:
+            print(
+                "  ⑤㉡코드가 읽는데 아무도 안 주는 값(기본값이 dev/localhost/test — "
+                "prod에서 다른 환경을 가리키는 그 사고 형태, 2026-07-28 실사고):"
+            )
+            for line in code_read_highest_failures:
+                print(f"    - {line}")
+        if code_read_report:
+            print("  ⑤㉠㉢코드가 읽는데 아무도 안 주는 값(report-only — 등급별, FAIL 아님):")
+            for line in code_read_report:
                 print(f"    - {line}")
         if settings_coverage_report:
             print(
@@ -353,16 +506,24 @@ def main() -> int:
             "③은 즉시 Secret Manager secretKeyRef로 전환 바라는(평문 유지 시 재확定 시마다 재발). "
             "④는 (a) 플랫폼/런타임 주입 → settings_exempt 등재(어느 파일이 읽는지 명시), "
             "(b) 진짜 무효 배선 → 제거 또는 Settings 필드 추가, (c) 이름만 다른 alias → "
-            "Settings 필드명 자체를 그 이름에 맞게 정정."
+            "Settings 필드명 자체를 그 이름에 맞게 정정. "
+            "⑤㉡은 즉시 그 서비스에 실제 값을 채우는 것(오늘 사고와 동일 형태 — 방치하면 그 "
+            "환경을 가리키는 채로 조용히 돈다). ⑤㉠㉢은 report-only — 의도적이면 "
+            "code_read_exempt(infra/manual-env-allowlist.yml)에 사유와 함께 등재."
         )
-        return 1
+        if not has_fail:
+            print("\n(⛔위는 report-only 항목뿐 — FAIL 아님. exit code는 0.)")
+        else:
+            return 1
 
     print(
-        f"✅ 드리프트 없음 — ①{checked}개 서비스 키집합"
+        f"✅ 드리프트 없음(FAIL 기준) — ①{checked}개 서비스 키집합"
         f"(제외 {sum(1 for a in excluded_axes.values() if 'key_set' in a)}개), "
         f"②{value_checked}개 서비스 값 대조, "
         f"③{len(live_services)}개 서비스 전체 평문시크릿 스캔 완료(제외 없음), "
-        f"④{len(_SETTINGS_CONSUMING_SERVICES)}개 서비스 Settings 커버리지 대조 완료."
+        f"④{len(_SETTINGS_CONSUMING_SERVICES)}개 서비스 Settings 커버리지 대조 완료, "
+        f"⑤{len(_WEB_CODE_SERVICES & set(live_services))}개 서비스 코드읽기↔공급 대조 완료"
+        f"(㉡최고위험 대조 포함)."
     )
     return 0
 

--- a/infra/check_env_drift.py
+++ b/infra/check_env_drift.py
@@ -334,9 +334,11 @@ def _unsupplied_code_read_findings(
     web_reads: dict[str, list[tuple[str, str | None]]],
     covered_keys: set[str],
     code_read_exempt: set[str],
-) -> tuple[list[str], list[str], list[str]]:
-    """covered_keys(그 서비스의 IaC∪라이브 키 «이름» 집합)에 없는 키만, 등급별로 3개 리스트로
-    나눠 돌려준다(highest, high, low). exempt는 아예 리스트에서 빠진다(알려진 정상)."""
+) -> tuple[list[tuple[str, str]], list[tuple[str, str]], list[tuple[str, str]]]:
+    """covered_keys(그 서비스의 IaC∪라이브 키 «이름» 집합)에 없는 키만, 등급별로 3개
+    (key, line) 리스트로 나눠 돌려준다(highest, high, low). exempt는 아예 리스트에서
+    빠진다(알려진 정상). key를 별도로 주는 이유 — ㉠(high)는 baseline 래칫과 대조해야
+    한다(story #2296 후속, 파울로군 지시 2026-07-28)."""
     highest, high, low = [], [], []
     for key in sorted(web_reads):
         if key in covered_keys or key in code_read_exempt:
@@ -345,7 +347,7 @@ def _unsupplied_code_read_findings(
         tier = _classify_code_read_risk([d for _, d in occurrences])
         sample = ", ".join(sorted({f for f, _ in occurrences})[:2])
         line = f"{key} ({sample})"
-        (highest if tier == "highest" else high if tier == "high" else low).append(line)
+        (highest if tier == "highest" else high if tier == "high" else low).append((key, line))
     return highest, high, low
 
 
@@ -355,6 +357,73 @@ def _load_code_read_exempt() -> set[str]:
     return {entry["key"] for entry in data.get("code_read_exempt", [])}
 
 
+# ⑤ 후속(2026-07-28, 파울로군 지시) — ㉠(high)를 전부 report-only로 영원히 두면 "없는
+# 가드"가 된다. 지금 알려진 것을 baseline으로 얼리고, baseline에 없는 «새» high만 FAIL —
+# 그러면 지금은 안 빨개지고, 새 구멍은 막히고, baseline을 줄여야 한다는 압력이 남는다.
+# ⛔baseline이 "묻어두는 곳"이 되지 않도록 self-expiring(#2280/#2174와 동일 원칙)+매 실행
+# 카운트 출력을 강제한다.
+_MAX_CODE_READ_BASELINE_HORIZON_DAYS = 30
+
+
+def _load_code_read_high_baseline() -> dict[str, dict]:
+    import yaml
+    data = yaml.safe_load(_ALLOWLIST_PATH.read_text())
+    return {entry["key"]: entry for entry in data.get("code_read_high_baseline", [])}
+
+
+def _baseline_entry_expired(entry: dict, today) -> str | None:
+    """infra/mcp_path_contract_guard.py::_expired와 동일 계약(만료·형식 위반이면 사유,
+    아니면 None) — 이 가드 계열 전체가 공유하는 규율이라 그대로 재현한다."""
+    from datetime import date
+
+    until_raw = entry.get("until")
+    if not until_raw:
+        return "`until`(만료일)이 없다 — 영원히 사는 baseline은 허용하지 않는다"
+    try:
+        until = date.fromisoformat(str(until_raw))
+    except ValueError:
+        return f"`until` 형식이 YYYY-MM-DD가 아니다: {until_raw!r}"
+    if until < today:
+        return f"baseline이 만료됐다(until={until}) — 재triage 필요"
+    horizon = (until - today).days
+    if horizon > _MAX_CODE_READ_BASELINE_HORIZON_DAYS:
+        return f"`until`이 너무 멀다({until} · {horizon}일 뒤) — 최대 {_MAX_CODE_READ_BASELINE_HORIZON_DAYS}일"
+    if not entry.get("reason"):
+        return "`reason`(사유)이 없다"
+    if not entry.get("declared_by"):
+        return "`declared_by`(선언자)가 없다"
+    return None
+
+
+def _split_high_by_baseline(
+    high_items: list[tuple[str, str]], baseline: dict[str, dict], today
+) -> tuple[list[str], list[str]]:
+    """high(㉠) findings를 baseline과 대조 — (baseline_ok_lines, new_or_expired_lines).
+    후자는 FAIL로 승격된다(baseline에 없거나, 있어도 만료됐으면)."""
+    ok, escalate = [], []
+    for key, line in high_items:
+        entry = baseline.get(key)
+        if entry is None:
+            escalate.append(f"{line} — 🔴baseline에 없는 신규")
+            continue
+        problem = _baseline_entry_expired(entry, today)
+        if problem:
+            escalate.append(f"{line} — 🔴baseline 등재는 있으나 {problem}")
+        else:
+            ok.append(f"{line} — baseline(until={entry['until']})")
+    return ok, escalate
+
+
+def _today():
+    import os as _os
+    from datetime import date, datetime, timezone
+
+    env = _os.environ.get("ENV_DRIFT_GUARD_TODAY")
+    if env:
+        return date.fromisoformat(env)
+    return datetime.now(timezone.utc).date()
+
+
 def main() -> int:
     excluded_axes, allowlist_services = _load_allowlist()
     iac_keys = _iac_covered_keys()
@@ -362,6 +431,8 @@ def main() -> int:
     settings_exempt = _load_settings_exempt()
     web_reads = _web_env_reads()  # ⑤ — repo 정적 스캔, 서비스 루프 밖(반복 파일 IO 방지)
     code_read_exempt = _load_code_read_exempt()
+    code_read_baseline = _load_code_read_high_baseline()
+    today = _today()
 
     live_services = _list_live_services()
     key_set_failures: list[str] = []
@@ -369,7 +440,9 @@ def main() -> int:
     secret_shape_failures: list[str] = []
     settings_coverage_report: list[str] = []  # ④ report-only — FAIL 집합에 안 넣음(위 docstring).
     code_read_highest_failures: list[str] = []  # ⑤㉡ — FAIL 집합에 들어감(오늘 실제 사고 등급).
-    code_read_report: list[str] = []  # ⑤㉠㉢ — report-only(오탐 triage 전까지, ④와 동일 원칙).
+    code_read_baseline_escalations: list[str] = []  # ⑤㉠ baseline 밖(신규/만료) — FAIL 집합.
+    code_read_baseline_ok_count = 0  # ⑤㉠ baseline 안(알려진 채무) — report-only, 매번 카운트만.
+    code_read_report: list[str] = []  # ⑤㉢ — report-only(환경무관, 승격 대상 아님).
     unmapped: list[str] = []
 
     checked = 0
@@ -386,10 +459,19 @@ def main() -> int:
             covered = _iac_covered_keys_for_service(service) | live_keys_for_web
             highest, high, low = _unsupplied_code_read_findings(web_reads, covered, code_read_exempt)
             if highest:
-                code_read_highest_failures.append(f"{service}: {', '.join(highest)}")
-            for tier_label, items in (("㉠기본값없음", high), ("㉢환경무관", low)):
-                if items:
-                    code_read_report.append(f"{service}[{tier_label}]: {', '.join(items)}")
+                code_read_highest_failures.append(
+                    f"{service}: {', '.join(line for _, line in highest)}"
+                )
+            # ⭐파울로군 지시(2026-07-28) — ㉠을 영원히 report-only로 두면 없는 가드가 된다.
+            # baseline(known, self-expiring)에 없는 신규 ㉠만 FAIL로 승격한다.
+            baseline_ok, escalate = _split_high_by_baseline(high, code_read_baseline, today)
+            code_read_baseline_ok_count += len(baseline_ok)
+            if escalate:
+                code_read_baseline_escalations.append(f"{service}: {', '.join(escalate)}")
+            if low:
+                code_read_report.append(
+                    f"{service}[㉢환경무관]: {', '.join(line for _, line in low)}"
+                )
 
         # ③ 평문 시크릿 형태 검출 — excluded_services 여부와 무관하게 전 서비스에 적용.
         secret_hits = _plain_secret_shaped_keys(envs)
@@ -452,9 +534,17 @@ def main() -> int:
     # ⑤㉠㉢도 같은 성질(report-only)로 설계하는 참이라 그대로 물려받으면 안 됨 — FAIL 판정과
     # report-only 판정을 여기서 명시적으로 분리한다.
     has_fail = bool(
-        key_set_failures or value_check_failures or secret_shape_failures or code_read_highest_failures
+        key_set_failures or value_check_failures or secret_shape_failures
+        or code_read_highest_failures or code_read_baseline_escalations
     )
     has_report_only = bool(settings_coverage_report or code_read_report)
+
+    # ⭐파울로군 지시 ③ — baseline 수를 «매번» 찍는다(FAIL이든 성공이든 무관). baseline을
+    # 묻어두는 곳으로 쓰지 않으려면 그 크기가 줄어드는지 매 실행 눈에 보여야 한다.
+    print(
+        f"⑤㉠ baseline(known, self-expiring): {code_read_baseline_ok_count}건 "
+        f"— infra/manual-env-allowlist.yml의 code_read_high_baseline 참고"
+    )
 
     if has_fail or has_report_only:
         print("❌ env 드리프트 발견:" if has_fail else "⚠️ env 드리프트 report-only 발견(FAIL 아님):")
@@ -477,8 +567,14 @@ def main() -> int:
             )
             for line in code_read_highest_failures:
                 print(f"    - {line}")
+        if code_read_baseline_escalations:
+            print(
+                "  ⑤㉠코드가 읽는데 아무도 안 주는 값 — baseline 밖(신규 또는 만료, FAIL):"
+            )
+            for line in code_read_baseline_escalations:
+                print(f"    - {line}")
         if code_read_report:
-            print("  ⑤㉠㉢코드가 읽는데 아무도 안 주는 값(report-only — 등급별, FAIL 아님):")
+            print("  ⑤㉢코드가 읽는데 아무도 안 주는 값(환경무관 상수 — report-only, FAIL 아님):")
             for line in code_read_report:
                 print(f"    - {line}")
         if settings_coverage_report:
@@ -508,8 +604,10 @@ def main() -> int:
             "(b) 진짜 무효 배선 → 제거 또는 Settings 필드 추가, (c) 이름만 다른 alias → "
             "Settings 필드명 자체를 그 이름에 맞게 정정. "
             "⑤㉡은 즉시 그 서비스에 실제 값을 채우는 것(오늘 사고와 동일 형태 — 방치하면 그 "
-            "환경을 가리키는 채로 조용히 돈다). ⑤㉠㉢은 report-only — 의도적이면 "
-            "code_read_exempt(infra/manual-env-allowlist.yml)에 사유와 함께 등재."
+            "환경을 가리키는 채로 조용히 돈다). ⑤㉠ baseline 밖(신규/만료)은 (a) 값을 채우거나 "
+            "(b) 정상이면 code_read_high_baseline에 reason/declared_by/until(최대30일)과 "
+            "함께 등재하거나 (c) 영구 정상이면 code_read_exempt로 승격 — 셋 다 "
+            "infra/manual-env-allowlist.yml. ⑤㉢은 report-only(승격 대상 아님)."
         )
         if not has_fail:
             print("\n(⛔위는 report-only 항목뿐 — FAIL 아님. exit code는 0.)")

--- a/infra/manual-env-allowlist.yml
+++ b/infra/manual-env-allowlist.yml
@@ -454,3 +454,72 @@ code_read_exempt:
     reason: INTERNAL_DOGFOOD_ACCESS_ENABLED가 꺼져 있으면(기본) 실질 영향 없음 — 같은 기능군.
   - key: INTERNAL_DOGFOOD_DEFAULT_PROJECT_NAME
     reason: INTERNAL_DOGFOOD_ACCESS_ENABLED가 꺼져 있으면(기본) 실질 영향 없음 — 같은 기능군.
+
+# ⑤㉠(story #2296 후속, 파울로군 지시 2026-07-28) — «알려진 채무» 래칫 baseline.
+# ⛔code_read_exempt(위)와 다르다 — exempt는 "코드로 확認해 영구히 정상"이고, 이건 "아직
+# triage 안 됐지만 지금 당장 FAIL로 막으면 가드가 꺼지니 일단 알고 있다"다. baseline에
+# 없는 새 ㉠(high)가 생기면 즉시 FAIL — 그래서 baseline 목록이 늘어나는 건 이 가드가
+# 막으려는 바로 그 방향이다(새 구멍 추가는 이 파일을 고치는 게 아니라 실제로 값을
+# 채우는 걸로 막혀야 한다).
+# reason/declared_by/until 필수(최대 30일) — mcp-path-contract-allowlist.yml(#2280)과
+# 동일 계약. 2026-07-28 실측 기준 14건 — check_env_drift.py 실행 로그의
+# "⑤㉠ baseline" 카운트가 이 숫자와 일치해야 정상(달라지면 파일이 낡은 것).
+code_read_high_baseline:
+  - key: AGENT_INBOX_HMAC_SECRET
+    reason: apps/web/src/services/inbox-item.service.ts — 기본값 없음, 미triage.
+    declared_by: PO
+    until: "2026-08-27"
+  - key: APP_BASE_URL
+    reason: apps/web/src/lib/auth/cookies.ts — 기본값 없음, 미triage(Amplify 레거시 override 후보).
+    declared_by: PO
+    until: "2026-08-27"
+  - key: FIREBASE_AUTH_ISSUE_SESSION
+    reason: apps/web/src/app/api/auth/firebase/session/route.ts — 기본값 없음, 미triage.
+    declared_by: PO
+    until: "2026-08-27"
+  - key: FIREBASE_AUTH_MOBILE_ISSUE
+    reason: apps/web/src/app/auth/native/route.ts — 기본값 없음, 미triage.
+    declared_by: PO
+    until: "2026-08-27"
+  - key: FIREBASE_OAUTH_HANDOFF_ENABLED
+    reason: apps/web/src/app/auth/oauth-handoff/route.ts — 기본값 없음, 미triage(기능 플래그 추정).
+    declared_by: PO
+    until: "2026-08-27"
+  - key: LICENSE_CONSENT
+    reason: apps/web/src/lib/ee-enabled.ts — 기본값 없음, 미triage.
+    declared_by: PO
+    until: "2026-08-27"
+  - key: MCP_ALLOWED_TOKEN_REFS
+    reason: apps/web/src/lib/mcp-secrets.ts — 기본값 없음, 미triage.
+    declared_by: PO
+    until: "2026-08-27"
+  - key: NEXT_PUBLIC_APP_URL
+    reason: apps/web/src/lib/auth/cookies.ts 등 — 기본값 없음, 미triage.
+    declared_by: PO
+    until: "2026-08-27"
+  - key: NEXT_PUBLIC_EE_ENABLED
+    reason: apps/web/src/lib/ee.ts — 기본값 없음, 미triage(기능 플래그 추정).
+    declared_by: PO
+    until: "2026-08-27"
+  - key: NEXT_PUBLIC_FIREBASE_API_KEY
+    reason: >-
+      apps/web/src/lib/auth/firebase-client.ts — 기본값 없음, 미triage. NEXT_PUBLIC_*
+      빌드타임 인라이닝 모호성 있음(AC6 한계 참고).
+    declared_by: PO
+    until: "2026-08-27"
+  - key: NEXT_PUBLIC_FIREBASE_APP_ID
+    reason: apps/web/src/lib/auth/firebase-client.ts — 기본값 없음, 미triage(위와 동일 축).
+    declared_by: PO
+    until: "2026-08-27"
+  - key: NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
+    reason: apps/web/src/lib/auth/firebase-client.ts — 기본값 없음, 미triage(위와 동일 축).
+    declared_by: PO
+    until: "2026-08-27"
+  - key: NEXT_PUBLIC_FIREBASE_AUTH_ENABLED
+    reason: apps/web/src/lib/auth/firebase-client.ts — 기본값 없음, 미triage(기능 플래그 추정).
+    declared_by: PO
+    until: "2026-08-27"
+  - key: NEXT_PUBLIC_FIREBASE_PROJECT_ID
+    reason: apps/web/src/lib/auth/firebase-client.ts·lib/db/server.ts — 기본값 없음, 미triage(위와 동일 축).
+    declared_by: PO
+    until: "2026-08-27"

--- a/infra/manual-env-allowlist.yml
+++ b/infra/manual-env-allowlist.yml
@@ -406,3 +406,51 @@ settings_exempt:
     reason: >-
       backend/scripts/deploy_realtime_gce.sh:349 "의도적 제외" — 재시작 트리거용 타임스탬프
       마커, 코드가 읽는 값이 아니라 애초에 no-read by design.
+
+# ⑤(story #2296, 2026-07-28) — apps/web이 읽는데 IaC∪라이브 어디에도 없는 키 중, 코드로
+# 직접 확認해 "정상(조건부로만 필요·기본값으로 도는 게 맞음)"이라고 판단한 것들.
+# ⛔여기 등재는 "영원히 안 본다"가 아니라 "지금 근거를 남긴다"다 — 그 조건부 스위치가
+# 실제로 켜지는 환경이 생기면 이 사유도 같이 재검토해야 한다.
+code_read_exempt:
+  - key: KMS_PROVIDER
+    reason: >-
+      apps/web/src/lib/kms/provider.ts — 'local'|'gcp'|'vault' 스위치, 기본값 'local'로
+      떨어지면 아래 GCP_KMS_*/VAULT_* 자체가 안 읽힘(코드 확認).
+  - key: LOCAL_KMS_MASTER_KEY
+    reason: KMS_PROVIDER=local(기본값)일 때만 실제로 쓰임 — 위 항목과 같은 스위치.
+  - key: GCP_KMS_BEARER_TOKEN
+    reason: KMS_PROVIDER=gcp일 때만 쓰임(기본은 local) — provider.ts 코드 확認.
+  - key: GCP_KMS_KEY_NAME
+    reason: KMS_PROVIDER=gcp일 때만 쓰임(기본은 local) — provider.ts 코드 확認.
+  - key: VAULT_ADDR
+    reason: KMS_PROVIDER=vault일 때만 쓰임(기본은 local) — provider.ts 코드 확認.
+  - key: VAULT_TOKEN
+    reason: KMS_PROVIDER=vault일 때만 쓰임(기본은 local) — provider.ts 코드 확認.
+  - key: STORAGE_PROVIDER
+    reason: >-
+      apps/web/src/lib/storage/config.ts:12-13 — 기본값 'local'로 떨어짐(코드 확認, ㉢로도
+      이미 낮음 등급). 아래 S3_*/GCS_*는 이 값이 s3/gcs일 때만 실제로 쓰임.
+  - key: S3_ACCESS_KEY_ID
+    reason: STORAGE_PROVIDER=s3일 때만 쓰임(기본은 local) — config.ts 코드 확認.
+  - key: S3_ENDPOINT
+    reason: STORAGE_PROVIDER=s3일 때만 쓰임(기본은 local) — config.ts 코드 확認.
+  - key: S3_SECRET_ACCESS_KEY
+    reason: STORAGE_PROVIDER=s3일 때만 쓰임(기본은 local) — config.ts 코드 확認.
+  - key: GCS_CREDENTIALS_JSON
+    reason: STORAGE_PROVIDER=gcs일 때만 쓰임(기본은 local) — providers/gcs.ts 코드 확認.
+  - key: GCS_PROJECT_ID
+    reason: STORAGE_PROVIDER=gcs일 때만 쓰임(기본은 local) — providers/gcs.ts 코드 확認.
+  - key: INTERNAL_DOGFOOD_ACCESS_ENABLED
+    reason: >-
+      apps/web/src/lib/internal-dogfood.ts:44 `=== 'true'` — 미설정 시 false로 떨어지는
+      명시적 기능 토글(내부 도그푸딩 전용, 이름 자체가 그 스코프를 명시).
+  - key: INTERNAL_DOGFOOD_ACCESS_MAX_AGE_SECONDS
+    reason: INTERNAL_DOGFOOD_ACCESS_ENABLED가 꺼져 있으면(기본) 실질 영향 없음 — 같은 기능군.
+  - key: INTERNAL_DOGFOOD_ACCESS_SECRET
+    reason: INTERNAL_DOGFOOD_ACCESS_ENABLED가 꺼져 있으면(기본) 실질 영향 없음 — 같은 기능군.
+  - key: INTERNAL_DOGFOOD_DEFAULT_ORG_ID
+    reason: INTERNAL_DOGFOOD_ACCESS_ENABLED가 꺼져 있으면(기본) 실질 영향 없음 — 같은 기능군.
+  - key: INTERNAL_DOGFOOD_DEFAULT_PROJECT_ID
+    reason: INTERNAL_DOGFOOD_ACCESS_ENABLED가 꺼져 있으면(기본) 실질 영향 없음 — 같은 기능군.
+  - key: INTERNAL_DOGFOOD_DEFAULT_PROJECT_NAME
+    reason: INTERNAL_DOGFOOD_ACCESS_ENABLED가 꺼져 있으면(기본) 실질 영향 없음 — 같은 기능군.


### PR DESCRIPTION
## Summary
story #2296 — 2026-07-28 prod 앱 로그인 장애(`MOBILE_APP_LINK_ORIGIN`·`FIREBASE_BFF_INTERNAL_SECRET` 둘 다 IaC에도 라이브에도 없었음, dev는 하드코딩 기본값이 우연히 dev 주소와 같아 "그냥 됐다")를 기존 `check_env_drift.py`가 못 잡은 이유: 그 가드는 "라이브 ↔ IaC" 두 자리만 본다 — 둘 다 그 값을 모르면 드리프트 없음으로 읽힌다. 세 번째 축 "코드가 읽는 이름"을 붙였다.

## 무엇을 했는가
- `apps/web/src` 정적 스캔(`process.env['X']`/`process.env.X`) → 기본값 리터럴로 위험 등급 3단(㉡dev/localhost/test 기본값=최고·㉠기본값없음=높음·㉢환경무관=낮음). **㉡만 FAIL** — ㉠㉢은 report-only(축④와 동일 원칙).
- `_iac_covered_keys_for_service()` 신설 — 기존 전역 합집합을 그대로 썼으면 `FIREBASE_BFF_INTERNAL_SECRET`이 "deploy_backend.sh엔 있으니 커버됨"으로 **오판정**될 뻔했다(frontend 스크립트엔 없었다 — 정확히 사고의 그 비대칭).
- **부수 발견·수정**: 축④(`settings_coverage_report`, report-only로 설계됐다고 docstring에 적혀 있었음)가 실제로는 값이 하나라도 있으면 무조건 `return 1`로 떨어지는 latent 버그였다(triage 직후라 지금까지 값이 0이라 안 드러남). `has_fail`/`has_report_only`를 명시 분리해 고쳤다.
- AC7: `MOBILE_APP_LINK_ORIGIN`·`FIREBASE_BFF_INTERNAL_SECRET`을 `deploy_frontend.sh`의 `ENV_VARS_SPEC`/`SECRETS_SPEC`에 실제로 반영(dev/prod 분리, prod는 저장소 전역 관례 `app.sprintable.ai` 그대로).

## AC별 근거
- **AC1(오늘의 두 건이 실제로 잡힌다)**: fixture로 "사고 당시" IaC 상태(그 두 키만 없음)를 재현 — `MOBILE_APP_LINK_ORIGIN`은 highest, `FIREBASE_BFF_INTERNAL_SECRET`은 high로 정확히 갈려 잡힘. `main()` 전체를 돌려 frontend-prod 시나리오에서 실제로 exit 1이 뜨는 것까지 고정.
- **AC2(양성대조)**: 실제 IaC(이 PR로 고쳐진 뒤)로 두 키가 전혀 안 걸리는 것 확認 — 인위적으로 다 가려서 초록을 만든 게 아니라 실제 IaC 상태로 통과.
- **AC3(위험 등급이 실제로 갈린다)**: `{highest, high, low}` 세 값이 실제로 다르다는 것을 유닛+실 저장소 스캔 양쪽으로 고정.
- **AC4(오탐 수 카운트)**: 실 저장소 스캔 — `highest=1`(`MOBILE_APP_LINK_ORIGIN`) · `high=15` · `low=9`. `exempt=18`건은 KMS/Storage/Dogfood 3개 기능-스위치 군으로 코드 직접 확認(`KMS_PROVIDER`/`STORAGE_PROVIDER`/`INTERNAL_DOGFOOD_ACCESS_ENABLED` 스위치가 각각 조건부 게이팅하는 것을 소스로 확認) 후 등재 — 사유에 파일:라인 남김.
- **AC5(값을 안 읽는다)**: `_web_env_reads()`는 소스 파일 Path만 받는 구조 — gcloud/`_live_env_entries` 호출 자체가 불가능하다는 것을 소스 검사로 고정. live entry가 `value` 필드 없이 `name`만 있어도 정상 동작.
- **AC6(못 잡는 것 선언)**: (1) 동적 키 조립(`process.env[varName]`)은 정적 스캔이 원천적으로 못 봄(테스트로 실증) (2) `if (!x) throw`류 런타임 가드는 "기본값 없음"으로 뭉뚱그려짐 (3) `NEXT_PUBLIC_*`은 빌드타임 인라이닝 가능성이 있어 라이브 env 유무가 무관해질 수 있음(과탐 방향) (4) IaC 커버리지는 조건부 분기 안에 있어도 스크립트 전체 텍스트 매치라 "있다"로 잡힘(과소탐지 방향).
- **AC7(배포 SSOT 반영)**: 위 참고. `DRY_RUN=1`로 dev/prod 둘 다 재검증 완료.

## Test plan
- [x] `uv run pytest -q tests/test_check_env_drift_code_read_axis.py` — 16 passed
- [x] `uv run pytest -q tests/test_check_env_drift_settings_coverage.py`(회귀) — 6 passed, 축④ 관련 무영향 확認
- [x] `bash -n backend/scripts/deploy_frontend.sh` — 문법 OK
- [x] `DRY_RUN=1 ENV=dev|prod bash backend/scripts/deploy_frontend.sh` 둘 다 — `MOBILE_APP_LINK_ORIGIN`/`FIREBASE_BFF_INTERNAL_SECRET`이 ENV_VARS_SPEC/SECRETS_SPEC에 올바른 값으로 들어가는 것 확認
- [x] `python3 infra/check_env_drift.py` 문법·yaml 파싱 검증(gcloud 라이브 접근은 이 세션에서 불가 — 인증 만료, CI의 WIF 인증 환경에서는 정상 동작 전제. 라이브 확認이 필요한 부분은 fixture 기반 테스트로 대체함, AC1 본문에 명시된 대로)

⚠️참고: 이 세션은 gcloud 라이브 접근이 안 됨(재인증 필요, non-interactive 환경) — ①②③④축의 실제 gcloud 호출 부분은 이 PR에서 라이브로 재검증하지 못했다(기존 로직 무변경이라 회귀 위험은 낮다고 판단하나, CI(WIF 인증)에서의 실행 결과를 파울로신이 한 번 확認해 주시면 좋겠음).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>