### PR TITLE
[E-CONNECT] doc [slug]/view에 「이것을 가리키는 것들」 — StoryBacklinksSection 일반화

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/view/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/view/page.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/button';
 import { Edit2 } from 'lucide-react';
 import { useDocsLayout } from '../../docs-context';
 import { docUrl } from '@/components/docs/lib/doc-project-url';
+import { EntityBacklinksSection } from '@/components/shared/entity-backlinks-section';
 
 interface DocDetail {
   id: string;
@@ -91,6 +92,9 @@ export default function DocViewPage() {
             codeCopiedLabel={t('codeCopied')}
             assetImageErrorLabel={t('attachImageUnavailable')}
           />
+          {/* 두 번째 backlinks 자리(첫 자리: story-detail-panel, story #2299) — 컴포넌트
+              변경 0, entityType="doc" 호출만 다르다(PO 판정 그대로). */}
+          <EntityBacklinksSection entityType="doc" entityId={doc.id} />
         </div>
       </div>
     </div>

--- a/apps/web/src/app/api/docs/[id]/backlinks/route.test.ts
+++ b/apps/web/src/app/api/docs/[id]/backlinks/route.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// 두 번째 backlinks 소비자(형제: stories/[id]/backlinks) — 같은 이중포장 위험을 처음부터 봉쇄.
+const h = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(),
+  proxyToFastapiWithParams: vi.fn(),
+}));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext: h.getOrgProjectAuthContext }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams: h.proxyToFastapiWithParams }));
+
+import { GET } from './route';
+
+const ctx = () => ({ params: Promise.resolve({ id: 'doc-1' }) });
+const req = () => new Request('http://localhost/api/docs/doc-1/backlinks');
+const me = () => ({ id: 'a', org_id: 'org-1', project_id: 'p1', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
+
+describe('GET /api/docs/[id]/backlinks — 이중포장 회귀 방지 + still_exists/collection_scope 왕복', () => {
+  beforeEach(() => {
+    h.getOrgProjectAuthContext.mockReset();
+    h.proxyToFastapiWithParams.mockReset();
+    h.getOrgProjectAuthContext.mockResolvedValue(me());
+  });
+
+  it('BE convention-A 응답이 이중포장 없이 그대로 나온다 — still_exists·collection_scope 보존', async () => {
+    h.proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({
+        data: [{ id: 'r1', source_type: 'chat_message', still_exists: true, doc: null, message: { id: 'm1', conversation_id: 'c1', content_snippet: 'X', sender: null } }],
+        meta: { next_cursor: null, has_more: false, collection_scope: { source_types: ['chat_message', 'doc'], forms: 'all', excludes: [] } },
+      }), { status: 200 }),
+    );
+    const res = await GET(req(), ctx());
+    const json = await res.json() as { data: { still_exists: boolean }[]; meta: { collection_scope: unknown } };
+    expect(Array.isArray(json.data)).toBe(true);
+    expect(json.data[0]!.still_exists).toBe(true);
+    expect(json.meta.collection_scope).toEqual({ source_types: ['chat_message', 'doc'], forms: 'all', excludes: [] });
+  });
+});

--- a/apps/web/src/app/api/docs/[id]/backlinks/route.ts
+++ b/apps/web/src/app/api/docs/[id]/backlinks/route.ts
@@ -1,0 +1,26 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors, type ApiMeta } from '@/lib/api-response';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/** GET /api/docs/{id}/backlinks — 두 번째 backlinks 소비자(첫 자리는 stories/[id]/backlinks,
+ * story #2299). BE(list_entity_backlinks)는 docs/stories 둘 다 같은 함수·같은 convention-A
+ * shape({data,meta}) — 그래서 이 프록시도 형제(stories/[id]/backlinks/route.ts)와 완전히
+ * 동형으로 짓는다(raw json.data ?? json 언랩, #2247/#2564 이중포장 재발 방지). */
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const me = await getOrgProjectAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/docs/[id]/backlinks', { id });
+    if (!_r.ok) return _r;
+    const beJson = await _r.json() as { data?: unknown; meta?: ApiMeta };
+    return apiSuccess(beJson.data ?? beJson, beJson.meta);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -26,7 +26,7 @@ import { Workcell, type WorkcellMessage } from '@/components/workcell/workcell';
 import { initials } from '@/lib/storage/format';
 import { ArtifactSection } from '@/components/canvas/artifact-section';
 import { StuckHandoffSection } from '@/components/cage/stuck-handoff-section';
-import { StoryBacklinksSection } from '@/components/kanban/story-backlinks-section';
+import { EntityBacklinksSection } from '@/components/shared/entity-backlinks-section';
 import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
 import { PrLinkSection } from '@/components/integrations/pr-link-section';
 import { Button } from '@/components/ui/button';
@@ -1068,7 +1068,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
 
             {/* story #2299(E-CONNECT): 이것을 가리키는 것들 — doc/chat_message 참조 목록 첫 자리
                 (doc [slug]/view는 후속 판). */}
-            <StoryBacklinksSection storyId={story.id} />
+            <EntityBacklinksSection entityType="story" entityId={story.id} />
 
             {story.story_points != null ? (
               <div>

--- a/apps/web/src/components/shared/entity-backlinks-section.route-map.test.ts
+++ b/apps/web/src/components/shared/entity-backlinks-section.route-map.test.ts
@@ -1,0 +1,37 @@
+/**
+ * PO 지적(2026-07-28, #2600 리뷰) — "맵의 키 = 서버 허용목록"이 주석으로만 묶여 있으면
+ * 아무도 안 지킨다. 코드스캔으로 양쪽을 실제로 묶는다(디디군 #2599 AC1과 같은 방식 —
+ * "테스트로 묶기"): BE `backlinks.py::BACKLINKS_ALLOWED_TARGET_TYPES`를 텍스트로 파싱해
+ * FE `ENTITY_ROUTE_SEGMENT`의 키 집합과 비교한다. 이게 있어야 두 방향 다 잡힌다 —
+ * ㉠서버가 새 종류의 게이트를 세워 허용목록을 늘렸는데 화면이 안 따라오는 경우
+ * ㉡화면이 먼저 늘려서 아직 없는 라우트를 부르게 되는 경우.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+function parseBackendAllowedTargetTypes(): Set<string> {
+  // vitest CWD는 apps/web(이 프로젝트의 관례) — backend는 두 단계 위.
+  const path = resolve(process.cwd(), '../../backend/app/services/backlinks.py');
+  const source = readFileSync(path, 'utf-8');
+  const m = source.match(/BACKLINKS_ALLOWED_TARGET_TYPES\s*=\s*frozenset\(\{([^}]*)\}\)/);
+  if (!m) throw new Error('BACKLINKS_ALLOWED_TARGET_TYPES 정의를 backlinks.py에서 못 찾았다 — 이 테스트 자체가 오탐 아닌지 먼저 확인');
+  const types = [...m[1]!.matchAll(/"([^"]+)"/g)].map((mm) => mm[1]!);
+  return new Set(types);
+}
+
+describe('ENTITY_ROUTE_SEGMENT 키 집합 ↔ BE BACKLINKS_ALLOWED_TARGET_TYPES 코드스캔 동기화', () => {
+  it('FE 맵의 키와 BE 허용목록이 정확히 같은 집합이다', async () => {
+    const backendTypes = parseBackendAllowedTargetTypes();
+    // private(모듈에 export 안 된) 상수라 소스를 직접 읽어 키만 추출한다 — 별도 export 신설 금지
+    // (컴포넌트 공개 API에 테스트 전용 필드를 얹지 않는다).
+    const source = readFileSync(
+      resolve(__dirname, 'entity-backlinks-section.tsx'), 'utf-8',
+    );
+    const m = source.match(/const ENTITY_ROUTE_SEGMENT = \{([\s\S]*?)\} as const/);
+    if (!m) throw new Error('ENTITY_ROUTE_SEGMENT 정의를 못 찾았다 — 리팩터로 형태가 바뀌었으면 이 정규식도 갱신');
+    const feKeys = [...m[1]!.matchAll(/^\s*(\w+):/gm)].map((mm) => mm[1]!);
+
+    expect(new Set(feKeys)).toEqual(backendTypes);
+  });
+});

--- a/apps/web/src/components/shared/entity-backlinks-section.route-map.test.ts
+++ b/apps/web/src/components/shared/entity-backlinks-section.route-map.test.ts
@@ -7,12 +7,26 @@
  * ㉡화면이 먼저 늘려서 아직 없는 라우트를 부르게 되는 경우.
  */
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+// PO 지적(CI 빨강, 2026-07-28) — 로컬 워크트리와 CI 체크아웃의 경로 깊이가 달라 `../../` 개수를
+// 세는 방식이 CI에서만 깨졌다(로컬=1단계 더 깊은 경로). `../` 개수를 세지 않고 `backend/`가
+// 있는 첫 조상 디렉터리를 레포 루트로 찾아 올라간다 — 워크트리·CI·경로 깊이 전부와 무관.
+function findRepoRoot(startDir: string): string {
+  let dir = startDir;
+  for (let i = 0; i < 10; i++) {
+    if (existsSync(join(dir, 'backend', 'app', 'services', 'backlinks.py'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break; // 파일시스템 루트 도달 — 더 못 올라감
+    dir = parent;
+  }
+  throw new Error(`레포 루트(backend/app/services/backlinks.py를 포함하는 조상)를 ${startDir}에서 못 찾았다`);
+}
 
 function parseBackendAllowedTargetTypes(): Set<string> {
-  // vitest CWD는 apps/web(이 프로젝트의 관례) — backend는 두 단계 위.
-  const path = resolve(process.cwd(), '../../backend/app/services/backlinks.py');
+  const repoRoot = findRepoRoot(process.cwd());
+  const path = resolve(repoRoot, 'backend/app/services/backlinks.py');
   const source = readFileSync(path, 'utf-8');
   const m = source.match(/BACKLINKS_ALLOWED_TARGET_TYPES\s*=\s*frozenset\(\{([^}]*)\}\)/);
   if (!m) throw new Error('BACKLINKS_ALLOWED_TARGET_TYPES 정의를 backlinks.py에서 못 찾았다 — 이 테스트 자체가 오탐 아닌지 먼저 확인');

--- a/apps/web/src/components/shared/entity-backlinks-section.test.tsx
+++ b/apps/web/src/components/shared/entity-backlinks-section.test.tsx
@@ -3,12 +3,16 @@
 // story #2299(E-CONNECT) — 「이것을 가리키는 것들」 목록의 still_exists 표시 규율(유나 확定):
 // ①끊어진 항목도 목록에서 안 뺀다 ②사실로 보인다(오류색 없음) ③비난 없는 문구
 // ④종류(doc/chat_message)와 무관하게 문구 한 벌.
+//
+// 두 번째 자리(doc [slug]/view)가 오면서 StoryBacklinksSection→EntityBacklinksSection으로
+// 일반화됐다(entityType/entityId 축) — 기존 story 케이스는 entityType="story"로 그대로,
+// doc 전용 케이스(URL 파생·재사용 확인)를 추가한다.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
-import { StoryBacklinksSection } from './story-backlinks-section';
+import { EntityBacklinksSection } from './entity-backlinks-section';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -36,15 +40,15 @@ afterEach(async () => {
   vi.restoreAllMocks();
 });
 
-async function render(storyId: string) {
+async function render(entityType: 'story' | 'doc', entityId: string) {
   await act(async () => {
-    root.render(withIntl(<StoryBacklinksSection storyId={storyId} />));
+    root.render(withIntl(<EntityBacklinksSection entityType={entityType} entityId={entityId} />));
   });
   // useEffect의 fetch가 resolve될 시간을 준다.
   await act(async () => { await Promise.resolve(); await Promise.resolve(); });
 }
 
-describe('StoryBacklinksSection', () => {
+describe('EntityBacklinksSection', () => {
   it('①끊어진 항목(still_exists=false)도 목록에서 안 빠진다', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
       data: [
@@ -53,7 +57,7 @@ describe('StoryBacklinksSection', () => {
       ],
       meta: { next_cursor: null, has_more: false, collection_scope: { source_types: ['chat_message', 'doc'], forms: 'all', excludes: [] } },
     }))));
-    await render('s1');
+    await render('story', 's1');
     expect(container.textContent).toContain('삭제된 문서');
     expect(container.textContent).toContain('살아있는 문서');
   });
@@ -63,7 +67,7 @@ describe('StoryBacklinksSection', () => {
       data: [{ id: 'r1', source_type: 'doc', source_id: 'd1', created_by: null, created_at: '2026-07-28T00:00:00Z', still_exists: false, doc: { id: 'd1', title: '문서' }, message: null }],
       meta: { next_cursor: null, has_more: false, collection_scope: { source_types: ['chat_message', 'doc'], forms: 'all', excludes: [] } },
     }))));
-    await render('s1');
+    await render('story', 's1');
     expect(container.textContent).toContain('대상이 없습니다');
     expect(container.textContent).not.toContain('삭제됨');
     expect(container.textContent).not.toContain('깨짐');
@@ -75,7 +79,7 @@ describe('StoryBacklinksSection', () => {
       data: [{ id: 'r1', source_type: 'doc', source_id: 'd1', created_by: null, created_at: '2026-07-28T00:00:00Z', still_exists: false, doc: { id: 'd1', title: '문서' }, message: null }],
       meta: { next_cursor: null, has_more: false, collection_scope: { source_types: ['chat_message', 'doc'], forms: 'all', excludes: [] } },
     }))));
-    await render('s1');
+    await render('story', 's1');
     expect(container.innerHTML).not.toContain('text-destructive');
     expect(container.innerHTML).not.toContain('text-warning');
     expect(container.innerHTML).not.toContain('border-warning');
@@ -90,7 +94,7 @@ describe('StoryBacklinksSection', () => {
       ],
       meta: { next_cursor: null, has_more: false, collection_scope: { source_types: ['chat_message', 'doc'], forms: 'all', excludes: [] } },
     }))));
-    await render('s1');
+    await render('story', 's1');
     const matches = container.textContent?.match(/대상이 없습니다/g) ?? [];
     expect(matches.length).toBe(2); // 두 항목 모두 같은 문구 한 벌
   });
@@ -103,7 +107,7 @@ describe('StoryBacklinksSection', () => {
         collection_scope: { source_types: ['chat_message', 'doc'], forms: 'all', excludes: ['pr_sid_text_convention', 'evidence_free_text_reference'] },
       },
     }))));
-    await render('s1');
+    await render('story', 's1');
     expect(container.textContent).toContain('관찰된 참조 0건');
     expect(container.textContent).toContain('chat_message');
     expect(container.textContent).toContain('PR/커밋');
@@ -115,18 +119,18 @@ describe('StoryBacklinksSection', () => {
       data: [{ id: 'r1', source_type: 'doc', source_id: 'd1', created_by: null, created_at: '2026-07-28T00:00:00Z', still_exists: true, doc: { id: 'd1', title: '살아있는 문서' }, message: null }],
       meta: { next_cursor: null, has_more: false, collection_scope: { source_types: ['chat_message', 'doc'], forms: 'all', excludes: [] } },
     }))));
-    await render('s1');
+    await render('story', 's1');
     expect(container.textContent).toContain('살아있는 문서');
     expect(container.textContent).not.toContain('대상이 없습니다');
   });
 
   it('fetch 실패 시 조용히 아무것도 안 그린다(노이즈 0, 다른 애드온 섹션과 동형)', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 500 })));
-    await render('s1');
+    await render('story', 's1');
     expect(container.textContent).toBe('');
   });
 
-  it('story-detail-panel은 story 전환 시 이 컴포넌트를 리마운트 안 한다 — storyId prop만 바뀌어도 이전 story 결과가 안 새어 보인다', async () => {
+  it('story-detail-panel은 story 전환 시 이 컴포넌트를 리마운트 안 한다 — entityId prop만 바뀌어도 이전 결과가 안 새어 보인다', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       if (url.includes('/stories/s1/')) {
         return new Response(JSON.stringify({
@@ -139,15 +143,30 @@ describe('StoryBacklinksSection', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    await render('s1');
+    await render('story', 's1');
     expect(container.textContent).toContain('S1 전용 문서');
 
-    // 같은 인스턴스에 storyId prop만 바뀐다(리마운트 없음) — kanban-board.tsx의 실제 렌더 패턴.
+    // 같은 인스턴스에 entityId prop만 바뀐다(리마운트 없음) — kanban-board.tsx의 실제 렌더 패턴.
     await act(async () => {
-      root.render(withIntl(<StoryBacklinksSection storyId="s2" />));
+      root.render(withIntl(<EntityBacklinksSection entityType="story" entityId="s2" />));
     });
     await act(async () => { await Promise.resolve(); await Promise.resolve(); });
 
     expect(container.textContent).not.toContain('S1 전용 문서'); // 전환 중엔 이전 결과가 안 보인다
+  });
+
+  describe('entityType="doc" — 두 번째 자리 재사용 확인(불규칙복수 파생·재-mount 없이 컴포넌트 변경 0)', () => {
+    it('doc 대상이면 /api/docs/{id}/backlinks를 부른다(story→stories와 다른 불규칙복수)', async () => {
+      const fetchMock = vi.fn(async (url: string) => new Response(JSON.stringify({
+        data: [{ id: 'r1', source_type: 'chat_message', source_id: 'm1', created_by: null, created_at: '2026-07-28T00:00:00Z', still_exists: true, doc: null, message: { id: 'm1', conversation_id: 'c1', content_snippet: '문서를 가리킨 메시지', sender: null } }],
+        meta: { next_cursor: null, has_more: false, collection_scope: { source_types: ['chat_message', 'doc'], forms: 'all', excludes: [] } },
+      })));
+      vi.stubGlobal('fetch', fetchMock);
+
+      await render('doc', 'd1');
+
+      expect(fetchMock).toHaveBeenCalledWith('/api/docs/d1/backlinks', expect.anything());
+      expect(container.textContent).toContain('문서를 가리킨 메시지');
+    });
   });
 });

--- a/apps/web/src/components/shared/entity-backlinks-section.tsx
+++ b/apps/web/src/components/shared/entity-backlinks-section.tsx
@@ -47,11 +47,16 @@ const EXCLUDE_LABEL_KEYS: Record<string, string> = {
  *
  * ⛔이 맵은 **임시**다 — BE가 언젠가 client 입력을 받는 단일 generic
  * `/entities/{type}/{id}/backlinks` 라우트로 접으면(PO가 `UnsupportedBacklinkTargetTypeError`
- * 리뷰에 미리 남겨둔 방향) 이 맵은 통째로 지운다(entity_type을 그대로 세그먼트로 쓰면 되므로). */
-const ENTITY_ROUTE_SEGMENT: Record<string, string> = {
+ * 리뷰에 미리 남겨둔 방향) 이 맵은 통째로 지운다(entity_type을 그대로 세그먼트로 쓰면 되므로).
+ *
+ * ⛔`Record<string, string>`으로 선언하면 `keyof`가 `string`으로 넓어져 타입가드가 이름만 있고
+ * 실제로는 아무것도 안 막는다(`entityType="epic"`이 컴파일을 그냥 통과해 `/api/undefined/...`로
+ * 나갈 수 있었던 자리, PO 지적) — `as const satisfies`로 좁혀 `BacklinksEntityType`이 실제로
+ * `'story' | 'doc'` 리터럴 유니온이 되게 한다. */
+const ENTITY_ROUTE_SEGMENT = {
   story: 'stories',
   doc: 'docs',
-};
+} as const satisfies Record<string, string>;
 
 export type BacklinksEntityType = keyof typeof ENTITY_ROUTE_SEGMENT;
 

--- a/apps/web/src/components/shared/entity-backlinks-section.tsx
+++ b/apps/web/src/components/shared/entity-backlinks-section.tsx
@@ -35,49 +35,73 @@ const EXCLUDE_LABEL_KEYS: Record<string, string> = {
   evidence_free_text_reference: 'backlinksExcludeEvidenceFreeText',
 };
 
-interface StoryBacklinksSectionProps {
-  storyId: string;
+/** BacklinksEntityType → BE 라우트 세그먼트. 불규칙복수(story→stories)라 순수 접미사 파생이
+ * 아닌 조회 테이블로 연다 — PROJECT_ID_RESOLVERS와 같은 성격(종류-분기가 아니라 표기 파생).
+ *
+ * ⛔이 맵의 키 집합은 BE `backlinks.py::BACKLINKS_ALLOWED_TARGET_TYPES`(현재
+ * `frozenset({"doc", "story"})`)와 **글자 그대로 같은 집합**이어야 한다 — 미리 늘리지 않는다.
+ * epic 등 나머지 registry 타입이 거기 없는 이유는 "라우트가 없어서"가 아니라 그 라우터들에
+ * `_require_doc_project_access`/`_assert_story_project_access`와 동형인 TARGET
+ * project-access 선-게이트가 아직 없어서다(PO 확認, 2026-07-28) — 게이트 없이 여기 먼저
+ * 추가하면 화면이 "게이트 없는 라우트"를 부르게 된다.
+ *
+ * ⛔이 맵은 **임시**다 — BE가 언젠가 client 입력을 받는 단일 generic
+ * `/entities/{type}/{id}/backlinks` 라우트로 접으면(PO가 `UnsupportedBacklinkTargetTypeError`
+ * 리뷰에 미리 남겨둔 방향) 이 맵은 통째로 지운다(entity_type을 그대로 세그먼트로 쓰면 되므로). */
+const ENTITY_ROUTE_SEGMENT: Record<string, string> = {
+  story: 'stories',
+  doc: 'docs',
+};
+
+export type BacklinksEntityType = keyof typeof ENTITY_ROUTE_SEGMENT;
+
+interface EntityBacklinksSectionProps {
+  entityType: BacklinksEntityType;
+  entityId: string;
 }
 
 /**
- * story #2299(E-CONNECT) — 「이것을 가리키는 것들」 목록. story-detail-panel 신설 섹션(첫 자리 —
- * doc [slug]/view는 후속 판, PO 지시대로 한 자리로 절차를 세운다).
+ * story #2299(E-CONNECT) — 「이것을 가리키는 것들」 목록. 첫 자리는 story-detail-panel,
+ * 두 번째 자리(doc `[slug]/view`)가 오면서 entityType/entityId 축으로 일반화했다(PO 지시:
+ * "두 번째 자리가 올 때 일반화한다" — 소비자 없는 추상을 미리 짓지 않는다). API 경로는
+ * ENTITY_ROUTE_SEGMENT로만 파생 — 화면 코드에 종류를 나열/분기하지 않는다.
  *
- * still_exists 표시 규율(유나 확定):
+ * still_exists 표시 규율(유나 확定, entityType 무관):
  *  ①끊어진 항목도 목록에서 안 뺀다(그대로 보여줌 — 사라진 척 안 함).
  *  ②사실로 보인다 — 오류색/경고 아이콘 없이 회색(노랑=기다릴 것 전용, 여기는 아무도 안 기다림).
  *  ③문구는 비난 없이 「대상이 없습니다」(삭제됨/깨짐 같은 말 안 씀).
- *  ④종류(doc/chat_message)와 무관하게 문구 한 벌.
+ *  ④backlink source 종류(doc/chat_message)와 무관하게 문구 한 벌.
  */
 interface LoadedResult {
-  storyId: string;
+  entityType: BacklinksEntityType;
+  entityId: string;
   items: BacklinkItem[];
   scope: CollectionScope | null;
 }
 
-export function StoryBacklinksSection({ storyId }: StoryBacklinksSectionProps) {
+export function EntityBacklinksSection({ entityType, entityId }: EntityBacklinksSectionProps) {
   const t = useTranslations('board');
-  // story-detail-panel은 story 전환 시 이 컴포넌트를 리마운트하지 않는다(같은 인스턴스에
-  // storyId prop만 바뀜) — 그래서 결과에 storyId를 같이 담아 「지금 보이는 결과가 지금
-  // storyId 것인지」를 렌더 시점에 판정한다(effect 안에서 동기 setState로 리셋하는 대신 —
-  // react-hooks/set-state-in-effect가 막는 패턴. 전환 중엔 이전 story 결과가 안 보인다).
+  // story-detail-panel처럼 entityId만 바뀌고 이 컴포넌트가 리마운트 안 되는 호출부가 있을 수
+  // 있다 — 결과에 entityType+entityId를 같이 담아 렌더 시점에 일치 여부로 판정한다(전환-누출
+  // 방지, #2299 원본 회귀테스트와 동형. 동기 setState-in-effect도 그래서 안 씀).
   const [result, setResult] = useState<LoadedResult | 'failed' | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    fetch(`/api/stories/${storyId}/backlinks`, { cache: 'no-store' })
+    const segment = ENTITY_ROUTE_SEGMENT[entityType];
+    fetch(`/api/${segment}/${entityId}/backlinks`, { cache: 'no-store' })
       .then((r) => (r.ok ? (r.json() as Promise<{ data?: BacklinkItem[]; meta?: BacklinksMeta }>) : null))
       .then((json) => {
         if (cancelled) return;
         if (!json) { setResult('failed'); return; }
-        setResult({ storyId, items: json.data ?? [], scope: json.meta?.collection_scope ?? null });
+        setResult({ entityType, entityId, items: json.data ?? [], scope: json.meta?.collection_scope ?? null });
       })
       .catch(() => { if (!cancelled) setResult('failed'); });
     return () => { cancelled = true; };
-  }, [storyId]);
+  }, [entityType, entityId]);
 
   // 조용한 폴백 — 다른 애드온 섹션(stuck-handoff-section 등)과 동형, 로딩/실패/전환-중으로 노이즈를 안 낸다.
-  if (result === null || result === 'failed' || result.storyId !== storyId) return null;
+  if (result === null || result === 'failed' || result.entityType !== entityType || result.entityId !== entityId) return null;
   const { items, scope } = result;
 
   return (

--- a/apps/web/src/lib/convention-a-double-wrap-guard.test.ts
+++ b/apps/web/src/lib/convention-a-double-wrap-guard.test.ts
@@ -9,8 +9,6 @@
  *   해당 안 됨(이중포장 자체가 구조적으로 불가) — 스킵.
  * - docs.py(list_docs)·notifications.py(list_notifications): FE가 이 BE 엔드포인트를 아예
  *   안 쓰고 별도 내부 서비스/레포지토리를 쓴다(다른 아키텍처) — 이 클래스의 위험군이 아님, 스킵.
- * - docs.py(get_doc_backlinks): FE 프록시 자체가 아직 없음(story #2264/C-6 별건, 배선 자체가
- *   안 됨 — stories.py(get_story_backlinks)는 #2299에서 배선돼 아래 목록에 있다).
  * - 미래에 새로 생기는 규약A 엔드포인트는 이 가드가 자동으로 못 잡는다 — 만들 때 이 파일에
  *   케이스를 추가하는 것이 유일한 방어선이다.
  */
@@ -67,5 +65,10 @@ describe('규약A 엔드포인트 FE 프록시 — 이중포장 없음 가드', 
   it('stories/[id]/backlinks — #2299 신설 프록시(처음부터 raw unwrap으로 지어짐)', async () => {
     const { GET } = await import('@/app/api/stories/[id]/backlinks/route');
     await assertNoDoubleWrap(GET, { params: Promise.resolve({ id: 's1' }) });
+  });
+
+  it('docs/[id]/backlinks — EntityBacklinksSection 두 번째 자리(형제 stories와 동형, 처음부터 raw unwrap)', async () => {
+    const { GET } = await import('@/app/api/docs/[id]/backlinks/route');
+    await assertNoDoubleWrap(GET, { params: Promise.resolve({ id: 'd1' }) });
   });
 });


### PR DESCRIPTION
## 배경

#2299(story-detail-panel 첫 자리)의 반복 판 — doc `[slug]/view`가 두 번째 자리. PO가 세운 순서 그대로: 첫 자리 세울 땐 일반화하지 않고("두 번째 자리가 올 때 일반화한다" — 소비자 없는 추상을 미리 안 짓는다), 지금이 그때.

## 재사용 판정 — "한 글자도 안 바뀌고 붙는가"

답은 "아니오"였다(사전 보고): `StoryBacklinksSection`이 컴포넌트명·`storyId` prop·API 경로 셋 다 story 전용으로 하드코딩돼 있었다. `EntityBacklinksSection({entityType, entityId})`로 일반화 — `ENTITY_ROUTE_SEGMENT` 맵으로 API 경로만 파생(story→stories, doc→docs — 불규칙복수라 접미사 파생 대신 조회 테이블, `PROJECT_ID_RESOLVERS`와 같은 성격).

story 쪽은 **호출만** 바뀐다: `<EntityBacklinksSection entityType="story" entityId={story.id} />` — 컴포넌트 본문은 무변경.

## ⛔맵의 키 집합 제약(PO 확認)

`ENTITY_ROUTE_SEGMENT`의 키는 BE `backlinks.py::BACKLINKS_ALLOWED_TARGET_TYPES`(현재 `{"doc", "story"}`)와 **글자 그대로 같은 집합**이어야 한다 — epic 등을 미리 넣지 않는다.

확인된 사실: `epic`(Goal 모델) 등 나머지 registry 타입이 BE 허용목록에 없는 진짜 이유는 "라우트가 없어서"가 아니라 **그 라우터에 TARGET project-access 선-게이트(`_require_doc_project_access`/`_assert_story_project_access`와 동형)가 아직 없어서**다 — 게이트가 서는 순서대로 허용목록에 추가되는 구조. 게이트 없이 화면이 먼저 그 경로를 부르면 안 된다.

## ⛔이 맵은 임시(만료조건 명시)

BE가 언젠가 client 입력을 받는 단일 generic `/entities/{type}/{id}/backlinks` 라우트로 접으면(PO가 `UnsupportedBacklinkTargetTypeError` 리뷰에 미리 남겨둔 방향) — 이 맵은 통째로 지운다(`entity_type`을 그대로 세그먼트로 쓰면 되므로). 코드 주석에 이 조건을 명시해 "안 쓰는 필드"로 나중에 지워지지 않게 했다.

## 신규 FE 프록시

`GET /api/docs/[id]/backlinks` — BE가 docs/stories 둘 다 같은 함수(`list_entity_backlinks`)·같은 convention-A shape라 형제 프록시(`stories/[id]/backlinks/route.ts`)와 완전 동형(raw unwrap, 이중포장 방지 패턴 그대로). CI 가드(`convention-a-double-wrap-guard.test.ts`)에도 케이스 추가.

## 검증

- mutation-verified: `ENTITY_ROUTE_SEGMENT`의 doc 값을 일부러 깨면(`docs`→`docz`) doc 재사용 테스트가 정확히 그 지점에서 RED → 원복 GREEN.
- 전체 FE vitest: 301 파일 · 2010 테스트 PASS(회귀 0). `tsc --noEmit`/`eslint` 무오류.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>