### PR TITLE
[SID:2327] SID 정규식이 우리 PR 제목 두 형식(story_number) 모두를 못 잡던 문제

### DIFF
--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -387,6 +387,18 @@ async def _process_webhook_event(
     # ⛔advance_story_to_done()은 gate-approve(_advance_story_on_merge_approve)와 공유 헬퍼라
     # 그 함수 자체는 손대지 않는다 — 이 호출부(webhook merge 분기) 하나만 멈춘다. `would_close`로
     # "정지 안 했으면 벌어졌을 일"은 계속 보이게 남겨(관측 가능·소급 판단 재료), 실제 mutation만 뺀다.
+    #
+    # ⛔PO 지적(2026-07-30, em-dash PR#2668/2670 되돌림과 같은 교훈 — "지운 이유를 안 남기면
+    # 다음 사람이 «자동 done이 빠졌네」로 되살린다"): 여기 다시 advance_story_to_done()을 넣기
+    # 前에 반드시 확認할 것 —
+    #   ①왜 뺐나: 「머지 ≠ done. done은 AC 전량 대조 실측 後」가 이 조직의 규율이고, 이 블록은
+    #     explicit/auto-high/sid confident link + merge만으로 사람 확認 없이 즉시 done을 밀었다.
+    #   ②무엇이 없어졌나: explicit SID + merged → 자동 done. 지금은 사람이 판단한다(auto_close.
+    #     would_close로 "됐을 일"만 관측 가능하게 남김, 실제 전이는 0).
+    #   ③⭐만료 조건(되살릴 문): 조직이 "자동 done을 켜고 끄는" 설정(org/workflow 단위)을 갖게
+    #     되면, 그 설정을 읽어 조건부로 되살린다 — 그 설정 자체가 아직 없다(이 파일 존재 확認,
+    #     별건으로 PO가 세운다). 설정 없이 이 줄만 되돌리면 오늘과 같은 사고(사람 확認 없는
+    #     자동 done)가 재발한다.
     if merged and rl.should_auto_close:
         result = {
             **result,

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -27,7 +27,6 @@ from app.models.pm import Story
 from app.routers.cron import CRON_SECRET, _err, _ok, verify_cron
 from app.services.github_app import get_installation_token
 from app.services.pr_story_link import merge_link_evidence, resolve_story_for_pr
-from app.services.story_status_events import advance_story_to_done
 from app.services.verdict_capture import (
     capture_pr_ci_verdict,
     capture_review_verdict,
@@ -377,17 +376,25 @@ async def _process_webhook_event(
     if native_ci_state is not None:
         result = {**result, "native_ci": {"state": native_ci_state, "reason": native_ci_reason}}
 
-    # Bot-L.1 close-on-merge: **confident link**(explicit·auto high·sid)+merge → story done(idempotent).
-    # med/low/text suggestion 은 should_auto_close=False → close 안 함(오매치 done 방지). gate-approve 와
-    # 동일 advance_story_to_done 헬퍼(단일 정책·중복 advance 0). actor=system(자동). already-done=no-op.
+    # ⛔story #2327 후속(PO 판정, 2026-07-30) — close-on-merge **정지**. 「머지 ≠ done, done은
+    # 사람 확認 後」가 팀 규율인데 이 블록은 explicit/auto-high/sid confident link + merge만으로
+    # 사람 확認 없이 즉시 done을 밀었다(advance_story_to_done 직접 호출) — 규율과 정면 충돌.
+    # 지금까지는 SID 링크 해소 자체가 거의 항상 실패해(story #2202/#2327 실측) 이 분기에 실제로
+    # 도달한 적이 드물어 드러나지 않았을 뿐, «게이트»가 아니라 **스위치 자체가 없는 무조건 실행**
+    # 이었다(should_auto_close는 org/workflow 설정이 아니라 매 PR confidence로 즉석 계산되는 값).
+    # SID 정규식 fix(story_number 인식, 이 PR)가 이 분기의 도달률을 정상적으로 되돌리면, 그 순간
+    # «거짓 done 자동화»가 라이브에서 돌기 시작한다 — 그래서 fix와 같은 PR에서 정지시킨다.
+    # ⛔advance_story_to_done()은 gate-approve(_advance_story_on_merge_approve)와 공유 헬퍼라
+    # 그 함수 자체는 손대지 않는다 — 이 호출부(webhook merge 분기) 하나만 멈춘다. `would_close`로
+    # "정지 안 했으면 벌어졌을 일"은 계속 보이게 남겨(관측 가능·소급 판단 재료), 실제 mutation만 뺀다.
     if merged and rl.should_auto_close:
-        story_obj = await session.get(Story, story_id)
-        closed = False
-        if story_obj is not None and story_obj.org_id == org_id:  # org-scope 재확인(anti-IDOR).
-            closed = await advance_story_to_done(session, org_id, story_obj, actor_type="system")
         result = {
             **result,
-            "auto_close": {"closed": closed, "source": rl.source, "confidence": rl.confidence},
+            "auto_close": {
+                "closed": False, "would_close": True,
+                "source": rl.source, "confidence": rl.confidence,
+                "note": "story #2327 PO 판정 2026-07-30: close-on-merge 정지 — done은 사람 확認 後",
+            },
         }
     if scope_result is not None:
         result = {**result, "scope_check": scope_result}

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -400,6 +400,13 @@ async def _process_webhook_event(
     #     별건으로 PO가 세운다). 설정 없이 이 줄만 되돌리면 오늘과 같은 사고(사람 확認 없는
     #     자동 done)가 재발한다.
     if merged and rl.should_auto_close:
+        # PO 지적(2026-07-30): 웹훅 HTTP 응답은 아무도 안 읽는다(호출자가 GitHub) — would_close를
+        # «셀 수 있게» 로그에도 남긴다. 이 로그 건수가 #2339(자동 done on/off 설정)의 크기를
+        # 재는 자다(0이면 안 급함·많으면 급함).
+        logger.info(
+            "auto_close suppressed: story=%s source=%s confidence=%s",
+            story_id, rl.source, rl.confidence,
+        )
         result = {
             **result,
             "auto_close": {

--- a/backend/app/services/pr_story_link.py
+++ b/backend/app/services/pr_story_link.py
@@ -20,7 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.pm import Story
 from app.models.pull_request_story_link import PullRequestStoryLink
-from app.services.verdict_capture import parse_story_id  # _SID_RE 흡수(legacy 무회귀).
+from app.services.verdict_capture import parse_story_id, parse_story_number  # _SID_RE 흡수(legacy 무회귀).
 
 _VALID_SOURCES = ("explicit", "auto_match", "sid", "text")
 _VALID_CONFIDENCE = ("high", "medium", "low")
@@ -72,6 +72,25 @@ async def _global_story(session: AsyncSession, story_id: uuid.UUID) -> Story | N
             select(Story).where(Story.id == story_id, Story.deleted_at.is_(None))
         )
     ).scalar_one_or_none()
+
+
+async def _scoped_story_by_number(
+    session: AsyncSession, org_id: uuid.UUID, story_number: int
+) -> Story | None:
+    """story #2327 후속 — org-scope story_number 조회. **정확히 1건일 때만** 반환(0건·2건+는 None).
+
+    story_number는 (project_id, story_number)만 유일 — org 안에 project가 여럿이면 같은 번호가
+    다른 project에도 있을 수 있다(dev 실측: 저번호는 실제 충돌 존재). 2건+ 나오면 어느 쪽인지
+    추측하지 않는다 — «틀리게 닫느니 안 닫는다»(이 파일 전체의 close-on-merge 규율과 동형).
+    org_id는 필수 인자(legacy org-미상 경로는 이 함수를 호출하지 않는다 — 호출부에서 가드)."""
+    rows = (
+        await session.execute(
+            select(Story).where(
+                Story.org_id == org_id, Story.story_number == story_number, Story.deleted_at.is_(None),
+            )
+        )
+    ).scalars().all()
+    return rows[0] if len(rows) == 1 else None
 
 
 async def _auto_match(
@@ -192,11 +211,45 @@ async def resolve_story_for_pr(
                 story.id, story.org_id, "sid", "high", True, "sid_exact", {"sid": str(sid)}
             )
 
+    # 3b) story #2327 후속 — SID(UUID)가 없거나 못 찾았을 때, story_number 태그(`[SID:2288]`·
+    # `fix(#2288):`, 팀이 실제로 쓰는 두 형식)로 재시도. ⛔org_id 없으면(legacy) 시도 자체를 안
+    # 한다 — story_number는 org 전체 유일이 아니라(§_scoped_story_by_number 주석) org 없이
+    # 전역 조회하면 다른 org 의 같은 번호로 오매치할 수 있다.
+    story_number = None
+    story_number_ambiguous = False
+    if sid is None and org_id is not None:
+        story_number = next((n for t in texts if (n := parse_story_number(t))), None)
+        if story_number is not None:
+            num_story = await _scoped_story_by_number(session, org_id, story_number)
+            if num_story is not None:
+                return ResolvedLink(
+                    num_story.id, num_story.org_id, "sid", "high", True, "sid_exact_by_number",
+                    {"story_number": story_number},
+                )
+            # 0건인지 2건+(ambiguous)인지 구분 — 리포트에서 사유를 정확히 읽으려면 필요.
+            probe = (
+                await session.execute(
+                    select(Story.id).where(
+                        Story.org_id == org_id, Story.story_number == story_number,
+                        Story.deleted_at.is_(None),
+                    )
+                )
+            ).scalars().all()
+            story_number_ambiguous = len(probe) > 1
+
     # 4) auto_match med/low → suggestion(영속·done 금지). 아니면 legacy 호환 skip reason.
     if auto_suggestion is not None:
         return auto_suggestion
-    # SID 있으나 story 미해소(org-scope 미매치 포함)=story_not_found·SID 없음=no_sid_tag(legacy 무회귀).
-    reason = "story_not_found" if sid is not None else "no_sid_tag"
+    # 사유 우선순위: UUID SID 있으나 미해소 > number SID ambiguous > number SID 미해소(0건) >
+    # number 태그인데 org 미상이라 시도 자체를 안 함 > 태그 자체가 없음(legacy 무회귀).
+    if sid is not None:
+        reason = "story_not_found"
+    elif story_number is not None:
+        reason = "story_number_ambiguous" if story_number_ambiguous else "story_number_not_found"
+    elif org_id is None and any(parse_story_number(t) for t in texts):
+        reason = "story_number_requires_org_scope"
+    else:
+        reason = "no_sid_tag"
     return ResolvedLink(None, org_id, None, None, False, reason)
 
 

--- a/backend/app/services/pr_story_link.py
+++ b/backend/app/services/pr_story_link.py
@@ -11,12 +11,15 @@ SID 전역 조회로 story→org 를 도출(기존 무회귀). story 는 항상 
 """
 from __future__ import annotations
 
+import logging
 import re
 import uuid
 from dataclasses import dataclass
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
 
 from app.models.pm import Story
 from app.models.pull_request_story_link import PullRequestStoryLink
@@ -236,6 +239,14 @@ async def resolve_story_for_pr(
                 )
             ).scalars().all()
             story_number_ambiguous = len(probe) > 1
+            # story #2327 후속(PO 지적, 2026-07-30): 「조용히 안 붙는」것 방지 — 사람 화면엔
+            # 안 나가도 개발자가 «몇 건이 이렇게 빠지는가»를 셀 수 있어야 한다(logger.warning
+            # 만으로 skip reason이 사라졌던 웹훅 handler와 같은 병 재발 방지).
+            if story_number_ambiguous:
+                logger.warning(
+                    "resolve_story_for_pr: story_number=%s ambiguous(%d project 충돌, org=%s) — "
+                    "추측 없이 skip(story_number_ambiguous)", story_number, len(probe), org_id,
+                )
 
     # 4) auto_match med/low → suggestion(영속·done 금지). 아니면 legacy 호환 skip reason.
     if auto_suggestion is not None:

--- a/backend/app/services/verdict_capture.py
+++ b/backend/app/services/verdict_capture.py
@@ -43,6 +43,37 @@ def parse_story_id(text: str) -> uuid.UUID | None:
         return None
 
 
+# story #2327 후속(2026-07-30, 디디 실측 — PR 웹훅 2466건 ignored의 rl.reason 축 근본원인):
+# 팀이 실제로 쓰는 두 PR 제목 관례(`[SID:2288]`·`fix(#2288):`)는 위 `_SID_RE`가 요구하는
+# UUID(36자)와 애초에 다른 값(story_number, 사람이 읽는 프로젝트 내 순번)이라 「한 형식만
+# 인식」이 아니라 «둘 다 인식 안 됨»이었다 — 오늘 실제 PR 제목 3건으로 직접 실행해 확認.
+# ⛔story_number는 (project_id, story_number)만 유일(org 전체 유일 아님, uq_stories_project_id_
+# story_number) — org 안에 project가 여럿이면 같은 번호가 여러 project에 동시에 존재할 수 있다
+# (dev DB 실측: 저번호(1~10)는 실제로 최대 24-project 충돌, 1000+ 는 이 org에서 충돌 0건이지만
+# 구조적으로 안전하다고 «가정»할 수 없다). 그래서 이 파서는 숫자만 뽑고, **org-scope 조회 +
+# 정확히 1건일 때만 확定**은 호출자(pr_story_link.py, org_id를 가진 웹훅 경로)의 책임으로
+# 남긴다 — 여기(CRON 수동 캡처 `capture_pr_verdict`)처럼 org_id가 아직 없는 경로는 이 값을
+# 안전하게 못 푼다(그 경로는 이 함수를 그대로 안 쓴다 — 아래 parse_story_number 참고).
+_SID_NUMBER_RE = re.compile(r"\[SID:\s*(\d{1,6})\]|fix\(#(\d{1,6})\):", re.IGNORECASE)
+
+
+def parse_story_number(text: str) -> int | None:
+    """텍스트에서 story_number 태그 파싱 — `[SID:2288]` 또는 `fix(#2288):` 형식.
+
+    ⛔UUID로 확定 짓지 않는다(story_number는 org 전체 유일이 아니다) — 그냥 파싱된 정수만
+    반환한다. org-scope 조회 + 유일성 검증은 호출자 몫(_scoped_story_by_number 참조).
+    음성 대조: `fix: bump to 2288ms` 처럼 숫자만 있고 마커(`[SID:`·`fix(#`)가 없으면 None —
+    "숫자처럼 생겼다"와 "SID 태그다"를 구분한다(부분매치 아니라 마커 필수).
+    """
+    m = _SID_NUMBER_RE.search(text)
+    if not m:
+        return None
+    try:
+        return int(m.group(1) or m.group(2))
+    except (ValueError, TypeError):
+        return None
+
+
 async def resolve_implementation_participation(
     session: AsyncSession,
     org_id: uuid.UUID,

--- a/backend/tests/test_bot_l1_pr_story_link.py
+++ b/backend/tests/test_bot_l1_pr_story_link.py
@@ -160,6 +160,73 @@ def test_normalize_repo_lowercase():
     assert normalize_repo("  MoonkLabs/Sprintable ") == "moonklabs/sprintable"
 
 
+# ── story_number SID(§2327 후속, 2026-07-30) — org-scope 조회 + 유일성 ─────────────
+# 실측 근거: _SID_RE(UUID 36자 전용)가 팀이 실제로 쓰는 두 PR 제목 형식(`[SID:2288]`·
+# `fix(#2288):`) 어느 쪽과도 안 맞았다 — 오늘 PR 제목 3건으로 직접 실행해 확認(story #2202).
+# story_number는 org 전체 유일이 아니므로(uq_stories_project_id_story_number) 여기서도 "정확히
+# 1건일 때만 확定"을 반드시 검증한다(0건·2건+는 오매치 방지를 위해 close 금지).
+
+@pytest.mark.anyio
+async def test_resolver_story_number_bracket_form_resolves_when_org_known():
+    """`[SID:2288]`(팀 실사용 형식1) + org 알 때 + 정확히 1건 → sid_exact_by_number·close 가능."""
+    story = _story(id=uuid.uuid4())
+    # explicit(None) → auto_match([]) → scoped_story_by_number([story]).
+    session = _session([_scalar(None), _scalars([]), _scalars([story])])
+    rl = await resolve_story_for_pr(session, ORG_A, "org/repo", 7, ["[SID:2288] 세 목록 상호참조 코멘트에 만료 조건 추가"])
+    assert rl.story_id == story.id and rl.source == "sid" and rl.confidence == "high"
+    assert rl.should_auto_close is True and rl.reason == "sid_exact_by_number"
+
+
+@pytest.mark.anyio
+async def test_resolver_story_number_fix_hash_form_resolves_when_org_known():
+    """`fix(#2328):`(팀 실사용 형식2) + org 알 때 + 정확히 1건 → 동일하게 해소."""
+    story = _story(id=uuid.uuid4())
+    session = _session([_scalar(None), _scalars([]), _scalars([story])])
+    rl = await resolve_story_for_pr(
+        session, ORG_A, "org/repo", 7, ["fix(#2328): 후보 머리글에 유나 규격의 em-dash 리터럴이 빠져 있었다"]
+    )
+    assert rl.story_id == story.id and rl.source == "sid" and rl.confidence == "high"
+    assert rl.should_auto_close is True
+
+
+@pytest.mark.anyio
+async def test_resolver_story_number_negative_no_marker_falls_through():
+    """숫자만 있고 마커 없으면(`fix: bump to 2288ms`) story_number 파싱 자체가 안 된다 — no_sid_tag로 귀결."""
+    session = _session([_scalar(None), _scalars([])])  # explicit(None) → auto_match([]) → 그 이상 안 감.
+    rl = await resolve_story_for_pr(session, ORG_A, "org/repo", 7, ["fix: bump timeout to 2288ms"])
+    assert rl.story_id is None and rl.reason == "no_sid_tag"
+
+
+@pytest.mark.anyio
+async def test_resolver_story_number_ambiguous_across_projects_no_resolve():
+    """같은 org 안 다른 project 에 같은 story_number 2건+ → 추측 안 함(close 금지·ambiguous 사유)."""
+    # explicit(None) → auto_match([]) → scoped_story_by_number(2건, len!=1 → None) → probe(2건, ambiguous 판정).
+    session = _session([_scalar(None), _scalars([]), _scalars([_story(), _story()]), _scalars([_story(), _story()])])
+    rl = await resolve_story_for_pr(session, ORG_A, "org/repo", 7, ["[SID:1] title"])
+    assert rl.story_id is None and rl.should_auto_close is False
+    assert rl.reason == "story_number_ambiguous"
+
+
+@pytest.mark.anyio
+async def test_resolver_story_number_not_found_when_org_known():
+    """org 알고 번호 태그 있으나 0건 → story_number_not_found(추측 없이 skip)."""
+    session = _session([_scalar(None), _scalars([]), _scalars([]), _scalars([])])
+    rl = await resolve_story_for_pr(session, ORG_A, "org/repo", 7, ["[SID:99999]"])
+    assert rl.story_id is None and rl.reason == "story_number_not_found"
+
+
+@pytest.mark.anyio
+async def test_resolver_story_number_requires_org_scope_when_org_none():
+    """legacy(org 미상) + 번호 태그 → «전역 조회로 오매치」를 막기 위해 DB 호출 자체를 안 함.
+
+    org_id None이면 explicit/auto_match/(uuid) global 조회 전부 미도달이고 number 축도 org
+    가드에 걸려 조회 자체가 없다 — execute 0회를 `_session([])`(빈 side_effect)로 직접 증명한다."""
+    session = _session([])
+    rl = await resolve_story_for_pr(session, None, "org/repo", 7, ["[SID:2288] title"])
+    assert rl.story_id is None and rl.reason == "story_number_requires_org_scope"
+    session.execute.assert_not_awaited()
+
+
 # ── explicit-link endpoint (anti-IDOR) ───────────────────────────────────────────
 def _inst(account_login="org"):
     return MagicMock(account_login=account_login, suspended_at=None)

--- a/backend/tests/test_bot_l1_pr_story_link.py
+++ b/backend/tests/test_bot_l1_pr_story_link.py
@@ -202,17 +202,23 @@ async def test_resolver_story_number_ambiguous_across_projects_no_resolve():
     """같은 org 안 다른 project 에 같은 story_number 2건+ → 추측 안 함(close 금지·ambiguous 사유)."""
     # explicit(None) → auto_match([]) → scoped_story_by_number(2건, len!=1 → None) → probe(2건, ambiguous 판정).
     session = _session([_scalar(None), _scalars([]), _scalars([_story(), _story()]), _scalars([_story(), _story()])])
-    rl = await resolve_story_for_pr(session, ORG_A, "org/repo", 7, ["[SID:1] title"])
+    with patch.object(prl.logger, "warning") as warn:
+        rl = await resolve_story_for_pr(session, ORG_A, "org/repo", 7, ["[SID:1] title"])
     assert rl.story_id is None and rl.should_auto_close is False
     assert rl.reason == "story_number_ambiguous"
+    # PO 지적(2026-07-30) — 「조용히 안 붙는」것 방지: skip이 셀 수 있는 신호를 남겨야 한다.
+    warn.assert_called_once()
+    assert "story_number_ambiguous" in warn.call_args.args[0]
 
 
 @pytest.mark.anyio
 async def test_resolver_story_number_not_found_when_org_known():
     """org 알고 번호 태그 있으나 0건 → story_number_not_found(추측 없이 skip)."""
     session = _session([_scalar(None), _scalars([]), _scalars([]), _scalars([])])
-    rl = await resolve_story_for_pr(session, ORG_A, "org/repo", 7, ["[SID:99999]"])
+    with patch.object(prl.logger, "warning") as warn:
+        rl = await resolve_story_for_pr(session, ORG_A, "org/repo", 7, ["[SID:99999]"])
     assert rl.story_id is None and rl.reason == "story_number_not_found"
+    warn.assert_not_called()  # not_found(0건)는 ambiguous가 아니다 — 경고 과다발생 방지.
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_bot_l1_pr_story_link.py
+++ b/backend/tests/test_bot_l1_pr_story_link.py
@@ -354,26 +354,33 @@ async def _merge_webhook(*, should_close: bool):
                  patch.object(vmod.settings, "github_app_webhook_secret", ""), \
                  patch.object(vmod, "resolve_story_for_pr", new=AsyncMock(return_value=rl)), \
                  patch.object(vmod, "capture_pr_ci_verdict",
-                              new=AsyncMock(return_value={"recorded": ["pr"], "skipped_reason": None})), \
-                 patch.object(vmod, "advance_story_to_done", new=AsyncMock(return_value=True)) as adv:
+                              new=AsyncMock(return_value={"recorded": ["pr"], "skipped_reason": None})):
                 resp = await c.post("/api/v2/internal/verdict/github-webhook", content=body, headers=headers)
-        return resp, adv, session
+        return resp, session
     finally:
         fastapi_app.dependency_overrides.clear()
 
 
 @pytest.mark.anyio
-async def test_close_on_merge_confident_advances_story():
-    """merge + confident link(should_auto_close) → advance_story_to_done 호출(done)."""
-    resp, adv, session = await _merge_webhook(should_close=True)
+async def test_close_on_merge_confident_reports_would_close_but_does_not_mutate():
+    """story #2327 PO 판정(2026-07-30, 「머지≠done」규율) — merge + confident link여도 close-on-merge
+
+    정지됐다: session.get(Story)로 실제 조회·mutation을 하지 않고(story.status 안 건드림), 응답의
+    auto_close.closed=False·would_close=True로만 «벌어졌을 일」을 관측 가능하게 남긴다."""
+    resp, session = await _merge_webhook(should_close=True)
     assert resp.status_code == 200
-    adv.assert_awaited_once()  # 단일 헬퍼로 done 진행.
-    assert "auto_close" in resp.text
+    body = resp.json()["data"]
+    assert body["auto_close"] == {
+        "closed": False, "would_close": True, "source": "sid", "confidence": "high",
+        "note": "story #2327 PO 판정 2026-07-30: close-on-merge 정지 — done은 사람 확認 後",
+    }
+    session.get.assert_not_awaited()  # story mutation 경로 자체에 안 감(no-op).
 
 
 @pytest.mark.anyio
 async def test_close_on_merge_skips_when_not_confident():
-    """merge 라도 should_auto_close=False(med/low/text) → advance 미호출(오매치 done 0)."""
-    resp, adv, session = await _merge_webhook(should_close=False)
+    """merge 라도 should_auto_close=False(med/low/text) → auto_close 필드 자체가 안 실림."""
+    resp, session = await _merge_webhook(should_close=False)
     assert resp.status_code == 200
-    adv.assert_not_awaited()
+    assert "auto_close" not in resp.json()["data"]
+    session.get.assert_not_awaited()

--- a/backend/tests/test_bot_l1_pr_story_link.py
+++ b/backend/tests/test_bot_l1_pr_story_link.py
@@ -354,9 +354,10 @@ async def _merge_webhook(*, should_close: bool):
                  patch.object(vmod.settings, "github_app_webhook_secret", ""), \
                  patch.object(vmod, "resolve_story_for_pr", new=AsyncMock(return_value=rl)), \
                  patch.object(vmod, "capture_pr_ci_verdict",
-                              new=AsyncMock(return_value={"recorded": ["pr"], "skipped_reason": None})):
+                              new=AsyncMock(return_value={"recorded": ["pr"], "skipped_reason": None})), \
+                 patch.object(vmod.logger, "info") as info_log:
                 resp = await c.post("/api/v2/internal/verdict/github-webhook", content=body, headers=headers)
-        return resp, session
+        return resp, session, info_log
     finally:
         fastapi_app.dependency_overrides.clear()
 
@@ -367,7 +368,7 @@ async def test_close_on_merge_confident_reports_would_close_but_does_not_mutate(
 
     정지됐다: session.get(Story)로 실제 조회·mutation을 하지 않고(story.status 안 건드림), 응답의
     auto_close.closed=False·would_close=True로만 «벌어졌을 일」을 관측 가능하게 남긴다."""
-    resp, session = await _merge_webhook(should_close=True)
+    resp, session, info_log = await _merge_webhook(should_close=True)
     assert resp.status_code == 200
     body = resp.json()["data"]
     assert body["auto_close"] == {
@@ -375,12 +376,17 @@ async def test_close_on_merge_confident_reports_would_close_but_does_not_mutate(
         "note": "story #2327 PO 판정 2026-07-30: close-on-merge 정지 — done은 사람 확認 後",
     }
     session.get.assert_not_awaited()  # story mutation 경로 자체에 안 감(no-op).
+    # PO 지적(2026-07-30) — 웹훅 HTTP 응답은 아무도 안 읽는다. would_close를 로그로도 셀 수
+    # 있어야 #2339(자동 done on/off 설정) 크기를 잴 수 있다.
+    info_log.assert_called_once()
+    assert "auto_close suppressed" in info_log.call_args.args[0]
 
 
 @pytest.mark.anyio
 async def test_close_on_merge_skips_when_not_confident():
     """merge 라도 should_auto_close=False(med/low/text) → auto_close 필드 자체가 안 실림."""
-    resp, session = await _merge_webhook(should_close=False)
+    resp, session, info_log = await _merge_webhook(should_close=False)
     assert resp.status_code == 200
     assert "auto_close" not in resp.json()["data"]
     session.get.assert_not_awaited()
+    info_log.assert_not_called()  # not-confident 는 suppressed 대상 자체가 아니다(로그 과다발생 방지).

--- a/backend/tests/test_e_cage_referee_p1_verdict_capture.py
+++ b/backend/tests/test_e_cage_referee_p1_verdict_capture.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.services.verdict_capture import parse_story_id
+from app.services.verdict_capture import parse_story_id, parse_story_number
 
 ORG_ID = uuid.uuid4()
 STORY_ID = uuid.uuid4()
@@ -44,6 +44,39 @@ def test_parse_story_id_case_insensitive():
 def test_parse_story_id_in_middle():
     sid = uuid.uuid4()
     assert parse_story_id(f"prefix [SID:{sid}] suffix") == sid
+
+
+# ── story_number 태그 파싱 단위 테스트 (story #2327 후속, 2026-07-30) ─────────
+# 양성 3건은 오늘 실제로 머지된 PR 제목 원문(PO 지시 — "오늘 실제 PR 제목 3건이 이미 표본").
+
+def test_parse_story_number_bracket_form_real_pr_title_1():
+    title = "[SID:2288] 세 목록 상호참조 코멘트에 만료 조건 추가"
+    assert parse_story_number(title) == 2288
+
+
+def test_parse_story_number_fix_hash_form_real_pr_title_2():
+    title = "fix(#2328): 후보 머리글에 유나 규격의 em-dash 리터럴이 빠져 있었다"
+    assert parse_story_number(title) == 2328
+
+
+def test_parse_story_number_bracket_form_real_pr_title_3():
+    title = "[SID:2267] AC4/AC7 — 컨테이너와 출처를 화면에서 가른다"
+    assert parse_story_number(title) == 2267
+
+
+def test_parse_story_number_negative_number_without_marker():
+    """음성 대조 — 숫자처럼 생겼지만 SID 마커(`[SID:`·`fix(#`)가 없으면 None.
+
+    "2288"이 본문에 있다고 다 잡으면 오매치(예: PR 번호·버전·ms 단위)가 SID로 오인된다."""
+    assert parse_story_number("fix: bump timeout to 2288ms") is None
+    assert parse_story_number("chore: release 2328") is None
+    assert parse_story_number("") is None
+
+
+def test_parse_story_number_does_not_match_uuid_form():
+    """UUID form([SID:<uuid>])은 이 파서가 안 잡는다 — parse_story_id 전용 축."""
+    sid = uuid.uuid4()
+    assert parse_story_number(f"[SID:{sid}] feat") is None
 
 
 # ── resolve_implementation_participation 단위 테스트 ─────────────────────────


### PR DESCRIPTION
## 이 PR이 하는 것 — 「두 가지」다 (한 PR에 같이 넣은 이유 아래)

### ①고치는 것 — SID 정규식이 우리 PR 제목 두 형식을 못 잡던 문제
- `_SID_RE`가 UUID(36자)만 인식 — 팀이 실제로 쓰는 `[SID:2288]`(story_number)·`fix(#2328):` 둘 다 매칭 실패
- 실측(story #2202): 오늘 실제 PR 제목 3건으로 정규식 직접 실행 → 전부 NO MATCH
- 근본원인 위치(story #2327): PR 웹훅 2468건 중 2466건 ignored의 `rl.reason` 축 상당수가 이 실패로 설명됨

### ②막는 것 — ①이 고쳐지면서 열리는 「자동 done」 문
- `_process_webhook_event()`의 close-on-merge 블록(`if merged and rl.should_auto_close: advance_story_to_done()`)은 **게이트가 아니라 스위치 자체가 없는 무조건 실행**이었다 — `should_auto_close`는 org/workflow 설정이 아니라 매 PR confidence로 즉석 계산되는 값
- 지금까지 SID 링크 해소가 거의 항상 실패해 이 분기 도달률이 낮아 안 드러났을 뿐 — ①이 도달률을 정상화하는 순간부터 "머지 ≠ done, done은 사람 확認 後"라는 팀 규율과 충돌하는 자동 done이 라이브에서 돌기 시작한다
- 그래서 **①과 같은 PR에서** advance_story_to_done() 실호출을 제거(헬퍼 자체는 gate-approve와 공유라 안 건드림). 응답엔 `auto_close.would_close`로 "정지 안 했으면 벌어졌을 일"만 관측 가능하게 남김(소급 판단 재료)
- ⛔①만 먼저 머지되면 그 사이 자동 done이 도는 창이 생긴다 — 그래서 나눠서 머지하지 않고 한 PR로 묶었다

## 변경 상세
- `parse_story_number()` 신설(verdict_capture.py) — `[SID:N]`·`fix(#N):` 파싱. 기존 `parse_story_id`(UUID 축)는 완전히 그대로(회귀 0)
- `pr_story_link.py` resolver 3단계에 story_number fallback — **org-scope + 정확히 1건일 때만 확定**(story_number는 project당 유일, org 전체 유일 아님 — dev 실측: 저번호는 최대 24-project 충돌). 2건+는 `story_number_ambiguous`로 skip + `logger.warning`(조용한 실패 방지)
- close-on-merge 정지 + 코드 주석에 왜·무엇·만료조건(조직이 자동 done on/off 설정을 갖게 되면 그때 조건부 되살림) 명시

## 테스트
- story_number: 양성 3건(오늘 실제 PR 제목) · 음성 1건(`fix: bump timeout to 2288ms`) · ambiguous(+warning 로그) · not_found · org-미상 skip
- close-on-merge 정지: would_close=True 관측되지만 실제 mutation 없음 확認(session.get 미호출)
- 뮤테이션 자가검증 3건(ambiguity 가드·ambiguous 로그·close-on-merge 정지) 전부 sabotage→RED→원복→GREEN
- 기존 63개 테스트 전부 회귀 0

## Backfill 사이징(참고용 — 이 PR은 backfill 자체를 하지 않음)
- merged PR 2592건에 새 파서 실행: story_number 매치 205건(PR)·150건(unique)
- org-scope 유일 해소 가능 148건(not_found 2건은 hotfix 체인의 PR번호 자기참조로 원인 확認·수동매핑 예정, ambiguous 0건)
- **그중 status가 아직 done이 아닌 것 = 30건** — 이게 "보드가 지금 거짓말하고 있는 실제 양"(148/203이 아님, PO 재판정)
- 소급 실행은 이 PR과 별도(잡으로, 링크만·status는 사람 판단, 10건→확認→나머지)

## 남은 것(이 PR 밖)
- 머지 후 실PR로 링크(양성)+status 불변(음성)을 한 사건에서 눈으로 확認 필요(PO 지시, 그 결과가 오면 머지 판정 및 #2327 closing)
- 소급 스크립트는 이 확認 이후 별도 잡으로

Closes 관련: #2327, #2202