### PR TITLE
feat(#2301): story 본문/AC # 참조 저장 — insert_chat_mentions·reconcile_doc_mentions 병합

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -982,6 +982,39 @@ async def update_story(
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")
 
+    # story #2301(E-CONNECT, 오르테가 판정 2026-07-29): story 본문/AC의 `#` 엔티티 토큰이
+    # 저장 시 entity_references로 걷히지 않던 갭(#2597이 FE 삽입 UI만 열고 BE 파서가 아예
+    # 없었다) — insert_chat_mentions·reconcile_doc_mentions를 병합한 공용 코어
+    # `reconcile_entity_references`를 직접 호출한다(AC1: story 전용 write 헬퍼를 새로
+    # 만들지 않는다). description과 acceptance_criteria는 **서로 다른 source_field**라
+    # 각각 독립적으로 reconcile — 같은 대상을 본문과 AC 양쪽에 걸면 두 행 다 남는다(멱등
+    # 키에 source_field가 있어 서로 다른 참조로 선다). **같은 트랜잭션**(commit 전, 실패
+    # 시 예외 propagate로 story 저장 전체가 롤백 — chat/doc과 동일 AC4 원자성).
+    if "description" in data or "acceptance_criteria" in data:
+        from app.services.mention_parser import extract_chat_entity_mentions, reconcile_entity_references
+
+        _mention_actor_id: uuid.UUID | None = None
+        try:
+            _mention_actor_id = await _resolve_team_member_id(auth, repo.org_id, db)
+        except Exception:
+            _mention_actor_id = None
+        if "description" in data:
+            _desc_pairs = extract_chat_entity_mentions(story.description or "")
+            await reconcile_entity_references(
+                db, org_id=repo.org_id, source_type="story", source_field="description",
+                source_id=story.id,
+                extracted_refs=[(t, i, "mention") for t, i in _desc_pairs],
+                created_by=_mention_actor_id,
+            )
+        if "acceptance_criteria" in data:
+            _ac_pairs = extract_chat_entity_mentions(story.acceptance_criteria or "")
+            await reconcile_entity_references(
+                db, org_id=repo.org_id, source_type="story", source_field="acceptance_criteria",
+                source_id=story.id,
+                extracted_refs=[(t, i, "mention") for t, i in _ac_pairs],
+                created_by=_mention_actor_id,
+            )
+
     # E-STORAGE-SSOT S2: 첨부 교체(attachments 제공) 시 asset registry 재동기화(reconcile·SSOT 정확).
     if "attachments" in data:
         _cb: uuid.UUID | None = None

--- a/backend/app/services/mention_parser.py
+++ b/backend/app/services/mention_parser.py
@@ -212,6 +212,123 @@ class ChatMentionResult:
     dropped: list[dict[str, str]]
 
 
+@dataclass(frozen=True)
+class ReconcileResult:
+    """story #2301(E-CONNECT, 오르테가 판정 2026-07-29) — `insert_chat_mentions`(마크다운
+    파서·target_types 인자·dropped 추적)와 `reconcile_doc_mentions`(diff 기반 stale 삭제)를
+    한 벌로 병합한 코어 `reconcile_entity_references`의 반환값.
+
+    ⛔파서(어떤 문법에서 어떤 토큰을 뽑는가)는 이 코어 밖이다 — caller가 source-format에
+    맞는 추출 함수(마크다운은 `extract_chat_entity_mentions`, doc HTML은
+    `extract_doc_mention_targets`)를 미리 돌려 `(target_type, target_id, form)` 3튜플
+    집합으로 넘긴다. 한 함수 안에 마크다운·HTML 파서 둘을 분기로 박지 않는다(PO 지시,
+    AC1: "story 전용 write 헬퍼가 0" — 이 병합 자체가 그 요건).
+
+    diff-against-empty(신규 source, 기존 참조 0건)는 순수 insert와 결과가 같다 — 그래서
+    이 코어는 "insert-only냐 reconcile이냐"를 인자로 안 가른다(항상 diff). 채팅처럼 불변
+    콘텐츠는 매번 기존 참조가 0건이라 stale 삭제가 구조적으로 안 도는 것으로 회귀 0을
+    보장한다(AC4 — insert_chat_mentions 래퍼가 이 사실에 의존)."""
+
+    stored: int
+    removed: int
+    dropped: list[dict[str, str]]
+
+
+async def reconcile_entity_references(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    source_type: str,
+    source_field: str,
+    source_id: uuid.UUID,
+    extracted_refs: list[tuple[str, uuid.UUID, str]],
+    created_by: uuid.UUID | None,
+    target_types: frozenset[str] = frozenset(ENTITY_RESOLVERS),
+) -> ReconcileResult:
+    """story #2301 — `(source_type, source_field, source_id)` 하나가 «지금» 가리키는 대상
+    전체를 diff로 맞춘다: 사라진 토큰의 참조는 삭제(`removed`), 새로 생긴 토큰은 insert
+    (`stored`). 자기참조(target==source, 예: doc이 자기 자신을 wikiLink)는 드롭(doc의
+    기존 self-ref 가드를 일반화한 것 — `tt == source_type and tid == source_id`).
+
+    `extracted_refs`는 caller가 이미 파싱해 온 (target_type, target_id, form) 3튜플이다 —
+    이 함수는 파싱을 하지 않는다(`ReconcileResult` docstring 참조). `target_types` 밖의
+    target_type은 registry 미등록으로 걸러 `dropped`에 담는다(#2294 관례 그대로 — 침묵 거부
+    금지).
+
+    같은 트랜잭션(caller 세션 그대로 사용, 별도 커밋 없음) — 실패 시 예외가 그대로
+    propagate되어 caller(story/doc/chat 저장 트랜잭션) 전체가 롤백된다(chat/doc 기존
+    AC4 원자성 계약과 동일)."""
+    valid = [(tt, tid, form) for tt, tid, form in extracted_refs if tt in target_types]
+    dropped = [
+        {"target_type": tt, "target_id": str(tid)}
+        for tt, tid, _form in extracted_refs if tt not in target_types
+    ]
+    if dropped:
+        logger.warning(
+            "reconcile_entity_references: dropped %d ref(s) with unregistered target_type "
+            "(source_type=%s, source_field=%s, source_id=%s, target_types=%s) dropped=%s",
+            len(dropped), source_type, source_field, source_id, sorted(target_types), dropped,
+        )
+
+    target_refs = {
+        (tt, tid, form) for tt, tid, form in valid
+        if not (tt == source_type and tid == source_id)
+    }
+
+    existing_rows = await db.execute(
+        select(Reference.target_type, Reference.target_id, Reference.form).where(
+            Reference.org_id == org_id,
+            Reference.source_type == source_type,
+            Reference.source_field == source_field,
+            Reference.source_id == source_id,
+            Reference.form.in_(("mention", "embed")),
+        )
+    )
+    existing_refs = {(row.target_type, row.target_id, row.form) for row in existing_rows.all()}
+
+    stale_refs = existing_refs - target_refs
+    if stale_refs:
+        from sqlalchemy import delete as sa_delete, tuple_
+
+        await db.execute(
+            sa_delete(Reference).where(
+                Reference.org_id == org_id,
+                Reference.source_type == source_type,
+                Reference.source_field == source_field,
+                Reference.source_id == source_id,
+                tuple_(Reference.target_type, Reference.target_id, Reference.form).in_(stale_refs),
+            )
+        )
+
+    new_refs = target_refs - existing_refs
+    if new_refs:
+        canonical_created_by = await canonicalize_member_id(created_by, db)
+        stmt = pg_insert(Reference).values([
+            {
+                "id": uuid.uuid4(),
+                "org_id": org_id,
+                "source_type": source_type,
+                "source_field": source_field,
+                "source_id": source_id,
+                "target_type": target_type,
+                "target_id": target_id,
+                "form": form,
+                "created_by": canonical_created_by,
+            }
+            for target_type, target_id, form in new_refs
+        ])
+        stmt = stmt.on_conflict_do_nothing(
+            index_elements=[
+                Reference.source_type, Reference.source_field, Reference.source_id,
+                Reference.target_type, Reference.target_id, Reference.form,
+            ],
+            index_where=Reference.form != "proof",
+        )
+        await db.execute(stmt)
+
+    return ReconcileResult(stored=len(new_refs), removed=len(stale_refs), dropped=dropped)
+
+
 async def insert_chat_mentions(
     db: AsyncSession,
     *,
@@ -251,7 +368,17 @@ async def insert_chat_mentions(
     없어져 정상 경로에선 `dropped`가 항상 빈 배열이다. 그래도 이 필드를 남기는 이유: 사람이
     손으로 토큰을 치거나 에이전트가 API로 본문을 직접 쓸 수 있어(PO가 직접 실측 — escape
     안 된 raw `]` 토큰이 조용히 버려지는 것을 확인) 그 경로는 여전히 registry 밖 타입을 만들
-    수 있다 — `dropped`가 비지 않는 것 자체가 그 신호(기능이 아니라 가드)다."""
+    수 있다 — `dropped`가 비지 않는 것 자체가 그 신호(기능이 아니라 가드)다.
+
+    ⛔story #2301(2026-07-29): 이 함수는 이제 `reconcile_entity_references`(공용 코어)의
+    얇은 래퍼다 — 파싱(`extract_chat_entity_mentions`, form 항상 "mention")만 여기서 하고
+    실제 write/diff는 코어에 위임한다. 채팅은 매번 신규 메시지(기존 참조 0건)라 diff가
+    항상 순수 insert로 귀결 — 동작 회귀 없음(`ReconcileResult` docstring AC4 참조).
+
+    `all_pairs`가 비거나(토큰 자체가 없는 일반 메시지, 압도적 다수) 필터 후 `pairs`가 비면
+    (전부 registry 밖이라 dropped) 코어 호출 자체를 skip(DB 왕복 0) — 이 원래 있던 얕은
+    최적화를 유지한다(`test_dropped_logging_red_green_mutation_self_check`가 `db=None`으로
+    이 경로를 직접 실증한다 — DB를 안 건드린다는 계약 자체가 테스트로 고정돼 있다)."""
     all_pairs = extract_chat_entity_mentions(content)
     if not all_pairs:
         return ChatMentionResult(stored=0, dropped=[])
@@ -270,33 +397,16 @@ async def insert_chat_mentions(
     if not pairs:
         return ChatMentionResult(stored=0, dropped=dropped)
 
-    canonical_created_by = await canonicalize_member_id(created_by, db)
-    stmt = pg_insert(Reference).values([
-        {
-            "id": uuid.uuid4(),
-            "org_id": org_id,
-            "source_type": "chat_message",
-            "source_field": "body",
-            "source_id": message_id,
-            "target_type": entity_type,
-            "target_id": entity_id,
-            "form": "mention",
-            "created_by": canonical_created_by,
-        }
-        for entity_type, entity_id in pairs
-    ])
-    # 부분 유니크(uq_entity_references_non_proof) 방어 — insert-only 전제라 원칙적으로 이
-    # message_id 에 대한 기존 row 는 없지만(신규 메시지), 같은 메시지 안에 동일 대상을 가리키는
-    # 토큰이 두 번 이상 남아도(추출 단계에서 이미 dedupe 하지만 방어적으로) 무해하게 흡수한다.
-    stmt = stmt.on_conflict_do_nothing(
-        index_elements=[
-            Reference.source_type, Reference.source_field, Reference.source_id,
-            Reference.target_type, Reference.target_id, Reference.form,
-        ],
-        index_where=Reference.form != "proof",
+    # ⛔pairs는 이미 target_types로 걸러졌다 — 코어에 다시 target_types를 넘기면 이중
+    # 필터링(무해하지만 코어 쪽 dropped는 항상 빈 배열)이라, 반환은 여기서 이미 계산한
+    # `dropped`를 쓴다(코어의 dropped를 쓰면 위에서 로그까지 남긴 사실이 반환값에서 사라진다).
+    extracted_refs = [(etype, eid, "mention") for etype, eid in pairs]
+    result = await reconcile_entity_references(
+        db, org_id=org_id, source_type="chat_message", source_field="body",
+        source_id=message_id, extracted_refs=extracted_refs, created_by=created_by,
+        target_types=target_types,
     )
-    await db.execute(stmt)
-    return ChatMentionResult(stored=len(pairs), dropped=dropped)
+    return ChatMentionResult(stored=result.stored, dropped=dropped)
 
 
 async def count_phantom_task_mentions(db: AsyncSession) -> int:
@@ -368,61 +478,19 @@ async def reconcile_doc_mentions(
     embed로 갈린다(그 doc이 재저장되지 않는 한 예전 값 그대로 남는다). 이건 소급 일괄
     재분류(=이 스토리가 안 하는 것)가 아니라 정상적인 reconcile-on-save의 자연스러운 결과다
     — 그래서 별도 backfill 코드는 없다. 그 doc의 `entity_references` row가 갈린 시점(=이
-    행의 `created_at`)이 그 doc 한정으로는 경계다."""
-    target_refs = {
-        (tid, form) for tid, form in extract_doc_mention_targets(html_content) if tid != doc_id
-    }
+    행의 `created_at`)이 그 doc 한정으로는 경계다.
 
-    existing_rows = (
-        await db.execute(
-            select(Reference.target_id, Reference.form).where(
-                Reference.source_type == "doc",
-                Reference.source_field == "body",
-                Reference.source_id == doc_id,
-                Reference.target_type == "doc",
-                Reference.form.in_(("mention", "embed")),
-            )
-        )
-    ).all()
-    existing_refs = {(row.target_id, row.form) for row in existing_rows}
-
-    stale_refs = existing_refs - target_refs
-    if stale_refs:
-        from sqlalchemy import delete as sa_delete, tuple_
-
-        await db.execute(
-            sa_delete(Reference).where(
-                Reference.source_type == "doc",
-                Reference.source_field == "body",
-                Reference.source_id == doc_id,
-                Reference.target_type == "doc",
-                Reference.form.in_(("mention", "embed")),
-                tuple_(Reference.target_id, Reference.form).in_(stale_refs),
-            )
-        )
-
-    new_refs = target_refs - existing_refs
-    if new_refs:
-        canonical_created_by = await canonicalize_member_id(created_by, db)
-        stmt = pg_insert(Reference).values([
-            {
-                "id": uuid.uuid4(),
-                "org_id": org_id,
-                "source_type": "doc",
-                "source_field": "body",
-                "source_id": doc_id,
-                "target_type": "doc",
-                "target_id": target_id,
-                "form": form,
-                "created_by": canonical_created_by,
-            }
-            for target_id, form in new_refs
-        ])
-        stmt = stmt.on_conflict_do_nothing(
-            index_elements=[
-                Reference.source_type, Reference.source_field, Reference.source_id,
-                Reference.target_type, Reference.target_id, Reference.form,
-            ],
-            index_where=Reference.form != "proof",
-        )
-        await db.execute(stmt)
+    ⛔story #2301(2026-07-29): 이 함수는 이제 `reconcile_entity_references`(공용 코어)의
+    얇은 래퍼다 — 파싱(`extract_doc_mention_targets`, HTML wikiLink/pageEmbed)만 여기서
+    하고 diff/write는 코어에 위임한다. self-ref 가드(`tid != doc_id`)는 코어의 일반화된
+    가드(`target_type==source_type and target_id==source_id`, source_type이 항상 "doc"
+    이므로 동치)로 대체됐다 — 동작 동일. `target_types={"doc"}`는 원래 이 함수가 registry
+    필터링을 아예 안 했던 것과 동치(추출 결과가 항상 "doc" 타입뿐이라 필터가 no-op)."""
+    extracted_refs = [
+        ("doc", target_id, form) for target_id, form in extract_doc_mention_targets(html_content)
+    ]
+    await reconcile_entity_references(
+        db, org_id=org_id, source_type="doc", source_field="body", source_id=doc_id,
+        extracted_refs=extracted_refs, created_by=created_by,
+        target_types=frozenset({"doc"}),
+    )

--- a/backend/app/services/mention_parser.py
+++ b/backend/app/services/mention_parser.py
@@ -244,6 +244,7 @@ async def reconcile_entity_references(
     extracted_refs: list[tuple[str, uuid.UUID, str]],
     created_by: uuid.UUID | None,
     target_types: frozenset[str] = frozenset(ENTITY_RESOLVERS),
+    known_new: bool = False,
 ) -> ReconcileResult:
     """story #2301 — `(source_type, source_field, source_id)` 하나가 «지금» 가리키는 대상
     전체를 diff로 맞춘다: 사라진 토큰의 참조는 삭제(`removed`), 새로 생긴 토큰은 insert
@@ -253,7 +254,19 @@ async def reconcile_entity_references(
     `extracted_refs`는 caller가 이미 파싱해 온 (target_type, target_id, form) 3튜플이다 —
     이 함수는 파싱을 하지 않는다(`ReconcileResult` docstring 참조). `target_types` 밖의
     target_type은 registry 미등록으로 걸러 `dropped`에 담는다(#2294 관례 그대로 — 침묵 거부
-    금지).
+    금지). 이 필터·dropped·경고 로직은 **여기 한 곳에만** 있다 — caller(래퍼)가 같은 로직을
+    다시 하면 코어가 나중에 바뀔 때 래퍼만 옛 모양으로 남는 twin-system 갭이 된다(오르테가
+    리뷰 지적, 2026-07-29 — `insert_chat_mentions`가 실제로 이 갭에 걸렸었다).
+
+    `known_new=True`(채팅 전용): source_id가 **이번에 처음 생긴 것이라 기존 참조가 있을
+    수 없다는 걸 caller가 이미 아는 경우**(메시지는 불변·매번 신규) — existing-refs SELECT와
+    stale-delete를 통째로 건너뛴다(insert-only 고속 경로). ⛔이걸 "valid가 비면 스킵"으로
+    일반화하면 안 된다 — doc/story처럼 **재조정되는** source는 이번 저장에 유효한 대상이
+    0개여도(토큰을 전부 지운 경우) 삭제해야 할 **기존** stale 참조가 있을 수 있어(`test_doc_
+    reconcile_adds_and_removes_stale_mentions`·`test_clearing_description_entirely_removes_
+    all_its_references` 참조) existing-refs 조회를 건너뛸 수 없다. `known_new`는 "이 source_id
+    자체가 신규"라는 caller의 사전 지식이지, "이번 파싱 결과가 비었다"는 사후 계산이 아니다
+    — 그래서 기본값 False(안전한 쪽)이고 chat만 명시적으로 True를 넘긴다.
 
     같은 트랜잭션(caller 세션 그대로 사용, 별도 커밋 없음) — 실패 시 예외가 그대로
     propagate되어 caller(story/doc/chat 저장 트랜잭션) 전체가 롤백된다(chat/doc 기존
@@ -275,30 +288,37 @@ async def reconcile_entity_references(
         if not (tt == source_type and tid == source_id)
     }
 
-    existing_rows = await db.execute(
-        select(Reference.target_type, Reference.target_id, Reference.form).where(
-            Reference.org_id == org_id,
-            Reference.source_type == source_type,
-            Reference.source_field == source_field,
-            Reference.source_id == source_id,
-            Reference.form.in_(("mention", "embed")),
-        )
-    )
-    existing_refs = {(row.target_type, row.target_id, row.form) for row in existing_rows.all()}
-
-    stale_refs = existing_refs - target_refs
-    if stale_refs:
-        from sqlalchemy import delete as sa_delete, tuple_
-
-        await db.execute(
-            sa_delete(Reference).where(
+    if known_new:
+        # insert-only 고속 경로 — existing-refs SELECT/stale-delete 자체를 건너뛴다(DB 왕복
+        # 0~1회: target_refs가 비면 그마저도 0). `test_dropped_logging_red_green_mutation_
+        # self_check`가 db=None으로 이 경로를 직접 실증한다.
+        existing_refs: set[tuple[str, uuid.UUID, str]] = set()
+        stale_refs: set[tuple[str, uuid.UUID, str]] = set()
+    else:
+        existing_rows = await db.execute(
+            select(Reference.target_type, Reference.target_id, Reference.form).where(
                 Reference.org_id == org_id,
                 Reference.source_type == source_type,
                 Reference.source_field == source_field,
                 Reference.source_id == source_id,
-                tuple_(Reference.target_type, Reference.target_id, Reference.form).in_(stale_refs),
+                Reference.form.in_(("mention", "embed")),
             )
         )
+        existing_refs = {(row.target_type, row.target_id, row.form) for row in existing_rows.all()}
+
+        stale_refs = existing_refs - target_refs
+        if stale_refs:
+            from sqlalchemy import delete as sa_delete, tuple_
+
+            await db.execute(
+                sa_delete(Reference).where(
+                    Reference.org_id == org_id,
+                    Reference.source_type == source_type,
+                    Reference.source_field == source_field,
+                    Reference.source_id == source_id,
+                    tuple_(Reference.target_type, Reference.target_id, Reference.form).in_(stale_refs),
+                )
+            )
 
     new_refs = target_refs - existing_refs
     if new_refs:
@@ -370,43 +390,27 @@ async def insert_chat_mentions(
     안 된 raw `]` 토큰이 조용히 버려지는 것을 확인) 그 경로는 여전히 registry 밖 타입을 만들
     수 있다 — `dropped`가 비지 않는 것 자체가 그 신호(기능이 아니라 가드)다.
 
-    ⛔story #2301(2026-07-29): 이 함수는 이제 `reconcile_entity_references`(공용 코어)의
-    얇은 래퍼다 — 파싱(`extract_chat_entity_mentions`, form 항상 "mention")만 여기서 하고
-    실제 write/diff는 코어에 위임한다. 채팅은 매번 신규 메시지(기존 참조 0건)라 diff가
-    항상 순수 insert로 귀결 — 동작 회귀 없음(`ReconcileResult` docstring AC4 참조).
+    ⛔story #2301(2026-07-29, 오르테가 리뷰 반영): 이 함수는 `reconcile_entity_references`
+    (공용 코어)의 **얇은 변환**이다 — 파싱(`extract_chat_entity_mentions`, form 항상
+    "mention")만 여기서 하고, 필터링·dropped 계산·경고 로그는 전부 코어에 맡긴다(코어를
+    두 번째로 재구현하지 않는다 — 최초 리뷰에서 이 래퍼가 코어와 같은 필터/dropped/로그
+    로직을 중복 소유해 "코어의 dropped 경로를 실제로 타는 호출부가 0"이 되는 twin-system
+    갭이었다는 지적을 반영해 고쳤다).
 
-    `all_pairs`가 비거나(토큰 자체가 없는 일반 메시지, 압도적 다수) 필터 후 `pairs`가 비면
-    (전부 registry 밖이라 dropped) 코어 호출 자체를 skip(DB 왕복 0) — 이 원래 있던 얕은
-    최적화를 유지한다(`test_dropped_logging_red_green_mutation_self_check`가 `db=None`으로
-    이 경로를 직접 실증한다 — DB를 안 건드린다는 계약 자체가 테스트로 고정돼 있다)."""
+    `known_new=True`를 코어에 넘긴다 — 채팅 메시지는 매번 신규(불변·재조정 불필요)라는
+    사실을 caller가 이미 알고 있다는 선언(`reconcile_entity_references` docstring 참조).
+    이 플래그 하나로 existing-refs 조회/stale-delete가 통째로 스킵되고, `extracted_refs`가
+    비거나 전부 dropped라 insert할 것도 없으면 DB 왕복이 0회로 자연히 귀결한다 — 별도의
+    "비면 skip" 분기를 이 래퍼에 따로 두지 않는다(`test_dropped_logging_red_green_mutation_
+    self_check`가 `db=None`으로 이 경로를 직접 실증한다)."""
     all_pairs = extract_chat_entity_mentions(content)
-    if not all_pairs:
-        return ChatMentionResult(stored=0, dropped=[])
-
-    pairs = [(etype, eid) for etype, eid in all_pairs if etype in target_types]
-    dropped = [
-        {"target_type": etype, "target_id": str(eid)}
-        for etype, eid in all_pairs if etype not in target_types
-    ]
-    if dropped:
-        logger.warning(
-            "insert_chat_mentions: dropped %d mention(s) with unregistered target_type "
-            "(message_id=%s, target_types=%s) dropped=%s",
-            len(dropped), message_id, sorted(target_types), dropped,
-        )
-    if not pairs:
-        return ChatMentionResult(stored=0, dropped=dropped)
-
-    # ⛔pairs는 이미 target_types로 걸러졌다 — 코어에 다시 target_types를 넘기면 이중
-    # 필터링(무해하지만 코어 쪽 dropped는 항상 빈 배열)이라, 반환은 여기서 이미 계산한
-    # `dropped`를 쓴다(코어의 dropped를 쓰면 위에서 로그까지 남긴 사실이 반환값에서 사라진다).
-    extracted_refs = [(etype, eid, "mention") for etype, eid in pairs]
+    extracted_refs = [(etype, eid, "mention") for etype, eid in all_pairs]
     result = await reconcile_entity_references(
         db, org_id=org_id, source_type="chat_message", source_field="body",
         source_id=message_id, extracted_refs=extracted_refs, created_by=created_by,
-        target_types=target_types,
+        target_types=target_types, known_new=True,
     )
-    return ChatMentionResult(stored=result.stored, dropped=dropped)
+    return ChatMentionResult(stored=result.stored, dropped=result.dropped)
 
 
 async def count_phantom_task_mentions(db: AsyncSession) -> int:
@@ -484,13 +488,18 @@ async def reconcile_doc_mentions(
     얇은 래퍼다 — 파싱(`extract_doc_mention_targets`, HTML wikiLink/pageEmbed)만 여기서
     하고 diff/write는 코어에 위임한다. self-ref 가드(`tid != doc_id`)는 코어의 일반화된
     가드(`target_type==source_type and target_id==source_id`, source_type이 항상 "doc"
-    이므로 동치)로 대체됐다 — 동작 동일. `target_types={"doc"}`는 원래 이 함수가 registry
-    필터링을 아예 안 했던 것과 동치(추출 결과가 항상 "doc" 타입뿐이라 필터가 no-op)."""
+    이므로 동치)로 대체됐다 — 동작 동일.
+
+    ⛔`target_types`는 명시로 안 넘긴다(코어 기본값 = registry 전체를 그대로 쓴다) — 지금은
+    추출 결과가 항상 "doc" 타입뿐이라 no-op이지만(오르테가 리뷰 지적, 2026-07-29), "doc은
+    doc만 가리킨다"를 여기 하드코딩(`target_types={"doc"}`)해 두면 파서가 나중에 다른
+    entity_type을 뽑게 되는 날(선생님 지시 원문 "어떤 엔티티든 임베드") 파서는 뽑았는데
+    필터가 조용히 막는 벽이 된다. no-op인 지금 없애 두면 파서가 늘 때 이 함수를 안 고쳐도
+    자동으로 따라온다."""
     extracted_refs = [
         ("doc", target_id, form) for target_id, form in extract_doc_mention_targets(html_content)
     ]
     await reconcile_entity_references(
         db, org_id=org_id, source_type="doc", source_field="body", source_id=doc_id,
         extracted_refs=extracted_refs, created_by=created_by,
-        target_types=frozenset({"doc"}),
     )

--- a/backend/tests/test_1993_mention_parser.py
+++ b/backend/tests/test_1993_mention_parser.py
@@ -6,6 +6,7 @@ DB/세션 불요 — extract_chat_doc_mention_ids(정규식)·extract_doc_mentio
 from __future__ import annotations
 
 import uuid
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -280,3 +281,60 @@ def test_extract_doc_mention_ids_wrapper_still_ignores_form():
         f'<div data-page-embed data-doc-id="{doc_id}"></div>'
     )
     assert extract_doc_mention_ids(html) == [doc_id]
+
+
+# ─── story #2301(오르테가 리뷰): insert_chat_mentions가 코어의 «얇은 변환»인지 직접 확인 ──
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_insert_chat_mentions_is_a_thin_conversion_of_core_result():
+    """`insert_chat_mentions`가 자체 필터/dropped 계산을 다시 하지 않고 코어의 결과값을
+    그대로 반환하는지 — 코어를 mock해 임의의 (stored, dropped) 조합을 주입했을 때
+    `ChatMentionResult`가 그 값과 **정확히 일치**하면 래퍼에 남은 이중 로직이 없다는 뜻이다
+    (오르테가 리뷰 지적, 2026-07-29 — 이전엔 래퍼가 자체 dropped를 계산해 반환해서 이
+    mock을 통과할 수 없었다)."""
+    import app.services.mention_parser as mp
+
+    org_id = uuid.uuid4()
+    message_id = uuid.uuid4()
+    fake_result = mp.ReconcileResult(
+        stored=7, removed=0, dropped=[{"target_type": "sentinel", "target_id": "x"}],
+    )
+    with patch.object(mp, "reconcile_entity_references", new=AsyncMock(return_value=fake_result)) as m:
+        result = await mp.insert_chat_mentions(
+            db=object(), org_id=org_id, message_id=message_id,
+            content=f"[X](entity:doc:{uuid.uuid4()})", created_by=uuid.uuid4(),
+        )
+    assert result.stored == fake_result.stored
+    assert result.dropped == fake_result.dropped
+    _, kwargs = m.call_args
+    assert kwargs["known_new"] is True
+    assert kwargs["source_type"] == "chat_message"
+    assert kwargs["source_field"] == "body"
+
+
+@pytest.mark.anyio
+async def test_insert_chat_mentions_no_tokens_passes_empty_refs_to_core():
+    """토큰이 아예 없는 일반 메시지도 코어를 호출한다(빈 `extracted_refs`로) — 별도
+    "비면 skip" 분기를 래퍼에 안 둔다(코어의 `known_new=True` 경로 자체가 이 경우 DB
+    왕복 0으로 귀결하므로, 래퍼가 따로 판단할 필요가 없다 — `reconcile_entity_references`
+    docstring의 known_new 설명 참조. 실제 DB 미접촉은 `db=None`으로 도는
+    `test_dropped_logging_red_green_mutation_self_check`가 실측한다)."""
+    import app.services.mention_parser as mp
+
+    fake_result = mp.ReconcileResult(stored=0, removed=0, dropped=[])
+    with patch.object(mp, "reconcile_entity_references", new=AsyncMock(return_value=fake_result)) as m:
+        result = await mp.insert_chat_mentions(
+            db=object(), org_id=uuid.uuid4(), message_id=uuid.uuid4(),
+            content="plain text, no tokens", created_by=uuid.uuid4(),
+        )
+    m.assert_awaited_once()
+    _, kwargs = m.call_args
+    assert kwargs["extracted_refs"] == []
+    assert result.stored == 0
+    assert result.dropped == []

--- a/backend/tests/test_1993_mention_parser.py
+++ b/backend/tests/test_1993_mention_parser.py
@@ -338,3 +338,42 @@ async def test_insert_chat_mentions_no_tokens_passes_empty_refs_to_core():
     assert kwargs["extracted_refs"] == []
     assert result.stored == 0
     assert result.dropped == []
+
+
+def test_chat_message_body_immutability_premise_still_holds():
+    """`insert_chat_mentions`가 코어에 넘기는 `known_new=True`는 "채팅 메시지 본문은 편집
+    되지 않는다"는 전제에 기댄다(오르테가 지적, 2026-07-29) — 그 전제가 사라지면 stale
+    참조 삭제가 조용히 안 도는 날이 오는데, 주석은 안 잡히니(다음 사람이 안 읽는다) 이
+    테스트로 묶는다: `conversations.py`에 메시지 «본문» 편집 라우트(messages/{id}의
+    PATCH/PUT)가 생기면 RED.
+
+    ⛔이 전제가 깨지면 할 일(실패 메시지에도 명시): `insert_chat_mentions`이 코어를 부를 때
+    `known_new=True`를 걷고(기본값 False로 되돌려) 완전 reconcile로 전환할 것 — doc/story와
+    동형으로 편집-가능 콘텐츠는 항상 stale-delete를 돈다.
+
+    양성대조: 이 스캐너가 실재하는 PATCH 라우트 3개(mute·status·conversation 본체)는 실제로
+    집는지 확인한다 — 안 그러면 "메시지 편집 라우트 0건"이 "정말 없다"인지 "스캐너가 안
+    본다"인지 구분이 안 된다."""
+    import re
+    from pathlib import Path
+
+    src = Path(__file__).resolve().parent.parent / "app" / "routers" / "conversations.py"
+    text = src.read_text()
+    routes = re.findall(r'@router\.(patch|put)\(\s*"([^"]+)"', text)
+
+    # 양성대조 — 스캐너가 실재하는 3건은 실제로 잡는다(안 그러면 아래 진짜 시험이 공허통과).
+    assert ("patch", "/{conversation_id}/mute") in routes, "스캐너가 실재 라우트를 못 잡는다"
+    assert ("patch", "/{conversation_id}/status") in routes, "스캐너가 실재 라우트를 못 잡는다"
+    assert ("patch", "/{conversation_id}") in routes, "스캐너가 실재 라우트를 못 잡는다"
+
+    # 진짜 시험 — 메시지 본문 편집 라우트(messages/{id} 형태의 PATCH/PUT)는 아직 없어야 한다.
+    message_edit_routes = [
+        (method, path) for method, path in routes
+        if "messages/" in path or path.rstrip("/").endswith("messages")
+    ]
+    assert message_edit_routes == [], (
+        f"메시지 편집 라우트가 생겼다({message_edit_routes}) — insert_chat_mentions의 "
+        "known_new=True 전제(채팅 메시지는 편집되지 않는다)가 깨졌다. mention_parser.py의 "
+        "insert_chat_mentions에서 known_new=True를 걷고 완전 reconcile(기본값 False)로 "
+        "되돌릴 것."
+    )

--- a/backend/tests/test_2301_story_body_mentions_realdb.py
+++ b/backend/tests/test_2301_story_body_mentions_realdb.py
@@ -1,0 +1,405 @@
+"""story #2301(E-CONNECT, 오르테가 판정 2026-07-29, 스레드 7256d5cc) — story 본문(description)·
+AC(acceptance_criteria)의 `#` 엔티티 토큰이 저장 시 `entity_references`로 실제로 걷히는지
+실PG 검증. #2597(FE)이 삽입 UI만 열었고 BE 파서가 없던 갭(화면은 되는데 저장 안 됨)의 배선.
+
+핵심 판정 AC들:
+  AC1: story 전용 write 헬퍼가 0 — `insert_chat_mentions`/`reconcile_doc_mentions`를 병합한
+    공용 코어(`reconcile_entity_references`)를 stories.py가 직접 호출(재구현 0, mention_
+    parser.py에 story 전용 함수 추가 안 함 — 이 파일이 코드가 아니라 테스트라 grep으로
+    직접 확인).
+  AC2: 본문·AC는 서로 다른 source_field라 각각 독립적으로 reconcile — 같은 대상을 양쪽에
+    걸면 두 행 다 남는다.
+  AC3(이 판의 진짜 시험): 토큰을 지우면 참조가 없어지는 것 — 양성대조를 같은 응답(같은
+    story)에: 안 지운 토큰의 참조는 남는 것. 둘 다 사라지면 "지운 것"이 아니라 "다 날린 것".
+  AC4: 채팅 회귀 0 — 메시지는 불변이라 stale 삭제가 "안 도는" 것(기존 test_1993_mentions_
+    realdb.py 전체 스위트가 별도로 이걸 실증 — 이 파일은 stories.py 신규 호출부만 스코프).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _make_org(session, name="Org"):
+    from app.models.organization import Organization
+    org = Organization(id=uuid.uuid4(), name=name, slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    return org
+
+
+async def _make_project(session, org_id, name="P"):
+    from app.models.project import Project
+    project = Project(id=uuid.uuid4(), org_id=org_id, name=name)
+    session.add(project)
+    await session.commit()
+    return project
+
+
+async def _make_human_member(session, org_id, project_id):
+    from app.models.user import User
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.member import Member
+
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="member")
+    session.add(om)
+    await session.flush()
+    m = Member(id=om.id, org_id=org_id, type="human", user_id=user.id, name="Human")
+    session.add(m)
+    await session.flush()
+    session.add(ProjectAccess(project_id=project_id, org_member_id=om.id, member_id=m.id, role="member"))
+    await session.commit()
+    return m.id, user.id
+
+
+async def _make_story(session, org_id, project_id, title="Story", description="", acceptance_criteria=""):
+    from app.models.pm import Story
+    story = Story(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title,
+        status="backlog", description=description, acceptance_criteria=acceptance_criteria,
+    )
+    session.add(story)
+    await session.commit()
+    return story
+
+
+async def _make_target_doc(session, org_id, project_id, title="Target"):
+    from app.models.doc import Doc
+    doc = Doc(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, slug=f"doc-{uuid.uuid4().hex[:8]}")
+    session.add(doc)
+    await session.commit()
+    return doc
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+def _token(title: str, target_type: str, target_id: uuid.UUID) -> str:
+    return f"[{title}](entity:{target_type}:{target_id})"
+
+
+async def _refs(session, org_id, story_id, source_field=None):
+    from sqlalchemy import select
+    from app.models.reference import Reference
+    conds = [Reference.org_id == org_id, Reference.source_type == "story", Reference.source_id == story_id]
+    if source_field is not None:
+        conds.append(Reference.source_field == source_field)
+    rows = (await session.execute(select(Reference).where(*conds))).scalars().all()
+    return rows
+
+
+# ─── AC1: story 전용 write 헬퍼 0(코드 스캔) ─────────────────────────────────
+
+
+def test_no_story_specific_mention_write_helper_added():
+    """mention_parser.py에 "story" 전용 write 함수가 새로 생기지 않았는지 직접 확인 —
+    공용 코어(`reconcile_entity_references`)만 있고, `insert_story_mentions`류 이름이
+    없어야 AC1이 선다."""
+    import app.services.mention_parser as mp
+
+    public_funcs = [
+        name for name in dir(mp)
+        if callable(getattr(mp, name)) and not name.startswith("_") and "story" in name.lower()
+    ]
+    assert public_funcs == [], f"story 전용 write 헬퍼가 생겼다: {public_funcs}"
+
+
+# ─── AC2: description·AC 각각 독립 reconcile ─────────────────────────────────
+
+
+async def test_patch_description_creates_reference():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_target_doc(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": _token("Target", "doc", target.id)},
+            )
+            assert resp.status_code == 200, resp.text
+
+            async with Session() as s:
+                refs = await _refs(s, org.id, story.id, source_field="description")
+                assert len(refs) == 1
+                assert refs[0].target_type == "doc"
+                assert refs[0].target_id == target.id
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_same_target_in_description_and_ac_both_persist_independently():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_target_doc(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={
+                    "description": _token("Target", "doc", target.id),
+                    "acceptance_criteria": _token("Target", "doc", target.id),
+                },
+            )
+            assert resp.status_code == 200, resp.text
+
+            async with Session() as s:
+                desc_refs = await _refs(s, org.id, story.id, source_field="description")
+                ac_refs = await _refs(s, org.id, story.id, source_field="acceptance_criteria")
+                assert len(desc_refs) == 1
+                assert len(ac_refs) == 1
+                assert desc_refs[0].id != ac_refs[0].id
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── AC3(진짜 시험): 토큰 삭제 → 참조 삭제, 양성대조는 남음 ──────────────────
+
+
+async def test_removing_token_deletes_reference_kept_token_survives_positive_control():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target_removed = await _make_target_doc(s, org.id, project.id, title="Removed")
+            target_kept = await _make_target_doc(s, org.id, project.id, title="Kept")
+            story = await _make_story(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            # ⛔선행 상태는 직접 ORM으로 심지 않는다(그러면 reconcile 경로를 안 거쳐 seed 자체가
+            # 거짓 전제가 된다) — 실 PATCH로 두 토큰을 먼저 «진짜로» 저장시킨다.
+            seed = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={
+                    "description": (
+                        _token("Removed", "doc", target_removed.id) + " and "
+                        + _token("Kept", "doc", target_kept.id)
+                    ),
+                },
+            )
+            assert seed.status_code == 200, seed.text
+            async with Session() as s:
+                before = await _refs(s, org.id, story.id, source_field="description")
+                assert {r.target_id for r in before} == {target_removed.id, target_kept.id}
+
+            # "Removed" 토큰만 지우고 "Kept" 토큰은 그대로 둔 채 재저장.
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": _token("Kept", "doc", target_kept.id) + " only now"},
+            )
+            assert resp.status_code == 200, resp.text
+
+            async with Session() as s:
+                after = await _refs(s, org.id, story.id, source_field="description")
+                after_targets = {r.target_id for r in after}
+                # ⭐양성대조 — 지운 것만 없어지고 안 지운 것은 남는다(둘 다 사라지면 "다 날린 것").
+                assert target_removed.id not in after_targets, "지운 토큰의 참조가 안 지워졌다"
+                assert target_kept.id in after_targets, "안 지운 토큰의 참조까지 같이 날아갔다"
+                assert after_targets == {target_kept.id}
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_clearing_description_entirely_removes_all_its_references():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_target_doc(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            seed = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": _token("Target", "doc", target.id)},
+            )
+            assert seed.status_code == 200, seed.text
+            async with Session() as s:
+                before = await _refs(s, org.id, story.id, source_field="description")
+                assert len(before) == 1
+
+            resp = await client.patch(f"/api/v2/stories/{story.id}", json={"description": "no tokens here"})
+            assert resp.status_code == 200, resp.text
+
+            async with Session() as s:
+                after = await _refs(s, org.id, story.id, source_field="description")
+                assert after == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── 미변경 필드는 재조정 안 함(불필요한 diff-쿼리 skip) ─────────────────────
+
+
+async def test_patching_unrelated_field_does_not_touch_description_references():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_target_doc(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            seed = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": _token("Target", "doc", target.id)},
+            )
+            assert seed.status_code == 200, seed.text
+
+            resp = await client.patch(f"/api/v2/stories/{story.id}", json={"priority": "high"})
+            assert resp.status_code == 200, resp.text
+
+            async with Session() as s:
+                refs = await _refs(s, org.id, story.id, source_field="description")
+                assert len(refs) == 1
+                assert refs[0].target_id == target.id
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── 미등록 target_type dropped(채팅과 동일 관례) ────────────────────────────
+
+
+async def test_unregistered_target_type_in_description_is_dropped_not_stored():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": _token("X", "goal", uuid.uuid4())},
+            )
+            assert resp.status_code == 200, resp.text
+
+            async with Session() as s:
+                refs = await _refs(s, org.id, story.id, source_field="description")
+                assert refs == [], "registry 밖 target_type이 저장됐다(조용히 통과 금지 위반)"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- #2597(FE)이 story description/acceptance_criteria에 `#` 엔티티 토큰 삽입 UI를 열었지만, `PATCH /api/v2/stories/{id}`에 참조를 걷는 절차 자체가 없었다(grep 0건) — 화면은 되는데 저장이 안 되는 갭.
- 오르테가 판정: 새로 만들지 말고 병합. `insert_chat_mentions`(마크다운 파서·target_types·dropped 추적) + `reconcile_doc_mentions`(diff 기반 stale 삭제) → `reconcile_entity_references`(공용 코어) 한 벌. 파서는 코어 밖(caller가 `(target_type,target_id,form)` 3튜플로 미리 뽑아 넘김).

## 설계
- `mention_parser.py`: 신규 공용 코어 + 기존 두 함수를 그 위 얇은 래퍼로 재작성(시그니처·3개 호출부 전부 무변경). self-ref 가드를 doc 전용에서 일반화.
- `stories.py` PATCH: description·acceptance_criteria가 서로 다른 `source_field`라 독립 reconcile(AC1: story 전용 write 헬퍼 0). commit 전 같은 트랜잭션(AC4 원자성).

## AC 대응
- AC1: 코드스캔 테스트로 story 전용 헬퍼 0건 고정
- AC2: 본문·AC 동일 대상 걸어도 두 행 다 남음(source_field가 다르므로)
- AC3(진짜 시험): 토큰 삭제→참조 삭제 + 양성대조(안 지운 토큰은 남음, 같은 응답에서)
- AC4: 채팅 회귀 0(기존 12/12, insert-only 동작 불변)

## Test plan
- [x] RED→GREEN 5건: 코어 stale-삭제 무력화 / 채팅 db=None 조기반환 제거 노출 / description 리와이어 무력화 / description↔AC source_field 혼선 — 각각 실패 확인 후 원복
- [x] 신규 realdb 7건 + 기존 mention 관련 realdb 61/61(회귀 0)
- [x] 전체 backend 회귀(realdb 제외) 4208 pass(6 fail 무관, pre-existing)

## FE 갭(별건, 미르코군)
`patchStory()`가 `json.data`만 읽어 sibling을 버림(#2591 MCP client와 동형) — 이 PR은 BE 저장 경로만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)