### PR TITLE
[SID:2299] story-detail-panel에 「이것을 가리키는 것들」 신설 — still_exists 표시

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -416,6 +416,12 @@
   "board": {
     "title": "Kanban Board",
     "subtitle": "Drag stories to change status",
+    "backlinksTitle": "Things that point here",
+    "backlinksTargetGone": "Target no longer exists",
+    "backlinksEmptyFallback": "0 references observed",
+    "backlinksEmptyScoped": "0 references observed (collection scope: source={sources} only · {excludes} not collected, so not counted here)",
+    "backlinksExcludePrSid": "PR/commit \"[SID:XXX]\" text convention",
+    "backlinksExcludeEvidenceFreeText": "Free-text evidence references",
     "backlog": "Backlog",
     "readyForDev": "Ready for Dev",
     "inProgress": "In Progress",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -416,6 +416,12 @@
   "board": {
     "title": "칸반 보드",
     "subtitle": "스토리를 드래그하여 상태를 변경하세요",
+    "backlinksTitle": "이것을 가리키는 것들",
+    "backlinksTargetGone": "대상이 없습니다",
+    "backlinksEmptyFallback": "관찰된 참조 0건",
+    "backlinksEmptyScoped": "관찰된 참조 0건 (수집범위: source={sources}만 · {excludes}는 미수집이라 이 수에 없음)",
+    "backlinksExcludePrSid": "PR/커밋의 [SID:XXX] 텍스트 관례",
+    "backlinksExcludeEvidenceFreeText": "증거(evidence) 자유텍스트 참조",
     "backlog": "백로그",
     "readyForDev": "개발 대기",
     "inProgress": "진행 중",

--- a/apps/web/src/app/api/stories/[id]/backlinks/route.test.ts
+++ b/apps/web/src/app/api/stories/[id]/backlinks/route.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// story #2299(E-CONNECT) — BE list_entity_backlinks도 convention-A({data,meta})라
+// activities/route.ts(#2247/#2564)와 같은 이중포장 위험을 처음부터 봉쇄한다.
+const h = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(),
+  proxyToFastapiWithParams: vi.fn(),
+}));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext: h.getOrgProjectAuthContext }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams: h.proxyToFastapiWithParams }));
+
+import { GET } from './route';
+
+const ctx = () => ({ params: Promise.resolve({ id: 'story-1' }) });
+const req = () => new Request('http://localhost/api/stories/story-1/backlinks');
+const me = () => ({ id: 'a', org_id: 'org-1', project_id: 'p1', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
+
+describe('GET /api/stories/[id]/backlinks — 이중포장 회귀 방지 + still_exists/collection_scope 왕복', () => {
+  beforeEach(() => {
+    h.getOrgProjectAuthContext.mockReset();
+    h.proxyToFastapiWithParams.mockReset();
+    h.getOrgProjectAuthContext.mockResolvedValue(me());
+  });
+
+  it('BE convention-A 응답이 이중포장 없이 그대로 나온다 — still_exists·collection_scope 보존', async () => {
+    h.proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({
+        data: [{ id: 'r1', source_type: 'doc', still_exists: false, doc: { id: 'd1', title: 'X' }, message: null }],
+        meta: { next_cursor: null, has_more: false, collection_scope: { source_types: ['chat_message', 'doc'], forms: 'all', excludes: [] } },
+      }), { status: 200 }),
+    );
+    const res = await GET(req(), ctx());
+    const json = await res.json() as { data: { still_exists: boolean }[]; meta: { collection_scope: unknown } };
+    expect(Array.isArray(json.data)).toBe(true);
+    expect(json.data[0]!.still_exists).toBe(false);
+    expect(json.meta.collection_scope).toEqual({ source_types: ['chat_message', 'doc'], forms: 'all', excludes: [] });
+  });
+});

--- a/apps/web/src/app/api/stories/[id]/backlinks/route.ts
+++ b/apps/web/src/app/api/stories/[id]/backlinks/route.ts
@@ -1,0 +1,26 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors, type ApiMeta } from '@/lib/api-response';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/** GET /api/stories/{id}/backlinks — story #2299(E-CONNECT): 이 스토리를 가리키는 것들
+ * (chat_message/doc source) 목록 + still_exists(끊어짐 사실). BE(list_entity_backlinks)는
+ * convention-A({data,meta}) — activities/route.ts의 이중포장 사고(#2247/#2564)와 같은 자리라
+ * 처음부터 raw json.data ?? json 언랩 패턴으로 짓는다(재발 금지). */
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const me = await getOrgProjectAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/stories/[id]/backlinks', { id });
+    if (!_r.ok) return _r;
+    const beJson = await _r.json() as { data?: unknown; meta?: ApiMeta };
+    return apiSuccess(beJson.data ?? beJson, beJson.meta);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/components/kanban/story-backlinks-section.test.tsx
+++ b/apps/web/src/components/kanban/story-backlinks-section.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+//
+// story #2299(E-CONNECT) — 「이것을 가리키는 것들」 목록의 still_exists 표시 규율(유나 확定):
+// ①끊어진 항목도 목록에서 안 뺀다 ②사실로 보인다(오류색 없음) ③비난 없는 문구
+// ④종류(doc/chat_message)와 무관하게 문구 한 벌.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { StoryBacklinksSection } from './story-backlinks-section';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function withIntl(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+async function render(storyId: string) {
+  await act(async () => {
+    root.render(withIntl(<StoryBacklinksSection storyId={storyId} />));
+  });
+  // useEffect의 fetch가 resolve될 시간을 준다.
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('StoryBacklinksSection', () => {
+  it('①끊어진 항목(still_exists=false)도 목록에서 안 빠진다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      data: [
+        { id: 'r1', source_type: 'doc', source_id: 'd1', created_by: null, created_at: '2026-07-28T00:00:00Z', still_exists: false, doc: { id: 'd1', title: '삭제된 문서' }, message: null },
+        { id: 'r2', source_type: 'doc', source_id: 'd2', created_by: null, created_at: '2026-07-28T00:00:00Z', still_exists: true, doc: { id: 'd2', title: '살아있는 문서' }, message: null },
+      ],
+      meta: { next_cursor: null, has_more: false, collection_scope: { source_types: ['chat_message', 'doc'], forms: 'all', excludes: [] } },
+    }))));
+    await render('s1');
+    expect(container.textContent).toContain('삭제된 문서');
+    expect(container.textContent).toContain('살아있는 문서');
+  });
+
+  it('②사실로만 보인다 — 경고 문구("삭제됨"·"깨짐") 없이 ③비난없는 「대상이 없습니다」', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      data: [{ id: 'r1', source_type: 'doc', source_id: 'd1', created_by: null, created_at: '2026-07-28T00:00:00Z', still_exists: false, doc: { id: 'd1', title: '문서' }, message: null }],
+      meta: { next_cursor: null, has_more: false, collection_scope: { source_types: ['chat_message', 'doc'], forms: 'all', excludes: [] } },
+    }))));
+    await render('s1');
+    expect(container.textContent).toContain('대상이 없습니다');
+    expect(container.textContent).not.toContain('삭제됨');
+    expect(container.textContent).not.toContain('깨짐');
+    expect(container.textContent).not.toContain('미기록');
+  });
+
+  it('②오류색/경고색이 아니라 회색이다 — text-destructive·text-warning·border-warning 클래스 미사용', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      data: [{ id: 'r1', source_type: 'doc', source_id: 'd1', created_by: null, created_at: '2026-07-28T00:00:00Z', still_exists: false, doc: { id: 'd1', title: '문서' }, message: null }],
+      meta: { next_cursor: null, has_more: false, collection_scope: { source_types: ['chat_message', 'doc'], forms: 'all', excludes: [] } },
+    }))));
+    await render('s1');
+    expect(container.innerHTML).not.toContain('text-destructive');
+    expect(container.innerHTML).not.toContain('text-warning');
+    expect(container.innerHTML).not.toContain('border-warning');
+    expect(container.innerHTML).not.toContain('bg-warning');
+  });
+
+  it('④종류가 doc이든 chat_message든 끊어짐 문구는 한 벌이다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      data: [
+        { id: 'r1', source_type: 'doc', source_id: 'd1', created_by: null, created_at: '2026-07-28T00:00:00Z', still_exists: false, doc: { id: 'd1', title: '문서 하나' }, message: null },
+        { id: 'r2', source_type: 'chat_message', source_id: 'm1', created_by: null, created_at: '2026-07-28T00:00:00Z', still_exists: false, doc: null, message: { id: 'm1', conversation_id: 'c1', content_snippet: '메시지 하나', sender: null } },
+      ],
+      meta: { next_cursor: null, has_more: false, collection_scope: { source_types: ['chat_message', 'doc'], forms: 'all', excludes: [] } },
+    }))));
+    await render('s1');
+    const matches = container.textContent?.match(/대상이 없습니다/g) ?? [];
+    expect(matches.length).toBe(2); // 두 항목 모두 같은 문구 한 벌
+  });
+
+  it('빈 목록이면 수집범위를 실은 0건 문구를 보인다(미수집을 없음으로 표시하지 않는다)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      data: [],
+      meta: {
+        next_cursor: null, has_more: false,
+        collection_scope: { source_types: ['chat_message', 'doc'], forms: 'all', excludes: ['pr_sid_text_convention', 'evidence_free_text_reference'] },
+      },
+    }))));
+    await render('s1');
+    expect(container.textContent).toContain('관찰된 참조 0건');
+    expect(container.textContent).toContain('chat_message');
+    expect(container.textContent).toContain('PR/커밋');
+    expect(container.textContent).toContain('증거');
+  });
+
+  it('빈 목록에 살아있는 항목만 있으면 「대상이 없습니다」가 안 뜬다(정상 케이스 오탐 방지)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      data: [{ id: 'r1', source_type: 'doc', source_id: 'd1', created_by: null, created_at: '2026-07-28T00:00:00Z', still_exists: true, doc: { id: 'd1', title: '살아있는 문서' }, message: null }],
+      meta: { next_cursor: null, has_more: false, collection_scope: { source_types: ['chat_message', 'doc'], forms: 'all', excludes: [] } },
+    }))));
+    await render('s1');
+    expect(container.textContent).toContain('살아있는 문서');
+    expect(container.textContent).not.toContain('대상이 없습니다');
+  });
+
+  it('fetch 실패 시 조용히 아무것도 안 그린다(노이즈 0, 다른 애드온 섹션과 동형)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 500 })));
+    await render('s1');
+    expect(container.textContent).toBe('');
+  });
+
+  it('story-detail-panel은 story 전환 시 이 컴포넌트를 리마운트 안 한다 — storyId prop만 바뀌어도 이전 story 결과가 안 새어 보인다', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/stories/s1/')) {
+        return new Response(JSON.stringify({
+          data: [{ id: 'r1', source_type: 'doc', source_id: 'd1', created_by: null, created_at: '2026-07-28T00:00:00Z', still_exists: true, doc: { id: 'd1', title: 'S1 전용 문서' }, message: null }],
+          meta: { next_cursor: null, has_more: false, collection_scope: { source_types: ['chat_message', 'doc'], forms: 'all', excludes: [] } },
+        }));
+      }
+      // s2 요청은 응답을 영원히 안 준다(pending) — s1 결과가 새어 나오면 이 테스트가 잡는다.
+      return new Promise(() => {});
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await render('s1');
+    expect(container.textContent).toContain('S1 전용 문서');
+
+    // 같은 인스턴스에 storyId prop만 바뀐다(리마운트 없음) — kanban-board.tsx의 실제 렌더 패턴.
+    await act(async () => {
+      root.render(withIntl(<StoryBacklinksSection storyId="s2" />));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).not.toContain('S1 전용 문서'); // 전환 중엔 이전 결과가 안 보인다
+  });
+});

--- a/apps/web/src/components/kanban/story-backlinks-section.tsx
+++ b/apps/web/src/components/kanban/story-backlinks-section.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { FileText, MessageSquare } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { formatRelativeTime } from '@/lib/storage/format';
+
+interface BacklinkMember { id: string; name: string; type: string }
+
+interface BacklinkItem {
+  id: string;
+  source_type: 'chat_message' | 'doc';
+  source_id: string;
+  created_by: BacklinkMember | null;
+  created_at: string;
+  /** story #2299: 「끊어짐」은 사실 필드 — 색/문구는 여기(FE)서 정한다(BE는 계산만). */
+  still_exists: boolean;
+  doc: { id: string; title: string } | null;
+  message: { id: string; conversation_id: string; content_snippet: string; sender: BacklinkMember | null } | null;
+}
+
+interface CollectionScope {
+  source_types: string[];
+  forms: string;
+  excludes: string[];
+}
+
+interface BacklinksMeta {
+  collection_scope?: CollectionScope;
+}
+
+/** excludes 코드 → i18n 키. BE가 사실만 주고 문안은 FE 몫(collection_scope 주석 그대로). */
+const EXCLUDE_LABEL_KEYS: Record<string, string> = {
+  pr_sid_text_convention: 'backlinksExcludePrSid',
+  evidence_free_text_reference: 'backlinksExcludeEvidenceFreeText',
+};
+
+interface StoryBacklinksSectionProps {
+  storyId: string;
+}
+
+/**
+ * story #2299(E-CONNECT) — 「이것을 가리키는 것들」 목록. story-detail-panel 신설 섹션(첫 자리 —
+ * doc [slug]/view는 후속 판, PO 지시대로 한 자리로 절차를 세운다).
+ *
+ * still_exists 표시 규율(유나 확定):
+ *  ①끊어진 항목도 목록에서 안 뺀다(그대로 보여줌 — 사라진 척 안 함).
+ *  ②사실로 보인다 — 오류색/경고 아이콘 없이 회색(노랑=기다릴 것 전용, 여기는 아무도 안 기다림).
+ *  ③문구는 비난 없이 「대상이 없습니다」(삭제됨/깨짐 같은 말 안 씀).
+ *  ④종류(doc/chat_message)와 무관하게 문구 한 벌.
+ */
+interface LoadedResult {
+  storyId: string;
+  items: BacklinkItem[];
+  scope: CollectionScope | null;
+}
+
+export function StoryBacklinksSection({ storyId }: StoryBacklinksSectionProps) {
+  const t = useTranslations('board');
+  // story-detail-panel은 story 전환 시 이 컴포넌트를 리마운트하지 않는다(같은 인스턴스에
+  // storyId prop만 바뀜) — 그래서 결과에 storyId를 같이 담아 「지금 보이는 결과가 지금
+  // storyId 것인지」를 렌더 시점에 판정한다(effect 안에서 동기 setState로 리셋하는 대신 —
+  // react-hooks/set-state-in-effect가 막는 패턴. 전환 중엔 이전 story 결과가 안 보인다).
+  const [result, setResult] = useState<LoadedResult | 'failed' | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/stories/${storyId}/backlinks`, { cache: 'no-store' })
+      .then((r) => (r.ok ? (r.json() as Promise<{ data?: BacklinkItem[]; meta?: BacklinksMeta }>) : null))
+      .then((json) => {
+        if (cancelled) return;
+        if (!json) { setResult('failed'); return; }
+        setResult({ storyId, items: json.data ?? [], scope: json.meta?.collection_scope ?? null });
+      })
+      .catch(() => { if (!cancelled) setResult('failed'); });
+    return () => { cancelled = true; };
+  }, [storyId]);
+
+  // 조용한 폴백 — 다른 애드온 섹션(stuck-handoff-section 등)과 동형, 로딩/실패/전환-중으로 노이즈를 안 낸다.
+  if (result === null || result === 'failed' || result.storyId !== storyId) return null;
+  const { items, scope } = result;
+
+  return (
+    <div className="border-t border-border/60 px-4 py-3">
+      <p className="mb-2 text-xs font-medium text-muted-foreground">{t('backlinksTitle')}</p>
+      {items.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          {scope
+            ? t('backlinksEmptyScoped', {
+                sources: scope.source_types.join('·'),
+                // 매핑에 없는 코드(향후 BE가 excludes를 늘릴 경우)는 원문 코드 그대로 — 번역
+                // 키 오조회 대신 "정상 경로"로 보여준다(#2263 ㉢와 같은 원칙).
+                excludes: scope.excludes.map((k) => (EXCLUDE_LABEL_KEYS[k] ? t(EXCLUDE_LABEL_KEYS[k]!) : k)).join('·'),
+              })
+            : t('backlinksEmptyFallback')}
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-1.5">
+          {items.map((item) => {
+            const Icon = item.source_type === 'doc' ? FileText : MessageSquare;
+            const label = item.source_type === 'doc' ? item.doc?.title : item.message?.content_snippet;
+            const creatorName = item.created_by?.name;
+            return (
+              <li
+                key={item.id}
+                className={`flex items-start gap-2 text-xs ${item.still_exists ? 'text-foreground' : 'text-muted-foreground'}`}
+              >
+                <Icon className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+                <div className="min-w-0 flex-1">
+                  <span className="[overflow-wrap:anywhere]">{label ?? item.source_id}</span>
+                  {!item.still_exists && (
+                    <span className="ml-1.5 rounded bg-muted px-1 py-0.5 text-[10px] text-muted-foreground">
+                      {t('backlinksTargetGone')}
+                    </span>
+                  )}
+                  <div className="text-[10px] text-muted-foreground">
+                    {creatorName ? `${creatorName} · ` : ''}
+                    {formatRelativeTime(item.created_at)}
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -26,6 +26,7 @@ import { Workcell, type WorkcellMessage } from '@/components/workcell/workcell';
 import { initials } from '@/lib/storage/format';
 import { ArtifactSection } from '@/components/canvas/artifact-section';
 import { StuckHandoffSection } from '@/components/cage/stuck-handoff-section';
+import { StoryBacklinksSection } from '@/components/kanban/story-backlinks-section';
 import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
 import { PrLinkSection } from '@/components/integrations/pr-link-section';
 import { Button } from '@/components/ui/button';
@@ -1064,6 +1065,10 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
 
             {/* E-DG S12: handoff stuck UX — DISPATCH 직후·handoff_stuck일 때만 조건부 렌더(자체 게이트) */}
             <StuckHandoffSection storyId={story.id} memberMap={memberMap} />
+
+            {/* story #2299(E-CONNECT): 이것을 가리키는 것들 — doc/chat_message 참조 목록 첫 자리
+                (doc [slug]/view는 후속 판). */}
+            <StoryBacklinksSection storyId={story.id} />
 
             {story.story_points != null ? (
               <div>

--- a/apps/web/src/lib/convention-a-double-wrap-guard.test.ts
+++ b/apps/web/src/lib/convention-a-double-wrap-guard.test.ts
@@ -9,7 +9,8 @@
  *   해당 안 됨(이중포장 자체가 구조적으로 불가) — 스킵.
  * - docs.py(list_docs)·notifications.py(list_notifications): FE가 이 BE 엔드포인트를 아예
  *   안 쓰고 별도 내부 서비스/레포지토리를 쓴다(다른 아키텍처) — 이 클래스의 위험군이 아님, 스킵.
- * - docs.py(get_doc_backlinks): FE 프록시 자체가 아직 없음(story #2263 별건, 배선 자체가 안 됨).
+ * - docs.py(get_doc_backlinks): FE 프록시 자체가 아직 없음(story #2264/C-6 별건, 배선 자체가
+ *   안 됨 — stories.py(get_story_backlinks)는 #2299에서 배선돼 아래 목록에 있다).
  * - 미래에 새로 생기는 규약A 엔드포인트는 이 가드가 자동으로 못 잡는다 — 만들 때 이 파일에
  *   케이스를 추가하는 것이 유일한 방어선이다.
  */
@@ -61,5 +62,10 @@ describe('규약A 엔드포인트 FE 프록시 — 이중포장 없음 가드', 
   it('standup/history — #2248 처방 유지 확認', async () => {
     const { GET } = await import('@/app/api/standup/history/route');
     await assertNoDoubleWrap(GET);
+  });
+
+  it('stories/[id]/backlinks — #2299 신설 프록시(처음부터 raw unwrap으로 지어짐)', async () => {
+    const { GET } = await import('@/app/api/stories/[id]/backlinks/route');
+    await assertNoDoubleWrap(GET, { params: Promise.resolve({ id: 's1' }) });
   });
 });


### PR DESCRIPTION
## 배경

#2593(디디군, BE)이 `GET /api/v2/{docs,stories}/{id}/backlinks` 응답에 `still_exists: bool`을 실었다. PO 초기 지시는 "화면이 그 값을 안 쓴다"였는데, 실측 결과(origin/develop 프레시 워크트리에서 `backlinks` grep) **그 값을 부르는 화면 자체가 어디에도 없었다** — PO가 그 자리에서 판정 정정("없는 것과 안 쓰는 것은 다르다"). story-detail-panel을 첫 자리로 연다(PO 근거: 매일 보는 자리, 오늘 참조가 가장 많이 붙은 종류가 story — doc `[slug]/view`는 후속 판, 한 판에 둘 다 안 연다).

## still_exists 표시 규율(유나 확定)

- ①끊어진 항목도 목록에서 안 뺀다 — `.filter()`로 조용히 빼지 않는다.
- ②사실로 보인다 — `text-destructive`/`text-warning`/`border-warning` 등 색 클래스 미사용(회색, 노랑은 "기다릴 것" 전용).
- ③문구는 비난 없이 "대상이 없습니다"("삭제됨"/"깨짐" 안 씀).
- ④종류(doc/chat_message)와 무관하게 문구 한 벌.

## 0건 zero-state — "미수집을 없음으로 표시하지 않는다"(#2266 AC4)

BE `meta.collection_scope`(`{source_types, forms, excludes}`)를 그대로 반영해 조립.

⛔**원 지시 카피안 정정 하나**: PO가 준 카피 초안은 "수집범위: mention/embed"였는데, BE `backlinks.py` 주석이 정확히 이렇게 경고한다 — 이 쿼리는 `Reference.form`을 필터링하지 않아(`forms: "all"`, mention/embed/proof 전부 포함) **"mention/embed만"이라고 쓰면 거짓**이 된다고. 그래서 그 표현을 빼고 `collection_scope` 객체의 실제 값(`source_types`/`excludes`)만 반영해 지었다.

## 이중포장 회귀 방지

신규 FE 프록시는 처음부터 규약A(`{data,meta}`) raw unwrap 패턴으로 짓는다(`json.data ?? json`) — `convention-a-double-wrap-guard.test.ts`에 케이스 추가.

## 부수로 잡은 것 — story 전환 시 리마운트 안 됨

`story-detail-panel`은 story를 바꿔도 이 섹션 컴포넌트를 리마운트하지 않는다(같은 인스턴스에 `storyId` prop만 바뀜, `kanban-board.tsx`가 `key` 없이 렌더). 단순 `loading/loaded` 2-state였다면 전환 중 **이전 story의 결과가 잠깐 새어 보였을 것** — 결과 객체에 `storyId`를 실어 렌더 시점에 현재 prop과 일치하는지 판정하는 패턴으로 처음부터 짓고, 이 정확한 시나리오를 재현하는 회귀 테스트를 mutation-verified로 추가했다.

## 검증

- 신규 8케이스(컴포넌트) + 1케이스(프록시 이중포장 가드) + 1케이스(CI 가드 목록 추가) — 전부 GREEN.
- mutation-verified 3건: ①필터로 끊어진 항목 제외 → 3개 테스트 RED → 원복 GREEN. ②프록시 이중포장 재도입 → RED → 원복 GREEN. ③storyId 불일치 가드 제거 → 전환-누출 테스트 RED → 원복 GREEN.
- 전체 FE vitest: 300 파일 · 2007 테스트 PASS(회귀 0). `tsc --noEmit`/`eslint` 무오류.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>