### PR TITLE
[SID:2265] C-7 PR1b — 대화 근거(proof) 섹션을 스토리 상세에 얹는다

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3308,6 +3308,7 @@
     "evidenceNotePlaceholder": "Note (optional)",
     "chatProofSectionTitle": "Chat evidence",
     "chatProofCount": "{count} chat evidence items",
+    "chatProofSomeUnavailable": "{count} unavailable",
     "chatProofOpenSource": "Open in chat",
     "chatProofOpenOriginal": "View original now",
     "chatProofEdited": "Original was edited · {date}",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3308,6 +3308,7 @@
     "evidenceNotePlaceholder": "메모(선택)",
     "chatProofSectionTitle": "대화 근거",
     "chatProofCount": "대화 근거 {count}건",
+    "chatProofSomeUnavailable": "{count}건은 표시할 수 없음",
     "chatProofOpenSource": "대화에서 열기",
     "chatProofOpenOriginal": "지금 원본 보기",
     "chatProofEdited": "원본이 수정되었습니다 · {date}",

--- a/apps/web/src/app/api/stories/[id]/references/route.test.ts
+++ b/apps/web/src/app/api/stories/[id]/references/route.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { vi } from 'vitest';
+
+// story #2265(C-7) PR1b — BE list_references도 convention-A({data,meta})라
+// activities/route.ts(#2247/#2564)와 같은 이중포장 위험을 처음부터 봉쇄한다(backlinks/
+// route.test.ts와 동형).
+const h = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(),
+  proxyToFastapiWithParams: vi.fn(),
+}));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext: h.getOrgProjectAuthContext }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams: h.proxyToFastapiWithParams }));
+
+import { GET, POST } from './route';
+
+const ctx = () => ({ params: Promise.resolve({ id: 'story-1' }) });
+const getReq = () => new Request('http://localhost/api/stories/story-1/references?direction=outgoing');
+const postReq = (body: unknown) => new Request('http://localhost/api/stories/story-1/references', {
+  method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+});
+const me = () => ({ id: 'a', org_id: 'org-1', project_id: 'p1', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
+
+describe('GET /api/stories/[id]/references — 이중포장 회귀 방지 + proof_payload 왕복', () => {
+  beforeEach(() => {
+    h.getOrgProjectAuthContext.mockReset();
+    h.proxyToFastapiWithParams.mockReset();
+    h.getOrgProjectAuthContext.mockResolvedValue(me());
+  });
+
+  it('BE convention-A 응답이 이중포장 없이 그대로 나온다 — proof_payload 보존', async () => {
+    h.proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({
+        data: [{
+          id: 'ref-1', form: 'proof', target_type: 'chat_message', target_id: 'msg-1',
+          created_at: '2026-07-29T00:00:00Z', still_exists: true,
+          proof_payload: { conversation_id: 'conv-1', start_message_id: 'msg-1', end_message_id: 'msg-1', snapshot: [] },
+        }],
+      }), { status: 200 }),
+    );
+    const res = await GET(getReq(), ctx());
+    const json = await res.json() as { data: { proof_payload: { conversation_id: string } }[] };
+    expect(Array.isArray(json.data)).toBe(true);
+    expect(json.data[0]!.proof_payload.conversation_id).toBe('conv-1');
+  });
+
+  it('BE 에러 응답(4xx)은 그대로 통과시킨다(재포장 없음)', async () => {
+    h.proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ error: { code: 'NOT_FOUND', message: 'Story not found' } }), { status: 404 }),
+    );
+    const res = await GET(getReq(), ctx());
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/stories/[id]/references — 저장 왕복', () => {
+  beforeEach(() => {
+    h.getOrgProjectAuthContext.mockReset();
+    h.proxyToFastapiWithParams.mockReset();
+    h.getOrgProjectAuthContext.mockResolvedValue(me());
+  });
+
+  it('BE 201 응답을 그대로 전달한다', async () => {
+    h.proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ id: 'ref-new', form: 'proof', target_type: 'chat_message', target_id: 'msg-1', created_at: '2026-07-29T00:00:00Z' }), { status: 201 }),
+    );
+    const res = await POST(postReq({
+      target_type: 'chat_message', target_id: 'msg-1', form: 'proof',
+      proof_payload: { conversation_id: 'conv-1', start_message_id: 'msg-1', end_message_id: 'msg-1', snapshot: [] },
+    }), ctx());
+    expect(res.status).toBe(201);
+    const json = await res.json() as { data: { id: string } };
+    expect(json.data.id).toBe('ref-new');
+  });
+
+  it('BE 400(잘못된 form/target 조합)을 그대로 전달한다 — 조용히 삼키지 않는다', async () => {
+    h.proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ error: { code: 'BAD_REQUEST', message: "target_type='chat_message'·form='proof' only" } }), { status: 400 }),
+    );
+    const res = await POST(postReq({ target_type: 'doc', target_id: 'd1', form: 'mention', proof_payload: {} }), ctx());
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/src/app/api/stories/[id]/references/route.ts
+++ b/apps/web/src/app/api/stories/[id]/references/route.ts
@@ -1,0 +1,45 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors, type ApiMeta } from '@/lib/api-response';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/** GET /api/stories/{id}/references?direction=outgoing — story #2265(C-7): 이 스토리가
+ * 가리키는 참조 목록(지금은 proof form만 실사용). BE(list_references)는 convention-A
+ * ({data,meta})라 raw json.data ?? json 언랩 패턴으로 짓는다(backlinks/route.ts와 동형 —
+ * #2247/#2564 이중포장 사고 재발 금지). */
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const me = await getOrgProjectAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/stories/[id]/references', { id });
+    if (!_r.ok) return _r;
+    const beJson = await _r.json() as { data?: unknown; meta?: ApiMeta };
+    return apiSuccess(beJson.data ?? beJson, beJson.meta);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}
+
+/** POST /api/stories/{id}/references — story #2265(C-7) PR1b: 대화 인용(proof) 저장.
+ * BE는 지금 target_type="chat_message"·form="proof" 조합만 받고 나머진 400(조용한 무시
+ * 금지) — 이 라우트는 그대로 통과시키기만 한다(검증 재구현 없음, BE가 SSOT). */
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const me = await getOrgProjectAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/stories/[id]/references', { id });
+    if (!_r.ok) return _r;
+    const beJson = await _r.json() as Record<string, unknown>;
+    return apiSuccess(beJson, undefined, _r.status);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -21,6 +21,7 @@ import { OutcomeResultCard, type OutcomeResult } from '@/components/outcome/outc
 import { StoryHypothesesSection } from '@/components/hypotheses/story-hypotheses-section';
 import { StoryMergeGate } from '@/components/cage/story-merge-gate';
 import { EvidenceSection } from '@/components/verify/evidence-section';
+import { ChatProofSection } from '@/components/verify/chat-proof-section';
 import { deriveInFlightTrustChip } from '@/services/verify';
 import type { ProofState } from '@/components/proof-capsule/proof-capsule';
 import { Workcell, type WorkcellMessage } from '@/components/workcell/workcell';
@@ -954,6 +955,10 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
               humanVerifiedAt={story.human_verified_at}
               memberMap={memberMap}
             />
+            {/* story #2265(C-7) PR1b — "대화 근거"(proof). EvidenceSection 바로 아래,
+                "근거" 계열 이름으로(구조 이름 "참조"·"임베드" 미노출, PO 확定). 0건이면
+                EvidenceSection과 동일하게 null 렌더. */}
+            <ChatProofSection storyId={story.id} />
           </div>
           <div className="flex shrink-0 items-center gap-2">
             {/* story #2104 — BE stories.py:1056이 human-only로 hard-delete를 403 거부한다(되돌릴

--- a/apps/web/src/components/verify/chat-proof-section.test.tsx
+++ b/apps/web/src/components/verify/chat-proof-section.test.tsx
@@ -34,42 +34,47 @@ const VALID_ROW = {
 };
 
 describe('parseStoryProofReferences — story #2265(C-7) PR1b 파싱', () => {
-  it('proof+chat_message 조합만 통과시킨다', () => {
-    const out = parseStoryProofReferences({
+  it('proof+chat_message 조합만 통과시킨다 — 다른 form/target은 skippedIds에도 안 잡힌다(후보가 아니므로)', () => {
+    const { items, skippedIds } = parseStoryProofReferences({
       data: [VALID_ROW, { ...VALID_ROW, id: 'ref-2', form: 'mention' }, { ...VALID_ROW, id: 'ref-3', target_type: 'doc' }],
     });
-    expect(out).toHaveLength(1);
-    expect(out[0]!.id).toBe('ref-1');
+    expect(items).toHaveLength(1);
+    expect(items[0]!.id).toBe('ref-1');
+    expect(skippedIds).toEqual([]);
   });
 
-  it('{data:{data:[...]}} 이중포장·{data:[...]}·bare 배열 셋 다 받는다', () => {
-    expect(parseStoryProofReferences({ data: [VALID_ROW] })).toHaveLength(1);
-    expect(parseStoryProofReferences([VALID_ROW])).toHaveLength(1);
+  it('{data:[...]}·bare 배열 둘 다 받는다', () => {
+    expect(parseStoryProofReferences({ data: [VALID_ROW] }).items).toHaveLength(1);
+    expect(parseStoryProofReferences([VALID_ROW]).items).toHaveLength(1);
   });
 
-  it('proof_payload가 없으면(아직 BE가 안 실어주는 옛 응답) 그 항목을 생략한다 — 지어내지 않는다', () => {
+  it('proof_payload가 없으면(아직 BE가 안 실어주는 옛 응답) 그 항목을 items에서 생략하고 skippedIds에 센다', () => {
     const { proof_payload: _omit, ...withoutPayload } = VALID_ROW;
-    const out = parseStoryProofReferences({ data: [withoutPayload] });
-    expect(out).toHaveLength(0);
+    const { items, skippedIds } = parseStoryProofReferences({ data: [withoutPayload] });
+    expect(items).toHaveLength(0);
+    expect(skippedIds).toEqual(['ref-1']);
   });
 
-  it('snapshot이 배열이 아니거나 항목 형상이 깨지면 그 항목만 생략한다(다른 항목은 살아남는다)', () => {
+  it('snapshot이 배열이 아니거나 항목 형상이 깨지면 그 항목만 skippedIds로 가고 다른 항목은 items에 살아남는다', () => {
     const broken = { ...VALID_ROW, id: 'ref-broken', proof_payload: { ...VALID_ROW.proof_payload, snapshot: 'not-an-array' } };
-    const out = parseStoryProofReferences({ data: [broken, VALID_ROW] });
-    expect(out).toHaveLength(1);
-    expect(out[0]!.id).toBe('ref-1');
+    const { items, skippedIds } = parseStoryProofReferences({ data: [broken, VALID_ROW] });
+    expect(items).toHaveLength(1);
+    expect(items[0]!.id).toBe('ref-1');
+    expect(skippedIds).toEqual(['ref-broken']);
   });
 
   it('still_exists가 boolean이 아니면 null로 정직하게 취급한다(모름을 false로 지어내지 않는다)', () => {
     const noFlag = { ...VALID_ROW, still_exists: undefined };
-    const out = parseStoryProofReferences({ data: [noFlag] });
-    expect(out[0]!.stillExists).toBeNull();
+    const { items } = parseStoryProofReferences({ data: [noFlag] });
+    expect(items[0]!.stillExists).toBeNull();
   });
 
-  it('malformed 최상위 입력(null·문자열·빈 객체)은 전부 빈 배열', () => {
-    expect(parseStoryProofReferences(null)).toEqual([]);
-    expect(parseStoryProofReferences('oops')).toEqual([]);
-    expect(parseStoryProofReferences({})).toEqual([]);
+  it('malformed 최상위 입력(null·문자열·빈 객체)은 전부 items·skippedIds 둘 다 빈 배열', () => {
+    for (const input of [null, 'oops', {}]) {
+      const { items, skippedIds } = parseStoryProofReferences(input);
+      expect(items).toEqual([]);
+      expect(skippedIds).toEqual([]);
+    }
   });
 });
 
@@ -89,7 +94,7 @@ afterEach(async () => {
 });
 
 describe('ChatProofSection — story #2265(C-7) PR1b 섹션 렌더', () => {
-  it('참조가 0건이면 섹션 자체를 null 렌더한다(EvidenceSection과 동일 관례)', async () => {
+  it('참조가 0건이고 생략도 0건이면 섹션 자체를 null 렌더한다(EvidenceSection과 동일 관례)', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: [] }) })));
     await act(async () => { root.render(wrap(<ChatProofSection storyId="story-1" />)); });
     await act(async () => { await Promise.resolve(); });
@@ -118,5 +123,35 @@ describe('ChatProofSection — story #2265(C-7) PR1b 섹션 렌더', () => {
     await act(async () => { await Promise.resolve(); });
     expect(container.textContent).not.toContain('이 방향으로 가시는');
     expect(container.textContent).toContain('삭제됨');
+  });
+
+  it('생략된 항목이 있으면 items가 0건이어도 섹션이 뜨고 "표시할 수 없음" 수를 보인다(모름이 괜찮음으로 안 사라짐, PO 지적 2026-07-29)', async () => {
+    const { proof_payload: _omit, ...broken } = VALID_ROW;
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: [broken] }) })));
+    await act(async () => { root.render(wrap(<ChatProofSection storyId="story-1" />)); });
+    await act(async () => { await Promise.resolve(); });
+    expect(container.textContent).toContain('1건은 표시할 수 없음');
+  });
+
+  it('생략된 항목이 있으면 개발환경에서 console.warn으로 남긴다(다음 사람이 왜 안 뜨는지 볼 수 있게)', async () => {
+    const { proof_payload: _omit, ...broken } = VALID_ROW;
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: [broken] }) })));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await act(async () => { root.render(wrap(<ChatProofSection storyId="story-1" />)); });
+    await act(async () => { await Promise.resolve(); });
+    expect(warnSpy).toHaveBeenCalledWith(
+      'ChatProofSection: skipped malformed proof reference(s)',
+      expect.objectContaining({ storyId: 'story-1', skippedIds: ['ref-1'] }),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('생략 없이 정상 항목만 있으면 console.warn을 안 부른다(노이즈 0)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: [VALID_ROW] }) })));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await act(async () => { root.render(wrap(<ChatProofSection storyId="story-1" />)); });
+    await act(async () => { await Promise.resolve(); });
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 });

--- a/apps/web/src/components/verify/chat-proof-section.test.tsx
+++ b/apps/web/src/components/verify/chat-proof-section.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { ChatProofSection, parseStoryProofReferences } from './chat-proof-section';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+const VALID_ROW = {
+  id: 'ref-1',
+  form: 'proof',
+  target_type: 'chat_message',
+  target_id: 'msg-1',
+  created_at: '2026-07-29T00:00:00.000Z',
+  still_exists: true,
+  proof_payload: {
+    conversation_id: 'conv-1',
+    start_message_id: 'msg-1',
+    end_message_id: 'msg-2',
+    snapshot: [
+      { message_id: 'msg-1', author_id: 'member-1', content: '이 방향으로 가시는', created_at: '2026-07-28T00:00:00.000Z' },
+    ],
+  },
+};
+
+describe('parseStoryProofReferences — story #2265(C-7) PR1b 파싱', () => {
+  it('proof+chat_message 조합만 통과시킨다', () => {
+    const out = parseStoryProofReferences({
+      data: [VALID_ROW, { ...VALID_ROW, id: 'ref-2', form: 'mention' }, { ...VALID_ROW, id: 'ref-3', target_type: 'doc' }],
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]!.id).toBe('ref-1');
+  });
+
+  it('{data:{data:[...]}} 이중포장·{data:[...]}·bare 배열 셋 다 받는다', () => {
+    expect(parseStoryProofReferences({ data: [VALID_ROW] })).toHaveLength(1);
+    expect(parseStoryProofReferences([VALID_ROW])).toHaveLength(1);
+  });
+
+  it('proof_payload가 없으면(아직 BE가 안 실어주는 옛 응답) 그 항목을 생략한다 — 지어내지 않는다', () => {
+    const { proof_payload: _omit, ...withoutPayload } = VALID_ROW;
+    const out = parseStoryProofReferences({ data: [withoutPayload] });
+    expect(out).toHaveLength(0);
+  });
+
+  it('snapshot이 배열이 아니거나 항목 형상이 깨지면 그 항목만 생략한다(다른 항목은 살아남는다)', () => {
+    const broken = { ...VALID_ROW, id: 'ref-broken', proof_payload: { ...VALID_ROW.proof_payload, snapshot: 'not-an-array' } };
+    const out = parseStoryProofReferences({ data: [broken, VALID_ROW] });
+    expect(out).toHaveLength(1);
+    expect(out[0]!.id).toBe('ref-1');
+  });
+
+  it('still_exists가 boolean이 아니면 null로 정직하게 취급한다(모름을 false로 지어내지 않는다)', () => {
+    const noFlag = { ...VALID_ROW, still_exists: undefined };
+    const out = parseStoryProofReferences({ data: [noFlag] });
+    expect(out[0]!.stillExists).toBeNull();
+  });
+
+  it('malformed 최상위 입력(null·문자열·빈 객체)은 전부 빈 배열', () => {
+    expect(parseStoryProofReferences(null)).toEqual([]);
+    expect(parseStoryProofReferences('oops')).toEqual([]);
+    expect(parseStoryProofReferences({})).toEqual([]);
+  });
+});
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe('ChatProofSection — story #2265(C-7) PR1b 섹션 렌더', () => {
+  it('참조가 0건이면 섹션 자체를 null 렌더한다(EvidenceSection과 동일 관례)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: [] }) })));
+    await act(async () => { root.render(wrap(<ChatProofSection storyId="story-1" />)); });
+    await act(async () => { await Promise.resolve(); });
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('참조가 있으면 인용 카드를 그리고 개수를 보인다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: [VALID_ROW] }) })));
+    await act(async () => { root.render(wrap(<ChatProofSection storyId="story-1" />)); });
+    await act(async () => { await Promise.resolve(); });
+    expect(container.textContent).toContain('이 방향으로 가시는');
+    expect(container.textContent).toContain('1');
+  });
+
+  it('fetch 실패 시 크래시 없이 빈 상태(null 렌더)로 graceful degrade한다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network'); }));
+    await act(async () => { root.render(wrap(<ChatProofSection storyId="story-1" />)); });
+    await act(async () => { await Promise.resolve(); });
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('still_exists=false인 항목은 삭제됨 상태로 렌더한다(내용 숨김·삭제됨 표지)', async () => {
+    const deleted = { ...VALID_ROW, still_exists: false };
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: [deleted] }) })));
+    await act(async () => { root.render(wrap(<ChatProofSection storyId="story-1" />)); });
+    await act(async () => { await Promise.resolve(); });
+    expect(container.textContent).not.toContain('이 방향으로 가시는');
+    expect(container.textContent).toContain('삭제됨');
+  });
+});

--- a/apps/web/src/components/verify/chat-proof-section.tsx
+++ b/apps/web/src/components/verify/chat-proof-section.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { ChatProofEmbed } from './chat-proof-embed';
+
+interface ProofSnapshotMessage {
+  message_id: string;
+  author_id: string;
+  content: string;
+  created_at: string;
+}
+
+export interface StoryProofReference {
+  id: string;
+  createdAt: string;
+  stillExists: boolean | null;
+  conversationId: string;
+  startMessageId: string;
+  snapshot: ProofSnapshotMessage[];
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function parseSnapshot(raw: unknown): ProofSnapshotMessage[] | null {
+  if (!Array.isArray(raw)) return null;
+  const out: ProofSnapshotMessage[] = [];
+  for (const item of raw) {
+    if (!isRecord(item)) return null;
+    const { message_id, author_id, content, created_at } = item;
+    if (
+      typeof message_id !== 'string' || typeof author_id !== 'string'
+      || typeof content !== 'string' || typeof created_at !== 'string'
+    ) return null;
+    out.push({ message_id, author_id, content, created_at });
+  }
+  return out;
+}
+
+/**
+ * story #2265(C-7) PR1b — `GET /api/stories/{id}/references?direction=outgoing` 응답을
+ * 검증된 proof 참조 배열로. `form="proof"`·`target_type="chat_message"` 조합만 대상(다른
+ * form/target은 이 화면 소관이 아니다 — 조용히 생략, no-fiction). `proof_payload`가
+ * 없거나(구 BE 응답·아직 배선 前) 형상이 안 맞으면 그 항목은 렌더할 재료가 없으므로 생략한다
+ * (지어내지 않음 — 항목 하나가 깨졌다고 전체를 실패시키지도 않는다).
+ */
+export function parseStoryProofReferences(json: unknown): StoryProofReference[] {
+  const inner = isRecord(json) ? (json['data'] ?? json) : json;
+  const rows = Array.isArray(inner) ? inner : [];
+
+  const out: StoryProofReference[] = [];
+  for (const row of rows) {
+    if (!isRecord(row)) continue;
+    if (row['form'] !== 'proof' || row['target_type'] !== 'chat_message') continue;
+    const id = row['id'];
+    const createdAt = row['created_at'];
+    if (typeof id !== 'string' || typeof createdAt !== 'string') continue;
+    const payload = row['proof_payload'];
+    if (!isRecord(payload)) continue; // 아직 payload가 안 실리는 BE 응답 — 이 항목은 못 그림.
+    const conversationId = payload['conversation_id'];
+    const startMessageId = payload['start_message_id'];
+    if (typeof conversationId !== 'string' || typeof startMessageId !== 'string') continue;
+    const snapshot = parseSnapshot(payload['snapshot']);
+    if (!snapshot) continue;
+    const stillExists = typeof row['still_exists'] === 'boolean' ? row['still_exists'] : null;
+    out.push({ id, createdAt, stillExists, conversationId, startMessageId, snapshot });
+  }
+  return out;
+}
+
+function formatCitationDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return new Intl.DateTimeFormat('ko-KR', { month: 'numeric', day: 'numeric' }).format(d);
+}
+
+interface ChatProofSectionProps {
+  storyId: string;
+}
+
+/**
+ * story #2265(C-7) PR1b — `EvidenceSection` 바로 아래 붙는 "대화 근거" 섹션. 참조 0건이면
+ * null 렌더(EvidenceSection과 동일 관례 — 빈 섹션을 굳이 안 보임).
+ *
+ * ⛔이름 해소 생략: snapshot의 author_id를 팀원 이름으로 바꾸려면 별도 조회가 필요한데, 이
+ * 슬라이스(PR1b-1, 읽기 전용 얹기)에는 없다 — 빈 문자열로 두어 raw UUID를 노출하지 않는
+ * 쪽을 택했다(없는 것을 지어내지 않음). 후속 슬라이스에서 memberMap을 받아 채운다.
+ */
+export function ChatProofSection({ storyId }: ChatProofSectionProps) {
+  const t = useTranslations('verify');
+  const [refs, setRefs] = useState<StoryProofReference[] | null>(null);
+  const [loadedForId, setLoadedForId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/stories/${storyId}/references?direction=outgoing`, { cache: 'no-store' })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json) => {
+        if (cancelled) return;
+        setRefs(json ? parseStoryProofReferences(json) : []);
+        setLoadedForId(storyId);
+      })
+      .catch(() => {
+        if (!cancelled) { setRefs([]); setLoadedForId(storyId); }
+      });
+    return () => { cancelled = true; };
+  }, [storyId]);
+
+  if (refs === null || loadedForId !== storyId || refs.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      <p className="text-[11px] font-medium text-muted-foreground">
+        {t('chatProofCount', { count: refs.length })}
+      </p>
+      {refs.map((ref) => (
+        <ChatProofEmbed
+          key={ref.id}
+          sourceLabel={`${t('chatProofSectionTitle')} · ${formatCitationDate(ref.createdAt)}`}
+          conversationHref={`/chats/${ref.conversationId}?messageId=${ref.startMessageId}`}
+          quotedAt={formatCitationDate(ref.createdAt)}
+          status={ref.stillExists === false ? 'deleted' : 'normal'}
+          messages={ref.snapshot.map((m) => ({ id: m.message_id, senderName: '', content: m.content }))}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/verify/chat-proof-section.tsx
+++ b/apps/web/src/components/verify/chat-proof-section.tsx
@@ -39,35 +39,48 @@ function parseSnapshot(raw: unknown): ProofSnapshotMessage[] | null {
   return out;
 }
 
+export interface ParsedStoryProofReferences {
+  items: StoryProofReference[];
+  /** story #2265(C-7), PO 지적(2026-07-29): form="proof"·target_type="chat_message"인
+   * «후보»였지만 이후 검증(payload 없음·형상 깨짐)에서 떨어져 못 그리는 항목의 id. 이걸
+   * 안 세면 "대화 근거 2건"이 실은 3건 중 2건이라는 사실이 사라진다 — "모름이 «괜찮음»으로
+   * 집계"되는 것을 막는다. 다른 form(mention 등)이나 다른 target_type은 애초에 이 섹션의
+   * 후보가 아니므로 여기 안 들어간다(스킵 대상은 "보여줘야 했는데 못 보여준 것"만). */
+  skippedIds: string[];
+}
+
 /**
  * story #2265(C-7) PR1b — `GET /api/stories/{id}/references?direction=outgoing` 응답을
  * 검증된 proof 참조 배열로. `form="proof"`·`target_type="chat_message"` 조합만 대상(다른
  * form/target은 이 화면 소관이 아니다 — 조용히 생략, no-fiction). `proof_payload`가
  * 없거나(구 BE 응답·아직 배선 前) 형상이 안 맞으면 그 항목은 렌더할 재료가 없으므로 생략한다
- * (지어내지 않음 — 항목 하나가 깨졌다고 전체를 실패시키지도 않는다).
+ * (지어내지 않음 — 항목 하나가 깨졌다고 전체를 실패시키지도 않는다). 다만 그 생략은
+ * `skippedIds`로 «세어서» 남긴다(호출부가 "N건은 표시할 수 없음"을 보일 수 있게).
  */
-export function parseStoryProofReferences(json: unknown): StoryProofReference[] {
+export function parseStoryProofReferences(json: unknown): ParsedStoryProofReferences {
   const inner = isRecord(json) ? (json['data'] ?? json) : json;
   const rows = Array.isArray(inner) ? inner : [];
 
-  const out: StoryProofReference[] = [];
+  const items: StoryProofReference[] = [];
+  const skippedIds: string[] = [];
   for (const row of rows) {
     if (!isRecord(row)) continue;
     if (row['form'] !== 'proof' || row['target_type'] !== 'chat_message') continue;
     const id = row['id'];
     const createdAt = row['created_at'];
-    if (typeof id !== 'string' || typeof createdAt !== 'string') continue;
+    if (typeof id !== 'string' || typeof createdAt !== 'string') continue; // id 자체가 없으면 셀 대상도 못 됨.
     const payload = row['proof_payload'];
-    if (!isRecord(payload)) continue; // 아직 payload가 안 실리는 BE 응답 — 이 항목은 못 그림.
-    const conversationId = payload['conversation_id'];
-    const startMessageId = payload['start_message_id'];
-    if (typeof conversationId !== 'string' || typeof startMessageId !== 'string') continue;
-    const snapshot = parseSnapshot(payload['snapshot']);
-    if (!snapshot) continue;
+    const conversationId = isRecord(payload) ? payload['conversation_id'] : undefined;
+    const startMessageId = isRecord(payload) ? payload['start_message_id'] : undefined;
+    const snapshot = isRecord(payload) ? parseSnapshot(payload['snapshot']) : null;
+    if (!isRecord(payload) || typeof conversationId !== 'string' || typeof startMessageId !== 'string' || !snapshot) {
+      skippedIds.push(id);
+      continue;
+    }
     const stillExists = typeof row['still_exists'] === 'boolean' ? row['still_exists'] : null;
-    out.push({ id, createdAt, stillExists, conversationId, startMessageId, snapshot });
+    items.push({ id, createdAt, stillExists, conversationId, startMessageId, snapshot });
   }
-  return out;
+  return { items, skippedIds };
 }
 
 function formatCitationDate(iso: string): string {
@@ -91,6 +104,7 @@ interface ChatProofSectionProps {
 export function ChatProofSection({ storyId }: ChatProofSectionProps) {
   const t = useTranslations('verify');
   const [refs, setRefs] = useState<StoryProofReference[] | null>(null);
+  const [skippedCount, setSkippedCount] = useState(0);
   const [loadedForId, setLoadedForId] = useState<string | null>(null);
 
   useEffect(() => {
@@ -99,21 +113,30 @@ export function ChatProofSection({ storyId }: ChatProofSectionProps) {
       .then((r) => (r.ok ? r.json() : null))
       .then((json) => {
         if (cancelled) return;
-        setRefs(json ? parseStoryProofReferences(json) : []);
+        const { items, skippedIds } = json ? parseStoryProofReferences(json) : { items: [], skippedIds: [] };
+        if (skippedIds.length > 0 && process.env.NODE_ENV !== 'production') {
+          // dev 전용: 다음 사람이 왜 안 뜨는지 보게(PO 지시, 2026-07-29).
+          console.warn('ChatProofSection: skipped malformed proof reference(s)', { storyId, skippedIds });
+        }
+        setRefs(items);
+        setSkippedCount(skippedIds.length);
         setLoadedForId(storyId);
       })
       .catch(() => {
-        if (!cancelled) { setRefs([]); setLoadedForId(storyId); }
+        if (!cancelled) { setRefs([]); setSkippedCount(0); setLoadedForId(storyId); }
       });
     return () => { cancelled = true; };
   }, [storyId]);
 
-  if (refs === null || loadedForId !== storyId || refs.length === 0) return null;
+  if (refs === null || loadedForId !== storyId || (refs.length === 0 && skippedCount === 0)) return null;
 
   return (
     <div className="space-y-2">
       <p className="text-[11px] font-medium text-muted-foreground">
         {t('chatProofCount', { count: refs.length })}
+        {/* story #2265(C-7), PO 지적(2026-07-29): 생략 건수는 반드시 세어서 말한다("모름"이
+            "괜찮음"으로 집계되면 안 됨) — 정확한 문구는 유나군 lane(자리만 확保). */}
+        {skippedCount > 0 ? ` · ${t('chatProofSomeUnavailable', { count: skippedCount })}` : ''}
       </p>
       {refs.map((ref) => (
         <ChatProofEmbed


### PR DESCRIPTION
## 요약
story #2265(C-7) PR1b — BE #2632(`feat/2263-story-outgoing-references`, 아직 develop 미머지)의 outgoing 읽기/쓰기 라우트를 소비해 `ChatProofEmbed`(PR1a)를 스토리 상세에 실제로 얹는다.

⚠️ **PR1a(`fix/2265-evidence-count-scoped-label`) 위에 스택된 PR입니다.**
⚠️ **BE 의존성**: 목록 응답(`GET /{id}/references`)에 `proof_payload`가 실리는 것을 전제로 짰습니다 — 이건 PO가 오늘 까심군에게 정정 요청한 변경(원래 계약은 목록=메타만이었는데, N개 카드를 한 화면에 펼치는 소비 패턴상 N+1을 피하려면 목록에 payload가 실려야 함)이라 아직 BE에 반영 전입니다. BE가 이 모양으로 착지한 뒤 머지해주세요.

## 변경 사항
- Next.js 프록시 라우트(`GET`+`POST /api/stories/{id}/references`) — `backlinks/route.ts`와 동형(이중포장 방지 패턴 재사용)
- `ChatProofSection`: `EvidenceSection` 바로 아래, "대화 근거" 이름(구조 이름 "참조"·"임베드" 미노출, PO 확定)
- `parseStoryProofReferences`: `form="proof"`·`target_type="chat_message"` 조합만 통과, `proof_payload` 없거나 형상이 깨진 항목은 개별 생략(no-fiction — 전체 실패시키지 않음)
- `still_exists=false` → `ChatProofEmbed status="deleted"`(AC7 결론대로 "수정됨"은 전제가 없어 절대 안 씀 — 편집 기능 자체가 제품에 없음. "삭제됨"만 실제로 도달 가능)

## 이 PR에 없는 것 (의도적, 다음 슬라이스 — PR1b-2)
- `author_id` → 이름 해소(memberMap 필요, 지금은 없는 것을 지어내지 않고 빈 문자열로 둠)
- 선택 확定 → POST 저장 액션 + `citeAction` 켜기(write 흐름 자체는 이미 서 있는 라우트를 그대로 씀)

## 검증
- [x] `pnpm build` 성공(EXIT 0)
- [x] `pnpm lint` 경고 0개(대상 파일 전수)
- [x] `tsc --noEmit` 클린
- [x] vitest verify/+stories API 56/56 통과(신규 14건, 무회귀)
- [x] 뮤테이션 검증 — form/target_type 필터 제거 → 테스트 RED 확認 후 원복 GREEN