### PR TITLE
[SID:2224] fix(긴급): PR#2709를 라이브에서 죽은 코드로 만들던 사전 필터 제거

### DIFF
--- a/apps/web/src/components/flow/flow-epic-nodes.test.tsx
+++ b/apps/web/src/components/flow/flow-epic-nodes.test.tsx
@@ -89,6 +89,43 @@ describe('FlowEpicNodes — merges dependencies-graph edges with reference-candi
     expect(line?.getAttribute('data-edge-confirmed')).toBe('false'); // status=estimated → 제안
   });
 
+  // 자가발견 결함(2026-07-30, PR#2709 배포 후 재검토 중) — "양끝 다 now/upcoming에 있는
+  // 것만" 미리 걸러내던 필터가 있으면, 과거(done) 스토리에 닿은 간선은 deriveFlowMapLane의
+  // 묶음-해소 로직(PR#2709)에 도달하기도 전에 사라진다. 그 필터를 없앤 것을 여기서 고정한다
+  // — target_id가 now/upcoming 어디에도 없는(=과거로 해석되는) 후보가 실제로 묶음-해소된
+  // <line>까지 그려지는 것을 왕복 확認.
+  it('renders a bundle-resolved line for a candidate edge whose target is NOT in now/upcoming (a past/done story) when pastTotal > 0 — regression for the premature pre-filter bug', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/analytics/epic-flow-nodes')) {
+        return jsonResponse({
+          data: {
+            epic_id: 'e1', now: { total: 1, items: [NOW_ITEM] }, upcoming: { total: 0, shown: 0, items: [] },
+            past: { total: 5 }, blocked_count: 0, last_changed_at: null,
+          },
+        });
+      }
+      if (url.includes('/api/dependencies/graph')) return jsonResponse({ item_type: 'story', nodes: [], edges: [] });
+      if (url.includes('/api/goals/e1/reference-candidates')) {
+        // target_id='past-story'는 now/upcoming 그 어디에도 없다 — 과거로 해석돼야 한다.
+        return jsonResponse([
+          { id: 'c1', source_id: 'past-story', source_field: 'description', target_type: 'story', target_id: 'n1', relation_kind: 'spawned', matched_keyword: null, snippet: 's', status: 'declared', declared_by: null, declared_at: null, created_at: '2026-07-30T00:00:00Z' },
+        ]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await act(async () => {
+      root.render(wrap(<FlowEpicNodes projectId="p1" epicId="e1" epicTitle="Epic 1" onSelectStory={() => {}} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const line = container.querySelector('line[data-edge-kind="spawn"]');
+    expect(line).not.toBeNull(); // 필터가 남아 있었다면 여기서 null이었을 것(재현 확認).
+    expect(line?.getAttribute('data-edge-confirmed')).toBe('true');
+  });
+
   it('still renders (no edges, no crash) when the reference-candidates fetch fails — partial failure does not kill the whole view', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);

--- a/apps/web/src/components/flow/flow-epic-nodes.tsx
+++ b/apps/web/src/components/flow/flow-epic-nodes.tsx
@@ -79,14 +79,17 @@ export function FlowEpicNodes({ projectId, epicId, epicTitle, onSelectStory }: F
         setState({ kind: 'error' });
         return;
       }
-      const epicNodeIds = new Set([...data.now.items, ...data.upcoming.items].map((i) => i.id));
       const graph = unwrap<{ edges: RawDependencyEdge[] }>(graphJson);
       const dependencyEdges = parseDependencyGraphEdges(graph?.edges ?? []);
       const rawCandidates: RawReferenceCandidate[] = Array.isArray(candidatesJson) ? candidatesJson : [];
       const candidateEdges = parseReferenceCandidateEdges(rawCandidates);
-      const edges = [...dependencyEdges, ...candidateEdges].filter(
-        (e) => epicNodeIds.has(e.fromNodeId) && epicNodeIds.has(e.toNodeId),
-      );
+      // ⛔자가발견 결함(2026-07-30, PR#2709 "묶음이 선을 통과시킨다" 배포 후 재검토 중) —
+      // "양끝 다 now/upcoming(=살아있음)에 있는 것만" 미리 걸러내던 이 필터가 있으면, 과거
+      // (done) 스토리에 닿은 간선은 deriveFlowMapLane에 «도달하기도 전에» 사라진다. 즉
+      // PR#2709의 묶음-해소 로직(양끝 살아있음/한쪽만 과거/양끝 과거 3분류)이 볼 재료 자체가
+      // 없어져 그 PR 전체가 라이브에서 죽은 코드가 되는 구조였다 — 분류는 이제
+      // deriveFlowMapLane 내부의 몫이라 여기서 미리 걸러내지 않는다. 원시 edges를 그대로 넘긴다.
+      const edges = [...dependencyEdges, ...candidateEdges];
       const lane = deriveFlowMapLane(epicId, epicTitle, data.past.total, data.now.items, data.upcoming.items, edges);
       setState({ kind: 'ready', lane });
     }).catch(() => {


### PR DESCRIPTION
## 배경
PR#2709 배포 후 라이브 검증 착수 직전 자가발견 — `flow-epic-nodes.tsx`에 PR#2706부터 있던 "양끝 다 now/upcoming에 있는 것만" 사전 필터가 그대로 남아 있어, 과거(done) 스토리에 닿은 간선이 `deriveFlowMapLane`에 도달하기도 전에 사라지고 있었습니다. PR#2709의 묶음-해소 로직이 볼 재료 자체가 없어 라이브에서는 죽은 코드였습니다.

## 왜 PR#2709 테스트는 못 잡았나
`deriveFlowMapLane`을 직접 호출하는 단위/컴포넌트 테스트라 이 사전 필터를 거치지 않았습니다 — 함수 단위로는 맞고 실제 배선에서는 어긋난, 오늘 아침 PR#2700(isFlowPath)과 같은 패턴입니다.

## 수정
사전 필터 제거 — 분류는 이제 `deriveFlowMapLane` 내부의 몫.

## 회귀가드
`flow-epic-nodes.test.tsx`에 신규 테스트 — 실제 제품 진입점(`FlowEpicNodes`, fetch 3건→파싱→병합→렌더 전체)을 직접 렌더해, 과거로 해석되는 후보가 `<line>`까지 그려지는 것을 확認. 뮤테이션 검증(필터 되살려 RED 확認 후 복원) 완료.

## 검증
tsc/lint/vitest(2251/2251)/build/verify:* 전부 그린.