### PR TITLE
[SID:2369] 갈래 지도 가로 잘림 알림 — 세로 접힘 줄과 같은 꼴 + 실측 N카드

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -494,6 +494,8 @@
     "flowMapMoreCount": "+{n} more",
     "flowLaneFoldedCount": "{n} goals with no recent movement",
     "flowLaneFoldedReason": "— no change in 30 days. Not hidden, just folded.",
+    "flowCanvasOffscreenCount": "{n} cards off-screen",
+    "flowCanvasOffscreenReason": "— scroll right to see them.",
     "nextMakerHeadline": "{needsNext} of {total} goals have no \"next\" set",
     "nextMakerHeadlineStall": "{n} are about to stall",
     "nextMakerQuietHint": "{n} may already be finished",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -494,6 +494,8 @@
     "flowMapMoreCount": "+{n}건 더 있습니다",
     "flowLaneFoldedCount": "움직임 없는 목표 {n}개",
     "flowLaneFoldedReason": "— 30일 안에 변화 없음. 숨긴 것이 아니라 접은 것입니다.",
+    "flowCanvasOffscreenCount": "카드 {n}장이 화면 밖",
+    "flowCanvasOffscreenReason": "— 오른쪽으로 스크롤하면 보입니다.",
     "nextMakerHeadline": "목표 {total}개 중 {needsNext}개에 「다음」이 정해지지 않았습니다",
     "nextMakerHeadlineStall": "{n}개는 곧 멈춥니다",
     "nextMakerQuietHint": "{n}개는 이미 끝났을 수 있습니다",

--- a/apps/web/src/components/flow/derive-flow-map.test.ts
+++ b/apps/web/src/components/flow/derive-flow-map.test.ts
@@ -4,7 +4,7 @@ import {
   computeNodeLogicalPositions, computeEdgeLineEndpoints, groupEdgesByEndpoints, edgeGroupStrokeWidth,
   parseDependencyGraphEdges, parseReferenceCandidateEdges, FLOW_MAP_TOP_N, FLOW_MAP_FOLD_THRESHOLD,
   FLOW_MAP_DEPTH0_X, FLOW_MAP_GRID_STEP, PAST_BUNDLE_NODE_ID,
-  computeCumulativeLaneHeight, snapToNearestLaneCount,
+  computeCumulativeLaneHeight, snapToNearestLaneCount, countCardsBeyondRightEdge,
   type FlowMapEdge, type FlowMapLane, type RawReferenceCandidate,
 } from './derive-flow-map';
 import type { EpicFlowNodeItem } from './derive-flow';
@@ -536,6 +536,39 @@ describe('snapToNearestLaneCount — story #2224 AC18 ①(자유 픽셀 드래�
   it('never returns less than 1 when at least one lane exists (하한 = 레인 1개, AC18 ②)', () => {
     const laneHeights = [50, 70, 80];
     expect(snapToNearestLaneCount(laneHeights, -9999)).toBe(1);
+  });
+});
+
+// story #2369 AC2(2026-07-31, PO 실측·물음) — "완전히 밖"인 카드만 센다, "걸친" 카드는
+// 안 센다(PO 물음에 대한 답 — 걸친 카드는 스스로 존재를 알리므로 이 스토리의 병에 안 걸림).
+describe('countCardsBeyondRightEdge — story #2369 AC2', () => {
+  it('counts a card as offscreen only when its LEFT edge is at/past the visible right boundary (완전히 밖)', () => {
+    const cardWidth = 110;
+    const scrollLeft = 0;
+    const viewportWidth = 400; // visibleRight = 400
+    // left=290: right=400 — 정확히 경계에 닿아 있다(오른쪽 끝이 딱 안 잘림) → 안 셈
+    // left=291: right=401 — 1px 걸침 → "완전히 밖"이 아니므로 안 셈(걸친 카드는 안 센다)
+    // left=400: right=510 — 완전히 밖 → 셈
+    const lefts = [290, 291, 400];
+    expect(countCardsBeyondRightEdge(lefts, cardWidth, scrollLeft, viewportWidth)).toBe(1);
+  });
+
+  it('a card straddling the right edge(왼쪽 일부만 보임) is NOT counted — only fully-hidden cards are (PO 물음에 대한 답)', () => {
+    const cardWidth = 110;
+    // 카드 left=350, viewportWidth=400 → 오른쪽 40px만 밖으로 잘림(왼쪽 70px은 보인다) → "걸침"
+    expect(countCardsBeyondRightEdge([350], cardWidth, 0, 400)).toBe(0);
+  });
+
+  it('respects scrollLeft — as the user scrolls right, fewer cards remain "beyond" the edge', () => {
+    const cardWidth = 110;
+    const viewportWidth = 400;
+    const lefts = [0, 500, 1000, 1500];
+    expect(countCardsBeyondRightEdge(lefts, cardWidth, 0, viewportWidth)).toBe(3); // 500,1000,1500 밖(visibleRight=400)
+    expect(countCardsBeyondRightEdge(lefts, cardWidth, 700, viewportWidth)).toBe(1); // visibleRight=1100 → 1500만 밖
+  });
+
+  it('returns 0 for an empty card list (org 0행과 동형 — 셀 것이 없다)', () => {
+    expect(countCardsBeyondRightEdge([], 110, 0, 400)).toBe(0);
   });
 });
 

--- a/apps/web/src/components/flow/derive-flow-map.ts
+++ b/apps/web/src/components/flow/derive-flow-map.ts
@@ -666,6 +666,19 @@ export function snapToNearestLaneCount(laneHeights: number[], candidateLanesOnly
   return bestCount;
 }
 
+/** story #2369 AC2(2026-07-31) — 가로로 «완전히» 화면 밖(오른쪽)인 카드 수를 실측으로
+ * 센다. 상수를 박지 않는다 — 지금 값(1440×900에서 12장)은 «이 데이터·이 뷰포트»의 수일
+ * 뿐이고 다음 렌더에서 달라진다. ⛔"걸친" 카드(오른쪽 경계에 한 픽셀이라도 걸린 카드)는
+ * 안 센다 — PO 물음(2026-07-31)에 대한 답: 걸친 카드는 스스로 자기 존재를 사용자에게 이미
+ * 알리고 있어(한 조각이라도 보인다) "화면이 아무 말도 안 한다"는 이 스토리의 병에 안
+ * 해당한다. 완전히 밖인 것만 "말 못 하는" 카드다. */
+export function countCardsBeyondRightEdge(
+  cardLefts: number[], cardWidth: number, scrollLeft: number, viewportWidth: number,
+): number {
+  const visibleRight = scrollLeft + viewportWidth;
+  return cardLefts.filter((left) => left >= visibleRight).length;
+}
+
 /** ⑥ 조건부 문구(PO 판정 2026-07-30) 트리거 — depth 0 열은 있는데 depth 1 이상이 «전혀»
  * 없을 때만 참. 하드코딩된 상수가 아니라 실제 맵 상태에서 계산하므로, 간선이 착지해
  * depth≥1 노드가 생기는 날 이 함수가 스스로 false를 내 문구가 사라진다(거짓말 될 위험 없음). */

--- a/apps/web/src/components/flow/flow-map-canvas.test.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.test.tsx
@@ -494,6 +494,16 @@ describe('FlowMapCanvas — story #2369 가로 잘림 발견성(세로 접힘 �
     expect(container.querySelector('[data-testid="flow-canvas-offscreen-hint"]')).toBeNull();
   });
 
+  it('the explanation span uses text-foreground (not the inherited text-muted-foreground, which fails AA 4.5:1 on bg-muted/90 in light mode — measured 4.43:1) (유나 라이브 실측 2026-07-31)', async () => {
+    mockClientWidth = 700;
+    mockScrollWidth = 1000;
+    const lane = makeQueueLane([0, 1, 2, 3, 4]);
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    const hint = container.querySelector('[data-testid="flow-canvas-offscreen-hint"]');
+    const reasonSpan = Array.from(hint?.querySelectorAll('span') ?? []).find((s) => s.textContent === '— 오른쪽으로 스크롤하면 보입니다.');
+    expect(reasonSpan?.getAttribute('class')).toContain('text-foreground');
+  });
+
   it('recomputes the count as the user scrolls(실측 — 스크롤할수록 밖인 카드가 준다)', async () => {
     mockClientWidth = 700;
     mockScrollWidth = 1000;

--- a/apps/web/src/components/flow/flow-map-canvas.test.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.test.tsx
@@ -439,3 +439,89 @@ describe('FlowMapCanvas — grouped edges (여러 선이 한 점에 모이면 �
     expect(container.querySelector('text')).toBeNull();
   });
 });
+
+// story #2369(2026-07-31) — "가로로는 못 움직인다"고 잘못 답했던 자리(overflow-x-auto는
+// 이미 있었는데 overlay 스크롤바라 안 보였을 뿐). 세로 접힘 줄과 같은 꼴로 대칭을 맞춘다.
+// jsdom은 clientWidth/scrollWidth를 항상 0으로 내므로(레이아웃 엔진 없음),
+// HTMLElement.prototype에 값을 주입해 재현한다.
+describe('FlowMapCanvas — story #2369 가로 잘림 발견성(세로 접힘 줄과 같은 꼴)', () => {
+  let originalClientWidth: PropertyDescriptor | undefined;
+  let originalScrollWidth: PropertyDescriptor | undefined;
+  let mockClientWidth = 0;
+  let mockScrollWidth = 0;
+
+  beforeEach(() => {
+    originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+    originalScrollWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollWidth');
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, get() { return mockClientWidth; } });
+    Object.defineProperty(HTMLElement.prototype, 'scrollWidth', { configurable: true, get() { return mockScrollWidth; } });
+  });
+
+  afterEach(() => {
+    if (originalClientWidth) Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth);
+    if (originalScrollWidth) Object.defineProperty(HTMLElement.prototype, 'scrollWidth', originalScrollWidth);
+  });
+
+  function scrollEl(): HTMLElement {
+    const el = container.querySelector('.focus-inset.overflow-x-auto');
+    expect(el).not.toBeNull();
+    return el as HTMLElement;
+  }
+
+  // FLOW_MAP_DEPTH0_X(402) + depth*FLOW_MAP_GRID_STEP(110) — 열마다 카드 하나씩, depth
+  // 0~4(5장)를 만들어 실제 computeNodePositions 좌표로 offscreen 판정을 태운다.
+  function makeQueueLane(depths: number[]): FlowMapLane {
+    const queueNodesByDepth = new Map<number, FlowMapNode[]>();
+    depths.forEach((d, i) => queueNodesByDepth.set(d, [makeNode({ id: `q${i}`, kind: 'queue', depth: d })]));
+    return makeLane({ queueNodesByDepth });
+  }
+
+  it('shows the real offscreen card count(양성대조 — 상수 아님, 실측) and hides it when everything fits', async () => {
+    mockScrollWidth = 1000;
+    // depth 0~4 → left = 402, 512, 622, 732, 842. clientWidth=700 → visibleRight=700.
+    // 완전히 밖(left>=700): 732, 842 → 2장.
+    mockClientWidth = 700;
+    const lane = makeQueueLane([0, 1, 2, 3, 4]);
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    const hint = container.querySelector('[data-testid="flow-canvas-offscreen-hint"]');
+    expect(hint).not.toBeNull();
+    expect(hint?.textContent).toContain('카드 2장이 화면 밖');
+
+    // 넓혀서 전부 보이게(clientWidth=1000, scrollLeft 0) — 힌트가 사라져야 한다(대칭:
+    // 세로 접힘 줄도 foldedCount===0이면 안 뜬다).
+    mockClientWidth = 1000;
+    await act(async () => { scrollEl().dispatchEvent(new Event('resize')); window.dispatchEvent(new Event('resize')); });
+    expect(container.querySelector('[data-testid="flow-canvas-offscreen-hint"]')).toBeNull();
+  });
+
+  it('recomputes the count as the user scrolls(실측 — 스크롤할수록 밖인 카드가 준다)', async () => {
+    mockClientWidth = 700;
+    mockScrollWidth = 1000;
+    const lane = makeQueueLane([0, 1, 2, 3, 4]); // lefts: 402,512,622,732,842
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    expect(container.querySelector('[data-testid="flow-canvas-offscreen-hint"]')?.textContent).toContain('카드 2장이 화면 밖');
+
+    const el = scrollEl();
+    Object.defineProperty(el, 'scrollLeft', { configurable: true, value: 300, writable: true });
+    await act(async () => { el.dispatchEvent(new Event('scroll')); });
+    // visibleRight = 300+700 = 1000 → 전부(402~842+110=952 이하) 안에 들어온다 → 0장.
+    expect(container.querySelector('[data-testid="flow-canvas-offscreen-hint"]')).toBeNull();
+  });
+
+  it('auto-scrolls on mount so the "지금" cluster is visible when the container is narrow(#2351과 공유하는 안전망)', async () => {
+    mockClientWidth = 356;
+    mockScrollWidth = 1660;
+    const lane = makeLane({ nowNodes: [makeNode({ id: 'n1', kind: 'now' })] });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    // NOW_CLUSTER_X(FLOW_MAP_NOW_LINE_X-40=252) + NODE_CARD_WIDTH(110)=362 > 356 → 스크롤.
+    expect(scrollEl().scrollLeft).toBe(Math.max(0, 252 - 356 / 2));
+  });
+
+  it('does NOT touch scrollLeft on a wide desktop container(AC8 회귀 없음)', async () => {
+    mockClientWidth = 1440;
+    mockScrollWidth = 1660;
+    const lane = makeLane({ nowNodes: [makeNode({ id: 'n1', kind: 'now' })] });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    expect(scrollEl().scrollLeft).toBe(0);
+  });
+});

--- a/apps/web/src/components/flow/flow-map-canvas.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.tsx
@@ -6,7 +6,8 @@ import type { FlowMapLane, FlowMapNode, FlowMapEdgeKind, FlowMapEdgeGroup } from
 import {
   FLOW_MAP_GRID_STEP, FLOW_MAP_NOW_LINE_X, FLOW_MAP_DEPTH0_X, computeLaneHeight, shouldShowNoDeeperReason,
   computeNodePositions, computeSupersededNodeIds, computeEdgeLineEndpoints, groupEdgesByEndpoints,
-  edgeGroupStrokeWidth, countRenderedEdgeLines, hasConfirmedRenderedEdgeLine, PAST_BUNDLE_NODE_ID, PAST_BUNDLE_LEFT, PAST_BUNDLE_TOP,
+  edgeGroupStrokeWidth, countRenderedEdgeLines, hasConfirmedRenderedEdgeLine, countCardsBeyondRightEdge,
+  PAST_BUNDLE_NODE_ID, PAST_BUNDLE_LEFT, PAST_BUNDLE_TOP,
   PAST_BUNDLE_CARD_WIDTH, PAST_BUNDLE_CARD_HEIGHT, PAST_EXPANDED_LEFT, PAST_EXPANDED_TOP_START,
   PAST_EXPANDED_ROW_HEIGHT, PAST_EXPANDED_BOX_WIDTH,
 } from './derive-flow-map';
@@ -266,6 +267,42 @@ export function FlowMapCanvas({
   // 좌표를 "그 레인 안의 논리 좌표"로 바꾸는 기준점(computeNodePositions와 같은 좌표계).
   const laneContainerRef = useRef<HTMLDivElement | null>(null);
 
+  // story #2369(2026-07-31, PO 실측·유나 라이브 뒤집음) — "가로로는 못 움직인다"고 잘못
+  // 답했던 자리. 실은 overflow-x-auto가 이미 동작했는데(스크롤바가 overlay라 자리를 안
+  // 차지해 "안 보였을" 뿐) 아무 시각 신호가 없어 아무도 몰랐다 — 세로 접힘 줄(「움직임 없는
+  // 목표 N개 — 숨긴 것이 아니라 접은 것입니다」)과 «같은 꼴»로 대칭을 맞춘다.
+  // N은 "완전히" 화면 밖인 카드 수만 센다(countCardsBeyondRightEdge) — 상수 아님, 매 스크롤·
+  // 리사이즈마다 실측. 카드 위치는 lane마다 이미 순수함수로 계산해 두는 computeNodePositions를
+  // 재사용한다(간선 그리기와 같은 좌표계, 두 벌 안 만든다).
+  const allCardLefts = useMemo(
+    () => lanes.flatMap((lane) => Array.from(computeNodePositions(lane, NODE_ROW_HEIGHT, NOW_CLUSTER_X).values()).map((p) => p.left)),
+    [lanes],
+  );
+  const [offscreenCardCount, setOffscreenCardCount] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return undefined;
+    const check = () => setOffscreenCardCount(countCardsBeyondRightEdge(allCardLefts, NODE_CARD_WIDTH, el.scrollLeft, el.clientWidth));
+    check();
+    el.addEventListener('scroll', check, { passive: true });
+    window.addEventListener('resize', check);
+    return () => {
+      el.removeEventListener('scroll', check);
+      window.removeEventListener('resize', check);
+    };
+  }, [allCardLefts]);
+  // AC3 — "지금" 열이 기본 상태에서 보이게. 가로축이 시간축이므로 "지금"을 놓치면 좌우가
+  // 뜻을 잃는다. 컨테이너가 좁아 NOW_CLUSTER_X+카드폭이 clientWidth를 넘을 때만 스크롤을
+  // 옮긴다 — 이미 보이는 넓은 화면(대부분의 데스크톱)에서는 조건이 거짓이라 손 안 댐
+  // (AC8: 데스크톱 회귀 없음, 레인이 "처음" 채워질 때 1회만).
+  const hasLanes = lanes.length > 0;
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || !hasLanes || el.clientWidth === 0) return;
+    if (NOW_CLUSTER_X + NODE_CARD_WIDTH <= el.clientWidth) return;
+    el.scrollLeft = Math.max(0, NOW_CLUSTER_X - el.clientWidth / 2);
+  }, [hasLanes]);
+
   const allEdges = useMemo(() => lanes.flatMap((l) => l.edges), [lanes]);
   const nodesById = useMemo(() => {
     const map = new Map<string, FlowMapNode>();
@@ -458,7 +495,7 @@ export function FlowMapCanvas({
   const isLinkingActive = linkDraft.phase !== 'idle';
 
   return (
-    <div className="overflow-hidden rounded-md border border-border bg-card">
+    <div className="relative overflow-hidden rounded-md border border-border bg-card">
       <div className="flex" style={{ height: HEADER_HEIGHT }}>
         <div className="w-[150px] shrink-0 border-b border-r border-border" />
         <div className="relative min-w-0 flex-1 overflow-hidden border-b border-border">
@@ -806,6 +843,22 @@ export function FlowMapCanvas({
           })}
         </div>
       </div>
+
+      {/* story #2369(2026-07-31) — 가로 잘림 발견성. 세로 접힘 줄과 «같은 꼴»(아이콘+굵은
+          수+설명)이되, 오른쪽 가장자리에 떠 있는 배지로 둔다(전체 폭 줄이면 스크롤 레이아웃
+          자체를 침범한다 — 세로 판은 캔버스 «아래»에 붙지만 가로 판은 캔버스 «가장자리
+          위»에 떠야 한다). pointer-events-none — 정보 전달용이지 클릭 대상이 아니다(세로
+          접힘 줄도 클릭 불가한 정적 안내문과 같은 성질). */}
+      {offscreenCardCount > 0 ? (
+        <div
+          data-testid="flow-canvas-offscreen-hint"
+          className="pointer-events-none absolute bottom-1 right-1 z-10 flex items-center gap-1.5 rounded border border-border bg-muted/90 px-2 py-1 text-[11px] text-muted-foreground shadow-sm"
+        >
+          <span aria-hidden="true">▸</span>
+          <b className="text-foreground">{t('flowCanvasOffscreenCount', { n: offscreenCardCount })}</b>
+          <span>{t('flowCanvasOffscreenReason')}</span>
+        </div>
+      ) : null}
 
       {/* 하단 범례 — 유나신 정정(2026-07-31, 라이브 실측 후속, 세 번째·최終 문구 확定): 옛
           4종×2축 범례는 실선(확定)이 «한 번도 안 나오는데» "실선=확定"이라 적어 없는 것을

--- a/apps/web/src/components/flow/flow-map-canvas.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.tsx
@@ -856,7 +856,10 @@ export function FlowMapCanvas({
         >
           <span aria-hidden="true">▸</span>
           <b className="text-foreground">{t('flowCanvasOffscreenCount', { n: offscreenCardCount })}</b>
-          <span>{t('flowCanvasOffscreenReason')}</span>
+          {/* 유나 라이브 실측(2026-07-31) — 컨테이너의 text-muted-foreground를 상속한 이
+              설명 줄이 bg-muted/90 위에서 라이트 4.43:1로 AA 미달(다크는 5.78 통과 — 또
+              라이트에서만). #2368의 같은 처방 — text-foreground로 올려 4.5:1을 넘긴다. */}
+          <span className="text-foreground">{t('flowCanvasOffscreenReason')}</span>
         </div>
       ) : null}
 


### PR DESCRIPTION
## Summary
- story #2369(선생님 물음 → PO 오답 → 유나 라이브가 뒤집음) — `overflow-x-auto`는 이미 있었고 scrollLeft가 실제로 밀렸다(0→518). overlay 스크롤바라 자리를 안 차지해 "안 보였을" 뿐. 지금 이미 1440×900에서 31%(카드 12장 완전히 밖·5장 걸침)가 잘려 있는데 화면이 아무 말도 안 했다.
- 세로 넘침은 "움직임 없는 목표 N개 — 숨긴 것이 아니라 접은 것입니다"로 알리는데 가로는 대칭이 깨져 있었다 — 이 PR이 그 대칭을 맞춘다.
- `countCardsBeyondRightEdge`(derive-flow-map.ts): "완전히" 화면 밖인 카드만 센다(상수 아님, 실 카드 좌표+scrollLeft+clientWidth로 매 스크롤·리사이즈 재계산). 걸친 카드는 안 센다 — 한 조각이라도 보이면 스스로 존재를 알리므로 "화면이 말 안 한다"는 병에 해당하지 않는다(PO 물음에 대한 답, 기준을 문구에도 반영).
- 우측 가장자리에 세로 접힘 줄과 같은 꼴(아이콘+굵은 수+설명)의 배지 — pointer-events-none.
- 초기 scrollLeft를 "지금" 클러스터가 보이는 자리로(#2351과 공유하는 메커니즘, 좁은 컨테이너에서만 작동 — 데스크톱 회귀 없음).
- 줌·미니맵·팬 추가 안 함 · 스크롤바 always-visible 추가 안 함(OS 관례 유지).

## 라이브 검증 필요 항목(AC5·AC7)
- [ ] 가로 휠·트랙패드가 실제로 먹는지 사람이 확認(유나 실측 — 합성 deltaX는 하니스 한계로 판정 보류)
- [ ] 1440×900, 1920 둘 다 라이브 픽셀로 힌트 문구 + N 값 확認
- [ ] 데스크톱 회귀 없음(지도 y≈152·헤드라인 y≈570·레인 스냅·pane 손잡이)

## Test plan
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm exec vitest run` — 334 files / 2432 tests 전부 PASS(신규 8건, 전부 mutation self-check 완료)
- [x] `pnpm run build` — 성공
- [x] verify:* 5개 — 전부 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)