### PR TITLE
[SID:2263] entities/search 이중 wrap 폴백 fix — PR#2615 선행

### DIFF
--- a/apps/web/src/hooks/use-entity-picker.test.ts
+++ b/apps/web/src/hooks/use-entity-picker.test.ts
@@ -1,0 +1,31 @@
+/**
+ * story #2263 BE 계약②(PR#2615) — `/api/v2/entities/search`가 flat list에서 `{data, types}`로
+ * 바뀐 뒤, Next.js route(apiSuccess)의 이중 wrap을 뚫고 실제 배열을 뽑아내는지 고정한다.
+ * ⛔이 테스트가 없던 채로 PR#2615가 merge됐으면 검색 결과가 조용히 0건이 되는 회귀가 났다.
+ */
+import { describe, expect, it } from 'vitest';
+import { parseEntitySearchResults } from './use-entity-picker';
+
+const item = { entity_type: 'story', entity_id: 's1', title: 'S1', status: null };
+
+describe('parseEntitySearchResults', () => {
+  it('과거 형태: Next.js가 flat list를 한 겹만 감싼 {data: [...]}에서 배열을 뽑는다', () => {
+    expect(parseEntitySearchResults({ data: [item], error: null, meta: null })).toEqual([item]);
+  });
+
+  it('⭐현재 형태(PR#2615): FastAPI가 {data,types}로 바뀐 뒤 Next.js가 또 감싼 이중 wrap을 뚫는다', () => {
+    const json = { data: { data: [item], types: { story: { shown: 1, total: 1 } } }, error: null, meta: null };
+    expect(parseEntitySearchResults(json)).toEqual([item]);
+  });
+
+  it('방어적: json 자체가 이미 flat array인 경우도 받는다', () => {
+    expect(parseEntitySearchResults([item])).toEqual([item]);
+  });
+
+  it('방어적: 알 수 없는 모양은 빈 배열로 떨어진다(throw 0)', () => {
+    expect(parseEntitySearchResults(null)).toEqual([]);
+    expect(parseEntitySearchResults(undefined)).toEqual([]);
+    expect(parseEntitySearchResults({})).toEqual([]);
+    expect(parseEntitySearchResults({ data: { types: {} } })).toEqual([]);
+  });
+});

--- a/apps/web/src/hooks/use-entity-picker.ts
+++ b/apps/web/src/hooks/use-entity-picker.ts
@@ -4,6 +4,23 @@ import { useEffect, useState } from 'react';
 import { applyEntity, entityTypeLabel, groupEntitiesByType, type EntityResult } from '@/components/chat/chat-input-entity-tokens';
 
 /**
+ * story #2263 BE 계약②(PR#2615) — FastAPI `/api/v2/entities/search`가 flat list에서
+ * `{data, types}`로 바뀌었다. 이 fetch는 Next.js route(`app/api/entities/search/route.ts`)의
+ * `apiSuccess(data)`를 한 겹 더 거친다 — 즉 이 hook이 받는 json은 항상
+ * `{data: <FastAPI 원본 바디>, error, meta}`다.
+ * ⛔예전 코드(`Array.isArray(json) ? json : (json.data ?? [])`)는 이 바깥 겹만 벗겨서 FastAPI가
+ * flat list이던 시절엔 우연히 맞았지만, `{data,types}`로 바뀐 뒤엔 `json.data`가 배열이 아니라
+ * `{data,types}` 객체가 되어 최종 결과가 매번 빈 배열로 떨어진다(검색 결과가 조용히 0건이 되는
+ * 회귀 — Next.js route 코드 추적 + 실제 응답 형상 대조로 확認). 안쪽 겹을 한 번 더 벗겨 두 모양
+ * (과거 flat list · 현재 `{data,types}`) 다 받는다.
+ */
+export function parseEntitySearchResults(json: unknown): EntityResult[] {
+  const outer = Array.isArray(json) ? json : ((json as { data?: unknown } | null)?.data ?? json);
+  const arr = Array.isArray(outer) ? outer : ((outer as { data?: EntityResult[] } | null)?.data ?? []);
+  return Array.isArray(arr) ? arr : [];
+}
+
+/**
  * story #2264(C-6) — `#` 엔티티 피커의 상태·검색·토큰조립을 채팅(chat-input.tsx)에서 뽑아낸
  * 재사용 hook. AC3(새 자리 비용 = 설정 한 줄) 판정의 핵심: 이 파일이 «참조 코어»고, 새 자리를
  * 여는 것은 이 hook을 부르고 렌더 3~4줄을 붙이는 것뿐이어야 한다.
@@ -28,10 +45,9 @@ export function useEntityPicker(projectId: string | undefined) {
       if (entityQuery) params.set('q', entityQuery);
       fetch(`/api/entities/search?${params}`)
         .then((r) => r.json())
-        .then((json: EntityResult[] | { data?: EntityResult[] }) => {
+        .then((json: unknown) => {
           if (cancelled) return;
-          const arr = Array.isArray(json) ? json : (json.data ?? []);
-          setEntityResults(groupEntitiesByType(Array.isArray(arr) ? arr : []));
+          setEntityResults(groupEntitiesByType(parseEntitySearchResults(json)));
           setEntityIndex(0);
         })
         .catch(() => {});


### PR DESCRIPTION
## Summary
- PO(#2263 스레드)가 PR#2615 머지 전 「use-entity-picker.ts의 폴백이 실제로 새 응답 형태를 먹는지」 확認을 요청 — 재보니 안 먹었다.
- `/api/v2/entities/search`가 PR#2615로 flat list → `{data, types}`로 바뀌는데, Next.js route(`app/api/entities/search/route.ts`)가 `apiSuccess(data)`로 한 겹 더 감싼다. 그래서 FE fetch가 받는 json은 항상 `{data: <FastAPI 바디>, error, meta}`.
- 기존 코드(`Array.isArray(json) ? json : (json.data ?? [])`)는 겹을 하나만 벗겨서, FastAPI가 flat list이던 시절엔 우연히 맞았지만 `{data,types}`로 바뀐 뒤엔 `json.data`가 배열이 아니라 `{data,types}` 객체가 되어 최종 결과가 매번 빈 배열로 떨어진다 — PR#2615가 그대로 머지되면 채팅 `#` 엔티티 검색이 **조용히 0건**이 된다.

## Changes
- `use-entity-picker.ts`: 겹을 두 번 벗기는 `parseEntitySearchResults()`로 추출(과거 flat list·현재 `{data,types}` 둘 다 처리, 알 수 없는 모양은 `[]`로 안전 폴백).
- `use-entity-picker.test.ts` 신설 — 4개 케이스(과거 형태·현재 형태·flat array 방어·알 수 없는 모양 방어). 옛 단일-unwrap 로직으로 되돌려 "현재 형태" 테스트가 RED로 떨어지는 것 확認(mutation self-check) 후 복구.

## Test plan
- [x] `vitest run use-entity-picker.test.ts chat-input.entity-picker-grouping.test.ts` — 11/11 green
- [x] mutation self-check: 단일-unwrap으로 되돌려 신규 테스트 RED 확認 → 복구 후 green
- [x] `tsc --noEmit`, `eslint` 둘 다 clean
- [x] PR#2615(BE)와 독립적으로 안전 — 이 fix는 과거 flat list 응답도 그대로 처리하므로 PR#2615 머지 순서와 무관하게 먼저 태워도 됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)