### PR TITLE
fix(#2327): legacy webhook org 해소 — repo owner→account_login exactly-1-match

### DIFF
--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, Header, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -268,6 +268,49 @@ def _extract_pr_ci(event: str, payload: dict) -> tuple[int, bool, str | None, st
     return pr_number, merged, ci_conclusion, head_sha
 
 
+def _repo_owner(repo: str) -> str | None:
+    """`owner/repo` → `owner`. 형식 아니면 None(추측 금지)."""
+    if not repo or "/" not in repo:
+        return None
+    owner = repo.split("/", 1)[0]
+    return owner or None
+
+
+async def _resolve_legacy_org_by_repo_owner(
+    session: AsyncSession, repo: str
+) -> tuple[uuid.UUID | None, str]:
+    """legacy webhook(이미 legacy_secret HMAC 을 통과한 «검증된» 요청)에서 org_id 를 repo owner 로 해소.
+    (org_id, reason) 반환 — reason ∈ {org_resolved_via_repo_owner, repo_owner_ambiguous, repo_owner_unknown}.
+
+    ①왜 이 길을 열었나: story #2327 후속 실측(2026-07-30) — legacy 는 서명검증을 이미 통과했는데
+    org_id 를 못 풀어 story_number/PR-link/auto_match 등 org-scope 필요 경로 전체가 막혀 있었다
+    (`GITHUB_APP_WEBHOOK_SECRET` 미설정 확認 — app 경로 자체가 전무·2575건 legacy ignored 다수가
+    이 갭). repository.full_name 의 owner 는 모든 webhook payload 에 항상 있고, PO 판정(2026-07-30):
+    「검증된 요청인데 org 를 못 푼다」는 보안 경계가 아니라 결함이라 이 매치는 우회가 아니라 정공이다.
+    ②무엇을 안 하는가: 서명검증을 건너뛰지 않는다(이 함수는 `_resolve_webhook_source`가 이미
+    source='legacy'로 확정한 요청에만 불린다) · source 를 'app'으로 바꿔치지 않는다(그대로 legacy로
+    기록) · **정확히 1건 매치일 때만** 해소한다(0건·2건+ 는 거부 — 「첫 것을 고른다」 금지).
+    ③⭐만료 조건: `GITHUB_APP_WEBHOOK_SECRET` 이 설정돼 app 경로가 라이브로 도는 것이 확認되면,
+    이 폴백은 다중 org 안전성(exactly-1-match 전제가 org 여러 개일 때도 유지되는지 — 지금은
+    `github_installation` 이 1행이라 위험 없음)을 다시 재고 그때 유지 여부를 정한다."""
+    owner = _repo_owner(repo)
+    if owner is None:
+        return None, "repo_owner_unknown"
+    rows = (
+        await session.execute(
+            select(GithubInstallation.org_id).where(
+                func.lower(GithubInstallation.account_login) == owner.lower(),
+                GithubInstallation.suspended_at.is_(None),
+            )
+        )
+    ).scalars().all()
+    if len(rows) == 0:
+        return None, "repo_owner_unknown"
+    if len(rows) > 1:
+        return None, "repo_owner_ambiguous"
+    return rows[0], "org_resolved_via_repo_owner"
+
+
 async def _process_webhook_event(
     session: AsyncSession, source: str, event: str, payload: dict, installation_id: int | None,
     delivery: GithubWebhookDelivery,
@@ -275,9 +318,10 @@ async def _process_webhook_event(
     """검증·dedup 통과한 이벤트 처리(legacy/app 라우팅·Bot-L.1 resolver 체인). (result, status) 반환.
 
     org resolve: **app**=installation.id→github_installation(suspended 제외)→그 org_id만(anti-IDOR·payload
-    추론 금지·resolve 先). **legacy**=resolver 가 SID 전역→story.org_id(무회귀). story 해소=resolver 체인
-    (explicit>auto high>SID>text). **close-on-merge**=should_auto_close(confident)+merge → advance_story_to_done
-    (단일 idempotent 헬퍼). native CI(Bot-M.1)=installation 토큰. caller 가 동일 트랜잭션으로 commit/rollback.
+    추론 금지·resolve 先). **legacy**=repo owner→account_login exactly-1-match 시도(story #2327 후속) →
+    실패시 resolver 가 SID 전역→story.org_id(무회귀). story 해소=resolver 체인(explicit>auto high>SID>text).
+    **close-on-merge**=should_auto_close(confident)+merge → advance_story_to_done(단일 idempotent 헬퍼).
+    native CI(Bot-M.1)=installation 토큰. caller 가 동일 트랜잭션으로 commit/rollback.
 
     P0-05 후속(doc scope-violation-signal-design §2): scope-violation 판정은 머지/CI 액션가능신호와
     **독립**(PR 자체 이벤트에서 판정) — resolver를 그 skip보다 먼저 실행해 두 판정이 서로를 막지 않게 한다.
@@ -305,12 +349,34 @@ async def _process_webhook_event(
             return {"skipped_reason": "installation_not_registered_or_suspended", "recorded": []}, "ignored"
         org_id = installation.org_id
         delivery.org_id = org_id
+    elif source == "legacy":
+        # ⭐story #2327 후속(PO 판정 2026-07-30): legacy 도 검증된 요청 — repo owner 로 org 해소
+        # 시도(exactly-1-match 만). 실패해도 아래 resolver 는 org_id=None 무회귀 경로로 그대로 진행.
+        repo_owner_org_id, repo_owner_reason = await _resolve_legacy_org_by_repo_owner(session, repo)
+        logger.info(
+            "legacy org resolve: repo=%s reason=%s org_id=%s", repo, repo_owner_reason, repo_owner_org_id,
+        )
+        if repo_owner_org_id is not None:
+            org_id = repo_owner_org_id
+            delivery.org_id = org_id
 
-    # Bot-L.1 resolver 체인: explicit>auto high>SID>text. app=org-scoped(org 알려짐)·legacy=SID 전역→story.org_id.
+    # Bot-L.1 resolver 체인: explicit>auto high>SID>text. app/repo-owner-resolved legacy=org-scoped·
+    # 그 외 legacy=SID 전역→story.org_id(무회귀).
     # ⚠️행동가능신호(merged/ci) skip **前**에 실행 — scope-check(§2)가 그 신호와 무관하게 판정돼야 함.
     rl = await resolve_story_for_pr(session, org_id, repo, pr_number, texts)
     if rl.story_id is None:
-        return {"skipped_reason": rl.reason, "recorded": []}, "ignored"  # no_match/auto suggestion 등.
+        skipped_reason = rl.reason
+        # legacy 에서 org 해소 자체가 실패(ambiguous/unknown)했고 resolver 가 바로 그 이유(org 없어서
+        # story_number 시도조차 못 함)로 skip했으면, 더 구체적인 새 이유로 대체 — 「조용히 안 붙는」
+        # 것 방지(PO 지적, story #2327 후속): skipped_reason 이 세지는 이름이어야 나중에 판단 가능.
+        if (
+            source == "legacy"
+            and org_id is None
+            and repo_owner_reason in ("repo_owner_ambiguous", "repo_owner_unknown")
+            and rl.reason == "story_number_requires_org_scope"
+        ):
+            skipped_reason = repo_owner_reason
+        return {"skipped_reason": skipped_reason, "recorded": []}, "ignored"  # no_match/auto suggestion 등.
     story_id = rl.story_id
     org_id = rl.org_id  # app=입력 org·legacy=story.org_id(resolver 검증). 단일 진실원.
     delivery.org_id = org_id

--- a/backend/tests/test_bot_l1_pr_story_link.py
+++ b/backend/tests/test_bot_l1_pr_story_link.py
@@ -233,6 +233,46 @@ async def test_resolver_story_number_requires_org_scope_when_org_none():
     session.execute.assert_not_awaited()
 
 
+# ── legacy org resolve(repo owner→account_login, story #2327 후속) ──────────────
+@pytest.mark.anyio
+async def test_resolve_legacy_org_by_repo_owner_exact_one_match():
+    from app.routers.verdict_capture import _resolve_legacy_org_by_repo_owner
+
+    session = _session([_scalars([ORG_A])])
+    org_id, reason = await _resolve_legacy_org_by_repo_owner(session, "moonklabs/sprintable")
+    assert org_id == ORG_A and reason == "org_resolved_via_repo_owner"
+
+
+@pytest.mark.anyio
+async def test_resolve_legacy_org_by_repo_owner_ambiguous_two_matches():
+    """2건+ → 「첫 것을 고른다」 금지 — 거부(None)."""
+    from app.routers.verdict_capture import _resolve_legacy_org_by_repo_owner
+
+    session = _session([_scalars([ORG_A, ORG_B])])
+    org_id, reason = await _resolve_legacy_org_by_repo_owner(session, "shared/repo")
+    assert org_id is None and reason == "repo_owner_ambiguous"
+
+
+@pytest.mark.anyio
+async def test_resolve_legacy_org_by_repo_owner_zero_matches():
+    from app.routers.verdict_capture import _resolve_legacy_org_by_repo_owner
+
+    session = _session([_scalars([])])
+    org_id, reason = await _resolve_legacy_org_by_repo_owner(session, "unknown-owner/repo")
+    assert org_id is None and reason == "repo_owner_unknown"
+
+
+@pytest.mark.anyio
+async def test_resolve_legacy_org_by_repo_owner_malformed_repo_no_db_call():
+    """`owner/repo` 형식 아니면 추측 없이 즉시 unknown — DB 조회 자체를 안 함."""
+    from app.routers.verdict_capture import _resolve_legacy_org_by_repo_owner
+
+    session = _session([])
+    org_id, reason = await _resolve_legacy_org_by_repo_owner(session, "no-slash-here")
+    assert org_id is None and reason == "repo_owner_unknown"
+    session.execute.assert_not_awaited()
+
+
 # ── explicit-link endpoint (anti-IDOR) ───────────────────────────────────────────
 def _inst(account_login="org"):
     return MagicMock(account_login=account_login, suspended_at=None)
@@ -352,6 +392,8 @@ async def _merge_webhook(*, should_close: bool):
         async with AsyncClient(transport=ASGITransport(app=fastapi_app), base_url="http://test") as c:
             with patch.object(vmod.settings, "github_webhook_secret", _WH_SECRET), \
                  patch.object(vmod.settings, "github_app_webhook_secret", ""), \
+                 patch.object(vmod, "_resolve_legacy_org_by_repo_owner",
+                              new=AsyncMock(return_value=(None, "repo_owner_unknown"))), \
                  patch.object(vmod, "resolve_story_for_pr", new=AsyncMock(return_value=rl)), \
                  patch.object(vmod, "capture_pr_ci_verdict",
                               new=AsyncMock(return_value={"recorded": ["pr"], "skipped_reason": None})), \
@@ -378,8 +420,82 @@ async def test_close_on_merge_confident_reports_would_close_but_does_not_mutate(
     session.get.assert_not_awaited()  # story mutation 경로 자체에 안 감(no-op).
     # PO 지적(2026-07-30) — 웹훅 HTTP 응답은 아무도 안 읽는다. would_close를 로그로도 셀 수
     # 있어야 #2339(자동 done on/off 설정) 크기를 잴 수 있다.
-    info_log.assert_called_once()
-    assert "auto_close suppressed" in info_log.call_args.args[0]
+    # story #2327 후속(legacy org repo-owner resolve)이 먼저 1회 로그 → suppressed 로그가 2번째.
+    assert info_log.call_count == 2
+    assert "legacy org resolve" in info_log.call_args_list[0].args[0]
+    assert "auto_close suppressed" in info_log.call_args_list[1].args[0]
+
+
+# ── _process_webhook_event: legacy org resolve 배선(story #2327 후속) ───────────
+def _delivery():
+    return MagicMock(org_id=None)
+
+
+@pytest.mark.anyio
+async def test_process_webhook_event_legacy_repo_owner_org_feeds_resolver():
+    """repo owner로 org가 풀리면 그 org_id가 resolve_story_for_pr에 그대로 전달된다(legacy도
+    app과 동등하게 org-scoped 해소를 탈 수 있게 되는 것 — 이 배선이 핵심 변경점)."""
+    from app.routers import verdict_capture as vmod
+
+    session = AsyncMock()
+    delivery = _delivery()
+    rl = ResolvedLink(STORY_ID, ORG_A, "sid", "high", True, "sid_exact_by_number")
+    payload = {"action": "closed", "repository": {"full_name": "moonklabs/sprintable"},
+               "pull_request": {"number": 9, "merged": True, "title": "fix(#2288): x"}}
+    with patch.object(vmod, "_resolve_legacy_org_by_repo_owner",
+                       new=AsyncMock(return_value=(ORG_A, "org_resolved_via_repo_owner"))), \
+         patch.object(vmod, "resolve_story_for_pr", new=AsyncMock(return_value=rl)) as resolver, \
+         patch.object(vmod, "capture_pr_ci_verdict",
+                       new=AsyncMock(return_value={"recorded": ["pr"]})), \
+         patch.object(vmod.logger, "info"):
+        await vmod._process_webhook_event(session, "legacy", "pull_request", payload, None, delivery)
+    resolver.assert_awaited_once()
+    called_org_id = resolver.call_args.args[1]
+    assert called_org_id == ORG_A  # None이 아니라 repo-owner로 풀린 org가 실제로 전달됨.
+
+
+@pytest.mark.anyio
+async def test_process_webhook_event_legacy_repo_owner_ambiguous_overrides_skipped_reason():
+    """org 해소가 ambiguous(2건+)로 실패 + resolver도 그것 때문에(story_number_requires_org_scope)
+    skip → 최종 skipped_reason이 더 구체적인 repo_owner_ambiguous로 대체된다(세는 자리 확보)."""
+    from app.routers import verdict_capture as vmod
+
+    session = AsyncMock()
+    delivery = _delivery()
+    rl = ResolvedLink(None, None, None, None, False, "story_number_requires_org_scope")
+    payload = {"action": "closed", "repository": {"full_name": "shared/repo"},
+               "pull_request": {"number": 9, "merged": True, "title": "fix(#2288): x"}}
+    with patch.object(vmod, "_resolve_legacy_org_by_repo_owner",
+                       new=AsyncMock(return_value=(None, "repo_owner_ambiguous"))), \
+         patch.object(vmod, "resolve_story_for_pr", new=AsyncMock(return_value=rl)), \
+         patch.object(vmod.logger, "info"):
+        result, status = await vmod._process_webhook_event(
+            session, "legacy", "pull_request", payload, None, delivery
+        )
+    assert status == "ignored"
+    assert result["skipped_reason"] == "repo_owner_ambiguous"
+
+
+@pytest.mark.anyio
+async def test_process_webhook_event_legacy_repo_owner_unknown_unrelated_reason_not_overridden():
+    """org 해소는 실패(unknown)했지만 resolver의 실제 skip 사유가 그것과 무관(no_sid_tag)하면
+    그대로 둔다 — 관련 없는 skip까지 repo_owner 사유로 덮어써 원인을 흐리지 않는다."""
+    from app.routers import verdict_capture as vmod
+
+    session = AsyncMock()
+    delivery = _delivery()
+    rl = ResolvedLink(None, None, None, None, False, "no_sid_tag")
+    payload = {"action": "closed", "repository": {"full_name": "unknown/repo"},
+               "pull_request": {"number": 9, "merged": True, "title": "no tag here"}}
+    with patch.object(vmod, "_resolve_legacy_org_by_repo_owner",
+                       new=AsyncMock(return_value=(None, "repo_owner_unknown"))), \
+         patch.object(vmod, "resolve_story_for_pr", new=AsyncMock(return_value=rl)), \
+         patch.object(vmod.logger, "info"):
+        result, status = await vmod._process_webhook_event(
+            session, "legacy", "pull_request", payload, None, delivery
+        )
+    assert status == "ignored"
+    assert result["skipped_reason"] == "no_sid_tag"
 
 
 @pytest.mark.anyio
@@ -389,4 +505,6 @@ async def test_close_on_merge_skips_when_not_confident():
     assert resp.status_code == 200
     assert "auto_close" not in resp.json()["data"]
     session.get.assert_not_awaited()
-    info_log.assert_not_called()  # not-confident 는 suppressed 대상 자체가 아니다(로그 과다발생 방지).
+    # not-confident 는 suppressed 로그 대상이 아니다(로그 과다발생 방지) — legacy org resolve 로그만 1회.
+    info_log.assert_called_once()
+    assert "legacy org resolve" in info_log.call_args.args[0]

--- a/backend/tests/test_bot_m2_webhook_integration.py
+++ b/backend/tests/test_bot_m2_webhook_integration.py
@@ -95,7 +95,13 @@ async def _post(payload, *, event="workflow_run", delivery="dlv-1", sign_secret=
         async with AsyncClient(transport=ASGITransport(app=fastapi_app), base_url="http://test") as c:
             with patch.object(mod.settings, "github_webhook_secret", legacy), \
                  patch.object(mod.settings, "github_app_webhook_secret", app), \
-                 patch.object(mod, "capture_pr_ci_verdict", new=cap):
+                 patch.object(mod, "capture_pr_ci_verdict", new=cap), \
+                 patch.object(mod, "_resolve_legacy_org_by_repo_owner",
+                              new=AsyncMock(return_value=(None, "repo_owner_unknown"))):
+                # story #2327 후속(legacy org repo-owner resolve) — 이 파일의 세션 mock 시퀀스는
+                # resolver 쿼리 수만 가정하므로, 그 앞의 새 org-resolve 쿼리는 여기서 고정
+                # bypass(org_id=None, 기존 legacy 무회귀 그대로) — org resolve 자체는
+                # test_bot_l1_pr_story_link.py 에서 단위로 커버.
                 resp = await c.post("/api/v2/internal/verdict/github-webhook", content=body, headers=headers)
         return resp, session, cap
     finally:

--- a/backend/tests/test_h1_s6_github_webhook.py
+++ b/backend/tests/test_h1_s6_github_webhook.py
@@ -120,8 +120,13 @@ async def _post(payload: dict, *, event: str, story=..., sign=True, installation
     try:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
             # legacy source(app secret 미설정 → app inert): 기존 무회귀 검증.
+            # story #2327 후속(legacy org repo-owner resolve) — 이 파일의 session.execute side_effect
+            # 시퀀스는 고정 순번을 가정하므로, 그 앞의 새 org-resolve 쿼리는 여기서 bypass(org_id=None,
+            # 기존 legacy 무회귀 그대로) — org resolve 자체는 test_bot_l1_pr_story_link.py 단위 커버.
             with patch.object(mod.settings, "github_webhook_secret", _SECRET), \
-                 patch.object(mod.settings, "github_app_webhook_secret", ""):
+                 patch.object(mod.settings, "github_app_webhook_secret", ""), \
+                 patch.object(mod, "_resolve_legacy_org_by_repo_owner",
+                              new=AsyncMock(return_value=(None, "repo_owner_unknown"))):
                 resp = await c.post("/api/v2/internal/verdict/github-webhook", content=body, headers=headers)
         return resp
     finally:


### PR DESCRIPTION
## 요약
- legacy webhook(이미 `github_webhook_secret` HMAC을 통과한 검증된 요청)이 org_id를 못 풀어 story_number/PR-link/auto_match 등 org-scope 필요 resolver 경로 전체가 막혀 있었다. 실측: `GITHUB_APP_WEBHOOK_SECRET` 미설정으로 app 경로 자체가 전무(legacy 23051건 vs app 0건, event='pull_request' 기준 processed 2/ignored 2580).
- `repository.full_name`의 owner를 `github_installation.account_login`과 **exactly-1-match**(0건·2건+는 거부 — 「첫 것을 고른다」 금지)로 대조해 legacy 경로에서도 org_id를 해소한다.
- PO 판정(2026-07-30, conversation 7256d5cc): 서명검증을 이미 통과한 요청에서 org를 못 푸는 것은 보안 경계가 아니라 결함 — 이 매치는 우회가 아니라 정공.

## 안전성
- 서명검증을 건너뛰지 않는다 — `_resolve_legacy_org_by_repo_owner`는 `_resolve_webhook_source`가 이미 `source='legacy'`로 확정한 요청에만 호출된다.
- `source`를 `'app'`으로 바꿔치지 않는다 — 계속 `'legacy'`로 정확히 기록(폴백이 app을 사칭하지 않음).
- 위험 조건 1개를 명시: legacy secret이 여러 org에 공유되면 A의 서명으로 B를 사칭 가능 — 지금은 `github_installation`이 1행뿐이라 위험 없음(PR 안 코멘트로 만료조건 남김: `GITHUB_APP_WEBHOOK_SECRET` 설정으로 app 경로가 라이브로 도는 것이 확認되면 다중 org 안전성을 다시 재고).
- 소급 재처리(과거 2575건)는 이 PR 범위 밖 — 새로 오는 웹훅에만 적용. 몇 건이 실제로 SID 태그를 갖고 있는지부터 세야 하는 별건.
- ⚠️**이 변경으로 legacy 경로가 org를 해소할 수 있게 된다** — 서명검증은 그대로이므로 권한 경계는 「legacy secret을 아는 자」로 동일하나, **그 자가 할 수 있는 일(org-scope resolver 전체)이 늘어난다**. legacy secret은 GitHub과 우리만 아는 값이고, 이 경로를 쓰기로 한 것 자체가 이 PR의 목적이라 **의도된 확장**이다(PO 판정, 2026-07-30) — 나중에 "legacy가 왜 org를 푸나"를 결함으로 오독하지 않도록 남긴다.

## 관측
- `skipped_reason` 신설 3종: `org_resolved_via_repo_owner`(성공) / `repo_owner_ambiguous`(2건+) / `repo_owner_unknown`(0건 또는 owner/repo 형식 아님) — 조용히 성공/실패하지 않고 셀 수 있게.
- 매 legacy 이벤트마다 `logger.info("legacy org resolve: ...")` 무조건 1회(Cloud Logging 카운트 가능).

## 테스트
- `_resolve_legacy_org_by_repo_owner` 단위 4종(정확1건/ambiguous/0건/형식오류-DB호출0회) — real 함수 직접 호출(patch 없음).
- `_process_webhook_event` 배선 3종(org가 resolver에 실제 전달됨 / ambiguous+org-scope-필요 skip → skipped_reason 대체 / 무관한 skip 사유는 안 덮어씀).
- 기존 close-on-merge 테스트 2종 — 새 로그 라인(legacy org resolve) 추가분 반영해 갱신.
- `test_bot_m2_webhook_integration.py`·`test_h1_s6_github_webhook.py` — 이 새 조회가 그 파일들의 고정 session.execute 호출 순번을 밀어 4건 RED였던 것을 발견·`_resolve_legacy_org_by_repo_owner`를 org_id=None 고정 bypass로 patch해 복구(그 파일들은 HMAC/dedup/rollback/native-CI 축이라 org-resolve와 무관한 축 — 새 경로 자체는 위 단위 4종이 patch 없이 잰다). bypass 제거→동일 4건 동일 시그니처로 RED 재현 확認 후 복원(격리가 실제로 일함을 실측).
- mutation self-check: ambiguous 가드(`len(rows) > 1`) 제거 → RED 확인 → 복원 → GREEN.
- 로컬 실PG(alembic upgrade heads, CI와 동일 env)로 전체 스위트(`pytest -m "not destructive_schema"`) 재확인 — 5391 passed(웹훅 관련 전건 포함). 남은 9건 실패는 이 PR과 무관한 로컬 머신 상태 테스트(ps aux 프로세스 수·MCP path contract) — `test_python_mcp_instances_running`은 `CI=true`에서 skip되도록 이미 설계돼 있어 실제 CI엔 애초에 안 뜨는 자리.

⚠️**후속 유의(PO 지적, 2026-07-30)**: `test_bot_m2_webhook_integration.py`·`test_h1_s6_github_webhook.py`의 세션 mock은 `session.execute()` 호출 **횟수·순번**을 고정해 검증한다 — 이는 「동작」이 아니라 「구현이 정확히 몇 번 쿼리하는가」를 고정하는 형태라, 앞으로 이 웹훅 경로에 쿼리를 하나만 더 추가해도(이번처럼) 무관한 이유로 깨질 수 있다. 오늘 고칠 범위는 아니라 남겨둔다.

## Test plan
- [x] 로컬 pytest green(81 passed, 웹훅 관련 전 파일)
- [x] 로컬 실PG 전체 스위트 재확인(5391 passed, 무관 9건 제외)
- [x] mutation self-check(sabotage→RED→restore→GREEN) — 신규 가드 + bypass-patch 둘 다
- [x] CI green
- [ ] PR 나간 뒤 실 legacy 웹훅에서 `org_resolved_via_repo_owner` 로그 관측(관찰 항목, merge 전 필수 아님)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
