### PR TITLE
fix(#2397): publish-mcp.yml 을 develop 으로 백포트 — 승격하면 «사라지는» 워크플로

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,51 @@
+name: Publish sprintable-mcp to PyPI
+
+# OB-PUBLISH(f5e1742d): uvx sprintable-mcp is currently PyPI 404 — this workflow is the
+# prerequisite. Filename/environment name below must match PyPI's registered pending
+# publisher exactly (repo: moonklabs/sprintable, workflow: publish-mcp.yml, environment: pypi).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Build and publish sprintable-mcp
+    runs-on: ubuntu-latest
+    # First publish creates the PyPI project from the pending publisher — no API token needed,
+    # OIDC only (id-token: write below). Never add a token/twine step here.
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: read
+    # Defense-in-depth: this is a monorepo, `release: published` could in principle fire for a
+    # release unrelated to sprintable-mcp. Require an explicit sprintable-mcp-v* tag (manual
+    # workflow_dispatch runs skip this guard — those are always intentional).
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'sprintable-mcp-v')
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Sanity-check release tag matches package version
+        if: github.event_name == 'release'
+        working-directory: backend/sprintable_mcp
+        run: |
+          pkg_version=$(grep -m1 '^version = ' pyproject.toml | sed -E 's/version = "(.*)"/\1/')
+          tag_version="${GITHUB_REF_NAME#sprintable-mcp-v}"
+          if [ "$pkg_version" != "$tag_version" ]; then
+            echo "::error::release tag sprintable-mcp-v$tag_version does not match pyproject.toml version $pkg_version — bump pyproject.toml before tagging"
+            exit 1
+          fi
+
+      - name: Build sdist and wheel
+        working-directory: backend/sprintable_mcp
+        run: uv build --out-dir dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: backend/sprintable_mcp/dist


### PR DESCRIPTION
## 무엇
`.github/workflows/publish-mcp.yml` 이 **2026-07-07(`9602d73b`)에 main 으로 «직접»** 들어갔고 develop 에는 없다.
⇒ 지금 develop→main 승격을 하면 **이 워크플로가 main 에서 사라진다.**

## 왜 지금
오늘 이 워크플로로 `sprintable-mcp` 0.1.2 를 PyPI 에 발행했다(P0 RED — `uvx sprintable` 이 나흘간 깨져 있던 것). 사라지면 다음 발행이 막힌다.

## 검산 — 옮겨 «적은» 것이 아니라 같은 객체다
```
main   .github/workflows/publish-mcp.yml  blob e68af5d0484ff600f714591e8450695860dd2dd1
이 PR                                     blob e68af5d0484ff600f714591e8450695860dd2dd1  ✅
```

## ⚠️이 갈림은 하나가 아니다 — `#2397`(critical) 참조
가장 위험한 것은 alembic `0163` 이 **같은 revision 인데 부모가 갈린 것**(main=`0161` / develop=`0162`).
승격하면 alembic 이 「0163 이미 적용됨」으로 보고 `0146`·`0147`·`0162` 를 **영원히 건너뛴다** — prod 에 `pricing_versions` 가 안 생기는데 코드는 그것을 읽는다.
**이 PR 은 그중 «파일 부재» 하나만 메운다.**

## 안 하는 것
- alembic 갈림 정리 — `#2397` 본체
- 나머지 갈린 다섯(`cloud-build.yml`·`billing-tab.tsx`·`org_subscription.py`·`ee/routers/billing.py`·`test_e_org_multi_s5_4_polar_webhook.py`) 판정 — `#2397` AC5