### PR TITLE
[SID:2224] fix(next-maker): 활성(active) 목표만 「다음 없음」으로 센다

### DIFF
--- a/apps/web/src/components/flow/derive-next-maker.test.ts
+++ b/apps/web/src/components/flow/derive-next-maker.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
-  parseGoals, parseStories, parseNextUp,
+  parseGoals, parseStories, parseNextUp, filterActiveGoals,
   deriveGoalStems, deriveRecentlyClosedEpicIds, sortStemsByStallUrgency,
   deriveHeadline, deriveZeroStageStats,
   type NextMakerGoal, type NextMakerStory,
 } from './derive-next-maker';
 
 function goal(overrides: Partial<NextMakerGoal> = {}): NextMakerGoal {
-  return { id: 'e1', title: 'Epic 1', totalStories: 10, doneStories: 2, ...overrides };
+  return { id: 'e1', title: 'Epic 1', status: 'active', totalStories: 10, doneStories: 2, ...overrides };
 }
 
 function story(overrides: Partial<NextMakerStory> = {}): NextMakerStory {
@@ -20,8 +20,8 @@ function story(overrides: Partial<NextMakerStory> = {}): NextMakerStory {
 
 describe('parseGoals / parseStories / parseNextUp', () => {
   it('maps snake_case BE fields to camelCase', () => {
-    expect(parseGoals([{ id: 'e1', title: 'T', total_stories: 5, done_stories: 2 }]))
-      .toEqual([{ id: 'e1', title: 'T', totalStories: 5, doneStories: 2 }]);
+    expect(parseGoals([{ id: 'e1', title: 'T', status: 'active', total_stories: 5, done_stories: 2 }]))
+      .toEqual([{ id: 'e1', title: 'T', status: 'active', totalStories: 5, doneStories: 2 }]);
     expect(parseStories([{
       id: 's1', story_number: 1, title: 'S', status: 'backlog',
       assignee_id: 'u1', updated_at: '2026-07-01T00:00:00Z', epic_id: 'e1',
@@ -38,6 +38,22 @@ describe('parseGoals / parseStories / parseNextUp', () => {
       sourceClosedAt: '2026-07-20T00:00:00Z', targetId: 't1', targetStoryNumber: 11,
       targetTitle: 'T', relationKind: 'spawned', status: 'estimated', isRecent: true,
     }]);
+  });
+});
+
+describe('filterActiveGoals', () => {
+  it('keeps only status=active, drops done/archived/draft', () => {
+    const goals = [
+      goal({ id: 'a', status: 'active' }),
+      goal({ id: 'd', status: 'done' }),
+      goal({ id: 'ar', status: 'archived' }),
+      goal({ id: 'dr', status: 'draft' }),
+    ];
+    expect(filterActiveGoals(goals).map((g) => g.id)).toEqual(['a']);
+  });
+
+  it('empty input → empty output', () => {
+    expect(filterActiveGoals([])).toEqual([]);
   });
 });
 

--- a/apps/web/src/components/flow/derive-next-maker.ts
+++ b/apps/web/src/components/flow/derive-next-maker.ts
@@ -10,6 +10,7 @@
 export interface NextMakerGoal {
   id: string;
   title: string;
+  status: string; // draft | active | done | archived (GOAL_STATUSES)
   totalStories: number;
   doneStories: number;
 }
@@ -17,12 +18,29 @@ export interface NextMakerGoal {
 export interface RawGoal {
   id: string;
   title: string;
+  status: string;
   total_stories: number;
   done_stories: number;
 }
 
 export function parseGoals(raw: RawGoal[]): NextMakerGoal[] {
-  return raw.map((g) => ({ id: g.id, title: g.title, totalStories: g.total_stories, doneStories: g.done_stories }));
+  return raw.map((g) => ({
+    id: g.id, title: g.title, status: g.status, totalStories: g.total_stories, doneStories: g.done_stories,
+  }));
+}
+
+/**
+ * 라이브 실측 결함 fix(2026-07-31, PO 지적 — 배포 직후 발견) — 이 필터가 빠져 있어 이미
+ * `done`/`archived`인 목표까지 「다음이 없다」로 세고 있었다(226개 중 223개, 그중
+ * 195개가 이미 닫힌 목표). 이미 끝난 목표에 다음이 없는 것은 당연한 사실이지, 사람이
+ * 처리할 숙제가 아니다 — 「다음을 만드는 화면」의 대상은 «활성» 목표뿐이다. `draft`도
+ * 제외한다(사람 확認 前 초안 — draft→active 전이 자체가 human-only, PO 판정 GOAL_STATUSES
+ * 참고). 이 필터는 goals 배열 하나에만 적용하면 되는 «단일 근본원인»이다 — 그 뒤를 잇는
+ * deriveGoalStems/deriveHeadline은 무변경으로 올바른 수를 낸다(활성 목표만 들어오므로
+ * "217개는 이미 끝났을 수 있습니다"도 자연히 "활성인데 오래 조용한 것"이 된다).
+ */
+export function filterActiveGoals(goals: NextMakerGoal[]): NextMakerGoal[] {
+  return goals.filter((g) => g.status === 'active');
 }
 
 export interface NextMakerStory {

--- a/apps/web/src/components/flow/next-maker-screen.test.tsx
+++ b/apps/web/src/components/flow/next-maker-screen.test.tsx
@@ -29,9 +29,13 @@ function jsonResponse(body: unknown, ok = true): Response {
 }
 
 const GOALS = [
-  { id: 'e-stall', title: 'E-Stall', total_stories: 10, done_stories: 2 },
-  { id: 'e-quiet', title: 'E-Quiet', total_stories: 5, done_stories: 5 },
-  { id: 'e-ready', title: 'E-Ready', total_stories: 8, done_stories: 3 },
+  { id: 'e-stall', title: 'E-Stall', status: 'active', total_stories: 10, done_stories: 2 },
+  { id: 'e-quiet', title: 'E-Quiet', status: 'active', total_stories: 5, done_stories: 5 },
+  { id: 'e-ready', title: 'E-Ready', status: 'active', total_stories: 8, done_stories: 3 },
+  // 라이브 결함 fix(2026-07-31) 회귀 가드 — 이미 닫힌 목표가 "다음이 없는" 목표로 잘못
+  // 세지 않는지를 이 fixture가 지킨다. E-Closed는 next-up으로 표시하지 않는다.
+  { id: 'e-closed', title: 'E-Closed', status: 'done', total_stories: 3, done_stories: 3 },
+  { id: 'e-archived', title: 'E-Archived', status: 'archived', total_stories: 4, done_stories: 4 },
 ];
 
 function makeStory(overrides: Partial<{
@@ -135,9 +139,12 @@ describe('NextMakerScreen — real fetch orchestration', () => {
 
     // e-stall: in-progress(p1) + no ready-for-dev → about-to-stall. e-quiet: neither → quiet.
     // e-ready: has ready-for-dev(r1) → excluded from "다음이 비어 있는" count.
+    // e-closed(done)/e-archived(archived) must never enter the count — totalGoals stays 3, not 5.
     expect(container.textContent).toContain('목표 3개 중 2개에');
     expect(container.textContent).toContain('E-Stall');
     expect(container.textContent).toContain('E-Quiet');
+    expect(container.textContent).not.toContain('E-Closed');
+    expect(container.textContent).not.toContain('E-Archived');
   });
 
   it('clicking 다음 고르기 fetches this epic reference-candidates and renders the backlog candidate with a waiting-days reason', async () => {

--- a/apps/web/src/components/flow/next-maker-screen.tsx
+++ b/apps/web/src/components/flow/next-maker-screen.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Loader2 } from 'lucide-react';
 import {
-  parseGoals, parseStories, parseNextUp,
+  parseGoals, parseStories, parseNextUp, filterActiveGoals,
   deriveGoalStems, deriveRecentlyClosedEpicIds, sortStemsByStallUrgency,
   deriveHeadline, deriveZeroStageStats,
   type NextMakerGoal, type NextMakerStory, type RawGoal, type RawStoryLite, type RawNextUp,
@@ -108,7 +108,7 @@ export function NextMakerScreen({ projectId, memberMap, onSelectStory }: NextMak
         ]);
         if (cancelled) return;
 
-        const goals = parseGoals(rawGoals);
+        const goals = filterActiveGoals(parseGoals(rawGoals));
         const activeStories = parseStories(storiesByStatus.flat());
         const rawNextUp: RawNextUp[] = Array.isArray(nextUpRes) ? nextUpRes : [];
         const nextUp = parseNextUp(rawNextUp);


### PR DESCRIPTION
## 배경
PR#2712 배포 직후 PO가 라이브에서 발견: `목표 226개 중 223개에 다음 없음` — 이 중 195개(done 85 + archived 110)가 이미 닫힌 목표였다. 이미 끝난 목표에 「다음」이 없는 것은 당연한 사실이지 사람이 처리할 숙제가 아니라, 화면 목적(다음을 만드는 화면)에 맞지 않는 카운트였다.

## 수정
`filterActiveGoals()` 신설 — `status='active'`만 남긴다(`draft`도 제외, human 확定 前 초안이라). 이 필터 하나가 `deriveGoalStems`/`deriveHeadline` 앞단에 들어가는 것으로 끝나는 단일 근본원인 수정 — 뒷단 로직은 무변경으로 올바른 수를 낸다.

## 검증
- 뮤테이션검증(필터 비활성화 → `next-maker-screen.test.tsx`/`derive-next-maker.test.ts` 4개 테스트 정확히 RED 확認 후 복원).
- 회귀가드 fixture 추가(`e-closed`/`e-archived` 목표가 절대 카운트에 안 들어가는지 컴포넌트 테스트로 확認).
- tsc/lint 클린, vitest 2288/2288 그린, `next build` 그린.

## 남은 확認 사항(코드 변경 없이 보고만)
라이브 재측정 시 project f3e6ed64의 active 목표가 31개로 나왔는데, PO가 재신 49(org 전체 재측정으로 추정)와 다릅니다 — 스코프(project vs org) 확認이 필요해 보여 별도로 보고하겠습니다. backlog 336 vs PO 484도 active-goal 스코프로 좁혀도(219) 484에 가까워지지 않아 스테일 수치일 가능성이 높다고 봅니다 — 코드 변경은 판정 후로 미룹니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)