### PR TITLE
[SID:2263] AC6 — 유령 칩(dropped 참조가 정상 칩으로 보이던 것) fix

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -60,6 +60,53 @@ afterEach(async () => {
   vi.unstubAllGlobals();
 });
 
+describe('ChatBubble — story #2263 AC6 유령 칩(stored 참조 대조)', () => {
+  it('references가 undefined(옛 서버·SSE 디스패치 폴백)면 유령 판정을 안 하고 그대로 그린다', async () => {
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={{ ...baseMessage, references: undefined }} isMine={false} />));
+    });
+    const chip = container.querySelector('button');
+    expect(chip).not.toBeNull();
+    expect(container.textContent).not.toContain('대상이 없습니다');
+  });
+
+  it('references가 빈 배열(읽기 경로가 참조 0건을 확認)이면 본문 토큰이 유령으로 그려진다', async () => {
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={{ ...baseMessage, references: [] }} isMine={false} />));
+    });
+    // 유령 칩은 버튼(클릭·모달)이 아니라 행동 0의 span이어야 한다.
+    expect(container.querySelector('button')).toBeNull();
+    expect(container.textContent).toContain('대상이 없습니다');
+  });
+
+  it('음성대조 — references에 본문 토큰과 정확히 일치하는 항목이 있으면 정상 칩 그대로다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, references: [{ target_type: 'doc', target_id: DOC_ID }] }}
+          isMine={false}
+        />,
+      ));
+    });
+    const chip = container.querySelector('button');
+    expect(chip).not.toBeNull();
+    expect(container.textContent).not.toContain('대상이 없습니다');
+    expect(container.textContent).toContain('제안서.md');
+  });
+
+  it('asset 토큰은 stored 참조 대조 대상이 아니다(registry 밖 타입 — 유령 오판 방지)', async () => {
+    const assetMsg: ChatMessage = {
+      ...baseMessage,
+      content: `[파일.png](entity:asset:${DOC_ID})`,
+      references: [], // 참조 0건이어도 asset은 유령 처리하면 안 된다.
+    };
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={assetMsg} isMine={false} />));
+    });
+    expect(container.textContent).not.toContain('대상이 없습니다');
+  });
+});
+
 describe('ChatBubble 문서 임베드 미리보기 모달 — 폴링 유발 리렌더 생존', () => {
   it('무관한 prop(presenceStatus)이 바뀌어 부모가 리렌더돼도 열린 모달이 유지된다', async () => {
     await act(async () => {

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -38,6 +38,21 @@ interface ContextMenuState {
   y: number;
 }
 
+// story #2263 AC6 — 본문 토큰(target_type+target_id)이 메시지의 stored 참조 목록에 있는지
+// 대조한다. `references === undefined`(옛 서버·SSE 디스패치 등 이 필드를 안 주는 경로)는
+// 판단 재료가 없다는 뜻이라 유령 처리를 보류한다(폴백 — 기존처럼 그대로 그린다). 대소문자
+// 차이(사용자가 UUID를 대문자로 쳐 넣는 경우)를 흡수하려 양쪽 다 lower-case로 비교한다.
+function isGhostReference(
+  references: ChatMessage['references'],
+  targetType: string,
+  targetId: string,
+): boolean {
+  if (references === undefined) return false;
+  const type = targetType.toLowerCase();
+  const id = targetId.toLowerCase();
+  return !references.some((r) => r.target_type.toLowerCase() === type && r.target_id.toLowerCase() === id);
+}
+
 // Convert @name tokens to markdown links so react-markdown v10 can render them via the `a` component.
 // Uses negative lookbehind to skip already-linked mentions (e.g. inside [...]).
 function prepareMentions(content: string): string {
@@ -98,7 +113,7 @@ function CopyableCode({ raw, inline, className }: { raw: string; inline: boolean
   );
 }
 
-function ChatMarkdown({ content, isMine }: { content: string; isMine: boolean }) {
+function ChatMarkdown({ content, isMine, references }: { content: string; isMine: boolean; references: ChatMessage['references'] }) {
   const text = isMine ? 'text-primary-foreground' : 'text-foreground';
   const muted = isMine ? 'text-primary-foreground/70' : 'text-muted-foreground';
   const codeBg = isMine ? 'bg-primary-foreground/10 text-primary-foreground' : 'bg-muted text-foreground';
@@ -160,14 +175,18 @@ function ChatMarkdown({ content, isMine }: { content: string; isMine: boolean })
       const m = href?.match(/^entity:(\w+):([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i);
       if (m) {
         // S6: 자산 토큰은 컴팩트 칩 대신 리치 임베드 카드(썸네일+메타+화살표).
+        // ⛔asset은 reference_registry.ENTITY_RESOLVERS 밖의 FE 전용 타입이라(embed-card.tsx
+        // 주석 참조) mention_parser가 애초에 entity_references에 안 쓴다 — stored 참조와
+        // 대조하면 asset 임베드가 전부 유령으로 오판된다. 유령 판정 자체를 안 태운다.
         if (m[1]!.toLowerCase() === 'asset') {
           return <AssetEmbedCard entityId={m[2]!} label={String(children)} ownMessage={isMine} />;
         }
-        return <EntityChip entityType={m[1]!} entityId={m[2]!} label={String(children)} href={getEntityHref(m[1]!, m[2]!)} />;
+        const ghost = isGhostReference(references, m[1]!, m[2]!);
+        return <EntityChip entityType={m[1]!} entityId={m[2]!} label={String(children)} href={getEntityHref(m[1]!, m[2]!)} ghost={ghost} />;
       }
       return <a href={href} target="_blank" rel="noopener noreferrer" className={`underline underline-offset-2 ${text}`}>{children}</a>;
     },
-  }), [text, muted, codeBg, border, isMine]);
+  }), [text, muted, codeBg, border, isMine, references]);
 
   if (!hasMarkdown && !hasMention) {
     return (
@@ -331,7 +350,7 @@ export function ChatBubble({ message, isMine, isGrouped = false, onOpenThread, o
                 ? 'rounded-tr-sm bg-primary text-primary-foreground'
                 : 'rounded-tl-sm bg-muted text-foreground'
             }`}>
-              <ChatMarkdown content={displayContent} isMine={isMine} />
+              <ChatMarkdown content={displayContent} isMine={isMine} references={message.references} />
             </div>
           )}
 

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -506,21 +506,31 @@ export function EntityChip({
   entityId,
   label,
   href,
+  ghost = false,
 }: {
   entityType: string;
   entityId?: string;
   label: string;
   href: string | null;
+  /** story #2263 AC6 — 본문 토큰이 메시지의 stored 참조(읽기 경로 사이드밴드)와 매칭되지
+   * 않을 때(=유령 칩, dropped됐거나 손으로 친 토큰). #2302 AC4 규율을 그대로 재사용한다 —
+   * 회색 하나(GRAY_STATE_COLOR)·행동 0(클릭·모달 없음)·기본 커서·문구는 이미 선 "대상이
+   * 없습니다"(신규 문구 발명 금지). */
+  ghost?: boolean;
 }) {
   const [showModal, setShowModal] = useState(false);
-  const colorClass = ENTITY_COLORS[entityType] ?? GRAY_STATE_COLOR;
+  const colorClass = ghost ? GRAY_STATE_COLOR : (ENTITY_COLORS[entityType] ?? GRAY_STATE_COLOR);
 
   const inner = (
     <span className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs font-medium ${colorClass}`}>
       <EntityGlyph Icon={resolveEntityIcon(entityType)} label={label} className="size-3 shrink-0" />
-      <span>{label}</span>
+      <span>{ghost ? '대상이 없습니다' : label}</span>
     </span>
   );
+
+  if (ghost) {
+    return <span className="inline-flex cursor-default no-underline">{inner}</span>;
+  }
 
   if (entityId) {
     return (

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -30,6 +30,12 @@ export interface ChatMessage {
   parent_id?: string | null;    // null = top-level message; set = this is a thread reply
   reply_count?: number;
   last_reply_at?: string | null;
+  /** story #2263 AC6 — 읽기 경로(list_messages/get_message/list_message_replies)만 싣는
+   * stored 참조 사이드밴드(conversations.py fetch_stored_references). ⛔`undefined`(키
+   * 자체가 없음 — SSE 디스패치·전송 직후 응답 등 이 필드를 안 주는 경로)와 `[]`(읽기 경로가
+   * 실제로 0건을 확認)를 구분한다 — 전자는 "판단 재료 없음"이라 유령 판정을 보류(폴백,
+   * 기존처럼 그대로 그린다)하고, 후자는 본문 토큰과 대조해 유령을 가른다. */
+  references?: Array<{ target_type: string; target_id: string }>;
 }
 
 // Normalize backend _to_chat_message format → ChatMessage
@@ -49,6 +55,10 @@ export function normalizeToMessage(raw: Record<string, unknown>): ChatMessage {
     parent_id: (raw.parent_id ?? raw.thread_id ?? null) as string | null,
     reply_count: (raw.reply_count ?? 0) as number,
     last_reply_at: (raw.last_reply_at ?? null) as string | null,
+    // story #2263 AC6 — key 부재(undefined)와 빈 배열([])을 그대로 통과시킨다. `raw.references
+    // ?? []`처럼 기본값을 주면 "옛 서버라 필드가 없다"가 "참조 0건 확認됨"으로 뭉개져 유령
+    // 판정이 항상 켜지는 회귀가 난다(오늘 아침 유령 칩 사고와 같은 모양).
+    references: Array.isArray(raw.references) ? raw.references as ChatMessage['references'] : undefined,
   };
 }
 


### PR DESCRIPTION
## Summary
- #2263 AC6: dropped/미등록/손으로 친 엔티티 토큰도 저장된 것과 똑같은 칩으로 그려지던 문제(오늘 아침 스레드에서 발견) — BE read-path(PR #2619, `references` 사이드밴드)가 이미 머지됐으니 FE에서 대조하는 반쪽.
- `ChatMarkdown`이 본문 토큰(target_type+target_id)을 `message.references`(stored 참조 목록)와 대조 — 없는 토큰은 "유령" 모드로 그린다.

## Changes
- `use-chat-sse.ts`: `ChatMessage.references?: Array<{target_type, target_id}>` 추가. `normalizeToMessage`가 key 부재(undefined)와 빈 배열([])을 구분해서 통과시킨다(기본값 부여 금지 — 기본값을 주면 "옛 서버"와 "참조 0건 확認"이 뭉개져 유령 판정이 항상 켜지는 회귀가 남).
- `chat-bubble.tsx`: `isGhostReference()` 헬퍼 신설. `references===undefined`면 유령 판정 보류(폴백, 기존 동작 유지) — 판단 재료가 없을 때 유령으로 단정하지 않는다. `asset` 타입은 판정에서 제외(registry 밖 FE 전용 타입이라 mention_parser가 애초에 안 씀 — 안 걸러내면 asset 임베드 전부가 오탐 유령이 됨).
- `embed-card.tsx`: `EntityChip`에 `ghost` prop 추가 — 회색(GRAY_STATE_COLOR)·"대상이 없습니다"(#2302 AC4 문구 그대로 재사용, 신규 문구 없음)·클릭 핸들러/모달 없음·cursor-default.

## Test plan
- [x] `chat-bubble.test.tsx`에 4건 신설: `references` undefined 폴백 / `[]`+미매칭 토큰 → 유령 / 매칭되는 참조 있으면 정상 칩(음성대조) / asset은 유령 판정 제외
- [x] 뮤테이션 자가검증: `isGhostReference`를 `return false`로 되돌려 "빈 배열→유령" 테스트가 RED로 떨어지는 것 확認 → 복구 후 5/5 GREEN
- [x] 전체 chat 컴포넌트+훅 테스트 스위트 15 files / 100 tests 전부 green(회귀 없음)
- [x] `tsc --noEmit`, `eslint` 둘 다 clean
- [ ] 라이브 픽셀 — 실제 dropped 참조가 있는 메시지로 새로고침 후 유령 칩 확認은 배포 후 필요(dev 서버 상엔 아직 이 fix가 없어 이번 세션에서 재현 불가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)