### PR TITLE
feat(infra): 서비스명 부분집합 wellformed 가드 신설 — 오타 유령이 조용히 들어오던 구멍 (#2305)

### DIFF
--- a/backend/tests/test_check_env_drift_service_subset_axis.py
+++ b/backend/tests/test_check_env_drift_service_subset_axis.py
@@ -1,0 +1,169 @@
+"""story #2305 — infra/check_env_drift.py 축⑥ "서비스명 부분집합 wellformed" 회귀가드.
+
+배경(doc `duplicate-registry-census-20260728` #9·#10, 원 판정 철회됨): "4곳이 같은 목록이라
+일치해야 한다"는 틀린 전제였다 — `_SETTINGS_CONSUMING_SERVICES`·`_SERVICE_DRY_RUN_MAP`·
+`_WEB_CODE_SERVICES`는 각자 다른 목적의 **의도적 부분집합**이다. 진짜 구멍은 그 부분집합들이
+마스터(`_SERVICE_SCRIPT_MAP`)의 실제 부분집합인지 재는 자가 0건이었다는 것.
+
+gcloud 라이브 접근 없이(순수 정적 로직) 실행 가능 — live_services 루프 밖에서 계산된다.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_INFRA_DIR = _REPO_ROOT / "infra"
+
+
+def _load_check_env_drift():
+    spec = importlib.util.spec_from_file_location(
+        "check_env_drift", _INFRA_DIR / "check_env_drift.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ── AC1: 마스터 확定 ────────────────────────────────────────────────────────────
+
+def test_service_script_map_is_declared_master_of_seven():
+    """`_SERVICE_SCRIPT_MAP`이 7개 실서비스를 담은 마스터다 — 이 카운트가 바뀌면(신규 서비스
+    추가/삭제) 알아야 하므로 명시 고정."""
+    mod = _load_check_env_drift()
+    assert set(mod._SERVICE_SCRIPT_MAP) == {
+        "sprintable-backend-dev", "sprintable-backend-prod",
+        "sprintable-frontend-dev", "sprintable-frontend-prod",
+        "sprintable-mcp-dev", "sprintable-mcp-prod",
+        "sprintable-realtime-dev",
+    }
+
+
+def test_realtime_prod_is_not_a_real_service_yet():
+    """AC1 근거 — "sprintable-realtime-prod"는 cloudbuild.yaml에 주석으로만 존재하고 마스터엔
+    없다(deploy-realtime 스텝이 prod에서 아직 스킵 중). 마스터에 없는 것이 맞다."""
+    mod = _load_check_env_drift()
+    assert "sprintable-realtime-prod" not in mod._SERVICE_SCRIPT_MAP
+
+
+# ── AC2: 부분집합 wellformed(한 방향만) ─────────────────────────────────────────
+
+def test_repo_current_subsets_are_wellformed():
+    """리포에 실제로 커밋된 세 부분집합 전부 마스터의 진짜 부분집합이다 — 지금 위반 0건."""
+    mod = _load_check_env_drift()
+    assert mod._service_subset_wellformed_violations() == []
+
+
+def test_subset_check_is_one_directional_master_superset_is_fine():
+    """⛔양방향(집합 동일)으로 재면 안 된다 — 마스터가 부분집합보다 «큰» 것(예: mcp-dev/prod가
+    세 부분집합 어디에도 없는 것)은 정상이라 잡지 않는다."""
+    mod = _load_check_env_drift()
+    for name in ("sprintable-mcp-dev", "sprintable-mcp-prod"):
+        assert name in mod._SERVICE_SCRIPT_MAP
+        assert name not in mod._SETTINGS_CONSUMING_SERVICES
+        assert name not in mod._SERVICE_DRY_RUN_MAP
+        assert name not in mod._WEB_CODE_SERVICES
+    # 위 비대칭이 있어도 wellformed 위반은 0건이어야 한다(마스터 초과분은 허용).
+    assert mod._service_subset_wellformed_violations() == []
+
+
+# ── AC4: 양성대조 — 뮤테이션으로 방법이 실제로 잡는지 증명 ──────────────────────────
+
+def test_positive_control_ghost_in_settings_consuming_is_caught(monkeypatch):
+    mod = _load_check_env_drift()
+    monkeypatch.setattr(
+        mod, "_SETTINGS_CONSUMING_SERVICES",
+        mod._SETTINGS_CONSUMING_SERVICES | {"sprintable-backend-typo-xyz"},
+    )
+    violations = mod._service_subset_wellformed_violations()
+    assert any("sprintable-backend-typo-xyz" in v for v in violations)
+    assert any("_SETTINGS_CONSUMING_SERVICES" in v for v in violations)
+
+
+def test_positive_control_ghost_in_dry_run_map_is_caught(monkeypatch):
+    mod = _load_check_env_drift()
+    monkeypatch.setattr(
+        mod, "_SERVICE_DRY_RUN_MAP",
+        {**mod._SERVICE_DRY_RUN_MAP, "sprintable-frontend-typo-xyz": ("x.sh", "dev")},
+    )
+    violations = mod._service_subset_wellformed_violations()
+    assert any("sprintable-frontend-typo-xyz" in v for v in violations)
+
+
+def test_positive_control_ghost_in_web_code_services_is_caught(monkeypatch):
+    mod = _load_check_env_drift()
+    monkeypatch.setattr(
+        mod, "_WEB_CODE_SERVICES", mod._WEB_CODE_SERVICES | {"sprintable-web-typo-xyz"},
+    )
+    violations = mod._service_subset_wellformed_violations()
+    assert any("sprintable-web-typo-xyz" in v for v in violations)
+
+
+# ── AC3+AC4: 외부 IaC 대조 + 주석-오탐 방지 ──────────────────────────────────────
+
+def test_external_iac_literals_match_master_exactly_today():
+    """cloudbuild.yaml·.github/workflows/*.yml·deploy_*.sh에 실선언된 서비스명 전량이 오늘
+    정확히 마스터 7개와 같다(realtime-prod는 주석에만 있으므로 여기 안 잡혀야 한다)."""
+    mod = _load_check_env_drift()
+    external = mod._external_iac_service_literals()
+    assert external == set(mod._SERVICE_SCRIPT_MAP)
+    assert "sprintable-realtime-prod" not in external
+
+
+def test_comment_only_service_name_is_not_a_real_declaration():
+    """⛔grep이 주석 문장을 실선언으로 오탐하던 병(#10 census 항목 원인)을 정확히 재현해
+    막는지 확認 — 주석 줄만 있는 파일에서 이름을 «안» 뽑아야 한다."""
+    mod = _load_check_env_drift()
+    comment_only = "# sprintable-ghost-dev가 아직 없다(계획 단계, PO 검증 전)\n"
+    assert mod._SERVICE_NAME_RE.findall(mod._strip_comment(comment_only)) == []
+    # 대조: 같은 텍스트에서 주석을 안 벗기면 오탐한다는 것도 같이 보인다(양성대조).
+    assert mod._SERVICE_NAME_RE.findall(comment_only) == ["sprintable-ghost-dev"]
+
+
+def test_external_iac_wellformed_positive_control(tmp_path, monkeypatch):
+    """실제 리포 파일 대신 임시 디렉터리에 유령 서비스명을 심어 위반이 잡히는지 증명 —
+    리포 원본은 건드리지 않는다."""
+    mod = _load_check_env_drift()
+    fake_root = tmp_path
+    (fake_root / ".github" / "workflows").mkdir(parents=True)
+    (fake_root / "backend" / "scripts").mkdir(parents=True)
+    (fake_root / "cloudbuild.yaml").write_text(
+        "steps:\n  - name: sprintable-backend-dev\n  - name: sprintable-typo-prod\n"
+    )
+    monkeypatch.setattr(mod, "_REPO_ROOT", fake_root)
+    external = mod._external_iac_service_literals()
+    assert external == {"sprintable-backend-dev", "sprintable-typo-prod"}
+    violations = mod._external_iac_wellformed_violations()
+    assert any("sprintable-typo-prod" in v for v in violations)
+
+
+# ── AC5: 재료를 못 찾으면 실패(skip 금지) ───────────────────────────────────────
+
+def test_external_iac_scan_raises_when_target_file_missing(tmp_path, monkeypatch):
+    """대상 파일(cloudbuild.yaml 등)이 없으면 조용히 빈 집합을 돌려주지 않고 즉시 실패한다."""
+    mod = _load_check_env_drift()
+    empty_root = tmp_path  # cloudbuild.yaml도 workflows/도 scripts/도 없는 빈 디렉터리
+    monkeypatch.setattr(mod, "_REPO_ROOT", empty_root)
+    import pytest
+
+    with pytest.raises(RuntimeError, match="스캔 대상 파일을 못 찾음"):
+        mod._external_iac_service_literals()
+
+
+def test_find_repo_root_raises_without_git_marker(tmp_path):
+    """`_find_repo_root`가 `.git` 표식 없는 경로에서 조용히 엉뚱한 조상 디렉터리를 반환하지
+    않고 실패하는지 — '../' 개수 세기 방식이 아니라 표식 탐색 방식임을 직접 증명."""
+    mod = _load_check_env_drift()
+    import pytest
+
+    isolated = tmp_path / "no" / "git" / "here"
+    isolated.mkdir(parents=True)
+    with pytest.raises(RuntimeError, match="repo root"):
+        mod._find_repo_root(isolated)
+
+
+def test_find_repo_root_finds_actual_repo_root():
+    mod = _load_check_env_drift()
+    root = mod._find_repo_root(_INFRA_DIR)
+    assert (root / ".git").exists()
+    assert (root / "cloudbuild.yaml").exists()

--- a/infra/check_env_drift.py
+++ b/infra/check_env_drift.py
@@ -57,7 +57,22 @@ import subprocess
 import sys
 from pathlib import Path
 
-_REPO_ROOT = Path(__file__).resolve().parent.parent
+def _find_repo_root(start: Path) -> Path:
+    """story #2305 AC5 — '../' 개수를 세지 않고 표식 디렉터리(.git)를 찾아 올라간다.
+    이 파일이 옮겨져도(디렉터리 깊이가 바뀌어도) 조용히 엉뚱한 경로를 안 가리킨다.
+    ⛔못 찾으면 조용히 넘기지 않고 즉시 실패한다(재료를 못 찾은 가드가 skip으로 통과하면
+    안 된다는 원칙 — 2026-07-28 #2600 실사고 교훈)."""
+    cur = start.resolve()
+    for _ in range(20):
+        if (cur / ".git").exists():
+            return cur
+        if cur.parent == cur:
+            break
+        cur = cur.parent
+    raise RuntimeError(f"repo root(.git 표식)를 {start} 위로 못 찾음 — 잘못된 위치에서 실행됐을 가능성")
+
+
+_REPO_ROOT = _find_repo_root(Path(__file__).resolve().parent)
 _REGION = "asia-northeast3"
 _ALLOWLIST_PATH = _REPO_ROOT / "infra" / "manual-env-allowlist.yml"
 
@@ -104,6 +119,13 @@ def _load_settings_exempt() -> dict[str, str]:
 # 전 서비스 공통으로 파싱해 합집합에 넣는다(어느 스텝이 어느 서비스를 겨냥하는지까지 세밀하게
 # 가르지 않음 — v1은 "이 repo의 IaC 전체에 이 키가 한 번이라도 선언된 적 있는가"로 판정).
 # 여기 없는 서비스가 gcloud 열거에 나타나면 FAIL로 잡는다(매핑 자체가 최신인지 강제).
+#
+# ⭐story #2305 — 이 dict의 key 집합(7개)이 서비스명의 **SSOT(마스터)**다. AC1 확定 근거:
+# `sprintable-realtime-prod`는 cloudbuild.yaml에 실선언이 아니라 **주석 문장에만** 등장한다
+# (deploy-realtime 스텝이 prod에서 아직 스킵 중 — 2026-07-29 직접 확認, grep이 주석을 매칭한
+# 오탐이 아님을 실코드로 재확認). `_SETTINGS_CONSUMING_SERVICES`·`_SERVICE_DRY_RUN_MAP`·
+# `_WEB_CODE_SERVICES`는 전부 이 마스터의 **부분집합**이어야 한다(서로 같을 필요는 없다 —
+# 각자 다른 목적의 의도적 서브셋). `_service_subset_wellformed_violations()`가 이걸 강제한다.
 _SERVICE_SCRIPT_MAP: dict[str, list[str]] = {
     "sprintable-backend-dev": ["backend/scripts/deploy_backend.sh"],
     "sprintable-backend-prod": ["backend/scripts/deploy_backend.sh"],
@@ -293,6 +315,78 @@ _WEB_ENV_IGNORE = {"NODE_ENV", "NEXT_RUNTIME"}
 _WEB_CODE_SERVICES = {"sprintable-frontend-dev", "sprintable-frontend-prod"}
 
 
+# ── ⑥ story #2305: 서비스명 부분집합 wellformed + 외부 IaC 대조 ────────────────────
+#
+# 배경(doc `duplicate-registry-census-20260728` #9·#10, 원 판정 철회됨): "4곳이 같은 목록이라
+# 일치해야 한다"는 애초에 틀린 전제였다 — 넷은 각자 다른 목적의 **의도적 부분집합**이다.
+# 진짜 구멍은 「그 부분집합들이 마스터(_SERVICE_SCRIPT_MAP)의 실제 부분집합인지 재는 자가
+# 0건」이었다 — 오타로 만든 유령 서비스명이 들어가도 아무도 못 잡는다.
+#
+# ⛔양방향(집합 동일)으로 재면 안 된다 — 의도적 부분집합이 거짓 불일치로 잡힌다. **한 방향만**
+# (subset - master == 공집합) 잰다.
+_SERVICE_NAME_RE = re.compile(r"sprintable-[a-z]+-(?:dev|prod)")
+
+
+def _service_subset_wellformed_violations() -> list[str]:
+    """`_SERVICE_SCRIPT_MAP`(마스터) 밖의 이름이 나머지 세 목록에 있으면 그 이름을 낸다.
+    한 방향만 잰다 — 마스터가 부분집합보다 큰 것(예: mcp-dev/prod가 이 셋 어디에도 없는 것)은
+    정상이라 잡지 않는다."""
+    master = set(_SERVICE_SCRIPT_MAP)
+    violations: list[str] = []
+    for label, subset in (
+        ("_SETTINGS_CONSUMING_SERVICES", _SETTINGS_CONSUMING_SERVICES),
+        ("_SERVICE_DRY_RUN_MAP", set(_SERVICE_DRY_RUN_MAP)),
+        ("_WEB_CODE_SERVICES", _WEB_CODE_SERVICES),
+    ):
+        for ghost in sorted(subset - master):
+            violations.append(
+                f"{label}: 마스터(_SERVICE_SCRIPT_MAP)에 없는 이름: {ghost!r} "
+                f"— 오타인가, 마스터에 추가할 것인가?"
+            )
+    return violations
+
+
+def _strip_comment(line: str) -> str:
+    """bash·YAML 둘 다 '#'가 주석 시작 — 이 저장소의 대상 파일들엔 문자열 리터럴 안에 '#'이
+    없음을 확認했다(2026-07-29). ⛔이걸 안 하면 "sprintable-realtime-prod가 없다"처럼 주석
+    문장 안의 서비스명을 실선언으로 오탐한다 — #10 census 항목이 정확히 이 오탐이었다."""
+    idx = line.find("#")
+    return line if idx == -1 else line[:idx]
+
+
+def _external_iac_service_literals() -> set[str]:
+    """cloudbuild.yaml·.github/workflows/*.yml·deploy_*.sh에서 실선언된(주석 아닌) 서비스명
+    리터럴을 정적으로 모은다. ⛔AC5 — 대상 파일이 하나라도 없으면 조용히 skip하지 않고
+    즉시 실패한다(재료를 못 찾은 가드가 "통과"로 읽히면 안 된다)."""
+    targets = [
+        _REPO_ROOT / "cloudbuild.yaml",
+        *sorted((_REPO_ROOT / ".github" / "workflows").glob("*.yml")),
+        *sorted((_REPO_ROOT / "backend" / "scripts").glob("deploy_*.sh")),
+    ]
+    missing = [str(p) for p in targets if not p.exists()]
+    if missing:
+        raise RuntimeError(
+            f"서비스명 스캔 대상 파일을 못 찾음(AC5 — skip 대신 실패): {missing}"
+        )
+    names: set[str] = set()
+    for path in targets:
+        for line in path.read_text().splitlines():
+            names |= set(_SERVICE_NAME_RE.findall(_strip_comment(line)))
+    return names
+
+
+def _external_iac_wellformed_violations() -> list[str]:
+    """외부 IaC(cloudbuild.yaml·workflows·deploy_*.sh)에 실선언된 서비스명이 마스터
+    (_SERVICE_SCRIPT_MAP)에 없으면 그 이름을 낸다 — 한 방향만."""
+    master = set(_SERVICE_SCRIPT_MAP)
+    external = _external_iac_service_literals()
+    return [
+        f"외부 IaC(cloudbuild.yaml/workflows/deploy_*.sh)에 있는데 마스터에 없는 이름: "
+        f"{ghost!r} — 오타인가, 마스터에 추가할 것인가?"
+        for ghost in sorted(external - master)
+    ]
+
+
 def _web_env_reads(src_dir: Path = _WEB_SRC_DIR) -> dict[str, list[tuple[str, str | None]]]:
     """반환: {key: [(file_relpath, default_literal_or_None), ...]}. 소스 «리터럴»만 읽는다
     (git에 이미 공개된 텍스트) — 라이브 env value는 이 함수가 존재를 몰라도 된다."""
@@ -434,6 +528,11 @@ def main() -> int:
     code_read_baseline = _load_code_read_high_baseline()
     today = _today()
 
+    # ⑥ story #2305 — 순수 정적 대조(라이브 서비스 열거 불필요), 루프 밖에서 한 번만.
+    service_subset_violations = (
+        _service_subset_wellformed_violations() + _external_iac_wellformed_violations()
+    )
+
     live_services = _list_live_services()
     key_set_failures: list[str] = []
     value_check_failures: list[str] = []
@@ -536,6 +635,7 @@ def main() -> int:
     has_fail = bool(
         key_set_failures or value_check_failures or secret_shape_failures
         or code_read_highest_failures or code_read_baseline_escalations
+        or service_subset_violations
     )
     has_report_only = bool(settings_coverage_report or code_read_report)
 
@@ -559,6 +659,13 @@ def main() -> int:
         if secret_shape_failures:
             print("  ③평문 시크릿 형태 검출(⛔ 값은 출력하지 않음 — 키 이름만):")
             for line in secret_shape_failures:
+                print(f"    - {line}")
+        if service_subset_violations:
+            print(
+                "  ⑥서비스명 부분집합 wellformed(story #2305) — 마스터(_SERVICE_SCRIPT_MAP)에\n"
+                "    없는 유령 이름이 부분집합 목록 또는 외부 IaC에 들어왔다:"
+            )
+            for line in service_subset_violations:
                 print(f"    - {line}")
         if code_read_highest_failures:
             print(
@@ -607,7 +714,9 @@ def main() -> int:
             "환경을 가리키는 채로 조용히 돈다). ⑤㉠ baseline 밖(신규/만료)은 (a) 값을 채우거나 "
             "(b) 정상이면 code_read_high_baseline에 reason/declared_by/until(최대30일)과 "
             "함께 등재하거나 (c) 영구 정상이면 code_read_exempt로 승격 — 셋 다 "
-            "infra/manual-env-allowlist.yml. ⑤㉢은 report-only(승격 대상 아님)."
+            "infra/manual-env-allowlist.yml. ⑤㉢은 report-only(승격 대상 아님). "
+            "⑥은 오타면 그 자리에서 고치고, 정말 새 서비스면 _SERVICE_SCRIPT_MAP(마스터)에 "
+            "먼저 추가한 뒤 필요한 부분집합에 편입."
         )
         if not has_fail:
             print("\n(⛔위는 report-only 항목뿐 — FAIL 아님. exit code는 0.)")
@@ -621,7 +730,9 @@ def main() -> int:
         f"③{len(live_services)}개 서비스 전체 평문시크릿 스캔 완료(제외 없음), "
         f"④{len(_SETTINGS_CONSUMING_SERVICES)}개 서비스 Settings 커버리지 대조 완료, "
         f"⑤{len(_WEB_CODE_SERVICES & set(live_services))}개 서비스 코드읽기↔공급 대조 완료"
-        f"(㉡최고위험 대조 포함)."
+        f"(㉡최고위험 대조 포함), "
+        f"⑥서비스명 부분집합 wellformed(마스터 {len(_SERVICE_SCRIPT_MAP)}개 기준) + "
+        f"외부 IaC 대조 완료."
     )
     return 0
 


### PR DESCRIPTION
## Summary
- doc `duplicate-registry-census-20260728` #9·#10 원 판정("4곳이 같은 목록이라 일치해야 한다")이 틀린 전제였음이 밝혀졌다 — `_SETTINGS_CONSUMING_SERVICES`·`_SERVICE_DRY_RUN_MAP`·`_WEB_CODE_SERVICES`는 각자 다른 목적의 **의도적 부분집합**이다.
- 진짜 구멍: 그 부분집합들이 마스터(`_SERVICE_SCRIPT_MAP`, 7개 실서비스)의 진짜 부분집합인지 재는 자가 0건 — 오타로 만든 유령 서비스명이 들어가도 아무도 못 잡는다.
- **AC1**: `_SERVICE_SCRIPT_MAP`을 SSOT로 코드에 명시. `sprintable-realtime-prod`가 `cloudbuild.yaml`의 **주석에만** 존재(실선언 아님, deploy-realtime prod 스텝 아직 스킵 중)함을 직접 재확認해 마스터가 맞다는 근거를 남김.
- **AC2**: `_service_subset_wellformed_violations()` — **한 방향만**(subset - master) 잰다. 양방향으로 재면 의도적 부분집합이 거짓 불일치로 잡힌다.
- **AC3**: `_external_iac_service_literals()` — `cloudbuild.yaml`·`.github/workflows/*.yml`·`deploy_*.sh`를 정적 파싱(주석 라인 제외)해 마스터와 대조. bash/YAML/Python 세 엔진이라 공유 import 불가 — 정적 파싱+집합비교로 봉합.
- **AC4**: 뮤테이션 양성대조 다수(가짜 서비스명 심어 RED 확認) + 주석-오탐 방지 회귀테스트(과거 "redis-prod" grep 오탐과 동형 케이스를 정확히 재현해 막는지 확認).
- **AC5**: `_find_repo_root()`가 `'../'` 개수 세기 대신 `.git` 표식을 찾아 올라간다 — 못 찾으면 즉시 실패(2026-07-28 #2600 교훈: 재료 못 찾은 가드가 skip으로 통과하면 안 됨). 외부 IaC 스캔 대상 파일이 없어도 조용히 skip하지 않고 `RuntimeError`.

## Test plan
- [x] 신규 테스트 파일 `backend/tests/test_check_env_drift_service_subset_axis.py` 13건 — GREEN.
- [x] 뮤테이션 자가검증 — fix 되돌리면(`git stash`) 11/13건 정확히 RED(나머지 2건은 기존 `_SERVICE_SCRIPT_MAP` 자체 관련이라 fix 전에도 통과가 맞음), 복원 후 GREEN.
- [x] 전체 env_drift 관련 43건 전부 GREEN(기존 축①-⑤ 무회귀).
- [x] `python3 -m py_compile infra/check_env_drift.py` — 구문 확認.
- [x] `tests/ -k "env_drift or check_env or check_serving or check_deploy_digest or mcp_path"` 88 passed / 4 failed — 실패 4건 전부 **origin/develop 기저선에서도 동일하게 실패**함을 별도 워크트리로 직접 재현·확認(내 변경과 무관, 다른 actor의 로컬 `.mcp.json` 환경의존 pre-existing 이슈).
- [x] `git diff origin/develop...HEAD --stat` — 의도한 2개 파일만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)