### PR TITLE
feat(#2224 S2-1): epics-progress-lane — 좌측 레인 진행/대기/막힘/멈춤 한 번의 호출

### DIFF
--- a/backend/app/repositories/analytics.py
+++ b/backend/app/repositories/analytics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import datetime, timezone
 
@@ -9,6 +10,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.gate import Gate
 from app.models.pm import Goal, Sprint, Story, Task
 from app.models.team import TeamMember
+
+logger = logging.getLogger(__name__)
 
 
 class AnalyticsRepository:
@@ -238,6 +241,27 @@ class AnalyticsRepository:
             )
         )
         blocked_ids = set(blocked_r.scalars().all())
+
+        # ⭐PO 지적(2026-07-30): ㉡류(pending Gate가 매였는데 위 좁힌 조건을 못 채워 blocked
+        # 밖으로 빠진 것)가 늘어나는 것을 "누가 아는가"가 남는다 — 칸(응답 필드)을 새로
+        # 만들지 않아도 «셀 수는» 있게, 매 호출마다 로그로 남긴다(dev 실측 2026-07-30: 1건).
+        gated_not_blocked_r = await self.session.execute(
+            select(func.count(Gate.work_item_id.distinct())).where(
+                Gate.org_id == self.org_id,
+                Gate.work_item_type == "story",
+                Gate.work_item_id.in_(story_ids),
+                Gate.status == "pending",
+                ~((Gate.requires_human.is_(True)) & (Gate.evidence_status == "insufficient")),
+            )
+        )
+        gated_not_blocked_count = gated_not_blocked_r.scalar_one()
+        if gated_not_blocked_count:
+            logger.info(
+                "get_epics_progress_lane: gated-but-not-blocked(㉡) count=%d project_id=%s "
+                "(pending Gate 있으나 requires_human/evidence_status 조건 미충족 — other에 섞임, "
+                "story #2224 PO 지적 — 늘면 별도 칸 분리 검토)",
+                gated_not_blocked_count, project_id,
+            )
 
         from app.services.next_action import next_action_category, verification_next_action
 

--- a/backend/app/repositories/analytics.py
+++ b/backend/app/repositories/analytics.py
@@ -180,14 +180,20 @@ class AnalyticsRepository:
         project 전체 에픽의 네 칸을 낸다.
 
         분류 우선순위(겹치는 신호를 하나로 정리하는 순서 — 다른 순서를 쓰면 답이 달라진다):
-          ①막힘(blocked)   = 그 story에 매인 pending 상태 Gate가 있다(§4-5 "문")
+          ①막힘(blocked)   = 그 story에 매인 pending Gate가 있고 requires_human=true·
+                              evidence_status='insufficient'다(§4-5 "문" · 민 실측 32건과
+                              같은 자로 맞춤 — PO 확認 요청에 따라 필터를 일치시켰다. 그냥
+                              "pending Gate 매임"만 쓰면 민 수와 다른 정의가 같은 화면에
+                              두 벌 서는 것이었다).
           ②대기(waiting)   = ①이 아니고 next_action_category=='waiting'(#2262 SSOT 재사용 —
                               verification_pending: self_reported=True·아직 human_verified 안 됨)
           ③진행(in_progress) = ①②가 아니고 status=='in-progress'
           ④멈춤(stalled)   = ①②③이 아니고 status!='done'이고 168시간(민 실측 — §7-③의 "48h"는
                               07-23 시안 값·미재측정, 문서로 남은 값은 168h) 넘게 updated_at 불변
-          그 외(backlog·ready-for-dev·in-review인데 최근 변경된 것·done)는 네 칸 어디에도 안
-          잡힌다 — 합계가 total_stories와 다를 수 있다(의도된 것, 지어내지 않는다).
+          ⑤그 외(other)    = ①~④ 어디에도 안 잡힘(backlog·ready-for-dev·in-review 중 최근
+                              변경된 것 · done) — ⛔PO 지적(2026-07-30): "합계≠total_stories는
+                              의도했어도 화면에서는 거짓말이 된다" — 그래서 이 칸도 명시로 낸다.
+                              in_progress+waiting+blocked+stalled+other == total_stories 항상 성립.
 
         ⛔이 우선순위·168h 임계 둘 다 «잠정»이다 — #2218(S0-1)이 임계를 실측(8~12건 나오는
         값)해 재확定하기 전까지 쓰는 값. 화면에 "이 수는 잠정"이라는 신호를 실어야 한다면
@@ -214,6 +220,8 @@ class AnalyticsRepository:
                 Gate.work_item_type == "story",
                 Gate.work_item_id.in_(story_ids),
                 Gate.status == "pending",
+                Gate.requires_human.is_(True),
+                Gate.evidence_status == "insufficient",
             )
         )
         blocked_ids = set(blocked_r.scalars().all())
@@ -227,7 +235,8 @@ class AnalyticsRepository:
         for s in stories:
             epic_key = str(s.epic_id)
             lane = lanes.setdefault(
-                epic_key, {"in_progress": 0, "waiting": 0, "blocked": 0, "stalled": 0}
+                epic_key,
+                {"in_progress": 0, "waiting": 0, "blocked": 0, "stalled": 0, "other": 0},
             )
             if s.id in blocked_ids:
                 lane["blocked"] += 1
@@ -245,6 +254,8 @@ class AnalyticsRepository:
                 age_hours = (now - s.updated_at).total_seconds() / 3600
                 if age_hours > stall_threshold_hours:
                     lane["stalled"] += 1
+                    continue
+            lane["other"] += 1  # done, 또는 backlog/ready-for-dev/in-review 중 최근 변경된 것
         return lanes
 
     async def get_agent_stats(self, project_id: uuid.UUID, agent_id: uuid.UUID) -> dict:

--- a/backend/app/repositories/analytics.py
+++ b/backend/app/repositories/analytics.py
@@ -190,10 +190,23 @@ class AnalyticsRepository:
           ③진행(in_progress) = ①②가 아니고 status=='in-progress'
           ④멈춤(stalled)   = ①②③이 아니고 status!='done'이고 168시간(민 실측 — §7-③의 "48h"는
                               07-23 시안 값·미재측정, 문서로 남은 값은 168h) 넘게 updated_at 불변
-          ⑤그 외(other)    = ①~④ 어디에도 안 잡힘(backlog·ready-for-dev·in-review 중 최근
-                              변경된 것 · done) — ⛔PO 지적(2026-07-30): "합계≠total_stories는
+          ⑤그 외(other)    = ①~④ 어디에도 안 잡힘 — ⛔PO 지적(2026-07-30): "합계≠total_stories는
                               의도했어도 화면에서는 거짓말이 된다" — 그래서 이 칸도 명시로 낸다.
                               in_progress+waiting+blocked+stalled+other == total_stories 항상 성립.
+
+        ⛔`other`에 실제로 드는 것 둘(성질이 다름, PO 지적 2026-07-30 — dev 실측 2026-07-30):
+          ㉠정상적으로 네 칸 밖(최근 168h 이내 변경된 backlog/ready-for-dev/in-review · done)
+            — dev 실측 약 2050/2079건, 압도 다수.
+          ㉡pending Gate가 매여 있는데 requires_human=false 또는 evidence_status가
+            'insufficient'가 아니라 ①막힘에서 빠진 것 — dev 실측 **1건**
+            (requires_human=False·evidence_status=None). 「승인도 자동 통과도 안 되는 결재」
+            류와 같은 냄새(#2261 계열)나 n=1이라 이 함수에서 별도 칸을 새로 만들지 않는다
+            — 필요해지면(건수가 늘면) 그때 쪼갠다. 지금은 ㉠과 ㉡을 `other` 하나로 합친 채
+            이 사실만 기록해 둔다(다음 사람이 "other=잡동사니"로 오인하지 않게).
+          참고: ①막힘(narrow) dev 실측 28건 — 민 실측 32건과 4건 차이는 **확認됨**: 이
+          함수는 epic_id가 있는 story만 레인에 담는데(에픽 좌측 레인이 목적이므로), 막힌
+          32건 중 4건이 epic_id가 없다(dev 실측). 버그 아님 — 이 엔드포인트의 스코프
+          자체가 "에픽에 속한 것"이라 그 4건은 애초에 이 화면의 대상이 아니다.
 
         ⛔이 우선순위·168h 임계 둘 다 «잠정»이다 — #2218(S0-1)이 임계를 실측(8~12건 나오는
         값)해 재확定하기 전까지 쓰는 값. 화면에 "이 수는 잠정"이라는 신호를 실어야 한다면

--- a/backend/app/repositories/analytics.py
+++ b/backend/app/repositories/analytics.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.gate import Gate
 from app.models.pm import Goal, Sprint, Story, Task
 from app.models.team import TeamMember
 
@@ -172,6 +173,79 @@ class AnalyticsRepository:
             "done_points": done_pts,
             "completion_pct": round((done / total) * 100) if total > 0 else 0,
         }
+
+    async def get_epics_progress_lane(self, project_id: uuid.UUID) -> dict[str, dict]:
+        """story #2224(S2-1, 갈래 화면) 좌측 레인 — 미르코 실측: `EpicProgress`에 진행/대기/
+        막힘/멈춤 네 칸이 없어 레인이 반만 선다. 에픽마다 따로 부르면 N+1이라 «한 번의 호출»로
+        project 전체 에픽의 네 칸을 낸다.
+
+        분류 우선순위(겹치는 신호를 하나로 정리하는 순서 — 다른 순서를 쓰면 답이 달라진다):
+          ①막힘(blocked)   = 그 story에 매인 pending 상태 Gate가 있다(§4-5 "문")
+          ②대기(waiting)   = ①이 아니고 next_action_category=='waiting'(#2262 SSOT 재사용 —
+                              verification_pending: self_reported=True·아직 human_verified 안 됨)
+          ③진행(in_progress) = ①②가 아니고 status=='in-progress'
+          ④멈춤(stalled)   = ①②③이 아니고 status!='done'이고 168시간(민 실측 — §7-③의 "48h"는
+                              07-23 시안 값·미재측정, 문서로 남은 값은 168h) 넘게 updated_at 불변
+          그 외(backlog·ready-for-dev·in-review인데 최근 변경된 것·done)는 네 칸 어디에도 안
+          잡힌다 — 합계가 total_stories와 다를 수 있다(의도된 것, 지어내지 않는다).
+
+        ⛔이 우선순위·168h 임계 둘 다 «잠정»이다 — #2218(S0-1)이 임계를 실측(8~12건 나오는
+        값)해 재확定하기 전까지 쓰는 값. 화면에 "이 수는 잠정"이라는 신호를 실어야 한다면
+        이 함수가 아니라 호출부(FE 계약)의 몫이다."""
+        stories_r = await self.session.execute(
+            select(Story.id, Story.epic_id, Story.status, Story.updated_at).where(
+                Story.project_id == project_id,
+                Story.org_id == self.org_id,
+                Story.deleted_at.is_(None),
+                Story.epic_id.is_not(None),
+            )
+        )
+        stories = stories_r.all()
+        story_ids = [s.id for s in stories]
+
+        from app.services.evidence_service import batch_has_evidence, batch_human_verified
+
+        evidence_ids = await batch_has_evidence(self.session, story_ids, "story")
+        verified_map = await batch_human_verified(self.session, story_ids, "story")
+
+        blocked_r = await self.session.execute(
+            select(Gate.work_item_id.distinct()).where(
+                Gate.org_id == self.org_id,
+                Gate.work_item_type == "story",
+                Gate.work_item_id.in_(story_ids),
+                Gate.status == "pending",
+            )
+        )
+        blocked_ids = set(blocked_r.scalars().all())
+
+        from app.services.next_action import next_action_category, verification_next_action
+
+        now = datetime.now(timezone.utc)
+        stall_threshold_hours = 168  # 민 실측(문서 기록값) — 48h는 07-23 시안의 미재측정 값
+
+        lanes: dict[str, dict] = {}
+        for s in stories:
+            epic_key = str(s.epic_id)
+            lane = lanes.setdefault(
+                epic_key, {"in_progress": 0, "waiting": 0, "blocked": 0, "stalled": 0}
+            )
+            if s.id in blocked_ids:
+                lane["blocked"] += 1
+                continue
+            self_reported = s.id in evidence_ids
+            human_verified = True if s.id in verified_map else None
+            code = verification_next_action(self_reported=self_reported, human_verified=human_verified)
+            if next_action_category(code) == "waiting":
+                lane["waiting"] += 1
+                continue
+            if s.status == "in-progress":
+                lane["in_progress"] += 1
+                continue
+            if s.status != "done":
+                age_hours = (now - s.updated_at).total_seconds() / 3600
+                if age_hours > stall_threshold_hours:
+                    lane["stalled"] += 1
+        return lanes
 
     async def get_agent_stats(self, project_id: uuid.UUID, agent_id: uuid.UUID) -> dict:
         member_r = await self.session.execute(

--- a/backend/app/repositories/analytics.py
+++ b/backend/app/repositories/analytics.py
@@ -225,6 +225,26 @@ class AnalyticsRepository:
         stories = stories_r.all()
         story_ids = [s.id for s in stories]
 
+        # ⭐PO 판정(2026-07-30, 에픽 없는 막힘 4건 건): "미배정" 레인은 안 만든다(만들면 에픽
+        # 안 다는 것이 "괜찮은 일"이 되어 그 줄이 계속 자란다) — 대신 «에픽 없는 story 전량»을
+        # 셀 수 있게 로그로 남긴다(㉡류와 같은 방식 — 칸은 안 만들되 0이 아니면 누군가 안다).
+        no_epic_count_r = await self.session.execute(
+            select(func.count(Story.id)).where(
+                Story.project_id == project_id,
+                Story.org_id == self.org_id,
+                Story.deleted_at.is_(None),
+                Story.epic_id.is_(None),
+            )
+        )
+        no_epic_count = no_epic_count_r.scalar_one()
+        if no_epic_count:
+            logger.info(
+                "get_epics_progress_lane: epic 없는 story count=%d project_id=%s "
+                "(이 레인 자체에서 영영 안 보임 — story #2224 PO 판정: 미배정 레인을 만들지 "
+                "않고 PO가 직접 에픽에 붙인다, 이 로그는 재발 감지용)",
+                no_epic_count, project_id,
+            )
+
         from app.services.evidence_service import batch_has_evidence, batch_human_verified
 
         evidence_ids = await batch_has_evidence(self.session, story_ids, "story")

--- a/backend/app/repositories/analytics.py
+++ b/backend/app/repositories/analytics.py
@@ -177,7 +177,7 @@ class AnalyticsRepository:
             "completion_pct": round((done / total) * 100) if total > 0 else 0,
         }
 
-    async def get_epics_progress_lane(self, project_id: uuid.UUID) -> dict[str, dict]:
+    async def get_epics_progress_lane(self, project_id: uuid.UUID) -> dict:
         """story #2224(S2-1, 갈래 화면) 좌측 레인 — 미르코 실측: `EpicProgress`에 진행/대기/
         막힘/멈춤 네 칸이 없어 레인이 반만 선다. 에픽마다 따로 부르면 N+1이라 «한 번의 호출»로
         project 전체 에픽의 네 칸을 낸다.
@@ -213,7 +213,14 @@ class AnalyticsRepository:
 
         ⛔이 우선순위·168h 임계 둘 다 «잠정»이다 — #2218(S0-1)이 임계를 실측(8~12건 나오는
         값)해 재확定하기 전까지 쓰는 값. 화면에 "이 수는 잠정"이라는 신호를 실어야 한다면
-        이 함수가 아니라 호출부(FE 계약)의 몫이다."""
+        이 함수가 아니라 호출부(FE 계약)의 몫이다.
+
+        ⛔`stories_without_epic`(PO 판정 2026-07-30, dev 445건 실측 후 뒤집힘): 처음엔
+        "미배정 레인을 만들지 않는다 + PO가 4건을 직접 붙인다"였으나, 전체 445건임이 실측되며
+        "손으로 못 붙이는 규모"·"에픽 없음은 결함이 아니라 사실"로 판정이 바뀌었다. 레인은
+        여전히 안 만들되(445를 한 줄에 담으면 화면을 그 줄이 먹는다), 그 수를 **응답에
+        실어** 화면이 "에픽에 속한 것만 여기 있습니다 · 나머지 N건은 이 레인 밖입니다"를
+        정직하게 말할 수 있게 한다 — 로그만으로는 화면이 그 말을 할 수 없다."""
         stories_r = await self.session.execute(
             select(Story.id, Story.epic_id, Story.status, Story.updated_at).where(
                 Story.project_id == project_id,
@@ -313,7 +320,7 @@ class AnalyticsRepository:
                     lane["stalled"] += 1
                     continue
             lane["other"] += 1  # done, 또는 backlog/ready-for-dev/in-review 중 최근 변경된 것
-        return lanes
+        return {"lanes": lanes, "stories_without_epic": no_epic_count}
 
     async def get_agent_stats(self, project_id: uuid.UUID, agent_id: uuid.UUID) -> dict:
         member_r = await self.session.execute(

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -108,10 +108,11 @@ async def get_epics_progress_lane(
     """story #2224(S2-1, 갈래 화면) 좌측 레인 — project 전체 에픽의 진행/대기/막힘/멈춤을
     «한 번의 호출»로 낸다(미르코 실측 갭: EpicProgressResponse엔 이 네 칸이 없었다)."""
     await _assert_project_access(repo, auth, project_id)
-    lanes = await repo.get_epics_progress_lane(project_id)
+    result = await repo.get_epics_progress_lane(project_id)
     return EpicsProgressLaneResponse(
-        epics={k: EpicProgressLane.model_validate(v) for k, v in lanes.items()},
+        epics={k: EpicProgressLane.model_validate(v) for k, v in result["lanes"].items()},
         stall_threshold_hours=168,
+        stories_without_epic=result["stories_without_epic"],
     )
 
 

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -11,7 +11,9 @@ from app.repositories.analytics import AnalyticsRepository
 from app.schemas.analytics import (
     AgentStatsResponse,
     BurndownResponse,
+    EpicProgressLane,
     EpicProgressResponse,
+    EpicsProgressLaneResponse,
     MemberWorkloadResponse,
     ProjectHealthResponse,
     ProjectOverviewResponse,
@@ -95,6 +97,22 @@ async def get_epic_progress(
     await _assert_project_access(repo, auth, project_id)
     data = await repo.get_epic_progress(project_id, epic_id)
     return EpicProgressResponse.model_validate(data)
+
+
+@router.get("/analytics/epics-progress-lane", response_model=EpicsProgressLaneResponse)
+async def get_epics_progress_lane(
+    project_id: uuid.UUID = Query(...),
+    repo: AnalyticsRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+) -> EpicsProgressLaneResponse:
+    """story #2224(S2-1, 갈래 화면) 좌측 레인 — project 전체 에픽의 진행/대기/막힘/멈춤을
+    «한 번의 호출»로 낸다(미르코 실측 갭: EpicProgressResponse엔 이 네 칸이 없었다)."""
+    await _assert_project_access(repo, auth, project_id)
+    lanes = await repo.get_epics_progress_lane(project_id)
+    return EpicsProgressLaneResponse(
+        epics={k: EpicProgressLane.model_validate(v) for k, v in lanes.items()},
+        stall_threshold_hours=168,
+    )
 
 
 @router.get("/analytics/agent-stats", response_model=AgentStatsResponse)

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -99,6 +99,24 @@ class EpicProgressResponse(BaseModel):
     completion_pct: int
 
 
+class EpicProgressLane(BaseModel):
+    """story #2224(S2-1) 좌측 레인 — 미르코 실측 갭. 네 칸이 서로 겹치지 않게 우선순위로
+    정리한다(막힘>대기>진행>멈춤, AnalyticsRepository.get_epics_progress_lane 참조) —
+    합계가 그 에픽의 total_stories와 다를 수 있다(의도된 것, backlog/최근변경/done은
+    네 칸 밖)."""
+    in_progress: int
+    waiting: int
+    blocked: int
+    stalled: int
+
+
+class EpicsProgressLaneResponse(BaseModel):
+    """{epic_id(str): EpicProgressLane} — project 전체 에픽을 «한 번의 호출»로 낸다(N+1 회피).
+    ⛔잠정치: 멈춤 임계 168h는 #2218(S0-1) 재측정 전까지의 값."""
+    epics: dict[str, EpicProgressLane]
+    stall_threshold_hours: int
+
+
 class AgentStatsResponse(BaseModel):
     # S2-1 신규 지표 (stories 기반)
     completed: int

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -114,9 +114,18 @@ class EpicProgressLane(BaseModel):
 
 class EpicsProgressLaneResponse(BaseModel):
     """{epic_id(str): EpicProgressLane} — project 전체 에픽을 «한 번의 호출»로 낸다(N+1 회피).
-    ⛔잠정치: 멈춤 임계 168h는 #2218(S0-1) 재측정 전까지의 값."""
+    ⛔잠정치: 멈춤 임계 168h는 #2218(S0-1) 재측정 전까지의 값.
+
+    ⛔`stories_without_epic`(PO 판정 2026-07-30, dev 실측 445건 후 뒤집힘): 에픽 없음은
+    결함이 아니라 «사실»이다(445건이면 손으로 붙일 수 있는 규모가 아니다 — 「미배정」
+    레인은 여전히 안 만든다, 다만 이유가 바뀌었다: "나쁜 습관을 굳힐까 봐"에서 "445를
+    한 줄에 담으면 그게 제일 큰 줄이 되어 화면을 먹는다"로). 화면이 «거짓말만 안 하면»
+    된다 — 좌 레인 합계를 project 전체인 것처럼 보이지 않는다. 그래서 이 수를 응답에
+    실어 화면이 "에픽에 속한 것만 여기 있습니다 · 나머지 N건은 이 레인 밖입니다"를
+    말할 수 있게 한다."""
     epics: dict[str, EpicProgressLane]
     stall_threshold_hours: int
+    stories_without_epic: int
 
 
 class AgentStatsResponse(BaseModel):

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -100,14 +100,16 @@ class EpicProgressResponse(BaseModel):
 
 
 class EpicProgressLane(BaseModel):
-    """story #2224(S2-1) 좌측 레인 — 미르코 실측 갭. 네 칸이 서로 겹치지 않게 우선순위로
-    정리한다(막힘>대기>진행>멈춤, AnalyticsRepository.get_epics_progress_lane 참조) —
-    합계가 그 에픽의 total_stories와 다를 수 있다(의도된 것, backlog/최근변경/done은
-    네 칸 밖)."""
+    """story #2224(S2-1) 좌측 레인 — 미르코 실측 갭. 다섯 칸이 서로 겹치지 않게 우선순위로
+    정리한다(막힘>대기>진행>멈춤>other, AnalyticsRepository.get_epics_progress_lane 참조).
+    ⛔`other`(PO 지적, 2026-07-30): 「합계≠total_stories는 의도했어도 화면에서는 거짓말이
+    된다」— done, 또는 backlog/ready-for-dev/in-review 중 최근(168h 이내) 변경된 것이 여기
+    든다. in_progress+waiting+blocked+stalled+other는 그 에픽의 total_stories와 항상 같다."""
     in_progress: int
     waiting: int
     blocked: int
     stalled: int
+    other: int
 
 
 class EpicsProgressLaneResponse(BaseModel):

--- a/backend/tests/test_2224_epics_progress_lane_realdb.py
+++ b/backend/tests/test_2224_epics_progress_lane_realdb.py
@@ -86,6 +86,11 @@ async def test_epics_progress_lane_buckets_correctly_and_one_call():
             story_not_blocked.epic_id = epic.id
             story_not_blocked.status = "in-progress"
 
+            # ⑦epic 없음 — story #2224 PO 판정(2026-07-30, dev 445건 실측 후): 레인은 여전히
+            # 안 만들되 이 수는 응답에 실린다(화면이 "나머지 N건은 레인 밖" 말할 수 있게).
+            story_no_epic = await _make_story(s, org.id, project.id, title="NO_EPIC")
+            story_no_epic.status = "backlog"
+
             await s.commit()
 
             from app.models.evidence import Evidence
@@ -141,6 +146,7 @@ async def test_epics_progress_lane_buckets_correctly_and_one_call():
             # 없어 blocked에 안 잡히고, status=in-progress라 in_progress로 떨어져야 한다.
             assert sum(lane.values()) == 6, "네 칸(진행/대기/막힘/멈춤) + other == total_stories 항상 성립해야 함"
             assert body["stall_threshold_hours"] == 168
+            assert body["stories_without_epic"] == 1, "epic 없는 story(story_no_epic) 1건이 응답에 실려야 함"
             assert call_count["n"] == 1, f"repo 메서드가 {call_count['n']}번 불림(N+1 의심)"
         finally:
             await client.aclose()

--- a/backend/tests/test_2224_epics_progress_lane_realdb.py
+++ b/backend/tests/test_2224_epics_progress_lane_realdb.py
@@ -1,0 +1,133 @@
+"""story #2224(S2-1, 갈래 화면) 좌측 레인 — GET /analytics/epics-progress-lane 실PG 검증.
+미르코가 지금 `/flow`를 짓고 있어 급히 공급된 계약(2026-07-30) — 한 번의 호출로 project
+전체 에픽의 진행/대기/막힘/멈춤을 낸다."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_2301_story_body_mentions_realdb import (
+    _REAL_DB_URL,
+    _client_for,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _make_story,
+    _session_factory,
+    _setup_app_human,
+)
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def test_epics_progress_lane_buckets_correctly_and_one_call():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+
+            from app.models.pm import Goal
+            epic = Goal(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Epic A")
+            s.add(epic)
+            await s.commit()
+
+            now = datetime.now(timezone.utc)
+
+            # ①in_progress: status만 in-progress, 최근 변경
+            story_ip = await _make_story(s, org.id, project.id, title="IP")
+            story_ip.epic_id = epic.id
+            story_ip.status = "in-progress"
+
+            # ②waiting: self_reported=True, human_verified 없음(evidence 1건, gate_approval 아님)
+            story_wait = await _make_story(s, org.id, project.id, title="WAIT")
+            story_wait.epic_id = epic.id
+            story_wait.status = "in-review"
+
+            # ③blocked: pending gate 매임
+            story_blocked = await _make_story(s, org.id, project.id, title="BLOCKED")
+            story_blocked.epic_id = epic.id
+            story_blocked.status = "in-progress"  # blocked가 in_progress보다 우선순위 높아야 함
+
+            # ④stalled: status=backlog, updated_at 169시간 전
+            story_stalled = await _make_story(s, org.id, project.id, title="STALLED")
+            story_stalled.epic_id = epic.id
+            story_stalled.status = "backlog"
+
+            # ⑤uncounted: done (네 칸 어디에도 안 잡힘)
+            story_done = await _make_story(s, org.id, project.id, title="DONE")
+            story_done.epic_id = epic.id
+            story_done.status = "done"
+
+            await s.commit()
+
+            from app.models.evidence import Evidence
+            s.add(Evidence(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story_wait.id, work_item_type="story",
+                type="url", ref="https://example.com/evidence", created_by=caller_id, created_at=now,
+            ))
+            from app.models.gate import Gate
+            s.add(Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story_blocked.id, work_item_type="story",
+                gate_type="merge", status="pending",
+            ))
+            await s.commit()
+
+            # updated_at은 서버 default라 직접 UPDATE로 과거로 되돌린다(실물 "멈춤" 재현).
+            from sqlalchemy import text
+            await s.execute(
+                text("UPDATE stories SET updated_at = :t WHERE id = :id"),
+                {"t": now - timedelta(hours=169), "id": story_stalled.id},
+            )
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        call_count = {"n": 0}
+        try:
+            import app.repositories.analytics as analytics_repo_mod
+            _orig = analytics_repo_mod.AnalyticsRepository.get_epics_progress_lane
+
+            async def _counting(self, project_id):
+                call_count["n"] += 1
+                return await _orig(self, project_id)
+
+            analytics_repo_mod.AnalyticsRepository.get_epics_progress_lane = _counting
+            try:
+                resp = await client.get(
+                    "/api/v2/analytics/epics-progress-lane", params={"project_id": str(project.id)}
+                )
+            finally:
+                analytics_repo_mod.AnalyticsRepository.get_epics_progress_lane = _orig
+
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            lane = body["epics"][str(epic.id)]
+            assert lane == {"in_progress": 1, "waiting": 1, "blocked": 1, "stalled": 1}, lane
+            assert body["stall_threshold_hours"] == 168
+            assert call_count["n"] == 1, f"repo 메서드가 {call_count['n']}번 불림(N+1 의심)"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_2224_epics_progress_lane_realdb.py
+++ b/backend/tests/test_2224_epics_progress_lane_realdb.py
@@ -74,10 +74,17 @@ async def test_epics_progress_lane_buckets_correctly_and_one_call():
             story_stalled.epic_id = epic.id
             story_stalled.status = "backlog"
 
-            # ⑤uncounted: done (네 칸 어디에도 안 잡힘)
+            # ⑤uncounted: done (네 칸 어디에도 안 잡힘 → other)
             story_done = await _make_story(s, org.id, project.id, title="DONE")
             story_done.epic_id = epic.id
             story_done.status = "done"
+
+            # ⑥음성대조: pending gate가 있어도 requires_human/evidence_status 조건을 안
+            # 채우면 「막힘」이 아니다(민 32건 정의와 좁혀 맞춘 것 — 그냥 "pending 매임"만
+            # 이었으면 이 story도 blocked로 잘못 잡혔을 것).
+            story_not_blocked = await _make_story(s, org.id, project.id, title="PENDING_BUT_NOT_BLOCKED")
+            story_not_blocked.epic_id = epic.id
+            story_not_blocked.status = "in-progress"
 
             await s.commit()
 
@@ -89,7 +96,11 @@ async def test_epics_progress_lane_buckets_correctly_and_one_call():
             from app.models.gate import Gate
             s.add(Gate(
                 id=uuid.uuid4(), org_id=org.id, work_item_id=story_blocked.id, work_item_type="story",
-                gate_type="merge", status="pending",
+                gate_type="merge", status="pending", requires_human=True, evidence_status="insufficient",
+            ))
+            s.add(Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story_not_blocked.id, work_item_type="story",
+                gate_type="merge", status="pending", requires_human=False, evidence_status=None,
             ))
             await s.commit()
 
@@ -123,7 +134,12 @@ async def test_epics_progress_lane_buckets_correctly_and_one_call():
             assert resp.status_code == 200, resp.text
             body = resp.json()
             lane = body["epics"][str(epic.id)]
-            assert lane == {"in_progress": 1, "waiting": 1, "blocked": 1, "stalled": 1}, lane
+            assert lane == {
+                "in_progress": 2, "waiting": 1, "blocked": 1, "stalled": 1, "other": 1,
+            }, lane
+            # story_not_blocked는 pending gate가 있어도 requires_human/evidence_status 조건이
+            # 없어 blocked에 안 잡히고, status=in-progress라 in_progress로 떨어져야 한다.
+            assert sum(lane.values()) == 6, "네 칸(진행/대기/막힘/멈춤) + other == total_stories 항상 성립해야 함"
             assert body["stall_threshold_hours"] == 168
             assert call_count["n"] == 1, f"repo 메서드가 {call_count['n']}번 불림(N+1 의심)"
         finally:

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -112,6 +112,8 @@ _FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
         "DD(#2047)에서 sprint.project_id 조회 후 _assert_project_access 호출(org_id 자체는 CRITICAL cross-org fix로 별도 봉인 완료)",
     "app.routers.analytics:get_sprint_velocity":
         "동일 패턴(sprint.project_id 조회 후 _assert_project_access)",
+    "app.routers.analytics:get_epics_progress_lane":
+        "story #2224(S2-1) 신규 — 동일 _assert_project_access 가드(다른 analytics 엔드포인트와 동일 패턴)",
     "app.routers.workflow_executions:list_executions":
         "설계상 안전(SEC-S8 BB 정리) — non-admin은 target_agent_id==member_id로 self-scope, admin은 org 전체 권한으로 통과",
     "app.routers.visual_artifacts:list_artifacts":


### PR DESCRIPTION
## Summary
미르코가 `/flow`(갈래 화면)를 짓다가 실측: `EpicProgressResponse`에 진행/대기/막힘/멈춤 네 칸이 없어 좌측 레인이 반만 선다. 에픽마다 따로 부르면 N+1이라 project 전체를 **한 번의 호출**로 낸다. 급히 공급된 계약(2026-07-30, PO 지시).

```
GET /api/v2/analytics/epics-progress-lane?project_id=...
→ {
    "epics": {
      "<epic_id>": {"in_progress": 3, "waiting": 1, "blocked": 2, "stalled": 5},
      ...
    },
    "stall_threshold_hours": 168
  }
```

## 분류 우선순위 (겹치는 신호를 하나로 정리 — 다른 순서면 답이 달라짐)
1. **막힘** = pending `Gate`가 매인 story (§4-5 "문")
2. **대기** = `next_action_category=='waiting'` (#2262 SSOT `verification_next_action` 재사용 — self_reported=true·human_verified 아직)
3. **진행** = `status=='in-progress'`
4. **멈춤** = `status!='done'`이고 168시간 넘게 `updated_at` 불변 (민 실측 — 문서로 남은 값, 07-23 시안의 "48h"는 미재측정 값)

그 외(backlog/ready-for-dev/in-review 중 최근 변경·done)는 네 칸 밖 — 합계가 그 에픽의 `total_stories`와 다를 수 있다(의도된 것, 지어내지 않는다).

## ⛔잠정치
우선순위·168h 임계 둘 다 **#2218(S0-1) 재측정 전까지의 값**이다. 화면에 "잠정"이라는 신호를 실을지는 FE 계약 몫.

## Test plan
- [x] 실PG 테스트(`test_2224_epics_progress_lane_realdb.py`) — 4버킷 각 1건씩 정확히 분류.
- [x] repo 메서드 호출 횟수를 직접 카운트해 **정확히 1번**만 불림 확認(N+1 없음).
- [x] 기존 analytics 테스트 17건(`test_analytics.py`·SEC-S8 project-scope) 회귀 없음.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>