### PR TITLE
fix(#2299, E-CONNECT): 끊어진 backlink source를 조용히 빼지 않고 still_exists로 표시

### DIFF
--- a/backend/app/services/backlinks.py
+++ b/backend/app/services/backlinks.py
@@ -326,8 +326,31 @@ async def list_entity_backlinks(
 
     반환: `{"data": [...], "meta": {"next_cursor": str|None, "has_more": bool}}` — list_messages와
     동일 shape(AC1 "same convention"). data 항목: {id, source_type, source_id, created_by,
-    created_at, doc: {id,title}|None, message: {id,conversation_id,content_snippet,sender}|None}.
-    `created_by`는 raw UUID가 아니라 `{id,name,type}`|None(sender와 동형 처리 — Extra fix).
+    created_at, still_exists, doc: {id,title}|None, message: {id,conversation_id,content_snippet,
+    sender}|None}. `created_by`는 raw UUID가 아니라 `{id,name,type}`|None(sender와 동형 처리 —
+    Extra fix).
+
+    `still_exists`(story #2299, E-CONNECT — "끊어진 참조 가시성" 배선): 이 backlink item의
+    **SOURCE**(target이 아니다 — target은 URL의 id 자신이고, 이 함수에 도달했다는 것 자체가
+    호출부의 404 게이트를 통과했다는 뜻이라 항상 존재한다. "끊어짐"이 있을 수 있는 쪽은
+    source뿐이다)가 아직 살아 있는지. doc source는 soft-delete 여부(`Doc.deleted_at`)로
+    판정 — 예전엔 이 조건이 JOIN에 있어 삭제된 source가 결과에서 통째로 빠졌다(PO가 "조용히
+    사라지는 것"으로 재판정, `test_soft_deleted_source_doc_excluded` 개정). chat_message
+    source는 SOURCE_ONLY_TYPES(불변, soft-delete 없음)라 항상 True — genuinely-missing
+    message row(하드삭제/오손 데이터)는 이 필드가 다루는 대상이 아니고 여전히 결과에서
+    제외된다(`test_missing_source_message_excluded_no_crash`, 이 스토리가 안 건드림 —
+    "삭제 lifecycle"과 "오손 데이터"는 다른 문제).
+
+    ⛔story #2299 AC⑥(이 판이 못 잡는 것 선언):
+      · `reference_core.list_references`는 여전히 아무도 안 부른다(#2591이 증명한 채 그대로 —
+        이 story는 그 함수를 살리지 않았다, PO 판정대로 "안 도는 문"을 살리는 대신 여기
+        `list_entity_backlinks`에 별도로 얹었다. `list_references`를 살릴지는 별건).
+      · story/task 등 doc이 아닌 source_type은 이 함수가 애초에 다루지 않는다(위 docstring
+        "source_type은 chat_message·doc 뿐" — still_exists도 그 두 종류에만 존재).
+      · target 자신이 이 응답 처리 도중(요청과 요청 사이가 아니라 같은 요청 내에서) 삭제되는
+        TOCTOU 창은 다루지 않는다(호출부의 404 게이트가 요청 시작 시점 1회 확인 — 그 이후
+        target 삭제는 이 응답에 반영 안 됨, 기존 backlinks 전체의 기존 계약과 동일).
+
     `next_cursor`는 opaque composite base64 토큰(B3) — `before` query param에 그대로 되돌려준다.
     """
     if target_type not in BACKLINKS_ALLOWED_TARGET_TYPES:
@@ -396,6 +419,16 @@ async def list_entity_backlinks(
             Reference,
             Doc.project_id.label("doc_project_id"),
             Doc.title.label("doc_title"),
+            # ⛔story #2299(E-CONNECT, PO 판정 2026-07-29): 여기 있던 `Doc.deleted_at.is_(None)`이
+            # JOIN ON절에서 soft-deleted source doc을 "매치 실패"로 만들어 project_id가 NULL이
+            # 되고, 그 결과 아래 WHERE의 authz 체크(project_access_valid_correlated)가 NULL
+            # project에 대해 무조건 거짓이 되어 행 자체가 결과에서 «조용히» 빠졌다(`test_soft_
+            # deleted_source_doc_excluded`가 그걸 "정답"으로 고정하고 있었다 — PO가 그 자체를
+            # 버그로 재판정: "목록에서 빼면 그게 바로 조용히 사라지는 것"). deleted_at 조건을
+            # JOIN에서 빼 soft-deleted 문서도 매치되게 하고(그래야 project_id가 살아서 authz가
+            # 원래 프로젝트 기준으로 정상 평가된다 — 삭제됐다고 접근권 검사가 사라지면 안 된다),
+            # 대신 deleted_at 자체를 별도 컬럼으로 select해 still_exists 판정에 쓴다.
+            Doc.deleted_at.label("doc_deleted_at"),
             ConversationMessage.conversation_id.label("msg_conversation_id"),
             ConversationMessage.content.label("msg_content"),
             ConversationMessage.sender_id.label("msg_sender_id"),
@@ -407,7 +440,6 @@ async def list_entity_backlinks(
                 Doc.id == Reference.source_id,
                 Reference.source_type == "doc",
                 Doc.org_id == org_id,
-                Doc.deleted_at.is_(None),  # soft-deleted source doc 배제
             ),
         )
         .outerjoin(
@@ -481,9 +513,14 @@ async def list_entity_backlinks(
             "created_at": m.created_at.isoformat(),
             "doc": None,
             "message": None,
+            # story #2299 AC⑤: 「끊어짐」은 색/경고가 아니라 사실 필드다 — 렌더(색·문구)는 FE
+            # 몫. chat_message는 SOURCE_ONLY_TYPES(불변·soft-delete 없음, reference_registry.py
+            # 참조)라 항상 True — doc만 아래서 실제 판정으로 덮어쓴다.
+            "still_exists": True,
         }
         if m.source_type == "doc":
             item["doc"] = {"id": str(m.source_id), "title": r.doc_title}
+            item["still_exists"] = r.doc_deleted_at is None
         elif m.source_type == "chat_message":
             sender = member_map.get(r.msg_sender_id) if r.msg_sender_id is not None else None
             item["message"] = {

--- a/backend/tests/test_1994_backlink_api_realdb.py
+++ b/backend/tests/test_1994_backlink_api_realdb.py
@@ -712,9 +712,21 @@ async def test_soft_deleted_source_doc_stays_marked_broken_not_excluded():
     """⭐PO 재판정(2026-07-29, story #2299): 이 테스트의 원래 이름은
     `test_soft_deleted_source_doc_excluded`였고 "삭제된 source는 결과에서 빠진다"를 정답으로
     고정하고 있었다 — PO가 그 자체를 「조용히 사라지는 것」버그로 재분류했다(#2591이 증명한
-    "still_exists는 있는데 내주는 길이 없다"의 배선 완료판). 이제는 반대를 고정한다: 행은
-    남고(①) `still_exists`가 정확히 갈린다(②양성대조 — 같은 응답에 살아있는 것과 죽은 것이
-    같이 있고, 살아있는 쪽엔 「끊어짐」 표기가 없다=still_exists true).
+    "still_exists는 있는데 내주는 길이 없다"의 배선 완료판).
+
+    ⛔왜 옛 기대가 틀렸는가(재분류 근거 — «누락»이 아니라 «authz 부작용»이었다): 옛 쿼리는
+    soft-deleted source doc을 JOIN **ON절**의 `Doc.deleted_at.is_(None)`로 걸렀다 — JOIN이
+    매치 실패하면 `Doc.project_id`가 NULL이 되고, WHERE절의 authz 체크
+    (`project_access_valid_correlated(Doc.project_id, ...)`)가 그 NULL에 대해 무조건
+    거짓으로 평가되어 행 자체가 결과에서 빠졌다. 즉 "삭제된 걸 의도적으로 숨긴 필터"가 아니라
+    "존재 판정을 authz 체크에 얹었다가 그 authz가 실패한" 부작용 — `still_exists` 필드만
+    얹고 이 JOIN을 안 고쳤으면 여전히 안 보였을 것이다. 그래서 deleted_at 조건을 JOIN에서
+    빼(project_id를 살려 authz가 원래 프로젝트 기준으로 정상 평가되게) 별도 select한
+    deleted_at으로 still_exists를 판정한다(위 `list_entity_backlinks` 코드 주석 참조).
+
+    이제는 반대를 고정한다: 행은 남고(①) `still_exists`가 정확히 갈린다(②양성대조 — 같은
+    응답에 살아있는 것과 죽은 것이 같이 있고, 살아있는 쪽엔 「끊어짐」 표기가 없다=still_exists
+    true).
 
     ⛔③대체 선언: 라이브로 실 `DELETE /api/v2/docs/{id}`를 호출하지 않는다 — 그 엔드포인트도
     story 삭제(오르테가군이 오늘 직접 밟은 403)와 동형으로 휴먼 전용이다(`docs.py` delete_doc

--- a/backend/tests/test_1994_backlink_api_realdb.py
+++ b/backend/tests/test_1994_backlink_api_realdb.py
@@ -705,10 +705,22 @@ async def test_pagination_has_more_false_and_no_next_cursor_when_all_fit_one_pag
         await engine.dispose()
 
 
-# ─── (e) soft-deleted / 미존재 source 제외 ──────────────────────────────────────
+# ─── (e) soft-deleted source doc — story #2299 재판정: 빼지 말고 still_exists=false로 표시 ──
 
 
-async def test_soft_deleted_source_doc_excluded():
+async def test_soft_deleted_source_doc_stays_marked_broken_not_excluded():
+    """⭐PO 재판정(2026-07-29, story #2299): 이 테스트의 원래 이름은
+    `test_soft_deleted_source_doc_excluded`였고 "삭제된 source는 결과에서 빠진다"를 정답으로
+    고정하고 있었다 — PO가 그 자체를 「조용히 사라지는 것」버그로 재분류했다(#2591이 증명한
+    "still_exists는 있는데 내주는 길이 없다"의 배선 완료판). 이제는 반대를 고정한다: 행은
+    남고(①) `still_exists`가 정확히 갈린다(②양성대조 — 같은 응답에 살아있는 것과 죽은 것이
+    같이 있고, 살아있는 쪽엔 「끊어짐」 표기가 없다=still_exists true).
+
+    ⛔③대체 선언: 라이브로 실 `DELETE /api/v2/docs/{id}`를 호출하지 않는다 — 그 엔드포인트도
+    story 삭제(오르테가군이 오늘 직접 밟은 403)와 동형으로 휴먼 전용이다(`docs.py` delete_doc
+    `deleter.type != "human"` → 403, 에이전트 API키 차단). 그래서 여기선 realdb에 `Doc.deleted_
+    at`를 직접 심어(soft-delete 상태를 만들어) 대체한다 — 라이브 시도가 막혀서가 아니라
+    애초에 이 caller(에이전트)로는 시도 자체가 불가능하다는 뜻."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -733,8 +745,13 @@ async def test_soft_deleted_source_doc_excluded():
             resp = await client.get(f"/api/v2/docs/{target_doc.id}/backlinks")
             assert resp.status_code == 200, resp.text
             body = resp.json()
+            # ①행 잔존 — 둘 다 결과에 있다(하나가 빠지면 그게 「조용히 사라지는 것」).
             ids = {item["source_id"] for item in body["data"]}
-            assert ids == {str(live_source.id)}, body
+            assert ids == {str(deleted_source.id), str(live_source.id)}, body
+            # ②양성대조 — 같은 응답 안에서 갈린다(전부 True/False면 판별력 0).
+            still_exists_by_id = {item["source_id"]: item["still_exists"] for item in body["data"]}
+            assert still_exists_by_id[str(deleted_source.id)] is False
+            assert still_exists_by_id[str(live_source.id)] is True
         finally:
             await client.aclose()
     finally:


### PR DESCRIPTION
## Summary
- #2591이 증명한 "still_exists는 계산되는데 내주는 길이 없다"(`list_references` zero callers)를 배선 완료 — `list_references`를 살리는 대신 이미 도는 `GET /stories|docs/{id}/backlinks`에 얹었다(새 라우트 0개, `app/routers/` diff 없음).
- `list_entity_backlinks`가 soft-deleted source doc을 JOIN ON절 `deleted_at` 필터로 조용히 제외하던 기존 동작을 재판정 — 이제 행은 남고(①) `still_exists: bool` per-item으로 갈린다(②양성대조: 같은 응답 안에 살아있는 것/죽은 것 공존).
- chat_message source는 불변(soft-delete 없음)이라 항상 `still_exists: true`.

## AC 대응
- ①행 잔존: `test_soft_deleted_source_doc_stays_marked_broken_not_excluded`
- ②양성대조: 같은 테스트, 살아있는 것/죽은 것 동시 확인
- ③라이브 delete 403 대체 선언: `DELETE /api/v2/docs/{id}`도 휴먼 전용(에이전트 403, story와 동형) — realdb에 `deleted_at` 직접 시드로 대체, 테스트 docstring에 명시
- ④새 라우트 0개: `app/routers/` diff 0줄(서비스 함수 1개 + 테스트 1개만 변경)
- ⑤사실 필드: `still_exists: bool`만 노출, 색/문구는 FE 몫
- ⑥이 판이 못 잡는 것: `list_entity_backlinks` docstring에 명시(`list_references` 여전히 zero callers·doc 외 source_type 미대상·요청 내 target TOCTOU)

## Test plan
- [x] RED→GREEN 자가검증: `still_exists` always-True로 sabotage → 새 테스트 실패 확인 → 원복
- [x] 실PG(alembic head까지 migrate)로 `test_1994_backlink_api_realdb.py` + `test_2266_story_backlinks_realdb.py` 50/50 통과
- [x] `test_2259_ac4_broken_reference_visibility_realdb.py` + `test_2259_entity_references_realdb.py` 28/28 통과(무관 회귀 없음 확인)
- [x] 전체 backend 회귀(realdb 제외) 4208 pass, 6 fail(모두 로컬 MCP path/instance-count 환경설정 테스트 — backlinks/reference 무관 확인, pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)