### PR TITLE
fix(entities): per-type quota, truncation counts, and picker identifiers in search

### DIFF
--- a/backend/app/routers/entities.py
+++ b/backend/app/routers/entities.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
-from sqlalchemy import and_, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
@@ -38,6 +38,25 @@ class EntitySearchResult(BaseModel):
     title: str
     status: str | None = None
     created_at: datetime
+    # ⭐story #2263(C-5) 계약③(PO 확定, 2026-07-28 유나 실측 뒤) — 「고르는 자리」는 status를
+    # 쓰지 않는다(어느 것인가 문제이지 지금 상태 문제가 아니라서). 대신 실제 식별자를 담는다.
+    # 종류마다 있는 재료만 채운다 — 없는 종류에 억지로 값을 만들지 않는다.
+    number: int | None = None  # 사람-읽는 순번(story의 story_number, task는 소속 story 순번)
+    epic_title: str | None = None  # 소속 에픽 제목(있는 종류만 — story/task/artifact)
+    identifier: str | None = None  # 그 외 문자열 식별자(doc의 slug — 사람이 손으로 복사하는 실키)
+
+
+class EntitySearchTypeMeta(BaseModel):
+    """⭐계약② — 「보여준 건수」와 「전체 건수」. 화면이 «몇 건 더 있다»를 지어내지 않고
+    이 수를 그대로 쓰게 한다."""
+
+    shown: int
+    total: int
+
+
+class EntitySearchResponse(BaseModel):
+    data: list[EntitySearchResult]
+    types: dict[str, EntitySearchTypeMeta]
 
 
 # ⛔story #2294 B단계 후속(오르테가 라이브 실측, 2026-07-29): "받아들이는 것"(_valid_types,
@@ -53,136 +72,186 @@ class EntitySearchResult(BaseModel):
 # 던진다 — "받는데 못 찾는" 상태를 다시는 침묵시키지 않는다. 키 집합 동일성은
 # test_2294_entities_search_open_4_types_realdb.py가 twin-key 테스트로 고정한다(#2283이
 # 세운 그 자와 동형 — 한쪽만 열리면 RED).
+#
+# ⭐story #2263(C-5) 계약①·② — handler가 items뿐 아니라 (items, total) 을 함께 준다. total은
+# DEFAULT_LIMIT 로 안 잘린 실제 매치 건수(계약②가 요구하는 "전체 건수" 그 자체) — items는
+# 지금까지처럼 최대 DEFAULT_LIMIT 개까지만 끌어온다(종류별 보장 몫이 DEFAULT_LIMIT 를 넘을 수
+# 없으므로 이걸로 충분하다).
 EntitySearchHandler = Callable[
-    [AsyncSession, uuid.UUID, uuid.UUID, "str | None"], Awaitable[list[EntitySearchResult]]
+    [AsyncSession, uuid.UUID, uuid.UUID, "str | None"],
+    Awaitable[tuple[list[EntitySearchResult], int]],
 ]
 
 
 async def _search_stories(
     db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID, search: str | None,
-) -> list[EntitySearchResult]:
-    stmt = select(Story.id, Story.title, Story.status, Story.created_at).where(
-        Story.org_id == org_id, Story.project_id == project_id, Story.deleted_at.is_(None),
-    )
+) -> tuple[list[EntitySearchResult], int]:
+    conditions = [Story.org_id == org_id, Story.project_id == project_id, Story.deleted_at.is_(None)]
     if search:
-        stmt = stmt.where(Story.title.ilike(search))
-    stmt = stmt.order_by(Story.created_at.desc()).limit(DEFAULT_LIMIT)
+        conditions.append(Story.title.ilike(search))
+    total = (await db.execute(select(func.count()).select_from(Story).where(*conditions))).scalar_one()
+    stmt = (
+        select(Story.id, Story.title, Story.status, Story.created_at, Story.story_number, Goal.title)
+        .outerjoin(Goal, Goal.id == Story.epic_id)
+        .where(*conditions)
+        .order_by(Story.created_at.desc())
+        .limit(DEFAULT_LIMIT)
+    )
     rows = await db.execute(stmt)
     return [
-        EntitySearchResult(entity_type="story", entity_id=rid, title=title, status=st, created_at=cat)
-        for rid, title, st, cat in rows
-    ]
+        EntitySearchResult(
+            entity_type="story", entity_id=rid, title=title, status=st, created_at=cat,
+            number=num, epic_title=epic_title,
+        )
+        for rid, title, st, cat, num, epic_title in rows
+    ], total
 
 
 async def _search_docs(
     db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID, search: str | None,
-) -> list[EntitySearchResult]:
-    stmt = select(Doc.id, Doc.title, Doc.created_at).where(
-        Doc.org_id == org_id, Doc.project_id == project_id, Doc.deleted_at.is_(None),
-    )
+) -> tuple[list[EntitySearchResult], int]:
+    conditions = [Doc.org_id == org_id, Doc.project_id == project_id, Doc.deleted_at.is_(None)]
     if search:
-        stmt = stmt.where(Doc.title.ilike(search))
-    stmt = stmt.order_by(Doc.created_at.desc()).limit(DEFAULT_LIMIT)
+        conditions.append(Doc.title.ilike(search))
+    total = (await db.execute(select(func.count()).select_from(Doc).where(*conditions))).scalar_one()
+    stmt = (
+        select(Doc.id, Doc.title, Doc.created_at, Doc.slug)
+        .where(*conditions)
+        .order_by(Doc.created_at.desc())
+        .limit(DEFAULT_LIMIT)
+    )
     rows = await db.execute(stmt)
     return [
-        EntitySearchResult(entity_type="doc", entity_id=rid, title=title, created_at=cat)
-        for rid, title, cat in rows
-    ]
+        EntitySearchResult(entity_type="doc", entity_id=rid, title=title, created_at=cat, identifier=slug)
+        for rid, title, cat, slug in rows
+    ], total
 
 
 async def _search_epics(
     db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID, search: str | None,
-) -> list[EntitySearchResult]:
-    stmt = select(Goal.id, Goal.title, Goal.status, Goal.created_at).where(
-        Goal.org_id == org_id, Goal.project_id == project_id,
-    )
+) -> tuple[list[EntitySearchResult], int]:
+    conditions = [Goal.org_id == org_id, Goal.project_id == project_id]
     if search:
-        stmt = stmt.where(Goal.title.ilike(search))
-    stmt = stmt.order_by(Goal.created_at.desc()).limit(DEFAULT_LIMIT)
+        conditions.append(Goal.title.ilike(search))
+    total = (await db.execute(select(func.count()).select_from(Goal).where(*conditions))).scalar_one()
+    stmt = (
+        select(Goal.id, Goal.title, Goal.status, Goal.created_at)
+        .where(*conditions)
+        .order_by(Goal.created_at.desc())
+        .limit(DEFAULT_LIMIT)
+    )
     rows = await db.execute(stmt)
     return [
         EntitySearchResult(entity_type="epic", entity_id=rid, title=title, status=st, created_at=cat)
         for rid, title, st, cat in rows
-    ]
+    ], total
 
 
 async def _search_tasks(
     db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID, search: str | None,
-) -> list[EntitySearchResult]:
-    stmt = (
-        select(Task.id, Task.title, Task.status, Task.created_at)
-        .join(Story, Task.story_id == Story.id)
-        .where(Task.org_id == org_id, Story.project_id == project_id, Task.deleted_at.is_(None))
-    )
+) -> tuple[list[EntitySearchResult], int]:
+    conditions = [Task.org_id == org_id, Story.project_id == project_id, Task.deleted_at.is_(None)]
     if search:
-        stmt = stmt.where(Task.title.ilike(search))
-    stmt = stmt.order_by(Task.created_at.desc()).limit(DEFAULT_LIMIT)
+        conditions.append(Task.title.ilike(search))
+    count_stmt = select(func.count()).select_from(Task).join(Story, Task.story_id == Story.id).where(*conditions)
+    total = (await db.execute(count_stmt)).scalar_one()
+    stmt = (
+        select(Task.id, Task.title, Task.status, Task.created_at, Story.story_number, Goal.title)
+        .join(Story, Task.story_id == Story.id)
+        .outerjoin(Goal, Goal.id == Story.epic_id)
+        .where(*conditions)
+        .order_by(Task.created_at.desc())
+        .limit(DEFAULT_LIMIT)
+    )
     rows = await db.execute(stmt)
     return [
-        EntitySearchResult(entity_type="task", entity_id=rid, title=title, status=st, created_at=cat)
-        for rid, title, st, cat in rows
-    ]
+        EntitySearchResult(
+            entity_type="task", entity_id=rid, title=title, status=st, created_at=cat,
+            number=num, epic_title=epic_title,
+        )
+        for rid, title, st, cat, num, epic_title in rows
+    ], total
 
 
 async def _search_sprints(
     db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID, search: str | None,
-) -> list[EntitySearchResult]:
-    stmt = select(Sprint.id, Sprint.title, Sprint.status, Sprint.created_at).where(
-        Sprint.org_id == org_id, Sprint.project_id == project_id,
-    )
+) -> tuple[list[EntitySearchResult], int]:
+    conditions = [Sprint.org_id == org_id, Sprint.project_id == project_id]
     if search:
-        stmt = stmt.where(Sprint.title.ilike(search))
-    stmt = stmt.order_by(Sprint.created_at.desc()).limit(DEFAULT_LIMIT)
+        conditions.append(Sprint.title.ilike(search))
+    total = (await db.execute(select(func.count()).select_from(Sprint).where(*conditions))).scalar_one()
+    stmt = (
+        select(Sprint.id, Sprint.title, Sprint.status, Sprint.created_at)
+        .where(*conditions)
+        .order_by(Sprint.created_at.desc())
+        .limit(DEFAULT_LIMIT)
+    )
     rows = await db.execute(stmt)
     return [
         EntitySearchResult(entity_type="sprint", entity_id=rid, title=title, status=st, created_at=cat)
         for rid, title, st, cat in rows
-    ]
+    ], total
 
 
 async def _search_artifacts(
     db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID, search: str | None,
-) -> list[EntitySearchResult]:
-    stmt = select(VisualArtifact.id, VisualArtifact.title, VisualArtifact.created_at).where(
+) -> tuple[list[EntitySearchResult], int]:
+    conditions = [
         VisualArtifact.org_id == org_id, VisualArtifact.project_id == project_id,
         VisualArtifact.deleted_at.is_(None),
-    )
+    ]
     if search:
-        stmt = stmt.where(VisualArtifact.title.ilike(search))
-    stmt = stmt.order_by(VisualArtifact.created_at.desc()).limit(DEFAULT_LIMIT)
+        conditions.append(VisualArtifact.title.ilike(search))
+    total = (await db.execute(select(func.count()).select_from(VisualArtifact).where(*conditions))).scalar_one()
+    stmt = (
+        select(VisualArtifact.id, VisualArtifact.title, VisualArtifact.created_at, Goal.title)
+        .outerjoin(Goal, Goal.id == VisualArtifact.epic_id)
+        .where(*conditions)
+        .order_by(VisualArtifact.created_at.desc())
+        .limit(DEFAULT_LIMIT)
+    )
     rows = await db.execute(stmt)
     return [
-        EntitySearchResult(entity_type="artifact", entity_id=rid, title=title, created_at=cat)
-        for rid, title, cat in rows
-    ]
+        EntitySearchResult(entity_type="artifact", entity_id=rid, title=title, created_at=cat, epic_title=epic_title)
+        for rid, title, cat, epic_title in rows
+    ], total
 
 
 async def _search_hypotheses(
     db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID, search: str | None,
-) -> list[EntitySearchResult]:
+) -> tuple[list[EntitySearchResult], int]:
     # Hypothesis엔 title 칼럼이 없다 — §2.2.4 "유일한 수동 텍스트 입력"인 statement가 제목
     # 대응 필드(reference_registry._project_id_of_hypothesis와 별개로, 검색 표시용 텍스트
     # 선택은 이 파일의 판단 — statement 외엔 사람이 읽을 자유텍스트가 없다).
-    stmt = select(Hypothesis.id, Hypothesis.statement, Hypothesis.status, Hypothesis.created_at).where(
-        Hypothesis.org_id == org_id, Hypothesis.project_id == project_id,
-    )
+    conditions = [Hypothesis.org_id == org_id, Hypothesis.project_id == project_id]
     if search:
-        stmt = stmt.where(Hypothesis.statement.ilike(search))
-    stmt = stmt.order_by(Hypothesis.created_at.desc()).limit(DEFAULT_LIMIT)
+        conditions.append(Hypothesis.statement.ilike(search))
+    total = (await db.execute(select(func.count()).select_from(Hypothesis).where(*conditions))).scalar_one()
+    stmt = (
+        select(Hypothesis.id, Hypothesis.statement, Hypothesis.status, Hypothesis.created_at)
+        .where(*conditions)
+        .order_by(Hypothesis.created_at.desc())
+        .limit(DEFAULT_LIMIT)
+    )
     rows = await db.execute(stmt)
     return [
         EntitySearchResult(entity_type="hypothesis", entity_id=rid, title=statement, status=st, created_at=cat)
         for rid, statement, st, cat in rows
-    ]
+    ], total
 
 
 async def _search_evidence(
     db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID, search: str | None,
-) -> list[EntitySearchResult]:
+) -> tuple[list[EntitySearchResult], int]:
     """Evidence는 project_id가 없다(work_item_id/work_item_type로 story/task를 폴리모픽
     참조 — reference_registry._project_id_of_evidence와 동일 축) — story-경유·task-경유
     둘을 각각 join해 project 스코프를 건다. title 대응 칼럼도 없어(자유텍스트가 아니라
-    ref/note/source) `ref`(NOT NULL)를 표시 필드로 쓴다."""
+    ref/note/source) `ref`(NOT NULL)를 표시 필드로 쓴다.
+
+    두 경유 쿼리 모두 LIMIT 없이 전량을 끌어온 뒤 파이썬에서 합쳐 정렬·자르므로(원래부터
+    그랬다) `len(combined)`가 이미 DEFAULT_LIMIT 에 안 잘린 계약②의 total 그 자체다 —
+    별도 count 쿼리가 필요 없다.
+    """
     via_story = (
         select(Evidence.id, Evidence.ref, Evidence.created_at)
         .join(Story, and_(Story.id == Evidence.work_item_id, Evidence.work_item_type == "story"))
@@ -204,16 +273,22 @@ async def _search_evidence(
         via_task = via_task.where(Evidence.ref.ilike(search))
     story_rows = (await db.execute(via_story)).all()
     task_rows = (await db.execute(via_task)).all()
-    combined = sorted(story_rows + task_rows, key=lambda r: r[2], reverse=True)[:DEFAULT_LIMIT]
+    combined = story_rows + task_rows
+    total = len(combined)
+    top = sorted(combined, key=lambda r: r[2], reverse=True)[:DEFAULT_LIMIT]
     return [
         EntitySearchResult(entity_type="evidence", entity_id=rid, title=ref, created_at=cat)
-        for rid, ref, cat in combined
-    ]
+        for rid, ref, cat in top
+    ], total
 
 
 # ⛔이 dict가 "찾는 것" 축의 유일한 SSOT — registry(ENTITY_RESOLVERS, "받아들이는 것" 축)와
 # 별개 dict로 둔다(reference_registry.py의 PROJECT_ID_RESOLVERS와 동일 twin-system 원칙 —
 # 합치면 한쪽만 늘리고 잊는 조용한 누락이 재발한다). 키 집합 동일성은 테스트로 고정.
+#
+# ⭐story #2263(C-5) 계약① — 이 dict의 삽입 순서를 search_entities의 종류별 순회 순서로도
+# 쓴다(고정·이름 무관). 정렬축(가나다·최신)이 그대로 "종류 편향"이 됐던 게 원래 결함이었으므로,
+# 종류를 도는 순서 자체가 텍스트 정렬에서 나오면 같은 함정을 반복하는 것이다.
 _SEARCH_HANDLERS: dict[str, "EntitySearchHandler"] = {
     "story": _search_stories,
     "doc": _search_docs,
@@ -226,7 +301,7 @@ _SEARCH_HANDLERS: dict[str, "EntitySearchHandler"] = {
 }
 
 
-@router.get("/search", response_model=list[EntitySearchResult])
+@router.get("/search", response_model=EntitySearchResponse)
 async def search_entities(
     project_id: uuid.UUID = Query(...),
     q: str | None = Query(default=None),
@@ -234,7 +309,7 @@ async def search_entities(
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
-) -> list[EntitySearchResult]:
+) -> EntitySearchResponse:
     # ratchet round4(story 03ee87cc): project_id 쿼리파라미터(조회대상 자체)에 caller
     # 접근권 검증이 없어 same-org cross-project의 여러 종류 title(+ILIKE 검색 매칭 시 내용
     # 존재여부)까지 한 엔드포인트에서 동시 노출됐다 — resource-actual 직접검증.
@@ -246,9 +321,22 @@ async def search_entities(
     requested = requested & valid_types
 
     search = f"%{q}%" if q else None
-    results: list[EntitySearchResult] = []
 
-    for entity_type in requested:
+    # ⭐story #2263(C-5) 계약① — 전체를 한 줄로 세워 자르지 않는다(유나 실측: 종류가 넷일 땐
+    # 평균 2.5/종류인데 여덟이 되면 1.25/종류라 어떤 종류는 후보에 «아예» 안 나오고, 편향의
+    # 원인도 가나다 정렬이라 사람이 짐작조차 못 한다). 각 종류가 먼저 최소 보장 몫을 받고,
+    # 남는 자리만 관련도로 채운다 — 종류 수가 늘어도 "어떤 종류든 최소 하나는 자리를 얻는다"는
+    # 이 성질이 유지된다.
+    # ⛔_SEARCH_HANDLERS에 없는(=원래 500을 던져야 하는) 요청 타입도 순회에 남겨야
+    # 아래 "handler is None" 방어가 여전히 걸린다 — _SEARCH_HANDLERS 기준으로만 돌면
+    # 그 타입 자체가 순회에서 통째로 빠져 방어가 무력화된다(직접 sabotage로 잡아낸 회귀).
+    ordered_types = [t for t in _SEARCH_HANDLERS if t in requested]
+    ordered_types += [t for t in requested if t not in _SEARCH_HANDLERS]
+    num_types = len(ordered_types)
+
+    fetched: dict[str, list[EntitySearchResult]] = {}
+    totals: dict[str, int] = {}
+    for entity_type in ordered_types:
         handler = _SEARCH_HANDLERS.get(entity_type)
         if handler is None:
             # ⛔registry엔 있는데 검색 handler가 없다 — "조용히 0건"으로 다시 넘기지 않는다
@@ -257,11 +345,38 @@ async def search_entities(
                 status_code=500,
                 detail=f"Entity type '{entity_type}' is registered but has no search handler",
             )
-        results.extend(await handler(db, org_id, project_id, search))
+        items, total = await handler(db, org_id, project_id, search)
+        fetched[entity_type] = items
+        totals[entity_type] = total
 
+    guaranteed = max(1, DEFAULT_LIMIT // num_types) if num_types else 0
+    selected: dict[str, list[EntitySearchResult]] = {t: fetched[t][:guaranteed] for t in ordered_types}
+    used = sum(len(v) for v in selected.values())
+    remaining_budget = DEFAULT_LIMIT - used
+
+    if remaining_budget > 0:
+        # 보장 몫을 채우고 남는 자리는 관련도(현재 정렬축과 동일)로 채운다 — 이미 선택된
+        # 항목을 뺀 나머지 후보 «전체»를 대상으로 하므로 특정 종류로 쏠릴 수 있으나, 이미
+        # 모든 종류가 최소 하나는 확보한 뒤라 계약①이 요구하는 "아예 안 나오는 종류 0"은
+        # 이 단계와 무관하게 성립한다.
+        leftover: list[EntitySearchResult] = []
+        for t in ordered_types:
+            leftover.extend(fetched[t][guaranteed:])
+        if search:
+            leftover.sort(key=lambda r: r.title.lower())
+        else:
+            leftover.sort(key=lambda r: r.created_at, reverse=True)
+        for item in leftover[:remaining_budget]:
+            selected[item.entity_type].append(item)
+
+    # ⭐계약② — 응답이 "잘렸음"을 들고 온다: 종류별 보여준 건수(shown)와 전체 건수(total)를
+    # 그대로 준다. 화면이 "이 종류에서 N건 더"를 지어내지 않게 한다.
+    types_meta = {t: EntitySearchTypeMeta(shown=len(selected[t]), total=totals[t]) for t in ordered_types}
+
+    data: list[EntitySearchResult] = [item for t in ordered_types for item in selected[t]]
     if search:
-        results.sort(key=lambda r: r.title.lower())
+        data.sort(key=lambda r: r.title.lower())
     else:
-        results.sort(key=lambda r: r.created_at, reverse=True)
+        data.sort(key=lambda r: r.created_at, reverse=True)
 
-    return results[:DEFAULT_LIMIT]
+    return EntitySearchResponse(data=data, types=types_meta)

--- a/backend/tests/test_2263_entities_search_quota_contract_realdb.py
+++ b/backend/tests/test_2263_entities_search_quota_contract_realdb.py
@@ -1,0 +1,343 @@
+"""story #2263(C-5) BE 계약 셋(PO 확定, 2026-07-28 유나 실측 뒤) — entities.py search_entities
+재설계 검증.
+
+⛔유나 실측: 종류별 최대 DEFAULT_LIMIT(10)건씩 뽑은 뒤 «전체를 한 줄로 세워» 10건으로
+자르던 것(entities.py:119 구 `results[:DEFAULT_LIMIT]`)이 종류 수가 늘수록(4→8) 평균
+몫이 줄어(2.5→1.25) 어떤 종류는 후보에 «아예» 안 나오게 만들었다. 편향의 원인도 정렬축
+(가나다·최신)이라 사람이 짐작조차 못 했다.
+
+처방 셋:
+①종류마다 최소 보장 몫 — 남는 자리만 관련도로 채운다(전체를 한 줄로 세워 자르지 않는다).
+②응답이 종류별 shown/total(=truncation)을 들고 온다 — 화면이 "몇 건 더"를 지어내지 않게.
+③고르는 재료(number·epic_title 등)를 status 대신 응답에 담는다.
+
+아래 테스트는 «양성대조»다 — Yuna가 실측한 정확히 그 붕괴 모양(여러 종류에 여러 건씩 있는데
+naive global-cut이면 특정 종류가 통째로 사라지는 것)을 재현해, 새 코드가 그것을 막는지를
+직접 증명한다(구 코드로 되돌리면 이 테스트들이 RED가 되는 것까지 확認했다).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from tests.test_2294_entities_search_open_4_types_realdb import (
+    _client_for,
+    _make_artifact,
+    _make_evidence,
+    _make_human_member,
+    _make_hypothesis,
+    _make_org,
+    _make_project,
+    _make_sprint,
+    _session_factory,
+    _setup_app_human,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _make_story(session, org_id, project_id, title, epic_id=None, story_number=None, created_at=None):
+    from app.models.pm import Story
+    kwargs = dict(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status="backlog")
+    if epic_id is not None:
+        kwargs["epic_id"] = epic_id
+    if story_number is not None:
+        kwargs["story_number"] = story_number
+    if created_at is not None:
+        kwargs["created_at"] = created_at
+    story = Story(**kwargs)
+    session.add(story)
+    await session.commit()
+    return story
+
+
+async def _make_task(session, org_id, story_id, title, created_at=None):
+    from app.models.pm import Task
+    kwargs = dict(id=uuid.uuid4(), org_id=org_id, story_id=story_id, title=title, status="todo")
+    if created_at is not None:
+        kwargs["created_at"] = created_at
+    task = Task(**kwargs)
+    session.add(task)
+    await session.commit()
+    return task
+
+
+async def _make_doc(session, org_id, project_id, title, created_at=None):
+    from app.models.doc import Doc
+    kwargs = dict(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title,
+        slug=f"slug-{uuid.uuid4().hex[:8]}",
+    )
+    if created_at is not None:
+        kwargs["created_at"] = created_at
+    doc = Doc(**kwargs)
+    session.add(doc)
+    await session.commit()
+    return doc
+
+
+async def _make_epic(session, org_id, project_id, title, created_at=None):
+    from app.models.pm import Goal
+    kwargs = dict(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status="active")
+    if created_at is not None:
+        kwargs["created_at"] = created_at
+    epic = Goal(**kwargs)
+    session.add(epic)
+    await session.commit()
+    return epic
+
+
+async def _seed_two_per_type_search_bias(session, org, project, member_id):
+    """8종 각 2건씩(총 16건) — 제목 접두어를 종류마다 다르게 줘서 구 코드(가나다 정렬+전체
+    10컷)면 알파벳 뒤쪽 종류(artifact/hypothesis/evidence)가 «통째로» 사라지게 배치한다."""
+    story1 = await _make_story(session, org.id, project.id, "AAA1 QUOTA")
+    story2 = await _make_story(session, org.id, project.id, "AAA2 QUOTA")
+    await _make_doc(session, org.id, project.id, "BBB1 QUOTA")
+    await _make_doc(session, org.id, project.id, "BBB2 QUOTA")
+    await _make_epic(session, org.id, project.id, "CCC1 QUOTA")
+    await _make_epic(session, org.id, project.id, "CCC2 QUOTA")
+    await _make_task(session, org.id, story1.id, "DDD1 QUOTA")
+    await _make_task(session, org.id, story2.id, "DDD2 QUOTA")
+    await _make_sprint(session, org.id, project.id, "EEE1 QUOTA")
+    await _make_sprint(session, org.id, project.id, "EEE2 QUOTA")
+    await _make_artifact(session, org.id, project.id, "FFF1 QUOTA")
+    await _make_artifact(session, org.id, project.id, "FFF2 QUOTA")
+    await _make_hypothesis(session, org.id, project.id, member_id, "GGG1 QUOTA")
+    await _make_hypothesis(session, org.id, project.id, member_id, "GGG2 QUOTA")
+    await _make_evidence(session, org.id, story1.id, "story", member_id, ref="zzz1-quota-evidence")
+    await _make_evidence(session, org.id, story2.id, "story", member_id, ref="zzz2-quota-evidence")
+
+
+@pytest.mark.anyio
+async def test_all_eight_types_survive_under_search_sort_bias():
+    """⭐계약① — search(q) 정렬(가나다)에서 evidence 등 알파벳 뒤쪽 종류가 통째로 안 사라진다.
+    구 코드(전체 16건을 가나다 정렬 후 10컷)였으면 FFF/GGG/ZZZ(artifact/hypothesis/evidence)
+    3종이 응답에서 완전히 빠졌을 것 — 새 코드는 종류마다 최소 보장 몫을 먼저 주므로 여덟
+    종류가 다 나온다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            await _seed_two_per_type_search_bias(s, org, project, member_id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/entities/search",
+                params={"project_id": str(project.id), "q": "QUOTA"},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            data = body["data"]
+            assert len(data) <= 10, f"DEFAULT_LIMIT(10)을 넘었다: {len(data)}"
+            found_types = {r["entity_type"] for r in data}
+            assert found_types == {
+                "story", "doc", "epic", "task", "sprint", "artifact", "hypothesis", "evidence",
+            }, f"여덟 종류가 다 안 나왔다(계약① 위반): {found_types}"
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_types_meta_reports_honest_shown_vs_total_not_fabricated():
+    """⭐계약② — 종류별 shown(보여준 건수)·total(전체 건수)이 실제 매치 건수를 그대로 반영한다.
+    evidence는 2건 매치인데 보장 몫(1)만 받고 남는 자리 채움에서 밀려 shown=1<total=2가
+    되는 것까지 정확히 고정한다(화면이 "1건 더"를 지어내지 않고 이 수를 그대로 쓸 수 있게)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            await _seed_two_per_type_search_bias(s, org, project, member_id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/entities/search",
+                params={"project_id": str(project.id), "q": "QUOTA"},
+            )
+            assert resp.status_code == 200, resp.text
+            types_meta = resp.json()["types"]
+            assert set(types_meta) == {
+                "story", "doc", "epic", "task", "sprint", "artifact", "hypothesis", "evidence",
+            }
+            for t, meta in types_meta.items():
+                assert meta["total"] == 2, f"{t}: total이 실제 시딩 건수(2)와 다르다 — {meta}"
+                assert meta["shown"] <= meta["total"]
+            assert types_meta["evidence"]["shown"] == 1, (
+                f"evidence는 보장 몫만 받아야(관련도 채움 순번상 밀림) 하는데 — {types_meta['evidence']}"
+            )
+            assert any(m["shown"] < m["total"] for m in types_meta.values()), (
+                "잘림(shown<total)이 하나도 없다 — 이 시나리오(16건/10슬롯)는 반드시 잘려야 한다"
+            )
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_all_eight_types_survive_under_default_date_sort_bias():
+    """⭐계약① — q 없이(최신순 정렬) sprint를 다른 7종보다 «훨씬 과거»로 심어도, 구 코드였으면
+    sprint 2건 모두 정렬 뒤쪽(11~16위)이라 통째로 사라졌을 것을 새 코드가 막는다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        old = datetime(2020, 1, 1, tzinfo=UTC)
+        newer = datetime.now(UTC)
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+
+            story1 = await _make_story(s, org.id, project.id, "Date Story 1", created_at=newer)
+            story2 = await _make_story(s, org.id, project.id, "Date Story 2", created_at=newer)
+            await _make_doc(s, org.id, project.id, "Date Doc 1", created_at=newer)
+            await _make_doc(s, org.id, project.id, "Date Doc 2", created_at=newer)
+            await _make_epic(s, org.id, project.id, "Date Epic 1", created_at=newer)
+            await _make_epic(s, org.id, project.id, "Date Epic 2", created_at=newer)
+            await _make_task(s, org.id, story1.id, "Date Task 1", created_at=newer)
+            await _make_task(s, org.id, story2.id, "Date Task 2", created_at=newer)
+            # ⛔sprint만 2020년(전역 최고참) — 구 코드면 top10(=최신순) 밖으로 완전히 밀려난다.
+            await _make_sprint(s, org.id, project.id, "Old Sprint 1", )
+            await _make_sprint(s, org.id, project.id, "Old Sprint 2", )
+            await _make_artifact(s, org.id, project.id, "Date Artifact 1")
+            await _make_artifact(s, org.id, project.id, "Date Artifact 2")
+            await _make_hypothesis(s, org.id, project.id, member_id, "Date Hyp 1")
+            await _make_hypothesis(s, org.id, project.id, member_id, "Date Hyp 2")
+            await _make_evidence(s, org.id, story1.id, "story", member_id, ref="date-evidence-1")
+            await _make_evidence(s, org.id, story2.id, "story", member_id, ref="date-evidence-2")
+
+            # Sprint 모델은 헬퍼가 created_at 파라미터를 안 받으므로(원본 헬퍼 재사용) 커밋 후
+            # 직접 과거로 되돌린다 — "구조적으로 가장 오래된 종류"를 확실히 만든다.
+            from sqlalchemy import update as sa_update
+
+            from app.models.pm import Sprint
+            await s.execute(
+                sa_update(Sprint).where(Sprint.org_id == org.id).values(created_at=old)
+            )
+            await s.commit()
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/entities/search",
+                params={"project_id": str(project.id)},
+            )
+            assert resp.status_code == 200, resp.text
+            found_types = {r["entity_type"] for r in resp.json()["data"]}
+            assert "sprint" in found_types, (
+                f"가장 과거(2020)로 심은 sprint가 최신순 정렬에서 통째로 잘렸다(계약① 위반): {found_types}"
+            )
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_story_and_task_carry_number_and_epic_identifier_material():
+    """⭐계약③ — 고르는 재료(status 아닌 식별자)가 실제로 응답에 있다. story는 story_number+
+    소속 에픽 제목, task는 부모 story의 순번+에픽 제목을 그대로 물려받는다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+            epic = await _make_epic(s, org.id, project.id, "ID Epic")
+            story = await _make_story(
+                s, org.id, project.id, "ID Story", epic_id=epic.id, story_number=2249,
+            )
+            task = await _make_task(s, org.id, story.id, "ID Task")
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/entities/search",
+                params={"project_id": str(project.id), "q": "ID", "types": "story,task"},
+            )
+            assert resp.status_code == 200, resp.text
+            data = resp.json()["data"]
+            story_row = next(r for r in data if r["entity_id"] == str(story.id))
+            task_row = next(r for r in data if r["entity_id"] == str(task.id))
+            assert story_row["number"] == 2249, story_row
+            assert story_row["epic_title"] == "ID Epic", story_row
+            assert task_row["number"] == 2249, task_row
+            assert task_row["epic_title"] == "ID Epic", task_row
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_doc_carries_slug_as_identifier():
+    """⭐계약③ — doc은 number/epic이 없지만(구조상), 사람이 손으로 복사하는 실제 식별자인
+    slug를 identifier로 담는다(doc.py 기존 코드 주석이 이미 "실제 식별자"로 지목한 그 필드)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+            doc = await _make_doc(s, org.id, project.id, "ID Doc")
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/entities/search",
+                params={"project_id": str(project.id), "q": "ID Doc", "types": "doc"},
+            )
+            assert resp.status_code == 200, resp.text
+            data = resp.json()["data"]
+            doc_row = next(r for r in data if r["entity_id"] == str(doc.id))
+            assert doc_row["identifier"] == doc.slug, doc_row
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2294_entities_search_open_4_types_realdb.py
+++ b/backend/tests/test_2294_entities_search_open_4_types_realdb.py
@@ -245,7 +245,7 @@ async def test_search_finds_sprint_with_data_present():
             )
             assert resp.status_code == 200, resp.text
             body = resp.json()
-            assert any(r["entity_id"] == str(sprint.id) and r["entity_type"] == "sprint" for r in body)
+            assert any(r["entity_id"] == str(sprint.id) and r["entity_type"] == "sprint" for r in body["data"])
         finally:
             await client.aclose()
             app.dependency_overrides.clear()
@@ -274,7 +274,7 @@ async def test_search_finds_artifact_with_data_present():
             )
             assert resp.status_code == 200, resp.text
             body = resp.json()
-            assert any(r["entity_id"] == str(artifact.id) and r["entity_type"] == "artifact" for r in body)
+            assert any(r["entity_id"] == str(artifact.id) and r["entity_type"] == "artifact" for r in body["data"])
         finally:
             await client.aclose()
             app.dependency_overrides.clear()
@@ -303,7 +303,7 @@ async def test_search_finds_hypothesis_with_data_present():
             )
             assert resp.status_code == 200, resp.text
             body = resp.json()
-            assert any(r["entity_id"] == str(hyp.id) and r["entity_type"] == "hypothesis" for r in body)
+            assert any(r["entity_id"] == str(hyp.id) and r["entity_type"] == "hypothesis" for r in body["data"])
         finally:
             await client.aclose()
             app.dependency_overrides.clear()
@@ -333,7 +333,7 @@ async def test_search_finds_evidence_via_story_work_item_with_data_present():
             )
             assert resp.status_code == 200, resp.text
             body = resp.json()
-            assert any(r["entity_id"] == str(ev.id) and r["entity_type"] == "evidence" for r in body)
+            assert any(r["entity_id"] == str(ev.id) and r["entity_type"] == "evidence" for r in body["data"])
         finally:
             await client.aclose()
             app.dependency_overrides.clear()
@@ -367,7 +367,7 @@ async def test_search_finds_evidence_via_task_work_item_with_data_present():
             )
             assert resp.status_code == 200, resp.text
             body = resp.json()
-            assert any(r["entity_id"] == str(ev.id) and r["entity_type"] == "evidence" for r in body)
+            assert any(r["entity_id"] == str(ev.id) and r["entity_type"] == "evidence" for r in body["data"])
         finally:
             await client.aclose()
             app.dependency_overrides.clear()
@@ -412,7 +412,7 @@ async def test_search_all_eight_types_in_one_request_when_no_types_filter():
             )
             assert resp.status_code == 200, resp.text
             body = resp.json()
-            found_types = {r["entity_type"] for r in body}
+            found_types = {r["entity_type"] for r in body["data"]}
             assert found_types == {"story", "doc", "epic", "task", "sprint", "artifact", "hypothesis", "evidence"}, (
                 f"여덟 종류가 다 안 나왔다: {found_types}"
             )

--- a/backend/tests/test_2294_task_registry_open_realdb.py
+++ b/backend/tests/test_2294_task_registry_open_realdb.py
@@ -202,7 +202,8 @@ async def test_entities_search_task_type_actually_returns_results():
             )
             assert resp.status_code == 200, resp.text
             body = resp.json()
-            assert any(r["entity_id"] == str(task.id) and r["entity_type"] == "task" for r in body)
+            # story #2263(C-5) 계약②: 응답 shape가 flat list → {data, types}로 바뀌었다.
+            assert any(r["entity_id"] == str(task.id) and r["entity_type"] == "task" for r in body["data"])
         finally:
             await client.aclose()
             app.dependency_overrides.clear()

--- a/backend/tests/test_e_security_sec_s8_ratchet_round4_entities_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_ratchet_round4_entities_realdb.py
@@ -136,7 +136,8 @@ async def test_project_a_human_can_search_own_project_empty_result():
         try:
             resp = await client.get(f"/api/v2/entities/search?project_id={seeded['project_a_id']}")
             assert resp.status_code == 200, resp.text
-            assert resp.json() == []
+            # story #2263(C-5) 계약②: 응답 shape가 flat list → {data, types}로 바뀌었다.
+            assert resp.json()["data"] == []
         finally:
             await client.aclose()
     finally:


### PR DESCRIPTION
## Summary
Story #2263 (C-5) BE contract, per PO decision on 2026-07-28.

`GET /api/v2/entities/search` fetched up to 10 results per entity type, then sorted the combined pool (title or `created_at`) and sliced to a single global limit of 10. As the number of searchable types grew (4 → 8), the average share per type dropped (2.5 → 1.25), so some types could be silently excluded entirely — and the exclusion was driven by sort order (alphabetical/recency), not relevance, making the cause undiscoverable from the client side.

**Contract ① — guaranteed per-type quota.** Each requested type reserves at least `max(1, DEFAULT_LIMIT // num_types)` slots before any remaining budget is filled by relevance across all types. A type with matches is never fully excluded because of others' volume.

**Contract ② — honest truncation counts.** Response shape changes from a flat `list[EntitySearchResult]` to `{data, types}`, where `types[entity_type] = {shown, total}` gives the real match count per type (not capped by `DEFAULT_LIMIT`), so a client can render "3 more" instead of guessing.

**Contract ③ — real picking material instead of `status`.** Items now carry `number` (story number, inherited by tasks from their parent story), `epic_title` (for story/task/artifact), and `identifier` (doc slug) — material that actually distinguishes same-titled results. `status` stays as-is for display; the previous asymmetry (only doc omitted `status`) is no longer load-bearing since picking no longer depends on it.

## Test plan
- [x] Updated existing tests (`test_2294_entities_search_open_4_types_realdb.py`, `test_2294_task_registry_open_realdb.py`, `test_e_security_sec_s8_ratchet_round4_entities_realdb.py`) for the new `{data, types}` response shape — all green.
- [x] New `test_2263_entities_search_quota_contract_realdb.py`:
  - Positive control (Paulo's ask): seed 2 matching items per all 8 types (16 total, over the 10-slot limit) under both search-sort bias and default date-sort bias; assert all 8 types are still represented.
  - `types` meta reports honest `shown`/`total` per type (verified `evidence` gets `shown=1 < total=2` deterministically).
  - `number`/`epic_title` present for story/task; `identifier` (slug) present for doc.
- [x] **Mutation self-check**: reverted `entities.py` to the pre-fix version and reran the new tests — confirmed RED (old code drops `artifact`/`hypothesis`/`evidence` entirely under search-sort bias, and `sprint` entirely under date-sort bias), matching the exact failure mode Yuna measured. Restored the fix afterward.
- [x] Full realdb suite filtered on `entities`/`entity` (130 tests) green against a disposable pgvector/pg15 container; 2 unrelated pre-existing errors (`test_edg_s34_line_versions.py`, `test_s29_active_line_get.py`) are a destructive-schema-reset safety-guard rejection tied to the disposable DB's name, unrelated to this change.

⚠️ **Frontend note for the FE story (#2264/#2263 FE side):** the endpoint no longer returns a flat array — it returns `{"data": [...], "types": {"story": {"shown": N, "total": M}, ...}}`. `use-entity-picker.ts`'s existing `Array.isArray(json) ? json : (json.data ?? [])` fallback needs to consume the new item fields (`number`, `epic_title`, `identifier`) to show "N more" per type per contract ②/③.

🤖 Generated with [Claude Code](https://claude.com/claude-code)