### PR TITLE
[SID:2393] RESERVED_FIRST_SEGMENTS 실측 6곳 어긋남 수정 — 파생/CI가드 이원화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -689,6 +689,15 @@ jobs:
       - name: "Verify no orphan resource routes (story #2376 regression guard)"
         run: pnpm --filter web verify:no-orphan-resource-routes
 
+      # story #2393 회귀가드: route-resolve.ts의 RESERVED_FIRST_SEGMENTS(런타임 미들웨어가
+      # 워크스페이스 slug 후보 여부를 직접 판정하는 값)가 실제 app/ 구조와 어긋나면 실패한다.
+      # 레거시 리소스명 축(MIGRATED_RESOURCES 등)은 파생이라 어긋날 수 없고, 라이브 top-level
+      # 라우트+메타데이터 파일 라우트 축은 edge 런타임 위험(node:fs 미지원) 때문에 의도적으로
+      # 손 스냅샷으로 남겨 이 가드가 대신 지킨다 — 첫 실측(2026-08-01)에서 이미 6곳(gates·
+      # more·apple-icon.png·manifest.webmanifest·flow·goals) 어긋나 있던 것을 이 스토리가 고쳤다.
+      - name: "Verify RESERVED_FIRST_SEGMENTS sync (story #2393 regression guard)"
+        run: pnpm --filter web verify:reserved-first-segments-sync
+
       - name: Test
         # set -o pipefail so vitest's non-zero exit propagates through `| tail` instead
         # of being masked by tail's 0 — without it the unit-test gate was a no-op

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "verify:focus-inset-coverage": "tsx scripts/verify-focus-inset-coverage.ts",
     "verify:no-i18n-phrase-collision": "tsx scripts/verify-no-i18n-phrase-collision.ts",
     "verify:no-orphan-resource-routes": "tsx scripts/verify-no-orphan-resource-routes.ts",
+    "verify:reserved-first-segments-sync": "tsx scripts/verify-reserved-first-segments-sync.ts",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
     "e2e:report": "playwright show-report"

--- a/apps/web/scripts/verify-reserved-first-segments-sync.test.ts
+++ b/apps/web/scripts/verify-reserved-first-segments-sync.test.ts
@@ -1,0 +1,37 @@
+// story #2393 — checkReservedFirstSegmentsSync()가 실제 저장소 구조를 스캔해 어긋남 0건을
+// 내는지 확認한다. main()은 import.meta.url 가드로 감싸져 있어 이 파일을 import해도 CLI 실행
+// (process.exit 포함)은 돌지 않는다 — checkReservedFirstSegmentsSync()만 안전하게 호출한다.
+import { describe, expect, it } from 'vitest';
+import { checkReservedFirstSegmentsSync, METADATA_FILE_ROUTES } from './verify-reserved-first-segments-sync';
+
+describe('checkReservedFirstSegmentsSync — story #2393 AC3', () => {
+  it('실제 저장소 기준 어긋남 0건이다(2026-08-01 AC1 실측으로 찾은 6곳을 이미 반영)', () => {
+    const result = checkReservedFirstSegmentsSync();
+    expect(result.missing).toEqual([]);
+  });
+
+  it('sanity floor — 스캔이 실제로 디렉터리를 훑었다(빈 배열을 0건으로 오독하지 않는다)', () => {
+    const result = checkReservedFirstSegmentsSync();
+    expect(result.liveDirs.length).toBeGreaterThan(20);
+    expect(result.liveMetadataRoutes.length).toBeGreaterThan(0);
+    expect(result.derivedLegacyNames.length).toBeGreaterThan(0);
+  });
+
+  it('gates·more가 라이브 디렉터리 목록에 실제로 잡힌다(2026-08-01 발견한 드리프트의 근거)', () => {
+    const result = checkReservedFirstSegmentsSync();
+    expect(result.liveDirs).toContain('gates');
+    expect(result.liveDirs).toContain('more');
+  });
+
+  it('manifest.webmanifest가 메타데이터 라우트로 잡힌다(manifest.ts가 소스, 서빙 경로는 다른 이름)', () => {
+    const result = checkReservedFirstSegmentsSync();
+    expect(result.liveMetadataRoutes).toContain('manifest.webmanifest');
+    expect(METADATA_FILE_ROUTES['manifest.ts']).toBe('manifest.webmanifest');
+  });
+
+  it('flow·goals가 파생 축(레거시 리소스명)에 들어 있다(레거시 리소스 표에서 직접 파생 확認)', () => {
+    const result = checkReservedFirstSegmentsSync();
+    expect(result.derivedLegacyNames).toContain('flow');
+    expect(result.derivedLegacyNames).toContain('goals');
+  });
+});

--- a/apps/web/scripts/verify-reserved-first-segments-sync.ts
+++ b/apps/web/scripts/verify-reserved-first-segments-sync.ts
@@ -1,0 +1,115 @@
+/**
+ * story #2393 AC3 — `src/lib/route-resolve.ts`의 `RESERVED_FIRST_SEGMENTS`는 두 축으로
+ * 나뉜다: ①레거시 리소스명(`legacy-resource-tables.ts`에서 파생, 스냅샷 아님) ②라이브
+ * top-level 페이지 라우트 + Next.js 메타데이터 파일 라우트(손 스냅샷, 의도적).
+ *
+ * ②를 `readdirSync`로 자동파생하지 않는 이유 — `route-resolve.ts`는 `proxy.ts`(Next.js
+ * 미들웨어)에 import돼 **edge 런타임 번들에 들어간다**. edge 런타임은 `node:fs`를 지원하지
+ * 않아, 그 파일 모듈 최상단에 `readdirSync`를 넣으면 빌드/배포가 깨질 위험을 진다 — 실 요청
+ * 라우팅을 다루는 자리에서 그 위험을 질 이유가 없다(PO 판단: "틀리면 사용자 요청이 다른
+ * 데로 간다"). 그래서 ②는 손 스냅샷으로 «남기고», 이 스크립트(순수 Node.js 프로세스로
+ * 돌아 `fs`가 안전한 CI 전용 자리)가 그 스냅샷과 실제 `app/` 구조의 어긋남을 매 빌드마다
+ * 잡는다 — "남겨 둔다"로 끝내지 않는다(AC3).
+ *
+ * AC1 실측(2026-08-01) — 이 가드를 짜기 전 스냅샷이 이미 6곳 어긋나 있었다: `gates`·`more`
+ * (라이브 디렉터리인데 목록에 없었음) · `apple-icon.png`·`manifest.webmanifest`(Next.js
+ * 메타데이터 파일 라우트, 목록에 없었음 — `manifest.ts`가 소스인데 서빙 경로는 다른 이름).
+ * `flow`·`goals`는 레거시 리소스명 축(①) 미적용으로 인한 어긋남이었다(이번 판에서 ①을
+ * 파생으로 바꿔 해결). 지금은 `route-resolve.ts`에 6개 다 반영해 0건이다.
+ */
+import { readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { MIGRATED_RESOURCES, RENAMED_RESOURCES, RETIRED_RESOURCES } from '../src/lib/legacy-resource-tables';
+import { RESERVED_FIRST_SEGMENTS } from '../src/lib/route-resolve';
+
+// story #2387/#2393 관례 — 스크립트 자기 위치(import.meta.url) 기준으로 SRC_ROOT를 잡는다.
+// process.cwd() 기준으로 잡으면 `pnpm --filter web`(cwd=apps/web)과 monorepo 루트에서 도는
+// `pnpm vitest run`(CI) 사이에서 어긋난다(#2387이 실 CI에서 겪은 함정, PR #2774).
+const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src');
+const APP_ROOT = path.resolve(SRC_ROOT, 'app');
+const AUTHENTICATED_ROOT = path.resolve(APP_ROOT, '(authenticated)');
+
+function listTopLevelDirs(dir: string): string[] {
+  return readdirSync(dir).filter((entry) => statSync(path.join(dir, entry)).isDirectory());
+}
+
+function listTopLevelFiles(dir: string): string[] {
+  return readdirSync(dir).filter((entry) => statSync(path.join(dir, entry)).isFile());
+}
+
+// Next.js 메타데이터 파일 컨벤션 — 소스 파일명이 실제 서빙 경로와 다를 수 있다(2026-08-01
+// `pnpm build` 라우트 표 실측 대조: `manifest.ts` → `/manifest.webmanifest`). 이 매핑은
+// Next.js 자체 컨벤션 표라 여기서 손으로 유지한다(컨벤션이 늘면 이 표에도 추가해야 한다 —
+// AC5 blind spot으로 파일 하단 주석에 선언).
+export const METADATA_FILE_ROUTES: Record<string, string> = {
+  'favicon.ico': 'favicon.ico',
+  'icon.svg': 'icon.svg',
+  'apple-icon.png': 'apple-icon.png',
+  'manifest.ts': 'manifest.webmanifest',
+};
+
+export interface SyncCheckResult {
+  liveDirs: string[];
+  liveMetadataRoutes: string[];
+  derivedLegacyNames: string[];
+  missing: string[];
+}
+
+export function checkReservedFirstSegmentsSync(): SyncCheckResult {
+  const liveDirs = [
+    ...listTopLevelDirs(APP_ROOT).filter((d) => d !== '(authenticated)'),
+    ...listTopLevelDirs(AUTHENTICATED_ROOT).filter((d) => d !== '[ws]'),
+  ];
+
+  const appRootFiles = listTopLevelFiles(APP_ROOT);
+  const liveMetadataRoutes = appRootFiles
+    .filter((f) => f in METADATA_FILE_ROUTES)
+    .map((f) => METADATA_FILE_ROUTES[f]!);
+
+  const derivedLegacyNames = new Set<string>([
+    ...Object.keys(MIGRATED_RESOURCES),
+    ...Object.keys(RENAMED_RESOURCES),
+    ...Object.keys(RETIRED_RESOURCES),
+  ]);
+
+  const missing: string[] = [];
+  for (const dir of liveDirs) {
+    if (derivedLegacyNames.has(dir)) continue; // 파생 축(①)이 이미 덮는다
+    if (!RESERVED_FIRST_SEGMENTS.has(dir)) missing.push(`routeWithoutReservation:${dir}`);
+  }
+  for (const route of liveMetadataRoutes) {
+    if (!RESERVED_FIRST_SEGMENTS.has(route)) missing.push(`metadataRouteWithoutReservation:${route}`);
+  }
+
+  return { liveDirs, liveMetadataRoutes, derivedLegacyNames: [...derivedLegacyNames], missing };
+}
+
+function main(): void {
+  const { liveDirs, liveMetadataRoutes, derivedLegacyNames, missing } = checkReservedFirstSegmentsSync();
+
+  if (missing.length > 0) {
+    console.error(`❌ RESERVED_FIRST_SEGMENTS가 실 app/ 구조와 어긋났습니다(${missing.length}건):`);
+    missing.forEach((m) => console.error(`  - ${m}`));
+    console.error(
+      '\nsrc/lib/route-resolve.ts의 RESERVED_FIRST_SEGMENTS(② 손 스냅샷 부분)에 위 항목을 추가하세요 — ' +
+        '이 항목이 예약되지 않으면 워크스페이스 slug로 오인될 수 있습니다(사용자 요청이 다른 데로 감).',
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `OK: RESERVED_FIRST_SEGMENTS 어긋남 0건 ` +
+      `(라이브 디렉터리 ${liveDirs.length}개 + 메타데이터 라우트 ${liveMetadataRoutes.length}개 ` +
+      `전부 예약됨, 레거시 리소스명 ${derivedLegacyNames.length}개는 파생 축)`,
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}
+
+// AC5 — 이 가드가 못 잡는 것: `METADATA_FILE_ROUTES`에 없는 새 Next.js 메타데이터 컨벤션
+// (예: robots.ts, sitemap.ts, opengraph-image.tsx, twitter-image.tsx)이 app root에 추가되면
+// 이 스크립트는 그 파일의 실제 서빙 경로를 모른 채 조용히 통과한다 — 그 컨벤션을 쓰기 시작할
+// 때 위 매핑에 손으로 추가해야 한다(Next.js 자체 문서가 SSOT, 이 스크립트가 추론하지 않는다).

--- a/apps/web/src/lib/legacy-resource-tables.ts
+++ b/apps/web/src/lib/legacy-resource-tables.ts
@@ -1,0 +1,90 @@
+/**
+ * story #2393 — `proxy.ts`(edge 미들웨어)와 `route-resolve.ts`가 «둘 다» 참조해야 하는
+ * 레거시 리소스 이름 표를 여기 하나로 뺐다. proxy.ts가 route-resolve.ts를 import하므로(fetchResolve
+ * 등), route-resolve.ts가 반대로 proxy.ts를 import하면 순환참조가 된다 — 이 파일은 어느 쪽도
+ * import하지 않는 순수 데이터 leaf 모듈이라 그 순환을 피한다. proxy.ts는 여기서 import해 그대로
+ * re-export한다(기존 소비처 `scripts/verify-no-orphan-resource-routes.ts`가 `../src/proxy`에서
+ * 이 표들을 가져오던 경로를 그대로 유지 — story #2387 참고).
+ */
+
+/**
+ * story a539c649 S-route-project — 이관 완료된 Project-tier 리소스 목록(flat 첫 세그먼트 →
+ * 그 리소스 밑에서 project-scope 아닌 채로 존치되는 서브패스 제외 목록). 슬라이스가 리소스를
+ * `/{ws}/{proj}/{resource}`로 옮길 때마다 여기 키 하나씩 추가한다(S2=docs, S3a=standup 등).
+ */
+export const MIGRATED_RESOURCES: Record<string, string[]> = {
+  docs: ['design-tokens'], // 비-project 정적 페이지, 존치
+  standup: [],
+  retro: [],
+  loops: [],
+  artifacts: [],
+  mockups: [],
+  sprints: [],
+  storage: [],
+  epics: [],
+  board: [],
+  // story #2224(선생님 정정 2026-07-30) — glance는 원래 ws/proj-scoped로 "이관"된 적이 없는
+  // 순수 top-level 라우트였지만, "보드+현황판 통합"의 실제 자리가 /flow로 확定되며 같은 부류의
+  // 문제(bare 딥링크가 org+project를 몰라 해소해야 함)가 생겼다 — 이미 검증된 이 표를 재사용
+  // 한다(새 미들웨어 층을 세우지 않는다, proxy.ts의 redirectRenamedResourcePath와 짝).
+  glance: [],
+  // ⛔실측 발견(2026-07-30, 진입점 전수 스윕 중) — `flow` 자체가 이 표에 «없었다». 사이드바
+  // (app-sidebar.tsx)는 항상 `resourceLink('flow')`로 실 slug를 채운 경로만 썼기에 이 갭이
+  // 안 보였는데, mobile-tab-bar.tsx의 "지금" 탭 href를 bare `/flow`로 바꾸며(옛 `/glance`
+  // 대체) 처음으로 실사용 경로가 생겼다 — 등록 없이 나갔으면 즉시 404였을 것.
+  flow: [],
+  // story #2016: 8fc51517(B1 리네이밍)이 epics→goals 경로 리터럴을 바꾸면서 RENAMED_RESOURCES에만
+  // 반영되고 여기(MIGRATED_RESOURCES)엔 신 이름 'goals'를 안 넣었다 — bare `/epics`는 이 표를 거쳐
+  // `/{ws}/{proj}/epics`로 301된 뒤 redirectRenamedResourcePath가 2차로 `goals`로 다시 301하지만,
+  // bare `/goals`(신 이름 그대로 오는 딥링크·북마크·검색결과)는 애초에 이 표에 키가 없어 redirectLegacyResourcePath가
+  // 즉시 null 반환 → Next 자체 404. 호스트/쿠키 무관 리소스 등록 누락 실측 확認(direct Cloud Run 호스트에서
+  // /board는 301 정상·/goals만 404, 동일 JWT fallback 경로 재사용).
+  goals: [],
+};
+
+/**
+ * story 8fc51517(계층 리네이밍 B1, doc hierarchy-renaming-url-implementation-design §ⓑ) —
+ * `/{ws}/{proj}/{resource}` 안의 **경로 리터럴**이 신 용어로 바뀔 때(에픽→목표 등)의 301.
+ * proxy.ts의 `redirectLegacyResourcePath`와 다른 관심사 — 저건 ws/proj 세그먼트 자체가 없던
+ * 옛 flat URL을 org/project 재조회로 채워 넣는 것이고, 이건 ws/proj가 **이미 URL에 있으므로**
+ * 3번째 세그먼트(리소스명)만 신 이름으로 교체하면 된다(org/project 재조회 fetch 불요).
+ *
+ * story #2387(2026-08-01) — `scripts/verify-no-orphan-resource-routes.ts`가 이 표(+
+ * RETIRED_RESOURCES)에서 RENAMED_RESOURCE_ALIASES를 파생시킨다(예전엔 손으로 옮겨 적은
+ * 스냅샷이었다 — story #2378 리뷰에서 유나양이 발견). story #2393(2026-08-01) — route-resolve.ts의
+ * RESERVED_FIRST_SEGMENTS도 여기서 파생시킨다(순환참조 회피를 위해 이 표 자체를 proxy.ts
+ * 밖으로 뺀 것이 그 이유).
+ */
+export const RENAMED_RESOURCES: Record<string, string> = {
+  epics: 'goals',
+  // story #2224(선생님 정정 2026-07-30) — glance는 이제 /flow 안의 한 조각. 위 MIGRATED_RESOURCES
+  // 항목과 짝: bare `/glance` → (redirectLegacyResourcePath) → `/{ws}/{proj}/glance` →
+  // (여기) → `/{ws}/{proj}/flow`. `?story=`/`?task_id=` 등 쿼리는 두 함수 다 request.nextUrl을
+  // clone해 그대로 들고 가므로 안전(RESOLVE_RETRY_PARAM 외엔 손대지 않는다).
+  glance: 'flow',
+  // #2227 AC8(2026-07-27) 종료 조건 — board 제거는 flow 리다이렉트 포함이 조건이었다(유나
+  // 2026-08-01 지적: prod 승격 #2373에서 board 라우트만 지우고 이 줄을 빠뜨려 외부 딥링크
+  // ~14곳이 404를 만날 뻔했다 — board/page.tsx:12-13 자체가 이 위험을 이미 적어 두고 있었다).
+  board: 'flow',
+};
+
+/**
+ * story #2378(2026-08-01, 유나양 design:changes) — `RENAMED_RESOURCES`와 «성격이 다른» 은퇴.
+ * 위 표(epics/glance/board)는 같은 행이 새 이름을 받은 rename이라 id를 그대로 들고 가도 안전
+ * (mockups 3번째 세그먼트 뒤 id가 있으면 「그 id」로 다시 찾을 수 있다). 여기는 반대 —
+ * `RETIRED_RESOURCES`에 오르면 옛 리소스가 «폐기»되고 다른 리소스가 그 자리를 대신할 뿐이라
+ * id 공간이 다르다(mockup id ≠ artifact id). id를 그대로 옮기면 두 가지 결과가 갈리는데
+ * ①못 찾음(404)보다 ⭐②우연히 같은 id의 «남의 항목»이 열리는 쪽이 더 무겁다 — 사용자가
+ * 잘못된 항목을 보고 있다는 것을 알 방법이 없다. 그래서 proxy.ts의 `redirectRetiredResourcePath`
+ * 는 id를 버리고 목록 루트로만 보낸다.
+ *
+ * `mockups: 'artifacts'` — dev DB 실측(2026-08-01, PO)으로 `mockups` 테이블 자체가 없고
+ * mockup_scenarios/versions/pages 전부 0건이라 dev 기준으로는 되살아날 id 자체가 없다(⚠️
+ * prod는 안 쟀다 — 오늘 이 저장소에서 `board:'flow'`가 main에만 있고 develop엔 없었던 사례처럼
+ * 환경별로 실측이 갈릴 수 있다. id를 버리는 처리 자체는 그 실측과 무관하게 안전하다). E-CANVAS가
+ * `mockups`의 부분 후계라(스토리 본문 — 시나리오 분기·자유배치 편집·버전 복원·9종 팔레트·
+ * category/slug는 안 옮겨짐, 필요 시 별건) 목록 화면(`/artifacts`)이 최소 충족선이다.
+ */
+export const RETIRED_RESOURCES: Record<string, string> = {
+  mockups: 'artifacts',
+};

--- a/apps/web/src/lib/route-resolve.test.ts
+++ b/apps/web/src/lib/route-resolve.test.ts
@@ -7,6 +7,7 @@ import {
   signResolveCache,
   verifyResolveCache,
 } from './route-resolve';
+import { MIGRATED_RESOURCES, RENAMED_RESOURCES, RETIRED_RESOURCES } from './legacy-resource-tables';
 
 const JWT_SECRET = 'test-secret-for-route-resolve-tests';
 
@@ -52,6 +53,40 @@ describe('looksLikeWorkspaceSegment', () => {
     expect(looksLikeWorkspaceSegment('-leading-hyphen')).toBe(true);
     expect(looksLikeWorkspaceSegment('trailing-hyphen-')).toBe(true);
   });
+});
+
+// story #2393 — AC1 실측으로 찾은 6개 드리프트(gates·more·apple-icon.png·manifest.webmanifest·
+// flow·goals)를 명시적으로 고정한다. 위 "rejects every current live flat-route literal" 은
+// RESERVED_FIRST_SEGMENTS 자신을 순회하므로 이 6개가 그 Set에서 통째로 사라져도 통과해 버린다
+// — 이름을 하드코딩해 그 실패 모드를 막는다.
+describe('RESERVED_FIRST_SEGMENTS — story #2393 AC1 드리프트 회귀 고정', () => {
+  it.each(['gates', 'more', 'apple-icon.png', 'manifest.webmanifest', 'flow', 'goals'])(
+    '%s는 예약 세그먼트다(2026-08-01 실측 당시 손 스냅샷에서 빠져 있던 6개 중 하나)',
+    (segment) => {
+      expect(RESERVED_FIRST_SEGMENTS.has(segment)).toBe(true);
+    },
+  );
+
+  // AC2 — 레거시 리소스명 축은 legacy-resource-tables.ts에서 파생된다(순수 데이터 참조,
+  // 스냅샷 아님). 그 표에 새 키가 추가되면 이 테스트가 자동으로 커버한다(하드코딩 목록 아님).
+  it('MIGRATED_RESOURCES · RENAMED_RESOURCES · RETIRED_RESOURCES 키 전부가 예약돼 있다(파생 축)', () => {
+    for (const key of Object.keys(MIGRATED_RESOURCES)) {
+      expect(RESERVED_FIRST_SEGMENTS.has(key), `MIGRATED_RESOURCES.${key}`).toBe(true);
+    }
+    for (const key of Object.keys(RENAMED_RESOURCES)) {
+      expect(RESERVED_FIRST_SEGMENTS.has(key), `RENAMED_RESOURCES.${key}`).toBe(true);
+    }
+    for (const key of Object.keys(RETIRED_RESOURCES)) {
+      expect(RESERVED_FIRST_SEGMENTS.has(key), `RETIRED_RESOURCES.${key}`).toBe(true);
+    }
+  });
+
+  // AC5 — 이 테스트가 못 잡는 것: 새 top-level 페이지 라우트(app/* 또는 app/(authenticated)/*)
+  // 가 추가돼도 이 파일(hand snapshot 축)이 자동으로 안 늘어난다 — readdirSync 파생을 의도적으로
+  // 안 하기 때문이다(edge 런타임 위험, 파일 헤더 주석 참조). 그 어긋남은 CI 가드
+  // (scripts/verify-reserved-first-segments-sync.ts)가 매 빌드마다 잡는다 — 이 테스트 파일이
+  // 아니다. 즉 "여기 테스트가 초록"이 "hand snapshot이 지금도 실제 라우트와 일치한다"를
+  // 보장하지 않는다 — 그 보장은 CI 가드 몫이다.
 });
 
 describe('signResolveCache / verifyResolveCache', () => {

--- a/apps/web/src/lib/route-resolve.ts
+++ b/apps/web/src/lib/route-resolve.ts
@@ -10,6 +10,7 @@
  * resolve 성공+캐시+301-chase 동작)만 증명한다.
  */
 import { SignJWT, jwtVerify } from 'jose';
+import { MIGRATED_RESOURCES, RENAMED_RESOURCES, RETIRED_RESOURCES } from './legacy-resource-tables';
 
 export const SP_RESOLVE_CACHE_COOKIE = 'sp_resolve_cache';
 
@@ -18,18 +19,56 @@ export const SP_RESOLVE_CACHE_COOKIE = 'sp_resolve_cache';
 export const RESOLVE_CACHE_TTL_SECONDS = 50;
 
 /**
- * 현재 라이브 flat 라우트 첫 세그먼트 전부(2026-07-15 grounding, apps/web/src/app/ 실측) — 이
- * 목록과 겹치는 첫 세그먼트는 workspace slug 시도 자체를 스킵한다. S2/S3 가 리소스를
- * `/{ws}/{proj}/{resource}` 로 이관하며 여기서 하나씩 제거해나간다(그 리소스가 이사하면 첫
- * 세그먼트가 더는 flat 라우트가 아니게 되므로).
+ * story #2393(2026-08-01) — 예전엔 아래 전부(레거시 리소스명 포함)가 "2026-07-15 grounding"
+ * 손 스냅샷 하나였다. story #2387이 같은 병(proxy.ts의 RENAMED_RESOURCE_ALIASES가 손 스냅샷
+ * 이라 리소스 표가 바뀌어도 안 따라옴)을 CI 가드 둘에서 고치며, 이 셋째는 «런타임 미들웨어
+ * 라우팅이 직접 쓰는 값»이라 리스크가 다르다는 이유로 후속 스토리로 남겼다(PR #2774) — 이
+ * 스토리가 그 후속이다.
+ *
+ * AC1 실측(2026-08-01, 코드 대조) — 손 스냅샷이 이미 6곳 어긋나 있었다:
+ *   ㉠`gates`·`more` — app/(authenticated)/ 밑에 실존하는 라이브 라우트인데 목록에 없었다.
+ *     이 둘이 워크스페이스 slug로 오인되면(리스크: 어떤 조직이 우연히 그 이름의 워크스페이스를
+ *     만들면 그 조직 사용자의 `/gates`·`/more` 요청이 실제 결재함/더보기 페이지 대신 워크스페이스
+ *     resolve 시도로 가로채진다) — 이번 판이 고치는 이유가 바로 이 자리다.
+ *   ㉡`apple-icon.png`·`manifest.webmanifest` — Next.js 메타데이터 파일 컨벤션이 실제로 그
+ *     경로에 라우트를 만든다(`pnpm build` 라우트 표로 직접 확認 — `manifest.ts`가 소스인데
+ *     서빙 경로는 파일명과 다른 `manifest.webmanifest`라는 것도 이번에 확認, story #2022가
+ *     인증 미들웨어 matcher에서 이미 한 번 겪은 것과 같은 함정).
+ *   ㉢`flow`·`goals` — `MIGRATED_RESOURCES`(proxy.ts의 bare-flat-URL 표)엔 있는데 여기 없었다.
+ *     정상 경로에선 `redirectLegacyResourcePath`가 먼저 가로채 실질 영향이 없지만, 그 함수가
+ *     이른 `return null`로 통과시키는 예외 경로(예: JWT에 org_id가 없는 경우, 있음 기록된
+ *     스토리 없이 이론상 가능)에서는 이 표까지 내려와야 안전하다.
+ *
+ * ⭐AC2 — 완전 자동파생은 하지 않는다(AC3 근거). 아래 두 갈래로 나눈 이유:
+ *   ①레거시 리소스명(MIGRATED_RESOURCES∪RENAMED_RESOURCES∪RETIRED_RESOURCES 키)은 순수 데이터
+ *     참조라 여기서 직접 import해 파생한다 — proxy.ts가 route-resolve.ts를 import하므로 반대
+ *     방향 import는 순환참조가 되고, 그래서 이 표들을 어느 쪽도 참조하지 않는 leaf 모듈
+ *     (`legacy-resource-tables.ts`)로 뺐다(proxy.ts는 거기서 import + 재수출). 이 부분은
+ *     스냅샷이 아니라 항상-동기화되는 참조라 «어긋날 수 없다».
+ *   ②라이브 top-level 페이지 라우트 + 메타데이터 파일 라우트는 `readdirSync`로 파생시키지
+ *     않는다 — 이 파일은 proxy.ts(Next.js 미들웨어)에 import돼 **edge 런타임 번들에 들어간다**
+ *     (`export const config = {...}`의 matcher가 있는 그 파일). CI 스크립트(`scripts/verify-
+ *     no-orphan-resource-routes.ts`)는 Node.js 프로세스로 도니 `readdirSync`가 안전하지만,
+ *     여기서 모듈 최상단에 `readdirSync`를 넣으면 edge 런타임(node:fs 미지원)에서 빌드/배포가
+ *     깨질 위험을 진다 — 실 요청 라우팅을 다루는 이 파일에서 그 위험을 질 이유가 없다(PO
+ *     지적과 동일 근거: "틀리면 사용자 요청이 다른 데로 간다"). 그래서 이 부분은 손 스냅샷으로
+ *     «남긴다»(AC3) — 대신 `scripts/verify-reserved-first-segments-sync.ts`(신규 CI 가드)가
+ *     이 목록과 실제 `app/` 구조의 어긋남을 매 빌드마다 잡는다(어긋나면 CI가 빨개진다 —
+ *     "남겨 둔다"로 끝내지 않는다).
  */
 export const RESERVED_FIRST_SEGMENTS = new Set([
-  'activity', 'api', 'artifacts', 'auth', 'board', 'channel', 'chats', 'dashboard',
-  'docs', 'epics', 'favicon.ico', 'forgot-password', 'glance', 'icon.svg', 'inbox',
-  'internal-dogfood', 'invite', 'login', 'loops', 'meetings', 'mfa', 'mockups',
-  'onboarding', 'org-briefing', 'organization', 'privacy', 'register', 'reset-password',
-  'retro', 'rewards', 'settings', 'share', 'sprints', 'standup', 'storage', 'terms',
-  'verify-email',
+  // ① 파생 — 레거시 리소스명. 순수 데이터 import라 항상 최신(위 주석 참조).
+  ...Object.keys(MIGRATED_RESOURCES),
+  ...Object.keys(RENAMED_RESOURCES),
+  ...Object.keys(RETIRED_RESOURCES),
+  // ② 손 스냅샷(의도적, 2026-08-01 재실측) — 라이브 top-level 페이지 라우트(`app/*`+
+  // `app/(authenticated)/*`, `[ws]`/`(authenticated)` 제외) + Next.js 메타데이터 파일
+  // 라우트. `scripts/verify-reserved-first-segments-sync.ts`가 어긋남을 CI에서 잡는다.
+  'activity', 'api', 'apple-icon.png', 'auth', 'channel', 'chats', 'dashboard',
+  'favicon.ico', 'forgot-password', 'gates', 'icon.svg', 'inbox', 'internal-dogfood',
+  'invite', 'login', 'manifest.webmanifest', 'meetings', 'mfa', 'more', 'onboarding',
+  'org-briefing', 'organization', 'privacy', 'register', 'reset-password', 'rewards',
+  'settings', 'share', 'terms', 'verify-email',
 ]);
 
 /**

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -3,6 +3,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 import { SESSION_EXPIRED_REASON } from '@/lib/auth/session-redirect';
 import { isRecentlySuperseded } from '@/lib/auth/switch-epoch';
+import { MIGRATED_RESOURCES, RENAMED_RESOURCES, RETIRED_RESOURCES } from '@/lib/legacy-resource-tables';
 import {
   fetchResolve,
   looksLikeWorkspaceSegment,
@@ -107,40 +108,14 @@ async function getProjectIdFromAccessToken(token: string): Promise<string | null
   }
 }
 
-/**
- * story a539c649 S-route-project — 이관 완료된 Project-tier 리소스 목록(flat 첫 세그먼트 →
- * 그 리소스 밑에서 project-scope 아닌 채로 존치되는 서브패스 제외 목록). 슬라이스가 리소스를
- * `/{ws}/{proj}/{resource}`로 옮길 때마다 여기 키 하나씩 추가한다(S2=docs, S3a=standup 등).
- */
-const MIGRATED_RESOURCES: Record<string, string[]> = {
-  docs: ['design-tokens'], // 비-project 정적 페이지, 존치
-  standup: [],
-  retro: [],
-  loops: [],
-  artifacts: [],
-  mockups: [],
-  sprints: [],
-  storage: [],
-  epics: [],
-  board: [],
-  // story #2224(선생님 정정 2026-07-30) — glance는 원래 ws/proj-scoped로 "이관"된 적이 없는
-  // 순수 top-level 라우트였지만, "보드+현황판 통합"의 실제 자리가 /flow로 확定되며 같은 부류의
-  // 문제(bare 딥링크가 org+project를 몰라 해소해야 함)가 생겼다 — 이미 검증된 이 표를 재사용
-  // 한다(새 미들웨어 층을 세우지 않는다, 아래 redirectRenamedResourcePath와 짝).
-  glance: [],
-  // ⛔실측 발견(2026-07-30, 진입점 전수 스윕 중) — `flow` 자체가 이 표에 «없었다». 사이드바
-  // (app-sidebar.tsx)는 항상 `resourceLink('flow')`로 실 slug를 채운 경로만 썼기에 이 갭이
-  // 안 보였는데, mobile-tab-bar.tsx의 "지금" 탭 href를 bare `/flow`로 바꾸며(옛 `/glance`
-  // 대체) 처음으로 실사용 경로가 생겼다 — 등록 없이 나갔으면 즉시 404였을 것.
-  flow: [],
-  // story #2016: 8fc51517(B1 리네이밍)이 epics→goals 경로 리터럴을 바꾸면서 RENAMED_RESOURCES에만
-  // 반영되고 여기(MIGRATED_RESOURCES)엔 신 이름 'goals'를 안 넣었다 — bare `/epics`는 이 표를 거쳐
-  // `/{ws}/{proj}/epics`로 301된 뒤 redirectRenamedResourcePath가 2차로 `goals`로 다시 301하지만,
-  // bare `/goals`(신 이름 그대로 오는 딥링크·북마크·검색결과)는 애초에 이 표에 키가 없어 redirectLegacyResourcePath가
-  // 즉시 null 반환 → Next 자체 404. 호스트/쿠키 무관 리소스 등록 누락 실측 확認(direct Cloud Run 호스트에서
-  // /board는 301 정상·/goals만 404, 동일 JWT fallback 경로 재사용).
-  goals: [],
-};
+// story #2393(2026-08-01) — MIGRATED_RESOURCES/RENAMED_RESOURCES/RETIRED_RESOURCES를
+// `lib/legacy-resource-tables.ts`로 옮겼다(위에서 import). route-resolve.ts의
+// RESERVED_FIRST_SEGMENTS가 이 표들에서 직접 파생해야 하는데, route-resolve.ts는 proxy.ts에
+// 이미 import되는 쪽(fetchResolve 등)이라 proxy.ts가 반대로 route-resolve.ts를 import하면
+// 순환참조가 된다 — 이 표들을 어느 쪽도 import하지 않는 leaf 모듈로 빼서 그 순환을 피했다.
+// 아래 재수출은 기존 소비처(`scripts/verify-no-orphan-resource-routes.ts`가 `../src/proxy`
+// 에서 가져오던 경로)가 안 깨지게 유지한다 — 값은 여전히 legacy-resource-tables.ts가 SSOT다.
+export { RENAMED_RESOURCES, RETIRED_RESOURCES };
 
 /**
  * story a539c649(S2 최초 도입·S3에서 리소스 파라미터화) — 옛 flat `/{resource}/*` 를
@@ -226,47 +201,9 @@ function redirectToProjectPicker(request: NextRequest, originalPathname: string)
  * `redirectLegacyResourcePath`(위)와 다른 관심사 — 저건 ws/proj 세그먼트 자체가 없던 옛 flat
  * URL을 org/project 재조회로 채워 넣는 것이고, 이건 ws/proj가 **이미 URL에 있으므로** 3번째
  * 세그먼트(리소스명)만 신 이름으로 교체하면 된다(org/project 재조회 fetch 불요, 훨씬 가벼움).
+ * `RENAMED_RESOURCES`(이 rename표)와 `RETIRED_RESOURCES`(폐기표, id 폐기 — 아래 함수와 짝)의
+ * 정의와 상세 주석은 `lib/legacy-resource-tables.ts`(위에서 import) 참조.
  */
-// story #2387(2026-08-01) — export한다: scripts/verify-no-orphan-resource-routes.ts가 이 표
-// (+RETIRED_RESOURCES)에서 RENAMED_RESOURCE_ALIASES를 파생시킨다(예전엔 손으로 옮겨 적은
-// 스냅샷이었다 — proxy.ts가 바뀌어도 그 스냅샷은 안 바뀌어 조용히 어긋날 수 있었다, story
-// #2378 리뷰에서 유나양이 발견). export 자체는 이 미들웨어의 런타임 동작을 바꾸지 않는다.
-export const RENAMED_RESOURCES: Record<string, string> = {
-  epics: 'goals',
-  // story #2224(선생님 정정 2026-07-30) — glance는 이제 /flow 안의 한 조각. 위 MIGRATED_RESOURCES
-  // 항목과 짝: bare `/glance` → (redirectLegacyResourcePath) → `/{ws}/{proj}/glance` →
-  // (여기) → `/{ws}/{proj}/flow`. `?story=`/`?task_id=` 등 쿼리는 두 함수 다 request.nextUrl을
-  // clone해 그대로 들고 가므로 안전(RESOLVE_RETRY_PARAM 외엔 손대지 않는다).
-  glance: 'flow',
-  // #2227 AC8(2026-07-27) 종료 조건 — board 제거는 flow 리다이렉트 포함이 조건이었다(유나
-  // 2026-08-01 지적: prod 승격 #2373에서 board 라우트만 지우고 이 줄을 빠뜨려 외부 딥링크
-  // ~14곳이 404를 만날 뻔했다 — board/page.tsx:12-13 자체가 이 위험을 이미 적어 두고 있었다).
-  board: 'flow',
-};
-
-/**
- * story #2378(2026-08-01, 유나양 design:changes) — `RENAMED_RESOURCES`와 «성격이 다른» 은퇴.
- * 위 표(epics/glance/board)는 같은 행이 새 이름을 받은 rename이라 id를 그대로 들고 가도 안전
- * (mockups 3번째 세그먼트 뒤 id가 있으면 「그 id」로 다시 찾을 수 있다). 여기는 반대 —
- * `RETIRED_RESOURCES`에 오르면 옛 리소스가 «폐기»되고 다른 리소스가 그 자리를 대신할 뿐이라
- * id 공간이 다르다(mockup id ≠ artifact id). id를 그대로 옮기면 두 가지 결과가 갈리는데
- * ①못 찾음(404)보다 ⭐②우연히 같은 id의 «남의 항목»이 열리는 쪽이 더 무겁다 — 사용자가
- * 잘못된 항목을 보고 있다는 것을 알 방법이 없다. 그래서 이 표는 id를 «버리고» 목록 루트로만
- * 보낸다(아래 `redirectRetiredResourcePath`가 segments[2] 뒤를 전부 잘라낸다).
- *
- * `mockups: 'artifacts'` — dev DB 실측(2026-08-01, PO)으로 `mockups` 테이블 자체가 없고
- * mockup_scenarios/versions/pages 전부 0건이라 dev 기준으로는 되살아날 id 자체가 없다(⚠️
- * prod는 안 쟀다 — 오늘 이 저장소에서 `board:'flow'`가 main에만 있고 develop엔 없었던 사례처럼
- * 환경별로 실측이 갈릴 수 있다. 이 코드가 id를 버리는 것은 그 실측과 무관하게 안전한 처리라
- * 결론 문장의 「dev 기준」 한정과는 별개로 방어적이다). E-CANVAS가 `mockups`의 부분 후계라
- * (스토리 본문 — 시나리오 분기·자유배치 편집·버전 복원·9종 팔레트·category/slug는 안 옮겨짐,
- * 필요 시 별건) 목록 화면(`/artifacts`)이 최소 충족선(AC3 「주소를 빈 채 두지 않는다」)이다.
- */
-// story #2387 — export한다(같은 이유, 위 RENAMED_RESOURCES 주석 참조).
-export const RETIRED_RESOURCES: Record<string, string> = {
-  mockups: 'artifacts',
-};
-
 function redirectRenamedResourcePath(request: NextRequest, pathname: string): NextResponse | null {
   const segments = pathname.split('/').filter(Boolean);
   const resourceName = segments[2]; // [ws]/[proj]/{resourceName}/...


### PR DESCRIPTION
## Summary
- story #2393 — story #2387의 후속. #2387이 `RENAMED_RESOURCE_ALIASES`/`KNOWN_NON_PROJECT_ROUTES`는 파생으로 바꾸고, `route-resolve.ts`의 `RESERVED_FIRST_SEGMENTS`는 "런타임 미들웨어 라우팅이 직접 쓰는 값이라 리스크가 다르다"며 후속 스토리로 남겼다(PR #2774). 이 PR이 그 후속.

**AC1 실측** — 손 스냅샷이 이미 6곳 어긋나 있었다(0건이 아니었다):
- `gates`·`more` — `app/(authenticated)/`의 라이브 디렉터리인데 목록에 없었음
- `apple-icon.png`·`manifest.webmanifest` — Next.js 메타데이터 파일 컨벤션 라우트(`pnpm build` 라우트 표로 직접 확認 — `manifest.ts`가 소스인데 서빙 경로는 다른 이름, story #2022가 인증 matcher에서 이미 한 번 겪은 것과 같은 함정)
- `flow`·`goals` — `proxy.ts`의 `MIGRATED_RESOURCES`엔 있는데 여기 없었음

**AC2/AC3** — 두 축으로 나눠 처리:
- 레거시 리소스명 축(`MIGRATED_RESOURCES ∪ RENAMED_RESOURCES ∪ RETIRED_RESOURCES` 키, 13개)은 순수 데이터 참조라 **파생**으로 바꿨다. 파생 결과(43개) vs 옛 스냅샷(37개): 추가 6개(정확히 AC1이 찾은 6개), 제거 0개 — 차이 전부가 "파생 로직 버그"가 아니라 "지금 라우팅이 이미 틀렸다"쪽이었다.
- 라이브 top-level 라우트 + 메타데이터 파일 축은 **파생하지 않는다**(AC3) — `route-resolve.ts`는 `proxy.ts`(Next.js 미들웨어)에 import돼 **edge 런타임 번들에 들어간다**. edge는 `node:fs`를 지원하지 않아 여기서 `readdirSync`를 쓰면 빌드/배포가 깨질 위험을 진다(CI 스크립트는 Node 프로세스라 안전하지만 이 파일은 다르다). 그래서 이 축은 **손 스냅샷으로 남기고**, 신규 CI 가드(`scripts/verify-reserved-first-segments-sync.ts`)가 실 `app/` 구조와의 어긋남을 매 빌드마다 잡는다 — "남겨 둔다"로 끝내지 않았다.

**부수 리팩터** — `MIGRATED_RESOURCES`/`RENAMED_RESOURCES`/`RETIRED_RESOURCES`를 `proxy.ts`에서 `lib/legacy-resource-tables.ts`(어느 쪽도 import하지 않는 leaf 모듈)로 뺐다. `route-resolve.ts`가 이 표들을 직접 import해야 하는데, `proxy.ts`가 이미 `route-resolve.ts`를 import하는 쪽이라(`fetchResolve` 등) 반대 방향 import는 순환참조가 되기 때문. `proxy.ts`는 재수출로 기존 소비처(`verify-no-orphan-resource-routes.ts`)의 import 경로를 그대로 유지한다.

**AC4** — 라이브 확認은 배포 후 필요(팀 관례 — 로컬 FE는 인증/BE 불일치로 검증 불가). tsc/lint/build/vitest는 전부 GREEN이지만, 실 배포 환경에서 대표 경로가 실제로 맞는 곳으로 가는지는 dev 배포 후 확認 예정.

**AC5** — 못 잡는 것: `verify-reserved-first-segments-sync.ts`의 `METADATA_FILE_ROUTES`에 없는 새 Next.js 메타데이터 컨벤션(`robots.ts`·`sitemap.ts`·`opengraph-image.tsx` 등)이 추가되면 그 실제 서빙 경로를 몰라 조용히 통과한다 — 그 컨벤션을 쓰기 시작할 때 손으로 매핑을 추가해야 한다.

## Test plan
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run build` — EXIT 0, `Proxy (Middleware)` 정상 생성 확認(edge 번들이 새 import로 안 깨짐)
- [x] `pnpm exec vitest run` — 339 files · 2497 tests 전부 PASS(신규 테스트 포함)
- [x] `pnpm run verify:reserved-first-segments-sync` — OK, 어긋남 0건
- [x] mutation self-check: `RESERVED_FIRST_SEGMENTS`에서 `more`·`manifest.webmanifest` 2개를 임시로 제거 → 신규 CI 가드가 정확히 그 2건을 검출(EXIT 1) → 복원 후 0건(EXIT 0)
- [x] `route-resolve.test.ts`에 6개 드리프트 항목을 명시적으로 하드코딩 회귀 테스트로 고정(Set 자체가 통째로 바뀌어도 잡히도록, 기존 순회 테스트만으론 부족)

🤖 Generated with [Claude Code](https://claude.com/claude-code)