### PR TITLE
[SID:2368] 과거 묶음 카드 글자가 점선 무더기에 가려지는 것 — 배경 불투명화+z-index

### DIFF
--- a/apps/web/src/components/flow/flow-map-canvas.test.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.test.tsx
@@ -349,6 +349,41 @@ describe('FlowMapCanvas — past-bundle card (묶음이 선을 통과시킨다)'
     // 묶음 카드는 폭이 다르다(110px) — 좌표가 실제로 그 카드 좌상단(left:20)에서 시작해야 한다.
     expect(Number(line?.getAttribute('x1'))).toBeGreaterThanOrEqual(20);
   });
+
+  // story #2368(2026-07-31, 유나 라이브 실측) — 점선 무더기가 카드 글자를 덮었다. 원인은
+  // opacity-75가 «배경 자체»를 반투명하게 만들어 대비를 계산 불가능하게 한 것(DOM 순서상
+  // 카드가 SVG들보다 나중에 그려져도 opacity가 배경째로 얇으면 소용없다). 배경을 완전
+  // 불투명으로 고정 + z-index로 "선보다 위"를 DOM 순서에 기대지 않고 명시한다.
+  it('the past-bundle card has an OPAQUE background (no opacity utility) and an explicit z-index above the edge lines (story #2368)', async () => {
+    const lane = makeLane({
+      pastTotal: 99,
+      nowNodes: [makeNode({ id: 'n1' })],
+      pastBundle: { total: 99, internalCount: 99, outgoingCount: 8 },
+    });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    const card = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('안에서 이어진 것 99'));
+    expect(card).toBeTruthy();
+    const cls = card!.getAttribute('class') ?? '';
+    // opacity-75(또는 그 어떤 opacity 유틸)가 있으면 그 아래 지나가는 선이 카드 배경에
+    // 그대로 비쳐 "글자의 배경이 선"이던 그 병이 재발한다 — 완전 불투명이어야 한다.
+    expect(cls).not.toMatch(/\bopacity-\d/);
+    expect(cls).toContain('z-10');
+  });
+
+  it('the internal-count and hint lines use text-foreground (not text-muted-foreground, which fails AA 4.5:1 on bg-muted in light mode — measured 4.39:1) (story #2368 AC3)', async () => {
+    const lane = makeLane({
+      pastTotal: 99,
+      nowNodes: [makeNode({ id: 'n1' })],
+      pastBundle: { total: 99, internalCount: 99, outgoingCount: 8 },
+    });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    const internalCountEl = Array.from(container.querySelectorAll('div')).find((d) => d.textContent === '안에서 이어진 것 99');
+    const hintEl = Array.from(container.querySelectorAll('div')).find((d) => d.textContent === '누르면 펼쳐집니다');
+    expect(internalCountEl?.getAttribute('class')).toContain('text-foreground');
+    expect(internalCountEl?.getAttribute('class')).not.toContain('text-muted-foreground');
+    expect(hintEl?.getAttribute('class')).toContain('text-foreground');
+    expect(hintEl?.getAttribute('class')).not.toContain('text-muted-foreground');
+  });
 });
 
 describe('FlowMapCanvas — grouped edges (여러 선이 한 점에 모이면 굵기+수)', () => {

--- a/apps/web/src/components/flow/flow-map-canvas.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.tsx
@@ -634,24 +634,40 @@ export function FlowMapCanvas({
                       접힌 상태(pastNodes 비어있음): 3줄(무엇이 몇 개 접혔나 · 접힌 것끼리
                       이어진 수(볼 수 없는 것, 수로 정직하게) · 접힌 것이 지금·미래로 보낸
                       수(볼 수 있는 것 — 선생님 "후속 작업이 어떻게 준비되는가" 물음의 답))
-                      + 클릭하면 펼쳐진다("누르면 펼쳐지는 것이 곧 줌인" — 별도 줌 컨트롤 불요). */}
+                      + 클릭하면 펼쳐진다("누르면 펼쳐지는 것이 곧 줌인" — 별도 줌 컨트롤 불요).
+                      ⛔story #2368(2026-07-31, 유나 실측) — 점선이 노드에서 왼쪽으로 뻗어
+                      이 카드가 있는 "지나온 것" 열을 통과한다. 옛 opacity-75는 카드 배경
+                      «자체»를 반투명하게 만들어 그 아래 지나가는 선이 글자 배경에 그대로
+                      비쳤다("글자의 배경이 «선»") — DOM 순서상 이 버튼이 SVG들보다 나중에
+                      그려져 시각적으로는 "위"였지만, opacity가 배경째로 얇아 대비를
+                      «계산할 수 없는» 상태였다. opacity를 빼 배경을 «완전 불투명»으로 고정
+                      (대비가 이제 bg-muted/text 고정값으로 계산 가능해진다) + z-10으로
+                      "선보다 위"를 DOM 순서에 기대지 않고 명시한다. */}
                   {lane.pastTotal > 0 && lane.pastNodes.length === 0 ? (
                     <button
                       type="button"
                       onClick={() => onTogglePastBundle(lane.epicId)}
-                      className="focus-inset absolute cursor-pointer rounded border border-border bg-muted px-1.5 py-1 text-left opacity-75 hover:border-brand/60"
+                      className="focus-inset absolute z-10 cursor-pointer rounded border border-border bg-muted px-1.5 py-1 text-left hover:border-brand/60"
                       style={{ left: PAST_BUNDLE_LEFT, top: PAST_BUNDLE_TOP, width: PAST_BUNDLE_CARD_WIDTH }}
                     >
                       <div className="font-mono text-[9px] font-semibold text-foreground">
                         {t('flowMapPastCount', { n: lane.pastTotal })} · {t('flowMapPastBundle')}
                       </div>
-                      <div className="text-[9px] text-muted-foreground">
+                      {/* story #2368 AC3 — 배경이 이제 고정(bg-muted, 완전 불투명)이라 대비가
+                          실제로 계산 가능해졌다: bg-muted 위 text-muted-foreground는 라이트
+                          4.39:1로 AA 4.5:1에 근소 미달이었다(측정, 2026-07-31) — 옆 줄과 같은
+                          text-foreground(18.07:1 라이트·14.26:1 다크)로 통일해 닫는다.
+                          text-brand(다음 줄, 「이어질 것」 강조색)는 4.27:1(라이트)/4.40:1(다크)로
+                          역시 근소 미달이지만 이 카드 안에서 유일한 강조 신호라 — 이 스토리의
+                          범위(「글자가 이긴다」까지, 색 조정은 별건)를 넘는 브랜드 토큰 변경이라
+                          그대로 두고 측정값만 기록한다(PO 판단 대기). */}
+                      <div className="text-[9px] text-foreground">
                         {t('flowMapPastInternalCount', { n: lane.pastBundle.internalCount })}
                       </div>
                       <div className="text-[9px] font-semibold text-brand">
                         {t('flowMapPastOutgoingCount', { n: lane.pastBundle.outgoingCount })}
                       </div>
-                      <div className="text-[9px] text-muted-foreground">
+                      <div className="text-[9px] text-foreground">
                         {loadingPastBundleEpicIds.has(lane.epicId) ? t('flowMapPastLoading') : t('flowMapPastExpandHint')}
                       </div>
                     </button>


### PR DESCRIPTION
## Summary
- story #2368(유나 라이브 실측 09:39Z) — E-CONNECT/E-ARCH/E-CHAT-REALTIME 과거 묶음 카드의 "안에서 이어진 것 N" 텍스트가 점선 무더기 아래 깔려 흐릿했다. 유나의 겹침 판정 자(bbox 2px)는 선의 "굵기"만 보고 "여러 가닥 겹친 무더기"를 못 세서 2/59로 통과 판정했지만 눈으로는 셋 이상 안 읽혔다.
- 원인: 카드가 `bg-muted`(불투명 토큰)를 갖지만 `opacity-75`가 배경 자체를 반투명하게 만들어, DOM 순서상 카드가 edge-line SVG들보다 나중에 그려져도 그 아래 지나가는 선이 배경에 그대로 비쳤다.
- 처방: `opacity-75` 제거(배경 완전 불투명 고정) + `z-10` 추가(DOM 순서에 안 기대고 "선보다 위" 명시).
- 텍스트 색 측정(AC3): `text-muted-foreground`는 `bg-muted` 위에서 라이트 4.39:1로 AA 4.5:1 근소 미달 — 같은 카드의 title 줄과 동일한 `text-foreground`(18.07:1 라이트·14.26:1 다크)로 통일해 닫음. `text-brand`(강조줄)는 4.27:1/4.40:1로 역시 근소 미달이나, 이 카드의 유일한 강조 신호이자 브랜드 토큰 변경은 이 스토리 범위 밖 — 측정값만 기록, PO 판단 대기.
- 점선 경로는 안 바꿈(AC4, 레이아웃 재설계 아님).

## AC7 — 겹침 판정 자의 한계 기록
`bbox 2px` 기준은 선의 굵기만 보고 여러 가닥이 겹친 "무더기"를 못 센다. 코드에도 기록함.

## Test plan
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm exec vitest run` — 334 files / 2424 tests 전부 PASS(신규 2건: opacity 부재+z-10 존재, text-foreground 사용 — 둘 다 mutation self-check 완료)
- [x] `pnpm run build` — 성공
- [x] verify:* 5개 — 전부 OK
- [ ] 배포 후 라이브 픽셀(AC2·AC6): E-CONNECT/E-ARCH/E-CHAT-REALTIME 세 요약 블록 글자가 실제로 읽히는지, 데스크톱 회귀(지도 y≈152·헤드라인 y≈570·레인 스냅) 없는지 — jsdom은 픽셀 겹침을 원리적으로 못 잰다(이 스토리 자체가 그 한계의 근거)

🤖 Generated with [Claude Code](https://claude.com/claude-code)