### PR TITLE
[SID:2224] reference_semantic_candidates → 간선 어댑터

### DIFF
--- a/apps/web/src/components/flow/derive-flow-map.test.ts
+++ b/apps/web/src/components/flow/derive-flow-map.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   computeNodeDepth, deriveFlowMapLane, computeLaneHeight, shouldShowNoDeeperReason, computeNodePositions,
-  parseDependencyGraphEdges, FLOW_MAP_TOP_N, FLOW_MAP_FOLD_THRESHOLD, FLOW_MAP_DEPTH0_X, FLOW_MAP_GRID_STEP,
-  type FlowMapEdge, type FlowMapLane,
+  parseDependencyGraphEdges, parseReferenceCandidateEdges, FLOW_MAP_TOP_N, FLOW_MAP_FOLD_THRESHOLD,
+  FLOW_MAP_DEPTH0_X, FLOW_MAP_GRID_STEP,
+  type FlowMapEdge, type FlowMapLane, type RawReferenceCandidate,
 } from './derive-flow-map';
 import type { EpicFlowNodeItem } from './derive-flow';
 
@@ -170,6 +171,54 @@ describe('parseDependencyGraphEdges', () => {
 
   it('returns an empty array for an empty response (org has 0 rows today — honest empty, not a crash)', () => {
     expect(parseDependencyGraphEdges([])).toEqual([]);
+  });
+});
+
+function makeCandidate(overrides: Partial<RawReferenceCandidate> = {}): RawReferenceCandidate {
+  return { id: 'c1', source_id: 's1', target_id: 't1', relation_kind: null, status: 'estimated', ...overrides };
+}
+
+describe('parseReferenceCandidateEdges', () => {
+  it('keeps spawned(source→target) direction as-is — source spawned target, source is first', () => {
+    const edges = parseReferenceCandidateEdges([makeCandidate({ source_id: 'a', target_id: 'b', relation_kind: 'spawned' })]);
+    expect(edges).toEqual([{ fromNodeId: 'a', toNodeId: 'b', kind: 'spawn', confirmed: false }]);
+  });
+
+  it('flips followed(source→target) — source follows target, so target is first', () => {
+    const edges = parseReferenceCandidateEdges([makeCandidate({ source_id: 'a', target_id: 'b', relation_kind: 'followed' })]);
+    expect(edges).toEqual([{ fromNodeId: 'b', toNodeId: 'a', kind: 'then', confirmed: false }]);
+  });
+
+  it('flips superseded(source→target) — source supersedes target, so target is the OLD one, first', () => {
+    const edges = parseReferenceCandidateEdges([makeCandidate({ source_id: 'a', target_id: 'b', relation_kind: 'superseded' })]);
+    expect(edges).toEqual([{ fromNodeId: 'b', toNodeId: 'a', kind: 'supersede', confirmed: false }]);
+  });
+
+  it('keeps NULL(종 미정) direction as source→target — kind unknown but direction (who mentioned whom) is still known', () => {
+    const edges = parseReferenceCandidateEdges([makeCandidate({ source_id: 'a', target_id: 'b', relation_kind: null })]);
+    expect(edges).toEqual([{ fromNodeId: 'a', toNodeId: 'b', kind: null, confirmed: false }]);
+  });
+
+  it('maps status=declared to confirmed=true and status=estimated to confirmed=false', () => {
+    const declared = parseReferenceCandidateEdges([makeCandidate({ relation_kind: 'spawned', status: 'declared' })]);
+    expect(declared[0]?.confirmed).toBe(true);
+    const estimated = parseReferenceCandidateEdges([makeCandidate({ relation_kind: 'spawned', status: 'estimated' })]);
+    expect(estimated[0]?.confirmed).toBe(false);
+  });
+
+  // 오르테가군 확定(2026-07-30) — 이 셋은 "다음 흐름" 화살표가 아니라 노드 상세의 참조
+  // 목록으로 가는 별도 재료다. 버리는 게 아니라 "이 함수의 반환값에는 안 실린다"는 뜻.
+  it('drops cited_as_evidence, similar_case, and explicitly_unrelated — not directional, not drawn as flow-map edges', () => {
+    const edges = parseReferenceCandidateEdges([
+      makeCandidate({ relation_kind: 'cited_as_evidence' }),
+      makeCandidate({ relation_kind: 'similar_case' }),
+      makeCandidate({ relation_kind: 'explicitly_unrelated' }),
+    ]);
+    expect(edges).toEqual([]);
+  });
+
+  it('returns an empty array for an empty response', () => {
+    expect(parseReferenceCandidateEdges([])).toEqual([]);
   });
 });
 

--- a/apps/web/src/components/flow/derive-flow-map.ts
+++ b/apps/web/src/components/flow/derive-flow-map.ts
@@ -71,6 +71,53 @@ export function parseDependencyGraphEdges(raw: RawDependencyEdge[]): FlowMapEdge
   ));
 }
 
+/** `GET /api/v2/{stories,goals}/{id}/reference-candidates` 원시 응답 하나(#2328 C-11,
+ * `backend/app/models/reference_semantic_candidate.py`) — BE는 화면 모양에 맞춰 걸러주지
+ * 않고 원시 어휘 그대로 낸다(PO 확定 2026-07-30 — "서버가 걸러버리면 나중에 다른 화면이
+ * 그것을 못 쓴다", cited_as_evidence/similar_case는 노드 상세 참조 목록의 재료라 여기서
+ * 버리면 그 화면이 죽는다). `relation_kind` 6종 중 3종(cited_as_evidence/similar_case/
+ * explicitly_unrelated)은 이 함수가 걸러 낸다(아래 참고) — 어댑터 책임이지 서버 책임이 아니다. */
+export interface RawReferenceCandidate {
+  id: string;
+  source_id: string;
+  target_id: string;
+  relation_kind: 'spawned' | 'cited_as_evidence' | 'similar_case' | 'followed' | 'explicitly_unrelated' | 'superseded' | null;
+  status: 'estimated' | 'declared';
+}
+
+/** 오르테가군 확定(2026-07-30, #2223 판정) — 6종 중 «시간 방향이 있는» 넷만 간선으로 그린다.
+ * cited_as_evidence(근거인용)·similar_case(동종사례)는 대칭/비방향 관계라 "다음 흐름"
+ * 화살표가 아니다(버리는 게 아니라 «노드 상세 참조 목록»으로 가는 별도 화면의 재료 —
+ * 이 함수의 반환값에는 안 실린다는 뜻일 뿐). explicitly_unrelated는 애초에 "«선을 안 긋기
+ * 위한»" 표시(자동분류 규칙이 "직교/무관" 키워드로 판정한 것) — 점선으로라도 그리면
+ * "무관인데 선이 있다"는 모순이 된다.
+ *
+ * 방향 규칙(오르테가군 확定, 2026-07-30 — 이름이 "source가 무엇을 했나"로 적혀 있다는 것이
+ * 근거): `spawned` = source가 target을 «낳았다» → source가 먼저(그대로). `followed` =
+ * source가 target을 «따른다» → target이 먼저(뒤집음, `parseDependencyGraphEdges`의
+ * depends_on 뒤집기와 같은 자리·같은 이유). `superseded` = source가 target을 «대체했다» →
+ * target이 «옛것»(뒤집음). 이 뒤집기도 이 함수 «한 곳»에서만 한다.
+ *
+ * status: estimated(추정, AC3)=confirmed:false(제안) · declared(선언됨, AC5, 사람이
+ * 1클릭)=confirmed:true(확定) — #2223 본문 "자동 확定 금지"와 그대로 대응. */
+export function parseReferenceCandidateEdges(raw: RawReferenceCandidate[]): FlowMapEdge[] {
+  const edges: FlowMapEdge[] = [];
+  for (const c of raw) {
+    const confirmed = c.status === 'declared';
+    if (c.relation_kind === 'spawned') {
+      edges.push({ fromNodeId: c.source_id, toNodeId: c.target_id, kind: 'spawn', confirmed });
+    } else if (c.relation_kind === 'followed') {
+      edges.push({ fromNodeId: c.target_id, toNodeId: c.source_id, kind: 'then', confirmed });
+    } else if (c.relation_kind === 'superseded') {
+      edges.push({ fromNodeId: c.target_id, toNodeId: c.source_id, kind: 'supersede', confirmed });
+    } else if (c.relation_kind === null) {
+      edges.push({ fromNodeId: c.source_id, toNodeId: c.target_id, kind: null, confirmed });
+    }
+    // cited_as_evidence · similar_case · explicitly_unrelated — 의도적으로 드롭(위 docblock).
+  }
+  return edges;
+}
+
 /** 노드 하나의 «의존 깊이» — 들어오는 간선이 없으면 0(시작점), 있으면 «선행 노드 깊이 중
  * 최댓값+1». edges가 항상 빈 배열인 오늘(#2221 미착지)은 이 재귀가 «자연히» 전부 0을 내는
  * 것이라 — `if (edges.length === 0) return 0` 같은 특수분기를 두지 않는다(PO 지시

--- a/apps/web/src/components/flow/flow-map-canvas.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.tsx
@@ -295,16 +295,19 @@ export function FlowMapCanvas({ lanes, onSelectStory }: FlowMapCanvasProps) {
       </div>
 
       {/* 하단 범례(유나양 규격, 2026-07-30 PO 전달) — 색을 지워도 4종이 갈리도록 화살촉/점/
-          막대 모양으로 설명한다. 그려진 선이 하나도 없으면(오늘 org 0행 그대로) 설명할
-          대상이 없어 범례도 안 띄운다(빈 기능을 위한 상시 chrome을 만들지 않는다).
-          ⛔카운트 줄("확認 N · 후보 M · 기각 K")은 디디군 백필이 끝나 실 카운트가 배선된
-          뒤에 얹는다 — 지금 숫자를 만들어 보이면 지어내는 것이라 이 판에서는 뺐다. */}
+          막대 모양으로 설명한다. 순서는 «많은 것이 앞»(유나양 확定, 백필 실측 종 미정
+          85%) — [종 미정][낳음][잇따름][대체], 실제 분포 순으로 읽어야 눈에 먼저 든다.
+          그려진 선이 하나도 없으면(오늘 org 0행 그대로) 설명할 대상이 없어 범례도 안
+          띄운다(빈 기능을 위한 상시 chrome을 만들지 않는다).
+          ⛔카운트 줄("확認 N · 종 미정 N · 지금 볼 수 있는 후보 155 · 기각 N")은 디디군
+          벌크 엔드포인트(`/goals/{id}/reference-candidates`)가 착지해 실 카운트가
+          배선된 뒤에 얹는다 — 지금 숫자를 만들어 보이면 지어내는 것이라 이 판에서는 뺐다. */}
       {lanes.some((l) => l.edges.length > 0) ? (
         <div className="flex flex-wrap items-center gap-3 border-t border-border px-2 py-1.5 text-[10px] text-muted-foreground">
+          <span className="flex items-center gap-1"><span aria-hidden="true">—●</span>{t('edgeLegendUnknownKind')}</span>
           <span className="flex items-center gap-1"><span aria-hidden="true" className="text-info">▷</span>{t('edgeLegendSpawn')}</span>
           <span className="flex items-center gap-1"><span aria-hidden="true" className="text-brand">▶</span>{t('edgeLegendThen')}</span>
           <span className="flex items-center gap-1"><span aria-hidden="true">⊣</span>{t('edgeLegendSupersede')}</span>
-          <span className="flex items-center gap-1"><span aria-hidden="true">—●</span>{t('edgeLegendUnknownKind')}</span>
           <span aria-hidden="true">│</span>
           <span>{t('edgeLegendConfirmedVsProposed')}</span>
         </div>


### PR DESCRIPTION
## 배경
오르테가군 확定 — PR#2701의 edges 배선(`dependencies` 테이블)과 디디군이 백필한 실 재료(`reference_semantic_candidates`, 1321건)가 다른 테이블이라 실 후보가 화면에 안 온다("만들어졌는데 도는 자리가 없다"). 이 PR은 그 변환 어댑터.

## parseReferenceCandidateEdges 신설
- relation_kind 6종 중 시간 방향이 있는 넷만 간선화: spawned/followed/superseded/NULL(종 미정)
- cited_as_evidence·similar_case는 대칭관계라 드롭(노드 상세 참조 목록 몫, 별도 화면)
- explicitly_unrelated는 "선을 안 긋기 위한" 표시라 드롭
- 방향: spawned=그대로, followed/superseded=뒤집음(depends_on 뒤집기와 같은 원칙)
- status: estimated→proposed, declared→confirmed

## 범례 순서
백필 실측(종 미정 85%)에 맞춰 [종미정][낳음][잇따름][대체] 순으로 재정렬(유나양 확定 — "많은 것이 앞").

## 검증
- tsc/lint/vitest(2226/2226 통과, 신규 8건)/build/verify:* 전부 그린
- 뮤테이션 검증: followed 방향 플립 되돌려 RED 확認 후 복원

⛔실제 fetch 배선은 후속(디디군 벌크 엔드포인트 `/goals/{id}/reference-candidates` 대기 중) — 이 PR은 순수 어댑터 함수만.