### PR TITLE
fix(#2319): 삭제된 메시지의 첨부 접근을 서버가 거부한다

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -138,6 +138,31 @@ describe('ChatBubble — story #2319 tombstone(메시지 삭제) 렌더', () => 
     expect(menuItems).not.toContain('삭제');
   });
 
+  it('미완 봉합(미르코 dev 실측) — tombstone된 메시지는 attachments가 있어도 첨부 카드를 안 그린다', async () => {
+    const deletedMsgWithAttachment: ChatMessage = {
+      ...baseMessage,
+      content: '',
+      deleted_at: '2026-08-02T00:00:00.000Z',
+      attachments: [{ url: 'chat/proj/conv/report.pdf', name: 'report.pdf', content_type: 'application/pdf' }],
+    };
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={deletedMsgWithAttachment} isMine={true} />));
+    });
+    expect(container.textContent).not.toContain('report.pdf');
+  });
+
+  it('음성대조 — 안 지워진 메시지는 attachments가 있으면 첨부 카드를 그린다', async () => {
+    const liveMsgWithAttachment: ChatMessage = {
+      ...baseMessage,
+      deleted_at: null,
+      attachments: [{ url: 'chat/proj/conv/report.pdf', name: 'report.pdf', content_type: 'application/pdf' }],
+    };
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={liveMsgWithAttachment} isMine={true} />));
+    });
+    expect(container.textContent).toContain('report.pdf');
+  });
+
   it('음성대조 — 본인 메시지가 안 지워진 상태면 컨텍스트 메뉴에 「삭제」가 뜬다', async () => {
     await act(async () => {
       root.render(wrap(<ChatBubble message={{ ...baseMessage, deleted_at: null }} isMine={true} />));

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -380,8 +380,11 @@ export function ChatBubble({
 
           {/* Attachments — a54ddc16: auth-gated 서명 라우트 경유(public 직링크 미사용).
               이미지=AttachmentImage(3상태 render)·오디오/비디오=AttachmentMedia(story #2051,
-              [재생] 누르기 전엔 fetch 0)·그 외=AttachmentFile(클릭 시 서명 다운로드). */}
-          {message.attachments && message.attachments.length > 0 && (
+              [재생] 누르기 전엔 fetch 0)·그 외=AttachmentFile(클릭 시 서명 다운로드).
+              story #2319 미완 — tombstone된 메시지의 첨부는 그리지 않는다(2차 방어. 서버가
+              이미 응답에서 빼고 authorize도 거부하므로 이 게이트가 빠져도 안전하지만, 화면이
+              서버 계약을 스스로 어기지 않는다는 것을 명시한다). */}
+          {!isDeleted && message.attachments && message.attachments.length > 0 && (
             <div className="flex flex-col gap-1.5">
               {message.attachments.map((att, i) => {
                 const href = att.url;

--- a/backend/app/routers/attachments.py
+++ b/backend/app/routers/attachments.py
@@ -138,12 +138,17 @@ async def authorize_attachment(
             ):
                 raise HTTPException(status_code=403, detail="Not a participant of this conversation")
         # ② 정확 매치: stored url == bare path(신규) OR == legacy 전체 URL. substring 금지.
+        # story #2319 미완(미르코 dev 라이브 실측 2026-08-02) — tombstone된 메시지의 첨부가 여기서
+        # 계속 "belongs"로 잡혀 서명URL이 계속 발급됐다(URL을 아는 사람은 화면 게이트와 무관하게
+        # 계속 접근). 금지는 화면이 안 그리는 것이 아니라 서버가 거부하는 것이어야 한다 —
+        # m.deleted_at IS NULL을 이 쿼리 자체에 추가한다(FE 게이트는 2차 방어일 뿐 여기가 1차).
         belongs = (await db.execute(
             text(
                 "SELECT EXISTS ("
                 " SELECT 1 FROM conversation_messages m,"
                 " jsonb_array_elements(coalesce(m.attachments, '[]'::jsonb)) att"
-                " WHERE m.conversation_id = :cid AND att->>'url' IN (:path, :legacy))"
+                " WHERE m.conversation_id = :cid AND m.deleted_at IS NULL"
+                " AND att->>'url' IN (:path, :legacy))"
             ),
             {"cid": conversation_id, "path": path, "legacy": legacy_url},
         )).scalar()

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -396,7 +396,11 @@ def _msg_payload(
     msg: ConversationMessage, sender: "ResolvedMember | TeamMember | None",
     *, references: list[dict[str, str]] | None = None,
 ) -> dict:
-    attachments = msg.attachments if isinstance(msg.attachments, list) else []
+    # story #2319 미완(미르코 dev 라이브 실측 2026-08-02) — tombstone인데 attachments가 응답에
+    # 그대로 남아 첨부(영상 등)가 계속 재생됐다. AC③(오발송 스크럽) 근거가 이걸로 무너진다 —
+    # 여기서 빈 배열로 덮는다(실제 근본은 attachments.py authorize의 belongs 쿼리에 deleted_at
+    # 필터를 추가한 것 — 이 payload 필터는 FE가 애초에 못 보게 하는 2차 방어).
+    attachments = (msg.attachments if isinstance(msg.attachments, list) else []) if msg.deleted_at is None else []
     payload = {
         "id": str(msg.id),
         "conversation_id": str(msg.conversation_id),

--- a/backend/tests/test_1994_backlink_api_realdb.py
+++ b/backend/tests/test_1994_backlink_api_realdb.py
@@ -2285,3 +2285,84 @@ async def test_delete_message_after_removed_from_participants_403():
             assert fresh.content == "제거 전에 보낸 메시지"
     finally:
         await engine.dispose()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# story #2319 미완(미르코 dev 라이브 실측 2026-08-02) — tombstone된 메시지의 첨부가
+# 화면 게이트 없이도(URL을 아는 사람은) 계속 authorize되던 결함. 근본은 attachments.py
+# authorize의 belongs 쿼리가 m.deleted_at을 안 보던 것 — 여기서 실 SQL로 재현·pin한다.
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+async def test_attachment_authorize_403_after_message_tombstoned():
+    """삭제 전엔 authorize 200(양성대조) → 삭제 후엔 403이어야 한다 — URL을 직접 아는 사람도
+    막혀야 한다(화면이 안 그리는 것과 별개로 서버가 거부해야 진짜 봉인)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [caller_id], created_by=caller_id, conv_type="dm")
+            path = f"chat/{project.id}/{conv_id}/u1-video.mp4"
+            msg = await _add_message(s, conv_id, caller_id, "영상 첨부", _t(1))
+            msg.attachments = [{"url": path, "content_type": "video/mp4"}]
+            await s.commit()
+            msg_id = msg.id
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            # 삭제 전 — 정상 authorize(양성대조, 회귀로 항상-403이 되는 것도 막는다).
+            before = await client.get(f"/api/v2/attachments/authorize?path={path}&conversation_id={conv_id}")
+            assert before.status_code == 200, before.text
+
+            del_resp = await client.delete(f"/api/v2/conversations/{conv_id}/messages/{msg_id}")
+            assert del_resp.status_code == 200, del_resp.text
+
+            # 삭제 후 — 이 테스트의 핵심 단언.
+            after = await client.get(f"/api/v2/attachments/authorize?path={path}&conversation_id={conv_id}")
+            assert after.status_code == 403, after.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+async def test_get_message_hides_attachments_after_delete():
+    """story #2319 미완 — _msg_payload가 tombstone된 메시지의 attachments를 빈 배열로 덮는다
+    (FE가 애초에 첨부 카드를 시도조차 안 하게, authorize 403의 2차 방어)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [caller_id], created_by=caller_id, conv_type="dm")
+            path = f"chat/{project.id}/{conv_id}/u1-video.mp4"
+            msg = await _add_message(s, conv_id, caller_id, "영상 첨부", _t(1))
+            msg.attachments = [{"url": path, "content_type": "video/mp4"}]
+            await s.commit()
+            msg_id = msg.id
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            before = await client.get(f"/api/v2/conversations/{conv_id}/messages/{msg_id}")
+            assert before.json()["attachments"] == [{"url": path, "content_type": "video/mp4"}]
+
+            del_resp = await client.delete(f"/api/v2/conversations/{conv_id}/messages/{msg_id}")
+            assert del_resp.status_code == 200, del_resp.text
+
+            after = await client.get(f"/api/v2/conversations/{conv_id}/messages/{msg_id}")
+            assert after.json()["attachments"] == [], "삭제 후에도 attachments가 응답에 남아있다"
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 요약

#2806(#2319 tombstone delete) 병합 후 미르코가 dev 라이브에서 실물로 발견: tombstone 문구는
정확히 뜨는데 **첨부(영상) 카드가 그대로 남고 재생까지 됐다.**

원래 PR의 "attachments는 안 지운다 — AC 문구가 '내용만'이라 스코프 밖"이라는 자백은 정직한
기록이었지만, 실은 **AC③(오·발송 스크럽)을 무너뜨리는** 것이었다 — "스코프 밖"이 성립하려면
기능의 목적을 안 건드려야 하는데, 지금은 목적 자체를 건드린다. 별도 스토리가 아니라 #2319의
미완으로 처리.

## 근본 — 서버가 거부한다(화면 게이트만으론 부족)

URL을 직접 아는 사람은 화면이 안 그려도 여전히 접근 가능하다 — 금지는 서버의 몫이어야 한다.

- **`backend/app/routers/attachments.py`**: `GET /authorize`의 `belongs` SQL(첨부가 그
  conversation 소속인지 확인하는 쿼리)에 `m.deleted_at IS NULL`을 추가. tombstone된 메시지의
  첨부는 서명URL 발급 자체가 403으로 거부된다.
- **`backend/app/routers/conversations.py`**: `_msg_payload`가 삭제된 메시지의 `attachments`를
  빈 배열로 덮는다(2차 방어 — FE가 애초에 카드를 시도조차 안 하게).
- **`apps/web/.../chat-bubble.tsx`**: attachments 렌더 블록에 `!isDeleted` 게이트 추가(3차
  방어 — 서버가 이미 막지만 화면도 서버 계약을 스스로 어기지 않는다는 것을 명시).

## 검증 — 자백을 실제로 재현했다

이전 라운드의 "스코프 밖" 자백이 리뷰를 그냥 통과한 전례가 있어, 이번엔 게이트를 실제로
빼서 재현했다:
- BE SQL 필터 제거 → `authorize`가 삭제 후에도 200을 주는 것을 실 PG로 확認 → 복원 → 403
  으로 돌아오는 것 재확認.
- FE `!isDeleted` 게이트 제거 → 첨부 카드가 다시 렌더되는 것을 실 DOM 테스트로 확認 → 복원.

신규 realdb 테스트 2건(`test_attachment_authorize_403_after_message_tombstoned`,
`test_get_message_hides_attachments_after_delete`) + FE 테스트 2건(양성/음성) 추가.
로컬 realdb 207개 관련 스위트 + FE 전체 350개 파일/2622개 테스트 전부 통과. type-check/lint 클린.

## 범위 밖으로 남긴 것 — 명시

**GCS 객체 자체는 지우지 않는다.** 되돌릴 수 없고 보존 정책·다른 참조와 얽힌다. 이 판은
「객체는 남되 도달 경로(서명URL 발급)가 막힌다」까지 — 실제 blob 삭제는 별도 판단.

## 잔여 노출 창 — TTL 실측(사부님/PO 요구)

삭제 전에 이미 발급된 서명URL은 만료까지 유효하다는 자백에 실제 TTL 수를 재서 박는다:

- 채팅 첨부 서명URL 발급처는 `apps/web/src/app/api/attachments/sign/route.ts` →
  `storage.signRead(...)`(expiresInMs 미지정) → `src/lib/storage/providers/gcs.ts:47`의
  기본값 `5 * 60 * 1000` = **5분**.
- (참고, 다른 축: `app/services/attachment_context.py`의 30분 TTL은 에이전트 컨텍스트
  주입용 별도 플로우 — 사람이 클릭해서 보는 이 경로와 다르다.)

5분은 좁은 창 쪽 — 이 PR로 닫는다(별도 스토리 필요 없음). 다만 「삭제 직후 5분 내에 이미
받은 링크는 여전히 유효하다」는 잔여 리스크는 실재하고, 근본 해소(서명URL 방식 대신 항상
서버 프록시 경유)는 이 판보다 큰 변경이라 여기서 하지 않는다 — 별도 판단이 필요하면 후속
스토리로.

## Test plan

- [ ] 첨부(영상) 있는 메시지 삭제 → placeholder로 바뀌고 첨부 카드도 같이 사라짐
- [ ] 삭제 전 받아둔 서명URL로 직접 접근 시도 → 5분 내엔 여전히 유효(위 TTL 실측 참고) ·
      5분 경과 후 또는 신규 발급 시도 시 거부
- [x] CI(type-check/lint/vitest/realdb pytest)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
