### PR TITLE
test(throwaway): design:pass freshness mutation evidence for #2361 — DO NOT MERGE

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -669,3 +669,5 @@
 .tiptap [data-type="toggleContent"] { padding-left: 1.25rem; margin-left: 0.875rem; border-left: 2px solid hsl(var(--border)); margin-top: 0.25rem; }
 [data-type="toggleSummary"],
 .tiptap [data-type="toggleSummary"] { cursor: pointer; }
+
+/* #2361 freshness mutation-test touch (commit 1) — throwaway, will be reverted */


### PR DESCRIPTION
Throwaway PR to prove the AC7 freshness check (#2731) actually catches a stale label. Will label now, then push a new commit to make it stale, then re-label. Close without merging when done.