### PR TITLE
feat(#2314): add GET /api/v2/evidence/{id}, wire MCP mentions + embed-chip parent nav

### DIFF
--- a/apps/web/src/app/api/evidence/[id]/route.ts
+++ b/apps/web/src/app/api/evidence/[id]/route.ts
@@ -1,0 +1,21 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/** story #2314 — GET /api/v2/evidence/{id} 신설분 프록시. 형제(GET /api/evidence 리스트)와
+ * 동일하게 apiSuccess로 감싼다 — raw passthrough가 필요한 곳(POST evidence)은 소비부가
+ * 단건 객체를 그대로 기대해서였지, 이 라우트의 소비부(embed-card.tsx EntityPreviewModal)는
+ * `json.data ?? json`로 이미 양쪽 shape를 다 받게 짜여 있어 감싸도 안전하다. */
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    const _r = await proxyToFastapi(request, `/api/v2/evidence/${id}`);
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/components/chat/embed-card.link-states.test.tsx
+++ b/apps/web/src/components/chat/embed-card.link-states.test.tsx
@@ -118,7 +118,7 @@ describe('AC3/AC4 — artifact는 레코드마다 갈린다(FK 있으면 ②, �
   });
 });
 
-describe('AC4 — hypothesis·evidence는 고정 ③(fetch 자체를 안 함, 무한 스피너 자체발견 회귀가드)', () => {
+describe('AC4 — hypothesis는 고정 ③(fetch 자체를 안 함, 무한 스피너 자체발견 회귀가드)', () => {
   it('hypothesis는 fetch를 시도하지 않고 즉시 "열 수 있는 화면이 없습니다"를 보인다(무한 스피너 아님)', async () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
@@ -131,17 +131,32 @@ describe('AC4 — hypothesis·evidence는 고정 ③(fetch 자체를 안 함, �
     expect(document.body.textContent).not.toContain('불러오는 중');
     expect(document.body.textContent).toContain('열 수 있는 화면이 없습니다');
   });
+});
 
-  it('evidence도 동일 — #2314(GET /api/v2/evidence/{id}) 개통 전까지 임시 ③', async () => {
-    const fetchSpy = vi.fn();
-    vi.stubGlobal('fetch', fetchSpy);
+describe('AC3/AC4 — evidence는 부모 story로("담긴 곳으로 갑니다", story #2314 승격)', () => {
+  it('story #2314(2026-07-29): GET /api/v2/evidence/{id} 개통 前엔 임시 ③이었으나, 이제 fetch해서 ②로 판정한다 — resolved_story_id를 BE가 이미 한 번에 해소해 준다(task처럼 2단 조인 불필요)', async () => {
+    stubFetch(async (url) => {
+      expect(url).toContain('/api/evidence/');
+      return { ok: true, json: async () => ({ data: { resolved_story_id: 's-parent-2' } }) };
+    });
     await act(async () => {
       root.render(<EmbedCard entity_type="evidence" entity_id="ev1" title="증거 A" status={null} />);
     });
     await openCard();
     await flush();
-    expect(fetchSpy).not.toHaveBeenCalled();
-    expect(document.body.textContent).not.toContain('불러오는 중');
+    const link = document.querySelector('a[href="/board?story=s-parent-2"]');
+    expect(link).not.toBeNull();
+    expect(link!.textContent).toContain('담긴 곳으로 갑니다');
+  });
+
+  it('resolved_story_id가 없으면(예: 부모 task가 사라짐) 회색·행동0 "열 수 있는 화면이 없습니다"(거짓 링크 금지)', async () => {
+    stubFetch(async () => ({ ok: true, json: async () => ({ data: { resolved_story_id: null } }) }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="evidence" entity_id="ev2" title="증거 B" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(document.querySelectorAll('a[href^="/board?story="]').length).toBe(0);
     expect(document.body.textContent).toContain('열 수 있는 화면이 없습니다');
   });
 });

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -66,14 +66,15 @@ const ENTITY_COLORS: Record<string, string> = {
 // 있는 상태가 아니다(담긴 곳으로 보내거나, 애초에 갈 곳이 없는 것). 구별은 색이 아니라 말로.
 export const GRAY_STATE_COLOR = 'border-border bg-muted/40 text-muted-foreground';
 
-/** story #2302 — task·evidence는 항상 담긴 곳(②) 또는 미승격(③) 판정에 own-href가 없다(모델
- * FK 그대로: Task.story_id/Evidence.work_item_id 항상 NOT NULL — 항상 유일한 부모, 모호함 0).
+/** story #2302 — task·evidence는 항상 담긴 곳(②) 판정에 own-href가 없다(모델 FK 그대로:
+ * Task.story_id/Evidence.work_item_id 항상 NOT NULL — 항상 유일한 부모, 모호함 0).
  * hypothesis는 링크테이블 3종(epic/story/sprint 다대다)이라 "담긴 곳 하나"를 정할 수 없어 항상
  * ③(만료조건: hypothesis 전용 화면이 생기면 ①로 승격). artifact는 story_id/epic_id/doc_id가
  * 전부 nullable·최대 1개뿐이라(hypothesis처럼 여럿 동시가능이 아님) 레코드마다 갈린다 —
  * EntityPreviewModal이 fetch한 detail로 판정(이 함수는 own-href만 다뤄 null 반환).
- * evidence는 #2314(GET /api/v2/evidence/{id} 개통) 전까지 임시 ③ — 그 라우트가 열리면 이 값을
- * task와 동형으로 승격한다(PO 확認, 2026-07-29).
+ * evidence는 story #2314(2026-07-29, GET /api/v2/evidence/{id} 개통)로 task와 동형인 ②로
+ * 승격됐다 — work_item_type이 story든 task든 응답의 resolved_story_id(BE가 이미 한 번에
+ * 해소해 준다) 하나로 EntityPreviewModal이 판정한다.
  */
 export function getEntityHref(entityType: string, entityId: string): string | null {
   switch (entityType) {
@@ -87,7 +88,7 @@ export function getEntityHref(entityType: string, entityId: string): string | nu
     case 'task': return null; // ② — 부모 story_id는 EntityPreviewModal이 fetch 후 판정.
     case 'artifact': return null; // 레코드마다 ②/③ — 위 함수 doc 참고.
     case 'hypothesis': return null; // ③ 고정 — 위 함수 doc 참고.
-    case 'evidence': return null; // ③ 임시(#2314 대기) — 위 함수 doc 참고.
+    case 'evidence': return null; // ② — resolved_story_id는 EntityPreviewModal이 fetch 후 판정(task와 동형).
     default: return null;
   }
 }
@@ -111,10 +112,13 @@ const ENTITY_API: Record<string, (id: string) => string> = {
   epic: (id) => `/api/goals/${id}`,
   asset: (id) => `/api/assets/${id}`,
   // story #2302 — task.story_id(항상 유일 부모)·artifact.{story_id,epic_id,doc_id}(최대 1개,
-  // 전부 nullable)를 읽어 ②/③을 레코드 단위로 판정하는 재료. hypothesis·evidence는 의도적으로
-  // 여기 없다(위 getEntityHref 주석 참고 — 애초에 fetch할 필요가 없는 고정 ③).
+  // 전부 nullable)를 읽어 ②/③을 레코드 단위로 판정하는 재료. hypothesis는 의도적으로 여기
+  // 없다(위 getEntityHref 주석 참고 — 애초에 fetch할 필요가 없는 고정 ③).
   task: (id) => `/api/tasks/${id}`,
   artifact: (id) => `/api/visual-artifacts/${id}`,
+  // story #2314(2026-07-29): GET /api/v2/evidence/{id}가 신설돼 evidence도 fetch-eligible로
+  // 승격 — 응답의 resolved_story_id를 EntityPreviewModal이 읽는다(아래 evidence 분기).
+  evidence: (id) => `/api/evidence/${id}`,
 };
 
 const MdBadge = ({ label }: { label: string }) => (
@@ -271,7 +275,7 @@ function EntityPreviewModal({
     }
 
     const url = ENTITY_API[entityType]?.(entityId);
-    if (!url) return; // hypothesis·evidence 등 — fetch 전략 자체가 없다(loading도 이미 false로 시작).
+    if (!url) return; // hypothesis 등 — fetch 전략 자체가 없다(loading도 이미 false로 시작).
     fetch(url)
       .then((r) => r.ok ? r.json() : Promise.reject())
       .then((json) => { if (!cancelled) setDetail((json as { data?: Record<string, unknown> }).data ?? json as Record<string, unknown>); })
@@ -318,8 +322,14 @@ function EntityPreviewModal({
       : null;
     resolvedHref = parentHref;
     linkKind = parentHref ? 'via-parent' : null;
-  } else if (entityType === 'hypothesis' || entityType === 'evidence') {
-    // ③ 고정(hypothesis) / ③ 임시(evidence, #2314 대기) — 위 getEntityHref 주석 참고.
+  } else if (entityType === 'evidence') {
+    // ② — story #2314(2026-07-29): BE GET /{id}가 work_item_type이 story든 task든 이미
+    // resolved_story_id 하나로 해소해 준다(task처럼 여기서 또 한 번 join할 필요가 없다).
+    const storyId = (detail as { resolved_story_id?: string | null } | null)?.resolved_story_id ?? null;
+    resolvedHref = storyId ? `/board?story=${storyId}` : null;
+    linkKind = resolvedHref ? 'via-parent' : null;
+  } else if (entityType === 'hypothesis') {
+    // ③ 고정 — 위 getEntityHref 주석 참고.
     resolvedHref = null;
     linkKind = null;
   } else {

--- a/backend/app/routers/evidence.py
+++ b/backend/app/routers/evidence.py
@@ -3,7 +3,7 @@ import uuid
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, computed_field, field_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -13,6 +13,7 @@ from app.models.evidence import _CLIENT_CREATABLE_TYPES, Evidence
 from app.models.pm import Story, Task
 from app.services.member_resolver import resolve_member
 from app.services.project_auth import has_project_access
+from app.services.reference_registry import _project_id_of_evidence
 
 router = APIRouter(prefix="/api/v2/evidence", tags=["evidence", "Trust"])
 
@@ -58,8 +59,21 @@ class EvidenceResponse(BaseModel):
     note: str | None
     created_by: uuid.UUID
     created_at: Any
+    resolved_story_id: uuid.UUID | None = None
+    """story #2314 AC3② — embed 칩이 evidence의 «담긴 곳»으로 한 번에 건너뛸 자리.
+    work_item_type='story'면 work_item_id 그 자체, 'task'면 그 task의 부모 story_id(2단
+    조인) — FE가 evidence→task→story로 왕복 fetch하지 않도록 GET /{id} 응답에 얹는다."""
 
     model_config = {"from_attributes": True}
+
+    # story #2314 AC5 — MCP mention 경로(_resolve_mention_content)가 title-미지정 mention을
+    # 이 GET 응답의 reference_token으로 조립한다(DocResponse/StoryResponse와 동일 SSOT
+    # builder). evidence엔 title이 없어 ref를 대신 쓴다 — "[pr] https://..." 형태.
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def reference_token(self) -> str | None:
+        from app.services.reference_token import build_reference_token
+        return build_reference_token("evidence", self.id, f"[{self.type}] {self.ref}")
 
 
 async def _assert_work_item_access(
@@ -141,6 +155,41 @@ async def list_evidence(
         ).order_by(Evidence.created_at.asc())
     )
     return list(result.scalars().all())
+
+
+@router.get("/{id}", response_model=EvidenceResponse)
+async def get_evidence(
+    id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> EvidenceResponse:
+    """story #2314 AC1 — 형제 단건 라우트(get_story 등)와 같은 관례. AC2: 못 보는 evidence는
+    「있다는 사실」도 새지 않는다 — org 안·project 밖도 404로 통일한다(#2322가 story 헬퍼에서
+    막 세운 그 방향과 동형 — evidence.py는 #2322의 4개 헬퍼 목록엔 없지만, 신규 라우트는
+    처음부터 그 방향을 따른다. 존재하지만 못 봄=404, 진짜 없음=404, 구분해 흘리지 않는다)."""
+    evidence = (await session.execute(
+        select(Evidence).where(Evidence.id == id, Evidence.org_id == org_id)
+    )).scalar_one_or_none()
+    if evidence is None:
+        raise HTTPException(status_code=404, detail="Evidence not found")
+
+    caller = await resolve_member(auth, org_id, session)
+    project_id = await _project_id_of_evidence(session, org_id, id)
+    if project_id is None or not await has_project_access(session, caller.id, project_id, org_id):
+        raise HTTPException(status_code=404, detail="Evidence not found")
+
+    resolved_story_id: uuid.UUID | None = None
+    if evidence.work_item_type == "story":
+        resolved_story_id = evidence.work_item_id
+    elif evidence.work_item_type == "task":
+        resolved_story_id = (await session.execute(
+            select(Task.story_id).where(Task.id == evidence.work_item_id, Task.org_id == org_id)
+        )).scalar_one_or_none()
+
+    return EvidenceResponse.model_validate(evidence, from_attributes=True).model_copy(
+        update={"resolved_story_id": resolved_story_id}
+    )
 
 
 @router.delete("/{id}", status_code=204)

--- a/backend/sprintable_mcp/tools/chat.py
+++ b/backend/sprintable_mcp/tools/chat.py
@@ -52,10 +52,10 @@ def escape_mention_title(title: str) -> str:
 # HEAD에서 RED였다 — 서로 다른 두 PR이 각각은 옳은 변경이었는데 합쳐지며 이 축이 깨진
 # "merge-order로만 드러나는" 드리프트였다(#2585는 #2294보다 먼저 작성돼 task를 몰랐다).
 # ⛔B단계(2026-07-29): sprint·artifact·hypothesis도 같이 연다(GET /{id} 단건조회 엔드포인트가
-# 실재해 title 미지정 mention의 auto-fetch가 가능함을 확認). `evidence`는 **의도적으로 뺀다**
-# — GET /api/v2/evidence/{id}(단건조회) 라우트 자체가 없다(list만 work_item_id로 필터링해서
-# 있음). 이 비대칭은 test_mcp_s1995의 `_MENTION_ENDPOINT_KNOWN_GAP`이 명시 선언한다(조용히
-# 빠진 것과 일부러 뺀 것은 처방이 다르다).
+# 실재해 title 미지정 mention의 auto-fetch가 가능함을 확認).
+# ⛔C단계(story #2314, 2026-07-29): `evidence`도 연다 — GET /api/v2/evidence/{id}가 신설돼
+# 그동안 「의도적 제외」였던 근거(단건조회 라우트 자체가 없음)가 사라졌다. evidence엔 title이
+# 없어 reference_token은 ref를 대신 쓴다(evidence.py EvidenceResponse.reference_token 참조).
 _MENTION_ENTITY_ENDPOINTS: dict[str, str] = {
     "doc": "/api/v2/docs/{id}",
     "story": "/api/v2/stories/{id}",
@@ -64,29 +64,30 @@ _MENTION_ENTITY_ENDPOINTS: dict[str, str] = {
     "sprint": "/api/v2/sprints/{id}",
     "artifact": "/api/v2/visual-artifacts/{id}",
     "hypothesis": "/api/v2/hypotheses/{id}",
+    "evidence": "/api/v2/evidence/{id}",
 }
 
 
 class MentionRef(SprintableInput):
     """agent 발신 채팅 메시지에 첨부할 entity mention — story 1995(doc 링크 안 됨 근본수정) +
     story #2283/#2294 후속(2026-07-28~29, doc→doc/story/epic/task/sprint/artifact/
-    hypothesis 확장 — evidence는 GET /{id} 단건조회가 없어 의도적으로 제외, 아래
-    `_MENTION_ENTITY_ENDPOINTS` 주석 참조).
+    hypothesis 확장) + story #2314(2026-07-29, evidence 확장 — GET /{id} 단건조회 신설로
+    「의도적 제외」 근거가 사라져 걷었다).
 
     type은 스키마 레벨에서 이 목록만 허용(Literal). MCP 서버는 백엔드 `app.*`를 import 하지
     않고 HTTP로만 통신하는 별도 프로세스라(api_client.py 참조) 이 목록을 백엔드
     `reference_registry.ENTITY_RESOLVERS`에서 런타임에 **파생시킬 수 없다** — 두 프로세스가
     같은 값을 손으로 맞춰 유지하는 수밖에 없는 자리다. 대신
     `test_mention_entity_endpoints_match_backend_entity_resolvers`가 **테스트로** 그 동일성을
-    (알려진 gap인 evidence를 뺀 나머지에 대해) 고정한다 — 백엔드 registry가 더 늘면 이 테스트가
-    빨개져서 여기(이 Literal + `_MENTION_ENTITY_ENDPOINTS`)도 늘리도록 강제한다.
+    고정한다 — 백엔드 registry가 더 늘면 이 테스트가 빨개져서 여기(이 Literal +
+    `_MENTION_ENTITY_ENDPOINTS`)도 늘리도록 강제한다.
 
     ⛔가드가 걸렸을 때 나올 수 있는 세 가지 반응 — 목록을 넓힌다 / 테스트를 고친다(또는
-    느슨하게 한다) / 무시한다 — 중 첫 번째만 옳다. GET /{id}가 아예 없는 타입(evidence류)만
-    예외로, 이유와 함께 명시 등재한다(조용히 빼지 않는다).
+    느슨하게 한다) / 무시한다 — 중 첫 번째만 옳다. GET /{id}가 아예 없는 타입만 예외로, 이유와
+    함께 명시 등재한다(조용히 빼지 않는다) — 지금은 그런 타입이 없다.
     """
 
-    type: Literal["doc", "story", "epic", "task", "sprint", "artifact", "hypothesis"]
+    type: Literal["doc", "story", "epic", "task", "sprint", "artifact", "hypothesis", "evidence"]
     id: str
     title: str | None = None
 

--- a/backend/tests/test_2314_evidence_get_by_id_realdb.py
+++ b/backend/tests/test_2314_evidence_get_by_id_realdb.py
@@ -1,0 +1,303 @@
+"""story #2314 — `GET /api/v2/evidence/{id}` 신설(형제 라우트 없던 갭). RED-먼저: 이 파일은
+라우트가 아직 없는 시점에 작성됐다 — `git stash`로 evidence.py 변경을 되돌리면 아래 전부
+404(라우트 자체 없음, FastAPI 기본)로 실패하는 것을 먼저 확認한 뒤에만 라우트를 구현한다
+(같은 세션 커밋 메시지에 그 순서를 남긴다).
+
+⭐AC2(존재 비노출): org 안·project 밖도 404로 통일한다 — #2322가 story 헬퍼(PR #2624)에서
+막 세운 방향과 동형. evidence.py는 #2322의 4개 헬퍼 목록엔 없지만, 신규 라우트는 처음부터
+그 방향을 따른다(403으로 새로 짓지 않는다)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project[grant된 agent]·other_project[무관agent]) + story(evidence 부착) +
+    task(story 하위, evidence 부착) + 다른 org(교차조직 케이스)."""
+    from app.models.evidence import Evidence
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.pm import Story, Task
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    other_org = Organization(id=uuid.uuid4(), name="OtherOrg", slug=f"other-org-{uuid.uuid4().hex[:8]}")
+    session.add_all([org, other_org])
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    other_project = Project(id=uuid.uuid4(), org_id=org.id, name="Other Project")
+    session.add_all([project, other_project])
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent", is_active=True)
+    stranger = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Stranger", is_active=True)
+    cross_org_agent = Member(id=uuid.uuid4(), org_id=other_org.id, type="agent", name="CrossOrgAgent", is_active=True)
+    session.add_all([agent, stranger, cross_org_agent])
+    await session.commit()
+
+    session.add_all([
+        ProjectAccess(id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted", role="member"),
+        ProjectAccess(id=uuid.uuid4(), project_id=other_project.id, member_id=stranger.id, permission="granted", role="member"),
+    ])
+    await session.commit()
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Story", status="in-progress")
+    session.add(story)
+    await session.commit()
+
+    task = Task(id=uuid.uuid4(), org_id=org.id, story_id=story.id, title="Task", status="in-progress")
+    session.add(task)
+    await session.commit()
+
+    story_evidence = Evidence(
+        id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+        type="url", ref="https://example.com/story-evidence", created_by=agent.id,
+    )
+    task_evidence = Evidence(
+        id=uuid.uuid4(), org_id=org.id, work_item_id=task.id, work_item_type="task",
+        type="pr", ref="https://example.com/task-evidence", created_by=agent.id,
+    )
+    session.add_all([story_evidence, task_evidence])
+    await session.commit()
+
+    return {
+        "org_id": org.id, "other_org_id": other_org.id,
+        "agent_id": agent.id, "stranger_id": stranger.id, "cross_org_agent_id": cross_org_agent.id,
+        "story_id": story.id, "task_id": task.id,
+        "story_evidence_id": story_evidence.id, "task_evidence_id": task_evidence.id,
+    }
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, member_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            yield s
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(member_id), email="agent@test",
+            claims={"app_metadata": {"org_id": str(org_id), "api_key_id": "test-key"}},
+        )
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_get_story_evidence_200_with_resolved_story_id():
+    """양성대조 — story-type evidence: resolved_story_id == work_item_id 그 자체."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/evidence/{seeded['story_evidence_id']}")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["work_item_type"] == "story"
+            assert body["ref"] == "https://example.com/story-evidence"
+            assert body["resolved_story_id"] == str(seeded["story_id"])
+            # AC5(MCP mention wiring) 전제조건 — reference_token이 실제로 실린다(제목이 없어
+            # ref를 대신 쓴다). _resolve_mention_content(chat.py)가 이 필드를 그대로 읽는다.
+            # 기대값은 실제 builder(build_reference_token)로 계산 — escape 규칙을 이 테스트에서
+            # 재구현하지 않는다(쌍둥이-체계 함정 회피, 이 세션 내내 반복 걸린 그 패턴).
+            from app.services.reference_token import build_reference_token
+            expected_token = build_reference_token(
+                "evidence", seeded["story_evidence_id"], "[url] https://example.com/story-evidence",
+            )
+            assert body["reference_token"] == expected_token
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_task_evidence_200_resolves_story_id_via_task():
+    """양성대조 — task-type evidence: resolved_story_id는 task의 부모 story(2단 조인)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/evidence/{seeded['task_evidence_id']}")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["work_item_type"] == "task"
+            assert body["work_item_id"] == str(seeded["task_id"])
+            assert body["resolved_story_id"] == str(seeded["story_id"])
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_evidence_nonexistent_id_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/evidence/{uuid.uuid4()}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_evidence_same_org_no_project_access_404_not_403():
+    """AC2 핵심 — 같은 org·다른 project(무권한)는 404(403 아님, 존재 비노출 통일)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["stranger_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/evidence/{seeded['story_evidence_id']}")
+            assert resp.status_code == 404, (
+                f"story #2314 AC2: 같은org·다른project 무권한은 404여야 한다 — {resp.status_code}: {resp.text}"
+            )
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_evidence_cross_org_404():
+    """다른 org의 caller — org 필터가 최초 조회에서부터 걸러 404(누출 0)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["cross_org_agent_id"], seeded["other_org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/evidence/{seeded['story_evidence_id']}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_evidence_mutation_self_check_gate_actually_blocks():
+    """뮤테이션 자가검증 — has_project_access를 항상-참으로 사보타주하면 stranger가 story
+    evidence를 볼 수 있게 되는 것으로(누출 재현), 이 가드가 동어반복이 아님을 증명한다."""
+    from app.main import app
+    from app.services import project_auth as project_auth_module
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["stranger_id"], seeded["org_id"])
+        client = _client_for(app)
+
+        original_gate = project_auth_module.has_project_access
+
+        async def _always_true(*args, **kwargs):
+            return True
+
+        import app.routers.evidence as evidence_module
+        evidence_module.has_project_access = _always_true
+        try:
+            resp = await client.get(f"/api/v2/evidence/{seeded['story_evidence_id']}")
+            assert resp.status_code == 200, (
+                f"사보타주 중엔 누출이 재현돼야 한다(가드가 실제로 막고 있었다는 증거) — {resp.status_code}"
+            )
+        finally:
+            evidence_module.has_project_access = original_gate
+            await client.aclose()
+
+        # 원복 후 GREEN 재확認 — 같은 caller가 다시 404.
+        client2 = _client_for(app)
+        try:
+            resp2 = await client2.get(f"/api/v2/evidence/{seeded['story_evidence_id']}")
+            assert resp2.status_code == 404, resp2.text
+        finally:
+            await client2.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_mcp_s1995_agent_doc_mentions.py
+++ b/backend/tests/test_mcp_s1995_agent_doc_mentions.py
@@ -84,14 +84,6 @@ def test_send_chat_input_rejects_invalid_mention_type():
         SendChatInput(thread_id="conv-1", content="hi", mentions=[{"type": "goal", "id": "t-1"}])
 
 
-def test_mention_ref_rejects_evidence_type_intentional_gap():
-    """`evidence`는 백엔드 ENTITY_RESOLVERS엔 있지만(#2294 B단계) MCP mentions Literal엔
-    없다 — GET /api/v2/evidence/{id} 단건조회 라우트가 없어서다(의도적 gap,
-    `_MENTION_ENDPOINT_KNOWN_GAP` 참조). 그 gap이 스키마 레벨에서 실제로 거부로 이어지는지."""
-    with pytest.raises(ValidationError):
-        MentionRef(type="evidence", id="ev-1")
-
-
 def test_mention_ref_accepts_doc_type():
     m = MentionRef(type="doc", id="d-1", title="My Doc")
     assert m.type == "doc"
@@ -127,26 +119,25 @@ def test_mention_ref_accepts_hypothesis_type():
     assert m.type == "hypothesis"
 
 
-# story #2294 B단계(2026-07-29): evidence는 백엔드 registry에 있지만 GET /{id} 단건조회
-# 라우트가 없어(list만 있음) MCP mentions에서 의도적으로 뺀다 — 조용히 빠진 것과 일부러
-# 뺀 것은 처방이 다르므로 이유를 명시 등재한다(infra/mcp-path-contract-allowlist.yml의
-# "알고 있다"는 선언 관례와 동형).
-_MENTION_ENDPOINT_KNOWN_GAP: frozenset[str] = frozenset({"evidence"})
+def test_mention_ref_accepts_evidence_type():
+    """story #2314(2026-07-29): GET /api/v2/evidence/{id} 단건조회가 신설돼 evidence도
+    다른 6종과 동형으로 열렸다 — 예전엔 `_MENTION_ENDPOINT_KNOWN_GAP`으로 의도적 제외였으나
+    그 근거(단건조회 라우트 부재)가 사라져 이 gap을 걷는다."""
+    m = MentionRef(type="evidence", id="ev-1", title="My Evidence")
+    assert m.type == "evidence"
 
 
 def test_mention_entity_endpoints_match_backend_entity_resolvers():
     """`_MENTION_ENTITY_ENDPOINTS`(MCP 쪽 type→GET endpoint 매핑)가 백엔드
     `reference_registry.ENTITY_RESOLVERS`(존재판정 registry, #2259/#2266/#2283이 계속 SSOT로
-    써 온 것)와 같은 타입 집합인지 고정(알려진 gap `_MENTION_ENDPOINT_KNOWN_GAP` 제외) —
-    한쪽만 늘면(예: 백엔드에 새 target_type 등록, MCP mentions는 안 넓힘) agent 경로만
-    뒤처지는 형제 비대칭이 조용히 생긴다. ⛔story #2294에서 이 테스트가 실제로 RED였다
-    (task가 백엔드에만 열리고 여기 안 넓혀진 채 develop에 머지됨 — merge-order 드리프트)."""
+    써 온 것)와 같은 타입 집합인지 고정 — 한쪽만 늘면(예: 백엔드에 새 target_type 등록, MCP
+    mentions는 안 넓힘) agent 경로만 뒤처지는 형제 비대칭이 조용히 생긴다. ⛔story #2294에서
+    이 테스트가 실제로 RED였다(task가 백엔드에만 열리고 여기 안 넓혀진 채 develop에 머지됨
+    — merge-order 드리프트). story #2314(2026-07-29): evidence도 완전히 합류해 이제 gap
+    없이 순수 등식이다(예전엔 `_MENTION_ENDPOINT_KNOWN_GAP`으로 evidence 하나를 뺐었다)."""
     from app.services.reference_registry import ENTITY_RESOLVERS
 
-    assert set(chat_mod._MENTION_ENTITY_ENDPOINTS) == set(ENTITY_RESOLVERS) - _MENTION_ENDPOINT_KNOWN_GAP
-    # gap 자체가 정말 gap인지도 고정 — evidence가 실수로 뚫려도(둘 다에 존재) 이 assert가 잡는다.
-    assert _MENTION_ENDPOINT_KNOWN_GAP <= set(ENTITY_RESOLVERS)
-    assert _MENTION_ENDPOINT_KNOWN_GAP.isdisjoint(chat_mod._MENTION_ENTITY_ENDPOINTS)
+    assert set(chat_mod._MENTION_ENTITY_ENDPOINTS) == set(ENTITY_RESOLVERS)
 
 
 def test_mention_ref_literal_matches_mention_entity_endpoints_directly():
@@ -168,24 +159,22 @@ def test_mention_ref_literal_matches_mention_entity_endpoints_directly():
 def test_mention_ref_literal_matches_backend_entity_resolvers_directly():
     """⭐PO 재지적(2026-07-29, 같은 메시지 후속): 바로 위 테스트(Literal↔dict)와
     `test_mention_entity_endpoints_match_backend_entity_resolvers`(dict↔registry)가
-    각각 통과해도 그건 dict를 매개로 한 «간접» 등식일 뿐 — Literal을 registry(8종)와
-    직접 비교하는 자리는 없었다. 두 테스트가 «우연히 같은 7종 집합」을 두 번 잰 것일
+    각각 통과해도 그건 dict를 매개로 한 «간접» 등식일 뿐 — Literal을 registry와
+    직접 비교하는 자리는 없었다. 두 테스트가 «우연히 같은 집합」을 두 번 잰 것일
     가능성을 배제 못 한다(예: 나중에 dict↔registry 테스트가 리팩터로 사라지면 이
-    등식이 조용히 깨질 수 있는 자리). registry를 매개 없이 직접 걸어 evidence 단
-    하나만 빠진 것인지 고정한다 — PO 표현 그대로 "evidence가 MCP 쪽에 «둘 다» 없는"
-    상태를 이 테스트 하나로 직접 증명."""
+    등식이 조용히 깨질 수 있는 자리). registry를 매개 없이 직접 걸어 고정한다.
+
+    story #2314(2026-07-29): evidence도 이제 Literal·registry 양쪽에 다 있다 — 예전엔
+    "evidence가 MCP 쪽에 «둘 다» 없는" 상태를 증명하던 자리였으나, GET /{id} 신설로
+    그 gap이 닫혀 이제는 순수 완전-일치 증명이다."""
     import typing
 
     from app.services.reference_registry import ENTITY_RESOLVERS
 
     literal_type = typing.get_type_hints(MentionRef)["type"]
     literal_values = set(typing.get_args(literal_type))
-    assert literal_values == set(ENTITY_RESOLVERS) - _MENTION_ENDPOINT_KNOWN_GAP
-    # ⭐PO 지적(2026-07-29): "없다"만 고정하면 다음 사람이 "빠뜨린 건가"를 다시 세게 된다 —
-    # WHY: evidence는 GET /api/v2/evidence/{id}(단건조회) 라우트 자체가 없어(work_item_id로
-    # 거르는 list만 존재) MCP가 title을 auto-fetch할 방법이 없다 — 그래서 Literal에 못 올린다.
-    # 단건 GET이 생기면 여기와 `_MENTION_ENTITY_ENDPOINTS`(chat.py)를 같이 늘린다.
-    assert "evidence" not in literal_values
+    assert literal_values == set(ENTITY_RESOLVERS)
+    assert "evidence" in literal_values
     assert "evidence" in set(ENTITY_RESOLVERS)
 
 


### PR DESCRIPTION
## Summary
- Evidence had no single-entity read route — only `POST /api/v2/evidence` and `GET /api/v2/evidence` (work_item_id-filtered list). Two independent consumers hit the same gap in one day: MCP chat mentions couldn't auto-fetch evidence by id, and the #2302 embed chip couldn't resolve evidence's "contained in" parent for navigation.
- Adds `GET /api/v2/evidence/{id}`, reusing the existing `_project_id_of_evidence` SSOT resolver (reference_registry.py) rather than reimplementing the story/task join a third time.
- Access-denial is 404-uniform from the start (not 403) — matches the direction #2322 just set for `stories.py` (PR #2624): org-in/project-out and truly-nonexistent both read as 404. evidence.py isn't one of #2322's 4 named helpers, but a brand-new route follows that direction rather than adding a fresh 403.
- `EvidenceResponse` gains `resolved_story_id` (a task-type evidence needs one more hop than its own row carries — BE resolves it so FE doesn't need a second round trip) and a `reference_token` computed field (evidence has no title, so `[type] ref` stands in as the token's title text).
- `chat.py`: evidence added to `_MENTION_ENTITY_ENDPOINTS` + `MentionRef` Literal; removed from `_MENTION_ENDPOINT_KNOWN_GAP` along with the now-stale "intentionally excluded" rationale comments — declaration and reason removed together, not just the frozenset entry.
- `embed-card.tsx`: evidence promoted from a fixed "no destination" (③) to a via-parent link (② — same as task), reading `resolved_story_id` directly.

## Test plan
- [x] RED-first: `test_2314_evidence_get_by_id_realdb.py` (6 tests) confirmed failing (405, route didn't exist) against the pre-change code via `git stash`, then GREEN after implementing.
- [x] RED-first (FE): the new embed-card link-state test confirmed failing against pre-change `embed-card.tsx` (no link rendered), then GREEN after wiring `resolved_story_id`.
- [x] Positive control both work-item shapes: story-type evidence (`resolved_story_id == work_item_id`) and task-type evidence (`resolved_story_id` via one extra join to the task's parent story).
- [x] 404-uniform: same-org/no-project-access and truly-nonexistent both 404, not 403 — verified plus a mutation self-check (sabotaging `has_project_access` to always-true reproduces the leak, proving the guard isn't tautological).
- [x] `reference_token` verified against the real `build_reference_token` builder (not reimplemented in the test, to avoid the twin-escape-logic trap this repo has hit before).
- [x] MCP mention Literal/dict/registry three-way parity tests (`test_mcp_s1995_agent_doc_mentions.py`) updated and green — evidence now fully included, no more "known gap".
- [x] Full existing evidence realdb suite (4 files) + MCP mention suite: 59/59 green, no regressions.
- [x] `tsc --noEmit` and `eslint` clean on touched FE files; `embed-card.entity-registry-parity.test.ts` (BE↔FE type-set parity) still green — key sets were already correct from #2302, only comments/branch logic changed.

**Honest gap (Diego's note, confirmed in the model)**: `Evidence` has no `status` field at all. Even with this route open and both consumers wired, an evidence card becomes browsable/linkable but not actionable — this closes the "created but nowhere to view it" gap, it does not add next-action material.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>