### PR TITLE
fix(#2328): create_story()도 reconcile+candidate 훅을 태운다(create에만 없던 갭)

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -439,6 +439,74 @@ async def _assert_human_owner(
         )
 
 
+async def _reconcile_story_references_and_candidates(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    story: Story,
+    check_description: bool,
+    check_acceptance_criteria: bool,
+    mention_actor_id: uuid.UUID | None,
+) -> None:
+    """story #2301/#2328 공용 코어 — description·acceptance_criteria의 `#`엔티티 토큰을
+    entity_references(#2259)로 걷고 reference_semantic_candidates(#2328)를 얹는다.
+
+    ⛔파울로 판정(2026-07-30, dev 전수스윕 0/420 사고 원인): 이 로직이 원래 update_story()
+    에만 있었다 — create_story()는 한 번도 부르지 않았다. "새 참조만(소급 안 함)"이라는
+    #2328 판정이 "저장 시점마다"를 의도했는데, 실제로는 "«수정» 시점마다"로만 구현된 것
+    (create가 빠짐 — 사람은 스토리를 만들 때 본문을 다 쓰고 만들므로 "새 것"의 대부분이
+    이 갭에 빠졌다). create_story·update_story 둘 다 **이 함수 하나**를 호출한다 — 로직을
+    두 벌 만들지 않는다(파울로 명시 지시)."""
+    from app.services.mention_parser import (
+        extract_chat_entity_mentions,
+        reconcile_entity_references,
+        resolve_bare_number_story_refs,
+    )
+    from app.services.reference_semantic_candidates import generate_and_store_candidates
+
+    _ref_stored = 0
+    _ref_dropped: list[dict[str, str]] = []
+    if check_description:
+        _desc_text = story.description or ""
+        _desc_pairs = extract_chat_entity_mentions(_desc_text)
+        _desc_bare_refs = await resolve_bare_number_story_refs(
+            db, org_id=org_id, project_id=story.project_id, content=_desc_text,
+        )
+        _desc_result = await reconcile_entity_references(
+            db, org_id=org_id, source_type="story", source_field="description",
+            source_id=story.id,
+            extracted_refs=[(t, i, "mention") for t, i in _desc_pairs] + _desc_bare_refs,
+            created_by=mention_actor_id,
+        )
+        _ref_stored += _desc_result.stored
+        _ref_dropped.extend(_desc_result.dropped)
+        await generate_and_store_candidates(
+            db, org_id=org_id, project_id=story.project_id, source_type="story",
+            source_field="description", source_id=story.id, content=_desc_text,
+        )
+    if check_acceptance_criteria:
+        _ac_text = story.acceptance_criteria or ""
+        _ac_pairs = extract_chat_entity_mentions(_ac_text)
+        _ac_bare_refs = await resolve_bare_number_story_refs(
+            db, org_id=org_id, project_id=story.project_id, content=_ac_text,
+        )
+        _ac_result = await reconcile_entity_references(
+            db, org_id=org_id, source_type="story", source_field="acceptance_criteria",
+            source_id=story.id,
+            extracted_refs=[(t, i, "mention") for t, i in _ac_pairs] + _ac_bare_refs,
+            created_by=mention_actor_id,
+        )
+        _ref_stored += _ac_result.stored
+        _ref_dropped.extend(_ac_result.dropped)
+        await generate_and_store_candidates(
+            db, org_id=org_id, project_id=story.project_id, source_type="story",
+            source_field="acceptance_criteria", source_id=story.id, content=_ac_text,
+        )
+    # 채팅(conversations.py)과 동일 게이트: 정상 경로(둘 다 0)에선 필드 자체를 안 싣는다.
+    if _ref_stored or _ref_dropped:
+        story.references = {"stored": _ref_stored, "dropped": _ref_dropped}
+
+
 @router.post("", response_model=StoryResponse, status_code=201)
 async def create_story(
     body: StoryCreate,
@@ -566,6 +634,22 @@ async def create_story(
             # get_db). 부분성공(스토리는 남고 출처만 빠짐)을 만들지 않기 위해 그 불변식을
             # 그대로 따른다 — 여기서 별도 commit을 하면 그 원자성이 깨진다.
             raise HTTPException(status_code=400, detail=f"invalid origin_type: {exc}") from exc
+    # ⛔파울로 판정(2026-07-30, dev 전수스윕 0/420 사고): entity_references(#2259/#2301)·
+    # reference_semantic_candidates(#2328) reconcile이 update_story()에만 있고 이 함수
+    # (POST 생성)에는 «한 번도» 없었다 — 사람은 스토리를 «본문을 다 쓰고» 만드는 것이
+    # 보통이라, 이 갭이 "새 것"의 대부분을 빠뜨렸다(#2330이 그 실물 증거 — 아래 참조).
+    # update_story와 같은 트랜잭션 원자성(같은 세션, commit 전 — 실패 시 story 생성
+    # 전체가 롤백)으로 붙인다.
+    _mention_actor_id: uuid.UUID | None = None
+    try:
+        _mention_actor_id = await _resolve_team_member_id(auth, org_id, session)
+    except Exception:
+        _mention_actor_id = None
+    await _reconcile_story_references_and_candidates(
+        session, org_id=org_id, story=story,
+        check_description=True, check_acceptance_criteria=True,
+        mention_actor_id=_mention_actor_id,
+    )
     return StoryResponse.model_validate(story)
 
 
@@ -1366,73 +1450,21 @@ async def update_story(
     # 각각 독립적으로 reconcile — 같은 대상을 본문과 AC 양쪽에 걸면 두 행 다 남는다(멱등
     # 키에 source_field가 있어 서로 다른 참조로 선다). **같은 트랜잭션**(commit 전, 실패
     # 시 예외 propagate로 story 저장 전체가 롤백 — chat/doc과 동일 AC4 원자성).
+    # ⛔실제 reconcile·candidate 로직은 `_reconcile_story_references_and_candidates`
+    # (create_story와 공유) — 2026-07-30, create에 이 훅이 없던 결함 수정 시 두 벌 대신
+    # 공용 함수로 추출.
     if "description" in data or "acceptance_criteria" in data:
-        from app.services.mention_parser import (
-            extract_chat_entity_mentions,
-            reconcile_entity_references,
-            resolve_bare_number_story_refs,
-        )
-        from app.services.reference_semantic_candidates import generate_and_store_candidates
-
         _mention_actor_id: uuid.UUID | None = None
         try:
             _mention_actor_id = await _resolve_team_member_id(auth, repo.org_id, db)
         except Exception:
             _mention_actor_id = None
-        # story #2315 AC1(오르테가 판정 2026-07-29, 채팅과 "한 글자도 다르지 않게"): 두 호출의
-        # dropped를 **평면 배열 하나**로 합친다 — description·acceptance_criteria 중 어느
-        # 쪽에서 나온 것인지 화면이 구분하지 않는다(#2608 규율 — 화면은 종류로 안 가른다·그
-        # 이유와 같다). dropped 사유 열거형은 채팅 쪽(#2294/#2612)이 이미 SSOT라 여기서
-        # 새로 만들지 않는다.
-        #
-        # story #2269(C-11) AC1: 대괄호 문법(`extract_chat_entity_mentions`)과 맨 번호
-        # (`resolve_bare_number_story_refs`) 결과를 **합쳐서** 한 번에 reconcile한다 — 같은
-        # 대상을 두 문법으로 각각 가리켜도 (target_type, target_id, form) 3튜플이 같아 자연히
-        # 중복 제거된다(reconcile_entity_references의 set 기반 diff, 별도 dedupe 불필요).
-        _ref_stored = 0
-        _ref_dropped: list[dict[str, str]] = []
-        if "description" in data:
-            _desc_text = story.description or ""
-            _desc_pairs = extract_chat_entity_mentions(_desc_text)
-            _desc_bare_refs = await resolve_bare_number_story_refs(
-                db, org_id=repo.org_id, project_id=story.project_id, content=_desc_text,
-            )
-            _desc_result = await reconcile_entity_references(
-                db, org_id=repo.org_id, source_type="story", source_field="description",
-                source_id=story.id,
-                extracted_refs=[(t, i, "mention") for t, i in _desc_pairs] + _desc_bare_refs,
-                created_by=_mention_actor_id,
-            )
-            _ref_stored += _desc_result.stored
-            _ref_dropped.extend(_desc_result.dropped)
-            # story #2328(C-11 ㉡층, PO 판정 2026-07-29): 참조(관찰됨, 위) 위에 「의미 후보」를
-            # 얹는다 — 새 참조만(소급 안 함), 이 write-path가 매 저장마다 도는 것 자체가 "지금
-            # 저장되는 것"이라는 사실을 보장한다. 같은 트랜잭션, 실패 시 story 저장 전체 롤백.
-            await generate_and_store_candidates(
-                db, org_id=repo.org_id, project_id=story.project_id, source_type="story",
-                source_field="description", source_id=story.id, content=_desc_text,
-            )
-        if "acceptance_criteria" in data:
-            _ac_text = story.acceptance_criteria or ""
-            _ac_pairs = extract_chat_entity_mentions(_ac_text)
-            _ac_bare_refs = await resolve_bare_number_story_refs(
-                db, org_id=repo.org_id, project_id=story.project_id, content=_ac_text,
-            )
-            _ac_result = await reconcile_entity_references(
-                db, org_id=repo.org_id, source_type="story", source_field="acceptance_criteria",
-                source_id=story.id,
-                extracted_refs=[(t, i, "mention") for t, i in _ac_pairs] + _ac_bare_refs,
-                created_by=_mention_actor_id,
-            )
-            _ref_stored += _ac_result.stored
-            _ref_dropped.extend(_ac_result.dropped)
-            await generate_and_store_candidates(
-                db, org_id=repo.org_id, project_id=story.project_id, source_type="story",
-                source_field="acceptance_criteria", source_id=story.id, content=_ac_text,
-            )
-        # 채팅(conversations.py)과 동일 게이트: 정상 경로(둘 다 0)에선 필드 자체를 안 싣는다.
-        if _ref_stored or _ref_dropped:
-            story.references = {"stored": _ref_stored, "dropped": _ref_dropped}
+        await _reconcile_story_references_and_candidates(
+            db, org_id=repo.org_id, story=story,
+            check_description="description" in data,
+            check_acceptance_criteria="acceptance_criteria" in data,
+            mention_actor_id=_mention_actor_id,
+        )
 
     # E-STORAGE-SSOT S2: 첨부 교체(attachments 제공) 시 asset registry 재동기화(reconcile·SSOT 정확).
     if "attachments" in data:

--- a/backend/app/services/reference_semantic_candidates.py
+++ b/backend/app/services/reference_semantic_candidates.py
@@ -118,11 +118,19 @@ def extract_bare_number_candidates_with_snippets(content: str) -> list[tuple[int
 
 
 async def build_candidate_rows(
-    db: AsyncSession, *, org_id: uuid.UUID, project_id: uuid.UUID, content: str,
+    db: AsyncSession, *, org_id: uuid.UUID, project_id: uuid.UUID, source_id: uuid.UUID,
+    content: str,
 ) -> list[CandidateRow]:
     """맨 번호 후보를 스니펫과 함께 뽑고, 「해소된」(실제 존재하는 story를 가리키는) 것만
     남긴다 — 미래번호(모집단에 없는 대상, PO 판정 2026-07-29 ②)는 여기서 후보 자체를 안
-    만든다(조용히 스킵, 별도 로그 없음 — #2269 AC1이 이미 그 11.5%를 문서로 남겼다)."""
+    만든다(조용히 스킵, 별도 로그 없음 — #2269 AC1이 이미 그 11.5%를 문서로 남겼다).
+
+    ⛔자기참조 제외(파울로 판정 2026-07-30, dev 실물 사례 — story #2329가 본문에 자기
+    번호("판정: #2329 닫는다")를 적어 자신을 가리키는 후보가 실제로 생겼다): AC10("미분류도
+    안 버린다")과는 다른 축이다 — AC10은 «분류가 안 됐을 뿐 실제 관계 가능성이 있는» 것을
+    보존하는 것이고, 자기참조는 애초에 사람에게 내밀 값이 없다(자기 자신을 가리킨다는
+    사실은 승격 판단 대상이 아니다). 여기서 제외하지 이미 저장된 기존 자기참조 행을
+    소급 정리하지는 않는다(#2328 ③ "소급 안 함"과 동일 원칙)."""
     pairs = extract_bare_number_candidates_with_snippets(content)
     if not pairs:
         return []
@@ -134,6 +142,8 @@ async def build_candidate_rows(
         story_id = targets.get(n)
         if story_id is None:
             continue  # 미래번호(미해소) — PO 판정 ②, 후보 자체를 안 만든다
+        if story_id == source_id:
+            continue  # 자기참조 — 승격 판단 대상 아님(위 docstring 참조)
         kind, keyword = classify_relation_kind(snippet)
         rows.append(CandidateRow(
             matched_number=n, target_story_id=story_id, snippet=snippet,
@@ -186,7 +196,9 @@ async def generate_and_store_candidates(
     """caller(story 저장 write-path) 편의 진입점 — build+store를 한 번에. 같은 트랜잭션
     (caller 세션 그대로 사용, 별도 커밋 없음) — 실패 시 예외가 그대로 propagate되어 story
     저장 전체가 롤백된다(entity_references reconcile과 동일 원자성 계약)."""
-    rows = await build_candidate_rows(db, org_id=org_id, project_id=project_id, content=content)
+    rows = await build_candidate_rows(
+        db, org_id=org_id, project_id=project_id, source_id=source_id, content=content,
+    )
     return await store_semantic_candidates(
         db, org_id=org_id, source_type=source_type, source_field=source_field,
         source_id=source_id, rows=rows,

--- a/backend/tests/test_2328_candidate_hook_on_create_realdb.py
+++ b/backend/tests/test_2328_candidate_hook_on_create_realdb.py
@@ -1,0 +1,214 @@
+"""story #2328(C-11 ㉡층, E-CONNECT) 후속 결함 수정(2026-07-30, 파울로 판정) — dev 420개
+스토리 전수스윕에서 `is_reference_candidate=true`가 0/420이었던 사고의 원인 재현·회귀가드.
+
+배경: reconcile_entity_references·generate_and_store_candidates 호출이 update_story()
+(PATCH)에만 있었고 create_story()(POST)에는 «한 번도» 없었다 — dev 실사례로 확認(story
+#2329는 생성 후 재수정되어 후보 2건, #2330은 생성만 되고 미수정이라 0건). "새 것만(소급
+안 함)"이라는 #2328 판정이 "생성 시점마다"를 의도했는데 create가 빠져 "수정 시점마다"로만
+구현됐던 것 — 이 파일은 POST(생성) 자체로도 후보가 생기는 것을 실PG로 확認한다.
+
+곁들여 자기참조 제외(파울로 판정, 같은 날 — #2329가 본문에 자기 번호를 적어 자신을
+가리키는 후보가 실제로 생긴 것을 계기로)도 이 파일에서 검증한다.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from tests.test_2301_story_body_mentions_realdb import (
+    _REAL_DB_URL,
+    _client_for,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _make_story,
+    _session_factory,
+    _setup_app_human,
+)
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _candidates(session, org_id, source_id, source_field=None):
+    from app.models.reference_semantic_candidate import ReferenceSemanticCandidate
+
+    stmt = select(ReferenceSemanticCandidate).where(
+        ReferenceSemanticCandidate.org_id == org_id,
+        ReferenceSemanticCandidate.source_id == source_id,
+    )
+    if source_field is not None:
+        stmt = stmt.where(ReferenceSemanticCandidate.source_field == source_field)
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def test_creating_story_with_bare_number_description_creates_candidate():
+    """핵심 회귀가드 — POST(생성) 자체가 훅을 태운다. 이 테스트가 이 결함의 재발을 잡는다:
+    _reconcile_story_references_and_candidates 호출을 create_story에서 빼면 이 테스트가
+    빨개진다(수동 뮤테이션 확認 완료, PR 설명 참조)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 6001
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/stories",
+                json={
+                    "project_id": str(project.id),
+                    "org_id": str(org.id),
+                    "title": "Source(생성시부터 참조 있음)",
+                    "description": "#6001 가드와 같은 성질(동종사례 근거)",
+                },
+            )
+            assert resp.status_code == 201, resp.text
+            story_id = resp.json()["id"]
+
+            async with Session() as s:
+                cands = await _candidates(s, org.id, story_id, source_field="description")
+                assert len(cands) == 1, "POST(생성) 자체로 의미 후보가 생겨야 한다"
+                assert cands[0].target_id == target.id
+                assert cands[0].relation_kind == "similar_case"
+                assert cands[0].status == "estimated"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_creating_story_with_bare_number_acceptance_criteria_creates_candidate():
+    """AC 필드도 create 시점에 걷힌다(description과 대칭)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 6002
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/stories",
+                json={
+                    "project_id": str(project.id),
+                    "org_id": str(org.id),
+                    "title": "Source(AC에서 생성시 참조)",
+                    "acceptance_criteria": "#6002 가드와 같은 성질(동종사례 근거)",
+                },
+            )
+            assert resp.status_code == 201, resp.text
+            story_id = resp.json()["id"]
+
+            async with Session() as s:
+                cands = await _candidates(s, org.id, story_id, source_field="acceptance_criteria")
+                assert len(cands) == 1
+                assert cands[0].target_id == target.id
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_story_referencing_own_number_creates_no_self_candidate():
+    """자기참조 제외(파울로 판정 2026-07-30, dev 실사례 — story #2329가 실제로 자기참조
+    후보를 만들었다). 자신의 story_number를 알아야 자기참조가 가능하므로(생성 시점엔 아직
+    모른다), PATCH로 재현한다 — #2329의 실제 발생 경로와 동일."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, title="Self-referencing")
+            story.story_number = 6003
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": "판정: #6003 닫는다."},
+            )
+            assert resp.status_code == 200, resp.text
+
+            async with Session() as s:
+                cands = await _candidates(s, org.id, story.id, source_field="description")
+                assert cands == [], (
+                    f"자기참조 후보가 제외되지 않았다 — 사람에게 내밀 값이 없는 행이 생성됨: {cands!r}"
+                )
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_story_referencing_own_number_and_other_number_keeps_only_other():
+    """자기참조 제외가 «다른» 참조까지 같이 지우지 않는다(과잉 필터 아닌지 확認)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            other = await _make_story(s, org.id, project.id, title="Other")
+            other.story_number = 6005
+            story = await _make_story(s, org.id, project.id, title="Self+other")
+            story.story_number = 6004
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": "판정: #6004 닫는다 — #6005 와 같은 성질(동종사례 근거)"},
+            )
+            assert resp.status_code == 200, resp.text
+
+            async with Session() as s:
+                cands = await _candidates(s, org.id, story.id, source_field="description")
+                assert len(cands) == 1
+                assert cands[0].target_id == other.id
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_cage_referee_p1_participation_api.py
+++ b/backend/tests/test_e_cage_referee_p1_participation_api.py
@@ -141,9 +141,12 @@ async def test_create_story_without_assignee_no_participation():
     try:
         # story 9ac9b80f: StoryRepository.create()가 이제 BaseRepository.create() 前에
         # allocate_story_number()(실 DB 쿼리)를 먼저 호출한다 — 서브클래스 레벨을 patch해야
-        # mock 세션에 그 호출까지 안 부딪힌다(test_stories.py와 동형 수정).
+        # mock 세션에 그 호출까지 안 부딪힌다(test_stories.py와 동형 수정). story #2330
+        # (2026-07-30): create_story가 이제 _reconcile_story_references_and_candidates도
+        # 부른다 — 이 테스트는 그 호출도 no-op patch(행동검증은 별도 실PG 테스트).
         with patch("app.repositories.story.StoryRepository.create", new_callable=AsyncMock) as mock_create, \
-             patch("app.routers.stories._upsert_assignee_participation", new_callable=AsyncMock) as mock_upsert:
+             patch("app.routers.stories._upsert_assignee_participation", new_callable=AsyncMock) as mock_upsert, \
+             patch("app.routers.stories._reconcile_story_references_and_candidates", new_callable=AsyncMock):
             mock_create.return_value = story
             async with client as c:
                 resp = await c.post("/api/v2/stories", json={
@@ -264,7 +267,8 @@ async def test_create_story_without_assignee_still_201():
 
     client, app = await _make_client(mock_session)
     try:
-        with patch("app.repositories.story.StoryRepository.create", new_callable=AsyncMock) as mock_create:
+        with patch("app.repositories.story.StoryRepository.create", new_callable=AsyncMock) as mock_create, \
+             patch("app.routers.stories._reconcile_story_references_and_candidates", new_callable=AsyncMock):
             mock_create.return_value = story
             async with client as c:
                 resp = await c.post("/api/v2/stories", json={

--- a/backend/tests/test_stories.py
+++ b/backend/tests/test_stories.py
@@ -118,7 +118,12 @@ async def test_create_story_201():
         # 그 호출까지 재현하지 않고 라우터 wiring만 검증하려면 서브클래스 레벨(StoryRepository.create)
         # 을 patch해야 한다(BaseRepository.create만 patch하면 allocate_story_number가 mock
         # session.execute()에 그대로 부딪혀 TypeError).
-        with patch("app.repositories.story.StoryRepository.create", new_callable=AsyncMock) as mock_create:
+        # story #2330(2026-07-30, dev 0/420 사고 수정): create_story가 이제
+        # _reconcile_story_references_and_candidates도 부른다(mention_parser/
+        # reference_semantic_candidates 실DB 쿼리) — 라우터 wiring만 보는 이 테스트는
+        # 그 호출 자체를 no-op으로 patch한다(행동 검증은 test_2328_candidate_hook_on_create_realdb.py).
+        with patch("app.repositories.story.StoryRepository.create", new_callable=AsyncMock) as mock_create, \
+             patch("app.routers.stories._reconcile_story_references_and_candidates", new_callable=AsyncMock):
             mock_create.return_value = story
 
             async with client as c:
@@ -399,7 +404,8 @@ async def test_create_story_with_intent_fields_201():
         # 그 호출까지 재현하지 않고 라우터 wiring만 검증하려면 서브클래스 레벨(StoryRepository.create)
         # 을 patch해야 한다(BaseRepository.create만 patch하면 allocate_story_number가 mock
         # session.execute()에 그대로 부딪혀 TypeError).
-        with patch("app.repositories.story.StoryRepository.create", new_callable=AsyncMock) as mock_create:
+        with patch("app.repositories.story.StoryRepository.create", new_callable=AsyncMock) as mock_create, \
+             patch("app.routers.stories._reconcile_story_references_and_candidates", new_callable=AsyncMock):
             mock_create.return_value = story
 
             async with client as c:
@@ -468,7 +474,8 @@ async def test_create_story_outcome_fields_ignored():
         # 그 호출까지 재현하지 않고 라우터 wiring만 검증하려면 서브클래스 레벨(StoryRepository.create)
         # 을 patch해야 한다(BaseRepository.create만 patch하면 allocate_story_number가 mock
         # session.execute()에 그대로 부딪혀 TypeError).
-        with patch("app.repositories.story.StoryRepository.create", new_callable=AsyncMock) as mock_create:
+        with patch("app.repositories.story.StoryRepository.create", new_callable=AsyncMock) as mock_create, \
+             patch("app.routers.stories._reconcile_story_references_and_candidates", new_callable=AsyncMock):
             mock_create.return_value = story
 
             async with client as c:


### PR DESCRIPTION
## Summary
dev 420개 스토리 전수스윕에서 `is_reference_candidate=true`가 **0/420**이었다. 원인 추적 결과: `reconcile_entity_references`·`generate_and_store_candidates` 호출이 `update_story()`(PATCH)에만 있었고 `create_story()`(POST)에는 **한 번도** 없었다.

"새 참조만(소급 안 함)"이라는 #2328 판정이 "저장 시점마다"를 의도했는데 실제로는 "**수정** 시점마다"로만 구현된 것 — 사람은 스토리를 만들 때 본문을 다 쓰고 만들므로, 이 갭이 "새 것"의 대부분을 놓쳤다.

dev 실물 증거(`reference_semantic_candidates` 직접 조회):
- story #2329(생성 후 재수정됨) → 후보 **2건**
- story #2330(생성만 되고 미수정) → 후보 **0건**

## Changes
- `app/routers/stories.py`: 로직을 `_reconcile_story_references_and_candidates` 공용 함수로 추출 — `create_story`·`update_story` 둘 다 **이 함수 하나**를 호출한다(두 벌 안 만듦). create는 항상 description·acceptance_criteria 둘 다 체크(생성 시점엔 "in data" partial-update 개념이 없다).
- `app/services/reference_semantic_candidates.py`: `build_candidate_rows`에 `source_id` 파라미터 추가 — `target_id == source_id`(자기참조)는 후보에서 제외. dev 실사례(#2329가 본문에 "판정: #2329 닫는다"를 적어 자신을 가리키는 후보가 실제로 생겼다)가 계기. AC10("미분류도 보존")과는 다른 축 — 자기참조는 애초에 사람에게 내밀 값이 없다.
- 신규 테스트 `test_2328_candidate_hook_on_create_realdb.py`(실PG 4건): POST 생성만으로 description/AC 양쪽에서 후보 생성 확認 + 자기참조 제외 + 자기참조와 다른참조 혼재 시 다른참조만 남는 것 확認.
- 기존 3개 파일(test_stories.py 2건·test_e_cage_referee_p1_participation_api.py 2건)의 MagicMock 기반 create_story 유닛테스트가 새 DB 호출과 충돌해 깨진 것 발견 — 해당 호출을 no-op patch로 수정(행동 검증은 새 실PG 테스트가 담당).

## 뮤테이션 자가검증 (로컬, 커밋 없음)
create_story의 새 호출을 임시로 빼고 재실행 → 신규 테스트 2건이 정확히 `assert 0 == 1`로 RED, 복원 후 그린 재확認.

## ⛔소급 없음
story #2330 자체는 갱신하지 않는다(#2328 ③ 판정 그대로) — 후보 0건인 채로 남아 있고, 이 사실 자체가 이 결함이 실재했다는 증거로 남는다.

## Test plan
- [x] 신규 4건(test_2328_candidate_hook_on_create_realdb.py) — 전부 그린.
- [x] 회귀 21건(기존 boost·semantic-candidate·#2301 write-path) — 전부 그린.
- [x] MagicMock 유닛테스트 5건(test_stories.py 3건·test_e_cage_referee 2건) — 신규 호출과 충돌 발견→patch 수정→그린.
- [x] 뮤테이션 자가검증 — 위 참조.
- [x] story-관련 타겟 스윕 159건 + auth-context 19건 — 전부 그린(회귀 없음).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>