### PR TITLE
refactor(web): derive RENAMED_RESOURCE_ALIASES/KNOWN_NON_PROJECT_ROUTES instead of hand-copying (story #2387)

### DIFF
--- a/apps/web/scripts/verify-no-orphan-resource-routes.test.ts
+++ b/apps/web/scripts/verify-no-orphan-resource-routes.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { RENAMED_RESOURCES, RETIRED_RESOURCES } from '../src/proxy';
 import {
   EXEMPT_TARGETS,
   extractComposedTargets,
@@ -125,7 +126,7 @@ describe('AC7 — 실제 저장소 첫 스캔의 검거(GRANDFATHER_BASELINE)이
   });
 });
 
-describe('EXEMPT_TARGETS — 실측 스냅샷 정합', () => {
+describe('EXEMPT_TARGETS — 파생 정합(story #2387)', () => {
   it('KNOWN_NON_PROJECT_ROUTES와 RENAMED_RESOURCE_ALIASES의 합집합이다', () => {
     expect(EXEMPT_TARGETS.size).toBe(KNOWN_NON_PROJECT_ROUTES.size + RENAMED_RESOURCE_ALIASES.size);
   });
@@ -134,5 +135,30 @@ describe('EXEMPT_TARGETS — 실측 스냅샷 정합', () => {
     for (const r of ['login', 'register', 'forgot-password', 'privacy', 'terms', 'verify-email', 'onboarding']) {
       expect(KNOWN_NON_PROJECT_ROUTES.has(r)).toBe(true);
     }
+  });
+});
+
+// story #2387 — RENAMED_RESOURCE_ALIASES는 이제 손 스냅샷이 아니라 proxy.ts를 직접 import해
+// 파생시킨다(AC1: 「어긋나는 길이 없어지는」 쪽). 아래는 그 파생이 실제로 두 표 모두를 보는지
+// 고정하는 회귀가드 — proxy.ts에 세 번째 키가 추가돼도(RENAMED_RESOURCES든 RETIRED_RESOURCES든)
+// 이 테스트가 같은 소스에서 다시 계산하므로 자동으로 통과한다. 실제 "proxy.ts가 바뀌면 자동
+// 반영되는가"는 CLI 뮤테이션으로 확인했다(PR 설명 — proxy.ts에 임시 키 추가 → 가드 재실행 →
+// exempt 수가 32로 늘어남(31→32) 확認 → 원복 → 31로 복귀. 커밋 없음).
+describe('RENAMED_RESOURCE_ALIASES — proxy.ts에서 실제로 파생되는지(AC1/AC2)', () => {
+  it('RENAMED_RESOURCES ∪ RETIRED_RESOURCES 키와 정확히 같다(같은 소스에서 다시 계산해도 일치)', () => {
+    const expected = new Set([...Object.keys(RENAMED_RESOURCES), ...Object.keys(RETIRED_RESOURCES)]);
+    expect(RENAMED_RESOURCE_ALIASES).toEqual(expected);
+  });
+
+  it('rename 축(id 보존)과 retire 축(id 폐기)이 겹치지 않는다(중복 키가 있으면 그 자체가 축 혼동)', () => {
+    const renameKeys = new Set(Object.keys(RENAMED_RESOURCES));
+    const retireKeys = new Set(Object.keys(RETIRED_RESOURCES));
+    const overlap = [...renameKeys].filter((k) => retireKeys.has(k));
+    expect(overlap).toEqual([]);
+  });
+
+  it('mockups는 RETIRED_RESOURCES 쪽이다(story #2378 리뷰가 잡은 그 축 혼동의 정답 확인)', () => {
+    expect(Object.keys(RETIRED_RESOURCES)).toContain('mockups');
+    expect(Object.keys(RENAMED_RESOURCES)).not.toContain('mockups');
   });
 });

--- a/apps/web/scripts/verify-no-orphan-resource-routes.ts
+++ b/apps/web/scripts/verify-no-orphan-resource-routes.ts
@@ -102,9 +102,17 @@
  */
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { RENAMED_RESOURCES, RETIRED_RESOURCES } from '../src/proxy';
 
-const SRC_ROOT = path.resolve(process.cwd(), 'src');
+// story #2387 회귀 — SRC_ROOT를 `process.cwd()` 기준으로 잡았다가 실 CI에서 깨졌다: `pnpm
+// --filter web verify:...`(cwd=apps/web)로 직접 돌릴 때는 맞지만, monorepo 루트에서 도는
+// `pnpm vitest run`(CI의 "Test" 스텝)이 이 파일을 import하면 cwd가 레포 루트라 `KNOWN_NON_
+// PROJECT_ROUTES`(모듈 최상단에서 즉시 readdirSync하는 이 파생 로직 자신)가 ENOENT로 죽었다
+// — 로컬 검증은 매번 `pnpm --filter web`로 돌려서 이 cwd 차이를 못 봤고, 실 CI(PR #2774,
+// 2026-08-01)에서 처음 드러났다. 스크립트 자기 위치(import.meta.url) 기준으로 고정하면
+// 호출부의 cwd와 무관해진다.
+const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src');
 const APP_ROOT = path.resolve(SRC_ROOT, 'app');
 const AUTHENTICATED_ROOT = path.resolve(APP_ROOT, '(authenticated)');
 const PROJECT_RESOURCE_ROOT = path.resolve(SRC_ROOT, 'app/(authenticated)/[ws]/[proj]');

--- a/apps/web/scripts/verify-no-orphan-resource-routes.ts
+++ b/apps/web/scripts/verify-no-orphan-resource-routes.ts
@@ -20,28 +20,37 @@
  *   routeWithoutEntry: 라우트(`page.tsx` 실존)는 있는데 위 두 축 어디에도 그 이름이 없다
  *                      → ⭐더 조용한 쪽(도달 불가, 아무도 「없어졌다」고 말 안 해줌).
  *
- * ── EXEMPT — 오탐 0건이 설계 전제(env-drift-guard 관례 재사용). 실측 근거 없이 안 넣는다 ──
- *   ①KNOWN_NON_PROJECT_ROUTES — `apps/web/src/app/*` 전수(실측 `find`, `(authenticated)`는 그
- *     밑 한 겹 더) — 로그인 전 공개 라우트(login·register·forgot-password·privacy·terms·
- *     verify-email·invite·internal-dogfood·mfa·reset-password·onboarding·share·auth)와
- *     (authenticated) 밑이지만 [ws]/[proj] 밖인 라우트(activity·channel·chats·gates·inbox·
- *     meetings·more·org-briefing·organization·rewards·settings) 전부 — [ws]/[proj] 밑이
- *     아닌 «다른 라우팅 계층»이라 AC1이 대조하는 축(`[ws]/[proj]/<resource>`) 자체가 없다
- *     (AC7㉡). ⚠️최초 스캔(2026-08-01)에서 이 목록을 `(authenticated)`만으로 좁게 잡았다가
- *     로그인 전 공개 라우트 7개(login↔register↔forgot-password↔privacy↔terms↔verify-email
- *     ↔onboarding — 서로 링크를 주고받는 자리라 「단일 세그먼트 리터럴」축에 우르르 걸림)가
- *     오탐으로 뜬 것을 보고 `app/*` 전수로 넓혔다 — 그 자체가 AC4④(정상 케이스가 과잉살상
- *     안 되는지)의 실측 사례다.
- *   ②RENAMED_RESOURCE_ALIASES — `apps/web/src/proxy.ts`가 `[ws]/[proj]/<resource>` 라우트
- *     대신 미들웨어 301로 해소하는 이름들(실측) — `redirectRenamedResourcePath`(rename,
- *     id 보존)와 `redirectRetiredResourcePath`(retire, id 폐기) «두 축을 뭉뚱그린» 이름이다.
- *     ⚠️story #2378 리뷰(민군 지적, 2026-08-01)로 이 뭉뚱그림 자체가 드러났다 — `mockups`는
- *     이름과 달리 retire 축인데 이 Set 이름만 보면 rename 축으로 잘못 읽힌다. story #2387이
- *     이 Set을 `RENAMED_RESOURCES ∪ RETIRED_RESOURCES` 키에서 파생시켜 축을 가를 예정(아래
- *     `RENAMED_RESOURCE_ALIASES` 정의 옆 주석 참조) — 지금(2026-08-01)은 표시만 해 둔다.
+ * ── EXEMPT — 오탐 0건이 설계 전제(env-drift-guard 관례 재사용) ──────────────────
+ *   ①KNOWN_NON_PROJECT_ROUTES — story #2387(2026-08-01) 후속: `apps/web/src/app/*` +
+ *     `app/(authenticated)/*`를 매 실행마다 `readdirSync`로 다시 읽는다(`listTopLevelDirs`).
+ *     예전엔 손 스냅샷("2026-08-01 실측"으로 얼린 목록)이었다 — `[ws]/[proj]/<resource>`
+ *     실존은 이미 `listRouteDirs`로 파생시키면서 이쪽만 손으로 유지할 이유가 없었다(#2387
+ *     PO 지적: 「파생이 이미 되는 곳이 있으면 «못 한다»가 아니라 «안 한 것»」). ⚠️최초
+ *     스캔(2026-08-01)에서 이 목록을 `(authenticated)`만으로 좁게 잡았다가 로그인 전 공개
+ *     라우트 7개(login↔register↔forgot-password↔privacy↔terms↔verify-email↔onboarding —
+ *     서로 링크를 주고받는 자리라 「단일 세그먼트 리터럴」축에 우르르 걸림)가 오탐으로 뜬
+ *     것을 보고 `app/*` 전수로 넓혔다(AC4④의 실측 사례) — 파생으로 바뀐 지금도 두 루트
+ *     (app/*·app/(authenticated)/*) 다 읽는 이유가 그것이다.
+ *   ②RENAMED_RESOURCE_ALIASES — story #2387(2026-08-01) 후속: `apps/web/src/proxy.ts`가
+ *     export하는 `RENAMED_RESOURCES ∪ RETIRED_RESOURCES` 키에서 직접 파생시킨다(위 import).
+ *     예전엔 그 두 표의 키를 손으로 옮겨 적은 Set이었다 — proxy.ts가 바뀌어도 안 바뀌어
+ *     조용히 어긋날 수 있었다(story #2378 리뷰, 유나양 발견 — `mockups`가 실은
+ *     `RETIRED_RESOURCES`(id 폐기) 값인데 스냅샷 이름만 보면 `RENAMED_RESOURCES`(id 보존)
+ *     쪽으로 잘못 읽혔다). 카디르군 QA 판정: 두 표를 합쳐도 **사용자 체감 동작**(리다이렉트는
+ *     `redirectRenamedResourcePath`/`redirectRetiredResourcePath`로 이미 분리 구현)엔
+ *     혼동 위험이 없다 — 혼동은 이 CI 전용 상수 하나에 한정됐던 것이라 파생으로 없앤다.
  *     이 이름들을 직접 가리키는 진입점은 없지만(전부 최종 목적지를 직접 가리키게 이미 고쳐짐
  *     — command-palette.tsx의 `boardHref` 주석 참조), 이 표에 있는 이름이 «장래에» 진입점
  *     target으로 다시 등장해도 오탐이 아니게 미리 막는다.
+ *
+ * ── AC3(story #2387) — 같은 성질의 «다른 손 스냅샷» 스윕 ──────────────────────
+ *   찾은 것 3개, 고친 것 2개(이 파일 안의 ①②) — 나머지 1개는 이 스토리 스코프 밖:
+ *   `apps/web/src/lib/route-resolve.ts`의 `RESERVED_FIRST_SEGMENTS`가 같은 병이다("현재
+ *   라이브 flat 라우트 첫 세그먼트 전부(2026-07-15 grounding, apps/web/src/app/ 실측)"라고
+ *   스스로 적은 손 스냅샷 — 새 top-level 라우트가 생겨도 안 늘어나면 조용히 어긋난다). 이
+ *   가드가 아니라 **런타임 미들웨어 라우팅 판정**(`looksLikeWorkspaceSegment`)이 그 값을
+ *   직접 쓰므로, 고치면 이 스토리(CI 전용 상수 정리)보다 넓은 리스크(실 요청 라우팅 변경)를
+ *   지고 별도 리뷰가 필요하다 — 여기서는 발견만 기록하고 후속 스토리로 남긴다.
  *
  * AC7 — 이 가드가 «못 잡는 것» (선언 없이 초록이면 「전부 봤다」로 읽힌다):
  *   ㉠런타임에 조립되는 경로 — `resourceLink(variable)`처럼 문자열 리터럴이 아닌 인자, 또는
@@ -52,6 +61,12 @@
  *   ㉢`<Link href>`/헬퍼 리턴값이 아니라 `router.push()`·`window.location` 류 프로그램적 이동
  *     — 단 `window.location.href = 'x'` 대입은 `href\s*[:=]` 정규식에 우연히 같이 걸린다
  *     (onboarding 케이스, AC8 스캔에서 실측 확認 — 못 잡는다가 아니라 덤으로 걸리는 쪽).
+ *   ㉣(story #2387 AC4) `RENAMED_RESOURCE_ALIASES` 파생은 `proxy.ts`의 `RENAMED_RESOURCES`·
+ *     `RETIRED_RESOURCES` 두 표만 본다 — `MIGRATED_RESOURCES`(bare legacy URL을 ws/proj로
+ *     채워 넣는 축, 세그먼트 자체가 없던 자리를 다루는 다른 관심사)는 의도적으로 안 본다.
+ *     proxy.ts에 리소스 별칭 성격의 네 번째 표가 또 생기면 이 파생은 그 표를 자동으로 안
+ *     잡는다 — 그때는 이 import 목록에 그 표도 추가해야 한다(그래도 "고쳐야 할 자리가
+ *     하나"라는 점은 손 스냅샷보다 낫다 — 어긋나는 게 아니라 빠뜨리는 것이라 눈에 띈다).
  *
  * ⚠️CI 안전장치 — GRANDFATHER_BASELINE을 둔다. PO는 2026-08-01 사전 협의에서 「어제 실측(#2373
  * AC5 검산)으로 짝이 다 맞으니 첫 스캔은 0건이 정상」이라 예상했으나, «전수»(AC2) 스캔은 그
@@ -87,8 +102,11 @@
  */
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
+import { RENAMED_RESOURCES, RETIRED_RESOURCES } from '../src/proxy';
 
 const SRC_ROOT = path.resolve(process.cwd(), 'src');
+const APP_ROOT = path.resolve(SRC_ROOT, 'app');
+const AUTHENTICATED_ROOT = path.resolve(APP_ROOT, '(authenticated)');
 const PROJECT_RESOURCE_ROOT = path.resolve(SRC_ROOT, 'app/(authenticated)/[ws]/[proj]');
 const EXT_RE = /\.(tsx?|jsx?)$/;
 const TEST_RE = /\.(test|spec)\.[tj]sx?$/;
@@ -115,28 +133,39 @@ export function extractLiteralTargets(content: string): string[] {
   return [...content.matchAll(LITERAL_HREF_RE)].map((m) => m[2]!);
 }
 
-// ── ①실측 — [ws]/[proj] 밖의 모든 app/ 라우트 ────────────────────────────────
-// `find apps/web/src/app -maxdepth 1 -type d` + `find apps/web/src/app/\(authenticated\)
-// -maxdepth 1 -type d`([ws] 제외) — 2026-08-01 실측 스냅샷. 새 최상위 라우트가 생기면 이
-// 목록도 같이 늘어난다 — 그 자체가 이 가드의 회귀 축은 아니다(AC1 스코프 밖 계층이므로).
+// ── ①파생(story #2387, 2026-08-01) — [ws]/[proj] 밖의 모든 app/ 라우트를 매 실행마다
+// readdirSync로 다시 읽는다. 예전엔 손으로 옮겨 적은 스냅샷("2026-08-01 실측")이었다 — 새
+// 최상위 라우트가 생겨도 이 목록이 안 늘어나면 조용히 어긋날 수 있었다(AC1: 「어긋나는
+// 길이 없어지는」 쪽이 「어긋나면 잡는 가드」보다 위). `[ws]/[proj]/<resource>` 실존을 이미
+// readdirSync로 파생시키는 `listRouteDirs`와 동형 — 그쪽만 파생이고 이쪽만 손 스냅샷일
+// 이유가 없었다(#2387 PO 지적).
+function listTopLevelDirs(dir: string): string[] {
+  return readdirSync(dir).filter((entry) => statSync(path.join(dir, entry)).isDirectory());
+}
+
 export const KNOWN_NON_PROJECT_ROUTES = new Set<string>([
-  // app/* — 로그인 전 공개 라우트 + auth/dashboard
-  'auth', 'dashboard', 'forgot-password', 'internal-dogfood', 'invite', 'login',
-  'mfa', 'onboarding', 'privacy', 'register', 'reset-password', 'share', 'terms',
-  'verify-email',
-  // app/(authenticated)/* — [ws]/[proj] 밖의 인증 후 최상위 라우트
-  'activity', 'channel', 'chats', 'gates', 'inbox', 'meetings',
-  'more', 'org-briefing', 'organization', 'rewards', 'settings',
+  // app/* — 로그인 전 공개 라우트 + auth/dashboard. `(authenticated)`는 URL에 안 나타나는
+  // Next.js route group이라 제외(그 자식은 아래에서 따로 나열).
+  ...listTopLevelDirs(APP_ROOT).filter((d) => d !== '(authenticated)'),
+  // app/(authenticated)/* — [ws]/[proj] 밖의 인증 후 최상위 라우트. `[ws]`는 프로젝트
+  // 스코프 트리 자신이라 "밖"이 아니므로 제외.
+  ...listTopLevelDirs(AUTHENTICATED_ROOT).filter((d) => d !== '[ws]'),
 ]);
 
-// ── ②실측 — apps/web/src/proxy.ts가 미들웨어 301로 대신 처리하는 리소스명(rename+retire
-// 통합, 2026-08-01 실측 스냅샷) ── ⚠️`mockups`는 이름과 달리 `RENAMED_RESOURCES`가 아니라
-// `RETIRED_RESOURCES`(id를 버리고 목록 루트로만 보내는 폐기 축) 값이다 — 이 Set이 축을
-// 구분 없이 「proxy.ts가 다뤄서 라우트가 없어도 정상」만 뭉뚱그려 표시하는 지금 구조라 이름만
-// 보면 「mockups가 개명됐다」로 잘못 읽힌다(민군 지적, story #2378 리뷰). story #2387이 이
-// Set을 proxy.ts의 두 표(RENAMED_RESOURCES ∪ RETIRED_RESOURCES 키)에서 파생시키는 것으로
-// 바꿀 예정 — 지금은 축을 가르지 않고 표시만 남긴다(가르는 것은 #2387 몫).
-export const RENAMED_RESOURCE_ALIASES = new Set<string>(['epics', 'glance', 'board', 'mockups']);
+// ── ②파생(story #2387) — apps/web/src/proxy.ts가 미들웨어 301로 대신 처리하는 리소스명을
+// 그 소스(RENAMED_RESOURCES·RETIRED_RESOURCES, 위에서 import)에서 직접 읽는다. 예전엔 이
+// 두 표의 키를 손으로 옮겨 적은 Set(`['epics','glance','board','mockups']`)이었다 —
+// proxy.ts가 바뀌어도 그 스냅샷은 안 바뀌어 조용히 어긋날 수 있었다(story #2378 리뷰,
+// 유나양 발견 — `mockups`가 실은 `RETIRED_RESOURCES` 값인데 스냅샷 이름만 보면 rename으로
+// 잘못 읽혔다). rename(id 보존)과 retire(id 폐기)는 사용자 체감 동작(리다이렉트)에서는
+// 이미 서로 다른 함수(`redirectRenamedResourcePath`/`redirectRetiredResourcePath`)로
+// 갈려 있다(카디르군 QA 판정: 축 혼동 위험은 CI 전용 상수에 한정, 제품 동작엔 없음) — 이
+// 가드는 「[ws]/[proj] 라우트 대신 프록시가 처리하는 이름」이라는 한 가지 사실만 보므로
+// 두 표를 합쳐도 그 판정이 흐려지지 않는다.
+export const RENAMED_RESOURCE_ALIASES = new Set<string>([
+  ...Object.keys(RENAMED_RESOURCES),
+  ...Object.keys(RETIRED_RESOURCES),
+]);
 
 export const EXEMPT_TARGETS = new Set<string>([...KNOWN_NON_PROJECT_ROUTES, ...RENAMED_RESOURCE_ALIASES]);
 

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -227,7 +227,11 @@ function redirectToProjectPicker(request: NextRequest, originalPathname: string)
  * URL을 org/project 재조회로 채워 넣는 것이고, 이건 ws/proj가 **이미 URL에 있으므로** 3번째
  * 세그먼트(리소스명)만 신 이름으로 교체하면 된다(org/project 재조회 fetch 불요, 훨씬 가벼움).
  */
-const RENAMED_RESOURCES: Record<string, string> = {
+// story #2387(2026-08-01) — export한다: scripts/verify-no-orphan-resource-routes.ts가 이 표
+// (+RETIRED_RESOURCES)에서 RENAMED_RESOURCE_ALIASES를 파생시킨다(예전엔 손으로 옮겨 적은
+// 스냅샷이었다 — proxy.ts가 바뀌어도 그 스냅샷은 안 바뀌어 조용히 어긋날 수 있었다, story
+// #2378 리뷰에서 유나양이 발견). export 자체는 이 미들웨어의 런타임 동작을 바꾸지 않는다.
+export const RENAMED_RESOURCES: Record<string, string> = {
   epics: 'goals',
   // story #2224(선생님 정정 2026-07-30) — glance는 이제 /flow 안의 한 조각. 위 MIGRATED_RESOURCES
   // 항목과 짝: bare `/glance` → (redirectLegacyResourcePath) → `/{ws}/{proj}/glance` →
@@ -258,7 +262,8 @@ const RENAMED_RESOURCES: Record<string, string> = {
  * (스토리 본문 — 시나리오 분기·자유배치 편집·버전 복원·9종 팔레트·category/slug는 안 옮겨짐,
  * 필요 시 별건) 목록 화면(`/artifacts`)이 최소 충족선(AC3 「주소를 빈 채 두지 않는다」)이다.
  */
-const RETIRED_RESOURCES: Record<string, string> = {
+// story #2387 — export한다(같은 이유, 위 RENAMED_RESOURCES 주석 참조).
+export const RETIRED_RESOURCES: Record<string, string> = {
   mockups: 'artifacts',
 };
 


### PR DESCRIPTION
## Summary
- AC1 (derivation over guard): `RENAMED_RESOURCE_ALIASES` was a hand-copied snapshot of `proxy.ts`'s `RENAMED_RESOURCES`/`RETIRED_RESOURCES` keys. Exported both tables from `proxy.ts` and derive the Set directly (`import { RENAMED_RESOURCES, RETIRED_RESOURCES } from '../src/proxy'`) — this is exactly the class of bug that let #2378's review find `mockups` misfiled under the wrong axis without anything going red.
- Also derived `KNOWN_NON_PROJECT_ROUTES` (was an identically-shaped frozen "2026-08-01 grounding" list) via `readdirSync` on `app/*` + `app/(authenticated)/*` — it sat right next to `listRouteDirs`, which already derives the same way; no reason for one axis to derive and the other to snapshot.
- `export` on `RENAMED_RESOURCES`/`RETIRED_RESOURCES` doesn't change proxy.ts's runtime behavior (middleware logic untouched).

## AC2 — real mutation, not just a definitional check
```
before: exempt 31개(known-non-project 27 + renamed-alias 4)
[temporarily added `zztest2387mutation: 'flow'` to proxy.ts's RENAMED_RESOURCES — zero edits to the guard file]
after:  exempt 32개(known-non-project 27 + renamed-alias 5)
[reverted proxy.ts]
back to: exempt 31개(known-non-project 27 + renamed-alias 4)
```
Confirms the Set actually tracks proxy.ts's source, not a copy — no separate "does derivation work" unit test would prove this as convincingly as watching the count move with zero guard-file changes.

## AC3 — swept for the same failure class elsewhere
Found 3, closed 2 (both here). The third — `apps/web/src/lib/route-resolve.ts`'s `RESERVED_FIRST_SEGMENTS` (a hand-frozen "2026-07-15 grounding, apps/web/src/app/ 실측" list) — is the same shape but **left alone**: it's read by live middleware routing logic (`looksLikeWorkspaceSegment`), not a CI-only constant, so fixing it carries actual request-routing risk this 1-point story doesn't take on. Documented as a follow-up in the guard's header comment.

## AC4 — what this doesn't catch
Documented in the guard's header (AC7㉣): the derivation only covers `RENAMED_RESOURCES`/`RETIRED_RESOURCES` — `MIGRATED_RESOURCES` (a different concern, bare-legacy-URL resolution) is intentionally not included. A future third proxy.ts alias table would need a matching import addition here; not derived automatically, but the gap itself is visible (an omission, not a silent divergence).

## Test plan
- [x] `pnpm --filter web verify:no-orphan-resource-routes` — exit 0, same result as before (907→895 files reflects #2378's mockups removal, unrelated to this PR).
- [x] `pnpm --filter web exec vitest run scripts/verify-no-orphan-resource-routes.test.ts src/proxy.test.ts` — 78/78 passed (3 new tests lock the derivation invariant + rename/retire non-overlap + the mockups-is-retired-not-renamed regression).
- [x] `pnpm --filter web exec eslint` / `tsc --noEmit` on all changed files — clean.
- [x] AC2 mutation demo above (real CLI run, no commits from the experiment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)