### PR TITLE
fix(#2346 AC7): 급감거부 메시지에 story_number 추가

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -1457,10 +1457,15 @@ async def update_story(
             _lost_chars = _before_len - _after_len
             _is_relative_shrink = _after_len < _before_len * (1 - _SHRINK_BLOCK_THRESHOLD)
             if _is_relative_shrink and _lost_chars >= _SHRINK_BLOCK_MIN_LOST_CHARS:
+                # ⛔story #2346(PO 2026-07-30 08:12Z): 「가드 신호를 사용자 숙제로 번역하지
+                # 않는다」— 「거부되었습니다」만 오면 포기하거나 우회한다. «무엇이»(story_number)
+                # «어디가»(필드명) «얼마나»(전→후 길이) 줄었는지와 «다음에 뭘 할지»
+                # (allow_shrink=true)를 한 메시지 안에 전부 싣는다 — #2342형 대상 혼동 사고를
+                # 그 자리서 보이게 하는 목적도 겸한다.
                 raise HTTPException(
                     status_code=400,
                     detail=(
-                        f"{_f} shrank {_before_len}→{_after_len} chars "
+                        f"#{story_before.story_number} {_f} shrank {_before_len}→{_after_len} chars "
                         f"({round((1 - _after_len / _before_len) * 100)}% smaller) — "
                         "if intentional, resend with allow_shrink=true"
                     ),

--- a/backend/tests/test_2346_story_update_length_change_activity_realdb.py
+++ b/backend/tests/test_2346_story_update_length_change_activity_realdb.py
@@ -64,8 +64,8 @@ async def _seed(s, initial_description: str) -> None:
         await s.execute(text(sql))
     await s.execute(
         text(
-            "INSERT INTO stories (id,org_id,project_id,title,status,priority,description) "
-            "VALUES (:id,:org,:proj,'test story','backlog','medium',:desc)"
+            "INSERT INTO stories (id,org_id,project_id,title,status,priority,description,story_number) "
+            "VALUES (:id,:org,:proj,'test story','backlog','medium',:desc,2346)"
         ),
         {"id": STORY, "org": ORG, "proj": PROJ, "desc": initial_description},
     )
@@ -206,6 +206,12 @@ async def test_ac7_shrink_over_50_percent_blocked_without_flag():
                 )
             assert ei.value.status_code == 400
             assert "3619" in ei.value.detail and "437" in ei.value.detail
+            # PO 요청(2026-07-30 08:12Z) — 가드 신호를 사용자 숙제로 번역하지 않는다: 무엇이
+            # (story_number) 어디가(필드명) 줄었는지와 다음 행동(allow_shrink=true)이 한
+            # 메시지 안에 다 있어야 한다.
+            assert "description" in ei.value.detail
+            assert "allow_shrink=true" in ei.value.detail
+            assert "#2346" in ei.value.detail, f"story_number이 메시지에 없음: {ei.value.detail}"
 
         # 봉인 — 거부됐으니 원본이 그대로 살아 있어야 한다(부분 적용 없음).
         async with Session() as s:


### PR DESCRIPTION
## Summary
PO 요청(2026-07-30 08:12Z): 400만 오면 사람/에이전트가 포기하거나 우회한다 — "무엇이(story_number) 어디가(필드명) 얼마나(전→후 길이) 줄었는지"와 "다음에 뭘 할지"(`allow_shrink=true`)가 한 메시지 안에 있어야 한다. 이미 필드명·전후길이·재시도법은 있었으나 `story_number`가 빠져 있었다(#2342형 대상 혼동 사고를 그 자리서 드러내는 목적도 겸함).

## Test plan
- [x] 실PG 테스트에 story_number 마커 검증 추가(#2346 전부 그린)
- [x] 전체 스위트 5415 passed(무회귀)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>