### PR TITLE
feat(reference-candidates): story#2355 — 사람이 연결을 처음 만드는 write 경로

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -803,6 +803,62 @@ async def get_story_reference_candidates(
     ]
 
 
+class DeclareNewReferenceRequest(BaseModel):
+    target_id: uuid.UUID
+    relation_kind: str | None = None
+
+
+@router.post("/{id}/reference-candidates", status_code=201)
+async def declare_new_story_reference_candidate(
+    id: uuid.UUID,
+    body: DeclareNewReferenceRequest,
+    repo: StoryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    """POST /api/v2/stories/{id}/reference-candidates — story #2355: 사람이 «후보가 아예
+    없던» 이 story(source) ↔ target_id(story) 연결을 처음 만든다. 기존 declare/relation-kind/
+    reject 셋 다 기존 candidate_id가 있어야만 쓰는 것과 달리, 이 엔드포인트는 그 candidate_id
+    자체를 새로 만든다(#2355 AC1). 방향은 «끈 순서» — id=source(«여기서 시작함»), target_id=
+    target(«여기로 놓음»)."""
+    story = await repo.get(id)
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+    await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
+
+    if body.target_id == id:
+        raise HTTPException(status_code=400, detail="Cannot link a story to itself")
+
+    target = (await repo.session.execute(
+        select(Story.id).where(Story.id == body.target_id, Story.org_id == repo.org_id)
+    )).scalar_one_or_none()
+    if target is None:
+        raise HTTPException(status_code=404, detail="Target story not found")
+
+    from app.services.reference_semantic_candidates import (
+        InvalidPortRelationKindError,
+        declare_new_candidate,
+    )
+
+    actor_id = await _resolve_team_member_id(auth, repo.org_id, repo.session)
+    try:
+        candidate = await declare_new_candidate(
+            repo.session, org_id=repo.org_id, source_type="story", source_field="body",
+            source_id=id, target_type="story", target_id=body.target_id,
+            relation_kind=body.relation_kind, declared_by=actor_id,
+        )
+    except InvalidPortRelationKindError:
+        raise HTTPException(status_code=400, detail="Invalid relation_kind")
+    await repo.session.commit()
+    return {
+        "id": str(candidate.id),
+        "target_id": str(candidate.target_id),
+        "relation_kind": candidate.relation_kind,
+        "status": candidate.status,
+        "declared_by": str(candidate.declared_by) if candidate.declared_by else None,
+        "declared_at": candidate.declared_at.isoformat() if candidate.declared_at else None,
+    }
+
+
 @router.post("/{id}/reference-candidates/{candidate_id}/declare")
 async def declare_story_reference_candidate(
     id: uuid.UUID,
@@ -914,6 +970,41 @@ async def reject_story_reference_candidate(
         )
     except CandidateNotFoundError:
         raise HTTPException(status_code=404, detail="Reference candidate not found")
+    await repo.session.commit()
+    return {"ok": True}
+
+
+@router.delete("/{id}/reference-candidates/{candidate_id}")
+async def undeclare_story_reference_candidate(
+    id: uuid.UUID,
+    candidate_id: uuid.UUID,
+    repo: StoryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    """DELETE .../reference-candidates/{candidate_id} — story #2355(AC8): 사람이 만든(또는
+    승격한) 연결을 지운다. ⛔`reject`와 다른 것이다 — reject는 `rejected_relations`에 기록해
+    다음 스캔에서도 영구히 거르지만, 이건 기록을 안 남긴다(실수로 지운 것을 영영 못 잇게
+    되면 안 되므로). status='declared'가 아닌 행(아직 estimated인 기계 후보)은 400 —
+    그런 행은 `reject`가 맞는 경로다."""
+    story = await repo.get(id)
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+    await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
+
+    from app.services.reference_semantic_candidates import (
+        CandidateNotDeclaredError,
+        CandidateNotFoundError,
+        undeclare_candidate,
+    )
+
+    try:
+        await undeclare_candidate(repo.session, org_id=repo.org_id, candidate_id=candidate_id)
+    except CandidateNotFoundError:
+        raise HTTPException(status_code=404, detail="Reference candidate not found")
+    except CandidateNotDeclaredError:
+        raise HTTPException(
+            status_code=400, detail="Only a declared reference can be removed this way; use reject",
+        )
     await repo.session.commit()
     return {"ok": True}
 

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -812,6 +812,7 @@ class DeclareNewReferenceRequest(BaseModel):
 async def declare_new_story_reference_candidate(
     id: uuid.UUID,
     body: DeclareNewReferenceRequest,
+    response: Response,
     repo: StoryRepository = Depends(_get_repo),
     auth: AuthContext = Depends(get_current_user),
 ) -> dict:
@@ -819,7 +820,13 @@ async def declare_new_story_reference_candidate(
     없던» 이 story(source) ↔ target_id(story) 연결을 처음 만든다. 기존 declare/relation-kind/
     reject 셋 다 기존 candidate_id가 있어야만 쓰는 것과 달리, 이 엔드포인트는 그 candidate_id
     자체를 새로 만든다(#2355 AC1). 방향은 «끈 순서» — id=source(«여기서 시작함»), target_id=
-    target(«여기로 놓음»)."""
+    target(«여기로 놓음»).
+
+    ⛔오르테가 지적(2026-07-31): 이미 declared인 쌍에 재호출하면 ON CONFLICT WHERE가 거짓이라
+    실제로는 아무것도 안 바뀌는데, 응답이 늘 201·"바뀐 값처럼" 보이면 호출자가 조용히
+    오독한다 — 409는 안 쓴다(이미 이어진 것은 오류가 아니다). 대신 `created`로 명시 구별하고
+    (no-op이면 200으로 status_code도 함께 낮춘다), 부르는 쪽이 "이미 있었다"를 코드로
+    구별할 수 있게 한다."""
     story = await repo.get(id)
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")
@@ -841,7 +848,7 @@ async def declare_new_story_reference_candidate(
 
     actor_id = await _resolve_team_member_id(auth, repo.org_id, repo.session)
     try:
-        candidate = await declare_new_candidate(
+        outcome = await declare_new_candidate(
             repo.session, org_id=repo.org_id, source_type="story", source_field="body",
             source_id=id, target_type="story", target_id=body.target_id,
             relation_kind=body.relation_kind, declared_by=actor_id,
@@ -849,6 +856,9 @@ async def declare_new_story_reference_candidate(
     except InvalidPortRelationKindError:
         raise HTTPException(status_code=400, detail="Invalid relation_kind")
     await repo.session.commit()
+    candidate = outcome.candidate
+    if not outcome.created:
+        response.status_code = 200
     return {
         "id": str(candidate.id),
         "target_id": str(candidate.target_id),
@@ -856,6 +866,7 @@ async def declare_new_story_reference_candidate(
         "status": candidate.status,
         "declared_by": str(candidate.declared_by) if candidate.declared_by else None,
         "declared_at": candidate.declared_at.isoformat() if candidate.declared_at else None,
+        "created": outcome.created,
     }
 
 

--- a/backend/app/services/reference_semantic_candidates.py
+++ b/backend/app/services/reference_semantic_candidates.py
@@ -431,11 +431,23 @@ class CandidateNotDeclaredError(Exception):
 PORT_RELATION_KINDS = frozenset({"spawned", "followed", "superseded"})
 
 
+@dataclass(frozen=True)
+class DeclareNewResult:
+    """`declare_new_candidate`의 반환값 — candidate와 함께 «이번 호출이 실제로 뭔가를
+    바꿨는가»를 명시로 들고 간다(오르테가 지적, 2026-07-31: WHERE 가 거짓이라 no-op일 때도
+    호출자가 이걸 모르면 "바뀌었다"로 조용히 오독한다 — 오늘 종일 잡은 «조용히 깨지는 자리»
+    부류를 새로 심지 않는다). `created=True`는 신규 삽입이거나 이번 호출에서 estimated→
+    declared로 승격된 경우, `created=False`는 이미 declared라 아무것도 안 바뀐 경우다."""
+
+    candidate: ReferenceSemanticCandidate
+    created: bool
+
+
 async def declare_new_candidate(
     db: AsyncSession, *, org_id: uuid.UUID, source_type: str, source_field: str,
     source_id: uuid.UUID, target_type: str, target_id: uuid.UUID,
     relation_kind: str | None, declared_by: uuid.UUID,
-) -> ReferenceSemanticCandidate:
+) -> DeclareNewResult:
     """story #2355 — 사람이 «후보가 아예 없던» source↔target 쌍을 처음 잇는 write 경로.
     `store_semantic_candidates`(기계 write-path)의 형제 함수 — 같은 자연키(source_type/
     source_field/source_id/target_type/target_id/form)를 쓰지만, status='declared'를
@@ -449,6 +461,11 @@ async def declare_new_candidate(
     추정보다 우선), 안 주면(None) 기존 값을 그대로 둔다(COALESCE) — declare와 relation-kind가
     "다른 질문"이라는 계약은 신규 행 생성 축에서는 적용되지 않는다(이 호출 자체가 이미 둘을
     함께 받는 새 계약이므로 모순 없음).
+
+    ⛔이미 declared인 행에 재호출하면 WHERE가 거짓이라 UPDATE 자체가 no-op이다 — 그 사실을
+    호출자가 구별할 수 있도록 `RETURNING`으로 «이번 문장이 실제로 그 행을 건드렸는가»를
+    관측해 `DeclareNewResult.created`에 싣는다(오르테가 지적 — 409는 안 쓴다: 이미 이어진
+    것은 오류가 아니다).
 
     ⛔relation_kind는 PORT_RELATION_KINDS(3종)만 허용 — 그 외 값은 InvalidPortRelationKindError."""
     if relation_kind is not None and relation_kind not in PORT_RELATION_KINDS:
@@ -474,8 +491,9 @@ async def declare_new_candidate(
             ),
         },
         where=(ReferenceSemanticCandidate.status == "estimated"),
-    )
-    await db.execute(stmt)
+    ).returning(ReferenceSemanticCandidate.id)
+    write_result = await db.execute(stmt)
+    created = write_result.first() is not None
     result = await db.execute(
         select(ReferenceSemanticCandidate).where(
             ReferenceSemanticCandidate.org_id == org_id,
@@ -487,7 +505,7 @@ async def declare_new_candidate(
             ReferenceSemanticCandidate.form == "mention",
         )
     )
-    return result.scalar_one()
+    return DeclareNewResult(candidate=result.scalar_one(), created=created)
 
 
 async def undeclare_candidate(

--- a/backend/app/services/reference_semantic_candidates.py
+++ b/backend/app/services/reference_semantic_candidates.py
@@ -24,7 +24,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -412,6 +412,107 @@ async def set_candidate_relation_kind(
         raise CandidateNotFoundError()
     candidate.relation_kind = relation_kind
     return candidate
+
+
+class InvalidPortRelationKindError(Exception):
+    pass
+
+
+class CandidateNotDeclaredError(Exception):
+    pass
+
+
+# story #2355(AC4) — 사람이 「연결 만들기」로 지정할 수 있는 relation_kind는 FE 포트가 실제로
+# 그리는 3종뿐이다. DB CHECK(RELATION_KINDS, app/models/reference_semantic_candidate.py)는
+# 6종 전부를 허용하지만, 나머지 3종(cited_as_evidence·similar_case·explicitly_unrelated)은
+# `derive-flow-map.ts`가 렌더링 축에서 의도적으로 드롭한다(오르테가 실측, 2026-07-31) —
+# 저장은 되나 화면엔 «안 그려지는» 값이라, 이 write 경로에서 만들 수 있게 두면 안 된다.
+# ⛔나열 안 된 값을 조용히 통과시키지 않는다 — 명시 400(오르테가 지시).
+PORT_RELATION_KINDS = frozenset({"spawned", "followed", "superseded"})
+
+
+async def declare_new_candidate(
+    db: AsyncSession, *, org_id: uuid.UUID, source_type: str, source_field: str,
+    source_id: uuid.UUID, target_type: str, target_id: uuid.UUID,
+    relation_kind: str | None, declared_by: uuid.UUID,
+) -> ReferenceSemanticCandidate:
+    """story #2355 — 사람이 «후보가 아예 없던» source↔target 쌍을 처음 잇는 write 경로.
+    `store_semantic_candidates`(기계 write-path)의 형제 함수 — 같은 자연키(source_type/
+    source_field/source_id/target_type/target_id/form)를 쓰지만, status='declared'를
+    **생성 시점에 바로** 채운다(estimated 경유 없음).
+
+    AC6(역방향) — 같은 자연키에 이미 estimated 행이 있으면 중복 행을 만들지 않고 그 행을
+    declared로 승격한다(ON CONFLICT DO UPDATE, WHERE status='estimated' — 이미 declared인
+    행은 건드리지 않는다: 재호출은 멱등이고, 원래 선언자의 declared_by/declared_at·AC3의
+    "누가·언제 만들었는가" 서명이 재호출로 지워지지 않는다). 승격 시 relation_kind는 이번
+    호출이 명시로 준 값이 있으면 그 값으로 덮어쓰고(사람이 지금 막 고른 종류가 과거 기계
+    추정보다 우선), 안 주면(None) 기존 값을 그대로 둔다(COALESCE) — declare와 relation-kind가
+    "다른 질문"이라는 계약은 신규 행 생성 축에서는 적용되지 않는다(이 호출 자체가 이미 둘을
+    함께 받는 새 계약이므로 모순 없음).
+
+    ⛔relation_kind는 PORT_RELATION_KINDS(3종)만 허용 — 그 외 값은 InvalidPortRelationKindError."""
+    if relation_kind is not None and relation_kind not in PORT_RELATION_KINDS:
+        raise InvalidPortRelationKindError(relation_kind)
+
+    now = datetime.now(UTC)
+    stmt = pg_insert(ReferenceSemanticCandidate).values(
+        id=uuid.uuid4(), org_id=org_id, source_type=source_type, source_field=source_field,
+        source_id=source_id, target_type=target_type, target_id=target_id, form="mention",
+        relation_kind=relation_kind, matched_keyword=None, snippet="",
+        status="declared", declared_by=declared_by, declared_at=now,
+    )
+    stmt = stmt.on_conflict_do_update(
+        index_elements=[
+            "source_type", "source_field", "source_id", "target_type", "target_id", "form",
+        ],
+        set_={
+            "status": "declared",
+            "declared_by": declared_by,
+            "declared_at": now,
+            "relation_kind": func.coalesce(
+                stmt.excluded.relation_kind, ReferenceSemanticCandidate.relation_kind,
+            ),
+        },
+        where=(ReferenceSemanticCandidate.status == "estimated"),
+    )
+    await db.execute(stmt)
+    result = await db.execute(
+        select(ReferenceSemanticCandidate).where(
+            ReferenceSemanticCandidate.org_id == org_id,
+            ReferenceSemanticCandidate.source_type == source_type,
+            ReferenceSemanticCandidate.source_field == source_field,
+            ReferenceSemanticCandidate.source_id == source_id,
+            ReferenceSemanticCandidate.target_type == target_type,
+            ReferenceSemanticCandidate.target_id == target_id,
+            ReferenceSemanticCandidate.form == "mention",
+        )
+    )
+    return result.scalar_one()
+
+
+async def undeclare_candidate(
+    db: AsyncSession, *, org_id: uuid.UUID, candidate_id: uuid.UUID,
+) -> None:
+    """story #2355(AC8) — 사람이 만든(또는 승격한) 연결을 지운다. ⛔`reject_candidate`와
+    다르다 — reject는 `rejected_relations`에 쌍을 기록해 다음 스캔에서도 영구히 거르지만,
+    이 함수는 아무 기록도 남기지 않는다(사람이 실수로 만든 것을 무르는 것이지, 기계 후보를
+    영구 기각하는 것이 아니다 — 기록을 남기면 「실수로 지웠는데 영영 다시 못 잇는」 것이 된다).
+
+    ⛔status='declared'가 아닌 행(아직 estimated인 기계 후보)은 지울 수 없다 —
+    CandidateNotDeclaredError. 그런 행을 지우고 싶으면 `reject_candidate`가 맞는 경로다(이
+    함수와 목적이 다르다: 그 표를 다음 스캔에서도 걸러야 하므로)."""
+    result = await db.execute(
+        select(ReferenceSemanticCandidate).where(
+            ReferenceSemanticCandidate.org_id == org_id,
+            ReferenceSemanticCandidate.id == candidate_id,
+        )
+    )
+    candidate = result.scalar_one_or_none()
+    if candidate is None:
+        raise CandidateNotFoundError()
+    if candidate.status != "declared":
+        raise CandidateNotDeclaredError()
+    await db.delete(candidate)
 
 
 class RejectedRelationNotFoundError(Exception):

--- a/backend/tests/test_2355_declare_new_reference_candidate_realdb.py
+++ b/backend/tests/test_2355_declare_new_reference_candidate_realdb.py
@@ -90,6 +90,7 @@ async def test_declare_new_creates_declared_row_directly():
             assert body["status"] == "declared"
             assert body["declared_by"] is not None
             assert body["declared_at"] is not None
+            assert body["created"] is True
 
             async with Session() as s:
                 row = await _candidate_row(s, org.id, source.id, target.id)
@@ -294,6 +295,7 @@ async def test_declare_new_on_existing_estimated_pair_promotes_not_duplicates():
             assert resp.status_code == 201, resp.text
             assert resp.json()["id"] == str(pre_id), "새 행이 만들어졌다 — 승격이 아니라 중복"
             assert resp.json()["status"] == "declared"
+            assert resp.json()["created"] is True, "승격도 «바뀜»이니 created=True여야 한다"
             # 사람이 이번 호출에서 명시로 준 relation_kind가 과거 기계 추정을 덮는다.
             assert resp.json()["relation_kind"] == "followed"
 
@@ -314,7 +316,11 @@ async def test_declare_new_on_existing_estimated_pair_promotes_not_duplicates():
 
 async def test_declare_new_is_idempotent_and_does_not_clobber_original_signer():
     """이미 declared된 행에 재호출해도 원래 declared_by/declared_at(사람 서명, AC3)가
-    지워지지 않는다 — WHERE status='estimated' 가드가 이미 declared인 행은 건드리지 않는다."""
+    지워지지 않는다 — WHERE status='estimated' 가드가 이미 declared인 행은 건드리지 않는다.
+
+    오르테가 지적(2026-07-31) — no-op을 조용히 201로 응답하면 호출자가 「바뀌었다」로
+    오독한다. 응답 status_code(200)와 `created:false` 둘 다로 이번 호출이 아무것도 안
+    바꿨음을 드러낸다(409 아님 — 이미 이어진 것은 오류가 아니다)."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -334,14 +340,16 @@ async def test_declare_new_is_idempotent_and_does_not_clobber_original_signer():
                 json={"target_id": str(target.id), "relation_kind": "spawned"},
             )
             assert first.status_code == 201, first.text
+            assert first.json()["created"] is True
             first_declared_at = first.json()["declared_at"]
 
             second = await client.post(
                 f"/api/v2/stories/{source.id}/reference-candidates",
                 json={"target_id": str(target.id), "relation_kind": "followed"},
             )
-            assert second.status_code == 201, second.text
             # WHERE status='estimated' 가드 — 이미 declared라 두 번째 호출은 no-op(원본 유지).
+            assert second.status_code == 200, second.text
+            assert second.json()["created"] is False
             assert second.json()["declared_at"] == first_declared_at
             assert second.json()["relation_kind"] == "spawned"
         finally:

--- a/backend/tests/test_2355_declare_new_reference_candidate_realdb.py
+++ b/backend/tests/test_2355_declare_new_reference_candidate_realdb.py
@@ -1,0 +1,665 @@
+"""story #2355(오르테가 판정 2026-07-31, 스레드 7256d5cc) — 사람이 «후보가 아예 없던»
+story↔story 연결을 처음 만드는 write 경로. 기존 declare/relation-kind/reject 셋 다 기존
+candidate_id가 있어야만 쓴다(디디 코드 직독) — 이 스토리가 그 candidate_id 자체를 새로
+만드는 경로를 연다.
+
+⛔`entity_references`가 아니라 후보 표(`reference_semantic_candidates`)에 `status='declared'`
+행을 바로 넣는다(디디 판정·PO 확定, AC7 — entity_references의 relation CHECK는 ('none',
+'created_from')뿐이라 spawned/followed/superseded를 구조적으로 못 받는다).
+
+AC 번호는 story #2355 본문 그대로 대응한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from tests.test_2301_story_body_mentions_realdb import (
+    _REAL_DB_URL,
+    _client_for,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _make_story,
+    _session_factory,
+    _setup_app_human,
+)
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _candidate_row(session, org_id, source_id, target_id):
+    from sqlalchemy import select
+    from app.models.reference_semantic_candidate import ReferenceSemanticCandidate as RSC
+    return (await session.execute(
+        select(RSC).where(
+            RSC.org_id == org_id, RSC.source_type == "story", RSC.source_id == source_id,
+            RSC.target_type == "story", RSC.target_id == target_id,
+        )
+    )).scalar_one_or_none()
+
+
+async def _make_goal(session, org_id, project_id, title="Epic"):
+    from app.models.pm import Goal
+    goal = Goal(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(goal)
+    await session.commit()
+    return goal
+
+
+# ─── AC1/AC2: 새 연결이 estimated 경유 없이 바로 declared로 생긴다 ───────────
+
+async def test_declare_new_creates_declared_row_directly():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            source = await _make_story(s, org.id, project.id, title="Source")
+            target = await _make_story(s, org.id, project.id, title="Target")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{source.id}/reference-candidates",
+                json={"target_id": str(target.id)},
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["status"] == "declared"
+            assert body["declared_by"] is not None
+            assert body["declared_at"] is not None
+
+            async with Session() as s:
+                row = await _candidate_row(s, org.id, source.id, target.id)
+                assert row is not None
+                assert row.status == "declared"
+                assert row.declared_by == caller_id
+                assert row.declared_at is not None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── AC3: relation_kind 비운 채로 만들 수 있고, 그 뒤 relation-kind 엔드포인트로 채울 수 있다 ───
+
+async def test_declare_new_without_relation_kind_then_set_it_later():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            source = await _make_story(s, org.id, project.id, title="Source")
+            target = await _make_story(s, org.id, project.id, title="Target")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{source.id}/reference-candidates",
+                json={"target_id": str(target.id)},
+            )
+            assert resp.status_code == 201, resp.text
+            assert resp.json()["relation_kind"] is None
+            candidate_id = resp.json()["id"]
+
+            resp2 = await client.post(
+                f"/api/v2/stories/{source.id}/reference-candidates/{candidate_id}/relation-kind",
+                json={"relation_kind": "followed"},
+            )
+            assert resp2.status_code == 200, resp2.text
+            assert resp2.json()["relation_kind"] == "followed"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── AC4: 포트가 쓰는 3종은 허용, 나머지 3종(+미지정 값)은 400 ───────────────
+
+@pytest.mark.parametrize("relation_kind", ["spawned", "followed", "superseded"])
+async def test_declare_new_accepts_port_relation_kinds(relation_kind):
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            source = await _make_story(s, org.id, project.id, title="Source")
+            target = await _make_story(s, org.id, project.id, title="Target")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{source.id}/reference-candidates",
+                json={"target_id": str(target.id), "relation_kind": relation_kind},
+            )
+            assert resp.status_code == 201, resp.text
+            assert resp.json()["relation_kind"] == relation_kind
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.parametrize("relation_kind", ["cited_as_evidence", "similar_case", "explicitly_unrelated", "bogus"])
+async def test_declare_new_rejects_non_port_relation_kinds(relation_kind):
+    """⛔나열 안 된 값을 조용히 통과시키지 않는다(오르테가 지시) — CHECK가 6종을 허용해도
+    이 write 경로는 FE 포트가 실제로 그리는 3종만 명시로 받는다. 저장은 되나 안 그려지는
+    값(cited_as_evidence·similar_case·explicitly_unrelated)과 완전 미지정 값(bogus) 모두
+    이 경로에서는 거부돼야 한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            source = await _make_story(s, org.id, project.id, title="Source")
+            target = await _make_story(s, org.id, project.id, title="Target")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{source.id}/reference-candidates",
+                json={"target_id": str(target.id), "relation_kind": relation_kind},
+            )
+            assert resp.status_code == 400, resp.text
+
+            async with Session() as s:
+                row = await _candidate_row(s, org.id, source.id, target.id)
+                assert row is None, "거부된 요청이 행을 남겼다"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── AC5: 기계 스캔이 나중에 같은 쌍을 estimated로 던져도 declared 행을 안 건드린다 ───
+
+async def test_declared_row_survives_later_machine_rescan_of_same_pair():
+    from app.main import app
+    from app.services.reference_semantic_candidates import CandidateRow, store_semantic_candidates
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            source = await _make_story(s, org.id, project.id, title="Source")
+            target = await _make_story(s, org.id, project.id, title="Target")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{source.id}/reference-candidates",
+                json={"target_id": str(target.id), "relation_kind": "spawned"},
+            )
+            assert resp.status_code == 201, resp.text
+            declared_at_first = resp.json()["declared_at"]
+        finally:
+            await client.aclose()
+
+        # 기계 재스캔 시뮬레이션 — 같은 자연키로 estimated 재저장을 시도(ON CONFLICT DO NOTHING).
+        async with Session() as s:
+            n = await store_semantic_candidates(
+                s, org_id=org.id, source_type="story", source_field="body", source_id=source.id,
+                rows=[CandidateRow(
+                    matched_number=0, target_story_id=target.id, snippet="rescan",
+                    relation_kind="similar_case", matched_keyword="같은 계열",
+                )],
+            )
+            await s.commit()
+            assert n == 0, "기계 재스캔이 declared 행을 조용히 건드렸다(rowcount != 0)"
+
+            row = await _candidate_row(s, org.id, source.id, target.id)
+            assert row.status == "declared"
+            assert row.relation_kind == "spawned"
+            assert row.declared_at.isoformat() == declared_at_first
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── AC6(역방향): 이미 estimated 행이 있는 쌍에 declare-new → 승격(중복 행 0) ───
+
+async def test_declare_new_on_existing_estimated_pair_promotes_not_duplicates():
+    from app.main import app
+    from app.services.reference_semantic_candidates import CandidateRow, store_semantic_candidates
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            source = await _make_story(s, org.id, project.id, title="Source")
+            target = await _make_story(s, org.id, project.id, title="Target")
+
+            await store_semantic_candidates(
+                s, org_id=org.id, source_type="story", source_field="body", source_id=source.id,
+                rows=[CandidateRow(
+                    matched_number=0, target_story_id=target.id, snippet="machine guess",
+                    relation_kind="similar_case", matched_keyword="같은 계열",
+                )],
+            )
+            await s.commit()
+            pre = await _candidate_row(s, org.id, source.id, target.id)
+            assert pre.status == "estimated"
+            pre_id = pre.id
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{source.id}/reference-candidates",
+                json={"target_id": str(target.id), "relation_kind": "followed"},
+            )
+            assert resp.status_code == 201, resp.text
+            assert resp.json()["id"] == str(pre_id), "새 행이 만들어졌다 — 승격이 아니라 중복"
+            assert resp.json()["status"] == "declared"
+            # 사람이 이번 호출에서 명시로 준 relation_kind가 과거 기계 추정을 덮는다.
+            assert resp.json()["relation_kind"] == "followed"
+
+            async with Session() as s:
+                from sqlalchemy import select
+                from app.models.reference_semantic_candidate import ReferenceSemanticCandidate as RSC
+                rows = (await s.execute(select(RSC).where(
+                    RSC.org_id == org.id, RSC.source_id == source.id, RSC.target_id == target.id,
+                ))).scalars().all()
+                assert len(rows) == 1, f"중복 행 생성: {len(rows)}건"
+                assert rows[0].status == "declared"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_declare_new_is_idempotent_and_does_not_clobber_original_signer():
+    """이미 declared된 행에 재호출해도 원래 declared_by/declared_at(사람 서명, AC3)가
+    지워지지 않는다 — WHERE status='estimated' 가드가 이미 declared인 행은 건드리지 않는다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            source = await _make_story(s, org.id, project.id, title="Source")
+            target = await _make_story(s, org.id, project.id, title="Target")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            first = await client.post(
+                f"/api/v2/stories/{source.id}/reference-candidates",
+                json={"target_id": str(target.id), "relation_kind": "spawned"},
+            )
+            assert first.status_code == 201, first.text
+            first_declared_at = first.json()["declared_at"]
+
+            second = await client.post(
+                f"/api/v2/stories/{source.id}/reference-candidates",
+                json={"target_id": str(target.id), "relation_kind": "followed"},
+            )
+            assert second.status_code == 201, second.text
+            # WHERE status='estimated' 가드 — 이미 declared라 두 번째 호출은 no-op(원본 유지).
+            assert second.json()["declared_at"] == first_declared_at
+            assert second.json()["relation_kind"] == "spawned"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── AC7: entity_references에는 아무것도 안 쓴다 ────────────────────────────
+
+async def test_declare_new_writes_nothing_to_entity_references():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            source = await _make_story(s, org.id, project.id, title="Source")
+            target = await _make_story(s, org.id, project.id, title="Target")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{source.id}/reference-candidates",
+                json={"target_id": str(target.id), "relation_kind": "spawned"},
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.reference import Reference
+            rows = (await s.execute(select(Reference).where(
+                Reference.org_id == org.id, Reference.source_id == source.id,
+                Reference.target_id == target.id,
+            ))).scalars().all()
+            assert rows == [], "entity_references에 행이 생겼다 — 구조적으로 막혀야 하는 표"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── AC8: 지우기(undeclare)는 reject와 다르다 — rejected_relations에 기록 안 남음 ───
+
+async def test_undeclare_removes_row_without_recording_rejection():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            source = await _make_story(s, org.id, project.id, title="Source")
+            target = await _make_story(s, org.id, project.id, title="Target")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            create = await client.post(
+                f"/api/v2/stories/{source.id}/reference-candidates",
+                json={"target_id": str(target.id)},
+            )
+            candidate_id = create.json()["id"]
+
+            delete = await client.delete(
+                f"/api/v2/stories/{source.id}/reference-candidates/{candidate_id}",
+            )
+            assert delete.status_code == 200, delete.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            row = await _candidate_row(s, org.id, source.id, target.id)
+            assert row is None, "지웠는데 행이 남아 있다"
+
+            from sqlalchemy import select
+            from app.models.rejected_relation import RejectedRelation
+            rejections = (await s.execute(select(RejectedRelation).where(
+                RejectedRelation.org_id == org.id, RejectedRelation.source_id == source.id,
+                RejectedRelation.target_id == target.id,
+            ))).scalars().all()
+            assert rejections == [], "지우기가 reject처럼 rejected_relations에 기록을 남겼다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_undeclare_refuses_estimated_row():
+    """아직 estimated인(사람이 declare한 적 없는) 행은 이 경로로 못 지운다 — reject가 맞는
+    경로다(다음 스캔에서도 걸러야 하므로)."""
+    from app.main import app
+    from app.services.reference_semantic_candidates import CandidateRow, store_semantic_candidates
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            source = await _make_story(s, org.id, project.id, title="Source")
+            target = await _make_story(s, org.id, project.id, title="Target")
+
+            await store_semantic_candidates(
+                s, org_id=org.id, source_type="story", source_field="body", source_id=source.id,
+                rows=[CandidateRow(
+                    matched_number=0, target_story_id=target.id, snippet="s",
+                    relation_kind=None, matched_keyword=None,
+                )],
+            )
+            await s.commit()
+            candidate = await _candidate_row(s, org.id, source.id, target.id)
+            candidate_id = candidate.id
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(
+                f"/api/v2/stories/{source.id}/reference-candidates/{candidate_id}",
+            )
+            assert resp.status_code == 400, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            row = await _candidate_row(s, org.id, source.id, target.id)
+            assert row is not None, "400 응답인데 행이 지워졌다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── AC9: source project 접근권 — cross-project는 404 ──────────────────────
+
+async def test_declare_new_cross_project_is_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project_a = await _make_project(s, org.id, name="A")
+            project_b = await _make_project(s, org.id, name="B")
+            # caller는 project_b에만 접근권이 있다.
+            _, caller_user_id = await _make_human_member(s, org.id, project_b.id)
+            source = await _make_story(s, org.id, project_a.id, title="Source")  # project_a
+            target = await _make_story(s, org.id, project_a.id, title="Target")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{source.id}/reference-candidates",
+                json={"target_id": str(target.id)},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_declare_new_self_link_is_400():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, caller_user_id = await _make_human_member(s, org.id, project.id)
+            source = await _make_story(s, org.id, project.id, title="Source")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{source.id}/reference-candidates",
+                json={"target_id": str(source.id)},
+            )
+            assert resp.status_code == 400, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_declare_new_target_not_found_is_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, caller_user_id = await _make_human_member(s, org.id, project.id)
+            source = await _make_story(s, org.id, project.id, title="Source")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{source.id}/reference-candidates",
+                json={"target_id": str(uuid.uuid4())},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── AC10: 라이브 왕복 — 만든 것이 GET /goals/{id}/reference-candidates에 declared로 나온다 ───
+
+async def test_write_then_read_via_goal_reference_candidates_endpoint():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, caller_user_id = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id)
+            source = await _make_story(s, org.id, project.id, title="Source")
+            target = await _make_story(s, org.id, project.id, title="Target")
+            from app.models.pm import Story
+            from sqlalchemy import update as sa_update
+            await s.execute(sa_update(Story).where(Story.id == source.id).values(epic_id=goal.id))
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            write_resp = await client.post(
+                f"/api/v2/stories/{source.id}/reference-candidates",
+                json={"target_id": str(target.id), "relation_kind": "spawned"},
+            )
+            assert write_resp.status_code == 201, write_resp.text
+
+            read_resp = await client.get(f"/api/v2/goals/{goal.id}/reference-candidates")
+            assert read_resp.status_code == 200, read_resp.text
+            rows = read_resp.json()
+            match = [r for r in rows if r["target_id"] == str(target.id)]
+            assert len(match) == 1
+            assert match[0]["status"] == "declared"
+            assert match[0]["relation_kind"] == "spawned"
+            assert match[0]["source_id"] == str(source.id)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── AC11: 회귀 — 기존 declare/relation-kind/reject 세 엔드포인트는 이 PR 전후로 같다 ───
+
+async def test_existing_declare_relation_kind_reject_still_work():
+    from app.main import app
+    from app.services.reference_semantic_candidates import CandidateRow, store_semantic_candidates
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, caller_user_id = await _make_human_member(s, org.id, project.id)
+            source = await _make_story(s, org.id, project.id, title="Source")
+            target1 = await _make_story(s, org.id, project.id, title="Target1")
+            target2 = await _make_story(s, org.id, project.id, title="Target2")
+
+            await store_semantic_candidates(
+                s, org_id=org.id, source_type="story", source_field="body", source_id=source.id,
+                rows=[
+                    CandidateRow(matched_number=0, target_story_id=target1.id, snippet="a",
+                                 relation_kind=None, matched_keyword=None),
+                    CandidateRow(matched_number=1, target_story_id=target2.id, snippet="b",
+                                 relation_kind=None, matched_keyword=None),
+                ],
+            )
+            await s.commit()
+            c1 = await _candidate_row(s, org.id, source.id, target1.id)
+            c2 = await _candidate_row(s, org.id, source.id, target2.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            declare_resp = await client.post(
+                f"/api/v2/stories/{source.id}/reference-candidates/{c1.id}/declare",
+            )
+            assert declare_resp.status_code == 200, declare_resp.text
+            assert declare_resp.json()["status"] == "declared"
+
+            kind_resp = await client.post(
+                f"/api/v2/stories/{source.id}/reference-candidates/{c1.id}/relation-kind",
+                json={"relation_kind": "spawned"},
+            )
+            assert kind_resp.status_code == 200, kind_resp.text
+            assert kind_resp.json()["relation_kind"] == "spawned"
+
+            reject_resp = await client.post(
+                f"/api/v2/stories/{source.id}/reference-candidates/{c2.id}/reject",
+                json={"reason": "정리"},
+            )
+            assert reject_resp.status_code == 200, reject_resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            assert (await _candidate_row(s, org.id, source.id, target2.id)) is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
story #2355 — 지금까지 `declare`/`relation-kind`/`reject` 셋 다 **기존 candidate_id가 있어야만** 쓸 수 있어(기계가 낸 후보 승인/기각뿐), 사람이 후보가 아예 없던 연결을 처음 만드는 write 경로가 제품에 0개였다(관계 후보 426건이 전부 estimated, 확인 0건인 근본 원인).

- `POST /api/v2/stories/{id}/reference-candidates` — `reference_semantic_candidates`에 `status='declared'` 행을 **estimated 경유 없이 바로** 생성. `store_semantic_candidates`(기계 write-path)의 형제 함수(`declare_new_candidate`)로 같은 자연키·같은 ON CONFLICT 불변식을 공유:
  - 같은 자연키에 이미 `estimated` 행이 있으면 **승격**(중복 행 0), 사람이 이번에 준 relation_kind가 과거 기계 추정을 덮는다.
  - 이미 `declared`면 no-op — 원래 서명(`declared_by`/`declared_at`)이 재호출로 지워지지 않는다.
  - `relation_kind`는 FE 포트가 실제로 그리는 3종(spawned/followed/superseded)만 허용 — DB CHECK는 6종이지만 나머지 3종은 `derive-flow-map.ts`가 렌더링에서 의도적으로 드롭하므로 이 경로에서 만들 수 있게 두면 안 된다(명시 400, 조용한 통과 금지).
- `DELETE /api/v2/stories/{id}/reference-candidates/{candidate_id}` — 사람이 만든 연결을 지운다. `reject`와 다르다(reject는 `rejected_relations`에 기록해 다음 스캔에서도 영구히 거른다) — 이건 기록을 안 남긴다. `status='declared'`가 아닌 행(아직 estimated)은 400.
- `entity_references`에는 쓰지 않는다 — 그 표의 `relation` CHECK는 `('none','created_from')`뿐이고 docstring이 스스로 "의미를 여기서 저장·판정하지 않는다"고 막는다(구조적으로 못 받음). 새 표도 만들지 않는다 — 후보 표에 declared로 넣으면 `derive-flow-map`이 그대로 소비해 FE 변경이 0이다.

## 알려진 한계 (오르테가 리뷰, 2026-07-31)
- **no-op 응답 구별**: 이미 `declared`인 쌍에 재호출하면 실제로는 아무것도 안 바뀐다 — `status_code`를 200으로 낮추고 본문에 `created:false`를 실어 호출자가 "이미 있었다"를 구별할 수 있게 한다(409는 안 씀 — 이미 이어진 것은 오류가 아니다).
- **`snippet`이 사람이 만든 행에서는 빈 문자열이다**: 기계가 만든 행은 `snippet`에 산문 조각이 있고, 사람이 declare-new로 만든 행은 `""`이다. 지금은 FE 소비처가 없어 급하지 않으나, 나중에 화면이 그 칸을 쓸 때 "빈 문자열=없음"인지 "빈 문자열=안 채움"인지 구별이 안 된다는 점을 남겨 둔다.

## Test plan
- [x] 신규 realdb 테스트(`test_2355_declare_new_reference_candidate_realdb.py`, 20건) — 실 HTTP(app.main.app + ASGITransport)로 라우터까지 전부 태움:
  - AC1/2: declared 직행 생성 + declared_by/declared_at
  - AC3: relation_kind 비운 채 생성 → 기존 relation-kind 엔드포인트로 왕복
  - AC4: 포트 3종 허용 / 나머지 3종+미지정값 400
  - AC5: 기계 재스캔(estimated)이 이미 declared인 행을 안 건드림(ON CONFLICT DO NOTHING 확인)
  - AC6: 기존 estimated 행에 declare-new → 승격(중복 0) + 재호출 idempotent(원 서명 보존)
  - AC7: entity_references 무기록
  - AC8: undeclare가 reject와 달리 rejected_relations에 기록 안 남김, estimated 행은 400
  - AC9: cross-project 404, self-link 400, target 미존재 404
  - AC10: write→read 왕복(`GET /goals/{id}/reference-candidates`에서 declared로 확인)
  - AC11: 기존 declare/relation-kind/reject 세 엔드포인트 무회귀
- [x] 관련 회귀 스위트(reference_semantic_candidates 계열 67건) 전부 통과
- [x] Query(None) sentinel lint / has_project_access 403 lint 둘 다 신규 위반 0건
- [x] 로컬 `alembic upgrade head`(실 마이그 스키마)로 검증 — create_all 아님

🤖 Generated with [Claude Code](https://claude.com/claude-code)
