### PR TITLE
fix(E-CONNECT B단계 후속): entities.py 검색축 마저 열기

### DIFF
--- a/backend/app/routers/entities.py
+++ b/backend/app/routers/entities.py
@@ -1,15 +1,19 @@
 import uuid
+from collections.abc import Awaitable, Callable
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.doc import Doc
-from app.models.pm import Goal, Story, Task
+from app.models.evidence import Evidence
+from app.models.hypothesis import Hypothesis
+from app.models.pm import Goal, Sprint, Story, Task
+from app.models.visual_artifact import VisualArtifact
 from app.services.project_auth import has_project_access
 from app.services.reference_registry import ENTITY_RESOLVERS
 
@@ -19,7 +23,7 @@ DEFAULT_LIMIT = 10
 
 
 def _valid_types() -> set[str]:
-    """story #2294 AC1: 검색 허용목록을 `reference_registry.ENTITY_RESOLVERS`에서 «파생»한다 —
+    """story #2294 AC1: 검색 허용목록을 `reference_registry.ENTITY_RESOLVERS`에서 «파생」한다 —
     여기 종류를 다시 나열하지 않는다(맞춘 목록은 다시 갈린다는 것을 오늘 `task`가 실측으로
     보였다: 이 파일이 예전엔 `{"story","doc","epic","task"}`를 손으로 들고 있었는데
     registry엔 `task`가 없어 검색은 되지만 저장은 안 되는 결함이 났다). 매 호출마다 registry를
@@ -36,18 +40,204 @@ class EntitySearchResult(BaseModel):
     created_at: datetime
 
 
+# ⛔story #2294 B단계 후속(오르테가 라이브 실측, 2026-07-29): "받아들이는 것"(_valid_types,
+# registry에서 파생)과 "찾는 것"(아래 _SEARCH_HANDLERS)이 따로 놀 수 있다는 것이 실제로
+# 드러났다 — B단계가 registry에 4종(sprint·artifact·hypothesis·evidence)을 열자 `types=`가
+# 그 값들을 200/0건으로 «받아들이기»는 했지만, 실제 SELECT 분기가 없어 데이터가 있어도
+# 조용히 0건을 냈다("스프린트 16개 실재하는데 검색은 0건" — 양성대조로 실증). 400도 아니고
+# 에러도 아닌 "조용히 0건"은 사용자에게 "그런 게 없다"로 읽힌다 — 있는데.
+#
+# 처방: entity_type(str) → 검색 handler 의 SSOT dict(reference_registry.py의 ENTITY_RESOLVERS/
+# PROJECT_ID_RESOLVERS와 동형 원칙). registry에 있는데 이 dict에 없으면(가능성 자체를 0으로
+# 만드는 게 아니라 재발했을 때를 대비한 방어) search_entities가 조용히 넘기지 않고 500을
+# 던진다 — "받는데 못 찾는" 상태를 다시는 침묵시키지 않는다. 키 집합 동일성은
+# test_2294_entities_search_open_4_types_realdb.py가 twin-key 테스트로 고정한다(#2283이
+# 세운 그 자와 동형 — 한쪽만 열리면 RED).
+EntitySearchHandler = Callable[
+    [AsyncSession, uuid.UUID, uuid.UUID, "str | None"], Awaitable[list[EntitySearchResult]]
+]
+
+
+async def _search_stories(
+    db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID, search: str | None,
+) -> list[EntitySearchResult]:
+    stmt = select(Story.id, Story.title, Story.status, Story.created_at).where(
+        Story.org_id == org_id, Story.project_id == project_id, Story.deleted_at.is_(None),
+    )
+    if search:
+        stmt = stmt.where(Story.title.ilike(search))
+    stmt = stmt.order_by(Story.created_at.desc()).limit(DEFAULT_LIMIT)
+    rows = await db.execute(stmt)
+    return [
+        EntitySearchResult(entity_type="story", entity_id=rid, title=title, status=st, created_at=cat)
+        for rid, title, st, cat in rows
+    ]
+
+
+async def _search_docs(
+    db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID, search: str | None,
+) -> list[EntitySearchResult]:
+    stmt = select(Doc.id, Doc.title, Doc.created_at).where(
+        Doc.org_id == org_id, Doc.project_id == project_id, Doc.deleted_at.is_(None),
+    )
+    if search:
+        stmt = stmt.where(Doc.title.ilike(search))
+    stmt = stmt.order_by(Doc.created_at.desc()).limit(DEFAULT_LIMIT)
+    rows = await db.execute(stmt)
+    return [
+        EntitySearchResult(entity_type="doc", entity_id=rid, title=title, created_at=cat)
+        for rid, title, cat in rows
+    ]
+
+
+async def _search_epics(
+    db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID, search: str | None,
+) -> list[EntitySearchResult]:
+    stmt = select(Goal.id, Goal.title, Goal.status, Goal.created_at).where(
+        Goal.org_id == org_id, Goal.project_id == project_id,
+    )
+    if search:
+        stmt = stmt.where(Goal.title.ilike(search))
+    stmt = stmt.order_by(Goal.created_at.desc()).limit(DEFAULT_LIMIT)
+    rows = await db.execute(stmt)
+    return [
+        EntitySearchResult(entity_type="epic", entity_id=rid, title=title, status=st, created_at=cat)
+        for rid, title, st, cat in rows
+    ]
+
+
+async def _search_tasks(
+    db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID, search: str | None,
+) -> list[EntitySearchResult]:
+    stmt = (
+        select(Task.id, Task.title, Task.status, Task.created_at)
+        .join(Story, Task.story_id == Story.id)
+        .where(Task.org_id == org_id, Story.project_id == project_id, Task.deleted_at.is_(None))
+    )
+    if search:
+        stmt = stmt.where(Task.title.ilike(search))
+    stmt = stmt.order_by(Task.created_at.desc()).limit(DEFAULT_LIMIT)
+    rows = await db.execute(stmt)
+    return [
+        EntitySearchResult(entity_type="task", entity_id=rid, title=title, status=st, created_at=cat)
+        for rid, title, st, cat in rows
+    ]
+
+
+async def _search_sprints(
+    db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID, search: str | None,
+) -> list[EntitySearchResult]:
+    stmt = select(Sprint.id, Sprint.title, Sprint.status, Sprint.created_at).where(
+        Sprint.org_id == org_id, Sprint.project_id == project_id,
+    )
+    if search:
+        stmt = stmt.where(Sprint.title.ilike(search))
+    stmt = stmt.order_by(Sprint.created_at.desc()).limit(DEFAULT_LIMIT)
+    rows = await db.execute(stmt)
+    return [
+        EntitySearchResult(entity_type="sprint", entity_id=rid, title=title, status=st, created_at=cat)
+        for rid, title, st, cat in rows
+    ]
+
+
+async def _search_artifacts(
+    db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID, search: str | None,
+) -> list[EntitySearchResult]:
+    stmt = select(VisualArtifact.id, VisualArtifact.title, VisualArtifact.created_at).where(
+        VisualArtifact.org_id == org_id, VisualArtifact.project_id == project_id,
+        VisualArtifact.deleted_at.is_(None),
+    )
+    if search:
+        stmt = stmt.where(VisualArtifact.title.ilike(search))
+    stmt = stmt.order_by(VisualArtifact.created_at.desc()).limit(DEFAULT_LIMIT)
+    rows = await db.execute(stmt)
+    return [
+        EntitySearchResult(entity_type="artifact", entity_id=rid, title=title, created_at=cat)
+        for rid, title, cat in rows
+    ]
+
+
+async def _search_hypotheses(
+    db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID, search: str | None,
+) -> list[EntitySearchResult]:
+    # Hypothesis엔 title 칼럼이 없다 — §2.2.4 "유일한 수동 텍스트 입력"인 statement가 제목
+    # 대응 필드(reference_registry._project_id_of_hypothesis와 별개로, 검색 표시용 텍스트
+    # 선택은 이 파일의 판단 — statement 외엔 사람이 읽을 자유텍스트가 없다).
+    stmt = select(Hypothesis.id, Hypothesis.statement, Hypothesis.status, Hypothesis.created_at).where(
+        Hypothesis.org_id == org_id, Hypothesis.project_id == project_id,
+    )
+    if search:
+        stmt = stmt.where(Hypothesis.statement.ilike(search))
+    stmt = stmt.order_by(Hypothesis.created_at.desc()).limit(DEFAULT_LIMIT)
+    rows = await db.execute(stmt)
+    return [
+        EntitySearchResult(entity_type="hypothesis", entity_id=rid, title=statement, status=st, created_at=cat)
+        for rid, statement, st, cat in rows
+    ]
+
+
+async def _search_evidence(
+    db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID, search: str | None,
+) -> list[EntitySearchResult]:
+    """Evidence는 project_id가 없다(work_item_id/work_item_type로 story/task를 폴리모픽
+    참조 — reference_registry._project_id_of_evidence와 동일 축) — story-경유·task-경유
+    둘을 각각 join해 project 스코프를 건다. title 대응 칼럼도 없어(자유텍스트가 아니라
+    ref/note/source) `ref`(NOT NULL)를 표시 필드로 쓴다."""
+    via_story = (
+        select(Evidence.id, Evidence.ref, Evidence.created_at)
+        .join(Story, and_(Story.id == Evidence.work_item_id, Evidence.work_item_type == "story"))
+        .where(
+            Evidence.org_id == org_id, Story.project_id == project_id, Story.deleted_at.is_(None),
+        )
+    )
+    via_task = (
+        select(Evidence.id, Evidence.ref, Evidence.created_at)
+        .join(Task, and_(Task.id == Evidence.work_item_id, Evidence.work_item_type == "task"))
+        .join(Story, Story.id == Task.story_id)
+        .where(
+            Evidence.org_id == org_id, Story.project_id == project_id,
+            Task.deleted_at.is_(None), Story.deleted_at.is_(None),
+        )
+    )
+    if search:
+        via_story = via_story.where(Evidence.ref.ilike(search))
+        via_task = via_task.where(Evidence.ref.ilike(search))
+    story_rows = (await db.execute(via_story)).all()
+    task_rows = (await db.execute(via_task)).all()
+    combined = sorted(story_rows + task_rows, key=lambda r: r[2], reverse=True)[:DEFAULT_LIMIT]
+    return [
+        EntitySearchResult(entity_type="evidence", entity_id=rid, title=ref, created_at=cat)
+        for rid, ref, cat in combined
+    ]
+
+
+# ⛔이 dict가 "찾는 것" 축의 유일한 SSOT — registry(ENTITY_RESOLVERS, "받아들이는 것" 축)와
+# 별개 dict로 둔다(reference_registry.py의 PROJECT_ID_RESOLVERS와 동일 twin-system 원칙 —
+# 합치면 한쪽만 늘리고 잊는 조용한 누락이 재발한다). 키 집합 동일성은 테스트로 고정.
+_SEARCH_HANDLERS: dict[str, "EntitySearchHandler"] = {
+    "story": _search_stories,
+    "doc": _search_docs,
+    "epic": _search_epics,
+    "task": _search_tasks,
+    "sprint": _search_sprints,
+    "artifact": _search_artifacts,
+    "hypothesis": _search_hypotheses,
+    "evidence": _search_evidence,
+}
+
+
 @router.get("/search", response_model=list[EntitySearchResult])
 async def search_entities(
     project_id: uuid.UUID = Query(...),
     q: str | None = Query(default=None),
-    types: str | None = Query(default=None, description="Comma-separated: story,doc,epic,task"),
+    types: str | None = Query(default=None, description="Comma-separated entity types"),
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> list[EntitySearchResult]:
     # ratchet round4(story 03ee87cc): project_id 쿼리파라미터(조회대상 자체)에 caller
-    # 접근권 검증이 없어 same-org cross-project의 story/doc/epic/task 4종 title(+ILIKE 검색
-    # 매칭 시 내용 존재여부)까지 한 엔드포인트에서 동시 노출됐다 — resource-actual 직접검증.
+    # 접근권 검증이 없어 same-org cross-project의 여러 종류 title(+ILIKE 검색 매칭 시 내용
+    # 존재여부)까지 한 엔드포인트에서 동시 노출됐다 — resource-actual 직접검증.
     if not await has_project_access(db, uuid.UUID(auth.user_id), project_id, org_id):
         raise HTTPException(status_code=404, detail="Project not found")
 
@@ -58,69 +248,16 @@ async def search_entities(
     search = f"%{q}%" if q else None
     results: list[EntitySearchResult] = []
 
-    if "story" in requested:
-        stmt = (
-            select(Story.id, Story.title, Story.status, Story.created_at)
-            .where(
-                Story.org_id == org_id,
-                Story.project_id == project_id,
-                Story.deleted_at.is_(None),
+    for entity_type in requested:
+        handler = _SEARCH_HANDLERS.get(entity_type)
+        if handler is None:
+            # ⛔registry엔 있는데 검색 handler가 없다 — "조용히 0건"으로 다시 넘기지 않는다
+            # (이번에 실제로 겪은 그 사고: 200/0건은 사용자에게 "그런 게 없다"로 읽힌다).
+            raise HTTPException(
+                status_code=500,
+                detail=f"Entity type '{entity_type}' is registered but has no search handler",
             )
-        )
-        if search:
-            stmt = stmt.where(Story.title.ilike(search))
-        stmt = stmt.order_by(Story.created_at.desc()).limit(DEFAULT_LIMIT)
-        rows = await db.execute(stmt)
-        for rid, title, st, cat in rows:
-            results.append(EntitySearchResult(entity_type="story", entity_id=rid, title=title, status=st, created_at=cat))
-
-    if "doc" in requested:
-        stmt = (
-            select(Doc.id, Doc.title, Doc.created_at)
-            .where(
-                Doc.org_id == org_id,
-                Doc.project_id == project_id,
-                Doc.deleted_at.is_(None),
-            )
-        )
-        if search:
-            stmt = stmt.where(Doc.title.ilike(search))
-        stmt = stmt.order_by(Doc.created_at.desc()).limit(DEFAULT_LIMIT)
-        rows = await db.execute(stmt)
-        for rid, title, cat in rows:
-            results.append(EntitySearchResult(entity_type="doc", entity_id=rid, title=title, created_at=cat))
-
-    if "epic" in requested:
-        stmt = (
-            select(Goal.id, Goal.title, Goal.status, Goal.created_at)
-            .where(
-                Goal.org_id == org_id,
-                Goal.project_id == project_id,
-            )
-        )
-        if search:
-            stmt = stmt.where(Goal.title.ilike(search))
-        stmt = stmt.order_by(Goal.created_at.desc()).limit(DEFAULT_LIMIT)
-        rows = await db.execute(stmt)
-        for rid, title, st, cat in rows:
-            results.append(EntitySearchResult(entity_type="epic", entity_id=rid, title=title, status=st, created_at=cat))
-
-    if "task" in requested:
-        stmt = (
-            select(Task.id, Task.title, Task.status, Task.created_at)
-            .join(Story, Task.story_id == Story.id)
-            .where(
-                Task.org_id == org_id,
-                Story.project_id == project_id,
-                Task.deleted_at.is_(None),
-            )
-        )
-        if search:
-            stmt = stmt.where(Task.title.ilike(search))
-        stmt = stmt.order_by(Task.created_at.desc()).limit(DEFAULT_LIMIT)
-        rows = await db.execute(stmt)
-        for rid, title, st, cat in rows:
-            results.append(EntitySearchResult(entity_type="task", entity_id=rid, title=title, status=st, created_at=cat))
+        results.extend(await handler(db, org_id, project_id, search))
 
     if search:
         results.sort(key=lambda r: r.title.lower())

--- a/backend/tests/test_2294_entities_search_open_4_types_realdb.py
+++ b/backend/tests/test_2294_entities_search_open_4_types_realdb.py
@@ -1,0 +1,423 @@
+"""story #2294 B단계 후속(E-CONNECT, 2026-07-29) — "받아들이는 것"(entities.py `_valid_types`,
+registry에서 파생)과 "찾는 것"(`_SEARCH_HANDLERS`)이 갈리는 것을 오르테가가 라이브로 잡았다:
+`types=sprint` 등이 400이 아니라 200/0건으로 «받아들여지기»는 했지만 실제 SELECT 분기가
+없어 데이터가 있어도(양성대조: sprint 16개 실재) 조용히 0건을 냈다.
+
+처방: `_SEARCH_HANDLERS`(entity_type→검색 handler SSOT dict) 신설 + registry에 있는데
+handler가 없으면 500(조용히 0건 금지) + twin-key 테스트(#2283이 세운 그 자와 동형)로
+"registry에 있는데 검색이 못 찾는 종류가 0"인 것을 고정.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _make_org(session, name="Org"):
+    from app.models.organization import Organization
+    org = Organization(id=uuid.uuid4(), name=name, slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    return org
+
+
+async def _make_project(session, org_id, name="P"):
+    from app.models.project import Project
+    project = Project(id=uuid.uuid4(), org_id=org_id, name=name)
+    session.add(project)
+    await session.commit()
+    return project
+
+
+async def _make_human_member(session, org_id, project_id):
+    from app.models.user import User
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.member import Member
+
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="member")
+    session.add(om)
+    await session.flush()
+    m = Member(id=om.id, org_id=org_id, type="human", user_id=user.id, name="Human")
+    session.add(m)
+    await session.flush()
+    session.add(ProjectAccess(project_id=project_id, org_member_id=om.id, member_id=m.id, role="member"))
+    await session.commit()
+    return m.id, user.id
+
+
+async def _make_story(session, org_id, project_id, title="Story"):
+    from app.models.pm import Story
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status="backlog")
+    session.add(story)
+    await session.commit()
+    return story
+
+
+async def _make_sprint(session, org_id, project_id, title="Findable Sprint"):
+    from app.models.pm import Sprint
+    sprint = Sprint(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(sprint)
+    await session.commit()
+    return sprint
+
+
+async def _make_artifact(session, org_id, project_id, title="Findable Artifact"):
+    from app.models.visual_artifact import VisualArtifact
+    artifact = VisualArtifact(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(artifact)
+    await session.commit()
+    return artifact
+
+
+async def _make_hypothesis(session, org_id, project_id, owner_member_id, statement="Findable Hypothesis"):
+    from app.models.hypothesis import Hypothesis
+    hyp = Hypothesis(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, owner_member_id=owner_member_id,
+        statement=statement, metric_definition={}, measure_after=datetime.now(timezone.utc),
+    )
+    session.add(hyp)
+    await session.commit()
+    return hyp
+
+
+async def _make_evidence(session, org_id, work_item_id, work_item_type, created_by, ref="https://findable.example"):
+    from app.models.evidence import Evidence
+    ev = Evidence(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=work_item_id, work_item_type=work_item_type,
+        type="url", ref=ref, created_by=created_by,
+    )
+    session.add(ev)
+    await session.commit()
+    return ev
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ─── twin-key — 「받아들이는 것」과 「찾는 것」이 같은 집합인지 ─────────────────
+
+
+def test_search_handlers_keys_match_entity_resolvers():
+    """⭐#2283이 세운 twin-key 원칙과 동형 — registry(ENTITY_RESOLVERS)에 있는데
+    _SEARCH_HANDLERS에 없는 종류가 «0»인 것을 고정한다. 한쪽만 열리면 이 테스트가 RED."""
+    from app.routers.entities import _SEARCH_HANDLERS
+    from app.services.reference_registry import ENTITY_RESOLVERS
+
+    assert set(_SEARCH_HANDLERS) == set(ENTITY_RESOLVERS)
+
+
+@pytest.mark.anyio
+async def test_search_rejects_registered_type_without_handler_instead_of_silent_zero():
+    """⛔registry엔 있는데 handler가 없는 상태를 인위로 만들어(sabotage) 500이 나는지 —
+    "조용히 0건"으로 다시 새지 않는다는 것을 직접 증명한다(RED→GREEN 자체검증과 동형)."""
+    import app.routers.entities as entities_module
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+
+        original_handlers = dict(entities_module._SEARCH_HANDLERS)
+        del entities_module._SEARCH_HANDLERS["sprint"]  # registry엔 여전히 있음(sabotage 지점)
+        try:
+            await _setup_app_human(app, Session, user_id, org.id)
+            client = _client_for(app)
+            try:
+                resp = await client.get(
+                    "/api/v2/entities/search",
+                    params={"project_id": str(project.id), "types": "sprint"},
+                )
+                assert resp.status_code == 500, (
+                    f"handler 없는 registry 타입이 조용히 통과했다(200이면 사고 재발) — {resp.status_code}: {resp.text}"
+                )
+            finally:
+                await client.aclose()
+                app.dependency_overrides.clear()
+        finally:
+            entities_module._SEARCH_HANDLERS.clear()
+            entities_module._SEARCH_HANDLERS.update(original_handlers)
+
+        # 원복 후 GREEN 재확認 — 같은 요청이 정상 200을 낸다.
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/entities/search",
+                params={"project_id": str(project.id), "types": "sprint"},
+            )
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── 양성대조 — 각 타입이 실제로 검색되는지(오르테가가 겪은 정확한 그 시나리오) ──
+
+
+@pytest.mark.anyio
+async def test_search_finds_sprint_with_data_present():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+            sprint = await _make_sprint(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/entities/search",
+                params={"project_id": str(project.id), "types": "sprint", "q": "Findable"},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert any(r["entity_id"] == str(sprint.id) and r["entity_type"] == "sprint" for r in body)
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_search_finds_artifact_with_data_present():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+            artifact = await _make_artifact(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/entities/search",
+                params={"project_id": str(project.id), "types": "artifact", "q": "Findable"},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert any(r["entity_id"] == str(artifact.id) and r["entity_type"] == "artifact" for r in body)
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_search_finds_hypothesis_with_data_present():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            hyp = await _make_hypothesis(s, org.id, project.id, member_id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/entities/search",
+                params={"project_id": str(project.id), "types": "hypothesis", "q": "Findable"},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert any(r["entity_id"] == str(hyp.id) and r["entity_type"] == "hypothesis" for r in body)
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_search_finds_evidence_via_story_work_item_with_data_present():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id)
+            ev = await _make_evidence(s, org.id, story.id, "story", member_id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/entities/search",
+                params={"project_id": str(project.id), "types": "evidence", "q": "findable"},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert any(r["entity_id"] == str(ev.id) and r["entity_type"] == "evidence" for r in body)
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_search_finds_evidence_via_task_work_item_with_data_present():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            from app.models.pm import Task
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id)
+            task = Task(id=uuid.uuid4(), org_id=org.id, story_id=story.id, title="T", status="todo")
+            s.add(task)
+            await s.commit()
+            ev = await _make_evidence(s, org.id, task.id, "task", member_id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/entities/search",
+                params={"project_id": str(project.id), "types": "evidence", "q": "findable"},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert any(r["entity_id"] == str(ev.id) and r["entity_type"] == "evidence" for r in body)
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_search_all_eight_types_in_one_request_when_no_types_filter():
+    """⭐오르테가가 예고한 다음 시험 — 여덟 종류를 한 요청(types 생략=전체)에 박아 재는 것과
+    같은 모양. 각 타입 1건씩 심고 응답에 여덟 다 있는지 본다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, title="ZZZ Story")
+            sprint = await _make_sprint(s, org.id, project.id, title="ZZZ Sprint")
+            artifact = await _make_artifact(s, org.id, project.id, title="ZZZ Artifact")
+            hyp = await _make_hypothesis(s, org.id, project.id, member_id, statement="ZZZ Hypothesis")
+            ev = await _make_evidence(s, org.id, story.id, "story", member_id, ref="https://zzz.example")
+
+            from app.models.doc import Doc
+            doc = Doc(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="ZZZ Doc", slug=f"zzz-{uuid.uuid4().hex[:8]}")
+            s.add(doc)
+            from app.models.pm import Goal, Task
+            epic = Goal(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="ZZZ Epic", status="active")
+            s.add(epic)
+            task = Task(id=uuid.uuid4(), org_id=org.id, story_id=story.id, title="ZZZ Task", status="todo")
+            s.add(task)
+            await s.commit()
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/entities/search",
+                params={"project_id": str(project.id), "q": "ZZZ"},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            found_types = {r["entity_type"] for r in body}
+            assert found_types == {"story", "doc", "epic", "task", "sprint", "artifact", "hypothesis", "evidence"}, (
+                f"여덟 종류가 다 안 나왔다: {found_types}"
+            )
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 배경 — 오르테가 라이브 실측(배포 착지 확認, SHA=353bd857=develop HEAD=#2589 머지 커밋)

```
GET /api/v2/entities/search?project_id=…&types=<종류>
  sprint      → 0건      artifact    → 0건
  hypothesis  → 0건      evidence    → 0건
  task        → 10건 ✅  (doc·story·epic 도 나오는)
```

양성대조(`sprintable_list_sprints` → 이 프로젝트에 스프린트 16개 실재)로 "데이터가 없어서
0건"이 아니라 "검색이 못 찾는" 것임을 실증. `types=sprint`가 400이 아니라 200/0건인 것은
`_valid_types()`(registry에서 파생, #2294 AC1)가 정확히 동작해 그 타입을 "받아들이는" 것은
맞지만, 실제 SELECT 분기가 없어 데이터가 있어도 조용히 빈 결과를 냈다. **"저장은 8종·검색은
4종"** — 400도 에러도 아닌 "조용히 0건"은 사용자에게 "그런 게 없다"로 읽힌다.

## 구현
`entities.py`의 if/elif 나열을 `_SEARCH_HANDLERS`(entity_type→검색 handler) SSOT dict로
리팩터 — `reference_registry.py`의 `ENTITY_RESOLVERS`/`PROJECT_ID_RESOLVERS`와 동형 원칙
(같은 축을 두 개의 별도 dict로 갈라 "한쪽만 추가"를 구조적으로 노출시킨다). 4종 SELECT
분기 신설:
- **sprint·artifact** — `title` 칼럼 직접 존재(doc/story와 동형).
- **hypothesis** — `title` 칼럼이 없다(모델 §2.2.4 "유일한 수동 텍스트 입력"인 `statement`가
  대응 필드).
- **evidence** — `project_id`도 `title`도 없다(`work_item_id`/`work_item_type` 폴리모픽
  참조, `ref`가 유일한 NOT NULL 자유텍스트) — story-경유·task-경유 두 join을 각각 돌려
  합친다(`reference_registry._project_id_of_evidence`와 동일 스코핑 축 재사용, 재구현 0).

registry에 있는데 `_SEARCH_HANDLERS`에 handler가 없으면(재발 방어) **500**을 던진다 —
"받는데 못 찾는" 상태를 다시는 침묵시키지 않는다.

## 검증
- **twin-key 테스트** — `_SEARCH_HANDLERS` 키 집합 == `ENTITY_RESOLVERS` 키 집합. #2283이
  세운 그 원칙과 동형(한쪽만 열리면 RED).
- **RED→GREEN 자체검증** — `_SEARCH_HANDLERS`에서 `"sprint"`를 in-test로 제거(registry엔
  여전히 있음) → 500 확認 → 원복 → 200 재확認.
- **양성대조 5개** — sprint/artifact/hypothesis/evidence(story 경유·task 경유 둘 다) 각각
  데이터를 심고 실제로 검색되는지 개별 확認(오르테가가 겪은 정확한 시나리오 재현).
- **"여덟 종류를 한 요청에"** — `types` 생략(전체)으로 여덟 종류 각 1건씩 심어 응답에 전부
  있는지 확認(오르테가가 예고한 다음 라이브 시험과 동형 시나리오를 미리 봉인).
- 회귀 321개 GREEN(mention/backlinks/#2259~#2294/docs/stories/conversations/evidence/
  sprints/hypotheses 관련 스위트).

⛔`#2589`는 이미 머지된 상태 — 저장 축은 그대로 두고 검색 축만 여는 것(되돌릴 일 아님).

## 롤백
`_SEARCH_HANDLERS`에서 4개 handler(sprint/artifact/hypothesis/evidence) 제거 +
`_search_*` 함수 4개 삭제하면 순수 revert(기존 4종 검색 동작 무변경).