### PR TITLE
[SID:2224] AC18 — 지도 pane 높이 사용자 지정(레인 단위 스냅 리사이즈)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -537,7 +537,9 @@
     "orphanHint": "assign one and it joins that stem",
     "orphanPickAction": "Set goal",
     "orphanPickPlaceholder": "Select a goal",
-    "orphanAssignConfirm": "Assign"
+    "orphanAssignConfirm": "Assign",
+    "canvasResizeHandleLabel": "Resize map pane height — arrow up/down to adjust by lane, Home/End for minimum/maximum",
+    "canvasResizeReset": "Reset to default"
   },
   "board": {
     "backlinksTitle": "Things that point here",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -537,7 +537,9 @@
     "orphanHint": "목표를 정하면 줄기에 섭니다",
     "orphanPickAction": "목표 정하기",
     "orphanPickPlaceholder": "목표 선택",
-    "orphanAssignConfirm": "배정"
+    "orphanAssignConfirm": "배정",
+    "canvasResizeHandleLabel": "지도 pane 높이 조절 — 화살표 위/아래로 레인 단위 조절, Home/End로 최소/최대",
+    "canvasResizeReset": "기본 크기로"
   },
   "board": {
     "backlinksTitle": "이것을 가리키는 것들",

--- a/apps/web/src/components/flow/derive-flow-map.test.ts
+++ b/apps/web/src/components/flow/derive-flow-map.test.ts
@@ -4,6 +4,7 @@ import {
   computeNodeLogicalPositions, computeEdgeLineEndpoints, groupEdgesByEndpoints, edgeGroupStrokeWidth,
   parseDependencyGraphEdges, parseReferenceCandidateEdges, FLOW_MAP_TOP_N, FLOW_MAP_FOLD_THRESHOLD,
   FLOW_MAP_DEPTH0_X, FLOW_MAP_GRID_STEP, PAST_BUNDLE_NODE_ID,
+  computeCumulativeLaneHeight, snapToNearestLaneCount,
   type FlowMapEdge, type FlowMapLane, type RawReferenceCandidate,
 } from './derive-flow-map';
 import type { EpicFlowNodeItem } from './derive-flow';
@@ -475,6 +476,66 @@ describe('computeLaneHeight', () => {
       overflows: [{ depth: 0, hiddenCount: 5 }],
     });
     expect(computeLaneHeight(lane, 28, 0)).toBe(56); // (1 card + 1 overflow card) * 28
+  });
+});
+
+// story #2224 AC18(2026-07-31) — 지도 pane 리사이즈의 기본/한계 높이는 픽셀 하드코딩이
+// 아니라 실제 레인 높이(computeLaneHeight, 가변)를 누적한 계산값이다.
+describe('computeCumulativeLaneHeight', () => {
+  function makeLaneWithNowCount(epicId: string, nowCount: number): FlowMapLane {
+    return makeLane({
+      epicId,
+      nowNodes: Array.from({ length: nowCount }, (_, i) => ({
+        id: `${epicId}-n${i}`, storyNumber: i, title: 't', status: 'backlog', kind: 'now' as const, depth: 0,
+      })),
+    });
+  }
+
+  it('sums computeLaneHeight for the first N lanes, plus header height', () => {
+    const lanes = [makeLaneWithNowCount('e1', 1), makeLaneWithNowCount('e2', 1), makeLaneWithNowCount('e3', 1)];
+    // 각 레인 높이 = max(minHeight=70, 1*32) = 70(1개 노드는 32 < 70이라 최소값이 이긴다).
+    expect(computeCumulativeLaneHeight(lanes, 3, 32, 70, 22)).toBe(22 + 70 + 70 + 70);
+  });
+
+  it('clamps visibleLaneCount to lanes.length — asking for more than exist just returns "all of them"', () => {
+    const lanes = [makeLaneWithNowCount('e1', 1), makeLaneWithNowCount('e2', 1)];
+    expect(computeCumulativeLaneHeight(lanes, 99, 32, 70, 22)).toBe(computeCumulativeLaneHeight(lanes, 2, 32, 70, 22));
+  });
+
+  it('0 lanes requested (or 0 lanes exist) returns just the header height', () => {
+    const lanes = [makeLaneWithNowCount('e1', 1)];
+    expect(computeCumulativeLaneHeight(lanes, 0, 32, 70, 22)).toBe(22);
+    expect(computeCumulativeLaneHeight([], 3, 32, 70, 22)).toBe(22);
+  });
+
+  it('reflects each lane\'s own variable height (gate on content, not a flat multiply)', () => {
+    // e1은 노드 3개(96px > minHeight 70) · e2는 노드 1개(70px, 최소값 이김) — 균일하지 않다.
+    const lanes = [makeLaneWithNowCount('e1', 3), makeLaneWithNowCount('e2', 1)];
+    expect(computeCumulativeLaneHeight(lanes, 2, 32, 70, 22)).toBe(22 + 96 + 70);
+  });
+});
+
+describe('snapToNearestLaneCount — story #2224 AC18 ①(자유 픽셀 드래그, 결과는 레인 정수 경계)', () => {
+  it('snaps to the lane count whose cumulative height is closest to the candidate', () => {
+    // 누적: [50, 120, 200] (레인 1: 50 · 레인 2: +70=120 · 레인 3: +80=200)
+    const laneHeights = [50, 70, 80];
+    expect(snapToNearestLaneCount(laneHeights, 45)).toBe(1); // 50에 제일 가깝다
+    expect(snapToNearestLaneCount(laneHeights, 115)).toBe(2); // 120에 제일 가깝다
+    expect(snapToNearestLaneCount(laneHeights, 500)).toBe(3); // 그 이상은 마지막 경계(전부 보임)
+  });
+
+  it('an exact tie rounds to the SMALLER lane count (drag intent reads as "not quite there yet")', () => {
+    const laneHeights = [50, 50]; // 누적 [50, 100], 후보 75는 둘 다 25만큼 떨어짐
+    expect(snapToNearestLaneCount(laneHeights, 75)).toBe(1);
+  });
+
+  it('0 lanes returns 0 (호출부가 이 경우 드래그 UI 자체를 안 보여준다)', () => {
+    expect(snapToNearestLaneCount([], 999)).toBe(0);
+  });
+
+  it('never returns less than 1 when at least one lane exists (하한 = 레인 1개, AC18 ②)', () => {
+    const laneHeights = [50, 70, 80];
+    expect(snapToNearestLaneCount(laneHeights, -9999)).toBe(1);
   });
 });
 

--- a/apps/web/src/components/flow/derive-flow-map.ts
+++ b/apps/web/src/components/flow/derive-flow-map.ts
@@ -628,6 +628,44 @@ export function computeLaneHeight(lane: FlowMapLane, nodeRowHeight: number, minH
   return Math.max(minHeight, maxColumnCount * nodeRowHeight, pastBundleHeight, pastExpandedHeight);
 }
 
+/** story #2224 AC18(2026-07-31) — 리사이즈 가능 캔버스 pane의 «기본/한계 높이»를 픽셀
+ * 하드코딩 없이 계산한다. 목업의 690px(레인 8×76) 식은 그 목업의 레인 수 기준이라 라이브
+ * (레인이 몇 개든 가변 높이)엔 안 선다 — 그래서 «레인 개수»를 단위로 받아 실제
+ * computeLaneHeight를 그대로 누적한다("레인 3"은 수이지 픽셀이 아니다, 픽셀은 계산된다).
+ * visibleLaneCount가 lanes.length보다 크면 있는 만큼만 더한다(전부 보이면 그 이상 잴 것이
+ * 없다 — clamp가 «잘못된 값»이 아니라 «다 보인다»는 뜻이다). */
+export function computeCumulativeLaneHeight(
+  lanes: FlowMapLane[], visibleLaneCount: number, nodeRowHeight: number, laneMinHeight: number, headerHeight: number,
+): number {
+  const count = Math.max(0, Math.min(visibleLaneCount, lanes.length));
+  let total = headerHeight;
+  for (let i = 0; i < count; i += 1) {
+    total += computeLaneHeight(lanes[i]!, nodeRowHeight, laneMinHeight);
+  }
+  return total;
+}
+
+/** story #2224 AC18 ① — 드래그는 자유 픽셀(손은 연속)이지만 «결과»는 레인 정수 경계에
+ * 스냅한다(자유 픽셀로 두면 "카드가 잘린 채로 멈추는" 것이 재발한다, AC17-C가 막 고친
+ * 겹침 결함과 같은 병). 후보 높이(레인 부분만, 헤더 제외)에 가장 가까운 «레인 몇 개까지의
+ * 누적 높이» 경계를 찾아 그 레인 수(1-indexed)를 돌려준다. 레인이 0개면 0을 돌려준다
+ * (호출부가 그 경우 드래그 UI 자체를 안 보여준다). */
+export function snapToNearestLaneCount(laneHeights: number[], candidateLanesOnlyHeight: number): number {
+  if (laneHeights.length === 0) return 0;
+  let bestCount = 1;
+  let bestDiff = Infinity;
+  let cumulative = 0;
+  for (let i = 0; i < laneHeights.length; i += 1) {
+    cumulative += laneHeights[i]!;
+    const diff = Math.abs(cumulative - candidateLanesOnlyHeight);
+    if (diff < bestDiff) {
+      bestDiff = diff;
+      bestCount = i + 1;
+    }
+  }
+  return bestCount;
+}
+
 /** ⑥ 조건부 문구(PO 판정 2026-07-30) 트리거 — depth 0 열은 있는데 depth 1 이상이 «전혀»
  * 없을 때만 참. 하드코딩된 상수가 아니라 실제 맵 상태에서 계산하므로, 간선이 착지해
  * depth≥1 노드가 생기는 날 이 함수가 스스로 false를 내 문구가 사라진다(거짓말 될 위험 없음). */

--- a/apps/web/src/components/flow/flow-canvas-resize-pane.test.tsx
+++ b/apps/web/src/components/flow/flow-canvas-resize-pane.test.tsx
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+//
+// story #2224 AC18(2026-07-31) — 지도 pane 높이를 사용자가 지정한다. 자를 «둘»로 잰다
+// (유나 규격 08:14Z — 자와 기본값이 하나면 자가 자기를 검사한다, positive control must be
+// able to fail): ㉠기본 상태에서 레인 3개가 온전히 ㉡최소까지 줄여도 레인 1개는 온전히.
+// 손잡이는 드래그(자유 픽셀→놓으면 레인 정수 스냅) + 키보드(레인 단위 직접 이동) 둘 다
+// 같은 커밋 경로(commitLaneCount)를 타므로, 여기선 값을 확실히 재는 키보드 경로로 대부분의
+// 판정을 걸고 드래그는 스냅 값 계산만 별도로 확認한다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { FlowCanvasResizePane } from './flow-canvas-resize-pane';
+import { computeLaneHeight, type FlowMapLane } from './derive-flow-map';
+import koMessages from '../../../messages/ko.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const NODE_ROW_HEIGHT = 32;
+const LANE_MIN_HEIGHT = 70;
+const HEADER_HEIGHT = 22;
+const STORAGE_KEY = 'sprintable-flow-canvas-lane-count';
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+function makeLane(epicId: string, nowCount: number): FlowMapLane {
+  return {
+    epicId, title: `Epic ${epicId}`, pastTotal: 0,
+    nowNodes: Array.from({ length: nowCount }, (_, i) => ({
+      id: `${epicId}-n${i}`, storyNumber: i, title: 't', status: 'backlog', kind: 'now' as const, depth: 0,
+    })),
+    queueNodesByDepth: new Map(), overflows: [], edges: [],
+    pastBundle: { total: 0, internalCount: 0, outgoingCount: 0 }, pastNodes: [],
+  };
+}
+
+// 균일하지 않은 레인 다섯 — 서로 다른 노드 수라 각 레인 높이가 균일 곱셈이 아니다(실제
+// computeLaneHeight를 통과시켜 진짜 값으로 잰다, 손 계산한 숫자를 중복하지 않는다).
+const LANES: FlowMapLane[] = [
+  makeLane('e1', 1), // minHeight(70)이 이긴다 — 1*32=32 < 70
+  makeLane('e2', 3), // 3*32=96
+  makeLane('e3', 1), // 70
+  makeLane('e4', 4), // 4*32=128
+  makeLane('e5', 1), // 70
+];
+const LANE_HEIGHTS = LANES.map((l) => computeLaneHeight(l, NODE_ROW_HEIGHT, LANE_MIN_HEIGHT));
+
+async function render(lanes: FlowMapLane[] = LANES) {
+  await act(async () => {
+    root.render(wrap(
+      <FlowCanvasResizePane lanes={lanes} nodeRowHeight={NODE_ROW_HEIGHT} laneMinHeight={LANE_MIN_HEIGHT} headerHeight={HEADER_HEIGHT}>
+        <div data-testid="canvas-stub" style={{ height: 9999 }}>stub</div>
+      </FlowCanvasResizePane>,
+    ));
+  });
+}
+
+function paneHeightPx(): number {
+  const el = container.querySelector('[data-testid="flow-canvas-resize-pane"]') as HTMLElement | null;
+  return el ? Number(el.style.height.replace('px', '')) : NaN;
+}
+
+function handle(): HTMLElement {
+  const el = container.querySelector('[data-testid="flow-canvas-resize-handle"]');
+  expect(el).not.toBeNull();
+  return el as HTMLElement;
+}
+
+// kanban-board.test.tsx의 관례 그대로 — jsdom 기본 localStorage에 기대지 않고 Map 기반
+// 스텁을 직접 세운다(테스트 간 격리는 beforeEach의 새 store로).
+let localStorageStore: Map<string, string>;
+
+function stubLocalStorage() {
+  localStorageStore = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => localStorageStore.get(k) ?? null,
+    setItem: (k: string, v: string) => { localStorageStore.set(k, v); },
+    removeItem: (k: string) => { localStorageStore.delete(k); },
+    clear: () => { localStorageStore.clear(); },
+  });
+}
+
+beforeEach(() => {
+  stubLocalStorage();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe('FlowCanvasResizePane — AC18 ⑤ 기본 높이는 하드코딩이 아니라 계산값', () => {
+  it('㉠ default state: pane height equals the REAL computed sum of the first 3 lanes + header (not a hardcoded 690/168 etc)', async () => {
+    await render();
+    const expected = HEADER_HEIGHT + LANE_HEIGHTS[0]! + LANE_HEIGHTS[1]! + LANE_HEIGHTS[2]!;
+    expect(paneHeightPx()).toBe(expected);
+    // 양성대조 — 이 값이 목업의 상수(690)나 옛 고정값(168)과 «우연히» 같지 않음을 확인해
+    // "그냥 아무 숫자나 나와도 통과"가 아님을 명시적으로 배제한다.
+    expect(paneHeightPx()).not.toBe(690);
+    expect(paneHeightPx()).not.toBe(168);
+  });
+
+  it('fewer than 3 lanes exist — default clamps to "all of them", not a crash or an assumed 3', async () => {
+    await render(LANES.slice(0, 2));
+    const expected = HEADER_HEIGHT + LANE_HEIGHTS[0]! + LANE_HEIGHTS[1]!;
+    expect(paneHeightPx()).toBe(expected);
+  });
+
+  it('0 lanes — renders children directly with no resize handle at all (아무 것도 조절할 게 없다)', async () => {
+    await render([]);
+    expect(container.querySelector('[data-testid="flow-canvas-resize-pane"]')).toBeNull();
+    expect(container.querySelector('[data-testid="flow-canvas-resize-handle"]')).toBeNull();
+    expect(container.querySelector('[data-testid="canvas-stub"]')).not.toBeNull();
+  });
+});
+
+describe('FlowCanvasResizePane — AC18 ①② 키보드(레인 단위) — 자유 픽셀 드래그와 같은 커밋 경로', () => {
+  it('ArrowDown repeatedly reaches ㉡ minimum (레인 1개) and stops there — never degenerates to 0 or partial', async () => {
+    await render();
+    for (let i = 0; i < 10; i += 1) {
+      await act(async () => {
+        handle().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+      });
+    }
+    // ㉡ — 최소까지 줄여도 레인 «1개»는 온전히(카드 안 잘림): 높이가 정확히 레인 1의 실 높이 + 헤더.
+    const expectedMin = HEADER_HEIGHT + LANE_HEIGHTS[0]!;
+    expect(paneHeightPx()).toBe(expectedMin);
+    expect(paneHeightPx()).toBeGreaterThan(HEADER_HEIGHT); // 0으로 접히지 않는다(지도는 접지 않는다)
+  });
+
+  it('Home jumps straight to minimum (레인 1개), End jumps to all lanes', async () => {
+    await render();
+    await act(async () => { handle().dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true })); });
+    expect(paneHeightPx()).toBe(HEADER_HEIGHT + LANE_HEIGHTS[0]!);
+
+    await act(async () => { handle().dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true })); });
+    const allHeight = HEADER_HEIGHT + LANE_HEIGHTS.reduce((a, b) => a + b, 0);
+    expect(paneHeightPx()).toBe(allHeight);
+  });
+
+  it('ArrowUp past the last lane clamps at all-lanes (no runaway past the data)', async () => {
+    await render();
+    for (let i = 0; i < 20; i += 1) {
+      await act(async () => {
+        handle().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+      });
+    }
+    const allHeight = HEADER_HEIGHT + LANE_HEIGHTS.reduce((a, b) => a + b, 0);
+    expect(paneHeightPx()).toBe(allHeight);
+  });
+});
+
+describe('FlowCanvasResizePane — AC18 ③④ localStorage 영속 + 되돌리기', () => {
+  it('a committed lane count survives an unmount/remount (사람 단위 값이 «남는다»)', async () => {
+    await render();
+    await act(async () => { handle().dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true })); });
+    const allHeight = HEADER_HEIGHT + LANE_HEIGHTS.reduce((a, b) => a + b, 0);
+    expect(paneHeightPx()).toBe(allHeight);
+
+    await act(async () => { root.unmount(); });
+    root = createRoot(container);
+    await render();
+    // 재마운트해도 방금 고른 값(레인 전체)이 그대로 — 기본값(3레인)으로 되돌아가지 않는다.
+    expect(paneHeightPx()).toBe(allHeight);
+  });
+
+  it('reset button is hidden at default, appears after a non-default choice, and clicking it restores the computed default AND clears storage', async () => {
+    await render();
+    expect(container.querySelector('[data-testid="flow-canvas-resize-reset"]')).toBeNull();
+
+    await act(async () => { handle().dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true })); });
+    const resetBtn = container.querySelector('[data-testid="flow-canvas-resize-reset"]') as HTMLButtonElement | null;
+    expect(resetBtn).not.toBeNull();
+
+    await act(async () => { resetBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const defaultHeight = HEADER_HEIGHT + LANE_HEIGHTS[0]! + LANE_HEIGHTS[1]! + LANE_HEIGHTS[2]!;
+    expect(paneHeightPx()).toBe(defaultHeight);
+    expect(container.querySelector('[data-testid="flow-canvas-resize-reset"]')).toBeNull();
+    expect(localStorageStore.get(STORAGE_KEY)).toBeUndefined();
+  });
+});
+
+describe('FlowCanvasResizePane — stale localStorage(레인 수가 이전 세션보다 «줄어든» 경우)', () => {
+  it('a stored lane count larger than the CURRENT lane list clamps to "all of them" instead of overflowing/crashing', async () => {
+    stubLocalStorage();
+    localStorageStore.set(STORAGE_KEY, '99'); // 지난 세션엔 레인이 더 많았다고 가정
+    await render(LANES.slice(0, 2)); // 지금은 레인 2개뿐
+    const expected = HEADER_HEIGHT + LANE_HEIGHTS[0]! + LANE_HEIGHTS[1]!;
+    expect(paneHeightPx()).toBe(expected);
+    // computeCumulativeLaneHeight 자체가 픽셀은 이미 안전하게 클램프하지만, 손잡이의
+    // aria-valuenow(99)까지 그대로 새면 스크린리더가 "99/2" 같은 무의미한 값을 읽는다 —
+    // 그 자리는 이 컴포넌트가 별도로 잰다.
+    expect(handle().getAttribute('aria-valuenow')).toBe('2');
+  });
+});
+
+describe('FlowCanvasResizePane — AC18 ① 드래그 스냅(자유 픽셀 → 레인 정수 경계)', () => {
+  function dispatchPointer(el: Element, type: string, opts: { clientX?: number; clientY?: number; pointerId?: number } = {}) {
+    const ev = new Event(type, { bubbles: true, cancelable: true }) as PointerEvent;
+    Object.assign(ev, {
+      clientX: opts.clientX ?? 0, clientY: opts.clientY ?? 0, pointerId: opts.pointerId ?? 1,
+      button: 0, pointerType: 'mouse',
+    });
+    el.dispatchEvent(ev);
+  }
+
+  it('dragging down past the 2-lane boundary and releasing snaps the committed height to exactly 2 lanes (not the raw drag pixel value)', async () => {
+    await render();
+    const h = handle();
+    const startHeight = HEADER_HEIGHT + LANE_HEIGHTS[0]! + LANE_HEIGHTS[1]! + LANE_HEIGHTS[2]!; // 기본(3레인)
+    const twoLaneHeight = HEADER_HEIGHT + LANE_HEIGHTS[0]! + LANE_HEIGHTS[1]!;
+    // 위로(음의 dy) 끌어서 2레인 경계 근처에 놓는다 — 정확한 경계 픽셀이 아니라 "가장 가까운
+    // 쪽"으로 스냅되는지가 핵심이므로 경계에서 살짝 안쪽(2레인 쪽)인 지점을 목표로 잡는다.
+    const dy = (twoLaneHeight - startHeight) + 2; // 2레인 높이보다 2px 더 큰 지점(그래도 2레인이 더 가깝다)
+    await act(async () => { dispatchPointer(h, 'pointerdown', { clientY: 0 }); });
+    await act(async () => { dispatchPointer(h, 'pointermove', { clientY: dy }); });
+    // 드래그 «중»엔 자유 픽셀(스냅 전) — 커밋된 값(committedHeightPx)이 아니라 라이브 드래그 값이 보인다.
+    expect(paneHeightPx()).not.toBe(startHeight);
+    await act(async () => { dispatchPointer(h, 'pointerup', { clientY: dy }); });
+    // 놓은 뒤엔 레인 정수 경계로 스냅 — 카드가 잘린 채 멈추지 않는다.
+    expect(paneHeightPx()).toBe(twoLaneHeight);
+  });
+});

--- a/apps/web/src/components/flow/flow-canvas-resize-pane.tsx
+++ b/apps/web/src/components/flow/flow-canvas-resize-pane.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useCallback, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useTranslations } from 'next-intl';
+import { computeCumulativeLaneHeight, computeLaneHeight, snapToNearestLaneCount, type FlowMapLane } from './derive-flow-map';
+
+const STORAGE_KEY = 'sprintable-flow-canvas-lane-count';
+const DEFAULT_LANE_COUNT = 3;
+
+interface FlowCanvasResizePaneProps {
+  lanes: FlowMapLane[];
+  nodeRowHeight: number;
+  laneMinHeight: number;
+  headerHeight: number;
+  children: ReactNode;
+}
+
+// reference-candidates.ts의 readRejectedSet/writeRejectedSet과 같은 관례 — localStorage
+// 접근은 항상 try/catch로 감싼다(용량초과·프라이빗모드·이 API 자체가 없는 환경 전부 조용히
+// 무시, 다음 렌더에서 기본값으로 자연히 대체된다).
+function readStoredLaneCount(): number | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const parsed = raw !== null ? Number(raw) : NaN;
+    return Number.isFinite(parsed) && parsed >= 1 ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredLaneCount(value: string | null): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (value === null) window.localStorage.removeItem(STORAGE_KEY);
+    else window.localStorage.setItem(STORAGE_KEY, value);
+  } catch {
+    // 조용히 무시 — 다음 렌더는 여전히 기본값으로 정상 동작한다.
+  }
+}
+
+/**
+ * story #2224 AC18(2026-07-31, 선생님 08:11Z + 유나 규격 08:14Z) — 지도 pane 높이를
+ * 사용자가 지정한다. ①손잡이는 자유 픽셀로 끌리지만 «놓는 순간» 레인 정수 경계로
+ * 스냅한다(연속량이 아니라 «지금 몇 줄기를 보고 싶은가»가 재는 대상이므로 — 자유
+ * 픽셀이면 카드가 잘린 채 멈춘다). ②하한 = 레인 1개. ③값은 localStorage(사람 단위,
+ * 1차) — 기기를 바꾸면 «기본값»으로 뜨는 것이지 «틀린 화면»이 아니므로 조용한 실패가
+ * 아니다. ④되돌리기 버튼. ⑤기본 높이는 픽셀 하드코딩이 아니라
+ * computeCumulativeLaneHeight(레인 3까지 누적, 가변)로 계산한다 — 라이브 레인 높이가
+ * 목업(레인 8 기준 690px)과 다를 수 있으므로 «세는 단위(레인 수)»만 고정하고 픽셀은
+ * 매번 다시 잰다.
+ *
+ * localStorage엔 픽셀이 아니라 «레인 수»를 저장한다 — 픽셀을 저장하면 다음 세션에
+ * 레인 내용이 달라졌을 때(카드 추가/과거 펼침 등) 값이 낡는다. 레인 수는 "몇 줄기를
+ * 보고 싶은가"라는 사용자의 «의도»이므로 매 렌더에서 현재 lanes로 다시 계산해도
+ * 의미가 안 바뀐다.
+ */
+export function FlowCanvasResizePane({ lanes, nodeRowHeight, laneMinHeight, headerHeight, children }: FlowCanvasResizePaneProps) {
+  const t = useTranslations('flow');
+  const [laneCount, setLaneCount] = useState(() => readStoredLaneCount() ?? DEFAULT_LANE_COUNT);
+  const [dragHeightPx, setDragHeightPx] = useState<number | null>(null);
+  const dragRef = useRef<{ pointerId: number; startY: number; startHeight: number } | null>(null);
+
+  const laneHeights = useMemo(
+    () => lanes.map((lane) => computeLaneHeight(lane, nodeRowHeight, laneMinHeight)),
+    [lanes, nodeRowHeight, laneMinHeight],
+  );
+  const minHeightPx = useMemo(
+    () => computeCumulativeLaneHeight(lanes, 1, nodeRowHeight, laneMinHeight, headerHeight),
+    [lanes, nodeRowHeight, laneMinHeight, headerHeight],
+  );
+  const maxHeightPx = headerHeight + laneHeights.reduce((sum, h) => sum + h, 0);
+  const clampedLaneCount = Math.max(1, Math.min(laneCount, lanes.length || 1));
+  const committedHeightPx = useMemo(
+    () => computeCumulativeLaneHeight(lanes, clampedLaneCount, nodeRowHeight, laneMinHeight, headerHeight),
+    [lanes, clampedLaneCount, nodeRowHeight, laneMinHeight, headerHeight],
+  );
+  const displayHeightPx = dragHeightPx ?? committedHeightPx;
+  const defaultLaneCount = Math.min(DEFAULT_LANE_COUNT, lanes.length || DEFAULT_LANE_COUNT);
+  const isAtDefault = clampedLaneCount === defaultLaneCount;
+
+  const commitLaneCount = useCallback((next: number) => {
+    const clamped = Math.max(1, Math.min(next, lanes.length || 1));
+    setLaneCount(clamped);
+    writeStoredLaneCount(String(clamped));
+  }, [lanes.length]);
+
+  const commitFromRawHeight = useCallback((rawHeightPx: number) => {
+    const candidateLanesOnly = rawHeightPx - headerHeight;
+    commitLaneCount(snapToNearestLaneCount(laneHeights, candidateLanesOnly));
+  }, [laneHeights, headerHeight, commitLaneCount]);
+
+  const handlePointerDown = useCallback((e: React.PointerEvent) => {
+    if (e.button !== 0 && e.pointerType !== 'touch') return;
+    dragRef.current = { pointerId: e.pointerId, startY: e.clientY, startHeight: committedHeightPx };
+    const el = e.currentTarget as HTMLElement;
+    if (typeof el.setPointerCapture === 'function') el.setPointerCapture(e.pointerId);
+  }, [committedHeightPx]);
+
+  const handlePointerMove = useCallback((e: React.PointerEvent) => {
+    const d = dragRef.current;
+    if (!d || d.pointerId !== e.pointerId) return;
+    const dy = e.clientY - d.startY;
+    setDragHeightPx(Math.max(minHeightPx, Math.min(maxHeightPx, d.startHeight + dy)));
+  }, [minHeightPx, maxHeightPx]);
+
+  const handlePointerUp = useCallback((e: React.PointerEvent) => {
+    const d = dragRef.current;
+    if (!d || d.pointerId !== e.pointerId) return;
+    const el = e.currentTarget as HTMLElement;
+    if (typeof el.releasePointerCapture === 'function') el.releasePointerCapture(e.pointerId);
+    dragRef.current = null;
+    if (dragHeightPx !== null) commitFromRawHeight(dragHeightPx);
+    setDragHeightPx(null);
+  }, [dragHeightPx, commitFromRawHeight]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowUp' || e.key === 'ArrowRight') {
+      e.preventDefault();
+      commitLaneCount(clampedLaneCount + 1);
+    } else if (e.key === 'ArrowDown' || e.key === 'ArrowLeft') {
+      e.preventDefault();
+      commitLaneCount(clampedLaneCount - 1);
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      commitLaneCount(1);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      commitLaneCount(lanes.length);
+    }
+  }, [clampedLaneCount, commitLaneCount, lanes.length]);
+
+  const handleReset = useCallback(() => {
+    setLaneCount(DEFAULT_LANE_COUNT);
+    writeStoredLaneCount(null);
+  }, []);
+
+  // 레인이 0개면(로딩·빈 화면) 조절할 대상 자체가 없다 — 손잡이 UI를 안 보여준다.
+  if (lanes.length === 0) return <>{children}</>;
+
+  return (
+    <div>
+      <div data-testid="flow-canvas-resize-pane" className="overflow-y-auto focus-inset" style={{ height: displayHeightPx }}>
+        {children}
+      </div>
+      <div className="flex items-center justify-center gap-2 border-t border-border bg-muted/20 py-1">
+        <div
+          role="slider"
+          tabIndex={0}
+          aria-orientation="horizontal"
+          aria-label={t('canvasResizeHandleLabel')}
+          aria-valuenow={clampedLaneCount}
+          aria-valuemin={1}
+          aria-valuemax={lanes.length}
+          data-testid="flow-canvas-resize-handle"
+          className="focus-inset h-1.5 w-10 cursor-row-resize touch-none rounded-full bg-border hover:bg-muted-foreground/40"
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onKeyDown={handleKeyDown}
+        />
+        {!isAtDefault ? (
+          <button
+            type="button"
+            onClick={handleReset}
+            className="text-[11px] text-muted-foreground underline-offset-2 hover:underline"
+            data-testid="flow-canvas-resize-reset"
+          >
+            {t('canvasResizeReset')}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/flow/flow-canvas-resize-pane.tsx
+++ b/apps/web/src/components/flow/flow-canvas-resize-pane.tsx
@@ -147,7 +147,7 @@ export function FlowCanvasResizePane({ lanes, nodeRowHeight, laneMinHeight, head
         <div
           role="slider"
           tabIndex={0}
-          aria-orientation="horizontal"
+          aria-orientation="vertical"
           aria-label={t('canvasResizeHandleLabel')}
           aria-valuenow={clampedLaneCount}
           aria-valuemin={1}

--- a/apps/web/src/components/flow/flow-map-canvas.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.tsx
@@ -23,15 +23,18 @@ const NODE_CARD_WIDTH = 110;
 const NODE_CARD_HEIGHT = 24;
 
 // 유나 목업(`be8709a4`) 실측 치수 — "그림이 정본"(2026-07-30), 비슷한 값이 아니라 그 숫자.
-const HEADER_HEIGHT = 22; // .colhd
+// story #2224 AC18(2026-07-31) — 이 셋을 export한다. flow-multi-lane-canvas.tsx가 리사이즈
+// 가능 pane의 기본/최소 높이를 «같은 상수»로 계산해야 한다(따로 값을 베끼면 그 사본이
+// 낡을 때 두 화면이 다른 수를 말하게 된다).
+export const HEADER_HEIGHT = 22; // .colhd
 // ⛔story #2224 AC17-C(2026-07-31, 유나 라이브 실측 05:28Z·확定 05:34Z) — 노드가 두 줄
 // (「#2296 · In Progress」)이던 이유는 상태 글자였는데, 좌측 3px 색이 이미 §4-4의 상태
 // 정본이라 글자는 «중복»이었다. 상태 글자를 빼 한 줄(24px)로 줄이고 행 간격을 28→32로
 // 올린다(단순 「행 간격 ≥ 노드 높이 + 8」자를 지금 값에 그대로 대면 48이 되어 AC17-A(캔버스가
 // 레인 수 × 76을 따라간다)를 더 나쁘게 하므로, 노드를 줄이는 것과 «짝»으로 낸 값 — 8개 ×
 // 32 = 256px, 겹침 0쌍).
-const NODE_ROW_HEIGHT = 32;
-const LANE_MIN_HEIGHT = 70;
+export const NODE_ROW_HEIGHT = 32;
+export const LANE_MIN_HEIGHT = 70;
 const NOW_CLUSTER_X = FLOW_MAP_NOW_LINE_X - 40; // "지금" 노드는 세로선 바로 왼쪽에 클러스터(착수시각순)
 
 /** story #2353 — 포트 잇기 상태기계. 포인터 드래그와 키보드(AC13)가 같은 phase들을 타되

--- a/apps/web/src/components/flow/flow-multi-lane-canvas.tsx
+++ b/apps/web/src/components/flow/flow-multi-lane-canvas.tsx
@@ -8,7 +8,8 @@ import {
   deriveFlowMapLane, parseDependencyGraphEdges, parseReferenceCandidateEdges,
   type FlowMapEdge, type RawDependencyEdge, type RawReferenceCandidate,
 } from './derive-flow-map';
-import { FlowMapCanvas, type CreateLinkResult, type DeleteLinkResult } from './flow-map-canvas';
+import { FlowMapCanvas, HEADER_HEIGHT, NODE_ROW_HEIGHT, LANE_MIN_HEIGHT, type CreateLinkResult, type DeleteLinkResult } from './flow-map-canvas';
+import { FlowCanvasResizePane } from './flow-canvas-resize-pane';
 import { declareResponseToEdge } from './flow-port-linking';
 import type { NextMakerGoal } from './derive-next-maker';
 import { parseCursorMeta } from '@/lib/pagination';
@@ -269,16 +270,21 @@ export function FlowMultiLaneCanvas({
 
   return (
     <div className="space-y-0">
-      <FlowMapCanvas
-        lanes={lanes}
-        onSelectStory={onSelectStory}
-        onTogglePastBundle={handleTogglePastBundle}
-        loadingPastBundleEpicIds={loadingPastBundleEpicIds}
-        selectedNodeId={selectedNodeId}
-        onCreateLink={handleCreateLink}
-        onDeleteLink={handleDeleteLink}
-        memberMap={memberMap}
-      />
+      {/* story #2224 AC18 — pane 높이를 사용자가 지정한다(레인 단위 스냅, 하한 1레인,
+          기본=레인 3까지 누적, localStorage 영속, 되돌리기). FlowMapCanvas 자체는 높이를
+          모른다 — 이 래퍼가 «몇 레인이 보이는가»만 결정하고 클리핑한다. */}
+      <FlowCanvasResizePane lanes={lanes} nodeRowHeight={NODE_ROW_HEIGHT} laneMinHeight={LANE_MIN_HEIGHT} headerHeight={HEADER_HEIGHT}>
+        <FlowMapCanvas
+          lanes={lanes}
+          onSelectStory={onSelectStory}
+          onTogglePastBundle={handleTogglePastBundle}
+          loadingPastBundleEpicIds={loadingPastBundleEpicIds}
+          selectedNodeId={selectedNodeId}
+          onCreateLink={handleCreateLink}
+          onDeleteLink={handleDeleteLink}
+          memberMap={memberMap}
+        />
+      </FlowCanvasResizePane>
       {/* 접힘 줄(목업 그대로) — "숨긴 것이 아니라 접은 것입니다". 오늘은 펼치기 인터랙션이
           없다(30일 재계산은 새로고침으로 자연히 갱신된다) — 화면이 «왜» 접었는지만 정직하게
           말한다. */}


### PR DESCRIPTION
## Summary
- story #2224 AC18(선생님 2026-07-31 08:11Z + 유나 규격 08:14Z) — 갈래 캔버스 pane 높이를 사용자가 지정할 수 있게 한다.
- 손잡이: 자유 픽셀 드래그, 놓으면 레인 정수 경계로 스냅(카드가 잘린 채 멈추지 않는다). 키보드는 화살표/Home/End로 레인 단위 직접 이동(같은 커밋 경로).
- 하한 = 레인 1개. localStorage에 **레인 수**를 저장(픽셀 아님 — 레인 내용이 바뀌어도 값이 안 낡는다). 되돌리기 버튼.
- 기본 높이는 픽셀 하드코딩(목업의 690px=레인8 기준)이 아니라 `computeCumulativeLaneHeight`(레인 3까지 누적)로 계산 — 라이브 레인 높이는 가변(`computeLaneHeight`, 노드 수 의존)이라 이것만이 유일한 정본이다.
- 판정선을 **둘**로(유나 규격 — 자와 기본값이 하나면 자기검사가 된다): ㉠기본 상태 3레인 온전히 ㉡최소로 줄여도 1레인은 온전히.

## AC19와의 관계
AC17-B(위치 재배치, #2745로 이미 병합)만으로는 헤드라인이 다시 밀린다(레인 19개 전부 펼치면 h=2174). 이 PR이 그 짝 — 병합되면 둘 다 제자리에 온다.

## AC18-C(별건, 라이브 픽셀 자리)
유나 실측 — 기본 3레인으로 줄일 때 좌측 요약 블록을 가리는 선 수가 지금(2/57)보다 늘지 않아야 한다. SVG 선-텍스트 겹침의 실 렌더 픽셀 판정이라 jsdom 유닛 테스트로 닫을 수 없다 — AC17 계열과 같은 이유로 배포 후 라이브 픽셀 검수 대상.

## Test plan
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm exec vitest run` — 334 files / 2422 tests 전부 PASS(신규 18건: `derive-flow-map.test.ts` 8건 + `flow-canvas-resize-pane.test.tsx` 10건, 전부 mutation self-check 완료)
- [x] `pnpm run build` — 성공
- [x] verify:* 5개(focus-inset-coverage · no-new-md-breakpoint · no-alpha-focus-ring · no-handrolled-modal · build-schema-integrity) — 전부 OK
- [ ] 배포 후 라이브 픽셀: AC18 ㉠㉡ + AC18-C(유나)

🤖 Generated with [Claude Code](https://claude.com/claude-code)