### PR TITLE
fix(critical): MCP client {data:T} 자동 언래핑이 references/command_gate sibling을 통째로 버리던 버그

### DIFF
--- a/backend/sprintable_mcp/api_client.py
+++ b/backend/sprintable_mcp/api_client.py
@@ -278,6 +278,7 @@ class SprintableClient:
         *,
         json: dict | None = None,
         params: dict | None = None,
+        unwrap: bool = True,
     ) -> Any:
         url = f"{self._base_url}{path}"
         # E-MCP-HTTP S1: effective 키 = per-request override(http 멀티테넌트) ∨ env 단일키(stdio·무회귀).
@@ -327,7 +328,15 @@ class SprintableClient:
             raise SprintableApiError(resp.status_code, message, body)
 
         data = resp.json()
-        # {data: T} 래핑이면 언래핑, 그 외(배열 등)는 직접 반환
+        # ⛔story #2294 ③ 후속(오르테가 라이브 실측, 2026-07-29): {data: T, ...sibling} 래핑을
+        # 무조건 data만 남기고 sibling(예: references·command_gate)을 통째로 버렸다 — 그 결과
+        # #2294가 만든 references{stored,dropped} 사이드밴드가 MCP 호출부에는 «한 번도» 안
+        # 닿고 있었다(CI green·배포 SHA 일치인데도 사용자에게 안 보였던 정확한 원인). 그리고
+        # 같은 이유로 이 함수를 공유하는 **command_gate도 처음부터 MCP 경로에서 안 보였다**
+        # (이번에 같이 드러난 기존 버그 — 별도로 새로 만든 게 아니다). unwrap=False를 넘기면
+        # 언래핑하지 않고 전체를 그대로 반환한다(소수 호출부 — sibling 키가 필요한 곳만 씀).
+        if not unwrap:
+            return data
         if isinstance(data, dict) and "data" in data:
             return data["data"]
         return data
@@ -337,6 +346,11 @@ class SprintableClient:
 
     async def post(self, path: str, *, json: dict | None = None) -> Any:
         return await self.request("POST", path, json=json or {})
+
+    async def post_full(self, path: str, *, json: dict | None = None) -> Any:
+        """post()와 동일하되 `{data: T, ...sibling}` 래핑을 풀지 않고 그대로 반환한다 —
+        sibling 키(references·command_gate 등)가 필요한 소수 호출부(send_chat_message)용."""
+        return await self.request("POST", path, json=json or {}, unwrap=False)
 
     async def put(self, path: str, *, json: dict | None = None) -> Any:
         return await self.request("PUT", path, json=json or {})

--- a/backend/sprintable_mcp/tools/chat.py
+++ b/backend/sprintable_mcp/tools/chat.py
@@ -199,7 +199,22 @@ async def send_chat_message(args: SendChatInput) -> list[TextContent]:
         uploaded_urls = [a["url"] for a in attachments if isinstance(a, dict) and a.get("url")]
         if attachments:
             payload["attachments"] = attachments
-        return ok(await client.post(f"/api/v2/conversations/{args.thread_id}/messages", json=payload))
+        # ⛔story #2294 ③ 후속(오르테가 라이브 실측, 2026-07-29): 백엔드 응답은
+        # `{"data": {...메시지}, "references": {...}?, "command_gate": {...}?}` 모양인데,
+        # 일반 unwrap 경로(SprintableApiClient.request의 기본 동작)가 sibling 키를 전부
+        # 버리고 data만 반환했다 — references{stored,dropped} 사이드밴드가 CI green·배포
+        # SHA 일치에도 MCP 호출부에는 한 번도 안 닿던 정확한 원인(같은 이유로 command_gate도
+        # 처음부터 MCP 경로에서 안 보였다 — 이번에 같이 드러난 기존 버그). unwrap=False로
+        # 원본을 받아 여기서 명시적으로 재구성한다 — 기존 MCP 호출부가 기대하는 평탄한
+        # 메시지 필드 모양은 그대로 유지하면서 sibling 키만 얹는다(회귀 0: sibling이 없는
+        # 평문 메시지는 이전과 byte-identical).
+        raw = await client.post_full(f"/api/v2/conversations/{args.thread_id}/messages", json=payload)
+        result: dict = dict(raw.get("data") or {}) if isinstance(raw, dict) else raw
+        if isinstance(raw, dict):
+            for sibling_key in ("references", "command_gate", "forked", "forked_conversation_id"):
+                if sibling_key in raw:
+                    result[sibling_key] = raw[sibling_key]
+        return ok(result)
     except Exception as exc:
         if uploaded_urls:
             # 업로드는 성공했으나 메시지 생성이 실패한 경우 — asset registry 는 SAVE-time(메시지

--- a/backend/tests/test_2259_ac4_broken_reference_visibility_realdb.py
+++ b/backend/tests/test_2259_ac4_broken_reference_visibility_realdb.py
@@ -1,0 +1,260 @@
+"""story #2259 AC4(E-CONNECT, 2026-07-29) — 끊어진 참조(broken reference)가 실제로 어떻게
+다뤄지는지 세 갈래로 증명한다(PO 요구, 라이브 시도가 403(「Story 삭제는 휴먼만」)으로
+막혀 realdb 테스트로 방식을 고정):
+
+  ㉠참조 «행»이 남는가/사라지는가 — target이 하드삭제돼도 CASCADE가 없어 행은 남는다.
+  ㉡read 경로(`reference_core.list_references`)가 그것을 어떻게 보여주는가 — `still_exists`
+    필드로 "존재하지 않는다"를 명시적으로 실어 보낸다(조용히 누락시키지 않는다).
+  ㉢「끊어졌다」가 사용자에게 어떻게 보이는가 — ⛔정직한 답: **아직 아무 라이브 엔드포인트도
+    `list_references`를 호출하지 않는다**(코드 grep으로 실증). 즉 ㉡의 신호는 서비스
+    레이어에서 올바르게 계산되지만, 지금은 어떤 사용자에게도 도달하지 않는다 — 이 설계
+    제약("조용히 사라지면 그건 거짓말이다")이 아직 지켜지지 않은 상태를 그대로 선언한다
+    (기능을 새로 짓지 않고, 갭을 정확히 재서 적는 것이 이번 판의 스코프).
+"""
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ─── ㉢ 코드 스캔 — list_references의 라이브 호출부가 정말 0인지 ────────────────
+
+
+def test_list_references_has_zero_live_router_callers():
+    """⛔이 테스트가 RED가 되면(즉 어딘가 router가 list_references를 부르기 시작하면) 이
+    파일의 ㉢ 선언(「아직 사용자에게 안 보인다」)을 다시 써야 한다는 신호다 — 그때는
+    선언을 지우는 게 아니라 이 테스트와 함께 갱신한다."""
+    routers_dir = Path(__file__).resolve().parents[1] / "app" / "routers"
+    callers = []
+    for py_file in sorted(routers_dir.glob("*.py")):
+        text = py_file.read_text()
+        if re.search(r"\blist_references\s*\(", text):
+            callers.append(py_file.name)
+    assert callers == [], (
+        f"list_references가 이제 router에서 호출된다({callers}) — "
+        "㉢ 선언(«아직 사용자에게 안 보인다»)이 낡았다. 이 테스트와 PR 본문을 같이 갱신할 것."
+    )
+
+
+# ─── ㉠㉡ realdb 왕복 — Story 하드삭제 시나리오(PO가 라이브에서 시도했던 그 경로) ───
+
+
+async def _session_factory():
+    import os
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    url = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+    if not url:
+        pytest.skip("통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _make_org(session, name="Org"):
+    from app.models.organization import Organization
+    org = Organization(id=uuid.uuid4(), name=name, slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    return org
+
+
+async def _make_project(session, org_id, name="P"):
+    from app.models.project import Project
+    project = Project(id=uuid.uuid4(), org_id=org_id, name=name)
+    session.add(project)
+    await session.commit()
+    return project
+
+
+async def _make_human_member(session, org_id, project_id):
+    from app.models.user import User
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.member import Member
+
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="member")
+    session.add(om)
+    await session.flush()
+    m = Member(id=om.id, org_id=org_id, type="human", user_id=user.id, name="Human")
+    session.add(m)
+    await session.flush()
+    session.add(ProjectAccess(project_id=project_id, org_member_id=om.id, member_id=m.id, role="member"))
+    await session.commit()
+    return m.id, user.id
+
+
+async def _make_story(session, org_id, project_id, title="Story"):
+    from app.models.pm import Story
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status="backlog")
+    session.add(story)
+    await session.commit()
+    return story
+
+
+async def _make_doc(session, org_id, project_id, title="Doc"):
+    from app.models.doc import Doc
+    doc = Doc(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, slug=f"d-{uuid.uuid4().hex[:8]}")
+    session.add(doc)
+    await session.commit()
+    return doc
+
+
+async def _make_reference(session, org_id, source_type, source_id, target_type, target_id, created_by, form="mention"):
+    from app.models.reference import Reference
+    ref = Reference(
+        id=uuid.uuid4(), org_id=org_id, source_type=source_type, source_field="body",
+        source_id=source_id, target_type=target_type, target_id=target_id, form=form,
+        created_by=created_by,
+    )
+    session.add(ref)
+    await session.commit()
+    return ref
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_reference_row_survives_hard_delete_of_target_story_no_cascade():
+    """㉠ — Story를 실제 DELETE 엔드포인트(휴먼 caller, PO가 라이브에서 겪은 바로 그 경로)로
+    하드삭제해도, 그 story를 target으로 가리키던 entity_references 행은 사라지지 않는다
+    (target_id에 FK/CASCADE가 없다 — reference.py 모델 설계상 폴리모픽 대상은 FK를 안 씀)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, title="To Be Deleted")
+            doc = await _make_doc(s, org.id, project.id)
+            ref = await _make_reference(
+                s, org.id, "doc", doc.id, "story", story.id, created_by=member_id,
+            )
+            ref_id = ref.id
+
+        # 라이브에서 PO가 겪은 그 경로 그대로: 휴먼 caller로 DELETE /api/v2/stories/{id}.
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/stories/{story.id}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        # story row 자체는 사라졌는지 확인(하드삭제였다는 전제 검증 — 아니면 이 테스트가
+        # 애초에 무의미).
+        async with Session() as s2:
+            from sqlalchemy import select
+            from app.models.pm import Story
+            still_there = (
+                await s2.execute(select(Story.id).where(Story.id == story.id))
+            ).scalar_one_or_none()
+            assert still_there is None, "story가 실제로는 하드삭제되지 않았다 — 전제가 틀렸다"
+
+            # ㉠ 핵심 — Reference 행은 살아 있다(CASCADE 없음).
+            from app.models.reference import Reference
+            ref_row = (
+                await s2.execute(select(Reference).where(Reference.id == ref_id))
+            ).scalar_one_or_none()
+            assert ref_row is not None, "Reference 행이 target 삭제로 같이 사라졌다 — CASCADE가 걸려 있다"
+            assert ref_row.target_id == story.id
+            assert ref_row.target_type == "story"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_references_marks_still_exists_false_for_broken_target_twin_comparison():
+    """㉡ — `list_references`(reference_core.py, direction="outgoing")가 끊어진 참조를
+    조용히 빼지 않고 `still_exists=False`로 명시한다. 양성대조로 같은 호출 안에 «여전히
+    존재하는» target도 같이 넣어 계측기가 살아 있는 것을 함께 본다(0건만 보면 "다 끊어짐"과
+    "계측기가 죽음"을 구별할 수 없다)."""
+    from app.services.reference_core import list_references
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, _ = await _make_human_member(s, org.id, project.id)
+            source_doc = await _make_doc(s, org.id, project.id, title="Source Doc")
+            broken_target_story = await _make_story(s, org.id, project.id, title="Will Be Deleted")
+            alive_target_story = await _make_story(s, org.id, project.id, title="Still Alive")
+
+            await _make_reference(
+                s, org.id, "doc", source_doc.id, "story", broken_target_story.id, created_by=member_id,
+            )
+            await _make_reference(
+                s, org.id, "doc", source_doc.id, "story", alive_target_story.id, created_by=member_id,
+            )
+
+            # target 하나만 직접 하드삭제(라우터를 거치지 않고 세션에서 바로 — 이 테스트는
+            # ㉡만 격리해서 보는 것이 목적, ㉠은 위 테스트가 이미 증명했다).
+            from app.models.pm import Story
+            await s.delete(await s.get(Story, broken_target_story.id))
+            await s.commit()
+
+            resolved = await list_references(
+                s, org_id=org.id, entity_type="doc", entity_id=source_doc.id, direction="outgoing",
+            )
+
+            by_target = {r.target_id: r for r in resolved}
+            assert by_target[broken_target_story.id].still_exists is False
+            assert by_target[alive_target_story.id].still_exists is True
+            # ⛔조용히 빠지지 않았다는 것 자체를 센다 — 두 참조 모두 응답에 남아 있다.
+            assert len(resolved) == 2
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_e_mcp_opt_s2_chat_attachment_tool.py
+++ b/backend/tests/test_e_mcp_opt_s2_chat_attachment_tool.py
@@ -105,9 +105,13 @@ async def test_upload_attachments_calls_endpoint_per_file():
 # ── send_chat_message 회귀 + 체이닝 ────────────────────────────────────────────
 @pytest.mark.anyio
 async def test_send_chat_message_no_attachments_unchanged_payload():
-    """첨부 없으면 기존 동작 그대로(회귀 0) — payload 에 attachments 키 자체가 없음."""
+    """첨부 없으면 기존 동작 그대로(회귀 0) — payload 에 attachments 키 자체가 없음.
+
+    ⛔story #2294 ③ 후속(2026-07-29): 메시지 전송은 이제 `client.post`가 아니라
+    `client.post_full`(unwrap=False, {"data": {...}} 응답의 sibling 보존용)을 쓴다 —
+    첨부 업로드(`client.post`)와는 다른 메서드라 각각 따로 mock한다."""
     args = SendChatInput(thread_id="conv-1", content="hi")
-    with patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m:
+    with patch.object(chat_mod.client, "post_full", new=AsyncMock(return_value={"data": {"id": "m1"}})) as m:
         await send_chat_message(args)
         _, kwargs = m.call_args
         assert "attachments" not in kwargs["json"]
@@ -124,11 +128,14 @@ async def test_send_chat_message_uploads_then_sends_with_attachments():
 
     async def _fake_post(path, json=None):
         calls.append((path, json))
-        if path.endswith("/attachments"):
-            return upload_result
-        return {"id": "m1"}
+        return upload_result
 
-    with patch.object(chat_mod.client, "post", new=AsyncMock(side_effect=_fake_post)):
+    async def _fake_post_full(path, json=None):
+        calls.append((path, json))
+        return {"data": {"id": "m1"}}
+
+    with patch.object(chat_mod.client, "post", new=AsyncMock(side_effect=_fake_post)), \
+         patch.object(chat_mod.client, "post_full", new=AsyncMock(side_effect=_fake_post_full)):
         result = await send_chat_message(args)
         assert len(calls) == 2
         assert calls[0][0] == "/api/v2/conversations/conv-1/attachments"
@@ -149,9 +156,11 @@ async def test_send_chat_message_upload_failure_does_not_call_message_create():
         calls.append(path)
         raise RuntimeError("upload 403")
 
-    with patch.object(chat_mod.client, "post", new=AsyncMock(side_effect=_fake_post)):
+    with patch.object(chat_mod.client, "post", new=AsyncMock(side_effect=_fake_post)), \
+         patch.object(chat_mod.client, "post_full", new=AsyncMock()) as m_full:
         result = await send_chat_message(args)
         assert calls == ["/api/v2/conversations/conv-1/attachments"]
+        m_full.assert_not_awaited()  # 업로드 실패 시 메시지 생성 자체를 시도하지 않는다
         assert result[0].text.startswith("Error")
 
 
@@ -164,13 +173,9 @@ async def test_send_chat_message_partial_failure_logs_orphan_warning(caplog):
     )
     upload_result = {"url": "org/o/project/p/chat/conv-1/x-s.png", "name": "s.png", "content_type": "image/png", "size": 4}
 
-    async def _fake_post(path, json=None):
-        if path.endswith("/attachments"):
-            return upload_result
-        raise RuntimeError("message create failed")
-
     with caplog.at_level(logging.WARNING, logger=chat_mod.logger.name):
-        with patch.object(chat_mod.client, "post", new=AsyncMock(side_effect=_fake_post)):
+        with patch.object(chat_mod.client, "post", new=AsyncMock(return_value=upload_result)), \
+             patch.object(chat_mod.client, "post_full", new=AsyncMock(side_effect=RuntimeError("message create failed"))):
             result = await send_chat_message(args)
     assert result[0].text.startswith("Error")
     assert any("orphaned" in r.message for r in caplog.records)

--- a/backend/tests/test_e_mcp_opt_s2_chat_attachment_tool.py
+++ b/backend/tests/test_e_mcp_opt_s2_chat_attachment_tool.py
@@ -145,6 +145,36 @@ async def test_send_chat_message_uploads_then_sends_with_attachments():
 
 
 @pytest.mark.anyio
+async def test_send_chat_message_with_attachment_still_surfaces_references_sideband():
+    """⭐PO 질문(2026-07-29) — 첨부가 있을 때도 references가 실리는가? 답: 실린다. 이유:
+    첨부는 `payload["attachments"]`에만 영향을 주고, 응답 재구성(`raw.get("data")` +
+    sibling 병합)은 첨부 유무와 무관하게 같은 코드 경로다 — 백엔드 메시지 엔드포인트도
+    하나뿐이고 그 엔드포인트의 `references` 계산은 `msg.content`(mention 토큰)만 본다,
+    `attachments` 필드와 독립. 이 테스트가 그 구조적 주장을 실측으로 고정한다(첨부+
+    mention 토큰을 같은 메시지에 같이 넣어 sibling이 살아남는지 직접 본다)."""
+    args = SendChatInput(
+        thread_id="conv-1", content="[T](entity:task:t-1)",
+        attachments=[{"content_base64": _b64(4), "name": "s.png", "content_type": "image/png"}],
+    )
+    upload_result = {"url": "org/o/project/p/chat/conv-1/x-s.png", "name": "s.png", "content_type": "image/png", "size": 4}
+    backend_response = {
+        "data": {"id": "m1", "content": "[T](entity:task:t-1)"},
+        "references": {"stored": 1, "dropped": []},
+    }
+
+    with patch.object(chat_mod.client, "post", new=AsyncMock(return_value=upload_result)), \
+         patch.object(chat_mod.client, "post_full", new=AsyncMock(return_value=backend_response)) as m_full:
+        result = await send_chat_message(args)
+
+    import json
+    body = json.loads(result[0].text)
+    assert body["id"] == "m1"
+    assert body["references"] == {"stored": 1, "dropped": []}
+    _, kwargs = m_full.call_args
+    assert kwargs["json"]["attachments"] == [upload_result]  # 첨부도 같이 전송됐다
+
+
+@pytest.mark.anyio
 async def test_send_chat_message_upload_failure_does_not_call_message_create():
     args = SendChatInput(
         thread_id="conv-1", content="x",

--- a/backend/tests/test_mcp_api_client_unwrap.py
+++ b/backend/tests/test_mcp_api_client_unwrap.py
@@ -1,0 +1,78 @@
+"""SprintableApiClient.request()의 `unwrap` 옵션 — story #2294 ③ 후속(2026-07-29, 오르테가
+라이브 실측 버그 수정). `{data: T, ...sibling}` 자동 언래핑이 sibling 키(references·
+command_gate 등)를 통째로 버리던 것을 `unwrap=False`로 끌 수 있게 했다 — 기본값(True)은
+기존 호출부 전부에 byte-identical(회귀 0)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _fake_httpx_response(json_body):
+    resp = MagicMock()
+    resp.is_success = True
+    resp.json.return_value = json_body
+    return resp
+
+
+@pytest.mark.anyio
+async def test_request_default_unwraps_data_wrapper():
+    from sprintable_mcp.api_client import SprintableClient
+
+    client = SprintableClient()
+    client.configure("http://test", "k")
+    resp = _fake_httpx_response({"data": {"id": "x"}, "references": {"stored": 1, "dropped": []}})
+    with patch("httpx.AsyncClient") as mock_cls:
+        mock_cls.return_value.__aenter__.return_value.request = AsyncMock(return_value=resp)
+        result = await client.request("GET", "/x")
+    assert result == {"id": "x"}  # sibling(references)은 기본 동작에서 여전히 버려진다(회귀 0)
+
+
+@pytest.mark.anyio
+async def test_request_unwrap_false_returns_full_body():
+    from sprintable_mcp.api_client import SprintableClient
+
+    client = SprintableClient()
+    client.configure("http://test", "k")
+    body = {"data": {"id": "x"}, "references": {"stored": 1, "dropped": []}}
+    resp = _fake_httpx_response(body)
+    with patch("httpx.AsyncClient") as mock_cls:
+        mock_cls.return_value.__aenter__.return_value.request = AsyncMock(return_value=resp)
+        result = await client.request("POST", "/x", unwrap=False)
+    assert result == body  # data와 sibling 전부 그대로 남는다
+
+
+@pytest.mark.anyio
+async def test_post_full_uses_unwrap_false():
+    from sprintable_mcp.api_client import SprintableClient
+
+    client = SprintableClient()
+    client.configure("http://test", "k")
+    body = {"data": {"id": "x"}, "command_gate": {"blocked": ["y"]}}
+    resp = _fake_httpx_response(body)
+    with patch("httpx.AsyncClient") as mock_cls:
+        mock_cls.return_value.__aenter__.return_value.request = AsyncMock(return_value=resp)
+        result = await client.post_full("/x", json={})
+    assert result == body
+
+
+@pytest.mark.anyio
+async def test_request_no_data_key_returns_as_is_regardless_of_unwrap():
+    """data 키 자체가 없는 응답(예: 배열)은 unwrap 값과 무관하게 그대로 반환된다."""
+    from sprintable_mcp.api_client import SprintableClient
+
+    client = SprintableClient()
+    client.configure("http://test", "k")
+    resp = _fake_httpx_response([{"id": "a"}, {"id": "b"}])
+    with patch("httpx.AsyncClient") as mock_cls:
+        mock_cls.return_value.__aenter__.return_value.request = AsyncMock(return_value=resp)
+        result = await client.request("GET", "/x")
+    assert result == [{"id": "a"}, {"id": "b"}]

--- a/backend/tests/test_mcp_s1995_agent_doc_mentions.py
+++ b/backend/tests/test_mcp_s1995_agent_doc_mentions.py
@@ -181,6 +181,10 @@ def test_mention_ref_literal_matches_backend_entity_resolvers_directly():
     literal_type = typing.get_type_hints(MentionRef)["type"]
     literal_values = set(typing.get_args(literal_type))
     assert literal_values == set(ENTITY_RESOLVERS) - _MENTION_ENDPOINT_KNOWN_GAP
+    # ⭐PO 지적(2026-07-29): "없다"만 고정하면 다음 사람이 "빠뜨린 건가"를 다시 세게 된다 —
+    # WHY: evidence는 GET /api/v2/evidence/{id}(단건조회) 라우트 자체가 없어(work_item_id로
+    # 거르는 list만 존재) MCP가 title을 auto-fetch할 방법이 없다 — 그래서 Literal에 못 올린다.
+    # 단건 GET이 생기면 여기와 `_MENTION_ENTITY_ENDPOINTS`(chat.py)를 같이 늘린다.
     assert "evidence" not in literal_values
     assert "evidence" in set(ENTITY_RESOLVERS)
 

--- a/backend/tests/test_mcp_s1995_agent_doc_mentions.py
+++ b/backend/tests/test_mcp_s1995_agent_doc_mentions.py
@@ -165,6 +165,26 @@ def test_mention_ref_literal_matches_mention_entity_endpoints_directly():
     assert literal_values == set(chat_mod._MENTION_ENTITY_ENDPOINTS)
 
 
+def test_mention_ref_literal_matches_backend_entity_resolvers_directly():
+    """⭐PO 재지적(2026-07-29, 같은 메시지 후속): 바로 위 테스트(Literal↔dict)와
+    `test_mention_entity_endpoints_match_backend_entity_resolvers`(dict↔registry)가
+    각각 통과해도 그건 dict를 매개로 한 «간접» 등식일 뿐 — Literal을 registry(8종)와
+    직접 비교하는 자리는 없었다. 두 테스트가 «우연히 같은 7종 집합」을 두 번 잰 것일
+    가능성을 배제 못 한다(예: 나중에 dict↔registry 테스트가 리팩터로 사라지면 이
+    등식이 조용히 깨질 수 있는 자리). registry를 매개 없이 직접 걸어 evidence 단
+    하나만 빠진 것인지 고정한다 — PO 표현 그대로 "evidence가 MCP 쪽에 «둘 다» 없는"
+    상태를 이 테스트 하나로 직접 증명."""
+    import typing
+
+    from app.services.reference_registry import ENTITY_RESOLVERS
+
+    literal_type = typing.get_type_hints(MentionRef)["type"]
+    literal_values = set(typing.get_args(literal_type))
+    assert literal_values == set(ENTITY_RESOLVERS) - _MENTION_ENDPOINT_KNOWN_GAP
+    assert "evidence" not in literal_values
+    assert "evidence" in set(ENTITY_RESOLVERS)
+
+
 # ── send_chat_message: token synthesis (title given) ─────────────────────────
 @pytest.mark.anyio
 async def test_send_chat_message_synthesizes_token_with_given_title():

--- a/backend/tests/test_mcp_s1995_agent_doc_mentions.py
+++ b/backend/tests/test_mcp_s1995_agent_doc_mentions.py
@@ -149,6 +149,22 @@ def test_mention_entity_endpoints_match_backend_entity_resolvers():
     assert _MENTION_ENDPOINT_KNOWN_GAP.isdisjoint(chat_mod._MENTION_ENTITY_ENDPOINTS)
 
 
+def test_mention_ref_literal_matches_mention_entity_endpoints_directly():
+    """⭐PO 지적(2026-07-29): 위 테스트는 `_MENTION_ENTITY_ENDPOINTS`↔`ENTITY_RESOLVERS`
+    (dict↔registry) «둘만» 잰다 — `MentionRef.type`의 Pydantic `Literal`(스키마 검증 축)은
+    지금까지 «손으로 같이 맞춰 왔을 뿐» 어느 테스트도 직접 재지 않았다. Literal과 dict가
+    서로 갈리면(예: dict에만 새 키를 추가하고 Literal enum을 깜빡하면) 위 테스트는 여전히
+    통과하는데(Literal은 안 보니까) 실제로는 `MentionRef(type="새키", ...)`가 스키마
+    레벨에서 거부되는 죽은 경로가 생긴다 — registry↔dict가 아니라 «dict↔Literal» 축의
+    twin-system 갭. `typing.get_args()`로 Literal의 실제 허용값을 직접 추출해 dict 키와
+    동일한지 고정한다(세 축 중 마지막 하나)."""
+    import typing
+
+    literal_type = typing.get_type_hints(MentionRef)["type"]
+    literal_values = set(typing.get_args(literal_type))
+    assert literal_values == set(chat_mod._MENTION_ENTITY_ENDPOINTS)
+
+
 # ── send_chat_message: token synthesis (title given) ─────────────────────────
 @pytest.mark.anyio
 async def test_send_chat_message_synthesizes_token_with_given_title():

--- a/backend/tests/test_mcp_s1995_agent_doc_mentions.py
+++ b/backend/tests/test_mcp_s1995_agent_doc_mentions.py
@@ -157,7 +157,7 @@ async def test_send_chat_message_synthesizes_token_with_given_title():
         content="see this",
         mentions=[{"type": "doc", "id": "11111111-1111-1111-1111-111111111111", "title": "My Doc"}],
     )
-    with patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m, \
+    with patch.object(chat_mod.client, "post_full", new=AsyncMock(return_value={"data": {"id": "m1"}})) as m, \
          patch.object(chat_mod.client, "get", new=AsyncMock()) as g:
         result = await send_chat_message(args)
         g.assert_not_called()  # title 명시 → doc GET 조회 스킵
@@ -178,7 +178,7 @@ async def test_send_chat_message_synthesizes_token_multiple_mentions_no_double_s
             {"type": "doc", "id": "doc-b", "title": "Doc B"},
         ],
     )
-    with patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m:
+    with patch.object(chat_mod.client, "post_full", new=AsyncMock(return_value={"data": {"id": "m1"}})) as m:
         await send_chat_message(args)
         _, kwargs = m.call_args
         assert kwargs["json"]["content"] == (
@@ -193,7 +193,7 @@ async def test_send_chat_message_escapes_adversarial_given_title():
         content="see this",
         mentions=[{"type": "doc", "id": "doc-1", "title": "x](https://evil.example)[y"}],
     )
-    with patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m:
+    with patch.object(chat_mod.client, "post_full", new=AsyncMock(return_value={"data": {"id": "m1"}})) as m:
         await send_chat_message(args)
         _, kwargs = m.call_args
         assert kwargs["json"]["content"] == (
@@ -223,7 +223,7 @@ async def test_send_chat_message_reuses_backend_reference_token_when_title_omitt
         "reference_token": "[SERVER-CANONICAL-TOKEN](entity:doc:doc-1)",
     }
     with patch.object(chat_mod.client, "get", new=AsyncMock(return_value=fetched)) as g, \
-         patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m:
+         patch.object(chat_mod.client, "post_full", new=AsyncMock(return_value={"data": {"id": "m1"}})) as m:
         result = await send_chat_message(args)
         g.assert_awaited_once_with("/api/v2/docs/doc-1")
         _, kwargs = m.call_args
@@ -245,7 +245,7 @@ async def test_send_chat_message_reuses_reference_token_for_story_type():
         "reference_token": "[SERVER-CANONICAL-STORY-TOKEN](entity:story:story-1)",
     }
     with patch.object(chat_mod.client, "get", new=AsyncMock(return_value=fetched)) as g, \
-         patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m:
+         patch.object(chat_mod.client, "post_full", new=AsyncMock(return_value={"data": {"id": "m1"}})) as m:
         await send_chat_message(args)
         g.assert_awaited_once_with("/api/v2/stories/story-1")
         _, kwargs = m.call_args
@@ -264,7 +264,7 @@ async def test_send_chat_message_reuses_reference_token_for_epic_type():
         "reference_token": "[SERVER-CANONICAL-EPIC-TOKEN](entity:epic:epic-1)",
     }
     with patch.object(chat_mod.client, "get", new=AsyncMock(return_value=fetched)) as g, \
-         patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m:
+         patch.object(chat_mod.client, "post_full", new=AsyncMock(return_value={"data": {"id": "m1"}})) as m:
         await send_chat_message(args)
         g.assert_awaited_once_with("/api/v2/goals/epic-1")
         _, kwargs = m.call_args
@@ -283,7 +283,7 @@ async def test_send_chat_message_falls_back_to_local_escape_when_reference_token
     fetched = {"id": "doc-1", "title": "Fetched Doc"}  # reference_token 없음
     with caplog.at_level(logging.WARNING, logger="sprintable_mcp.tools.chat"):
         with patch.object(chat_mod.client, "get", new=AsyncMock(return_value=fetched)), \
-             patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m:
+             patch.object(chat_mod.client, "post_full", new=AsyncMock(return_value={"data": {"id": "m1"}})) as m:
             await send_chat_message(args)
             _, kwargs = m.call_args
             assert kwargs["json"]["content"] == "see this [Fetched Doc](entity:doc:doc-1) "
@@ -300,12 +300,105 @@ async def test_send_chat_message_mention_doc_not_found_errors_without_posting_me
     )
 
     with patch.object(chat_mod.client, "get", new=AsyncMock(side_effect=RuntimeError("404 Not Found"))) as g, \
-         patch.object(chat_mod.client, "post", new=AsyncMock()) as m:
+         patch.object(chat_mod.client, "post_full", new=AsyncMock()) as m:
         result = await send_chat_message(args)
         g.assert_awaited_once_with("/api/v2/docs/missing-doc")
         m.assert_not_called()  # broken 토큰이 실린 반쪽 메시지가 저장되지 않는다
         assert result[0].text.startswith("Error")
         assert "404" in result[0].text
+
+
+# ── references/command_gate sibling 노출(2026-07-29 오르테가 라이브 실측 버그) ──
+
+
+@pytest.mark.anyio
+async def test_send_chat_message_surfaces_references_sideband_from_backend():
+    """⭐이 버그가 실제로 있었던 자리 — 백엔드가 `{"data": {...}, "references": {...}}`를
+    돌려줘도 예전엔 `client.post()`의 자동 unwrap이 `references`를 통째로 버려서 CI green·
+    배포 SHA 일치에도 MCP 호출부엔 한 번도 안 닿았다(라이브 재현으로 발견). `post_full`
+    (unwrap=False)로 원본을 받아 재구성하는지 — sibling이 실제로 살아남는지를 직접 본다."""
+    args = SendChatInput(thread_id="conv-1", content="[T](entity:task:t-1)")
+    backend_response = {
+        "data": {"id": "m1", "content": "[T](entity:task:t-1)"},
+        "references": {"stored": 1, "dropped": [{"target_type": "sprint", "target_id": "s-1"}]},
+    }
+    with patch.object(chat_mod.client, "post_full", new=AsyncMock(return_value=backend_response)):
+        result = await send_chat_message(args)
+    import json
+    body = json.loads(result[0].text)
+    assert body["id"] == "m1"  # data가 평탄하게 풀렸다(기존 MCP 호출부 기대 모양 유지)
+    assert body["references"] == {"stored": 1, "dropped": [{"target_type": "sprint", "target_id": "s-1"}]}
+
+
+@pytest.mark.anyio
+async def test_send_chat_message_surfaces_command_gate_sideband_from_backend():
+    """references와 같은 클래스의 기존 버그 — command_gate도 같은 이유로 MCP 경로에서
+    한 번도 안 보이고 있었다(이번에 같이 드러남). 같은 수정으로 같이 고쳐지는지."""
+    args = SendChatInput(thread_id="conv-1", content="/unsupported-command")
+    backend_response = {
+        "data": {"id": "m2", "content": "/unsupported-command"},
+        "command_gate": {"blocked": ["unsupported-command"]},
+    }
+    with patch.object(chat_mod.client, "post_full", new=AsyncMock(return_value=backend_response)):
+        result = await send_chat_message(args)
+    import json
+    body = json.loads(result[0].text)
+    assert body["command_gate"] == {"blocked": ["unsupported-command"]}
+
+
+@pytest.mark.anyio
+async def test_send_chat_message_plain_response_without_sideband_stays_flat():
+    """⛔회귀 0 — 백엔드가 sibling 없이 `{"data": {...}}`만 주면(평문 메시지의 일반 경로)
+    기존과 동일하게 평탄한 메시지 필드만 남는다(references/command_gate 키 자체가 없음)."""
+    args = SendChatInput(thread_id="conv-1", content="그냥 평문")
+    backend_response = {"data": {"id": "m3", "content": "그냥 평문"}}
+    with patch.object(chat_mod.client, "post_full", new=AsyncMock(return_value=backend_response)):
+        result = await send_chat_message(args)
+    import json
+    body = json.loads(result[0].text)
+    assert body["id"] == "m3"
+    assert "references" not in body
+    assert "command_gate" not in body
+
+
+# ── RED→GREEN 자체검증 — post_full 안 쓰면 sideband가 실제로 사라지는지 ──────────
+
+
+@pytest.mark.anyio
+async def test_sideband_exposure_red_green_mutation_self_check():
+    """`post_full` 대신 옛 `post`(자동 unwrap)를 쓰도록 사보타주하면 references가 실제로
+    사라지는지(RED) → 원복하면 다시 나오는지(GREEN) — 이번에 고친 버그 그 자체를 재현."""
+    import sprintable_mcp.tools.chat as chat_module
+
+    args = SendChatInput(thread_id="conv-1", content="[T](entity:task:t-1)")
+    backend_full_response = {
+        "data": {"id": "m1", "content": "[T](entity:task:t-1)"},
+        "references": {"stored": 1, "dropped": []},
+    }
+
+    original_send = chat_module.send_chat_message
+
+    async def _sabotaged_send(a):
+        # 사보타주: post_full 대신 post(자동 unwrap)를 써서 옛 버그를 재현.
+        unwrapped = await chat_module.client.post(
+            f"/api/v2/conversations/{a.thread_id}/messages", json={"content": a.content},
+        )
+        return chat_module.ok(unwrapped)
+
+    with patch.object(
+        chat_module.client, "post", new=AsyncMock(return_value=backend_full_response["data"]),
+    ):
+        # post()는 이미 unwrap된(= "data"만 있는) 값을 돌려준다고 가정(실제 client.post 동작과 동일).
+        import json
+        result = await _sabotaged_send(args)
+        body = json.loads(result[0].text)
+        assert "references" not in body, "사보타주가 안 먹었다 — references가 여전히 있다(RED 실패)"
+
+    # 원복 — 실제 send_chat_message(post_full 사용)로 같은 입력을 돌리면 references가 다시 뜬다.
+    with patch.object(chat_module.client, "post_full", new=AsyncMock(return_value=backend_full_response)):
+        result2 = await original_send(args)
+        body2 = json.loads(result2[0].text)
+        assert body2.get("references") == {"stored": 1, "dropped": []}, "원복 후에도 안 뜬다(GREEN 실패)"
 
 
 # ── mentions 생략 → 회귀 0 (가장 중요) ─────────────────────────────────────────
@@ -314,7 +407,7 @@ async def test_send_chat_message_mentions_omitted_byte_identical_to_current_beha
     """mentions 필드 자체를 안 넘긴 기존 호출자는 payload가 이 변경 前과 완전히 동일해야 한다."""
     args = SendChatInput(thread_id="conv-1", content="hi there")
     assert args.mentions is None
-    with patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m, \
+    with patch.object(chat_mod.client, "post_full", new=AsyncMock(return_value={"data": {"id": "m1"}})) as m, \
          patch.object(chat_mod.client, "get", new=AsyncMock()) as g:
         result = await send_chat_message(args)
         g.assert_not_called()
@@ -329,7 +422,7 @@ async def test_send_chat_message_mentions_omitted_byte_identical_to_current_beha
 async def test_send_chat_message_empty_mentions_list_byte_identical():
     """mentions=[] (falsy) 도 mentions=None과 동일하게 동작 — content 변조 없음."""
     args = SendChatInput(thread_id="conv-1", content="hi there", mentions=[])
-    with patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m:
+    with patch.object(chat_mod.client, "post_full", new=AsyncMock(return_value={"data": {"id": "m1"}})) as m:
         await send_chat_message(args)
         _, kwargs = m.call_args
         assert kwargs["json"]["content"] == "hi there"

--- a/infra/mcp_path_contract_guard.py
+++ b/infra/mcp_path_contract_guard.py
@@ -164,7 +164,12 @@ def load_mcp_declared(tools_dir: Path = _TOOLS_DIR):
     빠지지 않는다 — 2026-07-28 attachments.py:upload_attachments 발견 이후 필수 요건)."""
     calls = []
     unreadable = []
-    method_re = re.compile(r"client\.(get|post|patch|put|delete)\(")
+    # ⛔story #2294 ③ 후속(2026-07-29): `post_full`은 `post`와 «같은 HTTP verb·같은 경로
+    # 추적 대상»이다 — {data: T} 자동 언래핑을 끄는 것뿐(unwrap=False), 검증해야 할 경로
+    # 자체는 post()와 동일 축이라 verb=POST로 매칭한다(가드를 느슨하게 하는 게 아니라
+    # 어휘를 넓히는 것 — 위 모듈 docstring의 "자동으로 못 읽었다고 조용히 빠지지 않는다"
+    # 원칙 그대로 여기도 적용).
+    method_re = re.compile(r"client\.(get|post_full|post|patch|put|delete)\(")
     request_re = re.compile(r'client\.request\(\s*\n?\s*"(GET|POST|PATCH|PUT|DELETE)",\s*\n?\s*')
 
     for fpath in sorted(tools_dir.glob("*.py")):
@@ -172,7 +177,8 @@ def load_mcp_declared(tools_dir: Path = _TOOLS_DIR):
         src = fpath.read_text()
 
         for m in method_re.finditer(src):
-            method = m.group(1).upper()
+            # post_full은 언래핑만 끄는 post의 변형 — 검증 축은 여전히 실제 HTTP verb(POST).
+            method = "POST" if m.group(1) == "post_full" else m.group(1).upper()
             after = src[m.end():]
             lit = re.match(r'\s*f?"([^"]*)"', after)
             if lit:


### PR DESCRIPTION
## 배경 — 오르테가 라이브 실측(2026-07-29, dev revision 01983-7nh, 이미지 SHA=develop HEAD 확認)

"#2294가 실렸는데 안 먹는다": 메시지에 `entity:task:...` + `entity:doc:...`(양성대조) +
`entity:sprint:...`(미등록 종류) 토큰을 같이 넣어 보내면 저장은 정상(backlinks에 확認됨)인데
POST 응답에 `references` 필드가 **없었다**. CI 9개 초록·배포 SHA 일치·코드에 그 줄이 있는데도
사용자에겐 안 닿는 상태 — "조용히 버려지는 것을 고치는 기능이, 조용히 버려졌다."

## 근본원인

`SprintableClient.request()`(`sprintable_mcp/api_client.py`)의 공용 편의 로직이
`{"data": T, ...sibling}` 응답을 무조건 `data`만 남기고 sibling을 통째로 버렸다. 직접 라이브
재현(디디, dev API 직접 호출)으로 확認 — raw HTTP curl로는 `references`가 정상 노출되지만,
MCP `sprintable_send_chat_message` 경유로는 사라졌다. **이건 #2294가 만든 새 버그가 아니라,
이 함수를 공유하는 기존 기능(`command_gate`, #2201 E-CHAT-CMD)도 처음부터 MCP 경로에서 한
번도 안 보이고 있었다는 뜻**이다 — 이번에 같이 드러난 pre-existing 버그.

## 수정
- `request()`에 `unwrap: bool = True` 추가(기본값 유지 — 기존 호출부 전부 byte-identical,
  회귀 0). `unwrap=False`면 `{data, ...sibling}`을 통째로 반환.
- `post_full()` 신설 — sibling이 필요한 소수 호출부(`send_chat_message`)용.
- `send_chat_message`가 `post_full`로 원본을 받아 명시적으로 재구성 — 기존 MCP 호출부가
  기대하는 평탄한 메시지 필드 모양은 유지하면서 `references`/`command_gate`/`forked` 등
  sibling 키만 얹는다.
- `infra/mcp_path_contract_guard.py`의 `method_re`에 `post_full`을 추가(같은 HTTP verb·같은
  경로 추적 축 — 가드를 느슨하게 하는 게 아니라 어휘를 넓히는 것)해 이 새 호출부도 계속 정적
  대조 대상에 남게 했다. "POST_FULL" 오분류(가짜 verb)도 "POST"로 정규화해 같이 고쳤다.

## 검증
- **라이브 재현** — dev API에 직접 curl로 task+sprint 조합 메시지 전송 → 수정 前 코드로는
  MCP 경로에서 `references` 소실 재현, 수정 코드로는 `references: {stored: N, dropped: [...]}`
  정상 노출을 직접 확認(raw HTTP는 애초에 정상이었다는 것도 대조로 확認).
- 신규 유닛 테스트: `post_full` sibling 노출 3개(references·command_gate·평문 회귀 0) +
  api_client unwrap 옵션 4개 + RED→GREEN 자체검증(post_full 대신 옛 post로 사보타주 →
  references 소실 확認 → 원복 → 재노출 확認) — 정확히 이번에 고친 버그를 재현/증명.
- 기존 MCP mentions 테스트 27개도 `post_full` mock으로 갱신 + MCP 경로 계약 가드 13개
  (CI=1로 재현) + 회귀 371개 GREEN.

## #2259 AC4 — 끊어진 참조 가시성 ㉠㉡㉢ 증명 (같은 판에 같이 닫음)

라이브 시도가 403(「Story 삭제는 휴먼만」)으로 막혀 realdb 테스트로 방식을 고정(PO 판정):
- **㉠** Story를 실제 `DELETE /api/v2/stories/{id}` 엔드포인트(휴먼 caller)로 하드삭제해도
  `entity_references` 행은 CASCADE 없이 살아남는다 — `target_id`에 FK가 없는 폴리모픽 설계
  그대로 확認.
- **㉡** `reference_core.list_references`가 끊어진 참조를 조용히 빼지 않고 `still_exists=False`
  로 명시한다 — 양성대조(살아있는 target도 같은 호출에 넣어)로 계측기가 살아있음을 같이 확認.
- **㉢** 정직한 답: **아직 아무 라이브 엔드포인트도 `list_references`를 호출하지 않는다**
  (`app/routers/*.py` 전체 grep으로 실증 — 0건이면 이 선언 자체가 테스트로 고정됨). 즉 ㉡의
  신호는 서비스 레이어에서 올바르게 계산되지만 지금은 어떤 사용자에게도 안 닿는다 — "조용히
  사라지면 거짓말이다"라는 설계 제약이 아직 안 지켜진 상태를 그대로 선언한다(기능을 새로
  짓지 않고 갭을 정확히 재서 적는 것이 이번 판의 스코프).

## 롤백
`api_client.py`의 `unwrap` 파라미터+`post_full()` 제거 + `chat.py`의 `send_chat_message`를
`client.post()` 호출로 되돌리면 순수 revert(단, references/command_gate가 다시 안 보이는
상태로 돌아간다는 것을 인지할 것). `mcp_path_contract_guard.py`의 `post_full` 어휘 추가는
guard 정확도만 높이는 것이라 되돌릴 필요 없음.