### PR TITLE
[SID:2265] C-7 chat-view 배선 — 선택 상태 연결(진입점은 아직 안 켜짐) [재오픈: #2631 대체]

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -136,3 +136,55 @@ describe('ChatBubble 문서 임베드 미리보기 모달 — 폴링 유발 리�
     expect(document.body.querySelector('button[aria-label="닫기"]')).not.toBeNull();
   });
 });
+
+describe('ChatBubble — story #2265(C-7) 인용 범위 선택 배선(props 생략 시 회귀 0)', () => {
+  it('isCiteAnchor·isCiteInRange·citeAction을 전부 생략하면 좌측 표시가 안 생긴다(기존 호출부 무변경)', async () => {
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={baseMessage} isMine={false} />));
+    });
+    const wrapperDiv = container.querySelector(`#msg-${baseMessage.id}`);
+    expect(wrapperDiv?.className).not.toContain('border-l-primary');
+  });
+
+  it('isCiteAnchor가 true면 좌측 3px 표시 클래스가 붙는다', async () => {
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={baseMessage} isMine={false} isCiteAnchor />));
+    });
+    const wrapperDiv = container.querySelector(`#msg-${baseMessage.id}`);
+    expect(wrapperDiv?.className).toContain('border-l-primary');
+  });
+
+  it('isCiteInRange가 true면 좌측 3px 표시 클래스가 붙는다', async () => {
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={baseMessage} isMine={false} isCiteInRange />));
+    });
+    const wrapperDiv = container.querySelector(`#msg-${baseMessage.id}`);
+    expect(wrapperDiv?.className).toContain('border-l-primary');
+  });
+
+  it('citeAction을 생략하면(호출부가 아직 안 넘긴 상태) 우클릭 메뉴에 인용 항목이 안 뜬다', async () => {
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={baseMessage} isMine={false} />));
+    });
+    const wrapperDiv = container.querySelector(`#msg-${baseMessage.id}`)!;
+    await act(async () => {
+      wrapperDiv.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, clientX: 10, clientY: 10 }));
+    });
+    expect(container.textContent).not.toContain('인용');
+    expect(document.body.textContent).not.toContain('인용');
+  });
+
+  it('citeAction을 넘기면 우클릭 메뉴에 그 kind에 맞는 인용 항목이 뜬다', async () => {
+    const onSelect = () => {};
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble message={baseMessage} isMine={false} citeAction={{ kind: 'start', onSelect }} />,
+      ));
+    });
+    const wrapperDiv = container.querySelector(`#msg-${baseMessage.id}`)!;
+    await act(async () => {
+      wrapperDiv.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, clientX: 10, clientY: 10 }));
+    });
+    expect(document.body.textContent).toContain('여기부터 인용');
+  });
+});

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -14,7 +14,7 @@ import { getFileIcon } from '@/lib/file-icon';
 import { AttachmentImage } from './attachment-image';
 import { AttachmentMedia } from './attachment-media';
 import { AttachmentFile } from './attachment-file';
-import { MessageContextMenu } from './message-context-menu';
+import { MessageContextMenu, type CiteAction } from './message-context-menu';
 import { PresenceDot, WORKING_RING_CLASS, type PresenceStatus } from './presence-dot';
 import { ReferenceSuggestionRow } from './reference-suggestion-row';
 
@@ -31,6 +31,12 @@ interface ChatBubbleProps {
   highlight?: boolean;
   /** story #2283: 참조 후보(#번호·#슬러그) 해소 스코프. 없으면 그 확인 UI가 시도를 안 한다. */
   projectId?: string;
+  /** story #2265(C-7) — 대화 인용(proof) 범위 선택 배선. 셋 다 생략하면(undefined) 기존
+   * 렌더와 완전히 동일하다 — 진입점(citeAction)을 호출부가 아직 안 넘기는 한 이 기능은
+   * 사용자에게 안 보인다("짓되 안 켜는다", PO 지시 2026-07-29). */
+  isCiteAnchor?: boolean;
+  isCiteInRange?: boolean;
+  citeAction?: CiteAction;
 }
 
 interface ContextMenuState {
@@ -213,7 +219,10 @@ function ChatMarkdown({ content, isMine, references }: { content: string; isMine
 
 const LONG_PRESS_MS = 500;
 
-export function ChatBubble({ message, isMine, isGrouped = false, onOpenThread, onDelete, presenceStatus, isWorking = false, highlight = false, projectId }: ChatBubbleProps) {
+export function ChatBubble({
+  message, isMine, isGrouped = false, onOpenThread, onDelete, presenceStatus, isWorking = false,
+  highlight = false, projectId, isCiteAnchor = false, isCiteInRange = false, citeAction,
+}: ChatBubbleProps) {
   const t = useTranslations('chats');
   const isAgent = message.sender_type === 'agent';
   // S8: 슬래시 커맨드는 전용 버블(brand·mono·⌘). 리터럴(`//`)은 dequote된 일반 텍스트.
@@ -283,7 +292,7 @@ export function ChatBubble({ message, isMine, isGrouped = false, onOpenThread, o
     <>
       <div
         id={`msg-${message.id}`}
-        className={`flex scroll-mt-4 gap-2 transition-shadow ${isMine ? 'flex-row-reverse' : 'flex-row'} ${isGrouped ? 'mt-0.5' : 'mt-2'} ${highlight ? 'rounded-lg ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}`}
+        className={`flex scroll-mt-4 gap-2 transition-shadow ${isMine ? 'flex-row-reverse' : 'flex-row'} ${isGrouped ? 'mt-0.5' : 'mt-2'} ${highlight ? 'rounded-lg ring-2 ring-primary ring-offset-2 ring-offset-background' : ''} ${(isCiteAnchor || isCiteInRange) ? 'border-l-[3px] border-l-primary pl-1' : ''}`}
         onContextMenu={handleContextMenu}
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
@@ -426,6 +435,7 @@ export function ChatBubble({ message, isMine, isGrouped = false, onOpenThread, o
           onCopy={handleCopy}
           onDelete={handleDelete}
           onClose={() => setContextMenu(null)}
+          citeAction={citeAction}
         />
       )}
     </>

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ChevronLeft, RefreshCw } from 'lucide-react';
 import { usePathname, useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
@@ -13,6 +13,7 @@ import { ThreadPanel } from './thread-panel';
 import type { ChatMessage, SendAttachment } from '@/hooks/use-chat-sse';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { normalizeToMessage, useChatSse, type SseWorkingPayload } from '@/hooks/use-chat-sse';
+import { useMessageRangeSelection } from '@/hooks/use-message-range-selection';
 import { EmptyState } from '@/components/ui/empty-state';
 
 interface ChatViewProps {
@@ -62,6 +63,11 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   const t = useTranslations('chats');
   const isMobile = useIsMobile();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  // story #2265(C-7) — 대화 인용(proof) 범위 선택. 진입점(citeAction)은 아직 ChatBubble에
+  // 안 넘긴다("짓되 안 켜는다", PO 지시 2026-07-29 — write 엔드포인트가 서면 그 한 줄로 켠다).
+  // 그래서 mode는 지금 항상 'idle'이고 isAnchor/isInRange도 항상 false — 사용자 눈엔 무변화.
+  const citeSelection = useMessageRangeSelection();
+  const orderedMessageIds = useMemo(() => messages.map((m) => m.id), [messages]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(false);
@@ -645,6 +651,8 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
                             isWorking={typingAgents.some((a) => a.id === msg.created_by)}
                             highlight={msg.id === highlightId}
                             projectId={projectId}
+                            isCiteAnchor={citeSelection.isAnchor(msg.id)}
+                            isCiteInRange={citeSelection.isInRange(msg.id, orderedMessageIds)}
                           />
                           {/* S5: 트리거 메시지 직후 차단 hint notice(차단 에이전트별 1건) */}
                           {commandHints[msg.id]?.map((h) => (

--- a/apps/web/src/components/chat/message-context-menu.tsx
+++ b/apps/web/src/components/chat/message-context-menu.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef } from 'react';
 import { MessageSquareReply, Copy, Trash2, Quote } from 'lucide-react';
 
-interface CiteAction {
+export interface CiteAction {
   /** story #2265(C-7) PR2 — 아직 선택 중이 아니면 "start"(여기부터), 이미 다른 메시지가
    * anchor로 찍힌 중이면 "end"(여기까지). 라벨/판단은 호출부(use-message-range-selection
    * 소비부)가 정하고, 이 메뉴는 그 결정을 그대로 그린다. */


### PR DESCRIPTION
## 요약
PR#2631의 대체입니다 — #2631은 base(`feat/2265-message-range-selection`, PR#2630)가 머지 후 삭제되면서 GitHub이 자동으로 CLOSED 처리했습니다(재오픈 불가 확認). 내용은 #2631과 완전히 동일하며, `develop`(PR#2630 머지 후 최신)에서 새로 분기해 동일 커밋을 cherry-pick했습니다.

## 내용 (원본 #2631과 동일)
story #2265(C-7)의 다음 조각 — `use-message-range-selection`(PR#2630, 머지됨)을 실제 chat-view에 연결한다. **다만 진입점(`MessageContextMenu`의 `citeAction`)은 이 PR에서 켜지 않는다.**

왜 "짓되 켜지 않는가" — write 엔드포인트가 당시엔 없어(#2632로 이제 해결됨), 지금 메뉴 항목을 사용자에게 보이면 "골랐는데 저장이 안 되는" 결함이 된다.

- `ChatBubble`: `isCiteAnchor`/`isCiteInRange`/`citeAction` 3개 optional prop 추가. 전부 생략하면(기존 호출부) 렌더가 완전히 동일
- `MessageContextMenu`: `CiteAction` 타입 export
- `chat-view`: 훅 인스턴스화 + `orderedMessageIds` 계산 + `isCiteAnchor`/`isCiteInRange`를 `ChatBubble`에 전달. `citeAction`은 의도적으로 안 넘김

## 검증
- [x] `pnpm build` 성공(EXIT 0)
- [x] `pnpm lint` 경고 0개
- [x] `tsc --noEmit` 클린
- [x] vitest chat/ 스위트 105/105 통과(develop 최신 기준 재확認, 무회귀)
- [x] `git diff origin/develop --stat` — 정확히 4개 파일만(다른 PR 내용 안 섞임)