### PR TITLE
[SID:2249] Attention Queue에 체류시간(entered_state_at) 노출

### DIFF
--- a/apps/web/src/components/attention-queue/attention-queue-view.tsx
+++ b/apps/web/src/components/attention-queue/attention-queue-view.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl';
 import { ShieldCheck } from 'lucide-react';
 import { ProofCapsule } from '@/components/proof-capsule/proof-capsule';
 import { useSseNotifications } from '@/hooks/use-sse-notifications';
+import { formatRelativeTime } from '@/lib/storage/format';
 import { cn } from '@/lib/utils';
 import {
   parseAttentionQueueSignals, buildAttentionQueueFromBe, buildAttentionQueue, diffAttentionQueueItemIds,
@@ -58,6 +59,7 @@ function AttentionRow({ item, highlighted, onNavigate }: {
         human={item.actor && !item.actor.isAgent ? { name: item.actor.name, role: '' } : undefined}
         agent={item.actor?.isAgent ? { name: item.actor.name, initial: item.actor.name.slice(0, 1) } : undefined}
         gate={{ action: item.actionLabel, href: item.href, tone: item.actionTone }}
+        duration={item.enteredStateAtMs !== null ? formatRelativeTime(new Date(item.enteredStateAtMs).toISOString()) : undefined}
         className="rounded-none border-0"
       />
     </div>

--- a/apps/web/src/components/attention-queue/derive-attention-queue.test.ts
+++ b/apps/web/src/components/attention-queue/derive-attention-queue.test.ts
@@ -21,7 +21,7 @@ const t = createTranslator({ locale: 'ko', messages: koMessages, namespace: 'att
 const tEn = createTranslator({ locale: 'en', messages: enMessages, namespace: 'attentionQueue' }) as unknown as AttentionQueueTranslator;
 
 function beItem(overrides: Partial<BeAttentionItem> = {}): BeAttentionItem {
-  return { kind: 'verify_fail', story_id: 'story-1', title: '결제 복구 플로우', ref: {}, ...overrides };
+  return { kind: 'verify_fail', story_id: 'story-1', title: '결제 복구 플로우', ref: {}, entered_state_at: null, ...overrides };
 }
 
 describe('parseAttentionQueueSignals', () => {
@@ -72,6 +72,21 @@ describe('parseAttentionQueueSignals', () => {
       ],
     });
     expect(items).toHaveLength(0);
+  });
+
+  it('story #2249 — extracts entered_state_at when present as an ISO string', () => {
+    const items = parseAttentionQueueSignals({
+      items: [beItem({ entered_state_at: '2026-07-26T00:00:00.000Z' })],
+    });
+    expect(items[0]!.entered_state_at).toBe('2026-07-26T00:00:00.000Z');
+  });
+
+  it('story #2249 — defaults entered_state_at to null when absent or malformed (모름, 지어내지 않음)', () => {
+    const items = parseAttentionQueueSignals({
+      items: [beItem({ entered_state_at: undefined }), beItem({ entered_state_at: 12345 as unknown as null })],
+    });
+    expect(items[0]!.entered_state_at).toBeNull();
+    expect(items[1]!.entered_state_at).toBeNull();
   });
 });
 
@@ -148,17 +163,48 @@ describe('buildAttentionQueueFromBe', () => {
     ], tEn);
     expect(items[0]!.claim).toContain('blocked by 2');
   });
+
+  it('story #2249 — threads entered_state_at into enteredStateAtMs for 1:1 kinds (verify_fail/merge_ready)', () => {
+    const items = buildAttentionQueueFromBe([
+      beItem({ kind: 'verify_fail', entered_state_at: '2026-07-26T00:00:00.000Z' }),
+    ], t);
+    expect(items[0]!.enteredStateAtMs).toBe(Date.parse('2026-07-26T00:00:00.000Z'));
+    expect(items[0]!.sortKey).toBeGreaterThan(0);
+  });
+
+  it('story #2249 — enteredStateAtMs/sortKey stay null/0 when entered_state_at is unknown (blocked 등)', () => {
+    const items = buildAttentionQueueFromBe([beItem({ kind: 'blocked', entered_state_at: null })], t);
+    expect(items[0]!.enteredStateAtMs).toBeNull();
+    expect(items[0]!.sortKey).toBe(0);
+  });
+
+  it('story #2249 — blocked 집계는 여러 신호 중 가장 이른(min) entered_state_at을 쓴다', () => {
+    const items = buildAttentionQueueFromBe([
+      beItem({ kind: 'blocked', story_id: 'story-1', entered_state_at: '2026-07-27T00:00:00.000Z' }),
+      beItem({ kind: 'blocked', story_id: 'story-1', entered_state_at: '2026-07-25T00:00:00.000Z' }),
+    ], t);
+    expect(items[0]!.enteredStateAtMs).toBe(Date.parse('2026-07-25T00:00:00.000Z'));
+  });
+
+  it('story #2249 — decision_needed는 먼저 등장한 신호(gate_pending/needs_input)의 entered_state_at을 쓴다', () => {
+    const items = buildAttentionQueueFromBe([
+      beItem({ kind: 'gate_pending', story_id: 'story-1', entered_state_at: '2026-07-26T00:00:00.000Z' }),
+      beItem({ kind: 'needs_input', story_id: 'story-1', entered_state_at: '2026-07-28T00:00:00.000Z' }),
+    ], t);
+    expect(items[0]!.enteredStateAtMs).toBe(Date.parse('2026-07-26T00:00:00.000Z'));
+  });
 });
 
 describe('buildAttentionQueue', () => {
   function item(kind: AttentionQueueItem['kind'], sortKey: number): AttentionQueueItem {
     return {
       id: `${kind}-${sortKey}`, kind, kindLabel: kind, proofState: kind === 'merge_ready' ? 'green' : 'amber',
-      claim: kind, actor: null, actionLabel: '가기', actionTone: 'neutral', href: '/board', sortKey,
+      claim: kind, actor: null, actionLabel: '가기', actionTone: 'neutral', href: '/board',
+      enteredStateAtMs: null, sortKey,
     };
   }
 
-  it('sorts amber-tier items before merge_ready (green), most-recent-first within a tier', () => {
+  it('sorts amber-tier items before merge_ready (green), longest-elapsed(체류시간)-first within a tier', () => {
     const { shown } = buildAttentionQueue([
       item('merge_ready', 100),
       item('verify_fail', 10),
@@ -185,7 +231,8 @@ describe('diffAttentionQueueItemIds (9ef0f914 — SSE-triggered refetch diff)', 
   function item(id: string, claim: string): AttentionQueueItem {
     return {
       id, kind: 'blocked', kindLabel: '막힘', proofState: 'amber', claim,
-      actor: null, actionLabel: '조율', actionTone: 'neutral', href: '/board', sortKey: 0,
+      actor: null, actionLabel: '조율', actionTone: 'neutral', href: '/board',
+      enteredStateAtMs: null, sortKey: 0,
     };
   }
 

--- a/apps/web/src/components/attention-queue/derive-attention-queue.ts
+++ b/apps/web/src/components/attention-queue/derive-attention-queue.ts
@@ -17,8 +17,13 @@ export interface AttentionQueueItem {
   actionLabel: string;
   actionTone: 'primary' | 'neutral' | 'ready';
   href: string;
-  /** 정렬용 epoch ms. BE `/glance/attention`(P0-04)이 신호에 타임스탬프를 안 실어(정직 미가용)
-   * 전부 0 — 동급 티어 내 안정적 후순위(지어낸 최신순 아님). */
+  /** story #2249 — 「그 상태에 들어간 시각」epoch ms(모르면 null. blocked는 BE가 항상 값을
+   * 안 실어 null — glance.py 모듈 docstring: 재진입 시각 미기록이라 "모름"이지 근사 아님). FE는
+   * null 여부만으로 갈라 쓴다("exact"|null 두 상태뿐 — BE에 "approx"는 존재하지 않음, precision
+   * 필드는 그 값과 완전히 종속이라 별도로 안 읽는다). */
+  enteredStateAtMs: number | null;
+  /** 정렬용 경과시간(ms) — enteredStateAtMs 있으면 now-그값(체류시간이 위계를 만든다, 클수록
+   * 먼저), 없으면(모름) 0으로 동급 티어 내 안정적 후순위. */
   sortKey: number;
 }
 
@@ -40,6 +45,8 @@ export interface BeAttentionItem {
   story_id: string | null;
   title: string | null;
   ref: Record<string, unknown>;
+  /** story #2249 — glance.py `AttentionItem.entered_state_at`(UTC ISO). 없으면 null(모름). */
+  entered_state_at: string | null;
 }
 
 /** AQ가 소비하는 kind 전체(scope_violation은 BE가 §7 확定②로 미구현이라 kind 자체가 절대 미등장 —
@@ -81,9 +88,23 @@ export function parseAttentionQueueSignals(json: unknown): BeAttentionItem[] {
     const story_id = typeof rawStoryId === 'string' && rawStoryId ? rawStoryId : null;
     if (!story_id) continue; // href/집계 키를 지어낼 수 없으니 제외(no-fiction)
     const ref = isRecord(raw['ref']) ? (raw['ref'] as Record<string, unknown>) : {};
-    signals.push({ kind: kind as BeAttentionKind, story_id, title, ref });
+    const rawEnteredAt = raw['entered_state_at'];
+    const entered_state_at = typeof rawEnteredAt === 'string' ? rawEnteredAt : null;
+    signals.push({ kind: kind as BeAttentionKind, story_id, title, ref, entered_state_at });
   }
   return signals;
+}
+
+/** ISO 문자열 → epoch ms(모르면 null). 파싱 실패도 모름으로 취급(지어내지 않음). */
+function toEpochMs(iso: string | null): number | null {
+  if (!iso) return null;
+  const ms = Date.parse(iso);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/** enteredStateAtMs → 정렬키(경과시간 ms). 모르면 0(동급 티어 내 안정적 후순위). */
+function toSortKey(enteredStateAtMs: number | null): number {
+  return enteredStateAtMs === null ? 0 : Math.max(0, Date.now() - enteredStateAtMs);
 }
 
 const PROOF_STATE: Record<AttentionKind, ProofState> = {
@@ -107,48 +128,58 @@ export function buildAttentionQueueFromBe(
   t: AttentionQueueTranslator,
 ): AttentionQueueItem[] {
   const items: AttentionQueueItem[] = [];
-  const blockedByStory = new Map<string, { title: string; count: number }>();
-  const decisionNeededByStory = new Map<string, string>(); // story_id → title(첫 등장 것)
+  const blockedByStory = new Map<string, { title: string; count: number; enteredAtMs: number | null }>();
+  // story_id → { title, enteredAtMs }(첫 등장 것 — needs_input/gate_pending 중 먼저 온 신호 기준)
+  const decisionNeededByStory = new Map<string, { title: string; enteredAtMs: number | null }>();
 
   for (const sig of signals) {
     if (!sig.title || !sig.story_id) continue; // 방어적 재확인(parseAttentionQueueSignals가 이미 보장하지만 직접호출 대비)
+    const enteredAtMs = toEpochMs(sig.entered_state_at);
     if (sig.kind === 'blocked') {
-      const entry = blockedByStory.get(sig.story_id) ?? { title: sig.title, count: 0 };
+      // BE는 blocked에 entered_state_at을 항상 안 실어(재진입 시각 미기록 — glance.py 참조) 지금은
+      // 항상 null이지만, 나중에 재료가 생기면(#2256) 이 자리가 자동으로 값을 받는다 — "가장 먼저
+      // 막힌 엣지"가 이 story가 막힌 지 얼마나 됐는지를 가장 잘 대표하므로 min(가장 이른 시각)을 쓴다.
+      const entry = blockedByStory.get(sig.story_id) ?? { title: sig.title, count: 0, enteredAtMs: null };
       entry.count += 1;
+      if (enteredAtMs !== null && (entry.enteredAtMs === null || enteredAtMs < entry.enteredAtMs)) {
+        entry.enteredAtMs = enteredAtMs;
+      }
       blockedByStory.set(sig.story_id, entry);
     } else if (sig.kind === 'needs_input' || sig.kind === 'gate_pending') {
-      if (!decisionNeededByStory.has(sig.story_id)) decisionNeededByStory.set(sig.story_id, sig.title);
+      if (!decisionNeededByStory.has(sig.story_id)) {
+        decisionNeededByStory.set(sig.story_id, { title: sig.title, enteredAtMs });
+      }
     } else if (sig.kind === 'verify_fail') {
       items.push({
         id: `verify_fail-${sig.story_id}`, kind: 'verify_fail', kindLabel: t('kindVerifyFail'),
         proofState: PROOF_STATE.verify_fail, claim: t('claimVerifyFail', { title: sig.title }),
         actor: null, actionLabel: t('actionRework'), actionTone: 'neutral',
-        href: `/board?story=${sig.story_id}`, sortKey: 0,
+        href: `/board?story=${sig.story_id}`, enteredStateAtMs: enteredAtMs, sortKey: toSortKey(enteredAtMs),
       });
     } else if (sig.kind === 'merge_ready') {
       items.push({
         id: `merge_ready-${sig.story_id}`, kind: 'merge_ready', kindLabel: t('kindMergeReady'),
         proofState: PROOF_STATE.merge_ready, claim: t('claimMergeReady', { title: sig.title }),
         actor: null, actionLabel: t('actionMerge'), actionTone: 'ready',
-        href: `/board?story=${sig.story_id}`, sortKey: 0,
+        href: `/board?story=${sig.story_id}`, enteredStateAtMs: enteredAtMs, sortKey: toSortKey(enteredAtMs),
       });
     }
   }
 
-  for (const [storyId, { title, count }] of blockedByStory) {
+  for (const [storyId, { title, count, enteredAtMs }] of blockedByStory) {
     items.push({
       id: `blocked-${storyId}`, kind: 'blocked', kindLabel: t('kindBlocked'),
       proofState: PROOF_STATE.blocked, claim: t('claimBlocked', { title, count }),
       actor: null, actionLabel: t('actionCoordinate'), actionTone: 'neutral',
-      href: `/board?story=${storyId}`, sortKey: 0,
+      href: `/board?story=${storyId}`, enteredStateAtMs: enteredAtMs, sortKey: toSortKey(enteredAtMs),
     });
   }
-  for (const [storyId, title] of decisionNeededByStory) {
+  for (const [storyId, { title, enteredAtMs }] of decisionNeededByStory) {
     items.push({
       id: `decision_needed-${storyId}`, kind: 'decision_needed', kindLabel: t('kindDecisionNeeded'),
       proofState: PROOF_STATE.decision_needed, claim: t('claimDecisionNeeded', { title }),
       actor: null, actionLabel: t('actionDecide'), actionTone: 'primary',
-      href: `/board?story=${storyId}`, sortKey: 0,
+      href: `/board?story=${storyId}`, enteredStateAtMs: enteredAtMs, sortKey: toSortKey(enteredAtMs),
     });
   }
   return items;

--- a/apps/web/src/components/glance/derive-exception-signals.ts
+++ b/apps/web/src/components/glance/derive-exception-signals.ts
@@ -119,6 +119,9 @@ export function toExceptionQueueItems(
     actionLabel: labels.action[sig.kind],
     actionTone: TONE_BY_KIND[sig.kind],
     href: hrefFor(sig),
+    // story #2249: 이 엔드포인트(BeAttentionSignal)는 entered_state_at 자체를 안 실어(exception-stream
+    // 설계 자체가 "활동량/타임스탬프 0") null이 정확한 값 — 위조 금지.
+    enteredStateAtMs: null,
     sortKey: 0,
   }));
   return buildAttentionQueue(items, items.length).shown;

--- a/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
@@ -130,6 +130,21 @@ describe('ProofCapsule (안티패턴 자체 체크 — 도크트린 준수 회�
     expect(markup).toContain('border-proof-green');
     expect(markup).not.toContain('위험도');
   });
+
+  it('story #2249 — row density renders a pre-formatted duration badge when given one', () => {
+    const markup = renderWithIntl(
+      <ProofCapsule {...BASE} density="row" gate={{ action: '조율' }} duration="3일 전" />,
+    );
+    expect(markup).toContain('3일 전');
+  });
+
+  it('story #2249 — row density renders no duration badge when duration is omitted(모름, 지어내지 않음)', () => {
+    const markup = renderWithIntl(
+      <ProofCapsule {...BASE} density="row" gate={{ action: '조율' }} />,
+    );
+    expect(markup).not.toContain('일 전');
+    expect(markup).not.toContain('시간 전');
+  });
 });
 
 describe('ProofCapsule (human optional — Board card 확산, bf9037cb) — 다중 담당자 등 human 필드로 표현 안 되는 실 기능을 위한 완화', () => {

--- a/apps/web/src/components/proof-capsule/proof-capsule.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.tsx
@@ -46,6 +46,10 @@ export interface ProofCapsuleProps {
   proofState: ProofState;
   stateLabel: string;
   claim: string;
+  /** row 밀도 전용(story #2249, Attention Queue) — 「그 상태에 들어간 지 얼마나 됐는지」를 호출부가
+   * 미리 포맷해 넘긴다(예: "3일 전"). 모르면 아예 넘기지 않는다(빈 문자열/"모름" 라벨로 지어내지
+   * 않음 — glance.py의 entered_state_at이 null인 신호는 값 자체가 없다). */
+  duration?: string;
   /** full/audit만 사용 — card/row는 다중 담당자(예: Board card의 assignee 스택)를 자체
    * 렌더하는 경우가 많아 요구하지 않는다(optional, 2026-07-11 Board 확산 시 완화). */
   human?: ProofCapsuleHuman;
@@ -75,7 +79,7 @@ export interface ProofCapsuleProps {
  * glow·999px pill·숫자 KPI화·raw CoT·초록만-완료 전부 미사용(색은 항상 stateLabel 텍스트 병기).
  */
 export function ProofCapsule({
-  proofState, stateLabel, claim, human, agent, now, evidence, gate, trustSeal, density, footer, className,
+  proofState, stateLabel, claim, human, agent, now, evidence, gate, trustSeal, density, footer, className, duration,
 }: ProofCapsuleProps) {
   if (density === 'audit') {
     return (
@@ -86,7 +90,7 @@ export function ProofCapsule({
     return (
       <InlineRow
         proofState={proofState} stateLabel={stateLabel} claim={claim} human={human} agent={agent}
-        gate={gate} className={className}
+        gate={gate} duration={duration} className={className}
       />
     );
   }
@@ -314,14 +318,15 @@ const GATE_BUTTON_TONE: Record<NonNullable<ProofCapsuleGate['tone']>, string> = 
 };
 
 function InlineRow({
-  proofState, stateLabel, claim, human, agent, gate, className,
-}: Pick<ProofCapsuleProps, 'proofState' | 'stateLabel' | 'claim' | 'human' | 'agent' | 'gate' | 'className'>) {
+  proofState, stateLabel, claim, human, agent, gate, duration, className,
+}: Pick<ProofCapsuleProps, 'proofState' | 'stateLabel' | 'claim' | 'human' | 'agent' | 'gate' | 'duration' | 'className'>) {
   return (
     <CutCornerShell state={proofState} cut={16} className={cn('w-full', className)}>
       <div className="flex min-h-[52px] min-w-0 flex-1 items-center gap-2.5 px-3 py-2">
         <span className="w-24 shrink-0"><StateHeader state={proofState} label={stateLabel} /></span>
         <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-proof-ink">{claim}</span>
         <span className="inline-flex shrink-0 items-center gap-2">
+          {duration ? <span className="shrink-0 text-[10.5px] font-medium text-proof-ink-3">{duration}</span> : null}
           {human ? <ProofAvatar label={initials(human.name)} size={22} /> : null}
           {agent ? <ProofAvatar label={agent.initial} isAgent size={22} /> : null}
           {gate ? (


### PR DESCRIPTION
## 요약
- BE(#2249 BE 작업)가 5신호 전부(gate_pending/blocked/merge_ready/needs_input/verify_fail)에 `entered_state_at`+`entered_state_at_precision`을 실어 보내고 있었지만, 이를 읽는 FE 코드가 grep 0건이었다 — "만들어졌는데 도는 자리가 없는" 상태(AC3).
- Attention Queue(`/inbox?tab=attention`)에 이 필드를 배선해 "검증 대기가 10분째인지 사흘째인지"를 화면에서 구분할 수 있게 했다.

## 설계 결정 (PO 재확인 완료)
1. **어디에 세울 것인가** → Attention Queue만. `glance/exception-stream.tsx`는 "활동량/타임스탬프 0"이 설계 원칙이라 제외, 보드 카드는 5신호 1:1 매핑이 아니라 스코프 밖.
2. **precision을 어떻게 쓸 것인가** → BE 계약상 `entered_state_at_precision`은 `"exact"|null` 두 상태뿐이고 항상 값과 짝(근사는 존재하지 않음 — glance.py 모듈 docstring). 따라서 `entered_state_at`의 null 여부만으로 충분해 precision 필드는 별도로 파싱하지 않는다.

## 변경 사항
- `derive-attention-queue.ts`: `BeAttentionItem`/`AttentionQueueItem`에 `entered_state_at`/`enteredStateAtMs` 추가, 파싱 로직 신설
- `sortKey`를 "경과시간(ms)"으로 재정의 — 이전엔 BE 미가용으로 항상 0(무의미)이었으나, 이제 동급 티어 내 "오래 머문 것 먼저"(체류시간이 위계를 만든다) 정렬이 실제로 동작
- `blocked`(다중 차단엣지 집계)는 min(가장 이른 시각), `decision_needed`(gate_pending+needs_input 합류)는 먼저 등장한 신호의 시각을 사용
- `ProofCapsule`에 row 밀도 전용 `duration` prop 신설 — 값 없으면(모름) 아예 렌더 안 함(지어내지 않음)
- `glance/derive-exception-signals.ts`는 공유 타입만 맞춰 `enteredStateAtMs: null` 고정(그 위젯은 원래 타임스탬프를 안 보여주는 설계라 회귀 없음)

## 검증
- [x] `pnpm build` 성공(EXIT 0)
- [x] `pnpm lint` 경고 0개(대상 파일 전수)
- [x] `tsc --noEmit` 클린
- [x] vitest 64/64 통과(attention-queue·proof-capsule·derive-exception-signals)
- [x] 뮤테이션 검증 — `toEpochMs`를 강제로 `null` 반환하게 바꿔 신규 테스트 3건이 RED로 떨어지는 것 확認 후 원복해 GREEN 재확認