### PR TITLE
fix(#2262 AC1): story outgoing-references — created_at → referenced_at

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -947,7 +947,13 @@ async def get_story_outgoing_references(
                 "form": r.form,
                 "target_type": r.target_type,
                 "target_id": str(r.target_id),
-                "created_at": r.created_at.isoformat(),
+                # story #2262 AC1(「지점」, PO 판정 2026-07-30): 「이 참조가 언제 생겼나」이지
+                # 「대상이 언제 만들어졌나」가 아니다 — mention_parser.fetch_stored_references()는
+                # 이미 referenced_at으로 나가는데(conversations.py 소비), 이 라우트(story의
+                # outgoing references)는 reference_core.list_references()를 써서 이름이 안 바뀐
+                # 채 남아 있었다(실 dev GET으로 발견 — 본문의 "이미 반환한다"는 처방이지 현재
+                # 상태가 아니었다).
+                "referenced_at": r.created_at.isoformat(),
                 "still_exists": r.still_exists,
                 "proof_payload": r.proof_payload,
             }

--- a/backend/tests/test_2263_story_outgoing_references_realdb.py
+++ b/backend/tests/test_2263_story_outgoing_references_realdb.py
@@ -141,6 +141,14 @@ async def test_outgoing_references_shows_visible_target_only_includes_payload():
             # 애초에 없어 None — "키가 없다"가 아니라 "값이 null"이다(필드 자체는 항상 존재).
             assert "proof_payload" in item
             assert item["proof_payload"] is None
+            # story #2262 AC1(「지점」, PO 판정 2026-07-30): 응답이 「이 참조가 언제 생겼나」를
+            # referenced_at으로 실어야 한다 — created_at(옛 이름)이 아니다. 형제 함수
+            # mention_parser.fetch_stored_references()는 이미 이 이름으로 나가는데 이 라우트는
+            # 안 바뀐 채 남아 있었다(실 dev GET으로 발견).
+            assert "referenced_at" in item, "created_at(옛 이름)이 아니라 referenced_at이어야 함"
+            assert "created_at" not in item
+            from datetime import datetime
+            datetime.fromisoformat(item["referenced_at"])
         finally:
             await client.aclose()
     finally:


### PR DESCRIPTION
## Summary
실 dev GET으로 발견: story #2262 AC1(지점)이 "referenced_at을 이미 반환한다"고 본문에 적혀 있었으나, 라이브 응답은 여전히 옛 이름 `created_at`이었다 — 오늘 세 번째 형제 비대칭(#2272·#2245가 앞의 둘).

`mention_parser.fetch_stored_references()`(conversations.py 소비)는 `referenced_at`으로 이미 나가는데, story의 `GET /{id}/references` 라우터는 `reference_core.list_references()`의 반환을 수동으로 `created_at` 키로 직렬화하는 채 남아 있었다.

## 전수 확認 (형제 비대칭 재발 방지 체크리스트)
- ㉠ `list_references()` 호출부는 이 라우트 하나뿐 — 기존 `test_list_references_has_exactly_one_live_router_caller`가 이미 가드. 4번째 형제 위험 없음.
- ㉡ 두 함수(`fetch_stored_references` vs `list_references`)는 목적이 달라(전자: 채팅메시지 참조, 후자: 스토리 outgoing + 가시성 필터 + bare-number 매핑) 지금은 이름만 맞추고 통합은 별건으로.
- ㉢ FE `OutgoingReference` 타입은 `created_at`/`referenced_at` 어느 쪽도 아직 안 읽음(칩 자체가 미착수) — BE만 고치면 되고 FE 동시 변경 불요.

## Test plan
- [x] 실PG 테스트(기존 `test_2263_story_outgoing_references_realdb.py` 등 24건 전부 그린)
- [x] `referenced_at` 키 존재·ISO8601 포맷·`created_at` 부재 신규 assert 추가

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>