### PR TITLE
feat(#2298): GET /api/v2/goals?include=glance — 3단 웨이터폴 근절

### DIFF
--- a/backend/app/repositories/goal.py
+++ b/backend/app/repositories/goal.py
@@ -6,6 +6,7 @@ from typing import Any
 from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.gate import Gate
 from app.models.hypothesis import Hypothesis, HypothesisEpicLink
 from app.models.pm import Goal, Story
 from app.repositories.base import BaseRepository
@@ -152,6 +153,78 @@ class GoalRepository(BaseRepository[Goal]):
                 continue
             goal.total_stories = int(row.total_stories or 0)  # type: ignore[attr-defined]
             goal.done_stories = int(row.done_stories or 0)  # type: ignore[attr-defined]
+
+    async def attach_glance_aggregates(self, goals: Sequence[Goal]) -> None:
+        """story #2298(3단 웨이터폴 근절) — `?include=glance` 옵트인 전용, `list_paginated`
+        기본 경로는 이걸 안 부른다(byte-identical 보장은 라우터가 호출 여부로 가른다).
+
+        participant_ids: 에픽별 고유 assignee_id 집합(FE `deriveCollaboration` 이관 — "참여=
+        presence만"이라 집합 계산, 캡을 두면 뒤쪽 story의 assignee가 빠져 값 자체가 틀려진다
+        — 그래서 캡 없음).
+
+        focal_story: FE `pickFocalStory`(in-progress 중 gate-pending 우선, 없으면 최신
+        in-progress) 이관. tiebreak는 기존 `/api/stories?epic_id=` 기본 정렬(created_at DESC,
+        id DESC)과 동일하게 맞춘다 — gate 우선순위 자체는 이번에 "처음으로" 실제 재료(gate
+        데이터)를 갖고 평가된다(`GlanceFocalStory` docstring 참조 — 기존엔 재료가 없어 죽어
+        있던 분기)."""
+        for goal in goals:
+            goal.participant_ids = []  # type: ignore[attr-defined]
+            goal.focal_story = None  # type: ignore[attr-defined]
+        if not goals:
+            return
+
+        goal_ids = [g.id for g in goals]
+
+        participant_rows = await self.session.execute(
+            select(Story.epic_id, Story.assignee_id).where(
+                Story.epic_id.in_(goal_ids), Story.org_id == self.org_id,
+                Story.deleted_at.is_(None), Story.assignee_id.isnot(None),
+            )
+        )
+        participants_by_goal: dict[uuid.UUID, set[uuid.UUID]] = {}
+        for epic_id, assignee_id in participant_rows.all():
+            participants_by_goal.setdefault(epic_id, set()).add(assignee_id)
+        for goal in goals:
+            ids = participants_by_goal.get(goal.id)
+            if ids:
+                goal.participant_ids = sorted(ids, key=str)  # type: ignore[attr-defined]
+
+        in_progress_rows = await self.session.execute(
+            select(Story.id, Story.epic_id, Story.title, Story.status, Story.assignee_id)
+            .where(
+                Story.epic_id.in_(goal_ids), Story.org_id == self.org_id,
+                Story.deleted_at.is_(None), Story.status == "in-progress",
+            )
+            .order_by(Story.created_at.desc(), Story.id.desc())
+        )
+        candidates_by_goal: dict[uuid.UUID, list] = {}
+        story_ids: list[uuid.UUID] = []
+        for row in in_progress_rows.all():
+            candidates_by_goal.setdefault(row.epic_id, []).append(row)
+            story_ids.append(row.id)
+
+        # N+1 회피 — 배치 gate 조회. Gate는 work_item_id/work_item_type 폴리모픽(FK 없음,
+        # S11 workflow-line 배치 read와 동일 패턴: work_item_id.in_(ids)).
+        pending_story_ids: set[uuid.UUID] = set()
+        if story_ids:
+            gate_rows = await self.session.execute(
+                select(Gate.work_item_id).where(
+                    Gate.work_item_id.in_(story_ids), Gate.work_item_type == "story",
+                    Gate.org_id == self.org_id, Gate.status == "pending",
+                )
+            )
+            pending_story_ids = set(gate_rows.scalars().all())
+
+        for goal in goals:
+            candidates = candidates_by_goal.get(goal.id)
+            if not candidates:
+                continue
+            picked = next((r for r in candidates if r.id in pending_story_ids), candidates[0])
+            goal.focal_story = {  # type: ignore[attr-defined]
+                "id": picked.id, "title": picked.title, "status": picked.status,
+                "assignee_id": picked.assignee_id,
+                "gate_status": "pending" if picked.id in pending_story_ids else None,
+            }
 
     async def get_progress(self, id: uuid.UUID) -> GoalProgressResponse:
         result = await self.session.execute(

--- a/backend/app/routers/goals.py
+++ b/backend/app/routers/goals.py
@@ -8,6 +8,7 @@ import uuid
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -15,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.repositories.goal import GoalRepository
-from app.schemas.goal import GoalCreate, GoalProgressResponse, GoalResponse, GoalUpdate
+from app.schemas.goal import GoalCreate, GoalProgressResponse, GoalResponse, GoalUpdate, GoalWithGlanceResponse
 from app.services.project_auth import has_project_access
 
 router = APIRouter(tags=["goals", "Work"])
@@ -28,7 +29,7 @@ def _get_repo(
     return GoalRepository(session, org_id)
 
 
-@router.get("", response_model=list[GoalResponse])
+@router.get("", response_model=None)
 async def list_goals(
     response: Response,
     project_id: uuid.UUID | None = Query(default=None),
@@ -36,17 +37,27 @@ async def list_goals(
     limit: int | None = Query(default=None, ge=1, le=2000),
     cursor: str | None = Query(default=None, description="Cursor: ISO 8601 created_at, fetch before this time"),
     order_by: str = Query(default="created_at"),
+    include: str | None = Query(
+        default=None,
+        description='"glance"면 participant_ids/focal_story가 추가로 붙는다(story #2298, 옵트인).',
+    ),
     repo: GoalRepository = Depends(_get_repo),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
-) -> list[GoalResponse]:
+) -> list[GoalResponse] | JSONResponse:
     """목표 목록 — true cursor 페이지네이션 + 전체 카운트(X-Total-Count 헤더).
 
     1000+ 목표가 조용히 잘리던 문제(#1200/569f5316)를 근절: limit/cursor로 위임
     페이지네이션하고, 페이지와 무관한 전체 개수를 X-Total-Count로 노출한다.
     limit 미지정 시 기존 동작(최대 1000)과 호환되며, 1000+ 인 경우에도 헤더로
     잘림 여부를 호출자가 인지할 수 있어 silent-truncation이 아니다.
-    """
+
+    ⛔story #2298(3단 웨이터폴 근절, 오르테가 계약 2026-07-29): `include=glance`는 순수
+    옵트인이다 — 파라미터가 없으면 이 함수는 기존과 완전히 같은 코드 경로(`response_model`을
+    `None`으로 바꾼 것은 두 응답 모델을 라우터가 직접 분기하기 위함일 뿐, 미지정 시 반환값은
+    이전과 byte-identical — `test_2298_goals_glance_include_realdb.py`가 그걸 고정한다).
+    `GoalResponse`에 optional 필드를 얹지 않고 별도 `GoalWithGlanceResponse`로 가른 이유도
+    같다(같은 모델에 얹으면 기본값이라도 JSON에 항상 찍혀 계약이 깨진다)."""
     # ratchet round8(잔여 HIGH): project_id 필터(지정 시)에 caller 접근권 검증이 없어
     # same-org cross-project goal(제목/목표/전략의도)이 노출됐다 — resource-actual
     # project_id 직접검증. EE 훅 없음(이 엔드포인트는 EE RBAC 미적용 확認).
@@ -73,12 +84,29 @@ async def list_goals(
     goals, total = await repo.list_paginated(
         limit=limit, cursor=cursor_dt, order_by=order_by, **filters
     )
-    response.headers["X-Total-Count"] = str(total)
-    # order_by="position"(옵트인 로드맵 조타 정렬, wedge #2)은 복합 정렬이라 created_at cursor로
-    # 이어붙일 수 없다 — 이 모드에서는 X-Next-Cursor 미노출(호출자가 이어달리기 시도 안 하도록).
+
+    if include != "glance":
+        response.headers["X-Total-Count"] = str(total)
+        # order_by="position"(옵트인 로드맵 조타 정렬, wedge #2)은 복합 정렬이라 created_at
+        # cursor로 이어붙일 수 없다 — 이 모드에서는 X-Next-Cursor 미노출(호출자가 이어달리기
+        # 시도 안 하도록).
+        if goals and order_by != "position":
+            response.headers["X-Next-Cursor"] = goals[-1].created_at.isoformat()
+        return [GoalResponse.model_validate(e) for e in goals]
+
+    # ⛔직접 Response를 반환하면 위 `response: Response` 의존성에 건 헤더는 FastAPI가 안
+    # 적용한다(반환한 Response 객체가 그대로 나간다) — 여기 JSONResponse에 같은 헤더를
+    # 다시 건다.
+    await repo.attach_glance_aggregates(goals)
+    glance_response = JSONResponse(
+        content=[
+            GoalWithGlanceResponse.model_validate(e).model_dump(mode="json") for e in goals
+        ]
+    )
+    glance_response.headers["X-Total-Count"] = str(total)
     if goals and order_by != "position":
-        response.headers["X-Next-Cursor"] = goals[-1].created_at.isoformat()
-    return [GoalResponse.model_validate(e) for e in goals]
+        glance_response.headers["X-Next-Cursor"] = goals[-1].created_at.isoformat()
+    return glance_response
 
 
 def _resolve_outcome_status(metric_definition: object, measure_after: object, current_status: str = "n_a") -> str:

--- a/backend/app/schemas/goal.py
+++ b/backend/app/schemas/goal.py
@@ -104,6 +104,38 @@ class GoalResponse(BaseModel):
         return build_reference_token("epic", self.id, self.title)
 
 
+class GlanceFocalStory(BaseModel):
+    """story #2298(3단 웨이터폴 근절) — `pickFocalStory`(FE `hero-logic.ts`) 규칙을 서버로
+    이관한 결과. gate_status는 in-progress 후보들 중 하나라도 pending gate가 있으면 그
+    story가 우선 선택되고("gate-우선"), 이 필드엔 그 pending 게이트가 있었는지만 담는다
+    (전체 gate 목록은 안 실음 — 이 필드가 실제로 쓰이는 axis 하나뿐이라 과확장 금지).
+
+    ⛔이 규칙은 FE 원본에도 있었지만 `/api/stories?epic_id=` 응답에 `gates` 필드 자체가
+    없어(전 코드베이스 grep 확인, `StoryResponse`에 그 필드 없음) 실제로는 단 한 번도
+    평가된 적이 없다(2026-07-12 story dee92c96 도입 이래 죽어있던 분기 — git log -S로 확인,
+    "언제부터 회귀했는지"가 아니라 "애초에 재료가 없었다"). 여기서 되살리면 동작이 바뀐다 —
+    지금까지는 항상 in-progress 중 첫 번째였고, 이제부터 gate-pending이 우선한다. 조용히
+    바꾸지 않는다(PR 본문에 명시)."""
+    id: uuid.UUID
+    title: str
+    status: str
+    assignee_id: uuid.UUID | None
+    gate_status: str | None
+
+
+class GoalWithGlanceResponse(GoalResponse):
+    """story #2298 AC — `?include=glance` 옵트인 전용 응답(기본 `GoalResponse`와 별도 모델
+    이유: 파라미터 없을 때 기존 응답이 byte-identical이어야 하는 계약이라, 같은 모델에
+    optional 필드를 얹으면 기본값이라도 JSON에 항상 찍혀 계약이 깨진다 — 그래서 라우터가
+    두 모델을 분기해 반환한다).
+
+    participant_ids: 이 goal(에픽)에 연결된 story들의 고유 assignee_id 집합(FE
+    `deriveCollaboration` 이관 — "참여=presence만, 개수 집계 0"과 동일 의미. 집합 계산이라
+    부분 반환("N건 더")이 불가능 — 캡을 두면 그 자체로 값이 틀려진다, 그래서 캡을 두지 않는다."""
+    participant_ids: list[uuid.UUID] = []
+    focal_story: GlanceFocalStory | None = None
+
+
 class GoalProgressResponse(BaseModel):
     goal_id: uuid.UUID
     total_stories: int

--- a/backend/tests/test_2298_goals_glance_include_realdb.py
+++ b/backend/tests/test_2298_goals_glance_include_realdb.py
@@ -1,0 +1,375 @@
+"""story #2298(3단 웨이터폴 근절, 오르테가 계약 2026-07-29, 스레드 7256d5cc) —
+`GET /api/v2/goals?include=glance` 실PG 검증.
+
+계약 핵심 셋:
+  ①`include` 파라미터 없으면 기존 응답과 byte-identical(다른 소비자 안 무거워짐의 보증)
+  ②`participant_ids` — 에픽별 고유 assignee 집합, 캡 없음(집합 계산이라 부분 반환 불가)
+  ③`focal_story` — gate-pending 우선 선정(오늘 처음 실제로 재료를 갖고 평가되는 분기,
+    `GlanceFocalStory` docstring 참조)
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _make_org(session, name="Org"):
+    from app.models.organization import Organization
+    org = Organization(id=uuid.uuid4(), name=name, slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    return org
+
+
+async def _make_project(session, org_id, name="P"):
+    from app.models.project import Project
+    project = Project(id=uuid.uuid4(), org_id=org_id, name=name)
+    session.add(project)
+    await session.commit()
+    return project
+
+
+async def _make_human_member(session, org_id, project_id, name="Human"):
+    from app.models.user import User
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.member import Member
+
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="member")
+    session.add(om)
+    await session.flush()
+    m = Member(id=om.id, org_id=org_id, type="human", user_id=user.id, name=name)
+    session.add(m)
+    await session.flush()
+    session.add(ProjectAccess(project_id=project_id, org_member_id=om.id, member_id=m.id, role="member"))
+    await session.commit()
+    return m.id, user.id
+
+
+async def _make_goal(session, org_id, project_id, title="Goal"):
+    from app.models.pm import Goal
+    goal = Goal(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status="active")
+    session.add(goal)
+    await session.commit()
+    return goal
+
+
+async def _make_story(session, org_id, project_id, epic_id, assignee_id=None, status="backlog", title="Story"):
+    from app.models.pm import Story
+    story = Story(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, epic_id=epic_id,
+        title=title, status=status, assignee_id=assignee_id,
+    )
+    session.add(story)
+    await session.commit()
+    return story
+
+
+async def _make_gate(session, org_id, story_id, status="pending", gate_type="human_review"):
+    from app.models.gate import Gate
+    gate = Gate(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=story_id, work_item_type="story",
+        gate_type=gate_type, status=status,
+    )
+    session.add(gate)
+    await session.commit()
+    return gate
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ─── ①옵트인 — 파라미터 없으면 기존과 byte-identical ─────────────────────────
+
+
+async def test_goals_list_without_include_has_no_glance_fields():
+    from app.main import app
+    from app.schemas.goal import GoalResponse
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            await _make_goal(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/goals", params={"project_id": str(project.id)})
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert len(body) == 1
+            assert "participant_ids" not in body[0], body[0]
+            assert "focal_story" not in body[0], body[0]
+            assert set(body[0].keys()) == set(GoalResponse.model_fields) | {"reference_token"}
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_goals_list_include_glance_adds_the_two_new_fields_only():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            await _make_goal(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/goals", params={"project_id": str(project.id), "include": "glance"},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert len(body) == 1
+            assert body[0]["participant_ids"] == []
+            assert body[0]["focal_story"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ②participant_ids — 집합, 캡 없음 ────────────────────────────────────────
+
+
+async def test_participant_ids_collects_all_assignees_uncapped():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id)
+            member_ids = []
+            for i in range(6):
+                mid, _ = await _make_human_member(s, org.id, project.id, name=f"M{i}")
+                member_ids.append(mid)
+                await _make_story(s, org.id, project.id, goal.id, assignee_id=mid, title=f"S{i}")
+            # 미배정 story — participant_ids에 안 섞이는지(양성대조).
+            await _make_story(s, org.id, project.id, goal.id, assignee_id=None, title="Unassigned")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/goals", params={"project_id": str(project.id), "include": "glance"},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            got = set(body[0]["participant_ids"])
+            assert got == {str(m) for m in member_ids}, got
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ③focal_story — gate-pending 우선 ────────────────────────────────────────
+
+
+async def test_focal_story_prefers_gate_pending_over_more_recently_created():
+    """더 최근에 만들어진 in-progress story가 있어도, pending gate가 걸린 «더 오래된»
+    story가 focal로 뽑혀야 한다(gate-우선이 tiebreak-순서보다 이긴다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id)
+            older_gated = await _make_story(
+                s, org.id, project.id, goal.id, assignee_id=caller_id,
+                status="in-progress", title="Older, gate-pending",
+            )
+            await _make_gate(s, org.id, older_gated.id, status="pending")
+            # 더 나중에 생성 — created_at DESC tiebreak이면 이게 이겨야 하지만 gate가 없다.
+            await _make_story(
+                s, org.id, project.id, goal.id, assignee_id=caller_id,
+                status="in-progress", title="Newer, no gate",
+            )
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/goals", params={"project_id": str(project.id), "include": "glance"},
+            )
+            assert resp.status_code == 200, resp.text
+            focal = resp.json()[0]["focal_story"]
+            assert focal is not None
+            assert focal["id"] == str(older_gated.id), focal
+            assert focal["gate_status"] == "pending"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_focal_story_falls_back_to_most_recent_in_progress_when_no_gate_pending():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id)
+            await _make_story(
+                s, org.id, project.id, goal.id, assignee_id=caller_id,
+                status="in-progress", title="Older",
+            )
+            newer = await _make_story(
+                s, org.id, project.id, goal.id, assignee_id=caller_id,
+                status="in-progress", title="Newer",
+            )
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/goals", params={"project_id": str(project.id), "include": "glance"},
+            )
+            focal = resp.json()[0]["focal_story"]
+            assert focal is not None
+            assert focal["id"] == str(newer.id), focal
+            assert focal["gate_status"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_focal_story_null_when_no_in_progress_stories():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id)
+            await _make_story(s, org.id, project.id, goal.id, status="backlog")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/goals", params={"project_id": str(project.id), "include": "glance"},
+            )
+            assert resp.json()[0]["focal_story"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── 헤더 정합 — glance 분기도 X-Total-Count 유지(직접 Response 반환 시 놓치는 함정) ──
+
+
+async def test_glance_branch_still_carries_x_total_count_header():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            await _make_goal(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/goals", params={"project_id": str(project.id), "include": "glance"},
+            )
+            assert resp.headers.get("X-Total-Count") == "1", dict(resp.headers)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- 오르테가 계약(스레드 7256d5cc, 2026-07-29). 3단 웨이터폴(epic 목록→epic별 story→hero) 근본 원인: `/api/goals`가 story row를 안 줘서(payload bloat 방지, 원 커밋 e3338befd/0d4c89e8 확인 — 근거 지금도 유효) FE가 epic별로 `/api/stories?epic_id=X`를 따로 불러야 했다.
- 처방을 두 번 정정: row를 캡+옵트인으로 붙이려 했으나 FE가 그 row로 **계산**(collaboration presence·hero 선정)을 한다는 게 드러나 캡이 안전하지 않았다 → 최종은 서버가 계산한 **결과**(`participant_ids`·`focal_story`)만 보내는 것.

## ⚠️ 동작 변경(조용히 안 바꿈 — 명시)
`focal_story` 선정 규칙(FE `pickFocalStory` 이관, gate-pending 우선)이 **사용자가 보는 값을 바꾼다**:
- **지금까지**: in-progress story 중 **첫 번째**(생성순 최신)가 항상 hero로 뽑혔다.
- **이제부터**: in-progress 중 **pending gate가 걸린 것이 우선**, 없으면 기존과 동일(최신 첫 번째).

원인: `/api/stories?epic_id=`에 `gates` 필드가 아예 없어(`StoryResponse` 전체 grep 확인) FE의 gate-우선 분기가 **2026-07-12(story dee92c96) 도입 이래 재료 자체가 없어 한 번도 실제로 평가된 적이 없었다** — "언제부터 회귀했나"가 아니라 "애초에 죽어 있었다"(측정 가능한 사실, 못 쟀다가 아님). 서버 이관으로 실 gate 데이터를 처음 갖게 되어 의도대로 동작하게 되는 것 — 부작용이 아니라 부수적 버그 수정.

## 계약
```
GET /api/v2/goals?...&include=glance
  goals[].participant_ids: [uuid, ...]   ← 고유 assignee 집합, 캡 없음
  goals[].focal_story: {id,title,status,assignee_id,gate_status} | null
```
파라미터 없으면 기존과 byte-identical(다른 소비자 안 무거워짐 보증, 테스트로 고정).

## Test plan
- [x] RED→GREEN 3건(각각 다른 것을 지킴 — 하나로 안 뭉침): 기본경로 필드 leak / gate-우선 무력화 / participant 캡 — 각각 실패 확인 후 원복
- [x] 실PG(alembic head) 신규 7건 + 관련 goals realdb 16/16
- [x] 전체 backend 회귀(realdb 제외) 4207/4208 pass(1건 격리 재실행으로 flaky 확인, 무관)

## FE 핸드오프(미르코군, 별도 PR)
- `pickFocalStory`(hero-logic.ts)·`deriveCollaboration`(services/glance.ts) 완전 삭제(유닛테스트 포함)
- `load-glance-data.ts`의 storyLists per-epic fetch 제거, `include=glance` 응답 직접 사용

🤖 Generated with [Claude Code](https://claude.com/claude-code)