### PR TITLE
feat(auth): 로그인 화면 content-painted 신호 (#2310 웹 반쪽)

### DIFF
--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
@@ -10,6 +10,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { safeNextPath, SESSION_EXPIRED_REASON } from '@/lib/auth/session-redirect';
 import { FIREBASE_AUTH_ENABLED } from '@/lib/auth/firebase-client';
 import { signInAndExchangeFirebaseSession } from '@/lib/auth/firebase-login-flow';
+import { notifyContentPainted } from '@/lib/native-shell-bridge';
 
 export default function LoginPage() {
   const t = useTranslations('login');
@@ -38,6 +39,12 @@ export default function LoginPage() {
   );
   const [loading, setLoading] = useState(false);
   const [firebaseLoading, setFirebaseLoading] = useState(false);
+
+  // #2310(e-mobile-content-painted-contract): 이 화면은 서버 데이터 조회 없이 첫 렌더에
+  // 폼이 그대로 나온다(스켈레톤 단계 없음) — 마운트 직후가 "첫 유의미한 페인트"로 정확하다.
+  useEffect(() => {
+    notifyContentPainted();
+  }, []);
 
   // story a0118204: 스캐폴드 — NEXT_PUBLIC_FIREBASE_AUTH_ENABLED가 꺼져있으면(기본) 버튼 자체가
   // 안 보이니 호출 불가. 켜져 있어도 서버 플래그(FIREBASE_AUTH_ISSUE_SESSION)가 꺼져있으면

--- a/apps/web/src/components/glance/glance-board.test.tsx
+++ b/apps/web/src/components/glance/glance-board.test.tsx
@@ -203,3 +203,24 @@ describe('GlanceBoard — 실패 상태 구분(codex-silent-defect-sweep B-3/D-7
     expect(container.innerHTML).not.toContain('일부 정보를 불러오지 못했습니다');
   });
 });
+
+// #2310(e-mobile-content-painted-contract) — /glance는 웨이터폴이 있는 화면(#2298)이라
+// "첫 유의미한 페인트"를 데이터 도착이 아니라 스켈레톤이 뜨는 시점(마운트 즉시)으로 잡는다.
+// loadGlanceData를 절대 resolve하지 않는 pending promise로 고정해, 신호가 데이터를
+// «기다리지 않고» 나가는 것을 실증한다(이걸 놓치면 웨이터폴이 몇 초든 신호가 그만큼 늦어진다).
+describe('GlanceBoard — content-painted 신호(#2310)', () => {
+  it('데이터 fetch가 끝나기 전(스켈레톤 단계)에 이미 신호를 보낸다', async () => {
+    loadGlanceDataMock.mockReturnValue(new Promise(() => {})); // 영구 pending — resolve 없음
+    const postMessage = vi.fn();
+    (window as unknown as { ReactNativeWebView?: { postMessage: typeof postMessage } }).ReactNativeWebView = { postMessage };
+    await mount();
+    expect(postMessage).toHaveBeenCalledWith(JSON.stringify({ type: 'content-painted' }));
+    delete (window as unknown as { ReactNativeWebView?: unknown }).ReactNativeWebView;
+  });
+
+  it('네이티브 셸 밖(일반 브라우저)에서는 조용히 무동작(window.ReactNativeWebView 없음 — 크래시 0)', async () => {
+    loadGlanceDataMock.mockResolvedValue(EMPTY_DATA);
+    delete (window as unknown as { ReactNativeWebView?: unknown }).ReactNativeWebView;
+    await expect(mount()).resolves.not.toThrow();
+  });
+});

--- a/apps/web/src/components/glance/glance-board.tsx
+++ b/apps/web/src/components/glance/glance-board.tsx
@@ -19,6 +19,7 @@ import {
 } from './derive-exception-signals';
 import type { HeroEnvelope } from './derive-hero-envelope';
 import type { HeroStory, HeroMember } from './hero-logic';
+import { notifyContentPainted } from '@/lib/native-shell-bridge';
 
 // story 190f4c71(doc resource-view-firsttouch-identity-pattern §4 "현황판(glance)" 행 — 정체성=
 // 프로젝트 여정[시작→지금→앞으로]·visual=로드맵 waypoint·첫행동=첫 에픽): 3-waypoint **직선** 배치.
@@ -78,6 +79,17 @@ export function GlanceBoard({ projectId, className }: GlanceBoardProps) {
   const [epicsError, setEpicsError] = useState(false);
   // codex-silent-defect-sweep D-7 — 나머지 조각(overview/멤버/스토리/활동/예외) 개별 실패 플래그.
   const [partialErrors, setPartialErrors] = useState<GlanceDataPartialErrors>(EMPTY_PARTIAL_ERRORS);
+
+  // #2310(e-mobile-content-painted-contract) — 웹 반쪽은 로그인 화면(PR#2610)뿐이었다. /glance는
+  // 인증 후 화면이라 데이터 도착이 아니라 **스켈레톤이 뜨는 시점**(마운트 즉시, `loading` 초기값
+  // true라 아래 return이 항상 뭔가를 그린다)이 "첫 유의미한 페인트"다 — #2298 웨이터폴이 몇 초가
+  // 걸리든 이 신호는 그 전에 나가야 한다(유나 진단: "끊김이 아니라 비어 있음이 문제" — 스켈레톤도
+  // "보이는 것"이다). ⚠️(authenticated)/layout.tsx의 서버사이드 순차 await 체인(session→
+  // me/memberships/orgs→projectInfo)은 이 컴포넌트가 마운트되기 *전* 단계라 이 신호가 못 건드리는
+  // 별도 병목이다(#2298 그라운딩 당시 발견) — 이 스토리 범위 밖으로 남겨 둔다.
+  useEffect(() => {
+    notifyContentPainted();
+  }, []);
 
   const fetchGlance = useCallback((cancelledRef: { cancelled: boolean }) => {
     setLoading(true);

--- a/apps/web/src/lib/native-shell-bridge.ts
+++ b/apps/web/src/lib/native-shell-bridge.ts
@@ -1,0 +1,16 @@
+// 네이티브 셸(sprintable-mobile) ↔ 웹 브릿지 — 명시적 메시지 스키마만 쓴다(계약 doc:
+// e-mobile-content-painted-contract). window.ReactNativeWebView는 네이티브 웹뷰 안에서만
+// 존재하므로(브라우저 직접 접속 시 undefined) 항상 옵셔널 체이닝으로 다룬다.
+
+declare global {
+  interface Window {
+    ReactNativeWebView?: { postMessage(message: string): void };
+  }
+}
+
+// #2310: 이 화면의 첫 유의미한 페인트가 끝났음을 셸에 알린다 — 셸은 이 신호를 받을 때까지
+// 스플래시를 유지한다(앱 쪽은 이미 배선 완료 · sprintable-mobile PR#62). 여러 번 불려도
+// 무해(셸이 1회만 반응). 네이티브 셸 밖(일반 브라우저)에서는 조용히 아무 일도 안 한다.
+export function notifyContentPainted() {
+  window.ReactNativeWebView?.postMessage(JSON.stringify({ type: 'content-painted' }));
+}


### PR DESCRIPTION
## 무엇
`window.ReactNativeWebView?.postMessage(JSON.stringify({type:'content-painted'}))`를
로그인 화면 마운트 직후 발신 — `sprintable-mobile#62`(스플래시를 콘텐츠 도착까지 유지)의 짝.

## 왜
실측(민 레·2026-07-29): 앱 콜드 실행 시 스플래시가 걷힌 뒤 "흰 배경+스피너뿐인 빈 화면"이
1.9초 있었다 — 그 빈 시간이 "체감 10초"의 몸통이라는 진단(유나양). 앱 쪽은 이미 이 신호를
받으면 스플래시를 걷도록 배선 완료(`sprintable-mobile#62`, 머지 대기 중) — 웹이 신호를
안 보내는 지금은 8초 안전망 타임아웃이 매번 발동해 총 대기시간이 늘어난다(4.4s→~9s).

## 스코프
로그인 화면만(이 PR). 이 화면은 서버 데이터 조회 없이 첫 렌더에 폼이 그대로 나와(스켈레톤
단계 없음) 신호 시점이 명확하다. `/glance` 등 인증 후 화면(#2298 웨이터폴 대상)은 스코프 밖 —
그쪽은 스켈레톤 시점에 신호를 보내는 게 맞아 보이는데 판단은 그 작업 담당자(#2298) 몫으로 둠.
전체 스펙: Sprintable doc `e-mobile-content-painted-contract`.

## 검증
- `pnpm type-check` 클린(develop 기준 재브랜치·`.next` 캐시 초기화 후 재확認)
- 네이티브 셸 밖(일반 브라우저)에서는 `window.ReactNativeWebView`가 없어 무동작 — 안전

## 다음
머지되면 `sprintable-mobile#62`을 같은 방식(클린 설치·콜드·screenrecord+프레임 픽셀 분석)으로
재측정 — "빈 화면 0초 AND 총 시간 ≤4.4초" 둘 다 확認되면 그때 `#62` 머지.