### PR TITLE
[SID:2302] 채팅 임베드 칩/모달 — 종류별로 깨진 아이콘·색·링크를 한 레지스트리로

### DIFF
--- a/apps/web/src/components/chat/embed-card.entity-registry-parity.test.ts
+++ b/apps/web/src/components/chat/embed-card.entity-registry-parity.test.ts
@@ -1,0 +1,72 @@
+/**
+ * story #2302 AC2·AC5 — ENTITY_ICONS/ENTITY_COLORS/getEntityHref가 BE
+ * `reference_registry.py::ENTITY_RESOLVERS`와 어긋나면(등록된 종류를 FE가 모르는 채로 남으면)
+ * CI가 코드스캔으로 잡는다. 완전 동일은 요구하지 않는다 — `asset`은 registry 밖 FE 전용 타입
+ * (명시 예외, 이 파일에 그대로 선언). 가드가 자기 재료(backend 파일)를 못 찾으면 skip이 아니라
+ * 실패해야 한다(#2600에서 실제로 걸렸던 경로 — findRepoRoot는 그 교훈 그대로 재사용).
+ */
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { ENTITY_ICONS } from './embed-card';
+
+function findRepoRoot(startDir: string): string {
+  let dir = startDir;
+  for (let i = 0; i < 10; i++) {
+    if (existsSync(join(dir, 'backend', 'app', 'services', 'reference_registry.py'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(`레포 루트(backend/app/services/reference_registry.py를 포함하는 조상)를 ${startDir}에서 못 찾았다`);
+}
+
+function parseBackendEntityResolvers(): Set<string> {
+  const repoRoot = findRepoRoot(process.cwd());
+  const path = resolve(repoRoot, 'backend/app/services/reference_registry.py');
+  const source = readFileSync(path, 'utf-8');
+  const m = source.match(/ENTITY_RESOLVERS:\s*dict\[str,\s*EntityExistsResolver\]\s*=\s*\{([^}]*)\}/);
+  if (!m) throw new Error('ENTITY_RESOLVERS 정의를 reference_registry.py에서 못 찾았다 — 이 테스트 자체가 오탐 아닌지 먼저 확인');
+  const keys = [...m[1]!.matchAll(/"([^"]+)"\s*:/g)].map((mm) => mm[1]!);
+  return new Set(keys);
+}
+
+function parseFeSwitchKeys(source: string, functionSignature: RegExp): Set<string> {
+  const m = source.match(functionSignature);
+  if (!m) throw new Error('대상 함수 정의를 embed-card.tsx에서 못 찾았다 — 리팩터로 형태가 바뀌었으면 이 정규식도 갱신');
+  return new Set([...m[1]!.matchAll(/case '([^']+)':/g)].map((mm) => mm[1]!));
+}
+
+// asset은 BE reference_registry.py 밖의 FE 전용 타입(embed-card.tsx 주석 — 채팅 첨부는
+// mention_parser.py write-path가 하드코딩 source_type으로 직접 다뤄 target-resolver가 없다).
+const FE_ONLY_TYPES = new Set(['asset']);
+
+describe('embed-card.tsx 엔티티 키 집합 ↔ BE ENTITY_RESOLVERS 코드스캔 동기화', () => {
+  it('BE에 등록된 종류를 ENTITY_ICONS가 전부 안다(asset은 의도적 예외 — 아이콘 없이 글자로)', () => {
+    const backendTypes = parseBackendEntityResolvers();
+    const feIconTypes = new Set(Object.keys(ENTITY_ICONS));
+    // ENTITY_ICONS는 asset을 일부러 안 갖는다(embed-card.tsx 상단 주석) — 그래서 정확히 BE와 같아야 한다.
+    expect(feIconTypes).toEqual(backendTypes);
+  });
+
+  it('BE에 등록된 종류를 ENTITY_COLORS가 전부 안다(+ asset 예외 포함)', () => {
+    const backendTypes = parseBackendEntityResolvers();
+    const source = readFileSync(resolve(__dirname, 'embed-card.tsx'), 'utf-8');
+    const m = source.match(/const ENTITY_COLORS: Record<string, string> = \{([\s\S]*?)\n\};/);
+    if (!m) throw new Error('ENTITY_COLORS 정의를 embed-card.tsx에서 못 찾았다 — 리팩터로 형태가 바뀌었으면 이 정규식도 갱신');
+    const feColorTypes = new Set([...m[1]!.matchAll(/^\s*(\w+):/gm)].map((mm) => mm[1]!));
+    for (const t of backendTypes) expect(feColorTypes.has(t)).toBe(true);
+    expect(feColorTypes).toEqual(new Set([...backendTypes, ...FE_ONLY_TYPES]));
+  });
+
+  it('BE에 등록된 종류를 getEntityHref가 전부 안다(+ asset 예외 포함) — default 캐치올로 몰래 넘기지 않는다', () => {
+    const backendTypes = parseBackendEntityResolvers();
+    const source = readFileSync(resolve(__dirname, 'embed-card.tsx'), 'utf-8');
+    const feHrefTypes = parseFeSwitchKeys(
+      source,
+      /export function getEntityHref\(entityType: string, entityId: string\): string \| null \{\s*switch \(entityType\) \{([\s\S]*?)\n {4}default:/,
+    );
+    for (const t of backendTypes) expect(feHrefTypes.has(t)).toBe(true);
+    expect(feHrefTypes).toEqual(new Set([...backendTypes, ...FE_ONLY_TYPES]));
+  });
+});

--- a/apps/web/src/components/chat/embed-card.link-states.test.tsx
+++ b/apps/web/src/components/chat/embed-card.link-states.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+//
+// story #2302 — 채팅 임베드 칩(EntityChip)/카드(EmbedCard)가 종류마다 다르게 깨지던 것: epic
+// 링크 404(AC1), task/artifact가 "담긴 곳"으로 못 감(AC3), hypothesis/evidence가 무한
+// 스피너였던 것(자체발견 잠복 결함). 실제 렌더 경로(마크다운 토큰→EntityChip→클릭→
+// EntityPreviewModal, chat-bubble.tsx 확認)를 그대로 태워 검증한다 — base-ui Dialog는
+// document.body에 포탈되므로 assertion은 body를 본다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { EmbedCard, getEntityHref } from './embed-card';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+function stubFetch(impl: (url: string) => Promise<{ ok: boolean; json: () => Promise<unknown> }>) {
+  vi.stubGlobal('fetch', vi.fn((url: string) => impl(url)));
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  document.querySelectorAll('[data-slot="dialog-portal"], [role="dialog"]').forEach((el) => el.remove());
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+async function openCard() {
+  const btn = container.querySelector('button');
+  await act(async () => {
+    btn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+  });
+}
+
+async function flush(times = 4) {
+  await act(async () => {
+    for (let i = 0; i < times; i++) await Promise.resolve();
+  });
+}
+
+describe('AC1 — epic 링크가 은퇴한 /epics/ 대신 실재 라우트로 간다', () => {
+  it('getEntityHref("epic", id)가 /goals/{id}를 반환한다(404였던 /epics/ 아님)', () => {
+    expect(getEntityHref('epic', 'e1')).toBe('/goals/e1');
+  });
+});
+
+describe('AC3/AC4 — task는 부모 story로("담긴 곳으로 갑니다")', () => {
+  it('task 상세 fetch가 story_id를 주면 풋터가 파랑 링크 "담긴 곳으로 갑니다"·/board?story=로 간다', async () => {
+    stubFetch(async (url) => {
+      expect(url).toContain('/api/tasks/');
+      return { ok: true, json: async () => ({ data: { story_id: 's-parent-1' } }) };
+    });
+    await act(async () => {
+      root.render(<EmbedCard entity_type="task" entity_id="t1" title="작업 A" status={null} />);
+    });
+    await openCard();
+    await flush();
+    const link = document.querySelector('a[href="/board?story=s-parent-1"]');
+    expect(link).not.toBeNull();
+    expect(link!.textContent).toContain('담긴 곳으로 갑니다');
+  });
+});
+
+describe('AC3/AC4 — artifact는 레코드마다 갈린다(FK 있으면 ②, 전부 없으면 ③)', () => {
+  it('story_id가 있는 artifact는 "담긴 곳으로 갑니다"로 그 story로 간다', async () => {
+    stubFetch(async () => ({
+      ok: true,
+      json: async () => ({ data: { story_id: 's-1', epic_id: null, doc_id: null } }),
+    }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="artifact" entity_id="a1" title="목업 A" status={null} />);
+    });
+    await openCard();
+    await flush();
+    const link = document.querySelector('a[href="/board?story=s-1"]');
+    expect(link).not.toBeNull();
+    expect(link!.textContent).toContain('담긴 곳으로 갑니다');
+  });
+
+  it('epic_id만 있으면 그 epic(/goals/)으로 간다', async () => {
+    stubFetch(async () => ({
+      ok: true,
+      json: async () => ({ data: { story_id: null, epic_id: 'e-9', doc_id: null } }),
+    }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="artifact" entity_id="a2" title="목업 B" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(document.querySelector('a[href="/goals/e-9"]')).not.toBeNull();
+  });
+
+  it('전부 null(독립 artifact)이면 회색·행동0 "열 수 있는 화면이 없습니다"(거짓 링크 금지)', async () => {
+    stubFetch(async () => ({
+      ok: true,
+      json: async () => ({ data: { story_id: null, epic_id: null, doc_id: null } }),
+    }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="artifact" entity_id="a3" title="독립 목업" status={null} />);
+    });
+    await openCard();
+    await flush();
+    // 링크가 없어야 한다 — 있으면 "갈 수 있다고 말하고 배신하는"(유나 판정) 거짓.
+    expect(document.querySelectorAll('a[href^="/goals/"], a[href^="/board?story="], a[href^="/docs?id="]').length).toBe(0);
+    expect(document.body.textContent).toContain('열 수 있는 화면이 없습니다');
+  });
+});
+
+describe('AC4 — hypothesis·evidence는 고정 ③(fetch 자체를 안 함, 무한 스피너 자체발견 회귀가드)', () => {
+  it('hypothesis는 fetch를 시도하지 않고 즉시 "열 수 있는 화면이 없습니다"를 보인다(무한 스피너 아님)', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    await act(async () => {
+      root.render(<EmbedCard entity_type="hypothesis" entity_id="h1" title="가설 A" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(document.body.textContent).not.toContain('불러오는 중');
+    expect(document.body.textContent).toContain('열 수 있는 화면이 없습니다');
+  });
+
+  it('evidence도 동일 — #2314(GET /api/v2/evidence/{id}) 개통 전까지 임시 ③', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    await act(async () => {
+      root.render(<EmbedCard entity_type="evidence" entity_id="ev1" title="증거 A" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(document.body.textContent).not.toContain('불러오는 중');
+    expect(document.body.textContent).toContain('열 수 있는 화면이 없습니다');
+  });
+});
+
+describe('AC4 — 조회 실패(대상 사라짐)는 "대상이 없습니다"로 다른 문구·회색', () => {
+  it('task 상세 fetch가 실패하면 ㉠ "대상이 없습니다"를 보인다(㉡-b "열 수 있는 화면이 없습니다"와 문구가 다르다)', async () => {
+    stubFetch(async () => ({ ok: false, json: async () => ({}) }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="task" entity_id="t-gone" title="사라진 작업" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(document.body.textContent).toContain('대상이 없습니다');
+    expect(document.body.textContent).not.toContain('열 수 있는 화면이 없습니다');
+  });
+});

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -5,35 +5,89 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { ExternalLink, X, FileText, File, Layers, CheckSquare, Hash, Eye, type LucideIcon } from 'lucide-react';
+import {
+  ExternalLink, X, FileText, File, Layers, CheckSquare, Eye,
+  Calendar, Image, FlaskConical, Paperclip, type LucideIcon,
+} from 'lucide-react';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { docViewUrl } from '@/components/docs/lib/doc-project-url';
+import { initials } from '@/lib/storage/format';
 
-// 글리프(📋📄🎯✅) → lucide. 타입 식별=아이콘·색은 신호 토큰만(다크 무파손).
+// story #2302 — 이 8종은 BE reference_registry.py ENTITY_RESOLVERS 와 키 집합이 같아야 한다
+// (AC2·AC5, entity-icons.registry-parity.test.ts 가 코드스캔으로 대조). `asset`은 registry
+// 밖 FE 전용 타입(AC5 명시 예외) — 아이콘을 **일부러** 안 준다: asset은 이미지/PDF/영상 등
+// content-type이 제각각이라 타입 레벨 단일 아이콘이 의미가 없고(개별 파일 아이콘은
+// getFileIcon이 파일별로 처리), "아이콘 없으면 이름 글자로"가 AC4가 못박은 **기본값**이지
+// asset만의 예외 처리가 아니다 — 그래서 이 fallback은 `resolveEntityIcon()`이 모든 타입에
+// 공통 적용한다(Hash 캐치올을 버림 — 있지도 않은 아이콘을 그리는 거짓보다 글자가 정직하다).
 export const ENTITY_ICONS: Record<string, LucideIcon> = {
   story: FileText,
   doc: File,
   epic: Layers,
   task: CheckSquare,
+  sprint: Calendar,
+  artifact: Image,
+  hypothesis: FlaskConical,
+  evidence: Paperclip,
 };
 
+/** ENTITY_ICONS에 없는 타입(지금은 asset뿐) → 아이콘 대신 이름 첫 글자(들). 예외 처리 아님(위 주석). */
+export function resolveEntityIcon(entityType: string): LucideIcon | null {
+  return ENTITY_ICONS[entityType] ?? null;
+}
+
+/** 아이콘이 없는 타입(asset)의 렌더 지점 3곳(모달 헤더·EmbedCard·EntityChip)이 각자 Hash로
+ * 캐치올하지 않고 한 곳에서 초성/이니셜 폴백을 공유하게 — 새 타입이 추가돼도 렌더 지점마다
+ * 따로 안 고쳐도 된다. Icon은 호출부에서 미리 resolve해 prop으로 받는다(레포 관례 —
+ * storage-file-glyph.tsx 동일 주석: 컴포넌트 스코프 안에서 lookup한 컴포넌트를 바로 JSX로 쓰면
+ * `react-hooks/static-components`에 걸린다). */
+function EntityGlyph({ Icon, label, className }: { Icon: LucideIcon | null; label: string; className?: string }) {
+  if (Icon) return <Icon className={className ?? 'size-4 shrink-0'} />;
+  return <span className={`flex items-center justify-center text-[10px] font-bold ${className ?? 'size-4 shrink-0'}`}>{initials(label)}</span>;
+}
+
 // 엔티티 신호 토큰(하드코딩 blue/purple/emerald/slate 제거·다크 자동 정합). 타입별 절제 틴트.
+// ⛔AC4: ②/③(담긴 곳으로 보내거나 갈 곳이 없는) 상태에서는 이 틴트를 쓰지 않고 GRAY_STATE_COLOR로
+// 덮어쓴다(회색 하나로 통일 — 노랑 금지 근거는 그 상수 주석 참고). 여기 있는 색은 **①일 때만** 보인다.
 const ENTITY_COLORS: Record<string, string> = {
   story: 'border-info/30 bg-info/8 text-foreground',
   doc: 'border-border bg-muted/40 text-foreground',
   epic: 'border-secondary bg-secondary/40 text-foreground',
   task: 'border-success/30 bg-success/8 text-foreground',
+  sprint: 'border-warning/30 bg-warning/8 text-foreground',
+  artifact: 'border-info/30 bg-info/8 text-foreground',
+  hypothesis: 'border-border bg-muted/40 text-foreground',
+  evidence: 'border-border bg-muted/40 text-foreground',
   // S6: 스토리지 자산 토큰 — info 틴트(파일 아이콘은 content-type 의존이라 AssetEmbedCard 에서 getFileIcon 처리).
   asset: 'border-info/30 bg-info/8 text-foreground',
 };
 
+// ⛔AC4 색 규율: 노랑 금지 — 노랑은 "기다리면 풀리는 것"인데 ②/③은 사용자가 기다려서 풀 수
+// 있는 상태가 아니다(담긴 곳으로 보내거나, 애초에 갈 곳이 없는 것). 구별은 색이 아니라 말로.
+export const GRAY_STATE_COLOR = 'border-border bg-muted/40 text-muted-foreground';
+
+/** story #2302 — task·evidence는 항상 담긴 곳(②) 또는 미승격(③) 판정에 own-href가 없다(모델
+ * FK 그대로: Task.story_id/Evidence.work_item_id 항상 NOT NULL — 항상 유일한 부모, 모호함 0).
+ * hypothesis는 링크테이블 3종(epic/story/sprint 다대다)이라 "담긴 곳 하나"를 정할 수 없어 항상
+ * ③(만료조건: hypothesis 전용 화면이 생기면 ①로 승격). artifact는 story_id/epic_id/doc_id가
+ * 전부 nullable·최대 1개뿐이라(hypothesis처럼 여럿 동시가능이 아님) 레코드마다 갈린다 —
+ * EntityPreviewModal이 fetch한 detail로 판정(이 함수는 own-href만 다뤄 null 반환).
+ * evidence는 #2314(GET /api/v2/evidence/{id} 개통) 전까지 임시 ③ — 그 라우트가 열리면 이 값을
+ * task와 동형으로 승격한다(PO 확認, 2026-07-29).
+ */
 export function getEntityHref(entityType: string, entityId: string): string | null {
   switch (entityType) {
     case 'story': return `/board?story=${entityId}`;
     case 'doc': return `/docs?id=${entityId}`;
-    case 'epic': return `/epics/${entityId}`;
+    // AC1 — 은퇴한 이름(/epics/)이 주소로 남아 404였다. 모델은 Goal, 화면은 goals/[id]/page.tsx.
+    case 'epic': return `/goals/${entityId}`;
+    // sprint는 sprints-client.tsx가 `?id=`를 실제로 읽어 자동선택한다(딥링크 주석 확認됨) — ①.
+    case 'sprint': return `/sprints?id=${entityId}`;
     case 'asset': return `/storage?asset=${entityId}`;
-    case 'task': return null;
+    case 'task': return null; // ② — 부모 story_id는 EntityPreviewModal이 fetch 후 판정.
+    case 'artifact': return null; // 레코드마다 ②/③ — 위 함수 doc 참고.
+    case 'hypothesis': return null; // ③ 고정 — 위 함수 doc 참고.
+    case 'evidence': return null; // ③ 임시(#2314 대기) — 위 함수 doc 참고.
     default: return null;
   }
 }
@@ -56,6 +110,11 @@ const ENTITY_API: Record<string, (id: string) => string> = {
   story: (id) => `/api/stories/${id}`,
   epic: (id) => `/api/goals/${id}`,
   asset: (id) => `/api/assets/${id}`,
+  // story #2302 — task.story_id(항상 유일 부모)·artifact.{story_id,epic_id,doc_id}(최대 1개,
+  // 전부 nullable)를 읽어 ②/③을 레코드 단위로 판정하는 재료. hypothesis·evidence는 의도적으로
+  // 여기 없다(위 getEntityHref 주석 참고 — 애초에 fetch할 필요가 없는 고정 ③).
+  task: (id) => `/api/tasks/${id}`,
+  artifact: (id) => `/api/visual-artifacts/${id}`,
 };
 
 const MdBadge = ({ label }: { label: string }) => (
@@ -150,8 +209,17 @@ function EntityPreviewModal({
   href: string | null;
   onClose: () => void;
 }) {
+  // story #2302 — hypothesis·evidence는 fetch 자체를 안 한다(항상 고정 ③, ENTITY_API에 항목
+  // 없음) — 예전 코드는 'task'만 예외 취급해 loading을 false로 시작했는데, ENTITY_API에 없는
+  // 다른 타입(hypothesis·evidence·미등록 타입)은 아래 effect의 `if (!url) return` 이 loading을
+  // 영영 false로 안 만들어 **무한 스피너**였다(실측으로 발견 — 이 스토리가 고치기 전까지 잠복
+  // 결함). fetch 전략이 있는 타입(doc 특수분기 포함)만 loading=true로 시작한다.
+  const hasFetchStrategy = entityType === 'doc' || Boolean(ENTITY_API[entityType]);
   const [detail, setDetail] = useState<Record<string, unknown> | null>(null);
-  const [loading, setLoading] = useState(entityType !== 'task');
+  const [loading, setLoading] = useState(hasFetchStrategy);
+  // ㉠ "대상이 없습니다" 판정 — fetch를 **시도했는데** 실패한 경우만 켠다(fetch를 아예 안 하는
+  // hypothesis·evidence는 "존재하는지 모른다"이지 "없다"가 아니다 — 다른 결론을 함부로 안 낸다).
+  const [notFound, setNotFound] = useState(false);
   // #2168 PR-①: docPreview 가 이 doc이 실제로 속한 project(project_id)+경로 세그먼트
   // (org_slug/project_slug)를 함께 내려준다 — "현재 프로젝트"(useDashboardContext)를 더는
   // 추측에 쓰지 않는다. 크로스프로젝트 임베드(다른 project 문서가 채팅에 임베드된 경우)는
@@ -194,7 +262,7 @@ function EntityPreviewModal({
           const docJson = (await docRes.json()) as { data?: Record<string, unknown> };
           if (!cancelled) setDetail(docJson.data ?? null);
         } catch {
-          /* fetch 실패 시 fallback만 표시 */
+          if (!cancelled) setNotFound(true); // ㉠ — preview 해소든 본문 조회든 실패=대상이 없다.
         } finally {
           if (!cancelled) setLoading(false);
         }
@@ -203,30 +271,62 @@ function EntityPreviewModal({
     }
 
     const url = ENTITY_API[entityType]?.(entityId);
-    if (!url) return;
+    if (!url) return; // hypothesis·evidence 등 — fetch 전략 자체가 없다(loading도 이미 false로 시작).
     fetch(url)
       .then((r) => r.ok ? r.json() : Promise.reject())
       .then((json) => { if (!cancelled) setDetail((json as { data?: Record<string, unknown> }).data ?? json as Record<string, unknown>); })
-      .catch(() => { /* fetch 실패 시 fallback만 표시 */ })
+      .catch(() => { if (!cancelled) setNotFound(true); }) // ㉠ — 조회 실패=대상이 없다(story #2299 still_exists와 같은 원리).
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, [entityType, entityId]);
+  }, [entityType, entityId, hasFetchStrategy]);
 
-  const Icon = ENTITY_ICONS[entityType] ?? Hash;
-  const colorClass = ENTITY_COLORS[entityType] ?? 'border-border bg-muted text-foreground';
+  const colorClass = ENTITY_COLORS[entityType] ?? GRAY_STATE_COLOR;
   const label = title ?? entityId;
-  // #2168 PR-①: org_slug+project_slug 가 있으면 `/{ws}/{proj}/docs/{slug}/view`로 직행 —
-  // CURRENT_PROJECT_COOKIE 기반 middleware 추측(proxy.ts redirectLegacyResourcePath, "현재
-  // 프로젝트"만 봄)을 거치지 않아 크로스프로젝트에서도 항상 맞는 project 로 착지한다.
-  // project_slug 가 없으면(옛 미백필 프로젝트, Project.slug nullable) 예전 bare 링크로 우아하게
-  // 폴백 — 그 경우는 기존과 동일하게 middleware 추측에 의존(회귀 아님, 기존 동작 유지).
-  const resolvedHref = entityType === 'doc'
-    ? (docPreview
-        ? (docPreview.orgSlug && docPreview.projectSlug
-            ? docViewUrl(docPreview.orgSlug, docPreview.projectSlug, docPreview.slug)
-            : `/docs/${docPreview.slug}/view`)
-        : null)
-    : href;
+
+  // story #2302 AC3 — ①own-href(정적) / ②via-parent(레코드 fetch 필요) / ③없음, 세 갈래를
+  // "카드 전체를 죽이지 않는다"(AC4) 원칙대로 여기서만 계산 — 헤더의 아이콘·제목·상태는 이 값과
+  // 무관하게 항상 그대로 보인다(아래 return, 안 바뀜). 바뀌는 건 풋터의 링크/문구뿐이다.
+  type LinkKind = 'own' | 'via-parent' | null;
+  let resolvedHref: string | null;
+  let linkKind: LinkKind;
+  if (entityType === 'doc') {
+    // #2168 PR-①: org_slug+project_slug 가 있으면 `/{ws}/{proj}/docs/{slug}/view`로 직행 —
+    // CURRENT_PROJECT_COOKIE 기반 middleware 추측(proxy.ts redirectLegacyResourcePath, "현재
+    // 프로젝트"만 봄)을 거치지 않아 크로스프로젝트에서도 항상 맞는 project 로 착지한다.
+    // project_slug 가 없으면(옛 미백필 프로젝트, Project.slug nullable) 예전 bare 링크로 우아하게
+    // 폴백 — 그 경우는 기존과 동일하게 middleware 추측에 의존(회귀 아님, 기존 동작 유지).
+    resolvedHref = docPreview
+      ? (docPreview.orgSlug && docPreview.projectSlug
+          ? docViewUrl(docPreview.orgSlug, docPreview.projectSlug, docPreview.slug)
+          : `/docs/${docPreview.slug}/view`)
+      : null;
+    linkKind = resolvedHref ? 'own' : null;
+  } else if (entityType === 'task') {
+    // ② — Task.story_id는 NOT NULL(항상 유일 부모). fetch 전이면 아직 null(풋터는 loading이 가림).
+    const storyId = (detail as { story_id?: string } | null)?.story_id ?? null;
+    resolvedHref = storyId ? `/board?story=${storyId}` : null;
+    linkKind = resolvedHref ? 'via-parent' : null;
+  } else if (entityType === 'artifact') {
+    // 레코드마다 갈린다(story #2302 그라운딩) — story_id/epic_id/doc_id 전부 nullable·최대 1개
+    // (hypothesis의 다대다 링크테이블과 다른 모양이라 "하나 고르면 나머지를 숨기는 거짓"이 될
+    // 위험이 없다). 우선순위는 story>epic>doc — 동시에 여럿 있을 수 없어(모델 제약은 아니지만
+    // 실질적으로 최대 1개라는 그라운딩 전제) 순서 자체가 결과를 바꾸지 않는다.
+    const d = detail as { story_id?: string | null; epic_id?: string | null; doc_id?: string | null } | null;
+    const parentHref = d?.story_id ? `/board?story=${d.story_id}`
+      : d?.epic_id ? `/goals/${d.epic_id}`
+      : d?.doc_id ? `/docs?id=${d.doc_id}`
+      : null;
+    resolvedHref = parentHref;
+    linkKind = parentHref ? 'via-parent' : null;
+  } else if (entityType === 'hypothesis' || entityType === 'evidence') {
+    // ③ 고정(hypothesis) / ③ 임시(evidence, #2314 대기) — 위 getEntityHref 주석 참고.
+    resolvedHref = null;
+    linkKind = null;
+  } else {
+    // story·epic·sprint·asset — 전부 own-href를 동기로 아는 ①. href prop 그대로 신뢰.
+    resolvedHref = href;
+    linkKind = href ? 'own' : null;
+  }
 
   return (
     <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
@@ -234,7 +334,7 @@ function EntityPreviewModal({
         {/* Header */}
         <div className="flex-shrink-0 flex items-start gap-3 px-6 pt-5 pb-3 border-b border-border">
           <div className={`flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm ${colorClass} flex-1 min-w-0`}>
-            <Icon className="size-4 shrink-0" />
+            <EntityGlyph Icon={resolveEntityIcon(entityType)} label={label} />
             <DialogTitle className="font-semibold truncate text-sm">{label}</DialogTitle>
             {status ? (
               <span className="ml-auto shrink-0 rounded px-1.5 py-0.5 text-xs bg-black/10 dark:bg-white/10">{status}</span>
@@ -256,23 +356,32 @@ function EntityPreviewModal({
               <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
               불러오는 중…
             </div>
-          ) : detail ? (
+          ) : notFound ? (
+            <p className="text-xs text-muted-foreground py-4">대상을 찾을 수 없습니다.</p>
+          ) : detail && (entityType === 'story' || entityType === 'epic' || entityType === 'doc') ? (
             <EntityDetail entityType={entityType} detail={detail} />
-          ) : entityType === 'task' ? (
-            <p className="text-xs text-muted-foreground py-4">이 엔티티는 별도 페이지가 없습니다.</p>
-          ) : null}
+          ) : (
+            <p className="text-xs text-muted-foreground py-4">이 엔티티는 별도 미리보기가 없습니다.</p>
+          )}
         </div>
-        {/* Footer */}
-        {resolvedHref && (
+        {/* Footer — story #2302 AC4: ㉠/㉡-b는 회색·기본커서로 "죽는 건 링크뿐"(카드 전체 안
+            죽음). 색은 회색 하나(노랑 금지 — 위 GRAY_STATE_COLOR 주석 참고), 구별은 문구로. */}
+        {!loading && (
           <div className="flex-shrink-0 px-6 py-3 border-t border-border">
-            <Link
-              href={resolvedHref}
-              onClick={onClose}
-              className="flex items-center gap-1.5 text-sm text-primary hover:underline"
-            >
-              <ExternalLink className="h-3.5 w-3.5" />
-              전체 보기
-            </Link>
+            {notFound ? (
+              <span className="flex cursor-default items-center gap-1.5 text-sm text-muted-foreground">대상이 없습니다</span>
+            ) : resolvedHref ? (
+              <Link
+                href={resolvedHref}
+                onClick={onClose}
+                className="flex items-center gap-1.5 text-sm text-primary hover:underline"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+                {linkKind === 'via-parent' ? '담긴 곳으로 갑니다' : '전체 보기'}
+              </Link>
+            ) : (
+              <span className="flex cursor-default items-center gap-1.5 text-sm text-muted-foreground">열 수 있는 화면이 없습니다</span>
+            )}
           </div>
         )}
       </DialogContent>
@@ -284,8 +393,7 @@ export function EmbedCard({ entity_type, entity_id, title, status }: EmbedCardDa
   const [showModal, setShowModal] = useState(false);
   const [navigating, setNavigating] = useState(false);
   const router = useRouter();
-  const Icon = ENTITY_ICONS[entity_type] ?? Hash;
-  const colorClass = ENTITY_COLORS[entity_type] ?? 'border-border bg-muted text-foreground';
+  const colorClass = ENTITY_COLORS[entity_type] ?? GRAY_STATE_COLOR;
   const href = getEntityHref(entity_type, entity_id);
   const label = title ?? entity_id;
 
@@ -317,7 +425,7 @@ export function EmbedCard({ entity_type, entity_id, title, status }: EmbedCardDa
 
   const inner = (
     <div className={`flex items-center gap-2 rounded-md border px-3 py-2 text-sm ${colorClass}`}>
-      <Icon className="size-4 shrink-0" />
+      <EntityGlyph Icon={resolveEntityIcon(entity_type)} label={label} />
       <span className="font-medium">{label}</span>
       {status ? (
         <span className="ml-auto rounded px-1.5 py-0.5 text-xs bg-black/10 dark:bg-white/10">{status}</span>
@@ -339,7 +447,7 @@ export function EmbedCard({ entity_type, entity_id, title, status }: EmbedCardDa
             disabled={navigating}
             className="flex min-w-0 flex-1 items-center gap-2 text-left disabled:opacity-60"
           >
-            <Icon className="size-4 shrink-0" />
+            <EntityGlyph Icon={resolveEntityIcon(entity_type)} label={label} />
             <span className="min-w-0 flex-1 truncate font-medium">{label}</span>
             {status ? (
               <span className="shrink-0 rounded px-1.5 py-0.5 text-xs bg-black/10 dark:bg-white/10">{status}</span>
@@ -405,12 +513,11 @@ export function EntityChip({
   href: string | null;
 }) {
   const [showModal, setShowModal] = useState(false);
-  const Icon = ENTITY_ICONS[entityType] ?? Hash;
-  const colorClass = ENTITY_COLORS[entityType] ?? 'border-border bg-muted text-foreground';
+  const colorClass = ENTITY_COLORS[entityType] ?? GRAY_STATE_COLOR;
 
   const inner = (
     <span className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs font-medium ${colorClass}`}>
-      <Icon className="size-3 shrink-0" />
+      <EntityGlyph Icon={resolveEntityIcon(entityType)} label={label} className="size-3 shrink-0" />
       <span>{label}</span>
     </span>
   );

--- a/apps/web/src/components/storage/storage-view.deep-link.test.ts
+++ b/apps/web/src/components/storage/storage-view.deep-link.test.ts
@@ -1,0 +1,39 @@
+/**
+ * story #2302 AC1 — `/storage?asset=` 딥링크가 지금까지 사문(死文)이었다(searchParams를 읽는
+ * 코드 자체가 없었다). "첫 페이지에 있을 때만 되는 링크"는 반쪽 fix(PO 판정 — epic 404와 같은
+ * 부류: 갈 수 있다고 말하고 배신하는 것이 제일 나쁘다)라, 페이지에 없으면 무조건 포기하지 않고
+ * 단건조회 폴백으로 넘긴다는 판정 로직만 순수 함수로 검증한다.
+ */
+import { describe, expect, it } from 'vitest';
+import { resolveAssetDeepLinkAction } from './storage-view';
+
+const BASE = { projectId: 'p1', selectedAssetId: null as string | null, items: [] as { id: string }[], loading: false };
+
+describe('resolveAssetDeepLinkAction', () => {
+  it('asset 파라미터가 없으면 아무것도 안 한다', () => {
+    expect(resolveAssetDeepLinkAction({ ...BASE, assetId: null })).toEqual({ type: 'none' });
+  });
+
+  it('이미 그 asset이 선택돼 있으면 재실행하지 않는다(무한루프 방지)', () => {
+    expect(resolveAssetDeepLinkAction({ ...BASE, assetId: 'a1', selectedAssetId: 'a1' })).toEqual({ type: 'none' });
+  });
+
+  it('현재 로드된 페이지(items)에 있으면 그대로 선택한다 — fetch 불필요', () => {
+    expect(resolveAssetDeepLinkAction({ ...BASE, assetId: 'a1', items: [{ id: 'a1' }, { id: 'a2' }] }))
+      .toEqual({ type: 'select-from-page', assetId: 'a1' });
+  });
+
+  it('⛔현재 페이지에 없어도 «아직 로딩 중»이면 포기하지 않고 기다린다(첫 페이지 결과부터 본다)', () => {
+    expect(resolveAssetDeepLinkAction({ ...BASE, assetId: 'a1', items: [], loading: true }))
+      .toEqual({ type: 'wait' });
+  });
+
+  it('⭐로딩이 끝났는데도 현재 페이지에 없으면 단건조회 폴백으로 넘긴다(반쪽 링크 금지의 핵심)', () => {
+    expect(resolveAssetDeepLinkAction({ ...BASE, assetId: 'a1', items: [{ id: 'a2' }], loading: false }))
+      .toEqual({ type: 'fetch-fallback', assetId: 'a1' });
+  });
+
+  it('projectId가 없으면(아직 컨텍스트 미해소) 아무것도 안 한다', () => {
+    expect(resolveAssetDeepLinkAction({ ...BASE, assetId: 'a1', projectId: '' })).toEqual({ type: 'none' });
+  });
+});

--- a/apps/web/src/components/storage/storage-view.tsx
+++ b/apps/web/src/components/storage/storage-view.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
@@ -23,12 +24,40 @@ import type {
   StorageViewMode,
 } from '@/lib/storage/types';
 
+// story #2302 AC1 — `?asset=` 딥링크가 무엇을 해야 하는지의 판정만 순수 함수로 뽑아 둔다
+// (StorageView 전체를 렌더하지 않고도 이 결정 로직 자체를 단위테스트하기 위함 — 이 컴포넌트는
+// useDashboardContext/useContextualPanelState/useFocusTrap 등 컨텍스트가 많아 풀 렌더 테스트
+// 비용이 크다). 부수효과(fetch·setState)는 호출부(useEffect)에 그대로 둔다.
+export type AssetDeepLinkAction =
+  | { type: 'none' }
+  | { type: 'wait' }
+  | { type: 'select-from-page'; assetId: string }
+  | { type: 'fetch-fallback'; assetId: string };
+
+export function resolveAssetDeepLinkAction(params: {
+  assetId: string | null;
+  projectId: string;
+  selectedAssetId: string | null;
+  items: Pick<Asset, 'id'>[];
+  loading: boolean;
+}): AssetDeepLinkAction {
+  const { assetId, projectId, selectedAssetId, items, loading } = params;
+  if (!assetId || !projectId) return { type: 'none' };
+  if (selectedAssetId === assetId) return { type: 'none' }; // 이미 선택돼 있다 — 재실행 방지.
+  if (items.some((a) => a.id === assetId)) return { type: 'select-from-page', assetId };
+  // "첫 페이지에 있을 때만 되는" 반쪽 링크를 만들지 않기 위해(PO 판정 — epic 404와 같은 부류:
+  // 갈 수 있다고 말하고 배신하는 것이 제일 나쁘다) 못 찾으면 무조건 포기하지 않고 단건조회로 폴백한다.
+  if (loading) return { type: 'wait' }; // 첫 페이지 로드가 아직 안 끝났다 — 그 결과부터 보고 판단.
+  return { type: 'fetch-fallback', assetId };
+}
+
 // story a539c649 S3a/b: projectId 는 이제 page.tsx(headers() 경유 resolve 결과)가 prop 으로
 // 내려준다 — useDashboardContext()(전역 "현재 프로젝트")가 아니라 URL 이 가리키는 project.
 // projectName 은 순수 표시용(폴더 트리 헤더)이라 전역 컨텍스트 그대로 유지(artifacts와 동형).
 export function StorageView({ projectId }: { projectId: string }) {
   const t = useTranslations('storage');
   const { projectName } = useDashboardContext();
+  const searchParams = useSearchParams();
 
   const [folders, setFolders] = useState<Folder[]>([]);
   const [items, setItems] = useState<Asset[]>([]);
@@ -39,6 +68,13 @@ export function StorageView({ projectId }: { projectId: string }) {
 
   const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null);
   const [selectedAssetId, setSelectedAssetId] = useState<string | null>(null);
+  // story #2302 — `?asset=` 딥링크(embed-card getEntityHref('asset',...)·team-activity-view가
+  // 만드는 링크)가 지금까지 사문(死文)이었다(searchParams를 읽는 코드가 아예 없었다). items는
+  // 커서 페이지네이션이라 그 asset이 첫 페이지/현재 폴더에 없으면 `items.find`가 못 찾는데,
+  // "첫 페이지에 있을 때만 되는 링크"는 그 자체로 반쪽 fix(PO 판정 — epic 404와 같은 "갈 수
+  // 있다고 말하고 배신하는" 부류) — 그래서 fetch-by-id 폴백을 별도 state로 둔다(items에 억지로
+  // 끼워 넣지 않는다 — 다른 폴더 소속일 수 있어 목록 필터 의미를 깨지 않기 위함).
+  const [deepLinkedAsset, setDeepLinkedAsset] = useState<Asset | null>(null);
   const [viewMode, setViewMode] = useState<StorageViewMode>('list');
   const [sort, setSort] = useState<AssetSort>('date');
   const [order, setOrder] = useState<SortOrder>('desc');
@@ -151,6 +187,37 @@ export function StorageView({ projectId }: { projectId: string }) {
     })();
   }, [projectId, buildAssetsUrl]);
 
+  // story #2302 AC1(asset을 실제로 ①로 만든다) — `?asset=`이 가리키는 자산을 자동 선택한다.
+  // 현재(필터된) 페이지에 있으면 그대로 선택, 없으면(다른 폴더·다음 페이지) 단건 GET으로
+  // 폴백해서 가져온다 — "첫 페이지에 있을 때만 되는" 반쪽 링크를 만들지 않기 위해서다(PO 판정,
+  // epic 404와 같은 부류: 갈 수 있다고 말하고 배신하는 것이 제일 나쁘다).
+  useEffect(() => {
+    const action = resolveAssetDeepLinkAction({
+      assetId: searchParams.get('asset'), projectId, selectedAssetId, items, loading,
+    });
+    if (action.type === 'none' || action.type === 'wait') return;
+    if (action.type === 'select-from-page') {
+      setSelectedAssetId(action.assetId);
+      if (!detailPanel.supportsInlinePanel) setDetailDrawerOpen(true);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(`/api/assets/${action.assetId}`);
+        if (!res.ok) return; // 조용히 무시 — 대상이 없으면 그냥 선택되지 않는다(별도 에러 UI는 이 스코프 밖).
+        const json = (await res.json()) as { data?: Asset };
+        if (cancelled || !json.data) return;
+        setDeepLinkedAsset(json.data);
+        setSelectedAssetId(json.data.id);
+        if (!detailPanel.supportsInlinePanel) setDetailDrawerOpen(true);
+      } catch {
+        /* 조용히 무시 */
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [searchParams, projectId, selectedAssetId, items, loading, detailPanel.supportsInlinePanel, setDetailDrawerOpen]);
+
   const handleRetry = useCallback(() => {
     // buildAssetsUrl 의존성은 동일하므로 강제 재요청을 위해 effectiveSearch 토글 대신 재-set
     setError(false);
@@ -257,8 +324,9 @@ export function StorageView({ projectId }: { projectId: string }) {
   );
 
   const selectedAsset = useMemo(
-    () => items.find((a) => a.id === selectedAssetId) ?? null,
-    [items, selectedAssetId],
+    () => items.find((a) => a.id === selectedAssetId)
+      ?? (deepLinkedAsset?.id === selectedAssetId ? deepLinkedAsset : null),
+    [items, selectedAssetId, deepLinkedAsset],
   );
 
   // 요약 칩: 로드된 집합 기준(전체 카운트 전용 엔드포인트 부재 — 가정/NOTE).


### PR DESCRIPTION
## 요약
채팅 메시지에 임베드된 엔티티 토큰(`entity:<종류>:<uuid>` → `EntityChip` → 클릭 시 `EntityPreviewModal`)이 종류마다 `ENTITY_ICONS`/`ENTITY_COLORS`/`getEntityHref`/`ENTITY_API` 4벌을 따로 관리하면서 어긋나 있었다 — epic 링크가 은퇴한 `/epics/`로 404, asset 아이콘 누락, artifact/sprint/task/hypothesis/evidence는 링크가 아예 없었다(갈 수 있는 곳이 있는데도).

**정정**: 스토리 제목이 원래 "채팅 임베드 **카드**"였으나, 그라운딩 중 실제 채팅 렌더 경로가 `EmbedCard`(정의 파일 밖 사용처 0건 — 데드코드)가 아니라 `EntityChip`→`EntityPreviewModal`임을 확인해 제목·본문을 정정했다(수정 지점은 동일 — 셋 다 같은 4개 상수를 공유).

## 분류(유나 판정 — 갈 곳이 있는가만 묻는다, 종류가 아니라)
```
story·doc·sprint·asset·artifact(FK 있음)  → ① 또는 ②, own/parent href 실재
task·evidence(#2314 대기)·artifact(FK 없음) → ② 담긴 곳 / ③ 없음
hypothesis                                → ③ 고정(다대다라 담긴 곳 하나로 못 정함)
```
- **AC1**: `getEntityHref('epic', id)` → `/goals/{id}`(모델은 Goal, 화면은 goals/[id]/page.tsx — 은퇴한 이름이 주소로 남아 404였다).
- **AC2/AC5**: `ENTITY_ICONS`/`ENTITY_COLORS`/`getEntityHref` 키 집합을 BE `reference_registry.py::ENTITY_RESOLVERS`(8종)와 코드스캔으로 대조(`embed-card.entity-registry-parity.test.ts`) — `asset`만 명시 예외(registry 밖 FE 전용).
- **AC3**: task(`Task.story_id` NOT NULL·항상 유일 부모)·evidence(`work_item_id/type` NOT NULL·항상 유일하나 **BE에 단건조회 라우트가 없어**(#2314) 임시 ③)는 모델 FK로 실측, artifact(`story_id/epic_id/doc_id` 전부 nullable·최대 1개)는 **레코드마다** ②/③이 갈린다(EntityPreviewModal이 fetch한 detail로 판정 — hypothesis처럼 "하나 골라 나머지를 숨기는 거짓"이 안 생기는 이유는 애초에 최대 1개뿐이라 모호함이 없어서).
- **AC4**: ㉠"대상이 없습니다"(fetch 실패·gone)/㉡-a"담긴 곳으로 갑니다"(via-parent)/㉡-b"열 수 있는 화면이 없습니다"(no-link) — 색은 회색 하나(노랑 금지, 사용자가 기다려서 풀 수 있는 상태가 아니므로), 카드 전체(아이콘·제목·상태)는 안 죽고 풋터의 링크/문구만 갈린다.
- **AC6**: 라우트 실재 판정은 `page.tsx` 존재가 아니라 "그 id로 그 항목을 여는 경로가 실제로 동작하는가"(searchParams를 읽어 쓰는가)로 — artifact/asset 최초 판정이 이 기준 부재로 틀렸던 것을 PO가 직접 잡아 재확定했다.

## asset 딥링크(`/storage?asset=`) — 사문(死文) 배선 + 반쪽 fix 방지
`storage-view.tsx`는 `selectedAssetId` state가 있었지만 `searchParams`를 읽는 코드가 아예 없어 `?asset=`은 항상 무동작이었다. 단순히 첫 페이지에서 찾아 선택하는 것만으로는 "첫 페이지에 있을 때만 되는 링크"(PO 판정 — epic 404와 같은 부류: 갈 수 있다고 말하고 배신하는 것이 제일 나쁘다)가 되므로, 못 찾으면(로딩 완료 후) 단건조회(`GET /api/assets/{id}`)로 폴백한다. 판정 로직은 `resolveAssetDeepLinkAction()`로 순수함수 추출해 단위테스트(`storage-view.deep-link.test.ts`, 첫 페이지에 있음/없음+로딩중/양쪽 다 없음 4갈래 + 가드 케이스).

## 자체발견 결함 (스코프 밖이지만 같은 파일에서 발견해 함께 고침)
`EntityPreviewModal`의 `loading` 상태가 `ENTITY_API`에 항목이 없는 타입(sprint·hypothesis·evidence 등)에서 `if (!url) return` 이후 `false`로 안 돌아와 **무한 스피너**였다 — fetch 전략이 있는 타입만 `loading=true`로 시작하도록 수정, 회귀가드 테스트 포함.

## 테스트
- `embed-card.entity-registry-parity.test.ts`: FE/BE 키 집합 코드스캔 대조 3건. mutation-verify로 `hypothesis` 키를 일부러 빼서 실제로 RED 되는 것 확인 후 복구.
- `embed-card.link-states.test.tsx`: epic href·task/artifact via-parent 링크·artifact 전체 null(거짓 링크 금지)·hypothesis/evidence 무한스피너 회귀가드·notFound "대상이 없습니다" 8건. mutation-verify 2건(artifact 거짓 링크 폴백, 스피너 버그) 모두 실제 RED 확인 후 복구.
- `storage-view.deep-link.test.ts`: 딥링크 판정 4갈래 + 가드.
- 전체 스윕: `tsc --noEmit` 0 errors · `eslint`(대상 파일) 0 warnings · `vitest run`(전체 리포) 306 files/2019 tests pass · `pnpm build` 성공.

## ⛔라이브 검증 — 배포 후 필요(머지≠라이브)
이 PR의 실제 화면 변화(epic 링크 정상 이동, task/artifact 모달 하단 링크, asset 딥링크)는 로컬 build/test까지만 확인했다. dev 배포 후 실제 채팅 화면에서 각 타입 임베드를 열어 확인하는 것이 남아있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)