### PR TITLE
fix(security): story#2363 [CRITICAL] — reference-candidate 5경로 cross-project IDOR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,6 +360,17 @@ jobs:
             echo "baseline growth check skipped: no comparison base ($COMPARE_LABEL에 project_access_403_baseline.txt 없음 — 이 PR이 그 파일을 «처음 도입»하는 중이면 정상이다, story #2342 자신이 그 경우다. 다음 PR부터는 develop에 파일이 있어 실제 비교가 돈다)"
           fi
 
+  candidate-source-ownership-lint:
+    name: candidate_id source_id ownership lint (guard, story #2363)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Scan reference_semantic_candidates.py for candidate_id lookups missing source_id ownership check
+        working-directory: backend
+        run: python3 scripts/lint_candidate_source_ownership.py
+
   # story bda4beac: alembic-fresh-db(위)는 checkout된 브랜치(develop/PR)의 파일셋 기준이라
   # main이 develop과 다른 파일셋(ee_pricing 0146/0147 부재)일 때의 그래프 단절을 원천적으로
   # 못 잡는다(실제로 못 잡아서 prod 승격이 롤백된 그 사고). PR base가 main일 때만 도는 이

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -847,7 +847,13 @@ async def declare_new_story_reference_candidate(
     실제로는 아무것도 안 바뀌는데, 응답이 늘 201·"바뀐 값처럼" 보이면 호출자가 조용히
     오독한다 — 409는 안 쓴다(이미 이어진 것은 오류가 아니다). 대신 `created`로 명시 구별하고
     (no-op이면 200으로 status_code도 함께 낮춘다), 부르는 쪽이 "이미 있었다"를 코드로
-    구별할 수 있게 한다."""
+    구별할 수 있게 한다.
+
+    ⛔IDOR 수정(오르테가 실측, 2026-07-31): target도 source와 «독립적으로» project 접근권을
+    검사한다(references.py create_reference의 양쪽-아이템 게이트와 동형 — "반쪽 금지").
+    이전엔 org_id만 걸러 접근 못 하는 프로젝트의 story를 target으로 연결할 수 있었고,
+    404(없음)/201(성공)이 갈려 존재 여부까지 샜다. 미존재·무권한 두 경우 모두 같은
+    404 "Target story not found"로 응답해 존재 비노출을 지킨다."""
     story = await repo.get(id)
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")
@@ -856,10 +862,14 @@ async def declare_new_story_reference_candidate(
     if body.target_id == id:
         raise HTTPException(status_code=400, detail="Cannot link a story to itself")
 
+    from app.services.project_auth import has_project_access
+
     target = (await repo.session.execute(
-        select(Story.id).where(Story.id == body.target_id, Story.org_id == repo.org_id)
-    )).scalar_one_or_none()
-    if target is None:
+        select(Story.id, Story.project_id).where(Story.id == body.target_id, Story.org_id == repo.org_id)
+    )).one_or_none()
+    if target is None or not await has_project_access(
+        repo.session, uuid.UUID(auth.user_id), target.project_id, repo.org_id
+    ):
         raise HTTPException(status_code=404, detail="Target story not found")
 
     from app.services.reference_semantic_candidates import (
@@ -914,7 +924,8 @@ async def declare_story_reference_candidate(
     actor_id = await _resolve_team_member_id(auth, repo.org_id, repo.session)
     try:
         candidate = await declare_candidate(
-            repo.session, org_id=repo.org_id, candidate_id=candidate_id, declared_by=actor_id,
+            repo.session, org_id=repo.org_id, source_id=id, candidate_id=candidate_id,
+            declared_by=actor_id,
         )
     except CandidateNotFoundError:
         raise HTTPException(status_code=404, detail="Reference candidate not found")
@@ -956,7 +967,7 @@ async def set_story_reference_candidate_relation_kind(
 
     try:
         candidate = await set_candidate_relation_kind(
-            repo.session, org_id=repo.org_id, candidate_id=candidate_id,
+            repo.session, org_id=repo.org_id, source_id=id, candidate_id=candidate_id,
             relation_kind=body.relation_kind,
         )
     except CandidateNotFoundError:
@@ -997,7 +1008,7 @@ async def reject_story_reference_candidate(
     actor_id = await _resolve_team_member_id(auth, repo.org_id, repo.session)
     try:
         await reject_candidate(
-            repo.session, org_id=repo.org_id, candidate_id=candidate_id,
+            repo.session, org_id=repo.org_id, source_id=id, candidate_id=candidate_id,
             rejected_by=actor_id, reason=body.reason,
         )
     except CandidateNotFoundError:
@@ -1030,7 +1041,9 @@ async def undeclare_story_reference_candidate(
     )
 
     try:
-        await undeclare_candidate(repo.session, org_id=repo.org_id, candidate_id=candidate_id)
+        await undeclare_candidate(
+            repo.session, org_id=repo.org_id, source_id=id, candidate_id=candidate_id,
+        )
     except CandidateNotFoundError:
         raise HTTPException(status_code=404, detail="Reference candidate not found")
     except CandidateNotDeclaredError:

--- a/backend/app/services/reference_semantic_candidates.py
+++ b/backend/app/services/reference_semantic_candidates.py
@@ -360,17 +360,25 @@ class CandidateNotFoundError(Exception):
 
 
 async def declare_candidate(
-    db: AsyncSession, *, org_id: uuid.UUID, candidate_id: uuid.UUID, declared_by: uuid.UUID | None,
+    db: AsyncSession, *, org_id: uuid.UUID, source_id: uuid.UUID, candidate_id: uuid.UUID,
+    declared_by: uuid.UUID | None,
 ) -> ReferenceSemanticCandidate:
     """AC5 — 사람이 후보를 골라 「선언됨」으로 승격시킨다. ⛔AC4: 이 함수는 status·
     declared_by·declared_at **셋만** 바꾼다 — 그 외 어떤 부수효과(막힘·대기·종료·에이전트
     실행)도 일으키지 않는다(회귀 테스트+뮤테이션 자가검증이 이 계약을 지킨다).
     이미 declared된 것을 다시 declare해도 멱등(같은 값 재기록, 에러 아님) — 재클릭이
-    실패로 보이지 않게 한다."""
+    실패로 보이지 않게 한다.
+
+    ⛔IDOR 수정(story #2363, 오르테가/까심 실측 2026-07-31) — `source_id`가 필수 인자다.
+    caller(router)는 이미 project 접근권을 검사한 그 story의 id를 넘긴다. 이 조회가
+    `source_id`도 같이 걸어야 「접근 가능한 story 하나를 URL에 넣고 남의 candidate_id를
+    알면 그 행을 만진다」가 막힌다 — org_id만으로는 같은 org 다른 project의 candidate도
+    통과했다. 소유가 아니면 CandidateNotFoundError(404) — 존재 여부도 새지 않는다."""
     result = await db.execute(
         select(ReferenceSemanticCandidate).where(
             ReferenceSemanticCandidate.org_id == org_id,
             ReferenceSemanticCandidate.id == candidate_id,
+            ReferenceSemanticCandidate.source_id == source_id,
         )
     )
     candidate = result.scalar_one_or_none()
@@ -389,7 +397,8 @@ class InvalidRelationKindError(Exception):
 
 
 async def set_candidate_relation_kind(
-    db: AsyncSession, *, org_id: uuid.UUID, candidate_id: uuid.UUID, relation_kind: str | None,
+    db: AsyncSession, *, org_id: uuid.UUID, source_id: uuid.UUID, candidate_id: uuid.UUID,
+    relation_kind: str | None,
 ) -> ReferenceSemanticCandidate:
     """story #2223 판정(오르테가군, 2026-07-30) — "이 연결이 실재하는가"(declare)와 "무슨
     종류인가"(이 함수) 는 «다른 질문»이라 한 클릭에 안 묶는다. declare_candidate와 달리 이
@@ -398,13 +407,16 @@ async def set_candidate_relation_kind(
     무관하게 종 지정이 가능하다, 순서를 강제하지 않는다).
 
     relation_kind=None 허용 — 잘못 지정한 것을 「미분류」로 되돌리는 경로(AC10 정신: 모르는
-    것을 억지로 채운 채로 안 둔다)."""
+    것을 억지로 채운 채로 안 둔다).
+
+    ⛔IDOR 수정(story #2363) — `source_id` 필수(declare_candidate와 동형 이유)."""
     if relation_kind is not None and relation_kind not in RELATION_KINDS:
         raise InvalidRelationKindError(relation_kind)
     result = await db.execute(
         select(ReferenceSemanticCandidate).where(
             ReferenceSemanticCandidate.org_id == org_id,
             ReferenceSemanticCandidate.id == candidate_id,
+            ReferenceSemanticCandidate.source_id == source_id,
         )
     )
     candidate = result.scalar_one_or_none()
@@ -509,7 +521,7 @@ async def declare_new_candidate(
 
 
 async def undeclare_candidate(
-    db: AsyncSession, *, org_id: uuid.UUID, candidate_id: uuid.UUID,
+    db: AsyncSession, *, org_id: uuid.UUID, source_id: uuid.UUID, candidate_id: uuid.UUID,
 ) -> None:
     """story #2355(AC8) — 사람이 만든(또는 승격한) 연결을 지운다. ⛔`reject_candidate`와
     다르다 — reject는 `rejected_relations`에 쌍을 기록해 다음 스캔에서도 영구히 거르지만,
@@ -518,11 +530,14 @@ async def undeclare_candidate(
 
     ⛔status='declared'가 아닌 행(아직 estimated인 기계 후보)은 지울 수 없다 —
     CandidateNotDeclaredError. 그런 행을 지우고 싶으면 `reject_candidate`가 맞는 경로다(이
-    함수와 목적이 다르다: 그 표를 다음 스캔에서도 걸러야 하므로)."""
+    함수와 목적이 다르다: 그 표를 다음 스캔에서도 걸러야 하므로).
+
+    ⛔IDOR 수정(story #2363) — `source_id` 필수(declare_candidate와 동형 이유)."""
     result = await db.execute(
         select(ReferenceSemanticCandidate).where(
             ReferenceSemanticCandidate.org_id == org_id,
             ReferenceSemanticCandidate.id == candidate_id,
+            ReferenceSemanticCandidate.source_id == source_id,
         )
     )
     candidate = result.scalar_one_or_none()
@@ -538,7 +553,7 @@ class RejectedRelationNotFoundError(Exception):
 
 
 async def reject_candidate(
-    db: AsyncSession, *, org_id: uuid.UUID, candidate_id: uuid.UUID,
+    db: AsyncSession, *, org_id: uuid.UUID, source_id: uuid.UUID, candidate_id: uuid.UUID,
     rejected_by: uuid.UUID, reason: str | None = None,
 ) -> None:
     """story #2221 후속 — 관계 단위 기각. 클릭한 candidate 행의 (source, target) 쌍을
@@ -552,11 +567,14 @@ async def reject_candidate(
     ⛔rejected_by는 필수다(오르테가 지시, 2026-07-30) — 여러 사람이 같은 목록을 보므로
     「누가 기각했나」 없이는 되살릴 때 판단이 안 선다. caller(router)가 항상
     `_resolve_team_member_id`로 실제 team_member id를 넘긴다(그 함수는 non-optional
-    반환 계약이라 여기 None이 들어올 일이 없다)."""
+    반환 계약이라 여기 None이 들어올 일이 없다).
+
+    ⛔IDOR 수정(story #2363) — `source_id` 필수(declare_candidate와 동형 이유)."""
     result = await db.execute(
         select(ReferenceSemanticCandidate).where(
             ReferenceSemanticCandidate.org_id == org_id,
             ReferenceSemanticCandidate.id == candidate_id,
+            ReferenceSemanticCandidate.source_id == source_id,
         )
     )
     candidate = result.scalar_one_or_none()

--- a/backend/scripts/lint_candidate_source_ownership.py
+++ b/backend/scripts/lint_candidate_source_ownership.py
@@ -1,0 +1,102 @@
+"""story #2363([보안·CRITICAL] AC6) — reference_semantic_candidates.py의 `candidate_id`
+조회 함수가 소유(`source_id`) 대조 없이 새로 생기는 것을 CI에서 막는다.
+
+배경: `declare_candidate`/`set_candidate_relation_kind`/`undeclare_candidate`/
+`reject_candidate` 넷 다 원래 `org_id + candidate_id`로만 조회했다 — 라우터가 URL의
+`{id}` story에는 project 접근권을 검사하지만, 실제로 만지는 candidate가 «그 story의
+것»인지는 아무도 대조하지 않아 다른 project의 candidate를 만지고 지울 수 있었다(IDOR).
+
+⛔기존 `lint_project_access_403.py`가 이 결함을 못 잡은 이유(오르테가 가설, 디디 실측으로
+확認): 그 lint의 축은 「무권한 응답이 403이 아니라 404인가」— 즉 「검사를 «불렀는가»」다.
+이 결함은 검사를 부르긴 불렀다(`_assert_story_project_access`가 URL의 `{id}`에 대해
+정상 호출된다) — 다만 **검사한 대상과 실제로 만지는 대상이 달랐다.** 「불렀는가」 축은
+이 클래스를 원리적으로 못 본다. 그래서 이 lint는 다른 축을 본다: 「`candidate_id`로
+조회하는 함수가 그 조회 조건에 `source_id`도 같이 거는가」.
+
+⛔이 lint가 잡는 패턴: 이 파일(`reference_semantic_candidates.py`) 안의 `async def` 함수가
+파라미터로 `candidate_id`를 받으면서, ①파라미터 목록에 `source_id`가 없거나 ②함수 본문의
+`.where(...)` 안에서 `<Model>.source_id ==` 형태의 비교를 쓰지 않으면 위반이다.
+
+⛔이 lint가 못 잡는 것(정직하게 적는다, story #2342/#2335와 동일 정신):
+  - 이 파일 «밖»의 다른 서비스 모듈이 같은 문제 모양(검사한 것≠만지는 것)을 갖는 경우 —
+    정적으로 일반화하지 않는다(AC7이 이번 사고 범위를 stories.py 하나로 실측 확認했다).
+  - `source_id` 파라미터가 있고 `.where()`에도 등장하지만 라우터가 «잘못된» 값(권한 없는
+    id)을 넘기는 경우 — 이 lint는 함수 «내부 계약»만 본다, 호출부 검증은 못 본다.
+  - 1-hop 이상 간접 호출(다른 함수를 통해 이 select를 감싸는 경우) — 정적 단일 함수
+    스캔이라(project_access_403 lint와 동일 한계) 그 안까지는 못 본다.
+
+베이스라인 없음 — 이 lint를 켠 시점(2026-07-31) 코드베이스는 이미 4곳 다 준수 상태로
+고쳐졌다(story #2363 자신이 그 수정). 그래서 grandfather 메커니즘이 필요 없다 — 새 위반이든
+기존 위반이든 하나라도 있으면 즉시 CI가 빨개진다(project_access_403 lint의 baseline=0과
+동일 계약).
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+TARGET_FILE = Path(__file__).parent.parent / "app" / "services" / "reference_semantic_candidates.py"
+
+
+def _param_names(func: ast.AsyncFunctionDef) -> set[str]:
+    args = func.args
+    names = {a.arg for a in args.args}
+    names |= {a.arg for a in args.kwonlyargs}
+    if args.vararg:
+        names.add(args.vararg.arg)
+    return names
+
+
+def _has_source_id_where_clause(func: ast.AsyncFunctionDef) -> bool:
+    """함수 본문 어딘가에 `<Model>.source_id == <무언가>` 비교가 있는가(where절 안인지는
+    안 가린다 — Compare 자체가 select().where(...) 호출 인자 안에서만 의미가 있으므로
+    「그런 Compare가 존재한다」는 「filter에 안 걸었다」를 배제하기에 충분히 보수적이다)."""
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Compare):
+            continue
+        left = node.left
+        if (
+            isinstance(left, ast.Attribute)
+            and left.attr == "source_id"
+            and any(isinstance(op, ast.Eq) for op in node.ops)
+        ):
+            return True
+    return False
+
+
+def find_violations(tree: ast.Module) -> list[str]:
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        params = _param_names(node)
+        if "candidate_id" not in params:
+            continue
+        if "source_id" not in params:
+            violations.append(
+                f"{node.name}:{node.lineno} — candidate_id는 받지만 source_id 파라미터가 없다"
+            )
+            continue
+        if not _has_source_id_where_clause(node):
+            violations.append(
+                f"{node.name}:{node.lineno} — source_id 파라미터는 있으나 조회 조건에 "
+                f"쓰이지 않는다(<Model>.source_id == ... 비교가 함수 본문에 없다)"
+            )
+    return violations
+
+
+def main() -> int:
+    tree = ast.parse(TARGET_FILE.read_text())
+    violations = find_violations(tree)
+    if violations:
+        print(f"candidate_id 소유 대조 lint 위반 {len(violations)}건 — story #2363 회귀:")
+        for v in violations:
+            print(f"  {TARGET_FILE.relative_to(TARGET_FILE.parent.parent.parent)}:{v}")
+        return 1
+    print("OK: candidate_id를 받는 함수 전부 source_id로 소유 대조한다(새 위반 0건)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_2363_reference_candidate_cross_project_idor_realdb.py
+++ b/backend/tests/test_2363_reference_candidate_cross_project_idor_realdb.py
@@ -1,0 +1,365 @@
+"""story #2363([보안·CRITICAL], 오르테가/까심 실측 2026-07-31) — reference-candidate
+쓰기 경로 다섯이 «다른 프로젝트»의 연결을 만들고 지우던 IDOR을 실PG로 재현·검증한다.
+
+결함의 모양: 라우터는 URL의 `{id}` story에 대해서만 `_assert_story_project_access`를
+부른다. 그런데 실제로 «만지는» 대상(①의 target_id, ②~⑤의 candidate.source_id)은 org_id
+로만 걸러졌지 project 접근권을 한 번도 검사받지 않았다 — 검사한 것과 만지는 것이 달랐다.
+
+⛔이 파일이 «각각» 재는 다섯 자리(하나만 재면 나머지 넷이 안 잡힌다, AC1):
+  ① POST   /{id}/reference-candidates                (target이 남의 프로젝트)
+  ② POST   /{id}/reference-candidates/{cid}/declare        (candidate가 남의 것)
+  ③ POST   /{id}/reference-candidates/{cid}/relation-kind  (같음)
+  ④ POST   /{id}/reference-candidates/{cid}/reject         (같음)
+  ⑤ DELETE /{id}/reference-candidates/{cid}                (같음)
+
+각 자리마다 3중 대조를 함께 잰다(AC2/AC3):
+  - cross-project 대상 → 404 (결함이 고쳐졌는가)
+  - 같은-project 대상(양성대조) → 여전히 200/201 (기능이 안 죽었는가 — 전부 404로 막아도
+    "cross-project가 404"는 통과하고, 그러면 이 라우트가 죽은 채로 그린이 된다)
+  - 「없는 id」와 「있지만 접근 못 하는 id」가 같은 응답(존재 비노출, AC3)
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from tests.test_2301_story_body_mentions_realdb import (
+    _REAL_DB_URL,
+    _client_for,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _make_story,
+    _session_factory,
+    _setup_app_human,
+)
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _make_candidate(
+    session, org_id, source_id, target_id, *, status="estimated", relation_kind=None,
+):
+    from app.models.reference_semantic_candidate import ReferenceSemanticCandidate as RSC
+    c = RSC(
+        id=uuid.uuid4(), org_id=org_id, source_type="story", source_field="body",
+        source_id=source_id, target_type="story", target_id=target_id, form="mention",
+        relation_kind=relation_kind, matched_keyword=None, snippet="",
+        status=status, declared_by=None, declared_at=None,
+    )
+    session.add(c)
+    await session.commit()
+    return c
+
+
+async def _setup_two_projects(s, org):
+    """caller는 project_a 접근권만 있다. project_b는 caller에게 «남의 프로젝트»다."""
+    project_a = await _make_project(s, org.id, name="A")
+    project_b = await _make_project(s, org.id, name="B")
+    caller_id, caller_user_id = await _make_human_member(s, org.id, project_a.id)
+    return project_a, project_b, caller_id, caller_user_id
+
+
+NONEXISTENT_ID = uuid.UUID("00000000-0000-0000-0000-000000000000")
+
+
+# ─── ① POST /{id}/reference-candidates — target이 남의 프로젝트 ─────────────
+
+
+async def test_1_declare_new_target_cross_project_404_and_positive_control():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project_a, project_b, caller_id, caller_user_id = await _setup_two_projects(s, org)
+            source_a = await _make_story(s, org.id, project_a.id, title="Source(A)")
+            target_a = await _make_story(s, org.id, project_a.id, title="Target(A, accessible)")
+            target_b = await _make_story(s, org.id, project_b.id, title="Target(B, inaccessible)")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            # cross-project target → 404 (결함 고쳐졌는가)
+            resp_cross = await client.post(
+                f"/api/v2/stories/{source_a.id}/reference-candidates",
+                json={"target_id": str(target_b.id)},
+            )
+            assert resp_cross.status_code == 404, resp_cross.text
+
+            # nonexistent target → 같은 404 (존재 비노출, AC3)
+            resp_nonexistent = await client.post(
+                f"/api/v2/stories/{source_a.id}/reference-candidates",
+                json={"target_id": str(NONEXISTENT_ID)},
+            )
+            assert resp_nonexistent.status_code == resp_cross.status_code == 404
+            assert resp_nonexistent.json() == resp_cross.json(), (
+                "「없는 target」과 「접근 못 하는 target」의 응답이 달라 존재가 샌다"
+            )
+
+            # 양성대조 — 같은 프로젝트 target은 여전히 201 (AC2)
+            resp_ok = await client.post(
+                f"/api/v2/stories/{source_a.id}/reference-candidates",
+                json={"target_id": str(target_a.id)},
+            )
+            assert resp_ok.status_code == 201, resp_ok.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ② declare — candidate.source_id가 남의 프로젝트 story ──────────────────
+
+
+async def test_2_declare_cross_project_source_404_and_positive_control():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project_a, project_b, caller_id, caller_user_id = await _setup_two_projects(s, org)
+            accessible_story = await _make_story(s, org.id, project_a.id, title="Accessible(A)")
+            victim_story = await _make_story(s, org.id, project_b.id, title="Victim(B)")
+            target = await _make_story(s, org.id, project_b.id, title="Target(B)")
+            # candidate는 victim_story(project_b, caller 접근 불가) 소유다.
+            victim_candidate = await _make_candidate(s, org.id, victim_story.id, target.id)
+            # 양성대조용 — caller가 실제로 접근 가능한 story가 source인 candidate.
+            own_target = await _make_story(s, org.id, project_a.id, title="OwnTarget(A)")
+            own_candidate = await _make_candidate(s, org.id, accessible_story.id, own_target.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            # URL의 {id}는 caller가 접근 가능한 story(accessible_story)지만, candidate는
+            # 남의 project(project_b) story 소유다 — 이전엔 org_id만 걸러 통과했다.
+            resp_cross = await client.post(
+                f"/api/v2/stories/{accessible_story.id}/reference-candidates/{victim_candidate.id}/declare",
+            )
+            assert resp_cross.status_code == 404, resp_cross.text
+
+            resp_nonexistent = await client.post(
+                f"/api/v2/stories/{accessible_story.id}/reference-candidates/{NONEXISTENT_ID}/declare",
+            )
+            assert resp_nonexistent.status_code == resp_cross.status_code == 404
+            assert resp_nonexistent.json() == resp_cross.json()
+
+            # 양성대조 — 진짜 자기 candidate는 여전히 declare된다.
+            resp_ok = await client.post(
+                f"/api/v2/stories/{accessible_story.id}/reference-candidates/{own_candidate.id}/declare",
+            )
+            assert resp_ok.status_code == 200, resp_ok.text
+            assert resp_ok.json()["status"] == "declared"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ③ relation-kind — 같은 모양 ─────────────────────────────────────────────
+
+
+async def test_3_relation_kind_cross_project_source_404_and_positive_control():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project_a, project_b, caller_id, caller_user_id = await _setup_two_projects(s, org)
+            accessible_story = await _make_story(s, org.id, project_a.id, title="Accessible(A)")
+            victim_story = await _make_story(s, org.id, project_b.id, title="Victim(B)")
+            target = await _make_story(s, org.id, project_b.id, title="Target(B)")
+            victim_candidate = await _make_candidate(s, org.id, victim_story.id, target.id)
+            own_target = await _make_story(s, org.id, project_a.id, title="OwnTarget(A)")
+            own_candidate = await _make_candidate(s, org.id, accessible_story.id, own_target.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp_cross = await client.post(
+                f"/api/v2/stories/{accessible_story.id}/reference-candidates/{victim_candidate.id}/relation-kind",
+                json={"relation_kind": "followed"},
+            )
+            assert resp_cross.status_code == 404, resp_cross.text
+
+            resp_nonexistent = await client.post(
+                f"/api/v2/stories/{accessible_story.id}/reference-candidates/{NONEXISTENT_ID}/relation-kind",
+                json={"relation_kind": "followed"},
+            )
+            assert resp_nonexistent.status_code == resp_cross.status_code == 404
+            assert resp_nonexistent.json() == resp_cross.json()
+
+            resp_ok = await client.post(
+                f"/api/v2/stories/{accessible_story.id}/reference-candidates/{own_candidate.id}/relation-kind",
+                json={"relation_kind": "followed"},
+            )
+            assert resp_ok.status_code == 200, resp_ok.text
+            assert resp_ok.json()["relation_kind"] == "followed"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ④ reject — 같은 모양 ─────────────────────────────────────────────────────
+
+
+async def test_4_reject_cross_project_source_404_and_positive_control():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project_a, project_b, caller_id, caller_user_id = await _setup_two_projects(s, org)
+            accessible_story = await _make_story(s, org.id, project_a.id, title="Accessible(A)")
+            victim_story = await _make_story(s, org.id, project_b.id, title="Victim(B)")
+            target = await _make_story(s, org.id, project_b.id, title="Target(B)")
+            victim_candidate = await _make_candidate(s, org.id, victim_story.id, target.id)
+            own_target = await _make_story(s, org.id, project_a.id, title="OwnTarget(A)")
+            own_candidate = await _make_candidate(s, org.id, accessible_story.id, own_target.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp_cross = await client.post(
+                f"/api/v2/stories/{accessible_story.id}/reference-candidates/{victim_candidate.id}/reject",
+                json={},
+            )
+            assert resp_cross.status_code == 404, resp_cross.text
+
+            resp_nonexistent = await client.post(
+                f"/api/v2/stories/{accessible_story.id}/reference-candidates/{NONEXISTENT_ID}/reject",
+                json={},
+            )
+            assert resp_nonexistent.status_code == resp_cross.status_code == 404
+            assert resp_nonexistent.json() == resp_cross.json()
+
+            resp_ok = await client.post(
+                f"/api/v2/stories/{accessible_story.id}/reference-candidates/{own_candidate.id}/reject",
+                json={},
+            )
+            assert resp_ok.status_code == 200, resp_ok.text
+
+            # victim_candidate는 여전히 존재해야 한다(공격자 호출이 실제로 아무것도 못 지웠다).
+            async with Session() as s:
+                from sqlalchemy import select
+                from app.models.reference_semantic_candidate import ReferenceSemanticCandidate as RSC
+                still_there = (await s.execute(
+                    select(RSC).where(RSC.id == victim_candidate.id)
+                )).scalar_one_or_none()
+                assert still_there is not None, "cross-project reject 호출이 실제로 남의 행을 지웠다"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ⑤ DELETE(undeclare) — 같은 모양 ─────────────────────────────────────────
+
+
+async def test_5_undeclare_cross_project_source_404_and_positive_control():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project_a, project_b, caller_id, caller_user_id = await _setup_two_projects(s, org)
+            accessible_story = await _make_story(s, org.id, project_a.id, title="Accessible(A)")
+            victim_story = await _make_story(s, org.id, project_b.id, title="Victim(B)")
+            target = await _make_story(s, org.id, project_b.id, title="Target(B)")
+            # undeclare는 status='declared'만 지운다 — 양쪽 다 declared로 심는다.
+            victim_candidate = await _make_candidate(
+                s, org.id, victim_story.id, target.id, status="declared",
+            )
+            own_target = await _make_story(s, org.id, project_a.id, title="OwnTarget(A)")
+            own_candidate = await _make_candidate(
+                s, org.id, accessible_story.id, own_target.id, status="declared",
+            )
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp_cross = await client.delete(
+                f"/api/v2/stories/{accessible_story.id}/reference-candidates/{victim_candidate.id}",
+            )
+            assert resp_cross.status_code == 404, resp_cross.text
+
+            resp_nonexistent = await client.delete(
+                f"/api/v2/stories/{accessible_story.id}/reference-candidates/{NONEXISTENT_ID}",
+            )
+            assert resp_nonexistent.status_code == resp_cross.status_code == 404
+            assert resp_nonexistent.json() == resp_cross.json()
+
+            resp_ok = await client.delete(
+                f"/api/v2/stories/{accessible_story.id}/reference-candidates/{own_candidate.id}",
+            )
+            assert resp_ok.status_code == 200, resp_ok.text
+
+            async with Session() as s:
+                from sqlalchemy import select
+                from app.models.reference_semantic_candidate import ReferenceSemanticCandidate as RSC
+                still_there = (await s.execute(
+                    select(RSC).where(RSC.id == victim_candidate.id)
+                )).scalar_one_or_none()
+                assert still_there is not None, "cross-project undeclare 호출이 실제로 남의 행을 지웠다"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── AC7: 못 잡는 것 선언 — 이 네 서비스 함수를 부르는 caller가 stories.py 하나뿐인가 ──
+
+
+def test_only_stories_router_calls_the_four_candidate_service_functions():
+    """epic·doc 등 다른 source_type이 declare_candidate 등을 부르는 자리가 있으면 그
+    자리도 이번 고침(source_id 필수화)의 영향을 받으므로 반드시 같이 세어야 한다 —
+    코드 스캔으로 "그런 자리가 없다"를 직접 확認(AC7)."""
+    import ast
+    from pathlib import Path
+
+    routers_dir = Path(__file__).parent.parent / "app" / "routers"
+    target_funcs = {
+        "declare_candidate", "set_candidate_relation_kind",
+        "undeclare_candidate", "reject_candidate",
+    }
+    callers = set()
+    for path in routers_dir.glob("*.py"):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                func = node.func
+                name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+                if name in target_funcs:
+                    callers.add(path.name)
+    assert callers == {"stories.py"}, (
+        f"declare/relation-kind/reject/undeclare_candidate를 부르는 라우터가 stories.py "
+        f"하나가 아니다: {callers} — 이번 source_id 필수화가 그 자리들도 갱신해야 한다"
+    )


### PR DESCRIPTION
## 결함

라우터 다섯이 URL의 `{id}` story에는 `_assert_story_project_access`로 project 접근권을 검사한다. 그런데 실제로 **만지는** 대상은 다르다 — org_id만으로 걸러 project 접근권 검사가 없었다:

```
①POST   /{id}/reference-candidates            target_id가 남의 프로젝트 story
②POST   /{id}/reference-candidates/{cid}/declare        candidate.source_id가 남의 프로젝트 story
③POST   /{id}/reference-candidates/{cid}/relation-kind  같음
④POST   /{id}/reference-candidates/{cid}/reject         같음
⑤DELETE /{id}/reference-candidates/{cid}                같음
```

검사한 것(URL의 `{id}`)과 만지는 것(target/candidate.source_id)이 달라 — 접근 가능한 story 하나를 URL에 넣고 남의 candidate_id를 알면 그 행을 만들거나 지울 수 있었다. ①은 201/404가 갈려 대상 story의 존재 여부까지 샜다.

다섯 중 셋(declare·relation-kind·reject)은 `#2721`이 만든 게 아니라 그 전부터 있었다 — 되돌리기로는 안 닫힌다.

## prod(main) 노출 — 0건

`reference_semantic_candidates.py` 모듈 자체가 아직 `main`에 없다(까심 실측, `git show origin/main:...` → 파일 없음). dev 전용이나 develop 승격 시 그대로 나가므로 시급도는 그대로.

## 고침 — 「한 곳」에서

- `declare_new_story_reference_candidate`(①): target도 `has_project_access`로 독립 검사(`references.py`의 `create_reference` 양쪽-아이템 게이트와 동형 — 새 방식 도입 안 함). 미존재·무권한 둘 다 동일 404 `"Target story not found"`로 존재 비노출 유지.
- `declare_candidate`/`set_candidate_relation_kind`/`reject_candidate`/`undeclare_candidate`(②~⑤): `source_id`를 필수 인자로 추가해 서비스층 조회 자체에 소유 조건을 건다. 라우터 다섯에 if를 흩지 않음 — 여섯째 라우터가 생겨도 구조적으로 걸린다.

## AC 대조 (story #2363)

1. 5자리 각각 cross-project 404 — `test_2363_reference_candidate_cross_project_idor_realdb.py` 5개 테스트
2. 양성대조 — 같은 프로젝트 대상은 여전히 200/201 (전부 404로 막아도 AC1은 통과하므로 필수)
3. 존재 비노출 — 「없는 id」와 「접근 못하는 id」가 동일 응답(status+body)임을 각 테스트에서 직접 대조
4. 새 방식 미도입 — `#2724`의 `_story_source_access`(`has_project_access`)와 동형 패턴
5. 고침이 한 곳 — 서비스층 조회 조건. 여섯째 라우터도 구조적으로 걸림(신규 lint가 그 계약을 CI로 고정)
6. 기존 가드가 왜 못 잡았는지 — `lint_project_access_403.py`의 축은 "검사를 불렀는가"(403→404 여부). 이 결함은 검사를 부르긴 불렀다(URL의 `{id}`에 대해) — 검사한 대상과 만지는 대상이 달랐을 뿐이라 그 축으로는 원리적으로 안 보인다. 새 lint(`lint_candidate_source_ownership.py`, CI 잡 `candidate-source-ownership-lint` 추가)가 「candidate_id로 조회하는 함수가 source_id도 같이 거는가」축으로 이 클래스를 잡는다.
7. 못 잡는 것 선언 — 이 4개 서비스 함수(`declare_candidate` 등)를 부르는 라우터가 `stories.py` 하나뿐임을 AST 정적 스캔으로 테스트에 고정(`test_only_stories_router_calls_the_four_candidate_service_functions`). epic·doc 등 다른 source_type이 이 함수들을 부르는 자리는 지금 없다.
8. prod 노출 0건 — 위 "prod 노출" 절 그대로. 급하지 않다는 뜻 아님(develop 승격 시 그대로 나감).

## 검증

- fix 적용 전(stash)/후로 직접 대조 — 5개 테스트가 fix 없이는 실제로 red(그 중 하나는 실제로 남의 candidate 행을 지우는 것까지 확認: `{"ok":true}`)이고, fix 적용 후 green으로 바뀜을 실측했다.
- 기존 회귀 테스트(`test_2355`·`test_2221`·`test_2328`) 45개 전부 통과 — 시그니처 변경이 기존 동작을 안 깼다.
- 두 기존 lint(`lint_project_access_403`·`lint_query_sentinel_direct_calls`) + 신규 lint 모두 클린.
- 신규 lint 자체도 stash로 자가검증 — fix 전 코드에 돌리면 4건 정확히 잡는다.