### PR TITLE
fix(#2375): dispatched Event payload lacks content — adapters drop before ack, permanent pending

### DIFF
--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -288,7 +288,15 @@ async def dispatch_notification(
                         sender_id=None,
                         recipient_id=member_row.id,
                         recipient_type="agent",
-                        payload={"title": title, "body": body, "event_type": event_type},
+                        # #2375: content 키 없으면 SSE 어댑터(fakechat/server.ts·hermes adapter.py)가
+                        # 둘 다 ack 前에 조용히 드롭해 영구 pending — E-EVENT-INJECT S1이 만든
+                        # "content를 SSE top-level로 노출"(agent_gateway.py _row_to_payload) 방지장치가
+                        # 여기(생성부)에서 그 키를 안 채워 안 맞물려 있었다. body 없으면 title로
+                        # 폴백(title은 필수 파라미터라 항상 non-empty) — 절대 빈 content로 두지 않는다.
+                        payload={
+                            "title": title, "body": body, "event_type": event_type,
+                            "content": body or title,
+                        },
                         status="pending",
                     )
                     db.add(event)

--- a/backend/scripts/expire_contentless_pending_dispatched_events.py
+++ b/backend/scripts/expire_contentless_pending_dispatched_events.py
@@ -1,0 +1,88 @@
+"""#2375 AC2 — 이미 쌓인 payload-content-키-없는 pending dispatched Event를 만료한다.
+
+배경: notification_dispatch.py의 payload 구성에 `content` 키가 없어(이 스토리가 고치는 그
+결함) fakechat/hermes 두 어댑터가 ack 前에 조용히 드롭 → 영구 pending으로 쌓였다(2026-07-31
+02:42Z~13:45Z, 20건+ 실측). 코드 fix는 **새로 생성되는** Event부터만 적용된다 — 이미 DB에 있는
+행의 payload JSON은 소급 변경되지 않는다.
+
+## AC2 판정: 재전송하지 않고 만료한다
+- 이 20건+은 story 상태변경 알림이고, PO가 오늘 채팅으로 담당 에이전트에게 이미 수동으로
+  전달했다(story #2375 본문 "오늘 하루 종일 그렇게 돌았다") — 정보 자체는 이미 도달했다.
+- payload를 소급 patch해 "재전송"하면, 이미 지나간 상태변경(수 시간~하루 전)이 배포 시점에
+  갑자기 도착하는 뒤늦은 알림이 된다 — 신선하지 않은 정보를 새 알림처럼 재주입하는 것.
+- 그대로 두면(아무 조치 없음) 기존 `POST /events/expire-stale`(30일 pending 컷오프)이 언젠가
+  회수하지만, 그 사이 매 SSE 재연결마다 backfill이 이 20+건을 계속 재전송 시도한다(이 스토리가
+  고친 AC5 ack-then-skip 경로를 아직 안 거친 구행 payload라 여전히 no-op이지만, 헛수고가 반복).
+- ⇒ **만료가 맞다.** 30일 컷오프를 기다리지 않고, "payload에 content 키가 없다"는 구조적
+  조건(=이 fix 이전에 생성됐다는 증거, 시간 기반 추측이 아님)으로 지금 바로 회수한다.
+
+## 스코프 — 정밀 타겟팅(시간 창이 아니라 구조 조건)
+```sql
+event_type = 'dispatched' AND status = 'pending' AND NOT (payload ? 'content')
+```
+`payload ? 'content'`는 fix 이후 생성되는 모든 새 dispatched Event(content 키 항상 존재)를
+자동으로 제외한다 — 시간 컷오프처럼 배포 타이밍에 의존하지 않는 멱등 조건.
+
+## 실행
+```
+DATABASE_URL=postgresql+asyncpg://... python -m scripts.expire_contentless_pending_dispatched_events [--dry-run] [--org-id UUID]
+```
+기본은 `--dry-run`(카운트만 출력, 미변경) — 실 만료는 `--apply` 명시 필요.
+
+⚠️ 디디(이 스토리 담당)는 dev DB 직접 접근이 막혀 있어(VPC private-IP, 세션 샌드박스에 라우트
+없음 — [[reference_prod_db_query]] dev 항목) 이 스크립트를 스스로 실행하지 못했다. PO/QA가
+dev에서 `--dry-run` 먼저 돌려 카운트를 대조(스토리가 실측한 20건+과 근사해야 함)한 뒤 `--apply`
+하는 것을 권한다.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+import uuid
+
+from sqlalchemy import select, text, update
+
+
+async def main() -> int:
+    if not os.environ.get("DATABASE_URL"):
+        print("DATABASE_URL 미설정", file=sys.stderr)
+        return 2
+
+    parser = argparse.ArgumentParser(
+        description="content 키 없는 pending dispatched Event 만료(#2375 AC2)"
+    )
+    parser.add_argument("--org-id", type=str, default=None, help="특정 org로 스코프(기본: 전 org)")
+    parser.add_argument("--apply", action="store_true", help="실제로 만료 처리(기본은 dry-run)")
+    args = parser.parse_args()
+
+    from app.core.database import async_session_factory
+    from app.models.event import Event
+
+    where = [
+        Event.event_type == "dispatched",
+        Event.status == "pending",
+        text("NOT (payload ? 'content')"),
+    ]
+    if args.org_id:
+        where.append(Event.org_id == uuid.UUID(args.org_id))
+
+    async with async_session_factory() as db:
+        if not args.apply:
+            rows = (await db.execute(select(Event.id, Event.org_id, Event.created_at).where(*where))).all()
+            print(f"[dry-run] 만료 대상 {len(rows)}건 (--apply로 실제 만료)")
+            for r in rows[:30]:
+                print(f"  event_id={r.id} org_id={r.org_id} created_at={r.created_at}")
+            if len(rows) > 30:
+                print(f"  ... 외 {len(rows) - 30}건")
+            return 0
+
+        result = await db.execute(update(Event).where(*where).values(status="expired"))
+        await db.commit()
+        print(f"만료 완료: {result.rowcount}건")
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/backend/tests/test_2375_dispatched_content_key_realdb.py
+++ b/backend/tests/test_2375_dispatched_content_key_realdb.py
@@ -1,0 +1,167 @@
+"""#2375 — dispatched Event이 영구 pending으로 쌓이는 근본원인 재현·검산. 실 PG.
+
+양성대조(AC4): 고치기 前엔 payload에 content 키가 없어(어댑터가 ack 前에 조용히 드롭하는
+정확한 그 조건) pending에 남고, 고친 뒤엔 content가 채워져 어댑터의 injectable 판정을
+통과함을 실측한다. 어댑터(fakechat/server.ts·hermes adapter.py) 자체를 이 테스트에서 구동하진
+않지만, 그 두 곳이 실제로 검사하는 조건(`content` 키 존재·non-empty)을 그대로 재사용해 판정한다
+— "어댑터가 볼 것"과 "이 테스트가 재는 것"이 같은 필드여야 재현력이 있다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project_agent(session):
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent", is_active=True)
+    session.add(agent)
+    await session.commit()
+    session.add(ProjectAccess(id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted"))
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "agent_id": agent.id}
+
+
+def _adapter_would_ack(payload: dict) -> bool:
+    """fakechat/server.ts:218-219·hermes adapter.py:296-299와 동형 판정 —
+    두 어댑터 모두 `(data.content ?? payload.content ?? '').strip()`가 비면 ack 前에 return한다.
+    이 헬퍼가 그 정확한 조건을 재사용해, "Event가 났다"가 아니라 "어댑터가 실제로 넘어갔을
+    자리인가"를 판정한다."""
+    content = (payload or {}).get("content") or ""
+    return bool(content.strip())
+
+
+@pytest.mark.anyio
+async def test_dispatched_event_payload_carries_content_agent_would_ack():
+    """핵심 회귀 케이스 — story 상태변경 dispatched가 agent 수신자에게 갈 때, 그 payload가
+    어댑터의 injectable 판정(content non-empty)을 통과해야 한다. 통과 못 하면 정확히 오늘
+    #2375 상태(pending 영구 적체)를 재현하는 것이다."""
+    from sqlalchemy import select
+
+    from app.models.event import Event
+    from app.services.notification_dispatch import dispatch_notification
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_agent(s)
+
+        async with Session() as s:
+            await dispatch_notification(
+                s, org_id=seeded["org_id"], event_type="story.status_changed",
+                target_member_ids=[seeded["agent_id"]],
+                title="스토리 상태 변경: [결함·BE] ...", body="ready-for-dev → in-progress",
+                source_project_id=seeded["project_id"],
+            )
+            await s.commit()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Event).where(
+                    Event.org_id == seeded["org_id"], Event.recipient_id == seeded["agent_id"],
+                    Event.event_type == "dispatched",
+                )
+            )).scalars().all()
+            assert len(rows) == 1
+            event = rows[0]
+            assert event.status == "pending", "이 단계에선 아직 pending이 정상(ack는 어댑터가 함)"
+
+            # AC4 핵심 단언 — 이게 실패하면 #2375가 재현된 것(어댑터가 이 payload를 조용히 드롭)
+            assert "content" in event.payload, (
+                f"payload에 content 키가 없다 — 어댑터가 ack 없이 드롭해 영구 pending. payload={event.payload}"
+            )
+            assert _adapter_would_ack(event.payload), (
+                f"content가 비어 어댑터 injectable 판정을 통과 못 한다. payload={event.payload}"
+            )
+            assert event.payload["content"] == event.payload["body"], (
+                "body가 있을 땐 content가 body를 그대로 반영해야 한다(title로 뭉개면 안 됨)"
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_dispatched_event_falls_back_to_title_when_body_missing():
+    """body가 없는 호출(현재도 실제로 존재 — body: str | None = None)에서도 content가
+    비지 않아야 한다. title은 필수 파라미터라 항상 non-empty."""
+    from sqlalchemy import select
+
+    from app.models.event import Event
+    from app.services.notification_dispatch import dispatch_notification
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_agent(s)
+
+        async with Session() as s:
+            await dispatch_notification(
+                s, org_id=seeded["org_id"], event_type="story.status_changed",
+                target_member_ids=[seeded["agent_id"]],
+                title="스토리 상태 변경: 제목만 있는 경우",
+                source_project_id=seeded["project_id"],
+            )
+            await s.commit()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Event).where(
+                    Event.org_id == seeded["org_id"], Event.recipient_id == seeded["agent_id"],
+                )
+            )).scalars().all()
+            assert len(rows) == 1
+            event = rows[0]
+            assert _adapter_would_ack(event.payload), (
+                f"body 없는 호출에서 content가 비었다 — title 폴백이 안 걸렸다. payload={event.payload}"
+            )
+            assert event.payload["content"] == event.payload["title"]
+    finally:
+        await engine.dispose()

--- a/connectors/hermes-sprintable-prod/adapter.py
+++ b/connectors/hermes-sprintable-prod/adapter.py
@@ -231,8 +231,35 @@ class SprintableProdAdapter(BasePlatformAdapter):
         if event_type not in INJECTABLE_EVENT_TYPES:
             return  # not a recommended inject type (e.g. status_changed FYI)
         content = (data.get("content") or payload.get("content") or "").strip()
+
+        # seq for ack + reconnect cursor — check SSE id, then several data locations.
+        # Computed before the content guard below so the empty-content branch
+        # (#2375 AC5) can still ack.
+        seq = 0
+        for cand in (ev_id, data.get("recipient_seq"), data.get("seq"), payload.get("recipient_seq")):
+            try:
+                if cand is not None and str(cand) != "":
+                    seq = int(cand)
+                    break
+            except (ValueError, TypeError):
+                continue
+        if ev_id:
+            self._last_event_id = ev_id
+
         if not content:
-            return  # nothing to inject (e.g. dispatched/system event without text)
+            # #2375 AC5 — a content-less injectable event is "nothing to show", not a
+            # delivery failure. Returning here without acking used to leave seq
+            # unconfirmed forever, so every reconnect re-sent the same event via
+            # backfill — exactly the flood the ack mechanism exists to prevent
+            # (root cause of the 20+ permanently-pending `dispatched` events,
+            # 2026-07-31~08-01, dev). The server now fills content for the one known
+            # producer (notification_dispatch.py); this stays as a safety net for
+            # any other injectable event that genuinely carries no text. Kept in
+            # sync with connectors/hermes-sprintable/adapter.py per this file's own
+            # docstring policy.
+            if seq:
+                await self._send_ack(seq)
+            return
 
         event_id = data.get("event_id") or payload.get("id") or ev_id or uuid.uuid4().hex
         if self._is_duplicate(event_id):
@@ -245,18 +272,6 @@ class SprintableProdAdapter(BasePlatformAdapter):
         sender = payload.get("sender") or data.get("sender") or {}
         sender_id = sender.get("id") or data.get("sender_id") or "sprintable"
         sender_name = sender.get("name") or sender_id
-
-        # seq for ack + reconnect cursor — check SSE id, then several data locations
-        seq = 0
-        for cand in (ev_id, data.get("recipient_seq"), data.get("seq"), payload.get("recipient_seq")):
-            try:
-                if cand is not None and str(cand) != "":
-                    seq = int(cand)
-                    break
-            except (ValueError, TypeError):
-                continue
-        if ev_id:
-            self._last_event_id = ev_id
 
         # AC2: model a Sprintable conversation as a shared Hermes *thread*, not a
         # regular group chat.  Hermes splits regular groups into per-sender

--- a/connectors/hermes-sprintable/adapter.py
+++ b/connectors/hermes-sprintable/adapter.py
@@ -295,8 +295,33 @@ class SprintableAdapter(BasePlatformAdapter):
             return  # not a recommended inject type (e.g. status_changed FYI)
         content = (data.get("content") or payload.get("content") or "").strip()
         images = _normalize_image_items(data.get("images") or payload.get("images"))
+
+        # seq for ack + reconnect cursor — check SSE id, then several data locations.
+        # Computed before the content/images guard below so the empty-content branch
+        # (#2375 AC5) can still ack.
+        seq = 0
+        for cand in (ev_id, data.get("recipient_seq"), data.get("seq"), payload.get("recipient_seq")):
+            try:
+                if cand is not None and str(cand) != "":
+                    seq = int(cand)
+                    break
+            except (ValueError, TypeError):
+                continue
+        if ev_id:
+            self._last_event_id = ev_id
+
         if not content and not images:
-            return  # nothing to inject (e.g. dispatched/system event without text/media)
+            # #2375 AC5 — a content-less injectable event is "nothing to show", not a
+            # delivery failure. Returning here without acking used to leave seq
+            # unconfirmed forever, so every reconnect re-sent the same event via
+            # backfill — exactly the flood the ack mechanism exists to prevent
+            # (root cause of the 20+ permanently-pending `dispatched` events,
+            # 2026-07-31~08-01). The server now fills content for the one known
+            # producer (notification_dispatch.py); this stays as a safety net for
+            # any other injectable event that genuinely carries no text/media.
+            if seq:
+                await self._send_ack(seq)
+            return
 
         event_id = data.get("event_id") or payload.get("id") or ev_id or uuid.uuid4().hex
         if self._is_duplicate(event_id):
@@ -309,18 +334,6 @@ class SprintableAdapter(BasePlatformAdapter):
         sender = payload.get("sender") or data.get("sender") or {}
         sender_id = sender.get("id") or data.get("sender_id") or "sprintable"
         sender_name = sender.get("name") or sender_id
-
-        # seq for ack + reconnect cursor — check SSE id, then several data locations
-        seq = 0
-        for cand in (ev_id, data.get("recipient_seq"), data.get("seq"), payload.get("recipient_seq")):
-            try:
-                if cand is not None and str(cand) != "":
-                    seq = int(cand)
-                    break
-            except (ValueError, TypeError):
-                continue
-        if ev_id:
-            self._last_event_id = ev_id
 
         # AC2: model a Sprintable conversation as a shared Hermes *thread*, not a
         # regular group chat.  Hermes splits regular groups into per-sender

--- a/packages/fakechat/server.ts
+++ b/packages/fakechat/server.ts
@@ -215,15 +215,8 @@ async function _onEvent(evType: string, evId: string, dataStr: string): Promise<
   // 있으면 세션에 주입되던 보안 갭을 닫는다.
   if (!isInjectableEventType(data, payload)) return
 
-  const content = ((data.content ?? payload.content ?? '') as string).trim()
-  if (!content) return
-
-  const eventId = (data.event_id ?? payload.id ?? evId ?? crypto.randomUUID()) as string
-  if (_isDuplicate(eventId)) return
-
-  if (evId) _lastEventId = evId
-
-  // recipient_seq for ack — data 최상위 우선, payload fallback
+  // recipient_seq for ack — data 최상위 우선, payload fallback. content 체크보다 먼저 계산해야
+  // 아래 빈-content 분기에서도 ack할 수 있다(#2375 AC5).
   let seq = 0
   for (const cand of [data.recipient_seq, payload.recipient_seq]) {
     const n = Number(cand)
@@ -232,6 +225,23 @@ async function _onEvent(evType: string, evId: string, dataStr: string): Promise<
       break
     }
   }
+
+  const content = ((data.content ?? payload.content ?? '') as string).trim()
+  if (!content) {
+    // #2375 AC5 — 내용 없는 injectable 이벤트는 "전달 실패"가 아니라 "보일 것 없음"이다.
+    // 예전엔 여기서 ack 없이 return해 seq가 영원히 미확인으로 남았다 — 재연결마다 backfill이
+    // 같은 이벤트를 다시 보내는데, 그 backfill flood를 막으려던 ack 메커니즘(주석 참조) 자체가
+    // 이 경로에서만 무력화돼 있었다(2026-07-31~08-01 dispatched 20건+ 영구 pending의 근본원인).
+    // 서버가 content를 채운 뒤(notification_dispatch.py)로도 이 분기는 남는다 — 어떤 injectable
+    // event가 정말로 텍스트를 안 실은 채 오는 경우의 안전망.
+    if (seq > 0) await _sendAck(seq)
+    return
+  }
+
+  const eventId = (data.event_id ?? payload.id ?? evId ?? crypto.randomUUID()) as string
+  if (_isDuplicate(eventId)) return
+
+  if (evId) _lastEventId = evId
 
   const conversationId = (
     payload.conversation_id ??


### PR DESCRIPTION
## Summary

`dispatched` (and every other event routed to an agent without a webhook — see AC6) Event rows were getting created with a payload missing the `content` key. Both consuming adapters (fakechat, hermes) return before their ack call when content is empty, so these events never got acked, never got marked delivered, and kept re-arriving via backfill on every reconnect — forever pending. 20+ affected rows accumulated in dev between 02:42Z and 13:45Z on 2026-07-31.

## AC3 — one fix site

`notification_dispatch.py`'s agent-recipient `Event.payload` was `{"title", "body", "event_type"}`. `agent_gateway.py`'s `_row_to_payload()` already exposes `payload.content` at the SSE top level specifically so connectors can inject it (comment: *"E-EVENT-INJECT S1: content를 SSE top-level로 노출 → connector 드롭 방지"*) — the safety net existed, the producer just never fed it.

`dispatch_notification()` is the single choke point for ~20 call sites across the backend (tasks/sprints/stories/gates/docs/visual_artifacts/team_members/goal_events/workflow_*/story_assignee_events/story_status_events — full list via `grep -rn "dispatch_notification(" backend/app`), and it hardcodes `event_type="dispatched"` on the DB row for **every** agent recipient regardless of the caller's real `event_type` parameter. So this one payload fix covers all of them, not just story-status-change — no per-adapter fallback needed (that would have been the "사본" AC3 explicitly rules out).

```python
payload={
    "title": title, "body": body, "event_type": event_type,
    "content": body or title,   # title is required, so this is never empty
},
```

## AC4 — positive control (real PG, alembic-migrated — not create_all)

`team_members` is a VIEW in the real schema; `Base.metadata.create_all()` makes it an empty plain table instead, silently producing 0 rows for every agent-recipient test. Built a scratch DB via `alembic upgrade head` (pgvector already built locally for pg@16 from a prior session) to get a schema that actually matches prod/dev.

- **Before fix**: `2/2` new tests fail, reproducing the exact reported payload shape — `{'body': ..., 'title': ..., 'event_type': ...}`, no `content` key.
- **After fix**: `6/6` pass (2 new + the 4-test mute/webhook sibling suite, zero regression).
- Broader sweep against the same freshly-migrated DB: `test_04e059e5` (6), `test_2216` ×2 (2), `test_ccbcd9da` (3), `test_1934` (2) — all pass.
- ⚠️ Hit and diagnosed a known, pre-existing hazard mid-verification: some realdb test file's `create_all`/`drop_all` corrupted my *shared* scratch DB when I batched files together, producing 4+2 **false** regression failures. Traced it to exactly the class of bug [[project_loop_ledger_test_drops_shared_schema]] already documents, confirmed by recreating the DB fresh and re-running each file in isolation (all green). Not caused by this PR's diff — added an addendum to that memory with today's instance for the next person who hits it.

## AC5 — ack-on-empty-content design judgment

Judged the current "return before ack" behavior **wrong**. It treats "nothing to show" as a delivery failure worth retrying forever, which defeats the exact backfill-flood protection the ack mechanism's own comment says it exists for (`fakechat/server.ts:10`: *"ack: 주입 후 POST .../ack {seq} — backfill flood 방지"*).

Changed `fakechat/server.ts`, `connectors/hermes-sprintable/adapter.py`, and `connectors/hermes-sprintable-prod/adapter.py` (the second is a documented-intentional standalone clone — its own docstring says *"Keep behavioural changes in sync with the dev adapter"*, so both get the identical fix) to compute `seq` **before** the content/images check, and ack-then-skip-injection instead of silently returning when content is empty. This is a safety net, not the primary fix — AC3 means no current producer should hit this branch anymore, but it stops the next content-less injectable event (if one ever appears — see AC6) from repeating today's exact failure mode.

No pre-existing test harness for either adapter file (`packages/fakechat` has no test runner beyond an unrelated port-resolution smoke script; `connectors/hermes-sprintable` has none at all). Verified by: `bun build --no-bundle` transpile success on `server.ts`, `py_compile` + `ruff check` (0 new lint findings near the edited lines — the 31 pre-existing findings ruff reports are all elsewhere in the file) on both adapter.py files, and careful manual trace of both branches (empty-content → ack-then-return; non-empty → unchanged existing path, `seq` computed once, no dangling references from the reorder).

## AC2 — the ~20 already-stuck events

**Chose expire, not resend.** PO already relayed these manually via chat today (per the story: *"오늘 하루 종일 그렇게 돌았다"*) — the information already reached its recipients. Resending now, hours later, would be a stale re-notification of something already acted on, not a fix. Leaving them alone means every SSE reconnect keeps re-attempting backfill delivery on payloads that (pre-fix) still lack `content` — wasted work, though now harmless under AC5's ack-then-skip.

Wrote `backend/scripts/expire_contentless_pending_dispatched_events.py`, scoped by the **structural** condition `event_type='dispatched' AND status='pending' AND NOT (payload ? 'content')` rather than a time window — self-selects exactly the pre-fix rows (every event created after this PR always has `content`), no cutoff-date guessing. Defaults to `--dry-run`; `--apply` required for the real update. Smoke-tested against a local seed (1 contentless + 1 content-having row in the same org) — dry-run correctly identifies exactly the 1 contentless row, `--apply` expires only that one, the content-having row stays untouched.

⚠️ **I could not run this against dev myself.** Dev Cloud SQL is private-IP-only with no VPC route from this session's sandbox (documented blocker). PO/QA should `--dry-run` in dev first, sanity-check the count against the ~20 already measured via `poll_events`, then `--apply`.

## AC1 — live delivery (partial — flagging the gap honestly)

Verified the mechanism end-to-end by code reading (both adapters' exact drop condition) and the real-PG integration test above (server payload construction). **Could not verify true live injection into a running agent session.** This agent's own delivery channel is an active webhook, which skips the Event/poll path entirely (`event_skip_member_ids` in `notification_dispatch.py`) — I am structurally the wrong test subject for this specific path, and dev DB access is blocked from this sandbox regardless. Needs Qadir (who had the tooling/access to observe the original 20+ stuck rows) or PO to confirm live, post-merge: change a story's status for an agent that consumes via fakechat/hermes (not webhook), and watch it actually arrive rather than just flip to `status=delivered`.

## AC6 — what this doesn't cover

`INJECTABLE_EVENT_TYPES` (single source `connectors/sdk/sprintable_sse.py`) has 9 members:
```
dispatched                        ← fixed (this PR)
story_assigned                    ← already fine, payload includes "content" (story_assignee_events.py:157)
conversation.message_created      ← already fine, _msg_payload() includes msg.content (conversations.py:405)
conversation:mention              ← same _msg_payload(), same
kickoff / review_request /
qa_request / deploy_request /
handoff                           ← 0 current Event-creation call sites (exact `event_type="..."` grep,
                                     zero hits across backend/) — allowlisted for future workflow-line
                                     use, moot today. Would need this exact same content-fallback
                                     treatment the moment a real producer shows up.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
