### PR TITLE
#2224 후속: env drift 가드 — 환경별로 다른 브랜치 대조

### DIFF
--- a/.github/workflows/env-drift-guard.yml
+++ b/.github/workflows/env-drift-guard.yml
@@ -23,8 +23,24 @@ jobs:
     timeout-minutes: 5  # 설계 doc 비용축 목표(1분 미만) + 여유
 
     steps:
-      - name: Checkout
+      # story #2224 후속(오르테가 판정, 2026-07-31) — main(default branch, 이 스케줄 트리거가
+      # checkout하는 브랜치)만 보면 «develop에만 있는» IaC/allowlist 수정이 반영 안 된 채로
+      # dev 서비스가 매일 거짓 빨강을 낸다(#2320/#2205와 같은 클래스 — 스케줄이 checkout하는
+      # 브랜치 ≠ 대조해야 할 정본. PR#2678 allowlist 수정이 develop에만 있어 main 기준
+      # 대조는 그 수정을 영원히 못 보는 실사례). prod 서비스(main 기반 배포)는 main으로,
+      # dev 서비스(develop 기반 배포)는 develop으로 — 환경별로 정본 브랜치를 따로 checkout
+      # 한다. 이 첫 checkout이 main(default) — prod 대조는 여기서 그대로 돈다.
+      - name: Checkout (main — prod 대조용)
         uses: actions/checkout@v4
+
+      # develop을 별도 경로에 추가 checkout — dev 대조는 이 안의 스크립트/IaC/allowlist를
+      # 쓴다(check_env_drift.py의 _find_repo_root가 이 checkout의 .git을 찾아 자동으로
+      # develop 루트를 잡는다 — main 루트와 섞이지 않는다).
+      - name: Checkout (develop — dev 대조용)
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          path: develop-checkout
 
       # cloud-build.yml과 동일 WIF 패턴 재사용 — 신규 시크릿 불필요(이미 존재).
       - name: Authenticate to GCP (Workload Identity Federation)
@@ -49,9 +65,26 @@ jobs:
       # ⚠️ 값 자체는 여기서도 절대 로그에 안 남는다(check_env_drift.py가 매치 여부만 반환) —
       # 이 스텝 출력이 그대로 GHA 로그·아티팩트가 되니, 스크립트 쪽 보장이 이 워크플로우
       # 전체의 보장이기도 하다(설계 doc "③" 축 요구사항).
-      - name: Run drift check
+      #
+      # ⛔둘 다 실행하고 «둘 중 하나라도» FAIL이면 이 스텝 자체가 실패한다(continue-on-error
+      # 로 하나를 먼저 죽이고 다른 걸 스킵하면 안 됨 — 매일 두 축을 다 봐야 한다).
+      - name: Run drift check (prod — main)
+        id: drift_prod
+        run: python3 infra/check_env_drift.py --only-env prod
+
+      - name: Run drift check (dev — develop)
+        id: drift_dev
+        if: always()  # prod 스텝이 실패해도 dev 스텝은 반드시 돈다 — 한쪽이 다른 쪽을 가리면 안 됨.
+        run: python3 develop-checkout/infra/check_env_drift.py --only-env dev
+
+      - name: Combine drift results
         id: drift
-        run: python3 infra/check_env_drift.py
+        if: always()
+        run: |
+          if [ "${{ steps.drift_prod.outcome }}" = "failure" ] || [ "${{ steps.drift_dev.outcome }}" = "failure" ]; then
+            echo "::error::drift 발견 — prod=${{ steps.drift_prod.outcome }} dev=${{ steps.drift_dev.outcome }}"
+            exit 1
+          fi
 
       # FAIL 시에만 실행. 오르테가군 정정(2026-07-22): Sprintable story 자동생성은 뺀다 —
       # API 키를 GitHub secret에 하나 더 뿌리는 대가(오늘 하루 겪은 키 유출 사고 직후라

--- a/backend/tests/test_check_env_drift_env_split.py
+++ b/backend/tests/test_check_env_drift_env_split.py
@@ -1,0 +1,154 @@
+"""story #2224 후속(오르테가 판정, 2026-07-31) — infra/check_env_drift.py 「환경별 브랜치
+대조」 회귀가드. 배경: 스케줄 워크플로우가 main(default branch)만 checkout해 develop에만
+있는 IaC/allowlist 수정(PR#2678)이 dev 서비스 대조에 영원히 반영 안 됐다(#2320/#2205와
+같은 클래스 — 스케줄이 checkout하는 브랜치 ≠ 대조해야 할 정본). `_env_for_service`로
+환경을 가르고 `--only-env`로 워크플로우가 브랜치별로 스크립트를 두 번 따로 부를 수 있게 한다.
+
+gcloud 라이브 접근 없이(순수 정적 로직) 실행 가능.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_INFRA_DIR = _REPO_ROOT / "infra"
+
+
+def _load_check_env_drift():
+    spec = importlib.util.spec_from_file_location(
+        "check_env_drift", _INFRA_DIR / "check_env_drift.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ── _env_for_service — 명명 관례 둘 다 ───────────────────────────────────────
+
+def test_env_for_service_master_services_explicit_suffix():
+    """`_SERVICE_SCRIPT_MAP`(마스터) 7개 전부 "-dev"/"-prod" 접미사로 정확히 갈린다."""
+    mod = _load_check_env_drift()
+    expected = {
+        "sprintable-backend-dev": "dev", "sprintable-backend-prod": "prod",
+        "sprintable-frontend-dev": "dev", "sprintable-frontend-prod": "prod",
+        "sprintable-mcp-dev": "dev", "sprintable-mcp-prod": "prod",
+        "sprintable-realtime-dev": "dev",  # prod 짝 없음 — 그래도 접미사로 dev 판별.
+    }
+    for service, env in expected.items():
+        assert mod._env_for_service(service) == env, service
+
+
+def test_env_for_service_bare_name_is_prod_dev_suffix_pairs():
+    """`excluded_services`류(별도 repo IaC 소관) — bare 이름=prod, "-dev"만 명시(sprintable-
+    admin-web ↔ sprintable-admin-web-dev 실존 쌍, manual-env-allowlist.yml 참조)."""
+    mod = _load_check_env_drift()
+    assert mod._env_for_service("sprintable-admin-web") == "prod"
+    assert mod._env_for_service("sprintable-admin-web-dev") == "dev"
+    assert mod._env_for_service("sprintable-internal-api") == "prod"
+    assert mod._env_for_service("sprintable-internal-api-dev") == "dev"
+
+
+def test_env_for_service_never_raises_on_unknown_shape():
+    """신규/미분류 이름도 크래시 없이 분류된다(접미사 없으면 prod로 — 별도 unmapped 처리는
+    main() 루프의 ⑥축이 이미 담당, 이 함수는 크래시 대상이 아니다)."""
+    mod = _load_check_env_drift()
+    assert mod._env_for_service("some-brand-new-service") == "prod"
+
+
+# ── main() 필터링 — only_env가 live_services를 정확히 좁힌다 ─────────────────
+
+def test_main_only_env_filters_service_loop(monkeypatch):
+    """`only_env`를 넘기면 그 환경 서비스만 루프에 들어간다 — 다른 환경 서비스는 아예 안
+    보인다(라이브 gcloud 호출 없이, `_list_live_services`를 몽키패치해 순수 필터링만 검증)."""
+    mod = _load_check_env_drift()
+
+    seen_services: list[str] = []
+    fake_services = [
+        "sprintable-backend-dev", "sprintable-backend-prod",
+        "sprintable-frontend-dev", "sprintable-frontend-prod",
+    ]
+
+    def _fake_list_live_services():
+        return fake_services
+
+    def _fake_live_env_entries(service):
+        seen_services.append(service)
+        return []
+
+    monkeypatch.setattr(mod, "_list_live_services", _fake_list_live_services)
+    monkeypatch.setattr(mod, "_live_env_entries", _fake_live_env_entries)
+    monkeypatch.setattr(mod, "_load_allowlist", lambda: ({}, {}))
+    monkeypatch.setattr(mod, "_iac_covered_keys", lambda: set())
+    monkeypatch.setattr(mod, "_settings_field_env_keys", lambda: set())
+    monkeypatch.setattr(mod, "_load_settings_exempt", lambda: [])
+    monkeypatch.setattr(mod, "_web_env_reads", lambda: {})
+    monkeypatch.setattr(mod, "_load_code_read_exempt", lambda: [])
+    monkeypatch.setattr(mod, "_load_code_read_high_baseline", lambda: [])
+    monkeypatch.setattr(mod, "_service_subset_wellformed_violations", lambda: [])
+    monkeypatch.setattr(mod, "_external_iac_wellformed_violations", lambda: [])
+
+    mod.main(only_env="dev")
+
+    assert set(seen_services) == {"sprintable-backend-dev", "sprintable-frontend-dev"}
+
+
+def test_main_no_only_env_processes_all_services(monkeypatch):
+    """`only_env=None`(옛 동작·기본값)이면 전체 서비스를 그대로 본다 — 회귀 없음."""
+    mod = _load_check_env_drift()
+
+    seen_services: list[str] = []
+    fake_services = [
+        "sprintable-backend-dev", "sprintable-backend-prod",
+        "sprintable-frontend-dev", "sprintable-frontend-prod",
+    ]
+
+    def _fake_list_live_services():
+        return fake_services
+
+    def _fake_live_env_entries(service):
+        seen_services.append(service)
+        return []
+
+    monkeypatch.setattr(mod, "_list_live_services", _fake_list_live_services)
+    monkeypatch.setattr(mod, "_live_env_entries", _fake_live_env_entries)
+    monkeypatch.setattr(mod, "_load_allowlist", lambda: ({}, {}))
+    monkeypatch.setattr(mod, "_iac_covered_keys", lambda: set())
+    monkeypatch.setattr(mod, "_settings_field_env_keys", lambda: set())
+    monkeypatch.setattr(mod, "_load_settings_exempt", lambda: [])
+    monkeypatch.setattr(mod, "_web_env_reads", lambda: {})
+    monkeypatch.setattr(mod, "_load_code_read_exempt", lambda: [])
+    monkeypatch.setattr(mod, "_load_code_read_high_baseline", lambda: [])
+    monkeypatch.setattr(mod, "_service_subset_wellformed_violations", lambda: [])
+    monkeypatch.setattr(mod, "_external_iac_wellformed_violations", lambda: [])
+
+    mod.main()
+
+    assert set(seen_services) == set(fake_services)
+
+
+# ── --only-env CLI 파싱 ──────────────────────────────────────────────────────
+
+def test_parse_only_env_absent_returns_none():
+    mod = _load_check_env_drift()
+    assert mod._parse_only_env([]) is None
+
+
+def test_parse_only_env_valid_values():
+    mod = _load_check_env_drift()
+    assert mod._parse_only_env(["--only-env", "dev"]) == "dev"
+    assert mod._parse_only_env(["--only-env", "prod"]) == "prod"
+
+
+def test_parse_only_env_invalid_value_exits():
+    mod = _load_check_env_drift()
+    with pytest.raises(SystemExit):
+        mod._parse_only_env(["--only-env", "staging"])
+
+
+def test_parse_only_env_missing_value_exits():
+    mod = _load_check_env_drift()
+    with pytest.raises(SystemExit):
+        mod._parse_only_env(["--only-env"])

--- a/infra/check_env_drift.py
+++ b/infra/check_env_drift.py
@@ -76,6 +76,24 @@ _REPO_ROOT = _find_repo_root(Path(__file__).resolve().parent)
 _REGION = "asia-northeast3"
 _ALLOWLIST_PATH = _REPO_ROOT / "infra" / "manual-env-allowlist.yml"
 
+
+def _env_for_service(service: str) -> str:
+    """story #2224 후속(오르테가 판정, 2026-07-31) — 서비스 이름으로 환경(dev/prod)을 가른다.
+    두 가지 명명 관례가 실제로 섞여 있다(둘 다 실측 확認):
+      ㉠`_SERVICE_SCRIPT_MAP`(마스터) 서비스들 — "-dev"·"-prod" 둘 다 명시(sprintable-
+        backend-dev/-prod류). ⛔단 `sprintable-realtime-dev`는 prod 짝이 없다(cloudbuild.yaml
+        단일 소스, dev 전용 서비스) — 짝이 없어도 접미사만으로 dev로 판별한다(짝의 존재
+        여부와 이 판별은 별개 문제).
+      ㉡allowlist의 `excluded_services`(sprintable-admin-web류, 별도 repo IaC 소관) —
+        prod는 «접미사 없음»(bare), dev만 "-dev"가 붙는다(sprintable-admin-web ↔
+        sprintable-admin-web-dev 쌍으로 실존 확認, manual-env-allowlist.yml 참조).
+    ⇒ "-dev"로 끝나면 dev, 그 외(= "-prod"로 끝나거나 접미사 자체가 없는 bare 이름)는
+    전부 prod로 취급한다 — ㉡류가 ①②축은 이미 제외돼 있어(별도 repo IaC) 이 구분이
+    실제로 영향을 주는 것은 ③(평문 시크릿)뿐인데, ③은 "어느 한 실행에 정확히 한 번" 걸리면
+    되므로(두 번 걸리면 중복 로그일 뿐 오탐은 아니나, 정확한 배정이 더 낫다) bare=prod로
+    고정한다."""
+    return "dev" if service.endswith("-dev") else "prod"
+
 # ④ Settings 커버리지 대상 — app.core.config.Settings를 실제로 임포트해서 쓰는 서비스만
 # (같은 이미지). frontend·mcp·admin은 이 클래스 자체를 안 쓰므로 제외(오탐 방지 핵심).
 _SETTINGS_CONSUMING_SERVICES = {
@@ -518,7 +536,19 @@ def _today():
     return datetime.now(timezone.utc).date()
 
 
-def main() -> int:
+def main(only_env: str | None = None) -> int:
+    """story #2224 후속(오르테가 판정, 2026-07-31) — `only_env`("dev"|"prod"|None). 배경:
+    이 가드는 스케줄 워크플로우가 checkout한 «한 브랜치»(GHA 스케줄 트리거는 default
+    branch=main을 checkout한다)만 보는데, IaC/allowlist의 정본은 dev는 develop·prod는
+    main으로 갈린다(#2320/#2205와 같은 클래스 — 스케줄이 checkout하는 브랜치 ≠ 대조해야
+    할 정본). 지금까지는 dev 서비스도 main 기준으로 대조돼 «거짓 빨강»이 났다(develop에만
+    있는 allowlist 수정이 반영 안 됨, PR#2678 실사례).
+
+    ⛔이 함수 자체는 여전히 «한 checkout 루트»(`_REPO_ROOT`, 이 파일이 실제로 놓인 위치)만
+    본다 — 두 브랜치를 한 프로세스에서 동시에 보는 게 아니라, 워크플로우가 **브랜치별로
+    이 스크립트를 두 번 따로 실행**(각각 그 브랜치의 checkout 안에 있는 이 파일을 부른다
+    — `_find_repo_root`가 그 checkout의 `.git`을 찾으므로 자동으로 맞는 루트가 잡힌다)하고,
+    `only_env`로 자기 브랜치가 담당하는 환경의 서비스만 걸러 그 서비스만 검사한다."""
     excluded_axes, allowlist_services = _load_allowlist()
     iac_keys = _iac_covered_keys()
     settings_field_keys = _settings_field_env_keys()
@@ -534,6 +564,8 @@ def main() -> int:
     )
 
     live_services = _list_live_services()
+    if only_env is not None:
+        live_services = [s for s in live_services if _env_for_service(s) == only_env]
     key_set_failures: list[str] = []
     value_check_failures: list[str] = []
     secret_shape_failures: list[str] = []
@@ -544,6 +576,7 @@ def main() -> int:
     code_read_report: list[str] = []  # ⑤㉢ — report-only(환경무관, 승격 대상 아님).
     unmapped: list[str] = []
 
+    env_label = f"[{only_env}] " if only_env else ""
     checked = 0
     value_checked = 0
     for service in live_services:
@@ -647,7 +680,10 @@ def main() -> int:
     )
 
     if has_fail or has_report_only:
-        print("❌ env 드리프트 발견:" if has_fail else "⚠️ env 드리프트 report-only 발견(FAIL 아님):")
+        print(
+            f"{env_label}❌ env 드리프트 발견:" if has_fail
+            else f"{env_label}⚠️ env 드리프트 report-only 발견(FAIL 아님):"
+        )
         if key_set_failures:
             print("  ①키집합 대조:")
             for line in key_set_failures:
@@ -724,7 +760,7 @@ def main() -> int:
             return 1
 
     print(
-        f"✅ 드리프트 없음(FAIL 기준) — ①{checked}개 서비스 키집합"
+        f"{env_label}✅ 드리프트 없음(FAIL 기준) — ①{checked}개 서비스 키집합"
         f"(제외 {sum(1 for a in excluded_axes.values() if 'key_set' in a)}개), "
         f"②{value_checked}개 서비스 값 대조, "
         f"③{len(live_services)}개 서비스 전체 평문시크릿 스캔 완료(제외 없음), "
@@ -737,5 +773,19 @@ def main() -> int:
     return 0
 
 
+def _parse_only_env(argv: list[str]) -> str | None:
+    """`--only-env dev|prod` — 없으면 None(모든 서비스, 옛 동작 그대로 보존). argparse를 안
+    쓴 이유: 이 스크립트는 이 플래그 하나뿐이라 의존성을 늘릴 이유가 없다."""
+    if "--only-env" not in argv:
+        return None
+    idx = argv.index("--only-env")
+    if idx + 1 >= len(argv):
+        raise SystemExit("--only-env 뒤에 dev 또는 prod가 와야 함")
+    value = argv[idx + 1]
+    if value not in ("dev", "prod"):
+        raise SystemExit(f"--only-env는 dev 또는 prod만 허용(받은 값: {value!r})")
+    return value
+
+
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main(only_env=_parse_only_env(sys.argv[1:])))


### PR DESCRIPTION
## Summary
Env Drift Guard가 매일 빨간 원인을 재는 과정(#2716 이후 파울로 요청)에서 발견 — 스케줄 워크플로우는 `main`(default branch)만 checkout하는데, IaC/allowlist 정본은 dev는 `develop`·prod는 `main`으로 갈린다(#2320/#2205와 같은 클래스, memory 참조). `develop`에만 있던 allowlist 수정(PR#2678, `GITHUB_APP_WEBHOOK_SECRET` 등재)이 `main` 기준 대조에는 영원히 안 보여 dev 서비스가 매일 거짓 빨강을 냈다.

재확認 결과: 코드의 report-only(⑤㉢) 판정 로직 자체는 정확했다(`has_fail` 정의에 안 들어감, 직접 코드로 확認). 실제 exit 1은 진짜 ①키집합 드리프트였는데, 그 드리프트의 정체가 "고침이 develop에만 있어 main이 못 보는 것"이었다.

## 무엇
- `_env_for_service()` — 서비스 이름으로 환경 판별. 두 명명 관례 둘 다 실측 확認: `_SERVICE_SCRIPT_MAP` 서비스는 `-dev`/`-prod` 둘 다 명시, `excluded_services`(admin-web류, 별도 repo IaC)는 bare=prod·`-dev`만 명시.
- `main(only_env=...)` / `--only-env {dev,prod}` CLI 플래그 — 넘기면 그 환경 서비스만 검사.
- 워크플로우: `develop`을 별도 경로(`develop-checkout/`)에 추가 checkout하고, 스크립트를 두 번 따로 실행(prod는 기본 checkout=main 기준, dev는 develop-checkout 기준). 한쪽이 실패해도(`if: always()`) 다른 쪽이 반드시 돈다.

## ⛔이 PR이 안 하는 것 — main의 allowlist 콘텐츠는 별건
`main`의 allowlist를 직접 파싱해 보니 prod 항목(`GITHUB_APP_WEBHOOK_SECRET`·`FIREBASE_OAUTH_HANDOFF_ENABLED`)이 "뒤쳐진" 게 아니라 **애초에 옮겨진 적이 없다**(develop은 둘 다 있음). 지금 main에 그 줄을 손으로 넣으면 증상만 고치는 반창고일 수 있다 — `develop→main`이 왜 76/3235건씩 갈렸는지(squash merge 아티팩트인지 진짜 안 흐르는지) 원인을 모른 채다. PO 판정: 이 PR은 메커니즘만, main 콘텐츠/흐름 문제는 "재기"만 먼저 하고 별건으로 처리.

## Test plan
- [x] 로컬 실행으로 왕복 확認 — `--only-env dev`/`--only-env prod` 각각 실제 gcloud 대상으로 정상 필터링, 종전 인자 없는 호출은 회귀 없이 전체 서비스 처리
- [x] 신규 유닛 테스트 9건(`test_check_env_drift_env_split.py`) — 이름 접미사 두 관례 모두·필터링이 서비스 루프를 정확히 좁힘·`--only-env` 없음/있음/잘못된 값 CLI 파싱. gcloud 라이브 접근 없이 순수 정적 로직만
- [x] 기존 check_env_drift 축 테스트 3파일(43건) 전부 그린 — 무회귀

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>