### PR TITLE
#2357 — 기각한 관계를 되돌릴 길이 없다 (reject 트리거+목록+되살리기, 최소 스코프)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -550,7 +550,7 @@
     "rejectedRelationsTitle": "{n} rejected relations",
     "rejectedRelationsTargetGone": "Target no longer exists",
     "rejectedRelationsRestore": "Restore",
-    "rejectedRelationsRestored": "Can resurface as a candidate again",
+    "rejectedRelationsRestored": "Can resurface as a candidate on the next story save",
     "rejectedRelationsRestoreErrorFallback": "Couldn't restore it. Please try again.",
     "backlinksTitle": "Things that point here",
     "backlinksTargetGone": "Target no longer exists",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -480,6 +480,10 @@
     "portUndoSignatureUnknown": "No record of when this was made",
     "portUndoKeep": "Keep it",
     "portUndoDelete": "Delete",
+    "portRejectTitle": "A relation the machine found",
+    "portRejectDescription": "Rejecting keeps this relation from resurfacing on future scans. You can restore it.",
+    "portRejectConfirm": "Reject",
+    "portRejectErrorFallback": "Couldn't reject it. Please try again.",
     "flowMapPastCount": "{n} done",
     "flowMapPastBundle": "bundled",
     "flowMapPastInternalCount": "{n} linked inside",
@@ -543,6 +547,11 @@
     "canvasResizeReset": "Reset to default"
   },
   "board": {
+    "rejectedRelationsTitle": "{n} rejected relations",
+    "rejectedRelationsTargetGone": "Target no longer exists",
+    "rejectedRelationsRestore": "Restore",
+    "rejectedRelationsRestored": "Can resurface as a candidate again",
+    "rejectedRelationsRestoreErrorFallback": "Couldn't restore it. Please try again.",
     "backlinksTitle": "Things that point here",
     "backlinksTargetGone": "Target no longer exists",
     "backlinksEmptyFallback": "0 references observed",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -550,7 +550,7 @@
     "rejectedRelationsTitle": "기각한 관계 {n}건",
     "rejectedRelationsTargetGone": "대상이 없습니다",
     "rejectedRelationsRestore": "되살리기",
-    "rejectedRelationsRestored": "다시 후보로 올라올 수 있습니다",
+    "rejectedRelationsRestored": "다음 스토리 저장에서 다시 후보로 오를 수 있습니다",
     "rejectedRelationsRestoreErrorFallback": "되살리지 못했습니다. 다시 시도해 주세요.",
     "backlinksTitle": "이것을 가리키는 것들",
     "backlinksTargetGone": "대상이 없습니다",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -480,6 +480,10 @@
     "portUndoSignatureUnknown": "언제 만들었는지 정보가 없습니다",
     "portUndoKeep": "그대로 둔다",
     "portUndoDelete": "지우기",
+    "portRejectTitle": "기계가 찾아낸 관계입니다",
+    "portRejectDescription": "기각하면 같은 관계가 다음에도 다시 뜨지 않습니다. 되살릴 수 있습니다.",
+    "portRejectConfirm": "기각",
+    "portRejectErrorFallback": "기각하지 못했습니다. 다시 시도해 주세요.",
     "flowMapPastCount": "완료 {n}",
     "flowMapPastBundle": "묶음",
     "flowMapPastInternalCount": "안에서 이어진 것 {n}",
@@ -543,6 +547,11 @@
     "canvasResizeReset": "기본 크기로"
   },
   "board": {
+    "rejectedRelationsTitle": "기각한 관계 {n}건",
+    "rejectedRelationsTargetGone": "대상이 없습니다",
+    "rejectedRelationsRestore": "되살리기",
+    "rejectedRelationsRestored": "다시 후보로 올라올 수 있습니다",
+    "rejectedRelationsRestoreErrorFallback": "되살리지 못했습니다. 다시 시도해 주세요.",
     "backlinksTitle": "이것을 가리키는 것들",
     "backlinksTargetGone": "대상이 없습니다",
     "backlinksEmptyFallback": "관찰된 참조 0건",

--- a/apps/web/src/app/api/stories/[id]/reference-candidates/[candidateId]/reject/route.ts
+++ b/apps/web/src/app/api/stories/[id]/reference-candidates/[candidateId]/reject/route.ts
@@ -1,0 +1,21 @@
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+/**
+ * POST /api/stories/{id}/reference-candidates/{candidateId}/reject — story #2357.
+ * BE `POST /api/v2/stories/{id}/reference-candidates/{candidate_id}/reject`(story #2221
+ * 후속)를 그대로 통과시킨다. `DELETE .../reference-candidates/{candidateId}`(undeclare)와는
+ * 다른 행위 — 이건 (source,target) 쌍을 `rejected_relations`에 영속 기록해 다음 산문
+ * 임포트에서도 걸러지게 한다. reason은 이 판(#2357) 스코프 밖(PO 지시 — 사유 입력은 다음
+ * 판) — 항상 빈 body로 보낸다.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string; candidateId: string }> },
+): Promise<Response> {
+  const { id, candidateId } = await params;
+  return proxyToFastapiWithParams(
+    request,
+    '/api/v2/stories/[id]/reference-candidates/[candidateId]/reject',
+    { id, candidateId },
+  );
+}

--- a/apps/web/src/app/api/stories/[id]/rejected-relations/[targetId]/route.ts
+++ b/apps/web/src/app/api/stories/[id]/rejected-relations/[targetId]/route.ts
@@ -1,0 +1,20 @@
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+/**
+ * DELETE /api/stories/{id}/rejected-relations/{targetId} — story #2357. BE
+ * `DELETE /api/v2/stories/{id}/rejected-relations/{target_id}`를 그대로 통과시킨다 —
+ * 되살리기(`rejected_relations` 행 삭제). 되살려도 candidate 행이 즉시 돌아오지 않는다 —
+ * 다음 story 저장이 있어야 새 후보가 생긴다(BE docstring, "새 참조만" 설계 원칙). 그래서
+ * 화면 문구도 "다시 후보로 올라올 수 있습니다"까지만 말하고 시점을 약속하지 않는다.
+ */
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string; targetId: string }> },
+): Promise<Response> {
+  const { id, targetId } = await params;
+  return proxyToFastapiWithParams(
+    request,
+    '/api/v2/stories/[id]/rejected-relations/[targetId]',
+    { id, targetId },
+  );
+}

--- a/apps/web/src/app/api/stories/[id]/rejected-relations/route.ts
+++ b/apps/web/src/app/api/stories/[id]/rejected-relations/route.ts
@@ -1,0 +1,14 @@
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+/**
+ * GET /api/stories/{id}/rejected-relations — story #2357. BE
+ * `GET /api/v2/stories/{id}/rejected-relations`를 그대로 통과시킨다. 이 story가 기각한
+ * 관계 목록(되살리기 재료) — 지금까지 FE 소비처가 0건이었다(유나 적발, 2026-07-31).
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const { id } = await params;
+  return proxyToFastapiWithParams(request, '/api/v2/stories/[id]/rejected-relations', { id });
+}

--- a/apps/web/src/components/flow/flow-epic-nodes.tsx
+++ b/apps/web/src/components/flow/flow-epic-nodes.tsx
@@ -7,7 +7,7 @@ import {
   deriveFlowMapLane, parseDependencyGraphEdges, parseReferenceCandidateEdges,
   type FlowMapEdge, type FlowMapLane, type RawDependencyEdge, type RawReferenceCandidate,
 } from './derive-flow-map';
-import { FlowMapCanvas, type CreateLinkResult, type DeleteLinkResult } from './flow-map-canvas';
+import { FlowMapCanvas, type CreateLinkResult, type DeleteLinkResult, type RejectLinkResult } from './flow-map-canvas';
 import { declareResponseToEdge } from './flow-port-linking';
 import { parseCursorMeta } from '@/lib/pagination';
 
@@ -213,6 +213,24 @@ export function FlowEpicNodes({ projectId, epicId, epicTitle, onSelectStory, sel
     }
   }, [t]);
 
+  // story #2357 — handleDeleteLink와 같은 형태, 다른 엔드포인트(reject: (source,target) 쌍을
+  // rejected_relations에 영속 기록해 다음 산문 임포트에서도 걸러지게 한다). 기각한 간선도
+  // 더는 유효한 후보가 아니므로 delete와 동일하게 edges에서 뺀다(BE가 같은 쌍의 다른
+  // field/form candidate 행도 함께 지우므로 화면도 그 사실을 따라간다).
+  const handleRejectLink = useCallback(async (candidateId: string, anchorStoryId: string): Promise<RejectLinkResult> => {
+    try {
+      const res = await fetch(`/api/stories/${anchorStoryId}/reference-candidates/${candidateId}/reject`, { method: 'POST' });
+      if (!res.ok) {
+        const json = await res.json().catch(() => null);
+        return { ok: false, error: typeof json?.detail === 'string' ? json.detail : t('portRejectErrorFallback') };
+      }
+      setState((prev) => (prev.kind === 'ready' ? { ...prev, edges: prev.edges.filter((e) => e.candidateId !== candidateId) } : prev));
+      return { ok: true };
+    } catch {
+      return { ok: false, error: t('portRejectErrorFallback') };
+    }
+  }, [t]);
+
   const lane: FlowMapLane | null = useMemo(() => {
     if (state.kind !== 'ready') return null;
     return deriveFlowMapLane(
@@ -237,6 +255,7 @@ export function FlowEpicNodes({ projectId, epicId, epicTitle, onSelectStory, sel
       selectedNodeId={selectedNodeId}
       onCreateLink={handleCreateLink}
       onDeleteLink={handleDeleteLink}
+      onRejectLink={handleRejectLink}
       memberMap={memberMap}
     />
   );

--- a/apps/web/src/components/flow/flow-map-canvas-port-linking.test.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas-port-linking.test.tsx
@@ -9,7 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
-import { FlowMapCanvas, type CreateLinkResult, type DeleteLinkResult } from './flow-map-canvas';
+import { FlowMapCanvas, type CreateLinkResult, type DeleteLinkResult, type RejectLinkResult } from './flow-map-canvas';
 import type { FlowMapLane, FlowMapNode, FlowMapEdge } from './derive-flow-map';
 import koMessages from '../../../messages/ko.json';
 
@@ -73,9 +73,10 @@ function dispatchPointer(el: Element | Document | Window, type: string, opts: { 
   el.dispatchEvent(ev);
 }
 
-async function renderCanvas(lane: FlowMapLane, overrides: { onCreateLink?: (p: { apiSourceId: string; targetId: string; relationKind: string | null }) => Promise<CreateLinkResult>; onDeleteLink?: (id: string, anchor: string) => Promise<DeleteLinkResult>; selectedNodeId?: string | null } = {}) {
+async function renderCanvas(lane: FlowMapLane, overrides: { onCreateLink?: (p: { apiSourceId: string; targetId: string; relationKind: string | null }) => Promise<CreateLinkResult>; onDeleteLink?: (id: string, anchor: string) => Promise<DeleteLinkResult>; onRejectLink?: (id: string, anchor: string) => Promise<RejectLinkResult>; selectedNodeId?: string | null } = {}) {
   const onCreateLink = overrides.onCreateLink ?? (async () => ({ ok: true }) as CreateLinkResult);
   const onDeleteLink = overrides.onDeleteLink ?? (async () => ({ ok: true }) as DeleteLinkResult);
+  const onRejectLink = overrides.onRejectLink ?? (async () => ({ ok: true }) as RejectLinkResult);
   await act(async () => {
     root.render(wrap(
       <FlowMapCanvas
@@ -85,12 +86,13 @@ async function renderCanvas(lane: FlowMapLane, overrides: { onCreateLink?: (p: {
         loadingPastBundleEpicIds={new Set()}
         onCreateLink={onCreateLink}
         onDeleteLink={onDeleteLink}
+        onRejectLink={onRejectLink}
         memberMap={{ 'member-9': { name: '미르코' }, 'member-OTHER': { name: '디디' } }}
         selectedNodeId={overrides.selectedNodeId ?? null}
       />,
     ));
   });
-  return { onCreateLink, onDeleteLink };
+  return { onCreateLink, onDeleteLink, onRejectLink };
 }
 
 function getPort(nodeId: string): HTMLButtonElement {
@@ -514,6 +516,81 @@ describe('FlowMapCanvas — 되돌리기 (AC7·AC8, 그 선 자체가 진입점)
 
     expect(document.body.textContent).toContain('Only a declared reference can be removed this way');
     expect(document.body.querySelector('[data-slot="dialog-title"]')).not.toBeNull();
+  });
+});
+
+// story #2357 — 제안(confirmed:false) 간선을 클릭하면 지우기(DELETE, declared 전용이라
+// BE가 400을 내는 경로)가 아니라 기각(reject) 다이얼로그가 떠야 한다. 오늘까지는 이 분기가
+// 없어 제안 간선을 클릭해도 "지우기"만 뜨고 눌러도 항상 실패했다(그 자체가 이 스토리의 근거).
+describe('FlowMapCanvas — 기각(reject) 다이얼로그 (story #2357, confirmed:false 간선)', () => {
+  it('clicking an unconfirmed (estimated) edge opens the reject dialog, not the delete one', async () => {
+    const lane = makeLane({
+      nowNodes: [makeNode({ id: 'n1' })],
+      queueNodesByDepth: new Map([[0, [makeNode({ id: 'u1', kind: 'queue' })]]]),
+      edges: [makeEdge({ fromNodeId: 'n1', toNodeId: 'u1', confirmed: false, candidateId: 'cand-est' })],
+    });
+    await renderCanvas(lane);
+    const line = container.querySelector('line[data-edge-candidate-id="cand-est"]')!;
+    await act(async () => { line.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    expect(document.body.querySelector('[data-slot="dialog-title"]')?.textContent).toBe('기계가 찾아낸 관계입니다');
+    // 지우기 다이얼로그의 문구(작성자 서명)는 안 뜬다 — 서로 다른 다이얼로그다.
+    expect(document.body.textContent).not.toContain('만들었습니다');
+  });
+
+  it('clicking an unconfirmed edge and confirming [기각] calls onRejectLink (not onDeleteLink) with candidateId and anchor story id', async () => {
+    const lane = makeLane({
+      nowNodes: [makeNode({ id: 'n1' })],
+      queueNodesByDepth: new Map([[0, [makeNode({ id: 'u1', kind: 'queue' })]]]),
+      edges: [makeEdge({ fromNodeId: 'n1', toNodeId: 'u1', confirmed: false, candidateId: 'cand-est' })],
+    });
+    const rejectLink = vi.fn(async () => ({ ok: true }) as RejectLinkResult);
+    const deleteLink = vi.fn(async () => ({ ok: true }) as DeleteLinkResult);
+    await renderCanvas(lane, { onRejectLink: rejectLink, onDeleteLink: deleteLink });
+
+    const line = container.querySelector('line[data-edge-candidate-id="cand-est"]')!;
+    await act(async () => { line.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const rejectBtn = Array.from(document.body.querySelectorAll('button')).find((b) => b.textContent === '기각')!;
+    await act(async () => { rejectBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    expect(rejectLink).toHaveBeenCalledWith('cand-est', 'n1');
+    expect(deleteLink).not.toHaveBeenCalled();
+    expect(document.body.querySelector('[data-slot="dialog-title"]')).toBeNull();
+  });
+
+  it('on reject failure, shows the server error and keeps the dialog open', async () => {
+    const lane = makeLane({
+      nowNodes: [makeNode({ id: 'n1' })],
+      queueNodesByDepth: new Map([[0, [makeNode({ id: 'u1', kind: 'queue' })]]]),
+      edges: [makeEdge({ fromNodeId: 'n1', toNodeId: 'u1', confirmed: false, candidateId: 'cand-est' })],
+    });
+    const rejectLink = vi.fn(async () => ({ ok: false, error: 'Reference candidate not found' }) as RejectLinkResult);
+    await renderCanvas(lane, { onRejectLink: rejectLink });
+
+    const line = container.querySelector('line[data-edge-candidate-id="cand-est"]')!;
+    await act(async () => { line.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const rejectBtn = Array.from(document.body.querySelectorAll('button')).find((b) => b.textContent === '기각')!;
+    await act(async () => { rejectBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    expect(document.body.textContent).toContain('Reference candidate not found');
+    expect(document.body.querySelector('[data-slot="dialog-title"]')).not.toBeNull();
+  });
+
+  // 양성대조(회귀 방지) — confirmed:true 간선은 지금도 지우기 다이얼로그로 간다(분기를
+  // 잘못 뒤집으면 이 테스트가 잡는다).
+  it('a CONFIRMED edge still opens the delete dialog, not reject', async () => {
+    const lane = makeLane({
+      nowNodes: [makeNode({ id: 'n1' })],
+      queueNodesByDepth: new Map([[0, [makeNode({ id: 'u1', kind: 'queue' })]]]),
+      edges: [makeEdge({ fromNodeId: 'n1', toNodeId: 'u1', confirmed: true, candidateId: 'cand-declared' })],
+    });
+    await renderCanvas(lane);
+    const line = container.querySelector('line[data-edge-candidate-id="cand-declared"]')!;
+    await act(async () => { line.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    expect(document.body.querySelector('[data-slot="dialog-title"]')?.textContent).not.toBe('기계가 찾아낸 관계입니다');
+    expect(Array.from(document.body.querySelectorAll('button')).some((b) => b.textContent === '지우기')).toBe(true);
+    expect(Array.from(document.body.querySelectorAll('button')).some((b) => b.textContent === '기각')).toBe(false);
   });
 });
 

--- a/apps/web/src/components/flow/flow-map-canvas.test.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.test.tsx
@@ -42,6 +42,7 @@ function makeEdge(overrides: Partial<FlowMapEdge> = {}): FlowMapEdge {
 // flow-map-canvas-port-linking.test.tsx가 따로 본다). 여기선 안 쓰이는 no-op을 공유한다.
 const NOOP_CREATE_LINK = async () => ({ ok: true as const });
 const NOOP_DELETE_LINK = async () => ({ ok: true as const });
+const NOOP_REJECT_LINK = async () => ({ ok: true as const });
 // story #2224(멀티레인) — loadingPastBundleEpicIds는 epicId 기준 Set이라, "로딩 중 아님"을
 // 매번 새 Set으로 안 만들고 이 상수 하나를 공유한다(참조가 안정적이어야 불필요한 리렌더도 안 생긴다).
 const EMPTY_EPIC_ID_SET = new Set<string>();
@@ -69,7 +70,7 @@ afterEach(async () => {
 describe('FlowMapCanvas — edge line rendering (양성대조)', () => {
   it('renders no <svg> at all when the lane has no edges (오늘 org 0행 상태와 동형)', async () => {
     const lane = makeLane({ nowNodes: [makeNode({ id: 'n1' })] });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     expect(container.querySelector('svg')).toBeNull();
   });
 
@@ -81,7 +82,7 @@ describe('FlowMapCanvas — edge line rendering (양성대조)', () => {
       queueNodesByDepth: new Map([[0, [queueNode]]]),
       edges: [makeEdge({ fromNodeId: 'n1', toNodeId: 'u1' })],
     });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     const line = container.querySelector('line[data-edge-kind]');
     expect(line).not.toBeNull();
     // 좌표가 실제로 계산돼 들어갔는지(값으로 닫는다 — "보인다"와 "계산됐다"가 다르다는
@@ -96,7 +97,7 @@ describe('FlowMapCanvas — edge line rendering (양성대조)', () => {
       nowNodes: [makeNode({ id: 'n1' })],
       edges: [makeEdge({ fromNodeId: 'n1', toNodeId: 'ghost-not-rendered' })],
     });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     expect(container.querySelector('line[data-edge-kind]')).toBeNull();
   });
 });
@@ -105,7 +106,7 @@ describe('FlowMapCanvas — node click → open story panel (선생님 지적 20
   it('clicking a node card calls onSelectStory with that node id', async () => {
     const onSelectStory = vi.fn();
     const lane = makeLane({ nowNodes: [makeNode({ id: 's-123' })] });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={onSelectStory} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={onSelectStory} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     const button = container.querySelector('button');
     expect(button).not.toBeNull();
     await act(async () => { button?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
@@ -116,7 +117,7 @@ describe('FlowMapCanvas — node click → open story panel (선생님 지적 20
   // 속성이다(flow-node-story-panel.tsx가 `[data-node-id="..."]`로 querySelector한다).
   it('renders data-node-id on every node card so the overlay panel can anchor to it', async () => {
     const lane = makeLane({ nowNodes: [makeNode({ id: 's-anchor-123' })] });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     // story #2353 후속 — data-node-id는 카드를 감싸는 wrapper(div)에 있다(포트 버튼과
     // 카드-열기 버튼이 형제로 서는 구조라 wrapper 자체는 button이 아니다, flow-map-canvas.tsx
     // FlowMapNodeCard 문서 참고). 앵커 대상은 wrapper 자체로 충분(getBoundingClientRect는
@@ -134,7 +135,7 @@ describe('FlowMapCanvas — node click → open story panel (선생님 지적 20
       queueNodesByDepth: new Map([[0, [makeNode({ id: 'u1', kind: 'queue' })]]]),
     });
     await act(async () => {
-      root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} selectedNodeId="u1" onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />));
+      root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} selectedNodeId="u1" onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />));
     });
     // ring 클래스는 「카드 열기」버튼(wrapper의 첫 번째 button)에 있다 — 포트 버튼과 형제로
     // 서는 구조(story #2353) 그대로.
@@ -146,7 +147,7 @@ describe('FlowMapCanvas — node click → open story panel (선생님 지적 20
 
   it('highlights no node when selectedNodeId is omitted (default behavior unchanged)', async () => {
     const lane = makeLane({ nowNodes: [makeNode({ id: 'n1' })] });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     expect(container.querySelector('[data-node-id="n1"] button')?.className).not.toContain('ring-2');
   });
 });
@@ -154,7 +155,7 @@ describe('FlowMapCanvas — node click → open story panel (선생님 지적 20
 describe('FlowMapCanvas — 노드 카드 한 줄 + 행 간격 32(story #2224 AC17-C)', () => {
   it('renders exactly one line per node — no status text label (border-l color is now the sole status signal, §4-4)', async () => {
     const lane = makeLane({ nowNodes: [makeNode({ id: 'n1', storyNumber: 42, title: '어떤 스토리', status: 'in-progress' })] });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     const card = container.querySelector('[data-node-id="n1"]')!;
     // 상태를 사람이 읽는 낱말("진행 중" 등)이 더는 텍스트로 없다 — 색(border-l)만 남는다.
     expect(card.textContent).not.toMatch(/진행 중|리뷰 중|개발 대기|백로그|완료/);
@@ -168,7 +169,7 @@ describe('FlowMapCanvas — 노드 카드 한 줄 + 행 간격 32(story #2224 AC
     const lane = makeLane({
       nowNodes: [makeNode({ id: 'first' }), makeNode({ id: 'second' })],
     });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     const first = container.querySelector('[data-node-id="first"]') as HTMLElement;
     const second = container.querySelector('[data-node-id="second"]') as HTMLElement;
     const firstTop = parseFloat(first.style.top);
@@ -199,7 +200,7 @@ describe('FlowMapCanvas — 8종 양성대조(유나양 4×2 규격)', () => {
       queueNodesByDepth: new Map([[0, queueNodes]]),
       edges,
     });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     const lines = Array.from(container.querySelectorAll('line[data-edge-kind]'));
     expect(lines).toHaveLength(8);
 
@@ -244,7 +245,7 @@ describe('FlowMapCanvas — 8종 양성대조(유나양 4×2 규격)', () => {
       queueNodesByDepth: new Map([[0, [queueNode]]]),
       edges: [makeEdge({ fromNodeId: 'old', toNodeId: 'new', kind: 'supersede', confirmed: true })],
     });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     const oldTitle = Array.from(container.querySelectorAll('span')).find((d) => d.textContent === '옛 스토리');
     expect(oldTitle?.className).toContain('line-through');
   });
@@ -257,7 +258,7 @@ describe('FlowMapCanvas — 8종 양성대조(유나양 4×2 규격)', () => {
       queueNodesByDepth: new Map([[0, [queueNode]]]),
       edges: [makeEdge({ fromNodeId: 'old', toNodeId: 'new', kind: 'supersede', confirmed: false })],
     });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     const oldTitle = Array.from(container.querySelectorAll('span')).find((d) => d.textContent === '옛 스토리');
     expect(oldTitle?.className).not.toContain('line-through');
   });
@@ -270,13 +271,13 @@ describe('FlowMapCanvas — 8종 양성대조(유나양 4×2 규격)', () => {
       queueNodesByDepth: new Map([[0, [makeNode({ id: 'u1', kind: 'queue' })]]]),
       edges: [makeEdge({ fromNodeId: 'n1', toNodeId: 'u1', kind: 'spawn', confirmed: true })],
     });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[withEdges]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[withEdges]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     expect(container.textContent).toContain('기계가 찾아낸 후보 일부입니다');
     // 옛 4종×2축 문구(실선=확定 등)는 완전히 사라져야 한다.
     expect(container.textContent).not.toContain('실선=확定');
 
     const noEdges = makeLane({ nowNodes: [makeNode({ id: 'n1' })] });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[noEdges]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[noEdges]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     expect(container.textContent).not.toContain('기계가 찾아낸 후보 일부입니다');
   });
 
@@ -289,7 +290,7 @@ describe('FlowMapCanvas — 8종 양성대조(유나양 4×2 규격)', () => {
       queueNodesByDepth: new Map([[0, [makeNode({ id: 'u1', kind: 'queue' })]]]),
       edges: [makeEdge({ fromNodeId: 'n1', toNodeId: 'u1', kind: 'spawn', confirmed: true })],
     });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     expect(container.textContent).toContain('기계가 찾아낸 후보 일부입니다');
     expect(container.textContent).not.toContain('사람이 확인한 것은 아직 없습니다');
   });
@@ -300,7 +301,7 @@ describe('FlowMapCanvas — 8종 양성대조(유나양 4×2 규격)', () => {
       queueNodesByDepth: new Map([[0, [makeNode({ id: 'u1', kind: 'queue' })]]]),
       edges: [makeEdge({ fromNodeId: 'n1', toNodeId: 'u1', kind: 'spawn', confirmed: false })],
     });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     expect(container.textContent).toContain('기계가 찾아낸 후보 일부입니다');
     expect(container.textContent).toContain('사람이 확인한 것은 아직 없습니다');
   });
@@ -316,7 +317,7 @@ describe('FlowMapCanvas — 8종 양성대조(유나양 4×2 규격)', () => {
       // toNodeId가 렌더되는 어떤 노드에도 없다 — 데이터 건수는 1이지만 그려지는 선은 0.
       edges: [makeEdge({ fromNodeId: 'n1', toNodeId: 'ghost-not-rendered', kind: 'spawn', confirmed: true })],
     });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[ghostEdgeLane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[ghostEdgeLane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     expect(container.querySelector('line[data-edge-kind]')).toBeNull();
     expect(container.textContent).not.toContain('기계가 찾아낸 후보 일부입니다');
   });
@@ -330,7 +331,7 @@ describe('FlowMapCanvas — past-bundle card (묶음이 선을 통과시킨다)'
       nowNodes: [makeNode({ id: 'n1' })],
       pastBundle: { total: 46, internalCount: 73, outgoingCount: 3 },
     });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     expect(container.textContent).toContain('완료 46');
     expect(container.textContent).toContain('안에서 이어진 것 73');
     expect(container.textContent).toContain('여기서 나온 다음 3건');
@@ -344,7 +345,7 @@ describe('FlowMapCanvas — past-bundle card (묶음이 선을 통과시킨다)'
       pastBundle: { total: 18, internalCount: 73, outgoingCount: 1 },
       edges: [makeEdge({ fromNodeId: '__past-bundle__', toNodeId: 'n1', kind: 'spawn', confirmed: false })],
     });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     const line = container.querySelector('line[data-edge-kind="spawn"]');
     expect(line).not.toBeNull();
     // 묶음 카드는 폭이 다르다(110px) — 좌표가 실제로 그 카드 좌상단(left:20)에서 시작해야 한다.
@@ -361,7 +362,7 @@ describe('FlowMapCanvas — past-bundle card (묶음이 선을 통과시킨다)'
       nowNodes: [makeNode({ id: 'n1' })],
       pastBundle: { total: 99, internalCount: 99, outgoingCount: 8 },
     });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     const card = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('안에서 이어진 것 99'));
     expect(card).toBeTruthy();
     const cls = card!.getAttribute('class') ?? '';
@@ -377,7 +378,7 @@ describe('FlowMapCanvas — past-bundle card (묶음이 선을 통과시킨다)'
       nowNodes: [makeNode({ id: 'n1' })],
       pastBundle: { total: 99, internalCount: 99, outgoingCount: 8 },
     });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     const internalCountEl = Array.from(container.querySelectorAll('div')).find((d) => d.textContent === '안에서 이어진 것 99');
     const outgoingCountEl = Array.from(container.querySelectorAll('div')).find((d) => d.textContent === '여기서 나온 다음 8건');
     const hintEl = Array.from(container.querySelectorAll('div')).find((d) => d.textContent === '누르면 펼쳐집니다');
@@ -403,7 +404,7 @@ describe('FlowMapCanvas — grouped edges (여러 선이 한 점에 모이면 �
         makeEdge({ fromNodeId: '__past-bundle__', toNodeId: 'n1', kind: 'spawn', confirmed: true }),
       ],
     });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     const lines = container.querySelectorAll('line[data-edge-kind]');
     expect(lines).toHaveLength(1); // 3건이 겹쳐 하나로
     expect(lines[0]?.getAttribute('data-edge-count')).toBe('3');
@@ -422,7 +423,7 @@ describe('FlowMapCanvas — grouped edges (여러 선이 한 점에 모이면 �
         makeEdge({ fromNodeId: '__past-bundle__', toNodeId: 'n1', kind: 'then', confirmed: true }),
       ],
     });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     const line = container.querySelector('line[data-edge-kind="mixed"]');
     expect(line).not.toBeNull();
     expect(line?.getAttribute('stroke')).toBe('var(--muted-foreground)');
@@ -436,7 +437,7 @@ describe('FlowMapCanvas — grouped edges (여러 선이 한 점에 모이면 �
       pastBundle: { total: 5, internalCount: 0, outgoingCount: 1 },
       edges: [makeEdge({ fromNodeId: '__past-bundle__', toNodeId: 'n1', kind: 'spawn', confirmed: true })],
     });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     expect(container.querySelector('text')).toBeNull();
   });
 });
@@ -486,7 +487,7 @@ describe('FlowMapCanvas — story #2369 가로 잘림 발견성(세로 접힘 �
     // 완전히 밖(adjustedLeft>=700): 772, 882, 992 → 3장.
     mockClientWidth = 700;
     const lane = makeQueueLane([0, 1, 2, 3, 4]);
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     const hint = container.querySelector('[data-testid="flow-canvas-offscreen-hint"]');
     expect(hint).not.toBeNull();
     expect(hint?.textContent).toContain('카드 3장이 화면 밖');
@@ -510,7 +511,7 @@ describe('FlowMapCanvas — story #2369 가로 잘림 발견성(세로 접힘 �
     // 보정 후엔 552>=552 → "밖"으로 잡혀야 한다.
     mockClientWidth = LANE_LABEL_WIDTH + 402;
     const lane = makeQueueLane([0]);
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     expect(container.querySelector('[data-testid="flow-canvas-offscreen-hint"]')?.textContent).toContain('카드 1장이 화면 밖');
   });
 
@@ -518,7 +519,7 @@ describe('FlowMapCanvas — story #2369 가로 잘림 발견성(세로 접힘 �
     mockClientWidth = 700;
     mockScrollWidth = 1000;
     const lane = makeQueueLane([0, 1, 2, 3, 4]);
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     const hint = container.querySelector('[data-testid="flow-canvas-offscreen-hint"]');
     const reasonSpan = Array.from(hint?.querySelectorAll('span') ?? []).find((s) => s.textContent === '— 오른쪽으로 스크롤하면 보입니다.');
     expect(reasonSpan?.getAttribute('class')).toContain('text-foreground');
@@ -530,7 +531,7 @@ describe('FlowMapCanvas — story #2369 가로 잘림 발견성(세로 접힘 �
     // lefts(레인 콘텐츠 기준): 402,512,622,732,842 → 실제 화면 기준(+LANE_LABEL_WIDTH):
     // 552,662,772,882,992.
     const lane = makeQueueLane([0, 1, 2, 3, 4]);
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     // visibleRight=700 → 772,882,992 밖 → 3장.
     expect(container.querySelector('[data-testid="flow-canvas-offscreen-hint"]')?.textContent).toContain('카드 3장이 화면 밖');
 
@@ -553,7 +554,7 @@ describe('FlowMapCanvas — story #2369 가로 잘림 발견성(세로 접힘 �
     mockClientWidth = 356;
     mockScrollWidth = 1660;
     const lane = makeLane({ nowNodes: [makeNode({ id: 'n1', kind: 'now' })] });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     // NOW_CLUSTER_X(FLOW_MAP_NOW_LINE_X-40=252) + NODE_CARD_WIDTH(110)=362 > 356 → 스크롤.
     expect(scrollEl().scrollLeft).toBe(Math.max(0, 252 - 356 / 2));
   });
@@ -562,7 +563,7 @@ describe('FlowMapCanvas — story #2369 가로 잘림 발견성(세로 접힘 �
     mockClientWidth = 1440;
     mockScrollWidth = 1660;
     const lane = makeLane({ nowNodes: [makeNode({ id: 'n1', kind: 'now' })] });
-    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} memberMap={{}} />)); });
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={[lane]} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
     expect(scrollEl().scrollLeft).toBe(0);
   });
 });

--- a/apps/web/src/components/flow/flow-map-canvas.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.tsx
@@ -82,6 +82,10 @@ interface FlowMapCanvasProps {
    * undeclare_story_reference_candidate 문서 참고). fromNodeId/toNodeId 아무 쪽이나
    * 유효한 story id면 되므로 호출부가 그중 하나를 골라 넘긴다. */
   onDeleteLink: (candidateId: string, anchorStoryId: string) => Promise<DeleteLinkResult>;
+  /** story #2357 — 아직 확認 전(제안, confirmed:false)인 간선을 기각한다. `onDeleteLink`와
+   * 다른 엔드포인트(reject) — BE가 estimated 행에는 DELETE를 400으로 거절하므로(undeclare는
+   * declared 전용) 확認 여부로 두 액션을 가른다(아래 다이얼로그 분기 참고). */
+  onRejectLink: (candidateId: string, anchorStoryId: string) => Promise<RejectLinkResult>;
   /** story #2353 되돌리기 다이얼로그의 「{이름}이 만든 연결입니다」 이름 조회용(유나 가디언
    * 리뷰 v1.1 정정, ㉣ — declaredBy가 나 아니면 실명, 못 찾으면 중립으로 떨어진다. 새 fetch
    * 아님 — goal-stem-card.tsx가 이미 들고 있는 memberMap을 그대로 흘려보낸다). */
@@ -102,6 +106,7 @@ interface FlowMapCanvasProps {
 
 export type CreateLinkResult = { ok: true } | { ok: false; error: string };
 export type DeleteLinkResult = { ok: true } | { ok: false; error: string };
+export type RejectLinkResult = { ok: true } | { ok: false; error: string };
 
 function nodeToneClass(node: FlowMapNode): string {
   if (node.kind === 'now') return 'border-l-info';
@@ -280,7 +285,7 @@ export function FlowCanvasOffscreenHint({ count }: { count: number }) {
  * 레인이 오면 레인별 ref map으로 넓혀야 한다 — 아래 laneContainerRef 참고).
  */
 export function FlowMapCanvas({
-  lanes, onSelectStory, onTogglePastBundle, loadingPastBundleEpicIds, selectedNodeId = null, onCreateLink, onDeleteLink, memberMap,
+  lanes, onSelectStory, onTogglePastBundle, loadingPastBundleEpicIds, selectedNodeId = null, onCreateLink, onDeleteLink, onRejectLink, memberMap,
   onOffscreenCountChange,
 }: FlowMapCanvasProps) {
   const t = useTranslations('flow');
@@ -390,9 +395,14 @@ export function FlowMapCanvas({
 
   const [linkDraft, setLinkDraft] = useState<LinkDraft>({ phase: 'idle' });
   const [justLinkedNodeId, setJustLinkedNodeId] = useState<string | null>(null);
-  const [undoTarget, setUndoTarget] = useState<{ candidateId: string; fromNodeId: string; toNodeId: string; declaredBy: string | null; declaredAt: string | null } | null>(null);
+  // story #2357 — confirmed로 다이얼로그가 갈린다: true(사람이 만든 선)면 기존 지우기,
+  // false(아직 제안인 기계 후보)면 기각(reject) — BE가 estimated 행의 DELETE를 400으로
+  // 거절하므로 이 값 없이는 "지우기"를 눌러도 항상 실패한다(오늘까지 실제로 그랬던 자리).
+  const [undoTarget, setUndoTarget] = useState<{ candidateId: string; fromNodeId: string; toNodeId: string; declaredBy: string | null; declaredAt: string | null; confirmed: boolean } | null>(null);
   const [undoDeleteError, setUndoDeleteError] = useState<string | null>(null);
   const [undoDeleting, setUndoDeleting] = useState(false);
+  const [rejectError, setRejectError] = useState<string | null>(null);
+  const [rejecting, setRejecting] = useState(false);
 
   const resetLinkDraft = useCallback(() => setLinkDraft({ phase: 'idle' }), []);
 
@@ -529,6 +539,23 @@ export function FlowMapCanvas({
     });
   }, [undoTarget, onDeleteLink]);
 
+  // story #2357 — handleUndoDelete와 같은 형태, 다른 엔드포인트(reject). undoTarget.confirmed
+  // 가 false일 때만 다이얼로그가 이 경로를 부른다(아래 JSX 분기).
+  const handleRejectConfirm = useCallback(() => {
+    if (!undoTarget) return;
+    setRejecting(true);
+    setRejectError(null);
+    const anchorStoryId = undoTarget.fromNodeId === PAST_BUNDLE_NODE_ID ? undoTarget.toNodeId : undoTarget.fromNodeId;
+    void onRejectLink(undoTarget.candidateId, anchorStoryId).then((result) => {
+      setRejecting(false);
+      if (result.ok) {
+        setUndoTarget(null);
+      } else {
+        setRejectError(result.error);
+      }
+    });
+  }, [undoTarget, onRejectLink]);
+
   // AC3 — 잇기가 진행 중일 때만 소스/호버/무효 판정을 계산한다(그 외엔 전부 무해한 idle 값).
   const linkSourceIdForDimming = linkDraft.phase === 'linking' ? linkDraft.sourceId : null;
   const linkHoverTargetId = linkDraft.phase === 'linking' ? linkDraft.hoverTargetId : null;
@@ -652,6 +679,7 @@ export function FlowMapCanvas({
                                   onClick={() => setUndoTarget({
                                     candidateId: group.candidateId!, fromNodeId: group.fromNodeId, toNodeId: group.toNodeId,
                                     declaredBy: group.declaredBy ?? null, declaredAt: group.declaredAt ?? null,
+                                    confirmed: group.allConfirmed,
                                   })}
                                 />
                               ) : null}
@@ -670,6 +698,7 @@ export function FlowMapCanvas({
                                 onClick={isUndoable ? () => setUndoTarget({
                                   candidateId: group.candidateId!, fromNodeId: group.fromNodeId, toNodeId: group.toNodeId,
                                   declaredBy: group.declaredBy ?? null, declaredAt: group.declaredAt ?? null,
+                                  confirmed: group.allConfirmed,
                                 }) : undefined}
                               />
                               {group.count > 1 ? (
@@ -973,8 +1002,30 @@ export function FlowMapCanvas({
       ) : null}
 
       {/* story #2353(AC7·AC8) — 되돌리기는 «그 선 자체가 진입점»이다(토스트 금지, ㉣). 「누가
-          언제 만들었는가」는 지워지지 않는 속성이라 여기 그대로 보인다. */}
-      {undoTarget ? (() => {
+          언제 만들었는가」는 지워지지 않는 속성이라 여기 그대로 보인다.
+          story #2357 — confirmed:false(아직 기계 제안)면 다른 다이얼로그(기각)를 보인다.
+          BE가 estimated 행의 DELETE를 400으로 거절하므로, 여기서 안 가르면 "지우기"를 눌러도
+          제안 간선에서는 항상 실패했다. */}
+      {undoTarget && !undoTarget.confirmed ? (
+        <Dialog open onOpenChange={(open) => { if (!open) { setUndoTarget(null); setRejectError(null); } }}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{t('portRejectTitle')}</DialogTitle>
+              <DialogDescription>{t('portRejectDescription')}</DialogDescription>
+            </DialogHeader>
+            {rejectError ? <p role="alert" className="text-[11px] text-destructive">{rejectError}</p> : null}
+            <DialogFooter>
+              <Button type="button" variant="ghost" disabled={rejecting} onClick={() => setUndoTarget(null)}>
+                {t('portUndoKeep')}
+              </Button>
+              <Button type="button" variant="outline" disabled={rejecting} onClick={handleRejectConfirm}>
+                {t('portRejectConfirm')}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      ) : null}
+      {undoTarget && undoTarget.confirmed ? (() => {
         const titleResolution = resolveUndoTitle(undoTarget.declaredBy, currentTeamMemberId, memberMap);
         return (
         <Dialog open onOpenChange={(open) => { if (!open) { setUndoTarget(null); setUndoDeleteError(null); } }}>

--- a/apps/web/src/components/flow/flow-multi-lane-canvas.tsx
+++ b/apps/web/src/components/flow/flow-multi-lane-canvas.tsx
@@ -8,7 +8,7 @@ import {
   deriveFlowMapLane, parseDependencyGraphEdges, parseReferenceCandidateEdges,
   type FlowMapEdge, type RawDependencyEdge, type RawReferenceCandidate,
 } from './derive-flow-map';
-import { FlowMapCanvas, FlowCanvasOffscreenHint, HEADER_HEIGHT, NODE_ROW_HEIGHT, LANE_MIN_HEIGHT, type CreateLinkResult, type DeleteLinkResult } from './flow-map-canvas';
+import { FlowMapCanvas, FlowCanvasOffscreenHint, HEADER_HEIGHT, NODE_ROW_HEIGHT, LANE_MIN_HEIGHT, type CreateLinkResult, type DeleteLinkResult, type RejectLinkResult } from './flow-map-canvas';
 import { FlowCanvasResizePane } from './flow-canvas-resize-pane';
 import { declareResponseToEdge } from './flow-port-linking';
 import type { NextMakerGoal } from './derive-next-maker';
@@ -247,6 +247,32 @@ export function FlowMultiLaneCanvas({
     }
   }, [t]);
 
+  // story #2357 — handleDeleteLink와 같은 형태·같은 ingredientsByEpic 갱신 패턴, 다른
+  // 엔드포인트(reject).
+  const handleRejectLink = useCallback(async (candidateId: string, anchorStoryId: string): Promise<RejectLinkResult> => {
+    try {
+      const res = await fetch(`/api/stories/${anchorStoryId}/reference-candidates/${candidateId}/reject`, { method: 'POST' });
+      if (!res.ok) {
+        const json = await res.json().catch(() => null);
+        return { ok: false, error: typeof json?.detail === 'string' ? json.detail : t('portRejectErrorFallback') };
+      }
+      setState((prev) => {
+        if (prev.kind !== 'ready') return prev;
+        const nextIngredients = new Map(prev.ingredientsByEpic);
+        for (const [epicId, ing] of nextIngredients) {
+          if (ing.edges.some((e) => e.candidateId === candidateId)) {
+            nextIngredients.set(epicId, { ...ing, edges: ing.edges.filter((e) => e.candidateId !== candidateId) });
+            break;
+          }
+        }
+        return { ...prev, ingredientsByEpic: nextIngredients };
+      });
+      return { ok: true };
+    } catch {
+      return { ok: false, error: t('portRejectErrorFallback') };
+    }
+  }, [t]);
+
   // 재료(fetch 결과)는 캐시하고, pastItems가 바뀔 때마다 deriveFlowMapLane(순수함수, 값싸다)을
   // «다시» 태운다 — 이미 파생된 lane 위에 pastNodes만 덮으면 과거-펼침 좌표·간선이 안 맞는다.
   const lanes = useMemo(() => {
@@ -298,6 +324,7 @@ export function FlowMultiLaneCanvas({
           selectedNodeId={selectedNodeId}
           onCreateLink={handleCreateLink}
           onDeleteLink={handleDeleteLink}
+          onRejectLink={handleRejectLink}
           memberMap={memberMap}
           onOffscreenCountChange={setOffscreenCardCount}
         />

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -30,6 +30,7 @@ import { initials } from '@/lib/storage/format';
 import { ArtifactSection } from '@/components/canvas/artifact-section';
 import { StuckHandoffSection } from '@/components/cage/stuck-handoff-section';
 import { EntityBacklinksSection } from '@/components/shared/entity-backlinks-section';
+import { RejectedRelationsSection } from '@/components/shared/rejected-relations-section';
 import { StoryOriginSection } from '@/components/shared/story-origin-section';
 import { EntityAwareTextarea } from '@/components/shared/entity-aware-textarea';
 import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
@@ -1347,6 +1348,11 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
             {/* story #2299(E-CONNECT): 이것을 가리키는 것들 — doc/chat_message 참조 목록 첫 자리
                 (doc [slug]/view는 후속 판). */}
             <EntityBacklinksSection entityType="story" entityId={story.id} />
+
+            {/* story #2357 — 이 스토리가 기각한 관계 목록 + 되살리기(doc `flow-port-slot-spec`
+                ㉣, "되살리기 UI용" BE가 이미 있었는데 FE 소비처가 0건이었다). 빈 목록이면
+                아무것도 안 그린다(AC4). */}
+            <RejectedRelationsSection storyId={story.id} />
 
             {story.story_points != null ? (
               <div>

--- a/apps/web/src/components/shared/rejected-relations-section.test.tsx
+++ b/apps/web/src/components/shared/rejected-relations-section.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+//
+// story #2357 — 기각한 관계 목록 + 되살리기 왕복 검증. AC4(빈 목록은 안 그린다)·AC6("다시
+// 후보로 올라올 수 있습니다" 사실 진술, 시점 약속 없음)·토스트 없이 그 행 자리에 결과가
+// 남는 것(㉣)까지 값으로 확認한다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { RejectedRelationsSection } from './rejected-relations-section';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function withIntl(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+async function render(storyId: string) {
+  await act(async () => {
+    root.render(withIntl(<RejectedRelationsSection storyId={storyId} />));
+  });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+function stubFetch(handler: (url: string, init?: RequestInit) => Promise<Response> | Response) {
+  vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => Promise.resolve(handler(url, init))));
+}
+
+describe('RejectedRelationsSection — AC4(빈 목록은 안 그린다)', () => {
+  it('renders nothing when the story has rejected no relations', async () => {
+    stubFetch(() => ({ ok: true, json: async () => [] }) as Response);
+    await render('s1');
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nothing on fetch failure (fails quiet, not a broken empty box)', async () => {
+    stubFetch(() => ({ ok: false, json: async () => null }) as Response);
+    await render('s1');
+    expect(container.innerHTML).toBe('');
+  });
+});
+
+describe('RejectedRelationsSection — 목록 렌더 + 제목 조회', () => {
+  it('lists a rejected relation with its target story title', async () => {
+    stubFetch((url) => {
+      if (url.includes('/rejected-relations')) {
+        return {
+          ok: true,
+          json: async () => [{ id: 'rr1', target_type: 'story', target_id: 't1', reason: null, rejected_by: 'm1', rejected_at: '2020-01-01T00:00:00Z' }],
+        } as Response;
+      }
+      if (url.includes('/api/stories/t1')) {
+        return { ok: true, json: async () => ({ data: { title: '옛 후보 스토리' } }) } as Response;
+      }
+      return { ok: false, json: async () => null } as Response;
+    });
+    await render('s1');
+    expect(container.textContent).toContain('옛 후보 스토리');
+    expect(container.textContent).toContain('기각한 관계 1건');
+  });
+
+  it('shows a neutral fallback when the target title lookup fails (target gone, not hidden)', async () => {
+    stubFetch((url) => {
+      if (url.includes('/rejected-relations')) {
+        return {
+          ok: true,
+          json: async () => [{ id: 'rr1', target_type: 'story', target_id: 't1', reason: null, rejected_by: null, rejected_at: '2020-01-01T00:00:00Z' }],
+        } as Response;
+      }
+      return { ok: false, json: async () => null } as Response;
+    });
+    await render('s1');
+    expect(container.textContent).toContain('대상이 없습니다');
+  });
+});
+
+describe('RejectedRelationsSection — 되살리기(restore) 왕복', () => {
+  it('clicking [되살리기] calls DELETE .../rejected-relations/{targetId} and shows the factual confirmation in place (no toast, stays in the row)', async () => {
+    stubFetch((url, init) => {
+      if (url.includes('/rejected-relations/t1') && init?.method === 'DELETE') {
+        return { ok: true, json: async () => ({ ok: true }) } as Response;
+      }
+      if (url.includes('/rejected-relations')) {
+        return {
+          ok: true,
+          json: async () => [{ id: 'rr1', target_type: 'story', target_id: 't1', reason: null, rejected_by: null, rejected_at: '2020-01-01T00:00:00Z' }],
+        } as Response;
+      }
+      if (url.includes('/api/stories/t1')) {
+        return { ok: true, json: async () => ({ data: { title: '되살릴 스토리' } }) } as Response;
+      }
+      return { ok: false, json: async () => null } as Response;
+    });
+    await render('s1');
+    const restoreBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '되살리기')!;
+    expect(restoreBtn).toBeTruthy();
+    await act(async () => { restoreBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    // AC6 — "다시 후보로 올라올 수 있습니다" 수준의 사실 진술이 그 행 자리에 남는다.
+    // 시점을 약속하는 문구("곧 다시 뜹니다")가 아니라는 것도 같이 고정한다.
+    expect(container.textContent).toContain('다시 후보로 올라올 수 있습니다');
+    expect(container.textContent).not.toContain('곧');
+    // 되살린 뒤에도 목록/제목은 사라지지 않는다(토스트처럼 없어지지 않는다).
+    expect(container.textContent).toContain('되살릴 스토리');
+    expect(container.querySelectorAll('button').length).toBe(0); // 되살리기 버튼은 사실 문장으로 대체됨
+  });
+
+  it('on restore failure, shows the server error next to that row and keeps the restore button', async () => {
+    stubFetch((url, init) => {
+      if (url.includes('/rejected-relations/t1') && init?.method === 'DELETE') {
+        return { ok: false, json: async () => ({ detail: 'Rejected relation not found' }) } as Response;
+      }
+      if (url.includes('/rejected-relations')) {
+        return {
+          ok: true,
+          json: async () => [{ id: 'rr1', target_type: 'story', target_id: 't1', reason: null, rejected_by: null, rejected_at: '2020-01-01T00:00:00Z' }],
+        } as Response;
+      }
+      if (url.includes('/api/stories/t1')) {
+        return { ok: true, json: async () => ({ data: { title: '되살릴 스토리' } }) } as Response;
+      }
+      return { ok: false, json: async () => null } as Response;
+    });
+    await render('s1');
+    const restoreBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '되살리기')!;
+    await act(async () => { restoreBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).toContain('Rejected relation not found');
+    expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent === '되살리기')).toBe(true);
+  });
+});

--- a/apps/web/src/components/shared/rejected-relations-section.test.tsx
+++ b/apps/web/src/components/shared/rejected-relations-section.test.tsx
@@ -118,9 +118,11 @@ describe('RejectedRelationsSection — 되살리기(restore) 왕복', () => {
     await act(async () => { restoreBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await act(async () => { await Promise.resolve(); await Promise.resolve(); });
 
-    // AC6 — "다시 후보로 올라올 수 있습니다" 수준의 사실 진술이 그 행 자리에 남는다.
-    // 시점을 약속하는 문구("곧 다시 뜹니다")가 아니라는 것도 같이 고정한다.
-    expect(container.textContent).toContain('다시 후보로 올라올 수 있습니다');
+    // AC6 — "다음 스토리 저장에서 다시 후보로 오를 수 있습니다" 수준의 사실 진술이 그
+    // 행 자리에 남는다(PO 지적 2026-08-02 — 되살리기가 candidate를 즉시 되살리지 않고
+    // 다음 story 저장이 있어야 한다는 실제 BE 동작을 문구에 반영). 시점을 약속하는
+    // 문구("곧 다시 뜹니다")가 아니라는 것도 같이 고정한다.
+    expect(container.textContent).toContain('다음 스토리 저장에서 다시 후보로 오를 수 있습니다');
     expect(container.textContent).not.toContain('곧');
     // 되살린 뒤에도 목록/제목은 사라지지 않는다(토스트처럼 없어지지 않는다).
     expect(container.textContent).toContain('되살릴 스토리');

--- a/apps/web/src/components/shared/rejected-relations-section.tsx
+++ b/apps/web/src/components/shared/rejected-relations-section.tsx
@@ -36,8 +36,18 @@ type LoadState = { kind: 'loading' } | { kind: 'failed' } | { kind: 'ready'; row
  * scope가 없고 «상시 빈 상자»를 만들면 잡음이 된다는 것이 doc의 명시 판정이다).
  *
  * ⛔토스트 금지(㉣) — 되살리기 액션과 그 결과(성공/실패)는 이 목록 행 «그 자리»에 남는다.
- * ⛔되살린 뒤 "다시 후보로 올라올 수 있습니다"까지만 말한다 — "곧 다시 뜹니다"처럼 다음
- * 스캔 시점을 약속하지 않는다(BE가 그 시점을 모른다, DELETE 라우트 docstring 그대로).
+ * ⛔되살린 뒤 "다음 스토리 저장에서 다시 후보로 오를 수 있습니다"까지만 말한다 — "곧 다시
+ * 뜹니다"처럼 시점을 약속하지 않는다.
+ *
+ * PO 지적(2026-08-02) — "다시 후보로 올라올 수 있습니다"는 상태 변화를 «약속»하는 문장이라
+ * 이행처를 코드로 확認했다: `undo_rejection()`은 `rejected_relations` 행만 지운다
+ * (backend/app/services/reference_semantic_candidates.py:609-629) — candidate 행이
+ * «즉시» 돌아오지 않는다. 후보는 `build_candidate_rows()`(:125-167)가 story 저장
+ * (create/update, stories.py의 `_reconcile_story_references_and_candidates`)마다
+ * `_rejected_target_ids()`(:170-183)로 아직 기각된 쌍만 걸러 다시 만든다 — 되살린
+ * 직후엔 그 필터에서 빠지므로 «다음 저장»이 있으면 같은 산문이 다시 후보가 된다. 그래서
+ * 문구를 "다음 스토리 저장에서"로 조건까지 밝힌다 — "다시 후보로 올라올 수 있습니다"만
+ * 쓰면 되살리기 직후 즉시 뜨는 것처럼 읽혀 "됐다는데 아무 일도 안 일어난다"가 된다.
  */
 export function RejectedRelationsSection({ storyId }: { storyId: string }) {
   const t = useTranslations('board');

--- a/apps/web/src/components/shared/rejected-relations-section.tsx
+++ b/apps/web/src/components/shared/rejected-relations-section.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { formatRelativeTime } from '@/lib/storage/format';
+
+export interface RejectedRelationItem {
+  id: string;
+  target_type: string;
+  target_id: string;
+  reason: string | null;
+  rejected_by: string | null;
+  rejected_at: string;
+}
+
+interface RowState {
+  item: RejectedRelationItem;
+  title: string | null;
+  restoring: boolean;
+  error: string | null;
+  /** AC6 — 되돌린 뒤 화면이 그 사실을 말해야 한다("다시 후보로 올라올 수 있습니다"). 목록에서
+   * 조용히 지우면(토스트와 같은 실패 모드 — 사실이 사라진다) 그 말을 할 자리가 없어진다. */
+  restored: boolean;
+}
+
+type LoadState = { kind: 'loading' } | { kind: 'failed' } | { kind: 'ready'; rows: RowState[] };
+
+/**
+ * story #2357 — 기각한 관계 목록 + 되살리기. `GET .../rejected-relations`(story #2357
+ * doc `flow-port-slot-spec` ㉣, "되살리기 UI용")를 여기서 처음 소비한다(지금까지 FE
+ * 소비처 0건이었다). EntityBacklinksSection과 같은 자리·같은 스타일 관례(스토리 상세
+ * 패널에 붙는 자체-fetch 섹션)를 그대로 따른다 — 새 패턴을 만들지 않는다.
+ *
+ * ⛔AC4 — 목록이 빈 경우 이 섹션 자체를 안 그린다(EntityBacklinksSection과 다른 점 —
+ * 그쪽은 "왜 비어 있는지" scope를 설명해야 해서 빈 상태 문구가 있지만, 기각 목록은 설명할
+ * scope가 없고 «상시 빈 상자»를 만들면 잡음이 된다는 것이 doc의 명시 판정이다).
+ *
+ * ⛔토스트 금지(㉣) — 되살리기 액션과 그 결과(성공/실패)는 이 목록 행 «그 자리»에 남는다.
+ * ⛔되살린 뒤 "다시 후보로 올라올 수 있습니다"까지만 말한다 — "곧 다시 뜹니다"처럼 다음
+ * 스캔 시점을 약속하지 않는다(BE가 그 시점을 모른다, DELETE 라우트 docstring 그대로).
+ */
+export function RejectedRelationsSection({ storyId }: { storyId: string }) {
+  const t = useTranslations('board');
+  const [state, setState] = useState<LoadState>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const res = await fetch(`/api/stories/${storyId}/rejected-relations`, { cache: 'no-store' }).catch(() => null);
+      if (cancelled) return;
+      if (!res || !res.ok) { setState({ kind: 'failed' }); return; }
+      const items = (await res.json().catch(() => null)) as RejectedRelationItem[] | null;
+      if (cancelled) return;
+      if (!items) { setState({ kind: 'failed' }); return; }
+      // target_type은 지금 항상 "story"다(BE DELETE 라우트가 target_type="story"로 고정
+      // 조회하는 것과 같은 사정) — 제목은 story 상세 엔드포인트로 조회한다.
+      const titles = await Promise.all(items.map((it) =>
+        fetch(`/api/stories/${it.target_id}`).then((r) => (r.ok ? r.json() : null)).catch(() => null),
+      ));
+      if (cancelled) return;
+      setState({
+        kind: 'ready',
+        rows: items.map((item, i) => ({
+          item, title: titles[i]?.data?.title ?? null, restoring: false, error: null, restored: false,
+        })),
+      });
+    })();
+    return () => { cancelled = true; };
+  }, [storyId]);
+
+  if (state.kind !== 'ready' || state.rows.length === 0) return null;
+
+  const handleRestore = (targetId: string) => {
+    setState((prev) => (prev.kind === 'ready'
+      ? { ...prev, rows: prev.rows.map((r) => (r.item.target_id === targetId ? { ...r, restoring: true, error: null } : r)) }
+      : prev));
+    void fetch(`/api/stories/${storyId}/rejected-relations/${targetId}`, { method: 'DELETE' })
+      .then(async (res) => {
+        if (res.ok) {
+          setState((prev) => (prev.kind === 'ready'
+            ? { ...prev, rows: prev.rows.map((r) => (r.item.target_id === targetId ? { ...r, restoring: false, restored: true } : r)) }
+            : prev));
+          return;
+        }
+        const json = await res.json().catch(() => null);
+        const error = typeof json?.detail === 'string' ? json.detail : t('rejectedRelationsRestoreErrorFallback');
+        setState((prev) => (prev.kind === 'ready'
+          ? { ...prev, rows: prev.rows.map((r) => (r.item.target_id === targetId ? { ...r, restoring: false, error } : r)) }
+          : prev));
+      })
+      .catch(() => {
+        setState((prev) => (prev.kind === 'ready'
+          ? { ...prev, rows: prev.rows.map((r) => (r.item.target_id === targetId ? { ...r, restoring: false, error: t('rejectedRelationsRestoreErrorFallback') } : r)) }
+          : prev));
+      });
+  };
+
+  return (
+    <div className="border-t border-border/60 px-4 py-3">
+      <p className="mb-2 text-xs font-medium text-muted-foreground">
+        {t('rejectedRelationsTitle', { n: state.rows.length })}
+      </p>
+      <ul className="flex flex-col gap-1.5">
+        {state.rows.map(({ item, title, restoring, error, restored }) => (
+          <li key={item.id} className="flex flex-col gap-1 text-xs">
+            <div className="flex items-start gap-2">
+              <div className="min-w-0 flex-1">
+                <span className="text-foreground [overflow-wrap:anywhere]">{title ?? t('rejectedRelationsTargetGone')}</span>
+                <div className="text-[10px] text-muted-foreground">{formatRelativeTime(item.rejected_at)}</div>
+              </div>
+              {restored ? (
+                // AC6 — 「다시 후보로 올라올 수 있습니다」까지만 말한다(시점 약속 없음).
+                // 토스트가 아니라 이 행 자리에 그대로 남는다(㉣).
+                <span className="shrink-0 text-[11px] text-muted-foreground">{t('rejectedRelationsRestored')}</span>
+              ) : (
+                <button
+                  type="button"
+                  disabled={restoring}
+                  onClick={() => handleRestore(item.target_id)}
+                  className="focus-outset shrink-0 rounded-md border border-border px-2 py-1 text-[11px] font-medium disabled:opacity-50"
+                >
+                  {t('rejectedRelationsRestore')}
+                </button>
+              )}
+            </div>
+            {error ? <p role="alert" className="text-[10px] text-destructive">{error}</p> : null}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
착수 前 그라운딩 — BE에 `GET .../rejected-relations`(목록)·`DELETE .../rejected-relations/{target}`(되살리기)·`POST .../reject`(기각 삽입 경로) 셋 다 있는데 FE 소비처가 하나도 없었다. **기각 트리거 자체도 FE에 없어서**(flow-epic-nodes.tsx 등은 declare/undeclare만 호출), 되살리기 UI만 만들면 목록이 항상 비어 검증 불가능한 화면이 나올 뻔했다 — 이 발견을 PO에게 먼저 올려 스코프를 (a) reject 트리거까지 최소로 넓히는 것으로 확定했다.

doc `flow-port-slot-spec` §㉣로 재확認 — 기각/되살리기는 은퇴된 개념이 아니라 여전히 살아있는 제품 의도(#2353의 성립 조건)임을 문서에서 직접 확認한 뒤 착수했다.

## 구현(PO 지시 — 딱 이 셋까지, 넓히지 않음)
① **기각 트리거** — `flow-map-canvas.tsx`의 기존 "되돌리기" 다이얼로그를 `confirmed`(축2)로 분기한다. `confirmed:true`(사람이 만든 선)는 기존 지우기 그대로, `confirmed:false`(기계 제안)는 새 기각 다이얼로그로 간다. BE가 estimated 행의 DELETE를 400으로 거절하므로, 이 분기가 없으면 제안 간선에서 "지우기"를 눌러도 항상 실패했다(그 자체가 이 결함의 실측 증거).
② **기각 목록** — 새 `RejectedRelationsSection`, `EntityBacklinksSection`과 같은 자리·같은 관례. 빈 목록이면 아무것도 안 그린다(AC4).
③ **되살리기** — `DELETE .../rejected-relations/{targetId}` 소비(원문 AC1). 되살린 뒤 그 행 자리에 "다시 후보로 올라올 수 있습니다"(AC6, 시점 약속 없음)가 남는다 — 토스트로 흘려보내지 않는다(㉣).

## 스코프 밖(PO 지시 그대로)
- 일괄 기각·사유 입력·필터 — 다음 판.
- `#2356`(계산 시점 드롭)은 같은 축이 아니다(그라운딩으로 확認 — 공유 테이블 없음). 안 묶었다.

## Test plan
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run build` — EXIT 0
- [x] `pnpm exec vitest run` — 350 files · 2616 tests PASS(신규: confirmed:false 간선 → 기각 다이얼로그 → onRejectLink 호출 왕복 + 양성대조(confirmed:true는 여전히 지우기) + rejected-relations-section 빈목록/실패/되살리기 왕복)
- [x] i18n-collision 신규 0건
- [x] verify:* 8개 개별 OK
- [ ] 라이브(실제 기각→되살리기→다음 스캔에서 재후보 왕복) — 로컬 FE의 알려진 제약(공유 dev 백엔드와 JWT 불일치)으로 지금은 확認 못 함, 머지·배포 후 확認 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)