### PR TITLE
fix(#2422): env drift guard alibi silence — 4-day-old false positive + new-vs-recurring failure alert

### DIFF
--- a/.github/workflows/env-drift-guard.yml
+++ b/.github/workflows/env-drift-guard.yml
@@ -62,19 +62,38 @@ jobs:
       - name: Install deps
         run: pip install --quiet pyyaml
 
+      # story #2422 — 나흘째 FAIL인데 아무도 못 알아챈 병의 처방. 어제 이 워크플로우가 남긴
+      # "FAIL 집합 지문"(dev·prod 각각, 값 없이 키 이름만)을 캐시에서 복원한다. 고정 키가
+      # 아니라 run_id로 매번 새 키를 쓰고 restore-keys 접두사로 "가장 최근 것"을 찾는다 —
+      # actions/cache는 같은 키 재저장을 지원하지 않으므로 이게 표준 "매일 갱신되는 상태"
+      # 패턴이다(오래된 캐시는 GitHub의 7일 미접근 LRU가 자연히 정리한다).
+      - name: Restore previous drift digest
+        uses: actions/cache/restore@v4
+        with:
+          path: env-drift-digest.json
+          key: env-drift-digest-${{ github.run_id }}  # 절대 히트 안 함(고의) — restore-keys로만 찾는다.
+          restore-keys: |
+            env-drift-digest-
+
       # ⚠️ 값 자체는 여기서도 절대 로그에 안 남는다(check_env_drift.py가 매치 여부만 반환) —
       # 이 스텝 출력이 그대로 GHA 로그·아티팩트가 되니, 스크립트 쪽 보장이 이 워크플로우
       # 전체의 보장이기도 하다(설계 doc "③" 축 요구사항).
       #
       # ⛔둘 다 실행하고 «둘 중 하나라도» FAIL이면 이 스텝 자체가 실패한다(continue-on-error
       # 로 하나를 먼저 죽이고 다른 걸 스킵하면 안 됨 — 매일 두 축을 다 봐야 한다).
+      # story #2422 — ENV_DRIFT_STATE_FILE을 줘서 이번 실행의 FAIL 집합을 파일로 남긴다
+      # (FAIL이든 성공이든 반드시 쓰임 — check_env_drift.py의 _write_state_file 계약).
       - name: Run drift check (prod — main)
         id: drift_prod
+        env:
+          ENV_DRIFT_STATE_FILE: ${{ github.workspace }}/env-drift-state-prod.json
         run: python3 infra/check_env_drift.py --only-env prod
 
       - name: Run drift check (dev — develop)
         id: drift_dev
         if: always()  # prod 스텝이 실패해도 dev 스텝은 반드시 돈다 — 한쪽이 다른 쪽을 가리면 안 됨.
+        env:
+          ENV_DRIFT_STATE_FILE: ${{ github.workspace }}/env-drift-state-dev.json
         run: python3 develop-checkout/infra/check_env_drift.py --only-env dev
 
       - name: Combine drift results
@@ -85,6 +104,32 @@ jobs:
             echo "::error::drift 발견 — prod=${{ steps.drift_prod.outcome }} dev=${{ steps.drift_dev.outcome }}"
             exit 1
           fi
+
+      # story #2422 — 오늘 지문을 어제 지문과 대조해 "새 실패"·"해소"·"동일 반복 N일째"를
+      # 가른다. always()로 돈다 — drift-check가 실패해도(오히려 그때 이 정보가 제일 필요),
+      # 성공해도(어제 FAIL이 오늘 해소됐는지는 알아야) 이 비교는 항상 의미가 있다. 두 state
+      # 파일이 항상 존재한다(위 두 스텝이 always()로 도니 — prod가 실패해도 파일은 남는다).
+      - name: Compare against yesterday's drift digest
+        id: compare
+        if: always()
+        run: |
+          python3 infra/compare_env_drift_state.py \
+            --dev-state env-drift-state-dev.json \
+            --prod-state env-drift-state-prod.json \
+            --previous-digest env-drift-digest.json \
+            --output-digest env-drift-digest.json \
+            --today "$(date -u +%Y-%m-%d)" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --github-output "$GITHUB_OUTPUT"
+
+      # 다음 실행이 오늘을 "어제"로 볼 수 있게 저장한다. always()로 — drift-check 결과와
+      # 무관하게 매일 갱신돼야 다음 대조가 최신 상태를 기준으로 선다.
+      - name: Save today's drift digest
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: env-drift-digest.json
+          key: env-drift-digest-${{ github.run_id }}
 
       # FAIL 시에만 실행. 오르테가군 정정(2026-07-22): Sprintable story 자동생성은 뺀다 —
       # API 키를 GitHub secret에 하나 더 뿌리는 대가(오늘 하루 겪은 키 유출 사고 직후라
@@ -103,17 +148,21 @@ jobs:
       # 부재였다면, 이건 alert는 도착하는데 «구독자 없는 채널»로 가는 같은 병의 다음 얼굴일
       # 수 있다). 그 웹훅이 실제로 사람이 상주하는 채널에 꽂혀 있는지는 이 스토리·이 워크플로우
       # 밖의 운영 확認 사항이다.
+      # story #2422 — 문구를 위 compare 스텝의 출력(새 실패 vs 동일 반복 N일째)으로 바꾼다.
+      # ⛔이 스텝은 여전히 "동일 반복"이어도 매일 그대로 발송한다 — 조용히 억제하지 않는다
+      # (오르테가 원칙과 동형). 바뀐 것은 문구의 정보량뿐, 발송 여부·job 실패는 무변경.
       - name: Notify on drift (Discord)
         if: failure() && steps.drift.outcome == 'failure'
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.ENV_DRIFT_GUARD_DISCORD_WEBHOOK_URL }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          DRIFT_MESSAGE: ${{ steps.compare.outputs.message }}
         run: |
           set -euo pipefail
           if [ -z "${DISCORD_WEBHOOK_URL:-}" ]; then
             echo "::error::ENV_DRIFT_GUARD_DISCORD_WEBHOOK_URL 미등록 — drift를 감지했는데 알릴 방법이 없다. 이 자체가 실패여야 하는(PO 시크릿 등록 필요) — GHA 스케줄 워크플로우 실패 통지가 최소 폴백."
             exit 1
           fi
+          python3 -c "import json, os; print(json.dumps({'content': os.environ['DRIFT_MESSAGE']}))" > /tmp/discord-payload.json
           curl -fsS -X POST "${DISCORD_WEBHOOK_URL}" \
             -H "Content-Type: application/json" \
-            -d "$(printf '{"content":"⛔ env 드리프트 가드 FAIL — 상세: %s"}' "${RUN_URL}")"
+            -d @/tmp/discord-payload.json

--- a/backend/tests/test_check_env_drift_code_read_axis.py
+++ b/backend/tests/test_check_env_drift_code_read_axis.py
@@ -294,17 +294,20 @@ def test_ac4_real_repo_scan_counts_are_recorded():
         f"\n[AC4] 총 고유 env 키 {total_reads}개 · exempt {len(exempt)}개 · "
         f"미커버 findings {total_findings}개(highest={len(highest)}, high={len(high)}, low={len(low)})"
     )
-    # 정확한 숫자 고정(2026-07-28, 2026-07-31 ⑤ DI-패턴 후속으로 high 15→20 갱신) — 스위트가
-    # 실패하면 숫자가 바뀐 것, 원인을 봐야 한다. +5는 SPRINTABLE_RUNTIME_ROLE·
+    # 정확한 숫자 고정(2026-07-28, 2026-07-31 ⑤ DI-패턴 후속으로 high 15→20,
+    # 2026-08-02 story #2422 후속으로 high 20→15·exempt 18→23 갱신) — 스위트가 실패하면
+    # 숫자가 바뀐 것, 원인을 봐야 한다. 이번 -5/+5는 SPRINTABLE_RUNTIME_ROLE·
     # SPRINTABLE_{BACKGROUND,MEMO_DISPATCHER,DISCORD_OUTBOUND,TEAMS_OUTBOUND}_POLL_INTERVAL_MS
-    # — background-runtime.ts의 `env: NodeJS.ProcessEnv = process.env` DI 파라미터로 읽혀
-    # process.env 직접참조만 보던 스캔에 새로 잡히기 시작한 실제 미커버 값들(baseline에 일부러
-    # 안 넣었다 — SPRINTABLE_RUNTIME_ROLE은 PO 판단이 필요한 신규 실사고 후보라 스스로 baseline
-    # 처리하지 않는다).
+    # 다섯이 high(미triage)에서 code_read_exempt(영구 정상)로 승격된 것 — env 드리프트
+    # 가드가 나흘째 이 다섯을 FAIL로 잡던 것을 실측(gcloud)으로 추적한 결과, frontend-dev/
+    # prod 둘 다 NODE_ENV=production이라 SPRINTABLE_RUNTIME_ROLE 미설정 시 기본값이 'web'
+    # 으로 떨어져 이 값들을 쓰는 백그라운드 워커 자체가 안 켜진다(story #2423 — 이 기능군은
+    # 은퇴 상태). 값을 채워야 도는 게 아니라 안 채워야 지금 의도대로 도는 스위치라
+    # code_read_exempt가 정확한 분류다(baseline의 "아직 triage 안 됨"과 다르다).
     assert len(highest) == 1, highest
-    assert len(high) == 20, high
+    assert len(high) == 15, high
     assert len(low) == 9, low
-    assert len(exempt) == 18
+    assert len(exempt) == 23
 
 
 # ── AC5 — 값을 안 읽는다 ──────────────────────────────────────────────────────

--- a/backend/tests/test_check_env_drift_state_fingerprint.py
+++ b/backend/tests/test_check_env_drift_state_fingerprint.py
@@ -1,0 +1,195 @@
+"""story #2422 — env 드리프트 가드가 나흘째 FAIL인데 아무도 못 알아챈 병의 회귀가드.
+
+증상 재현: 매일 같은 모양의 Discord 알림(``⛔ env 드리프트 가드 FAIL — 상세: <link>``)이
+와서 "어제와 같은 실패"인지 "오늘 새로 생긴 실패"인지 구분이 안 됐다 — 빨강이 «배경음»이
+되면 가드가 있어도 없는 것과 같다(초록이 알리바이가 되는 것의 반대편). 두 축을 고정한다:
+①`check_env_drift.py`가 FAIL 집합을 파일로 남기는가(``ENV_DRIFT_STATE_FILE``), ②그 파일을
+전날 지문과 대조해 신규/해소/연속일수를 정확히 가르는가(``compare_env_drift_state.py``).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_INFRA_DIR = _REPO_ROOT / "infra"
+
+
+def _load_module(name: str):
+    spec = importlib.util.spec_from_file_location(name, _INFRA_DIR / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ── ① check_env_drift.py — 상태파일 기록 ─────────────────────────────────────
+
+def test_write_state_file_noop_without_env_var(tmp_path, monkeypatch):
+    """ENV_DRIFT_STATE_FILE이 안 설정돼 있으면(로컬 수동 실행 기본) 아무 파일도 안 남긴다."""
+    mod = _load_module("check_env_drift")
+    monkeypatch.delenv("ENV_DRIFT_STATE_FILE", raising=False)
+    mod._write_state_file(["some finding"], only_env="dev")
+    # 파일 경로 자체가 없으니 생성 여부를 직접 검증할 길이 없다 — 예외 없이 조용히 끝나야
+    # 정상(파일을 안 쓰는 것 자체가 이 테스트의 단언).
+
+
+def test_write_state_file_records_fail_lines_sorted_and_deduped(tmp_path, monkeypatch):
+    mod = _load_module("check_env_drift")
+    out = tmp_path / "state.json"
+    monkeypatch.setenv("ENV_DRIFT_STATE_FILE", str(out))
+    mod._write_state_file(["B finding", "A finding", "A finding"], only_env="prod")
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data == {"env": "prod", "fail_lines": ["A finding", "B finding"]}
+
+
+def test_write_state_file_records_empty_list_on_clean_run(tmp_path, monkeypatch):
+    """FAIL 0건이어도 반드시 파일을 남긴다 — "어제는 빨강, 오늘은 초록" 해소 전이를
+    다음 비교가 알아야 하므로 파일 부재와 빈 목록을 구분해야 한다."""
+    mod = _load_module("check_env_drift")
+    out = tmp_path / "state.json"
+    monkeypatch.setenv("ENV_DRIFT_STATE_FILE", str(out))
+    mod._write_state_file([], only_env="dev")
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data == {"env": "dev", "fail_lines": []}
+
+
+# ── ② compare_env_drift_state.py — 신규/해소/연속일수 판정 ──────────────────
+
+def _write(path: Path, fail_lines: list[str]) -> str:
+    path.write_text(json.dumps({"fail_lines": fail_lines}), encoding="utf-8")
+    return str(path)
+
+
+def test_first_ever_failure_is_new_with_streak_one(tmp_path):
+    """캐시 미스(직전 digest 파일 없음)면 지금 있는 것 전부가 "신규"로 읽혀야 한다 —
+    "처음 보는 빨강"과 "계속되던 빨강"을 가르지 못하면 이 스토리의 존재 이유가 없다."""
+    mod = _load_module("compare_env_drift_state")
+    dev = _write(tmp_path / "dev.json", ["A", "B"])
+    prod = _write(tmp_path / "prod.json", [])
+    missing_digest = str(tmp_path / "does-not-exist.json")
+
+    result = mod.compare([("dev", dev), ("prod", prod)], missing_digest, "2026-08-02")
+
+    assert result["new_items"] == ["[dev] A", "[dev] B"]
+    assert result["resolved_items"] == []
+    assert result["streak_days"] == 1
+    assert result["since"] == "2026-08-02"
+    assert result["unchanged"] is False
+
+
+def test_identical_failure_set_increments_streak_and_keeps_since(tmp_path):
+    """이 테스트가 스토리의 핵심 실패 재현이다 — 나흘 동안 정확히 이 경로를 탔다."""
+    mod = _load_module("compare_env_drift_state")
+    dev = _write(tmp_path / "dev.json", ["A", "B"])
+    prod = _write(tmp_path / "prod.json", [])
+    digest = tmp_path / "digest.json"
+    digest.write_text(
+        json.dumps({"fail_lines": ["[dev] A", "[dev] B"], "since": "2026-07-30", "streak_days": 3}),
+        encoding="utf-8",
+    )
+
+    result = mod.compare([("dev", dev), ("prod", prod)], str(digest), "2026-08-02")
+
+    assert result["new_items"] == []
+    assert result["resolved_items"] == []
+    assert result["streak_days"] == 4
+    assert result["since"] == "2026-07-30"
+    assert result["unchanged"] is True
+
+
+def test_mixed_new_and_resolved_resets_streak(tmp_path):
+    """집합이 «달라지면»(신규가 생겼든 기존이 없어졌든) 연속선은 오늘부터 다시 센다 —
+    "어제와 완전히 같은 그 문제"가 아니면 "며칠째"라는 말 자체가 거짓이 된다."""
+    mod = _load_module("compare_env_drift_state")
+    dev = _write(tmp_path / "dev.json", ["A", "C"])  # B 해소, C 신규
+    prod = _write(tmp_path / "prod.json", [])
+    digest = tmp_path / "digest.json"
+    digest.write_text(
+        json.dumps({"fail_lines": ["[dev] A", "[dev] B"], "since": "2026-07-30", "streak_days": 3}),
+        encoding="utf-8",
+    )
+
+    result = mod.compare([("dev", dev), ("prod", prod)], str(digest), "2026-08-02")
+
+    assert result["new_items"] == ["[dev] C"]
+    assert result["resolved_items"] == ["[dev] B"]
+    assert result["streak_days"] == 1
+    assert result["since"] == "2026-08-02"
+    assert result["unchanged"] is False
+
+
+def test_all_resolved_reports_resolved_with_no_current_fail(tmp_path):
+    mod = _load_module("compare_env_drift_state")
+    dev = _write(tmp_path / "dev.json", [])
+    prod = _write(tmp_path / "prod.json", [])
+    digest = tmp_path / "digest.json"
+    digest.write_text(
+        json.dumps({"fail_lines": ["[dev] A", "[dev] B"], "since": "2026-07-30", "streak_days": 3}),
+        encoding="utf-8",
+    )
+
+    result = mod.compare([("dev", dev), ("prod", prod)], str(digest), "2026-08-02")
+
+    assert result["current_fail"] == []
+    assert result["resolved_items"] == ["[dev] A", "[dev] B"]
+    assert result["new_items"] == []
+
+
+def test_prod_and_dev_findings_both_labeled_and_merged(tmp_path):
+    """두 env의 실패가 한 digest에 합쳐지되, 어느 쪽인지 라벨이 안 사라진다 — 그래야
+    다음 대조가 "dev의 A"와 "prod의 A"를 같은 것으로 잘못 묶지 않는다."""
+    mod = _load_module("compare_env_drift_state")
+    dev = _write(tmp_path / "dev.json", ["A"])
+    prod = _write(tmp_path / "prod.json", ["A"])  # 같은 이름, 다른 env
+    missing_digest = str(tmp_path / "none.json")
+
+    result = mod.compare([("dev", dev), ("prod", prod)], missing_digest, "2026-08-02")
+
+    assert result["current_fail"] == ["[dev] A", "[prod] A"]
+    assert len(result["new_items"]) == 2  # 둘 다 별개 신규 항목 — 병합되지 않음
+
+
+# ── digest 기록 — 다음 실행이 읽을 파일 자체가 맞게 쓰이는지 ────────────────
+
+def test_write_digest_persists_fail_lines_since_and_streak(tmp_path):
+    mod = _load_module("compare_env_drift_state")
+    out = tmp_path / "digest.json"
+    result = {
+        "current_fail": ["[dev] A"],
+        "new_items": ["[dev] A"],
+        "resolved_items": [],
+        "streak_days": 1,
+        "since": "2026-08-02",
+        "unchanged": False,
+    }
+    mod.write_digest(str(out), result)
+    saved = json.loads(out.read_text(encoding="utf-8"))
+    assert saved == {"fail_lines": ["[dev] A"], "since": "2026-08-02", "streak_days": 1}
+
+
+# ── 알림 문구 — "새 실패"와 "동일 반복"이 실제로 다른 문장을 낸다 ───────────
+
+def test_message_for_new_failure_leads_with_new_marker():
+    mod = _load_module("compare_env_drift_state")
+    result = {
+        "current_fail": ["[dev] A"], "new_items": ["[dev] A"], "resolved_items": [],
+        "streak_days": 1, "since": "2026-08-02", "unchanged": False,
+    }
+    msg = mod.format_discord_message(result, "https://example.com/run/1")
+    assert "새" in msg.splitlines()[0]
+    assert "[dev] A" in msg
+
+
+def test_message_for_recurring_failure_states_streak_not_new_marker():
+    """이 테스트가 스토리의 존재 이유다 — 문구 첫 줄이 "새 실패"와 "동일 반복"을 갈라야
+    다음 사람이 «어제와 같은 실패»를 클릭해서 확認하지 않고도 알 수 있다."""
+    mod = _load_module("compare_env_drift_state")
+    result = {
+        "current_fail": ["[dev] A", "[dev] B"], "new_items": [], "resolved_items": [],
+        "streak_days": 4, "since": "2026-07-30", "unchanged": True,
+    }
+    msg = mod.format_discord_message(result, "https://example.com/run/1")
+    first_line = msg.splitlines()[0]
+    assert "동일 반복 4일째" in first_line
+    assert "새" not in first_line.replace("새 항목 없음", "")  # "새 실패 발견" 마커가 없어야 함(양성대조)

--- a/infra/check_env_drift.py
+++ b/infra/check_env_drift.py
@@ -569,6 +569,26 @@ def _today():
     return datetime.now(timezone.utc).date()
 
 
+def _write_state_file(fail_lines: list[str], *, only_env: str | None) -> None:
+    """story #2422 — `ENV_DRIFT_STATE_FILE` 환경변수가 설정돼 있으면(설계상 CI에서만 —
+    로컬 수동 실행은 이 변수를 안 주므로 파일을 안 남긴다) 이번 실행의 FAIL 집합을 정렬된
+    JSON 목록으로 적는다. 값 자체는 여기 안 실린다 — 이미 위 finding 문자열들이 «키 이름만»
+    (①②③⑤ 전부 이 파일 상단 docstring이 보장하는 계약) 담고 있으므로 그대로 옮겨 적어도
+    안전하다. FAIL이 0건이어도(빈 리스트) 반드시 쓴다 — "어제는 빨강, 오늘은 초록"이라는
+    해소 전이도 다음 실행이 알아야 하기 때문이다(파일 부재와 '빈 목록'을 구분 못 하면
+    캐시 미스와 '실제로 깨끗함'을 못 가른다)."""
+    import json
+    import os as _os
+
+    path = _os.environ.get("ENV_DRIFT_STATE_FILE")
+    if not path:
+        return
+    payload = {"env": only_env, "fail_lines": sorted(set(fail_lines))}
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2, sort_keys=True)
+        f.write("\n")
+
+
 def main(only_env: str | None = None) -> int:
     """story #2224 후속(오르테가 판정, 2026-07-31) — `only_env`("dev"|"prod"|None). 배경:
     이 가드는 스케줄 워크플로우가 checkout한 «한 브랜치»(GHA 스케줄 트리거는 default
@@ -704,6 +724,18 @@ def main(only_env: str | None = None) -> int:
         or service_subset_violations
     )
     has_report_only = bool(settings_coverage_report or code_read_report)
+
+    # story #2422 — 나흘째 FAIL이었는데 아무도 못 알아챈 원인: 매일 같은 모양의 알림이
+    # "어제와 같은 실패"인지 "새 실패"인지 말해 주지 않았다(빨강이 배경음이 되는 병 —
+    # 초록이 알리바이가 되는 것의 반대편). 이 FAIL 집합(has_fail을 만드는 바로 그 목록들)의
+    # 안정적인 지문을 남겨 워크플로우가 어제 지문과 대조할 수 있게 한다 — report-only
+    # 항목은 지문에 안 넣는다(FAIL 판정과 무관한 축이 바뀌었다고 "새 실패"로 오판하면 안 됨).
+    _write_state_file(
+        key_set_failures + value_check_failures + secret_shape_failures
+        + code_read_highest_failures + code_read_baseline_escalations
+        + service_subset_violations,
+        only_env=only_env,
+    )
 
     # ⭐파울로군 지시 ③ — baseline 수를 «매번» 찍는다(FAIL이든 성공이든 무관). baseline을
     # 묻어두는 곳으로 쓰지 않으려면 그 크기가 줄어드는지 매 실행 눈에 보여야 한다.

--- a/infra/compare_env_drift_state.py
+++ b/infra/compare_env_drift_state.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""story #2422 — env 드리프트 가드가 나흘째 FAIL인데 아무도 못 알아챈 병의 근본 처방.
+
+증상: 매일 같은 모양(``⛔ env 드리프트 가드 FAIL — 상세: <link>``)의 알림이 와서, "어제와
+같은 실패"인지 "오늘 새로 생긴 실패"인지 알림 자체가 말해 주지 않았다 — 빨강이 «배경음»이
+되면(초록이 알리바이가 되는 것의 반대편) 가드가 있어도 없는 것과 같다.
+
+이 스크립트는 `check_env_drift.py`(``ENV_DRIFT_STATE_FILE`` 설정 시)가 매 실행 남기는
+"오늘의 FAIL 집합"(dev·prod 각각, 키 이름만 — 값 없음)을 어제 지문(직전 실행분, GHA
+cache로 영속화)과 대조해 셋을 가른다: 신규(새로 생긴 항목)·해소(어제 있었는데 오늘 없는
+항목)·연속일수(지금 이 정확한 집합이 며칠째 그대로인지). 알림 문구가 이 셋을 말하게 하는
+것이 스토리의 진짜 축이다(㉠ 드리프트 자체를 고치는 것보다 이쪽이 다음 드리프트도 똑같이
+묻히는가를 가른다).
+
+⛔절대 하지 않는 것 — "동일 반복이니 조용히 넘어간다"(오르테가군 원칙, 알림 불가/억제
+절대 금지와 동형). CI job의 실패(exit 1)는 이 스크립트와 무관하게 그대로 유지된다 — 이
+스크립트는 «알림 문구»만 더 정보가 있게 만들 뿐, 빨강을 초록으로 바꾸거나 알림 자체를
+끄지 않는다. "동일 반복 N일째"도 여전히 알림으로 나간다 — 다만 "새 실패인가"를 한눈에
+가를 수 있게 될 뿐이다.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def load_fail_lines(path: str) -> list[str]:
+    """state 파일이 없으면(첫 실행·캐시 미스) 빈 목록 — "지문 없음"과 "지문이 빈 목록"을
+    구분하지 않는다(둘 다 "그때는 알려진 게 없었다"로 같이 취급하는 게 이 대조에선 맞다 —
+    캐시가 비어 있는 첫날은 뭐가 나와도 전부 "신규"로 보이는 게 오히려 정확하다)."""
+    p = Path(path)
+    if not p.exists():
+        return []
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return []
+    return list(data.get("fail_lines", []))
+
+
+def compare(
+    envs: list[tuple[str, str]], previous_digest_path: str, today: str,
+) -> dict:
+    """envs: [(label, current_state_path), ...] — 오늘 각 env가 낸 raw state 파일.
+    previous_digest_path: 어제 이 함수가 남긴 digest(캐시에서 복원됨, 없으면 첫 실행).
+    반환: {"current_fail": set[str]로 join 안 된 label-tagged 문자열 목록, "new_items",
+    "resolved_items", "streak_days", "since", "unchanged"}."""
+    current_fail: list[str] = []
+    for label, path in envs:
+        for line in sorted(load_fail_lines(path)):
+            current_fail.append(f"[{label}] {line}")
+    current_set = set(current_fail)
+
+    prev_digest = _load_digest(previous_digest_path)
+    previous_set = set(prev_digest.get("fail_lines", []))
+
+    new_items = sorted(current_set - previous_set)
+    resolved_items = sorted(previous_set - current_set)
+    unchanged = current_set == previous_set
+
+    if unchanged and prev_digest.get("since"):
+        # 집합이 어제와 완전히 같다 — 연속선 그대로 이어간다(집합이 비어 있어도 "0일째 계속
+        # 깨끗함"은 이 스크립트 밖 관심사, 알림은 has_fail이 없으면 애초에 안 불린다).
+        since = prev_digest["since"]
+        streak_days = int(prev_digest.get("streak_days", 1)) + 1
+    else:
+        # 집합이 달라졌다(신규·해소 어느 쪽이든) — 오늘부터 새 연속선 시작.
+        since = today
+        streak_days = 1
+
+    return {
+        "current_fail": sorted(current_set),
+        "new_items": new_items,
+        "resolved_items": resolved_items,
+        "streak_days": streak_days,
+        "since": since,
+        "unchanged": unchanged,
+    }
+
+
+def _load_digest(path: str) -> dict:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def write_digest(path: str, result: dict) -> None:
+    payload = {
+        "fail_lines": result["current_fail"],
+        "since": result["since"],
+        "streak_days": result["streak_days"],
+    }
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def format_discord_message(result: dict, run_url: str) -> str:
+    """알림 문구 — 「새 실패인가」가 첫 줄에 오게(다음 발견을 그 자리에서 세지 못하면 이
+    스토리가 고치려는 그 병이 그대로 재발한다)."""
+    lines: list[str] = []
+    if not result["current_fail"]:
+        # has_fail이 없으면 워크플로우가 이 알림 스텝 자체를 안 부른다 — 방어적으로만 남김.
+        lines.append("⛔ env 드리프트 가드 FAIL — 상세 없음(호출 경로 오류 의심)")
+    elif result["new_items"] or (result["streak_days"] == 1 and not result["resolved_items"]):
+        lines.append(f"⭐ env 드리프트 가드 FAIL — «새» 실패 발견({len(result['new_items'])}건)")
+        for item in result["new_items"][:10]:
+            lines.append(f"  + {item}")
+        if len(result["new_items"]) > 10:
+            lines.append(f"  ... 외 {len(result['new_items']) - 10}건")
+    else:
+        lines.append(
+            f"⛔ env 드리프트 가드 FAIL — 동일 반복 {result['streak_days']}일째"
+            f"(since {result['since']}, 새 항목 없음)"
+        )
+
+    if result["resolved_items"]:
+        lines.append(f"✅ 해소된 항목({len(result['resolved_items'])}건):")
+        for item in result["resolved_items"][:10]:
+            lines.append(f"  - {item}")
+
+    if result["current_fail"] and not result["new_items"]:
+        lines.append(f"현재 유지 중인 실패 {len(result['current_fail'])}건 — 상세: {run_url}")
+    else:
+        lines.append(f"상세: {run_url}")
+
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str]) -> dict:
+    args = dict(zip(argv[::2], argv[1::2]))
+    required = {"--dev-state", "--prod-state", "--previous-digest", "--output-digest", "--today", "--run-url"}
+    missing = required - set(args)
+    if missing:
+        raise SystemExit(f"missing required args: {sorted(missing)}")
+    return args
+
+
+def main() -> int:
+    args = _parse_args(sys.argv[1:])
+    result = compare(
+        [("dev", args["--dev-state"]), ("prod", args["--prod-state"])],
+        args["--previous-digest"],
+        args["--today"],
+    )
+    write_digest(args["--output-digest"], result)
+
+    message = format_discord_message(result, args["--run-url"])
+    is_new = bool(result["new_items"]) or (result["streak_days"] == 1 and bool(result["current_fail"]))
+
+    github_output = args.get("--github-output")
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as f:
+            f.write(f"is_new_failure={'true' if is_new else 'false'}\n")
+            f.write(f"streak_days={result['streak_days']}\n")
+            f.write("message<<ENV_DRIFT_MSG_EOF\n")
+            f.write(message + "\n")
+            f.write("ENV_DRIFT_MSG_EOF\n")
+
+    print(message)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infra/manual-env-allowlist.yml
+++ b/infra/manual-env-allowlist.yml
@@ -496,6 +496,23 @@ code_read_exempt:
     reason: INTERNAL_DOGFOOD_ACCESS_ENABLED가 꺼져 있으면(기본) 실질 영향 없음 — 같은 기능군.
   - key: INTERNAL_DOGFOOD_DEFAULT_PROJECT_NAME
     reason: INTERNAL_DOGFOOD_ACCESS_ENABLED가 꺼져 있으면(기본) 실질 영향 없음 — 같은 기능군.
+  - key: SPRINTABLE_RUNTIME_ROLE
+    reason: >-
+      apps/web/src/services/background-runtime.ts:82-88 `resolveBackgroundRuntimeRole` —
+      미설정 시 `NODE_ENV==='production' ? 'web' : 'all'`로 떨어진다. frontend-dev/prod
+      둘 다 NODE_ENV=production(gcloud로 직접 확認, 2026-08-02)이라 기본값은 'web' —
+      instrumentation.ts의 `shouldStartBackgroundRuntime`이 role이 'worker'|'all'일 때만
+      true이므로 미설정 상태에서 백그라운드 워커(discord/teams/memo 아웃바운드 디스패처)는
+      항상 안 켜진다(story #2423, 페드루 판정 — 이 기능군은 은퇴 상태). 값을 채워야 도는
+      기능이 아니라, 안 채워야 지금 의도한 대로(web-only) 도는 스위치.
+  - key: SPRINTABLE_BACKGROUND_POLL_INTERVAL_MS
+    reason: SPRINTABLE_RUNTIME_ROLE이 web으로 떨어지면(기본) 워커 자체가 안 켜져 실질 영향 없음 — 같은 기능군.
+  - key: SPRINTABLE_DISCORD_OUTBOUND_POLL_INTERVAL_MS
+    reason: SPRINTABLE_RUNTIME_ROLE이 web으로 떨어지면(기본) 워커 자체가 안 켜져 실질 영향 없음 — 같은 기능군.
+  - key: SPRINTABLE_MEMO_DISPATCHER_POLL_INTERVAL_MS
+    reason: SPRINTABLE_RUNTIME_ROLE이 web으로 떨어지면(기본) 워커 자체가 안 켜져 실질 영향 없음 — 같은 기능군.
+  - key: SPRINTABLE_TEAMS_OUTBOUND_POLL_INTERVAL_MS
+    reason: SPRINTABLE_RUNTIME_ROLE이 web으로 떨어지면(기본) 워커 자체가 안 켜져 실질 영향 없음 — 같은 기능군.
 
 # ⑤㉠(story #2296 후속, 파울로군 지시 2026-07-28) — «알려진 채무» 래칫 baseline.
 # ⛔code_read_exempt(위)와 다르다 — exempt는 "코드로 확認해 영구히 정상"이고, 이건 "아직


### PR DESCRIPTION
## Summary

story #2422 — 이 워크플로우가 4일 연속 FAIL 상태였는데 아무도 못 알아챈 것을 조사·처방.

## axis ① — 지금도 참인가

gcloud로 직접 재확認(2026-08-02): 여전히 FAIL. dev/prod 둘 다 동일한 5개 항목(`SPRINTABLE_RUNTIME_ROLE`·`SPRINTABLE_{BACKGROUND,MEMO_DISPATCHER,DISCORD_OUTBOUND,TEAMS_OUTBOUND}_POLL_INTERVAL_MS`, `background-runtime.ts`).

## axis ② — 무엇이 드리프트인가(목록, 수 아님)

`instrumentation.ts`의 `shouldStartBackgroundRuntime()`이 role이 `'worker'|'all'`일 때만 백그라운드 워커(Discord/Teams/Memo 아웃바운드 디스패처)를 켠다. `SPRINTABLE_RUNTIME_ROLE` 미설정 시 기본값은 `NODE_ENV==='production' ? 'web' : 'all'` — `sprintable-frontend-dev`·`sprintable-frontend-prod` 둘 다 실제로 `NODE_ENV=production`(gcloud describe로 직접 확認)이라 기본값이 `'web'`으로 떨어져 워커 자체가 안 켜진다. story #2423에서 이 기능군이 은퇴 상태로 판정된 것과 일치 — 값을 채워야 도는 게 아니라 안 채워야 지금 의도대로(web-only) 도는 스위치다.

## axis ㉠ — 드리프트 자체를 고쳤는가

`code_read_exempt`로 5개 키 승격(`infra/manual-env-allowlist.yml`). gcloud로 재확認: dev·prod 둘 다 drift 0건.

## axis ㉡ — 알림이 새 실패를 구별하는가(진짜 축)

기존 알림은 매일 같은 모양(`⛔ env 드리프트 가드 FAIL — 상세: <link>`)이라 "어제와 같은 실패"와 "새 실패"를 구분 못 했다 — 4일이 그렇게 묻혔다.

- `check_env_drift.py`: `ENV_DRIFT_STATE_FILE` 설정 시 FAIL 집합(키 이름만, 값 없음)을 JSON으로 기록(FAIL이든 성공이든 항상 기록).
- `compare_env_drift_state.py`(신규): 어제 지문(GHA cache로 영속화)과 오늘 지문을 대조 — 신규/해소/연속일수(streak)를 정확히 가른다.
- 워크플로우: `actions/cache/restore`+`save`로 지문을 매일 영속화, 알림 문구를 "새 실패 발견 N건"/"동일 반복 N일째"로 구체화.

⛔이 스토리는 알림을 조용히 억제하지 않는다(오르테가 원칙) — "동일 반복"이어도 매일 그대로 발송한다. 바뀐 것은 문구의 정보량뿐, job 실패·발송 여부는 무변경.

## #2099 형제 확認(세기만, 판정은 PO)

`sprintable-admin-web(-dev)`·`sprintable-internal-api(-dev)` 4개 서비스는 여전히 `key_set`/`value_check` 축 감시 밖 그대로(allowlist `excluded_services` 무변경).

## Test plan

- [x] gcloud 라이브 재확認 — dev/prod 둘 다 drift 0건(수정 전: 5개 항목 FAIL)
- [x] 신규 pytest 11개(`test_check_env_drift_state_fingerprint.py`) — 상태파일 기록·신규/해소/연속일수 판정·알림 문구 분기
- [x] 기존 count-assertion 테스트(`test_ac4_real_repo_scan_counts_are_recorded`) 갱신 — high 20→15, exempt 18→23(정확히 5개 이동)
- [x] 기존 check_env_drift 스위트 66/66 통과
- [x] 뮤테이션(streak 항상 리셋) — 정확히 해당 테스트 1개만 RED, 나머지 10개 unaffected
- [x] CLI 엔드투엔드 수동 검증(2일치 시나리오 — 신규→동일반복 전이 확認)
- [ ] 실제 스케줄 실행(내일 00:00 UTC)에서 워크플로우가 정상 동작하는지는 배포 후 확認

🤖 Generated with [Claude Code](https://claude.com/claude-code)