### PR TITLE
guard(backend): CI catches scripts/jobs/ scripts missing the ALEMBIC_URL fallback (story #2386)

### DIFF
--- a/backend/scripts/jobs/README.md
+++ b/backend/scripts/jobs/README.md
@@ -37,9 +37,13 @@ against dev is PO/infra-lane, same as any other Cloud Run job execution.
 `app.core.database` import) instead of checking `os.environ["DATABASE_URL"]` directly —
 see any of `backfill_reference_semantic_candidates.py`, `backfill_activity_events.py`, or
 `expire_undeliverable_pending_dispatched_events.py` for the pattern.
-`test_2384_scripts_jobs_alembic_url_fallback.py` guards this for the two scripts moved by
-#2384 after 카디르군 caught them shipping without it (documented the pattern, didn't follow
-it — 2026-08-01 REQUEST_CHANGES).
+`test_2384_scripts_jobs_alembic_url_fallback.py` guards this for the three scripts that
+had a hand-written test proving the exact runtime call order; story #2386 added a
+repo-wide static lint (`test_2386_scripts_jobs_db_url_fallback_lint.py`) that catches any
+`scripts/jobs/` script touching the DB (`app.core.database` import) without referencing
+`resolve_database_url` at all — so a future script added here without the fallback fails
+CI immediately instead of waiting for someone to run it against `sprintable-verify-oneoff`
+and discover it the hard way.
 
 ## Before you add a script here
 
@@ -54,10 +58,3 @@ it — 2026-08-01 REQUEST_CHANGES).
    `app.core.database` import, instead of checking `DATABASE_URL` directly? Otherwise it
    passes locally (where `DATABASE_URL` is always set) and only fails inside
    `sprintable-verify-oneoff`, where only `ALEMBIC_URL` exists.
-
-⚠️ Known gap (out of scope for #2384, not yet fixed): `backfill_doc_base64_assets.py`,
-`audit_apikey_member_anchor.py`, `backfill_void_empty_merge_gates.py`, and
-`purge_test_agents.py` still check `DATABASE_URL` directly with no `_db_env.py` fallback —
-they predate this helper and were never run against `sprintable-verify-oneoff`, so nobody's
-hit it yet. Same failure mode as the two #2384 fixed; worth a follow-up sweep before one of
-them is.

--- a/backend/scripts/jobs/audit_apikey_member_anchor.py
+++ b/backend/scripts/jobs/audit_apikey_member_anchor.py
@@ -18,18 +18,26 @@ dual-write 했고 0075는 type='agent' team_member만 members에 넣었으므로
   grant-only 누락/union 복제 회귀/0075 파손 감지.
 - 0건(a∩b∩FK) → flag-on 안전(dead 키 INFO 는 비차단). 1건+ → 처리(regression: 0075 정합/members 보정 · 드리프트: 정렬 정합).
 
-env: DATABASE_URL (백엔드 동일, cloud-sql-proxy/in-VPC 경유). 읽기 전용(조회만).
+env: DATABASE_URL이 있으면 그것을 쓴다(백엔드 동일, cloud-sql-proxy/in-VPC 경유). 없으면
+ALEMBIC_URL로 떨어진다(scripts/jobs/_db_env.py — sprintable-verify-oneoff Cloud Run Job이
+DATABASE_URL이 아니라 ALEMBIC_URL만 갖고 있다). 읽기 전용(조회만).
 실행: cd backend && DATABASE_URL=... python -m scripts.jobs.audit_apikey_member_anchor
+
+story #2386(2026-08-01): resolve_database_url() 폴백 추가 — 이 스크립트는 sprintable-verify-oneoff에서
+한 번도 안 돌려봐서 DATABASE_URL 직접 체크 상태로 남아 있었다(#2386 가드가 잡음).
 """
 from __future__ import annotations
 
 import asyncio
-import os
 import sys
 
 from sqlalchemy import text
 
-from app.core.database import async_session_factory
+from scripts.jobs._db_env import resolve_database_url
+
+_db_url_summary = resolve_database_url()
+
+from app.core.database import async_session_factory  # noqa: E402 — 위 폴백이 먼저 돌아야 한다
 
 # (a) cut REGRESSION: legacy 가 해소되는데(active team_members 존재) anchor 는 401(members(agent,active) 부재)
 # = flip 으로 **실제 깨지는 working 키**. legacy 도 이미 401 인 dead 키(inactive tm)는 flip 무관이라 제외(INFO).
@@ -124,9 +132,10 @@ ORDER BY ak.created_at
 
 
 async def main() -> int:
-    if not os.environ.get("DATABASE_URL"):
-        print("[FAIL] DATABASE_URL 필요", file=sys.stderr)
+    if _db_url_summary is None:
+        print("[FAIL] DATABASE_URL·ALEMBIC_URL 둘 다 미설정", file=sys.stderr)
         return 2
+    print(f"[db] {_db_url_summary}", file=sys.stderr)
     async with async_session_factory() as s:
         rows = (await s.execute(text(AUDIT_SQL))).mappings().all()
         fk_bad = (await s.execute(text(FK_VIOLATION_SQL))).scalar_one()

--- a/backend/scripts/jobs/backfill_doc_base64_assets.py
+++ b/backend/scripts/jobs/backfill_doc_base64_assets.py
@@ -8,7 +8,9 @@ legacy base64 노드를 GCS 업로드 + asset registry 등록 + 본문을 `data-
 register 는 additive(reconcile=False·같은 doc 기존 FE-업로드 link clobber 금지). size 는 head_object
 authoritative.
 
-env: DATABASE_URL (백엔드 동일·cloud-sql-proxy/in-VPC)·STORAGE_PROVIDER/버킷 설정. apply 시 GCS 쓰기.
+env: DATABASE_URL이 있으면 그것을 쓴다(백엔드 동일·cloud-sql-proxy/in-VPC). 없으면 ALEMBIC_URL로
+떨어진다(scripts/jobs/_db_env.py — sprintable-verify-oneoff Cloud Run Job이 DATABASE_URL이
+아니라 ALEMBIC_URL만 갖고 있다). STORAGE_PROVIDER/버킷 설정. apply 시 GCS 쓰기.
 실행:
   cd backend && DATABASE_URL=... python -m scripts.jobs.backfill_doc_base64_assets            # dry-run
   cd backend && DATABASE_URL=... python -m scripts.jobs.backfill_doc_base64_assets --apply     # 실제 이관
@@ -16,23 +18,30 @@ env: DATABASE_URL (백엔드 동일·cloud-sql-proxy/in-VPC)·STORAGE_PROVIDER/�
 
 ⚠️ run 전 미르코 FE 렌더러(data-asset-id 분기) 머지 + 이미지 노드 markup byte-exact(§1) 대조 필수.
 dev 먼저·prod 는 선생님 승인 시(PO 게이트).
+
+story #2386(2026-08-01): resolve_database_url() 폴백 추가 — sprintable-verify-oneoff에서 한 번도
+안 돌려봐서 DATABASE_URL 직접 체크 상태로 남아 있었다(#2386 가드가 잡음).
 """
 from __future__ import annotations
 
 import argparse
 import asyncio
-import os
 import sys
 import uuid
 
-from app.core.database import async_session_factory
-from app.services.doc_asset_backfill import backfill_docs
+from scripts.jobs._db_env import resolve_database_url
+
+_db_url_summary = resolve_database_url()
+
+from app.core.database import async_session_factory  # noqa: E402 — 위 폴백이 먼저 돌아야 한다
+from app.services.doc_asset_backfill import backfill_docs  # noqa: E402
 
 
 async def main() -> int:
-    if not os.environ.get("DATABASE_URL"):
-        print("DATABASE_URL 미설정", file=sys.stderr)
+    if _db_url_summary is None:
+        print("DATABASE_URL·ALEMBIC_URL 둘 다 미설정", file=sys.stderr)
         return 2
+    print(f"[db] {_db_url_summary}", file=sys.stderr)
 
     parser = argparse.ArgumentParser(
         description="doc 본문 base64 첨부 → GCS 자산 이관 + ref rewrite (멱등·dry-run 기본)"

--- a/backend/scripts/jobs/backfill_void_empty_merge_gates.py
+++ b/backend/scripts/jobs/backfill_void_empty_merge_gates.py
@@ -9,25 +9,33 @@
 (self-report only)' · neutral_facts.pr_number 가 없음/0. 실 PR 있는 게이트·approved/auto_passed·
 held 등은 건드리지 않는다. 재실행 멱등(이미 voided면 status가 pending이 아니라 재대상 아님).
 
-env: DATABASE_URL (백엔드 동일·cloud-sql-proxy/in-VPC). 쓰기 작업.
+env: DATABASE_URL이 있으면 그것을 쓴다(백엔드 동일·cloud-sql-proxy/in-VPC). 없으면 ALEMBIC_URL로
+떨어진다(scripts/jobs/_db_env.py — sprintable-verify-oneoff Cloud Run Job이 DATABASE_URL이
+아니라 ALEMBIC_URL만 갖고 있다). 쓰기 작업.
 실행:
   cd backend && DATABASE_URL=... python -m scripts.jobs.backfill_void_empty_merge_gates            # dry-run
   cd backend && DATABASE_URL=... python -m scripts.jobs.backfill_void_empty_merge_gates --apply     # 실제 void
 옵션: --org <uuid> 로 특정 org만.
+
+story #2386(2026-08-01): resolve_database_url() 폴백 추가 — sprintable-verify-oneoff에서 한 번도
+안 돌려봐서 DATABASE_URL 직접 체크 상태로 남아 있었다(#2386 가드가 잡음).
 """
 from __future__ import annotations
 
 import argparse
 import asyncio
-import os
 import sys
 import uuid
 from datetime import datetime, timezone
 
 from sqlalchemy import select
 
-from app.core.database import async_session_factory
-from app.models.gate import Gate
+from scripts.jobs._db_env import resolve_database_url
+
+_db_url_summary = resolve_database_url()
+
+from app.core.database import async_session_factory  # noqa: E402 — 위 폴백이 먼저 돌아야 한다
+from app.models.gate import Gate  # noqa: E402
 
 MERGE_GATE_TYPE = "merge"
 _SHELL_BASIS = "CI unknown (self-report only)"
@@ -42,9 +50,10 @@ def _is_no_pr(neutral_facts: dict | None) -> bool:
 
 
 async def main() -> int:
-    if not os.environ.get("DATABASE_URL"):
-        print("DATABASE_URL 미설정", file=sys.stderr)
+    if _db_url_summary is None:
+        print("DATABASE_URL·ALEMBIC_URL 둘 다 미설정", file=sys.stderr)
         return 2
+    print(f"[db] {_db_url_summary}", file=sys.stderr)
 
     parser = argparse.ArgumentParser(description="void empty 'CI unknown' merge gate shells (idempotent)")
     parser.add_argument("--apply", action="store_true", help="실제 void 커밋 (미지정 시 dry-run)")

--- a/backend/scripts/jobs/purge_test_agents.py
+++ b/backend/scripts/jobs/purge_test_agents.py
@@ -49,19 +49,27 @@ uuid 컬럼을 뽑고, 각각을 (a) `members` FK CASCADE/SET NULL(자동 처리
     DATABASE_URL=... python -m scripts.jobs.purge_test_agents --org-id 54bac162-... --execute       # 실행(단일 트랜잭션)
 
 dry-run 출력을 눈으로 검수(비가역) 후에만 --execute. 대상 0건이면 --execute 도 no-op.
+
+story #2386(2026-08-01): resolve_database_url() 폴백 추가 — DATABASE_URL이 없으면 ALEMBIC_URL로
+떨어진다(scripts/jobs/_db_env.py — sprintable-verify-oneoff Cloud Run Job이 DATABASE_URL이
+아니라 ALEMBIC_URL만 갖고 있다). 이 스크립트는 그 잡에서 한 번도 안 돌려봐서 DATABASE_URL 직접
+체크 상태로 남아 있었다(#2386 가드가 잡음).
 """
 from __future__ import annotations
 
 import argparse
 import asyncio
-import os
 import sys
 import uuid
 
 from sqlalchemy import bindparam, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.database import async_session_factory
+from scripts.jobs._db_env import resolve_database_url
+
+_db_url_summary = resolve_database_url()
+
+from app.core.database import async_session_factory  # noqa: E402 — 위 폴백이 먼저 돌아야 한다
 
 
 class _TargetsChangedError(Exception):
@@ -334,9 +342,10 @@ async def main() -> int:
     args = parser.parse_args()
     org_id: uuid.UUID | None = args.org_id
 
-    if not os.environ.get("DATABASE_URL"):
-        print("[FAIL] DATABASE_URL 필요", file=sys.stderr)
+    if _db_url_summary is None:
+        print("[FAIL] DATABASE_URL·ALEMBIC_URL 둘 다 미설정", file=sys.stderr)
         return 2
+    print(f"[db] {_db_url_summary}", file=sys.stderr)
 
     # 완전성 자가감사 — dry-run 조차 진행 전에 먼저. schema.sql 이 아니라 이 세션이 실제로 붙은
     # live DB 를 물어서, 정적 스냅샷이 미래에 또 stale 해져도 구조적으로 재발을 막는다.

--- a/backend/scripts/jobs/verify_grant_only_story_assign.py
+++ b/backend/scripts/jobs/verify_grant_only_story_assign.py
@@ -11,7 +11,9 @@
 
 전제(환경변수):
   BACKEND_URL   예) https://sprintable-backend-dev-57iommnikq-du.a.run.app
-  DATABASE_URL  백엔드와 동일 (postgresql+asyncpg://...  cloud-sql-proxy 경유 가능)
+  DATABASE_URL  있으면 그것을 쓴다(postgresql+asyncpg://... cloud-sql-proxy 경유 가능). 없으면
+                ALEMBIC_URL로 떨어진다(scripts/jobs/_db_env.py — sprintable-verify-oneoff
+                Cloud Run Job이 DATABASE_URL이 아니라 ALEMBIC_URL만 갖고 있다).
   JWT_SECRET    dev와 동일 secret (Secret Manager JWT_SECRET) — create_access_token 서명용
   ORG_ID        대상 조직 (실 dev org)
   PROJECT_ID    대상 프로젝트 (해당 org 소속)
@@ -21,6 +23,9 @@
       python -m scripts.jobs.verify_grant_only_story_assign
 
 ⚠️ 0079 migrate-dev 적용 후 실행할 것. (0078만 적용 시 의도적으로 500이 나며 FAIL로 표시된다.)
+
+story #2386(2026-08-01): resolve_database_url() 폴백 추가 — sprintable-verify-oneoff에서 한 번도
+안 돌려봐서 DATABASE_URL 직접 체크 상태로 남아 있었다(#2386 가드가 잡음).
 """
 from __future__ import annotations
 
@@ -32,12 +37,16 @@ import uuid
 import httpx
 from sqlalchemy import text
 
-from app.core.database import async_session_factory
-from app.core.security import create_access_token
-from app.models.pm import Story
-from app.models.project import OrgMember
-from app.models.project_access import ProjectAccess
-from app.models.user import User
+from scripts.jobs._db_env import resolve_database_url
+
+_db_url_summary = resolve_database_url()
+
+from app.core.database import async_session_factory  # noqa: E402 — 위 폴백이 먼저 돌아야 한다
+from app.core.security import create_access_token  # noqa: E402
+from app.models.pm import Story  # noqa: E402
+from app.models.project import OrgMember  # noqa: E402
+from app.models.project_access import ProjectAccess  # noqa: E402
+from app.models.user import User  # noqa: E402
 
 
 def _env(name: str) -> str:
@@ -52,7 +61,10 @@ async def main() -> int:
     backend = _env("BACKEND_URL").rstrip("/")
     org_id = uuid.UUID(_env("ORG_ID"))
     project_id = uuid.UUID(_env("PROJECT_ID"))
-    _env("DATABASE_URL")  # async_session_factory가 settings.database_url로 이미 바인딩
+    if _db_url_summary is None:
+        print("[FAIL] DATABASE_URL·ALEMBIC_URL 둘 다 미설정", file=sys.stderr)
+        sys.exit(2)
+    print(f"[db] {_db_url_summary}", file=sys.stderr)  # async_session_factory가 이미 바인딩된 값
     _env("JWT_SECRET")
 
     suffix = uuid.uuid4().hex[:10]

--- a/backend/tests/test_2386_scripts_jobs_db_url_fallback_lint.py
+++ b/backend/tests/test_2386_scripts_jobs_db_url_fallback_lint.py
@@ -1,0 +1,110 @@
+"""story #2386 — `scripts/jobs/` 안에서 DB에 붙는 스크립트가 `DATABASE_URL`을 직접 읽고
+`_db_env.resolve_database_url()`(#2769)을 안 거치면 CI가 잡는다.
+
+배경: `sprintable-verify-oneoff`(dev Cloud Run Job)의 환경은 `DATABASE_URL`이 아니라
+`ALEMBIC_URL`만 준다. 이 폴백 없이 이동/작성된 스크립트는 로컬(항상 DATABASE_URL 있음)에선
+멀쩡히 돌다가 그 잡에서만 "DATABASE_URL 미설정"으로 죽는다 — 이미 세 번 반복됐다:
+  2026-07-31  오르테가, backfill_reference_semantic_candidates.py에 인라인으로 처음 붙임
+  2026-08-01  카디르군 REQUEST_CHANGES, story #2384가 옮긴 두 스크립트에 누락된 것을 잡음
+  2026-08-01  이 스토리 — 옮기기 전부터 있던 다섯(아래 AC3 참고)이 같은 구멍으로 남아 있었다
+매번 "그때그때 손으로 고친다"였지 재발을 막는 자리가 없었다 — 이 lint가 그 자리다.
+
+## AC5 — 판별은 allowlist가 아니라 «파생»이다
+#2769의 `test_2384_scripts_root_image_exclusion_lint.py`는 손으로 유지하는 allowlist를 쓰지만,
+여기서는 그 방식을 안 따른다 — "DB에 안 붙는 스크립트는 대상 아님"을 실제 import(
+`app.core.database`)로 판별한다. 지금 `scripts/jobs/`의 유일한 비-DB 파일(`_db_env.py` 자신)이
+이 조건 하나로 이미 정확히 빠진다(아래 test로 실측) — 손 allowlist를 하나 더 만들면 그 자체가
+#2387이 잡으려는 "손 스냅샷" 병의 다섯 번째 사례가 된다. `resolve_database_url`을 실제로
+호출하는지까지는 안 본다(문자열 존재만) — AC6 참고.
+
+## AC6 — 이 lint가 못 잡는 것
+  ㉠`resolve_database_url` 문자열이 있어도 실제로 **호출**하지 않거나(예: 그냥 import만),
+    호출 위치가 `app.core.database` import보다 **뒤**면(늦은 폴백) 정적으로 못 잡는다 —
+    `test_2384_scripts_jobs_alembic_url_fallback.py`가 그 세 스크립트에 한해 그 순서를
+    실행으로 확認하지만, 이 lint는 문자열 존재만 보는 더 얕은 축이다.
+  ㉡`app.core.database`를 안 거치고 다른 방식(raw psycopg2 등)으로 DB에 붙으면 `_touches_db`가
+    False라 스코프 밖으로 빠진다 — 지금 레포에 그런 스크립트는 없다(실측, 아래 classify 참고).
+  ㉢`scripts/jobs/` 밖(예: `backend/scripts/` 루트 — 그건 #2384의 다른 lint 담당)은 안 본다.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_SCRIPTS_JOBS_ROOT = Path(__file__).resolve().parent.parent / "scripts" / "jobs"
+
+_APP_CORE_DATABASE_IMPORT_RE = re.compile(r"from\s+app\.core\.database\s+import|^\s*import\s+app\.core\.database", re.MULTILINE)
+_RESOLVE_HELPER_RE = re.compile(r"resolve_database_url")
+
+# _db_env.py 자신은 스캔 대상이 아니다 — 헬퍼 구현 자체라 app.core.database를 안 거치고
+# (touches_db=False, 실측 확認) resolve_database_url을 "정의"할 뿐 "호출해 안전해질" 스크립트가
+# 아니다. 별도 근거 문서화 없이도 아래 _touches_db 조건 하나로 이미 자동 제외된다.
+
+
+def _touches_db(content: str) -> bool:
+    return bool(_APP_CORE_DATABASE_IMPORT_RE.search(content))
+
+
+def _uses_fallback_helper(content: str) -> bool:
+    return bool(_RESOLVE_HELPER_RE.search(content))
+
+
+def find_violations(root: Path) -> list[str]:
+    """DB에 붙는데(app.core.database import) resolve_database_url 폴백을 안 쓰는 스크립트 이름."""
+    violations = []
+    for f in sorted(root.glob("*.py")):
+        if f.name == "_db_env.py":
+            continue
+        content = f.read_text(encoding="utf-8")
+        if _touches_db(content) and not _uses_fallback_helper(content):
+            violations.append(f.name)
+    return violations
+
+
+# ── AC2 — 실제로 무는지: 폴백 없는 파일을 심어 빨개지는 것 + 정상 파일은 안 걸리는 것 ──
+
+def test_flags_a_script_that_touches_db_without_the_fallback_helper(tmp_path):
+    (tmp_path / "bad_script.py").write_text(
+        "import os\nfrom app.core.database import async_session_factory\n"
+        "if not os.environ.get('DATABASE_URL'):\n    raise SystemExit(2)\n",
+        encoding="utf-8",
+    )
+    assert find_violations(tmp_path) == ["bad_script.py"]
+
+
+def test_does_not_flag_a_script_using_the_fallback_helper(tmp_path):
+    (tmp_path / "good_script.py").write_text(
+        "from scripts.jobs._db_env import resolve_database_url\n"
+        "_db_url_summary = resolve_database_url()\n"
+        "from app.core.database import async_session_factory\n",
+        encoding="utf-8",
+    )
+    assert find_violations(tmp_path) == []
+
+
+def test_does_not_flag_a_script_that_never_touches_the_db(tmp_path):
+    (tmp_path / "no_db_script.py").write_text(
+        "import os\nprint('does not need DATABASE_URL at all')\n",
+        encoding="utf-8",
+    )
+    assert find_violations(tmp_path) == []
+
+
+# ── AC1/AC3 — 실제 저장소 ──────────────────────────────────────────────────
+
+def test_scripts_jobs_use_resolve_database_url_fallback():
+    violations = find_violations(_SCRIPTS_JOBS_ROOT)
+    assert not violations, (
+        f"scripts/jobs/에 DB에 붙는데 resolve_database_url() 폴백이 없는 스크립트: {violations}. "
+        "sprintable-verify-oneoff(dev Cloud Run Job)는 DATABASE_URL이 아니라 ALEMBIC_URL만 줘서 "
+        "이 스크립트들은 로컬에서만 멀쩡하고 그 잡에서는 죽는다. scripts/jobs/_db_env.py의 "
+        "resolve_database_url()을 app.core.database import보다 먼저 호출하라 — "
+        "backfill_reference_semantic_candidates.py를 참고."
+    )
+
+
+def test_db_env_helper_itself_is_excluded_because_it_does_not_touch_the_db():
+    """_db_env.py가 스캔 대상에서 빠지는 이유가 하드코딩 allowlist가 아니라 실제 import 부재
+    (touches_db=False)임을 실측으로 고정 — AC5가 파생이라고 주장하는 것의 증거."""
+    content = (_SCRIPTS_JOBS_ROOT / "_db_env.py").read_text(encoding="utf-8")
+    assert not _touches_db(content)


### PR DESCRIPTION
## Summary
- AC1: guard first — `backend/tests/test_2386_scripts_jobs_db_url_fallback_lint.py` fails CI if any `scripts/jobs/*.py` script touches the DB (`app.core.database` import) without referencing `resolve_database_url` (#2769's helper) anywhere.
- AC5: exemption is **derived**, not an allowlist — a script is in scope iff it imports `app.core.database`. `_db_env.py` itself is excluded because it doesn't import `app.core.database` (proven by `test_db_env_helper_itself_is_excluded_because_it_does_not_touch_the_db`, not asserted by a hardcoded name). Deliberately avoided adding a hand-maintained allowlist the same day #2387 was filed for exactly that failure class (`RENAMED_RESOURCE_ALIASES` drifting from `proxy.ts`).
- AC3: the guard found **five**, not the four named in #2769's README — `verify_grant_only_story_assign.py` has the identical bug (`app.core.database` imported at module top, before its `DATABASE_URL` check) but wasn't in the "known gap" list. Fixed all five with the established pattern.
- AC4: removed the README's "known gap" paragraph — the gap it described no longer exists.

## AC2 — guard actually bites (real pytest run, before the fix)
```
$ uv run pytest -q tests/test_2386_scripts_jobs_db_url_fallback_lint.py
...F.                                                                    [100%]
AssertionError: scripts/jobs/에 DB에 붙는데 resolve_database_url() 폴백이 없는 스크립트:
['audit_apikey_member_anchor.py', 'backfill_doc_base64_assets.py',
 'backfill_void_empty_merge_gates.py', 'purge_test_agents.py', 'verify_grant_only_story_assign.py']
1 failed, 4 passed in 0.06s
```
The 4 passing tests are the tmp_path-based mutation checks (plant a violation → red; normal fixture → green; non-DB fixture → green) plus the `_db_env.py`-exclusion proof — all pass independent of the real-repo state, confirming the logic itself (not just today's file set).

## Fix verified end-to-end, not just statically
For each of the five, actually imported it under an ALEMBIC_URL-only environment (same method 카디르군 used to verify the three #2769 scripts):
```
env -u DATABASE_URL ALEMBIC_URL="postgresql+psycopg2://u:secret-pw@alembic-host:5432/db" \
  uv run python -c "import scripts.jobs.<name>; ..."
```
All five: `_db_url_summary` shows `ALEMBIC_URL(스킴 변환) → scheme=postgresql+asyncpg host=alembic-host`, `DATABASE_URL` env var gets populated with the converted asyncpg URL, and the credential (`secret-pw`) never appears in the summary string.

## AC6 — what this lint doesn't catch
- Whether `resolve_database_url` is actually *called* (vs merely imported) or called *before* the `app.core.database` import (late-fallback is still broken) — that ordering is only verified for the three scripts `test_2384_scripts_jobs_alembic_url_fallback.py` already covers by import-order execution, not by this static lint.
- Non-`app.core.database` DB access paths (e.g. raw psycopg2) — none currently exist in `scripts/jobs/`, verified by grep.
- Anything outside `scripts/jobs/` (`backend/scripts/` root is #2384's separate lint).

## Test plan
- [x] `uv run pytest -q tests/test_2386_scripts_jobs_db_url_fallback_lint.py` — 5/5 passing after the fix (was 4/5 before, see AC2 log above).
- [x] Five `env -u DATABASE_URL ALEMBIC_URL=...` import checks — all pass (see above).
- [x] `python -c "import ast; ast.parse(...)"` on all 5 edited scripts — syntax OK.
- [x] `uv run pytest -q --collect-only` (full backend suite, 6209 tests) — 0 collection errors, confirms nothing else that imports these 5 scripts broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)