### PR TITLE
feat(#2263): story outgoing references — first read+write consumer of reference_core

### DIFF
--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -7,19 +7,23 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
   ExternalLink, X, FileText, File, Layers, CheckSquare, Eye,
-  Calendar, Image, FlaskConical, Paperclip, type LucideIcon,
+  Calendar, Image, FlaskConical, Paperclip, MessageSquareQuote, type LucideIcon,
 } from 'lucide-react';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { docViewUrl } from '@/components/docs/lib/doc-project-url';
 import { initials } from '@/lib/storage/format';
 
-// story #2302 — 이 8종은 BE reference_registry.py ENTITY_RESOLVERS 와 키 집합이 같아야 한다
-// (AC2·AC5, entity-icons.registry-parity.test.ts 가 코드스캔으로 대조). `asset`은 registry
+// story #2302 — 이 타입들은 BE reference_registry.py ENTITY_RESOLVERS 와 키 집합이 같아야
+// 한다(AC2·AC5, entity-icons.registry-parity.test.ts 가 코드스캔으로 대조). `asset`은 registry
 // 밖 FE 전용 타입(AC5 명시 예외) — 아이콘을 **일부러** 안 준다: asset은 이미지/PDF/영상 등
 // content-type이 제각각이라 타입 레벨 단일 아이콘이 의미가 없고(개별 파일 아이콘은
 // getFileIcon이 파일별로 처리), "아이콘 없으면 이름 글자로"가 AC4가 못박은 **기본값**이지
 // asset만의 예외 처리가 아니다 — 그래서 이 fallback은 `resolveEntityIcon()`이 모든 타입에
 // 공통 적용한다(Hash 캐치올을 버림 — 있지도 않은 아이콘을 그리는 거짓보다 글자가 정직하다).
+//
+// story #2263(C-7, 2026-07-29): chat_message가 BE ENTITY_RESOLVERS에 새로 등록됐다(proof
+// form이 대화 메시지를 인용하며 target이 됨) — parity 테스트가 그 즉시 이 파일에 걸렸다,
+// 정확히 의도한 대로(회귀 0건이 아니라 진짜 새 타입을 잡은 것).
 export const ENTITY_ICONS: Record<string, LucideIcon> = {
   story: FileText,
   doc: File,
@@ -29,6 +33,7 @@ export const ENTITY_ICONS: Record<string, LucideIcon> = {
   artifact: Image,
   hypothesis: FlaskConical,
   evidence: Paperclip,
+  chat_message: MessageSquareQuote,
 };
 
 /** ENTITY_ICONS에 없는 타입(지금은 asset뿐) → 아이콘 대신 이름 첫 글자(들). 예외 처리 아님(위 주석). */
@@ -58,6 +63,7 @@ const ENTITY_COLORS: Record<string, string> = {
   artifact: 'border-info/30 bg-info/8 text-foreground',
   hypothesis: 'border-border bg-muted/40 text-foreground',
   evidence: 'border-border bg-muted/40 text-foreground',
+  chat_message: 'border-border bg-muted/40 text-foreground',
   // S6: 스토리지 자산 토큰 — info 틴트(파일 아이콘은 content-type 의존이라 AssetEmbedCard 에서 getFileIcon 처리).
   asset: 'border-info/30 bg-info/8 text-foreground',
 };
@@ -89,6 +95,12 @@ export function getEntityHref(entityType: string, entityId: string): string | nu
     case 'artifact': return null; // 레코드마다 ②/③ — 위 함수 doc 참고.
     case 'hypothesis': return null; // ③ 고정 — 위 함수 doc 참고.
     case 'evidence': return null; // ② — resolved_story_id는 EntityPreviewModal이 fetch 후 판정(task와 동형).
+    // ③ 고정 — story #2263(C-7): chat_message를 가리키는 mention/embed 칩은 아직 아무도 안
+    // 만든다(proof의 실제 소비 UI는 이 범용 EntityChip/EmbedCard가 아니라 미르코의 전용
+    // ChatProofEmbed 컴포넌트, #2265 PR1a). 여기 키가 있어야 하는 이유는 BE registry
+    // parity뿐 — 실제 클릭 가능한 진입점이 생기면(바로 그 conversation으로 보내는 등) ②로
+    // 승격한다.
+    case 'chat_message': return null;
     default: return null;
   }
 }

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -98,7 +98,17 @@ export function getEntityHref(entityType: string, entityId: string): string | nu
     // ③ 고정 — story #2263(C-7): chat_message를 가리키는 mention/embed 칩은 아직 아무도 안
     // 만든다(proof의 실제 소비 UI는 이 범용 EntityChip/EmbedCard가 아니라 미르코의 전용
     // ChatProofEmbed 컴포넌트, #2265 PR1a). 여기 키가 있어야 하는 이유는 BE registry
-    // parity뿐 — 실제 클릭 가능한 진입점이 생기면(바로 그 conversation으로 보내는 등) ②로
+    // parity뿐.
+    //
+    // ⛔PO 지적(2026-07-29): hypothesis와 «다른» 이유로 ③이다 — hypothesis는 상세 라우트가
+    // 정말 없어서 모달 footer("열 수 있는 화면이 없습니다")가 참이지만, chat_message는
+    // 그 대화 화면(`/chats/{conversation_id}?messageId={id}`)이 실제로 «있다». 지금 이
+    // null이 그 화면을 감추는 거짓 응답을 만든다 — 다만 고치려면 BE
+    // `_resolve_chat_messages`(reference_registry.py)가 다른 8개 타입과 공유하는
+    // ENTITY_RESOLVERS 계약(session,org_id,ids)->set[uuid]을 깨거나, message_id 단독
+    // 조회 라우트(지금 0개 — conversations.py의 메시지 라우트 4개 전부 conversation_id를
+    // path에 요구)를 새로 지어야 해 이 PR 범위 밖으로 미룬다(#2263 본문에도 명시). 실제
+    // 클릭 가능한 진입점이 생기면(바로 그 conversation으로 보내는 등) ②로
     // 승격한다.
     case 'chat_message': return null;
     default: return null;

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -7,23 +7,26 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
   ExternalLink, X, FileText, File, Layers, CheckSquare, Eye,
-  Calendar, Image, FlaskConical, Paperclip, MessageSquareQuote, type LucideIcon,
+  Calendar, Image, FlaskConical, Paperclip, type LucideIcon,
 } from 'lucide-react';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { docViewUrl } from '@/components/docs/lib/doc-project-url';
 import { initials } from '@/lib/storage/format';
 
-// story #2302 — 이 타입들은 BE reference_registry.py ENTITY_RESOLVERS 와 키 집합이 같아야
-// 한다(AC2·AC5, entity-icons.registry-parity.test.ts 가 코드스캔으로 대조). `asset`은 registry
+// story #2302 — 이 8종은 BE reference_registry.py ENTITY_RESOLVERS 와 키 집합이 같아야 한다
+// (AC2·AC5, entity-icons.registry-parity.test.ts 가 코드스캔으로 대조). `asset`은 registry
 // 밖 FE 전용 타입(AC5 명시 예외) — 아이콘을 **일부러** 안 준다: asset은 이미지/PDF/영상 등
 // content-type이 제각각이라 타입 레벨 단일 아이콘이 의미가 없고(개별 파일 아이콘은
 // getFileIcon이 파일별로 처리), "아이콘 없으면 이름 글자로"가 AC4가 못박은 **기본값**이지
 // asset만의 예외 처리가 아니다 — 그래서 이 fallback은 `resolveEntityIcon()`이 모든 타입에
 // 공통 적용한다(Hash 캐치올을 버림 — 있지도 않은 아이콘을 그리는 거짓보다 글자가 정직하다).
 //
-// story #2263(C-7, 2026-07-29): chat_message가 BE ENTITY_RESOLVERS에 새로 등록됐다(proof
-// form이 대화 메시지를 인용하며 target이 됨) — parity 테스트가 그 즉시 이 파일에 걸렸다,
-// 정확히 의도한 대로(회귀 0건이 아니라 진짜 새 타입을 잡은 것).
+// ⛔story #2263(C-7, 2026-07-29) — 한 번 여기 chat_message를 추가했다가 되돌렸다: BE
+// ENTITY_RESOLVERS에 등록하면 «완전지원 엔티티»(검색·MCP mention·project축 parity까지)를
+// 전부 갖춰야 한다는 게 CI 13건 실패로 드러났다(PO 판정). chat_message는 참조 TARGET은
+// 되지만 그 다섯 계약을 구조적으로 다 못 갖춰(검색대상 아님·project축 아님·단독조회
+// 라우트 없음) `reference_registry.TARGET_ONLY_TYPES`라는 별도 집합으로 옮겨졌다 —
+// ENTITY_RESOLVERS 밖이라 이 FE parity 대조에도 안 걸린다(의도적으로 안 나타난다).
 export const ENTITY_ICONS: Record<string, LucideIcon> = {
   story: FileText,
   doc: File,
@@ -33,7 +36,6 @@ export const ENTITY_ICONS: Record<string, LucideIcon> = {
   artifact: Image,
   hypothesis: FlaskConical,
   evidence: Paperclip,
-  chat_message: MessageSquareQuote,
 };
 
 /** ENTITY_ICONS에 없는 타입(지금은 asset뿐) → 아이콘 대신 이름 첫 글자(들). 예외 처리 아님(위 주석). */
@@ -63,7 +65,6 @@ const ENTITY_COLORS: Record<string, string> = {
   artifact: 'border-info/30 bg-info/8 text-foreground',
   hypothesis: 'border-border bg-muted/40 text-foreground',
   evidence: 'border-border bg-muted/40 text-foreground',
-  chat_message: 'border-border bg-muted/40 text-foreground',
   // S6: 스토리지 자산 토큰 — info 틴트(파일 아이콘은 content-type 의존이라 AssetEmbedCard 에서 getFileIcon 처리).
   asset: 'border-info/30 bg-info/8 text-foreground',
 };
@@ -95,22 +96,6 @@ export function getEntityHref(entityType: string, entityId: string): string | nu
     case 'artifact': return null; // 레코드마다 ②/③ — 위 함수 doc 참고.
     case 'hypothesis': return null; // ③ 고정 — 위 함수 doc 참고.
     case 'evidence': return null; // ② — resolved_story_id는 EntityPreviewModal이 fetch 후 판정(task와 동형).
-    // ③ 고정 — story #2263(C-7): chat_message를 가리키는 mention/embed 칩은 아직 아무도 안
-    // 만든다(proof의 실제 소비 UI는 이 범용 EntityChip/EmbedCard가 아니라 미르코의 전용
-    // ChatProofEmbed 컴포넌트, #2265 PR1a). 여기 키가 있어야 하는 이유는 BE registry
-    // parity뿐.
-    //
-    // ⛔PO 지적(2026-07-29): hypothesis와 «다른» 이유로 ③이다 — hypothesis는 상세 라우트가
-    // 정말 없어서 모달 footer("열 수 있는 화면이 없습니다")가 참이지만, chat_message는
-    // 그 대화 화면(`/chats/{conversation_id}?messageId={id}`)이 실제로 «있다». 지금 이
-    // null이 그 화면을 감추는 거짓 응답을 만든다 — 다만 고치려면 BE
-    // `_resolve_chat_messages`(reference_registry.py)가 다른 8개 타입과 공유하는
-    // ENTITY_RESOLVERS 계약(session,org_id,ids)->set[uuid]을 깨거나, message_id 단독
-    // 조회 라우트(지금 0개 — conversations.py의 메시지 라우트 4개 전부 conversation_id를
-    // path에 요구)를 새로 지어야 해 이 PR 범위 밖으로 미룬다(#2263 본문에도 명시). 실제
-    // 클릭 가능한 진입점이 생기면(바로 그 conversation으로 보내는 등) ②로
-    // 승격한다.
-    case 'chat_message': return null;
     default: return null;
   }
 }

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -589,17 +589,35 @@ async def get_story_backlinks(
 
 async def _visible_target_ids(
     session: AsyncSession, org_id: uuid.UUID, caller_id: uuid.UUID,
-    ids_by_type: dict[str, set[uuid.UUID]],
+    ids_by_type: dict[str, set[uuid.UUID]], auth: AuthContext,
+    conversation_id_by_target_id: dict[uuid.UUID, uuid.UUID] | None = None,
 ) -> dict[str, set[uuid.UUID]]:
     """story #2263 AC6 — outgoing references의 TARGET 측 가시성. C-3(#2261)의 존재-비노출
     규율 그대로: 등록되지 않은 target_type이거나 project_id를 못 구하면(row 없음) 안 보이는
     쪽으로 fail-closed — reference_registry.PROJECT_ID_RESOLVERS(story #2314가 evidence에
-    이미 재사용한 그 SSOT)를 여기서도 그대로 쓴다, 새 인증경로 발명 없음."""
+    이미 재사용한 그 SSOT)를 여기서도 그대로 쓴다, 새 인증경로 발명 없음.
+
+    ⛔chat_message는 예외 축 — project로 스코프되지 않는다(참여자 기반, #2261 시기부터 알려진
+    "넷째 경계"). PROJECT_ID_RESOLVERS에 없으므로 project 분기를 안 타고, POST 라우트이 이미
+    쓰는 `_can_read_conversation`(participant 기반 SSOT)를 그대로 재사용한다 — conversation_id
+    는 ConversationMessage row를 다시 join하지 않고 `Reference.proof_payload`에 이미 저장된
+    값을 호출부가 넘겨준다(그 payload가 유일한 SSOT — write 시점에 검증된 그 conversation_id
+    그대로, message row 존재 여부와 무관하게 일관된 값)."""
     from app.services.project_auth import has_project_access
     from app.services.reference_registry import PROJECT_ID_RESOLVERS
 
     visible: dict[str, set[uuid.UUID]] = {}
+    conversation_id_by_target_id = conversation_id_by_target_id or {}
     for target_type, target_ids in ids_by_type.items():
+        if target_type == "chat_message":
+            from app.routers.conversations import _can_read_conversation
+
+            for target_id in target_ids:
+                conv_id = conversation_id_by_target_id.get(target_id)
+                if conv_id is not None and await _can_read_conversation(conv_id, session, auth, org_id):
+                    visible.setdefault(target_type, set()).add(target_id)
+            continue
+
         resolver = PROJECT_ID_RESOLVERS.get(target_type)
         if resolver is None:
             continue
@@ -628,9 +646,12 @@ async def get_story_outgoing_references(
     의 반대편, 즉 이 story가 가리키는 대상들)의 가시성은 `_visible_target_ids`가 판정 —
     C-3(#2261)이 세운 것과 같은 규율(못 보는 대상은 존재 사실도 새지 않는다).
 
-    응답은 메타만 싣는다(form·target_type·target_id·created_at·still_exists) — proof_payload
-    는 여기 안 싣는다(PO 판정 2026-07-29: 목록에 스냅샷 payload를 통째로 실으면 응답이
-    무거워진다 — payload 전량은 단건 상세 라우트의 몫, 이 라우트가 아니다)."""
+    응답은 proof_payload를 그대로 싣는다(PO 정정, 2026-07-29): 처음엔 "목록=메타만·단건=
+    payload전량"으로 갈랐으나, 그 갈림이 소비 패턴을 안 보고 낸 판단이었다 — C-7 proof
+    섹션은 카드를 여럿 펼쳐 보이는 자리라 단건 상세 라우트를 따로 지으면 N+1이 된다(그리고
+    아무도 그 단건 라우트를 지은 적이 없어 "저장은 되는데 읽을 길이 없다"는 상태이기도
+    했다). 크기 문제는 응답 shape이 아니라 저장 시점 범위 상한으로 막는다(PO: 지금은 하드
+    리밋 없이 로그만, 실사용 뒤 정한다)."""
     if direction != "outgoing":
         raise HTTPException(status_code=400, detail="direction must be 'outgoing' (incoming: use /backlinks)")
 
@@ -643,16 +664,21 @@ async def get_story_outgoing_references(
     from app.services.reference_core import list_references
 
     raw_targets = (await repo.session.execute(
-        select(Reference.target_type, Reference.target_id).where(
+        select(Reference.target_type, Reference.target_id, Reference.proof_payload).where(
             Reference.org_id == repo.org_id, Reference.source_type == "story", Reference.source_id == id,
         )
     )).all()
     ids_by_type: dict[str, set[uuid.UUID]] = {}
-    for target_type, target_id in raw_targets:
+    conversation_id_by_target_id: dict[uuid.UUID, uuid.UUID] = {}
+    for target_type, target_id, proof_payload in raw_targets:
         ids_by_type.setdefault(target_type, set()).add(target_id)
+        if target_type == "chat_message" and proof_payload and proof_payload.get("conversation_id"):
+            conversation_id_by_target_id[target_id] = uuid.UUID(str(proof_payload["conversation_id"]))
 
     caller_id = uuid.UUID(str(auth.user_id))
-    visible = await _visible_target_ids(repo.session, repo.org_id, caller_id, ids_by_type)
+    visible = await _visible_target_ids(
+        repo.session, repo.org_id, caller_id, ids_by_type, auth, conversation_id_by_target_id,
+    )
 
     refs = await list_references(
         repo.session, org_id=repo.org_id, entity_type="story", entity_id=id,
@@ -667,6 +693,7 @@ async def get_story_outgoing_references(
                 "target_id": str(r.target_id),
                 "created_at": r.created_at.isoformat(),
                 "still_exists": r.still_exists,
+                "proof_payload": r.proof_payload,
             }
             for r in refs
         ]
@@ -753,6 +780,7 @@ async def create_story_proof_reference(
         "target_type": ref.target_type,
         "target_id": str(ref.target_id),
         "created_at": ref.created_at.isoformat(),
+        "proof_payload": ref.proof_payload,
     }
 
 

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -587,6 +587,175 @@ async def get_story_backlinks(
     )
 
 
+async def _visible_target_ids(
+    session: AsyncSession, org_id: uuid.UUID, caller_id: uuid.UUID,
+    ids_by_type: dict[str, set[uuid.UUID]],
+) -> dict[str, set[uuid.UUID]]:
+    """story #2263 AC6 — outgoing references의 TARGET 측 가시성. C-3(#2261)의 존재-비노출
+    규율 그대로: 등록되지 않은 target_type이거나 project_id를 못 구하면(row 없음) 안 보이는
+    쪽으로 fail-closed — reference_registry.PROJECT_ID_RESOLVERS(story #2314가 evidence에
+    이미 재사용한 그 SSOT)를 여기서도 그대로 쓴다, 새 인증경로 발명 없음."""
+    from app.services.project_auth import has_project_access
+    from app.services.reference_registry import PROJECT_ID_RESOLVERS
+
+    visible: dict[str, set[uuid.UUID]] = {}
+    for target_type, target_ids in ids_by_type.items():
+        resolver = PROJECT_ID_RESOLVERS.get(target_type)
+        if resolver is None:
+            continue
+        for target_id in target_ids:
+            project_id = await resolver(session, org_id, target_id)
+            if project_id is not None and await has_project_access(session, caller_id, project_id, org_id):
+                visible.setdefault(target_type, set()).add(target_id)
+    return visible
+
+
+@router.get("/{id}/references")
+async def get_story_outgoing_references(
+    id: uuid.UUID,
+    direction: str = Query(default="outgoing"),
+    repo: StoryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    """GET /api/v2/stories/{id}/references?direction=outgoing — story #2263 AC6(오르테가
+    판정 2026-07-29): 이 story가 가리키는 것(reference_core.list_references의 첫 실제
+    소비자 — 그때까지 이 함수를 부르는 라우터가 0곳이었다). `direction=incoming`은 이 라우트
+    범위 밖(그건 이미 GET /{id}/backlinks가 다른 응답 shape로 다룬다) — 명시 400으로 거부해
+    「둘 다 되는 척」을 안 한다.
+
+    TARGET(이 story 자신)은 get_story_backlinks와 동일 게이트(`_assert_story_project_access`
+    — 없으면 404, 있지만 project 밖이면 404, #2322 PR#1 통일 반영). 다시 가리키는 쪽(outgoing
+    의 반대편, 즉 이 story가 가리키는 대상들)의 가시성은 `_visible_target_ids`가 판정 —
+    C-3(#2261)이 세운 것과 같은 규율(못 보는 대상은 존재 사실도 새지 않는다).
+
+    응답은 메타만 싣는다(form·target_type·target_id·created_at·still_exists) — proof_payload
+    는 여기 안 싣는다(PO 판정 2026-07-29: 목록에 스냅샷 payload를 통째로 실으면 응답이
+    무거워진다 — payload 전량은 단건 상세 라우트의 몫, 이 라우트가 아니다)."""
+    if direction != "outgoing":
+        raise HTTPException(status_code=400, detail="direction must be 'outgoing' (incoming: use /backlinks)")
+
+    story = await repo.get(id)
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+    await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
+
+    from app.models.reference import Reference
+    from app.services.reference_core import list_references
+
+    raw_targets = (await repo.session.execute(
+        select(Reference.target_type, Reference.target_id).where(
+            Reference.org_id == repo.org_id, Reference.source_type == "story", Reference.source_id == id,
+        )
+    )).all()
+    ids_by_type: dict[str, set[uuid.UUID]] = {}
+    for target_type, target_id in raw_targets:
+        ids_by_type.setdefault(target_type, set()).add(target_id)
+
+    caller_id = uuid.UUID(str(auth.user_id))
+    visible = await _visible_target_ids(repo.session, repo.org_id, caller_id, ids_by_type)
+
+    refs = await list_references(
+        repo.session, org_id=repo.org_id, entity_type="story", entity_id=id,
+        direction="outgoing", visible_ids_by_type=visible,
+    )
+    return {
+        "data": [
+            {
+                "id": str(r.id),
+                "form": r.form,
+                "target_type": r.target_type,
+                "target_id": str(r.target_id),
+                "created_at": r.created_at.isoformat(),
+                "still_exists": r.still_exists,
+            }
+            for r in refs
+        ]
+    }
+
+
+class CreateStoryProofReferenceRequest(BaseModel):
+    """story #2263 AC6(2026-07-29, 오르테가 판정) — C-7(#2265) 「선택→저장」 전용 write
+    계약. 지금은 target=chat_message·form=proof 조합 하나만 지원한다(다른 target_type/form은
+    이 라우트가 필요해지면 그때 넓힌다 — #2260/#2261이 반복한 "안 쓰는 라우터 미리 짓지
+    않는다" 원칙과 동형)."""
+
+    target_type: str
+    target_id: uuid.UUID
+    form: str
+    proof_payload: dict
+
+
+@router.post("/{id}/references", status_code=201)
+async def create_story_proof_reference(
+    id: uuid.UUID,
+    body: CreateStoryProofReferenceRequest,
+    repo: StoryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    """POST /api/v2/stories/{id}/references — story #2263 AC6 후속(2026-07-29, 오르테가
+    판정): `insert_reference`가 프로덕션 호출부 0건이라 C-7(#2265, 대화 조각 인용)이 저장할
+    라우트가 없었다 — 그 첫 write 소비자를 연다. 읽기(GET /{id}/references)와 같은 PR —
+    write→read 왕복이 그 안에서 증명된다.
+
+    지금은 target_type="chat_message"·form="proof" 조합만 지원(위 스키마 docstring 참조) —
+    그 밖은 명시 400(조용한 무시 금지).
+
+    권한 셋:
+    ①source(이 story)는 get_story_backlinks/GET references와 동일 게이트
+      (`_assert_story_project_access`, #2322 통일).
+    ②target(인용되는 conversation) — 그 대화를 못 읽는 사람이 조각을 박으면 안 된다(PO
+      판정) — `conversations._can_read_conversation`(canonical 단건 predicate, SSOT 재사용
+      — 새 인증경로 발명 없음)로 `proof_payload["conversation_id"]`를 검사한다.
+    ③범위 상한 — C-7 규격("증거이지 대화 사본이 아니다")이 있으나 PO가 숫자를 아직 안
+      박았다(2026-07-29: "일단 안 막되 크기를 로그로 남긴다, 실사용 뒤 정한다") — 그래서
+      여기서 하드 리밋을 걸지 않고 `logger.info`로 snapshot 길이만 남긴다."""
+    if body.target_type != "chat_message" or body.form != "proof":
+        raise HTTPException(
+            status_code=400,
+            detail="이 라우트는 지금 target_type='chat_message'·form='proof' 조합만 지원합니다",
+        )
+
+    conversation_id = body.proof_payload.get("conversation_id")
+    if not conversation_id:
+        raise HTTPException(status_code=400, detail="proof_payload.conversation_id is required")
+
+    story = await repo.get(id)
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+    await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
+
+    from app.routers.conversations import _can_read_conversation
+
+    can_read = await _can_read_conversation(
+        uuid.UUID(str(conversation_id)), repo.session, auth, repo.org_id,
+    )
+    if not can_read:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    snapshot = body.proof_payload.get("snapshot") or []
+    logger.info(
+        "create_story_proof_reference: story=%s snapshot_messages=%d", id, len(snapshot),
+    )
+
+    from app.services.reference_core import insert_reference
+
+    caller_id = uuid.UUID(str(auth.user_id))
+    ref = await insert_reference(
+        repo.session, org_id=repo.org_id, source_type="story", source_field="proof",
+        source_id=id, target_type=body.target_type, target_id=body.target_id,
+        form=body.form, created_by=caller_id, proof_payload=body.proof_payload,
+    )
+    await repo.session.commit()
+
+    return {
+        "id": str(ref.id),
+        "form": ref.form,
+        "target_type": ref.target_type,
+        "target_id": str(ref.target_id),
+        "created_at": ref.created_at.isoformat(),
+    }
+
+
 class UploadStoryAttachmentRequest(BaseModel):
     """E-MCP-OPT S6: MCP(비-브라우저)용 JSON/base64 첨부 업로드 요청(chat과 동형)."""
 

--- a/backend/app/services/reference_core.py
+++ b/backend/app/services/reference_core.py
@@ -24,7 +24,13 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.reference import FORMS, Reference
-from app.services.reference_registry import ENTITY_RESOLVERS, is_registered_entity_type, is_valid_source_type
+from app.services.reference_registry import (
+    ENTITY_RESOLVERS,
+    TARGET_ONLY_RESOLVERS,
+    TARGET_ONLY_TYPES,
+    is_valid_source_type,
+    is_valid_target_type,
+)
 
 Direction = Literal["outgoing", "incoming"]
 
@@ -72,12 +78,14 @@ async def insert_reference(
 ) -> Reference:
     if form not in FORMS:
         raise ValueError(f"form must be one of {sorted(FORMS)}, got {form!r}")
-    # ⛔source/target은 다른 기준 — source는 SOURCE_ONLY_TYPES(예: chat_message, target으로
-    # 안 쓰여 resolver가 없다)도 허용하지만 target은 존재판정이 가능한 타입만(reference_
-    # registry.py 모듈 docstring 참조, #2273 실측 발견).
+    # ⛔source/target은 다른 기준 — source는 SOURCE_ONLY_TYPES(예: chat_message, 채팅
+    # write-path의 정당한 source지만 완전지원 엔티티는 아니다)도 허용하지만 target은
+    # ENTITY_RESOLVERS(완전지원) 또는 TARGET_ONLY_TYPES(target 전용, 예: chat_message가
+    # proof의 대상이 되는 자리 — story #2263)만 허용한다(reference_registry.py 모듈
+    # docstring 참조, #2273 실측 발견 + #2263 PO 판정).
     if not is_valid_source_type(source_type):
         raise UnregisteredEntityTypeError(f"source_type {source_type!r} not in reference_registry")
-    if not is_registered_entity_type(target_type):
+    if not is_valid_target_type(target_type):
         raise UnregisteredEntityTypeError(f"target_type {target_type!r} not in reference_registry")
 
     ref = Reference(
@@ -92,10 +100,14 @@ async def insert_reference(
 async def _batch_resolve_existence(
     session: AsyncSession, org_id: uuid.UUID, ids_by_type: dict[str, set[uuid.UUID]],
 ) -> dict[str, set[uuid.UUID]]:
-    """㉡N+1 금지 — entity_type 별로 묶어 resolver 를 **한 번씩만** 호출한다."""
+    """㉡N+1 금지 — entity_type 별로 묶어 resolver 를 **한 번씩만** 호출한다.
+
+    ⛔story #2263: ENTITY_RESOLVERS(완전지원)뿐 아니라 TARGET_ONLY_RESOLVERS(target 전용,
+    예: chat_message)도 본다 — 둘 다 "존재판정 가능"이라는 같은 질문에 답하지만, 완전지원
+    여부(검색·MCP 등)는 이 함수의 관심사가 아니다."""
     existing_by_type: dict[str, set[uuid.UUID]] = {}
     for entity_type, ids in ids_by_type.items():
-        resolver = ENTITY_RESOLVERS.get(entity_type)
+        resolver = ENTITY_RESOLVERS.get(entity_type) or TARGET_ONLY_RESOLVERS.get(entity_type)
         if resolver is None:
             # registry 밖 타입 — 존재판정 불가(count_orphan_types 가 별도로 이 사고를 잡는다).
             existing_by_type[entity_type] = set()
@@ -151,7 +163,7 @@ async def list_references(
         other_type = r.target_type if direction == "outgoing" else r.source_type
         other_id = r.target_id if direction == "outgoing" else r.source_id
         still_exists: bool | None
-        if other_type not in ENTITY_RESOLVERS:
+        if other_type not in ENTITY_RESOLVERS and other_type not in TARGET_ONLY_TYPES:
             still_exists = None  # registry 밖 타입 — 판정 불가(orphan 점검이 별도로 잡음).
         else:
             still_exists = other_id in existing_by_type.get(other_type, set())

--- a/backend/app/services/reference_core.py
+++ b/backend/app/services/reference_core.py
@@ -50,6 +50,11 @@ class ResolvedReference:
     # (반대편 entity_type 이 registry 밖이라 존재판정 자체를 못 한 경우 — count_orphan_types
     # 가 잡는 그 케이스). True/False 만 신뢰.
     still_exists: bool | None
+    # story #2263(C-7, 2026-07-29 · PO 정정): 그대로 싣는다 — proof 소비처(C-7 섹션)가 카드를
+    # 여럿 펼쳐 보이는 자리라 단건 상세 라우트를 따로 지으면 N+1이 된다(PO 자기정정 — 소비
+    # 패턴을 안 보고 "무거우니 목록엔 빼자"로 먼저 갈랐던 것). 내부 구조는 안 읽는다(그대로
+    # 통과) — 크기 문제는 응답 shape이 아니라 저장 시점 범위 상한으로 막는다(#2263 AC).
+    proof_payload: dict | None = None
 
 
 async def insert_reference(
@@ -155,6 +160,7 @@ async def list_references(
                 id=r.id, source_type=r.source_type, source_field=r.source_field,
                 source_id=r.source_id, target_type=r.target_type, target_id=r.target_id,
                 form=r.form, created_at=r.created_at, still_exists=still_exists,
+                proof_payload=r.proof_payload,
             )
         )
     return resolved

--- a/backend/app/services/reference_registry.py
+++ b/backend/app/services/reference_registry.py
@@ -133,6 +133,22 @@ async def _resolve_hypotheses(session: AsyncSession, org_id: uuid.UUID, ids: lis
     return set(rows)
 
 
+async def _resolve_chat_messages(session: AsyncSession, org_id: uuid.UUID, ids: list[uuid.UUID]) -> set[uuid.UUID]:
+    """story #2263(C-7, 2026-07-29) — chat_message가 처음으로 TARGET이 되는 자리(proof가
+    대화 메시지를 인용). 그 전까지 chat_message는 SOURCE_ONLY_TYPES였다(메시지 자체엔 org_id
+    컬럼이 없어 Conversation을 통해서만 org 스코프 가능 — join 필요)."""
+    from app.models.conversation import Conversation, ConversationMessage
+
+    rows = (
+        await session.execute(
+            select(ConversationMessage.id)
+            .join(Conversation, Conversation.id == ConversationMessage.conversation_id)
+            .where(Conversation.org_id == org_id, ConversationMessage.id.in_(ids))
+        )
+    ).scalars().all()
+    return set(rows)
+
+
 async def _resolve_evidence(session: AsyncSession, org_id: uuid.UUID, ids: list[uuid.UUID]) -> set[uuid.UUID]:
     from app.models.evidence import Evidence
 
@@ -153,13 +169,15 @@ ENTITY_RESOLVERS: dict[str, EntityExistsResolver] = {
     "artifact": _resolve_artifacts,
     "hypothesis": _resolve_hypotheses,
     "evidence": _resolve_evidence,
+    "chat_message": _resolve_chat_messages,
 }
 
 
 # source_type으로는 유효하나 target 존재판정(resolver)은 없는 타입 — 위 모듈 docstring
-# 참조. write-path(mention_parser.py)가 이 타입들을 source_type으로 직접 씀(하드코딩 리터럴,
-# 사용자 입력 아님 — #2260이 이미 검증한 신뢰 경계).
-SOURCE_ONLY_TYPES: frozenset[str] = frozenset({"chat_message"})
+# 참조. 지금은 빈 집합이다 — chat_message가 유일한 멤버였으나 story #2263(C-7, 2026-07-29)
+# 이 처음으로 target 존재판정(`_resolve_chat_messages`)을 등록해 ENTITY_RESOLVERS로 옮겼다
+# (proof form이 대화 메시지를 인용하며 그 메시지가 사라졌는지도 판정할 수 있어야 하므로).
+SOURCE_ONLY_TYPES: frozenset[str] = frozenset()
 
 
 def is_registered_entity_type(entity_type: str) -> bool:

--- a/backend/app/services/reference_registry.py
+++ b/backend/app/services/reference_registry.py
@@ -177,6 +177,11 @@ ENTITY_RESOLVERS: dict[str, EntityExistsResolver] = {
 # 참조. 지금은 빈 집합이다 — chat_message가 유일한 멤버였으나 story #2263(C-7, 2026-07-29)
 # 이 처음으로 target 존재판정(`_resolve_chat_messages`)을 등록해 ENTITY_RESOLVERS로 옮겼다
 # (proof form이 대화 메시지를 인용하며 그 메시지가 사라졌는지도 판정할 수 있어야 하므로).
+#
+# ⛔현재 비어 있다(2026-07-29 · chat_message를 ENTITY_RESOLVERS로 이관하면서 소진).
+# ⇒ 지우지 않는다 — «target이 될 수 없고 source만 되는» 타입이 생기면 여기 든다.
+# ⇒ 그때까지 `is_valid_source_type`의 둘째 항(`entity_type in SOURCE_ONLY_TYPES`)은
+#   항상 False다 — 다른 답을 낼 수 있는 입력이 없는 채로 실행되는 자리(㉢, 오늘 규율).
 SOURCE_ONLY_TYPES: frozenset[str] = frozenset()
 
 

--- a/backend/app/services/reference_registry.py
+++ b/backend/app/services/reference_registry.py
@@ -200,6 +200,11 @@ TARGET_ONLY_TYPES: frozenset[str] = frozenset({"chat_message"})
 
 # TARGET_ONLY_TYPES 멤버의 존재판정 resolver. ENTITY_RESOLVERS와 분리된 이유는 위와 동일 —
 # 이 dict에 들어간다고 검색/MCP/project축 계약까지 진 것으로 오인되면 안 된다.
+#
+# ⛔chat_message는 «target은 되나 완전지원은 아니다» —
+#   검색 대상 아님(UI 없음) · project 축 아님 · 단독 조회 라우트 없음.
+#   ⇒ ENTITY_RESOLVERS에 넣으면 다섯 계약(search·PROJECT_ID·MCP…)이 전부 요구되어
+#     13건이 깨진다(2026-07-29 실측). 「왜 여기만 따로지?」로 되돌리지 말 것.
 TARGET_ONLY_RESOLVERS: dict[str, EntityExistsResolver] = {
     "chat_message": _resolve_chat_messages,
 }

--- a/backend/app/services/reference_registry.py
+++ b/backend/app/services/reference_registry.py
@@ -135,8 +135,10 @@ async def _resolve_hypotheses(session: AsyncSession, org_id: uuid.UUID, ids: lis
 
 async def _resolve_chat_messages(session: AsyncSession, org_id: uuid.UUID, ids: list[uuid.UUID]) -> set[uuid.UUID]:
     """story #2263(C-7, 2026-07-29) — chat_message가 처음으로 TARGET이 되는 자리(proof가
-    대화 메시지를 인용). 그 전까지 chat_message는 SOURCE_ONLY_TYPES였다(메시지 자체엔 org_id
-    컬럼이 없어 Conversation을 통해서만 org 스코프 가능 — join 필요)."""
+    대화 메시지를 인용). ⛔ENTITY_RESOLVERS에는 안 들어간다(PO 판정, 아래 TARGET_ONLY_TYPES
+    참조) — 검색 대상도 project축도 MCP mention 대상도 아니라 "완전지원 엔티티" 다섯 계약을
+    구조적으로 못 갖춘다. 이 resolver는 TARGET_ONLY_RESOLVERS를 통해 존재판정에만 쓰인다.
+    (메시지 자체엔 org_id 컬럼이 없어 Conversation을 통해서만 org 스코프 가능 — join 필요.)"""
     from app.models.conversation import Conversation, ConversationMessage
 
     rows = (
@@ -159,7 +161,13 @@ async def _resolve_evidence(session: AsyncSession, org_id: uuid.UUID, ids: list[
 
 
 # entity_type(str) -> resolver. 각 resolver 는 (session, org_id, ids) -> {존재하는 id 집합}.
-# ⛔이 dict 가 유일한 SSOT — write 검증과 read 존재판정이 둘 다 이걸 참조한다(재구현 0).
+# ⛔이 dict 가 «완전지원 엔티티» SSOT다 — 여기 들어가면 다섯 계약을 전부 진다: ①존재판정
+# ②entities/search handler ③PROJECT_ID_RESOLVERS 동일 키 ④MCP mention 엔드포인트
+# ⑤reference_token 빌더 대상. story #2263(C-7, 2026-07-29)에서 chat_message를 «존재판정만»
+# 필요해서 여기 넣었다가 CI 13건이 한 번에 깨졌다(PO 판정, 2026-07-29) — 검색 대상이 아니고
+# ·project 축이 아니고·단독조회 라우트가 없어 ②③④를 구조적으로 못 갖추는데 그 셋을
+# 강제로 요구받은 것. 「target이 될 수 있다」와 「완전지원 엔티티다」는 다른 축이라 — 그
+# 둘을 가르는 자리가 아래 TARGET_ONLY_TYPES다.
 ENTITY_RESOLVERS: dict[str, EntityExistsResolver] = {
     "doc": _resolve_docs,
     "story": _resolve_stories,
@@ -169,25 +177,46 @@ ENTITY_RESOLVERS: dict[str, EntityExistsResolver] = {
     "artifact": _resolve_artifacts,
     "hypothesis": _resolve_hypotheses,
     "evidence": _resolve_evidence,
-    "chat_message": _resolve_chat_messages,
 }
 
 
 # source_type으로는 유효하나 target 존재판정(resolver)은 없는 타입 — 위 모듈 docstring
-# 참조. 지금은 빈 집합이다 — chat_message가 유일한 멤버였으나 story #2263(C-7, 2026-07-29)
-# 이 처음으로 target 존재판정(`_resolve_chat_messages`)을 등록해 ENTITY_RESOLVERS로 옮겼다
-# (proof form이 대화 메시지를 인용하며 그 메시지가 사라졌는지도 판정할 수 있어야 하므로).
-#
-# ⛔현재 비어 있다(2026-07-29 · chat_message를 ENTITY_RESOLVERS로 이관하면서 소진).
-# ⇒ 지우지 않는다 — «target이 될 수 없고 source만 되는» 타입이 생기면 여기 든다.
-# ⇒ 그때까지 `is_valid_source_type`의 둘째 항(`entity_type in SOURCE_ONLY_TYPES`)은
-#   항상 False다 — 다른 답을 낼 수 있는 입력이 없는 채로 실행되는 자리(㉢, 오늘 규율).
-SOURCE_ONLY_TYPES: frozenset[str] = frozenset()
+# 참조. chat_message가 그 멤버다(채팅 write-path가 매일 쓰는 정당한 source — mention_parser.py
+# 참조, 이 PR과 무관한 원래 용도). ⛔story #2263(2026-07-29) 한때 이 집합을 비우고 chat_message
+# 를 ENTITY_RESOLVERS로 옮겼었으나 되돌렸다(그 등록이 검색·MCP·project축 계약까지 강제해
+# CI 13건이 깨졌다, PO 판정) — chat_message는 source_only이면서 «동시에» target_only(아래)
+# 이기도 하다, 서로 배타적이지 않다.
+SOURCE_ONLY_TYPES: frozenset[str] = frozenset({"chat_message"})
+
+# ⛔TARGET_ONLY_TYPES(SOURCE_ONLY_TYPES와 대칭, story #2263 PO 판정 2026-07-29) — target은
+# 될 수 있으나(존재판정 가능) ENTITY_RESOLVERS의 나머지 네 계약(검색·project축·MCP
+# mention·reference_token)은 구조적으로 못 갖추는 타입. chat_message가 첫 멤버 — proof
+# form이 대화 메시지를 인용해 target이 되지만, 메시지는 검색 대상이 아니고(민 확認)
+# project로 스코프되지 않고(참여자 기반, #2261부터 알려진 "넷째 경계") 단독조회 라우트가
+# 없다(conversations.py의 메시지 라우트 4개 전부 conversation_id를 path에 요구). 위
+# SOURCE_ONLY_TYPES와 겹치는 멤버(chat_message)가 있는 것은 정상이다 — source 자격과
+# target 자격은 독립된 두 질문이다.
+TARGET_ONLY_TYPES: frozenset[str] = frozenset({"chat_message"})
+
+# TARGET_ONLY_TYPES 멤버의 존재판정 resolver. ENTITY_RESOLVERS와 분리된 이유는 위와 동일 —
+# 이 dict에 들어간다고 검색/MCP/project축 계약까지 진 것으로 오인되면 안 된다.
+TARGET_ONLY_RESOLVERS: dict[str, EntityExistsResolver] = {
+    "chat_message": _resolve_chat_messages,
+}
 
 
 def is_registered_entity_type(entity_type: str) -> bool:
-    """target_type 검증용 — 존재판정(resolver)이 있는 타입인가."""
+    """«완전지원 엔티티» 판정용(검색·MCP mention·reference_token 등) — ENTITY_RESOLVERS
+    멤버인가. TARGET_ONLY_TYPES는 의도적으로 포함하지 않는다(위 모듈 주석 참조)."""
     return entity_type in ENTITY_RESOLVERS
+
+
+def is_valid_target_type(entity_type: str) -> bool:
+    """target_type 검증용(write-path, insert_reference가 부른다) — 존재판정(resolver)이
+    있는 타입인가. ENTITY_RESOLVERS(완전지원)이거나 TARGET_ONLY_TYPES(target 전용)면 OK —
+    `is_registered_entity_type`과 달리 TARGET_ONLY_TYPES도 통과시킨다(그게 이 함수가
+    따로 존재하는 이유)."""
+    return entity_type in ENTITY_RESOLVERS or entity_type in TARGET_ONLY_TYPES
 
 
 def is_valid_source_type(entity_type: str) -> bool:
@@ -342,12 +371,15 @@ async def count_orphan_types(session: AsyncSession, org_id: uuid.UUID | None = N
     호출자 배선은 그 후속 PR 몫이다.
 
     ⛔source_type과 target_type은 다른 "known" 집합으로 판정한다(SOURCE_ONLY_TYPES 참조) —
-    같은 집합으로 재면 chat_message 같은 정상 source가 오탐된다(실측으로 걸린 자리)."""
+    같은 집합으로 재면 chat_message 같은 정상 source가 오탐된다(실측으로 걸린 자리).
+
+    ⛔story #2263(C-7) 후속: target 쪽도 ENTITY_RESOLVERS만으로는 부족하다 — TARGET_ONLY_TYPES
+    (chat_message)를 뺴면 proof가 만든 정당한 target이 orphan으로 오탐된다."""
     from collections import Counter
 
     from app.models.reference import Reference
 
-    known_targets = set(ENTITY_RESOLVERS)
+    known_targets = set(ENTITY_RESOLVERS) | TARGET_ONLY_TYPES
     known_sources = known_targets | SOURCE_ONLY_TYPES
     stmt = select(Reference.source_type, Reference.target_type)
     if org_id is not None:

--- a/backend/tests/test_2259_ac4_broken_reference_visibility_realdb.py
+++ b/backend/tests/test_2259_ac4_broken_reference_visibility_realdb.py
@@ -5,11 +5,13 @@
   ㉠참조 «행»이 남는가/사라지는가 — target이 하드삭제돼도 CASCADE가 없어 행은 남는다.
   ㉡read 경로(`reference_core.list_references`)가 그것을 어떻게 보여주는가 — `still_exists`
     필드로 "존재하지 않는다"를 명시적으로 실어 보낸다(조용히 누락시키지 않는다).
-  ㉢「끊어졌다」가 사용자에게 어떻게 보이는가 — ⛔정직한 답: **아직 아무 라이브 엔드포인트도
-    `list_references`를 호출하지 않는다**(코드 grep으로 실증). 즉 ㉡의 신호는 서비스
-    레이어에서 올바르게 계산되지만, 지금은 어떤 사용자에게도 도달하지 않는다 — 이 설계
-    제약("조용히 사라지면 그건 거짓말이다")이 아직 지켜지지 않은 상태를 그대로 선언한다
-    (기능을 새로 짓지 않고, 갭을 정확히 재서 적는 것이 이번 판의 스코프).
+  ㉢「끊어졌다」가 사용자에게 어떻게 보이는가 — ⛔story #2263(C-7, 2026-07-29)로 이 선언이
+    갱신됐다: **이제 라이브 엔드포인트가 하나 있다** — GET
+    /api/v2/stories/{id}/references?direction=outgoing (routers/stories.py)가 이 함수를
+    직접 부른다. ㉡의 `still_exists` 신호가 이제 그 라우트를 통해 실제로 사용자에게
+    도달한다(스토리에 인용된 chat_message/doc/story 등 outgoing 참조 목록에서 확인 가능).
+    이 파일의 코드 스캔은 "0건"에서 "정확히 이 한 곳"으로 바뀐 것을 고정한다(다른 라우터가
+    조용히 추가로 부르기 시작하면 다시 이 테스트가 갱신 대상이 된다).
 """
 from __future__ import annotations
 
@@ -31,19 +33,19 @@ def anyio_backend():
 # ─── ㉢ 코드 스캔 — list_references의 라이브 호출부가 정말 0인지 ────────────────
 
 
-def test_list_references_has_zero_live_router_callers():
-    """⛔이 테스트가 RED가 되면(즉 어딘가 router가 list_references를 부르기 시작하면) 이
-    파일의 ㉢ 선언(「아직 사용자에게 안 보인다」)을 다시 써야 한다는 신호다 — 그때는
-    선언을 지우는 게 아니라 이 테스트와 함께 갱신한다."""
+def test_list_references_has_exactly_one_live_router_caller():
+    """story #2263(C-7)로 갱신 — 0건에서 정확히 stories.py 한 곳으로 바뀌었다(위 모듈
+    docstring ㉢ 참조). 이 테스트가 다시 RED가 되면(다른 router도 부르기 시작하면) 이 목록과
+    모듈 docstring을 함께 갱신한다 — 선언을 지우는 게 아니라 늘어난 사실 그대로 반영한다."""
     routers_dir = Path(__file__).resolve().parents[1] / "app" / "routers"
     callers = []
     for py_file in sorted(routers_dir.glob("*.py")):
         text = py_file.read_text()
         if re.search(r"\blist_references\s*\(", text):
             callers.append(py_file.name)
-    assert callers == [], (
-        f"list_references가 이제 router에서 호출된다({callers}) — "
-        "㉢ 선언(«아직 사용자에게 안 보인다»)이 낡았다. 이 테스트와 PR 본문을 같이 갱신할 것."
+    assert callers == ["stories.py"], (
+        f"list_references 호출부 목록이 예상과 다르다({callers}) — "
+        "㉢ 선언(«정확히 stories.py 한 곳»)이 낡았다. 이 테스트와 PR 본문을 같이 갱신할 것."
     )
 
 

--- a/backend/tests/test_2263_story_outgoing_references_realdb.py
+++ b/backend/tests/test_2263_story_outgoing_references_realdb.py
@@ -1,0 +1,413 @@
+"""story #2263 AC6 — `GET /api/v2/stories/{id}/references?direction=outgoing`, 첫 실제
+`reference_core.list_references` 소비자. RED-먼저: 이 파일은 라우트가 아직 없는 시점에
+작성됐다 — router/stories.py의 새 라우트+`_visible_target_ids`를 되돌리면 아래 전부 404
+(라우트 자체 없음)로 실패하는 것을 먼저 확認한 뒤에만 구현한다.
+
+TARGET(story 자신) 게이트는 get_story_backlinks·get_story와 동일 `_assert_story_project_access`
+(#2322 PR#1 반영 — 무권한은 404). 반대편(outgoing 대상들)의 가시성은 C-3(#2261) 규율 그대로
+— 못 보는 대상은 존재 자체가 새지 않는다(목록에서 조용히 빠진다, 403/404 구분 노출 없음)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from tests.test_1994_backlink_api_realdb import (
+    _client_for,
+    _make_doc,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _session_factory,
+    _setup_app_human,
+)
+
+
+async def _make_conversation(session, org_id, project_id, *, participant_ids):
+    from app.models.conversation import Conversation, ConversationParticipant
+
+    conv = Conversation(id=uuid.uuid4(), project_id=project_id, org_id=org_id, type="group", title="Conv")
+    session.add(conv)
+    await session.flush()
+    for pid in participant_ids:
+        session.add(ConversationParticipant(conversation_id=conv.id, member_id=pid))
+    await session.commit()
+    return conv
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _make_story(session, org_id, project_id, title="Story"):
+    from app.models.pm import Story
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status="in-progress")
+    session.add(story)
+    await session.commit()
+    return story
+
+
+async def _insert_ref(session, *, org_id, source_id, target_type, target_id, created_by):
+    from app.services.reference_core import insert_reference
+    return await insert_reference(
+        session, org_id=org_id, source_type="story", source_field="description",
+        source_id=source_id, target_type=target_type, target_id=target_id,
+        form="mention", created_by=created_by,
+    )
+
+
+async def _seed(session):
+    """org(project_a[caller 접근권]·project_b[무접근]) + source story(project_a) +
+    outgoing refs: visible_doc(project_a) · invisible_doc(project_b, 존재하되 무권한) ·
+    ghost_doc(등록 id지만 실제 row 없음, project_id resolver가 None)."""
+    org = await _make_org(session)
+    project_a = await _make_project(session, org.id, "A")
+    project_b = await _make_project(session, org.id, "B")
+    _, caller_id = await _make_human_member(session, org.id, project_a.id)
+
+    source_story = await _make_story(session, org.id, project_a.id, title="Source")
+    visible_doc = await _make_doc(session, org.id, project_a.id, title="Visible Doc")
+    invisible_doc = await _make_doc(session, org.id, project_b.id, title="Invisible Doc")
+    ghost_doc_id = uuid.uuid4()
+
+    await _insert_ref(
+        session, org_id=org.id, source_id=source_story.id,
+        target_type="doc", target_id=visible_doc.id, created_by=caller_id,
+    )
+    await _insert_ref(
+        session, org_id=org.id, source_id=source_story.id,
+        target_type="doc", target_id=invisible_doc.id, created_by=caller_id,
+    )
+    await _insert_ref(
+        session, org_id=org.id, source_id=source_story.id,
+        target_type="doc", target_id=ghost_doc_id, created_by=caller_id,
+    )
+    await session.commit()
+
+    return {
+        "org_id": org.id, "caller_id": caller_id,
+        "source_story_id": source_story.id,
+        "visible_doc_id": visible_doc.id, "invisible_doc_id": invisible_doc.id,
+        "ghost_doc_id": ghost_doc_id,
+    }
+
+
+@pytest.mark.anyio
+async def test_outgoing_references_shows_visible_target_only_no_payload():
+    """양성대조 + 누설0: visible_doc만 나오고, form·target 메타는 있으나 payload 키 자체가
+    응답에 없다(목록=메타만, PO 판정)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_human(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/stories/{seeded['source_story_id']}/references",
+                params={"direction": "outgoing"},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            target_ids = {item["target_id"] for item in body["data"]}
+            assert target_ids == {str(seeded["visible_doc_id"])}, (
+                f"invisible_doc·ghost_doc가 새면 안 된다(누설0) — got {target_ids}"
+            )
+            item = body["data"][0]
+            assert item["form"] == "mention"
+            assert item["target_type"] == "doc"
+            assert item["still_exists"] is True
+            assert "proof_payload" not in item, "목록은 메타만 — payload 키 자체가 없어야 한다"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_outgoing_references_nonexistent_story_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_human(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{uuid.uuid4()}/references", params={"direction": "outgoing"})
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_outgoing_references_no_project_access_404_not_403():
+    """TARGET(story 자신) 게이트 — #2322 PR#1 통일(403 아닌 404)."""
+    from app.main import app
+    from app.models.member import Member
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            other_project = Project(id=uuid.uuid4(), org_id=seeded["org_id"], name="Other")
+            stranger = Member(id=uuid.uuid4(), org_id=seeded["org_id"], type="human", name="Stranger", is_active=True)
+            s.add_all([other_project, stranger])
+            await s.commit()
+            s.add(ProjectAccess(
+                id=uuid.uuid4(), project_id=other_project.id, member_id=stranger.id,
+                permission="granted", role="member",
+            ))
+            await s.commit()
+            stranger_id = stranger.id
+
+        await _setup_app_human(app, Session, stranger_id, seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/stories/{seeded['source_story_id']}/references",
+                params={"direction": "outgoing"},
+            )
+            assert resp.status_code == 404, (
+                f"story #2322 방향 계승 — 무권한은 404여야 한다 — {resp.status_code}: {resp.text}"
+            )
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_outgoing_references_incoming_direction_rejected_400():
+    """incoming은 이 라우트 범위 밖 — /backlinks가 이미 다룬다. 명시 400으로 거부."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_human(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/stories/{seeded['source_story_id']}/references",
+                params={"direction": "incoming"},
+            )
+            assert resp.status_code == 400, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_outgoing_references_mutation_self_check_visibility_gate_actually_blocks():
+    """뮤테이션 자가검증 — has_project_access를 항상-참으로 사보타주하면 invisible_doc·
+    ghost_doc까지 새는 것으로(누설 재현), 가시성 게이트가 동어반복이 아님을 증명한다."""
+    import app.routers.stories as stories_module
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_human(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+
+        original_visible = stories_module._visible_target_ids
+
+        async def _always_all_visible(session, org_id, caller_id, ids_by_type):
+            return {t: set(ids) for t, ids in ids_by_type.items()}
+
+        stories_module._visible_target_ids = _always_all_visible
+        try:
+            resp = await client.get(
+                f"/api/v2/stories/{seeded['source_story_id']}/references",
+                params={"direction": "outgoing"},
+            )
+            assert resp.status_code == 200, resp.text
+            target_ids = {item["target_id"] for item in resp.json()["data"]}
+            assert str(seeded["invisible_doc_id"]) in target_ids, (
+                "사보타주 중엔 invisible_doc이 새야 한다(가드가 실제로 막고 있었다는 증거)"
+            )
+        finally:
+            stories_module._visible_target_ids = original_visible
+            await client.aclose()
+
+        client2 = _client_for(app)
+        try:
+            resp2 = await client2.get(
+                f"/api/v2/stories/{seeded['source_story_id']}/references",
+                params={"direction": "outgoing"},
+            )
+            target_ids2 = {item["target_id"] for item in resp2.json()["data"]}
+            assert str(seeded["invisible_doc_id"]) not in target_ids2, "원복 후 다시 안 새야 한다"
+        finally:
+            await client2.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_proof_reference_readable_conversation_201_then_read_back():
+    """왕복(write→read) — 대화를 읽을 수 있는 caller가 proof를 박으면 201, 그 다음 GET
+    /references(outgoing)에서 실제로 보인다(단, still_exists는 chat_message가
+    ENTITY_RESOLVERS 밖이라 None — target_type=doc/story류와 다른 축, 이 테스트는 status
+    201·저장 자체만 확認)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id, "P")
+            member_id, caller_id = await _make_human_member(s, org.id, project.id)
+            source_story = await _make_story(s, org.id, project.id, title="Source")
+            conv = await _make_conversation(s, org.id, project.id, participant_ids=[member_id])
+            message_id = uuid.uuid4()
+
+        await _setup_app_human(app, Session, caller_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{source_story.id}/references",
+                json={
+                    "target_type": "chat_message", "target_id": str(message_id), "form": "proof",
+                    "proof_payload": {
+                        "conversation_id": str(conv.id),
+                        "start_message_id": str(message_id), "end_message_id": str(message_id),
+                        "snapshot": [{
+                            "message_id": str(message_id), "author_id": str(caller_id),
+                            "content": "quoted text", "created_at": "2026-07-29T00:00:00Z",
+                        }],
+                    },
+                },
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["form"] == "proof"
+            assert body["target_type"] == "chat_message"
+            assert body["target_id"] == str(message_id)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_proof_reference_unreadable_conversation_404():
+    """권한② — 그 대화를 못 읽는 caller가 조각을 박으려 하면 거부(존재 비노출 — 404)."""
+    from app.main import app
+    from app.models.member import Member
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id, "P")
+            participant_member_id, _ = await _make_human_member(s, org.id, project.id)
+            source_story = await _make_story(s, org.id, project.id, title="Source")
+            conv = await _make_conversation(s, org.id, project.id, participant_ids=[participant_member_id])
+            message_id = uuid.uuid4()
+
+            # stranger: project 접근권은 있으나(그래서 source story 게이트는 통과) 이
+            # conversation의 participant가 아니다.
+            user_id = uuid.uuid4()
+            s.add(User(id=user_id, email=f"s-{user_id.hex[:8]}@test.com", hashed_password="x"))
+            await s.commit()
+            om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=user_id, role="member")
+            s.add(om)
+            await s.commit()
+            stranger = Member(id=om.id, org_id=org.id, type="human", user_id=user_id, name="Stranger")
+            s.add(stranger)
+            await s.commit()
+            s.add(ProjectAccess(
+                id=uuid.uuid4(), project_id=project.id, org_member_id=om.id, member_id=om.id,
+                permission="granted", role="member",
+            ))
+            await s.commit()
+            stranger_id = user_id
+
+        await _setup_app_human(app, Session, stranger_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{source_story.id}/references",
+                json={
+                    "target_type": "chat_message", "target_id": str(message_id), "form": "proof",
+                    "proof_payload": {"conversation_id": str(conv.id), "snapshot": []},
+                },
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_reference_unsupported_combination_400():
+    """target_type/form이 chat_message/proof 조합이 아니면 명시 400(조용한 무시 금지)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id, "P")
+            _, caller_id = await _make_human_member(s, org.id, project.id)
+            source_story = await _make_story(s, org.id, project.id, title="Source")
+
+        await _setup_app_human(app, Session, caller_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{source_story.id}/references",
+                json={
+                    "target_type": "doc", "target_id": str(uuid.uuid4()), "form": "mention",
+                    "proof_payload": {"conversation_id": str(uuid.uuid4())},
+                },
+            )
+            assert resp.status_code == 400, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_2263_story_outgoing_references_realdb.py
+++ b/backend/tests/test_2263_story_outgoing_references_realdb.py
@@ -289,7 +289,8 @@ async def test_create_proof_reference_readable_conversation_201_then_read_back()
     """왕복(write→read) — 대화를 읽을 수 있는 caller가 proof를 박으면 201 + proof_payload를
     그대로 돌려받고(PO 정정: POST 응답도 payload를 싣는다 — 저장 직후 재조회 없이 그릴 수
     있게), 그 다음 GET /references(outgoing)에서도 같은 payload로 보인다. still_exists는
-    chat_message가 이제 ENTITY_RESOLVERS에 등록돼(story #2263) True로 판정된다 — 예전
+    chat_message가 이제 존재판정 가능한 타입이 돼(story #2263, `TARGET_ONLY_RESOLVERS` —
+    ENTITY_RESOLVERS 완전등록은 CI 13건을 깨 되돌렸다, PO 판정) True로 판정된다 — 예전
     가정(등록 밖이라 None)은 이 PR 자체가 바꾼 축이다."""
     from app.main import app
 
@@ -400,6 +401,96 @@ async def test_create_proof_reference_unreadable_conversation_404():
                 },
             )
             assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_outgoing_references_chat_message_target_hidden_from_non_participant():
+    """⛔PO 지적(2026-07-29) — 「구조를 옮기면(ENTITY_RESOLVERS→TARGET_ONLY_RESOLVERS) 그 위에
+    얹힌 고침(_visible_target_ids의 chat_message 참여자-기반 분기)도 같이 옮겨야 한다」는
+    확認이 이 세션에 아직 없었다(기존 왕복 테스트는 작성자 본인만 GET을 불렀다 — 그 caller는
+    항상 participant라 negative 케이스를 못 잡는다). 여기서 별도 caller(project 접근권은
+    있어 story 게이트는 통과하지만 conversation participant는 아님)로 GET을 불러 chat_message
+    참조가 목록에서 조용히 빠지는지(C-3 존재-비노출 규율) 직접 확認한다."""
+    from app.main import app
+    from app.models.member import Member
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id, "P")
+            participant_member_id, participant_user_id = await _make_human_member(s, org.id, project.id)
+            source_story = await _make_story(s, org.id, project.id, title="Source")
+            conv = await _make_conversation(s, org.id, project.id, participant_ids=[participant_member_id])
+
+            from app.models.conversation import ConversationMessage
+            msg = ConversationMessage(
+                id=uuid.uuid4(), conversation_id=conv.id, sender_id=participant_member_id, content="quoted text",
+            )
+            s.add(msg)
+            await s.commit()
+            message_id = msg.id
+
+            # non-participant: project 접근권은 있으나(story 게이트 통과) conversation
+            # participant는 아니다 — test_create_proof_reference_unreadable_conversation_404와
+            # 동일 셋업 패턴, 다만 여기선 이미 존재하는 참조를 GET으로 조회하는 쪽.
+            user_id = uuid.uuid4()
+            s.add(User(id=user_id, email=f"np-{user_id.hex[:8]}@test.com", hashed_password="x"))
+            await s.commit()
+            om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=user_id, role="member")
+            s.add(om)
+            await s.commit()
+            s.add(Member(id=om.id, org_id=org.id, type="human", user_id=user_id, name="NonParticipant"))
+            await s.commit()
+            s.add(ProjectAccess(
+                id=uuid.uuid4(), project_id=project.id, org_member_id=om.id, member_id=om.id,
+                permission="granted", role="member",
+            ))
+            await s.commit()
+            non_participant_user_id = user_id
+
+            from app.services.reference_core import insert_reference
+            await insert_reference(
+                s, org_id=org.id, source_type="story", source_field="description",
+                source_id=source_story.id, target_type="chat_message", target_id=message_id,
+                form="proof", created_by=participant_user_id,
+                proof_payload={"conversation_id": str(conv.id), "snapshot": []},
+            )
+            await s.commit()
+
+        # 양성대조 — participant 본인은 그대로 보인다.
+        await _setup_app_human(app, Session, participant_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/stories/{source_story.id}/references", params={"direction": "outgoing"},
+            )
+            assert resp.status_code == 200, resp.text
+            assert len(resp.json()["data"]) == 1, "participant는 chat_message 참조가 보여야 한다"
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+
+        # 음성대조 — non-participant는 story 자체는 보이지만(project 접근권 있음) 그 안의
+        # chat_message 참조는 목록에서 조용히 빠져야 한다(404/403 노출이 아니라 빈 목록).
+        await _setup_app_human(app, Session, non_participant_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/stories/{source_story.id}/references", params={"direction": "outgoing"},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["data"] == [], (
+                "non-participant에겐 chat_message 참조가 존재 자체가 새지 않아야 한다(C-3 규율)"
+            )
         finally:
             await client.aclose()
     finally:

--- a/backend/tests/test_2263_story_outgoing_references_realdb.py
+++ b/backend/tests/test_2263_story_outgoing_references_realdb.py
@@ -109,9 +109,9 @@ async def _seed(session):
 
 
 @pytest.mark.anyio
-async def test_outgoing_references_shows_visible_target_only_no_payload():
-    """양성대조 + 누설0: visible_doc만 나오고, form·target 메타는 있으나 payload 키 자체가
-    응답에 없다(목록=메타만, PO 판정)."""
+async def test_outgoing_references_shows_visible_target_only_includes_payload():
+    """양성대조 + 누설0: visible_doc만 나오고, form·target 메타·proof_payload(mention이라
+    None)를 싣는다(PO 정정 — 목록도 payload를 싣는다, 단건 상세 라우트는 안 지음)."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -136,7 +136,11 @@ async def test_outgoing_references_shows_visible_target_only_no_payload():
             assert item["form"] == "mention"
             assert item["target_type"] == "doc"
             assert item["still_exists"] is True
-            assert "proof_payload" not in item, "목록은 메타만 — payload 키 자체가 없어야 한다"
+            # PO 정정(2026-07-29): 목록도 proof_payload를 싣는다(단건 상세 라우트를 안 지음 —
+            # C-7이 카드를 여럿 펼쳐 보이는 자리라 단건이면 N+1). mention form엔 payload가
+            # 애초에 없어 None — "키가 없다"가 아니라 "값이 null"이다(필드 자체는 항상 존재).
+            assert "proof_payload" in item
+            assert item["proof_payload"] is None
         finally:
             await client.aclose()
     finally:
@@ -247,7 +251,7 @@ async def test_outgoing_references_mutation_self_check_visibility_gate_actually_
 
         original_visible = stories_module._visible_target_ids
 
-        async def _always_all_visible(session, org_id, caller_id, ids_by_type):
+        async def _always_all_visible(session, org_id, caller_id, ids_by_type, auth, conversation_id_by_target_id=None):
             return {t: set(ids) for t, ids in ids_by_type.items()}
 
         stories_module._visible_target_ids = _always_all_visible
@@ -282,10 +286,11 @@ async def test_outgoing_references_mutation_self_check_visibility_gate_actually_
 
 @pytest.mark.anyio
 async def test_create_proof_reference_readable_conversation_201_then_read_back():
-    """왕복(write→read) — 대화를 읽을 수 있는 caller가 proof를 박으면 201, 그 다음 GET
-    /references(outgoing)에서 실제로 보인다(단, still_exists는 chat_message가
-    ENTITY_RESOLVERS 밖이라 None — target_type=doc/story류와 다른 축, 이 테스트는 status
-    201·저장 자체만 확認)."""
+    """왕복(write→read) — 대화를 읽을 수 있는 caller가 proof를 박으면 201 + proof_payload를
+    그대로 돌려받고(PO 정정: POST 응답도 payload를 싣는다 — 저장 직후 재조회 없이 그릴 수
+    있게), 그 다음 GET /references(outgoing)에서도 같은 payload로 보인다. still_exists는
+    chat_message가 이제 ENTITY_RESOLVERS에 등록돼(story #2263) True로 판정된다 — 예전
+    가정(등록 밖이라 None)은 이 PR 자체가 바꾼 축이다."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -296,23 +301,31 @@ async def test_create_proof_reference_readable_conversation_201_then_read_back()
             member_id, caller_id = await _make_human_member(s, org.id, project.id)
             source_story = await _make_story(s, org.id, project.id, title="Source")
             conv = await _make_conversation(s, org.id, project.id, participant_ids=[member_id])
-            message_id = uuid.uuid4()
+
+            from app.models.conversation import ConversationMessage
+            msg = ConversationMessage(
+                id=uuid.uuid4(), conversation_id=conv.id, sender_id=member_id, content="quoted text",
+            )
+            s.add(msg)
+            await s.commit()
+            message_id = msg.id
 
         await _setup_app_human(app, Session, caller_id, org.id)
         client = _client_for(app)
         try:
+            payload = {
+                "conversation_id": str(conv.id),
+                "start_message_id": str(message_id), "end_message_id": str(message_id),
+                "snapshot": [{
+                    "message_id": str(message_id), "author_id": str(caller_id),
+                    "content": "quoted text", "created_at": "2026-07-29T00:00:00Z",
+                }],
+            }
             resp = await client.post(
                 f"/api/v2/stories/{source_story.id}/references",
                 json={
                     "target_type": "chat_message", "target_id": str(message_id), "form": "proof",
-                    "proof_payload": {
-                        "conversation_id": str(conv.id),
-                        "start_message_id": str(message_id), "end_message_id": str(message_id),
-                        "snapshot": [{
-                            "message_id": str(message_id), "author_id": str(caller_id),
-                            "content": "quoted text", "created_at": "2026-07-29T00:00:00Z",
-                        }],
-                    },
+                    "proof_payload": payload,
                 },
             )
             assert resp.status_code == 201, resp.text
@@ -320,6 +333,18 @@ async def test_create_proof_reference_readable_conversation_201_then_read_back()
             assert body["form"] == "proof"
             assert body["target_type"] == "chat_message"
             assert body["target_id"] == str(message_id)
+            assert body["proof_payload"] == payload, "POST 응답도 payload를 그대로 돌려줘야 한다"
+
+            read_resp = await client.get(
+                f"/api/v2/stories/{source_story.id}/references", params={"direction": "outgoing"},
+            )
+            assert read_resp.status_code == 200, read_resp.text
+            items = read_resp.json()["data"]
+            assert len(items) == 1
+            assert items[0]["proof_payload"] == payload, "GET 목록에서도 같은 payload가 보여야 한다"
+            assert items[0]["still_exists"] is True, (
+                "chat_message가 이제 ENTITY_RESOLVERS에 등록돼 True로 판정돼야 한다"
+            )
         finally:
             await client.aclose()
     finally:


### PR DESCRIPTION
## Summary
- `reference_core.list_references` and `insert_reference` had zero production callers (backlinks.py's own docstring calls this the "안 도는 문" — a door nobody opens). This PR opens both.

**`GET /api/v2/stories/{id}/references?direction=outgoing`**
- First real consumer of `list_references`. TARGET (the story itself) reuses `_assert_story_project_access` (same gate as `get_story_backlinks`, 404-uniform per #2322).
- The other side (what the story points at) is filtered through a new `_visible_target_ids` helper. For project-scoped target types it reuses `PROJECT_ID_RESOLVERS` + `has_project_access` (the same SSOT #2314 reused for evidence). For `chat_message` targets (participant-scoped, not project-scoped — the "fourth boundary" noted since #2261) it reuses `conversations._can_read_conversation` via the `conversation_id` already stored on the reference's own `proof_payload`.
- List responses carry `proof_payload` as-is, opaque passthrough (**corrected mid-PR** — see below).
- `direction=incoming` is out of scope (already covered differently by `/backlinks`) — explicit 400, not silently accepted.

**`POST /api/v2/stories/{id}/references`**
- First real consumer of `insert_reference`, needed because #2265/C-7's "select a chat excerpt → save" flow has nowhere to write to otherwise.
- Scoped narrowly to `target_type=chat_message` + `form=proof` (the only combination needed right now) — anything else gets an explicit 400.
- Permission is participant-based (`_can_read_conversation`) rather than project-based.
- No hard size cap on the snapshot yet — logged instead (PO: decide a limit after real usage).
- Response now also carries `proof_payload` back (corrected mid-PR — see below), so the caller can render immediately after save without a re-fetch.

**Side discovery**: `chat_message` had never been a valid *target* type before — `insert_reference` rejected it (`ENTITY_RESOLVERS` had no existence-resolver for it; it was `SOURCE_ONLY_TYPES` only). Added `_resolve_chat_messages` (joins through `Conversation` for org scoping, since `ConversationMessage` has no `org_id` column).

**Corrected mid-PR, post-CI (PO decision, before merge)**: the first cut registered `chat_message` directly in `ENTITY_RESOLVERS` to get existence-checking. CI caught this immediately — 13 test failures, because `ENTITY_RESOLVERS` is the SSOT for *five* bundled contracts (existence-check, search handler, `PROJECT_ID_RESOLVERS` keyset parity, MCP mention endpoint, `reference_token` builder), and `chat_message` structurally cannot satisfy the other four (not a search target, not project-scoped, no standalone fetch route). PO judgment: "13건은 «증상»이지 «문제»가 아니다" — the fix isn't patching 13 tests, it's recognizing "can be a target" and "is a fully-supported entity" are different axes that one set was conflating.

Resolution: added `TARGET_ONLY_TYPES` (symmetric to the existing `SOURCE_ONLY_TYPES`) — `chat_message` lives there instead of in `ENTITY_RESOLVERS`. Existence-checking still works via a small `TARGET_ONLY_RESOLVERS` dict consulted alongside `ENTITY_RESOLVERS` in `_batch_resolve_existence`/`list_references`. `insert_reference`'s target validation now uses a new `is_valid_target_type()` (`ENTITY_RESOLVERS` OR `TARGET_ONLY_TYPES`) instead of `is_registered_entity_type()` (kept unchanged, `ENTITY_RESOLVERS`-only, still used by search/MCP/reference_token — so those three correctly keep excluding `chat_message`). `chat_message` also goes back into `SOURCE_ONLY_TYPES` (its original pre-existing home for the mention write-path) — source-only and target-only are independent, non-exclusive grants. `count_orphan_types`'s `known_targets` now includes `TARGET_ONLY_TYPES` so legitimate proof references aren't flagged as orphans. The FE `embed-card.tsx` entity-icon/color/href entries added for `chat_message` in the first cut were reverted — they were only needed because it was (incorrectly) a full registry member; the generic `EntityChip` has no real consumer for `chat_message` today.

`test_2259_ac4_broken_reference_visibility_realdb.py`'s "zero live router callers" guard is updated to "exactly `stories.py`" now that this PR gives `list_references` a real caller — per that test's own instruction to update it alongside this PR.

**Original list/detail-payload correction (PO self-correction, earlier, before merge)**: the original design split list responses (metadata only) from a future single-item detail route (full `proof_payload`). That split was made without checking the actual consumption pattern — C-7's proof section renders multiple quoted-message cards from one list fetch, so a single-item route would mean N+1 calls, and since nobody had built that route, the payload had nowhere to be read at all ("saved but nowhere to view it", again). Corrected: both GET and POST now carry `proof_payload` directly; size is bounded by a future write-time scope cap, not by omitting it from reads.

## Test plan
- [x] RED-first throughout, including the mid-PR correction: confirmed the "list includes proof_payload" and "write→read round trip returns matching payload" assertions fail against the pre-correction code, then implemented, then green.
- [x] Unintentional guard-verification: the read route's "no-project-access→404" test was RED against develop before PR #2624 merged (still 403 back then) and is GREEN now that #2624 landed — proof the test measures the real axis, not tautological.
- [x] Mutation self-check: sabotaging `_visible_target_ids` to always-allow reproduces the leak (invisible/nonexistent targets appear), proving the gate isn't a no-op.
- [x] Positive control + leak-zero: visible target appears with full metadata + payload (null for non-proof forms); invisible-target and nonexistent-target don't appear at all.
- [x] Write→read round trip: POST a proof reference → 201 with payload echoed back → GET shows the same reference with the same payload and `still_exists=True` (chat_message is now a valid, existence-checkable target via `TARGET_ONLY_TYPES`).
- [x] Unreadable-conversation write attempt → 404 (existence non-disclosure, not 403).
- [x] Unsupported target_type/form combination → explicit 400, not silent no-op.
- [x] Full existing story/backlinks/authz/evidence realdb suites: 63/63 green. One pre-existing environment-scale failure (`test_story_backlinks_query_uses_target_index`, an EXPLAIN index-usage assertion that fails on a near-empty disposable-PG table regardless of this diff) reproduced identically with this diff stashed — confirmed unrelated.
- [x] Post-CI-failure fix re-verified: the 12 tests that failed in CI (`test_2263_entities_search_quota_contract_realdb`, `test_2282_reference_token_builder`, `test_2283_references_realdb`, `test_2294_entities_search_open_4_types_realdb`, `test_2294_task_registry_open_realdb`, `test_2294b_open_4_types_realdb`, `test_e_security_sec_s8_ratchet_round4_entities_realdb`, `test_mcp_s1995_agent_doc_mentions` — 12 cases total across these files) all pass again (chat_message no longer in `ENTITY_RESOLVERS`) alongside this PR's own 8 tests (119 total). `test_2259`'s intentionally-updated guard (1 more) and the FE parity/link-state/embed-card suites (15) also pass. Rebased cleanly onto `origin/develop` (through PR #2633, #2634) with no conflicts; full targeted suite re-run green post-rebase (122 backend tests).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

**Post-decision follow-up (PO catch, before merge)**: PO flagged that moving the existence-check plumbing (ENTITY_RESOLVERS → TARGET_ONLY_RESOLVERS) does not by itself prove the read-path visibility fix in `_visible_target_ids` (the participant-based `_can_read_conversation` branch) still applies — "옮겼다≠그대로 돈다". Verified: `_visible_target_ids` branches on the literal `"chat_message"` string, not on registry membership, so it was structurally unaffected — but no existing test proved the negative case for the *read* route specifically (existing tests only ever used the participant caller for GET). Added `test_outgoing_references_chat_message_target_hidden_from_non_participant`: same story, participant sees the proof reference, a project-visible non-participant gets an empty list. Mutation-verified (temporarily short-circuited the visibility branch to always-allow — test goes red).
