### PR TITLE
feat(#2268 후속②, D단계): sprintable_add_judgment/list_judgments MCP 도구 노출

### DIFF
--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -72,6 +72,10 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # 동형(자기 작업에 self-proof 첨부 = 데이터 파괴 아닌 협업/증명 유틸) — 어떤 역할의 working
     # agent든 default_tool_groups 무관하게 done 첨부해야 하므로 always-allow.
     "sprintable_add_evidence",
+    # story #2268(D단계, E-CONNECT — "판단 칸"): add_judgment/list_judgments — 판단/철회는
+    # work_item_ids(다건 또는 0건 general)에 걸치는 cross-cutting 기록이라 add_evidence와
+    # 동일 논리로 core 취급. vendored 사본과 동기화 필수(sprintable_mcp/toolset.py).
+    "sprintable_add_judgment", "sprintable_list_judgments",
     # story b4027b2e(SEC — 까심 #2140 QA④): E-CANVAS visual_artifacts 11종(원 6개 + 7fe16274
     # 핀 4종 + list_spec_pins)을 여기서 제거하고 전용 "canvas" 그룹(_GROUP_KEYWORDS)으로 이관했다.
     # 이전엔 cross-cutting always-allow였는데(C1-S3 당시 "추가 성장 시 전용 canvas 그룹 신설
@@ -202,6 +206,8 @@ _ALWAYS_ALLOWED_PATH_PREFIXES: tuple[str, ...] = (
     # E-VERIFY V0-S1: evidence는 story/task 어느 쪽이든 첨부되는 cross-cutting 자기증명이라
     # 단일 도메인 그룹에 안 묶임(_ALWAYS_ALLOWED의 sprintable_add_evidence와 동일 근거).
     "/api/v2/evidence",
+    # story #2268(D단계): judgments도 evidence와 동일 근거(work_item_ids 다건/0건 cross-cutting).
+    "/api/v2/judgments",
     # story 205e6831(FR·대표요청): MCP _ALWAYS_ALLOWED에 스탠드업 5종을 core 편입했는데 여기(REST
     # path scope)를 같이 안 고치면 canvas 선례(b4027b2e)와 동일한 "도구는 보이는데 호출은 403"
     # 불일치가 재발한다 — tools/list는 항상 노출하지만 실제 HTTP 호출은 _check_api_key_scope가
@@ -338,6 +344,8 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_link_gate_to_task",
     # evidence (E-VERIFY V0-S1)
     "sprintable_add_evidence",
+    # 판단 칸 (story #2268, D단계)
+    "sprintable_add_judgment", "sprintable_list_judgments",
     # visual artifacts (E-CANVAS C1-S3 + C2-S6 코멘트 + C3-S7 편집 + C4-S8 정본 제안 + 핀 저작 story 7fe16274)
     "sprintable_create_artifact", "sprintable_get_artifact", "sprintable_list_artifacts",
     "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -29,6 +29,7 @@ from .schemas import SprintableInput
 from .toolset import is_tool_allowed
 from .tools.a2a import LinkGateToTaskInput, link_gate_to_task
 from .tools.evidence import AddEvidenceInput, add_evidence
+from .tools.judgments import AddJudgmentInput, ListJudgmentsInput, add_judgment, list_judgments
 from .tools.visual_artifacts import (
     AddArtifactCommentInput, CreateArtifactInput, CreateSpecPinInput, DeleteArtifactInput,
     DeleteSpecPinInput, EditArtifactInput, GetArtifactInput, ListArtifactCommentsInput,
@@ -542,6 +543,16 @@ _TOOL_DEFS: list[tuple] = [
      "done을 스스로 증명하는 자기 서명 첨부(PR·배포·지표·발행물 링크 등) — story/task에 evidence"
      " 남김. 선택제(첨부 안 해도 무불이익).",
      AddEvidenceInput, add_evidence),
+    # 판단 칸 (2) — story #2268(D단계, E-CONNECT)
+    ("sprintable_add_judgment",
+     "판단(judgment)·못 잰 것(unmeasurable)·철회(retraction)·정련(refinement)·세는 법 틀림"
+     "(method_error)을 남긴다. Evidence(됐다의 증거)와 별개 — 판정 자체의 기록. retraction/"
+     "refinement/method_error는 target_id(무엇에 대한 말인지) 필수.",
+     AddJudgmentInput, add_judgment),
+    ("sprintable_list_judgments",
+     "판단/철회 pull 조회 — work_item_id·method·scope로 좁혀 묻는다. retractions는 상한과"
+     " 무관하게 항상 전체, active는 캡되며 meta.omitted_count로 잘린 건수를 알려준다.",
+     ListJudgmentsInput, list_judgments),
     # Visual artifacts (12) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안) +
     # 핀 저작(story 7fe16274) + story #1922(delete_artifact, soft delete·생성자 전용)
     ("sprintable_create_artifact",

--- a/backend/sprintable_mcp/tools/judgments.py
+++ b/backend/sprintable_mcp/tools/judgments.py
@@ -1,0 +1,72 @@
+"""story #2268(D단계, E-CONNECT — "판단 칸") MCP 도구(2개) — REST뿐이던 pull 진입점을
+에이전트가 직접 쓰도록 노출. 오르테가 판단(2026-07-28 21:57): "쓰는 쪽이 아직 저 하나뿐이라
+다른 에이전트도 쓸 수 있어야" — evidence.py와 동형(단순 REST 위임, 재구현 0)."""
+from __future__ import annotations
+
+import uuid
+
+from mcp.types import TextContent
+
+from ..api_client import client
+from ..response import err, ok
+from ..schemas import SprintableInput
+
+
+class AddJudgmentInput(SprintableInput):
+    scope: str  # "items" | "general"
+    kind: str  # judgment | unmeasurable | retraction | refinement | method_error
+    statement: str
+    work_item_ids: list[str] = []
+    target_id: str | None = None  # ㉡(retraction/refinement/method_error)은 필수
+    method: str | None = None  # method_error 역추적 축
+
+
+async def add_judgment(args: AddJudgmentInput) -> list[TextContent]:
+    """판단(judgment)·못 잰 것(unmeasurable)·철회(retraction)·정련(refinement)·세는 법
+    틀림(method_error)을 남긴다. Evidence와 별개 — "됐다"의 증거가 아니라 "이렇게 판단했다/
+    이 판단은 틀렸다"는 판정 자체를 기록한다. scope="general"이면 work_item_ids는 비워야
+    하고(특정 작업과 무관한 일반 교훈), scope="items"면 최소 1개 필요하다. retraction/
+    refinement/method_error는 target_id(무엇에 대한 말인지)가 필수 — 없으면 서버가 422로
+    거절한다."""
+    try:
+        payload: dict = {
+            "scope": args.scope, "kind": args.kind, "statement": args.statement,
+            "work_item_ids": args.work_item_ids,
+        }
+        if args.target_id is not None:
+            payload["target_id"] = args.target_id
+        if args.method is not None:
+            payload["method"] = args.method
+        result = await client.post("/api/v2/judgments", json=payload)
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))
+
+
+class ListJudgmentsInput(SprintableInput):
+    work_item_id: str | None = None
+    method: str | None = None
+    scope: str | None = None  # "items" | "general"
+    limit: int | None = None
+
+
+async def list_judgments(args: ListJudgmentsInput) -> list[TextContent]:
+    """pull 전용 — 「물으면 준다」(push 없음). `retractions`는 상한과 무관하게 항상 전체
+    (철회된 판단을 다시 주장하지 않으려면 빠짐없이 봐야 한다). `active`(judgment/
+    unmeasurable/refinement/method_error)는 recency 기준으로 캡되며, `meta.omitted_count`가
+    실제로 몇 건 잘렸는지 알려준다. `method` 필터는 "같은 방법으로 낸 다른 말들"을 역추적할
+    때 쓴다(method_error를 남기기 전에 먼저 이걸로 훑어보는 것을 권장)."""
+    try:
+        params: dict = {}
+        if args.work_item_id is not None:
+            params["work_item_id"] = args.work_item_id
+        if args.method is not None:
+            params["method"] = args.method
+        if args.scope is not None:
+            params["scope"] = args.scope
+        if args.limit is not None:
+            params["limit"] = args.limit
+        result = await client.get("/api/v2/judgments", params=params)
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))

--- a/backend/sprintable_mcp/toolset.py
+++ b/backend/sprintable_mcp/toolset.py
@@ -64,6 +64,10 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # 유틸이라 단일 도메인 그룹에 못 묶음. link_gate_to_task와 동일 논리로 core 취급(백엔드
     # SSOT와 동기화, app/services/mcp_toolset.py 참고).
     "sprintable_add_evidence",
+    # story #2268(D단계, E-CONNECT — "판단 칸"): add_judgment/list_judgments — 판단/철회는
+    # work_item_ids(다건 또는 0건 general)에 걸치는 cross-cutting 기록이라 add_evidence와
+    # 동일 논리로 core 취급(백엔드 SSOT와 동기화, app/services/mcp_toolset.py 참고).
+    "sprintable_add_judgment", "sprintable_list_judgments",
     # E-MCP-OPT(story ff6cb90d): list_projects/set_default_project — 키 자기 신원/스코프 조회·전환
     # 유틸(sprintable_my_dashboard·sprintable_ping과 동형: 특정 비즈니스 도메인 아닌 self-scope
     # 도구). set_default_project는 write지만 caller 자신의 기본 프로젝트 설정만 바꾸는 self-scope

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -93,6 +93,8 @@ EXPECTED_TOOLS = {
     "sprintable_link_gate_to_task",
     # evidence (1) — E-VERIFY V0-S1
     "sprintable_add_evidence",
+    # 판단 칸 (2) — story #2268(D단계, E-CONNECT)
+    "sprintable_add_judgment", "sprintable_list_judgments",
     # visual artifacts (12) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안) +
     # 핀 저작(story 7fe16274) + story #1922(delete_artifact, soft delete·생성자 전용)
     "sprintable_create_artifact", "sprintable_get_artifact", "sprintable_list_artifacts",
@@ -114,8 +116,9 @@ def test_total_tool_count():
     # 구 sprintable_*_epic 4종은 deprecated 별칭으로 유지(제거 아님) — 107→111.
     # story #2010: sprintable_transition_goal 1종 신설(목표 lifecycle 전이, 구 _epic 별칭 없음) —
     # 111→112. story #1922: sprintable_delete_artifact 1종 신설(artifact soft delete, 생성자
-    # 전용) — 112→113.
-    assert len(_TOOLS) == 113
+    # 전용) — 112→113. story #2268(D단계): sprintable_add_judgment/list_judgments 2종 신설
+    # (판단 칸 pull 진입점 MCP 노출) — 113→115.
+    assert len(_TOOLS) == 115
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_mcp_axis_prefix_b_surface.py
+++ b/backend/tests/test_mcp_axis_prefix_b_surface.py
@@ -21,6 +21,7 @@ _CORE_NO_PREFIX = {
     "sprintable_list_team_members", "sprintable_poll_events", "sprintable_get_loop_context",
     "sprintable_lock_files", "sprintable_unlock_files", "sprintable_link_gate_to_task",
     "sprintable_add_evidence", "sprintable_list_projects", "sprintable_set_default_project",
+    "sprintable_add_judgment", "sprintable_list_judgments",
 }
 
 
@@ -63,6 +64,7 @@ def test_tool_names_and_param_models_untouched():
     """이름·시그니처 불변 — 계층 리네이밍 B1(story 1925)이 sprintable_*_goal 4종을 신설(구
     sprintable_*_epic 4종은 deprecated 별칭 유지, 제거 아님) — 106→110. story #2010:
     sprintable_transition_goal 1종 신설(구 _epic 별칭 없음) — 110→111. story #1922:
-    sprintable_delete_artifact 1종 신설(artifact soft delete, 생성자 전용) — 111→112."""
-    assert len(_TOOL_DEFS) == 112
+    sprintable_delete_artifact 1종 신설(artifact soft delete, 생성자 전용) — 111→112. story #2268
+    (D단계): sprintable_add_judgment/list_judgments 2종 신설(판단 칸 pull 진입점) — 112→114."""
+    assert len(_TOOL_DEFS) == 114
     assert all(name.startswith("sprintable_") for name in _TOOLS)


### PR DESCRIPTION
## Summary
- 오르테가 판단(2026-07-28 21:57, D단계 남은 것 ㉠): "쓰는 쪽이 아직 저(PO) 하나뿐 — 다른 에이전트도 쓸 수 있어야" — REST뿐이던 `/api/v2/judgments`를 MCP 도구 2종(`sprintable_add_judgment`/`sprintable_list_judgments`)으로 노출.
- `evidence.py`와 동형 패턴(단순 REST 위임, 재구현 0).
- `sprintable_add_evidence`와 동일 근거(work_item_ids가 다건/0건 general에 걸치는 cross-cutting)로 core(always-allow) 편입.

## twin-system 배선 5곳(오늘 세션 내내 반복된 그 패턴 — 전수 확인)
①`sprintable_mcp/tools/judgments.py`(신규 구현) ②`sprintable_mcp/server.py`(`_TOOL_DEFS` 등록) ③`app/services/mcp_toolset.py`(백엔드 SSOT — `_ALWAYS_ALLOWED`·`_ALWAYS_ALLOWED_PATH_PREFIXES`·`ALL_TOOL_NAMES` 3곳) ④`sprintable_mcp/toolset.py`(vendored 사본, ③과 동기화) ⑤`tests/mcp/test_contract.py` + `tests/test_mcp_axis_prefix_b_surface.py`(하드코딩 카운트 113→115, 112→114 + 양방향 봉인 세트)

## Test plan
- [x] 관련 계약 테스트 64/64(`test_contract`·`axis_prefix`·`toolset_catalog`·`e_mcp_s2_toolset`·`be_scope_enforce`)
- [x] MCP path-contract guard 13/13
- [x] 관련 realdb(judgments/backlinks/reference) 71/71
- [x] 전체 backend 회귀(realdb 제외) 4208 pass, 6 fail(pre-existing, 무관 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)