### PR TITLE
feat(#2268): expose session-context via MCP tool sprintable_get_session_context

### DIFF
--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -78,6 +78,11 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # work_item_ids(다건 또는 0건 general)에 걸치는 cross-cutting 기록이라 add_evidence와
     # 동일 논리로 core 취급. vendored 사본과 동기화 필수(sprintable_mcp/toolset.py).
     "sprintable_add_judgment", "sprintable_list_judgments",
+    # story #2268(C-10, E-CONNECT — "세션 시작 컨텍스트"): get_session_context — my_dashboard/
+    # get_loop_context와 동형(read-only·self-scope pull, 특정 도메인 그룹 아님) core 취급.
+    # PO 판정(2026-07-29): REST뿐이면 에이전트가 못 쓴다 — MCP core로 노출해야 실제로 도는
+    # 자리가 된다. vendored 사본과 동기화 필수(sprintable_mcp/toolset.py).
+    "sprintable_get_session_context",
     # story b4027b2e(SEC — 까심 #2140 QA④): E-CANVAS visual_artifacts 11종(원 6개 + 7fe16274
     # 핀 4종 + list_spec_pins)을 여기서 제거하고 전용 "canvas" 그룹(_GROUP_KEYWORDS)으로 이관했다.
     # 이전엔 cross-cutting always-allow였는데(C1-S3 당시 "추가 성장 시 전용 canvas 그룹 신설
@@ -355,6 +360,8 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_add_evidence",
     # 판단 칸 (story #2268, D단계)
     "sprintable_add_judgment", "sprintable_list_judgments",
+    # 세션 시작 컨텍스트 (story #2268, C-10)
+    "sprintable_get_session_context",
     # visual artifacts (E-CANVAS C1-S3 + C2-S6 코멘트 + C3-S7 편집 + C4-S8 정본 제안 + 핀 저작 story 7fe16274)
     "sprintable_create_artifact", "sprintable_get_artifact", "sprintable_list_artifacts",
     "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -30,6 +30,7 @@ from .toolset import is_tool_allowed
 from .tools.a2a import LinkGateToTaskInput, link_gate_to_task
 from .tools.evidence import AddEvidenceInput, add_evidence
 from .tools.judgments import AddJudgmentInput, ListJudgmentsInput, add_judgment, list_judgments
+from .tools.session_context import SessionContextInput, get_session_context
 from .tools.visual_artifacts import (
     AddArtifactCommentInput, CreateArtifactInput, CreateSpecPinInput, DeleteArtifactInput,
     DeleteSpecPinInput, EditArtifactInput, GetArtifactInput, ListArtifactCommentsInput,
@@ -555,6 +556,13 @@ _TOOL_DEFS: list[tuple] = [
      " meta.active_omitted_count로 잘린 건수를 알려준다. 각 원소의 correction_ids가"
      " 비어있지 않으면 이미 정정된 것이니 그대로 믿지 말 것.",
      ListJudgmentsInput, list_judgments),
+    # 세션 시작 컨텍스트 (1) — story #2268(C-10, E-CONNECT)
+    ("sprintable_get_session_context",
+     "세션 시작 컨텍스트 — 내 stories/tasks + 거기 붙은 판단/정정 + (since를 주면) 그 뒤"
+     " 최근 활동을 한 호출로 준다. since에 직전 세션 종료 시각(ISO 8601)을 주면 그 뒤"
+     " 활동만 옴 — 안 주면 recent_activity는 null(모름, 빈 목록 아님). progress.txt 같은"
+     " 제품 밖 파일 대신 이 도구가 그 자리를 대신한다.",
+     SessionContextInput, get_session_context),
     # Visual artifacts (12) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안) +
     # 핀 저작(story 7fe16274) + story #1922(delete_artifact, soft delete·생성자 전용)
     ("sprintable_create_artifact",

--- a/backend/sprintable_mcp/tools/session_context.py
+++ b/backend/sprintable_mcp/tools/session_context.py
@@ -1,0 +1,48 @@
+"""story #2268(E-CONNECT, C-10) MCP 도구 — REST뿐이던 GET /api/v2/session-context를
+에이전트가 직접 쓰도록 노출. PO 판정(2026-07-29): "REST로만 있으면 내가(오르테가) 못 쓴다 —
+MCP로만 붙는다" — 만들어졌는데 도는 자리가 없는 것(오늘 하루 반복 잡은 실패 클래스)을
+피한다. judgments.py/dashboard(core.py)와 동형(단순 REST 위임, 재구현 0)."""
+from __future__ import annotations
+
+from mcp.types import TextContent
+
+from ..api_client import client
+from ..response import err, ok
+from ..schemas import SprintableInput
+
+
+class SessionContextInput(SprintableInput):
+    member_id: str | None = None
+    # ⭐PO 지시(2026-07-29): 이 필드 설명이 곧 관례다 — 안 적으면 아무도 안 쓴다.
+    since: str | None = None  # 마지막 세션 종료 시각(ISO 8601)을 주면 그 뒤 활동만 온다.
+    activity_limit: int | None = None
+
+
+async def get_session_context(args: SessionContextInput) -> list[TextContent]:
+    """세션 시작 컨텍스트 — "여기까지 했고 · 판단/정정 · 최근 활동"을 한 호출로 받는다.
+    progress.txt 같은 제품 밖 파일 대신 이 도구가 그 자리를 대신한다(story #2268).
+
+    `since`에 **직전 세션이 끝난 시각**(ISO 8601, 예: "2026-07-29T14:00:00Z")을 주면
+    `recent_activity_by_work_item`에 그 뒤로 내 stories/tasks에 일어난 일(action·actor·
+    created_at)만 담겨 온다 — ⛔안 주면 이 필드는 `null`이다(빈 목록이 아니다: "안 물어봤다"와
+    "물어봤는데 없었다"는 다른 사실이라 섞으면 거짓이 된다). 매 세션 시작마다 **직전 호출
+    이후 시각**을 넘기는 것을 권장한다(pull 전용 — 이 도구가 알아서 "마지막 세션"을 기억하지
+    않는다, 에이전트는 잊으므로 받은 시점을 스스로 못 지킨다).
+
+    `judgments_by_work_item`은 내 story/task마다 거기 붙은 판단(judgment)과 정정
+    (retraction/refinement/method_error)을 함께 준다 — `active` 목록의 각 원소가 이미
+    `correction_ids`로 자신을 철회한 정정을 인라인 표시하므로, `active`만 읽어도 "이건
+    철회됐다"를 놓칠 수 없다(story #2308/#2611). `active`는 recency로 캡되고
+    `meta.active_omitted_count`가 잘린 개수를 사실 그대로 준다(비율 아님) — `corrections`는
+    캡 예외로 항상 전량이다.
+    """
+    try:
+        member = args.member_id or client.member_id
+        params: dict = {"member_id": member, "project_id": client.require_project_id()}
+        if args.since is not None:
+            params["since"] = args.since
+        if args.activity_limit is not None:
+            params["activity_limit"] = args.activity_limit
+        return ok(await client.get("/api/v2/session-context", params=params))
+    except Exception as exc:
+        return err(str(exc))

--- a/backend/sprintable_mcp/toolset.py
+++ b/backend/sprintable_mcp/toolset.py
@@ -73,6 +73,9 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # work_item_ids(다건 또는 0건 general)에 걸치는 cross-cutting 기록이라 add_evidence와
     # 동일 논리로 core 취급(백엔드 SSOT와 동기화, app/services/mcp_toolset.py 참고).
     "sprintable_add_judgment", "sprintable_list_judgments",
+    # story #2268(C-10, E-CONNECT — "세션 시작 컨텍스트"): get_session_context — my_dashboard/
+    # get_loop_context와 동형 core 취급(백엔드 SSOT와 동기화, app/services/mcp_toolset.py 참고).
+    "sprintable_get_session_context",
     # E-MCP-OPT(story ff6cb90d): list_projects/set_default_project — 키 자기 신원/스코프 조회·전환
     # 유틸(sprintable_my_dashboard·sprintable_ping과 동형: 특정 비즈니스 도메인 아닌 self-scope
     # 도구). set_default_project는 write지만 caller 자신의 기본 프로젝트 설정만 바꾸는 self-scope

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -95,6 +95,8 @@ EXPECTED_TOOLS = {
     "sprintable_add_evidence",
     # 판단 칸 (2) — story #2268(D단계, E-CONNECT)
     "sprintable_add_judgment", "sprintable_list_judgments",
+    # 세션 시작 컨텍스트 (1) — story #2268(C-10, E-CONNECT)
+    "sprintable_get_session_context",
     # visual artifacts (12) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안) +
     # 핀 저작(story 7fe16274) + story #1922(delete_artifact, soft delete·생성자 전용)
     "sprintable_create_artifact", "sprintable_get_artifact", "sprintable_list_artifacts",
@@ -117,8 +119,9 @@ def test_total_tool_count():
     # story #2010: sprintable_transition_goal 1종 신설(목표 lifecycle 전이, 구 _epic 별칭 없음) —
     # 111→112. story #1922: sprintable_delete_artifact 1종 신설(artifact soft delete, 생성자
     # 전용) — 112→113. story #2268(D단계): sprintable_add_judgment/list_judgments 2종 신설
-    # (판단 칸 pull 진입점 MCP 노출) — 113→115.
-    assert len(_TOOLS) == 115
+    # (판단 칸 pull 진입점 MCP 노출) — 113→115. story #2268(C-10): sprintable_get_session_context
+    # 1종 신설(세션 시작 컨텍스트 REST를 MCP로 노출 — PO 판정: REST뿐이면 못 쓴다) — 115→116.
+    assert len(_TOOLS) == 116
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_mcp_axis_prefix_b_surface.py
+++ b/backend/tests/test_mcp_axis_prefix_b_surface.py
@@ -22,6 +22,7 @@ _CORE_NO_PREFIX = {
     "sprintable_lock_files", "sprintable_unlock_files", "sprintable_link_gate_to_task",
     "sprintable_add_evidence", "sprintable_list_projects", "sprintable_set_default_project",
     "sprintable_add_judgment", "sprintable_list_judgments",
+    "sprintable_get_session_context",
 }
 
 
@@ -65,6 +66,8 @@ def test_tool_names_and_param_models_untouched():
     sprintable_*_epic 4종은 deprecated 별칭 유지, 제거 아님) — 106→110. story #2010:
     sprintable_transition_goal 1종 신설(구 _epic 별칭 없음) — 110→111. story #1922:
     sprintable_delete_artifact 1종 신설(artifact soft delete, 생성자 전용) — 111→112. story #2268
-    (D단계): sprintable_add_judgment/list_judgments 2종 신설(판단 칸 pull 진입점) — 112→114."""
-    assert len(_TOOL_DEFS) == 114
+    (D단계): sprintable_add_judgment/list_judgments 2종 신설(판단 칸 pull 진입점) — 112→114.
+    story #2268(C-10): sprintable_get_session_context 1종 신설(세션 시작 컨텍스트 MCP 노출) —
+    114→115."""
+    assert len(_TOOL_DEFS) == 115
     assert all(name.startswith("sprintable_") for name in _TOOLS)


### PR DESCRIPTION
## Summary
PO judgment (2026-07-29): `GET /api/v2/session-context` (PR #2645) existed only as REST, but PO — and agents generally — connect exclusively via MCP tools. That meant the endpoint was "built with nowhere to run" for its actual first intended consumer, the exact failure class ("만들어졌는데 도는 자리가 없다") caught repeatedly today across #2274/#2277/#2327.

## What this does
Thin wrapper only — zero logic reimplementation, matching the `judgments.py`/`dashboard` tool precedent in `sprintable_mcp/tools/` exactly: a pydantic input model + one async function that forwards to the REST endpoint via the existing `api_client`, returns `ok()`/`err()`.

## `since` documentation (PO explicit requirement)
`since` stays optional (defaults to `None`), but per PO: "도구 설명이 곧 관례인지라 — 없으면 아무도 안 쓰는 것이라" (the tool description IS the convention — without it nobody uses the parameter). Both the function docstring and the `server.py` registration description spell out up front: give the last session-end timestamp (ISO 8601) to get only activity after that; omitting it means `recent_activity_by_work_item` comes back `null`, not an empty list.

## Registration
Registered as an always-allowed "core" tool in `app/services/mcp_toolset.py` (backend SSOT) and its vendored copy `sprintable_mcp/toolset.py` (kept in sync per that file's own explicit anti-drift rule) — same classification as `sprintable_add_judgment`/`sprintable_list_judgments` and `sprintable_my_dashboard`/`sprintable_get_loop_context`, since this is a self-scope, cross-cutting utility rather than a single business domain.

## Test updates (registry-parity, not new logic)
Updated the hardcoded tool-count/registry-parity tests that this addition legitimately shifts:
- `tests/mcp/test_contract.py`: `test_total_tool_count` 115→116, `test_all_expected_tools_registered`'s `EXPECTED_TOOLS` set gets the new name.
- `tests/test_mcp_axis_prefix_b_surface.py`: `test_tool_names_and_param_models_untouched` 114→115; `_CORE_NO_PREFIX` gets the new tool (it's core, so it correctly carries no `[조직]`/`[일감]`/`[신뢰]`/`[지식]` axis prefix, matching `add_judgment`/`list_judgments`).

All updated with the same running-total comment convention already used in those files (so the next person sees the full history, not just my delta).

**Confirmed unrelated, left untouched**: `test_e2e_dev.py::test_tools_list_89_tools` hardcodes "89 tools" but the real count is already 110+ — a 21-tool gap that predates this change by a long margin (`git log` on that file's last touch: PR #1051, long before today). It's also `skipif`-gated on `not CI` (`pytestmark = pytest.mark.skipif(not (_API_URL and _API_KEY) or bool(_CI), ...)`), so it never runs in the actual CI pipeline regardless — pre-existing debt, out of scope for this PR.

## Test plan
- [x] Import sanity: `sprintable_mcp.server` and the new tool module both import cleanly.
- [x] `tests/mcp/test_contract.py`, `tests/test_mcp_axis_prefix_b_surface.py`, `tests/test_s2304_ping_tool_name_registry_match.py`, `tests/test_toolset_catalog.py`, `tests/test_e_mcp_s4_standalone.py`, `tests/test_s2311_vendor_const_sync.py` (vendored-copy drift / registration-parity suites) — 88 passed.
- [x] `tests/test_2268_judgments_endpoint_realdb.py`/`tests/test_2268_judgments_model_realdb.py` — unaffected, still green (confirms no collateral damage to the sibling story #2268 tools already in this file's neighborhood).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>