### PR TITLE
fix(#2426): MCP Cloud Run 을 배포 파이프라인에 넣고, 목록이 갈리면 빨간불이 되게 한다

### DIFF
--- a/.github/workflows/deploy-target-coverage-guard.yml
+++ b/.github/workflows/deploy-target-coverage-guard.yml
@@ -1,0 +1,45 @@
+# story #2426 (2026-08-02) — 「파이프라인이 배포하는 서비스」와 「실제 존재하는 Cloud Run
+# 서비스」가 갈리면 빨간불.
+#
+# ⛔이 가드가 없으면 무슨 일이 나는가: sprintable-mcp-{dev,prod} 가 cloudbuild.yaml 의 배포
+#   대상이 아니어서 dev 는 4일, prod 는 main HEAD 대비 449 커밋 뒤처진 채로 «요청을 받고»
+#   있었다. 아무 알림도 없었다 — 목록 밖은 아무도 안 보기 때문이다.
+#
+# ⚠️이 가드가 «못 잡는 것»(선언):
+#   - 손으로 만든 서비스는 다음 push 때까지 안 잡힌다(schedule 을 안 걸었다 — 매일 도는
+#     초록은 잡음이 되고, 그러면 진짜 빨강도 배경음이 된다).
+#   - 배포는 되는데 «환경변수»가 파이프라인 밖인 것은 안 본다.
+#   - 서비스가 «최신 이미지인지»는 안 본다 — 그건 각 deploy 스텝의 검산 몫이다.
+name: Deploy target coverage guard
+
+on:
+  push:
+    branches: [develop, main]
+    paths:
+      - 'cloudbuild.yaml'
+      - 'scripts/verify-deploy-target-coverage.sh'
+      - '.github/workflows/deploy-target-coverage-guard.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write  # Workload Identity Federation
+
+jobs:
+  coverage:
+    name: Cloud Run 배포 대상 누락 검사
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to GCP (Workload Identity Federation)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: 배포 대상 ↔ 실제 서비스 대조
+        run: bash scripts/verify-deploy-target-coverage.sh

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -471,6 +471,47 @@ steps:
           --quiet
     waitFor: [run-migrate-job]
 
+  # story #2426(2026-08-02) — MCP Cloud Run 서비스를 배포 대상에 넣는다.
+  # ⛔발견 경위: `sprintable-mcp-dev` 가 2026-07-29 코드(4일 전), `sprintable-mcp-prod` 가
+  # 2026-07-28 코드(main HEAD 대비 449 커밋 前)로 돌고 있었다. 넷이 **같은 backend 이미지**를
+  # 쓰도록 만들어진 짝인데, 이 파일이 backend·frontend·realtime 셋만 배포하고 mcp 둘은
+  # 목록 밖이었다. `.github` 전체에 `sprintable-mcp-dev` 문자열 0건 — 아무 자동화도 없었다.
+  # (`publish-mcp.yml` 은 PyPI 패키지 공개용이고 Cloud Run 과 무관하다. 「MCP 배포」라는 말이
+  #  두 가지를 가리켜, 처음엔 그쪽을 원인으로 짚었다가 이미지 태그를 열어 보고 갈렸다.)
+  # ⇒ 그래서 오늘 고친 MCP 인자 검증(#2412)이 **정작 그 도구를 쓰는 서버에는 안 닿아 있었다.**
+  #
+  # ⚠️이 스텝이 **하지 않는 것**(선언): `services update --image` 만 쓰므로 **환경변수는 안 건드린다.**
+  # mcp 서비스의 env 는 지금도 파이프라인 밖(손 설정)이다 — 그 SSOT 화는 별건이다.
+  # `run deploy` 를 안 쓰는 이유가 이것이다: 지정 안 한 설정이 기본값으로 되돌아가면
+  # 「배포가 손 고침을 지우는」 쪽 사고가 난다(deploy-realtime 주석의 #2078 사례와 같은 병).
+  #
+  # ⚠️realtime 과 달리 **prod 게이트를 두지 않는다** — `sprintable-mcp-prod` 는 이미 존재하고
+  # 실제로 요청을 받고 있다(2026-08-02 실측). backend-prod 가 이 파이프라인으로 갱신되는데
+  # mcp-prod 만 안 따라가는 것이 바로 이 스토리가 없애려는 «불일치»다.
+  - id: deploy-mcp
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -euo pipefail
+        gcloud run services update sprintable-mcp-${_DEPLOY_ENV} \
+          --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA} \
+          --region=${_AR_REGION} \
+          --quiet
+        # 검산: 「배포 success」가 아니라 «서빙 이미지가 backend 와 같은 태그인가»로 잰다.
+        served=$(gcloud run services describe sprintable-mcp-${_DEPLOY_ENV} \
+          --region=${_AR_REGION} --format='value(spec.template.spec.containers[0].image)')
+        expected="${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA}"
+        if [ "$served" != "$expected" ]; then
+          echo "FAIL: mcp-${_DEPLOY_ENV} 서빙 이미지가 기대와 다르다"
+          echo "  서빙: $served"
+          echo "  기대: $expected"
+          exit 1
+        fi
+        echo "OK: sprintable-mcp-${_DEPLOY_ENV} = backend:${COMMIT_SHA}"
+    waitFor: [run-migrate-job]
+
   # story #2185(2026-07-27) — GCE MIG(realtime-gateway) 자동배포. deploy-realtime(위, Cloud
   # Run 폴백)과 별개 타깃이다. ⛔dev 전용 하드게이트 — prod GCE 는 실사용 중(48h 정상응답
   # 353건)이라 승인 없는 자동 재배포가 되면 안 된다. prod 를 붙이는 시점엔 사람이 이 가드를

--- a/scripts/verify-deploy-target-coverage.sh
+++ b/scripts/verify-deploy-target-coverage.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# story #2426 (2026-08-02) — 「파이프라인이 배포하는 서비스」와 「실제 존재하는 Cloud Run
+# 서비스」가 갈리면 빨간불.
+#
+# ⛔왜 이 가드가 필요한가: cloudbuild.yaml 에 mcp 를 «더하는» 것만으로는 같은 일이 다시 난다.
+#   다음에 서비스가 하나 더 생기면 또 목록 밖에 남는다 — 그리고 그것을 아무도 안 본다.
+#   실제로 sprintable-mcp-{dev,prod} 가 그렇게 4일·449커밋 뒤처져 있었다.
+#
+# ⚠️이 가드가 «못 보는 것»(선언):
+#   - 배포는 되는데 «환경변수»가 파이프라인 밖인 것은 안 본다(mcp 가 지금 그 상태다).
+#   - 서비스가 «최신 이미지인지»는 안 본다 — 그건 각 deploy 스텝의 검산 몫이다.
+#   - 이 가드는 「목록에 있는가」만 본다.
+set -euo pipefail
+
+REGION="${AR_REGION:-asia-northeast3}"
+PROJECT="${GCP_PROJECT:-sprintable-494803}"
+CB="${CLOUDBUILD_PATH:-cloudbuild.yaml}"
+
+# 이 레포의 파이프라인이 배포하지 «않는» 서비스 — «왜»를 반드시 적는다.
+# ⚠️같은 GCP 프로젝트에 «다른 레포»의 서비스가 함께 산다. 그것들을 「누락」으로 세면
+#   이 가드가 잡은 것을 전부 고쳐도 사고가 안 줄어든다(= 틀린 것을 세는 자가 된다).
+#   그래서 «이 레포 밖»임을 이유로 명시해 뺀다 — 이름만 보고 빼지 않는다.
+INTENTIONALLY_UNMANAGED=(
+  "sprintable-admin-web"       # moonklabs/sprintable-admin 레포 소유 — 이 파이프라인 밖
+  "sprintable-admin-web-dev"   # 위와 같음
+  "sprintable-internal-api"    # moonklabs/sprintable-admin 레포 소유 — 배포 자동화가 아예 없다
+  "sprintable-internal-api-dev" # 위와 같음 (수동 gcloud run deploy)
+)
+
+echo "== cloudbuild.yaml 이 배포하는 서비스 =="
+# `gcloud run deploy <name>` · `gcloud run services update <name>` 둘 다 센다.
+# ⚠️호출 형태가 스텝마다 다르다 — deploy-frontend 는 YAML args 배열, deploy-backend/realtime 은
+# bash 한 줄, deploy-mcp 는 `services update`. 그래서 «명령 형태»가 아니라 «서비스 이름 자체»를
+# 찾는다. 주석 줄과 인라인 주석은 걷어낸다(설명문에도 같은 이름이 나온다).
+# ⚠️mapfile 은 bash 4+ 라 macOS 기본 bash(3.2)에서 안 돈다 — 「CI 에서만 돌아가는 가드」가
+# 되지 않게 이식 가능한 형태로 읽는다.
+declared=()
+while IFS= read -r line; do declared+=("$line"); done < <(
+  sed -E 's/#.*//' "$CB" \
+    | grep -oE 'sprintable-[a-z-]+-\$\{_DEPLOY_ENV\}' \
+    | sed -E 's/\$\{_DEPLOY_ENV\}//' | sort -u
+)
+printf '  %s{dev,prod}\n' "${declared[@]}"
+
+if [ "${#declared[@]}" -eq 0 ]; then
+  echo "FAIL: cloudbuild.yaml 에서 배포 대상을 하나도 못 찾았다 — 이 스크립트의 패턴이 낡았을 수 있다."
+  echo "      (자기 재료를 못 찾으면 초록이 아니라 빨강이어야 한다)"
+  exit 1
+fi
+
+echo
+echo "== 실제 Cloud Run 서비스 (${REGION}) =="
+actual=()
+while IFS= read -r line; do actual+=("$line"); done < <(
+  gcloud run services list --region="$REGION" --project="$PROJECT" \
+    --format='value(metadata.name)' | sort
+)
+printf '  %s\n' "${actual[@]}"
+
+echo
+echo "== 대조 =="
+missing=()
+for svc in "${actual[@]}"; do
+  base="$(echo "$svc" | sed -E 's/-(dev|prod)$//')-"
+  covered=0
+  for d in "${declared[@]}"; do
+    [ "$d" = "$base" ] && covered=1 && break
+  done
+  # ⚠️bash 3.2 + `set -u` 에서 «빈 배열» 확장은 unbound variable 로 터진다 — 길이를 먼저 본다.
+  if [ "${#INTENTIONALLY_UNMANAGED[@]}" -gt 0 ]; then
+    for u in "${INTENTIONALLY_UNMANAGED[@]}"; do
+      [ "$u" = "$svc" ] && covered=1 && break
+    done
+  fi
+  [ "$covered" -eq 0 ] && missing+=("$svc")
+done
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "FAIL: 파이프라인이 배포하지 않는 Cloud Run 서비스가 있다:"
+  printf '  - %s\n' "${missing[@]}"
+  echo
+  echo "고칠 길 둘:"
+  echo "  ① cloudbuild.yaml 에 배포 스텝을 더한다 (기본)"
+  echo "  ② 의도적으로 밖에 두는 것이면 이 스크립트의 INTENTIONALLY_UNMANAGED 에"
+  echo "     «이유와 함께» 적는다 — 이유 없이 넣지 말 것"
+  exit 1
+fi
+
+echo "OK: 실제 서비스 ${#actual[@]}개가 모두 파이프라인 안에 있다."


### PR DESCRIPTION
## 무엇이 문제였나

`sprintable-mcp-{dev,prod}` 가 `cloudbuild.yaml` 의 배포 대상이 **아니었다.**

```
sprintable-backend-dev    2026-08-02 (오늘)      ← 파이프라인이 배포
sprintable-realtime-dev   2026-08-02 03:38       ← 파이프라인이 배포
sprintable-mcp-dev        2026-07-29             ← 4일 전 · 목록 밖
sprintable-mcp-prod       main HEAD 대비 449커밋 前  ← 목록 밖
```

넷 다 **같은 backend 이미지**(`.../sprintable/backend:<SHA>`)를 쓰도록 만들어진 짝인데
mcp 둘만 다른 태그를 가리키고 있었다. `.github` 전체에 `sprintable-mcp-dev` 문자열 0건.

그리고 그 서버는 **죽은 게 아니라 지금 요청을 받고 있다** — 에이전트가 sprintable 도구를
부를 때 타는 경로다. 즉 오늘 머지한 MCP 인자 검증(#2412)이 **정작 그 도구를 쓰는 서버에는
안 닿아 있었다.**

⚠️`publish-mcp.yml` 은 **PyPI 패키지 공개**용이고 Cloud Run 과 무관하다. 「MCP 배포」라는
말이 두 가지를 가리켜 처음엔 그쪽을 원인으로 짚었다가, 서비스가 쓰는 **이미지 태그**를
열어 보고 갈렸다.

## 무엇을 했나

**① `cloudbuild.yaml` — `deploy-mcp` 스텝**
- `gcloud run services update --image` 만 쓴다. `run deploy` 를 안 쓰는 이유: 지정 안 한
  설정이 기본값으로 되돌아가면 「배포가 손 고침을 지우는」 사고가 난다(같은 파일
  `deploy-realtime` 주석의 #2078 사례).
- **검산을 스텝 안에** 넣었다 — 「배포 success」가 아니라 «서빙 이미지가 backend 와 같은
  태그인가»를 `describe` 로 대조하고 다르면 `exit 1`.
- realtime 과 달리 **prod 게이트를 두지 않았다** — mcp-prod 는 이미 존재하고 실제로 요청을
  받는다. backend-prod 가 갱신되는데 mcp-prod 만 안 따라가는 것이 이 스토리가 없애려는 불일치다.

**② 근본 — 목록이 갈리면 빨간불**

mcp 를 «더하는» 것만으로는 다음에 서비스가 하나 더 생길 때 또 빠진다.
`scripts/verify-deploy-target-coverage.sh` 가 「파이프라인이 배포하는 서비스」와
「실제 존재하는 Cloud Run 서비스」를 대조하고, 덮이지 않는 것이 있으면 실패한다.

## 검산

**양성대조 — 자가 실패할 수 있는가**
```
deploy-mcp 스텝을 뺀 사본으로 실행
→ FAIL: sprintable-mcp-dev · sprintable-mcp-prod  «정확히 그 둘만»
현재 상태로 실행
→ OK: 실제 서비스 11개가 모두 파이프라인 안에 있다
```

**음성대조** — 존재하지 않는 이름은 추출되지 않는다(0건).

**추출 패턴을 고친 경위(실행 중 발견)**
1차 패턴(`gcloud run deploy <name>` 한 줄 매칭)은 `sprintable-frontend-` 를 **못 잡았다** —
`deploy-frontend` 는 YAML args **배열** 형태로 부르기 때문이다. 호출 «형태»가 스텝마다
달라서, «서비스 이름 자체»를 찾는 쪽으로 바꿨다(주석·인라인 주석은 걷어냄).
⇒ 양성대조를 처음부터 대지 않았으면 CI 에서 거짓 FAIL 로 처음 터졌을 자리다.

**거짓양성 넷을 실행 중 발견**
실제로 돌려 보니 `sprintable-admin-web{,-dev}` · `sprintable-internal-api{,-dev}` 가
「누락」으로 잡혔다 — **다른 레포(`moonklabs/sprintable-admin`) 소유**다. 이름만 보고 빼지
않고 «왜 밖인지»를 이유로 적어 `INTENTIONALLY_UNMANAGED` 에 등록했다.

**이식성** — `mapfile`(bash 4+)을 걷어냈다. macOS 기본 bash 3.2 에서 안 돌면
「CI 에서만 돌아가는 가드」가 된다. 그리고 `set -u` + 빈 배열 확장이 bash 3.2 에서
unbound 로 터지는 것도 실행 중에 잡아 고쳤다.

## ⚠️이 PR 이 «못 잡는 것»(선언)

- **환경변수가 파이프라인 밖인 것은 안 본다.** mcp 서비스의 env 는 지금도 손 설정이다 —
  그 SSOT 화는 별건.
- **서비스가 최신 이미지인지는 가드가 안 본다** — 그건 각 deploy 스텝의 검산 몫.
- **손으로 만든 서비스는 다음 push 때까지 안 잡힌다.** `schedule` 을 안 걸었다 — 매일 도는
  초록은 잡음이 되고, 그러면 진짜 빨강도 배경음이 된다.

## ⚠️머지해도 «변화가 안 보인다»

dev(04:46Z)·prod(05:33Z)를 이미 손으로 맞춰 뒀다. 그래서 이 PR 이 머지·배포돼도
**이미지 태그가 안 바뀐다** — 「고쳤는데 수가 안 움직인다」로 읽지 말 것.
**이 PR 의 효과는 «다음 배포부터»** 보인다: 그때 mcp 가 자동으로 따라가는가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)