### PR TITLE
[SID:2328] 의존성 고르기 — 검색어 2글자 미만이면 본문 참조 후보를 보인다

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -552,7 +552,9 @@
       "typeBlocks": "Blocks",
       "typeDepends": "Depends",
       "searchPlaceholder": "Search by story title...",
-      "incompletePreds": "{count} incomplete predecessor(s) — check before starting"
+      "incompletePreds": "{count} incomplete predecessor(s) — check before starting",
+      "candidatesHeader": "Found in this story's body",
+      "candidateMentionHint": "Mentioned in this story's body"
     }
   },
   "session": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -552,7 +552,9 @@
       "typeBlocks": "차단",
       "typeDepends": "의존",
       "searchPlaceholder": "스토리 제목으로 검색...",
-      "incompletePreds": "미완료 선행 {count}건 — 시작 전 확인 권장"
+      "incompletePreds": "미완료 선행 {count}건 — 시작 전 확인 권장",
+      "candidatesHeader": "이 스토리 본문에 나온 것",
+      "candidateMentionHint": "이 스토리 본문에 나옵니다"
     }
   },
   "session": {

--- a/apps/web/src/app/api/stories/route.ts
+++ b/apps/web/src/app/api/stories/route.ts
@@ -75,6 +75,9 @@ export async function GET(request: Request) {
       q: searchParams.get('q') ?? undefined,
       unassigned: searchParams.get('unassigned') === 'true' ? true : undefined,
       story_number: storyNumberParam ? Number(storyNumberParam) : undefined,
+      // story #2328(C-11 ㉡층) — 083176e8/story_number와 같은 클래스(있는 필드가 프록시에서
+      // 빠지는 것) 재발 방지로 처음부터 포함.
+      boost_candidates_from: searchParams.get('boost_candidates_from') ?? undefined,
       limit: pageInput.limit + 1,  // RC3: 오버페치 → buildCursorPageMeta hasMore 판단
       cursor: pageInput.cursor,
     });

--- a/apps/web/src/components/kanban/dep-picker-candidates.test.ts
+++ b/apps/web/src/components/kanban/dep-picker-candidates.test.ts
@@ -1,0 +1,69 @@
+// story #2328(C-11 ㉡층, 유나 규격 2026-07-29) — 의존성 고르기 패널의 "후보 vs 검색" 전환
+// 판정. StoryDetailPanel 전체 마운트 없이 순수 함수만 격리 검증(같은 이유로 huge prop
+// surface라 전체 마운트 테스트가 비실용적 — description-viewer.test.tsx와 동일 관례).
+import { describe, expect, it } from 'vitest';
+import { selectDepPickerItems, extractReferenceCandidates } from './story-detail-panel';
+
+interface Item { id: string; title: string }
+
+const candidates: Item[] = [{ id: 'c1', title: '후보 스토리' }];
+const searchResults: Item[] = [{ id: 's1', title: '검색 결과 스토리' }];
+
+describe('selectDepPickerItems', () => {
+  it('①빈 입력이면 후보를 보인다', () => {
+    expect(selectDepPickerItems('', candidates, searchResults)).toEqual({ items: candidates, showingCandidates: true });
+  });
+
+  it('①1글자면 후보를 보인다', () => {
+    expect(selectDepPickerItems('a', candidates, searchResults)).toEqual({ items: candidates, showingCandidates: true });
+  });
+
+  it('①공백만 있어도(trim 후 0글자) 후보를 보인다 — "다 지운 것"과 같은 상태', () => {
+    expect(selectDepPickerItems('   ', candidates, searchResults)).toEqual({ items: candidates, showingCandidates: true });
+  });
+
+  it('②2글자 이상이면 검색 결과로 갈아치운다', () => {
+    expect(selectDepPickerItems('ab', candidates, searchResults)).toEqual({ items: searchResults, showingCandidates: false });
+  });
+
+  it('③후보와 검색 결과를 섞지 않는다 — 2글자 이상일 때 결과 배열엔 후보가 하나도 없다', () => {
+    const { items } = selectDepPickerItems('스토리', candidates, searchResults);
+    expect(items.some((i) => candidates.includes(i))).toBe(false);
+  });
+
+  it('2글자 이상에서 다시 1글자로 지우면(재요청 없이) held 후보가 그대로 복원된다', () => {
+    // depCandidates는 호출부가 들고 있는 held state를 그대로 넘긴다 — 이 함수 자체는 상태를
+    // 안 가지므로, 같은 candidates 참조를 다시 넘기면 그대로 복원되는 것이 곧 "재요청 없음"의
+    // 증거다(별도 fetch 트리거가 이 함수 안에 없다는 것 = 구조적으로 재요청이 없다).
+    const afterTyping = selectDepPickerItems('스토리', candidates, searchResults);
+    expect(afterTyping.showingCandidates).toBe(false);
+    const afterClearing = selectDepPickerItems('스', candidates, searchResults);
+    expect(afterClearing).toEqual({ items: candidates, showingCandidates: true });
+  });
+});
+
+describe('extractReferenceCandidates — story #2328, BE(PR#2659)는 필터가 아니라 재정렬만 한다', () => {
+  it('is_reference_candidate===true인 것만 남긴다(false·undefined는 제외)', () => {
+    const rows = [
+      { id: 'a', title: 'A', is_reference_candidate: true, matched_snippet: '본문 발췌' },
+      { id: 'b', title: 'B', is_reference_candidate: false },
+      { id: 'c', title: 'C' },
+    ];
+    expect(extractReferenceCandidates(rows, 'self')).toEqual([{ id: 'a', title: 'A', matched_snippet: '본문 발췌' }]);
+  });
+
+  it('자기 자신은 후보여도 제외한다', () => {
+    const rows = [{ id: 'self', title: 'Self', is_reference_candidate: true }];
+    expect(extractReferenceCandidates(rows, 'self')).toEqual([]);
+  });
+
+  it('상한 6개 — 기존 검색 결과 cap과 동일', () => {
+    const rows = Array.from({ length: 10 }, (_, i) => ({ id: `c${i}`, title: `C${i}`, is_reference_candidate: true }));
+    expect(extractReferenceCandidates(rows, 'self')).toHaveLength(6);
+  });
+
+  it('matched_snippet이 없으면(null·undefined) 그대로 넘긴다 — 지어내지 않는다', () => {
+    const rows = [{ id: 'a', title: 'A', is_reference_candidate: true, matched_snippet: null }];
+    expect(extractReferenceCandidates(rows, 'self')[0]!.matched_snippet).toBeNull();
+  });
+});

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -546,8 +546,15 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   // 건드린다 — 그 "else"가 "아무것도 안 함"에서 "후보를 보임"으로 바뀌는 것뿐이라, 후보는
   // 별도 소스(boost_candidates_from)로 따로 불러온다. BE는 필터링이 아니라 재정렬만 하므로
   // (PR#2659) is_reference_candidate===true인 것만 FE가 직접 골라낸다.
+  //
+  // 패널을 닫으면 ref를 풀어 "다음에 열 때 다시 부른다" — 닫힘이 자연스러운 무효화 신호라
+  // (PO 지적, 2026-07-30). 호출 횟수는 여전히 "사람이 패널을 여는 횟수"만큼이라 늘지 않는다
+  // (타이핑마다 부르는 게 아님 — 스펙 ①이 금지하는 것은 그것 하나뿐).
+  // ⛔지금 안 하는 것 — 패널이 열린 채로 본문을 저장해 BE가 새 후보를 만들어도(write-path
+  // 훅) 이 패널은 갱신하지 않는다. 다음 판으로 미룬다(오늘 규율 — 갭을 적어 남긴다).
   useEffect(() => {
-    if (!showAddDep || depCandidatesFetchedRef.current) return;
+    if (!showAddDep) { depCandidatesFetchedRef.current = false; return; }
+    if (depCandidatesFetchedRef.current) return;
     depCandidatesFetchedRef.current = true;
     const params = new URLSearchParams({ boost_candidates_from: story.id });
     if (projectId) params.set('project_id', projectId);

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -209,6 +209,36 @@ function isGhostOutgoingReference(
   return !references.some((r) => r.target_type.toLowerCase() === type && r.target_id.toLowerCase() === id);
 }
 
+// export: story #2328(C-11 ㉡층) — 후보/검색 전환 판정을 StoryDetailPanel 전체 마운트 없이
+// 격리 검증하기 위함(같은 이유로 huge prop surface라 전체 마운트 테스트가 비실용적). 유나
+// 규격 ①③: 2글자 미만(빈 입력·1글자·다 지운 것 — 한 상태)이면 후보, 아니면 검색 결과 —
+// 섞지 않는다. 트림 후 판정(공백만 있는 입력도 "미만"으로 취급).
+export function selectDepPickerItems<T>(
+  depQuery: string,
+  candidates: T[],
+  searchResults: T[],
+): { items: T[]; showingCandidates: boolean } {
+  const showingCandidates = depQuery.trim().length < 2;
+  return { items: showingCandidates ? candidates : searchResults, showingCandidates };
+}
+
+interface RawStoryRow {
+  id: string;
+  title: string;
+  is_reference_candidate?: boolean;
+  matched_snippet?: string | null;
+}
+
+// export: story #2328 — BE(PR#2659)는 필터링이 아니라 재정렬만 하므로(boost_candidates_from을
+// 줘도 전체 목록이 돌아온다), is_reference_candidate===true인 것만 FE가 직접 골라낸다.
+// 자기 자신 제외 + 상한 6(기존 검색 결과와 동일 cap, story-detail-panel.tsx:501)은 그대로.
+export function extractReferenceCandidates(rows: RawStoryRow[], selfId: string): { id: string; title: string; matched_snippet?: string | null }[] {
+  return rows
+    .filter((s) => s.id !== selfId && s.is_reference_candidate === true)
+    .slice(0, 6)
+    .map((s) => ({ id: s.id, title: s.title, matched_snippet: s.matched_snippet }));
+}
+
 // export: 회귀 테스트(부모 클릭=편집모드 진입 wrapper 안에서 링크 클릭이 전파를 끊는지)를
 // StoryDetailPanel 전체 마운트 없이 격리 검증하기 위함(story-detail-panel.tsx는 huge prop
 // surface라 전체 마운트 테스트가 비실용적) — 동작 변경 없는 순수 export 추가.
@@ -350,6 +380,13 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   const [showAddDep, setShowAddDep] = useState(false);
   const [depQuery, setDepQuery] = useState('');
   const [depQueryResults, setDepQueryResults] = useState<{ id: string; title: string }[]>([]);
+  // story #2328(C-11 ㉡층, 유나 규격 2026-07-29): 검색어 2글자 미만(빈 입력·1글자·다 지운
+  // 것 — 한 상태)일 때 "아무것도 안 함" 대신 이 스토리 본문에 나온 의미 후보를 보인다.
+  // 패널 열 때(showAddDep true 전이) «한 번»만 불러 상태로 들고 — 이후 쿼리를 지웠다 다시
+  // 비워도 재요청하지 않는다(depCandidatesFetchedRef). 후보와 검색 결과는 절대 안 섞는다 —
+  // 2글자 이상이면 이 배열이 아니라 depQueryResults를 그린다(아래 렌더 분기 참조).
+  const [depCandidates, setDepCandidates] = useState<{ id: string; title: string; matched_snippet?: string | null }[]>([]);
+  const depCandidatesFetchedRef = useRef(false);
   const [depType, setDepType] = useState<'blocks' | 'depends_on'>('blocks');
   const [addingDep, setAddingDep] = useState(false);
 
@@ -504,6 +541,24 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     }, 300);
     return () => clearTimeout(tid);
   }, [depQuery, story.id, projectId]);
+
+  // story #2328(C-11 ㉡층): 기존 검색 게이트(위 useEffect의 `length < 2`)는 한 줄도 안
+  // 건드린다 — 그 "else"가 "아무것도 안 함"에서 "후보를 보임"으로 바뀌는 것뿐이라, 후보는
+  // 별도 소스(boost_candidates_from)로 따로 불러온다. BE는 필터링이 아니라 재정렬만 하므로
+  // (PR#2659) is_reference_candidate===true인 것만 FE가 직접 골라낸다.
+  useEffect(() => {
+    if (!showAddDep || depCandidatesFetchedRef.current) return;
+    depCandidatesFetchedRef.current = true;
+    const params = new URLSearchParams({ boost_candidates_from: story.id });
+    if (projectId) params.set('project_id', projectId);
+    fetch(`/api/stories?${params}`)
+      .then((r) => r.ok ? r.json() : null)
+      .then((json) => {
+        const results = (json?.data ?? []) as RawStoryRow[];
+        setDepCandidates(extractReferenceCandidates(results, story.id));
+      })
+      .catch(() => {});
+  }, [showAddDep, story.id, projectId]);
 
   const handleAddDep = async (targetId: string) => {
     setAddingDep(true);
@@ -1711,22 +1766,39 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                     placeholder={t('dep.searchPlaceholder')}
                     className="w-full rounded border border-border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-primary"
                   />
-                  {depQueryResults.length > 0 && (
-                    <ul className="focus-inset max-h-32 overflow-y-auto rounded border border-border bg-background">
-                      {depQueryResults.map((s) => (
-                        <li key={s.id}>
-                          <button
-                            type="button"
-                            onClick={() => void handleAddDep(s.id)}
-                            disabled={addingDep}
-                            className="w-full px-2 py-1.5 text-left text-xs hover:bg-muted truncate disabled:opacity-50"
-                          >
-                            {s.title}
-                          </button>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
+                  {/* story #2328(C-11 ㉡층): 2글자 미만이면 후보(depCandidates), 2글자
+                      이상이면 검색 결과(depQueryResults) — 절대 안 섞는다(갈아치움). */}
+                  {(() => {
+                    const { items, showingCandidates } = selectDepPickerItems(depQuery, depCandidates, depQueryResults);
+                    if (items.length === 0) return null;
+                    return (
+                      <ul className="focus-inset max-h-32 overflow-y-auto rounded border border-border bg-background">
+                        {showingCandidates && (
+                          <li aria-hidden className="px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                            {t('dep.candidatesHeader')}
+                          </li>
+                        )}
+                        {items.map((s) => (
+                          <li key={s.id}>
+                            <button
+                              type="button"
+                              onClick={() => void handleAddDep(s.id)}
+                              disabled={addingDep}
+                              className="w-full px-2 py-1.5 text-left text-xs hover:bg-muted disabled:opacity-50"
+                            >
+                              <span className="block truncate">{s.title}</span>
+                              {showingCandidates ? (
+                                <span className="block truncate text-[11px] text-muted-foreground">
+                                  {t('dep.candidateMentionHint')}
+                                  {'matched_snippet' in s && s.matched_snippet ? ` · ${s.matched_snippet}` : ''}
+                                </span>
+                              ) : null}
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    );
+                  })()}
                 </div>
               )}
             </div>

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -552,6 +552,10 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   // (타이핑마다 부르는 게 아님 — 스펙 ①이 금지하는 것은 그것 하나뿐).
   // ⛔지금 안 하는 것 — 패널이 열린 채로 본문을 저장해 BE가 새 후보를 만들어도(write-path
   // 훅) 이 패널은 갱신하지 않는다. 다음 판으로 미룬다(오늘 규율 — 갭을 적어 남긴다).
+  // ⚠️테스트 갭 — `depQuery` 길이에 따라 "무엇을 보이는가"는 순수 함수(selectDepPickerItems/
+  // extractReferenceCandidates)로 빼 dep-picker-candidates.test.ts가 잡지만, 이 effect의
+  // showAddDep 전이/ref 리셋 자체는 effect라 단위테스트가 못 잡는다 — 이 자리를 만지면
+  // "닫고 다시 열어 후보가 새로 오는지"를 손으로(라이브) 확認할 것.
   useEffect(() => {
     if (!showAddDep) { depCandidatesFetchedRef.current = false; return; }
     if (depCandidatesFetchedRef.current) return;

--- a/packages/core-storage/src/interfaces/IStoryRepository.ts
+++ b/packages/core-storage/src/interfaces/IStoryRepository.ts
@@ -30,6 +30,10 @@ export interface Story {
   // E-VERIFY V0-S1/S2: 실증-done 신뢰 신호. positive 단방향(false 절대 안 씀) — true면 근거 有,
   // null이면 완전 무표시(신뢰 표면 렌더 조건 그 자체).
   has_evidence?: boolean | null;
+  // story #2328(C-11 ㉡층, PR#2659): boost_candidates_from 필터를 줬을 때만 non-default —
+  // 그 스토리 본문에서 발견된 의미 후보(status="estimated")면 true + 매칭 스니펫.
+  is_reference_candidate?: boolean;
+  matched_snippet?: string | null;
 }
 
 export interface CreateStoryInput {
@@ -97,6 +101,9 @@ export interface StoryListFilters extends PaginationOptions {
    * 무관한 배치 lookup 의미론(정확히 이 id들만, project 필터와 무관하게 cross-project는
    * BE가 조용히 걸러냄). */
   ids?: string[];
+  /** story #2328(C-11 ㉡층) — 이 story_id의 의미 후보를 결과 맨 앞으로 재정렬(필터 아님,
+   * q 비어도 동작). 해당 항목엔 is_reference_candidate=true·matched_snippet이 실린다. */
+  boost_candidates_from?: string;
 }
 
 export interface IStoryRepository {

--- a/packages/storage-api/src/ApiStoryRepository.ts
+++ b/packages/storage-api/src/ApiStoryRepository.ts
@@ -24,6 +24,8 @@ export class ApiStoryRepository implements IStoryRepository {
         // story #2283(참조 후보 해소) — BE(stories.py:93)는 이미 story_number 필터를 받는데
         // 이 query 객체엔 없었다(q 소실 083176e8과 같은 클래스 — 있는 필드가 여기서만 빠짐).
         story_number: filters.story_number,
+        // story #2328(C-11 ㉡층, PR#2659) — 같은 클래스 재발 방지로 처음부터 여기 포함.
+        boost_candidates_from: filters.boost_candidates_from,
       },
     });
   }


### PR DESCRIPTION
## 요약
story #2328(C-11 ㉡층) — 유나 규격(2026-07-29) 세 줄 그대로 구현. BE는 PR#2659(`boost_candidates_from`+`is_reference_candidate`+`matched_snippet`)로 이미 착지.

## 변경
- **①** 검색어 2글자 미만(빈 입력·1글자·다 지운 것 — 한 상태)이면 이 스토리 본문에서 발견된 참조 후보를 보인다. 패널이 열릴 때(`showAddDep` 최초 true 전이) 한 번만 `boost_candidates_from=<story.id>`로 불러 상태로 들고, 이후 재요청하지 않는다(`depCandidatesFetchedRef`). 기존 검색 게이트(`length < 2`)는 한 줄도 안 건드림 — "아무것도 안 함"이던 else 분기가 "후보를 보임"으로 바뀌는 것뿐.
- **②** 후보 줄에 "이 스토리 본문에 나옵니다" + `matched_snippet`(회색, `text-[11px] text-muted-foreground`) — 뱃지·수·신뢰도 없음.
- **③** 후보와 검색 결과를 절대 안 섞는다 — 2글자 이상이면 검색 결과로 완전히 갈아치우고, 후보 목록 위에 "── 이 스토리 본문에 나온 것 ──" 헤더. 다시 지우면 held 후보가 재요청 없이 복원.
- BE가 `boost_candidates_from`을 필터가 아니라 재정렬로만 처리하므로(PR#2659), FE가 `is_reference_candidate===true`인 것만 직접 골라낸다(`extractReferenceCandidates`, 자기 자신 제외 + 기존 검색과 동일 cap 6).
- FE 플러밍 3곳(`route.ts`→`StoryListFilters`→`ApiStoryRepository` query) — `boost_candidates_from`이 이전 `q`/`story_number` 소실 사고(083176e8)와 같은 클래스로 조용히 빠지지 않게 전 구간 명시 배선.
- 두 순수 함수(`selectDepPickerItems`/`extractReferenceCandidates`)를 export — `story-detail-panel.tsx`는 huge prop surface라 전체 마운트 테스트가 비실용적(`DescriptionViewer` export와 동일 관례), 이 판정 로직만 격리 테스트.

## 검증
- `pnpm vitest run` — 전체 316 files / 2166 tests 통과
- `pnpm tsc --noEmit`(apps/web + packages/core-storage + packages/storage-api 셋 다) — 통과
- `pnpm lint` — 0 errors · `pnpm build` — EXIT 0
- 뮤테이션 검증: 두 함수 모두 no-op으로 되돌려 신규 10테스트 중 7건이 정확히 그 증상으로 RED → 복원 GREEN

## Test plan
- [ ] dev 배포 후 사람 경로: 스토리 상세에서 의존성 추가 패널을 열고 — 빈 입력 상태에서 후보 헤더+매칭 스니펫이 뜨는지, 2글자 이상 입력 시 검색 결과로 완전히 바뀌는지, 다시 지웠을 때 후보가 즉시(재요청 없이) 복원되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)