### PR TITLE
promo(#2382, P0 RED): mcp<2.0.0 pin — 3-file selective promotion, DO NOT MERGE until #2766 lands

### DIFF
--- a/.github/workflows/mcp-pypi-smoke.yml
+++ b/.github/workflows/mcp-pypi-smoke.yml
@@ -1,0 +1,60 @@
+name: sprintable-mcp PyPI smoke test
+
+# story #2382 (P0 RED, 2026-08-01): mcp SDK 2.0.0 broke `uvx sprintable` for every new
+# install starting 2026-07-28 (FastMCP renamed to MCPServer, mcp.server.fastmcp module
+# path removed) — and nothing caught it for 4 days, because our CI tests this repo's local
+# source, never the artifact PyPI actually serves users. This job closes exactly that gap:
+# it installs the real published package from PyPI (uvx, not a local checkout) and runs it
+# far enough to prove the whole import chain resolves — no live credentials needed, no
+# hang, because sprintable_mcp/__main__.py:main() exits early with a friendly message the
+# moment SPRINTABLE_API_URL is unset, *after* every import in the chain has already
+# succeeded. Reaching that message is proof positive the package installs and imports
+# cleanly; a traceback anywhere before it is proof it doesn't.
+#
+# Positive control (verified 2026-08-01, story #2382 PR): this exact check told the broken
+# state (mcp>=1.8.0 unbounded → resolves mcp 2.0.0 → ModuleNotFoundError, no message match)
+# apart from the fixed state (mcp>=1.8.0,<2.0.0 → resolves mcp 1.x → friendly message,
+# match) — both reproduced against real installs (PyPI for broken, a local wheel build for
+# fixed) before this workflow was written. See the PR body for the transcripts.
+
+on:
+  schedule:
+    # mcp SDK majors aren't frequent — daily is enough to catch drift within a day, not
+    # the 4-day blind spot this story found.
+    - cron: "0 3 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  smoke-test:
+    name: uvx sprintable (real PyPI, no cache) reaches its own config guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Run uvx sprintable from PyPI with a fully clean environment
+        id: run
+        run: |
+          set +e
+          # env -i: don't let ambient CI env vars accidentally supply SPRINTABLE_API_URL/
+          # AGENT_API_KEY — this must fail at main()'s own config check, never attempt a
+          # live network call. --no-cache: this run must reflect what a brand-new install
+          # gets right now, not whatever uv already has cached on this runner.
+          output=$(env -i PATH="$PATH" HOME="$HOME" uvx --no-cache sprintable 2>&1)
+          code=$?
+          echo "$output"
+          {
+            echo "output<<SMOKE_EOF"
+            echo "$output"
+            echo "SMOKE_EOF"
+            echo "exit_code=$code"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Assert the import chain actually resolved
+        run: |
+          if echo "${{ steps.run.outputs.output }}" | grep -q "SPRINTABLE_API_URL environment variable required"; then
+            echo "uvx sprintable resolves and reaches its own config guard — the published package installs and imports cleanly."
+            exit 0
+          fi
+          echo "::error::uvx sprintable did NOT reach its own config-check (see the log above for the actual failure) — the published PyPI package is broken for fresh installs. This is exactly story #2382's failure mode; check for an unbounded/newly-incompatible dependency."
+          exit 1

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,7 +19,11 @@ dependencies = [
     "alembic>=1.13.0",
     "psycopg2-binary>=2.9.0",
     "slowapi>=0.1.9",
-    "mcp>=1.8.0",  # E-MCP-HTTP: streamable-http floor(sprintable-mcp-dev 서비스가 동 backend 이미지 사용)
+    # E-MCP-HTTP: streamable-http floor(sprintable-mcp-dev 서비스가 동 backend 이미지 사용).
+    # story #2382: <2.0.0 상한 — Docker 빌드는 uv sync --frozen(uv.lock 고정, 현재 1.27.1)이라
+    # 지금 당장 위험하진 않지만, 언젠가 uv lock --upgrade로 lock을 재생성하면 이 declared range가
+    # 그대로 mcp 2.0.0(FastMCP→MCPServer 개명)까지 열어 호스티드 MCP를 똑같이 깨뜨린다.
+    "mcp>=1.8.0,<2.0.0",
     "resend>=2.0.0",
     "google-analytics-data>=0.18.0",
     # R2 채팅 첨부 AI 컨텍스트(9d130c01): GCS 서비스계정 read + 문서 텍스트 추출

--- a/backend/sprintable_mcp/pyproject.toml
+++ b/backend/sprintable_mcp/pyproject.toml
@@ -6,10 +6,11 @@ build-backend = "hatchling.build"
 # OB-PUBLISH(f5e1742d): distribution name = "sprintable" (선생님 PyPI project 등록값·uvx sprintable
 # 한 줄 정합). 내부 모듈명은 sprintable_mcp 그대로(dist명≠모듈명 — hatch sources remap 아래 유지).
 name = "sprintable"
-# 0.1.1 (2026-07-27): story #2166 픽스가 PyPI 에 안 나가 사용자는 계속 옛 에러를 보고 있었다.
-# main 에서 릴리즈(sprintable-mcp-v0.1.1 · PyPI 05:55:20)했으므로 develop 도 같은 값으로 맞춘다
-# — 브랜치별로 버전이 갈리면 다음 사람이 "지금 나간 게 무엇인지"를 못 읽는다.
-version = "0.1.1"
+# 0.1.2 (2026-08-01, story #2382 · P0 RED): mcp 2.0.0이 07-28 PyPI에 올라오며 FastMCP→MCPServer
+# 개명·mcp.server.fastmcp→mcp.server.mcpserver 모듈 경로 변경 — 상한 없던 "mcp>=1.8.0"이 그 순간부터
+# `uvx sprintable`을 100% 깨뜨렸다(신규 설치자 전원, 나흘간 미발견). PO 판정(RED 상황 — 빠른 복구가
+# 지배): 2.0 이관은 별건으로 미루고 지금은 상한만 넣어 즉시 복구한다.
+version = "0.1.2"
 description = "Sprintable MCP server — BYO agent toolset over the Sprintable API (stdio). No repo clone required."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -19,7 +20,9 @@ keywords = ["mcp", "sprintable", "agent", "model-context-protocol"]
 dependencies = [
     # E-MCP-HTTP S1: streamable-http floor(mcp 1.8+·run_streamable_http_async/transport='streamable-http')
     # — fresh 빌드가 구버전 받아 http 미지원되는 footgun 방지(S2 Cloud Run 빌드 보증). 설치본 1.27.1 검증완.
-    "mcp>=1.8.0",
+    # story #2382: 상한 <2.0.0 — mcp 2.0.0이 FastMCP→MCPServer로 개명해 server.py의
+    # `from mcp.server.fastmcp import FastMCP`를 ModuleNotFoundError로 깨뜨린다. 2.0 이관은 별건.
+    "mcp>=1.8.0,<2.0.0",
     "httpx>=0.27",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",


### PR DESCRIPTION
## ⚠️ Sequencing — read before merging

Opened in advance per PO's explicit sequencing (story #2373-style selective promotion), **not ready to merge yet**:

```
①  #2766 (base=develop) — CI green + Qadir QA → PO merges          ← must land first
②  THIS PR (main) — 3 files only → PO reviews + merges
③  main push → publish-mcp.yml (OIDC trusted publisher) fires → PyPI sprintable 0.1.2 goes out
④  PO verifies `uvx sprintable` in a cache-cleared environment (symmetry — PO reproduced the break, PO measures the fix)
```

Marked as **draft** and titled DO NOT MERGE until #2766 is confirmed merged into develop — merging this before that would put content on `main` that develop doesn't have yet (exactly the drift #2762 needed a backport to fix earlier today).

## What's in this PR

Selective 3-file promotion, checked out directly from `fix/2382-pin-mcp-version` (identical content to what's in #2766):
- `backend/sprintable_mcp/pyproject.toml` — `mcp>=1.8.0,<2.0.0`, version `0.1.1`→`0.1.2` (PyPI requires a new version to publish; this bump is also what `publish-mcp.yml`'s release-tag-matches-pyproject-version check needs).
- `backend/pyproject.toml` — same pin, defense-in-depth for the Docker-deployed backend/hosted-MCP path.
- `.github/workflows/mcp-pypi-smoke.yml` — needs to land on `main` specifically, since this repo's `schedule` trigger only fires from the default branch (confirmed: `main`). Also staying in `develop` (already merged there via #2766) so the next promotion doesn't silently drop it.

Full verification (before/after positive control, the smoke test's own positive control, AC5 sweep of other packages) is in #2766's PR body — this PR is purely the promotion vehicle, not a place to re-derive that.

## After merge

Once this lands on `main`:
1. `publish-mcp.yml` needs a trigger — either a `sprintable-mcp-v0.1.2` tagged release, or manual `workflow_dispatch` (both documented as valid triggers in the workflow file itself).
2. PO verifies the real PyPI artifact in a cache-cleared environment (`uvx --no-cache sprintable`, no ambient `SPRINTABLE_API_URL`/`AGENT_API_KEY`) reaches its friendly config-guard message rather than crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)