### PR TITLE
fix(#2308): 캡 예외를 TARGET_REQUIRED_KINDS 전체로 — 가장 넓게 번지는 정정이 먼저 잘리던 결함

### DIFF
--- a/backend/app/routers/judgments.py
+++ b/backend/app/routers/judgments.py
@@ -50,13 +50,13 @@ class JudgmentResponse(BaseModel):
 
 class JudgmentListMeta(BaseModel):
     scope: str | None
-    capped: bool
-    cap_basis: str
-    omitted_count: int
+    active_capped: bool
+    active_cap_basis: str
+    active_omitted_count: int
 
 
 class JudgmentListResponse(BaseModel):
-    retractions: list[JudgmentResponse]
+    corrections: list[JudgmentResponse]
     active: list[JudgmentResponse]
     meta: JudgmentListMeta
 

--- a/backend/app/services/judgment_core.py
+++ b/backend/app/services/judgment_core.py
@@ -1,11 +1,24 @@
 """story #2268(D단계, E-CONNECT — "판단 칸") — judgments write/read 코어.
 
-AC(오르테가, 2026-07-29): pull 전용 — 「물으면 준다」, push 금지. `retractions`는 상한과
+AC(오르테가, 2026-07-29): pull 전용 — 「물으면 준다」, push 금지. `corrections`(앞선 말에
+대한 말 — retraction·refinement·method_error, `TARGET_REQUIRED_KINDS`와 동일 집합)는 상한과
 무관하게 항상 전체(캡 예외 — "철회된 걸 다시 주장 안 하는가"가 이 판의 판정기준이므로 여기서
-잘리면 그 기준 자체가 무너진다). `active`(judgment/unmeasurable/refinement/method_error)는
+잘리면 그 기준 자체가 무너진다). `active`(judgment/unmeasurable — corrections 아닌 나머지)는
 "다음 발 수" 기준으로 캡 — 지금 실측 가능한 랭킹 신호가 recency뿐이라 그걸로 자르고
-`meta.cap_basis`로 정직하게 선언한다(다른 신호 없으면 있는 척 안 함, #2266 backlinks의
+`meta.active_cap_basis`로 정직하게 선언한다(다른 신호 없으면 있는 척 안 함, #2266 backlinks의
 collection_scope 정직성 패턴과 동형).
+
+⛔story #2308(2026-07-29, 오르테가 자백): 최초 구현은 캡 예외를 `kind == "retraction"`
+하나로만 좁혀 썼다 — AC 원문 「retractions는 상한과 무관하게 전량」이 «집합의 정의»가 아니라
+«원소 이름 하나»를 썼기 때문(정확한 독해였지만 좁은 표현이 구현을 좁혔다). 결과: 셋 중 가장
+넓게 번지는 `method_error`(그 판단 + 같은 방법으로 낸 다른 모든 말을 무효화)가 캡에 가장 먼저
+걸리는, 설계 목적과 정반대인 상태였다. 지금은 `TARGET_REQUIRED_KINDS`(모델에 이미 있는 상수)를
+캡 예외 집합으로 직접 파생해 쓴다 — 종류를 손으로 다시 나열하지 않는다(새 correction 종류가
+생기면 자동으로 따라온다). 응답 필드도 `retractions`→`corrections`로 개명(내용이 이제 셋을
+담으므로 이름이 하나만 가리키면 거짓이 된다) — 이 필드의 실제 소비자는 이 저장소 안(router
+스키마·MCP 도구 wrapper·이 PR의 realdb 테스트)뿐임을 grep으로 확인했고(호출 경로·HTTP 경로
+둘 다 — import 그래프만으론 부족), 배포 하루 만의 라이브 사용도 ORM 계산값이라 저장되지
+않으므로 별도 마이그레이션 없이 한 커밋에서 전 소비자를 함께 갱신한다.
 
 app-level 검증을 먼저 하는 이유(#2259 reference_core.insert_reference와 동일 패턴 — 이중
 방어): DB CHECK만 믿으면 실패 시 raw IntegrityError 텍스트가 그대로 API 밖으로 샌다. 여기서
@@ -94,15 +107,15 @@ async def list_judgments(
     if scope is not None:
         filters.append(Judgment.scope == scope)
 
-    retraction_rows = (
+    correction_rows = (
         await session.execute(
             select(Judgment)
-            .where(*filters, Judgment.kind == "retraction")
+            .where(*filters, Judgment.kind.in_(TARGET_REQUIRED_KINDS))
             .order_by(Judgment.created_at.desc())
         )
     ).scalars().all()
 
-    active_filters = [*filters, Judgment.kind != "retraction"]
+    active_filters = [*filters, Judgment.kind.not_in(TARGET_REQUIRED_KINDS)]
     total_active = (
         await session.execute(select(func.count(Judgment.id)).where(*active_filters))
     ).scalar_one()
@@ -112,14 +125,17 @@ async def list_judgments(
         )
     ).scalars().all()
 
-    omitted_count = max(0, total_active - len(active_rows))
+    active_omitted_count = max(0, total_active - len(active_rows))
     return {
-        "retractions": list(retraction_rows),
+        # corrections는 캡 예외 — 위 쿼리에 limit이 없으므로 항상 전량, 그러므로 이쪽은
+        # 절대 잘리지 않는다(아래 meta가 active 쪽에만 있는 이유 — 어느 쪽이 잘렸는지
+        # 필드 이름 자체가 말하게 한다, story #2308 AC3).
+        "corrections": list(correction_rows),
         "active": list(active_rows),
         "meta": {
             "scope": scope,
-            "capped": omitted_count > 0,
-            "cap_basis": "recency",
-            "omitted_count": omitted_count,
+            "active_capped": active_omitted_count > 0,
+            "active_cap_basis": "recency",
+            "active_omitted_count": active_omitted_count,
         },
     }

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -550,8 +550,9 @@ _TOOL_DEFS: list[tuple] = [
      "refinement/method_error는 target_id(무엇에 대한 말인지) 필수.",
      AddJudgmentInput, add_judgment),
     ("sprintable_list_judgments",
-     "판단/철회 pull 조회 — work_item_id·method·scope로 좁혀 묻는다. retractions는 상한과"
-     " 무관하게 항상 전체, active는 캡되며 meta.omitted_count로 잘린 건수를 알려준다.",
+     "판단/철회 pull 조회 — work_item_id·method·scope로 좁혀 묻는다. corrections(retraction/"
+     "refinement/method_error)는 상한과 무관하게 항상 전체, active는 캡되며"
+     " meta.active_omitted_count로 잘린 건수를 알려준다.",
      ListJudgmentsInput, list_judgments),
     # Visual artifacts (12) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안) +
     # 핀 저작(story 7fe16274) + story #1922(delete_artifact, soft delete·생성자 전용)

--- a/backend/sprintable_mcp/tools/judgments.py
+++ b/backend/sprintable_mcp/tools/judgments.py
@@ -51,11 +51,13 @@ class ListJudgmentsInput(SprintableInput):
 
 
 async def list_judgments(args: ListJudgmentsInput) -> list[TextContent]:
-    """pull 전용 — 「물으면 준다」(push 없음). `retractions`는 상한과 무관하게 항상 전체
-    (철회된 판단을 다시 주장하지 않으려면 빠짐없이 봐야 한다). `active`(judgment/
-    unmeasurable/refinement/method_error)는 recency 기준으로 캡되며, `meta.omitted_count`가
-    실제로 몇 건 잘렸는지 알려준다. `method` 필터는 "같은 방법으로 낸 다른 말들"을 역추적할
-    때 쓴다(method_error를 남기기 전에 먼저 이걸로 훑어보는 것을 권장)."""
+    """pull 전용 — 「물으면 준다」(push 없음). `corrections`(retraction·refinement·
+    method_error — 앞선 말에 대한 말 전부)는 상한과 무관하게 항상 전체(철회된 판단을 다시
+    주장하지 않으려면 빠짐없이 봐야 한다). `active`(judgment/unmeasurable)는 recency
+    기준으로 캡되며, `meta.active_omitted_count`가 실제로 몇 건 잘렸는지 알려준다(잘리는
+    것은 항상 active뿐 — corrections는 절대 안 잘린다). `method` 필터는 "같은 방법으로 낸
+    다른 말들"을 역추적할 때 쓴다(method_error를 남기기 전에 먼저 이걸로 훑어보는 것을
+    권장)."""
     try:
         params: dict = {}
         if args.work_item_id is not None:

--- a/backend/tests/test_2268_judgments_endpoint_realdb.py
+++ b/backend/tests/test_2268_judgments_endpoint_realdb.py
@@ -3,8 +3,8 @@
 오르테가 AC(2026-07-29, 스레드 7256d5cc) 7개를 그대로 잰다:
   ①Evidence 카운트 오염 없음(judgment 삽입 전후 batch_has_evidence·GET /evidence·
     glance proof_count 변화 0)
-  ②철회는 캡을 안 받는다(active는 잘리고 retractions는 전량)
-  ③omitted_count가 정확한 수
+  ②철회는 캡을 안 받는다(active는 잘리고 corrections는 전량)
+  ③active_omitted_count가 정확한 수
   ④method 축 역추적(?method=Y로 같은 방법으로 낸 다른 말들이 함께 나옴)
   ⑤scope 위반이 API 층에서 422로 거절(DB CHECK가 아니라 사람이 읽을 메시지로)
   ⑥⛔"PO가 실제로 한 건 쓴다"는 이 PR의 몫이 아니다 — 여기선 그 «메커니즘»만 증명한다
@@ -185,10 +185,13 @@ async def test_judgment_insert_does_not_move_evidence_signals():
         await engine.dispose()
 
 
-# ─── ②③철회 uncapped + omitted_count 정확 ────────────────────────────────────
+# ─── ②③정정(retraction·refinement·method_error) uncapped + active_omitted_count 정확 ──
 
 
-async def test_retractions_uncapped_active_capped_with_accurate_omitted_count():
+async def test_corrections_uncapped_active_capped_with_accurate_omitted_count():
+    """story #2308(2026-07-29) — 캡 예외가 `TARGET_REQUIRED_KINDS` 전체(retraction·
+    refinement·method_error)를 덮는지 증명한다. retraction 하나만 테스트하면 그 회귀가
+    다시 들어와도 이 테스트가 못 잡는다 — 셋 다 각각 캡보다 많이 넣어 전량 생존을 본다."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -213,30 +216,36 @@ async def test_retractions_uncapped_active_capped_with_accurate_omitted_count():
                 assert resp.status_code == 201, resp.text
                 active_ids.append(resp.json()["id"])
 
-            retraction_ids = []
-            for target_id in active_ids[:3]:
+            correction_ids = []
+            for kind, target_id in zip(
+                ["retraction", "refinement", "method_error"], active_ids[:3], strict=True
+            ):
                 resp = await client.post(
                     "/api/v2/judgments",
                     json={
-                        "scope": "general", "kind": "retraction", "target_id": target_id,
-                        "statement": f"retract {target_id}",
+                        "scope": "general", "kind": kind, "target_id": target_id,
+                        "statement": f"{kind} of {target_id}",
                     },
                 )
                 assert resp.status_code == 201, resp.text
-                retraction_ids.append(resp.json()["id"])
+                correction_ids.append(resp.json()["id"])
 
             resp = await client.get("/api/v2/judgments", params={"scope": "general", "limit": 2})
             assert resp.status_code == 200, resp.text
             body = resp.json()
 
             assert len(body["active"]) == 2, body["active"]
-            assert {r["id"] for r in body["retractions"]} == set(retraction_ids), body["retractions"]
-            assert len(body["retractions"]) == 3
+            assert {r["id"] for r in body["corrections"]} == set(correction_ids), body["corrections"]
+            assert len(body["corrections"]) == 3
+            # 셋 다 실제로 섞여 나오는지(하나의 kind로 쏠려 있지 않은지) 확인.
+            assert {r["kind"] for r in body["corrections"]} == {
+                "retraction", "refinement", "method_error",
+            }, body["corrections"]
 
-            assert body["meta"]["capped"] is True
-            assert body["meta"]["cap_basis"] == "recency"
-            # active 총량 = 5(judgment) + 3(retraction은 active 아님) = 5. 2건 반환 → 3건 누락.
-            assert body["meta"]["omitted_count"] == 3, body["meta"]
+            assert body["meta"]["active_capped"] is True
+            assert body["meta"]["active_cap_basis"] == "recency"
+            # active 총량 = 5(judgment) + 0(정정 셋은 active 아님) = 5. 2건 반환 → 3건 누락.
+            assert body["meta"]["active_omitted_count"] == 3, body["meta"]
         finally:
             await client.aclose()
     finally:
@@ -302,8 +311,12 @@ async def test_method_filter_surfaces_all_statements_produced_by_same_method():
             assert resp.status_code == 200, resp.text
             body = resp.json()
             active_ids = {j["id"] for j in body["active"]}
-            assert active_ids == {r1.json()["id"], r2.json()["id"], r3.json()["id"]}
-            assert r_other.json()["id"] not in active_ids
+            correction_ids = {j["id"] for j in body["corrections"]}
+            # story #2308: method_error(r3)는 정정 축이라 corrections에 있다 — active엔
+            # judgment 둘(r1·r2)만 남는다. method 필터가 두 축 모두에 걸리는지도 여기서 확인.
+            assert active_ids == {r1.json()["id"], r2.json()["id"]}, active_ids
+            assert correction_ids == {r3.json()["id"]}, correction_ids
+            assert r_other.json()["id"] not in active_ids | correction_ids
         finally:
             await client.aclose()
     finally:
@@ -432,9 +445,10 @@ async def test_general_scope_entry_is_pullable_via_scope_filter():
 
             listed = await client.get("/api/v2/judgments", params={"scope": "general"})
             assert listed.status_code == 200, listed.text
-            ids = {j["id"] for j in listed.json()["active"]}
-            assert original.json()["id"] in ids
-            assert correction.json()["id"] in ids
+            body = listed.json()
+            # story #2308: judgment(original)은 active, method_error(correction)는 corrections.
+            assert original.json()["id"] in {j["id"] for j in body["active"]}
+            assert correction.json()["id"] in {j["id"] for j in body["corrections"]}
         finally:
             await client.aclose()
     finally:


### PR DESCRIPTION
## Summary
- `judgment_core.list_judgments`의 캡 예외가 `kind=="retraction"` 하나만 덮고 있었다 — 근인은 AC 문구 「retractions는 상한과 무관하게 전량」이 집합의 정의 대신 원소 이름 하나를 쓴 것(정확한 독해였지만 구현을 좁혔다, PO 자백).
- 결과: `retraction`·`refinement`·`method_error` 셋 중 가장 넓게 번지는 `method_error`(그 판단 + 같은 방법으로 낸 다른 모든 말을 무효화)가 recency 캡에 가장 먼저 걸리는, 설계 목적과 정반대인 상태였다.
- `TARGET_REQUIRED_KINDS`(모델에 이미 있는 상수)를 캡 예외 집합으로 직접 파생 — 종류를 손으로 나열하지 않는다.

## ⚠️ 응답 계약 변경
- `retractions` → `corrections`(retraction·refinement·method_error 셋을 담는 실제 내용에 맞춘 이름)
- `meta.capped`/`cap_basis`/`omitted_count` → `meta.active_capped`/`active_cap_basis`/`active_omitted_count` — 잘리는 쪽은 항상 active뿐(corrections는 캡 예외)이라는 사실을 필드 이름 자체가 말하게 한다(AC3).
- 소비자 확인(import 그래프 + 호출경로/HTTP경로 두 축 grep): router 스키마·MCP 도구 wrapper 2곳(`sprintable_mcp/tools/judgments.py`·`server.py`)·이 저장소 realdb 테스트뿐. FE/타 서비스 소비자 0건(기능 자체가 어제 신설, 오늘 첫 라이브 사용). 저장값이 아니라 매 조회 계산값이라 별도 마이그레이션 없이 한 커밋에서 전 소비자 함께 갱신.

## 부수 효과(설계 그대로)
refinement/method_error가 이제 corrections로 이동해 active에서 빠진다 — 기존 realdb 테스트 2건이 method_error를 active에서 찾도록 짜여 있어(구버전 버그를 그대로 인코딩한 상태) 함께 갱신했다.

## 검증
- 신규 realdb 테스트: 캡보다 많은 판단을 넣고 retraction·refinement·method_error 셋 다 섞어 전량 생존 확인
- 양성대조: 캡 예외를 `kind=="retraction"`으로 되돌려 RED 확認(corrections 3건 기대가 1건으로 깨짐) → 원복 → `git status` 무변경 확認
- 전체 회귀 `-k "not realdb"` 4212 pass(7 fail 전부 기존 미관련 베이스라인)
- judgments 관련 realdb 21/21 GREEN(alembic head 기준)

## Test plan
- [x] 신규 realdb 테스트(정정 3종 전량 생존) GREEN
- [x] 기존 realdb 테스트 2건 corrections 계약에 맞춰 갱신 후 GREEN
- [x] 양성대조 RED→GREEN
- [x] 전체 회귀 무관련 확인
- [ ] CI 확인 대기

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>