### PR TITLE
[SID:2415] 온보딩 검증 레일 — BE rail 필드를 FE가 steps로 오조회하던 것

### DIFF
--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
@@ -15,7 +15,8 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { cn } from '@/lib/utils';
 import {
-  VerifyRail, RAIL_ORDER, HTTP_RAIL_ORDER, type DisplayStep, type RailState, type RailStatus,
+  VerifyRail, RAIL_ORDER, HTTP_RAIL_ORDER, parseVerificationRail,
+  type DisplayStep, type RailState, type RailStatus, type RawStep,
 } from '@/app/onboarding/verify-rail';
 import type { RoleTemplateSummary, RecruitResponse, McpConfigBundle, RuntimeCapabilityItem } from '@/services/recruit';
 import { RUNTIME_CAPABILITIES_FALLBACK, RUNTIME_GUIDE_FILENAME_FALLBACK, KIT_FILENAME, resolveRuntimeWakeInfo } from '@/services/recruit';
@@ -145,12 +146,6 @@ function downloadTextFile(filename: string, content: string) {
   a.download = filename;
   a.click();
   URL.revokeObjectURL(url);
-}
-
-interface RawStep {
-  state: RailState;
-  status: RailStatus;
-  reason?: string;
 }
 
 // ─── 재사용 하위 컴포넌트 ────────────────────────────────────────────────────
@@ -540,15 +535,20 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
   const [verifying, setVerifying] = useState(false);
   const railOrder = recruitResult?.default_transport === 'http' ? HTTP_RAIL_ORDER : RAIL_ORDER;
 
+  // story #2404 후속(2026-08-02, 라이브 재확認 중 발견) — 이 코드는 `data.steps`를 읽었지만
+  // 백엔드(`backend/app/routers/agents.py::agent_verification_status`)의 실제 필드명은
+  // `rail`이다. `steps`는 항상 undefined였으므로 `setBeSteps`가 «단 한 번도» 실호출되지
+  // 않았다 — 검증이 실제로 성공해도 화면 레일은 영원히 초기 pending으로 멈춰 있었다.
+  // 파싱은 `parseVerificationRail`(verify-rail.tsx) 하나로 모았다 — 이 파일과
+  // onboarding/connect-step.tsx가 독립적으로 재구현하지 않게(같은 필드명 버그가 두 곳에서
+  // 동시에 존재했던 이유, story #2415 참조).
   const pollStatus = useCallback(async () => {
     if (!recruitResult) return;
     try {
       const res = await fetch(`/api/agents/${recruitResult.agent_id}/verification-status?transport=${recruitResult.default_transport}`);
       if (!res.ok) return;
-      const json = (await res.json()) as { data?: { steps?: RawStep[] } | RawStep[]; steps?: RawStep[] };
-      const d = json?.data;
-      const raw = (Array.isArray(d) ? d : d?.steps) ?? json?.steps;
-      if (Array.isArray(raw)) setBeSteps(raw);
+      const raw = parseVerificationRail(await res.json());
+      if (raw) setBeSteps(raw);
     } catch {
       // swallow — graceful degradation
     }

--- a/apps/web/src/app/onboarding/connect-step.tsx
+++ b/apps/web/src/app/onboarding/connect-step.tsx
@@ -7,7 +7,10 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
-import { VerifyRail, RAIL_ORDER, HTTP_RAIL_ORDER, type DisplayStep, type RailState, type RailStatus } from './verify-rail';
+import {
+  VerifyRail, RAIL_ORDER, HTTP_RAIL_ORDER, parseVerificationRail,
+  type DisplayStep, type RailState, type RailStatus, type RawStep,
+} from './verify-rail';
 import { emitOnboardingEvent, beaconOnboardingEvent } from './onboarding-telemetry';
 
 const RAIL_LABEL_KEY: Record<RailState, string> = {
@@ -21,12 +24,6 @@ const RAIL_LABEL_KEY: Record<RailState, string> = {
 
 /** E-MCP-OPT S3: SaaS 기본=호스팅(http)·OSS 기본=로컬(stdio) — BE `default_transport_for_edition()` 따름. */
 export type Transport = 'http' | 'stdio';
-
-interface RawStep {
-  state: RailState;
-  status: RailStatus;
-  reason?: string;
-}
 
 /** connection-artifact content(JSON)의 `mcpServers.sprintable.type` 필드만 읽는다(재조립 아님) —
  * transport 미지정 최초 요청은 BE edition 기본을 반환하므로, 어느 탭을 pre-select할지 이걸로 판별. */
@@ -118,15 +115,22 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
 
   // OB-2 verification-status poll (SSE-우선은 OB-2 SSE 포맷 확정 후 follow-up·현재 poll). 404 graceful.
   // E-MCP-OPT S3: transport별 레일 shape 다름(호스팅=4단계, event/ack 없음) — 쿼리로 분기.
+  //
+  // story #2404 후속(2026-08-02, 라이브 재확認 중 발견) — 이 코드는 `data.steps`를 읽었지만
+  // 백엔드(`backend/app/routers/agents.py::agent_verification_status`)는 그런 필드를 준 적이
+  // 없다 — 실제 필드명은 `rail`이다(`{"data":{"verified":true,"rail":[...]}}`). `steps`는 항상
+  // undefined였으므로 `setBeSteps`가 «단 한 번도» 실호출되지 않았다 — 검증이 실제로 성공해도
+  // 화면 레일은 영원히 초기 pending으로 멈춰 있었다(curl로 백엔드 값 자체는 verified:true를
+  // 직접 확認했는데 화면만 안 바뀌는 것으로 발견 — API 레벨 확認과 실제 렌더 확認은 다르다).
+  // 파싱은 이제 `parseVerificationRail`(verify-rail.tsx) 하나로 모았다 — recruiter-client.tsx
+  // 가 독립적으로 재구현하지 않게(같은 버그가 두 곳에서 동시에 존재했던 이유).
   const pollStatus = useCallback(async (forTransport: Transport) => {
     if (!agentId) return;
     try {
       const res = await fetch(`/api/agents/${agentId}/verification-status?transport=${forTransport}`);
       if (!res.ok) return; // 미머지/404 → pending 유지(가짜 에러 안 띄움)
-      const json = (await res.json()) as { data?: { steps?: RawStep[] } | RawStep[]; steps?: RawStep[] };
-      const d = json?.data;
-      const raw = (Array.isArray(d) ? d : d?.steps) ?? json?.steps;
-      if (Array.isArray(raw)) setBeSteps(raw);
+      const raw = parseVerificationRail(await res.json());
+      if (raw) setBeSteps(raw);
     } catch {
       // swallow — graceful degradation
     }

--- a/apps/web/src/app/onboarding/verify-rail.test.ts
+++ b/apps/web/src/app/onboarding/verify-rail.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { parseVerificationRail } from './verify-rail';
+
+// story #2415(2026-08-02, 라이브 재확認 중 발견) — recruiter-client.tsx·connect-step.tsx가
+// 각자 `json.data.steps`를 읽었는데, 백엔드(`GET /agents/{id}/verification-status`)의 실제
+// 필드명은 `rail`이다. `steps`는 항상 undefined였으므로 검증이 실제로 성공해도 화면 레일은
+// 초기 pending에서 한 번도 안 움직였다 — curl로 직접 확認한 실 응답 형태 그대로 고정한다.
+describe('parseVerificationRail — story #2415 (steps→rail 필드명 회귀 고정)', () => {
+  it('parses the real backend shape ({data:{rail:[...]}}) — this is the exact response captured live via curl', () => {
+    const realResponse = {
+      data: {
+        agent_id: '381276fa-ba35-432a-b5a6-9feadc6c9b03',
+        verification_seq: null,
+        verified: true,
+        rail: [
+          { state: 'config_copied', status: 'done' },
+          { state: 'waiting', status: 'done' },
+          { state: 'mcp_reachable', status: 'done' },
+          { state: 'verified', status: 'done' },
+        ],
+      },
+      error: null,
+      meta: null,
+    };
+    expect(parseVerificationRail(realResponse)).toEqual([
+      { state: 'config_copied', status: 'done' },
+      { state: 'waiting', status: 'done' },
+      { state: 'mcp_reachable', status: 'done' },
+      { state: 'verified', status: 'done' },
+    ]);
+  });
+
+  it('regression: a `steps` field (the bug this replaces) is NOT read as rail data', () => {
+    // 이전 버그의 정확한 재현 — `steps`라는 필드는 백엔드에 존재한 적이 없다. 이 필드가
+    // 있어도(다른 소비처의 실수·구버전 mock 등) 그것을 rail로 오인해서는 안 된다.
+    const responseWithWrongFieldName = {
+      data: { verified: true, steps: [{ state: 'verified', status: 'done' }] },
+    };
+    expect(parseVerificationRail(responseWithWrongFieldName)).toBeNull();
+  });
+
+  it('returns null (not a crash, not stale data) on malformed/empty responses', () => {
+    expect(parseVerificationRail(null)).toBeNull();
+    expect(parseVerificationRail(undefined)).toBeNull();
+    expect(parseVerificationRail({})).toBeNull();
+    expect(parseVerificationRail({ data: {} })).toBeNull();
+    expect(parseVerificationRail('not an object')).toBeNull();
+  });
+
+  it('also accepts a bare top-level rail (defensive — matches the pre-existing fallback shape)', () => {
+    const bareShape = { rail: [{ state: 'config_copied', status: 'done' }] };
+    expect(parseVerificationRail(bareShape)).toEqual([{ state: 'config_copied', status: 'done' }]);
+  });
+
+  it('also accepts data itself being the array (defensive — matches the pre-existing fallback shape)', () => {
+    const dataIsArray = { data: [{ state: 'config_copied', status: 'done' }] };
+    expect(parseVerificationRail(dataIsArray)).toEqual([{ state: 'config_copied', status: 'done' }]);
+  });
+});

--- a/apps/web/src/app/onboarding/verify-rail.tsx
+++ b/apps/web/src/app/onboarding/verify-rail.tsx
@@ -27,6 +27,32 @@ export interface DisplayStep {
   reason?: string;
 }
 
+/** BE `GET /agents/{id}/verification-status` 응답의 한 단계 원본(라벨 미부여). */
+export interface RawStep {
+  state: RailState;
+  status: RailStatus;
+  reason?: string;
+}
+
+/**
+ * story #2404 후속(2026-08-02, 라이브 재확認 중 발견) — recruiter-client.tsx와
+ * onboarding/connect-step.tsx가 각자 이 파싱을 따로 구현했는데, 둘 다 `json.data.steps`를
+ * 읽고 있었다. 백엔드(`backend/app/routers/agents.py::agent_verification_status`)는 그런
+ * 필드를 준 적이 없다 — 실제 필드명은 `rail`이다(`{"data":{"verified":true,"rail":[...]}}`).
+ * `steps`는 항상 undefined였으므로 이 파싱은 «단 한 번도» 실 데이터를 낸 적이 없었다 —
+ * 검증이 실제로 성공해도(curl로 직접 확認: verified:true) 화면 레일은 초기 pending에
+ * 멈춰 있었다. 두 파일이 같은 파싱을 각자 구현하고 있었던 것 자체가 이 버그가 두 곳에서
+ * 동시에 존재하게 된 이유이므로, 여기 하나로 모아 그 재발 경로를 없앤다.
+ */
+export function parseVerificationRail(json: unknown): RawStep[] | null {
+  if (json === null || typeof json !== 'object') return null;
+  const data = (json as { data?: unknown }).data;
+  const rail = Array.isArray(data)
+    ? data
+    : (data as { rail?: unknown } | undefined)?.rail ?? (json as { rail?: unknown }).rail;
+  return Array.isArray(rail) ? (rail as RawStep[]) : null;
+}
+
 function StepIcon({ status }: { status: RailStatus }) {
   if (status === 'done') {
     return (


### PR DESCRIPTION
## Summary
- story #2415(critical) — 선생님 원 지적("한 번도 성공 판정이 안 난다")의 직접적 원인. `#2404`/#2785(안내 문구 개선)는 그것대로 맞고 이미 머지됐지만, 그 안내를 정확히 따라도 화면은 절대 안 바뀌었다 — 다른 층(BE↔FE 응답 계약)의 버그였다.

**라이브 재확認(2026-08-02)** — `#2404` 예시 프롬프트대로 실 MCP 툴 호출(`sprintable_list_stories`)까지 실행한 뒤 curl로 백엔드 `verification-status`를 직접 확認: `verified:true`, rail 4단계 전부 done. **그런데 화면(STEP5 레일)은 "구성 적용"만 done인 채 그대로였다.**

**원인** — `recruiter-client.tsx`·`onboarding/connect-step.tsx` 둘 다 `json.data.steps`를 읽는데, 백엔드(`backend/app/routers/agents.py::agent_verification_status`)는 그런 필드를 준 적이 없다. 실제 필드명은 `rail`. `steps`는 항상 `undefined`였으므로 `setBeSteps`가 **단 한 번도 실호출되지 않았다** — 검증이 실제로 성공해도 화면 레일은 영원히 초기 pending이었다. "성공을 실패로 보여주는" 응답-방향 계약 불일치(오늘의 세 번째 같은 클래스 — #2412 요청 인자 무시, #2406 FE→BE 필드명 불일치에 이어 세 번째).

## AC 대응
1. **양쪽 파일이 BE 실 필드를 읽는다** — `steps`→`rail`로 수정. 파싱 로직을 `verify-rail.tsx`의 `parseVerificationRail()` 하나로 모았다 — 두 파일이 독립적으로 재구현하고 있었던 것 자체가 같은 버그가 두 곳에 동시에 생긴 이유였다.
2. **BE 응답 "실물"로 재는 검사** — 오늘 curl로 직접 캡처한 실제 백엔드 응답 그대로(`{"data":{"verified":true,"rail":[...]}}`)를 회귀 테스트로 고정. 양성대조: `steps` 필드가 있어도 rail로 오인하지 않는 것 확認. **뮤테이션 self-check**로 필드명을 다시 `steps`로 되돌리면 정확히 3개 테스트가 RED로 확認(복원 후 5/5 GREEN).
3. **라이브 검산은 배포 후** — curl로 이미 `verified:true`인 것을 재확認하는 건 이 AC를 만족 못 한다(스토리 AC 원문 그대로: "그건 이미 참이었다") — 실제로 **화면 레일이 done으로 바뀌는 것**을 눈으로 봐야 하므로 dev 배포 후 마저 진행.
4. **범위 — 같은 병이 다른 화면에도 있는지** — `.steps` 필드 접근 전수 grep. 이 두 소비처(그리고 `verification-status`/`verify-connection` 엔드포인트를 쓰는 곳 전수 — 정확히 이 둘뿐, 3번째 소비처 없음) 밖엔 전혀 다른 도메인(workflow config steps·loop recipe steps, 각자 자기 백엔드 계약과 정합)뿐 — 같은 클래스 재발 0건.

## Test plan
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run build` — EXIT 0
- [x] `pnpm exec vitest run` — 340 files · 2502 tests 전부 PASS(신규 5건 포함)
- [x] mutation self-check: 필드명을 `rail`→`steps`로 되돌리면 정확히 3개 테스트 RED, 복원 후 5/5 GREEN
- [x] verify:* 7개 전부 개별 실행 OK
- [ ] AC3(라이브로 화면 레일이 실제로 done 전환) — dev 배포 후 진행 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)