### PR TITLE
revert(#2328): 후보 머리글 em-dash 리터럴 되돌림 (PR#2668 정정)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -555,7 +555,7 @@
       "typeDepends": "Depends",
       "searchPlaceholder": "Search by story title...",
       "incompletePreds": "{count} incomplete predecessor(s) — check before starting",
-      "candidatesHeader": "── Found in this story's body ──",
+      "candidatesHeader": "Found in this story's body",
       "candidateMentionHint": "Mentioned in this story's body"
     }
   },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -555,7 +555,7 @@
       "typeDepends": "의존",
       "searchPlaceholder": "스토리 제목으로 검색...",
       "incompletePreds": "미완료 선행 {count}건 — 시작 전 확인 권장",
-      "candidatesHeader": "── 이 스토리 본문에 나온 것 ──",
+      "candidatesHeader": "이 스토리 본문에 나온 것",
       "candidateMentionHint": "이 스토리 본문에 나옵니다"
     }
   },

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -1791,6 +1791,11 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                     return (
                       <ul className="focus-inset max-h-32 overflow-y-auto rounded border border-border bg-background">
                         {showingCandidates && (
+                          // story #2328 — 유나 규격 원문의 「── ... ──」는 "구분선이 있다"를
+                          // 아스키로 흉내낸 표기였지 문자로 넣으라는 뜻이 아니었다(2026-07-30
+                          // 확定, PR#2668 되돌림). 스크린리더가 "대시 대시 대시"로 읽고, 폰트별
+                          // 길이가 달라지고, 번역 시 좌우 정렬이 무너진다 — 선이 필요하면 CSS로
+                          // 긋고 문자는 머리글 텍스트만 남긴다.
                           <li aria-hidden className="px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
                             {t('dep.candidatesHeader')}
                           </li>


### PR DESCRIPTION
## 요약
PR#2668("em-dash 누락 정정")은 방향이 반대였다. 유나 판정(2026-07-30): 규격 원문의 「── ... ──」는 목업에서 "구분선이 있다"를 아스키로 흉내낸 표기였지, 문자 그대로 넣으라는 뜻이 아니었다. 실물(em-dash 없음, PR#2662 원안)이 옳았고 규격을 고친다.

## 근거 (유나, 셋 다 다른 종류)
- ①스크린리더가 "대시 대시 대시"로 읽는다 — 장식이 내용으로 발화됨
- ②폰트마다 대시 길이가 달라진다 — 코드가 통제 못 함
- ③번역 시 en 문구 길이가 달라 좌우 정렬이 무너진다

⇒ 선이 필요하면 CSS로 긋고, 문자는 머리글 텍스트만 남긴다.

## 변경
- `dep.candidatesHeader`(ko/en) em-dash 리터럴 제거 — PR#2668 이전 상태로 복귀.
- 렌더 지점에 "왜 없는가"를 코드 주석으로 남김 — 다음 사람이 "빠졌다"고 오인해 또 넣는 것 방지(오늘 이미 제가 그 오인을 한 사람이었음).

## 검증
- 이 문구를 직접 assert하는 테스트 없음(순수 판정 로직만 격리 테스트) — 회귀 리스크 없음.
- `pnpm vitest run` 318/318 · `pnpm tsc --noEmit` 클린 · `pnpm lint` 0 errors · `pnpm build` EXIT 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)