### PR TITLE
feat(#2262 C-4 AC1): fetch_stored_references가 referenced_at을 나른다

### DIFF
--- a/backend/app/services/mention_parser.py
+++ b/backend/app/services/mention_parser.py
@@ -740,13 +740,19 @@ async def fetch_stored_references(
     `insert_reference`는 form 매개변수·FORMS 검증·proof_payload 필드까지 이미 갖췄는데(쓰기는
     갈리는데) 이 읽기 함수가 그 둘을 안 실어 와 화면이 mention/embed/proof를 못 갈랐다("저장·
     쓰기·읽기·표시" 중 읽기에서 끊기는 이 에픽의 반복 패턴). C-7(#2265)이 이 값으로 세 형태를
-    가르는 첫 소비자가 된다."""
+    가르는 첫 소비자가 된다.
+
+    ⛔story #2262 AC1(「지점」, PO 판정 2026-07-30): `Reference.created_at`을 `referenced_at`
+    으로 이름 붙여 추가한다 — **이 참조가 «언제 생겼나»**(본문에 그 토큰이 저장된 시각)이지
+    **가리키는 대상이 «언제 만들어졌나»가 아니다**. `created_at` 그대로 내면 "무엇의
+    created_at인가"가 안 갈려 오늘 반복된 그 병(한 이름이 두 뜻)이 또 난다. FE가 이 값을
+    실제로 보일지는 아직 안 정해졌다 — 이 함수는 나르기만 한다(판단은 카드 디자인 몫)."""
     if not source_ids:
         return {}
     rows = (await db.execute(
         select(
             Reference.source_id, Reference.target_type, Reference.target_id,
-            Reference.form, Reference.proof_payload,
+            Reference.form, Reference.proof_payload, Reference.created_at,
         ).where(
             Reference.org_id == org_id,
             Reference.source_type == source_type,
@@ -754,9 +760,10 @@ async def fetch_stored_references(
         )
     )).all()
     result: dict[uuid.UUID, list[dict[str, Any]]] = {}
-    for source_id, target_type, target_id, form, proof_payload in rows:
+    for source_id, target_type, target_id, form, proof_payload, created_at in rows:
         result.setdefault(source_id, []).append({
             "target_type": target_type, "target_id": str(target_id),
             "form": form, "proof_payload": proof_payload,
+            "referenced_at": created_at.isoformat(),
         })
     return result

--- a/backend/tests/test_2263_chat_message_read_references_realdb.py
+++ b/backend/tests/test_2263_chat_message_read_references_realdb.py
@@ -42,7 +42,14 @@ def _strip_referenced_at(refs: list[dict]) -> list[dict]:
     """story #2262 AC1(「지점」, 2026-07-30): fetch_stored_references가 이제
     `referenced_at`(비결정적 타임스탬프)도 낸다 — 아래 exact-equality 검증에서는
     그 필드가 «있다는 것»만 확認하고 값 자체는 떼어낸다(테스트가 시각을 하드코딩하지
-    않는다)."""
+    않는다).
+
+    ⛔가드 한계 선언(PO 지적, 2026-07-30 — "가드는 못 잡는 것도 선언한다"): 이 방식은
+    exact-equality의 원래 역할("의도치 않은 필드가 몰래 추가되면 빨개진다")을 이 dict에
+    한해 «약화»시킨다 — `referenced_at` 외의 새 키가 몰래 추가돼도 여기선 안 잡힌다
+    (떼어낸 뒤 비교라 남은 키 집합만 본다). 더 나은 대안(타임스탬프를 고정값으로 치환한
+    뒤 dict 전체를 그대로 대조 — 그러면 새 키 추가도 계속 잡힌다)이 있으나 지금은 고치지
+    않는다(PO 지시) — 이 주석이 그 미고침을 명시로 남긴다."""
     out = []
     for r in refs:
         assert "referenced_at" in r and isinstance(r["referenced_at"], str) and r["referenced_at"], (

--- a/backend/tests/test_2263_chat_message_read_references_realdb.py
+++ b/backend/tests/test_2263_chat_message_read_references_realdb.py
@@ -38,6 +38,20 @@ async def _dispose_global_engine_after_test():
     await _global_engine.dispose()
 
 
+def _strip_referenced_at(refs: list[dict]) -> list[dict]:
+    """story #2262 AC1(「지점」, 2026-07-30): fetch_stored_references가 이제
+    `referenced_at`(비결정적 타임스탬프)도 낸다 — 아래 exact-equality 검증에서는
+    그 필드가 «있다는 것»만 확認하고 값 자체는 떼어낸다(테스트가 시각을 하드코딩하지
+    않는다)."""
+    out = []
+    for r in refs:
+        assert "referenced_at" in r and isinstance(r["referenced_at"], str) and r["referenced_at"], (
+            f"referenced_at 누락 또는 빈 값: {r!r}"
+        )
+        out.append({k: v for k, v in r.items() if k != "referenced_at"})
+    return out
+
+
 def _async_url() -> str:
     url = _REAL_DB_URL
     for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
@@ -171,7 +185,7 @@ async def test_get_message_returns_stored_reference_after_reload():
             body = resp.json()
             # story #2316 후속: form·proof_payload 추가(C-7/#2265 소비 대상) — 채팅 mention은
             # 항상 form="mention"·proof_payload=None(insert_chat_mentions 계약).
-            assert body["references"] == [
+            assert _strip_referenced_at(body["references"]) == [
                 {"target_type": "doc", "target_id": str(target.id), "form": "mention", "proof_payload": None}
             ]
         finally:
@@ -218,11 +232,11 @@ async def test_list_messages_returns_stored_references_per_message_without_n_plu
             msgs = body["data"]
             assert len(msgs) == 3
             by_content = {m["content"]: m["references"] for m in msgs}
-            assert by_content[_token("A", "doc", target_a.id)] == [
+            assert _strip_referenced_at(by_content[_token("A", "doc", target_a.id)]) == [
                 {"target_type": "doc", "target_id": str(target_a.id), "form": "mention", "proof_payload": None}
             ]
             assert by_content["no tokens here"] == []
-            assert by_content[_token("B", "doc", target_b.id)] == [
+            assert _strip_referenced_at(by_content[_token("B", "doc", target_b.id)]) == [
                 {"target_type": "doc", "target_id": str(target_b.id), "form": "mention", "proof_payload": None}
             ]
             # ⭐N+1 방지 — 메시지 3건인데 참조 조회는 페이지당 1회만 나가야 한다.
@@ -316,7 +330,7 @@ async def test_list_message_replies_returns_stored_references():
             replies = resp.json()["data"]
             assert len(replies) == 1
             assert replies[0]["id"] == reply_id
-            assert replies[0]["references"] == [
+            assert _strip_referenced_at(replies[0]["references"]) == [
                 {"target_type": "doc", "target_id": str(target.id), "form": "mention", "proof_payload": None}
             ]
         finally:


### PR DESCRIPTION
## Summary
Story #2262(C-4) AC1(「사실성·표면·지점」)의 마지막 갭 — `Reference.created_at` 컬럼은 있었으나 `fetch_stored_references`의 SELECT가 안 뽑고 있었다. select에 추가 + 반환 dict에 `referenced_at`으로 실었다(한 줄, PO 지적).

- **이름을 `created_at` 그대로 안 쓴 이유**: 이 값은 "이 참조가 언제 생겼나"이지 "가리키는 대상이 언제 만들어졌나"가 아니다 — 같은 이름이 두 뜻을 가지면 오늘 반복된 그 병(null의 이중 의미, next_action_code의 3종 혼재 등)이 또 난다.
- FE가 이 값을 실제로 화면에 보일지는 아직 안 정해졌다 — 이 함수는 나르기만 한다(판단은 카드 디자인 몫, 미르코 lane).

이걸로 AC1(표면=form, 사실성=관찰됨 상수, 지점=referenced_at) BE가 전부 닫힌다. AC2(status 번역맵)·AC3(next_action_code/category)도 이미 있어(#2645·#2655) **#2262는 이제 순수 FE 판**이다.

## Test plan
- [x] 기존 exact-equality 테스트 3건(`test_2263_chat_message_read_references_realdb.py`)이 새 필드로 깨지는 것 확認 — `referenced_at`이 "있다는 것만" 확認하고 값 자체(비결정적 타임스탬프)는 떼어내는 헬퍼(`_strip_referenced_at`)로 수정.
- [x] 재검증 20건(2263 read-path·conversations) + 회귀 33건(2301·2269·2259 write-path/entity_references) 전부 그린.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>