### PR TITLE
fix(#2380): human dispatched Events marked delivered but never stamp delivered_at

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -2,8 +2,14 @@
 
 C-S6: SSE 스트림 (메모 변경 이벤트 실시간 푸시)
 E-EVENTBUS S1: events 테이블 CRUD (이벤트버스 기반)
-E-EVENTBUS S2: MCP Streamable HTTP SSE 푸시 (에이전트 전용)
+E-EVENTBUS S2: MCP Streamable HTTP SSE 푸시 (에이전트 전용 — 단, `resolve_member_identity`가
+grant-only human(OrgMember)도 해소하므로 이 스트림 자체는 human도 실제로 붙을 수 있다. #2380)
 E-EVENTBUS S3: 이벤트 큐 + 오프라인 재전달 (at-least-once + 배치 + expired)
+
+story #2380: `Event.status`와 `Event.read_at`은 별개 축이다 — `status`는 "배달됐는가"(pending
+→delivered/expired), `read_at`은 "사람이 열람했는가"(event_notifications.py가 관리, status와
+무관하게 갱신). 두 값을 섞어 읽지 않는다 — status=delivered·read_at=NULL은 정상(배달됐지만
+아직 안 읽음)이지 결함이 아니다.
 """
 from __future__ import annotations
 

--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -342,6 +342,13 @@ async def dispatch_notification(
                                 recipient_type="human",
                                 payload={"title": title, "body": body, "event_type": event_type},
                                 status="delivered",
+                                # ⛔이 순간이 "배달 시도 순간"과 같다고 볼 수 있는 건 이 분기가
+                                # 지금 동기라서다 — 바로 다음 줄들이 실제 배달 행위(Notification
+                                # INSERT·개인 webhook 시도)를 같은 호출 안에서 한다. 이 경로가
+                                # 나중에 진짜 비동기(예: webhook 배달확認 콜백)가 되면 이 값도
+                                # 그 확認 시점으로 옮겨야 한다 — 여기 그대로 둔 채 비동기화하면
+                                # #2380이 고친 문제(delivered_at이 실제 배달 시점을 안 가리킴)가
+                                # 값이 없는 대신 "틀린 값"으로 재발한다.
                                 delivered_at=datetime.now(timezone.utc),
                             )
                             db.add(event)

--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from datetime import datetime, timezone
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -323,6 +324,13 @@ async def dispatch_notification(
                 if member_row.project_id:
                     try:
                         async with db.begin_nested():
+                            # story #2380: 이 분기는 human Event를 생성 즉시 status="delivered"로
+                            # 박는다(human은 agent SSE ack 사이클을 안 타므로 pending을 안 거치는
+                            # 것 자체는 맞다) — 그런데 delivered_at을 한 번도 안 채워 왔다. dev
+                            # 실측(2026-08-01): 이 경로로 난 human Event의 74%가 status=delivered
+                            # 인데 delivered_at=NULL — "배달됐다"만 있고 "언제"가 없어, 이 값을
+                            # coalesce(delivered_at, now())로 지연을 재려던 첫 시도가 「p50 9.4일」
+                            # 이라는 거짓 수치를 냈다(실제로는 그 행들 나이가 now()로 치환된 것).
                             event = Event(
                                 project_id=member_row.project_id,
                                 org_id=org_id,
@@ -334,6 +342,7 @@ async def dispatch_notification(
                                 recipient_type="human",
                                 payload={"title": title, "body": body, "event_type": event_type},
                                 status="delivered",
+                                delivered_at=datetime.now(timezone.utc),
                             )
                             db.add(event)
                         created_events.append(event)

--- a/backend/tests/test_notification_dispatch.py
+++ b/backend/tests/test_notification_dispatch.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -190,6 +191,52 @@ async def test_grant_only_human_gets_notification(mock_session, org_id):
     added = mock_session.add.call_args[0][0]
     assert added.user_id == user_id
     assert added.title == "그랜트 알림"
+
+
+# ─── story #2380: human Event는 status="delivered"와 함께 delivered_at도 찍혀야 한다 ──
+
+@pytest.mark.anyio
+async def test_human_dispatched_event_gets_delivered_at_stamped(mock_session, org_id):
+    """dev 실측(2026-08-01): 이 분기가 만드는 human Event의 74%가 status="delivered"인데
+    delivered_at=NULL이었다 — "배달됐다"만 있고 "언제"가 없어, delivered_at 대신 now()로
+    지연을 재려던 첫 측정이 실제와 무관한 거짓 수치(p50 9.4일)를 냈다. status="delivered"를
+    박는 바로 그 자리에서 delivered_at도 같이 찍여야 한다."""
+    from app.services.notification_dispatch import dispatch_notification
+
+    member_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+
+    settings = _settings_result([])
+    wh_result = MagicMock()
+    wh_result.scalars.return_value.all.return_value = []
+    members = _members_result([(member_id, user_id)], project_id=project_id)
+    mock_session.execute.side_effect = [settings, wh_result, members]
+
+    before = datetime.now(timezone.utc)
+    await dispatch_notification(
+        mock_session,
+        org_id=org_id,
+        event_type="dispatched",
+        target_member_ids=[member_id],
+        title="상태 변경",
+        body="pending → in-progress",
+        reference_type="story",
+        reference_id=uuid.uuid4(),
+    )
+    after = datetime.now(timezone.utc)
+
+    from app.models.event import Event
+
+    added_events = [
+        c.args[0] for c in mock_session.add.call_args_list if isinstance(c.args[0], Event)
+    ]
+    assert len(added_events) == 1, "이 경로는 human recipient당 Event를 정확히 하나 만들어야 한다"
+    event = added_events[0]
+    assert event.recipient_type == "human"
+    assert event.status == "delivered"
+    assert event.delivered_at is not None, "status=delivered인데 delivered_at이 없으면 #2380 재발"
+    assert before <= event.delivered_at <= after
 
 
 # ─── 빈 target → 즉시 반환 ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Story #2380 started as an investigation: #2375's expire-script scope decision relied on "human is always created status=delivered, immediately, never pending" — PO's own dev measurement disproved that (found human/pending/seq-NULL rows) and asked me to trace the real code paths. That investigation surfaced this bug.

## AC1 — two separate human "dispatched" Event sources, both identified

- `app/services/notification_dispatch.py` (`dispatch_notification()`'s human branch) — creates the Event with `status="delivered"` immediately at INSERT time.
- `app/services/agent_dispatch.py` (`_finalize_dispatch()`, shared by `dispatch_entity_to_assignee`/`dispatch_payload_to_member`) — creates a *second*, separate Event per human dispatch with `status="pending"`, which later transitions via the generic SSE stream (`events.py`, reachable by grant-only human org-members despite its "agent-only" docstring).

## AC2/AC3 — the actual bug, and the fix

`dispatch_notification()`'s human branch has never once set `delivered_at` — it just writes the literal string `status="delivered"` and moves on. `delivered_at` is nullable with no default, so it stays `NULL` forever on every row created this way.

PO's own dev measurement got directly misled by this today: a first pass at measuring human notification delivery latency via `coalesce(delivered_at, now()) - created_at` produced a bogus p50 of **9.4 days** — because 74% of these rows have `delivered_at=NULL`, so the query substituted each row's current *age* for its delivery latency. Re-measuring only rows with a real `delivered_at` gave the true, unremarkable p50 (~400s) — confirming this isn't a delivery-speed problem, purely a missing-timestamp one.

Fix: set `delivered_at=datetime.now(timezone.utc)` alongside `status="delivered"` at the same construction site.

Also added a short doc note at the top of `events.py`: for this event system, `status` (delivered vs pending) and `read_at` (consumed vs not) are independent axes — `status=delivered` + `read_at=NULL` is normal (delivered, not yet read), not a defect. Raw data without this framing is easy to misread (as today's investigation itself demonstrated).

## Verification

New test `test_human_dispatched_event_gets_delivered_at_stamped` in `tests/test_notification_dispatch.py` — asserts the Event this branch creates has `delivered_at` set to a timestamp within the call window. Verified via positive control (reverted the fix, confirmed the test fails on exactly that assertion; restored, confirmed green). Full existing `test_notification_dispatch.py` suite (14 tests) plus the broader wake/dispatch-adjacent battery (135 tests total) pass.

## Verification layer — what this PR's tests do and don't prove

PO flagged this explicitly and it's worth being precise about: three separate claims, three separate levels of confidence.
1. **The code sets the right value at construction time** — ✅ proven by the new mock-session test + positive control.
2. **The value actually persists to the real DB row** — ⚠️ a mock session can't test this (it never touches SQL). This needs QA against real Postgres.
3. **New human rows in dev/prod actually carry a `delivered_at` after this deploys** — ⚠️ only a live post-deploy measurement can confirm this (same pattern as #2381's AC1 — PO will re-check dev after merge).

Green tests here cover (1) only. Not claiming more than that.

## Is `datetime.now(timezone.utc)` at this call site the *right* moment — same as "actually delivered"?

PO's sharper question: even with a `delivered_at` value now present, is it measuring the right instant, or would it just replace "no data" with "wrong data"?

For this specific code path, I believe the answer is yes, they coincide — because the original code already treats "delivered" as synchronous for humans, not as the result of an async round-trip:
- Unlike the agent path (dispatch → SSE push → client ACK, a genuine time gap the `recipient_seq`/ack machinery exists to track), the human branch has no async delivery step to wait on inside `dispatch_notification()`. In the same function call, right after this Event is constructed, the code creates the actual in-app `Notification` row and attempts the personal-webhook POST (best-effort, result not persisted anywhere) — both of which are the *real* delivery actions for a human. There's no later "and now it's truly delivered" event this Event row is meant to precede or follow.
- `status="delivered"` was already being set unconditionally at construction, before my change — the original design's own position is "this row is delivered the moment it exists." My change doesn't move that decision point; it just timestamps a moment the code was already treating as instantaneous.
- So `delivered_at = now()` here means "the moment we decided this notification's job is done" — which, for this path, is the same moment as the `Notification` INSERT and the webhook attempt, i.e., the actual delivery attempt. It is not standing in for some later real-world confirmation that doesn't exist in this code path.

If a future change makes human delivery genuinely async here (e.g., an actual webhook-delivery-confirmation callback), `delivered_at` would need to move to that confirmation point instead of construction time — but as the code exists today, they're the same instant.

## AC4 — accepted from the investigation thread as-is

The 32 historical human-recipient rows with a non-null `recipient_seq` are a fixed artifact of the one-time `0071_per_recipient_dense_seq` migration backfill (unfiltered by `recipient_type`), predating every currently-live (correctly agent-gated) `assign_recipient_seq()` call site. Not growing, not touched by this PR.

## AC5 — acknowledged, not fixable in code

"When did an event get expired" is unmeasurable after the fact — `events` has no `updated_at` column. Noted, not addressed here (would need a schema change).

## Out of scope — follow-up stories tracked separately (per PO)

- `EventStatus` enum doesn't declare `"expired"` as a member (plain `Text` column, no DB check constraint — any raw string is writable).
- `events.py`'s `/events/stream` docstring says "agent-only" but grant-only human org-members can and do connect (confirmed via `resolve_member_identity`'s `OrgMember` fallback).
- The 30-day `expire_stale_events_core` cron (`events.py:799`) has no `recipient_type`/`event_type` filter — confirmed harmless so far via dev measurement (0 rows have ever been expired past the 30-day cutoff while still legitimately deliverable), but worth a scoped look later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
