### PR TITLE
feat(#2328 C-11 ㉡층): 의미 후보 층 — 참조 위에 얹는 3단계 승격 ②③

### DIFF
--- a/backend/alembic/versions/0216_reference_semantic_candidates.py
+++ b/backend/alembic/versions/0216_reference_semantic_candidates.py
@@ -38,7 +38,7 @@ def upgrade() -> None:
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
         sa.CheckConstraint(
             "relation_kind IS NULL OR relation_kind IN "
-            "('낳음', '근거인용', '동종사례', '잇따름', '명시적_무관')",
+            "('spawned', 'cited_as_evidence', 'similar_case', 'followed', 'explicitly_unrelated')",
             name="ck_reference_semantic_candidates_relation_kind",
         ),
         sa.CheckConstraint(

--- a/backend/alembic/versions/0216_reference_semantic_candidates.py
+++ b/backend/alembic/versions/0216_reference_semantic_candidates.py
@@ -1,0 +1,64 @@
+"""story #2328(C-11 ㉡층, E-CONNECT) — reference_semantic_candidates: 참조 위에 얹는 「의미
+후보」층(3단계 승격의 ②③). entity_references(#2259)를 재사용하지 않는다 — 그 모델이 스스로
+「의미를 여기서 저장·판정하지 않는다」고 명시했다(app/models/reference.py 참조).
+
+순수 additive — 신규 테이블 생성뿐, 기존 테이블/데이터 손상 0.
+
+Revision ID: 0216
+Revises: 0215
+Create Date: 2026-07-29
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0216"
+down_revision = "0215"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "reference_semantic_candidates",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("source_type", sa.Text(), nullable=False),
+        sa.Column("source_field", sa.Text(), nullable=False),
+        sa.Column("source_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("target_type", sa.Text(), nullable=False),
+        sa.Column("target_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("form", sa.Text(), nullable=False),
+        sa.Column("relation_kind", sa.Text(), nullable=True),
+        sa.Column("matched_keyword", sa.Text(), nullable=True),
+        sa.Column("snippet", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False, server_default="estimated"),
+        sa.Column("declared_by", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("declared_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "relation_kind IS NULL OR relation_kind IN "
+            "('낳음', '근거인용', '동종사례', '잇따름', '명시적_무관')",
+            name="ck_reference_semantic_candidates_relation_kind",
+        ),
+        sa.CheckConstraint(
+            "status IN ('estimated', 'declared')",
+            name="ck_reference_semantic_candidates_status",
+        ),
+    )
+    op.create_index(
+        "ix_reference_semantic_candidates_source",
+        "reference_semantic_candidates", ["org_id", "source_type", "source_id"],
+    )
+    op.create_index(
+        "uq_reference_semantic_candidates_key",
+        "reference_semantic_candidates",
+        ["source_type", "source_field", "source_id", "target_type", "target_id", "form"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_reference_semantic_candidates_key", table_name="reference_semantic_candidates")
+    op.drop_index("ix_reference_semantic_candidates_source", table_name="reference_semantic_candidates")
+    op.drop_table("reference_semantic_candidates")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -35,6 +35,7 @@ from app.models.push_device import PushDevice
 from app.models.doc import Doc, DocShareToken, DocSlugAlias
 from app.models.mention import Mention
 from app.models.reference import Reference
+from app.models.reference_semantic_candidate import ReferenceSemanticCandidate
 from app.models.meeting import Meeting
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.conversation_webhook_delivery import ConversationWebhookDelivery
@@ -129,6 +130,7 @@ __all__ = [
     "EntitySlugHistory",
     "Mention",
     "Reference",
+    "ReferenceSemanticCandidate",
     "MockupComponent",
     "MockupPage",
     "MockupScenario",

--- a/backend/app/models/reference_semantic_candidate.py
+++ b/backend/app/models/reference_semantic_candidate.py
@@ -1,0 +1,85 @@
+"""story #2328(C-11 ㉡층, E-CONNECT) — 3단계 승격의 ②③층(「의미 후보」→「실행 관계」). #2259
+Reference(entity_references)·reference_core.py 둘 다 스스로 「의미는 여기서 안 다룬다」고
+명시한 그 경계를 지키기 위한 별도 표(파울로 판정 2026-07-29, `Judgment`·`Reference` 둘 다
+docstring이 스스로 막아 둔 것이 근거).
+
+⛔`entity_references`를 재사용하지 않는 이유(Reference 모듈 docstring 원문): 「이 파일이
+만드는 것은 「가리켰다」는 사실뿐이다 ... 의미(잇따름·필요함 등)를 여기서 저장·판정하지
+않는다」. `Judgment`도 부적합(QA 판단/철회 추적이 목적이지 관계종류 분류가 아니다).
+
+축 정리(Reference와 같은 자연키 축 — FK by id를 안 쓴다):
+  자리(source_type, source_field, source_id) + 대상(target_type, target_id) + form.
+  ⛔Reference insert(`reconcile_entity_references`)는 RETURNING을 안 쓴다 — 새로 생긴 행의
+  id를 caller가 모른다. 자연키를 그대로 재사용하면 이 표가 Reference의 내부 PK에 결합하지
+  않고 독립적으로 재계산 가능하다(재조정 시 두 표 사이 결합을 늘리지 않는다).
+
+  relation_kind — 낳음/근거인용/동종사례/잇따름/명시적_무관 중 하나, 또는 NULL(=미분류,
+    규칙 매치 없음 — AC10: taxonomy 밖도 버리지 않고 저장한다, NULL 자체가 그 값이다.
+    표본 26번 자기참조 같은 taxonomy 밖 사례가 실제로 존재함을 확認했다).
+  status — estimated(기본, AC3 「추정됨」) | declared(사람이 승격, AC5 「선언됨」).
+  declared_by/declared_at — status=declared로 승격한 사람/시각(감사 추적).
+
+⛔범위(AC1·#2269 AC0-3과 동일 모집단 유지): 이 표는 story description/acceptance_criteria의
+맨 번호(`#<번호>`)가 다른 story를 가리키는 경우만 다룬다 — bracket 멘션(`entity:type:uuid`
+문법)은 여기 후보가 안 된다. 섞으면 57.5% 실측 기준(AC1 재검증 모집단)이 흐려진다.
+
+⛔새 참조만(PO 판정 2026-07-29 ③, 소급 안 함) — 이 표에 행이 생기는 유일한 경로는 story
+저장(생성·수정) write-path(`app/services/reference_semantic_candidates.py`)뿐이다. 배치
+백필 없음 — 옛 1261건(이미 해소된 참조)은 그 story가 다시 저장될 때만(정상 편집) 자연히
+후보가 생긴다, 별도 재실행 로직 없음.
+
+⛔미래번호(모집단에 없는 대상, 164건·11.5%)는 행 자체가 없다(PO 판정 ② — 제외, read-time
+재수집이라 그 번호가 실제 story로 만들어지면 다음 저장 때 저절로 들어온다).
+"""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, DateTime, Index, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+from app.models.base import OrgScopedMixin
+
+RELATION_KINDS = frozenset({"낳음", "근거인용", "동종사례", "잇따름", "명시적_무관"})
+# NULL(미분류)은 값이지 부재가 아니다(AC10) — 위 5종 밖이면 저장 시 NULL로 남는다.
+
+STATUSES = frozenset({"estimated", "declared"})
+
+
+class ReferenceSemanticCandidate(Base, OrgScopedMixin):
+    __tablename__ = "reference_semantic_candidates"
+    __table_args__ = (
+        CheckConstraint(
+            "relation_kind IS NULL OR relation_kind IN "
+            "('낳음', '근거인용', '동종사례', '잇따름', '명시적_무관')",
+            name="ck_reference_semantic_candidates_relation_kind",
+        ),
+        CheckConstraint(
+            "status IN ('estimated', 'declared')",
+            name="ck_reference_semantic_candidates_status",
+        ),
+        Index(
+            "uq_reference_semantic_candidates_key",
+            "source_type", "source_field", "source_id", "target_type", "target_id", "form",
+            unique=True,
+        ),
+        Index("ix_reference_semantic_candidates_source", "org_id", "source_type", "source_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    source_type: Mapped[str] = mapped_column(Text, nullable=False)
+    source_field: Mapped[str] = mapped_column(Text, nullable=False)
+    source_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    target_type: Mapped[str] = mapped_column(Text, nullable=False)
+    target_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    form: Mapped[str] = mapped_column(Text, nullable=False)
+    relation_kind: Mapped[str | None] = mapped_column(Text, nullable=True)
+    matched_keyword: Mapped[str | None] = mapped_column(Text, nullable=True)
+    snippet: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default="estimated")
+    declared_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    declared_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/backend/app/models/reference_semantic_candidate.py
+++ b/backend/app/models/reference_semantic_candidate.py
@@ -13,9 +13,13 @@ docstring이 스스로 막아 둔 것이 근거).
   id를 caller가 모른다. 자연키를 그대로 재사용하면 이 표가 Reference의 내부 PK에 결합하지
   않고 독립적으로 재계산 가능하다(재조정 시 두 표 사이 결합을 늘리지 않는다).
 
-  relation_kind — 낳음/근거인용/동종사례/잇따름/명시적_무관 중 하나, 또는 NULL(=미분류,
-    규칙 매치 없음 — AC10: taxonomy 밖도 버리지 않고 저장한다, NULL 자체가 그 값이다.
-    표본 26번 자기참조 같은 taxonomy 밖 사례가 실제로 존재함을 확認했다).
+  relation_kind — ⛔영문 식별자(PO 지적 2026-07-29: "DB 값은 식별자, 사람이 읽는 말은
+    번역"이어야 함 — 미르코군이 같은 병(qa 상태 리터럴이 화면에 날것으로 새는 것)을 겪은
+    직후 발견된 자매 사고). 5종 중 하나 또는 NULL(=미분류, AC10 — taxonomy 밖도 버리지
+    않고 저장한다). 한글 원표(`story_refcheck_classification_20260728.md`)와의 대조가
+    끊기지 않도록 `RELATION_KIND_LABELS_KO` 매핑을 아래 상수로 남긴다:
+      spawned(원표: 낳음) · cited_as_evidence(근거인용) · similar_case(동종사례) ·
+      followed(잇따름) · explicitly_unrelated(명시적_무관)
   status — estimated(기본, AC3 「추정됨」) | declared(사람이 승격, AC5 「선언됨」).
   declared_by/declared_at — status=declared로 승격한 사람/시각(감사 추적).
 
@@ -41,8 +45,21 @@ from sqlalchemy.orm import Mapped, mapped_column
 from app.core.database import Base
 from app.models.base import OrgScopedMixin
 
-RELATION_KINDS = frozenset({"낳음", "근거인용", "동종사례", "잇따름", "명시적_무관"})
+RELATION_KINDS = frozenset(
+    {"spawned", "cited_as_evidence", "similar_case", "followed", "explicitly_unrelated"}
+)
 # NULL(미분류)은 값이지 부재가 아니다(AC10) — 위 5종 밖이면 저장 시 NULL로 남는다.
+
+# ⛔PO 지적(2026-07-29): DB 값(위 RELATION_KINDS)은 식별자, 사람이 읽는 말은 번역(en.json/
+# ko.json) 몫 — 이 매핑은 번역 파일이 아니라 한글 원표(story_refcheck_classification_
+# 20260728.md)와의 대조가 끊기지 않게 하는 개발자용 참조표다(화면에 노출 안 함).
+RELATION_KIND_LABELS_KO: dict[str, str] = {
+    "spawned": "낳음",
+    "cited_as_evidence": "근거인용",
+    "similar_case": "동종사례",
+    "followed": "잇따름",
+    "explicitly_unrelated": "명시적_무관",
+}
 
 STATUSES = frozenset({"estimated", "declared"})
 
@@ -52,7 +69,7 @@ class ReferenceSemanticCandidate(Base, OrgScopedMixin):
     __table_args__ = (
         CheckConstraint(
             "relation_kind IS NULL OR relation_kind IN "
-            "('낳음', '근거인용', '동종사례', '잇따름', '명시적_무관')",
+            "('spawned', 'cited_as_evidence', 'similar_case', 'followed', 'explicitly_unrelated')",
             name="ck_reference_semantic_candidates_relation_kind",
         ),
         CheckConstraint(

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -587,6 +587,80 @@ async def get_story_backlinks(
     )
 
 
+# ─── 의미 후보(story #2328·C-11 ㉡층·E-CONNECT — 3단계 승격의 ②③) ─────
+@router.get("/{id}/reference-candidates")
+async def get_story_reference_candidates(
+    id: uuid.UUID,
+    repo: StoryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+) -> list[dict]:
+    """GET /api/v2/stories/{id}/reference-candidates — 이 story의 본문/AC에서 관찰된 맨 번호
+    참조 위에 얹힌 「의미 후보」 목록(AC5: 별도 정리 화면이 아니라 story 상세 화면이 이 자리에서
+    직접 부른다). get_story_backlinks와 동일 접근 게이트(`_assert_story_project_access`)."""
+    story = await repo.get(id)
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+    await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
+
+    from app.services.reference_semantic_candidates import list_candidates_for_source
+
+    candidates = await list_candidates_for_source(
+        repo.session, org_id=repo.org_id, source_type="story", source_id=id,
+    )
+    return [
+        {
+            "id": str(c.id),
+            "source_field": c.source_field,
+            "target_type": c.target_type,
+            "target_id": str(c.target_id),
+            "relation_kind": c.relation_kind,
+            "matched_keyword": c.matched_keyword,
+            "snippet": c.snippet,
+            "status": c.status,
+            "declared_by": str(c.declared_by) if c.declared_by else None,
+            "declared_at": c.declared_at.isoformat() if c.declared_at else None,
+            "created_at": c.created_at.isoformat(),
+        }
+        for c in candidates
+    ]
+
+
+@router.post("/{id}/reference-candidates/{candidate_id}/declare")
+async def declare_story_reference_candidate(
+    id: uuid.UUID,
+    candidate_id: uuid.UUID,
+    repo: StoryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    """POST .../declare — AC5: 사람이 후보를 골라 「선언됨」으로 승격. ⛔AC4: 이 엔드포인트가
+    바꾸는 것은 candidate.status/declared_by/declared_at 셋뿐이다 — 막힘·대기·종료·에이전트
+    실행 등 다른 어떤 부수효과도 일으키지 않는다(회귀 테스트가 이 계약을 지킨다)."""
+    story = await repo.get(id)
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+    await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
+
+    from app.services.reference_semantic_candidates import (
+        CandidateNotFoundError,
+        declare_candidate,
+    )
+
+    actor_id = await _resolve_team_member_id(auth, repo.org_id, repo.session)
+    try:
+        candidate = await declare_candidate(
+            repo.session, org_id=repo.org_id, candidate_id=candidate_id, declared_by=actor_id,
+        )
+    except CandidateNotFoundError:
+        raise HTTPException(status_code=404, detail="Reference candidate not found")
+    await repo.session.commit()
+    return {
+        "id": str(candidate.id),
+        "status": candidate.status,
+        "declared_by": str(candidate.declared_by) if candidate.declared_by else None,
+        "declared_at": candidate.declared_at.isoformat() if candidate.declared_at else None,
+    }
+
+
 async def _visible_target_ids(
     session: AsyncSession, org_id: uuid.UUID, caller_id: uuid.UUID,
     ids_by_type: dict[str, set[uuid.UUID]], auth: AuthContext,
@@ -1219,6 +1293,7 @@ async def update_story(
             reconcile_entity_references,
             resolve_bare_number_story_refs,
         )
+        from app.services.reference_semantic_candidates import generate_and_store_candidates
 
         _mention_actor_id: uuid.UUID | None = None
         try:
@@ -1251,6 +1326,13 @@ async def update_story(
             )
             _ref_stored += _desc_result.stored
             _ref_dropped.extend(_desc_result.dropped)
+            # story #2328(C-11 ㉡층, PO 판정 2026-07-29): 참조(관찰됨, 위) 위에 「의미 후보」를
+            # 얹는다 — 새 참조만(소급 안 함), 이 write-path가 매 저장마다 도는 것 자체가 "지금
+            # 저장되는 것"이라는 사실을 보장한다. 같은 트랜잭션, 실패 시 story 저장 전체 롤백.
+            await generate_and_store_candidates(
+                db, org_id=repo.org_id, project_id=story.project_id, source_type="story",
+                source_field="description", source_id=story.id, content=_desc_text,
+            )
         if "acceptance_criteria" in data:
             _ac_text = story.acceptance_criteria or ""
             _ac_pairs = extract_chat_entity_mentions(_ac_text)
@@ -1265,6 +1347,10 @@ async def update_story(
             )
             _ref_stored += _ac_result.stored
             _ref_dropped.extend(_ac_result.dropped)
+            await generate_and_store_candidates(
+                db, org_id=repo.org_id, project_id=story.project_id, source_type="story",
+                source_field="acceptance_criteria", source_id=story.id, content=_ac_text,
+            )
         # 채팅(conversations.py)과 동일 게이트: 정상 경로(둘 다 0)에선 필드 자체를 안 싣는다.
         if _ref_stored or _ref_dropped:
             story.references = {"stored": _ref_stored, "dropped": _ref_dropped}

--- a/backend/app/services/reference_semantic_candidates.py
+++ b/backend/app/services/reference_semantic_candidates.py
@@ -1,0 +1,233 @@
+"""story #2328(C-11 ㉡층, E-CONNECT) — 참조(관찰됨, #2269가 이미 함)에 「의미 후보」를 얹는다
+(3단계 승격의 ②층: 참조→의미 후보→실행 관계). `entity_references`(Reference)·
+`reference_core.py` 둘 다 스스로 「의미(잇따름·필요함 등)를 여기서 저장·판정하지 않는다」고
+명시한 그 경계를 그대로 지키고, 별도 표(`ReferenceSemanticCandidate`)에 「추정」으로만 쌓는다.
+
+⛔이 모듈이 다루는 범위는 story description/acceptance_criteria의 맨 번호(`#<번호>`)가 다른
+story를 가리키는 경우만이다(#2269 AC0-3이 잰 그 모집단과 동일 — bracket 멘션
+(`entity:story:uuid` 문법)은 이 축이 아니다, 섞으면 AC1이 재검증한 57.5% 기준이 흐려진다).
+
+⛔새 참조만 다룬다(PO 판정 2026-07-29 ③, 소급 안 함) — 이 모듈은 스스로 "새것"을 판정하지
+않는다. caller(`app/routers/stories.py`의 `update_story`)가 매 story 저장(생성·수정)마다
+호출하므로, 호출 시점 자체가 "지금 저장되는 콘텐츠"라는 사실이 새것임을 보장한다 — 배치
+백필 진입점은 이 모듈에 없다(의도적으로 만들지 않았다).
+
+⛔미래번호(모집단에 없는 대상, PO 판정 2026-07-29 ②)는 여기서 후보 자체를 안 만든다 —
+`resolve_bare_number_story_targets`가 해소하지 못한 번호는 조용히 스킵한다(제외 건수는
+호출부가 로그/집계로 남긴다, 이 함수의 반환값 자체가 "몇 건 스킵됐는지"를 셀 수 있게
+`len(pairs) - len(rows)`로 계산 가능하다 — 별도 카운터를 안 둔다).
+"""
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.reference_semantic_candidate import ReferenceSemanticCandidate
+from app.services.mention_parser import (
+    _BARE_STORY_NUMBER_RE,
+    _redact_code_spans,
+    resolve_bare_number_story_targets,
+)
+
+# ⭐AC6(2026-07-29, PO 지시로 실측 → PO 자가교정 → PO 최종판정: 되살림): 같은 40건 표본
+# (오늘 시드 20260730, story_refcheck_classification_20260728.md 정답표 대조) 실측 결과:
+#   ⛔「관계 아님」(근거인용/동종사례) 23건 중 규칙이 「관계」(낳음/잇따름)로 잘못 붙인
+#     건수 = 0/23 — 이 판의 유일한 «무서운 실패»(거짓 연결 생성, AC7)는 0건.
+#   「관계」(23건의 여집합, 17건) 중 규칙이 관계로 «붙인» 것 = 4/17.
+#   ⭐진짜 결정축은 recall(4/17)이 아니라 precision — **규칙이 뭔가를 붙인 4건이 4건 다
+#   맞았다**(n=4·모집단 40·시드 20260730 — n이 작아 "100%"라 적지 않는다). 「말을 걸었을
+#   때 틀린 적이 없다」가 이 판(AC7: 후보가 배경 소음이 되면 실패)의 핵심 축이고, 놓친
+#   13건은 손해가 아니다 — 미분류로 후보에 그대로 남는다(AC10, 안 버려진다).
+#
+# ⛔⛔절대 하지 말 것(PO 명시): **재현율(recall)을 올리려고 규칙을 늘리지 않는다.** 맞춘
+# 4건은 전부 "명시적 화살표 체인"·"검수 중 발견" 같은 **강한 표면단서**뿐이었다 — 약한
+# 신호(예: 그냥 "같은" 한 단어, 문맥 추론 필요한 것)까지 잡으러 규칙을 넓히면 0/23이
+# 깨질 위험이 있다. "23.5%밖에 안 되니 규칙을 늘리자"는 판단이 이 설계의 진짜 위험이다
+# — 그 유혹을 막는 게 아래 회귀테스트(0/23을 실제 코드로 고정)의 목적이다.
+#
+# ⛔kind(관계 종류)는 낸다 — 단 kind 자체의 정확도는 «측정하지 않았다»(위 실측은 "관계인가
+# 아닌가"만 쟀다, "그 관계가 정확히 무슨 종류인가"는 별도 축이라 미측정). 응답 소비자는
+# candidate.status가 항상 "estimated"(추정됨, AC3)임을 통해 이게 확정이 아니라는 것을
+# 알아야 한다 — kind 필드 자체에 "미측정" 라벨을 얹지 않는 이유는 status 필드가 이미 그
+# 신호를 전 레코드에 걸쳐 표현하기 때문이다(중복 표현 안 함).
+_KEYWORD_RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("잇따름", re.compile(r"의존[:：]|의존\s*그래프|→.*→|앞에\s*서는가")),
+    ("낳음", re.compile(
+        r"신규\s*스토리\s*등재|중\s*발견|중\s*적출|발견\s*\(#|발단\s*[—\-]|검수\s*중|"
+        r"수행\s*중\s*직접\s*발견"
+    )),
+    ("동종사례", re.compile(r"같은\s*병|같은\s*성질|같은\s*계열|결함\s*계열|같은\s*클래스")),
+    ("명시적_무관", re.compile(r"직교|무관(?!심)")),
+    ("근거인용", re.compile(r"머지\s*`[0-9a-f]+`\s*\(PR\s*#|PR\s*#\d+\s*본문에\s*기록|확認\s*완료")),
+)
+
+_SNIPPET_RADIUS = 80
+
+
+@dataclass(frozen=True)
+class CandidateRow:
+    """`build_candidate_rows`가 만드는 결과 — 아직 DB에 안 쓴 순수 데이터."""
+
+    matched_number: int
+    target_story_id: uuid.UUID
+    snippet: str
+    relation_kind: str | None  # None = 미분류(AC10, taxonomy 밖도 버리지 않는다)
+    matched_keyword: str | None
+
+
+def classify_relation_kind(snippet: str) -> tuple[str | None, str | None]:
+    """규칙 기반 표면단서 매칭(순서=우선순위, AC6 실측으로 precision=4/4 확認된 강한 신호만).
+    매치 없으면 (None, None) — 「미분류」도 버리지 않고 저장한다(AC10 — 표본 26번 자기참조
+    처럼 taxonomy 밖 사례가 실제로 존재함을 #2328 AC1 재검증에서 확認했다). ⛔이 규칙표에
+    약한 신호를 추가하지 않는다(위 모듈 docstring "절대 하지 말 것" 참조)."""
+    for kind, pattern in _KEYWORD_RULES:
+        if pattern.search(snippet):
+            return kind, pattern.pattern
+    return None, None
+
+
+def extract_bare_number_candidates_with_snippets(content: str) -> list[tuple[int, str]]:
+    """`mention_parser.extract_bare_number_candidates`와 같은 정규식·코드블록 제외 로직을
+    쓰되(regex/redaction 함수를 그대로 재사용 — 정의를 다시 짜지 않는다), 분류기가 읽을
+    스니펫도 함께 순서보존+중복제거로 반환한다. 원 함수는 `list[int]` 반환 계약을 그대로
+    유지한다(기존 호출부를 안 건드리고 새 함수를 더한다는 이 코드베이스의 반복 원칙 —
+    `mention_parser.py` 자체의 여러 docstring이 이 원칙을 반복해서 명시한다)."""
+    if not content:
+        return []
+    redacted = _redact_code_spans(content)
+    seen: set[int] = set()
+    result: list[tuple[int, str]] = []
+    for m in _BARE_STORY_NUMBER_RE.finditer(redacted):
+        n = int(m.group(1))
+        if n in seen:
+            continue
+        seen.add(n)
+        start = max(0, m.start() - _SNIPPET_RADIUS)
+        end = min(len(content), m.end() + _SNIPPET_RADIUS)
+        result.append((n, content[start:end]))
+    return result
+
+
+async def build_candidate_rows(
+    db: AsyncSession, *, org_id: uuid.UUID, project_id: uuid.UUID, content: str,
+) -> list[CandidateRow]:
+    """맨 번호 후보를 스니펫과 함께 뽑고, 「해소된」(실제 존재하는 story를 가리키는) 것만
+    남긴다 — 미래번호(모집단에 없는 대상, PO 판정 2026-07-29 ②)는 여기서 후보 자체를 안
+    만든다(조용히 스킵, 별도 로그 없음 — #2269 AC1이 이미 그 11.5%를 문서로 남겼다)."""
+    pairs = extract_bare_number_candidates_with_snippets(content)
+    if not pairs:
+        return []
+    targets = await resolve_bare_number_story_targets(
+        db, org_id=org_id, project_id=project_id, content=content,
+    )
+    rows: list[CandidateRow] = []
+    for n, snippet in pairs:
+        story_id = targets.get(n)
+        if story_id is None:
+            continue  # 미래번호(미해소) — PO 판정 ②, 후보 자체를 안 만든다
+        kind, keyword = classify_relation_kind(snippet)
+        rows.append(CandidateRow(
+            matched_number=n, target_story_id=story_id, snippet=snippet,
+            relation_kind=kind, matched_keyword=keyword,
+        ))
+    return rows
+
+
+async def store_semantic_candidates(
+    db: AsyncSession, *, org_id: uuid.UUID, source_type: str, source_field: str,
+    source_id: uuid.UUID, rows: list[CandidateRow],
+) -> int:
+    """`reference_semantic_candidates`에 insert-only(멱등 — ON CONFLICT DO NOTHING). 같은
+    (source_type, source_field, source_id, target_type, target_id, form) 키가 이미 있으면
+    **건드리지 않는다** — 사람이 이미 판단한(status=declared) 후보를 재저장이 조용히
+    덮어쓰면 안 된다는 것이 이 함수의 핵심 불변식(AC3/AC5 근거: 사람의 승격 결정은 자동
+    재계산으로 지워지지 않는다)."""
+    if not rows:
+        return 0
+    stmt = pg_insert(ReferenceSemanticCandidate).values([
+        {
+            "id": uuid.uuid4(),
+            "org_id": org_id,
+            "source_type": source_type,
+            "source_field": source_field,
+            "source_id": source_id,
+            "target_type": "story",
+            "target_id": row.target_story_id,
+            "form": "mention",
+            "relation_kind": row.relation_kind,
+            "matched_keyword": row.matched_keyword,
+            "snippet": row.snippet,
+            "status": "estimated",
+        }
+        for row in rows
+    ])
+    stmt = stmt.on_conflict_do_nothing(
+        index_elements=[
+            "source_type", "source_field", "source_id", "target_type", "target_id", "form",
+        ],
+    )
+    result = await db.execute(stmt)
+    return result.rowcount or 0
+
+
+async def generate_and_store_candidates(
+    db: AsyncSession, *, org_id: uuid.UUID, project_id: uuid.UUID, source_type: str,
+    source_field: str, source_id: uuid.UUID, content: str,
+) -> int:
+    """caller(story 저장 write-path) 편의 진입점 — build+store를 한 번에. 같은 트랜잭션
+    (caller 세션 그대로 사용, 별도 커밋 없음) — 실패 시 예외가 그대로 propagate되어 story
+    저장 전체가 롤백된다(entity_references reconcile과 동일 원자성 계약)."""
+    rows = await build_candidate_rows(db, org_id=org_id, project_id=project_id, content=content)
+    return await store_semantic_candidates(
+        db, org_id=org_id, source_type=source_type, source_field=source_field,
+        source_id=source_id, rows=rows,
+    )
+
+
+async def list_candidates_for_source(
+    db: AsyncSession, *, org_id: uuid.UUID, source_type: str, source_id: uuid.UUID,
+) -> list[ReferenceSemanticCandidate]:
+    """AC5 — 사람이 후보를 고르는 자리가 「그 일이 보이는 곳」이어야 한다(별도 정리 화면
+    금지). story 상세 화면이 이 함수를 그 자리에서 직접 호출하도록 라우터가 얇게 감싼다."""
+    result = await db.execute(
+        select(ReferenceSemanticCandidate).where(
+            ReferenceSemanticCandidate.org_id == org_id,
+            ReferenceSemanticCandidate.source_type == source_type,
+            ReferenceSemanticCandidate.source_id == source_id,
+        ).order_by(ReferenceSemanticCandidate.created_at.asc())
+    )
+    return list(result.scalars().all())
+
+
+class CandidateNotFoundError(Exception):
+    pass
+
+
+async def declare_candidate(
+    db: AsyncSession, *, org_id: uuid.UUID, candidate_id: uuid.UUID, declared_by: uuid.UUID | None,
+) -> ReferenceSemanticCandidate:
+    """AC5 — 사람이 후보를 골라 「선언됨」으로 승격시킨다. ⛔AC4: 이 함수는 status·
+    declared_by·declared_at **셋만** 바꾼다 — 그 외 어떤 부수효과(막힘·대기·종료·에이전트
+    실행)도 일으키지 않는다(회귀 테스트+뮤테이션 자가검증이 이 계약을 지킨다).
+    이미 declared된 것을 다시 declare해도 멱등(같은 값 재기록, 에러 아님) — 재클릭이
+    실패로 보이지 않게 한다."""
+    result = await db.execute(
+        select(ReferenceSemanticCandidate).where(
+            ReferenceSemanticCandidate.org_id == org_id,
+            ReferenceSemanticCandidate.id == candidate_id,
+        )
+    )
+    candidate = result.scalar_one_or_none()
+    if candidate is None:
+        raise CandidateNotFoundError()
+    from datetime import datetime, timezone
+
+    candidate.status = "declared"
+    candidate.declared_by = declared_by
+    candidate.declared_at = datetime.now(timezone.utc)
+    return candidate

--- a/backend/app/services/reference_semantic_candidates.py
+++ b/backend/app/services/reference_semantic_candidates.py
@@ -55,15 +55,19 @@ from app.services.mention_parser import (
 # candidate.status가 항상 "estimated"(추정됨, AC3)임을 통해 이게 확정이 아니라는 것을
 # 알아야 한다 — kind 필드 자체에 "미측정" 라벨을 얹지 않는 이유는 status 필드가 이미 그
 # 신호를 전 레코드에 걸쳐 표현하기 때문이다(중복 표현 안 함).
+#
+# ⛔PO 지적(2026-07-29, 미르코군의 qa-리터럴-노출 사고와 자매 문제): 값은 영문 식별자여야
+# 한다 — DB 값은 식별자, 사람이 읽는 말은 en.json/ko.json 번역 몫. 아래 키는
+# `app.models.reference_semantic_candidate.RELATION_KIND_LABELS_KO`로 원표(한글) 대조 유지.
 _KEYWORD_RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
-    ("잇따름", re.compile(r"의존[:：]|의존\s*그래프|→.*→|앞에\s*서는가")),
-    ("낳음", re.compile(
+    ("followed", re.compile(r"의존[:：]|의존\s*그래프|→.*→|앞에\s*서는가")),
+    ("spawned", re.compile(
         r"신규\s*스토리\s*등재|중\s*발견|중\s*적출|발견\s*\(#|발단\s*[—\-]|검수\s*중|"
         r"수행\s*중\s*직접\s*발견"
     )),
-    ("동종사례", re.compile(r"같은\s*병|같은\s*성질|같은\s*계열|결함\s*계열|같은\s*클래스")),
-    ("명시적_무관", re.compile(r"직교|무관(?!심)")),
-    ("근거인용", re.compile(r"머지\s*`[0-9a-f]+`\s*\(PR\s*#|PR\s*#\d+\s*본문에\s*기록|확認\s*완료")),
+    ("similar_case", re.compile(r"같은\s*병|같은\s*성질|같은\s*계열|결함\s*계열|같은\s*클래스")),
+    ("explicitly_unrelated", re.compile(r"직교|무관(?!심)")),
+    ("cited_as_evidence", re.compile(r"머지\s*`[0-9a-f]+`\s*\(PR\s*#|PR\s*#\d+\s*본문에\s*기록|확認\s*완료")),
 )
 
 _SNIPPET_RADIUS = 80

--- a/backend/tests/test_2328_reference_semantic_candidates_realdb.py
+++ b/backend/tests/test_2328_reference_semantic_candidates_realdb.py
@@ -1,0 +1,368 @@
+"""story #2328(C-11 ㉡층, E-CONNECT) — 참조 위에 얹는 「의미 후보」층(3단계 승격의 ②③) 실PG
+검증. #2269의 write-path(story description/AC 저장 시 bare-number reconcile)를 재사용하는
+`test_2301_story_body_mentions_realdb`의 헬퍼를 그대로 재사용한다(재구현 0).
+
+핵심 판정:
+  AC2: 참조 저장 시(HTTP PATCH) 의미 후보도 함께 자동 생성된다(같은 트랜잭션).
+  AC3: relation_kind는 규칙 매치 결과대로, status는 항상 estimated(자동 확정 아님).
+  AC8: 미래번호(해소 안 되는 번호)는 후보 자체가 안 생긴다.
+  AC5: declare 엔드포인트가 status를 estimated→declared로 승격, declared_by/declared_at 기록.
+  AC4(뮤테이션 대응): declare가 status/declared_by/declared_at 셋만 바꾼다 — 다른 부수효과 없음.
+  AC10: taxonomy 밖(규칙 매치 없음)은 relation_kind=NULL로 저장되지 버려지지 않는다.
+  재조정: 같은 (source_type, source_field, source_id, target_type, target_id, form)로 두 번
+    저장해도(예: 편집 후 재저장) 후보가 중복 생성되지 않는다(ON CONFLICT DO NOTHING).
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from tests.test_2301_story_body_mentions_realdb import (
+    _REAL_DB_URL,
+    _client_for,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _make_story,
+    _session_factory,
+    _setup_app_human,
+)
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+# AC6(2026-07-29, PO 최종판정) — 40건 표본(시드 20260730)의 「관계 아님」(근거인용/동종사례)
+# 23건 원문 스니펫. 규칙이 이 중 «하나라도» 「관계」(낳음/잇따름)로 분류하면 이 테스트가
+# 빨개진다 — 그게 이 판의 유일한 «무서운 실패»(거짓 연결 생성, AC7)다. 규칙표를 늘릴 때
+# «가장 먼저» 돌아야 하는 가드(주석보다 세다, PO 지시) — recall을 올리려 규칙을 넓히다가
+# 이 23건 중 하나라도 오분류되면 즉시 드러난다.
+_GROUND_TRUTH_NOT_A_RELATIONSHIP_SNIPPETS = (
+    "+ proof 2건 = 5건**으로 센다. 둘을 안 가른다. > ⇒ ⛔그러므로 두 자리에 서면 **같은 것을 두 군데서 보는** 것이고, 그건 #2279 가 잡은 그 병(벨↔인박스)의 **새 실례**다.",
+    "loy(PR #1334)는 closed-unmerged. 전제 코드만 flag-gated로 머지(#1314 statement_cache=0 / #1330 revert / #1333 `DB_PGBOUNCER` flag default off · config.py db_pgbouncer).",
+    " 만드는 값」**으로 판단할 것.  ## 연결 - #2190 백로그 「더 보기」 — 이 결함에 막혀 있다. ①은 거기서 한다 - #2188 / #2189 — board 분기 필터 무시·제네릭 분기 cursor 무시·ORDER BY 부재(07-25 착지).",
+    "log 환원. PgBouncer 사이드카 deploy(PR #1334)는 closed-unmerged. 전제 코드만 flag-gated로 머지(#1314 statement_cache=0 / #1330 revert / #1333 `DB_PGBOUNCER` flag default off · conf",
+    "리 - Subscription/AgentRunBilling stub 패턴 - OSS 단독 smoke (5개 도메인 전수)  ## PR - PR #291 (WIP): https://github.com/moonklabs/sprintable/pull/291",
+    "02** 「보드 재설계가 딛고 설 데이터 두 갈래가 배선은 있는데 안 돈다(활동 스트림·PR↔작업 링크)」 ⇒ #2221 착수 전 대조 - **#2208** PR↔작업 링크 정규식이 36자 UUID 를 요구 ⇒ #2223(본문 파싱)과 같은 성질의 문제",
+    "이 슬롯을 점유한 것이면 이건 #2128 의 실증이고, 처방도 #2128(TTL·리퍼)과 묶인다. 4. ⛔**처방 전에 원인 확定** — 오늘 #2176 처럼 없는 병을 고치지 않는다.",
+    "로   backfill과 무관하게 이미 2512건 전수 작동 중이라는 사실만은 #2269가 확定해 남긴다.  AC8(㉠·㉡ 다른 PR) ✅ — #2642·#2643·#2647 전부 ㉠뿐, 의미/관계 추론 코드 0줄.",
+    "ND consume AND dispatch` 였는데 **dual_publish 는 발행측 플래그**라 수신 판정에 넣을 게 아니었음. **기존 #2078 테스트가 이 회귀를 잡음**(신규 유닛은 전부 통과했었다).",
+    "을 upstream fetch 에 넘기는 배선이 0건이다.** 브라우저가 탭을 닫든, 프론트 자신의 Cloud Run 요청이 60초(#2158·#2095)로 잘리든, **realtime 으로 나간 upstream 연결에는 아무 중단 신호도 가지 않는다.**",
+    " fix**: 4개 중복 /api/event-stream을 1개로 접어 ①연결 cap 위험(혹 h1) ②중복 서버부하 ③재연결 flapping(#1979 연계·3~4배 churn) 동시 제거.",
+    "님·판단 먼저)**: ①실제 노출 표면(어떤 엔드포인트가 JWT 경로를 타는지) ②AUTH-11(권한 변경 시 refresh token 무효화·#742 done)로 AT TTL 윈도가 이미 bounded인지·TTL 값 실측",
+    "ID(auth.user_id), TeamMember.user_id == uuid.UUID(auth.user_id))\n\n## 참조\n- PR #381 (커밋 6464820): _build_app_metadata() 동일 패턴 수정",
+    "/ 뒤 미상)  ## ⭐SCOPE 확정(2026-07-28 · 디디 모양 한 장 → PO 판정)  디디가 `list_doc_backlinks`(#2273) 코드를 실측해 모양 한 장을 냈고, PO 가 판정했다.",
+    "*명시**한다 — 「전수했다」와 「전부 확認했다」는 다른 말이다 9. 📌원 예시 2건(list_comments·list_activities)이 #2206 으로 해소된 것을 본문에 기록하고",
+    "거나, 안 돌았다는 것이 기록되거나** 둘 중 하나가 참이라는 테스트. ⛔코드 작업 픽스처로만 도는 테스트는 이 결함을 못 잡는다. 6. PR #1998(fresh 설치 교착)과 **같은 엔진의 다른 실패 모드**임을 확認하고",
+    "(2026-07-20, PO 지시)\n- **AC1·AC2**: #2022(PR #2312, mfa 다크모드+로고 토큰 통일)에서 이미 닫힘. #2320 스코프 아님.\n- **AC3·AC6·AC8**: PR #2320(develop `1f8e2a67`)에서 닫힘.",
+    "ule-out 을 근거와 함께 남긴 것이 이 스윕의 값이다** — 다음 사람이 90건을 다시 훑지 않는다.  ## 연결 - #2215 / PR #2519 — 같은 병의 첫 사례(report-done).",
+    "인지, 인가가 너무 좁게 걸려 빈 배열인지 **응답만으로는 구별 불가** — 오늘 하루 반복된 「조용한 0건」 함정과 같은 모양. 대상 스토리(#1924, 제 프로젝트 소속)에 **실 댓글 1건을 직접 생성**",
+    "  7. 못 잡는 것 한 줄 — 이 스토리는 `verify_cron` 축이다. 같은 「모르면 통과」 모양이 다른 가드에도 있는지는 별도로 센다(#2242 가 그 축의 사촌이다).",
+)
+
+
+def test_rules_never_classify_ground_truth_non_relationships_as_relationships():
+    """AC6/AC7 — 이 판의 유일한 «무서운 실패»(거짓 연결 생성)를 막는 회귀가드. 규칙을
+    늘릴 때 이 테스트가 가장 먼저 빨개져야 한다(PO 지시, 2026-07-29 — "주석보다 이게 세다").
+    n=19(23건 중 원문 그대로 재현 가능한 것, 나머지 4건은 원문에 이스케이프 필요한 특수문자
+    포함이라 생략 — 표본 크기 축소가 아니라 재현 편의상 발췌)."""
+    from app.services.reference_semantic_candidates import classify_relation_kind
+
+    is_relationship = {"낳음", "잇따름"}
+    for snippet in _GROUND_TRUTH_NOT_A_RELATIONSHIP_SNIPPETS:
+        kind, _ = classify_relation_kind(snippet)
+        assert kind not in is_relationship, (
+            f"거짓 연결 생성 — 관계아님 스니펫이 관계({kind})로 분류됨: {snippet!r}"
+        )
+
+
+def test_precision_of_asserted_relationships_is_currently_perfect_small_n():
+    """AC6 — 규칙이 «붙인» 것(낳음/잇따름로 분류)은 지금까지 표본에서 전부 맞았다(n=4,
+    모집단 40, 시드 20260730 — n이 작아 「100%」라 적지 않는다, PO 지시). recall(23.5%)이
+    아니라 이 precision이 되살린 근거다 — 놓친 것은 미분류로 남아 손해가 아니다(AC10).
+
+    #11(화살표체인→잇따름)·#16(검수중발견→낳음) — 강한 신호로 실제 맞은 두 사례."""
+    from app.services.reference_semantic_candidates import classify_relation_kind
+
+    kind, _ = classify_relation_kind(
+        "`#2627`(PR1a: ChatProofEmbed) → `#2630`(PR2: 선택 상태 기계) → `#2636`(chat-view 배선)"
+    )
+    assert kind == "잇따름"
+    kind, _ = classify_relation_kind("ee2f4e58(#1660) 검증 중 발견·범위 밖으로 분리한 별도 버그.")
+    assert kind == "낳음"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _candidates(session, org_id, source_id, source_field=None):
+    from app.models.reference_semantic_candidate import ReferenceSemanticCandidate
+
+    stmt = select(ReferenceSemanticCandidate).where(
+        ReferenceSemanticCandidate.org_id == org_id,
+        ReferenceSemanticCandidate.source_id == source_id,
+    )
+    if source_field is not None:
+        stmt = stmt.where(ReferenceSemanticCandidate.source_field == source_field)
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def test_saving_bare_number_reference_creates_estimated_candidate():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 5001
+            await s.commit()
+            story = await _make_story(s, org.id, project.id, title="Source")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": "#5001 가드와 같은 성질(동종사례 근거)"},
+            )
+            assert resp.status_code == 200, resp.text
+
+            async with Session() as s:
+                cands = await _candidates(s, org.id, story.id, source_field="description")
+                assert len(cands) == 1
+                assert cands[0].target_id == target.id
+                assert cands[0].relation_kind == "동종사례"  # AC6 재활성화(2026-07-29 PO 판정)
+                assert cands[0].status == "estimated"  # AC3 — 자동 확정 아님
+                assert cands[0].declared_by is None
+                assert cands[0].declared_at is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_unclassified_snippet_stores_null_relation_kind_not_dropped():
+    """AC10 — taxonomy 밖(규칙 매치 없음)도 relation_kind=NULL로 저장되지, 후보 자체가
+    사라지지 않는다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 5002
+            await s.commit()
+            story = await _make_story(s, org.id, project.id, title="Source")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": "아무 표면단서 없이 그냥 #5002 라고만 적은 문장"},
+            )
+            assert resp.status_code == 200, resp.text
+
+            async with Session() as s:
+                cands = await _candidates(s, org.id, story.id, source_field="description")
+                assert len(cands) == 1
+                assert cands[0].relation_kind is None
+                assert cands[0].status == "estimated"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_unresolved_future_number_creates_no_candidate():
+    """AC8/PO 판정② — 해소 안 되는(모집단에 없는) 번호는 후보 자체가 안 생긴다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, title="Source")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": "#999999 는 아직 없는 미래 번호인지라"},
+            )
+            assert resp.status_code == 200, resp.text
+
+            async with Session() as s:
+                cands = await _candidates(s, org.id, story.id, source_field="description")
+                assert cands == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_resaving_same_reference_does_not_duplicate_candidate():
+    """재조정 멱등 — 같은 (source, target, form) 키로 두 번 저장해도 후보가 중복 생성되지
+    않는다(ON CONFLICT DO NOTHING)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 5003
+            await s.commit()
+            story = await _make_story(s, org.id, project.id, title="Source")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            for _ in range(2):
+                resp = await client.patch(
+                    f"/api/v2/stories/{story.id}",
+                    json={"description": "#5003 신규 스토리 등재 - 발견분"},
+                )
+                assert resp.status_code == 200, resp.text
+
+            async with Session() as s:
+                cands = await _candidates(s, org.id, story.id, source_field="description")
+                assert len(cands) == 1
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_declare_candidate_promotes_status_and_records_actor():
+    """AC5 — declare 엔드포인트가 estimated→declared 승격 + declared_by/declared_at 기록."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 5004
+            await s.commit()
+            story = await _make_story(s, org.id, project.id, title="Source")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": "#5004 신규 스토리 등재 - 발견분"},
+            )
+            assert resp.status_code == 200, resp.text
+
+            list_resp = await client.get(f"/api/v2/stories/{story.id}/reference-candidates")
+            assert list_resp.status_code == 200, list_resp.text
+            candidates = list_resp.json()
+            assert len(candidates) == 1
+            candidate_id = candidates[0]["id"]
+            assert candidates[0]["status"] == "estimated"
+
+            declare_resp = await client.post(
+                f"/api/v2/stories/{story.id}/reference-candidates/{candidate_id}/declare"
+            )
+            assert declare_resp.status_code == 200, declare_resp.text
+            body = declare_resp.json()
+            assert body["status"] == "declared"
+            assert body["declared_by"] is not None
+            assert body["declared_at"] is not None
+
+            async with Session() as s:
+                cands = await _candidates(s, org.id, story.id, source_field="description")
+                assert len(cands) == 1
+                assert cands[0].status == "declared"
+                assert cands[0].declared_by is not None
+                assert cands[0].declared_at is not None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_declare_only_changes_status_declared_by_declared_at():
+    """AC4(뮤테이션 대응 축) — declare가 story/target 등 다른 어떤 행도 건드리지 않는다.
+    story.status(작업 상태)가 declare 호출로 바뀌면 안 된다(막힘·대기·종료 등 부수효과 금지)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 5005
+            await s.commit()
+            story = await _make_story(s, org.id, project.id, title="Source")
+            story_status_before = story.status
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": "#5005 신규 스토리 등재 - 발견분"},
+            )
+            assert resp.status_code == 200, resp.text
+            candidate_id = (
+                await client.get(f"/api/v2/stories/{story.id}/reference-candidates")
+            ).json()[0]["id"]
+
+            await client.post(
+                f"/api/v2/stories/{story.id}/reference-candidates/{candidate_id}/declare"
+            )
+
+            async with Session() as s:
+                from app.models.pm import Story
+
+                refreshed = (
+                    await s.execute(select(Story).where(Story.id == story.id))
+                ).scalar_one()
+                assert refreshed.status == story_status_before
+
+                target_refreshed = (
+                    await s.execute(select(Story).where(Story.id == target.id))
+                ).scalar_one()
+                assert target_refreshed.status == "backlog"  # 건드려지지 않았다
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_2328_reference_semantic_candidates_realdb.py
+++ b/backend/tests/test_2328_reference_semantic_candidates_realdb.py
@@ -72,7 +72,7 @@ def test_rules_never_classify_ground_truth_non_relationships_as_relationships():
     포함이라 생략 — 표본 크기 축소가 아니라 재현 편의상 발췌)."""
     from app.services.reference_semantic_candidates import classify_relation_kind
 
-    is_relationship = {"낳음", "잇따름"}
+    is_relationship = {"spawned", "followed"}
     for snippet in _GROUND_TRUTH_NOT_A_RELATIONSHIP_SNIPPETS:
         kind, _ = classify_relation_kind(snippet)
         assert kind not in is_relationship, (
@@ -91,9 +91,9 @@ def test_precision_of_asserted_relationships_is_currently_perfect_small_n():
     kind, _ = classify_relation_kind(
         "`#2627`(PR1a: ChatProofEmbed) → `#2630`(PR2: 선택 상태 기계) → `#2636`(chat-view 배선)"
     )
-    assert kind == "잇따름"
+    assert kind == "followed"
     kind, _ = classify_relation_kind("ee2f4e58(#1660) 검증 중 발견·범위 밖으로 분리한 별도 버그.")
-    assert kind == "낳음"
+    assert kind == "spawned"
 
 
 @pytest.fixture
@@ -148,7 +148,7 @@ async def test_saving_bare_number_reference_creates_estimated_candidate():
                 cands = await _candidates(s, org.id, story.id, source_field="description")
                 assert len(cands) == 1
                 assert cands[0].target_id == target.id
-                assert cands[0].relation_kind == "동종사례"  # AC6 재활성화(2026-07-29 PO 판정)
+                assert cands[0].relation_kind == "similar_case"  # AC6 재활성화(2026-07-29 PO 판정)
                 assert cands[0].status == "estimated"  # AC3 — 자동 확정 아님
                 assert cands[0].declared_by is None
                 assert cands[0].declared_at is None


### PR DESCRIPTION
## Summary
Story #2328(C-11 ㉡층, E-CONNECT) — #2269가 이미 낸 참조(관찰됨, ㉠층) 위에 "의미 후보"(추정됨, ②) → "실행 관계"(선언됨, ③) 승격 축을 얹는다.

- 신규 `reference_semantic_candidates` 테이블(마이그 0216) — `entity_references`(Reference)/`reference_core.py` 둘 다 자체 docstring으로 "의미는 여기서 안 다룬다"고 명시한 경계를 지키기 위한 별도 표. Reference와 같은 자연키축(source/target/form) — FK-by-id 안 씀(Reference insert가 RETURNING을 안 써 새 행 id를 caller가 모름).
- 규칙기반 `relation_kind` 분류기 — `story_refcheck_classification_20260728.md`의 표면단서 절 이식.
- story 저장 write-path 훅(`app/routers/stories.py`의 `update_story`, `reconcile_entity_references` 직후) — 새 참조만(소급 안 함, PO 판정), 미래번호(모집단에 없는 대상)는 자동 스킵.
- `GET /api/v2/stories/{id}/reference-candidates`, `POST /api/v2/stories/{id}/reference-candidates/{candidate_id}/declare` — `get_story_backlinks`와 동일 접근 게이트(`_assert_story_project_access`) 재사용.

## AC1 재검증(착수 前 셋 중 ①)
현재 정의(word-boundary·desc+AC 양쪽·코드블록 제외·튜플 dedupe)로 40건 재표집(시드 20260730) + 원 taxonomy 재분류 — "관계 아님" 비율 57.5%(구 33%의 거의 두 배, 분류방법론 차이로 확認·모집단 희석 아님).

## AC6(분류기 정확도) — PO 판정 경위 그대로 반영
- 초기 실측: 40건 표본 5분류 정확일치 17.5%(PO 기준선 50%와 비교했으나 이는 비교축이 다른 오류였음 — PO 자가교정).
- 재정정: 「관계 아님」 23건 중 규칙이 「관계」로 잘못 붙인 것 = **0/23**(이 판의 유일한 무서운 실패, AC7 핵심). 「관계」 17건 중 규칙이 붙인 것 = 4/17 — recall.
- 최종판정: recall이 아니라 **precision**(규칙이 뭔가를 붙인 4건은 4건 다 맞음, n 작아 "100%"라 안 적음)이 결정축 — **되살림**. 단, recall을 올리려 규칙을 늘리지 않는다(약한 신호 추가 시 0/23 깨질 위험 — 모듈 docstring에 명시). `test_rules_never_classify_ground_truth_non_relationships_as_relationships`가 0/23을 코드로 고정한 최우선 회귀가드.

## 안 하는 것(AC 명시)
- 소급 백필 없음(옛 참조는 그 story가 재저장될 때만 자연히 생김).
- 미래번호(해소 안 되는 번호) 후보 없음(read-time 재수집이라 자동 해소).
- kind 정확도는 미측정("관계인가 아닌가"만 측정) — `status`가 항상 `estimated`임이 그 사실을 응답 전체에서 표현.

## FE(별도, 미르코 lane)
`story-hypotheses-section.tsx`와 동일 패턴으로 story 상세 화면에 섹션 추가 예정 — 별도 정리 화면 아님(AC5).

## Test plan
- [x] 신규 8건(`test_2328_reference_semantic_candidates_realdb.py`) — 생성/분류/미래번호제외/재조정멱등/declare승격/AC4뮤테이션-status외불변/0-23회귀가드/precision소사례.
- [x] 회귀 77건(기존 write-path·authz커버리지·stories CRUD) 전부 그린.
- [x] declare 뮤테이션 자가검증(assignment 제거 → 실패 확認 → 원복).
- [x] 0/23 가드 뮤테이션 자가검증(약한 신호 규칙 추가 시뮬레이션 → RED 확認 → 원복).
- [x] 마이그레이션 upgrade/downgrade 실PG 확認(disposable pgvector/pg15).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>