### PR TITLE
[SID:2265] C-7 PR1a — 대화 인용(proof) view-only 렌더 + EvidenceCount 라벨 정정

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3291,7 +3291,7 @@
     "trustSealSignedOff": "Signed off",
     "evidenceShow": "Show evidence",
     "evidenceHide": "Hide evidence",
-    "evidenceCount": "{count} evidence items",
+    "evidenceCount": "{count} attached evidence items",
     "evidenceSignedBy": "Evidence for this completion — left by {name}",
     "evidenceMore": "{count} more evidence items",
     "evidenceLoadError": "Couldn't load evidence",
@@ -3305,7 +3305,17 @@
     "evidenceAdd": "Link evidence",
     "evidenceAddFailed": "Failed to link evidence",
     "evidenceRefPlaceholder": "URL or reference",
-    "evidenceNotePlaceholder": "Note (optional)"
+    "evidenceNotePlaceholder": "Note (optional)",
+    "chatProofSectionTitle": "Chat evidence",
+    "chatProofCount": "{count} chat evidence items",
+    "chatProofOpenSource": "Open in chat",
+    "chatProofOpenOriginal": "View original now",
+    "chatProofEdited": "Original was edited · {date}",
+    "chatProofDeleted": "Original was deleted · quoted {date}",
+    "chatProofDeletedTag": "Deleted",
+    "chatProofNoAccess": "Can't view · permission",
+    "chatProofTruncatedBefore": "{count} lines omitted above",
+    "chatProofTruncatedAfter": "{count} lines omitted below"
   },
   "canvas": {
     "versionLineage": "Version lineage",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3291,7 +3291,7 @@
     "trustSealSignedOff": "책임 서명",
     "evidenceShow": "근거 보기",
     "evidenceHide": "근거 접기",
-    "evidenceCount": "근거 {count}건",
+    "evidenceCount": "첨부 근거 {count}건",
     "evidenceSignedBy": "이 완결의 근거 — {name}가 남김",
     "evidenceMore": "근거 {count}건 더 보기",
     "evidenceLoadError": "근거를 불러오지 못했습니다",
@@ -3305,7 +3305,17 @@
     "evidenceAdd": "증거 연결",
     "evidenceAddFailed": "증거 연결 실패",
     "evidenceRefPlaceholder": "URL 또는 참조",
-    "evidenceNotePlaceholder": "메모(선택)"
+    "evidenceNotePlaceholder": "메모(선택)",
+    "chatProofSectionTitle": "대화 근거",
+    "chatProofCount": "대화 근거 {count}건",
+    "chatProofOpenSource": "대화에서 열기",
+    "chatProofOpenOriginal": "지금 원본 보기",
+    "chatProofEdited": "원본이 수정되었습니다 · {date}",
+    "chatProofDeleted": "원본이 삭제되었습니다 · 인용 시점 {date}",
+    "chatProofDeletedTag": "삭제됨",
+    "chatProofNoAccess": "볼 수 없습니다 · 권한",
+    "chatProofTruncatedBefore": "앞 {count}줄 생략",
+    "chatProofTruncatedAfter": "뒤 {count}줄 생략"
   },
   "canvas": {
     "versionLineage": "버전 lineage",

--- a/apps/web/src/components/verify/chat-proof-embed.test.tsx
+++ b/apps/web/src/components/verify/chat-proof-embed.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { ChatProofEmbed } from './chat-proof-embed';
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+const BASE_MESSAGES = [
+  { id: 'm1', senderName: '오르테가', content: '이 방향으로 가시는' },
+  { id: 'm2', senderName: '미르코', content: '확認했는' },
+];
+
+describe('ChatProofEmbed — story #2265(C-7) PR1a 4상태', () => {
+  it('정상 상태 — 인용 메시지가 그대로 렌더되고 변경 신호가 없다', () => {
+    const html = renderToStaticMarkup(wrap(
+      <ChatProofEmbed
+        sourceLabel="채팅 · 7/26 · 오르테가군 외 2명"
+        conversationHref="/chats/conv-1?messageId=m1"
+        messages={BASE_MESSAGES}
+        quotedAt="7/26"
+        status="normal"
+      />,
+    ));
+    expect(html).toContain('이 방향으로 가시는');
+    expect(html).toContain('확認했는');
+    expect(html).toContain('대화에서 열기');
+    expect(html).not.toContain('삭제됨');
+    expect(html).not.toContain('수정되었습니다');
+  });
+
+  it('수정됨 — 박힌 시점 내용은 그대로 유지되고 «원본이 수정되었습니다»가 얹힌다(자동 교체 아님)', () => {
+    const html = renderToStaticMarkup(wrap(
+      <ChatProofEmbed
+        sourceLabel="채팅 · 7/26 · 오르테가군 외 2명"
+        conversationHref="/chats/conv-1?messageId=m1"
+        messages={BASE_MESSAGES}
+        quotedAt="7/26"
+        status="edited"
+        editedAt="7/28"
+      />,
+    ));
+    // 박힌 시점 내용이 살아있다 — 조용한 교체가 아니라 "얹기"임을 확認.
+    expect(html).toContain('이 방향으로 가시는');
+    expect(html).toContain('원본이 수정되었습니다');
+    expect(html).toContain('7/28');
+    expect(html).toContain('지금 원본 보기');
+  });
+
+  it('삭제됨 — 내용은 접히고(안 보이고) «삭제됨» 표지 + 인용 시점이 선다', () => {
+    const html = renderToStaticMarkup(wrap(
+      <ChatProofEmbed
+        sourceLabel="채팅 · 7/26 · 오르테가군 외 2명"
+        conversationHref="/chats/conv-1?messageId=m1"
+        messages={BASE_MESSAGES}
+        quotedAt="7/26"
+        status="deleted"
+      />,
+    ));
+    expect(html).not.toContain('이 방향으로 가시는');
+    expect(html).toContain('삭제됨');
+    expect(html).toContain('원본이 삭제되었습니다');
+    expect(html).toContain('인용 시점');
+  });
+
+  it('권한없음 — 내용·출처줄 전부 안 보이고 «볼 수 없습니다 · 권한»만 선다(삭제됨과 다른 문구)', () => {
+    const html = renderToStaticMarkup(wrap(
+      <ChatProofEmbed
+        sourceLabel="채팅 · 7/26 · 오르테가군 외 2명"
+        conversationHref={null}
+        messages={BASE_MESSAGES}
+        quotedAt="7/26"
+        status="no_access"
+      />,
+    ));
+    expect(html).not.toContain('이 방향으로 가시는');
+    expect(html).not.toContain('채팅 · 7/26');
+    expect(html).not.toContain('삭제됨');
+    expect(html).toContain('볼 수 없습니다');
+    expect(html).toContain('권한');
+  });
+
+  it('잘림 표시 — 앞/뒤 생략 줄 수가 실제로 렌더된다', () => {
+    const html = renderToStaticMarkup(wrap(
+      <ChatProofEmbed
+        sourceLabel="채팅 · 7/26 · 오르테가군 외 2명"
+        conversationHref="/chats/conv-1?messageId=m1"
+        messages={BASE_MESSAGES}
+        quotedAt="7/26"
+        status="normal"
+        truncatedBefore={12}
+        truncatedAfter={3}
+      />,
+    ));
+    expect(html).toContain('앞 12줄 생략');
+    expect(html).toContain('뒤 3줄 생략');
+  });
+
+  it('conversationHref가 null이면(권한 없음 아닌 다른 사유) «대화에서 열기» 링크를 안 그린다', () => {
+    const html = renderToStaticMarkup(wrap(
+      <ChatProofEmbed
+        sourceLabel="채팅 · 7/26 · 오르테가군 외 2명"
+        conversationHref={null}
+        messages={BASE_MESSAGES}
+        quotedAt="7/26"
+        status="normal"
+      />,
+    ));
+    expect(html).not.toContain('대화에서 열기');
+  });
+
+  it('사용자 노출 문구에 구조 이름(참조·임베드)이 안 섞인다 — PO 규율(2026-07-29)', () => {
+    const html = renderToStaticMarkup(wrap(
+      <ChatProofEmbed
+        sourceLabel="채팅 · 7/26 · 오르테가군 외 2명"
+        conversationHref="/chats/conv-1?messageId=m1"
+        messages={BASE_MESSAGES}
+        quotedAt="7/26"
+        status="edited"
+        editedAt="7/28"
+      />,
+    ));
+    for (const forbidden of ['참조', '임베드', 'reference', 'embed']) {
+      expect(html.toLowerCase()).not.toContain(forbidden.toLowerCase());
+    }
+  });
+});

--- a/apps/web/src/components/verify/chat-proof-embed.tsx
+++ b/apps/web/src/components/verify/chat-proof-embed.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+
+export interface ChatProofMessage {
+  id: string;
+  senderName: string;
+  content: string;
+}
+
+export interface ChatProofEmbedProps {
+  /** 출처줄: "채팅 · 7/26 · 오르테가군 외 2명" 같은 완성 문구(호출부가 조립 — 이 컴포넌트는
+   * 문구를 지어내지 않는다). */
+  sourceLabel: string;
+  /** "대화에서 열기"의 목적지. null이면 그 링크 자체를 안 그린다(권한 없음 케이스와 동형이지만
+   * 별개 축 — 아래 status와 독립). */
+  conversationHref: string | null;
+  messages: ChatProofMessage[];
+  /** 인용 시점(항상 필요 — deleted 상태의 "인용 시점" 문구에 쓰인다). */
+  quotedAt: string;
+  status: 'normal' | 'edited' | 'deleted' | 'no_access';
+  /** status="edited"일 때만 의미 있음. */
+  editedAt?: string;
+  truncatedBefore?: number;
+  truncatedAfter?: number;
+  className?: string;
+}
+
+/**
+ * story #2265(C-7) PR1a — 대화 일부를 view-only로 박는 렌더. props로만 데이터를 받아
+ * 실제 라우트(설계 진행 중, #2262 C-4와 자리 겹침 조율 中)와 분리해 먼저 세운다(PO 지시,
+ * 2026-07-29 — "라우트가 뭐가 되든 안 흔들리는 자리"). PR1b가 실 데이터를 연결한다.
+ *
+ * 화면 규격(유나 확定 2026-07-28, PO 채택):
+ * - 카드(테두리 상자) 금지 — 본문과 같은 배경 + 좌측 세로선(인용 관용구).
+ * - 회색으로 죽이지 않는다 — 증거는 읽히라고 박은 것(본문과 같은 명도).
+ * - 원본 변경은 "얹기"다 — 내용을 조용히 교체하지 않고 출처줄에 신호만 덧붙인다.
+ * - 삭제 ≠ 권한 상실 — 서로 다른 문구·다른 렌더(no_access는 내용 자체를 안 보인다).
+ */
+export function ChatProofEmbed({
+  sourceLabel, conversationHref, messages, quotedAt, status, editedAt,
+  truncatedBefore, truncatedAfter, className,
+}: ChatProofEmbedProps) {
+  const t = useTranslations('verify');
+
+  if (status === 'no_access') {
+    return (
+      <div className={cn('border-l-2 border-border py-1.5 pl-3', className)}>
+        <p className="text-[11.5px] text-muted-foreground">{t('chatProofNoAccess')}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('border-l-2 border-border py-1.5 pl-3', className)}>
+      <div className="mb-1 flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[11px] text-muted-foreground">
+        <span>{sourceLabel}</span>
+        {conversationHref ? (
+          <Link href={conversationHref} className="text-primary hover:underline">
+            {t('chatProofOpenSource')}
+          </Link>
+        ) : null}
+        {status === 'edited' ? (
+          <>
+            <span aria-hidden>·</span>
+            <span>{t('chatProofEdited', { date: editedAt ?? '' })}</span>
+            {conversationHref ? (
+              <Link href={conversationHref} className="text-primary hover:underline">
+                {t('chatProofOpenOriginal')}
+              </Link>
+            ) : null}
+          </>
+        ) : null}
+        {status === 'deleted' ? (
+          <>
+            <span aria-hidden>·</span>
+            <span>{t('chatProofDeleted', { date: quotedAt })}</span>
+          </>
+        ) : null}
+      </div>
+
+      {status === 'deleted' ? (
+        <p className="text-[11.5px] text-muted-foreground">
+          <span className="mr-1 rounded bg-muted px-1 py-0.5 text-[10px]">{t('chatProofDeletedTag')}</span>
+        </p>
+      ) : (
+        <div className="flex flex-col gap-1">
+          {truncatedBefore ? (
+            <p className="text-[10.5px] text-muted-foreground">{t('chatProofTruncatedBefore', { count: truncatedBefore })}</p>
+          ) : null}
+          {messages.map((m) => (
+            <p key={m.id} className="text-[13px] leading-snug text-foreground">
+              <span className="font-medium">{m.senderName}</span>{' '}
+              <span className="[overflow-wrap:anywhere]">{m.content}</span>
+            </p>
+          ))}
+          {truncatedAfter ? (
+            <p className="text-[10.5px] text-muted-foreground">{t('chatProofTruncatedAfter', { count: truncatedAfter })}</p>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/verify/evidence-section.tsx
+++ b/apps/web/src/components/verify/evidence-section.tsx
@@ -162,6 +162,10 @@ export function EvidenceSection({
             aria-hidden
           />
           <span className="text-xs font-semibold text-foreground">{sealLabel}</span>
+          {/* story #2265(C-7) PO 지적, 2026-07-29: 이 수는 Evidence 테이블 건수뿐이다 — 바로
+            아래 붙을 proof(채팅 인용) 섹션은 다른 모델이라 여기 안 잡힌다. "근거 N건"으로
+            두면 그 옆의 proof가 안 세어진 것처럼 보여 총량을 거짓으로 만든다 — "첨부 근거"로
+            좁혀 이 수가 «첨부형»만 센다는 것을 명시한다(두 섹션 통합은 별건으로 등재). */}
           {items ? (
             <span className="text-[11px] text-muted-foreground">· {t('evidenceCount', { count: items.length })}</span>
           ) : null}


### PR DESCRIPTION
## 요약
story #2265(C-7, 13pt)의 첫 조각(PR1a) — BE 라우트 설계가 #2262(C-4)와 자리가 겹칠 수 있어 조율 중이라(PO 확認 진행 중), 실 데이터 연결과 무관하게 먼저 설 수 있는 **순수 렌더 컴포넌트**만 이 PR에 담았다.

- `ChatProofEmbed`: 대화 일부를 view-only로 인용하는 렌더 — 정상/수정됨/삭제됨/권한없음 4상태 + 앞뒤 잘림 표시
- `EvidenceSection`의 "근거 N건" 라벨을 "첨부 근거 N건"으로 좁힘(PO 지적: 바로 아래 붙을 이 섹션과 안 갈리면 총량이 거짓이 됨)

## 화면 규격 (유나 확定 2026-07-28, PO 채택)
- 카드(테두리 상자) 금지 — 좌측 세로선(인용 관용구), 회색으로 죽이지 않음
- 수정됨: 원본을 조용히 교체하지 않고 출처줄에 신호만 "얹는다"(내용은 인용 시점 그대로 유지)
- 삭제됨: 내용을 접고 "삭제됨" 표지 + 인용 시점 표시
- 권한없음: 삭제됨과 다른 문구 — 내용·출처줄 전부 비표시("볼 수 없습니다 · 권한")
- 사용자 노출 문구에 "참조"/"임베드" 등 구조 이름을 쓰지 않음(회귀가드 테스트 포함)

## 이 PR에 없는 것 (의도적)
- 실 데이터 연결(BE 라우트 미확定 — PR1b)
- 메시지 범위 선택 UI(PR2, 렌더이 서야 저장 모양이 확定됨 — PO 지시)
- 원본 변경 자동 감지(PR3, AC7 선행실측 필요)

## 검증
- [x] `pnpm build` 성공(EXIT 0)
- [x] `pnpm lint` 경고 0개(대상 파일 전수)
- [x] `tsc --noEmit` 클린
- [x] vitest 16/16 통과(신규 7건 + 기존 evidence-section 9건 무회귀)