### PR TITLE
[SID:2224] include=glance가 FE 4단 체인 어디서도 BE로 전달 안 되던 결함 fix

### DIFF
--- a/apps/web/src/app/api/goals/route.test.ts
+++ b/apps/web/src/app/api/goals/route.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// 결함 fix(2026-07-30) — `include` searchParam이 GET 핸들러에서 GoalService.list()로 한 번도
+// 전달되지 않았다(story #2298/#2303의 `include=glance` 옵트인이 이 지점에서부터 이미 죽어
+// 있었다 — #2224 초점 스트립 결함의 진짜 근본). ca37b2b0(stories route)와 같은 패턴으로
+// GoalService.list()를 목킹해 실제로 전달되는 filters 객체를 직접 검증한다.
+const h = vi.hoisted(() => ({
+  getAuthContext: vi.fn(), createGoalRepository: vi.fn(), list: vi.fn(),
+}));
+vi.mock('@/lib/auth-helpers', () => ({ getAuthContext: h.getAuthContext }));
+vi.mock('@/lib/storage/factory', () => ({ createGoalRepository: h.createGoalRepository }));
+vi.mock('@/services/goal', async (importActual) => ({
+  ...(await importActual<typeof import('@/services/goal')>()),
+  GoalService: class { list = h.list; },
+}));
+
+import { GET } from './route';
+
+const agent = () => ({ id: 'a', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
+
+describe('/api/goals GET — include(story #2298 glance 옵트인) forwarding', () => {
+  beforeEach(() => {
+    Object.values(h).forEach((m) => m.mockReset());
+    h.getAuthContext.mockResolvedValue(agent());
+    h.createGoalRepository.mockResolvedValue({});
+    h.list.mockResolvedValue([]);
+  });
+
+  it('forwards include=glance from the query string to GoalService.list()', async () => {
+    await GET(new Request('http://localhost/api/goals?project_id=p&order_by=position&include=glance'));
+
+    const calledWith = h.list.mock.calls[0]![0] as { include?: string };
+    expect(calledWith.include).toBe('glance');
+  });
+
+  it('omits include when the query string has none(기존 무옵션 호출 byte-identical 유지)', async () => {
+    await GET(new Request('http://localhost/api/goals?project_id=p'));
+
+    const calledWith = h.list.mock.calls[0]![0] as { include?: string };
+    expect(calledWith.include).toBeUndefined();
+  });
+});

--- a/apps/web/src/app/api/goals/route.ts
+++ b/apps/web/src/app/api/goals/route.ts
@@ -32,6 +32,12 @@ export async function GET(request: Request) {
       limit: positionMode ? pageInput.limit : pageInput.limit + 1,
       cursor: positionMode ? undefined : pageInput.cursor,
       order_by: orderBy,
+      // 결함 fix(2026-07-30) — `include=glance`가 여기서 한 번도 읽힌 적이 없어 story
+      // #2298/#2303의 participant_ids/focal_story 옵트인이 BE까지 한 번도 도달하지
+      // 못했다(선생님이 /flow에서 본 "열린 스토리가 없다"의 진짜 근본 — PR#2680의
+      // "focal_story 있는 active 에픽 우선" 로직은 focal_story가 애초에 안 오니 항상
+      // 폴백만 타는 죽은 코드였다). BE는 정확히 "glance" 리터럴만 특별취급하므로 그대로 전달.
+      include: searchParams.get('include') ?? undefined,
     });
     if (positionMode) {
       return apiSuccess(epics, { limit: pageInput.limit, hasMore: false, nextCursor: null });

--- a/apps/web/src/services/goal.ts
+++ b/apps/web/src/services/goal.ts
@@ -12,7 +12,7 @@ export class GoalService {
     return this.repository.create(input);
   }
 
-  async list(filters: { project_id?: string; limit?: number; cursor?: string | null; order_by?: string }) {
+  async list(filters: { project_id?: string; limit?: number; cursor?: string | null; order_by?: string; include?: string }) {
     return this.repository.list(filters);
   }
 

--- a/packages/core-storage/src/interfaces/IEpicRepository.ts
+++ b/packages/core-storage/src/interfaces/IEpicRepository.ts
@@ -56,6 +56,10 @@ export interface EpicListFilters extends PaginationOptions {
    * "position"(로드맵 조타·wedge #2)은 복합 정렬((position IS NULL) ASC, position ASC,
    * created_at DESC)이라 BE가 X-Next-Cursor를 내지 않는다 — 소비 측은 커서 이어달리기 금지. */
   order_by?: string;
+  /** 결함 fix(2026-07-30) — "glance"면 BE가 participant_ids/focal_story를 추가로 싣는다
+   * (story #2298 옵트인). 이 필드가 없어 route.ts→GoalService→ApiEpicRepository 4단 체인
+   * 전체가 이 파라미터를 한 번도 BE까지 실어 나르지 못했다(#2224 초점 스트립 결함의 진짜 근본). */
+  include?: string;
 }
 
 /** 로드맵 조타 재정렬(wedge #2·BE `PATCH /api/v2/epics/bulk`). 큐레이션한 에픽만 position 세팅. */

--- a/packages/storage-api/src/ApiEpicRepository.test.ts
+++ b/packages/storage-api/src/ApiEpicRepository.test.ts
@@ -1,0 +1,36 @@
+// 결함 fix(2026-07-30) — 083176e8(ApiStoryRepository의 `q` 소실)와 같은 클래스인지라: `include`가
+// 이 파일의 list() query 객체 조립 지점에서만 빠져 있었다. BE(goals.py)는 `include=glance`를
+// 정상 처리하는데(participant_ids/focal_story 추가), FE 4단 체인(route.ts→GoalService→
+// ApiEpicRepository) 전체가 그 파라미터를 한 번도 실어 나른 적이 없었다 — story #2298/#2303의
+// 옵트인이 배선 이후 지금까지 사실상 죽어 있었다(#2224 초점 스트립 결함의 진짜 근본).
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { ApiEpicRepository } from './ApiEpicRepository';
+
+describe('ApiEpicRepository.list — include(story #2298 glance 옵트인) 파라미터가 실제 요청 URL에 실린다', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [] }),
+    })) as unknown as ReturnType<typeof vi.fn>;
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  it('includes include=glance in the outgoing query string when filters.include is set', async () => {
+    const repo = new ApiEpicRepository('token');
+    await repo.list({ project_id: 'proj-1', include: 'glance' });
+
+    const requestedUrl = (fetchMock.mock.calls[0]![0] as URL | string).toString();
+    expect(requestedUrl).toContain('include=glance');
+  });
+
+  it('omits include from the query string when filters.include is undefined(기존 무옵션 호출 byte-identical 유지)', async () => {
+    const repo = new ApiEpicRepository('token');
+    await repo.list({ project_id: 'proj-1' });
+
+    const requestedUrl = (fetchMock.mock.calls[0]![0] as URL | string).toString();
+    expect(requestedUrl).not.toContain('include=');
+  });
+});

--- a/packages/storage-api/src/ApiEpicRepository.ts
+++ b/packages/storage-api/src/ApiEpicRepository.ts
@@ -14,12 +14,17 @@ export class ApiEpicRepository implements IEpicRepository {
     // story 8fc51517 AC5: BE B1(#2225) 라이브 확認 후 신 엔드포인트로 전환(/api/v2/epics는
     // deprecated 별칭으로 계속 서빙되나, 신규 소비는 /goals가 SSOT). 응답 필드명은 id 그대로
     // (goal_id 아님 — backend/app/schemas/goal.py GoalResponse 실측 확認, FE 타입 무변경).
+    // 결함 fix(2026-07-30) — `include`가 이 4번째 쿼리 인자로 빠져 있어 story #2298/#2303의
+    // `include=glance` 옵트인이 BE(`goal.py` `Query(...include...)`)까지 한 번도 도달하지
+    // 못했다. focal_story/participant_ids는 이 fix 이전엔 응답에 «키 자체가» 없었다(null도
+    // 아님) — #2224 초점 스트립이 항상 빈 이유의 진짜 근본.
     return fastapiCall<Epic[]>('GET', '/api/v2/goals', this.accessToken, {
       query: {
         project_id: filters.project_id,
         cursor: filters.cursor,
         limit: filters.limit,
         order_by: filters.order_by,
+        include: filters.include,
       },
     });
   }


### PR DESCRIPTION
## 배경

PR#2680(초점 스트립 hero 픽 로직 fix)을 배포 후 puppeteer로 라이브 픽셀 확인하다 발견: 머지·배포됐는데도 화면이 여전히 "지금 진행 중인 스토리가 없습니다"였다. 더 파보니 PR#2680의 진단이 불완전했다 — 진짜 근본은 훨씬 앞단에 있었다.

## 진짜 근본

`?include=glance`가 다음 4단 체인 어디에서도 백엔드로 전달된 적이 없다:

1. `apps/web/src/app/api/goals/route.ts` GET — `project_id`/`limit`/`cursor`/`order_by`만 파싱, `include`는 아예 안 읽음
2. `apps/web/src/services/goal.ts` `GoalService.list()` — filters 타입에 `include` 없음
3. `packages/core-storage` `EpicListFilters` — `include` 필드 없음
4. `packages/storage-api` `ApiEpicRepository.list()` — BE `/api/v2/goals` 호출 시 `{project_id, cursor, limit, order_by}` 4개만 하드코딩, `include` 없음

BE(`goal.py`)는 `include=glance`를 정상 지원(`participant_ids`/`focal_story` 추가, story #2298/#2303)하지만, FE가 그 파라미터를 한 번도 실어 나른 적이 없어 이 옵트인이 배선 이후 지금까지 사실상 죽어 있었다. 직접 확인: `Object.keys(epic)`에 `focal_story` 키 자체가 없다(`null`도 아님).

PR#2680의 "focal_story 실재하는 active 에픽 우선" 로직 자체는 틀리지 않았으나, `focal_story`가 애초에 응답에 안 오니 그 조건이 항상 거짓이라 폴백 분기만 타는 죽은 코드였다 — 오늘 팀이 반복해 잡은 "자기 재료를 못 만나는" 클래스를 이 PR이 만들 뻔했다.

## 수정

4단 전부에 `include`를 관통시킨다(route.ts → GoalService → EpicListFilters → ApiEpicRepository → BE 쿼리스트링).

## 검증

`ApiStoryRepository`의 083176e8(`q` 파라미터 소실)·stories route의 ca37b2b0와 같은 defect class·같은 테스트 패턴(fetch-spy로 실제 요청 URL/전달 filters 객체 직접 검증):

- `packages/storage-api/src/ApiEpicRepository.test.ts` 신규 2건
- `apps/web/src/app/api/goals/route.test.ts` 신규 2건
- 뮤테이션 검증: `route.ts`의 include 라인과 `ApiEpicRepository.ts`의 include 라인을 각각 제거 → 정확히 2건 RED(각 파일 1건씩) → 복원 GREEN
- tsc(apps/web·core-storage·storage-api 3곳 개별)·lint·vitest(apps/web 2210/2210 + storage-api 14/14)·build·`verify:*` 5종 전부 로컬 통과

## 남은 것

배포 후 puppeteer로 직접 재확인 예정 — `/glance`·`/flow` 둘 다 이제 실제 `focal_story`를 받는지, 그리고 PR#2680의 우선순위 로직이 이제 실제로 작동하는지(응답에 있다 ≠ 화면에 있다).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**PR#2680과의 관계**: #2680은 로직이 맞았고 «재료(focal_story)»가 애초에 응답에 안 와서 안 돌았다. 이 PR이 그 재료를 나른다 — #2680을 되돌리지 않는다(52→3으로 좁힌 로직 자체는 유효, 재료가 오면 그대로 작동한다).