### PR TITLE
feat(ci): design:changes/qa:changes actively block merge

### DIFF
--- a/.github/workflows/design-review-gate.yml
+++ b/.github/workflows/design-review-gate.yml
@@ -94,6 +94,24 @@ jobs:
             echo "No changed file matches the design-review path list — this PR is out of this gate's scope (not a skip: it was evaluated and found empty)."
           fi
 
+      # ⭐유나신 지적(2026-07-31) — design:changes 라벨 설명은 "design:pass로 바뀌기 前에는
+      # 머지하지 않는다"고 약속하는데, 그 약속을 지키는 코드가 아무것도 없었다(가드는
+      # design:pass «존재»만 본다). design:pass와 design:changes가 같이 붙어 있으면(수정
+      # 요청이 아직 안 반영됐는데 pass도 남아 있는 경우) 그린이 뜨는 구멍이었다 — pass 유무와
+      # 무관하게 changes가 있으면 무조건 빨강으로 막는다. 게이트가 막 서서 아무도 위에 안
+      # 쌓았을 때가 이 구멍을 막기 제일 싼 자리라 지금 잡는다.
+      - name: Enforce design:changes blocks merge (unconditional — regardless of design:pass)
+        if: steps.scope.outputs.in_scope == 'true'
+        env:
+          HAS_DESIGN_CHANGES: ${{ contains(github.event.pull_request.labels.*.name, 'design:changes') }}
+        run: |
+          set -euo pipefail
+          if [ "${HAS_DESIGN_CHANGES}" = "true" ]; then
+            echo "::error title=design:changes open::A design guardian requested changes (design:changes) and they haven't been marked resolved yet. This blocks merge regardless of whether design:pass is also present — remove design:changes (or let the guardian replace it with design:pass) after the changes are addressed."
+            exit 1
+          fi
+          echo "design:changes not present."
+
       # AC1/AC6: design:pass가 있으면 초록, 없으면 빨강. labeled/unlabeled 이벤트가 트리거
       # 목록에 있어 라벨을 떼면 이 스텝이 다시 돌아 빨강으로 되돌아간다.
       - name: Enforce design:pass label when in scope

--- a/.github/workflows/qa-review-gate.yml
+++ b/.github/workflows/qa-review-gate.yml
@@ -86,6 +86,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      # ⭐design-review-gate.yml과 대칭(유나신 지적, 2026-07-31) — qa:changes가 열려 있으면
+      # qa:pass 유무와 무관하게 무조건 빨강. 두 changes 라벨이 기계적으로 배타가 되어 changes
+      # 라벨도 "하는 일"이 생긴다(전엔 설명뿐이었다).
+      - name: Enforce qa:changes blocks merge (unconditional — regardless of qa:pass)
+        env:
+          HAS_QA_CHANGES: ${{ contains(github.event.pull_request.labels.*.name, 'qa:changes') }}
+        run: |
+          set -euo pipefail
+          if [ "${HAS_QA_CHANGES}" = "true" ]; then
+            echo "::error title=qa:changes open::QA requested changes (qa:changes) and they haven't been marked resolved yet. This blocks merge regardless of whether qa:pass is also present — remove qa:changes (or let QA replace it with qa:pass) after the changes are addressed."
+            exit 1
+          fi
+          echo "qa:changes not present."
+
       # AC1: qa:pass가 없으면 빨강. labeled/unlabeled 이벤트가 트리거 목록에 있어 라벨을
       # 떼면 이 스텝이 다시 돌아 빨강으로 되돌아간다. ⛔경로 필터 없음 — 모든 PR에 적용(AC2).
       - name: Enforce qa:pass label (no path scoping — applies to every PR)


### PR DESCRIPTION
유나신 지적 — `design:changes`/`qa:changes` 라벨 설명은 "pass로 바뀌기 前엔 머지 안 한다"고 약속하지만, 게이트는 `*:pass` 존재만 봐서 pass+changes가 같이 붙어도(수정요청 뒤 pass가 안 떼진 경우) 그린이 떴다. 두 게이트 모두에 대칭으로: `*:changes`가 있으면 `*:pass` 유무와 무관하게 무조건 빨강.

## AC10·11(오르테가군·유나신) 반영 — 5단 뮤테이션 증거 (스로어웨이 #2743, 캡처 후 close·머지 안 함)
```
① 라벨 없음                    → RED
   design: https://github.com/moonklabs/sprintable/actions/runs/30613569336/job/91101569936
   qa:     https://github.com/moonklabs/sprintable/actions/runs/30613569343/job/91101569861
② *:pass만 부착                → GREEN
   design: https://github.com/moonklabs/sprintable/actions/runs/30613601551/job/91101669872
   qa:     https://github.com/moonklabs/sprintable/actions/runs/30613601545/job/91101669960
③ ⭐*:pass + *:changes 동시 부착 → RED (핵심 loophole — 평소엔 안 생기는 조합, 유나신이
   늘 라벨을 "바꿔" 달아서 저절로는 한 번도 안 돌아보는 분기)
   design: https://github.com/moonklabs/sprintable/actions/runs/30613629321/job/91101756136
   qa:     https://github.com/moonklabs/sprintable/actions/runs/30613629304/job/91101754452
④ *:changes 제거(*:pass는 남음) → GREEN
   design: https://github.com/moonklabs/sprintable/actions/runs/30613668482/job/91101870873
   qa:     https://github.com/moonklabs/sprintable/actions/runs/30613668658/job/91101871176
```

## 이 PR 자신도 자기 게이트를 받는다
`.github/workflows`만 건드려 design gate는 경로 밖(pass), qa gate는 경로 필터가 없어 qa:pass 미부착으로 fail — 자기 배타 규칙(③)에 직접 걸린 건 아니지만 자기 게이트를 자기가 받는 것 자체는 확認됨.

[SID:ec7a401f-7b63-480c-89f5-eaf833ef3d85][SID:3b0559c7-68aa-488d-bdc6-84ff8a747cfd]