### PR TITLE
fix(#2340): PROJECT_GUARD_FUNCTIONS에 has_project_role 추가(가드 어휘 동기화)

### DIFF
--- a/backend/tests/authz_coverage_lib.py
+++ b/backend/tests/authz_coverage_lib.py
@@ -52,6 +52,12 @@ PROJECT_PARAM_RE = re.compile(
 
 PROJECT_GUARD_FUNCTIONS: frozenset[str] = frozenset({
     "has_project_access",
+    # story #2340 실측(2026-08-02, 디디) — 이름·실동작 둘 다 project-scope 가드(project_id를
+    # 받아 그 project의 role을 검사)인데 이 목록에서만 누락돼 있었다(GUARD_FUNCTIONS(identity
+    # 축)엔 있었다 — 두 목록이 서로 다른 걸 보는 것 자체는 설계지만, 이 함수는 어느 쪽에도
+    # 실수로 안 빠져야 했다). project_settings.py:upsert_project_settings가 이걸 직접 호출하는데도
+    # allowlist에 올라 있던 원인이 이것 — 그 allowlist 엔트리는 이 추가와 함께 제거한다.
+    "has_project_role",
     "resolve_member",
     "accessible_project_ids_in_org",
     "get_project_role",

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -92,8 +92,6 @@ _FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
         "_assert_self_or_org_admin(member_id,...) — 본인 잔액 또는 org admin만 조회 가능해 project_id 자체는 blast-radius가 self-data로 제한",
     "app.routers.current_project:set_current_project":
         "assert_caller_is_member self-scope 후 (member_id, body.project_id) TeamMember 행 존재를 요구 — has_project_access보다 엄격(IDOR 아님)",
-    "app.routers.project_settings:upsert_project_settings":
-        "has_project_role(body.project_id, min_role=admin) 가드",
     "app.routers.analytics:get_overview":
         "SEC-S8 DD(#2047)에서 추가된 로컬 _assert_project_access(repo,auth,project_id) wrapper가 has_project_access를 1-hop 아래서 호출",
     "app.routers.analytics:get_member_workload":


### PR DESCRIPTION
## 요약

`#2319`의 신규 `delete_message` 라우트가 authz coverage 정적 가드에 걸려 `#2340`을 열게 됐다.
`_FALSE_POSITIVE_ALLOWLIST`(project-scope 축) 37건을 전수 재검산하다 「미해명 한 건」을
실행으로 잡았다 — `project_settings.py:upsert_project_settings`가 `has_project_role`을
**직접 호출**하는데도(AST `_called_names()`로 실제 확認됨) `PROJECT_GUARD_FUNCTIONS`에만
누락돼 있었다(`GUARD_FUNCTIONS`(identity 축)엔 있었음).

## 원인 — 1-hop 문제가 아니다. 세 번째 축이다

```
①1-hop 래퍼      래퍼 「이름」은 보이는데 그 안 실 가드 호출이 안 보이는 — 37건 대부분
②인라인 비교식    revoke_project_api_key — 「볼 이름이 없어」 원리적으로 안 잡히는
③⭐두 축의 가드 어휘 목록이 서로 안 맞는  ← 이 PR이 고치는 것
   has_project_role이 GUARD_FUNCTIONS엔 있고 PROJECT_GUARD_FUNCTIONS엔 빠져 있었다
```

`has_project_role`은 이름·실동작(project_id를 받아 그 project의 role을 검사) 둘 다
project-scope 가드인데 그 축 목록에서만 누락돼 있었다 — direct call인데도 vocab이 없어
allowlist로 새는 구조였다.

## 「목록을 하나로 합쳐야 하는가」— 대칭차집합으로 확認, 답은 「아니오」

```
GUARD_FUNCTIONS(identity) only:
  _assert_can_manage_human·_assert_self_or_org_admin·_is_org_admin·assert_agent_owner·
  assert_caller_is_member·has_project_role·is_caller_member·is_org_owner·is_org_owner_or_admin

PROJECT_GUARD_FUNCTIONS(project-scope) only:
  _assert_doc_parent_in_project·_assert_hypothesis_project_access·_assert_item_project_access·
  _assert_link_target_in_scope·_assert_story_link_targets_in_project·_assert_story_project_access·
  _assert_task_project_access·_require_doc_project_access·_require_retro_project_access·
  accessible_project_ids_in_org·get_project_role·project_access_valid_correlated·resolve_member

교집합: has_project_access 뿐
```

두 목록이 다른 것을 보는 것 자체가 설계(identity-only는 본인/org-level, project-only는
project 축 전용 헬퍼) — 부분집합 관계도 아니고 합칠 이유도 없다. 결함은 `has_project_role`
하나뿐이라 「어휘 넓히기」가 아니라 「이 한 줄을 맞는 목록에도 추가」가 처방.

## 처방(이 PR)

- `backend/tests/authz_coverage_lib.py` — `PROJECT_GUARD_FUNCTIONS`에 `has_project_role` 추가.
  왜 빠져 있었는지 모른 채 넣는 것이라, 실측 근거를 주석으로 남김(나중에 「일부러 뺀 것
  아닌가」로 되돌리는 것을 막기 위함).
- `backend/tests/test_authz_project_scope_coverage.py` — 이제 결함이 닫혀 정적 가드가 직접
  잡으므로 `upsert_project_settings` allowlist 엔트리 제거. 넣는 것과 빼는 것이 한 벌.

## 뮤테이션 검증

`has_project_role`을 `PROJECT_GUARD_FUNCTIONS`에서 다시 빼고(sabotage) →
`test_authz_project_scope_coverage.py`가 정확히 원래 버그를 재현하며 RED(정적 가드가
`upsert_project_settings`를 다시 미해명 케이스로 잡음) → 복원 후 GREEN 재확認.

## 스코프 밖(별도 축, 이 PR에서 안 다룸)

```
①1-hop 래퍼 인식 — 몇 hop까지 볼 것인지 수를 정하고 적는 작업(AC2). 이 PR 이후 별도로 진행.
②인라인 비교식(revoke_project_api_key) — 이름이 없어 원리적으로 못 잡음. ①③ 반영 후
  남는 수를 보고 처리 여부를 정함(PO 지시).
37건 재검산·받침 테스트 census 결과는 스토리 #2340 본문에 기록됨(받침 있음 3·없음 9·
미확定 25 — 25건 개별 확認은 판정을 안 바꿔 PO 지시로 중단).
```

## Test plan

- [x] `test_authz_project_scope_coverage.py` 전체 통과
- [x] 뮤테이션(sabotage→RED→복원→GREEN)
- [x] CI(lint/type-check/pytest)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
