### PR TITLE
feat(#2277): zero-referenced entities cron — count only, no table/exposure

### DIFF
--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -319,6 +319,60 @@ async def entity_references_orphan_check(
         return _err("INTERNAL_ERROR", "Internal server error", 500)
 
 
+# ─── GET /api/v2/internal/cron/zero-referenced-entities-check ─────────────────
+# story #2277(E-CONNECT) AC1/AC2/AC3 — "이것을 가리키는 참조가 0건"인 doc·story 수를 센다.
+# #2274와 동일 패턴(verify_cron·read-only·다른 인증 발명 없음, AC7 동형 근거).
+#
+# ⛔AC5(권한)는 이 cron에 안 붙는다(PO 판정 2026-07-29) — cron엔 「보는 사람」이 없어 권한
+# 축이 서지 않는다. AC5는 이 수를 사용자에게 노출하는 층이 생길 때 그 층에 붙는다.
+#
+# ⛔AC2 최종판정(PO, dev 실측 후 정정, 2026-07-29): 표·노출층은 «짓지 않는다». dev 실측
+# (`sprintable-verify-oneoff` job 재사용, CRON_SECRET 불필요 — job이 private-IP로 dev DB에
+# 직접 접속): doc 871/883·story 2497/2512가 zero_referenced였으나 `entity_references` 총
+# 행수가 62뿐이었다 — 이 수는 「고아」가 아니라 「참조추적 자체가 아직 안 돈 것」(분모미채움)
+# 이었다. 지금 표를 지으면 2497건이 「고아」로 보여 없는 문제를 만드는 거짓 지표가 된다.
+# AC2는 여기서 "지금은 없다"로 명시하고 닫는다 — ⭐만료 조건: `entity_references_total`이
+# 일감 수(story 총량) 대비 유의미해질 때(예: 1/10 초과) 이 수가 비로소 「고아」를 뜻하기
+# 시작하고, 그때 표·노출층을 짓는다. 그 전까지 이 cron의 응답+로그가 이 스토리의 「도는
+# 자리」 전부다.
+#
+# ⛔AC3 — 응답은 zero_referenced/total 절대값과 entity_references_total(분모)을 **항상 같이**
+# 싣는다(분모 없이 절대값만 보면 다음 사람이 "2497건 고아"로 오독한다 — 오늘 실제로 PO
+# 자신이 먼저 그 오독을 할 뻔했다가 스스로 잡았다). caveat 문안은 디디가 세운 것 그대로
+# (bare "출처 없음"/"참조 없음" 금지 — 미수집을 "없음"으로 표시하면 거짓이라는 게 핵심).
+_AC3_CAVEAT = (
+    "관찰된 참조 0건(수집범위: mention/embed, source=chat_message·doc만 — "
+    "PR/커밋/증거자유텍스트는 미수집이라 이 수에 없음)"
+)
+
+
+@router.get("/zero-referenced-entities-check")
+async def zero_referenced_entities_check(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    verify_cron(request)
+    try:
+        from app.services.backlinks import count_entity_references_total, count_zero_referenced_entities
+
+        zero_referenced = await count_zero_referenced_entities(session)  # org_id=None → 전체 org
+        entity_references_total = await count_entity_references_total(session)
+        total = sum(zero_referenced.values())
+        logger.info(
+            "zero-referenced entities: %s (total=%d, entity_references_total=%d)",
+            zero_referenced, total, entity_references_total,
+        )
+        return _ok({
+            "zero_referenced": zero_referenced,
+            "total": total,
+            "entity_references_total": entity_references_total,
+            "caveat": _AC3_CAVEAT,
+        })
+    except Exception as exc:
+        logger.exception("cron error: %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)
+
+
 # ─── GET /api/v2/internal/cron/inbox-outbox ────────────────────────────────────
 
 @router.get("/inbox-outbox")

--- a/backend/app/services/backlinks.py
+++ b/backend/app/services/backlinks.py
@@ -177,12 +177,13 @@ import uuid
 from datetime import datetime
 
 from fastapi import HTTPException
-from sqlalchemy import and_, false as sa_false, or_, select, tuple_
+from sqlalchemy import and_, false as sa_false, func, or_, select, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext
 from app.models.conversation import Conversation, ConversationMessage
 from app.models.doc import Doc
+from app.models.pm import Story
 from app.models.reference import Reference
 from app.services.conversation_auth import conversation_readable_predicate
 from app.services.member_resolver import ResolvedMember, lookup_members_by_ids
@@ -302,6 +303,56 @@ class UnsupportedBacklinkTargetTypeError(ValueError):
     `test_list_entity_backlinks_rejects_unsupported_target_type`이 이 분기를 직접 타서
     커버리지에 살아 있고, 허용목록을 게이트 없이 늘리면 그 테스트가 걸린다(RED로 잡는다는
     뜻이 아니라 — 허용목록에 추가한 사람이 이 클래스의 존재를 코드에서 보게 된다는 뜻)."""
+
+
+# ⛔story #2277(E-CONNECT) target_type → model — count_zero_referenced_entities 전용.
+# BACKLINKS_ALLOWED_TARGET_TYPES와 반드시 같은 키 집합이어야 한다(AC1: "#2266이 세운 허용
+# 목록과 같은 목록을 쓴다, 별도 목록을 만들지 않는다") — 이 dict의 키를 늘릴 땐 반드시
+# BACKLINKS_ALLOWED_TARGET_TYPES도 같이 늘어 있어야 한다(파생이 아니라 하드코딩인 이유: model
+# 클래스 자체는 registry가 담을 수 없는 타입정보라 여기 한 곳에만 둔다).
+_ZERO_REF_MODELS: dict[str, type] = {"doc": Doc, "story": Story}
+
+
+async def count_zero_referenced_entities(
+    session: AsyncSession, org_id: uuid.UUID | None = None,
+) -> dict[str, int]:
+    """story #2277 AC1/AC2 — target_type별로 "가리키는 참조가 0건"인 엔티티 수를 센다.
+    대상 타입은 #2266이 세운 `BACKLINKS_ALLOWED_TARGET_TYPES`(doc·story)와 동일 허용목록만
+    쓴다(AC1 — 별도 목록을 새로 만들지 않는다). org_id=None(기본)이면 전체 org 스코프.
+
+    ⛔AC2 후속(PO 정정, 2026-07-29): 이 함수가 세는 수는 「고아」가 아니라 「이 항목을 가리키는
+    mention/embed/proof 참조가 entity_references에 0건」이라는 사실뿐이다 — `entity_references`
+    테이블 자체가 아직 얕게 채워진 상태(참조추적 기능이 신생)라면 이 수의 대부분은 「실제로
+    미언급」이 아니라 「추적이 아직 안 돈 것」이다. 그래서 이 함수를 부르는 자리는 항상
+    `count_entity_references_total`(아래)도 같이 불러 분모를 나란히 실어야 한다(cron endpoint
+    참조) — 절대값만 단독으로 보고하지 않는다."""
+    counts: dict[str, int] = {}
+    for target_type in sorted(BACKLINKS_ALLOWED_TARGET_TYPES):
+        model = _ZERO_REF_MODELS[target_type]
+        stmt = (
+            select(func.count())
+            .select_from(model)
+            .outerjoin(
+                Reference,
+                and_(Reference.target_type == target_type, Reference.target_id == model.id),
+            )
+            .where(model.deleted_at.is_(None), Reference.id.is_(None))
+        )
+        if org_id is not None:
+            stmt = stmt.where(model.org_id == org_id)
+        counts[target_type] = (await session.execute(stmt)).scalar_one()
+    return counts
+
+
+async def count_entity_references_total(session: AsyncSession, org_id: uuid.UUID | None = None) -> int:
+    """story #2277 AC2/AC3 — `entity_references` 총행수(분모). `count_zero_referenced_entities`의
+    결과를 단독으로 보고하면 다음 사람이 그 수를 「고아 수」로 오독한다(2026-07-29 dev 실측:
+    zero_referenced doc 871/story 2497인데 이 총행수가 62뿐이라 실은 분모미채움이었다) — 이
+    함수가 그 오독을 막는 짝이다."""
+    stmt = select(func.count()).select_from(Reference)
+    if org_id is not None:
+        stmt = stmt.where(Reference.org_id == org_id)
+    return (await session.execute(stmt)).scalar_one()
 
 
 async def list_entity_backlinks(

--- a/backend/tests/test_2277_zero_referenced_audit_realdb.py
+++ b/backend/tests/test_2277_zero_referenced_audit_realdb.py
@@ -1,0 +1,234 @@
+"""story #2277(E-CONNECT) — 「이것을 가리키는 것이 0건」 감사, ㉠「도는 자리」 실PG 검증.
+
+AC1: target_type은 #2266이 세운 `BACKLINKS_ALLOWED_TARGET_TYPES`(doc·story)와 같은 허용목록.
+AC2: 도는 자리 — cron endpoint(#2274 패턴 그대로, verify_cron·read-only). ⛔이 cron 자체엔
+  AC5(권한)를 안 붙인다 — PO 판정(2026-07-29): cron엔 「보는 사람」이 없어 권한 축이 안 선다.
+AC2 후속(PO 정정, 2026-07-29 dev 실측 후): 표·노출층은 **짓지 않는다**. dev 실측
+  doc 871/883·story 2497/2512가 zero_referenced였으나 `entity_references` 총행수가 62뿐이라
+  — 이 수는 「고아」가 아니라 「참조추적 자체가 아직 안 돈 것」(분모미채움)이다. 표를 지으면
+  2497건이 「고아」로 보여 거짓 지표가 선다. AC2는 「지금은 없다」로 명시하고 닫는다 — 만료
+  조건: `entity_references` 총행수가 일감 수(story_number 총량) 대비 유의미해질 때(예:
+  1/10 초과) 이 수가 비로소 「고아」를 뜻하기 시작하고, 그때 표·노출층을 짓는다.
+AC3: ⛔문안은 디디가 세운 것 글자 그대로 — "관찰된 참조 0건(수집범위: mention/embed,
+  source=chat_message·doc만 — PR/커밋/증거자유텍스트는 미수집이라 이 수에 없음)".
+  ⛔PO 추가지적: 응답·로그에 **분모**(`entity_references_total`)를 zero_referenced/total과
+  항상 같이 싣는다 — 안 그러면 다음 사람이 절대값(예 "2497")을 「고아 2497건」으로 오독한다.
+AC6: 이 파일의 delta-based 측정 + 뮤테이션 자가검증이 「돈다」의 증거(#2274 선례 그대로 —
+  PO 확認: 실PG 통합테스트+뮤테이션 자가검증=충분, 라이브 GCP 트리거는 불필요. 실제 dev DB
+  수치는 `sprintable-verify-oneoff` Cloud Run job 재실행으로 별도 확認 완료 — CRON_SECRET
+  불필요).
+
+이 파일은 #2274의 test_2274_cron_orphan_check_realdb.py와 동형 패턴(공유 DB라 절대값 0을
+기대하지 않고 delta로 증명 · monkeypatch.setattr로 CRON_SECRET 자동복원 · 라우터 함수 직접
+호출로 HTTP 계층 우회)을 그대로 따른다(재구현 0).
+"""
+from __future__ import annotations
+
+import json
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project_member(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.user import User
+    from app.models.member import Member
+
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.flush()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.flush()
+    member = Member(id=uuid.uuid4(), org_id=org.id, type="human", user_id=user.id, name="Test Human")
+    session.add(member)
+    await session.flush()
+    return org, project, member
+
+
+async def _make_doc(session, org_id, project_id, title="Doc"):
+    from app.models.doc import Doc
+    doc = Doc(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title,
+        slug=f"doc-{uuid.uuid4().hex[:8]}",
+    )
+    session.add(doc)
+    await session.flush()
+    return doc
+
+
+async def _make_story(session, org_id, project_id, title="Story"):
+    from app.models.pm import Story
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status="backlog")
+    session.add(story)
+    await session.flush()
+    return story
+
+
+def _request():
+    from starlette.requests import Request as StarletteRequest
+    return StarletteRequest(scope={
+        "type": "http", "headers": [(b"authorization", b"Bearer the-real-secret")],
+    })
+
+
+@pytest.mark.anyio
+async def test_zero_referenced_check_endpoint_rejects_missing_auth(monkeypatch):
+    """AC2 — 다른 cron 엔드포인트와 같은 verify_cron() 게이트(새 인증 발명 없음)."""
+    import app.routers.cron as cron_module
+    from app.routers.cron import zero_referenced_entities_check
+    from fastapi import HTTPException
+    from starlette.requests import Request as StarletteRequest
+
+    monkeypatch.setattr(cron_module, "CRON_SECRET", "the-real-secret")
+
+    request = StarletteRequest(scope={"type": "http", "headers": []})
+    with pytest.raises(HTTPException) as exc_info:
+        await zero_referenced_entities_check(request, session=None)
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_zero_referenced_check_counts_unreferenced_doc_and_story(monkeypatch):
+    """⭐AC1/AC4 핵심 — 참조가 0건인 doc·story가 정확히 카운트되는지 delta로 증명한다
+    (공유 DB라 절대값 0 가정 안 함 — #2274 패턴)."""
+    import app.routers.cron as cron_module
+    from app.routers.cron import zero_referenced_entities_check
+
+    monkeypatch.setattr(cron_module, "CRON_SECRET", "the-real-secret")
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            await session.commit()
+
+            resp_before = await zero_referenced_entities_check(_request(), session=session)
+            body_before = json.loads(resp_before.body)
+            doc_before = body_before["data"]["zero_referenced"]["doc"]
+            story_before = body_before["data"]["zero_referenced"]["story"]
+
+            await _make_doc(session, org.id, project.id, title="Unreferenced Doc")
+            await _make_story(session, org.id, project.id, title="Unreferenced Story")
+            await session.commit()
+
+            resp_after = await zero_referenced_entities_check(_request(), session=session)
+            body_after = json.loads(resp_after.body)
+            assert body_after["data"]["zero_referenced"]["doc"] == doc_before + 1
+            assert body_after["data"]["zero_referenced"]["story"] == story_before + 1
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_zero_referenced_check_excludes_referenced_doc():
+    """⭐뮤테이션 대응 축 — 참조가 «있는» doc은 zero_referenced에 안 잡혀야 한다(항상
+    +1되는 죽은 카운터가 아님을 증명 — #2274의 「real orphan 잡기」테스트와 동형 목적)."""
+    from app.routers.cron import zero_referenced_entities_check
+    from app.services.reference_core import insert_reference
+    import app.routers.cron as cron_module
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project, member = await _seed_org_project_member(session)
+            await session.commit()
+
+            resp_before = await zero_referenced_entities_check(_request(), session=session)
+            doc_before = json.loads(resp_before.body)["data"]["zero_referenced"]["doc"]
+
+            referenced_doc = await _make_doc(session, org.id, project.id, title="Referenced Doc")
+            unreferenced_doc = await _make_doc(session, org.id, project.id, title="Unreferenced Doc")
+            await session.commit()
+
+            await insert_reference(
+                session, org_id=org.id, source_type="story", source_field="description",
+                source_id=uuid.uuid4(), target_type="doc", target_id=referenced_doc.id,
+                form="mention", created_by=member.id,
+            )
+            await session.commit()
+
+            resp_after = await zero_referenced_entities_check(_request(), session=session)
+            doc_after = json.loads(resp_after.body)["data"]["zero_referenced"]["doc"]
+            assert doc_after == doc_before + 1, (
+                f"referenced_doc은 안 잡히고 unreferenced_doc({unreferenced_doc.id}) 하나만 "
+                f"늘어야 한다(before={doc_before}, after={doc_after})"
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_zero_referenced_check_response_carries_ac3_exact_wording():
+    """⛔AC3 — 디디가 세운 정확한 문안을 응답에 그대로 싣는다. bare 「출처 없음」·「참조 없음」은
+    금지(미수집을 「없음」으로 표시하면 거짓이라는 게 AC3의 핵심)."""
+    from app.routers.cron import zero_referenced_entities_check
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            resp = await zero_referenced_entities_check(_request(), session=session)
+            body = json.loads(resp.body)
+            assert body["data"]["caveat"] == (
+                "관찰된 참조 0건(수집범위: mention/embed, source=chat_message·doc만 — "
+                "PR/커밋/증거자유텍스트는 미수집이라 이 수에 없음)"
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_zero_referenced_check_response_always_carries_denominator():
+    """⛔PO 정정(2026-07-29, dev 실측 후) — zero_referenced/total 절대값만 실으면 다음
+    사람이 「고아 수」로 오독한다(실측: doc 871/883·story 2497/2512인데 entity_references
+    총행수가 62뿐이라 실은 「참조추적이 아직 안 돈 것」이었다). 응답에 `entity_references_total`
+    이 항상 같이 실려 있어야 이 오독을 구조적으로 막는다."""
+    from app.routers.cron import zero_referenced_entities_check
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            resp = await zero_referenced_entities_check(_request(), session=session)
+            body = json.loads(resp.body)
+            assert "entity_references_total" in body["data"]
+            assert isinstance(body["data"]["entity_references_total"], int)
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- `reference_core`/backlinks now has a "referenced-by-zero" audit primitive: `count_zero_referenced_entities` (backlinks.py), counting doc/story entities with no incoming `entity_references` row.
- AC1: reuses #2266's `BACKLINKS_ALLOWED_TARGET_TYPES` (`doc`, `story`) — no new allowlist invented.
- AC2 (batch-vs-on-demand decision): `GET /api/v2/internal/cron/zero-referenced-entities-check` — same `verify_cron()` pattern as #2274, read-only, no permission axis (a cron has no caller/viewer, PO judgment 2026-07-29).

## Design correction that happened mid-PR (PO, after live measurement)
The story originally called for measuring the real count first, then deciding storage/exposure. I obtained the real dev-DB count via the existing `sprintable-verify-oneoff` Cloud Run job (direct SQL against the private-IP dev database — **not** via CRON_SECRET, which PO explicitly said not to touch: "시크릿을 옮기는 순간 표면이 하나 늘어나는 것"):

```
doc:   zero_referenced=871 / total=883
story: zero_referenced=2497 / total=2512
entity_references total rows: 62 (61 mention + 1 proof)
```

At first glance 871/2497 looks like "hundreds+" → build a table + exposed layer. PO caught the real story before I did: `entity_references` itself only has 62 rows total — this ratio doesn't mean "orphaned," it means the reference-tracking mechanism (mention/embed/proof) has barely populated yet (the feature is brand new). Building a table now would present ~2497 rows as "orphans" when the vast majority simply haven't been re-measured — a false metric that would read as "our data is broken" when it isn't.

**Corrected AC2**: no table, no exposure layer. The cron itself is the entirety of "도는 자리" for now, explicitly closed as "none built yet" rather than silently deferred — with a stated expiry condition: once `entity_references_total` becomes meaningful relative to story count (e.g. >10%), the count starts meaning "orphan" and the table/exposed layer gets built then. This is documented in both the code comment (cron.py) and the story body (AC2 section, story #2277).

**AC3**: exact caveat wording embedded verbatim in the response (per Diddy's phrasing, no bare "no source"/"no references"). PO also caught that reporting `zero_referenced`/`total` alone (without the `entity_references_total` denominator) is exactly the misreading trap above — the response and log line now always carry all three together.

**AC4/AC5**: no user-facing exposure exists, so neither a perf-boundary nor a permission axis applies yet — both become relevant once the AC2 expiry condition triggers building the table/exposed layer (SOURCE+TARGET permission would reuse #2266's `project_access_valid_correlated`/`conversation_readable_predicate`, already confirmed reusable).

**AC6** ("actually ran, not just green tests"): proven the same way as #2274's own precedent (confirmed against #2274's actual PR/tests) — realdb integration tests with delta-based measurement (shared DB, so no absolute-zero assumptions) plus a mutation self-check (temporarily removed the "not-yet-referenced" filter, confirmed the exclusion test goes red, restored, confirmed green). PO confirmed this bar is sufficient — a live GCP Cloud Scheduler trigger is not required (and #2274's own endpoint has no scheduler job either, a separate gap PO is tracking). The real dev-DB numbers above were independently obtained via direct SQL, not through this cron route.

## Test plan
- [x] RED-first: all 5 new tests failed with `ImportError` before the endpoint/function existed.
- [x] `test_zero_referenced_check_endpoint_rejects_missing_auth` — same `verify_cron()` gate as every other cron endpoint (no new auth invented).
- [x] `test_zero_referenced_check_counts_unreferenced_doc_and_story` — delta-based (shared DB): adding one unreferenced doc/story each increases the respective count by exactly 1.
- [x] `test_zero_referenced_check_excludes_referenced_doc` — a doc with an incoming reference is NOT counted; mutation self-check (removed the exclusion filter, confirmed this test goes red, restored, confirmed green).
- [x] `test_zero_referenced_check_response_carries_ac3_exact_wording` — verbatim caveat string.
- [x] `test_zero_referenced_check_response_always_carries_denominator` — `entity_references_total` always present as an int.
- [x] Regression: `test_1994_backlink_api_realdb.py`, `test_2274_cron_orphan_check_realdb.py`, `test_2274_module_global_leak_guard.py` — 37/37 passed alongside the 5 new tests.
- [x] Real dev-DB count independently obtained (see above) — not part of automated test suite, documented here and in story #2277's AC2/AC6.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>