### PR TITLE
fix(#2329): shape_count 경고 오탐 95% 걷기 — 이미 있는 헬퍼 한 줄 재사용

### DIFF
--- a/backend/app/services/mention_parser.py
+++ b/backend/app/services/mention_parser.py
@@ -116,7 +116,16 @@ def extract_chat_entity_mentions(content: str) -> list[tuple[str, uuid.UUID]]:
     "토큰 모양"(`](entity:`)이 본문에 있는데 실제 추출 건수가 그보다 적으면 경고 로그를
     남긴다 — 재발해도 조용히 안 넘어가게 하는 최소 감시망(완벽한 검출은 아니다 — 우연히
     `](entity:`를 포함한 무관한 텍스트가 오탐을 낼 수 있다는 것도 안다, 그래도 "0신호"보다
-    낫다)."""
+    낫다).
+
+    ⛔story #2329(2026-07-30 실측, #2316 AC8): 이 경고가 95%(dev 14일 n=39 중 37건) 우리가
+    스토리/AC 본문·팀 채팅에서 `](entity:` 문법을 «인용·설명»할 때 울렸다 — 실제 파싱 실패가
+    아니라 코드펜스·인라인코드 안의 예시 텍스트였다. `shape_count`를 재기 前에
+    `_redact_code_spans()`(#2269가 만든 헬퍼, 지금까지 `extract_bare_number_candidates`
+    전용)를 통과시켜 코드펜스/인라인코드 안의 `](entity:`는 안 센다 — 새 헬퍼를 만들지
+    않는다(두 자리가 "코드블록이란 무엇인가"를 각자 정의하면 #2242의 "한 개념에 두 기준"이
+    된다). ⛔인용 블록(`>`)까지는 `_redact_code_spans()`가 안 덮는다 — 그 문법으로 인용된
+    `](entity:`는 여전히 shape_count에 잡힌다(넓히는 것은 이 스토리 범위 밖)."""
     if not content:
         return []
     seen: set[tuple[str, uuid.UUID]] = set()
@@ -131,7 +140,7 @@ def extract_chat_entity_mentions(content: str) -> list[tuple[str, uuid.UUID]]:
         if key not in seen:
             seen.add(key)
             result.append(key)
-    shape_count = content.count("](entity:")
+    shape_count = _redact_code_spans(content).count("](entity:")
     if len(result) < shape_count:
         logger.warning(
             "mention_parser: token-shaped substring count(%d) exceeds extracted count(%d) — "

--- a/backend/tests/test_1993_mention_parser.py
+++ b/backend/tests/test_1993_mention_parser.py
@@ -159,6 +159,68 @@ def test_extract_chat_no_warning_when_shapes_all_parsed(caplog):
     assert not any("possible silent parse failure" in r.message for r in caplog.records)
 
 
+# ─── story #2329(2026-07-30, #2316 AC8) — shape_count 오탐 95% 걷기 ───────────
+# _redact_code_spans() 재사용(코드펜스/인라인코드 안의 `](entity:`는 안 센다) — AC2 양성
+# 대조(펜스 안은 안 세이고 펜스 밖 진짜 깨진 토큰은 여전히 세인다) + AC3 뮤테이션 자가검증.
+
+
+def test_extract_chat_no_warning_when_broken_shape_is_inside_fenced_code_block(caplog):
+    """AC2 ㉠ — 코드펜스 «안»의 토큰형 문자열(우리가 문법을 설명·인용할 때 쓰는 것과 동형)은
+    shape_count에서 안 세인다 — 경고가 안 뜬다."""
+    import logging
+    from app.services.mention_parser import extract_chat_entity_mentions
+
+    caplog.set_level(logging.WARNING, logger="app.services.mention_parser")
+    doc_id = uuid.uuid4()
+    content = (
+        f"[Real](entity:doc:{doc_id}) 그리고 설명:\n"
+        "```\n"
+        "예시 문법: ](entity: 이렇게 생겼다\n"
+        "```"
+    )
+    result = extract_chat_entity_mentions(content)
+    assert result == [("doc", doc_id)]
+    assert not any("possible silent parse failure" in r.message for r in caplog.records)
+
+
+def test_extract_chat_still_warns_when_broken_shape_is_outside_fenced_code_block(caplog):
+    """AC2 ㉡(판별력) — 펜스 «밖»의 진짜 깨진 토큰형은 여전히 세인다·경고가 뜬다. ①만
+    재면(안 세이는 것만 확인) 「경고를 죽인 것」과 구별이 안 된다 — ①②를 같이 재야 이
+    처방이 "소음만 걷었다"이지 "감시망 자체를 죽였다"가 아님을 증명한다."""
+    import logging
+    from app.services.mention_parser import extract_chat_entity_mentions
+
+    caplog.set_level(logging.WARNING, logger="app.services.mention_parser")
+    doc_id = uuid.uuid4()
+    content = f"[Real](entity:doc:{doc_id}) 그리고 이상한 텍스트 ](entity: 어쩌고"
+    result = extract_chat_entity_mentions(content)
+    assert result == [("doc", doc_id)]
+    assert any("possible silent parse failure" in r.message for r in caplog.records)
+
+
+def test_extract_chat_shape_count_redaction_mutation_self_check(caplog, monkeypatch):
+    """AC3 — 뮤테이션 자가검증. `_redact_code_spans` 호출을 빼면(=고치기 前 상태로 되돌리면)
+    코드펜스 안 토큰형에도 다시 경고가 뜬다(RED) — 방금 위 테스트가 실제로 이 배선을
+    지키고 있다는 것을 증명한다."""
+    import logging
+    import app.services.mention_parser as mp
+
+    monkeypatch.setattr(mp, "_redact_code_spans", lambda content: content)
+
+    caplog.set_level(logging.WARNING, logger="app.services.mention_parser")
+    doc_id = uuid.uuid4()
+    content = (
+        f"[Real](entity:doc:{doc_id}) 그리고 설명:\n"
+        "```\n"
+        "예시 문법: ](entity: 이렇게 생겼다\n"
+        "```"
+    )
+    mp.extract_chat_entity_mentions(content)
+    assert any("possible silent parse failure" in r.message for r in caplog.records), (
+        "_redact_code_spans 배선을 빼도 경고가 안 뜨면 위 양성 테스트가 아무것도 안 지키는 것"
+    )
+
+
 # ─── extract_doc_mention_ids (HTMLParser — wikiLink/pageEmbed data-doc-id) ────
 
 


### PR DESCRIPTION
## 무엇
#2316 AC8 실측(dev 14일, n=39): "possible silent parse failure" 경고의 95%(37건)가
실제 파싱 실패가 아니라 스토리/AC 본문·채팅에서 `](entity:` 문법을 인용·설명할 때
코드펜스 안에서 울린 것. `extract_chat_entity_mentions()`의 `shape_count` 계산 前에
`_redact_code_spans()`(#2269가 이미 만든 헬퍼)를 통과시킨다 — 새 함수 0개.

## AC 대조
- AC1 ✅ shape_count가 코드펜스/인라인코드 안의 `](entity:`를 안 센다
- AC2 ✅ 양성 대조(양방향) — 펜스 안 토큰형은 안 세이고, 펜스 밖 진짜 깨진 토큰형은 여전히 세인다
- AC3 ✅ 뮤테이션 자가검증 — `_redact_code_spans` 배선 제거 시 RED 확인
- AC4 ✅ #2269와 같은 헬퍼 재사용(새 헬퍼 0개)
- AC5 ✅ 경고 자체는 안 지움(소음만 걷음)
- AC6 ⛔ 미측정 — "스토리 본문을 채팅에 한 번 더 붙여넣은 뒤" 사건 기반, 배포 후 재측정 필요(오늘 그 사건이 안 오면 미측정으로 남김)
- AC7 ✅ 못 잡는 것 명시 — `_redact_code_spans`는 인용 블록(`>`)은 안 덮음(docstring에 기록, 넓히지 않음)

## 증거
- `test_1993_mention_parser.py` 신규 3건 포함 41건 green(로컬)
- 인접 회귀(reference_token/story_body_mentions) 61건 green

story #2329