### PR TITLE
[SID:2224] feat(next-maker): 목표에 안 붙은 스토리 — 「목표 정하기」 패널

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -517,7 +517,12 @@
     "nextPickReasonReferenced": "referenced in the text",
     "nextPickReasonOwned": "owned",
     "nextPickReasonOwnedNamed": "owned · {name}",
-    "nextPickReasonWaiting": "waiting {n}d"
+    "nextPickReasonWaiting": "waiting {n}d",
+    "orphanSummary": "{n} items have no goal",
+    "orphanHint": "assign one and it joins that stem",
+    "orphanPickAction": "Set goal",
+    "orphanPickPlaceholder": "Select a goal",
+    "orphanAssignConfirm": "Assign"
   },
   "board": {
     "backlinksTitle": "Things that point here",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -517,7 +517,12 @@
     "nextPickReasonReferenced": "본문에서 이어짐",
     "nextPickReasonOwned": "주인 있음",
     "nextPickReasonOwnedNamed": "주인 있음 · {name}",
-    "nextPickReasonWaiting": "{n}일 기다림"
+    "nextPickReasonWaiting": "{n}일 기다림",
+    "orphanSummary": "목표에 안 붙은 일이 {n}건 있습니다",
+    "orphanHint": "목표를 정하면 줄기에 섭니다",
+    "orphanPickAction": "목표 정하기",
+    "orphanPickPlaceholder": "목표 선택",
+    "orphanAssignConfirm": "배정"
   },
   "board": {
     "backlinksTitle": "이것을 가리키는 것들",

--- a/apps/web/src/components/flow/derive-next-maker.test.ts
+++ b/apps/web/src/components/flow/derive-next-maker.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   parseGoals, parseStories, parseNextUp, filterActiveGoals,
   deriveGoalStems, deriveRecentlyClosedEpicIds, sortStemsByStallUrgency,
-  deriveHeadline, deriveZeroStageStats,
+  deriveHeadline, deriveZeroStageStats, deriveOrphanStories,
   type NextMakerGoal, type NextMakerStory,
 } from './derive-next-maker';
 
@@ -179,5 +179,38 @@ describe('deriveZeroStageStats', () => {
 
   it('empty input → all zero except the injected blocked count', () => {
     expect(deriveZeroStageStats([], 0)).toEqual({ canDo: 0, unowned: 0, blocked: 0, backlogTotal: 0, backlogOwned: 0 });
+  });
+});
+
+describe('deriveOrphanStories', () => {
+  it('keeps only backlog stories with no epicId', () => {
+    const result = deriveOrphanStories([
+      story({ id: 'a', status: 'backlog', epicId: null }),
+      story({ id: 'b', status: 'backlog', epicId: 'e1' }), // has an epic — excluded
+      story({ id: 'c', status: 'ready-for-dev', epicId: null }), // not backlog — excluded
+      story({ id: 'd', status: 'in-progress', epicId: null }), // not backlog — excluded
+    ]);
+    expect(result.map((s) => s.id)).toEqual(['a']);
+  });
+
+  it('sorts owned-first (PO: "주인 있는데 목표 없는 것이 제일 이상한 것")', () => {
+    const result = deriveOrphanStories([
+      story({ id: 'unowned1', status: 'backlog', epicId: null, assigneeId: null }),
+      story({ id: 'owned1', status: 'backlog', epicId: null, assigneeId: 'u1' }),
+      story({ id: 'unowned2', status: 'backlog', epicId: null, assigneeId: null }),
+      story({ id: 'owned2', status: 'backlog', epicId: null, assigneeId: 'u2' }),
+    ]);
+    expect(result.map((s) => s.id)).toEqual(['owned1', 'owned2', 'unowned1', 'unowned2']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [story({ id: 'a', status: 'backlog', epicId: null })];
+    const original = [...input];
+    deriveOrphanStories(input);
+    expect(input).toEqual(original);
+  });
+
+  it('empty input → empty output, no crash', () => {
+    expect(deriveOrphanStories([])).toEqual([]);
   });
 });

--- a/apps/web/src/components/flow/derive-next-maker.ts
+++ b/apps/web/src/components/flow/derive-next-maker.ts
@@ -286,3 +286,20 @@ export function deriveZeroStageStats(activeStories: NextMakerStory[], blockedCou
   }
   return { canDo, unowned, blocked: blockedCount, backlogTotal, backlogOwned };
 }
+
+/**
+ * PO 판정(2026-07-31, 라이브 실측 후속 — 샘플 5건이 전부 «오늘 만든» 스토리였다) — 새로
+ * 만든 스토리가 목표에 안 붙는 패턴이 있고, 줄기별로 고르는 이 화면 구조상 목표 없는
+ * backlog는 «영영 안 보인다»(안 보이면 잃는 것). 「다음 고르기」(이 목표의 다음은 무엇인가)
+ * 와는 «다른 물음»(이것은 어느 목표의 일인가)이라 별도 패널·별도 행동([목표 정하기])으로
+ * 세운다 — 「다음으로」를 달면 안 되는 이유: 목표가 없는데 "이 목표의 다음"이 될 수 없다.
+ * 주인 있는데 목표 없는 것이 가장 이상한 경우라 그것을 맨 위로(PO 판정, "제일 이상한 것").
+ */
+export function deriveOrphanStories(activeStories: NextMakerStory[]): NextMakerStory[] {
+  const orphans = activeStories.filter((s) => s.status === 'backlog' && !s.epicId);
+  return [...orphans].sort((a, b) => {
+    const aOwned = a.assigneeId ? 1 : 0;
+    const bOwned = b.assigneeId ? 1 : 0;
+    return bOwned - aOwned;
+  });
+}

--- a/apps/web/src/components/flow/next-maker-screen.test.tsx
+++ b/apps/web/src/components/flow/next-maker-screen.test.tsx
@@ -40,7 +40,7 @@ const GOALS = [
 
 function makeStory(overrides: Partial<{
   id: string; story_number: number; title: string; status: string;
-  assignee_id: string | null; updated_at: string; epic_id: string;
+  assignee_id: string | null; updated_at: string; epic_id: string | null;
 }> = {}) {
   return {
     id: 's1', story_number: 1, title: 'Story', status: 'backlog',
@@ -64,6 +64,8 @@ function buildFetchMock(calledUrls: string[], patchBodies: unknown[] = []) {
           data: [
             makeStory({ id: 'b1', story_number: 101, epic_id: 'e-stall', updated_at: '2026-06-01T00:00:00Z' }),
             makeStory({ id: 'b2', story_number: 102, epic_id: 'e-quiet' }),
+            // 목표(epic) 없는 orphan — 「목표 정하기」패널의 대상(PO 판정 2026-07-31).
+            makeStory({ id: 'o1', story_number: 401, epic_id: null, title: 'Orphan Story' }),
           ],
           meta: { hasMore: false, nextCursor: null, limit: 100 },
         });
@@ -104,6 +106,9 @@ function buildFetchMock(calledUrls: string[], patchBodies: unknown[] = []) {
     }
     if (url.includes('/transition') && init?.method === 'POST') {
       return jsonResponse({ data: { id: 'e-quiet', status: 'done' } });
+    }
+    if (/^\/api\/stories\/[^/]+$/.test(url) && init?.method === 'PATCH') {
+      return jsonResponse({ data: { id: 'o1', epic_id: 'e-stall' } });
     }
     throw new Error(`unexpected fetch: ${url}`);
   });
@@ -225,5 +230,53 @@ describe('NextMakerScreen — real fetch orchestration', () => {
     expect(container.textContent).not.toContain('E-Quiet');
     // 3 goals total, e-quiet removed entirely → totalGoals in the headline drops to 2.
     expect(container.textContent).toContain('목표 2개 중 1개에');
+  });
+
+  it('orphan panel: assigning a goal PATCHes /api/stories/[id] with epic_id and the story disappears from the orphan list', async () => {
+    const calledUrls: string[] = [];
+    const patchBodies: unknown[] = [];
+    vi.stubGlobal('fetch', buildFetchMock(calledUrls, patchBodies));
+
+    await act(async () => {
+      root.render(wrap(<NextMakerScreen projectId="p1" memberMap={{}} onSelectStory={() => {}} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(container.textContent).toContain('목표에 안 붙은 일이 1건 있습니다');
+
+    const summaryButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('목표에 안 붙은 일이'));
+    await act(async () => {
+      summaryButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(container.textContent).toContain('Orphan Story');
+    const pickButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '목표 정하기');
+    expect(pickButton).toBeTruthy();
+    await act(async () => {
+      pickButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const select = container.querySelector('select')!;
+    expect(select).toBeTruthy();
+    await act(async () => {
+      const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, 'value')!.set!;
+      nativeSetter.call(select, 'e-stall');
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const confirmButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '배정');
+    expect(confirmButton).toBeTruthy();
+    await act(async () => {
+      confirmButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(calledUrls.some((u) => u === '/api/stories/o1')).toBe(true);
+    expect(patchBodies).toContainEqual({ epic_id: 'e-stall' });
+    expect(container.textContent).not.toContain('목표에 안 붙은 일이');
+    expect(container.textContent).not.toContain('Orphan Story');
   });
 });

--- a/apps/web/src/components/flow/next-maker-screen.tsx
+++ b/apps/web/src/components/flow/next-maker-screen.tsx
@@ -6,12 +6,13 @@ import { Loader2 } from 'lucide-react';
 import {
   parseGoals, parseStories, parseNextUp, filterActiveGoals,
   deriveGoalStems, deriveRecentlyClosedEpicIds, sortStemsByStallUrgency,
-  deriveHeadline, deriveZeroStageStats,
+  deriveHeadline, deriveZeroStageStats, deriveOrphanStories,
   type NextMakerGoal, type NextMakerStory, type RawGoal, type RawStoryLite, type RawNextUp,
   type GoalStem,
 } from './derive-next-maker';
 import { NextMakerHeader } from './next-maker-header';
 import { GoalStemCard, type MemberLite } from './goal-stem-card';
+import { OrphanStoriesPanel } from './orphan-stories-panel';
 import { parseCursorMeta } from '@/lib/pagination';
 
 interface NextMakerScreenProps {
@@ -91,6 +92,10 @@ export function NextMakerScreen({ projectId, memberMap, onSelectStory }: NextMak
   // "실제로 다음이 생겼다"가 눈으로 보인다). refetchNonce로 강제 전체 재계산은 별도 트리거.
   const [promotedIds, setPromotedIds] = useState<Set<string>>(new Set());
   const [transitionedEpicIds, setTransitionedEpicIds] = useState<Set<string>>(new Set());
+  // 「목표 정하기」(PO 판정 2026-07-31) — 배정된 스토리는 로컬에서 즉시 그 목표 소속으로
+  // 반영한다(promotedIds와 같은 패턴). 재fetch 없이도 그 목표의 대기 칸이 즉시 늘고 orphan
+  // 목록에서 즉시 빠진다 — "안 보이면 잃는다"의 반대(배정하면 즉시 줄기에 서는 것이 보인다).
+  const [assignedEpicByStoryId, setAssignedEpicByStoryId] = useState<Map<string, string>>(new Map());
 
   useEffect(() => {
     let cancelled = false;
@@ -134,14 +139,24 @@ export function NextMakerScreen({ projectId, memberMap, onSelectStory }: NextMak
   const handleGoalTransitioned = useCallback((epicId: string) => {
     setTransitionedEpicIds((prev) => new Set(prev).add(epicId));
   }, []);
+  const handleOrphanAssigned = useCallback((storyId: string, epicId: string) => {
+    setAssignedEpicByStoryId((prev) => new Map(prev).set(storyId, epicId));
+  }, []);
 
-  // 승격된 스토리는 로컬에서 즉시 ready-for-dev로 승격 반영(재fetch 없이) — 왕복이 화면에
-  // 바로 보이는 것이 완료 조건(PO)이라 서버 재조회를 기다리게 하지 않는다.
+  // 승격된 스토리는 로컬에서 즉시 ready-for-dev로 승격 반영, 배정된 스토리는 즉시 그
+  // 목표 소속으로 반영(재fetch 없이) — 왕복이 화면에 바로 보이는 것이 완료 조건(PO)이라
+  // 서버 재조회를 기다리게 하지 않는다.
   const effectiveActiveStories = useMemo(() => {
     if (state.kind !== 'ready') return [];
-    if (promotedIds.size === 0) return state.activeStories;
-    return state.activeStories.map((s) => (promotedIds.has(s.id) ? { ...s, status: 'ready-for-dev' } : s));
-  }, [state, promotedIds]);
+    if (promotedIds.size === 0 && assignedEpicByStoryId.size === 0) return state.activeStories;
+    return state.activeStories.map((s) => {
+      const patched = { ...s };
+      if (promotedIds.has(s.id)) patched.status = 'ready-for-dev';
+      const newEpicId = assignedEpicByStoryId.get(s.id);
+      if (newEpicId) patched.epicId = newEpicId;
+      return patched;
+    });
+  }, [state, promotedIds, assignedEpicByStoryId]);
 
   const effectiveGoals = useMemo(() => {
     if (state.kind !== 'ready') return [];
@@ -173,6 +188,7 @@ export function NextMakerScreen({ projectId, memberMap, onSelectStory }: NextMak
 
   const needsNextStems = useMemo(() => sortStemsByStallUrgency(stems.filter((s) => !s.hasNext)), [stems]);
   const hasNextStems = useMemo(() => stems.filter((s) => s.hasNext), [stems]);
+  const orphanStories = useMemo(() => deriveOrphanStories(effectiveActiveStories), [effectiveActiveStories]);
 
   if (state.kind === 'loading') {
     return (
@@ -189,6 +205,15 @@ export function NextMakerScreen({ projectId, memberMap, onSelectStory }: NextMak
   return (
     <div className="space-y-4">
       <NextMakerHeader headline={headline} zeroStage={zeroStage} />
+
+      {/* PO 판정(2026-07-31) — 첫 줄 «아래» 별도 줄(다른 축, 섞지 않는다). 줄기가 없는
+          것은 「다음 고르기」 목록에 영영 안 뜬다(줄기별 구조라서) — 별도 패널로 세운다. */}
+      <OrphanStoriesPanel
+        orphanStories={orphanStories}
+        activeGoals={effectiveGoals}
+        onSelectStory={onSelectStory}
+        onAssigned={handleOrphanAssigned}
+      />
 
       <div className="space-y-2">
         <p className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">

--- a/apps/web/src/components/flow/orphan-stories-panel.tsx
+++ b/apps/web/src/components/flow/orphan-stories-panel.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Loader2 } from 'lucide-react';
+import type { NextMakerGoal, NextMakerStory } from './derive-next-maker';
+
+interface OrphanStoriesPanelProps {
+  orphanStories: NextMakerStory[];
+  activeGoals: NextMakerGoal[];
+  onSelectStory: (storyId: string) => void;
+  onAssigned: (storyId: string, epicId: string) => void;
+}
+
+/**
+ * story #2224 후속(2026-07-31, PO 판정 — 샘플 5건이 전부 "오늘 만든" 스토리였다). 「다음
+ * 고르기」(이 목표의 다음은 무엇인가)와 «다른 물음»(이것은 어느 목표의 일인가)이라 별도
+ * 패널·별도 행동([목표 정하기])으로 세운다. 첫 줄(헤드라인) «아래»에 별도 줄로 — 다른 축이라
+ * 섞지 않는다(PO: "첫 줄 옆이 아니라 아래"). PATCH `/api/stories/{id}` body `{epic_id}` —
+ * 기존 계약(updateStorySchema에 epic_id 이미 있음, 그라운딩 확認) 그대로, 새 BE 계약 불요.
+ */
+export function OrphanStoriesPanel({ orphanStories, activeGoals, onSelectStory, onAssigned }: OrphanStoriesPanelProps) {
+  const t = useTranslations('flow');
+  const [expanded, setExpanded] = useState(false);
+
+  if (orphanStories.length === 0) return null;
+
+  return (
+    <div className="rounded-lg border border-dashed border-border">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full items-center gap-2 px-3 py-2.5 text-left"
+      >
+        <span className="text-[13px] text-foreground">
+          {t('orphanSummary', { n: orphanStories.length })}
+        </span>
+        <span className="text-[11px] text-muted-foreground">{t('orphanHint')}</span>
+      </button>
+      {expanded && (
+        <div className="space-y-1.5 border-t border-border bg-muted/30 px-3 py-3">
+          {orphanStories.map((story) => (
+            <OrphanRow
+              key={story.id}
+              story={story}
+              activeGoals={activeGoals}
+              onSelectStory={onSelectStory}
+              onAssigned={onAssigned}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function OrphanRow({
+  story, activeGoals, onSelectStory, onAssigned,
+}: {
+  story: NextMakerStory;
+  activeGoals: NextMakerGoal[];
+  onSelectStory: (storyId: string) => void;
+  onAssigned: (storyId: string, epicId: string) => void;
+}) {
+  const t = useTranslations('flow');
+  const [picking, setPicking] = useState(false);
+  const [selectedEpicId, setSelectedEpicId] = useState('');
+  const [assigning, setAssigning] = useState(false);
+
+  const handleConfirm = useCallback(() => {
+    if (!selectedEpicId) return;
+    setAssigning(true);
+    fetch(`/api/stories/${story.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ epic_id: selectedEpicId }),
+    })
+      .then((r) => {
+        if (r.ok) onAssigned(story.id, selectedEpicId);
+      })
+      .finally(() => setAssigning(false));
+  }, [story.id, selectedEpicId, onAssigned]);
+
+  return (
+    <div className={`flex items-center gap-2.5 rounded-md border border-l-2 bg-card px-2.5 py-2 ${story.assigneeId ? 'border-l-primary' : 'border-l-border'}`}>
+      <button type="button" onClick={() => onSelectStory(story.id)} className="min-w-0 flex-1 truncate text-left text-xs text-foreground">
+        #{story.storyNumber} {story.title}
+      </button>
+      {story.assigneeId && <span className="shrink-0 text-[10.5px] text-primary">{t('nextPickReasonOwned')}</span>}
+      {picking ? (
+        <div className="flex shrink-0 items-center gap-1.5">
+          <select
+            value={selectedEpicId}
+            onChange={(e) => setSelectedEpicId(e.target.value)}
+            className="rounded border border-border bg-card px-1.5 py-1 text-[11px]"
+          >
+            <option value="">{t('orphanPickPlaceholder')}</option>
+            {activeGoals.map((g) => (
+              <option key={g.id} value={g.id}>{g.title}</option>
+            ))}
+          </select>
+          <button
+            type="button"
+            disabled={!selectedEpicId || assigning}
+            onClick={handleConfirm}
+            className="rounded-md border border-primary bg-primary px-2 py-1 text-[11px] font-medium text-primary-foreground disabled:opacity-50"
+          >
+            {assigning ? <Loader2 className="size-3 animate-spin" aria-hidden="true" /> : t('orphanAssignConfirm')}
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setPicking(true)}
+          className="shrink-0 rounded-md border border-border px-2.5 py-1 text-[11px] font-medium"
+        >
+          {t('orphanPickAction')}
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 배경
PR#2713 배포 후 PO 판정 — backlog 336건 중 112건이 epic(목표) 없이 떠 있고, 샘플 5건이 전부 오늘 만든 스토리였다("새 스토리가 목표에 안 붙는 패턴"이 있음). 지금 화면은 줄기(목표)별로 「다음」을 고르는 구조라, 목표가 없는 112건은 **영영 어느 줄기에도 안 뜬다** — 안 보이면 잃는 것이라 별도로 세운다.

## 설계
PO 판정대로 「다음 고르기」(이 목표의 다음은 무엇인가)와 **다른 물음**(이것은 어느 목표의 일인가)이라 다른 행동·다른 자리로 분리:
- 자리: 첫 줄(헤드라인) **아래** 별도 줄(다른 축 — 섞지 않음)
- 행동: `[목표 정하기]`(다음으로 X) — 목표가 없는데 "이 목표의 다음"이 될 수 없음
- 정렬: 주인 있는 것 먼저(PO: "주인이 있는데 목표가 없는 것이 제일 이상한 것")

## 구현
- `deriveOrphanStories()` — backlog + epic 없음만, 주인 있는 것 우선 정렬(순수함수, 뮤테이션검증 완료)
- `OrphanStoriesPanel` — 접힌 요약("목표에 안 붙은 일이 N건 있습니다") → 펼치면 목록, 행마다 `<select>`(활성 목표) + `[배정]` → `PATCH /api/stories/{id}` `{epic_id}`
- **새 BE 계약 불요** — `updateStorySchema`(FE)/`StoryUpdate`(BE)에 `epic_id`가 이미 있음을 그라운딩 확認 후 착수
- 배정 성공 시 로컬 즉시반영(재fetch 없이 orphan 목록에서 사라지고 해당 목표 줄기의 대기 칸에 즉시 반영) — 기존 promotedIds 패턴과 동일

## 검증
- 뮤테이션검증 2건(정렬 로직 반전 → RED, 로컬반영 패치 비활성화 → RED, 각각 확認 후 복원)
- 컴포넌트 시험이 실제 fetch→expand→select→PATCH 왕복 전체를 태움(순수함수 우회 없음)
- tsc/lint 클린, vitest 2293/2293 그린, `next build` 그린

🤖 Generated with [Claude Code](https://claude.com/claude-code)