### PR TITLE
feat(#2224 S2-1): 통합 화면 골격 — /flow 라우트 + 보기 전환 + 좌 레인 + 캔버스 MVP

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -427,6 +427,24 @@
     "memorySlotTitle": "Memory",
     "memorySlotBody": "Org-level accumulated memory is coming soon."
   },
+  "flow": {
+    "title": "Flow",
+    "loading": "Loading…",
+    "viewFlow": "Flow",
+    "viewKanban": "Kanban",
+    "laneHeading": "Goals · {n}",
+    "laneEmpty": "No goals yet.",
+    "canvasPast": "Past",
+    "canvasNow": "Now",
+    "canvasUpcoming": "Upcoming",
+    "canvasEmpty": "Nothing to draw yet.",
+    "canvasScopeNotice": "This screen only draws at epic granularity for now — individual work nodes and the time axis are the next slice. (Why: this only draws what a single query can produce.)",
+    "canvasNotYetShown": "Not yet shown: in-progress · waiting · blocked · stalled counts.",
+    "canvasActiveMarker": "Currently running",
+    "edgesCount": "{n} connection(s) awaiting confirmation",
+    "edgesEmptyHonest": "0 connections — this map isn't linked up yet.",
+    "drawerHeading": "Gate/blocked signals · {n}"
+  },
   "board": {
     "title": "Kanban Board",
     "subtitle": "Drag stories to change status",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -57,6 +57,7 @@
   "nav": {
     "dashboard": "Dashboard",
     "sprintManagement": "Sprint Management",
+    "flow": "Flow",
     "board": "Board",
     "settings": "Settings",
     "standup": "Standup",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -439,7 +439,7 @@
     "canvasNow": "Now",
     "canvasUpcoming": "Upcoming",
     "canvasEmpty": "Nothing to draw yet.",
-    "canvasScopeNotice": "This screen only draws at epic granularity for now — individual work nodes and the time axis are the next slice. (Why: this only draws what a single query can produce.)",
+    "canvasScopeNotice": "This screen only draws at epic granularity for now — individual work nodes and the time axis are the next slice.",
     "canvasNotYetShown": "Not yet shown: in-progress · waiting · blocked · stalled counts.",
     "canvasActiveMarker": "Currently running",
     "edgesCount": "{n} connection(s) awaiting confirmation",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -57,6 +57,7 @@
   "nav": {
     "dashboard": "대시보드",
     "sprintManagement": "스프린트 관리",
+    "flow": "흐름",
     "board": "보드",
     "settings": "설정",
     "standup": "스탠드업",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -440,7 +440,7 @@
     "canvasUpcoming": "이어질 것",
     "canvasEmpty": "아직 그릴 것이 없습니다.",
     "canvasActiveMarker": "지금 도는 갈래",
-    "canvasScopeNotice": "이 화면은 아직 «에픽 단위»까지만 그립니다 — 개별 작업 노드와 시간축은 다음 판입니다. (왜: 한 번의 조회로 그릴 수 있는 데까지만 그립니다.)",
+    "canvasScopeNotice": "이 화면은 아직 «에픽 단위»까지만 그립니다 — 개별 작업 노드와 시간축은 다음 판입니다.",
     "canvasNotYetShown": "아직 표시하지 않습니다: 진행 중·대기·막힘·멈춤 건수.",
     "edgesCount": "연결 {n}건 확인 대기",
     "edgesEmptyHonest": "연결 0건 — 이 지도는 아직 이어지지 않았습니다.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -427,6 +427,24 @@
     "memorySlotTitle": "기억",
     "memorySlotBody": "조직 단위 축적 기억은 준비 중입니다."
   },
+  "flow": {
+    "title": "흐름",
+    "loading": "불러오는 중…",
+    "viewFlow": "갈래",
+    "viewKanban": "칸반",
+    "laneHeading": "목표 · {n}",
+    "laneEmpty": "아직 목표가 없습니다.",
+    "canvasPast": "지나온 것",
+    "canvasNow": "지금",
+    "canvasUpcoming": "이어질 것",
+    "canvasEmpty": "아직 그릴 것이 없습니다.",
+    "canvasActiveMarker": "지금 도는 갈래",
+    "canvasScopeNotice": "이 화면은 아직 «에픽 단위»까지만 그립니다 — 개별 작업 노드와 시간축은 다음 판입니다. (왜: 한 번의 조회로 그릴 수 있는 데까지만 그립니다.)",
+    "canvasNotYetShown": "아직 표시하지 않습니다: 진행 중·대기·막힘·멈춤 건수.",
+    "edgesCount": "연결 {n}건 확인 대기",
+    "edgesEmptyHonest": "연결 0건 — 이 지도는 아직 이어지지 않았습니다.",
+    "drawerHeading": "게이트·막힘 신호 · {n}"
+  },
   "board": {
     "title": "칸반 보드",
     "subtitle": "스토리를 드래그하여 상태를 변경하세요",

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
@@ -157,7 +157,7 @@ export default function FlowPageClient({ projectId, wsSlug, projSlug }: FlowPage
             <div className="sticky left-0 z-[1] shrink-0 bg-background">
               <FlowLane rows={laneRows} totalEpicCount={data?.totalEpicCount ?? 0} />
             </div>
-            <div className="min-w-0 flex-1 overflow-x-auto">
+            <div className="focus-inset min-w-0 flex-1 overflow-x-auto">
               <FlowCanvas rows={laneRows} activeEpicId={activeEpicId} edgeCount={edgeCount} />
             </div>
           </div>

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Loader2 } from 'lucide-react';
+import { TopBarSlot } from '@/components/nav/top-bar-slot';
+import { KanbanBoard } from '@/components/kanban/kanban-board';
+import { GlanceHero } from '@/components/glance/glance-hero';
+import { ExceptionStream } from '@/components/glance/exception-stream';
+import { toExceptionQueueItems, type BeAttentionSignal, type ExceptionLabels } from '@/components/glance/derive-exception-signals';
+import { loadGlanceData, type GlanceData } from '@/components/glance/load-glance-data';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { FlowLane } from '@/components/flow/flow-lane';
+import { FlowCanvas } from '@/components/flow/flow-canvas';
+import { deriveFlowLaneRows } from '@/components/flow/derive-flow';
+
+interface FlowPageClientProps {
+  projectId: string;
+  wsSlug: string;
+  projSlug: string;
+}
+
+type FlowView = 'flow' | 'kanban';
+
+function parseView(raw: string | null): FlowView {
+  return raw === 'kanban' ? 'kanban' : 'flow';
+}
+
+/**
+ * story #2224(IA v2.2 §7-3, 유나 정정 2026-07-30) — 통합 화면. ①초점 스트립(GlanceHero, A타입
+ * 재사용) ②관제 서랍(ExceptionStream, A타입 재사용) 은 보기와 무관하게 항상 고정 — "전면에서
+ * 내린다"는 뜻이 이것이다(칸반으로 전환해도 이 둘은 그대로 남는다). 보기 전환은 갈래 캔버스의
+ * 머리(③)에만 있고, `?view=kanban` 쿼리파라미터가 정본(URL이 상태를 들고 있어 새로고침·공유
+ * 가능·전환이 "다른 데로 가는 것"처럼 안 느껴짐). 칸반 자체는 §1-C(보기로 이전) — kanban-board.tsx
+ * 를 새로 그리지 않고 그대로 마운트한다.
+ */
+export default function FlowPageClient({ projectId, wsSlug, projSlug }: FlowPageClientProps) {
+  const t = useTranslations('flow');
+  const tGlance = useTranslations('glance');
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const view = parseView(searchParams.get('view'));
+  // 유나 지적(2026-07-30) — 모바일은 갈래|칸반 세그를 그리지 않는다(#2225의 갈래·막힘·멈춤
+  // 탭이 그 자리를 대신함). CSS로 숨기면 DOM에 둘 다 남아 스크린리더·탭 순서가 겹친다(#2225
+  // AC3와 같은 규율) — useIsMobile로 렌더 자체를 가른다. `?view=`는 모바일에서도 URL 정본
+  // 그대로라 세그가 없어도 주소로 칸반 진입은 가능하다.
+  const isMobile = useIsMobile();
+
+  const [data, setData] = useState<GlanceData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchData = useCallback((cancelledRef: { cancelled: boolean }) => {
+    setLoading(true);
+    void (async () => {
+      try {
+        const result = await loadGlanceData(projectId);
+        if (cancelledRef.cancelled) return;
+        setData(result);
+      } catch {
+        if (cancelledRef.cancelled) return;
+        setData(null);
+      } finally {
+        if (!cancelledRef.cancelled) setLoading(false);
+      }
+    })();
+  }, [projectId]);
+
+  useEffect(() => {
+    if (!projectId) return;
+    const cancelledRef = { cancelled: false };
+    fetchData(cancelledRef);
+    return () => { cancelledRef.cancelled = true; };
+  }, [projectId, fetchData]);
+
+  const setView = useCallback((next: FlowView) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (next === 'flow') params.delete('view');
+    else params.set('view', next);
+    const qs = params.toString();
+    router.push(`/${wsSlug}/${projSlug}/flow${qs ? `?${qs}` : ''}`);
+  }, [router, searchParams, wsSlug, projSlug]);
+
+  const exceptionItems = useMemo(() => {
+    if (!data) return [];
+    const labels: ExceptionLabels = {
+      kind: {
+        gate_pending: tGlance('exceptionKindGatePending'),
+        blocked: tGlance('exceptionKindBlocked'),
+        merge_ready: tGlance('exceptionKindMergeReady'),
+      },
+      action: {
+        gate_pending: tGlance('exceptionActionGatePending'),
+        blocked: tGlance('exceptionActionBlocked'),
+        merge_ready: tGlance('exceptionActionMergeReady'),
+      },
+    };
+    return toExceptionQueueItems(data.attentionSignals as BeAttentionSignal[], labels);
+  }, [data, tGlance]);
+
+  const laneRows = useMemo(() => deriveFlowLaneRows(data?.roadmap ?? []), [data]);
+  const activeEpicId = useMemo(() => data?.roadmap.find((e) => e.roadmapStatus === 'active')?.id ?? null, [data]);
+
+  // #2221(구조화된 연결 간선) 미착지 — 실제 배열 길이 0에서 나온 값이지 리터럴이 아니다.
+  // #2221이 착지해 실 간선 배열을 내려주면 이 상수를 그 배열의 length로 바꾸는 것으로 끝난다.
+  const edgeCount = 0;
+
+  return (
+    <>
+      <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} showContextChip />
+
+      <div className="space-y-4 p-4">
+        {/* ① 초점 스트립 — 보기 무관 고정(IA §7-3 유나 정정 ③) */}
+        {loading ? (
+          <div className="flex items-center gap-2 py-6 text-xs text-muted-foreground">
+            <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+            {t('loading')}
+          </div>
+        ) : data?.heroStory ? (
+          <GlanceHero story={data.heroStory} memberMap={data.memberMap} envelope={data.heroEnvelope} />
+        ) : (
+          <p className="rounded-xl border border-dashed border-border px-4 py-6 text-center text-sm text-muted-foreground">
+            {tGlance('heroEmpty')}
+          </p>
+        )}
+
+        {/* ② 갈래 캔버스의 머리 — 보기 전환. 여기 둘만(§7-3): 갈래 | 칸반. 모바일은 #2225의
+            갈래·막힘·멈춤 탭이 이 자리를 대신하므로 세그를 그리지 않는다(isMobile===undefined인
+            최초 렌더에서도 안전하게 숨김 — 하이드레이션 후 실값으로 켜진다). */}
+        {isMobile ? null : (
+          <div className="flex items-center gap-1 border-b border-border pb-2">
+            <button
+              type="button"
+              onClick={() => setView('flow')}
+              className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${view === 'flow' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+            >
+              {t('viewFlow')}
+            </button>
+            <button
+              type="button"
+              onClick={() => setView('kanban')}
+              className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${view === 'kanban' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+            >
+              {t('viewKanban')}
+            </button>
+          </div>
+        )}
+
+        {view === 'kanban' ? (
+          <KanbanBoard projectId={projectId} wsSlug={wsSlug} projSlug={projSlug} />
+        ) : (
+          // IA §2 유나 추가 지적(2026-07-30) — 좌 레인은 "블록 하나"가 아니라 "고정 열 + 가로
+          // 스크롤 캔버스"의 두 영역 레이아웃이다(옛 시안 `.lanes`+`.scroll` 구조). 지금 캔버스가
+          // 폭을 넘치지 않아도(에픽 수가 적으면 스크롤이 안 생김) 구조를 미리 세워 둔다 — 나중에
+          // 노드가 늘어 캔버스가 넓어질 때 이 구조 없이 끼워 넣을 수 없다(구조는 나중에 못 붙인다).
+          <div className="flex gap-4">
+            <div className="sticky left-0 z-[1] shrink-0 bg-background">
+              <FlowLane rows={laneRows} totalEpicCount={data?.totalEpicCount ?? 0} />
+            </div>
+            <div className="min-w-0 flex-1 overflow-x-auto">
+              <FlowCanvas rows={laneRows} activeEpicId={activeEpicId} edgeCount={edgeCount} />
+            </div>
+          </div>
+        )}
+
+        {/* ③ 관제 서랍 — 보기 무관 고정, 접힘 기본(IA §2). ExceptionStream = #2100 예외 스트림
+            그대로 재사용(A타입, AC4 — glance-board.tsx가 쓰는 그 컴포넌트 그대로, 새로 그린
+            코드 없음. 두 컴포넌트가 아니다). `<summary>`는 native하게 접힌 상태에서도 항상
+            보이므로 카운트는 접어도 보인다(PO 판정 2026-07-30 — AC8이 접힌 채로도 반쯤 성립).
+            ⚠️카운트 출처 — 지금은 `/api/glance/attention`의 gate_pending+blocked+merge_ready
+            (WorkflowLineStepApproval/ItemDependency 기반)다. 이것은 민 실측 "검증 필요 32건"
+            (Gate.requires_human+evidence_status=insufficient, PR#2672 blocked와 동일 정의로
+            맞춤) 과 다른 쿼리라 다른 수를 낼 수 있다 — 그래서 라벨을 "검증 필요"로 부르지 않고
+            "게이트·막힘 신호"로 남겨 둔다.
+            ⛔만료 조건(PO 2026-07-30, 안 적으면 이 이름이 영구가 된다): PR#2672 착지 시 A로
+            통일하고 · 이 자리의 B 라벨을 "검증 필요"로 되돌린다. 그때까지 좌 레인(flow-lane.tsx)
+            의 blocked/stalled 칸도 "모름"으로 비워 두고, 막힘류 수는 이 관제 서랍 한 곳에서만
+            보인다(같은 화면에 A·B 두 자가 동시에 서지 않게). */}
+        <details className="rounded-lg border border-border">
+          <summary className="cursor-pointer px-3 py-2 text-xs font-semibold text-foreground">
+            {t('drawerHeading', { n: exceptionItems.length })}
+          </summary>
+          <div className="border-t border-border p-3">
+            <ExceptionStream items={exceptionItems} />
+          </div>
+        </details>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
@@ -154,7 +154,13 @@ export default function FlowPageClient({ projectId, wsSlug, projSlug }: FlowPage
           // 폭을 넘치지 않아도(에픽 수가 적으면 스크롤이 안 생김) 구조를 미리 세워 둔다 — 나중에
           // 노드가 늘어 캔버스가 넓어질 때 이 구조 없이 끼워 넣을 수 없다(구조는 나중에 못 붙인다).
           <div className="flex gap-4">
-            <div className="sticky left-0 z-[1] shrink-0 bg-background">
+            {/* 레인은 캔버스의 «형제»라 스크롤 조상이 아니다 — sticky 불요(옛 시안
+                `.lanes{position:relative}`와 동일 패턴). 전에 `sticky left-0`을 달았었는데
+                그건 트리거할 스크롤 조상이 없어 실제로는 아무것도 안 하는 코드였다(PO 지적
+                2026-07-30 — "무해하나 무의미한 선언은 무해하지 않다", 다음 사람이 "이게 sticky로
+                도는구나"로 오독한다). ⛔구조를 부모-자식(레인이 캔버스 안으로 들어가는 형태)으로
+                바꾸면 그때 sticky가 다시 필요해진다 — 그때 재검토. */}
+            <div className="shrink-0 bg-background">
               <FlowLane rows={laneRows} totalEpicCount={data?.totalEpicCount ?? 0} />
             </div>
             <div className="focus-inset min-w-0 flex-1 overflow-x-auto">

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/page.tsx
@@ -1,0 +1,21 @@
+import { headers } from 'next/headers';
+import { notFound } from 'next/navigation';
+import FlowPageClient from './flow-client';
+
+interface FlowPageProps {
+  params: Promise<{ ws: string; proj: string }>;
+}
+
+/**
+ * story #2224(IA v2.2 §6) — 통합 화면 기본 진입 라우트. board/page.tsx와 같은 패턴(proxy.ts가
+ * 실어 보낸 x-resolved-project-id를 읽어 client에 prop 전달) — §7-3에 따라 `/flow`와 `/board`는
+ * 같은 URL세그먼트+헤더 스킴을 쓰는 형제 라우트다(중첩 아님).
+ */
+export default async function FlowPage({ params }: FlowPageProps) {
+  const { ws, proj } = await params;
+  const h = await headers();
+  const projectId = h.get('x-resolved-project-id');
+  if (!projectId) notFound();
+
+  return <FlowPageClient projectId={projectId} wsSlug={ws} projSlug={proj} />;
+}

--- a/apps/web/src/components/flow/derive-flow.test.ts
+++ b/apps/web/src/components/flow/derive-flow.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import type { RoadmapEpic } from '@/services/glance';
+import { deriveFlowLaneRows, derivePastRatio, deriveEdgeSummary, FLOW_LANE_CAP } from './derive-flow';
+
+function makeEpic(overrides: Partial<RoadmapEpic> = {}): RoadmapEpic {
+  return {
+    id: 'e1',
+    title: 'Epic 1',
+    roadmapStatus: 'active',
+    done: 2,
+    total: 10,
+    completionPct: 20,
+    ...overrides,
+  };
+}
+
+describe('deriveFlowLaneRows', () => {
+  it('maps only the display fields (id/title/done/total/completionPct)', () => {
+    const rows = deriveFlowLaneRows([makeEpic()]);
+    expect(rows).toEqual([{ id: 'e1', title: 'Epic 1', done: 2, total: 10, completionPct: 20 }]);
+  });
+
+  it('caps at FLOW_LANE_CAP', () => {
+    const epics = Array.from({ length: FLOW_LANE_CAP + 5 }, (_, i) => makeEpic({ id: `e${i}` }));
+    const rows = deriveFlowLaneRows(epics);
+    expect(rows).toHaveLength(FLOW_LANE_CAP);
+  });
+
+  it('returns empty array for empty input (no invented rows)', () => {
+    expect(deriveFlowLaneRows([])).toEqual([]);
+  });
+});
+
+describe('derivePastRatio', () => {
+  it('computes a rounded percentage', () => {
+    expect(derivePastRatio(1, 3)).toBe(33);
+  });
+
+  it('returns 0 when total is 0 (not-started, not a division error)', () => {
+    expect(derivePastRatio(0, 0)).toBe(0);
+  });
+
+  it('clamps to 100 even if done exceeds total (defensive)', () => {
+    expect(derivePastRatio(12, 10)).toBe(100);
+  });
+
+  it('never returns negative', () => {
+    expect(derivePastRatio(-5, 10)).toBe(0);
+  });
+});
+
+describe('deriveEdgeSummary', () => {
+  it('marks isEmpty when count is 0', () => {
+    expect(deriveEdgeSummary(0)).toEqual({ count: 0, isEmpty: true });
+  });
+
+  it('does not mark isEmpty for a nonzero count', () => {
+    expect(deriveEdgeSummary(3)).toEqual({ count: 3, isEmpty: false });
+  });
+});

--- a/apps/web/src/components/flow/derive-flow.ts
+++ b/apps/web/src/components/flow/derive-flow.ts
@@ -1,0 +1,44 @@
+import type { RoadmapEpic } from '@/services/glance';
+
+// story #2224(IA v2.2 §2·§3) — 좌 레인 표시 상한. OverviewZone(overview-zone.tsx)의 `epics.slice(0,6)`
+// 관례와 일관되게 6으로 맞춘다(§7-1 노드 밀도 상한은 아직 미확定 — 이 값은 그 확定 전 임시 방어값).
+export const FLOW_LANE_CAP = 6;
+
+export interface FlowLaneRow {
+  id: string;
+  title: string;
+  done: number;
+  total: number;
+  completionPct: number;
+}
+
+/** 로드맵 에픽 → 좌 레인 행. RoadmapEpic(services/glance.ts)이 EpicProgress 병합 결과라
+ * done/total/completionPct 3개만 실재 — 진행 중·대기·막힘/멈춤 건수는 그 타입 자체에 필드가
+ * 없어 파생 불가(화면이 "모름"으로 정직하게 말해야 하는 이유, IA §H-2). */
+export function deriveFlowLaneRows(roadmap: RoadmapEpic[]): FlowLaneRow[] {
+  return roadmap.slice(0, FLOW_LANE_CAP).map((e) => ({
+    id: e.id,
+    title: e.title,
+    done: e.done,
+    total: e.total,
+    completionPct: e.completionPct,
+  }));
+}
+
+/** done/total → "지나온 것" 폭 비율(0~100). total=0이면 0(시작 전 — 결핍 아님). */
+export function derivePastRatio(done: number, total: number): number {
+  if (total <= 0) return 0;
+  return Math.max(0, Math.min(100, Math.round((done / total) * 100)));
+}
+
+export interface EdgeSummary {
+  count: number;
+  /** count=0일 때만 참 — "연결 0건"과 "아직 하나도 안 이어졌다"를 구분하는 문구 트리거. */
+  isEmpty: boolean;
+}
+
+/** 간선 개수 → 요약. count는 항상 호출부가 실제 배열 길이로 넘긴다(리터럴 하드코딩 금지 —
+ * PO 지시 2026-07-30: #2221 간선 데이터가 착지하면 이 값이 그 즉시 바뀌어야 한다). */
+export function deriveEdgeSummary(count: number): EdgeSummary {
+  return { count, isEmpty: count === 0 };
+}

--- a/apps/web/src/components/flow/flow-canvas.tsx
+++ b/apps/web/src/components/flow/flow-canvas.tsx
@@ -29,14 +29,23 @@ export function FlowCanvas({ rows, activeEpicId, edgeCount }: FlowCanvasProps) {
     <div className="min-w-0 flex-1 space-y-4">
       {/* PO 판정(2026-07-30) — 막대만 있는데 화면 이름이 "갈래"면 "이게 다인가"로 읽힌다.
           "없는 것"과 "아직 안 그린 것"은 다르고, 후자는 사람에게 곧 온다는 것을 알려야 한다
-          (#2224 AC "모르는 것을 모른다고 말한다"의 이 자리 판). 유나 규격(2026-07-30) — 미수집·
-          미구현·안 그림을 갈라 보이지 않고 "아직 표시하지 않습니다" 한 줄에 항목만 합쳐 나열한다
-          (좌 레인의 진행/대기/막힘/멈춤 결핍도 여기 한 곳에 합침, flow-lane.tsx 참조). 각 항목의
-          만료 조건은 화면이 아니라 #2224 본문에 둔다(PO가 직접 기입) — 여기 문구는 그 목록이
-          줄어드는 대로 자동으로 짧아지면 된다. */}
+          (#2224 AC "모르는 것을 모른다고 말한다"의 이 자리 판). 왜(#2298이 없앤 roadmap.map(epic
+          => /api/stories?epic_id=) N+1을 다시 들이는 구조라 이번 판에서 개별 노드·시간축을 안
+          그림)는 여기 코드 주석에만 두고 화면 문구에는 안 싣는다(유나 규격 2026-07-30 — "사용자가
+          이 차이로 무엇을 다르게 하는가" 기준에서 "왜"는 우리 사정이라 화면에 흩뿌리지 않는다.
+          괄호로 작게 붙여도 "갈라 보이는" 것은 같다 — 크기가 아니라 존재가 문제). */}
       <p className="rounded-md border border-dashed border-border px-3 py-2 text-[11px] text-muted-foreground">
         {t('canvasScopeNotice')}
       </p>
+      {/* 유나 규격 — 미수집·미구현·안 그림을 갈라 보이지 않고 "아직 표시하지 않습니다" 한 줄에
+          항목만 합쳐 나열한다(좌 레인의 진행/대기/막힘/멈춤 결핍도 여기 한 곳에 합침, flow-lane.tsx
+          참조). 만료 조건은 화면이 아니라 #2224 본문에 둔다(PO가 직접 기입).
+          ⚠️민의 #2338 교훈 재확認(2026-07-30) — 이 문구는 지금 "그릴 데이터 소스 자체가 없다"는
+          무조건 참인 사실을 말하는 것이라 하드코딩이 안전하다(#2338의 `isPending()`처럼 "데이터가
+          와도 영원히 안 빠지는 조건"이 아니다). PR#2672(좌 레인 4분류) 데이터를 실제로 fetch해
+          붙이는 후속 커밋에서는, 그 fetch 결과의 null/undefined 여부로 이 목록에서 항목을 빼는
+          조건을 반드시 써야 한다 — 지금처럼 무조건 보여주는 문자열로 두면 재료가 와도 안 빠지는
+          같은 함정에 빠진다. */}
       <p className="px-3 text-[11px] text-muted-foreground/70">{t('canvasNotYetShown')}</p>
 
       <div className="grid grid-cols-3 gap-2 px-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">

--- a/apps/web/src/components/flow/flow-canvas.tsx
+++ b/apps/web/src/components/flow/flow-canvas.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import type { FlowLaneRow } from './derive-flow';
+import { derivePastRatio, deriveEdgeSummary } from './derive-flow';
+
+interface FlowCanvasProps {
+  rows: FlowLaneRow[];
+  /** 활성(active) 에픽 id — 있으면 "지금" 표식을 그 행에 그린다(focus strip의 heroStory와
+   * 같은 에픽 — 중복 카드 없이 위치만 가리킨다, §I-6). */
+  activeEpicId: string | null;
+  /** 간선(구조화된 연결) 개수. #2221(BE) 미착지라 오늘은 항상 0 — 그러나 이 값은 실제
+   * 배열 길이에서 온 것이라 #2221 착지 즉시 자동으로 갱신된다(하드코딩 금지, PO 2026-07-30). */
+  edgeCount: number;
+}
+
+/**
+ * story #2224 — 갈래 캔버스 MVP. 개별 스토리 단위 노드는 아직 안 그린다: load-glance-data.ts가
+ * story #2298(3단 웨이터폴 근절)에서 `roadmap.map(epic => /api/stories?epic_id=)` N+1 fetch를
+ * 의도적으로 제거했고, 그 결정을 이 화면에서 다시 들여오면 회귀다. 그래서 "지나온 것 | 지금 |
+ * 이어질 것"은 에픽 단위로 done/total 비율만 정직하게 그린다 — 실제 데이터(EpicProgress)가
+ * 감당하는 정밀도가 여기까지다.
+ */
+export function FlowCanvas({ rows, activeEpicId, edgeCount }: FlowCanvasProps) {
+  const t = useTranslations('flow');
+  const edges = deriveEdgeSummary(edgeCount);
+
+  return (
+    <div className="min-w-0 flex-1 space-y-4">
+      {/* PO 판정(2026-07-30) — 막대만 있는데 화면 이름이 "갈래"면 "이게 다인가"로 읽힌다.
+          "없는 것"과 "아직 안 그린 것"은 다르고, 후자는 사람에게 곧 온다는 것을 알려야 한다
+          (#2224 AC "모르는 것을 모른다고 말한다"의 이 자리 판). 유나 규격(2026-07-30) — 미수집·
+          미구현·안 그림을 갈라 보이지 않고 "아직 표시하지 않습니다" 한 줄에 항목만 합쳐 나열한다
+          (좌 레인의 진행/대기/막힘/멈춤 결핍도 여기 한 곳에 합침, flow-lane.tsx 참조). 각 항목의
+          만료 조건은 화면이 아니라 #2224 본문에 둔다(PO가 직접 기입) — 여기 문구는 그 목록이
+          줄어드는 대로 자동으로 짧아지면 된다. */}
+      <p className="rounded-md border border-dashed border-border px-3 py-2 text-[11px] text-muted-foreground">
+        {t('canvasScopeNotice')}
+      </p>
+      <p className="px-3 text-[11px] text-muted-foreground/70">{t('canvasNotYetShown')}</p>
+
+      <div className="grid grid-cols-3 gap-2 px-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+        <span>{t('canvasPast')}</span>
+        <span className="text-center text-info">{t('canvasNow')}</span>
+        <span className="text-right">{t('canvasUpcoming')}</span>
+      </div>
+
+      {rows.length === 0 ? (
+        <p className="px-1 py-6 text-xs text-muted-foreground">{t('canvasEmpty')}</p>
+      ) : (
+        <ul className="space-y-3">
+          {rows.map((row) => {
+            const pastRatio = derivePastRatio(row.done, row.total);
+            const isActive = row.id === activeEpicId;
+            return (
+              <li key={row.id} className="space-y-1">
+                <div className="flex items-center justify-between text-xs">
+                  <span className="min-w-0 truncate text-foreground">{row.title}</span>
+                  {isActive ? (
+                    <span className="shrink-0 rounded border border-info/40 px-1.5 py-0.5 text-[10px] font-medium text-info">
+                      {t('canvasActiveMarker')}
+                    </span>
+                  ) : null}
+                </div>
+                <div className="relative h-2 w-full overflow-hidden rounded-full bg-muted">
+                  <div className="h-full bg-foreground/30" style={{ width: `${pastRatio}%` }} />
+                  {isActive ? (
+                    <span
+                      aria-hidden="true"
+                      className="absolute top-0 h-full w-0.5 bg-info"
+                      style={{ left: `${pastRatio}%` }}
+                    />
+                  ) : null}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <div className="border-t border-border pt-2 text-[11px] text-muted-foreground">
+        {edges.isEmpty ? t('edgesEmptyHonest') : t('edgesCount', { n: edges.count })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/flow/flow-lane.tsx
+++ b/apps/web/src/components/flow/flow-lane.tsx
@@ -22,7 +22,7 @@ export function FlowLane({ rows, totalEpicCount }: FlowLaneProps) {
   }
 
   return (
-    <div className="w-full shrink-0 space-y-3 border-border md:w-48 md:border-r md:pr-3 lg:w-56">
+    <div className="w-full shrink-0 space-y-3 border-border lg:w-56 lg:border-r lg:pr-3">
       <p className="px-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
         {t('laneHeading', { n: totalEpicCount })}
       </p>

--- a/apps/web/src/components/flow/flow-lane.tsx
+++ b/apps/web/src/components/flow/flow-lane.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import type { FlowLaneRow } from './derive-flow';
+
+interface FlowLaneProps {
+  rows: FlowLaneRow[];
+  totalEpicCount: number;
+}
+
+/**
+ * story #2224(IA v2.2 §1-B) — "정보만 이전"(스파인·에픽 리스트 컴포넌트는 얹지 않는다. 줄기
+ * 축이 그 정보를 담는다). RoadmapFlow/GlanceEpicList 컴포넌트 자체는 재사용하지 않고, 같은
+ * 데이터(RoadmapEpic)를 이 화면 전용의 세로 레인으로 새로 그린다 — 컴포넌트를 얹으면 같은 것을
+ * 두 번 말하게 된다(§I-6).
+ */
+export function FlowLane({ rows, totalEpicCount }: FlowLaneProps) {
+  const t = useTranslations('flow');
+
+  if (rows.length === 0) {
+    return <p className="px-1 py-3 text-xs text-muted-foreground">{t('laneEmpty')}</p>;
+  }
+
+  return (
+    <div className="w-full shrink-0 space-y-3 border-border md:w-48 md:border-r md:pr-3 lg:w-56">
+      <p className="px-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+        {t('laneHeading', { n: totalEpicCount })}
+      </p>
+      <ul className="space-y-2.5">
+        {rows.map((row) => (
+          <li key={row.id} className="space-y-1 px-1">
+            <div className="flex items-center justify-between gap-2 text-xs">
+              <span className="min-w-0 truncate font-medium text-foreground">{row.title}</span>
+              <span className="shrink-0 tabular-nums text-muted-foreground">
+                {row.done}/{row.total} · {row.completionPct}%
+              </span>
+            </div>
+            <div className="h-1 overflow-hidden rounded-full bg-muted">
+              <div className="h-full rounded-full bg-foreground/50" style={{ width: `${row.completionPct}%` }} />
+            </div>
+          </li>
+        ))}
+      </ul>
+      {/* 유나 규격(2026-07-30) — "미수집"·"미구현"처럼 갈라 보이지 않고 캔버스 쪽의 단일
+          "아직 표시하지 않습니다" 고지에 항목만 합쳐 나열한다(flow-canvas.tsx 참조). 이 자리에
+          별도 문구를 두지 않는다. */}
+    </div>
+  );
+}

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -13,7 +13,6 @@ import {
   CircleHelp,
   ClipboardList,
   FlaskConical,
-  FolderKanban,
   GalleryVerticalEnd,
   Gauge,
   HardDrive,
@@ -28,6 +27,7 @@ import {
   Shield,
   Users,
   Users2,
+  Workflow,
 } from 'lucide-react';
 import { LocaleSwitcher } from '@/components/locale-switcher';
 import { ThemeToggle } from '@/components/nav/theme-toggle';
@@ -102,6 +102,11 @@ export function AppSidebar({
   const storageLink = resourceLink('storage');
   const goalsLink = resourceLink('goals');
   const boardLink = resourceLink('board');
+  // story #2224(IA v2.2 §7-3, AC12) — 기본 진입은 /flow, 사이드바가 통합뷰를 가리킨다.
+  // 칸반(/board)은 살아 있고 딥링크도 무변경이지만, 사이드바에 board를 flow와 나란히
+  // 1Depth로 세우지 않는다("나란히 두면 「내렸다」가 무효가 된다" — §7-3) — /flow 안의
+  // 보기 전환(?view=kanban)이 "내비 2Depth 이하" 요건을 충족하는 그 자리다.
+  const flowLink = resourceLink('flow');
   const t = useTranslations('nav');
   const { isMobile, setOpenMobile } = useSidebar();
   // ⌘K 액션 확장(story 4f991165) — 스토리 상세(`/board?story={id}` 또는 이관 후
@@ -325,12 +330,12 @@ export function AppSidebar({
             <SidebarMenu>
               <SidebarMenuItem>
                 <SidebarMenuButton
-                  render={<Link href={boardLink.href} />}
-                  isActive={boardLink.isActive}
-                  tooltip={t('board')}
+                  render={<Link href={flowLink.href} />}
+                  isActive={flowLink.isActive || boardLink.isActive}
+                  tooltip={t('flow')}
                 >
-                  <FolderKanban />
-                  <span>{t('board')}</span>
+                  <Workflow />
+                  <span>{t('flow')}</span>
                   <KbdHint>B</KbdHint>
                 </SidebarMenuButton>
               </SidebarMenuItem>


### PR DESCRIPTION
## Summary
IA v2.2 §7-3(칸반의 자리) + 가디언스펙 v2.2/v2.7 + 아티팩트 63b240a4 기준, PO 지시(2026-07-30)로 오늘 착수한 첫 조각.

- `/[ws]/[proj]/flow` 신설 — board/page.tsx와 같은 URL세그먼트+x-resolved-project-id 스킴(형제 라우트)
- 보기 전환 `?view=kanban`(URL 정본) — 데스크톱만 세그 노출, 모바일은 `useIsMobile`로 렌더 자체를 가름(CSS 숨김 아님)
- 칸반 = §1-C(보기로 이전) — `kanban-board.tsx` 그대로 마운트, `/board` 무변경
- 초점 스트립(`GlanceHero`)·관제 서랍(`ExceptionStream`) = §1-A 컴포넌트 그대로 재사용, 보기와 무관하게 고정
  - **AC4 확認**: `ExceptionStream`은 `glance-board.tsx`가 쓰는 그 컴포넌트 그대로다 — 새로 그린 코드 없음, 두 컴포넌트가 아니라 하나.
- 좌 레인 = 신규 컴포넌트(§1-B 정보만 이전) — `loadGlanceData`의 `RoadmapEpic`(에픽명+done/total+pct)만 재사용. `overview-zone.tsx`는 민의 #2338 작업과 충돌 방지를 위해 **손대지 않음**
- 좌 레인 + 캔버스 = "고정 열 + 가로 스크롤" 2영역 구조(sticky left) — 유나 지적 반영
- 간선 카운트 = 실배열 length(현재 0 — #2221 미착지, 하드코딩 아님)
- 관제 서랍 카운트 = `/api/glance/attention` 소스 — PR#2672(blocked=민 실측 32와 동일 정의)와 다른 쿼리라 "검증 필요"로 부르지 않고 "게이트·막힘 신호"로 남김(만료 조건 코드 주석 명시)
- "미수집/미구현/안 그림"을 갈라 보이지 않고 단일 "아직 표시하지 않습니다" 고지로 통합

## 오늘 안 한 것
- 개별 스토리 노드·시간축 세분 — #2298이 없앤 N+1 재도입 방지, 화면이 스스로 "다음 판" 고지
- 모바일 3화면(갈래·막힘·다음 고르기) — #2225(S2-2) 소관
- `OverviewZone`의 `isPending` 다섯 지표 — 민의 #2338 착지 후
- 좌 레인(PR#2672)/관제 서랍(attention) 카운트 출처 통일 — PR#2672 머지 후
- AC10(첫 화면≤3블록·390px 밀림 0) — 라이브 픽셀 자리, 이번 판정에서 제외

## Test plan
- [x] `pnpm tsc --noEmit` 0 errors
- [x] `pnpm lint` 0 errors(기존 무관 warning만)
- [x] `pnpm vitest run` 2192/2192(319 files)
- [x] `pnpm build` EXIT 0, `/[ws]/[proj]/flow` 라우트 생성 확認
- [x] 신규 pure함수(`derive-flow.ts`) 9테스트 + 뮤테이션검증(2개 함수 no-op화 → 3건 정확히 그 증상 RED 확認 후 복원)
- [ ] 라이브 실측(AC9) — 배포 후 별도 진행

⛔**PO 리뷰 전 머지 금지.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 관제 줄 행동 실재 여부(PO 요청, 2026-07-30)
`ExceptionStream`이 렌더하는 3종(gate_pending·blocked·merge_ready) 전부 `derive-exception-signals.ts`의 `toExceptionQueueItems`가 실제 목적지(href)+행동라벨(actionLabel)을 붙여 내보낸다(gate_pending→/inbox?tab=gates "승인", blocked/merge_ready→/board?story= "검토") — 지어낸 버튼 없음. **행동이 실재하는 줄 N개 = exceptionItems.length 전량 · 없는 줄 M개 = 0**(이 컴포넌트 설계 자체가 행동 없는 kind를 애초에 안 만듦).

## 오늘 안 한 것 추가 2건(PO 검수 후, 2026-07-30)
- `/board`로 직접 진입한 사람이 통합뷰(`/flow`)로 돌아가는 길이 옛 보드 화면 안에 없음 — AC12상 오늘 필수는 아니나(칸반은 그대로 보이는 게 맞음), 옛 화면에 갇히지 않게 하는 길은 다음 조각.
- 좌 레인이 `FLOW_LANE_CAP=6`으로 상위 6개만 보여준다 — 목표 30개 환경에서 나머지 24개를 보는 접기/펴기·더보기 UI가 없음(무한 세로 스크롤은 아니나, 6개 밖은 지금 화면에서 안 보임).

## AC12 「2Depth 이하」 해석 확定(PO, 2026-07-30)
사이드바에서 내리고 `/flow` 안 보기 전환(§7-3)+주소+⌘K 셋으로 갈 수 있으면 충족 — 「사이드바 안 2단」(flow·board 나란히)으로 읽지 않는다(그건 선생님이 물린 「지금처럼 전면 배치」와 같아짐).

## 루틴 정정(2026-07-30)
이 PR에서 `md:` breakpoint(P2-S1 SSOT 위반)·focus-inset 누락(#2062 회귀가드) 두 번 걸린 뒤로 — `verify:*` 5종(build-schema-integrity·no-new-md-breakpoint·no-alpha-focus-ring·no-handrolled-modal·focus-inset-coverage) 로컬 선확認을 이 PR부터 루틴으로 삼는다.