### PR TITLE
fix(web): remove dead i18n key steerHandoffAgent (#2370)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2594,7 +2594,6 @@
     "steerReorderAria": "Reorder {title}",
     "steerHandoffReceived": "Priorities received",
     "steerHandoffOrchestrating": "Applying",
-    "steerHandoffAgent": "Ortega",
     "steerError": "Couldn't save the new order. Please try again.",
     "steerCappedNote": "Showing the top {count}. Setting priorities floats items to the front.",
     "steerCommit": "Send priorities",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2594,7 +2594,6 @@
     "steerReorderAria": "{title} 순서 변경",
     "steerHandoffReceived": "우선순위 접수",
     "steerHandoffOrchestrating": "반영 중",
-    "steerHandoffAgent": "오르테가군",
     "steerError": "재정렬을 저장하지 못했습니다. 다시 시도해 주세요.",
     "steerCappedNote": "상위 {count}개만 표시됩니다. 우선순위를 정하면 상위 항목이 앞으로 올라옵니다.",
     "steerCommit": "우선순위 보내기",


### PR DESCRIPTION
## Summary
- Removes `steerHandoffAgent` from `apps/web/messages/en.json` and `ko.json` (2 lines) — an unused i18n key left over from an early draft that embedded the agent's name in copy
- Verified zero consumers: static grep + dynamic key-composition check against `origin/develop`, both clean
- Sibling keys `steerHandoffReceived` / `steerHandoffOrchestrating` untouched — still consumed at `goals-client.tsx:1035`
- Diff is exactly 2 lines across 2 files, nothing else touched (AC6 — no scope creep into the ~383 files carrying old agent names in judgment-history comments/docstrings)

## Test plan
- [x] `python3 -m json.tool` validity check on both edited files
- [x] `git grep steerHandoffAgent` across repo → no remaining references
- [x] `node scripts/check-i18n-keys.js` output diffed byte-for-byte against unmodified `origin/develop` baseline — identical (355 pre-existing unrelated findings, none new)
- [x] AC4 — en/ko key-set symmetric difference computed via recursive flatten: `0`
- [x] AC3 (regression) — traced the render path at `goals-client.tsx:1029-1040`: the `justDispatched` banner renders only `steerHandoffReceived`, `steerHandoffOrchestrating`, and `dispatchedTo` (dynamic recipient list) — `steerHandoffAgent` is not referenced anywhere in that JSX, so removal cannot affect the banner. **No live screenshot taken** — reproducing `justDispatched`/`dispatchedTo` state requires seeded curated-goals + steer-dispatch data behind auth; flagging that a static trace substitutes for it here rather than claiming a screenshot that doesn't exist. Happy to stand up the full stack if AC3 requires a literal screenshot before merge.
- [x] Confirmed only `en.json`/`ko.json` exist under `apps/web/messages/` (no other locales to update)

Closes #2370

🤖 Generated with [Claude Code](https://claude.com/claude-code)