### PR TITLE
[SID:2265] 대화 근거 로딩 실패를 404(존재 비노출)와 갈라 세운다

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3315,6 +3315,8 @@
     "chatProofSectionTitle": "Chat evidence",
     "chatProofCount": "{count} chat evidence items",
     "chatProofSomeUnavailable": "{count} unavailable",
+    "chatProofLoadFailed": "Couldn't load chat evidence",
+    "chatProofRetry": "Retry",
     "chatProofOpenSource": "Open in chat",
     "chatProofOpenOriginal": "View original now",
     "chatProofEdited": "Original was edited · {date}",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3315,6 +3315,8 @@
     "chatProofSectionTitle": "대화 근거",
     "chatProofCount": "대화 근거 {count}건",
     "chatProofSomeUnavailable": "{count}건은 표시할 수 없음",
+    "chatProofLoadFailed": "대화 근거를 불러오지 못했습니다",
+    "chatProofRetry": "다시 시도",
     "chatProofOpenSource": "대화에서 열기",
     "chatProofOpenOriginal": "지금 원본 보기",
     "chatProofEdited": "원본이 수정되었습니다 · {date}",

--- a/apps/web/src/components/verify/chat-proof-section.test.tsx
+++ b/apps/web/src/components/verify/chat-proof-section.test.tsx
@@ -109,11 +109,43 @@ describe('ChatProofSection — story #2265(C-7) PR1b 섹션 렌더', () => {
     expect(container.textContent).toContain('1');
   });
 
-  it('fetch 실패 시 크래시 없이 빈 상태(null 렌더)로 graceful degrade한다', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network'); }));
+  it('404(C-3 존재 비노출)이면 조용히 빈 화면(null 렌더) — "권한 없음" 배너를 안 띄운다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 404, json: async () => ({}) })));
     await act(async () => { root.render(wrap(<ChatProofSection storyId="story-1" />)); });
     await act(async () => { await Promise.resolve(); });
     expect(container.innerHTML).toBe('');
+  });
+
+  it('네트워크 예외(fetch throw)면 "모름"을 "없음"으로 지어내지 않고 불러오기 실패를 보인다(PO 지적 2026-07-29)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network'); }));
+    await act(async () => { root.render(wrap(<ChatProofSection storyId="story-1" />)); });
+    await act(async () => { await Promise.resolve(); });
+    expect(container.textContent).toContain('불러오지 못했습니다');
+    expect(container.textContent).toContain('다시 시도');
+  });
+
+  it('5xx 응답도 네트워크 예외와 동일하게 불러오기 실패로 처리한다(404만 «없음»)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) })));
+    await act(async () => { root.render(wrap(<ChatProofSection storyId="story-1" />)); });
+    await act(async () => { await Promise.resolve(); });
+    expect(container.textContent).toContain('불러오지 못했습니다');
+  });
+
+  it('다시 시도를 누르면 재요청하고, 그때 성공하면 정상 렌더로 복귀한다', async () => {
+    const fetchMock = vi.fn()
+      .mockImplementationOnce(async () => { throw new Error('network'); })
+      .mockImplementationOnce(async () => ({ ok: true, json: async () => ({ data: [VALID_ROW] }) }));
+    vi.stubGlobal('fetch', fetchMock);
+    await act(async () => { root.render(wrap(<ChatProofSection storyId="story-1" />)); });
+    await act(async () => { await Promise.resolve(); });
+    expect(container.textContent).toContain('불러오지 못했습니다');
+
+    const retryBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '다시 시도');
+    await act(async () => { retryBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain('이 방향으로 가시는');
   });
 
   it('still_exists=false인 항목은 삭제됨 상태로 렌더한다(내용 숨김·삭제됨 표지)', async () => {

--- a/apps/web/src/components/verify/chat-proof-section.tsx
+++ b/apps/web/src/components/verify/chat-proof-section.tsx
@@ -106,13 +106,24 @@ export function ChatProofSection({ storyId }: ChatProofSectionProps) {
   const [refs, setRefs] = useState<StoryProofReference[] | null>(null);
   const [skippedCount, setSkippedCount] = useState(0);
   const [loadedForId, setLoadedForId] = useState<string | null>(null);
+  // story #2265(C-7), PO 지적(2026-07-29): 404(C-3 존재 비노출 — 이 스토리에 접근권이 없어
+  // «없는 것»으로 보여야 함)와 «그 외 실패»(네트워크 끊김·5xx — «모름»)를 같은 빈 화면으로
+  // 접으면 폴백이 모름을 없음으로 지어낸다. loadError는 후자만 표시한다(재시도 가능·사용자
+  // 숙제 아님 — 다시 누르면 실제로 결과가 바뀔 수 있는 자리).
+  const [loadError, setLoadError] = useState(false);
+  const [retryNonce, setRetryNonce] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
     fetch(`/api/stories/${storyId}/references?direction=outgoing`, { cache: 'no-store' })
-      .then((r) => (r.ok ? r.json() : null))
+      .then((r) => {
+        if (r.ok) return r.json();
+        if (r.status === 404) return null; // C-3 존재 비노출 — 확認된 "없음".
+        throw new Error(`load failed: ${r.status}`); // 그 외(권한 이외 오류)는 "모름".
+      })
       .then((json) => {
         if (cancelled) return;
+        setLoadError(false);
         const { items, skippedIds } = json ? parseStoryProofReferences(json) : { items: [], skippedIds: [] };
         if (skippedIds.length > 0 && process.env.NODE_ENV !== 'production') {
           // dev 전용: 다음 사람이 왜 안 뜨는지 보게(PO 지시, 2026-07-29).
@@ -123,12 +134,28 @@ export function ChatProofSection({ storyId }: ChatProofSectionProps) {
         setLoadedForId(storyId);
       })
       .catch(() => {
-        if (!cancelled) { setRefs([]); setSkippedCount(0); setLoadedForId(storyId); }
+        if (cancelled) return;
+        setLoadError(true);
+        setRefs([]);
+        setSkippedCount(0);
+        setLoadedForId(storyId);
       });
     return () => { cancelled = true; };
-  }, [storyId]);
+  }, [storyId, retryNonce]);
 
-  if (refs === null || loadedForId !== storyId || (refs.length === 0 && skippedCount === 0)) return null;
+  if (refs === null || loadedForId !== storyId) return null;
+  if (!loadError && refs.length === 0 && skippedCount === 0) return null; // 확認된 0건 — 조용히 안 보임.
+
+  if (loadError) {
+    return (
+      <p className="text-[11px] text-muted-foreground">
+        {t('chatProofLoadFailed')}{' '}
+        <button type="button" onClick={() => setRetryNonce((n) => n + 1)} className="text-primary hover:underline">
+          {t('chatProofRetry')}
+        </button>
+      </p>
+    );
+  }
 
   return (
     <div className="space-y-2">


### PR DESCRIPTION
## 요약
PO 지적(2026-07-29): `ChatProofSection`이 fetch 실패/404를 같은 빈 화면(섹션 null)으로 접고 있었다 — 404는 C-3 존재 비노출("없는 것"으로 보여야 함)이라 맞지만, 네트워크 끊김·5xx는 "모름"인데 "없음"으로 지어내는 것이었다.

## 변경 사항
- 404 → 조용한 빈 화면(변경 없음, 정확함)
- 그 외 실패(네트워크 예외·5xx) → "대화 근거를 불러오지 못했습니다 · 다시 시도" 표시. 재시도 버튼으로 재요청

## 검증
- [x] `pnpm build` 성공(EXIT 0)
- [x] `pnpm lint` 경고 0개
- [x] `tsc --noEmit` 클린
- [x] vitest verify/ 38/38 통과(신규 4건 포함, 무회귀)