### PR TITLE
feat(#2679): epic-flow-nodes에 epic_ids 배치 지원 — L3 캔버스 N+1 방지

### DIFF
--- a/backend/app/repositories/analytics.py
+++ b/backend/app/repositories/analytics.py
@@ -366,35 +366,45 @@ class AnalyticsRepository:
     async def get_epic_flow_nodes(
         self, project_id: uuid.UUID, epic_id: uuid.UUID, upcoming_limit: int = 15,
     ) -> dict:
-        """story #2224(S2-1, 갈래 화면) 노드 계약 — 급전환(2026-07-30, PO 판정): "N+1이라
-        노드를 안 그린다"는 안 그릴 이유가 아니라 BE 계약을 하나 더 만들 이유였다(선생님 질책).
+        """story #2224(S2-1, 갈래 화면) 노드 계약 — 단일 에픽 편의 래퍼. 실 쿼리는
+        `get_epic_flow_nodes_batch`(story #2679, 2026-07-30 — L3 캔버스가 여러 레인을
+        «한 화면»에 동시에 그리게 되며 «에픽 하나»뿐이던 이 계약이 레인 수만큼 호출을
+        요구하게 됐다, 오늘 금지한 그 패턴)가 하고, 이 메서드는 배치 결과에서 하나만 꺼낸다
+        — 로직을 두 곳에 두지 않는다."""
+        batch = await self.get_epic_flow_nodes_batch(project_id, [epic_id], upcoming_limit)
+        return batch["epics"][0]
 
-        ⛔한 에픽 최대 141건(dev 실측) — 179개 에픽 전체를 한 번에 주면(수천 건) 응답이
-        죽는다. 그래서 이 계약은 «에픽 하나» 단위다(?epic_id= 필수) — 좌 레인(전체 에픽
-        요약)은 이미 get_epics_progress_lane이 주고, 펼친 에픽만 이 함수가 노드를 준다
-        (유나 "접기/펴기 1차 필수"와 맞물림). 한 에픽 141건이면 단일 쿼리로 N+1 없이 충분.
+    # ⛔story #2679 AC1(2026-07-30, PO 급요청 — #2346보다 먼저): epic_ids 상한. 179개 에픽
+    # 전체를 한 번에 받으면(에픽당 최대 141건 실측) 응답이 죽는다 — L3 캔버스가 실제로
+    # 동시에 그리는 레인 수(오늘 예시 6개)보다 5배 넉넉히 잡는다. 넘으면 앞 N개만 처리하고
+    # 잘린 epic_id들을 명시한다(오늘 규율 그대로 — "없앤 것"이 아니라 "안 그린 것").
+    EPIC_FLOW_NODES_BATCH_MAX = 30
 
-        세 구역(시간축) — ⛔7상태(실행가능·검증필요·멈춤·연결미상…, 노드에 붙는 «표시»)와는
-        다른 축이다. 섞으면 같은 것을 두 번 말하는 것이라 여기서는 구역만 가른다:
-          ①지금(now)     = status in {in-progress, in-review} — "검토 중"도 사람이 지금
-                            손대는 중이라 지금에 든다(PO 판정). ready-for-dev는 안 넣는다 —
-                            "잡을 수 있는 것"과 "잡고 있는 것"이 섞인다. «전량» 반환.
-          ②이어질(upcoming) = 나머지(backlog·ready-for-dev 등, done 제외) — «상위 upcoming_limit
-                            건»만. 순서: 막힌 것(pending Gate·requires_human=true·
-                            evidence_status=insufficient, 좌 레인과 같은 정의) > 실행가능
-                            (status=='ready-for-dev', PO: "이어질 것의 맨 앞") > 나머지, 그
-                            안에서 최근 변경 순. ⛔잘린 개수를 반드시 함께 낸다("없앤 것"이
-                            아니라 "안 그린 것" — 오늘 규율 그대로).
-          ③지나온(past)  = status=='done' — ⛔노드로 안 그린다. «수»로만 접는다.
+    async def get_epic_flow_nodes_batch(
+        self, project_id: uuid.UUID, epic_ids: list[uuid.UUID], upcoming_limit: int = 15,
+    ) -> dict:
+        """story #2679 — epic_flow_nodes를 N개 에픽에 대해 «한 번의 호출»로 낸다(FE가
+        이미 아는 epic_id 목록을 넘긴다 — lane과 다른 정렬을 새로 판정하지 않는다, PO 판정).
+
+        N+1 없음: story 쿼리 1번(전체 epic_ids에 IN) + Gate 쿼리 1번(전체 story_ids에 IN) —
+        에픽 개수와 무관하게 쿼리 수 고정, get_epics_progress_lane과 같은 패턴.
+
+        세 구역(시간축) 정의는 get_epic_flow_nodes(단일)와 100% 동일(한 자리에서만 정의 —
+        두 곳이 각자 정의하면 갈린다): ①지금=in-progress+in-review ②이어질=나머지(상위
+        upcoming_limit만, 막힌 것>ready-for-dev>나머지 순) ③지나온=done(수만).
         """
+        requested = list(dict.fromkeys(epic_ids))  # 순서 보존 중복 제거
+        processed = requested[: self.EPIC_FLOW_NODES_BATCH_MAX]
+        skipped = requested[self.EPIC_FLOW_NODES_BATCH_MAX:]
+
         stories_r = await self.session.execute(
             select(
                 Story.id, Story.story_number, Story.title, Story.status,
-                Story.assignee_id, Story.updated_at,
+                Story.assignee_id, Story.updated_at, Story.epic_id,
             ).where(
                 Story.project_id == project_id,
                 Story.org_id == self.org_id,
-                Story.epic_id == epic_id,
+                Story.epic_id.in_(processed),
                 Story.deleted_at.is_(None),
             )
         )
@@ -423,27 +433,39 @@ class AnalyticsRepository:
                 "updated_at": s.updated_at.isoformat(),
             }
 
-        now_items, upcoming_all, past_count = [], [], 0
+        by_epic: dict[uuid.UUID, dict] = {
+            eid: {"now_items": [], "upcoming_all": [], "past_count": 0} for eid in processed
+        }
         for s in stories:
+            bucket = by_epic[s.epic_id]
             if s.status == "done":
-                past_count += 1
+                bucket["past_count"] += 1
             elif s.status in ("in-progress", "in-review"):
-                now_items.append(_node(s))
+                bucket["now_items"].append(_node(s))
             else:
                 priority = 0 if s.id in blocked_ids else (1 if s.status == "ready-for-dev" else 2)
-                upcoming_all.append((priority, s.updated_at, _node(s)))
+                bucket["upcoming_all"].append((priority, s.updated_at, _node(s)))
 
-        upcoming_all.sort(key=lambda t: (t[0], -t[1].timestamp()))
-        upcoming_total = len(upcoming_all)
-        upcoming_shown = [n for _, _, n in upcoming_all[:upcoming_limit]]
+        epics_out = []
+        for eid in processed:
+            bucket = by_epic[eid]
+            upcoming_all = bucket["upcoming_all"]
+            upcoming_all.sort(key=lambda t: (t[0], -t[1].timestamp()))
+            upcoming_shown = [n for _, _, n in upcoming_all[:upcoming_limit]]
+            epics_out.append({
+                "epic_id": str(eid),
+                "now": {"total": len(bucket["now_items"]), "items": bucket["now_items"]},
+                "upcoming": {
+                    "total": len(upcoming_all), "shown": len(upcoming_shown), "items": upcoming_shown,
+                },
+                "past": {"total": bucket["past_count"]},
+            })
 
         return {
-            "epic_id": str(epic_id),
-            "now": {"total": len(now_items), "items": now_items},
-            "upcoming": {
-                "total": upcoming_total, "shown": len(upcoming_shown), "items": upcoming_shown,
-            },
-            "past": {"total": past_count},
+            "epics": epics_out,
+            "requested_count": len(requested),
+            "processed_count": len(processed),
+            "skipped_epic_ids": [str(eid) for eid in skipped],
         }
 
     async def get_agent_stats(self, project_id: uuid.UUID, agent_id: uuid.UUID) -> dict:

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -11,6 +11,7 @@ from app.repositories.analytics import AnalyticsRepository
 from app.schemas.analytics import (
     AgentStatsResponse,
     BurndownResponse,
+    EpicFlowNodesBatchResponse,
     EpicFlowNodesResponse,
     EpicProgressLane,
     EpicProgressResponse,
@@ -119,20 +120,38 @@ async def get_epics_progress_lane(
     )
 
 
-@router.get("/analytics/epic-flow-nodes", response_model=EpicFlowNodesResponse)
+@router.get("/analytics/epic-flow-nodes")
 async def get_epic_flow_nodes(
     project_id: uuid.UUID = Query(...),
-    epic_id: uuid.UUID = Query(...),
+    epic_id: uuid.UUID | None = Query(default=None),
+    epic_ids: str | None = Query(default=None, description="콤마구분 UUID 목록(story #2679 배치)"),
     upcoming_limit: int = Query(default=15, ge=1, le=100),
     repo: AnalyticsRepository = Depends(_get_repo),
     auth: AuthContext = Depends(get_current_user),
-) -> EpicFlowNodesResponse:
+) -> EpicFlowNodesResponse | EpicFlowNodesBatchResponse:
     """story #2224 노드 계약(급전환, 2026-07-30 PO 판정) — 「지금/이어질/지나온」 세 구역
     노드를 «에픽 하나» 단위로 한 번의 호출로 낸다(179 에픽 전체를 한 번에 주면 수천 건이라
-    안 준다 — 펼친 에픽만). `upcoming_limit`은 FE 화면 상한(PO 감 10~15, 기본 15)."""
+    안 준다 — 펼친 에픽만). `upcoming_limit`은 FE 화면 상한(PO 감 10~15, 기본 15).
+
+    story #2679(2026-07-30, PO 급요청) — L3 캔버스가 여러 레인을 한 화면에 동시에 그리며
+    이 «에픽 하나» 계약이 레인 수만큼 호출을 요구하게 됐다(오늘 금지한 패턴). `epic_ids`
+    (콤마구분)로 여러 에픽을 한 번에 받는다 — FE가 이미 아는 epic_id 목록을 넘긴다(lane과
+    다른 정렬을 새로 판정하지 않는다, PO 판정). `epic_id`·`epic_ids` 중 정확히 하나만."""
     await _assert_project_access(repo, auth, project_id)
-    result = await repo.get_epic_flow_nodes(project_id, epic_id, upcoming_limit)
-    return EpicFlowNodesResponse.model_validate(result)
+    if (epic_id is None) == (epic_ids is None):
+        raise HTTPException(status_code=400, detail="epic_id 또는 epic_ids 중 정확히 하나를 지정하십시오")
+    if epic_id is not None:
+        result = await repo.get_epic_flow_nodes(project_id, epic_id, upcoming_limit)
+        return EpicFlowNodesResponse.model_validate(result)
+
+    try:
+        parsed_ids = [uuid.UUID(s.strip()) for s in epic_ids.split(",") if s.strip()]
+    except ValueError:
+        raise HTTPException(status_code=400, detail="epic_ids는 콤마구분 UUID 목록이어야 합니다")
+    if not parsed_ids:
+        raise HTTPException(status_code=400, detail="epic_ids가 비어 있습니다")
+    batch_result = await repo.get_epic_flow_nodes_batch(project_id, parsed_ids, upcoming_limit)
+    return EpicFlowNodesBatchResponse.model_validate(batch_result)
 
 
 @router.get("/analytics/agent-stats", response_model=AgentStatsResponse)

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -183,6 +183,18 @@ class EpicFlowNodesResponse(BaseModel):
     past: FlowNodePastZone
 
 
+class EpicFlowNodesBatchResponse(BaseModel):
+    """story #2679(2026-07-30) — GET .../epic-flow-nodes?epic_ids=a,b,c. L3 캔버스가 여러
+    레인을 한 화면에 동시에 그리며 단일-에픽 계약이 레인 수만큼 호출을 요구하게 됐다
+    (오늘 금지한 패턴) — FE가 이미 아는 epic_id 목록을 넘겨 한 번에 받는다.
+    ⛔epic_ids가 상한(EPIC_FLOW_NODES_BATCH_MAX)을 넘으면 앞 N개만 처리되고 나머지는
+    skipped_epic_ids에 실린다("없앤 것"이 아니라 "안 그린 것" — 오늘 규율 그대로)."""
+    epics: list[EpicFlowNodesResponse]
+    requested_count: int
+    processed_count: int
+    skipped_epic_ids: list[uuid.UUID]
+
+
 class AgentStatsResponse(BaseModel):
     # S2-1 신규 지표 (stories 기반)
     completed: int

--- a/backend/tests/test_2224_epic_flow_nodes_realdb.py
+++ b/backend/tests/test_2224_epic_flow_nodes_realdb.py
@@ -143,6 +143,149 @@ async def test_epic_flow_nodes_three_zones_and_one_call():
         await engine.dispose()
 
 
+async def test_epic_flow_nodes_batch_multiple_epics_one_call_each_query():
+    """story #2679 — epic_ids로 여러 에픽을 «한 번의 호출»로 받고, story/Gate 쿼리가 각각
+    1번씩(에픽 개수와 무관, N+1 없음)인지."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+
+            from app.models.pm import Goal
+            epic_a = Goal(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Epic A")
+            epic_b = Goal(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Epic B")
+            s.add_all([epic_a, epic_b])
+            await s.commit()
+
+            story_a_ip = await _make_story(s, org.id, project.id, title="A_IP")
+            story_a_ip.epic_id = epic_a.id
+            story_a_ip.status = "in-progress"
+
+            story_a_done = await _make_story(s, org.id, project.id, title="A_DONE")
+            story_a_done.epic_id = epic_a.id
+            story_a_done.status = "done"
+
+            story_b_backlog = await _make_story(s, org.id, project.id, title="B_BACKLOG")
+            story_b_backlog.epic_id = epic_b.id
+            story_b_backlog.status = "backlog"
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        query_count = {"n": 0}
+        try:
+            from sqlalchemy import event
+            from app.core.database import engine as _global_engine
+
+            def _count(*args, **kwargs):
+                query_count["n"] += 1
+
+            event.listen(_global_engine.sync_engine, "before_cursor_execute", _count)
+            try:
+                resp = await client.get(
+                    "/api/v2/analytics/epic-flow-nodes",
+                    params={
+                        "project_id": str(project.id),
+                        "epic_ids": f"{epic_a.id},{epic_b.id}",
+                    },
+                )
+            finally:
+                event.remove(_global_engine.sync_engine, "before_cursor_execute", _count)
+
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["requested_count"] == 2
+            assert body["processed_count"] == 2
+            assert body["skipped_epic_ids"] == []
+            assert len(body["epics"]) == 2
+
+            by_id = {e["epic_id"]: e for e in body["epics"]}
+            assert by_id[str(epic_a.id)]["now"]["total"] == 1
+            assert by_id[str(epic_a.id)]["past"]["total"] == 1
+            assert by_id[str(epic_b.id)]["upcoming"]["total"] == 1
+
+            # story 쿼리 1 + gate 쿼리 1(+ project-access 확認용 소수) — 에픽 개수(2)만큼
+            # 곱해지지 않는 것이 핵심(N+1이면 훨씬 커진다). 넉넉히 10 미만으로 고정 상한 확認.
+            assert query_count["n"] < 10, f"쿼리 수가 큼(N+1 의심): {query_count['n']}"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_epic_flow_nodes_batch_over_cap_truncates_and_reports_skipped():
+    """상한(EPIC_FLOW_NODES_BATCH_MAX) 초과 시 앞 N개만 처리되고 나머지는 skipped_epic_ids에
+    실린다 — "없앤 것"이 아니라 "안 그린 것"(오늘 규율)."""
+    from app.main import app
+    from app.repositories.analytics import AnalyticsRepository
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            fake_ids = [str(uuid.uuid4()) for _ in range(AnalyticsRepository.EPIC_FLOW_NODES_BATCH_MAX + 5)]
+            resp = await client.get(
+                "/api/v2/analytics/epic-flow-nodes",
+                params={"project_id": str(project.id), "epic_ids": ",".join(fake_ids)},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["requested_count"] == len(fake_ids)
+            assert body["processed_count"] == AnalyticsRepository.EPIC_FLOW_NODES_BATCH_MAX
+            assert len(body["skipped_epic_ids"]) == 5
+            assert set(body["skipped_epic_ids"]) == set(fake_ids[AnalyticsRepository.EPIC_FLOW_NODES_BATCH_MAX:])
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_epic_flow_nodes_requires_exactly_one_of_epic_id_or_epic_ids():
+    """양쪽 다 주거나 둘 다 안 주면 400 — 모호한 요청을 서버가 임의로 고르지 않는다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            neither = await client.get(
+                "/api/v2/analytics/epic-flow-nodes", params={"project_id": str(project.id)},
+            )
+            assert neither.status_code == 400
+
+            both = await client.get(
+                "/api/v2/analytics/epic-flow-nodes",
+                params={
+                    "project_id": str(project.id), "epic_id": str(uuid.uuid4()),
+                    "epic_ids": str(uuid.uuid4()),
+                },
+            )
+            assert both.status_code == 400
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
 async def test_epic_flow_nodes_upcoming_limit_truncates_and_reports_total():
     """upcoming_limit보다 이어질 것이 많으면 shown < total이어야 하고, 잘린 개수를 응답이
     말해야 한다("없앤 것"이 아니라 "안 그린 것", PO 규율)."""


### PR DESCRIPTION
## Summary
L3(갈래 캔버스)가 여러 레인의 노드를 한 캔버스에 동시에 그리는 것으로 확定됨 — 기존 `epic-flow-nodes`는 "에픽 하나" 단위 계약이라 레인 6개면 6번 호출(오늘 금지한 패턴).

`GET .../epic-flow-nodes?project_id=…&epic_ids=a,b,c`(콤마구분)로 여러 에픽을 한 번에 받는다. FE가 이미 아는 epic_id 목록을 넘기는 방식(lane과 다른 정렬을 새로 판정하지 않음).

## N+1 없음
story 쿼리 1번(전체 epic_ids에 IN) + Gate 쿼리 1번(전체 story_ids에 IN) — 에픽 개수와 무관하게 쿼리 수 고정. 세 구역 정의는 단일-에픽 계약과 100% 동일 재사용.

## 상한
`EPIC_FLOW_NODES_BATCH_MAX=30`(L3가 실제로 동시에 그리는 레인 수의 5배 여유) 초과 시 앞 N개만 처리, `skipped_epic_ids`에 나머지 명시.

## 하위호환
기존 `epic_id`(단일) 경로는 그대로 동작 — 배치 메서드의 결과에서 하나만 꺼내는 얇은 래퍼로 리팩터(로직 중복 없음).

## Test plan
- [x] 실PG 테스트 3건 추가(다중에픽 쿼리수 고정 · 상한초과 truncate+skipped · epic_id/epic_ids 상호배타 400) — 기존 2건 포함 5건 전부 그린
- [x] 전체 스위트 5409 passed(남은 실패는 stash로 unmodified develop과 비교해 순서의존 flaky 확認 — 이 diff와 무관)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>