### PR TITLE
fix(backend): EventStatus enum missing 'expired' + stale agent-only docstring (story #2391)

### DIFF
--- a/backend/alembic/versions/0221_events_status_check_constraint.py
+++ b/backend/alembic/versions/0221_events_status_check_constraint.py
@@ -1,0 +1,43 @@
+"""story #2391(2026-08-01) — events.status에 CHECK 제약을 붙인다(구조로 막기, AC2).
+
+배경: `events.status`는 여태 순수 Text 컬럼이라 오타·미선언 값이 조용히 통과했다.
+`EventStatus`(app/models/event.py) enum이 pending/delivered/failed 셋만 선언했는데, 실제로는
+`expired`(30일 초과 pending을 회수하는 expire_stale_events_core, app/routers/events.py)가
+8개월 가까이 이 enum 밖에서 살아 있었다 — enum에 없고 DB CHECK도 없어 아무도 안 걸렸다.
+
+dev DB `status` DISTINCT 실측(전량, 2026-08-01 12:4xZ, PO):
+  delivered 4,151 · pending 86 · expired 80 · failed 0
+⛔이 넷은 dev 기준이다. prod는 이 마이그레이션 작성 시점에 측정하지 못했다 — prod에 이 넷
+밖의 값이 있으면 이 마이그레이션이 prod에 적용될 때(NOT VALID 없는 일반 CHECK ADD는 기존
+행을 즉시 검증한다) 실패로 멈춘다. 그 실패는 안전한 방향이다(데이터 훼손이 아니라 배포
+정지) — 그래도 적용 전에 prod에서 `SELECT DISTINCT status FROM events`로 한 번 더 확認하는
+것을 권장한다(PO/디디군 lane).
+
+`failed`는 코드·dev DB 둘 다 0건이지만 CHECK에는 포함한다(app/models/event.py의 EventStatus
+docstring 참조 — "지금 0건"과 "원리적으로 안 난다"는 다른 주장이라는 PO 판단).
+
+순수 additive — 신규 CHECK 제약 하나, 기존 컬럼/데이터 변경 0. 넷 다(pending/delivered/
+expired/failed) 허용하므로 기존 행 4,317개(dev 기준) 전부 통과.
+
+Revision ID: 0221
+Revises: 0220
+Create Date: 2026-08-01
+"""
+from alembic import op
+
+revision = "0221"
+down_revision = "0220"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_check_constraint(
+        "ck_events_status",
+        "events",
+        "status IN ('pending', 'delivered', 'expired', 'failed')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_events_status", "events", type_="check")

--- a/backend/app/models/event.py
+++ b/backend/app/models/event.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, Enum, ForeignKey, Text, func
+from sqlalchemy import CheckConstraint, DateTime, Enum, ForeignKey, Text, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -18,6 +18,14 @@ class EventType(str, enum.Enum):
     # 결과 `EventType.memo_created`/`EventType.memo_replied` 속성 접근이 어디에도 없었다 —
     # events.event_type 컬럼 자체가 Text(native enum 아님)라 역직렬화 경로도 없다. 살아 있는
     # memo 기능(SaaS webhook 발송 등)은 이 enum을 거치지 않으므로 영향 없음.
+    #
+    # ⚠️story #2391 AC4 후속 — 이 enum과 `event_type`의 실사용은 `EventStatus`보다 훨씬 크게
+    # 어긋난다(dev DB DISTINCT, 2026-08-01, PO): dispatched 2,694 · conversation.message_created
+    # 1,602 · story_assigned 19 · a2a.task_message 1 · qa_test_ping 1 — dispatched만 이 enum과
+    # 일치하고 나머지 넷은 전부 밖이다. `status_changed`(선언)는 dev에 0건. `event_type`은 이
+    # 스토리(#2391)의 스코프(EventStatus + /events/stream docstring) 밖이라 CHECK 제약을 안
+    # 붙였다 — 여기 손대면 실제로 쓰이는 문자열 리터럴 이벤트 타입(자유 형식 네임스페이스,
+    # a2a.*류)까지 전수해야 하는 별도 규모의 작업이다. 다음 사람을 위해 사실만 남긴다.
     dispatched = "dispatched"
     status_changed = "status_changed"
 
@@ -36,8 +44,20 @@ class EventRecipientType(str, enum.Enum):
 
 
 class EventStatus(str, enum.Enum):
+    """story #2391(2026-08-01) — dev DB status DISTINCT 실측(전량 · 2026-08-01 12:4xZ, PO):
+    delivered 4,151 · pending 86 · expired 80 · failed 0. `expired`는 30일 초과 pending을
+    회수하는 실동작 경로(expire_stale_events_core, 이 파일 밑 events.py 참조)가 실제로 쓰는데
+    이 enum에 없었다 — 추가한다.
+
+    `failed`는 반대 방향 문제다 — 코드 전수 grep(프로덕션+테스트, `EventType.memo_created`
+    제거 때와 동일 방법)으로 `Event.status`에 "failed"를 쓰는 자리가 0건, dev DB도 0건. 그래도
+    지우지 않는다 — "지금 dev에 0건"과 "원리적으로 안 난다"는 다른 주장이고(PO 판단), prod는
+    측정하지 못했다. CHECK 제약(아래)에는 포함시켜 둔다 — 미래에 실제로 쓰이기 시작해도 구조를
+    또 안 바꿔도 되고, 지금 당장 무해하다(쓰는 자리가 없으니 존재해도 아무 행도 이 값을 안 가짐).
+    """
     pending = "pending"
     delivered = "delivered"
+    expired = "expired"
     failed = "failed"
 
 
@@ -66,3 +86,16 @@ class Event(Base, OrgScopedMixin):
     )
     delivered_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     read_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # story #2391 AC2 — 구조로 막는다. status는 여태 순수 Text라 오타·미선언 값이 조용히 통과
+    # 했다(`expired`가 그렇게 8개월 가까이 enum 밖에 살았다). SQL 문자열을 손으로 다시 적지
+    # 않고 EventStatus에서 직접 파생시킨다 — #2387이 같은 날 잡은 "손 스냅샷" 병을 여기서
+    # 새로 만들지 않기 위함. enum에 멤버를 추가/제거하면 이 조건도 같이 바뀌지만, 이미 적용된
+    # DB 제약 자체를 바꾸려면 여전히 새 Alembic 마이그레이션이 필요하다(그 비대칭은 CHECK
+    # 제약의 근본 성질 — 이 파생이 없앨 수 있는 건 "작성 시점 오타"뿐이다, AC5 참조).
+    __table_args__ = (
+        CheckConstraint(
+            f"status IN ({', '.join(repr(s.value) for s in EventStatus)})",
+            name="ck_events_status",
+        ),
+    )

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -322,7 +322,14 @@ async def agent_event_stream(
     since_timestamp: datetime | None = Query(default=None),
     last_event_id: uuid.UUID | None = Query(default=None),
 ):
-    """GET /api/v2/events/stream — 에이전트 전용 SSE 스트림.
+    """GET /api/v2/events/stream — SSE 스트림.
+
+    story #2391(2026-08-01) — "에이전트 전용"은 사실이 아니었다. 아래 `resolve_member_identity`
+    호출이 TeamMember(에이전트+레거시 휴먼) 다음으로 OrgMember(grant-only 휴먼)도 해소하므로,
+    이 스트림은 설계상 human도 실제로 붙는다(E-MEMBER-SSOT Phase 0 — team_member 강요를
+    의도적으로 없앤 것이지 사고가 아니다, `resolve_member_identity` 자신의 docstring 참조).
+    모듈 최상단 docstring(#2380)은 이미 이 사실을 적어 뒀었는데 이 함수 자신의 docstring만
+    안 따라왔었다.
 
     인증: Authorization: Bearer {API_KEY} 또는 JWT.
     API Key 사용 시 member_id 자동 추출 — 쿼리 파라미터 불필요.

--- a/backend/tests/test_2391_events_status_check_constraint_realdb.py
+++ b/backend/tests/test_2391_events_status_check_constraint_realdb.py
@@ -1,0 +1,99 @@
+"""story #2391 AC2 — events.status에 붙인 ck_events_status가 실제 라이브 DB에서 무는지.
+
+로컬(직접) 검증은 pgvector/pg16 docker 컨테이너로 이미 했다(PR 설명 참조 — 4개 유효값 삽입
+성공 + 무효값 삽입이 정확히 "ck_events_status violates check constraint"로 실패). 이 테스트는
+그 확認을 CI의 실제 Postgres(backend-test job의 `DATABASE_URL`)에서도 고정한다 — DB env
+없으면 skip(로컬 무DB 환경 배려, 다른 `_realdb` 테스트와 동일 관례).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("DATABASE_URL") or ""
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL(DATABASE_URL) 미설정 — skip")
+
+ORG = uuid.UUID("2391e000-0000-0000-0000-000000000001")
+PROJECT = uuid.UUID("2391e000-0000-0000-0000-000000000002")
+RECIPIENT = uuid.UUID("2391e000-0000-0000-0000-000000000003")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _seed(s):
+    # events.recipient_id/sender_id는 실측(2026-08-01, \d events)상 FK가 없다 — team_members가
+    # 뷰(0088_team_members_projection_view)라 DB 레벨 FK를 못 건다(purge_test_agents.py
+    # docstring이 이미 문서화한 사실). 그래서 recipient_id는 실 members row 없이도 들어간다 —
+    # organizations/projects(둘 다 실 FK 있음, `\d events` 확認)만 심으면 된다.
+    for sql in [
+        f"DELETE FROM events WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE id='{PROJECT}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','2391-org','2391-org-{uuid.uuid4().hex[:8]}','free')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJECT}','{ORG}','2391-proj')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _cleanup(s):
+    for sql in [
+        f"DELETE FROM events WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE id='{PROJECT}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+def _insert_event_sql(status: str) -> str:
+    eid = uuid.uuid4()
+    return (
+        "INSERT INTO events (id,org_id,project_id,event_type,recipient_id,recipient_type,payload,status) "
+        f"VALUES ('{eid}','{ORG}','{PROJECT}','2391_test','{RECIPIENT}','agent','{{}}'::jsonb,'{status}')"
+    )
+
+
+@pytest.mark.anyio
+async def test_ck_events_status_rejects_a_value_outside_the_enum():
+    engine = create_async_engine(_RAW)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as s:
+        await _seed(s)
+        try:
+            with pytest.raises(IntegrityError, match="ck_events_status"):
+                await s.execute(text(_insert_event_sql("bogus_status")))
+                await s.commit()
+        finally:
+            await s.rollback()
+            await _cleanup(s)
+    await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ck_events_status_accepts_all_four_declared_values():
+    engine = create_async_engine(_RAW)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as s:
+        await _seed(s)
+        try:
+            # AC1 — dev DB 실측(2026-08-01, PO): delivered 4,151 · pending 86 · expired 80 ·
+            # failed 0. 넷 다 CHECK를 통과해야 한다(failed는 지금 미사용이어도 구조상 허용).
+            for status in ("pending", "delivered", "expired", "failed"):
+                await s.execute(text(_insert_event_sql(status)))
+            await s.commit()
+
+            result = await s.execute(text(f"SELECT status, count(*) FROM events WHERE org_id='{ORG}' GROUP BY status"))
+            counts = dict(result.all())
+            assert counts == {"pending": 1, "delivered": 1, "expired": 1, "failed": 1}
+        finally:
+            await _cleanup(s)
+    await engine.dispose()


### PR DESCRIPTION
## Summary
- AC1: `EventStatus` declared `pending`/`delivered`/`failed`, but real code and dev DB also use `expired` — missing for ~8 months with nothing to catch it (plain `Text` column, no CHECK).
- AC2: structural enforcement, not just a doc fix — added `ck_events_status` DB CHECK constraint, derived directly from the `EventStatus` enum (not hand-typed, matching #2387's derivation lesson from earlier today).
- AC3: fixed `agent_event_stream`'s stale "에이전트 전용" docstring — judged **design, not accident**.
- AC4: swept the 3 named files for the same drift class; found a much bigger instance in `event_type` (flagged, not fixed here — separate scope).
- AC5: documented what this doesn't catch.

## AC1 — the finding is two-directional, and scope is explicitly dev-only
PO measured dev DB `status` DISTINCT (2026-08-01, full count, not sampled):
```
delivered  4,151
pending       86
expired       80   <- missing from the enum, actually used (expire_stale_events_core)
failed          0  <- declared, but zero rows AND zero literal-write call-sites (grep, full sweep)
```
⚠️**This is dev-only** — prod was not measured (PO: no prod access from this investigation). `failed` is kept in the enum/constraint rather than removed: "0 rows today" and "structurally can't happen" are different claims, and removal is a bigger, separate judgment call this story doesn't need to force.

## AC2 — verified against a real Postgres, not just asserted
Spun up `pgvector/pgvector:pg16` locally (matching CI's exact service image) and ran the full migration chain:
```
$ alembic upgrade head   # 0001 -> ... -> 0221, applies cleanly
$ \d events               # ck_events_status CHECK (status = ANY (ARRAY['pending','delivered','expired','failed']))

# invalid value -> real constraint violation:
INSERT ... VALUES (..., 'bogus_status', ...);
ERROR: new row for relation "events" violates check constraint "ck_events_status"

# all 4 declared values -> all accepted:
INSERT ... VALUES (..., 'pending', ...), (..., 'delivered', ...), (..., 'expired', ...), (..., 'failed', ...);
INSERT 0 4
```
Added a permanent `_realdb`-suffixed test pair (`test_2391_events_status_check_constraint_realdb.py`, same skip-if-no-DB convention as `test_audit_apikey_parity_realdb.py`) that proves the same two things against CI's actual Postgres service — this isn't a mocked assertion, CI's `Backend pytest` job will exercise a real constraint violation.

## AC3 — design, not accident
`resolve_member_identity`'s own docstring already says "TeamMember(에이전트+레거시 휴먼) 우선, 없으면 OrgMember(grant-only 휴먼) 조회" — unambiguous, and a code comment at the call site cites **E-MEMBER-SSOT Phase 0** as the deliberate change that removed the `team_member` requirement. The module-level docstring in `events.py` (top of file) had already been corrected during #2380's investigation to note humans connect — only the per-function docstring on `agent_event_stream` hadn't caught up. Fixed that one, pointed to the real source of truth instead of restating it (so it can't drift again the same way).

## AC4 — same disease, much bigger, in event_type
Dev DB `event_type` DISTINCT (PO, same query pass):
```
dispatched                    2,694   <- only one matching EventType enum
conversation.message_created  1,602   <- not in enum
story_assigned                   19   <- not in enum
a2a.task_message                  1   <- not in enum
qa_test_ping                      1   <- not in enum
status_changed (declared)         0   <- in enum, zero rows
```
Only 1 of 5 real values matches the enum, and the enum's second member has zero rows. This is out of #2391's stated scope (`EventStatus` + the docstring) — fixing it would mean enumerating every free-form event-type string across the org (`a2a.*`-style namespacing suggests this is intentionally open-ended, unlike `status`). Documented as a code comment for whoever picks up the follow-up rather than silently left for someone to rediscover.

## AC5 — what this doesn't catch
- `event_type` is unconstrained (see AC4).
- Prod `status` distinct values are unmeasured — if prod has a 5th value, this migration will fail loudly at apply time (safe direction: deploy blocked, not data corrupted), but should be checked with `SELECT DISTINCT status FROM events` on prod before applying there.
- The CHECK constraint only catches genuinely out-of-set values; it doesn't validate `status` transition legality (e.g., nothing stops `delivered` -> `pending`) — that's a different, larger concern this story doesn't take on.

## Test plan
- [x] Full migration chain (`alembic upgrade head`, fresh `pgvector/pg16` container) — clean.
- [x] Real constraint-violation + all-4-valid-values proof (see AC2 log above).
- [x] `uv run pytest tests/test_2391_events_status_check_constraint_realdb.py` — 2/2 passed against the same local Postgres.
- [x] `uv run pytest --collect-only` (full backend suite) — 0 collection errors.
- [x] `uv run pytest tests/test_eventbus_s1.py tests/test_eventbus_s2.py tests/test_eventbus_s3.py tests/test_notification_dispatch.py tests/test_audit_apikey_parity_realdb.py` — all pass (realdb ones correctly skip without `DATABASE_URL`).
- [x] `python -c "import ast; ast.parse(...)"` + direct import check on all 4 changed/new files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)