### PR TITLE
fix(#2414, #2413 AC3): reject fully-blank standup content and blank titles

### DIFF
--- a/backend/app/schemas/retro.py
+++ b/backend/app/schemas/retro.py
@@ -7,9 +7,12 @@ from pydantic import BaseModel, ConfigDict, field_validator
 from app.schemas.validators import is_blank
 
 # story #2413 AC3(PO 지시, 2026-08-02) — "회고제목"처럼 이름이 비어 있는 회고를 만들 수 없게
-# 서버가 거부한다. 실측(dev, MCP list_retro_sessions): 6건 중 blank title 0건 — "회고제목"은
-# blank가 아니라 "지우지 않은 기본값"이라 이 가드로는 못 잡는다(별건, FE placeholder 축). 그래도
-# 앞으로의 진짜 빈 제목은 이 가드가 막는다.
+# 서버가 거부한다.
+# ⭐이 가드는 «관측된 결함 수정»이 아니라 «방어»다 — 실측(dev, MCP list_retro_sessions):
+# 6건 중 blank title 0건. 지금 고장난 것을 고친 게 아니라, 아직 비어 있는 구멍을 미리 막은 것.
+# ⛔이 가드가 «못 잡는» 것: 그 실측 문제의 원 사례("회고제목")는 blank가 아니라 "지우지 않은
+# 기본값"이다 — 값이 있으니 이 가드를 그냥 통과한다(별건, FE placeholder 축). 나중에 "가드가
+# 있는데 왜 회고제목이 그대로냐"고 묻는다면 이게 답이다.
 _BLANK_TITLE_MSG = "title은 비어 있을 수 없습니다"
 
 

--- a/backend/app/schemas/retro.py
+++ b/backend/app/schemas/retro.py
@@ -2,7 +2,15 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from app.schemas.validators import is_blank
+
+# story #2413 AC3(PO 지시, 2026-08-02) — "회고제목"처럼 이름이 비어 있는 회고를 만들 수 없게
+# 서버가 거부한다. 실측(dev, MCP list_retro_sessions): 6건 중 blank title 0건 — "회고제목"은
+# blank가 아니라 "지우지 않은 기본값"이라 이 가드로는 못 잡는다(별건, FE placeholder 축). 그래도
+# 앞으로의 진짜 빈 제목은 이 가드가 막는다.
+_BLANK_TITLE_MSG = "title은 비어 있을 수 없습니다"
 
 
 class CreateSession(BaseModel):
@@ -12,12 +20,30 @@ class CreateSession(BaseModel):
     sprint_id: uuid.UUID | None = None
     created_by: uuid.UUID | None = None
 
+    @field_validator("title")
+    @classmethod
+    def _reject_blank_title(cls, v: str) -> str:
+        if is_blank(v):
+            raise ValueError(_BLANK_TITLE_MSG)
+        return v
+
 
 class GetOrCreateBySprint(BaseModel):
     """story #2281 AC3ⓐ — sprint_id 기준 get-or-create. project_id는 안 받는다 —
     sprint 자체가 project를 이미 알아 caller가 넘긴 값과 어긋날 여지가 없다."""
     sprint_id: uuid.UUID
     title: str | None = None
+
+    @field_validator("title")
+    @classmethod
+    def _reject_blank_title(cls, v: str | None) -> str | None:
+        # None(생략)은 통과 — 라우터(get_or_create_session_by_sprint)가 `body.title or
+        # f"{sprint.title} 회고"`로 자동 제목을 붙인다. 예전엔 ""도 이 `or`로 조용히
+        # 자동제목이 됐지만, story #2413 AC3는 "명시적으로 보낸 빈 값"을 거부하라는
+        # 것이라 여기서 먼저 막는다(자동생성 경로는 None 생략일 때만).
+        if v is not None and is_blank(v):
+            raise ValueError(_BLANK_TITLE_MSG)
+        return v
 
 
 class ItemResponse(BaseModel):

--- a/backend/app/schemas/sprint.py
+++ b/backend/app/schemas/sprint.py
@@ -4,6 +4,11 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, computed_field, field_validator, model_validator
 from app.schemas.story import _validate_metric_definition
+from app.schemas.validators import is_blank
+
+# story #2413 AC3(PO 지시, 2026-08-02) — 제목이 빈 스프린트를 만들 수 없게 서버가 거부한다.
+# 실측(dev, MCP list_sprints): 16건 중 blank title 0건.
+_BLANK_TITLE_MSG = "title은 비어 있을 수 없습니다"
 
 # E-DG S26: sprint status contract. de-facto(planning|active|done)에 review(선택)·archived(terminal) 신설.
 # ⭐review 선택(active→done 직행 허용·active→review→done도 OK). hypothesis/epic _VALID_TRANSITIONS 패턴.
@@ -56,6 +61,13 @@ class SprintBase(BaseModel):
     def validate_metric_definition(cls, v: dict | None) -> dict | None:
         return _validate_metric_definition(v)
 
+    @field_validator("title")
+    @classmethod
+    def _reject_blank_title(cls, v: str) -> str:
+        if is_blank(v):
+            raise ValueError(_BLANK_TITLE_MSG)
+        return v
+
 
 class SprintCreate(SprintBase):
     project_id: uuid.UUID
@@ -84,6 +96,15 @@ class SprintUpdate(BaseModel):
     @classmethod
     def validate_metric_definition(cls, v: dict | None) -> dict | None:
         return _validate_metric_definition(v)
+
+    @field_validator("title")
+    @classmethod
+    def _reject_blank_title(cls, v: str | None) -> str | None:
+        # None(생략 또는 명시 null)은 통과 — update_sprint가 model_dump(exclude_unset=True)라
+        # 생략 필드는 애초에 안 건드린다. 명시적으로 ""를 보낸 경우만 거부(story #2413 AC3).
+        if v is not None and is_blank(v):
+            raise ValueError(_BLANK_TITLE_MSG)
+        return v
 
 
 class SprintResponse(SprintBase):

--- a/backend/app/schemas/sprint.py
+++ b/backend/app/schemas/sprint.py
@@ -7,7 +7,8 @@ from app.schemas.story import _validate_metric_definition
 from app.schemas.validators import is_blank
 
 # story #2413 AC3(PO 지시, 2026-08-02) — 제목이 빈 스프린트를 만들 수 없게 서버가 거부한다.
-# 실측(dev, MCP list_sprints): 16건 중 blank title 0건.
+# ⭐관측된 결함 수정이 아니라 방어다 — 실측(dev, MCP list_sprints): 16건 중 blank title 0건.
+# 지금 고장난 것을 고친 게 아니라, 아직 빈 구멍을 미리 막은 것(#2413 retro.py 쪽 동형 주석 참고).
 _BLANK_TITLE_MSG = "title은 비어 있을 수 없습니다"
 
 # E-DG S26: sprint status contract. de-facto(planning|active|done)에 review(선택)·archived(terminal) 신설.

--- a/backend/app/schemas/standup.py
+++ b/backend/app/schemas/standup.py
@@ -1,7 +1,9 @@
 import uuid
 from datetime import date, datetime
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from app.schemas.validators import reject_if_all_blank
 
 REVIEW_TYPES = ("comment", "approve", "request_changes")
 
@@ -19,6 +21,14 @@ class StandupUpsert(BaseModel):
     blockers: str | None = None
     plan_story_ids: list[uuid.UUID] = []
 
+    # story #2414(PO 지시, 2026-08-02) — 세 칸이 전부 빈 스탠드업이 저장돼 있었다(실측
+    # 2건). done만 빈 것(오늘 시작한 사람)은 정상이라 막지 않는다 — 실측 122건 중 73건이
+    # 이 모양이라 그것까지 막으면 과잉차단이다. 셋 다 빌 때만 거부.
+    @model_validator(mode="after")
+    def _reject_all_blank_content(self) -> "StandupUpsert":
+        reject_if_all_blank(done=self.done, plan=self.plan, blockers=self.blockers)
+        return self
+
 
 class StandupSelfUpdate(BaseModel):
     """self-save(PUT) 전용 — author_id는 서버가 인증 유저(resolve_member)에서 도출.
@@ -33,6 +43,12 @@ class StandupSelfUpdate(BaseModel):
     plan: str | None = None
     blockers: str | None = None
     plan_story_ids: list[uuid.UUID] = []
+
+    # story #2414 — POST(StandupUpsert)와 동일 규칙, PUT도 같은 결함을 낼 수 있어 동형 적용.
+    @model_validator(mode="after")
+    def _reject_all_blank_content(self) -> "StandupSelfUpdate":
+        reject_if_all_blank(done=self.done, plan=self.plan, blockers=self.blockers)
+        return self
 
 
 class StandupEntryResponse(BaseModel):

--- a/backend/app/schemas/validators.py
+++ b/backend/app/schemas/validators.py
@@ -1,0 +1,19 @@
+"""공용 스키마 검증 헬퍼.
+
+story #2414 + #2413 AC3(PO 지시, 2026-08-02) — "빈 값"의 정의를 한 곳에 둔다. ""·공백만·
+개행만·None 넷 다 blank로 본다. 이 판정이 엔드포인트마다 갈리면 한쪽은 막고 한쪽은 통과하는
+재발 축이 된다(#2410 당일 EXEMPT 누적과 같은 뿌리 — 무엇을 재는지가 갈리면 가드가 무뎌진다).
+"""
+
+
+def is_blank(value: str | None) -> bool:
+    return value is None or value.strip() == ""
+
+
+def reject_if_all_blank(**fields: str | None) -> None:
+    """story #2414 — 셋(또는 그 이상) 칸이 «전부» 다 blank일 때만 거부. 하나라도 채워지면
+    통과(예: done만 빈 것은 오늘 시작한 사람의 정상 상태 — 실측 73/122건이 이 모양이었다).
+    호출부가 필드명=값으로 넘기면 메시지에 그 필드명을 그대로 쓴다."""
+    if all(is_blank(v) for v in fields.values()):
+        names = "·".join(fields.keys())
+        raise ValueError(f"{names} 중 최소 하나는 채워야 합니다")

--- a/backend/tests/test_2414_2413ac3_blank_content_reject.py
+++ b/backend/tests/test_2414_2413ac3_blank_content_reject.py
@@ -1,0 +1,249 @@
+"""story #2414 + #2413 AC3(PO 지시, 2026-08-02) — "빈 값" 판정을 서버가 거부하는지 고정한다.
+
+#2414: 스탠드업 done·plan·blockers가 «전부» 빈 경우만 거부(한두 칸만 빈 것은 정상 — 실측
+122건 중 73건이 "done만 빔" 모양이었다. 이걸 막으면 과잉차단이다).
+#2413 AC3: 회고 세션·스프린트 title이 빈 경우 거부.
+
+공용 축(is_blank/reject_if_all_blank, app/schemas/validators.py) — ""·공백만·"\n"만·None
+넷 다 blank로 본다. 이 정의가 갈리면 한쪽은 막고 한쪽은 통과하는 재발 축이 된다.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date as _date
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from pydantic import ValidationError
+
+from app.schemas.validators import is_blank, reject_if_all_blank
+
+
+# ─── 공용 blank 판정 축 ───────────────────────────────────────────────────────
+
+class TestIsBlank:
+    @pytest.mark.parametrize("value", [None, "", "   ", "\n", "\n\t "])
+    def test_blank_values(self, value):
+        assert is_blank(value) is True
+
+    @pytest.mark.parametrize("value", ["a", " a ", "\n일함\n", "0"])
+    def test_non_blank_values(self, value):
+        assert is_blank(value) is False
+
+
+class TestRejectIfAllBlank:
+    def test_all_blank_raises_with_actionable_message(self):
+        with pytest.raises(ValueError, match="done·plan·blockers 중 최소 하나는 채워야 합니다"):
+            reject_if_all_blank(done=None, plan="", blockers="   ")
+
+    def test_one_filled_passes(self):
+        reject_if_all_blank(done="did stuff", plan=None, blockers="")  # no raise
+
+    def test_all_filled_passes(self):
+        reject_if_all_blank(done="d", plan="p", blockers="b")  # no raise
+
+
+# ─── #2414: StandupUpsert/StandupSelfUpdate ─────────────────────────────────
+
+class TestStandupBlankReject:
+    def test_all_three_blank_rejected(self):
+        from app.schemas.standup import StandupUpsert
+        with pytest.raises(ValidationError, match="done·plan·blockers 중 최소 하나는 채워야 합니다"):
+            StandupUpsert(author_id=uuid.uuid4(), date=_date(2026, 8, 2))
+
+    def test_all_three_whitespace_only_rejected(self):
+        # story #2414 공용축 — ""뿐 아니라 공백/개행만 있는 것도 blank.
+        from app.schemas.standup import StandupUpsert
+        with pytest.raises(ValidationError):
+            StandupUpsert(
+                author_id=uuid.uuid4(), date=_date(2026, 8, 2),
+                done=" ", plan="\n", blockers="   \n  ",
+            )
+
+    def test_done_only_filled_passes(self):
+        # ⭐음성대조 — 실측 122건 중 73건이 이 모양(오늘 시작한 사람, done만 빔이 아니라
+        # plan/blockers만 빔인 경우도 포함해 "한두 칸만 빈 것"은 전부 정상 취급돼야 한다).
+        from app.schemas.standup import StandupUpsert
+        u = StandupUpsert(author_id=uuid.uuid4(), date=_date(2026, 8, 2), done="어제 한 일")
+        assert u.done == "어제 한 일"
+
+    def test_normal_standup_passes(self):
+        from app.schemas.standup import StandupUpsert
+        u = StandupUpsert(
+            author_id=uuid.uuid4(), date=_date(2026, 8, 2),
+            done="a", plan="b", blockers="c",
+        )
+        assert (u.done, u.plan, u.blockers) == ("a", "b", "c")
+
+    def test_self_update_same_rule(self):
+        from app.schemas.standup import StandupSelfUpdate
+        with pytest.raises(ValidationError):
+            StandupSelfUpdate(date=_date(2026, 8, 2))
+        s = StandupSelfUpdate(date=_date(2026, 8, 2), blockers="막힘")
+        assert s.blockers == "막힘"
+
+
+# ─── #2413 AC3: 회고 세션 title ──────────────────────────────────────────────
+
+class TestRetroTitleBlankReject:
+    def test_create_session_blank_title_rejected(self):
+        from app.schemas.retro import CreateSession
+        with pytest.raises(ValidationError, match="title은 비어 있을 수 없습니다"):
+            CreateSession(project_id=uuid.uuid4(), org_id=uuid.uuid4(), title="")
+
+    def test_create_session_whitespace_title_rejected(self):
+        from app.schemas.retro import CreateSession
+        with pytest.raises(ValidationError):
+            CreateSession(project_id=uuid.uuid4(), org_id=uuid.uuid4(), title="   ")
+
+    def test_create_session_real_title_passes(self):
+        from app.schemas.retro import CreateSession
+        s = CreateSession(project_id=uuid.uuid4(), org_id=uuid.uuid4(), title="Sprint 14 회고")
+        assert s.title == "Sprint 14 회고"
+
+    def test_get_or_create_by_sprint_omitted_title_passes(self):
+        # None(생략) = 라우터가 자동 제목을 붙이는 경로 — 이 가드가 막지 않는다.
+        from app.schemas.retro import GetOrCreateBySprint
+        g = GetOrCreateBySprint(sprint_id=uuid.uuid4())
+        assert g.title is None
+
+    def test_get_or_create_by_sprint_explicit_blank_rejected(self):
+        from app.schemas.retro import GetOrCreateBySprint
+        with pytest.raises(ValidationError):
+            GetOrCreateBySprint(sprint_id=uuid.uuid4(), title="")
+
+    def test_get_or_create_by_sprint_real_title_passes(self):
+        from app.schemas.retro import GetOrCreateBySprint
+        g = GetOrCreateBySprint(sprint_id=uuid.uuid4(), title="수동 제목")
+        assert g.title == "수동 제목"
+
+
+# ─── #2413 AC3: 스프린트 title ───────────────────────────────────────────────
+
+class TestSprintTitleBlankReject:
+    def test_sprint_create_blank_title_rejected(self):
+        from app.schemas.sprint import SprintCreate
+        with pytest.raises(ValidationError, match="title은 비어 있을 수 없습니다"):
+            SprintCreate(project_id=uuid.uuid4(), org_id=uuid.uuid4(), title="")
+
+    def test_sprint_create_whitespace_title_rejected(self):
+        from app.schemas.sprint import SprintCreate
+        with pytest.raises(ValidationError):
+            SprintCreate(project_id=uuid.uuid4(), org_id=uuid.uuid4(), title="\n")
+
+    def test_sprint_create_real_title_passes(self):
+        from app.schemas.sprint import SprintCreate
+        s = SprintCreate(project_id=uuid.uuid4(), org_id=uuid.uuid4(), title="Sprint 14")
+        assert s.title == "Sprint 14"
+
+    def test_sprint_update_omitted_title_passes(self):
+        from app.schemas.sprint import SprintUpdate
+        u = SprintUpdate(velocity=10)
+        assert u.title is None
+
+    def test_sprint_update_explicit_blank_rejected(self):
+        from app.schemas.sprint import SprintUpdate
+        with pytest.raises(ValidationError):
+            SprintUpdate(title="   ")
+
+    def test_sprint_update_real_title_passes(self):
+        from app.schemas.sprint import SprintUpdate
+        u = SprintUpdate(title="새 제목")
+        assert u.title == "새 제목"
+
+
+# ─── #2414 AC4: HTTP 레벨 검산 — 422를 실제로 받는지, 정상 값은 그대로 저장되는지 ──────────
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+AUTHOR_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _standup_client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(AUTHOR_ID)
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), app
+
+
+@pytest.mark.anyio
+async def test_post_standup_all_blank_returns_422_with_actionable_message():
+    client, app = await _standup_client()
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/standups", json={
+                "project_id": str(PROJECT_ID),
+                "org_id": str(ORG_ID),
+                "author_id": str(AUTHOR_ID),
+                "date": "2026-08-02",
+                # ⛔done/plan/blockers 전부 생략(=None) — story #2414의 실측 결함 그대로 재현.
+            })
+        assert resp.status_code == 422
+        assert "done·plan·blockers 중 최소 하나는 채워야 합니다" in resp.text
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_post_standup_normal_content_still_saves():
+    """⭐양성대조 — 막는 규칙이 정상 값까지 잡아먹지 않는지(AC4)."""
+    from app.services.member_resolver import ResolvedMember
+    from unittest.mock import patch
+    from datetime import date, datetime, timezone
+
+    client, app = await _standup_client()
+    try:
+        entry = MagicMock()
+        entry.id = uuid.uuid4()
+        entry.org_id = ORG_ID
+        entry.project_id = PROJECT_ID
+        entry.sprint_id = None
+        entry.author_id = AUTHOR_ID
+        entry.date = date(2026, 8, 2)
+        entry.done = "어제 한 일"
+        entry.plan = None
+        entry.blockers = None
+        entry.plan_story_ids = []
+        entry.created_at = datetime(2026, 8, 2, tzinfo=timezone.utc)
+        entry.updated_at = datetime(2026, 8, 2, tzinfo=timezone.utc)
+        member = ResolvedMember(
+            id=AUTHOR_ID, user_id=AUTHOR_ID, name="h", type="human", role="member", org_id=ORG_ID,
+        )
+        with patch("app.repositories.standup.StandupEntryRepository.upsert", new_callable=AsyncMock) as mock_upsert, \
+             patch("app.routers.standups.resolve_member", new=AsyncMock(return_value=member)):
+            mock_upsert.return_value = entry
+            async with client as c:
+                resp = await c.post("/api/v2/standups", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "author_id": str(AUTHOR_ID),
+                    "date": "2026-08-02",
+                    "done": "어제 한 일",  # done만 채움 — 73/122건이 이 모양이었다(정상).
+                })
+        assert resp.status_code == 201
+        assert resp.json()["done"] == "어제 한 일"
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_standup_org_write_1c2be9db.py
+++ b/backend/tests/test_standup_org_write_1c2be9db.py
@@ -24,10 +24,12 @@ def anyio_backend():
 def test_schema_project_id_optional():
     from app.schemas.standup import StandupSelfUpdate, StandupUpsert
 
-    # project_id 생략해도 검증 통과(org-level)
-    u = StandupUpsert(author_id=uuid.uuid4(), date=_date(2026, 6, 5))
+    # project_id 생략해도 검증 통과(org-level). story #2414 후속 — done/plan/blockers 전부
+    # 빈 것은 이제 별개 사유(전부 blank)로 거부되므로, 이 테스트가 재는 축(project_id
+    # optionality)과 안 섞이게 done 하나는 채운다.
+    u = StandupUpsert(author_id=uuid.uuid4(), date=_date(2026, 6, 5), done="did stuff")
     assert u.project_id is None
-    s = StandupSelfUpdate(date=_date(2026, 6, 5))
+    s = StandupSelfUpdate(date=_date(2026, 6, 5), done="did stuff")
     assert s.project_id is None
 
 


### PR DESCRIPTION
## Summary
- **#2414**: `POST`/`PUT /api/v2/standups` now reject when `done`/`plan`/`blockers` are ALL blank. This fixes an **observed defect** — real dev data had 2 such rows (all-three-blank, same author, two consecutive days). A single filled field still passes — 73/122 real rows are "done only" (day-1 normal), blocking those would be over-blocking (explicitly measured and excluded per AC2).
- **#2413 AC3**: retro session (`POST /api/v2/retro-sessions`, `POST .../by-sprint`) and sprint (`POST`/`PATCH /api/v2/sprints`) title now reject blank.
- Shared `is_blank()` (`app/schemas/validators.py`) — `""` / whitespace-only / `"\n"`-only / `None` all count as blank, used by both stories so the definition can't drift between endpoints.
- Error messages are actionable (422): `"done·plan·blockers 중 최소 하나는 채워야 합니다"` / `"title은 비어 있을 수 없습니다"`.
- Does not touch or delete existing blank rows — both stories explicitly scope this to count-then-decide-separately.

## #2413 AC3 is prevention, not a fix — read this before assuming what changed
Counted live via MCP (`list_retro_sessions`/`list_sprints`, same methodology as #2413's own description) **before** writing the guard: **0 blank titles in either table today** (retro: 6/6 non-blank, sprint: 16/16 non-blank). So unlike #2414 (which closes an already-observed defect), the retro/sprint half of this PR is a **defense against a future occurrence** — nothing was broken and got fixed here; a hole that could produce breakage later got closed while it was still empty.

**What this guard does NOT catch**: the story's own motivating example — a retro session titled literally `"회고제목"` (Korean for "retro title", i.e. an uncleared placeholder/test-leftover) — is **not blank** by any definition, so this guard passes it through untouched. That's a separate, FE-side "default value never got replaced" problem, out of scope here. If someone later asks "why does 회고제목 still exist, didn't we add a title guard?" — this is why: the guard blocks *empty*, not *meaningless-but-non-empty*. Left as material for #2413's own body per PO (not spun into a new story for now).

## Test plan
- [x] New `test_2414_2413ac3_blank_content_reject.py` (31 tests): unit-level for `is_blank`/`reject_if_all_blank`, schema-level for `StandupUpsert`/`StandupSelfUpdate`/`CreateSession`/`GetOrCreateBySprint`/`SprintCreate`/`SprintUpdate`, plus HTTP-level 422 + positive-control 201 (normal "done only" content still saves).
- [x] Positive control: sabotaged `reject_if_all_blank` → 4 tests correctly went red, restored → green.
- [x] Fixed one pre-existing test (`test_standup_org_write_1c2be9db.py::test_schema_project_id_optional`) that constructed a fully-blank standup as a fixture for an unrelated axis (project_id optionality) — added `done="did stuff"` so it doesn't collide with the new invariant.
- [x] Full backend suite: 4355 passed, 13 pre-existing failures confirmed unrelated (same failures reproduce on pristine `origin/develop` — local `.mcp.json`/realdb-dependent tests, not touched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
