### PR TITLE
[SID:2224] 초점 스트립 hero 에픽 선택 결함 fix — 진행중 스토리 있는 active 에픽 우선

### DIFF
--- a/apps/web/src/components/glance/load-glance-data.test.ts
+++ b/apps/web/src/components/glance/load-glance-data.test.ts
@@ -122,6 +122,48 @@ describe('loadGlanceData (§10 데이터 소스 4종 단순 1회 fetch — dedup
     expect(data.heroEnvelope).toBeNull();
   });
 
+  it('picks an active epic that actually has a focal_story over an earlier active epic with none(결함 fix 2026-07-30 — 선생님 실측 "열린 스토리가 없다": active 에픽 다수 중 «첫 번째»가 무조건 뽑혀 실제 진행중 스토리가 있는 다른 active 에픽을 두고 빈 에픽이 hero로 선택되던 버그)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.startsWith('/api/goals')) {
+        return jsonResponse([
+          { id: 'e-empty', title: 'E-CHAT-REALTIME(진행중 없음)', status: 'active', created_at: '2026-07-01T00:00:00Z', participant_ids: [], focal_story: null },
+          { id: 'e-has-work', title: 'E-UI-DAEGBYEON(진행중 있음)', status: 'active', created_at: '2026-07-02T00:00:00Z', participant_ids: [], focal_story: {
+            id: 's-real', title: '실제 진행중 스토리', status: 'in-progress', assignee_id: null, assignee_ids: [],
+            proof_count: 0, auto_verify: null, gate: null,
+            trust: { self_reported: false, human_verified: false, human_verified_by: null, human_verified_at: null },
+          } },
+        ]);
+      }
+      if (url.startsWith('/api/dashboard/overview')) return jsonResponse({ project_status: { epics: [] } });
+      if (url.startsWith('/api/team-members')) return jsonResponse([]);
+      if (url.startsWith('/api/activity-logs')) return jsonResponse({ items: [], total: 0, limit: 20, offset: 0 });
+      if (url.startsWith('/api/glance/attention')) return jsonResponse({ items: [] });
+      return jsonResponse([]);
+    }));
+    const data = await loadGlanceData('proj-multi-active');
+    expect(data.activeEpicTitle).toBe('E-UI-DAEGBYEON(진행중 있음)');
+    expect(data.heroStory?.id).toBe('s-real');
+  });
+
+  it('falls back to the first active epic when none of the active epics have a focal_story(진짜 0건 — 정직한 빈 상태 유지)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.startsWith('/api/goals')) {
+        return jsonResponse([
+          { id: 'e1', title: 'Epic One', status: 'active', created_at: '2026-07-01T00:00:00Z', participant_ids: [], focal_story: null },
+          { id: 'e2', title: 'Epic Two', status: 'active', created_at: '2026-07-02T00:00:00Z', participant_ids: [], focal_story: null },
+        ]);
+      }
+      if (url.startsWith('/api/dashboard/overview')) return jsonResponse({ project_status: { epics: [] } });
+      if (url.startsWith('/api/team-members')) return jsonResponse([]);
+      if (url.startsWith('/api/activity-logs')) return jsonResponse({ items: [], total: 0, limit: 20, offset: 0 });
+      if (url.startsWith('/api/glance/attention')) return jsonResponse({ items: [] });
+      return jsonResponse([]);
+    }));
+    const data = await loadGlanceData('proj-all-empty-active');
+    expect(data.activeEpicTitle).toBe('Epic One');
+    expect(data.heroStory).toBeNull();
+  });
+
   it('unwraps the attention envelope {data:{items}} into attentionSignals — 형상 불일치 crash 없이 실신호 배선', async () => {
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
       if (url.startsWith('/api/goals')) return jsonResponse([]);

--- a/apps/web/src/components/glance/load-glance-data.ts
+++ b/apps/web/src/components/glance/load-glance-data.ts
@@ -117,7 +117,21 @@ export async function loadGlanceData(projectId: string): Promise<GlanceData> {
 
   // 2D 재설계: hero = 현재(active) 에픽의 focal 활성 story. story #2298/#2303부터 story·
   // envelope 재료 전부 `focal_story`(같은 epics(+glance) 응답)에서 나온다 — 추가 fetch 0.
-  const activeEpic = roadmap.find((e) => e.roadmapStatus === 'active') ?? null;
+  //
+  // 결함 fix(2026-07-30, 선생님 직접 발견 — "열린 스토리가 없다고 나오던데"): 이전엔 roadmap
+  // 안에서 status==='active'인 «첫» 에픽을 무조건 집었다. 이 프로젝트엔 active 에픽이 52개나
+  // 동시에 있어(179개 중) "첫 번째"가 실제 진행 상황과 무관하게 뽑혔다 — E-UI-DAEGBYEON(진행중
+  // 스토리 실재)을 두고 E-CHAT-REALTIME(진행중 스토리 0건)이 "지금"으로 뽑혀 초점 스트립이
+  // 항상 빈 채로 뜬 사례가 실측됨. focal_story가 실재하는 active 에픽을 우선한다 — 그런 에픽이
+  // 하나도 없을 때만(=진짜 0건) 기존처럼 첫 active로 폴백(정직한 빈 상태).
+  // ⛔불완전한 처방: active 에픽 52개 중에서도 여전히 roadmap 배열 순서상 «먼저 오는 하나»를
+  // 고르는 것뿐 — "가장 최근에 움직인 에픽"으로 좁히려면 에픽의 updated_at이 필요한데
+  // `BeEpicListItem`엔 created_at만 있고 updated_at이 없다(BE 계약에 없음). 그 필드가
+  // 오면(#미정, BE 후속) "focal_story 있음" 다음 tie-break로 최신순 정렬을 추가한다.
+  const activeEpic =
+    roadmap.find((e) => e.roadmapStatus === 'active' && rawById.get(e.id)?.focal_story) ??
+    roadmap.find((e) => e.roadmapStatus === 'active') ??
+    null;
   const focal = activeEpic ? (rawById.get(activeEpic.id)?.focal_story ?? null) : null;
   const heroStory: HeroStory | null = focal
     ? { id: focal.id, title: focal.title, status: focal.status, assignee_id: focal.assignee_id, assignee_ids: focal.assignee_ids }

--- a/apps/web/src/components/glance/load-glance-data.ts
+++ b/apps/web/src/components/glance/load-glance-data.ts
@@ -127,7 +127,9 @@ export async function loadGlanceData(projectId: string): Promise<GlanceData> {
   // ⛔불완전한 처방: active 에픽 52개 중에서도 여전히 roadmap 배열 순서상 «먼저 오는 하나»를
   // 고르는 것뿐 — "가장 최근에 움직인 에픽"으로 좁히려면 에픽의 updated_at이 필요한데
   // `BeEpicListItem`엔 created_at만 있고 updated_at이 없다(BE 계약에 없음). 그 필드가
-  // 오면(#미정, BE 후속) "focal_story 있음" 다음 tie-break로 최신순 정렬을 추가한다.
+  // 오면(#2341, BE 후속 — "상태 자가회수" 스토리 AC2) "focal_story 있음" 다음 tie-break로
+  // 최신순 정렬을 추가한다. #2341 AC1은 더 근본적으로 "active"를 파생값으로 바꾸는 방향도
+  // 검토 중 — 이 tie-break는 그 방향이 확정되기 전까지의 완화(PR#2680)에 그친다.
   const activeEpic =
     roadmap.find((e) => e.roadmapStatus === 'active' && rawById.get(e.id)?.focal_story) ??
     roadmap.find((e) => e.roadmapStatus === 'active') ??


### PR DESCRIPTION
## 무엇을 고쳤나

선생님이 배포된 `/flow` 직접 확인 중 발견: "열린 스토리가 없다고 나오던데 목업에서 본거랑 사뭇 다른 렌더링".

`/glance`(기존, #2224와 무관)와 `/flow`(신규, #2224/PR#2674)가 공유하는 `loadGlanceData()`의 초점 스트립(`GlanceHero`, A타입 재사용 컴포넌트) 선택 로직 결함 — `roadmap.find(e => e.roadmapStatus === 'active')`가 이 프로젝트에 **active 에픽이 52개(179개 중)** 동시에 있는 상황에서 배열의 "첫 번째"를 무조건 집었다.

## 근본원인 (grep + API 직접 실측)

- 실제 in-progress 스토리 8건 실재(#2338·#2224·#2268 등) — "열린 게 없다"는 거짓
- `attach_glance_aggregates`(BE goal.py:198-236)에 assignee 필터 없음 — "나 기준"이 아니라 **프로젝트 전체 기준인데 버그**
- E-UI-DAEGBYEON(진행중 스토리 실재, position 0)을 두고 E-CHAT-REALTIME(진행중 0건, position 10)이 "지금"으로 뽑힘 — `scopeRoadmapEpics`의 윈도잉 자체는 정상, `find()`의 "첫 active"가 실제 활동과 무관했던 것이 결함

## 수정

`load-glance-data.ts`: `focal_story`가 실재하는 active 에픽을 우선 선택 — 그런 에픽이 하나도 없을 때만(진짜 0건) 기존 첫-active 폴백 유지(정직한 빈 상태).

## ⛔ 불완전한 처방 — 명시

active 에픽 52개 중에서도 여전히 배열 순서상 "먼저 오는 하나"를 고른다. "가장 최근에 움직인 에픽"으로 좁히려면 에픽의 `updated_at`이 필요한데 `BeEpicListItem`(FE 계약)엔 `created_at`만 있고 `updated_at`이 없다 — BE 계약 확장 필요(#2341, 후속). 코드 주석에 만료조건 명시.

## 검증

- 새 테스트 2건 추가: ①다수 active 에픽 중 focal_story 있는 것 우선 선택 ②전부 없으면 첫 active로 정직 폴백
- 뮤테이션 검증: 수정 로직을 원복 → 신규 테스트 1건 정확히 RED 확인 → 복원 후 GREEN
- tsc 클린 · lint 클린 · vitest 2205/2205 · build 성공 · verify:* 5종 전부 로컬 통과

## 영향 범위

같은 `loadGlanceData()`를 쓰는 `/glance`·`/flow` 둘 다 동시에 고쳐짐(A타입 재사용의 좋은 쪽). `/flow`(#2224/PR#2674)와 별개 PR — 기존 버그이므로 되돌릴 때 따로 되돌릴 수 있게.

🤖 Generated with [Claude Code](https://claude.com/claude-code)