### PR TITLE
[SID:2739 후속] fakechat 온보딩 안내 env 키 이름 SPRINTABLE_API_KEY로

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1264,7 +1264,7 @@
     "agentMcpSecurityNote": "For security, existing keys can't be shown again. Generate a new one in the API Keys section above to see the real config here.",
     "agentFakechatTitle": "Fakechat Channel",
     "agentFakechatDescription": "This agent dials out to the server — nothing listens on a port. Set the value below in its launch shell.",
-    "agentFakechatEnvKeyInstruction": "① In the launch shell, export AGENT_API_KEY=<this agent's key>.",
+    "agentFakechatEnvKeyInstruction": "① In the launch shell, export SPRINTABLE_API_KEY=<this agent's key>.",
     "agentFakechatWebhookActiveNote": "② This agent's webhook is currently on — launch it with HAS_WEBHOOK=\"true\" and it'll use the webhook path instead (SSE won't open).",
     "agentFakechatWebhookOffNote": "② If HAS_WEBHOOK=\"true\" is set, SSE won't open (the webhook path is used instead).",
     "agentFakechatSuccessCheck": "③ Confirm it worked — stderr should show \"[fakechat] SSE stream open\". If that line never appears, it failed silently (no error is thrown).",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1264,7 +1264,7 @@
     "agentMcpSecurityNote": "보안상 기존 키는 재표시되지 않습니다. 위 API Keys 섹션에서 새 키를 발급하면 실제 키가 포함된 Config가 여기에 자동으로 나타납니다.",
     "agentFakechatTitle": "Fakechat 채널",
     "agentFakechatDescription": "이 에이전트가 서버로 나가서 듣는 방식입니다(포트로 접속하는 것이 아닙니다). 런치 셸에 아래 값을 넣어 주세요.",
-    "agentFakechatEnvKeyInstruction": "① 런치 셸에 export AGENT_API_KEY=<이 에이전트의 키>를 넣으세요.",
+    "agentFakechatEnvKeyInstruction": "① 런치 셸에 export SPRINTABLE_API_KEY=<이 에이전트의 키>를 넣으세요.",
     "agentFakechatWebhookActiveNote": "② 이 에이전트는 지금 웹훅이 켜져 있습니다 — launch 셸에 HAS_WEBHOOK=\"true\"를 주면 SSE 대신 웹훅 경로를 씁니다(SSE는 열리지 않습니다).",
     "agentFakechatWebhookOffNote": "② HAS_WEBHOOK=\"true\"가 켜져 있으면 SSE가 열리지 않습니다(웹훅 경로를 대신 씁니다).",
     "agentFakechatSuccessCheck": "③ 성공 확인 — stderr에 「[fakechat] SSE stream open」이 뜨면 연결된 것입니다. 이 줄이 안 보이면 실패한 것입니다(오류 없이 조용히 실패할 수 있습니다).",

--- a/apps/web/src/app/(authenticated)/organization/workforce/[id]/page.test.ts
+++ b/apps/web/src/app/(authenticated)/organization/workforce/[id]/page.test.ts
@@ -1,0 +1,16 @@
+// story #2739 후속(2026-07-31, PO 실측) — fakechat 온보딩 안내가 실제 코드가 읽는 env 키
+// 이름과 달랐다. packages/fakechat/server.ts:27가 SPRINTABLE_API_KEY를 먼저 보고
+// AGENT_API_KEY는 하위호환 폴백일 뿐인데, 화면 안내는 AGENT_API_KEY만 말하고 있었다.
+// i18n 값 자체를 직접 확認하는 값 회귀가드 — 컴포넌트 렌더 없이 문자열만 잰다.
+import { describe, expect, it } from 'vitest';
+import ko from '../../../../../../messages/ko.json';
+import en from '../../../../../../messages/en.json';
+
+describe('workforce agent detail — fakechat env key onboarding copy (story #2739 후속)', () => {
+  it('ko/en 안내 문구 둘 다 SPRINTABLE_API_KEY를 말하고, 옛 AGENT_API_KEY는 0건이다', () => {
+    expect(ko.settings.agentFakechatEnvKeyInstruction).toContain('SPRINTABLE_API_KEY');
+    expect(ko.settings.agentFakechatEnvKeyInstruction).not.toContain('AGENT_API_KEY');
+    expect(en.settings.agentFakechatEnvKeyInstruction).toContain('SPRINTABLE_API_KEY');
+    expect(en.settings.agentFakechatEnvKeyInstruction).not.toContain('AGENT_API_KEY');
+  });
+});

--- a/apps/web/src/app/(authenticated)/organization/workforce/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/[id]/page.tsx
@@ -291,7 +291,7 @@ export default function AgentDetailPage() {
   const handleCopyFakechatEnvKey = async () => {
     if (!freshApiKey) return;
     try {
-      await navigator.clipboard.writeText(`export AGENT_API_KEY=${freshApiKey}`);
+      await navigator.clipboard.writeText(`export SPRINTABLE_API_KEY=${freshApiKey}`);
       setFakechatEnvKeyCopied(true);
       setTimeout(() => setFakechatEnvKeyCopied(false), 2000);
     } catch {
@@ -646,7 +646,7 @@ export default function AgentDetailPage() {
             <>
               <p className="text-xs text-success">{t('agentFakechatEnvKeyFreshNote')}</p>
               <code className="block overflow-x-auto rounded-md border border-border bg-muted/30 p-3 text-xs text-foreground/80">
-                export AGENT_API_KEY={freshApiKey}
+                export SPRINTABLE_API_KEY={freshApiKey}
               </code>
             </>
           ) : !hasActiveKey ? (


### PR DESCRIPTION
## Summary
- `packages/fakechat/server.ts:27`가 `SPRINTABLE_API_KEY`를 먼저 읽고 `AGENT_API_KEY`는 기존 `.mcp.json` 하위호환 폴백일 뿐인데, 워크포스 상세 화면의 온보딩 안내(클립보드 복사 텍스트 + 코드 스니펫 + i18n 문구)는 옛 `AGENT_API_KEY`만 말하고 있었다.
- 둘 다 설정돼 있으면 `SPRINTABLE_API_KEY`가 이기므로, 안내대로 고쳐도 기존 동작에 영향 없음.
- `page.tsx` 2곳 + `messages/ko.json`·`en.json` `agentFakechatEnvKeyInstruction` 수정.
- 신규 회귀가드: 두 로케일 모두 `SPRINTABLE_API_KEY`를 말하고 옛 `AGENT_API_KEY`가 0건인지 직접 재는 i18n 값 테스트(mutation self-check 완료).

## Test plan
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm exec vitest run` — 336 files / 2453 tests 전부 PASS
- [x] `pnpm run build` — 성공
- [x] verify:* 5개 — 전부 OK
- [x] 검산: 화면에서 `AGENT_API_KEY` 0건 확認(grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)