### PR TITLE
[SID:2263] AC6 — 채팅 메시지 읽기 응답에 stored 참조 사이드밴드

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -391,9 +391,12 @@ def _build_message_summary(content: str | None, sender_name: str | None, has_att
     return f"{name}: {preview}" if preview else name
 
 
-def _msg_payload(msg: ConversationMessage, sender: "ResolvedMember | TeamMember | None") -> dict:
+def _msg_payload(
+    msg: ConversationMessage, sender: "ResolvedMember | TeamMember | None",
+    *, references: list[dict[str, str]] | None = None,
+) -> dict:
     attachments = msg.attachments if isinstance(msg.attachments, list) else []
-    return {
+    payload = {
         "id": str(msg.id),
         "conversation_id": str(msg.conversation_id),
         "thread_id": str(msg.thread_id) if msg.thread_id else None,
@@ -412,6 +415,17 @@ def _msg_payload(msg: ConversationMessage, sender: "ResolvedMember | TeamMember 
         "summary": _build_message_summary(msg.content, sender.name if sender else None, bool(attachments)),
         "created_at": msg.created_at.isoformat(),
     }
+    # story #2263 AC6(오르테가 판정 2026-07-29, 스레드 7256d5cc): 읽기 경로(list_messages·
+    # get_message·list_message_replies)만 이 키를 싣는다 — 그 셋만 호출부에서 `references=`
+    # 를 넘긴다(항상 list, 빈 배열도 명시). 다른 호출부(SSE 디스패치·POST 전송 응답)는 넘기지
+    # 않아 키 자체가 없다(기존 동작 무변경) — 그 표면들은 이미 별개의 write-time 사이드밴드
+    # (`response["references"] = {stored, dropped}`, #2294/#2315)를 갖고 있어 의미가 다르다.
+    # ⛔`references is None`(파라미터 미전달)과 `references=[]`(읽기 경로·저장된 참조 0건)를
+    # 여기서 구분한다 — 빈 배열도 없는 배열처럼 다뤄 키를 빼면, FE가 "옛 서버라 필드가 없다"와
+    # "이 메시지엔 참조가 없다"를 못 가른다(오늘 아침 유령 칩 사고의 뿌리와 같은 모양).
+    if references is not None:
+        payload["references"] = references
+    return payload
 
 
 async def _dispatch_conversation_event(
@@ -1395,8 +1409,17 @@ async def list_messages(
 
     sender_ids = {m.sender_id for m in msgs if m.sender_id}
     member_map = await lookup_members_by_ids(sender_ids, db)
+    # story #2263 AC6(오르테가 판정 2026-07-29): 페이지 전체를 쿼리 1회로 해소(N+1 방지) —
+    # 메시지별 왕복 없음.
+    from app.services.mention_parser import fetch_stored_references
+    refs_by_msg = await fetch_stored_references(
+        db, org_id=org_id, source_type="chat_message", source_ids=[m.id for m in msgs],
+    )
 
-    data = [_msg_payload(m, member_map.get(m.sender_id)) for m in msgs]
+    data = [
+        _msg_payload(m, member_map.get(m.sender_id), references=refs_by_msg.get(m.id, []))
+        for m in msgs
+    ]
     next_cursor = msgs[0].created_at.isoformat() if has_more and msgs else None
 
     return {"data": data, "meta": {"next_cursor": next_cursor, "has_more": has_more}}
@@ -1428,7 +1451,11 @@ async def get_message(
         raise HTTPException(status_code=404, detail="Message not found")
 
     sender_map = await lookup_members_by_ids({msg.sender_id} if msg.sender_id else set(), db)
-    return _msg_payload(msg, sender_map.get(msg.sender_id))
+    from app.services.mention_parser import fetch_stored_references
+    refs_by_msg = await fetch_stored_references(
+        db, org_id=org_id, source_type="chat_message", source_ids=[msg.id],
+    )
+    return _msg_payload(msg, sender_map.get(msg.sender_id), references=refs_by_msg.get(msg.id, []))
 
 
 @router.get("/{conversation_id}/messages/{message_id}/replies")
@@ -1470,8 +1497,16 @@ async def list_message_replies(
 
     sender_ids = {m.sender_id for m in msgs if m.sender_id}
     member_map = await lookup_members_by_ids(sender_ids, db)
+    # story #2263 AC6: list_messages와 동형 — 페이지 전체 쿼리 1회(N+1 방지).
+    from app.services.mention_parser import fetch_stored_references
+    refs_by_msg = await fetch_stored_references(
+        db, org_id=org_id, source_type="chat_message", source_ids=[m.id for m in msgs],
+    )
 
-    data = [_msg_payload(m, member_map.get(m.sender_id)) for m in msgs]
+    data = [
+        _msg_payload(m, member_map.get(m.sender_id), references=refs_by_msg.get(m.id, []))
+        for m in msgs
+    ]
     next_cursor = msgs[0].created_at.isoformat() if has_more and msgs else None
 
     return {"data": data, "meta": {"next_cursor": next_cursor, "has_more": has_more}}

--- a/backend/app/services/mention_parser.py
+++ b/backend/app/services/mention_parser.py
@@ -592,3 +592,43 @@ async def reconcile_doc_mentions(
         db, org_id=org_id, source_type="doc", source_field="body", source_id=doc_id,
         extracted_refs=extracted_refs, created_by=created_by,
     )
+
+
+async def fetch_stored_references(
+    db: AsyncSession, *, org_id: uuid.UUID, source_type: str, source_ids: list[uuid.UUID],
+) -> dict[uuid.UUID, list[dict[str, str]]]:
+    """story #2263 AC6 / #2262(C-4) 첫 발(오르테가 판정 2026-07-29, 스레드 7256d5cc) — 읽기
+    경로용. 채팅 `#` 검색이 만든 칩은 write 응답(`references.dropped[]`, #2294)으로만
+    한 번 확인되고 새로고침하면 사라진다 — `get_chat_message`가 그 메시지가 실제로 건
+    참조를 다시 안 실어서(파서가 `content`를 재작성하지 않는 insert-only라 화면은 본문
+    정규식 매치만으로 칩을 그리므로, dropped된 참조도 저장된 것과 똑같은 칩으로 보인다).
+
+    ⛔이 함수는 **stored 참조만** 되살린다(`target_type`·`target_id` — "무엇을 가리키나"까지).
+    `dropped`는 그 저장 시점의 이야기라 영속이 아니다(오르테가 판정) — 복원 대상이 아니고,
+    FE는 "본문 토큰 N개 ↔ stored M개"를 대조해 어느 칩이 안 걸렸는지 스스로 가른다. 「지금
+    상태·다음 행동」(status 등)은 여기서 안 얹는다 — #2262 본체가 얹을 자리(그 순간부터는
+    새 노출이라 C-3/#2261 권한 게이트가 #2262 前에 서야 한다, 오르테가 판정 그대로).
+
+    N+1 방지 — 호출자가 여러 source_id(예: `list_messages`의 페이지 전체)를 한 번에 넘기면
+    쿼리 1회로 전부 해소한다(개별 message마다 왕복하지 않는다). `ix_entity_references_source`
+    (org_id, source_type, source_id)가 이 IN 쿼리를 커버한다.
+
+    반환: `source_id -> [{"target_type", "target_id"}, ...]`. 호출자는 이 dict에 없는
+    source_id를 **빈 리스트**로 취급해야 한다(그 source가 stored 참조 0건이라는 뜻 —
+    "옛 서버라 필드가 없다"와 구분하기 위해 호출자가 payload에 항상 `references: []`를
+    싣는 것이 이 함수의 계약이 아니라 **호출자의 책임**이다, 아래 conversations.py 참조)."""
+    if not source_ids:
+        return {}
+    rows = (await db.execute(
+        select(Reference.source_id, Reference.target_type, Reference.target_id).where(
+            Reference.org_id == org_id,
+            Reference.source_type == source_type,
+            Reference.source_id.in_(source_ids),
+        )
+    )).all()
+    result: dict[uuid.UUID, list[dict[str, str]]] = {}
+    for source_id, target_type, target_id in rows:
+        result.setdefault(source_id, []).append(
+            {"target_type": target_type, "target_id": str(target_id)}
+        )
+    return result

--- a/backend/tests/test_2263_chat_message_read_references_realdb.py
+++ b/backend/tests/test_2263_chat_message_read_references_realdb.py
@@ -53,15 +53,26 @@ async def _session_factory():
 
 
 async def _setup(session):
-    """org + project + human(TeamMember, user_id 경유 해소) + conversation(참가자=그 human).
+    """org + project + human(members ⋈ project_access) + conversation(참가자=그 human).
 
-    `Conversation.created_by`는 `team_members.id` FK다 — `_resolve_member`(conversations.py)가
-    JWT 휴먼을 `TeamMember.user_id == auth.user_id`로 해소하므로, TeamMember.id 자체가 아니라
-    User.id를 auth 신원으로 쓴다(team_member.id는 participant/created_by 양쪽의 canonical key).
+    ⛔story #2263 CI 회귀(오르테가 실측, 2026-07-29): `team_members`는 0088부터 **뷰**다
+    (members ⋈ project_access, `_e_members_projection_view` 계열 마이그레이션 참조) — `TeamMember`
+    ORM으로 직접 `session.add()`하면 로컬 `create_all`(진짜 테이블 재현)에서는 통과하지만 실
+    마이그레이션된 스키마(CI)에서는 `cannot insert into view`로 죽는다(로컬/CI 스키마 드리프트,
+    reference_local_realdb_pg16_pgvector 계열 함정과 동형). 그래서 뷰가 아니라 **뷰의 원재료**
+    (`Member` + `ProjectAccess`)에 쓴다 — 뷰가 `m.id`를 그대로 투영하므로 `member.id`가
+    곧 `team_members.id`(0075 ID 보존과 같은 원리). `_resolve_member`(conversations.py)는
+    JWT 휴먼을 `TeamMember.user_id == auth.user_id`(뷰 경유)로 해소하므로 auth 신원은
+    `member.id`가 아니라 `user.id`를 쓴다.
+
+    `conversations.created_by`/`conversation_participants.member_id`는 현재 스키마에 FK가
+    없다(schema.sql 확認) — `team_members(_legacy)`를 가리키는 값을 몰라도 무방, `member.id`를
+    그대로 쓴다.
     """
     from app.models.organization import Organization
     from app.models.project import Project
-    from app.models.team import TeamMember
+    from app.models.member import Member
+    from app.models.project_access import ProjectAccess
     from app.models.user import User
     from app.models.conversation import Conversation, ConversationParticipant
 
@@ -74,18 +85,17 @@ async def _setup(session):
     user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
     session.add(user)
     await session.flush()
-    tm = TeamMember(
-        id=uuid.uuid4(), org_id=org.id, project_id=project.id, user_id=user.id,
-        type="human", name="Human",
-    )
-    session.add(tm)
+    member = Member(id=uuid.uuid4(), org_id=org.id, type="human", user_id=user.id, name="Human")
+    session.add(member)
     await session.flush()
-    conv = Conversation(id=uuid.uuid4(), org_id=org.id, project_id=project.id, type="group", created_by=tm.id)
+    session.add(ProjectAccess(project_id=project.id, member_id=member.id, permission="granted", role="member"))
+    await session.flush()
+    conv = Conversation(id=uuid.uuid4(), org_id=org.id, project_id=project.id, type="group", created_by=member.id)
     session.add(conv)
     await session.flush()
-    session.add(ConversationParticipant(conversation_id=conv.id, member_id=tm.id))
+    session.add(ConversationParticipant(conversation_id=conv.id, member_id=member.id))
     await session.commit()
-    return org, project, tm, user, conv
+    return org, project, member, user, conv
 
 
 async def _make_target_doc(session, org_id, project_id, title="Target"):
@@ -144,7 +154,7 @@ async def test_get_message_returns_stored_reference_after_reload():
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
-            org, project, tm, user, conv = await _setup(s)
+            org, project, member, user, conv = await _setup(s)
             target = await _make_target_doc(s, org.id, project.id)
 
         from app.main import app
@@ -174,7 +184,7 @@ async def test_list_messages_returns_stored_references_per_message_without_n_plu
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
-            org, project, tm, user, conv = await _setup(s)
+            org, project, member, user, conv = await _setup(s)
             target_a = await _make_target_doc(s, org.id, project.id, title="A")
             target_b = await _make_target_doc(s, org.id, project.id, title="B")
 
@@ -227,7 +237,7 @@ async def test_message_with_no_tokens_has_empty_references_list_not_missing_fiel
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
-            org, project, tm, user, conv = await _setup(s)
+            org, project, member, user, conv = await _setup(s)
 
         from app.main import app
         await _setup_app_human(app, Session, user.id, org.id)
@@ -254,7 +264,7 @@ async def test_dropped_reference_is_not_restored_on_reload_only_absence_from_sto
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
-            org, project, tm, user, conv = await _setup(s)
+            org, project, member, user, conv = await _setup(s)
 
         from app.main import app
         await _setup_app_human(app, Session, user.id, org.id)
@@ -285,7 +295,7 @@ async def test_list_message_replies_returns_stored_references():
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
-            org, project, tm, user, conv = await _setup(s)
+            org, project, member, user, conv = await _setup(s)
             target = await _make_target_doc(s, org.id, project.id)
 
         from app.main import app

--- a/backend/tests/test_2263_chat_message_read_references_realdb.py
+++ b/backend/tests/test_2263_chat_message_read_references_realdb.py
@@ -1,0 +1,310 @@
+"""story #2263 AC6 / #2262(C-4) 첫 발(오르테가 판정 2026-07-29, 스레드 7256d5cc) — 채팅
+메시지 읽기 경로(GET list/단건/replies)가 그 메시지가 실제로 건 **stored** 참조를 실는지
+실PG 검증.
+
+배경: send 응답(`references.dropped[]`, #2294)은 보낸 그 순간에만 어느 토큰이 안 걸렸는지
+말한다. 새로고침해서 `GET .../messages`로 다시 읽으면 그 사이드밴드가 없어 — 파서가
+`content`를 재작성하지 않는 insert-only라 화면이 본문 정규식 매치만으로 칩을 그리므로,
+dropped된 참조도 저장된 것과 똑같은 칩으로 보인다(유령 칩). 이 스토리는 그 읽기 축을 연다.
+
+⛔범위: stored 참조(target_type·target_id)만 되살린다. dropped는 그 순간의 이야기라
+영속이 아니므로 여기서 복원하지 않는다(오르테가 판정). 「상태·다음 행동」도 #2262 몫이라
+여기선 안 얹는다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _setup(session):
+    """org + project + human(TeamMember, user_id 경유 해소) + conversation(참가자=그 human).
+
+    `Conversation.created_by`는 `team_members.id` FK다 — `_resolve_member`(conversations.py)가
+    JWT 휴먼을 `TeamMember.user_id == auth.user_id`로 해소하므로, TeamMember.id 자체가 아니라
+    User.id를 auth 신원으로 쓴다(team_member.id는 participant/created_by 양쪽의 canonical key).
+    """
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.team import TeamMember
+    from app.models.user import User
+    from app.models.conversation import Conversation, ConversationParticipant
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.flush()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.flush()
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    tm = TeamMember(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id, user_id=user.id,
+        type="human", name="Human",
+    )
+    session.add(tm)
+    await session.flush()
+    conv = Conversation(id=uuid.uuid4(), org_id=org.id, project_id=project.id, type="group", created_by=tm.id)
+    session.add(conv)
+    await session.flush()
+    session.add(ConversationParticipant(conversation_id=conv.id, member_id=tm.id))
+    await session.commit()
+    return org, project, tm, user, conv
+
+
+async def _make_target_doc(session, org_id, project_id, title="Target"):
+    from app.models.doc import Doc
+    doc = Doc(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, slug=f"doc-{uuid.uuid4().hex[:8]}")
+    session.add(doc)
+    await session.commit()
+    return doc
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+def _token(title: str, target_type: str, target_id) -> str:
+    return f"[{title}](entity:{target_type}:{target_id})"
+
+
+async def _send(client, conv_id, content, thread_id=None):
+    body = {"content": content}
+    if thread_id is not None:
+        body["thread_id"] = str(thread_id)
+    resp = await client.post(f"/api/v2/conversations/{conv_id}/messages", json=body)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+# ─── AC6①: 단건(get_message)이 stored 참조를 되살린다 ────────────────────────
+
+
+async def test_get_message_returns_stored_reference_after_reload():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project, tm, user, conv = await _setup(s)
+            target = await _make_target_doc(s, org.id, project.id)
+
+        from app.main import app
+        await _setup_app_human(app, Session, user.id, org.id)
+        client = _client_for(app)
+        try:
+            sent = await _send(client, conv.id, _token("Target", "doc", target.id))
+            msg_id = sent["data"]["id"]
+            assert sent["references"]["stored"] == 1
+
+            # ⭐진짜 "새로고침" — 별개의 GET 왕복으로 다시 읽는다(send 응답 재사용 아님).
+            resp = await client.get(f"/api/v2/conversations/{conv.id}/messages/{msg_id}")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["references"] == [{"target_type": "doc", "target_id": str(target.id)}]
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── AC6②: 목록(list_messages)도 같다 + N+1 방지(쿼리 1회) ──────────────────
+
+
+async def test_list_messages_returns_stored_references_per_message_without_n_plus_1():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project, tm, user, conv = await _setup(s)
+            target_a = await _make_target_doc(s, org.id, project.id, title="A")
+            target_b = await _make_target_doc(s, org.id, project.id, title="B")
+
+        from app.main import app
+        await _setup_app_human(app, Session, user.id, org.id)
+        client = _client_for(app)
+        try:
+            await _send(client, conv.id, _token("A", "doc", target_a.id))
+            await _send(client, conv.id, "no tokens here")
+            await _send(client, conv.id, _token("B", "doc", target_b.id))
+
+            import app.services.mention_parser as mp
+            calls = {"n": 0}
+            _orig = mp.fetch_stored_references
+
+            async def _counting(*a, **kw):
+                calls["n"] += 1
+                return await _orig(*a, **kw)
+
+            mp.fetch_stored_references = _counting
+            try:
+                resp = await client.get(f"/api/v2/conversations/{conv.id}/messages")
+            finally:
+                mp.fetch_stored_references = _orig
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            msgs = body["data"]
+            assert len(msgs) == 3
+            by_content = {m["content"]: m["references"] for m in msgs}
+            assert by_content[_token("A", "doc", target_a.id)] == [
+                {"target_type": "doc", "target_id": str(target_a.id)}
+            ]
+            assert by_content["no tokens here"] == []
+            assert by_content[_token("B", "doc", target_b.id)] == [
+                {"target_type": "doc", "target_id": str(target_b.id)}
+            ]
+            # ⭐N+1 방지 — 메시지 3건인데 참조 조회는 페이지당 1회만 나가야 한다.
+            assert calls["n"] == 1, f"페이지 1개에 참조 조회가 {calls['n']}번 나갔다(N+1)"
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── 빈 것의 표현: references가 항상 실린다(빈 배열 ≠ 필드 누락) ─────────────
+
+
+async def test_message_with_no_tokens_has_empty_references_list_not_missing_field():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project, tm, user, conv = await _setup(s)
+
+        from app.main import app
+        await _setup_app_human(app, Session, user.id, org.id)
+        client = _client_for(app)
+        try:
+            sent = await _send(client, conv.id, "plain text, no tokens")
+            msg_id = sent["data"]["id"]
+
+            resp = await client.get(f"/api/v2/conversations/{conv.id}/messages/{msg_id}")
+            body = resp.json()
+            assert "references" in body, "필드 자체가 빠졌다 — FE가 옛 서버인지 참조가 없는지 못 가른다"
+            assert body["references"] == []
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── dropped는 읽기 경로에 복원되지 않는다(영속 아님, 설계상 의도) ──────────
+
+
+async def test_dropped_reference_is_not_restored_on_reload_only_absence_from_stored():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project, tm, user, conv = await _setup(s)
+
+        from app.main import app
+        await _setup_app_human(app, Session, user.id, org.id)
+        client = _client_for(app)
+        try:
+            # registry 밖 target_type → dropped(unregistered_target_type), stored 0.
+            sent = await _send(client, conv.id, _token("X", "goal", uuid.uuid4()))
+            msg_id = sent["data"]["id"]
+            assert sent["references"]["stored"] == 0
+            assert sent["references"]["dropped"][0]["reason"] == "unregistered_target_type"
+
+            resp = await client.get(f"/api/v2/conversations/{conv.id}/messages/{msg_id}")
+            body = resp.json()
+            # ⭐dropped 사유는 읽기 응답 어디에도 없다 — stored가 빈 것으로만 "안 걸렸다"가 드러난다.
+            assert body["references"] == []
+            assert "dropped" not in body
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── replies 목록도 동형 ──────────────────────────────────────────────────
+
+
+async def test_list_message_replies_returns_stored_references():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project, tm, user, conv = await _setup(s)
+            target = await _make_target_doc(s, org.id, project.id)
+
+        from app.main import app
+        await _setup_app_human(app, Session, user.id, org.id)
+        client = _client_for(app)
+        try:
+            root = await _send(client, conv.id, "root message")
+            root_id = root["data"]["id"]
+            reply = await _send(client, conv.id, _token("Target", "doc", target.id), thread_id=root_id)
+            reply_id = reply["data"]["id"]
+
+            resp = await client.get(f"/api/v2/conversations/{conv.id}/messages/{root_id}/replies")
+            assert resp.status_code == 200, resp.text
+            replies = resp.json()["data"]
+            assert len(replies) == 1
+            assert replies[0]["id"] == reply_id
+            assert replies[0]["references"] == [{"target_type": "doc", "target_id": str(target.id)}]
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -364,8 +364,14 @@ async def test_list_messages_response_shape():
         agents_result = MagicMock()
         agents_result.scalars.return_value.all.return_value = [agent_id]
 
+        # story #2263 AC6: list_messages가 페이지 전체 참조를 쿼리 1회로 배치 조회
+        # (fetch_stored_references) — `.all()`(scalars 아님) 결과, 빈 페이지 가정.
+        refs_result = MagicMock()
+        refs_result.all.return_value = []
+
         session.execute = AsyncMock(side_effect=[
             conv_project_result, member_result, pids_result, agents_result, msgs_result, sender_result,
+            refs_result,
         ])
 
         async with client as c:


### PR DESCRIPTION
## 배경 (오르테가 판정 2026-07-29, 스레드 7256d5cc)
채팅 send 응답(`references.dropped[]`, #2294)은 보낸 그 순간에만 어느 토큰이 안 걸렸는지 말한다. 새로고침해서 `GET .../messages`로 다시 읽으면 그 사이드밴드가 없다 — 파서(`mention_parser.py`)가 `content`를 재작성하지 않는 insert-only라 화면은 본문의 `[title](entity:type:id)` 정규식 매치만으로 칩을 그린다. 그 결과 **dropped된 참조도 저장된 것과 똑같은 칩으로 보인다** — 새로고침한 순간 어느 칩이 유령인지 FE가 원리적으로 알 방법이 없었다.

## 계약 (오르테가 확정)
```
①단건(get_message)·목록(list_messages) 둘 다 — 단건만 열면 봉인이 반쪽
②실을 것은 stored 참조(target_type·target_id)뿐 — dropped는 그 순간의 이야기라 영속이 아니다.
  복원 대상이 아니고, FE가 "본문 토큰 N개 ↔ stored M개"를 대조해 어느 칩이 안 걸렸는지 스스로 가른다.
③「무엇을 가리키나」까지만 — 「지금 상태·다음 행동」은 #2262 본체가 얹을 자리
  (그 순간부터는 새 노출이라 C-3/#2261 권한 게이트가 #2262 前에 서야 한다).
```
추가로 오르테가가 얹은 물음 둘:
- **N+1**: 메시지 50건에 참조 조회 50번 나가면 안 된다.
- **빈 것의 표현**: `references: []`인지 필드를 빼는지 — 빼면 FE가 "옛 서버인가 참조가 없나"를 못 가른다.

## 변경
- **`backend/app/services/mention_parser.py`**: `fetch_stored_references(db, org_id, source_type, source_ids)` 신설 — `entity_references`를 `source_id IN (...)` 배치 조회 1회로 해소(`ix_entity_references_source` 커버). `source_id -> [{target_type, target_id}, ...]` 반환.
- **`backend/app/routers/conversations.py`**: `_msg_payload`에 `references: list[dict] | None = None` 키워드 인자 추가 — `None`이면 키 자체를 안 싣고(기존 SSE 디스패치·POST 전송 응답 호출부는 무변경), 넘기면(항상 실제 list) 항상 키가 실린다. `list_messages`·`get_message`·`list_message_replies` 셋 다 페이지/단건 전체를 `fetch_stored_references` 1회로 조회해 배선(N+1 방지).
- **`references`가 항상 리스트로 실리는 이유**: `null`/키-누락과 구분해 FE가 "옛 서버라 필드가 없다"와 "이 메시지엔 참조가 없다"를 가를 수 있게 한다(오르테가 지적 그대로).

## 테스트
- 신규 realdb 5건(`test_2263_chat_message_read_references_realdb.py`):
  - 단건 재조회가 stored 참조를 되살린다(진짜 별개 GET 왕복 — send 응답 재사용 아님).
  - 목록이 메시지별 stored 참조를 정확히 매칭 + **N+1 방지 실증**(`fetch_stored_references` 호출 횟수를 monkeypatch로 세어 페이지당 정확히 1회임을 assert).
  - 토큰 없는 메시지도 `references: []`가 실린다(필드 누락 아님).
  - dropped 사유는 읽기 응답 어디에도 없다(stored가 빈 것으로만 "안 걸렸다"가 드러남).
  - `list_message_replies`도 동형.
- **뮤테이션 자가검증**: `fetch_stored_references`를 항상 `{}` 반환하도록 사보타주 → 실 데이터를 검증하는 3건 정확히 RED(나머지 2건은 무영향 — "빈 배열" 케이스라 사보타주와 무관함도 같이 확인) → 원복 → 17건(신규 5 + 기존 mentions 12) 재-GREEN.
- 마스크된 스위트 `-k "conversation or message or chat"` 203건 GREEN — `test_conversations.py::test_list_messages_response_shape`의 mock에 배치조회 1콜분 결과 추가(새 DB 왕복 반영, 그 외 무변경).
- `python -c "from app.main import app"` — 501 routes, import 정상.

## 스코프 밖 (다음 사람 참고)
- FE 소비(`chat-bubble.tsx`의 `EntityChip`이 이 `references`를 실제로 읽어 유령 칩을 가리는 것)는 이 PR 범위 밖 — #2315 패턴과 동일하게 BE만 먼저 착지한다.
- 「지금 상태·다음 행동」 노출은 #2262 본체 — 그때 C-3(#2261) 권한 게이트가 먼저 서야 한다(오르테가 판정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)