### PR TITLE
feat(#2328 C-11 ㉡층): 의존성 고르기 검색결과에 의미 후보 부스트 + 이유 필드

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -194,12 +194,15 @@ async def list_stories(
     stories = await repo.list(limit=limit, q=q, cursor=cursor_dt, **filters)
     await _attach_assignee_ids(repo.session, repo.org_id, stories)
     await _attach_has_evidence(repo.session, stories)
-    # ⛔isinstance 가드(단순 `is not None` 아님) — 이 라우터 함수를 FastAPI 경유 없이 직접
-    # 호출하는 기존 실PG 테스트 다수(test_2188_*·test_2189_*·test_083176e8_* 등)가 이
-    # 새 파라미터를 모른 채 kwargs를 안 넘기면, Python 기본값 평가상 `Query(default=None,
-    # ...)` 센티널 객체 그대로가 들어온다(FastAPI가 실 HTTP 요청에서만 그 센티널을 실제
-    # 값으로 해소해 준다) — 그 객체는 `is not None`을 통과해 버려 DB 쿼리에 UUID 자리로
-    # 새 나가 asyncpg가 깨진다. isinstance로 진짜 UUID만 받아들인다.
+    # ⛔일반 함정(2026-07-29, PO 지적 — "측정 경로 ≠ 실행 경로"): `Query(default=None, ...)`
+    # 기본값은 「값」이 아니라 「센티널 객체」다 — FastAPI가 실 HTTP 요청 경유에서만 그것을
+    # 실제 값(여기선 None)으로 해소한다. 이 라우터 함수를 FastAPI 경유 없이 직접 호출하는
+    # 테스트(이 새 파라미터를 모른 채 kwargs를 안 넘기는 기존 다수 — test_2188_*·
+    # test_2189_*·test_083176e8_* 등)는 그 센티널 객체 그대로를 받는다. 센티널은 `is not
+    # None` 가드를 «참»으로 통과시켜 버린다("None이 아니다"는 맞지만 "UUID다"는 아니다) —
+    # DB 쿼리에 UUID 자리로 새 나가 asyncpg가 깨진다. ⛔이 코드베이스 다른 곳에 `Query(...)`/
+    # `Depends(...)` 기본값을 옵셔널 파라미터로 받는 자리가 또 있으면 같은 함정이다 —
+    # `is not None`이 아니라 `isinstance(..., <실제타입>)`으로 검사할 것.
     if isinstance(boost_candidates_from, uuid.UUID):
         stories = await _boost_reference_candidates(
             repo.session, repo.org_id, stories, boost_candidates_from,

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -194,7 +194,13 @@ async def list_stories(
     stories = await repo.list(limit=limit, q=q, cursor=cursor_dt, **filters)
     await _attach_assignee_ids(repo.session, repo.org_id, stories)
     await _attach_has_evidence(repo.session, stories)
-    if boost_candidates_from is not None:
+    # ⛔isinstance 가드(단순 `is not None` 아님) — 이 라우터 함수를 FastAPI 경유 없이 직접
+    # 호출하는 기존 실PG 테스트 다수(test_2188_*·test_2189_*·test_083176e8_* 등)가 이
+    # 새 파라미터를 모른 채 kwargs를 안 넘기면, Python 기본값 평가상 `Query(default=None,
+    # ...)` 센티널 객체 그대로가 들어온다(FastAPI가 실 HTTP 요청에서만 그 센티널을 실제
+    # 값으로 해소해 준다) — 그 객체는 `is not None`을 통과해 버려 DB 쿼리에 UUID 자리로
+    # 새 나가 asyncpg가 깨진다. isinstance로 진짜 UUID만 받아들인다.
+    if isinstance(boost_candidates_from, uuid.UUID):
         stories = await _boost_reference_candidates(
             repo.session, repo.org_id, stories, boost_candidates_from,
         )

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -92,6 +92,14 @@ async def list_stories(
     ids: str | None = Query(default=None, description="comma-separated story ids — 배치 앵커 조회(정확한 집합, ORDER BY/limit 무관)"),
     story_number: int | None = Query(default=None, description="프로젝트 내 사람-읽는 #N(project_id와 함께 사용 — N은 project 내에서만 유일)"),
     q: str | None = Query(default=None, description="title 부분검색(ILIKE) — 기존 필터와 AND 결합"),
+    boost_candidates_from: uuid.UUID | None = Query(
+        default=None,
+        description=(
+            "story #2328(C-11 ㉡층) — 이 story의 의미 후보(status=estimated) 대상을 결과 "
+            "맨 앞으로 재정렬(필터링 아님, q 비어도 동작). 해당 항목엔 is_reference_candidate="
+            "true·matched_snippet이 실린다(유나 규격, 2026-07-29)."
+        ),
+    ),
     limit: int = Query(default=1000, ge=1, le=2000),
     cursor: str | None = Query(default=None, description="Cursor: ISO 8601 created_at, fetch before this time"),
     response: Response = None,  # type: ignore[assignment]
@@ -186,7 +194,41 @@ async def list_stories(
     stories = await repo.list(limit=limit, q=q, cursor=cursor_dt, **filters)
     await _attach_assignee_ids(repo.session, repo.org_id, stories)
     await _attach_has_evidence(repo.session, stories)
+    if boost_candidates_from is not None:
+        stories = await _boost_reference_candidates(
+            repo.session, repo.org_id, stories, boost_candidates_from,
+        )
     return [StoryResponse.model_validate(s) for s in stories]
+
+
+async def _boost_reference_candidates(
+    session: AsyncSession, org_id: uuid.UUID, stories: list[Story], source_id: uuid.UUID,
+) -> list[Story]:
+    """story #2328(C-11 ㉡층, 유나 규격 2026-07-29) — 의존성 고르기 검색결과 중 source_id
+    story의 의미 후보(status=estimated)를 맨 앞으로 재정렬한다. ⛔거르지 않는다(유나 규격
+    ③) — 전달받은 stories를 그대로 재정렬만 한다. 후보인 항목엔 transient attr(agent_
+    delegate_ids 패턴 동형)로 is_reference_candidate=True·matched_snippet을 세팅해
+    "왜 여기 있는지"를 응답에 싣는다(유나 규격 ①② — 뱃지가 아니라 이유, 지어내지 않는다)."""
+    from app.models.reference_semantic_candidate import ReferenceSemanticCandidate
+
+    result = await session.execute(
+        select(ReferenceSemanticCandidate.target_id, ReferenceSemanticCandidate.snippet).where(
+            ReferenceSemanticCandidate.org_id == org_id,
+            ReferenceSemanticCandidate.source_type == "story",
+            ReferenceSemanticCandidate.source_id == source_id,
+            ReferenceSemanticCandidate.target_type == "story",
+            ReferenceSemanticCandidate.status == "estimated",
+        )
+    )
+    snippet_by_target: dict[uuid.UUID, str] = {row.target_id: row.snippet for row in result.all()}
+    if not snippet_by_target:
+        return stories
+    for story in stories:
+        if story.id in snippet_by_target:
+            story.is_reference_candidate = True
+            story.matched_snippet = snippet_by_target[story.id]
+    # stable sort — 후보가 앞으로, 각 그룹 내 원래 상대순서는 그대로 유지(유나 규격 ③).
+    return sorted(stories, key=lambda s: 0 if s.id in snippet_by_target else 1)
 
 
 async def _attach_agent_delegate_ids(session: AsyncSession, stories: list[Story]) -> None:

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -224,6 +224,13 @@ class StoryResponse(BaseModel):
     # 채팅 GET도 같은 침묵이라 새로고침한 메시지가 어느 참조가 걸렸는지 원리적으로 말 못
     # 하는 것과 동일 갭). 이 필드 하나로 "참조가 걸렸었는지"를 되살릴 수 없다.
     references: dict | None = None
+    # story #2328(C-11 ㉡층, 유나 규격 2026-07-29) — GET /api/stories?boost_candidates_from=
+    # 가 붙었을 때만 채워진다(다른 모든 경로는 기본값 False/None으로 빠진다 — agent_delegate_
+    # ids 패턴 동형, ORM 컬럼 아님, 라우터가 model_validate 前 transient attr로 세팅).
+    # ⛔후보가 아닌 항목엔 반드시 False/None으로 남는다(유나 규격 ①, FE가 섞지 않게).
+    # ⛔matched_snippet은 본문의 그 자리를 그대로 낸다 — 지어내지 않는다(유나 규격 ②).
+    is_reference_candidate: bool = False
+    matched_snippet: str | None = None
     # E-FILE S4: 보드 스토리 첨부 (column 값). list 아니면 [](레거시 None/mock 안전).
     attachments: list[dict] = []
     meeting_id: uuid.UUID | None = None

--- a/backend/tests/test_2328_dependency_picker_candidate_boost_realdb.py
+++ b/backend/tests/test_2328_dependency_picker_candidate_boost_realdb.py
@@ -1,0 +1,265 @@
+"""story #2328(C-11 ㉡층, E-CONNECT) — 의존성 고르기 검색결과에 의미 후보(status=estimated)를
+맨 앞으로 재정렬 + "왜 여기 있는지" 실물 근거(is_reference_candidate·matched_snippet)를 싣는다
+(유나 규격, 2026-07-29). #2301의 실PG 헬퍼를 그대로 재사용한다(재구현 0).
+
+핵심 판정:
+  후보 재정렬: boost_candidates_from 지정 시 후보가 결과 맨 앞에 온다.
+  이유 필드: 후보 항목에만 is_reference_candidate=True + matched_snippet(스니펫)이 실린다.
+  후보 아닌 항목: is_reference_candidate=False·matched_snippet=None(섞이지 않는다, 유나 규격①).
+  거르지 않는다: boost_candidates_from을 줘도 매칭 안 되는 항목이 결과에서 사라지지 않는다.
+  q 비어도 동작: q 없이 boost_candidates_from만 줘도 후보가 앞으로 온다(유나 규격②의 전제).
+  declared 후보는 안 뜬다: status='declared'로 승격된 후보는 이 재정렬 대상이 아니다
+    (estimated만 — declared는 이미 사람이 판단해 실행 관계로 선언된 것이라 "제안"이 아니다).
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tests.test_2301_story_body_mentions_realdb import (
+    _REAL_DB_URL,
+    _client_for,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _make_story,
+    _session_factory,
+    _setup_app_human,
+)
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _insert_candidate(session, *, org_id, source_id, target_id, status="estimated", snippet="스니펫"):
+    from app.models.reference_semantic_candidate import ReferenceSemanticCandidate
+
+    session.add(ReferenceSemanticCandidate(
+        id=uuid.uuid4(), org_id=org_id, source_type="story", source_field="description",
+        source_id=source_id, target_type="story", target_id=target_id, form="mention",
+        relation_kind=None, matched_keyword=None, snippet=snippet, status=status,
+    ))
+    await session.commit()
+
+
+async def test_candidate_boosted_to_front_with_reason_fields():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            source = await _make_story(s, org.id, project.id, title="Source")
+            # 후보가 아닌 항목이 이름순으로 먼저 오게 title을 앞세운다("Aaa" < "Zzz-candidate").
+            non_candidate = await _make_story(s, org.id, project.id, title="Aaa non-candidate")
+            candidate = await _make_story(s, org.id, project.id, title="Zzz-candidate target")
+            await _insert_candidate(
+                s, org_id=org.id, source_id=source.id, target_id=candidate.id,
+                snippet="이건 #123 를 가리키는 스니펫",
+            )
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/stories",
+                params={
+                    "project_id": str(project.id), "q": "candidate",
+                    "boost_candidates_from": str(source.id),
+                },
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            # candidate가 검색어("candidate")에 매치되고, non_candidate는 매치 안 되므로
+            # 정렬 판정 자체보다 "이유 필드가 실렸는가"가 이 테스트의 핵심.
+            matched = [r for r in body if r["id"] == str(candidate.id)]
+            assert len(matched) == 1
+            assert matched[0]["is_reference_candidate"] is True
+            assert matched[0]["matched_snippet"] == "이건 #123 를 가리키는 스니펫"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_non_candidate_has_false_and_none_not_mixed():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            source = await _make_story(s, org.id, project.id, title="Source")
+            plain = await _make_story(s, org.id, project.id, title="Plain story")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/stories",
+                params={"project_id": str(project.id), "boost_candidates_from": str(source.id)},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            row = next(r for r in body if r["id"] == str(plain.id))
+            assert row["is_reference_candidate"] is False
+            assert row["matched_snippet"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_boost_reorders_but_does_not_filter():
+    """유나 규격③ — 매칭 안 되는 항목도 결과에서 사라지지 않는다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            source = await _make_story(s, org.id, project.id, title="Source")
+            candidate = await _make_story(s, org.id, project.id, title="Candidate")
+            unrelated_a = await _make_story(s, org.id, project.id, title="Unrelated A")
+            unrelated_b = await _make_story(s, org.id, project.id, title="Unrelated B")
+            await _insert_candidate(s, org_id=org.id, source_id=source.id, target_id=candidate.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/stories",
+                params={"project_id": str(project.id), "boost_candidates_from": str(source.id)},
+            )
+            assert resp.status_code == 200, resp.text
+            ids = {r["id"] for r in resp.json()}
+            assert str(candidate.id) in ids
+            assert str(unrelated_a.id) in ids
+            assert str(unrelated_b.id) in ids
+            assert str(source.id) in ids  # source 자기 자신도 목록에서 안 사라진다
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_boost_works_with_empty_q():
+    """유나 규격② 전제 — q 없이 boost_candidates_from만 줘도 동작(검색어 치기 前 기본목록)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            source = await _make_story(s, org.id, project.id, title="Source")
+            candidate = await _make_story(s, org.id, project.id, title="Zzz Candidate")
+            await _make_story(s, org.id, project.id, title="Aaa Other")
+            await _insert_candidate(s, org_id=org.id, source_id=source.id, target_id=candidate.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/stories",
+                params={"project_id": str(project.id), "boost_candidates_from": str(source.id)},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            candidate_row = next(r for r in body if r["id"] == str(candidate.id))
+            assert candidate_row["is_reference_candidate"] is True
+            # "Zzz Candidate"는 제목순으로는 뒤인데 후보라 앞으로 왔는지 확인.
+            ids_in_order = [r["id"] for r in body]
+            assert ids_in_order.index(str(candidate.id)) < ids_in_order.index(str(source.id))
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_declared_candidate_not_boosted():
+    """status='declared'(이미 사람이 승격시킨 것)는 "제안"이 아니므로 재정렬 대상이 아니다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            source = await _make_story(s, org.id, project.id, title="Source")
+            declared_target = await _make_story(s, org.id, project.id, title="Declared target")
+            await _insert_candidate(
+                s, org_id=org.id, source_id=source.id, target_id=declared_target.id,
+                status="declared",
+            )
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/stories",
+                params={"project_id": str(project.id), "boost_candidates_from": str(source.id)},
+            )
+            assert resp.status_code == 200, resp.text
+            row = next(r for r in resp.json() if r["id"] == str(declared_target.id))
+            assert row["is_reference_candidate"] is False
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_no_boost_param_leaves_fields_at_default():
+    """기존 호출부(boost_candidates_from 없음)는 두 필드가 항상 False/None으로 빠진다 —
+    회귀 없음(다른 모든 /api/v2/stories 소비처에 영향 없음)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            await _make_story(s, org.id, project.id, title="Plain")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/stories", params={"project_id": str(project.id)})
+            assert resp.status_code == 200, resp.text
+            for row in resp.json():
+                assert row["is_reference_candidate"] is False
+                assert row["matched_snippet"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_cage_referee_p1_exclusion.py
+++ b/backend/tests/test_e_cage_referee_p1_exclusion.py
@@ -101,6 +101,10 @@ async def test_patch_story_is_excluded_true():
     marked_story.agent_delegate_ids = []
     # story #2315 AC1: references(transient, dict|None) — 위와 동일 이유로 명시 세팅.
     marked_story.references = None
+    # story #2328(C-11 ㉡층): 위와 동일 이유(MagicMock 자동 속성이 Pydantic bool/str|None
+    # 검증 실패)로 명시 세팅.
+    marked_story.is_reference_candidate = False
+    marked_story.matched_snippet = None
     marked_story.meeting_id = None
     # E-BOARD S5: update_story가 _attach_assignee_ids로 story_assignees 조회 → 빈 결과 모킹
     # E-SECURITY SEC-S8(G): update_story가 이제 먼저 repo.get(id)(access 체크용) +

--- a/backend/tests/test_e_cage_referee_p1_participation_api.py
+++ b/backend/tests/test_e_cage_referee_p1_participation_api.py
@@ -34,6 +34,9 @@ def _mock_story_obj(assignee_id=None):
     s.agent_delegate_ids = []
     # story #2315 AC1: references(transient, dict|None) — 위와 동일 이유로 명시 세팅.
     s.references = None
+    # story #2328(C-11 ㉡층): 위와 동일 이유로 명시 세팅.
+    s.is_reference_candidate = False
+    s.matched_snippet = None
     s.meeting_id = None
     s.title = "Story 1"
     s.status = "backlog"

--- a/backend/tests/test_e_event_inject_s3_assignment_wake.py
+++ b/backend/tests/test_e_event_inject_s3_assignment_wake.py
@@ -36,6 +36,9 @@ def _story(assignee_id):
     s.agent_delegate_ids = []
     # story #2315 AC1: references(transient, dict|None) — 위와 동일 이유로 명시 세팅.
     s.references = None
+    # story #2328(C-11 ㉡층): 위와 동일 이유로 명시 세팅.
+    s.is_reference_candidate = False
+    s.matched_snippet = None
     s.meeting_id = None
     s.title = "Build login"
     s.description = "OAuth + password"

--- a/backend/tests/test_stories.py
+++ b/backend/tests/test_stories.py
@@ -28,8 +28,11 @@ def _mock_story(status: str = "backlog") -> MagicMock:
     # story #2315 AC1: references(transient, dict|None) — 위와 동일 이유(MagicMock 자동
     # 속성이 Pydantic dict|None 검증 실패)로 명시 세팅.
     s.references = None
-    # story #2328(C-11 ㉡층): is_reference_candidate·matched_snippet(transient) — 위와 동일
-    # 이유(MagicMock 자동 속성이 Pydantic bool/str|None 검증 실패)로 명시 세팅.
+    # ⛔일반 함정(2026-07-29, PO 지적 — 오늘 두 번째로 같은 부류): MagicMock은 "모르는 속성"을
+    # 에러 없이 그럴싸한 MagicMock 값으로 «조용히» 채운다 — StoryResponse에 새 필드를 추가할
+    # 때마다 이 mock fixture(및 같은 패턴을 쓰는 다른 mock 기반 테스트 파일들)에도 그 필드를
+    # 명시로 세팅해야 한다(안 하면 Pydantic 검증에서 "Input should be a valid X"로 실패).
+    # story #2328(C-11 ㉡층): is_reference_candidate·matched_snippet(transient) — 명시 세팅.
     s.is_reference_candidate = False
     s.matched_snippet = None
     s.meeting_id = None

--- a/backend/tests/test_stories.py
+++ b/backend/tests/test_stories.py
@@ -28,6 +28,10 @@ def _mock_story(status: str = "backlog") -> MagicMock:
     # story #2315 AC1: references(transient, dict|None) — 위와 동일 이유(MagicMock 자동
     # 속성이 Pydantic dict|None 검증 실패)로 명시 세팅.
     s.references = None
+    # story #2328(C-11 ㉡층): is_reference_candidate·matched_snippet(transient) — 위와 동일
+    # 이유(MagicMock 자동 속성이 Pydantic bool/str|None 검증 실패)로 명시 세팅.
+    s.is_reference_candidate = False
+    s.matched_snippet = None
     s.meeting_id = None
     s.title = "Story 1"
     s.status = status


### PR DESCRIPTION
## Summary
Story #2328(C-11 ㉡층, E-CONNECT)의 AC5("사람이 후보를 고르는 자리가 「그 일이 보이는 곳」") — 유나 규격 확定(2026-07-29) 반영. 신규 테이블 0, 신규 화면 0 — 이미 있는 의존성 고르기 UI의 검색결과에 얹는 작은 조각.

- `GET /api/stories`에 선택적 `boost_candidates_from: uuid` 추가 — 지정하면 그 story의 의미 후보(`reference_semantic_candidates`, `status=estimated`)를 결과 맨 앞으로 재정렬한다.
- **필터링 아님**(유나 규격③) — 매칭 안 되는 항목도 결과에서 사라지지 않는다.
- **`q`가 비어도 동작**(유나 규격②) — 검색어를 치기 前(피커를 막 열었을 때)에도 후보가 보이는 것이 이 기능의 핵심 가치.
- 후보인 항목에만 `is_reference_candidate=true` + `matched_snippet`(본문의 그 자리)을 싣는다(유나 규격① — 뱃지가 아니라 "왜 여기 있는지" 한 줄 이유, 지어내지 않는다).
- `boost_candidates_from`을 안 쓰는 기존 모든 호출부는 두 필드가 `False`/`None` 기본값으로 남는다(`agent_delegate_ids` 패턴 동형, ORM 컬럼 아님 — 회귀 없음).
- `status=declared`(이미 사람이 승격시킨 것)는 재정렬 대상이 아니다 — "제안"이 아니라 이미 선언된 관계이므로.

## Test plan
- [x] 신규 6건(`test_2328_dependency_picker_candidate_boost_realdb.py`) — 부스트+이유필드/후보아닌항목 false·None/필터안함/q비어도동작/declared제외/boost파라미터없으면기존동작불변.
- [x] 뮤테이션 자가검증 — "필터링 아님" 보장을 실제로 필터하도록 바꿔봄 → RED 확認 → 원복.
- [x] `test_stories.py`(MagicMock 기반) 기존 fixture가 신규 필드로 깨지는 것 발견·수정(기존 컨벤션과 동일 패턴) — 회귀 아님, 새 필드 추가 시 항상 필요한 절차.
- [x] 회귀 94건(stories CRUD·authz coverage·entity_references·바레넘버 write-path 등) 전부 그린.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>