### PR TITLE
fix(story #2428, phase 1/2): compound (created_at, id) cursor for 4 endpoints — not a pure refactor

### DIFF
--- a/backend/app/core/pagination.py
+++ b/backend/app/core/pagination.py
@@ -1,0 +1,90 @@
+"""story #2428 — 공용 cursor 페이지네이션 헬퍼(#2231 정본 규약 A: limit+1 오버페치 +
+has_more/next_cursor body meta).
+
+`encode_cursor`/`decode_cursor`는 story #1994(backlinks.py)가 이미 옳은 형태로 만들어 둔
+것을 그대로 옮겨왔다 — `created_at` 단독이 아니라 `(created_at, id)` 복합 opaque 토큰.
+`created_at`이 같은 두 행이 있으면(대량 생성·백필 등 흔한 상황) 단독 정렬키로는 페이지
+경계에서 행이 누락되거나 중복될 수 있다는 것을 docs.py(story #2191, `encode_doc_cursor`
+docstring 참조 — 그쪽은 `sort_order` 축이라 형태는 다르지만 같은 이유로 id 2차 정렬키를
+쓴다)와 backlinks.py 둘 다 각자 발견해서 각자 고쳤다.
+
+⚠️그런데 #2231이 정본으로 지목한 원본 구현(stories.py::list_comments/list_activities·
+notifications.py·conversations.py::list_messages)은 `created_at` 단독 정렬 + 단독 cursor
+그대로였다 — 같은 결함이 문서화되고 두 번 고쳐지는 동안 "정본"이라 불린 원본 넷에는 한
+번도 안 돌아갔다. "정본"이라는 라벨이 "가장 옳다"를 뜻하지 않았다(#2412가 story #2248의
+`/standups/history`만 고치고 `repo.list()`는 안 고쳤던 것과 같은 얼굴 — 매번 "한쪽만
+고친다"). 이 헬퍼로 그 넷을 이관하는 것은 리팩터가 아니라 그 결함의 수정이다 — 기존에
+발급된(단독 `created_at.isoformat()` 형태) cursor는 이 형태 변경으로 무효가 된다.
+`decode_cursor`가 그 구형 포맷을 구분해 명시적으로 거부한다(조용히 잘못 해석하지 않는다 —
+오늘 이 세션이 온종일 잡은 그 병과 동형).
+"""
+from __future__ import annotations
+
+import base64
+import json
+import uuid
+from collections.abc import Callable, Sequence
+from datetime import datetime
+from typing import TypeVar
+
+from fastapi import HTTPException
+
+T = TypeVar("T")
+
+
+def encode_cursor(created_at: datetime, id_: uuid.UUID) -> str:
+    """opaque composite keyset cursor — `(created_at, id)` 둘 다 인코드해 같은 `created_at`을
+    가진 여러 행이 페이지 경계에서 영구 드롭/중복되지 않게 한다. 클라이언트는 이 토큰을 절대
+    파싱하지 않고(불투명) 그대로 다음 요청에 되돌려준다."""
+    payload = {"created_at": created_at.isoformat(), "id": str(id_)}
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii")
+
+
+def decode_cursor(token: str) -> tuple[datetime, uuid.UUID]:
+    """`encode_cursor`의 역함수. 손상/변조된 토큰은 400(Invalid cursor format).
+
+    story #2428: 이 헬퍼로 막 이관된 호출부(stories.py/notifications.py/conversations.py)는
+    이전엔 커서가 `created_at.isoformat()` 평문이었다 — 그 구형 토큰이 들어오면 base64/JSON
+    파싱에 실패해 자연스럽게 400이 나지만, 그것만으론 호출자가 "왜" 깨졌는지 모른다(오타
+    커서와 구분 안 됨). 원본 토큰이 그 자체로 유효한 ISO datetime으로 파싱되면(신형 토큰은
+    base64+JSON이라 이렇게 우연히 파싱될 확률이 사실상 0) 구형 포맷이었다고 보고 전용
+    메시지로 명시적으로 안내한다 — 조용히 잘못 해석해 틀린 페이지를 주는 대신, 처음부터
+    다시 부르라고 말해준다.
+    """
+    try:
+        raw = base64.urlsafe_b64decode(token.encode("ascii"))
+        payload = json.loads(raw)
+        return datetime.fromisoformat(payload["created_at"]), uuid.UUID(str(payload["id"]))
+    except Exception as exc:
+        try:
+            datetime.fromisoformat(token)
+            is_legacy_cursor = True
+        except (ValueError, TypeError):
+            is_legacy_cursor = False
+        if is_legacy_cursor:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "cursor 형식이 바뀌었습니다(story #2428 — 페이지 경계 동률 버그 수정). "
+                    "next_cursor 값을 다시 받아 처음부터 호출하세요."
+                ),
+            ) from exc
+        raise HTTPException(status_code=400, detail="Invalid cursor format") from exc
+
+
+def assemble_page(
+    rows: Sequence[T], limit: int, cursor_key: Callable[[T], tuple[datetime, uuid.UUID]]
+) -> tuple[list[T], bool, str | None]:
+    """`rows`는 이미 limit+1개까지 조회된 상태로 들어온다(호출부에서 overfetch, order_by는
+    반드시 `(정렬컬럼 DESC, id DESC)` 복합이어야 이 헬퍼의 전제가 성립한다). `cursor_key`는
+    페이지 마지막 행에서 `(created_at, id)`를 뽑는 함수 — 정렬 기준 컬럼이 `created_at`이
+    아닌 경우(예: updated_at)에도 재사용 가능하도록 호출부가 넘긴다.
+
+    반환: (해당 페이지 행 목록, has_more, next_cursor) — `#2231` body meta(`{"has_more":
+    ..., "next_cursor": ...}`)에 그대로 넣으면 된다.
+    """
+    has_more = len(rows) > limit
+    page = list(rows[:limit])
+    next_cursor = encode_cursor(*cursor_key(page[-1])) if has_more and page else None
+    return page, has_more, next_cursor

--- a/backend/app/repositories/notification.py
+++ b/backend/app/repositories/notification.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import select, update
+from sqlalchemy import select, tuple_, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.notification import InboxItem, Notification, NotificationSetting
@@ -21,16 +21,25 @@ class NotificationRepository(BaseRepository[Notification]):
         is_read: bool | None = None,
         limit: int = 200,
         before: datetime | None = None,
+        before_id: uuid.UUID | None = None,
     ) -> list[Notification]:  # type: ignore[override]
+        """story #2428: `before`(created_at) 단독 커서는 동률(같은 created_at) 시 페이지
+        경계에서 행이 누락/중복될 수 있었다 — `before_id`가 같이 오면 (created_at, id) 복합
+        비교로 전환한다(호출부 routers/notifications.py가 새 cursor 포맷 이관 시 항상 같이
+        넘김). `before_id` 없이 `before`만 오는 옛 호출부는 없다 — 있었다면 그게 바로 이
+        결함의 재현 경로였을 것.
+        """
         q = select(Notification).where(
             self._org_filter(),
             Notification.user_id == user_id,
         )
         if is_read is not None:
             q = q.where(Notification.is_read == is_read)
-        if before is not None:
+        if before is not None and before_id is not None:
+            q = q.where(tuple_(Notification.created_at, Notification.id) < tuple_(before, before_id))
+        elif before is not None:
             q = q.where(Notification.created_at < before)
-        q = q.order_by(Notification.created_at.desc()).limit(limit)
+        q = q.order_by(Notification.created_at.desc(), Notification.id.desc()).limit(limit)
         result = await self.session.execute(q)
         return list(result.scalars().all())
 

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -9,12 +9,13 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict, Field, field_validator
-from sqlalchemy import and_, func, select, text, update
+from sqlalchemy import and_, func, select, text, tuple_, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
 from app.core.config import settings
+from app.core.pagination import assemble_page, decode_cursor
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
@@ -1382,6 +1383,11 @@ async def list_messages(
 
     thread_id 미지정: top-level 메시지만 반환 (thread_id IS NULL).
     thread_id 지정: 해당 thread의 reply 목록 반환.
+
+    story #2428: cursor가 `created_at` 단독이라 동률 시 페이지 경계에서 메시지가 누락/중복될
+    수 있었다(docs.py·backlinks.py가 각자 발견해 고친 것과 동형 결함 — #2231이 이 함수를
+    "참조 구현"으로 지목했는데 정작 이 결함을 안고 있었다). (created_at, id) 복합 cursor로
+    이관 — 순수 리팩터 아님, 기존 cursor 무효화.
     """
     await _authorize_message_read(conversation_id, db, auth, org_id)
 
@@ -1393,19 +1399,18 @@ async def list_messages(
     stmt = (
         select(ConversationMessage)
         .where(ConversationMessage.conversation_id == conversation_id, thread_filter)
-        .order_by(ConversationMessage.created_at.desc())
+        .order_by(ConversationMessage.created_at.desc(), ConversationMessage.id.desc())
         .limit(limit + 1)
     )
     if before:
-        try:
-            before_dt = datetime.fromisoformat(before)
-        except ValueError:
-            raise HTTPException(status_code=400, detail="Invalid cursor format")
-        stmt = stmt.where(ConversationMessage.created_at < before_dt)
+        before_dt, before_id = decode_cursor(before)
+        stmt = stmt.where(tuple_(ConversationMessage.created_at, ConversationMessage.id) < tuple_(before_dt, before_id))
 
     rows = (await db.execute(stmt)).scalars().all()
-    has_more = len(rows) > limit
-    msgs = list(reversed(rows[:limit]))
+    page, has_more, next_cursor = assemble_page(rows, limit, lambda m: (m.created_at, m.id))
+    # 화면 표시는 오래된→최신 순(자연스러운 대화 순서) — cursor 경계 계산은 desc 원본
+    # `page`(assemble_page가 그 순서로 계산)에서 이미 끝났으니 여기서 reverse해도 안전.
+    msgs = list(reversed(page))
 
     sender_ids = {m.sender_id for m in msgs if m.sender_id}
     member_map = await lookup_members_by_ids(sender_ids, db)
@@ -1420,7 +1425,6 @@ async def list_messages(
         _msg_payload(m, member_map.get(m.sender_id), references=refs_by_msg.get(m.id, []))
         for m in msgs
     ]
-    next_cursor = msgs[0].created_at.isoformat() if has_more and msgs else None
 
     return {"data": data, "meta": {"next_cursor": next_cursor, "has_more": has_more}}
 
@@ -1472,6 +1476,9 @@ async def list_message_replies(
 
     story 3cf50d90: list_messages의 `?thread_id=` 파라미터와 동형 필터(discoverability용 전용
     서브리소스 — 호출자가 thread_id 쿼리파라미터의 존재를 몰라도 원문 리플 왕복이 가능하도록).
+
+    story #2428: list_messages와 동형 결함(단독 created_at cursor, 동률 시 페이지 경계
+    누락/중복) — (created_at, id) 복합 cursor로 이관. 순수 리팩터 아님, 기존 cursor 무효화.
     """
     await _authorize_message_read(conversation_id, db, auth, org_id)
 
@@ -1481,19 +1488,16 @@ async def list_message_replies(
             ConversationMessage.conversation_id == conversation_id,
             ConversationMessage.thread_id == message_id,
         )
-        .order_by(ConversationMessage.created_at.desc())
+        .order_by(ConversationMessage.created_at.desc(), ConversationMessage.id.desc())
         .limit(limit + 1)
     )
     if before:
-        try:
-            before_dt = datetime.fromisoformat(before)
-        except ValueError:
-            raise HTTPException(status_code=400, detail="Invalid cursor format")
-        stmt = stmt.where(ConversationMessage.created_at < before_dt)
+        before_dt, before_id = decode_cursor(before)
+        stmt = stmt.where(tuple_(ConversationMessage.created_at, ConversationMessage.id) < tuple_(before_dt, before_id))
 
     rows = (await db.execute(stmt)).scalars().all()
-    has_more = len(rows) > limit
-    msgs = list(reversed(rows[:limit]))
+    page, has_more, next_cursor = assemble_page(rows, limit, lambda m: (m.created_at, m.id))
+    msgs = list(reversed(page))
 
     sender_ids = {m.sender_id for m in msgs if m.sender_id}
     member_map = await lookup_members_by_ids(sender_ids, db)
@@ -1507,7 +1511,6 @@ async def list_message_replies(
         _msg_payload(m, member_map.get(m.sender_id), references=refs_by_msg.get(m.id, []))
         for m in msgs
     ]
-    next_cursor = msgs[0].created_at.isoformat() if has_more and msgs else None
 
     return {"data": data, "meta": {"next_cursor": next_cursor, "has_more": has_more}}
 

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.pagination import assemble_page, decode_cursor
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.dependencies.ownership import _is_org_admin
@@ -91,22 +92,25 @@ async def list_notifications(
     인박스 페이지 기본 탭이 FE 고정 limit=50·커서 없음이라 51번째부터 조용히 잘렸었다
     (참조 구현: conversations.py::list_messages — 동일 오버페치+cursor 패턴).
     MCP check_notifications 호환: unread=true → is_read=False 변환.
+
+    story #2428: "정본"이 사실 `created_at` 단독 cursor였다 — 동률 시 페이지 경계 누락/중복
+    (docs.py·backlinks.py가 각자 발견해 고친 것과 동형 결함, 이 "정본"엔 한 번도 안 돌아갔었다).
+    (created_at, id) 복합 cursor로 이관 — 순수 리팩터 아님, 기존 cursor 무효화(decode_cursor가
+    구형 포맷을 명시로 거부).
     """
     user_id = await _resolve_notification_user_id(auth, db)
     resolved_is_read = (not unread) if unread is not None else is_read
     before_dt: datetime | None = None
+    before_id: uuid.UUID | None = None
     # #2540 CI 교훈(오르테가군, 2026-07-27): "값이 있는지"만 보면 안 되고 "그 값이
     # 문자열인지"까지 봐야 한다 — 이 함수를 FastAPI DI 없이 직접 호출하며 before= 를
     # 누락하면 파이썬 기본값인 Query(...) 센티넬 객체(truthy)가 그대로 들어온다.
     if isinstance(before, str) and before:
-        try:
-            before_dt = datetime.fromisoformat(before)
-        except ValueError:
-            raise HTTPException(status_code=400, detail="Invalid cursor format")
-    rows = await repo.list(user_id=user_id, is_read=resolved_is_read, limit=limit + 1, before=before_dt)
-    has_more = len(rows) > limit
-    page = rows[:limit]
-    next_cursor = page[-1].created_at.isoformat() if has_more and page else None
+        before_dt, before_id = decode_cursor(before)
+    rows = await repo.list(
+        user_id=user_id, is_read=resolved_is_read, limit=limit + 1, before=before_dt, before_id=before_id,
+    )
+    page, has_more, next_cursor = assemble_page(rows, limit, lambda n: (n.created_at, n.id))
     return {
         "data": [NotificationResponse.model_validate(n) for n in page],
         "meta": {"has_more": has_more, "next_cursor": next_cursor},

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -6,10 +6,11 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Query, Response
 from pydantic import BaseModel, field_validator
-from sqlalchemy import or_, select, text
+from sqlalchemy import or_, select, text, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
+from app.core.pagination import assemble_page, decode_cursor
 from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user, get_project_scoped_org_id, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.deletion_audit import DeletionAuditLog
@@ -2242,6 +2243,13 @@ async def list_comments(
     죽은 파라미터) — FE(story-detail-panel.tsx)는 이미 이 파라미터로 「더보기」를 완결해
     두고 기다리고 있었다. #2231 정본 규약 A(limit+1 오버페치 + has_more/next_cursor body
     meta, 참조 구현: conversations.py::list_messages)로 실제 동작하게 한다.
+
+    story #2428: 그 "정본"이 사실 `created_at` 단독 정렬+cursor였다 — 동률(같은 created_at)
+    두 행이 페이지 경계에 걸치면 행이 누락/중복될 수 있었다(docs.py encode_doc_cursor·
+    backlinks.py encode_cursor가 각자 발견해 고친 것과 동형 결함인데 이 "정본"엔 한 번도
+    안 돌아갔었다). `app.core.pagination`의 (created_at, id) 복합 cursor로 이관 — 순수
+    리팩터가 아니라 수정이다. 기존(단독 평문) cursor는 이제 무효이며 `decode_cursor`가
+    명시로 거부한다(조용히 재해석해 틀린 페이지를 주지 않는다).
     """
     # SEC(story #2206, 까심 인가 전수 스윕 A급): 쿼리 술어가 StoryComment.story_id == id 뿐이라
     # org_id 조건 자체가 없었다(project-only 누락이 아니라 org 조건 부재 — 같은 파일 다른
@@ -2257,17 +2265,12 @@ async def list_comments(
     # 한다 — 이 함수를 FastAPI DI 없이 직접 호출하며 cursor= 를 누락하면 파이썬 기본값인
     # Query(...) 센티넬 객체(truthy) 가 그대로 들어온다. 문자열이 아니면 커서 없음으로 취급.
     if isinstance(cursor, str) and cursor:
-        try:
-            cursor_dt = datetime.fromisoformat(cursor)
-        except ValueError:
-            raise HTTPException(status_code=400, detail="Invalid cursor format")
-        q = q.where(StoryComment.created_at < cursor_dt)
-    q = q.order_by(StoryComment.created_at.desc()).limit(limit + 1)
+        cursor_dt, cursor_id = decode_cursor(cursor)
+        q = q.where(tuple_(StoryComment.created_at, StoryComment.id) < tuple_(cursor_dt, cursor_id))
+    q = q.order_by(StoryComment.created_at.desc(), StoryComment.id.desc()).limit(limit + 1)
     result = await db.execute(q)
     rows = list(result.scalars())
-    has_more = len(rows) > limit
-    page = rows[:limit]
-    next_cursor = page[-1].created_at.isoformat() if has_more and page else None
+    page, has_more, next_cursor = assemble_page(rows, limit, lambda r: (r.created_at, r.id))
     return {
         "data": [CommentResponse.model_validate(r) for r in page],
         "meta": {"has_more": has_more, "next_cursor": next_cursor},
@@ -2403,6 +2406,9 @@ async def list_activities(
     이 엔드포인트에 cursor 자체가 없어 원천적으로 도달 불가였다(#2231 표 CAPPED-NO-NEXT-PAGE).
     #2231 정본 규약 A(limit+1 오버페치 + has_more/next_cursor body meta, 참조 구현:
     stories.py::list_comments — #2230에서 이미 같은 처방을 받은 형제 엔드포인트)로 도달 가능하게 한다.
+
+    story #2428: list_comments와 동형 결함(단독 created_at cursor, 동률 시 페이지 경계
+    누락/중복) — (created_at, id) 복합 cursor로 이관. 순수 리팩터 아님, 기존 cursor 무효화.
     """
     # SEC(story #2206) — list_comments(1339)와 동형 갭·동형 처방. 자세한 사유는 그쪽 주석 참조.
     story = await repo.get(id)
@@ -2414,17 +2420,12 @@ async def list_activities(
     # 한다 — 이 함수를 FastAPI DI 없이 직접 호출하며 cursor= 를 누락하면 파이썬 기본값인
     # Query(...) 센티넬 객체(truthy) 가 그대로 들어온다. 문자열이 아니면 커서 없음으로 취급.
     if isinstance(cursor, str) and cursor:
-        try:
-            cursor_dt = datetime.fromisoformat(cursor)
-        except ValueError:
-            raise HTTPException(status_code=400, detail="Invalid cursor format")
-        q = q.where(StoryActivity.created_at < cursor_dt)
-    q = q.order_by(StoryActivity.created_at.desc()).limit(limit + 1)
+        cursor_dt, cursor_id = decode_cursor(cursor)
+        q = q.where(tuple_(StoryActivity.created_at, StoryActivity.id) < tuple_(cursor_dt, cursor_id))
+    q = q.order_by(StoryActivity.created_at.desc(), StoryActivity.id.desc()).limit(limit + 1)
     result = await db.execute(q)
     rows = list(result.scalars())
-    has_more = len(rows) > limit
-    page = rows[:limit]
-    next_cursor = page[-1].created_at.isoformat() if has_more and page else None
+    page, has_more, next_cursor = assemble_page(rows, limit, lambda r: (r.created_at, r.id))
     return {
         "data": [ActivityResponse.model_validate(r) for r in page],
         "meta": {"has_more": has_more, "next_cursor": next_cursor},

--- a/backend/app/services/backlinks.py
+++ b/backend/app/services/backlinks.py
@@ -171,8 +171,6 @@ org로 그대로 새는 IDOR이었다(row 자체를 숨기는 게 아니라, row
 """
 from __future__ import annotations
 
-import base64
-import json
 import uuid
 from datetime import datetime
 
@@ -180,6 +178,7 @@ from fastapi import HTTPException
 from sqlalchemy import and_, false as sa_false, func, or_, select, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.pagination import decode_cursor, encode_cursor
 from app.dependencies.auth import AuthContext
 from app.models.conversation import Conversation, ConversationMessage
 from app.models.doc import Doc
@@ -219,25 +218,6 @@ def _member_summary_same_org(resolved: ResolvedMember | None, org_id: uuid.UUID)
         return None
     return {"id": str(resolved.id), "name": resolved.name, "type": resolved.type}
 
-
-def encode_cursor(created_at: datetime, id_: uuid.UUID) -> str:
-    """story #1994 B3: opaque composite keyset cursor — `(created_at, id)` 둘 다 인코드해
-    같은 `created_at`을 가진 여러 mention이 페이지 경계에서 영구 드롭되지 않도록 한다.
-    클라이언트는 이 토큰을 절대 파싱하지 않고(불투명) 그대로 다음 요청의 `before`에 되돌려준다."""
-    payload = {"created_at": created_at.isoformat(), "id": str(id_)}
-    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
-    return base64.urlsafe_b64encode(raw).decode("ascii")
-
-
-def decode_cursor(token: str) -> tuple[datetime, uuid.UUID]:
-    """`encode_cursor`의 역함수. 손상/변조된 토큰은 400(Invalid cursor format) — 파싱 실패를
-    500으로 흘리지 않는다."""
-    try:
-        raw = base64.urlsafe_b64decode(token.encode("ascii"))
-        payload = json.loads(raw)
-        return datetime.fromisoformat(payload["created_at"]), uuid.UUID(str(payload["id"]))
-    except Exception as exc:  # noqa: BLE001 — 모든 파싱 실패를 균일하게 400으로 정규화
-        raise HTTPException(status_code=400, detail="Invalid cursor format") from exc
 
 
 async def _chat_predicate_inputs(

--- a/backend/tests/test_2428_cursor_tiebreak_realdb.py
+++ b/backend/tests/test_2428_cursor_tiebreak_realdb.py
@@ -1,0 +1,203 @@
+"""story #2428 — cursor 페이지네이션이 `created_at` 단독 정렬/커서였던 4곳(stories.py::
+list_comments·list_activities·notifications.py::list_notifications·conversations.py::
+list_messages ×2)에서, 같은 `created_at`을 가진 두 행이 페이지 경계에 걸치면 행이
+누락되거나 중복될 수 있었다 — docs.py(#2191)·backlinks.py(#1994)가 각자 발견해 각자
+고친 결함과 동형인데, `#2231`이 "정본"으로 지목한 이 넷엔 한 번도 안 돌아갔다.
+
+이 테스트는 그 정확한 시나리오를 실 Postgres로 재현한다: `created_at`이 완전히 같은 두
+행을 만들어 `limit=1` 페이지 경계에 걸치게 하고, (created_at, id) 복합 cursor로 넘어간
+뒤엔 누락/중복 없이 전부 도달 가능한지 확認한다.
+
+positive control(AC4류): 이 파일은 notifications 도메인에서 실측한다 — 아래
+`test_tie_break_page_boundary_no_drop_or_duplicate_realdb`가 통과하는 것 자체가
+"수정 후" 증거다. "수정 전"(단독 created_at cursor) 재현은 `_legacy_single_column_query`가
+별도로 흉내내 같은 조건에서 실제로 행이 드롭되는 것을 보인다(#2412 스타일 — 코드를
+되돌리는 대신, 옛 쿼리 형태를 로컬 함수로 나란히 재현해 대조).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("d2428000-0000-0000-0000-000000000001")
+USER = uuid.UUID("d2428000-0000-0000-0000-000000000002")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _clean(s):
+    await s.execute(text(f"DELETE FROM notifications WHERE org_id='{ORG}'"))
+    await s.commit()
+
+
+async def _seed_tie(s) -> list[uuid.UUID]:
+    """3건: 최신 둘(A·B)이 «완전히 같은 created_at»으로 경계에 걸치고, 하나(C)는 더 오래됨.
+    삽입 순서는 의도적으로 A·B·C 순(정렬과 무관하게 섞음 — id 자체는 uuid4라 정렬 순서를
+    예측할 수 없으므로, 어느 쪽이 A/B인지는 실제 (created_at,id) 정렬 결과로 판정한다)."""
+    await _clean(s)
+    tie_at = datetime(2026, 8, 1, 12, 0, 0, tzinfo=timezone.utc)
+    older_at = tie_at - timedelta(days=1)
+    ids = {}
+    for label, ts in (("A", tie_at), ("B", tie_at), ("C", older_at)):
+        nid = uuid.uuid4()
+        ids[label] = nid
+        await s.execute(text(
+            f"INSERT INTO notifications (id,org_id,user_id,type,title,is_read,created_at) VALUES "
+            f"('{nid}','{ORG}','{USER}','test','{label}',false,'{ts.isoformat()}')"
+        ))
+    await s.commit()
+    return ids
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+
+
+@pytest.mark.anyio
+async def test_tie_break_page_boundary_no_drop_or_duplicate_realdb():
+    """AC 본체 — limit=1로 강제 페이지네이션, A/B(동률) 둘 다 빠짐/중복 없이 나와야 한다."""
+    from app.routers.notifications import list_notifications
+    from app.repositories.notification import NotificationRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            ids = await _seed_tie(s)
+        by_id = {v: k for k, v in ids.items()}
+
+        seen_labels: list[str] = []
+        cursor = None
+        for _ in range(5):  # 안전 상한(무한루프 방지) — 실제로는 3페이지면 끝나야 한다
+            async with Session() as s:
+                repo = NotificationRepository(s, ORG)
+                page = await list_notifications(
+                    unread=None, is_read=None, limit=1, before=cursor,
+                    db=s, auth=_auth(), repo=repo,
+                )
+            assert len(page["data"]) == 1
+            seen_labels.append(by_id[page["data"][0].id])
+            if not page["meta"]["has_more"]:
+                assert page["meta"]["next_cursor"] is None
+                break
+            cursor = page["meta"]["next_cursor"]
+        else:
+            pytest.fail("5페이지 넘게 끝나지 않음 — 무한루프(중복 재방문) 의심")
+
+        assert sorted(seen_labels) == ["A", "B", "C"], (
+            f"동률 경계에서 행이 빠지거나 중복됐다: {seen_labels}"
+        )
+        assert len(seen_labels) == len(set(seen_labels)), f"중복 방문: {seen_labels}"
+    finally:
+        async with Session() as s:
+            await _clean(s)
+        await eng.dispose()
+
+
+async def _legacy_single_column_query(session, org_id, user_id, limit, before_dt):
+    """story #2428 — 수정 «전» 쿼리 형태를 로컬로 재현(코드를 되돌리지 않고 나란히 비교).
+    routers/notifications.py가 실제로 갖고 있던 형태: `created_at DESC` 단독 정렬 + 단독
+    `created_at < before` cursor."""
+    from app.models.notification import Notification
+
+    q = select(Notification).where(Notification.org_id == org_id, Notification.user_id == user_id)
+    if before_dt is not None:
+        q = q.where(Notification.created_at < before_dt)
+    q = q.order_by(Notification.created_at.desc()).limit(limit)
+    result = await session.execute(q)
+    return list(result.scalars().all())
+
+
+@pytest.mark.anyio
+async def test_legacy_single_column_cursor_actually_drops_a_row_realdb():
+    """positive control — «수정 전» 형태가 실제로 이 시나리오에서 행을 드롭시키는 것을
+    직접 재현. 이게 없으면 위 test가 통과하는 이유가 "애초에 안 깨지는 시나리오라서"인지
+    "진짜로 고쳐서"인지 구분이 안 된다."""
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            ids = await _seed_tie(s)
+        by_id = {v: k for k, v in ids.items()}
+
+        async with Session() as s:
+            page1 = await _legacy_single_column_query(s, ORG, USER, limit=1, before_dt=None)
+        assert len(page1) == 1
+        page1_label = by_id[page1[0].id]
+        assert page1_label in ("A", "B")  # 동률 둘 중 하나(DB가 임의로 고른 순서)
+
+        # 레거시 커서: created_at.isoformat()만 — id 정보 없음.
+        legacy_cursor = page1[0].created_at
+
+        async with Session() as s:
+            page2 = await _legacy_single_column_query(s, ORG, USER, limit=1, before_dt=legacy_cursor)
+        page2_labels = [by_id[r.id] for r in page2]
+
+        # 레거시 형태의 결함 재현: created_at < cursor는 "같은 created_at"인 동률 짝을
+        # 자동으로 건너뛴다 — page2는 동률 짝(A/B 중 나머지)이 아니라 곧장 C로 간다.
+        assert "C" in page2_labels
+        remaining_tied = {"A", "B"} - {page1_label}
+        assert not (remaining_tied & set(page2_labels)), (
+            f"예상대로라면 동률 짝({remaining_tied})이 여기서 «드롭»되는 게 결함 재현인데 "
+            f"실제로 나왔다({page2_labels}) — 이 테스트 자체가 시나리오를 잘못 재현했을 수 있다."
+        )
+    finally:
+        async with Session() as s:
+            await _clean(s)
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_tie_normal_data_page_result_unaffected_realdb():
+    """음성대조 — created_at이 전부 다른 평범한 데이터에선 신구 방식 결과가 같아야 한다."""
+    from app.routers.notifications import list_notifications
+    from app.repositories.notification import NotificationRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _clean(s)
+            base = datetime(2026, 7, 1, tzinfo=timezone.utc)
+            ids = []
+            for i in range(4):
+                nid = uuid.uuid4()
+                ids.append(nid)
+                ts = base + timedelta(hours=i)
+                await s.execute(text(
+                    f"INSERT INTO notifications (id,org_id,user_id,type,title,is_read,created_at) VALUES "
+                    f"('{nid}','{ORG}','{USER}','test','n{i}',false,'{ts.isoformat()}')"
+                ))
+            await s.commit()
+        newest_first = list(reversed(ids))
+
+        async with Session() as s:
+            repo = NotificationRepository(s, ORG)
+            page = await list_notifications(
+                unread=None, is_read=None, limit=10, before=None, db=s, auth=_auth(), repo=repo,
+            )
+        got_ids = [d.id for d in page["data"]]
+        assert got_ids == newest_first
+        assert page["meta"]["has_more"] is False
+    finally:
+        async with Session() as s:
+            await _clean(s)
+        await eng.dispose()


### PR DESCRIPTION
## This is not a pure refactor

4 endpoints' cursor pagination format changes. Previously-issued cursors from before this change are now explicitly rejected (clear "format changed, restart" message) — not silently reinterpreted.

## Summary

story #2428 started as "21 list/search MCP tools have no limit parameter at all" (found while auditing the fallout from `#2412`'s unknown-arg-rejection fix). Before extending the `#2231` canonical `has_more`/`next_cursor` shape to those 21 tools, 올리베이라군 asked whether the 6 existing hand-copied implementations of that shape were actually identical — they weren't.

## The finding

`docs.py`(`#2191`, `encode_doc_cursor`) and `backlinks.py`(`#1994`, `encode_cursor`) each independently discovered and fixed the same defect: sorting/paginating by `created_at` alone means two rows sharing the exact same timestamp (common under bulk creation/backfills) can straddle a page boundary and get silently dropped or duplicated. Both fixed it by adding `id` as a second sort/cursor key.

That fix never propagated back to the 4 sibling endpoints `#2231` named as the *canonical reference implementation* for this pattern:
- `stories.py::list_comments`
- `stories.py::list_activities`
- `notifications.py` (`list_notifications`, via `NotificationRepository.list`)
- `conversations.py::list_messages` (top-level + thread replies)

All 4 were still on the older, single-column `created_at` cursor — exposed to the exact bug docs.py/backlinks.py had already found and fixed elsewhere. "Canonical" didn't mean "most correct" here. Same shape as `#2412`'s finding that `#2248` fixed `/standups/history` but left `repo.list()` (the thing actually shared) broken — a fix landing on one sibling and never reaching the one held up as the reference.

## Fix

Extracted the already-correct `(created_at, id)` compound cursor logic (previously private to `backlinks.py`) into a shared `app/core/pagination.py`: `encode_cursor`/`decode_cursor`/`assemble_page`. Migrated the 4 endpoints above to use it — compound sort key, compound cursor comparison, `assemble_page` for the `has_more`/`next_cursor` envelope.

`decode_cursor` explicitly distinguishes old-format cursors: if a token happens to parse as a bare ISO datetime (new-format tokens are base64-encoded JSON and essentially never coincide), it returns a distinct 400 telling the caller the format changed and to restart — not a generic parse error, and never a silent reinterpretation.

`BaseRepository.list_paginated()` (a separate, total-count-based pagination shape used elsewhere, e.g. `goal.py`) is untouched — a different axis, reconciling the two shapes is explicitly out of scope here.

## Verified (real Postgres)

- Seeded two notifications sharing an identical `created_at`, forced pagination with `limit=1` across that boundary. All 3 seeded rows (the tied pair + one older) reachable with no drop, no duplicate, no infinite loop.
- **Positive control**: a local reproduction of the pre-fix single-column query (`_legacy_single_column_query`, not a reverted code path — a parallel function run against the same seed) actually drops the tied sibling row under the identical scenario. Confirms the test is exercising the real defect, not a scenario that happens to pass either way.
- **Negative control**: normal (all-distinct-timestamp) data pages identically to before.
- Old-cursor rejection verified at both the `decode_cursor` unit level and the full router level (`list_notifications` called with a pre-#2428-format cursor).
- Full existing regression suite for the 4 touched endpoints + docs.py's own cursor tests: 95 passed, 0 failures (one unrelated flaky test in a different file — `test_e_canvas_c2_s6_artifact_comments_realdb.py`'s MCP roundtrip — confirmed via git-stash comparison to be pre-existing test-ordering fragility, reproduces identically on clean `develop` with the same file combination, unrelated to this change).

**Root cause of that flaky test, tracked separately as story #2429** (not fixed here, out of scope): `tests/test_authz_project_scope_coverage.py:36` does `sys.path.insert(0, str(Path(__file__).parent))` to import its own local helper — but `backend/tests/mcp/` is a real package (has `__init__.py`), so once `backend/tests/` is prepended to `sys.path`, any later `from mcp.types import ...` resolves to that test directory instead of the real PyPI `mcp` SDK. Minimal repro (~2s): `pytest tests/test_authz_project_scope_coverage.py tests/test_e_canvas_c2_s6_artifact_comments_realdb.py -q` — fails in either file order; either file alone passes.

## Scope note — phase 2 not included here

The original ask (21 list/search MCP tools with no limit param at all — `sprintable_search_stories`, `sprintable_poll_events`, etc., story #2428's other half) is separate follow-up work. This PR is exclusively the "make the existing canonical pattern actually correct, in one shared place" phase — extending it to the 21 tools happens next, on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
