### PR TITLE
fix(infra): close env-drift-guard DI-pattern blind spot — SPRINTABLE_RUNTIME_ROLE first catch (#2296)

### DIFF
--- a/backend/tests/test_check_env_drift_code_read_axis.py
+++ b/backend/tests/test_check_env_drift_code_read_axis.py
@@ -81,6 +81,56 @@ def test_web_env_reads_ignores_test_files(tmp_path):
     assert "SOME_TEST_ONLY_KEY" not in reads
 
 
+# ── ⑤ 후속(2026-07-31) — `env: NodeJS.ProcessEnv = process.env` DI 관례 블라인드스팟 ──
+
+def test_web_env_reads_catches_di_pattern_when_declared(tmp_path):
+    """process.env를 파라미터(관례 이름 `env`)로 받는 함수 안의 `env['X']`도 이 DI 선언이
+    실제로 있는 파일이면 process.env['X']와 같은 자리로 잡혀야 한다 —
+    SPRINTABLE_RUNTIME_ROLE이 정확히 이 모양으로 못 잡히고 있었다."""
+    mod = _load_check_env_drift()
+    src = tmp_path / "background-runtime.ts"
+    src.write_text(
+        "export function resolveRole(env: NodeJS.ProcessEnv = process.env) {\n"
+        "  const rawRole = env['SPRINTABLE_RUNTIME_ROLE'];\n"
+        "  return rawRole;\n"
+        "}\n"
+    )
+    reads = mod._web_env_reads(tmp_path)
+    assert "SPRINTABLE_RUNTIME_ROLE" in reads
+    assert reads["SPRINTABLE_RUNTIME_ROLE"][0][1] is None  # 기본값 없음(㉠high)
+
+
+def test_web_env_reads_ignores_env_bracket_without_di_declaration(tmp_path):
+    """DI 선언(`env: NodeJS.ProcessEnv = process.env`)이 «없는» 파일에서 우연히 `env`라는
+    이름의 변수를 쓰면(env var와 무관한 지역변수) 잡지 않는다 — 오탐 방지가 이 스캔 확장의
+    전제 조건이다."""
+    mod = _load_check_env_drift()
+    src = tmp_path / "unrelated.ts"
+    src.write_text(
+        "function pick(env: Record<string, string>) {\n"
+        "  return env['SOME_UNRELATED_KEY'];\n"
+        "}\n"
+    )
+    reads = mod._web_env_reads(tmp_path)
+    assert "SOME_UNRELATED_KEY" not in reads
+
+
+def test_ac_sprintable_runtime_role_reproduces_via_real_repo_scan():
+    """실제 리포 소스(apps/web/src/services/background-runtime.ts)를 그대로 스캔 —
+    SPRINTABLE_RUNTIME_ROLE이 IaC 어디에도 없는 실제 상태에서 high로 잡혀야 한다(라이브
+    실측 2026-07-31: sprintable-frontend-{dev,prod} 둘 다 이 키가 없음 — gcloud로 직접 확認)."""
+    mod = _load_check_env_drift()
+    reads = mod._web_env_reads()  # 실제 apps/web/src 스캔
+    assert "SPRINTABLE_RUNTIME_ROLE" in reads
+
+    covered = mod._iac_covered_keys_for_service("sprintable-frontend-prod")
+    assert "SPRINTABLE_RUNTIME_ROLE" not in covered  # IaC 스크립트 전수에도 없음(실측)
+
+    highest, high, low = mod._unsupplied_code_read_findings(reads, covered, set())
+    high_keys = {k for k, _ in high}
+    assert "SPRINTABLE_RUNTIME_ROLE" in high_keys  # 기본값 없음(dev/localhost 문자열 아님) → high, highest 아님
+
+
 def test_web_env_reads_never_touches_live_values():
     """AC5 — 이 함수의 시그니처 자체가 소스 Path만 받는다(라이브 env 접근 불가능한 구조).
     함수가 아예 gcloud를 부를 방법이 없다는 것을 소스 검사로 고정."""
@@ -97,6 +147,20 @@ def test_web_env_reads_never_touches_live_values():
 # 재현하는 것이 목적이라 그 두 키만 빼서 사고 시점 상태를 흉내낸다(그 외 실제 IaC 상태는
 # 그대로 써서 NEXT_PUBLIC_FASTAPI_URL 같은 무관한 키가 findings에 섞이지 않게 한다).
 _INCIDENT_KEYS = {"MOBILE_APP_LINK_ORIGIN", "FIREBASE_BFF_INTERNAL_SECRET"}
+
+# ⑤ 후속(2026-07-31) — DI 패턴 확장으로 새로 잡히기 시작한 실제 미커버 값들. 이 아래
+# 포지티브컨트롤 테스트는 "그 두 사고 키가 커버되면 나머지는 실제로 이미 깨끗하다"는 원래
+# 시나리오를 재는 것이라 이 신규 발견들과는 별개 관심사(별도로
+# test_ac_sprintable_runtime_role_reproduces_via_real_repo_scan이 이걸 전담해서 잡는다) —
+# 그래서 여기서만 빼고, baseline에는 안 넣는다(SPRINTABLE_RUNTIME_ROLE은 PO 판단 대기 신규
+# 실사고 후보라 스스로 조용히 얼리지 않는다).
+_DI_FOLLOWUP_KEYS = {
+    "SPRINTABLE_RUNTIME_ROLE",
+    "SPRINTABLE_BACKGROUND_POLL_INTERVAL_MS",
+    "SPRINTABLE_MEMO_DISPATCHER_POLL_INTERVAL_MS",
+    "SPRINTABLE_DISCORD_OUTBOUND_POLL_INTERVAL_MS",
+    "SPRINTABLE_TEAMS_OUTBOUND_POLL_INTERVAL_MS",
+}
 
 
 def test_ac1_mobile_app_link_origin_reproduces_as_highest_fail():
@@ -178,6 +242,25 @@ def test_ac2_positive_control_full_main_passes_when_covered(monkeypatch, capsys)
         ],
     )
     monkeypatch.setattr(mod, "_load_allowlist", lambda: ({}, {}))
+    # ⑤ 후속(2026-07-31) — DI 패턴으로 새로 잡히기 시작한 키들을 이 테스트 안에서만 "이미
+    # baseline 처리된 것"으로 스텁한다(실제 infra/manual-env-allowlist.yml은 안 건드린다).
+    # ⛔`_live_env_entries`에 이 키들을 얹는 방식은 안 쓴다 — 그러면 ①키집합 대조(실제
+    # IaC와 비교)가 "라이브엔 있는데 IaC엔 없는 새 키"로 따로 잡아 이 테스트의 관심사(사고
+    # 두 키가 커버되면 나머지는 실제로 깨끗한가)와 무관한 실패가 섞인다. 이 신규 발견 자체는
+    # test_ac_sprintable_runtime_role_reproduces_via_real_repo_scan이 전담해서 잡는다.
+    from datetime import date, timedelta
+    _until = (date.today() + timedelta(days=10)).isoformat()
+    real_baseline = mod._load_code_read_high_baseline()
+    monkeypatch.setattr(
+        mod, "_load_code_read_high_baseline",
+        lambda: {
+            **real_baseline,
+            **{
+                k: {"key": k, "reason": "test stub — see ⑤ 후속 comment", "declared_by": "test", "until": _until}
+                for k in _DI_FOLLOWUP_KEYS
+            },
+        },
+    )
 
     exit_code = mod.main()
     out = capsys.readouterr().out
@@ -211,9 +294,15 @@ def test_ac4_real_repo_scan_counts_are_recorded():
         f"\n[AC4] 총 고유 env 키 {total_reads}개 · exempt {len(exempt)}개 · "
         f"미커버 findings {total_findings}개(highest={len(highest)}, high={len(high)}, low={len(low)})"
     )
-    # 정확한 숫자 고정(2026-07-28) — 스위트가 실패하면 숫자가 바뀐 것, 원인을 봐야 한다.
+    # 정확한 숫자 고정(2026-07-28, 2026-07-31 ⑤ DI-패턴 후속으로 high 15→20 갱신) — 스위트가
+    # 실패하면 숫자가 바뀐 것, 원인을 봐야 한다. +5는 SPRINTABLE_RUNTIME_ROLE·
+    # SPRINTABLE_{BACKGROUND,MEMO_DISPATCHER,DISCORD_OUTBOUND,TEAMS_OUTBOUND}_POLL_INTERVAL_MS
+    # — background-runtime.ts의 `env: NodeJS.ProcessEnv = process.env` DI 파라미터로 읽혀
+    # process.env 직접참조만 보던 스캔에 새로 잡히기 시작한 실제 미커버 값들(baseline에 일부러
+    # 안 넣었다 — SPRINTABLE_RUNTIME_ROLE은 PO 판단이 필요한 신규 실사고 후보라 스스로 baseline
+    # 처리하지 않는다).
     assert len(highest) == 1, highest
-    assert len(high) == 15, high
+    assert len(high) == 20, high
     assert len(low) == 9, low
     assert len(exempt) == 18
 

--- a/infra/check_env_drift.py
+++ b/infra/check_env_drift.py
@@ -43,6 +43,17 @@ IaC∪라이브(그 서비스 것) 어디에도 없는 키를 위험 등급별�
 공개돼 있는 것, 예: `'https://dev-app.sprintable.ai'`)만 읽는다. 라이브 Cloud Run env
 value는 이 축도 절대 안 읽는다(①이 이미 뽑아 둔 키 «이름» 집합만 재사용).
 
+⑤ 후속(2026-07-31, 민 지적) — `env: NodeJS.ProcessEnv = process.env` DI 관례 블라인드스팟.
+⑤가 원래 `process.env['X']`/`process.env.X`만 봐서, process.env를 파라미터(관례상 이름
+`env`)로 받아 테스트 가능하게 만드는 함수 안의 읽기(`env['X']`)는 못 봤다. 이 코드베이스에
+9개 파일·12개 읽기가 이 패턴이고, `SPRINTABLE_RUNTIME_ROLE`이 정확히 이 구멍으로 빠져 있었다
+— apps/web/src/services/background-runtime.ts가 이 값으로 배경 워커(Discord/Slack/Teams
+아웃바운드+메모 디스패처) 기동 여부를 정하는데, 값이 없으면 프로덕션에서 `role='web'`으로
+조용히 떨어져 instrumentation.ts가 워커를 시작 안 하고 그냥 `return`한다(throw도 로그도
+없음). 라이브 실측(2026-07-31): `sprintable-frontend-{dev,prod}` 둘 다 이 값이 없다 —
+IaC에도 없다(스크립트 전수 grep 0건). 이 DI 관례를 실제로 선언한 파일에서만 `env[...]`도
+추가로 본다(무관 변수명 오탐 방지).
+
 로컬 수동 실행:
     python3 infra/check_env_drift.py
 
@@ -319,6 +330,18 @@ def _iac_covered_keys() -> set[str]:
 _WEB_SRC_DIR = _REPO_ROOT / "apps" / "web" / "src"
 _ENV_BRACKET_RE = re.compile(r"process\.env\[\s*['\"]([A-Z][A-Z0-9_]*)['\"]\s*\]")
 _ENV_DOT_RE = re.compile(r"process\.env\.([A-Z][A-Z0-9_]*)")
+
+# ⑤ 후속(2026-07-31) — `env: NodeJS.ProcessEnv = process.env` DI 관례 블라인드스팟. 함수가
+# process.env를 파라미터(관례상 이름 `env`)로 받아 테스트 가능하게 만드는 패턴이 이
+# 코드베이스에 9개 파일·12개 읽기로 실재한다 — 그 파라미터로 읽으면 문자열 리터럴
+# 「process.env」가 없어 위 두 정규식이 못 본다. `SPRINTABLE_RUNTIME_ROLE`이 정확히 이
+# 구멍으로 빠졌다(apps/web/src/services/background-runtime.ts:83, `env['SPRINTABLE_RUNTIME_ROLE']`
+# — 값이 없으면 apps/web/scripts/background-runtime-worker.ts가 즉시 throw한다).
+# ⛔무관 변수명 오탐을 막으려고 "이 DI 관례를 실제로 선언한 파일에서만" 추가로 본다 —
+# 아무 파일에서나 `env[...]`를 다 잡으면 관계없는 지역변수까지 오염된다.
+_ENV_PARAM_DI_RE = re.compile(r"\benv\s*:\s*NodeJS\.ProcessEnv\s*=\s*process\.env\b")
+_ENV_PARAM_BRACKET_RE = re.compile(r"(?<!process\.)\benv\[\s*['\"]([A-Z][A-Z0-9_]*)['\"]\s*\]")
+_ENV_PARAM_DOT_RE = re.compile(r"(?<!process\.)\benv\.([A-Z][A-Z0-9_]*)\b")
 # 매치 직후 200자 안에서 `?? '...'`/`|| '...'`(문자열 리터럴 폴백)만 인식한다 — 함수 호출·
 # 변수 등 리터럴이 아닌 폴백은 "기본값 없음"과 동일하게 취급(안전 쪽, ㉠으로 승격).
 _DEFAULT_LITERAL_RE = re.compile(r"""^\s*(?:\?\?|\|\|)\s*['"]([^'"]*)['"]""")
@@ -327,7 +350,12 @@ _DEFAULT_LITERAL_RE = re.compile(r"""^\s*(?:\?\?|\|\|)\s*['"]([^'"]*)['"]""")
 # NEXT_RUNTIME — Next.js가 빌드/런타임에 자동 주입(nodejs/edge 런타임 구분), 사람이 배포
 # 설정으로 "공급"하는 값이 아니다(2026-07-28 실측 확認 — instrumentation.ts가 읽지만 그
 # 값은 배포 SSOT/라이브 env var가 아니라 프레임워크가 실행 컨텍스트에 따라 스스로 세팅).
-_WEB_ENV_IGNORE = {"NODE_ENV", "NEXT_RUNTIME"}
+# VERCEL_URL·VERCEL_PROJECT_PRODUCTION_URL — Vercel 플랫폼이 배포 시 자동 주입하는
+# 값이다(app-url.ts의 Vercel-auto-env 폴백 계단). 이 저장소는 GCP Cloud Run으로 나가(
+# env-drift-guard.yml의 WIF 인증이 그 증거) Vercel에서 도는 일이 없으니 이 두 키는 «항상»
+# undefined가 정상이다 — ⑤ 후속(2026-07-31, env: NodeJS.ProcessEnv 파라미터 스캔 확장)에서
+# 새로 잡히기 시작해 여기 추가했다(NEXT_RUNTIME과 같은 이유).
+_WEB_ENV_IGNORE = {"NODE_ENV", "NEXT_RUNTIME", "VERCEL_URL", "VERCEL_PROJECT_PRODUCTION_URL"}
 
 # ⑤가 대상으로 삼는 서비스 — apps/web 코드베이스를 실제로 구동하는 라이브 서비스만.
 _WEB_CODE_SERVICES = {"sprintable-frontend-dev", "sprintable-frontend-prod"}
@@ -420,7 +448,12 @@ def _web_env_reads(src_dir: Path = _WEB_SRC_DIR) -> dict[str, list[tuple[str, st
             rel = str(path.relative_to(_REPO_ROOT))
         except ValueError:
             rel = str(path)  # src_dir이 repo 밖(테스트의 tmp_path 등)일 때의 폴백
-        for regex in (_ENV_BRACKET_RE, _ENV_DOT_RE):
+        regexes = [_ENV_BRACKET_RE, _ENV_DOT_RE]
+        # ⑤ 후속 — 이 파일이 `env: NodeJS.ProcessEnv = process.env` DI 관례를 실제로
+        # 선언했을 때만 env[...]/env.X도 process.env[...]와 같은 자리로 본다.
+        if _ENV_PARAM_DI_RE.search(text):
+            regexes += [_ENV_PARAM_BRACKET_RE, _ENV_PARAM_DOT_RE]
+        for regex in regexes:
             for m in regex.finditer(text):
                 key = m.group(1)
                 if key in _WEB_ENV_IGNORE:


### PR DESCRIPTION
오르테가군 지시(#2296 후속) — "②를 먼저 짓고 ①로 검거를 보이는" 순서 그대로.

## 원인
axis ⑤가 `process.env['X']`/`process.env.X` 리터럴만 봐서, `env: NodeJS.ProcessEnv =
process.env` 파라미터 DI 관례(테스트 가능성을 위한 9개 파일·12개 읽기)로 읽는 자리는
못 봤다. `SPRINTABLE_RUNTIME_ROLE`이 정확히 이 구멍으로 빠져 있었다
(`apps/web/src/services/background-runtime.ts:83`).

## 실측(①) — 라이브 서비스 직접 대조 (2026-07-31)
```
gcloud run services describe sprintable-frontend-{dev,prod} → SPRINTABLE_RUNTIME_ROLE 없음(둘 다)
IaC 스크립트 전수 grep(cloudbuild.yaml·.github/workflows/*.yml·deploy_*.sh) → 0건
⇒ 코드에도 IaC에도 라이브에도 없다 — 손 gcloud 값도 아니다
```

## ⚠️결과가 심각하다 — 이건 그냥 "설정 누락"이 아니다
```
resolveBackgroundRuntimeRole(): 값 없으면 NODE_ENV==='production' ? 'web' : 'all'
⇒ prod에서 role='web' ⇒ shouldStartBackgroundRuntime()=false
instrumentation.ts register(): shouldStartBackgroundRuntime()===false면 그냥 return
  (throw 없음·로그 없음 — apps/web/scripts/background-runtime-worker.ts의 throw는
  독립 실행 스크립트에만 있고, 실제 프로덕션 경로인 instrumentation.ts엔 그 안전장치가 없다)
⇒ ⭐Discord/Slack/Teams 아웃바운드 디스패처 + 메모 디스패처가 프로덕션에서 «한 번도»
  시작한 적이 없을 개연성 — 조용히, 관측 0으로.
```
이 값을 지금 채울지·어떻게 채울지는 PO/오르테가군 판단 자리라 제가 손대지 않았다 —
baseline에도 안 넣고 «잡힌 채로» 뒀다(가드의 진짜 첫 검거를 흐리지 않으려는 것).

## 고침 — ②
`env: NodeJS.ProcessEnv = process.env` 관례를 실제로 선언한 파일에서만 `env[...]`도
`process.env[...]`와 같은 자리로 본다(무관 변수명 오탐 방지). `VERCEL_URL`/
`VERCEL_PROJECT_PRODUCTION_URL`은 이 확장으로 같이 잡힌 노이즈라 NODE_ENV/NEXT_RUNTIME과
같은 이유(플랫폼 자동주입·이 리포는 Cloud Run이라 Vercel 값이 항상 없는 게 정상)로
`_WEB_ENV_IGNORE`에 추가.

## 못 잡는 것(③)
- 여전히 동적 조립 이름(`env[computedName]`)은 정적 스캔이 못 본다(axis ⑤ 원 설계 한계 그대로).
- ⭐이번 확장 자체의 한계: `env: NodeJS.ProcessEnv = process.env`라는 «정확한 문자열»을
  선언한 파일만 대상이다 — 구조분해(`const { X } = env`)나 다른 파라미터명·다른 타입 표기로
  같은 일을 하면 여전히 못 본다.

## 회귀 테스트
- DI 패턴 양성/음성 대조(신규) + 실제 리포로 SPRINTABLE_RUNTIME_ROLE 재현(신규).
- 기존 pinned-count 테스트(AC4, high 15→20)·positive-control 테스트(AC2, baseline
  stub으로 이번 신규 발견과 분리 — 실 저장소/allowlist는 안 건드림) 갱신, 이유 코멘트로 남김.
- `uv run pytest tests/test_check_env_drift_code_read_axis.py` 27 passed.
- `uv run python3 ../infra/check_env_drift.py` 실제 로컬 실행 — 라이브 gcloud 대조 포함
  end-to-end로 SPRINTABLE_RUNTIME_ROLE 등 5건 FAIL 확認(본문 위 실측 그대로).

[SID:9d4a35d2-3b5b-4ead-9ed1-c77b214573ce]
