### PR TITLE
feat(#2335 클래스 봉인): Query(None) 센티널 직접호출 lint — 세 번째 재발 방지

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,18 +255,28 @@ jobs:
         working-directory: backend
         run: |
           set -e
-          BASE_REF="${{ github.event.pull_request.base.ref }}"
-          if [ -z "$BASE_REF" ]; then
-            BASE_REF="develop"
+          # PO 질문(2026-07-30): "PR은 develop 대비인데, develop 자신에 푸시될 때는 무엇과
+          # 견주는가?" — pull_request 이벤트는 PR의 base 브랜치(보통 develop)와, push
+          # 이벤트(예: develop에 직접 머지)는 그 push 직전 커밋(github.event.before)과
+          # 비교한다. 둘 다 없으면(예: 새 브랜치 최초 push) 비교 대상이 없어 검사를 스킵한다
+          # — 그 경로에서는 이 가드가 안 돈다(한계로 남김, "이제 다 잡는다"로 안 읽히게).
+          PR_BASE_REF="${{ github.event.pull_request.base.ref }}"
+          PUSH_BEFORE_SHA="${{ github.event.before }}"
+          COMPARE_REF=""
+          if [ -n "$PR_BASE_REF" ]; then
+            git fetch origin "$PR_BASE_REF" --depth=1 2>&1 | tail -3 || true
+            COMPARE_REF="origin/$PR_BASE_REF"
+          elif [ -n "$PUSH_BEFORE_SHA" ] && [ "$PUSH_BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+            git fetch origin "$PUSH_BEFORE_SHA" --depth=1 2>&1 | tail -3 || true
+            COMPARE_REF="$PUSH_BEFORE_SHA"
           fi
-          git fetch origin "$BASE_REF" --depth=1 2>&1 | tail -3 || true
-          if git show "origin/$BASE_REF:backend/scripts/query_sentinel_baseline.txt" > /tmp/base_baseline.txt 2>/dev/null; then
+          if [ -n "$COMPARE_REF" ] && git show "$COMPARE_REF:backend/scripts/query_sentinel_baseline.txt" > /tmp/base_baseline.txt 2>/dev/null; then
             grep -vE '^#|^$' /tmp/base_baseline.txt | sort -u > /tmp/base_sorted.txt
             grep -vE '^#|^$' scripts/query_sentinel_baseline.txt | sort -u > /tmp/head_sorted.txt
             new_lines=$(comm -13 /tmp/base_sorted.txt /tmp/head_sorted.txt || true)
             base_count=$(wc -l < /tmp/base_sorted.txt | tr -d ' ')
             head_count=$(wc -l < /tmp/head_sorted.txt | tr -d ' ')
-            echo "baseline entries: base($BASE_REF)=$base_count head=$head_count"
+            echo "baseline entries: base($COMPARE_REF)=$base_count head=$head_count"
             if [ -n "$new_lines" ]; then
               echo "FAIL: 베이스라인에 «새» 항목이 추가됐다 — 이 파일은 줄기만 허용한다(story #2335)." \
                    "새 위반은 여기 grandfather로 넣지 말고 실제로 고치는(파라미터를 명시로 넘기는) 것이 맞다:"
@@ -275,7 +285,7 @@ jobs:
             fi
             echo "OK: baseline은 늘지 않았다(줄었으면 환영 — 그만큼 사이트가 고쳐진 것)"
           else
-            echo "base($BASE_REF)에 베이스라인 파일이 아직 없음 — 이 PR이 첫 도입이라 증가검사 스킵"
+            echo "비교 대상 없음(PR 컨텍스트 아님 + push-before 미상 — 예: 새 브랜치 최초 push) — 증가검사 스킵"
           fi
 
   # story bda4beac: alembic-fresh-db(위)는 checkout된 브랜치(develop/PR)의 파일셋 기준이라

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,9 +242,41 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Scan for Query(...) params missing at router direct-call sites
         working-directory: backend
         run: python3 scripts/lint_query_sentinel_direct_calls.py
+      # ⭐PO 판정(2026-07-30): grandfather 베이스라인은 "지금 있는 걸 봐준다"이지 "앞으로도
+      # 여기 한 줄 더 넣고 넘어가도 된다"가 아니다 — 그러면 이 가드를 우회하는 «합법적인 문»이
+      # 된다. 베이스라인 파일은 «줄기만» 허용한다: base 브랜치(보통 develop) 대비 새로 추가된
+      # 줄이 있으면 실패시킨다(제거는 자유 — 사이트를 고쳐서 줄어드는 것은 언제나 환영).
+      - name: "Verify baseline can only shrink (story #2335 — no new grandfather entries)"
+        working-directory: backend
+        run: |
+          set -e
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          if [ -z "$BASE_REF" ]; then
+            BASE_REF="develop"
+          fi
+          git fetch origin "$BASE_REF" --depth=1 2>&1 | tail -3 || true
+          if git show "origin/$BASE_REF:backend/scripts/query_sentinel_baseline.txt" > /tmp/base_baseline.txt 2>/dev/null; then
+            grep -vE '^#|^$' /tmp/base_baseline.txt | sort -u > /tmp/base_sorted.txt
+            grep -vE '^#|^$' scripts/query_sentinel_baseline.txt | sort -u > /tmp/head_sorted.txt
+            new_lines=$(comm -13 /tmp/base_sorted.txt /tmp/head_sorted.txt || true)
+            base_count=$(wc -l < /tmp/base_sorted.txt | tr -d ' ')
+            head_count=$(wc -l < /tmp/head_sorted.txt | tr -d ' ')
+            echo "baseline entries: base($BASE_REF)=$base_count head=$head_count"
+            if [ -n "$new_lines" ]; then
+              echo "FAIL: 베이스라인에 «새» 항목이 추가됐다 — 이 파일은 줄기만 허용한다(story #2335)." \
+                   "새 위반은 여기 grandfather로 넣지 말고 실제로 고치는(파라미터를 명시로 넘기는) 것이 맞다:"
+              echo "$new_lines"
+              exit 1
+            fi
+            echo "OK: baseline은 늘지 않았다(줄었으면 환영 — 그만큼 사이트가 고쳐진 것)"
+          else
+            echo "base($BASE_REF)에 베이스라인 파일이 아직 없음 — 이 PR이 첫 도입이라 증가검사 스킵"
+          fi
 
   # story bda4beac: alembic-fresh-db(위)는 checkout된 브랜치(develop/PR)의 파일셋 기준이라
   # main이 develop과 다른 파일셋(ee_pricing 0146/0147 부재)일 때의 그래프 단절을 원천적으로

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,7 +306,7 @@ jobs:
             # 라인 파일 자체가 아직 없었다"(예: 이 lint를 «처음» 들여오는 PR 자신). 이것도
             # 앞의 것과 별개 이유이므로 다른 문구로 남긴다 — 다음 사람이 "PR context가 없어서
             # 스킵됐나?"와 헷갈리지 않게.
-            echo "baseline growth check skipped: no comparison base ($COMPARE_LABEL에 query_sentinel_baseline.txt 없음 — 최초 도입 PR 등)"
+            echo "baseline growth check skipped: no comparison base ($COMPARE_LABEL에 query_sentinel_baseline.txt 없음 — 이 PR이 그 파일을 «처음 도입»하는 중이면 정상이다, story #2335 자신이 그 경우다. 다음 PR부터는 develop에 파일이 있어 실제 비교가 돈다)"
           fi
 
   # story bda4beac: alembic-fresh-db(위)는 checkout된 브랜치(develop/PR)의 파일셋 기준이라

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,10 @@ jobs:
             fi
             echo "OK: baseline은 늘지 않았다(줄었으면 환영 — 그만큼 사이트가 고쳐진 것)"
           else
-            echo "비교 대상 없음(PR 컨텍스트 아님 + push-before 미상 — 예: 새 브랜치 최초 push) — 증가검사 스킵"
+            # PO 지적(2026-07-30): 한계를 문서에만 적으면 "그 파일 여는 사람"만 안다(#2191이
+            # 그렇게 세 번째 재발했다) — 이 스킵도 CI stdout에 즉시·눈에 띄게 찍어야 그 자리로
+            # 들어온 사람이 바로 안다. grep하기 쉬운 고정 문구로 남긴다.
+            echo "baseline growth check skipped: no comparison base (PR context 아님 + push-before 미상 — 예: 새 브랜치 최초 push)"
           fi
 
   # story bda4beac: alembic-fresh-db(위)는 checkout된 브랜치(develop/PR)의 파일셋 기준이라

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,26 @@ jobs:
           fi
           echo "OK: no autocommit_block() calls in migration files"
 
+  # story #2335([클래스 봉인]) — Query(default=None) 센티널이 «직접호출 테스트»를 통해 새는
+  # 클래스를 막는다. 같은 병이 #2191(테스트 주석에만 남고 코드가드 안 고침)→#2659(CI 21건
+  # 실패)로 두 번 났고, 오늘(2026-07-30) 전수 스윕에서 12건 전부 크래시(조용히 틀리는 것 0건)
+  # 임을 확認 — 그래서 41건 개별 수리는 안 하고(AC6, 크래시는 CI가 이미 잡는다) "이 클래스가
+  # 세 번째 나지 않게" 막는 lint만 짓는다. 순수 AST 정적분석 — DB/의존성 불요, python3 stdlib뿐.
+  #
+  # grandfather 베이스라인(scripts/query_sentinel_baseline.txt): lint 도입 시점 develop에
+  # 이미 있던 위반은 실패시키지 않는다(41건 개별 수리는 이 판이 아니라는 AC6 판정 그대로) —
+  # 베이스라인에 없는 **새** 위반만 여기서 빨개진다.
+  query-sentinel-direct-call-lint:
+    name: Query(None) sentinel direct-call lint (guard)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Scan for Query(...) params missing at router direct-call sites
+        working-directory: backend
+        run: python3 scripts/lint_query_sentinel_direct_calls.py
+
   # story bda4beac: alembic-fresh-db(위)는 checkout된 브랜치(develop/PR)의 파일셋 기준이라
   # main이 develop과 다른 파일셋(ee_pricing 0146/0147 부재)일 때의 그래프 단절을 원천적으로
   # 못 잡는다(실제로 못 잡아서 prod 승격이 롤백된 그 사고). PR base가 main일 때만 도는 이

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,15 +260,26 @@ jobs:
           # 이벤트(예: develop에 직접 머지)는 그 push 직전 커밋(github.event.before)과
           # 비교한다. 둘 다 없으면(예: 새 브랜치 최초 push) 비교 대상이 없어 검사를 스킵한다
           # — 그 경로에서는 이 가드가 안 돈다(한계로 남김, "이제 다 잡는다"로 안 읽히게).
+          # ⛔실측(2026-07-30, CI 로그로 발견): `git fetch origin <branch> --depth=1`은
+          # `FETCH_HEAD`만 채운다 — `refs/remotes/origin/<branch>`(즉 `origin/develop`
+          # 이라는 이름)는 «만들지 않는다». 그래서 이 스텝이 처음 실렸을 때 PR_BASE_REF가
+          # 정확히 "develop"으로 치환됐는데도 `git show origin/develop:...`가 그런 ref가
+          # 없어 조용히 실패 → else(스킵) 분기로 떨어졌다(정확히 이 가드가 막으려던 그 모양
+          # — "실행되는데 바깥을 안 만나는" 것. 뮤테이션 없이 실전에서 스스로 걸린 사례).
+          # 고침: fetch 직후의 `FETCH_HEAD`를 그 자리에서 바로 쓴다(별도 remote-tracking
+          # ref 이름에 의존하지 않는다).
           PR_BASE_REF="${{ github.event.pull_request.base.ref }}"
           PUSH_BEFORE_SHA="${{ github.event.before }}"
           COMPARE_REF=""
+          COMPARE_LABEL=""
           if [ -n "$PR_BASE_REF" ]; then
             git fetch origin "$PR_BASE_REF" --depth=1 2>&1 | tail -3 || true
-            COMPARE_REF="origin/$PR_BASE_REF"
+            COMPARE_REF="FETCH_HEAD"
+            COMPARE_LABEL="PR base:$PR_BASE_REF"
           elif [ -n "$PUSH_BEFORE_SHA" ] && [ "$PUSH_BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
             git fetch origin "$PUSH_BEFORE_SHA" --depth=1 2>&1 | tail -3 || true
-            COMPARE_REF="$PUSH_BEFORE_SHA"
+            COMPARE_REF="FETCH_HEAD"
+            COMPARE_LABEL="push-before:$PUSH_BEFORE_SHA"
           fi
           if [ -n "$COMPARE_REF" ] && git show "$COMPARE_REF:backend/scripts/query_sentinel_baseline.txt" > /tmp/base_baseline.txt 2>/dev/null; then
             grep -vE '^#|^$' /tmp/base_baseline.txt | sort -u > /tmp/base_sorted.txt
@@ -276,7 +287,7 @@ jobs:
             new_lines=$(comm -13 /tmp/base_sorted.txt /tmp/head_sorted.txt || true)
             base_count=$(wc -l < /tmp/base_sorted.txt | tr -d ' ')
             head_count=$(wc -l < /tmp/head_sorted.txt | tr -d ' ')
-            echo "baseline entries: base($COMPARE_REF)=$base_count head=$head_count"
+            echo "baseline entries: base($COMPARE_LABEL)=$base_count head=$head_count"
             if [ -n "$new_lines" ]; then
               echo "FAIL: 베이스라인에 «새» 항목이 추가됐다 — 이 파일은 줄기만 허용한다(story #2335)." \
                    "새 위반은 여기 grandfather로 넣지 말고 실제로 고치는(파라미터를 명시로 넘기는) 것이 맞다:"
@@ -284,11 +295,18 @@ jobs:
               exit 1
             fi
             echo "OK: baseline은 늘지 않았다(줄었으면 환영 — 그만큼 사이트가 고쳐진 것)"
-          else
+          elif [ -z "$COMPARE_REF" ]; then
             # PO 지적(2026-07-30): 한계를 문서에만 적으면 "그 파일 여는 사람"만 안다(#2191이
             # 그렇게 세 번째 재발했다) — 이 스킵도 CI stdout에 즉시·눈에 띄게 찍어야 그 자리로
             # 들어온 사람이 바로 안다. grep하기 쉬운 고정 문구로 남긴다.
             echo "baseline growth check skipped: no comparison base (PR context 아님 + push-before 미상 — 예: 새 브랜치 최초 push)"
+          else
+            # ⭐COMPARE_REF는 있었으나(PR base 또는 push-before를 정상 식별) git show가
+            # 실패한 경우 — 가장 흔한 정당한 사유는 "그 비교시점(base 브랜치)에는 이 베이스
+            # 라인 파일 자체가 아직 없었다"(예: 이 lint를 «처음» 들여오는 PR 자신). 이것도
+            # 앞의 것과 별개 이유이므로 다른 문구로 남긴다 — 다음 사람이 "PR context가 없어서
+            # 스킵됐나?"와 헷갈리지 않게.
+            echo "baseline growth check skipped: no comparison base ($COMPARE_LABEL에 query_sentinel_baseline.txt 없음 — 최초 도입 PR 등)"
           fi
 
   # story bda4beac: alembic-fresh-db(위)는 checkout된 브랜치(develop/PR)의 파일셋 기준이라

--- a/backend/scripts/lint_query_sentinel_direct_calls.py
+++ b/backend/scripts/lint_query_sentinel_direct_calls.py
@@ -317,6 +317,11 @@ def main() -> int:
     new_violations = [v for v in result.violations if violation_key(v) not in baseline]
     grandfathered = [v for v in result.violations if violation_key(v) in baseline]
 
+    # ⭐PO 지적(2026-07-30): 베이스라인 «수»를 CI 로그에 매번 찍는다 — 아무도 안 보면 「줄고
+    # 있는지」가 죽는다(줄지 않아도 최소한 보이기는 해야 한다). 별도 CI 스텝(git diff 기반)이
+    # 이 파일 자체에 새 줄이 «추가»되는 것을 막는다(baseline은 줄기만 허용) — 이 스크립트는
+    # "지금 몇 개가 grandfathered인가"만 보인다.
+    print(f"grandfathered: {len(baseline)}")
     print(f"위반 {len(result.violations)}건(베이스라인 기존 {len(grandfathered)}건 + 신규 {len(new_violations)}건) "
           f"· SKIPPED {len(result.skipped)}건(추적불가 — story #2335 AC5, «못 잡는 것»의 크기)")
 

--- a/backend/scripts/lint_query_sentinel_direct_calls.py
+++ b/backend/scripts/lint_query_sentinel_direct_calls.py
@@ -1,0 +1,345 @@
+"""story #2335([클래스 봉인]) — `Query(default=None)` 센티널이 직접호출 테스트로 새는
+클래스를 CI에서 막는다. 세 번째 재발(#2191→#2659→이 전수) 뒤에 세운 lint다.
+
+메커니즘(story #2330/#2335 본문과 동일): `x: T | None = Query(default=None)`의 기본값은
+`T | None`이 아니라 `fastapi.params.Query` **인스턴스**다. FastAPI가 실제 HTTP 요청 경로를
+탈 때만 그 센티널을 실값(쿼리 파라미터 또는 None)으로 해소한다. 테스트가 라우터 함수를
+직접 호출(`await list_stories(...)`)하면서 그 파라미터를 명시로 안 넘기면, 그 자리에
+`Query` 객체 그대로가 들어간다 — `if x is not None:` 같은 가드는 그 객체가 "값이 있다"고
+착각해 통과시킨다.
+
+⛔이 lint가 하는 일: `app/routers/*.py`의 각 함수가 선언한 `Query(...)` 파라미터 집합과,
+`tests/`의 그 함수 직접호출부가 명시로 넘기는 인자 집합을 AST로 대조한다. 명시로 안 넘긴
+Query 파라미터가 하나라도 있으면 그 호출부를 위반으로 보고한다.
+
+⛔grandfather 베이스라인(story #2335 AC6과의 접점 — 반드시 읽어야 한다): 이 lint를 처음
+켠 시점(2026-07-30) develop에 이미 위반이 있었다(`query_sentinel_baseline.txt`에 스냅샷).
+#2335 AC6은 "41건(그 부분집합이 이 기존 위반들)을 «고치지 않는다»"고 명시로 판정했다 —
+조용히 틀리는 것이 0(전부 크래시)이라 개별 수리가 이 판이 아니기 때문이다. 그래서 이 lint는
+베이스라인에 있는 기존 위반을 실패시키지 않는다 — 대신 **베이스라인에 없는 새 위반**
+(`(파일, 함수, 누락파라미터집합)` 3중키로 식별, 라인번호는 무관한 다른 편집으로 흔들리므로
+키에서 제외)만 CI를 빨갛게 한다. 즉 이 lint의 계약은 "지금 있는 걸 고쳐라"가 아니라
+"더 이상 늘리지 마라"다 — #2335 AC1이 요구하는 게 정확히 그것이다.
+
+⛔범위: `Query(...)`만 본다(`Depends(...)`는 story #2335 스코프 밖 — 대부분 세션/인증처럼
+생략하면 즉시 명백하게 죽어 "조용히 새는" 이 클래스가 아니다).
+
+⛔이 lint가 «못 잡는» 것(story #2335 AC5 — 반드시 읽어야 하는 한계):
+  ①`getattr`/동적 함수참조로 호출하는 경우(`fn = globals()[name]; await fn(...)`) — 정적으로
+    호출 대상을 특정 못 하면 검사 자체를 안 한다(오탐 방지 우선).
+  ②라우터 밖(서비스/repository 계층)에 같은 Query 센티널 패턴을 쓰는 경우 — 이 lint는
+    `app/routers/*.py`만 스캔한다. 서비스 함수가 직접 `Query(...)`를 쓰는 것 자체가
+    이례적이라 실제 사례는 없었으나, 생기면 이 lint 밖이다.
+  ③`**kwargs`로 뭉쳐 넘기는 호출부: 그 kwargs 변수의 출처를 «한 단계»(같은 함수 안의
+    `dict(...)` 리터럴 대입 + 그 뒤 `.update(dict-리터럴)` 체이닝까지만) 추적한다. 그보다
+    복잡한 경로(다른 함수가 만들어 리턴한 dict, 조건부로 키가 붙는 dict 등)는 «추적 불가»로
+    판단해 검사를 건너뛴다(SKIPPED로 집계).
+    ⭐SKIPPED에 대한 정확한 문장(2026-07-30, PO 확認): 「안전하다」도 「샌다」도 아니다 —
+    **이 lint가 «모른다»**다. 오탐 방지가 확실성보다 우선이라 의도적으로 미검사한 것이지,
+    안전을 확인해서 봐준 게 아니다. ⛔SKIPPED 4건이 실제로 새는지 알고 싶으면 이 lint가
+    아니라 **직접 호출해 보면 된다** — story #2335 조사에서 12건(gates.py 3종·docs.py
+    project_id/q·visual_artifacts.py story_id·workflow_executions.py member_id 등)을
+    바로 그렇게(disposable PG로 직접 호출) 쟀다.
+  ④41건(story #2335 전수 스윕) 자체가 «하한»이었다 — 함수명 충돌(`list_docs`가 라우터에도
+    MCP 툴에도 있는 사례)로 grep이 실제로 놓친 적이 있다. 이 lint는 import 문으로 정확한
+    모듈 출처를 추적해 그 충돌은 막지만, «아직 파악 못 한 다른 종류의 충돌»이 있을 가능성은
+    남는다.
+「이제 다 잡는다」로 읽으면 그것이 네 번째 사고다.
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+ROUTERS_DIR = "app/routers"
+TESTS_DIR = "tests"
+
+
+@dataclass
+class RouterFunctionInfo:
+    module: str  # "app.routers.stories" 형태(점 표기, import 문 대조용)
+    name: str
+    query_params: set[str] = field(default_factory=set)
+    param_order: list[str] = field(default_factory=list)  # 위치인자 매핑용
+
+
+def _is_query_call(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "Query"
+    )
+
+
+def find_router_functions(source: str, module: str) -> list[RouterFunctionInfo]:
+    """모듈 소스에서 `Query(...)` 기본값을 가진 파라미터를 하나 이상 선언한
+    (async) 함수를 전부 뽑는다."""
+    tree = ast.parse(source)
+    results: list[RouterFunctionInfo] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        args = node.args
+        # ast: posonlyargs + args가 defaults와 뒤에서부터 정렬, kwonlyargs는 kw_defaults와 병렬.
+        all_positional = list(args.posonlyargs) + list(args.args)
+        defaults = list(args.defaults)
+        pad = len(all_positional) - len(defaults)
+        query_params: set[str] = set()
+        param_order = [a.arg for a in all_positional] + [a.arg for a in args.kwonlyargs]
+        for i, a in enumerate(all_positional):
+            if i < pad:
+                continue
+            default = defaults[i - pad]
+            if _is_query_call(default):
+                query_params.add(a.arg)
+        for a, default in zip(args.kwonlyargs, args.kw_defaults):
+            if default is not None and _is_query_call(default):
+                query_params.add(a.arg)
+        if query_params:
+            results.append(RouterFunctionInfo(
+                module=module, name=node.name, query_params=query_params, param_order=param_order,
+            ))
+    return results
+
+
+def _module_name_for(routers_root: Path, file_path: Path) -> str:
+    rel = file_path.relative_to(routers_root.parent.parent)  # backend/ 기준
+    return ".".join(rel.with_suffix("").parts)
+
+
+def collect_router_functions(backend_root: Path) -> dict[str, dict[str, RouterFunctionInfo]]:
+    """{module: {func_name: RouterFunctionInfo}}"""
+    out: dict[str, dict[str, RouterFunctionInfo]] = {}
+    routers_root = backend_root / ROUTERS_DIR
+    for f in sorted(routers_root.glob("*.py")):
+        module = _module_name_for(routers_root, f)
+        source = f.read_text(encoding="utf-8")
+        try:
+            funcs = find_router_functions(source, module)
+        except SyntaxError:
+            continue
+        if funcs:
+            out[module] = {fi.name: fi for fi in funcs}
+    return out
+
+
+@dataclass
+class Violation:
+    file: str
+    line: int
+    func_name: str
+    missing: set[str]
+
+
+@dataclass
+class ScanResult:
+    violations: list[Violation]
+    skipped: list[str]  # 추적불가로 건너뛴 자리 설명(파일:줄)
+
+
+def _resolve_dict_literal_keys(
+    func_body: list[ast.stmt], var_name: str, call_lineno: int,
+) -> set[str] | None:
+    """`var_name = dict(k=v, ...)` (선택: 그 뒤 `var_name.update(dict(...))` 1회까지) 를
+    같은 함수 body 안에서, call_lineno 이전 라인 중 «가장 가까운» 대입부터 추적한다.
+    못 찾으면 None(추적불가 — 호출부는 SKIPPED 처리)."""
+    keys: set[str] | None = None
+    for stmt in ast.walk(ast.Module(body=func_body, type_ignores=[])):
+        if getattr(stmt, "lineno", 10**9) >= call_lineno:
+            continue
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and stmt.targets[0].id == var_name
+        ):
+            val = stmt.value
+            if isinstance(val, ast.Call) and isinstance(val.func, ast.Name) and val.func.id == "dict":
+                keys = {kw.arg for kw in val.keywords if kw.arg is not None}
+            elif isinstance(val, ast.Dict):
+                keys = {
+                    k.value for k in val.keys
+                    if isinstance(k, ast.Constant) and isinstance(k.value, str)
+                }
+        elif (
+            keys is not None
+            and isinstance(stmt, ast.Expr)
+            and isinstance(stmt.value, ast.Call)
+            and isinstance(stmt.value.func, ast.Attribute)
+            and stmt.value.func.attr == "update"
+            and isinstance(stmt.value.func.value, ast.Name)
+            and stmt.value.func.value.id == var_name
+        ):
+            arg = stmt.value.args[0] if stmt.value.args else None
+            if isinstance(arg, ast.Call) and isinstance(arg.func, ast.Name) and arg.func.id == "dict":
+                keys |= {kw.arg for kw in arg.keywords if kw.arg is not None}
+            elif isinstance(arg, ast.Dict):
+                keys |= {
+                    k.value for k in arg.keys
+                    if isinstance(k, ast.Constant) and isinstance(k.value, str)
+                }
+            else:
+                return None  # update()에 리터럴 아닌 것 — 추적불가
+    return keys
+
+
+def _imports_from_routers(tree: ast.Module) -> dict[str, tuple[str, str]]:
+    """`from app.routers.stories import list_stories as ls` → {"ls": ("app.routers.stories", "list_stories")}.
+    함수명 충돌(story #2335 배경 — list_docs가 라우터/MCP 툴 둘 다에 있던 사례) 방지를 위해
+    import 출처 모듈을 명시로 추적한다(bare 이름 매치 금지)."""
+    out: dict[str, tuple[str, str]] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module and node.module.startswith("app.routers"):
+            for alias in node.names:
+                local = alias.asname or alias.name
+                out[local] = (node.module, alias.name)
+    return out
+
+
+def _build_parent_map(tree: ast.Module) -> dict[ast.AST, ast.AST]:
+    parents: dict[ast.AST, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[child] = parent
+    return parents
+
+
+def _enclosing_function_body(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> list[ast.stmt] | None:
+    """call node가 속한 가장 가까운 (async) 함수의 body를 반환한다 — dict 변수 추적을
+    «그 함수 안»으로만 한정하기 위함(다른 함수의 동명 변수와 섞이지 않게)."""
+    cur = parents.get(node)
+    while cur is not None:
+        if isinstance(cur, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return cur.body
+        cur = parents.get(cur)
+    return None
+
+
+def scan_test_file(
+    source: str, file_label: str, router_functions: dict[str, dict[str, RouterFunctionInfo]],
+) -> ScanResult:
+    tree = ast.parse(source)
+    imports = _imports_from_routers(tree)
+    violations: list[Violation] = []
+    skipped: list[str] = []
+    parents = _build_parent_map(tree)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+            continue
+        local_name = node.func.id
+        if local_name not in imports:
+            continue
+        module, orig_name = imports[local_name]
+        info = router_functions.get(module, {}).get(orig_name)
+        if info is None:
+            continue
+
+        explicit: set[str] = {kw.arg for kw in node.keywords if kw.arg is not None}
+        has_dyn_kwargs = any(kw.arg is None for kw in node.keywords)  # **something
+        # 위치인자 매핑(드묾 — 대부분 kwargs 스타일이나 방어적으로 처리).
+        for i, _ in enumerate(node.args):
+            if i < len(info.param_order):
+                explicit.add(info.param_order[i])
+
+        if has_dyn_kwargs:
+            splat_name = None
+            for kw in node.keywords:
+                if kw.arg is None and isinstance(kw.value, ast.Name):
+                    splat_name = kw.value.id
+                    break
+            if splat_name is None:
+                skipped.append(f"{file_label}:{node.lineno} ({orig_name}) — **동적표현식 splat, 추적불가")
+                continue
+            owning_body = _enclosing_function_body(node, parents)
+            resolved = _resolve_dict_literal_keys(owning_body or [], splat_name, node.lineno) if owning_body else None
+            if resolved is None:
+                skipped.append(f"{file_label}:{node.lineno} ({orig_name}) — **{splat_name} 출처 추적불가")
+                continue
+            explicit |= resolved
+
+        missing = info.query_params - explicit
+        if missing:
+            violations.append(Violation(file=file_label, line=node.lineno, func_name=orig_name, missing=missing))
+
+    return ScanResult(violations=violations, skipped=skipped)
+
+
+def scan_repo(backend_root: Path) -> ScanResult:
+    router_functions = collect_router_functions(backend_root)
+    all_violations: list[Violation] = []
+    all_skipped: list[str] = []
+    tests_root = backend_root / TESTS_DIR
+    for f in sorted(tests_root.rglob("*.py")):
+        source = f.read_text(encoding="utf-8")
+        try:
+            result = scan_test_file(source, str(f.relative_to(backend_root)), router_functions)
+        except SyntaxError:
+            continue
+        all_violations.extend(result.violations)
+        all_skipped.extend(result.skipped)
+    return ScanResult(violations=all_violations, skipped=all_skipped)
+
+
+BASELINE_FILE = "scripts/query_sentinel_baseline.txt"
+
+
+def violation_key(v: Violation) -> str:
+    """(파일, 함수, 정렬된 누락파라미터집합) — 라인번호는 무관한 편집으로 흔들리므로 키에서
+    제외한다(story #2335 AC6 grandfather 계약: 베이스라인은 "이 자리가 이 파라미터들을 안
+    넘긴다"는 사실을 추적하지, 정확한 줄 위치를 추적하지 않는다)."""
+    return f"{v.file}::{v.func_name}::{','.join(sorted(v.missing))}"
+
+
+def load_baseline(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    return {line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip() and not line.startswith("#")}
+
+
+def write_baseline(path: Path, keys: set[str]) -> None:
+    header = (
+        "# story #2335 grandfather 베이스라인 — 2026-07-30 lint 첫 도입 시점 develop의 기존 위반\n"
+        "# AC6 판정: 조용히 틀리는 것 0건(전부 크래시)이라 개별 수리는 이 판이 아니다 — 그래서\n"
+        "# 여기 있는 항목은 실패시키지 않는다. 새 위반(여기 없는 것)만 CI를 빨갛게 한다.\n"
+        "# 형식: 파일::함수::정렬된누락파라미터(콤마구분) — 라인번호는 고의로 안 담는다(편집마다 흔들림).\n"
+    )
+    path.write_text(header + "\n".join(sorted(keys)) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    backend_root = Path(__file__).resolve().parent.parent
+    result = scan_repo(backend_root)
+    baseline = load_baseline(backend_root / BASELINE_FILE)
+
+    new_violations = [v for v in result.violations if violation_key(v) not in baseline]
+    grandfathered = [v for v in result.violations if violation_key(v) in baseline]
+
+    print(f"위반 {len(result.violations)}건(베이스라인 기존 {len(grandfathered)}건 + 신규 {len(new_violations)}건) "
+          f"· SKIPPED {len(result.skipped)}건(추적불가 — story #2335 AC5, «못 잡는 것»의 크기)")
+
+    if new_violations:
+        print("\nFAIL: 베이스라인에 없는 «새» 위반 — 라우터 함수를 직접호출하며 Query(...) 파라미터를 "
+              "명시로 안 넘긴 자리(센티널이 새어 들어갈 수 있다):")
+        for v in new_violations:
+            print(f"  {v.file}:{v.line} {v.func_name}() — 누락: {sorted(v.missing)}")
+        return 1
+
+    if grandfathered:
+        print(f"\n(참고) 베이스라인 grandfather {len(grandfathered)}건은 실패시키지 않음(AC6 — 41건 개별수리는 이 판이 아니다):")
+        for v in grandfathered:
+            print(f"  {v.file}:{v.line} {v.func_name}() — 누락: {sorted(v.missing)}")
+
+    if result.skipped:
+        print(f"\n못 잡는 것(SKIPPED {len(result.skipped)}건 — story #2335 AC5, 스크립트 docstring 참조):")
+        for s in result.skipped:
+            print(f"  {s}")
+
+    print("\nOK: 새 위반 0건")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/query_sentinel_baseline.txt
+++ b/backend/scripts/query_sentinel_baseline.txt
@@ -1,0 +1,13 @@
+# story #2335 grandfather 베이스라인 — 2026-07-30 lint 첫 도입 시점 develop의 기존 위반
+# AC6 판정: 조용히 틀리는 것 0건(전부 크래시)이라 개별 수리는 이 판이 아니다 — 그래서
+# 여기 있는 항목은 실패시키지 않는다. 새 위반(여기 없는 것)만 CI를 빨갛게 한다.
+# 형식: 파일::함수::정렬된누락파라미터(콤마구분) — 라인번호는 고의로 안 담는다(편집마다 흔들림).
+tests/test_1970_gate_single_get.py::list_gates::sort
+tests/test_1972_gate_risk_grade.py::list_gates::sort
+tests/test_2188_no_sprint_alone_contract_pin.py::list_stories::boost_candidates_from
+tests/test_2198_non_doc_gate_authz_realdb.py::list_gates::sort
+tests/test_2206_story_comments_activities_org_scope_realdb.py::list_activities::cursor
+tests/test_ca37b2b0_stories_ids_batch_realdb.py::list_stories::assignee_id,boost_candidates_from,cursor,epic_id,limit,no_sprint,project_id,q,sprint_id,status_filter,story_number
+tests/test_chat_visibility_admin_bypass.py::list_messages::before,limit,thread_id
+tests/test_gate_decider_can_approve_89484c8c.py::list_gates::sort
+tests/test_gate_inbox_doc_enrich.py::list_gates::sort

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,4 +1,31 @@
-"""Shared pytest fixtures for backend tests."""
+"""Shared pytest fixtures for backend tests.
+
+⛔⛔라우터 함수를 직접 호출할 때: `Query(...)`/`Depends(...)` 기본값은 실값이 아니라
+«센티널 객체»다 — 명시로 안 넘기면 그 객체 자체가 그대로 들어간다(story #2191이 2026-07-XX
+`test_2193_doc_summary_created_at_realdb.py`에서 처음 겪었고, #2659(2026-07-30)가 CI 21건
+실패로 같은 병을 두 번째로 냈다).
+
+`x: T | None = Query(default=None)`의 실제 기본값은 `fastapi.params.Query` 인스턴스다 —
+FastAPI가 **실제 HTTP 요청 경로**를 탈 때만 이 센티널을 실값(쿼리 파라미터 또는 None)으로
+해소한다. 이 코드베이스는 라우터 함수를 `client.get(...)`(HTTP 경유) 대신 `await
+list_stories(...)`처럼 **직접 호출**하는 테스트가 흔한데(HTTP 왕복 없이 빠르게 wiring만
+보려는 것), 그 경로에서는 FastAPI의 해소가 안 일어난다 — 파라미터를 안 넘기면 센티널
+객체가 그대로 함수 안으로 들어가고, `if x is not None:` 같은 가드는 그 객체를 "값이 있다"고
+착각해 통과시킨다(크래시하거나, 더 나쁘면 조용히 틀린 분기를 탄다).
+
+⇒ ⭐**규율: 라우터 함수를 직접 호출하는 테스트는 그 함수가 선언한 `Query(...)`/`Depends(...)`
+파라미터를 «전부» 명시로 넘겨라** — 하나라도 빠뜨리면 안 된다.
+
+⛔이 규율이 지켜지는지는 CI의 `scripts/lint_query_sentinel_direct_calls.py`(story #2335,
+"Query(None) sentinel direct-call lint" 잡)가 AST로 자동 대조한다 — 새로 빠뜨리면 그 잡이
+빨개진다. 다만 그 lint를 처음 켠 시점(2026-07-30) develop에 이미 있던 위반은
+`scripts/query_sentinel_baseline.txt`에 grandfather로 남아 있다(전부 실행 시 크래시로
+드러나는 것이 실측 확認됐고 — 조용히 틀리는 사례는 0건이었다 — 그래서 개별 수리는 안 하기로
+판정됐다, story #2335 AC6). 새 테스트를 쓸 때 이 주석을 «봤어야» 그 병을 세 번째로 안 낸다
+— 지금까지는 이 주석이 `test_2193_*.py` 파일 안에만 있어서 그 파일을 여는 사람만 읽었다
+(story #2335가 잡은 세 번째 재발의 근본 원인). 이 conftest.py는 모든 테스트 파일이 로드
+시점에 거치는 자리라, 여기 적어야 «다음 사람도» 읽는다.
+"""
 import ast
 import os
 import re

--- a/backend/tests/test_2335_query_sentinel_lint.py
+++ b/backend/tests/test_2335_query_sentinel_lint.py
@@ -1,0 +1,162 @@
+"""story #2335([클래스 봉인]) — Query(None) 센티널 직접호출 lint(scripts/
+lint_query_sentinel_direct_calls.py) 자체를 검증한다. 실PG 불요(순수 AST 정적분석).
+
+⛔영구 양성표본(AC2): 실물 test_2188_no_sprint_alone_contract_pin.py:80이 지금 이 위반을
+보여주지만, 그 파일이 언젠가 고쳐지면(boost_candidates_from을 명시로 넘기게 되면) 살아있는
+표본이 사라진다 — 그러면 "이 lint가 진짜 잡는가"를 다음에 재확認할 길이 없다(PO 지적,
+2026-07-30). 그래서 이 테스트 파일 자체가 고정 fixture(문자열 소스)로 별도의 양성표본을
+하나 둔다 — 실물 site가 고쳐져도 이 표본은 그대로 살아있다.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+from lint_query_sentinel_direct_calls import (  # noqa: E402
+    find_router_functions,
+    scan_test_file,
+)
+
+_ROUTER_SOURCE = '''
+from fastapi import Query
+
+async def list_things(
+    project_id: str | None = Query(default=None),
+    q: str | None = Query(default=None),
+    limit: int = Query(default=50),
+):
+    ...
+'''
+
+_MODULE = "app.routers.things"
+
+
+def _router_functions():
+    return {_MODULE: {fi.name: fi for fi in find_router_functions(_ROUTER_SOURCE, _MODULE)}}
+
+
+def test_find_router_functions_collects_query_params_only():
+    """limit도 Query(...)를 쓰지만 기본값이 None이 아니어도(50) 여전히 센티널 객체이므로
+    잡혀야 한다 — «None 기본값»이 아니라 «Query(...) 자체»가 위험축임을 고정."""
+    funcs = find_router_functions(_ROUTER_SOURCE, _MODULE)
+    assert len(funcs) == 1
+    assert funcs[0].name == "list_things"
+    assert funcs[0].query_params == {"project_id", "q", "limit"}
+
+
+# ─── ⭐AC2 — 영구 양성표본: 파라미터를 «아예 안 넘기는» 직접호출 ───────────────
+
+
+def test_direct_call_omitting_query_param_is_flagged():
+    test_source = '''
+from app.routers.things import list_things
+
+async def test_something():
+    result = await list_things(project_id="p1")
+    assert result is None
+'''
+    result = scan_test_file(test_source, "tests/test_fixture.py", _router_functions())
+    assert len(result.violations) == 1
+    v = result.violations[0]
+    assert v.func_name == "list_things"
+    assert v.missing == {"q", "limit"}
+
+
+# ─── ⭐AC3 — 음성대조: 전부 명시로 넘기면 오탐 없음 ─────────────────────────
+
+
+def test_direct_call_passing_all_query_params_is_not_flagged():
+    test_source = '''
+from app.routers.things import list_things
+
+async def test_something():
+    result = await list_things(project_id="p1", q="hello", limit=10)
+    assert result is None
+'''
+    result = scan_test_file(test_source, "tests/test_fixture.py", _router_functions())
+    assert result.violations == []
+    assert result.skipped == []
+
+
+def test_http_client_call_is_not_a_direct_call_and_not_flagged():
+    """client.get(...)(실제 HTTP 경유)은 이 lint의 대상이 아니다 — FastAPI가 정상적으로
+    센티널을 해소하므로 새지 않는다. import는 있지만 함수를 직접 부르지 않는 경우도 안전."""
+    test_source = '''
+from app.routers.things import list_things
+
+async def test_something(client):
+    resp = await client.get("/api/v2/things", params={"project_id": "p1"})
+    assert resp.status_code == 200
+'''
+    result = scan_test_file(test_source, "tests/test_fixture.py", _router_functions())
+    assert result.violations == []
+
+
+def test_dict_literal_splat_with_all_keys_is_not_flagged():
+    """dict(...) 리터럴로 만든 뒤 **splat — 모든 키가 있으면 오탐 없어야 한다(추적 성공 케이스)."""
+    test_source = '''
+from app.routers.things import list_things
+
+async def test_something():
+    params = dict(project_id="p1", q="hello", limit=10)
+    result = await list_things(**params)
+    assert result is None
+'''
+    result = scan_test_file(test_source, "tests/test_fixture.py", _router_functions())
+    assert result.violations == []
+    assert result.skipped == []
+
+
+def test_dict_literal_splat_missing_a_key_is_flagged():
+    """dict(...) 리터럴 추적이 성공하면 «빠진 키»도 정확히 잡아야 한다(test_2188_no_sprint_
+    alone_contract_pin.py의 실물 모양 — 간접화 «한 단계»는 추적한다)."""
+    test_source = '''
+from app.routers.things import list_things
+
+async def test_something():
+    params = dict(project_id="p1", limit=10)
+    result = await list_things(**params)
+    assert result is None
+'''
+    result = scan_test_file(test_source, "tests/test_fixture.py", _router_functions())
+    assert len(result.violations) == 1
+    assert result.violations[0].missing == {"q"}
+
+
+def test_opaque_kwargs_forwarding_is_skipped_not_flagged_and_not_cleared():
+    """⭐AC5의 핵심 — `**kwargs`가 다른 함수의 진짜 **kwargs 파라미터라 리터럴로 추적이
+    안 되면, 「안전」도 「위반」도 아니라 SKIPPED로 남아야 한다(test_2188_list_backlog_
+    filter_drop_realdb.py의 실물 모양)."""
+    test_source = '''
+from app.routers.things import list_things
+
+async def _call_list_things(**kwargs):
+    params = dict(project_id=None, q=None, limit=50)
+    params.update(kwargs)
+    return await list_things(**params)
+'''
+    result = scan_test_file(test_source, "tests/test_fixture.py", _router_functions())
+    assert result.violations == []
+    assert len(result.skipped) == 1
+    assert "추적불가" in result.skipped[0]
+
+
+def test_function_name_collision_across_modules_is_not_confused():
+    """⭐AC5④의 핵심 — story #2335를 촉발한 실제 사례(list_docs가 라우터·MCP 툴 둘 다에
+    있던 것)를 고정 회귀가드로 만든다. 같은 이름 다른 모듈에서 온 함수는 무관해야 한다."""
+    test_source = '''
+from app.other_module.things import list_things
+
+async def test_something():
+    result = await list_things()
+    assert result is None
+'''
+    result = scan_test_file(test_source, "tests/test_fixture.py", _router_functions())
+    assert result.violations == [], "다른 모듈(app.other_module.things)의 동명함수를 라우터로 착각하면 안 된다"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
같은 병이 두 번 났다 — #2191(테스트 주석에만 남고 코드가드 안 고침) → #2659(까심, `boost_candidates_from` 추가 시 CI 21건 실패). 오늘 전수 스윕 결과 위험한 12건 전부 **크래시**(asyncpg DataError/AttributeError)이지 조용히 틀리는 것은 0건 — CI가 이미 잡으므로 41건 개별 수리는 값이 없다(PO 판정). 진짜 문제는 "그 자가 사고 난 뒤에야 울린다"는 것 — 그래서 이 PR은 41건을 고치지 않고 **클래스를 막는 lint**를 짓는다.

## Changes
- `backend/scripts/lint_query_sentinel_direct_calls.py` — `app/routers/*.py`의 `Query(...)` 파라미터 선언과 `tests/`의 직접호출부 명시인자를 AST로 대조. import 문으로 정확한 모듈 출처를 추적해 함수명 충돌(story #2335를 촉발한 실사례 — `list_docs`가 라우터/MCP 툴 둘 다에 있던 것)을 피한다. `dict(...)` 리터럴 한 단계까지는 `**kwargs` 간접화를 추적하고, 그보다 복잡한 경로는 SKIPPED로 남긴다(오탐 방지 우선 — "모른다"가 정확한 답, "안전하다"가 아님).
- `backend/scripts/query_sentinel_baseline.txt` — grandfather 베이스라인. lint 도입 시점 develop에 이미 있던 위반 9개 키(15개 호출부가 이 9개로 수렴)는 실패시키지 않는다 — 41건 개별 수리는 이 판이 아니라는 PO 판정 그대로. 베이스라인에 없는 **새** 위반만 CI를 빨갛게 한다.
- CI에 새 잡 "Query(None) sentinel direct-call lint (guard)" 추가 — 순수 AST 정적분석이라 DB/의존성 없이 `python3` stdlib만으로 돈다(빠름, 5분 타임아웃).
- `backend/tests/test_2335_query_sentinel_lint.py` — lint 자체의 영구 회귀가드(8건, 실PG 불요). 실물 `test_2188_no_sprint_alone_contract_pin.py:80`가 나중에 고쳐져도 이 fixture는 그대로 남아 양성/음성 대조를 계속 증명한다. 함수명 충돌 회귀가드 포함.
- `backend/tests/conftest.py` — #2191의 경고가 `test_2193_*.py` 파일 안에만 있어서 "그 파일을 여는 사람만" 읽었다(세 번째 재발의 근본 원인). 모든 테스트가 로드하는 conftest.py 모듈 docstring으로 옮겼다.

## 실측 (2026-07-30)
- 현재 develop 전체 스캔: 위반 15건(호출부 단위, 유일 (함수,파라미터)쌍 16개) · SKIPPED 4건(전부 `list_stories`, `**kwargs` 간접화로 추적불가).
- 실물 살아있는 표본으로 확認: `test_2188_no_sprint_alone_contract_pin.py:80`(순수 명시 kwargs, 간접화 없음)이 `boost_candidates_from`을 지금도 안 넘기고 있어 lint 실행 즉시 잡힘.

## 뮤테이션 자가검증 (로컬)
`missing` 계산을 무력화 → `test_2335_query_sentinel_lint.py`의 정확히 2건이 RED → 복원 후 그린 재확認.

## ⛔이 lint가 못 잡는 것 (스크립트 docstring에 상세)
- 동적/`getattr` 호출 — 정적으로 특정 못 하면 검사 안 함.
- 라우터 밖(서비스 계층) 같은 패턴 — 스코프 밖(실사례 없음).
- `**kwargs` 간접화가 `dict(...)` 리터럴 한 단계를 넘으면 추적불가 → SKIPPED("모른다"가 정확한 답, 확인하려면 직접 호출해 봐야 한다 — 오늘 12건을 그렇게 쟀다).
- 41건 자체가 하한이었다(함수명 충돌로 grep이 놓친 전례) — 이 lint는 import로 그 충돌은 막지만 다른 종류의 충돌 가능성은 남는다.

## Test plan
- [x] 신규 8건(test_2335_query_sentinel_lint.py) — 전부 그린, 실PG 불요.
- [x] 회귀 35건(test_stories.py 등) — conftest.py 변경 후에도 그린.
- [x] `python3 scripts/lint_query_sentinel_direct_calls.py` 로컬 실행 — 베이스라인 대비 새 위반 0건.
- [x] 뮤테이션 자가검증 — 위 참조.
- [x] actionlint로 워크플로 YAML 구문 검증.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>