### PR TITLE
fix(scripts): story#2223 — 백필 스크립트가 ALEMBIC_URL로도 돌게 폴백

### DIFF
--- a/backend/scripts/backfill_reference_semantic_candidates.py
+++ b/backend/scripts/backfill_reference_semantic_candidates.py
@@ -11,9 +11,17 @@
 안전하게 만든다. 이미 declared된 후보는 caller가 그 키로 다시 insert를 시도해도 conflict라
 그대로 보존된다(사람의 승격 결정이 재계산으로 지워지지 않는다는 #2328의 불변식 그대로).
 
-env: DATABASE_URL (백엔드 동일, cloud-sql-proxy/in-VPC 경유). 쓰기 작업.
+env: DATABASE_URL이 있으면 그것을 쓴다(백엔드 동일, cloud-sql-proxy/in-VPC 경유). 없으면
+ALEMBIC_URL로 떨어진다(오르테가 판정, 2026-07-31 — Cloud Run Job `sprintable-verify-oneoff`가
+DATABASE_URL이 아니라 ALEMBIC_URL만 갖고 있어, 잡 설정을 안 건드리고 이 스크립트 한 곳에서
+받는다: "손질이 한 번이면 코드로 넣고, 매번이면 그건 손질이 아니라 결함이다"). ALEMBIC_URL은
+psycopg2 스킴이라 이 스크립트가 쓰는 async engine(asyncpg)용으로 자동 변환한다. ⛔조용히
+넘어가지 않는다 — 어느 쪽을 썼는지(스킴+호스트만, 자격증명 제외) 첫 로그 줄에 남긴다.
+쓰기 작업.
+
 실행: cd backend && DATABASE_URL=... python -m scripts.backfill_reference_semantic_candidates
       [--batch-size N] [--dry-run]
+      (또는 ALEMBIC_URL만 있는 환경 — sprintable-verify-oneoff 잡 등 — 에서 그대로 실행)
 """
 from __future__ import annotations
 
@@ -24,14 +32,45 @@ import os
 import sys
 import uuid
 from collections import Counter
+from urllib.parse import urlsplit
 
 from sqlalchemy import select
 
-from app.core.database import async_session_factory
-from app.models.pm import Story
-from app.services.reference_semantic_candidates import generate_and_store_candidates
-
 logger = logging.getLogger("backfill_reference_semantic_candidates")
+
+
+def _resolve_database_url() -> str | None:
+    """DATABASE_URL이 있으면 그것을 그대로 쓴다. 없고 ALEMBIC_URL이 있으면 psycopg2→asyncpg
+    스킴 변환 후 os.environ["DATABASE_URL"]에 심는다. 반환값은 로그용 요약(스킴+호스트만) —
+    자격증명은 절대 담지 않는다.
+
+    ⛔이 함수는 반드시 `app.core.database` import **前**에 호출돼야 한다 — 그 모듈의
+    `engine`은 import 시점에 `settings.database_url`(pydantic, DATABASE_URL env 자동매핑)로
+    한 번만 만들어져서, 여기서 나중에 os.environ을 채워도 이미 만들어진 engine엔 반영되지
+    않는다(2026-07-31 오르테가 판정 — "main() 안 폴백은 이미 늦다")."""
+    if os.environ.get("DATABASE_URL"):
+        source = "DATABASE_URL"
+    elif os.environ.get("ALEMBIC_URL"):
+        raw = os.environ["ALEMBIC_URL"]
+        converted = raw
+        for prefix in ("postgresql+psycopg2://", "postgresql://"):
+            if raw.startswith(prefix):
+                converted = "postgresql+asyncpg://" + raw[len(prefix):]
+                break
+        os.environ["DATABASE_URL"] = converted
+        source = "ALEMBIC_URL(스킴 변환)"
+    else:
+        return None
+
+    parts = urlsplit(os.environ["DATABASE_URL"])
+    return f"{source} → scheme={parts.scheme} host={parts.hostname}"
+
+
+_db_url_summary = _resolve_database_url()
+
+from app.core.database import async_session_factory  # noqa: E402 — 위 폴백이 먼저 돌아야 한다
+from app.models.pm import Story  # noqa: E402
+from app.services.reference_semantic_candidates import generate_and_store_candidates  # noqa: E402
 
 
 async def _run(batch_size: int, dry_run: bool) -> dict:
@@ -104,9 +143,12 @@ async def _run(batch_size: int, dry_run: bool) -> dict:
 
 
 async def main() -> int:
-    if not os.environ.get("DATABASE_URL"):
-        print("DATABASE_URL 미설정", file=sys.stderr)
+    if _db_url_summary is None:
+        print("DATABASE_URL·ALEMBIC_URL 둘 다 미설정", file=sys.stderr)
         return 2
+    # ⛔폴백이 조용하면 나중에 "왜 그 DB를 봤지"를 못 찾는다(오르테가 지시) — 값이 아니라
+    # 스킴+호스트만(자격증명 제외) 첫 줄에 남긴다.
+    logger.info("DB 연결: %s", _db_url_summary)
 
     parser = argparse.ArgumentParser(description="reference_semantic_candidates 배치 백필 (idempotent)")
     parser.add_argument("--batch-size", type=int, default=200, help="배치당 story 수 (기본 200)")

--- a/backend/tests/test_2223_backfill_script_db_url_fallback.py
+++ b/backend/tests/test_2223_backfill_script_db_url_fallback.py
@@ -1,0 +1,96 @@
+"""story #2223 후속(오르테가 판정, 2026-07-31) — `backfill_reference_semantic_candidates.py`가
+DATABASE_URL 없이 ALEMBIC_URL만 있는 환경(Cloud Run Job `sprintable-verify-oneoff`)에서도
+돌 수 있게 하는 폴백. 순수 로직 테스트 — DB 연결 없음(모듈 import가 만드는 engine은 lazy라
+실제 연결을 안 한다).
+
+⛔이 스크립트의 engine은 `app.core.database` import **시점**에 만들어진다 — 폴백은 반드시
+그 import 前에 os.environ["DATABASE_URL"]을 채워야 한다(늦으면 무효). 이 파일은 매 테스트마다
+모듈을 `importlib.reload`해 그 순서를 실제로 태운다."""
+from __future__ import annotations
+
+import importlib
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _restore_env():
+    saved = {k: os.environ.get(k) for k in ("DATABASE_URL", "ALEMBIC_URL")}
+    yield
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+def _reload_script():
+    import scripts.backfill_reference_semantic_candidates as mod
+    return importlib.reload(mod)
+
+
+def test_prefers_database_url_when_present():
+    os.environ["DATABASE_URL"] = "postgresql+asyncpg://u:p@myhost:5432/db"
+    os.environ.pop("ALEMBIC_URL", None)
+    mod = _reload_script()
+
+    assert mod._db_url_summary is not None
+    assert mod._db_url_summary.startswith("DATABASE_URL")
+    assert "myhost" in mod._db_url_summary
+    assert os.environ["DATABASE_URL"] == "postgresql+asyncpg://u:p@myhost:5432/db"
+
+
+def test_falls_back_to_alembic_url_with_scheme_conversion():
+    os.environ.pop("DATABASE_URL", None)
+    os.environ["ALEMBIC_URL"] = "postgresql+psycopg2://u:secret-pw@alembic-host:5432/db"
+    mod = _reload_script()
+
+    assert mod._db_url_summary is not None
+    assert "ALEMBIC_URL" in mod._db_url_summary
+    assert "alembic-host" in mod._db_url_summary
+    # 스킴이 asyncpg로 바뀌어야 engine이 실제로 쓸 수 있다.
+    assert os.environ["DATABASE_URL"].startswith("postgresql+asyncpg://")
+    assert "alembic-host" in os.environ["DATABASE_URL"]
+
+
+def test_falls_back_plain_postgresql_scheme_too():
+    os.environ.pop("DATABASE_URL", None)
+    os.environ["ALEMBIC_URL"] = "postgresql://u:pw@plain-host:5432/db"
+    mod = _reload_script()
+
+    assert os.environ["DATABASE_URL"] == "postgresql+asyncpg://u:pw@plain-host:5432/db"
+
+
+def test_summary_never_contains_credentials():
+    os.environ.pop("DATABASE_URL", None)
+    os.environ["ALEMBIC_URL"] = "postgresql+psycopg2://myuser:supersecret@somehost:5432/db"
+    mod = _reload_script()
+
+    assert "supersecret" not in mod._db_url_summary
+    assert "myuser" not in mod._db_url_summary
+
+
+def test_neither_set_returns_none():
+    os.environ.pop("DATABASE_URL", None)
+    os.environ.pop("ALEMBIC_URL", None)
+    mod = _reload_script()
+
+    assert mod._db_url_summary is None
+
+
+@pytest.mark.anyio
+async def test_main_returns_2_and_prints_error_when_neither_set(capsys):
+    os.environ.pop("DATABASE_URL", None)
+    os.environ.pop("ALEMBIC_URL", None)
+    mod = _reload_script()
+
+    rc = await mod.main()
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "미설정" in captured.err
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"


### PR DESCRIPTION
## Summary
story #2223(#번호 산문 참조 백필)의 `sprintable-verify-oneoff` Cloud Run Job 실행 경로를 여는 작업. 스크립트가 `DATABASE_URL`을 요구하는데 그 잡은 `ALEMBIC_URL`만 갖고 있어(Alembic 마이그레이션용 시크릿 재사용) 지금까지 dry-run조차 못 돌렸다.

### 판단 근거(PO 요청 — 스크립트 폴백 vs 잡 env 추가, 어느 쪽이 되돌릴 게 적은가)
- 잡(`sprintable-verify-oneoff`)은 여러 일회성 스크립트가 공유하는 자원이라, 거기에 영구 env를 더하면 다음 사람이 쓸 다른 스크립트에도 영향을 준다.
- `ALEMBIC_URL`은 psycopg2 스킴인데 이 스크립트가 쓰는 async engine은 asyncpg 스킴을 요구한다 — 잡에 env만 얹으면 **매번 실행자가 손으로 스킴을 변환**해야 하는데, "손질이 한 번이면 코드로 넣고 매번이면 그건 결함"이라는 판정에 따라 스크립트 쪽에 흡수했다.
- `app.core.database.engine`은 **모듈 import 시점**에 만들어지므로(pydantic settings가 `DATABASE_URL` env를 그때 읽는다), 폴백 로직은 반드시 그 import **前**에 실행돼야 한다 — import 순서를 재배치했다.

### 동작
- `DATABASE_URL`이 있으면 그대로 쓴다.
- 없고 `ALEMBIC_URL`이 있으면 `postgresql+psycopg2://`/`postgresql://` → `postgresql+asyncpg://`로 변환해 `DATABASE_URL`에 심는다.
- 어느 쪽도 없으면 명확한 에러(종료 코드 2).
- ⛔조용히 넘어가지 않는다 — 첫 로그 줄에 어느 쪽을 썼는지(스킴+호스트만, **자격증명 제외**) 남긴다.

## Test plan
- [x] 신규 유닛 테스트(`test_2223_backfill_script_db_url_fallback.py`, 6건, DB 불요·순수 로직): DATABASE_URL 우선 · ALEMBIC_URL 폴백(psycopg2/plain 스킴 둘 다) · 요약 문자열에 자격증명 미포함 · 둘 다 없으면 명확한 에러(exit 2)
- [x] Query(None) sentinel lint / has_project_access 403 lint 둘 다 신규 위반 0건
- [x] 수동 sanity: `DATABASE_URL` 지정 환경에서 `_db_url_summary`가 올바르게 스킴+호스트만 담는 것 확인

⚠️이 PR은 **폴백만** 연다 — 실제 백필 실행(dry-run→실행)은 목업 판정과 순서를 맞춰 별도로 진행한다(PO 판정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)