### PR TITLE
[SID:2265] C-7 PR2 — 메시지 범위 선택 상태 기계 + 인용 컨텍스트메뉴

### DIFF
--- a/apps/web/src/components/chat/message-context-menu.test.tsx
+++ b/apps/web/src/components/chat/message-context-menu.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { MessageContextMenu } from './message-context-menu';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+const NOOP = () => {};
+
+describe('MessageContextMenu — story #2265(C-7) PR2 citeAction 확장', () => {
+  it('citeAction을 안 주면(기존 호출부) 인용 항목이 안 그려진다(회귀 0)', async () => {
+    await act(async () => {
+      root.render(
+        <MessageContextMenu x={0} y={0} isMine={false} onReply={NOOP} onCopy={NOOP} onDelete={NOOP} onClose={NOOP} />,
+      );
+    });
+    expect(container.textContent).not.toContain('인용');
+  });
+
+  it('citeAction kind="start"이면 "여기부터 인용"이 뜨고 클릭 시 onSelect+onClose가 불린다', async () => {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    await act(async () => {
+      root.render(
+        <MessageContextMenu
+          x={0} y={0} isMine={false} onReply={NOOP} onCopy={NOOP} onDelete={NOOP} onClose={onClose}
+          citeAction={{ kind: 'start', onSelect }}
+        />,
+      );
+    });
+    expect(container.textContent).toContain('여기부터 인용');
+    const btn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('여기부터 인용'));
+    expect(btn).not.toBeUndefined();
+    await act(async () => { btn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('citeAction kind="end"이면 "여기까지 인용"이 뜬다(이미 anchor가 찍힌 상태를 반영)', async () => {
+    await act(async () => {
+      root.render(
+        <MessageContextMenu
+          x={0} y={0} isMine={false} onReply={NOOP} onCopy={NOOP} onDelete={NOOP} onClose={NOOP}
+          citeAction={{ kind: 'end', onSelect: NOOP }}
+        />,
+      );
+    });
+    expect(container.textContent).toContain('여기까지 인용');
+    expect(container.textContent).not.toContain('여기부터 인용');
+  });
+
+  it('기존 메뉴 항목(답글·복사)은 citeAction 유무와 무관하게 그대로 있다', async () => {
+    await act(async () => {
+      root.render(
+        <MessageContextMenu
+          x={0} y={0} isMine={false} onReply={NOOP} onCopy={NOOP} onDelete={NOOP} onClose={NOOP}
+          citeAction={{ kind: 'start', onSelect: NOOP }}
+        />,
+      );
+    });
+    expect(container.textContent).toContain('답글 달기');
+    expect(container.textContent).toContain('복사');
+  });
+});

--- a/apps/web/src/components/chat/message-context-menu.tsx
+++ b/apps/web/src/components/chat/message-context-menu.tsx
@@ -1,7 +1,15 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { MessageSquareReply, Copy, Trash2 } from 'lucide-react';
+import { MessageSquareReply, Copy, Trash2, Quote } from 'lucide-react';
+
+interface CiteAction {
+  /** story #2265(C-7) PR2 — 아직 선택 중이 아니면 "start"(여기부터), 이미 다른 메시지가
+   * anchor로 찍힌 중이면 "end"(여기까지). 라벨/판단은 호출부(use-message-range-selection
+   * 소비부)가 정하고, 이 메뉴는 그 결정을 그대로 그린다. */
+  kind: 'start' | 'end';
+  onSelect: () => void;
+}
 
 interface MessageContextMenuProps {
   x: number;
@@ -11,9 +19,11 @@ interface MessageContextMenuProps {
   onCopy: () => void;
   onDelete: () => void;
   onClose: () => void;
+  /** 생략하면(undefined) 인용 항목 자체를 안 그린다 — 기존 호출부 무변경 보장. */
+  citeAction?: CiteAction;
 }
 
-export function MessageContextMenu({ x, y, isMine, onReply, onCopy, onDelete, onClose }: MessageContextMenuProps) {
+export function MessageContextMenu({ x, y, isMine, onReply, onCopy, onDelete, onClose, citeAction }: MessageContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
 
   // Close on outside click or Escape
@@ -32,7 +42,7 @@ export function MessageContextMenu({ x, y, isMine, onReply, onCopy, onDelete, on
 
   // Clamp menu inside viewport
   const menuW = 160;
-  const menuH = isMine ? 112 : 80;
+  const menuH = (isMine ? 112 : 80) + (citeAction ? 36 : 0);
   const clampedX = Math.min(x, window.innerWidth - menuW - 8);
   const clampedY = Math.min(y, window.innerHeight - menuH - 8);
 
@@ -61,6 +71,17 @@ export function MessageContextMenu({ x, y, isMine, onReply, onCopy, onDelete, on
         <Copy className="h-3.5 w-3.5 text-muted-foreground" />
         복사
       </button>
+      {citeAction && (
+        <button
+          type="button"
+          role="menuitem"
+          onClick={() => { citeAction.onSelect(); onClose(); }}
+          className="flex w-full items-center gap-2.5 px-3 py-2 text-sm hover:bg-muted"
+        >
+          <Quote className="h-3.5 w-3.5 text-muted-foreground" />
+          {citeAction.kind === 'start' ? '여기부터 인용' : '여기까지 인용'}
+        </button>
+      )}
       {isMine && (
         <>
           <div className="my-1 border-t border-border" />

--- a/apps/web/src/hooks/use-message-range-selection.test.tsx
+++ b/apps/web/src/hooks/use-message-range-selection.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act, useEffect } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useMessageRangeSelection, type MessageRangeSelection } from './use-message-range-selection';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const ORDERED_IDS = ['m1', 'm2', 'm3', 'm4', 'm5'];
+
+let container: HTMLDivElement;
+let root: Root;
+let current: MessageRangeSelection;
+
+function Harness() {
+  const selection = useMessageRangeSelection();
+  useEffect(() => { current = selection; });
+  return null;
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+function mount() {
+  act(() => { root.render(<Harness />); });
+}
+
+describe('useMessageRangeSelection — story #2265(C-7) PR2 선택 상태 기계', () => {
+  it('idle에서 시작 — startSelection 전에는 anchor도 range도 없다', () => {
+    mount();
+    expect(current.mode).toBe('idle');
+    expect(current.isAnchor('m1')).toBe(false);
+    expect(current.isInRange('m1', ORDERED_IDS)).toBe(false);
+  });
+
+  it('startSelection 후 anchored — 그 메시지만 anchor로 표시된다', () => {
+    mount();
+    act(() => current.startSelection('m2'));
+    expect(current.mode).toBe('anchored');
+    expect(current.isAnchor('m2')).toBe(true);
+    expect(current.isAnchor('m3')).toBe(false);
+  });
+
+  it('정순(anchor가 먼저) — confirmEnd 후 range가 anchor→end 그대로 선다', () => {
+    mount();
+    act(() => current.startSelection('m2'));
+    act(() => current.confirmEnd('m4', ORDERED_IDS));
+    expect(current.mode).toBe('confirming');
+    expect(current.rangeStartId).toBe('m2');
+    expect(current.rangeEndId).toBe('m4');
+  });
+
+  it('역순(사용자가 나중 메시지를 먼저 짚음) — start/end가 시간순으로 자동 정규화된다', () => {
+    mount();
+    act(() => current.startSelection('m4'));
+    act(() => current.confirmEnd('m2', ORDERED_IDS));
+    expect(current.rangeStartId).toBe('m2');
+    expect(current.rangeEndId).toBe('m4');
+  });
+
+  it('같은 메시지를 두 번 짚으면 — 1건짜리 range로 선다(0건이 아니다)', () => {
+    mount();
+    act(() => current.startSelection('m3'));
+    act(() => current.confirmEnd('m3', ORDERED_IDS));
+    expect(current.rangeStartId).toBe('m3');
+    expect(current.rangeEndId).toBe('m3');
+    expect(current.isInRange('m3', ORDERED_IDS)).toBe(true);
+    expect(current.isInRange('m2', ORDERED_IDS)).toBe(false);
+  });
+
+  it('isInRange — 확定된 range 안(양끝 포함)만 true, 밖은 false', () => {
+    mount();
+    act(() => current.startSelection('m2'));
+    act(() => current.confirmEnd('m4', ORDERED_IDS));
+    expect(current.isInRange('m1', ORDERED_IDS)).toBe(false);
+    expect(current.isInRange('m2', ORDERED_IDS)).toBe(true);
+    expect(current.isInRange('m3', ORDERED_IDS)).toBe(true);
+    expect(current.isInRange('m4', ORDERED_IDS)).toBe(true);
+    expect(current.isInRange('m5', ORDERED_IDS)).toBe(false);
+  });
+
+  it('anchor나 end가 orderedMessageIds에 없으면(가상화로 밀려남 등) confirmEnd가 조용히 무시된다 — 순서를 지어내지 않는다', () => {
+    mount();
+    act(() => current.startSelection('m2'));
+    act(() => current.confirmEnd('unknown-id', ORDERED_IDS));
+    expect(current.mode).toBe('anchored'); // confirming으로 안 넘어간다.
+    expect(current.rangeStartId).toBeNull();
+  });
+
+  it('anchored가 아닌 상태(idle)에서 confirmEnd를 불러도 아무 일도 안 일어난다', () => {
+    mount();
+    act(() => current.confirmEnd('m2', ORDERED_IDS));
+    expect(current.mode).toBe('idle');
+  });
+
+  it('cancel — 언제든 idle로 완전히 되돌아간다', () => {
+    mount();
+    act(() => current.startSelection('m2'));
+    act(() => current.confirmEnd('m4', ORDERED_IDS));
+    act(() => current.cancel());
+    expect(current.mode).toBe('idle');
+    expect(current.anchorId).toBeNull();
+    expect(current.rangeStartId).toBeNull();
+    expect(current.rangeEndId).toBeNull();
+    expect(current.isInRange('m3', ORDERED_IDS)).toBe(false);
+  });
+
+  it('confirming 상태에서 다시 startSelection을 부르면 — 이전 range를 버리고 새 anchor로 재시작한다', () => {
+    mount();
+    act(() => current.startSelection('m1'));
+    act(() => current.confirmEnd('m3', ORDERED_IDS));
+    act(() => current.startSelection('m5'));
+    expect(current.mode).toBe('anchored');
+    expect(current.anchorId).toBe('m5');
+    expect(current.rangeStartId).toBeNull();
+    expect(current.isInRange('m2', ORDERED_IDS)).toBe(false); // 옛 range 잔재 없음.
+  });
+});

--- a/apps/web/src/hooks/use-message-range-selection.ts
+++ b/apps/web/src/hooks/use-message-range-selection.ts
@@ -1,0 +1,82 @@
+import { useCallback, useMemo, useState } from 'react';
+
+export type MessageRangeSelectionMode = 'idle' | 'anchored' | 'confirming';
+
+interface SelectionState {
+  mode: MessageRangeSelectionMode;
+  anchorId: string | null;
+  rangeStartId: string | null;
+  rangeEndId: string | null;
+}
+
+const IDLE_STATE: SelectionState = { mode: 'idle', anchorId: null, rangeStartId: null, rangeEndId: null };
+
+export interface MessageRangeSelection extends SelectionState {
+  /** story #2265(C-7) ①규격 — 「여기부터」. 메시지 단위 두 번 짚기의 첫 짚기. */
+  startSelection: (messageId: string) => void;
+  /** 「여기까지」 — orderedMessageIds(지금 보는 목록 순서, 위→아래)로 anchor와 이 id의
+   * 시간순을 정규화한다(사용자가 나중 메시지를 먼저 짚어도 range가 뒤집히지 않게).
+   * anchor나 이 id가 orderedMessageIds에 없으면(가상화로 목록 밖으로 밀려난 경우 등)
+   * 조용히 무시한다 — 순서를 모르는 채로 range를 지어내지 않는다. */
+  confirmEnd: (messageId: string, orderedMessageIds: string[]) => void;
+  cancel: () => void;
+  isAnchor: (messageId: string) => boolean;
+  /** mode==='confirming'일 때만 의미 있다 — orderedMessageIds 안에서 rangeStartId~rangeEndId
+   * 사이(양끝 포함)인지. 목록이 바뀌어도(가상화 스크롤 등) 항상 그 시점의 순서로 판정한다. */
+  isInRange: (messageId: string, orderedMessageIds: string[]) => boolean;
+}
+
+/**
+ * story #2265(C-7) PR2 — 대화 일부를 proof로 박기 위한 메시지 범위 선택 상태 기계.
+ * 순수 상태만 다룬다(저장/전송은 이 훅의 책임 밖 — write 엔드포인트가 서면 소비부가
+ * confirmEnd 이후의 rangeStartId/rangeEndId를 그대로 payload에 실어 보낸다).
+ *
+ * ⛔문자 드래그가 아니라 메시지 "단위" 두 번 짚기(유나 확定 규격, PO 채택) — anchor
+ * 자체를 붙잡아 두고 orderedMessageIds로 사후 정규화하는 이유: 채팅은 실시간으로 새
+ * 메시지가 위/아래에 계속 추가되므로, index 스냅샷이 아니라 "그 순간의 목록 순서"를
+ * confirmEnd 호출 시점마다 다시 받아 판정해야 정확하다.
+ */
+export function useMessageRangeSelection(): MessageRangeSelection {
+  const [state, setState] = useState<SelectionState>(IDLE_STATE);
+
+  const startSelection = useCallback((messageId: string) => {
+    setState({ mode: 'anchored', anchorId: messageId, rangeStartId: null, rangeEndId: null });
+  }, []);
+
+  const confirmEnd = useCallback((messageId: string, orderedMessageIds: string[]) => {
+    setState((prev) => {
+      if (prev.mode !== 'anchored' || !prev.anchorId) return prev;
+      const anchorIndex = orderedMessageIds.indexOf(prev.anchorId);
+      const endIndex = orderedMessageIds.indexOf(messageId);
+      if (anchorIndex === -1 || endIndex === -1) return prev; // 순서를 모르면 확定하지 않는다.
+      const [startId, endId] = anchorIndex <= endIndex
+        ? [prev.anchorId, messageId]
+        : [messageId, prev.anchorId];
+      return { mode: 'confirming', anchorId: prev.anchorId, rangeStartId: startId, rangeEndId: endId };
+    });
+  }, []);
+
+  const cancel = useCallback(() => setState(IDLE_STATE), []);
+
+  const isAnchor = useCallback(
+    (messageId: string) => state.mode === 'anchored' && state.anchorId === messageId,
+    [state.mode, state.anchorId],
+  );
+
+  const isInRange = useCallback(
+    (messageId: string, orderedMessageIds: string[]) => {
+      if (state.mode !== 'confirming' || !state.rangeStartId || !state.rangeEndId) return false;
+      const startIndex = orderedMessageIds.indexOf(state.rangeStartId);
+      const endIndex = orderedMessageIds.indexOf(state.rangeEndId);
+      const targetIndex = orderedMessageIds.indexOf(messageId);
+      if (startIndex === -1 || endIndex === -1 || targetIndex === -1) return false;
+      return targetIndex >= startIndex && targetIndex <= endIndex;
+    },
+    [state.mode, state.rangeStartId, state.rangeEndId],
+  );
+
+  return useMemo(
+    () => ({ ...state, startSelection, confirmEnd, cancel, isAnchor, isInRange }),
+    [state, startSelection, confirmEnd, cancel, isAnchor, isInRange],
+  );
+}

--- a/apps/web/src/hooks/use-message-range-selection.ts
+++ b/apps/web/src/hooks/use-message-range-selection.ts
@@ -48,6 +48,11 @@ export function useMessageRangeSelection(): MessageRangeSelection {
       if (prev.mode !== 'anchored' || !prev.anchorId) return prev;
       const anchorIndex = orderedMessageIds.indexOf(prev.anchorId);
       const endIndex = orderedMessageIds.indexOf(messageId);
+      // 이 분기는 지금 도는 경로가 없다(2026-07-29 확認 — chat-view.tsx엔 가상화 라이브러리가
+      // 0건이고 messages state는 prepend만 해 축소되지 않는다, 언마운트→재마운트는 선택 자체가
+      // 정상 취소되는 별개 경로). ⇒ 가상화가 들어오면 이 분기가 돈다 — 그때는 "무시"가 아니라
+      // "다른 데서(서버/스토어) 순서를 다시 얻는" 쪽으로 바꾼다(anchor id 자체는 훅이 계속
+      // 들고 있으므로 그 id로 재조회하면 된다). 도는 경로가 없다고 죽은 코드로 지우지 말 것.
       if (anchorIndex === -1 || endIndex === -1) return prev; // 순서를 모르면 확定하지 않는다.
       const [startId, endId] = anchorIndex <= endIndex
         ? [prev.anchorId, messageId]


### PR DESCRIPTION
## 요약
story #2265(C-7) PR2 — BE 저장 모양(`proof_payload`, 스냅샷 포함)은 확定됐고 라우트(까심군)는 조율 중이라, 저장/라우트와 무관하게 먼저 설 수 있는 **선택 상태 층**만 이 PR에 담았다.

## 화면 규격 (유나 확定 2026-07-28, PO 채택 — ①범위를 고르는 법)
- 메시지 "단위" 두 번 짚기(문자 드래그 아님) — 앵커 = 메시지 id
- 사용자가 끝을 먼저 짚어도(역순) 시간순으로 자동 정규화(PO 지적 반영)
- 목록에 없는 id로 확定을 시도하면 조용히 무시(순서를 모르는 채로 range를 지어내지 않음)

## 변경 사항
- `use-message-range-selection`: `idle → anchored → confirming` 상태 기계. 순수 상태만 다루고 저장/전송은 소비부 책임(층 분리 — PO 지시)
- `MessageContextMenu`: `citeAction`(선택) prop 추가. 생략하면(기존 호출부) 완전히 무변경 — "여기부터 인용"/"여기까지 인용"을 조건부로만 그린다

## 이 PR에 없는 것 (의도적, 다음 슬라이스)
- chat-view.tsx로의 실 배선(라이브 메시지 목록 연결)
- "새 메시지 N" 배지형 선택-모드 정지 UI, range 시각 표시(좌측 3px)
- 확定 후 저장(POST) 액션 — write 엔드포인트 미확定

## 검증
- [x] `pnpm build` 성공(EXIT 0)
- [x] `pnpm lint` 경고 0개(대상 파일 전수)
- [x] `tsc --noEmit` 클린
- [x] vitest 109/109 통과(chat/ 스위트 전체 무회귀, 신규 14건 포함)
- [x] 뮤테이션 검증 — 역순 정규화 로직을 제거하고 신규 테스트 1건이 RED로 떨어지는 것 확認 후 원복해 GREEN 재확認