### PR TITLE
[SID:1933] request.url을 URL base로 쓰지 않는다 — Cloud Run 내부주소 유출 차단

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -656,6 +656,12 @@ jobs:
       - name: "Verify no hand-rolled modal without accessibility (story #2061 regression guard)"
         run: pnpm --filter web verify:no-handrolled-modal
 
+      # story #1933 회귀가드: request.url을 new URL()의 base로 쓰면 Cloud Run 내부 주소가
+      # 새어 나간다(플랫폼 성질). auth/native·internal-dogfood 3곳을 resolveAppUrl(null)로
+      # 고쳤고, 재도입되면 이 스텝이 실패한다.
+      - name: "Verify no request.url used as URL base (story #1933 regression guard)"
+        run: pnpm --filter web verify:no-request-url-as-base
+
       # story #2062 회귀가드: 패딩도 focus-inset(유나 규격)도 없는 overflow-*-auto|scroll
       # 스크롤 컨테이너가 새로 들어오면 이 스텝이 실패한다(#2057 포커스 링 클리핑 재발 방지).
       - name: "Verify focus-inset coverage on scroll containers (story #2062 regression guard)"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "verify:no-new-md-breakpoint": "tsx scripts/verify-no-new-md-breakpoint.ts",
     "verify:no-alpha-focus-ring": "tsx scripts/verify-no-alpha-focus-ring.ts",
     "verify:no-handrolled-modal": "tsx scripts/verify-no-handrolled-modal.ts",
+    "verify:no-request-url-as-base": "tsx scripts/verify-no-request-url-as-base.ts",
     "verify:focus-inset-coverage": "tsx scripts/verify-focus-inset-coverage.ts",
     "verify:no-i18n-phrase-collision": "tsx scripts/verify-no-i18n-phrase-collision.ts",
     "verify:no-orphan-resource-routes": "tsx scripts/verify-no-orphan-resource-routes.ts",

--- a/apps/web/scripts/verify-no-request-url-as-base.test.ts
+++ b/apps/web/scripts/verify-no-request-url-as-base.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { hasRequestUrlAsBase } from './verify-no-request-url-as-base';
+
+describe('hasRequestUrlAsBase (story #1933 regression guard)', () => {
+  it('flags new URL(target, request.url)', () => {
+    expect(hasRequestUrlAsBase("const res = NextResponse.redirect(new URL(target, request.url), 303);")).toBe(true);
+  });
+
+  it('flags new URL(literal path, request.url)', () => {
+    expect(hasRequestUrlAsBase("const url = new URL('/internal-dogfood', request.url);")).toBe(true);
+  });
+
+  it('flags req.url (short param name variant)', () => {
+    expect(hasRequestUrlAsBase("const url = new URL(target, req.url);")).toBe(true);
+  });
+
+  // 안전 패턴 — 자기 자신의 query만 읽는 단일 인자 폼은 밖으로 새는 base가 아니다.
+  it('does not flag single-argument new URL(request.url) (query parsing, not a base)', () => {
+    expect(hasRequestUrlAsBase('const { searchParams } = new URL(request.url);')).toBe(false);
+  });
+
+  it('does not flag the fixed pattern (resolveAppUrl(null) as base)', () => {
+    expect(hasRequestUrlAsBase('const res = NextResponse.redirect(new URL(target, resolveAppUrl(null)), 303);')).toBe(false);
+  });
+
+  it('does not flag unrelated new URL() calls', () => {
+    expect(hasRequestUrlAsBase("const url = new URL('https://example.com/path', 'https://example.com');")).toBe(false);
+  });
+});

--- a/apps/web/scripts/verify-no-request-url-as-base.test.ts
+++ b/apps/web/scripts/verify-no-request-url-as-base.test.ts
@@ -26,4 +26,25 @@ describe('hasRequestUrlAsBase (story #1933 regression guard)', () => {
   it('does not flag unrelated new URL() calls', () => {
     expect(hasRequestUrlAsBase("const url = new URL('https://example.com/path', 'https://example.com');")).toBe(false);
   });
+
+  // PO 지적(2026-08-02) — 「넷을 다 잡았는가」가 아니라 「이 가드의 자가 어디까지인가」를
+  // 심어서 재는 것. 세 우회 형태를 실제로 넣어 봤다 — 결과는 아래 두 it()에서 보듯 갈린다.
+  describe('known evasions (PO-requested probe, 2026-08-02) — documents the guard\'s actual reach, not a spec to widen blindly', () => {
+    // req.url 단축형은 이미 (?:request|req) 대체로 잡힌다 — 새 우회가 아니라 기존 커버리지 재확認.
+    it('DOES catch req.url (short param name) — already covered, not a gap', () => {
+      expect(hasRequestUrlAsBase('const url = new URL(target, req.url);')).toBe(true);
+    });
+
+    // ⚠️알려진 미탐(未探) — 변수를 한 번 거치면 정규식이 이 줄 안에서 request.url 문자열을 못 본다.
+    it('MISSES variable indirection (const base = request.url; new URL(x, base)) — known gap, not caught', () => {
+      const code = "const base = request.url; const url = new URL(target, base);";
+      expect(hasRequestUrlAsBase(code)).toBe(false);
+    });
+
+    // ⚠️알려진 미탐(未探) — 대괄호 접근은 `.url` 리터럴이 아니라 정규식이 못 본다.
+    it("MISSES bracket-notation access (new URL(x, request['url'])) — known gap, not caught", () => {
+      const code = "const url = new URL(target, request['url']);";
+      expect(hasRequestUrlAsBase(code)).toBe(false);
+    });
+  });
 });

--- a/apps/web/scripts/verify-no-request-url-as-base.ts
+++ b/apps/web/scripts/verify-no-request-url-as-base.ts
@@ -12,6 +12,14 @@
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
 
+// ⚠️알려진 미탐(PO 지적 2026-08-02, verify-no-request-url-as-base.test.ts에 실제로 심어 확認됨) —
+// 이 가드는 리터럴 `new URL(x, request.url)`/`new URL(x, req.url)` 형태만 잡는다. 아래 둘은
+// «못» 잡는다:
+//   1) 변수 경유:      const base = request.url; new URL(x, base)
+//   2) 대괄호 접근:    new URL(x, request['url'])
+// 정규식을 이 둘까지 넓히려면 AST 분석이 필요하다(문자열 매칭의 근본 한계) — 지금은 넓히지
+// 않는다(PO: "넓히라는 게 아니라 가드의 자를 재라는 것"). 리뷰에서 이 두 형태를 직접 눈으로
+// 잡는 것까지가 이 가드의 실제 커버리지다.
 export const REQUEST_URL_AS_BASE = /new URL\([^)]*,\s*(?:request|req)\.url\)/;
 
 export function hasRequestUrlAsBase(content: string): boolean {

--- a/apps/web/scripts/verify-no-request-url-as-base.ts
+++ b/apps/web/scripts/verify-no-request-url-as-base.ts
@@ -1,0 +1,74 @@
+/**
+ * story #1933 회귀가드 — `new URL(x, request.url)`(또는 `req.url`) 처럼 request.url을
+ * 상대경로의 base로 쓰면, Cloud Run에서 컨테이너가 실제로 받는 요청의 내부 주소가 그대로
+ * 새어 나간다(플랫폼 성질, 개별 라우트의 우연이 아니다) — auth/native·internal-dogfood
+ * 3곳(session/sign-out/stories)에서 잡혀 전부 `resolveAppUrl(null)` 기반으로 고쳤다.
+ *
+ * 이 가드는 그 네 곳을 다시 하나하나 예외 목록으로 만들지 않는다 — 고친 뒤 0건을 고정해
+ * 새로 생기는 것만 막는다(#2340에서 겪은 "예외 목록 만들다 판정 못 바꾸는 25건 더 세기"와
+ * 같은 길을 피한다). `new URL(request.url)`처럼 단일 인자로 자기 자신의 query만 읽는 자리는
+ * 안전하다(밖으로 새는 base가 아니다) — 두 번째 인자에 request.url/req.url이 오는 경우만 잡는다.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+export const REQUEST_URL_AS_BASE = /new URL\([^)]*,\s*(?:request|req)\.url\)/;
+
+export function hasRequestUrlAsBase(content: string): boolean {
+  return REQUEST_URL_AS_BASE.test(content);
+}
+
+const EXT_RE = /\.(tsx?|jsx?)$/;
+const TEST_RE = /\.test\.[tj]sx?$/;
+
+function walk(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walk(full, out);
+    } else if (EXT_RE.test(entry) && !TEST_RE.test(entry)) {
+      out.push(full);
+    }
+  }
+}
+
+const MIN_EXPECTED_FILES = 500;
+
+function main(): void {
+  const srcRoot = path.resolve(process.cwd(), 'src');
+  const files: string[] = [];
+  walk(srcRoot, files);
+
+  if (files.length < MIN_EXPECTED_FILES) {
+    console.error(
+      `FAIL: 검사 대상 파일이 ${files.length}개뿐 — 경로/실행 위치가 틀렸을 가능성. 가드가 헛돌고 있다.`,
+    );
+    console.error(`  srcRoot=${srcRoot} (기대 최소 ${MIN_EXPECTED_FILES}개)`);
+    process.exit(1);
+  }
+
+  const violations: string[] = [];
+  for (const abs of files) {
+    const rel = path.relative(srcRoot, abs).split(path.sep).join('/');
+    const content = readFileSync(abs, 'utf8');
+    if (hasRequestUrlAsBase(content)) violations.push(rel);
+  }
+
+  if (violations.length > 0) {
+    console.error('FAIL: request.url을 상대경로 base로 쓴 자리 발견(story #1933 회귀 — Cloud Run 내부주소 유출):');
+    for (const v of violations) console.error(`  - ${v}`);
+    console.error(
+      '\nCloud Run은 컨테이너에 내부 주소로 요청을 전달한다 — request.url을 new URL()의 base로 쓰면' +
+        ' 그 내부 주소가 redirect Location 등으로 새어 나간다. resolveAppUrl(null)(@/services/app-url)을' +
+        ' base로 쓴다.',
+    );
+    process.exit(1);
+  }
+
+  console.log('OK: request.url을 base로 쓰는 자리 0건');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/apps/web/src/app/api/internal-dogfood/session/route.test.ts
+++ b/apps/web/src/app/api/internal-dogfood/session/route.test.ts
@@ -72,4 +72,28 @@ describe('POST /api/internal-dogfood/session', () => {
     expect(response.headers.get('location')).toContain('error=invalid_secret');
     expect(resolveInternalDogfoodActor).not.toHaveBeenCalled();
   });
+
+  // story #1933 — request.url을 base로 쓰면 Cloud Run 내부 주소가 샌다. resolveAppUrl(null)이
+  // 항상 공개 주소를 강제하는지 여기서 고정한다(요청이 내부 run.app 호스트로 들어와도 무관).
+  it('redirect Location uses the configured public app URL, never the request origin (Cloud Run internal address never leaks)', async () => {
+    const originalAppUrl = process.env['NEXT_PUBLIC_APP_URL'];
+    process.env['NEXT_PUBLIC_APP_URL'] = 'https://dev-app.sprintable.ai';
+    try {
+      const formData = new FormData();
+      formData.set('secret', 'wrong');
+      formData.set('team_member_id', 'tm-1');
+
+      const response = await POST(new Request(
+        'https://sprintable-frontend-dev-57iommnikq-du.a.run.app/api/internal-dogfood/session',
+        { method: 'POST', body: formData },
+      ));
+
+      const location = response.headers.get('location') ?? '';
+      expect(location).toBe('https://dev-app.sprintable.ai/internal-dogfood?error=invalid_secret');
+      expect(location).not.toContain('run.app');
+    } finally {
+      if (originalAppUrl === undefined) delete process.env['NEXT_PUBLIC_APP_URL'];
+      else process.env['NEXT_PUBLIC_APP_URL'] = originalAppUrl;
+    }
+  });
 });

--- a/apps/web/src/app/api/internal-dogfood/session/route.ts
+++ b/apps/web/src/app/api/internal-dogfood/session/route.ts
@@ -6,9 +6,12 @@ import {
   isInternalDogfoodEnabled,
   resolveInternalDogfoodActor,
 } from '@/lib/internal-dogfood';
+import { resolveAppUrl } from '@/services/app-url';
 
-function redirectToInternalDogfood(request: Request, params: Record<string, string>) {
-  const url = new URL('/internal-dogfood', request.url);
+// story #1933 — request.url을 base로 쓰면 Cloud Run 내부 주소가 샌다. resolveAppUrl(null)로
+// 공개 주소를 강제한다(request는 더 이상 필요 없다).
+function redirectToInternalDogfood(params: Record<string, string>) {
+  const url = new URL('/internal-dogfood', resolveAppUrl(null));
   Object.entries(params).forEach(([key, value]) => url.searchParams.set(key, value));
   return url;
 }
@@ -28,19 +31,19 @@ export async function POST(request: Request) {
   }
 
   if (!teamMemberId) {
-    return NextResponse.redirect(redirectToInternalDogfood(request, { error: 'team_member_required' }));
+    return NextResponse.redirect(redirectToInternalDogfood({ error: 'team_member_required' }));
   }
 
   if (secret !== expectedSecret) {
-    return NextResponse.redirect(redirectToInternalDogfood(request, { error: 'invalid_secret' }));
+    return NextResponse.redirect(redirectToInternalDogfood({ error: 'invalid_secret' }));
   }
 
   const actor = resolveInternalDogfoodActor(teamMemberId);
   if (!actor) {
-    return NextResponse.redirect(redirectToInternalDogfood(request, { error: 'member_not_allowed' }));
+    return NextResponse.redirect(redirectToInternalDogfood({ error: 'member_not_allowed' }));
   }
 
-  const response = NextResponse.redirect(redirectToInternalDogfood(request, { actor: actor.id }));
+  const response = NextResponse.redirect(redirectToInternalDogfood({ actor: actor.id }));
   response.cookies.set({
     name: INTERNAL_DOGFOOD_COOKIE,
     value: encodeInternalDogfoodSession({

--- a/apps/web/src/app/api/internal-dogfood/sign-out/route.ts
+++ b/apps/web/src/app/api/internal-dogfood/sign-out/route.ts
@@ -1,11 +1,14 @@
 import { NextResponse } from 'next/server';
 import { apiError } from '@/lib/api-response';
 import { INTERNAL_DOGFOOD_COOKIE, isInternalDogfoodEnabled } from '@/lib/internal-dogfood';
+import { resolveAppUrl } from '@/services/app-url';
 
-export async function POST(request: Request) {
+export async function POST() {
   if (!isInternalDogfoodEnabled()) return apiError('NOT_FOUND', 'Not found', 404);
 
-  const url = new URL('/internal-dogfood', request.url);
+  // story #1933 — request.url을 base로 쓰면 Cloud Run 내부 주소가 샌다. resolveAppUrl(null)로
+  // 공개 주소를 강제한다.
+  const url = new URL('/internal-dogfood', resolveAppUrl(null));
   url.searchParams.set('signed_out', '1');
   const response = NextResponse.redirect(url);
   response.cookies.set(INTERNAL_DOGFOOD_COOKIE, '', {

--- a/apps/web/src/app/api/internal-dogfood/stories/route.ts
+++ b/apps/web/src/app/api/internal-dogfood/stories/route.ts
@@ -1,9 +1,12 @@
 import { NextResponse } from 'next/server';
 import { getInternalDogfoodContext } from '@/lib/internal-dogfood-server';
 import { createInternalDogfoodStoryInSprintable } from '@/services/internal-dogfood-sprintable';
+import { resolveAppUrl } from '@/services/app-url';
 
-function redirectToInternalDogfood(request: Request, params: Record<string, string>) {
-  const url = new URL('/internal-dogfood', request.url);
+// story #1933 — request.url을 base로 쓰면 Cloud Run 내부 주소가 샌다. resolveAppUrl(null)로
+// 공개 주소를 강제한다(request는 더 이상 필요 없다).
+function redirectToInternalDogfood(params: Record<string, string>) {
+  const url = new URL('/internal-dogfood', resolveAppUrl(null));
   Object.entries(params).forEach(([key, value]) => url.searchParams.set(key, value));
   return url;
 }
@@ -20,7 +23,7 @@ export async function POST(request: Request) {
   const priority = String(formData.get('priority') ?? '').trim() || 'medium';
 
   if (!title) {
-    return NextResponse.redirect(redirectToInternalDogfood(request, { error: 'story_title_required' }));
+    return NextResponse.redirect(redirectToInternalDogfood({ error: 'story_title_required' }));
   }
 
   const story = await createInternalDogfoodStoryInSprintable(context.db, context.actor, {
@@ -31,5 +34,5 @@ export async function POST(request: Request) {
     priority,
   });
 
-  return NextResponse.redirect(redirectToInternalDogfood(request, { created_story_id: String((story as { id: string }).id) }));
+  return NextResponse.redirect(redirectToInternalDogfood({ created_story_id: String((story as { id: string }).id) }));
 }

--- a/apps/web/src/app/auth/native/route.test.ts
+++ b/apps/web/src/app/auth/native/route.test.ts
@@ -40,7 +40,7 @@ function makeUrlencodedRequest(fields: Record<string, string>): Request {
   });
 }
 
-const ENV_KEYS = ['FIREBASE_AUTH_MOBILE_ISSUE', 'FIREBASE_BFF_INTERNAL_SECRET', 'NEXT_PUBLIC_FASTAPI_URL'];
+const ENV_KEYS = ['FIREBASE_AUTH_MOBILE_ISSUE', 'FIREBASE_BFF_INTERNAL_SECRET', 'NEXT_PUBLIC_FASTAPI_URL', 'NEXT_PUBLIC_APP_URL', 'APP_BASE_URL'];
 
 describe('POST /auth/native', () => {
   beforeEach(() => {
@@ -49,6 +49,9 @@ describe('POST /auth/native', () => {
     h.resolveFirebaseServerSessionMock.mockReset();
     mockFetch.mockReset();
     for (const k of ENV_KEYS) delete process.env[k];
+    // resolveAppUrl(null) fallback 순서상 NEXT_PUBLIC_APP_URL이 최우선 실질값 — 기존 테스트들의
+    // request URL origin(http://localhost)과 동일하게 맞춰 기존 assertion을 그대로 둔다.
+    process.env['NEXT_PUBLIC_APP_URL'] = 'http://localhost';
   });
 
   afterEach(() => {
@@ -236,5 +239,26 @@ describe('POST /auth/native', () => {
     const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
     const sentBody = JSON.parse(opts.body as string) as { existing_session_user_id?: string };
     expect(sentBody.existing_session_user_id).toBeUndefined();
+  });
+
+  // story #1933 — Cloud Run은 컨테이너에 내부 주소로 요청을 전달한다(플랫폼 성질, 이 라우트의
+  // 우연이 아니다). request.url을 base로 쓰면 그 내부 주소가 그대로 redirect Location에 실려
+  // 나간다. resolveAppUrl(null)이 항상 공개 주소를 강제하는지 여기서 고정한다.
+  it('on success: redirect Location uses the configured public app URL, never the request origin (Cloud Run internal address never leaks)', async () => {
+    process.env['FIREBASE_AUTH_MOBILE_ISSUE'] = 'true';
+    process.env['NEXT_PUBLIC_APP_URL'] = 'https://dev-app.sprintable.ai';
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ session_cookie: 'c' }) });
+
+    // 실제 Cloud Run 컨테이너가 보는 request.url 형태 — 내부 run.app 호스트.
+    const internalHostRequest = new Request('https://sprintable-frontend-dev-57iommnikq-du.a.run.app/auth/native', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: 'x' }),
+    });
+    const res = await POST(internalHostRequest);
+
+    const location = res.headers.get('location') ?? '';
+    expect(location).toBe('https://dev-app.sprintable.ai/inbox');
+    expect(location).not.toContain('run.app');
   });
 });

--- a/apps/web/src/app/auth/native/route.ts
+++ b/apps/web/src/app/auth/native/route.ts
@@ -33,6 +33,7 @@ import { setFirebaseSessionCookie, SP_FS_COOKIE } from '@/lib/auth/firebase-sess
 import { safeNextPath } from '@/lib/auth/session-redirect';
 import { cookieBase } from '@/lib/auth/cookies';
 import { SP_AT_COOKIE, SP_RT_COOKIE, resolveFirebaseServerSession } from '@/lib/db/server';
+import { resolveAppUrl } from '@/services/app-url';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -158,7 +159,9 @@ export async function POST(request: Request) {
   // doc §9.1 6단계: 303 + 원래 딥링크 경로(허용목록 검증) + no-store + Referrer-Policy: no-referrer
   // (code가 이 응답 이전 요청의 body에만 있었으므로 여기선 이미 무관 — 그래도 방어적으로 설정).
   const target = safeNextPath(redirectPathInput);
-  const res = NextResponse.redirect(new URL(target, request.url), 303);
+  // story #1933 — request.url을 base로 쓰면 Cloud Run 내부 주소가 샌다(플랫폼 성질,
+  // 이 라우트만의 우연 아님). resolveAppUrl(null)로 공개 주소를 강제한다(oauth-handoff와 동일 패턴).
+  const res = NextResponse.redirect(new URL(target, resolveAppUrl(null)), 303);
   res.headers.set('Cache-Control', 'no-store');
   res.headers.set('Referrer-Policy', 'no-referrer');
   setFirebaseSessionCookie(res, consumeJson.session_cookie);


### PR DESCRIPTION
## 무엇

`new URL(x, request.url)` 패턴 4곳을 `resolveAppUrl(null)` 기반으로 교체:
- `apps/web/src/app/auth/native/route.ts:164`
- `apps/web/src/app/api/internal-dogfood/session/route.ts`
- `apps/web/src/app/api/internal-dogfood/sign-out/route.ts`
- `apps/web/src/app/api/internal-dogfood/stories/route.ts`

Cloud Run은 컨테이너에 내부 주소로 요청을 전달한다(플랫폼 성질) — `request.url`을 상대경로의
base로 쓰면 그 내부 주소가 그대로 redirect Location에 실려 나간다.

`apps/web` 전체를 `new URL([^)]*, (request|req).url)` 패턴으로 grep해 이 4곳이 전부임을
확인했다(5번째 없음).

## 라이브로 못 잰 이유(정직 고지)

4곳 전부 지금 dev에서 feature flag로 가려져 있다(`FIREBASE_AUTH_MOBILE_ISSUE`·
`INTERNAL_DOGFOOD_ACCESS_ENABLED`) — 라이브 POST로 확인해도 501/404만 나오고 성공
경로(유출이 실제로 나가는 자리)에 도달하지 못한다. 게이트를 열어 재는 것 자체가 실제
유출을 일으키는 사고이므로(PO 판단), 대신:

1. **단위 테스트**: 실제 Cloud Run 내부 주소 형태(`https://sprintable-frontend-dev-....a.run.app`)를
   request origin으로 구성해 POST하고, redirect Location이 여전히 설정된 공개 주소
   (`NEXT_PUBLIC_APP_URL`)인지 확인 — 두 라우트(`auth/native`, `internal-dogfood/session`)에 추가.
2. **뮤테이션 셀프체크(양성대조)**: 두 라우트 모두 옛 코드(`request.url` 그대로)로 되돌려
   해당 테스트가 RED로 떨어지는 것을 로컬에서 직접 확인 후 복원 — 테스트가 실제로
   회귀를 잡는다는 증거.
3. **회귀가드**: `verify:no-request-url-as-base` 신설(CI 연결) — 이 패턴이 새로 생기면
   즉시 막는다. 기존 4곳을 예외 목록으로 만들지 않고 고친 뒤 0건을 고정했다.

**게이트가 켜지는 날 라이브로 한 번 밟는 것**은 별도로 필요하다 — 이 PR은 그 전까지의
안전판이다.

## 검증
- `pnpm --filter web type-check` — 0 에러
- `pnpm --filter web lint`(대상 파일) — 0 경고
- `pnpm --filter web build` — EXIT 0
- vitest(대상 4파일 — auth/native, internal-dogfood/session, internal-dogfood/stories, 신규 가드) — 28/28 pass
- `verify:no-request-url-as-base` — OK: 0건

## Test plan
- [x] 단위 테스트(내부 주소 request → 공개 주소 Location)
- [x] 뮤테이션 셀프체크(옛 코드 되돌리면 RED)
- [x] CI 가드 신설·연결
- [ ] 게이트(FIREBASE_AUTH_MOBILE_ISSUE 등) 활성화 시 라이브 1회 재검증 — 별도 후속

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>