### PR TITLE
feat(analytics): story#2366 — 화면 레인 집합 안의 확認 대기 후보 수 (BE)

### DIFF
--- a/backend/app/repositories/analytics.py
+++ b/backend/app/repositories/analytics.py
@@ -847,3 +847,65 @@ class AnalyticsRepository:
                 "count": bucket["count"], "kind": kind,
             })
         return result
+
+    async def get_pending_candidate_count(
+        self, project_id: uuid.UUID, epic_ids: list[uuid.UUID],
+    ) -> dict:
+        """story #2366 — 화면이 지금 그리는 목표(epic) 집합 «안에서» 확認 대기 중인
+        reference_semantic_candidates(status='estimated') 후보 쌍 수를 낸다.
+
+        ⛔get_goal_edges(바로 위)가 세는 축(status='declared')은 안 건드린다 — #2360
+        AC3 「자동 확定 금지」의 대가를 이 메서드가 깨면 안 된다(estimated를 확定된
+        연결처럼 세는 것은 「실선=確定」의 재발이다). 그래서 완전히 별도 메서드·별도
+        엔드포인트로 둔다 — get_goal_edges 코드는 고치지 않는다.
+
+        epic_ids는 프로젝트 전체가 아니라 «화면이 지금 렌더 중인» 레인 집합이다
+        (오르테가 판정, 2026-07-31 — 297은 프로젝트 전체 수라 화면이 말해야 하는
+        「이 지도에서 N건」과는 다른 표다). get_epic_flow_nodes_batch와 동일하게
+        dedup+cap한다(같은 상한 EPIC_FLOW_NODES_BATCH_MAX 재사용 — 새 상한을 만들지
+        않는다).
+
+        project_id로도 양쪽을 건다(get_goal_edges와 동일 축 — cross-project epic_id를
+        넘겨도 다른 프로젝트 데이터가 안 새게, story #2363 IDOR 교훈과 같은 자리)."""
+        from sqlalchemy.orm import aliased
+
+        from app.models.reference_semantic_candidate import ReferenceSemanticCandidate
+
+        requested = list(dict.fromkeys(epic_ids))
+        processed = requested[: self.EPIC_FLOW_NODES_BATCH_MAX]
+        skipped = requested[self.EPIC_FLOW_NODES_BATCH_MAX:]
+
+        if not processed:
+            return {
+                "count": 0,
+                "requested_count": len(requested),
+                "processed_count": 0,
+                "skipped_epic_ids": skipped,
+            }
+
+        src, tgt = aliased(Story), aliased(Story)
+        rows = (await self.session.execute(
+            select(ReferenceSemanticCandidate.source_id, ReferenceSemanticCandidate.target_id)
+            .select_from(ReferenceSemanticCandidate)
+            .join(src, src.id == ReferenceSemanticCandidate.source_id)
+            .join(tgt, tgt.id == ReferenceSemanticCandidate.target_id)
+            .where(
+                ReferenceSemanticCandidate.org_id == self.org_id,
+                ReferenceSemanticCandidate.source_type == "story",
+                ReferenceSemanticCandidate.target_type == "story",
+                ReferenceSemanticCandidate.status == "estimated",
+                src.project_id == project_id,
+                tgt.project_id == project_id,
+                src.epic_id.in_(processed),
+                tgt.epic_id.in_(processed),
+                src.epic_id != tgt.epic_id,
+            )
+        )).all()
+
+        pairs = {(min(s, t), max(s, t)) for s, t in rows}
+        return {
+            "count": len(pairs),
+            "requested_count": len(requested),
+            "processed_count": len(processed),
+            "skipped_epic_ids": skipped,
+        }

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -19,6 +19,7 @@ from app.schemas.analytics import (
     EpicZoneCounts,
     GoalEdge,
     MemberWorkloadResponse,
+    PendingCandidateCountResponse,
     ProjectHealthResponse,
     ProjectOverviewResponse,
     RecentActivityResponse,
@@ -168,6 +169,29 @@ async def get_goal_edges(
     await _assert_project_access(repo, auth, project_id)
     rows = await repo.get_goal_edges(project_id)
     return [GoalEdge.model_validate(r) for r in rows]
+
+
+@router.get("/analytics/goal-edges/pending-count", response_model=PendingCandidateCountResponse)
+async def get_pending_candidate_count(
+    project_id: uuid.UUID = Query(...),
+    epic_ids: str = Query(..., description="콤마구분 UUID 목록 — 화면이 지금 그리는 레인 집합"),
+    repo: AnalyticsRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+) -> PendingCandidateCountResponse:
+    """story #2366 — 주어진 목표(epic) 집합 «안에서» 확認 대기 중인 후보 쌍 수를 낸다.
+    ⛔`goal-edges`(바로 위)가 세는 축(`status='declared'`)은 안 건드린다 — 이 엔드포인트는
+    별도다(#2360 AC3 "자동 확定 금지"의 대가를 estimated를 확定된 연결처럼 세는 방식으로
+    깨지 않는다). `epic_ids`는 프로젝트 전체가 아니라 «화면이 지금 렌더 중인» 레인 집합
+    이다 — 프로젝트 전체 수가 필요하면 이 엔드포인트가 아니라 별도 판단이 필요하다."""
+    await _assert_project_access(repo, auth, project_id)
+    try:
+        parsed_ids = [uuid.UUID(s.strip()) for s in epic_ids.split(",") if s.strip()]
+    except ValueError:
+        raise HTTPException(status_code=400, detail="epic_ids는 콤마구분 UUID 목록이어야 합니다")
+    if not parsed_ids:
+        raise HTTPException(status_code=400, detail="epic_ids가 비어 있습니다")
+    result = await repo.get_pending_candidate_count(project_id, parsed_ids)
+    return PendingCandidateCountResponse.model_validate(result)
 
 
 @router.get("/analytics/agent-stats", response_model=AgentStatsResponse)

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -284,3 +284,20 @@ class GoalEdge(BaseModel):
     to_goal_id: uuid.UUID
     count: int
     kind: str | None = None
+
+
+class PendingCandidateCountResponse(BaseModel):
+    """story #2366 — 주어진 목표(epic) 집합 안에서 확認 대기 중인
+    `reference_semantic_candidates(status='estimated')` 후보 쌍 수. `GoalEdge`가 세는
+    `status='declared'` 축은 건드리지 않는 별도 지표다(#2360 AC3 "자동 확定 금지"의
+    대가를 이 응답이 깨지 않는다 — estimated는 여기서도 「확定된 연결」이 아니라
+    「대기 중인 제안」으로만 취급된다).
+
+    `requested_count`/`processed_count`/`skipped_epic_ids`는 `EpicFlowNodesBatchResponse`
+    와 동일 계약(입력이 상한을 넘으면 앞쪽만 처리하고 나머지는 skipped로 정직하게
+    알린다) — 새 상한·새 필드 이름을 짓지 않는다."""
+
+    count: int
+    requested_count: int
+    processed_count: int
+    skipped_epic_ids: list[uuid.UUID]

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -295,7 +295,12 @@ class PendingCandidateCountResponse(BaseModel):
 
     `requested_count`/`processed_count`/`skipped_epic_ids`는 `EpicFlowNodesBatchResponse`
     와 동일 계약(입력이 상한을 넘으면 앞쪽만 처리하고 나머지는 skipped로 정직하게
-    알린다) — 새 상한·새 필드 이름을 짓지 않는다."""
+    알린다) — 새 상한·새 필드 이름을 짓지 않는다.
+
+    ⛔FE가 「이 count가 전부인가」를 판정하는 자리(오르테가 지적, 2026-07-31 — cap이
+    실제로 걸리면 그 epic 쪽 대기 쌍이 count에서 «조용히» 빠진다): `skipped_epic_ids`가
+    비어 있지 않으면 count는 «부분»이다. 그 필드 하나로만 판정한다 — `count`가 0이라고
+    「대기 없음」으로 읽으면 안 된다(skipped가 있으면 그 0은 «못 잰 것»일 수 있다)."""
 
     count: int
     requested_count: int

--- a/backend/tests/test_2366_pending_candidate_count_realdb.py
+++ b/backend/tests/test_2366_pending_candidate_count_realdb.py
@@ -1,0 +1,332 @@
+"""story #2366(오르테가 판정 2026-07-31, 스레드 7256d5cc) — 「연결 0건」 화면이 297건의
+확認 대기 후보를 못 말하던 갭의 BE 지원 경로: `GET /analytics/goal-edges/pending-count`.
+
+디디 실측(2026-07-31 07:19Z, dev DB 직접) — `goal-edges`는 `status='declared'`만 세는데
+org 전체에 declared 행이 0건이라, 297건의 cross-epic `estimated` 후보 쌍이 화면에 안
+잡혔다. 이 엔드포인트는 그 297을 «화면이 지금 그리는 목표 집합 안에서만» 세도록 낸다.
+
+⛔가장 중요한 핀(AC4) — `goal-edges`가 세는 축(status='declared')을 이 엔드포인트가
+건드리지 않는다는 것을 실제로 대조한다: declared 상태 후보는 이 카운트에 «안 잡힌다».
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tests.test_2267_story_origin_realdb import (
+    _REAL_DB_URL,
+    _client_for,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _session_factory,
+    _setup_app_human,
+)
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _make_goal(session, org_id, project_id, title="Goal"):
+    from app.models.pm import Goal
+    goal = Goal(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(goal)
+    await session.commit()
+    return goal
+
+
+async def _make_story(session, org_id, project_id, epic_id=None, title="S"):
+    from app.models.pm import Story
+    story = Story(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title,
+        status="backlog", priority="medium", epic_id=epic_id,
+    )
+    session.add(story)
+    await session.commit()
+    return story
+
+
+async def _make_candidate(
+    session, org_id, source_id, target_id, *, status, source_field="body",
+):
+    from app.models.reference_semantic_candidate import ReferenceSemanticCandidate
+    session.add(ReferenceSemanticCandidate(
+        id=uuid.uuid4(), org_id=org_id, source_type="story", source_field=source_field,
+        source_id=source_id, target_type="story", target_id=target_id, form="mention",
+        relation_kind=None, matched_keyword=None, snippet="s", status=status,
+        declared_by=None, declared_at=None,
+    ))
+    await session.commit()
+
+
+async def _call(client, project_id, epic_ids):
+    return await client.get(
+        "/api/v2/analytics/goal-edges/pending-count",
+        params={"project_id": str(project_id), "epic_ids": ",".join(str(e) for e in epic_ids)},
+    )
+
+
+# ─── AC 핵심: cross-epic estimated 쌍이 주어진 epic 집합 안에서 세어진다 ─────
+
+
+async def test_counts_cross_epic_estimated_pairs_within_given_epic_set():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+            goal_a = await _make_goal(s, org.id, project.id, "A")
+            goal_b = await _make_goal(s, org.id, project.id, "B")
+            story_a = await _make_story(s, org.id, project.id, epic_id=goal_a.id)
+            story_b = await _make_story(s, org.id, project.id, epic_id=goal_b.id)
+            await _make_candidate(s, org.id, story_a.id, story_b.id, status="estimated")
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await _call(client, project.id, [goal_a.id, goal_b.id])
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["count"] == 1
+            assert body["requested_count"] == 2
+            assert body["processed_count"] == 2
+            assert body["skipped_epic_ids"] == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── AC4 핵심 핀: declared 상태는 이 카운트에 «안 잡힌다» — goal-edges 축과 분리 ──
+
+
+async def test_declared_status_is_not_counted_here_goal_edges_axis_untouched():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+            goal_a = await _make_goal(s, org.id, project.id, "A")
+            goal_b = await _make_goal(s, org.id, project.id, "B")
+            story_a = await _make_story(s, org.id, project.id, epic_id=goal_a.id)
+            story_b = await _make_story(s, org.id, project.id, epic_id=goal_b.id)
+            # declared 상태 — goal-edges가 세는 것이지 이 엔드포인트가 세는 게 아니다.
+            await _make_candidate(s, org.id, story_a.id, story_b.id, status="declared")
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await _call(client, project.id, [goal_a.id, goal_b.id])
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["count"] == 0, "declared 상태가 pending count에 새어 들어갔다"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── 같은 목표 안(A→A)은 제외 ────────────────────────────────────────────────
+
+
+async def test_same_epic_pair_excluded():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+            goal_a = await _make_goal(s, org.id, project.id, "A")
+            story_1 = await _make_story(s, org.id, project.id, epic_id=goal_a.id)
+            story_2 = await _make_story(s, org.id, project.id, epic_id=goal_a.id)
+            await _make_candidate(s, org.id, story_1.id, story_2.id, status="estimated")
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await _call(client, project.id, [goal_a.id])
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["count"] == 0
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── epic_id가 NULL이면 제외 ─────────────────────────────────────────────────
+
+
+async def test_epic_id_null_excluded():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+            goal_a = await _make_goal(s, org.id, project.id, "A")
+            story_a = await _make_story(s, org.id, project.id, epic_id=goal_a.id)
+            story_no_epic = await _make_story(s, org.id, project.id, epic_id=None)
+            await _make_candidate(s, org.id, story_a.id, story_no_epic.id, status="estimated")
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await _call(client, project.id, [goal_a.id])
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["count"] == 0
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── epic_ids 집합 밖의 쌍은 안 잡힌다(프로젝트 전체가 아니라 «화면의 레인»만) ──
+
+
+async def test_pair_outside_requested_epic_set_not_counted():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+            goal_a = await _make_goal(s, org.id, project.id, "A")
+            goal_b = await _make_goal(s, org.id, project.id, "B")
+            goal_c = await _make_goal(s, org.id, project.id, "C — 화면에 없음")
+            story_a = await _make_story(s, org.id, project.id, epic_id=goal_a.id)
+            story_c = await _make_story(s, org.id, project.id, epic_id=goal_c.id)
+            # goal_c는 요청 집합 밖 — 이 쌍은 화면(goal_a·goal_b)에 안 그려진다.
+            await _make_candidate(s, org.id, story_a.id, story_c.id, status="estimated")
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await _call(client, project.id, [goal_a.id, goal_b.id])
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["count"] == 0, "화면에 없는 목표(goal_c) 쪽 쌍이 새어 들어왔다"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── 같은 스토리 쌍이 두 field(body/acceptance_criteria)에 걸려도 1로 dedup ──
+
+
+async def test_same_story_pair_across_two_source_fields_dedups_to_one():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+            goal_a = await _make_goal(s, org.id, project.id, "A")
+            goal_b = await _make_goal(s, org.id, project.id, "B")
+            story_a = await _make_story(s, org.id, project.id, epic_id=goal_a.id)
+            story_b = await _make_story(s, org.id, project.id, epic_id=goal_b.id)
+            await _make_candidate(
+                s, org.id, story_a.id, story_b.id, status="estimated", source_field="body",
+            )
+            await _make_candidate(
+                s, org.id, story_a.id, story_b.id, status="estimated",
+                source_field="acceptance_criteria",
+            )
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await _call(client, project.id, [goal_a.id, goal_b.id])
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["count"] == 1
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── cross-project 404(기존 analytics 라우트와 동일 게이트) ─────────────────
+
+
+async def test_cross_project_access_denied_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project_a = await _make_project(s, org.id, name="A")
+            project_b = await _make_project(s, org.id, name="B")
+            _, user_id = await _make_human_member(s, org.id, project_a.id)
+            goal = await _make_goal(s, org.id, project_b.id, "B-goal")
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await _call(client, project_b.id, [goal.id])
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── 빈 프로젝트 — 0/0 (오류 아님) ───────────────────────────────────────────
+
+
+async def test_empty_project_returns_zero_not_error():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+            goal_a = await _make_goal(s, org.id, project.id, "A")
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await _call(client, project.id, [goal_a.id])
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["count"] == 0
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_2366_pending_candidate_count_realdb.py
+++ b/backend/tests/test_2366_pending_candidate_count_realdb.py
@@ -278,6 +278,97 @@ async def test_same_story_pair_across_two_source_fields_dedups_to_one():
         await engine.dispose()
 
 
+# ─── cap 경로 실측(오르테가 지적, 2026-07-31) — 8건 표본 어디도 30건을 안 넘겨
+# skipped_epic_ids를 채우는 두 줄이 「한 번도 실행되지 않는」 채로 초록이었다. 여기서
+# 실제로 EPIC_FLOW_NODES_BATCH_MAX(30)을 넘겨 그 경로를 밟는다. ─────────────
+
+
+async def test_cap_applies_when_epic_ids_exceeds_max_but_real_pair_stays_within_processed():
+    """실제 쌍의 두 epic이 상한 30 «안»에 들면 — 나머지가 fake로 채워져도 정상 집계되고,
+    skipped_epic_ids가 정확히 넘친 만큼만(가짜 것들) 채워진다."""
+    from app.repositories.analytics import AnalyticsRepository
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+            goal_a = await _make_goal(s, org.id, project.id, "A")
+            goal_b = await _make_goal(s, org.id, project.id, "B")
+            story_a = await _make_story(s, org.id, project.id, epic_id=goal_a.id)
+            story_b = await _make_story(s, org.id, project.id, epic_id=goal_b.id)
+            await _make_candidate(s, org.id, story_a.id, story_b.id, status="estimated")
+
+        max_batch = AnalyticsRepository.EPIC_FLOW_NODES_BATCH_MAX
+        fillers = [uuid.uuid4() for _ in range(max_batch - 2)]
+        overflow = [uuid.uuid4() for _ in range(5)]
+        # goal_a·goal_b를 앞쪽(처리되는 30개 안)에 두고, 뒤에 33개째부터 넘치게 채운다.
+        epic_ids = [goal_a.id, goal_b.id, *fillers, *overflow]
+        assert len(epic_ids) == max_batch + 5
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await _call(client, project.id, epic_ids)
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["requested_count"] == max_batch + 5
+            assert body["processed_count"] == max_batch
+            assert set(body["skipped_epic_ids"]) == {str(e) for e in overflow}
+            # 실제 쌍의 두 epic이 processed 안에 있으므로 여전히 잡힌다.
+            assert body["count"] == 1
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_pair_silently_excluded_when_its_epics_fall_in_skipped_range():
+    """⭐이것이 오르테가군이 짚은 위험이다 — 실제 쌍의 두 epic이 «넘친 쪽»(skipped)에
+    있으면 count에 안 잡힌다. skipped_epic_ids가 비어 있지 않으면 그 count는 «부분»이라는
+    것을 FE가 그 필드로만 판정할 수 있어야 한다(응답에 재료가 있는지가 이 테스트의 요지)."""
+    from app.repositories.analytics import AnalyticsRepository
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _, user_id = await _make_human_member(s, org.id, project.id)
+            goal_a = await _make_goal(s, org.id, project.id, "A")
+            goal_b = await _make_goal(s, org.id, project.id, "B")
+            story_a = await _make_story(s, org.id, project.id, epic_id=goal_a.id)
+            story_b = await _make_story(s, org.id, project.id, epic_id=goal_b.id)
+            await _make_candidate(s, org.id, story_a.id, story_b.id, status="estimated")
+
+        max_batch = AnalyticsRepository.EPIC_FLOW_NODES_BATCH_MAX
+        fillers = [uuid.uuid4() for _ in range(max_batch)]
+        # goal_a·goal_b를 상한 밖(31·32번째)에 둔다 — processed에서 빠진다.
+        epic_ids = [*fillers, goal_a.id, goal_b.id]
+        assert len(epic_ids) == max_batch + 2
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await _call(client, project.id, epic_ids)
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["processed_count"] == max_batch
+            assert set(body["skipped_epic_ids"]) == {str(goal_a.id), str(goal_b.id)}
+            # ⭐실제로 존재하는 대기 쌍인데도 count=0 — skipped_epic_ids를 안 보면
+            # FE가 이 0을 「대기 없음」으로 오독한다(오르테가 지적 그대로).
+            assert body["count"] == 0
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
 # ─── cross-project 404(기존 analytics 라우트와 동일 게이트) ─────────────────
 
 

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -118,6 +118,8 @@ _FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
         "story #2224 노드 계약 신규 — 동일 _assert_project_access 가드(다른 analytics 엔드포인트와 동일 패턴)",
     "app.routers.analytics:get_goal_edges":
         "story #2360 신규 — 동일 _assert_project_access 가드(다른 analytics 엔드포인트와 동일 패턴)",
+    "app.routers.analytics:get_pending_candidate_count":
+        "story #2366 신규 — 동일 _assert_project_access 가드(다른 analytics 엔드포인트와 동일 패턴)",
     "app.routers.workflow_executions:list_executions":
         "설계상 안전(SEC-S8 BB 정리) — non-admin은 target_agent_id==member_id로 self-scope, admin은 org 전체 권한으로 통과",
     "app.routers.visual_artifacts:list_artifacts":


### PR DESCRIPTION
## 배경
「연결 0건 — 이 지도는 아직 이어지지 않았습니다」 문구가 297건의 확認 대기(estimated) 후보를 못 말하던 갭(#2223 조사·#2366 스토리)의 BE 지원 축.

`GET /api/v2/analytics/goal-edges`는 `status='declared'`만 센다(#2360 설계 그대로). 실측 결과 org 전체에 declared 행이 0건이라, 실제로는 cross-epic `estimated` 후보 297건이 대기 중이어도 화면엔 0으로만 보였다.

Ortega 요청 — "297은 프로젝트 전체 수이고, 화면이 말해야 하는 것은 「이 지도에서 N건」이다(지금 띄운 레인들의 것). 축을 먼저 재고(기존 경로 있는지), 없으면 짓되 goal-edges 축은 안 건드린다."

## 조사
기존 코드에 이 정확한 지표(epic_ids 집합 스코프의 estimated cross-epic 쌍 수)는 없음을 확인 — `status == "estimated"` 쿼리는 write-path(`store_semantic_candidates` 기본값 등)뿐이고 count/aggregate 용도로 쓰인 곳이 없다.

## 구현
`GET /api/v2/analytics/goal-edges/pending-count?project_id=...&epic_ids=...`

- `AnalyticsRepository.get_pending_candidate_count`: `get_goal_edges`(#2360)의 cross-epic dedup SQL 형태를 그대로 가져오되 `status='estimated'`로, `get_epic_flow_nodes_batch`(#2679)의 `epic_ids: list[uuid]` 스코핑·dedup+cap 관례를 그대로 재사용(같은 상한 `EPIC_FLOW_NODES_BATCH_MAX`, 새 상한 안 만듦).
- 응답 필드명도 `EpicFlowNodesBatchResponse`와 동일 계약(`requested_count`/`processed_count`/`skipped_epic_ids`) — 리뷰가 "저것과 같은가"로 재질 수 있게.
- `goal-edges`가 세는 축(`status='declared'`)은 완전히 별도 메서드/엔드포인트로 — 손대지 않음(#2360 AC3 "자동 확定 금지"의 대가를 이 지표가 깨면 오늘 지운 "실선=確定"의 재발).

## 검증
- realdb 테스트 8개: cross-epic 집계 · **declared 미포함(핵심 핀 — goal-edges 축과 분리됨을 직접 대조)** · A→A 제외 · epic NULL 제외 · epic_ids 집합 밖 제외(화면에 없는 목표 쪽 쌍이 안 새는 것) · source_field 2종 dedup(같은 스토리 쌍 1로) · cross-project 404 · 빈 프로젝트 0건(오류 아님)
- 기존 `test_2360_goal_edges_realdb.py` 8개 전부 재통과 — 회귀 없음
- `test_authz_project_scope_coverage.py`에 신규 라우트 등록(기존 analytics 라우트와 동일 `_assert_project_access` 패턴 확인 후)
- 두 기존 lint(`lint_project_access_403`·`lint_query_sentinel_direct_calls`) + story #2363의 신규 lint(`lint_candidate_source_ownership`) 전부 클린