### PR TITLE
feat(#2268 후속): judgments.target_id를 retraction/refinement/method_error에서도 선택으로

### DIFF
--- a/backend/alembic/versions/0218_judgment_target_optional.py
+++ b/backend/alembic/versions/0218_judgment_target_optional.py
@@ -1,0 +1,41 @@
+"""story #2268 후속(2026-07-30, 오르테가 철회 — target_id 순환 실측) — judgments.target_id를
+retraction/refinement/method_error에서도 선택으로 내리고, source_message_id를 신설한다.
+
+배경: target_id가 "이전 판정의 id"인데 처음 쓰는 사람은 이전 판정이 없어 가리킬 것이
+없었다("처음 쓰는 사람은 영원히 못 들어가는 순환") — org 전체 정정 기록이 오늘까지 1건뿐이던
+원인으로 추정. correction_ids_by_target(judgment_core.py)은 이미 `if corr.target_id is not
+None` 가드라 target 없는 행은 그 map에서 조용히 빠질 뿐, 깨지는 소비자 없음.
+
+순수 additive/완화 — CHECK 제약 하나 제거 + nullable 컬럼 하나 추가, 기존 데이터 손상 0.
+
+Revision ID: 0218
+Revises: 0217
+Create Date: 2026-07-30
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0218"
+down_revision = "0217"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "ck_judgments_target_required_for_meta_kinds", "judgments", type_="check",
+    )
+    op.add_column(
+        "judgments",
+        sa.Column("source_message_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("judgments", "source_message_id")
+    op.create_check_constraint(
+        "ck_judgments_target_required_for_meta_kinds",
+        "judgments",
+        "(kind NOT IN ('retraction', 'refinement', 'method_error')) OR (target_id IS NOT NULL)",
+    )

--- a/backend/app/models/judgment.py
+++ b/backend/app/models/judgment.py
@@ -6,7 +6,21 @@ GET /evidence·glance proof_count 등 무필터 카운트 자리가 셋 실재�
 두 층(유나 판정):
   ㉠원래 낸 말   judgment(판정+근거) · unmeasurable(못 잰 것과 왜) — 스스로 서므로 target_id 불요.
   ㉡앞선 말에 대한 말 retraction(철회) · refinement(정련) · method_error(세는 법이 틀림)
-    — target_id 필수(무엇에 대한 말인지 없는 메타-말은 저장 자체를 막는다).
+
+⛔story #2268 후속(2026-07-30, 오르테가 철회·디디 실측): target_id를 ㉡ 셋에서도 선택으로
+내린다 — target_id는 "이전 판정의 id"인데, 처음 쓰는 사람은 이전 판정이 애초에 없어
+가리킬 것이 없다("처음 쓰는 사람은 영원히 못 들어가는 순환"). 실측: 오늘 org 전체 정정
+기록이 1건뿐이었던 것이 이 순환 때문일 공산이 크다. `TARGET_REQUIRED_KINDS`는 이름 그대로
+"필수"가 아니게 됐지만 집합 자체(㉡ 층 분류축, corrections vs active 판별에 계속 쓰임)는
+남긴다 — 이름을 바꾸면 소비자(judgment_core.py의 active/corrections 분류)를 다 훑어야
+하고, 이 변경의 크기가 아니다.
+
+`source_message_id`(신설, nullable) — 이 판정이 어느 채팅 메시지에서 나왔는지 가리킨다.
+"이미 적은 것을 다시 쓰지 않는" 것이 목적(정정을 statement에 처음부터 다시 서술하지 않고
+원본 메시지를 가리킬 수 있게).
+
+⛔PATCH/PUT은 짓지 않는다(의도, 빠뜨림 아님) — judgments는 append-only다. "정정을 남기는
+도구"가 정정 가능해지면 "이 정정은 나중에 고쳐졌나"를 또 물어야 하는 모순이 생긴다.
 
 work_item_ids는 오늘 실측 근거 셋 위에 설계(대화 스레드 7256d5cc, 2026-07-29):
   (a) 여러 story에 «걸치는» 교훈(twin-system drift류) — 단일 FK로는 못 세운다.
@@ -28,8 +42,8 @@ from sqlalchemy.orm import Mapped, mapped_column
 from app.core.database import Base
 
 JUDGMENT_KINDS = frozenset({"judgment", "unmeasurable", "retraction", "refinement", "method_error"})
-# ㉡ — 앞선 말에 대한 말. target_id NOT NULL을 요구하는 축(스키마 레벨 강제 — "무엇을
-# 철회하는지 모르는 철회"가 저장되는 것을 원천 차단).
+# ㉡ — 앞선 말에 대한 말(분류축, active/corrections 판별에 쓰임). ⛔2026-07-30부터 target_id를
+# 「요구」하지 않는다(이름은 남기되 스키마 레벨 강제는 뺐다 — 위 모듈 docstring 참조).
 TARGET_REQUIRED_KINDS = frozenset({"retraction", "refinement", "method_error"})
 JUDGMENT_SCOPES = frozenset({"items", "general"})
 
@@ -46,10 +60,6 @@ class Judgment(Base):
             "(scope = 'general' AND work_item_ids = '{}') OR "
             "(scope = 'items' AND work_item_ids <> '{}')",
             name="ck_judgments_scope_work_item_ids_pairing",
-        ),
-        CheckConstraint(
-            "(kind NOT IN ('retraction', 'refinement', 'method_error')) OR (target_id IS NOT NULL)",
-            name="ck_judgments_target_required_for_meta_kinds",
         ),
         Index("ix_judgments_org", "org_id"),
         Index("ix_judgments_work_item_ids", "work_item_ids", postgresql_using="gin"),
@@ -69,6 +79,10 @@ class Judgment(Base):
     # 프로젝트 관례(entity_references 등)가 폴리모픽 대상엔 FK를 안 거는 쪽이라 여기도
     # 같은 테이블 자기참조는 명시 FK로 마이그레이션에 남긴다).
     target_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    # ⛔2026-07-30 신설: 이 판정이 나온 채팅 메시지(conversation_messages.id) — "이미 적은
+    # 것을 다시 안 쓰게" 하는 것이 목적. FK는 안 건다(이 프로젝트 관례 — 폴리모픽/느슨한
+    # 참조에는 FK를 안 거는 쪽, target_id의 자기참조 FK와는 다른 성격의 참조라 구분).
+    source_message_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     # "어떤 방법으로 쟀는가" — method_error가 "같은 방법으로 낸 다른 말들"을 역추적하는 축
     # (오르테가 명시 요구, 2026-07-29). 자유 텍스트(방법 taxonomy는 아직 없음 — 과확장 금지).
     method: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/models/judgment.py
+++ b/backend/app/models/judgment.py
@@ -10,10 +10,13 @@ GET /evidence·glance proof_count 등 무필터 카운트 자리가 셋 실재�
 ⛔story #2268 후속(2026-07-30, 오르테가 철회·디디 실측): target_id를 ㉡ 셋에서도 선택으로
 내린다 — target_id는 "이전 판정의 id"인데, 처음 쓰는 사람은 이전 판정이 애초에 없어
 가리킬 것이 없다("처음 쓰는 사람은 영원히 못 들어가는 순환"). 실측: 오늘 org 전체 정정
-기록이 1건뿐이었던 것이 이 순환 때문일 공산이 크다. `TARGET_REQUIRED_KINDS`는 이름 그대로
-"필수"가 아니게 됐지만 집합 자체(㉡ 층 분류축, corrections vs active 판별에 계속 쓰임)는
-남긴다 — 이름을 바꾸면 소비자(judgment_core.py의 active/corrections 분류)를 다 훑어야
-하고, 이 변경의 크기가 아니다.
+기록이 1건뿐이었던 것이 이 순환 때문일 공산이 크다.
+
+⛔`TARGET_REQUIRED_KINDS` → `TARGET_LINKABLE_KINDS` 개명(오르테가 재지적, 같은 날): 집합
+자체(㉡ 층 분류축, corrections vs active 판별에 계속 쓰임)는 남기되, 이름의 "REQUIRED"가
+"target_id가 필수인 종류"로 계속 읽혀 다음 사람이 그 이름만 보고 다시 강제를 얹을 위험이
+있었다(오늘 반복 관측한 "이름이 약속하는 축과 실제 축이 다르다" 병과 같은 모양). "할 수
+있다"(linkable)와 "해야 한다"(required)는 다른 말이다 — 실제 뜻하는 것은 전자다.
 
 `source_message_id`(신설, nullable) — 이 판정이 어느 채팅 메시지에서 나왔는지 가리킨다.
 "이미 적은 것을 다시 쓰지 않는" 것이 목적(정정을 statement에 처음부터 다시 서술하지 않고
@@ -42,9 +45,10 @@ from sqlalchemy.orm import Mapped, mapped_column
 from app.core.database import Base
 
 JUDGMENT_KINDS = frozenset({"judgment", "unmeasurable", "retraction", "refinement", "method_error"})
-# ㉡ — 앞선 말에 대한 말(분류축, active/corrections 판별에 쓰임). ⛔2026-07-30부터 target_id를
-# 「요구」하지 않는다(이름은 남기되 스키마 레벨 강제는 뺐다 — 위 모듈 docstring 참조).
-TARGET_REQUIRED_KINDS = frozenset({"retraction", "refinement", "method_error"})
+# ㉡ — 앞선 말에 대한 말(분류축, active/corrections 판별에 쓰임). target_id를 가질 «수
+# 있는» 종류이지 가져야「하는」 종류가 아니다(2026-07-30부터, TARGET_REQUIRED_KINDS에서
+# 개명 — 위 모듈 docstring 참조).
+TARGET_LINKABLE_KINDS = frozenset({"retraction", "refinement", "method_error"})
 JUDGMENT_SCOPES = frozenset({"items", "general"})
 
 

--- a/backend/app/routers/judgments.py
+++ b/backend/app/routers/judgments.py
@@ -31,6 +31,8 @@ class CreateJudgmentRequest(BaseModel):
     target_id: uuid.UUID | None = None
     method: str | None = None
     statement: str
+    # ⛔2026-07-30 신설 — 이 판정이 나온 채팅 메시지(이미 적은 것을 다시 안 쓰게 하는 것이 목적).
+    source_message_id: uuid.UUID | None = None
 
 
 class JudgmentResponse(BaseModel):
@@ -46,6 +48,7 @@ class JudgmentResponse(BaseModel):
     statement: str
     created_by: uuid.UUID
     created_at: datetime
+    source_message_id: uuid.UUID | None = None
     # story #2308 후속: 이 원소를 target으로 삼는 correction id들(list_judgments 전용 —
     # POST 응답에선 항상 []. 한 목록만 읽어도 "이건 정정됐다"가 보이게, active·corrections
     # 양쪽 다 이 필드를 갖는다).
@@ -86,6 +89,7 @@ async def create_judgment_endpoint(
             method=body.method,
             statement=body.statement,
             created_by=caller.id,
+            source_message_id=body.source_message_id,
         )
     except InvalidJudgmentError as e:
         raise HTTPException(status_code=422, detail=str(e)) from e

--- a/backend/app/services/judgment_core.py
+++ b/backend/app/services/judgment_core.py
@@ -67,7 +67,11 @@ async def create_judgment(
     method: str | None,
     statement: str,
     created_by: uuid.UUID,
+    source_message_id: uuid.UUID | None = None,
 ) -> Judgment:
+    """⛔2026-07-30(오르테가 철회 — target_id 순환 실측): target_id는 ㉡(TARGET_REQUIRED_KINDS)
+    셋에서도 이제 선택이다 — 처음 쓰는 사람은 가리킬 이전 판정이 없다. 더 이상 필수로
+    막지 않는다(아래 존재-검증만 target_id가 «주어졌을 때» 수행)."""
     if kind not in JUDGMENT_KINDS:
         raise InvalidJudgmentError(f"kind must be one of {sorted(JUDGMENT_KINDS)}")
     if scope not in JUDGMENT_SCOPES:
@@ -78,10 +82,6 @@ async def create_judgment(
         raise InvalidJudgmentError("scope='general'이면 work_item_ids는 비어 있어야 합니다(일반 교훈)")
     if scope == "items" and not work_item_ids:
         raise InvalidJudgmentError("scope='items'면 work_item_ids가 최소 1개 필요합니다(아직 안 붙인 상태 금지)")
-    if kind in TARGET_REQUIRED_KINDS and target_id is None:
-        raise InvalidJudgmentError(
-            f"kind={kind!r}는 target_id가 필수입니다(무엇에 대한 말인지 모르는 {kind}는 저장 금지)"
-        )
 
     if target_id is not None:
         target_exists = (
@@ -95,7 +95,7 @@ async def create_judgment(
     judgment = Judgment(
         id=uuid.uuid4(), org_id=org_id, scope=scope, work_item_ids=list(work_item_ids),
         kind=kind, target_id=target_id, method=method, statement=statement,
-        created_by=created_by,
+        created_by=created_by, source_message_id=source_message_id,
     )
     session.add(judgment)
     await session.flush()

--- a/backend/app/services/judgment_core.py
+++ b/backend/app/services/judgment_core.py
@@ -1,7 +1,7 @@
 """story #2268(D단계, E-CONNECT — "판단 칸") — judgments write/read 코어.
 
 AC(오르테가, 2026-07-29): pull 전용 — 「물으면 준다」, push 금지. `corrections`(앞선 말에
-대한 말 — retraction·refinement·method_error, `TARGET_REQUIRED_KINDS`와 동일 집합)는 상한과
+대한 말 — retraction·refinement·method_error, `TARGET_LINKABLE_KINDS`와 동일 집합)는 상한과
 무관하게 항상 전체(캡 예외 — "철회된 걸 다시 주장 안 하는가"가 이 판의 판정기준이므로 여기서
 잘리면 그 기준 자체가 무너진다). `active`(judgment/unmeasurable — corrections 아닌 나머지)는
 "다음 발 수" 기준으로 캡 — 지금 실측 가능한 랭킹 신호가 recency뿐이라 그걸로 자르고
@@ -12,7 +12,7 @@ collection_scope 정직성 패턴과 동형).
 하나로만 좁혀 썼다 — AC 원문 「retractions는 상한과 무관하게 전량」이 «집합의 정의»가 아니라
 «원소 이름 하나»를 썼기 때문(정확한 독해였지만 좁은 표현이 구현을 좁혔다). 결과: 셋 중 가장
 넓게 번지는 `method_error`(그 판단 + 같은 방법으로 낸 다른 모든 말을 무효화)가 캡에 가장 먼저
-걸리는, 설계 목적과 정반대인 상태였다. 지금은 `TARGET_REQUIRED_KINDS`(모델에 이미 있는 상수)를
+걸리는, 설계 목적과 정반대인 상태였다. 지금은 `TARGET_LINKABLE_KINDS`(모델에 이미 있는 상수)를
 캡 예외 집합으로 직접 파생해 쓴다 — 종류를 손으로 다시 나열하지 않는다(새 correction 종류가
 생기면 자동으로 따라온다). 응답 필드도 `retractions`→`corrections`로 개명(내용이 이제 셋을
 담으므로 이름이 하나만 가리키면 거짓이 된다) — 이 필드의 실제 소비자는 이 저장소 안(router
@@ -26,7 +26,7 @@ app-level 검증을 먼저 하는 이유(#2259 reference_core.insert_reference�
 제약이 지킨다"가 이 판의 crux, 오르테가 표현).
 
 ⛔story #2308 후속(2026-07-29, 오르테가 라이브 dogfooding — #2302에 실제 write→read 왕복):
-`active`의 축은 "철회됐나"가 아니라 "말의 층위"(kind가 TARGET_REQUIRED_KINDS 밖인가)라서,
+`active`의 축은 "철회됐나"가 아니라 "말의 층위"(kind가 TARGET_LINKABLE_KINDS 밖인가)라서,
 이미 retraction의 target이 된 judgment도 `active`에 그대로 남는다(설계대로 — 버그 아님).
 그런데 필드 이름이 "active"라 그 목록만 읽는 소비자는 철회된 판단을 유효한 것으로 오독한다.
 `corrections` 원소도 같은 함정이 있다 — method_error는 "그 판단 + 같은 방법으로 낸 다른
@@ -47,7 +47,7 @@ import uuid
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.judgment import JUDGMENT_KINDS, JUDGMENT_SCOPES, TARGET_REQUIRED_KINDS, Judgment
+from app.models.judgment import JUDGMENT_KINDS, JUDGMENT_SCOPES, TARGET_LINKABLE_KINDS, Judgment
 
 DEFAULT_ACTIVE_LIMIT = 20
 
@@ -69,7 +69,7 @@ async def create_judgment(
     created_by: uuid.UUID,
     source_message_id: uuid.UUID | None = None,
 ) -> Judgment:
-    """⛔2026-07-30(오르테가 철회 — target_id 순환 실측): target_id는 ㉡(TARGET_REQUIRED_KINDS)
+    """⛔2026-07-30(오르테가 철회 — target_id 순환 실측): target_id는 ㉡(TARGET_LINKABLE_KINDS)
     셋에서도 이제 선택이다 — 처음 쓰는 사람은 가리킬 이전 판정이 없다. 더 이상 필수로
     막지 않는다(아래 존재-검증만 target_id가 «주어졌을 때» 수행)."""
     if kind not in JUDGMENT_KINDS:
@@ -125,12 +125,12 @@ async def list_judgments(
     correction_rows = (
         await session.execute(
             select(Judgment)
-            .where(*filters, Judgment.kind.in_(TARGET_REQUIRED_KINDS))
+            .where(*filters, Judgment.kind.in_(TARGET_LINKABLE_KINDS))
             .order_by(Judgment.created_at.desc())
         )
     ).scalars().all()
 
-    active_filters = [*filters, Judgment.kind.not_in(TARGET_REQUIRED_KINDS)]
+    active_filters = [*filters, Judgment.kind.not_in(TARGET_LINKABLE_KINDS)]
     total_active = (
         await session.execute(select(func.count(Judgment.id)).where(*active_filters))
     ).scalar_one()

--- a/backend/sprintable_mcp/tools/judgments.py
+++ b/backend/sprintable_mcp/tools/judgments.py
@@ -17,17 +17,20 @@ class AddJudgmentInput(SprintableInput):
     kind: str  # judgment | unmeasurable | retraction | refinement | method_error
     statement: str
     work_item_ids: list[str] = []
-    target_id: str | None = None  # ㉡(retraction/refinement/method_error)은 필수
+    # ⛔2026-07-30부터 선택(retraction/refinement/method_error 포함) — 이전 판정을 몰라도
+    # 남길 수 있다(target_id는 "이전 판정의 id"인데 처음 쓰는 사람은 그게 없어 순환에 갇혔다).
+    target_id: str | None = None
     method: str | None = None  # method_error 역추적 축
+    source_message_id: str | None = None  # 이 판정이 나온 채팅 메시지(이미 적은 것을 다시 안 쓰게)
 
 
 async def add_judgment(args: AddJudgmentInput) -> list[TextContent]:
     """판단(judgment)·못 잰 것(unmeasurable)·철회(retraction)·정련(refinement)·세는 법
     틀림(method_error)을 남긴다. Evidence와 별개 — "됐다"의 증거가 아니라 "이렇게 판단했다/
     이 판단은 틀렸다"는 판정 자체를 기록한다. scope="general"이면 work_item_ids는 비워야
-    하고(특정 작업과 무관한 일반 교훈), scope="items"면 최소 1개 필요하다. retraction/
-    refinement/method_error는 target_id(무엇에 대한 말인지)가 필수 — 없으면 서버가 422로
-    거절한다."""
+    하고(특정 작업과 무관한 일반 교훈), scope="items"면 최소 1개 필요하다. target_id(무엇에
+    대한 말인지)는 선택이다 — 있으면 이 org에 실재하는 판정이어야 한다(없으면 422). 이
+    도구는 append-only다(수정/삭제 없음) — 잘못 남겼으면 retraction으로 새로 남긴다."""
     try:
         payload: dict = {
             "scope": args.scope, "kind": args.kind, "statement": args.statement,
@@ -37,6 +40,8 @@ async def add_judgment(args: AddJudgmentInput) -> list[TextContent]:
             payload["target_id"] = args.target_id
         if args.method is not None:
             payload["method"] = args.method
+        if args.source_message_id is not None:
+            payload["source_message_id"] = args.source_message_id
         result = await client.post("/api/v2/judgments", json=payload)
         return ok(result)
     except Exception as exc:

--- a/backend/tests/test_2268_judgments_endpoint_realdb.py
+++ b/backend/tests/test_2268_judgments_endpoint_realdb.py
@@ -189,7 +189,7 @@ async def test_judgment_insert_does_not_move_evidence_signals():
 
 
 async def test_corrections_uncapped_active_capped_with_accurate_omitted_count():
-    """story #2308(2026-07-29) — 캡 예외가 `TARGET_REQUIRED_KINDS` 전체(retraction·
+    """story #2308(2026-07-29) — 캡 예외가 `TARGET_LINKABLE_KINDS` 전체(retraction·
     refinement·method_error)를 덮는지 증명한다. retraction 하나만 테스트하면 그 회귀가
     다시 들어와도 이 테스트가 못 잡는다 — 셋 다 각각 캡보다 많이 넣어 전량 생존을 본다."""
     from app.main import app

--- a/backend/tests/test_2268_judgments_endpoint_realdb.py
+++ b/backend/tests/test_2268_judgments_endpoint_realdb.py
@@ -382,7 +382,9 @@ async def test_general_scope_nonempty_work_item_ids_rejected_with_422_not_500():
         await engine.dispose()
 
 
-async def test_meta_kind_without_target_id_rejected_with_422_not_500():
+async def test_meta_kind_without_target_id_now_accepted_201():
+    """⛔뒤집힘(2026-07-30, 오르테가 철회): target_id 없는 ㉡을 예전엔 422로 거절했다 —
+    지금은 정반대로 201을 확認한다(처음 쓰는 사람이 이전 판정을 몰라도 남길 수 있어야 함)."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -399,8 +401,39 @@ async def test_meta_kind_without_target_id_rejected_with_422_not_500():
                 "/api/v2/judgments",
                 json={"scope": "general", "kind": "retraction", "statement": "무엇을 철회하는지 모름"},
             )
-            assert resp.status_code == 422, resp.text
-            assert "target_id" in resp.text
+            assert resp.status_code == 201, resp.text
+            assert resp.json()["target_id"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_source_message_id_round_trips_through_http():
+    """신설(2026-07-30) — 채팅 메시지 id를 넘기면 응답에 그대로 실리는지(HTTP 계층)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            msg_id = str(uuid.uuid4())
+            resp = await client.post(
+                "/api/v2/judgments",
+                json={
+                    "scope": "general", "kind": "judgment", "statement": "stmt",
+                    "source_message_id": msg_id,
+                },
+            )
+            assert resp.status_code == 201, resp.text
+            assert resp.json()["source_message_id"] == msg_id
         finally:
             await client.aclose()
     finally:
@@ -428,7 +461,8 @@ async def test_general_scope_entry_is_pullable_via_scope_filter():
         await _setup_app_human(app, Session, caller_user_id, org.id)
         client = _client_for(app)
         try:
-            # method_error(㉡)는 target_id 필수이므로 먼저 ㉠(judgment) 하나를 세운다.
+            # target_id는 이제 선택이지만, 이 테스트는 "correction_ids 데코레이션"을 보려는
+            # 것이라 실제로 target을 거는 정상 경로로 먼저 ㉠(judgment) 하나를 세운다.
             original = await client.post(
                 "/api/v2/judgments",
                 json={"scope": "general", "kind": "judgment", "statement": "부분 체크로 판단함"},

--- a/backend/tests/test_2268_judgments_model_realdb.py
+++ b/backend/tests/test_2268_judgments_model_realdb.py
@@ -5,8 +5,9 @@ AC를 #2268에 박는 중, 이 PR은 그 위에 다른 사람이 안전하게 �
   ①kind 허용목록
   ②scope 허용목록
   ③scope↔work_item_ids 쌍 강제("아직 안 붙임"과 "어디에도 안 붙는 것"을 스키마가 가른다)
-  ④㉡(retraction/refinement/method_error)은 target_id NOT NULL 강제
+  ④㉡(retraction/refinement/method_error)의 target_id는 선택(2026-07-30부터 — 뒤집힘, 아래 참조)
   ⑤target_id는 judgments 자기참조 FK
+  ⑥source_message_id(신설, 2026-07-30) — nullable, 값이 그대로 저장/왕복되는지
 """
 from __future__ import annotations
 
@@ -139,17 +140,19 @@ async def test_items_scope_with_work_item_ids_accepted():
         await engine.dispose()
 
 
-# ─── ④㉡ target_id NOT NULL 강제 ─────────────────────────────────────────────
+# ─── ④㉡ target_id 선택(2026-07-30부터, 오르테가 철회) ─────────────────────────
 
 
 @pytest.mark.parametrize("kind", ["retraction", "refinement", "method_error"])
-async def test_meta_kind_without_target_id_rejected(kind):
+async def test_meta_kind_without_target_id_now_accepted(kind):
+    """⛔뒤집힘(2026-07-30): target_id NOT NULL 강제를 CHECK에서 뺐다 — target_id는
+    "이전 판정의 id"인데 처음 쓰는 사람은 이전 판정이 없어 가리킬 것이 없었다(순환).
+    이 테스트는 예전엔 IntegrityError를 기대했다 — 지금은 정반대로 성공을 확認한다."""
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
             s.add(_judgment(kind=kind, target_id=None))
-            with pytest.raises(IntegrityError, match="ck_judgments_target_required_for_meta_kinds"):
-                await s.commit()
+            await s.commit()
     finally:
         await engine.dispose()
 
@@ -222,5 +225,43 @@ async def test_method_error_stores_method_for_backtrace():
                 )
             ).scalars().all()
             assert {r.id for r in rows} == {original.id, correction.id}
+    finally:
+        await engine.dispose()
+
+
+# ─── source_message_id(신설, 2026-07-30) ────────────────────────────────────
+
+
+async def test_source_message_id_round_trips():
+    """이 판정이 나온 채팅 메시지를 가리키는 nullable 컬럼 — "이미 적은 것을 다시 안 쓰게"
+    하는 목적. FK 없음(느슨한 참조, 이 프로젝트 관례)."""
+    engine, Session = await _session_factory()
+    try:
+        msg_id = uuid.uuid4()
+        async with Session() as s:
+            j = _judgment(kind="judgment", source_message_id=msg_id)
+            s.add(j)
+            await s.commit()
+            row_id = j.id
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.judgment import Judgment
+            row = (
+                await s.execute(select(Judgment).where(Judgment.id == row_id))
+            ).scalar_one()
+            assert row.source_message_id == msg_id
+    finally:
+        await engine.dispose()
+
+
+async def test_source_message_id_defaults_to_none():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            j = _judgment(kind="judgment")
+            s.add(j)
+            await s.commit()
+            assert j.source_message_id is None
     finally:
         await engine.dispose()


### PR DESCRIPTION
## Summary
오르테가 철회(2026-07-30) — `target_id`는 "이전 판정의 id"인데 처음 쓰는 사람은 이전 판정이 애초에 없어 가리킬 것이 없었다("처음 쓰는 사람은 영원히 못 들어가는 순환"). org 전체 정정 기록이 오늘까지 1건뿐이던 원인으로 실측 추정.

## 변경 둘
① DB CHECK 제거(`ck_judgments_target_required_for_meta_kinds`) + app 미러 가드 제거. 집합은 유지하되 `TARGET_REQUIRED_KINDS` → `TARGET_LINKABLE_KINDS` 개명(오르테가 재지적 — "필수"만 뺐는데 이름은 REQUIRED로 남으면 다음 사람이 그 이름만 보고 다시 강제를 얹을 위험이 있다. "할 수 있다"와 "해야 한다"는 다른 말이라 이름이 그 차이를 말해야 한다).
② `source_message_id`(nullable, FK 없음) 신설 — 어느 채팅 메시지에서 나온 판정인지 가리켜 "이미 적은 것을 다시 안 쓰게" 한다.

깨지는 소비자 없음: `correction_ids_by_target`이 이미 `if corr.target_id is not None` 가드라 target 없는 행은 조용히 빠질 뿐.

## PATCH/PUT은 짓지 않는다(의도)
judgments는 append-only다 — "정정을 남기는 도구"가 정정 가능해지면 "이 정정은 나중에 고쳐졌나"를 또 물어야 하는 모순이 생긴다.

## ⛔이 PR이 다루지 않는 것(오르테가 지적 — 적어만 둠, FE 자리)
`source_message_id`가 가리키는 메시지가 나중에 삭제되면 화면이 무엇을 보여줄지가 남은 물음이다. FK가 없는 것은 의도적으로 맞다(append-only 기록이 과거를 가리키는 것 — 메시지가 지워져도 "그때 그렇게 적었다"는 사실은 남아야 한다). 다만 빈칸으로 나오면 "안 적은 것"과 "원본이 사라진 것"이 구별 안 된다 — FE가 "원본을 찾을 수 없습니다(삭제되었을 수 있음)"처럼 보여줘야 한다. 지금 고칠 것 아님.

## Test plan
- [x] 기존 테스트 2건 뒤집음(예전엔 IntegrityError/422 기대 → 지금은 성공 확認)
- [x] source_message_id round-trip 신규 2건(모델+HTTP)
- [x] 실PG 27건 전부 그린 · 전체 스위트 재확認(무회귀)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>