### PR TITLE
[SID:2269] C-11 AC0-2 축A + AC1 — story #<번호> 관찰수집(write-path)

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -1194,7 +1194,11 @@ async def update_story(
     # 키에 source_field가 있어 서로 다른 참조로 선다). **같은 트랜잭션**(commit 전, 실패
     # 시 예외 propagate로 story 저장 전체가 롤백 — chat/doc과 동일 AC4 원자성).
     if "description" in data or "acceptance_criteria" in data:
-        from app.services.mention_parser import extract_chat_entity_mentions, reconcile_entity_references
+        from app.services.mention_parser import (
+            extract_chat_entity_mentions,
+            reconcile_entity_references,
+            resolve_bare_number_story_refs,
+        )
 
         _mention_actor_id: uuid.UUID | None = None
         try:
@@ -1206,24 +1210,37 @@ async def update_story(
         # 쪽에서 나온 것인지 화면이 구분하지 않는다(#2608 규율 — 화면은 종류로 안 가른다·그
         # 이유와 같다). dropped 사유 열거형은 채팅 쪽(#2294/#2612)이 이미 SSOT라 여기서
         # 새로 만들지 않는다.
+        #
+        # story #2269(C-11) AC1: 대괄호 문법(`extract_chat_entity_mentions`)과 맨 번호
+        # (`resolve_bare_number_story_refs`) 결과를 **합쳐서** 한 번에 reconcile한다 — 같은
+        # 대상을 두 문법으로 각각 가리켜도 (target_type, target_id, form) 3튜플이 같아 자연히
+        # 중복 제거된다(reconcile_entity_references의 set 기반 diff, 별도 dedupe 불필요).
         _ref_stored = 0
         _ref_dropped: list[dict[str, str]] = []
         if "description" in data:
-            _desc_pairs = extract_chat_entity_mentions(story.description or "")
+            _desc_text = story.description or ""
+            _desc_pairs = extract_chat_entity_mentions(_desc_text)
+            _desc_bare_refs = await resolve_bare_number_story_refs(
+                db, org_id=repo.org_id, project_id=story.project_id, content=_desc_text,
+            )
             _desc_result = await reconcile_entity_references(
                 db, org_id=repo.org_id, source_type="story", source_field="description",
                 source_id=story.id,
-                extracted_refs=[(t, i, "mention") for t, i in _desc_pairs],
+                extracted_refs=[(t, i, "mention") for t, i in _desc_pairs] + _desc_bare_refs,
                 created_by=_mention_actor_id,
             )
             _ref_stored += _desc_result.stored
             _ref_dropped.extend(_desc_result.dropped)
         if "acceptance_criteria" in data:
-            _ac_pairs = extract_chat_entity_mentions(story.acceptance_criteria or "")
+            _ac_text = story.acceptance_criteria or ""
+            _ac_pairs = extract_chat_entity_mentions(_ac_text)
+            _ac_bare_refs = await resolve_bare_number_story_refs(
+                db, org_id=repo.org_id, project_id=story.project_id, content=_ac_text,
+            )
             _ac_result = await reconcile_entity_references(
                 db, org_id=repo.org_id, source_type="story", source_field="acceptance_criteria",
                 source_id=story.id,
-                extracted_refs=[(t, i, "mention") for t, i in _ac_pairs],
+                extracted_refs=[(t, i, "mention") for t, i in _ac_pairs] + _ac_bare_refs,
                 created_by=_mention_actor_id,
             )
             _ref_stored += _ac_result.stored

--- a/backend/app/services/mention_parser.py
+++ b/backend/app/services/mention_parser.py
@@ -41,13 +41,22 @@ design-org-knowledge-mentions-backlinks §2.
 시점에 버리지 않게 고친 것뿐이라 작은 일이었지만, proof는 새 UI 흐름(어느 대화 구간을
 자를지)과 새 write 경로가 통째로 필요해 크기가 다르다.
 
-⛔story #2316 AC5(미르코 문안, 디디 반영): 이 파서가 «못 보는» 것:
-  ①맨 번호 — 본문의 `#2249`처럼 대괄호·`entity:` 문법이 **아예 없는** 참조. 이 판은 그것을
-    **한 건도 안 센다.** 사람이 손으로 쓴 참조 대부분이 이 모양이다(C-11이 다룬다).
+⛔story #2316 AC5(미르코 문안, 디디 반영): 이 파서(`extract_chat_entity_mentions` 등 대괄호
+문법 추출기)가 «못 보는» 것:
+  ①맨 번호 — 본문의 `#2249`처럼 대괄호·`entity:` 문법이 **아예 없는** 참조. **이 대괄호
+    파서는** 그것을 한 건도 안 센다. 사람이 손으로 쓴 참조 대부분이 이 모양이다.
   ②닫힌 문법 밖 — `](entity:`를 포함한 무관한 텍스트가 오탐을 낼 수 있다(기존).
-  ⇒ 즉 이 파서의 수치는 **「멘션 문법으로 쓰인 것」의 전수**이지 **「본문에 있는 참조」의
-    전수가 아니다.** 두 수를 같은 이름으로 부르면 안 된다 — #2269(C-11)의 원석 830~1993건이
-    전부 ①모양이라, 이 파서로 재고 "참조 N건"이라 부르면 그 수가 실제의 몇십 분의 일이다.
+  ⇒ 즉 **대괄호 파서**의 수치는 「멘션 문법으로 쓰인 것」의 전수이지 「본문에 있는 참조」의
+    전수가 아니다. #2269(C-11)의 원석 830~1993건이 전부 ①모양이었다.
+
+⭐story #2269(C-11) AC1(2026-07-29): 위 ①갭 중 **story description/acceptance_criteria의
+"#<번호>"가 다른 story를 가리키는 경우만** `extract_bare_number_candidates` +
+`resolve_bare_number_story_refs`가 별도로 채운다(대괄호 파서를 고치지 않고 **더한다** — 함수
+안에 분기 추가 금지 원칙 유지). ⛔여전히 못 보는 것: (a) 채팅 메시지 본문의 맨 번호(이
+write-path는 story description/AC 전용 — conversations.py 쪽은 별건), (b) story가 아닌
+타입(task/doc/epic 등)을 가리키는 맨 번호(story_number 스코프만 지원), (c) 신규 story
+생성 시점(`create_story`는 애초에 이 reconcile 자체를 안 부른다 — 대괄호 멘션도 마찬가지
+기존 갭, 이 스토리가 만든 것 아님).
 """
 from __future__ import annotations
 
@@ -164,6 +173,74 @@ def find_malformed_chat_tokens(content: str) -> list[dict[str, str]]:
         seen.add(key)
         malformed.append({"target_type": entity_type, "target_id": raw_id, "reason": "malformed_token"})
     return malformed
+
+
+# story #2269(C-11) AC0-3 세는 정의(doc `c11-2269-ac0-findings` 확定분) — word-boundary로
+# `##`·URL 프래그먼트 등 오탐을 배제한다. `(?<![\w#])`: 바로 앞이 단어문자·#이면 매치 안 함
+# (`##2258`이나 `foo#2258`은 스킵 — 후자는 URL 프래그먼트 패턴과 겹칠 수 있어 보수적으로 뺀다).
+_BARE_STORY_NUMBER_RE = re.compile(r"(?<![\w#])#(\d+)\b")
+_FENCED_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_SPAN_RE = re.compile(r"`[^`\n]*`")
+
+
+def _redact_code_spans(content: str) -> str:
+    """세는 정의: 코드블록/인라인 코드 안의 `#번호`는 참조가 아니다(예시·복사용 텍스트).
+    같은 길이의 공백으로 치환해 나머지 텍스트의 문자 위치는 그대로 유지한다(위치가 필요한
+    호출부는 아직 없지만, 치환 대신 삭제하면 인접 텍스트가 붙어 새 오탐을 만들 수 있어
+    길이 보존 쪽을 택했다)."""
+    def _blank(m: re.Match[str]) -> str:
+        return " " * len(m.group(0))
+    return _INLINE_CODE_SPAN_RE.sub(_blank, _FENCED_CODE_BLOCK_RE.sub(_blank, content))
+
+
+def extract_bare_number_candidates(content: str) -> list[int]:
+    """story #2269(C-11) AC0-3 — 대괄호·`entity:` 문법이 «없는» `#<번호>` 원석 후보를 순서
+    보존 + 중복 제거로 뽑는다(순수 함수, DB 왕복 없음 — 번호가 실제 존재하는 story를
+    가리키는지는 이 함수의 관심사가 아니다, `resolve_bare_number_story_refs` 참조). 코드블록/
+    인라인 코드 안의 매치는 제외한다(위 `_redact_code_spans`)."""
+    if not content:
+        return []
+    redacted = _redact_code_spans(content)
+    seen: set[int] = set()
+    result: list[int] = []
+    for m in _BARE_STORY_NUMBER_RE.finditer(redacted):
+        n = int(m.group(1))
+        if n not in seen:
+            seen.add(n)
+            result.append(n)
+    return result
+
+
+async def resolve_bare_number_story_refs(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID,
+    content: str,
+) -> list[tuple[str, uuid.UUID, str]]:
+    """story #2269(C-11) AC0-2 축A — `extract_bare_number_candidates`가 뽑은 번호를 실제
+    story로 해소해 `reconcile_entity_references`가 바로 받는 (target_type, target_id, form)
+    3튜플로 반환한다(caller가 대괄호 파서 결과와 합쳐 한 번에 reconcile — 저장 시 원문
+    rewrite는 하지 않는다, doc `c11-2269-ac0-findings` AC0-2 축A/축B 구분 참조).
+
+    ⛔`story_number`는 **project_id 유일**이지 org 유일이 아니다(`pm.py`
+    uq_stories_project_id_story_number) — 반드시 이 텍스트가 쓰인 소스(caller)의
+    project_id로 스코프한다. 존재하지 않는 번호는 다른 추출기와 동형으로 조용히 스킵
+    (`reconcile_entity_references`의 target_not_found 게이트가 어차피 한 번 더 걸러
+    주지만, 여기서도 최소한만 걸러 불필요한 존재판정 왕복을 줄인다)."""
+    numbers = extract_bare_number_candidates(content)
+    if not numbers:
+        return []
+    from app.models.pm import Story
+
+    rows = (await db.execute(
+        select(Story.id).where(
+            Story.org_id == org_id,
+            Story.project_id == project_id,
+            Story.story_number.in_(numbers),
+        )
+    )).all()
+    return [("story", row.id, "mention") for row in rows]
 
 
 def extract_chat_doc_mention_ids(content: str) -> list[uuid.UUID]:

--- a/backend/tests/test_2269_c11_bare_number_story_refs_realdb.py
+++ b/backend/tests/test_2269_c11_bare_number_story_refs_realdb.py
@@ -1,0 +1,266 @@
+"""story #2269(C-11) AC0-2 축A + AC1 — story description/acceptance_criteria의 대괄호 없는
+`#<번호>`(«맨 번호» 원석, 사람이 손으로 쓰는 대부분의 참조 모양)를 저장 시 entity_references에
+form='mention'으로 관찰 수집한다(doc `c11-2269-ac0-findings` AC0-2 축A/축B 구분 참조 — 이
+테스트는 축A, 원문 rewrite 없음).
+
+핵심 판정:
+  AC0-3(세는 정의): `extract_bare_number_candidates` — word-boundary, 코드블록/인라인 코드
+    제외, 중복 제거(순수 함수, DB 없음).
+  AC1-project-scope(AC0-2에서 지목한 진짜 위험): `story_number`는 project_id 유일(org 유일
+    아님) — 다른 project의 같은 번호 story는 «해소되면 안 된다»(교차 프로젝트 오연결 방지).
+  AC1-존재하지 않는 번호: 조용히 스킵(다른 추출기와 동형 malformed-tolerance).
+  AC1-대괄호+맨번호 동일 대상: 두 문법이 같은 story를 가리키면 참조 행은 하나(3튜플 set diff).
+  AC1-재조정: 맨 번호를 지우면 참조도 사라진다(#2301과 동일 diff 계약을 상속).
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tests.test_2301_story_body_mentions_realdb import (
+    _REAL_DB_URL,
+    _client_for,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _make_story,
+    _refs,
+    _session_factory,
+    _setup_app_human,
+    _token,
+)
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+# ─── AC0-3: 순수 추출 함수(DB 없음) ──────────────────────────────────────────
+
+
+def test_extract_bare_number_candidates_word_boundary_and_dedupe():
+    from app.services.mention_parser import extract_bare_number_candidates
+
+    result = extract_bare_number_candidates(
+        "이건 #2258 참조고 #2258 또 나오고 #99 도 있는지라. ##2260은 아니고 foo#2261도 아님."
+    )
+    assert result == [2258, 99]  # 중복 제거 + ##·foo# 오탐 배제, 순서 보존
+
+
+def test_extract_bare_number_candidates_excludes_fenced_code_block():
+    from app.services.mention_parser import extract_bare_number_candidates
+
+    content = "실참조 #100.\n```\n예시: #200 은 코드블록 안이라 참조 아님\n```\n또 실참조 #300."
+    assert extract_bare_number_candidates(content) == [100, 300]
+
+
+def test_extract_bare_number_candidates_excludes_inline_code_span():
+    from app.services.mention_parser import extract_bare_number_candidates
+
+    assert extract_bare_number_candidates("본문 #100, 코드 `#200 예시`, 다시 #300") == [100, 300]
+
+
+def test_extract_bare_number_candidates_empty_content():
+    from app.services.mention_parser import extract_bare_number_candidates
+
+    assert extract_bare_number_candidates("") == []
+    assert extract_bare_number_candidates(None) == []  # type: ignore[arg-type]
+
+
+# ─── AC1: write-path 통합(실PG) ──────────────────────────────────────────────
+
+
+async def test_bare_number_referencing_story_in_same_project_creates_reference():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 4242
+            await s.commit()
+            story = await _make_story(s, org.id, project.id, title="Source")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": "이건 #4242 를 가리키는지라 (맨 번호, 대괄호 없음)"},
+            )
+            assert resp.status_code == 200, resp.text
+
+            async with Session() as s:
+                refs = await _refs(s, org.id, story.id, source_field="description")
+                assert len(refs) == 1
+                assert refs[0].target_type == "story"
+                assert refs[0].target_id == target.id
+                assert refs[0].form == "mention"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_bare_number_matching_story_number_in_different_project_is_not_resolved():
+    """AC0-2가 지목한 진짜 위험: story_number는 project_id 유일이지 org 유일이 아니다 — 다른
+    project의 같은 번호 story가 잘못 해소되면 교차 프로젝트 오연결이 된다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project_a = await _make_project(s, org.id, name="A")
+            project_b = await _make_project(s, org.id, name="B")
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project_a.id)
+            # ⛔같은 org, 다른 project(B)에 같은 번호(4242)의 story가 존재.
+            other_project_story = await _make_story(s, org.id, project_b.id, title="OtherProjectTarget")
+            other_project_story.story_number = 4242
+            await s.commit()
+            story = await _make_story(s, org.id, project_a.id, title="Source")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": "이건 #4242 참조지만 project A에서 쓰인 것이라"},
+            )
+            assert resp.status_code == 200, resp.text
+
+            async with Session() as s:
+                refs = await _refs(s, org.id, story.id, source_field="description")
+                assert refs == [], (
+                    "다른 project의 story_number가 잘못 해소됐다(교차 프로젝트 오연결)"
+                )
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_bare_number_with_no_matching_story_is_silently_skipped():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, title="Source")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": "존재하지 않는 #999999 참조인지라"},
+            )
+            assert resp.status_code == 200, resp.text
+
+            async with Session() as s:
+                refs = await _refs(s, org.id, story.id, source_field="description")
+                assert refs == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_bracket_syntax_and_bare_number_to_same_story_dedupe_to_one_reference():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 5151
+            await s.commit()
+            story = await _make_story(s, org.id, project.id, title="Source")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={
+                    "description": (
+                        _token("Target", "story", target.id) + " 그리고 같은 대상을 #5151 로도 가리키는지라"
+                    ),
+                },
+            )
+            assert resp.status_code == 200, resp.text
+
+            async with Session() as s:
+                refs = await _refs(s, org.id, story.id, source_field="description")
+                assert len(refs) == 1, "대괄호 문법과 맨 번호가 같은 대상을 가리키면 참조는 하나여야 한다"
+                assert refs[0].target_id == target.id
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_removing_bare_number_from_description_removes_its_reference():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 6161
+            await s.commit()
+            story = await _make_story(s, org.id, project.id, title="Source")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            seed = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": "#6161 참조가 있는지라"},
+            )
+            assert seed.status_code == 200, seed.text
+            async with Session() as s:
+                before = await _refs(s, org.id, story.id, source_field="description")
+                assert len(before) == 1
+
+            resp = await client.patch(f"/api/v2/stories/{story.id}", json={"description": "참조를 지운지라"})
+            assert resp.status_code == 200, resp.text
+
+            async with Session() as s:
+                after = await _refs(s, org.id, story.id, source_field="description")
+                assert after == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_2301_story_body_mentions_realdb.py
+++ b/backend/tests/test_2301_story_body_mentions_realdb.py
@@ -158,14 +158,30 @@ async def _refs(session, org_id, story_id, source_field=None):
 def test_no_story_specific_mention_write_helper_added():
     """mention_parser.py에 "story" 전용 write 함수가 새로 생기지 않았는지 직접 확인 —
     공용 코어(`reconcile_entity_references`)만 있고, `insert_story_mentions`류 이름이
-    없어야 AC1이 선다."""
+    없어야 AC1이 선다.
+
+    ⛔story #2269(C-11) 후속 정정: 이름에 "story"가 들어가는 것과 "write 헬퍼"인 것은
+    다른 축이다 — #2269가 추가한 `resolve_bare_number_story_refs`는 이름에 "story"가
+    있지만 **SELECT만 하고** 그 결과를 그대로 이 파일 위 reconcile_entity_references(공용
+    코어)에 넘기는 resolver다(`extract_chat_entity_mentions`와 같은 역할 — 다만 uuid가
+    본문에 이미 있지 않아 번호→uuid 해소에 DB 조회가 필요할 뿐). 원래 이름 substring
+    체크는 "이 가드가 실제로 막으려는 것"(story 전용 INSERT/write 로직 재구현)의 근사치일
+    뿐이었다 — 근사치가 깨지자(정당한 resolver가 이름에 걸림) 근사치가 아니라 진짜 불변식
+    (write API를 직접 호출하는가)으로 판정을 옮긴다."""
+    import inspect
+
     import app.services.mention_parser as mp
 
-    public_funcs = [
+    story_named_funcs = [
         name for name in dir(mp)
         if callable(getattr(mp, name)) and not name.startswith("_") and "story" in name.lower()
     ]
-    assert public_funcs == [], f"story 전용 write 헬퍼가 생겼다: {public_funcs}"
+    _WRITE_SIGNALS = ("pg_insert(", "sa_delete(", "Reference(", "session.add(", "db.add(")
+    write_helpers = [
+        name for name in story_named_funcs
+        if any(sig in inspect.getsource(getattr(mp, name)) for sig in _WRITE_SIGNALS)
+    ]
+    assert write_helpers == [], f"story 전용 write 헬퍼가 생겼다: {write_helpers}"
 
 
 # ─── AC2: description·AC 각각 독립 reconcile ─────────────────────────────────


### PR DESCRIPTION
## Summary
- story #2269(C-11) AC1 — 대괄호 문법(`entity:type:uuid`) 없이 사람이 손으로 쓰는 「#2258」 같은 맨 번호 참조를, story description/acceptance_criteria 저장 시 `entity_references`에 `form='mention'`으로 관찰 수집(doc `c11-2269-ac0-findings` AC0-2 축A — 원문 rewrite 없음, 축B/화면표시는 이미 머지된 #2642와 별건)
- `extract_bare_number_candidates`(순수 함수, AC0-3 세는 정의: word-boundary·코드블록/인라인 코드 제외·중복 제거) + `resolve_bare_number_story_refs`(project_id 스코프 DB 조회) 신설, 기존 `extract_chat_entity_mentions` 결과와 합쳐 같은 `reconcile_entity_references` 코어로 한 번에 diff — story 전용 write 헬퍼는 새로 만들지 않음(#2301 AC1 원칙 유지)
- `story_number`는 project_id 유일(org 유일 아님) — 소스의 project_id로만 스코프, 뮤테이션 자가검증(project_id 필터 제거 → 교차 프로젝트 오연결 RED 확인 → 복원 → GREEN)으로 실증
- 부수 발견: #2301의 "story 전용 write 헬퍼 0" 가드가 이름 substring(`"story" in name`)으로 이번 resolver를 오탐 — write API 호출 여부로 판정축을 정확하게 이동(근사치 가드가 깨지자 진짜 불변식으로 옮김)

## Out of scope (명시)
- story 생성 시점(`create_story`)은 애초에 이 reconcile 자체를 안 부름(대괄호 멘션도 동일한 기존 갭 — 이 PR이 만든 것 아님)
- 채팅 메시지 본문의 맨 번호(이 write-path는 story description/AC 전용)
- 기존 2256건 story에 대한 소급 백필(AC7 별도 미정)

## Test plan
- [x] `test_2269_c11_bare_number_story_refs_realdb.py` — 9 tests 신규(추출 함수 4·같은 project 해소·교차 project 미해소(뮤테이션 자가검증)·미존재 번호 스킵·대괄호+맨번호 동일대상 dedupe·삭제 시 참조 제거)
- [x] `test_2301_story_body_mentions_realdb.py` 가드 정정 + 전체 green
- [x] 인접 realdb 스위트(`test_2263`, `test_2315`) 회귀 0 — 총 30 tests green(신선 alembic-migrated DB, `sprintable_2269_test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)