### PR TITLE
[SID:2288] BE 명세1+2+5 — 태스크 줄·무게·담당 판정 확장

### DIFF
--- a/backend/app/routers/command_center.py
+++ b/backend/app/routers/command_center.py
@@ -168,6 +168,10 @@ async def my_actions(
                 # story #2288 리뷰(2026-07-29, PO 지적): "미완료"는 명세5(review_merge)와
                 # «같은 자»를 써야 한다 — 안 그러면 같은 화면에 "다른 뜻의 미완료"가 둘 선다.
                 # _OPEN_EXCLUDED_STATUSES(파일 상단, 지금은 ("done",) 하나)가 그 SSOT다.
+                # ⛔이 상수는 Story 어휘로 지어졌다 — Task에 얹기 전 CHECK 제약을 직접
+                # 조회해 어휘가 같은지 실측했다(psql \d+ tasks, 2026-07-29): tasks_status_
+                # check = ANY('todo','in-progress','done') — Story와 "done" 하나로 동일하다.
+                # Task 전용 완료값이 따로 있었다면 이 재사용은 결함이었을 것(그런 값 없음).
                 Task.status.not_in(_OPEN_EXCLUDED_STATUSES),
                 Task.deleted_at.is_(None),
                 Story.org_id == org_id,

--- a/backend/app/routers/command_center.py
+++ b/backend/app/routers/command_center.py
@@ -60,6 +60,20 @@ async def my_actions(
     member_id = member.id
     now = _now()
 
+    # ⛔⛔ story #2288 리뷰(2026-07-29, PO 지적 — my_blockers 누락 버그의 근본): 이 함수가
+    # queue.append({"type": ...})로 내보내는 문자열 전수는 **세 곳이 같이 움직여야 하는**
+    # 목록의 원천이다 — ①여기(BE, SSOT) ②apps/web/src/components/dashboard/command-center/
+    # types.ts의 QueueItem.type union ③같은 디렉터리 derive-action-zone.ts의
+    # RENDERABLE_TYPES(Record<QueueItem['type'], true> — TS 컴파일 타임에 ②와는 이미 강제
+    # 동기화됨). 여기 새 "type" 값을 추가하면 ②도 같이 늘려야 한다(안 그러면 splitRenderableQueue
+    # 가 "표시할 수 없음"으로 조용히 떨어뜨린다).
+    #
+    # ⛔실측(2026-07-29): OpenAPI→FE 타입 자동생성 파이프라인이 이 레포에 없다(grep 전수 —
+    # openapi_tags는 Swagger UI 문서 그룹핑 용도뿐). 이 엔드포인트 자체도 Pydantic response_model
+    # 없이 raw dict를 JSONResponse로 반환해(FastAPI 자동 스키마 생성 대상이 아님) 있었다 해도
+    # 이 필드는 안 걸렸을 것 — 그래서 "한 정의로 묶기"는 지금 인프라로는 불가능하다는 것이
+    # 확인된 사실이다(추측 아님). 진짜 재발 방지(BE↔FE type 집합 parity 테스트)는 PO가 별도
+    # 스토리로 세운다 — 이 코멘트는 그 전까지의 "적어 둔 것" 역할(미르코의 types.ts 코멘트와 짝).
     queue: list[dict] = []
     # 게이트 승인 대기 = 내가 approver 인 pending blocking approval(member-private·서버 resolve member_id).
     # story #2288(E-CONNECT) BE 명세3(§3-1㉢·§4-1, 미르코 작성): gate_type 패스스루 —

--- a/backend/app/routers/command_center.py
+++ b/backend/app/routers/command_center.py
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
-from sqlalchemy import func, select
+from sqlalchemy import exists, func, select
 from sqlalchemy.orm import aliased
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -27,7 +27,7 @@ from app.models.agent_run import AgentRun
 from app.models.dependency import ItemDependency
 from app.models.hypothesis import Hypothesis
 from app.models.member import AgentProjectProfile, Member
-from app.models.pm import Goal, Story, StoryActivity
+from app.models.pm import Goal, Story, StoryActivity, Task
 from app.models.workflow_line import WorkflowLineStepApproval, WorkflowLineStepRun
 from app.services.member_resolver import resolve_member
 
@@ -80,24 +80,65 @@ async def my_actions(
             .limit(50)
         )
     ).all()
+    # story #2288(E-CONNECT) BE 명세2(§2③, 무게 — 근사치 OK, 정확 집계는 #2221 별건): 같은
+    # approval_group_id(quorum)에 나 말고 몇 명이 더 pending인지. N+1 금지 — group by 배치.
+    _approval_group_ids = [a.approval_group_id for a, _gt in approvals]
+    approval_group_counts: dict[uuid.UUID, int] = {}
+    if _approval_group_ids:
+        rows = (
+            await session.execute(
+                select(WorkflowLineStepApproval.approval_group_id, func.count(WorkflowLineStepApproval.id))
+                .where(
+                    WorkflowLineStepApproval.org_id == org_id,
+                    WorkflowLineStepApproval.approval_group_id.in_(_approval_group_ids),
+                    WorkflowLineStepApproval.status == "pending",
+                    WorkflowLineStepApproval.blocking.is_(True),
+                )
+                .group_by(WorkflowLineStepApproval.approval_group_id)
+            )
+        ).all()
+        approval_group_counts = {gid: cnt for gid, cnt in rows}
     for a, gate_type in approvals:
+        # 그룹 전체 pending 수 - 나 자신 = "나 말고 몇 명 더" — 음수 방지 max(0, ...).
+        waiting_count = max(0, approval_group_counts.get(a.approval_group_id, 1) - 1)
         queue.append({
             "type": "gate_approval",
             "priority": "warn",
             "context": {"gate_id": str(a.gate_id) if a.gate_id else None,
                         "approval_group_id": str(a.approval_group_id), "kind": a.kind,
-                        "gate_type": gate_type},
+                        "gate_type": gate_type, "waiting_count": waiting_count},
             "created_at": a.created_at.isoformat() if a.created_at else None,
         })
-    # 리뷰/머지 대기 = 내 배정 in-review 스토리(member-private).
+    # story #2288(E-CONNECT) BE 명세5(2026-07-29 확定, PO 기준): review_merge를 status==
+    # 'in-review' 하나에서 "done 아닌 전체"로 넓힌다 — PO 기준 그대로 "내가 지금 손을 대면
+    # 무언가 달라지는가". ⛔단 "선행 대기"(아직 안 풀린 blocks 의존성이 이 story를 막고
+    # 있음)는 제외한다 — 손대도 안 바뀌는 것은 waiting 축이지 review_merge 축이 아니다
+    # (그 축은 이미 my_blockers/waiting_on_others가 다룬다 — 여기서 새로 안 만든다).
+    _ReviewBlocker = aliased(Story)
+    _blocked_by_open_dependency = (
+        select(ItemDependency.id)
+        .select_from(ItemDependency)
+        .join(_ReviewBlocker, _ReviewBlocker.id == ItemDependency.from_id)
+        .where(
+            ItemDependency.org_id == org_id,
+            ItemDependency.to_id == Story.id,
+            ItemDependency.dep_type == "blocks",
+            ItemDependency.item_type == "story",
+            _ReviewBlocker.org_id == org_id,
+            _ReviewBlocker.status.not_in(_OPEN_EXCLUDED_STATUSES),  # 막는 쪽이 아직 open.
+            _ReviewBlocker.deleted_at.is_(None),
+        )
+        .correlate(Story)
+    )
     reviews = (
         await session.execute(
             select(Story)
             .where(
                 Story.org_id == org_id,
                 Story.assignee_id == member_id,
-                Story.status == "in-review",
+                Story.status.not_in(_OPEN_EXCLUDED_STATUSES),
                 Story.deleted_at.is_(None),
+                ~exists(_blocked_by_open_dependency),
             )
             .order_by(Story.updated_at.desc())
             .limit(50)
@@ -110,6 +151,33 @@ async def my_actions(
             "title": s.title,
             "context": {"story_id": str(s.id), "status": s.status},
             "created_at": s.updated_at.isoformat() if s.updated_at else None,
+        })
+    # story #2288(E-CONNECT) BE 명세1(§1-1, 태스크 줄): 담당 스토리 소속 여부와 무관하게
+    # "내가 담당인 미완료 Task"를 그 자체로 항목화한다 — 스토리는 소속 표시만(미르코 명세
+    # 원문 그대로, 스토리를 따로 my_task로 중복 안 냄).
+    my_tasks = (
+        await session.execute(
+            select(Task, Story.title)
+            .join(Story, Story.id == Task.story_id)
+            .where(
+                Task.org_id == org_id,
+                Task.assignee_id == member_id,
+                Task.status != "done",
+                Task.deleted_at.is_(None),
+                Story.org_id == org_id,
+                Story.deleted_at.is_(None),
+            )
+            .order_by(Task.updated_at.desc())
+            .limit(50)
+        )
+    ).all()
+    for t, story_title in my_tasks:
+        queue.append({
+            "type": "my_task",
+            "priority": "info",
+            "title": t.title,
+            "context": {"task_id": str(t.id), "story_id": str(t.story_id), "story_title": story_title},
+            "created_at": t.updated_at.isoformat() if t.updated_at else None,
         })
     # CC-BE.2 내가 풀 블로커(member-private): 내 담당(blocker) 스토리가 막은 open 스토리. caller-bound.
     _Blocker = aliased(Story)
@@ -134,11 +202,35 @@ async def my_actions(
             .limit(50)
         )
     ).all()
+    # story #2288 BE 명세2(§2③, 무게): 같은 blocker_story_id가 총 몇 개의 open story를
+    # 막고 있는지 — N+1 금지, group by 배치(위 my_blockers 쿼리와 동일 WHERE 축 재사용).
+    _blocker_ids = [blocker_id for blocker_id, _blocked_id in my_blockers]
+    blocker_weight_counts: dict[uuid.UUID, int] = {}
+    if _blocker_ids:
+        rows = (
+            await session.execute(
+                select(ItemDependency.from_id, func.count(func.distinct(ItemDependency.to_id)))
+                .select_from(ItemDependency)
+                .join(_Blocked, _Blocked.id == ItemDependency.to_id)
+                .where(
+                    ItemDependency.org_id == org_id,
+                    ItemDependency.dep_type == "blocks",
+                    ItemDependency.item_type == "story",
+                    ItemDependency.from_id.in_(_blocker_ids),
+                    _Blocked.org_id == org_id,
+                    _Blocked.status.not_in(_OPEN_EXCLUDED_STATUSES),
+                    _Blocked.deleted_at.is_(None),
+                )
+                .group_by(ItemDependency.from_id)
+            )
+        ).all()
+        blocker_weight_counts = {bid: cnt for bid, cnt in rows}
     for blocker_id, blocked_id in my_blockers:
         queue.append({
             "type": "my_blockers",
             "priority": "danger",  # 내가 푸는 게 남을 막고 있음 — 최우선.
-            "context": {"blocker_story_id": str(blocker_id), "blocked_story_id": str(blocked_id)},
+            "context": {"blocker_story_id": str(blocker_id), "blocked_story_id": str(blocked_id),
+                        "waiting_count": blocker_weight_counts.get(blocker_id, 1)},
         })
 
     # story #2288(E-CONNECT) BE 명세4(§3-1㉢·§4-1, PO 강조 — 이 스토리의 심장): 「내 것인데

--- a/backend/app/routers/command_center.py
+++ b/backend/app/routers/command_center.py
@@ -100,13 +100,16 @@ async def my_actions(
         approval_group_counts = {gid: cnt for gid, cnt in rows}
     for a, gate_type in approvals:
         # 그룹 전체 pending 수 - 나 자신 = "나 말고 몇 명 더" — 음수 방지 max(0, ...).
-        waiting_count = max(0, approval_group_counts.get(a.approval_group_id, 1) - 1)
+        # story #2288 리뷰(2026-07-29, PO 지적): 필드명 자체에 "approx"를 박는다 — 정확
+        # 집계(#2221 별건)와 헷갈리면 "N건 기다립니다"가 정확한 수로 읽혀 오늘 그 병(수를
+        # 내밀면 사람은 정확한 줄 안다)이 재발한다. 응답 밖(코드 주석만)으론 안 드러난다.
+        waiting_count_approx = max(0, approval_group_counts.get(a.approval_group_id, 1) - 1)
         queue.append({
             "type": "gate_approval",
             "priority": "warn",
             "context": {"gate_id": str(a.gate_id) if a.gate_id else None,
                         "approval_group_id": str(a.approval_group_id), "kind": a.kind,
-                        "gate_type": gate_type, "waiting_count": waiting_count},
+                        "gate_type": gate_type, "waiting_count_approx": waiting_count_approx},
             "created_at": a.created_at.isoformat() if a.created_at else None,
         })
     # story #2288(E-CONNECT) BE 명세5(2026-07-29 확定, PO 기준): review_merge를 status==
@@ -162,7 +165,10 @@ async def my_actions(
             .where(
                 Task.org_id == org_id,
                 Task.assignee_id == member_id,
-                Task.status != "done",
+                # story #2288 리뷰(2026-07-29, PO 지적): "미완료"는 명세5(review_merge)와
+                # «같은 자»를 써야 한다 — 안 그러면 같은 화면에 "다른 뜻의 미완료"가 둘 선다.
+                # _OPEN_EXCLUDED_STATUSES(파일 상단, 지금은 ("done",) 하나)가 그 SSOT다.
+                Task.status.not_in(_OPEN_EXCLUDED_STATUSES),
                 Task.deleted_at.is_(None),
                 Story.org_id == org_id,
                 Story.deleted_at.is_(None),
@@ -229,8 +235,10 @@ async def my_actions(
         queue.append({
             "type": "my_blockers",
             "priority": "danger",  # 내가 푸는 게 남을 막고 있음 — 최우선.
+            # story #2288 리뷰(2026-07-29, PO 지적): gate_approval과 동일 이유로
+            # waiting_count_approx — 정확 집계(#2221)와 구분되게 필드명 자체에 근사치임을 싣는다.
             "context": {"blocker_story_id": str(blocker_id), "blocked_story_id": str(blocked_id),
-                        "waiting_count": blocker_weight_counts.get(blocker_id, 1)},
+                        "waiting_count_approx": blocker_weight_counts.get(blocker_id, 1)},
         })
 
     # story #2288(E-CONNECT) BE 명세4(§3-1㉢·§4-1, PO 강조 — 이 스토리의 심장): 「내 것인데

--- a/backend/tests/test_2288_command_center_gate_type_waiting_realdb.py
+++ b/backend/tests/test_2288_command_center_gate_type_waiting_realdb.py
@@ -369,7 +369,11 @@ async def test_review_merge_now_includes_non_in_review_assigned_stories_realdb()
 
 async def test_review_merge_excludes_story_blocked_by_open_dependency_realdb():
     """BE 명세5 「선행 대기」 제외 — 아직 안 풀린 blocks 의존성이 있으면 review_merge에서 빠진다.
-    양성대조: blocker가 done이면(선행이 풀렸으면) 다시 뜬다."""
+    양성대조: blocker가 done이면(선행이 풀렸으면) 다시 뜬다.
+
+    ⛔뮤테이션 자가검증(2026-07-29, PO 지시 — "없으면 「제외했다」가 주장"): command_center.py의
+    `~exists(_blocked_by_open_dependency)` 조건을 실제로 지우고 이 테스트를 돌려 RED 확認함
+    (blocked_story.id가 review_story_ids에 새는 것을 직접 관측) → 복원 → GREEN 재확認."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -446,7 +450,7 @@ async def test_gate_approval_waiting_count_quorum_realdb():
             assert resp.status_code == 200, resp.text
             items = resp.json()["action_queue"]["items"]
             ga = next(i for i in items if i["type"] == "gate_approval")
-            assert ga["context"]["waiting_count"] == 1  # 나 제외 1명 더.
+            assert ga["context"]["waiting_count_approx"] == 1  # 나 제외 1명 더.
         finally:
             await client.aclose()
     finally:
@@ -481,7 +485,7 @@ async def test_my_blockers_waiting_count_realdb():
             items = resp.json()["action_queue"]["items"]
             my_blockers_items = [i for i in items if i["type"] == "my_blockers"]
             assert len(my_blockers_items) == 2  # 여전히 blocked story당 한 항목(변경 없음).
-            assert all(i["context"]["waiting_count"] == 2 for i in my_blockers_items)  # 무게는 공유.
+            assert all(i["context"]["waiting_count_approx"] == 2 for i in my_blockers_items)  # 무게는 공유.
         finally:
             await client.aclose()
     finally:

--- a/backend/tests/test_2288_command_center_gate_type_waiting_realdb.py
+++ b/backend/tests/test_2288_command_center_gate_type_waiting_realdb.py
@@ -75,12 +75,14 @@ async def _make_step_run(session, org_id, project_id, *, entity_type, entity_id,
     return run
 
 
-async def _make_approval(session, org_id, project_id, *, step_run_id, approver_member_id, status="pending"):
+async def _make_approval(
+    session, org_id, project_id, *, step_run_id, approver_member_id, status="pending", approval_group_id=None,
+):
     from app.models.workflow_line import WorkflowLineStepApproval
 
     approval = WorkflowLineStepApproval(
         id=uuid.uuid4(), org_id=org_id, project_id=project_id,
-        step_run_id=step_run_id, approval_group_id=uuid.uuid4(),
+        step_run_id=step_run_id, approval_group_id=approval_group_id or uuid.uuid4(),
         approver_member_id=approver_member_id, approver_member_type="human",
         kind="approver", blocking=True, status=status,
     )
@@ -265,6 +267,221 @@ async def test_waiting_on_others_dedupes_multi_approver_quorum_realdb():
             items = resp.json()["action_queue"]["items"]
             matches = [i for i in items if i["type"] == "waiting_on_others" and i["context"]["story_id"] == str(story.id)]
             assert len(matches) == 1
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── BE 명세1(태스크 줄)·명세2(무게)·명세5(담당 판정 확장) — 2026-07-29 ────────────
+
+
+async def _make_task(session, org_id, story_id, *, assignee_id=None, title="Task", status="todo"):
+    from app.models.pm import Task
+
+    task = Task(
+        id=uuid.uuid4(), org_id=org_id, story_id=story_id, assignee_id=assignee_id,
+        title=title, status=status,
+    )
+    session.add(task)
+    await session.commit()
+    return task
+
+
+async def _make_dependency(session, org_id, *, from_id, to_id, dep_type="blocks", item_type="story"):
+    from app.models.dependency import ItemDependency
+
+    dep = ItemDependency(
+        id=uuid.uuid4(), org_id=org_id, from_id=from_id, to_id=to_id,
+        dep_type=dep_type, item_type=item_type,
+    )
+    session.add(dep)
+    await session.commit()
+    return dep
+
+
+async def test_my_task_shows_for_incomplete_assigned_task_realdb():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, title="Parent")
+            task = await _make_task(s, org.id, story.id, assignee_id=caller_id, title="구현", status="in-progress")
+            # 양성대조: done task는 안 뜬다.
+            await _make_task(s, org.id, story.id, assignee_id=caller_id, title="이미끝남", status="done")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/command-center/my-actions")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()["action_queue"]["items"]
+            my_tasks = [i for i in items if i["type"] == "my_task"]
+            assert len(my_tasks) == 1
+            assert my_tasks[0]["context"]["task_id"] == str(task.id)
+            assert my_tasks[0]["context"]["story_id"] == str(story.id)
+            assert my_tasks[0]["context"]["story_title"] == "Parent"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_review_merge_now_includes_non_in_review_assigned_stories_realdb():
+    """BE 명세5: status=='in-review' 하나가 아니라 done 아닌 전체로 넓어졌는지 실PG로 확인."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_member(s, org.id, project.id)
+            in_progress_story = await _make_story(s, org.id, project.id, title="InProgress")
+            in_progress_story.assignee_id = caller_id
+            in_progress_story.status = "in-progress"
+            done_story = await _make_story(s, org.id, project.id, title="Done")
+            done_story.assignee_id = caller_id
+            done_story.status = "done"
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/command-center/my-actions")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()["action_queue"]["items"]
+            review_story_ids = {i["context"]["story_id"] for i in items if i["type"] == "review_merge"}
+            assert str(in_progress_story.id) in review_story_ids
+            assert str(done_story.id) not in review_story_ids
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_review_merge_excludes_story_blocked_by_open_dependency_realdb():
+    """BE 명세5 「선행 대기」 제외 — 아직 안 풀린 blocks 의존성이 있으면 review_merge에서 빠진다.
+    양성대조: blocker가 done이면(선행이 풀렸으면) 다시 뜬다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_member(s, org.id, project.id)
+            blocked_story = await _make_story(s, org.id, project.id, title="Blocked")
+            blocked_story.assignee_id = caller_id
+            blocked_story.status = "in-progress"
+            open_blocker = await _make_story(s, org.id, project.id, title="OpenBlocker")
+            open_blocker.status = "in-progress"
+            await s.commit()
+            await _make_dependency(s, org.id, from_id=open_blocker.id, to_id=blocked_story.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/command-center/my-actions")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()["action_queue"]["items"]
+            review_story_ids = {i["context"]["story_id"] for i in items if i["type"] == "review_merge"}
+            assert str(blocked_story.id) not in review_story_ids
+
+            # 양성대조: blocker를 done으로 풀면 다시 뜬다.
+            from sqlalchemy import select as sa_select
+            from app.models.pm import Story as StoryModel
+
+            async with Session() as s2:
+                res = await s2.execute(sa_select(StoryModel).where(StoryModel.id == open_blocker.id))
+                row = res.scalar_one()
+                row.status = "done"
+                await s2.commit()
+
+            resp2 = await client.get("/api/v2/command-center/my-actions")
+            assert resp2.status_code == 200, resp2.text
+            items2 = resp2.json()["action_queue"]["items"]
+            review_story_ids2 = {i["context"]["story_id"] for i in items2 if i["type"] == "review_merge"}
+            assert str(blocked_story.id) in review_story_ids2
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_gate_approval_waiting_count_quorum_realdb():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_member(s, org.id, project.id)
+            other_id, _ = await _make_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, title="QuorumGate")
+            run = await _make_step_run(s, org.id, project.id, entity_type="story", entity_id=story.id)
+            group_id = uuid.uuid4()
+            await _make_approval(
+                s, org.id, project.id, step_run_id=run.id, approver_member_id=caller_id,
+                approval_group_id=group_id,
+            )
+            await _make_approval(
+                s, org.id, project.id, step_run_id=run.id, approver_member_id=other_id,
+                approval_group_id=group_id,
+            )
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/command-center/my-actions")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()["action_queue"]["items"]
+            ga = next(i for i in items if i["type"] == "gate_approval")
+            assert ga["context"]["waiting_count"] == 1  # 나 제외 1명 더.
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_my_blockers_waiting_count_realdb():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_member(s, org.id, project.id)
+            blocker = await _make_story(s, org.id, project.id, title="MultiBlocker")
+            blocker.assignee_id = caller_id
+            blocked_a = await _make_story(s, org.id, project.id, title="A")
+            blocked_a.status = "in-progress"
+            blocked_b = await _make_story(s, org.id, project.id, title="B")
+            blocked_b.status = "in-progress"
+            await s.commit()
+            await _make_dependency(s, org.id, from_id=blocker.id, to_id=blocked_a.id)
+            await _make_dependency(s, org.id, from_id=blocker.id, to_id=blocked_b.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/command-center/my-actions")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()["action_queue"]["items"]
+            my_blockers_items = [i for i in items if i["type"] == "my_blockers"]
+            assert len(my_blockers_items) == 2  # 여전히 blocked story당 한 항목(변경 없음).
+            assert all(i["context"]["waiting_count"] == 2 for i in my_blockers_items)  # 무게는 공유.
         finally:
             await client.aclose()
     finally:

--- a/backend/tests/test_command_center.py
+++ b/backend/tests/test_command_center.py
@@ -307,7 +307,7 @@ async def test_gate_approval_waiting_count_excludes_self():
     assert resp.status_code == 200
     items = _data(resp)["action_queue"]["items"]
     ga = next(i for i in items if i["type"] == "gate_approval")
-    assert ga["context"]["waiting_count"] == 2
+    assert ga["context"]["waiting_count_approx"] == 2
 
 
 @pytest.mark.anyio
@@ -324,7 +324,7 @@ async def test_my_blockers_waiting_count_reflects_total_blocked():
     assert resp.status_code == 200
     items = _data(resp)["action_queue"]["items"]
     mb = next(i for i in items if i["type"] == "my_blockers")
-    assert mb["context"]["waiting_count"] == 3
+    assert mb["context"]["waiting_count_approx"] == 3
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_command_center.py
+++ b/backend/tests/test_command_center.py
@@ -81,13 +81,32 @@ def _data(resp):
     return body.get("data", body) if isinstance(body, dict) else {}
 
 
-# my-actions 쿼리 순서: approvals(.all, gate_type 조인) → reviews → my_blockers(.all) →
-# waiting_on_others(.all, story #2288 BE 명세4 신규) → agent_stuck → stalled(.all) → unanswered(.all).
+# my-actions 쿼리 순서: approvals(.all, gate_type 조인) → [approval_group_counts, approvals
+# 비어있지 않을 때만·명세2 무게] → reviews → my_tasks(명세1, 항상 실행) → my_blockers(.all) →
+# [blocker_weight_counts, my_blockers 비어있지 않을 때만·명세2 무게] → waiting_on_others(.all) →
+# agent_stuck → stalled(.all) → unanswered(.all).
 # ⛔approvals는 story #2288 BE 명세3(gate_type 패스스루)로 WorkflowLineStepRun과 조인해 이제
 # (approval, gate_type) 튜플을 낸다 — 단일 ORM 엔티티가 아니므로 scalars() 대신 .all().
-def _ma_seq(approvals=(), reviews=(), my_blockers=(), waiting=(), stuck=(), stalled=(), unanswered=()):
-    return [_r_all(approvals), _r_scalars(reviews), _r_all(my_blockers), _r_all(waiting),
-            _r_scalars(stuck), _r_all(stalled), _r_all(unanswered)]
+# ⛔명세2(무게) 배치 쿼리 둘은 **조건부**(원본 리스트가 비면 DB 왕복 자체를 스킵) — 그래서
+# 이 헬퍼도 고정 리스트가 아니라 그 조건을 그대로 반영해 순서를 조립한다(안 그러면 approvals/
+# my_blockers를 채운 테스트만 다음 호출들이 전부 밀려 엉뚱한 mock을 받는다).
+def _ma_seq(
+    approvals=(), reviews=(), my_blockers=(), waiting=(), stuck=(), stalled=(), unanswered=(),
+    my_tasks=(), approval_group_counts=(), blocker_weight_counts=(),
+):
+    seq = [_r_all(approvals)]
+    if approvals:
+        seq.append(_r_all(approval_group_counts))
+    seq.append(_r_scalars(reviews))
+    seq.append(_r_all(my_tasks))
+    seq.append(_r_all(my_blockers))
+    if my_blockers:
+        seq.append(_r_all(blocker_weight_counts))
+    seq.append(_r_all(waiting))
+    seq.append(_r_scalars(stuck))
+    seq.append(_r_all(stalled))
+    seq.append(_r_all(unanswered))
+    return seq
 
 
 _DT = datetime(2026, 6, 23, tzinfo=timezone.utc)
@@ -179,10 +198,11 @@ async def test_waiting_on_others_dedupes_multi_approver_story_to_one_item():
 async def test_waiting_on_others_query_scopes_by_assignee_and_excludes_self_as_approver():
     """⛔뮤테이션 자가검증 축 대신 쿼리 자체를 직접 읽어 확인(모킹 세션이라 SQL 실행은 못함) —
     approver_member_id != member_id 조건과 assignee_id == member_id 조건이 둘 다 WHERE에
-    있는지 5번째(0-indexed 3) execute 호출의 컴파일된 SQL 문자열로 검증."""
+    있는지 확인한다. 순서: approvals(0)·reviews(1)·my_tasks(2)·my_blockers(3)·waiting(4)
+    — story #2288 BE 명세1(my_tasks)이 my_blockers 앞에 삽입되며 인덱스가 밀렸다."""
     resp, session, resolver = await _get("/api/v2/command-center/my-actions", execute_seq=_ma_seq())
     assert resp.status_code == 200
-    waiting_call_sql = str(session.execute.await_args_list[3].args[0])
+    waiting_call_sql = str(session.execute.await_args_list[4].args[0])
     assert "assignee_id" in waiting_call_sql
     assert "approver_member_id" in waiting_call_sql
 
@@ -228,11 +248,12 @@ async def test_my_actions_uses_canonical_member_resolver():
 
 @pytest.mark.anyio
 async def test_my_actions_agent_stuck_filters_to_agent():
-    """HIGH2: agent_stuck 쿼리(story #2288 BE 명세4 삽입으로 5번째 execute로 밀림)가
+    """HIGH2: agent_stuck 쿼리(story #2288 BE 명세1 my_tasks 삽입으로 6번째 execute로
+    다시 밀림 — approvals(0)·reviews(1)·my_tasks(2)·my_blockers(3)·waiting(4)·stuck(5))가
     resolved_member_type=='agent' 로 필터."""
     resp, session, resolver = await _get("/api/v2/command-center/my-actions", execute_seq=_ma_seq())
     assert resp.status_code == 200
-    assert "resolved_member_type" in str(session.execute.await_args_list[4].args[0])
+    assert "resolved_member_type" in str(session.execute.await_args_list[5].args[0])
 
 
 @pytest.mark.anyio
@@ -251,6 +272,71 @@ async def test_my_actions_resolver_failure_propagates():
         resolve_raises=HTTPException(status_code=400, detail="member not found"))
     assert resp.status_code == 400
     session.execute.assert_not_awaited()
+
+
+# ── story #2288(E-CONNECT) BE 명세1(태스크 줄)·명세2(무게)·명세5(담당 판정 확장) ──────────
+@pytest.mark.anyio
+async def test_my_task_item_from_incomplete_assigned_task():
+    """BE 명세1(§1-1): 담당 미완료 Task가 my_task 항목으로 뜬다 — 스토리는 소속 표시만
+    (별도 review_merge/story 항목으로 중복 안 남)."""
+    story_id = uuid.uuid4()
+    task = MagicMock(id=uuid.uuid4(), story_id=story_id, title="구현 마무리", updated_at=_DT)
+    resp, session, resolver = await _get(
+        "/api/v2/command-center/my-actions",
+        execute_seq=_ma_seq(my_tasks=[(task, "부모 스토리 제목")]))
+    assert resp.status_code == 200
+    items = _data(resp)["action_queue"]["items"]
+    mt = next(i for i in items if i["type"] == "my_task")
+    assert mt["title"] == "구현 마무리"
+    assert mt["context"] == {
+        "task_id": str(task.id), "story_id": str(story_id), "story_title": "부모 스토리 제목",
+    }
+
+
+@pytest.mark.anyio
+async def test_gate_approval_waiting_count_excludes_self():
+    """BE 명세2(§2③, 무게): 같은 approval_group에 총 3명 pending이면 waiting_count=2(나 제외)."""
+    approval = MagicMock(gate_id=uuid.uuid4(), approval_group_id=uuid.uuid4(), kind="approver", created_at=_DT)
+    resp, session, resolver = await _get(
+        "/api/v2/command-center/my-actions",
+        execute_seq=_ma_seq(
+            approvals=[(approval, "merge")],
+            approval_group_counts=[(approval.approval_group_id, 3)],
+        ),
+    )
+    assert resp.status_code == 200
+    items = _data(resp)["action_queue"]["items"]
+    ga = next(i for i in items if i["type"] == "gate_approval")
+    assert ga["context"]["waiting_count"] == 2
+
+
+@pytest.mark.anyio
+async def test_my_blockers_waiting_count_reflects_total_blocked():
+    """BE 명세2(§2③, 무게): 이 blocker가 총 3개 open story를 막고 있으면 waiting_count=3."""
+    blocker_id, blocked_id = uuid.uuid4(), uuid.uuid4()
+    resp, session, resolver = await _get(
+        "/api/v2/command-center/my-actions",
+        execute_seq=_ma_seq(
+            my_blockers=[(blocker_id, blocked_id)],
+            blocker_weight_counts=[(blocker_id, 3)],
+        ),
+    )
+    assert resp.status_code == 200
+    items = _data(resp)["action_queue"]["items"]
+    mb = next(i for i in items if i["type"] == "my_blockers")
+    assert mb["context"]["waiting_count"] == 3
+
+
+@pytest.mark.anyio
+async def test_review_merge_excludes_blocked_by_open_dependency_query_shape():
+    """BE 명세5: review_merge 쿼리가 status!=done으로 넓어지고, 아직 안 풀린 blocks
+    의존성이 있는 story는 제외하는 EXISTS 서브쿼리를 갖는지 SQL 문자열로 확인
+    (모킹 세션이라 실행 결과는 test_2288 realdb가 증명 — 여긴 쿼리 shape만)."""
+    resp, session, resolver = await _get("/api/v2/command-center/my-actions", execute_seq=_ma_seq())
+    assert resp.status_code == 200
+    reviews_sql = str(session.execute.await_args_list[1].args[0])
+    assert "status" in reviews_sql
+    assert "EXISTS" in reviews_sql.upper()
 
 
 # ── /overview ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- story #2288(E-CONNECT) 목업v3 대조표(2026-07-29 갱신)의 남은 미구현 셋 — 명세3·4는 #2650으로 이미 착지
- 명세1(§1-1 태스크 줄): 담당 미완료 Task를 `type:"my_task"`로 항목화. 스토리는 소속 표시만(`story_title` 병기)
- 명세2(§2③ 무게): `gate_approval`·`my_blockers`에 `context.waiting_count` 추가(근사치, 정확 집계는 #2221 별건). N+1 금지 — group by 배치 쿼리
- 명세5(담당 판정 확장, PO 기준 확定 — "내가 지금 손을 대면 무언가 달라지는가"): `review_merge`를 `status=='in-review'` 하나에서 done 아닌 전체로. 단 "선행 대기"(아직 안 풀린 blocks 의존성)는 EXISTS 서브쿼리로 제외

## Test plan
- [x] mock 4개 신규 + 기존 2개 인덱스 보정(my_task 쿼리 삽입으로 execute 시퀀스 shift) — `test_command_center.py` 전부 green
- [x] realdb 6개 신규(`test_2288_command_center_gate_type_waiting_realdb.py`) — my_task 양성/음성 대조, review_merge 확장+선행대기 제외+blocker done 시 재노출 양성대조, gate quorum waiting_count, multi-blocked waiting_count — mock으로는 증명 못 하는 SQLAlchemy join/EXISTS 문법 유효성을 실PG로 검증
- [x] 전부 green(mock 29 + realdb 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)