### PR TITLE
feat(ci): qa-review-gate — qa:pass label required on every PR (#2364)

### DIFF
--- a/.github/workflows/qa-review-gate.yml
+++ b/.github/workflows/qa-review-gate.yml
@@ -43,6 +43,19 @@ name: QA Review Gate
 # 않는다. qa:pass/qa:changes 라벨은 이 스토리 착수 시점에 없어서 새로 만들었다
 # (design:pass/design:changes와 같은 색·문구 관례로: pass=#0E8A16·changes=#D93F0B).
 #
+# ⭐AC8(유나신 지적, 뒤늦게 추가) — 라벨 «설명» 자신이 「무엇을 말하지 않는가」를 적는다.
+# 오늘 QA 없이 머지된 일곱 중 둘은 유나신 자신이 design:pass를 준 판이었는데, 리뷰 본문엔
+# "디자인 축만 통과"라 적어 놓고도 라벨 설명 자체엔 그 경계가 없었다 — 머지 누르는 사람은
+# 리뷰 본문이 아니라 라벨만 본다(라벨이 리뷰 본문보다 «멀리» 간다). 그래서 GitHub label
+# 자체의 description을 고쳤다: qa:pass = "QA 축(사람이 쓰는 경로)만 확認 — 디자인·성능·
+# 라이브 픽셀은 이 라벨이 말하지 않는다." 이 워크플로의 성공 메시지에도 같은 경계를 반복한다.
+#
+# ⭐AC9(유나신 지적) — design:pass·qa:pass 둘 다 초록이어도 "다 됐다"가 아니다. 둘을 합쳐도
+# 안 덮는 것: 라이브 픽셀(실제 렌더 회귀)·성능·접근성. 이 워크플로가 두 게이트 중 나중에
+# 도는 자리(머지 직전에 읽히는 자리)라 아래 freshness 스텝의 마지막 성공 로그에 이 문장을
+# 박아 둔다 — 안 적으면 "게이트 둘 다 초록"이 또 다른 거짓 안심(오늘 CI 초록이 그랬던 것과
+# 같은 모양)을 판다.
+#
 # ⚠️이 워크플로우가 실제로 머지를 막으려면 GitHub 저장소 설정 > Branch protection의
 # required status checks에 아래 job 이름("QA review gate")을 등록해야 한다 — repo admin
 # 권한이 필요해 이 PR로는 못 하고, 등록 자체의 양성대조(라벨 없는 PR이 실제로 merge 버튼이
@@ -81,7 +94,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${HAS_QA_PASS}" = "true" ]; then
-            echo "qa:pass present — QA reviewed this PR's user-facing path(s)."
+            echo "qa:pass present — QA axis (the paths a real user takes) reviewed. (AC8: this label speaks only to the QA axis — design, performance, and live-pixel rendering are not what it says.)"
           else
             echo "::error title=qa:pass missing::This PR has no qa:pass label. QA review is required before merge — CI green only proves the code runs, not that the paths a real user takes are correct (2026-07-31: authz gaps passed CI because the tests only checked same-project access; nobody checked cross-project)."
             exit 1
@@ -113,3 +126,4 @@ jobs:
             exit 1
           fi
           echo "qa:pass attached at ${LABEL_TS} — at or after the latest commit (${LAST_COMMIT_TS}). Fresh."
+          echo "(AC9: design:pass + qa:pass both green is not 'everything is done' — live-pixel rendering, performance, and accessibility are covered by neither gate.)"

--- a/.github/workflows/qa-review-gate.yml
+++ b/.github/workflows/qa-review-gate.yml
@@ -1,0 +1,108 @@
+name: QA Review Gate
+
+# story #2364: QA 없이 머지되는 것을 막는다 — qa:pass 라벨 게이트.
+# 배경: 2026-07-31, PO가 PR 일곱(#2719·#2721·#2722·#2724·#2726·#2727·#2720)을 QA 없이
+# 눌렀다. 까심 사후검수: 여섯 APPROVE·하나(#2721) CRITICAL(authz 다섯 → #2363). CI는
+# "코드가 도는가"만 잰다 — authz 다섯 건은 테스트가 전부 초록이었다(그 테스트 자신이
+# "자기 프로젝트만" 쟀기 때문). "남의 프로젝트로 재는 사람"이 없었던 자리가 QA다.
+#
+# story #2361(design-review-gate.yml)과 같은 틀. 다른 점 하나(AC2): ⛔경로 필터가 없다 —
+# QA는 시각·문구뿐 아니라 «모든 PR»에 걸린다. 이번 판에서는 문서/CI 전용 PR도 예외로
+# 빼지 않는다(예외를 열면 그 예외가 자란다 — 필요해지면 그때 수를 세고 정한다).
+#
+# ⛔⭐⭐AC3 — 트리거를 on.pull_request.paths로 거르지 않는다(design-review-gate.yml AC8과
+# 같은 이유): required check에서 미실행이 스킵=통과로 세어지는 위험. 이 워크플로는 애초에
+# 경로 필터가 없으니 job은 항상 돌고, qa:pass 존재/신선도 판정만 아래 스텝에서 한다.
+#
+# ⭐AC4 — 라벨 신선도를 «처음부터» 건다(design-review-gate.yml #2731이 만든 판정을 그대로
+# 재사용 — 파일은 안 나누고 로직만 같은 패턴으로 복제했다. 근거: 2026-07-31 하루에 "승인
+# 뒤 코드가 바뀐" 실물이 셋 — #2725 라벨 뒤 develop 재당김·#2718 라벨 뒤 파일집합 변경·
+# 까심 QA APPROVE가 옛 SHA).
+#
+# 이 가드가 «못 잡는 것» — 셋(AC7). 선언 안 하면 다음 사람이 "이게 다 막는다"로 읽는다.
+#   ①라벨이 «옳게» 붙었는지는 못 본다 — 존재만 본다.
+#   ②계정이 하나라 "누가" 붙였는지로도 못 가른다.
+#   ③⭐⭐PO가 --admin으로 우회할 수 있는가 — required check도 admin merge는 못 막을 수
+#     있다. 실측(2026-07-31, gh api branches/{develop,main}/protection, repo rulesets 0건):
+#       develop: enforce_admins=true  → 지금은 admin도 required check을 못 건너뛴다
+#       main:    enforce_admins=false → admin은 지금도 required check을 건너뛸 수 있다
+#     (스토리 AC의 최초 문구는 "이 리포는 enforce_admins=false"였다 — 브랜치마다 갈리는
+#     것이 실측 결과라 블랑켓으로 안 쓴다. develop이 오늘 사고 PR들의 실제 merge base였다.)
+#     ⛔이 갭을 없애려면(main도 develop처럼) enforce_admins를 켜야 하는데 그건 이 스토리가
+#     안 짓는다 — "없앤다"가 아니라 "안 짓는다"다. 관리자가 스스로를 묶는 설정이라 그 판단은
+#     이 가드 밖(선생님/저장소 관리자 자리)이라고 본다.
+#
+# ⛔사람을 인질로 잡지 않는다 — 이 가드는 CI 자리다. 런타임·요청경로에는 아무것도 붙지
+# 않는다. qa:pass/qa:changes 라벨은 이 스토리 착수 시점에 없어서 새로 만들었다
+# (design:pass/design:changes와 같은 색·문구 관례로: pass=#0E8A16·changes=#D93F0B).
+#
+# ⚠️이 워크플로우가 실제로 머지를 막으려면 GitHub 저장소 설정 > Branch protection의
+# required status checks에 아래 job 이름("QA review gate")을 등록해야 한다 — repo admin
+# 권한이 필요해 이 PR로는 못 하고, 등록 자체의 양성대조(라벨 없는 PR이 실제로 merge 버튼이
+# 막히는지)까지 별도로 확認해야 "걸렸다"이다(AC6).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [main, develop]
+
+concurrency:
+  group: qa-review-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  qa-review-gate:
+    name: QA review gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # AC1: qa:pass가 없으면 빨강. labeled/unlabeled 이벤트가 트리거 목록에 있어 라벨을
+      # 떼면 이 스텝이 다시 돌아 빨강으로 되돌아간다. ⛔경로 필터 없음 — 모든 PR에 적용(AC2).
+      - name: Enforce qa:pass label (no path scoping — applies to every PR)
+        env:
+          HAS_QA_PASS: ${{ contains(github.event.pull_request.labels.*.name, 'qa:pass') }}
+        run: |
+          set -euo pipefail
+          if [ "${HAS_QA_PASS}" = "true" ]; then
+            echo "qa:pass present — QA reviewed this PR's user-facing path(s)."
+          else
+            echo "::error title=qa:pass missing::This PR has no qa:pass label. QA review is required before merge — CI green only proves the code runs, not that the paths a real user takes are correct (2026-07-31: authz gaps passed CI because the tests only checked same-project access; nobody checked cross-project)."
+            exit 1
+          fi
+
+      # AC4: qa:pass가 «있어도» 최신 커밋보다 먼저 붙었으면 stale이다(design-review-gate.yml
+      # #2731과 동일 로직 — 로직만 복제, 라벨 이름만 다르다). fail-closed: timeline 이벤트를
+      # 못 찾거나 gh api 자체가 실패해도 이 스텝은 그대로 실패(빨강)한다.
+      - name: Enforce qa:pass label freshness (not stale vs latest commit)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          LAST_COMMIT_TS="$(git log -1 --format=%cI "${HEAD_SHA}")"
+          LABEL_TS="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/events" --paginate \
+            --jq '[.[] | select(.event=="labeled" and .label.name=="qa:pass") | .created_at] | sort | last // empty')"
+          echo "latest commit (${HEAD_SHA}): ${LAST_COMMIT_TS}"
+          echo "qa:pass last attached: ${LABEL_TS:-<none found>}"
+          if [ -z "${LABEL_TS}" ]; then
+            echo "::error title=qa:pass timeline unreadable::qa:pass label is present but no matching 'labeled' timeline event was found for it — freshness can't be verified. Failing closed (treated as stale)."
+            exit 1
+          fi
+          LAST_COMMIT_EPOCH="$(date -d "${LAST_COMMIT_TS}" +%s)"
+          LABEL_EPOCH="$(date -d "${LABEL_TS}" +%s)"
+          if [ "${LABEL_EPOCH}" -lt "${LAST_COMMIT_EPOCH}" ]; then
+            echo "::error title=qa:pass is stale::qa:pass was attached at ${LABEL_TS}, before the latest commit (${LAST_COMMIT_TS}). Code has moved since QA reviewed — re-review and re-attach qa:pass."
+            exit 1
+          fi
+          echo "qa:pass attached at ${LABEL_TS} — at or after the latest commit (${LAST_COMMIT_TS}). Fresh."

--- a/.github/workflows/qa-review-gate.yml
+++ b/.github/workflows/qa-review-gate.yml
@@ -32,6 +32,13 @@ name: QA Review Gate
 #     안 짓는다 — "없앤다"가 아니라 "안 짓는다"다. 관리자가 스스로를 묶는 설정이라 그 판단은
 #     이 가드 밖(선생님/저장소 관리자 자리)이라고 본다.
 #
+# ⭐왜 required PR review가 아니라 라벨 게이트인가 — develop은 required_pull_request_reviews
+# 자체가 «없다»(오늘 사고의 구조적 이유 중 하나: reviews:0으로도 다 머지됐다). 그런데 이
+# 조직 계정이 하나뿐이라, required reviews를 그냥 켜면 "자기 PR은 자기가 approve 못 한다"는
+# GitHub 규칙에 걸려 «아무것도» 머지가 안 된다(유나 실측). 그래서 승인의 증거를 "review
+# 객체"가 아니라 "라벨"로 대신 나른다 — 라벨은 같은 계정이라도 리뷰어 역할(유나=design·
+# 까심=QA)이 붙였다는 사실 자체는 남기고, self-approve 제약에 걸리지 않는다.
+#
 # ⛔사람을 인질로 잡지 않는다 — 이 가드는 CI 자리다. 런타임·요청경로에는 아무것도 붙지
 # 않는다. qa:pass/qa:changes 라벨은 이 스토리 착수 시점에 없어서 새로 만들었다
 # (design:pass/design:changes와 같은 색·문구 관례로: pass=#0E8A16·changes=#D93F0B).


### PR DESCRIPTION
story #2364 — 선생님 지적("무슨 생각으로 QA를 건너 뛰었는지?")에 대한 PO 답이 "PR이 쌓이는
것"을 "팀이 멈추는 것"으로 착각했다는 것이었다. CI green은 "코드가 도는가"만 잰다 — #2721의
authz 다섯 건은 테스트가 전부 초록이었다(그 테스트 자신이 자기 프로젝트만 쟀기 때문).

## 무엇 — #2361(design-review-gate.yml)과 같은 틀
- 경로 필터 없음(AC2) — QA는 모든 PR에 걸린다. 이 PR 자신도 예외 없음.
- 트리거를 paths로 거르지 않음(AC3) — job 항상 돎, 판정은 안에서.
- 라벨 신선도를 처음부터 검(AC4) — #2731 로직 재사용(라벨 이름만 qa:pass로).
- qa:pass/qa:changes 라벨이 없어서 새로 만듦(design:pass/changes와 같은 색·문구 관례).
- required PR review 대신 라벨 게이트인 이유도 주석에 남김 — develop은
  required_pull_request_reviews가 아예 없고(오늘 사고의 구조적 원인), 계정이 하나뿐이라
  그냥 켜면 self-approve 금지 규칙에 걸려 아무것도 못 머지한다(유나 실측).

## AC7 — 못 잡는 것 셋 (③ 실측치를 스토리 원문과 다르게 정정 — 오르테가군이 재실측해 확認·반영)
```
①라벨이 «옳게» 붙었는지 못 본다(존재만 봄)
②계정이 하나라 「누가」 붙였는지 못 가름
③PO가 --admin으로 우회 가능한가 — 실측(2026-07-31):
   develop: enforce_admins=true  → 지금은 admin도 못 건너뜀 · required reviews 없음
   main:    enforce_admins=false → admin은 지금도 건너뛸 수 있음 · required reviews 1
   (repo rulesets 0건 — classic protection이 전부)
   main도 develop처럼 enforce_admins 켜는 것은 이 스토리가 안 짓는다("없앤다"가 아니라
   "안 짓는다") — 관리자 자신을 묶는 설정이라 판단 주체가 이 가드 밖.
```

## 뮤테이션 증거 (스로어웨이 #2736, 4단 — 캡처 후 close·머지 안 함)
```
① 라벨 없음                → RED
   https://github.com/moonklabs/sprintable/actions/runs/30609684327/job/91089488993
② qa:pass 부착(fresh)      → GREEN
   https://github.com/moonklabs/sprintable/actions/runs/30609704870/job/91089556273
③ 새 커밋 push(stale)      → RED
   https://github.com/moonklabs/sprintable/actions/runs/30609725118/job/91089620796
④ 라벨 제거 후 재부착(fresh) → GREEN
   https://github.com/moonklabs/sprintable/actions/runs/30609749060/job/91089693770
```

## 다음
- 이 PR 자체도 다른 모든 PR과 동일 규칙 적용받는다 — 까심군 QA 리뷰 후 qa:pass 필요.
- required check 등록 + 등록 자체의 양성대조는 PO 손(AC6).

[SID:3b0559c7-68aa-488d-bdc6-84ff8a747cfd]