### PR TITLE
[SID:2371] i18n 키 검사기 정규식 결함 5종 수정 + dead-key 역방향 스캔 + CI 배선

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -668,6 +668,18 @@ jobs:
       - name: "Verify no i18n phrase substring collision (story #2367 regression guard)"
         run: pnpm --filter web verify:no-i18n-phrase-collision
 
+      # story #2371 회귀가드: `scripts/check-i18n-keys.js`(code→messages missing-key 축)를
+      # 처음으로 CI에 건다 — 이전엔 CI/husky/package.json 어디에도 안 걸려 있었고 손으로
+      # 돌리면 344 issues·exit 1이 나왔는데(2026-07-31 실측) 344건 전부 도구 결함(워드바운더리
+      # ㉠·네임스페이스 점 미지원+matchAll 미사용 ㉡·2단 이상 중첩 미지원 ㉢, 여기 더해 훅
+      # 변수명 t 하드코딩 ㉣·주석 안 예시코드 오인 ㉤ 둘을 새로 찾아 고쳤다)이라 걸어도 상시
+      # 빨간불이었다. 위 결함을 전부 고친 뒤 재측정한 missing 축은 0건(자가 재현) — 이제
+      # 걸어도 실사용 회귀만 잡는다. messages→코드 dead-key 축(AC3)은 이 스텝을 실패시키지
+      # 않는다(스크립트 자체가 non-zero exit을 missing 축에만 건다) — 후보 목록일 뿐 삭제
+      # 판단은 사람이 소비처를 하나씩 봐야 하는 별건(AC6)이라 CI 게이트로 강제하지 않는다.
+      - name: "Verify i18n translation keys (story #2371 regression guard)"
+        run: pnpm verify:i18n-keys
+
       # story #2376 회귀가드: 사이드바(app-sidebar.tsx)·⌘K 팔레트(command-palette.tsx)·모바일
       # 더보기(more/page.tsx) 등이 조합(resourceLink/resourceHref)·리터럴(href=/href:) 어느
       # 축으로 걸든, [ws]/[proj]/<resource> 라우트 실존과 어긋나면(양방향) 실패한다 — #2373

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev:be": "cd backend && uv run uvicorn app.main:app --host 0.0.0.0 --port 8001 --reload",
     "lint": "turbo run lint",
     "type-check": "turbo run type-check",
-    "test": "vitest run"
+    "test": "vitest run",
+    "verify:i18n-keys": "node scripts/check-i18n-keys.js"
   },
   "devDependencies": {
     "concurrently": "^9.2.1",

--- a/scripts/check-i18n-keys.js
+++ b/scripts/check-i18n-keys.js
@@ -1,108 +1,267 @@
 #!/usr/bin/env node
 /**
- * Translation key validation script
- * Scans all TSX/TS files for t() calls and validates against locale files
+ * Translation key validation — story #2371.
+ *
+ * 이전 버전(2026-07-31 이전)은 코드→messages 한 방향만 쟀고 정규식 결함 셋을 갖고 있었다
+ * (실측: 손으로 돌리면 344 issues, 그런데 진짜 누락은 0건 — 전부 도구 결함). 이 판이 고친 것:
+ *
+ *   ㉠ `t(` 매치가 `get(`처럼 다른 식별자 끝에 걸리는 워드바운더리 누락
+ *      → `(?<![\w$])t\(` 네거티브 룩비하인드로 앞이 단어문자/`$`가 아닐 때만 매치.
+ *   ㉡ `useTranslations(['"])(\w+)(['"])` 가 `\w`라 점 포함 네임스페이스(`'settings.mcpConnections'`)
+ *      를 못 읽고, `.match()`(matchAll 아님)라 그 파일의 «다음» useTranslations 호출로
+ *      오조회하던 것 → `[\w.]+`로 점 허용 + `matchAll`로 파일당 «모든» 선언을 모은다.
+ *   ㉢ `en[ns]?.[key]` 1단 조회라 messages의 2단 이상 중첩을 원리적으로 못 보던 것
+ *      → messages를 완전히 평탄화(flatten)한 뒤 `"${ns}.${key}"` 문자열 조회로 바꿔 깊이
+ *      제한을 없앴다(네임스페이스가 `a.b`든 `a`든, key가 `c`든 `b.c`든 최종 합성 문자열이
+ *      같으면 같은 키로 잡힌다).
+ *
+ * ⭐추가로 이번 조사에서 스토리 원문에 없던 4번째 결함을 새로 찾아 고쳤다 —
+ *   ㉣ 훅 변수명이 하드코딩된 `t`뿐이었다. 실측(grep, 2026-08-01): `const t =`가 256곳이지만
+ *      `tc`(24)·`th`(7)·`tr`(2)·`tGlance`(2)·`tCage`(2)·`ta`(2)·`shellT`·`tSettings`·
+ *      `tRecruiter`·`tOnboarding`·`tn`·`tMore`·`tInvite`·`tInbox`·`tEditor`·`tAgents`·`_t`·
+ *      `tCommon`(7) 등 다르게 이름 붙인 훅이 55곳 넘게 있다 — 하드코딩 `t(`는 이 전부를
+ *      놓친다(양방향 다). → `HOOK_BIND_RE`로 각 파일의 실제 로컬 변수명을 잡아 그 이름으로
+ *      호출을 찾는다.
+ *
+ * 방향 둘:
+ *   ① 코드 → messages (missing) — 코드가 쓰는 키가 messages에 없다.
+ *   ② messages → 코드 (dead, story AC3) — messages에 있는 키를 어느 소비처도 안 읽는다.
+ *      ⛔이 판은 ②의 결과를 «지우지 않는다»(AC6) — 다음 판의 재료로 목록만 낸다.
+ *
+ * 이 도구가 못 보는 것(AC8, 구조적 blind spot — 고치지 않고 선언만 한다):
+ *   - 바닥(bare) 변수를 그대로 t()에 넘기는 자리 — `t(labelKey)`류. 리터럴이 전혀 없어
+ *     정적으로 «어떤 문자열이 오는지» 알 방법이 없다(값이 아니라 변수). 실측 12파일(2026-08-01
+ *     grep): activity/page.tsx · inbox/page.tsx · more/page.tsx ·
+ *     settings/workflow-line-editor-section.tsx · hypotheses/hypothesis-status-badge.tsx ·
+ *     cage/gate-evidence.tsx · dashboard/command-center/action-zone.tsx ·
+ *     kanban/story-detail-panel.tsx · loops/loop-status-badge.tsx · nav/mobile-tab-bar.tsx ·
+ *     services/notification-display.ts · loops/loop-create-dialog.tsx(`tr` 훅).
+ *     이 파일들이 참조하는 네임스페이스의 키는 ②(dead) 결과에서 오탐(거짓 dead)일 수 있다
+ *     — 삭제 전 사람이 그 소비처를 직접 봐야 한다(AC6와 같은 이유).
+ *   - 훅이 다른 컴포넌트로 prop 전달돼 그 안에서 쓰이는 경우(파일 경계를 넘는 스코프) —
+ *     이 도구는 파일 단위로만 훅↔호출을 묶는다.
+ *   - 상수맵 간접 호출 자체(`t(LABEL_KEY[status])`)는 위 「바닥 변수」류와 같은 근본 이유로
+ *     못 본다 — 다만 그 호출이 «리터럴 접두사를 낀 템플릿 리터럴» 안에 있으면
+ *     (`t(\`risk.${RISK_KEY[x]}\`)`) 그 접두사(`risk.`)는 DYNAMIC_KEY_PREFIXES가 잡는다(아래).
+ *   - 서버 `getTranslations()`는 실측 결과 전부 `useTranslations`와 동형 인자(단순 문자열
+ *     네임스페이스)라 HOOK_BIND_RE가 이미 같이 잡는다 — 별도 blind spot 아님.
  */
-
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 
-// Load locale files
 const rootDir = path.join(__dirname, '..');
-const enMessages = JSON.parse(fs.readFileSync(path.join(rootDir, 'apps/web/messages/en.json'), 'utf8'));
-const koMessages = JSON.parse(fs.readFileSync(path.join(rootDir, 'apps/web/messages/ko.json'), 'utf8'));
 
-// Find all TSX/TS files
-const files = execSync('find apps/web/src -name "*.tsx" -o -name "*.ts"', { encoding: 'utf8', cwd: rootDir })
-  .trim()
-  .split('\n')
-  .filter(f => !f.includes('.test.') && !f.includes('.spec.'));
-
-const issues = [];
-const namespaceUsage = new Map();
-
-files.forEach(file => {
-  const content = fs.readFileSync(path.join(rootDir, file), 'utf8');
-
-  // Extract useTranslations() calls to find namespace
-  const namespaceMatch = content.match(/useTranslations\(['"]([\w]+)['"]\)/);
-  if (!namespaceMatch) return;
-
-  const namespace = namespaceMatch[1];
-
-  // Extract all t() calls
-  const tCallMatches = content.matchAll(/\{?t\(['"]([\w]+)['"]\)/g);
-
-  for (const match of tCallMatches) {
-    const key = match[1];
-    const fullKey = `${namespace}.${key}`;
-
-    // Track usage
-    if (!namespaceUsage.has(namespace)) {
-      namespaceUsage.set(namespace, new Set());
-    }
-    namespaceUsage.get(namespace).add(key);
-
-    // Check if key exists
-    const enValue = enMessages[namespace]?.[key];
-    const koValue = koMessages[namespace]?.[key];
-
-    if (!enValue) {
-      issues.push({
-        file,
-        namespace,
-        key,
-        fullKey,
-        missing: ['en'],
-        type: 'missing_en'
-      });
-    }
-
-    if (!koValue) {
-      issues.push({
-        file,
-        namespace,
-        key,
-        fullKey,
-        missing: ['ko'],
-        type: 'missing_ko'
-      });
+function flatten(obj, prefix = '') {
+  const out = {};
+  for (const [k, v] of Object.entries(obj)) {
+    const p = prefix ? `${prefix}.${k}` : k;
+    if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
+      Object.assign(out, flatten(v, p));
+    } else {
+      out[p] = v;
     }
   }
-});
-
-// Report
-console.log('\n=== Translation Key Validation Report ===\n');
-
-if (issues.length === 0) {
-  console.log('✅ All translation keys are valid!\n');
-} else {
-  console.log(`❌ Found ${issues.length} issues:\n`);
-
-  const missingEn = issues.filter(i => i.type === 'missing_en');
-  const missingKo = issues.filter(i => i.type === 'missing_ko');
-
-  if (missingEn.length > 0) {
-    console.log(`\n🚨 Missing in en.json (${missingEn.length}):`);
-    missingEn.forEach(issue => {
-      console.log(`  - ${issue.fullKey} (used in ${issue.file})`);
-    });
-  }
-
-  if (missingKo.length > 0) {
-    console.log(`\n🚨 Missing in ko.json (${missingKo.length}):`);
-    missingKo.forEach(issue => {
-      console.log(`  - ${issue.fullKey} (used in ${issue.file})`);
-    });
-  }
-
-  console.log('\n');
-  process.exit(1);
+  return out;
 }
 
-console.log('Namespace usage summary:');
-for (const [namespace, keys] of namespaceUsage.entries()) {
-  console.log(`  ${namespace}: ${keys.size} keys`);
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
-console.log('');
+
+/**
+ * ㉤ — AC2 positive-control로 새로 찾은 5번째 결함(스토리 원문에도 없던 것). 주석 안에 예시로
+ * 남은 옛 호출(`t('title')`처럼 은퇴 사유를 설명하는 주석 — inbox/page.tsx:188, story #2164)
+ * 을 실제 호출로 오인해 「missing」 오탐을 냈다(en/ko 모두 `inbox.title` 자체가 없어 즉시
+ * 눈에 띄었다 — AC9-c와 같은 교훈: 놀란 수가 나오면 자리부터 볼 게 아니라 자부터 본다).
+ * 문자열/템플릿 리터럴 내용은 보존하고 `//`·`/* *\/` 주석만 제거한다.
+ */
+function stripComments(source) {
+  let out = '';
+  let i = 0;
+  const n = source.length;
+  while (i < n) {
+    const c = source[i];
+    const c2 = source[i + 1];
+    if (c === '/' && c2 === '/') {
+      while (i < n && source[i] !== '\n') i++;
+      continue;
+    }
+    if (c === '/' && c2 === '*') {
+      i += 2;
+      while (i < n && !(source[i] === '*' && source[i + 1] === '/')) i++;
+      i += 2;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      const quote = c;
+      out += c; i++;
+      while (i < n && source[i] !== quote) {
+        if (source[i] === '\\') { out += source[i]; i++; if (i < n) { out += source[i]; i++; } continue; }
+        out += source[i]; i++;
+      }
+      if (i < n) { out += source[i]; i++; }
+      continue;
+    }
+    if (c === '`') {
+      out += c; i++;
+      let depth = 0;
+      while (i < n) {
+        if (source[i] === '\\') { out += source[i]; i++; if (i < n) { out += source[i]; i++; } continue; }
+        if (source[i] === '`' && depth === 0) { out += source[i]; i++; break; }
+        if (source[i] === '$' && source[i + 1] === '{') { depth++; out += source[i] + source[i + 1]; i += 2; continue; }
+        if (source[i] === '}' && depth > 0) { depth--; out += source[i]; i++; continue; }
+        out += source[i]; i++;
+      }
+      continue;
+    }
+    out += c; i++;
+  }
+  return out;
+}
+
+/**
+ * AC4 — 동적 조합 화이트리스트. AC3(②)보다 먼저 서야 하는 이유: 이게 없으면 아래 접두사를
+ * 쓰는 «살아 있는» 키 전부가 dead 후보로 잘못 뜬다(실측 2026-08-01 grep 전수 —
+ * `grep -rEn "\bt\(\`" apps/web/src` 로 찾은 전체 템플릿 리터럴 t() 호출 기준).
+ * 각 항목: 그 접두사를 쓰는 실제 호출부 파일 + 왜 정적으로 완전한 키를 못 뽑는지.
+ */
+const DYNAMIC_KEY_PREFIXES = [
+  { prefix: 'kitOrientingWakeBody_', file: 'app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx', reason: 't(`kitOrientingWakeBody_${wakeInfo.method}`) — method는 RuntimeWakeMethod 유니온의 런타임 값' },
+  { prefix: 'notificationLevel_', file: 'app/(authenticated)/settings/page.tsx', reason: 't(`notificationLevel_${level}`)' },
+  { prefix: 'notification_category_', file: 'app/(authenticated)/settings/page.tsx', reason: 't(`notification_category_${category.key}`)' },
+  { prefix: 'event_', file: 'app/(authenticated)/settings/page.tsx', reason: 't(`event_${eventType}`)' },
+  { prefix: 'status', file: 'app/(authenticated)/[ws]/[proj]/loops/loops-client.tsx', reason: 't(`status${s.charAt(0).toUpperCase()}${s.slice(1)}` as "statusDraft") — camelCase 합성, 접두만 정적(대소문자 변환 이후 값은 런타임)' },
+  { prefix: 'work_', file: 'components/settings/gate-level-matrix.tsx', reason: 't(`work_${wt}`)' },
+  { prefix: 'actor_', file: 'components/settings/gate-level-matrix.tsx', reason: 't(`actor_${at}`)' },
+  { prefix: 'billingMode_', file: 'components/agents/agent-runs-list.tsx', reason: 't(`billingMode_${billingMode}`)' },
+  { prefix: 'status_', file: 'components/agents/agent-runs-list.tsx', reason: 't(`status_${s}`) / t(`status_${run.status}`)' },
+  { prefix: 'failureDisposition_', file: 'components/agents/agent-runs-list.tsx', reason: 't(`failureDisposition_${getRunFailureDisposition(run)}`)' },
+  { prefix: 'toolAuditSource_', file: 'components/agents/agent-run-detail.tsx', reason: 't(`toolAuditSource_${toolSource}`)' },
+  { prefix: 'reviewType_', file: 'components/standup/standup-feedback-dialog.tsx', reason: 't(`reviewType_${item.review_type}`) / t(`reviewType_${option}`)' },
+  { prefix: 'metric_', file: 'components/outcome/outcome-result-card.tsx', reason: 't(`metric_${result.metric}` as "metric_velocity")' },
+  { prefix: 'galleryAxis', file: 'components/canvas/artifact-gallery-view.tsx', reason: 't(`galleryAxis${a[0].toUpperCase()}${a.slice(1)}`) — camelCase 합성' },
+  { prefix: 'responsivePreview', file: 'components/canvas/artifact-expand-dialog.tsx', reason: 't(`responsivePreview${bp[0].toUpperCase()}${bp.slice(1)}`) — camelCase 합성' },
+  { prefix: 'galleryFormat', file: 'components/canvas/artifact-thumbnail.tsx', reason: 't(`galleryFormat${state.format[0].toUpperCase()}${state.format.slice(1)}`) — camelCase 합성' },
+  { prefix: 'entityType', file: 'components/loops/context-pack-panel.tsx', reason: 't(`entityType${item.entity_type...}` as "entityTypeLoop") — camelCase 합성' },
+  { prefix: 'aiConfidenceLevel_', file: 'components/loops/ai-attribution.tsx', reason: 't(`aiConfidenceLevel_${confidence}` as "aiConfidenceLevel_high")' },
+  { prefix: 'loopPhrase', file: 'components/org-briefing/derive-loop-face.ts', reason: 't(`loopPhrase${capitalize(derivePhrase(...))}`) — camelCase 합성' },
+  { prefix: 'laneFlag_', file: 'components/flow/flow-lane.tsx', reason: 't(`laneFlag_${flag.key}`, { n: flag.count })' },
+  { prefix: 'portLinkKind_', file: 'components/flow/flow-map-canvas.tsx', reason: 't(`portLinkKind_${kind}`) — 기존 코드베이스 관례' },
+  { prefix: 'risk.', file: 'components/proof-capsule/proof-capsule.tsx', reason: 't(`risk.${RISK_KEY[gate.risk]}`) — 상수맵 간접 + 점 표기 하위 네임스페이스' },
+  { prefix: 'status.', file: 'components/settings/mcp-connection-settings.tsx', reason: 't(`status.${connection.status}`)' },
+  { prefix: 'auth.', file: 'components/settings/mcp-connection-settings.tsx', reason: 't(`auth.${connection.authStrategy}`)' },
+  { prefix: 'toolPermissions.groups.', file: 'components/agents/tool-permission-picker.tsx', reason: 't(`toolPermissions.groups.${key}`)' },
+];
+
+function isDynamicallyComposed(flatKeyPath) {
+  return DYNAMIC_KEY_PREFIXES.some(({ prefix }) => {
+    const re = new RegExp(`(^|\\.)${escapeRegExp(prefix)}[\\w-]*$`);
+    return re.test(flatKeyPath);
+  });
+}
+
+// ㉣ — 훅이 바인딩되는 실제 로컬 변수명을 파일마다 잡는다(하드코딩 `t` 가정을 버린다).
+const HOOK_BIND_RE = /const\s+(\w+)\s*=\s*(?:await\s+)?(?:useTranslations|getTranslations)\(\s*['"]([\w.]+)['"]/g;
+
+// main()으로 감싸 CLI 실행(require.main === module)일 때만 돈다 — 그래야 테스트가 순수함수
+// (flatten/stripComments/isDynamicallyComposed)만 require해 쓸 때 이 스캔 전체(파일 I/O·
+// process.exit)가 같이 실행되는 부작용이 없다.
+function main() {
+  const enMessages = JSON.parse(fs.readFileSync(path.join(rootDir, 'apps/web/messages/en.json'), 'utf8'));
+  const koMessages = JSON.parse(fs.readFileSync(path.join(rootDir, 'apps/web/messages/ko.json'), 'utf8'));
+  const enFlat = flatten(enMessages);
+  const koFlat = flatten(koMessages);
+
+  const files = execSync('find apps/web/src -name "*.tsx" -o -name "*.ts"', { encoding: 'utf8', cwd: rootDir })
+    .trim()
+    .split('\n')
+    .filter(f => !f.includes('.test.') && !f.includes('.spec.'));
+
+  const issues = [];
+  const namespaceUsage = new Map(); // namespace -> Set(key) — 리포트용 요약
+  const referencedPaths = new Set(); // 방향② dead-key 스캔이 쓰는 「참조된 전체 경로」 집합
+
+  files.forEach(file => {
+    const content = stripComments(fs.readFileSync(path.join(rootDir, file), 'utf8'));
+
+    const varToNamespace = new Map();
+    for (const m of content.matchAll(HOOK_BIND_RE)) {
+      varToNamespace.set(m[1], m[2]);
+    }
+    if (varToNamespace.size === 0) return;
+
+    for (const [varName, namespace] of varToNamespace) {
+      // ㉠ 워드바운더리 — `varName(` 바로 앞이 단어문자/`$`가 아닐 때만(다른 식별자 끝에
+      // 우연히 걸리는 것 방지, 예: 훅 변수명이 `t`일 때 `get(`의 `t(`에 안 걸림).
+      const callRe = new RegExp(`(?<![\\w$])${escapeRegExp(varName)}\\(\\s*['"]([\\w.]+)['"]`, 'g');
+      for (const m of content.matchAll(callRe)) {
+        const key = m[1];
+        const fullKey = `${namespace}.${key}`;
+        referencedPaths.add(fullKey);
+
+        if (!namespaceUsage.has(namespace)) namespaceUsage.set(namespace, new Set());
+        namespaceUsage.get(namespace).add(key);
+
+        const enValue = enFlat[fullKey];
+        const koValue = koFlat[fullKey];
+        if (enValue === undefined) issues.push({ file, namespace, key, fullKey, type: 'missing_en' });
+        if (koValue === undefined) issues.push({ file, namespace, key, fullKey, type: 'missing_ko' });
+      }
+    }
+  });
+
+  // ── AC3 — messages → 코드(dead key). en.json을 SSOT로 순회(ko는 phrase-collision 가드가
+  // 따로 en/ko 짝을 지킨다 — 이 스캔은 「코드가 안 읽는다」만 잰다, en/ko 짝 불일치는 다른 자리).
+  const deadCandidates = [];
+  for (const flatPath of Object.keys(enFlat)) {
+    if (referencedPaths.has(flatPath)) continue;
+    if (isDynamicallyComposed(flatPath)) continue;
+    deadCandidates.push(flatPath);
+  }
+
+  // ── Report ──
+  console.log('\n=== Translation Key Validation Report (story #2371) ===\n');
+
+  console.log('① 코드 → messages (missing)');
+  if (issues.length === 0) {
+    console.log('  ✅ 0건\n');
+  } else {
+    const missingEn = issues.filter(i => i.type === 'missing_en');
+    const missingKo = issues.filter(i => i.type === 'missing_ko');
+    console.log(`  ❌ ${issues.length}건`);
+    if (missingEn.length > 0) {
+      console.log(`\n  🚨 Missing in en.json (${missingEn.length}):`);
+      missingEn.forEach(i => console.log(`    - ${i.fullKey} (used in ${i.file})`));
+    }
+    if (missingKo.length > 0) {
+      console.log(`\n  🚨 Missing in ko.json (${missingKo.length}):`);
+      missingKo.forEach(i => console.log(`    - ${i.fullKey} (used in ${i.file})`));
+    }
+    console.log('');
+  }
+
+  const dynamicallyExempted = Object.keys(enFlat).filter(isDynamicallyComposed).length;
+  console.log('② messages → 코드 (dead-key 후보 — ⛔목록일 뿐, 이 도구는 지우지 않는다·AC6)');
+  console.log(`  후보 ${deadCandidates.length}건 · 동적조합 화이트리스트로 제외 ${dynamicallyExempted}건`);
+  if (deadCandidates.length > 0 && process.env.I18N_SHOW_DEAD === '1') {
+    deadCandidates.forEach(k => console.log(`    - ${k}`));
+  }
+  console.log('  (전체 목록: I18N_SHOW_DEAD=1 node scripts/check-i18n-keys.js)\n');
+
+  console.log('Namespace usage summary:');
+  for (const [namespace, keys] of namespaceUsage.entries()) {
+    console.log(`  ${namespace}: ${keys.size} keys`);
+  }
+  console.log('');
+
+  if (issues.length > 0) {
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { flatten, escapeRegExp, stripComments, isDynamicallyComposed, DYNAMIC_KEY_PREFIXES, main };

--- a/scripts/check-i18n-keys.test.js
+++ b/scripts/check-i18n-keys.test.js
@@ -1,0 +1,76 @@
+// story #2371 — check-i18n-keys.js의 순수함수 회귀가드. main()은 require해도 안 돈다
+// (require.main === module 가드) — 그래서 이 테스트는 파일 I/O나 process.exit 부작용 없이
+// flatten/stripComments/isDynamicallyComposed만 직접 잰다.
+import { describe, expect, it } from 'vitest';
+import { flatten, stripComments, isDynamicallyComposed, DYNAMIC_KEY_PREFIXES } from './check-i18n-keys.js';
+
+describe('flatten — ㉢ 2단 이상 중첩 dot-path 평탄화', () => {
+  it('flattens arbitrarily deep nesting into dot-joined leaf paths', () => {
+    const out = flatten({ a: { b: { c: 'leaf' } }, top: 'x' });
+    expect(out).toEqual({ 'a.b.c': 'leaf', top: 'x' });
+  });
+
+  it('does not descend into arrays — arrays are treated as leaf values', () => {
+    const out = flatten({ a: ['x', 'y'] });
+    expect(out).toEqual({ a: ['x', 'y'] });
+  });
+});
+
+describe('stripComments — ㉤ 주석 안 예시코드를 실호출로 오인하는 것 방지', () => {
+  it('removes // line comments', () => {
+    expect(stripComments("const x = 1; // t('title')\n")).toBe('const x = 1; \n');
+  });
+
+  it('removes /* block */ comments including across newlines', () => {
+    expect(stripComments("/* t('title')\nold call */\nconst y = 2;")).toBe('\nconst y = 2;');
+  });
+
+  it('preserves string literal contents (does not eat // inside a string)', () => {
+    const src = "const url = 'https://example.com';";
+    expect(stripComments(src)).toBe(src);
+  });
+
+  it('preserves template literal contents including ${} interpolation', () => {
+    const src = 'const k = `status_${s}`;';
+    expect(stripComments(src)).toBe(src);
+  });
+
+  it('regression: a comment citing an old call as history (inbox/page.tsx:188 shape) is stripped, not counted as a real call', () => {
+    const src = "// t('title')(\"제목\") 이제 안 씀\nconst t2 = useTranslations('inbox');";
+    const stripped = stripComments(src);
+    expect(stripped).not.toContain("t('title')");
+    expect(stripped).toContain("useTranslations('inbox')");
+  });
+});
+
+describe('isDynamicallyComposed — AC4 화이트리스트, AC5 양성대조', () => {
+  // 유나 표본(#2756) — 실제 messages에 존재하는 살아있는 동적 조합 키. 화이트리스트가 이들을
+  // dead 후보에서 빼지 못하면(=false라고 답하면) 실사용 키가 삭제 후보로 잘못 뜬다.
+  it.each([
+    'settings.notificationLevel_all',
+    'standup.reviewType_approve',
+    'canvas.galleryAxisEpic',
+    'recruiter.kitOrientingWakeBody_channel-plugin',
+  ])('%s는 화이트리스트에 걸려 dead 후보에서 빠진다', (key) => {
+    expect(isDynamicallyComposed(key)).toBe(true);
+  });
+
+  it('a plain unrelated key is NOT exempted (whitelist must be able to fail — the other half of AC5)', () => {
+    expect(isDynamicallyComposed('settings.title')).toBe(false);
+    expect(isDynamicallyComposed('goals.newGoal')).toBe(false);
+  });
+
+  it('matches only at a path-segment boundary, not as an arbitrary substring', () => {
+    // "actor_" 화이트리스트가 있어도 그 앞에 임의 문자가 붙어 «비-경계» 위치에서 우연히
+    // 걸리면 안 된다(과잉면제 방지) — 세그먼트 시작(`^`나 직전 `.`)에서만 매치해야 한다.
+    expect(isDynamicallyComposed('settings.xactor_foo')).toBe(false);
+    expect(isDynamicallyComposed('settings.actor_foo')).toBe(true);
+  });
+
+  it('DYNAMIC_KEY_PREFIXES entries all carry a file + reason (no bare additions)', () => {
+    for (const entry of DYNAMIC_KEY_PREFIXES) {
+      expect(entry.file, `${entry.prefix} missing file`).toBeTruthy();
+      expect(entry.reason, `${entry.prefix} missing reason`).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- story #2371 — `scripts/check-i18n-keys.js`가 손으로 돌리면 344 issues·exit 1을 냈지만 CI/husky/package.json 어디에도 안 걸려 있었다(2026-07-31 유나 실측). 344건 전부 도구 결함이었다(진짜 누락 0건).
- **스토리 원문 AC1의 3결함**(워드바운더리 ㉠·네임스페이스 점+matchAll 미지원 ㉡·2단 이상 중첩 미지원 ㉢)을 고쳤고, **조사 중 원문에 없던 2결함을 새로 찾아 같이 고쳤다**:
  - ㉣ 훅 변수명 `t` 하드코딩 — 실측 `const t=`가 256곳이지만 `tc`/`th`/`tr`/`tGlance`/`tCage`/`ta`/`shellT`/`tSettings`/`tRecruiter`/`tOnboarding`/`tn`/`tMore`/`tInvite`/`tInbox`/`tEditor`/`tAgents`/`_t`/`tCommon` 등 55곳 넘는 다른 이름의 훅이 있었다. 뮤테이션 검증: 훅명을 다시 `t`로만 좁히면 dead 후보가 869→944건(75건 증가)으로 뛴다 — 이 결함이 실제로 75건의 거짓 dead를 만들고 있었다.
  - ㉤ 주석 안 예시 코드 오인 — `inbox/page.tsx:188`(#2164 은퇴 사유를 설명하는 주석)의 `t('title')` 문구를 실호출로 읽어 `inbox.title`을 missing으로 오탐(en/ko 둘 다 그 키 자체가 없다 — 놀란 수가 나오면 자리부터 볼 게 아니라 자부터 본다는 교훈의 재현).
- messages→코드 **역방향(dead-key) 스캔 신설**(AC3) — 869건 후보 산출, **삭제는 이 PR에서 하지 않는다**(AC6).
- **동적 조합 화이트리스트**(AC4) 25항목, 각 항목에 실 호출부 파일+이유 명시 — 유나 표본(`notificationLevel_all`·`reviewType_approve`·`galleryAxis*`) 전부 정확히 "살아있음"으로 판정됨을 확認(AC5), 경계매칭을 깨는 뮤테이션으로 화이트리스트가 실제로 실패할 수 있음도 증명.
- **CI 배선**(AC7) — root `package.json`에 `verify:i18n-keys`, `ci.yml`에 신규 스텝 추가. missing(①) 축만 CI를 실패시키고, dead-key(②) 후보 축은 non-blocking(삭제 판단은 사람이 소비처를 하나씩 봐야 하는 별건).
- blind spot 3종을 스크립트 헤더 주석에 선언(AC8) — 바닥 변수 `t(labelKey)`류 12파일 실측 나열, 파일경계 넘는 훅 전달, 상수맵 간접 호출. `getTranslations()`는 실측 결과 `useTranslations`와 동형 인자라 blind spot 아님으로 정정.
- AC9(라이브 삭제 판정선)은 이 PR의 스코프 밖 — AC6대로 삭제 자체를 안 하므로 다음 삭제 판의 재료로 스토리에 기록만 해 뒀다.

## 구현 메모
- `require.main === module` 가드로 CLI 실행(`main()`)과 순수함수(`flatten`/`stripComments`/`isDynamicallyComposed`)를 분리 — 테스트가 `require()`해도 파일 스캔·`process.exit`이 같이 실행되지 않는다.
- 신규 테스트(`scripts/check-i18n-keys.test.js`) 14건, 2건은 뮤테이션 self-check로 검증(훅변수명 고정 시 dead 후보 수 변화, 경계매칭 깨면 boundary 테스트가 정확히 RED).

## Test plan
- [x] `pnpm verify:i18n-keys` — EXIT 0 (missing 0건, dead 후보 869건 informational)
- [x] mutation self-check: `t`로만 좁히면 dead 후보 869→944건(㉣ 결함의 실효성 정량 확認)
- [x] mutation self-check: 경계매칭 정규식을 깨면 `check-i18n-keys.test.js`의 boundary 테스트가 정확히 1건 RED, 복원 시 14/14 GREEN
- [x] mutation self-check: 실제로 존재하지 않는 키를 참조하는 파일을 임시로 추가하면 `pnpm verify:i18n-keys` EXIT 1(missing 축 정상 검출), 삭제 후 EXIT 0 복원
- [x] 루트 `pnpm exec vitest run` — 358 files · 2682 tests 전부 PASS(신규 14건 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)