### PR TITLE
[SID:2224] AC17-B 재정정 — 지도를 화면 맨 위로(높이 판정이 아니라 자리 판정)

### DIFF
--- a/apps/web/src/components/flow/next-maker-screen.test.tsx
+++ b/apps/web/src/components/flow/next-maker-screen.test.tsx
@@ -205,6 +205,27 @@ describe('NextMakerScreen — real fetch orchestration + lane grouping', () => {
     expect(container.querySelector('[data-testid="folded-count"]')?.textContent).toBe('1');
   });
 
+  // 유나 라이브 실측(2026-07-31, AC17-B 재정정 — 선생님 직접 지적) — "지도가 가장 높은
+  // 블록"으로만 재던 판정이 «자리»(어디에 있는가)를 안 물어, 캔버스 y=2108(뷰포트
+  // 900) — 레인이 한 조각도 첫 화면에 없는 사고가 났다. 캔버스가 DOM에서 헤드라인보다
+  // «먼저» 오는 것 자체를 값으로 고정한다(순서가 바뀌면 다시 아래로 밀릴 수 있다).
+  it('AC17-B: the multi-lane canvas renders BEFORE the headline/strip in DOM order (canvas is the top block, not just the tallest)', async () => {
+    const calledUrls: string[] = [];
+    vi.stubGlobal('fetch', buildFetchMock(calledUrls));
+
+    await act(async () => {
+      root.render(wrap(<NextMakerScreen projectId="p1" memberMap={{}} onSelectStory={() => {}} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const html = container.innerHTML;
+    const canvasIdx = html.indexOf('multi-lane-canvas-stub');
+    const headlineIdx = html.indexOf('목표 3개 중');
+    expect(canvasIdx).toBeGreaterThan(-1);
+    expect(headlineIdx).toBeGreaterThan(-1);
+    expect(canvasIdx).toBeLessThan(headlineIdx);
+  });
+
   it('orphan panel: assigning a goal PATCHes /api/stories/[id] with epic_id and the story disappears from the orphan list', async () => {
     const calledUrls: string[] = [];
     const patchBodies: unknown[] = [];

--- a/apps/web/src/components/flow/next-maker-screen.tsx
+++ b/apps/web/src/components/flow/next-maker-screen.tsx
@@ -87,8 +87,14 @@ type LoadState =
  * (백로그 스토리 승격 / 조용한 목표 닫기·보관)은 «수단»(픽 패널)이 아니라 «목적»이라 같이
  * 죽으면 안 된다(PO: 「«수단»을 빼면 그 위에 탄 «다른 목적»이 같이 죽는다」). 그래서
  * `NextActionsStrip`(다음이 없는 목표만, 접힌 채 기본·펼치면 그 목표의 승격/전환 패널만)을
- * 헤드라인과 캔버스 사이에 다시 세웠다 — 캔버스(FlowMultiLaneCanvas)는 여전히 이 화면의
- * 몸통이고, 이 스트립은 그 위에 얹히는 «좁은» 자리다(고아 배정은 원래도 안 지웠다).
+ * 다시 세웠다 — 캔버스(FlowMultiLaneCanvas)는 여전히 이 화면의 몸통이고, 이 스트립은 그
+ * «아래»에 얹히는 자리다(고아 배정은 원래도 안 지웠다).
+ *
+ * ⛔AC17-B 재정정(2026-07-31, 선생님 직접 지적) — 처음엔 헤드라인+스트립을 캔버스 «위»에
+ * 두고 "지도가 가장 높은 블록"이면 된다고 판단했는데, 그건 «높이» 판정이지 «자리» 판정이
+ * 아니었다. 선생님: "지도가 페이지 상단에 붙어야 맞을 것 같고, 나머지는 지도 하단에
+ * 붙어야 하지 않을지" — 순서 자체를 뒤집었다. 캔버스가 이 화면의 맨 위, 헤드라인+스트립+
+ * 고아 패널은 전부 그 아래.
  *
  * 새 BE 계약 불요(next-up(PR#2707)·goals(total_stories/done_stories 기존 존재)·stories
  * (status 필터 기존 존재)만으로 충분함을 그라운딩 확認했다).
@@ -260,11 +266,29 @@ export function NextMakerScreen({ projectId, memberMap, onSelectStory, selectedN
 
   return (
     <div className="space-y-4">
+      {/* story #2224 AC17-B 재정정(2026-07-31, 선생님 직접 지적) — AC17-B를 "지도가 첫
+          화면에서 가장 높은 블록"(높이 비교)으로만 쟀는데, 그건 «높이»를 줄이는 처방(스트립을
+          접는 것)에는 걸리되 «자리»(어디에 있는가) 문제는 안 풀었다. 지도가 맨 위, 나머지
+          (헤드라인·수 카드·다음-비어있음/조용함 목록)는 전부 그 아래로 — 순서 자체를
+          뒤집는다. 지도 pane 높이를 사용자가 조절하는 것(유나 소견 대기 — 기본 높이·저장
+          자리)은 후속 조각. */}
+      <FlowMultiLaneCanvas
+        projectId={projectId}
+        expandGoals={laneGrouping.expand}
+        foldedCount={laneGrouping.fold.length}
+        onSelectStory={onSelectStory}
+        selectedNodeId={selectedNodeId}
+        memberMap={memberMap}
+      />
+
       <NextMakerHeader headline={headline} zeroStage={zeroStage} />
 
-      {/* PO 정정(2026-07-31) — 픽 패널의 «고르기»는 뺐지만 승격/전환 «동사»는 살린다. 접힌
-          채가 기본이라 이 스트립의 높이는 목표 수만큼이 아니라 늘 한 줄×목표 수(펼친 것만
-          예외) — AC17-B(캔버스가 위 어떤 블록보다 크다) 판정에 이 스트립이 걸리지 않는다. */}
+      {/* PO 정정(2026-07-31) — 픽 패널의 «고르기»는 뺐지만 승격/전환 «동사»는 살린다. 이
+          스트립이 목표 수만큼 길어질 수 있다는 것(AC17-B 재발의 원인이었다 — next-maker-
+          screen.tsx 상단 문서 참고)은 그대로다 — 다만 이제 캔버스가 «맨 위»라 이 스트립이
+          아무리 길어도 첫 화면(캔버스)을 밀어내지 않는다. 접기(그룹 요약 한 줄)는 시도했다가
+          물렀다(PO: "지도가 위에 있으면 아래가 길어도 첫 화면은 안 밀린다") — 자리 문제를
+          자리로 풀었으니 높이를 줄이는 처방은 이제 안 필요하다. */}
       <NextActionsStrip
         needsNextStems={needsNextStems}
         quietCount={headline.quietCount}
@@ -276,17 +300,6 @@ export function NextMakerScreen({ projectId, memberMap, onSelectStory, selectedN
         onStoryPromoted={handleStoryPromoted}
         onPromoteFailed={handlePromoteFailed}
         onGoalTransitioned={handleGoalTransitioned}
-      />
-
-      {/* story #2224 AC17-B — 지도가 첫 화면에서 «가장 높은 블록»이어야 한다(위 어떤 블록보다
-          커야 한다는 «비교» 판정, % 아님). */}
-      <FlowMultiLaneCanvas
-        projectId={projectId}
-        expandGoals={laneGrouping.expand}
-        foldedCount={laneGrouping.fold.length}
-        onSelectStory={onSelectStory}
-        selectedNodeId={selectedNodeId}
-        memberMap={memberMap}
       />
 
       {/* 목표가 «없는» 스토리 — 목표별 레인 캔버스 다음 순서(자리는 «남는 곳»이 아니라


### PR DESCRIPTION
## Summary
유나 라이브 실측(dev /flow, 1440×900) — 캔버스 y=2108, 레인 19개 중 온전히 보이는 것 0개. NextActionsStrip이 목표당 한 줄로 49줄(~3200px)을 캔버스 위에 쌓아, 기존 AC17-B("지도가 가장 높은 블록")를 지켰어도 지도가 뷰포트 훨씬 아래로 밀렸음.

선생님 직접 지적 — 판정 자체가 반쪽이었음: 「높이」가 아니라 「자리」를 물었어야 함. 처방은 순서를 뒤집는 것 — **캔버스가 화면 맨 위, 나머지(헤드라인+NextActionsStrip+OrphanStoriesPanel)는 전부 그 아래.**

- `next-maker-screen.tsx`: `FlowMultiLaneCanvas`를 `NextMakerHeader`/`NextActionsStrip`보다 먼저 렌더 — DOM 순서만 변경, 로직 변경 없음
- 회귀 가드: 캔버스가 헤드라인보다 DOM에서 먼저 오는 것을 값으로 고정, mutation self-check로 순서 되돌리면 정확히 RED 확認 후 복원

## AC17-B 재정의 (PO가 스토리에 PATCH)
"지도가 가장 높은 블록"은 뺐음 — 사용자가 pane 높이를 직접 줄이는 후속 기능(AC18)이 서면 그 판정이 스스로 깨지기 때문. 새 판정:
- ㉠ 지도가 헤드라인 다음 첫 자리(자리 판정)
- ㉡ 기본 상태에서 레인 3개가 스크롤 없이 온전히 보임

둘 다 배포 후 라이브에서 확認 필요 — 코드 리뷰로 안 닫음.

## 후속
지도 pane 높이 사용자 지정(AC18, 유나 소견 반영 — 레인 단위 스냅·하한 1레인·값 영속·기본으로 되돌리기·기본 높이는 픽셀 대신 "세 번째 레인 하단까지" 계산값)은 별도 PR.

## Test plan
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm exec vitest run` — 332 files / 2397 tests 전부 통과
- [x] `pnpm run build` — 성공
- [x] 5개 verify:* 스크립트 전부 통과
- [x] DOM 순서 회귀 가드 + mutation self-check
- [ ] 배포 후 라이브: 캔버스 y가 헤드라인 높이 근처인지, 레인 3개가 스크롤 없이 온전히 보이는지(㉠㉡)

🤖 Generated with [Claude Code](https://claude.com/claude-code)