### PR TITLE
[SID:2269] C-11 AC0-2 축B — #<번호>를 실제로 클릭 가능한 것으로 화면에 그린다

### DIFF
--- a/apps/web/src/app/api/stories/[id]/references/route.ts
+++ b/apps/web/src/app/api/stories/[id]/references/route.ts
@@ -1,3 +1,4 @@
+import { NextResponse } from 'next/server';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors, type ApiMeta } from '@/lib/api-response';
 import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
@@ -8,7 +9,14 @@ type RouteParams = { params: Promise<{ id: string }> };
 /** GET /api/stories/{id}/references?direction=outgoing — story #2265(C-7): 이 스토리가
  * 가리키는 참조 목록(지금은 proof form만 실사용). BE(list_references)는 convention-A
  * ({data,meta})라 raw json.data ?? json 언랩 패턴으로 짓는다(backlinks/route.ts와 동형 —
- * #2247/#2564 이중포장 사고 재발 금지). */
+ * #2247/#2564 이중포장 사고 재발 금지).
+ *
+ * story #2269(C-11) AC0-2 축B(2026-07-29): BE가 `data`의 형제 필드로 얹는
+ * `bare_number_targets`(번호→story_id 매핑, render-time #<번호> 치환용)를 `apiSuccess(beJson.
+ * data ?? beJson, ...)` 언랩 패턴 그대로 두면 조용히 버려진다(#2315 route.ts와 같은 함정 —
+ * 정책 7.3의 `{data, error, meta}` 삼종엔 그 자리가 없다). `bare_number_targets`가 있을 때만
+ * NextResponse.json으로 직접 형제 필드를 싣는다(정책 7.3 의도적 예외, #2315 route.ts와 동일
+ * 근거 — `data` 배열 안에 섞으면 참조 목록 타입이 오염된다). */
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
@@ -18,7 +26,15 @@ export async function GET(request: Request, { params }: RouteParams) {
 
     const _r = await proxyToFastapiWithParams(request, '/api/v2/stories/[id]/references', { id });
     if (!_r.ok) return _r;
-    const beJson = await _r.json() as { data?: unknown; meta?: ApiMeta };
+    const beJson = await _r.json() as { data?: unknown; meta?: ApiMeta; bare_number_targets?: Record<string, string> };
+    if (beJson.bare_number_targets) {
+      return NextResponse.json({
+        data: beJson.data ?? beJson,
+        error: null,
+        meta: beJson.meta ?? null,
+        bare_number_targets: beJson.bare_number_targets,
+      });
+    }
     return apiSuccess(beJson.data ?? beJson, beJson.meta);
   } catch (err: unknown) {
     return handleApiError(err);

--- a/apps/web/src/components/kanban/description-viewer.test.tsx
+++ b/apps/web/src/components/kanban/description-viewer.test.tsx
@@ -179,3 +179,120 @@ describe('DescriptionViewer — entity: 허용 목록 추가가 다른 위험 sc
     expect(link!.getAttribute('href')).toBe('https://sprintable.example/x');
   });
 });
+
+// story #2269(C-11) AC0-2 축B — bare_number_targets(번호→story_id)를 이용한 render-time
+// #<번호> 치환. 축A(entity_references 관찰수집)만으로는 화면에 아무것도 안 뜬다는 PO 지적
+// (2026-07-29)을 반영한 실제 표시 레이어.
+describe('DescriptionViewer — bare #<번호>가 bareNumberTargets로 렌더되는지(AC0-2 축B)', () => {
+  const TARGET_ID = '22222222-2222-2222-2222-222222222222';
+
+  it('bareNumberTargets에 매칭되는 번호는 정상 칩으로 그린다', async () => {
+    await act(async () => {
+      root.render(
+        <DescriptionViewer
+          description="이건 #2258 참조인지라"
+          bareNumberTargets={{ '2258': TARGET_ID }}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('#2258');
+    expect(container.textContent).not.toContain('대상이 없습니다');
+    expect(container.querySelector('button')).toBeTruthy();
+  });
+
+  it('bareNumberTargets에 없는 번호(미해소)는 유령 칩으로 그린다 — «삭제됨»이 아니라 시제 중립 문구', async () => {
+    await act(async () => {
+      root.render(
+        <DescriptionViewer
+          description="이건 #9999 참조인지라"
+          bareNumberTargets={{}}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('대상이 없습니다');
+    expect(container.textContent).not.toContain('삭제');
+    expect(container.querySelector('button')).toBeFalsy();
+  });
+
+  it('bareNumberTargets가 undefined(미로드)면 치환을 보류하고 #<번호>가 평문 그대로 남는다', async () => {
+    await act(async () => {
+      root.render(<DescriptionViewer description="이건 #2258 참조인지라" />);
+    });
+
+    expect(container.textContent).toContain('#2258');
+    expect(container.textContent).not.toContain('대상이 없습니다');
+    expect(container.querySelector('button')).toBeFalsy();
+    expect(container.querySelector('a')).toBeFalsy();
+  });
+
+  it('여러 번호 중 일부만 해소돼도 각자 독립적으로 정상/유령을 가른다', async () => {
+    await act(async () => {
+      root.render(
+        <DescriptionViewer
+          description="해소됨 #100, 미해소 #200"
+          bareNumberTargets={{ '100': TARGET_ID }}
+        />,
+      );
+    });
+
+    const html = container.innerHTML;
+    const buttons = container.querySelectorAll('button');
+    expect(buttons.length).toBe(1);
+    expect(html).toContain('대상이 없습니다');
+  });
+
+  it('코드블록 안의 #<번호>는 치환되지 않는다(AC0-3 세는 정의)', async () => {
+    await act(async () => {
+      root.render(
+        <DescriptionViewer
+          description={'실참조 #100.\n```\n예시 #200\n```'}
+          bareNumberTargets={{ '100': TARGET_ID, '200': TARGET_ID }}
+        />,
+      );
+    });
+
+    const buttons = container.querySelectorAll('button');
+    expect(buttons.length).toBe(1); // #100만 칩, #200은 코드블록 안이라 평문
+    expect(container.querySelector('code')?.textContent).toContain('#200');
+  });
+
+  it('bare-number: 링크 클릭도 부모(편집모드 진입) onClick으로 안 샌다', async () => {
+    let parentClicked = false;
+    await act(async () => {
+      root.render(
+        <div onClick={() => { parentClicked = true; }}>
+          <DescriptionViewer description="#2258" bareNumberTargets={{ '2258': TARGET_ID }} />
+        </div>,
+      );
+    });
+
+    const button = container.querySelector('button') as HTMLButtonElement;
+    expect(button).toBeTruthy();
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+
+    expect(parentClicked).toBe(false);
+  });
+});
+
+// ⛔뮤테이션 자가검증(PO 지시 패턴 재사용) — `bare-number:` 스킴 추가가 다른 위험 scheme까지
+// 안 여는지.
+describe('DescriptionViewer — bare-number: 허용 목록 추가가 다른 위험 scheme까지 안 여는지', () => {
+  it('bareNumberTargets가 있어도 javascript: href는 여전히 제거된다(치환 대상 아닌 일반 링크)', async () => {
+    await act(async () => {
+      root.render(
+        <DescriptionViewer
+          description="[클릭](javascript:alert(1))"
+          bareNumberTargets={{ '1': '11111111-1111-1111-1111-111111111111' }}
+        />,
+      );
+    });
+
+    const link = container.querySelector('a');
+    expect(link).toBeTruthy();
+    expect(link!.getAttribute('href')).toBeNull();
+  });
+});

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -109,13 +109,51 @@ const STORY_ATTACHMENT_LIMIT = 10;
 // ①을 위한 것 — 두 겹 다 `entity:` 하나만 추가로 열고 그 외(특히 javascript:/data:)는
 // 원래 막던 대로 둔다(뮤테이션 자가검증: description-viewer.test.tsx의 "javascript:/data:
 // href는 여전히 막힌다" 테스트가 그 증거).
+// story #2269(C-11) AC0-2 축B(2026-07-29, PO 지적) — `bare-number:` 도 같은 두 겹 필터를
+// 통과해야 한다(entity:와 동일 이유). `#<번호>`를 render-time에 `[#번호](bare-number:번호)`
+// 로 치환(`prepareBareNumberRefs`)해 이 스킴으로 태우므로 여기서도 열어야 한다.
 const descriptionSanitizeSchema = {
   ...defaultSchema,
   protocols: {
     ...defaultSchema.protocols,
-    href: [...(defaultSchema.protocols?.href ?? []), 'entity'],
+    href: [...(defaultSchema.protocols?.href ?? []), 'entity', 'bare-number'],
   },
 };
+
+// story #2269(C-11) AC0-3 세는 정의(backend `mention_parser._BARE_STORY_NUMBER_RE`/
+// `_redact_code_spans`와 1:1 대응 — 정의가 두 곳에 따로 있으면 그 자체가 드리프트 위험이라
+// 정규식을 문자 그대로 포트했다). word-boundary로 `##`·`foo#123` 오탐 배제, 코드블록/인라인
+// 코드 안은 참조 아님으로 제외.
+const BARE_STORY_NUMBER_RE = /(?<![\w#])#(\d+)\b/g;
+const FENCED_CODE_BLOCK_RE = /```[\s\S]*?```/g;
+const INLINE_CODE_SPAN_RE = /`[^`\n]*`/g;
+
+function redactCodeSpans(content: string): string {
+  const blank = (m: string) => ' '.repeat(m.length);
+  return content.replace(FENCED_CODE_BLOCK_RE, blank).replace(INLINE_CODE_SPAN_RE, blank);
+}
+
+// story #2269(C-11) AC0-2 축B — chat-bubble.tsx의 `prepareMentions()`(@name → [@name]
+// (mention:name))와 동형. `#2258` 을 `[#2258](bare-number:2258)` 마크다운 링크 문법으로
+// 바꿔 기존 `a` 오버라이드 경로에 태운다. ⛔치환은 redact된 사본에서 위치만 찾고, 실제
+// 삽입은 **원문**에 대해 한다(redact가 길이를 보존하므로 위치가 그대로 대응) — 코드블록
+// 안의 원문 백틱 등을 훼손하지 않기 위함.
+function prepareBareNumberRefs(content: string): string {
+  const redacted = redactCodeSpans(content);
+  let result = '';
+  let lastIndex = 0;
+  BARE_STORY_NUMBER_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = BARE_STORY_NUMBER_RE.exec(redacted)) !== null) {
+    const start = m.index;
+    const end = start + m[0].length;
+    result += content.slice(lastIndex, start);
+    result += `[#${m[1]}](bare-number:${m[1]})`;
+    lastIndex = end;
+  }
+  result += content.slice(lastIndex);
+  return result;
+}
 
 // story #2021 후속(PO 리뷰): components 객체를 렌더 함수 안에서 인라인으로 만들면 매 렌더
 // 새 함수 참조가 되어 react-markdown이 서브트리를 리마운트한다(chat-bubble 근본원인과 동형).
@@ -177,13 +215,42 @@ function isGhostOutgoingReference(
 //
 // story #2269(C-11) AC0: `references`는 GET /api/stories/{id}/references?direction=outgoing
 // 응답(이 story의 outgoing 참조 전체) — undefined면 유령 판정을 보류한다(#2622와 동일 폴백
-// 원칙). entity: 링크 렌더는 `a` 오버라이드 하나만 `references`에 의존하므로 그 함수만
-// useMemo로 새로 만들고 나머지(descriptionViewerComponents)는 그대로 재사용해 리마운트
-// 표면을 최소화한다.
-export function DescriptionViewer({ description, references }: { description: string; references?: OutgoingReference[] }) {
+// 원칙). `bareNumberTargets`는 같은 응답의 형제 필드(번호→story_id, AC0-2 축B) — undefined면
+// `#<번호>` 치환 자체를 보류한다(축A 결과 없이 렌더하면 전부 거짓 유령이 된다). entity:/
+// bare-number: 링크 렌더는 `a` 오버라이드 하나만 이 값들에 의존하므로 그 함수만 useMemo로
+// 새로 만들고 나머지(descriptionViewerComponents)는 그대로 재사용해 리마운트 표면을 최소화.
+export function DescriptionViewer({
+  description, references, bareNumberTargets,
+}: {
+  description: string;
+  references?: OutgoingReference[];
+  bareNumberTargets?: Record<string, string>;
+}) {
   const components = useMemo(() => ({
     ...descriptionViewerComponents,
     a: ({ href, children }: { href?: string; children?: React.ReactNode }) => {
+      // story #2269(C-11) AC0-2 축B — `prepareBareNumberRefs`가 만든 `bare-number:<번호>`
+      // 토큰. `bareNumberTargets`에 매칭되면 정상 칩(entityId=uuid), 없으면(미해소·미로드
+      // 둘 다) **유령 칩**으로 그린다 — entityId 없이 ghost=true(EntityChip의 ghost 분기는
+      // entityId를 아예 안 쓴다). ⛔"삭제됨"이 아니라 "대상이 없습니다"(EntityChip 기존
+      // 문구, 시제 중립) 그대로 재사용 — PO 우려(「삭제됨」처럼 보이면 거짓)를 위해 새 문구를
+      // 발명하지 않고 기존 문구가 이미 시제 중립임을 그대로 쓴다(문구 변경 0).
+      const bareMatch = href?.match(/^bare-number:(\d+)$/);
+      if (bareMatch) {
+        const number = bareMatch[1]!;
+        const targetId = bareNumberTargets?.[number];
+        return (
+          <span onClick={(e) => e.stopPropagation()}>
+            <EntityChip
+              entityType="story"
+              entityId={targetId}
+              label={`#${number}`}
+              href={targetId ? getEntityHref('story', targetId) : null}
+              ghost={!targetId}
+            />
+          </span>
+        );
+      }
       // id는 UUID만 허용 — chat-bubble.tsx의 entity: 파싱 규칙과 동일.
       const m = href?.match(/^entity:(\w+):([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i);
       // ⛔asset은 reference_registry.ENTITY_RESOLVERS 밖의 FE 전용 타입(mention_parser.py
@@ -199,16 +266,20 @@ export function DescriptionViewer({ description, references }: { description: st
       }
       return descriptionViewerComponents.a({ href, children });
     },
-  }), [references]);
+  }), [references, bareNumberTargets]);
+
+  // bareNumberTargets가 아직 없으면(미로드) 치환을 보류 — #<번호>는 그대로 평문(#2622와
+  // 동일 폴백 원칙, 미판정을 유령으로 지어내지 않는다).
+  const prepared = bareNumberTargets !== undefined ? prepareBareNumberRefs(description) : description;
 
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
       rehypePlugins={[[rehypeSanitize, descriptionSanitizeSchema]]}
-      urlTransform={(url) => (url.startsWith('entity:') ? url : defaultUrlTransform(url))}
+      urlTransform={(url) => (url.startsWith('entity:') || url.startsWith('bare-number:') ? url : defaultUrlTransform(url))}
       components={components}
     >
-      {description}
+      {prepared}
     </ReactMarkdown>
   );
 }
@@ -344,18 +415,24 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
       .finally(() => setLoadingLabels(false));
   }, [story.id]);
 
-  // story #2269(C-11) AC0-2 축B — description/AC 본문의 entity: 링크 유령 판정용 outgoing
-  // 참조 목록. ChatProofSection과 같은 엔드포인트(GET /{id}/references?direction=outgoing)를
-  // 재사용한다(전용 라우트 신설 0). 실패·미로드 시 undefined 유지 — #2622와 동일하게 판단
-  // 재료가 없으면 유령 판정을 보류한다(false-ghost보다 미판정이 안전).
+  // description/AC 본문의 entity: 링크 유령 판정용 outgoing 참조 목록. ChatProofSection과
+  // 같은 엔드포인트(GET /{id}/references?direction=outgoing)를 재사용한다(전용 라우트
+  // 신설 0). 실패·미로드 시 undefined 유지 — #2622와 동일하게 판단 재료가 없으면 유령
+  // 판정을 보류한다(false-ghost보다 미판정이 안전).
   const [outgoingRefs, setOutgoingRefs] = useState<OutgoingReference[] | undefined>(undefined);
+  // story #2269(C-11) AC0-2 축B(2026-07-29, PO 지적) — 「#<번호>」 관찰 수집(축A, #2643)만
+  // 해서는 화면에 아무것도 안 뜬다. 같은 응답의 형제 필드 `bare_number_targets`(번호→story_id)
+  // 를 받아 DescriptionViewer의 render-time 치환에 넘긴다. undefined면 치환 자체를 보류(축A
+  // 미로드와 동형 폴백 — 안 뜨는 게 거짓 렌더보다 안전).
+  const [bareNumberTargets, setBareNumberTargets] = useState<Record<string, string> | undefined>(undefined);
 
   useEffect(() => {
     let cancelled = false;
     setOutgoingRefs(undefined);
+    setBareNumberTargets(undefined);
     fetch(`/api/stories/${story.id}/references?direction=outgoing`, { cache: 'no-store' })
       .then((r) => (r.ok ? r.json() : null))
-      .then((json: { data?: unknown } | null) => {
+      .then((json: { data?: unknown; bare_number_targets?: unknown } | null) => {
         if (cancelled || !json) return;
         const rows = Array.isArray(json.data) ? json.data : [];
         setOutgoingRefs(
@@ -365,8 +442,11 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
               && typeof (r as { target_id?: unknown })?.target_id === 'string')
             .map((r) => ({ target_type: r.target_type, target_id: r.target_id })),
         );
+        if (json.bare_number_targets && typeof json.bare_number_targets === 'object') {
+          setBareNumberTargets(json.bare_number_targets as Record<string, string>);
+        }
       })
-      .catch(() => { /* undefined 유지 — 유령 판정 보류 */ });
+      .catch(() => { /* undefined 유지 — 유령/치환 판정 보류 */ });
     return () => { cancelled = true; };
   }, [story.id]);
 
@@ -1235,7 +1315,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 // ⛔이 div에 onClick을 다시 붙이지 않는다 — 편집 진입은 «수정 버튼»으로만.
                 // 본문 안의 링크·멘션·체크박스가 자기 일을 해야 하기 때문이다.
                 <div className="mt-2">
-                  <DescriptionViewer description={story.description} references={outgoingRefs} />
+                  <DescriptionViewer description={story.description} references={outgoingRefs} bareNumberTargets={bareNumberTargets} />
                 </div>
               ) : (
                 <button
@@ -1287,7 +1367,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 // ⛔이 div에 onClick을 다시 붙이지 않는다 — 본문 안의 링크·멘션·체크박스가
                 // 자기 일을 해야 하기 때문이다.
                 <div className="mt-2">
-                  <DescriptionViewer description={story.acceptance_criteria} references={outgoingRefs} />
+                  <DescriptionViewer description={story.acceptance_criteria} references={outgoingRefs} bareNumberTargets={bareNumberTargets} />
                 </div>
               ) : (
                 <button

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -684,6 +684,25 @@ async def get_story_outgoing_references(
         repo.session, org_id=repo.org_id, entity_type="story", entity_id=id,
         direction="outgoing", visible_ids_by_type=visible,
     )
+
+    # story #2269(C-11) AC0-2 축B(2026-07-29, PO 지적): 「#<번호> 관찰 수집(축A, #2643)」만
+    # 해서는 화면에 아무것도 안 뜬다 — render-time 치환에 필요한 번호→story_id 매핑을 이
+    # 응답에 함께 싣는다. description+acceptance_criteria 둘 다 스캔해 하나로 합친다(번호는
+    # project 스코프라 필드와 무관하게 항상 같은 대상을 가리킨다). ⛔대괄호 참조(위 `refs`)와
+    # 달리 이 매핑은 가시성(visible) 필터를 거치지 않는다 — story는 이 write-path가 project
+    # 안에서만 해소하므로(project_id 스코프 자체가 가시성 경계와 같다) 별도 존재-비노출
+    # 판정이 이미 필요 없다(C-3 원칙과 충돌하지 않음 — target이 항상 caller와 같은 project다).
+    from app.services.mention_parser import resolve_bare_number_story_targets
+
+    bare_number_targets: dict[int, uuid.UUID] = {}
+    for field_text in (story.description, story.acceptance_criteria):
+        if not field_text:
+            continue
+        resolved = await resolve_bare_number_story_targets(
+            repo.session, org_id=repo.org_id, project_id=story.project_id, content=field_text,
+        )
+        bare_number_targets.update(resolved)
+
     return {
         "data": [
             {
@@ -696,7 +715,8 @@ async def get_story_outgoing_references(
                 "proof_payload": r.proof_payload,
             }
             for r in refs
-        ]
+        ],
+        "bare_number_targets": {str(number): str(story_id) for number, story_id in bare_number_targets.items()},
     }
 
 

--- a/backend/app/services/mention_parser.py
+++ b/backend/app/services/mention_parser.py
@@ -211,6 +211,37 @@ def extract_bare_number_candidates(content: str) -> list[int]:
     return result
 
 
+async def resolve_bare_number_story_targets(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID,
+    content: str,
+) -> dict[int, uuid.UUID]:
+    """story #2269(C-11) AC0-2 축B(2026-07-29 추가, PO 지적 — 축A만으로는 화면에 아무것도 안
+    뜬다: "번역만 하면 되겠지" 함정 재현) — `extract_bare_number_candidates`가 뽑은 번호를
+    **번호를 보존한 채** story로 해소한다(number → story_id). `resolve_bare_number_story_refs`
+    (축A, reconcile 3튜플 전용 — 번호를 버리고 target만 반환)와 같은 SELECT를 하지만, 화면
+    표시(render-time `#<번호>` → `entity:story:<uuid>` 치환)엔 어느 번호가 어느 대상인지가
+    필요해 번호를 살려 반환하는 별도 함수로 분리했다.
+
+    ⛔`story_number`는 **project_id 유일**이지 org 유일이 아니다 — 소스의 project_id로만
+    스코프(축A와 동일 규율, mutation self-check로 실증됨 — test_2269 참조)."""
+    numbers = extract_bare_number_candidates(content)
+    if not numbers:
+        return {}
+    from app.models.pm import Story
+
+    rows = (await db.execute(
+        select(Story.story_number, Story.id).where(
+            Story.org_id == org_id,
+            Story.project_id == project_id,
+            Story.story_number.in_(numbers),
+        )
+    )).all()
+    return {row.story_number: row.id for row in rows}
+
+
 async def resolve_bare_number_story_refs(
     db: AsyncSession,
     *,
@@ -218,29 +249,14 @@ async def resolve_bare_number_story_refs(
     project_id: uuid.UUID,
     content: str,
 ) -> list[tuple[str, uuid.UUID, str]]:
-    """story #2269(C-11) AC0-2 축A — `extract_bare_number_candidates`가 뽑은 번호를 실제
-    story로 해소해 `reconcile_entity_references`가 바로 받는 (target_type, target_id, form)
-    3튜플로 반환한다(caller가 대괄호 파서 결과와 합쳐 한 번에 reconcile — 저장 시 원문
-    rewrite는 하지 않는다, doc `c11-2269-ac0-findings` AC0-2 축A/축B 구분 참조).
-
-    ⛔`story_number`는 **project_id 유일**이지 org 유일이 아니다(`pm.py`
-    uq_stories_project_id_story_number) — 반드시 이 텍스트가 쓰인 소스(caller)의
-    project_id로 스코프한다. 존재하지 않는 번호는 다른 추출기와 동형으로 조용히 스킵
-    (`reconcile_entity_references`의 target_not_found 게이트가 어차피 한 번 더 걸러
-    주지만, 여기서도 최소한만 걸러 불필요한 존재판정 왕복을 줄인다)."""
-    numbers = extract_bare_number_candidates(content)
-    if not numbers:
-        return []
-    from app.models.pm import Story
-
-    rows = (await db.execute(
-        select(Story.id).where(
-            Story.org_id == org_id,
-            Story.project_id == project_id,
-            Story.story_number.in_(numbers),
-        )
-    )).all()
-    return [("story", row.id, "mention") for row in rows]
+    """story #2269(C-11) AC0-2 축A — `resolve_bare_number_story_targets`가 준 number→id
+    매핑을 `reconcile_entity_references`가 바로 받는 (target_type, target_id, form) 3튜플로
+    변환한다(caller가 대괄호 파서 결과와 합쳐 한 번에 reconcile — 저장 시 원문 rewrite는
+    하지 않는다, doc `c11-2269-ac0-findings` AC0-2 축A/축B 구분 참조)."""
+    targets = await resolve_bare_number_story_targets(
+        db, org_id=org_id, project_id=project_id, content=content,
+    )
+    return [("story", story_id, "mention") for story_id in targets.values()]
 
 
 def extract_chat_doc_mention_ids(content: str) -> list[uuid.UUID]:

--- a/backend/tests/test_2269_c11_bare_number_story_refs_realdb.py
+++ b/backend/tests/test_2269_c11_bare_number_story_refs_realdb.py
@@ -264,3 +264,85 @@ async def test_removing_bare_number_from_description_removes_its_reference():
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+# ─── AC0-2 축B: 번호→uuid 매핑(화면 표시용, PO 지적 2026-07-29) ──────────────
+# 「축A(관찰수집)만 해서는 화면에 아무것도 안 뜬다」— resolve_bare_number_story_targets가
+# reconcile용 3튜플(축A)과 달리 번호를 보존해 반환하는지, 그리고 GET /{id}/references가
+# 그 매핑을 형제 필드로 정확히 싣는지 검증한다.
+
+
+def test_resolve_bare_number_story_targets_preserves_number_unit():
+    """순수 로직 확인: reconcile용 축A 함수는 번호를 버리지만, 축B 함수는 number→id를 그대로
+    보존한다(같은 SELECT를 재사용하는 리팩터가 축A 계약을 깨지 않았는지 코드 레벨 확인)."""
+    import inspect
+
+    from app.services.mention_parser import resolve_bare_number_story_refs
+
+    # 축A가 축B를 재사용(중복 쿼리 로직 없음)하는지 소스로 직접 확인 — DRY 회귀 감시.
+    assert "resolve_bare_number_story_targets" in inspect.getsource(resolve_bare_number_story_refs)
+
+
+async def test_outgoing_references_endpoint_includes_bare_number_targets():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 7171
+            await s.commit()
+            story = await _make_story(
+                s, org.id, project.id, title="Source",
+                description="해소됨 #7171, 미해소 #999999",
+            )
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{story.id}/references?direction=outgoing")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["bare_number_targets"] == {"7171": str(target.id)}
+            assert "999999" not in body["bare_number_targets"]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_outgoing_references_bare_number_targets_merges_description_and_ac():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target_a = await _make_story(s, org.id, project.id, title="A")
+            target_a.story_number = 8181
+            target_b = await _make_story(s, org.id, project.id, title="B")
+            target_b.story_number = 8282
+            await s.commit()
+            story = await _make_story(
+                s, org.id, project.id, title="Source",
+                description="본문 #8181", acceptance_criteria="AC #8282",
+            )
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{story.id}/references?direction=outgoing")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["bare_number_targets"] == {"8181": str(target_a.id), "8282": str(target_b.id)}
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- 축A(#2643, `entity_references` 관찰수집)만으로는 화면에 아무것도 안 뜬다는 PO 지적(2026-07-29, "번역만 하면 되겠지" 함정 재현) — 축A 결과를 실제 render-time 치환으로 잇는다
- BE: `resolve_bare_number_story_targets`(번호 보존 반환) 신설, 기존 `resolve_bare_number_story_refs`(reconcile 3튜플 전용)가 이를 재사용하도록 리팩터(DRY). `GET /{id}/references?direction=outgoing` 응답에 `bare_number_targets`(번호→story_id) 형제 필드 추가(description+AC 병합)
- FE proxy(`references/route.ts`): `apiSuccess()`의 `{data,error,meta}` 삼종이 그 형제 필드 자리가 없어 조용히 버려지던 것을 #2315 route.ts와 동일한 정책 7.3 의도적 예외로 살림
- FE(`DescriptionViewer`): `prepareBareNumberRefs()`(chat-bubble.tsx의 `prepareMentions()`와 동형) — `#<번호>`를 `[#번호](bare-number:번호)`로 치환 후 기존 `a` 핸들러 경로에 태움. 해소되면 정상 칩, 미해소면 유령 칩(entityId 없이 ghost=true) — 문구는 기존 EntityChip "대상이 없습니다"(시제 중립) 그대로 재사용, "삭제됨"처럼 읽히는 새 문구를 만들지 않음(PO 우려 대응)
- `bare-number:` 스킴도 `entity:`와 동형으로 urlTransform + rehypeSanitize 스키마 양쪽에 열어야 렌더됨(#2642에서 확인된 그 두 겹 필터 함정과 동일 구조)

## Test plan
- [x] FE 16 tests(`description-viewer.test.tsx`) — 해소/미해소/미로드 폴백/코드블록 제외/편집모드 버블링 차단/뮤테이션 자가검증(bareNumberTargets 있어도 javascript: 여전히 차단)
- [x] BE 3 tests — 번호 보존 DRY 확인, GET 응답 형제필드 정확성, description+AC 병합
- [x] 인접 회귀: FE 30 files/222 tests, BE 관련 33 tests(축A+축B+outgoing-references+C-7 proof 소비처) 전부 green
- [x] `tsc --noEmit`, `eslint` 변경 파일 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)