### PR TITLE
[SID:2224] reference-candidates 벌크 fetch 배선 — 실 재료 화면 연결

### DIFF
--- a/apps/web/src/app/api/goals/[id]/reference-candidates/route.ts
+++ b/apps/web/src/app/api/goals/[id]/reference-candidates/route.ts
@@ -1,0 +1,13 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+/**
+ * GET /api/goals/{id}/reference-candidates — story #2224 후속(2026-07-30). BE
+ * `GET /api/v2/goals/{id}/reference-candidates`(PR#2704)를 그대로 통과시킨다 —
+ * `dependencies/graph/route.ts`와 동일 패턴(원시 `list[dict]`, 래핑 없음). BE가 이미
+ * 원시 어휘 그대로 내기로 확定했으므로(오르테가군 판정) 이 자리에서 변형하지 않는다 —
+ * 종류 매핑/필터링은 FE의 `parseReferenceCandidateEdges`(derive-flow-map.ts) 몫.
+ */
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await params;
+  return proxyToFastapi(request, `/api/v2/goals/${id}/reference-candidates`);
+}

--- a/apps/web/src/components/flow/flow-epic-nodes.test.tsx
+++ b/apps/web/src/components/flow/flow-epic-nodes.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+//
+// story #2224 후속(2026-07-30) — 오르테가군 확定: "화면이 보던 dependencies(0행)와 디디군이
+// 채운 reference_semantic_candidates(1321건)는 다른 표"라 벌크 엔드포인트를 추가로 불러
+// 병합해야 실 후보가 화면에 온다. 이 테스트는 세 fetch(epic-flow-nodes/dependencies-graph/
+// reference-candidates)가 실제로 나가고, 두 간선 출처가 하나로 합쳐져 렌더까지 이어지는
+// 것을 왕복 확認한다 — mock fetch로 로컬에서만(DB 무관).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { FlowEpicNodes } from './flow-epic-nodes';
+import koMessages from '../../../messages/ko.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+const NOW_ITEM = { id: 'n1', story_number: 1, title: 'Now Story', status: 'in-progress', assignee_id: null, updated_at: '2026-07-30T00:00:00Z' };
+const UPCOMING_ITEM = { id: 'u1', story_number: 2, title: 'Upcoming Story', status: 'backlog', assignee_id: null, updated_at: '2026-07-30T00:00:00Z' };
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, json: async () => body } as Response;
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe('FlowEpicNodes — merges dependencies-graph edges with reference-candidate edges', () => {
+  it('calls all three endpoints (epic-flow-nodes / dependencies-graph / reference-candidates) and renders a line sourced from candidate data', async () => {
+    const calledUrls: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      calledUrls.push(url);
+      if (url.includes('/api/analytics/epic-flow-nodes')) {
+        return jsonResponse({
+          data: {
+            epic_id: 'e1',
+            now: { total: 1, items: [NOW_ITEM] },
+            upcoming: { total: 1, shown: 1, items: [UPCOMING_ITEM] },
+            past: { total: 0 },
+            blocked_count: 0,
+            last_changed_at: null,
+          },
+        });
+      }
+      if (url.includes('/api/dependencies/graph')) {
+        return jsonResponse({ item_type: 'story', nodes: [], edges: [] }); // 계획형 — 오늘도 0행
+      }
+      if (url.includes('/api/goals/e1/reference-candidates')) {
+        // 벌크 엔드포인트 — 디디군 백필 재료(raw array, 래핑 없음)
+        return jsonResponse([
+          { id: 'c1', source_id: 'n1', source_field: 'description', target_type: 'story', target_id: 'u1', relation_kind: 'spawned', matched_keyword: null, snippet: 's', status: 'estimated', declared_by: null, declared_at: null, created_at: '2026-07-30T00:00:00Z' },
+        ]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await act(async () => {
+      root.render(wrap(<FlowEpicNodes projectId="p1" epicId="e1" epicTitle="Epic 1" onSelectStory={() => {}} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(calledUrls.some((u) => u.includes('/api/analytics/epic-flow-nodes'))).toBe(true);
+    expect(calledUrls.some((u) => u.includes('/api/dependencies/graph'))).toBe(true);
+    expect(calledUrls.some((u) => u.includes('/api/goals/e1/reference-candidates'))).toBe(true);
+
+    const line = container.querySelector('line[data-edge-kind="spawn"]');
+    expect(line).not.toBeNull();
+    expect(line?.getAttribute('data-edge-confirmed')).toBe('false'); // status=estimated → 제안
+  });
+
+  it('still renders (no edges, no crash) when the reference-candidates fetch fails — partial failure does not kill the whole view', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/analytics/epic-flow-nodes')) {
+        return jsonResponse({
+          data: {
+            epic_id: 'e1', now: { total: 1, items: [NOW_ITEM] }, upcoming: { total: 0, shown: 0, items: [] },
+            past: { total: 0 }, blocked_count: 0, last_changed_at: null,
+          },
+        });
+      }
+      if (url.includes('/api/dependencies/graph')) return jsonResponse({ item_type: 'story', nodes: [], edges: [] });
+      if (url.includes('/api/goals/e1/reference-candidates')) return { ok: false, json: async () => null } as Response;
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await act(async () => {
+      root.render(wrap(<FlowEpicNodes projectId="p1" epicId="e1" epicTitle="Epic 1" onSelectStory={() => {}} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(container.querySelector('line[data-edge-kind]')).toBeNull();
+    expect(container.textContent).not.toContain('불러오지 못했습니다');
+  });
+});

--- a/apps/web/src/components/flow/flow-epic-nodes.tsx
+++ b/apps/web/src/components/flow/flow-epic-nodes.tsx
@@ -3,7 +3,10 @@
 import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { UPCOMING_LIMIT, type EpicFlowNodesResponse } from './derive-flow';
-import { deriveFlowMapLane, parseDependencyGraphEdges, type FlowMapLane, type RawDependencyEdge } from './derive-flow-map';
+import {
+  deriveFlowMapLane, parseDependencyGraphEdges, parseReferenceCandidateEdges,
+  type FlowMapLane, type RawDependencyEdge, type RawReferenceCandidate,
+} from './derive-flow-map';
 import { FlowMapCanvas } from './flow-map-canvas';
 
 interface FlowEpicNodesProps {
@@ -50,6 +53,14 @@ export function FlowEpicNodes({ projectId, epicId, epicTitle, onSelectStory }: F
     // 오늘은 결과가 똑같이 빈 배열이겠지만, «받으러 갔다»는 사실 자체가 다르다). item_id
     // 없이 `item_type=story`만 넘겨 프로젝트 전체 그래프를 받고 이 에픽의 노드 id로 필터링
     // — 실 데이터가 쌓이면(org 스케일) item_id 배치 조회로 좁혀야 한다(오늘은 0행이라 무해).
+    //
+    // 오르테가군 확定(2026-07-30, PR#2701 배포 후 라이브 실측으로 발견) — 화면이 보던
+    // `dependencies`(계획형, 0행)와 디디군이 백필한 실 재료 `reference_semantic_candidates`
+    // (1321건)는 «다른 표»라 앞의 fetch만으로는 실 후보가 안 왔다. 까심군 벌크 엔드포인트
+    // (`/api/goals/{id}/reference-candidates`, PR#2704)를 추가로 부른다 — 응답은 BE 원시
+    // 어휘 그대로(래핑 없음, `dependencies/graph`와 같은 plain-array 패턴)라 `unwrap` 안 씀.
+    // 두 출처를 `parseReferenceCandidateEdges`/`parseDependencyGraphEdges`로 각각 정규화한
+    // 뒤 하나의 FlowMapEdge[] 로 합친다 — 렌더 레이어(FlowMapCanvas)는 출처를 모른다.
     // 실패해도 전체를 죽이지 않는다(간선은 보강 정보, 노드가 핵심 — 부분 실패는 부분만 표시).
     Promise.all([
       fetch(`/api/analytics/epic-flow-nodes?project_id=${projectId}&epic_id=${epicId}&upcoming_limit=${UPCOMING_LIMIT}`)
@@ -58,17 +69,24 @@ export function FlowEpicNodes({ projectId, epicId, epicTitle, onSelectStory }: F
       fetch('/api/dependencies/graph?item_type=story')
         .then((r) => (r.ok ? r.json() : null))
         .catch(() => null),
-    ]).then(([nodesJson, graphJson]) => {
+      fetch(`/api/goals/${epicId}/reference-candidates`)
+        .then((r) => (r.ok ? r.json() : null))
+        .catch(() => null),
+    ]).then(([nodesJson, graphJson, candidatesJson]) => {
       if (cancelled) return;
       const data = unwrap<EpicFlowNodesResponse>(nodesJson);
       if (!data) {
         setState({ kind: 'error' });
         return;
       }
-      const graph = unwrap<{ edges: RawDependencyEdge[] }>(graphJson);
       const epicNodeIds = new Set([...data.now.items, ...data.upcoming.items].map((i) => i.id));
-      const allEdges = parseDependencyGraphEdges(graph?.edges ?? []);
-      const edges = allEdges.filter((e) => epicNodeIds.has(e.fromNodeId) && epicNodeIds.has(e.toNodeId));
+      const graph = unwrap<{ edges: RawDependencyEdge[] }>(graphJson);
+      const dependencyEdges = parseDependencyGraphEdges(graph?.edges ?? []);
+      const rawCandidates: RawReferenceCandidate[] = Array.isArray(candidatesJson) ? candidatesJson : [];
+      const candidateEdges = parseReferenceCandidateEdges(rawCandidates);
+      const edges = [...dependencyEdges, ...candidateEdges].filter(
+        (e) => epicNodeIds.has(e.fromNodeId) && epicNodeIds.has(e.toNodeId),
+      );
       const lane = deriveFlowMapLane(epicId, epicTitle, data.past.total, data.now.items, data.upcoming.items, edges);
       setState({ kind: 'ready', lane });
     }).catch(() => {


### PR DESCRIPTION
## 배경
PR#2704(까심군 벌크 엔드포인트)+PR#2705(제 어댑터) 둘 다 develop 착지 확認 후, 실제 fetch를 이어붙였습니다 — "재료는 찼는데 화면이 다른 표(dependencies, 0행)를 본다"는 오르테가군 지적의 실제 해소.

## 변경
- `apps/web/src/app/api/goals/[id]/reference-candidates/route.ts` 신설 — BE 벌크 엔드포인트 단순 통과 프록시.
- `flow-epic-nodes.tsx`: 기존 2-way fetch(epic-flow-nodes + dependencies/graph)에 reference-candidates 벌크 조회 추가, 두 간선 출처를 하나로 병합해 렌더.
- `flow-epic-nodes.test.tsx` 신설(이 컴포넌트 최초 테스트) — mock fetch로 3개 엔드포인트 호출 확認 + 후보 데이터 기반 간선이 실제 렌더까지 이어지는 것 확認 + 부분 실패 방어 확認.

## 검증
- tsc/lint/vitest(2228/2228, 신규2)/build/verify:* 전부 그린
- 뮤테이션 검증: 병합 로직에서 candidateEdges 제거해 RED 확認 후 복원