### PR TITLE
docs: E-MODERN Track C 코드 코멘트 조각 이름 붙이기(이름 겹침 정정)

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -8,7 +8,10 @@ import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { Button } from '@/components/ui/button';
 import { CommandCenter } from '@/components/dashboard/command-center/command-center';
 
-// E-MODERN [Track C] 커맨드 센터로 교체(현 vanity 위젯 제거). 헤더+2구역·canonical 부품·pending_data graceful.
+// E-MODERN [Track C/command-center] 커맨드 센터로 교체(현 vanity 위젯 제거). 헤더+2구역·canonical
+// 부품·pending_data graceful. ⚠️이 "Track C"는 command-center라는 «조각» 이름이지, E-MODERN
+// 블루프린트(doc: e-modern-modernization-blueprint)의 전략 Track C("UI 갈아엎기" 전체)가 아니다
+// — 같은 글자가 두 다른 체계에서 쓰여 "Track C 했다"가 어느 쪽인지 헷갈리던 것을 정정(2026-07-30).
 // 데이터는 CommandCenter(client)가 org-scope BE 2엔드포인트로 자체 fetch — 서버 prefetch 불요.
 export default async function DashboardPage() {
   const t = await getTranslations('dashboard');

--- a/apps/web/src/components/dashboard/command-center/command-center.tsx
+++ b/apps/web/src/components/dashboard/command-center/command-center.tsx
@@ -10,9 +10,15 @@ import { OverviewZone } from './overview-zone';
 import { derivePhrase } from '@/services/glance';
 
 /**
- * E-MODERN [Track C] 커맨드 센터 — 현 대시보드 위젯 교체. 2구역+헤더.
+ * E-MODERN [Track C/command-center] 커맨드 센터 — 현 대시보드 위젯 교체. 2구역+헤더.
  * "괜찮다 / 내가 OO 해야" 한눈에. canonical 부품·색=신호·pending_data graceful(mock-0 금지).
  * 데이터: org-scope BE 2엔드포인트(caller 쿠키 resolve·param 불요) + team-members(이름 resolve).
+ *
+ * ⚠️이 "Track C"는 command-center라는 «조각» 이름이지, E-MODERN 블루프린트
+ * (doc: e-modern-modernization-blueprint)의 전략 Track C("UI 갈아엎기" 전체 — 디자인시스템
+ * enforcement·god-component 분해·랜딩 편입·alert→ConfirmDialog 등)가 아니다. 같은 글자가
+ * 두 다른 체계에서 쓰여 "Track C 했다"가 어느 쪽인지 헷갈리던 것을 정정(2026-07-30) —
+ * 이 커맨드 센터는 전략 Track C의 «한 조각»일 뿐, 전체가 아니다.
  */
 
 function unwrap<T>(json: unknown): T | null {


### PR DESCRIPTION
## 요약
「E-MODERN [Track C]」 코드 코멘트가 전략 레벨 Track C(E-MODERN 블루프린트, "UI 갈아엎기" 전체)와 이름이 같아 "Track C 했다"가 어느 쪽인지 구분이 안 되던 것을 정정. 오늘 보드+현황판 통합 조사 중 발견.

## 변경
- `apps/web/src/app/dashboard/page.tsx`, `apps/web/src/components/dashboard/command-center/command-center.tsx` — 코드 코멘트만 「[Track C/command-center]」로 조각 이름 부여, 전략 Track C와의 관계를 명시.
- 순수 코멘트 변경 — 로직/렌더 무영향.

## 검증
- `pnpm tsc --noEmit` 클린 · `pnpm lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)