### PR TITLE
fix(#2294, #2316): reconcile_entity_references target 검증 — 실재+org 소속+파싱 성공 3사유

### DIFF
--- a/backend/app/services/mention_parser.py
+++ b/backend/app/services/mention_parser.py
@@ -55,6 +55,7 @@ from sqlalchemy import select
 
 from app.models.reference import Reference
 from app.services.member_resolver import canonicalize_member_id
+from app.services.reference_core import _batch_resolve_existence
 from app.services.reference_registry import ENTITY_RESOLVERS
 
 logger = logging.getLogger(__name__)
@@ -273,7 +274,7 @@ async def reconcile_entity_references(
     AC4 원자성 계약과 동일)."""
     valid = [(tt, tid, form) for tt, tid, form in extracted_refs if tt in target_types]
     dropped = [
-        {"target_type": tt, "target_id": str(tid)}
+        {"target_type": tt, "target_id": str(tid), "reason": "unregistered_target_type"}
         for tt, tid, _form in extracted_refs if tt not in target_types
     ]
     if dropped:
@@ -287,6 +288,41 @@ async def reconcile_entity_references(
         (tt, tid, form) for tt, tid, form in valid
         if not (tt == source_type and tid == source_id)
     }
+
+    # ⛔story #2294 후속(2026-07-29, 오르테가 라이브 실측): 실재하지 않는(또는 이 org 밖)
+    # target_id가 그대로 저장되던 결함 — POST /references(insert_reference 호출부)·
+    # GET /entities/search는 이미 존재판정을 거치는데 이 write-path만 target_types(등록된
+    # «타입»인가)만 보고 target_id의 «실재»는 한 번도 확認하지 않았다(미르코 코드 추적으로
+    # 좁힌 자리, PO가 dev 라이브에서 직접 재현). `reference_core._batch_resolve_existence`
+    # (POST /references·GET /search와 같은 계열, ENTITY_RESOLVERS 그 자체)를 그대로 재사용
+    # — 세 번째 게이트를 새로 짓지 않는다(PO 지시). 각 resolver가 `WHERE org_id == org_id`로
+    # 스코프하므로 크로스-org 실재 UUID도 "없음"으로 걸린다(존재+org 소속을 한 번에 검증).
+    # 존재하지 않는 target은 `dropped`로(사유를 `unregistered_target_type`과 구분되게
+    # `target_not_found`로 — "타입이 미등록"과 "대상이 없음"은 사람이 할 일이 다르다는 PO
+    # 판단). ㉠target_refs가 비면 ids_by_type도 비어 `_batch_resolve_existence`가 session을
+    # 아예 안 건드린다 — known_new=True·db=None 자기검증 경로(아래 known_new 분기 참조)의
+    # "DB 왕복 0" 불변식을 이 게이트가 깨지 않는다.
+    if target_refs:
+        ids_by_type: dict[str, set[uuid.UUID]] = {}
+        for tt, tid, _form in target_refs:
+            ids_by_type.setdefault(tt, set()).add(tid)
+        existing_by_type = await _batch_resolve_existence(db, org_id, ids_by_type)
+        not_found = [
+            (tt, tid, form) for tt, tid, form in target_refs
+            if tid not in existing_by_type.get(tt, set())
+        ]
+        if not_found:
+            dropped.extend(
+                {"target_type": tt, "target_id": str(tid), "reason": "target_not_found"}
+                for tt, tid, _form in not_found
+            )
+            logger.warning(
+                "reconcile_entity_references: dropped %d ref(s) whose target does not exist "
+                "(source_type=%s, source_field=%s, source_id=%s) dropped=%s",
+                len(not_found), source_type, source_field, source_id,
+                [{"target_type": tt, "target_id": str(tid)} for tt, tid, _form in not_found],
+            )
+            target_refs -= set(not_found)
 
     if known_new:
         # insert-only 고속 경로 — existing-refs SELECT/stale-delete 자체를 건너뛴다(DB 왕복

--- a/backend/app/services/mention_parser.py
+++ b/backend/app/services/mention_parser.py
@@ -121,6 +121,42 @@ def extract_chat_entity_mentions(content: str) -> list[tuple[str, uuid.UUID]]:
     return result
 
 
+# story #2316(2026-07-29, 까심 라이브 실측 — dev, 읽기 전용): id 부분이 UUID 모양이 아닌
+# 토큰(`](entity:task:not-a-uuid)`)은 `_CHAT_TOKEN_RE`의 id 그룹이 `_UUID_RE`를 강제하므로
+# 매치 자체가 실패한다 — `try/except ValueError`(위 106-109행)는 그래서 사실상 도달 불가
+# 코드다. 그 결과 `count_phantom_task_mentions`(AC6)가 이 케이스를 영원히 "0건"으로
+# 보고한다 — "탐지가 없다"가 아니라 "탐지된 게(위 shape_count 경고 로그) 도달하는 자리가
+# 없다"(PO 표현). id를 느슨하게(`[^)]*`) 잡는 별도 정규식으로 "모양은 맞는데 못 파싱한"
+# 토큰만 골라 caller(`insert_chat_mentions`)에 반환 — 그쪽이 `dropped`에
+# `reason="malformed_token"`으로 얹는다. 코어(`reconcile_entity_references`)에 안 넣는
+# 이유: 코어는 이미 파싱된 `extracted_refs`만 받는 계약이라(#2301) 애초에 추출조차 안 된
+# 토큰은 코어의 시야 밖 — #2301의 "얇은 변환" 원칙 위반이 아니라 코어가 볼 수 없는 축이다.
+_CHAT_TOKEN_SHAPE_RE = re.compile(
+    r"\[(?:[^\]\\]|\\.)*\]\(entity:(?P<type>[a-z]+):(?P<id>[^)]*)\)"
+)
+
+
+def find_malformed_chat_tokens(content: str) -> list[dict[str, str]]:
+    """모양(`](entity:<type>:...)`)은 맞지만 id가 UUID가 아니라 `extract_chat_entity_
+    mentions`가 애초에 못 뽑은 토큰을 찾는다. 순서 무관, 중복 제거(동일 (type, raw_id)
+    반복은 한 건으로)."""
+    if not content:
+        return []
+    strict_matches = {
+        (m.group("type"), m.group("id")) for m in _CHAT_TOKEN_RE.finditer(content)
+    }
+    seen: set[tuple[str, str]] = set()
+    malformed: list[dict[str, str]] = []
+    for m in _CHAT_TOKEN_SHAPE_RE.finditer(content):
+        entity_type, raw_id = m.group("type"), m.group("id")
+        key = (entity_type, raw_id)
+        if key in strict_matches or key in seen:
+            continue
+        seen.add(key)
+        malformed.append({"target_type": entity_type, "target_id": raw_id, "reason": "malformed_token"})
+    return malformed
+
+
 def extract_chat_doc_mention_ids(content: str) -> list[uuid.UUID]:
     """`extract_chat_entity_mentions`의 doc-only 하위집합(하위호환 편의 래퍼) — 순서 보존.
     ⛔새 호출부는 이 함수 대신 `extract_chat_entity_mentions`를 쓸 것(타입 필터링이 이미
@@ -446,7 +482,16 @@ async def insert_chat_mentions(
         source_id=message_id, extracted_refs=extracted_refs, created_by=created_by,
         target_types=target_types, known_new=True,
     )
-    return ChatMentionResult(stored=result.stored, dropped=result.dropped)
+    # story #2316: 코어가 못 보는 축(추출조차 실패한 토큰) — 래퍼가 직접 찾아 dropped에
+    # 얹는다(위 find_malformed_chat_tokens docstring 참조, #2301 "얇은 변환" 예외 아님).
+    malformed = find_malformed_chat_tokens(content)
+    if malformed:
+        logger.warning(
+            "insert_chat_mentions: dropped %d malformed-id token(s) — shape matched but id "
+            "is not a UUID (message_id=%s) dropped=%s",
+            len(malformed), message_id, malformed,
+        )
+    return ChatMentionResult(stored=result.stored, dropped=[*result.dropped, *malformed])
 
 
 async def count_phantom_task_mentions(db: AsyncSession) -> int:

--- a/backend/tests/test_1993_mentions_realdb.py
+++ b/backend/tests/test_1993_mentions_realdb.py
@@ -78,6 +78,22 @@ async def _seed_org_project_member(session):
     return org, project, member
 
 
+async def _make_doc(session, org_id, project_id, title="Doc"):
+    """story #2294 후속(2026-07-29): reconcile_entity_references가 이제 target 실재를
+    검증하므로(오르테가 라이브 실측 — 존재하지 않는 대상이 그대로 저장되던 결함), 이
+    파일의 write-path 테스트들은 target으로 fabricated uuid.uuid4()가 아니라 실재하는
+    Doc 행을 써야 한다."""
+    from app.models.doc import Doc
+
+    doc = Doc(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title,
+        slug=f"doc-{uuid.uuid4().hex[:8]}",
+    )
+    session.add(doc)
+    await session.commit()
+    return doc
+
+
 # ─── AC4-1: 채팅 멘션 삽입 → mentions row ──────────────────────────────────────
 
 
@@ -89,9 +105,9 @@ async def test_chat_mention_insert_creates_row():
     try:
         async with factory() as session:
             org, project, member = await _seed_org_project_member(session)
-            await session.commit()
+            target_doc = await _make_doc(session, org.id, project.id)
 
-            target_doc_id = uuid.uuid4()
+            target_doc_id = target_doc.id
             message_id = uuid.uuid4()
             content = f"[참고 doc](entity:doc:{target_doc_id})"
 
@@ -127,11 +143,12 @@ async def test_doc_reconcile_adds_and_removes_stale_mentions():
     try:
         async with factory() as session:
             org, project, member = await _seed_org_project_member(session)
-            await session.commit()
+            target_b_doc = await _make_doc(session, org.id, project.id, title="B")
+            target_c_doc = await _make_doc(session, org.id, project.id, title="C")
 
             source_doc_id = uuid.uuid4()
-            target_b = uuid.uuid4()
-            target_c = uuid.uuid4()
+            target_b = target_b_doc.id
+            target_c = target_c_doc.id
 
             # 1차: B 를 wikiLink 로 멘션.
             html_v1 = f'<span data-type="wikiLink" data-doc-id="{target_b}">B</span>'
@@ -176,11 +193,12 @@ async def test_doc_reconcile_wikilink_and_page_embed_land_as_distinct_forms():
     try:
         async with factory() as session:
             org, project, member = await _seed_org_project_member(session)
-            await session.commit()
+            mention_target_doc = await _make_doc(session, org.id, project.id, title="M")
+            embed_target_doc = await _make_doc(session, org.id, project.id, title="E")
 
             source_doc_id = uuid.uuid4()
-            mention_target = uuid.uuid4()
-            embed_target = uuid.uuid4()
+            mention_target = mention_target_doc.id
+            embed_target = embed_target_doc.id
 
             html = (
                 f'<span data-type="wikiLink" data-doc-id="{mention_target}">M</span>'
@@ -213,10 +231,10 @@ async def test_doc_reconcile_switching_page_embed_to_wikilink_swaps_form_not_sta
     try:
         async with factory() as session:
             org, project, member = await _seed_org_project_member(session)
-            await session.commit()
+            target_doc = await _make_doc(session, org.id, project.id)
 
             source_doc_id = uuid.uuid4()
-            target = uuid.uuid4()
+            target = target_doc.id
 
             html_v1 = f'<div data-page-embed data-doc-id="{target}"></div>'
             await reconcile_doc_mentions(
@@ -295,9 +313,9 @@ async def test_duplicate_target_collapses_to_one_row_via_unique():
     try:
         async with factory() as session:
             org, project, member = await _seed_org_project_member(session)
-            await session.commit()
+            target_doc = await _make_doc(session, org.id, project.id)
 
-            target_doc_id = uuid.uuid4()
+            target_doc_id = target_doc.id
             message_id = uuid.uuid4()
             content = f"[A](entity:doc:{target_doc_id})"
 
@@ -436,10 +454,10 @@ async def test_mentions_rollback_when_enclosing_transaction_fails():
     try:
         async with factory() as session:
             org, project, member = await _seed_org_project_member(session)
-            await session.commit()
+            target_doc = await _make_doc(session, org.id, project.id)
 
             source_doc_id = uuid.uuid4()
-            target_doc_id = uuid.uuid4()
+            target_doc_id = target_doc.id
             html = f'<span data-type="wikiLink" data-doc-id="{target_doc_id}">X</span>'
 
             await reconcile_doc_mentions(
@@ -475,8 +493,9 @@ async def test_created_by_is_canonicalized_via_alias():
                 alias_id=legacy_alias_id, member_id=member.id, org_id=org.id, alias_source="human_team_member",
             ))
             await session.commit()
+            target_doc = await _make_doc(session, org.id, project.id)
 
-            target_doc_id = uuid.uuid4()
+            target_doc_id = target_doc.id
             message_id = uuid.uuid4()
             content = f"[A](entity:doc:{target_doc_id})"
 

--- a/backend/tests/test_2260_mention_target_type_not_hardcoded_realdb.py
+++ b/backend/tests/test_2260_mention_target_type_not_hardcoded_realdb.py
@@ -74,6 +74,36 @@ async def _seed_org_project_member(session):
     return org, project, member
 
 
+async def _make_doc(session, org_id, project_id, title="Doc"):
+    from app.models.doc import Doc
+
+    doc = Doc(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title,
+        slug=f"doc-{uuid.uuid4().hex[:8]}",
+    )
+    session.add(doc)
+    await session.commit()
+    return doc
+
+
+async def _make_story(session, org_id, project_id, title="Story"):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status="backlog")
+    session.add(story)
+    await session.commit()
+    return story
+
+
+async def _make_epic(session, org_id, project_id, title="Epic"):
+    from app.models.pm import Goal
+
+    goal = Goal(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status="active")
+    session.add(goal)
+    await session.commit()
+    return goal
+
+
 @pytest.mark.anyio
 async def test_chat_mention_to_story_round_trips():
     """⭐AC1 핵심 — 메시지→스토리 임베드가 실제로 만들어지고 다시 읽힌다(죽은 경로 재현/해소)."""
@@ -86,9 +116,9 @@ async def test_chat_mention_to_story_round_trips():
     try:
         async with factory() as session:
             org, project, member = await _seed_org_project_member(session)
-            await session.commit()
+            target_story = await _make_story(session, org.id, project.id)
 
-            target_story_id = uuid.uuid4()
+            target_story_id = target_story.id
             message_id = uuid.uuid4()
             content = f"[관련 스토리](entity:story:{target_story_id})"
 
@@ -124,9 +154,11 @@ async def test_chat_mention_to_epic_round_trips():
     try:
         async with factory() as session:
             org, project, member = await _seed_org_project_member(session)
-            await session.commit()
+            doc = await _make_doc(session, org.id, project.id)
+            story = await _make_story(session, org.id, project.id)
+            epic = await _make_epic(session, org.id, project.id)
 
-            doc_id, story_id, epic_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+            doc_id, story_id, epic_id = doc.id, story.id, epic.id
             message_id = uuid.uuid4()
             content = (
                 f"[문서](entity:doc:{doc_id}) [스토리](entity:story:{story_id}) "
@@ -161,9 +193,10 @@ async def test_target_types_param_is_the_boundary_not_a_body_branch():
     try:
         async with factory() as session:
             org, project, member = await _seed_org_project_member(session)
-            await session.commit()
+            doc = await _make_doc(session, org.id, project.id)
+            story = await _make_story(session, org.id, project.id)
 
-            doc_id, story_id = uuid.uuid4(), uuid.uuid4()
+            doc_id, story_id = doc.id, story.id
             message_id = uuid.uuid4()
             content = f"[문서](entity:doc:{doc_id}) [스토리](entity:story:{story_id})"
 

--- a/backend/tests/test_2294_reference_target_existence_gate_realdb.py
+++ b/backend/tests/test_2294_reference_target_existence_gate_realdb.py
@@ -11,6 +11,14 @@ target_id의 «실재»는 한 번도 확認하지 않았다.
 `reference_core._batch_resolve_existence`(ENTITY_RESOLVERS 그 자체)를 재사용. 각 resolver가
 `WHERE org_id == org_id`로 스코프하므로 실재하지만 다른 org 소속인 UUID도 "없음"으로 걸린다
 (존재+org 소속을 한 번에 검증) — ㉠새는가(보안) 질문에 대한 답이 이것.
+
+⛔story #2316(같은 PR·같은 스레드, 까심 라이브 실측): 「대상이 없음」과는 다른 셋째 사유
+— `](entity:task:not-a-uuid)`처럼 모양은 맞는데 id가 UUID가 아닌 토큰은 `extract_chat_
+entity_mentions`가 애초에 못 뽑아 `candidate_ids`에도 못 들어간다(`count_phantom_task_
+mentions`가 이 케이스를 영원히 0건으로 보고하던 이유). `dropped` 사유를 셋으로 가른다:
+`unregistered_target_type`(타입 미등록)·`target_not_found`(대상 실재 안 함)·
+`malformed_token`(모양은 맞으나 파싱 실패) — 사람이 할 일이 다르므로("다른 종류로 걸어라"
+vs "다시 골라라" vs "고쳐 쳐라") 데이터 축으로 가른다(화면 문구는 여전히 종류 안 가림).
 """
 from __future__ import annotations
 
@@ -313,5 +321,90 @@ async def test_doc_reconcile_to_nonexistent_target_is_dropped():
                 select(Reference).where(Reference.target_id == fake_target_doc_id)
             )).scalars().all()
             assert rows == []
+    finally:
+        await engine.dispose()
+
+
+# ─── story #2316 — 셋째 사유: malformed_token(모양은 맞으나 id가 UUID 아님) ─────
+
+
+async def test_chat_mention_with_non_uuid_id_reports_malformed_token():
+    """까심 라이브 재현 — `](entity:task:...)` 모양은 있는데 id 부분이 UUID가 아니다.
+    strict 정규식(id 그룹이 UUID 형태 강제)이 매치 자체를 실패하므로 candidate_ids에도
+    못 들어간다 — 이 테스트가 그 케이스를 dropped 채널로 실제로 드러내는지 증명한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [member_id], member_id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/conversations/{conv_id}/messages",
+                json={"content": "[망가진 토큰](entity:task:not-a-uuid)"},
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["references"]["stored"] == 0, body["references"]
+            assert body["references"]["dropped"] == [
+                {"target_type": "task", "target_id": "not-a-uuid", "reason": "malformed_token"}
+            ], body["references"]
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+async def test_chat_mention_mixing_valid_and_malformed_tokens_reports_both_correctly():
+    """정상 토큰과 망가진 토큰이 한 메시지에 섞이면 — 정상은 저장되고 망가진 것만
+    dropped에 실린다(하나가 다른 하나를 가리지 않는다, 오르테가 «양방향 재기» 규율)."""
+    from app.main import app
+    from app.models.reference import Reference
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [member_id], member_id)
+            story = await _make_story(s, org.id, project.id)
+            task = await _make_task(s, org.id, story.id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/conversations/{conv_id}/messages",
+                json={
+                    "content": (
+                        f"[진짜 작업](entity:task:{task.id}) "
+                        "[망가진 토큰](entity:task:not-a-uuid)"
+                    ),
+                },
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["references"]["stored"] == 1, body["references"]
+            assert body["references"]["dropped"] == [
+                {"target_type": "task", "target_id": "not-a-uuid", "reason": "malformed_token"}
+            ], body["references"]
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Reference).where(Reference.target_id == task.id)
+            )).scalars().all()
+            assert len(rows) == 1
     finally:
         await engine.dispose()

--- a/backend/tests/test_2294_reference_target_existence_gate_realdb.py
+++ b/backend/tests/test_2294_reference_target_existence_gate_realdb.py
@@ -1,0 +1,317 @@
+"""story #2294 후속(2026-07-29, 오르테가 라이브 실측 — 스레드 7256d5cc) —
+`reconcile_entity_references`(mention_parser.py)의 target 실재+org 소속 검증 실PG 검증.
+
+⛔무엇이 어긋나 있었는가: 채팅에 `[제목](entity:task:<존재하지 않는 uuid>)`를 손으로 쳐도
+그대로 `references={"stored": 1, "dropped": []}`로 저장됐다 — 미르코가 코드로 좁힌 자리:
+POST /references(단건)·GET /entities/search는 이미 존재판정(`ENTITY_RESOLVERS`)을 거치는데,
+채팅 전송이 실제로 타는 `reconcile_entity_references`만 target_type(등록된 «타입»인가)만 보고
+target_id의 «실재»는 한 번도 확認하지 않았다.
+
+처방(PO 승인 — 새 게이트 신설 아님): POST /references·GET /search와 같은 계열인
+`reference_core._batch_resolve_existence`(ENTITY_RESOLVERS 그 자체)를 재사용. 각 resolver가
+`WHERE org_id == org_id`로 스코프하므로 실재하지만 다른 org 소속인 UUID도 "없음"으로 걸린다
+(존재+org 소속을 한 번에 검증) — ㉠새는가(보안) 질문에 대한 답이 이것.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _make_org(session, name="Org"):
+    from app.models.organization import Organization
+    org = Organization(id=uuid.uuid4(), name=name, slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    return org
+
+
+async def _make_project(session, org_id, name="P"):
+    from app.models.project import Project
+    project = Project(id=uuid.uuid4(), org_id=org_id, name=name)
+    session.add(project)
+    await session.commit()
+    return project
+
+
+async def _make_human_member(session, org_id, project_id):
+    from app.models.user import User
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.member import Member
+
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="member")
+    session.add(om)
+    await session.flush()
+    m = Member(id=om.id, org_id=org_id, type="human", user_id=user.id, name="Human")
+    session.add(m)
+    await session.flush()
+    session.add(ProjectAccess(project_id=project_id, org_member_id=om.id, member_id=m.id, role="member"))
+    await session.commit()
+    return m.id, user.id
+
+
+async def _make_story(session, org_id, project_id, title="Story"):
+    from app.models.pm import Story
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status="backlog")
+    session.add(story)
+    await session.commit()
+    return story
+
+
+async def _make_task(session, org_id, story_id, title="Task"):
+    from app.models.pm import Task
+    task = Task(id=uuid.uuid4(), org_id=org_id, story_id=story_id, title=title)
+    session.add(task)
+    await session.commit()
+    return task
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+async def _make_conversation(session, org_id, project_id, member_ids, created_by_member_id):
+    from app.models.conversation import Conversation, ConversationParticipant
+    conv = Conversation(
+        id=uuid.uuid4(), project_id=project_id, org_id=org_id, type="dm",
+        title="Test convo", created_by=created_by_member_id,
+    )
+    session.add(conv)
+    await session.flush()
+    for mid in member_ids:
+        session.add(ConversationParticipant(conversation_id=conv.id, member_id=mid))
+    await session.commit()
+    return conv.id
+
+
+# ─── 오르테가가 dev 라이브에 실제로 친 그 시나리오 — 존재하지 않는 task ─────────
+
+
+async def test_chat_mention_to_nonexistent_target_is_dropped_not_stored():
+    from app.main import app
+    from app.models.reference import Reference
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [member_id], member_id)
+
+        fake_task_id = uuid.uuid4()
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/conversations/{conv_id}/messages",
+                json={"content": f"[존재하지 않는 작업](entity:task:{fake_task_id})"},
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["references"]["stored"] == 0, body["references"]
+            assert body["references"]["dropped"] == [
+                {"target_type": "task", "target_id": str(fake_task_id), "reason": "target_not_found"}
+            ], body["references"]
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Reference).where(Reference.target_id == fake_task_id)
+            )).scalars().all()
+            assert rows == [], "존재하지 않는 target을 가리키는 행이 저장되면 안 된다"
+    finally:
+        await engine.dispose()
+
+
+# ─── 크로스-org 실재 UUID — 존재는 하지만 이 org 소속이 아닌 대상 ──────────────
+
+
+async def test_chat_mention_to_real_cross_org_target_is_dropped():
+    """org B에 실재하는 task를 org A의 채팅 메시지가 가리키면 — resolver가 org로
+    스코프하므로 "없음"으로 걸려야 한다(존재+org 소속을 한 번에 검증)."""
+    from app.main import app
+    from app.models.reference import Reference
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_a = await _make_org(s, name="OrgA")
+            project_a = await _make_project(s, org_a.id)
+            member_id, user_id = await _make_human_member(s, org_a.id, project_a.id)
+            conv_id = await _make_conversation(s, org_a.id, project_a.id, [member_id], member_id)
+
+            org_b = await _make_org(s, name="OrgB")
+            project_b = await _make_project(s, org_b.id)
+            story_b = await _make_story(s, org_b.id, project_b.id)
+            task_b = await _make_task(s, org_b.id, story_b.id)
+
+        await _setup_app_human(app, Session, user_id, org_a.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/conversations/{conv_id}/messages",
+                json={"content": f"[타 org 작업](entity:task:{task_b.id})"},
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["references"]["stored"] == 0, body["references"]
+            assert body["references"]["dropped"] == [
+                {"target_type": "task", "target_id": str(task_b.id), "reason": "target_not_found"}
+            ], body["references"]
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Reference).where(Reference.target_id == task_b.id)
+            )).scalars().all()
+            assert rows == [], "크로스-org 실재 target을 가리키는 행이 저장되면 안 된다"
+    finally:
+        await engine.dispose()
+
+
+# ─── 양성대조 — 실재+같은 org 대상은 정상 저장 ──────────────────────────────────
+
+
+async def test_chat_mention_to_real_same_org_target_is_stored():
+    from app.main import app
+    from app.models.reference import Reference
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [member_id], member_id)
+            story = await _make_story(s, org.id, project.id)
+            task = await _make_task(s, org.id, story.id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/conversations/{conv_id}/messages",
+                json={"content": f"[진짜 작업](entity:task:{task.id})"},
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["references"]["stored"] == 1, body["references"]
+            assert body["references"]["dropped"] == [], body["references"]
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Reference).where(Reference.target_id == task.id)
+            )).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].target_type == "task"
+    finally:
+        await engine.dispose()
+
+
+# ─── doc write-path(reconcile_doc_mentions)도 같은 게이트를 탄다 ────────────────
+
+
+async def test_doc_reconcile_to_nonexistent_target_is_dropped():
+    from app.services.mention_parser import reconcile_doc_mentions
+    from app.models.reference import Reference
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+
+            source_doc_id = uuid.uuid4()
+            fake_target_doc_id = uuid.uuid4()
+            html = f'<span data-type="wikiLink" data-doc-id="{fake_target_doc_id}">X</span>'
+
+            # reconcile_doc_mentions는 -> None(반환값 없음) — 존재하지 않는 대상이 «저장
+            # 안 됐는지»는 DB를 직접 대조해 확認한다(로그로 dropped 발화는 이미 확認됨,
+            # 위 캡처된 WARNING 참조).
+            await reconcile_doc_mentions(
+                s, org_id=org.id, doc_id=source_doc_id, html_content=html, created_by=member_id,
+            )
+            await s.commit()
+
+            rows = (await s.execute(
+                select(Reference).where(Reference.target_id == fake_target_doc_id)
+            )).scalars().all()
+            assert rows == []
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2294_task_registry_open_realdb.py
+++ b/backend/tests/test_2294_task_registry_open_realdb.py
@@ -425,7 +425,7 @@ async def test_send_message_with_unregistered_type_mention_reports_dropped(caplo
             body = resp.json()
             assert body["references"]["stored"] == 0
             assert body["references"]["dropped"] == [
-                {"target_type": "goal", "target_id": str(fake_goal_id)}
+                {"target_type": "goal", "target_id": str(fake_goal_id), "reason": "unregistered_target_type"}
             ]
         finally:
             await client.aclose()


### PR DESCRIPTION
## Summary
- 오르테가가 dev 라이브 채팅에 `[존재하지 않는 작업](entity:task:<fake-uuid>)`를 직접 쳐서 확定: 응답이 `{"stored": 1, "dropped": []}`로 참조 행이 그대로 저장됐다.
- 미르코가 코드로 좁힌 자리 — POST /references(단건)·GET /entities/search는 이미 존재판정(`ENTITY_RESOLVERS`)을 거치는데, 채팅 전송이 실제로 타는 `reconcile_entity_references`(mention_parser.py)만 target_type(등록된 타입인가)만 보고 target_id의 실재는 한 번도 확認하지 않았다.
- 까심이 dev 라이브를 읽기 전용으로 훑다 추가 발견(#2316): `](entity:task:...)` 모양은 있는데 id가 UUID가 아닌 토큰은 strict 정규식이 애초에 매치를 못 해 `candidate_ids`에도 못 들어갔다 — `count_phantom_task_mentions`가 이 케이스를 영원히 0건으로 보고하던 이유.

## 보안 판정(㉠새는가) — blast radius 0, 그러나 참조 카드(#2262) 착수 조건
`entity_references` 모델을 실제로 import하는 6개 소비처 전수 grep. 라이브로 도는 읽기 경로는 `list_entity_backlinks`/`list_doc_backlinks`(incoming 방향만) 하나뿐이고, forward 방향 읽기 경로는 `reference_core.list_references`가 코드엔 있지만 어느 라우터에도 안 배선돼 있다(#2299 AC⑥이 이미 선언). 오늘 만들어진 참조 행은 지금 아무도 안 읽어 blast radius 0 — 하지만 참조 카드 기능이 forward-resolve를 열 때 이 write-gap이 문제가 되므로 지금 고친다. FE 확認: 임베드 카드가 `entity_references`를 안 읽고 대상 API를 직접 재호출(양쪽 다 안 샌다).

## 처방 — 새 게이트 신설 아님, 있는 것 재사용
1. `reference_core._batch_resolve_existence`(POST /references·GET /search와 같은 계열)를 재사용. 각 resolver가 `WHERE org_id == org_id`로 스코프하므로 크로스-org 실재 UUID도 "없음"으로 걸린다(존재+org 소속 동시 검증).
2. `find_malformed_chat_tokens`(느슨한 id 캡처 정규식)로 "모양은 맞는데 strict 정규식에 안 걸린" 토큰을 찾아 `insert_chat_mentions`가 `dropped`에 얹는다. 코어에 안 넣는 이유: 코어는 이미 파싱된 `extracted_refs`만 보는 계약이라 추출조차 안 된 토큰은 코어 시야 밖(doc write-path는 HTMLParser라 이 실패 모드가 구조적으로 다름, 이번 스코프 밖).

`dropped` 사유가 이제 셋 — 사람이 할 일이 다르므로 데이터 축으로 가른다(화면 문구는 여전히 종류 안 가림, #2608 규율):
- `unregistered_target_type`(#2294): 타입 자체가 미등록 → 다른 종류로 걸어라
- `target_not_found`(#2294 후속): 타입은 등록됐으나 대상 실재 안 함 → 다시 골라라
- `malformed_token`(#2316): 모양은 맞으나 파싱 실패 → 고쳐 쳐라

## 부수 효과
기존 realdb 테스트 다수가 fabricated `uuid.uuid4()`를 target으로 써서 저장을 검증하고 있었다 — 실재 Doc/Story/Epic 시드로 갱신했다.

## 검증
- realdb 신규 6건: 존재하지 않는 target 드롭 · 크로스-org target 드롭(㉠ 핵심 시험) · 양성대조 · doc write-path도 같은 게이트 · malformed 토큰 단독 재현(까심 시나리오) · 정상+malformed 혼합(하나가 다른 하나를 안 가림)
- RED→GREEN 2세트: 존재판정 사보타주(3건 실패) · malformed 탐지 사보타주(2건 실패) — 둘 다 원복 후 git diff 무변경
- mention/reference 인접 realdb 79/79 GREEN + 전체 회귀 4246 pass(기존 미관련 베이스라인만)

## Test plan
- [x] realdb 신규 6건 GREEN
- [x] RED→GREEN self-check 2세트
- [x] 전체 회귀 무관련 확인
- [ ] CI 확인 대기

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>