### PR TITLE
fix(#2382, P0 RED): pin mcp<2.0.0 — unbounded dependency broke uvx sprintable

### DIFF
--- a/.github/workflows/mcp-pypi-smoke.yml
+++ b/.github/workflows/mcp-pypi-smoke.yml
@@ -1,0 +1,60 @@
+name: sprintable-mcp PyPI smoke test
+
+# story #2382 (P0 RED, 2026-08-01): mcp SDK 2.0.0 broke `uvx sprintable` for every new
+# install starting 2026-07-28 (FastMCP renamed to MCPServer, mcp.server.fastmcp module
+# path removed) — and nothing caught it for 4 days, because our CI tests this repo's local
+# source, never the artifact PyPI actually serves users. This job closes exactly that gap:
+# it installs the real published package from PyPI (uvx, not a local checkout) and runs it
+# far enough to prove the whole import chain resolves — no live credentials needed, no
+# hang, because sprintable_mcp/__main__.py:main() exits early with a friendly message the
+# moment SPRINTABLE_API_URL is unset, *after* every import in the chain has already
+# succeeded. Reaching that message is proof positive the package installs and imports
+# cleanly; a traceback anywhere before it is proof it doesn't.
+#
+# Positive control (verified 2026-08-01, story #2382 PR): this exact check told the broken
+# state (mcp>=1.8.0 unbounded → resolves mcp 2.0.0 → ModuleNotFoundError, no message match)
+# apart from the fixed state (mcp>=1.8.0,<2.0.0 → resolves mcp 1.x → friendly message,
+# match) — both reproduced against real installs (PyPI for broken, a local wheel build for
+# fixed) before this workflow was written. See the PR body for the transcripts.
+
+on:
+  schedule:
+    # mcp SDK majors aren't frequent — daily is enough to catch drift within a day, not
+    # the 4-day blind spot this story found.
+    - cron: "0 3 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  smoke-test:
+    name: uvx sprintable (real PyPI, no cache) reaches its own config guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Run uvx sprintable from PyPI with a fully clean environment
+        id: run
+        run: |
+          set +e
+          # env -i: don't let ambient CI env vars accidentally supply SPRINTABLE_API_URL/
+          # AGENT_API_KEY — this must fail at main()'s own config check, never attempt a
+          # live network call. --no-cache: this run must reflect what a brand-new install
+          # gets right now, not whatever uv already has cached on this runner.
+          output=$(env -i PATH="$PATH" HOME="$HOME" uvx --no-cache sprintable 2>&1)
+          code=$?
+          echo "$output"
+          {
+            echo "output<<SMOKE_EOF"
+            echo "$output"
+            echo "SMOKE_EOF"
+            echo "exit_code=$code"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Assert the import chain actually resolved
+        run: |
+          if echo "${{ steps.run.outputs.output }}" | grep -q "SPRINTABLE_API_URL environment variable required"; then
+            echo "uvx sprintable resolves and reaches its own config guard — the published package installs and imports cleanly."
+            exit 0
+          fi
+          echo "::error::uvx sprintable did NOT reach its own config-check (see the log above for the actual failure) — the published PyPI package is broken for fresh installs. This is exactly story #2382's failure mode; check for an unbounded/newly-incompatible dependency."
+          exit 1

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,7 +19,11 @@ dependencies = [
     "alembic>=1.13.0",
     "psycopg2-binary>=2.9.0",
     "slowapi>=0.1.9",
-    "mcp>=1.8.0",  # E-MCP-HTTP: streamable-http floor(sprintable-mcp-dev 서비스가 동 backend 이미지 사용)
+    # E-MCP-HTTP: streamable-http floor(sprintable-mcp-dev 서비스가 동 backend 이미지 사용).
+    # story #2382: <2.0.0 상한 — Docker 빌드는 uv sync --frozen(uv.lock 고정, 현재 1.27.1)이라
+    # 지금 당장 위험하진 않지만, 언젠가 uv lock --upgrade로 lock을 재생성하면 이 declared range가
+    # 그대로 mcp 2.0.0(FastMCP→MCPServer 개명)까지 열어 호스티드 MCP를 똑같이 깨뜨린다.
+    "mcp>=1.8.0,<2.0.0",
     "resend>=2.0.0",
     "google-analytics-data>=0.18.0",
     # R2 채팅 첨부 AI 컨텍스트(9d130c01): GCS 서비스계정 read + 문서 텍스트 추출

--- a/backend/sprintable_mcp/pyproject.toml
+++ b/backend/sprintable_mcp/pyproject.toml
@@ -6,10 +6,11 @@ build-backend = "hatchling.build"
 # OB-PUBLISH(f5e1742d): distribution name = "sprintable" (선생님 PyPI project 등록값·uvx sprintable
 # 한 줄 정합). 내부 모듈명은 sprintable_mcp 그대로(dist명≠모듈명 — hatch sources remap 아래 유지).
 name = "sprintable"
-# 0.1.1 (2026-07-27): story #2166 픽스가 PyPI 에 안 나가 사용자는 계속 옛 에러를 보고 있었다.
-# main 에서 릴리즈(sprintable-mcp-v0.1.1 · PyPI 05:55:20)했으므로 develop 도 같은 값으로 맞춘다
-# — 브랜치별로 버전이 갈리면 다음 사람이 "지금 나간 게 무엇인지"를 못 읽는다.
-version = "0.1.1"
+# 0.1.2 (2026-08-01, story #2382 · P0 RED): mcp 2.0.0이 07-28 PyPI에 올라오며 FastMCP→MCPServer
+# 개명·mcp.server.fastmcp→mcp.server.mcpserver 모듈 경로 변경 — 상한 없던 "mcp>=1.8.0"이 그 순간부터
+# `uvx sprintable`을 100% 깨뜨렸다(신규 설치자 전원, 나흘간 미발견). PO 판정(RED 상황 — 빠른 복구가
+# 지배): 2.0 이관은 별건으로 미루고 지금은 상한만 넣어 즉시 복구한다.
+version = "0.1.2"
 description = "Sprintable MCP server — BYO agent toolset over the Sprintable API (stdio). No repo clone required."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -19,7 +20,9 @@ keywords = ["mcp", "sprintable", "agent", "model-context-protocol"]
 dependencies = [
     # E-MCP-HTTP S1: streamable-http floor(mcp 1.8+·run_streamable_http_async/transport='streamable-http')
     # — fresh 빌드가 구버전 받아 http 미지원되는 footgun 방지(S2 Cloud Run 빌드 보증). 설치본 1.27.1 검증완.
-    "mcp>=1.8.0",
+    # story #2382: 상한 <2.0.0 — mcp 2.0.0이 FastMCP→MCPServer로 개명해 server.py의
+    # `from mcp.server.fastmcp import FastMCP`를 ModuleNotFoundError로 깨뜨린다. 2.0 이관은 별건.
+    "mcp>=1.8.0,<2.0.0",
     "httpx>=0.27",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",


### PR DESCRIPTION
## Summary — P0 RED

`mcp` SDK 2.0.0 hit PyPI 2026-07-28 (renamed `FastMCP`→`MCPServer`, moved `mcp.server.fastmcp`→`mcp.server.mcpserver`). Our `sprintable_mcp` package declared `"mcp>=1.8.0"` with no upper bound, and `uvx` always resolves latest-at-invocation — every fresh `uvx sprintable` since 07-28 has pulled 2.0.0 and died with `ModuleNotFoundError` at import time. 100% failure for new installs, silent from the user's side (host CLIs report the MCP server as "enabled" while the tool list stays empty).

## AC1 — pin, PO's call (RED: fast recovery, no menu)

`backend/sprintable_mcp/pyproject.toml`: `mcp>=1.8.0` → `mcp>=1.8.0,<2.0.0`, version `0.1.1` → `0.1.2` (PyPI needs a new version to publish). Migrating to `mcp` 2.0 is explicitly deferred to a separate story per PO decision — RED situations don't get a menu.

## AC3 — positive control, clean environment

Two independent fresh venvs, no shared cache:
- **Before** (real PyPI `sprintable==0.1.1`): `pip install --no-cache-dir sprintable` resolves `mcp==2.0.0` → `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`, exact match to the reported traceback.
- **After** (local `0.1.2` build via `uv build`): fresh venv install resolves `mcp==1.29.0` → clean import through the full `sprintable_mcp.server` chain. Cross-verified with `uvx --from <local-wheel>` directly (the actual user-facing invocation, not just pip).

Caught and corrected a mistake mid-verification: an early run of the "after" check leaked this session's own `SPRINTABLE_API_URL`/`AGENT_API_KEY` env vars and made a live call to dev backend before I noticed. Redone with `env -i` — clean separation now. Final signal:
```
broken: exit 1, traceback, no match on "SPRINTABLE_API_URL environment variable required"
fixed:  exit 1, that exact friendly message, match
```
That discriminating signal is exactly what AC4's new CI check asserts on.

## AC4 — CI checks the actual published artifact, with its own positive control

New `.github/workflows/mcp-pypi-smoke.yml`: daily cron + `workflow_dispatch`, runs `uvx --no-cache sprintable` against real PyPI with `env -i` (fully clean — must fail at the config-guard, never attempt a live call) and asserts the run reaches `sprintable_mcp/__main__.py`'s own "SPRINTABLE_API_URL required" exit path. Reaching that message proves the whole import chain resolved without needing credentials or blocking on stdio (`main()` exits before any network touch).

Per Pedro's follow-up ask, this check's discriminating power was verified *before* being written, not assumed — the AC3 transcripts above are that verification (broken input → no match, fixed input → match). This directly closes the "4 days, nobody knew" gap: existing CI tests this repo's local source, never the artifact PyPI actually serves.

## AC5 — swept for the same disease elsewhere

| Artifact | Published? | Unbounded dep? | Status |
|---|---|---|---|
| `backend/sprintable_mcp` (PyPI `sprintable`) | yes, live | `mcp>=1.8.0` | **broken — fixed this PR** |
| `backend` main app (Docker, backs hosted MCP too) | Docker image | `mcp>=1.8.0` | latent only — `Dockerfile` runs `uv sync --frozen`, installs exactly what `uv.lock` pins (`mcp==1.27.1`) regardless of the declared range — **fixed anyway**, so a future `uv lock --upgrade` can't reopen this |
| `packages/cli` (npm `sprintable`) | yes, live (`0.1.0`/`0.1.1` on npm) | no — `^` caret ranges (`^14.0.0` etc.) | checked, safe by existing convention — npm caret already excludes major bumps, unlike Python's bare `>=` |
| `connectors/opencode-sprintable` | no — 404 on npm registry | `peerDependencies` `>=1.0.0` unbounded | flagged, not fixed — source-distributed only, doesn't share `uvx`'s always-latest-at-install risk |
| `connectors/openclaw-sprintable` | no — 404 on npm registry | `peerDependencies` `>=2026.1.0` unbounded | same as above |

5 checked, 2 broken (1 active incident + 1 latent-but-fixed), 1 safe by existing convention, 2 latent-only (currently unpublished, so lower priority — worth a follow-up if either ever gets a real npm publish workflow).

## AC2 — not closed by this PR, needs PO

Actually publishing to PyPI requires reaching `main`: `publish-mcp.yml`'s OIDC trusted publisher lives there (confirmed — not on `develop`), and separately, this repo's `schedule` trigger for AC4's new workflow only fires from the *default* branch (`main`), so that job won't actually run on its own cron until it's there either. Both AC2 and AC4's "self-sustaining" requirement converge on the same next step: promoting these 3 files to `main`.

Given today's earlier promotion work (`#2373`) established "PR base=develop, main touches go through PO" as a hard boundary in this session, I'm not pushing to `main` myself — opening a small, scoped promotion PR next for review, since this is a tiny 3-file promotion (not the earlier full-feature one) and time-sensitive given the RED.

## AC6 — separate axis, not this PR's scope

"Host CLIs report a crashed MCP server as enabled" is real but not something we control (codex/claude-code's own status reporting) — left as material for `#2377`'s discoverability spec, per the story's own instruction.

## AC7 — what this doesn't cover

- `mcp` 2.0 migration itself — deferred, separate story per PO.
- The two unpublished connector packages' unbounded peer deps — flagged only, not fixed (no active risk while unpublished).
- Whether `#2374`'s original P0 report (선생님's `codex mcp` session) was *this* specific bug or a stale `uvx` cache — story itself already notes this is unresolved and orthogonal (new installs are broken regardless of which one 선생님 hit).
- `uv.lock` for `backend/sprintable_mcp` — this package has no lockfile at all (by design, `uvx` doesn't use repo-committed locks), so the `<2.0.0` cap is the only guard; documented as such in the pyproject.toml comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
