### PR TITLE
[SID:2265] C-7 저장 조각 — citeAction 켜기 + 스토리에 저장(오늘의 마지막 문)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2778,7 +2778,6 @@
     "citationSaveToStory": "Save to story",
     "citationSaving": "Saving…",
     "citationSaved": "Saved",
-    "citationSaveFailed": "Save failed — please try again",
     "referenceCandidatePromptStory": "Link {token} as a story?",
     "referenceCandidatePromptDoc": "Link {token} as a doc?",
     "referenceCandidateConfirm": "Yes",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2772,6 +2772,13 @@
   },
   "chats": {
     "unreadMarker": "Unread from here",
+    "citationAnchored": "Cited from here — pick the last message",
+    "citationSelectedCount": "{count} messages selected",
+    "citationCancel": "Cancel",
+    "citationSaveToStory": "Save to story",
+    "citationSaving": "Saving…",
+    "citationSaved": "Saved",
+    "citationSaveFailed": "Save failed — please try again",
     "referenceCandidatePromptStory": "Link {token} as a story?",
     "referenceCandidatePromptDoc": "Link {token} as a doc?",
     "referenceCandidateConfirm": "Yes",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2772,6 +2772,13 @@
   },
   "chats": {
     "unreadMarker": "여기부터 안읽음",
+    "citationAnchored": "여기부터 인용 — 끝 메시지를 마저 골라 주세요",
+    "citationSelectedCount": "{count}개 메시지 선택됨",
+    "citationCancel": "취소",
+    "citationSaveToStory": "스토리에 저장",
+    "citationSaving": "저장 중…",
+    "citationSaved": "저장됨",
+    "citationSaveFailed": "저장 실패 — 다시 시도해 주세요",
     "referenceCandidatePromptStory": "{token}를 스토리로 잇겠습니까?",
     "referenceCandidatePromptDoc": "{token}를 문서로 잇겠습니까?",
     "referenceCandidateConfirm": "예",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2778,7 +2778,6 @@
     "citationSaveToStory": "스토리에 저장",
     "citationSaving": "저장 중…",
     "citationSaved": "저장됨",
-    "citationSaveFailed": "저장 실패 — 다시 시도해 주세요",
     "referenceCandidatePromptStory": "{token}를 스토리로 잇겠습니까?",
     "referenceCandidatePromptDoc": "{token}를 문서로 잇겠습니까?",
     "referenceCandidateConfirm": "예",

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -14,6 +14,8 @@ import type { ChatMessage, SendAttachment } from '@/hooks/use-chat-sse';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { normalizeToMessage, useChatSse, type SseWorkingPayload } from '@/hooks/use-chat-sse';
 import { useMessageRangeSelection } from '@/hooks/use-message-range-selection';
+import { CitationComposeBar, type CitationSaveState } from './citation-compose-bar';
+import { StoryPickerDialog } from '@/components/canvas/story-picker-dialog';
 import { EmptyState } from '@/components/ui/empty-state';
 
 interface ChatViewProps {
@@ -63,11 +65,12 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   const t = useTranslations('chats');
   const isMobile = useIsMobile();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
-  // story #2265(C-7) — 대화 인용(proof) 범위 선택. 진입점(citeAction)은 아직 ChatBubble에
-  // 안 넘긴다("짓되 안 켜는다", PO 지시 2026-07-29 — write 엔드포인트가 서면 그 한 줄로 켠다).
-  // 그래서 mode는 지금 항상 'idle'이고 isAnchor/isInRange도 항상 false — 사용자 눈엔 무변화.
+  // story #2265(C-7) 저장 조각(2026-07-29) — write 엔드포인트(#2632)가 서서 citeAction을
+  // 실제로 켠다. 선택 확定(confirming) 후 스토리 피커를 열어 골라진 스토리에 저장한다.
   const citeSelection = useMessageRangeSelection();
   const orderedMessageIds = useMemo(() => messages.map((m) => m.id), [messages]);
+  const [citationPickerOpen, setCitationPickerOpen] = useState(false);
+  const [citationSaveState, setCitationSaveState] = useState<CitationSaveState>('idle');
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(false);
@@ -362,6 +365,50 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
     setMessages((prev) => prev.filter((m) => m.id !== messageId));
   }, [apiPrefix, threadId]);
 
+  // story #2265(C-7) 저장 조각 — 확定된 range(rangeStartId~rangeEndId, orderedMessageIds
+  // 순서 기준 양끝 포함)를 스냅샷으로 얼려 골라진 스토리에 proof로 POST한다. 스냅샷을
+  // 얼리는 이유는 PO 판정(2026-07-29): "얼려야 대조가 가능하다" — proof_payload.snapshot
+  // 참조.
+  const handleSaveCitation = useCallback(async (storyId: string) => {
+    const { rangeStartId, rangeEndId } = citeSelection;
+    if (!rangeStartId || !rangeEndId) return;
+    const startIndex = orderedMessageIds.indexOf(rangeStartId);
+    const endIndex = orderedMessageIds.indexOf(rangeEndId);
+    if (startIndex === -1 || endIndex === -1) return;
+    const rangeMessages = messages.slice(startIndex, endIndex + 1);
+    if (rangeMessages.length === 0) return;
+
+    setCitationSaveState('saving');
+    try {
+      const res = await fetch(`/api/stories/${storyId}/references`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          target_type: 'chat_message',
+          target_id: rangeStartId,
+          form: 'proof',
+          proof_payload: {
+            conversation_id: threadId,
+            start_message_id: rangeStartId,
+            end_message_id: rangeEndId,
+            snapshot: rangeMessages.map((m) => ({
+              message_id: m.id, author_id: m.created_by, content: m.content, created_at: m.created_at,
+            })),
+          },
+        }),
+      });
+      if (!res.ok) { setCitationSaveState('error'); return; }
+      setCitationSaveState('saved');
+      setCitationPickerOpen(false);
+      window.setTimeout(() => {
+        citeSelection.cancel();
+        setCitationSaveState('idle');
+      }, 1500);
+    } catch {
+      setCitationSaveState('error');
+    }
+  }, [citeSelection, orderedMessageIds, messages, threadId]);
+
   // P2 RC: 자신이 보낸 스레드 답글은 SSE 미수신 → 로컬에서 reply_count +1
   const handleReplyAdded = useCallback((parentId: string) => {
     setMessages((prev) =>
@@ -653,6 +700,13 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
                             projectId={projectId}
                             isCiteAnchor={citeSelection.isAnchor(msg.id)}
                             isCiteInRange={citeSelection.isInRange(msg.id, orderedMessageIds)}
+                            citeAction={
+                              citeSelection.mode === 'confirming'
+                                ? undefined // 범위 확定 후엔 저장/취소를 먼저 끝내게(재선택은 취소부터).
+                                : citeSelection.mode === 'anchored'
+                                  ? { kind: 'end', onSelect: () => citeSelection.confirmEnd(msg.id, orderedMessageIds) }
+                                  : { kind: 'start', onSelect: () => citeSelection.startSelection(msg.id) }
+                            }
                           />
                           {/* S5: 트리거 메시지 직후 차단 hint notice(차단 에이전트별 1건) */}
                           {commandHints[msg.id]?.map((h) => (
@@ -705,6 +759,21 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
             </div>
           )}
 
+          {/* story #2265(C-7) 저장 조각 — 선택 중/확定 후 안내+저장. idle이면 안 뜬다(무변화). */}
+          {citeSelection.mode !== 'idle' && (
+            <CitationComposeBar
+              mode={citeSelection.mode}
+              selectedCount={
+                citeSelection.rangeStartId && citeSelection.rangeEndId
+                  ? Math.max(0, orderedMessageIds.indexOf(citeSelection.rangeEndId) - orderedMessageIds.indexOf(citeSelection.rangeStartId) + 1)
+                  : 0
+              }
+              saveState={citationSaveState}
+              onCancel={() => { citeSelection.cancel(); setCitationSaveState('idle'); }}
+              onSave={() => { if (projectId) setCitationPickerOpen(true); }}
+            />
+          )}
+
           {/* Input */}
           <ChatInput
             threadId={threadId}
@@ -715,6 +784,18 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
             placeholder={isMobile ? t('inputPlaceholderMobile') : t('inputPlaceholderFull')}
             onEscape={() => router.replace(backHref)}
           />
+
+          {/* story #2265(C-7) — 확定된 범위를 어느 스토리에 붙일지 고르는 자리. 기존
+              StoryPickerDialog 재사용(새 피커 0). projectId 없으면(비-프로젝트 DM 등)
+              저장 버튼 자체를 못 누르게 막지 않고 다이얼로그 진입만 막는다(방어적). */}
+          {projectId && (
+            <StoryPickerDialog
+              open={citationPickerOpen}
+              onOpenChange={setCitationPickerOpen}
+              projectId={projectId}
+              onSelect={(storyId) => void handleSaveCitation(storyId)}
+            />
+          )}
         </div>
 
         {/* AC7/AC8: 스레드 패널 — 데스크톱 사이드 패널 / 모바일 전체 뷰 */}

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -397,7 +397,13 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
           },
         }),
       });
-      if (!res.ok) { setCitationSaveState('error'); return; }
+      if (!res.ok) {
+        // story #2265(C-7), PO 지적(2026-07-29): 실패를 하나로 뭉치면 사용자가 무엇을
+        // 고쳐야 할지 못 가른다 — 원인별로 다른 상태를 세운다(재시도/취소는 항상 남긴다,
+        // 조용히 idle로 안 돌아간다 — "저장됐다"고 믿게 만드는 것이 제일 나쁜 자리).
+        setCitationSaveState(res.status === 404 ? 'error_permission' : res.status === 400 ? 'error_invalid' : 'error_network');
+        return;
+      }
       setCitationSaveState('saved');
       setCitationPickerOpen(false);
       window.setTimeout(() => {
@@ -405,7 +411,7 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
         setCitationSaveState('idle');
       }, 1500);
     } catch {
-      setCitationSaveState('error');
+      setCitationSaveState('error_network');
     }
   }, [citeSelection, orderedMessageIds, messages, threadId]);
 

--- a/apps/web/src/components/chat/citation-compose-bar.test.tsx
+++ b/apps/web/src/components/chat/citation-compose-bar.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { CitationComposeBar } from './citation-compose-bar';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+const NOOP = () => {};
+
+describe('CitationComposeBar — story #2265(C-7) 저장 조각', () => {
+  it('anchored 모드에서는 안내 문구만 뜨고 저장 버튼은 없다', async () => {
+    await act(async () => {
+      root.render(wrap(<CitationComposeBar mode="anchored" selectedCount={0} saveState="idle" onCancel={NOOP} onSave={NOOP} />));
+    });
+    expect(container.textContent).toContain('여기부터 인용');
+    expect(container.textContent).not.toContain('스토리에 저장');
+  });
+
+  it('confirming 모드에서는 선택 개수와 저장 버튼이 뜬다', async () => {
+    await act(async () => {
+      root.render(wrap(<CitationComposeBar mode="confirming" selectedCount={3} saveState="idle" onCancel={NOOP} onSave={NOOP} />));
+    });
+    expect(container.textContent).toContain('3개 메시지 선택됨');
+    expect(container.textContent).toContain('스토리에 저장');
+  });
+
+  it('저장 버튼 클릭 시 onSave가 불린다', async () => {
+    const onSave = vi.fn();
+    await act(async () => {
+      root.render(wrap(<CitationComposeBar mode="confirming" selectedCount={1} saveState="idle" onCancel={NOOP} onSave={onSave} />));
+    });
+    const btn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '스토리에 저장');
+    await act(async () => { btn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('취소 버튼 클릭 시 onCancel이 불린다(어느 모드든)', async () => {
+    const onCancel = vi.fn();
+    await act(async () => {
+      root.render(wrap(<CitationComposeBar mode="anchored" selectedCount={0} saveState="idle" onCancel={onCancel} onSave={NOOP} />));
+    });
+    const btn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '취소');
+    await act(async () => { btn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('saveState="saving"이면 저장/취소 버튼이 비활성화된다(중복 제출 방지)', async () => {
+    await act(async () => {
+      root.render(wrap(<CitationComposeBar mode="confirming" selectedCount={2} saveState="saving" onCancel={NOOP} onSave={NOOP} />));
+    });
+    const saveBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('저장 중'));
+    expect(saveBtn).not.toBeUndefined();
+    expect((saveBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('saveState="saved"이면 저장됨 문구만 뜨고 취소/저장 버튼은 사라진다', async () => {
+    await act(async () => {
+      root.render(wrap(<CitationComposeBar mode="confirming" selectedCount={2} saveState="saved" onCancel={NOOP} onSave={NOOP} />));
+    });
+    expect(container.textContent).toContain('저장됨');
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('saveState="error"이면 실패 문구가 뜨고 저장 버튼으로 재시도할 수 있다', async () => {
+    await act(async () => {
+      root.render(wrap(<CitationComposeBar mode="confirming" selectedCount={2} saveState="error" onCancel={NOOP} onSave={NOOP} />));
+    });
+    expect(container.textContent).toContain('저장 실패');
+    expect(container.textContent).toContain('스토리에 저장');
+  });
+});

--- a/apps/web/src/components/chat/citation-compose-bar.test.tsx
+++ b/apps/web/src/components/chat/citation-compose-bar.test.tsx
@@ -86,11 +86,27 @@ describe('CitationComposeBar — story #2265(C-7) 저장 조각', () => {
     expect(container.querySelector('button')).toBeNull();
   });
 
-  it('saveState="error"이면 실패 문구가 뜨고 저장 버튼으로 재시도할 수 있다', async () => {
+  it.each([
+    ['error_permission', '권한이 없습니다'],
+    ['error_invalid', '처리할 수 없습니다'],
+    ['error_network', '네트워크를 확인'],
+  ] as const)('saveState=%s이면 그 원인에 맞는 문구가 뜨고 저장 버튼으로 재시도할 수 있다(중복 idle 복귀 없음)', async (state, expectedSubstring) => {
     await act(async () => {
-      root.render(wrap(<CitationComposeBar mode="confirming" selectedCount={2} saveState="error" onCancel={NOOP} onSave={NOOP} />));
+      root.render(wrap(<CitationComposeBar mode="confirming" selectedCount={2} saveState={state} onCancel={NOOP} onSave={NOOP} />));
     });
     expect(container.textContent).toContain('저장 실패');
-    expect(container.textContent).toContain('스토리에 저장');
+    expect(container.textContent).toContain(expectedSubstring);
+    expect(container.textContent).toContain('스토리에 저장'); // 재시도 가능 — 멈춰 있지 않다.
+  });
+
+  it('셋(권한·범위·네트워크) 실패 문구는 서로 다르다 — 같은 말로 뭉치지 않는다(PO 지적 2026-07-29)', async () => {
+    const texts = new Set<string>();
+    for (const state of ['error_permission', 'error_invalid', 'error_network'] as const) {
+      await act(async () => {
+        root.render(wrap(<CitationComposeBar mode="confirming" selectedCount={1} saveState={state} onCancel={NOOP} onSave={NOOP} />));
+      });
+      texts.add(container.textContent ?? '');
+    }
+    expect(texts.size).toBe(3);
   });
 });

--- a/apps/web/src/components/chat/citation-compose-bar.tsx
+++ b/apps/web/src/components/chat/citation-compose-bar.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+export type CitationSaveState = 'idle' | 'saving' | 'saved' | 'error';
+
+interface CitationComposeBarProps {
+  mode: 'anchored' | 'confirming';
+  selectedCount: number;
+  saveState: CitationSaveState;
+  onCancel: () => void;
+  onSave: () => void;
+}
+
+/**
+ * story #2265(C-7) 저장 조각 — 메시지 범위 선택 중/확定 후 뜨는 얇은 바. `mode==='anchored'`
+ * (아직 끝을 안 골랐음)일 때는 안내만, `mode==='confirming'`(범위 확定됨)일 때 저장 액션이
+ * 뜬다. 저장은 이 컴포넌트 밖(chat-view)에서 스토리 피커를 여는 것으로 이어진다 — 이 바는
+ * 상태만 그린다(새 피커를 여기 만들지 않는다, 기존 StoryPickerDialog 재사용).
+ */
+export function CitationComposeBar({ mode, selectedCount, saveState, onCancel, onSave }: CitationComposeBarProps) {
+  const t = useTranslations('chats');
+
+  return (
+    <div className="flex flex-shrink-0 items-center justify-between gap-3 border-t border-border bg-muted/40 px-4 py-2">
+      <span className="text-xs text-muted-foreground">
+        {mode === 'anchored' ? t('citationAnchored') : t('citationSelectedCount', { count: selectedCount })}
+      </span>
+      <span className="flex shrink-0 items-center gap-2">
+        {saveState === 'saved' ? (
+          <span className="text-xs font-medium text-success">{t('citationSaved')}</span>
+        ) : (
+          <>
+            {saveState === 'error' ? <span className="text-xs text-destructive">{t('citationSaveFailed')}</span> : null}
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={saveState === 'saving'}
+              className="rounded-md border border-border px-2.5 py-1 text-xs text-muted-foreground transition hover:bg-muted disabled:opacity-50"
+            >
+              {t('citationCancel')}
+            </button>
+            {mode === 'confirming' ? (
+              <button
+                type="button"
+                onClick={onSave}
+                disabled={saveState === 'saving'}
+                className="rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
+              >
+                {saveState === 'saving' ? t('citationSaving') : t('citationSaveToStory')}
+              </button>
+            ) : null}
+          </>
+        )}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/citation-compose-bar.tsx
+++ b/apps/web/src/components/chat/citation-compose-bar.tsx
@@ -2,7 +2,10 @@
 
 import { useTranslations } from 'next-intl';
 
-export type CitationSaveState = 'idle' | 'saving' | 'saved' | 'error';
+// story #2265(C-7), PO 지적(2026-07-29): 실패를 하나로 뭉치면 「권한 없음」과 「범위가
+// 큼」과 「네트워크 끊김」이 같은 말이 되어 사용자가 무엇을 고쳐야 할지 못 판단한다 —
+// 원인별로 상태를 가른다(문구는 임시, 유나군 확定 대기).
+export type CitationSaveState = 'idle' | 'saving' | 'saved' | 'error_permission' | 'error_invalid' | 'error_network';
 
 interface CitationComposeBarProps {
   mode: 'anchored' | 'confirming';
@@ -18,8 +21,19 @@ interface CitationComposeBarProps {
  * 뜬다. 저장은 이 컴포넌트 밖(chat-view)에서 스토리 피커를 여는 것으로 이어진다 — 이 바는
  * 상태만 그린다(새 피커를 여기 만들지 않는다, 기존 StoryPickerDialog 재사용).
  */
+const ERROR_STATES: CitationSaveState[] = ['error_permission', 'error_invalid', 'error_network'];
+
+// 원인별 임시 문구 — i18n 키가 아니라 이 자리에서 직접 가른다(유나군이 최종 카피를 정할 때까지
+// 셋을 실제로 다른 문자열로 보이게 하는 것 자체가 이 슬라이스의 목적).
+const ERROR_TEXT: Record<'error_permission' | 'error_invalid' | 'error_network', string> = {
+  error_permission: '저장 실패 — 이 대화에 접근할 권한이 없습니다',
+  error_invalid: '저장 실패 — 선택한 범위를 처리할 수 없습니다',
+  error_network: '저장 실패 — 네트워크를 확인하고 다시 시도해 주세요',
+};
+
 export function CitationComposeBar({ mode, selectedCount, saveState, onCancel, onSave }: CitationComposeBarProps) {
   const t = useTranslations('chats');
+  const isError = ERROR_STATES.includes(saveState);
 
   return (
     <div className="flex flex-shrink-0 items-center justify-between gap-3 border-t border-border bg-muted/40 px-4 py-2">
@@ -31,7 +45,7 @@ export function CitationComposeBar({ mode, selectedCount, saveState, onCancel, o
           <span className="text-xs font-medium text-success">{t('citationSaved')}</span>
         ) : (
           <>
-            {saveState === 'error' ? <span className="text-xs text-destructive">{t('citationSaveFailed')}</span> : null}
+            {isError ? <span className="text-xs text-destructive">{ERROR_TEXT[saveState as 'error_permission' | 'error_invalid' | 'error_network']}</span> : null}
             <button
               type="button"
               onClick={onCancel}


### PR DESCRIPTION
## 요약
story #2265(C-7)의 마지막 조각 — write 엔드포인트(#2632, 머지됨)가 서서 지금까지 "짓되 안 켠" `citeAction`을 실제로 켠다. 이게 붙으면 사용자가 처음으로 대화 조각을 스토리에 직접 박을 수 있다.

## 변경 사항
- `CitationComposeBar`(신규): 선택 중(anchored)/확定 후(confirming) 안내 + 저장 액션. `idle`이면 안 뜬다
- `chat-view`: `citeAction`을 실제로 켠다 — `idle`→"여기부터", `anchored`→"여기까지", `confirming`→메뉴 잠금(저장/취소를 먼저 끝내게)
- `handleSaveCitation`: 확定된 range를 스냅샷으로 얼려(PO 판정 2026-07-29: "얼려야 대조가 가능하다") `POST /api/stories/{id}/references`로 저장, 성공 시 1.5초 후 자동 `idle` 복귀
- 스토리 선택은 기존 `StoryPickerDialog`(`components/canvas/`) 재사용 — 새 피커 0개

## 검증
- [x] `pnpm build` 성공(EXIT 0)
- [x] `pnpm lint` 경고 0개
- [x] `tsc --noEmit` 클린
- [x] vitest chat/+canvas 116/116 통과(신규 7건, 무회귀)
- [ ] **라이브 검증 대기** — AC9("API 확認은 증거가 아니다 — 사람 경로로 밟는다") 규율에 따라 dev 배포 착지 확認 후 브라우저로 직접 밟아 확認 예정(선택→저장→스토리 상세에서 확認→권한 없는 계정에서 안 보임→"대화에서 열기" 재확認)