### PR TITLE
[SID:2288] BE 명세3+4 — gate_type 패스스루 + waiting_on_others 쿼리

### DIFF
--- a/backend/app/routers/command_center.py
+++ b/backend/app/routers/command_center.py
@@ -62,9 +62,14 @@ async def my_actions(
 
     queue: list[dict] = []
     # 게이트 승인 대기 = 내가 approver 인 pending blocking approval(member-private·서버 resolve member_id).
+    # story #2288(E-CONNECT) BE 명세3(§3-1㉢·§4-1, 미르코 작성): gate_type 패스스루 —
+    # WorkflowLineStepApproval 자체엔 gate_type 필드가 없다(kind는 approver 역할 축, 다른 개념).
+    # WorkflowLineStepRun.effective_gate_type이 SSOT(위 stuck 자동감지 쿼리도 이 필드를 그대로
+    # 쓴다 — 새 값을 만들지 않는다) — step_run_id로 조인해 그대로 실어 보낸다.
     approvals = (
         await session.execute(
-            select(WorkflowLineStepApproval)
+            select(WorkflowLineStepApproval, WorkflowLineStepRun.effective_gate_type)
+            .join(WorkflowLineStepRun, WorkflowLineStepRun.id == WorkflowLineStepApproval.step_run_id)
             .where(
                 WorkflowLineStepApproval.org_id == org_id,
                 WorkflowLineStepApproval.approver_member_id == member_id,
@@ -74,13 +79,14 @@ async def my_actions(
             .order_by(WorkflowLineStepApproval.created_at.asc())
             .limit(50)
         )
-    ).scalars().all()
-    for a in approvals:
+    ).all()
+    for a, gate_type in approvals:
         queue.append({
             "type": "gate_approval",
             "priority": "warn",
             "context": {"gate_id": str(a.gate_id) if a.gate_id else None,
-                        "approval_group_id": str(a.approval_group_id), "kind": a.kind},
+                        "approval_group_id": str(a.approval_group_id), "kind": a.kind,
+                        "gate_type": gate_type},
             "created_at": a.created_at.isoformat() if a.created_at else None,
         })
     # 리뷰/머지 대기 = 내 배정 in-review 스토리(member-private).
@@ -133,6 +139,60 @@ async def my_actions(
             "type": "my_blockers",
             "priority": "danger",  # 내가 푸는 게 남을 막고 있음 — 최우선.
             "context": {"blocker_story_id": str(blocker_id), "blocked_story_id": str(blocked_id)},
+        })
+
+    # story #2288(E-CONNECT) BE 명세4(§3-1㉢·§4-1, PO 강조 — 이 스토리의 심장): 「내 것인데
+    # 남이 잡고 있음」 = 내가 담당(assignee)인 story인데 그 워크플로 라인의 pending blocking
+    # 승인 대기가 «내가 아닌» approver에게 있는 경우. §3-1㉢ 정의 그대로 — 발(다음 행동)이
+    # 내게 없다. ⛔이 항목엔 버튼을 안 단다(FE 몫 — 여기선 type만 가른다): 목적이 «행동
+    # 유도»가 아니라 「내가 놓친 게 아니라 남이 잡고 있다」는 «해소»다.
+    # 「나의 것」 정의(AC2 명시 요구): 지금은 **담당(assignee_id)** 하나만 — 결재자·멘션·claim
+    # 은 포함 안 함(추측으로 넓히지 않는다, 대조표가 곧 명세라는 PO 지시 그대로).
+    _WaitingStory = aliased(Story)
+    waiting_rows = (
+        await session.execute(
+            select(
+                _WaitingStory.id,
+                WorkflowLineStepRun.effective_gate_type,
+                WorkflowLineStepApproval.approver_member_id,
+            )
+            .select_from(_WaitingStory)
+            .join(
+                WorkflowLineStepRun,
+                (WorkflowLineStepRun.org_id == org_id)
+                & (WorkflowLineStepRun.entity_type == "story")
+                & (WorkflowLineStepRun.entity_id == _WaitingStory.id)
+                & (WorkflowLineStepRun.status == "pending"),
+            )
+            .join(
+                WorkflowLineStepApproval,
+                (WorkflowLineStepApproval.org_id == org_id)
+                & (WorkflowLineStepApproval.step_run_id == WorkflowLineStepRun.id)
+                & (WorkflowLineStepApproval.status == "pending")
+                & (WorkflowLineStepApproval.blocking.is_(True)),
+            )
+            .where(
+                _WaitingStory.org_id == org_id,
+                _WaitingStory.assignee_id == member_id,
+                _WaitingStory.deleted_at.is_(None),
+                WorkflowLineStepApproval.approver_member_id != member_id,
+            )
+            .order_by(_WaitingStory.updated_at.desc())
+            .limit(100)
+        )
+    ).all()
+    # ⛔한 story에 승인자가 여럿(quorum)이면 위 join이 story당 여러 행을 낸다 — story는 화면에
+    # «한 번»만 뜨는 게 맞다(대기 이유가 여럿이어도 "기다리는 대상"은 하나). story_id로 dedupe.
+    seen_waiting_story_ids: set[uuid.UUID] = set()
+    for story_id, gate_type, approver_id in waiting_rows:
+        if story_id in seen_waiting_story_ids:
+            continue
+        seen_waiting_story_ids.add(story_id)
+        queue.append({
+            "type": "waiting_on_others",
+            "priority": "info",  # §3-1㉢: 행동 없음 — danger/warn(행동 촉구) 축과 안 섞는다.
+            "context": {"story_id": str(story_id), "gate_type": gate_type,
+                        "approver_member_id": str(approver_id)},
         })
 
     # ── 자동 이상감지(org-scope) — enum/ids/age 만(민감 텍스트 0) ──────────────────────

--- a/backend/tests/test_2288_command_center_gate_type_waiting_realdb.py
+++ b/backend/tests/test_2288_command_center_gate_type_waiting_realdb.py
@@ -1,0 +1,272 @@
+"""story #2288(E-CONNECT) BE 명세3+4(2026-07-29, 미르코 명세·PO 강조 — 이 스토리의 심장) —
+GET /api/v2/command-center/my-actions의 두 신규 조각을 실PG로 검증한다. 기존
+test_command_center.py는 mock 세션이라 SQLAlchemy 조인 문법 자체가 유효한지는 증명하지
+못한다(모킹된 session.execute는 실제로 쿼리를 실행하지 않는다) — 이 파일이 그 공백을 메운다.
+
+명세3: gate_approval 항목의 context.gate_type이 WorkflowLineStepRun.effective_gate_type을
+  그대로 실어 나른다(새 값 발명 없음, step_run_id 조인).
+명세4: 「내 것인데 남이 잡음」 — 내가 담당(assignee)인 story의 워크플로 라인에 pending
+  blocking 승인이 있는데 approver가 내가 아니면 waiting_on_others(§3-1㉢, 버튼 없음)로 뜬다.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tests.test_2301_story_body_mentions_realdb import (
+    _REAL_DB_URL,
+    _client_for,
+    _make_org,
+    _make_project,
+    _make_story,
+    _session_factory,
+)
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _make_member(session, org_id, project_id, *, type_="human"):
+    from app.models.user import User
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.member import Member
+
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="member")
+    session.add(om)
+    await session.flush()
+    m = Member(id=om.id, org_id=org_id, type=type_, user_id=user.id, name="Human")
+    session.add(m)
+    await session.flush()
+    session.add(ProjectAccess(project_id=project_id, org_member_id=om.id, member_id=m.id, role="member"))
+    await session.commit()
+    return m.id, user.id
+
+
+async def _make_step_run(session, org_id, project_id, *, entity_type, entity_id, status="pending"):
+    from app.models.workflow_line import WorkflowLineStepRun
+
+    run = WorkflowLineStepRun(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id,
+        entity_type=entity_type, entity_id=entity_id,
+        from_status="in-review", to_status="done", status=status, mode="enforcing",
+        effective_gate_type="merge", correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex,
+    )
+    session.add(run)
+    await session.commit()
+    return run
+
+
+async def _make_approval(session, org_id, project_id, *, step_run_id, approver_member_id, status="pending"):
+    from app.models.workflow_line import WorkflowLineStepApproval
+
+    approval = WorkflowLineStepApproval(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id,
+        step_run_id=step_run_id, approval_group_id=uuid.uuid4(),
+        approver_member_id=approver_member_id, approver_member_type="human",
+        kind="approver", blocking=True, status=status,
+    )
+    session.add(approval)
+    await session.commit()
+    return approval
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="human@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+async def test_gate_approval_carries_gate_type_from_step_run_realdb():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, title="Gated")
+            run = await _make_step_run(s, org.id, project.id, entity_type="story", entity_id=story.id)
+            await _make_approval(s, org.id, project.id, step_run_id=run.id, approver_member_id=caller_id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/command-center/my-actions")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()["action_queue"]["items"]
+            ga = next(i for i in items if i["type"] == "gate_approval")
+            assert ga["context"]["gate_type"] == "merge"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_waiting_on_others_shows_when_assignee_but_approver_is_someone_else_realdb():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_member(s, org.id, project.id)
+            other_id, _ = await _make_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, title="MyStoryWaitingOnOther")
+            story.assignee_id = caller_id
+            await s.commit()
+            run = await _make_step_run(s, org.id, project.id, entity_type="story", entity_id=story.id)
+            await _make_approval(s, org.id, project.id, step_run_id=run.id, approver_member_id=other_id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/command-center/my-actions")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()["action_queue"]["items"]
+            w = next(i for i in items if i["type"] == "waiting_on_others")
+            assert w["context"]["story_id"] == str(story.id)
+            assert w["context"]["gate_type"] == "merge"
+            assert w["context"]["approver_member_id"] == str(other_id)
+            assert w["priority"] == "info"
+            # ⭐양성대조: 승인 대기가 «나에게» 있으면 gate_approval로 뜨지 waiting_on_others로
+            # 안 뜬다(§3-1㉠ vs ㉢ 구분 — 발이 나한테 있으면 행동 항목).
+            assert not any(i["type"] == "waiting_on_others" and i["context"]["story_id"] == str(story.id)
+                            for i in items if i.get("context", {}).get("approver_member_id") == str(caller_id))
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_waiting_on_others_absent_when_i_am_the_approver_realdb():
+    """⛔뮤테이션 성격 양성대조: 내가 담당이면서 «내가 approver»인 경우엔 waiting_on_others가
+    안 뜬다(발이 나한테 있다 — gate_approval만 떠야 한다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, title="MyStoryIAmApprover")
+            story.assignee_id = caller_id
+            await s.commit()
+            run = await _make_step_run(s, org.id, project.id, entity_type="story", entity_id=story.id)
+            await _make_approval(s, org.id, project.id, step_run_id=run.id, approver_member_id=caller_id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/command-center/my-actions")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()["action_queue"]["items"]
+            assert not any(i["type"] == "waiting_on_others" for i in items)
+            assert any(i["type"] == "gate_approval" for i in items)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_waiting_on_others_absent_when_not_assignee_realdb():
+    """양성대조: 담당이 아니면(§3-1㉢ 전제 자체가 성립 안 함) waiting_on_others도 안 뜬다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_member(s, org.id, project.id)
+            other_assignee_id, _ = await _make_member(s, org.id, project.id)
+            approver_id, _ = await _make_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, title="NotMyStory")
+            story.assignee_id = other_assignee_id
+            await s.commit()
+            run = await _make_step_run(s, org.id, project.id, entity_type="story", entity_id=story.id)
+            await _make_approval(s, org.id, project.id, step_run_id=run.id, approver_member_id=approver_id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/command-center/my-actions")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()["action_queue"]["items"]
+            assert not any(i["type"] == "waiting_on_others" for i in items)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_waiting_on_others_dedupes_multi_approver_quorum_realdb():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_member(s, org.id, project.id)
+            other_a, _ = await _make_member(s, org.id, project.id)
+            other_b, _ = await _make_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, title="QuorumStory")
+            story.assignee_id = caller_id
+            await s.commit()
+            run = await _make_step_run(s, org.id, project.id, entity_type="story", entity_id=story.id)
+            await _make_approval(s, org.id, project.id, step_run_id=run.id, approver_member_id=other_a)
+            await _make_approval(s, org.id, project.id, step_run_id=run.id, approver_member_id=other_b)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/command-center/my-actions")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()["action_queue"]["items"]
+            matches = [i for i in items if i["type"] == "waiting_on_others" and i["context"]["story_id"] == str(story.id)]
+            assert len(matches) == 1
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_command_center.py
+++ b/backend/tests/test_command_center.py
@@ -81,9 +81,12 @@ def _data(resp):
     return body.get("data", body) if isinstance(body, dict) else {}
 
 
-# my-actions 쿼리 순서: approvals → reviews → my_blockers(.all) → agent_stuck → stalled(.all) → unanswered(.all).
-def _ma_seq(approvals=(), reviews=(), my_blockers=(), stuck=(), stalled=(), unanswered=()):
-    return [_r_scalars(approvals), _r_scalars(reviews), _r_all(my_blockers),
+# my-actions 쿼리 순서: approvals(.all, gate_type 조인) → reviews → my_blockers(.all) →
+# waiting_on_others(.all, story #2288 BE 명세4 신규) → agent_stuck → stalled(.all) → unanswered(.all).
+# ⛔approvals는 story #2288 BE 명세3(gate_type 패스스루)로 WorkflowLineStepRun과 조인해 이제
+# (approval, gate_type) 튜플을 낸다 — 단일 ORM 엔티티가 아니므로 scalars() 대신 .all().
+def _ma_seq(approvals=(), reviews=(), my_blockers=(), waiting=(), stuck=(), stalled=(), unanswered=()):
+    return [_r_all(approvals), _r_scalars(reviews), _r_all(my_blockers), _r_all(waiting),
             _r_scalars(stuck), _r_all(stalled), _r_all(unanswered)]
 
 
@@ -100,7 +103,7 @@ async def test_my_actions_scope_separation_and_items():
                       started_at=_DT, failure_message="SECRET raw error")
     resp, session, resolver = await _get(
         "/api/v2/command-center/my-actions",
-        execute_seq=_ma_seq(approvals=[approval], reviews=[review], stuck=[stuck]))
+        execute_seq=_ma_seq(approvals=[(approval, "merge")], reviews=[review], stuck=[stuck]))
     assert resp.status_code == 200
     d = _data(resp)
     assert d["action_queue"]["scope"] == "member"      # ⭐member-private.
@@ -109,6 +112,79 @@ async def test_my_actions_scope_separation_and_items():
     assert d["attention"]["items"][0]["type"] == "agent_stuck" and d["attention"]["items"][0]["auto_detected"]
     assert "SECRET raw error" not in resp.text          # ⭐민감 텍스트 비노출.
     assert d["attention"]["pending"] == ["time_sensitive"]  # CC-BE.2서 나머지 채움(my_blockers→큐로 이동).
+
+
+# ── story #2288(E-CONNECT) BE 명세3+4 ────────────────────────────────────────
+@pytest.mark.anyio
+async def test_gate_approval_carries_gate_type_passthrough():
+    """BE 명세3(§3-1㉢·§4-1): gate_approval 항목의 context에 gate_type이 WorkflowLineStepRun.
+    effective_gate_type 그대로 실린다(값을 새로 만들지 않고 기존 SSOT를 조인해 패스스루)."""
+    approval = MagicMock(gate_id=uuid.uuid4(), approval_group_id=uuid.uuid4(), kind="approver", created_at=_DT)
+    resp, session, resolver = await _get(
+        "/api/v2/command-center/my-actions",
+        execute_seq=_ma_seq(approvals=[(approval, "merge")]))
+    assert resp.status_code == 200
+    items = _data(resp)["action_queue"]["items"]
+    ga = next(i for i in items if i["type"] == "gate_approval")
+    assert ga["context"]["gate_type"] == "merge"
+
+
+@pytest.mark.anyio
+async def test_gate_approval_gate_type_null_when_run_has_none():
+    approval = MagicMock(gate_id=uuid.uuid4(), approval_group_id=uuid.uuid4(), kind="approver", created_at=_DT)
+    resp, session, resolver = await _get(
+        "/api/v2/command-center/my-actions",
+        execute_seq=_ma_seq(approvals=[(approval, None)]))
+    assert resp.status_code == 200
+    items = _data(resp)["action_queue"]["items"]
+    ga = next(i for i in items if i["type"] == "gate_approval")
+    assert ga["context"]["gate_type"] is None
+
+
+@pytest.mark.anyio
+async def test_waiting_on_others_item_shape_and_priority():
+    """BE 명세4: 내 담당 story인데 승인 대기가 남에게 있으면 waiting_on_others(§3-1㉢) —
+    priority=info(danger/warn류 행동촉구 축과 안 섞는다, 버튼 없는 자리)."""
+    story_id = uuid.uuid4()
+    approver_id = uuid.uuid4()
+    resp, session, resolver = await _get(
+        "/api/v2/command-center/my-actions",
+        execute_seq=_ma_seq(waiting=[(story_id, "merge", approver_id)]))
+    assert resp.status_code == 200
+    items = _data(resp)["action_queue"]["items"]
+    w = next(i for i in items if i["type"] == "waiting_on_others")
+    assert w["priority"] == "info"
+    assert w["context"] == {
+        "story_id": str(story_id), "gate_type": "merge", "approver_member_id": str(approver_id),
+    }
+
+
+@pytest.mark.anyio
+async def test_waiting_on_others_dedupes_multi_approver_story_to_one_item():
+    """한 story에 승인자가 여럿(quorum)이어도 waiting_on_others는 story당 한 항목만."""
+    story_id = uuid.uuid4()
+    resp, session, resolver = await _get(
+        "/api/v2/command-center/my-actions",
+        execute_seq=_ma_seq(waiting=[
+            (story_id, "merge", uuid.uuid4()),
+            (story_id, "merge", uuid.uuid4()),
+        ]),
+    )
+    assert resp.status_code == 200
+    items = [i for i in _data(resp)["action_queue"]["items"] if i["type"] == "waiting_on_others"]
+    assert len(items) == 1
+
+
+@pytest.mark.anyio
+async def test_waiting_on_others_query_scopes_by_assignee_and_excludes_self_as_approver():
+    """⛔뮤테이션 자가검증 축 대신 쿼리 자체를 직접 읽어 확인(모킹 세션이라 SQL 실행은 못함) —
+    approver_member_id != member_id 조건과 assignee_id == member_id 조건이 둘 다 WHERE에
+    있는지 5번째(0-indexed 3) execute 호출의 컴파일된 SQL 문자열로 검증."""
+    resp, session, resolver = await _get("/api/v2/command-center/my-actions", execute_seq=_ma_seq())
+    assert resp.status_code == 200
+    waiting_call_sql = str(session.execute.await_args_list[3].args[0])
+    assert "assignee_id" in waiting_call_sql
+    assert "approver_member_id" in waiting_call_sql
 
 
 @pytest.mark.anyio
@@ -152,10 +228,11 @@ async def test_my_actions_uses_canonical_member_resolver():
 
 @pytest.mark.anyio
 async def test_my_actions_agent_stuck_filters_to_agent():
-    """HIGH2: agent_stuck 쿼리(4번째 execute)가 resolved_member_type=='agent' 로 필터."""
+    """HIGH2: agent_stuck 쿼리(story #2288 BE 명세4 삽입으로 5번째 execute로 밀림)가
+    resolved_member_type=='agent' 로 필터."""
     resp, session, resolver = await _get("/api/v2/command-center/my-actions", execute_seq=_ma_seq())
     assert resp.status_code == 200
-    assert "resolved_member_type" in str(session.execute.await_args_list[3].args[0])
+    assert "resolved_member_type" in str(session.execute.await_args_list[4].args[0])
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- story #2288(E-CONNECT) 목업v3↔현재화면 대조표(미르코)의 §3-1(빈칸 세 뜻)·기다리는것 구역·비운사이 이동 셋을 동시에 여는 조각(PO 지목: "가장 값진 한 조각")
- 명세3: `gate_approval` 항목의 `context.gate_type` — `WorkflowLineStepRun.effective_gate_type`을 `step_run_id` 조인으로 패스스루(새 값 발명 없음, 기존 `agent_stuck` 자동감지 쿼리가 이미 쓰는 필드와 동일 SSOT)
- 명세4: `waiting_on_others` 신규 쿼리 — 내가 담당(`assignee_id`)인 story인데 워크플로 라인의 pending blocking 승인이 「내가 아닌」 approver에게 있으면 §3-1㉢("발이 내게 없다")로 판정. `priority=info`(행동 없음 — danger/warn류 행동촉구 축과 안 섞음). 승인자가 여럿(quorum)이어도 story당 한 항목만
- 「나의 것」 정의(AC2 명시 요구): 지금은 담당(`assignee_id`) 하나만 — 결재자·멘션·claim은 포함 안 함(대조표가 곧 명세라는 PO 지시대로 추측으로 안 넓힘)

## Test plan
- [x] 기존 mock 스위트(`test_command_center.py`) — 신규 5개(gate_type 패스스루·null 케이스·waiting_on_others 모양·dedupe·쿼리 WHERE절 확인) + 기존 인덱스 의존 어서션 보정(신규 쿼리 삽입으로 execute 호출 시퀀스 shift)
- [x] realdb 5개 신규(`test_2288_command_center_gate_type_waiting_realdb.py`) — mock 세션은 SQLAlchemy join 문법이 실제로 유효한지 증명 못 해 별도 보강. 양성대조 3종: 내가 approver면 waiting 안 뜸 · 담당 아니면 안 뜸 · quorum(승인자 2명)이어도 story당 1항목
- [x] 전부 green(mock 20 + realdb 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)