### PR TITLE
feat(analytics): story#2360 — GET /analytics/goal-edges 목표 간 연결 집계

### DIFF
--- a/backend/app/repositories/analytics.py
+++ b/backend/app/repositories/analytics.py
@@ -739,3 +739,111 @@ class AnalyticsRepository:
         params2["lim"] = limit
         result2 = await self.session.execute(text(q2), params2)
         return [{"member_id": r[0], "balance": float(r[1])} for r in result2.all()]
+
+    async def get_goal_edges(self, project_id: uuid.UUID) -> list[dict]:
+        """story #2360 — 목표(에픽) 간 「낳음」 연결을 목표 쌍 단위로 집계한다. 지금까지
+        유일한 읽기 길은 `GET /stories/{id}/backlinks`(스토리 한 건씩·limit 200·최대
+        10페이지)뿐이라 목표 간 선 하나에 「스토리 수 × 1~10 콜」이 들었다 — 이 메서드는
+        스토리 수·건수와 무관한 «고정 2쿼리»로 낸다(AC6 — 그게 이 메서드의 존재 이유다).
+
+        두 소스를 합산한다(유나 축 판정 — 가르는 건 «사람이 봐야 하는가»이므로 둘 다
+        실선이다):
+          ① entity_references(relation='created_from') — 이 표엔 kind 축 자체가 없다
+             (relation 컬럼은 'none'|'created_from'뿐, spawned/followed/superseded는
+             reference_semantic_candidates에만 있는 별개 컬럼) — kind=None으로 집계.
+          ② reference_semantic_candidates(status='declared') — relation_kind를 kind로.
+
+        ⛔SQL에서 미리 GROUP BY 하지 않는다 — reference_semantic_candidates는 source_field
+        (description/acceptance_criteria)가 유니크 키에 포함돼 같은 스토리 쌍이 두 field
+        모두에서 발견되면 행이 2개일 수 있다. 그리고 같은 스토리 쌍이 entity_references와
+        reference_semantic_candidates 양쪽에 «동시에» 걸릴 수도 있다(created_from으로도
+        기록되고 별도로 declared로도 승격된 경우). "count = 스토리 «쌍»의 수"(AC 문구
+        그대로)를 지키려면 스토리 쌍 단위로 먼저 dedup한 뒤에 목표 쌍으로 올려야 한다 —
+        그래서 두 쿼리는 raw 행만 내고, dedup·kind 판정은 여기(파이썬)에서 한다(쿼리
+        개수는 여전히 고정 2개 — AC6 위반 아님).
+
+        A→A(같은 목표 안)·epic_id가 한쪽이라도 NULL인 쌍은 두 쿼리 WHERE 절에서 제외한다
+        (목표 «간» 연결의 정의 그대로, AC4/5)."""
+        from sqlalchemy.orm import aliased
+
+        from app.models.reference import Reference
+        from app.models.reference_semantic_candidate import ReferenceSemanticCandidate
+
+        src1, tgt1 = aliased(Story), aliased(Story)
+        created_from_rows = (await self.session.execute(
+            select(Reference.source_id, Reference.target_id, src1.epic_id, tgt1.epic_id)
+            .select_from(Reference)
+            .join(src1, src1.id == Reference.source_id)
+            .join(tgt1, tgt1.id == Reference.target_id)
+            .where(
+                Reference.org_id == self.org_id,
+                Reference.source_type == "story",
+                Reference.target_type == "story",
+                Reference.relation == "created_from",
+                src1.project_id == project_id,
+                tgt1.project_id == project_id,
+                src1.epic_id.is_not(None),
+                tgt1.epic_id.is_not(None),
+                src1.epic_id != tgt1.epic_id,
+            )
+        )).all()
+
+        src2, tgt2 = aliased(Story), aliased(Story)
+        declared_rows = (await self.session.execute(
+            select(
+                ReferenceSemanticCandidate.source_id, ReferenceSemanticCandidate.target_id,
+                ReferenceSemanticCandidate.relation_kind, src2.epic_id, tgt2.epic_id,
+            )
+            .select_from(ReferenceSemanticCandidate)
+            .join(src2, src2.id == ReferenceSemanticCandidate.source_id)
+            .join(tgt2, tgt2.id == ReferenceSemanticCandidate.target_id)
+            .where(
+                ReferenceSemanticCandidate.org_id == self.org_id,
+                ReferenceSemanticCandidate.source_type == "story",
+                ReferenceSemanticCandidate.target_type == "story",
+                ReferenceSemanticCandidate.status == "declared",
+                src2.project_id == project_id,
+                tgt2.project_id == project_id,
+                src2.epic_id.is_not(None),
+                tgt2.epic_id.is_not(None),
+                src2.epic_id != tgt2.epic_id,
+            )
+        )).all()
+
+        # story-쌍 단위 dedup: (source_id, target_id) -> {kinds seen for that pair}.
+        # created_from 기여분은 "종류 없음" sentinel로 None을 넣는다.
+        pair_kinds: dict[tuple[uuid.UUID, uuid.UUID], set] = {}
+        pair_epics: dict[tuple[uuid.UUID, uuid.UUID], tuple[uuid.UUID, uuid.UUID]] = {}
+
+        for source_id, target_id, src_epic, tgt_epic in created_from_rows:
+            key = (source_id, target_id)
+            pair_kinds.setdefault(key, set()).add(None)
+            pair_epics[key] = (src_epic, tgt_epic)
+
+        for source_id, target_id, relation_kind, src_epic, tgt_epic in declared_rows:
+            key = (source_id, target_id)
+            pair_kinds.setdefault(key, set()).add(relation_kind)
+            pair_epics[key] = (src_epic, tgt_epic)
+
+        # 목표 쌍 단위 롤업 — 위에서 이미 스토리 쌍 단위로 dedup됐으므로 여기서는 그
+        # 결과(쌍마다 정확히 1개)만 센다.
+        agg: dict[tuple[uuid.UUID, uuid.UUID], dict] = {}
+        for pair, kinds in pair_kinds.items():
+            epic_pair = pair_epics[pair]
+            bucket = agg.setdefault(epic_pair, {"count": 0, "kinds": set()})
+            bucket["count"] += 1
+            # 한 스토리 쌍 자체가 이미 여러 종류로 걸려 있으면(예: description은
+            # created_from, acceptance_criteria는 declared·다른 kind) 그 쌍 자체가
+            # 모호하다 — None으로 접어 목표 쌍 레벨의 「섞이면 null」로 자연히 흡수시킨다.
+            resolved_kind = next(iter(kinds)) if len(kinds) == 1 else None
+            bucket["kinds"].add(resolved_kind)
+
+        result: list[dict] = []
+        for (from_id, to_id), bucket in agg.items():
+            kinds = bucket["kinds"]
+            kind = next(iter(kinds)) if len(kinds) == 1 else None
+            result.append({
+                "from_goal_id": from_id, "to_goal_id": to_id,
+                "count": bucket["count"], "kind": kind,
+            })
+        return result

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -17,6 +17,7 @@ from app.schemas.analytics import (
     EpicProgressResponse,
     EpicsProgressLaneResponse,
     EpicZoneCounts,
+    GoalEdge,
     MemberWorkloadResponse,
     ProjectHealthResponse,
     ProjectOverviewResponse,
@@ -152,6 +153,21 @@ async def get_epic_flow_nodes(
         raise HTTPException(status_code=400, detail="epic_ids가 비어 있습니다")
     batch_result = await repo.get_epic_flow_nodes_batch(project_id, parsed_ids, upcoming_limit)
     return EpicFlowNodesBatchResponse.model_validate(batch_result)
+
+
+@router.get("/analytics/goal-edges", response_model=list[GoalEdge])
+async def get_goal_edges(
+    project_id: uuid.UUID = Query(...),
+    repo: AnalyticsRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+) -> list[GoalEdge]:
+    """story #2360 — 목표(에픽) 간 「낳음」 연결을 목표 쌍 단위로 집계해 낸다. 지금까지는
+    `GET /stories/{id}/backlinks`(스토리 한 건씩)로만 읽혀 목표 간 선 하나에 스토리 수만큼
+    콜이 들었다 — 이 엔드포인트는 스토리 수와 무관한 고정 쿼리로 대체한다(AC6).
+    빈 배열은 「연결이 없다」이지 「못 읽었다」가 아니다 — 오류는 그대로 오류 코드로 난다."""
+    await _assert_project_access(repo, auth, project_id)
+    rows = await repo.get_goal_edges(project_id)
+    return [GoalEdge.model_validate(r) for r in rows]
 
 
 @router.get("/analytics/agent-stats", response_model=AgentStatsResponse)

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -272,3 +272,15 @@ class SprintVelocityResponse(BaseModel):
 class LeaderboardEntry(BaseModel):
     member_id: uuid.UUID
     balance: float
+
+
+class GoalEdge(BaseModel):
+    """story #2360 — 목표(에픽) 쌍을 잇는 「낳음」 연결의 집계 한 행. `count`는 그 목표
+    쌍을 잇는 «스토리 쌍»의 수(같은 스토리 쌍이 두 소스 표 모두에 걸려 있어도 1로 센다).
+    `kind`는 그 목표 쌍의 관계 종류가 단일값일 때만 채워지고, 섞이거나(created_from처럼
+    종류 축이 없는 것과 declared가 섞이는 경우 포함) 없으면 None이다."""
+
+    from_goal_id: uuid.UUID
+    to_goal_id: uuid.UUID
+    count: int
+    kind: str | None = None

--- a/backend/tests/test_2360_goal_edges_realdb.py
+++ b/backend/tests/test_2360_goal_edges_realdb.py
@@ -1,0 +1,374 @@
+"""story #2360(오르테가 판정 2026-07-31, 스레드 7256d5cc) — 목표(에픽) 간 「낳음」 연결을
+목표 쌍 단위로 집계하는 `GET /api/v2/analytics/goal-edges`.
+
+착수 前 조사(디디)에서 답한 넷을 그대로 AC로 박은 것 + 구현 중 발견한 다섯째(같은 스토리
+쌍이 entity_references·reference_semantic_candidates 양쪽에 걸려도 1로 세야 한다)를
+이 파일이 실측으로 고정한다.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tests.test_2267_story_origin_realdb import (
+    _REAL_DB_URL,
+    _client_for,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _session_factory,
+    _setup_app_human,
+)
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _make_goal(session, org_id, project_id, title="Goal"):
+    from app.models.pm import Goal
+    goal = Goal(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(goal)
+    await session.commit()
+    return goal
+
+
+async def _make_story(session, org_id, project_id, epic_id=None, title="S"):
+    from app.models.pm import Story
+    story = Story(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title,
+        status="backlog", priority="medium", epic_id=epic_id,
+    )
+    session.add(story)
+    await session.commit()
+    return story
+
+
+async def _make_created_from(session, org_id, source_id, target_id):
+    from app.services.reference_core import insert_reference
+    await insert_reference(
+        session, org_id=org_id, source_type="story", source_field="self", source_id=source_id,
+        target_type="story", target_id=target_id, form="mention", created_by=None,
+        relation="created_from",
+    )
+    await session.commit()
+
+
+async def _make_declared_candidate(session, org_id, source_id, target_id, relation_kind, source_field="body"):
+    from app.models.reference_semantic_candidate import ReferenceSemanticCandidate
+    session.add(ReferenceSemanticCandidate(
+        id=uuid.uuid4(), org_id=org_id, source_type="story", source_field=source_field,
+        source_id=source_id, target_type="story", target_id=target_id, form="mention",
+        relation_kind=relation_kind, matched_keyword=None, snippet="s", status="declared",
+        declared_by=None, declared_at=None,
+    ))
+    await session.commit()
+
+
+async def _call(client, project_id):
+    return await client.get("/api/v2/analytics/goal-edges", params={"project_id": str(project_id)})
+
+
+def _find_edge(rows, from_id, to_id):
+    return next((r for r in rows if r["from_goal_id"] == str(from_id) and r["to_goal_id"] == str(to_id)), None)
+
+
+# ─── ①②③: 두 소스 합산·A→A 제외·epic NULL 제외 ─────────────────────────────
+
+async def test_goal_edges_combines_both_sources_excludes_self_loop_and_no_epic():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+            goal_a = await _make_goal(s, org.id, project.id, "A")
+            goal_b = await _make_goal(s, org.id, project.id, "B")
+
+            # A -> B: created_from 한 건(kind 없음)
+            s1 = await _make_story(s, org.id, project.id, epic_id=goal_a.id, title="A1")
+            s2 = await _make_story(s, org.id, project.id, epic_id=goal_b.id, title="B1")
+            await _make_created_from(s, org.id, s1.id, s2.id)
+
+            # A -> B: declared 한 건 더(다른 스토리 쌍, kind='spawned') — count가 2로 늘어야 함
+            s3 = await _make_story(s, org.id, project.id, epic_id=goal_a.id, title="A2")
+            s4 = await _make_story(s, org.id, project.id, epic_id=goal_b.id, title="B2")
+            await _make_declared_candidate(s, org.id, s3.id, s4.id, "spawned")
+
+            # A -> A(자기 목표 안) — 제외돼야 함
+            s5 = await _make_story(s, org.id, project.id, epic_id=goal_a.id, title="A3")
+            s6 = await _make_story(s, org.id, project.id, epic_id=goal_a.id, title="A4")
+            await _make_created_from(s, org.id, s5.id, s6.id)
+
+            # epic 없는 스토리가 낀 연결 — 제외돼야 함
+            s7 = await _make_story(s, org.id, project.id, epic_id=None, title="NOEPIC")
+            await _make_created_from(s, org.id, s7.id, s2.id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await _call(client, project.id)
+            assert resp.status_code == 200, resp.text
+            rows = resp.json()
+
+            edge_ab = _find_edge(rows, goal_a.id, goal_b.id)
+            assert edge_ab is not None, "A->B 연결이 아예 안 나왔다"
+            assert edge_ab["count"] == 2, "두 소스(created_from+declared)가 합산 안 됐다"
+
+            assert _find_edge(rows, goal_a.id, goal_a.id) is None, "A->A 자기 목표 안이 안 빠졌다"
+            # epic 없는 스토리(s7)가 낀 연결은 goal_id 자체가 없어 어느 쪽에도 안 잡혀야 한다.
+            assert all(r["from_goal_id"] != str(goal_a.id) or r["to_goal_id"] != str(goal_b.id)
+                       or r["count"] == 2 for r in rows)
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── ⑤(구현 중 발견): 같은 스토리 쌍이 두 표 모두에 걸려도 1로 센다 ──────────
+
+async def test_goal_edges_same_story_pair_in_both_sources_counts_once():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+            goal_a = await _make_goal(s, org.id, project.id, "A")
+            goal_b = await _make_goal(s, org.id, project.id, "B")
+
+            src = await _make_story(s, org.id, project.id, epic_id=goal_a.id, title="SRC")
+            tgt = await _make_story(s, org.id, project.id, epic_id=goal_b.id, title="TGT")
+            # 같은 (src, tgt) 쌍이 created_from으로도, declared로도 동시에 걸린다.
+            await _make_created_from(s, org.id, src.id, tgt.id)
+            await _make_declared_candidate(s, org.id, src.id, tgt.id, "spawned", source_field="description")
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await _call(client, project.id)
+            assert resp.status_code == 200, resp.text
+            edge = _find_edge(resp.json(), goal_a.id, goal_b.id)
+            assert edge is not None
+            assert edge["count"] == 1, "같은 스토리 쌍이 두 표에 걸려 있다고 2로 중복 집계했다"
+            # 한 쌍 안에서 kind가 섞였다(created_from=없음 vs declared=spawned) — None이어야 함.
+            assert edge["kind"] is None
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── kind 규칙 — 단일/혼합/없음 세 갈래 ──────────────────────────────────────
+
+async def test_goal_edges_kind_single_value_when_uniform():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+            goal_a = await _make_goal(s, org.id, project.id, "A")
+            goal_b = await _make_goal(s, org.id, project.id, "B")
+
+            s1 = await _make_story(s, org.id, project.id, epic_id=goal_a.id, title="A1")
+            t1 = await _make_story(s, org.id, project.id, epic_id=goal_b.id, title="B1")
+            await _make_declared_candidate(s, org.id, s1.id, t1.id, "spawned")
+            s2 = await _make_story(s, org.id, project.id, epic_id=goal_a.id, title="A2")
+            t2 = await _make_story(s, org.id, project.id, epic_id=goal_b.id, title="B2")
+            await _make_declared_candidate(s, org.id, s2.id, t2.id, "spawned")
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await _call(client, project.id)
+            edge = _find_edge(resp.json(), goal_a.id, goal_b.id)
+            assert edge["count"] == 2
+            assert edge["kind"] == "spawned"
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+async def test_goal_edges_kind_null_when_mixed():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+            goal_a = await _make_goal(s, org.id, project.id, "A")
+            goal_b = await _make_goal(s, org.id, project.id, "B")
+
+            s1 = await _make_story(s, org.id, project.id, epic_id=goal_a.id, title="A1")
+            t1 = await _make_story(s, org.id, project.id, epic_id=goal_b.id, title="B1")
+            await _make_declared_candidate(s, org.id, s1.id, t1.id, "spawned")
+            s2 = await _make_story(s, org.id, project.id, epic_id=goal_a.id, title="A2")
+            t2 = await _make_story(s, org.id, project.id, epic_id=goal_b.id, title="B2")
+            await _make_declared_candidate(s, org.id, s2.id, t2.id, "followed")
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await _call(client, project.id)
+            edge = _find_edge(resp.json(), goal_a.id, goal_b.id)
+            assert edge["count"] == 2
+            assert edge["kind"] is None, "섞인 종류인데 kind가 null이 아니다"
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+async def test_goal_edges_kind_null_when_created_from_only():
+    """entity_references(created_from)는 kind 축이 없다 — None으로 집계된다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+            goal_a = await _make_goal(s, org.id, project.id, "A")
+            goal_b = await _make_goal(s, org.id, project.id, "B")
+            s1 = await _make_story(s, org.id, project.id, epic_id=goal_a.id, title="A1")
+            t1 = await _make_story(s, org.id, project.id, epic_id=goal_b.id, title="B1")
+            await _make_created_from(s, org.id, s1.id, t1.id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await _call(client, project.id)
+            edge = _find_edge(resp.json(), goal_a.id, goal_b.id)
+            assert edge["count"] == 1
+            assert edge["kind"] is None
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── AC6 — 쿼리 개수가 스토리 수와 무관하게 고정(2) ─────────────────────────
+
+async def test_goal_edges_query_count_is_fixed_regardless_of_story_count():
+    from app.core.database import async_session_factory
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            goal_a = await _make_goal(s, org.id, project.id, "A")
+            goal_b = await _make_goal(s, org.id, project.id, "B")
+            # 목표 쌍 하나에 스토리 쌍 5개를 심는다 — 쿼리 수는 이 개수와 무관해야 한다.
+            for i in range(5):
+                src = await _make_story(s, org.id, project.id, epic_id=goal_a.id, title=f"A{i}")
+                tgt = await _make_story(s, org.id, project.id, epic_id=goal_b.id, title=f"B{i}")
+                if i % 2 == 0:
+                    await _make_created_from(s, org.id, src.id, tgt.id)
+                else:
+                    await _make_declared_candidate(s, org.id, src.id, tgt.id, "spawned")
+
+        from app.repositories.analytics import AnalyticsRepository
+
+        async with Session() as s:
+            repo = AnalyticsRepository(s, org.id)
+            call_count = {"n": 0}
+            _orig_execute = s.execute
+
+            async def _counting_execute(*args, **kwargs):
+                call_count["n"] += 1
+                return await _orig_execute(*args, **kwargs)
+
+            s.execute = _counting_execute
+            try:
+                rows = await repo.get_goal_edges(project.id)
+            finally:
+                s.execute = _orig_execute
+
+            assert call_count["n"] == 2, f"쿼리 개수가 고정 2가 아니다(스토리 5쌍인데 {call_count['n']}회)"
+            edge = _find_edge(
+                [{"from_goal_id": str(r["from_goal_id"]), "to_goal_id": str(r["to_goal_id"]),
+                  "count": r["count"], "kind": r["kind"]} for r in rows],
+                goal_a.id, goal_b.id,
+            )
+            assert edge["count"] == 5
+    finally:
+        await engine.dispose()
+
+
+# ─── 권한·빈 프로젝트 ────────────────────────────────────────────────────────
+
+async def test_goal_edges_cross_project_is_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project_a = await _make_project(s, org.id, name="A")
+            project_b = await _make_project(s, org.id, name="B")
+            _, user_id = await _make_human_member(s, org.id, project_b.id)  # caller는 B만 접근권
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await _call(client, project_a.id)
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+async def test_goal_edges_empty_project_returns_empty_array_not_error():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await _call(client, project.id)
+            assert resp.status_code == 200, resp.text
+            assert resp.json() == []
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -116,6 +116,8 @@ _FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
         "story #2224(S2-1) 신규 — 동일 _assert_project_access 가드(다른 analytics 엔드포인트와 동일 패턴)",
     "app.routers.analytics:get_epic_flow_nodes":
         "story #2224 노드 계약 신규 — 동일 _assert_project_access 가드(다른 analytics 엔드포인트와 동일 패턴)",
+    "app.routers.analytics:get_goal_edges":
+        "story #2360 신규 — 동일 _assert_project_access 가드(다른 analytics 엔드포인트와 동일 패턴)",
     "app.routers.workflow_executions:list_executions":
         "설계상 안전(SEC-S8 BB 정리) — non-admin은 target_agent_id==member_id로 self-scope, admin은 org 전체 권한으로 통과",
     "app.routers.visual_artifacts:list_artifacts":


### PR DESCRIPTION
## Summary
목업 v3 승인 본체(목표 여럿 세로·시간 가로·목표 간 선)에 필요한 BE 경로. 지금까지 유일한 읽기 길은 `GET /stories/{id}/backlinks`(스토리 한 건씩·limit 200·최대 10페이지)뿐이라 목표 간 선 하나에 「스토리 수 × 1~10 콜」이 들었다.

`GET /api/v2/analytics/goal-edges?project_id=...` → `[{from_goal_id, to_goal_id, count, kind}]`을 **고정 2쿼리**(스토리 수·건수와 무관, AC6)로 낸다.

### 두 소스 합산 + 구현 중 발견한 dedup 함정
- `entity_references(relation='created_from')` + `reference_semantic_candidates(status='declared')` 둘 다 센다(유나 축 판정 — "사람이 봐야 하는가"로 가르므로 둘 다 실선).
- `entity_references`는 `kind` 축 자체가 없다(relation 컬럼은 `'none'|'created_from'`뿐) — created_from 기원은 "종류 없음"으로 집계, declared와 섞이면 기존 "섞이면 null" 규칙이 그대로 덮는다(새 규칙 불요).
- ⚠️**구현 중 발견**: SQL에서 미리 `GROUP BY`하면 안 된다 — `reference_semantic_candidates`는 `source_field`(description/acceptance_criteria)가 유니크 키에 포함돼 같은 스토리 쌍이 두 field 모두에서 걸리면 행이 2개일 수 있고, 같은 스토리 쌍이 `entity_references`와 `reference_semantic_candidates` 양쪽에 동시에 걸릴 수도 있다(created_from으로 기록되고 별도로 declared로도 승격된 경우). "count = 스토리 **쌍**의 수"(AC 문구 그대로)를 지키려면 두 쿼리를 raw 행으로만 받고 스토리 쌍 단위로 먼저 파이썬에서 dedup한 뒤 목표 쌍으로 올려야 한다 — 그대로 SQL GROUP BY했으면 같은 스토리 쌍이 두 표에 걸릴 때 count가 부풀었을 것이다(테스트로 고정).

### 나머지 AC
- A→A(자기 목표 안) 제외, 한쪽이라도 `epic_id` NULL이면 제외(별도 버킷 없음).
- `_assert_project_access` 기존 analytics 라우트와 동일 재사용 — cross-project 404.
- 빈 프로젝트는 빈 배열(200), 못 읽은 건 오류 코드로.

## AC9 라이브 실측 — 배포 前이라 미실행
dev 백엔드에 아직 이 엔드포인트가 없어(`404 Not Found` 직접 확인) 라이브 호출은 배포 후에나 가능하다. 머지·배포되면 실제로 호출해 값을 적겠다(#2222 AC4와 같은 처지 — "배선했다"로 갈음하지 않는다).

## Test plan
- [x] 신규 realdb 테스트(`test_2360_goal_edges_realdb.py`, 8건): 두 소스 합산·A→A 제외·epic NULL 제외·같은 스토리 쌍 양쪽 표 중복 방지(dedup 함정)·kind 단일/혼합/created_from-only 세 갈래·**쿼리 개수 고정 2(스토리 5쌍 심고 직접 확인)**·cross-project 404·빈 프로젝트 빈 배열
- [x] 관련 회귀(analytics/epics-progress-lane) 29건 전부 통과
- [x] Query(None) sentinel lint / has_project_access 403 lint 둘 다 신규 위반 0건
- [x] 로컬 `alembic upgrade head`(실 마이그 스키마)로 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)