### PR TITLE
feat(#2679 후속): epic-flow-nodes에 초점 스트립 재료 2종 추가

### DIFF
--- a/backend/app/repositories/analytics.py
+++ b/backend/app/repositories/analytics.py
@@ -392,6 +392,16 @@ class AnalyticsRepository:
         세 구역(시간축) 정의는 get_epic_flow_nodes(단일)와 100% 동일(한 자리에서만 정의 —
         두 곳이 각자 정의하면 갈린다): ①지금=in-progress+in-review ②이어질=나머지(상위
         upcoming_limit만, 막힌 것>ready-for-dev>나머지 순) ③지나온=done(수만).
+
+        ⛔story #2679 후속(2026-07-30, PO 판정 — /flow 초점 스트립 4종 수치 중 둘): 새 쿼리 없이
+        이미 fetch한 stories/blocked_ids에서 파생만 한다.
+          `blocked_count` — get_epics_progress_lane의 lane["blocked"](analytics.py 참조)와
+            «같은 Gate 필터»를 status와 무관하게 센다(형제 화면과 갈리지 않게).
+          `last_changed_at` — ⛔「멈춘 시간」의 옳은 정의는 「마지막 머지/배포 이후」이나 그
+            소스가 없다(merged_at 저장 안 됨·배포 추적 테이블 없음, PR 본문 참조). 지금 잴 수
+            있는 것은 Story.updated_at 최댓값뿐이라 이름을 「마지막 변경 이후」로 좁혀 낸다 —
+            «재는 것보다 이름이 넓으면 화면이 거짓말한다»(오늘 규율). ISO 문자열 그대로 반환
+            (시간→N시간 환산은 FE 몫, 화면에 시계가 있다).
         """
         requested = list(dict.fromkeys(epic_ids))  # 순서 보존 중복 제거
         processed = requested[: self.EPIC_FLOW_NODES_BATCH_MAX]
@@ -434,10 +444,25 @@ class AnalyticsRepository:
             }
 
         by_epic: dict[uuid.UUID, dict] = {
-            eid: {"now_items": [], "upcoming_all": [], "past_count": 0} for eid in processed
+            eid: {
+                "now_items": [], "upcoming_all": [], "past_count": 0,
+                "blocked_count": 0, "last_changed_at": None,
+            }
+            for eid in processed
         }
         for s in stories:
             bucket = by_epic[s.epic_id]
+            # ⛔story #2679(2026-07-30, PO 판정) — 초점 스트립 「문 앞 N」: 같은 Gate 필터를
+            # get_epics_progress_lane의 lane["blocked"](analytics.py:343)과 동일하게 status와
+            # 무관하게 센다(그 형제 메서드와 갈리면 두 화면이 다른 수를 말한다).
+            if s.id in blocked_ids:
+                bucket["blocked_count"] += 1
+            # ⛔story #2679 「멈춘 시간」 재료 — PO 판정(2026-07-30): 「최근 머지/배포 이후」가
+            # 옳은 정의이나 그 소스가 없다(merged_at·배포 추적 테이블 전무, PR본문 참조).
+            # 지금 잴 수 있는 것은 Story.updated_at 최댓값뿐이라 «마지막 변경 이후»로 이름을
+            # 좁혀 낸다(재는 것보다 이름이 넓으면 화면이 거짓말한다 — 오늘 규율의 거울상).
+            if bucket["last_changed_at"] is None or s.updated_at > bucket["last_changed_at"]:
+                bucket["last_changed_at"] = s.updated_at
             if s.status == "done":
                 bucket["past_count"] += 1
             elif s.status in ("in-progress", "in-review"):
@@ -459,6 +484,10 @@ class AnalyticsRepository:
                     "total": len(upcoming_all), "shown": len(upcoming_shown), "items": upcoming_shown,
                 },
                 "past": {"total": bucket["past_count"]},
+                "blocked_count": bucket["blocked_count"],
+                "last_changed_at": (
+                    bucket["last_changed_at"].isoformat() if bucket["last_changed_at"] else None
+                ),
             })
 
         return {

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -181,6 +181,12 @@ class EpicFlowNodesResponse(BaseModel):
     now: FlowNodeZone
     upcoming: FlowNodeUpcomingZone
     past: FlowNodePastZone
+    # ⛔story #2679 후속(2026-07-30) — /flow 초점 스트립 4종 수치 중 둘. blocked_count는
+    # get_epics_progress_lane의 lane["blocked"]와 같은 Gate 필터(status 무관, 형제 화면과
+    # 안 갈림). last_changed_at은 「마지막 변경 이후」다 — 「마지막 머지/배포 이후」가 옳은
+    # 정의이나 그 소스가 없어(merged_at 미저장·배포 추적 테이블 없음) 이름을 좁혀 낸다.
+    blocked_count: int
+    last_changed_at: datetime | None
 
 
 class EpicFlowNodesBatchResponse(BaseModel):

--- a/backend/tests/test_2224_epic_flow_nodes_realdb.py
+++ b/backend/tests/test_2224_epic_flow_nodes_realdb.py
@@ -130,6 +130,10 @@ async def test_epic_flow_nodes_three_zones_and_one_call():
             assert body["past"]["total"] == 2
             assert "items" not in body["past"], "지나온 것은 노드로 안 나간다 — 수로만"
 
+            # story #2679 후속(초점 스트립) — blocked_count(story_blocked 1건)·last_changed_at(존재).
+            assert body["blocked_count"] == 1
+            assert body["last_changed_at"] is not None
+
             for node in body["now"]["items"] + body["upcoming"]["items"]:
                 assert set(node.keys()) == {
                     "id", "story_number", "title", "status", "assignee_id", "updated_at",
@@ -211,6 +215,83 @@ async def test_epic_flow_nodes_batch_multiple_epics_one_call_each_query():
             # story 쿼리 1 + gate 쿼리 1(+ project-access 확認용 소수) — 에픽 개수(2)만큼
             # 곱해지지 않는 것이 핵심(N+1이면 훨씬 커진다). 넉넉히 10 미만으로 고정 상한 확認.
             assert query_count["n"] < 10, f"쿼리 수가 큼(N+1 의심): {query_count['n']}"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_epic_flow_nodes_focus_metrics_blocked_count_and_last_changed_at():
+    """story #2679 후속(2026-07-30, /flow 초점 스트립) — blocked_count는 status와 무관하게
+    pending-gate 건수를 세고(get_epics_progress_lane의 lane["blocked"]와 같은 필터),
+    last_changed_at은 그 에픽 스토리들의 updated_at 최댓값(「마지막 변경 이후」— 「마지막
+    머지」가 아님, 그 소스가 없어 이름을 좁혀 낸 것)."""
+    from datetime import datetime
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+
+            from app.models.pm import Goal
+            epic = Goal(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Epic")
+            s.add(epic)
+            await s.commit()
+
+            older = await _make_story(s, org.id, project.id, title="OLDER")
+            older.epic_id = epic.id
+            older.status = "in-progress"
+            await s.commit()
+
+            blocked_1 = await _make_story(s, org.id, project.id, title="BLOCKED_1")
+            blocked_1.epic_id = epic.id
+            blocked_1.status = "backlog"
+
+            blocked_2 = await _make_story(s, org.id, project.id, title="BLOCKED_2_DONE")
+            blocked_2.epic_id = epic.id
+            blocked_2.status = "done"  # 막힘은 status(zone)와 무관하게 세어야 함
+            await s.commit()
+
+            # ⛔onupdate=func.now()가 커밋 시 실제 시각으로 덮어써 Python에서 과거 시각을
+            # 직접 대입해도 안 먹는다(SQLAlchemy 컬럼 레벨 onupdate가 항상 이긴다) — 그래서
+            # 「나중에 커밋된 것이 더 최근」이라는 자연스러운 순서로 MAX를 검증한다.
+            newest = await _make_story(s, org.id, project.id, title="NEWEST")
+            newest.epic_id = epic.id
+            newest.status = "backlog"
+            await s.commit()
+            await s.refresh(newest)
+            await s.refresh(older)
+
+            from app.models.gate import Gate
+            s.add_all([
+                Gate(
+                    id=uuid.uuid4(), org_id=org.id, work_item_id=blocked_1.id, work_item_type="story",
+                    gate_type="merge", status="pending", requires_human=True, evidence_status="insufficient",
+                ),
+                Gate(
+                    id=uuid.uuid4(), org_id=org.id, work_item_id=blocked_2.id, work_item_type="story",
+                    gate_type="merge", status="pending", requires_human=True, evidence_status="insufficient",
+                ),
+            ])
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/analytics/epic-flow-nodes",
+                params={"project_id": str(project.id), "epic_id": str(epic.id)},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["blocked_count"] == 2, "done 상태(blocked_2)도 막힘이면 세어야 함(status 무관)"
+            last_changed = datetime.fromisoformat(body["last_changed_at"])
+            assert last_changed == newest.updated_at, "MAX가 가장 나중에 커밋된 것이어야 함"
+            assert last_changed > older.updated_at, "더 먼저 커밋된 것보다 나중이어야 함"
         finally:
             await client.aclose()
     finally:


### PR DESCRIPTION
## Summary
PO 판정(2026-07-30) — `/flow` 초점 스트립 4종 수치 중 ㉠㉡은 이미 있고, ㉢㉣ 둘을 새 쿼리 없이 얹는다(이미 fetch한 데이터에서 파생만).

**blocked_count**: `get_epics_progress_lane`의 `lane["blocked"]`와 같은 Gate 필터를 status와 무관하게 센다 — 형제 화면과 다르게 세면 두 화면이 다른 수를 말한다.

**last_changed_at**: 「멈춘 시간」의 옳은 정의는 「마지막 머지/배포 이후」이나 그 소스가 없다(`merged=True`는 웹훅 처리 중 일시 감지일 뿐 저장 안 됨, `PullRequestStoryLink`에 `merged_at` 없음, 배포 추적 테이블 자체가 없음). 지금 잴 수 있는 것은 `Story.updated_at` 최댓값뿐이라 이름을 「마지막 변경 이후」로 좁혀 낸다. ISO 문자열 그대로 반환(N시간 환산은 FE 몫 — 서버가 환산하면 캐시된 순간의 시계가 굳는다).

단일-`epic_id` 경로도 배치 메서드를 재사용하므로(#2692 구조) 두 필드가 자동으로 양쪽 다 실린다.

## ⛔이 PR이 못 재는 것
- 「마지막 머지/배포 이후」축 — 소스 자체가 없다(위 참조). ③(머지 기준)이 나중에 서면 그때 이름을 바꾼다.
- `blocked_count`는 status 무관(lane과 같은 필터를 쓰기 위함) — 즉 done인데 게이트가 pending인 건도 포함된다. 두 화면이 다른 수를 내지 않는 것이 우선이므로 그대로 둔다. 단 "문 앞 N" 라벨이 그 경우를 설명하지 못한다는 것은 알고 있다.

## Test plan
- [x] blocked_count가 status 무관하게 세는지(done 상태 막힘도 포함) · last_changed_at이 나중 커밋 스토리를 정확히 가리키는지 — 기존 5건 포함 6건 전부 그린
- [x] 전체 스위트 5422 passed(무회귀)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>