### PR TITLE
fix(#2384): scripts/ root doesn't ship in deploy image — move operational scripts to scripts/jobs/

### DIFF
--- a/backend/scripts/jobs/README.md
+++ b/backend/scripts/jobs/README.md
@@ -1,0 +1,48 @@
+# scripts/jobs/ — operational scripts that run against a live database
+
+## This is the canonical location
+
+If a script needs to connect to a real (dev/prod) database — backfills, one-off
+migrations of data (not schema), audits, expiries — it goes **here**, not in
+`backend/scripts/` root.
+
+`backend/Dockerfile` only `COPY`s `scripts/jobs/` and `scripts/migrate.sh` into the
+deployed backend image (story #1666 — deliberate: `scripts/` root also holds
+deploy/setup/provision `.sh` files and a `RUNBOOK.md` that have no reason to ship
+inside a running container, and keeping them out minimizes recon-surface). A script
+placed in `scripts/` root will pass CI, merge, and deploy cleanly — and then be
+completely unreachable from inside the container. This has already happened twice
+before this story existed (`backfill_reference_semantic_candidates.py`, moved by
+오르테가 2026-07-31; `backfill_activity_events.py` and
+`expire_undeliverable_pending_dispatched_events.py`, moved by story #2384 itself).
+`backend/tests/test_2384_scripts_root_image_exclusion_lint.py` now guards against a
+fourth occurrence — any new `.py` added to `scripts/` root that isn't on that test's
+explicit CI/local-only allowlist fails CI.
+
+## How to actually run one against dev
+
+The only currently-provisioned Cloud Run Job for this is **`sprintable-verify-oneoff`**
+(dev). It's a manual/occasional-use job, not a standing pipeline — someone with gcloud
+access to the project runs it via `gcloud run jobs execute sprintable-verify-oneoff
+--args=...` (or the Cloud Console), overriding the command to
+`python -m scripts.jobs.<script_name> [args...]`. There is currently **no self-service
+path** for an agent session to trigger this directly — running an operational script
+against dev is PO/infra-lane, same as any other Cloud Run job execution.
+
+⚠️ The job's environment supplies `ALEMBIC_URL` (psycopg2-scheme), not `DATABASE_URL`
+(asyncpg-scheme) — this was itself a prior footgun (오르테가 판정, 2026-07-31, on
+`backfill_reference_semantic_candidates.py`: *"손질이 한 번이면 코드로 넣고, 매번이면
+그건 손질이 아니라 결함이다"*). A script meant to run in this job should fall back to
+`ALEMBIC_URL` when `DATABASE_URL` is unset and convert the scheme itself — see
+`backfill_reference_semantic_candidates.py` for the reference implementation. Log which
+one it used (scheme+host only, never credentials) on its first line of output.
+
+## Before you add a script here
+
+1. Does it write to (or delete/expire) production-adjacent data? If yes, it needs a
+   `--dry-run` default and an explicit `--apply` (or equivalent) to actually mutate —
+   see `expire_undeliverable_pending_dispatched_events.py` for the pattern.
+2. Is it idempotent? Someone will re-run it, on purpose or by accident.
+3. Does its docstring state the exact invocation (`python -m scripts.jobs.<name>
+   [args]`) and what env var it needs? The next person running it under time pressure
+   won't read the source first.

--- a/backend/scripts/jobs/README.md
+++ b/backend/scripts/jobs/README.md
@@ -32,10 +32,14 @@ against dev is PO/infra-lane, same as any other Cloud Run job execution.
 ⚠️ The job's environment supplies `ALEMBIC_URL` (psycopg2-scheme), not `DATABASE_URL`
 (asyncpg-scheme) — this was itself a prior footgun (오르테가 판정, 2026-07-31, on
 `backfill_reference_semantic_candidates.py`: *"손질이 한 번이면 코드로 넣고, 매번이면
-그건 손질이 아니라 결함이다"*). A script meant to run in this job should fall back to
-`ALEMBIC_URL` when `DATABASE_URL` is unset and convert the scheme itself — see
-`backfill_reference_semantic_candidates.py` for the reference implementation. Log which
-one it used (scheme+host only, never credentials) on its first line of output.
+그건 손질이 아니라 결함이다"*). A script meant to run in this job **must** call
+`resolve_database_url()` from `scripts/jobs/_db_env.py` (module-level, before any
+`app.core.database` import) instead of checking `os.environ["DATABASE_URL"]` directly —
+see any of `backfill_reference_semantic_candidates.py`, `backfill_activity_events.py`, or
+`expire_undeliverable_pending_dispatched_events.py` for the pattern.
+`test_2384_scripts_jobs_alembic_url_fallback.py` guards this for the two scripts moved by
+#2384 after 카디르군 caught them shipping without it (documented the pattern, didn't follow
+it — 2026-08-01 REQUEST_CHANGES).
 
 ## Before you add a script here
 
@@ -46,3 +50,14 @@ one it used (scheme+host only, never credentials) on its first line of output.
 3. Does its docstring state the exact invocation (`python -m scripts.jobs.<name>
    [args]`) and what env var it needs? The next person running it under time pressure
    won't read the source first.
+4. Does it call `resolve_database_url()` from `_db_env.py` before its first
+   `app.core.database` import, instead of checking `DATABASE_URL` directly? Otherwise it
+   passes locally (where `DATABASE_URL` is always set) and only fails inside
+   `sprintable-verify-oneoff`, where only `ALEMBIC_URL` exists.
+
+⚠️ Known gap (out of scope for #2384, not yet fixed): `backfill_doc_base64_assets.py`,
+`audit_apikey_member_anchor.py`, `backfill_void_empty_merge_gates.py`, and
+`purge_test_agents.py` still check `DATABASE_URL` directly with no `_db_env.py` fallback —
+they predate this helper and were never run against `sprintable-verify-oneoff`, so nobody's
+hit it yet. Same failure mode as the two #2384 fixed; worth a follow-up sweep before one of
+them is.

--- a/backend/scripts/jobs/_db_env.py
+++ b/backend/scripts/jobs/_db_env.py
@@ -1,0 +1,40 @@
+"""공용 헬퍼 — scripts/jobs/ 스크립트가 DATABASE_URL 없이 ALEMBIC_URL만 있는 환경(Cloud Run
+Job `sprintable-verify-oneoff` 등)에서도 돌 수 있게 하는 폴백.
+
+story #2223 후속(오르테가 판정, 2026-07-31)에서 `backfill_reference_semantic_candidates.py`에
+처음 인라인으로 생겼다가, story #2384에서 같은 잡으로 옮겨진 두 스크립트(`backfill_activity_events.py`,
+`expire_undeliverable_pending_dispatched_events.py`)가 이 폴백 없이 옮겨져 카디르군 REQUEST_CHANGES로
+드러났다 — 문서(README AC4)는 패턴을 알았는데 옮겨진 코드가 그걸 안 따랐다. 세 번째 사본을 또
+안 만들려고 여기로 뺐다.
+
+⛔ 호출 시점 주의: `app.core.database`의 `engine`은 그 모듈 **import 시점**에
+`settings.database_url`(pydantic, DATABASE_URL env 자동매핑)로 한 번만 만들어진다. 이 함수는
+반드시 그 import **前**에 호출돼 os.environ["DATABASE_URL"]을 채워야 한다 — main() 안에서
+늦게 부르면 이미 만들어진 engine엔 반영되지 않는다("main() 안 폴백은 이미 늦다").
+"""
+from __future__ import annotations
+
+import os
+from urllib.parse import urlsplit
+
+
+def resolve_database_url() -> str | None:
+    """DATABASE_URL이 있으면 그것을 그대로 쓴다. 없고 ALEMBIC_URL이 있으면 psycopg2→asyncpg
+    스킴 변환 후 os.environ["DATABASE_URL"]에 심는다. 반환값은 로그용 요약(스킴+호스트만) —
+    자격증명은 절대 담지 않는다. 둘 다 없으면 None."""
+    if os.environ.get("DATABASE_URL"):
+        source = "DATABASE_URL"
+    elif os.environ.get("ALEMBIC_URL"):
+        raw = os.environ["ALEMBIC_URL"]
+        converted = raw
+        for prefix in ("postgresql+psycopg2://", "postgresql://"):
+            if raw.startswith(prefix):
+                converted = "postgresql+asyncpg://" + raw[len(prefix):]
+                break
+        os.environ["DATABASE_URL"] = converted
+        source = "ALEMBIC_URL(스킴 변환)"
+    else:
+        return None
+
+    parts = urlsplit(os.environ["DATABASE_URL"])
+    return f"{source} → scheme={parts.scheme} host={parts.hostname}"

--- a/backend/scripts/jobs/backfill_activity_events.py
+++ b/backend/scripts/jobs/backfill_activity_events.py
@@ -4,32 +4,42 @@ events를 (created_at ASC, id ASC)로 cursor scan하며 BE-2 extractor(upsert_ac
 로 activity_events에 흡수한다. 0116 마이그는 테이블만 만들고 데이터는 이 job이 채운다. 재실행
 멱등 — (org_id, dedup_key) unique + array_agg DISTINCT라 row count·source 누적이 안정.
 
-env: DATABASE_URL (백엔드 동일, cloud-sql-proxy/in-VPC 경유). 쓰기 작업.
+env: DATABASE_URL이 있으면 그것을 쓴다(백엔드 동일, cloud-sql-proxy/in-VPC 경유). 없으면
+ALEMBIC_URL로 떨어진다(scripts/jobs/_db_env.py — Cloud Run Job `sprintable-verify-oneoff`가
+DATABASE_URL이 아니라 ALEMBIC_URL만 갖고 있다). 쓰기 작업.
 실행: cd backend && DATABASE_URL=... python -m scripts.jobs.backfill_activity_events [--batch-size N]
 
 story #2384: scripts/jobs/ 로 이동(기존 scripts/ 루트는 Dockerfile이 명시적으로 배포 이미지에서
 빼는 자리라 — deploy/setup/provision .sh·RUNBOOK 등 비-런타임 전용, recon-surface 최소화 의도.
 운영 DB에 실제로 접속하는 스크립트는 여기(scripts/jobs/)에 둬야 sprintable-verify-oneoff 같은
 Cloud Run 잡에서 실행 가능하다 — 자세한 경위는 scripts/jobs/README.md 참고.
+
+2026-08-01, 카디르군 REQUEST_CHANGES 후속: 옮기기만 하고 README가 문서화한 ALEMBIC_URL 폴백을
+안 붙였던 것을 놓쳤다(옆의 backfill_reference_semantic_candidates.py가 이미 하던 패턴). _db_env.py의
+공용 헬퍼로 붙인다.
 """
 from __future__ import annotations
 
 import argparse
 import asyncio
 import logging
-import os
 import sys
 
-from app.core.database import async_session_factory
-from app.services.activity_stream import backfill_activity_events
+from scripts.jobs._db_env import resolve_database_url
 
 logger = logging.getLogger("backfill_activity_events")
 
+_db_url_summary = resolve_database_url()
+
+from app.core.database import async_session_factory  # noqa: E402 — 위 폴백이 먼저 돌아야 한다
+from app.services.activity_stream import backfill_activity_events  # noqa: E402
+
 
 async def main() -> int:
-    if not os.environ.get("DATABASE_URL"):
-        print("DATABASE_URL 미설정", file=sys.stderr)
+    if _db_url_summary is None:
+        print("DATABASE_URL·ALEMBIC_URL 둘 다 미설정", file=sys.stderr)
         return 2
+    logger.info("DB 연결: %s", _db_url_summary)
 
     parser = argparse.ArgumentParser(description="events → activity_events backfill (idempotent)")
     parser.add_argument("--batch-size", type=int, default=1000, help="배치당 scan할 event 수 (기본 1000)")

--- a/backend/scripts/jobs/backfill_activity_events.py
+++ b/backend/scripts/jobs/backfill_activity_events.py
@@ -5,7 +5,12 @@ events를 (created_at ASC, id ASC)로 cursor scan하며 BE-2 extractor(upsert_ac
 멱등 — (org_id, dedup_key) unique + array_agg DISTINCT라 row count·source 누적이 안정.
 
 env: DATABASE_URL (백엔드 동일, cloud-sql-proxy/in-VPC 경유). 쓰기 작업.
-실행: cd backend && DATABASE_URL=... python -m scripts.backfill_activity_events [--batch-size N]
+실행: cd backend && DATABASE_URL=... python -m scripts.jobs.backfill_activity_events [--batch-size N]
+
+story #2384: scripts/jobs/ 로 이동(기존 scripts/ 루트는 Dockerfile이 명시적으로 배포 이미지에서
+빼는 자리라 — deploy/setup/provision .sh·RUNBOOK 등 비-런타임 전용, recon-surface 최소화 의도.
+운영 DB에 실제로 접속하는 스크립트는 여기(scripts/jobs/)에 둬야 sprintable-verify-oneoff 같은
+Cloud Run 잡에서 실행 가능하다 — 자세한 경위는 scripts/jobs/README.md 참고.
 """
 from __future__ import annotations
 

--- a/backend/scripts/jobs/backfill_reference_semantic_candidates.py
+++ b/backend/scripts/jobs/backfill_reference_semantic_candidates.py
@@ -17,7 +17,8 @@ DATABASE_URL이 아니라 ALEMBIC_URL만 갖고 있어, 잡 설정을 안 건드
 받는다: "손질이 한 번이면 코드로 넣고, 매번이면 그건 손질이 아니라 결함이다"). ALEMBIC_URL은
 psycopg2 스킴이라 이 스크립트가 쓰는 async engine(asyncpg)용으로 자동 변환한다. ⛔조용히
 넘어가지 않는다 — 어느 쪽을 썼는지(스킴+호스트만, 자격증명 제외) 첫 로그 줄에 남긴다.
-쓰기 작업.
+쓰기 작업. (2026-08-01, story #2384 REQUEST_CHANGES 후속: 이 폴백 로직은 `_db_env.py`로
+빠졌다 — scripts/jobs/의 다른 스크립트가 옮겨질 때 같은 함정에 또 걸리지 않도록.)
 
 실행: cd backend && DATABASE_URL=... python -m scripts.jobs.backfill_reference_semantic_candidates
       [--batch-size N] [--dry-run]
@@ -35,45 +36,17 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
-import os
 import sys
 import uuid
 from collections import Counter
-from urllib.parse import urlsplit
 
 from sqlalchemy import select
 
+from scripts.jobs._db_env import resolve_database_url
+
 logger = logging.getLogger("backfill_reference_semantic_candidates")
 
-
-def _resolve_database_url() -> str | None:
-    """DATABASE_URL이 있으면 그것을 그대로 쓴다. 없고 ALEMBIC_URL이 있으면 psycopg2→asyncpg
-    스킴 변환 후 os.environ["DATABASE_URL"]에 심는다. 반환값은 로그용 요약(스킴+호스트만) —
-    자격증명은 절대 담지 않는다.
-
-    ⛔이 함수는 반드시 `app.core.database` import **前**에 호출돼야 한다 — 그 모듈의
-    `engine`은 import 시점에 `settings.database_url`(pydantic, DATABASE_URL env 자동매핑)로
-    한 번만 만들어져서, 여기서 나중에 os.environ을 채워도 이미 만들어진 engine엔 반영되지
-    않는다(2026-07-31 오르테가 판정 — "main() 안 폴백은 이미 늦다")."""
-    if os.environ.get("DATABASE_URL"):
-        source = "DATABASE_URL"
-    elif os.environ.get("ALEMBIC_URL"):
-        raw = os.environ["ALEMBIC_URL"]
-        converted = raw
-        for prefix in ("postgresql+psycopg2://", "postgresql://"):
-            if raw.startswith(prefix):
-                converted = "postgresql+asyncpg://" + raw[len(prefix):]
-                break
-        os.environ["DATABASE_URL"] = converted
-        source = "ALEMBIC_URL(스킴 변환)"
-    else:
-        return None
-
-    parts = urlsplit(os.environ["DATABASE_URL"])
-    return f"{source} → scheme={parts.scheme} host={parts.hostname}"
-
-
-_db_url_summary = _resolve_database_url()
+_db_url_summary = resolve_database_url()
 
 from app.core.database import async_session_factory  # noqa: E402 — 위 폴백이 먼저 돌아야 한다
 from app.models.pm import Story  # noqa: E402

--- a/backend/scripts/jobs/expire_undeliverable_pending_dispatched_events.py
+++ b/backend/scripts/jobs/expire_undeliverable_pending_dispatched_events.py
@@ -43,9 +43,14 @@ human-recipient pending dispatched를 만드는 경로가 지금도 살아 있�
 
 ## 실행
 ```
-DATABASE_URL=postgresql+asyncpg://... python -m scripts.expire_undeliverable_pending_dispatched_events [--dry-run] [--org-id UUID]
+DATABASE_URL=postgresql+asyncpg://... python -m scripts.jobs.expire_undeliverable_pending_dispatched_events [--dry-run] [--org-id UUID]
 ```
 기본은 `--dry-run`(카운트만 출력, 미변경) — 실 만료는 `--apply` 명시 필요.
+
+story #2384: PO가 이 스크립트를 실제로 돌리려다 배포 이미지에 없는 것을 발견해 scripts/jobs/로
+옮겼다(원래 있던 scripts/ 루트는 Dockerfile이 명시적으로 배포 이미지에서 빼는 자리 — 자세한
+경위는 scripts/jobs/README.md 참고). PO는 이 스크립트를 못 쓴 채 같은 조건을 직접 세워 수동
+UPDATE로 만료를 돌렸다(49건, 사후 잔여 0 확認) — 이 이동 이후엔 스크립트 자체를 쓸 수 있다.
 
 ⚠️ 디디(이 스토리 담당)는 dev DB 직접 접근이 막혀 있어(VPC private-IP, 세션 샌드박스에 라우트
 없음 — [[reference_prod_db_query]] dev 항목) 이 스크립트를 스스로 실행하지 못했다. PO/QA가

--- a/backend/scripts/jobs/expire_undeliverable_pending_dispatched_events.py
+++ b/backend/scripts/jobs/expire_undeliverable_pending_dispatched_events.py
@@ -46,11 +46,17 @@ human-recipient pending dispatched를 만드는 경로가 지금도 살아 있�
 DATABASE_URL=postgresql+asyncpg://... python -m scripts.jobs.expire_undeliverable_pending_dispatched_events [--dry-run] [--org-id UUID]
 ```
 기본은 `--dry-run`(카운트만 출력, 미변경) — 실 만료는 `--apply` 명시 필요.
+DATABASE_URL이 없으면 ALEMBIC_URL로 떨어진다(scripts/jobs/_db_env.py — sprintable-verify-oneoff
+잡이 실제로 갖고 있는 쪽).
 
 story #2384: PO가 이 스크립트를 실제로 돌리려다 배포 이미지에 없는 것을 발견해 scripts/jobs/로
 옮겼다(원래 있던 scripts/ 루트는 Dockerfile이 명시적으로 배포 이미지에서 빼는 자리 — 자세한
 경위는 scripts/jobs/README.md 참고). PO는 이 스크립트를 못 쓴 채 같은 조건을 직접 세워 수동
 UPDATE로 만료를 돌렸다(49건, 사후 잔여 0 확認) — 이 이동 이후엔 스크립트 자체를 쓸 수 있다.
+
+2026-08-01, 카디르군 REQUEST_CHANGES 후속: 옮기기만 하고 README가 문서화한 ALEMBIC_URL 폴백을
+안 붙였던 것을 놓쳤다 — 그대로 배포하면 sprintable-verify-oneoff에서 "No module named"가
+"DATABASE_URL 미설정"으로 바뀔 뿐 여전히 못 돈다. _db_env.py의 공용 헬퍼로 붙인다.
 
 ⚠️ 디디(이 스토리 담당)는 dev DB 직접 접근이 막혀 있어(VPC private-IP, 세션 샌드박스에 라우트
 없음 — [[reference_prod_db_query]] dev 항목) 이 스크립트를 스스로 실행하지 못했다. PO/QA가
@@ -60,17 +66,20 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import os
 import sys
 import uuid
 
 from sqlalchemy import select, update
 
+from scripts.jobs._db_env import resolve_database_url
+
 
 async def main() -> int:
-    if not os.environ.get("DATABASE_URL"):
-        print("DATABASE_URL 미설정", file=sys.stderr)
+    db_url_summary = resolve_database_url()
+    if db_url_summary is None:
+        print("DATABASE_URL·ALEMBIC_URL 둘 다 미설정", file=sys.stderr)
         return 2
+    print(f"[db] {db_url_summary}", file=sys.stderr)
 
     parser = argparse.ArgumentParser(
         description="recipient_seq 없는(=스트림에 영영 못 실리는) pending dispatched Event 만료(#2375 AC2)"

--- a/backend/tests/test_2384_scripts_jobs_alembic_url_fallback.py
+++ b/backend/tests/test_2384_scripts_jobs_alembic_url_fallback.py
@@ -1,0 +1,110 @@
+"""story #2384 REQUEST_CHANGES 후속(카디르군, 2026-08-01) — 이 PR이 scripts/jobs/로 옮긴 두
+스크립트가 README(AC4)가 문서화한 ALEMBIC_URL 폴백을 실제로는 안 따랐다: 옮기기만 했지
+`backfill_reference_semantic_candidates.py`가 이미 하던 패턴(_db_env.resolve_database_url())을
+안 붙였다. 그대로 배포하면 sprintable-verify-oneoff에서 "No module named"가 "DATABASE_URL
+미설정"으로 자리만 옮겨 갈 뿐이었다.
+
+순수 로직 테스트 — DB 연결 없음(engine은 lazy라 실제 연결을 안 한다). 세 스크립트 모두
+`importlib.reload`로 모듈 최상위(또는 main() 진입 직후)에서 resolve가 실제로 도는 순서를 태운다."""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _restore_env():
+    saved = {k: os.environ.get(k) for k in ("DATABASE_URL", "ALEMBIC_URL")}
+    yield
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+def _reload(module_path: str):
+    """정확히 한 번만 실행한다. import_module()에 이어 바로 reload()하면(둘 다 "실행"이라
+    믿기 쉽지만) 첫 실행이 resolve_database_url()의 부작용으로 os.environ["DATABASE_URL"]을
+    채워 두 번째 실행이 그걸 "이미 있던 DATABASE_URL"로 오인한다 — 이 테스트 파일 자신이
+    오늘 하루 종일 다룬 그 자(문서/의도와 실제 실행의 불일치)에 걸릴 뻔한 자리."""
+    if module_path in sys.modules:
+        return importlib.reload(sys.modules[module_path])
+    return importlib.import_module(module_path)
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "scripts.jobs.backfill_activity_events",
+        "scripts.jobs.backfill_reference_semantic_candidates",
+    ],
+)
+def test_module_level_falls_back_to_alembic_url(module_path):
+    """backfill_activity_events.py·backfill_reference_semantic_candidates.py는 DB-touching
+    import가 모듈 최상위에 있어, 폴백도 모듈 최상위(_db_url_summary)에서 돌아야 한다."""
+    os.environ.pop("DATABASE_URL", None)
+    os.environ["ALEMBIC_URL"] = "postgresql+psycopg2://u:secret-pw@alembic-host:5432/db"
+    mod = _reload(module_path)
+
+    assert mod._db_url_summary is not None
+    assert "ALEMBIC_URL" in mod._db_url_summary
+    assert "alembic-host" in mod._db_url_summary
+    assert os.environ["DATABASE_URL"].startswith("postgresql+asyncpg://")
+    assert "secret-pw" not in mod._db_url_summary
+
+
+@pytest.mark.anyio
+async def test_expire_script_main_falls_back_to_alembic_url(monkeypatch):
+    """expire_undeliverable_pending_dispatched_events.py는 DB-touching import가 main() 안에
+    지연돼 있어, resolve_database_url()도 main() 진입 시점에 불러야 한다 — argparse 뒤가 아니라
+    맨 앞이어야 그 뒤의 app.core.database import가 올바른 DATABASE_URL을 본다."""
+    os.environ.pop("DATABASE_URL", None)
+    os.environ["ALEMBIC_URL"] = "postgresql+psycopg2://u:secret-pw@alembic-host:5432/db"
+    monkeypatch.setattr("sys.argv", ["expire_undeliverable_pending_dispatched_events.py"])
+
+    import scripts.jobs.expire_undeliverable_pending_dispatched_events as mod
+    importlib.reload(mod)
+
+    # DB 세션을 열지 않고 resolve 결과만 확認 — async_session_factory는 main() 안에서 argparse
+    # 뒤에 지연 import되므로, 여기까지 오면 이미 DATABASE_URL 폴백이 성공했다는 뜻이다.
+    called = {}
+
+    class _FakeSession:
+        async def __aenter__(self):
+            called["opened"] = True
+            raise SystemExit(0)  # 실제 DB 접속 전에 여기서 멈춘다
+
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr(
+        "app.core.database.async_session_factory", lambda: _FakeSession()
+    )
+
+    with pytest.raises(SystemExit):
+        await mod.main()
+
+    assert called.get("opened") is True
+    assert os.environ["DATABASE_URL"].startswith("postgresql+asyncpg://")
+    assert "alembic-host" in os.environ["DATABASE_URL"]
+
+
+@pytest.mark.anyio
+async def test_expire_script_main_returns_2_when_neither_set():
+    os.environ.pop("DATABASE_URL", None)
+    os.environ.pop("ALEMBIC_URL", None)
+
+    import scripts.jobs.expire_undeliverable_pending_dispatched_events as mod
+    importlib.reload(mod)
+
+    rc = await mod.main()
+    assert rc == 2
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"

--- a/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
+++ b/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
@@ -1,0 +1,55 @@
+"""story #2384 — backend/scripts/ 루트에 새 .py가 조용히 추가되는 것을 막는 lint.
+
+배경: backend/Dockerfile은 scripts/jobs/·scripts/migrate.sh만 배포 이미지에 COPY한다(#1666
+의도적 축소 — deploy/setup/provision .sh·RUNBOOK 등 비-런타임 전용, recon-surface 최소화).
+그런데 이 경계가 코드 어디에도 강제되지 않아 "운영 DB에 실제로 접속하는 스크립트"가 이
+scripts/ 루트에 놓이는 사고가 이미 두 번 났다:
+  1. backfill_reference_semantic_candidates.py — 오르테가 2026-07-31(#2727 후속)
+     scripts/jobs/로 이동, 이유를 자기 docstring에 남김.
+  2. backfill_activity_events.py·expire_undeliverable_pending_dispatched_events.py —
+     이 스토리(#2384)에서 같은 이유로 같은 이동.
+두 번 다 "그때그때 옮긴다"였지 재발을 막는 자리가 없었다 — 이 lint가 그 자리다.
+
+메커니즘: scripts/ 루트의 .py 파일을 전수로 훑어 아래 allowlist와 대조한다. allowlist에
+없는 새 .py가 추가되면 이 테스트가 빨개진다 — 작성자가 "이건 CI 전용(로컬/CI에서만 돌고
+배포 이미지 진입 불필요)"이라고 판단했으면 allowlist에 그 근거와 함께 추가하고, "운영 DB에
+접속해야 한다"고 판단했으면 scripts/jobs/로 옮긴다. ⛔이 lint는 새 파일이 어느 쪽인지
+대신 판단해 주지 않는다 — 판단을 강제로 만들 뿐이다(안 만들면 조용히 scripts/ 루트에
+얹히던 지금까지의 실패 모드를 막는다).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_SCRIPTS_ROOT = Path(__file__).resolve().parent.parent / "scripts"
+
+# CI/로컬 전용으로 확인된 .py — 전부 CI 워크플로가 리포 체크아웃에서 직접 부르거나(lint 게이트),
+# 엔지니어가 로컬에서 1회성으로 돌리는 분석 도구. 운영 DB에 상시 접속해 데이터를 변경하지
+# 않는다(model_db_drift_audit.py는 읽기 전용 감사 — ALEMBIC_DATABASE_URL로 로컬에서 돌리는
+# 것을 전제로 문서화돼 있다, story #2181).
+_CI_OR_LOCAL_ONLY_ALLOWLIST = frozenset({
+    "ci_alembic_single_step_promotion_check.py",  # story #2330 — CI 전용 fresh-DB 재현
+    "lint_candidate_source_ownership.py",         # story #2363 AC6 — CI lint 게이트
+    "lint_project_access_403.py",                 # story #2342 AC7 — CI lint 게이트
+    "lint_query_sentinel_direct_calls.py",        # story #2335 — CI lint 게이트
+    "model_db_drift_audit.py",                    # story #2181 — 로컬 1회성 감사(읽기 전용)
+    "shard_destructive_tests.py",                 # story #2293 — CI 매트릭스 샤딩 유틸
+})
+
+
+def test_scripts_root_python_files_are_all_allowlisted():
+    root_py_files = {p.name for p in _SCRIPTS_ROOT.glob("*.py")}
+    unlisted = root_py_files - _CI_OR_LOCAL_ONLY_ALLOWLIST
+    assert not unlisted, (
+        f"backend/scripts/ 루트에 allowlist 밖 .py가 있다: {sorted(unlisted)}. "
+        "이 파일이 운영 DB에 접속하는 스크립트라면 scripts/jobs/로 옮겨라(그래야 배포 이미지에 "
+        "실린다 — Dockerfile은 scripts/jobs/만 COPY한다, story #1666/#2727/#2384 참조). "
+        "CI/로컬 전용이 맞다면 이 파일의 _CI_OR_LOCAL_ONLY_ALLOWLIST에 근거와 함께 추가하라."
+    )
+
+
+def test_allowlist_entries_still_exist_in_scripts_root():
+    """allowlist가 옛 파일명을 들고 죽지 않게 — 옮기거나 지웠으면 여기서도 빼야 한다."""
+    root_py_files = {p.name for p in _SCRIPTS_ROOT.glob("*.py")}
+    stale = _CI_OR_LOCAL_ONLY_ALLOWLIST - root_py_files
+    assert not stale, f"allowlist에 있지만 scripts/ 루트에 더 이상 없는 파일: {sorted(stale)}"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1967,7 +1967,7 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "imagesize", specifier = ">=2.0.0" },
-    { name = "mcp", specifier = ">=1.8.0" },
+    { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
     { name = "passlib", extras = ["argon2", "bcrypt"], specifier = ">=1.7.4" },
     { name = "pgvector", specifier = ">=0.3.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.0" },


### PR DESCRIPTION
## Summary

`backend/scripts/` root doesn't ship in the deployed backend image — `Dockerfile` only `COPY`s `scripts/jobs/` and `scripts/migrate.sh` (story #1666, deliberate: root also holds deploy/setup/provision `.sh` scripts and a `RUNBOOK.md` with no reason to run inside a container). PO hit this today trying to run `#2375`'s expire script via the `sprintable-verify-oneoff` Cloud Run job.

## AC1 — where exactly, and why (not "added it and moved on")

Found precisely in `backend/Dockerfile`:
```dockerfile
COPY scripts/jobs/ scripts/jobs/
COPY scripts/migrate.sh scripts/migrate.sh
```
This is the **second** time this exact bug class has hit. `backfill_reference_semantic_candidates.py` was moved from `scripts/` root to `scripts/jobs/` by 오르테가 on 2026-07-31 (`#2727` follow-up) — same root cause, same fix shape, documented in its own docstring. No systemic guard followed that fix, so it recurred: `backfill_activity_events.py` (had been in `scripts/` root all along, nobody hit it until now) and `#2375`'s `expire_undeliverable_pending_dispatched_events.py` (my own script, landed in the wrong place today without me noticing the landmine).

Fix: moved both into `scripts/jobs/`, updated each docstring's invocation example (`scripts.X` → `scripts.jobs.X`). **No Dockerfile change** — `scripts/jobs/` was already copied wholesale, this was purely a misplacement.

## AC2 — before/after, both reproduced

- **Before**: simulated the actual deployed-image layout (only `scripts/jobs/` present, matching the real `Dockerfile`) with the script still at its old root path — `python -m scripts.jobs.expire_undeliverable_pending_dispatched_events --help` fails with exactly the reported `No module named` error.
- **After**: same command, script now actually in `scripts/jobs/` — resolves and prints usage cleanly. Same for `backfill_activity_events.py`.

## AC3 — counted the rest + a guard against a 4th occurrence

Swept every `.py` in `scripts/` root (13 total). 6 are genuinely CI/local-only and correctly stay excluded:
```
ci_alembic_single_step_promotion_check.py   — CI fresh-DB repro (story #2330)
lint_candidate_source_ownership.py          — CI lint gate (story #2363 AC6)
lint_project_access_403.py                  — CI lint gate (story #2342 AC7)
lint_query_sentinel_direct_calls.py         — CI lint gate (story #2335)
model_db_drift_audit.py                     — local-only, read-only audit (story #2181)
shard_destructive_tests.py                  — CI matrix sharding utility (story #2293)
```
2 were the bug (moved this PR). The other 5 root-level entries are `.sh`/`.md`/data files, out of scope (this story is about the "operational script missing from image" class specifically, per its own description).

New `backend/tests/test_2384_scripts_root_image_exclusion_lint.py`: asserts every `.py` in `scripts/` root is on an explicit allowlist. A new unlisted file fails CI, forcing the author to either justify staying in `scripts/` root (add to the allowlist with a reason) or move to `scripts/jobs/`. **Verified the guard actually discriminates** (not vacuous, per today's repeated lesson) — added a throwaway unlisted `.py`, confirmed the test goes red, removed it, confirmed green again. Transcript:
```
$ echo '"""fake"""' > scripts/fake_unlisted_script.py && pytest test_2384_...
FAILED — AssertionError: ...allowlist 밖 .py가 있다: ['fake_unlisted_script.py']
$ rm scripts/fake_unlisted_script.py && pytest test_2384_...
2 passed
```

## AC4 — documented the operational path

New `backend/scripts/jobs/README.md`:
- States plainly: this directory is canonical for scripts touching live data, everything else in `scripts/` root either doesn't ship or shouldn't need to.
- Documents the actual execution path: Cloud Run Job `sprintable-verify-oneoff` (dev), manual/occasional-use, no self-service trigger — running one against dev is PO/infra-lane.
- Documents the `ALEMBIC_URL` vs `DATABASE_URL` env var gotcha (itself a prior footgun, per 오르테가's 2026-07-31 note on the same file — now written down once instead of relearned per script).
- A short pre-flight checklist for the next person adding a script here (dry-run default, idempotency, docstring states exact invocation).

## AC5 — what this doesn't cover

- Whether other `backend/` subdirectories are missing from the image for the same reason — out of scope; this story is specifically about `scripts/`, the directory that actually bit PO today. A broader Dockerfile `COPY`-surface audit is a separate exercise if it's ever needed.
- Prod's Cloud Run Job equivalent wasn't checked — all of today's evidence (including PO's own reproduction) is dev-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
