### PR TITLE
fix(mcp): 카탈로그 등록명↔실등록명 축 불일치 해소 — ping 확정, 유령 sprintable_ping 제거 (#2304)

### DIFF
--- a/apps/web/src/lib/toolset-catalog.ts
+++ b/apps/web/src/lib/toolset-catalog.ts
@@ -31,7 +31,7 @@ export interface ToolsetCatalog {
  */
 export const TEMP_TOOLSET_CATALOG: ToolsetCatalog = {
   groups: [
-    { key: 'core', is_core: true, is_destructive: false, tools: ['sprintable_ping', 'sprintable_my_dashboard', 'sprintable_check_notifications'] },
+    { key: 'core', is_core: true, is_destructive: false, tools: ['ping', 'sprintable_my_dashboard', 'sprintable_check_notifications'] },
     { key: 'stories', is_core: false, is_destructive: false, tools: ['sprintable_add_story', 'sprintable_list_stories', 'sprintable_update_story_status', 'sprintable_claim_story', 'sprintable_search_stories'] },
     { key: 'tasks', is_core: false, is_destructive: false, tools: ['sprintable_add_task', 'sprintable_list_tasks', 'sprintable_update_task_status', 'sprintable_get_task'] },
     { key: 'sprints', is_core: false, is_destructive: false, tools: ['sprintable_list_sprints', 'sprintable_assign_story_to_sprint', 'sprintable_checkin_sprint', 'sprintable_sprint_summary'] },

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -51,7 +51,9 @@ _CORE = "core"  # ping/notifications-check 등 기본 — 항상 허용
 # (workflow_guide·team_members·poll_events)을 여기 포함 — picker 가 core(always-on)로 표시하는데
 # enforcement 가 explicit scope 에서 거부하던 비정합 해소. read 유틸은 비파괴라 always-allow 안전.
 _ALWAYS_ALLOWED: frozenset[str] = frozenset({
-    "ping", "sprintable_ping", "sprintable_my_dashboard", "sprintable_check_notifications",
+    # story #2304: "sprintable_ping"은 실재하지 않는 유령 이름이라 걷는다 — 이 목록에 둘 다
+    # 적어 두는 "우연한 방패"는 다음 이름축 불일치도 조용히 지나가게 한다.
+    "ping", "sprintable_my_dashboard", "sprintable_check_notifications",
     "sprintable_get_workflow_guide", "sprintable_list_team_members", "sprintable_poll_events",
     # P1-S12: get_workflow_guide 동형(read-only·에이전트 on-demand pull) — 항상 허용.
     "sprintable_get_loop_context",
@@ -289,7 +291,10 @@ def resolve_manifest(scope: list[str] | None, all_tool_names: list[str]) -> dict
 # ⚠️ backend 는 sprintable_mcp 를 import 하지 않으므로(디탱글) 이 목록이 backend-owned SSOT.
 #    도구 추가/삭제 시 여기 동기화(테스트가 그룹 커버리지·core/admin 정합 검증).
 ALL_TOOL_NAMES: tuple[str, ...] = (
-    "sprintable_ping",
+    # story #2304: 실등록명은 "ping"이다(server.py:311 `@mcp.tool()` 데코레이터, `_TOOL_DEFS`
+    # 밖에서 단독등록 — sprintable_mcp/tests/test_e2e_dev.py 등 다수 테스트·라이브 MCP client가
+    # 이미 이 이름으로 실호출한다). "sprintable_ping"은 이 목록에만 존재하던 유령 이름이었다.
+    "ping",
     "sprintable_activate_sprint", "sprintable_add_epic", "sprintable_add_goal",
     "sprintable_add_retro_action",
     "sprintable_add_retro_item", "sprintable_add_story", "sprintable_add_task",
@@ -386,7 +391,10 @@ def build_toolset_catalog() -> dict:
     - is_core = core(항상허용 잠금 그룹). is_destructive = admin(위험 작업 격리·opt-in).
     - 순서: core → 비파괴 15그룹(_CATALOG_DISPLAY_ORDER) → admin(파괴적) 마지막.
     """
-    always = {t for t in _ALWAYS_ALLOWED if t.startswith("sprintable_")}
+    # story #2304: 예전엔 "sprintable_" 접두사로 필터했는데, 그 필터의 유일한 실효과가
+    # "ping"(비접두사, 실등록명)을 core 그룹에서 조용히 빼는 것이었다 — _ALWAYS_ALLOWED가
+    # 이제 정확한 이름만 담으므로 필터 없이 그대로 쓴다.
+    always = set(_ALWAYS_ALLOWED)
     buckets: dict[str, list[str]] = {}
     for t in ALL_TOOL_NAMES:
         if t in always:

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -294,6 +294,10 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     # story #2304: 실등록명은 "ping"이다(server.py:311 `@mcp.tool()` 데코레이터, `_TOOL_DEFS`
     # 밖에서 단독등록 — sprintable_mcp/tests/test_e2e_dev.py 등 다수 테스트·라이브 MCP client가
     # 이미 이 이름으로 실호출한다). "sprintable_ping"은 이 목록에만 존재하던 유령 이름이었다.
+    # ⛔접두사 없음은 실수가 아니라 «의도»다 — 나머지 114개가 전부 sprintable_* 라고 이 줄을
+    # "sprintable_ping"으로 되돌리지 말 것. 실등록명이 ping이고 e2e·라이브 MCP client가 이
+    # 이름으로 부른다. 바꾸려면 클라이언트 쪽이 먼저 따라와야 한다(server.py:311 데코레이터
+    # 개명 + 모든 호출자 마이그 선행, story #2304).
     "ping",
     "sprintable_activate_sprint", "sprintable_add_epic", "sprintable_add_goal",
     "sprintable_add_retro_action",

--- a/backend/sprintable_mcp/toolset.py
+++ b/backend/sprintable_mcp/toolset.py
@@ -45,7 +45,9 @@ _GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
 _CORE = "core"
 
 _ALWAYS_ALLOWED: frozenset[str] = frozenset({
-    "ping", "sprintable_ping", "sprintable_my_dashboard", "sprintable_check_notifications",
+    # story #2304(2026-07-29): "sprintable_ping"은 실재하지 않는 유령 이름이라 걷는다 —
+    # app/services/mcp_toolset.py와 짝맞춤(SEC-S8류 재드리프트 방지).
+    "ping", "sprintable_my_dashboard", "sprintable_check_notifications",
     # P1-S12: 백엔드 SSOT(app/services/mcp_toolset.py)와 대조해 기존 드리프트 발견 후 동기화
     # (get_workflow_guide/list_team_members/poll_events가 vendored 사본에 빠져있었음 — 발견 즉시
     # 수정, read 유틸은 비파괴라 always-allow 안전). sprintable_get_loop_context(P1-S12, 이 스토리

--- a/backend/tests/test_e_mcp_s2_toolset.py
+++ b/backend/tests/test_e_mcp_s2_toolset.py
@@ -94,8 +94,14 @@ def test_real_destructive_tools_still_blocked_without_admin_grant_after_s17():
 
 
 def test_always_allowed_tools():
-    assert is_tool_allowed("sprintable_ping", ["stories"])  # 핵심 도구는 그룹 무관 허용
+    assert is_tool_allowed("ping", ["stories"])  # 핵심 도구는 그룹 무관 허용
     assert is_tool_allowed("ping", [])
+
+
+def test_ghost_sprintable_ping_no_longer_always_allowed():
+    """story #2304: "sprintable_ping"은 실재하지 않는 이름이라 더는 _ALWAYS_ALLOWED 방패를 안 받는다
+    — group 판정 경로로 떨어져 명시 scope 밖이면 거부된다(실제 도구가 아니므로 호출될 일도 없다)."""
+    assert not is_tool_allowed("sprintable_ping", ["stories"])
 
 
 def test_lock_unlock_allowed_regardless_of_domain_scope():

--- a/backend/tests/test_e_mcp_s4_standalone.py
+++ b/backend/tests/test_e_mcp_s4_standalone.py
@@ -40,7 +40,7 @@ def test_vendored_toolset_matches_backend_rules():
     matrix_tools = [
         "sprintable_add_story", "sprintable_add_task", "sprintable_delete_story",
         "sprintable_give_reward", "sprintable_send_chat_message", "sprintable_get_velocity",
-        "sprintable_ping", "sprintable_create_sprint", "sprintable_lock_files",
+        "ping", "sprintable_ping", "sprintable_create_sprint", "sprintable_lock_files",
     ]
     matrix_scopes = [None, [], ["read", "write"], ["stories"], ["stories", "tasks"],
                      ["stories", "destructive"], ["admin"]]

--- a/backend/tests/test_e_recruit_s2_compose_prompt.py
+++ b/backend/tests/test_e_recruit_s2_compose_prompt.py
@@ -274,7 +274,7 @@ def test_compose_kit_always_allowed_tools_present_regardless_of_groups():
     role = _role(default_tool_groups=["stories"])
     out = compose_kit(role, "claude-code")["onboarding"]
     assert "sprintable_get_workflow_guide" in out
-    assert "sprintable_ping" in out
+    assert "ping" in out  # story #2304: 실등록명 — "sprintable_ping"은 유령이었다
 
 
 def test_compose_kit_raises_on_unknown_default_tool_group():

--- a/backend/tests/test_s2304_ping_tool_name_registry_match.py
+++ b/backend/tests/test_s2304_ping_tool_name_registry_match.py
@@ -1,0 +1,132 @@
+"""story #2304 — 카탈로그(ALL_TOOL_NAMES)가 «없는 도구»를 광고하고 «있는 도구»를 숨기던 병.
+
+배경: `_TOOL_DEFS` 밖에서 `@mcp.tool()` 데코레이터로 단독등록되는 `ping`이 실제 등록명인데,
+`ALL_TOOL_NAMES`(mcp_toolset.py)는 존재하지 않는 "sprintable_ping"을 대신 담고 있었다.
+`_ALWAYS_ALLOWED`가 두 이름을 다 적어 둔 덕에 권한 게이팅만 우연히 안 깨졌을 뿐 —
+FE 피커 core 그룹엔 유령 도구가 노출되고 agent_recruiter 치트시트엔 진짜 ping이 빠져 있었다.
+
+AC1: 정답은 "ping"(실등록명, 다수 기존 테스트+라이브 MCP client가 이미 이 이름으로 씀)로 확정.
+AC2: `_TOOL_DEFS` 루프만 세지 않는다 — `mcp.list_tools()`(실제 등록 결과 전량)와 직접 대조한다.
+AC3: agent_recruiter 치트시트가 그 실등록 집합과 어긋나면 RED.
+AC4: 카운트/집합비교마다 "이 방법이 실제로 무언가를 잡는가"를 양성대조로 증명한다.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── AC2: 실제 등록 전량(_TOOL_DEFS 루프 + 데코레이터 단독등록분) ↔ ALL_TOOL_NAMES ──────────
+
+@pytest.mark.anyio
+async def test_all_tool_names_matches_real_mcp_registration_bidirectionally():
+    """`mcp.list_tools()`가 돌려주는 실제 등록 도구명 전량과 ALL_TOOL_NAMES가 양방향으로
+    일치한다 — 어느 한쪽에만 있는 도구가 없다(가드 사슬의 A↔C 갭을 여기서 막는다)."""
+    from sprintable_mcp import server as srv
+    from app.services import mcp_toolset as backend
+
+    real_tools = {t.name for t in await srv.mcp.list_tools()}
+    declared = set(backend.ALL_TOOL_NAMES)
+
+    only_in_declared = declared - real_tools
+    only_in_real = real_tools - declared
+    assert only_in_declared == set(), f"ALL_TOOL_NAMES에만 있는 유령 이름: {only_in_declared}"
+    assert only_in_real == set(), f"실등록인데 ALL_TOOL_NAMES에 없는 도구: {only_in_real}"
+
+
+@pytest.mark.anyio
+async def test_ping_specifically_is_the_real_registered_name():
+    """AC1 확정 — "ping"이 실등록명, "sprintable_ping"은 존재하지 않는다."""
+    from sprintable_mcp import server as srv
+
+    real_names = {t.name for t in await srv.mcp.list_tools()}
+    assert "ping" in real_names
+    assert "sprintable_ping" not in real_names
+
+
+def test_all_tool_names_no_longer_contains_ghost_sprintable_ping():
+    from app.services import mcp_toolset as backend
+
+    assert "ping" in backend.ALL_TOOL_NAMES
+    assert "sprintable_ping" not in backend.ALL_TOOL_NAMES
+
+
+def test_always_allowed_no_longer_double_shields_ping():
+    """`_ALWAYS_ALLOWED`가 두 이름을 다 적어 두는 "우연한 방패"를 걷었다 — ping 하나만 남는다."""
+    from app.services import mcp_toolset as backend
+
+    assert "ping" in backend._ALWAYS_ALLOWED
+    assert "sprintable_ping" not in backend._ALWAYS_ALLOWED
+
+
+# ── AC4: 양성대조 — 이 비교 방법이 실제로 드리프트를 잡는지 뮤테이션으로 증명 ──────────
+
+@pytest.mark.anyio
+async def test_positive_control_ghost_name_in_all_tool_names_is_caught(monkeypatch):
+    """ALL_TOOL_NAMES에 실재하지 않는 이름을 인위로 하나 심으면, 위 AC2 비교가 실제로 잡는다."""
+    from sprintable_mcp import server as srv
+    from app.services import mcp_toolset as backend
+
+    real_tools = {t.name for t in await srv.mcp.list_tools()}
+    mutated_declared = set(backend.ALL_TOOL_NAMES) | {"sprintable_definitely_not_real_xyz"}
+
+    only_in_declared = mutated_declared - real_tools
+    assert only_in_declared == {"sprintable_definitely_not_real_xyz"}
+
+
+@pytest.mark.anyio
+async def test_positive_control_missing_real_tool_is_caught(monkeypatch):
+    """실등록 집합에서 하나를 인위로 빼면(예: ping을 제거한 척), 비교가 그 누락을 잡는다."""
+    from sprintable_mcp import server as srv
+    from app.services import mcp_toolset as backend
+
+    real_tools = {t.name for t in await srv.mcp.list_tools()}
+    mutated_real = real_tools - {"ping"}
+    declared = set(backend.ALL_TOOL_NAMES)
+
+    only_in_declared = declared - mutated_real
+    assert "ping" in only_in_declared
+
+
+# ── AC3: 치트시트가 실등록 집합에서 파생되고, 어긋나면 RED ──────────────────────────────
+
+def test_cheat_sheet_lists_real_ping_not_ghost():
+    """agent_recruiter 치트시트가 "sprintable_ping"(유령)이 아니라 "ping"(실등록명)을 항상-노출로
+    낸다 — SSOT 주장(agent_recruiter.py docstring)이 실제로 지켜지는지 직접 확認."""
+    from app.services.agent_recruiter import _tool_cheat_sheet
+
+    out = _tool_cheat_sheet(["stories"], locale="ko")
+    assert "`ping`" in out
+    assert "`sprintable_ping`" not in out
+
+
+def test_cheat_sheet_always_on_derives_from_all_tool_names_and_always_allowed():
+    """치트시트의 always-on 목록은 ALL_TOOL_NAMES ∩ _ALWAYS_ALLOWED로 파생된다(손으로 안 만든다) —
+    이 교집합이 정확히 _ALWAYS_ALLOWED와 같아야 한다(ALL_TOOL_NAMES가 _ALWAYS_ALLOWED 전량을
+    포함해야 함, AC2가 이미 이를 보장하지만 치트시트 관점에서 다시 고정한다)."""
+    from app.services import mcp_toolset as backend
+
+    always_on = {t for t in backend.ALL_TOOL_NAMES if t in backend._ALWAYS_ALLOWED}
+    assert always_on == set(backend._ALWAYS_ALLOWED), (
+        f"_ALWAYS_ALLOWED 중 ALL_TOOL_NAMES에 없는 것: {set(backend._ALWAYS_ALLOWED) - always_on}"
+    )
+
+
+# ── build_toolset_catalog(): FE 피커 core 그룹에 ping이 정상 노출되는지 ───────────────
+
+def test_catalog_core_group_exposes_ping_not_ghost():
+    """FE 피커 SSOT 응답의 core 그룹이 "ping"을 담는다(전엔 "sprintable_" 접두사 필터 때문에
+    core 버킷에서 조용히 빠졌었다) — "sprintable_ping"은 어디에도 없다."""
+    from app.services.mcp_toolset import build_toolset_catalog
+
+    catalog = build_toolset_catalog()
+    core = next(g for g in catalog["groups"] if g["key"] == "core")
+    assert "ping" in core["tools"]
+    assert "sprintable_ping" not in core["tools"]
+
+    all_tools = [t for g in catalog["groups"] for t in g["tools"]]
+    assert all_tools.count("ping") == 1  # core에만, 다른 그룹에 중복노출 없음


### PR DESCRIPTION
## Summary
- `_TOOL_DEFS` 밖에서 `@mcp.tool()` 데코레이터로 단독등록되는 `ping`이 실제 등록명인데, `ALL_TOOL_NAMES`(mcp_toolset.py)는 존재하지 않는 `sprintable_ping`을 대신 담고 있었다(story #2304, doc `duplicate-registry-census-20260728` #3항목에서 발견).
- `_ALWAYS_ALLOWED`가 두 이름을 다 적어 둔 덕에 권한 게이팅만 우연히 안 깨졌다 — 실제로 깨진 자리: `build_toolset_catalog()`가 FE 피커 core 그룹에 유령 `sprintable_ping`을 노출하고, `agent_recruiter.py` 치트시트는 진짜 `ping`을 아예 누락했다.
- AC1: 정답은 `ping`으로 확정(다수 기존 테스트+라이브 MCP client가 이미 이 이름으로 실호출).
- `ALL_TOOL_NAMES`·`_ALWAYS_ALLOWED`(app+vendored 양쪽) 갱신, `build_toolset_catalog()`의 `sprintable_` 접두사 필터(ping을 core 버킷에서 조용히 빼던 원인) 제거.
- AC2: `mcp.list_tools()`(실등록 전량, `_TOOL_DEFS`만 세지 않음)와 `ALL_TOOL_NAMES`를 양방향 대조하는 회귀테스트 신설 + 양성대조(뮤테이션으로 방법이 실제로 잡는지 증명, RED→GREEN 확인 완료).
- AC3: 치트시트가 실등록 집합과 어긋나면 RED.

## Test plan
- [x] 신규 테스트 파일 `backend/tests/test_s2304_ping_tool_name_registry_match.py` 9건 — fix 적용 상태 GREEN.
- [x] 뮤테이션 자가검증 — fix 되돌리면(`git stash`) 8/9건 RED로 정확히 재현, 복원 후 GREEN.
- [x] 관련 기존 테스트 전수 재확인·필요한 3개 파일 갱신(sprintable_ping→ping 어서션): `test_e_mcp_s2_toolset.py`·`test_e_mcp_s4_standalone.py`·`test_e_recruit_s2_compose_prompt.py`.
- [x] `tests/ -k "mcp or ping or toolset or e_recruit or catalog"` 477 passed / 7 failed — 실패 7건 전부 **origin/develop 기저선에서도 동일하게 실패**함을 별도 워크트리로 직접 재현·확인(내 변경과 무관, 사전존재 환경/구식카운트 이슈: `.mcp.json` 로컬환경 의존 3건 + 라이브 dev서버 도구수 하드코딩(89) 구식카운트 4건).
- [x] `git diff origin/develop...HEAD --stat` — 의도한 7개 파일만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)