### PR TITLE
refactor(#2407): unify verification rail state/polling into useVerificationRail

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3311,6 +3311,7 @@
     "rotating": "Rotating…",
     "rotateFailed": "Rotate failed. Please try again.",
     "verifyGuideMcp": "Copy the .mcp.json shown below into {runtime}'s MCP settings as-is (don't retype it by hand — a dropped line is a common cause of silent failures), then open {runtime} and make it call any Sprintable tool — adding the config alone does not connect it, that first real tool call is what completes verification.",
+    "verifyGuideMcpStdio": "Copy the .mcp.json shown below into {runtime}'s MCP settings as-is (don't retype it by hand — a dropped line is a common cause of silent failures), then open {runtime} and connect — verification completes automatically once the connection is live.",
     "verifyGuideConnector": "Finish the connector setup, then have it make one real Sprintable tool call — finishing setup alone does not connect it, that first real tool call is what completes verification.",
     "verifyExampleLabel": "Try telling your agent:",
     "verifyExamplePrompt": "Show me my story list",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3311,6 +3311,7 @@
     "rotating": "재발급 중…",
     "rotateFailed": "재발급에 실패했습니다. 다시 시도해 주세요.",
     "verifyGuideMcp": "아래 .mcp.json을 화면에 있는 그대로 {runtime} MCP 설정에 붙여넣으세요(손으로 옮겨 적지 마세요 — 한 줄이 빠지면 조용히 실패하는 흔한 원인입니다), 그런 다음 {runtime}을 열어 Sprintable 도구를 아무거나 한 번 실제로 호출하게 하세요 — 설정만으로는 연결되지 않고, 그 첫 실제 호출이 검증을 완료시킵니다.",
+    "verifyGuideMcpStdio": "아래 .mcp.json을 화면에 있는 그대로 {runtime} MCP 설정에 붙여넣으세요(손으로 옮겨 적지 마세요 — 한 줄이 빠지면 조용히 실패하는 흔한 원인입니다), 그런 다음 {runtime}을 열어 연결하세요 — 연결이 확인되면 자동으로 검증이 완료됩니다.",
     "verifyGuideConnector": "커넥터 연결 설정을 완료한 뒤, Sprintable 도구를 아무거나 한 번 실제로 호출하게 하세요 — 설정만으로는 연결되지 않고, 그 첫 실제 호출이 검증을 완료시킵니다.",
     "verifyExampleLabel": "에이전트에게 이렇게 말해 보세요:",
     "verifyExamplePrompt": "내 스토리 목록 보여줘",

--- a/apps/web/scripts/verify-no-i18n-phrase-collision.ts
+++ b/apps/web/scripts/verify-no-i18n-phrase-collision.ts
@@ -208,6 +208,12 @@ export function findSubstringCollisions(
 // «가드가 스스로 안 겹친다는 걸 아는» 상태로 옮겨졌다 — EXEMPT_PAIRS는 이제 빈 목록이 맞고,
 // 앞으로 이름·런타임류 보간이 다시 오탐으로 걸리면 그건 NON_NUMBER_PLACEHOLDER_NAMES에
 // 새 이름을 더할 자리이지 여기 되돌아올 자리가 아니다.
+//
+// story #2792(2026-08-02) — `recruiter.verifyGuideMcpStdio`(verifyGuideMcp의 stdio 전용
+// 짝)도 같은 `{runtime}` 보간을 쓴다. rebase 前(#2410/#2790 이전 기준 worktree)에는 이
+// denylist가 없어 신규 짝 4개를 여기 추가했었으나, rebase 뒤 재스캔(신규 0건·exempt 0건)으로
+// «필요 없음»이 실측 확認돼 다시 뺐다 — NON_NUMBER_PLACEHOLDER_NAMES의 `runtime`이 이미
+// 덮는다(PO 지적: rebase 안 하면 #2790이 오늘 한 일이 부분적으로 되돌아간다).
 export const EXEMPT_PAIRS = new Set<string>([]);
 
 // ⛔⭐오르테가군 지적(2026-07-31) — 이 목록에 «새로» 넣는 것은 PO 승인을 거친다. 이유 없이

--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.test.tsx
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { spliceApiKey, splitRuntimeCapabilities, pickDefaultRuntime, groupAndFilterRoleTemplates, resolveKitFilename } from './recruiter-client';
+import { spliceApiKey, splitRuntimeCapabilities, pickDefaultRuntime, groupAndFilterRoleTemplates, resolveKitFilename, resolveVerifyGuideKey } from './recruiter-client';
 import type { McpConfigBundle, RuntimeCapabilityItem, RoleTemplateSummary } from '@/services/recruit';
 import { RUNTIME_CAPABILITIES_FALLBACK, KIT_FILENAME } from '@/services/recruit';
 import enMessages from '../../../../../../messages/en.json';
@@ -259,5 +259,30 @@ describe('recruiter-client STEP4 — story #2377 §2(단계 셋)·§4(발견 가
 
   it('shows an explicit "not registered yet" fallback for the wake-up step instead of staying silent', () => {
     expect(source).toContain("t('kitOrientingWakeBodyUnknown')");
+  });
+});
+
+// story #2792 design:changes(카디르 QA, 2026-08-02) — verifyGuideMcp가 transport 무관 항상
+// "tool을 호출해야 검증이 완료된다"고 말했다(http만 사실). stdio는 세션 연결만으로 SSE ack가
+// 자동 진행되므로 별개 문장(verifyGuideMcpStdio)이어야 한다 — 이 판정이 다시 안 갈리게 pin.
+describe('resolveVerifyGuideKey — story #2792 (STEP5 안내문도 showVerifyExamplePrompt와 같은 축)', () => {
+  it('no mcp_config → connector guide regardless of transport', () => {
+    expect(resolveVerifyGuideKey(false, 'http')).toBe('verifyGuideConnector');
+    expect(resolveVerifyGuideKey(false, null)).toBe('verifyGuideConnector');
+  });
+
+  it('mcp_config + http → the tool-call-completes-verification guide (accurate for heartbeat)', () => {
+    expect(resolveVerifyGuideKey(true, 'http')).toBe('verifyGuideMcp');
+  });
+
+  it('mcp_config + stdio → the auto-completes-on-connect guide, not the tool-call one', () => {
+    expect(resolveVerifyGuideKey(true, 'stdio')).toBe('verifyGuideMcpStdio');
+  });
+
+  it('both locales have the new key', () => {
+    const en = (enMessages as { recruiter: Record<string, string> }).recruiter.verifyGuideMcpStdio;
+    const ko = (koMessages as { recruiter: Record<string, string> }).recruiter.verifyGuideMcpStdio;
+    expect(en).toBeTruthy();
+    expect(ko).toBeTruthy();
   });
 });

--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
@@ -14,10 +14,7 @@ import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui
 import { Skeleton } from '@/components/ui/skeleton';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { cn } from '@/lib/utils';
-import {
-  VerifyRail, RAIL_ORDER, HTTP_RAIL_ORDER, parseVerificationRail,
-  type DisplayStep, type RailState, type RailStatus, type RawStep,
-} from '@/app/onboarding/verify-rail';
+import { VerifyRail, useVerificationRail } from '@/app/onboarding/verify-rail';
 import type { RoleTemplateSummary, RecruitResponse, McpConfigBundle, RuntimeCapabilityItem } from '@/services/recruit';
 import { RUNTIME_CAPABILITIES_FALLBACK, RUNTIME_GUIDE_FILENAME_FALLBACK, KIT_FILENAME, resolveRuntimeWakeInfo } from '@/services/recruit';
 
@@ -32,15 +29,6 @@ const CATEGORY_ICON: Record<string, typeof Palette> = {
   backend: Cog,
   qa: Search,
   pm: ClipboardList,
-};
-
-const RAIL_LABEL_KEY: Record<RailState, string> = {
-  config_copied: 'railConfigCopied',
-  waiting: 'railWaiting',
-  mcp_reachable: 'railMcpReachable',
-  event_delivered: 'railEventDelivered',
-  ack: 'railAck',
-  verified: 'railVerified',
 };
 
 /**
@@ -220,8 +208,9 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
   const tSettings = useTranslations('settings');
   // 오르테가 라이브 스모크 적출(2026-07-06): railXxx/railStageHosted 키는 connect-step이 원래
   // 정의한 'onboarding' 네임스페이스에 있는데 STEP4가 이걸 'agents'(tAgents)로 조회해 전부
-  // MISSING_MESSAGE였음 — S4 merge(#1900) 때부터의 잠재 버그. 발견 즉시 여기서 수정.
-  const tOnboarding = useTranslations('onboarding');
+  // MISSING_MESSAGE였음 — S4 merge(#1900) 때부터의 잠재 버그. story #2407로 useVerificationRail
+  // hook이 이 네임스페이스 조회를 내부로 흡수해, 이 파일에서 직접 useTranslations('onboarding')를
+  // 들 필요가 없어졌다(hook 쪽 t는 verify-rail.tsx 소유).
   const [step, setStep] = useState<Step>(1);
 
   // STEP 1 — role catalog (+ equip-skip: "역할 없이(키만)")
@@ -427,7 +416,6 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
   const [recruitResult, setRecruitResult] = useState<RecruitResponse | null>(null);
   const [copiedGuide, setCopiedGuide] = useState(false);
   const [copiedMcp, setCopiedMcp] = useState(false);
-  const [copiedVerifyPrompt, setCopiedVerifyPrompt] = useState(false);
   const [showRotateConfirm, setShowRotateConfirm] = useState(false);
   const [rotating, setRotating] = useState(false);
   const [rotateError, setRotateError] = useState<string | null>(null);
@@ -530,74 +518,25 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
     }
   };
 
-  // STEP 4 — verify rail (connect-step 재사용 패턴)
-  const [beSteps, setBeSteps] = useState<RawStep[] | null>(null);
-  const [verifying, setVerifying] = useState(false);
-  const railOrder = recruitResult?.default_transport === 'http' ? HTTP_RAIL_ORDER : RAIL_ORDER;
-
-  // story #2404 후속(2026-08-02, 라이브 재확認 중 발견) — 이 코드는 `data.steps`를 읽었지만
-  // 백엔드(`backend/app/routers/agents.py::agent_verification_status`)의 실제 필드명은
-  // `rail`이다. `steps`는 항상 undefined였으므로 `setBeSteps`가 «단 한 번도» 실호출되지
-  // 않았다 — 검증이 실제로 성공해도 화면 레일은 영원히 초기 pending으로 멈춰 있었다.
-  // 파싱은 `parseVerificationRail`(verify-rail.tsx) 하나로 모았다 — 이 파일과
-  // onboarding/connect-step.tsx가 독립적으로 재구현하지 않게(같은 필드명 버그가 두 곳에서
-  // 동시에 존재했던 이유, story #2415 참조).
-  const pollStatus = useCallback(async () => {
-    if (!recruitResult) return;
-    try {
-      const res = await fetch(`/api/agents/${recruitResult.agent_id}/verification-status?transport=${recruitResult.default_transport}`);
-      if (!res.ok) return;
-      const raw = parseVerificationRail(await res.json());
-      if (raw) setBeSteps(raw);
-    } catch {
-      // swallow — graceful degradation
-    }
-  }, [recruitResult]);
-
-  useEffect(() => {
-    if (step !== 5 || !recruitResult) return;
-    void pollStatus();
-    const iv = setInterval(() => void pollStatus(), 2500);
-    return () => clearInterval(iv);
-  }, [step, recruitResult, pollStatus]);
-
-  const displaySteps: DisplayStep[] = railOrder.map((state) => {
-    const be = beSteps?.find((s) => s.state === state);
-    let status: RailStatus = be?.status ?? 'pending';
-    if (state === 'config_copied' && status === 'pending') status = 'done'; // 번들 다운로드=STEP3 완주로 이미 완료
-    // story 5ea9bafe §5.5: 크로스-플로우 SSOT 수렴 — recruiter만 로컬 오버라이드하던 라벨을 제거하고
-    // onboarding-connect와 동일한 공용 rail 라벨을 쓴다(공용 키 자체를 kit-model에 맞게 개정: "구성 적용").
-    const label = tOnboarding(RAIL_LABEL_KEY[state]);
-    return { state, status, label, reason: be?.reason };
+  // STEP 4/5 — verify rail. story #2407: 상태파생·폴링·핸들러는 verify-rail.tsx의
+  // useVerificationRail로 이동(connect-step.tsx와 각자 재구현하던 자리 — #2404의 steps/rail
+  // 필드명 버그가 두 곳에 동시에 있었던 이유). configCopiedDone=true 항상 — 번들 다운로드=STEP3
+  // 완주로 이미 완료(기존 판단 그대로, 이유는 hook 쪽 주석 참고).
+  //
+  // ⚠️②-3/②-4 두 지점은 이 통합으로 recruiter 쪽 동작이 바뀐다(#2407 조사에서 무근거
+  // 비대칭으로 판정 — connect-step의 더 정확한 쪽으로 통일):
+  //   railStageLabel — 예전엔 http만 라벨 표시·stdio는 빈 문자열. 이제 stdio도 "로컬 · 6단계" 표시.
+  //   showVerifyExamplePrompt — 예전엔 transport 무관 항상 노출. 이제 connect-step과 동일하게
+  //     http에서만(heartbeat=tool호출이 verify 메커니즘 자체인 쪽에만 인과적으로 맞는 안내라서).
+  const rail = useVerificationRail({
+    agentId: recruitResult?.agent_id ?? null,
+    transport: recruitResult?.default_transport ?? null,
+    enabled: step === 5 && Boolean(recruitResult),
+    configCopiedDone: true,
   });
-  const verified = displaySteps.find((s) => s.state === 'verified')?.status === 'done';
-
-  const handleVerify = async () => {
-    if (!recruitResult) return;
-    setVerifying(true);
-    try {
-      await fetch(`/api/agents/${recruitResult.agent_id}/verify-connection?transport=${recruitResult.default_transport}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: '{}',
-      }).catch(() => {});
-      await pollStatus();
-    } finally {
-      setVerifying(false);
-    }
-  };
-
-  // story #2404 — 검증이 "설정만 넣으면 자동으로 된다"는 오해로 무한 대기하던 것의 처방(AC5, PO
-  // 확정): 지금 할 일을 그 자리에서 손에 쥐여 준다 — 복사 가능한 예시 프롬프트 하나.
-  const handleCopyVerifyPrompt = async () => {
-    try {
-      await navigator.clipboard.writeText(t('verifyExamplePrompt'));
-      setCopiedVerifyPrompt(true);
-      setTimeout(() => setCopiedVerifyPrompt(false), 2000);
-    } catch {
-      // ignore clipboard failure
-    }
-  };
+  const { displaySteps, verified, verifying } = rail;
+  const handleVerify = rail.handleVerify;
+  const handleCopyVerifyPrompt = rail.handleCopyVerifyPrompt;
 
   const mcpConfigText = useMemo(
     () => (recruitResult ? JSON.stringify(recruitResult.mcp_config, null, 2) : ''),
@@ -1215,13 +1154,13 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
               {/* story #2404(AC5, PO 확定) — "설정만 넣으면 자동으로 된다"는 오해가 무한 대기의
                   실원인이었다(검증은 실제 tool 호출로만 완료됨). 대기 문구를 지우고 "지금 할 일"을
                   복사 가능한 한 줄로 그 자리에 쥐여 준다. */}
-              {!verified && (
+              {rail.showVerifyExamplePrompt && (
                 <div className="flex items-center justify-between gap-2 rounded-md border border-info-border bg-info-tint px-3 py-2 text-xs">
                   <span className="min-w-0 truncate text-info">
                     {t('verifyExampleLabel')} <span className="font-mono text-foreground">&ldquo;{t('verifyExamplePrompt')}&rdquo;</span>
                   </span>
                   <Button variant="outline" size="sm" onClick={() => void handleCopyVerifyPrompt()} className="shrink-0">
-                    {copiedVerifyPrompt ? <><Check className="h-3.5 w-3.5" />{t('copied')}</> : <><Copy className="h-3.5 w-3.5" />{t('copy')}</>}
+                    {rail.copiedVerifyPrompt ? <><Check className="h-3.5 w-3.5" />{t('copied')}</> : <><Copy className="h-3.5 w-3.5" />{t('copy')}</>}
                   </Button>
                 </div>
               )}
@@ -1230,7 +1169,7 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
                 <p className="text-sm font-medium">
                   {t('verifyTitle')}{' '}
                   <span className={cn('text-xs font-normal', recruitResult.default_transport === 'http' ? 'text-info' : 'text-muted-foreground')}>
-                    {recruitResult.default_transport === 'http' ? tOnboarding('railStageHosted') : ''}
+                    {rail.railStageLabel}
                   </span>
                 </p>
                 <Button variant="ghost" size="sm" onClick={() => void handleVerify()} disabled={verifying}>

--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
@@ -96,6 +96,21 @@ export function resolveKitFilename(
   return KIT_FILENAME;
 }
 
+/**
+ * story #2792 design:changes(카디르 QA, 2026-08-02) — STEP5 상단 안내문이 mcp_config 유무로만
+ * 갈리고 transport는 안 봤다. `verifyGuideMcp`("도구를 호출해야 검증이 완료된다")는 http
+ * heartbeat 축에만 인과적으로 맞는 문장(agent_verify.py — stdio는 SSE 연결만으로 자동 ack)이라
+ * stdio에 그대로 쓰면 없는 요구를 있다고 말하는 것이다. `showVerifyExamplePrompt`(verify-rail.tsx)
+ * 와 같은 근거·같은 축.
+ */
+export function resolveVerifyGuideKey(
+  hasMcpConfig: boolean,
+  transport: 'http' | 'stdio' | null,
+): 'verifyGuideConnector' | 'verifyGuideMcp' | 'verifyGuideMcpStdio' {
+  if (!hasMcpConfig) return 'verifyGuideConnector';
+  return transport === 'http' ? 'verifyGuideMcp' : 'verifyGuideMcpStdio';
+}
+
 export interface RoleGroup {
   label: string;
   roles: RoleTemplateSummary[];
@@ -1144,11 +1159,17 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
           {/* ── STEP 5 : 검증 + 배치(G5) ── */}
           {step === 5 && recruitResult && (
             <div className="space-y-4">
+              {/* story #2792 design:changes(카디르 QA, 2026-08-02) — ②를 「stdio에서 예시프롬프트
+                  게이팅」만 고치고 이 문구는 안 고쳐서 절반짜리였다. showVerifyExamplePrompt와
+                  같은 근거(agent_verify.py — http만 heartbeat=tool호출이 verify 메커니즘 자체,
+                  stdio는 세션 연결만으로 SSE ack가 자동 진행)를 이 안내에도 적용한다 — stdio는
+                  "tool을 호출해야 완료된다"가 아니라 "연결되면 자동 완료된다"가 맞는 문장이다. */}
               <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
                 <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
-                {recruitResult.mcp_config
-                  ? t('verifyGuideMcp', { runtime: currentRuntimeDisplayName })
-                  : t('verifyGuideConnector')}
+                {t(
+                  resolveVerifyGuideKey(Boolean(recruitResult.mcp_config), recruitResult.default_transport),
+                  { runtime: currentRuntimeDisplayName },
+                )}
               </p>
 
               {/* story #2404(AC5, PO 확定) — "설정만 넣으면 자동으로 된다"는 오해가 무한 대기의

--- a/apps/web/src/app/onboarding/connect-step.tsx
+++ b/apps/web/src/app/onboarding/connect-step.tsx
@@ -161,7 +161,10 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
   // 아티팩트 fetch 전체)와 동형인 기존 패턴(pristine origin/develop에도 있던 자리 — #2407가
   // 만든 게 아니라 리팩터로 컴파일러 분석이 더 깊이 들어가면서 드러난 것)이라 이 스토리
   // 범위에서 effect 아키텍처를 통째로 바꾸지 않는다 — 이 코드베이스 기존 관례(use-swipe-drawer.ts
-  // 등 7곳)를 따라 disable로 명시한다.
+  // 등, PO 지적 2026-08-02 기준 이 PR로 여덟 번째)를 따라 disable로 명시한다.
+  // ⛔이 disable은 면제가 아니라 부채다 — «걷을 조건»: 이 세 effect(§아티팩트 fetch) 구조를
+  // 다시 손대는 판이 오면(예: fetchArtifact를 재설계·SWR류로 옮기는 스토리) 이 disable 세 개도
+  // 함께 재평가한다. 조용히 영구화하지 않는다.
   useEffect(() => {
     if (!agentId || !apiKey) return;
     // eslint-disable-next-line react-hooks/set-state-in-effect

--- a/apps/web/src/app/onboarding/connect-step.tsx
+++ b/apps/web/src/app/onboarding/connect-step.tsx
@@ -8,22 +8,15 @@ import { Button } from '@/components/ui/button';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 import {
-  VerifyRail, RAIL_ORDER, HTTP_RAIL_ORDER, parseVerificationRail,
-  type DisplayStep, type RailState, type RailStatus, type RawStep,
+  VerifyRail, useVerificationRail,
+  type Transport,
 } from './verify-rail';
 import { emitOnboardingEvent, beaconOnboardingEvent } from './onboarding-telemetry';
 
-const RAIL_LABEL_KEY: Record<RailState, string> = {
-  config_copied: 'railConfigCopied',
-  waiting: 'railWaiting',
-  mcp_reachable: 'railMcpReachable',
-  event_delivered: 'railEventDelivered',
-  ack: 'railAck',
-  verified: 'railVerified',
-};
-
-/** E-MCP-OPT S3: SaaS 기본=호스팅(http)·OSS 기본=로컬(stdio) — BE `default_transport_for_edition()` 따름. */
-export type Transport = 'http' | 'stdio';
+// story #2407 — Transport는 이제 verify-rail.tsx가 소유(useVerificationRail이 그 값을 직접
+// 다룸). 이 re-export는 기존 소비자(onboarding-form.tsx 등)의 import 경로를 안 건드리려는
+// 하위호환 자리 — 새 소비자는 verify-rail에서 바로 import한다.
+export type { Transport };
 
 /** connection-artifact content(JSON)의 `mcpServers.sprintable.type` 필드만 읽는다(재조립 아님) —
  * transport 미지정 최초 요청은 BE edition 기본을 반환하므로, 어느 탭을 pre-select할지 이걸로 판별. */
@@ -105,44 +98,18 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
   // transport 미판별 상태(최초 default-resolve 요청)에서의 실패 — 이후엔 위 per-transport 에러로 대체.
   const [initialError, setInitialError] = useState(false);
   const [hostedUnavailable, setHostedUnavailable] = useState(false);
-  const [beSteps, setBeSteps] = useState<RawStep[] | null>(null);
   const [hasCopiedMap, setHasCopiedMap] = useState<Partial<Record<Transport, boolean>>>({});
   const [justCopied, setJustCopied] = useState(false);
-  const [copiedVerifyPrompt, setCopiedVerifyPrompt] = useState(false);
-  const [verifying, setVerifying] = useState(false);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const leftRef = useRef(false);
 
-  // OB-2 verification-status poll (SSE-우선은 OB-2 SSE 포맷 확정 후 follow-up·현재 poll). 404 graceful.
-  // E-MCP-OPT S3: transport별 레일 shape 다름(호스팅=4단계, event/ack 없음) — 쿼리로 분기.
-  //
-  // story #2404 후속(2026-08-02, 라이브 재확認 중 발견) — 이 코드는 `data.steps`를 읽었지만
-  // 백엔드(`backend/app/routers/agents.py::agent_verification_status`)는 그런 필드를 준 적이
-  // 없다 — 실제 필드명은 `rail`이다(`{"data":{"verified":true,"rail":[...]}}`). `steps`는 항상
-  // undefined였으므로 `setBeSteps`가 «단 한 번도» 실호출되지 않았다 — 검증이 실제로 성공해도
-  // 화면 레일은 영원히 초기 pending으로 멈춰 있었다(curl로 백엔드 값 자체는 verified:true를
-  // 직접 확認했는데 화면만 안 바뀌는 것으로 발견 — API 레벨 확認과 실제 렌더 확認은 다르다).
-  // 파싱은 이제 `parseVerificationRail`(verify-rail.tsx) 하나로 모았다 — recruiter-client.tsx
-  // 가 독립적으로 재구현하지 않게(같은 버그가 두 곳에서 동시에 존재했던 이유).
-  const pollStatus = useCallback(async (forTransport: Transport) => {
-    if (!agentId) return;
-    try {
-      const res = await fetch(`/api/agents/${agentId}/verification-status?transport=${forTransport}`);
-      if (!res.ok) return; // 미머지/404 → pending 유지(가짜 에러 안 띄움)
-      const raw = parseVerificationRail(await res.json());
-      if (raw) setBeSteps(raw);
-    } catch {
-      // swallow — graceful degradation
-    }
-  }, [agentId]);
-
-  useEffect(() => {
-    if (!agentId || !apiKey || !transport) return;
-    setBeSteps(null); // transport 전환 시 이전 transport의 레일 상태가 새 레일에 새는 것 방지
-    void pollStatus(transport);
-    const iv = setInterval(() => void pollStatus(transport), 2500);
-    return () => clearInterval(iv);
-  }, [agentId, apiKey, transport, pollStatus]);
+  const hasCopied = transport ? Boolean(hasCopiedMap[transport]) : false;
+  // misconfig 폴백(아래) — edition 기본이 http인데 배포가 없을 때 stdio로 명시 재요청해야
+  // 한다. useCallback으로 메모된 fetchArtifact가 자기 자신을 몸체 안에서 직접 호출하면
+  // eslint-plugin-react-hooks(immutability)가 "선언 前 접근"으로 잡는다(TDZ 우려 — 이 값이
+  // 시간에 따라 갱신될 때 몸체 안 참조가 갱신 前 클로저를 볼 수 있다는 경고) — effect로
+  // 한 단계 분리해 자기참조 자체를 없앤다.
+  const [needsStdioFallback, setNeedsStdioFallback] = useState(false);
 
   // OB-1 connection-artifact = 아티팩트 SSOT(구조+backend-direct URL). OB-1 라이브라 정상응답 디폴트.
   // 실패 시 클라빌드로 메우지 않고(§2 CF env 노출 금지·AC3) pending+재시도 유지.
@@ -162,9 +129,9 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
         }
         if (!reqTransport && res.status === 400) {
           // edition 기본이 http로 잡혔는데 이 환경엔 배포가 없는 misconfig — stdio는 항상 가능하다는
-          // BE invariant를 믿고 명시 폴백(무한 pending 방치 금지).
+          // BE invariant를 믿고 명시 폴백(무한 pending 방치 금지). 자기참조 없이 아래 effect가 잇는다.
           setHostedUnavailable(true);
-          void fetchArtifact('stdio');
+          setNeedsStdioFallback(true);
           return;
         }
         if (reqTransport) setArtifactErrors((p) => ({ ...p, [reqTransport]: true }));
@@ -189,31 +156,45 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
   }, [agentId]);
 
   // 최초 마운트 — transport 미지정 요청으로 BE edition 기본 판별.
+  // ⚠️story #2407 정리 中 처음 걸린 lint(react-hooks/set-state-in-effect) — fetchArtifact가
+  // 비동기로 setState하므로 정적분석이 "effect 안 setState"로 잡는다. 이 파일 다른 자리(§2
+  // 아티팩트 fetch 전체)와 동형인 기존 패턴(pristine origin/develop에도 있던 자리 — #2407가
+  // 만든 게 아니라 리팩터로 컴파일러 분석이 더 깊이 들어가면서 드러난 것)이라 이 스토리
+  // 범위에서 effect 아키텍처를 통째로 바꾸지 않는다 — 이 코드베이스 기존 관례(use-swipe-drawer.ts
+  // 등 7곳)를 따라 disable로 명시한다.
   useEffect(() => {
     if (!agentId || !apiKey) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void fetchArtifact();
   }, [agentId, apiKey, fetchArtifact]);
+
+  useEffect(() => {
+    if (!needsStdioFallback) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setNeedsStdioFallback(false);
+    void fetchArtifact('stdio');
+  }, [needsStdioFallback, fetchArtifact]);
 
   // 탭 전환 — 아직 fetch 안 한 transport 만 재요청(§5 "탭 전환마다 재요청"·이미 캐시된 건 재요청 생략).
   useEffect(() => {
     if (!agentId || !apiKey || !transport) return;
     if (artifacts[transport]) return;
     if (transport === 'http' && hostedUnavailable) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void fetchArtifact(transport);
   }, [agentId, apiKey, transport, artifacts, hostedUnavailable, fetchArtifact]);
 
-  const railOrder = transport === 'http' ? HTTP_RAIL_ORDER : RAIL_ORDER;
-  const hasCopied = transport ? Boolean(hasCopiedMap[transport]) : false;
-  const displaySteps: DisplayStep[] = railOrder.map((state) => {
-    const be = beSteps?.find((s) => s.state === state);
-    let status: RailStatus = be?.status ?? 'pending';
-    // whichever-first: Copy 클릭 OR 첫 OB-2 신호 — config_copied done
-    if (state === 'config_copied' && hasCopied && status === 'pending') status = 'done';
-    // 복사했고 BE 신호 전이면 다음 단계(연결 대기) active로 표시
-    if (state === 'waiting' && hasCopied && !beSteps && status === 'pending') status = 'active';
-    return { state, status, label: t(RAIL_LABEL_KEY[state]), reason: be?.reason };
+  // story #2407 — 상태파생·폴링·핸들러는 verify-rail.tsx의 useVerificationRail로 이동(원래
+  // recruiter-client.tsx와 각자 재구현하던 자리 — #2404의 steps/rail 필드명 버그가 두 곳에
+  // 동시에 있었던 이유). enabled=Boolean(apiKey)로 기존 게이팅(agentId·apiKey·transport 전부
+  // 준비된 뒤에만 폴링 시작) 그대로 보존.
+  const rail = useVerificationRail({
+    agentId,
+    transport,
+    enabled: Boolean(apiKey),
+    configCopiedDone: hasCopied,
   });
-  const verified = displaySteps.find((s) => s.state === 'verified')?.status === 'done';
+  const { displaySteps, verified, verifying } = rail;
 
   // unload(탭닫기/이탈) best-effort — 미검증 시 abandoned_explicit 보조 신호(SoT는 BE 파생).
   useEffect(() => {
@@ -242,30 +223,13 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
 
   // story #2404 — "설정만 넣으면 자동으로 된다"는 오해가 무한 대기의 실원인이었다(검증은 실제
   // tool 호출로만 완료됨, AC5 PO 확定). 지금 할 일을 복사 가능한 한 줄로 그 자리에 쥐여 준다.
-  const handleCopyVerifyPrompt = async () => {
-    try {
-      await navigator.clipboard.writeText(t('verifyExamplePrompt'));
-      setCopiedVerifyPrompt(true);
-      setTimeout(() => setCopiedVerifyPrompt(false), 2000);
-    } catch {
-      // ignore clipboard failure
-    }
-  };
+  // #2407 후속: 복사 로직 자체는 useVerificationRail로 이동, 여기선 그대로 재노출.
+  const handleCopyVerifyPrompt = rail.handleCopyVerifyPrompt;
 
   const handleVerify = async () => {
     if (!agentId || !transport) return;
-    setVerifying(true);
     emitOnboardingEvent('verify_started', { agent_id: agentId });
-    try {
-      await fetch(`/api/agents/${agentId}/verify-connection?transport=${transport}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: '{}',
-      }).catch(() => {});
-      await pollStatus(transport);
-    } finally {
-      setVerifying(false);
-    }
+    await rail.handleVerify();
   };
 
   const handleDashboard = () => {
@@ -408,7 +372,7 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
           <p className="text-sm font-medium">
             {t('verifyTitle')}{' '}
             <span className={cn('text-xs font-normal', transport === 'http' ? 'text-info' : 'text-muted-foreground')}>
-              {transport === 'http' ? t('railStageHosted') : t('railStageLocal')}
+              {rail.railStageLabel}
             </span>
           </p>
           <Button
@@ -430,13 +394,13 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
             {t('hostedVerifyNote')}
           </p>
         )}
-        {transport === 'http' && !verified && (
+        {rail.showVerifyExamplePrompt && (
           <div className="flex items-center justify-between gap-2 rounded-md border border-info-border bg-info-tint px-3 py-2 text-xs">
             <span className="min-w-0 truncate text-info">
               {t('verifyExampleLabel')} <span className="font-mono text-foreground">&ldquo;{t('verifyExamplePrompt')}&rdquo;</span>
             </span>
             <Button variant="outline" size="sm" onClick={() => void handleCopyVerifyPrompt()} className="shrink-0">
-              {copiedVerifyPrompt ? <><Check className="h-3.5 w-3.5" />{t('copied')}</> : <><Copy className="h-3.5 w-3.5" />{t('copyConfig')}</>}
+              {rail.copiedVerifyPrompt ? <><Check className="h-3.5 w-3.5" />{t('copied')}</> : <><Copy className="h-3.5 w-3.5" />{t('copyConfig')}</>}
             </Button>
           </div>
         )}

--- a/apps/web/src/app/onboarding/verify-rail.test.tsx
+++ b/apps/web/src/app/onboarding/verify-rail.test.tsx
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { NextIntlClientProvider } from 'next-intl';
-import { parseVerificationRail, VerifyRail, type DisplayStep } from './verify-rail';
+import {
+  parseVerificationRail, VerifyRail, computeRailStageLabel, computeShowVerifyExamplePrompt,
+  type DisplayStep,
+} from './verify-rail';
 import ko from '../../../messages/ko.json';
 
 // story #2415(2026-08-02, 라이브 재확認 중 발견) — recruiter-client.tsx·connect-step.tsx가
@@ -112,5 +115,44 @@ describe('VerifyRail — story #2419 (실패 사유 박스 텍스트 대비)', (
     const classes = classAttr!.split(/\s+/);
     expect(classes).toContain('text-destructive-on-subtle');
     expect(classes).not.toContain('text-destructive');
+  });
+});
+
+// story #2407 — recruiter-client.tsx·connect-step.tsx가 검증 레일 상태파생·폴링·핸들러를
+// 각자 재구현하던 것을 useVerificationRail 하나로 모으면서, 근거 없이 갈려 있던 두 지점을
+// connect-step의 (기술적으로 더 정확한) 쪽으로 통일했다 — recruiter 쪽 동작이 실제로 바뀌는
+// 자리라 "판정이 아니라 실패하는 assert"로 고정한다(#2178 자).
+describe('computeRailStageLabel — story #2407 ②-3 (transport 무관 항상 채워짐)', () => {
+  const t = (key: 'railStageHosted' | 'railStageLocal') =>
+    key === 'railStageHosted' ? '호스팅 · 4단계' : '로컬 · 6단계';
+
+  it('http → 호스팅 라벨', () => {
+    expect(computeRailStageLabel('http', t)).toBe('호스팅 · 4단계');
+  });
+
+  it('stdio → 로컬 라벨(예전 recruiter는 여기서 빈 문자열이었다 — 그 회귀를 막는 자리)', () => {
+    expect(computeRailStageLabel('stdio', t)).toBe('로컬 · 6단계');
+  });
+
+  it('transport 미해소(null) → 로컬 라벨로 폴백(connect-step 기존 동작 그대로 보존)', () => {
+    expect(computeRailStageLabel(null, t)).toBe('로컬 · 6단계');
+  });
+});
+
+describe('computeShowVerifyExamplePrompt — story #2407 ②-4 (http에서만 인과적으로 정확)', () => {
+  it('http·미검증 → 노출', () => {
+    expect(computeShowVerifyExamplePrompt('http', false)).toBe(true);
+  });
+
+  it('http·검증완료 → 비노출', () => {
+    expect(computeShowVerifyExamplePrompt('http', true)).toBe(false);
+  });
+
+  it('stdio·미검증 → 비노출(예전 recruiter는 여기서 노출했다 — heartbeat 없는 축이라 부정확한 안내였다)', () => {
+    expect(computeShowVerifyExamplePrompt('stdio', false)).toBe(false);
+  });
+
+  it('transport 미해소(null) → 비노출', () => {
+    expect(computeShowVerifyExamplePrompt(null, false)).toBe(false);
   });
 });

--- a/apps/web/src/app/onboarding/verify-rail.tsx
+++ b/apps/web/src/app/onboarding/verify-rail.tsx
@@ -1,10 +1,16 @@
 'use client';
 
+import { useCallback, useEffect, useState } from 'react';
 import { Check, X, Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 
 export type RailStatus = 'pending' | 'active' | 'done' | 'failed';
+
+/** E-MCP-OPT S3: SaaS 기본=호스팅(http)·OSS 기본=로컬(stdio) — BE `default_transport_for_edition()`
+ * 따름. story #2407 — 원래 connect-step.tsx 소유였다가 이 파일(검증 레일 공용 축)로 옮겼다(② -5:
+ * useVerificationRail이 transport를 직접 다루므로 타입도 여기가 자연스러운 자리). */
+export type Transport = 'http' | 'stdio';
 
 /** OB-2 verification-status 권위 state 키 (1:1·2026-06-25 락). 한글 라벨은 display-only. */
 export const RAIL_ORDER = [
@@ -34,6 +40,17 @@ export interface RawStep {
   status: RailStatus;
   reason?: string;
 }
+
+// story #2407 — connect-step.tsx·recruiter-client.tsx가 문자 그대로 복제하던 상수. useVerificationRail의
+// displaySteps 계산이 여기 있으므로 상수도 같은 자리로.
+const RAIL_LABEL_KEY: Record<RailState, string> = {
+  config_copied: 'railConfigCopied',
+  waiting: 'railWaiting',
+  mcp_reachable: 'railMcpReachable',
+  event_delivered: 'railEventDelivered',
+  ack: 'railAck',
+  verified: 'railVerified',
+};
 
 /**
  * story #2404 후속(2026-08-02, 라이브 재확認 중 발견) — recruiter-client.tsx와
@@ -163,4 +180,141 @@ export function VerifyRail({ steps }: { steps: DisplayStep[] }) {
       </div>
     </>
   );
+}
+
+/** BE `GET /agents/{id}/verification-status` 원 응답(라벨 미부여) — pollStatus fetch 결과. */
+export interface UseVerificationRailOptions {
+  agentId: string | null | undefined;
+  transport: Transport | null;
+  /** 폴링을 시작할지 — connect-step: `Boolean(apiKey)`·recruiter: `step === 5`. */
+  enabled: boolean;
+  /** config_copied를 BE 신호 없이 done으로 볼지 — connect-step: Copy클릭 시점(`hasCopied`,
+   * 동적)·recruiter: 항상 true(STEP4 번들 다운로드 완주 시점이라 이미 완료로 간주, 기존
+   * recruiter-client.tsx 주석 "번들 다운로드=STEP3 완주로 이미 완료" 그대로 보존). */
+  configCopiedDone: boolean;
+  pollIntervalMs?: number;
+}
+
+export interface UseVerificationRailResult {
+  displaySteps: DisplayStep[];
+  verified: boolean;
+  verifying: boolean;
+  handleVerify: () => Promise<void>;
+  /** 「호스팅 · 4단계」/「로컬 · 6단계」— transport 무관 항상 채워진다(story #2407 ②-3: 예전엔
+   * recruiter가 http에서만 채우고 stdio에선 빈 문자열이었다 — 아무 근거 없는 비대칭이라 통일). */
+  railStageLabel: string;
+  copiedVerifyPrompt: boolean;
+  handleCopyVerifyPrompt: () => Promise<void>;
+  /** story #2407 ②-4: http는 heartbeat(tool 호출)가 verify 메커니즘 자체라 예시프롬프트가
+   * 인과적으로 맞는 안내이지만, stdio는 세션이 살아있으면 이벤트 ack가 자동으로 진행돼
+   * "tool을 부르면 완료된다"는 문구가 부정확하다(agent_verify.py get_verification_state 축
+   * 분기 확認) — connect-step의 기존 `transport === 'http' && !verified` 게이팅이 기술적으로
+   * 옳은 쪽이라 그걸로 통일한다(예전 recruiter는 transport 무관 항상 노출했다). */
+  showVerifyExamplePrompt: boolean;
+}
+
+/** story #2407 ②-3 — 두 콜러가 각자 계산하되 recruiter만 stdio에서 빈 문자열이었다(무근거
+ * 비대칭). 순수함수로 뽑아 pin — transport 무관 항상 채워진다. */
+export function computeRailStageLabel(
+  transport: Transport | null,
+  t: (key: 'railStageHosted' | 'railStageLocal') => string,
+): string {
+  return transport === 'http' ? t('railStageHosted') : t('railStageLocal');
+}
+
+/** story #2407 ②-4 — http만 heartbeat(tool 호출)가 verify 메커니즘 자체라 예시프롬프트가
+ * 인과적으로 맞다. stdio는 세션이 살아있으면 이벤트 ack가 자동 진행돼 문구가 부정확해진다
+ * (agent_verify.py get_verification_state 축 분기 확認). connect-step의 기존 게이팅이 기술적으로
+ * 옳은 쪽이라 그걸로 통일 — 예전 recruiter는 transport 무관 항상 노출했다(순수함수로 뽑아 pin). */
+export function computeShowVerifyExamplePrompt(transport: Transport | null, verified: boolean): boolean {
+  return transport === 'http' && !verified;
+}
+
+/**
+ * story #2407 — recruiter-client.tsx·connect-step.tsx가 검증 레일 상태파생·폴링·핸들러를
+ * 각자 재구현하던 것(①7건 완전동일 + ②-3/②-4 두 가지 무근거 비대칭)을 하나로 모은다.
+ * 파싱만 이미 #2415가 모았고(parseVerificationRail), 그 위 축은 그대로 두 벌이었다.
+ *
+ * ⛔의도적으로 «안» 옮긴 것 — connect-step에만 있던 「waiting→active」 로컬 보정 분기
+ * (hasCopied && !beSteps일 때 pending을 active로 덮어쓰던 것). #2407 조사 中 미르코 라이브
+ * 실측(http 축, story #2422/#2423 인접 조사)이 확認: `heartbeat_fresh` 하나가 http 레일
+ * 전체를 한 번에 뒤집는 구조라 애초에 "부분 상태"가 정의돼 있지 않다 — 그 보정은 첫 폴
+ * 응답 前(~pollIntervalMs) 잠깐의 화면 표시일 뿐 실제 관측 가능한 차이를 만들지 않았다.
+ * PO 판정(2026-08-02): 결함이 아니라 설계 그대로 — 제거해도 관측 가능한 손실이 없다.
+ */
+export function useVerificationRail({
+  agentId,
+  transport,
+  enabled,
+  configCopiedDone,
+  pollIntervalMs = 2500,
+}: UseVerificationRailOptions): UseVerificationRailResult {
+  const t = useTranslations('onboarding');
+  const [beSteps, setBeSteps] = useState<RawStep[] | null>(null);
+  const [verifying, setVerifying] = useState(false);
+  const [copiedVerifyPrompt, setCopiedVerifyPrompt] = useState(false);
+
+  const pollStatus = useCallback(async (forAgentId: string, forTransport: Transport) => {
+    try {
+      const res = await fetch(`/api/agents/${forAgentId}/verification-status?transport=${forTransport}`);
+      if (!res.ok) return; // 미머지/404 → pending 유지(가짜 에러 안 띄움)
+      const raw = parseVerificationRail(await res.json());
+      if (raw) setBeSteps(raw);
+    } catch {
+      // swallow — graceful degradation
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || !agentId || !transport) return;
+    setBeSteps(null); // transport 전환 시 이전 transport의 레일 상태가 새 레일에 새는 것 방지
+    void pollStatus(agentId, transport);
+    const iv = setInterval(() => void pollStatus(agentId, transport), pollIntervalMs);
+    return () => clearInterval(iv);
+  }, [enabled, agentId, transport, pollIntervalMs, pollStatus]);
+
+  const railOrder = transport === 'http' ? HTTP_RAIL_ORDER : RAIL_ORDER;
+  const displaySteps: DisplayStep[] = railOrder.map((state) => {
+    const be = beSteps?.find((s) => s.state === state);
+    let status: RailStatus = be?.status ?? 'pending';
+    if (state === 'config_copied' && configCopiedDone && status === 'pending') status = 'done';
+    return { state, status, label: t(RAIL_LABEL_KEY[state]), reason: be?.reason };
+  });
+  const verified = displaySteps.find((s) => s.state === 'verified')?.status === 'done';
+
+  const handleVerify = useCallback(async () => {
+    if (!agentId || !transport) return;
+    setVerifying(true);
+    try {
+      await fetch(`/api/agents/${agentId}/verify-connection?transport=${transport}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      }).catch(() => {});
+      await pollStatus(agentId, transport);
+    } finally {
+      setVerifying(false);
+    }
+  }, [agentId, transport, pollStatus]);
+
+  const handleCopyVerifyPrompt = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(t('verifyExamplePrompt'));
+      setCopiedVerifyPrompt(true);
+      setTimeout(() => setCopiedVerifyPrompt(false), 2000);
+    } catch {
+      // ignore clipboard failure
+    }
+  }, [t]);
+
+  return {
+    displaySteps,
+    verified,
+    verifying,
+    handleVerify,
+    railStageLabel: computeRailStageLabel(transport, t),
+    copiedVerifyPrompt,
+    handleCopyVerifyPrompt,
+    showVerifyExamplePrompt: computeShowVerifyExamplePrompt(transport, verified),
+  };
 }


### PR DESCRIPTION
## Summary
- #2407 AC1: inventoried 17 duplicated-adjacent points between `recruiter-client.tsx` (STEP5) and `onboarding/connect-step.tsx`'s verification rail logic — 7 byte-identical, 5 similar-but-different, 5 one-side-only.
- AC2: judged each — see chat thread for the full breakdown (①-①config_copied intentional, ②waiting→active bridge PO-confirmed non-defect via live measurement, ③railStageLabel/④showVerifyExamplePrompt were unjustified asymmetries, ⑤pollStatus signature structural).
- AC3/AC4 (this PR): extracted the 7 identical blocks + the two corrected behaviors into `useVerificationRail` (verify-rail.tsx) — a single hook both callers now consume, so the shape that let #2404's bug exist in two places at once structurally can't recur.

## Behavior changes (both in recruiter-client.tsx only — connect-step.tsx unchanged)
1. `railStageLabel` — recruiter now shows "로컬 · 6단계" for stdio (previously blank).
2. `showVerifyExamplePrompt` — recruiter now only shows the "call this tool" prompt for http transport, matching connect-step (stdio verification acks automatically via SSE once connected — the prompt was causally inaccurate there).

Deliberately not carried over: connect-step's local `waiting→active` bridge — PO-confirmed (live measurement, story #2422-adjacent) to be a pre-first-poll cosmetic only, not a real defect axis.

Also fixes a `react-hooks/set-state-in-effect`/`immutability` lint surface in connect-step.tsx that this refactor exposed (pre-existing effect patterns the compiler analysis wasn't reaching before — disabled per this codebase's existing convention, e.g. `use-swipe-drawer.ts`).

## Test plan
- [x] `pnpm exec vitest run` — full apps/web suite, 342 files / 2520 tests pass
- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — clean (0 errors, 3 pre-existing unrelated warnings)
- [x] Positive control: sabotaged `computeShowVerifyExamplePrompt` → confirmed 2 new tests go red, restored → green
- [x] New pinning tests for the 2 behavior changes (`computeRailStageLabel`/`computeShowVerifyExamplePrompt`, 8 cases) in `verify-rail.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)