### PR TITLE
fix(scripts): story#2223 — 백필 스크립트가 이미지 밖에 있던 문제(scripts/jobs/로 이동)

### DIFF
--- a/backend/app/models/reference_semantic_candidate.py
+++ b/backend/app/models/reference_semantic_candidate.py
@@ -38,7 +38,7 @@ docstring이 스스로 막아 둔 것이 근거).
 `_reconcile_story_references_and_candidates()`를 한 번도 안 불렀던 버그(오르테가군, 오늘
 아침 수정)로 이 표가 선 뒤(2026-07-29 23:18~) 실제로 쌓인 행이 104건뿐(해소된 후보
 1349건 대비 7.7%)이었던 것이 실측으로 드러나 "소급"이 사실상 "첫 채우기"였다 — 그래서
-`backend/scripts/backfill_reference_semantic_candidates.py`(1회성, Cloud Run Job으로
+`backend/scripts/jobs/backfill_reference_semantic_candidates.py`(1회성, Cloud Run Job으로
 실행·재실행해도 멱등 — `store_semantic_candidates`의 ON CONFLICT DO NOTHING 그대로 재사용)
 가 생겼다. write-path(story 저장 시점)는 여전히 유일한 **상시** 경로다 — 백필은 그 경로를
 과거 데이터에 한 번 더 돌리는 것뿐, 별도 로직을 새로 만들지 않는다.

--- a/backend/scripts/jobs/backfill_reference_semantic_candidates.py
+++ b/backend/scripts/jobs/backfill_reference_semantic_candidates.py
@@ -19,9 +19,16 @@ psycopg2 스킴이라 이 스크립트가 쓰는 async engine(asyncpg)용으로 
 넘어가지 않는다 — 어느 쪽을 썼는지(스킴+호스트만, 자격증명 제외) 첫 로그 줄에 남긴다.
 쓰기 작업.
 
-실행: cd backend && DATABASE_URL=... python -m scripts.backfill_reference_semantic_candidates
+실행: cd backend && DATABASE_URL=... python -m scripts.jobs.backfill_reference_semantic_candidates
       [--batch-size N] [--dry-run]
       (또는 ALEMBIC_URL만 있는 환경 — sprintable-verify-oneoff 잡 등 — 에서 그대로 실행)
+
+⚠️2026-07-31 오르테가 실측(#2727 후속) — 이 파일은 원래 `scripts/` 루트에 있었으나
+`backend/Dockerfile`이 `COPY scripts/jobs/`·`COPY scripts/migrate.sh`만 담아 scripts/ 루트는
+이미지에 안 들어갔다(#1666 의도적 축소 — deploy/setup/provision 등 비-런타임 제외).
+즉 이 스크립트가 backend:latest-dev 이미지 «안에 없어» Cloud Run Job이 못 열었다 —
+Dockerfile에 COPY를 더하지 않고 `scripts/jobs/`(같은 종류의 백필들이 이미 사는 자리)로
+옮기는 쪽이 근본이다.
 """
 from __future__ import annotations
 

--- a/backend/tests/test_2223_backfill_script_db_url_fallback.py
+++ b/backend/tests/test_2223_backfill_script_db_url_fallback.py
@@ -26,7 +26,7 @@ def _restore_env():
 
 
 def _reload_script():
-    import scripts.backfill_reference_semantic_candidates as mod
+    import scripts.jobs.backfill_reference_semantic_candidates as mod
     return importlib.reload(mod)
 
 


### PR DESCRIPTION
## 무엇
#2727(DATABASE_URL/ALEMBIC_URL 폴백)이 머지된 뒤, 오르테가님이 실측으로 잡은 것 — `backend/Dockerfile`이 `COPY scripts/jobs/`·`COPY scripts/migrate.sh`만 담아 `scripts/` **루트**는 `backend:latest-dev` 이미지에 안 들어간다(#1666에서 의도적으로 좁힌 것). `backfill_reference_semantic_candidates.py`가 그 루트에 있어 Cloud Run Job이 못 여는 상태였다 — "폴백을 고쳤다"와 "돌릴 수 있다"가 다른 칸이었다.

## 왜 이 방식인가
Dockerfile에 COPY를 한 줄 더 붙이는 대신(#1666의 축소 의도를 갉는 방식), 같은 종류의 백필들(`backfill_doc_base64_assets.py`, `backfill_void_empty_merge_gates.py`)이 이미 사는 `scripts/jobs/`로 파일을 옮겼다 — 자리를 잘못 잡았던 것이 근본이라 Dockerfile은 안 건드려도 된다.

## 변경
- `git mv backend/scripts/{,jobs/}backfill_reference_semantic_candidates.py`
- 모듈 경로 변경(`scripts.backfill_...` → `scripts.jobs.backfill_...`)에 맞춰 테스트 import·스크립트 docstring 실행 커맨드·모델 docstring 참조 갱신
- Dockerfile 변경 없음(`COPY scripts/jobs/`가 자동으로 새 위치를 담는다)

## 검증(수로 확認 — Ortega 요청 AC)
- 로컬 `docker build`로 실제 `backend:latest-dev`와 동일한 Dockerfile 빌드 후, 이미지 안에서 직접 확인:
  ```
  ls /app/scripts/jobs/backfill_reference_semantic_candidates.py   # 존재
  ls /app/scripts/backfill_reference_semantic_candidates.py        # No such file (구 경로엔 없음, 정상)
  python -c "import scripts.jobs.backfill_reference_semantic_candidates as m; print(m.__file__)"  # import OK
  ```
- 유닛테스트 6개 통과(`test_2223_backfill_script_db_url_fallback.py`, import 경로만 갱신)
- 두 lint 가드(Query sentinel·has_project_access 403) 클린 — 신규 위반 0건

## 다음
이 PR이 서면 잡 실행은 오르테가님 손(잡을 잡고 대기 중이라 하심).