### PR TITLE
fix(#2327 redefined): persist skipped_reason on github_webhook_delivery

### DIFF
--- a/backend/alembic/versions/0215_webhook_delivery_skipped_reason.py
+++ b/backend/alembic/versions/0215_webhook_delivery_skipped_reason.py
@@ -1,0 +1,30 @@
+"""story #2327(재정의) — github_webhook_delivery.skipped_reason 신설.
+
+배경: `_process_webhook_event`가 "ignored" 상태로 반환할 때 그 사유(no_installation_id·
+installation_not_registered_or_suspended·resolve_story_for_pr 실패·no_actionable_signal 등)를
+HTTP 응답 본문으로만 돌려주고 DB에는 안 남겼다 — 웹훅은 GitHub이 호출하는 쪽이라 그 응답을
+아무도 안 읽는다. 실측(dev, 2026-07-29): pull_request 이벤트 2468건 중 2건만 processed,
+나머지 2466건이 ignored인데 **어느 분기로 얼마나 갔는지 회고로 측정 불가**했다(원인: 이
+컬럼 부재). 다음부터는 잴 수 있게 이 컬럼을 남긴다 — 이 마이그 자체가 그 스토리의
+AC1(재정의판) 산출물이다.
+
+Revision ID: 0215
+Revises: 0214
+Create Date: 2026-07-29
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0215"
+down_revision = "0214"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE github_webhook_delivery ADD COLUMN IF NOT EXISTS skipped_reason varchar(64)")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE github_webhook_delivery DROP COLUMN IF EXISTS skipped_reason")

--- a/backend/app/models/github_installation.py
+++ b/backend/app/models/github_installation.py
@@ -76,6 +76,11 @@ class GithubWebhookDelivery(Base):
     status: Mapped[str] = mapped_column(String(16), nullable=False, default="received")
     error_code: Mapped[str | None] = mapped_column(String(64), nullable=True)
     error_message: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    # story #2327(재정의): status="ignored"일 때의 실제 사유(no_installation_id·
+    # installation_not_registered_or_suspended·resolve_story_for_pr 실패·no_actionable_signal
+    # 등) — 이전엔 HTTP 응답에만 있어(웹훅 호출자는 GitHub라 아무도 안 읽음) 회고 측정이
+    # 원천 불가능했다(2466/2468 ignored 원인 분기를 못 좁힌 실측이 그 증거).
+    skipped_reason: Mapped[str | None] = mapped_column(String(64), nullable=True)
     received_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -505,6 +505,9 @@ async def github_webhook(
             session, source, event, payload, installation_id, delivery
         )
         delivery.status = status_label
+        # story #2327(재정의): "ignored"의 실제 사유를 delivery 행에도 남긴다 — HTTP 응답
+        # 본문에만 있으면 웹훅 호출자(GitHub)만 보고 아무도 회고 측정을 못 한다.
+        delivery.skipped_reason = result.get("skipped_reason") if status_label == "ignored" else None
         delivery.processed_at = datetime.now(timezone.utc)
         await session.commit()
         return _ok(result)

--- a/backend/tests/test_2327_webhook_skipped_reason_realdb.py
+++ b/backend/tests/test_2327_webhook_skipped_reason_realdb.py
@@ -1,0 +1,228 @@
+"""story #2327(재정의, 2026-07-29) — github_webhook_delivery.skipped_reason 실PG 검증.
+
+배경: `_process_webhook_event`가 "ignored"로 반환할 때 그 사유(skipped_reason)가 HTTP 응답
+본문에만 있고 DB엔 안 남아, 실측(dev DB) 결과 pull_request 이벤트 2468건 중 2466건이
+ignored인데 «어느 분기로 얼마나 갔는지» 회고로 측정 불가능했다. 이 파일은 실제 HTTP
+엔드포인트(POST /api/v2/internal/verdict/github-webhook)를 실PG 세션으로 통과시켜
+`skipped_reason`이 실제 delivery 행에 정확히 남는지 확認한다."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+LEGACY_SECRET = "legacy-secret"
+APP_SECRET = "app-secret"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _sign(body: bytes, secret: str) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+async def _post(payload, Session, *, delivery_id, event="pull_request"):
+    from app.dependencies.database import get_db
+    from app.main import app as fastapi_app
+    from app.routers import verdict_capture as mod
+
+    async def override_db():
+        async with Session() as s:
+            yield s
+
+    fastapi_app.dependency_overrides[get_db] = override_db
+    body = json.dumps(payload).encode()
+    headers = {
+        "X-GitHub-Event": event, "X-GitHub-Delivery": delivery_id,
+        "X-Hub-Signature-256": _sign(body, LEGACY_SECRET),
+    }
+    try:
+        async with AsyncClient(transport=ASGITransport(app=fastapi_app), base_url="http://test") as c:
+            with patch.object(mod.settings, "github_webhook_secret", LEGACY_SECRET), \
+                 patch.object(mod.settings, "github_app_webhook_secret", APP_SECRET):
+                return await c.post(
+                    "/api/v2/internal/verdict/github-webhook", content=body, headers=headers,
+                )
+    finally:
+        fastapi_app.dependency_overrides.clear()
+
+
+async def _delivery_row(Session, delivery_id):
+    from app.models.github_installation import GithubWebhookDelivery
+    async with Session() as s:
+        return (
+            await s.execute(
+                select(GithubWebhookDelivery).where(GithubWebhookDelivery.delivery_id == delivery_id)
+            )
+        ).scalar_one_or_none()
+
+
+def _pr_payload(*, action, pr_number, installation_id=None, merged=False, title="chore: unrelated work"):
+    payload = {
+        "action": action,
+        "repository": {"full_name": "moonklabs/sprintable"},
+        "pull_request": {
+            "number": pr_number, "title": title, "body": "", "merged": merged,
+            "head": {"sha": "sha1", "ref": "feat-branch"},
+        },
+    }
+    if installation_id is not None:
+        payload["installation"] = {"id": installation_id}
+    return payload
+
+
+@pytest.mark.anyio
+async def test_no_actionable_signal_persists_skipped_reason():
+    """④no_actionable_signal — legacy source(installation 없음)로 opened(미머지) 이벤트를
+    보내면 resolve_story_for_pr가 SID 없어 먼저 실패할 수 있으니, SID를 실제 존재하는
+    story에 달아 resolver를 통과시키고 merged=False로 no_actionable_signal까지 도달시킨다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            from app.models.organization import Organization
+            from app.models.pm import Story
+            from app.models.project import Project
+
+            org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+            s.add(org)
+            await s.commit()
+            project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+            s.add(project)
+            await s.commit()
+            story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="S", status="in-progress")
+            s.add(story)
+            await s.commit()
+            story_id = story.id
+
+        delivery_id = f"dlv-{uuid.uuid4().hex[:8]}"
+        payload = _pr_payload(
+            action="opened", pr_number=1, merged=False,
+            title=f"feat: work [SID:{story_id}]",
+        )
+        resp = await _post(payload, Session, delivery_id=delivery_id)
+        assert resp.status_code == 200, resp.text
+
+        row = await _delivery_row(Session, delivery_id)
+        assert row is not None
+        assert row.status == "ignored"
+        assert row.skipped_reason == "no_actionable_signal"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_installation_not_registered_persists_skipped_reason():
+    """②installation_not_registered_or_suspended — app source(installation.id 있음)인데
+    그 installation이 DB에 없으면 이 사유가 정확히 남아야 한다."""
+    engine, Session = await _session_factory()
+    try:
+        delivery_id = f"dlv-{uuid.uuid4().hex[:8]}"
+        payload = _pr_payload(action="opened", pr_number=2, installation_id=999999)
+
+        from app.dependencies.database import get_db
+        from app.main import app as fastapi_app
+        from app.routers import verdict_capture as mod
+
+        async def override_db():
+            async with Session() as s:
+                yield s
+
+        fastapi_app.dependency_overrides[get_db] = override_db
+        body = json.dumps(payload).encode()
+        headers = {
+            "X-GitHub-Event": "pull_request", "X-GitHub-Delivery": delivery_id,
+            "X-Hub-Signature-256": _sign(body, APP_SECRET),
+        }
+        try:
+            async with AsyncClient(transport=ASGITransport(app=fastapi_app), base_url="http://test") as c:
+                with patch.object(mod.settings, "github_webhook_secret", LEGACY_SECRET), \
+                     patch.object(mod.settings, "github_app_webhook_secret", APP_SECRET):
+                    resp = await c.post(
+                        "/api/v2/internal/verdict/github-webhook", content=body, headers=headers,
+                    )
+        finally:
+            fastapi_app.dependency_overrides.clear()
+        assert resp.status_code == 200, resp.text
+
+        row = await _delivery_row(Session, delivery_id)
+        assert row is not None
+        assert row.status == "ignored"
+        assert row.skipped_reason == "installation_not_registered_or_suspended"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_processed_delivery_has_null_skipped_reason():
+    """⭐뮤테이션 대응 축 — status="processed"일 땐 skipped_reason이 항상 None이어야 한다
+    (이전 delivery의 값이 실수로 남는 사고를 막는다 — 매 요청 값을 명시적으로 갱신해야 함)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            from app.models.organization import Organization
+            from app.models.pm import Story
+            from app.models.project import Project
+
+            org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+            s.add(org)
+            await s.commit()
+            project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+            s.add(project)
+            await s.commit()
+            story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="S", status="in-progress")
+            s.add(story)
+            await s.commit()
+            story_id = story.id
+
+        delivery_id = f"dlv-{uuid.uuid4().hex[:8]}"
+        payload = _pr_payload(
+            action="closed", pr_number=3, merged=True,
+            title=f"feat: work [SID:{story_id}]",
+        )
+        resp = await _post(payload, Session, delivery_id=delivery_id)
+        assert resp.status_code == 200, resp.text
+
+        row = await _delivery_row(Session, delivery_id)
+        assert row is not None
+        assert row.status == "processed"
+        assert row.skipped_reason is None
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
Story #2327's original premise ("scope_violation detection is structurally 0-forever because the only writer hardcodes `link_source="explicit"`") turned out to be substantially wrong on inspection — twice over:

1. There's a **second writer**: `merge_link_evidence` (called from `_maybe_check_scope_violation`) persists `PullRequestStoryLink` rows with `link_source=rl.source`, which can be `"auto_match"`/`"sid"`, whenever a scope check actually runs.
2. An **existing, currently-passing test** (`test_declared_and_out_of_scope_file_violates`) already proves the full pipeline end-to-end: a SID-tagged PR with an out-of-scope file produces a real `PullRequestStoryLink` row via the sid path, and `compute_trust_facts().has_scope_violation` correctly comes back `True`. The read-side query is not "structurally impossible" — it works, and it's already covered.

PO redefined the story around the real open question once this was found: real dev-DB data shows 2468 `pull_request` webhook deliveries with only 2 marked `"processed"` (2466 `"ignored"`). The actual reason for each ignored delivery was **retroactively unmeasurable** — `github_webhook_delivery` has no column recording *why* a delivery was ignored (only `status`), and the reason previously only went out in the transient HTTP response body, which nobody (GitHub, the webhook caller) ever reads back.

## What this PR does
First fix under the redefinition: add `skipped_reason` (nullable, varchar(64)) to `github_webhook_delivery`, and have the webhook handler persist `result.get("skipped_reason")` whenever `status_label == "ignored"` (explicitly `None` otherwise, so a stale value from a prior delivery attempt can never leak forward onto a later processed one).

## Investigation choices made explicit (not decided silently)
- **Did not attempt to flow a real PR through dev** to observe live webhook behavior — that would require either webhook-secret access (touching a secret not otherwise needed for this fix) or creating an externally-visible GitHub PR (a hard-to-reverse, externally-visible action). Flagged this to PO rather than deciding unilaterally; he confirmed declining was the correct call given today's standing rules (don't touch secrets you don't need; ask before anything hard-to-reverse or externally visible).
- **Did not report a guess as a finding.** The code strongly suggests `no_actionable_signal` (pull_request events only carry `merged=true` on the single terminal `"closed"` action — every other action on a PR's lifecycle, opened/synchronize/labeled/etc., is "no_actionable_signal" by design) is the dominant cause of the 2466 ignored deliveries. But with no reason/payload persisted historically, there's no way to actually measure the breakdown — so per PO's explicit correction, the honest answer is "unmeasurable retroactively," not "probably X." This PR is what makes it measurable going forward; the actual breakdown is future work once real traffic accumulates against the new column.

## Closing this story (PO judgment, 2026-07-29)

**AC5 (what this can never recover)**: the scope_violation signal itself is delivered purely via a transient SSE push (`trust_pipeline._maybe_emit` → `_push_to_agent`) — zero `Event` rows are ever created, and the only `logger` call in that path is a warning on SSE-forward *failure*, not on the signal's content. So even beyond the "ignored" webhook deliveries this PR now makes measurable, **past occurrences of `has_scope_violation` flipping True are unrecoverable** — there was never a durable record of the signal firing, independent of the webhook-ignore question this PR addresses. Stating this plainly rather than leaving it implied.

**AC3 (skip-reason breakdown) is explicitly "cannot answer yet," not closed as done.** Re-examine once new data has accumulated — the re-check condition is **not** a raw count threshold but "once each of the 4 skip reasons has actually appeared at least once in `skipped_reason`" (a count threshold would let one dominant reason mask that a rarer branch never fires at all, or fires in a way nobody's looked at).

**Who re-checks, and when**: PO will pull the `skipped_reason` distribution once at the start of his next session (self-assigned, not left to "someone eventually notices this exists"). Recording this here so the logging addition doesn't just get merged and forgotten.

## Test plan
- [x] `tests/test_2327_webhook_skipped_reason_realdb.py` (new, 3 tests) — exercises the real HTTP endpoint (`POST /api/v2/internal/verdict/github-webhook`) end-to-end with a real PG session:
  - `test_no_actionable_signal_persists_skipped_reason` — an `opened` (unmerged) SID-tagged PR event correctly persists `skipped_reason="no_actionable_signal"`.
  - `test_installation_not_registered_persists_skipped_reason` — an app-source event with an unregistered `installation.id` correctly persists `skipped_reason="installation_not_registered_or_suspended"`.
  - `test_processed_delivery_has_null_skipped_reason` — a fully processed (merged, SID-tagged) delivery has `skipped_reason=None` (guards against a stale value leaking across deliveries).
- [x] Mutation self-check: removed the `skipped_reason` assignment line, confirmed 2 of the 3 new tests go red, restored, confirmed all 3 green.
- [x] Regression: `test_bot_m2_webhook_integration.py`, `test_e_ui_daegbyeon_174be6bc_scope_violation_realdb.py`, `test_e_ui_daegbyeon_p0_04_trust_pipeline_realdb.py`, `test_bot_l1_pr_story_link.py`, `test_h1_s6_github_webhook.py` — 66 passed, unaffected by the new column/assignment.
- [x] Migration applies cleanly against a fresh local disposable Postgres (`alembic upgrade head`).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
