### PR TITLE
fix(mcp): 벤더 사본↔원본 공통 상수 자동대조 가드 신설 + delete_sprint 잔존 해소 (#2311)

### DIFF
--- a/backend/sprintable_mcp/toolset.py
+++ b/backend/sprintable_mcp/toolset.py
@@ -38,8 +38,11 @@ _GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
     # (app/services/mcp_toolset.py 참고. "canonical_version"은 propose_canonical_version에
     # "artifact" substring이 없어 별도 키워드 필요, "spec_pin"은 핀 4종).
     ("canvas", ("artifact", "canonical_version", "spec_pin")),
+    # story #2311(2026-07-29): "delete_sprint" 제거 — E-SECURITY SEC-S8 확장으로 그 이름의
+    # 도구 자체가 이미 없다(원본 app/services/mcp_toolset.py에는 "제거했다"는 주석만 남아
+    # 있었는데 vendored 사본에만 실제 키워드로 잔존해 있었다 — 원본과 동기화).
     ("admin", ("give_reward", "emit_event", "trigger_ai", "activate_sprint",
-               "close_sprint", "delete_sprint", "create_sprint", "upsert_webhook", "delete_webhook")),
+               "close_sprint", "create_sprint", "upsert_webhook", "delete_webhook")),
 ]
 
 _CORE = "core"

--- a/backend/tests/test_s2311_vendor_const_sync.py
+++ b/backend/tests/test_s2311_vendor_const_sync.py
@@ -1,0 +1,175 @@
+"""story #2311 — infra/check_mcp_vendor_sync.py 회귀가드.
+
+배경: `backend/app/services/mcp_toolset.py`(원본) ↔ `backend/sprintable_mcp/toolset.py`
+(vendored 사본)가 값이 갈려도 아무도 못 잡던 구멍. 전례가 둘(P1-S12 lock_files/standup 누락,
+2026-07-29 delete_sprint 잔존) — 둘 다 「누가 우연히 볼 때까지」 발견 안 됐다.
+
+AC1: 대조 대상을 손으로 나열하지 않는다 — 양쪽 모듈에서 같은 이름을 가진 공개 상수를 자동으로
+찾아 비교한다. AC3: 실제 파싱(모듈 import+실행, 텍스트/블록 추출 아님)이라 `ALL_GROUPS`처럼
+계산식으로 된 상수도 올바르게 비교된다(예전 블록 추출 파서가 "완전일치"라는 거짓 답을 낸
+전례를 피한다). AC4: 재료(파일/공통 이름)를 못 찾으면 skip 대신 실패한다.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_INFRA_DIR = _REPO_ROOT / "infra"
+
+
+def _load_check_mcp_vendor_sync():
+    spec = importlib.util.spec_from_file_location(
+        "check_mcp_vendor_sync", _INFRA_DIR / "check_mcp_vendor_sync.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ── AC1: 자동 발견 — 손으로 나열한 목록이 아니라 실제 교집합 ────────────────────────
+
+def test_common_constants_are_auto_discovered_not_hardcoded():
+    """지금 리포에 실제로 공통 이름 6개가 있다 — 이 값이 이 테스트가 하드코딩한 «기대 목록»이
+    아니라 `find_matching_constants()`가 두 모듈을 실행해 스스로 찾은 결과임을 확認한다
+    (AC1: 새 상수가 양쪽에 추가되면 이 집합도 저절로 늘어난다 — 유지보수 불필요)."""
+    mod = _load_check_mcp_vendor_sync()
+    common = mod.find_matching_constants()
+    assert set(common) == {
+        "ALL_GROUPS", "_ALWAYS_ALLOWED", "_CORE", "_DESTRUCTIVE_SCOPES",
+        "_GROUP_KEYWORDS", "_LEGACY_SCOPES",
+    }
+
+
+def test_future_annotations_feature_is_not_counted_as_a_constant():
+    """`from __future__ import annotations`가 두 파일 모두에 있어 `annotations`라는 이름이
+    양쪽 최상위에 바인딩되지만, 이건 실제 데이터 상수가 아니라 언어 기능 객체다 — 대조 대상에서
+    빠져야 한다."""
+    mod = _load_check_mcp_vendor_sync()
+    common = mod.find_matching_constants()
+    assert "annotations" not in common
+
+
+# ── AC2: 지금 있는 차이가 실제로 없어졌다 ───────────────────────────────────────
+
+def test_repo_current_state_has_no_mismatches():
+    """리포에 실제로 커밋된 두 파일이 지금 완전히 동일하다 — delete_sprint 잔존이 해소됐다."""
+    mod = _load_check_mcp_vendor_sync()
+    assert mod.mismatches() == []
+
+
+def test_main_returns_zero_on_repo_current_state():
+    mod = _load_check_mcp_vendor_sync()
+    assert mod.main() == 0
+
+
+# ── AC3: 실제 파싱(import+실행) — 계산식 상수(`ALL_GROUPS`)도 올바르게 비교된다 ────────
+
+def test_computed_constant_all_groups_is_correctly_compared():
+    """`ALL_GROUPS`는 리터럴이 아니라 `tuple(g for g, _ in _GROUP_KEYWORDS if ...) + (_CORE,)`
+    계산식이다 — 텍스트/AST 블록 추출로는 이런 형태를 놓치기 쉽다(예전 실패 사례와 동형).
+    모듈을 실제로 import해 실행하므로 이것도 정확한 값으로 비교된다는 것을 직접 확認."""
+    mod = _load_check_mcp_vendor_sync()
+    common = mod.find_matching_constants()
+    orig_val, vend_val = common["ALL_GROUPS"]
+    assert orig_val == vend_val
+    assert "stories" in orig_val and "core" in orig_val  # sanity — 실제 계산된 값
+
+
+# ── AC4: 양성대조 — 뮤테이션으로 방법이 실제로 잡는지 증명 ──────────────────────────
+
+def test_positive_control_group_keyword_mismatch_is_caught(monkeypatch):
+    """`_GROUP_KEYWORDS`에 한쪽에만 있는 키워드를 인위로 넣으면 잡히는지 — delete_sprint
+    잔존과 정확히 같은 모양의 결함을 재현한다."""
+    mod = _load_check_mcp_vendor_sync()
+
+    real_load = mod._load_module
+
+    def fake_load(path, name):
+        module = real_load(path, name)
+        if "sprintable_mcp" in str(path):  # vendored 쪽에만 뮤테이션
+            mutated = [
+                (g, kws + ("ghost_typo_keyword",)) if g == "admin" else (g, kws)
+                for g, kws in module._GROUP_KEYWORDS
+            ]
+            module._GROUP_KEYWORDS = mutated
+        return module
+
+    monkeypatch.setattr(mod, "_load_module", fake_load)
+    problems = mod.mismatches()
+    assert any("ghost_typo_keyword" in p for p in problems)
+
+
+def test_positive_control_set_constant_mismatch_is_caught(monkeypatch):
+    """`_ALWAYS_ALLOWED`(frozenset)에 인위 항목을 넣으면 집합 대칭차로 잡히는지."""
+    mod = _load_check_mcp_vendor_sync()
+    real_load = mod._load_module
+
+    def fake_load(path, name):
+        module = real_load(path, name)
+        if "sprintable_mcp" in str(path):
+            module._ALWAYS_ALLOWED = module._ALWAYS_ALLOWED | frozenset({"ghost_tool_xyz"})
+        return module
+
+    monkeypatch.setattr(mod, "_load_module", fake_load)
+    problems = mod.mismatches()
+    assert any("ghost_tool_xyz" in p for p in problems)
+
+
+def test_positive_control_does_not_touch_disk(monkeypatch):
+    """AC3 원복 확認 — 양성대조는 monkeypatch로 «로드된 모듈 객체»만 변형해야 하고 디스크의
+    실제 파일은 건드리면 안 된다. 파일 바이트 내용을 실행 전후로 직접 대조해 확認한다
+    (ambient git 상태에 기대지 않음 — 이 PR 자체가 AC2로 vendored 파일을 정당하게 고쳤으므로
+    git status는 이 테스트 시점에 이미 non-empty일 수 있다)."""
+    original_bytes = _INFRA_DIR.parent.joinpath(
+        "backend", "sprintable_mcp", "toolset.py"
+    ).read_bytes()
+
+    mod = _load_check_mcp_vendor_sync()
+    real_load = mod._load_module
+
+    def fake_load(path, name):
+        module = real_load(path, name)
+        if "sprintable_mcp" in str(path):
+            module._ALWAYS_ALLOWED = module._ALWAYS_ALLOWED | frozenset({"disk_touch_probe"})
+        return module
+
+    monkeypatch.setattr(mod, "_load_module", fake_load)
+    mod.mismatches()  # 뮤테이션이 실제로 실행되게 트리거
+
+    after_bytes = _INFRA_DIR.parent.joinpath(
+        "backend", "sprintable_mcp", "toolset.py"
+    ).read_bytes()
+    assert original_bytes == after_bytes, "양성대조가 실제 파일 바이트를 건드렸다"
+
+
+# ── AC4: 재료를 못 찾으면 실패(skip 금지) ───────────────────────────────────────
+
+def test_load_module_raises_when_file_missing(tmp_path):
+    mod = _load_check_mcp_vendor_sync()
+    with pytest.raises(RuntimeError, match="대조 대상 파일을 못 찾음"):
+        mod._load_module(tmp_path / "does_not_exist.py", "ghost")
+
+
+def test_find_matching_constants_raises_when_no_common_names(monkeypatch, tmp_path):
+    """양쪽 파일이 로드는 되지만 공통 상수 이름이 0건이면 조용히 빈 결과를 돌려주지 않고
+    실패한다."""
+    mod = _load_check_mcp_vendor_sync()
+    empty_a = tmp_path / "a.py"
+    empty_b = tmp_path / "b.py"
+    empty_a.write_text("FOO_ONLY_IN_A = 1\n")
+    empty_b.write_text("BAR_ONLY_IN_B = 2\n")
+    monkeypatch.setattr(mod, "_ORIGINAL_PATH", empty_a)
+    monkeypatch.setattr(mod, "_VENDORED_PATH", empty_b)
+    with pytest.raises(RuntimeError, match="공통 상수 이름 0건"):
+        mod.find_matching_constants()
+
+
+def test_find_repo_root_raises_without_git_marker(tmp_path):
+    mod = _load_check_mcp_vendor_sync()
+    isolated = tmp_path / "no" / "git" / "here"
+    isolated.mkdir(parents=True)
+    with pytest.raises(RuntimeError, match="repo root"):
+        mod._find_repo_root(isolated)

--- a/infra/check_mcp_vendor_sync.py
+++ b/infra/check_mcp_vendor_sync.py
@@ -1,0 +1,131 @@
+"""story #2311 — `backend/app/services/mcp_toolset.py`(원본) ↔ `backend/sprintable_mcp/toolset.py`
+(vendored 사본) 대응 상수 대조 가드.
+
+배경: `sprintable_mcp`는 PyPI에 독립 배포되는 패키지라 `backend/app`을 import할 수 없다(양방향
+import 0건, 디커플링이 설계 의도 — doc `duplicate-registry-census-20260728` 부록에서 확認됨).
+그래서 toolset 규칙(`_GROUP_KEYWORDS`·`_ALWAYS_ALLOWED` 등)을 두 파일에 **각자** 유지한다.
+전례가 둘이다 — P1-S12(lock_files·standup 누락)·2026-07-29(delete_sprint 잔존) 둘 다 「누가
+우연히 볼 때까지」 드리프트가 안 잡혔다.
+
+방법: 두 파일을 **실제로 import해서 실행**한다(정적 텍스트/AST 블록 추출이 아니다 — PO가 이 건을
+처음 잴 때 블록 추출 파서가 "완전일치"라는 거짓 답을 낸 전례가 있다). 둘 다 `from __future__
+import annotations` 외에 의존성이 0이라 실행이 안전하고 빠르다(`test_e_mcp_s4_standalone.py`가
+이미 같은 방식으로 두 모듈을 직접 import하는 것과 동형). 양쪽 모듈의 최상위 이름공간에서
+**같은 이름으로 존재하는 데이터 상수 전부**를 자동으로 찾아 값 동일성을 비교한다 — 대조 대상을
+손으로 나열하지 않는다(새 상수가 생겨도 따라온다).
+"""
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+
+
+def _find_repo_root(start: Path) -> Path:
+    """'../' 개수를 세지 않고 .git 표식을 찾아 올라간다 — 못 찾으면 즉시 실패한다
+    (story #2305와 동일 원칙: 재료 못 찾은 가드가 skip으로 통과하면 안 된다)."""
+    cur = start.resolve()
+    for _ in range(20):
+        if (cur / ".git").exists():
+            return cur
+        if cur.parent == cur:
+            break
+        cur = cur.parent
+    raise RuntimeError(f"repo root(.git 표식)를 {start} 위로 못 찾음")
+
+
+_REPO_ROOT = _find_repo_root(Path(__file__).resolve().parent)
+_ORIGINAL_PATH = _REPO_ROOT / "backend" / "app" / "services" / "mcp_toolset.py"
+_VENDORED_PATH = _REPO_ROOT / "backend" / "sprintable_mcp" / "toolset.py"
+
+
+def _load_module(path: Path, name: str):
+    if not path.exists():
+        raise RuntimeError(f"대조 대상 파일을 못 찾음(AC4 — skip 대신 실패): {path}")
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _module_level_constants(module) -> dict[str, object]:
+    """모듈 최상위 이름공간에서 함수·클래스·서브모듈·`__future__` 기능 객체·dunder를 뺀
+    나머지 — 즉 데이터 상수만."""
+    result: dict[str, object] = {}
+    for name, value in vars(module).items():
+        if name.startswith("__"):
+            continue
+        if inspect.isfunction(value) or inspect.isclass(value) or inspect.ismodule(value):
+            continue
+        if type(value).__module__ == "__future__":  # `from __future__ import annotations` 자체
+            continue
+        result[name] = value
+    return result
+
+
+def find_matching_constants() -> dict[str, tuple[object, object]]:
+    """양쪽에 같은 이름으로 존재하는 상수만 {name: (원본값, vendored값)}로 반환.
+    ⛔AC4 — 공통 이름이 0건이면(파싱이 깨졌거나 재료가 없는 것) skip하지 않고 실패한다."""
+    original = _module_level_constants(_load_module(_ORIGINAL_PATH, "mcp_toolset_original"))
+    vendored = _module_level_constants(_load_module(_VENDORED_PATH, "mcp_toolset_vendored"))
+    common_names = sorted(set(original) & set(vendored))
+    if not common_names:
+        raise RuntimeError(
+            "원본↔vendored 공통 상수 이름 0건 — 모듈 로드가 깨졌거나 두 파일이 완전히 달라졌다"
+        )
+    return {name: (original[name], vendored[name]) for name in common_names}
+
+
+def _is_pair_list(value: object) -> bool:
+    """`_GROUP_KEYWORDS`류 — `[(key, values), ...]` 형태(list/tuple of 2-tuples, key는 str)."""
+    if not isinstance(value, (list, tuple)):
+        return False
+    return all(
+        isinstance(item, tuple) and len(item) == 2 and isinstance(item[0], str)
+        for item in value
+    )
+
+
+def mismatches() -> list[str]:
+    """값이 다른 공통 상수를 상세 사유와 함께 낸다 — 집합류는 대칭차, `_GROUP_KEYWORDS`류
+    (key→values 쌍 목록)는 키 단위 대칭차, 그 외는 원본/vendored 값 자체를 보인다."""
+    violations: list[str] = []
+    for name, (orig_val, vend_val) in find_matching_constants().items():
+        if orig_val == vend_val:
+            continue
+        if isinstance(orig_val, (set, frozenset)) and isinstance(vend_val, (set, frozenset)):
+            only_orig = sorted(orig_val - vend_val)
+            only_vend = sorted(vend_val - orig_val)
+            violations.append(
+                f"{name}: 원본에만 {only_orig} · vendored에만 {only_vend}"
+            )
+        elif _is_pair_list(orig_val) and _is_pair_list(vend_val):
+            orig_map, vend_map = dict(orig_val), dict(vend_val)
+            for key in sorted(set(orig_map) | set(vend_map)):
+                o_vals, v_vals = set(orig_map.get(key, ())), set(vend_map.get(key, ()))
+                if o_vals != v_vals:
+                    violations.append(
+                        f"{name}[{key!r}]: 원본에만 {sorted(o_vals - v_vals)} "
+                        f"· vendored에만 {sorted(v_vals - o_vals)}"
+                    )
+        else:
+            violations.append(f"{name}: 값 불일치 — 원본={orig_val!r} · vendored={vend_val!r}")
+    return violations
+
+
+def main() -> int:
+    common = find_matching_constants()
+    print(f"공통 상수 {len(common)}개 대조: {', '.join(sorted(common))}")
+    problems = mismatches()
+    if problems:
+        print("❌ 원본↔vendored 드리프트 발견:")
+        for line in problems:
+            print(f"  - {line}")
+        return 1
+    print("✅ 드리프트 없음 — 원본↔vendored 공통 상수 전부 값 동일.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- doc `duplicate-registry-census-20260728` #1·#6항목 — `backend/app/services/mcp_toolset.py`(원본) ↔ `backend/sprintable_mcp/toolset.py`(vendored 사본)가 값이 갈려도 아무도 못 잡던 구멍. 전례가 둘(P1-S12 lock_files/standup 누락, 2026-07-29 delete_sprint 잔존) — 둘 다 "누가 우연히 볼 때까지" 안 잡혔다.
- 벤더링 자체는 정당(PyPI 독립배포, 양방향 import 0건, 디커플링이 설계 의도 — 이전 조사에서 확認) — 처방은 합치는 게 아니라 **테스트로 묶는 것**.
- **AC1**: `infra/check_mcp_vendor_sync.py` — 대조 대상을 손으로 나열하지 않는다. 두 모듈을 **실제로 import해서 실행**(정적 텍스트/AST 블록 추출 아님 — PO가 처음 잴 때 블록 추출 파서가 "완전일치"라는 거짓 답을 낸 전례가 있다)한 뒤, 최상위 이름공간에서 같은 이름을 가진 데이터 상수를 자동으로 찾아(set 교집합) 비교한다. `ALL_GROUPS`처럼 계산식으로 된 상수도 실행 기반이라 정확히 비교된다.
- **AC2**: vendored `_GROUP_KEYWORDS`의 `"delete_sprint"` 제거 — 원본에 맞춤(SEC-S8이 의도적으로 제거한 것, 반대 방향 아님).
- **AC4**: 뮤테이션 양성대조 2건(리스트류·집합류 각각) + 재료(파일/공통이름) 못 찾으면 skip 대신 `RuntimeError`. `_find_repo_root()`는 story #2305와 동일하게 `.git` 표식 탐색(`../` 카운팅 아님).

## Test plan
- [x] 신규 테스트 파일 `backend/tests/test_s2311_vendor_const_sync.py` 11건 — GREEN.
- [x] 뮤테이션 자가검증 — fix 되돌리면(`git stash`) 2/11건 정확히 RED(나머지 9건은 fix 이전에도 통과가 맞음), 복원 후 GREEN.
- [x] 양성대조가 디스크 파일을 안 건드리는지 바이트 단위 직접 대조로 확認(`test_positive_control_does_not_touch_disk`).
- [x] `tests/ -k "mcp or toolset or vendor"` 372 passed / 7 failed — 실패 7건 전부 **origin/develop 기저선에서도 동일하게 실패**하는 pre-existing 이슈(다른 actor 로컬 `.mcp.json` 환경의존 3건 + 구식 도구수 하드코딩(89) 4건, 이번 세션에서 앞선 PR들로 이미 확認된 것과 동형).
- [x] `git diff origin/develop...HEAD --stat` — 의도한 3개 파일만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)