### PR TITLE
fix(#2327): merge 웹훅이 PullRequestStoryLink에도 쓴다 — 화면이 읽는 축

### DIFF
--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -442,6 +442,25 @@ async def _process_webhook_event(
     if native_ci_state is not None:
         result = {**result, "native_ci": {"state": native_ci_state, "reason": native_ci_reason}}
 
+    # ⭐story #2327 후속(PO 판정, 2026-07-30, PR#2685 실 웹훅 시험대가 드러낸 갭) — merge 시
+    # PullRequestStoryLink 에도 쓴다. `Verdict`(record_verdict, 위 capture_pr_ci_verdict 안)에도
+    # 쓰고 `PullRequestStoryLink`(여기)에도 쓴다 — 전자는 «신뢰/게이트 축» · 후자는 «UI 가 읽는
+    # 링크 축»(GET /api/v2/integrations/github/links, github_integration.py). **둘이 갈리면 화면과
+    # 판정이 다른 말을 한다** — 그래서 같은 이벤트에서 둘 다 쓴다(중복이 아니라 각자 다른 소비처).
+    # ⛔여기서 도달한 story_id는 항상 confident 매치(explicit/auto-high/sid)뿐이라 rl.source가
+    # 'sid'/'auto_match'/'explicit' 중 하나 — 사람이 명시한 게 아닌 이상 'explicit'로 «절대» 안
+    # 찍힌다(오늘 소급 205건과 동일 라벨 규율). merge_link_evidence는 이미 있는 함수(scope-check
+    # 용도로 open/synchronize에서 이미 쓰임)를 그대로 재사용 — 새 함수 0개, org+repo+pr_number
+    # 존재 확인 후 upsert(멱등 — synchronize 뒤 merge가 와도 행 하나).
+    # ⭐만료 조건: #2327의 「Verdict를 정본으로 삼고 PullRequestStoryLink를 은퇴」 판단이 실행되면,
+    # 이 두 번째 쓰기(PullRequestStoryLink)는 그때 정리 대상이 된다.
+    if merged:
+        await merge_link_evidence(
+            session, org_id, story_id, repo, pr_number,
+            link_source=rl.source, confidence=rl.confidence,
+            patch={"webhook_merge": {"recorded_at": datetime.now(timezone.utc).isoformat()}},
+        )
+
     # ⛔story #2327 후속(PO 판정, 2026-07-30) — close-on-merge **정지**. 「머지 ≠ done, done은
     # 사람 확認 後」가 팀 규율인데 이 블록은 explicit/auto-high/sid confident link + merge만으로
     # 사람 확認 없이 즉시 done을 밀었다(advance_story_to_done 직접 호출) — 규율과 정면 충돌.

--- a/backend/tests/test_bot_l1_pr_story_link.py
+++ b/backend/tests/test_bot_l1_pr_story_link.py
@@ -447,6 +447,7 @@ async def test_process_webhook_event_legacy_repo_owner_org_feeds_resolver():
          patch.object(vmod, "resolve_story_for_pr", new=AsyncMock(return_value=rl)) as resolver, \
          patch.object(vmod, "capture_pr_ci_verdict",
                        new=AsyncMock(return_value={"recorded": ["pr"]})), \
+         patch.object(vmod, "merge_link_evidence", new=AsyncMock()), \
          patch.object(vmod.logger, "info"):
         await vmod._process_webhook_event(session, "legacy", "pull_request", payload, None, delivery)
     resolver.assert_awaited_once()
@@ -508,3 +509,87 @@ async def test_close_on_merge_skips_when_not_confident():
     # not-confident 는 suppressed 로그 대상이 아니다(로그 과다발생 방지) — legacy org resolve 로그만 1회.
     info_log.assert_called_once()
     assert "legacy org resolve" in info_log.call_args.args[0]
+
+
+# ── merge_link_evidence 자체(idempotent upsert, story #2327 후속 PR#2685 시험대 갭) ─────
+@pytest.mark.anyio
+async def test_merge_link_evidence_creates_when_no_existing_row():
+    """행이 없으면 patch만으로 신규 생성(link_source/confidence 그대로 실림)."""
+    from app.services.pr_story_link import merge_link_evidence
+
+    session = _session([_scalar(None)])  # existing 조회 → 없음.
+    link = await merge_link_evidence(
+        session, ORG_A, STORY_ID, "org/repo", 9,
+        link_source="sid", confidence="high", patch={"webhook_merge": {"recorded_at": "t1"}},
+    )
+    session.add.assert_called_once()
+    added = session.add.call_args.args[0]
+    assert added.link_source == "sid" and added.confidence == "high"
+    assert added.evidence == {"webhook_merge": {"recorded_at": "t1"}}
+
+
+@pytest.mark.anyio
+async def test_merge_link_evidence_idempotent_updates_existing_row_no_duplicate():
+    """행이 이미 있으면(예: synchronize 뒤 merge) 새로 안 만들고 evidence만 dict-merge —
+    두 번 불러도 행 하나(멱등, story #2327 PO 조건③)."""
+    from app.services.pr_story_link import merge_link_evidence
+
+    existing = MagicMock(evidence={"old_key": "kept"}, deleted_at=None, link_source="sid", confidence="high")
+    session = _session([_scalar(existing)])
+    result = await merge_link_evidence(
+        session, ORG_A, STORY_ID, "org/repo", 9,
+        link_source="sid", confidence="high", patch={"webhook_merge": {"recorded_at": "t2"}},
+    )
+    session.add.assert_not_called()  # 신규 생성 0 — 같은 행 재사용.
+    assert result is existing
+    assert result.evidence == {"old_key": "kept", "webhook_merge": {"recorded_at": "t2"}}  # dict-merge 보존.
+
+
+# ── _process_webhook_event: merge 시 PullRequestStoryLink 배선(story #2327 후속, PR#2685) ──
+@pytest.mark.anyio
+async def test_process_webhook_event_merge_writes_link_with_sid_label():
+    """merge + confident(sid) 링크 → merge_link_evidence가 link_source='sid'(사람이 명시한
+    'explicit' 아님)로 호출된다 — 오늘 소급 205건과 같은 라벨 규율(PO 조건①)."""
+    from app.routers import verdict_capture as vmod
+
+    session = AsyncMock()
+    delivery = _delivery()
+    rl = ResolvedLink(STORY_ID, ORG_A, "sid", "high", True, "sid_exact_by_number")
+    payload = {"action": "closed", "repository": {"full_name": "moonklabs/sprintable"},
+               "pull_request": {"number": 2685, "merged": True, "title": "[SID:2224] x"}}
+    with patch.object(vmod, "_resolve_legacy_org_by_repo_owner",
+                       new=AsyncMock(return_value=(ORG_A, "org_resolved_via_repo_owner"))), \
+         patch.object(vmod, "resolve_story_for_pr", new=AsyncMock(return_value=rl)), \
+         patch.object(vmod, "capture_pr_ci_verdict",
+                       new=AsyncMock(return_value={"recorded": ["pr", "ci"]})), \
+         patch.object(vmod, "merge_link_evidence", new=AsyncMock()) as link_write, \
+         patch.object(vmod.logger, "info"):
+        await vmod._process_webhook_event(session, "legacy", "pull_request", payload, None, delivery)
+    link_write.assert_awaited_once()
+    kwargs = link_write.call_args.kwargs
+    assert kwargs["link_source"] == "sid" and kwargs["link_source"] != "explicit"
+    assert kwargs["confidence"] == "high"
+    assert link_write.call_args.args[1:5] == (ORG_A, STORY_ID, "moonklabs/sprintable", 2685)
+
+
+@pytest.mark.anyio
+async def test_process_webhook_event_ci_only_does_not_write_link():
+    """merge가 아닌 CI-only 이벤트(merged=False)는 링크를 쓰지 않는다 — merge 분기로만
+    명시 스코프(PO 승인 범위, 「merge 분기」)."""
+    from app.routers import verdict_capture as vmod
+
+    session = AsyncMock()
+    delivery = _delivery()
+    rl = ResolvedLink(STORY_ID, ORG_A, "sid", "high", True, "sid_exact_by_number")
+    payload = {"repository": {"full_name": "moonklabs/sprintable"},
+               "workflow_run": {"conclusion": "failure", "head_sha": "sha1",
+                                "head_branch": "feat-[SID:2224]", "pull_requests": [{"number": 2685}]}}
+    with patch.object(vmod, "_resolve_legacy_org_by_repo_owner",
+                       new=AsyncMock(return_value=(ORG_A, "org_resolved_via_repo_owner"))), \
+         patch.object(vmod, "resolve_story_for_pr", new=AsyncMock(return_value=rl)), \
+         patch.object(vmod, "capture_pr_ci_verdict",
+                       new=AsyncMock(return_value={"recorded": ["ci"]})), \
+         patch.object(vmod, "merge_link_evidence", new=AsyncMock()) as link_write, \
+         patch.object(vmod.logger, "info"):
+        await vmod._process_webhook_event(session, "legacy", "workflow_run", payload, None, delivery)
+    link_write.assert_not_awaited()


### PR DESCRIPTION
## 요약
- PR#2685 실 웹훅 시험대(2026-07-30)에서 드러난 갭: org 해소·story 해소(#2224)·`Verdict` 기록까지는 흘렀는데, FE가 실제로 읽는 테이블(`pull_request_story_link`, `GET /api/v2/integrations/github/links`)에는 merge 이벤트가 아무것도 안 쓰고 있었다.
- 이 갭은 이미 `session_context_core.py` 헤더 주석에 story #2327 자신으로 등재돼 있었다 — 유일한 쓰기처가 explicit-link API(`POST /links`)와 open/synchronize 이벤트의 scope-check(`merge_link_evidence`)뿐, merge(`action="closed"`)는 그 조건에 안 걸렸다.
- `merge_link_evidence()`(이미 있는 함수, scope-check용으로 이미 씀)를 merge 분기에 재사용 — 새 함수 0개.

## 라벨 규율(PO 조건①)
- `link_source=rl.source` 그대로 전달 — 여기 도달하는 건 항상 confident 매치(explicit/auto-high/sid)뿐이라 사람이 명시하지 않는 한 `'explicit'`로 절대 안 찍힌다. 오늘 소급 205건(`link_source='sid'`)과 동일 라벨 규율.

## 이중 쓰기 명시(PO 조건②)
- `Verdict`(신뢰/게이트 축)와 `PullRequestStoryLink`(UI 링크 축)에 같은 이벤트에서 둘 다 쓴다 — 서로 다른 목적의 별개 테이블이라 중복이 아니다. 코드 주석에 이유 + 만료조건(#2327의 「Verdict 정본화+PullRequestStoryLink 은퇴」 판단이 서면 이 두 번째 쓰기는 그때 정리 대상) 명시.

## 멱등(PO 조건③)
- `merge_link_evidence`는 기존 행 존재 확인 후 upsert(dict-merge evidence, link_source/confidence는 최초 생성 값 유지) — synchronize 뒤 merge가 와도 행 하나.

## 테스트
- `merge_link_evidence` 단위 2종(신규 생성 / 기존 행 dict-merge 멱등 — 이 함수 자체에 대한 직접 커버가 이전에 없었음).
- 배선 2종(`merge` + confident → `link_source='sid'`로 호출 / CI-only 이벤트는 안 씀 — 명시 스코프인 「merge 분기」로만 한정).
- 기존 배선 테스트 1건 패치 추가(`merge_link_evidence` 신규 호출 반영, 미패치 시 세션 mock이 코루틴을 그대로 대입해 `AttributeError`).
- mutation self-check: `if merged:` 블록 제거 → RED 확인 → 복원 → GREEN.
- 로컬 실PG(**fresh** DB, `alembic upgrade heads`, CI와 동일 env)로 전체 스위트 재확인 — 5391 passed. 먼저 재사용 DB로 돌렸을 때 5개 추가 실패(슬러그/문서 realdb 테스트)가 났었는데 fresh DB로 재실행하니 전부 사라짐 — 오늘 반복 실행으로 누적된 로컬 DB 상태 문제였지 이 diff의 회귀가 아님(직접 재현·재확인).

## Test plan
- [x] 로컬 pytest green(89 passed, 웹훅+신규 테스트 전 파일)
- [x] 로컬 실PG fresh DB 전체 스위트 재확인(5391 passed)
- [x] mutation self-check(sabotage→RED→restore→GREEN)
- [ ] CI green
- [ ] 배포 후 다음 merge PR에서 `pull_request_story_link` 행이 실제로 생기는지 + `GET /api/v2/integrations/github/links`로 화면에 보이는지 라이브 확認(관찰 항목)

🤖 Generated with [Claude Code](https://claude.com/claude-code)