### PR TITLE
fix(#2328): 후보 머리글 em-dash 리터럴 누락 정정

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -553,7 +553,7 @@
       "typeDepends": "Depends",
       "searchPlaceholder": "Search by story title...",
       "incompletePreds": "{count} incomplete predecessor(s) — check before starting",
-      "candidatesHeader": "Found in this story's body",
+      "candidatesHeader": "── Found in this story's body ──",
       "candidateMentionHint": "Mentioned in this story's body"
     }
   },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -553,7 +553,7 @@
       "typeDepends": "의존",
       "searchPlaceholder": "스토리 제목으로 검색...",
       "incompletePreds": "미완료 선행 {count}건 — 시작 전 확인 권장",
-      "candidatesHeader": "이 스토리 본문에 나온 것",
+      "candidatesHeader": "── 이 스토리 본문에 나온 것 ──",
       "candidateMentionHint": "이 스토리 본문에 나옵니다"
     }
   },


### PR DESCRIPTION
## 요약
#2328 라이브 검증 중 발견 — 유나 규격 원문 「── 이 스토리 본문에 나온 것 ──」의 em-dash가 실제 렌더 문구엔 빠져 있었음(CSS로 시각 구분은 이미 되어 있었으나 문구 자체가 규격과 글자 그대로 다름).

## 변경
- `dep.candidatesHeader` i18n 키(ko/en) 양쪽에 em-dash 리터럴 추가.

## 검증
- 라이브 확認: PR#2662(#2328 FE) + PR#2666(까심 create-hook) 둘 다 배포된 dev 환경에서 QA 스토리 2개(양성/음성)로 6개 체크 전부 PASS — 이 과정에서 이 gap을 직접 눈으로 발견.
- 이 문구를 직접 assert하는 테스트는 없음(순수 판정 로직만 격리 테스트) — 회귀 리스크 없음.
- `pnpm vitest run` 316/316 · `pnpm build` EXIT 0.

## Test plan
- [ ] dev 배포 후 재확認 — 의존성 고르기 패널에서 후보 머리글이 「── 이 스토리 본문에 나온 것 ──」로 정확히 렌더되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)