### PR TITLE
fix(#2319): attachments authorize의 asset_id 분기도 tombstone을 본다

### DIFF
--- a/backend/app/routers/attachments.py
+++ b/backend/app/routers/attachments.py
@@ -15,13 +15,13 @@ import os
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import select, text
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
-from app.models.asset import Asset
-from app.models.conversation import Conversation, ConversationParticipant
+from app.models.asset import Asset, AssetLink
+from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.pm import Story
 from app.services.asset_registry import path_in_source_scope
 from app.services.member_resolver import resolve_member
@@ -88,6 +88,32 @@ async def authorize_attachment(
             db, uuid.UUID(auth.user_id), asset.project_id, org_id
         ):
             raise HTTPException(status_code=403, detail="No access to this project")
+
+        # story #2319 미완 2차(미르코 dev 라이브 실측 2026-08-02) — #2808이 conversation_id+path
+        # 분기(belongs SQL)만 고쳤고 이 asset_id 분기는 Asset.deleted_at만 봐서 tombstone된
+        # 메시지의 첨부도 asset_id를 아는 쪽에겐 «무기한» 재발급됐다(5분 TTL 문제가 아니라
+        # 매번 새로 발급받을 수 있는 더 나쁜 형태). 정책(PO 승인, 2026-08-02): asset은 여러
+        # source(conversation_message·story·doc·manual·loop_artifact)에 동시에 걸릴 수 있다
+        # (AssetLink UNIQUE(asset_id,source_type,source_id)) — 「모든 링크가
+        # conversation_message이고 그게 전부 삭제됐을 때만」 거부한다. doc/story 등 다른 살아있는
+        # 문맥에 걸린 자산의 접근권은 이 스토리가 안 건드린다. 링크가 0건(orphan)이면 이 판
+        # 이전과 동일하게 그대로 통과(새 거부를 만들지 않는다).
+        link_rows = (await db.execute(
+            select(AssetLink.source_type, AssetLink.source_id).where(AssetLink.asset_id == asset.id)
+        )).all()
+        if link_rows:
+            message_source_ids = [sid for (stype, sid) in link_rows if stype == "conversation_message"]
+            has_non_message_link = any(stype != "conversation_message" for (stype, sid) in link_rows)
+            if message_source_ids and not has_non_message_link:
+                alive_count = (await db.execute(
+                    select(func.count()).select_from(ConversationMessage).where(
+                        ConversationMessage.id.in_(message_source_ids),
+                        ConversationMessage.deleted_at.is_(None),
+                    )
+                )).scalar_one()
+                if alive_count == 0:
+                    raise HTTPException(status_code=403, detail="Attachment's message has been deleted")
+
         # BE 권위 좌표 반환 — FE 는 이걸로 signRead(외부URL/wrong-bucket 불가·AC3).
         return {"authorized": True, "container": asset.container, "object_path": asset.object_path}
 

--- a/backend/tests/test_1994_backlink_api_realdb.py
+++ b/backend/tests/test_1994_backlink_api_realdb.py
@@ -2366,3 +2366,168 @@ async def test_get_message_hides_attachments_after_delete():
             app.dependency_overrides.clear()
     finally:
         await engine.dispose()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# story #2319 미완 2차(미르코 dev 라이브 실측 2026-08-02) — attachments.py authorize의
+# asset_id 분기가 Asset.deleted_at만 보고 tombstone된 메시지는 안 봐서, 그 메시지의 첨부가
+# asset_id를 아는 쪽에겐 무기한(5분 TTL조차 아니라 재발급 가능) 계속 authorize됐다.
+# 정책(PO 승인): 모든 AssetLink가 conversation_message 타입이고 전부 삭제됐을 때만 거부 —
+# 다른 살아있는 링크(다른 메시지·doc 등)가 하나라도 있으면 허용(다른 문맥의 접근권은 안 건드림).
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+async def _link_asset_to_message(session, *, org_id, asset_id, message_id):
+    from app.models.asset import AssetLink
+    session.add(AssetLink(
+        id=uuid.uuid4(), org_id=org_id, asset_id=asset_id,
+        source_type="conversation_message", source_id=message_id,
+    ))
+    await session.commit()
+
+
+async def _make_asset(session, *, org_id, project_id, object_path="chat/x/y/z.mp4"):
+    from app.models.asset import Asset
+    asset = Asset(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id,
+        container="sprintable-memo-attachments", object_path=object_path,
+        name="z.mp4", content_type="video/mp4", size_bytes=3,
+    )
+    session.add(asset)
+    await session.commit()
+    return asset
+
+
+async def test_attachment_authorize_asset_id_403_when_sole_message_link_tombstoned():
+    """핵심 재현 — asset의 유일한 링크가 삭제된 메시지 하나뿐이면 asset_id 분기가 거부해야 한다.
+    #2808은 이 분기(asset_id)를 안 고쳤다 — 이 테스트가 그 갭을 pin한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [caller_id], created_by=caller_id, conv_type="dm")
+            msg = await _add_message(s, conv_id, caller_id, "영상", _t(1))
+            asset = await _make_asset(s, org_id=org.id, project_id=project.id)
+            await _link_asset_to_message(s, org_id=org.id, asset_id=asset.id, message_id=msg.id)
+            msg_id, asset_id = msg.id, asset.id
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            before = await client.get(f"/api/v2/attachments/authorize?asset_id={asset_id}")
+            assert before.status_code == 200, before.text  # 양성대조 — 삭제 전엔 정상 authorize.
+
+            del_resp = await client.delete(f"/api/v2/conversations/{conv_id}/messages/{msg_id}")
+            assert del_resp.status_code == 200, del_resp.text
+
+            after = await client.get(f"/api/v2/attachments/authorize?asset_id={asset_id}")
+            assert after.status_code == 403, after.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+async def test_attachment_authorize_asset_id_200_when_another_message_link_alive():
+    """정책 확인 — 같은 asset이 메시지 둘에 걸려 있고 하나만 삭제되면 여전히 authorize된다
+    (다른 살아있는 문맥의 접근권은 이 정책이 안 건드린다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [caller_id], created_by=caller_id, conv_type="dm")
+            msg_a = await _add_message(s, conv_id, caller_id, "영상 A", _t(1))
+            msg_b = await _add_message(s, conv_id, caller_id, "영상 B(같은 첨부 재사용)", _t(2))
+            asset = await _make_asset(s, org_id=org.id, project_id=project.id)
+            await _link_asset_to_message(s, org_id=org.id, asset_id=asset.id, message_id=msg_a.id)
+            await _link_asset_to_message(s, org_id=org.id, asset_id=asset.id, message_id=msg_b.id)
+            msg_a_id, asset_id = msg_a.id, asset.id
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            del_resp = await client.delete(f"/api/v2/conversations/{conv_id}/messages/{msg_a_id}")
+            assert del_resp.status_code == 200, del_resp.text
+
+            # msg_a만 지워졌다 — msg_b가 여전히 살아있으므로 authorize는 여전히 200.
+            resp = await client.get(f"/api/v2/attachments/authorize?asset_id={asset_id}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+async def test_attachment_authorize_asset_id_200_when_non_message_link_present():
+    """정책 확인 — 메시지 링크가 삭제됐어도 non-message(예: doc) 링크가 하나라도 있으면
+    authorize된다(doc 등 다른 문맥의 접근권은 이 스토리가 안 건드린다는 정책의 직접 증거)."""
+    from app.main import app
+    from app.models.asset import AssetLink
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            conv_id = await _make_conversation(s, org.id, project.id, [caller_id], created_by=caller_id, conv_type="dm")
+            msg = await _add_message(s, conv_id, caller_id, "영상", _t(1))
+            asset = await _make_asset(s, org_id=org.id, project_id=project.id)
+            await _link_asset_to_message(s, org_id=org.id, asset_id=asset.id, message_id=msg.id)
+            # non-message 링크(doc — source_id는 임의 uuid로 충분, 이 분기는 존재 검증을 안 한다).
+            s.add(AssetLink(
+                id=uuid.uuid4(), org_id=org.id, asset_id=asset.id,
+                source_type="doc", source_id=uuid.uuid4(),
+            ))
+            await s.commit()
+            msg_id, asset_id = msg.id, asset.id
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            del_resp = await client.delete(f"/api/v2/conversations/{conv_id}/messages/{msg_id}")
+            assert del_resp.status_code == 200, del_resp.text
+
+            resp = await client.get(f"/api/v2/attachments/authorize?asset_id={asset_id}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+async def test_attachment_authorize_asset_id_200_when_no_links_orphan():
+    """정책 확인 — 링크가 0건(orphan asset)이면 이 판 이전과 동일하게 그대로 authorize된다
+    (이 스토리가 새 거부를 만들지 않는다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            asset = await _make_asset(s, org_id=org.id, project_id=project.id)
+            asset_id = asset.id
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/attachments/authorize?asset_id={asset_id}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 요약

#2808 라이브 검증 중 dev에서 실측: `attachments.py authorize()`는 세 분기(conversation_id+path·
story_id+path·asset_id)인데 #2808은 conversation_id+path 분기(belongs SQL)만 고쳤다. 같은 판이
세 번째로 안 닫히는 중이었다 — `#2806`은 본문만, `#2808`은 그 한 분기만.

```
분기                  무엇으로 인가하는가                    tombstone(메시지 삭제)를 보는가
conversation_id+path  belongs SQL(메시지 attachments 배열)    ✅ #2808에서 고침
story_id+path         Story.attachments 배열                 ✅ 원래부터 봄(메시지 개념 자체가 없는 분기)
asset_id              Asset.deleted_at만                     ⛔ 메시지 개념을 아예 안 봄 — 이 PR
```

**이전 갭보다 나쁘다** — conversation_id+path 분기는 이미 발급된 서명URL이 5분 TTL 안에서만
유효했지만, asset_id 분기는 삭제 후에도 `asset_id`를 아는 쪽이 계속 **새로 재발급**받을 수 있었다
(무기한).

## 정책 — asset은 여러 곳에 걸릴 수 있다

`AssetLink`는 `source_type IN (conversation_message·story·doc·manual·loop_artifact)` 다섯 종류를
받고 `(asset_id, source_type, source_id)` UNIQUE라 같은 asset이 여러 링크를 가질 수 있다
(`sync_attachment_assets`가 매 저장마다 upsert).

**정책(PO 승인)**: 모든 링크가 `conversation_message` 타입이고 그게 **전부** 삭제됐을 때만 거부한다.
- doc/story 등 다른 살아있는 문맥에 걸린 자산의 접근권은 이 스토리가 안 건드린다.
- 링크가 0건(orphan asset)이면 이 판 이전과 동일하게 통과 — 새 거부를 만들지 않는다.

## ⚠️알려진 한계(PO 지시로 명시, 별도 스토리로 추적 예정 — 이 PR에서 안 고침)

**이 정책은 "링크가 살아있는가"만 보고 "그 링크의 문맥에 접근권이 있는가"는 안 본다.**
`asset_id` 분기는 원래부터 문맥별(예: 그 doc에 대한) 인가 검사가 없는 구조다 — 이 PR은 그
구조 자체를 바꾸지 않는다. 즉 오발송한 첨부가 doc에도 걸려 있으면, `asset_id`를 아는 사람은
그 doc 접근권과 무관하게 계속 받을 수 있다. 이건 이 PR보다 큰 자리라 지금 고치지 않는다.

## 검증

- 신규 realdb 테스트 4건: 핵심 재현(유일 메시지 링크 삭제→403) · 다른 메시지 링크 생존 시 200 ·
  non-message(doc) 링크 존재 시 200 · orphan(링크 0건) 시 200(회귀 없음).
- 분기별 뮤테이션: asset_id 분기만 sabotage→그 분기 테스트만 RED(다른 5개 그대로 GREEN) ·
  conversation_id+path 분기만 sabotage→그 분기 테스트만 RED · 둘 다 sabotage→둘 다 RED. 각각
  복원 후 재확認.
- 관련 스위트(backlink·attachment authorize 양쪽 파일·efile·authz coverage·conversations)
  91개 전부 통과.

## Test plan

- [ ] 첨부(영상) 있는 메시지를 삭제한 뒤, 그 asset_id를 직접 알아도(devtools 등) 새 서명URL을
      못 받는지
- [ ] 같은 파일이 doc에도 첨부돼 있으면(공유 케이스) 그 doc 열람 시엔 여전히 보이는지
- [x] CI(type-check/lint/vitest/realdb pytest)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
