### PR TITLE
feat(#2308 후속): active·corrections 교차참조 — 「이건 그대로 믿으면 안 된다」를 한 목록에서

### DIFF
--- a/backend/app/routers/judgments.py
+++ b/backend/app/routers/judgments.py
@@ -46,6 +46,10 @@ class JudgmentResponse(BaseModel):
     statement: str
     created_by: uuid.UUID
     created_at: datetime
+    # story #2308 후속: 이 원소를 target으로 삼는 correction id들(list_judgments 전용 —
+    # POST 응답에선 항상 []. 한 목록만 읽어도 "이건 정정됐다"가 보이게, active·corrections
+    # 양쪽 다 이 필드를 갖는다).
+    correction_ids: list[uuid.UUID] = []
 
 
 class JudgmentListMeta(BaseModel):

--- a/backend/app/services/judgment_core.py
+++ b/backend/app/services/judgment_core.py
@@ -24,6 +24,21 @@ app-level 검증을 먼저 하는 이유(#2259 reference_core.insert_reference�
 방어): DB CHECK만 믿으면 실패 시 raw IntegrityError 텍스트가 그대로 API 밖으로 샌다. 여기서
 먼저 걸러 사람이 읽을 수 있는 메시지로 거절한다 — CHECK는 그래도 안 뺀다("코드가 아니라
 제약이 지킨다"가 이 판의 crux, 오르테가 표현).
+
+⛔story #2308 후속(2026-07-29, 오르테가 라이브 dogfooding — #2302에 실제 write→read 왕복):
+`active`의 축은 "철회됐나"가 아니라 "말의 층위"(kind가 TARGET_REQUIRED_KINDS 밖인가)라서,
+이미 retraction의 target이 된 judgment도 `active`에 그대로 남는다(설계대로 — 버그 아님).
+그런데 필드 이름이 "active"라 그 목록만 읽는 소비자는 철회된 판단을 유효한 것으로 오독한다.
+`corrections` 원소도 같은 함정이 있다 — method_error는 "그 판단 + 같은 방법으로 낸 다른
+모든 말"을 무효화하는 «번지는» 정정이라, 정정이 다른 정정을 target하는 것이 예외가 아니라
+method_error의 정상 모양이다(예: 관측 방법 자체가 틀렸다고 밝혀지면 그 방법으로 낸 판단들
+전부가 흔들린다). 그래서 `active`와 `corrections` 양쪽 모두를, 각 원소가 target인
+correction id 목록(`correction_ids`)으로 decorate한다 — 한 목록만 읽어도 "이건 그대로
+믿으면 안 된다"를 그 자리에서 알 수 있게(계보 전체를 재귀로 펼치지 않는다 — 그건 소비자가
+target_id를 따라가면 되는 별개 층위, 1단계 표시만 이 판의 경계).
+`correction_ids_by_target`은 `correction_rows`(캡 예외, 항상 전량)에서만 파생하므로 캡과
+무충돌 — active가 recency로 잘려도(그 항목 자체가 안 보이는 것) correction_ids 계산 자체는
+항상 완전한 데이터 위에서 이뤄진다.
 """
 from __future__ import annotations
 
@@ -126,6 +141,18 @@ async def list_judgments(
     ).scalars().all()
 
     active_omitted_count = max(0, total_active - len(active_rows))
+
+    # story #2308 후속: "이건 그대로 믿으면 안 된다" 교차참조 — target인 원소를 가진 모든
+    # correction을 target_id별로 묶는다. corrections는 캡 예외(항상 전량)라 이 map은
+    # 완전하다. active·corrections 양쪽 원소를 이 «단일» map으로 decorate — 두 자리에
+    # 따로 계산하면 한쪽만 고쳐지는 비대칭이 재발한다(오늘 하루 반복 관측된 병).
+    correction_ids_by_target: dict[uuid.UUID, list[uuid.UUID]] = {}
+    for corr in correction_rows:
+        if corr.target_id is not None:
+            correction_ids_by_target.setdefault(corr.target_id, []).append(corr.id)
+    for row in (*active_rows, *correction_rows):
+        row.correction_ids = correction_ids_by_target.get(row.id, [])  # type: ignore[attr-defined]
+
     return {
         # corrections는 캡 예외 — 위 쿼리에 limit이 없으므로 항상 전량, 그러므로 이쪽은
         # 절대 잘리지 않는다(아래 meta가 active 쪽에만 있는 이유 — 어느 쪽이 잘렸는지

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -552,7 +552,8 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_list_judgments",
      "판단/철회 pull 조회 — work_item_id·method·scope로 좁혀 묻는다. corrections(retraction/"
      "refinement/method_error)는 상한과 무관하게 항상 전체, active는 캡되며"
-     " meta.active_omitted_count로 잘린 건수를 알려준다.",
+     " meta.active_omitted_count로 잘린 건수를 알려준다. 각 원소의 correction_ids가"
+     " 비어있지 않으면 이미 정정된 것이니 그대로 믿지 말 것.",
      ListJudgmentsInput, list_judgments),
     # Visual artifacts (12) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안) +
     # 핀 저작(story 7fe16274) + story #1922(delete_artifact, soft delete·생성자 전용)

--- a/backend/sprintable_mcp/tools/judgments.py
+++ b/backend/sprintable_mcp/tools/judgments.py
@@ -55,9 +55,12 @@ async def list_judgments(args: ListJudgmentsInput) -> list[TextContent]:
     method_error — 앞선 말에 대한 말 전부)는 상한과 무관하게 항상 전체(철회된 판단을 다시
     주장하지 않으려면 빠짐없이 봐야 한다). `active`(judgment/unmeasurable)는 recency
     기준으로 캡되며, `meta.active_omitted_count`가 실제로 몇 건 잘렸는지 알려준다(잘리는
-    것은 항상 active뿐 — corrections는 절대 안 잘린다). `method` 필터는 "같은 방법으로 낸
-    다른 말들"을 역추적할 때 쓴다(method_error를 남기기 전에 먼저 이걸로 훑어보는 것을
-    권장)."""
+    것은 항상 active뿐 — corrections는 절대 안 잘린다). ⛔각 원소(`active`·`corrections`
+    둘 다)의 `correction_ids`가 비어있지 않으면 그 항목은 이미 정정됐다는 뜻 — 그대로
+    믿지 말고 `corrections`에서 그 id를 찾아 무엇이 어떻게 정정됐는지 확인할 것(정정이
+    다른 정정을 target하는 것도 정상 — method_error는 여러 말에 번지므로). `method` 필터는
+    "같은 방법으로 낸 다른 말들"을 역추적할 때 쓴다(method_error를 남기기 전에 먼저 이걸로
+    훑어보는 것을 권장)."""
     try:
         params: dict = {}
         if args.work_item_id is not None:

--- a/backend/tests/test_2268_judgments_endpoint_realdb.py
+++ b/backend/tests/test_2268_judgments_endpoint_realdb.py
@@ -454,3 +454,174 @@ async def test_general_scope_entry_is_pullable_via_scope_filter():
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+# ─── correction_ids 교차참조(2026-07-29, 오르테가 라이브 dogfooding 후속) ──────
+#
+# "active(유효)"라는 이름만 읽고 철회된 판단을 유효로 오독하는 함정 — active·corrections
+# 양쪽 원소가 자신을 target으로 삼는 correction id들을 실어, 한 목록만 읽어도 "이건 그대로
+# 믿으면 안 된다"가 보이게 한다. 정정이 다른 정정을 target하는 것(method_error가 흔히 그렇듯)
+# 도 정상 모양이라 corrections 원소도 똑같이 decorate한다.
+
+
+def _find(items, item_id):
+    return next(j for j in items if j["id"] == item_id)
+
+
+async def test_active_item_carries_correction_ids_when_retracted():
+    """오르테가가 #2302에서 실제로 재현한 시나리오 그대로 — judgment→retraction 왕복."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            original = await client.post(
+                "/api/v2/judgments",
+                json={
+                    "scope": "general", "kind": "judgment",
+                    "statement": "artifact/asset은 전용 화면 있음 — page.tsx 파일 실재가 근거",
+                },
+            )
+            assert original.status_code == 201, original.text
+            retraction = await client.post(
+                "/api/v2/judgments",
+                json={
+                    "scope": "general", "kind": "retraction", "target_id": original.json()["id"],
+                    "statement": "철회 — 파일이 있다는 화면이 있다의 근거가 못 된다(사문 코드)",
+                },
+            )
+            assert retraction.status_code == 201, retraction.text
+
+            resp = await client.get("/api/v2/judgments", params={"scope": "general"})
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+
+            active_item = _find(body["active"], original.json()["id"])
+            assert active_item["correction_ids"] == [retraction.json()["id"]], active_item
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_correction_item_itself_carries_correction_ids_when_further_corrected():
+    """method_error는 «번지는» 정정이라 정정이 정정을 target하는 것이 정상 모양 —
+    corrections[] 원소도 active와 동형으로 decorate돼야 한다(오늘 세션에 반복 관측된
+    "한쪽만 고쳐지는 비대칭" 재발 방지 — PO 결정: 같은 PR에서 두 목록 다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            original = await client.post(
+                "/api/v2/judgments",
+                json={
+                    "scope": "general", "kind": "judgment",
+                    "statement": "4fps 관측 기반 — 렌더 파이프라인이 안정적이라 판단",
+                },
+            )
+            assert original.status_code == 201, original.text
+            refinement = await client.post(
+                "/api/v2/judgments",
+                json={
+                    "scope": "general", "kind": "refinement", "target_id": original.json()["id"],
+                    "statement": "저해상도에서만 안정적 — 고해상도는 별도 재측정 필요",
+                },
+            )
+            assert refinement.status_code == 201, refinement.text
+            # refinement 자체가 method_error의 target이 되는 경우 — "관측 방법 자체가
+            # 틀렸다"는 정정이 이미 나온 정정(refinement)까지 함께 흔든다.
+            method_error = await client.post(
+                "/api/v2/judgments",
+                json={
+                    "scope": "general", "kind": "method_error", "target_id": refinement.json()["id"],
+                    "statement": "4fps 관측 자체가 틀렸다(15fps로 재측정) — 그 관측 기반 정련도 무효",
+                },
+            )
+            assert method_error.status_code == 201, method_error.text
+
+            resp = await client.get("/api/v2/judgments", params={"scope": "general"})
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+
+            refinement_item = _find(body["corrections"], refinement.json()["id"])
+            assert refinement_item["correction_ids"] == [method_error.json()["id"]], refinement_item
+            # method_error 자신은 아무도 target하지 않았으므로 빈 배열.
+            method_error_item = _find(body["corrections"], method_error.json()["id"])
+            assert method_error_item["correction_ids"] == [], method_error_item
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_correction_ids_decoration_positively_fires_for_every_targeted_item():
+    """⭐오르테가 요청 가드 — «decoration이 빠진 원소가 0인가». map이 비면 조용히 전부
+    무표시가 되는 실패 모드가 있다(«돌고 있는데 아무것도 안 재는» 모양) — 그러니 단일
+    사례가 아니라 여러 개 동시에 넣어, 매칭돼야 할 게 전부 매칭됐는지(누락 0)와 매칭되면
+    안 될 게 실제로 비어있는지(오염 0) 양방향으로 잰다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            targets = []
+            for i in range(4):
+                r = await client.post(
+                    "/api/v2/judgments",
+                    json={"scope": "general", "kind": "judgment", "statement": f"판단 {i}"},
+                )
+                assert r.status_code == 201, r.text
+                targets.append(r.json()["id"])
+
+            # 0·1·2번째만 철회, 3번째는 안 건드림(음성대조).
+            retraction_ids = {}
+            for idx in (0, 1, 2):
+                r = await client.post(
+                    "/api/v2/judgments",
+                    json={
+                        "scope": "general", "kind": "retraction", "target_id": targets[idx],
+                        "statement": f"철회 {idx}",
+                    },
+                )
+                assert r.status_code == 201, r.text
+                retraction_ids[targets[idx]] = r.json()["id"]
+
+            resp = await client.get("/api/v2/judgments", params={"scope": "general", "limit": 10})
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            active_by_id = {j["id"]: j for j in body["active"]}
+
+            for idx in (0, 1, 2):
+                item = active_by_id[targets[idx]]
+                assert item["correction_ids"] == [retraction_ids[targets[idx]]], (idx, item)
+            # 안 건드린 3번째는 correction_ids가 실제로 비어있어야(오염 0).
+            assert active_by_id[targets[3]]["correction_ids"] == [], active_by_id[targets[3]]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- 오르테가가 #2302에 실제 write→read 왕복(judgment→retraction)을 재현하며 발견: `active`는 "철회됐나"가 아니라 "말의 층위" 축이라, 이미 retraction의 target이 된 judgment도 `active`에 그대로 남는다(설계대로 — 버그 아님). 하지만 필드 이름이 "active(유효)"라 그 목록만 읽는 소비자는 철회된 판단을 유효로 오독한다.
- PO 결정(3안 중 ㉠): `active` 원소마다 자신을 target으로 삼는 correction id들(`correction_ids`)을 실어, 한 목록만 읽어도 철회 여부가 그 자리에 보이게 한다.
- `corrections[]` 원소도 같은 PR에서 함께 decorate — method_error는 다른 정정을 target하는 것이 정상 모양이라(관측 방법 자체가 틀렸다고 밝혀지면 그 방법으로 낸 판단들 전부가 흔들림), active만 먼저 고치면 "표시되는 목록 vs 안 되는 목록" 비대칭이 생긴다는 PO 판단.

## 캡 무충돌
`correction_rows` 쿼리엔 `.limit()`이 없다 — corrections는 캡 예외로 항상 전량 로드된 상태에서 decorate하므로 `correction_ids` 계산은 항상 완전한 데이터 위에서 이뤄진다.

## 스코프 경계
계보를 재귀로 펼치지 않는다 — 1단계 표시까지만. target_id를 따라가는 것은 소비자 몫.

## 검증
- realdb 신규 3건: retraction 왕복(PO 시나리오 재현) · corrections 원소가 또 다른 correction의 target이 되는 체인(refinement→method_error) · PO 요청 가드("decoration이 빠진 원소가 0인가" — 4건 중 3건만 철회해 매칭 누락/오염 양방향 확인)
- RED→GREEN 2건: `correction_ids_by_target`을 강제로 빈 dict로(silent no-op 실패 모드) → 3개 테스트 즉시 실패 → 원복. corrections만 decoration 누락시키는 사보타주 → 체인 테스트 실패 → 원복. 둘 다 원복 후 git diff 무변경 확인
- judgments realdb 24/24 GREEN(alembic head) + 전체 회귀 4235 pass(7 fail 전부 기존 미관련 베이스라인)

## Test plan
- [x] realdb 신규 3건 GREEN
- [x] RED→GREEN self-check 2건
- [x] 전체 회귀 무관련 확인
- [ ] CI 확인 대기

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>