### PR TITLE
[SID:2262] AC9 — next_action_code 컴퓨티드 필드 (참조 카드 「다음 행동」 SSOT)

### DIFF
--- a/backend/app/schemas/doc.py
+++ b/backend/app/schemas/doc.py
@@ -117,6 +117,13 @@ class DocResponse(BaseModel):
         from app.services.reference_token import build_reference_token
         return build_reference_token("doc", self.id, self.title)
 
+    # story #2262(C-4) AC9: 참조 카드의 「다음 행동」 재료 — SSOT는 app.services.next_action.
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def next_action_code(self) -> str | None:
+        from app.services.next_action import doc_next_action
+        return doc_next_action(status=self.status, superseded_by=self.superseded_by)
+
 
 class ShareStatusResponse(BaseModel):
     """b1574f5a: 문서 공유 상태(관리 API). enabled=active 토큰 유무."""

--- a/backend/app/schemas/goal.py
+++ b/backend/app/schemas/goal.py
@@ -103,6 +103,18 @@ class GoalResponse(BaseModel):
         from app.services.reference_token import build_reference_token
         return build_reference_token("epic", self.id, self.title)
 
+    # story #2262(C-4) AC9: outcome-measurement 축만(doc `e-connect-c4-trigger-condition-
+    # table` 승인 범위) — 「미결 스토리 수」·risky_status 축은 outcome 축과 동시에 참일 수
+    # 있어 우선순위 판단이 필요한 별건(미구현, doc에 기록).
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def next_action_code(self) -> str | None:
+        from app.services.next_action import outcome_measurement_next_action
+        return outcome_measurement_next_action(
+            outcome_status=self.outcome_status, measure_after=self.measure_after,
+            metric_definition=self.metric_definition, system_owned_sources=frozenset({"ga4", "internal_ops"}),
+        )
+
 
 class GlanceFocalStoryGate(BaseModel):
     """story #2303 — `synthesizeGateAction`(FE, `glance-hero.tsx` 밖의 다른 파일 — 단일

--- a/backend/app/schemas/hypothesis.py
+++ b/backend/app/schemas/hypothesis.py
@@ -8,7 +8,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, computed_field, field_validator, model_validator
 
 from app.schemas.story import _validate_metric_definition
 
@@ -113,6 +113,15 @@ class HypothesisResponse(BaseModel):
     sprint_id: uuid.UUID | None = None
     created_at: datetime
     updated_at: datetime
+
+    # story #2262(C-4) AC9: 참조 카드의 「다음 행동」 재료 — SSOT는 app.services.next_action.
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def next_action_code(self) -> str | None:
+        from app.services.next_action import hypothesis_next_action
+        return hypothesis_next_action(
+            status=self.status, measure_after=self.measure_after, metric_definition=self.metric_definition,
+        )
 
     @classmethod
     def from_model(

--- a/backend/app/schemas/sprint.py
+++ b/backend/app/schemas/sprint.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import date, datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, computed_field, field_validator, model_validator
 from app.schemas.story import _validate_metric_definition
 
 # E-DG S26: sprint status contract. de-facto(planning|active|done)에 review(선택)·archived(terminal) 신설.
@@ -112,6 +112,20 @@ class SprintResponse(SprintBase):
         if derived is not None:
             self.duration = derived
         return self
+
+    # story #2262(C-4) AC9: outcome-measurement 축만(doc `e-connect-c4-trigger-condition-
+    # table` 승인 범위) — internal_ops는 sprint close() 시점 즉시 채점(repositories/
+    # sprint.py) — cron 지연 아님. 그래도 「사람 몫이 아니다」는 동일하므로 system_owned_
+    # sources에 그대로 포함한다(④주체 판정은 "언제"가 아니라 "누구"라 이 축에선 영향 없음).
+    # ⛔「기간 지났는데 안 닫힘」 축은 별건(doc에 기록, 미구현).
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def next_action_code(self) -> str | None:
+        from app.services.next_action import outcome_measurement_next_action
+        return outcome_measurement_next_action(
+            outcome_status=self.outcome_status, measure_after=self.measure_after,
+            metric_definition=self.metric_definition, system_owned_sources=frozenset({"ga4", "internal_ops"}),
+        )
 
 
 class KickoffBody(BaseModel):

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -302,3 +302,18 @@ class StoryResponse(BaseModel):
     def reference_token(self) -> str | None:
         from app.services.reference_token import build_reference_token
         return build_reference_token("story", self.id, self.title)
+
+    # story #2262(C-4) AC9: 참조 카드의 「다음 행동」 재료 — SSOT는 app.services.next_action
+    # (조건식만, 문구는 유나 lane). None="디딜 것 없음"(positive 단방향, has_evidence와 동형).
+    # ⛔doc(e-connect-c4-trigger-condition-table)이 승인한 축은 outcome-measurement 하나뿐 —
+    # self_reported/human_verified(task와 동일 필드)도 story에 있다는 것을 구현 중 발견했지만,
+    # 그걸 story의 다음 행동으로도 쓸지는 리뷰 안 된 별건 판단이라 여기서 임의로 안 얹는다
+    # (지어내지 않는다 원칙 — PO 승인 없이 새 축 추가 금지).
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def next_action_code(self) -> str | None:
+        from app.services.next_action import outcome_measurement_next_action
+        return outcome_measurement_next_action(
+            outcome_status=self.outcome_status, measure_after=self.measure_after,
+            metric_definition=self.metric_definition, system_owned_sources=frozenset({"ga4"}),
+        )

--- a/backend/app/schemas/task.py
+++ b/backend/app/schemas/task.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, computed_field, field_validator
 
 
 class TaskCreate(BaseModel):
@@ -62,3 +62,10 @@ class TaskResponse(BaseModel):
     @classmethod
     def _coerce_human_verified_at(cls, v):
         return v if isinstance(v, datetime) else None
+
+    # story #2262(C-4) AC9: 참조 카드의 「다음 행동」 재료 — SSOT는 app.services.next_action.
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def next_action_code(self) -> str | None:
+        from app.services.next_action import verification_next_action
+        return verification_next_action(self_reported=self.self_reported, human_verified=self.human_verified)

--- a/backend/app/schemas/visual_artifact.py
+++ b/backend/app/schemas/visual_artifact.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator, model_validator
 
 # 뷰어 통합 재설계(story 1948d19d): 비정상 거대값 방어 상한. Figma류 대형 캔버스 툴의 실용 한계보다
 # 넉넉하되(20000px), 정수 오버플로/스토리지 남용성 값은 확실히 막는 값 — 특정 스펙 수치가 아니라
@@ -108,6 +108,13 @@ class VisualArtifactSummary(BaseModel):
     # 세팅되므로(N+1 방지 배치 조회, 0도 명시) 여기 기본값(0)이 실제로 쓰일 일은 없다.
     unresolved_comment_count: int = 0
 
+    # story #2262(C-4) AC9: 참조 카드의 「다음 행동」 재료 — SSOT는 app.services.next_action.
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def next_action_code(self) -> str | None:
+        from app.services.next_action import artifact_next_action
+        return artifact_next_action(unresolved_comment_count=self.unresolved_comment_count)
+
 
 class VisualArtifactDetail(BaseModel):
     id: uuid.UUID
@@ -136,6 +143,13 @@ class VisualArtifactDetail(BaseModel):
     # from_attributes를 안 쓰므로(라우터가 키워드 인자로 직접 생성) 기본값 0이 실제로
     # 쓰이지 않는다는 보장이 없다 — 호출부(_load_detail)가 항상 명시로 넘긴다.
     unresolved_comment_count: int = 0
+
+    # story #2262(C-4) AC9: VisualArtifactSummary와 동형.
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def next_action_code(self) -> str | None:
+        from app.services.next_action import artifact_next_action
+        return artifact_next_action(unresolved_comment_count=self.unresolved_comment_count)
 
 
 class CreateArtifactCommentRequest(BaseModel):

--- a/backend/app/services/next_action.py
+++ b/backend/app/services/next_action.py
@@ -1,0 +1,113 @@
+"""story #2262(C-4, E-CONNECT) — 참조 카드의 「지금 상태·다음 행동」 재료. SSOT.
+
+doc `e-connect-c4-trigger-condition-table`(디디 작성, 오르테가군 리뷰 4회 반영, 2026-07-29)의
+발생조건표를 그대로 코드화한다 — **조건식만 이 함수들에 있고, 사람-읽는 문구는 여기 없다**
+(문구는 유나 lane, 이 모듈은 `next_action_code: str | None`만 반환한다). 카드가 코드를 문구로
+번역하는 건 FE/유나 몫 — 이 모듈은 "지어낼 여지가 없는" 조건식만 고정한다.
+
+⛔positive 단방향 규율(has_evidence·self_reported와 동형): "디딜 것이 있다"만 non-None으로
+반환한다. "디딜 것 없음"과 "아직 모름"은 여기서 안 가른다 — 발생조건표 감사 결과(2026-07-29)
+이 8종 전부 필드가 존재하는 한 "아직 모름"이 구조적으로 안 생긴다(null도 항상 "명시적으로
+없음"). 그러므로 이 모듈이 하는 일은 딱 하나 — **인간이 디딜 것이 있으면 코드를, 없으면
+None을** 반환하는 것. FE는 None을 "디딜 것 없음"으로 읽으면 된다(이 모듈이 "아직 모름"
+케이스를 만들지 않으므로 None과 "모름"을 헷갈릴 자리가 없다).
+
+⛔④주체(사람/시스템) 축: 시스템이 자동으로 처리할 예정인 조건은 **여기서 이미 걸러진다** —
+`system_owned_sources`에 속하는 `metric_definition.source`는 조건이 참이어도 None을
+반환한다(오르테가 판정 2026-07-29: "시스템이 디딜 것은 카드에 행동으로 안 단다").
+
+⛔스코프(이 첫 PR에서 구현 안 함, 정밀화 필요해 후속으로 미룸 — 지어내지 않는다):
+  - epic의 「미결 스토리 수」·「risky_status」 축 — outcome-measurement 축과 동시에 참일 수
+    있어 우선순위 판단이 필요하다(어느 것을 "그" next_action으로 보일지). PO 승인 없이
+    임의로 순서를 정하지 않는다.
+  - sprint의 「기간 지났는데 안 닫힘」 축 — 같은 이유.
+  이 두 축은 doc(`e-connect-c4-trigger-condition-table`)에 "미구현·후속 필요"로 기록돼 있다.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+# story #2262 AC9④: outcome_status 3단계(n_a→pending→hit|miss, outcome_scorer.py:15 확인)
+# 공유 — story/epic/sprint 전부 이 전이를 쓴다.
+_OUTCOME_MEASUREMENT_DUE = "outcome_measurement_due"
+_VERIFICATION_PENDING = "verification_pending"
+_DOC_DECISION_PENDING = "decision_pending"
+_DOC_SUPERSEDED = "superseded"
+_HYPOTHESIS_MEASUREMENT_DUE = "hypothesis_measurement_due"
+_ARTIFACT_UNRESOLVED_COMMENTS = "artifact_has_unresolved_comments"
+
+
+def _is_system_owned(metric_definition: dict[str, Any] | None, system_owned_sources: frozenset[str]) -> bool:
+    if not metric_definition:
+        return False
+    return metric_definition.get("source") in system_owned_sources
+
+
+def outcome_measurement_next_action(
+    *,
+    outcome_status: str,
+    measure_after: datetime | None,
+    metric_definition: dict[str, Any] | None,
+    system_owned_sources: frozenset[str],
+    now: datetime | None = None,
+) -> str | None:
+    """story·epic·sprint 공유 — outcome_status='pending' ∧ measure_after<=now일 때만 사람
+    몫("outcome_measurement_due")을 반환한다. `system_owned_sources`에 속하는 source는
+    조건이 참이어도 None(④주체=시스템, 카드에 행동으로 안 닮).
+
+    ⛔`n_a`(측정 대상 아님)·`hit`/`miss`(이미 채점됨)·`pending`인데 아직 안 지남은 전부
+    None — 발생조건표 §②(확定 없음)에 해당, "디딜 것 없음"이지 "모름"이 아니다."""
+    if outcome_status != "pending":
+        return None
+    if measure_after is None or measure_after > (now or datetime.now(timezone.utc)):
+        return None
+    if _is_system_owned(metric_definition, system_owned_sources):
+        return None
+    return _OUTCOME_MEASUREMENT_DUE
+
+
+def verification_next_action(*, self_reported: bool | None, human_verified: bool | None) -> str | None:
+    """story·task 공유 — claimed(self_reported=true) ∧ 아직 human_verified 안 됨일 때만.
+    ⛔self_reported가 None/False(주장 자체 없음)·human_verified가 이미 정해짐(True/False
+    어느 쪽이든)은 None — "디딜 것 없음"(발생조건표 §②)."""
+    if self_reported is not True:
+        return None
+    if human_verified is not None:
+        return None
+    return _VERIFICATION_PENDING
+
+
+def doc_next_action(*, status: str, superseded_by: object | None) -> str | None:
+    """superseded_by가 우선(더 확定적인 다음 행동 — "가라"는 목적지가 이미 있다)."""
+    if superseded_by is not None:
+        return _DOC_SUPERSEDED
+    if status == "draft":
+        return _DOC_DECISION_PENDING
+    return None
+
+
+def hypothesis_next_action(
+    *,
+    status: str,
+    measure_after: datetime | None,
+    metric_definition: dict[str, Any] | None,
+    now: datetime | None = None,
+) -> str | None:
+    """`measuring` ∧ measure_after<=now ∧ source가 자동채점 대상(ga4/internal_ops) 아닐 때만.
+    ⛔ga4/internal_ops면 cron(`score_hypotheses`)이 매 실행마다 시도한다(④주체=시스템) —
+    실패해도 measuring에 남는 것은 "카드가 채워야 할 다음 행동"이 아니라 별도 결함 신호
+    (doc에 "기록, 미판단"으로 남겨둠 — #2262 스코프 밖)."""
+    if status != "measuring":
+        return None
+    if measure_after is None or measure_after > (now or datetime.now(timezone.utc)):
+        return None
+    if _is_system_owned(metric_definition, frozenset({"ga4", "internal_ops"})):
+        return None
+    return _HYPOTHESIS_MEASUREMENT_DUE
+
+
+def artifact_next_action(*, unresolved_comment_count: int) -> str | None:
+    if unresolved_comment_count > 0:
+        return _ARTIFACT_UNRESOLVED_COMMENTS
+    return None

--- a/backend/tests/test_2262_next_action_conditions.py
+++ b/backend/tests/test_2262_next_action_conditions.py
@@ -1,0 +1,156 @@
+"""story #2262(C-4) AC9 — app.services.next_action의 조건식 단위 검증. 순수 함수(DB 무접촉)라
+실PG 없이 돈다. doc `e-connect-c4-trigger-condition-table`의 발생조건표를 그대로 pin한다 —
+①있음/②확定 없음/④주체 세 축을 각 함수마다 양성·음성 대조로 고정."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.services.next_action import (
+    artifact_next_action,
+    doc_next_action,
+    hypothesis_next_action,
+    outcome_measurement_next_action,
+    verification_next_action,
+)
+
+_NOW = datetime(2026, 7, 29, 12, 0, 0, tzinfo=timezone.utc)
+_PAST = _NOW - timedelta(days=1)
+_FUTURE = _NOW + timedelta(days=1)
+
+
+# ─── outcome_measurement_next_action (story·epic·sprint 공유) ───────────────
+
+
+def test_outcome_due_human_source_returns_code():
+    assert outcome_measurement_next_action(
+        outcome_status="pending", measure_after=_PAST, metric_definition={"source": "manual"},
+        system_owned_sources=frozenset({"ga4"}), now=_NOW,
+    ) == "outcome_measurement_due"
+
+
+def test_outcome_due_no_metric_definition_still_human():
+    """source가 아예 없으면(metric_definition=None) 시스템 소유가 아니므로 사람 몫."""
+    assert outcome_measurement_next_action(
+        outcome_status="pending", measure_after=_PAST, metric_definition=None,
+        system_owned_sources=frozenset({"ga4"}), now=_NOW,
+    ) == "outcome_measurement_due"
+
+
+def test_outcome_due_but_system_owned_returns_none():
+    assert outcome_measurement_next_action(
+        outcome_status="pending", measure_after=_PAST, metric_definition={"source": "ga4"},
+        system_owned_sources=frozenset({"ga4"}), now=_NOW,
+    ) is None
+
+
+def test_outcome_due_internal_ops_system_owned_for_epic_sprint():
+    assert outcome_measurement_next_action(
+        outcome_status="pending", measure_after=_PAST, metric_definition={"source": "internal_ops"},
+        system_owned_sources=frozenset({"ga4", "internal_ops"}), now=_NOW,
+    ) is None
+
+
+def test_outcome_not_yet_due_returns_none():
+    assert outcome_measurement_next_action(
+        outcome_status="pending", measure_after=_FUTURE, metric_definition=None,
+        system_owned_sources=frozenset({"ga4"}), now=_NOW,
+    ) is None
+
+
+def test_outcome_n_a_returns_none():
+    assert outcome_measurement_next_action(
+        outcome_status="n_a", measure_after=None, metric_definition=None,
+        system_owned_sources=frozenset({"ga4"}), now=_NOW,
+    ) is None
+
+
+def test_outcome_already_scored_hit_miss_returns_none():
+    for status in ("hit", "miss"):
+        assert outcome_measurement_next_action(
+            outcome_status=status, measure_after=_PAST, metric_definition=None,
+            system_owned_sources=frozenset({"ga4"}), now=_NOW,
+        ) is None
+
+
+def test_outcome_pending_measure_after_none_returns_none():
+    """pending인데 measure_after가 없으면(데이터 불일치) 판정 못 하므로 None — 지어내지 않는다."""
+    assert outcome_measurement_next_action(
+        outcome_status="pending", measure_after=None, metric_definition=None,
+        system_owned_sources=frozenset({"ga4"}), now=_NOW,
+    ) is None
+
+
+# ─── verification_next_action (story·task 공유) ─────────────────────────────
+
+
+def test_verification_claimed_not_verified_returns_code():
+    assert verification_next_action(self_reported=True, human_verified=None) == "verification_pending"
+
+
+def test_verification_no_claim_returns_none():
+    assert verification_next_action(self_reported=None, human_verified=None) is None
+    assert verification_next_action(self_reported=False, human_verified=None) is None
+
+
+def test_verification_already_resolved_returns_none_either_direction():
+    assert verification_next_action(self_reported=True, human_verified=True) is None
+    assert verification_next_action(self_reported=True, human_verified=False) is None
+
+
+# ─── doc_next_action ─────────────────────────────────────────────────────────
+
+
+def test_doc_draft_returns_decision_pending():
+    assert doc_next_action(status="draft", superseded_by=None) == "decision_pending"
+
+
+def test_doc_superseded_returns_superseded_even_if_also_draft():
+    """superseded_by가 우선 — 더 확定적인 다음 행동(가야 할 곳이 이미 정해짐)."""
+    import uuid
+    target = uuid.uuid4()
+    assert doc_next_action(status="draft", superseded_by=target) == "superseded"
+    assert doc_next_action(status="active", superseded_by=target) == "superseded"
+
+
+def test_doc_decided_not_superseded_returns_none():
+    assert doc_next_action(status="active", superseded_by=None) is None
+
+
+# ─── hypothesis_next_action ───────────────────────────────────────────────────
+
+
+def test_hypothesis_measuring_due_human_source_returns_code():
+    assert hypothesis_next_action(
+        status="measuring", measure_after=_PAST, metric_definition={"source": "manual"}, now=_NOW,
+    ) == "hypothesis_measurement_due"
+
+
+def test_hypothesis_measuring_due_auto_source_returns_none():
+    for source in ("ga4", "internal_ops"):
+        assert hypothesis_next_action(
+            status="measuring", measure_after=_PAST, metric_definition={"source": source}, now=_NOW,
+        ) is None
+
+
+def test_hypothesis_not_measuring_status_returns_none():
+    for status in ("proposed", "active", "verified", "falsified", "killed", "archived"):
+        assert hypothesis_next_action(
+            status=status, measure_after=_PAST, metric_definition={"source": "manual"}, now=_NOW,
+        ) is None
+
+
+def test_hypothesis_measuring_not_yet_due_returns_none():
+    assert hypothesis_next_action(
+        status="measuring", measure_after=_FUTURE, metric_definition={"source": "manual"}, now=_NOW,
+    ) is None
+
+
+# ─── artifact_next_action ─────────────────────────────────────────────────────
+
+
+def test_artifact_unresolved_returns_code():
+    assert artifact_next_action(unresolved_comment_count=3) == "artifact_has_unresolved_comments"
+
+
+def test_artifact_zero_returns_none():
+    assert artifact_next_action(unresolved_comment_count=0) is None

--- a/backend/tests/test_2262_next_action_schema_wiring.py
+++ b/backend/tests/test_2262_next_action_schema_wiring.py
@@ -1,0 +1,100 @@
+"""story #2262(C-4) AC9 — next_action_code가 실제 응답 스키마 클래스에 배선됐는지(조건식
+자체는 test_2262_next_action_conditions.py가 이미 pin) — 여기는 "그 필드가 응답에
+나타나는가"만 확인한다. DB 무접촉(모든 대상 클래스가 from_attributes라 최소 속성 객체로
+model_validate 가능)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+_NOW = datetime.now(timezone.utc)
+_PAST = _NOW - timedelta(days=1)
+
+
+def test_story_response_exposes_next_action_code():
+    from app.schemas.story import StoryResponse
+
+    obj = SimpleNamespace(
+        id=uuid.uuid4(), story_number=1, project_id=uuid.uuid4(), org_id=uuid.uuid4(),
+        epic_id=None, sprint_id=None, assignee_id=None, assignee_ids=[], human_owner_member_id=None,
+        declared_scope_paths=None, agent_delegate_ids=[], references=None, attachments=[],
+        meeting_id=None, title="T", status="in-progress", priority="medium", story_points=None,
+        description=None, acceptance_criteria=None, position=None, success_hypothesis=None,
+        metric_definition={"source": "manual"}, measure_after=_PAST, outcome_status="pending",
+        outcome_result=None, is_excluded=False, created_at=_NOW, updated_at=_NOW, violation=None,
+        has_evidence=None, self_reported=None, human_verified=None, human_verified_by=None,
+        human_verified_at=None,
+    )
+    resp = StoryResponse.model_validate(obj)
+    assert resp.next_action_code == "outcome_measurement_due"
+
+
+def test_doc_response_exposes_next_action_code():
+    from app.schemas.doc import DocResponse
+
+    obj = SimpleNamespace(
+        id=uuid.uuid4(), project_id=uuid.uuid4(), org_id=uuid.uuid4(), parent_id=None,
+        created_by=None, assignee_id=None, status="draft", superseded_by=None, title="D",
+        slug="d", canonical_slug="d", slug_locked=False, content="c", icon=None, sort_order=0,
+        doc_type="page", content_format="markdown", tags=[], created_at=_NOW, updated_at=_NOW,
+        assignee=None, revisions=None,
+    )
+    resp = DocResponse.model_validate(obj)
+    assert resp.next_action_code == "decision_pending"
+
+
+def test_artifact_summary_exposes_next_action_code():
+    from app.schemas.visual_artifact import VisualArtifactSummary
+
+    obj = SimpleNamespace(
+        id=uuid.uuid4(), title="A", story_id=None, epic_id=None, doc_id=None, source="created",
+        latest_version_number=1, anchor_version=None, created_by=None, created_at=_NOW,
+        canvas_bounds=None, unresolved_comment_count=2,
+    )
+    resp = VisualArtifactSummary.model_validate(obj)
+    assert resp.next_action_code == "artifact_has_unresolved_comments"
+
+
+def test_task_response_exposes_next_action_code():
+    from app.schemas.task import TaskResponse
+
+    obj = SimpleNamespace(
+        id=uuid.uuid4(), story_id=uuid.uuid4(), org_id=uuid.uuid4(), assignee_id=None,
+        title="T", status="in-review", story_points=None, created_at=_NOW, updated_at=_NOW,
+        has_evidence=True, self_reported=True, human_verified=None, human_verified_by=None,
+        human_verified_at=None,
+    )
+    resp = TaskResponse.model_validate(obj)
+    assert resp.next_action_code == "verification_pending"
+
+
+def test_goal_response_exposes_next_action_code():
+    from app.schemas.goal import GoalResponse
+
+    obj = SimpleNamespace(
+        id=uuid.uuid4(), project_id=uuid.uuid4(), org_id=uuid.uuid4(), assignee_id=None,
+        title="G", status="active", priority="medium", description=None, objective=None,
+        success_criteria=None, target_sp=None, target_date=None, success_hypothesis=None,
+        metric_definition={"source": "manual"}, measure_after=_PAST, outcome_status="pending",
+        outcome_result=None, hypothesis_count=0, risky_status=None, total_stories=0, done_stories=0,
+        position=None, source_loop_id=None, created_at=_NOW, updated_at=_NOW,
+    )
+    resp = GoalResponse.model_validate(obj)
+    assert resp.next_action_code == "outcome_measurement_due"
+
+
+def test_sprint_response_exposes_next_action_code():
+    from app.schemas.sprint import SprintResponse
+
+    obj = SimpleNamespace(
+        id=uuid.uuid4(), project_id=uuid.uuid4(), org_id=uuid.uuid4(), status="active",
+        velocity=None, duration=14, report_doc_id=None, outcome_status="pending",
+        outcome_result=None, created_at=_NOW, updated_at=_NOW,
+        title="S", start_date=None, end_date=None, team_size=None, goal=None, capacity=None,
+        success_hypothesis=None,
+        metric_definition={"source": "manual", "metric": "x", "direction": "up", "target": 1},
+        measure_after=_PAST,
+    )
+    resp = SprintResponse.model_validate(obj)
+    assert resp.next_action_code == "outcome_measurement_due"

--- a/backend/tests/test_2298_goals_glance_include_realdb.py
+++ b/backend/tests/test_2298_goals_glance_include_realdb.py
@@ -166,7 +166,11 @@ async def test_goals_list_without_include_has_no_glance_fields():
             assert len(body) == 1
             assert "participant_ids" not in body[0], body[0]
             assert "focal_story" not in body[0], body[0]
-            assert set(body[0].keys()) == set(GoalResponse.model_fields) | {"reference_token"}
+            # story #2262(C-4) AC9(오르테가 근본처방, 2026-07-29): 손으로 {"reference_token",
+            # "next_action_code"}를 더하면 다음 computed_field가 또 이 테스트를 깬다(오늘
+            # 두 번째로 같은 병) — pydantic v2가 이미 구분해 추적하는 model_computed_fields를
+            # 써서 "computed_field가 늘어도 테스트가 저절로 따라가게" 근본으로 고친다.
+            assert set(body[0].keys()) == set(GoalResponse.model_fields) | set(GoalResponse.model_computed_fields)
         finally:
             await client.aclose()
     finally:


### PR DESCRIPTION
## 배경
doc [E-CONNECT C-4 발생조건표](entity:doc:bcfb430d-f3ed-40b0-a41a-c9ee901757ba)(오르테가 리뷰 4회 반영, 2026-07-29)에서 확정한 8종 발생조건표를 코드화한다 — #2262 AC3("없는 행동을 지어내지 않는다")을 **구조로** 지키는 방법: 조건이 참일 때만 코드가 나오므로 카드가 임의로 문구를 고를 여지가 없다.

## 계약
```
app/services/next_action.py — 순수 함수 SSOT(DB 무접촉, 문구 없음 — 유나 lane)
각 응답 스키마에 next_action_code: str | None을 @computed_field로 배선(reference_token과 동일 패턴)
None = "디딜 것 없음"(positive 단방향, has_evidence와 동형 규율)
```

| 종류 | 조건 | 코드 |
|---|---|---|
| story·epic·sprint | `outcome_status='pending' ∧ measure_after<=now ∧ source 자동채점 대상 아님` | `outcome_measurement_due` |
| task | `self_reported=true ∧ human_verified=null` | `verification_pending` |
| doc | `superseded_by` set(우선) 또는 `status='draft'` | `superseded` / `decision_pending` |
| hypothesis | `status='measuring' ∧ measure_after<=now ∧ source 자동채점 대상 아님` | `hypothesis_measurement_due` |
| artifact | `unresolved_comment_count>0`(#2623 재사용) | `artifact_has_unresolved_comments` |

**④주체(사람/시스템) 축**은 여기서 걸러진다 — `metric_definition.source`가 자동채점 대상(story/hypothesis: `ga4`, epic/sprint: `ga4`+`internal_ops`)이면 조건이 참이어도 `None`을 반환한다(오르테가 판정: "시스템이 디딜 것은 카드에 행동으로 안 단다").

**③ 아직 모름 축**: doc 감사 결과 이 8종 전부 필드가 항상 존재(null도 명시적 신호)해 "아직 모름"이 구조적으로 안 생긴다 — `next_action_code` 필드 자체의 존재가 곧 그 해소다(#2623 이전 `unresolved_comment_count` 부재가 실물 사례였음).

## 스코프 밖 (doc에 기록, PO 승인 없이 임의 순서 안 정함)
- epic의 「미결 스토리 수」/`risky_status` 축, sprint의 「기간 지났는데 안 닫힘」 축 — outcome-measurement 축과 동시에 참일 수 있어 우선순위 판단 필요.
- story의 `self_reported`/`human_verified`(task와 동일 필드가 story에도 있다는 것을 구현 중 발견) — 다음 행동으로 쓸지는 리뷰 안 된 판단이라 이번 PR엔 안 얹었다.

## 테스트
- 조건식 단위 20건(`test_2262_next_action_conditions.py`) — 양성/음성/경계(measure_after 미래·null 등) 전부.
- 스키마 배선 확인 6건(`test_2262_next_action_schema_wiring.py`) — story/goal/sprint/task/doc/artifact 전부 `.model_validate()`로 실제 응답 클래스에서 값이 나오는 것 확인.
- **뮤테이션 자가검증**: `outcome_measurement_next_action`의 ④주체(시스템 소유) 가드를 실 프로덕션 코드에서 제거 → 정확히 그 2건(ga4·internal_ops 케이스)만 RED, 나머지 24건 무영향 → 원복 → 26/26 재-GREEN.
- 마스크된 관련 스위트(`-k "story or stories or goal or epic or sprint or task or doc or hypothesis or artifact"`) 817건 무회귀 — 5건 실패는 MCP 경로 설정 관련 기존(baseline) 실패, 무관 확인.
- `python -c "from app.main import app"` — 500 routes, import 정상.

## 왜 라우터를 안 건드렸는가
`next_action_code`는 이미 응답에 있는 필드(outcome_status·measure_after·metric_definition·self_reported·human_verified·status·superseded_by·unresolved_comment_count)만 읽는 순수 계산이다 — 라우터가 세팅할 transient attr이 없고, N+1 위험도 0(추가 쿼리 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)