### PR TITLE
fix(#2322): unify story access-denial to 404 (PR 1/4 — story)

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -258,11 +258,17 @@ async def _assert_story_project_access(
     """E-SECURITY SEC-S8(story 83ea3d6a) G: 개별-ID story 접근(get/update/status)이 org-scope만
     있고 project 접근권 미검증이던 갭 — 같은 org 다른 project 멤버가 story id만 알면 조회/수정
     가능했다. upload_story_attachment와 동형으로 has_project_access 재사용(휴먼 team_member·
-    에이전트 project_access grant 양쪽 처리). delete_story는 SEC-S3(#2014)가 별도 처리."""
+    에이전트 project_access grant 양쪽 처리). delete_story는 SEC-S3(#2014)가 별도 처리.
+
+    ⛔story #2322(2026-07-29, PO 판정): 무권한을 403이 아닌 404로 낸다 — 존재 비노출 규율을
+    이 파일 전체에서 통일한다(participation.py의 동명 헬퍼·gates.py get_gate_endpoint가 이미
+    이 규율이었다 — 「같은 엔티티가 경로마다 다른 답」을 내던 것이 진짜 결함이었다). 조직
+    경계(다른 org)는 이 함수 호출 前에 이미 404로 막혀 있다(repo.get()의 org 필터) — 이 함수가
+    새로 여는 것은 「조직 안·프로젝트 밖」 하나뿐이고, 그 답도 이제 404다."""
     from app.services.project_auth import has_project_access
 
     if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
-        raise HTTPException(status_code=403, detail="No access to this project")
+        raise HTTPException(status_code=404, detail="Story not found")
 
 
 async def _upsert_assignee_participation(

--- a/backend/tests/test_2245_stories_workflow_line_status_project_scope_realdb.py
+++ b/backend/tests/test_2245_stories_workflow_line_status_project_scope_realdb.py
@@ -81,7 +81,7 @@ async def _seed(session):
 
 
 def _client_for(app):
-    from httpx import AsyncClient, ASGITransport
+    from httpx import ASGITransport, AsyncClient
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
 
 
@@ -135,8 +135,9 @@ async def test_get_workflow_line_status_own_project_200():
 
 
 @pytest.mark.anyio
-async def test_get_workflow_line_status_no_project_access_blocked_403():
-    """본체: 같은 org 이지만 project 접근권 없는 caller는 거부(기존엔 org-scope만이라 200)."""
+async def test_get_workflow_line_status_no_project_access_blocked_404():
+    """본체: 같은 org 이지만 project 접근권 없는 caller는 거부 — story #2322(2026-07-29):
+    404로 통일(예전엔 403이었으나 존재 비노출 규율로 정정, 기존엔 org-scope만이라 200이었음)."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -148,7 +149,7 @@ async def test_get_workflow_line_status_no_project_access_blocked_403():
         client = _client_for(app)
         try:
             resp = await client.get(f"/api/v2/stories/{seeded['story_b_id']}/workflow-line/status")
-            assert resp.status_code == 403, resp.text
+            assert resp.status_code == 404, resp.text
         finally:
             await client.aclose()
     finally:

--- a/backend/tests/test_2245_stories_workflow_line_writes_project_scope_realdb.py
+++ b/backend/tests/test_2245_stories_workflow_line_writes_project_scope_realdb.py
@@ -88,7 +88,7 @@ async def _seed(session):
 
 
 def _client_for(app):
-    from httpx import AsyncClient, ASGITransport
+    from httpx import ASGITransport, AsyncClient
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
 
 
@@ -146,8 +146,9 @@ async def test_fallback_notify_own_project_passes_guard_404_step_run():
 
 
 @pytest.mark.anyio
-async def test_fallback_notify_no_project_access_blocked_403():
-    """본체: 같은 org 이지만 project 접근권 없는 caller는 서비스 레이어 도달 前 403으로 거부."""
+async def test_fallback_notify_no_project_access_blocked_404():
+    """본체: 같은 org 이지만 project 접근권 없는 caller는 서비스 레이어 도달 前 404로 거부
+    (story #2322, 2026-07-29 — 예전엔 403이었으나 존재 비노출 규율로 통일)."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -162,7 +163,7 @@ async def test_fallback_notify_no_project_access_blocked_403():
                 f"/api/v2/stories/{seeded['story_b_id']}/workflow-line/fallback-notify",
                 json={"step_run_id": str(uuid.uuid4())},
             )
-            assert resp.status_code == 403, resp.text
+            assert resp.status_code == 404, resp.text
         finally:
             await client.aclose()
     finally:
@@ -197,9 +198,9 @@ async def test_withdraw_own_project_passes_guard_404_step_run():
 
 
 @pytest.mark.anyio
-async def test_withdraw_no_project_access_blocked_403():
+async def test_withdraw_no_project_access_blocked_404():
     """본체(가장 아픈 자리 — 쓰기): 같은 org 이지만 project 접근권 없는 caller는 pending gate
-    run 철회 서비스에 도달하지도 못하고 403으로 거부."""
+    run 철회 서비스에 도달하지도 못하고 404로 거부(story #2322, 2026-07-29 — 예전엔 403)."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -214,7 +215,7 @@ async def test_withdraw_no_project_access_blocked_403():
                 f"/api/v2/stories/{seeded['story_b_id']}/workflow-line/withdraw",
                 json={"step_run_id": str(uuid.uuid4())},
             )
-            assert resp.status_code == 403, resp.text
+            assert resp.status_code == 404, resp.text
         finally:
             await client.aclose()
     finally:

--- a/backend/tests/test_2258_story_request_verification_realdb.py
+++ b/backend/tests/test_2258_story_request_verification_realdb.py
@@ -99,7 +99,7 @@ async def _seed(session, *, with_default_role: bool = True):
 
 
 def _client_for(app):
-    from httpx import AsyncClient, ASGITransport
+    from httpx import ASGITransport, AsyncClient
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
 
 
@@ -212,8 +212,9 @@ async def test_request_verification_without_default_role_falls_back_not_500():
 
 
 @pytest.mark.anyio
-async def test_request_verification_cross_project_blocked_403_no_gate():
-    """봉인: 접근권 없는 project의 story에 검증요청 시도 → 403 + gate 미생성."""
+async def test_request_verification_cross_project_blocked_404_no_gate():
+    """봉인: 접근권 없는 project의 story에 검증요청 시도 → 404(story #2322, 2026-07-29 —
+    예전엔 403이었으나 존재 비노출 규율로 통일) + gate 미생성."""
     from app.main import app
     engine, Session = await _session_factory()
     try:
@@ -223,7 +224,7 @@ async def test_request_verification_cross_project_blocked_403_no_gate():
         client = _client_for(app)
         try:
             resp = await client.post(f"/api/v2/stories/{seeded['story_other_id']}/request-verification")
-            assert resp.status_code == 403, resp.text
+            assert resp.status_code == 404, resp.text
         finally:
             await client.aclose()
 

--- a/backend/tests/test_2261_c3_reference_leak_zero_procedure_realdb.py
+++ b/backend/tests/test_2261_c3_reference_leak_zero_procedure_realdb.py
@@ -300,17 +300,15 @@ async def test_three_way_byte_identical_story_backlinks_source_axis():
 
 @pytest.mark.anyio
 async def test_single_axis_target_gate_flagged_403_vs_404_asymmetry():
-    """⚠️실측 결과 — 스토리 본문이 가정한 «단건 축도 byte-identical»이 지금 코드에서는 안 선다.
+    """⚠️실측 결과(2026-07-29 갱신) — 이 테스트가 처음 적힌 시점엔 story·doc 둘 다 «존재하되
+    접근권 없음»=403이었다(#2261 원 실측). 그 비대칭은 #2322로 별건 등재됐고, #2322 PR #1
+    (PR #2624)이 stories.py `_assert_story_project_access`를 403→404로 통일했다 — 그래서
+    story 축은 이제 404다(#2261이 찾아낸 문제 하나가 실제로 닫혔다는 증거이기도 하다).
 
-    `_assert_story_project_access`/`_require_doc_project_access`는 대상이 «존재하되 접근권
-    없음»이면 403, «존재 자체가 없음»이면 404를 낸다(stories.py:264·docs.py:598 — 코드로
-    직접 확認, 둘 다 일관되게 이 패턴). references.py의 create/delete 게이트(둘 다 404 —
-    "존재 비노출 오라클")와 다른 설계다.
-
-    ⛔이 테스트는 실패가 아니라 «지금 상태를 고정하는 기록»이다 — SEC-S8(story 83ea3d6a)가
-    이미 감사한 기존 계약을 이 PR이 조용히 바꾸지 않는다(범위 밖 변경 금지). 이 비대칭이
-    #2261의 «누설 0» 기준에 부합하는지는 PO 판단으로 남긴다 — 코드가 그렇다는 사실만 여기
-    실측으로 고정해 둔다."""
+    docs.py `_require_doc_project_access`는 #2322 PR #3(아직 미착수 — E-CONNECT 에픽
+    완료 후로 보류, 2026-07-29 3차 선생님 지시)이라 doc 축은 여전히 403 — 지금은 **story만
+    404·doc은 403**인 상태를 그대로 고정한다(이것도 #2322 자신이 명시한 "의도적 과도기
+    비대칭"이다). #2322 PR #3이 착지하면 doc 쪽도 여기서 404로 다시 갱신해야 한다."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -331,8 +329,9 @@ async def test_single_axis_target_gate_flagged_403_vs_404_asymmetry():
             resp_doc_theirs = await client.get(f"/api/v2/docs/{doc_theirs.id}/backlinks")
             resp_doc_ghost = await client.get(f"/api/v2/docs/{uuid.uuid4()}/backlinks")
 
-            # 실측 그대로 기록 — 존재하되 접근권 없음=403, 존재 자체가 없음=404.
-            assert resp_story_theirs.status_code == 403, resp_story_theirs.text
+            # story: #2322 PR #1(PR #2624)로 404 통일 완료 — 존재하되 접근권 없음도 404.
+            # doc: #2322 PR #3 미착수(E-CONNECT 완료 후 보류) — 아직 403 그대로.
+            assert resp_story_theirs.status_code == 404, resp_story_theirs.text
             assert resp_story_ghost.status_code == 404, resp_story_ghost.text
             assert resp_doc_theirs.status_code == 403, resp_doc_theirs.text
             assert resp_doc_ghost.status_code == 404, resp_doc_ghost.text

--- a/backend/tests/test_2266_story_backlinks_realdb.py
+++ b/backend/tests/test_2266_story_backlinks_realdb.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import os
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -71,10 +71,10 @@ async def _make_project(session, org_id, name="P"):
 async def _make_human_member(session, org_id, project_id):
     """test_1994의 동명 helper와 동일 anchor 패턴(members + org_members + project_access
     직접 write — team_members는 VIEW라 INSERT 불가)."""
-    from app.models.user import User
+    from app.models.member import Member
     from app.models.project import OrgMember
     from app.models.project_access import ProjectAccess
-    from app.models.member import Member
+    from app.models.user import User
 
     user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
     session.add(user)
@@ -116,7 +116,7 @@ async def _add_message(session, conv_id, sender_id, content, created_at=None):
     from app.models.conversation import ConversationMessage
     msg = ConversationMessage(
         id=uuid.uuid4(), conversation_id=conv_id, sender_id=sender_id,
-        content=content, created_at=created_at or datetime.now(timezone.utc),
+        content=content, created_at=created_at or datetime.now(UTC),
     )
     session.add(msg)
     await session.commit()
@@ -136,7 +136,7 @@ async def _make_reference(session, org_id, source_type, source_id, target_type, 
 
 
 def _client_for(app):
-    from httpx import AsyncClient, ASGITransport
+    from httpx import ASGITransport, AsyncClient
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
 
 
@@ -169,8 +169,11 @@ async def _setup_app_human(app, Session, user_id, org_id):
 @pytest.mark.anyio
 async def test_list_entity_backlinks_rejects_unsupported_target_type():
     """게이트가 안 선 타입(epic 등)은 허용목록 밖 — UnsupportedBacklinkTargetTypeError."""
-    from app.services.backlinks import list_entity_backlinks, UnsupportedBacklinkTargetTypeError
     from app.dependencies.auth import AuthContext
+    from app.services.backlinks import (
+        UnsupportedBacklinkTargetTypeError,
+        list_entity_backlinks,
+    )
 
     engine, Session = await _session_factory()
     try:
@@ -223,7 +226,8 @@ async def test_story_backlinks_404_for_nonexistent_story():
 async def test_story_backlinks_project_access_twin_comparison():
     """⭐AC2·AC5 핵심 — 양성대조(twin comparison, PO가 #2277에도 요구한 그 패턴): 같은
     story·같은 참조 데이터에 대해 project 접근이 «있는» caller는 200+데이터를 보고, 접근이
-    «없는» caller는 403을 받는다. 하나만 재면(0건만 확인) 권한 게이트가 실제로 도는지
+    «없는» caller는 404를 받는다(story #2322, 2026-07-29 — 예전엔 403이었으나 존재 비노출
+    규율로 통일). 하나만 재면(0건만 확인) 권한 게이트가 실제로 도는지
     "없어서 0건"인지 "막혀서 0건"인지 구분이 안 된다 — 이 테스트가 그 둘을 가른다."""
     from app.main import app
 
@@ -257,12 +261,13 @@ async def test_story_backlinks_project_access_twin_comparison():
             await client.aclose()
             app.dependency_overrides.clear()
 
-        # (2) 접근 없는 caller(다른 project) — 403, 데이터 유출 0
+        # (2) 접근 없는 caller(다른 project) — story #2322(2026-07-29): 404로 통일(존재
+        # 비노출 규율 — 예전엔 403이었다가 이 스토리에서 정정됨), 데이터 유출 0
         await _setup_app_human(app, Session, user_without_access, org.id)
         client = _client_for(app)
         try:
             resp = await client.get(f"/api/v2/stories/{story.id}/backlinks")
-            assert resp.status_code == 403, resp.text
+            assert resp.status_code == 404, resp.text
         finally:
             await client.aclose()
             app.dependency_overrides.clear()
@@ -310,12 +315,12 @@ async def test_story_backlinks_gate_red_green_mutation_self_check():
         finally:
             stories_module._assert_story_project_access = original_gate
 
-        # 원복 후 GREEN 재확인 — 같은 caller가 다시 403.
+        # 원복 후 GREEN 재확인 — 같은 caller가 다시 404(story #2322 통일).
         await _setup_app_human(app, Session, user_without_access, org.id)
         client = _client_for(app)
         try:
             resp = await client.get(f"/api/v2/stories/{story.id}/backlinks")
-            assert resp.status_code == 403, resp.text
+            assert resp.status_code == 404, resp.text
         finally:
             await client.aclose()
             app.dependency_overrides.clear()

--- a/backend/tests/test_2322_story_403_to_404_unification_realdb.py
+++ b/backend/tests/test_2322_story_403_to_404_unification_realdb.py
@@ -1,0 +1,208 @@
+"""story #2322 — PR #1(story 헬퍼) — `_assert_story_project_access`(stories.py)를 쓰는
+5개 호출부(그때까지 403전용 테스트가 없던 곳: get_story·update_story·update_story_status·
+list_comments·list_activities) 각각에 «무권한→404» 계약을 새로 못박는다.
+
+⛔RED-먼저 규율(PO 판정, 2026-07-29): 옛 403을 테스트로 고정하지 않는다 — 이 파일은
+헬퍼가 아직 403을 내는 시점에 작성됐고, 코드를 고치기 前에 반드시 RED(404 기대인데 실제
+403이 와서 실패)를 눈으로 본 뒤에만 헬퍼를 바꾼다(같은 세션 커밋 메시지에 그 순서를 남긴다).
+
+⭐양성대조: 접근권 있는 caller는 여전히 200 + 실제 데이터를 받는다(기존 test_stories.py::
+test_get_story_200 등이 이미 그 축을 덮고 있어 여기서 재짓지 않는다 — 발명 금지).
+
+다른 5개 호출부(backlinks·workflow-line-status·fallback-notify·withdraw·request-verification)
+는 이미 403전용 테스트가 있어 — 이 파일이 아니라 그 기존 테스트 파일들을 직접 403→404로
+수정한다(동일 커밋).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from tests.test_2266_story_backlinks_realdb import (
+    _client_for,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _make_story,
+    _session_factory,
+    _setup_app_human,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _seed_cross_project(session):
+    """org 하나에 project 둘 — caller는 other_project 소속(=target story의 project에 접근권 없음),
+    같은 org 라서 org 경계는 이미 통과(그건 #2261이 이미 확認한 축, 이 PR과 무관)."""
+    org = await _make_org(session)
+    project = await _make_project(session, org.id, "Target Project")
+    other_project = await _make_project(session, org.id, "Other Project")
+    _, user_id = await _make_human_member(session, org.id, other_project.id)
+    story = await _make_story(session, org.id, project.id, title="Target Story")
+    return org, story, user_id
+
+
+@pytest.mark.anyio
+async def test_get_story_no_project_access_is_404_not_403():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, story, user_id = await _seed_cross_project(s)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{story.id}")
+            assert resp.status_code == 404, (
+                f"story #2322: 같은 org·다른 project 무권한은 404여야 한다(존재 비노출 통일) — "
+                f"{resp.status_code}: {resp.text}"
+            )
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_story_no_project_access_is_404_not_403():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, story, user_id = await _seed_cross_project(s)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(f"/api/v2/stories/{story.id}", json={"title": "hacked"})
+            assert resp.status_code == 404, (
+                f"story #2322: PATCH 무권한도 404여야 한다 — {resp.status_code}: {resp.text}"
+            )
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_story_status_no_project_access_is_404_not_403():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, story, user_id = await _seed_cross_project(s)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(f"/api/v2/stories/{story.id}/status", json={"status": "in-progress"})
+            assert resp.status_code == 404, (
+                f"story #2322: PATCH /status 무권한도 404여야 한다 — {resp.status_code}: {resp.text}"
+            )
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_comments_no_project_access_is_404_not_403():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, story, user_id = await _seed_cross_project(s)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{story.id}/comments")
+            assert resp.status_code == 404, (
+                f"story #2322: GET /comments 무권한도 404여야 한다 — {resp.status_code}: {resp.text}"
+            )
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_activities_no_project_access_is_404_not_403():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, story, user_id = await _seed_cross_project(s)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{story.id}/activities")
+            assert resp.status_code == 404, (
+                f"story #2322: GET /activities 무권한도 404여야 한다 — {resp.status_code}: {resp.text}"
+            )
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_story_still_404_for_genuinely_nonexistent_id():
+    """양성대조의 다른 절반 — 「전부 404로 만들어 조용해진 것」과 구분(AC4). 존재 자체가
+    없는 id도 여전히 404(이건 원래도 404였다 — 회귀 아님)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id, "P")
+            _, user_id = await _make_human_member(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{uuid.uuid4()}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- `_assert_story_project_access`(stories.py) previously returned 403 for a same-org caller lacking project access, leaking existence of a story they shouldn't be able to see — inconsistent with `gates.py`/`participation.py`'s already-established 404 convention for the identical scenario.
- Unified to 404 across all 10 call sites of this helper (get_story, get_story_backlinks, get_workflow_line_status, workflow_line_fallback_notify, workflow_line_withdraw, update_story, update_story_status, list_comments, request_verification, list_activities).
- Org-boundary (different org entirely) was already 404 before this change (row-level org filter) — unaffected. Only the "same org, no project access" case changes 403→404.
- Split from the shared-helper investigation (#2322) into 4 helper-scoped PRs (story → task → doc → retro) to keep blast radius reviewable. This is PR 1/4.

## Test plan
- [x] New test file `test_2322_story_403_to_404_unification_realdb.py` — RED-first: 5 new 404-expectation tests confirmed failing against pre-change code (403), then confirmed passing after the helper change.
- [x] Updated 5 pre-existing 403-only tests across `test_2266_story_backlinks_realdb.py`, `test_2245_stories_workflow_line_status_project_scope_realdb.py`, `test_2245_stories_workflow_line_writes_project_scope_realdb.py`, `test_2258_story_request_verification_realdb.py` to assert 404 — own-project 200/guard-passed-404 regression axes left untouched.
- [x] Full story-related realdb suite (64 tests across 8 files) green.
- [x] Positive control unaffected: `test_stories.py::test_get_story_200` and friends still pass.
- [x] FE has no existing 403/404-specific messaging for these endpoints — errors surface as generic translated failure toasts, never a false "deleted" claim — so no FE change needed.
- Note (honest gap, not silently skipped): no regression guard exists today that would fail if a *future* endpoint reintroduced a 403 for this scenario outside this helper; `test_authz_project_scope_coverage.py`'s registry only checks that new project-scoped routes call a recognized gate function, not its status code.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>