### PR TITLE
feat(#2410 ③-1): add verifiedBanner to recruiter STEP5

### DIFF
--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.test.tsx
@@ -286,3 +286,27 @@ describe('resolveVerifyGuideKey — story #2792 (STEP5 안내문도 showVerifyEx
     expect(ko).toBeTruthy();
   });
 });
+
+// story #2410 ③-1(유나 판정, 2026-08-02) — connect-step에만 있던 verifiedBanner(aria-live 성공
+// 낭독)가 recruiter STEP5에는 없었다. 근거: ①같은 제품 안에서 왜 다른지가 코드 어디에도 안
+// 적혀 있었다(누락이지 판단이 아니다) ②recruiter STEP5는 채용할 때마다(반복) 뜨는 화면이라
+// connect-step(신규 가입 온보딩, 1회성)보다 없을 때의 대가가 크다. 소스 텍스트 수준으로
+// pin(이 파일의 기존 관례 — 컴포넌트 전체 마운트 테스트가 없다).
+describe('recruiter-client STEP5 — story #2410 ③-1(verifiedBanner)', () => {
+  const source = readFileSync(fileURLToPath(new URL('./recruiter-client.tsx', import.meta.url)), 'utf-8');
+
+  it('renders verifiedBanner with the same role/aria contract as connect-step (role=status aria-live=polite aria-atomic=true)', () => {
+    const m = /role="status" aria-live="polite" aria-atomic="true"[^>]*>\s*\{tOnboarding\('verifiedBanner'\)\}/.exec(source);
+    expect(m).not.toBeNull();
+  });
+
+  it('reuses the same i18n key as connect-step, not a recruiter-local one (single key per Yuna\'s judgment)', () => {
+    expect(source).toContain("tOnboarding('verifiedBanner')");
+    expect(source).not.toMatch(/t\('recruiterVerifiedBanner'\)|t\('verifiedBanner'\)/);
+  });
+
+  it('only renders when verified — does not duplicate the rail\'s own step-by-step aria-live announcements', () => {
+    // {verified && ( ... verifiedBanner ... )} — gated, not unconditional.
+    expect(source).toMatch(/\{verified && \([\s\S]{0,700}tOnboarding\('verifiedBanner'\)/);
+  });
+});

--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
@@ -223,9 +223,11 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
   const tSettings = useTranslations('settings');
   // 오르테가 라이브 스모크 적출(2026-07-06): railXxx/railStageHosted 키는 connect-step이 원래
   // 정의한 'onboarding' 네임스페이스에 있는데 STEP4가 이걸 'agents'(tAgents)로 조회해 전부
-  // MISSING_MESSAGE였음 — S4 merge(#1900) 때부터의 잠재 버그. story #2407로 useVerificationRail
-  // hook이 이 네임스페이스 조회를 내부로 흡수해, 이 파일에서 직접 useTranslations('onboarding')를
-  // 들 필요가 없어졌다(hook 쪽 t는 verify-rail.tsx 소유).
+  // MISSING_MESSAGE였음 — S4 merge(#1900) 때부터의 잠재 버그. story #2407로 railXxx/railStage
+  // 계열 조회는 useVerificationRail hook이 내부로 흡수했다(hook 쪽 t는 verify-rail.tsx 소유) —
+  // 다만 story #2410 ③-1이 connect-step과 «같은 키»를 그대로 재사용하는 verifiedBanner를
+  // 다시 필요로 해 이 바인딩을 되살린다(그 키도 'onboarding' 네임스페이스 소유).
+  const tOnboarding = useTranslations('onboarding');
   const [step, setStep] = useState<Step>(1);
 
   // STEP 1 — role catalog (+ equip-skip: "역할 없이(키만)")
@@ -1203,6 +1205,15 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
                   즉시 알려져야 하는 사실이다. 주 동선(위 예시 프롬프트)보다 약하게(muted). */}
               {!verified && (
                 <p className="text-xs text-muted-foreground">{t('verifySkippableHint')}</p>
+              )}
+              {verified && (
+                // story #2410 ③-1(유나 판정, 2026-08-02) — connect-step과 같은 키·같은 role/aria.
+                // recruiter STEP5는 채용할 때마다 반복되는 화면이라 접근성 누락의 대가가 connect-step
+                // (신규 가입 온보딩, 1회성)보다 크다는 것이 결함으로 판정된 근거. 레일이 이미 단계
+                // 전환을 aria-live로 말하므로 이 배너는 "완료" 한 마디만 — 중복 낭독하지 않는다.
+                <div role="status" aria-live="polite" aria-atomic="true" className="rounded-md border border-success/20 bg-success/10 px-3 py-2.5 text-sm text-success">
+                  {tOnboarding('verifiedBanner')}
+                </div>
               )}
 
               <div className="flex items-center gap-3 rounded-md border border-success/20 bg-success/10 p-3">


### PR DESCRIPTION
## Summary
- Yuna's a11y judgment: connect-step announces "connection confirmed" to screen readers on success (`role=status aria-live=polite aria-atomic=true`); recruiter STEP5 never did, with no comment anywhere explaining the difference — that's an omission, not a design decision. Recruiter STEP5 is the more repeated of the two flows (hired every time vs. one-time onboarding), so the omission costs more there.
- Reuses the exact same i18n key as connect-step (`verifiedBanner`, 'onboarding' namespace) rather than a recruiter-local one — both currently mean the same thing ("connection confirmed"); split later if recruiter ever needs a distinct message.
- Gated on `verified` only — the rail already announces per-step transitions via its own `aria-live`; this banner covers completion only, so screen reader users don't hear the same fact twice.
- Separate PR from #2792 per PO/Kadir's request (refactor vs a11y-addition axes shouldn't share a review), based on top of #2792's now-merged `useVerificationRail`.

## Test plan
- [x] New tests in `recruiter-client.test.tsx` (3 cases, source-text pinning — matches this file's existing convention since there's no full-component-mount test infra): role/aria contract matches connect-step, same i18n key reused (not a recruiter-local duplicate), gated on `verified` (not unconditional, doesn't duplicate rail announcements).
- [x] Positive control: replaced the `tOnboarding('verifiedBanner')` call with a literal string → all 3 new tests correctly went red, restored → green.
- [x] `pnpm type-check` / `pnpm exec tsx scripts/verify-no-i18n-phrase-collision.ts` (new 0, exempt 0) — clean.
- [x] Full suite: 342 files / 2535 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)