### PR TITLE
feat(#2223): 에픽 단위 참조 후보 벌크 조회 + relation_kind CHECK 실증

### DIFF
--- a/backend/app/routers/goals.py
+++ b/backend/app/routers/goals.py
@@ -425,6 +425,46 @@ async def get_goal_progress(
     return await repo.get_progress(id)
 
 
+@router.get("/{id}/reference-candidates")
+async def get_goal_reference_candidates(
+    id: uuid.UUID,
+    repo: GoalRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+) -> list[dict]:
+    """GET .../goals/{id}/reference-candidates — story #2223 후속(오르테가군 판정,
+    2026-07-30): 캔버스가 에픽 하나치 「의미 후보」(간선 재료)를 한 번에 받는 자리.
+    story별 개별 조회(`/stories/{id}/reference-candidates`)는 N+1이라 캔버스엔 못 쓴다 —
+    이 엔드포인트는 그 에픽 소속 story 전체의 candidate를 한 번에 반환한다. 응답에
+    `source_id`를 명시로 싣는다(단건 story 엔드포인트는 URL이 이미 source를 담아 생략했지만,
+    여러 story가 섞이는 이 응답에선 각 행이 어느 story에서 왔는지를 알아야 간선을 그린다)."""
+    goal = await repo.get(id)
+    if goal is None:
+        raise HTTPException(status_code=404, detail="Goal not found")
+    if not await has_project_access(repo.session, uuid.UUID(auth.user_id), goal.project_id, repo.org_id):
+        raise HTTPException(status_code=404, detail="Goal not found")
+
+    from app.services.reference_semantic_candidates import list_candidates_for_epic_stories
+
+    candidates = await list_candidates_for_epic_stories(repo.session, org_id=repo.org_id, epic_id=id)
+    return [
+        {
+            "id": str(c.id),
+            "source_id": str(c.source_id),
+            "source_field": c.source_field,
+            "target_type": c.target_type,
+            "target_id": str(c.target_id),
+            "relation_kind": c.relation_kind,
+            "matched_keyword": c.matched_keyword,
+            "snippet": c.snippet,
+            "status": c.status,
+            "declared_by": str(c.declared_by) if c.declared_by else None,
+            "declared_at": c.declared_at.isoformat() if c.declared_at else None,
+            "created_at": c.created_at.isoformat(),
+        }
+        for c in candidates
+    ]
+
+
 class GoalTransitionRequest(BaseModel):
     status: str
 

--- a/backend/app/services/reference_semantic_candidates.py
+++ b/backend/app/services/reference_semantic_candidates.py
@@ -209,6 +209,28 @@ async def generate_and_store_candidates(
     )
 
 
+async def list_candidates_for_epic_stories(
+    db: AsyncSession, *, org_id: uuid.UUID, epic_id: uuid.UUID,
+) -> list[ReferenceSemanticCandidate]:
+    """story #2223 후속(오르테가군 판정, 2026-07-30) — 캔버스는 에픽 하나치 후보를 «한 번에»
+    받아야 한다. story별 왕복(`/stories/{id}/reference-candidates`, N+1)으로는 못 쓴다 —
+    stories JOIN으로 그 에픽 소속 story 전체의 candidate를 한 쿼리로 반환한다. 새 재료를
+    만들지 않는다(같은 `reference_semantic_candidates` 표, 조회 축만 다르다)."""
+    from app.models.pm import Story
+
+    result = await db.execute(
+        select(ReferenceSemanticCandidate)
+        .join(Story, ReferenceSemanticCandidate.source_id == Story.id)
+        .where(
+            ReferenceSemanticCandidate.org_id == org_id,
+            ReferenceSemanticCandidate.source_type == "story",
+            Story.epic_id == epic_id,
+        )
+        .order_by(ReferenceSemanticCandidate.created_at.asc())
+    )
+    return list(result.scalars().all())
+
+
 async def list_candidates_for_source(
     db: AsyncSession, *, org_id: uuid.UUID, source_type: str, source_id: uuid.UUID,
 ) -> list[ReferenceSemanticCandidate]:

--- a/backend/tests/test_2328_reference_semantic_candidates_realdb.py
+++ b/backend/tests/test_2328_reference_semantic_candidates_realdb.py
@@ -19,6 +19,7 @@ import uuid
 import pytest
 from sqlalchemy import select
 
+from tests.test_2298_goals_glance_include_realdb import _make_goal
 from tests.test_2301_story_body_mentions_realdb import (
     _REAL_DB_URL,
     _client_for,
@@ -548,4 +549,159 @@ async def test_set_relation_kind_does_not_require_declare_first():
             await client.aclose()
     finally:
         app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# story #2223 후속(2026-07-30, 오르테가군 판정) — 캔버스는 에픽 하나치를 한 번에 받아야
+# 한다(story별 N+1로는 못 쓴다). 아래 셋이 그 신설 엔드포인트를 실PG로 고정한다.
+
+
+async def test_epic_reference_candidates_returns_candidates_across_stories():
+    """같은 에픽 소속 story 둘이 각각 만든 candidate가 «한 번의» 에픽 조회로 다 나온다 —
+    각 행에 source_id가 명시로 실려(어느 story에서 왔는지 캔버스가 알아야 간선을 그린다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id, title="Epic")
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 5010
+            await s.commit()
+            story_a = await _make_story(s, org.id, project.id, title="Source A")
+            story_a.epic_id = goal.id
+            story_b = await _make_story(s, org.id, project.id, title="Source B")
+            story_b.epic_id = goal.id
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            for story, keyword in ((story_a, "#5010 신규 스토리 등재 - 발견분"), (story_b, "#5010 아무 단서 없음")):
+                resp = await client.patch(
+                    f"/api/v2/stories/{story.id}", json={"description": keyword},
+                )
+                assert resp.status_code == 200, resp.text
+
+            resp = await client.get(f"/api/v2/goals/{goal.id}/reference-candidates")
+            assert resp.status_code == 200, resp.text
+            candidates = resp.json()
+            assert len(candidates) == 2
+            source_ids = {c["source_id"] for c in candidates}
+            assert source_ids == {str(story_a.id), str(story_b.id)}
+            for c in candidates:
+                assert c["target_id"] == str(target.id)
+                assert "relation_kind" in c and "status" in c
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_epic_reference_candidates_excludes_other_epics():
+    """다른 에픽 소속 story의 candidate는 안 새어 나온다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            goal_a = await _make_goal(s, org.id, project.id, title="Epic A")
+            goal_b = await _make_goal(s, org.id, project.id, title="Epic B")
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 5011
+            await s.commit()
+            story_in_b = await _make_story(s, org.id, project.id, title="Source in B")
+            story_in_b.epic_id = goal_b.id
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story_in_b.id}",
+                json={"description": "#5011 신규 스토리 등재 - 발견분"},
+            )
+            assert resp.status_code == 200, resp.text
+
+            resp = await client.get(f"/api/v2/goals/{goal_a.id}/reference-candidates")
+            assert resp.status_code == 200, resp.text
+            assert resp.json() == []
+
+            resp = await client.get(f"/api/v2/goals/{goal_b.id}/reference-candidates")
+            assert resp.status_code == 200, resp.text
+            assert len(resp.json()) == 1
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_epic_reference_candidates_404_for_missing_goal():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/goals/{uuid.uuid4()}/reference-candidates")
+            assert resp.status_code == 404
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# 오르테가군 지적(2026-07-30, PR#2702 리뷰 후속) — 까심군이 중복 `PATCH relation_kind` 테스트를
+# 지우면서 「app 검증(RELATION_KINDS)을 우회한 값을 DB CHECK가 실제로 막는가」를 재던 시험이
+# 같이 사라졌다. 이 CHECK는 `reference_semantic_candidates`(이 테이블) 소유라 그쪽 PR엔 세울
+# 자리가 없다 — 여기가 그 갭을 되메우는 자리. raw SQL로 ORM(`set_candidate_relation_kind`의
+# `RELATION_KINDS` 검증)을 완전히 우회해 마이그레이션/수동 INSERT 경로에서도 CHECK 자체가
+# 정말 거는지를 직접 확인한다(app 단 검증만 믿으면 그 경로들에서 샌다).
+
+
+async def test_check_constraint_rejects_invalid_relation_kind_via_raw_sql():
+    from sqlalchemy import text
+    from sqlalchemy.exc import IntegrityError
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _caller_id, _caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 5012
+            await s.commit()
+            source = await _make_story(s, org.id, project.id, title="Source")
+
+            with pytest.raises(IntegrityError) as exc_info:
+                await s.execute(
+                    text(
+                        "INSERT INTO reference_semantic_candidates "
+                        "(id, org_id, source_type, source_field, source_id, target_type, "
+                        "target_id, form, relation_kind, snippet, status) "
+                        "VALUES (gen_random_uuid(), :org_id, 'story', 'description', :source_id, "
+                        "'story', :target_id, 'mention', 'not_a_real_kind', 'snippet', 'estimated')"
+                    ),
+                    {"org_id": org.id, "source_id": source.id, "target_id": target.id},
+                )
+                await s.commit()
+            assert "ck_reference_semantic_candidates_relation_kind" in str(exc_info.value)
+            await s.rollback()
+    finally:
         await engine.dispose()


### PR DESCRIPTION
## Summary
- `GET /api/v2/goals/{id}/reference-candidates`(`/api/v2/epics/{id}` 별칭 동일) 신설 — 캔버스가 에픽 하나치 「의미 후보」(간선 재료)를 한 번에 받는 자리. story별 개별 조회(`/stories/{id}/reference-candidates`)는 N+1이라 캔버스엔 못 쓴다는 오르테가군 판정 반영. 새 표 없이 기존 `reference_semantic_candidates`를 `story.epic_id`로 JOIN만 추가(`list_candidates_for_epic_stories`).
- 응답에 `source_id`를 명시(여러 story가 섞이는 응답이라 필수).
- BE 응답은 원시 어휘(6종 relation_kind) 그대로 유지 — 오르테가군 판정: FE(`derive-flow-map.ts`)의 4종(`spawn`/`then`/`supersede`/`null`) 번역·3종 필터링은 미르코군의 `parseReferenceCandidateEdges` 몫. 이유: ①화면 규격이 오늘만 세 번 바뀜(그때마다 BE 배포는 못 따라감) ②서버가 미리 필터링하면 cited_as_evidence/similar_case/explicitly_unrelated가 노드 상세 화면에서 아예 안 보이게 됨 ③source_id(데이터 축)와 fromNodeId(화면 축) 분리가 소유권을 명확히 함.
- PR#2702 리뷰 후속 — 까심군이 중복 테스트를 지우면서 함께 사라진 「app 검증을 우회해도 DB CHECK가 실제로 막는가」 실증을 raw SQL insert로 재수립(해당 CHECK가 이 표 소유라 이 PR 몫).

## Test plan
- [x] 로컬 실PG(pgvector/pg15 docker, 0219 head)로 `test_2328_reference_semantic_candidates_realdb.py` 16/16 GREEN(기존 12 + 신규 4: 에픽 벌크 3 + CHECK 실증 1)
- [x] 연관 회귀 8개 파일(goals×4 + stories×4) 70/70 GREEN
- [x] ruff clean(FastAPI `Depends()` 관례 경고만, 파일 전체 기존 패턴과 동일)
- [x] FE 코드(`derive-flow-map.ts`/`flow-epic-nodes.tsx`) 직접 확인 — 지금 이 엔드포인트를 부르는 자리가 없어 조용한 갭 아님, 오르테가군 판정으로 어댑터 위치 확定

🤖 Generated with [Claude Code](https://claude.com/claude-code)