### PR TITLE
[SID:2372] 문서 편집기 DnD 드롭 오버레이 — 스크롤하면 사라지는 결함 fix

### DIFF
--- a/apps/web/src/components/docs/doc-editor.dragdrop.test.tsx
+++ b/apps/web/src/components/docs/doc-editor.dragdrop.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+//
+// story #2372(2026-08-01) — #2757과 같은 병(같은 규격의 두 번째 적용 사례). doc-editor.tsx엔
+// 지금까지 테스트가 아예 없었다 — 실제 Tiptap/ProseMirror는 jsdom이 못 주는 DOM 측정 API들
+// (getClientRects 등)을 요구해 전체 마운트가 안 된다(이 파일의 관심사와 무관한 jsdom 갭).
+// 그래서 useEditor/EditorContent/BubbleMenu만 얇게 스텁하고(editor=null — 실제로 tiptap이
+// 아직 준비 안 된 상태와 같은, 컴포넌트가 이미 처리하는 정상 분기) 이 파일의 진짜 관심사인
+// 주변 JSX 구조(스크롤 컨테이너·DnD 오버레이의 위치)만 잰다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+
+vi.mock('@tiptap/react', () => ({
+  useEditor: () => null,
+  EditorContent: () => <div data-testid="editor-content-stub" />,
+}));
+vi.mock('@tiptap/react/menus', () => ({
+  BubbleMenu: () => null,
+}));
+
+const { DocEditor } = await import('./doc-editor');
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+const LABELS = {
+  contentFormat: 'Format', markdown: 'Markdown', preview: 'Preview', save: 'Save', toolbar: 'Toolbar',
+  placeholder: 'Write something…', h1: 'H1', h2: 'H2', bold: 'Bold', italic: 'Italic', bullet: 'Bullet',
+  quote: 'Quote', code: 'Code', link: 'Link', autosave: 'Autosave', undo: 'Undo', redo: 'Redo',
+};
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+function scrollContainer(): HTMLElement {
+  const el = container.querySelector('.tiptap-editor-wrapper');
+  expect(el).not.toBeNull();
+  return el as HTMLElement;
+}
+
+function fireDragEnterWithFiles(el: Element) {
+  const ev = new Event('dragenter', { bubbles: true, cancelable: true }) as DragEvent;
+  Object.defineProperty(ev, 'dataTransfer', { value: { types: ['Files'] } });
+  el.dispatchEvent(ev);
+}
+
+describe('DocEditor — story #2372: DnD 드롭 오버레이가 세로 스크롤에 클리핑되지 않는다', () => {
+  it('shows the drop overlay on dragenter with Files, positioned outside the scrolling container', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <DocEditor value="hello" contentFormat="markdown" onChange={() => {}} labels={LABELS} />,
+      ));
+    });
+
+    expect(container.querySelector('[data-testid="doc-editor-drop-overlay"]')).toBeNull();
+
+    await act(async () => { fireDragEnterWithFiles(scrollContainer()); });
+
+    const overlay = container.querySelector('[data-testid="doc-editor-drop-overlay"]');
+    expect(overlay).not.toBeNull();
+
+    // story #2369 회귀 테스트(flow-multi-lane-canvas.test.tsx)와 같은 성질 — 오버레이의
+    // 조상 중 overflow-y-auto(세로로 스크롤하는 요소)가 없어야 한다. `.tiptap-editor-wrapper`
+    // 자신이 그 스크롤 컨테이너이므로, 오버레이가 «그 밖»(형제)에 있어야 이 성질이 선다.
+    let node = overlay!.parentElement;
+    let hasScrollingAncestor = false;
+    while (node) {
+      if (node.className.includes('overflow-y-auto')) hasScrollingAncestor = true;
+      node = node.parentElement;
+    }
+    expect(hasScrollingAncestor).toBe(false);
+
+    // 그리고 오버레이는 스크롤 컨테이너의 «형제»(같은 non-clipping relative wrapper의 자식)
+    // 여야 한다 — 스크롤 컨테이너 자신의 자손이면 안 된다.
+    expect(scrollContainer().contains(overlay)).toBe(false);
+  });
+
+  it('drag handlers stay on the scrolling container (AC5 — drop itself keeps working)', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <DocEditor value="hello" contentFormat="markdown" onChange={() => {}} labels={LABELS} />,
+      ));
+    });
+    // React attaches synthetic handlers at the root, but the element the props were given to
+    // is still this one — dispatching straight at it must still flip isDragging (proves the
+    // handlers moved with the element, not silently dropped during the restructure).
+    await act(async () => { fireDragEnterWithFiles(scrollContainer()); });
+    expect(container.querySelector('[data-testid="doc-editor-drop-overlay"]')).not.toBeNull();
+  });
+});

--- a/apps/web/src/components/docs/doc-editor.dragdrop.test.tsx
+++ b/apps/web/src/components/docs/doc-editor.dragdrop.test.tsx
@@ -79,19 +79,13 @@ describe('DocEditor — story #2372: DnD 드롭 오버레이가 세로 스크롤
     const overlay = container.querySelector('[data-testid="doc-editor-drop-overlay"]');
     expect(overlay).not.toBeNull();
 
-    // story #2369 회귀 테스트(flow-multi-lane-canvas.test.tsx)와 같은 성질 — 오버레이의
-    // 조상 중 overflow-y-auto(세로로 스크롤하는 요소)가 없어야 한다. `.tiptap-editor-wrapper`
-    // 자신이 그 스크롤 컨테이너이므로, 오버레이가 «그 밖»(형제)에 있어야 이 성질이 선다.
-    let node = overlay!.parentElement;
-    let hasScrollingAncestor = false;
-    while (node) {
-      if (node.className.includes('overflow-y-auto')) hasScrollingAncestor = true;
-      node = node.parentElement;
-    }
-    expect(hasScrollingAncestor).toBe(false);
-
-    // 그리고 오버레이는 스크롤 컨테이너의 «형제»(같은 non-clipping relative wrapper의 자식)
-    // 여야 한다 — 스크롤 컨테이너 자신의 자손이면 안 된다.
+    // ⛔올리베이라군 리뷰(2026-08-01, PR#2760) — "조상 중 overflow-y-auto가 하나도 없다"는
+    // 실제 앱에서는 항상 거짓이다(페이지 셸 어딘가에 스크롤하는 조상이 늘 있다 — 유나양이
+    // flow-multi-lane-canvas.test.tsx에서 정확히 이 문장을 정정한 그 자리). 겨눠야 할
+    // 성질은 "오버레이와 그 containing block «사이»에 스크롤 조상이 없다"이고, 여기서는
+    // `.tiptap-editor-wrapper`(`.scrollContainer()`)가 정확히 그 스크롤하는 요소이므로,
+    // "오버레이가 그 요소의 자손이 아니다"만 재면 충분하다 — 더 넓게(조상 전체를) 약속하면
+    // 페이지 셸이 나중에 바뀔 때 이 결함과 무관하게 빨개질 수 있다.
     expect(scrollContainer().contains(overlay)).toBe(false);
   });
 

--- a/apps/web/src/components/docs/doc-editor.dragdrop.test.tsx
+++ b/apps/web/src/components/docs/doc-editor.dragdrop.test.tsx
@@ -6,6 +6,14 @@
 // 그래서 useEditor/EditorContent/BubbleMenu만 얇게 스텁하고(editor=null — 실제로 tiptap이
 // 아직 준비 안 된 상태와 같은, 컴포넌트가 이미 처리하는 정상 분기) 이 파일의 진짜 관심사인
 // 주변 JSX 구조(스크롤 컨테이너·DnD 오버레이의 위치)만 잰다.
+//
+// ⛔이 테스트가 «못 잡는» 것을 스스로 말해 둔다(올리베이라군 리뷰, 2026-08-01) — jsdom엔
+// 레이아웃 엔진이 없어 scrollHeight/clientHeight가 항상 같은 값(뜻이 없는 수)을 낸다. 그래서
+// 이 파일은 «구조»(오버레이가 클리핑 밖인가)만 재고, «레이아웃»(min-h-0 누락처럼 편집기 내부
+// 스크롤이 실제로 죽는가)은 원리적으로 못 잰다 — 이 신규 테스트 110줄이 전부 초록이었을
+// 때도 그 회귀(바깥 flex-1이 overflow:visible이라 min-height:auto가 콘텐츠 높이만큼 살아남아
+// 내부 스크롤이 죽고 편집기 셸이 넘치는 것)를 못 잡았다. 후자는 실제 브라우저에서만 갈린다
+// (이 PR의 doc-editor.tsx 쪽 주석에 붙인 puppeteer 실측 수치 참고).
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -527,73 +527,95 @@ export function DocEditor({
           placeholder={labels.placeholder}
         />
       ) : (
-        <div
-          ref={editorContentRef as RefObject<HTMLDivElement>}
-          onDragEnter={onDragEnter}
-          onDragOver={(e) => { if (Array.from(e.dataTransfer?.types ?? []).includes('Files')) e.preventDefault(); }}
-          onDragLeave={onDragLeave}
-          onDrop={onDrop}
-          className="tiptap-editor-wrapper relative flex-1 overflow-y-auto p-3 pl-9 max-md:pb-20 max-md:min-h-[50vh]"
-        >
-          <EditorContent editor={editor} className="tiptap-content h-full outline-none" />
+        // story #2372 QA 후속(2026-08-01) — #2757과 같은 병(같은 규격의 두 번째 적용 사례,
+        // AC7). 아래 안쪽 div가 이 편집기의 «유일한» relative 기준점이자 «유일한» 세로
+        // 스크롤 컨테이너였다 — 빈 문서 힌트(L~기존 542)·gutter "+"(551)·삽입 메뉴(569)는
+        // «콘텐츠를 따라가는 것이 맞아»(관련 위치가 캐럿·문서 좌표) 그 기준점이 그대로
+        // 필요하다(유나 판정 — 이 셋은 병이 아니다, relative를 옮기면 회귀). 반면 DnD 드롭
+        // 오버레이는 "세로 스크롤 위치와 무관하게 «보이는 창»을 덮어야" 하는데 같은
+        // 기준점(=스크롤하는 그 요소)에 얹혀 있어 스크롤과 함께 그대로 밀렸다(라이브 실측:
+        // scrollTop 1200 — 문서의 11% 지점 — 에서 가시비율 0%). 처방은 안쪽 relative를
+        // 옮기는 것이 아니라 relative를 «하나 더»(바깥, 스크롤 안 함) 두고 오버레이만 그
+        // 밖으로 — #2757(flow-canvas-resize-pane.tsx)에서 쓴 것과 같은 non-clipping wrapper
+        // 구조. 드래그 핸들러(onDragEnter/onDragOver/onDragLeave/onDrop)는 안쪽(실제 스크롤
+        // 컨테이너)에 그대로 둔다 — 오버레이가 pointer-events-none이라 그 아래 안쪽 div가
+        // 여전히 이벤트를 받으므로 드롭 자체는 구조 변경과 무관하게 그대로 동작한다(AC5).
+        <div className="relative flex-1">
+          <div
+            ref={editorContentRef as RefObject<HTMLDivElement>}
+            onDragEnter={onDragEnter}
+            onDragOver={(e) => { if (Array.from(e.dataTransfer?.types ?? []).includes('Files')) e.preventDefault(); }}
+            onDragLeave={onDragLeave}
+            onDrop={onDrop}
+            className="tiptap-editor-wrapper relative h-full overflow-y-auto p-3 pl-9 max-md:pb-20 max-md:min-h-[50vh]"
+          >
+            <EditorContent editor={editor} className="tiptap-content h-full outline-none" />
 
-          {/* 빈 문서 힌트 — 첨부 진입 discoverability(+ · / · DnD). */}
-          {editable && isEmpty ? (
-            <p className="pointer-events-none absolute left-9 top-3 select-none text-sm text-muted-foreground/50">
-              {tEditor('attachEmptyHint')}
-            </p>
-          ) : null}
+            {/* 빈 문서 힌트 — 첨부 진입 discoverability(+ · / · DnD). 콘텐츠를 따라가는 것이
+                맞다 — 안쪽 relative(스크롤 컨테이너) 기준 그대로 둔다. */}
+            {editable && isEmpty ? (
+              <p className="pointer-events-none absolute left-9 top-3 select-none text-sm text-muted-foreground/50">
+                {tEditor('attachEmptyHint')}
+              </p>
+            ) : null}
 
-          {/* gutter "+" — 현재 줄 좌측 거터·항상 표시·클릭 시 이미지/파일 삽입 메뉴 */}
-          {editable && gutterTop !== null ? (
-            <div
-              contentEditable={false}
-              className="absolute left-1.5 z-20"
-              style={{ top: gutterTop }}
-              onMouseDown={(e) => e.preventDefault()}
-            >
-              <button
-                type="button"
-                aria-label={tEditor('attachInsertMenu')}
-                aria-haspopup="menu"
-                aria-expanded={insertMenuOpen}
-                onClick={(e) => { e.stopPropagation(); setInsertMenuOpen((v) => !v); }}
-                className="flex size-6 items-center justify-center rounded-md border border-border bg-card text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            {/* gutter "+" — 현재 줄 좌측 거터·항상 표시·클릭 시 이미지/파일 삽입 메뉴. 캐럿
+                위치를 따라가는 것이 맞다 — 안쪽 relative 기준 그대로 둔다. */}
+            {editable && gutterTop !== null ? (
+              <div
+                contentEditable={false}
+                className="absolute left-1.5 z-20"
+                style={{ top: gutterTop }}
+                onMouseDown={(e) => e.preventDefault()}
               >
-                <Plus className="size-3.5" />
-              </button>
-              {insertMenuOpen ? (
-                <div
-                  role="menu"
-                  onClick={(e) => e.stopPropagation()}
-                  className="absolute left-7 top-0 w-36 overflow-hidden rounded-lg border border-border bg-card p-1 shadow-lg"
+                <button
+                  type="button"
+                  aria-label={tEditor('attachInsertMenu')}
+                  aria-haspopup="menu"
+                  aria-expanded={insertMenuOpen}
+                  onClick={(e) => { e.stopPropagation(); setInsertMenuOpen((v) => !v); }}
+                  className="flex size-6 items-center justify-center rounded-md border border-border bg-card text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 >
-                  <button
-                    type="button"
-                    role="menuitem"
-                    onClick={openImagePicker}
-                    className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-muted"
+                  <Plus className="size-3.5" />
+                </button>
+                {insertMenuOpen ? (
+                  <div
+                    role="menu"
+                    onClick={(e) => e.stopPropagation()}
+                    className="absolute left-7 top-0 w-36 overflow-hidden rounded-lg border border-border bg-card p-1 shadow-lg"
                   >
-                    <ImageIcon className="size-4 text-muted-foreground" />
-                    {tEditor('attachImage')}
-                  </button>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    onClick={openFilePicker}
-                    className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-muted"
-                  >
-                    <Paperclip className="size-4 text-muted-foreground" />
-                    {tEditor('attachFile')}
-                  </button>
-                </div>
-              ) : null}
-            </div>
-          ) : null}
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={openImagePicker}
+                      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-muted"
+                    >
+                      <ImageIcon className="size-4 text-muted-foreground" />
+                      {tEditor('attachImage')}
+                    </button>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={openFilePicker}
+                      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-muted"
+                    >
+                      <Paperclip className="size-4 text-muted-foreground" />
+                      {tEditor('attachFile')}
+                    </button>
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
 
-          {/* DnD active-zone 오버레이 — 파일 드래그 중(목업 .dnd.active). pointer-events-none 로 실 drop 통과. */}
+          {/* DnD active-zone 오버레이 — 파일 드래그 중(목업 .dnd.active). pointer-events-none
+              으로 실 drop 통과. story #2372 후속 — 바깥(스크롤 안 하는) relative 기준으로
+              옮겨 세로 스크롤 위치와 무관하게 «보이는 창»을 덮는다. */}
           {editable && isDragging ? (
-            <div className="pointer-events-none absolute inset-2 z-30 flex flex-col items-center justify-center gap-1.5 rounded-lg border-[1.5px] border-dashed border-info bg-info/10 text-center">
+            <div
+              data-testid="doc-editor-drop-overlay"
+              className="pointer-events-none absolute inset-2 z-30 flex flex-col items-center justify-center gap-1.5 rounded-lg border-[1.5px] border-dashed border-info bg-info/10 text-center"
+            >
               <span className="flex size-9 items-center justify-center rounded-full bg-info/10 text-info">
                 <Plus className="size-4" />
               </span>

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -540,7 +540,19 @@ export function DocEditor({
         // 구조. 드래그 핸들러(onDragEnter/onDragOver/onDragLeave/onDrop)는 안쪽(실제 스크롤
         // 컨테이너)에 그대로 둔다 — 오버레이가 pointer-events-none이라 그 아래 안쪽 div가
         // 여전히 이벤트를 받으므로 드롭 자체는 구조 변경과 무관하게 그대로 동작한다(AC5).
-        <div className="relative flex-1">
+        //
+        // ⛔올리베이라군 리뷰(2026-08-01, PR#2760) — 옛 코드는 `flex-1`과 `overflow-y-auto`가
+        // «같은 요소»에 있어(flex item 자신이 overflow-y-auto) CSS 명세상 그 요소의
+        // `min-height:auto`가 0으로 처리돼(자동 최소 크기가 overflow≠visible일 때만 0이 되는
+        // 규칙) 정상적으로 축소됐다. 여기서는 `flex-1`이 바깥(overflow:visible인 채)으로
+        // 옮겨져 바깥의 `min-height:auto`가 콘텐츠 높이만큼 살아남을 뻔했다 — 로컬 puppeteer
+        // 실측(Tailwind와 같은 border-box 전제)으로 직접 확認: `min-h-0` 없이는 스크롤
+        // 컨테이너가 전체 콘텐츠 높이(2016px)만큼 그대로 커져 내부 스크롤이 아예 죽고
+        // 편집기 셸을 1748px 밀어낸다. `min-h-0`을 더하면 옛 구조와 동일하게(clientHeight
+        // 266·scrollHeight 2016·내부 스크롤 O) 돌아온다 — #2757은 바깥이 «고정 height»였어서
+        // 이 함정을 안 만났을 뿐, 같은 규격이라도 축(고정 height ↔ flex-1)이 다르면 같은
+        // 처방이 조용히 다른 결과를 낼 수 있다는 것이 이 리뷰의 요지.
+        <div className="relative min-h-0 flex-1">
           <div
             ref={editorContentRef as RefObject<HTMLDivElement>}
             onDragEnter={onDragEnter}


### PR DESCRIPTION
## Summary
- story #2372 — #2757(갈래 지도 오프스크린 힌트)과 같은 클래스의 결함(AC7, 그 규격의 두 번째 적용 사례). 문서 편집기에 파일을 드래그하면 뜨는 「여기에 파일을 놓아 첨부」 오버레이가 스크롤하면 사라진다. `onDrop`은 wrapper에 그대로 붙어 있어 드롭 자체는 되지만(정보 결손이 아니라 발견 가능성 결손), 유일한 시각 신호가 죽어 있었다.
- 원인은 #2757과 동일: `editorContentRef` 하나가 `relative`(기준점)이자 동시에 `overflow-y-auto`(유일한 세로 스크롤 컨테이너)였다 — `absolute` 오버레이가 그 위에 얹혀 스크롤과 함께 그대로 밀렸다(유나 라이브 실측: `scrollTop=1200`, 문서의 11% 지점에서 가시비율 0%).
- **AC2(안쪽 `relative`를 지우지 않는다)** — 빈 문서 힌트·gutter "+"·삽입 메뉴는 콘텐츠/캐럿 좌표를 따라가는 것이 맞아 병이 아니다(유나 판정). 처방은 바깥에 non-clipping `relative` wrapper를 하나 더 두고 오버레이만 그 밖(스크롤 div의 형제)으로 옮기는 것 — `flow-canvas-resize-pane.tsx`(#2757)에서 이미 쓴 것과 같은 구조.
- 드래그 핸들러(`onDragEnter`/`onDragOver`/`onDragLeave`/`onDrop`)는 안쪽(실제 스크롤 컨테이너)에 그대로 둔다 — 오버레이가 `pointer-events-none`이라 그 아래로 이벤트가 그대로 통과해 드롭 자체는 구조 변경과 무관하게 동작한다(AC5).
- `doc-editor.tsx`엔 지금까지 테스트가 아예 없었다. 실제 Tiptap/ProseMirror는 jsdom이 못 주는 DOM 측정 API(`getClientRects` 등)를 요구해 전체 마운트가 안 돼, `useEditor`/`EditorContent`/`BubbleMenu`만 얇게 스텁하고(editor=null — 컴포넌트가 이미 처리하는 정상 분기) 이 결함의 관심사인 주변 JSX 구조(오버레이가 세로 스크롤에 클리핑되지 않는 성질)만 재는 회귀 테스트 2건을 새로 세웠다. mutation self-check로 옛 구조(오버레이가 스크롤 컨테이너 안에 있던 상태)로 되돌려 테스트가 실제로 빨개지는 것 확認 후 복원했다.
- AC6(`docs-client-layout.tsx:441·474` 무관 판정)은 이미 완료 상태(유나 2026-07-31 13:26Z)로 시작됐다 — 이 PR에서 별도 조치 없음.
- AC8(#2757이 남긴 틀린 문장 정정, `flow-multi-lane-canvas.test.tsx`)은 이 PR이 그 파일을 건드리지 않으므로 스토리 자체 규정("그 파일을 만지는 PR이 오면 그 PR에서 같이 고친다")에 따라 이번엔 손대지 않았다.

## Test plan
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm exec vitest run` — 337 files / 2457 tests 전부 PASS(신규 2건 포함, mutation self-check 완료)
- [x] `pnpm run build` — 성공(EXIT 0)
- [x] verify:* 6개 — 전부 OK, 신규 회귀 0건
- [ ] AC3(라이브 실측, scrollTop 0/400/1200 3지점 + dragenter만·drop 안 함) — 배포 후 재확認 예정
- [ ] AC5(실제 파일 드롭 회귀 없음) — 배포 후 재확認 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)