### PR TITLE
feat(#2268, E-CONNECT D단계): judgments 테이블+pull 엔드포인트 — 판단 칸

### DIFF
--- a/backend/alembic/versions/0214_judgments.py
+++ b/backend/alembic/versions/0214_judgments.py
@@ -1,0 +1,65 @@
+"""story #2268(D단계, E-CONNECT — "판단 칸") — judgments 테이블 신설.
+
+순수 additive — 신규 테이블뿐, 기존 테이블/데이터 손상 0. `app/models/judgment.py` 모듈
+docstring에 전체 설계 배경(두 층·work_item_ids 셋 근거·scope 명시화 이유) 있음.
+
+Revision ID: 0214
+Revises: 0213
+Create Date: 2026-07-29
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0214"
+down_revision = "0213"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "judgments",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("scope", sa.String(20), nullable=False),
+        sa.Column(
+            "work_item_ids", postgresql.ARRAY(postgresql.UUID(as_uuid=True)),
+            nullable=False, server_default="{}",
+        ),
+        sa.Column("kind", sa.String(20), nullable=False),
+        sa.Column("target_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("method", sa.Text(), nullable=True),
+        sa.Column("statement", sa.Text(), nullable=False),
+        sa.Column("created_by", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "kind IN ('judgment', 'method_error', 'refinement', 'retraction', 'unmeasurable')",
+            name="ck_judgments_kind",
+        ),
+        sa.CheckConstraint("scope IN ('general', 'items')", name="ck_judgments_scope"),
+        sa.CheckConstraint(
+            "(scope = 'general' AND work_item_ids = '{}') OR "
+            "(scope = 'items' AND work_item_ids <> '{}')",
+            name="ck_judgments_scope_work_item_ids_pairing",
+        ),
+        sa.CheckConstraint(
+            "(kind NOT IN ('retraction', 'refinement', 'method_error')) OR (target_id IS NOT NULL)",
+            name="ck_judgments_target_required_for_meta_kinds",
+        ),
+        sa.ForeignKeyConstraint(["target_id"], ["judgments.id"], name="fk_judgments_target_id_judgments"),
+    )
+    op.create_index("ix_judgments_org", "judgments", ["org_id"])
+    op.create_index(
+        "ix_judgments_work_item_ids", "judgments", ["work_item_ids"], postgresql_using="gin",
+    )
+    op.create_index("ix_judgments_target", "judgments", ["target_id"])
+    op.create_index("ix_judgments_method", "judgments", ["org_id", "method"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_judgments_method", table_name="judgments")
+    op.drop_index("ix_judgments_target", table_name="judgments")
+    op.drop_index("ix_judgments_work_item_ids", table_name="judgments")
+    op.drop_index("ix_judgments_org", table_name="judgments")
+    op.drop_table("judgments")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -169,7 +169,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import a2a, account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, deeplink_manifest, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, device_installations, dispatch, docs, entities, goals, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, project_access, project_settings, projects, public_docs, references, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import a2a, account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, deeplink_manifest, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, device_installations, dispatch, docs, entities, goals, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, judgments, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, project_access, project_settings, projects, public_docs, references, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 # 도메인 축 B(org-1st-class-surface-ia-design-b §3): OpenAPI 태그 조직-우선 위계.
 # 개별 라우터는 기존 세부 tag(예 "stories")를 그대로 유지하고 이 4축 태그를 추가로 보유(다중
@@ -309,6 +309,7 @@ app.include_router(trust_scores.router)
 app.include_router(hitl_config.router)
 app.include_router(gates.router)
 app.include_router(evidence.router)
+app.include_router(judgments.router)
 app.include_router(github_integration.router)
 app.include_router(gate_config.router)
 app.include_router(gate_config.org_router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -20,6 +20,7 @@ from app.models.event_outbox import EventOutbox
 from app.models.gate import Gate
 from app.models.github_installation import GithubInstallation, GithubInstallNonce, GithubWebhookDelivery
 from app.models.hitl import HitlPolicy, HitlRequest
+from app.models.judgment import Judgment
 from app.models.mockup import MockupComponent, MockupPage, MockupScenario, MockupVersion, UsageMeter
 from app.models.user import RefreshToken, User
 from app.models.workflow_version import WorkflowVersion

--- a/backend/app/models/judgment.py
+++ b/backend/app/models/judgment.py
@@ -1,0 +1,79 @@
+"""story #2268(D단계, E-CONNECT — "판단 칸") — 판정/철회/정련/측정법오류를 Evidence 옆에
+1급으로 세운다. Evidence type 확장이 아니다(오르테가 판정, 2026-07-29): batch_has_evidence·
+GET /evidence·glance proof_count 등 무필터 카운트 자리가 셋 실재해, Evidence에 얹으면
+「못 쟀다」가 「증거 있음」으로 잘못 읽힌다.
+
+두 층(유나 판정):
+  ㉠원래 낸 말   judgment(판정+근거) · unmeasurable(못 잰 것과 왜) — 스스로 서므로 target_id 불요.
+  ㉡앞선 말에 대한 말 retraction(철회) · refinement(정련) · method_error(세는 법이 틀림)
+    — target_id 필수(무엇에 대한 말인지 없는 메타-말은 저장 자체를 막는다).
+
+work_item_ids는 오늘 실측 근거 셋 위에 설계(대화 스레드 7256d5cc, 2026-07-29):
+  (a) 여러 story에 «걸치는» 교훈(twin-system drift류) — 단일 FK로는 못 세운다.
+  (b) 특정 story와 무관한 일반 프로세스 교훈(예: "부분 체크만 보고 끝났다 판단") — 「어디에도
+      안 붙는」 것이 정당한 상태.
+  (c) 특정 하나에만 붙는 사례.
+`scope`(items|general)을 명시 필드로 두는 이유: 빈 배열이 "어디에도 안 붙는 것"(b)과
+"아직 안 붙인 것"(입력 누락)을 구별 못 하는 함정 — 추론 금지, 선언으로 받는다.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, DateTime, Index, String, Text, func
+from sqlalchemy.dialects.postgresql import ARRAY, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+JUDGMENT_KINDS = frozenset({"judgment", "unmeasurable", "retraction", "refinement", "method_error"})
+# ㉡ — 앞선 말에 대한 말. target_id NOT NULL을 요구하는 축(스키마 레벨 강제 — "무엇을
+# 철회하는지 모르는 철회"가 저장되는 것을 원천 차단).
+TARGET_REQUIRED_KINDS = frozenset({"retraction", "refinement", "method_error"})
+JUDGMENT_SCOPES = frozenset({"items", "general"})
+
+
+class Judgment(Base):
+    __tablename__ = "judgments"
+
+    __table_args__ = (
+        CheckConstraint(f"kind IN {tuple(sorted(JUDGMENT_KINDS))}", name="ck_judgments_kind"),
+        CheckConstraint(f"scope IN {tuple(sorted(JUDGMENT_SCOPES))}", name="ck_judgments_scope"),
+        # scope='general'이면 work_item_ids는 반드시 빈 배열(=진짜로 어디에도 안 붙음),
+        # scope='items'면 반드시 비어있지 않음(=붙이는 걸 깜빡한 상태를 CHECK가 즉시 거절).
+        CheckConstraint(
+            "(scope = 'general' AND work_item_ids = '{}') OR "
+            "(scope = 'items' AND work_item_ids <> '{}')",
+            name="ck_judgments_scope_work_item_ids_pairing",
+        ),
+        CheckConstraint(
+            "(kind NOT IN ('retraction', 'refinement', 'method_error')) OR (target_id IS NOT NULL)",
+            name="ck_judgments_target_required_for_meta_kinds",
+        ),
+        Index("ix_judgments_org", "org_id"),
+        Index("ix_judgments_work_item_ids", "work_item_ids", postgresql_using="gin"),
+        Index("ix_judgments_target", "target_id"),
+        Index("ix_judgments_method", "org_id", "method"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    scope: Mapped[str] = mapped_column(String(20), nullable=False)
+    work_item_ids: Mapped[list[uuid.UUID]] = mapped_column(
+        ARRAY(UUID(as_uuid=True)), nullable=False, server_default="{}"
+    )
+    kind: Mapped[str] = mapped_column(String(20), nullable=False)
+    # 자기참조(judgments.id) — ㉡의 "앞선 말". FK는 마이그레이션에서 건다(모델은 컬럼만
+    # 선언 — 순환 자기참조 FK는 SQLAlchemy Core에서 문자열 타겟으로도 표현 가능하나, 이
+    # 프로젝트 관례(entity_references 등)가 폴리모픽 대상엔 FK를 안 거는 쪽이라 여기도
+    # 같은 테이블 자기참조는 명시 FK로 마이그레이션에 남긴다).
+    target_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    # "어떤 방법으로 쟀는가" — method_error가 "같은 방법으로 낸 다른 말들"을 역추적하는 축
+    # (오르테가 명시 요구, 2026-07-29). 자유 텍스트(방법 taxonomy는 아직 없음 — 과확장 금지).
+    method: Mapped[str | None] = mapped_column(Text, nullable=True)
+    statement: Mapped[str] = mapped_column(Text, nullable=False)
+    created_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/routers/judgments.py
+++ b/backend/app/routers/judgments.py
@@ -1,0 +1,104 @@
+"""story #2268(D단계, E-CONNECT — "판단 칸"). AC(오르테가, 2026-07-29, 스레드 7256d5cc):
+pull 전용 — 「물으면 준다」, push 금지. 자세한 배경은 `app/models/judgment.py`·
+`app/services/judgment_core.py` 모듈 docstring 참조.
+
+⛔이 판이 못 잡는 것(AC⑦, 명시 선언): progress.txt를 실제로 지우는 것은 이 판의 몫이 아니다
+— 이 스토리는 판단/철회를 저장·조회하는 자리만 세운다. 판정 기준("철회를 다시 주장하지
+않는가")은 이 API 자체로는 못 잰다 — 그건 **다음 세션**에서 이 API를 실제로 pull해 쓰는
+에이전트의 행동으로만 관측 가능하다.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, ConfigDict
+
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.services.judgment_core import DEFAULT_ACTIVE_LIMIT, InvalidJudgmentError, create_judgment, list_judgments
+from sqlalchemy.ext.asyncio import AsyncSession
+
+router = APIRouter(prefix="/api/v2/judgments", tags=["judgments", "Work"])
+
+
+class CreateJudgmentRequest(BaseModel):
+    scope: str
+    work_item_ids: list[uuid.UUID] = []
+    kind: str
+    target_id: uuid.UUID | None = None
+    method: str | None = None
+    statement: str
+
+
+class JudgmentResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    scope: str
+    work_item_ids: list[uuid.UUID]
+    kind: str
+    target_id: uuid.UUID | None
+    method: str | None
+    statement: str
+    created_by: uuid.UUID
+    created_at: datetime
+
+
+class JudgmentListMeta(BaseModel):
+    scope: str | None
+    capped: bool
+    cap_basis: str
+    omitted_count: int
+
+
+class JudgmentListResponse(BaseModel):
+    retractions: list[JudgmentResponse]
+    active: list[JudgmentResponse]
+    meta: JudgmentListMeta
+
+
+@router.post("", response_model=JudgmentResponse, status_code=201)
+async def create_judgment_endpoint(
+    body: CreateJudgmentRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> Any:
+    from app.services.member_resolver import resolve_member
+
+    caller = await resolve_member(auth, org_id, session)
+    try:
+        judgment = await create_judgment(
+            session,
+            org_id=org_id,
+            scope=body.scope,
+            work_item_ids=body.work_item_ids,
+            kind=body.kind,
+            target_id=body.target_id,
+            method=body.method,
+            statement=body.statement,
+            created_by=caller.id,
+        )
+    except InvalidJudgmentError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+    await session.commit()
+    return judgment
+
+
+@router.get("", response_model=JudgmentListResponse)
+async def list_judgments_endpoint(
+    work_item_id: uuid.UUID | None = Query(default=None),
+    method: str | None = Query(default=None),
+    scope: str | None = Query(default=None),
+    limit: int = Query(default=DEFAULT_ACTIVE_LIMIT, ge=1, le=200),
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> Any:
+    return await list_judgments(
+        session, org_id=org_id, work_item_id=work_item_id, method=method, scope=scope, limit=limit,
+    )

--- a/backend/app/services/judgment_core.py
+++ b/backend/app/services/judgment_core.py
@@ -1,0 +1,125 @@
+"""story #2268(D단계, E-CONNECT — "판단 칸") — judgments write/read 코어.
+
+AC(오르테가, 2026-07-29): pull 전용 — 「물으면 준다」, push 금지. `retractions`는 상한과
+무관하게 항상 전체(캡 예외 — "철회된 걸 다시 주장 안 하는가"가 이 판의 판정기준이므로 여기서
+잘리면 그 기준 자체가 무너진다). `active`(judgment/unmeasurable/refinement/method_error)는
+"다음 발 수" 기준으로 캡 — 지금 실측 가능한 랭킹 신호가 recency뿐이라 그걸로 자르고
+`meta.cap_basis`로 정직하게 선언한다(다른 신호 없으면 있는 척 안 함, #2266 backlinks의
+collection_scope 정직성 패턴과 동형).
+
+app-level 검증을 먼저 하는 이유(#2259 reference_core.insert_reference와 동일 패턴 — 이중
+방어): DB CHECK만 믿으면 실패 시 raw IntegrityError 텍스트가 그대로 API 밖으로 샌다. 여기서
+먼저 걸러 사람이 읽을 수 있는 메시지로 거절한다 — CHECK는 그래도 안 뺀다("코드가 아니라
+제약이 지킨다"가 이 판의 crux, 오르테가 표현).
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.judgment import JUDGMENT_KINDS, JUDGMENT_SCOPES, TARGET_REQUIRED_KINDS, Judgment
+
+DEFAULT_ACTIVE_LIMIT = 20
+
+
+class InvalidJudgmentError(ValueError):
+    """app-level 검증 실패 — 라우터가 422로 번역한다."""
+
+
+async def create_judgment(
+    session: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    scope: str,
+    work_item_ids: list[uuid.UUID],
+    kind: str,
+    target_id: uuid.UUID | None,
+    method: str | None,
+    statement: str,
+    created_by: uuid.UUID,
+) -> Judgment:
+    if kind not in JUDGMENT_KINDS:
+        raise InvalidJudgmentError(f"kind must be one of {sorted(JUDGMENT_KINDS)}")
+    if scope not in JUDGMENT_SCOPES:
+        raise InvalidJudgmentError(f"scope must be one of {sorted(JUDGMENT_SCOPES)}")
+    # ⛔scope↔work_item_ids 쌍 — 빈 배열의 "어디에도 안 붙는 것"과 "아직 안 붙인 것" 모호성을
+    # 여기서도 명확한 메시지로 막는다(DB CHECK가 최종 방어선, 이건 그 앞단).
+    if scope == "general" and work_item_ids:
+        raise InvalidJudgmentError("scope='general'이면 work_item_ids는 비어 있어야 합니다(일반 교훈)")
+    if scope == "items" and not work_item_ids:
+        raise InvalidJudgmentError("scope='items'면 work_item_ids가 최소 1개 필요합니다(아직 안 붙인 상태 금지)")
+    if kind in TARGET_REQUIRED_KINDS and target_id is None:
+        raise InvalidJudgmentError(
+            f"kind={kind!r}는 target_id가 필수입니다(무엇에 대한 말인지 모르는 {kind}는 저장 금지)"
+        )
+
+    if target_id is not None:
+        target_exists = (
+            await session.execute(
+                select(Judgment.id).where(Judgment.id == target_id, Judgment.org_id == org_id)
+            )
+        ).scalar_one_or_none()
+        if target_exists is None:
+            raise InvalidJudgmentError(f"target_id {target_id}가 이 org에 존재하지 않습니다")
+
+    judgment = Judgment(
+        id=uuid.uuid4(), org_id=org_id, scope=scope, work_item_ids=list(work_item_ids),
+        kind=kind, target_id=target_id, method=method, statement=statement,
+        created_by=created_by,
+    )
+    session.add(judgment)
+    await session.flush()
+    await session.refresh(judgment)
+    return judgment
+
+
+async def list_judgments(
+    session: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    work_item_id: uuid.UUID | None,
+    method: str | None,
+    scope: str | None,
+    limit: int = DEFAULT_ACTIVE_LIMIT,
+) -> dict:
+    """pull 진입점 코어. 세 축(work_item_id/method/scope)은 AND로 결합 — 필요한 것만
+    좁혀 묻는다는 전제(#2268 AC ②의 "다음 발에 필요한 것만"과 짝)."""
+    filters = [Judgment.org_id == org_id]
+    if work_item_id is not None:
+        filters.append(Judgment.work_item_ids.any(work_item_id))
+    if method is not None:
+        filters.append(Judgment.method == method)
+    if scope is not None:
+        filters.append(Judgment.scope == scope)
+
+    retraction_rows = (
+        await session.execute(
+            select(Judgment)
+            .where(*filters, Judgment.kind == "retraction")
+            .order_by(Judgment.created_at.desc())
+        )
+    ).scalars().all()
+
+    active_filters = [*filters, Judgment.kind != "retraction"]
+    total_active = (
+        await session.execute(select(func.count(Judgment.id)).where(*active_filters))
+    ).scalar_one()
+    active_rows = (
+        await session.execute(
+            select(Judgment).where(*active_filters).order_by(Judgment.created_at.desc()).limit(limit)
+        )
+    ).scalars().all()
+
+    omitted_count = max(0, total_active - len(active_rows))
+    return {
+        "retractions": list(retraction_rows),
+        "active": list(active_rows),
+        "meta": {
+            "scope": scope,
+            "capped": omitted_count > 0,
+            "cap_basis": "recency",
+            "omitted_count": omitted_count,
+        },
+    }

--- a/backend/tests/test_2268_judgments_endpoint_realdb.py
+++ b/backend/tests/test_2268_judgments_endpoint_realdb.py
@@ -1,0 +1,442 @@
+"""story #2268(D단계, E-CONNECT — "판단 칸") — POST/GET /api/v2/judgments 엔드포인트 실PG 검증.
+
+오르테가 AC(2026-07-29, 스레드 7256d5cc) 7개를 그대로 잰다:
+  ①Evidence 카운트 오염 없음(judgment 삽입 전후 batch_has_evidence·GET /evidence·
+    glance proof_count 변화 0)
+  ②철회는 캡을 안 받는다(active는 잘리고 retractions는 전량)
+  ③omitted_count가 정확한 수
+  ④method 축 역추적(?method=Y로 같은 방법으로 낸 다른 말들이 함께 나옴)
+  ⑤scope 위반이 API 층에서 422로 거절(DB CHECK가 아니라 사람이 읽을 메시지로)
+  ⑥⛔"PO가 실제로 한 건 쓴다"는 이 PR의 몫이 아니다 — 여기선 그 «메커니즘»만 증명한다
+    (scope=general 항목이 실제로 GET /judgments?scope=general로 나오는가). 실사용은 배포
+    후 오르테가 본인이 라이브로 한다(AC 원문 그대로).
+  ⑦이 판이 못 잡는 것: `app/routers/judgments.py` 모듈 docstring 참조(progress.txt 실삭제·
+    "철회를 다시 주장 안 하는가"는 다음 세션에서만 관측 가능).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+# ─── Seeding helpers(test_2266_story_backlinks_realdb.py와 동형 — 이 파일 자체 완결) ──
+
+
+async def _make_org(session, name="Org"):
+    from app.models.organization import Organization
+    org = Organization(id=uuid.uuid4(), name=name, slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    return org
+
+
+async def _make_project(session, org_id, name="P"):
+    from app.models.project import Project
+    project = Project(id=uuid.uuid4(), org_id=org_id, name=name)
+    session.add(project)
+    await session.commit()
+    return project
+
+
+async def _make_human_member(session, org_id, project_id):
+    from app.models.user import User
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.member import Member
+
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="member")
+    session.add(om)
+    await session.flush()
+    m = Member(id=om.id, org_id=org_id, type="human", user_id=user.id, name="Human")
+    session.add(m)
+    await session.flush()
+    session.add(ProjectAccess(project_id=project_id, org_member_id=om.id, member_id=m.id, role="member"))
+    await session.commit()
+    return m.id, user.id
+
+
+async def _make_story(session, org_id, project_id, title="Story"):
+    from app.models.pm import Story
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status="backlog")
+    session.add(story)
+    await session.commit()
+    return story
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ─── ①Evidence 카운트 오염 없음 ──────────────────────────────────────────────
+
+
+async def test_judgment_insert_does_not_move_evidence_signals():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            from app.services.evidence_service import batch_has_evidence
+
+            async with Session() as s:
+                before_batch = await batch_has_evidence(s, [story.id], "story")
+
+            before_evidence = await client.get(
+                "/api/v2/evidence", params={"work_item_id": str(story.id), "work_item_type": "story"},
+            )
+            before_glance = await client.get("/api/v2/glance/hero", params={"story_id": str(story.id)})
+            assert before_evidence.status_code == 200, before_evidence.text
+            assert before_glance.status_code == 200, before_glance.text
+
+            resp = await client.post(
+                "/api/v2/judgments",
+                json={
+                    "scope": "items", "work_item_ids": [str(story.id)], "kind": "judgment",
+                    "statement": "이 스토리는 realdb로 검증됨",
+                },
+            )
+            assert resp.status_code == 201, resp.text
+
+            async with Session() as s:
+                after_batch = await batch_has_evidence(s, [story.id], "story")
+            after_evidence = await client.get(
+                "/api/v2/evidence", params={"work_item_id": str(story.id), "work_item_type": "story"},
+            )
+            after_glance = await client.get("/api/v2/glance/hero", params={"story_id": str(story.id)})
+
+            assert before_batch == after_batch == set()
+            assert before_evidence.json() == after_evidence.json() == []
+            assert before_glance.json()["proof_count"] == after_glance.json()["proof_count"] == 0
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ②③철회 uncapped + omitted_count 정확 ────────────────────────────────────
+
+
+async def test_retractions_uncapped_active_capped_with_accurate_omitted_count():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            active_ids = []
+            for i in range(5):
+                resp = await client.post(
+                    "/api/v2/judgments",
+                    json={
+                        "scope": "general", "kind": "judgment",
+                        "statement": f"active lesson {i}",
+                    },
+                )
+                assert resp.status_code == 201, resp.text
+                active_ids.append(resp.json()["id"])
+
+            retraction_ids = []
+            for target_id in active_ids[:3]:
+                resp = await client.post(
+                    "/api/v2/judgments",
+                    json={
+                        "scope": "general", "kind": "retraction", "target_id": target_id,
+                        "statement": f"retract {target_id}",
+                    },
+                )
+                assert resp.status_code == 201, resp.text
+                retraction_ids.append(resp.json()["id"])
+
+            resp = await client.get("/api/v2/judgments", params={"scope": "general", "limit": 2})
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+
+            assert len(body["active"]) == 2, body["active"]
+            assert {r["id"] for r in body["retractions"]} == set(retraction_ids), body["retractions"]
+            assert len(body["retractions"]) == 3
+
+            assert body["meta"]["capped"] is True
+            assert body["meta"]["cap_basis"] == "recency"
+            # active 총량 = 5(judgment) + 3(retraction은 active 아님) = 5. 2건 반환 → 3건 누락.
+            assert body["meta"]["omitted_count"] == 3, body["meta"]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ④method 축 역추적 ────────────────────────────────────────────────────────
+
+
+async def test_method_filter_surfaces_all_statements_produced_by_same_method():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            method = f"grep-based-scan-{uuid.uuid4().hex[:8]}"
+
+            r1 = await client.post(
+                "/api/v2/judgments",
+                json={
+                    "scope": "general", "kind": "judgment", "method": method,
+                    "statement": "이 스토리들은 grep으로 훑어 안전하다고 판단",
+                },
+            )
+            assert r1.status_code == 201, r1.text
+            r2 = await client.post(
+                "/api/v2/judgments",
+                json={
+                    "scope": "general", "kind": "judgment", "method": method,
+                    "statement": "다른 이슈도 같은 grep 방법으로 판단",
+                },
+            )
+            assert r2.status_code == 201, r2.text
+            r3 = await client.post(
+                "/api/v2/judgments",
+                json={
+                    "scope": "general", "kind": "method_error", "method": method,
+                    "target_id": r1.json()["id"],
+                    "statement": "grep 스캔이 동적 import를 놓쳤다 — 세는 법이 틀림",
+                },
+            )
+            assert r3.status_code == 201, r3.text
+
+            # 무관한 다른 method — 역추적 결과에 안 섞이는지 확인(양성대조).
+            r_other = await client.post(
+                "/api/v2/judgments",
+                json={
+                    "scope": "general", "kind": "judgment", "method": "different-method",
+                    "statement": "다른 방법으로 낸 말",
+                },
+            )
+            assert r_other.status_code == 201, r_other.text
+
+            resp = await client.get("/api/v2/judgments", params={"method": method})
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            active_ids = {j["id"] for j in body["active"]}
+            assert active_ids == {r1.json()["id"], r2.json()["id"], r3.json()["id"]}
+            assert r_other.json()["id"] not in active_ids
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ⑤scope 위반 API 층 422 거절 ─────────────────────────────────────────────
+
+
+async def test_items_scope_empty_work_item_ids_rejected_with_422_not_500():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/judgments",
+                json={"scope": "items", "work_item_ids": [], "kind": "judgment", "statement": "x"},
+            )
+            assert resp.status_code == 422, resp.text
+            assert "work_item_ids" in resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_general_scope_nonempty_work_item_ids_rejected_with_422_not_500():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/judgments",
+                json={
+                    "scope": "general", "work_item_ids": [str(story.id)], "kind": "judgment",
+                    "statement": "x",
+                },
+            )
+            assert resp.status_code == 422, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_meta_kind_without_target_id_rejected_with_422_not_500():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/judgments",
+                json={"scope": "general", "kind": "retraction", "statement": "무엇을 철회하는지 모름"},
+            )
+            assert resp.status_code == 422, resp.text
+            assert "target_id" in resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ⑥scope=general 메커니즘 증명(실사용 자체는 오르테가가 라이브로) ───────────
+
+
+async def test_general_scope_entry_is_pullable_via_scope_filter():
+    """⭐AC⑥의 «메커니즘» 절반 — scope=general로 넣은 항목이 scope=general 필터로 실제로
+    나오는가. "PO가 실제로 한 건 쓴다"(도는 자리 증명)는 배포 후 오르테가 본인의 라이브
+    액션이라 이 PR의 realdb 테스트로 대신할 수 없다(AC 원문이 그렇게 요구한다 — 대체 아님,
+    이건 그 전제가 되는 배관이 실제로 도는지만 증명)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            # method_error(㉡)는 target_id 필수이므로 먼저 ㉠(judgment) 하나를 세운다.
+            original = await client.post(
+                "/api/v2/judgments",
+                json={"scope": "general", "kind": "judgment", "statement": "부분 체크로 판단함"},
+            )
+            assert original.status_code == 201, original.text
+            correction = await client.post(
+                "/api/v2/judgments",
+                json={
+                    "scope": "general", "kind": "method_error", "target_id": original.json()["id"],
+                    "statement": "CI 초록 오독 — 부분 체크만 보고 끝났다 판단",
+                },
+            )
+            assert correction.status_code == 201, correction.text
+
+            listed = await client.get("/api/v2/judgments", params={"scope": "general"})
+            assert listed.status_code == 200, listed.text
+            ids = {j["id"] for j in listed.json()["active"]}
+            assert original.json()["id"] in ids
+            assert correction.json()["id"] in ids
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_2268_judgments_model_realdb.py
+++ b/backend/tests/test_2268_judgments_model_realdb.py
@@ -1,0 +1,226 @@
+"""story #2268(D단계, E-CONNECT — "판단 칸") — `judgments` 모델/마이그레이션 실PG 검증.
+
+여기선 스키마 레벨 불변식만 잰다(엔드포인트/서비스 계층은 별도 스토리로 배선 — 오르테가가
+AC를 #2268에 박는 중, 이 PR은 그 위에 다른 사람이 안전하게 올릴 수 있는 기반만 세운다):
+  ①kind 허용목록
+  ②scope 허용목록
+  ③scope↔work_item_ids 쌍 강제("아직 안 붙임"과 "어디에도 안 붙는 것"을 스키마가 가른다)
+  ④㉡(retraction/refinement/method_error)은 target_id NOT NULL 강제
+  ⑤target_id는 judgments 자기참조 FK
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _judgment(**overrides):
+    from app.models.judgment import Judgment
+    org_id = overrides.pop("org_id", uuid.uuid4())
+    created_by = overrides.pop("created_by", uuid.uuid4())
+    defaults = dict(
+        id=uuid.uuid4(), org_id=org_id, scope="general", work_item_ids=[],
+        kind="judgment", target_id=None, method=None,
+        statement="stmt", created_by=created_by,
+    )
+    defaults.update(overrides)
+    return Judgment(**defaults)
+
+
+# ─── ①kind 허용목록 ─────────────────────────────────────────────────────────
+
+
+async def test_kind_outside_allowlist_rejected():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            s.add(_judgment(kind="not_a_real_kind"))
+            with pytest.raises(IntegrityError, match="ck_judgments_kind"):
+                await s.commit()
+    finally:
+        await engine.dispose()
+
+
+# ─── ②scope 허용목록 ────────────────────────────────────────────────────────
+
+
+async def test_scope_outside_allowlist_rejected():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            s.add(_judgment(scope="not_a_real_scope"))
+            with pytest.raises(IntegrityError, match="ck_judgments_scope"):
+                await s.commit()
+    finally:
+        await engine.dispose()
+
+
+# ─── ③scope↔work_item_ids 쌍 강제 ───────────────────────────────────────────
+
+
+async def test_general_scope_with_nonempty_work_item_ids_rejected():
+    """"어디에도 안 붙는 것"(general)이라면서 work_item_ids를 채우는 건 모순 — 거절."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            s.add(_judgment(scope="general", work_item_ids=[uuid.uuid4()]))
+            with pytest.raises(IntegrityError, match="ck_judgments_scope_work_item_ids_pairing"):
+                await s.commit()
+    finally:
+        await engine.dispose()
+
+
+async def test_items_scope_with_empty_work_item_ids_rejected():
+    """"특정 항목에 붙는다"(items)면서 work_item_ids가 비어 있는 건 "아직 안 붙인" 잘못된
+    상태 — CHECK가 즉시 거절한다(오르테가 지적: 빈 배열을 추론하지 말고 선언으로 받는다)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            s.add(_judgment(scope="items", work_item_ids=[]))
+            with pytest.raises(IntegrityError, match="ck_judgments_scope_work_item_ids_pairing"):
+                await s.commit()
+    finally:
+        await engine.dispose()
+
+
+async def test_general_scope_with_empty_work_item_ids_accepted():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            s.add(_judgment(scope="general", work_item_ids=[]))
+            await s.commit()
+    finally:
+        await engine.dispose()
+
+
+async def test_items_scope_with_work_item_ids_accepted():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            s.add(_judgment(scope="items", work_item_ids=[uuid.uuid4(), uuid.uuid4()]))
+            await s.commit()
+    finally:
+        await engine.dispose()
+
+
+# ─── ④㉡ target_id NOT NULL 강제 ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("kind", ["retraction", "refinement", "method_error"])
+async def test_meta_kind_without_target_id_rejected(kind):
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            s.add(_judgment(kind=kind, target_id=None))
+            with pytest.raises(IntegrityError, match="ck_judgments_target_required_for_meta_kinds"):
+                await s.commit()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.parametrize("kind", ["judgment", "unmeasurable"])
+async def test_original_kind_without_target_id_accepted(kind):
+    """㉠(원래 낸 말)은 target_id 없이도 스스로 선다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            s.add(_judgment(kind=kind, target_id=None))
+            await s.commit()
+    finally:
+        await engine.dispose()
+
+
+async def test_meta_kind_with_target_id_accepted():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            original = _judgment(kind="judgment")
+            s.add(original)
+            await s.flush()
+            s.add(_judgment(kind="retraction", target_id=original.id))
+            await s.commit()
+    finally:
+        await engine.dispose()
+
+
+# ─── ⑤target_id 자기참조 FK ─────────────────────────────────────────────────
+
+
+async def test_target_id_referencing_nonexistent_judgment_rejected():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            s.add(_judgment(kind="retraction", target_id=uuid.uuid4()))
+            with pytest.raises(IntegrityError, match="fk_judgments_target_id_judgments"):
+                await s.commit()
+    finally:
+        await engine.dispose()
+
+
+# ─── method 필드 ─────────────────────────────────────────────────────────────
+
+
+async def test_method_error_stores_method_for_backtrace():
+    """method_error가 "같은 방법으로 낸 다른 말들"을 역추적하려면 그 방법 자체를
+    저장해야 한다 — method가 NULL이면 역추적 축이 애초에 존재하지 않는다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            original = _judgment(kind="judgment", method="grep-based scan")
+            s.add(original)
+            await s.flush()
+            correction = _judgment(
+                org_id=original.org_id, kind="method_error",
+                target_id=original.id, method="grep-based scan",
+            )
+            s.add(correction)
+            await s.commit()
+
+            from sqlalchemy import select
+            from app.models.judgment import Judgment
+            rows = (
+                await s.execute(
+                    select(Judgment).where(
+                        Judgment.org_id == original.org_id, Judgment.method == "grep-based scan",
+                    )
+                )
+            ).scalars().all()
+            assert {r.id for r in rows} == {original.id, correction.id}
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- 스레드 7256d5cc(2026-07-29)에서 오르테가와 합의한 계약 + AC 7개를 그대로 구현.
- **모델/마이그레이션**: `judgments` 테이블. Evidence type 확장이 아니라 별도 테이블(무필터 카운트 자리 셋 오염 방지). 두 층(㉠judgment/unmeasurable, target 불요 ㉡retraction/refinement/method_error, target_id NOT NULL — CHECK로 스키마 레벨 강제). `work_item_ids: uuid[]` + `scope: items|general` 쌍을 CHECK로 강제.
- **엔드포인트**: `POST/GET /api/v2/judgments`. 3축 필터(work_item_id/method/scope) + retractions는 캡 예외(항상 전체) + active는 recency 캡 + omitted_count 정확값.

## AC 대응
1. Evidence 오염 없음 — `batch_has_evidence`·`GET /evidence`·`glance proof_count` 변화 0(realdb 직접 증명)
2. 철회 uncapped
3. omitted_count 정확값
4. `?method=` 역추적
5. scope/target 위반 앱레벨 422(DB CHECK가 최종 방어선, 이중방어)
6. scope=general 배관 증명(⛔"PO가 실제로 한 건 쓴다"는 배포 후 오르테가 본인 라이브 액션 — 이 PR이 대체하지 않음)
7. 못 잡는 것 — `judgments.py` 모듈 docstring에 명시

## Test plan
- [x] RED→GREEN 3건: scope↔work_item_ids CHECK DB DROP·omitted_count 계산 무력화·retraction limit 적용·app-level 422 검증 비활성화 — 각각 실패 확인 후 원복
- [x] 실PG(alembic head) 모델 14/14 + 엔드포인트 7/7
- [x] 관련 backlinks/reference realdb 71/71(무관 회귀 없음)
- [x] 전체 backend 회귀(realdb 제외) 4208 pass, 6 fail(로컬 MCP path 환경설정, 무관)
- [x] MCP path-contract guard 13/13

🤖 Generated with [Claude Code](https://claude.com/claude-code)