### PR TITLE
[SID:2315] story 저장 참조 사이드밴드 FE 반쪽 — BE 도착 전 안전하게 먼저 배선

### DIFF
--- a/apps/web/src/components/chat/reference-drop-notice.test.ts
+++ b/apps/web/src/components/chat/reference-drop-notice.test.ts
@@ -36,4 +36,20 @@ describe('parseDroppedReferences', () => {
     expect(parseDroppedReferences(undefined)).toEqual([]);
     expect(parseDroppedReferences('garbage')).toEqual([]);
   });
+
+  // #2612 — dropped 항목에 reason이 붙었다(unregistered_target_type/target_not_found/
+  // malformed_token). FE는 이걸로 분기하지 않으므로(AC9) reason 유무와 무관하게 개수만
+  // 맞으면 된다 — reason 값 자체를 검증/필터링하지 않는 것이 의도다.
+  it('reason이 실려도(#2612) 그대로 통과한다 — 값을 검증/분기하지 않는다', () => {
+    const raw = {
+      references: {
+        dropped: [
+          { target_type: 'task', target_id: 't1', reason: 'unregistered_target_type' },
+          { target_type: 'story', target_id: 's1', reason: 'target_not_found' },
+          { target_type: 'epic', target_id: 'e1', reason: 'malformed_token' },
+        ],
+      },
+    };
+    expect(parseDroppedReferences(raw)).toHaveLength(3);
+  });
 });

--- a/apps/web/src/components/chat/reference-drop-notice.tsx
+++ b/apps/web/src/components/chat/reference-drop-notice.tsx
@@ -4,14 +4,17 @@ import { X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
 /**
- * story #2294 AC8/AC9/AC11 — 메시지 전송 응답 최상위(`data`의 형제, `conversations.py:2165`)
- * `references.dropped[]` 1건. BE는 `target_type`/`target_id`만 준다 — FE는 그것으로 **분기하지
- * 않는다**(분기하면 그 자체가 "화면이 종류를 아는 것"이 되어 AC9 "종류-무관"이 깨진다). 그래서
- * 이 타입엔 일부러 target_type을 안 실었다 — 개수만 센다.
+ * story #2294 AC8/AC9/AC11 — 메시지 전송(및 #2315: story PATCH) 응답 최상위(`data`의 형제,
+ * `conversations.py:2165`) `references.dropped[]` 1건. BE(#2612)는 `reason`도 함께 싣는다
+ * (`unregistered_target_type`/`target_not_found`/`malformed_token`) — FE는 그것으로 **분기하지
+ * 않는다**(분기하면 그 자체가 "화면이 이유/종류를 아는 것"이 되어 AC9 "종류-무관"이 깨진다).
+ * 그래서 `reason`을 구체 리터럴 유니온이 아니라 `string`으로만 받는다 — BE가 사유를 넷·다섯으로
+ * 늘려도 이 파일이 그 집합을 다시 나열(twin-system)하지 않게. 개수만 센다.
  */
 export interface DroppedReference {
   target_type: string;
   target_id: string;
+  reason?: string;
 }
 
 /**

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -14,6 +14,7 @@ import { imageFilesFromClipboard } from '@/lib/clipboard-image';
 import { parseCursorMeta } from '@/lib/pagination';
 import { AttachmentImage } from '@/components/chat/attachment-image';
 import { AttachmentFile } from '@/components/chat/attachment-file';
+import { ReferenceDropNotice, parseDroppedReferences, type DroppedReference } from '@/components/chat/reference-drop-notice';
 import { LabelChip, LABEL_PRESET_COLORS, type LabelData } from '@/components/ui/label-chip';
 import { DependencyGraph } from './dependency-graph';
 import { OutcomeResultCard, type OutcomeResult } from '@/components/outcome/outcome-result-card';
@@ -181,6 +182,10 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   const [editingAC, setEditingAC] = useState(false);
   const [acDraft, setAcDraft] = useState(story.acceptance_criteria ?? '');
   const [savingAC, setSavingAC] = useState(false);
+  // story #2315 — description/acceptance_criteria PATCH가 참조를 조용히 거를 수 있다(#2294와
+  // 같은 병, story 저장 축). BE가 아직 사이드밴드를 안 실어도(parseDroppedReferences가 빈
+  // 배열로 폴백) 안 깨지고, 실으면 바로 뜬다 — ephemeral(persist 안 함·패널 재오픈 시 소멸).
+  const [referenceDropped, setReferenceDropped] = useState<DroppedReference[]>([]);
   const [uploadingAttachment, setUploadingAttachment] = useState(false);
   const [attachError, setAttachError] = useState(false);
   const attachInputRef = useRef<HTMLInputElement>(null);
@@ -489,15 +494,21 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     body: c.content,
   }));
 
-  const patchStory = async (body: Record<string, unknown>): Promise<KanbanStory | null> => {
+  // story #2315 — patchStory는 예전엔 `json.data`만 읽어 최상위 형제 필드를 전부 버렸다(채팅
+  // handleSend가 raw 최상위에서 command_gate를 읽는 것과 같은 자리인데, 여기는 그렇게 안 하고
+  // 있었다). description/acceptance_criteria PATCH는 BE가 참조를 추출하는데(#2599)
+  // 그 결과(`references.dropped[]`)를 아직 안 실어보내는 상태 — 그래도 미리 읽는 쪽을 갖춰
+  // 둔다: parseDroppedReferences는 필드가 없으면 빈 배열로 안전하게 폴백하므로(throw 0),
+  // BE가 나중에 사이드밴드를 실어도 FE를 따로 안 건드려도 되고, 지금 당장도 안 깨진다.
+  const patchStory = async (body: Record<string, unknown>): Promise<{ story: KanbanStory | null; dropped: DroppedReference[] }> => {
     const res = await fetch(`/api/stories/${story.id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
-    if (!res.ok) return null;
+    if (!res.ok) return { story: null, dropped: [] };
     const json = await res.json();
-    return json.data as KanbanStory;
+    return { story: json.data as KanbanStory, dropped: parseDroppedReferences(json) };
   };
 
   const handleChangeStatus = async (newStatus: string) => {
@@ -538,7 +549,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
       return;
     }
     setSavingTitle(true);
-    const updated = await patchStory({ title: titleDraft.trim() });
+    const { story: updated } = await patchStory({ title: titleDraft.trim() });
     setSavingTitle(false);
     setEditingTitle(false);
     if (updated) onStoryUpdate?.({ ...story, title: updated.title });
@@ -566,7 +577,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     assigneeIdsRef.current = next;   // 동기 갱신 → 연타 시 다음 클릭이 최신 기준으로 계산
     setLocalAssigneeIds(next);       // 옵티미스틱 — 체크마크/표시 즉시 반영
     // assignee_ids 전체 배열 교체(서버 last-write-wins) → 연타 시 마지막 로컬과 정합.
-    const updated = await patchStory({ assignee_ids: next });
+    const { story: updated } = await patchStory({ assignee_ids: next });
     if (updated) {
       // story #2133 — BE 응답(assignee_ids 우선, 없으면 로컬 next)을 normalizeAssigneePatch로
       // 통과시켜 assignee_id를 손으로 다시 계산하지 않는다.
@@ -586,7 +597,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     assigneeIdsRef.current = [];
     setLocalAssigneeIds([]);         // 옵티미스틱
     setEditingAssignee(false);
-    const updated = await patchStory({ assignee_ids: [] });
+    const { story: updated } = await patchStory({ assignee_ids: [] });
     if (updated) {
       onStoryUpdate?.({ ...story, ...normalizeAssigneePatch({ assignee_ids: [] }) });
     } else {
@@ -602,9 +613,10 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
       return;
     }
     setSavingDescription(true);
-    const updated = await patchStory({ description: descriptionDraft || null });
+    const { story: updated, dropped } = await patchStory({ description: descriptionDraft || null });
     setSavingDescription(false);
     setEditingDescription(false);
+    setReferenceDropped(dropped);
     if (updated) onStoryUpdate?.({ ...story, description: updated.description });
   };
 
@@ -614,9 +626,10 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
       return;
     }
     setSavingAC(true);
-    const updated = await patchStory({ acceptance_criteria: acDraft || null });
+    const { story: updated, dropped } = await patchStory({ acceptance_criteria: acDraft || null });
     setSavingAC(false);
     setEditingAC(false);
+    setReferenceDropped(dropped);
     if (updated) onStoryUpdate?.({ ...story, acceptance_criteria: updated.acceptance_criteria });
   };
 
@@ -639,7 +652,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
         uploaded.push(await res.json() as SendAttachment);
       }
       const next = [...current, ...uploaded]; // 전체 교체: 기존 보존 + 신규 누적
-      const updated = await patchStory({ attachments: next });
+      const { story: updated } = await patchStory({ attachments: next });
       onStoryUpdate?.({ ...story, attachments: updated?.attachments ?? next });
     } catch {
       setAttachError(true);
@@ -660,7 +673,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
 
   const handleRemoveAttachment = async (url: string) => {
     const next = (story.attachments ?? []).filter((a) => a.url !== url); // filter → 전체 교체
-    const updated = await patchStory({ attachments: next });
+    const { story: updated } = await patchStory({ attachments: next });
     onStoryUpdate?.({ ...story, attachments: updated?.attachments ?? next });
   };
 
@@ -1188,6 +1201,12 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 </button>
               )}
             </div>
+
+            {/* story #2315 — description/acceptance_criteria 저장이 참조를 조용히 거를 수
+                있다는 것을 화면이 말한다(#2294와 동일 컴포넌트·동일 규율 — 종류-무관 문구). */}
+            {referenceDropped.length > 0 && (
+              <ReferenceDropNotice dropped={referenceDropped} onDismiss={() => setReferenceDropped([])} />
+            )}
 
             {/* Attachments — chat-attach 자산 미러 (E-FILE S4) */}
             <div>


### PR DESCRIPTION
## 배경
채팅 전송은 `references: {stored, dropped[]}`를 응답 최상위(`data`의 형제)에 실어 화면이 저장실패를 말할 수 있다(#2294). story PATCH도 #2599로 참조 추출(description·acceptance_criteria)이 도는데 그 결과를 응답에 안 싣는다(grep 0건 — Ortega 실측 확인) — 채팅에서 고친 병이 story 저장 축엔 그대로 남아 있었다.

게다가 FE 쪽에 짝이 되는 잠자는 위험이 있었다: `story-detail-panel.tsx`의 `patchStory()`가 `json.data`만 읽어 최상위 형제 필드를 전부 버린다 — BE가 사이드밴드를 실어도 이 자리가 조용히 버리는 상태였다.

## 이 PR의 범위 — FE 반쪽만(AC1은 BE, Didi 담당·#2612 이후 순서)
BE(AC1, story PATCH 응답에 `references` 삽입)는 backend/라 제 스코프(apps/web) 밖 — Ortega가 Didi에게 순서를 맡겼다. 이 PR은 AC2(FE가 그것을 읽는다)만 다룬다.

**BE보다 먼저 안전하게 나갈 수 있는 이유**: `parseDroppedReferences`(#2294에서 이미 만든 것)가 `references` 필드 자체가 없으면 빈 배열로 폴백한다(throw 0) — 그래서 이 PR이 먼저 머지돼도 지금 당장 아무것도 안 깨지고, BE가 나중에 필드를 실으면 FE를 다시 안 건드려도 그대로 작동한다. #2294에서 났던 "BE만 서고 FE가 반년 안 읽음"의 반대 실패(FE만 서고 BE가 아직 안 실음)도 이 폴백 덕에 안전하다.

## 변경
- `patchStory()`: `json.data`만 반환하던 것을 `{ story, dropped }`로 확장 — 7개 호출부 전부 갱신(title/assignee×2/description/acceptance_criteria/attachments×2). description·acceptance_criteria 저장 시에만 `dropped`를 로컬 state(`referenceDropped`)에 반영.
- `ReferenceDropNotice`/`parseDroppedReferences`(#2294 컴포넌트 그대로 재사용, story 전용 변형 신설 안 함) — AC/설명 저장 섹션 바로 아래 렌더.
- **AC1(필드 구분 여부) 판정**: description·acceptance_criteria 어느 쪽에서 나온 dropped인지 화면이 구분하지 않는다 — Ortega 확정: "종류를 화면이 분기 안 하는 것과 같은 이유로 필드도 안 밝힌다"(BE는 두 호출의 dropped를 평면 배열 하나로 합쳐 실어야 함, 채팅과 한 글자도 다르지 않은 모양).
- `DroppedReference.reason`을 `#2612`가 추가한 3종(`unregistered_target_type`/`target_not_found`/`malformed_token`) 리터럴 유니온이 아니라 `string`으로 — FE가 이 값으로 분기하지 않으므로(AC9) BE 소유 enum을 이 파일에 다시 나열하지 않기 위함.

## 테스트
- `reference-drop-notice.test.ts`: 기존 6건 + `reason` 필드가 실려도 개수만 세고 값은 검증/분기하지 않는 것 1건 추가(7건).
- `story-detail-panel.tsx`에는 기존 테스트 파일이 없다(대형 컴포넌트, 다수 컨텍스트 의존) — 새 로직의 핵심(파싱)은 이미 `reference-drop-notice.test.ts`가 커버하고, 7개 호출부의 타입 정합은 `tsc`가 강제한다. 신규 무거운 렌더 테스트 인프라를 이 작은 fix를 위해 새로 짓지 않았다.
- 전체 스윕: `tsc --noEmit` 0 errors · `eslint`(대상 파일) 0 warnings · `vitest run`(전체) 307 files/2028 tests pass · `pnpm build` 성공.

## ⛔라이브 검증 — BE(AC1) 도착 후 필요
AC4(침묵이 실제로 깨지는 것 실측)는 BE가 사이드밴드를 실어야 재현 가능하다 — 지금은 폴백 경로(필드 없음→빈 배열→알림 미노출)만 확인 가능한 상태. BE 머지 확인되면 #2294와 같은 puppeteer A/B/C 패턴으로 재확인하겠다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)