### PR TITLE
feat(#2232): needs_input attention item에 gate_type·evidence_status 실기

### DIFF
--- a/backend/app/routers/glance.py
+++ b/backend/app/routers/glance.py
@@ -222,9 +222,16 @@ async def glance_attention(
             ))
 
     # ④ needs_input = 프로젝트의 오픈 story 중 사람 판단 대기(§7 확定① — Gate(requires_human, pending)).
+    # ⛔story #2232(2026-07-30, PO 판정 — 실측으로 "degraded로 접을 이유 없음" 확認 후 지금 굴림):
+    # gate_type·evidence_status를 ref에 싣는다 — «있는데 안 나르던» 값. FE(derive-exception-
+    # signals.ts:96)가 지금은 ref.approval_id만 다음 마디로 넘겨 이 값들이 죽었으나, 그건
+    # FE 몫(미르코)이라 여기서는 BE 계약에만 싣는다.
     needs_input_rows = (
         await session.execute(
-            select(Story.id, Story.title, Gate.status_entered_at)
+            select(
+                Story.id, Story.title, Gate.status_entered_at, Gate.id,
+                Gate.gate_type, Gate.evidence_status,
+            )
             .select_from(Gate)
             .join(Story, (Story.id == Gate.work_item_id) & (Gate.work_item_type == "story"))
             .where(
@@ -238,9 +245,12 @@ async def glance_attention(
             .limit(_LIMIT)
         )
     ).all()
-    for story_id, title, entered_at in needs_input_rows:
+    for story_id, title, entered_at, gate_id, gate_type, evidence_status in needs_input_rows:
         items.append(AttentionItem(
             kind="needs_input", story_id=story_id, title=title, entered_state_at=entered_at,
+            ref={
+                "gate_id": str(gate_id), "gate_type": gate_type, "evidence_status": evidence_status,
+            },
             # 배포 前 생성된 기존 Gate 행은 status_entered_at이 아직 None일 수 있다(다음 전이
             # 때 채워짐) — 값 없을 땐 정밀도도 None(값과 정밀도는 항상 짝으로 움직인다).
             entered_state_at_precision=_PRECISION_EXACT if entered_at is not None else None,

--- a/backend/tests/test_2249_glance_entered_state_at_realdb.py
+++ b/backend/tests/test_2249_glance_entered_state_at_realdb.py
@@ -173,8 +173,8 @@ async def test_needs_input_and_verify_fail_use_new_gate_columns():
             ni_entered = datetime(2026, 7, 20, 0, 0, 0, tzinfo=timezone.utc)
             gate_ni = Gate(
                 id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story_ni.id,
-                work_item_type="story", gate_type="review", status="pending",
-                status_entered_at=ni_entered, requires_human=True,
+                work_item_type="story", gate_type="doc_approval", status="pending",
+                status_entered_at=ni_entered, requires_human=True, evidence_status="insufficient",
                 # updated_at은 onupdate=func.now()라 커밋 시점이 됨 — status_entered_at과
                 # 다른 값이어야 "updated_at을 쓴 게 아니다"가 실증된다.
             )
@@ -200,6 +200,11 @@ async def test_needs_input_and_verify_fail_use_new_gate_columns():
             got_ni = datetime.fromisoformat(ni_item["entered_state_at"].replace("Z", "+00:00"))
             assert got_ni == ni_entered
             assert ni_item["entered_state_at_precision"] == "exact"
+            # ⛔story #2232(2026-07-30) — 값이 있는데 ref가 안 나르던 것을 고침. 값-레벨 증거로
+            # 닫는다("코드에 넣었다"가 아니라 "응답에 실제로 있다"가 증거, 오늘 아침 교훈).
+            assert ni_item["ref"]["gate_type"] == "doc_approval"
+            assert ni_item["ref"]["evidence_status"] == "insufficient"
+            assert ni_item["ref"]["gate_id"] == str(gate_ni.id)
 
             vf_item = next(i for i in items if i["kind"] == "verify_fail")
             got_vf = datetime.fromisoformat(vf_item["entered_state_at"].replace("Z", "+00:00"))
@@ -207,6 +212,47 @@ async def test_needs_input_and_verify_fail_use_new_gate_columns():
             assert vf_item["entered_state_at_precision"] == "exact"
 
             assert got_ni != got_vf  # 서로 다른 축(status vs evidence_status)임을 재확認.
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_needs_input_ref_carries_null_evidence_status_faithfully():
+    """story #2232 — evidence_status가 구조적으로 NULL인 게이트(예: artifact_canonicalize류)도
+    ref에 «None 그대로» 실려야 한다(빈 문자열로 뭉개거나 키 자체를 생략하면 FE가 "구조적 NULL"과
+    "값 없는 에러"를 못 가른다 — 실측: 37건 중 5건이 NULL, 그중 merge인데 NULL인 1건은 다른
+    의미라 FE가 갈라야 한다는 것이 오르테가 판정, BE는 값을 «그대로» 나르기만 한다)."""
+    from app.main import app
+    from app.models.gate import Gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            story = _story(seeded["org_id"], seeded["project_id"], "No Evidence Status")
+            s.add(story)
+            await s.commit()
+
+            gate = Gate(
+                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story.id,
+                work_item_type="story", gate_type="artifact_canonicalize", status="pending",
+                requires_human=True,  # evidence_status 생략 — 구조적으로 None
+            )
+            s.add(gate)
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/glance/attention?project_id={seeded['project_id']}")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()["items"]
+            ni_item = next(i for i in items if i["kind"] == "needs_input")
+            assert ni_item["ref"]["gate_type"] == "artifact_canonicalize"
+            assert ni_item["ref"]["evidence_status"] is None
         finally:
             await client.aclose()
     finally:


### PR DESCRIPTION
## Summary
실측(2026-07-30) — dev pending 37건 중 gate_type 4종·evidence_status 32/37 채워짐(약 14% 구조적 NULL) 확認됨. "값이 없어 degraded로 접는다"는 목업 자체 주석 4번의 fallback 조건이 성립하지 않는다.

지금 값으로 목업의 "원인 넷" 그룹핑을 그릴 수 있는데, `derive-exception-signals.ts:96`이 `ref.approval_id`만 다음 마디로 나르는 FE 쪽 전달 경로가 값을 죽이고 있었다(오늘 아침 "?include=glance가 프록시 체인에서 증발한다"와 같은 클래스 — 보내는 쪽도 받는 쪽도 자기 코드는 맞고, 결함이 파일 사이에 있다).

이 PR은 ①(BE ref에 싣기)만 한다 — ②(FE가 다음 마디로 나르기)는 미르코 몫으로 넘긴다.

`needs_input`(Gate.status=pending·requires_human=True) 쿼리에 `gate_type`·`evidence_status`를 추가로 select해 `AttentionItem.ref`에 그대로 싣는다(None도 그대로 — 구조적 NULL과 "merge인데 NULL"을 가르는 것은 FE 표시 판단이라 BE는 값을 그대로 나르기만 한다).

## Test plan
- [x] 실PG 테스트 2건 추가(gate_type·evidence_status가 ref에 실리는지 · 구조적 NULL이 빈 문자열로 뭉개지거나 키 자체가 생략되지 않고 None 그대로 실리는지) — 기존 6건 포함 8건 전부 그린
- [x] 전체 스위트 5423 passed(무회귀)

## ⛔③(값으로 도착 확認) — 「못 잼」으로 남긴다(P도 F도 아님)
2026-07-30 — `gate_type`/`evidence_status`를 `AttentionItem.ref`에 싣는 코드는 배포 확認(리비전 `sprintable-backend-dev-02081-zmj`, 10:07:44Z). 다만 실제 도착값으로 닫지 못했다: 이 org의 pending·requires_human 게이트 32건이 전부 done 스토리에 걸려 있고 `needs_input` 쿼리가 done을 제외하므로 — 지금 잴 대상이 0건이다.

**닫는 조건**: done이 아닌 스토리에 requires_human 게이트가 하나라도 생기면 그때 `glance/attention` 응답에 `gate_type`이 실리는지 확認한다(#2232 FE 작업이 붙을 때 그 자리에서 같이 닫는 것으로).

실 dev에 검증용 게이트를 직접 만드는 것은 시도하지 않았다(실 데이터에 검증용 행을 만드는 것 — 지운다 해도 흔적이 남고 다른 화면 수를 잠깐 움직인다. "못 잼"으로 남기는 것이 더 정직하다).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>