### PR TITLE
[SID:2279] 모바일 탭바 「알림」→「결재」 — 이름=착지=배지 정합

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -49,7 +49,7 @@
   "mobileTabBar": {
     "navLabel": "Mobile tab navigation",
     "now": "Now",
-    "approvals": "Notifications",
+    "approvals": "Approvals",
     "chat": "Chat",
     "more": "More",
     "moreTempNotice": "Temporary list — will be replaced by the full screen soon."

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -49,7 +49,7 @@
   "mobileTabBar": {
     "navLabel": "모바일 탭 내비게이션",
     "now": "지금",
-    "approvals": "알림",
+    "approvals": "결재",
     "chat": "채팅",
     "more": "전체",
     "moreTempNotice": "임시 목록입니다 — 정식 화면으로 곧 교체됩니다."

--- a/apps/web/src/app/(authenticated)/inbox/inbox-labels.test.ts
+++ b/apps/web/src/app/(authenticated)/inbox/inbox-labels.test.ts
@@ -31,26 +31,33 @@ describe('inbox tab labels (#2164)', () => {
       expect((messages.inbox as Record<string, unknown>).title).toBeUndefined();
     });
 
-    // 파울로 정정(2026-07-25): 사이드바/모바일탭/커맨드팔레트 진입점이 전부 bare `/inbox`
+    // 파울로 정정(2026-07-25): 사이드바/커맨드팔레트 진입점이 전부 bare `/inbox`
     // (=알림 탭)로 착지하는데 라벨은 "결재함"이었다 — "가장 많이 눌리는 그 이름"이 여전히
     // 어긋나 있으면 반쪽. 진입점 라벨은 착지하는 탭 이름과 일치해야 한다(area 진입점 원칙).
-    it(`${locale}: /inbox(bare) 진입점 라벨(GNB·모바일탭·커맨드팔레트·인박스내 뒤로가기)이 착지 탭과 일치한다`, () => {
+    it(`${locale}: /inbox(bare) 진입점 라벨(GNB·커맨드팔레트·인박스내 뒤로가기)이 착지 탭과 일치한다`, () => {
       const approvalsWord = locale === 'ko' ? '결재함' : 'Approvals';
       const notificationsLabel = messages.inbox.notificationsTabLabel;
 
       // app-sidebar.tsx: <Link href="/inbox" /> 라벨
       expect(messages.nav.inbox).toBe(notificationsLabel);
-      // mobile-tab-bar.tsx: { href: '/inbox', labelKey: 'approvals' } 라벨
-      expect(messages.mobileTabBar.approvals).toBe(notificationsLabel);
       // command-palette.tsx: { href: '/inbox', labelKey: 'goInbox' } 라벨
       expect(messages.commandPalette.goInbox).toContain(notificationsLabel);
       // inbox/page.tsx 모바일 상세뷰 "목록으로" — 알림 목록으로 돌아가는 것이므로 동일
       expect(messages.inbox.backToList).toBe(notificationsLabel);
 
-      // 이 넷 중 어느 것도 "결재함"/"Approvals"를 자칭하지 않는다(진짜 게이트 탭 전용 이름).
+      // 이 셋 중 어느 것도 "결재함"/"Approvals"를 자칭하지 않는다(진짜 게이트 탭 전용 이름).
       expect(messages.nav.inbox).not.toBe(approvalsWord);
-      expect(messages.mobileTabBar.approvals).not.toBe(approvalsWord);
       expect(messages.inbox.backToList).not.toBe(approvalsWord);
+    });
+
+    // story #2279(PO 판정, 2026-07-29): 모바일 탭바의 이 진입점만은 «다른 그룹»이다 —
+    // href가 `/inbox?tab=gates`로 게이트 탭에 착지하고, 배지도 게이트 대기 수(#api/gates)라
+    // "알림"이 아니라 "결재"가 맞는 이름이다(위 그룹과 같은 원칙 — 착지 탭과 이름을
+    // 맞춘다 — 을 «다른 착지 탭»에 적용한 것뿐, 원칙 자체가 바뀐 게 아니다).
+    it(`${locale}: 모바일 탭바 "결재" 진입점은 게이트 탭에 착지하므로 알림 라벨을 안 쓴다`, () => {
+      const notificationsLabel = messages.inbox.notificationsTabLabel;
+      expect(messages.mobileTabBar.approvals).not.toBe(notificationsLabel);
+      expect(messages.mobileTabBar.approvals).not.toBe('');
     });
 
     // gates/[id]/page.tsx의 "← 결재함" 뒤로가기는 게이트 워크플로 내부 이동이라 반대 원칙:

--- a/apps/web/src/components/nav/mobile-tab-bar.test.ts
+++ b/apps/web/src/components/nav/mobile-tab-bar.test.ts
@@ -3,7 +3,7 @@
 // organization/settings 등, #1958 "전체" 스텁 목록 그대로)이 전부 회색이었다. getActiveTabKey가
 // #1951 매니페스트 SSOT(상세→parentTab)를 그대로 재사용해 정확히 판정하는지 고정.
 import { describe, expect, it } from 'vitest';
-import { getActiveTabKey } from './mobile-tab-bar';
+import { getActiveTabKey, TABS } from './mobile-tab-bar';
 
 describe('getActiveTabKey', () => {
   it('/glance 및 하위 경로는 now', () => {
@@ -39,5 +39,14 @@ describe('getActiveTabKey', () => {
 
   it('/more 자기 자신도 more', () => {
     expect(getActiveTabKey('/more')).toBe('more');
+  });
+});
+
+// story #2279(PO 판정, 2026-07-29): 라벨("결재")·배지(게이트 대기 수)·착지(href)가 한 줄로
+// 서야 한다 — bare `/inbox`(알림 탭 착지)로 되돌아가면 라벨과 다시 어긋난다.
+describe('TABS — story #2279 회귀가드', () => {
+  it('approvals 탭은 게이트 탭(/inbox?tab=gates)에 착지한다 — 알림 탭(bare /inbox)이 아니다', () => {
+    const approvalsTab = TABS.find((t) => t.key === 'approvals');
+    expect(approvalsTab?.href).toBe('/inbox?tab=gates');
   });
 });

--- a/apps/web/src/components/nav/mobile-tab-bar.tsx
+++ b/apps/web/src/components/nav/mobile-tab-bar.tsx
@@ -16,9 +16,14 @@ import { MOBILE_BREAKPOINT } from '@/hooks/use-mobile';
 // route 매핑(오르테가군 확定, 2026-07-17): "지금"·"결재함" 탭은 셸-우선 원칙에 따라 최종 콘텐츠
 // (지금 홈=S8/#1964, 결재함 통합큐=S4/#1960) 없이 기존 라우트를 그대로 가리킨다 — 후속 스토리가
 // 그 자리에서 콘텐츠만 원자적으로 교체한다(빅뱅 전환 금지).
-const TABS = [
+// export: story #2279 회귀가드(href가 조용히 되돌아가지 않게 직접 단위테스트).
+export const TABS = [
   { key: 'now', href: '/glance', icon: CircleDot, labelKey: 'now' as const },
-  { key: 'approvals', href: '/inbox', icon: Inbox, labelKey: 'approvals' as const },
+  // story #2279(PO 판정, 2026-07-29): 라벨("결재")·배지(게이트 대기 수)와 착지가 어긋나
+  // 있던 것 — 이름=가는 곳=세는 것 셋을 한 줄로 맞춘다. #2164가 세운 "진입점 라벨은 착지
+  // 탭과 일치" 규칙은 그대로 두고 착지 쪽을 게이트 탭으로 옮긴다(라벨을 규칙에 맞춘다).
+  // "알림" 탭은 안 없어진다 — /inbox 페이지 내부 탭 스위처로 한 번 더 탭하면 그대로 있다.
+  { key: 'approvals', href: '/inbox?tab=gates', icon: Inbox, labelKey: 'approvals' as const },
   { key: 'chat', href: '/chats', icon: MessageSquare, labelKey: 'chat' as const },
   // "전체"는 시안상 정식 목록화 대상(S9/#1965) — 기존 모바일 GNB Sheet(햄버거) 재사용은
   // blueprint §3.2 "모바일 사이드바 폐기" 방향과 충돌해 하지 않는다(오르테가군 확定). 이 스토리


### PR DESCRIPTION
## 요약
story #2279 — 사이드바「알림 6」/상단 벨「알림 7개」가 다른 수를 말하는 문제의 처방(합치지 않고 이름을 가른다)을 모바일 탭바에 적용. 유나 판정: 이 탭의 배지가 "결재 대기 수"(읽어서가 아니라 결재해야 없어짐)이므로 "알림"이라 부르면 안 된다.

## 착수 전 발견 + 판정(PO)
라벨만 바꾸면 기존 회귀가드(#2164, `inbox-labels.test.ts`)가 깨졌다 — 이 탭의 `href`는 여전히 bare `/inbox`(=「알림」 탭 착지)였기 때문에, 라벨만 "결재"로 바꾸면 "결재라 써놓고 알림 탭으로 보내는" 정반대 방향의 같은 병이 재발. PO 판정: **href를 `/inbox?tab=gates`로 옮겨 이름·착지·배지 셋을 정합시킨다.**

착수 전 확認: "알림" 탭은 안 없어짐 — `/inbox` 페이지 내부 탭 스위처(오늘/알림/게이트)로 한 번 더 탭하면 그대로 접근 가능.

## 변경
- `ko.json`/`en.json`: `mobileTabBar.approvals` "알림"→"결재" / "Notifications"→"Approvals"
- `mobile-tab-bar.tsx`: 이 탭의 `href`를 `/inbox` → `/inbox?tab=gates`로 변경, `TABS` export(회귀가드용)
- `inbox-labels.test.ts`(#2164): 이 진입점을 "알림 착지" 그룹에서 분리 — 원칙(착지 탭=이름)은 유지, 착지 탭이 바뀌었으니 소속 그룹만 변경
- `mobile-tab-bar.test.ts`: `TABS`의 approvals href가 `/inbox?tab=gates`인지 직접 회귀가드

## 검증
- `pnpm vitest run` — 전체 315 files / 2156 tests 통과 (기존 #2164 테스트 포함, 원본 훼손 없이 재구성)
- `pnpm tsc --noEmit` — 통과 · `pnpm lint` — 0 errors · `pnpm build` — EXIT 0
- 뮤테이션 검증: href를 되돌리면(`/inbox` bare) 신규 회귀가드가 정확히 그 증상으로 RED

## Test plan
- [ ] dev 모바일 뷰포트에서: 하단 탭 "결재" 클릭 → 게이트 탭 랜딩 확認, 인박스 내부 탭에서 "알림" 탭도 여전히 접근 가능한지 확認

🤖 Generated with [Claude Code](https://claude.com/claude-code)