### PR TITLE
[SID:2288] 「자리를 비운 사이」 배너를 attention(3관계 밖)까지 넓힌다

### DIFF
--- a/apps/web/src/components/dashboard/command-center/action-zone.test.tsx
+++ b/apps/web/src/components/dashboard/command-center/action-zone.test.tsx
@@ -191,4 +191,18 @@ describe('ActionZone — story #2288 §8-8 자리를 비운 사이', () => {
     await render(data); // 같은 data, 재마운트 — 기준점이 갱신됐으면 더 이상 "새것"이 아니다.
     expect(container.textContent).not.toContain('변경이 있었습니다');
   });
+
+  it('story #2288, PO 확認(2026-07-29): attention(감지 신호) 쪽 새 항목도 같은 배너에 합산된다', async () => {
+    store.set('sprintable:command-center:v1:last-seen-actions', String(new Date('2026-07-29T00:00:00Z').getTime()));
+    await render({
+      action_queue: { scope: 'project', items: [] },
+      attention: {
+        scope: 'project',
+        items: [{ type: 'agent_stuck', severity: 'warn', auto_detected: true, entity_type: 'story', entity_id: 'e1', gate_type: null, stuck_since: '2026-07-29T01:00:00Z' }],
+        pending: [],
+      },
+      is_clear: false,
+    });
+    expect(container.textContent).toContain('내 것 1건에 변경이 있었습니다');
+  });
 });

--- a/apps/web/src/components/dashboard/command-center/action-zone.tsx
+++ b/apps/web/src/components/dashboard/command-center/action-zone.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { ShieldCheck, GitPullRequest, Ban, AlertTriangle, CheckCircle2, ChevronRight, History } from 'lucide-react';
 import { type MyActions, type Priority, type QueueItem, type AttentionItem } from './types';
-import { selectVisibleQueue, countChangedSince, getLastSeenMs, markSeenNow, minutesAgo } from './derive-action-zone';
+import { selectVisibleQueue, countChangedSince, countAttentionChangedSince, getLastSeenMs, markSeenNow, minutesAgo } from './derive-action-zone';
 
 const QUEUE_CAP = 5; // now-face.tsx CAP 관례 재사용(§7-4 잘림-보이기).
 
@@ -110,18 +110,22 @@ export function ActionZone({ data, resolveName, epicTitles }: {
 }) {
   const t = useTranslations('dashboard');
   const queue = useMemo(() => data?.action_queue.items ?? [], [data]);
-  const attention = data?.attention.items ?? [];
+  const attention = useMemo(() => data?.attention.items ?? [], [data]);
   const hasPending = (data?.attention.pending.length ?? 0) > 0;
   const isClear = data?.is_clear === true;
 
   // story #2288 §8-4·§7-4: 자를 땐 review_merge부터, 잘렸으면 반드시 말한다.
   const { visible: visibleQueue, cutCount } = selectVisibleQueue(queue, QUEUE_CAP);
 
-  // story #2288 §8-8(기존 3관계 범위): 방문 사이 새로 생긴 항목 수를 접힌 줄로 알린다.
+  // story #2288 §8-8: 방문 사이 새로 생긴 것 — action_queue 3관계뿐 아니라 attention(감지
+  // 신호, org-scope이나 「지금 볼 것」에 이미 뜨는 것)도 PO 확認(2026-07-29)으로 포함.
   // 처음 방문(기준점 없음)은 0 — 「모름」을 「전부 새것」으로 지어내지 않는다(getLastSeenMs 참조).
   // 읽기는 useSyncExternalStore(하이드레이션 안전, setState-in-effect 없음) · 쓰기만 effect로.
   const lastSeenMs = useSyncExternalStore(subscribeNoop, getLastSeenMs, getServerSnapshot);
-  const awayCount = useMemo(() => countChangedSince(queue, lastSeenMs), [queue, lastSeenMs]);
+  const awayCount = useMemo(
+    () => countChangedSince(queue, lastSeenMs) + countAttentionChangedSince(attention, lastSeenMs),
+    [queue, attention, lastSeenMs],
+  );
   const lastSeenMinutesAgo = minutesAgo(lastSeenMs);
   useEffect(() => {
     if (!data) return;
@@ -181,6 +185,8 @@ export function ActionZone({ data, resolveName, epicTitles }: {
               <p className="text-xs text-muted-foreground">{t('ccQueueEmpty')}</p>
             )}
             {cutCount > 0 ? (
+              // ccQueueTruncated 문구는 자리만 확保 — 최종 워딩은 유나 lane(§8-4 규율을
+              // 담아 통일된 톤으로 검수 예정, 지금은 기능 검증용 임시 문구).
               <p className="text-[11px] text-muted-foreground">{t('ccQueueTruncated', { shown: visibleQueue.length, total: queue.length })}</p>
             ) : null}
           </div>

--- a/apps/web/src/components/dashboard/command-center/derive-action-zone.test.ts
+++ b/apps/web/src/components/dashboard/command-center/derive-action-zone.test.ts
@@ -1,10 +1,14 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { selectVisibleQueue, countChangedSince, getLastSeenMs, markSeenNow } from './derive-action-zone';
-import type { QueueItem } from './types';
+import { selectVisibleQueue, countChangedSince, countAttentionChangedSince, getLastSeenMs, markSeenNow } from './derive-action-zone';
+import type { QueueItem, AttentionItem } from './types';
 
 function item(type: QueueItem['type'], createdAt: string | null = null): QueueItem {
   return { type, priority: 'info', context: {}, created_at: createdAt };
+}
+
+function attentionItem(stuckSince: string | null = null): AttentionItem {
+  return { type: 'agent_stuck', severity: 'warn', auto_detected: true, entity_type: 'story', entity_id: 'e1', gate_type: null, stuck_since: stuckSince };
 }
 
 describe('selectVisibleQueue — story #2288 §7-4·§8-4', () => {
@@ -56,6 +60,22 @@ describe('countChangedSince — story #2288 §8-8', () => {
       item('my_blockers', null), // created_at 없음 — 안 셈
     ];
     expect(countChangedSince(queue, lastSeen)).toBe(1);
+  });
+});
+
+describe('countAttentionChangedSince — story #2288, PO 확認(2026-07-29): §8-8을 attention까지 넓힘', () => {
+  it('기준점이 없으면(첫 방문) 0', () => {
+    expect(countAttentionChangedSince([attentionItem('2026-07-29T00:00:00Z')], null)).toBe(0);
+  });
+
+  it('stuck_since가 기준점 이후인 것만 센다(생겨난 시점으로 씀)', () => {
+    const lastSeen = new Date('2026-07-29T00:00:00Z').getTime();
+    const attention = [
+      attentionItem('2026-07-28T23:00:00Z'), // 이전 — 안 셈
+      attentionItem('2026-07-29T01:00:00Z'), // 이후 — 셈
+      attentionItem(null), // 없음 — 안 셈
+    ];
+    expect(countAttentionChangedSince(attention, lastSeen)).toBe(1);
   });
 });
 

--- a/apps/web/src/components/dashboard/command-center/derive-action-zone.ts
+++ b/apps/web/src/components/dashboard/command-center/derive-action-zone.ts
@@ -1,4 +1,4 @@
-import type { QueueItem } from './types';
+import type { QueueItem, AttentionItem } from './types';
 
 /**
  * story #2288 — 명세(`me-axis-screen-spec-2288`) §7-4·§8-4·§8-8 중 «재료 없이도 서는» 셋:
@@ -51,18 +51,33 @@ function writeLastSeenMs(nowMs: number): void {
   }
 }
 
-/**
- * §8-8 — 자리를 비운 사이 몇 건이 바뀌었는지(기존 3관계 범위 한정). 처음 방문(기준점 없음)은
- * 0으로 — 「모름」을 「전부 새것」으로 지어내지 않는다. `nowMs`는 호출부가 넘긴다
- * (Date.now() 직접 호출 없이 테스트 가능하게).
- */
-export function countChangedSince(queue: QueueItem[], lastSeenMs: number | null): number {
+function countChangedSinceGeneric<T>(items: T[], lastSeenMs: number | null, getIso: (item: T) => string | null): number {
   if (lastSeenMs === null) return 0;
-  return queue.filter((q) => {
-    if (!q.created_at) return false;
-    const t = new Date(q.created_at).getTime();
+  return items.filter((item) => {
+    const iso = getIso(item);
+    if (!iso) return false;
+    const t = new Date(iso).getTime();
     return Number.isFinite(t) && t > lastSeenMs;
   }).length;
+}
+
+/**
+ * §8-8 — 자리를 비운 사이 action_queue(담당·결재자·내가 막고 있음) 중 몇 건이 바뀌었는지.
+ * 처음 방문(기준점 없음)은 0으로 — 「모름」을 「전부 새것」으로 지어내지 않는다.
+ */
+export function countChangedSince(queue: QueueItem[], lastSeenMs: number | null): number {
+  return countChangedSinceGeneric(queue, lastSeenMs, (q) => q.created_at);
+}
+
+/**
+ * story #2288, PO 확認(2026-07-29) — §8-8을 action_queue 3관계 밖으로 넓힌다: attention(감지
+ * 신호, org-scope이나 「지금 볼 것」에 나와 이미 내가 보는 것)도 같은 자로 잰다. `stuck_since`를
+ * 「생겨난 시점」으로 쓴다(created_at 없음 — 감지 시각이 그 역할). 별도 함수인 이유:
+ * attention은 action_queue와 다른 배열·다른 타임스탬프 필드라 하나로 합칠 근거가 약하고,
+ * 호출부(ActionZone)가 둘을 더해 하나의 배너로 보인다(계산은 분리, 표시만 합침 — §7-0 층3).
+ */
+export function countAttentionChangedSince(attention: AttentionItem[], lastSeenMs: number | null): number {
+  return countChangedSinceGeneric(attention, lastSeenMs, (a) => a.stuck_since);
 }
 
 /** 방문 시 1회 호출 — 「지금」을 다음 방문의 기준점으로 남긴다. */


### PR DESCRIPTION
## 요약
PR#2644에 이어 story #2288의 §8-8("자리를 비운 사이")을 PO 지시(2026-07-29)대로 action_queue 3관계(담당/결재자/내가 막고 있음)를 넘어 **attention(감지 신호)**까지 넓힌다. attention은 org-scope 신호지만 이미 커맨드센터의 「지금 볼 것」 섹션에 나에게 보여지고 있으므로 같은 "비운 사이" 자로 재는 것이 자연스럽다는 판단.

## 변경
- `countAttentionChangedSince()` 신규 — `AttentionItem.stuck_since`를 "생겨난 시점"으로 써 기준점 이후 감지된 신호 수를 센다. `countChangedSince()`와 같은 로직(`countChangedSinceGeneric`)을 공유하되 배열/타임스탬프 필드가 달라 별도 함수로 유지.
- `ActionZone`에서 두 카운트를 더해 하나의 배너("내 것 N건에 변경이 있었습니다")로 합쳐 보인다 — 계산은 분리, 표시만 합침.
- 잘림 표시(`ccQueueTruncated`) 문구에 "자리만 확保, 최종 워딩은 유나 lane" 코멘트 추가 — 임의로 확定된 문구인 양 굳히지 않음.

## 검증
- `pnpm vitest run` — 전체 315 files / 2134 tests 통과
- `pnpm tsc --noEmit` — 통과 · `pnpm lint` — 0 errors · `pnpm build` — EXIT 0
- 뮤테이션 검증: `countAttentionChangedSince`를 no-op(0 리턴)으로 되돌려 신규 테스트 2건이 정확히 그 증상으로 RED → 복원 GREEN

## Test plan
- [ ] dev 배포 후 사람 경로: attention에 새 감지 신호가 있는 상태에서 재방문 시 배너 카운트에 합산되는 것 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)