### PR TITLE
feat(#2268 AC1): GET /api/v2/session-context — bundle my work + judgments

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -169,7 +169,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import a2a, account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, deeplink_manifest, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, device_installations, dispatch, docs, entities, goals, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, judgments, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, project_access, project_settings, projects, public_docs, references, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import a2a, account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, deeplink_manifest, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, device_installations, dispatch, docs, entities, goals, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, judgments, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, project_access, project_settings, projects, public_docs, references, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, session_context, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 # 도메인 축 B(org-1st-class-surface-ia-design-b §3): OpenAPI 태그 조직-우선 위계.
 # 개별 라우터는 기존 세부 tag(예 "stories")를 그대로 유지하고 이 4축 태그를 추가로 보유(다중
@@ -310,6 +310,7 @@ app.include_router(hitl_config.router)
 app.include_router(gates.router)
 app.include_router(evidence.router)
 app.include_router(judgments.router)
+app.include_router(session_context.router)
 app.include_router(github_integration.router)
 app.include_router(gate_config.router)
 app.include_router(gate_config.org_router)

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -1,14 +1,12 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
-from app.models.pm import Story, Task
-from app.models.team import TeamMember
-from app.schemas.dashboard import DashboardResponse, StoryItem, TaskItem
+from app.schemas.dashboard import DashboardResponse
+from app.services.dashboard_core import MemberNotFoundError, get_my_work
 
 router = APIRouter(prefix="/api/v2/dashboard", tags=["dashboard", "Work"])
 
@@ -28,39 +26,15 @@ async def get_dashboard(
     자체가 생략돼 더 심했다. member가 caller org 소속인지 항상 검증(project_id 명시 여부 무관).
     assignee 기준 열람 자체는 stories/tasks 목록 필터와 동일한 프로젝트 협업 시야라 자기 자신으로
     제한하지 않는다(PO 확인).
+
+    ⛔story #2268: 쿼리 본체는 `dashboard_core.get_my_work`로 뽑았다(session_context_core.py가
+    같은 함수를 재사용 — 재구현 0). 이 라우터는 그 함수를 부르고 404로 번역하는 얇은 래퍼다.
     """
-    member_check = await session.execute(
-        select(TeamMember.project_id).where(
-            TeamMember.id == member_id, TeamMember.org_id == org_id, TeamMember.is_active.is_(True)
-        ).limit(1)
-    )
-    member_project_id = member_check.scalar_one_or_none()
-    if member_project_id is None:
-        raise HTTPException(status_code=404, detail="Member not found or inactive")
-    if project_id is None:
-        project_id = member_project_id
-
-    stories_r = await session.execute(
-        select(Story.id, Story.title, Story.status, Story.story_points).where(
-            Story.project_id == project_id,
-            Story.assignee_id == member_id,
-            Story.status != "done",
-            Story.deleted_at.is_(None),
+    try:
+        my_stories, my_tasks = await get_my_work(
+            session, org_id=org_id, member_id=member_id, project_id=project_id,
         )
-    )
-    story_rows = stories_r.all()
+    except MemberNotFoundError as e:
+        raise HTTPException(status_code=404, detail="Member not found or inactive") from e
 
-    tasks_r = await session.execute(
-        select(Task.id, Task.title, Task.status).where(
-            Task.assignee_id == member_id,
-            Task.status != "done",
-            Task.deleted_at.is_(None),
-        )
-    )
-    task_rows = tasks_r.all()
-
-    return DashboardResponse(
-        my_stories=[StoryItem(id=r[0], title=r[1], status=r[2], story_points=r[3]) for r in story_rows],
-        my_tasks=[TaskItem(id=r[0], title=r[1], status=r[2]) for r in task_rows],
-        open_memos=[],
-    )
+    return DashboardResponse(my_stories=my_stories, my_tasks=my_tasks, open_memos=[])

--- a/backend/app/routers/session_context.py
+++ b/backend/app/routers/session_context.py
@@ -1,0 +1,75 @@
+"""story #2268(E-CONNECT, C-10) — GET /api/v2/session-context. 배경은
+`app/services/session_context_core.py` 모듈 docstring 참조.
+
+⛔이름 주의(PO 지시, 2026-07-29): `get_loop_context`/`loops.py`와 헷갈리지 않는다 — 그건
+E-LOOP-LEDGER의 `LoopRun`(가설/실험 실행 단위) 유사과거 Context Pack이고, 이 라우터는
+세션 연속성(진행 중인 내 일 + 판단/정정 + 최근 활동)을 준다 — 둘은 서로 다른 개념이다.
+
+pull 전용(judgment_core와 동일 원칙, story #2268 AC 자체가 요구) — 세션 시작 시 에이전트가
+직접 물어서 받는다, push 없음.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.routers.judgments import JudgmentListResponse
+from app.schemas.dashboard import StoryItem, TaskItem
+from app.services.dashboard_core import MemberNotFoundError
+from app.services.session_context_core import DEFAULT_RECENT_ACTIVITY_LIMIT, get_session_context
+
+router = APIRouter(prefix="/api/v2/session-context", tags=["session-context", "Work"])
+
+
+class ActivityItem(BaseModel):
+    id: uuid.UUID
+    action: str
+    actor_id: uuid.UUID | None
+    actor_type: str
+    created_at: datetime
+    context: dict
+
+
+class RecentActivityForItem(BaseModel):
+    items: list[ActivityItem]
+    # ⛔사실 그대로(비율 아님, PO 판정 2026-07-29) — "12건 중 8건"이 아니라 "4건은 안 실렸다".
+    omitted_count: int
+
+
+class SessionContextResponse(BaseModel):
+    my_stories: list[StoryItem]
+    my_tasks: list[TaskItem]
+    judgments_by_work_item: dict[str, JudgmentListResponse]
+    # ⛔None = "since를 안 줘서 안 물어봤다"(AC4 — 모름), {} = "물어봤는데 전 항목 0건이었다".
+    # 이 둘을 같은 값으로 섞지 않는다.
+    recent_activity_since: datetime | None
+    recent_activity_by_work_item: dict[str, RecentActivityForItem] | None
+
+
+@router.get("", response_model=SessionContextResponse)
+async def get_session_context_endpoint(
+    member_id: uuid.UUID = Query(...),
+    project_id: uuid.UUID | None = Query(default=None),
+    since: datetime | None = Query(
+        default=None,
+        description="이 시각 이후 활동만 포함(AC4 — 생략하면 recent_activity 축 전체가 null, 빈 배열이 아니다)",
+    ),
+    activity_limit: int = Query(default=DEFAULT_RECENT_ACTIVITY_LIMIT, ge=1, le=100),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth: AuthContext = Depends(get_current_user),
+) -> Any:
+    try:
+        return await get_session_context(
+            session, org_id=org_id, member_id=member_id, project_id=project_id,
+            since=since, activity_limit=activity_limit,
+        )
+    except MemberNotFoundError as e:
+        raise HTTPException(status_code=404, detail="Member not found or inactive") from e

--- a/backend/app/services/dashboard_core.py
+++ b/backend/app/services/dashboard_core.py
@@ -1,0 +1,61 @@
+"""story #2268(E-CONNECT) — dashboard.py의 my_stories/my_tasks 쿼리를 재사용 가능한
+서비스 함수로 뽑는다(재구현 0). session_context_core.py가 이 함수를 그대로 불러 쓴다 —
+member 존재/활성 검증·project_id 해석 로직을 두 번째로 다시 짜지 않는다.
+
+⛔dashboard.py의 원 로직·주석(prod 핫픽스 cross-org 차단 근거)은 그대로 옮겼다 — 동작 변경 0.
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.pm import Story, Task
+from app.models.team import TeamMember
+from app.schemas.dashboard import StoryItem, TaskItem
+
+
+class MemberNotFoundError(ValueError):
+    """member_id가 caller org 소속 활성 멤버가 아님 — 호출 라우터가 404로 번역한다."""
+
+
+async def get_my_work(
+    session: AsyncSession, *, org_id: uuid.UUID, member_id: uuid.UUID, project_id: uuid.UUID | None,
+) -> tuple[list[StoryItem], list[TaskItem]]:
+    """dashboard.get_dashboard와 동일 쿼리(cross-org 차단 검증 포함). project_id=None이면
+    member의 소속 project로 해석한다(dashboard.py 원 로직 그대로)."""
+    member_check = await session.execute(
+        select(TeamMember.project_id).where(
+            TeamMember.id == member_id, TeamMember.org_id == org_id, TeamMember.is_active.is_(True)
+        ).limit(1)
+    )
+    member_project_id = member_check.scalar_one_or_none()
+    if member_project_id is None:
+        raise MemberNotFoundError(f"member {member_id} not found or inactive in org {org_id}")
+    if project_id is None:
+        project_id = member_project_id
+
+    stories_r = await session.execute(
+        select(Story.id, Story.title, Story.status, Story.story_points).where(
+            Story.project_id == project_id,
+            Story.assignee_id == member_id,
+            Story.status != "done",
+            Story.deleted_at.is_(None),
+        )
+    )
+    story_rows = stories_r.all()
+
+    tasks_r = await session.execute(
+        select(Task.id, Task.title, Task.status).where(
+            Task.assignee_id == member_id,
+            Task.status != "done",
+            Task.deleted_at.is_(None),
+        )
+    )
+    task_rows = tasks_r.all()
+
+    return (
+        [StoryItem(id=r[0], title=r[1], status=r[2], story_points=r[3]) for r in story_rows],
+        [TaskItem(id=r[0], title=r[1], status=r[2]) for r in task_rows],
+    )

--- a/backend/app/services/session_context_core.py
+++ b/backend/app/services/session_context_core.py
@@ -1,0 +1,109 @@
+"""story #2268(E-CONNECT, C-10) — 「세션 시작 컨텍스트」한 호출의 몸통.
+
+AC1: 「여기까지 했고 · 전진 경계 · 내 것」을 한 호출로 준다 —
+  ①내 것        = `dashboard_core.get_my_work` 그대로 재사용(재구현 0)
+  ②판단과 정정   = `judgment_core.list_judgments`를 work_item마다 재사용(재구현 0) — active
+                  원소가 이미 `correction_ids`로 철회를 인라인 표시한다(story #2308/#2611,
+                  별도 목록으로 안 뺀다는 이 스토리의 요구를 이미 만족).
+  ③전진 경계(부분) = `activity_logs`(PO 판정 2026-07-29, 스레드 e5c0d2ad 이후): 원래 "마지막
+                  세션 이후 무엇이 «머지»됐는가"로 물었으나, PR은 「사실」이 아니라 「수단」이고
+                  한 스토리에 여럿·에픽/문서엔 아예 없다 — `activity_logs`가 모든 엔티티 타입에
+                  같은 모양(entity_type·entity_id·action·created_at)으로 있어 이 축을 전부
+                  덮는다(PullRequestStoryLink 기반안은 폐기 — 아래 참고).
+
+⛔폐기한 안: PullRequestStoryLink 테이블로 "최근 머지"를 구하는 것. 이 테이블의 유일한
+쓰기처(routers/github_integration.py)가 link_source="explicit"를 하드코딩해 auto_match/sid
+매치(실제 PR 대다수)는 애초에 저장되지 않는다 — 그 테이블로 재면 실제 머지 대부분이 빠진
+거짓 0에 가까운 수가 된다. 이 갭 자체는 story #2327(trust_pipeline.batch_scope_violation의
+동일 근본 결함)로 별도 트래킹.
+
+AC4(모르는 것을 「없음」으로 주지 않는다): `since`가 주어지지 않으면 `recent_activity_by_work_item`
+자체가 None이다 — 빈 dict `{}`는 안 쓴다("물어봤는데 없었다"와 "안 물어봤다"가 다른 사실이므로
+같은 falsy 값으로 섞으면 그 자체가 거짓이 된다).
+
+AC5(예산): my_stories/my_tasks는 이미 "지금 열린 것"(status != done)으로 좁혀진 집합이라
+추가 상한을 두지 않는다. judgments_by_work_item의 `active`는 judgment_core 기존
+recency-cap(20)을 그대로 물려받고 `meta.active_omitted_count`가 잘린 개수를 사실 그대로
+보고한다(비율로 접지 않는다, PO 판정 2026-07-29 — "8건 중 4건"이 아니라 "4건은 안 실렸다").
+recent_activity_by_work_item도 동일 원칙 적용 — 각 work_item의 값 자체에 `omitted_count`를
+인라인으로 싣는다(별도 목록으로 안 뺀다는 원칙①을 여기도 동형 적용, 소비자가 한 자리만
+읽어도 잘렸는지 알 수 있게). 조회 범위는 「내가 지금 손대려는 것과 교차하는 것만」(PO 지시)
+— my_stories/my_tasks에 속한 work_item만 본다, 전체 activity_logs 나열은 하지 않는다.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.activity_log import ActivityLog
+from app.services.dashboard_core import get_my_work
+from app.services.judgment_core import list_judgments
+
+DEFAULT_RECENT_ACTIVITY_LIMIT = 10
+
+
+async def _recent_activity_for_one(
+    session: AsyncSession, *, org_id: uuid.UUID, entity_type: str, entity_id: uuid.UUID,
+    since: datetime, limit: int,
+) -> dict:
+    base_filters = [
+        ActivityLog.org_id == org_id, ActivityLog.entity_type == entity_type,
+        ActivityLog.entity_id == entity_id, ActivityLog.created_at >= since,
+    ]
+    total = (
+        await session.execute(select(func.count()).select_from(ActivityLog).where(*base_filters))
+    ).scalar_one()
+    rows = (
+        await session.execute(
+            select(ActivityLog).where(*base_filters).order_by(ActivityLog.created_at.desc()).limit(limit)
+        )
+    ).scalars().all()
+    return {
+        "items": [
+            {
+                "id": r.id, "action": r.action, "actor_id": r.actor_id, "actor_type": r.actor_type,
+                "created_at": r.created_at, "context": r.context,
+            }
+            for r in rows
+        ],
+        "omitted_count": max(0, total - len(rows)),
+    }
+
+
+async def get_session_context(
+    session: AsyncSession, *, org_id: uuid.UUID, member_id: uuid.UUID, project_id: uuid.UUID | None,
+    since: datetime | None, activity_limit: int = DEFAULT_RECENT_ACTIVITY_LIMIT,
+) -> dict:
+    """세션 시작 컨텍스트 「한 호출」 진입점. `dashboard_core.get_my_work`/`judgment_core.
+    list_judgments`를 그대로 재사용(신규 테이블 0) — 이 함수 자체는 그 둘 + activity_logs를
+    work_item 교집합으로 좁혀 묶는 것뿐이다."""
+    my_stories, my_tasks = await get_my_work(
+        session, org_id=org_id, member_id=member_id, project_id=project_id,
+    )
+
+    judgments_by_work_item: dict[str, dict] = {}
+    for item in (*my_stories, *my_tasks):
+        judgments_by_work_item[str(item.id)] = await list_judgments(
+            session, org_id=org_id, work_item_id=item.id, method=None, scope=None,
+        )
+
+    recent_activity_by_work_item: dict[str, dict] | None = None
+    if since is not None:
+        recent_activity_by_work_item = {}
+        for entity_type, items in (("story", my_stories), ("task", my_tasks)):
+            for item in items:
+                recent_activity_by_work_item[str(item.id)] = await _recent_activity_for_one(
+                    session, org_id=org_id, entity_type=entity_type, entity_id=item.id,
+                    since=since, limit=activity_limit,
+                )
+
+    return {
+        "my_stories": my_stories,
+        "my_tasks": my_tasks,
+        "judgments_by_work_item": judgments_by_work_item,
+        "recent_activity_since": since,
+        "recent_activity_by_work_item": recent_activity_by_work_item,
+    }

--- a/backend/tests/test_2268_session_context_realdb.py
+++ b/backend/tests/test_2268_session_context_realdb.py
@@ -1,0 +1,300 @@
+"""story #2268(E-CONNECT, C-10) — GET /api/v2/session-context 실PG 검증.
+
+AC1: my_stories/my_tasks(dashboard_core 재사용) + judgments_by_work_item(judgment_core
+재사용) + recent_activity_by_work_item(activity_logs, PO 축전환 2026-07-29)이 한 호출로 온다.
+AC4: `since` 생략 시 recent_activity_by_work_item은 None(빈 dict가 아니다).
+AC5: 캡에 잘린 것은 비율이 아니라 사실(omitted_count)로 — judgments든 activity든 동형.
+
+#2263/#2277과 동일 실PG 패턴(_client_for/_setup_app_human/_make_human_member 재사용,
+delta 없이도 되는 이유는 이 테스트들이 매번 새 org/story를 만들어 절대값 assertion이
+안전하기 때문 — 공유 테이블 delta 필요 없는 케이스)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_1994_backlink_api_realdb import (
+    _client_for,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _session_factory,
+    _setup_app_human,
+)
+
+pytestmark = [pytest.mark.anyio]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _make_story(session, org_id, project_id, *, assignee_id, title="Story", status="in-progress"):
+    from app.models.pm import Story
+    story = Story(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status=status,
+        assignee_id=assignee_id,
+    )
+    session.add(story)
+    await session.flush()
+    return story
+
+
+@pytest.mark.anyio
+async def test_session_context_bundles_my_work_and_judgments():
+    """AC1 핵심 — 한 호출에서 my_stories와 그 스토리에 붙은 judgment가 같이 온다."""
+    from app.main import app
+    from app.services.judgment_core import create_judgment
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id, "P")
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, assignee_id=member_id, title="My Story")
+            await s.commit()
+
+            await create_judgment(
+                s, org_id=org.id, scope="items", work_item_ids=[story.id], kind="judgment",
+                target_id=None, method=None, statement="초기 판단", created_by=member_id,
+            )
+            await s.commit()
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/session-context", params={"member_id": str(member_id)},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert any(st["id"] == str(story.id) for st in body["my_stories"])
+            judgments = body["judgments_by_work_item"][str(story.id)]
+            assert len(judgments["active"]) == 1
+            assert judgments["active"][0]["statement"] == "초기 판단"
+            assert judgments["corrections"] == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_session_context_retraction_visible_inline_not_separate_only():
+    """⭐PO 요구① — 철회를 「따로 목록」으로만 두지 않는다. active 원소 자체의 correction_ids로
+    철회된 사실이 그 자리에서 보여야 한다(#2308/#2611 재사용, 이 엔드포인트가 그 필드를
+    안 지우고 그대로 통과시키는지 확認)."""
+    from app.main import app
+    from app.services.judgment_core import create_judgment
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id, "P")
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, assignee_id=member_id)
+            await s.commit()
+
+            original = await create_judgment(
+                s, org_id=org.id, scope="items", work_item_ids=[story.id], kind="judgment",
+                target_id=None, method=None, statement="원 판단(틀림)", created_by=member_id,
+            )
+            await s.commit()
+            await create_judgment(
+                s, org_id=org.id, scope="items", work_item_ids=[story.id], kind="retraction",
+                target_id=original.id, method=None, statement="철회함", created_by=member_id,
+            )
+            await s.commit()
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/session-context", params={"member_id": str(member_id)},
+            )
+            assert resp.status_code == 200, resp.text
+            judgments = resp.json()["judgments_by_work_item"][str(story.id)]
+            active_original = next(j for j in judgments["active"] if j["id"] == str(original.id))
+            assert active_original["correction_ids"] == [str(next(
+                c["id"] for c in judgments["corrections"]
+            ))], "active 목록의 원 판단 자체가 자신을 철회한 correction id를 물고 있어야 한다"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_session_context_since_omitted_gives_null_not_empty_list():
+    """⛔AC4 — since를 안 주면 recent_activity_by_work_item은 None이어야 한다({}가 아니다).
+    None="안 물어봤다", {}는 "물어봤는데 없었다" — 다른 사실이라 섞으면 거짓."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id, "P")
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            await _make_story(s, org.id, project.id, assignee_id=member_id)
+            await s.commit()
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/session-context", params={"member_id": str(member_id)},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["recent_activity_by_work_item"] is None
+            assert body["recent_activity_since"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_session_context_since_provided_returns_activity_scoped_to_my_work():
+    """AC1③ — since를 주면 내 work_item에 붙은 activity_logs만(다른 work_item의 활동은
+    안 새는지도 대조) 반환한다."""
+    from app.main import app
+    from app.models.activity_log import ActivityLog
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id, "P")
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            my_story = await _make_story(s, org.id, project.id, assignee_id=member_id, title="Mine")
+            other_story = await _make_story(
+                s, org.id, project.id, assignee_id=uuid.uuid4(), title="NotMine",
+            )
+            await s.commit()
+
+            now = datetime.now(timezone.utc)
+            s.add(ActivityLog(
+                id=uuid.uuid4(), org_id=org.id, project_id=project.id, actor_id=member_id,
+                actor_type="human", action="status_changed", entity_type="story",
+                entity_id=my_story.id, context={"from": "backlog", "to": "in-progress"},
+                created_at=now,
+            ))
+            s.add(ActivityLog(
+                id=uuid.uuid4(), org_id=org.id, project_id=project.id, actor_id=member_id,
+                actor_type="human", action="status_changed", entity_type="story",
+                entity_id=other_story.id, context={}, created_at=now,
+            ))
+            await s.commit()
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            since = (now - timedelta(hours=1)).isoformat()
+            resp = await client.get(
+                "/api/v2/session-context",
+                params={"member_id": str(member_id), "since": since},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            activity = body["recent_activity_by_work_item"]
+            assert str(my_story.id) in activity
+            assert len(activity[str(my_story.id)]["items"]) == 1
+            assert activity[str(my_story.id)]["items"][0]["action"] == "status_changed"
+            assert str(other_story.id) not in activity, "내 것 아닌 스토리의 활동이 새면 안 된다"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_session_context_activity_cap_reports_omitted_as_fact():
+    """⛔PO 판정② — 캡에 잘린 것은 비율이 아니라 사실로. activity_limit=1로 좁혀 2건 중
+    1건만 실리면 omitted_count=1이 정확히 나와야 한다(잘렸다는 사실 자체가 사라지면 안 됨)."""
+    from app.main import app
+    from app.models.activity_log import ActivityLog
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id, "P")
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, assignee_id=member_id)
+            await s.commit()
+
+            now = datetime.now(timezone.utc)
+            for i in range(2):
+                s.add(ActivityLog(
+                    id=uuid.uuid4(), org_id=org.id, project_id=project.id, actor_id=member_id,
+                    actor_type="human", action=f"event_{i}", entity_type="story",
+                    entity_id=story.id, context={}, created_at=now - timedelta(minutes=i),
+                ))
+            await s.commit()
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            since = (now - timedelta(hours=1)).isoformat()
+            resp = await client.get(
+                "/api/v2/session-context",
+                params={"member_id": str(member_id), "since": since, "activity_limit": 1},
+            )
+            assert resp.status_code == 200, resp.text
+            item = resp.json()["recent_activity_by_work_item"][str(story.id)]
+            assert len(item["items"]) == 1
+            assert item["omitted_count"] == 1
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_session_context_404_when_member_not_in_caller_org():
+    """dashboard.py와 동일 cross-org 차단(dashboard_core.get_my_work 재사용이 이 게이트도
+    같이 물려받는지 확認)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_a = await _make_org(s)
+            org_b = await _make_org(s)
+            project_a = await _make_project(s, org_a.id, "A")
+            project_b = await _make_project(s, org_b.id, "B")
+            _, caller_user_id = await _make_human_member(s, org_a.id, project_a.id)
+            other_member_id, _ = await _make_human_member(s, org_b.id, project_b.id)
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user_id, org_a.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/session-context", params={"member_id": str(other_member_id)},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -141,6 +141,8 @@ _KNOWN_DEBT_ALLOWLIST: dict[str, str] = {
         "MEDIUM — S20 fast-follow가 cross-org만 막았고 same-org cross-project는 오늘 계열과 동형 미검증",
     "app.routers.dashboard:get_dashboard":
         "MEDIUM — member_id는 org-scope 검증하나 explicit project_id에 접근권 검증 없음(assignee 필터로 blast-radius는 좁음)",
+    "app.routers.session_context:get_session_context_endpoint":
+        "MEDIUM — dashboard.get_dashboard와 동일 갭(story #2268이 dashboard_core.get_my_work를 그대로 재사용해 상속, 신규 결함 아님)",
     "app.routers.agent_runs:create_agent_run":
         "MEDIUM — body.agent_id의 org 소속만 검증하고 body.story_id는 caller org/project 접근권 미검증",
     "app.routers.merge_gate:get_merge_gate_metrics":


### PR DESCRIPTION
## Summary
Story #2268 (C-10, "the last link" of E-CONNECT) — instead of agents relying on a self-managed `progress.txt` for session continuity, this adds `GET /api/v2/session-context`: one call bundling what's mine, judgments/corrections attached to it, and recent activity — the AC1 core of the story.

**Reused with zero reimplementation:**
- `dashboard.py`'s `my_stories`/`my_tasks` query, factored into `dashboard_core.get_my_work()`. `dashboard.py` becomes a thin wrapper calling the same function — behavior unchanged (confirmed: 100 existing tests across `test_authz_project_scope_coverage.py`, `test_be_scope_enforce_7b63c226.py`, `test_integration.py`, `test_s33.py` all still pass).
- `judgment_core.list_judgments()`, called once per work item. Its existing `correction_ids` cross-referencing (story #2308/PR#2611) already satisfies PO's requirement that a retracted judgment can't be missed by only reading the `active` list — this endpoint passes that shape through untouched.

## AC1③ design pivot (mid-implementation, PO decision)
The story originally scoped this row as "what merged since last session." I investigated `PullRequestStoryLink` as the data source and found it structurally can't answer this: its only writer (`github_integration.py:214`) hardcodes `link_source="explicit"`, so PRs matched via `auto_match`/`sid` (the vast majority of real merges) are never persisted there — using it would silently under-report almost everything, the same "looks filled but isn't" trap caught elsewhere today.

PO's correction: the axis itself was wrong. What's actually needed isn't "a PR merged" (a mechanism) but "something happened to this work item" (the fact) — `activity_logs` already covers every entity type uniformly (`entity_type`/`entity_id`/`action`/`created_at`), so it answers the real question directly, with no PR-linkage dependency at all. Implemented `recent_activity_by_work_item` on `activity_logs`, scoped to the caller's own `my_stories`/`my_tasks` (never a global dump), gated behind an optional `since` param (pull-only, matching `judgment_core`'s existing principle — there's no "session" concept to compute this automatically from).

## AC4 (never disguise "didn't check" as "found nothing")
`since` omitted → `recent_activity_by_work_item` is `null`, not `{}`. A caller that didn't ask for recent activity gets an explicit "unknown," not a falsy value indistinguishable from "checked every item, found zero."

## AC5 (budget: document what's cut, don't just dump)
`judgments_by_work_item` inherits `judgment_core`'s existing recency cap + `active_omitted_count`, reported as a raw count — PO explicitly rejected a ratio framing ("8 of 12") since it can obscure that real items were dropped ("4 items were not shown" is the required framing). `recent_activity` applies the same discipline per work item via an inline `omitted_count` on each item's own object (not a separate list a caller could skip — the same principle PO required for retraction visibility, applied here too).

## Side finding — reported, not fixed here
While investigating `PullRequestStoryLink`, found `trust_pipeline.batch_scope_violation()` queries it for `link_source IN ("auto_match", "sid")` — a filter that, given the hardcoded-`"explicit"` writer above, can never match any row. Scope-violation detection is structurally blind to the vast majority of real PRs while reporting "clean" (0 violations reads as "nothing's wrong" when it's actually "nothing was checked"). PO filed this separately as **story #2327** (high priority) — out of scope for this PR, not touched here.

## Test plan
- [x] RED-first design iteration: wrote the core module and router together with the test file, then mutation-verified two of the most safety-critical behaviors rather than trusting green alone:
  - Removed the `since is not None` guard (making the endpoint always compute activity even when unrequested) → `test_session_context_since_omitted_gives_null_not_empty_list` goes red (SQL error comparing `created_at >= NULL`, confirming the guard is load-bearing, not decorative).
  - Hardcoded `omitted_count` to `0` → `test_session_context_activity_cap_reports_omitted_as_fact` goes red, confirming the cap-honesty assertion isn't tautological.
  - Both restored, confirmed green.
- [x] `test_session_context_bundles_my_work_and_judgments` — AC1 core: one call returns both my story and its attached judgment.
- [x] `test_session_context_retraction_visible_inline_not_separate_only` — a retracted judgment's `correction_ids` field (in the `active` list itself) reflects the retraction; not relying on the caller to separately cross-reference the `corrections` list.
- [x] `test_session_context_since_omitted_gives_null_not_empty_list` / `test_session_context_since_provided_returns_activity_scoped_to_my_work` — AC4 null-vs-empty distinction, and activity scoped correctly to *my* work items only (a sibling story's activity doesn't leak in).
- [x] `test_session_context_activity_cap_reports_omitted_as_fact` — AC5 honesty.
- [x] `test_session_context_404_when_member_not_in_caller_org` — confirms the cross-org guard is inherited from `dashboard_core.get_my_work` along with everything else.
- [x] Full regression: 100 passed, 1 xfailed (pre-existing) across judgments/activity_logs/authz-coverage/dashboard-touching suites.
- [x] `test_authz_project_scope_coverage.py`'s known-debt baseline updated: this route inherits `dashboard.get_dashboard`'s existing, already-accepted `project_id` gap (same reasoning, not a new vulnerability introduced by this change) — this is why that file shows as modified.
- [x] `app.openapi()` schema generation confirmed clean (no Pydantic validation issues in the new response model).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>