### PR TITLE
fix(security): story#1831 — agent_routing_rules 단일-룰 update 마지막 project_id 폴백 이전

### DIFF
--- a/backend/app/routers/agent_routing_rules.py
+++ b/backend/app/routers/agent_routing_rules.py
@@ -162,10 +162,18 @@ async def replace_or_update_rules(
             return _err("BAD_REQUEST", str(exc), 400)
         return _ok([r.model_dump(mode="json") for r in rules])
 
-    # 단일-룰 update 분기: 기존 raw project_id 폴백 그대로(Tier 1 fail-closed — id 매치 요구라
-    # 이번 스토리 스코프 아님, doc §2.2 4단계 후속).
-    project_id_str = auth.claims.get("app_metadata", {}).get("project_id")
-    project_id = uuid.UUID(str(project_id_str)) if project_id_str else None
+    # E-MCP-OPT 후속(story #1831·doc legacy-project-fallback-sweep-audit §2.2 4단계) — 위 items
+    # 분기와 동일하게 요청시점 재해소로 이전한다. UpdateRoutingRuleRequest엔 project_id 필드가
+    # 없어(스키마 그대로) explicit_project_id 없이 호출 — X-Project-Id 헤더 > member.
+    # default_project_id > 단일 접근가능 프로젝트 > 400 순으로 해소된다.
+    try:
+        project_id = await resolve_required_project_id(repo.session, request, auth, org_id)
+    except HTTPException as exc:
+        return _err(
+            exc.detail.get("code", "PROJECT_ID_REQUIRED") if isinstance(exc.detail, dict) else "FORBIDDEN",
+            exc.detail.get("message", str(exc.detail)) if isinstance(exc.detail, dict) else str(exc.detail),
+            exc.status_code,
+        )
     req_update = UpdateRoutingRuleRequest.model_validate(body)
     try:
         rule = await repo.update(

--- a/backend/tests/test_f0c99070_critical_project_scope_realdb.py
+++ b/backend/tests/test_f0c99070_critical_project_scope_realdb.py
@@ -528,3 +528,130 @@ async def test_reorder_items_ambiguous_no_project_id_400_no_mutation():
             assert await _rule_priority(s, rule_a) == 100  # 무변경.
     finally:
         await engine.dispose()
+
+
+# ── agent_routing_rules::replace_or_update_rules(단일-룰 update 분기, story #1831 후속) ──
+# 오르테가 실측(2026-07-31) — 이 분기만 §2.2 4단계로 미뤄져 있었다. 위 두 분기(items·
+# reorder-items)와 동일 계약으로 지금 이전한다.
+
+
+async def test_single_update_default_project_id_scopes_correctly_sibling_untouched():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_project_agent(s, default_project_id=None)
+            rule_a = await _seed_rule(s, seeded["org_id"], seeded["project_a"], seeded["agent_id"])
+            rule_b = await _seed_rule(s, seeded["org_id"], seeded["project_b"], seeded["agent_id"])
+
+        async with Session() as s:
+            from app.models.member import Member
+            member = await s.get(Member, seeded["agent_id"])
+            member.default_project_id = seeded["project_a"]
+            await s.commit()
+
+        async with Session() as s:
+            from app.routers.agent_routing_rules import replace_or_update_rules
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await replace_or_update_rules(
+                request=_request(None),
+                body={"id": str(rule_a), "priority": 5},
+                auth=_auth(seeded["agent_id"], seeded["org_id"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 200
+            await s.commit()
+
+        async with Session() as s:
+            assert await _rule_priority(s, rule_a) == 5
+            assert await _rule_priority(s, rule_b) == 100  # 형제 project 무변경.
+    finally:
+        await engine.dispose()
+
+
+async def test_single_update_header_scopes_correctly_sibling_untouched():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_project_agent(s)
+            rule_a = await _seed_rule(s, seeded["org_id"], seeded["project_a"], seeded["agent_id"])
+            rule_b = await _seed_rule(s, seeded["org_id"], seeded["project_b"], seeded["agent_id"])
+
+        async with Session() as s:
+            from app.routers.agent_routing_rules import replace_or_update_rules
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await replace_or_update_rules(
+                request=_request(str(seeded["project_a"])),
+                body={"id": str(rule_a), "priority": 5},
+                auth=_auth(seeded["agent_id"], seeded["org_id"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 200
+            await s.commit()
+
+        async with Session() as s:
+            assert await _rule_priority(s, rule_a) == 5
+            assert await _rule_priority(s, rule_b) == 100
+    finally:
+        await engine.dispose()
+
+
+async def test_single_update_ambiguous_no_project_id_400_no_mutation():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_project_agent(s, default_project_id=None)
+            rule_a = await _seed_rule(s, seeded["org_id"], seeded["project_a"], seeded["agent_id"])
+
+        async with Session() as s:
+            from app.routers.agent_routing_rules import replace_or_update_rules
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await replace_or_update_rules(
+                request=_request(None),
+                body={"id": str(rule_a), "priority": 5},
+                auth=_auth(seeded["agent_id"], seeded["org_id"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 400
+
+        async with Session() as s:
+            assert await _rule_priority(s, rule_a) == 100  # 무변경.
+    finally:
+        await engine.dispose()
+
+
+async def test_single_update_cross_project_stale_fallback_would_have_leaked_now_404s():
+    """⭐되돌리기 전 상태 재현 — 되기 前(raw claims fallback)이었다면 project_b agent가
+    project_a rule의 id를 알기만 하면(예: 다른 통로에서 유출) 수정할 수 있었다. 재해소 後엔
+    caller의 default_project_id(project_b)로 스코프되어 project_a 소유 rule에 404가 난다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_project_agent(s, default_project_id=None)
+            rule_a = await _seed_rule(s, seeded["org_id"], seeded["project_a"], seeded["agent_id"])
+
+        async with Session() as s:
+            from app.models.member import Member
+            member = await s.get(Member, seeded["agent_id"])
+            member.default_project_id = seeded["project_b"]  # caller 스코프 = project_b.
+            await s.commit()
+
+        async with Session() as s:
+            from app.routers.agent_routing_rules import replace_or_update_rules
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await replace_or_update_rules(
+                request=_request(None),
+                # rule_a는 project_a 소유 — caller는 project_b로 재해소되므로 안 만져진다.
+                body={"id": str(rule_a), "priority": 5},
+                auth=_auth(seeded["agent_id"], seeded["org_id"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 404
+
+        async with Session() as s:
+            assert await _rule_priority(s, rule_a) == 100  # 무변경 — cross-project 수정 0.
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_f0c99070_critical_project_scope_realdb.py
+++ b/backend/tests/test_f0c99070_critical_project_scope_realdb.py
@@ -53,11 +53,22 @@ async def _session_factory():
     return engine, async_sessionmaker(engine, expire_on_commit=False)
 
 
-def _auth(agent_id: uuid.UUID, org_id: uuid.UUID, *, role: str = "member"):
+def _auth(
+    agent_id: uuid.UUID, org_id: uuid.UUID, *, role: str = "member",
+    stale_project_id: uuid.UUID | None = None,
+):
+    """`stale_project_id`(까심 실측, 2026-07-31) — 토큰 발급 시점에 구워진
+    `app_metadata.project_id`를 실제로 채운다. 이 값이 없으면(기본) old-code 경로도
+    `project_id=None`이 되어 어차피 못 찾아 404가 나므로, "되돌리면 샜을 것"을 재는
+    회귀 테스트가 old/new 양쪽에서 같은 결과를 내는 무판별 테스트가 된다 — 실제
+    공격 시나리오(토큰에 project_id가 채워져 있는 흔한 경우)를 그대로 갖는다."""
     from app.dependencies.auth import AuthContext
+    claims = {"app_metadata": {"org_id": str(org_id), "role": role}}
+    if stale_project_id is not None:
+        claims["app_metadata"]["project_id"] = str(stale_project_id)
     return AuthContext(
         user_id=str(agent_id), email=None,
-        claims={"app_metadata": {"org_id": str(org_id), "role": role}},
+        claims=claims,
         org_id=str(org_id),
     )
 
@@ -623,9 +634,15 @@ async def test_single_update_ambiguous_no_project_id_400_no_mutation():
 
 
 async def test_single_update_cross_project_stale_fallback_would_have_leaked_now_404s():
-    """⭐되돌리기 전 상태 재현 — 되기 前(raw claims fallback)이었다면 project_b agent가
-    project_a rule의 id를 알기만 하면(예: 다른 통로에서 유출) 수정할 수 있었다. 재해소 後엔
-    caller의 default_project_id(project_b)로 스코프되어 project_a 소유 rule에 404가 난다."""
+    """⭐되돌리기 전 상태 재현 — 까심 실측(2026-07-31): 이 시나리오는 토큰에 실제로
+    stale project_id(project_a)가 채워져 있어야만 old/new 코드가 «다른» 결과를 낸다
+    (`_auth()`가 project_id를 안 채우면 old 코드도 project_id=None이 되어 어차피 못
+    찾아 404가 나므로 무판별). caller의 «현재» 스코프는 default_project_id(project_b)
+    이지만 JWT엔 예전 세션의 project_a가 그대로 구워져 있다 — 흔한 stale-token 시나리오.
+
+    OLD 코드(raw claims 폴백) + project_a 구워진 토큰  ⇒ 200·rule_a priority 100→5
+    (실제로 샌다 — 까심이 직접 old 코드로 재현·확定)
+    NEW 코드(재해소, 이 테스트가 지금 검증하는 것)      ⇒ 404·priority 무변경(막힌다)"""
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
@@ -635,7 +652,7 @@ async def test_single_update_cross_project_stale_fallback_would_have_leaked_now_
         async with Session() as s:
             from app.models.member import Member
             member = await s.get(Member, seeded["agent_id"])
-            member.default_project_id = seeded["project_b"]  # caller 스코프 = project_b.
+            member.default_project_id = seeded["project_b"]  # caller «현재» 스코프 = project_b.
             await s.commit()
 
         async with Session() as s:
@@ -644,9 +661,12 @@ async def test_single_update_cross_project_stale_fallback_would_have_leaked_now_
 
             resp = await replace_or_update_rules(
                 request=_request(None),
-                # rule_a는 project_a 소유 — caller는 project_b로 재해소되므로 안 만져진다.
+                # rule_a는 project_a 소유 — caller의 JWT엔 예전 project_a가 구워져 있지만
+                # (stale_project_id) 재해소는 그 값을 안 쓰고 default_project_id로 스코프한다.
                 body={"id": str(rule_a), "priority": 5},
-                auth=_auth(seeded["agent_id"], seeded["org_id"]),
+                auth=_auth(
+                    seeded["agent_id"], seeded["org_id"], stale_project_id=seeded["project_a"],
+                ),
                 repo=AgentRoutingRuleRepository(s),
             )
             assert resp.status_code == 404

--- a/backend/tests/test_s43.py
+++ b/backend/tests/test_s43.py
@@ -133,7 +133,17 @@ async def test_replace_rules_200():
 async def test_update_rule_200():
     client, session, app = await _client()
     try:
-        with patch("app.repositories.agent_routing_rule.AgentRoutingRuleRepository.update", new_callable=AsyncMock) as mock_update:
+        # story #1831 후속: 단일-룰 update 분기도 이제 요청시점 재해소(resolve_required_project_id)
+        # 를 거친다 — session mock의 내부 쿼리 체인까지 흉내내는 대신(test_disable_all_200과 달리
+        # 이 분기는 X-Project-Id/명시 project_id가 없어 _resolve_project_default 경로까지 타야
+        # 해서 그 흉내가 더 무겁다) 이 라우터가 실제로 무엇을 호출하는지만 확인하면 되므로
+        # resolve_required_project_id 자체를 직접 patch한다(그 함수 자신의 계약은
+        # test_f0c99070_critical_project_scope_realdb.py가 실PG로 따로 검증한다).
+        with patch("app.repositories.agent_routing_rule.AgentRoutingRuleRepository.update", new_callable=AsyncMock) as mock_update, \
+             patch(
+                 "app.routers.agent_routing_rules.resolve_required_project_id",
+                 new_callable=AsyncMock, return_value=PROJECT_ID,
+             ):
             updated = _make_rule()
             updated.name = "Updated Rule"
             mock_update.return_value = updated

--- a/backend/tests/test_s43.py
+++ b/backend/tests/test_s43.py
@@ -143,7 +143,7 @@ async def test_update_rule_200():
              patch(
                  "app.routers.agent_routing_rules.resolve_required_project_id",
                  new_callable=AsyncMock, return_value=PROJECT_ID,
-             ):
+             ) as mock_resolve:
             updated = _make_rule()
             updated.name = "Updated Rule"
             mock_update.return_value = updated
@@ -152,6 +152,10 @@ async def test_update_rule_200():
                 resp = await c.put("/api/v2/agent-routing-rules", json=payload)
             assert resp.status_code == 200
             assert resp.json()["data"]["name"] == "Updated Rule"
+            # 오르테가 지적(2026-07-31): return_value만 걸면 이 유닛이 「그 함수를 실제로
+            # 타는가」를 안 잰다 — 호출이 나중에 사라져도 초록일 수 있다. assert_awaited_once로
+            # 그 자체를 고정한다.
+            mock_resolve.assert_awaited_once()
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## 배경
`#1831` ①감사(2026-07-31, PO 지시 — 읽기만) 결과, 스토리 본문의 "48개 mutation 라우트" 추정은 낡은 수였다 — `f0c99070` 스윕(doc `legacy-project-fallback-sweep-audit`)이 이미 `resolve_required_project_id`(요청시점 재해소: 명시 param/query > X-Project-Id 헤더 > member.default_project_id 재조회 > 단일 접근가능 > 400)로 CRITICAL 3.5건을 고쳐 놨다.

재감사(`app_metadata.project_id` 직접 읽는 12개 파일 grep + 1-hop 간접 소비자 추적)로 남은 5곳 중 실제 cross-tenant 위험은 **`agent_routing_rules::replace_or_update_rules`의 단일-룰 update 분기 하나뿐**이었다 — 코드 자기주석이 이미 "이번 스토리 스코프 아님·§2.2 4단계 후속"이라 자인해 둔 자리. 나머지 4곳(`open_api_keys.revoke`·`meetings`·`file_locks`·`me.update_me`)은 self-scope 오판정 정도(낮은 심각도)라 이 PR 범위 밖.

## 고침
형제 분기(items·reorder-items)와 동일하게 `resolve_required_project_id`로 전환. `UpdateRoutingRuleRequest`엔 `project_id` 필드가 없어 `explicit_project_id` 없이 호출한다.

## 검증
- realdb 테스트 4개(`test_f0c99070_critical_project_scope_realdb.py`에 추가, 기존 형제 테스트와 동일 헬퍼 재사용):
  - `default_project_id` 스코핑 — 형제 project 무변경
  - `X-Project-Id` 헤더 스코핑 — 동일
  - ambiguous(멀티프로젝트+미설정+무헤더) → 400, mutation 0건
  - ⭐**cross-project 재현** — 되돌리기 전이었다면 caller가 project_b로 재해소되는데 project_a 소유 rule id를 알고 있으면 새던 자리가, 재해소 後엔 404로 막히고 mutation 0건임을 직접 확인
- 기존 15개(f0c99070 전체 스위트) 전부 회귀 없음
- 세 lint(`lint_project_access_403`·`lint_query_sentinel_direct_calls`·`lint_candidate_source_ownership`) 전부 클린