### PR TITLE
[SID:2327] manual-env-allowlist.yml에 GITHUB_APP_WEBHOOK_SECRET 등재(값 없이 자리만)

### DIFF
--- a/infra/manual-env-allowlist.yml
+++ b/infra/manual-env-allowlist.yml
@@ -115,6 +115,14 @@ services:
       - key: GITHUB_WEBHOOK_SECRET
         reason: GitHub 웹훅 서명 검증 시크릿 — 부트스트랩 스크립트 미편입.
         owner: TBD
+      - key: GITHUB_APP_WEBHOOK_SECRET
+        reason: >-
+          GitHub App 웹훅 서명 검증 — 이 값이 없으면 App 서명 검증을 통째로 건너뛰고
+          «전부 legacy» 로 떨어진다(#2327 실측, app_inert = not app_secret). 부트스트랩
+          스크립트 미편입(GITHUB_WEBHOOK_SECRET과 동일 카테고리) — 값은 GitHub App
+          설정 화면에서만 얻을 수 있어 별도 확認 필요, 이 항목은 그 값이 채워지기 前에도
+          허용목록 등재만 먼저 한다.
+        owner: TBD
       - key: H1_MERGE_GATE_ADVISORY
         value_check: skip
         reason: feature flag — 수동 토글.
@@ -205,6 +213,9 @@ services:
       - key: GITHUB_WEBHOOK_SECRET
         reason: dev와 동일 사유.
         owner: TBD
+      - key: GITHUB_APP_WEBHOOK_SECRET
+        reason: dev와 동일 사유 — GitHub App 웹훅 서명 검증(#2327 실측 참고).
+        owner: TBD
       - key: H1_MERGE_GATE_ADVISORY
         value_check: skip
         reason: dev와 동일 — feature flag.
@@ -290,6 +301,9 @@ services:
         owner: TBD
       - key: GITHUB_WEBHOOK_SECRET
         reason: backend-dev와 동일 사유.
+        owner: TBD
+      - key: GITHUB_APP_WEBHOOK_SECRET
+        reason: backend-dev와 동일 사유 — GitHub App 웹훅 서명 검증(#2327 실측 참고).
         owner: TBD
       - key: H1_MERGE_GATE_ADVISORY
         value_check: skip


### PR DESCRIPTION
## 배경
story #2327 AC4 왕복(PR#2676)에서 발견: 배포 환경에 `GITHUB_APP_WEBHOOK_SECRET`이 없어 `app_inert=True`가 항상 성립 → App 서명 검증 스킵 → 모든 웹훅이 legacy로 분류 → org_id 원천 미해소 → story_number 태그 라이브 해소가 항상 skip.

## 이 PR이 하는 것
`infra/manual-env-allowlist.yml`에 `GITHUB_APP_WEBHOOK_SECRET` 키를 등재(형제 키 `GITHUB_WEBHOOK_SECRET`과 동일 패턴 — 카테고리 C 순수 수동, 부트스트랩 스크립트 미편입). 값은 아직 안 넣는다 — GitHub App 설정 화면에서만 얻을 수 있는 시크릿이라 별도 확認 필요.

## 왜 값 없이 먼저 등재하나
값이 채워지고 나서(gcloud secret bind) env-drift-guard가 "미승인 라이브 키"로 FAIL 잡지 않도록 자리를 먼저 만드는 것. 이 PR 자체는 실제 동작을 바꾸지 않는다(설정 파일 데이터 추가만).

## 테스트
`test_check_env_drift_*` 43개 그대로 통과(회귀 0).

Closes 관련: #2327