### PR TITLE
[SID:2298] 글랜스 웨이터폴 정리 — 에픽→per-epic 스토리→hero 3웨이브를 1웨이브로

### DIFF
--- a/apps/web/src/components/glance/derive-hero-envelope.test.ts
+++ b/apps/web/src/components/glance/derive-hero-envelope.test.ts
@@ -1,93 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import {
-  parseHeroEnvelope,
-  synthesizeGateAction,
-  type HeroActionLabels,
-  type HeroGateEnvelope,
-} from './derive-hero-envelope';
+import { synthesizeGateAction, type HeroActionLabels, type HeroGateEnvelope } from './derive-hero-envelope';
 
 const LABELS: HeroActionLabels = { merge: '병합 검토', decide: '방향 결정', review: '검토 승인' };
 
-/** 실 BE payload를 프록시(apiSuccess)가 감싼 형태 = `{data:{…}}`. */
-function proxied(body: unknown): unknown {
-  return { data: body, error: null, meta: null };
-}
-
-const FULL = {
-  story_id: 's1',
-  claim: '결제 위젯 재설계',
-  status: 'in-review',
-  proof_count: 3,
-  auto_verify: 'passed',
-  gate: { status: 'pending', gate_type: 'merge', requires_human: true, decision_basis: 'ci_pass', auto_decision_reason: null },
-  trust: {
-    self_reported: true,
-    human_verified: true,
-    human_verified_by: { member_id: 'm1', name: '유나 홀름', role: 'admin' },
-    human_verified_at: '2026-07-12T10:00:00Z',
-  },
-};
-
-describe('parseHeroEnvelope — AC1 shape-safety (이중 엔벨로프 방어·형상 붕괴=null 폴백)', () => {
-  it('unwraps the proxy envelope {data:{…}} into a typed HeroEnvelope', () => {
-    const env = parseHeroEnvelope(proxied(FULL));
-    expect(env).not.toBeNull();
-    expect(env!.claim).toBe('결제 위젯 재설계');
-    expect(env!.status).toBe('in-review');
-    expect(env!.proof_count).toBe(3);
-    expect(env!.auto_verify).toBe('passed');
-    expect(env!.gate?.gate_type).toBe('merge');
-    expect(env!.trust.human_verified_by?.name).toBe('유나 홀름');
-  });
-
-  it('also accepts the raw BE envelope (프록시 미경유 방어)', () => {
-    const env = parseHeroEnvelope(FULL);
-    expect(env!.claim).toBe('결제 위젯 재설계');
-  });
-
-  it('returns null (minimal-render fallback) — not throw — on shape collapse', () => {
-    expect(parseHeroEnvelope(null)).toBeNull();
-    expect(parseHeroEnvelope(undefined)).toBeNull();
-    expect(parseHeroEnvelope('nope')).toBeNull();
-    expect(parseHeroEnvelope([])).toBeNull();
-    expect(parseHeroEnvelope(proxied({}))).toBeNull(); // claim/status 없음
-    expect(parseHeroEnvelope(proxied({ claim: 'x' }))).toBeNull(); // status 없음
-    expect(() => parseHeroEnvelope(proxied({ claim: 5, status: 7 }))).not.toThrow();
-    expect(parseHeroEnvelope(proxied({ claim: 5, status: 7 }))).toBeNull();
-  });
-
-  it('coerces proof_count and auto_verify defensively (unknown values → safe defaults)', () => {
-    const env = parseHeroEnvelope(proxied({
-      claim: 'c', status: 'in-progress', proof_count: 'not-a-number', auto_verify: 'weird',
-    }));
-    expect(env!.proof_count).toBe(0);
-    expect(env!.auto_verify).toBeNull();
-  });
-
-  it('tolerates a missing/broken gate and trust (renders what exists, no fiction)', () => {
-    const env = parseHeroEnvelope(proxied({ claim: 'c', status: 'done', proof_count: 0 }));
-    expect(env!.gate).toBeNull();
-    expect(env!.trust).toEqual({ self_reported: false, human_verified: false, human_verified_by: null, human_verified_at: null });
-  });
-
-  it('drops a structurally-broken gate (no status/gate_type) rather than rendering a hollow one', () => {
-    const env = parseHeroEnvelope(proxied({ claim: 'c', status: 'in-review', proof_count: 1, gate: { requires_human: true } }));
-    expect(env!.gate).toBeNull();
-  });
-
-  it('drops human_verified_by when member fields are missing (no fabricated name)', () => {
-    const env = parseHeroEnvelope(proxied({
-      claim: 'c', status: 'done', proof_count: 2,
-      trust: { self_reported: true, human_verified: true, human_verified_by: { member_id: 'm1' }, human_verified_at: null },
-    }));
-    expect(env!.trust.human_verified).toBe(true);
-    expect(env!.trust.human_verified_by).toBeNull();
-  });
-});
-
 describe('synthesizeGateAction — FE 라벨 합성(인간 결정 필요 gate에만·gate_type 분기)', () => {
   const gate = (over: Partial<HeroGateEnvelope>): HeroGateEnvelope => ({
-    status: 'pending', gate_type: 'merge', requires_human: true, decision_basis: null, auto_decision_reason: null, ...over,
+    gate_type: 'merge', requires_human: true, ...over,
   });
 
   it('returns null for null gate or auto (requires_human=false) gate — no fabricated action', () => {

--- a/apps/web/src/components/glance/derive-hero-envelope.ts
+++ b/apps/web/src/components/glance/derive-hero-envelope.ts
@@ -1,25 +1,25 @@
 /**
- * E-GLANCE 2D hero ProofCapsule 리치 렌더(story 04da0281) — BE `GET /api/v2/glance/hero?story_id=`
- * (#2099·d02082e1) envelope 소비. 계약 SSOT = doc `glance-hero-proofcapsule-be-contract`.
+ * E-GLANCE 2D hero ProofCapsule 리치 렌더(story 04da0281) — 원래 `GET /api/v2/glance/hero?story_id=`
+ * (#2099·d02082e1) envelope 소비였으나, story #2298/#2303(3단 웨이터폴 근절)로 그 fetch(웨이브③)
+ * 자체가 없어졌다 — `?include=glance`의 `focal_story`(#2303, `services/glance.ts`의
+ * `BeFocalStory`)가 같은 재료를 웨이브①에서 함께 실어온다(load-glance-data.ts가 조립).
  *
- * ⚠️ **AC1 shape-safety**: attention(#2100)과 동형 — BE는 `HeroResponse` 객체를 주고 FE 프록시가
- * `apiSuccess`로 감싸 실 payload는 `{data:{…}}`가 된다. 방어적 unwrap하고, 형상 불일치(비객체·
- * 핵심 필드 누락·타입 붕괴)는 crash가 아니라 `null` 반환 → 상위(glance-hero)가 리치 필드 없이
- * 정직 최소 렌더로 폴백(no-fiction). BE는 구조화 필드만 주므로 action 라벨은 FE가 합성(i18n=FE lane).
+ * ⛔타입 셋(HeroGateEnvelope·HeroTrustMember·HeroEnvelope)은 `glance-hero.tsx` + 호출체인
+ * (splitParticipants·heroProofState·buildEvidence·buildTrustSeal·synthesizeGateAction)이
+ * **실제로 읽는 필드만** 남겼다(2026-07-29 그라운딩) — `story_id`·`claim`·`status`(envelope 쪽,
+ * story.title/status를 대신 쓴다)·`gate.status`/`decision_basis`/`auto_decision_reason`·
+ * `human_verified_by.member_id`/`role`은 화면이 안 읽어 뺐다. 파싱 함수(`parseHeroEnvelope` 등)도
+ * 함께 삭제 — 소스가 이제 신뢰된 BE JSON 그대로라(load-glance-data.ts가 직접 조립) 방어적
+ * unwrap이 더는 필요 없다.
  */
 
 export interface HeroGateEnvelope {
-  status: string;
   gate_type: string;
   requires_human: boolean;
-  decision_basis: string | null;
-  auto_decision_reason: string | null;
 }
 
 export interface HeroTrustMember {
-  member_id: string;
   name: string;
-  role: string | null;
 }
 
 export interface HeroTrustEnvelope {
@@ -30,89 +30,10 @@ export interface HeroTrustEnvelope {
 }
 
 export interface HeroEnvelope {
-  story_id: string;
-  claim: string;
-  status: string;
   proof_count: number;
   auto_verify: 'passed' | 'failed' | null;
   gate: HeroGateEnvelope | null;
   trust: HeroTrustEnvelope;
-}
-
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return typeof v === 'object' && v !== null && !Array.isArray(v);
-}
-
-function unwrapEnvelope(json: unknown): unknown {
-  if (!isRecord(json)) return json;
-  const d = json['data'];
-  return d ?? json;
-}
-
-function str(v: unknown): string | null {
-  return typeof v === 'string' ? v : null;
-}
-
-function parseGate(raw: unknown): HeroGateEnvelope | null {
-  if (!isRecord(raw)) return null;
-  const status = str(raw['status']);
-  const gateType = str(raw['gate_type']);
-  if (!status || !gateType) return null; // 구조 붕괴 게이트는 생략(no-fiction)
-  return {
-    status,
-    gate_type: gateType,
-    requires_human: raw['requires_human'] === true,
-    decision_basis: str(raw['decision_basis']),
-    auto_decision_reason: str(raw['auto_decision_reason']),
-  };
-}
-
-function parseMember(raw: unknown): HeroTrustMember | null {
-  if (!isRecord(raw)) return null;
-  const memberId = str(raw['member_id']);
-  const name = str(raw['name']);
-  if (!memberId || name == null) return null;
-  return { member_id: memberId, name, role: str(raw['role']) };
-}
-
-function parseTrust(raw: unknown): HeroTrustEnvelope {
-  if (!isRecord(raw)) {
-    return { self_reported: false, human_verified: false, human_verified_by: null, human_verified_at: null };
-  }
-  return {
-    self_reported: raw['self_reported'] === true,
-    human_verified: raw['human_verified'] === true,
-    human_verified_by: parseMember(raw['human_verified_by']),
-    human_verified_at: str(raw['human_verified_at']),
-  };
-}
-
-/**
- * 실 payload → 검증된 hero envelope. 핵심 필드(claim·status) 없거나 형상 붕괴면 `null`(리치 렌더
- * 포기·최소 폴백). auto_verify는 알려진 값만 통과(그 외 null), proof_count는 유한 정수만.
- */
-export function parseHeroEnvelope(json: unknown): HeroEnvelope | null {
-  const inner = unwrapEnvelope(json);
-  if (!isRecord(inner)) return null;
-
-  const claim = str(inner['claim']);
-  const status = str(inner['status']);
-  if (!claim || !status) return null; // 핵심 필드 없으면 리치 소스로 못 씀
-
-  const rawCount = inner['proof_count'];
-  const proof_count = typeof rawCount === 'number' && Number.isFinite(rawCount) ? Math.trunc(rawCount) : 0;
-  const av = inner['auto_verify'];
-  const auto_verify = av === 'passed' || av === 'failed' ? av : null;
-
-  return {
-    story_id: str(inner['story_id']) ?? '',
-    claim,
-    status,
-    proof_count,
-    auto_verify,
-    gate: parseGate(inner['gate']),
-    trust: parseTrust(inner['trust']),
-  };
 }
 
 export interface HeroActionLabels {

--- a/apps/web/src/components/glance/glance-board.tsx
+++ b/apps/web/src/components/glance/glance-board.tsx
@@ -59,7 +59,6 @@ interface GlanceBoardProps {
 const EMPTY_PARTIAL_ERRORS: GlanceDataPartialErrors = {
   overview: false,
   members: false,
-  stories: false,
   activity: false,
   attention: false,
 };

--- a/apps/web/src/components/glance/hero-logic.test.ts
+++ b/apps/web/src/components/glance/hero-logic.test.ts
@@ -1,36 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { pickFocalStory, heroProofState, splitParticipants, type HeroStory, type HeroMember } from './hero-logic';
+import { heroProofState, splitParticipants, type HeroStory, type HeroMember } from './hero-logic';
 
 const story = (id: string, status: string, extra: Partial<HeroStory> = {}): HeroStory => ({
-  id, title: `S-${id}`, status, description: null, assignee_id: null, ...extra,
-});
-
-describe('pickFocalStory (현재 에픽 focal 활성 story·in-progress 중 gate-pending 우선)', () => {
-  it('in-progress가 하나도 없으면 null(hero 미표시·평온 빈상태)', () => {
-    expect(pickFocalStory([story('a', 'backlog'), story('b', 'done')])).toBeNull();
-    expect(pickFocalStory([])).toBeNull();
-  });
-
-  it('in-progress 중 gate-pending 있는 story 우선', () => {
-    const s = pickFocalStory([
-      story('a', 'in-progress'),
-      story('b', 'in-progress', { gates: [{ gate_type: 'merge', status: 'pending' }] }),
-    ]);
-    expect(s?.id).toBe('b');
-  });
-
-  it('gate-pending 없으면 첫 in-progress', () => {
-    const s = pickFocalStory([story('x', 'done'), story('a', 'in-progress'), story('b', 'in-progress')]);
-    expect(s?.id).toBe('a');
-  });
-
-  it('gate가 pending 아니면(approved 등) 우선 대상 아님', () => {
-    const s = pickFocalStory([
-      story('a', 'in-progress'),
-      story('b', 'in-progress', { gates: [{ gate_type: 'merge', status: 'approved' }] }),
-    ]);
-    expect(s?.id).toBe('a');
-  });
+  id, title: `S-${id}`, status, assignee_id: null, ...extra,
 });
 
 describe('heroProofState (story.status → ProofState·정본 매핑)', () => {

--- a/apps/web/src/components/glance/hero-logic.ts
+++ b/apps/web/src/components/glance/hero-logic.ts
@@ -6,15 +6,16 @@ import type { ProofState } from '@/components/proof-capsule/proof-capsule';
  * 활성 story**를 렌더한다("지금 무엇을 하는가"). 에픽 레벨 발명 절대 0(no-fiction).
  */
 
-/** hero 배선에 필요한 story 최소 형상(`/api/stories?epic_id=` 응답에서). */
+/** hero 배선에 필요한 story 최소 형상 — story #2303 그라운딩(glance-hero.tsx + 호출체인이
+ * 실제로 읽는 필드만): `description`·`gates`(전체배열)는 화면이 안 읽어 뺐다(focal story
+ * 선정 자체가 BE `?include=glance`로 이관되며 이 파일에서 gate 우선순위를 다시 평가할
+ * 필요가 없어졌다 — pickFocalStory 삭제, 아래 참고). */
 export interface HeroStory {
   id: string;
   title: string;
   status: string;
-  description: string | null;
   assignee_id: string | null;
   assignee_ids?: string[];
-  gates?: { gate_type: string; status: string }[];
 }
 
 export interface HeroMember {
@@ -27,17 +28,6 @@ const PROOF_STATE_BY_STATUS: Record<string, ProofState> = {
   'in-review': 'amber',
   done: 'green',
 };
-
-/**
- * 현재 에픽의 focal 활성 story 선정(spec 락): **in-progress 중 gate-pending 우선, 없으면 첫 in-progress**.
- * in-progress가 하나도 없으면 null → hero 미표시(평온 빈상태·억지 렌더 0).
- */
-export function pickFocalStory(stories: HeroStory[]): HeroStory | null {
-  const inProgress = stories.filter((s) => s.status === 'in-progress');
-  if (inProgress.length === 0) return null;
-  const withPendingGate = inProgress.find((s) => s.gates?.some((g) => g.status === 'pending'));
-  return withPendingGate ?? inProgress[0]!;
-}
 
 /** story.status → ProofState(StoryDetailPanel 정본 매핑). 프루프 표면 없는 상태(backlog 등)는 null. */
 export function heroProofState(status: string): ProofState | null {

--- a/apps/web/src/components/glance/load-glance-data.test.ts
+++ b/apps/web/src/components/glance/load-glance-data.test.ts
@@ -33,49 +33,92 @@ describe('loadGlanceData (§10 데이터 소스 4종 단순 1회 fetch — dedup
       roadmap: [], totalEpicCount: 0, collaboration: [], events: [],
       activeEpicTitle: null, heroStory: null, memberMap: {}, attentionSignals: [], heroEnvelope: null,
       // codex-silent-defect-sweep D-7 — 진짜 빈 데이터(fetch 성공, 내용 0건)는 partialErrors가
-      // 전부 false여야 한다(fetch 실패와 구분되는 것이 이 필드의 존재 이유).
-      partialErrors: { overview: false, members: false, stories: false, activity: false, attention: false },
+      // 전부 false여야 한다(fetch 실패와 구분되는 것이 이 필드의 존재 이유). story #2298: `stories`
+      // 필드는 그 fetch 자체가 없어져 이 타입에서 삭제됐다.
+      partialErrors: { overview: false, members: false, activity: false, attention: false },
     });
   });
 
-  it('fetches + unwraps the hero envelope for the focal story of the active epic (form {data:{…}})', async () => {
-    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
-      if (url.startsWith('/api/goals')) return jsonResponse([{ id: 'e1', title: 'Epic One', status: 'active', created_at: '2026-07-01T00:00:00Z' }]);
-      if (url.startsWith('/api/dashboard/overview')) return jsonResponse({ project_status: { epics: [] } });
-      if (url.startsWith('/api/team-members')) return jsonResponse([]);
-      if (url.startsWith('/api/activity-logs')) return jsonResponse({ items: [], total: 0, limit: 20, offset: 0 });
-      if (url.startsWith('/api/glance/attention')) return jsonResponse({ items: [] });
-      if (url.startsWith('/api/stories')) return jsonResponse([{ id: 's1', epic_id: 'e1', assignee_id: null, title: 'Story One', status: 'in-progress' }]);
-      if (url.startsWith('/api/glance/hero')) {
-        return jsonResponse({
-          story_id: 's1', claim: 'Story One', status: 'in-progress', proof_count: 2, auto_verify: 'passed',
-          gate: { status: 'pending', gate_type: 'merge', requires_human: true, decision_basis: null, auto_decision_reason: null },
-          trust: { self_reported: true, human_verified: false, human_verified_by: null, human_verified_at: null },
-        });
-      }
-      return jsonResponse([]);
-    }));
-    const data = await loadGlanceData('proj-hero');
-    expect(data.heroStory?.id).toBe('s1');
-    expect(data.heroEnvelope).not.toBeNull();
-    expect(data.heroEnvelope!.proof_count).toBe(2);
-    expect(data.heroEnvelope!.auto_verify).toBe('passed');
-    expect(data.heroEnvelope!.gate?.gate_type).toBe('merge');
+  it('includes ?include=glance in the goals request URL(story #2298/#2303 — 웨이브②③을 웨이브①로 흡수)', async () => {
+    const fetchMock = mockEmptyFetch();
+    vi.stubGlobal('fetch', fetchMock);
+    await loadGlanceData('proj-a');
+    const goalsCall = fetchMock.mock.calls.find(([url]) => (url as string).startsWith('/api/goals'));
+    expect(goalsCall?.[0]).toContain('include=glance');
   });
 
-  it('leaves heroEnvelope null when the hero fetch fails (not-ok) — minimal render fallback, no throw', async () => {
-    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
-      if (url.startsWith('/api/goals')) return jsonResponse([{ id: 'e1', title: 'Epic One', status: 'active', created_at: '2026-07-01T00:00:00Z' }]);
+  it('derives collaboration from participant_ids on the goals(+glance) response — no per-epic story-list fetch', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.startsWith('/api/goals')) {
+        return jsonResponse([
+          { id: 'e1', title: 'Epic One', status: 'active', created_at: '2026-07-01T00:00:00Z', participant_ids: ['m1', 'm2'], focal_story: null },
+        ]);
+      }
+      if (url.startsWith('/api/dashboard/overview')) return jsonResponse({ project_status: { epics: [] } });
+      if (url.startsWith('/api/team-members')) return jsonResponse([{ id: 'm1', name: '미르코 페트로비치' }, { id: 'm2', name: '유나 홀름' }]);
+      if (url.startsWith('/api/activity-logs')) return jsonResponse({ items: [], total: 0, limit: 20, offset: 0 });
+      if (url.startsWith('/api/glance/attention')) return jsonResponse({ items: [] });
+      return jsonResponse([]);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const data = await loadGlanceData('proj-collab');
+    expect(data.collaboration).toEqual([
+      { epicId: 'e1', collaborators: [{ id: 'm1', name: '미르코 페트로비치' }, { id: 'm2', name: '유나 홀름' }] },
+    ]);
+    // ⛔fetchJson()이 .catch(()=>null)로 예외를 삼키므로 mock 안에서 throw하는 방식은
+    // "회귀 시 조용히 통과하는 가드"가 된다(mutation-verify 중 직접 발견 — 삼켜진 예외는
+    // 테스트를 실패시키지 못했다). 실제로 나간 URL을 mock.calls에서 직접 세는 방식만 신뢰 가능.
+    const calledUrls = fetchMock.mock.calls.map(([u]) => u as string);
+    expect(calledUrls.some((u) => u.startsWith('/api/stories'))).toBe(false);
+    expect(calledUrls.some((u) => u.startsWith('/api/glance/hero'))).toBe(false);
+  });
+
+  it('builds heroStory + heroEnvelope from focal_story on the active epic — no separate hero fetch', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.startsWith('/api/goals')) {
+        return jsonResponse([{
+          id: 'e1', title: 'Epic One', status: 'active', created_at: '2026-07-01T00:00:00Z',
+          participant_ids: [],
+          focal_story: {
+            id: 's1', title: 'Story One', status: 'in-progress', assignee_id: null, assignee_ids: ['a1', 'h1'],
+            proof_count: 2, auto_verify: 'passed',
+            gate: { gate_type: 'merge', requires_human: true },
+            trust: { self_reported: true, human_verified: false, human_verified_by: null, human_verified_at: null },
+          },
+        }]);
+      }
       if (url.startsWith('/api/dashboard/overview')) return jsonResponse({ project_status: { epics: [] } });
       if (url.startsWith('/api/team-members')) return jsonResponse([]);
       if (url.startsWith('/api/activity-logs')) return jsonResponse({ items: [], total: 0, limit: 20, offset: 0 });
       if (url.startsWith('/api/glance/attention')) return jsonResponse({ items: [] });
-      if (url.startsWith('/api/stories')) return jsonResponse([{ id: 's1', epic_id: 'e1', assignee_id: null, title: 'Story One', status: 'in-progress' }]);
-      if (url.startsWith('/api/glance/hero')) return { ok: false, json: async () => ({}) } as Response;
+      return jsonResponse([]);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const data = await loadGlanceData('proj-hero');
+    const calledUrls = fetchMock.mock.calls.map(([u]) => u as string);
+    expect(calledUrls.some((u) => u.startsWith('/api/stories'))).toBe(false);
+    expect(calledUrls.some((u) => u.startsWith('/api/glance/hero'))).toBe(false);
+    expect(data.heroStory).toEqual({ id: 's1', title: 'Story One', status: 'in-progress', assignee_id: null, assignee_ids: ['a1', 'h1'] });
+    expect(data.heroEnvelope).toEqual({
+      proof_count: 2, auto_verify: 'passed',
+      gate: { gate_type: 'merge', requires_human: true },
+      trust: { self_reported: true, human_verified: false, human_verified_by: null, human_verified_at: null },
+    });
+  });
+
+  it('heroStory/heroEnvelope stay null together when the active epic has no focal_story (no in-progress story)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.startsWith('/api/goals')) {
+        return jsonResponse([{ id: 'e1', title: 'Epic One', status: 'active', created_at: '2026-07-01T00:00:00Z', participant_ids: [], focal_story: null }]);
+      }
+      if (url.startsWith('/api/dashboard/overview')) return jsonResponse({ project_status: { epics: [] } });
+      if (url.startsWith('/api/team-members')) return jsonResponse([]);
+      if (url.startsWith('/api/activity-logs')) return jsonResponse({ items: [], total: 0, limit: 20, offset: 0 });
+      if (url.startsWith('/api/glance/attention')) return jsonResponse({ items: [] });
       return jsonResponse([]);
     }));
-    const data = await loadGlanceData('proj-hero-fail');
-    expect(data.heroStory?.id).toBe('s1');
+    const data = await loadGlanceData('proj-no-hero');
+    expect(data.heroStory).toBeNull();
     expect(data.heroEnvelope).toBeNull();
   });
 
@@ -143,6 +186,10 @@ describe('loadGlanceData (§10 데이터 소스 4종 단순 1회 fetch — dedup
     vi.stubGlobal('fetch', mockEmptyFetch());
     await loadGlanceData('proj-d');
     await loadGlanceData('proj-d');
+    // story #2298: 고정 엔드포인트 수(5: epics+glance·overview·members·activity·attention) 자체는
+    // 그대로다 — 줄어든 건 이 5개에 "얹혀 있던" 가변 웨이브다(에픽 수만큼의 story-list N건 +
+    // 조건부 hero 1건, 이 mock엔 아예 없어서 숫자로는 안 보인다 — 그 웨이브가 실제로 안 나가는
+    // 것은 위 "no per-epic story-list fetch"/"no separate hero fetch" 테스트가 throw로 잡는다).
     expect(vi.mocked(fetch).mock.calls.length).toBe(10); // 5 endpoints × 2 calls (epics·overview·members·activity·attention)
   });
 });

--- a/apps/web/src/components/glance/load-glance-data.ts
+++ b/apps/web/src/components/glance/load-glance-data.ts
@@ -1,28 +1,28 @@
 import type { EpicProgress } from '@/components/dashboard/command-center/types';
 import {
-  deriveCollaboration,
   mergeRoadmap,
   filterMilestoneEvents,
   scopeRoadmapEpics,
   type BeActivityLogItem,
   type BeEpicListItem,
-  type BeStoryListItem,
   type EpicCollaboration,
   type RoadmapEpic,
 } from '@/services/glance';
-import { pickFocalStory, type HeroStory, type HeroMember } from './hero-logic';
+import type { HeroStory, HeroMember } from './hero-logic';
+import type { HeroEnvelope } from './derive-hero-envelope';
 import { parseAttentionSignals, type BeAttentionSignal } from './derive-exception-signals';
-import { parseHeroEnvelope, type HeroEnvelope } from './derive-hero-envelope';
 
-// codex-silent-defect-sweep D-7 — overview/멤버/스토리/활동/예외 fetch 실패를 `?? []`/`?? 0`으로
+// codex-silent-defect-sweep D-7 — overview/멤버/활동/예외 fetch 실패를 `?? []`/`?? 0`으로
 // 실제 빈 데이터처럼 치환하면 "데이터가 없다"와 "못 가져왔다"가 화면에서 구분이 안 된다. 폴백
 // 자체(빈 배열로 렌더 지속)는 유지하되, 어떤 조각이 실패했는지 이 플래그로 caller에 넘겨 caller가
 // 그 영역만 "재시도 가능" 표시로 구분되게 그린다 — 전면 에러 화면으로 바꾸지 않는다(부분 실패는
 // 부분만 표시).
+// story #2298(3단 웨이터폴 근절): `stories` 필드 삭제 — 예전엔 per-epic story-list fetch(웨이브②)의
+// 실패를 따로 추적했으나, 그 fetch 자체가 없어졌다(collaboration·heroStory 전부 epics(+glance)
+// 응답에서 나온다 — 그 fetch가 실패하면 epicsRaw가 null이 되어 이 함수 자체가 throw한다, 아래 참고).
 export interface GlanceDataPartialErrors {
   overview: boolean;
   members: boolean;
-  stories: boolean;
   activity: boolean;
   attention: boolean;
 }
@@ -39,8 +39,9 @@ export interface GlanceData {
   // 예외 스트림(story 0441a197): #2097 glance/attention 실신호(gate_pending·blocked·merge_ready).
   // 미가용/실패는 빈 배열로 정직 처리(throw 0) — 예외 스트림은 없으면 "손 필요한 것 없음" 빈상태.
   attentionSignals: BeAttentionSignal[];
-  // hero ProofCapsule 리치 envelope(story 04da0281): #2099 glance/hero. 형상 붕괴/미가용은 null →
-  // hero 최소 렌더 폴백(claim+state+참여자만·no-fiction). heroStory 없으면 애초에 fetch 안 함.
+  // hero ProofCapsule 리치 envelope(story 04da0281→#2298/#2303) — heroStory와 항상 짝(둘 다
+  // null이거나 둘 다 존재). 예전엔 별도 fetch(웨이브③)라 story는 있는데 envelope만 실패하는
+  // 상태가 가능했으나, 이제 같은 focal_story 객체에서 나오므로 그 상태 자체가 구조적으로 없다.
   heroEnvelope: HeroEnvelope | null;
   partialErrors: GlanceDataPartialErrors;
 }
@@ -56,20 +57,32 @@ async function fetchJson(url: string): Promise<unknown> {
 }
 
 /**
- * E-GLANCE 현황판 데이터 병합 — §10 소스 4종: /api/goals(순서 SSOT) · /api/dashboard/overview
- * (진척) · /api/stories?epic_id=(참여) · /api/activity-logs(생동). 로드맵 blank 재발(2026-07-11)
- * 진짜 근본은 이 함수의 activity-logs 처리였다 — `GET /api/v2/activity-logs`는 flat 배열이
- * 아니라 `ActivityLogListResponse{items,total,limit,offset}`(activity_logs.py:65)를 반환하는데
- * `.items` 추출 없이 그 wrapper를 배열인 척 넘겨 매번 throw했다(dashboard-activity-timeline.tsx의
- * `json.data.items`와 대조해 확인). 애초에 재마운트 레이스가 아니라 이 결정적 크래시였던 것으로
- * 밝혀져, 이전 라운드(in-flight dedup·resolvedCache·동기 마운트 읽기)의 module-level 캐시
- * 복잡도는 걷어냈다(#c3d1565d, less-is-more) — 단순 1회 fetch로 되돌린다.
+ * E-GLANCE 현황판 데이터 병합 — §10 소스 4종(이제 3종 fetch): `/api/goals?include=glance`
+ * (순서 SSOT + 참여·hero 재료) · `/api/dashboard/overview`(진척) · `/api/activity-logs`(생동).
+ * story #2298(3단 웨이터폴 근절, PO 실측 2026-07-28 — 로그인 後 2.07초가 이 웨이터폴에서
+ * 나옴)+#2303(계약 확장): `roadmap.map(epic ⇒ /api/stories?epic_id=)`(N건, 예전 웨이브②)와
+ * `/api/glance/hero?story_id=`(예전 웨이브③) 둘 다 제거 — `?include=glance`의
+ * `participant_ids`/`focal_story`가 그 재료를 웨이브①에서 함께 싣는다. ⛔판정 기준은
+ * "요청이 3→1로 줄었는가"가 아니라 "화면이 그리는 것 중 하나도 안 줄어드는가 + 요청이
+ * 주는가"(PO 재확定, 2026-07-28) — hero envelope의 9필드(assignee_ids·proof_count·
+ * auto_verify·gate.*·trust.*, glance-hero.tsx 호출체인 그라운딩으로 확정)가 전부 BE 계약에
+ * 실려 화면 표시 내용은 한 글자도 안 줄었다.
+ *
+ * ⛔동작 변경 하나(PR 본문에도 명시): `pickFocalStory`의 gate-우선 분기가 이 story가 도입된
+ * 2026-07-12부터 재료(story listing에 `gates` 필드 자체가 없었음) 없이 죽어있었다 — 지금
+ * BE가 실제 gate 데이터로 그 분기를 처음 살린다. 지금까지는 in-progress 중 항상 첫 번째가
+ * hero였는데, 이제부터는 gate-pending story가 있으면 그게 우선한다.
+ *
+ * activity-logs는 flat 배열이 아니라 `ActivityLogListResponse{items,total,limit,offset}` —
+ * 로드맵 blank 재발(2026-07-11)의 진짜 근본이 이 처리였다(#c3d1565d). 단순 1회 fetch(dedup/캐시
+ * 없음)로 유지.
  */
 export async function loadGlanceData(projectId: string): Promise<GlanceData> {
   const [epicsJson, overviewJson, membersJson, activityJson, attentionJson] = await Promise.all([
     // wedge #2: order_by=position 옵트인 — 조타(큐레이션) 결과를 아크가 curated-first로 소비만
     // 반영(드래그 없음). position 모드는 커서 미발행이나 아크는 원래 전량로드(limit=100)라 무관.
-    fetchJson(`/api/goals?project_id=${projectId}&limit=100&order_by=position`),
+    // story #2298/#2303: include=glance — participant_ids/focal_story를 같은 응답에 싣는다.
+    fetchJson(`/api/goals?project_id=${projectId}&limit=100&order_by=position&include=glance`),
     fetchJson('/api/dashboard/overview'),
     fetchJson('/api/team-members'),
     fetchJson(`/api/activity-logs?project_id=${projectId}&limit=20`),
@@ -94,39 +107,31 @@ export async function loadGlanceData(projectId: string): Promise<GlanceData> {
     memberMap[m.id] = { name: m.name, type: m.type ?? 'human' };
   }
 
-  const storyLists = await Promise.all(roadmap.map((e) => fetchJson(`/api/stories?epic_id=${e.id}&limit=100`)));
-  const stories = storyLists.flatMap((s) => unwrap<BeStoryListItem[]>(s) ?? []);
-  const collaboration = deriveCollaboration(roadmap.map((e) => e.id), stories, memberNames);
+  // story #2298/#2303: collaboration은 이제 `participant_ids`(에픽별 고유 assignee_id 집합,
+  // BE가 이미 distinct로 계산)에서 바로 파생 — 추가 fetch·재-distinct 둘 다 불필요.
+  const rawById = new Map(arc.epics.map((e) => [e.id, e]));
+  const collaboration: EpicCollaboration[] = roadmap.map((e) => {
+    const ids = rawById.get(e.id)?.participant_ids ?? [];
+    return { epicId: e.id, collaborators: ids.map((id) => ({ id, name: memberNames[id] ?? id })) };
+  });
 
-  // codex-silent-defect-sweep D-7 — fetchJson은 실패(네트워크 오류·!res.ok·파싱 실패) 시 항상
-  // `null`을 반환한다(catch(() => null)). 이 null 자체가 "못 가져왔다"의 유일한 신호라, unwrap
-  // 이후(형상 파싱 이후)가 아니라 여기서 원본 fetch 결과로 판정해야 진짜 실패와 형상은 맞지만
-  // 우연히 빈 배열인 정상 응답을 안 섞는다.
+  // 2D 재설계: hero = 현재(active) 에픽의 focal 활성 story. story #2298/#2303부터 story·
+  // envelope 재료 전부 `focal_story`(같은 epics(+glance) 응답)에서 나온다 — 추가 fetch 0.
+  const activeEpic = roadmap.find((e) => e.roadmapStatus === 'active') ?? null;
+  const focal = activeEpic ? (rawById.get(activeEpic.id)?.focal_story ?? null) : null;
+  const heroStory: HeroStory | null = focal
+    ? { id: focal.id, title: focal.title, status: focal.status, assignee_id: focal.assignee_id, assignee_ids: focal.assignee_ids }
+    : null;
+  const heroEnvelope: HeroEnvelope | null = focal
+    ? { proof_count: focal.proof_count, auto_verify: focal.auto_verify, gate: focal.gate, trust: focal.trust }
+    : null;
+
   const partialErrors: GlanceDataPartialErrors = {
     overview: overviewJson === null,
     members: membersJson === null,
-    stories: storyLists.some((s) => s === null),
     activity: activityJson === null,
     attention: attentionJson === null,
   };
-
-  // 2D 재설계: hero = 현재(active) 에픽의 focal 활성 story. 위에서 이미 per-epic으로 받은
-  // 스토리 목록(storyLists)을 재사용해 활성 에픽의 full 스토리에서 focal을 고른다(추가 fetch 0).
-  const activeEpic = roadmap.find((e) => e.roadmapStatus === 'active') ?? null;
-  let heroStory: HeroStory | null = null;
-  if (activeEpic) {
-    const idx = roadmap.findIndex((e) => e.id === activeEpic.id);
-    const activeStories = unwrap<HeroStory[]>(storyLists[idx]) ?? [];
-    heroStory = pickFocalStory(activeStories);
-  }
-
-  // hero 리치 envelope — focal story가 있을 때만 fetch(#2099 glance/hero). 실패/형상붕괴는 null →
-  // hero 최소 렌더 폴백(parseHeroEnvelope가 방어). 신규 fetch는 hero 있는 경우 1회뿐(추가부하 최소).
-  let heroEnvelope: HeroEnvelope | null = null;
-  if (heroStory) {
-    const heroJson = await fetchJson(`/api/glance/hero?story_id=${heroStory.id}`);
-    heroEnvelope = parseHeroEnvelope(heroJson);
-  }
 
   // activity-logs는 flat 배열이 아니라 {items,...} wrapper — 위 함수 doc 참고.
   const activityItems = unwrap<{ items: BeActivityLogItem[] }>(activityJson)?.items ?? [];

--- a/apps/web/src/services/glance.test.ts
+++ b/apps/web/src/services/glance.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import {
-  deriveCollaboration,
   deriveRoadmapStatus,
   deriveVagueRecency,
   derivePhrase,
@@ -9,7 +8,6 @@ import {
   scopeRoadmapEpics,
   type BeActivityLogItem,
   type BeEpicListItem,
-  type BeStoryListItem,
 } from './glance';
 import type { EpicProgress } from '@/components/dashboard/command-center/types';
 
@@ -150,32 +148,6 @@ describe('derivePhrase (정성 진척 언어 — %는 보조)', () => {
   });
   it('buckets near-complete progress as wrappingUp', () => {
     expect(derivePhrase(95, 20)).toBe('wrappingUp');
-  });
-});
-
-describe('deriveCollaboration (참여=presence만, 개수 집계 0)', () => {
-  const stories: BeStoryListItem[] = [
-    { id: 's1', epic_id: 'e1', assignee_id: 'm1' },
-    { id: 's2', epic_id: 'e1', assignee_id: 'm1' }, // 같은 사람 중복 스토리 — collaborator는 1명이어야
-    { id: 's3', epic_id: 'e1', assignee_id: 'm2' },
-    { id: 's4', epic_id: 'e2', assignee_id: null }, // 미배정
-  ];
-  const memberNames = { m1: '미르코 페트로비치', m2: '유나 홀름' };
-
-  it('dedupes repeated assignees on the same epic into a single presence entry', () => {
-    const [e1] = deriveCollaboration(['e1'], stories, memberNames);
-    expect(e1!.collaborators).toHaveLength(2);
-    expect(e1!.collaborators.map((c) => c.name).sort()).toEqual(['미르코 페트로비치', '유나 홀름']);
-  });
-
-  it('returns an empty collaborator list (not a crash) when no story is assigned', () => {
-    const [e2] = deriveCollaboration(['e2'], stories, memberNames);
-    expect(e2!.collaborators).toEqual([]);
-  });
-
-  it('returns an empty collaborator list for an epic with no stories at all', () => {
-    const [e3] = deriveCollaboration(['e3'], stories, memberNames);
-    expect(e3!.collaborators).toEqual([]);
   });
 });
 

--- a/apps/web/src/services/glance.ts
+++ b/apps/web/src/services/glance.ts
@@ -26,6 +26,27 @@ export interface RoadmapEpic {
   completionPct: number;
 }
 
+/** story #2298/#2303 — `?include=glance` 옵트인 시 `focal_story`에 실리는 9필드. `/api/glance/hero?story_id=`
+ * 전체 웨이브를 대체(#2303 그라운딩: glance-hero.tsx + 호출체인이 실제로 읽는 필드만 — description·
+ * envelope.claim/status·gate.status/decision_basis/auto_decision_reason·human_verified_by.member_id/role·
+ * gates 전체배열은 화면이 안 읽어 의도적으로 뺐다). */
+export interface BeFocalStory {
+  id: string;
+  title: string;
+  status: string;
+  assignee_id: string | null;
+  assignee_ids: string[];
+  proof_count: number;
+  auto_verify: 'passed' | 'failed' | null;
+  gate: { gate_type: string; requires_human: boolean } | null;
+  trust: {
+    self_reported: boolean;
+    human_verified: boolean;
+    human_verified_by: { name: string } | null;
+    human_verified_at: string | null;
+  };
+}
+
 /** `GET /api/goals` 응답 항목(core-storage `Epic` 인터페이스 미러, 필요 필드만). */
 export interface BeEpicListItem {
   id: string;
@@ -36,6 +57,10 @@ export interface BeEpicListItem {
   // (드래그 없음). BE order_by=position 미지정/미보유 시 전부 null 취급 → 기존 created_at 정렬과
   // 동일(#2056 회귀0).
   position?: number | null;
+  // story #2298(3단 웨이터폴 근절) — `?include=glance` 옵트인일 때만 실린다(미지정 시 undefined,
+  // BE byte-identical 계약 그대로). participant_ids: 이 에픽의 고유 assignee_id 집합(캡 없음).
+  participant_ids?: string[];
+  focal_story?: BeFocalStory | null;
 }
 
 /**
@@ -133,13 +158,6 @@ export function derivePhrase(completionPct: number, total: number): ProgressPhra
   return 'wrappingUp';
 }
 
-/** `GET /api/stories?epic_id=` 항목(core-storage `Story` 인터페이스 미러, 필요 필드만). */
-export interface BeStoryListItem {
-  id: string;
-  epic_id: string | null;
-  assignee_id: string | null;
-}
-
 export interface EpicCollaborator {
   id: string;
   name: string;
@@ -148,29 +166,6 @@ export interface EpicCollaborator {
 export interface EpicCollaboration {
   epicId: string;
   collaborators: EpicCollaborator[];
-}
-
-/**
- * 참여 = "붙어있나" 여부만(§5 하드라인) — 개수·처리량 절대 집계 안 함. 스토리를 배정자별로
- * 세지 않고 distinct assignee_id만 뽑아 "이 사람이 이 에픽에 함께 있다"만 표현.
- */
-export function deriveCollaboration(
-  epicIds: string[],
-  stories: BeStoryListItem[],
-  memberNames: Record<string, string>,
-): EpicCollaboration[] {
-  const storiesByEpic = new Map<string, BeStoryListItem[]>();
-  for (const s of stories) {
-    if (!s.epic_id) continue;
-    const list = storiesByEpic.get(s.epic_id) ?? [];
-    list.push(s);
-    storiesByEpic.set(s.epic_id, list);
-  }
-  return epicIds.map((epicId) => {
-    const list = storiesByEpic.get(epicId) ?? [];
-    const ids = Array.from(new Set(list.map((s) => s.assignee_id).filter((id): id is string => !!id)));
-    return { epicId, collaborators: ids.map((id) => ({ id, name: memberNames[id] ?? id })) };
-  });
 }
 
 /** `GET /api/activity-logs` 항목(`dashboard-activity-timeline.tsx`의 로컬 인터페이스 미러). */


### PR DESCRIPTION
## 요약
- `GET /api/goals?include=glance`(#2602/#2603)가 `participant_ids`(에픽별 고유 assignee 집합)와 `focal_story`(hero story + ProofCapsule envelope 9필드)를 같은 응답에 싣기 시작해, `load-glance-data.ts`의 웨이브②(에픽별 `/api/stories?epic_id=` N건)와 웨이브③(`/api/glance/hero?story_id=`)를 전부 제거했다.
- `deriveCollaboration`/`pickFocalStory`/`parseHeroEnvelope`+내부 헬퍼(`isRecord`/`unwrapEnvelope`/`str`/`parseGate`/`parseMember`/`parseTrust`)를 삭제. `HeroEnvelope`/`HeroGateEnvelope`/`HeroTrustMember`/`HeroStory` 타입을 `glance-hero.tsx` 호출체인이 실제로 읽는 필드만 남게 narrowing.
- `GlanceDataPartialErrors`에서 `stories` 필드 제거(그 fetch 자체가 없어짐 — 실패 시 `epicsRaw===null`로 함수 전체가 throw하는 기존 경로에 흡수).

## 판정 기준
"요청이 3→1로 줄었는가"가 아니라 **"화면이 그리는 것 중 하나도 줄지 않는가 + 요청이 줄었는가"**(PO 재확定, 2026-07-28) — 둘 다 확認:
- 화면 표시 내용: `assignee_ids`(human+agent 동시표시)·`proof_count`·`auto_verify`·`gate.gate_type`·`gate.requires_human`·`trust.self_reported`·`trust.human_verified`·`trust.human_verified_by.name`·`trust.human_verified_at` — 9필드 전부 BE 계약에 실려 화면이 예전과 동일하게 그린다(`glance-hero.tsx` 변경 0).
- 요청 수: 고정 엔드포인트(5개: epics+glance·overview·members·activity·attention) 자체는 그대로지만, 거기 얹혀 있던 가변 웨이브(에픽 수만큼의 story-list N건 + 조건부 hero 1건)가 완전히 사라짐 — 로컬에서 개발 프로젝트로 라이브 확인, dev API 직접 curl로 9필드 실 데이터(`proof_count:2`, `self_reported:true` 등 non-trivial 사례 포함) 확인 완료.

## ⛔동작 변경
`pickFocalStory`의 "in-progress 중 gate-pending 우선" 분기는 이 story가 도입된 2026-07-12부터 **죽어있었다** — 그 시점 story listing에 `gates` 필드 자체가 없어 조건이 항상 거짓이었다. 이번 변경으로 BE가 실제 gate 데이터를 `focal_story.gate`로 실어보내면서 이 분기가 처음으로 살아난다. 지금까지는 활성 에픽의 in-progress 스토리 중 **항상 첫 번째**가 hero였는데, 이제부터는 gate-pending 스토리가 있으면 그게 우선한다 — 사용자가 보는 hero 스토리가 실제로 달라질 수 있다.

## 테스트
- `load-glance-data.test.ts`: 새 계약 mock으로 전면 재작성 — collaboration이 `participant_ids`에서, heroStory/heroEnvelope가 `focal_story`에서 파생됨을 검증. mutation-verify 중 자체발견: mock 안에서 throw하는 회귀가드는 `fetchJson`의 `.catch(()=>null)`에 삼켜져 무력화됨 — `mock.calls`를 직접 세는 방식으로 교체.
- `hero-logic.test.ts`/`derive-hero-envelope.test.ts`: 삭제된 함수(`pickFocalStory`/`parseHeroEnvelope`)의 describe 블록 제거, 남은 함수(`heroProofState`/`splitParticipants`/`synthesizeGateAction`)는 narrowing된 타입에 맞춰 갱신.
- `glance.test.ts`: `deriveCollaboration` describe 블록 제거.
- 전체 스윕: `tsc --noEmit` 0 errors · `eslint` 0 warnings · `vitest run`(전체 리포) 303 files / 2002 tests pass · `pnpm build` 성공.

🤖 Generated with [Claude Code](https://claude.com/claude-code)