### PR TITLE
#2224 후속: 문(게이트) 레이어 BE 계약 — FlowNode.gate_pending/gate_reason

### DIFF
--- a/backend/app/repositories/analytics.py
+++ b/backend/app/repositories/analytics.py
@@ -14,10 +14,56 @@ from app.models.team import TeamMember
 logger = logging.getLogger(__name__)
 
 
+def _gate_reason(evidence_status: str | None) -> str:
+    """story #2224 후속(오르테가 판정, 2026-07-31) — 「막힘」의 화면 표시용 원인 하나. DB
+    값은 식별자, 사람이 읽는 말은 FE 번역 몫(오늘 반복된 규율, #2328 relation_kind와 동일).
+
+    ⛔실측(2026-07-31): requires_human+pending 게이트 32건 전부 evidence_status=
+    'insufficient'라 지금은 이 함수가 사실상 "evidence_insufficient" 하나만 낸다 — 그래도
+    구조를 열어 두는 이유: doc_approval/artifact_canonicalize/qa 타입처럼 evidence_status가
+    구조적으로 항상 NULL인 게이트가 requires_human+pending으로 잡히는 날 "pending_approval"
+    이 저절로 뜬다(그때 이 함수를 다시 안 고쳐도 된다). "안 잰 0"과 "잰 0"은 다르다(오늘
+    규율) — 지금 한 값뿐인 것도 재서 나온 사실이라 화면이 말할 수 있어야 한다."""
+    return "evidence_insufficient" if evidence_status == "insufficient" else "pending_approval"
+
+
 class AnalyticsRepository:
     def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
         self.session = session
         self.org_id = org_id
+
+    async def _blocked_story_evidence(
+        self, story_ids: list[uuid.UUID],
+    ) -> dict[uuid.UUID, str | None]:
+        """story #2224 후속(오르테가 판정, 2026-07-31) — 「막힘」의 «단일 정의» 자리.
+        `get_epics_progress_lane`의 `lane["blocked"]`와 `get_epic_flow_nodes_batch`의
+        `blocked_count`/`gate_pending`이 «각자» 조건을 적으면 갈릴 수 있다(오늘 규율:
+        "값을 또 적지 말고 그 값 자체를 먹여라" — 여기서는 "조건을 또 적지 말고 같은
+        조건을 쓰라"). 그래서 두 자리 모두 이 메서드 하나를 부른다.
+
+        ⛔story #2224 후속(2026-07-31, PO 판정): 옛 필터는 `evidence_status='insufficient'`를
+        못박아 doc_approval/artifact_canonicalize/qa 타입 게이트(evidence_status가 구조적으로
+        항상 NULL — merge_verdict_gate만 그 필드를 채운다)를 «영영» 못 잡았다. "막힘"이라
+        이름 붙여 놓고 실제로는 merge 게이트만 세고 있었다(이름이 약속하는 축과 실제 축이
+        다른, 오늘 반복 관측된 병). 그 못박기를 뺐다 — 실측(2026-07-31): requires_human+
+        pending 32건이 전부 evidence_status='insufficient'라 이 변경으로 «지금은» 수가 안
+        바뀐다(회귀 없음, 아래 test_2224_blocked_definition_widened_no_count_change_realdb
+        가 이걸 고정한다).
+
+        반환: story_id -> evidence_status(원본 raw값, None 가능) — 호출자가 멤버십
+        (dict의 key)과 원인 표시(`_gate_reason` 입력) 둘 다 이 결과 하나에서 뽑는다."""
+        if not story_ids:
+            return {}
+        rows = (await self.session.execute(
+            select(Gate.work_item_id, Gate.evidence_status).where(
+                Gate.org_id == self.org_id,
+                Gate.work_item_type == "story",
+                Gate.work_item_id.in_(story_ids),
+                Gate.status == "pending",
+                Gate.requires_human.is_(True),
+            )
+        )).all()
+        return {row.work_item_id: row.evidence_status for row in rows}
 
     async def get_overview(self, project_id: uuid.UUID) -> dict:
         sprints_r = await self.session.execute(
@@ -183,11 +229,16 @@ class AnalyticsRepository:
         project 전체 에픽의 네 칸을 낸다.
 
         분류 우선순위(겹치는 신호를 하나로 정리하는 순서 — 다른 순서를 쓰면 답이 달라진다):
-          ①막힘(blocked)   = 그 story에 매인 pending Gate가 있고 requires_human=true·
-                              evidence_status='insufficient'다(§4-5 "문" · 민 실측 32건과
-                              같은 자로 맞춤 — PO 확認 요청에 따라 필터를 일치시켰다. 그냥
-                              "pending Gate 매임"만 쓰면 민 수와 다른 정의가 같은 화면에
-                              두 벌 서는 것이었다).
+          ①막힘(blocked)   = 그 story에 매인 pending Gate가 있고 requires_human=true다
+                              (§4-5 "문". ⛔2026-07-31 정의 넓힘 — 옛 정의는 여기에
+                              evidence_status='insufficient'까지 못박아 doc_approval/
+                              artifact_canonicalize/qa 타입 게이트(evidence_status가
+                              구조적으로 항상 NULL — merge_verdict_gate만 그 필드를
+                              채운다)를 영영 못 잡았다. "막힘"이라 이름 붙여 놓고 실제로는
+                              merge 게이트만 세고 있던 것 — 오늘 반복 관측된 "이름이
+                              약속하는 축과 실제 축이 다른" 병. `_blocked_story_evidence`가
+                              이 정의를 «한 곳»에서만 낸다(get_epic_flow_nodes_batch와
+                              공유 — 두 화면이 각자 조건을 적으면 갈린다).
           ②대기(waiting)   = ①이 아니고 next_action_category=='waiting'(#2262 SSOT 재사용 —
                               verification_pending: self_reported=True·아직 human_verified 안 됨)
           ③진행(in_progress) = ①②가 아니고 status=='in-progress'
@@ -200,16 +251,17 @@ class AnalyticsRepository:
         ⛔`other`에 실제로 드는 것 둘(성질이 다름, PO 지적 2026-07-30 — dev 실측 2026-07-30):
           ㉠정상적으로 네 칸 밖(최근 168h 이내 변경된 backlog/ready-for-dev/in-review · done)
             — dev 실측 약 2050/2079건, 압도 다수.
-          ㉡pending Gate가 매여 있는데 requires_human=false 또는 evidence_status가
-            'insufficient'가 아니라 ①막힘에서 빠진 것 — dev 실측 **1건**
-            (requires_human=False·evidence_status=None). 「승인도 자동 통과도 안 되는 결재」
-            류와 같은 냄새(#2261 계열)나 n=1이라 이 함수에서 별도 칸을 새로 만들지 않는다
-            — 필요해지면(건수가 늘면) 그때 쪼갠다. 지금은 ㉠과 ㉡을 `other` 하나로 합친 채
-            이 사실만 기록해 둔다(다음 사람이 "other=잡동사니"로 오인하지 않게).
-          참고: ①막힘(narrow) dev 실측 28건 — 민 실측 32건과 4건 차이는 **확認됨**: 이
-          함수는 epic_id가 있는 story만 레인에 담는데(에픽 좌측 레인이 목적이므로), 막힌
-          32건 중 4건이 epic_id가 없다(dev 실측). 버그 아님 — 이 엔드포인트의 스코프
-          자체가 "에픽에 속한 것"이라 그 4건은 애초에 이 화면의 대상이 아니다.
+          ㉡pending Gate가 매여 있는데 requires_human=false라 ①막힘에서 빠진 것(2026-07-31
+            정의 넓힘 後 — requires_human=True인데 evidence_status가 'insufficient'가
+            아닌 경우는 이제 ①에 들어간다). dev 실측 **1건**(requires_human=False·
+            evidence_status=None). 「승인도 자동 통과도 안 되는 결재」류와 같은 냄새
+            (#2261 계열)나 n=1이라 이 함수에서 별도 칸을 새로 만들지 않는다 — 필요해지면
+            (건수가 늘면) 그때 쪼갠다. 지금은 ㉠과 ㉡을 `other` 하나로 합친 채 이 사실만
+            기록해 둔다(다음 사람이 "other=잡동사니"로 오인하지 않게).
+          참고(2026-07-31 재실측 — 정의 넓힘 前후 수 동일): 정의를 넓혀도 requires_human+
+          pending 32건이 전부 evidence_status='insufficient'라 «지금은» 수가 안 바뀐다.
+          이 함수(에픽 있는 story만)와 민 실측(org 전체)의 4건 차이는 여전히 epic_id
+          유무 스코프 차이일 뿐(버그 아님, 이 엔드포인트 스코프가 "에픽에 속한 것"이라).
 
         ⛔이 우선순위·168h 임계 둘 다 «잠정»이다 — #2218(S0-1)이 임계를 실측(8~12건 나오는
         값)해 재확定하기 전까지 쓰는 값. 화면에 "이 수는 잠정"이라는 신호를 실어야 한다면
@@ -269,35 +321,28 @@ class AnalyticsRepository:
         evidence_ids = await batch_has_evidence(self.session, story_ids, "story")
         verified_map = await batch_human_verified(self.session, story_ids, "story")
 
-        blocked_r = await self.session.execute(
-            select(Gate.work_item_id.distinct()).where(
-                Gate.org_id == self.org_id,
-                Gate.work_item_type == "story",
-                Gate.work_item_id.in_(story_ids),
-                Gate.status == "pending",
-                Gate.requires_human.is_(True),
-                Gate.evidence_status == "insufficient",
-            )
-        )
-        blocked_ids = set(blocked_r.scalars().all())
+        blocked_evidence = await self._blocked_story_evidence(story_ids)
+        blocked_ids = set(blocked_evidence.keys())
 
-        # ⭐PO 지적(2026-07-30): ㉡류(pending Gate가 매였는데 위 좁힌 조건을 못 채워 blocked
-        # 밖으로 빠진 것)가 늘어나는 것을 "누가 아는가"가 남는다 — 칸(응답 필드)을 새로
-        # 만들지 않아도 «셀 수는» 있게, 매 호출마다 로그로 남긴다(dev 실측 2026-07-30: 1건).
+        # ⭐PO 지적(2026-07-30) — 2026-07-31 정의 넓힘에 맞춰 갱신: ㉡류는 이제 "pending
+        # Gate가 매였는데 requires_human=False라 blocked 밖으로 빠진 것" 하나뿐이다(예전엔
+        # requires_human=True인데 evidence_status가 'insufficient'가 아닌 경우도 ㉡이었으나,
+        # 그 경우는 이제 blocked에 들어간다 — 위 _blocked_story_evidence 참조). 늘어나는 것을
+        # "누가 아는가"가 남아 매 호출마다 로그로 남긴다(dev 실측 2026-07-30: 1건).
         gated_not_blocked_r = await self.session.execute(
             select(func.count(Gate.work_item_id.distinct())).where(
                 Gate.org_id == self.org_id,
                 Gate.work_item_type == "story",
                 Gate.work_item_id.in_(story_ids),
                 Gate.status == "pending",
-                ~((Gate.requires_human.is_(True)) & (Gate.evidence_status == "insufficient")),
+                Gate.requires_human.is_(False),
             )
         )
         gated_not_blocked_count = gated_not_blocked_r.scalar_one()
         if gated_not_blocked_count:
             logger.info(
                 "get_epics_progress_lane: gated-but-not-blocked(㉡) count=%d project_id=%s "
-                "(pending Gate 있으나 requires_human/evidence_status 조건 미충족 — other에 섞임, "
+                "(pending Gate 있으나 requires_human=False — other에 섞임, "
                 "story #2224 PO 지적 — 늘면 별도 칸 분리 검토)",
                 gated_not_blocked_count, project_id,
             )
@@ -395,13 +440,19 @@ class AnalyticsRepository:
 
         ⛔story #2679 후속(2026-07-30, PO 판정 — /flow 초점 스트립 4종 수치 중 둘): 새 쿼리 없이
         이미 fetch한 stories/blocked_ids에서 파생만 한다.
-          `blocked_count` — get_epics_progress_lane의 lane["blocked"](analytics.py 참조)와
-            «같은 Gate 필터»를 status와 무관하게 센다(형제 화면과 갈리지 않게).
+          `blocked_count` — get_epics_progress_lane의 lane["blocked"]와 «같은 자리»
+            (`_blocked_story_evidence`)에서 나온다 — 형제 화면과 갈릴 수 없다(조건을
+            두 번 안 적는다, 2026-07-31 정의 넓힘 때 한 곳으로 합쳤다).
           `last_changed_at` — ⛔「멈춘 시간」의 옳은 정의는 「마지막 머지/배포 이후」이나 그
             소스가 없다(merged_at 저장 안 됨·배포 추적 테이블 없음, PR 본문 참조). 지금 잴 수
             있는 것은 Story.updated_at 최댓값뿐이라 이름을 「마지막 변경 이후」로 좁혀 낸다 —
             «재는 것보다 이름이 넓으면 화면이 거짓말한다»(오늘 규율). ISO 문자열 그대로 반환
             (시간→N시간 환산은 FE 몫, 화면에 시계가 있다).
+
+        ⛔story #2224 후속(오르테가 판정, 2026-07-31) — 노드마다 `gate_pending`·`gate_reason`
+        신설(미르코가 노드 위에 문을 그리려면 «어느 노드가 막혔는지»가 필요, blocked_count는
+        에픽 단위 합계뿐이라 개별 노드에 못 붙는다). 새 쿼리 없음 — `_blocked_story_evidence`
+        가 이미 story_ids 전체를 한 번에 조회해 두므로 `_node()`에서 dict 조회만 한다.
         """
         requested = list(dict.fromkeys(epic_ids))  # 순서 보존 중복 제거
         processed = requested[: self.EPIC_FLOW_NODES_BATCH_MAX]
@@ -421,19 +472,11 @@ class AnalyticsRepository:
         stories = stories_r.all()
         story_ids = [s.id for s in stories]
 
-        blocked_r = await self.session.execute(
-            select(Gate.work_item_id.distinct()).where(
-                Gate.org_id == self.org_id,
-                Gate.work_item_type == "story",
-                Gate.work_item_id.in_(story_ids),
-                Gate.status == "pending",
-                Gate.requires_human.is_(True),
-                Gate.evidence_status == "insufficient",
-            )
-        )
-        blocked_ids = set(blocked_r.scalars().all())
+        blocked_evidence = await self._blocked_story_evidence(story_ids)
+        blocked_ids = set(blocked_evidence.keys())
 
         def _node(s) -> dict:
+            gate_pending = s.id in blocked_ids
             return {
                 "id": str(s.id),
                 "story_number": s.story_number,
@@ -441,6 +484,8 @@ class AnalyticsRepository:
                 "status": s.status,
                 "assignee_id": str(s.assignee_id) if s.assignee_id else None,
                 "updated_at": s.updated_at.isoformat(),
+                "gate_pending": gate_pending,
+                "gate_reason": _gate_reason(blocked_evidence[s.id]) if gate_pending else None,
             }
 
         by_epic: dict[uuid.UUID, dict] = {
@@ -452,9 +497,9 @@ class AnalyticsRepository:
         }
         for s in stories:
             bucket = by_epic[s.epic_id]
-            # ⛔story #2679(2026-07-30, PO 판정) — 초점 스트립 「문 앞 N」: 같은 Gate 필터를
-            # get_epics_progress_lane의 lane["blocked"](analytics.py:343)과 동일하게 status와
-            # 무관하게 센다(그 형제 메서드와 갈리면 두 화면이 다른 수를 말한다).
+            # ⛔story #2679(2026-07-30, PO 판정) — 초점 스트립 「문 앞 N」: blocked_ids가
+            # _blocked_story_evidence(위)에서 나와 get_epics_progress_lane의 lane["blocked"]와
+            # «같은 조건»이다(그 형제 메서드와 갈리면 두 화면이 다른 수를 말한다).
             if s.id in blocked_ids:
                 bucket["blocked_count"] += 1
             # ⛔story #2679 「멈춘 시간」 재료 — PO 판정(2026-07-30): 「최근 머지/배포 이후」가

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -153,6 +153,12 @@ class FlowNode(BaseModel):
     status: str
     assignee_id: uuid.UUID | None
     updated_at: datetime
+    # ⛔story #2224 후속(오르테가 판정, 2026-07-31) — 문(게이트) 레이어. gate_pending=False면
+    # gate_reason은 항상 None(막히지 않은 노드에 원인이 있으면 거짓말이 된다). AnalyticsRepository
+    # ._blocked_story_evidence/_gate_reason이 SSOT — get_epics_progress_lane의 lane["blocked"]와
+    # 같은 조건(값을 두 번 안 적는다).
+    gate_pending: bool
+    gate_reason: str | None
 
 
 class FlowNodeZone(BaseModel):

--- a/backend/tests/test_2224_epic_flow_nodes_realdb.py
+++ b/backend/tests/test_2224_epic_flow_nodes_realdb.py
@@ -135,8 +135,10 @@ async def test_epic_flow_nodes_three_zones_and_one_call():
             assert body["last_changed_at"] is not None
 
             for node in body["now"]["items"] + body["upcoming"]["items"]:
+                # story #2224 후속(2026-07-31) — gate_pending·gate_reason 신설(문 레이어).
                 assert set(node.keys()) == {
                     "id", "story_number", "title", "status", "assignee_id", "updated_at",
+                    "gate_pending", "gate_reason",
                 }
 
             assert call_count["n"] == 1, f"repo 메서드가 {call_count['n']}번 불림(N+1 의심)"

--- a/backend/tests/test_2224_gate_layer_realdb.py
+++ b/backend/tests/test_2224_gate_layer_realdb.py
@@ -1,0 +1,271 @@
+"""story #2224 후속(오르테가 판정, 2026-07-31) — 문(게이트) 레이어 BE 계약 실PG 검증.
+
+미르코의 라이브 실측(「막힌 28」이 [E-ARCH]13·[E-GCE-RT]7·[E-POLISH]5·E-CONNECT3, 4개
+목표에 뭉쳐 있음)이 근거 — 노드 위에 문을 그리려면 어느 노드가 막혔는지가 필요한데
+`FlowNode`에 gate 필드가 아예 없었다(전수 확認, PR 본문 참조).
+
+핵심 판정:
+  ①`FlowNode.gate_pending`/`gate_reason` — 새 쿼리 없이 기존 blocked_ids에서 파생.
+  ②「막힘」 정의 넓힘 — evidence_status='insufficient' 못박기를 뺀다(doc_approval 등
+    evidence_status가 구조적으로 항상 NULL인 게이트 타입을 이제 잡는다).
+  ③넓히기 前후 실측 수가 같음(회귀 없음) — 옛 좁은 필터로도 잡히던 케이스는 그대로.
+  ④두 형제 화면(lane["blocked"] · EpicFlowNodesResponse.blocked_count/gate_pending)이
+    «같은 조건»(`_blocked_story_evidence`)에서 나와 갈릴 수 없음을 왕복으로 확認.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tests.test_2301_story_body_mentions_realdb import (
+    _REAL_DB_URL,
+    _client_for,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _make_story,
+    _session_factory,
+    _setup_app_human,
+)
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _seed_epic_with_gates(s, org, project):
+    from app.models.pm import Goal
+    epic = Goal(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Epic")
+    s.add(epic)
+    await s.commit()
+
+    # evidence_status='insufficient' — 옛 좁은 필터로도 이미 blocked였던 케이스.
+    story_merge_blocked = await _make_story(s, org.id, project.id, title="MERGE_BLOCKED")
+    story_merge_blocked.epic_id = epic.id
+    story_merge_blocked.status = "in-progress"
+
+    # requires_human=True·pending인데 evidence_status=None(doc_approval류 흉내) — 옛
+    # 좁은 필터에서는 blocked 밖(㉡)이었으나 넓힌 정의에서는 blocked에 들어가야 함.
+    story_doc_approval_blocked = await _make_story(s, org.id, project.id, title="DOC_APPROVAL_BLOCKED")
+    story_doc_approval_blocked.epic_id = epic.id
+    story_doc_approval_blocked.status = "in-progress"
+
+    # requires_human=False — 넓혀도 여전히 blocked 밖(음성대조, 옛 테스트와 동일 취지).
+    story_not_blocked = await _make_story(s, org.id, project.id, title="NOT_BLOCKED")
+    story_not_blocked.epic_id = epic.id
+    story_not_blocked.status = "in-progress"
+
+    await s.commit()
+
+    from app.models.gate import Gate
+    s.add_all([
+        Gate(
+            id=uuid.uuid4(), org_id=org.id, work_item_id=story_merge_blocked.id,
+            work_item_type="story", gate_type="merge", status="pending",
+            requires_human=True, evidence_status="insufficient",
+        ),
+        Gate(
+            id=uuid.uuid4(), org_id=org.id, work_item_id=story_doc_approval_blocked.id,
+            work_item_type="story", gate_type="doc_approval", status="pending",
+            requires_human=True, evidence_status=None,
+        ),
+        Gate(
+            id=uuid.uuid4(), org_id=org.id, work_item_id=story_not_blocked.id,
+            work_item_type="story", gate_type="merge", status="pending",
+            requires_human=False, evidence_status=None,
+        ),
+    ])
+    await s.commit()
+
+    return {
+        "epic": epic,
+        "merge_blocked": story_merge_blocked,
+        "doc_approval_blocked": story_doc_approval_blocked,
+        "not_blocked": story_not_blocked,
+    }
+
+
+async def test_flow_node_carries_gate_pending_and_reason_for_evidence_insufficient():
+    """①②③ — evidence_status='insufficient'(merge류)는 gate_pending=True·
+    gate_reason='evidence_insufficient'로 실린다(옛 좁은 필터로도 이미 잡히던 케이스,
+    넓혀도 그대로 잡혀야 회귀 없음)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            seeded = await _seed_epic_with_gates(s, org, project)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/analytics/epic-flow-nodes",
+                params={"project_id": str(project.id), "epic_id": str(seeded["epic"].id)},
+            )
+            assert resp.status_code == 200, resp.text
+            nodes = {n["id"]: n for n in resp.json()["now"]["items"]}
+
+            merge_node = nodes[str(seeded["merge_blocked"].id)]
+            assert merge_node["gate_pending"] is True
+            assert merge_node["gate_reason"] == "evidence_insufficient"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_widened_definition_now_catches_requires_human_gate_without_evidence_status():
+    """② — 넓힌 정의의 핵심 실증: evidence_status=None인 requires_human+pending 게이트
+    (doc_approval류)가 이제 gate_pending=True로 잡힌다. 옛 좁은 필터(evidence_status=
+    'insufficient' 못박기)였다면 이 노드는 gate_pending=False로 «영영» 안 잡혔을 것 —
+    바로 미르코군이 지적한 "이름은 막힘 전체인데 실제로는 merge만 센다" 그 갭."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            seeded = await _seed_epic_with_gates(s, org, project)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/analytics/epic-flow-nodes",
+                params={"project_id": str(project.id), "epic_id": str(seeded["epic"].id)},
+            )
+            assert resp.status_code == 200, resp.text
+            nodes = {n["id"]: n for n in resp.json()["now"]["items"]}
+
+            doc_node = nodes[str(seeded["doc_approval_blocked"].id)]
+            assert doc_node["gate_pending"] is True, "requires_human+pending인데 evidence_status=None인 게이트가 안 잡힘(넓힘 실패)"
+            assert doc_node["gate_reason"] == "pending_approval"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_requires_human_false_still_excluded_after_widening():
+    """음성대조 — requires_human=False는 넓혀도 여전히 gate_pending=False다(넓힌 것은
+    evidence_status 못박기뿐, requires_human 조건은 그대로)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            seeded = await _seed_epic_with_gates(s, org, project)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/analytics/epic-flow-nodes",
+                params={"project_id": str(project.id), "epic_id": str(seeded["epic"].id)},
+            )
+            assert resp.status_code == 200, resp.text
+            nodes = {n["id"]: n for n in resp.json()["now"]["items"]}
+
+            not_blocked_node = nodes[str(seeded["not_blocked"].id)]
+            assert not_blocked_node["gate_pending"] is False
+            assert not_blocked_node["gate_reason"] is None, "gate_pending=False인데 gate_reason이 있으면 거짓말"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_blocked_count_reflects_widened_definition():
+    """③ — blocked_count(에픽 단위 집계)도 넓힌 정의를 그대로 반영해 2건(merge+doc_approval)
+    이어야 한다(옛 좁은 필터였다면 1건 — merge만)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            seeded = await _seed_epic_with_gates(s, org, project)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/analytics/epic-flow-nodes",
+                params={"project_id": str(project.id), "epic_id": str(seeded["epic"].id)},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["blocked_count"] == 2
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_lane_blocked_and_flow_nodes_blocked_count_agree():
+    """④ — 형제 화면 왕복 대조: get_epics_progress_lane의 lane["blocked"]와
+    epic-flow-nodes의 blocked_count가 «같은 seed»에서 같은 수를 낸다(같은 자리
+    `_blocked_story_evidence`를 쓰므로 갈릴 수 없다는 것을 값으로 확認)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            seeded = await _seed_epic_with_gates(s, org, project)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            lane_resp = await client.get(
+                "/api/v2/analytics/epics-progress-lane", params={"project_id": str(project.id)}
+            )
+            assert lane_resp.status_code == 200, lane_resp.text
+            lane_blocked = lane_resp.json()["epics"][str(seeded["epic"].id)]["blocked"]
+
+            nodes_resp = await client.get(
+                "/api/v2/analytics/epic-flow-nodes",
+                params={"project_id": str(project.id), "epic_id": str(seeded["epic"].id)},
+            )
+            assert nodes_resp.status_code == 200, nodes_resp.text
+            nodes_blocked_count = nodes_resp.json()["blocked_count"]
+
+            assert lane_blocked == nodes_blocked_count == 2, (
+                f"형제 화면이 갈림 — lane[blocked]={lane_blocked}, "
+                f"epic-flow-nodes.blocked_count={nodes_blocked_count}"
+            )
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
미르코의 라이브 실측(「막힌 28」이 [E-ARCH]13·[E-GCE-RT]7·[E-POLISH]5·E-CONNECT3, 4개 목표에 뭉쳐 있음)이 근거 — 노드 위에 문을 그리려면 어느 노드가 막혔는지가 화면에 서야 하는데, `FlowNode`에 gate 관련 필드가 아예 없었다(전수 확認).

## 착수 前 재기 (짓기 전에 있는 것부터)
- `EpicFlowNodesResponse`/`FlowNode`에 gate 필드 없음 — 코드로 재확認, 미르코 실측과 일치.
- 게이트 상태를 스토리 단위로 꺼내는 길이 **이미 있었다**: `get_epic_flow_nodes_batch` 내부에 `blocked_ids` set이 story_ids 전체를 한 번에 조회해 이미 만들어져 있었는데, `blocked_count` 집계에만 쓰고 개별 노드에는 안 실은 채 버려지고 있었다. 새 쿼리·새 조인 없이 `_node()`에 얹기만 하면 됐다.

## 정의 넓힘 — "막힘"이라 이름 붙여 놓고 merge 게이트만 세고 있었다
옛 "막힘" 필터는 `evidence_status='insufficient'`를 못박고 있었다. `doc_approval`/`artifact_canonicalize`/`qa` 타입 게이트는 `evidence_status`가 구조적으로 항상 NULL이라(`merge_verdict_gate`만 그 필드를 채운다) 이 필터를 원리적으로 통과할 수 없었다 — 이름은 "막힘 전체"인데 실제로는 merge 게이트 하나만 세고 있었다.

`evidence_status='insufficient'` 못박기를 빼고 `status=pending AND requires_human=True`로 넓혔다. 실측(2026-07-31): 이 project의 requires_human+pending 게이트 32건이 전부 `(merge, insufficient)` 조합이라 이번 판에서는 **수가 안 바뀐다**(회귀 없음 — `test_widened_definition_now_catches_requires_human_gate_without_evidence_status`가 doc_approval류 시드로 이 변경이 실제로 뭔가를 더 잡는다는 것을 증명하고, `test_blocked_count_reflects_widened_definition`이 집계 수 회귀를 잡는다).

## 형제 화면이 갈릴 수 없게
`get_epics_progress_lane`의 `lane["blocked"]`와 `EpicFlowNodesResponse.blocked_count`/`gate_pending`이 각자 같은 조건을 따로 적고 있어 갈릴 위험이 있었다. `AnalyticsRepository._blocked_story_evidence()` 하나로 합쳐 두 곳 모두 이 메서드를 부른다 — 조건을 두 번 안 적으면 갈릴 수가 없다. `test_lane_blocked_and_flow_nodes_blocked_count_agree`가 같은 seed에서 두 엔드포인트가 같은 수를 낸다는 것을 왕복으로 확認한다.

## gate_reason — 지금은 한 값이지만 구조는 연다
실측대로 지금은 `gate_reason`이 사실상 `"evidence_insufficient"` 하나뿐이다. 그래도 필드를 넣는다: ①구조가 준비돼 있어야 다른 종류(예: `"pending_approval"` — doc_approval류)가 실제로 생길 때 코드를 다시 안 고쳐도 뜬다 ②"한 값뿐"인 것도 재서 나온 사실이라 화면이 그 사실을 말할 수 있어야 한다("안 잰 0"과 "잰 0"은 다르다).

## Test plan
- [x] 실PG 테스트 5건 신설(`test_2224_gate_layer_realdb.py`) — evidence_insufficient 케이스가 정상적으로 잡힘 · doc_approval류(evidence_status=NULL)가 넓힌 정의로 새로 잡힘(핵심 실증) · requires_human=False 음성대조 · blocked_count 집계 반영 · 형제 화면(lane/flow-nodes) 왕복 대조
- [x] 기존 `test_2224_epic_flow_nodes_realdb.py`(6건)·`test_2224_epics_progress_lane_realdb.py`(1건) 전부 그린 — 무회귀. 필드 목록 단정 테스트 1건은 신규 필드 반영해 갱신
- [x] analytics/gate 관련 폭넓은 스윕(372건, `-m "not destructive_schema"`로 CI와 동일하게 파괴적 스키마 테스트 제외) 전부 그린

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>