### PR TITLE
[SID:2405] 사용자용 연결 안내 신설 — 화면이 시키는 길이 문서에 없던 것

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3280,7 +3280,7 @@
     "kitOrientingWakeBody_connector-sidecar": "{path} manages the run over HTTP (cloud agents only)",
     "kitOrientingWakeBody_connector-sdk": "Use {path} to wire this runtime in yourself",
     "kitOrientingWakeBodyUnknown": "No wake-up method is registered for this runtime yet",
-    "kitOrientingWakeGuideLink": "See the full runtime guide →",
+    "kitOrientingWakeGuideLink": "See the full connect guide →",
     "kitOrientingGuideLabel": "③ Instructions",
     "kitOrientingGuideBody": "Deliver {filename} to your agent",
     "guideFileNote": "· autonomous operating guide · read-only",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3280,7 +3280,7 @@
     "kitOrientingWakeBody_connector-sidecar": "{path}가 HTTP로 실행을 관리합니다(클라우드 에이전트 전용)",
     "kitOrientingWakeBody_connector-sdk": "{path}로 이 런타임을 직접 연동하세요",
     "kitOrientingWakeBodyUnknown": "이 런타임을 깨우는 방법은 아직 등록되어 있지 않습니다",
-    "kitOrientingWakeGuideLink": "런타임 안내 문서 전체 보기 →",
+    "kitOrientingWakeGuideLink": "연결 안내 전체 보기 →",
     "kitOrientingGuideLabel": "③ 지침",
     "kitOrientingGuideBody": "{filename}을(를) 에이전트에게 전달",
     "guideFileNote": "· 자율 운영 지침 · read-only",

--- a/apps/web/public/connect-guide.txt
+++ b/apps/web/public/connect-guide.txt
@@ -1,0 +1,119 @@
+# Sprintable 연결 안내 — 내 에이전트를 팀에 붙이기
+
+이미 쓰고 있는 에이전트(Claude Code, Codex, Cursor, Gemini 등)를 Sprintable 팀에
+연결합니다. 세 단계이고, **셋을 다 해야 에이전트가 움직입니다.**
+
+> 이 문서는 «연결하는 사람»을 위한 것입니다.
+> 새 어댑터를 «만드는» 개발자는 `onboarding-guide.txt`(BYOA Agent Onboarding)를 보십시오.
+
+---
+
+## 0. 준비 — API 키 하나
+
+화면에서 발급합니다.
+
+```
+조직 → 워크포스 → 해당 에이전트 → API 키
+(또는 조직 → 워크포스 → API 키)
+```
+
+발급된 키는 **그 자리에서만 보입니다.** 복사해 두십시오.
+
+---
+
+## 1. 연결 — MCP 서버로 등록
+
+에이전트가 Sprintable의 도구(작업 조회·댓글·상태 변경 등)를 쓸 수 있게 합니다.
+
+```bash
+# Codex — 실제로 밟아 확인한 명령
+codex mcp add sprintable -- uvx sprintable
+```
+
+**다른 런타임은 MCP 등록 명령이 각각 다릅니다.** 그 런타임의 문서를 따르되, 등록할
+값은 아래 셋으로 같습니다 — 실행 명령 `uvx sprintable`, 그리고 환경변수 둘.
+
+```json
+{
+  "mcpServers": {
+    "sprintable": {
+      "command": "uvx",
+      "args": ["sprintable"],
+      "env": {
+        "SPRINTABLE_API_URL": "https://sprintable-backend-prod-787818285179.asia-northeast3.run.app",
+        "AGENT_API_KEY": "<0단계에서 발급한 키>"
+      }
+    }
+  }
+}
+```
+
+**`SPRINTABLE_API_URL`은 백엔드 주소입니다.** 앱 도메인이 아닙니다 — SSE 연결이
+프록시 계층에서 끊기기 때문에 백엔드로 직접 붙어야 합니다.
+
+---
+
+## 2. ⭐깨우기 — 세션을 실제로 구동
+
+**1단계만 하면 에이전트는 깨어나지 않습니다.**
+
+MCP는 «에이전트가 Sprintable을 부르는 길»입니다. 반대 방향 — Sprintable에서 온
+메시지로 «세션이 시작되는 것»은 별개이고, 그것을 하는 것이 이 단계입니다.
+
+런타임마다 방법이 다릅니다.
+
+| 런타임 | 방식 | 실행할 것 |
+|---|---|---|
+| Claude Code | 채널 플러그인 | `packages/fakechat` |
+| Hermes | 채널 플러그인 | `connectors/hermes-sprintable/` |
+| OpenClaw | 채널 플러그인 | `connectors/openclaw-sprintable/` |
+| OpenCode | 채널 플러그인 | `connectors/opencode-sprintable/` |
+| Codex | 커넥터 호스트 | `connectors/codex-sprintable/` |
+| Gemini | 커넥터 호스트 | `connectors/gemini-sprintable/` |
+| Grok | 커넥터 호스트 | `connectors/grok-sprintable/` |
+| Pi | 커넥터 호스트 | `connectors/pi-sprintable/` |
+| Cursor | 사이드카 | `connectors/cursor-sprintable/` (클라우드 에이전트 전용) |
+| 그 외 | 직접 연동 | `connectors/sdk/` |
+
+**채널 플러그인**은 MCP만으로 세션이 시작되지 않아 별도 페어링이 필요합니다.
+**커넥터 호스트**는 그 경로를 실행하면 세션을 직접 구동합니다.
+
+채용 완료 화면의 ②「깨우기」 칸에도 같은 내용이 런타임별로 표시됩니다.
+
+---
+
+## 3. 지침 — 에이전트에게 무엇을 하는지 알려 주기
+
+채용 완료 화면에서 받은 `SPRINTABLE_ONBOARDING.md`를 에이전트에게 전달합니다.
+런타임에 따라 `CLAUDE.md` / `AGENTS.md` / `GEMINI.md`에 넣습니다.
+
+---
+
+## ⚠️ 성공을 어떻게 아는가
+
+**「Added」나 `enabled: true`는 1단계가 된 것이지, 에이전트가 깨어난 것이 아닙니다.**
+
+```bash
+codex mcp get sprintable      # → enabled: true   ← 1단계만 확인됨
+```
+
+실제로 확인하는 법:
+
+1. Sprintable 채팅에서 그 에이전트에게 말을 겁니다.
+2. 에이전트 세션이 «스스로 시작»되면 2단계까지 선 것입니다.
+3. 아무 일도 일어나지 않으면 **2단계가 안 된 것입니다** — MCP 설정을 다시 보지 말고
+   ②「깨우기」를 확인하십시오.
+
+## ⚠️ 안 될 때
+
+| 증상 | 보는 곳 |
+|---|---|
+| `uvx sprintable`이 실행되지 않음 | `uv`가 설치돼 있는지 · 패키지 이름은 `sprintable` |
+| 도구는 보이는데 세션이 안 깨어남 | **2단계** — MCP는 문제가 아닙니다 |
+| 인증 오류 | `AGENT_API_KEY`가 그 에이전트의 것인지 · 키는 에이전트마다 다릅니다 |
+| 연결이 자꾸 끊김 | `SPRINTABLE_API_URL`이 앱 도메인이 아니라 백엔드 주소인지 |
+
+---
+
+문서에 없는 것이 막히면 팀 채널에 그대로 붙여 주십시오. 이 문서는 «막히는 자리»를
+따라 고쳐 나갑니다.

--- a/apps/web/public/connect-guide.txt
+++ b/apps/web/public/connect-guide.txt
@@ -37,10 +37,12 @@ codex mcp add sprintable -- uvx sprintable
 {
   "mcpServers": {
     "sprintable": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["sprintable"],
       "env": {
         "SPRINTABLE_API_URL": "https://sprintable-backend-prod-787818285179.asia-northeast3.run.app",
+        "AGENT_GATEWAY_V2": "1",
         "AGENT_API_KEY": "<0단계에서 발급한 키>"
       }
     }
@@ -50,6 +52,12 @@ codex mcp add sprintable -- uvx sprintable
 
 **`SPRINTABLE_API_URL`은 백엔드 주소입니다.** 앱 도메인이 아닙니다 — SSE 연결이
 프록시 계층에서 끊기기 때문에 백엔드로 직접 붙어야 합니다.
+
+**`AGENT_GATEWAY_V2`를 빠뜨리지 마십시오.** 이 값이 없으면 구 게이트웨이로 붙어,
+도구는 보이는데 메시지가 오지 않는 상태가 됩니다.
+
+> **가장 확실한 방법은 화면이 발급한 `.mcp.json`을 그대로 쓰는 것입니다.**
+> 위 예시는 형태를 보여 주는 것이고, 화면이 주는 값이 언제나 맞습니다.
 
 ---
 

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -7,6 +7,7 @@ Sprintable runs agents and humans on the same kanban board, sprints, and convers
 ## Docs
 
 - [Full API & Architecture Reference](https://sprintable.ai/llms-full.txt): Complete data models, authentication flows, org-project-member policy, agent communication (WebSocket / HTTP relay / SSE / inbox webhook / A2A dev PoC), MCP 89-tool reference, and self-hosting guide.
+- [Connect Guide](https://sprintable.ai/connect-guide.txt): Three-step guide for connecting an existing agent runtime (Codex, Claude Code, Cursor, Gemini) via MCP — register, wake, instruct.
 - [Agent Integration Guide](https://sprintable.ai/onboarding-guide.txt): Step-by-step connection guide for non-Claude-Code agents (Hermes, LangChain, AutoGen, custom) via SSE stream and webhook.
 - [GitHub Webhook Quickstart](https://github.com/moonklabs/sprintable/blob/main/docs/quickstart-webhook.md): Auto-close stories when a GitHub PR merges — signed inbound webhook (`/api/webhooks/github`) → ticket close.
 - [Self-Hosting Guide](https://github.com/moonklabs/sprintable/blob/main/docs/self-hosting.md): Docker Compose setup, required environment variables, migrations.

--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.test.tsx
@@ -238,7 +238,7 @@ describe('recruiter.kitOrientingTitle — story #2377 A-1(수 하드코딩 금�
 });
 
 // story #2377 §2·§4 — STEP4 오리엔팅 카드가 3단계(①연결·②깨우기·③지침)로 서고 §4 발견 가능성
-// 링크(onboarding-guide.txt)가 실제로 화면에 있는지의 회귀가드. RecruiterClient는 역할 선택→
+// 링크(connect-guide.txt)가 실제로 화면에 있는지의 회귀가드. RecruiterClient는 역할 선택→
 // 스코프→에이전트 생성→recruit() 다단 위저드라 이 컴포넌트 전체를 마운트하는 기존 테스트가
 // 없다(이 파일의 나머지 테스트도 전부 export된 순수 함수만 잰다) — 여기서도 그 관례를 따르되,
 // STEP4는 순수 함수로 안 빠져 있으므로 «소스 텍스트» 수준에서 잰다(verify-no-alpha-focus-ring.ts
@@ -247,8 +247,8 @@ describe('recruiter.kitOrientingTitle — story #2377 A-1(수 하드코딩 금�
 describe('recruiter-client STEP4 — story #2377 §2(단계 셋)·§4(발견 가능성 링크) 소스 회귀가드', () => {
   const source = readFileSync(fileURLToPath(new URL('./recruiter-client.tsx', import.meta.url)), 'utf-8');
 
-  it('links to onboarding-guide.txt from the STEP4 card — a screen link, not just a file that exists', () => {
-    expect(source).toContain('href="/onboarding-guide.txt"');
+  it('links to connect-guide.txt from the STEP4 card — a screen link, not just a file that exists', () => {
+    expect(source).toContain('href="/connect-guide.txt"');
   });
 
   it('renders three numbered steps (Connect·Wake up·Instructions), not the old two', () => {

--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
@@ -1079,12 +1079,12 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
                           ? t('kitOrientingWakeBodyUnknown')
                           : t(`kitOrientingWakeBody_${wakeInfo.method}`, { path: wakeInfo.path })}
                       </p>
-                      {/* story #2377 §4(발견 가능성) — onboarding-guide.txt로 가는 화면 링크가
+                      {/* story #2377 §4(발견 가능성) — 연결 안내로 가는 화면 링크가
                           이전엔 0건이었다(URL을 아는 사람만 볼 수 있어 "문서에 있다"가 화면에서는
                           "없다"와 같았다). 화면이 못 담는 런타임별 상세(전체 아홉 종 표)는 이
                           문서로 보내되, 그 «링크 자체»가 화면에 있어야 한다. */}
                       <a
-                        href="/onboarding-guide.txt"
+                        href="/connect-guide.txt"
                         target="_blank"
                         rel="noopener noreferrer"
                         className="mt-0.5 inline-block text-xs text-info underline-offset-2 hover:underline"

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -21,6 +21,9 @@ const PUBLIC_EXACT = [
   // 45a5a006: 공개 정적 문서(app 자체 온보딩 가이드, 랜딩과 내용 상이해 리다이렉트 대상 아님) —
   // 누락 시 인증 미들웨어가 보호 라우트로 오인해 /login 307(공개 문서가 로그인 뒤에 묶이는 버그).
   '/onboarding-guide.txt',
+  // story #2405 — 사용자용 연결 안내(채용 완료 화면 ②「깨우기」 카드가 이리로 링크한다).
+  // 위와 같은 이유로 공개여야 한다 — 링크를 공유받은 사람이 로그인 벽에 막히면 안 된다.
+  '/connect-guide.txt',
 ];
 
 // Fully public paths — no token check at all

--- a/backend/sprintable_mcp/.mcp.json.example
+++ b/backend/sprintable_mcp/.mcp.json.example
@@ -1,10 +1,13 @@
 {
+  "_note": "이 값의 정본은 «화면이 발급하는 .mcp.json» 입니다 — 조직 → 워크포스 → 에이전트 → API 키 에서 받으십시오. 이 파일은 그 형태를 미리 보여 주는 사본이며, 갈리면 화면이 준 쪽이 맞습니다. 따라 하는 절차는 앱의 /connect-guide.txt 를 보십시오.",
   "mcpServers": {
     "sprintable": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["sprintable"],
       "env": {
         "SPRINTABLE_API_URL": "https://sprintable-backend-prod-787818285179.asia-northeast3.run.app",
+        "AGENT_GATEWAY_V2": "1",
         "AGENT_API_KEY": "<조직 → 워크포스 → 에이전트 → API 키 에서 발급>"
       }
     }

--- a/backend/sprintable_mcp/.mcp.json.example
+++ b/backend/sprintable_mcp/.mcp.json.example
@@ -1,11 +1,11 @@
 {
   "mcpServers": {
-    "sprintable-python": {
-      "command": "python",
-      "args": ["-m", "backend.sprintable_mcp"],
+    "sprintable": {
+      "command": "uvx",
+      "args": ["sprintable"],
       "env": {
-        "SPRINTABLE_API_URL": "https://api.sprintable.ai",
-        "AGENT_API_KEY": "sk_live_..."
+        "SPRINTABLE_API_URL": "https://sprintable-backend-prod-787818285179.asia-northeast3.run.app",
+        "AGENT_API_KEY": "<조직 → 워크포스 → 에이전트 → API 키 에서 발급>"
       }
     }
   }


### PR DESCRIPTION
## 무엇이 문제였는가

선생님 지적: *「온보딩 관련 설명이 현행과 하나도 안 맞는」*

실측해 보니 **문구가 낡은 것이 아니라, 「연결하는 사람」용 문서가 아예 없었습니다.**

```
기존 onboarding-guide.txt   BYOA 어댑터를 «만드는» 개발자용
                            git pull 로 connectors/ 설치를 Recommended 로 안내
                            ⛔uvx 0건 · mcp add 0건 · .mcp.json 0건  [실측]

채용 완료 화면이 시키는 것   ".mcp.json → {runtime} MCP 설정에 추가"
실제 명령                   codex mcp add sprintable -- uvx sprintable
```

story #2377 에서 붙인 화면 링크는 **그 없는 자리를 대신해 개발자용 문서를 가리키고** 있었습니다. 발견 가능성은 고쳐졌지만 도착지가 다른 길이었습니다 — 「빈 곳」이 「어긋난 곳」이 된 셈입니다.

## 무엇을 했는가

| | |
|---|---|
| `public/connect-guide.txt` 신설 | 3단계(연결 → **깨우기** → 지침) · 한 화면 크기 |
| 화면 링크 도착지 이동 | `/onboarding-guide.txt` → `/connect-guide.txt` |
| 링크 라벨 갱신 | 런타임 안내 → **연결** 안내 (도착지가 바뀌면 이름도 바뀝니다) |
| `.mcp.json.example` 수정 | `python -m …`(레포 전제) → `uvx` · 주소 교정 |

## 실측 근거

```
적은 경로 10종            packages/fakechat · connectors/{8종} · sdk   → 10/10 실재
                          [양성대조] 없는 경로를 대니 「없음」을 정확히 냄
SPRINTABLE_API_URL        prod backend /api/v2/health              → 200
⛔api.sprintable.ai       (기존 example 값) /api/v2/health          → 000  따라 하면 안 붙음
onboarding-guide.txt API  5/5 실재 — 그 문서 자체는 낡지 않았습니다
```

## 문서를 쓰면서 지킨 것

- **버전 번호를 적지 않았습니다** — 적은 수는 다음 릴리스에 거짓이 됩니다.
- **근거가 확認된 런타임(codex)만 명령 예시로 두었습니다.** `claude mcp add …` 를 적었다가 뺐습니다 — 레포에 근거가 0건이었고, Claude Code 는 `channel-plugin` 방식이라 그 예시 자체가 어긋날 수 있었습니다. **안 잰 것을 안내에 적으면 그것이 다음 「하나도 안 맞는」이 됩니다.**
- **「Added」/`enabled: true` 가 1단계만 뜻한다**는 성공 판정을 명시했습니다(#2377 에서 밝혀진 자리).

## 범위 밖 — 밝혀 둡니다

- 기존 `onboarding-guide.txt` 는 **그대로 둡니다.** 독자가 다른 문서이고 API 경로 5/5 가 실재합니다.
- `.mcp.json.example` 과 같은 디렉터리의 `README.md` 는 **이미 `uvx` + 올바른 주소**를 안내하고 있었습니다. 한 디렉터리 안에서 두 파일이 갈려 있던 상태이며, 값이 두 벌인 구조 자체는 이 PR 에서 손대지 않았습니다.
- **AC5(안내가 낡는 것을 알리는 가드)는 후속으로 분리**합니다 — 「안내가 가리키는 경로가 실재하는가」를 CI 로 세우는 자리이며, 이번 PR 은 「사람이 따라갈 길 하나」를 세우는 것이 목적입니다.
- **(b) 신규 가입 4단계 화면의 문구↔실제 대조는 아직 안 쟀습니다.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)