### PR TITLE
fix(#2411): log when pricing_versions grandfather lookup has no match

### DIFF
--- a/backend/ee/routers/billing.py
+++ b/backend/ee/routers/billing.py
@@ -351,6 +351,17 @@ async def _update_subscription(
             # 의도된 상태다). grandfather 기준점 없이 구독이 만들어진다는 뜻이라 결제 자체는
             # 안 막히지만(체크아웃·화면은 코드 상수 _POLAR_PRICE_IDS/_PLAN_CATALOG를 봐서
             # DB와 무관하게 도는 — 그래서 여태 아무도 못 알아챘다) 반드시 로그로는 남긴다.
+            #
+            # ⚠️여기 도달하는 tier는 항상 "team"|"pro"뿐이다(이 함수의 두 호출부 —
+            # checkout.completed·subscription.updated — 모두 tier를 그 둘로만 산출한다,
+            # PO 확認 2026-08-01). "free"로 이 함수가 불리는 경로는 없다(무료 티어는 Polar
+            # 구독/결제 이벤트 자체가 없어 upsert 대상이 아님) — 그러니 이 경고는 "free라서
+            # 원래 없는 행"이라는 잡음이 될 수 없다.
+            #
+            # ⛔이 경고가 «그쳐야 정상»인 시점: #2403이 실제 판매 정책(티어·통화·PG)을 확정하고
+            # 그에 맞는 pricing_versions 시드가 들어간 뒤. 그 후에도 이 경고가 뜨면 시드가
+            # 누락됐거나(새 tier/billing_cycle 조합 추가 시 시드 갱신을 잊음) 진짜 결함 신호다 —
+            # 계속 울리는데 아무도 안 본다면 이 로그가 무뎌진 것이니 다시 살펴봐야 한다.
             logger.warning(
                 "pricing_version_id 미배정 — pricing_versions에 (tier=%s, billing_cycle=%s, "
                 "currency=usd) 매칭 행 없음. org=%s는 grandfather 기준점 없이 구독됨.",

--- a/backend/ee/routers/billing.py
+++ b/backend/ee/routers/billing.py
@@ -342,6 +342,20 @@ async def _update_subscription(
     try:
         now = datetime.now(timezone.utc)
         pricing_version_id = await _current_pricing_version_id(session, tier, billing_cycle)
+        if pricing_version_id is None:
+            # story #2411: 빈 조회(pricing_versions에 (tier, billing_cycle, "usd") 매칭 행이
+            # 없음)는 예외가 아니라서 위 try/except의 "조용한 실패 봉쇄"에 안 걸린다 —
+            # org_subscriptions.pricing_version_id가 nullable이라 그냥 NULL로 조용히 통과했다
+            # (prod 실측, 2026-08-01: pricing_versions가 #2397/0222로 테이블만 생기고 아직
+            # 시드가 없어 지금은 매번 이 분기를 탄다 — #2403이 실제 판매 정책을 정하기 前까지는
+            # 의도된 상태다). grandfather 기준점 없이 구독이 만들어진다는 뜻이라 결제 자체는
+            # 안 막히지만(체크아웃·화면은 코드 상수 _POLAR_PRICE_IDS/_PLAN_CATALOG를 봐서
+            # DB와 무관하게 도는 — 그래서 여태 아무도 못 알아챘다) 반드시 로그로는 남긴다.
+            logger.warning(
+                "pricing_version_id 미배정 — pricing_versions에 (tier=%s, billing_cycle=%s, "
+                "currency=usd) 매칭 행 없음. org=%s는 grandfather 기준점 없이 구독됨.",
+                tier, billing_cycle, org_id,
+            )
         await session.execute(
             pg_insert(OrgSubscription)
             .values(

--- a/backend/tests/test_e_org_multi_s5_4_polar_webhook.py
+++ b/backend/tests/test_e_org_multi_s5_4_polar_webhook.py
@@ -157,6 +157,57 @@ async def test_update_subscription_logs_error_and_reraises_on_db_failure(caplog)
     assert any(record.levelno == logging.ERROR for record in caplog.records)
 
 
+# ─── story #2411: pricing_versions 빈 조회가 예외가 아니라 조용히 NULL로 통과하던 것 ──
+# (org_subscriptions.pricing_version_id가 nullable이라 위 실패-로깅 try/except에 안 걸림 —
+# prod 실측 2026-08-01: #2397/0222로 테이블만 생기고 아직 시드가 없어 매번 이 분기를 탐)
+
+@pytest.mark.anyio
+async def test_update_subscription_warns_when_no_pricing_version_matches(caplog):
+    import logging
+    from unittest.mock import AsyncMock, MagicMock
+
+    from ee.routers import billing
+
+    org_id = uuid.uuid4()
+    session = AsyncMock()
+    empty_lookup = MagicMock()
+    empty_lookup.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(side_effect=[empty_lookup, MagicMock()])
+
+    with caplog.at_level(logging.WARNING, logger="ee.routers.billing"):
+        await billing._update_subscription(
+            session, org_id, "team", "monthly", "cus_x", "sub_x", "active"
+        )
+
+    assert any(
+        "pricing_version_id 미배정" in record.message and str(org_id) in record.message
+        for record in caplog.records
+    )
+    assert any(record.levelno == logging.WARNING for record in caplog.records)
+
+
+@pytest.mark.anyio
+async def test_update_subscription_no_warning_when_pricing_version_matches(caplog):
+    import logging
+    import uuid as uuid_mod
+    from unittest.mock import AsyncMock, MagicMock
+
+    from ee.routers import billing
+
+    org_id = uuid.uuid4()
+    session = AsyncMock()
+    found_lookup = MagicMock()
+    found_lookup.scalar_one_or_none.return_value = uuid_mod.uuid4()
+    session.execute = AsyncMock(side_effect=[found_lookup, MagicMock()])
+
+    with caplog.at_level(logging.WARNING, logger="ee.routers.billing"):
+        await billing._update_subscription(
+            session, org_id, "team", "monthly", "cus_x", "sub_x", "active"
+        )
+
+    assert not any("pricing_version_id 미배정" in record.message for record in caplog.records)
+
+
 @pytest.fixture
 def anyio_backend():
     return "asyncio"


### PR DESCRIPTION
## Summary

`_current_pricing_version_id()` (`ee/routers/billing.py`) returns `None` when no `pricing_versions` row matches `(tier, billing_cycle, currency="usd")` — that's not an exception, just an empty query result. `org_subscriptions.pricing_version_id` is nullable, so that `None` sailed straight through `_update_subscription()`'s upsert without ever touching the function's own `try/except` — the one its docstring says exists specifically to prevent silent failures (added for the #0148 fire-and-forget webhook incident: *"조용한 실패 봉쇄가 핵심"*). A missing row and a successful-but-empty lookup look identical from the caller's side; the docstring's promise only covered one of them.

## Why nobody noticed

Checkout and the billing screen both read from hardcoded Python dicts (`_POLAR_PRICE_IDS`, `_PLAN_CATALOG`), not the DB — payments keep working, the UI keeps rendering. `pricing_versions` is only consulted for the grandfather timestamp on `org_subscriptions`, which is invisible in any response or screen. PO's prod measurement (2026-08-01): `alembic_version=0222`, `pricing_versions` table exists, **0 rows** — so this branch fires on every single subscription create/update right now.

## Why not seed it and close the loop

That empty state is deliberate, not a gap to seed away: #2397/`0222` created the table but withheld the seed data (former `0147`'s 10 Polar/USD rows) because #2403 found the actual pricing policy (v2.3: KRW, Toss Payments, 4-tier Free/Starter/Team/Business) is a completely different shape than what's currently coded (USD, Polar, team/pro). Seeding the old values now would plant data that's getting discarded anyway. This PR is independent of that — the "empty lookup goes silent" gap exists regardless of what #2403 eventually decides to sell.

## Fix

Log a `WARNING` when `pricing_version_id` resolves to `None`, right where it's used in `_update_subscription()`, with `tier`/`billing_cycle`/`org_id` context. No behavior change — the subscription still gets created/updated with `pricing_version_id=NULL` (that's the correct fallback per the nullable design), this just makes the gap observable instead of silent.

## Verification

Two new tests in `test_e_org_multi_s5_4_polar_webhook.py` (warns when no match / stays silent when a match exists). Positive control: temporarily disabled the new warning branch, confirmed the new test fails on exactly the missing warning; restored, confirmed green. Full `test_e_org_multi_s5_*` billing suite (41 passed, 2 skipped) unaffected.

## Scope note (per PO)

Prod currently has 0 paid subscriptions, 0 checkouts, 0 webhooks fired (measured 2026-08-01) — nothing is leaking yet. This closes the observability gap before the first real payment arrives, independent of #2403's outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)