### PR TITLE
[SID:2224] fix: 인접 depth·같은 행 간선 0길이 렌더 결함

### DIFF
--- a/apps/web/src/components/flow/derive-flow-map.test.ts
+++ b/apps/web/src/components/flow/derive-flow-map.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   computeNodeDepth, deriveFlowMapLane, computeLaneHeight, shouldShowNoDeeperReason, computeNodePositions,
-  parseDependencyGraphEdges, parseReferenceCandidateEdges, FLOW_MAP_TOP_N, FLOW_MAP_FOLD_THRESHOLD,
-  FLOW_MAP_DEPTH0_X, FLOW_MAP_GRID_STEP,
+  computeEdgeLineEndpoints, parseDependencyGraphEdges, parseReferenceCandidateEdges, FLOW_MAP_TOP_N,
+  FLOW_MAP_FOLD_THRESHOLD, FLOW_MAP_DEPTH0_X, FLOW_MAP_GRID_STEP,
   type FlowMapEdge, type FlowMapLane, type RawReferenceCandidate,
 } from './derive-flow-map';
 import type { EpicFlowNodeItem } from './derive-flow';
@@ -244,6 +244,40 @@ describe('computeNodePositions', () => {
     const lane = deriveFlowMapLane('e1', 'Epic 1', 0, [], items, []);
     const positions = computeNodePositions(lane, 28, 252);
     expect(positions.has(`u${FLOW_MAP_TOP_N}`)).toBe(false);
+  });
+});
+
+// 라이브 실측 자가발견(2026-07-30, PR#2706 배포 후) — 실제로 x1===x2===732, y1===y2===16으로
+// 완전히 겹친 선(0길이, 화면에 안 보임)이 라이브에서 나왔다. 카드 너비(110)와 그리드 간격(110)이
+// 같아 인접 depth·같은 행 사이 간격이 0인 게 원인 — 재현 케이스를 그대로 고정한다.
+describe('computeEdgeLineEndpoints', () => {
+  it('returns null when either endpoint has no position (truncated node)', () => {
+    const positions = new Map([['a', { left: 0, top: 0 }]]);
+    expect(computeEdgeLineEndpoints(positions, edge('a', 'ghost'), 110, 24)).toBeNull();
+  });
+
+  it('connects a card\'s right edge to the target card\'s left edge for a normal (non-adjacent) gap', () => {
+    const positions = new Map([
+      ['a', { left: 100, top: 0 }],
+      ['b', { left: 300, top: 0 }],
+    ]);
+    const coords = computeEdgeLineEndpoints(positions, edge('a', 'b'), 110, 24);
+    expect(coords).toEqual({ x1: 210, y1: 12, x2: 300, y2: 12 });
+  });
+
+  // 라이브 재현 — depth2(left=622)→depth3(left=732), 같은 행(top=4): 카드너비(110)=
+  // 그리드간격(110)이라 x1(622+110=732)===x2(732), y1===y2 ⇒ 고침 전엔 0길이였다.
+  it('nudges endpoints apart when they would otherwise collapse to the same point (실 재현)', () => {
+    const positions = new Map([
+      ['from', { left: 622, top: 4 }],
+      ['to', { left: 732, top: 4 }],
+    ]);
+    const coords = computeEdgeLineEndpoints(positions, edge('from', 'to'), 110, 24);
+    expect(coords).not.toBeNull();
+    const dx = coords!.x2 - coords!.x1;
+    const dy = coords!.y2 - coords!.y1;
+    expect(Math.sqrt(dx * dx + dy * dy)).toBeGreaterThanOrEqual(6);
+    expect(coords!.x1).not.toBe(coords!.x2); // 고침 전엔 여기서 732===732로 실패했다.
   });
 });
 

--- a/apps/web/src/components/flow/derive-flow-map.ts
+++ b/apps/web/src/components/flow/derive-flow-map.ts
@@ -251,6 +251,39 @@ export function computeNodePositions(
   return positions;
 }
 
+// 라이브 실측 자가발견(2026-07-30, PR#2706 배포 후) — `FlowMapNodeCard`의 카드 너비(110px)와
+// `FLOW_MAP_GRID_STEP`(110px)이 «정확히 같아서» 인접 depth 열(예: depth2→depth3)의 «같은
+// 행(row)»에 있는 두 카드는 간격이 0이다. 그 경우 간선의 x1(from 오른쪽 끝)과 x2(to 왼쪽 끝)이
+// «완전히 같은 좌표»가 돼 선 길이가 0(점 하나, 화면에 안 보임)이 된다 — 데이터는 맞게 왔는데
+// 렌더가 점이 되는 것은 진짜 병이다(라이브에서 x1===x2===732, y1===y2===16으로 직접 확認).
+const EDGE_MIN_VISIBLE_LENGTH = 6;
+
+/** 간선 하나의 SVG `<line>` 시작/끝 좌표. 두 끝점이 실질적으로 겹치면(위 사정) 최소 가시
+ * 길이를 보장하도록 x축으로 살짝 벌린다(이 지도는 depth가 x축이라 "벌어져 보여야 하는"
+ * 방향도 x축과 같다) — 카드 쪽으로 몇 px 파고드는 것이, 데이터가 왔는데 안 보이는 것보다
+ * 낫다. 위치가 없는(TOP_N에 잘린) 노드로의 간선은 null(호출부가 그 자리를 건너뛴다). */
+export function computeEdgeLineEndpoints(
+  positions: Map<string, { left: number; top: number }>,
+  edge: FlowMapEdge,
+  cardWidth: number,
+  cardHeight: number,
+): { x1: number; y1: number; x2: number; y2: number } | null {
+  const from = positions.get(edge.fromNodeId);
+  const to = positions.get(edge.toNodeId);
+  if (!from || !to) return null;
+  let x1 = from.left + cardWidth;
+  const y1 = from.top + cardHeight / 2;
+  let x2 = to.left;
+  const y2 = to.top + cardHeight / 2;
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  if (Math.sqrt(dx * dx + dy * dy) < EDGE_MIN_VISIBLE_LENGTH) {
+    x1 -= EDGE_MIN_VISIBLE_LENGTH / 2;
+    x2 += EDGE_MIN_VISIBLE_LENGTH / 2;
+  }
+  return { x1, y1, x2, y2 };
+}
+
 /** 유나양 지적(2026-07-30, PO 전달) — "대체"(supersede)만 유일하게 «간선이 노드 렌더에
  * 영향을 주는» 종류다(낳음·잇따름은 둘 다 살아있는 관계라 선만 그으면 되지만, 대체는 한쪽이
  * 죽는 관계라 «옛 노드»의 표시가 같이 바뀌어야 — 안 그러면 "대체됐는데 옛 것이 멀쩡히 살아

--- a/apps/web/src/components/flow/flow-map-canvas.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from 'next-intl';
 import type { FlowMapLane, FlowMapNode, FlowMapEdgeKind } from './derive-flow-map';
 import {
   FLOW_MAP_GRID_STEP, FLOW_MAP_NOW_LINE_X, FLOW_MAP_DEPTH0_X, computeLaneHeight, shouldShowNoDeeperReason,
-  computeNodePositions, computeSupersededNodeIds,
+  computeNodePositions, computeSupersededNodeIds, computeEdgeLineEndpoints,
 } from './derive-flow-map';
 
 // 카드 실측(FlowMapNodeCard): w-[110px], 높이는 두 줄 텍스트+padding으로 24px 안팎(NODE_ROW_HEIGHT
@@ -196,13 +196,9 @@ export function FlowMapCanvas({ lanes, onSelectStory }: FlowMapCanvasProps) {
                       {(() => {
                         const positions = computeNodePositions(lane, NODE_ROW_HEIGHT, NOW_CLUSTER_X);
                         return lane.edges.map((edge) => {
-                          const from = positions.get(edge.fromNodeId);
-                          const to = positions.get(edge.toNodeId);
-                          if (!from || !to) return null;
-                          const x1 = from.left + NODE_CARD_WIDTH;
-                          const y1 = from.top + NODE_CARD_HEIGHT / 2;
-                          const x2 = to.left;
-                          const y2 = to.top + NODE_CARD_HEIGHT / 2;
+                          const coords = computeEdgeLineEndpoints(positions, edge, NODE_CARD_WIDTH, NODE_CARD_HEIGHT);
+                          if (!coords) return null;
+                          const { x1, y1, x2, y2 } = coords;
                           const style = edgeKindStyle(edge.kind);
                           return (
                             <line


### PR DESCRIPTION
## 배경
라이브 실측 자가발견(PR#2706 배포 후 1440px `/flow` 직접 측정 중) — `<line>` 5개 중 1개가 `x1===x2, y1===y2`로 완전히 겹친 점(0길이)이라 안 보였다. 데이터는 정상 도착, 렌더 계산이 만든 병.

## 근본원인
`NODE_CARD_WIDTH`(110px)와 `FLOW_MAP_GRID_STEP`(110px)이 정확히 같아 인접 depth 열의 같은 행(row)에서 카드 사이 간격이 0 — 그 경우 x1(from 오른쪽 끝)===x2(to 왼쪽 끝).

## 수정
`computeEdgeLineEndpoints()` 신설(순수함수) — 두 끝점 거리가 6px 미만이면 x축으로 살짝 벌려 최소 가시 길이 보장. flow-map-canvas.tsx의 인라인 계산을 이 함수 호출로 교체.

## 검증
- 라이브 재현 케이스((622,4)→(732,4)) 그대로 고정한 회귀테스트 3건
- 뮤테이션 검증(RED 확認 후 복원)
- tsc/lint/vitest(2231/2231)/build/verify:* 전부 그린