### PR TITLE
fix(#2410): isNumberAdjacent no longer treats name/runtime interpolation as a number

### DIFF
--- a/apps/web/scripts/verify-no-i18n-phrase-collision.test.ts
+++ b/apps/web/scripts/verify-no-i18n-phrase-collision.test.ts
@@ -10,6 +10,7 @@ import {
   pairKey,
   parseKeyUsages,
   parseTranslationBindings,
+  scanRepository,
 } from './verify-no-i18n-phrase-collision';
 
 describe('parseTranslationBindings — story #2367', () => {
@@ -285,5 +286,29 @@ describe('GRANDFATHER_BASELINE — 기존 채무는 통과, 새 충돌만 막는
 describe('GRANDFATHER_BASELINE_COUNT_TEST — 41번째부터는 PO 승인, 조용한 증감을 막는다', () => {
   it('#2367 최초 스캔 스냅샷은 정확히 40건이다', () => {
     expect(GRANDFATHER_BASELINE.size).toBe(40);
+  });
+});
+
+// story #2410(PO 지적, 2026-08-02): «선언된» 40건과 «실제로 지금 걸리는» 건수는 다른 축이다
+// (isNumberAdjacent 정밀화로 18건이 더 안 걸리게 됐다 — GRANDFATHER_BASELINE 상단 주석 참조).
+// console.log의 "안 걸림" 경고만으로는 다음 사람이 노이즈로 읽고 넘길 수 있어, 실제 저장소
+// 전체를 스캔해 «지금 몇 건이 실제로 걸리는지»를 이 테스트가 고정한다 — GRANDFATHER_BASELINE_
+// COUNT_TEST(선언 수 40)와 이 테스트(실 걸림 수 22)가 서로 다른 값을 지키는 것 자체가 그
+// 간극(18)이 조용히 사라지지 않게 하는 자리다.
+describe('GRANDFATHER_LIVE_COUNT_TEST — 「선언된 40」과 「지금 실제로 걸리는 수」는 다른 축이다', () => {
+  it('실제 저장소 스캔에서 지금 걸리는 grandfather는 22건이다(18건은 #2410으로 안 걸리게 됨)', () => {
+    const { grandfatherHit } = scanRepository();
+    expect(grandfatherHit.size).toBe(22);
+  });
+
+  it('새 FAIL은 없다(#2410 자체가 신규 회귀를 안 냈다는 증거)', () => {
+    const { newFindings } = scanRepository();
+    expect(newFindings.size).toBe(0);
+  });
+
+  it('EXEMPT_PAIRS는 이제 비어 있고, 그러니 exemptHit도 항상 빈 집합이다', () => {
+    expect(GRANDFATHER_BASELINE.size).toBeGreaterThan(0); // sanity: baseline은 안 비었다
+    const { exemptHit } = scanRepository();
+    expect(exemptHit.size).toBe(0);
   });
 });

--- a/apps/web/scripts/verify-no-i18n-phrase-collision.test.ts
+++ b/apps/web/scripts/verify-no-i18n-phrase-collision.test.ts
@@ -166,18 +166,22 @@ describe('AC2 — 옛 값(#2352·#2365 모양) 되돌리면 파이프라인이 �
 });
 
 // AC7 — 첫 검거를 «지어낸 것»이 아니라 «실제 저장소에 있는 것»으로도 보인다(오르테가군
-// 지적, 2026-07-31) — action-zone.tsx의 ccWaitingGateReason과 ccAgentStuck이 완전히 같은
-// 템플릿("{gate} 대기 중")을 같은 파일에서 쓴다. 오늘 이 스토리가 실제로 처음 잡은 것 중
-// 하나 — 고치지 않고(AC6) 그대로 재현만 고정한다.
-describe('AC7 — 실제 저장소의 첫 검거 재현(action-zone.tsx)', () => {
-  it('ccWaitingGateReason과 ccAgentStuck이 완전히 같은 템플릿이라 잡힌다', () => {
-    const file = path.resolve(__dirname, '../src/components/dashboard/command-center/action-zone.tsx');
+// 지적, 2026-07-31) — notification-bell.tsx의 panelTitle("알림")이 bellAriaLabelCount
+// ("알림 {count}개")의 부분문자열이고 {count}는 진짜 카운터다. story #2410 전엔 이 자리가
+// action-zone.tsx의 ccWaitingGateReason/ccAgentStuck({gate} 대기 중)이었으나, {gate}는
+// 게이트 «이름»이지 수가 아니라는 게 #2410에서 밝혀져(아래 '이름·런타임류 보간은 더 이상
+// numberAdjacent가 아니다' 참조) 그 쌍은 더 이상 이 스캔에 안 걸린다 — AC7이 증명하려는
+// "실제 저장소에서 진짜로 걸린다"는 그 쌍으론 더 이상 못 서므로, 여전히 진짜 카운터인
+// 다른 실제 쌍으로 옮겼다.
+describe('AC7 — 실제 저장소의 첫 검거 재현(notification-bell.tsx)', () => {
+  it('panelTitle과 bellAriaLabelCount가 부분문자열+진짜 카운터라 잡힌다', () => {
+    const file = path.resolve(__dirname, '../src/components/nav/notification-bell.tsx');
     const content = readFileSync(file, 'utf8');
     const bindings = parseTranslationBindings(content);
-    expect(bindings.get('t')).toBe('dashboard');
+    expect(bindings.get('t')).toBe('inbox');
     const usages = parseKeyUsages(content, bindings);
-    expect(usages.has('dashboard.ccWaitingGateReason')).toBe(true);
-    expect(usages.has('dashboard.ccAgentStuck')).toBe(true);
+    expect(usages.has('inbox.panelTitle')).toBe(true);
+    expect(usages.has('inbox.bellAriaLabelCount')).toBe(true);
 
     const messagesPath = path.resolve(__dirname, '../messages/ko.json');
     const messages = flattenMessages(JSON.parse(readFileSync(messagesPath, 'utf8')));
@@ -189,10 +193,66 @@ describe('AC7 — 실제 저장소의 첫 검거 재현(action-zone.tsx)', () =>
     const collisions = findSubstringCollisions(phrases);
     const hit = collisions.find(
       (c) =>
-        new Set([c.keyA, c.keyB]).has('dashboard.ccWaitingGateReason') &&
-        new Set([c.keyA, c.keyB]).has('dashboard.ccAgentStuck'),
+        new Set([c.keyA, c.keyB]).has('inbox.panelTitle') &&
+        new Set([c.keyA, c.keyB]).has('inbox.bellAriaLabelCount'),
     );
     expect(hit).toBeDefined();
+  });
+});
+
+// ── story #2410 — isNumberAdjacent가 이름·런타임류 보간을 더 이상 "수와 함께 선다"로
+// 오판하지 않는다. #2404({runtime})·#2406({name})의 실제 오탐이었던 쌍을 실 ko.json 값으로
+// 재현해 이제 안 잡힌다는 것을 보이고, 그 근본원인 때문에 우연히 걸렸던
+// dashboard.ccWaitingGateReason/ccAgentStuck({gate})도 같은 이유로 안 잡힌다는 것을 확認한다.
+describe('story #2410 — isNumberAdjacent: 이름 보간은 numberAdjacent가 아니다', () => {
+  it('{name}·{runtime}류(사람/런타임 이름)는 false', () => {
+    expect(isNumberAdjacent('{name} 비활성화')).toBe(false);
+    expect(isNumberAdjacent('{runtime} MCP 설정')).toBe(false);
+    expect(isNumberAdjacent('{gate} 대기 중')).toBe(false);
+  });
+
+  it('{n}·{count}류(카운터)는 여전히 true', () => {
+    expect(isNumberAdjacent('목표 · {n}')).toBe(true);
+    expect(isNumberAdjacent('{count}개 문서 일치')).toBe(true);
+  });
+
+  it('알 수 없는 보간 이름은 «안전한 쪽»(true)으로 남는다 — 모르면 놓치지 않는다', () => {
+    expect(isNumberAdjacent('{somethingBrandNew} 상태')).toBe(true);
+  });
+
+  it('#2404 재현 — recruiter.verifyGuideMcp({runtime})와 짧은 라벨 넷은 이제 안 겹친다', () => {
+    const messagesPath = path.resolve(__dirname, '../messages/ko.json');
+    const messages = flattenMessages(JSON.parse(readFileSync(messagesPath, 'utf8')));
+    const keys = [
+      'recruiter.verifyGuideMcp',
+      'recruiter.equipDone',
+      'recruiter.next',
+      'recruiter.stepComplete',
+      'recruiter.stepVerify',
+    ];
+    const phrases = new Map(
+      keys
+        .filter((k) => messages.has(k))
+        .map((k) => [k, { value: messages.get(k)!, numberAdjacent: isNumberAdjacent(messages.get(k)!) }] as const),
+    );
+    expect(findSubstringCollisions(phrases)).toHaveLength(0);
+  });
+
+  it('#2406 재현 — settings.deactivateAgentDialogTitle({name})와 나머지 셋은 이제 안 겹친다', () => {
+    const messagesPath = path.resolve(__dirname, '../messages/ko.json');
+    const messages = flattenMessages(JSON.parse(readFileSync(messagesPath, 'utf8')));
+    const keys = [
+      'settings.deactivateAgentDialogTitle',
+      'settings.deactivateAgent',
+      'settings.activateAgent',
+      'settings.deactivateAgentDialogConfirm',
+    ];
+    const phrases = new Map(
+      keys
+        .filter((k) => messages.has(k))
+        .map((k) => [k, { value: messages.get(k)!, numberAdjacent: isNumberAdjacent(messages.get(k)!) }] as const),
+    );
+    expect(findSubstringCollisions(phrases)).toHaveLength(0);
   });
 });
 

--- a/apps/web/scripts/verify-no-i18n-phrase-collision.ts
+++ b/apps/web/scripts/verify-no-i18n-phrase-collision.ts
@@ -139,6 +139,13 @@ export function flattenMessages(obj: Record<string, unknown>, prefix = ''): Map<
 //   teamId     — Slack 워크스페이스 ID(문자열 식별자, 카운트 아님)
 //   dir        — 방향 기호(↑/↓), 수치 아님
 //   sources·excludes — 수집 범위를 나타내는 라벨 목록
+// ⛔새 이름을 여기 더하기 前에(PO 지적, 2026-08-02): 그 이름이 실제로 채우는 ko.json 값을
+// 먼저 읽는다. 정말 이름·경로류(수가 아님)면 더한다. 그런데 만약 «숫자인» 값인데 여기 걸려
+// EXEMPT_PAIRS에 다시 나타난다면, 그건 denylist 후보가 아니라 «진짜 충돌»이다 — 그 경우
+// denylist를 늘려 조용히 덮지 말고 그 충돌 자체를 고치거나(문구 수정) EXEMPT_PAIRS에
+// 이유와 함께 등재한다. 이 목록은 "수가 아님이 확認된 것"만 오는 자리이지 "오탐을 없애는
+// 자리"가 아니다 — 그 둘을 섞으면 이 스토리(#2410)가 고친 바로 그 병(가드가 자기가 뭘
+// 재는지 모르게 되는 것)이 재발한다.
 const NON_NUMBER_PLACEHOLDER_NAMES = new Set([
   'name', 'runtime', 'filename', 'promptFile', 'gate', 'role', 'project', 'teamId', 'dir',
   'sources', 'excludes',
@@ -212,6 +219,23 @@ export const EXEMPT_PAIRS = new Set<string>([]);
 // 고치는 일이 아니다"(AC6)를 지키는
 // 방법이다 — 여기 있는 40건 «중 실제로 몇 건이 진짜 결함인지»는 이 스토리가 판정하지 않는다.
 // 그래도 매 실행 로그에 grandfather 카운트로 찍혀 "원래 그런 것"으로 조용히 묻히지 않는다.
+// story #2410(PO 지적, 2026-08-02): 이 40건 중 18건은 이제 이 스캔에 «안 걸린다» — isNumberAdjacent
+// 정밀화(이름·런타임류 배제) 여파로, 그동안 「진짜 결함인지 몰랐던」게 아니라 「애초에 numberAdjacent가
+// 아니었던」 것으로 밝혀졌다. Set 크기(40)는 #2367 최초 스캔 스냅샷이라 그대로 두지만("아래 40건" 문단
+// 그대로), 매 실행 로그의 "안 걸림" 경고만으로는 다음 사람이 노이즈로 읽고 넘길 수 있어 여기 명시로
+// 남긴다 — 실 걸림 수(22)는 GRANDFATHER_LIVE_COUNT_TEST가 고정한다(아래).
+// 안 걸리는 18건: board.backlinksEmptyFallback<->board.backlinksEmptyScoped · canvas.resolveAction<->
+// canvas.resolvedByNote · dashboard.ccAgentStuck<->dashboard.ccWaitingGateReason ·
+// recruiter.back<->recruiter.{guideFileDeliveryNoteConnector,guideFileDeliveryNoteMcp,kitOrientingGuideBody} ·
+// recruiter.equipCreatedTitle<->recruiter.{equipDone,stepComplete} ·
+// recruiter.equipDone<->recruiter.{guideFileDeliveryNoteConnector,kitOrientingTitle} ·
+// recruiter.guideFileDeliveryNoteConnector<->recruiter.{kitOrientingGuideBody,stepComplete} ·
+// recruiter.kitOrientingTitle<->recruiter.stepComplete · settings.projectCreated<->settings.tabProjects ·
+// settings.slackIntegration.{mappedElsewhereHint,pendingHint}<->settings.slackIntegration.saveLabel ·
+// settings.slackIntegration.workspaceConnectedSummary<->settings.slackIntegration.workspaceLabel ·
+// standup.feedback<->standup.feedbackDialogTitle
+// ⇒ 이 18건을 GRANDFATHER_BASELINE에서 걷어낼지(진짜 결함이 아니었다고 결론)는 이 PR이 정하지 않는다
+// (AC6과 같은 판단 — 이 스토리는 정밀화만, triage는 별도).
 export const GRANDFATHER_BASELINE = new Set<string>([
   'board.backlinksEmptyFallback <-> board.backlinksEmptyScoped',
   'cage.pendingSummary <-> cage.trustScorePending',
@@ -270,7 +294,19 @@ function walk(dir: string, out: string[]): void {
   }
 }
 
-function main(): void {
+export interface RepositoryScanResult {
+  files: string[];
+  totalDynamicCalls: number;
+  newFindings: Map<string, CollisionPair>;
+  grandfathered: Map<string, CollisionPair>;
+  exemptHit: Set<string>;
+  grandfatherHit: Set<string>;
+}
+
+/** main()에서 뽑아낸 전 저장소 스캔 — story #2410, GRANDFATHER_LIVE_COUNT_TEST가 이걸 불러
+ * "지금 실제로 걸리는 grandfather 수"를 고정한다(console.log 경고만으로는 다음 사람이
+ * 노이즈로 읽고 넘기는 것을 막는다, PO 지적). */
+export function scanRepository(): RepositoryScanResult {
   const files: string[] = [];
   walk(SRC_ROOT, files);
   const messages = flattenMessages(JSON.parse(readFileSync(MESSAGES_PATH, 'utf8')));
@@ -309,6 +345,12 @@ function main(): void {
       }
     }
   }
+
+  return { files, totalDynamicCalls, newFindings, grandfathered, exemptHit, grandfatherHit };
+}
+
+function main(): void {
+  const { files, totalDynamicCalls, newFindings, grandfathered, exemptHit, grandfatherHit } = scanRepository();
 
   const staleExempt = [...EXEMPT_PAIRS].filter((pk) => !exemptHit.has(pk));
   const staleGrandfather = [...GRANDFATHER_BASELINE].filter((pk) => !grandfatherHit.has(pk));

--- a/apps/web/scripts/verify-no-i18n-phrase-collision.ts
+++ b/apps/web/scripts/verify-no-i18n-phrase-collision.ts
@@ -50,9 +50,15 @@
  */
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const SRC_ROOT = path.resolve(process.cwd(), 'src');
-const MESSAGES_PATH = path.resolve(process.cwd(), 'messages', 'ko.json');
+// story #2410 회귀(카디르 QA, PR #2790, 2026-08-01) — SRC_ROOT를 `process.cwd()` 기준으로
+// 잡았다가 루트에서 도는 `pnpm vitest run`(CI)이 이 모듈을 import하는 순간 ENOENT로 죽었다.
+// scanRepository() 추출 전엔 main()이 CLI 전용이라 cwd가 항상 apps/web이라 안 터졌던 것 —
+// 같은 레포 같은 날 #2774(verify-no-orphan-resource-routes.ts)와 동일한 병. 스크립트 자기
+// 위치(import.meta.url) 기준으로 고정하면 호출부의 cwd와 무관해진다.
+const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src');
+const MESSAGES_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../messages', 'ko.json');
 const EXT_RE = /\.(tsx?|jsx?)$/;
 const TEST_RE = /\.(test|spec)\.[tj]sx?$/;
 

--- a/apps/web/scripts/verify-no-i18n-phrase-collision.ts
+++ b/apps/web/scripts/verify-no-i18n-phrase-collision.ts
@@ -119,19 +119,51 @@ export function flattenMessages(obj: Record<string, unknown>, prefix = ''): Map<
   return flat;
 }
 
-// ko.json 값 자체가 보간 자리(`{n}`류)를 갖고 있으면 그 키는 "수와 함께 서는" 축이다
-// (예: "목표 · {n}"·"{count}개 문서 일치"). 이 신호 하나만 쓴다 — 위 모듈 코멘트 경위 참조
-// (호출 자리 근접 휴리스틱은 노이즈가 더 커서 뺐다).
-const PLACEHOLDER_VALUE_RE = /\{[a-zA-Z_][a-zA-Z0-9_]*\}/;
+// story #2410 — 이름(isNumberAdjacent)과 «재는 것»을 맞춘다. 예전 PLACEHOLDER_VALUE_RE는
+// 보간 자리가 «있기만 하면» true였다 — 그게 이름·런타임처럼 «수가 아닌» 보간까지 「수와
+// 함께 선다」로 잘못 읽어 EXEMPT_PAIRS가 7건까지 쌓인 근본원인이었다(#2404: {runtime} ·
+// #2406: {name}). 47개(GRANDFATHER_BASELINE 40 + EXEMPT_PAIRS 7)에 실제로 쓰이는 보간
+// 이름을 전수 대조해(2026-08-02) 「절대 수가 아님을 값을 직접 읽어 확認한」 이름만 배제
+// 목록에 올린다 — 나머지(미확認·모호한 것 포함)는 «안전한 쪽»(예전과 동일하게 true)으로
+// 남긴다. 모르는 이름을 마음대로 false로 내리면 그게 새 오탐이 아니라 새 «누락»(놓친 진짜
+// 충돌)이 되고, 이 가드는 놓치는 쪽보다 과하게 잡는 쪽이 안전하다(EXEMPT_PAIRS로 되돌릴
+// 수 있지만 누락은 그 자체로 안 보인다).
+//
+// 배제 근거(각 이름의 실제 ko.json 값을 직접 읽고 판정, 파일 하단 커밋 참조):
+//   name       — 사람/에이전트 이름("{name} 비활성화"·"{name}이(가)...")
+//   runtime    — MCP 런타임 이름("{runtime} MCP 설정" — claude-code 등)
+//   filename·promptFile — 파일 이름
+//   gate       — 게이트 이름/사유 문자열("{gate} 대기 중")
+//   role       — 역할 이름(PM/Engineer 등)
+//   project    — 프로젝트 이름
+//   teamId     — Slack 워크스페이스 ID(문자열 식별자, 카운트 아님)
+//   dir        — 방향 기호(↑/↓), 수치 아님
+//   sources·excludes — 수집 범위를 나타내는 라벨 목록
+const NON_NUMBER_PLACEHOLDER_NAMES = new Set([
+  'name', 'runtime', 'filename', 'promptFile', 'gate', 'role', 'project', 'teamId', 'dir',
+  'sources', 'excludes',
+]);
+const PLACEHOLDER_NAME_RE = /\{([a-zA-Z_][a-zA-Z0-9_]*)\}/g;
 
 export function isNumberAdjacent(value: string): boolean {
-  return PLACEHOLDER_VALUE_RE.test(value);
+  for (const m of value.matchAll(PLACEHOLDER_NAME_RE)) {
+    if (!NON_NUMBER_PLACEHOLDER_NAMES.has(m[1]!)) return true;
+  }
+  return false;
 }
 
 // ── 충돌 판정 ────────────────────────────────────────────────────────────
 
 /** 서로 다른 키의 값이 부분문자열 관계(포함하거나 포함되는)면서 «최소 한쪽이 수와 함께
- * 서면» 그 쌍을 낸다. docs.save↔statusSaved류(수 없음)는 저절로 빠진다. */
+ * 서면» 그 쌍을 낸다. docs.save↔statusSaved류(수 없음)는 저절로 빠진다.
+ *
+ * ⛔story #2410에서 "값이 완전히 동일하면 numberAdjacent 무관하게 항상 잡는다"는 분기를
+ * 한 번 넣었다가 «되돌렸다» — 실측하니 완전동일-정적라벨 쌍(예: docs.preview="미리보기"
+ * <-> docs.formatPreview="미리보기", "완료"·"저장 중..." 등)이 29건 «신규 FAIL»로 쏟아졌다.
+ * 이건 이 가드가 원래부터 저절로 빼려던 그 모양(docs.save↔statusSaved류) 그 자체다 — 수와
+ * 무관하게 완전동일이면 다 잡는다는 건 이 가드의 존재 이유(#2352·#2365 — «수와 함께 서는»
+ * 축)를 무시한 과확장이었다. 값을 실행해 보지 않고 판단부터 넣으면 이렇게 걸린다는 걸
+ * 스스로 보인 자리라 남겨 둔다. */
 export function findSubstringCollisions(
   phrases: Map<string, { value: string; numberAdjacent: boolean }>,
 ): Array<{ keyA: string; keyB: string; valueA: string; valueB: string }> {
@@ -154,27 +186,16 @@ export function findSubstringCollisions(
 // «영구 정상»으로 코드로 확認된 것만 여기 온다 — GRANDFATHER_BASELINE(아래, 미triage 채무)과
 // 다르다.
 //
-// story #2404(2026-08-01, PO 승인) — `recruiter.verifyGuideMcp`(#2404가 신설한 온보딩 안내문)
-// 4건. `PLACEHOLDER_VALUE_RE`가 이름 보간(`{runtime}`)까지 "수와 함께 서는" 신호로 잡아
-// numberAdjacent=true가 됐지만, verifyGuideMcp는 숫자를 전혀 담지 않는 안내문(보간은 런타임
-// 이름뿐)이고 짝지어진 넷(stepComplete/stepVerify/next/equipDone)도 카운터가 아닌 고정
-// 내비게이션 라벨이다 — #2352/#2365가 잡으려는 "두 셈이 같은 말로 헷갈리는" 병이 아니다.
-// ⭐이 오탐의 근본 원인(`PLACEHOLDER_VALUE_RE`가 숫자·이름 보간을 구분 못 하는 것 자체)은
-// story #2410으로 별도 추적한다 — 여기서는 면제만.
-// story #2406 AC1(2026-08-02, PO 승인) — 비활성화 확認 다이얼로그 신규 키 3쌍.
-// ①왜 안전한가 — `{name}`은 카운터가 아니라 대상 이름 placeholder이고, 반복되는 낱말
-// ("비활성화")은 «한 다이얼로그 안»의 제목·버튼·기존 짧은 라벨일 뿐이라 사용자가 두 셈을
-// 헷갈릴 자리가 아니다(#2352/#2365가 잡으려는 병이 아니다) — #2410과 같은 근본원인 클래스.
-// ②언제 걷는가 — #2410(가드 자체의 `PLACEHOLDER_VALUE_RE` 수정) 머지 시 이 셋도 같이 재평가.
-export const EXEMPT_PAIRS = new Set<string>([
-  'recruiter.equipDone <-> recruiter.verifyGuideMcp',
-  'recruiter.next <-> recruiter.verifyGuideMcp',
-  'recruiter.stepComplete <-> recruiter.verifyGuideMcp',
-  'recruiter.stepVerify <-> recruiter.verifyGuideMcp',
-  'settings.deactivateAgent <-> settings.deactivateAgentDialogTitle',
-  'settings.activateAgent <-> settings.deactivateAgentDialogTitle',
-  'settings.deactivateAgentDialogConfirm <-> settings.deactivateAgentDialogTitle',
-]);
+// ✅story #2410(2026-08-02)에서 아래 일곱을 «재평가»해 전부 걷어냈다 — 예전엔 여기 있었다:
+//   recruiter.{equipDone,next,stepComplete,stepVerify} <-> recruiter.verifyGuideMcp (#2404, {runtime})
+//   settings.{deactivateAgent,activateAgent,deactivateAgentDialogConfirm} <-> settings.deactivateAgentDialogTitle (#2406, {name})
+// 근본원인(isNumberAdjacent가 이름·런타임 보간까지 "수와 함께 선다"로 오판)을 고치니 이
+// 일곱 전부 이 스캔에서 «다시 안 걸린다»(재현 확認 — tsx로 실행해 exemptHit 0/7, 신규
+// FAIL도 0건인 것까지 봤다). 즉 «지금 정말 안전한데 가드가 몰라서 면제해 둔» 상태에서
+// «가드가 스스로 안 겹친다는 걸 아는» 상태로 옮겨졌다 — EXEMPT_PAIRS는 이제 빈 목록이 맞고,
+// 앞으로 이름·런타임류 보간이 다시 오탐으로 걸리면 그건 NON_NUMBER_PLACEHOLDER_NAMES에
+// 새 이름을 더할 자리이지 여기 되돌아올 자리가 아니다.
+export const EXEMPT_PAIRS = new Set<string>([]);
 
 // ⛔⭐오르테가군 지적(2026-07-31) — 이 목록에 «새로» 넣는 것은 PO 승인을 거친다. 이유 없이
 // 넣지 않는다. 이 길을 그냥 열어 두면 "새 충돌이 FAIL 났을 때 담당이 baseline에 넣고 지나가는"


### PR DESCRIPTION
## Summary

The old `PLACEHOLDER_VALUE_RE` matched any `{identifier}` interpolation at all — its name (`isNumberAdjacent`) claimed to detect "this phrase carries a number," but it actually just detected "this phrase has *any* interpolation whatsoever." That mismatch is what let `{runtime}` (#2404) and `{name}` (#2406) get misclassified as number-adjacent, piling up to **7** `EXEMPT_PAIRS` entries — each individually justified at the time, but the accumulation itself was the signal the guard was measuring the wrong thing.

## Fix

Extract every placeholder name from a value and check it against `NON_NUMBER_PLACEHOLDER_NAMES`, a small denylist built by reading the **actual ko.json value** behind every placeholder name used across all 47 currently-tracked pairs (`GRANDFATHER_BASELINE` 40 + `EXEMPT_PAIRS` 7): `name`, `runtime`, `filename`, `promptFile`, `gate`, `role`, `project`, `teamId`, `dir`, `sources`, `excludes`. Anything **not** on that list still defaults to number-adjacent=`true`, same as before — an unrecognized placeholder name errs toward over-catching (costs a PO-reviewed `EXEMPT` entry) rather than under-catching (costs nothing visible — a missed real collision). Matches how "안전한 쪽 누락" is applied elsewhere in this same file.

## AC2 — re-evaluated all 7 EXEMPT_PAIRS, not assumed

Re-ran the actual scan after the fix: **0 new findings**, and all 7 `EXEMPT_PAIRS` entries stopped triggering — confirmed by running `tsx scripts/verify-no-i18n-phrase-collision.ts`, not assumed. `EXEMPT_PAIRS` is now empty, with a comment pointing at this story instead of silently deleting the history.

18 of 40 `GRANDFATHER_BASELINE` entries also stopped triggering (their false-positive-ness was never actually verified before — they'd just been sitting there since #2367's first scan). The `Set` itself stays at 40 members unchanged (that count is a deliberate snapshot, not a live-hit count — `GRANDFATHER_BASELINE_COUNT_TEST` still asserts 40) and the script's own existing "stale grandfather" warning surfaces the 18 without failing CI.

## AC3 — positive control

Temporarily dropped `'name'` from the denylist, confirmed the new `#2406` reproduction test fails on exactly that removal; restored, confirmed green.

## AC4 — a dead end worth recording (the story's own thesis, proven on myself)

First attempt also added "identical full string always collides regardless of `numberAdjacent`" specifically to keep catching `dashboard.ccWaitingGateReason`/`ccAgentStuck` (both `"{gate} 대기 중"` — `gate` is a name, not a number). Running the script with that in place produced **29 new FAIL findings** — pairs like `docs.preview`/`docs.formatPreview` (both `"미리보기"`, zero placeholders) that this guard was explicitly designed to leave alone (the `docs.save`/`statusSaved` shape from the module's own opening comment). Reverted before committing. That `{gate}` pair is now correctly one of the 18 stale grandfather entries instead, and AC7's "real repo, not synthetic" test moved to a still-genuinely-numeric pair (`inbox.panelTitle`/`bellAriaLabelCount`, `{count}`) since the pair it used to point at no longer qualifies.

## Verification

- Full script test suite: 24 tests pass (5 new: 3 unit-level `isNumberAdjacent` cases, 2 reproducing #2404/#2406 against real ko.json values and asserting they no longer collide).
- Broader `apps/web/scripts/` suite: 83 tests pass.
- Project `type-check`: clean (the modified file only).
- Positive control as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)