### PR TITLE
feat(#2224): epic-flow-nodes — /flow 노드 계약(급전환)

### DIFF
--- a/backend/app/repositories/analytics.py
+++ b/backend/app/repositories/analytics.py
@@ -322,6 +322,89 @@ class AnalyticsRepository:
             lane["other"] += 1  # done, 또는 backlog/ready-for-dev/in-review 중 최근 변경된 것
         return {"lanes": lanes, "stories_without_epic": no_epic_count}
 
+    async def get_epic_flow_nodes(
+        self, project_id: uuid.UUID, epic_id: uuid.UUID, upcoming_limit: int = 15,
+    ) -> dict:
+        """story #2224(S2-1, 갈래 화면) 노드 계약 — 급전환(2026-07-30, PO 판정): "N+1이라
+        노드를 안 그린다"는 안 그릴 이유가 아니라 BE 계약을 하나 더 만들 이유였다(선생님 질책).
+
+        ⛔한 에픽 최대 141건(dev 실측) — 179개 에픽 전체를 한 번에 주면(수천 건) 응답이
+        죽는다. 그래서 이 계약은 «에픽 하나» 단위다(?epic_id= 필수) — 좌 레인(전체 에픽
+        요약)은 이미 get_epics_progress_lane이 주고, 펼친 에픽만 이 함수가 노드를 준다
+        (유나 "접기/펴기 1차 필수"와 맞물림). 한 에픽 141건이면 단일 쿼리로 N+1 없이 충분.
+
+        세 구역(시간축) — ⛔7상태(실행가능·검증필요·멈춤·연결미상…, 노드에 붙는 «표시»)와는
+        다른 축이다. 섞으면 같은 것을 두 번 말하는 것이라 여기서는 구역만 가른다:
+          ①지금(now)     = status in {in-progress, in-review} — "검토 중"도 사람이 지금
+                            손대는 중이라 지금에 든다(PO 판정). ready-for-dev는 안 넣는다 —
+                            "잡을 수 있는 것"과 "잡고 있는 것"이 섞인다. «전량» 반환.
+          ②이어질(upcoming) = 나머지(backlog·ready-for-dev 등, done 제외) — «상위 upcoming_limit
+                            건»만. 순서: 막힌 것(pending Gate·requires_human=true·
+                            evidence_status=insufficient, 좌 레인과 같은 정의) > 실행가능
+                            (status=='ready-for-dev', PO: "이어질 것의 맨 앞") > 나머지, 그
+                            안에서 최근 변경 순. ⛔잘린 개수를 반드시 함께 낸다("없앤 것"이
+                            아니라 "안 그린 것" — 오늘 규율 그대로).
+          ③지나온(past)  = status=='done' — ⛔노드로 안 그린다. «수»로만 접는다.
+        """
+        stories_r = await self.session.execute(
+            select(
+                Story.id, Story.story_number, Story.title, Story.status,
+                Story.assignee_id, Story.updated_at,
+            ).where(
+                Story.project_id == project_id,
+                Story.org_id == self.org_id,
+                Story.epic_id == epic_id,
+                Story.deleted_at.is_(None),
+            )
+        )
+        stories = stories_r.all()
+        story_ids = [s.id for s in stories]
+
+        blocked_r = await self.session.execute(
+            select(Gate.work_item_id.distinct()).where(
+                Gate.org_id == self.org_id,
+                Gate.work_item_type == "story",
+                Gate.work_item_id.in_(story_ids),
+                Gate.status == "pending",
+                Gate.requires_human.is_(True),
+                Gate.evidence_status == "insufficient",
+            )
+        )
+        blocked_ids = set(blocked_r.scalars().all())
+
+        def _node(s) -> dict:
+            return {
+                "id": str(s.id),
+                "story_number": s.story_number,
+                "title": s.title,
+                "status": s.status,
+                "assignee_id": str(s.assignee_id) if s.assignee_id else None,
+                "updated_at": s.updated_at.isoformat(),
+            }
+
+        now_items, upcoming_all, past_count = [], [], 0
+        for s in stories:
+            if s.status == "done":
+                past_count += 1
+            elif s.status in ("in-progress", "in-review"):
+                now_items.append(_node(s))
+            else:
+                priority = 0 if s.id in blocked_ids else (1 if s.status == "ready-for-dev" else 2)
+                upcoming_all.append((priority, s.updated_at, _node(s)))
+
+        upcoming_all.sort(key=lambda t: (t[0], -t[1].timestamp()))
+        upcoming_total = len(upcoming_all)
+        upcoming_shown = [n for _, _, n in upcoming_all[:upcoming_limit]]
+
+        return {
+            "epic_id": str(epic_id),
+            "now": {"total": len(now_items), "items": now_items},
+            "upcoming": {
+                "total": upcoming_total, "shown": len(upcoming_shown), "items": upcoming_shown,
+            },
+            "past": {"total": past_count},
+        }
+
     async def get_agent_stats(self, project_id: uuid.UUID, agent_id: uuid.UUID) -> dict:
         member_r = await self.session.execute(
             select(TeamMember.id).where(

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -11,6 +11,7 @@ from app.repositories.analytics import AnalyticsRepository
 from app.schemas.analytics import (
     AgentStatsResponse,
     BurndownResponse,
+    EpicFlowNodesResponse,
     EpicProgressLane,
     EpicProgressResponse,
     EpicsProgressLaneResponse,
@@ -114,6 +115,22 @@ async def get_epics_progress_lane(
         stall_threshold_hours=168,
         stories_without_epic=result["stories_without_epic"],
     )
+
+
+@router.get("/analytics/epic-flow-nodes", response_model=EpicFlowNodesResponse)
+async def get_epic_flow_nodes(
+    project_id: uuid.UUID = Query(...),
+    epic_id: uuid.UUID = Query(...),
+    upcoming_limit: int = Query(default=15, ge=1, le=100),
+    repo: AnalyticsRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+) -> EpicFlowNodesResponse:
+    """story #2224 노드 계약(급전환, 2026-07-30 PO 판정) — 「지금/이어질/지나온」 세 구역
+    노드를 «에픽 하나» 단위로 한 번의 호출로 낸다(179 에픽 전체를 한 번에 주면 수천 건이라
+    안 준다 — 펼친 에픽만). `upcoming_limit`은 FE 화면 상한(PO 감 10~15, 기본 15)."""
+    await _assert_project_access(repo, auth, project_id)
+    result = await repo.get_epic_flow_nodes(project_id, epic_id, upcoming_limit)
+    return EpicFlowNodesResponse.model_validate(result)
 
 
 @router.get("/analytics/agent-stats", response_model=AgentStatsResponse)

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -128,6 +128,45 @@ class EpicsProgressLaneResponse(BaseModel):
     stories_without_epic: int
 
 
+class FlowNode(BaseModel):
+    """story #2224 노드 계약 — 화면 한 줄에 필요한 만큼만(id·SID·제목·status·담당·마지막
+    변화 시각). 7상태 뱃지는 이 필드가 아니라 FE가 status에서 도출(다른 축, PO 판정)."""
+    id: uuid.UUID
+    story_number: int | None  # allocate_story_number()가 채번 — DB제약은 nullable(모델 참조)
+    title: str
+    status: str
+    assignee_id: uuid.UUID | None
+    updated_at: datetime
+
+
+class FlowNodeZone(BaseModel):
+    total: int
+    items: list[FlowNode]
+
+
+class FlowNodeUpcomingZone(BaseModel):
+    """⛔`shown`(PO 규율 2026-07-30): 잘린 개수를 반드시 함께 낸다 — "없앤 것"이 아니라
+    "안 그린 것"이라 말할 수 있게. total > shown이면 화면이 "N건 중 M건 표시"를 말한다."""
+    total: int
+    shown: int
+    items: list[FlowNode]
+
+
+class FlowNodePastZone(BaseModel):
+    """지나온(done) 것은 노드로 안 그린다 — 수로만 접는다(PO 판정)."""
+    total: int
+
+
+class EpicFlowNodesResponse(BaseModel):
+    """GET .../epic-flow-nodes?epic_id=... — 한 에픽 단위(179개 에픽 전체를 한 번에 주면
+    수천 건이라 응답이 죽는다, dev 실측 최대 141건/에픽). 세 구역(지금·이어질·지나온)은
+    «시간»축이지 7상태(실행가능·검증필요…) 축이 아니다 — 섞으면 같은 것을 두 번 말한다."""
+    epic_id: uuid.UUID
+    now: FlowNodeZone
+    upcoming: FlowNodeUpcomingZone
+    past: FlowNodePastZone
+
+
 class AgentStatsResponse(BaseModel):
     # S2-1 신규 지표 (stories 기반)
     completed: int

--- a/backend/tests/test_2224_epic_flow_nodes_realdb.py
+++ b/backend/tests/test_2224_epic_flow_nodes_realdb.py
@@ -1,0 +1,185 @@
+"""story #2224 노드 계약 — GET /analytics/epic-flow-nodes 실PG 검증. 급전환(2026-07-30,
+PO 판정) — 「N+1이라 안 그린다」는 안 그릴 이유가 아니라 BE 계약을 하나 더 만들 이유였다.
+세 구역(지금/이어질/지나온)을 한 에픽 단위 한 번의 호출로 낸다."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_2301_story_body_mentions_realdb import (
+    _REAL_DB_URL,
+    _client_for,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _make_story,
+    _session_factory,
+    _setup_app_human,
+)
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def test_epic_flow_nodes_three_zones_and_one_call():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+
+            from app.models.pm import Goal
+            epic = Goal(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Epic A")
+            s.add(epic)
+            await s.commit()
+
+            now = datetime.now(timezone.utc)
+
+            # ①지금(now): in-progress 1건 + in-review 1건 — "검토 중"도 지금(PO 판정)
+            story_ip = await _make_story(s, org.id, project.id, title="IP")
+            story_ip.epic_id = epic.id
+            story_ip.status = "in-progress"
+
+            story_review = await _make_story(s, org.id, project.id, title="IN_REVIEW")
+            story_review.epic_id = epic.id
+            story_review.status = "in-review"
+
+            # ②이어질(upcoming) — 우선순위 검증용 3건: 막힘 > ready-for-dev > backlog
+            story_blocked = await _make_story(s, org.id, project.id, title="BLOCKED_BACKLOG")
+            story_blocked.epic_id = epic.id
+            story_blocked.status = "backlog"  # 막힘이 status와 무관하게 최우선이어야 함
+
+            story_ready = await _make_story(s, org.id, project.id, title="READY")
+            story_ready.epic_id = epic.id
+            story_ready.status = "ready-for-dev"
+
+            story_backlog = await _make_story(s, org.id, project.id, title="BACKLOG")
+            story_backlog.epic_id = epic.id
+            story_backlog.status = "backlog"
+
+            # ③지나온(past): done 2건 — 노드로 안 나가고 수로만
+            for i in range(2):
+                sd = await _make_story(s, org.id, project.id, title=f"DONE_{i}")
+                sd.epic_id = epic.id
+                sd.status = "done"
+
+            await s.commit()
+
+            from app.models.gate import Gate
+            s.add(Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story_blocked.id, work_item_type="story",
+                gate_type="merge", status="pending", requires_human=True, evidence_status="insufficient",
+            ))
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        call_count = {"n": 0}
+        try:
+            import app.repositories.analytics as analytics_repo_mod
+            _orig = analytics_repo_mod.AnalyticsRepository.get_epic_flow_nodes
+
+            async def _counting(self, project_id, epic_id, upcoming_limit=15):
+                call_count["n"] += 1
+                return await _orig(self, project_id, epic_id, upcoming_limit)
+
+            analytics_repo_mod.AnalyticsRepository.get_epic_flow_nodes = _counting
+            try:
+                resp = await client.get(
+                    "/api/v2/analytics/epic-flow-nodes",
+                    params={"project_id": str(project.id), "epic_id": str(epic.id)},
+                )
+            finally:
+                analytics_repo_mod.AnalyticsRepository.get_epic_flow_nodes = _orig
+
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+
+            assert body["epic_id"] == str(epic.id)
+
+            assert body["now"]["total"] == 2, "in-progress+in-review 둘 다 지금 구역"
+            now_statuses = {n["status"] for n in body["now"]["items"]}
+            assert now_statuses == {"in-progress", "in-review"}
+
+            assert body["upcoming"]["total"] == 3
+            assert body["upcoming"]["shown"] == 3
+            upcoming_ids = [n["id"] for n in body["upcoming"]["items"]]
+            assert upcoming_ids[0] == str(story_blocked.id), "막힌 것이 status와 무관하게 최우선이어야 함"
+            assert upcoming_ids[1] == str(story_ready.id), "ready-for-dev가 backlog보다 앞이어야 함(PO: 이어질 것의 맨 앞)"
+            assert upcoming_ids[2] == str(story_backlog.id)
+
+            assert body["past"]["total"] == 2
+            assert "items" not in body["past"], "지나온 것은 노드로 안 나간다 — 수로만"
+
+            for node in body["now"]["items"] + body["upcoming"]["items"]:
+                assert set(node.keys()) == {
+                    "id", "story_number", "title", "status", "assignee_id", "updated_at",
+                }
+
+            assert call_count["n"] == 1, f"repo 메서드가 {call_count['n']}번 불림(N+1 의심)"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_epic_flow_nodes_upcoming_limit_truncates_and_reports_total():
+    """upcoming_limit보다 이어질 것이 많으면 shown < total이어야 하고, 잘린 개수를 응답이
+    말해야 한다("없앤 것"이 아니라 "안 그린 것", PO 규율)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+
+            from app.models.pm import Goal
+            epic = Goal(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Epic B")
+            s.add(epic)
+            await s.commit()
+
+            for i in range(5):
+                st = await _make_story(s, org.id, project.id, title=f"BACKLOG_{i}")
+                st.epic_id = epic.id
+                st.status = "backlog"
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/analytics/epic-flow-nodes",
+                params={"project_id": str(project.id), "epic_id": str(epic.id), "upcoming_limit": 2},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["upcoming"]["total"] == 5
+            assert body["upcoming"]["shown"] == 2
+            assert len(body["upcoming"]["items"]) == 2
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -114,6 +114,8 @@ _FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
         "동일 패턴(sprint.project_id 조회 후 _assert_project_access)",
     "app.routers.analytics:get_epics_progress_lane":
         "story #2224(S2-1) 신규 — 동일 _assert_project_access 가드(다른 analytics 엔드포인트와 동일 패턴)",
+    "app.routers.analytics:get_epic_flow_nodes":
+        "story #2224 노드 계약 신규 — 동일 _assert_project_access 가드(다른 analytics 엔드포인트와 동일 패턴)",
     "app.routers.workflow_executions:list_executions":
         "설계상 안전(SEC-S8 BB 정리) — non-admin은 target_agent_id==member_id로 self-scope, admin은 org 전체 권한으로 통과",
     "app.routers.visual_artifacts:list_artifacts":


### PR DESCRIPTION
## Summary
"N+1이라 노드를 안 그린다"는 안 그릴 이유가 아니라 BE 계약을 하나 더 만들 이유였다(PO 판정 번복, 선생님 질책 반영). 오늘 lane 계약(#2672)과 같은 값으로 급공급.

```
GET /api/v2/analytics/epic-flow-nodes?project_id=...&epic_id=...&upcoming_limit=15
→ {
    "epic_id": "...",
    "now": {"total": N, "items": [{id, story_number, title, status, assignee_id, updated_at}, ...]},
    "upcoming": {"total": N, "shown": M, "items": [...]},
    "past": {"total": N}
  }
```

## 계약이 «에픽 하나» 단위인 이유
dev 실측 최대 141건/에픽(179개 에픽 전체 합은 수천 건) — 한 번에 다 주면 응답이 죽는다. 좌 레인(#2672)은 이미 전체 에픽 요약을 주고, 이 엔드포인트는 펼친 에픽 하나만 노드를 준다(유나 "접기/펴기 1차 필수"와 맞물림).

## 세 구역(시간축) — 7상태(뱃지)와는 다른 축
- **지금(now)** = `in-progress` + `in-review`(검토 중도 사람이 지금 손대는 것) — 전량. `ready-for-dev`는 안 넣는다("잡을 수 있는 것" vs "잡고 있는 것"이 섞인다).
- **이어질(upcoming)** = 나머지(done 제외) — 상위 `upcoming_limit`(기본 15)건만. 순서: 막힘(pending Gate·requires_human=true·evidence_status=insufficient, 좌 레인과 동일 정의) > `ready-for-dev`("이어질 것의 맨 앞") > 나머지, 그 안에서 최근 변경 순. 잘린 개수(`total - shown`)를 반드시 함께 낸다 — "없앤 것"이 아니라 "안 그린 것".
- **지나온(past)** = `done` — 노드로 안 그린다, 수로만 접는다.

## Test plan
- [x] 실PG 테스트 — 세 구역 정확 분류 + 우선순위(막힘>ready>backlog) 검증
- [x] N+1 없음(repo 메서드 정확히 1회 직접 카운트)
- [x] `upcoming_limit` 자르기와 `total`/`shown` 정확성
- [x] authz coverage allowlist에 동일 사유로 등록(다른 analytics 형제와 동일 `_assert_project_access` 패턴) — 기존 23건 회귀 없음

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>