### PR TITLE
[SID:2224] epic-flow-nodes FE 프록시 라우트 신설 — 브라우저 BE 직접호출 401 fix

### DIFF
--- a/apps/web/src/app/api/analytics/epic-flow-nodes/route.test.ts
+++ b/apps/web/src/app/api/analytics/epic-flow-nodes/route.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// 결함 fix(2026-07-30, 라이브 픽셀 검증 중 발견) — 이 라우트 자체가 없어서 flow-epic-nodes.tsx가
+// 백엔드 원본 경로(/api/v2/...)를 브라우저에서 직접 fetch했고 401(Missing Authorization
+// header)로 실패했다. dashboard/route.test.ts와 같은 패턴(proxyToFastapi 위임 검증).
+const { getOrgProjectAuthContext, proxyToFastapi } = vi.hoisted(() => ({ getOrgProjectAuthContext: vi.fn(), proxyToFastapi: vi.fn() }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
+
+import { GET } from './route';
+
+const PATH = '/api/v2/analytics/epic-flow-nodes';
+const agent = () => ({ id: 'a', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
+const okRes = (b: unknown = { epic_id: 'e1', now: { total: 0, items: [] }, upcoming: { total: 0, items: [] }, past: { total: 0 } }) =>
+  new Response(JSON.stringify(b), { status: 200, headers: { 'content-type': 'application/json' } });
+const req = () => new Request('http://localhost/api/analytics/epic-flow-nodes?project_id=p&epic_id=e1&upcoming_limit=15');
+
+describe('GET /api/analytics/epic-flow-nodes (proxy 위임)', () => {
+  beforeEach(() => { getOrgProjectAuthContext.mockReset(); proxyToFastapi.mockReset(); getOrgProjectAuthContext.mockResolvedValue(agent()); });
+
+  it('401 when unauthenticated', async () => {
+    getOrgProjectAuthContext.mockResolvedValue(null);
+    expect((await GET(req())).status).toBe(401);
+    expect(proxyToFastapi).not.toHaveBeenCalled();
+  });
+
+  it('delegates to the backend path with the same request(query string forwarded by proxyToFastapi)', async () => {
+    proxyToFastapi.mockResolvedValue(okRes());
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    expect(proxyToFastapi).toHaveBeenCalledWith(expect.anything(), PATH);
+    expect((await res.json()).data).toMatchObject({ epic_id: 'e1' });
+  });
+
+  it('passes through proxy errors', async () => {
+    proxyToFastapi.mockResolvedValue(new Response('e', { status: 500 }));
+    expect((await GET(req())).status).toBe(500);
+  });
+});

--- a/apps/web/src/app/api/analytics/epic-flow-nodes/route.ts
+++ b/apps/web/src/app/api/analytics/epic-flow-nodes/route.ts
@@ -1,0 +1,22 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// GET /api/analytics/epic-flow-nodes?project_id=&epic_id=&upcoming_limit= — 결함 fix(2026-07-30):
+// flow-epic-nodes.tsx가 이 프록시 라우트 없이 브라우저에서 백엔드 원본 경로
+// `/api/v2/analytics/epic-flow-nodes`를 직접 fetch해 401(Missing Authorization header)로
+// 라이브 픽셀 검증 중 실패했다 — 다른 모든 엔드포인트(glance/attention 등)와 같은
+// proxyToFastapi 패턴으로 인증 토큰을 실어 나른다(#2224 후속, PR#2679 계약).
+export async function GET(request: Request) {
+  try {
+    const me = await getOrgProjectAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+    const res = await proxyToFastapi(request, '/api/v2/analytics/epic-flow-nodes');
+    if (!res.ok) return res;
+    return apiSuccess(await res.json());
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/components/flow/flow-epic-nodes.tsx
+++ b/apps/web/src/components/flow/flow-epic-nodes.tsx
@@ -36,7 +36,11 @@ export function FlowEpicNodes({ projectId, epicId }: FlowEpicNodesProps) {
     // FlowCanvas에서 조건부 렌더 — 다른 행이 펼쳐지면 이 인스턴스 자체가 언마운트/재마운트된다,
     // "상세페이지 key-remount" 표준과 동형) effect 안에서 loading으로 재설정할 필요가 없다.
     let cancelled = false;
-    fetch(`/api/v2/analytics/epic-flow-nodes?project_id=${projectId}&epic_id=${epicId}&upcoming_limit=${UPCOMING_LIMIT}`)
+    // 결함 fix(2026-07-30, 라이브 픽셀 검증 중 발견) — `/api/v2/...`는 백엔드 원본 경로
+    // 패턴이지 FE가 브라우저에서 직접 부를 상대경로가 아니다(401 Missing Authorization
+    // header로 실패했다, 직접 실측). 다른 모든 엔드포인트처럼 FE 프록시 라우트
+    // (`/api/analytics/epic-flow-nodes/route.ts`)를 거쳐야 인증 토큰이 실린다.
+    fetch(`/api/analytics/epic-flow-nodes?project_id=${projectId}&epic_id=${epicId}&upcoming_limit=${UPCOMING_LIMIT}`)
       .then((r) => (r.ok ? r.json() : null))
       .then((json: unknown) => {
         if (cancelled) return;


### PR DESCRIPTION
## 배경

PR#2681(노드 틀)의 라이브 픽셀 검증(㉠펼치면 실제 노드가 나오는가) 중 발견 — 펼치면 "노드를 불러오지 못했습니다"(nodesError)로 실패.

## 원인

`flow-epic-nodes.tsx`가 `/api/v2/analytics/epic-flow-nodes`를 브라우저에서 직접 fetch했다. 이건 백엔드 원본 경로 패턴이지 FE가 호출할 상대경로가 아니다 — 직접 확인: 401 `{"error":{"code":"UNAUTHORIZED","message":"Missing Authorization header"}}`.

다른 모든 엔드포인트(`glance/attention`·`dashboard/overview` 등)는 FE 프록시 라우트(`apps/web/src/app/api/.../route.ts`)가 `proxyToFastapi`로 인증 토큰을 실어 백엔드를 대신 호출하는 구조인데, 이번 건 그 프록시 라우트 자체를 만들지 않고 클라이언트에서 백엔드 경로를 바로 부른 설계 실수였다.

## 결함 클래스

083176e8(`ApiStoryRepository`의 `q` 소실) · 오늘 아침 PR#2683(`include=glance` 4단 소실)과 같은 "FE↔BE 이음매" 결함 클래스의 세 번째 인스턴스 — 이번엔 이음매(프록시 라우트) 자체가 아예 없어서 요청이 BE에 닿지도 못했다.

## 수정

- `apps/web/src/app/api/analytics/epic-flow-nodes/route.ts` 신설 — `glance/attention/route.ts`와 같은 `proxyToFastapi` 패턴
- `flow-epic-nodes.tsx`의 fetch 대상을 `/api/v2/...`(BE 원본)에서 `/api/analytics/epic-flow-nodes`(FE 프록시)로 정정

## 검증

- `dashboard/route.test.ts`와 같은 패턴(proxyToFastapi 위임 검증) 신규 테스트 3건(401·성공 위임·에러 전달)
- 뮤테이션 확인: 프록시 대상 경로 문자열 오염 → 정확히 1건 RED → 복원 GREEN
- tsc·lint·vitest 2213/2213·build·`verify:*` 5종 전부 로컬 통과

## 남은 것

배포 후 puppeteer로 노드 틀 라이브 픽셀 재확인 예정(㉠실제 노드 표시 ㉡"67 중 15" 모양 ㉢단일 아코디언 ㉣접힘 기본).

🤖 Generated with [Claude Code](https://claude.com/claude-code)