### PR TITLE
fix(story #2412): standup order + MCP unknown-arg rejection

### DIFF
--- a/backend/app/repositories/standup.py
+++ b/backend/app/repositories/standup.py
@@ -60,6 +60,17 @@ class StandupEntryRepository(BaseRepository[StandupEntry]):
         org-level 엔트리(project_id NULL·링크로 surface)도 링크된 프로젝트 뷰에 나타난다.
         EXISTS 라 double-count 없음. legacy 엔트리는 0099 백필 링크로 동일 커버(연속성).
         project_id 외 필터(author_id·sprint_id·date)는 기존대로 컬럼 일치.
+
+        story #2412 AC1 — order_by 없이 limit만 있었다("최근"을 요구하면서 결정적 순서 보장이
+        없었다, #2231 표 CAPPED-NO-NEXT-PAGE와 동형). #2248이 `/standups/history`(list_standup_history,
+        routers/standups.py)를 raw 쿼리로 우회 고칠 때 "이 메서드는 list_standups(routers/standups.py:181)와
+        공유하는 범용이라 여기서 손 안 댄다"고 명시 — 그 남겨둔 쪽을 여기서 고친다. 이 리포에서
+        `.list()` 실호출처는 코드베이스 전체에 **routers/standups.py:181(list_standups) 1곳뿐**
+        (grep 확認 — routers/sprints.py의 StandupEntryRepository 사용은 `.get_missing()`만, `.list()`
+        미호출). 그 1곳이 FE `/api/standup` 화면 프록시 대상이자 MCP get_standup/list_standup_entries
+        도구가 공유하는 자리라, 여기 한 번 고치면 셋 다 같이 고쳐진다(다른 소비처가 없어 "한쪽만
+        고치는" 분기가 아예 없다). `date`(스탠드업 실제 날짜) 우선 정렬 — `created_at`(제출 시각)은
+        같은 date 내 동석차 tiebreak로만(제출 늦은 순이 아니라 날짜 자체가 최근인 게 먼저).
         """
         project_id = filters.pop("project_id", None)
         q = select(StandupEntry).where(self._org_filter())
@@ -72,6 +83,7 @@ class StandupEntryRepository(BaseRepository[StandupEntry]):
                     StandupEntryProject.project_id == project_id,
                 )
             )
+        q = q.order_by(StandupEntry.date.desc(), StandupEntry.created_at.desc())
         result = await self.session.execute(q.limit(limit))
         return list(result.scalars().all())
 

--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import exists, select
@@ -256,6 +256,7 @@ async def list_standup_history(
     project_id: uuid.UUID = Query(...),
     limit: int = Query(default=30, ge=1, le=200),
     cursor: str | None = Query(default=None),
+    days: int | None = Query(default=None, ge=1),
     repo: StandupEntryRepository = Depends(_get_repo),
     auth: AuthContext = Depends(get_current_user),
 ) -> dict:
@@ -267,9 +268,18 @@ async def list_standup_history(
     story #2248: 이 엔드포인트엔 원래 cursor도 order_by도 없었다(repo.list()가 정렬 없이 limit만
     적용) — "최근 N개"라면서 결정적 순서 보장이 없었다(#2231 표 CAPPED-NO-NEXT-PAGE, ㉯✗). #2231
     정본 규약 A(참조 구현: stories.py::list_comments/list_activities)로 도달 가능하게 한다.
-    repo.list()는 다른 호출부(list_standups, line 181)와 공유하는 범용 메서드라 여기서 손대지
-    않고, 이 엔드포인트만 raw 쿼리로 바이패스한다(project_id EXISTS join은 repo.list()와 동일 로직
-    재현 — 규약 재발명 없음, 필터 로직만 재현).
+    repo.list()는 다른 호출부(list_standups, line 181)와 공유하는 범용 메서드라 그때는 여기서
+    손대지 않고 이 엔드포인트만 raw 쿼리로 바이패스했다(project_id EXISTS join은 repo.list()와
+    동일 로직 재현 — 규약 재발명 없음, 필터 로직만 재현). ⚠️story #2412 AC1: 그 "손대지 않은"
+    repo.list() 쪽이 결국 진짜 화면(FE `/api/standup`, list_standups)의 미정렬 버그였다 —
+    repositories/standup.py::list()에 order_by(date desc, created_at desc)를 직접 추가해서 고쳤다
+    (이 엔드포인트의 cursor 페이지네이션과 무관 — 이쪽은 그대로 raw 쿼리 유지, 커서 시맨틱이 달라
+    repo.list()로 합칠 이유 없음).
+
+    story #2412 AC3: `days` 추가 — MCP standup_history 도구가 실제로는 존재하지도 않는 `days`
+    인자를 조용히 삼키던 것(AC2)의 후속. `date`(스탠드업 실제 날짜) 기준 "최근 N일"— `created_at`
+    (제출 시각)이 아니다: 늦게 제출된 옛날 날짜 스탠드업을 "최근"으로 잘못 포함시키지 않기 위함.
+    cursor와 결합 가능(둘 다 독립 필터 — days=기간 창, cursor/limit=페이지네이션).
     """
     # ratchet round5(잔여 HIGH): 동일 패턴(project_id 필터 미검증) — resource-actual 직접검증.
     if not await has_project_access(repo.session, uuid.UUID(auth.user_id), project_id, repo.org_id):
@@ -282,6 +292,11 @@ async def list_standup_history(
             StandupEntryProject.project_id == project_id,
         ),
     )
+    # #2540 CI 교훈(오르테가군)과 동일 패턴 — 이 함수를 FastAPI DI 없이 직접 호출하며 days= 를
+    # 누락하면 파이썬 기본값인 Query(...) 센티넬 객체(정수 아님·truthy) 가 그대로 들어온다.
+    # int가 아니면 필터 없음으로 취급(cursor의 isinstance(..., str) 가드와 동형).
+    if isinstance(days, int):
+        q = q.where(StandupEntry.date >= date.today() - timedelta(days=days - 1))
     # #2540 CI 교훈(오르테가군): "값이 있는지"만 보면 안 되고 "그 값이 문자열인지"까지 봐야
     # 한다 — 이 함수를 FastAPI DI 없이 직접 호출하며 cursor= 를 누락하면 파이썬 기본값인
     # Query(...) 센티넬 객체(truthy) 가 그대로 들어온다. 문자열이 아니면 커서 없음으로 취급.

--- a/backend/sprintable_mcp/schemas.py
+++ b/backend/sprintable_mcp/schemas.py
@@ -73,7 +73,16 @@ class SprintableInput(BaseModel):
     org-agent 멀티프로젝트 grant(ProjectAccess) 시 특정 프로젝트를 타겟(미지정=키 default project·무회귀).
     설정 시 client.project_id(쿼리/바디) + X-Project-Id 헤더에 반영(85429ee0).
     Optional 필드는 기본값 None → MCP schema required에서 제외.
+
+    story #2412 AC2: extra="ignore"→"forbid" — 미지정 인자(예: `days`)를 조용히 버리지 않고
+    ValidationError로 거부. ⚠️이것만으론 실제 MCP 호출 경로의 증상을 못 고친다 — 진짜 삼킴은
+    이보다 한 겹 앞, FastMCP 자체가 도구 함수 시그니처로 만드는 내부 arg_model(`mcp` SDK
+    `func_metadata.py`, extra 미지정이라 pydantic 기본값=ignore와 동일)에서 일어난다(`Tool.run()`
+    실측 확認 — `wrapper()`는 `days`를 아예 전달받지도 못했다). 진짜 fix는 server.py의
+    `_lock_down_extra_args`(등록 루프에서 그 arg_model을 forbid로 패치). 여기 SprintableInput
+    쪽은 defense-in-depth — `input_cls(**kwargs)`를 MCP 호출 경로 밖에서 직접 쓰는 코드(테스트 등)
+    까지 같이 잠근다.
     """
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="forbid")
     project_id: str | None = None

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -14,9 +14,10 @@ from mcp.server.transport_security import TransportSecuritySettings
 logger = logging.getLogger(__name__)
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.tools.base import Tool as _FastMCPTool
 from mcp.types import TextContent
 from mcp.types import Tool as MCPTool
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, model_validator
 from pydantic.fields import PydanticUndefined
 
 from .api_client import _api_key_override, client, reset_project_override, set_project_override
@@ -284,7 +285,85 @@ _transport_security = TransportSecuritySettings(
 # 스킵해 시맨틱을 명확히 하고 매 stdio list_tools 호출마다 불필요한 manifest 캐시 조회도 피한다.
 # fail-open(scope=None → 비파괴셋)은 call-time(_flat wrapper)과 동일 철학 — 백엔드가 최종 SSOT라 list는
 # degrade(더 보여줌)해도 call은 여전히 403 차단.
+def _lock_down_extra_args(tool: _FastMCPTool) -> None:
+    """story #2412 AC2 — 실제 삼킴 지점은 SprintableInput.extra 가 아니라 한 겹 앞이다.
+
+    FastMCP가 도구 함수 시그니처(_flat()의 wrapper.__signature__)로 만드는 내부
+    arg_model(mcp SDK `func_metadata.py`)은 extra 를 명시 안 해 pydantic 기본값(=ignore와
+    동일)을 쓴다 — `Tool.run()`으로 끝까지 태워 실측 확認: wrapper()는 미선언 인자(`days` 등)를
+    아예 전달받지도 못한다. 그래서 SprintableInput 쪽만 forbid 로 바꿔선 이 증상엔 무효과 —
+    여기(등록 시점, arg_model 자체)를 고쳐야 실제로 막힌다. 벤더 파일은 안 건드리고 등록 루프
+    한 곳(add_tool 오버라이드)에서 전 도구 동시 적용 — SprintableInput 상속이냐
+    BaseModel 직접상속(projects.py 2종)이냐 안 갈라도 된다.
+
+    거부 메시지에 accepted 인자 목록을 넣는다(올리베이라군 요청, #2412) — "unexpected
+    keyword"로 끝나면 부른 쪽이 다음에 뭘 보내야 할지 모른다.
+
+    ⚠️`fn_metadata`/`arg_model`은 mcp SDK 비공개급 내부라 버전업 결합 리스크가 있다 — 구조가
+    바뀌면 아래 assert가 등록 시점(서버 부팅)에 크게 터진다. 조용히 원복(=다시 전부 조용히
+    먹는 상태로 폴백)해 green을 대신 만드는 것을 막기 위함(선생님 실기기 정신병 제로 원칙과
+    동형 — 검증 없이 통과를 만들지 않는다).
+    """
+    assert hasattr(tool, "fn_metadata") and hasattr(tool.fn_metadata, "arg_model"), (
+        f"mcp SDK 내부구조 변경 감지 — Tool.fn_metadata.arg_model 없음(tool={tool.name}). "
+        "story #2412 AC2 lockdown이 더 이상 안 먹는다 — _lock_down_extra_args를 새 mcp 버전에 맞춰 다시 봐야 한다."
+    )
+    arg_model = tool.fn_metadata.arg_model
+    assert hasattr(arg_model, "model_fields") and hasattr(arg_model, "model_config"), (
+        f"mcp SDK 내부구조 변경 감지 — arg_model이 더 이상 pydantic BaseModel 형태가 아님(tool={tool.name})."
+    )
+
+    allowed = sorted(arg_model.model_fields)
+    tool_name = tool.name
+
+    def _reject_unknown(cls: type, data: object) -> object:
+        if isinstance(data, dict):
+            unknown = sorted(set(data) - set(allowed))
+            if unknown:
+                raise ValueError(
+                    f"{tool_name}: unexpected argument(s) {unknown} — accepted arguments: {allowed}"
+                )
+        return data
+
+    strict_arg_model = type(
+        arg_model.__name__,
+        (arg_model,),
+        {
+            "model_config": ConfigDict(extra="forbid"),
+            "_reject_unknown_args_2412": model_validator(mode="before")(classmethod(_reject_unknown)),
+            "__module__": arg_model.__module__,
+        },
+    )
+    tool.fn_metadata.arg_model = strict_arg_model
+
+
 class SprintableFastMCP(FastMCP):
+    def add_tool(
+        self,
+        fn,
+        name: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
+        annotations=None,
+        icons=None,
+        meta: dict | None = None,
+        structured_output: bool | None = None,
+    ) -> None:
+        super().add_tool(
+            fn,
+            name=name,
+            title=title,
+            description=description,
+            annotations=annotations,
+            icons=icons,
+            meta=meta,
+            structured_output=structured_output,
+        )
+        # FastMCP.add_tool()은 -> None(내부 ToolManager.add_tool()의 Tool 반환값을 버린다) —
+        # 등록된 Tool을 다시 얻으려면 매니저에서 name으로 조회해야 한다(name 미지정 시 fn.__name__로
+        # 귀결되는 FastMCP 자체 규약과 동일하게 재현).
+        _lock_down_extra_args(self._tool_manager.get_tool(name or fn.__name__))
+
     async def list_tools(self) -> list[MCPTool]:
         tools = await super().list_tools()
         if (settings.mcp_transport or "stdio").strip().lower() != "http":

--- a/backend/sprintable_mcp/tools/analytics.py
+++ b/backend/sprintable_mcp/tools/analytics.py
@@ -33,7 +33,10 @@ class GoalProgressInput(SprintableInput):
     # 계층 리네이밍 B1(story 1925): REST 호출 대상(/api/v2/analytics/epic-progress)은 B1 스코프
     # 밖(analytics 도메인 하위 엔드포인트, 별도 후속)이라 무변경 — tool/필드명만 신 용어.
     # deprecated 별칭(sprintable_get_epic_progress)도 이 스키마 재사용 — 구 필드명 epic_id 수용.
-    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+    # story #2412 AC2: extra="ignore"→"forbid" — populate_by_name=True(alias 수용)만 유지 목적으로
+    # override했던 자리라 extra는 base(SprintableInput)와 다시 맞춘다(subclass override는 base
+    # model_config를 병합이 아니라 대체하므로 여기서 안 맞추면 이 클래스만 계속 조용히 먹는다).
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
     goal_id: str = Field(validation_alias=AliasChoices("goal_id", "epic_id"))
 
 

--- a/backend/sprintable_mcp/tools/goals.py
+++ b/backend/sprintable_mcp/tools/goals.py
@@ -38,7 +38,10 @@ class AddGoalInput(SprintableInput):
 class UpdateGoalInput(SprintableInput):
     # ⚠️deprecated 별칭(sprintable_update_epic)도 같은 스키마 재사용 — 구 필드명 epic_id도
     # 계속 받아야 무중단(hierarchy-rename-alias-mechanism-design §1/§3 동형).
-    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+    # story #2412 AC2: extra="ignore"→"forbid" — populate_by_name=True(alias 수용)만 유지 목적으로
+    # override했던 자리라 extra는 base(SprintableInput)와 다시 맞춘다(subclass override는 base
+    # model_config를 병합이 아니라 대체하므로 여기서 안 맞추면 이 클래스만 계속 조용히 먹는다).
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
     goal_id: str = Field(validation_alias=AliasChoices("goal_id", "epic_id"))
     title: str | None = None
     status: GoalStatus | None = None

--- a/backend/sprintable_mcp/tools/projects.py
+++ b/backend/sprintable_mcp/tools/projects.py
@@ -10,7 +10,11 @@ from ..response import err, ok
 
 
 class ListProjectsInput(BaseModel):
-    model_config = ConfigDict(extra="ignore")
+    # story #2412 AC2: 이 파일 둘(ListProjectsInput·SetDefaultProjectInput)은 SprintableInput을
+    # 상속 안 해서(모듈 docstring 참조 — project_id 의미 충돌 회피) base의 extra="forbid" 변경이
+    # 자동으로 안 닿는다 — 여기서 손으로 맞춘다(안 맞추면 115개 중 이 둘만 계속 조용히 먹는
+    # 별도 병인이 된다).
+    model_config = ConfigDict(extra="forbid")
 
 
 async def list_projects(_args: ListProjectsInput) -> list:
@@ -24,7 +28,8 @@ async def list_projects(_args: ListProjectsInput) -> list:
 
 
 class SetDefaultProjectInput(BaseModel):
-    model_config = ConfigDict(extra="ignore")
+    # story #2412 AC2 — 위 ListProjectsInput과 동일 사유.
+    model_config = ConfigDict(extra="forbid")
     project_id: str
 
 

--- a/backend/sprintable_mcp/tools/standup.py
+++ b/backend/sprintable_mcp/tools/standup.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from mcp.types import TextContent
+from pydantic import Field
 
 from ..api_client import client
 from ..response import err, ok
@@ -17,8 +18,11 @@ class StandupHistoryInput(SprintableInput):
     # story #2412 AC3 — 예전엔 여기 없는 `days`를 보내도(SprintableInput.extra="ignore" +
     # FastMCP 내부 arg_model 둘 다 관대) 조용히 무시됐다(AC2 lockdown 후로는 애초에 미선언 인자가
     # 전부 거부되지만, "최근 N일"은 실제 수요라 진짜 필드로 만든다). BE `/standups/history`의
-    # date>=오늘-(days-1) 필터로 전달(제출 시각이 아니라 스탠드업 실제 날짜 기준).
-    days: int | None = None
+    # date>=오늘-(days-1) 필터로 전달(제출 시각이 아니라 스탠드업 실제 날짜 기준). ge=1 —
+    # BE(`Query(..., ge=1)`)와 경계를 맞춘다. 안 맞추면 days=0/음수가 MCP는 조용히 통과하고
+    # BE에서만 422로 막혀, 호출자에게 raw HTTP 에러 문자열이 그대로 새 나간다(올리베이라군
+    # 지적 — 배포 뒤 반드시 볼 것 ②).
+    days: int | None = Field(default=None, ge=1)
 
 
 class GetStandupInput(SprintableInput):

--- a/backend/sprintable_mcp/tools/standup.py
+++ b/backend/sprintable_mcp/tools/standup.py
@@ -14,6 +14,11 @@ class StandupDateInput(SprintableInput):
 
 class StandupHistoryInput(SprintableInput):
     limit: int | None = None
+    # story #2412 AC3 — 예전엔 여기 없는 `days`를 보내도(SprintableInput.extra="ignore" +
+    # FastMCP 내부 arg_model 둘 다 관대) 조용히 무시됐다(AC2 lockdown 후로는 애초에 미선언 인자가
+    # 전부 거부되지만, "최근 N일"은 실제 수요라 진짜 필드로 만든다). BE `/standups/history`의
+    # date>=오늘-(days-1) 필터로 전달(제출 시각이 아니라 스탠드업 실제 날짜 기준).
+    days: int | None = None
 
 
 class GetStandupInput(SprintableInput):
@@ -63,6 +68,8 @@ async def standup_history(args: StandupHistoryInput) -> list[TextContent]:
         params: dict = {"project_id": client.require_project_id()}
         if args.limit is not None:
             params["limit"] = str(args.limit)
+        if args.days is not None:
+            params["days"] = str(args.days)
         return ok(await client.get("/api/v2/standups/history", params=params))
     except Exception as exc:
         return err(str(exc))

--- a/backend/tests/mcp/test_schemas.py
+++ b/backend/tests/mcp/test_schemas.py
@@ -45,11 +45,16 @@ def test_story_priority_enum_values():
     assert StoryPriority.low == "low"
 
 
-def test_extra_fields_ignored():
-    args = ListStoriesInput(unknown_field="should_be_ignored")
-    assert not hasattr(args, "unknown_field")
+def test_extra_fields_rejected():
+    """story #2412 AC2 — 예전엔 미선언 필드를 조용히 버렸다(hasattr()이 False가 되는 식으로만
+    드러남, 호출자에겐 무증상). 이제는 구성 시점에 ValidationError로 거부한다."""
+    with pytest.raises(ValueError):
+        ListStoriesInput(unknown_field="should_be_rejected")
 
 
 def test_sprintable_input_base():
+    """story #2412 AC2 — extra="ignore"→"forbid". (실제 MCP 호출 경로의 삼킴은 이 한 겹
+    앞(FastMCP 내부 arg_model, server.py::_lock_down_extra_args)에서 막힌다 — 여기는
+    defense-in-depth, 직접 `SprintableInput(**kwargs)` 구성 경로까지 잠근다.)"""
     base = SprintableInput()
-    assert base.model_config.get("extra") == "ignore"
+    assert base.model_config.get("extra") == "forbid"

--- a/backend/tests/test_2248_standup_history_cursor_pagination_realdb.py
+++ b/backend/tests/test_2248_standup_history_cursor_pagination_realdb.py
@@ -111,14 +111,14 @@ async def test_second_page_returns_different_rows_realdb():
 
         async with Session() as s:
             repo = StandupEntryRepository(s, ORG)
-            page1 = await list_standup_history(project_id=PROJ, limit=2, cursor=None, repo=repo, auth=_auth())
+            page1 = await list_standup_history(project_id=PROJ, limit=2, cursor=None, days=None, repo=repo, auth=_auth())
         assert [e.id for e in page1["data"]] == newest_first[0:2]
         assert page1["meta"]["has_more"] is True
 
         async with Session() as s:
             repo = StandupEntryRepository(s, ORG)
             page2 = await list_standup_history(
-                project_id=PROJ, limit=2, cursor=page1["meta"]["next_cursor"], repo=repo, auth=_auth(),
+                project_id=PROJ, limit=2, cursor=page1["meta"]["next_cursor"], days=None, repo=repo, auth=_auth(),
             )
         page2_ids = [e.id for e in page2["data"]]
         assert page2_ids == newest_first[2:4], "page2가 page1과 다른 행을 반환해야 한다(#2231 AC3 본체)"
@@ -127,7 +127,7 @@ async def test_second_page_returns_different_rows_realdb():
         async with Session() as s:
             repo = StandupEntryRepository(s, ORG)
             page3 = await list_standup_history(
-                project_id=PROJ, limit=2, cursor=page2["meta"]["next_cursor"], repo=repo, auth=_auth(),
+                project_id=PROJ, limit=2, cursor=page2["meta"]["next_cursor"], days=None, repo=repo, auth=_auth(),
             )
         assert [e.id for e in page3["data"]] == newest_first[4:5]
         assert page3["meta"]["has_more"] is False
@@ -148,7 +148,7 @@ async def test_no_cursor_under_limit_has_more_false_realdb():
 
         async with Session() as s:
             repo = StandupEntryRepository(s, ORG)
-            page = await list_standup_history(project_id=PROJ, limit=20, cursor=None, repo=repo, auth=_auth())
+            page = await list_standup_history(project_id=PROJ, limit=20, cursor=None, days=None, repo=repo, auth=_auth())
         assert [e.id for e in page["data"]] == seeded
         assert page["meta"]["has_more"] is False
         assert page["meta"]["next_cursor"] is None
@@ -177,7 +177,7 @@ async def test_non_string_truthy_cursor_treated_as_no_cursor_not_crash_realdb():
 
         async with Session() as s:
             repo = StandupEntryRepository(s, ORG)
-            page = await list_standup_history(project_id=PROJ, limit=20, cursor=fake_sentinel, repo=repo, auth=_auth())
+            page = await list_standup_history(project_id=PROJ, limit=20, cursor=fake_sentinel, days=None, repo=repo, auth=_auth())
         assert [e.id for e in page["data"]] == seeded, "커서 없음으로 취급돼 전체가 나와야 한다(크래시 아님)"
     finally:
         await eng.dispose()
@@ -197,7 +197,7 @@ async def test_invalid_cursor_format_400_realdb():
         async with Session() as s:
             repo = StandupEntryRepository(s, ORG)
             with pytest.raises(HTTPException) as ei:
-                await list_standup_history(project_id=PROJ, limit=20, cursor="not-a-date", repo=repo, auth=_auth())
+                await list_standup_history(project_id=PROJ, limit=20, cursor="not-a-date", days=None, repo=repo, auth=_auth())
             assert ei.value.status_code == 400
     finally:
         await eng.dispose()

--- a/backend/tests/test_2412_mcp_unknown_arg_rejection.py
+++ b/backend/tests/test_2412_mcp_unknown_arg_rejection.py
@@ -1,0 +1,110 @@
+"""story #2412 AC2 — MCP 도구가 미선언 인자(`days` 등)를 조용히 삼키던 것.
+
+⚠️실제 삼킴 지점은 처음 지목됐던 SprintableInput.extra="ignore"가 아니라 한 겹 앞이었다 —
+FastMCP가 도구 함수 시그니처(_flat()의 wrapper.__signature__)로 만드는 내부 arg_model(mcp
+SDK `func_metadata.py`)이 먼저 거른다(extra 미지정 → pydantic 기본값=ignore와 동일). 이
+테스트는 `Tool.run()`으로 끝까지 태워 그 실제 경로를 검증한다(SprintableInput만 직접
+구성(`SomeInput(**kwargs)`)해서는 이 층을 안 지나가므로 이 증상을 못 잡는다 — 그게 바로
+처음 판단이 틀렸던 이유).
+
+positive control(AC4): 아래 첫 테스트가 "패치 전" 상태(관대한 원본 arg_model)를 직접
+재현해 여전히 조용히 삼킨다는 것부터 보여준 뒤, 실제 등록된(=server.py의
+`SprintableFastMCP.add_tool` 패치가 적용된) 도구가 정확히 거부한다는 것을 대조한다.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+sys.path.insert(0, ".")
+
+
+@pytest.mark.anyio
+async def test_baseline_unpatched_arg_model_silently_drops_unknown_kwarg():
+    """positive control — 패치 전 FastMCP 기본 동작 자체가 조용히 삼킨다는 것을 직접 재현.
+    이게 실측 없이 「SprintableInput만 고치면 된다」고 믿기 쉬웠던 지점이다."""
+    from mcp.server.fastmcp.tools.base import Tool
+
+    captured = {}
+
+    async def wrapper(limit: int | None = None, project_id: str | None = None):
+        captured["received"] = {"limit": limit, "project_id": project_id}
+        return []
+
+    tool = Tool.from_function(wrapper, name="unpatched_probe")
+    # wrapper 시그니처엔 애초에 존재하지 않는 인자 — MCP 클라가 미지 필드(days같은)를 보내는
+    # 상황을 재현. 패치 전 baseline은 이걸 조용히 버리고 정상 200류 응답을 낸다(에러 0).
+    result = await tool.run({"limit": 5, "some_field_wrapper_never_declared": 14})
+    assert result == []
+    assert captured["received"] == {"limit": 5, "project_id": None}, (
+        "패치 전 baseline은 wrapper 시그니처에 없는 인자를 조용히 버린다(에러 없음) — "
+        "이게 스토리가 보고한 증상의 실제 원인."
+    )
+
+
+@pytest.mark.anyio
+async def test_registered_standup_history_tool_rejects_unknown_days_arg():
+    """AC2 본체 — 실제 등록된(server.py, lockdown 패치 적용됨) 도구로 스토리 repro를 재현."""
+    from sprintable_mcp import server as srv
+    from mcp.server.fastmcp.exceptions import ToolError
+
+    tool = srv.mcp._tool_manager.get_tool("sprintable_standup_history")
+    with pytest.raises(ToolError) as ei:
+        await tool.run({"limit": 5, "totally_bogus_arg": 1})
+    msg = str(ei.value)
+    assert "totally_bogus_arg" in msg
+    assert "accepted arguments" in msg, "거부 메시지가 accepted 인자 목록을 말해야 한다(올리베이라군 요청 — «다음 발»을 줘야 함)"
+    assert "limit" in msg and "project_id" in msg
+
+
+@pytest.mark.anyio
+async def test_registered_standup_history_tool_still_accepts_known_args():
+    """회귀 방지 — lockdown이 정상 콜까지 깨면 안 된다."""
+    from sprintable_mcp import server as srv
+
+    tool = srv.mcp._tool_manager.get_tool("sprintable_standup_history")
+    result = await tool.run({"limit": 5, "days": 7})
+    assert isinstance(result, list)
+
+
+def test_all_registered_tools_share_the_same_lockdown():
+    """AC2 카운트 — `_TOOL_DEFS` 115개 + ping 1개 = 116개 전부 arg_model이 extra=forbid로
+    잠겨 있어야 한다(상속 갈래 SprintableInput/BaseModel 안 가리고 전부)."""
+    from sprintable_mcp import server as srv
+
+    tools = srv.mcp._tool_manager.list_tools()
+    assert len(tools) == 116
+    unlocked = [
+        t.name for t in tools
+        if t.fn_metadata.arg_model.model_config.get("extra") != "forbid"
+    ]
+    assert unlocked == [], f"lockdown이 안 걸린 도구가 있다: {unlocked}"
+
+
+@pytest.mark.anyio
+async def test_baseclass_direct_outliers_also_reject_unknown_kwarg():
+    """115/115 카운트에서 SprintableInput을 상속 안 하는 2개(list_projects·set_default_project,
+    tools/projects.py) — SprintableInput만 고쳤으면 놓쳤을 자리. 스키마 레벨(defense-in-depth)
+    로도 직접 확認."""
+    from sprintable_mcp.tools.projects import ListProjectsInput, SetDefaultProjectInput
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        ListProjectsInput(bogus="x")
+    with pytest.raises(ValidationError):
+        SetDefaultProjectInput(project_id="p1", bogus="x")
+
+
+def test_sprintable_input_extra_forbid_defense_in_depth():
+    """SprintableInput.extra="forbid" — MCP 호출 경로 밖(예: 테스트 코드)에서 직접
+    `SomeInput(**kwargs)`로 구성하는 경우까지 잠그는 defense-in-depth(진짜 fix는 위 lockdown)."""
+    from sprintable_mcp.tools.standup import StandupHistoryInput
+    from pydantic import ValidationError
+
+    # days는 AC3에서 진짜 필드가 됐으니 통과해야 정상 — 회귀 방지 겸.
+    ok = StandupHistoryInput(limit=5, days=14)
+    assert ok.days == 14
+
+    with pytest.raises(ValidationError):
+        StandupHistoryInput(limit=5, totally_unknown_field=1)

--- a/backend/tests/test_2412_mcp_unknown_arg_rejection.py
+++ b/backend/tests/test_2412_mcp_unknown_arg_rejection.py
@@ -108,3 +108,18 @@ def test_sprintable_input_extra_forbid_defense_in_depth():
 
     with pytest.raises(ValidationError):
         StandupHistoryInput(limit=5, totally_unknown_field=1)
+
+
+def test_days_ge_1_boundary_matches_backend():
+    """올리베이라군 QA 요청 — 배포 뒤 볼 것 ②(days 경계). MCP 쪽에 ge=1 없으면 days=0/음수가
+    MCP는 조용히 통과하고 BE(`Query(..., ge=1)`)에서만 422로 막혀 raw HTTP 에러 문자열이
+    호출자에게 그대로 샌다 — MCP 스키마 경계를 BE와 맞춰서 막는다."""
+    from sprintable_mcp.tools.standup import StandupHistoryInput
+    from pydantic import ValidationError
+
+    for bad in (0, -1, -100):
+        with pytest.raises(ValidationError):
+            StandupHistoryInput(limit=5, days=bad)
+
+    assert StandupHistoryInput(limit=5, days=1).days == 1
+    assert StandupHistoryInput(limit=5, days=365).days == 365  # 상한 없음(BE도 무상한 — 대칭)

--- a/backend/tests/test_2412_standup_history_days_filter_realdb.py
+++ b/backend/tests/test_2412_standup_history_days_filter_realdb.py
@@ -1,0 +1,149 @@
+"""story #2412 AC3 — MCP `standup_history` 도구가 존재하지도 않는 `days` 인자를 조용히
+삼키던 것(AC2)의 후속: `days`를 실제 필드로 만들고 BE `/api/v2/standups/history`가 진짜로
+그 기간으로 필터링하는지 확認. `date`(스탠드업 실제 날짜) 기준 — `created_at`(제출 시각)이
+아니다: 늦게 제출된 옛날 날짜 스탠드업을 "최근"으로 잘못 포함시키지 않기 위해서다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("d2412d00-0000-0000-0000-000000000010")
+PROJ = uuid.UUID("d2412d00-0000-0000-0000-000000000011")
+AUTHOR_USER = uuid.UUID("d2412d00-0000-0000-0000-000000000013")
+AUTHOR_MEMBER = uuid.UUID("d2412d00-0000-0000-0000-000000000014")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(AUTHOR_USER), email=None,
+        claims={"app_metadata": {"org_id": str(ORG)}},
+        org_id=str(ORG),
+    )
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _clean(s):
+    for sql in [
+        f"DELETE FROM standup_entry_projects WHERE project_id='{PROJ}'",
+        f"DELETE FROM standup_entries WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE id='{PROJ}'",
+        f"DELETE FROM users WHERE id='{AUTHOR_USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _seed(s) -> None:
+    """오늘 기준 0/5/10/20일 전 4건 — days=7이면 앞의 둘(0·5일 전)만 남아야 한다."""
+    await _clean(s)
+    await s.execute(text(f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','O','d2412d-org','free')"))
+    await s.execute(text(
+        f"INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{AUTHOR_USER}','d2412d@d2412d.test','x','D2412D',true,true,0,false,0)"
+    ))
+    await s.execute(text(f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ}','{ORG}','P2412D')"))
+    await s.execute(text(
+        f"INSERT INTO members (id,org_id,user_id,type,name,is_active) VALUES "
+        f"('{AUTHOR_MEMBER}','{ORG}','{AUTHOR_USER}','human','D2412D',true)"
+    ))
+    await s.execute(text(
+        f"INSERT INTO project_access (id,project_id,member_id,role,permission) VALUES "
+        f"(gen_random_uuid(),'{PROJ}','{AUTHOR_MEMBER}','member','granted')"
+    ))
+    today = datetime.now(timezone.utc).date()
+    for i, days_ago in enumerate([0, 5, 10, 20]):
+        eid = uuid.uuid4()
+        the_date = today - timedelta(days=days_ago)
+        created_at = datetime(the_date.year, the_date.month, the_date.day, 9, 0, tzinfo=timezone.utc)
+        await s.execute(text(
+            f"INSERT INTO standup_entries (id,org_id,project_id,author_id,date,done,plan,blockers,"
+            f"plan_story_ids,created_at,updated_at) VALUES "
+            f"('{eid}','{ORG}','{PROJ}','{AUTHOR_MEMBER}','{the_date.isoformat()}','done-{i}','plan-{i}',NULL,"
+            f"'{{}}','{created_at.isoformat()}','{created_at.isoformat()}')"
+        ))
+        await s.execute(text(
+            f"INSERT INTO standup_entry_projects (id,org_id,entry_id,project_id) VALUES "
+            f"(gen_random_uuid(),'{ORG}','{eid}','{PROJ}')"
+        ))
+    await s.commit()
+
+
+@pytest.mark.anyio
+async def test_days_filter_excludes_entries_older_than_window_realdb():
+    from app.routers.standups import list_standup_history
+    from app.repositories.standup import StandupEntryRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            repo = StandupEntryRepository(s, ORG)
+            page = await list_standup_history(project_id=PROJ, limit=30, cursor=None, days=7, repo=repo, auth=_auth())
+        assert len(page["data"]) == 2, "days=7이면 0일전·5일전 2건만 — 10일전·20일전은 창 밖"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_days_param_returns_all_realdb():
+    from app.routers.standups import list_standup_history
+    from app.repositories.standup import StandupEntryRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            repo = StandupEntryRepository(s, ORG)
+            page = await list_standup_history(project_id=PROJ, limit=30, cursor=None, days=None, repo=repo, auth=_auth())
+        assert len(page["data"]) == 4, "days 미지정 = 기존 동작(기간 필터 없음) 그대로 4건 전부"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_days_one_means_today_only_realdb():
+    from app.routers.standups import list_standup_history
+    from app.repositories.standup import StandupEntryRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            repo = StandupEntryRepository(s, ORG)
+            page = await list_standup_history(project_id=PROJ, limit=30, cursor=None, days=1, repo=repo, auth=_auth())
+        assert len(page["data"]) == 1, "days=1은 오늘 하루만(0일전 1건) — 스토리 repro(days=14 vs days=1)와 반대증명"
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_2412_standup_repo_list_order_realdb.py
+++ b/backend/tests/test_2412_standup_repo_list_order_realdb.py
@@ -1,0 +1,202 @@
+"""story #2412 AC1/AC4 — StandupEntryRepository.list()에 order_by가 없었다(limit만 적용).
+
+"최근"을 요구하는 화면(FE `/api/standup` → GET /api/v2/standups → list_standups →
+repo.list(), routers/standups.py:181)이 결정적 순서 보장 없이 나갔다 — #2248이
+`/standups/history`(별도 엔드포인트, raw 쿼리로 우회)만 고치고 repo.list() 자체는
+"공유 범용 메서드라 손 안 댄다"고 명시적으로 남겨둔 자리(그 주석 참조, routers/standups.py).
+
+repo.list() 실호출처는 코드베이스 전체에 routers/standups.py:181(list_standups) 1곳뿐(grep
+확認, routers/sprints.py는 get_missing()만 사용) — 그 1곳을 고치면 FE 화면 + MCP
+get_standup/list_standup_entries 도구까지 전부 같이 고쳐진다.
+
+positive control(AC4, 실제로 이 테스트 개발 중 수행): repositories/standup.py::list()의
+order_by(...) 줄을 지우고 이 파일을 돌리면 test_list_returns_entries_ordered_by_date_desc가
+빨간불로 돌아간다(다중 project 랜덤 insert 순서 때문에 결정적으로 재현) — order_by가 실제로
+결과를 만드는 코드임을 확認했다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("d2412000-0000-0000-0000-000000000010")
+PROJ = uuid.UUID("d2412000-0000-0000-0000-000000000011")
+VIEWER_USER = uuid.UUID("d2412000-0000-0000-0000-000000000013")
+VIEWER_MEMBER = uuid.UUID("d2412000-0000-0000-0000-000000000014")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _clean(s):
+    for sql in [
+        f"DELETE FROM standup_entry_projects WHERE project_id='{PROJ}'",
+        f"DELETE FROM standup_entries WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE id='{PROJ}'",
+        f"DELETE FROM users WHERE id='{VIEWER_USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _seed_viewer_access(s) -> None:
+    """list_standups(routers/standups.py)의 has_project_access 게이트를 통과시키기 위한
+    최소 seed(test_2248과 동형)."""
+    await s.execute(text(
+        f"INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{VIEWER_USER}','d2412@d2412.test','x','D2412',true,true,0,false,0)"
+    ))
+    await s.execute(text(
+        f"INSERT INTO members (id,org_id,user_id,type,name,is_active) VALUES "
+        f"('{VIEWER_MEMBER}','{ORG}','{VIEWER_USER}','human','D2412',true)"
+    ))
+    await s.execute(text(
+        f"INSERT INTO project_access (id,project_id,member_id,role,permission) VALUES "
+        f"(gen_random_uuid(),'{PROJ}','{VIEWER_MEMBER}','member','granted')"
+    ))
+
+
+async def _seed_entry(s, *, author_id: uuid.UUID, the_date: date, created_at: datetime) -> uuid.UUID:
+    eid = uuid.uuid4()
+    await s.execute(text(
+        f"INSERT INTO standup_entries (id,org_id,project_id,author_id,date,done,plan,blockers,"
+        f"plan_story_ids,created_at,updated_at) VALUES "
+        f"('{eid}','{ORG}','{PROJ}','{author_id}','{the_date.isoformat()}','done','plan',NULL,"
+        f"'{{}}','{created_at.isoformat()}','{created_at.isoformat()}')"
+    ))
+    await s.execute(text(
+        f"INSERT INTO standup_entry_projects (id,org_id,entry_id,project_id) VALUES "
+        f"(gen_random_uuid(),'{ORG}','{eid}','{PROJ}')"
+    ))
+    return eid
+
+
+@pytest.mark.anyio
+async def test_list_returns_entries_ordered_by_date_desc_realdb():
+    """AC1/AC4 본체 — 여러 날짜에 걸쳐 삽입 순서를 뒤섞어도(가장 오래된 것을 먼저 넣음) 반환은
+    date 내림차순이어야 한다. 스토리 repro(142건 중 2026-07-01 최신 건이 맨 앞이 아님)를
+    작은 스케일로 재현."""
+    from app.repositories.standup import StandupEntryRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _clean(s)
+            await s.execute(text(f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','O','d2412-org','free')"))
+            await s.execute(text(f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ}','{ORG}','P2412')"))
+
+            base = datetime(2026, 6, 1, tzinfo=timezone.utc)
+            # 의도적으로 날짜 오름차순(가장 오래된 것부터)으로 삽입 — order_by 없으면 삽입/PK
+            # 순서에 의존하는 우연한 정렬이 나올 수 있어, 그 우연을 배제하려 정반대로 넣는다.
+            dates = [base.date() + timedelta(days=i) for i in range(5)]  # [06-01 .. 06-05]
+            oldest_first_ids = []
+            for i, d in enumerate(dates):
+                eid = await _seed_entry(s, author_id=uuid.uuid4(), the_date=d, created_at=base + timedelta(seconds=i))
+                oldest_first_ids.append(eid)
+            await s.commit()
+
+            repo = StandupEntryRepository(s, ORG)
+            result = await repo.list(project_id=PROJ)
+
+        got_ids = [e.id for e in result]
+        assert got_ids == list(reversed(oldest_first_ids)), (
+            "date 내림차순(최신이 맨 앞)이어야 한다 — repo.list()에 order_by가 없으면 "
+            "삽입 순서 그대로(오래된 게 맨 앞) 나온다."
+        )
+        assert [e.date for e in result] == sorted(dates, reverse=True)
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_same_date_tiebreaks_by_created_at_desc_realdb():
+    """같은 date(서로 다른 author, org-level 다건 제출 상황)일 때 created_at 내림차순으로
+    동석차 tiebreak — 순서가 매 실행 랜덤이 아니라 결정적이어야 한다."""
+    from app.repositories.standup import StandupEntryRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _clean(s)
+            await s.execute(text(f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','O','d2412-org','free')"))
+            await s.execute(text(f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ}','{ORG}','P2412')"))
+
+            same_date = date(2026, 6, 10)
+            base = datetime(2026, 6, 10, 9, 0, tzinfo=timezone.utc)
+            # created_at 오름차순(먼저 제출한 사람 순)으로 삽입 — 기대 결과는 그 역순.
+            earliest_first_ids = []
+            for i in range(3):
+                eid = await _seed_entry(s, author_id=uuid.uuid4(), the_date=same_date, created_at=base + timedelta(minutes=i))
+                earliest_first_ids.append(eid)
+            await s.commit()
+
+            repo = StandupEntryRepository(s, ORG)
+            result = await repo.list(project_id=PROJ)
+
+        assert [e.id for e in result] == list(reversed(earliest_first_ids)), (
+            "같은 date면 created_at 내림차순(가장 최근 제출이 먼저)이어야 한다."
+        )
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_standups_router_uses_ordered_repo_list_realdb():
+    """AC1 — 실제 소비처(routers/standups.py:181, list_standups = FE `/api/standup` 화면
+    데이터 경로)를 통해서도 동일하게 정렬돼 나온다."""
+    from app.routers.standups import list_standups
+    from app.repositories.standup import StandupEntryRepository
+    from app.dependencies.auth import AuthContext
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _clean(s)
+            await s.execute(text(f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','O','d2412-org','free')"))
+            await s.execute(text(f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ}','{ORG}','P2412')"))
+            await _seed_viewer_access(s)
+
+            base = datetime(2026, 6, 1, tzinfo=timezone.utc)
+            dates = [base.date() + timedelta(days=i) for i in range(4)]
+            oldest_first_ids = []
+            for i, d in enumerate(dates):
+                eid = await _seed_entry(s, author_id=uuid.uuid4(), the_date=d, created_at=base + timedelta(seconds=i))
+                oldest_first_ids.append(eid)
+            await s.commit()
+
+        async with Session() as s:
+            repo = StandupEntryRepository(s, ORG)
+            auth = AuthContext(
+                user_id=str(VIEWER_USER), email=None,
+                claims={"app_metadata": {"org_id": str(ORG)}}, org_id=str(ORG),
+            )
+            entries = await list_standups(project_id=PROJ, author_id=None, sprint_id=None, date_filter=None, repo=repo, auth=auth)
+
+        assert [e.id for e in entries] == list(reversed(oldest_first_ids)), (
+            "화면 데이터 경로(list_standups)도 최신 date가 맨 앞이어야 한다(AC1 본체)."
+        )
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_standup_plan_stories_enrich.py
+++ b/backend/tests/test_standup_plan_stories_enrich.py
@@ -141,7 +141,7 @@ async def test_history_endpoint_enriches_backlog_plan_story():
     session.execute = AsyncMock(return_value=result)
     repo = _repo(list_ret=[_entry([backlog])], session=session)
     with _accessible(PROJECT_ID):
-        out = await list_standup_history(project_id=uuid.uuid4(), limit=30, cursor=None, repo=repo, auth=_auth())
+        out = await list_standup_history(project_id=uuid.uuid4(), limit=30, cursor=None, days=None, repo=repo, auth=_auth())
     assert [ps.id for ps in out["data"][0].plan_stories] == [backlog]  # 백로그 노출(enrich)
 
 


### PR DESCRIPTION
## Summary
story #2412 — 스탠드업이 「최근」을 못 준다 (도구는 인자를 조용히 먹고, 화면은 정렬이 없다)

**Part A (AC2/AC3)**: MCP 도구가 미선언 인자를 조용히 삼켰다(`standup_history`의 `days=14`와 `days=1`이 동일 결과). 처음 지목된 원인(`SprintableInput.extra="ignore"`)은 실제 삼킴 지점이 **아니었다** — `Tool.run()`으로 끝까지 태워 확認한 결과, FastMCP 자체가 도구 함수 시그니처로 만드는 내부 arg_model(mcp SDK `func_metadata.py`, extra 미지정 → pydantic 기본값=ignore와 동일)이 SprintableInput에 닿기도 전에 먼저 거른다. 진짜 fix는 등록 시점(`server.py`의 `SprintableFastMCP.add_tool` 오버라이드)에 그 arg_model을 forbid로 패치하는 것 — 벤더 파일은 안 건드리고 등록 루프 한 곳에서 116개 도구(등록되는 `_TOOL_DEFS` 115개 + `ping` 1개) 전부 동시 적용(`SprintableInput` 상속이냐 `BaseModel` 직접상속(`list_projects`/`set_default_project` 2종)이냐 안 갈라도 됨 — SprintableInput만 고쳤으면 이 둘은 놓쳤을 자리). `mcp` SDK 비공개급 내부 결합이라 버전업 시 구조가 바뀌면 조용히 원복하지 않고 등록 시점(서버 부팅)에 assert로 크게 터지게 함. 거부 메시지에 accepted 인자 목록 포함. `SprintableInput`도 defense-in-depth로 `extra="forbid"`. `days`는 이제 `/api/v2/standups/history`의 진짜 필터(date 기준).

**Part B (AC1)**: `StandupEntryRepository.list()`에 `order_by`가 없어 FE `/api/standup` 화면 데이터 경로(`list_standups`)가 정렬 없이 나갔다. 코드베이스 전체에서 `.list()` 실호출처는 `routers/standups.py:181` **1곳뿐**(grep 확認) — 그 1곳을 고치면 MCP `get_standup`/`list_standup_entries`까지 같이 고쳐진다. `#2248`이 `/standups/history`를 raw 쿼리로 우회 고치며 "공유 범용이라 여기 손 안 댄다"고 명시적으로 남겨둔 자리.

## Evidence
- 실 Postgres(`pgvector/pgvector:pg16`, 전체 Alembic 마이그레이션)로 검증, positive control 포함: `order_by` 제거 시 정렬 테스트 3종 전부 red 확認 후 복구. 패치 전 baseline arg_model 직접 재현해 조용히 삼키는 것도 확認.
- dev 라이브 직접 확認(수정 전 현재 상태): `GET /api/v2/standups?project_id=...` 122건 미정렬, 최신(2026-07-01)이 맨 앞 아님. MCP `standup_history(days=1)`도 2026-06-08까지 반환(기간 필터 무시).
- 로컬 전체 backend 테스트 스위트 중 대상 도메인(standup/mcp/#2412/#2248) 전부 green. 무관 도메인(retro/webhook/i18n migration 등) 대량 실패는 로컬 bare Postgres 컨테이너의 seed 데이터 부재(`violation_level NOT NULL` 등, CI parity DB와 무관)로 확認 — 스토리 스코프 밖.

## Test plan
- [x] `test_2412_standup_repo_list_order_realdb.py` (3 tests, positive control 확認)
- [x] `test_2412_standup_history_days_filter_realdb.py` (3 tests)
- [x] `test_2412_mcp_unknown_arg_rejection.py` (7 tests, baseline vs patched 대조 + days ge=1 경계 포함)
- [x] `test_2248_standup_history_cursor_pagination_realdb.py`, `test_standup_plan_stories_enrich.py`, `mcp/test_schemas.py` — 회귀 없음(schemas.py 2종은 옛 ignore 동작을 잠갔던 것이라 새 의도로 업데이트)
- [x] `backend/scripts/lint_query_sentinel_direct_calls.py` (Query(None) sentinel direct-call lint guard, 로컬로 직접 실행) — **총 위반 15건(베이스라인 기존 15 + 신규 0) · SKIPPED 4건(추적불가, story #2335 AC5)**. 15건은 이 PR 스코프 밖(gate/story 도메인)이라 그대로 둠 — "전부 깨끗"이 아니라 "신규 미추가"임을 명시. SKIPPED 4건은 가드 자신이 "검사 못 닿음"을 스스로 신고하는 것이라 별도 조치 없음(스크립트 docstring 참조).
- [x] CI green (`gh pr checks 2794` 실 잡 이름으로 확認 — 최초 RC였던 `Query(None) sentinel direct-call lint (guard)`는 이 PR이 추가한 `days` 파라미터를 두 기존 realdb 테스트 파일의 7개 직접호출부가 명시로 안 넘긴 자리였음, `a3896201`로 수정)
- [x] dev 배포 후 라이브 재확認(develop 병합 `406cda6b`, Cloud Run 리비전 `sprintable-backend-dev-02161-b7b`가 트래픽 100% 받는 것 gcloud로 확認 후 측정):
  - GET /api/v2/standups — 122건, 정렬됨(최신 2026-07-01이 맨 앞). 확認.
  - /standups/history days 필터 — 이 프로젝트 최신 데이터가 32일 전이라 days=1/14는 둘 다 0건(정상, 재발 아님). 경계값 days=32(0건) vs days=33(1건, 2026-07-01)로 재측정 — 인자가 실제로 필터링하는 것 확認.
- [x] MCP 도구 `standup_history`의 `days` 실동작을 **실제 MCP 프로토콜 호출**로 재확認. `cloudbuild.yaml`이 backend/frontend/realtime만 배포하고 mcp를 배포 대상에서 빠뜨린 것이 근본 원인으로 확認됨(올리베이라군, 후속 인프라 스토리로 별도 추적) — `sprintable-mcp-dev`를 같은 이미지로 수동 재배포(`sprintable-mcp-dev-00023-nst`, 이미지 다이제스트가 backend-dev와 일치 확認) 후 실제 MCP 호출로 재측정: `days=32`→0건, `days=33`→1건(2026-07-01) — API 레벨에서 잰 것과 정확히 같은 경계. 두 레이어가 붙어 있는 것 확認.
- [x] MCP 도구의 미선언 인자 거부 + accepted 인자 목록 메시지 — 오타 인자(`dayz=1`)로 실제 호출: `unexpected argument(s) ['dayz'] — accepted arguments: ['days', 'limit', 'project_id']`로 정확히 거부됨. 정상 인자 호출은 그대로 통과 확認(회귀 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)




