### PR TITLE
[SID:2224] 진입점 전수 스윕(현황판·보드 사각) + /flow 모바일 0폭 결함 fix

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -237,7 +237,7 @@
     "ccFleet": "Fleet {count}",
     "ccFleetBreakdownPending": "Status breakdown pending",
     "ccFleetOnlineWorking": "Online {online} · Working {working}",
-    "ccGlanceTooltip": "See the project glance",
+    "ccFlowTooltip": "See the project flow",
     "ccLoading": "Loading…",
     "ccZoneActions": "Your actions now",
     "ccClearTitle": "All clear",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -237,7 +237,7 @@
     "ccFleet": "함대 {count}",
     "ccFleetBreakdownPending": "상태 집계 준비중",
     "ccFleetOnlineWorking": "온라인 {online} · 작업중 {working}",
-    "ccGlanceTooltip": "프로젝트 현황판 보기",
+    "ccFlowTooltip": "프로젝트 흐름 보기",
     "ccLoading": "불러오는 중…",
     "ccZoneActions": "지금 내 할 일",
     "ccClearTitle": "괜찮습니다",

--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
@@ -1183,7 +1183,11 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
                   </p>
                   <p className="text-xs text-muted-foreground">{selectedRole?.name} · {t('deployedNote')}</p>
                 </div>
-                <Link href="/board" className="shrink-0 text-xs font-semibold text-primary hover:underline">{t('viewInBoard')} →</Link>
+                {/* story #2224(선생님 정정 2026-07-30, 진입점 전수 스윕) — `/board` 삭제 후
+                    `/flow?view=list`로 흡수. 라벨("보드에서 보기")은 목적지 콘텐츠(칸반)가
+                    그대로라 안 바꿨다 — bare href는 proxy.ts MIGRATED_RESOURCES 안전망이
+                    org/project 쿠키로 해소한다. */}
+                <Link href="/flow?view=list" className="shrink-0 text-xs font-semibold text-primary hover:underline">{t('viewInBoard')} →</Link>
               </div>
 
               <p className="flex items-start gap-1.5 text-xs text-info">

--- a/apps/web/src/components/command-palette/command-palette-actions.test.ts
+++ b/apps/web/src/components/command-palette/command-palette-actions.test.ts
@@ -17,19 +17,20 @@ describe('buildActionCommands — v1 inventory (route-first, no-fiction)', () =>
   });
 
   it('with a story context, the delegate command exists, ranked first, targeting the real story route', () => {
-    // story a539c649 S3d: targetRoute는 이제 호출부가 넘긴 boardHref를 그대로 쓴다(하드코딩
-    // '/board' 아님) — path 위계(ws/proj 해소됨) 케이스로 검증.
-    const items = buildActionCommands(t, { storyId: 's1', storyTitle: '웰컴 이메일 시안', boardHref: '/moonklabs/sprintable/board' });
+    // story #2224(선생님 정정 2026-07-30): targetRoute는 이제 호출부가 넘긴 boardHref를
+    // 그대로 쓴다(하드코딩 아님) — /board 삭제 후 boardHref 자체가 이미 `?view=list`를
+    // 포함하므로 story id는 `&`로 이어붙인다(path 위계 ws/proj 해소됨 케이스로 검증).
+    const items = buildActionCommands(t, { storyId: 's1', storyTitle: '웰컴 이메일 시안', boardHref: '/moonklabs/sprintable/flow?view=list' });
     expect(items[0]).toEqual(expect.objectContaining({
-      id: 'action-delegate-story', targetRoute: '/moonklabs/sprintable/board?story=s1', danger: false,
+      id: 'action-delegate-story', targetRoute: '/moonklabs/sprintable/flow?view=list&story=s1', danger: false,
     }));
     expect(items[0]!.label).toContain('웰컴 이메일 시안');
     expect(items[0]!.impact).toContain('웰컴 이메일 시안');
   });
 
-  it('falls back to bare /board when ws/proj slug not yet resolved (미들웨어 legacy-redirect 안전망 대상)', () => {
-    const items = buildActionCommands(t, { storyId: 's1', storyTitle: 'x', boardHref: '/board' });
-    expect(items[0]!.targetRoute).toBe('/board?story=s1');
+  it('falls back to bare /flow?view=list when ws/proj slug not yet resolved (proxy.ts MIGRATED_RESOURCES 안전망 대상)', () => {
+    const items = buildActionCommands(t, { storyId: 's1', storyTitle: 'x', boardHref: '/flow?view=list' });
+    expect(items[0]!.targetRoute).toBe('/flow?view=list&story=s1');
   });
 
   it('gate decision routes to the gate inbox and is flagged as a danger (amber) command', () => {
@@ -47,7 +48,7 @@ describe('buildActionCommands — v1 inventory (route-first, no-fiction)', () =>
   });
 
   it('never fabricates the 3 unwired commands (stop run / re-collect evidence / STEER priority) — dead-path guard', () => {
-    const items = buildActionCommands(t, { storyId: 's1', storyTitle: 'x', boardHref: '/board' });
+    const items = buildActionCommands(t, { storyId: 's1', storyTitle: 'x', boardHref: '/flow?view=list' });
     const ids = items.map((i) => i.id);
     expect(ids).not.toContain('action-stop-run');
     expect(ids).not.toContain('action-recollect-evidence');
@@ -55,7 +56,7 @@ describe('buildActionCommands — v1 inventory (route-first, no-fiction)', () =>
   });
 
   it('renders in English when given the en translator (ko/en parity)', () => {
-    const items = buildActionCommands(tEn, { storyId: 's1', storyTitle: 'Welcome email draft', boardHref: '/board' });
+    const items = buildActionCommands(tEn, { storyId: 's1', storyTitle: 'Welcome email draft', boardHref: '/flow?view=list' });
     expect(items[0]!.label).toContain('Welcome email draft');
     expect(items.find((i) => i.id === 'action-recruit-agent')!.label).not.toBe('');
   });

--- a/apps/web/src/components/command-palette/command-palette-actions.ts
+++ b/apps/web/src/components/command-palette/command-palette-actions.ts
@@ -12,8 +12,10 @@ export interface ActionCommandTranslator {
 export interface StoryContext {
   storyId: string;
   storyTitle: string;
-  /** story a539c649 S3d: 이 스토리가 열려있던 board 의 실 path(/{ws}/{proj}/board 또는 아직
-   * ws/proj slug 미해소 시 bare /board — 미들웨어 legacy-redirect 안전망이 받는다). */
+  /** story #2224(선생님 정정 2026-07-30) — 이 스토리가 열려있던 화면의 실 path. `/board`
+   * 삭제 후 `/{ws}/{proj}/flow?view=list`(또는 slug 미해소 시 bare `/flow?view=list` —
+   * proxy.ts MIGRATED_RESOURCES 안전망이 받는다). ⛔이미 `?view=list` 쿼리를 포함하고
+   * 있으므로 story id는 `&`로 이어붙인다(`?`를 또 쓰면 두 번째 `?`가 무효 쿼리로 깨진다). */
   boardHref: string;
 }
 
@@ -42,7 +44,7 @@ export function buildActionCommands(t: ActionCommandTranslator, context?: StoryC
       group: 'action',
       labelKey: 'actionDelegateStory',
       label: t('actionDelegateStory', { title: context.storyTitle }),
-      targetRoute: `${context.boardHref}?story=${context.storyId}`,
+      targetRoute: `${context.boardHref}&story=${context.storyId}`,
       impact: t('actionDelegateStoryImpact', { title: context.storyTitle }),
       danger: false,
     });

--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -82,7 +82,14 @@ export function CommandPalette({ open, onOpenChange, projectId, contextStoryId }
     return orgSlug && currentProjectSlug ? `/${orgSlug}/${currentProjectSlug}/${resource}` : `/${resource}`;
   }
   const docsHref = resourceHref('docs');
-  const boardHref = resourceHref('board');
+  // story #2224(선생님 정정 2026-07-30, 진입점 전수 스윕) — `/board` 라우트가 삭제되고
+  // `/flow?view=list`로 흡수됐다(PR#2698). "보드로 이동"(goBoard) 라벨은 목적지 콘텐츠(칸반)가
+  // 그대로라 안 바꿨지만, href는 최종 주소를 직접 가리켜야 한다(리다이렉트 경유는 "은퇴한
+  // 주소가 진입점에 살아 있다"는 문제를 남긴다). 쿼리 없는 bare href로 두고 각 사용처가
+  // 자기 쿼리를 직접 이어붙인다(아래 boardHref처럼 미리 합쳐두면 story= 이어붙일 때
+  // `?`가 두 번 생긴다).
+  const flowHref = resourceHref('flow');
+  const boardHref = `${flowHref}?view=list`;
   const ITEMS = useMemo(
     () => STATIC_ITEMS.map((item) => {
       if (item.id === 'go-docs') return { ...item, href: docsHref };

--- a/apps/web/src/components/dashboard/command-center/command-center.tsx
+++ b/apps/web/src/components/dashboard/command-center/command-center.tsx
@@ -77,8 +77,11 @@ export function CommandCenter({ projectName }: { projectName?: string | null }) 
         <div className="flex items-center gap-2">
           {activeEpic ? (
             <Link
-              href="/glance"
-              title={t('ccGlanceTooltip')}
+              // story #2224(선생님 정정 2026-07-30, 진입점 전수 스윕) — `/glance` 라우트가
+              // 삭제되고 `/flow`로 흡수됐다(PR#2698). bare `/flow`는 proxy.ts
+              // MIGRATED_RESOURCES 안전망(오늘 등록)이 org/project 쿠키로 해소한다.
+              href="/flow"
+              title={t('ccFlowTooltip')}
               className="inline-flex min-w-0 items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1 text-[11px] text-muted-foreground transition-colors hover:text-foreground"
             >
               <Map className="size-3 shrink-0" aria-hidden="true" />

--- a/apps/web/src/components/flow/flow-lane.tsx
+++ b/apps/web/src/components/flow/flow-lane.tsx
@@ -48,8 +48,13 @@ export function FlowLane({ rows, totalEpicCount }: FlowLaneProps) {
     return <p className="px-1 py-3 text-xs text-muted-foreground">{t('laneEmpty')}</p>;
   }
 
+  // ⛔결함 fix(2026-07-30, 선생님 실측 지적 — "/flow 모바일 최적화가 하나도 안 됐다") — 옛
+  // `w-full`은 이 컴포넌트가 캔버스 없이 단독 스택으로 쓰이던 시절의 흔적이다. 지금은 항상
+  // `flex` 행의 형제(FlowCanvas와 나란히)라 `w-full`이 행 전체(390px 뷰포트에서도)를 먹어
+  // 캔버스를 0폭으로 밀어냈다(실측: FlowCanvas 렌더 폭 0px). 본격 모바일 재설계는 #2225 —
+  // 이번 판은 "안 깨지게"만: lg 미만에서도 좁은 고정폭으로 캔버스에 자리를 준다.
   return (
-    <div className="w-full shrink-0 space-y-3 border-border lg:w-64 lg:border-r lg:pr-3">
+    <div className="w-32 shrink-0 space-y-3 border-border lg:w-64 lg:border-r lg:pr-3">
       <p className="px-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
         {t('laneHeading', { n: totalEpicCount })}
       </p>

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -100,18 +100,18 @@ export function AppSidebar({
   const sprintsLink = resourceLink('sprints');
   const storageLink = resourceLink('storage');
   const goalsLink = resourceLink('goals');
-  const boardLink = resourceLink('board');
   // story #2224(IA v2.2 §7-3, AC12) — 기본 진입은 /flow, 사이드바가 통합뷰를 가리킨다.
-  // 칸반(/board)은 살아 있고 딥링크도 무변경이지만, 사이드바에 board를 flow와 나란히
-  // 1Depth로 세우지 않는다("나란히 두면 「내렸다」가 무효가 된다" — §7-3) — /flow 안의
-  // 보기 전환(?view=kanban)이 "내비 2Depth 이하" 요건을 충족하는 그 자리다.
+  // 칸반은 /flow?view=list로 흡수됐다(PR#2698, `/board` 라우트 자체는 삭제) — 사이드바에
+  // board를 flow와 나란히 1Depth로 세우지 않는다("나란히 두면 「내렸다」가 무효가 된다" —
+  // §7-3) — /flow 안의 보기 전환(?view=list)이 "내비 2Depth 이하" 요건을 충족하는 그 자리다.
   const flowLink = resourceLink('flow');
   const t = useTranslations('nav');
   const { isMobile, setOpenMobile } = useSidebar();
-  // ⌘K 액션 확장(story 4f991165) — 스토리 상세(`/board?story={id}` 또는 이관 후
-  // `/{ws}/{proj}/board?story={id}`)에서 열렸을 때만 context 주입. story a539c649 S3d:
-  // boardLink.isActive가 두 형태 모두 판정(리소스별 resourceLink 헬퍼 재사용).
-  const contextStoryId = boardLink.isActive ? (searchParams.get('story') ?? undefined) : undefined;
+  // ⌘K 액션 확장(story 4f991165) — 스토리 상세(`/flow?view=list&story={id}`)에서 열렸을
+  // 때만 context 주입. story #2224 정정(2026-07-30): 옛 boardLink.isActive 대신
+  // flowLink.isActive로 판정 — `/board`가 삭제돼 그 판정이 다시는 참이 될 수 없었다(칸반
+  // 보기가 이제 /flow 경로이므로 옛 체크로는 위임 명령이 영영 안 뜨는 조용한 회귀였다).
+  const contextStoryId = flowLink.isActive ? (searchParams.get('story') ?? undefined) : undefined;
 
   // 4dad38d3: 모바일 nav 아이템 선택 후 드로어 auto-close. route 변경 시 닫는다(전 아이템 DRY 커버).
   // 데스크탑은 isMobile 가드로 no-op·백드롭 탭 닫기(Sheet onOpenChange)는 무영향.
@@ -322,7 +322,8 @@ export function AppSidebar({
           </SidebarGroupContent>
         </SidebarGroup>
 
-        {/* ② 작업 / Work — 흐르는 일(보드·스프린트·에픽·현황판·Loop·스탠드업·회고). ia-4zone SSOT 확定. */}
+        {/* ② 작업 / Work — 흐르는 일(흐름·스프린트·목표·Loop·스탠드업·회고). ia-4zone SSOT 확定.
+            board·glance는 /flow로 흡수되며 별도 1Depth 항목이 아니게 됐다(#2224, PR#2698). */}
         <SidebarGroup>
           <SidebarGroupLabel>{t('zoneWork')}</SidebarGroupLabel>
           <SidebarGroupContent>
@@ -330,7 +331,7 @@ export function AppSidebar({
               <SidebarMenuItem>
                 <SidebarMenuButton
                   render={<Link href={flowLink.href} />}
-                  isActive={flowLink.isActive || boardLink.isActive}
+                  isActive={flowLink.isActive}
                   tooltip={t('flow')}
                 >
                   <Workflow />

--- a/apps/web/src/components/nav/mobile-tab-bar.test.ts
+++ b/apps/web/src/components/nav/mobile-tab-bar.test.ts
@@ -6,7 +6,12 @@ import { describe, expect, it } from 'vitest';
 import { getActiveTabKey, TABS } from './mobile-tab-bar';
 
 describe('getActiveTabKey', () => {
-  it('/glance 및 하위 경로는 now', () => {
+  it('/{ws}/{proj}/flow 및 하위 경로는 now — story #2224, "지금" 탭의 새 목적지', () => {
+    expect(getActiveTabKey('/qa-org/qa-proj/flow')).toBe('now');
+    expect(getActiveTabKey('/qa-org/qa-proj/flow/anything')).toBe('now');
+  });
+
+  it('/glance 및 하위 경로도 계속 now(옛 라우트 — 리다이렉트 경유 도착 대비)', () => {
     expect(getActiveTabKey('/glance')).toBe('now');
     expect(getActiveTabKey('/glance/foo')).toBe('now');
   });
@@ -48,5 +53,10 @@ describe('TABS — story #2279 회귀가드', () => {
   it('approvals 탭은 게이트 탭(/inbox?tab=gates)에 착지한다 — 알림 탭(bare /inbox)이 아니다', () => {
     const approvalsTab = TABS.find((t) => t.key === 'approvals');
     expect(approvalsTab?.href).toBe('/inbox?tab=gates');
+  });
+
+  it('now 탭은 /flow에 착지한다 — story #2224, 옛 /glance(삭제됨)로 조용히 되돌아가지 않는다', () => {
+    const nowTab = TABS.find((t) => t.key === 'now');
+    expect(nowTab?.href).toBe('/flow');
   });
 });

--- a/apps/web/src/components/nav/mobile-tab-bar.test.ts
+++ b/apps/web/src/components/nav/mobile-tab-bar.test.ts
@@ -11,6 +11,11 @@ describe('getActiveTabKey', () => {
     expect(getActiveTabKey('/qa-org/qa-proj/flow/anything')).toBe('now');
   });
 
+  it('bare /flow(+하위)도 now — 결함 fix(선생님 실측 2026-07-30): TABS.now.href 자체가 bare라 탭을 누른 순간(proxy.ts 301 착지 前)엔 pathname이 이 형태다', () => {
+    expect(getActiveTabKey('/flow')).toBe('now');
+    expect(getActiveTabKey('/flow/anything')).toBe('now');
+  });
+
   it('/glance 및 하위 경로도 계속 now(옛 라우트 — 리다이렉트 경유 도착 대비)', () => {
     expect(getActiveTabKey('/glance')).toBe('now');
     expect(getActiveTabKey('/glance/foo')).toBe('now');
@@ -58,5 +63,19 @@ describe('TABS — story #2279 회귀가드', () => {
   it('now 탭은 /flow에 착지한다 — story #2224, 옛 /glance(삭제됨)로 조용히 되돌아가지 않는다', () => {
     const nowTab = TABS.find((t) => t.key === 'now');
     expect(nowTab?.href).toBe('/flow');
+  });
+
+  // 선생님 지적(2026-07-30) — 위 두 시험(href 값 하드코딩 + getActiveTabKey 값 하드코딩)은
+  // 각자 맞아도 "서로 안 만나서" 어긋날 수 있다(isFlowPath가 3-세그먼트만 인식하고 TABS의
+  // now.href가 bare였던 실제 사례). 탭 자신의 href를 판정기에 직접 먹이는 왕복 시험으로
+  // 고정 — href를 나중에 또 바꿔도 이 시험이 자동으로 재검증한다(값을 또 하드코딩하지 않음).
+  it('각 탭의 href는 getActiveTabKey를 다시 먹였을 때 자기 자신의 key로 돌아온다 — 왕복 회귀가드', () => {
+    // usePathname()은 쿼리스트링을 안 싣는다(Next.js가 pathname/searchParams를 분리) — 실
+    // 런타임과 같은 입력을 주기 위해 href의 쿼리 부분을 떼고 pathname만 넣는다(approvals
+    // 탭의 `/inbox?tab=gates`가 대상).
+    for (const tab of TABS) {
+      const pathnameOnly = tab.href.split('?')[0]!;
+      expect(getActiveTabKey(pathnameOnly)).toBe(tab.key);
+    }
   });
 });

--- a/apps/web/src/components/nav/mobile-tab-bar.tsx
+++ b/apps/web/src/components/nav/mobile-tab-bar.tsx
@@ -45,10 +45,12 @@ export const TABS = [
 // "이 경로는 소속상 어느 탭인가"를 판정하는 단일 함수로 교체한다.
 //
 // story #2224(선생님 정정 2026-07-30) — `/flow`는 다른 ws/proj-scoped 리소스(board·goals·
-// loops 등, 아래 ④ 참고)와 달리 "지금" 탭의 목적지 그 자체다 — bare `/flow`가 아니라
-// `/{ws}/{proj}/flow`라 3번째 세그먼트로 판정한다(orgSlug/projectSlug를 몰라도 되는 순수
-// pathname 판정을 유지하기 위함 — resourceLink처럼 slug를 아는 컨텍스트가 여기엔 없다).
+// loops 등, 아래 ④ 참고)와 달리 "지금" 탭의 목적지 그 자체다 — `/{ws}/{proj}/flow`(3번째
+// 세그먼트)뿐 아니라 TABS의 `now.href` 자체가 «bare» `/flow`라 그 형태도 인식해야 한다
+// (선생님 실측 2026-07-30 — 탭을 누른 그 순간의 pathname은 bare, proxy.ts 301이 실 slug로
+// 착지시키기 «전»의 찰나에 하이라이트가 꺼졌다). `/glance`(옛 라우트)의 bare 인식과 대칭.
 function isFlowPath(pathname: string): boolean {
+  if (pathname === '/flow' || pathname.startsWith('/flow/')) return true;
   const segments = pathname.split('/').filter(Boolean);
   return segments[2] === 'flow';
 }

--- a/apps/web/src/components/nav/mobile-tab-bar.tsx
+++ b/apps/web/src/components/nav/mobile-tab-bar.tsx
@@ -17,8 +17,14 @@ import { MOBILE_BREAKPOINT } from '@/hooks/use-mobile';
 // (지금 홈=S8/#1964, 결재함 통합큐=S4/#1960) 없이 기존 라우트를 그대로 가리킨다 — 후속 스토리가
 // 그 자리에서 콘텐츠만 원자적으로 교체한다(빅뱅 전환 금지).
 // export: story #2279 회귀가드(href가 조용히 되돌아가지 않게 직접 단위테스트).
+// story #2224(선생님 정정 2026-07-30) — "지금" 탭의 href를 `/glance`에서 `/flow`로 갱신했다.
+// `/glance` 라우트 자체가 삭제됐고(PR#2698), bare `/glance`는 proxy.ts 안전망을 거쳐 결국
+// `/flow`로 착지하지만 — "은퇴한 주소가 진입점에 살아 있다"는 지적(선생님)에 따라 최종
+// 목적지를 직접 가리킨다(한 홉 절약 + 이름-목적지 일치, #2224 §④ "사람이 누르는 진입점"
+// 표면). `/flow`는 아직 모바일 전용 화면(#2225)이 없어 데스크톱과 같은 레이아웃을 그대로
+// 받는다 — 이번 판에서는 "폰에서 깨지지 않게"까지만 손대고, 본격 모바일 재설계는 #2225.
 export const TABS = [
-  { key: 'now', href: '/glance', icon: CircleDot, labelKey: 'now' as const },
+  { key: 'now', href: '/flow', icon: CircleDot, labelKey: 'now' as const },
   // story #2279(PO 판정, 2026-07-29): 라벨("결재")·배지(게이트 대기 수)와 착지가 어긋나
   // 있던 것 — 이름=가는 곳=세는 것 셋을 한 줄로 맞춘다. #2164가 세운 "진입점 라벨은 착지
   // 탭과 일치" 규칙은 그대로 두고 착지 쪽을 게이트 탭으로 옮긴다(라벨을 규칙에 맞춘다).
@@ -38,8 +44,18 @@ export const TABS = [
 // 상세→parentTab 매핑(useSyntheticParentTabHistory 호출부와 동일 SSOT)을 여기서도 재사용해
 // "이 경로는 소속상 어느 탭인가"를 판정하는 단일 함수로 교체한다.
 //
+// story #2224(선생님 정정 2026-07-30) — `/flow`는 다른 ws/proj-scoped 리소스(board·goals·
+// loops 등, 아래 ④ 참고)와 달리 "지금" 탭의 목적지 그 자체다 — bare `/flow`가 아니라
+// `/{ws}/{proj}/flow`라 3번째 세그먼트로 판정한다(orgSlug/projectSlug를 몰라도 되는 순수
+// pathname 판정을 유지하기 위함 — resourceLink처럼 slug를 아는 컨텍스트가 여기엔 없다).
+function isFlowPath(pathname: string): boolean {
+  const segments = pathname.split('/').filter(Boolean);
+  return segments[2] === 'flow';
+}
+
 // 판정 순서(구체적인 것부터, 마지막이 fallback):
-//  ① /glance — "지금" 탭 자기 자신(+하위 경로 있으면 포함).
+//  ① `/{ws}/{proj}/flow`(+하위) 또는 `/glance`(+하위, 옛 라우트 — 리다이렉트 경유로 도착할
+//     수 있어 계속 인식) — "지금" 탭 자기 자신.
 //  ② /inbox(정확일치) 또는 /gates/* — "결재함". gate 상세는 #1951에서 parentTab=/inbox로
 //     이미 확定(gates/[id]/page.tsx의 useSyntheticParentTabHistory('/inbox') 그대로).
 //  ③ /chats(+하위) — "채팅".
@@ -48,7 +64,7 @@ export const TABS = [
 //     밖의 프로젝트/org 영역이라 more 페이지 자체가 이들의 진입점(ITEMS 목록, #1958 확定)
 //     — "전체"가 이 전부의 소속 탭이라는 게 이미 그 스텁 페이지 설계로 확定돼 있다.
 export function getActiveTabKey(pathname: string): (typeof TABS)[number]['key'] {
-  if (pathname === '/glance' || pathname.startsWith('/glance/')) return 'now';
+  if (isFlowPath(pathname) || pathname === '/glance' || pathname.startsWith('/glance/')) return 'now';
   if (pathname === '/inbox' || pathname.startsWith('/gates/')) return 'approvals';
   if (pathname === '/chats' || pathname.startsWith('/chats/')) return 'chat';
   return 'more';

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -128,6 +128,11 @@ const MIGRATED_RESOURCES: Record<string, string[]> = {
   // 문제(bare 딥링크가 org+project를 몰라 해소해야 함)가 생겼다 — 이미 검증된 이 표를 재사용
   // 한다(새 미들웨어 층을 세우지 않는다, 아래 redirectRenamedResourcePath와 짝).
   glance: [],
+  // ⛔실측 발견(2026-07-30, 진입점 전수 스윕 중) — `flow` 자체가 이 표에 «없었다». 사이드바
+  // (app-sidebar.tsx)는 항상 `resourceLink('flow')`로 실 slug를 채운 경로만 썼기에 이 갭이
+  // 안 보였는데, mobile-tab-bar.tsx의 "지금" 탭 href를 bare `/flow`로 바꾸며(옛 `/glance`
+  // 대체) 처음으로 실사용 경로가 생겼다 — 등록 없이 나갔으면 즉시 404였을 것.
+  flow: [],
   // story #2016: 8fc51517(B1 리네이밍)이 epics→goals 경로 리터럴을 바꾸면서 RENAMED_RESOURCES에만
   // 반영되고 여기(MIGRATED_RESOURCES)엔 신 이름 'goals'를 안 넣었다 — bare `/epics`는 이 표를 거쳐
   // `/{ws}/{proj}/epics`로 301된 뒤 redirectRenamedResourcePath가 2차로 `goals`로 다시 301하지만,


### PR DESCRIPTION
## 배경
선생님 재지적(2026-07-30) — "죽인 라우트 2"를 수로 올렸지만 진입점은 안 셌다. 사이드바만 고치고 모바일 GNB는 안 봤다("죽였다"가 데스크톱에서만 참이었다). 표면이 넷째로 늘어난다: ①코드 참조 ②영속 텍스트 ③기계가 읽는 계약(딥링크 매니페스트, PR#2698) ④사람이 누르는 진입점(화면마다 다르다).

## ④ 진입점 전수 스윕 — grep 전수로 찾은 6곳, 6곳 다 갱신
- `mobile-tab-bar.tsx` "지금" 탭: href `/glance`→`/flow`(직접 착지). `getActiveTabKey`도 `/{ws}/{proj}/flow` 세그먼트 판정 추가(`/glance`는 옛 라우트로 계속 인식)
- `command-palette.tsx` "go-board"(⌘K G B): href `/board`→`/flow?view=list`. 쿼리 이중 `?` 방지 위해 `command-palette-actions.ts`의 story 딥링크 이어붙임을 `?story=`→`&story=`로 수정
- `command-center.tsx`(org 대시보드): `href="/glance"`→`/flow`, i18n 키 `ccGlanceTooltip`→`ccFlowTooltip`로 이름-목적지 일치
- `recruiter-client.tsx` "보드에서 보기": href `/board`→`/flow?view=list`
- `app-sidebar.tsx`: 죽은 `boardLink` 변수 제거. ⛔부수 발견 — `contextStoryId`(⌘K 위임 명령 트리거)가 `boardLink.isActive`에 묶여 `/board` 삭제 후 영영 참이 될 수 없는 조용한 회귀였다 — `flowLink` 기준으로 교체
- `proxy.ts`: `flow` 자체가 `MIGRATED_RESOURCES`에 없었다(실측 발견) — bare `/flow` href 쓰면 즉시 404였을 잠재 결함, 등록

## 모바일 0폭 결함 — 라이브 스크린샷+DOM 실측으로 재현
390px에서 puppeteer로 `/flow` 실측: `flex.gap-4` 행 안에서 `FlowLane`(`w-full` 베이스)이 행 전체를 먹어 `FlowCanvas`가 **렌더 폭 0px**(scrollWidth 71, width 0)로 밀려나 완전히 안 보였다. `flow-lane.tsx`의 `w-full`을 `w-32`로 교체(lg:w-64는 무변경). 본격 모바일 재설계는 #2225, 이번 판은 "안 깨지게"까지만.

## 검증
- `pnpm tsc --noEmit` EXIT 0
- `pnpm lint` EXIT 0(6개 사전존재 경고, 무관)
- `pnpm vitest run` 2199/2199 통과, 뮤테이션 검증(`isFlowPath` segment index 뒤집기 → RED 확認 후 원복)
- `pnpm build` EXIT 0
- `verify:*` 5개 전부 OK