### PR TITLE
feat(#2223): reference_semantic_candidates 백필 + superseded 종 + 종 지정 분리

### DIFF
--- a/backend/alembic/versions/0219_reference_candidate_superseded_kind.py
+++ b/backend/alembic/versions/0219_reference_candidate_superseded_kind.py
@@ -1,0 +1,53 @@
+"""story #2223(E-CONNECT) 판정(오르테가군, 2026-07-30) — reference_semantic_candidates.
+relation_kind CHECK에 'superseded'(대체) 추가. 다른 5종과 성질이 다른 유일한 값(한쪽이
+죽는 관계) — 자동분류 규칙에는 안 넣는다, 사람이 직접 골라야만 붙는다
+(app/models/reference_semantic_candidate.py 참조).
+
+순수 additive — CHECK 재정의뿐, 기존 행 손상 0(기존 값 전부 새 CHECK를 그대로 통과).
+
+Revision ID: 0219
+Revises: 0218
+Create Date: 2026-07-30
+"""
+from alembic import op
+
+revision = "0219"
+down_revision = "0218"
+branch_labels = None
+depends_on = None
+
+OLD_CHECK = (
+    "relation_kind IS NULL OR relation_kind IN "
+    "('spawned', 'cited_as_evidence', 'similar_case', 'followed', 'explicitly_unrelated')"
+)
+NEW_CHECK = (
+    "relation_kind IS NULL OR relation_kind IN "
+    "('spawned', 'cited_as_evidence', 'similar_case', 'followed', "
+    "'explicitly_unrelated', 'superseded')"
+)
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "ck_reference_semantic_candidates_relation_kind",
+        "reference_semantic_candidates",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_reference_semantic_candidates_relation_kind",
+        "reference_semantic_candidates",
+        NEW_CHECK,
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_reference_semantic_candidates_relation_kind",
+        "reference_semantic_candidates",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_reference_semantic_candidates_relation_kind",
+        "reference_semantic_candidates",
+        OLD_CHECK,
+    )

--- a/backend/app/models/reference_semantic_candidate.py
+++ b/backend/app/models/reference_semantic_candidate.py
@@ -15,22 +15,33 @@ docstring이 스스로 막아 둔 것이 근거).
 
   relation_kind — ⛔영문 식별자(PO 지적 2026-07-29: "DB 값은 식별자, 사람이 읽는 말은
     번역"이어야 함 — 미르코군이 같은 병(qa 상태 리터럴이 화면에 날것으로 새는 것)을 겪은
-    직후 발견된 자매 사고). 5종 중 하나 또는 NULL(=미분류, AC10 — taxonomy 밖도 버리지
+    직후 발견된 자매 사고). 6종 중 하나 또는 NULL(=미분류, AC10 — taxonomy 밖도 버리지
     않고 저장한다). 한글 원표(`story_refcheck_classification_20260728.md`)와의 대조가
     끊기지 않도록 `RELATION_KIND_LABELS_KO` 매핑을 아래 상수로 남긴다:
       spawned(원표: 낳음) · cited_as_evidence(근거인용) · similar_case(동종사례) ·
-      followed(잇따름) · explicitly_unrelated(명시적_무관)
+      followed(잇따름) · explicitly_unrelated(명시적_무관) · superseded(대체)
+
+    ⛔superseded(대체) — story #2223 판정(오르테가군, 2026-07-30) 추가. 다른 5종과 성질이
+    다르다(한쪽이 죽는 유일한 관계) — 표본 실측 0건이라 자동분류 규칙(`_KEYWORD_RULES`)에
+    안 넣는다. 사람이 직접 골라야만 붙는 값 — declare와는 별도 액션(아래 참조).
   status — estimated(기본, AC3 「추정됨」) | declared(사람이 승격, AC5 「선언됨」).
   declared_by/declared_at — status=declared로 승격한 사람/시각(감사 추적).
+  ⛔relation_kind와 status는 서로 «다른 질문»이다(오르테가군 판정, 2026-07-30) — declare는
+  "이 연결이 실재하는가"만 확認하고(AC4 계약 그대로, 셋만 바꿈), "무슨 종류인가"는 별도
+  엔드포인트(`set_candidate_relation_kind`)가 담당한다. 한 클릭에 두 판단을 묶지 않는다.
 
 ⛔범위(AC1·#2269 AC0-3과 동일 모집단 유지): 이 표는 story description/acceptance_criteria의
 맨 번호(`#<번호>`)가 다른 story를 가리키는 경우만 다룬다 — bracket 멘션(`entity:type:uuid`
 문법)은 여기 후보가 안 된다. 섞으면 57.5% 실측 기준(AC1 재검증 모집단)이 흐려진다.
 
-⛔새 참조만(PO 판정 2026-07-29 ③, 소급 안 함) — 이 표에 행이 생기는 유일한 경로는 story
-저장(생성·수정) write-path(`app/services/reference_semantic_candidates.py`)뿐이다. 배치
-백필 없음 — 옛 1261건(이미 해소된 참조)은 그 story가 다시 저장될 때만(정상 편집) 자연히
-후보가 생긴다, 별도 재실행 로직 없음.
+⛔story #2223(2026-07-30) 판정으로 위 "소급 안 함"이 뒤집혔다 — create_story가
+`_reconcile_story_references_and_candidates()`를 한 번도 안 불렀던 버그(오르테가군, 오늘
+아침 수정)로 이 표가 선 뒤(2026-07-29 23:18~) 실제로 쌓인 행이 104건뿐(해소된 후보
+1349건 대비 7.7%)이었던 것이 실측으로 드러나 "소급"이 사실상 "첫 채우기"였다 — 그래서
+`backend/scripts/backfill_reference_semantic_candidates.py`(1회성, Cloud Run Job으로
+실행·재실행해도 멱등 — `store_semantic_candidates`의 ON CONFLICT DO NOTHING 그대로 재사용)
+가 생겼다. write-path(story 저장 시점)는 여전히 유일한 **상시** 경로다 — 백필은 그 경로를
+과거 데이터에 한 번 더 돌리는 것뿐, 별도 로직을 새로 만들지 않는다.
 
 ⛔미래번호(모집단에 없는 대상, 164건·11.5%)는 행 자체가 없다(PO 판정 ② — 제외, read-time
 재수집이라 그 번호가 실제 story로 만들어지면 다음 저장 때 저절로 들어온다).
@@ -46,9 +57,12 @@ from app.core.database import Base
 from app.models.base import OrgScopedMixin
 
 RELATION_KINDS = frozenset(
-    {"spawned", "cited_as_evidence", "similar_case", "followed", "explicitly_unrelated"}
+    {
+        "spawned", "cited_as_evidence", "similar_case", "followed", "explicitly_unrelated",
+        "superseded",
+    }
 )
-# NULL(미분류)은 값이지 부재가 아니다(AC10) — 위 5종 밖이면 저장 시 NULL로 남는다.
+# NULL(미분류)은 값이지 부재가 아니다(AC10) — 위 6종 밖이면 저장 시 NULL로 남는다.
 
 # ⛔PO 지적(2026-07-29): DB 값(위 RELATION_KINDS)은 식별자, 사람이 읽는 말은 번역(en.json/
 # ko.json) 몫 — 이 매핑은 번역 파일이 아니라 한글 원표(story_refcheck_classification_
@@ -59,6 +73,7 @@ RELATION_KIND_LABELS_KO: dict[str, str] = {
     "similar_case": "동종사례",
     "followed": "잇따름",
     "explicitly_unrelated": "명시적_무관",
+    "superseded": "대체",
 }
 
 STATUSES = frozenset({"estimated", "declared"})
@@ -69,7 +84,8 @@ class ReferenceSemanticCandidate(Base, OrgScopedMixin):
     __table_args__ = (
         CheckConstraint(
             "relation_kind IS NULL OR relation_kind IN "
-            "('spawned', 'cited_as_evidence', 'similar_case', 'followed', 'explicitly_unrelated')",
+            "('spawned', 'cited_as_evidence', 'similar_case', 'followed', "
+            "'explicitly_unrelated', 'superseded')",
             name="ck_reference_semantic_candidates_relation_kind",
         ),
         CheckConstraint(

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -839,6 +839,46 @@ async def declare_story_reference_candidate(
     }
 
 
+class SetReferenceCandidateRelationKindRequest(BaseModel):
+    relation_kind: str | None = None
+
+
+@router.post("/{id}/reference-candidates/{candidate_id}/relation-kind")
+async def set_story_reference_candidate_relation_kind(
+    id: uuid.UUID,
+    candidate_id: uuid.UUID,
+    body: SetReferenceCandidateRelationKindRequest,
+    repo: StoryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    """POST .../relation-kind — story #2223 판정(오르테가군, 2026-07-30): "이 연결이
+    실재하는가"(declare, 위)와 "무슨 종류인가"(이 엔드포인트)는 «다른 질문» — 한 클릭에
+    안 묶는다. declare 전후 아무 때나 호출 가능(순서 강제 없음). relation_kind=null로
+    미분류로 되돌릴 수 있다(AC10 정신)."""
+    story = await repo.get(id)
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+    await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
+
+    from app.services.reference_semantic_candidates import (
+        CandidateNotFoundError,
+        InvalidRelationKindError,
+        set_candidate_relation_kind,
+    )
+
+    try:
+        candidate = await set_candidate_relation_kind(
+            repo.session, org_id=repo.org_id, candidate_id=candidate_id,
+            relation_kind=body.relation_kind,
+        )
+    except CandidateNotFoundError:
+        raise HTTPException(status_code=404, detail="Reference candidate not found")
+    except InvalidRelationKindError:
+        raise HTTPException(status_code=400, detail="Invalid relation_kind")
+    await repo.session.commit()
+    return {"id": str(candidate.id), "relation_kind": candidate.relation_kind}
+
+
 async def _visible_target_ids(
     session: AsyncSession, org_id: uuid.UUID, caller_id: uuid.UUID,
     ids_by_type: dict[str, set[uuid.UUID]], auth: AuthContext,

--- a/backend/app/services/reference_semantic_candidates.py
+++ b/backend/app/services/reference_semantic_candidates.py
@@ -22,12 +22,16 @@ from __future__ import annotations
 import re
 import uuid
 from dataclasses import dataclass
+from datetime import UTC
 
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.reference_semantic_candidate import ReferenceSemanticCandidate
+from app.models.reference_semantic_candidate import (
+    RELATION_KINDS,
+    ReferenceSemanticCandidate,
+)
 from app.services.mention_parser import (
     _BARE_STORY_NUMBER_RE,
     _redact_code_spans,
@@ -241,9 +245,39 @@ async def declare_candidate(
     candidate = result.scalar_one_or_none()
     if candidate is None:
         raise CandidateNotFoundError()
-    from datetime import datetime, timezone
+    from datetime import datetime
 
     candidate.status = "declared"
     candidate.declared_by = declared_by
-    candidate.declared_at = datetime.now(timezone.utc)
+    candidate.declared_at = datetime.now(UTC)
+    return candidate
+
+
+class InvalidRelationKindError(Exception):
+    pass
+
+
+async def set_candidate_relation_kind(
+    db: AsyncSession, *, org_id: uuid.UUID, candidate_id: uuid.UUID, relation_kind: str | None,
+) -> ReferenceSemanticCandidate:
+    """story #2223 판정(오르테가군, 2026-07-30) — "이 연결이 실재하는가"(declare)와 "무슨
+    종류인가"(이 함수) 는 «다른 질문»이라 한 클릭에 안 묶는다. declare_candidate와 달리 이
+    함수는 relation_kind **하나만** 바꾼다 — status/declared_by/declared_at는 안 건드린다
+    (AC4가 declare 쪽에 지운 그 경계를 이 함수 쪽에서도 대칭으로 지킨다 — declare 여부와
+    무관하게 종 지정이 가능하다, 순서를 강제하지 않는다).
+
+    relation_kind=None 허용 — 잘못 지정한 것을 「미분류」로 되돌리는 경로(AC10 정신: 모르는
+    것을 억지로 채운 채로 안 둔다)."""
+    if relation_kind is not None and relation_kind not in RELATION_KINDS:
+        raise InvalidRelationKindError(relation_kind)
+    result = await db.execute(
+        select(ReferenceSemanticCandidate).where(
+            ReferenceSemanticCandidate.org_id == org_id,
+            ReferenceSemanticCandidate.id == candidate_id,
+        )
+    )
+    candidate = result.scalar_one_or_none()
+    if candidate is None:
+        raise CandidateNotFoundError()
+    candidate.relation_kind = relation_kind
     return candidate

--- a/backend/scripts/backfill_reference_semantic_candidates.py
+++ b/backend/scripts/backfill_reference_semantic_candidates.py
@@ -1,0 +1,134 @@
+"""story #2223(E-CONNECT) — reference_semantic_candidates 배치 백필.
+
+#2328이 "새 참조만"(소급 안 함)로 설계했으나, create_story가 그 write-path
+(_reconcile_story_references_and_candidates)를 한 번도 안 불렀던 버그(오르테가군,
+2026-07-30 아침 수정) 때문에 이 표가 선 뒤(2026-07-29)로도 실제로 쌓인 행이 거의 없었다
+(실측: 104/1349 ≈ 7.7%) — "소급"이 사실상 "첫 채우기"다.
+
+기존 story description/acceptance_criteria 전량을 `generate_and_store_candidates()`(story
+저장 시점 write-path와 완전히 같은 함수)에 다시 흘려보낸다 — 새 로직을 만들지 않는다.
+멱등 — `store_semantic_candidates`의 ON CONFLICT DO NOTHING(자연키 유니크)이 재실행을
+안전하게 만든다. 이미 declared된 후보는 caller가 그 키로 다시 insert를 시도해도 conflict라
+그대로 보존된다(사람의 승격 결정이 재계산으로 지워지지 않는다는 #2328의 불변식 그대로).
+
+env: DATABASE_URL (백엔드 동일, cloud-sql-proxy/in-VPC 경유). 쓰기 작업.
+실행: cd backend && DATABASE_URL=... python -m scripts.backfill_reference_semantic_candidates
+      [--batch-size N] [--dry-run]
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+import uuid
+from collections import Counter
+
+from sqlalchemy import select
+
+from app.core.database import async_session_factory
+from app.models.pm import Story
+from app.services.reference_semantic_candidates import generate_and_store_candidates
+
+logger = logging.getLogger("backfill_reference_semantic_candidates")
+
+
+async def _run(batch_size: int, dry_run: bool) -> dict:
+    stories_scanned = 0
+    stories_with_content = 0
+    candidates_inserted = 0
+    errors: list[tuple[str, str]] = []
+    last_created_at = None
+    last_id: uuid.UUID | None = None
+
+    async with async_session_factory() as db:
+        while True:
+            query = select(Story).order_by(Story.created_at.asc(), Story.id.asc()).limit(batch_size)
+            if last_created_at is not None:
+                query = query.where(
+                    (Story.created_at > last_created_at)
+                    | ((Story.created_at == last_created_at) & (Story.id > last_id))
+                )
+            rows = (await db.execute(query)).scalars().all()
+            if not rows:
+                break
+
+            for story in rows:
+                stories_scanned += 1
+                last_created_at, last_id = story.created_at, story.id
+                has_content = bool(story.description) or bool(story.acceptance_criteria)
+                if not has_content:
+                    continue
+                stories_with_content += 1
+                if dry_run:
+                    continue
+                try:
+                    for field, content in (
+                        ("description", story.description),
+                        ("acceptance_criteria", story.acceptance_criteria),
+                    ):
+                        if not content:
+                            continue
+                        n = await generate_and_store_candidates(
+                            db, org_id=story.org_id, project_id=story.project_id,
+                            source_type="story", source_field=field, source_id=story.id,
+                            content=content,
+                        )
+                        candidates_inserted += n
+                    await db.commit()
+                except Exception as exc:  # noqa: BLE001 — 한 스토리 실패가 배치 전체를 안 죽인다
+                    await db.rollback()
+                    errors.append((str(story.id), repr(exc)))
+                    logger.warning("story %s backfill 실패: %r", story.id, exc)
+
+            if len(rows) < batch_size:
+                break
+
+        # 분포 리포트 — 오르테가군 요청(종별 분포 + 미분류 수)
+        from app.models.reference_semantic_candidate import ReferenceSemanticCandidate
+
+        all_rows = (await db.execute(
+            select(ReferenceSemanticCandidate.relation_kind)
+        )).scalars().all()
+        kind_dist = Counter(k if k is not None else "(미분류)" for k in all_rows)
+
+    return {
+        "stories_scanned": stories_scanned,
+        "stories_with_content": stories_with_content,
+        "candidates_inserted": candidates_inserted,
+        "errors": errors,
+        "total_candidate_rows": sum(kind_dist.values()),
+        "kind_distribution": dict(kind_dist),
+    }
+
+
+async def main() -> int:
+    if not os.environ.get("DATABASE_URL"):
+        print("DATABASE_URL 미설정", file=sys.stderr)
+        return 2
+
+    parser = argparse.ArgumentParser(description="reference_semantic_candidates 배치 백필 (idempotent)")
+    parser.add_argument("--batch-size", type=int, default=200, help="배치당 story 수 (기본 200)")
+    parser.add_argument("--dry-run", action="store_true", help="쓰기 없이 대상 건수만 센다")
+    args = parser.parse_args()
+
+    result = await _run(batch_size=args.batch_size, dry_run=args.dry_run)
+
+    print(
+        f"backfill done: stories_scanned={result['stories_scanned']} "
+        f"stories_with_content={result['stories_with_content']} "
+        f"candidates_inserted={result['candidates_inserted']} "
+        f"errors={len(result['errors'])}"
+    )
+    print(f"total_candidate_rows(now)={result['total_candidate_rows']}")
+    print(f"kind_distribution={result['kind_distribution']}")
+    if result["errors"]:
+        for sid, err in result["errors"][:20]:
+            print(f"  ERROR story={sid}: {err}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    raise SystemExit(asyncio.run(main()))

--- a/backend/tests/test_2328_reference_semantic_candidates_realdb.py
+++ b/backend/tests/test_2328_reference_semantic_candidates_realdb.py
@@ -366,3 +366,186 @@ async def test_declare_only_changes_status_declared_by_declared_at():
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+# story #2223(2026-07-30, 오르테가군 판정) — relation_kind 지정은 declare와 «다른 질문»이라
+# 별도 엔드포인트로 분리됐다. 아래 넷이 그 계약을 실PG로 고정한다.
+
+
+async def test_set_relation_kind_updates_kind_only():
+    """새 엔드포인트가 relation_kind만 바꾸고 status/declared_by/declared_at은 안 건드린다
+    (declare 쪽 AC4와 대칭 계약)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 5006
+            await s.commit()
+            story = await _make_story(s, org.id, project.id, title="Source")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": "아무 표면단서 없이 그냥 #5006 라고만 적은 문장"},
+            )
+            assert resp.status_code == 200, resp.text
+            candidate_id = (
+                await client.get(f"/api/v2/stories/{story.id}/reference-candidates")
+            ).json()[0]["id"]
+
+            kind_resp = await client.post(
+                f"/api/v2/stories/{story.id}/reference-candidates/{candidate_id}/relation-kind",
+                json={"relation_kind": "superseded"},
+            )
+            assert kind_resp.status_code == 200, kind_resp.text
+            assert kind_resp.json()["relation_kind"] == "superseded"
+
+            async with Session() as s:
+                cands = await _candidates(s, org.id, story.id, source_field="description")
+                assert len(cands) == 1
+                assert cands[0].relation_kind == "superseded"
+                assert cands[0].status == "estimated"  # declare 안 거쳤으니 그대로
+                assert cands[0].declared_by is None
+                assert cands[0].declared_at is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_set_relation_kind_rejects_invalid_value():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 5007
+            await s.commit()
+            story = await _make_story(s, org.id, project.id, title="Source")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": "#5007 아무 단서 없음"},
+            )
+            assert resp.status_code == 200, resp.text
+            candidate_id = (
+                await client.get(f"/api/v2/stories/{story.id}/reference-candidates")
+            ).json()[0]["id"]
+
+            kind_resp = await client.post(
+                f"/api/v2/stories/{story.id}/reference-candidates/{candidate_id}/relation-kind",
+                json={"relation_kind": "not_a_real_kind"},
+            )
+            assert kind_resp.status_code == 400, kind_resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_set_relation_kind_to_none_clears_it():
+    """AC10 정신 — 잘못 지정한 종을 다시 미분류(NULL)로 되돌릴 수 있다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 5008
+            await s.commit()
+            story = await _make_story(s, org.id, project.id, title="Source")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": "#5008 아무 단서 없음"},
+            )
+            assert resp.status_code == 200, resp.text
+            candidate_id = (
+                await client.get(f"/api/v2/stories/{story.id}/reference-candidates")
+            ).json()[0]["id"]
+
+            await client.post(
+                f"/api/v2/stories/{story.id}/reference-candidates/{candidate_id}/relation-kind",
+                json={"relation_kind": "spawned"},
+            )
+            clear_resp = await client.post(
+                f"/api/v2/stories/{story.id}/reference-candidates/{candidate_id}/relation-kind",
+                json={"relation_kind": None},
+            )
+            assert clear_resp.status_code == 200, clear_resp.text
+            assert clear_resp.json()["relation_kind"] is None
+
+            async with Session() as s:
+                cands = await _candidates(s, org.id, story.id, source_field="description")
+                assert cands[0].relation_kind is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_set_relation_kind_does_not_require_declare_first():
+    """순서 강제 없음 — declare 전에도 종을 지정할 수 있다(오르테가군 판정 그대로)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 5009
+            await s.commit()
+            story = await _make_story(s, org.id, project.id, title="Source")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": "#5009 아무 단서 없음"},
+            )
+            assert resp.status_code == 200, resp.text
+            candidate_id = (
+                await client.get(f"/api/v2/stories/{story.id}/reference-candidates")
+            ).json()[0]["id"]
+
+            kind_resp = await client.post(
+                f"/api/v2/stories/{story.id}/reference-candidates/{candidate_id}/relation-kind",
+                json={"relation_kind": "followed"},
+            )
+            assert kind_resp.status_code == 200, kind_resp.text
+
+            async with Session() as s:
+                cands = await _candidates(s, org.id, story.id, source_field="description")
+                assert cands[0].relation_kind == "followed"
+                assert cands[0].status == "estimated"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- story #2223 판정(오르테가군, 2026-07-30) 반영 — 3종(낳음/잇따름/대체) 설계는 07-23 것으로 낡았고, 어제(07-29) #2328이 이미 5종+미분류로 라이브 구현했다는 것을 코드 실측으로 확인. 그 위에 6번째 값 `superseded`(대체)만 추가.
- `declare`(연결 실재 확인)와 relation_kind 지정(무슨 종류인가)은 서로 다른 질문이라 한 클릭에 안 묶는다(오르테가군 판정) — 새 엔드포인트 `POST /{id}/reference-candidates/{candidate_id}/relation-kind`로 분리. 기존 declare의 AC4 계약("status/declared_by/declared_at 셋만 바꿈")은 그대로 보존.
- 배치 백필 스크립트 추가 — #2328은 "새 참조만"(소급 안 함)으로 설계했으나 `create_story`가 write-path(`_reconcile_story_references_and_candidates`)를 한 번도 호출하지 않았던 버그(오늘 아침 별도 수정)로 실측상 사실상 첫 채우기였음을 확인(104/1349 ≈ 7.7%만 존재). 기존 함수(`generate_and_store_candidates`)를 재사용해 story 전량에 재실행 — 새 로직 없음, 멱등.

## Test plan
- [x] 로컬 실PG(pgvector/pg15 docker, 0219까지 alembic upgrade head)로 `test_2328_reference_semantic_candidates_realdb.py` 12개 전부 GREEN(기존 8 + 신규 4)
- [x] 신규 endpoint 관련 파일 ruff clean
- [x] `test_stories.py`/`test_2301_story_body_mentions_realdb.py`/`test_2328_candidate_hook_on_create_realdb.py`/`test_2328_dependency_picker_candidate_boost_realdb.py` 전부 회귀 없음(44 passed)
- [x] 백필 스크립트: write-path를 우회해 직접 ORM으로 심은 story로 실측 — 1회차 candidates_inserted=1(정확히 그 신규 후보), 2회차 재실행 candidates_inserted=0(멱등 확인)
- [x] 뮤테이션 자가검증: `InvalidRelationKindError` 가드를 임시 무력화 → `test_set_relation_kind_rejects_invalid_value` RED 확인 → 복원 → 전체 GREEN 재확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)