### PR TITLE
fix(infra): allowlist FIREBASE_OAUTH_HANDOFF_ENABLED for backend-prod/frontend-prod

### DIFF
--- a/infra/manual-env-allowlist.yml
+++ b/infra/manual-env-allowlist.yml
@@ -169,6 +169,21 @@ services:
       - key: CRON_SECRET
         reason: dev와 동일 — cron 엔드포인트 인증 시크릿, 부트스트랩 스크립트 미편입.
         owner: TBD
+      - key: FIREBASE_OAUTH_HANDOFF_ENABLED
+        value_check: skip
+        reason: >-
+          story #1931 feature flag(dev/realtime-dev와 동일 축) — settings.py:261
+          firebase_oauth_handoff_enabled, backend/app/routers/auth_firebase_internal.py:503,576
+          이 게이트로 issue/consume 501 분기(껐다 켰다 배포 없이 토글하는 것이 이 값의
+          존재 이유라 SSOT 편입 대상 아님). frontend-prod의 동일 키와 «짝»이라 — 프론트가
+          FIREBASE_OAUTH_HANDOFF_ENABLED를 켠 채 이 값만 꺼지면 BFF 내부호출이 501로
+          막힌다. ⛔만료 조건: handoff가 기본 동작으로 승격되면 이 값·위 게이트·FE 분기를
+          함께 제거할 것(2026-07-28 인시던트 대응 중 수동 세팅 확認, 계정으로 주체 특定 불가).
+          ⚠️값 형식 위험: 지금 이 서비스는 `1`(pydantic bool 파서가 True로 읽음), frontend-prod는
+          문자열 `true`(정확 일치 비교) — 지금은 둘 다 켜진 뜻이 같지만, 누가 frontend를
+          `1`로 바꾸면 그쪽은 정확 일치가 깨져 조용히 꺼진다. 통일은 이번 판 스코프 밖 — 위험만
+          기록해 둔다.
+        owner: TBD
       - key: GITHUB_APP_CLIENT_ID
         reason: dev와 동일 사유.
         owner: TBD
@@ -344,6 +359,19 @@ services:
     keys:
       - key: APP_BASE_URL
         reason: 용도/생성 경위 미확認 — owner 확인 필요(TBD로 이미 알려진 항목, memory 참고).
+        owner: TBD
+      - key: FIREBASE_OAUTH_HANDOFF_ENABLED
+        value_check: skip
+        reason: >-
+          story #1931 feature flag(dev와 동일 축) — apps/web/src/app/auth/oauth-handoff/route.ts:65
+          가 이 값을 정확히 문자열 'true'로 검사한다(껐다 켰다 배포 없이 토글하는 것이 이
+          값의 존재 이유라 SSOT 편입 대상 아님). backend-prod의 동일 키와 «짝»이라 — 둘이
+          같이 켜져 있어야 handoff issue/consume 내부호출이 성공한다. ⛔만료 조건: handoff가
+          기본 동작으로 승격되면 이 값·FE 분기·백엔드 게이트를 함께 제거할 것(2026-07-28
+          인시던트 대응 중 수동 세팅 확認, 계정으로 주체 특定 불가).
+          ⚠️값 형식 위험: 이 서비스는 문자열 `true`(정확 일치 비교), backend-prod는 `1`(pydantic
+          bool 파서가 True로 읽음) — 지금은 둘 다 켜진 뜻이 같지만, 이 값이 `1`로 바뀌면 route.ts:65의
+          정확 일치가 깨져 프론트만 조용히 꺼진다. 통일은 이번 판 스코프 밖 — 위험만 기록해 둔다.
         owner: TBD
       - key: SECRET_REFRESH_1777617854
         reason: >-


### PR DESCRIPTION
## Summary
`env-drift-guard`'s key-set axis started failing on 2026-07-29 00:39 UTC for `sprintable-backend-prod` and `sprintable-frontend-prod`: `FIREBASE_OAUTH_HANDOFF_ENABLED` is live on both but not declared in IaC or `infra/manual-env-allowlist.yml`.

**Root cause investigation** (Cloud Run revision history):
- `backend-prod`: first appears in revision `sprintable-backend-prod-00246-fcd`, created 2026-07-28T12:07:32Z
- `frontend-prod`: first appears in revision `sprintable-frontend-prod-00221-j9b`, created 2026-07-28T12:08:50Z
- 90 seconds apart, same account (`serving.knative.dev/creator`), both via `client-name: gcloud` (manual CLI, not the deploy pipeline). The backend revision carries an `incident-restart` label — this was a manual production intervention during an incident, not attributable to a specific individual since the account is shared for incident response.

**Why allowlist, not IaC (SSOT)**: this is a feature-flag pair, not an environment constant like `MOBILE_APP_LINK_ORIGIN`.
- `apps/web/src/app/api/auth/callback/[provider]/route.ts` and `apps/web/src/app/auth/oauth-handoff/route.ts:65` — frontend checks it against the literal string `'true'`.
- `backend/app/core/config.py:261` (Settings field `firebase_oauth_handoff_enabled`) gates two endpoints in `backend/app/routers/auth_firebase_internal.py` (lines 503, 576) with a `501` when off.

Both flags must be on together for the handoff flow to work. Toggling a flag is meant to happen without a deploy — sibling services (`backend-dev`, `realtime-dev`, `frontend-dev`) already carry this exact key in the allowlist rather than in `deploy_backend.sh`/`deploy_frontend.sh`. This brings prod in line with that existing pattern instead of introducing a new dev/prod asymmetry.

**Value format note**: frontend is live with `'true'`, backend with `'1'` — pydantic's bool parser accepts both as truthy today, so both are currently on. But they're not interchangeable: frontend's check is an exact string comparison, so if its value ever changes to `'1'` it silently turns off while backend stays on. Documented as a risk in both entries; not fixed in this PR (out of scope, per discussion in story chat).

Each new entry documents: the code that reads it, why it's a manual toggle rather than an IaC value, the pairing constraint, the value-format risk, and an expiry condition (remove the flag + both code branches together once OAuth handoff becomes default behavior).

## Test plan
- [x] `python3 infra/check_env_drift.py` against live GCP state on this branch — exits 0 (previously exited 1 on the key-set axis for both services).
- [x] `pytest tests/test_check_env_drift_settings_coverage.py tests/test_check_env_drift_code_read_axis.py tests/test_check_env_drift_service_subset_axis.py` — 43 passed, no regression.
- [ ] Confirm the next scheduled/dispatched `env-drift-guard` GHA run is green after this merges to develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)