### PR TITLE
fix(#2427): make conversation_id the primary chat MCP arg, thread_id a deprecated alias

### DIFF
--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -714,23 +714,28 @@ _TOOL_DEFS: list[tuple] = [
      ProposeCanonicalInput, propose_canonical_version),
     # Chat (4)
     ("sprintable_send_chat_message",
-     "[조직] conversation thread에 채팅 메시지 발송. mentions=[{type:\"doc\"|\"story\"|\"epic\", id,"
-     " title?}]로 human `#`-검색 mention과 동형인 `[title](entity:<type>:id)` 토큰을 content에"
-     " 합성(title 생략 시 서버가 canonical title로 만든 reference_token을 그대로 재사용 —"
-     " content에 직접 `[제목](entity:...)` 문자열을 손으로 짓지 말 것: 제목에 `]`가 들어가면"
-     " (예: \"[TAG] 제목\" 관례) 파서가 못 읽는다) — agent 발신 메시지에서도 링크/backlink가"
-     " 동작하게 한다.",
+     "[조직] conversation thread에 채팅 메시지 발송. conversation_id로 대화를 지정(thread_id는"
+     " 폐기 예정 별칭 — story #2427: 이 도구들의 «응답» thread_id는 대화 ID가 아니라 회신 스레드"
+     " ID이므로, 응답을 보고 그대로 다시 부를 때는 conversation_id를 쓸 것). mentions="
+     "[{type:\"doc\"|\"story\"|\"epic\", id, title?}]로 human `#`-검색 mention과 동형인"
+     " `[title](entity:<type>:id)` 토큰을 content에 합성(title 생략 시 서버가 canonical title로"
+     " 만든 reference_token을 그대로 재사용 — content에 직접 `[제목](entity:...)` 문자열을 손으로"
+     " 짓지 말 것: 제목에 `]`가 들어가면(예: \"[TAG] 제목\" 관례) 파서가 못 읽는다) — agent 발신"
+     " 메시지에서도 링크/backlink가 동작하게 한다.",
      SendChatInput, send_chat_message),
     ("sprintable_create_conversation",
      "[조직] 새 conversation thread 생성.",
      CreateConversationInput, create_conversation),
     ("sprintable_list_chat_messages",
-     "[조직] conversation thread 메시지 목록 조회.",
+     "[조직] conversation thread 메시지 목록 조회. conversation_id로 대화를 지정(thread_id는"
+     " 폐기 예정 별칭 — 응답의 thread_id는 대화 ID가 아니라 각 메시지의 회신 스레드 ID, story #2427).",
      ListChatMessagesInput, list_chat_messages),
     ("sprintable_get_chat_message",
      "[조직] conversation thread 내 메시지 단건 원문 조회(message_id로 즉시 픽업). ⭐웹훅 payload가"
-     " 잘렸거나 원문이 의심될 때 재발신 요청 대신 이걸로 먼저 확인 — thread_id=conversation_id,"
-     " message_id=조회할 메시지 id(top-level·리플 공용).",
+     " 잘렸거나 원문이 의심될 때 재발신 요청 대신 이걸로 먼저 확인 — conversation_id=대화 id"
+     "(thread_id는 폐기 예정 별칭), message_id=조회할 메시지 id(top-level·리플 공용). ⚠️응답의"
+     " thread_id는 대화 ID가 아니라 그 메시지의 회신 스레드 ID다(story #2427) — 응답을 보고 그대로"
+     " 다시 부를 때는 응답의 conversation_id를 쓸 것.",
      GetChatMessageInput, get_chat_message),
     # Meetings (6)
     ("sprintable_list_meetings",

--- a/backend/sprintable_mcp/tools/chat.py
+++ b/backend/sprintable_mcp/tools/chat.py
@@ -6,6 +6,7 @@ import re
 from typing import Literal
 
 from mcp.types import TextContent
+from pydantic import model_validator
 
 from ..api_client import client
 from ..response import err, ok
@@ -92,8 +93,44 @@ class MentionRef(SprintableInput):
     title: str | None = None
 
 
-class SendChatInput(SprintableInput):
-    thread_id: str
+class ConversationScopedInput(SprintableInput):
+    """story #2427 — send/list/get_chat_message 셋이 요청은 `thread_id`로 받으면서 실제로는
+    conversation_id를 뜻했다(URL 경로로 씀). 그런데 이 셋의 «응답」은 백엔드
+    `_msg_payload()`(app/routers/conversations.py)가 매번 `conversation_id`·`thread_id`
+    필드를 «둘 다» 싣는다 — 응답의 thread_id는 진짜 회신 스레드(nullable, 보통 null)라
+    요청의 thread_id(=conversation)와 다른 것을 가리킨다. 같은 이름이 요청·응답에서
+    다른 뜻이면, 응답을 보고 그 값을 그대로 다시 넣는 자연스러운 다음 행동이 조용히
+    틀린 값을 보내게 된다 — 그게 이 결함의 정의였다(PO 판정, 2026-08-02).
+
+    처방: 요청 쪽 정식 이름을 `conversation_id`로 맞춘다(응답이 이미 그 이름으로 준다).
+    `thread_id`는 «폐기 예정 별칭»으로 한동안 받는다 — extra="forbid"(story #2412)와는
+    안 부딪힌다(둘 다 «선언된» 필드라 미선언 인자를 막는 축과 다른 축이다). 둘 다 왔는데
+    값이 다르면 거부한다 — 조용히 하나를 고르면 이 판이 없애려는 병이 그대로 되살아난다.
+
+    ⛔걷을 조건 — 다음 판에서 실사용 로그(agent 호출)를 세어 `thread_id`(옛 이름) 사용이
+    0에 수렴하면 이 필드와 아래 검증을 뺀다. #2792에서 react-hooks lint disable에 붙인
+    것과 같은 형태(면제/별칭은 «언제 없앨 수 있는가»가 없으면 영원히 남는다).
+    """
+
+    conversation_id: str | None = None
+    thread_id: str | None = None  # 폐기 예정 별칭 — conversation_id를 쓰세요
+
+    @model_validator(mode="after")
+    def _resolve_conversation_id(self) -> "ConversationScopedInput":
+        if self.conversation_id and self.thread_id and self.conversation_id != self.thread_id:
+            raise ValueError(
+                "conversation_id와 thread_id가 둘 다 주어졌는데 값이 다릅니다 — "
+                "thread_id는 conversation_id의 폐기 예정 별칭입니다(응답의 thread_id와는 "
+                "다른 뜻이니 혼동하지 마세요). 하나만 쓰거나 같은 값을 주세요."
+            )
+        resolved = self.conversation_id or self.thread_id
+        if not resolved:
+            raise ValueError("conversation_id가 필요합니다.")
+        self.conversation_id = resolved
+        return self
+
+
+class SendChatInput(ConversationScopedInput):
     content: str
     reply_thread_id: str | None = None
     message_type: str | None = None
@@ -112,14 +149,12 @@ class CreateConversationInput(SprintableInput):
     title: str | None = None
 
 
-class ListChatMessagesInput(SprintableInput):
-    thread_id: str
+class ListChatMessagesInput(ConversationScopedInput):
     limit: int | None = None
     before: str | None = None
 
 
-class GetChatMessageInput(SprintableInput):
-    thread_id: str  # conversation_id — send/list_chat_message와 동일 네이밍 관례
+class GetChatMessageInput(ConversationScopedInput):
     message_id: str
 
 
@@ -178,7 +213,11 @@ async def _resolve_mention_content(args: SendChatInput) -> str:
 
 
 async def send_chat_message(args: SendChatInput) -> list[TextContent]:
-    """conversation thread에 채팅 메시지 발송."""
+    """conversation thread에 채팅 메시지 발송.
+
+    응답의 thread_id는 «회신 스레드» ID입니다(대화 ID가 아닙니다 — 대화 ID는
+    conversation_id입니다). 회신이 아닌 메시지는 보통 null입니다.
+    """
     uploaded_urls: list[str] = []
     try:
         content = await _resolve_mention_content(args) if args.mentions else args.content
@@ -195,7 +234,7 @@ async def send_chat_message(args: SendChatInput) -> list[TextContent]:
         if meta:
             payload["metadata"] = meta
         attachments = await upload_attachments(
-            f"/api/v2/conversations/{args.thread_id}/attachments", args.attachments,
+            f"/api/v2/conversations/{args.conversation_id}/attachments", args.attachments,
         )
         uploaded_urls = [a["url"] for a in attachments if isinstance(a, dict) and a.get("url")]
         if attachments:
@@ -209,7 +248,7 @@ async def send_chat_message(args: SendChatInput) -> list[TextContent]:
         # 원본을 받아 여기서 명시적으로 재구성한다 — 기존 MCP 호출부가 기대하는 평탄한
         # 메시지 필드 모양은 그대로 유지하면서 sibling 키만 얹는다(회귀 0: sibling이 없는
         # 평문 메시지는 이전과 byte-identical).
-        raw = await client.post_full(f"/api/v2/conversations/{args.thread_id}/messages", json=payload)
+        raw = await client.post_full(f"/api/v2/conversations/{args.conversation_id}/messages", json=payload)
         result: dict = dict(raw.get("data") or {}) if isinstance(raw, dict) else raw
         if isinstance(raw, dict):
             for sibling_key in ("references", "command_gate", "forked", "forked_conversation_id"):
@@ -247,21 +286,29 @@ async def create_conversation(args: CreateConversationInput) -> list[TextContent
 
 
 async def list_chat_messages(args: ListChatMessagesInput) -> list[TextContent]:
-    """conversation thread 메시지 목록 조회."""
+    """conversation thread 메시지 목록 조회.
+
+    각 메시지의 thread_id는 «회신 스레드» ID입니다(대화 ID가 아닙니다 — 대화 ID는
+    conversation_id입니다). 회신이 아닌 메시지는 보통 null입니다.
+    """
     params: dict = {}
     if args.limit is not None:
         params["limit"] = str(args.limit)
     if args.before:
         params["before"] = args.before
     try:
-        return ok(await client.get(f"/api/v2/conversations/{args.thread_id}/messages", params=params))
+        return ok(await client.get(f"/api/v2/conversations/{args.conversation_id}/messages", params=params))
     except Exception as exc:
         return err(str(exc))
 
 
 async def get_chat_message(args: GetChatMessageInput) -> list[TextContent]:
-    """메시지 단건 원문 조회 — 웹훅 payload가 잘렸을 때 message_id로 즉시 원문 픽업."""
+    """메시지 단건 원문 조회 — 웹훅 payload가 잘렸을 때 message_id로 즉시 원문 픽업.
+
+    응답의 thread_id는 «회신 스레드» ID입니다(대화 ID가 아닙니다 — 대화 ID는
+    conversation_id입니다). 회신이 아닌 메시지는 보통 null입니다.
+    """
     try:
-        return ok(await client.get(f"/api/v2/conversations/{args.thread_id}/messages/{args.message_id}"))
+        return ok(await client.get(f"/api/v2/conversations/{args.conversation_id}/messages/{args.message_id}"))
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/chat.py
+++ b/backend/sprintable_mcp/tools/chat.py
@@ -110,6 +110,12 @@ class ConversationScopedInput(SprintableInput):
     ⛔걷을 조건 — 다음 판에서 실사용 로그(agent 호출)를 세어 `thread_id`(옛 이름) 사용이
     0에 수렴하면 이 필드와 아래 검증을 뺀다. #2792에서 react-hooks lint disable에 붙인
     것과 같은 형태(면제/별칭은 «언제 없앨 수 있는가»가 없으면 영원히 남는다).
+
+    ⛔PO 지적(2026-08-02, #2799 리뷰) — 「걷을 조건」이 적혀만 있으면 그 조건이 «충족됐는지»를
+    아무도 못 잰다(호출자는 코드가 아니라 에이전트들의 습관이라 grep으로 못 센다). `thread_id`
+    로 들어오면 매번 경고 로그 한 줄을 남긴다 — 이 로그가 그 카운터다. Cloud Logging에서
+    `logger="sprintable_mcp.tools.chat"` + "deprecated thread_id alias"로 검색해 최근 N일간
+    발화 빈도를 센다. 0에 수렴하면(또는 특정 소수 소비처로만 좁혀지면) 그때 별칭을 걷는다.
     """
 
     conversation_id: str | None = None
@@ -123,9 +129,18 @@ class ConversationScopedInput(SprintableInput):
                 "thread_id는 conversation_id의 폐기 예정 별칭입니다(응답의 thread_id와는 "
                 "다른 뜻이니 혼동하지 마세요). 하나만 쓰거나 같은 값을 주세요."
             )
+        if self.thread_id and not self.conversation_id:
+            logger.warning(
+                "%s: deprecated thread_id alias used instead of conversation_id "
+                "(story #2427 — usage counter for when to remove the alias)",
+                self.__class__.__name__,
+            )
         resolved = self.conversation_id or self.thread_id
         if not resolved:
-            raise ValueError("conversation_id가 필요합니다.")
+            raise ValueError(
+                "conversation_id가 필요합니다 — thread_id는 폐기 예정 별칭이니 "
+                "conversation_id를 쓰세요."
+            )
         self.conversation_id = resolved
         return self
 

--- a/backend/tests/test_2427_chat_conversation_id_alias.py
+++ b/backend/tests/test_2427_chat_conversation_id_alias.py
@@ -62,6 +62,34 @@ class TestConversationIdResolution:
             SendChatInput(conversation_id=CONV, content="hi", bogus_field="x")
 
 
+class TestDeprecatedAliasUsageCounter:
+    """PO 요청(2026-08-02, #2799 리뷰) — 「걷을 조건」은 잴 수 있어야 선언이다.
+    thread_id로 들어오면 경고 로그가 남아야 나중에 "0에 수렴했는가"를 셀 수 있다."""
+
+    def test_thread_id_only_logs_deprecation_warning(self, caplog):
+        import logging
+        with caplog.at_level(logging.WARNING, logger="sprintable_mcp.tools.chat"):
+            SendChatInput(thread_id=CONV, content="hi")
+        assert any("deprecated thread_id alias" in r.message for r in caplog.records)
+        assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+    def test_conversation_id_only_does_not_log(self, caplog):
+        """음성대조 — 정식 이름을 쓰면 카운터가 조용해야 한다(안 그러면 카운터가 항상 시끄러워
+        「0에 수렴」을 못 판별한다)."""
+        import logging
+        with caplog.at_level(logging.WARNING, logger="sprintable_mcp.tools.chat"):
+            SendChatInput(conversation_id=CONV, content="hi")
+        assert not any("deprecated thread_id alias" in r.message for r in caplog.records)
+
+    def test_both_same_value_does_not_log(self, caplog):
+        """둘 다 주어졌고 conversation_id를 이미 쓰고 있다면 별칭에 «의존»하는 게 아니다 —
+        경고는 "conversation_id 없이 thread_id만" 자리에서만 의미가 있다."""
+        import logging
+        with caplog.at_level(logging.WARNING, logger="sprintable_mcp.tools.chat"):
+            SendChatInput(conversation_id=CONV, thread_id=CONV, content="hi")
+        assert not any("deprecated thread_id alias" in r.message for r in caplog.records)
+
+
 # ─── 판별(PO 요청) — 응답을 보고 그대로 다시 부르면 통하는가 ──────────────────
 
 class TestResponseRoundTrip:

--- a/backend/tests/test_2427_chat_conversation_id_alias.py
+++ b/backend/tests/test_2427_chat_conversation_id_alias.py
@@ -1,0 +1,130 @@
+"""story #2427 — send/list/get_chat_message의 request `thread_id`가 실은 conversation_id를
+뜻했는데, 이 셋의 응답은 백엔드 `_msg_payload()`가 `conversation_id`·`thread_id`(진짜 회신
+스레드, 보통 null) 필드를 «둘 다» 싣는다 — 같은 이름이 요청·응답에서 다른 것을 가리켰다.
+
+처방: 요청 쪽 정식 이름을 `conversation_id`로 맞추고, `thread_id`는 폐기 예정 별칭으로
+받는다(extra="forbid"와 안 부딪힌다 — 둘 다 «선언된» 필드). 둘 다 왔는데 값이 다르면 거부.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from sprintable_mcp.tools.chat import (
+    GetChatMessageInput,
+    ListChatMessagesInput,
+    SendChatInput,
+    get_chat_message,
+    send_chat_message,
+)
+
+CONV = "11111111-1111-1111-1111-111111111111"
+OTHER = "99999999-9999-9999-9999-999999999999"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ─── 스키마 레벨 — conversation_id/thread_id 해소 ────────────────────────────
+
+class TestConversationIdResolution:
+    def test_conversation_id_alone_resolves(self):
+        i = SendChatInput(conversation_id=CONV, content="hi")
+        assert i.conversation_id == CONV
+
+    def test_thread_id_alone_still_works_backward_compat(self):
+        # 기존 호출부(예: test_mcp_get_chat_message_3cf50d90.py)가 thread_id=만 쓴다 — 안 깨져야 한다.
+        i = GetChatMessageInput(thread_id=CONV, message_id="m1")
+        assert i.conversation_id == CONV
+
+    def test_both_same_value_passes(self):
+        # 음성대조(PO 요청) — ③이 과잉거부로 가면 안 된다.
+        i = ListChatMessagesInput(conversation_id=CONV, thread_id=CONV)
+        assert i.conversation_id == CONV
+
+    def test_both_different_values_rejected(self):
+        # 양성대조 — 이 축의 값. 조용히 하나를 고르면 이 스토리가 없애려는 병이 되살아난다.
+        with pytest.raises(ValidationError, match="다릅니다"):
+            SendChatInput(conversation_id=CONV, thread_id=OTHER, content="hi")
+
+    def test_neither_provided_rejected(self):
+        with pytest.raises(ValidationError, match="conversation_id가 필요"):
+            SendChatInput(content="hi")
+
+    def test_extra_forbid_unaffected(self):
+        # story #2412 lockdown과 안 부딪히는지 — 미선언 인자는 여전히 거부된다.
+        with pytest.raises(ValidationError):
+            SendChatInput(conversation_id=CONV, content="hi", bogus_field="x")
+
+
+# ─── 판별(PO 요청) — 응답을 보고 그대로 다시 부르면 통하는가 ──────────────────
+
+class TestResponseRoundTrip:
+    @pytest.mark.anyio
+    async def test_calling_again_with_response_conversation_id_works(self):
+        """이 결함의 정의를 뒤집어 pin — 고친 뒤 이게 «예»여야 닫힌다."""
+        msg_resp = {
+            "id": "m1", "conversation_id": CONV, "thread_id": None,
+            "content": "hello", "sender": {"id": "s", "name": "디디", "type": "agent"},
+        }
+        with patch("sprintable_mcp.tools.chat.client") as mock_client:
+            mock_client.get = AsyncMock(return_value=msg_resp)
+            out = await get_chat_message(GetChatMessageInput(conversation_id=CONV, message_id="m1"))
+        parsed = json.loads(out[0].text)
+
+        # 응답의 conversation_id를 그대로 다시 넣는다 — 이게 이제 자연스럽고 맞는 다음 행동이다.
+        again = GetChatMessageInput(conversation_id=parsed["conversation_id"], message_id="m1")
+        assert again.conversation_id == CONV
+
+    def test_naively_reusing_response_thread_id_alone_now_fails_loudly_not_silently(self):
+        """예전엔 응답의 thread_id(=None, 회신스레드)를 실수로 재사용하면 URL에
+        "None"이 박혀 조용히 엉뚱한 404로 샜다. 지금은 필수값 누락으로 «즉시» 명확하게 막힌다
+        — 조용한 오류가 시끄러운 오류로 바뀐 것이 이 스토리의 값이다."""
+        msg_resp_thread_id = None  # 최상위 메시지는 항상 이렇다(회신 아님).
+        with pytest.raises(ValidationError, match="conversation_id가 필요"):
+            GetChatMessageInput(thread_id=msg_resp_thread_id, message_id="m1")
+
+
+# ─── 전 경로(Tool.run) — 실 등록 도구까지 태워 회귀가 없는지 ───────────────────
+
+class TestRegisteredToolEndToEnd:
+    @pytest.mark.anyio
+    async def test_send_chat_message_tool_accepts_conversation_id(self):
+        from sprintable_mcp import server as srv
+
+        tool = srv.mcp._tool_manager.get_tool("sprintable_send_chat_message")
+        with patch("sprintable_mcp.tools.chat.client") as mock_client:
+            mock_client.post_full = AsyncMock(return_value={
+                "data": {"id": "m1", "conversation_id": CONV, "thread_id": None, "content": "hi"},
+            })
+            result = await tool.run({"conversation_id": CONV, "content": "hi"})
+        assert isinstance(result, list)
+
+    @pytest.mark.anyio
+    async def test_send_chat_message_tool_rejects_the_old_bug_shape(self):
+        """실물 재현 — story #2427의 발단 그대로: conversation_id를 넘긴 옛 습관이 아니라
+        thread_id/conversation_id를 «둘 다·다른 값으로» 넘기는 자리를 통한 도구 경로 회귀 확認."""
+        from sprintable_mcp import server as srv
+        from mcp.server.fastmcp.exceptions import ToolError
+
+        tool = srv.mcp._tool_manager.get_tool("sprintable_send_chat_message")
+        with pytest.raises(ToolError):
+            await tool.run({"conversation_id": CONV, "thread_id": OTHER, "content": "hi"})
+
+    @pytest.mark.anyio
+    async def test_send_chat_message_tool_still_accepts_legacy_thread_id_only(self):
+        """회귀 방지 — 기존 호출부가 thread_id=만 쓰던 습관이 안 깨져야 한다."""
+        from sprintable_mcp import server as srv
+
+        tool = srv.mcp._tool_manager.get_tool("sprintable_send_chat_message")
+        with patch("sprintable_mcp.tools.chat.client") as mock_client:
+            mock_client.post_full = AsyncMock(return_value={
+                "data": {"id": "m1", "conversation_id": CONV, "thread_id": None, "content": "hi"},
+            })
+            result = await tool.run({"thread_id": CONV, "content": "hi"})
+        assert isinstance(result, list)


### PR DESCRIPTION
## Summary
- **Scope (AC1)**: surveyed all 103 `*Input` pydantic classes / ~474 fields across `sprintable_mcp/tools/*.py`, cross-checked against actual backend routers/schemas (this checkout has both). Exactly **3 tools, 1 root cause**: `send_chat_message`, `list_chat_messages`, `get_chat_message` all take request `thread_id` meaning conversation_id (substituted into `/api/v2/conversations/{id}/...`), while their responses pass through backend's `_msg_payload()` (`app/routers/conversations.py:394`), which always includes a genuine `thread_id` field too — the reply-thread id (nullable, usually null), unrelated to the conversation. No other field-name collision of this shape exists anywhere else in the surveyed set (0 SUSPECTED, 0 additional CONFIRMED).
- **Fix (AC3, PO decision — alias)**: `conversation_id` is now the primary/documented field on all 3 Input models (`ConversationScopedInput` base in `chat.py`); `thread_id` stays as a deprecated alias. `extra="forbid"` (#2412) blocks *undeclared* args — both names are declared here, so there's no conflict with that gate. If both are given and disagree, the request is rejected (422/ValidationError) rather than silently picking one.
- Expiry condition is in the class docstring, same shape as the #2792 lint-disable pattern: drop the alias once real `thread_id` usage converges to zero.
- Response shape is untouched — `_msg_payload()` returning both `conversation_id` and `thread_id` is correct as-is. Added one line to each tool's description in `server.py`'s `_TOOL_DEFS` (what MCP callers actually see) clarifying that the response's `thread_id` means something different from the request's.

## Test plan (AC2 discriminator / AC4 positive control)
- [x] `test_2427_chat_conversation_id_alias.py` (11 tests):
  - `conversation_id` alone resolves; `thread_id` alone still works (backward compat — matches existing tests in `test_mcp_get_chat_message_3cf50d90.py` that already call with `thread_id=`).
  - Both given, same value → passes (negative control — the fix must not over-reject).
  - Both given, different values → rejected (positive control — the bug this closes).
  - Neither given → rejected (still required).
  - `extra="forbid"` unaffected (unrelated unknown arg still rejected).
  - **The litmus test PO asked for**: call again using the response's own `conversation_id` → works. Naively reusing the response's `thread_id` alone (the old trap) → now fails loudly with a clear "conversation_id가 필요합니다" instead of silently sending `None` into a URL path.
  - Full `Tool.run()`-level tests through the real registered tool (not just direct schema construction) for `sprintable_send_chat_message`: accepts `conversation_id`, rejects the conflicting-both-names shape, still accepts legacy `thread_id`-only calls.
- [x] Positive control on the implementation itself: sabotaged the conflict check → 2 tests (schema-level + `Tool.run()`-level) correctly went red, restored → green.
- [x] Existing chat MCP tests unaffected: `test_mcp_get_chat_message_3cf50d90.py`, `test_mcp_s1995_agent_doc_mentions.py`, `test_e_mcp_opt_s2_chat_attachment_tool.py`, `test_2412_mcp_unknown_arg_rejection.py` (including the 116-tool lockdown count) — all pass unchanged.
- [x] Full backend suite: 4404 passed, 13 pre-existing failures confirmed unrelated (same failures reproduce independent of this change — local `.mcp.json`/realdb-dependent tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)