### PR TITLE
feat(#2303): focal_story 계약 확장 — hero가 실제로 읽는 9필드 한 왕복에

### DIFF
--- a/backend/app/models/gate.py
+++ b/backend/app/models/gate.py
@@ -43,6 +43,14 @@ def is_valid_transition(from_status: str, to_status: str) -> bool:
     return (from_status, to_status) in _VALID_TRANSITIONS
 
 
+# story #2303(2026-07-29): Gate.evidence_status(merge gate 재평가 결과)의 원자료→간소화값
+# 매핑 — 원래 app/routers/glance.py의 hero 엔드포인트 전용 상수였다. app/repositories/goal.py
+# (`?include=glance`의 focal_story.auto_verify)가 같은 매핑이 다시 필요해지면서 두 자리에
+# 같은 dict를 각자 적어두면 오늘 하루 반복 관측된 twin-system 갭이 재발한다 — 모델 레이어를
+# 단일 소유자로 삼고 양쪽(라우터·레포지토리)이 여기서 import한다.
+AUTO_VERIFY_MAP: dict[str, str] = {"sufficient": "passed", "blocked": "failed"}
+
+
 class Gate(Base):
     __tablename__ = "gate"
 

--- a/backend/app/repositories/goal.py
+++ b/backend/app/repositories/goal.py
@@ -6,9 +6,13 @@ from typing import Any
 from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.evidence import Evidence
+from app.models.gate import AUTO_VERIFY_MAP as _AUTO_VERIFY_MAP
 from app.models.gate import Gate
 from app.models.hypothesis import Hypothesis, HypothesisEpicLink
+from app.models.member import Member
 from app.models.pm import Goal, Story
+from app.models.story_assignee import StoryAssignee
 from app.repositories.base import BaseRepository
 from app.schemas.goal import GoalProgressResponse
 
@@ -166,7 +170,9 @@ class GoalRepository(BaseRepository[Goal]):
         in-progress) 이관. tiebreak는 기존 `/api/stories?epic_id=` 기본 정렬(created_at DESC,
         id DESC)과 동일하게 맞춘다 — gate 우선순위 자체는 이번에 "처음으로" 실제 재료(gate
         데이터)를 갖고 평가된다(`GlanceFocalStory` docstring 참조 — 기존엔 재료가 없어 죽어
-        있던 분기)."""
+        있던 분기). story #2303부터 `focal_story`가 `/api/glance/hero?story_id=`가 주던
+        9필드(assignee_ids·proof_count·auto_verify·gate.*·trust.*)까지 싣는다 — 전부 픽된
+        focal story id 집합(페이지 전체 goal 기준)으로 배치 조회, N+1 없음."""
         for goal in goals:
             goal.participant_ids = []  # type: ignore[attr-defined]
             goal.focal_story = None  # type: ignore[attr-defined]
@@ -203,27 +209,111 @@ class GoalRepository(BaseRepository[Goal]):
             candidates_by_goal.setdefault(row.epic_id, []).append(row)
             story_ids.append(row.id)
 
-        # N+1 회피 — 배치 gate 조회. Gate는 work_item_id/work_item_type 폴리모픽(FK 없음,
-        # S11 workflow-line 배치 read와 동일 패턴: work_item_id.in_(ids)).
-        pending_story_ids: set[uuid.UUID] = set()
+        # N+1 회피 — 배치 pending-gate 조회. Gate는 work_item_id/work_item_type 폴리모픽(FK
+        # 없음, S11 workflow-line 배치 read와 동일 패턴: work_item_id.in_(ids)). gate_type·
+        # requires_human까지 같이 뽑아 두면(story #2303) tie-break 판정과 최종 gate 필드를
+        # «같은 쿼리»로 겸한다(따로 또 조회 안 함) — created_at DESC라 story별 첫 항목이
+        # 최신 pending gate(기존 hero의 `.order_by(created_at.desc()).limit(1)`과 동형).
+        pending_gate_by_story: dict[uuid.UUID, Any] = {}
         if story_ids:
             gate_rows = await self.session.execute(
-                select(Gate.work_item_id).where(
+                select(Gate.work_item_id, Gate.gate_type, Gate.requires_human).where(
                     Gate.work_item_id.in_(story_ids), Gate.work_item_type == "story",
                     Gate.org_id == self.org_id, Gate.status == "pending",
-                )
+                ).order_by(Gate.created_at.desc())
             )
-            pending_story_ids = set(gate_rows.scalars().all())
+            for row in gate_rows.all():
+                pending_gate_by_story.setdefault(row.work_item_id, row)
+        pending_story_ids = set(pending_gate_by_story)
 
+        picked_by_goal: dict[uuid.UUID, Any] = {}
         for goal in goals:
             candidates = candidates_by_goal.get(goal.id)
             if not candidates:
                 continue
-            picked = next((r for r in candidates if r.id in pending_story_ids), candidates[0])
+            picked_by_goal[goal.id] = next(
+                (r for r in candidates if r.id in pending_story_ids), candidates[0]
+            )
+        if not picked_by_goal:
+            return
+
+        focal_ids = [r.id for r in picked_by_goal.values()]
+
+        # assignee_ids — StoryAssignee join(E-BOARD S5). 배열이라 캡 없음(전부).
+        assignee_rows = await self.session.execute(
+            select(StoryAssignee.story_id, StoryAssignee.member_id).where(
+                StoryAssignee.story_id.in_(focal_ids), StoryAssignee.org_id == self.org_id,
+            )
+        )
+        assignee_ids_by_story: dict[uuid.UUID, list[uuid.UUID]] = {}
+        for story_id, member_id in assignee_rows.all():
+            assignee_ids_by_story.setdefault(story_id, []).append(member_id)
+
+        # proof_count — evidence row 개수(hero와 동일 정의).
+        proof_rows = await self.session.execute(
+            select(Evidence.work_item_id, func.count(Evidence.id)).where(
+                Evidence.org_id == self.org_id, Evidence.work_item_id.in_(focal_ids),
+                Evidence.work_item_type == "story",
+            ).group_by(Evidence.work_item_id)
+        )
+        proof_count_by_story: dict[uuid.UUID, int] = dict(proof_rows.all())
+
+        # auto_verify — merge gate의 evidence_status(hero의 _AUTO_VERIFY_MAP과 동일 원자료).
+        merge_rows = await self.session.execute(
+            select(Gate.work_item_id, Gate.evidence_status).where(
+                Gate.org_id == self.org_id, Gate.work_item_id.in_(focal_ids),
+                Gate.work_item_type == "story", Gate.gate_type == "merge",
+            ).order_by(Gate.created_at.desc())
+        )
+        merge_status_by_story: dict[uuid.UUID, str | None] = {}
+        for story_id, evidence_status in merge_rows.all():
+            merge_status_by_story.setdefault(story_id, evidence_status)
+
+        # human_verified — 최신 gate_approval evidence(휴먼 서명·스푸핑불가, hero와 동일).
+        hv_rows = await self.session.execute(
+            select(Evidence.work_item_id, Evidence.created_by, Evidence.created_at).where(
+                Evidence.org_id == self.org_id, Evidence.work_item_id.in_(focal_ids),
+                Evidence.work_item_type == "story", Evidence.type == "gate_approval",
+            ).order_by(Evidence.created_at.desc())
+        )
+        hv_by_story: dict[uuid.UUID, Any] = {}
+        for row in hv_rows.all():
+            hv_by_story.setdefault(row.work_item_id, row)
+
+        hv_member_ids = {row.created_by for row in hv_by_story.values() if row.created_by}
+        member_name_by_id: dict[uuid.UUID, str] = {}
+        if hv_member_ids:
+            member_rows = await self.session.execute(
+                select(Member.id, Member.name).where(Member.id.in_(hv_member_ids))
+            )
+            member_name_by_id = dict(member_rows.all())
+
+        for goal_id, picked in picked_by_goal.items():
+            proof_count = proof_count_by_story.get(picked.id, 0)
+            hv_row = hv_by_story.get(picked.id)
+            hv_member = None
+            if hv_row is not None and hv_row.created_by in member_name_by_id:
+                hv_member = {"name": member_name_by_id[hv_row.created_by]}
+            pending_gate = pending_gate_by_story.get(picked.id)
+            merge_status = merge_status_by_story.get(picked.id)
+
+            goal = next(g for g in goals if g.id == goal_id)
             goal.focal_story = {  # type: ignore[attr-defined]
                 "id": picked.id, "title": picked.title, "status": picked.status,
                 "assignee_id": picked.assignee_id,
-                "gate_status": "pending" if picked.id in pending_story_ids else None,
+                "assignee_ids": assignee_ids_by_story.get(picked.id, []),
+                "proof_count": proof_count,
+                "auto_verify": _AUTO_VERIFY_MAP.get(merge_status) if merge_status else None,
+                "gate": (
+                    {"gate_type": pending_gate.gate_type, "requires_human": pending_gate.requires_human}
+                    if pending_gate is not None else None
+                ),
+                "trust": {
+                    "self_reported": proof_count > 0,
+                    "human_verified": hv_row is not None,
+                    "human_verified_by": hv_member,
+                    "human_verified_at": hv_row.created_at if hv_row is not None else None,
+                },
             }
 
     async def get_progress(self, id: uuid.UUID) -> GoalProgressResponse:

--- a/backend/app/routers/glance.py
+++ b/backend/app/routers/glance.py
@@ -44,6 +44,7 @@ from app.dependencies.auth import AuthContext, get_current_user, get_verified_or
 from app.dependencies.database import get_db
 from app.models.dependency import ItemDependency
 from app.models.evidence import Evidence
+from app.models.gate import AUTO_VERIFY_MAP as _GATE_AUTO_VERIFY_MAP
 from app.models.gate import Gate
 from app.models.member import Member
 from app.models.pm import Story, StoryActivity
@@ -281,7 +282,10 @@ async def glance_attention(
 # ac_met/ac_total(acceptance_criteria=freeform Text)·risk(플랫폼 위험도판정 안 함)·diff(미저장).
 # PO判定(2026-07-12): BE는 구조화 필드만·표시문자열/라벨 금지(i18n=FE lane)·라벨 합성은 FE가
 # decision_basis/auto_decision_reason verbatim으로.
-_AUTO_VERIFY_MAP = {"sufficient": "passed", "blocked": "failed"}
+# story #2303: 이 매핑의 단일 소유자는 app/models/gate.py(AUTO_VERIFY_MAP)로 옮겼다 —
+# app/repositories/goal.py(`?include=glance`의 focal_story.auto_verify)도 같은 매핑이
+# 필요해져, 라우터 전용 상수를 두 곳에 각자 두면 twin-system 갭이 된다.
+_AUTO_VERIFY_MAP = _GATE_AUTO_VERIFY_MAP
 
 
 class HeroMember(BaseModel):

--- a/backend/app/schemas/goal.py
+++ b/backend/app/schemas/goal.py
@@ -104,23 +104,58 @@ class GoalResponse(BaseModel):
         return build_reference_token("epic", self.id, self.title)
 
 
+class GlanceFocalStoryGate(BaseModel):
+    """story #2303 — `synthesizeGateAction`(FE, `glance-hero.tsx` 밖의 다른 파일 — 단일
+    파일 grep만으론 놓치는 자리, 미르코 실측)이 읽는 딱 둘. `gate.status`("pending")는 안
+    싣는다 — `gate`가 non-null인 것 자체가 이미 "pending 게이트가 있다"는 뜻이라 중복."""
+    gate_type: str
+    requires_human: bool
+
+
+class GlanceFocalStoryVerifiedBy(BaseModel):
+    """story #2303 — `name`만. member 서브객체(`member_id`/`role`)는 화면이 안 읽어서 뺀다."""
+    name: str
+
+
+class GlanceFocalStoryTrust(BaseModel):
+    self_reported: bool
+    human_verified: bool
+    human_verified_by: GlanceFocalStoryVerifiedBy | None = None
+    human_verified_at: datetime | None = None
+
+
 class GlanceFocalStory(BaseModel):
     """story #2298(3단 웨이터폴 근절) — `pickFocalStory`(FE `hero-logic.ts`) 규칙을 서버로
-    이관한 결과. gate_status는 in-progress 후보들 중 하나라도 pending gate가 있으면 그
-    story가 우선 선택되고("gate-우선"), 이 필드엔 그 pending 게이트가 있었는지만 담는다
-    (전체 gate 목록은 안 실음 — 이 필드가 실제로 쓰이는 axis 하나뿐이라 과확장 금지).
+    이관한 결과.
 
     ⛔이 규칙은 FE 원본에도 있었지만 `/api/stories?epic_id=` 응답에 `gates` 필드 자체가
     없어(전 코드베이스 grep 확인, `StoryResponse`에 그 필드 없음) 실제로는 단 한 번도
     평가된 적이 없다(2026-07-12 story dee92c96 도입 이래 죽어있던 분기 — git log -S로 확인,
     "언제부터 회귀했는지"가 아니라 "애초에 재료가 없었다"). 여기서 되살리면 동작이 바뀐다 —
     지금까지는 항상 in-progress 중 첫 번째였고, 이제부터 gate-pending이 우선한다. 조용히
-    바꾸지 않는다(PR 본문에 명시)."""
+    바꾸지 않는다(PR 본문에 명시).
+
+    ⛔story #2303(계약 확장, 오르테가+미르코 판정 2026-07-29): #2298이 처음 냈던 4필드
+    (id·title·status·assignee_id·gate_status)로 `/api/glance/hero?story_id=`를 완전히
+    대체하려 했더니 **화면이 실제로 읽는 것 중 둘이 빠져 있었다**(assignee_ids 배열 —
+    없으면 다중배정 story의 human+agent 동시표시가 항상 단일로 좁혀짐·gate.requires_human —
+    gate_status로 근사 불가, 미르코 확인). 판정 기준이 "요청 수 감소"가 아니라 "화면이
+    그리는 것 중 하나도 안 줄어드는가 + 요청이 주는가"로 재확정되며, 미르코가
+    `glance-hero.tsx` + 호출체인(`splitParticipants`·`heroProofState`·`buildEvidence`·
+    `buildTrustSeal`·`synthesizeGateAction`)을 끝까지 추적해 뽑은 9필드만 정확히 싣는다.
+    `description`·`envelope.*`·`gate.status`·`gate.decision_basis`·`gate.
+    auto_decision_reason`·`human_verified_by.member_id`·`human_verified_by.role`·
+    `gates`(전체배열)는 화면이 안 읽는 것으로 확인돼 의도적으로 뺀다("있는 만큼만 단다").
+    합성(i18n 라벨 등)은 서버가 하지 않는다 — 원자료만 싣고 조립은 화면이 한다(AC4)."""
     id: uuid.UUID
     title: str
     status: str
     assignee_id: uuid.UUID | None
-    gate_status: str | None
+    assignee_ids: list[uuid.UUID] = []
+    proof_count: int
+    auto_verify: str | None = None
+    gate: GlanceFocalStoryGate | None = None
+    trust: GlanceFocalStoryTrust
 
 
 class GoalWithGlanceResponse(GoalResponse):

--- a/backend/tests/test_2298_goals_glance_include_realdb.py
+++ b/backend/tests/test_2298_goals_glance_include_realdb.py
@@ -277,7 +277,8 @@ async def test_focal_story_prefers_gate_pending_over_more_recently_created():
             focal = resp.json()[0]["focal_story"]
             assert focal is not None
             assert focal["id"] == str(older_gated.id), focal
-            assert focal["gate_status"] == "pending"
+            # story #2303: gate_status(str) → gate(object|None). non-null 자체가 "pending 있음".
+            assert focal["gate"] == {"gate_type": "human_review", "requires_human": False}, focal
         finally:
             await client.aclose()
     finally:
@@ -313,7 +314,7 @@ async def test_focal_story_falls_back_to_most_recent_in_progress_when_no_gate_pe
             focal = resp.json()[0]["focal_story"]
             assert focal is not None
             assert focal["id"] == str(newer.id), focal
-            assert focal["gate_status"] is None
+            assert focal["gate"] is None  # story #2303: gate_status(str) → gate(object|None)
         finally:
             await client.aclose()
     finally:

--- a/backend/tests/test_2303_goals_glance_focal_story_fields_realdb.py
+++ b/backend/tests/test_2303_goals_glance_focal_story_fields_realdb.py
@@ -406,3 +406,106 @@ async def test_focal_story_excludes_fields_the_screen_does_not_read():
         }, focal
     finally:
         await engine.dispose()
+
+
+# ─── 오르테가 리뷰(2026-07-29, PR #2602) — 「반만 고친」 지적 ──────────────────
+#
+# _AUTO_VERIFY_MAP은 단일 소유자로 옮겼지만, proof_count/human_verified/self_reported의
+# «쿼리 조건»은 hero(routers/glance.py 단건)와 goal.py(배치)가 각자 다시 쓴 것 — 지금은
+# 같은 값을 내지만 규칙이 두 자리에 산다(상수보다 위험 — 조건이 조용히 갈릴 수 있다).
+# 배치 vs 단건이라 함수 공유가 억지가 될 수 있어, 처방은 "같은 story_id에 대해 두 경로가
+# 같은 값을 내는지" 값 동일성으로 대조하는 realdb 테스트 — AC3의 진짜 형태.
+
+
+async def _fetch_hero(app, Session, caller_user_id, org_id, story_id):
+    await _setup_app_human(app, Session, caller_user_id, org_id)
+    client = _client_for(app)
+    try:
+        resp = await client.get("/api/v2/glance/hero", params={"story_id": str(story_id)})
+        assert resp.status_code == 200, resp.text
+        return resp.json()
+    finally:
+        await client.aclose()
+        app.dependency_overrides.clear()
+
+
+async def test_focal_story_values_match_glance_hero_for_same_story_rich_case():
+    """같은 story_id — hero(단건)와 focal_story(배치)가 값 하나하나 같아야 한다(존재
+    여부가 아니라 값 동일성). rich 케이스: evidence 다건 + human_verified + merge gate +
+    pending gate 전부 갖춘 story."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            verifier_id, _ = await _make_human_member(s, org.id, project.id, name="Verifier")
+            goal = await _make_goal(s, org.id, project.id)
+            story = await _make_story(
+                s, org.id, project.id, goal.id, assignee_id=caller_id,
+                status="in-progress", title="Rich",
+            )
+            await _make_evidence(s, org.id, story.id, created_by=caller_id, type="url", ref="https://a")
+            await _make_evidence(s, org.id, story.id, created_by=caller_id, type="pr", ref="https://b")
+            await _make_evidence(
+                s, org.id, story.id, created_by=verifier_id, type="gate_approval", ref="approved",
+            )
+            await _make_gate(
+                s, org.id, story.id, status="pending", gate_type="human_review",
+                requires_human=True,
+            )
+            await _make_gate(
+                s, org.id, story.id, status="approved", gate_type="merge",
+                evidence_status="sufficient",
+            )
+
+        hero = await _fetch_hero(app, Session, caller_user_id, org.id, story.id)
+        focal = await _fetch_focal(app, Session, caller_user_id, org.id, project.id)
+        assert focal is not None
+        assert focal["id"] == str(story.id), focal
+
+        # proof_count는 evidence type을 안 가린다(hero·goal.py 둘 다 work_item_type만 필터) —
+        # url·pr·gate_approval 3건 전부 세어져야 한다.
+        assert focal["proof_count"] == hero["proof_count"] == 3, (focal, hero)
+        assert focal["auto_verify"] == hero["auto_verify"] == "passed", (focal, hero)
+        assert focal["trust"]["self_reported"] == hero["trust"]["self_reported"] is True
+        assert focal["trust"]["human_verified"] == hero["trust"]["human_verified"] is True
+        assert focal["trust"]["human_verified_at"] == hero["trust"]["human_verified_at"], (focal, hero)
+        assert focal["trust"]["human_verified_by"]["name"] == hero["trust"]["human_verified_by"]["name"]
+        assert focal["gate"]["gate_type"] == hero["gate"]["gate_type"] == "human_review"
+        assert focal["gate"]["requires_human"] == hero["gate"]["requires_human"] is True
+    finally:
+        await engine.dispose()
+
+
+async def test_focal_story_values_match_glance_hero_for_same_story_empty_case():
+    """빈 케이스 — evidence·gate 전부 없는 story도 두 경로가 같은 "없음"을 낸다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id)
+            story = await _make_story(
+                s, org.id, project.id, goal.id, assignee_id=caller_id,
+                status="in-progress", title="Empty",
+            )
+
+        hero = await _fetch_hero(app, Session, caller_user_id, org.id, story.id)
+        focal = await _fetch_focal(app, Session, caller_user_id, org.id, project.id)
+        assert focal is not None
+
+        assert focal["proof_count"] == hero["proof_count"] == 0
+        assert focal["auto_verify"] == hero["auto_verify"] is None
+        assert focal["trust"]["self_reported"] == hero["trust"]["self_reported"] is False
+        assert focal["trust"]["human_verified"] == hero["trust"]["human_verified"] is False
+        assert focal["trust"]["human_verified_at"] == hero["trust"]["human_verified_at"] is None
+        assert focal["trust"]["human_verified_by"] == hero["trust"]["human_verified_by"] is None
+        assert focal["gate"] == hero["gate"] is None
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2303_goals_glance_focal_story_fields_realdb.py
+++ b/backend/tests/test_2303_goals_glance_focal_story_fields_realdb.py
@@ -1,0 +1,408 @@
+"""story #2303(E-POLISH, 오르테가+미르코 판정 2026-07-29, 스레드 7256d5cc) —
+`GET /api/v2/goals?include=glance`의 `focal_story` 9필드 확장 실PG 검증.
+
+#2298이 처음 낸 4필드(id·title·status·assignee_id·gate_status)로 `/api/glance/hero?
+story_id=`를 대체하려 했더니 화면이 실제로 읽는 것 중 둘(assignee_ids·gate.requires_human)이
+빠져 있었다 — 미르코가 `glance-hero.tsx` + 호출체인(splitParticipants·heroProofState·
+buildEvidence·buildTrustSeal·synthesizeGateAction)을 끝까지 추적해 뽑은 9필드:
+  assignee_ids · proof_count · auto_verify · gate.gate_type · gate.requires_human ·
+  trust.self_reported · trust.human_verified · trust.human_verified_by.name ·
+  trust.human_verified_at
+판정 기준: 화면이 그리는 것 중 하나도 안 줄어드는가(AC3) + 서버가 합성하지 않는가(AC4,
+원자료만 싣고 조립은 화면이 한다) + «있는 만큼만 단다»(넣지 않는 것 10건은 실제로 없어야 함).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _make_org(session, name="Org"):
+    from app.models.organization import Organization
+    org = Organization(id=uuid.uuid4(), name=name, slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    return org
+
+
+async def _make_project(session, org_id, name="P"):
+    from app.models.project import Project
+    project = Project(id=uuid.uuid4(), org_id=org_id, name=name)
+    session.add(project)
+    await session.commit()
+    return project
+
+
+async def _make_human_member(session, org_id, project_id, name="Human"):
+    from app.models.user import User
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.member import Member
+
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="member")
+    session.add(om)
+    await session.flush()
+    m = Member(id=om.id, org_id=org_id, type="human", user_id=user.id, name=name)
+    session.add(m)
+    await session.flush()
+    session.add(ProjectAccess(project_id=project_id, org_member_id=om.id, member_id=m.id, role="member"))
+    await session.commit()
+    return m.id, user.id
+
+
+async def _make_goal(session, org_id, project_id, title="Goal"):
+    from app.models.pm import Goal
+    goal = Goal(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status="active")
+    session.add(goal)
+    await session.commit()
+    return goal
+
+
+async def _make_story(session, org_id, project_id, epic_id, assignee_id=None, status="backlog", title="Story"):
+    from app.models.pm import Story
+    story = Story(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, epic_id=epic_id,
+        title=title, status=status, assignee_id=assignee_id,
+    )
+    session.add(story)
+    await session.commit()
+    return story
+
+
+async def _make_gate(
+    session, org_id, story_id, status="pending", gate_type="human_review",
+    requires_human=False, evidence_status=None,
+):
+    from app.models.gate import Gate
+    gate = Gate(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=story_id, work_item_type="story",
+        gate_type=gate_type, status=status, requires_human=requires_human,
+        evidence_status=evidence_status,
+    )
+    session.add(gate)
+    await session.commit()
+    return gate
+
+
+async def _make_evidence(session, org_id, story_id, created_by, type="url", ref="https://x"):
+    from app.models.evidence import Evidence
+    evidence = Evidence(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=story_id, work_item_type="story",
+        type=type, ref=ref, created_by=created_by,
+    )
+    session.add(evidence)
+    await session.commit()
+    return evidence
+
+
+async def _make_story_assignee(session, org_id, story_id, member_id):
+    from app.models.story_assignee import StoryAssignee
+    sa = StoryAssignee(id=uuid.uuid4(), org_id=org_id, story_id=story_id, member_id=member_id)
+    session.add(sa)
+    await session.commit()
+    return sa
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+async def _fetch_focal(app, Session, caller_user_id, org_id, project_id):
+    await _setup_app_human(app, Session, caller_user_id, org_id)
+    client = _client_for(app)
+    try:
+        resp = await client.get(
+            "/api/v2/goals", params={"project_id": str(project_id), "include": "glance"},
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.json()[0]["focal_story"]
+    finally:
+        await client.aclose()
+        app.dependency_overrides.clear()
+
+
+# ─── 9필드 전부 재료 없을 때 안전 기본값(크래시 없이 null/0/false/빈배열) ──────────
+
+
+async def test_focal_story_defaults_when_no_evidence_no_gate_no_extra_assignees():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id)
+            await _make_story(
+                s, org.id, project.id, goal.id, assignee_id=caller_id,
+                status="in-progress", title="Bare",
+            )
+
+        focal = await _fetch_focal(app, Session, caller_user_id, org.id, project.id)
+        assert focal is not None
+        assert focal["assignee_ids"] == []
+        assert focal["proof_count"] == 0
+        assert focal["auto_verify"] is None
+        assert focal["gate"] is None
+        assert focal["trust"] == {
+            "self_reported": False, "human_verified": False,
+            "human_verified_by": None, "human_verified_at": None,
+        }
+    finally:
+        await engine.dispose()
+
+
+# ─── assignee_ids — 다중배정, StoryAssignee join ────────────────────────────
+
+
+async def test_focal_story_assignee_ids_reflects_all_story_assignees():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id, name="Caller")
+            second_id, _ = await _make_human_member(s, org.id, project.id, name="Second")
+            goal = await _make_goal(s, org.id, project.id)
+            story = await _make_story(
+                s, org.id, project.id, goal.id, assignee_id=caller_id,
+                status="in-progress", title="Multi-assigned",
+            )
+            await _make_story_assignee(s, org.id, story.id, caller_id)
+            await _make_story_assignee(s, org.id, story.id, second_id)
+
+        focal = await _fetch_focal(app, Session, caller_user_id, org.id, project.id)
+        assert focal is not None
+        assert set(focal["assignee_ids"]) == {str(caller_id), str(second_id)}, focal
+    finally:
+        await engine.dispose()
+
+
+# ─── proof_count / trust.self_reported — Evidence row 개수 ──────────────────
+
+
+async def test_focal_story_proof_count_and_self_reported_from_evidence_rows():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id)
+            story = await _make_story(
+                s, org.id, project.id, goal.id, assignee_id=caller_id,
+                status="in-progress", title="Proven",
+            )
+            await _make_evidence(s, org.id, story.id, created_by=caller_id, type="url", ref="https://a")
+            await _make_evidence(s, org.id, story.id, created_by=caller_id, type="pr", ref="https://b")
+
+        focal = await _fetch_focal(app, Session, caller_user_id, org.id, project.id)
+        assert focal is not None
+        assert focal["proof_count"] == 2, focal
+        assert focal["trust"]["self_reported"] is True
+    finally:
+        await engine.dispose()
+
+
+# ─── auto_verify — merge gate evidence_status → AUTO_VERIFY_MAP 매핑 ────────
+
+
+@pytest.mark.parametrize(
+    "evidence_status,expected",
+    [("sufficient", "passed"), ("blocked", "failed")],
+)
+async def test_focal_story_auto_verify_maps_merge_gate_evidence_status(evidence_status, expected):
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id)
+            story = await _make_story(
+                s, org.id, project.id, goal.id, assignee_id=caller_id,
+                status="in-progress", title="Merge-evaluated",
+            )
+            # merge gate 자체는 status="approved"(resolved) — pending 아니어도 auto_verify는
+            # evidence_status 원자료 그대로다(gate 필드=pending 전용, auto_verify=merge 전용, 별축).
+            await _make_gate(
+                s, org.id, story.id, status="approved", gate_type="merge",
+                evidence_status=evidence_status,
+            )
+
+        focal = await _fetch_focal(app, Session, caller_user_id, org.id, project.id)
+        assert focal is not None
+        assert focal["auto_verify"] == expected, focal
+    finally:
+        await engine.dispose()
+
+
+# ─── gate — pending gate의 gate_type/requires_human(status는 안 싣는다) ─────
+
+
+async def test_focal_story_gate_carries_type_and_requires_human_not_status():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id)
+            story = await _make_story(
+                s, org.id, project.id, goal.id, assignee_id=caller_id,
+                status="in-progress", title="Gated",
+            )
+            await _make_gate(
+                s, org.id, story.id, status="pending", gate_type="merge",
+                requires_human=True,
+            )
+
+        focal = await _fetch_focal(app, Session, caller_user_id, org.id, project.id)
+        assert focal is not None
+        assert focal["gate"] == {"gate_type": "merge", "requires_human": True}, focal
+        assert "status" not in focal["gate"], focal  # AC4: gate.status는 중복이라 안 싣는다
+    finally:
+        await engine.dispose()
+
+
+# ─── trust.human_verified* — 최신 gate_approval Evidence, name만 ────────────
+
+
+async def test_focal_story_human_verified_by_resolves_name_from_latest_gate_approval():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id, name="Caller")
+            verifier_id, _ = await _make_human_member(s, org.id, project.id, name="Verifier Name")
+            goal = await _make_goal(s, org.id, project.id)
+            story = await _make_story(
+                s, org.id, project.id, goal.id, assignee_id=caller_id,
+                status="in-progress", title="Verified",
+            )
+            await _make_evidence(
+                s, org.id, story.id, created_by=verifier_id, type="gate_approval", ref="approved",
+            )
+
+        focal = await _fetch_focal(app, Session, caller_user_id, org.id, project.id)
+        assert focal is not None
+        assert focal["trust"]["human_verified"] is True
+        assert focal["trust"]["human_verified_by"] == {"name": "Verifier Name"}, focal
+        assert focal["trust"]["human_verified_at"] is not None
+        # AC4: member_id/role은 화면이 안 읽어서 뺀다 — name만.
+        assert set(focal["trust"]["human_verified_by"].keys()) == {"name"}
+    finally:
+        await engine.dispose()
+
+
+# ─── AC4 — 있는 만큼만 단다: 뺀 필드가 실제로 없어야 한다 ────────────────────
+
+
+async def test_focal_story_excludes_fields_the_screen_does_not_read():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id)
+            story = await _make_story(
+                s, org.id, project.id, goal.id, assignee_id=caller_id,
+                status="in-progress", title="Lean",
+            )
+            await _make_gate(
+                s, org.id, story.id, status="pending", gate_type="human_review",
+                requires_human=True,
+            )
+            await _make_evidence(
+                s, org.id, story.id, created_by=caller_id, type="gate_approval", ref="approved",
+            )
+
+        focal = await _fetch_focal(app, Session, caller_user_id, org.id, project.id)
+        assert focal is not None
+        assert set(focal.keys()) == {
+            "id", "title", "status", "assignee_id", "assignee_ids", "proof_count",
+            "auto_verify", "gate", "trust",
+        }, focal
+        assert set(focal["gate"].keys()) == {"gate_type", "requires_human"}, focal
+        assert set(focal["trust"].keys()) == {
+            "self_reported", "human_verified", "human_verified_by", "human_verified_at",
+        }, focal
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- story #2303(E-POLISH): `GET /api/v2/goals?include=glance`의 `focal_story`를 #2298의 4필드(id·title·status·assignee_id·gate_status)에서 hero 화면이 실제로 읽는 9필드(assignee_ids·proof_count·auto_verify·gate.gate_type·gate.requires_human·trust.self_reported·trust.human_verified·trust.human_verified_by.name·trust.human_verified_at)로 확장 — `/api/glance/hero?story_id=` 왕복을 이 한 왕복이 실제로 대체할 수 있게.
- 판정 기준: 미르코가 `glance-hero.tsx` + 호출체인(splitParticipants·heroProofState·buildEvidence·buildTrustSeal·synthesizeGateAction)을 끝까지 추적해 화면이 읽는 것 중 하나도 안 줄어드는지 확인 — 넣지 않는 것(description·envelope.*·gate.status·gate.decision_basis/auto_decision_reason·human_verified_by.member_id/role·gates 전체배열)은 "있는 만큼만 단다" 원칙으로 의도적으로 뺐다.

## ⚠️ 계약 변경
`focal_story.gate_status`(str|None) → `focal_story.gate`(object|None: `gate_type`·`requires_human`)로 교체. `gate`가 non-null인 것 자체가 "pending 게이트가 있다"는 뜻이라 status를 별도로 싣지 않는다. #2298의 기존 realdb 테스트를 이 계약에 맞춰 갱신했다.

## twin-system 회피
`_AUTO_VERIFY_MAP`이 `app/routers/glance.py` 전용 상수였는데 `app/repositories/goal.py`도 같은 매핑이 필요해져, `app/models/gate.py`에 공개 `AUTO_VERIFY_MAP`으로 단일 소유자를 옮기고 양쪽이 import하도록 배선했다.

## 검증
- realdb 신규 9필드 테스트(`tests/test_2303_goals_glance_focal_story_fields_realdb.py`) — assignee_ids 다중배정·proof_count/self_reported·auto_verify(sufficient→passed/blocked→failed) 매핑·gate 필드(status 미포함 확인)·human_verified_by name 해소·재료 0건 시 안전 기본값·AC4 필드셋 검증. 실PG(alembic head) GREEN.
- assignee_ids 배치쿼리·gate 필드 조립·human_verified_by 이름 해소 3곳 독립 RED→GREEN self-check(각각 강제 실패→대응 테스트 낙제 확인→복구, `git status --short` 무변경 확인).
- 전체 회귀 스윕 `-k "not realdb"` 4212 passed + goals/glance/mention 인접 realdb 15파일 156 passed(alembic head 기준). 실패 7건 전부 기존 미관련 베이스라인 확인(MCP 도구 수 하드코딩 드리프트 1건 포함).

## Test plan
- [x] realdb 9필드 테스트 GREEN
- [x] #2298 기존 realdb 테스트 gate 계약 갱신 후 GREEN
- [x] RED→GREEN self-check 3곳
- [x] 전체 회귀 스윕 무관련 확인
- [ ] CI 확인 대기

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>