### PR TITLE
[SID:2313] 참조 제안 거절 기억 — 메시지 단위→토큰 단위 재확定

### DIFF
--- a/apps/web/src/components/chat/reference-suggestion-row.test.tsx
+++ b/apps/web/src/components/chat/reference-suggestion-row.test.tsx
@@ -187,4 +187,25 @@ describe('ReferenceSuggestionRow — story #2283', () => {
     await render({ messageId: 'm1', content: '#2249 확認 부탁', isMine: true });
     expect(container.textContent).toBe('');
   });
+
+  it('#2313 — 한 메시지에서 거절한 토큰을 다른(새) 메시지에서 다시 쳐도 제안이 안 뜬다(사람 경로 재현: #2283 결함)', async () => {
+    await render({ messageId: 'm1', content: '#2049 이건 거절 테스트', isMine: true });
+    const rejectBtn = container.querySelector('button[aria-label="묻지 않기"]') as HTMLButtonElement;
+    await act(async () => { rejectBtn.click(); });
+    await act(async () => { root.unmount(); });
+    root = createRoot(container);
+    // 같은 토큰, 다른 messageId — #2283 원 구현(messageId::raw 키)에서는 여기서 다시 떴다.
+    await render({ messageId: 'm2', content: '#2049 두번째 시도 — 다시 안 물어야 하는', isMine: true });
+    expect(container.textContent).toBe('');
+  });
+
+  it('#2313 양성대조 — 거절 안 한 다른 토큰은 다른 메시지에서도 여전히 제안된다', async () => {
+    await render({ messageId: 'm1', content: '#2049 거절할 것', isMine: true });
+    const rejectBtn = container.querySelector('button[aria-label="묻지 않기"]') as HTMLButtonElement;
+    await act(async () => { rejectBtn.click(); });
+    await act(async () => { root.unmount(); });
+    root = createRoot(container);
+    await render({ messageId: 'm2', content: '#2250 은 거절 안 함', isMine: true, projectId: 'p1' });
+    expect(container.textContent).toContain('#2250를 스토리로 잇겠습니까?');
+  });
 });

--- a/apps/web/src/components/chat/reference-suggestion-row.tsx
+++ b/apps/web/src/components/chat/reference-suggestion-row.tsx
@@ -69,9 +69,9 @@ export function ReferenceSuggestionRow({ messageId, content, isMine, projectId }
   const candidates = useMemo(() => {
     if (!isMine) return [];
     return findReferenceCandidates(content).filter(
-      (c) => !isCandidateRejected(messageId, c.raw) && !locallyDismissed.has(c.raw),
+      (c) => !isCandidateRejected(c.raw) && !locallyDismissed.has(c.raw),
     );
-  }, [isMine, content, messageId, locallyDismissed]);
+  }, [isMine, content, locallyDismissed]);
 
   if (candidates.length === 0) return null;
 
@@ -84,7 +84,7 @@ export function ReferenceSuggestionRow({ messageId, content, isMine, projectId }
   };
 
   const handleReject = (raw: string) => {
-    rejectCandidate(messageId, raw);
+    rejectCandidate(raw);
     setLocallyDismissed((prev) => new Set(prev).add(raw));
   };
 

--- a/apps/web/src/lib/reference-candidates.test.ts
+++ b/apps/web/src/lib/reference-candidates.test.ts
@@ -59,7 +59,7 @@ describe('findReferenceCandidates', () => {
   });
 });
 
-describe('거절 기억(localStorage, durable 아님)', () => {
+describe('거절 기억(localStorage, durable 아님, #2313 토큰 단위 스코프)', () => {
   beforeEach(() => {
     stubLocalStorage();
   });
@@ -68,16 +68,30 @@ describe('거절 기억(localStorage, durable 아님)', () => {
   });
 
   it('거절 전엔 rejected가 아니다', () => {
-    expect(isCandidateRejected('msg-1', '#2249')).toBe(false);
+    expect(isCandidateRejected('#2249')).toBe(false);
   });
 
-  it('거절하면 같은 (messageId, raw) 쌍은 rejected로 남는다', () => {
-    rejectCandidate('msg-1', '#2249');
-    expect(isCandidateRejected('msg-1', '#2249')).toBe(true);
+  it('거절하면 그 토큰 문자열은 rejected로 남는다', () => {
+    rejectCandidate('#2249');
+    expect(isCandidateRejected('#2249')).toBe(true);
   });
 
-  it('다른 메시지의 같은 토큰 문자열은 거절 영향을 안 받는다(메시지 단위 스코프)', () => {
-    rejectCandidate('msg-1', '#2249');
-    expect(isCandidateRejected('msg-2', '#2249')).toBe(false);
+  it('다른 토큰은 거절 영향을 안 받는다(양성대조, AC5)', () => {
+    rejectCandidate('#2249');
+    expect(isCandidateRejected('#2250')).toBe(false);
+  });
+
+  it('#2313 — 한 메시지에서 거절한 토큰은 다른(새) 메시지에 다시 쳐도 기억된다(토큰 단위 스코프, 메시지 단위 아님)', () => {
+    // #2283 원 구현은 키가 `messageId::raw`라 이 경우 false가 나왔다 — 그게 #2313의 재현 결함.
+    rejectCandidate('#2249');
+    expect(isCandidateRejected('#2249')).toBe(true); // 어느 메시지에서 왔는지와 무관.
+  });
+
+  it('저장 키에 버전 프리픽스가 붙는다(#2313 PO 지시 — 키 모양 바뀌면 옛 값이 조용히 안 맞지 않고 깨끗이 무시)', () => {
+    rejectCandidate('#2249');
+    const raw = localStorage.getItem('sprintable:reference-candidates:rejected');
+    expect(raw).not.toBeNull();
+    const stored = JSON.parse(raw!) as string[];
+    expect(stored).toEqual(['v1:#2249']);
   });
 });

--- a/apps/web/src/lib/reference-candidates.ts
+++ b/apps/web/src/lib/reference-candidates.ts
@@ -46,18 +46,23 @@ export function findReferenceCandidates(content: string): ReferenceCandidate[] {
   return result;
 }
 
-// ── 거절 기억(AC3 ②) ─────────────────────────────────────────────────────────
-// ⛔이 세션이 짓는 만큼만 정직하게: BE에 거절 상태를 남길 표가 아직 없어(이 스토리의
-// 쓰기 경로 자체가 미해결 — 착수 보고 참조) 브라우저 localStorage에만 남긴다. 즉 다른
-// 기기·시크릿창·캐시삭제 후에는 다시 물을 수 있다 — durable하지 않다는 점을 명시한다.
-// 거절 기억은 "소음 억제"이지 "데이터"가 아니라 잃어버려도 손해는 "한 번 더 묻는 것"뿐이라
-// 지금은 이걸로 충분하다(PO 판정, 2026-07-28).
+// ── 거절 기억(AC3 ②, #2313 재확定) ───────────────────────────────────────────
+// 네 축 전부 PO 판정(2026-07-29):
+//   저장소=클라이언트 로컬(localStorage) — 잃어도 손해는 "한 번 더 묻는 것"뿐, 사고가
+//     아니다(반대로 서버 저장은 오클릭 거절이 영영 남는 위험이 있다).
+//   키    =원문 토큰 문자열 그대로(메시지 단위 아님) — #2049처럼 해소 안 되는 토큰도 키가 됨.
+//   범위  =사용자 × 브라우저(로컬 저장이라 자동으로 그렇게 된다).
+//   수명  =무기한(TTL 없음) — "며칠 뒤 다시 뜬다"는 사용자가 예측 못 하는 동작이라 금지.
+// ⛔이전(#2283) 구현은 키가 `messageId::raw`라 같은 토큰도 다른 메시지에서 다시 물었다 —
+// 그게 #2313의 재현 결함. 키에서 messageId를 뺐다(같은 토큰이면 어느 메시지에서 왔든 기억).
 //
-// ⛔이 선택이 부족해지는 조건(다음 사람이 "왜 localStorage지?"를 다시 판단하지 않도록 —
-// 조건이 오면 서버 쪽(거절 기억 전용 표 또는 Reference 신설 시 그 옆)으로 옮긴다):
-//   ①사람이 기기를 바꾸면 거절이 안 따라간다 — 같은 후보를 또 묻게 된다.
-//   ②제안이 잦아지면(#2269가 본문에 쌓인 기존 참조를 캐기 시작하면) 체감이 커진다.
+// ⛔다시 볼 조건(사람이 안 기억해도 사건으로 걸리는 것):
+//   ①에이전트 경로에서도 이 제안이 나가게 될 때 — 에이전트에겐 브라우저(localStorage)가 없다.
+//   ②사용자가 "또 떴다"를 실제로 불평할 때 — 그때가 서버 저장의 값이 증명되는 자리.
 const REJECTED_KEY = 'sprintable:reference-candidates:rejected';
+// 키 모양이 바뀌면(#2313 이전 messageId::raw 포함) 옛 값이 조용히 오매칭되지 않고 깨끗이
+// 무시되도록 버전 프리픽스를 둔다.
+const KEY_VERSION = 'v1';
 
 function readRejectedSet(): Set<string> {
   if (typeof window === 'undefined') return new Set();
@@ -80,16 +85,16 @@ function writeRejectedSet(s: Set<string>): void {
   }
 }
 
-function rejectionKey(messageId: string, raw: string): string {
-  return `${messageId}::${raw}`;
+function rejectionKey(raw: string): string {
+  return `${KEY_VERSION}:${raw}`;
 }
 
-export function isCandidateRejected(messageId: string, raw: string): boolean {
-  return readRejectedSet().has(rejectionKey(messageId, raw));
+export function isCandidateRejected(raw: string): boolean {
+  return readRejectedSet().has(rejectionKey(raw));
 }
 
-export function rejectCandidate(messageId: string, raw: string): void {
+export function rejectCandidate(raw: string): void {
   const s = readRejectedSet();
-  s.add(rejectionKey(messageId, raw));
+  s.add(rejectionKey(raw));
   writeRejectedSet(s);
 }


### PR DESCRIPTION
## 요약
- #2283에서 만든 참조 제안 거절 기억이 키를 `messageId::raw`로 잡아, 같은 토큰(`#2049`)을 거절해도 **다른 메시지**에서 재전송하면 제안이 다시 떴다(실측 재현, story #2313).
- PO 판정(2026-07-29)에 따라 네 축 전부 확定: 저장소=클라이언트 로컬(localStorage), 키=원문 토큰 문자열 그대로, 범위=사용자×브라우저(자동), 수명=무기한(TTL 없음).
- 저장 키에 `v1:` 버전 프리픽스 추가 — 키 모양이 바뀌면 옛 값이 조용히 오매칭되지 않고 깨끗이 무시된다.

## 변경
- `src/lib/reference-candidates.ts`: `rejectionKey`/`isCandidateRejected`/`rejectCandidate`에서 `messageId` 파라미터 제거, `v1:` 프리픽스 추가.
- `src/components/chat/reference-suggestion-row.tsx`: 호출부 갱신(messageId 인자 제거).
- 테스트 갱신 + 신규: 토큰 단위 스코프 회귀 테스트(구현 되돌려 RED 확인 후 복원해 GREEN 재확인 — mutation-verified), 버전 프리픽스 검증, 양성대조(다른 토큰은 영향 없음).

## 검증
- `pnpm vitest run` — 전체 314 files / 2107 tests 통과
- `pnpm tsc --noEmit` — 통과
- `pnpm lint` — 0 errors(기존 무관 warning만)
- `pnpm build` — EXIT 0
- 뮤테이션 검증: 수정 되돌리면 신규 회귀 테스트 2건이 정확히 그 증상으로 RED(다른 메시지에서 제안 재노출), 복원 시 GREEN

## Test plan
- [ ] dev 배포 후 사람 경로 재현: `#2049` 포함 메시지 전송 → 제안 거절 → 같은 토큰 포함한 **새 메시지** 전송 → 제안이 다시 안 뜨는 것을 화면에서 확인(AC1)
- [ ] 양성대조: 거절 안 한 다른 토큰은 새 메시지에서도 여전히 제안됨(AC5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)