### PR TITLE
feat(#2346 AC3/AC7): stories.py 긴 텍스트 급감 — 기록 + 기계 게이트

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -394,6 +394,20 @@ def _enforce_mcp_attachment_declared_limit(attachments: list[dict]) -> None:
 
 _STORY_LINK_TABLES = {"epic_id": "goals", "sprint_id": "sprints", "meeting_id": "meetings"}
 
+# ⛔story #2346 AC3(2026-07-30, story 하나만 먼저 — docs.py/agent_runs.py는 미착수, 아래
+# _STORY_UPDATED_ACTIVITY_TODO 참조): 「긴 텍스트 필드」의 정의를 한 자리 상수로 — 필드명을
+# 흩어 놓지 않는다. 나중에 필드가 늘면 여기만 고친다.
+_LENGTH_TRACKED_FIELDS = ("description", "acceptance_criteria")
+# ⛔story #2346 AC7(2026-07-30, PO 판정 — 사람 세기에서 기계 게이트로 격상): 같은 날 실제로
+# 난 3건의 급감 사고가 전부 -80%대였다(3619→437·4052→경고문구·2121→진행현황뿐) — 그보다
+# 훨씬 낮은 50%를 임계로 잡아도 셋 다 막혔을 것이다. `allow_shrink=true`로 명시 승인 가능.
+_SHRINK_BLOCK_THRESHOLD = 0.5
+# ⛔story #2346 AC7 회귀 발견(2026-07-30): 짧은 문자열(예: entity 토큰 하나)은 몇 글자만
+# 바뀌어도 퍼센트가 크다("[Target](entity:doc:…)"(~48자)→"no tokens here"(14자)가 -70%지만
+# 무해한 정상 편집이다) — 이 게이트는 «긴 텍스트 필드의 참사적 손실»을 막는 것이지 «모든
+# 문자열의 비율 변화»를 막는 게 아니므로, 원본이 이 길이 미만이면 게이트를 안 켠다.
+_SHRINK_BLOCK_MIN_LENGTH = 200
+
 
 async def _assert_story_link_targets_in_project(
     session: AsyncSession, project_id: uuid.UUID, body: "StoryCreate | StoryUpdate",
@@ -1408,6 +1422,8 @@ async def update_story(
         if settings.is_ee_enabled:
             from ee.plan_limits import check_storage_capacity  # type: ignore[import]
             await check_storage_capacity(db, repo.org_id, data["attachments"])
+    # ⛔story #2346 AC7: allow_shrink는 stories 컬럼이 아니므로 repo.update 전에 분리(assignee_ids와 동형).
+    allow_shrink = data.pop("allow_shrink", False)
     # E-BOARD S5: assignee_ids는 stories 컬럼이 아니므로 repo.update 전에 분리.
     assignee_ids_in = data.pop("assignee_ids", None)
     # assignee_ids만 제공되면 단일 assignee_id(주담당)를 첫 요소로 동기화 → 기존 event/notify 로직 재사용.
@@ -1415,13 +1431,37 @@ async def update_story(
         data["assignee_id"] = assignee_ids_in[0] if assignee_ids_in else None
     old_assignee_id: uuid.UUID | None = None
     old_position: int | None = None
+    old_field_lengths: dict[str, int] = {}
     story_before = None
     # story #2172 AC2: position 변경도 old-value 대조가 필요해 assignee_id와 같은 사전조회를 공유.
-    if "assignee_id" in data or "position" in data:
+    # story #2346 AC3: 긴 텍스트 필드 급감 기록도 같은 사전조회(repo.update() 前 old 값)가 필요.
+    if "assignee_id" in data or "position" in data or any(f in data for f in _LENGTH_TRACKED_FIELDS):
         story_before = await repo.get(id)
         if story_before:
             old_assignee_id = story_before.assignee_id
             old_position = story_before.position
+            # ⛔story_before는 같은 세션의 identity map이라 repo.update() 뒤 story와 «같은
+            # 객체»가 된다(속성이 그 자리서 덮어써짐) — old_assignee_id/old_position처럼
+            # «스칼라 값»으로 지금 떠 둬야 update 前 값을 실제로 보존한다.
+            for _f in _LENGTH_TRACKED_FIELDS:
+                if _f in data:
+                    old_field_lengths[_f] = len(getattr(story_before, _f) or "")
+    # ⛔story #2346 AC7: 긴 텍스트 필드가 50% 이상 줄면 거부 — 오늘 실제 3건 사고(모두 -80%대)가
+    # 전부 이 게이트에 막혔을 것이다. allow_shrink=true로 명시 승인(정당한 축약)만 통과.
+    if old_field_lengths and not allow_shrink:
+        for _f, _before_len in old_field_lengths.items():
+            if _before_len < _SHRINK_BLOCK_MIN_LENGTH:
+                continue
+            _after_len = len(data.get(_f) or "")
+            if _after_len < _before_len * (1 - _SHRINK_BLOCK_THRESHOLD):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"{_f} shrank {_before_len}→{_after_len} chars "
+                        f"({round((1 - _after_len / _before_len) * 100)}% smaller) — "
+                        "if intentional, resend with allow_shrink=true"
+                    ),
+                )
     # H1-S5: PATCH /{id} 로 status=done 전이 시도도 board 경로와 동일하게 preflight 게이트(AC②).
     if data.get("status") == "done":
         gate_story = story_before or await repo.get(id)
@@ -1573,6 +1613,19 @@ async def update_story(
     # S-C2: story_updated — actor가 agent인 경우 기록 (AC2, AC6)
     if actor_id:
         from app.services.activity_log import record_activity_bg
+        _context: dict = {"fields": list(data.keys()), "story_title": story.title}
+        # ⛔story #2346 AC3(2026-07-30): 「지워졌는지 원래 없었는지 구분할 수단이 없다」던
+        # 갭 — 전문 스냅샷은 비싸 「이전 길이 → 이후 길이」만 남긴다. 길이가 «안 변한» 경우엔
+        # 안 남긴다(양성 대조 — 매번 남으면 로그가 잡음이 된다). docs.py·agent_runs.py는
+        # 아직 activity 로깅 자체가 없어 미착수 — #2346 본문에 남은 항목으로 적어 둔다.
+        if old_field_lengths:
+            _length_changes = {}
+            for _f, _before_len in old_field_lengths.items():
+                _after_len = len(getattr(story, _f) or "")
+                if _before_len != _after_len:
+                    _length_changes[_f] = {"before": _before_len, "after": _after_len}
+            if _length_changes:
+                _context["length_changes"] = _length_changes
         background_tasks.add_task(
             record_activity_bg,
             org_id=repo.org_id,
@@ -1581,7 +1634,7 @@ async def update_story(
             project_id=story.project_id,
             entity_type="story",
             entity_id=id,
-            context={"fields": list(data.keys()), "story_title": story.title},
+            context=_context,
         )
 
     await _attach_assignee_ids(db, repo.org_id, [story])

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -402,11 +402,12 @@ _LENGTH_TRACKED_FIELDS = ("description", "acceptance_criteria")
 # 난 3건의 급감 사고가 전부 -80%대였다(3619→437·4052→경고문구·2121→진행현황뿐) — 그보다
 # 훨씬 낮은 50%를 임계로 잡아도 셋 다 막혔을 것이다. `allow_shrink=true`로 명시 승인 가능.
 _SHRINK_BLOCK_THRESHOLD = 0.5
-# ⛔story #2346 AC7 회귀 발견(2026-07-30): 짧은 문자열(예: entity 토큰 하나)은 몇 글자만
-# 바뀌어도 퍼센트가 크다("[Target](entity:doc:…)"(~48자)→"no tokens here"(14자)가 -70%지만
-# 무해한 정상 편집이다) — 이 게이트는 «긴 텍스트 필드의 참사적 손실»을 막는 것이지 «모든
-# 문자열의 비율 변화»를 막는 게 아니므로, 원본이 이 길이 미만이면 게이트를 안 켠다.
-_SHRINK_BLOCK_MIN_LENGTH = 200
+# ⛔story #2346 AC7 정정(2026-07-30, PO 지적 — 「원본 길이」 floor는 구멍을 남긴다): 200자
+# 본문이 통째로 지워지는 것("읽지 않고 쓰는" 것 자체가 문제지 길이가 아니다)은 원본-길이
+# floor로는 안 막혔다. 「원본 길이」 대신 「손실 절대량」으로 자를 바꾼다 — floor가 필요
+# 없어진다: entity 토큰(~48자→14자, -70%지만 -34자)은 절대량이 작아 안 막히고, 200자→10자
+# (-95%·-190자)는 막힌다 — 특수 분기 없이 자연히 갈린다.
+_SHRINK_BLOCK_MIN_LOST_CHARS = 100
 
 
 async def _assert_story_link_targets_in_project(
@@ -1450,10 +1451,12 @@ async def update_story(
     # 전부 이 게이트에 막혔을 것이다. allow_shrink=true로 명시 승인(정당한 축약)만 통과.
     if old_field_lengths and not allow_shrink:
         for _f, _before_len in old_field_lengths.items():
-            if _before_len < _SHRINK_BLOCK_MIN_LENGTH:
+            if _before_len == 0:
                 continue
             _after_len = len(data.get(_f) or "")
-            if _after_len < _before_len * (1 - _SHRINK_BLOCK_THRESHOLD):
+            _lost_chars = _before_len - _after_len
+            _is_relative_shrink = _after_len < _before_len * (1 - _SHRINK_BLOCK_THRESHOLD)
+            if _is_relative_shrink and _lost_chars >= _SHRINK_BLOCK_MIN_LOST_CHARS:
                 raise HTTPException(
                     status_code=400,
                     detail=(

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -171,6 +171,10 @@ class StoryUpdate(BaseModel):
     # outcome_status/outcome_result는 Update 제외 — 채점잡 전용
     # E-CAGE-REFEREE P1: 오염 마킹 (PO 직접 플래그, 자동 대량 마킹 금지)
     is_excluded: bool | None = None
+    # ⛔story #2346 AC7(2026-07-30, PO 판정 — 「사람 세기」에서 「기계 게이트」로 격상): 긴
+    # 텍스트 필드(description·acceptance_criteria)가 절반 이상 줄면 기본 거부한다(오늘 3건
+    # 모두 -80%대 급감 — 정당한 축약이면 이 플래그로 명시 승인한다).
+    allow_shrink: bool = False
 
     @field_validator("metric_definition")
     @classmethod

--- a/backend/tests/test_2346_story_update_length_change_activity_realdb.py
+++ b/backend/tests/test_2346_story_update_length_change_activity_realdb.py
@@ -1,0 +1,267 @@
+"""story #2346 AC3(범위: stories 하나만 — docs.py·agent_runs.py는 미착수, 본문 참조) — 긴
+텍스트 필드(description·acceptance_criteria)가 update_story로 바뀔 때 「이전 길이 → 이후
+길이」를 기존 story_updated activity log의 context에 얹는다(신규 장치 0, 전문 스냅샷 아님).
+
+양성 대조: 길이가 안 변하면(또는 그 필드가 아예 안 바뀌면) length_changes 자체가 안 남는다
+— 매번 남으면 로그가 잡음이 된다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import BackgroundTasks
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("ab910000-0000-0000-0000-000000000001")
+PROJ = uuid.UUID("ab910000-0000-0000-0000-000000000002")
+STORY = uuid.UUID("ab910000-0000-0000-0000-000000000003")
+AGENT_IN = uuid.UUID("ab910000-0000-0000-0000-0000000000a1")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _auth() -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(AGENT_IN), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(ORG),
+    )
+
+
+async def _seed(s, initial_description: str) -> None:
+    for sql in [
+        f"DELETE FROM activity_logs WHERE org_id='{ORG}'",
+        f"DELETE FROM stories WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','2346SD','s2346-org','free')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ}','{ORG}','P','none')",
+        f"INSERT INTO members (id,org_id,type,name) VALUES ('{AGENT_IN}','{ORG}','agent','AgentIn')",
+        f"INSERT INTO project_access (project_id,member_id,permission) VALUES ('{PROJ}','{AGENT_IN}','granted')",
+    ]:
+        await s.execute(text(sql))
+    await s.execute(
+        text(
+            "INSERT INTO stories (id,org_id,project_id,title,status,priority,description) "
+            "VALUES (:id,:org,:proj,'test story','backlog','medium',:desc)"
+        ),
+        {"id": STORY, "org": ORG, "proj": PROJ, "desc": initial_description},
+    )
+    await s.commit()
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _fetch_latest_story_updated_context(Session):
+    async with Session() as s:
+        row = (
+            await s.execute(
+                text(
+                    "SELECT context FROM activity_logs WHERE org_id=:org AND action='story_updated' "
+                    "ORDER BY created_at DESC LIMIT 1"
+                ),
+                {"org": ORG},
+            )
+        ).scalar_one_or_none()
+        return row
+
+
+@pytest.mark.anyio
+async def test_shrinking_description_records_before_after_length():
+    """AC3 핵심 — 3619자 → 437자 같은 급감이 story_updated activity의 context.length_changes에
+    남는지(오늘 실제 사고 재현 규모)."""
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        long_desc = "x" * 3619
+        async with Session() as s:
+            await _seed(s, long_desc)
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            bg = BackgroundTasks()
+            short_desc = "y" * 437
+            # AC7 게이트(50% 이상 급감 차단)가 이 크기의 축소를 막으므로 allow_shrink=true로
+            # 명시 승인 — 이 테스트는 AC3(length_changes 기록) 검증이지 AC7 게이트 검증이 아니다.
+            await update_story(
+                STORY, StoryUpdate(description=short_desc, allow_shrink=True), bg, repo=repo, db=s, auth=_auth(),
+            )
+            await bg()
+
+        context = await _fetch_latest_story_updated_context(Session)
+        assert context is not None, "story_updated activity가 안 남음"
+        assert context["length_changes"]["description"] == {"before": 3619, "after": 437}
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_unchanged_length_does_not_pollute_the_log():
+    """양성 대조 — description을 같은 길이의 다른 텍스트로 바꾸면 length_changes 자체가
+    안 남는다(매번 남으면 잡음)."""
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        original = "a" * 100
+        async with Session() as s:
+            await _seed(s, original)
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            bg = BackgroundTasks()
+            same_length_different_text = "b" * 100
+            await update_story(
+                STORY, StoryUpdate(description=same_length_different_text), bg, repo=repo, db=s, auth=_auth(),
+            )
+            await bg()
+
+        context = await _fetch_latest_story_updated_context(Session)
+        assert context is not None
+        assert "length_changes" not in context, f"길이가 안 변했는데 기록됨(잡음): {context}"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_untouched_field_not_included_even_if_other_field_changes():
+    """양성 대조 — description은 안 건드리고 title만 바꾸면, description은 length_changes에
+    안 실린다(건드린 필드만 잰다)."""
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s, "unchanged description")
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            bg = BackgroundTasks()
+            await update_story(
+                STORY, StoryUpdate(title="new title"), bg, repo=repo, db=s, auth=_auth(),
+            )
+            await bg()
+
+        context = await _fetch_latest_story_updated_context(Session)
+        assert context is not None
+        assert "length_changes" not in context, f"안 건드린 필드가 기록됨: {context}"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac7_shrink_over_50_percent_blocked_without_flag():
+    """AC7(2026-07-30, PO 판정 — 사람 세기에서 기계 게이트로 격상) 핵심 — description이
+    50% 이상 줄면 allow_shrink 없이는 400. 오늘 실제 3건 사고(전부 -80%대) 재현 규모."""
+    from fastapi import HTTPException
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        long_desc = "x" * 3619
+        async with Session() as s:
+            await _seed(s, long_desc)
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            bg = BackgroundTasks()
+            short_desc = "y" * 437  # -88%, 오늘 #2268 사고와 동일 규모
+            with pytest.raises(HTTPException) as ei:
+                await update_story(
+                    STORY, StoryUpdate(description=short_desc), bg, repo=repo, db=s, auth=_auth(),
+                )
+            assert ei.value.status_code == 400
+            assert "3619" in ei.value.detail and "437" in ei.value.detail
+
+        # 봉인 — 거부됐으니 원본이 그대로 살아 있어야 한다(부분 적용 없음).
+        async with Session() as s:
+            row = (await s.execute(
+                text("SELECT description FROM stories WHERE id=:i"), {"i": STORY}
+            )).scalar_one()
+            assert row == long_desc, "거부됐는데 description이 바뀜(부분 적용 회귀)"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac7_shrink_with_allow_shrink_flag_passes():
+    """AC7 — allow_shrink=true로 명시 승인하면 같은 급감도 통과한다(정당한 축약 경로)."""
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        long_desc = "x" * 3619
+        async with Session() as s:
+            await _seed(s, long_desc)
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            bg = BackgroundTasks()
+            short_desc = "y" * 437
+            resp = await update_story(
+                STORY, StoryUpdate(description=short_desc, allow_shrink=True), bg, repo=repo, db=s, auth=_auth(),
+            )
+            assert resp.description == short_desc
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac7_small_shrink_under_threshold_not_blocked():
+    """양성 대조 — 50% 미만 축소(정상적인 편집 범위)는 플래그 없이도 통과한다(잡음 방지)."""
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        original = "x" * 100
+        async with Session() as s:
+            await _seed(s, original)
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            bg = BackgroundTasks()
+            slightly_shorter = "y" * 60  # -40%, 임계(50%) 밑
+            resp = await update_story(
+                STORY, StoryUpdate(description=slightly_shorter), bg, repo=repo, db=s, auth=_auth(),
+            )
+            assert resp.description == slightly_shorter
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_2346_story_update_length_change_activity_realdb.py
+++ b/backend/tests/test_2346_story_update_length_change_activity_realdb.py
@@ -265,3 +265,56 @@ async def test_ac7_small_shrink_under_threshold_not_blocked():
             assert resp.description == slightly_shorter
     finally:
         await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac7_absolute_loss_catches_the_200_char_gap_floor_used_to_miss():
+    """AC7 정정(2026-07-30, PO 지적) — 「원본 길이」 floor는 200자 미만 본문의 완전 삭제를
+    안 막는 구멍이 있었다. 「손실 절대량」 자로 바꿔 이 정확한 사례(200자→10자, -95%·-190자)가
+    이제 막히는지."""
+    from fastapi import HTTPException
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        original = "x" * 200
+        async with Session() as s:
+            await _seed(s, original)
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            bg = BackgroundTasks()
+            with pytest.raises(HTTPException) as ei:
+                await update_story(
+                    STORY, StoryUpdate(description="y" * 10), bg, repo=repo, db=s, auth=_auth(),
+                )
+            assert ei.value.status_code == 400
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac7_small_absolute_loss_not_blocked_even_at_high_percentage():
+    """양성 대조 — entity 토큰류 짧은 문자열은 퍼센트가 커도(절대량이 작으면) 안 막힌다.
+    test_2301의 "[Target](entity:doc:…)"(~48자)→"no tokens here"(14자, -70%·-34자) 재현."""
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        token_like = "[Target](entity:doc:11111111-1111-1111-1111-111111111111)"  # 48자
+        async with Session() as s:
+            await _seed(s, token_like)
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            bg = BackgroundTasks()
+            resp = await update_story(
+                STORY, StoryUpdate(description="no tokens here"), bg, repo=repo, db=s, auth=_auth(),
+            )
+            assert resp.description == "no tokens here"
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## Summary
**AC3**(변경 이력, story 범위만 먼저 — docs.py·agent_runs.py는 activity 로깅 자체가 없어 미착수, `#2346` 본문에 항목으로 남김): `update_story`의 기존 `story_updated` activity log(신규 장치 0)에 `description`·`acceptance_criteria`가 바뀔 때 "이전 길이→이후 길이"를 얹는다. 길이가 안 변하면(또는 안 건드린 필드면) 안 남긴다.

**AC7**(PO 판정 격상 — "사람 세기"에서 "기계 게이트"로): 오늘 실제로 같은 종류의 사고가 세 번 났다(①#2268 3619→437 ②story_id 혼동으로 #2342 덮어씀 ③#2346 자체를 고치며 그 스토리가 지적한 실수를 반복). `description`·`acceptance_criteria`가 50% 이상 **그리고** 100자 이상 소실되면 기본 거부(400)하고 `allow_shrink=true`로만 명시 승인한다.

⛔**정정(PO 지적, 07:48Z)**: 처음엔 「원본 ≥200자」floor를 뒀으나, 200자 미만 본문의 완전 삭제(예: 200자→10자, -95%·-190자)를 안 막는 구멍이 있었다. 자를 「원본 길이」에서 「손실 절대량」(100자 이상)으로 바꿔 floor를 없앴다 — entity 토큰류(~48자→14자, -70%지만 -34자)는 절대량이 작아 특수 분기 없이 자연히 안 막히고, 200자→10자는 막힌다.

## ⛔이 게이트가 «못 잡는 것»(PO 요청 — 가드는 못 잡는 것도 선언한다)
- ㉠ title·다른 필드(description·acceptance_criteria 외)의 손실
- ㉡ docs.py·agent_runs.py — activity 로깅 자체가 없어 이 게이트도 없음(미착수)
- ㉢ **「덮어쓴 대상이 틀린」 경우(#2342형, story_id 혼동)** — 길이가 안 줄어도(또는 오히려 늘어도) 엉뚱한 스토리를 고칠 수 있다. 이게 큰 구멍이다.

## Test plan
- [x] 실PG 테스트 15건(길이기록 3 + 게이트 5, 기존 `test_2301` 7건 포함 무회귀)
- [x] 50%+ 급감 차단(부분 적용 없음 확認) · `allow_shrink`로 통과 · 200자→10자(절대량 게이트로 새로 막힘) · entity 토큰류(절대량 작아 여전히 안 막힘)
- [x] 전체 스위트 5414 passed(남은 8건은 develop에서도 동일 실패 — 로컬환경 의존)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>