### PR TITLE
fix(#2373 backport): board→flow redirect missing from develop's own #2224 migration

### DIFF
--- a/apps/web/src/app/(authenticated)/more/page.tsx
+++ b/apps/web/src/app/(authenticated)/more/page.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import {
-  FolderKanban,
   CalendarRange,
   Layers,
   Compass,
@@ -23,8 +22,9 @@ import {
 // P2-S9(story #1965)가 담당 — 이 페이지는 그때 교체된다(오르테가군 확定, 2026-07-17).
 // bare 경로만 씀 — 미들웨어의 bare→쿠키 default 해소 301 안전망이 ws/proj slug를 채운다
 // (app-sidebar.tsx의 resourceLink()와 동형 전제).
+// board 항목은 없다(유나 2026-08-01) — /board는 /flow로 리다이렉트되니(#2227 AC8·proxy.ts
+// RENAMED_RESOURCES) flow 링크가 따로 생기면 같은 화면으로 가는 항목이 두 개가 된다.
 const ITEMS = [
-  { href: '/board', icon: FolderKanban, labelKey: 'board' as const },
   { href: '/sprints', icon: CalendarRange, labelKey: 'sprints' as const },
   { href: '/goals', icon: Layers, labelKey: 'goals' as const },
   { href: '/loops', icon: FlaskConical, labelKey: 'loops' as const },

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -408,7 +408,10 @@ describe('proxy — resolve (story a539c649 S-route-project S1)', () => {
       ok: true,
       json: async () => ({ org_id: 'org-1', org_slug: 'moonklabs', org_role: 'admin', project_id: 'proj-1', project_slug: 'sprintable' }),
     });
-    const response = await middleware(makeRequest('/moonklabs/sprintable/board', { sp_at: token }));
+    // 리소스명은 이 테스트의 관심사(workspace/project resolve)와 무관 — RENAMED_RESOURCES에
+    // 없는 이름을 써야 redirectRenamedResourcePath가 가로채지 않는다(#2373 board→flow 편입 후
+    // 'board'를 쓰면 이 resolve 로직에 닿기 전에 301로 새는 회귀가 났다).
+    const response = await middleware(makeRequest('/moonklabs/sprintable/goals', { sp_at: token }));
     expect(response.status).toBe(200);
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining('/api/v2/resolve?workspace=moonklabs&project=sprintable'),
@@ -421,7 +424,7 @@ describe('proxy — resolve (story a539c649 S-route-project S1)', () => {
   it('resolve 실패(미존재/미소속) → 개입 없이 통과(200) — Next 자체 404 렌더에 위임', async () => {
     const token = await makeAccessToken();
     mockFetch.mockResolvedValueOnce({ ok: false, status: 404, json: async () => ({}) });
-    const response = await middleware(makeRequest('/ghost-workspace/proj/board', { sp_at: token }));
+    const response = await middleware(makeRequest('/ghost-workspace/proj/goals', { sp_at: token }));
     expect(response.status).toBe(200);
     const setCookie = response.headers.get('set-cookie') ?? '';
     expect(setCookie).not.toContain('sp_resolve_cache=');
@@ -458,13 +461,16 @@ describe('proxy — resolve (story a539c649 S-route-project S1)', () => {
       ok: true,
       json: async () => ({ org_id: 'org-1', org_slug: 'moonklabs', org_role: 'admin', project_id: 'proj-1', redirect: { project: 'project-307152f3' } }),
     });
-    const response = await middleware(makeRequest('/moonklabs/%EC%9E%A5%EC%82%AC%EC%99%95/board', { sp_at: token }));
+    // 리소스명은 board 대신 goals — #2373로 board가 RENAMED_RESOURCES에 편입되면서 이 자리에
+    // board를 쓰면 redirectRenamedResourcePath가 workspace resolve보다 먼저 가로채 mockFetch가
+    // 0회 호출되는 회귀가 났다(이 테스트가 재려는 한글 slug 이중인코딩 가드 자체가 무력화된다).
+    const response = await middleware(makeRequest('/moonklabs/%EC%9E%A5%EC%82%AC%EC%99%95/goals', { sp_at: token }));
     expect(mockFetch).toHaveBeenCalledWith(
       'http://localhost:8000/api/v2/resolve?workspace=moonklabs&project=%EC%9E%A5%EC%82%AC%EC%99%95',
       expect.any(Object),
     );
     expect(response.status).toBe(301);
-    expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/project-307152f3/board');
+    expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/project-307152f3/goals');
   });
 
   it('캐시 hit(유효 sp_resolve_cache 쿠키+동일 slug) → resolve fetch 생략', async () => {
@@ -689,16 +695,15 @@ describe('proxy — 경로 리터럴 rename 301(story 8fc51517, 에픽→목표)
     expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/sprintable/goals/e-123');
   });
 
-  it('다른 리소스(예: /{ws}/{proj}/board)는 스코프 밖이라 개입 없이 통과 — RENAMED_RESOURCES에 없는 이름은 무변경', async () => {
+  it('/{ws}/{proj}/board → 301 /{ws}/{proj}/flow(board도 RENAMED_RESOURCES 대상 — #2373 prod 승격 board 은퇴 회귀가드)', async () => {
     const token = await makeAccessToken({ orgId: 'org-1' });
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => ({ org_id: 'org-1', org_slug: 'moonklabs', org_role: 'member', project_id: 'proj-1', project_slug: 'sprintable' }),
-    });
     const response = await middleware(makeRequest('/moonklabs/sprintable/board', {
       sp_at: token, sprintable_current_project_id: 'proj-1',
     }));
-    expect(response.status).not.toBe(301);
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/sprintable/flow');
+    // 3번째 세그먼트만 교체하는 순수 문자열 치환이라 org/project fetch가 전혀 없어야 한다(epics→goals와 동형).
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('이미 신 경로(/goals)로 들어온 요청은 재리다이렉트 없이 그대로 통과(무한루프 방지 확인)', async () => {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -234,6 +234,10 @@ const RENAMED_RESOURCES: Record<string, string> = {
   // (여기) → `/{ws}/{proj}/flow`. `?story=`/`?task_id=` 등 쿼리는 두 함수 다 request.nextUrl을
   // clone해 그대로 들고 가므로 안전(RESOLVE_RETRY_PARAM 외엔 손대지 않는다).
   glance: 'flow',
+  // #2227 AC8(2026-07-27) 종료 조건 — board 제거는 flow 리다이렉트 포함이 조건이었다(유나
+  // 2026-08-01 지적: prod 승격 #2373에서 board 라우트만 지우고 이 줄을 빠뜨려 외부 딥링크
+  // ~14곳이 404를 만날 뻔했다 — board/page.tsx:12-13 자체가 이 위험을 이미 적어 두고 있었다).
+  board: 'flow',
 };
 
 function redirectRenamedResourcePath(request: NextRequest, pathname: string): NextResponse | null {


### PR DESCRIPTION
## Summary

Backport of the board→flow redirect fix from the #2373 prod-promotion PR (#2758) into `develop` itself — not a sync between two copies, a return to one copy.

## Why this is urgent, not cosmetic

`develop`'s own commit `0ca5a9f90` (`[SID:2224] /board·/glance 라우트 삭제 + /flow 리다이렉트(통합 완료 조건)`) claims a flow redirect landed for both routes, but only wired `glance → flow` into `proxy.ts`'s `RENAMED_RESOURCES` — `board` was dropped. The commit title doesn't match what it shipped. `#2227` AC8 registered the redirect as a hard exit condition for removing `/board`, and that condition went unmet on `develop` even though `/board`'s own route comment (still true on `main` pre-promotion) called it "this migration's last and highest-risk slice — ~14 measured external deep links."

Without this fix, `develop` is currently: `/board` route gone, no redirect, `/glance` → `flow` redirect present. Any of those ~14 deep links hit `develop` today, they 404.

**Why urgent for the next promotion specifically**: this promotion (#2373) is selective-checkout (`git checkout origin/develop -- <path>`), which replaces `proxy.ts` wholesale from whatever `develop` has at promotion time. Right now `main`'s promo branch carries `board: 'flow'` but `develop` doesn't — a third main-only-ism nobody had listed, on top of the two already tracked (`cloud-build.yml`'s `REALTIME_URL`, `publish-mcp.yml`). The next promotion would silently drop this line and reopen the exact 404 this PR closes. Fixing it in `develop` removes the condition instead of documenting around it.

## Changes (identical to promo PR commits `92a4f3a33` + `c029fbe3a`, cherry-picked)

- `apps/web/src/proxy.ts` — `RENAMED_RESOURCES` gets `board: 'flow'`, alongside the existing `glance: 'flow'`.
- `apps/web/src/app/(authenticated)/more/page.tsx` — dropped the dead `{ href: '/board', ... }` mobile nav entry (now a duplicate of flow, not a 404, per Yuna's finding — `board` route content itself lives inside `/flow?view=list` in the desktop command palette's own override, so this isn't removing the kanban view, just a stale duplicate entry pointing at it via the wrong URL).
- `apps/web/src/proxy.test.ts` — 4 fixture updates: one stale "board is out of scope" assertion flipped to assert the real 301→`/flow`, three workspace-resolve tests that used `/board` as a content-irrelevant placeholder swapped to `/goals` (a `RENAMED_RESOURCES` *value*, not a key, so it doesn't trigger the redirect and stops shadowing the logic those tests actually exercise) — including `#2039` AC3's Korean-slug double-encoding guard, which had silently dropped to 0 `mockFetch` calls.

## Verification
- `git diff origin/main <this-branch> -- apps/web/src/proxy.ts apps/web/src/app/'(authenticated)'/more/page.tsx apps/web/src/proxy.test.ts` → empty on all three (this branch and `main` are now byte-identical on these files — the intended state per Pedro: after this backport, `main`↔`develop` divergence on the board/flow/glance migration axis should be down to zero, with only `billing-tab.tsx` (EE, separate axis) remaining as an actual main-only-ism).
- `tsc --noEmit` clean, `pnpm build` exit 0.
- `vitest run src/proxy.test.ts` — 56/56 pass.

Small, mechanical PR — cherry-picks already-reviewed commits, no new logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
