### PR TITLE
[SID:2264] story 본문·AC에도 `#` 엔티티 피커 — 참조 코어 추출(useEntityPicker)

### DIFF
--- a/apps/web/src/components/chat/chat-input-entity-tokens.ts
+++ b/apps/web/src/components/chat/chat-input-entity-tokens.ts
@@ -1,0 +1,71 @@
+/**
+ * story #2264(C-6) — `#` 엔티티 토큰 조립의 참조 코어. chat-input.tsx(채팅)와
+ * use-entity-picker.ts(다른 자리 — story 본문/AC 등) 둘 다 이 파일 하나를 쓴다.
+ * AC3 판정: 새 자리를 열 때 이 파일의 diff가 0이어야 한다 — 여기 손대는 순간 "코어를
+ * 고쳤다"는 뜻이라 이 스토리가 막으려는 바로 그 일이 된다.
+ */
+
+export interface EntityResult {
+  entity_type: string;
+  entity_id: string;
+  title: string;
+  status: string | null;
+}
+
+export function getEntityQuery(value: string, cursorPos: number): string | null {
+  const before = value.slice(0, cursorPos);
+  const m = before.match(/#([\w가-힣]*)$/);
+  return m ? m[1]! : null;
+}
+
+// story #2292(보안·critical) — 링크 텍스트(markdown `[text](url)`의 text 부분) escape.
+// `[ ] ( ) \` 와 개행이 markdown-link 토큰 구조를 변조(예 `x](https://phish)[y` → 외부
+// phishing 링크 렌더)하는 걸 차단한다. ⛔형제 함수(applyEntity·applyAsset)가 이 상수 하나를
+// 공유해야 한다 — 각자 자기 정규식을 들고 있으면 그게 바로 형제 비대칭이다.
+export function escapeMarkdownLinkText(text: string): string {
+  return text.replace(/[\\[\]()]/g, '\\$&').replace(/[\r\n]+/g, ' ');
+}
+
+export function applyEntity(
+  value: string,
+  cursorPos: number,
+  title: string,
+  entityType: string,
+  entityId: string,
+): { text: string; caretPos: number } {
+  const before = value.slice(0, cursorPos);
+  const m = before.match(/#([\w가-힣]*)$/);
+  if (!m) return { text: value, caretPos: cursorPos };
+  const start = cursorPos - m[0].length;
+  // story #2292: title은 story/doc/epic/task 검색결과 — 자유 텍스트라 escape 필수(형제
+  // applyAsset은 이미 하고 있었다. 여기만 빠져 있던 것이 발견된 결함).
+  const safeTitle = escapeMarkdownLinkText(title);
+  const replacement = `[${safeTitle}](entity:${entityType}:${entityId}) `;
+  return { text: value.slice(0, start) + replacement + value.slice(cursorPos), caretPos: start + replacement.length };
+}
+
+// story #2263(C-5) ㉠㉢: 종류를 «글자»로 보이는 라벨. ⛔서버가 신규 종류를 주면(registry는
+// 화면이 모르는 채로 늘 수 있다) 목록에 없는 값도 "정상 경로"로 그려야 한다 — 매핑이 없으면
+// 원문 종류 문자열을 그대로 쓴다(공백/대문자 처리 없이도 "sprint"·"hypothesis"처럼 읽을 수
+// 있는 값이라 그 자체로 충분히 "정상"이다. 빈 문자열·물음표·아이콘만 남기는 실패 대신).
+const ENTITY_TYPE_LABELS: Record<string, string> = {
+  story: '스토리', doc: '문서', epic: '에픽', task: '작업',
+};
+export function entityTypeLabel(type: string): string {
+  return ENTITY_TYPE_LABELS[type] ?? type;
+}
+
+// story #2263(C-5) ㉡: 종류로 묶어 보이되 열은 나누지 않는다(키보드 이동이 한 줄기여야 하므로
+// entityResults 자체의 순서를 그룹 순서로 재배열한다 — entityIndex가 이 배열을 그대로
+// 인덱싱하므로 렌더 순서=키보드 이동 순서가 항상 같다, 별도 변환이 렌더 시점에 필요 없다).
+// ⛔BE(entities.py)의 최종 정렬(가나다/최신순)이 종류를 뒤섞을 수 있으므로 첫 등장 순서를
+// 그룹 우선순위로 쓰는 stable regroup(하드코딩된 타입 나열 없음 — 데이터가 순서를 정한다).
+export function groupEntitiesByType(results: EntityResult[]): EntityResult[] {
+  const order: string[] = [];
+  const buckets = new Map<string, EntityResult[]>();
+  for (const r of results) {
+    if (!buckets.has(r.entity_type)) { buckets.set(r.entity_type, []); order.push(r.entity_type); }
+    buckets.get(r.entity_type)!.push(r);
+  }
+  return order.flatMap((type) => buckets.get(type)!);
+}

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -20,6 +20,14 @@ import type { Asset } from '@/lib/storage/types';
 import { imageFilesFromClipboard } from '@/lib/clipboard-image';
 import { ENTITY_ICONS } from './embed-card';
 import { AssetPickerPopover } from './asset-picker-popover';
+import {
+  applyEntity, entityTypeLabel, escapeMarkdownLinkText, getEntityQuery, groupEntitiesByType, type EntityResult,
+} from './chat-input-entity-tokens';
+import { useEntityPicker } from '@/hooks/use-entity-picker';
+
+// story #2264(C-6): 토큰조립/그룹핑/라벨은 이제 참조 코어(chat-input-entity-tokens.ts)에
+// 산다 — 여기선 재-export만 해서 기존 소비부(테스트 등)의 import 경로를 그대로 둔다.
+export { applyEntity, entityTypeLabel, escapeMarkdownLinkText, groupEntitiesByType };
 
 /** S8 #2: pre-send capability 경고 대상 — 대화의 에이전트 participant(본인 제외) runtime. */
 export interface CommandTarget {
@@ -44,39 +52,6 @@ function applyMention(value: string, cursorPos: number, name: string): { text: s
   const replacement = `@${name} `;
   return { text: value.slice(0, start) + replacement + value.slice(cursorPos), caretPos: start + replacement.length };
 }
-
-function getEntityQuery(value: string, cursorPos: number): string | null {
-  const before = value.slice(0, cursorPos);
-  const m = before.match(/#([\w가-힣]*)$/);
-  return m ? m[1] : null;
-}
-
-// story #2292(보안·critical) — 링크 텍스트(markdown `[text](url)`의 text 부분) escape.
-// `[ ] ( ) \` 와 개행이 markdown-link 토큰 구조를 변조(예 `x](https://phish)[y` → 외부
-// phishing 링크 렌더)하는 걸 차단한다. ⛔형제 함수(applyEntity·applyAsset)가 이 상수 하나를
-// 공유해야 한다 — 각자 자기 정규식을 들고 있으면 그게 바로 오늘 반복된 「형제 비대칭」이다.
-export function escapeMarkdownLinkText(text: string): string {
-  return text.replace(/[\\[\]()]/g, '\\$&').replace(/[\r\n]+/g, ' ');
-}
-
-export function applyEntity(
-  value: string,
-  cursorPos: number,
-  title: string,
-  entityType: string,
-  entityId: string,
-): { text: string; caretPos: number } {
-  const before = value.slice(0, cursorPos);
-  const m = before.match(/#([\w가-힣]*)$/);
-  if (!m) return { text: value, caretPos: cursorPos };
-  const start = cursorPos - m[0].length;
-  // story #2292: title은 story/doc/epic/task 검색결과 — 자유 텍스트라 escape 필수(형제
-  // applyAsset은 이미 하고 있었다. 여기만 빠져 있던 것이 발견된 결함).
-  const safeTitle = escapeMarkdownLinkText(title);
-  const replacement = `[${safeTitle}](entity:${entityType}:${entityId}) `;
-  return { text: value.slice(0, start) + replacement + value.slice(cursorPos), caretPos: start + replacement.length };
-}
-
 
 // S6: 스토리지 자산 선택 → 토큰 삽입. applyEntity 미러(트리거 문자 없이 caret 위치에 삽입).
 // 토큰 형식 정확히 `[${name}](entity:asset:${id}) ` (chat-bubble 의 entity:asset 렌더 경로와 정합).
@@ -121,39 +96,6 @@ interface MentionMember {
   id: string;
   name: string;
   role?: string | null;
-}
-
-interface EntityResult {
-  entity_type: string;
-  entity_id: string;
-  title: string;
-  status: string | null;
-}
-
-// story #2263(C-5) ㉠㉢: 종류를 «글자»로 보이는 라벨. ⛔서버가 신규 종류를 주면(registry는
-// 화면이 모르는 채로 늘 수 있다) 목록에 없는 값도 "정상 경로"로 그려야 한다 — 매핑이 없으면
-// 원문 종류 문자열을 그대로 쓴다(공백/대문자 처리 없이도 "sprint"·"hypothesis"처럼 읽을 수
-// 있는 값이라 그 자체로 충분히 "정상"이다. 빈 문자열·물음표·아이콘만 남기는 실패 대신).
-const ENTITY_TYPE_LABELS: Record<string, string> = {
-  story: '스토리', doc: '문서', epic: '에픽', task: '작업',
-};
-export function entityTypeLabel(type: string): string {
-  return ENTITY_TYPE_LABELS[type] ?? type;
-}
-
-// story #2263(C-5) ㉡: 종류로 묶어 보이되 열은 나누지 않는다(키보드 이동이 한 줄기여야 하므로
-// entityResults 자체의 순서를 그룹 순서로 재배열한다 — entityIndex가 이 배열을 그대로
-// 인덱싱하므로 렌더 순서=키보드 이동 순서가 항상 같다, 별도 변환이 렌더 시점에 필요 없다).
-// ⛔BE(entities.py)의 최종 정렬(가나다/최신순)이 종류를 뒤섞을 수 있으므로 첫 등장 순서를
-// 그룹 우선순위로 쓰는 stable regroup(하드코딩된 타입 나열 없음 — 데이터가 순서를 정한다).
-export function groupEntitiesByType(results: EntityResult[]): EntityResult[] {
-  const order: string[] = [];
-  const buckets = new Map<string, EntityResult[]>();
-  for (const r of results) {
-    if (!buckets.has(r.entity_type)) { buckets.set(r.entity_type, []); order.push(r.entity_type); }
-    buckets.get(r.entity_type)!.push(r);
-  }
-  return order.flatMap((type) => buckets.get(type)!);
 }
 
 // story #2032 — 대화별 임시저장(localStorage). 대화 전환은 ChatView가 key={conversation_id}로
@@ -219,9 +161,9 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
   const [mentionMembers, setMentionMembers] = useState<MentionMember[]>([]);
   const [mentionIndex, setMentionIndex] = useState(0);
 
-  const [entityQuery, setEntityQuery] = useState<string | null>(null);
-  const [entityResults, setEntityResults] = useState<EntityResult[]>([]);
-  const [entityIndex, setEntityIndex] = useState(0);
+  // story #2264(C-6): 채팅 전용이던 entityQuery/entityResults/entityIndex + 검색 effect가
+  // 참조 코어 hook으로 옮겨갔다 — 이 컴포넌트는 소비자일 뿐이다.
+  const entityPicker = useEntityPicker(projectId);
 
   const [commandQuery, setCommandQuery] = useState<string | null>(null);
   const [commandIndex, setCommandIndex] = useState(0);
@@ -249,25 +191,6 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
       .catch(() => {});
     return () => { cancelled = true; };
   }, [mentionQuery, projectId]);
-
-  useEffect(() => {
-    let cancelled = false;
-    if (entityQuery === null || !projectId) { setEntityResults([]); return; }
-    const timer = window.setTimeout(() => {
-      const params = new URLSearchParams({ project_id: projectId });
-      if (entityQuery) params.set('q', entityQuery);
-      fetch(`/api/entities/search?${params}`)
-        .then((r) => r.json())
-        .then((json: EntityResult[] | { data?: EntityResult[] }) => {
-          if (cancelled) return;
-          const arr = Array.isArray(json) ? json : (json.data ?? []);
-          setEntityResults(groupEntitiesByType(Array.isArray(arr) ? arr : []));
-          setEntityIndex(0);
-        })
-        .catch(() => {});
-    }, 200);
-    return () => { cancelled = true; window.clearTimeout(timer); };
-  }, [entityQuery, projectId]);
 
   const adjustHeight = () => {
     const el = textareaRef.current;
@@ -312,23 +235,20 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
       setCommandIndex(0);
       setMentionQuery(null);
       setMentionMembers([]);
-      setEntityQuery(null);
-      setEntityResults([]);
+      entityPicker.close();
     } else if (mq !== null) {
       setMentionQuery(mq);
       setCommandQuery(null);
-      setEntityQuery(null);
-      setEntityResults([]);
+      entityPicker.close();
     } else if (eq !== null) {
-      setEntityQuery(eq);
+      entityPicker.setEntityQuery(eq);
       setCommandQuery(null);
       setMentionQuery(null);
       setMentionMembers([]);
     } else {
       setMentionQuery(null);
       setMentionMembers([]);
-      setEntityQuery(null);
-      setEntityResults([]);
+      entityPicker.close();
       setCommandQuery(null);
     }
   };
@@ -355,8 +275,7 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
     const cursorPos = textarea?.selectionStart ?? text.length;
     const { text: nextText, caretPos } = applyEntity(text, cursorPos, entity.title, entity.entity_type, entity.entity_id);
     setText(nextText);
-    setEntityQuery(null);
-    setEntityResults([]);
+    entityPicker.close();
     requestAnimationFrame(() => {
       textarea?.focus();
       textarea?.setSelectionRange(caretPos, caretPos);
@@ -436,12 +355,12 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
       if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); const c = commandCandidates[commandIndex] ?? commandCandidates[0]; if (c) selectCommand(c); return; }
       if (e.key === 'Escape') { setCommandQuery(null); return; }
     }
-    if (entityResults.length > 0) {
-      if (e.key === 'ArrowDown') { e.preventDefault(); setEntityIndex((i) => (i + 1) % entityResults.length); return; }
-      if (e.key === 'ArrowUp') { e.preventDefault(); setEntityIndex((i) => (i - 1 + entityResults.length) % entityResults.length); return; }
+    if (entityPicker.entityResults.length > 0) {
+      if (e.key === 'ArrowDown') { e.preventDefault(); entityPicker.moveDown(); return; }
+      if (e.key === 'ArrowUp') { e.preventDefault(); entityPicker.moveUp(); return; }
       // §5.2 select 가드: async 윈도우서 index가 범위 밖이면 undefined select 방지(클램프+존재 체크).
-      if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); const ent = entityResults[entityIndex] ?? entityResults[0]; if (ent) selectEntity(ent); return; }
-      if (e.key === 'Escape') { setEntityQuery(null); setEntityResults([]); return; }
+      if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); const ent = entityPicker.entityResults[entityPicker.entityIndex] ?? entityPicker.entityResults[0]; if (ent) selectEntity(ent); return; }
+      if (e.key === 'Escape') { entityPicker.close(); return; }
     }
     if (mentionMembers.length > 0) {
       if (e.key === 'ArrowDown') { e.preventDefault(); setMentionIndex((i) => (i + 1) % mentionMembers.length); return; }
@@ -648,11 +567,11 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
 
         {/* Entity dropdown — story #2263(C-5) ㉡: 종류별 구역(머리글)으로 묶되 열은 안 나눈다
             (entityResults가 이미 groupEntitiesByType로 그룹 순서라 렌더 순서=entityIndex 순서). */}
-        {entityResults.length > 0 && (
+        {entityPicker.entityResults.length > 0 && (
           <ul role="listbox" aria-label="엔티티 후보" className="focus-inset absolute bottom-full left-8 z-50 mb-1 max-h-48 w-72 overflow-y-auto rounded-md border border-border bg-popover shadow-md">
-            {entityResults.map((entity, idx) => {
+            {entityPicker.entityResults.map((entity, idx) => {
               const EntityIcon = ENTITY_ICONS[entity.entity_type] ?? Hash;
-              const isNewGroup = idx === 0 || entityResults[idx - 1]!.entity_type !== entity.entity_type;
+              const isNewGroup = idx === 0 || entityPicker.entityResults[idx - 1]!.entity_type !== entity.entity_type;
               return (
               <li key={`${entity.entity_type}:${entity.entity_id}`}>
                 {isNewGroup && (
@@ -664,9 +583,9 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
                   type="button"
                   id={`entity-opt-${idx}`}
                   role="option"
-                  aria-selected={idx === entityIndex}
+                  aria-selected={idx === entityPicker.entityIndex}
                   onMouseDown={(e) => { e.preventDefault(); selectEntity(entity); }}
-                  className={`flex w-full items-center px-3 py-2 text-left text-sm transition ${idx === entityIndex ? 'bg-accent text-foreground font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}`}
+                  className={`flex w-full items-center px-3 py-2 text-left text-sm transition ${idx === entityPicker.entityIndex ? 'bg-accent text-foreground font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}`}
                 >
                   {/* ㉠: 종류는 위 머리글의 «글자»가 1차 신호 — 이 아이콘은 어디까지나 보조. */}
                   <EntityIcon className="mr-1.5 size-3.5 shrink-0" aria-hidden />
@@ -733,11 +652,11 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
           ref={textareaRef}
           rows={1}
           value={text}
-          aria-controls={commandCandidates.length > 0 ? 'command-opt-0' : mentionMembers.length > 0 ? 'mention-opt-0' : entityResults.length > 0 ? 'entity-opt-0' : undefined}
+          aria-controls={commandCandidates.length > 0 ? 'command-opt-0' : mentionMembers.length > 0 ? 'mention-opt-0' : entityPicker.entityResults.length > 0 ? 'entity-opt-0' : undefined}
           aria-activedescendant={
             commandCandidates.length > 0 ? `command-opt-${commandIndex}`
               : mentionMembers.length > 0 ? `mention-opt-${mentionIndex}`
-              : entityResults.length > 0 ? `entity-opt-${entityIndex}`
+              : entityPicker.entityResults.length > 0 ? `entity-opt-${entityPicker.entityIndex}`
               : undefined
           }
           onChange={(e) => handleTextChange(e.target.value, e.target.selectionStart ?? e.target.value.length)}
@@ -747,8 +666,7 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
             window.setTimeout(() => {
               setMentionQuery(null);
               setMentionMembers([]);
-              setEntityQuery(null);
-              setEntityResults([]);
+              entityPicker.close();
               setCommandQuery(null);
             }, 150);
           }}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -27,6 +27,7 @@ import { initials } from '@/lib/storage/format';
 import { ArtifactSection } from '@/components/canvas/artifact-section';
 import { StuckHandoffSection } from '@/components/cage/stuck-handoff-section';
 import { EntityBacklinksSection } from '@/components/shared/entity-backlinks-section';
+import { EntityAwareTextarea } from '@/components/shared/entity-aware-textarea';
 import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
 import { PrLinkSection } from '@/components/integrations/pr-link-section';
 import { Button } from '@/components/ui/button';
@@ -1093,10 +1094,14 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
               </div>
               {editingDescription ? (
                 <div className="mt-2 space-y-2">
-                  <textarea
+                  {/* story #2264(C-6) AC3: 새 자리 비용 = 설정 한 줄 — <textarea>를
+                      <EntityAwareTextarea>로 바꾸고 projectId만 넘기면 `#` 피커가 붙는다.
+                      참조 코어(chat-input-entity-tokens.ts/use-entity-picker.ts) diff 0. */}
+                  <EntityAwareTextarea
                     value={descriptionDraft}
-                    onChange={(e) => setDescriptionDraft(e.target.value)}
+                    onChange={setDescriptionDraft}
                     onPaste={handlePasteAttach}
+                    projectId={projectId}
                     placeholder="Markdown 형식으로 작성하세요..."
                     className="flex field-sizing-content min-h-[160px] w-full resize-y rounded-lg border border-input bg-transparent px-2.5 py-2 font-mono text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
                     autoFocus
@@ -1148,9 +1153,11 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
               </div>
               {editingAC ? (
                 <div className="mt-2 space-y-2">
-                  <textarea
+                  {/* story #2264(C-6) AC3: 같은 설정 한 줄 — description과 동일 컴포넌트 재사용. */}
+                  <EntityAwareTextarea
                     value={acDraft}
-                    onChange={(e) => setAcDraft(e.target.value)}
+                    onChange={setAcDraft}
+                    projectId={projectId}
                     placeholder="Markdown 형식으로 작성하세요..."
                     className="flex field-sizing-content min-h-[160px] w-full resize-y rounded-lg border border-input bg-transparent px-2.5 py-2 font-mono text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
                     autoFocus

--- a/apps/web/src/components/shared/entity-aware-textarea.test.tsx
+++ b/apps/web/src/components/shared/entity-aware-textarea.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+//
+// story #2264(C-6) — EntityAwareTextarea가 참조 코어(chat-input-entity-tokens.ts +
+// use-entity-picker.ts)를 그대로 재사용해 `#` 피커가 실제로 동작하는지 확인한다. 채팅
+// (chat-input.test.tsx)과 같은 검색 fetch·토큰조립을 story 본문 자리에서도 그대로 검증.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { EntityAwareTextarea } from './entity-aware-textarea';
+
+// 실제 controlled input처럼 동작해야 e.target.value/selectionStart가 이어지는 입력에서
+// 최신값을 반영한다 — 바깥 let 변수만 갱신하면 리렌더가 없어 DOM value가 안 바뀐다.
+function ControlledHarness({ initial, projectId, onValueChange }: { initial: string; projectId?: string; onValueChange: (v: string) => void }) {
+  const [value, setValue] = useState(initial);
+  return (
+    <EntityAwareTextarea
+      value={value}
+      onChange={(v) => { setValue(v); onValueChange(v); }}
+      projectId={projectId}
+    />
+  );
+}
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+function textarea(): HTMLTextAreaElement {
+  return container.querySelector('textarea') as HTMLTextAreaElement;
+}
+
+describe('EntityAwareTextarea — story #2264', () => {
+  it('projectId 없이는 `#`을 쳐도 피커가 안 뜬다(검색 스코프 없이 조회 안 함)', async () => {
+    let value = '';
+    await act(async () => {
+      root.render(<EntityAwareTextarea value={value} onChange={(v) => { value = v; }} />);
+    });
+    const el = textarea();
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(el, '#');
+      el.selectionStart = 1;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => { await new Promise((r) => setTimeout(r, 260)); });
+    expect(container.querySelector('[role="listbox"]')).toBeNull();
+  });
+
+  it('projectId가 있으면 `#` 후보 검색이 뜨고 선택하면 escape된 토큰이 삽입된다(채팅 applyEntity와 동일 규칙)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/entities/search')) {
+        return new Response(JSON.stringify({
+          data: [{ entity_type: 'story', entity_id: '11111111-1111-1111-1111-111111111111', title: '[TAG] 위험한 제목]', status: null }],
+        }));
+      }
+      return new Response(JSON.stringify({ data: [] }));
+    }));
+
+    let value = '';
+    await act(async () => {
+      root.render(<ControlledHarness initial="" projectId="p1" onValueChange={(v) => { value = v; }} />);
+    });
+    const el = textarea();
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(el, '#');
+      el.selectionStart = 1;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => { await new Promise((r) => setTimeout(r, 260)); });
+
+    const option = container.querySelector('[role="option"]') as HTMLButtonElement;
+    expect(option).not.toBeNull();
+    await act(async () => {
+      option.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    });
+
+    // ⛔title에 `]`가 있어도(팀 [TAG] 관례) 링크 구문이 안 끊긴다 — #2292 escape 규칙 그대로.
+    expect(value).toContain('\\]');
+    expect(value).toContain('(entity:story:11111111-1111-1111-1111-111111111111)');
+  });
+});

--- a/apps/web/src/components/shared/entity-aware-textarea.test.tsx
+++ b/apps/web/src/components/shared/entity-aware-textarea.test.tsx
@@ -92,4 +92,25 @@ describe('EntityAwareTextarea — story #2264', () => {
     expect(value).toContain('\\]');
     expect(value).toContain('(entity:story:11111111-1111-1111-1111-111111111111)');
   });
+
+  it('⛔드롭다운(overflow-y-auto listbox)에 focus-inset이 있다 — story #2062 회귀가드(verify:focus-inset-coverage) 재발 방지', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      data: [{ entity_type: 'story', entity_id: '11111111-1111-1111-1111-111111111111', title: '제목', status: null }],
+    }))));
+    await act(async () => {
+      root.render(<ControlledHarness initial="" projectId="p1" onValueChange={() => {}} />);
+    });
+    const el = textarea();
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(el, '#');
+      el.selectionStart = 1;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => { await new Promise((r) => setTimeout(r, 260)); });
+
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox).not.toBeNull();
+    expect(listbox!.className).toContain('focus-inset');
+  });
 });

--- a/apps/web/src/components/shared/entity-aware-textarea.tsx
+++ b/apps/web/src/components/shared/entity-aware-textarea.tsx
@@ -86,6 +86,10 @@ export function EntityAwareTextarea({ value, onChange, projectId, placeholder, c
                     {entityTypeLabel(entity.entity_type)}
                   </div>
                 )}
+                {/* ⛔focus-outset을 일부러 안 붙인다(PO 확認, 2026-07-28) — 이 하이라이트(bg-accent)는
+                    entityIndex state로 그려지는 것이지 실제 DOM :focus가 아니다(화살표nav가 textarea에
+                    머물고 이 버튼으로 진짜 focus를 옮기지 않는다). 즉 여기엔 클리핑될 포커스 링 자체가
+                    없다 — "형제(listbox)엔 focus-inset이 있는데 여긴 outset이 없네" 하고 넣지 말 것. */}
                 <button
                   type="button"
                   role="option"

--- a/apps/web/src/components/shared/entity-aware-textarea.tsx
+++ b/apps/web/src/components/shared/entity-aware-textarea.tsx
@@ -75,7 +75,7 @@ export function EntityAwareTextarea({ value, onChange, projectId, placeholder, c
       />
       {/* story #2263(C-5) ㉠㉡㉢ 그대로 재사용 — chat-input.tsx 엔티티 dropdown과 동형 렌더. */}
       {entityPicker.entityResults.length > 0 && (
-        <ul role="listbox" aria-label="엔티티 후보" className="absolute left-0 z-50 mt-1 max-h-48 w-72 overflow-y-auto rounded-md border border-border bg-popover shadow-md">
+        <ul role="listbox" aria-label="엔티티 후보" className="focus-inset absolute left-0 z-50 mt-1 max-h-48 w-72 overflow-y-auto rounded-md border border-border bg-popover shadow-md">
           {entityPicker.entityResults.map((entity, idx) => {
             const EntityIcon = ENTITY_ICONS[entity.entity_type] ?? Hash;
             const isNewGroup = idx === 0 || entityPicker.entityResults[idx - 1]!.entity_type !== entity.entity_type;

--- a/apps/web/src/components/shared/entity-aware-textarea.tsx
+++ b/apps/web/src/components/shared/entity-aware-textarea.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useRef, type ClipboardEvent, type KeyboardEvent } from 'react';
+import { Hash } from 'lucide-react';
+import { ENTITY_ICONS } from '@/components/chat/embed-card';
+import { entityTypeLabel, getEntityQuery, type EntityResult } from '@/components/chat/chat-input-entity-tokens';
+import { useEntityPicker } from '@/hooks/use-entity-picker';
+
+interface EntityAwareTextareaProps {
+  value: string;
+  onChange: (next: string) => void;
+  /** 후보 검색 스코프 — 없으면 `#` 트리거는 그대로 타이핑되고 피커는 안 뜬다(useEntityPicker
+   * 자체가 projectId 없이는 검색을 안 걺). */
+  projectId?: string;
+  placeholder?: string;
+  className?: string;
+  autoFocus?: boolean;
+  onPaste?: (e: ClipboardEvent<HTMLTextAreaElement>) => void;
+}
+
+/**
+ * story #2264(C-6) AC3 판정 대상 — 새 자리를 여는 «설정 한 줄». `#` 엔티티 피커가 필요한
+ * 어떤 textarea든 이 컴포넌트로 바꾸기만 하면 된다(참조 코어 = chat-input-entity-tokens.ts +
+ * use-entity-picker.ts, 이 파일은 그 위의 얇은 렌더 래퍼 — chat-input.tsx의 entity dropdown
+ * JSX를 그대로 재사용). story description/AC(story-detail-panel.tsx)가 첫 소비자.
+ */
+export function EntityAwareTextarea({ value, onChange, projectId, placeholder, className, autoFocus, onPaste }: EntityAwareTextareaProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const entityPicker = useEntityPicker(projectId);
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const nextValue = e.target.value;
+    const cursorPos = e.target.selectionStart ?? nextValue.length;
+    onChange(nextValue);
+    const eq = getEntityQuery(nextValue, cursorPos);
+    if (eq !== null) entityPicker.setEntityQuery(eq);
+    else entityPicker.close();
+  };
+
+  const selectEntity = (entity: EntityResult) => {
+    const textarea = textareaRef.current;
+    const cursorPos = textarea?.selectionStart ?? value.length;
+    const { text: nextText, caretPos } = entityPicker.selectAndApply(entity, value, cursorPos);
+    onChange(nextText);
+    requestAnimationFrame(() => {
+      textarea?.focus();
+      textarea?.setSelectionRange(caretPos, caretPos);
+    });
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (entityPicker.entityResults.length === 0) return;
+    if (e.key === 'ArrowDown') { e.preventDefault(); entityPicker.moveDown(); return; }
+    if (e.key === 'ArrowUp') { e.preventDefault(); entityPicker.moveUp(); return; }
+    if (e.key === 'Enter' || e.key === 'Tab') {
+      e.preventDefault();
+      const ent = entityPicker.entityResults[entityPicker.entityIndex] ?? entityPicker.entityResults[0];
+      if (ent) selectEntity(ent);
+      return;
+    }
+    if (e.key === 'Escape') { entityPicker.close(); return; }
+  };
+
+  return (
+    <div className="relative">
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onPaste={onPaste}
+        placeholder={placeholder}
+        className={className}
+        autoFocus={autoFocus}
+      />
+      {/* story #2263(C-5) ㉠㉡㉢ 그대로 재사용 — chat-input.tsx 엔티티 dropdown과 동형 렌더. */}
+      {entityPicker.entityResults.length > 0 && (
+        <ul role="listbox" aria-label="엔티티 후보" className="absolute left-0 z-50 mt-1 max-h-48 w-72 overflow-y-auto rounded-md border border-border bg-popover shadow-md">
+          {entityPicker.entityResults.map((entity, idx) => {
+            const EntityIcon = ENTITY_ICONS[entity.entity_type] ?? Hash;
+            const isNewGroup = idx === 0 || entityPicker.entityResults[idx - 1]!.entity_type !== entity.entity_type;
+            return (
+              <li key={`${entity.entity_type}:${entity.entity_id}`}>
+                {isNewGroup && (
+                  <div className="sticky top-0 bg-popover px-3 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    {entityTypeLabel(entity.entity_type)}
+                  </div>
+                )}
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={idx === entityPicker.entityIndex}
+                  onMouseDown={(e) => { e.preventDefault(); selectEntity(entity); }}
+                  className={`flex w-full items-center px-3 py-2 text-left text-sm transition ${idx === entityPicker.entityIndex ? 'bg-accent text-foreground font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}`}
+                >
+                  <EntityIcon className="mr-1.5 size-3.5 shrink-0" aria-hidden />
+                  <span className="font-medium">{entity.title}</span>
+                  {entity.status ? (
+                    <span className="ml-2 rounded px-1.5 py-0.5 text-xs bg-muted text-muted-foreground">{entity.status}</span>
+                  ) : null}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-entity-picker.ts
+++ b/apps/web/src/hooks/use-entity-picker.ts
@@ -1,0 +1,62 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { applyEntity, entityTypeLabel, groupEntitiesByType, type EntityResult } from '@/components/chat/chat-input-entity-tokens';
+
+/**
+ * story #2264(C-6) — `#` 엔티티 피커의 상태·검색·토큰조립을 채팅(chat-input.tsx)에서 뽑아낸
+ * 재사용 hook. AC3(새 자리 비용 = 설정 한 줄) 판정의 핵심: 이 파일이 «참조 코어»고, 새 자리를
+ * 여는 것은 이 hook을 부르고 렌더 3~4줄을 붙이는 것뿐이어야 한다.
+ *
+ * 스코프: `#` 트리거·후보 검색·토큰조립(applyEntity)·키보드nav만 담당한다. `@`멘션·`/`커맨드는
+ * 채팅 전용 개념이라 이 hook 밖(ChatInput이 계속 소유)이다 — story 본문/AC엔 그 둘이 없다.
+ */
+export function useEntityPicker(projectId: string | undefined) {
+  const [entityQuery, setEntityQuery] = useState<string | null>(null);
+  const [entityResults, setEntityResults] = useState<EntityResult[]>([]);
+  const [entityIndex, setEntityIndex] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    // ⛔entityQuery가 null로 바뀌는 유일한 경로는 close()/selectAndApply()인데 그 둘 다 이미
+    // entityResults를 직접 비운다 — 여기서 또 setState하면 react-hooks/set-state-in-effect가
+    // 막는 "effect 안 동기 setState" 패턴이 된다(#2299에서 만난 같은 규율). 그래서 이 분기는
+    // fetch를 안 거는 것으로 충분하고, 결과 초기화 책임은 호출부(close 등)에 둔다.
+    if (entityQuery === null || !projectId) return;
+    const timer = window.setTimeout(() => {
+      const params = new URLSearchParams({ project_id: projectId });
+      if (entityQuery) params.set('q', entityQuery);
+      fetch(`/api/entities/search?${params}`)
+        .then((r) => r.json())
+        .then((json: EntityResult[] | { data?: EntityResult[] }) => {
+          if (cancelled) return;
+          const arr = Array.isArray(json) ? json : (json.data ?? []);
+          setEntityResults(groupEntitiesByType(Array.isArray(arr) ? arr : []));
+          setEntityIndex(0);
+        })
+        .catch(() => {});
+    }, 200);
+    return () => { cancelled = true; window.clearTimeout(timer); };
+  }, [entityQuery, projectId]);
+
+  return {
+    entityQuery,
+    entityResults,
+    entityIndex,
+    /** 입력 텍스트가 `#쿼리`로 바뀔 때마다 호출 — null이면 피커를 닫는다. */
+    setEntityQuery,
+    close: () => { setEntityQuery(null); setEntityResults([]); },
+    moveDown: () => setEntityIndex((i) => (entityResults.length ? (i + 1) % entityResults.length : 0)),
+    moveUp: () => setEntityIndex((i) => (entityResults.length ? (i - 1 + entityResults.length) % entityResults.length : 0)),
+    /** 선택 결과 텍스트/caret을 돌려주고 피커를 닫는다 — text state 반영·refocus는 호출부 책임
+     * (호출부마다 textarea ref가 다르므로 hook이 DOM을 직접 만지지 않는다). */
+    selectAndApply(entity: EntityResult, value: string, cursorPos: number): { text: string; caretPos: number } {
+      const result = applyEntity(value, cursorPos, entity.title, entity.entity_type, entity.entity_id);
+      setEntityQuery(null);
+      setEntityResults([]);
+      return result;
+    },
+  };
+}
+
+export { entityTypeLabel, groupEntitiesByType, type EntityResult };


### PR DESCRIPTION
## AC3 판정 — "새 자리 비용 = 설정 한 줄"

- **참조 코어(신규)**: `chat-input-entity-tokens.ts`(EntityResult·getEntityQuery·escapeMarkdownLinkText·applyEntity·entityTypeLabel·groupEntitiesByType) + `use-entity-picker.ts`(검색 상태·디바운스·키보드nav) — 전부 `chat-input.tsx`에서 로직 변경 없이 그대로 옮겼다.
- `chat-input.tsx`는 이제 이 둘의 **소비자**로 바뀌었다(재-export로 기존 테스트 import 경로 보존) — 전체 chat 테스트 73건 무회귀.
- **새 자리(story 본문/AC)**: `entity-aware-textarea.tsx`(신규, 얇은 렌더 래퍼) + `story-detail-panel.tsx`의 `<textarea>` 2곳을 교체 + `projectId` prop 1개. **참조 코어 두 파일은 이 새 자리가 생긴 뒤로 한 글자도 안 바뀌었다** — diff로 확인 가능.

## AC4(권한) — 새 판정 0

`useEntityPicker`가 부르는 `/api/entities/search`는 chat-input.tsx와 완전히 같은 엔드포인트라 `has_project_access` 게이트가 자동으로 그대로 적용된다.

## AC5 — 연 것과 안 연 것

| 자리 | 상태 |
|---|---|
| story 본문 | ✅이번 판 |
| story AC | ✅이번 판 |
| doc 본문 | ❌미착수 — tiptap(HTML wikiLink/pageEmbed, `data-doc-id` 전용) 구조가 채팅의 마크다운 토큰과 완전히 달라 파서 자체를 바꿔야 함(사전 그라운딩 ①~④ 보고 그대로) — 별건 |
| 에픽 본문 | ❌미착수 |
| 댓글 | ❌미착수 |

## ⛔아직 남은 BE 갭 (그라운딩 ④에서 이미 보고, 재확인됨)

`POST /api/v2/references`(#2582)의 `_SOURCE_TYPE_CONFIG`는 지금 `"chat_message"` 하나만 등록돼 있다. story 본문에 `#`으로 토큰을 심는 것(이 PR로 가능해짐)과, 그 관계가 실제 `Reference` 행으로 저장되는 것(BE 파서, story-본문판 `insert_chat_mentions` 필요)은 다른 일이다 — 토큰은 렌더되지만(entity 링크로 정상 표시) #2299 backlinks에는 아직 안 잡힌다. "왕복"의 쓰기-UI 절반은 이번 판, 저장·파싱 절반은 BE 별건으로 남는다.

## 검증

- mutation-verified: `selectAndApply`가 실제로 `applyEntity`(escape 포함)를 부르는지 — 우회 삽입으로 바꾸면 테스트 RED → 원복 GREEN.
- 신규 테스트: `entity-aware-textarea.test.tsx` 2건(projectId 없으면 검색 안 함 / 있으면 검색+토큰조립+escape 확인).
- 전체 FE vitest: 299 파일 · 1999 테스트 PASS(회귀 0). `tsc --noEmit`/`eslint` 무오류.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>