### PR TITLE
#2083 — 채팅 영상 CSP 차단(코덱/MIME 아님) — media-src에 GCS 허용

### DIFF
--- a/apps/web/next.config.test.ts
+++ b/apps/web/next.config.test.ts
@@ -1,0 +1,31 @@
+// story #2083 회귀가드 — 채팅 첨부 영상(GCS 서명 URL)이 <video>로 로드될 때 CSP의
+// media-src에 storage.googleapis.com이 없으면 브라우저가 로드를 통째로 차단한다(콘솔
+// 실측: "violates ... media-src 'self' blob:"). 그 실패가 화면엔 "지원하지 않는 형식"으로
+// 잘못 보인다 — 코덱/MIME 문제가 아니라 CSP였다. img-src에는 같은 호스트가 이미 있다
+// (story #2050) — media-src만 빠져 있었던 것을 여기서 고정한다.
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const CONFIG_SOURCE = readFileSync(path.resolve(__dirname, 'next.config.ts'), 'utf-8');
+
+function extractDirective(name: string): string {
+  const match = new RegExp(`"${name} ([^"]*)"`).exec(CONFIG_SOURCE);
+  if (!match) throw new Error(`${name} directive not found in next.config.ts`);
+  return match[1]!;
+}
+
+describe('CSP media-src (story #2083 regression guard)', () => {
+  it('allows storage.googleapis.com so chat video attachments can load', () => {
+    expect(extractDirective('media-src')).toContain('https://storage.googleapis.com');
+  });
+
+  it('still allows blob: (download-then-play path relies on it)', () => {
+    expect(extractDirective('media-src')).toContain('blob:');
+  });
+
+  it('img-src and media-src agree on the GCS origin (same signed-URL exposure surface, story #2050)', () => {
+    expect(extractDirective('img-src')).toContain('https://storage.googleapis.com');
+    expect(extractDirective('media-src')).toContain('https://storage.googleapis.com');
+  });
+});

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -13,7 +13,11 @@ const _CSP = [
   "font-src 'self' data:",
   // API 호출 (self = Next.js rewrites 경유, googleapis = Cloud KMS/AI)
   "connect-src 'self' https://*.googleapis.com",
-  "media-src 'self' blob:",
+  // story #2083 — 채팅 첨부 영상(GCS 서명 URL)이 <video>로 로드될 때 media-src에
+  // storage.googleapis.com이 없어 CSP가 통째로 차단하고 있었다(콘솔 실측). img-src에는
+  // 이미 같은 호스트가 허용돼 있다(story #2050, 서명 URL·노출 축 동일) — 새 origin을
+  // 여는 것이 아니라 media-src를 img-src와 같은 경계로 맞추는 것이다.
+  "media-src 'self' blob: https://storage.googleapis.com",
   "frame-src 'none'",
   "object-src 'none'",
   "base-uri 'self'",


### PR DESCRIPTION
## Summary
선생님 실사용: 채팅에 올린 mp4가 재생 시도 시 "지원하지 않는 형식입니다"를 띄우고 다운로드해야 팝오버로 재생됐다. 착수 전 격리 채팅(참가자=본인만)에 표준 H.264/AAC mp4(29KB)를 실제 업로드해 재현했고, 브라우저 콘솔에서 실제 원인을 잡았다 — **코덱도 MIME도 아니고 CSP**였다:

```
Loading media from 'https://storage.googleapis.com/...test-2083.mp4?...'
violates the following Content Security Policy directive:
"media-src 'self' blob:". The action has been blocked.
```

`next.config.ts`의 CSP에서 `img-src`는 이미 `storage.googleapis.com`을 허용하는데(story #2050, 채팅 첨부 이미지/썸네일용 — 같은 서명 URL 노출 축) `media-src`는 `'self' blob:`뿐이었다. `<video>` 태그가 GCS 서명 URL을 로드하려는 순간 브라우저가 통째로 차단하고, 그 실패가 화면에는 "지원 안 함"으로 잘못 번역돼 보인다.

두 번째 증상("다운로드 누르면 팝오버로 재생된다")도 같은 뿌리로 설명된다 — 다운로드 경로는 `fetch()`로 받은 `blob:` URL을 쓰는 것으로 보이고, `media-src`가 `blob:`은 이미 허용해 그 경로만 CSP를 안 탄다.

## 처방
`media-src`에 `https://storage.googleapis.com` 한 줄 추가 — `img-src`와 동일 패턴. 새 origin을 여는 것이 아니라 `media-src`를 `img-src`와 같은 경계로 맞추는 것이다.

## 검증
로컬 dev 서버(인증 불요 — CSP 헤더는 모든 응답에 적용):
```
curl -sI http://localhost:3459/login | grep content-security-policy
→ media-src 'self' blob: https://storage.googleapis.com  (수정 반영 확認)
```

## 라이브에서 못 잰 것
실제 영상 재생 + 콘솔에 CSP 위반이 다시 안 뜨는지는 머지·배포 후 확認 예정이다. 로컬 FE는 공유 dev 백엔드와 JWT 불일치로 로그인 자체가 막히는 알려진 제약(#2415와 같은 패턴)이라, 지금은 헤더 레벨(인증 불요)까지만 검증됐다.

## Test plan
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run build` — EXIT 0
- [x] `pnpm exec vitest run` — 349 files · 2606 tests 전부 PASS(신규 3건 — media-src에 GCS 호스트 포함 여부, 뮤테이션 self-check 포함)
- [x] 로컬 dev 서버 curl로 실제 헤더 반영 확認
- [ ] 라이브(실제 재생 + 콘솔 CSP 위반 소거) — 머지·배포 후 확認

🤖 Generated with [Claude Code](https://claude.com/claude-code)