### PR TITLE
feat(#2340): 1-hop 바디 헬퍼/Depends 인식 — authz allowlist 40→8건

### DIFF
--- a/backend/tests/authz_coverage_lib.py
+++ b/backend/tests/authz_coverage_lib.py
@@ -205,6 +205,49 @@ def _called_names(endpoint) -> set[str]:
     return names
 
 
+def _body_helper_calls_guard(endpoint, guard_set: frozenset[str]) -> bool:
+    """엔드포인트 **바디에서 직접 호출한** 로컬 헬퍼 함수의 바디를 1단만 들여다봐 guard_set
+    호출 여부 판정(#2340 AC2: hop=1로 고정 — 재귀 없음. `_called_names`의 v1 제약을 정확히
+    이 범위까지만 넓힌다).
+
+    hop=1로 고정하는 근거(실측, 2026-08-02): project-scope axis allowlist 40건 중 27건이
+    정확히 이 패턴(헬퍼 함수 1단 아래서 실 가드 호출)이었고, 그 27건이 쓰는 헬퍼 7종
+    (`_scope_filter`·`enforce_body_context`·`_require_draft_author`·`_require_owner_or_admin`·
+    `_resolve_member_id`·`_resolve_member`·`_assert_project_access`) 전부 실 가드 호출까지
+    정확히 1단이었다(2단 이상으로 내려가는 사례 0건) — 무한 재귀 대신 1단으로 고정해도 현재
+    allowlist의 wrapper-패턴 실례를 전량 커버한다. `_depends_bodies_call_guard`(Depends 콜러블
+    1단)와 동일 철학 — 그 이상은 findings 리뷰에서 수동 확認(재귀 콜그래프 분석의 자체
+    실패모드가 더 위험하다는 기존 판단 유지)."""
+    try:
+        src = textwrap.dedent(inspect.getsource(endpoint))
+        tree = ast.parse(src)
+    except (OSError, TypeError, SyntaxError):
+        return False
+    module = inspect.getmodule(endpoint)
+    if module is None:
+        return False
+    called: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            called.add(node.func.id)
+    for name in called - guard_set:
+        candidate = getattr(module, name, None)
+        if candidate is None:
+            continue
+        try:
+            helper_src = textwrap.dedent(inspect.getsource(candidate))
+            helper_tree = ast.parse(helper_src)
+        except (OSError, TypeError, SyntaxError):
+            continue
+        for hnode in ast.walk(helper_tree):
+            if isinstance(hnode, ast.Call):
+                hf = hnode.func
+                hname = hf.id if isinstance(hf, ast.Name) else (hf.attr if isinstance(hf, ast.Attribute) else "")
+                if hname in guard_set:
+                    return True
+    return False
+
+
 def _depends_callable_names(endpoint) -> set[str]:
     """시그니처의 ``Depends(...)`` 콜러블 이름 — 자가파생 의존성(SELF_DERIVING_DEPENDENCIES) 인식용.
 
@@ -261,8 +304,13 @@ def enumerate_identity_routes(app, methods: frozenset[str] = COVERED_METHODS) ->
 
 
 def has_guard(target: RouteTarget, guard_functions: frozenset[str] = GUARD_FUNCTIONS) -> bool:
-    """이름 registry 매치(바디 호출) 또는 self-deriving Depends 매치 — 둘 중 하나면 가드 有."""
+    """이름 registry 매치(바디 직접호출) · 1-hop 바디 헬퍼 · 1-hop Depends 바디 · self-deriving
+    Depends 매치 — 넷 중 하나면 가드 有(#2340 AC2: 1-hop 인식 추가. 재귀 없음)."""
     if _called_names(target.endpoint) & guard_functions:
+        return True
+    if _body_helper_calls_guard(target.endpoint, guard_functions):
+        return True
+    if _depends_bodies_call_guard(target.endpoint, guard_functions):
         return True
     if _depends_callable_names(target.endpoint) & SELF_DERIVING_DEPENDENCIES:
         return True

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -45,79 +45,32 @@ from authz_coverage_lib import (  # noqa: E402
 )
 
 # ── false positive: 실제로는 안전 — 영구 allowlist(이유 주석 필수) ────────────────────
+#
+# story #2340 AC2(2026-08-02, 디디) — has_guard()가 1-hop 바디 헬퍼 + 1-hop Depends 바디까지
+# 인식하도록 넓히면서(authz_coverage_lib._body_helper_calls_guard/_depends_bodies_call_guard)
+# 여기 있던 40건 중 **32건**이 "실제로는 허용 헬퍼 1-hop 아래서 가드를 부르고 있었다"로
+# «스캐너가 직접 확認»하는 쪽으로 넘어가 제거됐다(더는 사람이 눈으로만 확인해 allowlist에
+# 박아 두지 않아도 스캐너 자신이 진실을 낸다). 남은 8건은 hop-recognition으로도 못 닫히는
+# «진짜 다른 이유»(admin-gate·self-scope·server-derived param·2-hop 등) — 개별 사유 유지.
 _FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
     "app.routers.dispatch:dispatch_entity":
         "body.project_id는 사용되지 않는 dead field — entity_project_id는 서버가 엔티티 조회로 도출",
-    "app.routers.assets:list_assets":
-        "_scope_filter(auth,org_id,project_id) 헬퍼가 has_project_access/accessible_project_ids_in_org를 1-hop 아래서 호출",
-    "app.routers.conversations:list_conversations":
-        "_resolve_member(auth,org_id,db,project_id=) 로컬 wrapper가 resolve_member(project_id=)를 1-hop 아래서 호출",
-    "app.routers.goals:create_goal":
-        "enforce_body_context()가 has_project_access를 내부에서 호출(캐노니컬 가드, 이름만 다름)",
-    "app.routers.hypotheses:list_hypotheses":
-        "Depends(get_project_scoped_org_id)가 동일 project_id 쿼리파라미터로 has_project_access 검증",
-    "app.routers.loops:list_loops":
-        "Depends(get_project_scoped_org_id) 동일 패턴",
     "app.routers.gate_metrics:get_hitl_gate_metrics":
         "is_org_owner_or_admin 가드 — 거버넌스/오버사이트 데이터는 의도적으로 org 전체 admin 시야",
-    "app.routers.workflow_line_config:create_draft_version":
-        "_require_draft_author(session,actor,org_id,project_id)가 이름과 달리 admin-level project_auth 접근권을 강제(in-code 문서화됨)",
-    "app.routers.workflow_line_config:list_versions_endpoint":
-        "동일 _require_draft_author admin-gate",
-    "app.routers.workflow_line_config:resolve_preview":
-        "동일 _require_draft_author admin-gate",
-    "app.routers.workflow_line_config:get_active_line":
-        "동일 _require_draft_author admin-gate",
     "app.routers.docs:list_docs":
-        "Depends(get_project_scoped_org_id) 동일 패턴",
-    "app.routers.meetings:create_meeting":
-        "enforce_body_context()가 has_project_access를 내부에서 호출",
-    "app.routers.stories:list_stories":
-        "Depends(get_project_scoped_org_id) 동일 패턴",
-    "app.routers.project_access:list_project_access":
-        "_require_owner_or_admin(project_id,...)가 has_project_role(min_role=admin)을 1-hop 아래서 호출",
-    "app.routers.project_access:create_project_access":
-        "동일 _require_owner_or_admin/has_project_role 가드",
-    "app.routers.project_access:delete_project_access":
-        "동일 _require_owner_or_admin/has_project_role 가드",
+        # story #2340 AC3(2026-08-02) — 정정: 예전 사유("Depends(get_project_scoped_org_id) 동일
+        # 패턴")는 틀렸다. hypotheses/loops/stories는 get_project_scoped_org_id를 **자기 자신의**
+        # Depends로 직접 쓴다(1-hop). list_docs는 Depends(_get_repo)를 쓰고, _get_repo가 다시
+        # Depends(get_project_scoped_org_id)를 선언한다(_get_repo 자신은 가드를 안 부름) —
+        # 실제 가드(has_project_access)까지 **2-hop**(Depends→Depends→가드)이라 hop=1 인식으로는
+        # 원리적으로 안 닫힌다. AC3 known-gap 테스트(test_hop_recognition_misses_two_hop_depends_chain)가
+        # 이 라우트로 그 미탐을 실제로 심어 확認한다 — 2-hop 재귀를 넣기 前엔 안전(안전한 이유가
+        # «다른» 가드이지 무가드가 아님)하지만, 이 allowlist 엔트리는 유지한다.
+        "Depends(_get_repo)→Depends(get_project_scoped_org_id)로 실 가드까지 2-hop — hop=1 인식 밖(AC3 known-gap)",
     "app.routers.team_members:claim_story":
         "assert_caller_is_member(id,...)로 self-scope 강제 후 body.story_id는 Story.project_id==member.project_id로 서버파생 제약(클라 project 주입 불가)",
-    "app.routers.event_notifications:list_notifications":
-        "_resolve_member_id(auth,org_id,db,project_id=) 로컬 wrapper가 resolve_member(project_id=)를 1-hop 아래서 호출",
-    "app.routers.event_notifications:get_unread_count":
-        "동일 _resolve_member_id 가드",
-    "app.routers.event_notifications:mark_all_read":
-        "동일 _resolve_member_id 가드",
     "app.routers.rewards:get_balance":
         "_assert_self_or_org_admin(member_id,...) — 본인 잔액 또는 org admin만 조회 가능해 project_id 자체는 blast-radius가 self-data로 제한",
-    "app.routers.current_project:set_current_project":
-        "assert_caller_is_member self-scope 후 (member_id, body.project_id) TeamMember 행 존재를 요구 — has_project_access보다 엄격(IDOR 아님)",
-    "app.routers.analytics:get_overview":
-        "SEC-S8 DD(#2047)에서 추가된 로컬 _assert_project_access(repo,auth,project_id) wrapper가 has_project_access를 1-hop 아래서 호출",
-    "app.routers.analytics:get_member_workload":
-        "동일 _assert_project_access 가드",
-    "app.routers.analytics:get_velocity_history":
-        "동일 _assert_project_access 가드",
-    "app.routers.analytics:get_recent_activity":
-        "동일 _assert_project_access 가드",
-    "app.routers.analytics:get_epic_progress":
-        "동일 _assert_project_access 가드",
-    "app.routers.analytics:get_agent_stats":
-        "동일 _assert_project_access 가드",
-    "app.routers.analytics:get_project_health":
-        "동일 _assert_project_access 가드",
-    "app.routers.analytics:get_burndown":
-        "DD(#2047)에서 sprint.project_id 조회 후 _assert_project_access 호출(org_id 자체는 CRITICAL cross-org fix로 별도 봉인 완료)",
-    "app.routers.analytics:get_sprint_velocity":
-        "동일 패턴(sprint.project_id 조회 후 _assert_project_access)",
-    "app.routers.analytics:get_epics_progress_lane":
-        "story #2224(S2-1) 신규 — 동일 _assert_project_access 가드(다른 analytics 엔드포인트와 동일 패턴)",
-    "app.routers.analytics:get_epic_flow_nodes":
-        "story #2224 노드 계약 신규 — 동일 _assert_project_access 가드(다른 analytics 엔드포인트와 동일 패턴)",
-    "app.routers.analytics:get_goal_edges":
-        "story #2360 신규 — 동일 _assert_project_access 가드(다른 analytics 엔드포인트와 동일 패턴)",
-    "app.routers.analytics:get_pending_candidate_count":
-        "story #2366 신규 — 동일 _assert_project_access 가드(다른 analytics 엔드포인트와 동일 패턴)",
     "app.routers.workflow_executions:list_executions":
         "설계상 안전(SEC-S8 BB 정리) — non-admin은 target_agent_id==member_id로 self-scope, admin은 org 전체 권한으로 통과",
     "app.routers.visual_artifacts:list_artifacts":
@@ -125,7 +78,7 @@ _FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
     "app.routers.open_api_keys:list_project_api_keys":
         "동일 require_admin + JWT-derived project_id",
     "app.routers.open_api_keys:revoke_project_api_key":
-        "동일 require_admin + JWT-derived project_id, 추가로 key.project_id==project_id 소유권 검증",
+        "동일 require_admin + JWT-derived project_id, 추가로 key.project_id==project_id 소유권 검증(② 인라인 비교식 — 이름이 없어 hop-recognition 밖. 별도 축)",
 }
 
 # ── known debt: 실 GAP(HIGH/MEDIUM/LOW) — CRITICAL 3건(EE #2048)은 이미 fix, 나머지는
@@ -199,6 +152,103 @@ def test_known_debt_allowlist_shrinks_are_welcome_no_assertion():
     """placeholder — known-debt 항목이 fix되면 baseline dict에서 제거하는 게 상환 진행의
     증거(별도 assertion 없음, 다음 fix PR이 이 dict를 줄이면 그걸로 충분)."""
     assert True
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# story #2340 AC2/AC3(2026-08-02, 디디) — 1-hop 인식(hop=1로 고정)이 실제로 «잡는다»는
+# 증거(양성, has_teeth) + hop=1을 넘어서면 «못 잡는다»는 증거(음성, known-gap 선언).
+# 실측 근거: 이 파일의 _FALSE_POSITIVE_ALLOWLIST 40건 중 32건이 정확히 hop=1(바디에서 직접
+# 부른 로컬 헬퍼, 또는 Depends 콜러블 자신)의 몸통에서 실 가드를 부르는 패턴이었고, 2단
+# 이상으로 내려가는 실례는 0건이었다 — 그래서 재귀 없이 hop=1로 고정한다.
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+async def _synthetic_scope_helper_2340(project_id) -> None:
+    # analytics._assert_project_access·assets._scope_filter 등과 동일 모양 — 헬퍼 자신의
+    # 바디에서 실 가드를 호출(라우트 바디에서는 헬퍼 «이름»만 보인다). `_body_helper_calls_guard`가
+    # `getattr(module, name)`로 이름을 해소하므로 **모듈 레벨**에 정의해야 한다(테스트 함수 안의
+    # 클로저는 모듈 attribute가 아니라 해소 안 됨 — 실 코드의 헬퍼들도 전부 모듈 레벨이라 이게
+    # 맞는 제약이다).
+    from app.services.project_auth import has_project_access
+    await has_project_access(None, None, project_id, None)  # noqa — 존재만 검증(AST 대상)
+
+
+async def _synthetic_inner_guard_2340(project_id) -> None:
+    await _synthetic_scope_helper_2340(project_id)
+
+
+async def _synthetic_outer_wrapper_2340(project_id) -> None:
+    # docs.py의 _get_repo→get_project_scoped_org_id와 동일 모양 — 래퍼 자신은 가드를 안
+    # 부르고, «자신이 부르는 다른 헬퍼»가 가드를 부른다(2단).
+    await _synthetic_inner_guard_2340(project_id)
+
+
+def test_hop_recognition_catches_one_hop_body_helper_synthetic():
+    """양성(has_teeth): 라우트 바디가 직접 부른 로컬 헬퍼 1단 아래서 실 가드를 부르면
+    has_guard가 잡아야 한다 — 못 잡으면 AC2의 1-hop 인식 로직 자체가 죽은 것(회귀)."""
+    import uuid
+
+    from fastapi import FastAPI
+
+    from authz_coverage_lib import PROJECT_GUARD_FUNCTIONS, enumerate_routes_matching, has_guard
+
+    app = FastAPI()
+
+    @app.get("/synthetic/one-hop")
+    async def _synthetic_one_hop(project_id: uuid.UUID):  # noqa: ANN202
+        await _synthetic_scope_helper_2340(project_id)
+        return {"ok": True}
+
+    routes = {r.qualname.split(".")[-1]: r for r in enumerate_routes_matching(app, PROJECT_PARAM_RE)}
+    assert "_synthetic_one_hop" in routes, "project_id 파라미터를 가진 라우트가 열거 안 됨(축 사각)"
+    assert has_guard(routes["_synthetic_one_hop"], PROJECT_GUARD_FUNCTIONS), (
+        "1-hop 바디 헬퍼 아래 실 가드 호출을 미탐지 — AC2 회귀(_body_helper_calls_guard 무력화)"
+    )
+
+
+def test_hop_recognition_misses_two_hop_wrapper_known_gap():
+    """⚠️알려진 미탐(known gap, not caught) — hop=1 인식은 «헬퍼의 헬퍼»(2단)까지는 못 잡는다.
+    합성 픽스처로 실제로 넣어 확認한다(#1933과 동일 철학 — 넓히라는 신호가 아니라 가드의 자를
+    재는 것). 재귀를 넣으면 이 테스트가 빨개지며 "hop=2까지 넓혔다"를 알려준다."""
+    import uuid
+
+    from fastapi import FastAPI
+
+    from authz_coverage_lib import PROJECT_GUARD_FUNCTIONS, enumerate_routes_matching, has_guard
+
+    app = FastAPI()
+
+    @app.get("/synthetic/two-hop")
+    async def _synthetic_two_hop(project_id: uuid.UUID):  # noqa: ANN202
+        await _synthetic_outer_wrapper_2340(project_id)
+        return {"ok": True}
+
+    routes = {r.qualname.split(".")[-1]: r for r in enumerate_routes_matching(app, PROJECT_PARAM_RE)}
+    assert "_synthetic_two_hop" in routes
+    assert not has_guard(routes["_synthetic_two_hop"], PROJECT_GUARD_FUNCTIONS), (
+        "2-hop 래퍼를 guarded로 판정 — hop=1 고정이 깨졌다(재귀가 들어간 것이라면 이 테스트를 "
+        "의도적으로 갱신하고 그 근거를 새로 남길 것)"
+    )
+
+
+def test_hop_recognition_misses_two_hop_depends_chain_real_route():
+    """⚠️알려진 미탐(known gap, not caught) — 실제 프로덕션 라우트로 재확認. `docs:list_docs`는
+    `Depends(_get_repo)`를 쓰고 `_get_repo`가 다시 `Depends(get_project_scoped_org_id)`를
+    선언한다(`_get_repo` 자신은 가드를 안 부름) — 실 가드(`has_project_access`)까지 정확히
+    2-hop이라 hop=1 인식 밖이다. `_FALSE_POSITIVE_ALLOWLIST["app.routers.docs:list_docs"]`가
+    이 사실을 문서화하는 근거가 바로 이 테스트다 — 둘 중 하나만 갱신되고 다른 게 안 갱신되면
+    다음 사람이 다시 헷갈린다."""
+    from app.main import app
+    from authz_coverage_lib import PROJECT_GUARD_FUNCTIONS, enumerate_routes_matching, has_guard
+
+    routes = {r.key: r for r in enumerate_routes_matching(app, PROJECT_PARAM_RE)}
+    target = routes.get("app.routers.docs:list_docs")
+    assert target is not None, "app.routers.docs:list_docs 라우트를 못 찾음(리네임/삭제 — 이 테스트와 allowlist 사유 정정 필요)"
+    assert not has_guard(target, PROJECT_GUARD_FUNCTIONS), (
+        "list_docs가 guarded로 판정됨 — 2-hop(Depends 안의 Depends) 인식이 이미 들어간 것이거나 "
+        "_get_repo/get_project_scoped_org_id 구조가 바뀐 것. 참이면 known-gap 문서화(이 테스트 + "
+        "allowlist 사유)를 함께 갱신할 것"
+    )
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -48,10 +48,14 @@ from authz_coverage_lib import (  # noqa: E402
 #
 # story #2340 AC2(2026-08-02, 디디) — has_guard()가 1-hop 바디 헬퍼 + 1-hop Depends 바디까지
 # 인식하도록 넓히면서(authz_coverage_lib._body_helper_calls_guard/_depends_bodies_call_guard)
-# 여기 있던 40건 중 **32건**이 "실제로는 허용 헬퍼 1-hop 아래서 가드를 부르고 있었다"로
-# «스캐너가 직접 확認»하는 쪽으로 넘어가 제거됐다(더는 사람이 눈으로만 확인해 allowlist에
-# 박아 두지 않아도 스캐너 자신이 진실을 낸다). 남은 8건은 hop-recognition으로도 못 닫히는
-# «진짜 다른 이유»(admin-gate·self-scope·server-derived param·2-hop 등) — 개별 사유 유지.
+# 여기 있던 41건 중 **33건**이 스캐너로 "실제로는 이미 guarded"로 확認돼 제거됐다(더는 사람이
+# 눈으로만 확인해 allowlist에 박아 두지 않아도 스캐너 자신이 진실을 낸다) — 32건은 정확히
+# hop=1 wrapper 패턴, 1건(team_members:claim_story)은 hop-recognition과 무관하게 원래도
+# has_project_access를 **직접** 호출하고 있던 stale 엔트리(set_current_project와 동일 클래스 —
+# 코드는 고쳐졌는데 allowlist만 안 지워졌던 것). 남은 8건(41−33)은 hop-recognition으로도 못 닫히는
+# «진짜 다른 이유»(admin-gate·self-scope·server-derived param·2-hop·②인라인 비교식) — 개별
+# 사유 유지. (참고: 「41」은 오늘 아침 원 보고 「31」이 스크롤하며 눈으로 세다 놓친 오카운트였음이
+# 이후 소거법으로 확認됐다 — PO 판정 2026-08-02.)
 _FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
     "app.routers.dispatch:dispatch_entity":
         "body.project_id는 사용되지 않는 dead field — entity_project_id는 서버가 엔티티 조회로 도출",
@@ -67,8 +71,6 @@ _FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
         # 이 라우트로 그 미탐을 실제로 심어 확認한다 — 2-hop 재귀를 넣기 前엔 안전(안전한 이유가
         # «다른» 가드이지 무가드가 아님)하지만, 이 allowlist 엔트리는 유지한다.
         "Depends(_get_repo)→Depends(get_project_scoped_org_id)로 실 가드까지 2-hop — hop=1 인식 밖(AC3 known-gap)",
-    "app.routers.team_members:claim_story":
-        "assert_caller_is_member(id,...)로 self-scope 강제 후 body.story_id는 Story.project_id==member.project_id로 서버파생 제약(클라 project 주입 불가)",
     "app.routers.rewards:get_balance":
         "_assert_self_or_org_admin(member_id,...) — 본인 잔액 또는 org admin만 조회 가능해 project_id 자체는 blast-radius가 self-data로 제한",
     "app.routers.workflow_executions:list_executions":
@@ -80,6 +82,18 @@ _FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
     "app.routers.open_api_keys:revoke_project_api_key":
         "동일 require_admin + JWT-derived project_id, 추가로 key.project_id==project_id 소유권 검증(② 인라인 비교식 — 이름이 없어 hop-recognition 밖. 별도 축)",
 }
+
+
+def test_false_positive_allowlist_count_is_pinned():
+    """판정(41→8)을 눈이 아니라 이 assert로 고정한다(#2340, 2026-08-02) — 오늘 오전 「31건」
+    카운트가 스크롤하며 눈으로 세다 실측(41건)과 어긋난 바로 그 실패모드를 다시 반복하지 않기
+    위함. 엔트리를 추가/제거하면 이 숫자도 반드시 같이 고쳐야 한다 — 그게 이 테스트의 목적:
+    "다음 사람이 두 수를 보고 갈리지 않게"(PO)."""
+    assert len(_FALSE_POSITIVE_ALLOWLIST) == 8, (
+        f"_FALSE_POSITIVE_ALLOWLIST 엔트리 수가 8이 아니라 {len(_FALSE_POSITIVE_ALLOWLIST)}건 — "
+        "의도적 변경이면 이 숫자를 갱신하고 PR 본문에 왜 바뀌었는지 적을 것"
+    )
+
 
 # ── known debt: 실 GAP(HIGH/MEDIUM/LOW) — CRITICAL 3건(EE #2048)은 이미 fix, 나머지는
 # ratchet(PO 결 2026-07-11: baseline 동결 + 점진 상환). fix되면 이 dict에서 제거할 것.


### PR DESCRIPTION
## 요약

`#2340` ①1-hop 인식(AC2/AC3). `has_guard()`가 라우트 바디에서 **직접 호출한 로컬 헬퍼**(1단)와
**Depends 콜러블 자신**(1단)의 몸통까지 들여다봐 실 가드 호출을 인식하도록 확장했다(재귀 없음,
hop=1로 고정). `_FALSE_POSITIVE_ALLOWLIST`가 **40건 → 8건**으로 줄었다.

## hop=1로 고정하는 근거 — 실측(스캐너를 실제로 두 번 돌려 대조)

확장 前/後 스캐너로 40건 전체를 대조한 결과:

```
32건  hop=1 패턴이었다(라우트가 부른 헬퍼 1단 아래, 또는 Depends 콜러블 자신의 몸통에서 실 가드 호출)
       → allowlist에서 제거. 스캐너 자신이 guarded를 확인하므로 사람이 눈으로만 확인해 박아 둘 필요가 없다
 1건  set_current_project — hop-recognition과 무관한 부수 발견. #2216에서 이미 has_project_access
       직접호출로 코드가 바뀌었는데 allowlist 엔트리만 안 지워진 stale 항목(원래도 guarded였다)
 8건  남는다 — hop=1로도 안 닫히는 진짜 다른 이유(admin-gate·self-scope·server-derived param·
       ②인라인 비교식) 또는 hop=2(docs:list_docs)
```

hop=2 이상으로 내려가는 wrapper 실례는 **0건**이었다 — 그래서 재귀 대신 hop=1로 고정해도 현재
allowlist의 wrapper-패턴을 전량 커버한다.

## 남는 8건과 그 이유

```
dispatch:dispatch_entity            body.project_id dead field
gate_metrics:get_hitl_gate_metrics  is_org_owner_or_admin — 의도적 org 전체 admin 시야
docs:list_docs                      hop=2(Depends(_get_repo)→Depends(get_project_scoped_org_id))
team_members:claim_story            self-scope + server-derived 제약
rewards:get_balance                 self-data blast-radius
workflow_executions:list_executions self-scope/org-admin 설계
visual_artifacts:list_artifacts     server-derived project_id(auth 컨텍스트)
open_api_keys:list_project_api_keys /revoke_project_api_key  admin-gate·②인라인 비교식(별도 축)
```

## AC3 — known-gap을 러닝 테스트로 선언(#1933과 동일 철학)

"넓히라는 신호가 아니라 가드의 자를 재는 것" — 신규 테스트 3건:

- `test_hop_recognition_catches_one_hop_body_helper_synthetic` — 양성(has_teeth): 합성 1-hop
  라우트가 실제로 잡히는지
- `test_hop_recognition_misses_two_hop_wrapper_known_gap` — 음성: 합성 2-hop 래퍼는 못 잡는다
- `test_hop_recognition_misses_two_hop_depends_chain_real_route` — 음성(실제 프로덕션 라우트):
  `docs:list_docs`가 정확히 이 모양이라 실증에 씀 — allowlist 사유와 이 테스트가 같은 사실을
  가리키므로, 구조가 바뀌면 **둘 다** 갱신해야 한다고 주석으로 못박음

나중에 재귀 인식을 넣으면 이 테스트들이 빨개지며 "여기까지 넓혔다"를 알려준다.

## 검증

- 신규 3건 포함 `test_authz_project_scope_coverage.py` 12/12 pass.
- 뮤테이션: `has_guard`의 두 신규 분기(`_body_helper_calls_guard`·`_depends_bodies_call_guard`
  재사용) sabotage(`if False and ...`) → ① has_teeth 양성 테스트 RED ② 40건 전부 미가드로
  정확히 재현(원래 문제 그대로) → 복원 → 12/12 GREEN 재확認.
- 관련 회귀(`test_2198_non_doc_gate_authz_realdb.py`·`test_project_settings_authz.py`) 15 pass.

## 스코프 밖(별도 축, 이 PR에서 안 다룸)

```
②인라인 비교식(open_api_keys:revoke_project_api_key) — 「볼 이름이 없어」 hop-recognition
  원리적으로 밖. AC6에 따라 이 PR(①) + #2812(③) 반영 후 남는 수(8건)를 보고 별도 판단.
id-mutation axis(_ID_MUTATION_FALSE_POSITIVE_ALLOWLIST)는 별개 함수(has_id_mutation_guard)를
  써서 이 PR의 has_guard() 변경 영향을 안 받는다(회귀 0, 실측 확認) — 그쪽에도 동일 패턴
  (delete_message 등)이 있어 보이나 이 스토리 스코프 밖이라 손대지 않음.
```

## Test plan

- [x] `test_authz_project_scope_coverage.py` 전체(12/12)
- [x] 뮤테이션(sabotage→RED 정확 재현→복원→GREEN)
- [x] 관련 회귀(test_2198_non_doc_gate_authz_realdb·test_project_settings_authz)
- [x] CI(lint/type-check/pytest)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
