### PR TITLE
fix(gates): list_gates도 project_id를 응답에 채운다

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -402,18 +402,14 @@ async def list_gates(
 
     # project_id 배치 해소(story #1968 resolve_work_item_project_id 의 IN-clause 배치 버전 — 개별
     # gate 마다 신규 쿼리 금지). doc 은 위에서 이미 배치 조회한 doc_proj 재사용(중복 쿼리 0).
-    # #2198: 이제 can_approve enrich(assigned_to_me 무관)와 assigned_to_me 필터링이 이 배치를
-    # 공유한다(예전엔 assigned_to_me=true 일 때만 계산했다). ⚠️전부 `resolved is not None and
-    # resolved.type == "human"` 게이트 **안**에서만 실행한다 — 캐치 안 되면(비휴먼/resolve 실패)
-    # eligible_ids 가 자연히 빈 채로 남고 can_approve=False(fail-closed)이므로 이 배치 쿼리들
-    # 자체가 불필요(N+1 0 철학과 동형 — "계산해도 결론이 안 바뀔 쿼리는 안 낸다").
+    # ⚠️2026-07-31 수정(오르테가 라이브 실측 — GET /api/v2/gates pending 37/37 project_id=None):
+    # 이 배치는 **caller 타입과 무관하게** 항상 돈다 — project_id 는 응답 데이터 정합성 문제지
+    # authz 판정이 아니다. 예전엔 `resolved.type == "human"` 게이트 안에서만 돌아서(can_approve
+    # 전용 배치인 줄 알고 얹었던 것) agent 호출은 story/task/artifact 케이스가 통째로 스킵되고,
+    # 게다가 human 호출이어도 이 dict 자체를 resp.project_id 에 대입하는 코드가 애초에 없었다
+    # (아래 enrich 루프 참조 — 그게 진짜 근본원인. 이 게이트 분리는 caller 의존성 제거용).
     project_id_by_work_item: dict[uuid.UUID, uuid.UUID | None] = dict(doc_proj)
-    # #2198(PO 판정): 캐시 키가 project_id 단독에서 (gate_type, project_id) 로 바뀌었다 — 승인
-    # 자격이 이제 gate_type 에도 의존한다(_non_doc_can_approve 표 참조. artifact_canonicalize
-    # 는 project_id 무관 항상 True).
-    approvable_cache: dict[tuple[str, uuid.UUID | None], bool] = {}
-    eligible_ids: set[uuid.UUID] = set()
-    if non_doc_gates and resolved is not None and resolved.type == "human":
+    if non_doc_gates:
         story_ids = {g.work_item_id for _, g in non_doc_gates if g.work_item_type == "story"}
         task_ids = {g.work_item_id for _, g in non_doc_gates if g.work_item_type == "task"}
         # story #2082: artifact_canonicalize 게이트(work_item_type="visual_artifact")가 이 배치에서
@@ -444,6 +440,20 @@ async def list_gates(
             )).all()
             project_id_by_work_item.update({aid: pid for aid, pid in rows})
 
+    # ⭐신규 enrich(원인 수정 본체): 위에서 이미 계산해 둔 project_id_by_work_item 을
+    # can_approve 판정뿐 아니라 응답 필드 자체에도 대입한다 — 지금까지 이 값이 어디에도 안
+    # 흘러가 GateResponse.project_id 가 Pydantic 기본값 None 그대로 나갔다(get_gate_endpoint
+    # 단건 조회만 resp.project_id 를 대입했고 목록은 빠져 있었다). doc/story/task/artifact 전부
+    # 이 한 dict 로 커버(project_id_by_work_item 은 dict(doc_proj) 로 시작).
+    for resp, g in zip(responses, gates):
+        resp.project_id = project_id_by_work_item.get(g.work_item_id)
+
+    # #2198(PO 판정): 캐시 키가 project_id 단독에서 (gate_type, project_id) 로 바뀌었다 — 승인
+    # 자격이 이제 gate_type 에도 의존한다(_non_doc_can_approve 표 참조. artifact_canonicalize
+    # 는 project_id 무관 항상 True).
+    approvable_cache: dict[tuple[str, uuid.UUID | None], bool] = {}
+    eligible_ids: set[uuid.UUID] = set()
+    if non_doc_gates and resolved is not None and resolved.type == "human":
         # N+1 방지: gate 여러 건이 같은 (gate_type, project_id) 를 가리켜도 _non_doc_can_approve 는
         # **고유 조합당 1회**만 호출(캐시) — gate 개수와 무관.
         for _resp, g in non_doc_gates:

--- a/backend/tests/test_1970_gate_single_get.py
+++ b/backend/tests/test_1970_gate_single_get.py
@@ -563,9 +563,13 @@ async def test_realdb_cold_get_task_gate_summary_none_when_soft_deleted():
 
 
 @pytest.mark.anyio
-async def test_list_gates_regression_doc_enrich_unaffected_by_project_id_field():
-    """GateResponse에 project_id 필드(default None) 추가가 list_gates 의 기존 doc-only enrich
-    응답을 깨지 않는지(project_id 는 list에서 채우지 않으므로 그대로 None)."""
+async def test_list_gates_doc_enrich_and_project_id_both_populated():
+    """⚠️2026-07-31 수정(오르테가 라이브 실측 — GET /api/v2/gates pending 37/37 project_id=None):
+    이 테스트는 원래 "list는 project_id를 채우지 않는다(GET /{id} 전용 enrich)"를 정상 동작으로
+    단정했었다 — 그게 바로 그 결함이었다(계산은 doc_proj로 이미 하는데 응답 필드로 흘려보내는
+    대입이 통째로 빠져 있었다). GateResponse.project_id 필드 추가가 doc-only work_item_summary
+    enrich 를 깨지 않는다는 원래 취지는 유지하되, project_id 도 이제 doc_proj 배치에서 정상
+    채워지는 것까지 함께 고정한다(단건 GET /{id}와 동형 — 회귀 시 재발 방지)."""
     from app.routers import gates as gates_mod
     from app.routers.gates import list_gates
 
@@ -584,4 +588,4 @@ async def test_list_gates_regression_doc_enrich_unaffected_by_project_id_field()
                                assigned_to_me=False, session=session, org_id=org, auth=auth)
 
     assert out[0].work_item_summary.title == "설계 문서"
-    assert out[0].project_id is None  # list는 project_id 를 채우지 않는다(GET /{id} 전용 enrich)
+    assert out[0].project_id == pid  # ⭐근본수정 본체 — doc_proj 배치가 응답 필드까지 흘러간다

--- a/backend/tests/test_gate_inbox_doc_enrich.py
+++ b/backend/tests/test_gate_inbox_doc_enrich.py
@@ -57,14 +57,25 @@ async def test_doc_gate_enriched_with_title_slug():
 
 @pytest.mark.anyio
 async def test_non_doc_gate_no_enrich_no_extra_query():
-    """비-doc gate 는 enrich 0(work_item_summary None)·doc 쿼리 미발생(N+1 0)·can_approve enrich skip."""
-    org = uuid.uuid4()
+    """비-doc gate 는 work_item_summary enrich 0·doc 쿼리 미발생(N+1 0)·can_approve enrich skip(비휴먼/
+    resolve 실패 caller).
+
+    ⚠️2026-07-31 수정(오르테가 라이브 실측 — GET /api/v2/gates pending 37/37 project_id=None):
+    story/task/artifact project_id 배치 조회는 이제 caller 타입과 무관하게 항상 돈다(project_id는
+    authz 판정이 아니라 데이터 정합성이라 caller 의존이면 결함). 그래서 이 케이스도 session.execute
+    호출이 1(gates)→2(gates+story 배치)로 늘었다 —
+    "쿼리가 아예 안 남"이 아니라 "doc 전용 쿼리·can_approve 판정 쿼리가 안 남"으로 좁혀 재확認한다."""
+    org, story_id, pid = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
     gates_res = MagicMock()
-    gates_res.scalars.return_value.all.return_value = [_gate(org, uuid.uuid4(), "story")]
+    gates_res.scalars.return_value.all.return_value = [_gate(org, story_id, "story")]
+    story_batch_res = MagicMock()
+    story_batch_res.all.return_value = [(story_id, pid)]
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[gates_res])
+    session.execute = AsyncMock(side_effect=[gates_res, story_batch_res])
     with patch.object(gates_mod, "get_org_posture", AsyncMock(return_value=None)):
         out = await list_gates(work_item_id=None, work_item_type=None, status=None,
                                assigned_to_me=False, session=session, org_id=org, auth=None)
     assert out[0].work_item_summary is None
-    assert session.execute.await_count == 1  # gates 쿼리만(doc/can_approve enrich 쿼리 0·posture는 mocked)
+    assert out[0].can_approve is False  # 비휴먼/resolve 실패 caller — authz enrich 는 여전히 skip
+    assert out[0].project_id == pid  # ⭐데이터 enrich 는 caller 무관 — 근본수정 본체
+    assert session.execute.await_count == 2  # gates + story project_id 배치(doc 쿼리·posture 는 mocked)

--- a/backend/tests/test_gate_list_project_id_enrich_realdb.py
+++ b/backend/tests/test_gate_list_project_id_enrich_realdb.py
@@ -115,7 +115,7 @@ async def test_list_and_single_gate_agree_on_project_id():
 
         async with Session() as s:
             listed = await list_gates(
-                work_item_id=None, work_item_type=None, status=None, assigned_to_me=False,
+                work_item_id=None, work_item_type=None, status=None, sort=None, assigned_to_me=False,
                 session=s, org_id=ORG, auth=_auth_human(OWNER_USER),
             )
         list_item = next(g for g in listed if g.id == gate_id)
@@ -147,7 +147,7 @@ async def test_list_gates_project_id_populated_for_agent_caller():
 
         async with Session() as s:
             listed = await list_gates(
-                work_item_id=None, work_item_type=None, status=None, assigned_to_me=False,
+                work_item_id=None, work_item_type=None, status=None, sort=None, assigned_to_me=False,
                 session=s, org_id=ORG, auth=_auth_agent(AGENT_TM),
             )
         list_item = next(g for g in listed if g.id == gate_id)

--- a/backend/tests/test_gate_list_project_id_enrich_realdb.py
+++ b/backend/tests/test_gate_list_project_id_enrich_realdb.py
@@ -64,11 +64,17 @@ async def _engine():
 
 async def _seed(s) -> uuid.UUID:
     """ORG · PROJ(project_id 있음) · STORY(project_id=PROJ) · human owner(project_access) ·
-    agent team_member · merge 게이트 1건(work_item_type=story). gate_id 반환."""
+    agent team_member · merge 게이트 1건(work_item_type=story). gate_id 반환.
+
+    ⚠️team_members는 실 배포 스키마에서 members ⋈ project_access UNION 뷰라 직접 INSERT/
+    DELETE 불가(CI 실측: ObjectNotInPrerequisiteStateError — cannot delete from view). 로컬
+    create_all은 이 모델을 실 테이블로 지어 조용히 통과했었다(로컬 초록≠CI). 실 base 테이블인
+    members + project_access(member_id 경유)에 심으면 뷰가 자연히 반영한다 — test_2215_report_
+    done_owner_floor_agent_id_realdb.py `_seed_agent_with_grant`와 동일 관례."""
     for sql in [
         f"DELETE FROM gate WHERE org_id='{ORG}'",
-        f"DELETE FROM team_members WHERE org_id='{ORG}'",
         f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
         f"DELETE FROM org_members WHERE org_id='{ORG}'",
         f"DELETE FROM stories WHERE org_id='{ORG}'",
         f"DELETE FROM projects WHERE org_id='{ORG}'",
@@ -85,12 +91,12 @@ async def _seed(s) -> uuid.UUID:
         f"(gen_random_uuid(),'{PROJ}','{OWNER_OM}','granted','owner')",
         f"INSERT INTO stories (id,org_id,project_id,title,status,priority) VALUES "
         f"('{STORY}','{ORG}','{PROJ}','S','backlog','medium')",
+        f"INSERT INTO members (id,org_id,type,name,is_active) VALUES "
+        f"('{AGENT_TM}','{ORG}','agent','에이전트',true)",
+        f"INSERT INTO project_access (id,project_id,member_id,permission) VALUES "
+        f"(gen_random_uuid(),'{PROJ}','{AGENT_TM}','granted')",
     ]:
         await s.execute(text(sql))
-    from app.models.team import TeamMember
-    s.add(TeamMember(
-        id=AGENT_TM, org_id=ORG, project_id=PROJ, type="agent", name="에이전트", role="member",
-    ))
     from app.models.gate import Gate
     gate = Gate(
         id=uuid.uuid4(), org_id=ORG, work_item_id=STORY, work_item_type="story",

--- a/backend/tests/test_gate_list_project_id_enrich_realdb.py
+++ b/backend/tests/test_gate_list_project_id_enrich_realdb.py
@@ -1,0 +1,156 @@
+"""오르테가 라이브 실측(2026-07-31, GET /api/v2/gates?status=pending 37/37 project_id=None) —
+「단건은 맞고 목록은 틀린」형제 비대칭.
+
+get_gate_endpoint(GET /{id})는 resp.project_id를 대입하는데 list_gates(GET '')는 project_id_
+by_work_item을 can_approve 판정에만 쓰고 응답 필드엔 흘려보내지 않았다(대입 자체가 없었다).
+거기에 그 배치 조회가 `resolved.type == "human"` 게이트 안에서만 돌아 agent caller는 story/
+task/artifact 케이스가 통째로 스킵되는 문제까지 겹쳐 있었다 — project_id는 authz가 아니라
+데이터 정합성이라 caller 타입에 의존하면 안 된다(오르테가 판정).
+
+이 파일은 그 두 갈래를 각각 회귀 가드로 고정한다:
+  ① 단건/목록 왕복 parity — 같은 gate가 두 엔드포인트에서 같은 project_id를 낸다.
+  ② agent caller도 project_id가 채워진다 — human-only 게이트 밖으로 뺀 것의 직접 증거.
+
+#2198/#2027과 동일 정신 — 격리 로컬 throwaway realdb만 사용(라이브 배포 시스템 무접촉).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("d2e77100-0000-0000-0000-000000000001")
+OWNER_USER = uuid.UUID("d2e77100-0000-0000-0000-0000000000a1")
+OWNER_OM = uuid.UUID("d2e77100-0000-0000-0000-0000000000b1")
+PROJ = uuid.UUID("d2e77100-0000-0000-0000-0000000000c1")
+STORY = uuid.UUID("d2e77100-0000-0000-0000-0000000000d1")
+AGENT_TM = uuid.UUID("d2e77100-0000-0000-0000-0000000000e1")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth_human(user_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(user_id), email=None, claims={}, org_id=str(ORG))
+
+
+def _auth_agent(team_member_id: uuid.UUID):
+    """is_api_key 판정(member_resolver._resolve_member_legacy)은 claims.app_metadata.api_key_id
+    존재 여부만 본다 — 값 자체는 무의미(존재만 체크)."""
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(team_member_id), email=None,
+        claims={"app_metadata": {"api_key_id": "test-key"}}, org_id=str(ORG),
+    )
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _seed(s) -> uuid.UUID:
+    """ORG · PROJ(project_id 있음) · STORY(project_id=PROJ) · human owner(project_access) ·
+    agent team_member · merge 게이트 1건(work_item_type=story). gate_id 반환."""
+    for sql in [
+        f"DELETE FROM gate WHERE org_id='{ORG}'",
+        f"DELETE FROM team_members WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM stories WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{OWNER_USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','D2E77100','d2e77100-org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{OWNER_USER}','owner@d2e77100.test','x','Owner',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OWNER_OM}','{ORG}','{OWNER_USER}','member')",
+        f"INSERT INTO projects (id,org_id,name,slug,violation_level) VALUES "
+        f"('{PROJ}','{ORG}','P','d2e77100-proj','warn')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission,role) VALUES "
+        f"(gen_random_uuid(),'{PROJ}','{OWNER_OM}','granted','owner')",
+        f"INSERT INTO stories (id,org_id,project_id,title,status,priority) VALUES "
+        f"('{STORY}','{ORG}','{PROJ}','S','backlog','medium')",
+    ]:
+        await s.execute(text(sql))
+    from app.models.team import TeamMember
+    s.add(TeamMember(
+        id=AGENT_TM, org_id=ORG, project_id=PROJ, type="agent", name="에이전트", role="member",
+    ))
+    from app.models.gate import Gate
+    gate = Gate(
+        id=uuid.uuid4(), org_id=ORG, work_item_id=STORY, work_item_type="story",
+        gate_type="merge", status="pending", neutral_facts={},
+    )
+    s.add(gate)
+    await s.commit()
+    return gate.id
+
+
+# ───────────────────────── ① 단건/목록 project_id 왕복 parity ─────────────────────────
+
+@pytest.mark.anyio
+async def test_list_and_single_gate_agree_on_project_id():
+    """오르테가 명시 요청 — 「단건과 목록이 같은 답을 낸다」 왕복. 한쪽만 고치면 다음에
+    또 갈리므로(오늘 게이트 쪽 두 번째 형제 비대칭) 이 parity 자체를 회귀 가드로 고정."""
+    from app.routers.gates import get_gate_endpoint, list_gates
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            gate_id = await _seed(s)
+
+        async with Session() as s:
+            listed = await list_gates(
+                work_item_id=None, work_item_type=None, status=None, assigned_to_me=False,
+                session=s, org_id=ORG, auth=_auth_human(OWNER_USER),
+            )
+        list_item = next(g for g in listed if g.id == gate_id)
+
+        async with Session() as s:
+            single = await get_gate_endpoint(
+                id=gate_id, session=s, org_id=ORG, auth=_auth_human(OWNER_USER),
+            )
+
+        assert single.project_id == PROJ
+        assert list_item.project_id == PROJ
+        assert list_item.project_id == single.project_id
+    finally:
+        await eng.dispose()
+
+
+# ───────────────────────── ② agent caller도 project_id가 채워진다 ─────────────────────────
+
+@pytest.mark.anyio
+async def test_list_gates_project_id_populated_for_agent_caller():
+    """수정 前엔 story/task/artifact 배치 조회가 `resolved.type == "human"` 게이트 안에서만
+    돌아 agent caller는 이 dict가 doc_proj만 남고(story 케이스 스킵) project_id가 항상 None
+    이었다 — project_id는 authz가 아니라 데이터 정합성이라 caller 타입 의존은 결함이다."""
+    from app.routers.gates import list_gates
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            gate_id = await _seed(s)
+
+        async with Session() as s:
+            listed = await list_gates(
+                work_item_id=None, work_item_type=None, status=None, assigned_to_me=False,
+                session=s, org_id=ORG, auth=_auth_agent(AGENT_TM),
+            )
+        list_item = next(g for g in listed if g.id == gate_id)
+        assert list_item.project_id == PROJ
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## Summary
- `GET /api/v2/gates`(목록)가 `project_id`를 항상 `None`으로 응답하던 결함 수정(오르테가 라이브 실측: pending 게이트 37/37 `project_id=None`).
- 근본원인: `list_gates`가 `project_id_by_work_item`/`doc_proj`를 `can_approve` 판정에만 쓰고 응답 필드(`resp.project_id`)로 대입하는 코드가 애초에 없었음. `GET /{id}`(단건)만 이 대입이 있어 "단건은 맞고 목록은 틀린" 형제 비대칭이었음.
- 추가로: story/task/artifact project_id 배치 조회가 `resolved.type == "human"` 게이트 안에서만 돌아 agent caller는 이 배치 자체가 스킵됐음 — project_id는 authz 판정이 아니라 데이터 정합성이므로 caller 타입 의존성을 제거하고 human-only 게이트 밖으로 뺌(`can_approve`/`eligible_ids` 계산만 human-only 유지).

## Test plan
- [x] 신규 realdb 테스트(`test_gate_list_project_id_enrich_realdb.py`): 단건/목록 project_id parity + agent caller에서도 project_id 채워짐 확인. 픽스 되돌리면 둘 다 실패함을 확인(회귀 가드 유효성 검증).
- [x] 기존 테스트 2건(`test_1970_gate_single_get.py`, `test_gate_inbox_doc_enrich.py`)이 옛 버그를 "정상 동작"으로 단정하고 있어 새 계약에 맞게 갱신(project_id 채워짐 확인 + 쿼리 카운트 1→2 반영).
- [x] 관련 gate 테스트 67건 전체 통과(로컬 throwaway DB, create_all 스키마).
- [x] N+1 없음 확인 — 배치 쿼리는 기존과 동일한 IN-clause 배치 형태 그대로, human-only 게이트만 제거.

🤖 Generated with [Claude Code](https://claude.com/claude-code)