### PR TITLE
test(throwaway): design:changes/qa:changes block-merge mutation evidence — DO NOT MERGE

### DIFF
--- a/.github/workflows/design-review-gate.yml
+++ b/.github/workflows/design-review-gate.yml
@@ -94,6 +94,24 @@ jobs:
             echo "No changed file matches the design-review path list — this PR is out of this gate's scope (not a skip: it was evaluated and found empty)."
           fi
 
+      # ⭐유나신 지적(2026-07-31) — design:changes 라벨 설명은 "design:pass로 바뀌기 前에는
+      # 머지하지 않는다"고 약속하는데, 그 약속을 지키는 코드가 아무것도 없었다(가드는
+      # design:pass «존재»만 본다). design:pass와 design:changes가 같이 붙어 있으면(수정
+      # 요청이 아직 안 반영됐는데 pass도 남아 있는 경우) 그린이 뜨는 구멍이었다 — pass 유무와
+      # 무관하게 changes가 있으면 무조건 빨강으로 막는다. 게이트가 막 서서 아무도 위에 안
+      # 쌓았을 때가 이 구멍을 막기 제일 싼 자리라 지금 잡는다.
+      - name: Enforce design:changes blocks merge (unconditional — regardless of design:pass)
+        if: steps.scope.outputs.in_scope == 'true'
+        env:
+          HAS_DESIGN_CHANGES: ${{ contains(github.event.pull_request.labels.*.name, 'design:changes') }}
+        run: |
+          set -euo pipefail
+          if [ "${HAS_DESIGN_CHANGES}" = "true" ]; then
+            echo "::error title=design:changes open::A design guardian requested changes (design:changes) and they haven't been marked resolved yet. This blocks merge regardless of whether design:pass is also present — remove design:changes (or let the guardian replace it with design:pass) after the changes are addressed."
+            exit 1
+          fi
+          echo "design:changes not present."
+
       # AC1/AC6: design:pass가 있으면 초록, 없으면 빨강. labeled/unlabeled 이벤트가 트리거
       # 목록에 있어 라벨을 떼면 이 스텝이 다시 돌아 빨강으로 되돌아간다.
       - name: Enforce design:pass label when in scope

--- a/.github/workflows/qa-review-gate.yml
+++ b/.github/workflows/qa-review-gate.yml
@@ -86,6 +86,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      # ⭐design-review-gate.yml과 대칭(유나신 지적, 2026-07-31) — qa:changes가 열려 있으면
+      # qa:pass 유무와 무관하게 무조건 빨강. 두 changes 라벨이 기계적으로 배타가 되어 changes
+      # 라벨도 "하는 일"이 생긴다(전엔 설명뿐이었다).
+      - name: Enforce qa:changes blocks merge (unconditional — regardless of qa:pass)
+        env:
+          HAS_QA_CHANGES: ${{ contains(github.event.pull_request.labels.*.name, 'qa:changes') }}
+        run: |
+          set -euo pipefail
+          if [ "${HAS_QA_CHANGES}" = "true" ]; then
+            echo "::error title=qa:changes open::QA requested changes (qa:changes) and they haven't been marked resolved yet. This blocks merge regardless of whether qa:pass is also present — remove qa:changes (or let QA replace it with qa:pass) after the changes are addressed."
+            exit 1
+          fi
+          echo "qa:changes not present."
+
       # AC1: qa:pass가 없으면 빨강. labeled/unlabeled 이벤트가 트리거 목록에 있어 라벨을
       # 떼면 이 스텝이 다시 돌아 빨강으로 되돌아간다. ⛔경로 필터 없음 — 모든 PR에 적용(AC2).
       - name: Enforce qa:pass label (no path scoping — applies to every PR)

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -669,3 +669,5 @@
 .tiptap [data-type="toggleContent"] { padding-left: 1.25rem; margin-left: 0.875rem; border-left: 2px solid hsl(var(--border)); margin-top: 0.25rem; }
 [data-type="toggleSummary"],
 .tiptap [data-type="toggleSummary"] { cursor: pointer; }
+
+/* #2361/#2364 changes-label mutation-test touch — throwaway, will be reverted */


### PR DESCRIPTION
Positive control for feat/2361-2364-changes-label-blocks-merge (#2742). Will attach pass+changes together to confirm RED despite pass, then remove changes to confirm GREEN. Close without merging.