### PR TITLE
채용 STEP5에 온보딩 텔레메트리 신설 — 두 흐름을 나란히 잰다

### DIFF
--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useLocale, useTranslations } from 'next-intl';
 import {
@@ -15,6 +15,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { cn } from '@/lib/utils';
 import { VerifyRail, useVerificationRail } from '@/app/onboarding/verify-rail';
+import { emitOnboardingEvent, beaconOnboardingEvent } from '@/app/onboarding/onboarding-telemetry';
 import type { RoleTemplateSummary, RecruitResponse, McpConfigBundle, RuntimeCapabilityItem } from '@/services/recruit';
 import { RUNTIME_CAPABILITIES_FALLBACK, RUNTIME_GUIDE_FILENAME_FALLBACK, KIT_FILENAME, resolveRuntimeWakeInfo } from '@/services/recruit';
 
@@ -552,8 +553,35 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
     configCopiedDone: true,
   });
   const { displaySteps, verified, verifying } = rail;
-  const handleVerify = rail.handleVerify;
   const handleCopyVerifyPrompt = rail.handleCopyVerifyPrompt;
+
+  // story(2026-08-02, 채용 흐름 텔레메트리 부재) — connect-step.tsx는 config_copied·
+  // verify_started·abandoned_explicit 셋을 쏘는데 이 STEP5는 onboarding-telemetry import
+  // 자체가 없었다. connect-step과 같은 이름·같은 트리거 시점으로 맞추고 meta.flow로만
+  // 흐름을 가른다(리딩 쪽은 아직 없음 — 이 스토리 판정문에 명시).
+  const recruiterAgentId = recruitResult?.agent_id ?? null;
+  const leftRef = useRef(false);
+
+  const handleVerify = async () => {
+    emitOnboardingEvent('verify_started', { agent_id: recruiterAgentId, flow: 'recruit' });
+    await rail.handleVerify();
+  };
+
+  useEffect(() => {
+    const onHide = () => {
+      if (leftRef.current || verified || step !== 5) return;
+      beaconOnboardingEvent('abandoned_explicit', { agent_id: recruiterAgentId, failure_reason: 'abandoned_explicit', flow: 'recruit' });
+    };
+    window.addEventListener('pagehide', onHide);
+    return () => window.removeEventListener('pagehide', onHide);
+  }, [recruiterAgentId, verified, step]);
+
+  const handleFinish = () => {
+    leftRef.current = true;
+    if (!verified) {
+      emitOnboardingEvent('abandoned_explicit', { agent_id: recruiterAgentId, failure_reason: 'abandoned_explicit', flow: 'recruit' });
+    }
+  };
 
   const mcpConfigText = useMemo(
     () => (recruitResult ? JSON.stringify(recruitResult.mcp_config, null, 2) : ''),
@@ -1086,7 +1114,17 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
                 <div className="overflow-hidden rounded-md border border-border">
                   <div className="flex items-center justify-between gap-2 border-b border-border bg-muted px-3 py-2">
                     <span className="font-mono text-xs text-foreground">📄 .mcp.json <span className="text-muted-foreground">{t('mcpFileNote')}</span></span>
-                    <CopyDownloadButtons content={mcpConfigText} filename=".mcp.json" copied={copiedMcp} onCopied={() => setCopiedMcp(true)} />
+                    <CopyDownloadButtons
+                      content={mcpConfigText}
+                      filename=".mcp.json"
+                      copied={copiedMcp}
+                      onCopied={() => {
+                        setCopiedMcp(true);
+                        // connect-step.tsx의 handleCopy와 같은 트리거(복사 버튼 클릭 — 다운로드는
+                        // 양쪽 다 텔레메트리 대상이 아니다)·같은 이름으로 맞춘다.
+                        emitOnboardingEvent('config_copied', { agent_id: recruitResult?.agent_id ?? null, flow: 'recruit' });
+                      }}
+                    />
                   </div>
                   <pre className="overflow-x-auto bg-muted/40 p-3 text-xs leading-relaxed">{mcpConfigText}</pre>
                 </div>
@@ -1241,7 +1279,7 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
 
               <div className="flex justify-between gap-2 pt-2">
                 <Button variant="ghost" onClick={() => setStep(4)}><ChevronLeft className="h-4 w-4" />{t('back')}</Button>
-                <Link href="/dashboard"><Button variant={verified ? 'hero' : 'glass'}>{t('finish')}</Button></Link>
+                <Link href="/dashboard" onClick={handleFinish}><Button variant={verified ? 'hero' : 'glass'}>{t('finish')}</Button></Link>
               </div>
             </div>
           )}

--- a/apps/web/src/app/onboarding/connect-step.tsx
+++ b/apps/web/src/app/onboarding/connect-step.tsx
@@ -203,7 +203,7 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
   useEffect(() => {
     const onHide = () => {
       if (leftRef.current || verified) return;
-      beaconOnboardingEvent('abandoned_explicit', { agent_id: agentId, failure_reason: 'abandoned_explicit' });
+      beaconOnboardingEvent('abandoned_explicit', { agent_id: agentId, failure_reason: 'abandoned_explicit', flow: 'onboarding' });
     };
     window.addEventListener('pagehide', onHide);
     return () => window.removeEventListener('pagehide', onHide);
@@ -221,7 +221,7 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
     setHasCopiedMap((p) => ({ ...p, [transport]: true }));
     setJustCopied(true);
     setTimeout(() => setJustCopied(false), 2000);
-    emitOnboardingEvent('config_copied', { agent_id: agentId });
+    emitOnboardingEvent('config_copied', { agent_id: agentId, flow: 'onboarding' });
   };
 
   // story #2404 — "설정만 넣으면 자동으로 된다"는 오해가 무한 대기의 실원인이었다(검증은 실제
@@ -231,14 +231,14 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
 
   const handleVerify = async () => {
     if (!agentId || !transport) return;
-    emitOnboardingEvent('verify_started', { agent_id: agentId });
+    emitOnboardingEvent('verify_started', { agent_id: agentId, flow: 'onboarding' });
     await rail.handleVerify();
   };
 
   const handleDashboard = () => {
     leftRef.current = true;
     if (!verified) {
-      emitOnboardingEvent('abandoned_explicit', { agent_id: agentId, failure_reason: 'abandoned_explicit' });
+      emitOnboardingEvent('abandoned_explicit', { agent_id: agentId, failure_reason: 'abandoned_explicit', flow: 'onboarding' });
     }
     onFinish();
   };

--- a/apps/web/src/app/onboarding/onboarding-telemetry.test.ts
+++ b/apps/web/src/app/onboarding/onboarding-telemetry.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+//
+// story(2026-08-02, 채용 흐름 텔레메트리 부재) — connect-step.tsx는 config_copied·
+// verify_started·abandoned_explicit 셋을 쏘는데 recruiter STEP5엔 onboarding-telemetry
+// import 자체가 없었다. 이 회귀를 다시 못 만들도록, 실제로 fetch에 실리는 body(meta.flow
+// 포함)를 직접 검증한다 — emit이 fire-and-forget(fetch 실패 swallow)이라 "호출됐다"만으론
+// 부족하고 "무엇을 보냈는가"까지 재야 한다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { emitOnboardingEvent, beaconOnboardingEvent } from './onboarding-telemetry';
+
+function lastFetchBody(mockFetch: ReturnType<typeof vi.fn>): Record<string, unknown> {
+  const call = mockFetch.mock.calls.at(-1);
+  return JSON.parse(call![1].body as string);
+}
+
+describe('emitOnboardingEvent — meta.flow 조립(story #2413 계열 — 채용 흐름 텔레메트리)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({}) }));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('flow를 주면 meta.flow로 담긴다(recruit)', () => {
+    emitOnboardingEvent('config_copied', { agent_id: 'a1', flow: 'recruit' });
+    const body = lastFetchBody(fetchMock);
+    expect(body.event).toBe('config_copied');
+    expect(body.meta).toEqual({ flow: 'recruit' });
+  });
+
+  it('flow를 주면 meta.flow로 담긴다(onboarding)', () => {
+    emitOnboardingEvent('verify_started', { agent_id: 'a1', flow: 'onboarding' });
+    const body = lastFetchBody(fetchMock);
+    expect(body.meta).toEqual({ flow: 'onboarding' });
+  });
+
+  it('음성대조 — flow를 안 주면 meta가 빈 객체다(기존 호출부 무회귀)', () => {
+    emitOnboardingEvent('abandoned_explicit', { agent_id: 'a1', failure_reason: 'abandoned_explicit' });
+    const body = lastFetchBody(fetchMock);
+    expect(body.meta).toEqual({});
+  });
+
+  it('POST 대상은 항상 /api/onboarding/events다', () => {
+    emitOnboardingEvent('config_copied', { flow: 'recruit' });
+    const url = fetchMock.mock.calls.at(-1)![0];
+    expect(url).toBe('/api/onboarding/events');
+  });
+});
+
+describe('beaconOnboardingEvent — sendBeacon 경로도 meta.flow를 싣는다', () => {
+  it('sendBeacon 지원 시 그 Blob 본문에 meta.flow가 실린다', async () => {
+    const sendBeacon = vi.fn((_url: string, _data: Blob) => true);
+    vi.stubGlobal('navigator', { ...navigator, sendBeacon });
+    beaconOnboardingEvent('abandoned_explicit', { agent_id: 'a1', failure_reason: 'abandoned_explicit', flow: 'recruit' });
+    expect(sendBeacon).toHaveBeenCalledTimes(1);
+    const blob = sendBeacon.mock.calls[0]![1];
+    const text = await blob.text();
+    expect(JSON.parse(text).meta).toEqual({ flow: 'recruit' });
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/web/src/app/onboarding/onboarding-telemetry.ts
+++ b/apps/web/src/app/onboarding/onboarding-telemetry.ts
@@ -10,10 +10,18 @@ export type OnboardingEvent =
   | 'verify_started'
   | 'abandoned_explicit';
 
+// story(2026-08-02, 채용 흐름 텔레메트리 부재) — 두 흐름(onboarding/connect-step.tsx ·
+// recruiter STEP5)이 같은 이벤트 이름을 쏘게 되면서, 합계만 보고는 어느 흐름에서 온
+// 이벤트인지 구분이 안 된다. 확認: 백엔드 OnboardingEventBody(pydantic)에 이미
+// `meta: dict` 필드가 있고 OnboardingEvent 모델까지 JSONB로 실제 저장되는 것까지 이어진다
+// — 새 top-level 필드를 추가하는 것보다 안전한 확장 지점이라 flow는 meta 안에 담는다.
+export type OnboardingFlow = 'onboarding' | 'recruit';
+
 interface EventPayload {
   agent_id?: string | null;
   runtime?: string;
   failure_reason?: string;
+  flow?: OnboardingFlow;
 }
 
 /**
@@ -42,6 +50,7 @@ function buildBody(event: OnboardingEvent, payload?: EventPayload): string {
     runtime: payload?.runtime ?? 'claude-code',
     failure_reason: payload?.failure_reason ?? null,
     client_ts: new Date().toISOString(),
+    meta: payload?.flow ? { flow: payload.flow } : {},
   });
 }
 


### PR DESCRIPTION
## Summary
실측(디디 · #2407 대조 중) — `onboarding/connect-step.tsx`는 config_copied·verify_started·abandoned_explicit 셋을 쏘는데 `recruiter-client.tsx`(STEP5)엔 onboarding-telemetry import 자체가 없어 셋 다 없었다. 같은 STEP5 화면을 쓰면서 채용 흐름만 이탈률을 못 재는 상태였다 — 선생님이 "한 번도 성공 판정이 안 난다"고 지적한 화면이 바로 이 recruiter STEP5다.

## 라이브에서 못 잰 것 (중요)
이 PR은 **테스트 통과까지만** 확認됐고, **실제 dev 환경에서 세 이벤트가 정말 쌓이는지는 아직 안 쟀다.** 로컬 dev 서버로 시도했으나 로컬 FE가 공유 dev 백엔드와 JWT가 안 맞아 로그인 자체가 401로 막혔다(알려진 제약 — `reference-live-fe-verify-deployed-only` 메모, #2415와 같은 패턴). 머지·배포 후 puppeteer로 dev에 실제 로그인해 STEP4/STEP5를 밟고 `/api/onboarding/events` 네트워크 호출 3건(config_copied·verify_started·abandoned_explicit)이 실제로 나가는지 확認할 예정이다 — 그 전까지 "라이브 검증 완료"로 읽으면 안 된다.

## 착수 전 확認(PO 요청사항)
- **소비처**: `backend/app/routers/onboarding.py`의 `OnboardingEventBody`(pydantic)에 이미 `meta: dict` 필드가 있고 `OnboardingEvent` 모델(JSONB)까지 실제 저장되는 것을 확認했다. 새 top-level 필드보다 이 확장 지점이 안전해 흐름 구분(`recruit`/`onboarding`)은 `meta.flow`에 담는다.
- **키 이름 안전 설계**: `meta.flow` 조립은 `onboarding-telemetry.ts`의 `buildBody()` 한 곳에서만 하고, 호출부는 타입 있는 `OnboardingFlow`('onboarding'|'recruit') 값만 넘긴다. 오타가 날 자리가 원천적으로 하나뿐이다(뮤테이션 self-check: `'flw'` 오타를 내면 5개 중 3개가 정확히 RED).
- **트리거 시점 대조**: connect-step.tsx는 복사 버튼 하나뿐(다운로드 버튼 자체가 없다)이고 config_copied는 그 복사 클릭에만 붙는다. recruiter 쪽 `CopyDownloadButtons`도 `onCopied`는 복사 버튼에서만 호출되어(다운로드는 별개 콜백) 두 흐름의 실제 트리거 시점이 일치한다 — STEP5 레일이 config_copied를 이미 done으로 "간주"하는 건 레일 표시 로직일 뿐, 텔레메트리 이벤트 자체는 실제 복사 클릭 시점에 쏜다(층이 다르다).

## 구현
- `verify_started`는 story #2407로 두 파일이 공유하게 된 `useVerificationRail` 훅의 `handleVerify`를 각 호출부에서 얇게 감싸 emit — 트리거 함수 자체가 하나라 시점이 갈릴 수 없다.
- `abandoned_explicit`은 `pagehide`(탭닫기)·완료 링크 클릭 둘 다에서 connect-step과 동일하게 붙인다.
- 흐름을 바꾸지 않는다(AC③ — emit은 fire-and-forget·fail-silent, 기존 계약 그대로).

## 판정 — 아직 안 된 것
저장까지 확認했고, `meta.flow`를 읽어 흐름별로 가르는 집계/대시보드 자리는 아직 없다. "이제 흐름별로 볼 수 있다"가 아니라 "가를 수 있는 재료가 쌓이기 시작한다"로 읽어야 한다 — 다음 판(집계 쪽)의 재료.

## Test plan
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run build` — EXIT 0
- [x] `pnpm exec vitest run` — 343 files · 2537 tests 전부 PASS(신규 5건 — meta.flow 조립·미지정 시 빈 객체·sendBeacon 경로, 뮤테이션 self-check 포함)
- [x] verify:* 7개 전부 개별 실행 OK
- [ ] AC4(dev에서 실제로 밟아 세 이벤트가 쌓이는지) — 로컬 dev 서버로 시도했으나 알려진 제약(로컬 FE는 공유 dev 백엔드와 JWT 불일치로 로그인 자체가 401)에 막혔다. #2415와 같은 패턴으로 머지·배포 후 라이브로 마저 확認 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
