### PR TITLE
[SID:2354] 노드를 눌러도 지도가 살아 있게 — 지도 위에 겹치는 상세 패널

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+//
+// story #2354 회귀 가드 — 「노드를 눌러도 지도가 살아 있게」의 근본(옛 handleSelectStory가
+// `view=list`를 함께 갈아 끼워 캔버스를 언마운트시켰다)이 다시 안 나는지 값으로 닫는다.
+// KanbanBoard/NextMakerScreen/FlowNodeStoryPanel은 각자 자기 테스트가 있으므로 여기선 얇은
+// 스텁으로 대체하고, flow-client.tsx 자신의 배선(URL 조립·panelOpen 로컬 상태·view별
+// 렌더 분기)만 값으로 잰다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../../../../messages/ko.json';
+
+let currentSearch = '';
+// push는 실제 next/navigation처럼 "URL이 바뀐다"까지 흉내낸다(그래야 뒤이은
+// setPanelOpen(true)로 인한 리렌더에서 useSearchParams()가 새 값을 본다) — 실제 앱에서는
+// router.push 자체가 이 반영을 일으킨다, 이 목이 그 효과만 대신한다.
+const pushMock = vi.fn((url: string) => {
+  const qIndex = url.indexOf('?');
+  currentSearch = qIndex >= 0 ? url.slice(qIndex + 1) : '';
+});
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock, replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(currentSearch),
+}));
+
+vi.mock('@/components/nav/top-bar-slot', () => ({
+  TopBarSlot: ({ title }: { title: React.ReactNode }) => <div>{title}</div>,
+}));
+
+vi.mock('@/components/kanban/kanban-board', () => ({
+  KanbanBoard: () => <div data-testid="kanban-board-stub">kanban</div>,
+}));
+
+vi.mock('@/components/glance/exception-stream', () => ({
+  ExceptionStream: () => <div data-testid="exception-stream-stub" />,
+}));
+
+vi.mock('@/components/glance/load-glance-data', () => ({
+  loadGlanceData: async () => ({ memberMap: {}, attentionSignals: [] }),
+}));
+
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => false,
+}));
+
+// NextMakerScreen 스텁 — onSelectStory 호출 버튼 + selectedNodeId를 텍스트로 노출(threading 검증용).
+vi.mock('@/components/flow/next-maker-screen', () => ({
+  NextMakerScreen: ({ onSelectStory, selectedNodeId }: { onSelectStory: (id: string) => void; selectedNodeId?: string | null }) => (
+    <div data-testid="next-maker-screen-stub">
+      <span data-testid="selected-node-id">{selectedNodeId ?? 'none'}</span>
+      <button type="button" onClick={() => onSelectStory('story-abc')}>select-node</button>
+    </div>
+  ),
+}));
+
+// FlowNodeStoryPanel 스텁 — storyId를 텍스트로 노출 + close 버튼.
+vi.mock('@/components/flow/flow-node-story-panel', () => ({
+  FlowNodeStoryPanel: ({ storyId, onClose }: { storyId: string; onClose: () => void }) => (
+    <div data-testid="flow-node-story-panel-stub">
+      <span data-testid="panel-story-id">{storyId}</span>
+      <button type="button" onClick={onClose}>close-panel</button>
+    </div>
+  ),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  currentSearch = '';
+  pushMock.mockClear();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function renderFlowClient() {
+  const { default: FlowPageClient } = await import('./flow-client');
+  await act(async () => {
+    root.render(wrap(<FlowPageClient projectId="p1" wsSlug="ws-1" projSlug="proj-1" />));
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+describe('FlowPageClient — story #2354 (노드 클릭이 지도를 안 끈다)', () => {
+  it('handleSelectStory pushes ?story=<id> WITHOUT touching view — 옛 버그(view=list 강제)가 재발하지 않는다', async () => {
+    await renderFlowClient();
+
+    const selectButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'select-node');
+    expect(selectButton).toBeTruthy();
+    await act(async () => {
+      selectButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(pushMock).toHaveBeenCalledTimes(1);
+    const pushedUrl = pushMock.mock.calls[0]?.[0] as string;
+    expect(pushedUrl).toContain('story=story-abc');
+    // 이게 이 회귀가드의 핵심 — 옛 코드는 여기서 반드시 view=list를 같이 붙였다.
+    expect(pushedUrl).not.toContain('view=');
+  });
+
+  it('clicking a node opens the overlay panel while the flow canvas stub stays mounted (캔버스가 언마운트되지 않는다)', async () => {
+    await renderFlowClient();
+    expect(container.querySelector('[data-testid="next-maker-screen-stub"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="flow-node-story-panel-stub"]')).toBeNull();
+
+    const selectButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'select-node');
+    await act(async () => {
+      selectButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    // 캔버스 스텁은 그대로 살아있다 — 클릭이 언마운트를 일으키지 않는다.
+    expect(container.querySelector('[data-testid="next-maker-screen-stub"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="flow-node-story-panel-stub"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="panel-story-id"]')?.textContent).toBe('story-abc');
+  });
+
+  it('deep link (?story=<id> already in URL) opens the panel on mount without needing a click', async () => {
+    currentSearch = 'story=story-deep';
+    await renderFlowClient();
+
+    expect(container.querySelector('[data-testid="flow-node-story-panel-stub"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="panel-story-id"]')?.textContent).toBe('story-deep');
+    // selectedNodeId도 같은 값으로 NextMakerScreen에 threading됨 — 노드 고리 강조의 재료.
+    expect(container.querySelector('[data-testid="selected-node-id"]')?.textContent).toBe('story-deep');
+  });
+
+  it('closing the panel keeps the node selected (AC6 판정선) — selectedNodeId survives close, only panel visibility toggles', async () => {
+    currentSearch = 'story=story-abc';
+    await renderFlowClient();
+    expect(container.querySelector('[data-testid="flow-node-story-panel-stub"]')).not.toBeNull();
+
+    const closeButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'close-panel');
+    await act(async () => {
+      closeButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    // 패널은 사라지지만 — URL의 story는 안 지웠으므로(닫기가 router 호출을 안 함) selectedNodeId는 그대로다.
+    expect(container.querySelector('[data-testid="flow-node-story-panel-stub"]')).toBeNull();
+    expect(container.querySelector('[data-testid="selected-node-id"]')?.textContent).toBe('story-abc');
+  });
+
+  it('view=list renders KanbanBoard and does NOT also mount the flow overlay panel (AC9 — no double panel)', async () => {
+    currentSearch = 'view=list&story=story-abc';
+    await renderFlowClient();
+
+    expect(container.querySelector('[data-testid="kanban-board-stub"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="next-maker-screen-stub"]')).toBeNull();
+    // KanbanBoard 스스로 story=를 읽어 자기 방식으로 여는 것이 기존 동작 — 여기서 또 열면 두 벌.
+    expect(container.querySelector('[data-testid="flow-node-story-panel-stub"]')).toBeNull();
+  });
+});

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
@@ -11,6 +11,7 @@ import { toExceptionQueueItems, type BeAttentionSignal, type ExceptionLabels } f
 import { loadGlanceData, type GlanceData } from '@/components/glance/load-glance-data';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { NextMakerScreen } from '@/components/flow/next-maker-screen';
+import { FlowNodeStoryPanel } from '@/components/flow/flow-node-story-panel';
 
 interface FlowPageClientProps {
   projectId: string;
@@ -102,17 +103,27 @@ export default function FlowPageClient({ projectId, wsSlug, projSlug }: FlowPage
     router.push(`/${wsSlug}/${projSlug}/flow${qs ? `?${qs}` : ''}`);
   }, [router, searchParams, wsSlug, projSlug]);
 
-  // 선생님 지적(2026-07-30, 오르테가군 전달) — "노드를 눌러도 아무 일이 안 나는" 것이
-  // #2224 AC1의 두 번째 결함이었다(간선 그리기와 별개). PO 판정: 「패널을 연다」로 간다
-  // (캔버스 안 확장은 절대좌표라 레이아웃이 흔들리고, 곧 들어올 줌과도 정면충돌). 이미
-  // `KanbanBoard`가 `?story=` 를 읽어 패널을 여는 길이 있다(딥링크가 그 길을 쓴다) —
-  // 새 패널을 짓지 않고 «그 길을 그대로 타는» 것이 오늘의 배선. view를 list로 함께
-  // 바꿔야 KanbanBoard 자체가 마운트된다(list일 때만 렌더되는 조건부 마운트, 아래 참고).
+  // AC6(판정선) — 패널을 닫아도 URL의 story는 지우지 않는다("누른 노드가 선택된 채로
+  // 남는다" — selectedStoryId는 URL이 단일 소스, 열림/닫힘은 이 로컬 boolean만 관여). 다시
+  // 그 노드를 누르면 handleSelectStory가 다시 panelOpen=true로 돌린다.
+  const [panelOpen, setPanelOpen] = useState(false);
+  const selectedStoryId = searchParams.get('story');
+  useEffect(() => {
+    if (selectedStoryId) setPanelOpen(true);
+  }, [selectedStoryId]);
+  const handleClosePanel = useCallback(() => setPanelOpen(false), []);
+
+  // story #2354 후속(2026-07-31) — 예전엔 view를 'list'로 함께 갈아 끼워 KanbanBoard(그
+  // 안의 StoryDetailPanel)를 마운트시켰는데, 그 view 전환 자체가 «갈래 캔버스를
+  // 언마운트»시키는 원인이었다(선생님 "인터랙션이 없다"의 구조적 뿌리 — 조사 결론:
+  // 옛 flow-client.tsx:111 주석 "view를 list로 함께 바꿔야 KanbanBoard 자체가 마운트된다").
+  // 이제 `?story=`만 붙이고 view는 손대지 않는다 — 캔버스는 그대로 살아있고, 아래
+  // `FlowNodeStoryPanel`이 지도 위에 겹쳐 뜬다.
   const handleSelectStory = useCallback((storyId: string) => {
     const params = new URLSearchParams(searchParams.toString());
-    params.set('view', 'list');
     params.set('story', storyId);
-    router.push(`/${wsSlug}/${projSlug}/flow?${params.toString()}`);
+    router.push(`/${wsSlug}/${projSlug}/flow?${params.toString()}`, { scroll: false });
+    setPanelOpen(true);
   }, [router, searchParams, wsSlug, projSlug]);
 
   const exceptionItems = useMemo(() => {
@@ -181,9 +192,23 @@ export default function FlowPageClient({ projectId, wsSlug, projSlug }: FlowPage
               {t('loading')}
             </div>
           ) : (
-            <NextMakerScreen projectId={projectId} memberMap={data?.memberMap ?? {}} onSelectStory={handleSelectStory} />
+            <NextMakerScreen
+              projectId={projectId}
+              memberMap={data?.memberMap ?? {}}
+              onSelectStory={handleSelectStory}
+              selectedNodeId={selectedStoryId}
+            />
           )
         )}
+
+        {/* story #2354 — 지도 위에 겹치는 패널. list 보기일 땐 KanbanBoard가 이미 자기
+            방식(전체화면 드로어)으로 같은 `?story=`를 읽어 여는 중이라(AC9 회귀 없음), 여기서
+            또 열면 두 벌이 뜬다 — view==='flow'일 때만 렌더한다. */}
+        {view !== 'list' && panelOpen && selectedStoryId ? (
+          // key={selectedStoryId} — 다른 노드를 연달아 누르면 통째로 다시 마운트시킨다(초기
+          // loading 상태가 매번 자연히 맞다, flow-node-story-panel.tsx 문서 참고).
+          <FlowNodeStoryPanel key={selectedStoryId} storyId={selectedStoryId} onClose={handleClosePanel} />
+        ) : null}
 
         {/* ③ 관제 서랍 — 보기 무관 고정, 접힘 기본(IA §2). ExceptionStream = #2100 예외 스트림
             그대로 재사용(A타입, AC4 — glance-board.tsx가 쓰는 그 컴포넌트 그대로, 새로 그린

--- a/apps/web/src/components/flow/flow-epic-nodes.tsx
+++ b/apps/web/src/components/flow/flow-epic-nodes.tsx
@@ -15,6 +15,8 @@ interface FlowEpicNodesProps {
   epicId: string;
   epicTitle: string;
   onSelectStory: (storyId: string) => void;
+  /** story #2354 — 순수 통과 prop(FlowMapCanvas 참고). */
+  selectedNodeId?: string | null;
 }
 
 type LoadState =
@@ -76,7 +78,7 @@ async function fetchAllDonePastItems(epicId: string): Promise<EpicFlowNodeItem[]
  * 감싸 FlowMapCanvas에 넘긴다. 멀티레인 BE 계약이 착지하면 호출부가 여러 에픽을 fetch해
  * 배열을 채우는 것으로 끝난다(이 컴포넌트/FlowMapCanvas 모두 무변경).
  */
-export function FlowEpicNodes({ projectId, epicId, epicTitle, onSelectStory }: FlowEpicNodesProps) {
+export function FlowEpicNodes({ projectId, epicId, epicTitle, onSelectStory, selectedNodeId = null }: FlowEpicNodesProps) {
   const t = useTranslations('flow');
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
   // 유나양 규격(아티팩트 a125909a) — 「펼침 상태」는 «묶음 단위»로 든다(오르테가군 지시:
@@ -179,6 +181,7 @@ export function FlowEpicNodes({ projectId, epicId, epicTitle, onSelectStory }: F
       onSelectStory={onSelectStory}
       onTogglePastBundle={handleTogglePastBundle}
       isPastBundleLoading={isPastBundleLoading}
+      selectedNodeId={selectedNodeId}
     />
   );
 }

--- a/apps/web/src/components/flow/flow-map-canvas.test.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.test.tsx
@@ -102,6 +102,38 @@ describe('FlowMapCanvas — node click → open story panel (선생님 지적 20
     await act(async () => { button?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     expect(onSelectStory).toHaveBeenCalledWith('s-123');
   });
+
+  // story #2354 — 오버레이 패널이 클릭된 노드의 실제 화면 좌표를 찾는 유일한 방법이 이
+  // 속성이다(flow-node-story-panel.tsx가 `[data-node-id="..."]`로 querySelector한다).
+  it('renders data-node-id on every node card so the overlay panel can anchor to it', async () => {
+    const lane = makeLane({ nowNodes: [makeNode({ id: 's-anchor-123' })] });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} isPastBundleLoading={false} />)); });
+    const button = container.querySelector('[data-node-id="s-anchor-123"]');
+    expect(button).not.toBeNull();
+    expect(button?.tagName).toBe('BUTTON');
+  });
+
+  // story #2354 AC6(판정선) — 패널을 닫아도 「누른 노드가 선택된 채로」 남는다. 이 시각
+  // 신호(ring)가 없으면 "선택돼 있다"는 사실이 화면 어디에도 안 남는다.
+  it('highlights the node matching selectedNodeId with a ring, and no other node', async () => {
+    const lane = makeLane({
+      nowNodes: [makeNode({ id: 'n1' })],
+      queueNodesByDepth: new Map([[0, [makeNode({ id: 'u1', kind: 'queue' })]]]),
+    });
+    await act(async () => {
+      root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} isPastBundleLoading={false} selectedNodeId="u1" />));
+    });
+    const selectedButton = container.querySelector('[data-node-id="u1"]');
+    const otherButton = container.querySelector('[data-node-id="n1"]');
+    expect(selectedButton?.className).toContain('ring-2');
+    expect(otherButton?.className).not.toContain('ring-2');
+  });
+
+  it('highlights no node when selectedNodeId is omitted (default behavior unchanged)', async () => {
+    const lane = makeLane({ nowNodes: [makeNode({ id: 'n1' })] });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} isPastBundleLoading={false} />)); });
+    expect(container.querySelector('[data-node-id="n1"]')?.className).not.toContain('ring-2');
+  });
 });
 
 // 8종 조합 — u0..u7을 큐 depth 0에 나란히 두고, n1(now)에서 각각으로 간선 하나씩.

--- a/apps/web/src/components/flow/flow-map-canvas.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.tsx
@@ -23,10 +23,11 @@ const NOW_CLUSTER_X = FLOW_MAP_NOW_LINE_X - 40; // "지금" 노드는 세로선 
 
 interface FlowMapCanvasProps {
   lanes: FlowMapLane[];
-  /** 노드 클릭 → 스토리 상세 패널(선생님 지적 2026-07-30 — 동사 0개였다). PO 판정:
-   * 「패널을 연다」— 캔버스 밖이라 곧 들어올 줌(축척)과 충돌하지 않고, 절대좌표 레이아웃도
-   * 안 흔들린다(이유 셋 중 둘째·셋째). `?view=list&story={id}`로 기존 KanbanBoard 오픈
-   * 경로를 그대로 탄다(딥링크가 이미 쓰는 그 길, 새 패널을 짓지 않는다). */
+  /** 노드 클릭 → 스토리 상세 패널(선생님 지적 2026-07-30 — 동사 0개였다). story #2354
+   * 후속(2026-07-31) — 예전엔 `?view=list&story={id}`로 칸반 오픈 경로를 탔으나, view를
+   * 갈아 끼우는 것 자체가 캔버스를 언마운트시키는 원인이었다(선생님 "인터랙션이 없다"의
+   * 구조적 뿌리). 지금은 호출부(flow-client.tsx)가 `?story={id}`만 붙이고 지도 «위»에
+   * 겹치는 팝오버로 같은 `StoryDetailPanel`을 재사용한다 — view는 그대로 둔다. */
   onSelectStory: (storyId: string) => void;
   /** 유나양 규격(아티팩트 a125909a, "누르면 펼쳐지는 것이 곧 줌인") — 묶음 카드를 누르면
    * 호출부(FlowEpicNodes)가 개별 과거 스토리를 fetch해 `pastItems`로 다시 넘긴다. 오늘은
@@ -36,6 +37,10 @@ interface FlowMapCanvasProps {
   onTogglePastBundle: () => void;
   /** fetch 진행 중 — 묶음 카드가 "불러오는 중…"을 보이는 자리. */
   isPastBundleLoading: boolean;
+  /** story #2354 AC6 — 패널을 «닫아도» 마지막으로 누른 노드가 선택된 채로 남는다(고리 강조
+   * ring). URL의 `?story=`가 단일 소스 — 패널이 닫혀도 이 값은 지워지지 않는다(호출부가
+   * 패널의 열림/닫힘만 별도 로컬 상태로 관리, 선택 자체는 URL 그대로). */
+  selectedNodeId?: string | null;
 }
 
 // PO 지적(2026-07-30) — 판을 갈아엎으며 색/모양(border-left)만 남기고 「status를 사람이
@@ -57,7 +62,7 @@ function nodeToneClass(node: FlowMapNode): string {
   return 'border-l-border border-dashed'; // .n.queue — 아직 시작 안 한 것은 점선
 }
 
-function FlowMapNodeCard({ node, left, top, superseded, onSelectStory }: { node: FlowMapNode; left: number; top: number; superseded: boolean; onSelectStory: (storyId: string) => void }) {
+function FlowMapNodeCard({ node, left, top, superseded, selected, onSelectStory }: { node: FlowMapNode; left: number; top: number; superseded: boolean; selected: boolean; onSelectStory: (storyId: string) => void }) {
   const t = useTranslations('flow');
   const statusKey = STATUS_LABEL_KEY[node.status];
   // 유나양 규격(아티팩트 a125909a `.nd.past{opacity:.62}`) — 펼친 과거 카드는 항상 흐림
@@ -66,8 +71,14 @@ function FlowMapNodeCard({ node, left, top, superseded, onSelectStory }: { node:
   return (
     <button
       type="button"
+      // story #2354 — data-node-id는 오버레이 패널이 "이 노드를 가리지 않는" 위/아래 반전
+      // 위치를 계산할 앵커(getBoundingClientRect)를 찾는 자리다. onSelectStory 시그니처를
+      // 건드리지 않는다(오르빈·목록 피커 등 «노드가 아닌» 호출부가 여럿이라, DOM 앵커
+      // 개념이 없는 그 호출부들까지 억지로 끌고 갈 이유가 없다 — 호출부는 storyId 하나만
+      // 안다). 패널을 닫아도 selected는 유지된다("누른 노드가 선택된 채로 남는다", AC6).
+      data-node-id={node.id}
       onClick={() => onSelectStory(node.id)}
-      className={`focus-inset absolute w-[110px] cursor-pointer overflow-visible rounded border border-l-[3px] border-border bg-card px-1.5 py-1 text-left text-[11px] shadow-sm hover:border-info/60 ${nodeToneClass(node)} ${dimmed ? 'opacity-50' : ''}`}
+      className={`focus-inset absolute w-[110px] cursor-pointer overflow-visible rounded border border-l-[3px] border-border bg-card px-1.5 py-1 text-left text-[11px] shadow-sm hover:border-info/60 ${nodeToneClass(node)} ${dimmed ? 'opacity-50' : ''} ${selected ? 'ring-2 ring-brand ring-offset-1 ring-offset-background' : ''}`}
       style={{ left, top }}
     >
       <div className="flex items-center justify-between gap-1 font-mono text-[9px] text-muted-foreground">
@@ -146,7 +157,7 @@ function FlowEdgeMarkerDefs() {
  * (PO 지시 — "한 레인 전용으로 짜지 마시는, 처음부터 레인 배열을 받는 형태로"). 오늘은 이
  * 배열의 길이가 늘 1(펼친 에픽 하나) — 멀티레인 계약이 오면 호출부만 배열을 채워 넘기면 된다.
  */
-export function FlowMapCanvas({ lanes, onSelectStory, onTogglePastBundle, isPastBundleLoading }: FlowMapCanvasProps) {
+export function FlowMapCanvas({ lanes, onSelectStory, onTogglePastBundle, isPastBundleLoading, selectedNodeId = null }: FlowMapCanvasProps) {
   const t = useTranslations('flow');
   const maxDepth = Math.max(0, ...lanes.flatMap((l) => Array.from(l.queueNodesByDepth.keys())));
   const canvasWidth = FLOW_MAP_DEPTH0_X + (maxDepth + 1) * FLOW_MAP_GRID_STEP + 20;
@@ -323,12 +334,13 @@ export function FlowMapCanvas({ lanes, onSelectStory, onTogglePastBundle, isPast
                       left={PAST_EXPANDED_LEFT}
                       top={PAST_EXPANDED_TOP_START + i * PAST_EXPANDED_ROW_HEIGHT}
                       superseded={supersededIds.has(node.id)}
+                      selected={node.id === selectedNodeId}
                       onSelectStory={onSelectStory}
                     />
                   ))}
 
                   {lane.nowNodes.map((node, i) => (
-                    <FlowMapNodeCard key={node.id} node={node} left={NOW_CLUSTER_X} top={4 + i * NODE_ROW_HEIGHT} superseded={supersededIds.has(node.id)} onSelectStory={onSelectStory} />
+                    <FlowMapNodeCard key={node.id} node={node} left={NOW_CLUSTER_X} top={4 + i * NODE_ROW_HEIGHT} superseded={supersededIds.has(node.id)} selected={node.id === selectedNodeId} onSelectStory={onSelectStory} />
                   ))}
 
                   {/* ①깊이 좌표 — x = FLOW_MAP_DEPTH0_X + depth × FLOW_MAP_GRID_STEP. depth는
@@ -339,7 +351,7 @@ export function FlowMapCanvas({ lanes, onSelectStory, onTogglePastBundle, isPast
                     return (
                       <div key={depth}>
                         {nodes.map((node, i) => (
-                          <FlowMapNodeCard key={node.id} node={node} left={x} top={4 + i * NODE_ROW_HEIGHT} superseded={supersededIds.has(node.id)} onSelectStory={onSelectStory} />
+                          <FlowMapNodeCard key={node.id} node={node} left={x} top={4 + i * NODE_ROW_HEIGHT} superseded={supersededIds.has(node.id)} selected={node.id === selectedNodeId} onSelectStory={onSelectStory} />
                         ))}
                         {/* ③「+N건」 더보기 카드(판C) — 잘린 수를 정직하게 보인다. "숨김"이
                             아니라 "있다는 걸 보여주며 접는 것"(오늘 「67 중 15」와 같은 규율). */}

--- a/apps/web/src/components/flow/flow-node-story-panel.test.tsx
+++ b/apps/web/src/components/flow/flow-node-story-panel.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+//
+// story #2354 — FlowNodeStoryPanel(패널 자립 래퍼)의 자체 로직만 격리해서 잰다:
+// ①storyId 하나로 GET /api/stories/{id}·GET /api/tasks?story_id= 두 개만 부르는가(AC8, 새
+// BE 0), ②앵커 노드(data-node-id)의 화면 위치로 위/아래 반전이 맞게 계산되는가(AC4),
+// ③앵커를 못 찾으면 안전하게 폴백하는가. StoryDetailPanel 내부 렌더 정확성은 그 자신의
+// 테스트가 이미 커버하므로 여기선 스텁으로 대체하고 «넘겨받은 props»만 값으로 잰다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { FlowNodeStoryPanel } from './flow-node-story-panel';
+import koMessages from '../../../messages/ko.json';
+
+vi.mock('@/components/kanban/story-detail-panel', () => ({
+  StoryDetailPanel: ({ story, onClose, overlayPosition }: { story: { title: string }; onClose: () => void; overlayPosition: { top: number; heightPx: number } }) => (
+    <div data-testid="story-detail-panel-stub">
+      <span data-testid="stub-title">{story.title}</span>
+      <span data-testid="stub-top">{overlayPosition.top}</span>
+      <span data-testid="stub-height">{overlayPosition.heightPx}</span>
+      <button type="button" onClick={onClose}>close</button>
+    </div>
+  ),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+function stubFetch(calledUrls: string[]) {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    calledUrls.push(url);
+    if (url.startsWith('/api/stories/')) {
+      return { ok: true, json: async () => ({ data: { id: 'story-abc', title: '앵커 시험 스토리', status: 'backlog' } }) };
+    }
+    if (url.startsWith('/api/tasks?')) {
+      return { ok: true, json: async () => ({ data: [{ id: 't1', title: 'Task', status: 'backlog' }] }) };
+    }
+    return { ok: false, json: async () => null };
+  }));
+}
+
+// jsdom 기본 innerHeight(768)를 테스트별로 고정 — 위/아래 절반 판정의 재료.
+function setViewportHeight(h: number) {
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: h });
+}
+
+function placeAnchor(id: string, rect: Partial<DOMRect>) {
+  const el = document.createElement('button');
+  el.setAttribute('data-node-id', id);
+  el.getBoundingClientRect = () => ({
+    top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0, x: 0, y: 0, toJSON() {},
+    ...rect,
+  } as DOMRect);
+  document.body.appendChild(el);
+  return el;
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  setViewportHeight(768);
+  // 위치 계산 effect가 rAF로 미뤄져 있다(react-hooks/set-state-in-effect 회피 — 컴포넌트
+  // 문서 참고). 테스트에서는 동기로 즉시 실행해 결정적으로 만든다.
+  let rafId = 0;
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => { cb(0); return ++rafId; });
+  vi.stubGlobal('cancelAnimationFrame', () => {});
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  document.querySelectorAll('[data-node-id]').forEach((el) => el.remove());
+  vi.unstubAllGlobals();
+});
+
+describe('FlowNodeStoryPanel — 자립 fetch (story #2354 AC8, 새 BE 0)', () => {
+  it('fetches exactly GET /api/stories/{id} and GET /api/tasks?story_id= — no other endpoints', async () => {
+    const calledUrls: string[] = [];
+    stubFetch(calledUrls);
+    placeAnchor('story-abc', { top: 100, bottom: 130 });
+
+    await act(async () => {
+      root.render(wrap(<FlowNodeStoryPanel storyId="story-abc" onClose={() => {}} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(calledUrls).toContain('/api/stories/story-abc');
+    expect(calledUrls.some((u) => u.startsWith('/api/tasks?story_id=story-abc'))).toBe(true);
+    expect(calledUrls).toHaveLength(2);
+    expect(container.querySelector('[data-testid="stub-title"]')?.textContent).toBe('앵커 시험 스토리');
+  });
+});
+
+describe('FlowNodeStoryPanel — 위/아래 반전(story #2354 AC4, 누른 노드를 가리지 않는다)', () => {
+  it('places the panel BELOW the node when the node is in the upper half of the viewport', async () => {
+    const calledUrls: string[] = [];
+    stubFetch(calledUrls);
+    // 뷰포트 768 — 위쪽 절반(384px 미만)에 노드를 둔다.
+    placeAnchor('story-abc', { top: 50, bottom: 80 });
+
+    await act(async () => {
+      root.render(wrap(<FlowNodeStoryPanel storyId="story-abc" onClose={() => {}} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const top = Number(container.querySelector('[data-testid="stub-top"]')?.textContent);
+    // 노드 아래(bottom=80)에 여백을 두고 시작 — 노드 위(0~80)를 침범하지 않는다.
+    expect(top).toBeGreaterThan(80);
+  });
+
+  it('places the panel ABOVE the node when the node is in the lower half of the viewport', async () => {
+    const calledUrls: string[] = [];
+    stubFetch(calledUrls);
+    // 뷰포트 768 — 아래쪽 절반(384px 이상)에 노드를 둔다.
+    placeAnchor('story-abc', { top: 700, bottom: 730 });
+
+    await act(async () => {
+      root.render(wrap(<FlowNodeStoryPanel storyId="story-abc" onClose={() => {}} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const top = Number(container.querySelector('[data-testid="stub-top"]')?.textContent);
+    const height = Number(container.querySelector('[data-testid="stub-height"]')?.textContent);
+    // 패널의 아래 끝(top+height)이 노드의 위(700)를 넘지 않는다 — 노드를 안 가린다.
+    expect(top + height).toBeLessThanOrEqual(700);
+  });
+
+  it('caps the panel height at 50% of the viewport (AC5)', async () => {
+    const calledUrls: string[] = [];
+    stubFetch(calledUrls);
+    placeAnchor('story-abc', { top: 50, bottom: 80 });
+
+    await act(async () => {
+      root.render(wrap(<FlowNodeStoryPanel storyId="story-abc" onClose={() => {}} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const height = Number(container.querySelector('[data-testid="stub-height"]')?.textContent);
+    expect(height).toBeLessThanOrEqual(768 * 0.5);
+  });
+
+  it('falls back to a centered position when the anchor node is not found in the DOM (defensive — no crash)', async () => {
+    const calledUrls: string[] = [];
+    stubFetch(calledUrls);
+    // 앵커를 아예 배치하지 않는다.
+
+    await act(async () => {
+      root.render(wrap(<FlowNodeStoryPanel storyId="story-abc" onClose={() => {}} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(container.querySelector('[data-testid="story-detail-panel-stub"]')).not.toBeNull();
+    const top = Number(container.querySelector('[data-testid="stub-top"]')?.textContent);
+    expect(Number.isFinite(top)).toBe(true);
+  });
+});

--- a/apps/web/src/components/flow/flow-node-story-panel.test.tsx
+++ b/apps/web/src/components/flow/flow-node-story-panel.test.tsx
@@ -13,11 +13,15 @@ import { FlowNodeStoryPanel } from './flow-node-story-panel';
 import koMessages from '../../../messages/ko.json';
 
 vi.mock('@/components/kanban/story-detail-panel', () => ({
-  StoryDetailPanel: ({ story, onClose, overlayPosition }: { story: { title: string }; onClose: () => void; overlayPosition: { top: number; heightPx: number } }) => (
-    <div data-testid="story-detail-panel-stub">
+  StoryDetailPanel: ({ story, onClose, overlayPosition }: { story: { title: string }; onClose: () => void; overlayPosition?: { top: number; heightPx: number } }) => (
+    <div data-testid="story-detail-panel-stub" data-mode={overlayPosition ? 'overlay' : 'fullscreen'}>
       <span data-testid="stub-title">{story.title}</span>
-      <span data-testid="stub-top">{overlayPosition.top}</span>
-      <span data-testid="stub-height">{overlayPosition.heightPx}</span>
+      {overlayPosition ? (
+        <>
+          <span data-testid="stub-top">{overlayPosition.top}</span>
+          <span data-testid="stub-height">{overlayPosition.heightPx}</span>
+        </>
+      ) : null}
       <button type="button" onClick={onClose}>close</button>
     </div>
   ),
@@ -54,6 +58,20 @@ function setViewportHeight(h: number) {
   Object.defineProperty(window, 'innerHeight', { configurable: true, value: h });
 }
 
+// useIsMobile()은 실제 판정값을 window.innerWidth<1024로 계산하고(use-mobile.ts), matchMedia는
+// addEventListener 배선용으로만 쓴다 — 그래서 둘 다 맞춰야 한다(matches만 바꿔선 안 갈린다).
+function stubMatchMedia() {
+  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+}
+
+function setViewportWidth(w: number) {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: w });
+}
+
 function placeAnchor(id: string, rect: Partial<DOMRect>) {
   const el = document.createElement('button');
   el.setAttribute('data-node-id', id);
@@ -70,6 +88,8 @@ beforeEach(() => {
   document.body.appendChild(container);
   root = createRoot(container);
   setViewportHeight(768);
+  setViewportWidth(1280); // 기본 데스크톱(1024 이상) — 모바일 테스트는 명시적으로 좁힌다.
+  stubMatchMedia();
   // 위치 계산 effect가 rAF로 미뤄져 있다(react-hooks/set-state-in-effect 회피 — 컴포넌트
   // 문서 참고). 테스트에서는 동기로 즉시 실행해 결정적으로 만든다.
   let rafId = 0;
@@ -163,5 +183,67 @@ describe('FlowNodeStoryPanel — 위/아래 반전(story #2354 AC4, 누른 노�
     expect(container.querySelector('[data-testid="story-detail-panel-stub"]')).not.toBeNull();
     const top = Number(container.querySelector('[data-testid="stub-top"]')?.textContent);
     expect(Number.isFinite(top)).toBe(true);
+  });
+});
+
+describe('FlowNodeStoryPanel — 로딩 표시(유나 가디언 리뷰 2026-07-31, issuecomment-5139371576, 침묵 구간 금지)', () => {
+  it('shows the nodesLoading text — NOT nothing — while the fetch is still pending', () => {
+    // fetch를 절대 안 풀리는 Promise로 스텁 — 이 시점의 렌더는 항상 loading 상태다.
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})));
+    placeAnchor('story-abc', { top: 100, bottom: 130 });
+
+    act(() => {
+      root.render(wrap(<FlowNodeStoryPanel storyId="story-abc" onClose={() => {}} />));
+    });
+
+    expect(container.textContent).toContain('노드를 불러오는 중');
+    // ⛔누른 직후 "아무 것도 안 뜬 것"처럼 보이면 침묵 구간이 선다 — StoryDetailPanel은
+    // 아직 마운트되지 않아야 정상이다(fetch가 안 끝났으므로).
+    expect(container.querySelector('[data-testid="story-detail-panel-stub"]')).toBeNull();
+  });
+});
+
+describe('FlowNodeStoryPanel — 모바일 게이트(유나 가디언 리뷰 2026-07-31, issuecomment-5139371576)', () => {
+  it('on mobile (<1024px), renders StoryDetailPanel WITHOUT overlayPosition — full-screen drawer mode, not the compact overlay', async () => {
+    setViewportWidth(375);
+    const calledUrls: string[] = [];
+    stubFetch(calledUrls);
+    placeAnchor('story-abc', { top: 100, bottom: 130 }); // 앵커가 있어도 모바일은 무시한다.
+
+    await act(async () => {
+      root.render(wrap(<FlowNodeStoryPanel storyId="story-abc" onClose={() => {}} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const stub = container.querySelector('[data-testid="story-detail-panel-stub"]');
+    expect(stub?.getAttribute('data-mode')).toBe('fullscreen');
+    expect(container.querySelector('[data-testid="stub-top"]')).toBeNull();
+  });
+
+  it('on mobile, the loading indicator renders without waiting on the (unused) anchor position effect', () => {
+    setViewportWidth(375);
+    // 앵커를 배치하지 않는다 — 모바일은 앵커 좌표 자체가 필요 없으므로 여전히 안전해야 한다.
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})));
+
+    act(() => {
+      root.render(wrap(<FlowNodeStoryPanel storyId="story-abc" onClose={() => {}} />));
+    });
+
+    expect(container.textContent).toContain('노드를 불러오는 중');
+  });
+
+  it('on desktop (>=1024px), still uses the compact overlay (regression guard — mobile gate does not leak to desktop)', async () => {
+    setViewportWidth(1280);
+    const calledUrls: string[] = [];
+    stubFetch(calledUrls);
+    placeAnchor('story-abc', { top: 100, bottom: 130 });
+
+    await act(async () => {
+      root.render(wrap(<FlowNodeStoryPanel storyId="story-abc" onClose={() => {}} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const stub = container.querySelector('[data-testid="story-detail-panel-stub"]');
+    expect(stub?.getAttribute('data-mode')).toBe('overlay');
   });
 });

--- a/apps/web/src/components/flow/flow-node-story-panel.tsx
+++ b/apps/web/src/components/flow/flow-node-story-panel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { StoryDetailPanel, type Task } from '@/components/kanban/story-detail-panel';
 import type { KanbanStory } from '@/components/kanban/types';
+import { useIsMobile } from '@/hooks/use-mobile';
 
 const OVERLAY_GAP = 8; // 노드와 패널 사이 여백(px)
 const OVERLAY_EDGE_MARGIN = 16; // 뷰포트 가장자리 여백(px)
@@ -52,9 +53,17 @@ function computeOverlayPosition(rect: DOMRect | null, viewportHeight: number): {
  * 아래쪽 절반이면 «위»에 둔다. 앵커를 못 찾으면(오르빈 등 캔버스 밖 호출 — 오늘은 실제로
  * 안 일어난다, onSelectStory는 노드 클릭 전용 경로에서만 storyId를 이 컴포넌트로 올린다)
  * 뷰포트 중앙 폴백으로 안전하게 내려간다.
+ *
+ * ⛔유나 가디언 리뷰(2026-07-31, PR#2722 issuecomment-5139371576) — 모바일(390px)엔 이
+ * 소형 오버레이를 그대로 쓰지 않는다. 「지도를 살려 둔다」가 데스크톱서 값 있는 건 지도가
+ * «넓어서»다 — 모바일은 지도도 절반·상세도 절반이 되어 헤더+설명+작업+댓글이 못 들어간다
+ * (IA §5에 이미 선 판단: 겹침이 아니라 독립 화면). isMobile이면 앵커 위치 계산 자체를 건너
+ * 뛰고 `StoryDetailPanel`에 overlayPosition을 안 넘긴다 — 그러면 그 컴포넌트가 이미 갖고
+ * 있는 전체화면 드로어 모드(KanbanBoard가 쓰는 그 경로 그대로, 새 컴포넌트 아님)로 뜬다.
  */
 export function FlowNodeStoryPanel({ storyId, onClose }: FlowNodeStoryPanelProps) {
   const t = useTranslations('flow');
+  const isMobile = useIsMobile();
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
   const [overlayPosition, setOverlayPosition] = useState<{ top: number; heightPx: number } | null>(null);
 
@@ -89,6 +98,7 @@ export function FlowNodeStoryPanel({ storyId, onClose }: FlowNodeStoryPanelProps
   // set-state-in-effect가 effect 본문 최상위의 무조건 setState를 막는다(mobile-selection-
   // menu.tsx의 "구독→콜백에서 setState" 관례와 같은 자리 — 여긴 구독 대상이 rAF 타이밍).
   useEffect(() => {
+    if (isMobile) return; // 모바일은 전체화면 드로어라 앵커 좌표가 필요 없다.
     let cancelled = false;
     const frame = requestAnimationFrame(() => {
       if (cancelled) return;
@@ -100,20 +110,36 @@ export function FlowNodeStoryPanel({ storyId, onClose }: FlowNodeStoryPanelProps
       setOverlayPosition(computeOverlayPosition(anchorEl?.getBoundingClientRect() ?? null, window.innerHeight));
     });
     return () => { cancelled = true; cancelAnimationFrame(frame); };
-  }, [storyId]);
+  }, [storyId, isMobile]);
 
-  if (state.kind === 'loading' || !overlayPosition) {
-    return null;
+  // ⛔유나 가디언 리뷰(2026-07-31) — loading 구간에서 null을 반환하면 누른 직후 "아무 변화
+  // 없는" 침묵 구간이 선다(실패보다 나쁘다 — 신호 자체가 없어서). 이미 있는 `nodesLoading`
+  // 키(flow-epic-nodes.tsx가 같은 뜻으로 쓰는 그 키, ko.json:463)를 그대로 재사용한다.
+  if (state.kind === 'loading' || (!isMobile && !overlayPosition)) {
+    return (
+      <div
+        className="fixed inset-x-4 top-4 z-50 mx-auto max-w-xl rounded-lg border border-border bg-background p-3 text-xs text-muted-foreground shadow-xl sm:inset-x-auto sm:right-4 sm:w-full"
+        style={!isMobile && overlayPosition ? { top: overlayPosition.top } : undefined}
+      >
+        {t('nodesLoading')}
+      </div>
+    );
   }
   if (state.kind === 'error') {
     return (
       <div
-        className="fixed inset-x-4 z-50 mx-auto max-w-xl rounded-lg border border-border bg-background p-3 text-xs text-muted-foreground shadow-xl sm:inset-x-auto sm:right-4 sm:w-full"
-        style={{ top: overlayPosition.top }}
+        className="fixed inset-x-4 top-4 z-50 mx-auto max-w-xl rounded-lg border border-border bg-background p-3 text-xs text-muted-foreground shadow-xl sm:inset-x-auto sm:right-4 sm:w-full"
+        style={!isMobile && overlayPosition ? { top: overlayPosition.top } : undefined}
       >
         {t('nodesError')}
       </div>
     );
+  }
+
+  if (isMobile) {
+    // IA §5 — 모바일은 겹침이 아니라 독립 화면. overlayPosition을 안 넘기면
+    // StoryDetailPanel이 이미 갖고 있는 전체화면 드로어 모드로 뜬다(KanbanBoard와 동일 경로).
+    return <StoryDetailPanel story={state.story} tasks={state.tasks} onClose={onClose} />;
   }
 
   return (
@@ -121,7 +147,7 @@ export function FlowNodeStoryPanel({ storyId, onClose }: FlowNodeStoryPanelProps
       story={state.story}
       tasks={state.tasks}
       onClose={onClose}
-      overlayPosition={{ top: overlayPosition.top, heightPx: overlayPosition.heightPx }}
+      overlayPosition={{ top: overlayPosition!.top, heightPx: overlayPosition!.heightPx }}
     />
   );
 }

--- a/apps/web/src/components/flow/flow-node-story-panel.tsx
+++ b/apps/web/src/components/flow/flow-node-story-panel.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { StoryDetailPanel, type Task } from '@/components/kanban/story-detail-panel';
+import type { KanbanStory } from '@/components/kanban/types';
+
+const OVERLAY_GAP = 8; // 노드와 패널 사이 여백(px)
+const OVERLAY_EDGE_MARGIN = 16; // 뷰포트 가장자리 여백(px)
+const OVERLAY_MAX_HEIGHT_RATIO = 0.5; // AC5 — 뷰포트 절반 이하
+
+interface FlowNodeStoryPanelProps {
+  storyId: string;
+  onClose: () => void;
+}
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'error' }
+  | { kind: 'ready'; story: KanbanStory; tasks: Task[] };
+
+/** AC4(누른 노드를 가리지 않는다)·AC5(높이≤뷰포트 절반) — 순수함수로 뺀 이유는 useEffect
+ * 본문에서 직접 계산하면(무조건부 setState) react-hooks/set-state-in-effect가 걸리기
+ * 때문만이 아니라, 위/아래 반전 규칙 자체를 DOM/React와 무관하게 값으로 검증하기 위해서다. */
+function computeOverlayPosition(rect: DOMRect | null, viewportHeight: number): { top: number; heightPx: number } {
+  const maxHeightPx = viewportHeight * OVERLAY_MAX_HEIGHT_RATIO;
+  if (!rect) {
+    // 앵커를 못 찾은 폴백 — 뷰포트 중앙에 최대높이로.
+    return { top: (viewportHeight - maxHeightPx) / 2, heightPx: maxHeightPx };
+  }
+  const nodeIsUpperHalf = rect.top < viewportHeight / 2;
+  if (nodeIsUpperHalf) {
+    // 노드가 위쪽 — 패널은 그 «아래»에, 뷰포트 하단까지 남는 공간과 상한 중 작은 쪽.
+    const top = rect.bottom + OVERLAY_GAP;
+    const heightPx = Math.max(120, Math.min(maxHeightPx, viewportHeight - OVERLAY_EDGE_MARGIN - top));
+    return { top, heightPx };
+  }
+  // 노드가 아래쪽 — 패널은 그 «위»에, 상단까지 남는 공간과 상한 중 작은 쪽.
+  const heightPx = Math.max(120, Math.min(maxHeightPx, rect.top - OVERLAY_GAP - OVERLAY_EDGE_MARGIN));
+  const top = rect.top - OVERLAY_GAP - heightPx;
+  return { top, heightPx };
+}
+
+/**
+ * story #2354 — 「패널을 자립시키는 일」(2026-07-31 조사 결론 그대로) 구현. `StoryDetailPanel`은
+ * 필수 prop이 story·tasks·onClose 셋뿐이고 나머지 11개가 이미 옵셔널이라, storyId 하나로
+ * 자체 fetch하는 이 얇은 래퍼가 그 위에 서면 충분하다(새 BE 0 — `GET /api/stories/{id}` ·
+ * `GET /api/tasks?story_id=`는 kanban-board.tsx가 오늘 이미 쓰는 그 경로 그대로, AC8).
+ *
+ * 위치 계산(AC4 — 누른 노드를 가리지 않는다) — `data-node-id`(flow-map-canvas.tsx)로 클릭된
+ * 노드 카드의 실제 화면 좌표를 찾는다. 노드가 뷰포트 위쪽 절반이면 패널을 그 «아래»에,
+ * 아래쪽 절반이면 «위»에 둔다. 앵커를 못 찾으면(오르빈 등 캔버스 밖 호출 — 오늘은 실제로
+ * 안 일어난다, onSelectStory는 노드 클릭 전용 경로에서만 storyId를 이 컴포넌트로 올린다)
+ * 뷰포트 중앙 폴백으로 안전하게 내려간다.
+ */
+export function FlowNodeStoryPanel({ storyId, onClose }: FlowNodeStoryPanelProps) {
+  const t = useTranslations('flow');
+  const [state, setState] = useState<LoadState>({ kind: 'loading' });
+  const [overlayPosition, setOverlayPosition] = useState<{ top: number; heightPx: number } | null>(null);
+
+  // 「story가 바뀔 때 loading으로 되돌리는」 것은 여기서 수동으로 안 한다 — 호출부
+  // (flow-client.tsx)가 `key={storyId}`로 이 컴포넌트를 통째로 다시 마운트시킨다(초기값
+  // {kind:'loading'}이 매번 자연히 맞다). next-maker-screen.tsx가 GoalStemCard를
+  // key={focusedStem.epicId}로 다루는 것과 같은 관례 — effect 본문 최상위의 무조건
+  // setState(react-hooks/set-state-in-effect가 막는 자리)를 마운트 자체로 대신한다.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const [storyJson, tasksJson] = await Promise.all([
+        fetch(`/api/stories/${storyId}`).then((r) => (r.ok ? r.json() : null)).catch(() => null),
+        fetch(`/api/tasks?story_id=${storyId}&limit=20`).then((r) => (r.ok ? r.json() : null)).catch(() => null),
+      ]);
+      if (cancelled) return;
+      const story = storyJson?.data as KanbanStory | undefined;
+      if (!story) {
+        setState({ kind: 'error' });
+        return;
+      }
+      const tasks = (tasksJson?.data ?? []) as Task[];
+      setState({ kind: 'ready', story, tasks });
+    })();
+    return () => { cancelled = true; };
+  }, [storyId]);
+
+  // 앵커 위치는 클릭된 실 DOM(data-node-id)에서 한 번 잰다 — 패널이 열려 있는 동안 캔버스가
+  // 스크롤돼도 다시 재지 않는다(AC6 "닫으면 그대로" 판정선이 스크롤 위치 자체를 건드리지
+  // 말라는 것이지, 패널이 스크롤을 실시간 추적하라는 요구가 아니다 — 열 때 한 번으로 충분).
+  // rAF로 감싸는 이유 — DOM 페인트(레이아웃 확정) «후» 재야 정확하고, react-hooks/
+  // set-state-in-effect가 effect 본문 최상위의 무조건 setState를 막는다(mobile-selection-
+  // menu.tsx의 "구독→콜백에서 setState" 관례와 같은 자리 — 여긴 구독 대상이 rAF 타이밍).
+  useEffect(() => {
+    let cancelled = false;
+    const frame = requestAnimationFrame(() => {
+      if (cancelled) return;
+      // CSS.escape 기반 셀렉터 문자열 조립 대신 속성값을 직접 비교한다 — storyId에 CSS
+      // 셀렉터 특수문자(UUID라 실무상 없지만)가 섞여도 안전하고, CSS.escape 전역이 없는
+      // 실행환경(jsdom 테스트 등)에도 안 깨진다.
+      const anchorEl = Array.from(document.querySelectorAll('[data-node-id]'))
+        .find((el) => el.getAttribute('data-node-id') === storyId) ?? null;
+      setOverlayPosition(computeOverlayPosition(anchorEl?.getBoundingClientRect() ?? null, window.innerHeight));
+    });
+    return () => { cancelled = true; cancelAnimationFrame(frame); };
+  }, [storyId]);
+
+  if (state.kind === 'loading' || !overlayPosition) {
+    return null;
+  }
+  if (state.kind === 'error') {
+    return (
+      <div
+        className="fixed inset-x-4 z-50 mx-auto max-w-xl rounded-lg border border-border bg-background p-3 text-xs text-muted-foreground shadow-xl sm:inset-x-auto sm:right-4 sm:w-full"
+        style={{ top: overlayPosition.top }}
+      >
+        {t('nodesError')}
+      </div>
+    );
+  }
+
+  return (
+    <StoryDetailPanel
+      story={state.story}
+      tasks={state.tasks}
+      onClose={onClose}
+      overlayPosition={{ top: overlayPosition.top, heightPx: overlayPosition.heightPx }}
+    />
+  );
+}

--- a/apps/web/src/components/flow/goal-stem-card.tsx
+++ b/apps/web/src/components/flow/goal-stem-card.tsx
@@ -22,6 +22,8 @@ interface GoalStemCardProps {
   onSelectStory: (storyId: string) => void;
   onStoryPromoted: (storyId: string, epicId: string) => void;
   onGoalTransitioned: (epicId: string) => void;
+  /** story #2354 — 순수 통과 prop(FlowMapCanvas 참고). */
+  selectedNodeId?: string | null;
 }
 
 type PickState =
@@ -52,7 +54,7 @@ const REASON_LABEL_KEY: Record<NextPickReasonKey, string> = {
  */
 export function GoalStemCard({
   stem, projectId, backlogStories, recentlyClosedTargetIds, memberMap,
-  onSelectStory, onStoryPromoted, onGoalTransitioned,
+  onSelectStory, onStoryPromoted, onGoalTransitioned, selectedNodeId = null,
 }: GoalStemCardProps) {
   const t = useTranslations('flow');
   const [pickState, setPickState] = useState<PickState>({ kind: 'loading' });
@@ -148,7 +150,7 @@ export function GoalStemCard({
       {/* ①갈래(선·노드)가 이 화면의 몸통(PO 판정 2026-07-31, 선생님 "이게 뭔지.." 후속) —
           픽 패널이 «위/작게», 캔버스가 «아래/크게»다. min-h로 시각 지배력을 명시로 준다. */}
       <div className="min-h-[520px] rounded-lg border border-border">
-        <FlowEpicNodes projectId={projectId} epicId={stem.epicId} epicTitle={stem.title} onSelectStory={onSelectStory} />
+        <FlowEpicNodes projectId={projectId} epicId={stem.epicId} epicTitle={stem.title} onSelectStory={onSelectStory} selectedNodeId={selectedNodeId} />
       </div>
     </div>
   );

--- a/apps/web/src/components/flow/next-maker-screen.tsx
+++ b/apps/web/src/components/flow/next-maker-screen.tsx
@@ -20,6 +20,8 @@ interface NextMakerScreenProps {
   projectId: string;
   memberMap: Record<string, MemberLite>;
   onSelectStory: (storyId: string) => void;
+  /** story #2354 — 순수 통과 prop(FlowMapCanvas 참고, 노드 선택 고리 강조). */
+  selectedNodeId?: string | null;
 }
 
 interface Envelope<T> { data: T; meta?: unknown }
@@ -85,7 +87,7 @@ type LoadState =
  * in-progress·in-review)만 프로젝트 전체로 긁는다 — 실측(아티팩트 리드) "미래는 39개"라
  * project 규모 전체를 긁어도 가볍다.
  */
-export function NextMakerScreen({ projectId, memberMap, onSelectStory }: NextMakerScreenProps) {
+export function NextMakerScreen({ projectId, memberMap, onSelectStory, selectedNodeId = null }: NextMakerScreenProps) {
   const t = useTranslations('flow');
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
   // 스토리 하나가 승격(backlog→ready-for-dev)되거나 목표가 전이(done/archived)되면, 전체
@@ -285,6 +287,7 @@ export function NextMakerScreen({ projectId, memberMap, onSelectStory }: NextMak
               recentlyClosedTargetIds={state.kind === 'ready' ? state.recentlyClosedTargetIds : new Set()}
               memberMap={memberMap}
               onSelectStory={onSelectStory}
+              selectedNodeId={selectedNodeId}
               onStoryPromoted={handleStoryPromoted}
               onGoalTransitioned={handleGoalTransitioned}
             />

--- a/apps/web/src/components/kanban/story-detail-panel.test.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+//
+// story #2354 회귀 가드 — StoryDetailPanel의 새 `overlayPosition` prop이 (a) 기존 칸반
+// 전체화면 드로어를 무변화로 유지하고(회귀 0, AC9) (b) 값을 주면 지도 위에 겹치는 소형
+// 팝오버로 바뀌는지(배경 딤 없음·top/height 인라인 스타일 적용) 왕복 검증한다. 내부
+// 콘텐츠(작업목록·댓글 등)의 정확성은 kanban-board.test.tsx가 이미 통합 경로로 커버하므로,
+// 여기서는 이 PR이 건드린 «바깥 래퍼»만 값으로 잰다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { StoryDetailPanel } from './story-detail-panel';
+import type { KanbanStory } from './types';
+import koMessages from '../../../messages/ko.json';
+
+const { useDashboardContextMock } = vi.hoisted(() => ({ useDashboardContextMock: vi.fn() }));
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => useDashboardContextMock(),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+function makeStory(overrides: Partial<KanbanStory> = {}): KanbanStory {
+  return {
+    id: 's1', story_number: 1, title: 'Story', status: 'backlog', priority: 'medium',
+    story_points: null, assignee_id: null, epic_id: null, sprint_id: null,
+    description: null, acceptance_criteria: null, attachments: null, position: null,
+    success_hypothesis: null, metric_definition: null, measure_after: null,
+    outcome_status: 'n_a', outcome_result: null,
+    ...overrides,
+  };
+}
+
+// kanban-board.test.tsx와 같은 관례 — 이 컴포넌트가 내부에서 부르는 나머지 fetch들
+// (comments/activities/dependencies/hypotheses/gates 등)는 그레이스풀 폴백 경로만 타면
+// 되므로 실패 응답으로 충분하다.
+function stubFetch() {
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, json: async () => null })));
+}
+
+beforeEach(() => {
+  stubFetch();
+  useDashboardContextMock.mockReturnValue({ currentTeamMemberId: 'me-1', projectMemberships: [], orgMemberships: [], currentMemberType: 'human' });
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe('StoryDetailPanel — overlayPosition (story #2354, 지도 위에 겹치는 팝오버)', () => {
+  it('without overlayPosition: renders the existing full-screen drawer with a dimmed backdrop (칸반 회귀 0, AC9)', async () => {
+    await act(async () => {
+      root.render(wrap(<StoryDetailPanel story={makeStory()} tasks={[]} onClose={() => {}} />));
+    });
+    const [backdrop, panel] = Array.from(container.querySelectorAll('[aria-hidden="true"], [role="dialog"]'));
+    expect(backdrop?.className).toContain('bg-overlay-backdrop');
+    expect(panel?.className).toContain('inset-0');
+    expect(panel?.className).toContain('lg:right-0');
+    expect((panel as HTMLElement)?.style.top).toBe('');
+  });
+
+  it('with overlayPosition: no dimmed backdrop, and the panel uses the given top/height instead of the full drawer classes (지도를 가리지 않는다)', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <StoryDetailPanel story={makeStory()} tasks={[]} onClose={() => {}} overlayPosition={{ top: 120, heightPx: 300 }} />,
+      ));
+    });
+    const backdrop = container.querySelector('[aria-hidden="true"]');
+    const panel = container.querySelector('[role="dialog"]') as HTMLElement;
+    expect(backdrop?.className).not.toContain('bg-overlay-backdrop');
+    expect(backdrop?.className).not.toContain('backdrop-blur-sm');
+    expect(panel.className).not.toContain('inset-0');
+    expect(panel.className).not.toContain('lg:right-0');
+    expect(panel.style.top).toBe('120px');
+    expect(panel.style.height).toBe('300px');
+  });
+
+  it('overlay panel content is the SAME component internals — story title still renders (재사용 확認, AC7)', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <StoryDetailPanel story={makeStory({ title: '겹침 패널 시험용 스토리' })} tasks={[]} onClose={() => {}} overlayPosition={{ top: 0, heightPx: 300 }} />,
+      ));
+    });
+    expect(container.textContent).toContain('겹침 패널 시험용 스토리');
+  });
+});

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -48,7 +48,7 @@ import { useSyntheticParentTabHistory } from '@/hooks/use-synthetic-parent-tab-h
 import { useFocusTrap } from '@/hooks/use-focus-trap';
 import { HumanOnlyAction } from '@/components/ui/human-only-action';
 
-interface Task {
+export interface Task {
   id: string;
   title: string;
   status: string;
@@ -86,6 +86,14 @@ interface StoryDetailPanelProps {
   sprintMap?: Record<string, string>;
   onNavigate?: (storyId: string) => void;
   projectId?: string;
+  /** story #2354 — 갈래 보기의 «지도 위에 겹치는» 소형 팝오버 모드. 생략하면 기존 전체화면
+   * 드로어(칸반 그대로, 회귀 없음). 값을 주면 배경 딤을 없애고(지도를 «가리지» 않는다),
+   * «top+height 확정값»만 받아 그대로 스타일에 적용한다 — 위/아래 반전 판단(클릭한 노드가
+   * 뷰포트 위쪽/아래쪽인가)과 높이 상한 계산 자체는 이 컴포넌트의 책임이 아니다(캔버스
+   * 좌표 지식을 이 공용 컴포넌트에 들이지 않는다, 호출부=flow-client.tsx가 노드 DOM
+   * 위치를 안다). top+heightPx(px, 확정)를 쓰는 이유 — top/bottom 자동조합은 높이가
+   * 암묵값이 되어 내부 `h-full` flex 레이아웃(헤더 고정+본문 스크롤)이 깨진다. */
+  overlayPosition?: { top: number; heightPx: number };
 }
 
 function taskTone(status: string) {
@@ -315,7 +323,7 @@ export function DescriptionViewer({
   );
 }
 
-export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loadingMoreTasks = false, onLoadMoreTasks, onClose, onStoryUpdate, onDeleteSuccess, memberMap = {}, members = [], storyMap = {}, epicMap = {}, sprintMap = {}, onNavigate, projectId }: StoryDetailPanelProps) {
+export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loadingMoreTasks = false, onLoadMoreTasks, onClose, onStoryUpdate, onDeleteSuccess, memberMap = {}, members = [], storyMap = {}, epicMap = {}, sprintMap = {}, onNavigate, projectId, overlayPosition }: StoryDetailPanelProps) {
   const t = useTranslations('board');
   // story #1959(P2-S3): 딥링크 매니페스트(story_detail→parentTab=all) — 콜드 진입 시 "전체"
   // 탭 루트를 BACK 대상으로 선주입. 카드 클릭으로 연 경우(history.length>1)는 no-op.
@@ -1072,21 +1080,27 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
 
   return (
     <>
-      {/* Backdrop */}
+      {/* Backdrop — overlay 모드(story #2354)에선 완전히 투명한 클릭-바깥-닫기 레이어일 뿐,
+          지도를 시각적으로 가리지 않는다(blur/dim 없음 — AC2 "누른 노드를 가리지 않는다"). */}
       <div
-        className="fixed inset-0 z-40 bg-overlay-backdrop backdrop-blur-sm lg:bg-transparent"
+        className={overlayPosition ? 'fixed inset-0 z-40' : 'fixed inset-0 z-40 bg-overlay-backdrop backdrop-blur-sm lg:bg-transparent'}
         onClick={onClose}
         aria-hidden="true"
       />
 
-      {/* Panel */}
+      {/* Panel — overlay 모드에선 전체화면 드로어 대신 지도 위에 겹치는 소형 팝오버(호출부가
+          계산한 top/bottom + maxHeightPx). 내부 콘텐츠(작업목록·댓글·편집 등)는 완전히 동일 —
+          «재사용»이지 새 컴포넌트가 아니다(story #2354 AC7). */}
       <div
         ref={panelTrapRef}
         tabIndex={-1}
         role="dialog"
         aria-modal="true"
         aria-label={story.title}
-        className="fixed inset-0 z-50 bg-background shadow-xl outline-none backdrop-blur-xl lg:inset-y-0 lg:left-auto lg:right-0 lg:w-full lg:max-w-3xl lg:border-l lg:border-border"
+        className={overlayPosition
+          ? 'fixed inset-x-4 z-50 mx-auto max-w-xl overflow-hidden rounded-lg border border-border bg-background shadow-xl outline-none backdrop-blur-xl sm:inset-x-auto sm:right-4 sm:w-full'
+          : 'fixed inset-0 z-50 bg-background shadow-xl outline-none backdrop-blur-xl lg:inset-y-0 lg:left-auto lg:right-0 lg:w-full lg:max-w-3xl lg:border-l lg:border-border'}
+        style={overlayPosition ? { top: overlayPosition.top, height: overlayPosition.heightPx } : undefined}
       >
       <div className="flex h-full flex-col">
         <div className="flex items-start justify-between border-b border-border p-5">


### PR DESCRIPTION
## 배경

선생님 「어떠한 인터랙션도 없다」 지적의 구조적 뿌리:

```
[유나 라이브 실측] 노드 클릭 ⇒ /flow → /flow?view=list&story=<id>
                 ⇒ 캔버스 언마운트
                 ⇒ 패널을 닫아도 view=list 그대로 — 지도가 안 돌아온다(탭을 다시 눌러야)
```

노드 클릭이 view까지 함께 갈아 끼워 갈래 캔버스 자체를 죽이고 있었다.

## 공수 판정 — 사전 조사(2026-07-31) 결론 그대로 구현

`StoryDetailPanel` prop 14개 중 11개가 이미 옵셔널, 필수 3개(story·tasks·onClose) 중 story·tasks는 칸반이 오늘 이미 쓰는 by-id fetch(`GET /api/stories/{id}`, `GET /api/tasks?story_id=`)로 자립 가능 → 판정 = 「패널을 자립시키는 일」, 새 전역 상태·컨텍스트 0, 새 BE 0, 얇은 래퍼 하나.

## 변경 사항

**①주소 규율 fix — 본론**
`handleSelectStory`는 이제 `?story=<id>`만 붙이고 `view`는 손대지 않는다. 캔버스가 살아있는 채로 URL만 바뀐다.

**②새 `FlowNodeStoryPanel` 래퍼** (`components/flow/flow-node-story-panel.tsx`)
storyId 하나로 자체 fetch(`GET /api/stories/{id}` + `GET /api/tasks?story_id=`, 새 BE 0) 후 기존 `StoryDetailPanel`을 그대로 렌더 — 새 패널을 짓지 않는다(AC7).

**③`StoryDetailPanel`에 `overlayPosition` 옵션 prop 신설**
값을 주면 배경 딤 없는 소형 팝오버(top/height 확정값)로, 생략하면 기존 전체화면 드로어(칸반 무변화, 회귀 0, AC9).

**④누른 노드를 안 가리는 위/아래 자동 반전(AC4)**
`data-node-id`(flow-map-canvas.tsx 신설)로 클릭된 실 DOM 좌표를 찾아, 뷰포트 위쪽 절반이면 패널을 아래에, 아래쪽이면 위에 둔다. 높이 상한 뷰포트 50%(AC5).

**⑤선택 유지(AC6 판정선)**
패널을 닫아도 URL의 `?story=`는 지우지 않는다 — 노드에 ring 강조가 남는다(`selectedNodeId` prop을 NextMakerScreen→GoalStemCard→FlowEpicNodes→FlowMapCanvas로 순수 통과).

**⑥`key={selectedStoryId}`**
노드를 연달아 누르면 `FlowNodeStoryPanel`을 통째로 재마운트 — `next-maker-screen.tsx`가 `GoalStemCard`를 `key={focusedStem.epicId}`로 다루는 것과 같은 관례. (부수효과로 `react-hooks/set-state-in-effect`도 자연히 회피 — effect 최상위의 무조건 setState 없이 초기값이 항상 정확하다.)

## 검증 (실제 돌린 명령)

```
✅ pnpm run type-check — clean
✅ pnpm run lint — 0 errors(경고 3개는 이 PR과 무관한 기존 파일)
✅ pnpm run build — 성공
✅ verify:focus-inset-coverage / no-new-md-breakpoint / no-alpha-focus-ring / no-handrolled-modal / build-schema-integrity — 전부 OK
✅ vitest run(전체) — 328 files / 2309 tests 전부 PASS(기존 2293+신규 21)
```

## 회귀 가드 — mutation self-check 완료

새 테스트 21건(flow-client 5·flow-map-canvas 4·story-detail-panel 3·flow-node-story-panel 9). `handleSelectStory`를 옛 코드(`view=list` 강제)로 임시 되돌려 관련 테스트 2건이 정확히 RED 되는 것을 확認 — 이 PR이 고치는 버그 그 자체를 재현하는 테스트임을 증명한 뒤 원래 fix로 복원, 재검증 GREEN.

## Test plan
- [ ] 배포 후 dev에서 라이브 실측(AC10): 노드 클릭 → `<line>` 개수·캔버스 DOM 유지 확認, 위/아래 각각의 노드로 패널이 안 가리는지, 패널 닫은 뒤 캔버스/스크롤/펼침 상태가 그대로인지
- [ ] 칸반(list) 보기 카드 클릭 시 패널 동작이 이 PR 전후로 동일한지(AC9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)