### PR TITLE
[SID:2369] 라이브 QA 후속 — 오프스크린 힌트 세로 클리핑 + 카운트 오판정 fix

### DIFF
--- a/apps/web/src/components/flow/derive-flow-map.ts
+++ b/apps/web/src/components/flow/derive-flow-map.ts
@@ -336,6 +336,18 @@ export interface FlowMapLogicalPosition {
 // 과거 묶음 카드의 고정 위치(px) — flow-map-canvas.tsx의 기존 하드코딩(left:20, top:4)과
 // 정확히 같은 값을 여기 단일 소스로 옮긴다(카드 렌더링과 간선 계산이 서로 다른 좌표를
 // 쓰면 언젠가 어긋난다 — computeNodePositions의 존재 이유 그대로).
+// story #2369 QA 후속(2026-07-31, 라이브 실측 자가발견 — dev-app 1440×900) — 레인 라벨 칸
+// 너비. flow-map-canvas.tsx의 `w-[150px]`(헤더·레인 타이틀 칸) 두 곳과 반드시 같은 값이어야
+// 한다. computeNodePositions가 내는 `left`는 각 레인의 콘텐츠 영역(`flex-1`, 라벨 칸
+// «다음»부터) 기준 좌표인데, 카드가 실제로 그려지는 화면은 스크롤 컨테이너 원점(라벨 칸
+// «포함» 시작)이다 — 오프스크린 판정(countCardsBeyondRightEdge)이 이 상수를 안 더하면
+// 라벨 칸 폭만큼 "화면 밖"을 "아직 안 밖"으로 잘못 판정한다(실측: style.left=1062px인 카드가
+// 실제 화면에서는 1212px에 그려져 있었다 — QA가 원인 지목 없이 넘긴 ②③ 두 가지 다 이 한
+// 자리였다: scrollLeft=0에서 "6장"이라 말해야 할 자리가 "5장"이었던 것도, scrollLeft=260에서
+// 셋이 여전히 밖인데 힌트가 통째로 꺼진 것도, 라벨 칸만큼 못 미쳐 "아직 안 밖"으로 오판한
+// 같은 병이었다).
+export const LANE_LABEL_WIDTH = 150;
+
 export const PAST_BUNDLE_LEFT = 20;
 export const PAST_BUNDLE_TOP = 4;
 // 유나양 규격(아티팩트 a125909a) 3줄(완료 N·묶음 / 안에서 이어진 것 M / 여기서 나온 다음 K건)

--- a/apps/web/src/components/flow/derive-flow-map.ts
+++ b/apps/web/src/components/flow/derive-flow-map.ts
@@ -337,8 +337,10 @@ export interface FlowMapLogicalPosition {
 // 정확히 같은 값을 여기 단일 소스로 옮긴다(카드 렌더링과 간선 계산이 서로 다른 좌표를
 // 쓰면 언젠가 어긋난다 — computeNodePositions의 존재 이유 그대로).
 // story #2369 QA 후속(2026-07-31, 라이브 실측 자가발견 — dev-app 1440×900) — 레인 라벨 칸
-// 너비. flow-map-canvas.tsx의 `w-[150px]`(헤더·레인 타이틀 칸) 두 곳과 반드시 같은 값이어야
-// 한다. computeNodePositions가 내는 `left`는 각 레인의 콘텐츠 영역(`flex-1`, 라벨 칸
+// 너비. flow-map-canvas.tsx의 헤더 스페이서·레인 타이틀 칸 두 자리(`style={{ width:
+// LANE_LABEL_WIDTH }}`)가 이 상수 하나에서 나온다(올리베이라군 리뷰 반영, PR#2757 — 예전엔
+// `w-[150px]` Tailwind 클래스로 사본이 있었으나 사본 자체를 없앴다). computeNodePositions가
+// 내는 `left`는 각 레인의 콘텐츠 영역(`flex-1`, 라벨 칸
 // «다음»부터) 기준 좌표인데, 카드가 실제로 그려지는 화면은 스크롤 컨테이너 원점(라벨 칸
 // «포함» 시작)이다 — 오프스크린 판정(countCardsBeyondRightEdge)이 이 상수를 안 더하면
 // 라벨 칸 폭만큼 "화면 밖"을 "아직 안 밖"으로 잘못 판정한다(실측: style.left=1062px인 카드가

--- a/apps/web/src/components/flow/flow-canvas-resize-pane.tsx
+++ b/apps/web/src/components/flow/flow-canvas-resize-pane.tsx
@@ -146,8 +146,20 @@ export function FlowCanvasResizePane({ lanes, nodeRowHeight, laneMinHeight, head
 
   return (
     <div>
-      <div data-testid="flow-canvas-resize-pane" className="relative overflow-y-auto focus-inset" style={{ height: displayHeightPx }}>
-        {children}
+      {/* 유나 design:changes 재현(2026-07-31, PR#2757) — «반만» 고친 자리. `position:absolute`는
+          기준점(containing block)을 `position:relative` 조상으로 잡을 뿐, 그 조상 «자신»이
+          스크롤하면 콘텐츠와 함께 그대로 움직인다(overlay가 이 div의 자식이면서 이 div가
+          스크롤하니, overlay도 스크롤을 탄다 — 실측: scrollTop=350에서 overlay가 화면
+          밖으로 350px 밀려 사라짐). 클리핑(`overflow-y-auto`)과 기준점(`relative`+고정
+          height)을 같은 요소에 두면 이 병을 못 피한다 — 스크롤하는 요소(안쪽, `{children}`만)와
+          기준점 역할을 하는 요소(바깥쪽, 스크롤 안 함)를 갈라야 overlay가 안쪽의 스크롤과
+          무관해진다. `data-testid="flow-canvas-resize-pane"`와 `style={{ height }}`는 기존
+          테스트(paneHeightPx 등)가 참조하는 요소라 바깥쪽에 그대로 둔다 — 실제로 스크롤하는
+          것은 그 안의 새 `overflow-y-auto` div뿐이다. */}
+      <div data-testid="flow-canvas-resize-pane" className="relative" style={{ height: displayHeightPx }}>
+        <div className="h-full overflow-y-auto focus-inset">
+          {children}
+        </div>
         {overlay}
       </div>
       <div className="flex items-center justify-center gap-2 border-t border-border bg-muted/20 py-1">

--- a/apps/web/src/components/flow/flow-canvas-resize-pane.tsx
+++ b/apps/web/src/components/flow/flow-canvas-resize-pane.tsx
@@ -13,6 +13,12 @@ interface FlowCanvasResizePaneProps {
   laneMinHeight: number;
   headerHeight: number;
   children: ReactNode;
+  /** story #2369 QA 후속(2026-07-31) — 이 컴포넌트가 «세로로 실제 클리핑하는» 유일한 조상
+   * (`overflow-y-auto` + 고정 `displayHeightPx`)이다. 오프스크린(가로 잘림) 힌트처럼 "세로
+   * 스크롤 위치와 무관하게 항상 보여야 하는" 오버레이는 `children`(FlowMapCanvas, 클리핑
+   * 대상 그 자체 — 세로로는 클리핑 «되는» 쪽이라 자기 기준으로 붙이면 클리핑된 자리에
+   * 갇힌다) 안이 아니라 여기, 이 클리핑 컨테이너 자신의 «보이는 창» 기준으로 그려야 한다. */
+  overlay?: ReactNode;
 }
 
 // reference-candidates.ts의 readRejectedSet/writeRejectedSet과 같은 관례 — localStorage
@@ -55,7 +61,7 @@ function writeStoredLaneCount(value: string | null): void {
  * 보고 싶은가"라는 사용자의 «의도»이므로 매 렌더에서 현재 lanes로 다시 계산해도
  * 의미가 안 바뀐다.
  */
-export function FlowCanvasResizePane({ lanes, nodeRowHeight, laneMinHeight, headerHeight, children }: FlowCanvasResizePaneProps) {
+export function FlowCanvasResizePane({ lanes, nodeRowHeight, laneMinHeight, headerHeight, children, overlay }: FlowCanvasResizePaneProps) {
   const t = useTranslations('flow');
   const [laneCount, setLaneCount] = useState(() => readStoredLaneCount() ?? DEFAULT_LANE_COUNT);
   const [dragHeightPx, setDragHeightPx] = useState<number | null>(null);
@@ -140,8 +146,9 @@ export function FlowCanvasResizePane({ lanes, nodeRowHeight, laneMinHeight, head
 
   return (
     <div>
-      <div data-testid="flow-canvas-resize-pane" className="overflow-y-auto focus-inset" style={{ height: displayHeightPx }}>
+      <div data-testid="flow-canvas-resize-pane" className="relative overflow-y-auto focus-inset" style={{ height: displayHeightPx }}>
         {children}
+        {overlay}
       </div>
       <div className="flex items-center justify-center gap-2 border-t border-border bg-muted/20 py-1">
         <div

--- a/apps/web/src/components/flow/flow-map-canvas.test.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.test.tsx
@@ -13,6 +13,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
 import { FlowMapCanvas } from './flow-map-canvas';
+import { LANE_LABEL_WIDTH } from './derive-flow-map';
 import type { FlowMapLane, FlowMapNode, FlowMapEdge, FlowMapEdgeKind } from './derive-flow-map';
 import koMessages from '../../../messages/ko.json';
 
@@ -478,20 +479,39 @@ describe('FlowMapCanvas — story #2369 가로 잘림 발견성(세로 접힘 �
 
   it('shows the real offscreen card count(양성대조 — 상수 아님, 실측) and hides it when everything fits', async () => {
     mockScrollWidth = 1000;
-    // depth 0~4 → left = 402, 512, 622, 732, 842. clientWidth=700 → visibleRight=700.
-    // 완전히 밖(left>=700): 732, 842 → 2장.
+    // depth 0~4 → left = 402, 512, 622, 732, 842 — 그런데 이건 레인 콘텐츠(flex-1) 기준
+    // 좌표라, 실제 화면(스크롤 원점 기준)에서는 LANE_LABEL_WIDTH(150)만큼 더 오른쪽:
+    // 552, 662, 772, 882, 992(story #2369 QA 후속 — 라이브 실측으로 밝혀진 자리, 위
+    // allCardLefts 문서 참고). clientWidth=700 → visibleRight=700.
+    // 완전히 밖(adjustedLeft>=700): 772, 882, 992 → 3장.
     mockClientWidth = 700;
     const lane = makeQueueLane([0, 1, 2, 3, 4]);
     await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
     const hint = container.querySelector('[data-testid="flow-canvas-offscreen-hint"]');
     expect(hint).not.toBeNull();
-    expect(hint?.textContent).toContain('카드 2장이 화면 밖');
+    expect(hint?.textContent).toContain('카드 3장이 화면 밖');
 
-    // 넓혀서 전부 보이게(clientWidth=1000, scrollLeft 0) — 힌트가 사라져야 한다(대칭:
-    // 세로 접힘 줄도 foldedCount===0이면 안 뜬다).
+    // 넓혀서 전부 보이게(clientWidth=1000, scrollLeft 0) — 가장 큰 adjustedLeft(992)도
+    // 1000 밑이라 전부 들어온다 — 힌트가 사라져야 한다(대칭: 세로 접힘 줄도 foldedCount===0
+    // 이면 안 뜬다).
     mockClientWidth = 1000;
     await act(async () => { scrollEl().dispatchEvent(new Event('resize')); window.dispatchEvent(new Event('resize')); });
     expect(container.querySelector('[data-testid="flow-canvas-offscreen-hint"]')).toBeNull();
+  });
+
+  // story #2369 QA 후속(2026-07-31, 라이브 실측 자가발견) — LANE_LABEL_WIDTH를 안 더하면
+  // 라벨 칸(150px) 폭만큼 "화면 밖"인 카드를 "아직 안 밖"으로 잘못 판정한다. 이 테스트는
+  // 그 경계에 정확히 걸치는 카드 하나로 회귀를 잡는다 — 라벨 칸을 «빼고» 재면(옛 버그) 이
+  // 카드는 "안 밖"으로 잘못 판정된다.
+  it('accounts for the lane label column width so a card sitting exactly at that boundary counts as offscreen(라벨 칸 폭 보정 회귀)', async () => {
+    mockScrollWidth = 1000;
+    // depth 0 하나만 → left(레인 콘텐츠 기준) = 402. 실제 화면 기준 = 402+150 = 552.
+    // clientWidth를 552로 두면(옛 버그: visibleRight=552, 402<552 → "안 밖"으로 오판)
+    // 보정 후엔 552>=552 → "밖"으로 잡혀야 한다.
+    mockClientWidth = LANE_LABEL_WIDTH + 402;
+    const lane = makeQueueLane([0]);
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    expect(container.querySelector('[data-testid="flow-canvas-offscreen-hint"]')?.textContent).toContain('카드 1장이 화면 밖');
   });
 
   it('the explanation span uses text-foreground (not the inherited text-muted-foreground, which fails AA 4.5:1 on bg-muted/90 in light mode — measured 4.43:1) (유나 라이브 실측 2026-07-31)', async () => {
@@ -507,14 +527,25 @@ describe('FlowMapCanvas — story #2369 가로 잘림 발견성(세로 접힘 �
   it('recomputes the count as the user scrolls(실측 — 스크롤할수록 밖인 카드가 준다)', async () => {
     mockClientWidth = 700;
     mockScrollWidth = 1000;
-    const lane = makeQueueLane([0, 1, 2, 3, 4]); // lefts: 402,512,622,732,842
+    // lefts(레인 콘텐츠 기준): 402,512,622,732,842 → 실제 화면 기준(+LANE_LABEL_WIDTH):
+    // 552,662,772,882,992.
+    const lane = makeQueueLane([0, 1, 2, 3, 4]);
     await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
-    expect(container.querySelector('[data-testid="flow-canvas-offscreen-hint"]')?.textContent).toContain('카드 2장이 화면 밖');
+    // visibleRight=700 → 772,882,992 밖 → 3장.
+    expect(container.querySelector('[data-testid="flow-canvas-offscreen-hint"]')?.textContent).toContain('카드 3장이 화면 밖');
 
     const el = scrollEl();
+    // story #2369 QA 후속(③) — 중간 스크롤에서도 여전히 밖인 카드가 있는데 라벨 칸 폭을
+    // 안 더하면 전부 "안에 들어온" 것으로 잘못 꺼졌었다(실측: scrollLeft=260에서 3장이
+    // 여전히 밖인데 힌트가 통째로 0으로 꺼짐). 여기 scrollLeft=250 → visibleRight=950 →
+    // 992(마지막 카드)만 여전히 밖 → 1장(0으로 꺼지면 안 된다).
+    Object.defineProperty(el, 'scrollLeft', { configurable: true, value: 250, writable: true });
+    await act(async () => { el.dispatchEvent(new Event('scroll')); });
+    expect(container.querySelector('[data-testid="flow-canvas-offscreen-hint"]')?.textContent).toContain('카드 1장이 화면 밖');
+
+    // 끝까지 밀면(scrollLeft=300 → visibleRight=1000) 992도 안에 들어와 0장 → 힌트 사라짐.
     Object.defineProperty(el, 'scrollLeft', { configurable: true, value: 300, writable: true });
     await act(async () => { el.dispatchEvent(new Event('scroll')); });
-    // visibleRight = 300+700 = 1000 → 전부(402~842+110=952 이하) 안에 들어온다 → 0장.
     expect(container.querySelector('[data-testid="flow-canvas-offscreen-hint"]')).toBeNull();
   });
 

--- a/apps/web/src/components/flow/flow-map-canvas.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.tsx
@@ -520,8 +520,12 @@ export function FlowMapCanvas({
   return (
     <div className="relative overflow-hidden rounded-md border border-border bg-card">
       <div className="flex" style={{ height: HEADER_HEIGHT }}>
-        {/* LANE_LABEL_WIDTH와 같은 값(위 레인 타이틀 칸 주석 참고). */}
-        <div className="w-[150px] shrink-0 border-b border-r border-border" />
+        {/* 올리베이라군 리뷰(2026-07-31, PR#2757) — 이 칸 너비는 offscreen 카운트 보정에
+            쓰이는 LANE_LABEL_WIDTH와 같은 값이어야 하는데, Tailwind 클래스로 사본을 두면
+            "누가 이 칸만 고치고 그 상수는 안 고치는" 조용한 어긋남을 막을 자가 없다(오늘
+            고친 결함의 뿌리가 정확히 이 종류의 어긋남이었다) — 사본을 없애고 상수 하나에서
+            나오게 한다. */}
+        <div className="shrink-0 border-b border-r border-border" style={{ width: LANE_LABEL_WIDTH }} />
         <div className="relative min-w-0 flex-1 overflow-hidden border-b border-border">
           <span className="absolute top-[5px] text-[9.5px] uppercase tracking-[0.06em] text-muted-foreground" style={{ left: 10 }}>
             {t('canvasPast')}
@@ -548,10 +552,8 @@ export function FlowMapCanvas({
             const supersededIds = computeSupersededNodeIds(lane.edges);
             return (
               <div key={lane.epicId} className="relative flex border-b border-border last:border-b-0" style={{ height }}>
-                {/* ⛔story #2369 QA 후속 — 이 150px는 LANE_LABEL_WIDTH(derive-flow-map.ts)와
-                    반드시 같은 값이어야 한다(offscreen 카운트가 그 상수로 화면 좌표를
-                    보정한다) — 여길 바꾸면 그 상수도 같이 바꿔야 한다. */}
-                <div className="w-[150px] shrink-0 border-r border-border px-2 py-1.5">
+                {/* 위 헤더 칸과 같은 사정 — LANE_LABEL_WIDTH 하나에서 나온다(사본 없음). */}
+                <div className="shrink-0 border-r border-border px-2 py-1.5" style={{ width: LANE_LABEL_WIDTH }}>
                   <p className="truncate text-[11px] font-semibold text-foreground">{lane.title}</p>
                 </div>
                 <div ref={laneIndex === 0 ? laneContainerRef : undefined} className="relative min-w-0 flex-1">

--- a/apps/web/src/components/flow/flow-map-canvas.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.tsx
@@ -232,6 +232,33 @@ function FlowEdgeMarkerDefs() {
 }
 
 /**
+ * story #2369 QA 후속(2026-07-31, 유나 design:changes 재현 코멘트) — 오프스크린(가로 잘림)
+ * 배지 마크업의 단일 소스. 올리베이라군 자기 지적(③) — `LANE_LABEL_WIDTH` 사본 셋을 잡으면서
+ * «같은 diff 안에서» 이 배지 마크업(클래스 문자열·아이콘·i18n 키)을 두 자리(FlowMapCanvas
+ * 내부 · flow-multi-lane-canvas.tsx의 overlay)에 손으로 복제하는 새 사본을 만들었다 — 그
+ * 사본을 여기 하나로 없앤다. 콜백이 있는 호출부(멀티레인)는 이 컴포넌트를 클리핑 밖(overlay
+ * 슬롯)에서 쓰고, 콜백이 없는 호출부(단일-레인)는 FlowMapCanvas 안에서 그대로 쓴다 — 마크업
+ * 자체는 어느 쪽이든 같다.
+ */
+export function FlowCanvasOffscreenHint({ count }: { count: number }) {
+  const t = useTranslations('flow');
+  if (count <= 0) return null;
+  return (
+    <div
+      data-testid="flow-canvas-offscreen-hint"
+      className="pointer-events-none absolute bottom-1 right-1 z-10 flex items-center gap-1.5 rounded border border-border bg-muted/90 px-2 py-1 text-[11px] text-muted-foreground shadow-sm"
+    >
+      <span aria-hidden="true">▸</span>
+      <b className="text-foreground">{t('flowCanvasOffscreenCount', { n: count })}</b>
+      {/* 유나 라이브 실측(2026-07-31) — 컨테이너의 text-muted-foreground를 상속한 이 설명
+          줄이 bg-muted/90 위에서 라이트 4.43:1로 AA 미달(다크는 5.78 통과 — 또 라이트에서만).
+          #2368의 같은 처방 — text-foreground로 올려 4.5:1을 넘긴다. */}
+      <span className="text-foreground">{t('flowCanvasOffscreenReason')}</span>
+    </div>
+  );
+}
+
+/**
  * story #2224 L3 — 갈래 «지도»(유나 목업 `be8709a4` 판A/판B/판C, PO 판정 2026-07-30).
  * ⑤레인 높이가 «내용에서 계산»(고정 아님) · ①노드가 «의존 깊이 좌표»(x = depth × 110px,
  * computeNodeDepth가 실제 계산 — 오늘은 간선이 없어 전부 depth 0) · ②「지금」 세로선
@@ -873,29 +900,13 @@ export function FlowMapCanvas({
         </div>
       </div>
 
-      {/* story #2369(2026-07-31) — 가로 잘림 발견성. 세로 접힘 줄과 «같은 꼴»(아이콘+굵은
-          수+설명)이되, 오른쪽 가장자리에 떠 있는 배지로 둔다(전체 폭 줄이면 스크롤 레이아웃
-          자체를 침범한다 — 세로 판은 캔버스 «아래»에 붙지만 가로 판은 캔버스 «가장자리
-          위»에 떠야 한다). pointer-events-none — 정보 전달용이지 클릭 대상이 아니다(세로
-          접힘 줄도 클릭 불가한 정적 안내문과 같은 성질). */}
       {/* story #2369 QA 후속(2026-07-31) — onOffscreenCountChange가 있으면(멀티레인 호출부)
-          호출부가 세로-클리핑 조상의 «보이는 창» 안에서 이 힌트를 직접 그린다(위
-          onOffscreenCountChange 문서 참고) — 여기서 또 그리면 세로로 클리핑돼 아무도 못
-          보는 자리에 중복으로 뜬다. 콜백이 없는(단일-레인, flow-epic-nodes.tsx) 호출부만
-          기존 그대로 여기서 그린다 — 그쪽은 세로 클리핑 조상이 없어 이 자리가 이미 맞다. */}
-      {!onOffscreenCountChange && offscreenCardCount > 0 ? (
-        <div
-          data-testid="flow-canvas-offscreen-hint"
-          className="pointer-events-none absolute bottom-1 right-1 z-10 flex items-center gap-1.5 rounded border border-border bg-muted/90 px-2 py-1 text-[11px] text-muted-foreground shadow-sm"
-        >
-          <span aria-hidden="true">▸</span>
-          <b className="text-foreground">{t('flowCanvasOffscreenCount', { n: offscreenCardCount })}</b>
-          {/* 유나 라이브 실측(2026-07-31) — 컨테이너의 text-muted-foreground를 상속한 이
-              설명 줄이 bg-muted/90 위에서 라이트 4.43:1로 AA 미달(다크는 5.78 통과 — 또
-              라이트에서만). #2368의 같은 처방 — text-foreground로 올려 4.5:1을 넘긴다. */}
-          <span className="text-foreground">{t('flowCanvasOffscreenReason')}</span>
-        </div>
-      ) : null}
+          호출부가 세로-클리핑 조상의 «보이는 창» 밖(overlay 슬롯)에서 FlowCanvasOffscreenHint를
+          직접 그린다(위 onOffscreenCountChange 문서 참고) — 여기서 또 그리면 세로로 클리핑돼
+          아무도 못 보는 자리에 중복으로 뜬다. 콜백이 없는(단일-레인, flow-epic-nodes.tsx)
+          호출부만 기존 그대로 여기서 그린다 — 그쪽은 세로 클리핑 조상이 없어 이 자리가 이미
+          맞다. */}
+      {!onOffscreenCountChange ? <FlowCanvasOffscreenHint count={offscreenCardCount} /> : null}
 
       {/* 하단 범례 — 유나신 정정(2026-07-31, 라이브 실측 후속, 세 번째·최終 문구 확定): 옛
           4종×2축 범례는 실선(확定)이 «한 번도 안 나오는데» "실선=확定"이라 적어 없는 것을

--- a/apps/web/src/components/flow/flow-map-canvas.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.tsx
@@ -7,7 +7,7 @@ import {
   FLOW_MAP_GRID_STEP, FLOW_MAP_NOW_LINE_X, FLOW_MAP_DEPTH0_X, computeLaneHeight, shouldShowNoDeeperReason,
   computeNodePositions, computeSupersededNodeIds, computeEdgeLineEndpoints, groupEdgesByEndpoints,
   edgeGroupStrokeWidth, countRenderedEdgeLines, hasConfirmedRenderedEdgeLine, countCardsBeyondRightEdge,
-  PAST_BUNDLE_NODE_ID, PAST_BUNDLE_LEFT, PAST_BUNDLE_TOP,
+  LANE_LABEL_WIDTH, PAST_BUNDLE_NODE_ID, PAST_BUNDLE_LEFT, PAST_BUNDLE_TOP,
   PAST_BUNDLE_CARD_WIDTH, PAST_BUNDLE_CARD_HEIGHT, PAST_EXPANDED_LEFT, PAST_EXPANDED_TOP_START,
   PAST_EXPANDED_ROW_HEIGHT, PAST_EXPANDED_BOX_WIDTH,
 } from './derive-flow-map';
@@ -86,6 +86,18 @@ interface FlowMapCanvasProps {
    * 리뷰 v1.1 정정, ㉣ — declaredBy가 나 아니면 실명, 못 찾으면 중립으로 떨어진다. 새 fetch
    * 아님 — goal-stem-card.tsx가 이미 들고 있는 memberMap을 그대로 흘려보낸다). */
   memberMap: Record<string, { name: string }>;
+  /** story #2369 QA 후속(2026-07-31) — 라이브 실측(dev-app, 1440×900): 이 컴포넌트 안에서
+   * `absolute bottom-1`로 띄우던 오프스크린 힌트가 멀티레인 호출부(flow-multi-lane-canvas.tsx)
+   * 에서는 `FlowCanvasResizePane`(`overflow-y-auto`로 세로를 «클리핑»하는 조상)의 «보이는
+   * 창»이 아니라 이 컴포넌트 자신의 루트(세로 클리핑 없이 전체 콘텐츠 높이만큼 자연히 커지는
+   * 상자) 기준으로 붙어, 화면 위 1814px 아래(콘텐츠의 «진짜 맨 아래»)에 가 있었다 —
+   * 「말한다」의 뜻은 「보이는 자리에서 말한다」인데 아무도 못 보는 자리에 있었던 것.
+   * 이 콜백이 있으면(멀티레인 판) 힌트를 이 컴포넌트 «안에서» 안 그리고 대신 수를 위로
+   * 보고한다 — 호출부가 실제로 세로로 클리핑되는 그 조상의 «보이는 창» 안에 직접 그린다
+   * (세로 접힘 줄「움직임 없는 목표 N개」과 정확히 같은 사정 — 그 줄도 클리핑 밖에 있어
+   * 항상 보인다). 콜백이 없으면(단일-레인 호출부, flow-epic-nodes.tsx — 세로 클리핑 조상이
+   * 아예 없다) 기존 그대로 이 컴포넌트 안에서 그린다. */
+  onOffscreenCountChange?: (count: number) => void;
 }
 
 export type CreateLinkResult = { ok: true } | { ok: false; error: string };
@@ -242,6 +254,7 @@ function FlowEdgeMarkerDefs() {
  */
 export function FlowMapCanvas({
   lanes, onSelectStory, onTogglePastBundle, loadingPastBundleEpicIds, selectedNodeId = null, onCreateLink, onDeleteLink, memberMap,
+  onOffscreenCountChange,
 }: FlowMapCanvasProps) {
   const t = useTranslations('flow');
   const { currentTeamMemberId } = useDashboardContext();
@@ -274,8 +287,13 @@ export function FlowMapCanvas({
   // N은 "완전히" 화면 밖인 카드 수만 센다(countCardsBeyondRightEdge) — 상수 아님, 매 스크롤·
   // 리사이즈마다 실측. 카드 위치는 lane마다 이미 순수함수로 계산해 두는 computeNodePositions를
   // 재사용한다(간선 그리기와 같은 좌표계, 두 벌 안 만든다).
+  // ⛔story #2369 QA 후속(2026-07-31, 라이브 실측 자가발견) — computeNodePositions의 `left`는
+  // 레인 콘텐츠 영역(`flex-1`, 라벨 칸 «다음»부터) 기준이라 스크롤 원점(라벨 칸 «포함» 시작)
+  // 기준인 실제 화면 좌표보다 LANE_LABEL_WIDTH(150px)만큼 작다 — 이걸 안 더하면 라벨 칸
+  // 폭만큼 "화면 밖"인 카드를 "아직 안 밖"으로 잘못 판정한다(실측: style.left=1062px 카드가
+  // 실제 화면에서는 1212px에 그려져 있었다).
   const allCardLefts = useMemo(
-    () => lanes.flatMap((lane) => Array.from(computeNodePositions(lane, NODE_ROW_HEIGHT, NOW_CLUSTER_X).values()).map((p) => p.left)),
+    () => lanes.flatMap((lane) => Array.from(computeNodePositions(lane, NODE_ROW_HEIGHT, NOW_CLUSTER_X).values()).map((p) => p.left + LANE_LABEL_WIDTH)),
     [lanes],
   );
   const [offscreenCardCount, setOffscreenCardCount] = useState(0);
@@ -291,6 +309,11 @@ export function FlowMapCanvas({
       window.removeEventListener('resize', check);
     };
   }, [allCardLefts]);
+  // story #2369 QA 후속 — 멀티레인 호출부가 세로로 클리핑되는 «보이는 창» 안에서 이 힌트를
+  // 직접 그릴 수 있도록 수만 위로 보고한다(위 onOffscreenCountChange 문서 참고).
+  useEffect(() => {
+    onOffscreenCountChange?.(offscreenCardCount);
+  }, [offscreenCardCount, onOffscreenCountChange]);
   // AC3 — "지금" 열이 기본 상태에서 보이게. 가로축이 시간축이므로 "지금"을 놓치면 좌우가
   // 뜻을 잃는다. 컨테이너가 좁아 NOW_CLUSTER_X+카드폭이 clientWidth를 넘을 때만 스크롤을
   // 옮긴다 — 이미 보이는 넓은 화면(대부분의 데스크톱)에서는 조건이 거짓이라 손 안 댐
@@ -497,6 +520,7 @@ export function FlowMapCanvas({
   return (
     <div className="relative overflow-hidden rounded-md border border-border bg-card">
       <div className="flex" style={{ height: HEADER_HEIGHT }}>
+        {/* LANE_LABEL_WIDTH와 같은 값(위 레인 타이틀 칸 주석 참고). */}
         <div className="w-[150px] shrink-0 border-b border-r border-border" />
         <div className="relative min-w-0 flex-1 overflow-hidden border-b border-border">
           <span className="absolute top-[5px] text-[9.5px] uppercase tracking-[0.06em] text-muted-foreground" style={{ left: 10 }}>
@@ -524,6 +548,9 @@ export function FlowMapCanvas({
             const supersededIds = computeSupersededNodeIds(lane.edges);
             return (
               <div key={lane.epicId} className="relative flex border-b border-border last:border-b-0" style={{ height }}>
+                {/* ⛔story #2369 QA 후속 — 이 150px는 LANE_LABEL_WIDTH(derive-flow-map.ts)와
+                    반드시 같은 값이어야 한다(offscreen 카운트가 그 상수로 화면 좌표를
+                    보정한다) — 여길 바꾸면 그 상수도 같이 바꿔야 한다. */}
                 <div className="w-[150px] shrink-0 border-r border-border px-2 py-1.5">
                   <p className="truncate text-[11px] font-semibold text-foreground">{lane.title}</p>
                 </div>
@@ -849,7 +876,12 @@ export function FlowMapCanvas({
           자체를 침범한다 — 세로 판은 캔버스 «아래»에 붙지만 가로 판은 캔버스 «가장자리
           위»에 떠야 한다). pointer-events-none — 정보 전달용이지 클릭 대상이 아니다(세로
           접힘 줄도 클릭 불가한 정적 안내문과 같은 성질). */}
-      {offscreenCardCount > 0 ? (
+      {/* story #2369 QA 후속(2026-07-31) — onOffscreenCountChange가 있으면(멀티레인 호출부)
+          호출부가 세로-클리핑 조상의 «보이는 창» 안에서 이 힌트를 직접 그린다(위
+          onOffscreenCountChange 문서 참고) — 여기서 또 그리면 세로로 클리핑돼 아무도 못
+          보는 자리에 중복으로 뜬다. 콜백이 없는(단일-레인, flow-epic-nodes.tsx) 호출부만
+          기존 그대로 여기서 그린다 — 그쪽은 세로 클리핑 조상이 없어 이 자리가 이미 맞다. */}
+      {!onOffscreenCountChange && offscreenCardCount > 0 ? (
         <div
           data-testid="flow-canvas-offscreen-hint"
           className="pointer-events-none absolute bottom-1 right-1 z-10 flex items-center gap-1.5 rounded border border-border bg-muted/90 px-2 py-1 text-[11px] text-muted-foreground shadow-sm"

--- a/apps/web/src/components/flow/flow-multi-lane-canvas.test.tsx
+++ b/apps/web/src/components/flow/flow-multi-lane-canvas.test.tsx
@@ -275,11 +275,17 @@ describe('FlowMultiLaneCanvas — N개 레인 병렬 fetch', () => {
 // 못 채웠다: 오프스크린(가로 잘림) 힌트가 `FlowMapCanvas`(세로 클리핑되는 쪽) 자신의
 // `absolute bottom-1`로 붙어 있어, 그 조상 `FlowCanvasResizePane`(`overflow-y-auto`로
 // 실제 세로 클리핑하는 «보이는 창»)의 전체 콘텐츠 맨 아래(스크롤 1814px 아래)로 가버려
-// 기본 상태에서 화면에 0%였다. 이 테스트는 힌트가 실제 클리핑 컨테이너
-// (`[data-testid="flow-canvas-resize-pane"]`)의 «직계 자식»으로 붙어(그 자신은 클리핑
-// «대상»이 아니라 클리핑하는 쪽이므로 세로 스크롤과 무관하게 항상 보인다) 정확히 하나만
-// 존재하는지 확認한다 — FlowMapCanvas 안에서 또 그려 중복되는 것도 여기서 잡힌다.
-describe('FlowMultiLaneCanvas — story #2369 QA 후속: 오프스크린 힌트가 실제 클리핑 창 기준으로 뜬다', () => {
+// 기본 상태에서 화면에 0%였다.
+//
+// ⛔유나 design:changes 재현(2026-07-31) — 1차 수정은 힌트를 `[data-testid="flow-canvas-
+// resize-pane"]`의 «직계 자식»으로만 옮겼는데, 그 div 자신이 `overflow-y-auto`(스크롤하는
+// 쪽)였다 — `position:absolute`는 기준점(containing block)만 그 조상으로 잡을 뿐, 조상
+// 자신이 스크롤하면 콘텐츠와 함께 그대로 딸려 움직인다(실측: scrollTop=350에서 350px 밀려
+// 화면 밖으로 사라짐). 「직계 자식인가」와 「세로 스크롤에 클리핑 안 되는가」는 같은 질문이
+// 아니었다 — 직계 자식이면서 클리핑 «되는» 것이 정확히 그 반례였다. 이 테스트는 그래서
+// 위치(자식 관계)가 아니라 «성질»을 잰다: 힌트의 조상 중 `overflow-y-auto` 클래스를 가진
+// 요소가 하나도 없어야 한다 — 이 성질은 DOM을 나중에 어떻게 재배치해도 뜻이 안 바뀐다.
+describe('FlowMultiLaneCanvas — story #2369 QA 후속: 오프스크린 힌트가 세로 스크롤에 클리핑되지 않는다', () => {
   let originalClientWidth: PropertyDescriptor | undefined;
   let originalScrollWidth: PropertyDescriptor | undefined;
 
@@ -298,7 +304,7 @@ describe('FlowMultiLaneCanvas — story #2369 QA 후속: 오프스크린 힌트�
     if (originalScrollWidth) Object.defineProperty(HTMLElement.prototype, 'scrollWidth', originalScrollWidth);
   });
 
-  it('renders exactly one offscreen-hint, as a direct child of the resize-pane (the actual vertically-clipping ancestor) — not inside FlowMapCanvas', async () => {
+  it('renders exactly one offscreen-hint, with no overflow-y-auto (vertically-scrolling) ancestor — not clipped regardless of scroll position', async () => {
     vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.includes('/api/dependencies/graph')) return jsonResponse({ item_type: 'story', nodes: [], edges: [] });
@@ -327,10 +333,15 @@ describe('FlowMultiLaneCanvas — story #2369 QA 후속: 오프스크린 힌트�
     expect(hints).toHaveLength(1);
     expect(hints[0]?.textContent).toContain('카드 1장이 화면 밖');
 
-    const resizePane = container.querySelector('[data-testid="flow-canvas-resize-pane"]');
-    expect(resizePane).not.toBeNull();
-    // 직계 자식이어야 한다 — FlowMapCanvas(자식의 자식들) 안이 아니라 클리핑 컨테이너
-    // «자신»의 보이는 창 기준으로 붙어야 세로 스크롤과 무관하게 항상 보인다.
-    expect(Array.from(resizePane!.children)).toContain(hints[0]);
+    // 유나 design:changes 지적 — 「직계 자식인가」가 아니라 「세로로 스크롤하는 조상이
+    // 있는가」가 실제로 겨눠야 할 성질이다. 직계 자식이면서도 그 부모 자신이
+    // overflow-y-auto(스크롤하는 쪽)면 여전히 클리핑을 탄다(1차 수정이 정확히 이 반례였다).
+    let node = hints[0]!.parentElement;
+    let hasScrollingAncestor = false;
+    while (node) {
+      if (node.className.includes('overflow-y-auto')) hasScrollingAncestor = true;
+      node = node.parentElement;
+    }
+    expect(hasScrollingAncestor).toBe(false);
   });
 });

--- a/apps/web/src/components/flow/flow-multi-lane-canvas.test.tsx
+++ b/apps/web/src/components/flow/flow-multi-lane-canvas.test.tsx
@@ -270,3 +270,67 @@ describe('FlowMultiLaneCanvas — N개 레인 병렬 fetch', () => {
     expect(createLinkCalls).toHaveLength(0);
   });
 });
+
+// story #2369 QA 후속(2026-07-31, 라이브 실측 — dev-app 1440×900) — merged PR#2753가 AC를
+// 못 채웠다: 오프스크린(가로 잘림) 힌트가 `FlowMapCanvas`(세로 클리핑되는 쪽) 자신의
+// `absolute bottom-1`로 붙어 있어, 그 조상 `FlowCanvasResizePane`(`overflow-y-auto`로
+// 실제 세로 클리핑하는 «보이는 창»)의 전체 콘텐츠 맨 아래(스크롤 1814px 아래)로 가버려
+// 기본 상태에서 화면에 0%였다. 이 테스트는 힌트가 실제 클리핑 컨테이너
+// (`[data-testid="flow-canvas-resize-pane"]`)의 «직계 자식»으로 붙어(그 자신은 클리핑
+// «대상»이 아니라 클리핑하는 쪽이므로 세로 스크롤과 무관하게 항상 보인다) 정확히 하나만
+// 존재하는지 확認한다 — FlowMapCanvas 안에서 또 그려 중복되는 것도 여기서 잡힌다.
+describe('FlowMultiLaneCanvas — story #2369 QA 후속: 오프스크린 힌트가 실제 클리핑 창 기준으로 뜬다', () => {
+  let originalClientWidth: PropertyDescriptor | undefined;
+  let originalScrollWidth: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+    originalScrollWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollWidth');
+    // depth 0 열의 기본 화면 좌표(FLOW_MAP_DEPTH0_X=402 + LANE_LABEL_WIDTH=150 = 552)보다
+    // 좁은 500으로 둬 depth-0 카드 하나만으로도(멀티 depth·edges 없이) 곧바로 offscreen이
+    // 되도록 한다 — LANE_LABEL_WIDTH 보정이 실제로 적용됐는지까지 같이 잡는 값.
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, get() { return 500; } });
+    Object.defineProperty(HTMLElement.prototype, 'scrollWidth', { configurable: true, get() { return 1000; } });
+  });
+
+  afterEach(() => {
+    if (originalClientWidth) Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth);
+    if (originalScrollWidth) Object.defineProperty(HTMLElement.prototype, 'scrollWidth', originalScrollWidth);
+  });
+
+  it('renders exactly one offscreen-hint, as a direct child of the resize-pane (the actual vertically-clipping ancestor) — not inside FlowMapCanvas', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/dependencies/graph')) return jsonResponse({ item_type: 'story', nodes: [], edges: [] });
+      if (url.includes('/api/analytics/epic-flow-nodes')) {
+        return jsonResponse({
+          data: {
+            epic_id: 'e1',
+            now: { total: 0, items: [] },
+            upcoming: { total: 1, shown: 1, items: [{ id: 'q1', story_number: 9, title: 'Queued Story', status: 'backlog', assignee_id: null, updated_at: '2026-07-31T00:00:00Z' }] },
+            past: { total: 0 }, blocked_count: 0, last_changed_at: null,
+          },
+        });
+      }
+      if (url.includes('/reference-candidates')) return jsonResponse([]);
+      throw new Error(`unexpected fetch: ${url}`);
+    }));
+
+    await act(async () => {
+      root.render(wrap(
+        <FlowMultiLaneCanvas projectId="p1" expandGoals={[goal({ id: 'e1' })]} foldedCount={0} onSelectStory={() => {}} />,
+      ));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const hints = container.querySelectorAll('[data-testid="flow-canvas-offscreen-hint"]');
+    expect(hints).toHaveLength(1);
+    expect(hints[0]?.textContent).toContain('카드 1장이 화면 밖');
+
+    const resizePane = container.querySelector('[data-testid="flow-canvas-resize-pane"]');
+    expect(resizePane).not.toBeNull();
+    // 직계 자식이어야 한다 — FlowMapCanvas(자식의 자식들) 안이 아니라 클리핑 컨테이너
+    // «자신»의 보이는 창 기준으로 붙어야 세로 스크롤과 무관하게 항상 보인다.
+    expect(Array.from(resizePane!.children)).toContain(hints[0]);
+  });
+});

--- a/apps/web/src/components/flow/flow-multi-lane-canvas.tsx
+++ b/apps/web/src/components/flow/flow-multi-lane-canvas.tsx
@@ -8,7 +8,7 @@ import {
   deriveFlowMapLane, parseDependencyGraphEdges, parseReferenceCandidateEdges,
   type FlowMapEdge, type RawDependencyEdge, type RawReferenceCandidate,
 } from './derive-flow-map';
-import { FlowMapCanvas, HEADER_HEIGHT, NODE_ROW_HEIGHT, LANE_MIN_HEIGHT, type CreateLinkResult, type DeleteLinkResult } from './flow-map-canvas';
+import { FlowMapCanvas, FlowCanvasOffscreenHint, HEADER_HEIGHT, NODE_ROW_HEIGHT, LANE_MIN_HEIGHT, type CreateLinkResult, type DeleteLinkResult } from './flow-map-canvas';
 import { FlowCanvasResizePane } from './flow-canvas-resize-pane';
 import { declareResponseToEdge } from './flow-port-linking';
 import type { NextMakerGoal } from './derive-next-maker';
@@ -283,20 +283,12 @@ export function FlowMultiLaneCanvas({
         nodeRowHeight={NODE_ROW_HEIGHT}
         laneMinHeight={LANE_MIN_HEIGHT}
         headerHeight={HEADER_HEIGHT}
-        overlay={offscreenCardCount > 0 ? (
-          // story #2369 QA 후속 — flow-map-canvas.tsx의 기존 배지와 «같은 꼴»(pointer-events-none·
-          // 아이콘+굵은 수+설명·같은 클래스). 여기 그리는 이유는 이 div가 FlowCanvasResizePane의
-          // «보이는 창»(overflow-y-auto 조상) 기준으로 붙기 때문 — FlowMapCanvas 안에 있었으면
-          // 세로 전체 콘텐츠 높이 기준이 돼 클리핑 밖(안 보이는 자리)에 갔다.
-          <div
-            data-testid="flow-canvas-offscreen-hint"
-            className="pointer-events-none absolute bottom-1 right-1 z-10 flex items-center gap-1.5 rounded border border-border bg-muted/90 px-2 py-1 text-[11px] text-muted-foreground shadow-sm"
-          >
-            <span aria-hidden="true">▸</span>
-            <b className="text-foreground">{t('flowCanvasOffscreenCount', { n: offscreenCardCount })}</b>
-            <span className="text-foreground">{t('flowCanvasOffscreenReason')}</span>
-          </div>
-        ) : null}
+        // story #2369 QA 후속(2026-07-31, 유나 design:changes ③) — 배지 마크업은
+        // FlowCanvasOffscreenHint(flow-map-canvas.tsx) 단일 소스에서만 나온다(예전엔 여기
+        // 손으로 복제한 사본이었다). overlay로 넘기는 이유는 FlowCanvasResizePane이 이 자리를
+        // 세로 클리핑 «밖»(스크롤 컨테이너의 형제)에 그리기 때문 — FlowMapCanvas 안에 있었으면
+        // 콘텐츠 전체 높이 기준이 돼 클리핑 안(스크롤해야 보이는 자리)에 갔다.
+        overlay={<FlowCanvasOffscreenHint count={offscreenCardCount} />}
       >
         <FlowMapCanvas
           lanes={lanes}

--- a/apps/web/src/components/flow/flow-multi-lane-canvas.tsx
+++ b/apps/web/src/components/flow/flow-multi-lane-canvas.tsx
@@ -118,6 +118,11 @@ export function FlowMultiLaneCanvas({
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
   const [pastItemsByEpic, setPastItemsByEpic] = useState<Map<string, EpicFlowNodeItem[]>>(new Map());
   const [loadingPastBundleEpicIds, setLoadingPastBundleEpicIds] = useState<Set<string>>(new Set());
+  // story #2369 QA 후속(2026-07-31) — FlowMapCanvas가 세는 오프스크린(가로 잘림) 수를 여기로
+  // 끌어올린다. FlowCanvasResizePane이 세로로 «실제 클리핑하는» 유일한 조상이라, 힌트는
+  // FlowMapCanvas 안이 아니라 그 조상의 «보이는 창» 기준(overlay prop)으로 그려야 항상
+  // 보인다(위 FlowCanvasResizePane/FlowMapCanvas 문서 참고).
+  const [offscreenCardCount, setOffscreenCardCount] = useState(0);
 
   const expandGoalIds = useMemo(() => expandGoals.map((g) => g.id).join(','), [expandGoals]);
 
@@ -273,7 +278,26 @@ export function FlowMultiLaneCanvas({
       {/* story #2224 AC18 — pane 높이를 사용자가 지정한다(레인 단위 스냅, 하한 1레인,
           기본=레인 3까지 누적, localStorage 영속, 되돌리기). FlowMapCanvas 자체는 높이를
           모른다 — 이 래퍼가 «몇 레인이 보이는가»만 결정하고 클리핑한다. */}
-      <FlowCanvasResizePane lanes={lanes} nodeRowHeight={NODE_ROW_HEIGHT} laneMinHeight={LANE_MIN_HEIGHT} headerHeight={HEADER_HEIGHT}>
+      <FlowCanvasResizePane
+        lanes={lanes}
+        nodeRowHeight={NODE_ROW_HEIGHT}
+        laneMinHeight={LANE_MIN_HEIGHT}
+        headerHeight={HEADER_HEIGHT}
+        overlay={offscreenCardCount > 0 ? (
+          // story #2369 QA 후속 — flow-map-canvas.tsx의 기존 배지와 «같은 꼴»(pointer-events-none·
+          // 아이콘+굵은 수+설명·같은 클래스). 여기 그리는 이유는 이 div가 FlowCanvasResizePane의
+          // «보이는 창»(overflow-y-auto 조상) 기준으로 붙기 때문 — FlowMapCanvas 안에 있었으면
+          // 세로 전체 콘텐츠 높이 기준이 돼 클리핑 밖(안 보이는 자리)에 갔다.
+          <div
+            data-testid="flow-canvas-offscreen-hint"
+            className="pointer-events-none absolute bottom-1 right-1 z-10 flex items-center gap-1.5 rounded border border-border bg-muted/90 px-2 py-1 text-[11px] text-muted-foreground shadow-sm"
+          >
+            <span aria-hidden="true">▸</span>
+            <b className="text-foreground">{t('flowCanvasOffscreenCount', { n: offscreenCardCount })}</b>
+            <span className="text-foreground">{t('flowCanvasOffscreenReason')}</span>
+          </div>
+        ) : null}
+      >
         <FlowMapCanvas
           lanes={lanes}
           onSelectStory={onSelectStory}
@@ -283,6 +307,7 @@ export function FlowMultiLaneCanvas({
           onCreateLink={handleCreateLink}
           onDeleteLink={handleDeleteLink}
           memberMap={memberMap}
+          onOffscreenCountChange={setOffscreenCardCount}
         />
       </FlowCanvasResizePane>
       {/* 접힘 줄(목업 그대로) — "숨긴 것이 아니라 접은 것입니다". 오늘은 펼치기 인터랙션이


### PR DESCRIPTION
## Summary
- story #2369(가로 잘림 발견성) — merged PR#2753이 라이브 QA(1440×900, dev-app.sprintable.ai)에서 AC를 못 채워 스토리가 in-progress로 되돌아간 후속.
- **①(가장 무거움) 힌트가 사람이 볼 수 없는 자리** — `flow-map-canvas.tsx`의 오프스크린(가로 잘림) 배지가 `FlowMapCanvas` 자신의 루트(overflow-hidden, 세로 클리핑 없이 전체 콘텐츠 높이만큼 자연히 커짐) 기준 `absolute bottom-1`이었다. 실제 「보이는 창」은 그 조상 `FlowCanvasResizePane`의 `overflow-y-auto` 뷰포트(`displayHeightPx`, 기본 3레인분 ~380px)였다 — 기본 상태(scrollTop=0)에서 힌트가 콘텐츠 전체 높이(~2194px)의 맨 아래에 가 있어 화면에 0% 노출이었다(QA 실측: pane h=380, 콘텐츠 scrollHeight=2194, 힌트 y=2288).
  - `FlowCanvasResizePane`에 `relative` + `overlay` 슬롯을 추가하고, `FlowMapCanvas`는 `onOffscreenCountChange` 콜백으로 카운트만 위로 보고하도록 바꿔, 실제 클리핑 컨테이너(그 자신은 세로 스크롤과 무관하게 늘 보이는 쪽)의 보이는 창 기준으로 그리게 했다 — 세로 접힘 줄(「움직임 없는 목표 N개」, 클리핑 밖에 있어 항상 보임)과 정확히 같은 사정으로 맞췄다.
  - 콜백이 없는 단일-레인 호출부(`flow-epic-nodes.tsx`, 세로 클리핑 조상 자체가 없음)는 기존 그대로 `FlowMapCanvas` 내부에서 그린다(회귀 없음).
- **②③ 카운트 오판정(6장인데 5장 · 중간 스크롤에서 0으로 꺼짐)** — `countCardsBeyondRightEdge`에 들어가는 카드 `left`가 레인 콘텐츠 영역(레인 타이틀 칸 «다음»부터) 기준이었는데, 스크롤 원점(타이틀 칸 «포함» 시작)엔 `LANE_LABEL_WIDTH`(150px, 레인 타이틀 칸 폭)만큼 못 미쳤다. dev-app 라이브 DOM 실측으로 확認(`style.left=1062px`인 카드가 실제 화면에서는 `getBoundingClientRect().left`≈1212px에 그려짐, 정확히 +150). 이 한 가지 원인이 QA가 보고한 두 증상(실측 6장·표시 5장 / scrollLeft=260에서 여전히 3장 밖인데 힌트 통째로 꺼짐)을 모두 설명한다 — `allCardLefts`에 `LANE_LABEL_WIDTH`를 더하는 것으로 둘 다 해결됨을 재계산으로 확認.
- PO 메시지의 원인 추정("제 추론이지 증명이 아니니 재서 정하기 바라는")을 dev-app에 실제 로그인(puppeteer)해 DOM을 직접 측정하는 것으로 증명 후 수정 — 추측으로 구현하지 않았다.

## Test plan
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm run lint`(eslint) — 0 errors (변경 파일 대상)
- [x] `pnpm exec vitest run` — 336 files / 2455 tests 전부 PASS(신규/수정 회귀가드 포함, mutation self-check 완료)
- [x] `pnpm run build` — 성공(EXIT 0)
- [x] verify:* 6개 — 전부 OK, 신규 회귀 0건
- [ ] 라이브 픽셀(배포 후, dev-app 1440×900): 기본 상태(scrollTop=0)에서 힌트 노출 + scrollLeft 0/중간/끝 3지점 카운트 실측표 — QA가 요청한 형식 그대로 재제출 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)