### PR TITLE
[SID:2368] AC3 재정정 — 「여기서 나온 다음」줄도 text-foreground로 (두 테마 다 AA 미달)

### DIFF
--- a/apps/web/src/components/flow/flow-map-canvas.test.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.test.tsx
@@ -370,7 +370,7 @@ describe('FlowMapCanvas — past-bundle card (묶음이 선을 통과시킨다)'
     expect(cls).toContain('z-10');
   });
 
-  it('the internal-count and hint lines use text-foreground (not text-muted-foreground, which fails AA 4.5:1 on bg-muted in light mode — measured 4.39:1) (story #2368 AC3)', async () => {
+  it('the internal-count, outgoing-count, and hint lines all use text-foreground — not text-muted-foreground(라이트 4.39:1 미달) or text-brand(라이트 4.27:1·다크 4.40:1 «두 테마 다» 미달) on bg-muted (story #2368 AC3, PO 재정정 2026-07-31)', async () => {
     const lane = makeLane({
       pastTotal: 99,
       nowNodes: [makeNode({ id: 'n1' })],
@@ -378,9 +378,12 @@ describe('FlowMapCanvas — past-bundle card (묶음이 선을 통과시킨다)'
     });
     await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
     const internalCountEl = Array.from(container.querySelectorAll('div')).find((d) => d.textContent === '안에서 이어진 것 99');
+    const outgoingCountEl = Array.from(container.querySelectorAll('div')).find((d) => d.textContent === '여기서 나온 다음 8건');
     const hintEl = Array.from(container.querySelectorAll('div')).find((d) => d.textContent === '누르면 펼쳐집니다');
     expect(internalCountEl?.getAttribute('class')).toContain('text-foreground');
     expect(internalCountEl?.getAttribute('class')).not.toContain('text-muted-foreground');
+    expect(outgoingCountEl?.getAttribute('class')).toContain('text-foreground');
+    expect(outgoingCountEl?.getAttribute('class')).not.toMatch(/\btext-brand\b/);
     expect(hintEl?.getAttribute('class')).toContain('text-foreground');
     expect(hintEl?.getAttribute('class')).not.toContain('text-muted-foreground');
   });

--- a/apps/web/src/components/flow/flow-map-canvas.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.tsx
@@ -657,14 +657,18 @@ export function FlowMapCanvas({
                           실제로 계산 가능해졌다: bg-muted 위 text-muted-foreground는 라이트
                           4.39:1로 AA 4.5:1에 근소 미달이었다(측정, 2026-07-31) — 옆 줄과 같은
                           text-foreground(18.07:1 라이트·14.26:1 다크)로 통일해 닫는다.
-                          text-brand(다음 줄, 「이어질 것」 강조색)는 4.27:1(라이트)/4.40:1(다크)로
-                          역시 근소 미달이지만 이 카드 안에서 유일한 강조 신호라 — 이 스토리의
-                          범위(「글자가 이긴다」까지, 색 조정은 별건)를 넘는 브랜드 토큰 변경이라
-                          그대로 두고 측정값만 기록한다(PO 판단 대기). */}
+                          ⛔PO 재정정(2026-07-31, 유나 라이브 재측정) — text-brand(다음 줄)도
+                          라이트 4.27:1·다크 4.40:1로 «두 테마 다» AA 미달이었다(opacity-75가
+                          걷히며 «계산 가능해져 드러난» 것 — 이 PR이 만든 결함이 아니다). PO의
+                          첫 판정("이 판에서 안 고친다")은 «--brand 전역 토큰을 바꾸는 것»과
+                          «이 줄만 다른 토큰으로 옮기는 것»을 안 갈랐던 것이라 정정됐다 — 후자는
+                          토큰 무관·한 줄짜리 스코프다. 구분은 이미 "여기서 나온 다음"이라는
+                          말이 하고 있어 색은 보조 신호였다(유나) — text-foreground로 통일해도
+                          뜻이 안 죽는다. --brand 토큰 자체는 전역이라 안 건드린다. */}
                       <div className="text-[9px] text-foreground">
                         {t('flowMapPastInternalCount', { n: lane.pastBundle.internalCount })}
                       </div>
-                      <div className="text-[9px] font-semibold text-brand">
+                      <div className="text-[9px] font-semibold text-foreground">
                         {t('flowMapPastOutgoingCount', { n: lane.pastBundle.outgoingCount })}
                       </div>
                       <div className="text-[9px] text-foreground">


### PR DESCRIPTION
## Summary
- story #2368 AC3 후속(유나 라이브 재측정) — 과거 묶음 카드의 "여기서 나온 다음 N건" 줄(`text-brand`)이 `bg-muted` 위에서 라이트 4.27:1·다크 4.40:1로 두 테마 다 AA 4.5:1 미달이었다.
- `#2750`이 만든 결함이 아니다 — `opacity-75`가 걷히며(같은 PR) 대비가 계산 가능해져 드러난 것.
- PO의 첫 판정("이 판에서 `text-brand`는 안 고친다")은 "`--brand` 전역 토큰 변경"과 "이 줄만 다른 토큰으로"를 안 가른 것이었음을 정정 — 후자는 토큰 무관·스코프가 이 한 줄뿐.
- 구분은 이미 "여기서 나온 다음"이라는 말이 하고 있어(유나) 색은 보조 신호 — `text-foreground`(카드의 다른 세 줄과 동일, 18.07:1/14.26:1)로 통일. `--brand` 전역 토큰 자체는 안 건드림.
- 이것으로 `#2368` AC3("고침 뒤 대비비를 실제로 재어 적는다")가 완전히 닫힌다 — 카드 네 줄 전부 `text-foreground` on `bg-muted`(불투명)로 고정.

## Test plan
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm exec vitest run` — 334 files / 2424 tests 전부 PASS(기존 회귀가드 확장, mutation self-check 완료)
- [x] `pnpm run build` — 성공
- [x] verify:* 5개 — 전부 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)