### PR TITLE
fix(#2381): auto-schedule agent wake in assign_recipient_seq() — dispatch_notification() never fired it

### DIFF
--- a/backend/app/services/event_seq.py
+++ b/backend/app/services/event_seq.py
@@ -1,23 +1,45 @@
-"""per-recipient dense commit-ordered seq 발급 헬퍼.
+"""per-recipient dense commit-ordered seq 발급 헬퍼 + commit 후 자동 wake 예약.
 
 이벤트 생성과 동일 트랜잭션에서 호출해야 직렬화 보장.
 카운터 row-lock → seq N+1은 N 커밋 전에 발급 불가 → commit 순서 = seq 순서 = dense.
 abort 시 카운터도 롤백 → 빈 번호 없음.
+
+story #2381 — dispatch_notification()의 ~20개 호출부 어디도 commit 후 wake_agent()를 부르지
+않아, 연결 中인 에이전트가 다음 재연결(SSE lifespan cap, 최대 300s+지터)까지 새 이벤트를
+몰랐다(근본: 부르는 것 자체가 없었다). "각 호출부가 commit 후 기억해서 불러야 한다"는 조건부
+계약을 하나 더 추가하는 대신 — assign_recipient_seq()가 agent Event 가시성(/stream 커서 쿼리
+`recipient_seq > after_seq`)의 유일한 관문이라는, #2375가 이미 세운 불변식을 그대로 이용해
+여기 한 곳에 자동 예약을 건다. 새 호출부가 생겨도(현재도 미래도) 이 함수를 거치지 않고는
+agent Event가 애초에 안 보이므로, wake 도 구조적으로 놓칠 수 없다 — commit=False로 세션에
+합류하는 호출부(예: gates.py의 기존 agent_wake 반환값 스레딩 경로, 0f428e1e 사고 계열)도 같은
+db 세션 객체에 훅이 걸리므로 그 스레딩이 틀려도 이제 무음이 되지 않는다(다만 그 기존 경로를
+이 스토리에서 제거하지는 않았다 — 중복 발화는 무해하고, 이미 검증된 코드의 블라스트 반경을
+필요 이상으로 건드리지 않기 위함. scripts/jobs/README.md에 남긴 "알려진 갭, 안 고침"과 같은
+판단).
 """
 from __future__ import annotations
 
-import uuid
+import logging
 
+from sqlalchemy import event as sa_event
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
 
 from app.models.event import Event
+
+logger = logging.getLogger(__name__)
+
+_PENDING_WAKES_KEY = "e2381_pending_agent_wakes"
+_HOOKED_KEY = "e2381_wake_hook_installed"
 
 
 async def assign_recipient_seq(db: AsyncSession, event: Event) -> int:
     """같은 트랜잭션에서 per-recipient seq 발급 후 event.recipient_seq 설정.
 
-    반드시 Event INSERT + flush 후, commit 전에 호출.
+    반드시 Event INSERT + flush 후, commit 전에 호출. 이 세션이 실제로 commit에 성공하면
+    자동으로 이 recipient에게 wake_agent()가 발화되도록 예약한다(호출자가 별도로 부를 필요
+    없음 — _schedule_wake_after_commit 참고).
     """
     result = await db.execute(
         text("""
@@ -32,4 +54,54 @@ async def assign_recipient_seq(db: AsyncSession, event: Event) -> int:
     )
     seq: int = result.scalar_one()
     event.recipient_seq = seq
+    _schedule_wake_after_commit(db, str(event.recipient_id), seq)
     return seq
+
+
+def _schedule_wake_after_commit(db: AsyncSession, recipient_id: str, seq: int) -> None:
+    """commit 성공 後 wake_agent(recipient_id, seq)가 정확히 한 번 자동 발화되도록 세션에 예약.
+
+    ⛔wake_agent()를 여기서 직접 부르지 않는다 — 아직 commit 前이면 recipient는 이 row를 볼 수
+    없다(MVCC 가시성 레이스 — 이 스토리의 본체). SQLAlchemy의 `after_commit` 세션 이벤트는 실제
+    COMMIT이 성공한 뒤에만(rollback 시엔 아예 안 불림) 호출을 보장한다 — "commit 후에"를 코드
+    규율이 아니라 트랜잭션 경계 자체가 강제하게 만든다.
+
+    ⚠️단위테스트가 db를 MagicMock/AsyncMock으로 대체하는 경로(assign_recipient_seq를 직접
+    호출하는 기존 테스트 다수)에서는 `sync_session`이 진짜 Session이 아니라 SQLAlchemy가
+    `event.listen()`에서 InvalidRequestError를 던진다 — 조용히 스킵한다(프로덕션은 db가 항상
+    실 AsyncSession이라 여기 걸릴 일이 없다).
+    """
+    sync_session = db.sync_session
+    if not isinstance(sync_session, Session):
+        logger.debug(
+            "wake scheduling skipped — db.sync_session is not a real Session (test double?) "
+            "recipient_id=%s", recipient_id,
+        )
+        return
+    pending: list[tuple[str, int]] = sync_session.info.setdefault(_PENDING_WAKES_KEY, [])
+    pending.append((recipient_id, seq))
+    if not sync_session.info.get(_HOOKED_KEY):
+        sync_session.info[_HOOKED_KEY] = True
+        sa_event.listen(sync_session, "after_commit", _fire_pending_wakes)
+        sa_event.listen(sync_session, "after_rollback", _clear_pending_wakes_on_rollback)
+
+
+def _fire_pending_wakes(sync_session: Session) -> None:
+    pending = sync_session.info.pop(_PENDING_WAKES_KEY, None) or []
+    if not pending:
+        return
+    from app.routers.agent_gateway import wake_agent
+
+    for recipient_id, seq in pending:
+        try:
+            wake_agent(recipient_id, seq)
+        except Exception:
+            logger.warning(
+                "post-commit wake_agent failed recipient_id=%s seq=%s", recipient_id, seq, exc_info=True,
+            )
+
+
+def _clear_pending_wakes_on_rollback(sync_session: Session) -> None:
+    """롤백된 트랜잭션에서 쌓인 예약은 버린다 — 같은 세션이 다음 트랜잭션에 재사용돼도
+    이전 롤백분이 잘못 발화되지 않도록(_HOOKED_KEY는 유지 — 리스너 재등록 방지, 예약 목록만 초기화)."""
+    sync_session.info.pop(_PENDING_WAKES_KEY, None)

--- a/backend/tests/test_2381_wake_after_commit_race_realdb.py
+++ b/backend/tests/test_2381_wake_after_commit_race_realdb.py
@@ -1,0 +1,241 @@
+"""story #2381 — wake_agent()이 commit 前에 발화되면 수신자가 아직 그 Event row를 못 보는
+레이스를 실제로 재현해 보인 뒤(AC3: "재현 없이 «이렇게 하면 안전하다»로 넘어가지 않는다"),
+고친 뒤 그 레이스가 구조적으로 사라지는 것까지 같은 파일에서 보인다.
+
+배경: dispatch_notification()의 agent-recipient Event 생성 경로는 지금까지 어디서도
+wake_agent()를 부르지 않았다(이 스토리의 근본 — /stream은 wake 신호가 큐에 와야 DB를
+재조회하므로, 연결 中인 에이전트도 다음 재연결까지 새 이벤트를 몰랐다). event_seq.py의
+assign_recipient_seq()에 "commit 성공 後에만" wake_agent()가 자동 발화되도록 예약을 걸어
+고쳤다 — 호출부(dispatch_notification()의 ~20곳, 현재도 미래도)가 wake를 기억해서 불러야
+한다는 조건부 계약을 추가하는 대신, agent Event 가시성의 유일한 관문(#2375가 세운 불변식)에
+자동으로 묶어 "부르는 것을 잊으면 재발한다"는 조건 자체를 없앴다(AC2).
+
+실 PG 필요 — MVCC 가시성(별개 커넥션 간 실제 트랜잭션 격리)은 mock으로도 SQLite로도 재현
+불가능하다. 이 파일 자체가 그 격리를 증명 대상으로 삼는다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# story 8236bbc3: create_all로 자체 스키마를 직접 다룸 — 격리 DB 전용(conftest.py 가드).
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _asyncpg_url(url: str) -> str:
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+def _raw_url(url: str) -> str:
+    """asyncpg.connect()가 받는 순수 postgresql:// (SQLAlchemy 드라이버 접미사 제거)."""
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://"):
+        if url.startswith(prefix):
+            return "postgresql://" + url[len(prefix):]
+    return url
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.event  # noqa: F401
+    engine = create_async_engine(_asyncpg_url(_REAL_DB_URL))
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project_agent(s):
+    from app.models.project import Project
+    from app.models.team import TeamMember
+
+    org, proj = uuid.uuid4(), uuid.uuid4()
+    s.add(Project(id=proj, org_id=org, name="p"))
+    await s.flush()
+    agent = TeamMember(
+        id=uuid.uuid4(), org_id=org, project_id=proj, type="agent",
+        name="agent", role="member", is_active=True,
+    )
+    s.add(agent)
+    await s.flush()
+    await s.commit()
+    return org, proj, agent.id
+
+
+async def _visible_recipient_seq_count(raw_url: str, recipient_id: uuid.UUID, after_seq: int) -> int:
+    """agent_gateway.py `_fetch_events`의 커서 조건(recipient_seq > after_seq)과 동일 — 별개
+    (raw asyncpg) 커넥션에서 조회해 진짜 cross-transaction MVCC 가시성을 잰다. 같은 세션 내
+    조회는 flush만으로도 보여 이 레이스를 재현하지 못한다."""
+    import asyncpg
+    conn = await asyncpg.connect(raw_url)
+    try:
+        return int(await conn.fetchval(
+            "SELECT count(*) FROM events WHERE recipient_id = $1 AND recipient_seq > $2",
+            recipient_id, after_seq,
+        ))
+    finally:
+        await conn.close()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_race_reproduced_wake_before_commit_sees_invisible_row():
+    """AC3 재현: commit 前에 "wake"(=다른 커넥션이 재조회하라는 신호)가 나가면, 바로 그 순간
+    다른 커넥션이 같은 커서 쿼리를 돌려도 0건이다 — "깨웠지만 아직 아무것도 없다"는 헛걸음이
+    실제로 존재함을, 구식(commit 前 발화) 패턴으로 직접 재현한다. event_seq.py의 새 자동예약과
+    무관하게, "commit 前 wake"라는 패턴 자체가 왜 위험한지를 독립적으로 증명하는 대조군."""
+    raw_url = _raw_url(_asyncpg_url(_REAL_DB_URL))
+    engine, Session = await _session()
+    try:
+        async with Session() as seed_s:
+            org, proj, agent_id = await _seed_org_project_agent(seed_s)
+
+        from app.models.event import Event
+        from app.services.event_seq import assign_recipient_seq
+
+        async with Session() as s:
+            event = Event(
+                project_id=proj, org_id=org, event_type="dispatched",
+                recipient_id=agent_id, recipient_type="agent",
+                payload={"content": "x"}, status="pending",
+            )
+            s.add(event)
+            await s.flush()
+            seq = await assign_recipient_seq(s, event)
+
+            # ⛔구식 패턴 재현: commit 前에 wake 신호(=다른 커넥션의 재조회)가 이미 도착했다고 가정.
+            visible_before_commit = await _visible_recipient_seq_count(raw_url, agent_id, seq - 1)
+            assert visible_before_commit == 0, (
+                "레이스가 재현되지 않았다 — commit 前인데 다른 커넥션에 row가 보인다면 "
+                "이 테스트의 전제(MVCC 격리)가 깨진 것이다"
+            )
+
+            await s.commit()
+
+            visible_after_commit = await _visible_recipient_seq_count(raw_url, agent_id, seq - 1)
+            assert visible_after_commit == 1, "commit 後에는 반드시 보여야 한다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_fix_wake_fires_only_after_commit_and_row_already_visible_by_then(monkeypatch):
+    """고친 뒤: assign_recipient_seq()가 예약한 wake는 db.commit() 호출 안에서(반환 전에) 정확히
+    한 번 발화되고, 그 발화 시점엔 이미 다른 커넥션에서도 row가 보인다 — 위 대조군이 재현한
+    레이스가 이 경로에서는 구조적으로 성립할 수 없음을 보인다(재현 후 소거, AC3 요구)."""
+    raw_url = _raw_url(_asyncpg_url(_REAL_DB_URL))
+    engine, Session = await _session()
+    try:
+        async with Session() as seed_s:
+            org, proj, agent_id = await _seed_org_project_agent(seed_s)
+
+        from app.models.event import Event
+        from app.services.event_seq import assign_recipient_seq
+        import app.routers.agent_gateway as gw_mod
+
+        woken: list[tuple[str, int]] = []
+        monkeypatch.setattr(gw_mod, "wake_agent", lambda rid, seq: woken.append((rid, seq)))
+        # event_seq._fire_pending_wakes는 `from app.routers.agent_gateway import wake_agent`를
+        # 발화 시점에 매번 late-import하므로, gw_mod 속성을 바꾸는 것만으로 monkeypatch가 반영된다.
+
+        async with Session() as s:
+            event = Event(
+                project_id=proj, org_id=org, event_type="dispatched",
+                recipient_id=agent_id, recipient_type="agent",
+                payload={"content": "x"}, status="pending",
+            )
+            s.add(event)
+            await s.flush()
+            seq = await assign_recipient_seq(s, event)
+
+            assert woken == [], "commit 前인데 이미 wake가 발화됐다 — 레이스 재발"
+
+            await s.commit()
+
+        assert woken == [(str(agent_id), seq)], f"commit 後 정확히 한 번 발화돼야 하는데: {woken}"
+
+        visible = await _visible_recipient_seq_count(raw_url, agent_id, seq - 1)
+        assert visible == 1
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_rollback_never_fires_wake(monkeypatch):
+    """seq 발급 트랜잭션이 rollback되면 wake는 절대 발화되지 않아야 한다(존재하지 않게 될 row를
+    가리키는 헛된 wake 방지)."""
+    engine, Session = await _session()
+    try:
+        async with Session() as seed_s:
+            org, proj, agent_id = await _seed_org_project_agent(seed_s)
+
+        from app.models.event import Event
+        from app.services.event_seq import assign_recipient_seq
+        import app.routers.agent_gateway as gw_mod
+
+        woken: list[tuple[str, int]] = []
+        monkeypatch.setattr(gw_mod, "wake_agent", lambda rid, seq: woken.append((rid, seq)))
+
+        async with Session() as s:
+            event = Event(
+                project_id=proj, org_id=org, event_type="dispatched",
+                recipient_id=agent_id, recipient_type="agent",
+                payload={"content": "x"}, status="pending",
+            )
+            s.add(event)
+            await s.flush()
+            await assign_recipient_seq(s, event)
+            await s.rollback()
+
+        assert woken == []
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_multiple_dispatches_same_session_each_wake_exactly_once(monkeypatch):
+    """한 세션에서 여러 번 commit(=여러 dispatch)해도 매번 그 트랜잭션분만 정확히 한 번씩
+    발화한다 — 세션 재사용 시 리스너 중복등록(이중발화)도, 예약 누락(무발화)도 없어야 한다."""
+    engine, Session = await _session()
+    try:
+        async with Session() as seed_s:
+            org, proj, agent_id = await _seed_org_project_agent(seed_s)
+
+        from app.models.event import Event
+        from app.services.event_seq import assign_recipient_seq
+        import app.routers.agent_gateway as gw_mod
+
+        woken: list[tuple[str, int]] = []
+        monkeypatch.setattr(gw_mod, "wake_agent", lambda rid, seq: woken.append((rid, seq)))
+
+        async with Session() as s:
+            seqs = []
+            for _ in range(3):
+                event = Event(
+                    project_id=proj, org_id=org, event_type="dispatched",
+                    recipient_id=agent_id, recipient_type="agent",
+                    payload={"content": "x"}, status="pending",
+                )
+                s.add(event)
+                await s.flush()
+                seqs.append(await assign_recipient_seq(s, event))
+                await s.commit()
+
+        assert woken == [(str(agent_id), seq) for seq in seqs]
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary

`dispatch_notification()`'s ~20 call sites never called `wake_agent()` after their own commit. `/stream` only re-queries the DB when a wake signal arrives in its queue — so an already-connected agent had no way to learn about a new event until its next reconnect (SSE lifespan cap, up to ~300s + jitter). Story #2381.

PO's own dev measurements today found this had partially self-healed since #2764 (recipient_seq assignment) — samples arrived 22s~4min later instead of never — but that's consistent with periodic-reconnect backfill luck, not a real wake firing (`dispatch_notification()` has zero `wake_agent()` calls anywhere). The already-correct path (`_finalize_dispatch()`, used by entity-assignee dispatch e.g. `ready-for-dev`) already called `wake_agent()` after its own commit — that's a separate, unaffected code path.

## AC1 — root cause confirmed by code, not just measurement

`dispatch_notification()` (`app/services/notification_dispatch.py`) creates the agent-recipient `Event` and assigns `recipient_seq` (#2375), but never calls `wake_agent()`. Grepped every `wake_agent()` call site — none originate from `dispatch_notification()`'s ~20 callers.

## AC2 — condition-free fix, not "remember to call it"

Instead of adding "call `wake_agent()` after your commit" as a contract every current *and future* `dispatch_notification()` call site has to remember (the same forgettable-condition class as today's earlier #2384 README-vs-code drift), this hooks the wake into `assign_recipient_seq()` (`event_seq.py`) — the one function every agent-recipient `Event` already has to go through to become visible on `/stream` at all (#2375's own invariant: `recipient_seq IS NULL` never passes the stream's cursor filter).

A SQLAlchemy `after_commit` session-instance listener fires `wake_agent()` exactly once per transaction, only once `COMMIT` has actually succeeded (never on rollback). This makes "commit before wake" a transaction-boundary guarantee instead of call-site discipline — covers all 6 existing `assign_recipient_seq()` callers (`a2a.py`, `agent_dispatch.py`, `conversations.py`×2, `story_assignee_events.py`, `agent_verify.py`, `notification_dispatch.py`) and any future one, with zero changes to any of them.

Left `_finalize_dispatch()`'s existing manual `wake_agent()` call and `gates.py`'s `agent_wake` threading in place — now redundant (harmless duplicate wake) but out of scope to remove today given the blast radius of already-verified, already-tested code. Noted in the fix commit for a future cleanup if wanted.

## AC3 — race reproduced, then shown to disappear

`test_2381_wake_after_commit_race_realdb.py` (real Postgres — MVCC visibility across independent connections isn't mockable):
- **Control**: reproduces the danger directly — calling a wake-equivalent signal before commit, then querying from a *separate* connection, returns 0 rows even though the row was just flushed. Proves the race class is real.
- **Fix**: proves the new scheduling never fires before `db.commit()` returns, fires exactly once after, and by the time it fires the row is already visible from another connection.
- Rollback never fires the wake.
- Session reuse across multiple commits fires exactly once per transaction (no double-registration, no missed transactions).

## Bonus: a real crash this surfaced

`assign_recipient_seq()` is called by several existing unit tests with a mocked `db` session. `sqlalchemy.event.listen()` raises `InvalidRequestError` on a non-`Session` mock target — would have broken those tests. Guarded with `isinstance(sync_session, Session)` (production `db` is always a real `AsyncSession`; test doubles skip gracefully). Verified via positive control — removing the guard reproduces the crash.

## Verification

Local Postgres scratch DB (no dev DB access — [[reference_prod_db_query]] dev item). 138 passed across the new test file plus every existing wake/dispatch-adjacent test file (`test_ccbcd9da_gate_wake_wiring_realdb`, `test_gateway_ack_realdb`, `test_gateway_realdb_race`, `test_notification_dispatch`, `test_agent_dispatch`, `test_a2a`, `test_e_event_inject_s3/s4`, `test_l2_e2e_status_changed`, `test_conversations`, `test_agent_gateway`, etc.). A wider `team_members`-VIEW-dependent realdb sweep (conversations/a2a/participants tests) fails locally against my `create_all()`-only scratch DB — confirmed via baseline diff that this is a pre-existing local-environment gap (needs true alembic migration + pgvector), not something this change caused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)