### PR TITLE
fix(web,backend): retire dead /memos notification link + EventType fossils (story #2379)

### DIFF
--- a/apps/web/scripts/verify-no-orphan-resource-routes.test.ts
+++ b/apps/web/scripts/verify-no-orphan-resource-routes.test.ts
@@ -114,7 +114,7 @@ describe('AC4 — 네 방향 mutation (단위테스트 고정)', () => {
 });
 
 // AC7 — 실제 저장소의 첫 검거를 재현한다(지어낸 픽스처가 아니라 실제 파일 경로로).
-describe('AC7 — 실제 저장소 첫 스캔의 검거 2건(GRANDFATHER_BASELINE)이 진짜인지 확認', () => {
+describe('AC7 — 실제 저장소 첫 스캔의 검거(GRANDFATHER_BASELINE)이 진짜인지 확認', () => {
   it('mockups — [ws]/[proj]/mockups 라우트가 있고 KNOWN 진입점 목록엔 없다', () => {
     // app-sidebar.tsx/command-palette.tsx/more/page.tsx 어디에도 resourceLink('mockups')·
     // resourceHref('mockups')·literal '/mockups'가 없음을 실제 파일 3개로 확認(2026-08-01 grep 전수).
@@ -133,10 +133,13 @@ describe('AC7 — 실제 저장소 첫 스캔의 검거 2건(GRANDFATHER_BASELIN
     expect([...composed, ...literal]).not.toContain('mockups');
   });
 
-  it('GRANDFATHER_BASELINE 크기는 정확히 2다(3번째부터는 PO 승인 없이 조용히 못 들어온다)', () => {
-    expect(GRANDFATHER_BASELINE.size).toBe(2);
+  // story #2379(2026-08-01) — entryWithoutRoute:memos는 실제로 고쳐져 baseline에서 빠졌다
+  // (notification-navigation.ts memo 분기 제거 + backend EventType 화석 제거). routeWithoutEntry:
+  // mockups만 남는다(#2378 별도 판정 대기).
+  it('GRANDFATHER_BASELINE 크기는 정확히 1이다(새 항목은 PO 승인 없이 조용히 못 들어온다)', () => {
+    expect(GRANDFATHER_BASELINE.size).toBe(1);
     expect(GRANDFATHER_BASELINE.has('routeWithoutEntry:mockups')).toBe(true);
-    expect(GRANDFATHER_BASELINE.has('entryWithoutRoute:memos')).toBe(true);
+    expect(GRANDFATHER_BASELINE.has('entryWithoutRoute:memos')).toBe(false);
   });
 });
 

--- a/apps/web/scripts/verify-no-orphan-resource-routes.ts
+++ b/apps/web/scripts/verify-no-orphan-resource-routes.ts
@@ -61,9 +61,15 @@
  *     ⭐같은 파일의 바로 아래(`task` 케이스) 주석이 이미 "`/boards`(오탈자·복수형)라 알림
  *     클릭이 항상 무효였다"는 동형 사고를 한 번 고친 전례를 남기고 있다 — `memo`가 같은
  *     클래스의 두 번째 사례로 보인다.
- * ⛔AC6에 따라 이 스토리는 위 2건을 «고치지 않는다» — GRANDFATHER_BASELINE에 이유와 함께
- * 얼려 두고 별도 triage로 넘긴다(#2367의 GRANDFATHER_BASELINE·40건과 동일 관례). PO 승인
- * 없이 41번째(3번째) 항목이 조용히 추가되지 않게 COUNT_TEST로 크기(2)를 고정한다.
+ * ⛔AC6에 따라 이 스토리(#2376)는 위 2건을 «고치지 않는다» — GRANDFATHER_BASELINE에 이유와
+ * 함께 얼려 두고 별도 triage로 넘긴다(#2367의 GRANDFATHER_BASELINE·40건과 동일 관례). PO
+ * 승인 없이 조용히 추가되지 않게 COUNT_TEST로 크기를 고정한다.
+ *
+ * ⭐후속(story #2379, 2026-08-01) — `entryWithoutRoute: memos` 정리 완료. notification-
+ * navigation.ts의 memo 분기 제거(기본 fallback href:null로 흡수) + backend EventType.
+ * memo_created/memo_replied 화석 제거. baseline에서 뺐다 — staleness 체크가 「고쳐졌는데
+ * 목록에 남음」을 잡아 주는 자리라 여기서 그 값이 실증된다. `routeWithoutEntry: mockups`는
+ * #2378(별도, mockups=E-CANVAS 전신 화면 — 진입점 0이 의도인지 PO 판단 대기)로 남아 있다.
  */
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
@@ -114,13 +120,13 @@ export const RENAMED_RESOURCE_ALIASES = new Set<string>(['epics', 'glance', 'boa
 
 export const EXEMPT_TARGETS = new Set<string>([...KNOWN_NON_PROJECT_ROUTES, ...RENAMED_RESOURCE_ALIASES]);
 
-// ── GRANDFATHER_BASELINE — 첫 스캔(2026-08-01)이 잡은 기존 채무 2건. AC6: 이 스토리는 안
-// 고친다. 41번째(3번째) 항목부터는 PO 승인 없이 조용히 추가되지 않는다(#2367 관례 재사용) —
-// GRANDFATHER_BASELINE_COUNT_TEST가 크기 2를 고정, staleness 체크가 "고쳐졌는데 목록에
-// 남은" 항목을 잡는다.
+// ── GRANDFATHER_BASELINE — 첫 스캔(2026-08-01)이 잡은 기존 채무. AC6: #2376 스토리는 안
+// 고친다. 새 항목부터는 PO 승인 없이 조용히 추가되지 않는다(#2367 관례 재사용) —
+// GRANDFATHER_BASELINE_COUNT_TEST가 크기를 고정, staleness 체크가 "고쳐졌는데 목록에
+// 남은" 항목을 잡는다. `entryWithoutRoute:memos`는 story #2379(2026-08-01)가 실제로
+// 고치고 여기서 뺐다 — staleness 체크가 그 자리에서 값을 한다.
 export const GRANDFATHER_BASELINE = new Set<string>([
   'routeWithoutEntry:mockups',
-  'entryWithoutRoute:memos',
 ]);
 
 // ── 라우트 실존 — [ws]/[proj]/<resource>/page.tsx 직접 존재 ────────────────────
@@ -241,7 +247,7 @@ function main(): void {
     console.log(`  ⚠️ grandfather로 등재됐으나 이번 스캔에서 안 걸린(고쳐졌다면 목록에서 빼도 되는): ${staleBaseline.join(', ')}`);
   }
   if (baselineHit.size > 0) {
-    console.log(`\n📋 grandfather(#2376 최초 스캔 2건 — AC6: 이 스토리는 안 고친다): ${[...baselineHit].join(', ')}`);
+    console.log(`\n📋 grandfather(#2376 최초 스캔·#2379 triage — AC6: 이 스토리는 안 고친다): ${[...baselineHit].join(', ')}`);
   }
 
   if (failed) {

--- a/apps/web/src/services/notification-navigation.test.ts
+++ b/apps/web/src/services/notification-navigation.test.ts
@@ -34,9 +34,8 @@ function createDbStub() {
 }
 
 describe('attachNotificationHrefs', () => {
-  it('builds memo and doc comment deep links with safe docs fallback', async () => {
+  it('builds doc comment deep links with safe docs fallback', async () => {
     const notifications = await attachNotificationHrefs(createDbStub(), [
-      { id: 'notif-1', reference_type: 'memo', reference_id: 'memo-1' },
       { id: 'notif-2', reference_type: 'doc_comment', reference_id: 'comment-1' },
       { id: 'notif-3', reference_type: 'doc_comment', reference_id: 'missing-comment' },
       { id: 'notif-4', reference_type: 'doc', reference_id: 'doc-2' },
@@ -44,11 +43,23 @@ describe('attachNotificationHrefs', () => {
     ]);
 
     expect(notifications).toEqual([
-      expect.objectContaining({ id: 'notif-1', href: '/memos?id=memo-1' }),
       expect.objectContaining({ id: 'notif-2', href: '/docs/ops-guide?commentId=comment-1' }),
       expect.objectContaining({ id: 'notif-3', href: '/docs' }),
       expect.objectContaining({ id: 'notif-4', href: '/docs/runbook' }),
       expect.objectContaining({ id: 'notif-5', href: null }),
+    ]);
+  });
+
+  // story #2379 — '/memos' 라우트가 앱 어디에도 없어(#2376 가드 실측) 죽은 링크였다. memo
+  // 분기를 지운 뒤 다른 미매치 reference_type과 동일하게 href: null로 떨어지는 것을 고정한다
+  // (기본 fallback 재사용 — 새 결함이 아님을 회귀가드로 남긴다).
+  it('falls back to href: null for the retired memo notification path (story #2379)', async () => {
+    const notifications = await attachNotificationHrefs(createDbStub(), [
+      { id: 'notif-9', reference_type: 'memo', reference_id: 'memo-1' },
+    ]);
+
+    expect(notifications).toEqual([
+      expect.objectContaining({ id: 'notif-9', href: null }),
     ]);
   });
 

--- a/apps/web/src/services/notification-navigation.ts
+++ b/apps/web/src/services/notification-navigation.ts
@@ -65,9 +65,11 @@ export async function attachNotificationHrefs<T extends NotificationReference>(
       return { ...notification, href: null };
     }
 
-    if (notification.reference_type === 'memo') {
-      return { ...notification, href: `/memos?id=${referenceId}` };
-    }
+    // story #2379 — '/memos' 라우트는 앱 어디에도 없다(#2376 가드 실측, 죽은 링크). memo 기능
+    // 자체는 SaaS에서 살아 있지만(memo-assignment-dispatch.ts·memo-reply-webhook-dispatch.ts가
+    // 직접 webhook으로 발송), 인앱 notifications 테이블(reference_type='memo') 생성 콜사이트는
+    // 0건이라(backend 전수 grep) 이 분기는 도달 불가였다. 지운 뒤엔 아래 기본 fallback(href:
+    // null)으로 떨어진다 — 다른 미매치 reference_type과 동일한 처리라 새 결함이 아니다.
 
     if (notification.reference_type === 'task') {
       // story a539c649 S3d 그라운딩 중 발견: '/boards'(오탈자·복수형)+task_id 자체 누락이라

--- a/backend/app/models/event.py
+++ b/backend/app/models/event.py
@@ -14,8 +14,10 @@ import enum
 
 
 class EventType(str, enum.Enum):
-    memo_created = "memo_created"
-    memo_replied = "memo_replied"
+    # story #2379 — memo_created/memo_replied 제거(2026-08-01). 전수 grep(프로덕션+테스트)
+    # 결과 `EventType.memo_created`/`EventType.memo_replied` 속성 접근이 어디에도 없었다 —
+    # events.event_type 컬럼 자체가 Text(native enum 아님)라 역직렬화 경로도 없다. 살아 있는
+    # memo 기능(SaaS webhook 발송 등)은 이 enum을 거치지 않으므로 영향 없음.
     dispatched = "dispatched"
     status_changed = "status_changed"
 

--- a/backend/app/repositories/bridge_inbound.py
+++ b/backend/app/repositories/bridge_inbound.py
@@ -84,8 +84,16 @@ class BridgeInboundRepository:
         metadata: "dict[str, Any]",
         assigned_to: "uuid.UUID | None",
     ) -> str:
-        # Memos are retired (E-MEMO-RETIRE S3-3); channels should use conversation_id mapping.
-        raise NotImplementedError("Memo creation is retired. Configure conversation_id in channel mapping.")
+        # story #2379 AC5 (2026-08-01) — scoped per PO: this "retired" claim is about ONE
+        # narrow path only, inbound bridge/channel message → memo routing (E-MEMO-RETIRE
+        # S3-3; channels should use conversation_id mapping instead). Memo itself remains a
+        # live SaaS feature elsewhere (assignment/reply/webhook dispatch, agent-execution-loop
+        # HITL) — an unscoped reading of this comment led #2379 to briefly (and wrongly)
+        # conclude the whole memo feature was retired. Don't widen this without re-checking
+        # apps/web/src/services/memo*.ts and docs/oss-memo-repository.md first.
+        raise NotImplementedError(
+            "Inbound bridge→memo routing is retired for this channel. Configure conversation_id in channel mapping."
+        )
 
     async def find_fallback_author(self, org_id: uuid.UUID, project_id: uuid.UUID) -> uuid.UUID | None:
         for member_type in ("agent", "human"):


### PR DESCRIPTION
## Summary
- #2376's guard first scan caught `entryWithoutRoute: memos` — `notification-navigation.ts` links `memo`-type notifications to `/memos?id=...`, a route that doesn't exist anywhere.
- Base is `develop` (learned from the #2762 mixup earlier today).

## AC1 — safe to remove?
Yes. The memo branch is removed; it now falls through to the same `href: null` default already used for every other unmatched `reference_type` — not a new failure mode, just the pre-existing fallback.

## AC2/AC3 — EventType.memo_created/memo_replied enum fate
Removed. Zero attribute-access usages anywhere (`grep -rn "EventType\.memo"` across production + tests = empty), and `events.event_type` is a plain `Text` column (not enum-bound) — no deserialization risk. AC3 (DB row count) — not measured in this session (no DB access); PO offered to count via their Cloud Run job.

## ⚠️Correction made during this investigation
I initially told PO "the memo feature itself is retired" based on `bridge_inbound.py:87`'s comment — that was an overgeneralization. Full AC4 sweep found the memo *feature* is alive in SaaS: `apps/web/src/services/memo.ts` (real repo via SaaS overlay), `memo-assignment-dispatch.ts`, `memo-reply-webhook-dispatch.ts`, `agent-execution-loop` HITL, and all three outbound dispatchers (slack/discord/teams) actively call `MemoService`. Only the **in-app `notifications` table path** (`reference_type='memo'`) has zero creation call-sites — memo notifications go out via direct webhook dispatch, never touching the bell/`notifications` table that `notification-navigation.ts` serves.

Per PO's follow-up AC5: scoped `bridge_inbound.py:87`'s comment (and the exception message) so it's clear the "retired" claim covers only the inbound-bridge→memo-routing sub-path, not the whole feature — the unscoped wording is exactly what led this investigation astray initially.

## AC4 — full sweep of the name "memos"
Routing (2 files touched: `notification-navigation.ts` FE branch, `event.py` enum) · alembic (0011/0028, left alone — historical, correctly scoped already) · i18n (no `memo*` keys in `ko.json`/`en.json` under this notification path) · live SaaS memo subsystem (10+ files, all left untouched — out of scope, confirmed live).

## AC6 — what this doesn't catch
- Didn't touch `EventSourceEntityType.memo` (a different, also-unused enum) — out of this story's stated AC2 scope (which named only `EventType.memo_created`/`memo_replied`).
- DB row count for pre-existing `memo_created`/`memo_replied` `Event` rows — not measured here (no DB access).

## Test plan
- [x] `pnpm --filter web verify:no-orphan-resource-routes` — exit 0. `entryWithoutRoute:memos` is gone (literal hit count 77→76); `routeWithoutEntry:mockups` (#2378, separate) still correctly grandfathered.
- [x] `pnpm --filter web exec vitest run scripts/verify-no-orphan-resource-routes.test.ts src/services/notification-navigation.test.ts` — 20/20 passed (new test locks the `href: null` fallback for retired memo notifications).
- [x] `pnpm --filter web exec eslint` / `tsc --noEmit` on all changed files — clean.
- [x] `uv run python -c "from app.models.event import EventType; print(list(EventType))"` — imports cleanly with only `dispatched`/`status_changed` left.
- [x] `uv run pytest --collect-only` on the 5 backend test files that reference the `memo_created`/`memo_replied` *strings* — all 41 tests still collect (they use plain string literals as generic fixture data, never `EventType.memo_created` attribute access, so unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)