### PR TITLE
feat(#2346): AC3(변경 이력) — docs.py·agent_runs.py에 stories.py 패턴 배선

### DIFF
--- a/backend/app/routers/agent_runs.py
+++ b/backend/app/routers/agent_runs.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -18,6 +18,16 @@ router = APIRouter(prefix="/api/v2/agent-runs", tags=["agent-runs", "Work"])
 # story #2161: PATCH가 이 세 상태로 전이시키는데 클라가 finished_at을 안 보내면 서버가 채운다
 # (server-authority — MCP는 이미 finished_at을 보낼 수 있지만 항상 보낸다고 신뢰하지 않는다).
 _TERMINAL_STATUSES = {"completed", "failed", "abandoned"}
+
+# story #2346 AC3(범위: 기록만) — 「긴 텍스트 필드」 정의, stories.py/docs.py와 동형.
+_LENGTH_TRACKED_FIELDS = ("result_summary", "last_error_code")
+# ⛔story #2346 AC7을 여기 «의도적으로» 안 넣는다 — 넣지 않는 것 자체가 판단이라 이유를 남긴다.
+# stories.py/docs.py와 달리 이 라우터는 status 전이(_TERMINAL_STATUSES)와 얽혀 있다: 진행 중
+# 요약("작업 중... X... Y...")이 완료 시 짧고 확정적인 요약("완료: Z")으로 «의도적으로» 줄어드는
+# 것이 정상 흐름이다. stories.py의 급감 차단(50%+절대손실100자)을 그대로 이식하면 이 legitimate
+# 축약이 매번 막혀 allow_shrink=true를 상시 붙여야 하는 잡음이 된다(PO 판정 2026-08-02) — AC3
+# (기록)만으로 범위를 좁힌다. 나중에 이 라우터에 AC7을 넣고 싶으면 «완료 시 축약»과 «중간에
+# 읽지 않고 덮어씀」을 가르는 별도 판별자부터 세워야 한다(이 코멘트를 지우지 말 것).
 
 
 def _get_repo(session: AsyncSession = Depends(get_db)) -> AgentRunRepository:
@@ -131,6 +141,7 @@ async def create_agent_run(
 async def update_agent_run(
     id: uuid.UUID,
     body: UpdateAgentRun,
+    background_tasks: BackgroundTasks,
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
     repo: AgentRunRepository = Depends(_get_repo),
@@ -159,6 +170,12 @@ async def update_agent_run(
     # 비우기) 여전히 지워진다 — "생략"과 "명시적 null"을 이제 구분한다(repo.update()의 예외
     # 특례는 그 구분을 못 해 항상 지웠다 — 아래에서 제거).
     _explicit_fields = body.model_dump(exclude_unset=True, exclude={"status", "finished_at"})
+    # story #2346 AC3(범위: 기록만, AC7 차단 없음 — 위 모듈 상단 코멘트 참조): existing이 이미
+    # access-check용으로 조회돼 있어(stories.py처럼 조건부 재조회 불필요) old 길이를 지금 스칼라로
+    # 떠 둔다.
+    _old_lengths = {
+        f: len(getattr(existing, f) or "") for f in _LENGTH_TRACKED_FIELDS if f in _explicit_fields
+    }
     run = await repo.update(
         id,
         status=body.status,
@@ -167,4 +184,25 @@ async def update_agent_run(
     )
     if run is None:
         raise HTTPException(status_code=404, detail="Agent run not found")
+    if _old_lengths:
+        _length_changes = {}
+        for _f, _before_len in _old_lengths.items():
+            _after_len = len(getattr(run, _f) or "")
+            if _before_len != _after_len:
+                _length_changes[_f] = {"before": _before_len, "after": _after_len}
+        if _length_changes:
+            from app.services.activity_log import record_activity_bg
+            from app.services.member_resolver import resolve_member
+
+            _actor = await resolve_member(auth, org_id, repo.session, project_id=existing.project_id)
+            background_tasks.add_task(
+                record_activity_bg,
+                org_id=org_id,
+                action="agent_run_updated",
+                actor_id=_actor.id,
+                project_id=existing.project_id,
+                entity_type="agent_run",
+                entity_id=id,
+                context={"length_changes": _length_changes},
+            )
     return AgentRunResponse.model_validate(run)

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -73,6 +73,11 @@ async def _enrich_doc_summary(doc, session: AsyncSession) -> DocSummaryResponse:
 
 router = APIRouter(prefix="/api/v2/docs", tags=["docs", "Knowledge"])
 
+# story #2346 AC7 — stories.py의 두 임계값을 그대로 재사용(2026-08-02 PO 지시로 doc content
+# 실측 후 재확認: 50%만 쓰면 짧은 필드가 걸리고 절대량만 쓰면 긴 필드가 새는 동일 문제).
+_SHRINK_BLOCK_THRESHOLD = 0.5
+_SHRINK_BLOCK_MIN_LOST_CHARS = 100
+
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
@@ -395,6 +400,7 @@ async def get_doc(
 async def update_doc(
     id: uuid.UUID,
     body: DocUpdate,
+    background_tasks: BackgroundTasks,
     repo: DocRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
@@ -408,6 +414,8 @@ async def update_doc(
     # 151e05f1: 동시성 제어 필드 — Doc 컬럼이 아니므로 분리(setattr 루프서 제외).
     expected_updated_at = data.pop("expected_updated_at", None)
     force_overwrite = data.pop("force_overwrite", None)
+    # story #2346 AC7: allow_shrink는 Doc 컬럼이 아니므로 repo mutate 前 분리(stories.py와 동형).
+    allow_shrink = data.pop("allow_shrink", False)
 
     doc = await repo.get(id)
     if doc is None:
@@ -430,6 +438,27 @@ async def update_doc(
                     "message": "문서가 다른 곳에서 수정됨 — 최신본을 다시 불러오세요",
                     "current_updated_at": doc.updated_at.isoformat(),
                 },
+            )
+
+    # ⛔story #2346 AC3/AC7(stories.py와 동형 — 이 라우터는 activity 로깅 자체가 없어 신규 배선):
+    # doc.content는 이미 위에서 조회돼 있어(항상 조회, stories.py처럼 조건부 필요 없음) old 길이를
+    # 지금 스칼라로 떠 둔다. 임계값(50%·절대손실 100자)은 stories.py 그대로 재사용 — doc content가
+    # story description보다 훨씬 길지만(실측 3000~4500자대 표본), 그 스케일에서는 퍼센트 임계가
+    # 실질적으로 작동하고(50% 손실이면 자연히 절대량도 100자를 훌쩍 넘음) 절대 floor는 짧은
+    # 문서에서만 의미가 있어 그대로 전이해도 무리가 없다(PO 지시 2026-08-02 — 재보고 정한 것).
+    old_content_length: int | None = len(doc.content or "") if "content" in data else None
+    if old_content_length is not None and old_content_length > 0 and not allow_shrink:
+        _after_len = len(data.get("content") or "")
+        _lost_chars = old_content_length - _after_len
+        _is_relative_shrink = _after_len < old_content_length * (1 - _SHRINK_BLOCK_THRESHOLD)
+        if _is_relative_shrink and _lost_chars >= _SHRINK_BLOCK_MIN_LOST_CHARS:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"doc '{doc.title}' content shrank {old_content_length}→{_after_len} chars "
+                    f"({round((1 - _after_len / old_content_length) * 100)}% smaller) — "
+                    "if intentional, resend with allow_shrink=true"
+                ),
             )
 
     if "parent_id" in data:
@@ -527,6 +556,29 @@ async def update_doc(
         await reconcile_doc_mentions(
             session, org_id=repo.org_id, doc_id=doc.id, html_content=doc.content, created_by=actor_id,
         )
+
+        # story #2346 AC3 — content 길이가 실제로 바뀌면 doc_updated activity에 「이전 길이→이후
+        # 길이」를 얹는다(신규 장치 0, 전문 스냅샷 아님). 안 바뀌면 안 남긴다(양성 대조 — stories.py와
+        # 동형, 매번 남으면 잡음). old_content_length는 위에서 setattr 前에 이미 스칼라로 떠 뒀다.
+        if old_content_length is not None:
+            _after_content_len = len(doc.content or "")
+            if _after_content_len != old_content_length:
+                from app.services.activity_log import record_activity_bg
+                background_tasks.add_task(
+                    record_activity_bg,
+                    org_id=repo.org_id,
+                    action="doc_updated",
+                    actor_id=actor_id,
+                    project_id=doc.project_id,
+                    entity_type="doc",
+                    entity_id=id,
+                    context={
+                        "doc_title": doc.title,
+                        "length_changes": {
+                            "content": {"before": old_content_length, "after": _after_content_len},
+                        },
+                    },
+                )
 
     return DocResponse.model_validate(doc)
 

--- a/backend/app/schemas/doc.py
+++ b/backend/app/schemas/doc.py
@@ -37,6 +37,9 @@ class DocUpdate(BaseModel):
     # force_overwrite=True 면 검사 우회(last-write-wins 의도적). ⚠️ 이 2필드는 strip 금지(BE 수용).
     expected_updated_at: datetime | None = None
     force_overwrite: bool | None = None
+    # story #2346 AC7 — stories.py와 동형(50% 이상 급감+절대손실 100자 이상이면 기본 거부).
+    # 정당한 대규모 축약(예: 낡은 섹션 통째로 제거)은 이 플래그로 명시 승인한다.
+    allow_shrink: bool = False
 
 
 class DocSummaryResponse(BaseModel):

--- a/backend/tests/test_2346_agent_run_update_length_change_activity_realdb.py
+++ b/backend/tests/test_2346_agent_run_update_length_change_activity_realdb.py
@@ -1,0 +1,216 @@
+"""story #2346 AC3(범위: 기록만, AC7 차단 없음 — agent_runs.py 모듈 상단 코멘트 참조) —
+update_agent_run이 result_summary/last_error_code 길이 변화를 agent_run_updated activity log에
+얹는지. stories.py/docs.py와 달리 이 라우터는 상태전이(완료 시 요약 축약이 legitimate)와
+얽혀 있어 급감 차단(AC7)을 의도적으로 넣지 않았다 — 그 판단 자체를 여기서도 실측으로
+고정한다(양성 대조: 완료 요약 축약이 막히지 «않는다»).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import BackgroundTasks
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("ab930000-0000-0000-0000-000000000001")
+PROJ = uuid.UUID("ab930000-0000-0000-0000-000000000002")
+RUN = uuid.UUID("ab930000-0000-0000-0000-000000000003")
+AGENT_IN = uuid.UUID("ab930000-0000-0000-0000-0000000000a1")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _auth() -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(AGENT_IN), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(ORG),
+    )
+
+
+async def _seed(s, initial_result_summary: str | None) -> None:
+    for sql in [
+        f"DELETE FROM activity_logs WHERE org_id='{ORG}'",
+        f"DELETE FROM agent_runs WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','2346RUN','s2346-run-org','free')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ}','{ORG}','P','none')",
+        f"INSERT INTO members (id,org_id,type,name) VALUES ('{AGENT_IN}','{ORG}','agent','AgentIn')",
+        f"INSERT INTO project_access (project_id,member_id,permission) VALUES ('{PROJ}','{AGENT_IN}','granted')",
+    ]:
+        await s.execute(text(sql))
+    await s.execute(
+        text(
+            "INSERT INTO agent_runs (id,org_id,project_id,agent_id,trigger,status,result_summary) "
+            "VALUES (:id,:org,:proj,:agent,'manual','running',:summary)"
+        ),
+        {"id": RUN, "org": ORG, "proj": PROJ, "agent": AGENT_IN, "summary": initial_result_summary},
+    )
+    await s.commit()
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _fetch_latest_agent_run_updated_context(Session):
+    async with Session() as s:
+        row = (
+            await s.execute(
+                text(
+                    "SELECT context FROM activity_logs WHERE org_id=:org AND action='agent_run_updated' "
+                    "ORDER BY created_at DESC LIMIT 1"
+                ),
+                {"org": ORG},
+            )
+        ).scalar_one_or_none()
+        return row
+
+
+@pytest.mark.anyio
+async def test_shrinking_result_summary_records_before_after_length():
+    """AC3 핵심 — result_summary 급감이 agent_run_updated activity의 length_changes에 남는다."""
+    from app.repositories.agent_run import AgentRunRepository
+    from app.routers.agent_runs import update_agent_run
+    from app.schemas.agent_run import UpdateAgentRun
+
+    eng, Session = await _engine()
+    try:
+        long_summary = "working on step 1... step 2... step 3... " * 20  # ~880자
+        async with Session() as s:
+            await _seed(s, long_summary)
+
+        async with Session() as s:
+            repo = AgentRunRepository(s)
+            bg = BackgroundTasks()
+            short_summary = "done"
+            await update_agent_run(
+                RUN, UpdateAgentRun(status="running", result_summary=short_summary), bg,
+                org_id=ORG, auth=_auth(), repo=repo,
+            )
+            await bg()
+
+        context = await _fetch_latest_agent_run_updated_context(Session)
+        assert context is not None, "agent_run_updated activity가 안 남음"
+        assert context["length_changes"]["result_summary"] == {
+            "before": len(long_summary), "after": len(short_summary),
+        }
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac7_is_intentionally_absent_completion_summary_shrink_not_blocked():
+    """양성 대조 — 이 판정 자체를 실측으로 고정한다: 진행요약이 완료시 짧은 확정 요약으로
+    -90%대까지 줄어도 차단되지 않는다(stories.py/docs.py였다면 AC7에 걸렸을 규모).
+    agent_runs.py에 AC7을 안 넣기로 한 판단이 실제로 지켜지는지 재는 것 — 나중에 실수로
+    누가 AC7을 이식하면 이 테스트가 RED로 그 변경을 잡아낸다."""
+    from app.repositories.agent_run import AgentRunRepository
+    from app.routers.agent_runs import update_agent_run
+    from app.schemas.agent_run import UpdateAgentRun
+
+    eng, Session = await _engine()
+    try:
+        long_progress_summary = "x" * 900
+        async with Session() as s:
+            await _seed(s, long_progress_summary)
+
+        async with Session() as s:
+            repo = AgentRunRepository(s)
+            bg = BackgroundTasks()
+            final_summary = "Completed successfully"  # -97%대, allow_shrink 없이 호출
+            resp = await update_agent_run(
+                RUN, UpdateAgentRun(status="completed", result_summary=final_summary), bg,
+                org_id=ORG, auth=_auth(), repo=repo,
+            )
+            assert resp.result_summary == final_summary
+            assert resp.status == "completed"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_unchanged_length_does_not_pollute_the_log():
+    """양성 대조 — result_summary를 같은 길이의 다른 텍스트로 바꾸면 activity 자체가 안 남는다
+    (agent_runs.py도 사전 존재하던 로그가 없어 docs.py와 동형 — 엔트리 자체가 없어야 정상)."""
+    from app.repositories.agent_run import AgentRunRepository
+    from app.routers.agent_runs import update_agent_run
+    from app.schemas.agent_run import UpdateAgentRun
+
+    eng, Session = await _engine()
+    try:
+        original = "a" * 50
+        async with Session() as s:
+            await _seed(s, original)
+
+        async with Session() as s:
+            repo = AgentRunRepository(s)
+            bg = BackgroundTasks()
+            same_length_different_text = "b" * 50
+            await update_agent_run(
+                RUN, UpdateAgentRun(status="running", result_summary=same_length_different_text), bg,
+                org_id=ORG, auth=_auth(), repo=repo,
+            )
+            await bg()
+
+        context = await _fetch_latest_agent_run_updated_context(Session)
+        assert context is None, f"길이가 안 변했는데 activity가 남음(잡음): {context}"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_status_only_update_without_result_summary_not_logged():
+    """양성 대조 — result_summary/last_error_code를 아예 안 건드리고 status만 바꾸면 activity
+    자체가 안 남는다(AC1의 exclude_unset 회귀 감시도 겸함 — 생략됐으면 old_lengths가 비어야 함)."""
+    from app.repositories.agent_run import AgentRunRepository
+    from app.routers.agent_runs import update_agent_run
+    from app.schemas.agent_run import UpdateAgentRun
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s, "unchanged summary")
+
+        async with Session() as s:
+            repo = AgentRunRepository(s)
+            bg = BackgroundTasks()
+            await update_agent_run(
+                RUN, UpdateAgentRun(status="running"), bg, org_id=ORG, auth=_auth(), repo=repo,
+            )
+            await bg()
+
+        context = await _fetch_latest_agent_run_updated_context(Session)
+        assert context is None, f"result_summary 안 건드렸는데 activity가 남음: {context}"
+
+        # AC1 회귀 감시 겸용 — result_summary가 그대로 살아 있어야 한다(생략=불변).
+        async with Session() as s:
+            row = (await s.execute(
+                text("SELECT result_summary FROM agent_runs WHERE id=:i"), {"i": RUN}
+            )).scalar_one()
+            assert row == "unchanged summary", "생략했는데 result_summary가 지워짐(AC1 회귀)"
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_2346_doc_update_length_change_activity_realdb.py
+++ b/backend/tests/test_2346_doc_update_length_change_activity_realdb.py
@@ -1,0 +1,293 @@
+"""story #2346 AC3/AC7 — docs.py::update_doc (stories.py에서 이미 검증된 패턴의 두 번째 적용).
+
+docs.py는 stories.py와 달리 activity 로깅 자체가 없었다(신규 배선) — content가 실제로 바뀔 때
+「이전 길이→이후 길이」를 doc_updated activity log에 얹는다. AC7(50% 이상 급감+절대손실 100자
+이상이면 400 거부, allow_shrink=true로 승인)도 stories.py와 동일 임계값으로 이식했다(doc
+content 실측 결과 — 그 스케일에서는 퍼센트 임계가 실질적으로 작동해 그대로 전이해도 무리 없음,
+PO 판정 2026-08-02).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import BackgroundTasks
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("ab920000-0000-0000-0000-000000000001")
+PROJ = uuid.UUID("ab920000-0000-0000-0000-000000000002")
+DOC = uuid.UUID("ab920000-0000-0000-0000-000000000003")
+AGENT_IN = uuid.UUID("ab920000-0000-0000-0000-0000000000a1")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _auth() -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(AGENT_IN), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(ORG),
+    )
+
+
+async def _seed(s, initial_content: str) -> None:
+    for sql in [
+        f"DELETE FROM activity_logs WHERE org_id='{ORG}'",
+        f"DELETE FROM docs WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','2346DOC','s2346-doc-org','free')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ}','{ORG}','P','none')",
+        f"INSERT INTO members (id,org_id,type,name) VALUES ('{AGENT_IN}','{ORG}','agent','AgentIn')",
+        f"INSERT INTO project_access (project_id,member_id,permission) VALUES ('{PROJ}','{AGENT_IN}','granted')",
+    ]:
+        await s.execute(text(sql))
+    await s.execute(
+        text(
+            "INSERT INTO docs (id,org_id,project_id,title,slug,content,doc_type,content_format) "
+            "VALUES (:id,:org,:proj,'test doc','test-doc-2346',:content,'page','markdown')"
+        ),
+        {"id": DOC, "org": ORG, "proj": PROJ, "content": initial_content},
+    )
+    await s.commit()
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _fetch_latest_doc_updated_context(Session):
+    async with Session() as s:
+        row = (
+            await s.execute(
+                text(
+                    "SELECT context FROM activity_logs WHERE org_id=:org AND action='doc_updated' "
+                    "ORDER BY created_at DESC LIMIT 1"
+                ),
+                {"org": ORG},
+            )
+        ).scalar_one_or_none()
+        return row
+
+
+@pytest.mark.anyio
+async def test_shrinking_content_records_before_after_length():
+    """AC3 핵심 — content 급감이 doc_updated activity의 context.length_changes에 남는지."""
+    from app.repositories.doc import DocRepository
+    from app.routers.docs import update_doc
+    from app.schemas.doc import DocUpdate
+
+    eng, Session = await _engine()
+    try:
+        long_content = "x" * 4000
+        async with Session() as s:
+            await _seed(s, long_content)
+
+        async with Session() as s:
+            repo = DocRepository(s, ORG)
+            bg = BackgroundTasks()
+            short_content = "y" * 300
+            await update_doc(
+                DOC, DocUpdate(content=short_content, allow_shrink=True), bg,
+                repo=repo, session=s, auth=_auth(),
+            )
+            await bg()
+
+        context = await _fetch_latest_doc_updated_context(Session)
+        assert context is not None, "doc_updated activity가 안 남음"
+        assert context["length_changes"]["content"] == {"before": 4000, "after": 300}
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_unchanged_length_does_not_pollute_the_log():
+    """양성 대조 — content를 같은 길이의 다른 텍스트로 바꾸면 activity 자체가 안 남는다.
+    docs.py는 stories.py와 달리 사전 존재하던 doc_updated 로그가 없어(신규 배선) 길이가
+    실제로 안 바뀌면 로그 호출 자체를 안 한다 — "엔트리는 있는데 length_changes만 없다"가
+    아니라 "엔트리 자체가 없다"가 맞는 동작(잡음을 만들 pre-existing 자리가 없으므로)."""
+    from app.repositories.doc import DocRepository
+    from app.routers.docs import update_doc
+    from app.schemas.doc import DocUpdate
+
+    eng, Session = await _engine()
+    try:
+        original = "a" * 200
+        async with Session() as s:
+            await _seed(s, original)
+
+        async with Session() as s:
+            repo = DocRepository(s, ORG)
+            bg = BackgroundTasks()
+            same_length_different_text = "b" * 200
+            await update_doc(
+                DOC, DocUpdate(content=same_length_different_text), bg,
+                repo=repo, session=s, auth=_auth(),
+            )
+            await bg()
+
+        context = await _fetch_latest_doc_updated_context(Session)
+        assert context is None, f"길이가 안 변했는데 activity가 남음(잡음): {context}"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_untouched_content_not_logged_when_only_title_changes():
+    """양성 대조 — content는 안 건드리고 title만 바꾸면 activity 자체가 아예 안 남는다
+    (docs.py의 length 기록은 "content in data" 블록 안에서만 도는 것이 정확한 스코프)."""
+    from app.repositories.doc import DocRepository
+    from app.routers.docs import update_doc
+    from app.schemas.doc import DocUpdate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s, "unchanged content")
+
+        async with Session() as s:
+            repo = DocRepository(s, ORG)
+            bg = BackgroundTasks()
+            await update_doc(
+                DOC, DocUpdate(title="new title"), bg, repo=repo, session=s, auth=_auth(),
+            )
+            await bg()
+
+        context = await _fetch_latest_doc_updated_context(Session)
+        assert context is None, f"content 안 건드렸는데 doc_updated activity가 남음: {context}"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac7_shrink_over_50_percent_blocked_without_flag():
+    """AC7 핵심 — content가 50% 이상 줄면 allow_shrink 없이는 400."""
+    from fastapi import HTTPException
+    from app.repositories.doc import DocRepository
+    from app.routers.docs import update_doc
+    from app.schemas.doc import DocUpdate
+
+    eng, Session = await _engine()
+    try:
+        long_content = "x" * 4000
+        async with Session() as s:
+            await _seed(s, long_content)
+
+        async with Session() as s:
+            repo = DocRepository(s, ORG)
+            bg = BackgroundTasks()
+            short_content = "y" * 300  # -92.5%
+            with pytest.raises(HTTPException) as ei:
+                await update_doc(
+                    DOC, DocUpdate(content=short_content), bg, repo=repo, session=s, auth=_auth(),
+                )
+            assert ei.value.status_code == 400
+            assert "4000" in ei.value.detail and "300" in ei.value.detail
+            assert "allow_shrink=true" in ei.value.detail
+            assert "test doc" in ei.value.detail, f"doc 제목이 메시지에 없음: {ei.value.detail}"
+
+        # 봉인 — 거부됐으니 원본이 그대로 살아 있어야 한다.
+        async with Session() as s:
+            row = (await s.execute(
+                text("SELECT content FROM docs WHERE id=:i"), {"i": DOC}
+            )).scalar_one()
+            assert row == long_content, "거부됐는데 content가 바뀜(부분 적용 회귀)"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac7_shrink_with_allow_shrink_flag_passes():
+    """AC7 — allow_shrink=true로 명시 승인하면 같은 급감도 통과한다."""
+    from app.repositories.doc import DocRepository
+    from app.routers.docs import update_doc
+    from app.schemas.doc import DocUpdate
+
+    eng, Session = await _engine()
+    try:
+        long_content = "x" * 4000
+        async with Session() as s:
+            await _seed(s, long_content)
+
+        async with Session() as s:
+            repo = DocRepository(s, ORG)
+            bg = BackgroundTasks()
+            short_content = "y" * 300
+            resp = await update_doc(
+                DOC, DocUpdate(content=short_content, allow_shrink=True), bg,
+                repo=repo, session=s, auth=_auth(),
+            )
+            assert resp.content == short_content
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac7_small_shrink_under_threshold_not_blocked():
+    """양성 대조 — 50% 미만 축소(정상적인 편집 범위)는 플래그 없이도 통과한다."""
+    from app.repositories.doc import DocRepository
+    from app.routers.docs import update_doc
+    from app.schemas.doc import DocUpdate
+
+    eng, Session = await _engine()
+    try:
+        original = "x" * 1000
+        async with Session() as s:
+            await _seed(s, original)
+
+        async with Session() as s:
+            repo = DocRepository(s, ORG)
+            bg = BackgroundTasks()
+            slightly_shorter = "y" * 600  # -40%, 임계(50%) 밑
+            resp = await update_doc(
+                DOC, DocUpdate(content=slightly_shorter), bg, repo=repo, session=s, auth=_auth(),
+            )
+            assert resp.content == slightly_shorter
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac7_small_absolute_loss_not_blocked_even_at_high_percentage():
+    """양성 대조 — 짧은 content는 퍼센트가 커도(절대량이 작으면) 안 막힌다."""
+    from app.repositories.doc import DocRepository
+    from app.routers.docs import update_doc
+    from app.schemas.doc import DocUpdate
+
+    eng, Session = await _engine()
+    try:
+        token_like = "[Target](entity:doc:11111111-1111-1111-1111-111111111111)"  # 48자
+        async with Session() as s:
+            await _seed(s, token_like)
+
+        async with Session() as s:
+            repo = DocRepository(s, ORG)
+            bg = BackgroundTasks()
+            resp = await update_doc(
+                DOC, DocUpdate(content="no tokens here"), bg, repo=repo, session=s, auth=_auth(),
+            )
+            assert resp.content == "no tokens here"
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_doc_concurrency_151e05f1.py
+++ b/backend/tests/test_doc_concurrency_151e05f1.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import BackgroundTasks
 
 from app.dependencies.auth import AuthContext
 from app.routers import docs as docs_mod
@@ -48,7 +49,9 @@ async def _call(body_kwargs, doc_updated_at=T1):
     # f69fcd91: update_doc 가 project authz(_require_doc_project_access) 선행 — 이 테스트는 409 동시성
     # 로직 검증이라 authz 게이트는 통과(doc 반환)로 패치.
     with patch.object(docs_mod, "_require_doc_project_access", AsyncMock(return_value=d)):
-        resp = await update_doc(d.id, DocUpdate(**body_kwargs), repo, session, auth=auth)
+        # story #2346: update_doc가 background_tasks(신규 필수 파라미터, AC3 activity 로깅용)를
+        # 받는다 — 이 테스트는 그 이전 시그니처를 positional로 호출하고 있었다.
+        resp = await update_doc(d.id, DocUpdate(**body_kwargs), BackgroundTasks(), repo, session, auth=auth)
     return resp, d
 
 

--- a/backend/tests/test_doc_mutation_project_scope_idor_realdb.py
+++ b/backend/tests/test_doc_mutation_project_scope_idor_realdb.py
@@ -14,7 +14,7 @@ import os
 import uuid
 
 import pytest
-from fastapi import HTTPException
+from fastapi import BackgroundTasks, HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
@@ -160,12 +160,14 @@ async def test_update_cross_project_forbidden_same_project_ok():
             with pytest.raises(HTTPException) as ei:
                 await update_doc(
                     id=docs["b_upd"], body=DocUpdate(title="hacked"),
+                    background_tasks=BackgroundTasks(),
                     repo=DocRepository(s, ORG), session=s, auth=_auth(),
                 )
             assert ei.value.status_code == 403
         async with Session() as s:
             out = await update_doc(
                 id=docs["a_upd"], body=DocUpdate(title="ok-edit"),
+                background_tasks=BackgroundTasks(),
                 repo=DocRepository(s, ORG), session=s, auth=_auth(),
             )
             assert out.title == "ok-edit"


### PR DESCRIPTION
## 무엇

story #2346의 AC3(변경 이력)를 stories.py에 이어 docs.py·agent_runs.py에도 배선한다. stories.py는 이미 develop에 AC3+AC7(50%+절대손실100자 이상 급감 400 거부, allow_shrink=true 승인)까지 완료돼 있었다(코드 직접 확認 — 커밋 31e8c3282·755fe9616·45aa64816).

## docs.py — AC3 + AC7 둘 다

- content 길이 실측(3000~4500자대 표본, project f3e6ed64) 결과 stories.py의 두 임계값(50%·절대손실100자)이 이 스케일에서도 그대로 작동 — 재사용.
- activity 로깅 자체가 없던 라우터라 `background_tasks` 파라미터 + `record_activity_bg` 최초 호출을 새로 배선.
- `DocUpdate`에 `allow_shrink: bool = False` 추가.

## agent_runs.py — AC3만, AC7은 의도적으로 안 넣음

상태전이(`_TERMINAL_STATUSES`)와 얽혀 있어 "완료 시 요약이 legitimate하게 짧아지는" 정상 흐름을 AC7류 차단이 막을 위험이 있다(PO 판정 2026-08-02). 코드 주석으로 이유를 남기고, "완료 요약 축약이 차단되지 않는다"를 실측 테스트로 고정해 나중에 실수로 AC7이 이식되면 그 테스트가 잡는다.

## 배선 중 발견한 회귀 — 기존 테스트 2건 수정

`background_tasks`를 필수 파라미터로 추가하면서 `update_doc`을 positional 인자로 호출하던 기존 realdb 테스트(`test_doc_concurrency_151e05f1.py`·`test_doc_mutation_project_scope_idor_realdb.py`)의 인자 매핑이 밀렸다 — stories.py의 AC3 PR도 같은 이유로 자기 테스트를 갱신했었다. 두 파일 모두 `BackgroundTasks()`를 명시 전달하도록 수정(양쪽 다 이미 develop에 머지된 stories.py 패턴과 동형).

## 알려진 한계(PO 지적, 2026-08-02) — length_changes는 복구 수단이 아니다

`context.length_changes`는 필드별 `{before, after}` **길이 숫자만** 남긴다 — 지워지기 전 **내용 자체**는 어디에도 남지 않는다. `actor_id`가 남으므로 "누가 지웠는지"는 알 수 있지만, "무엇이 지워졌는지"(그 값 자체)는 이 판으로 복구할 수 없다. 목적은 "조용한 축소를 말하게 만드는 것"이지 "되돌리게 하는 것"이 아니다 — #2346의 축 자체가 그렇다(전문 스냅샷은 비용 문제로 처음부터 스코프 밖).

## 검증

- 신규 realdb 테스트 11건(docs 7 + agent_runs 4) 전부 통과.
- 뮤테이션: docs.py AC7 게이트 비활성화 → 정확히 1건만 RED(6개 unaffected). agent_runs.py length-logging 비활성화 → 정확히 1건만 RED(3개 unaffected). 둘 다 복원 후 재확認.
- 기존 관련 테스트(concurrency·mutation-idor·update-project-scope) 25건 전부 통과 재확認.
- py_compile 클린.

## Test plan

- [x] 신규 realdb 테스트 11건
- [x] 뮤테이션(sabotage→RED→복원→GREEN) 양쪽
- [x] 기존 회귀 스위트 25건
- [x] CI(lint/type-check/pytest)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

