### PR TITLE
fix(#2349): route_message(webhook 채널)에 user_blocks 배선 — 차단 실효 갭

### DIFF
--- a/backend/app/services/channel_router.py
+++ b/backend/app/services/channel_router.py
@@ -64,6 +64,42 @@ async def route_message(
             )
         )).scalars().all()
         recipient_ids = [pid for pid in participant_rows if pid != msg.sender_id]
+
+        # story #2349 AC3 — 라이브 검증(2026-08-03, PO+디디, 스레드 7256d5cc)에서 실측으로 발견:
+        # send_message의 user_blocker_ids exclusion은 _dispatch_conversation_event(Event row)·
+        # mention_targets·candidate_targets 3곳만 잡았고, 이 함수(route_message)는 별개 쿼리로
+        # recipient_ids를 처음부터 다시 뽑아 그 exclusion이 전혀 안 닿았다 — webhook-covered
+        # 수신자(에이전트 대다수의 실제 수신 경로)에게는 차단이 «전혀 안 먹는» 상태로 머지됐었다.
+        # route_message는 코드베이스 전체에서 정의 1곳·호출 2곳(pre-check용 별칭 _route L2033·
+        # 실 webhook 발송용 L702)뿐이고, decisions 소비 분기도 channel=="discord"(webhook)·
+        # 그 외(sse) 정확히 둘뿐이다(grep 전수 확認) — recipient_ids 원재료가 만들어지는 이
+        # 지점 한 곳이 sse·discord·향후 추가될 모든 채널의 공통 상류라, 여기서 한 번만 걸러도
+        # 채널 수와 무관하게 구조적으로 전부 막힌다.
+        #
+        # ⚠️recipient_ids는 이 함수 안에서만 쓰이는 local(decisions 계산 전용) — 이 목록을
+        # 밖으로 반환하거나 ConversationParticipant를 건드리지 않는다(PO 확認 요청, 2026-08-03).
+        # 즉 여기서 거르는 것은 «이 메시지의 알림/발송 대상»뿐이고 「대화 참가자」 관계 자체는
+        # 그대로다 — 참가자 목록·읽기 권한(list_messages/_authorize_message_read)은 이 함수를
+        # 전혀 거치지 않는 별도 경로라 안 끊긴다.
+        #
+        # #2814와 같은 결의 fail-open — 조회 실패해도 라우팅 자체는 안 막는다(대화 전송을
+        # 부수 조회 하나 때문에 죽이지 않는다는 동일 트레이드오프. 로그 문구도 동일 패턴으로
+        # 맞춰 "차단이 새는 빈도"를 하나의 문구로 셀 수 있게 한다).
+        if msg.sender_id and recipient_ids:
+            try:
+                from app.models.user_block import UserBlock
+                blocker_ids = set((await db.execute(
+                    select(UserBlock.blocker_member_id).where(UserBlock.blocked_member_id == msg.sender_id)
+                )).scalars().all())
+                if blocker_ids:
+                    recipient_ids = [pid for pid in recipient_ids if pid not in blocker_ids]
+            except Exception:
+                import logging
+                logging.getLogger(__name__).warning(
+                    "user_blocker_ids lookup failed message_id=%s — fail-open(no exclusion)", msg.id,
+                    exc_info=True,
+                )
+
         if not recipient_ids:
             return []
 

--- a/backend/app/services/channel_router.py
+++ b/backend/app/services/channel_router.py
@@ -4,6 +4,7 @@
 """
 from __future__ import annotations
 
+import logging
 import uuid
 from dataclasses import dataclass, field
 from typing import Sequence
@@ -14,6 +15,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.notification_preference import NotificationPreference
 from app.models.team import TeamMember
+from app.models.user_block import UserBlock
+
+logger = logging.getLogger(__name__)
 
 
 class ChannelRouterError(Exception):
@@ -87,15 +91,13 @@ async def route_message(
         # 맞춰 "차단이 새는 빈도"를 하나의 문구로 셀 수 있게 한다).
         if msg.sender_id and recipient_ids:
             try:
-                from app.models.user_block import UserBlock
                 blocker_ids = set((await db.execute(
                     select(UserBlock.blocker_member_id).where(UserBlock.blocked_member_id == msg.sender_id)
                 )).scalars().all())
                 if blocker_ids:
                     recipient_ids = [pid for pid in recipient_ids if pid not in blocker_ids]
             except Exception:
-                import logging
-                logging.getLogger(__name__).warning(
+                logger.warning(
                     "user_blocker_ids lookup failed message_id=%s — fail-open(no exclusion)", msg.id,
                     exc_info=True,
                 )

--- a/backend/tests/test_2349_user_blocks_realdb.py
+++ b/backend/tests/test_2349_user_blocks_realdb.py
@@ -486,3 +486,68 @@ async def test_unblocked_sender_mention_still_notifies():
         assert mention_count == 1
     finally:
         await engine.dispose()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# ④ route_message(channel_router.py) — webhook/채널 결정 축 (2026-08-03 라이브에서 발견된 갭)
+#
+# 실측(PO+디디, 라이브, 스레드 7256d5cc): send_message의 user_blocker_ids exclusion은
+# _dispatch_conversation_event/mention_targets/candidate_targets 3곳만 잡았고, route_message는
+# 별개 쿼리로 recipient_ids를 다시 뽑아 그 exclusion이 안 닿았다 — webhook-covered 수신자
+# (에이전트 대다수의 실제 수신 경로)에게는 차단이 «전혀 안 먹는» 상태로 머지됐었다. 이 절이
+# 그 갭을 직접 재현·고정한다.
+# ═══════════════════════════════════════════════════════════════════════════
+
+async def test_route_message_excludes_recipient_who_blocked_sender():
+    """route_message가 발신자를 차단한 수신자를 decisions에서 뺀다(discord든 sse든 무관 —
+    recipient_ids 상류 한 곳에서 걸러지므로 채널 무관하게 빠져야 한다)."""
+    from app.services.channel_router import route_message
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as session:
+            org = await _make_org(session)
+            project = await _make_project(session, org.id)
+            blocker_id, _ = await _make_human_member(session, org.id, project.id)
+            other_id, _ = await _make_human_member(session, org.id, project.id)
+            sender_id, _ = await _make_human_member(session, org.id, project.id)
+            conv_id = await _make_conversation(
+                session, org.id, project.id, [blocker_id, other_id, sender_id], sender_id,
+            )
+            msg = await _add_message(session, conv_id, sender_id, "hello", datetime.now(timezone.utc))
+
+            from app.models.user_block import UserBlock
+            session.add(UserBlock(id=uuid.uuid4(), blocker_member_id=blocker_id, blocked_member_id=sender_id))
+            await session.commit()
+
+        async with Session() as session:
+            decisions = await route_message(msg.id, session)
+
+        decided_ids = {d.member_id for d in decisions}
+        assert blocker_id not in decided_ids, "차단한 수신자가 route_message decisions에 남아 있음 — #2349 갭 재발"
+        assert other_id in decided_ids, "차단 안 한 3자까지 같이 빠짐(양성대조 실패 — 전체가 죽은 것)"
+    finally:
+        await engine.dispose()
+
+
+async def test_route_message_no_block_all_recipients_present():
+    """양성대조 — 차단 관계가 전혀 없으면 route_message가 참가자 전원을 그대로 낸다."""
+    from app.services.channel_router import route_message
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as session:
+            org = await _make_org(session)
+            project = await _make_project(session, org.id)
+            a_id, _ = await _make_human_member(session, org.id, project.id)
+            b_id, _ = await _make_human_member(session, org.id, project.id)
+            sender_id, _ = await _make_human_member(session, org.id, project.id)
+            conv_id = await _make_conversation(session, org.id, project.id, [a_id, b_id, sender_id], sender_id)
+            msg = await _add_message(session, conv_id, sender_id, "hi all", datetime.now(timezone.utc))
+
+        async with Session() as session:
+            decisions = await route_message(msg.id, session)
+
+        assert {d.member_id for d in decisions} == {a_id, b_id}
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_channel_router_multiproject_sender.py
+++ b/backend/tests/test_channel_router_multiproject_sender.py
@@ -57,6 +57,7 @@ async def test_multiproject_agent_sender_dispatches_without_crash():
         _scalar(msg),                       # 1 메시지
         _scalar("agent"),                   # 2 sender_type — .limit(1)로 단일 행(뷰 다중에도 안전)
         _scalars([sender, recipient]),      # 3 participants(발신자 포함)
+        _scalars([]),                       # 3b story #2349: user_blocker_ids 조회(차단 0건)
         _all([(recipient, "agent")]),       # 4 수신자 type 배치
         _scalar(proj),                      # 5 conv project_id
         _scalars([]),                       # 6 preferences


### PR DESCRIPTION
## 요약

`#2349`(사용자 차단) 라이브 재검증 중 발견 — 머지된 1차 구현이 **webhook-covered 수신자에게는
차단이 실질적으로 안 먹는** 상태였다. 이 PR이 그 갭을 닫는다.

## 발견 경위(라이브, PO+디디)

```
①blocker가 sender를 차단 → sender가 DM 발송
②events/pending(agent 폴링 채널) 조회 → 0건 → 「막혔다」로 1차 판정
③webhook deliveries 조회(PO 지적으로 추가로 봄) → «둘 다 실제로 Discord로 갔음» 발견
  (차단 중에 보낸 메시지도, 해제 후 보낸 메시지도 동일하게 webhook 배달됨)
```

원인: `send_message`의 `user_blocker_ids` exclusion은 `_dispatch_conversation_event`(Event
row)·`mention_targets`·`candidate_targets` 3곳만 잡았다. `channel_router.py`의
`route_message`(webhook 배달 채널을 결정하는 함수)는 **완전히 별개의 새 쿼리**로
`recipient_ids`를 처음부터 다시 뽑아 그 exclusion이 전혀 안 닿았다.

## 경로 표(고치기 前에 — #2319가 세 번 안 닫힌 것과 같은 실수를 반복 안 하려고)

```
경로                          무엇이 대상을 정하는가              user_blocks 보는가
──────────────────────────────────────────────────────────────────
Event row(SSE)                _dispatch_conversation_event        ✅(#2314/#2814)
mention SSE                   _dispatch_mention_events             ✅(mention_targets가 이미 필터)
mention 알림(human in-app)      dispatch_notification(mention)      ✅
message 알림(human in-app)      dispatch_notification(candidate)    ✅
채널결정 pre-check(SSE제외용)     route_message (별칭 _route)         ⛔이 PR
webhook 실발송(Discord)         route_message (동일 함수)            ⛔이 PR(같은 자리)
```

**「전부인 이유」— 구조**: `route_message`는 정의 1곳·호출 2곳(grep 전수, 별칭 포함)뿐이고,
`decisions` 소비 분기도 `channel=="discord"`(webhook)·그 외(sse) 정확히 둘뿐이다.
`recipient_ids`가 만들어지는 지점 **한 곳**이 지금·미래의 모든 채널의 공통 상류라, 여기
한 번만 걸러도 채널 수와 무관하게 구조적으로 전부 막힌다 — `#2810`의 `sum()!=1`보다 강한
형태(향후 채널 추가에도 자동 방어).

## 안전 확認(PO 요청)

`recipient_ids`는 `route_message` 내부 local 변수(decisions 계산 전용) — 밖으로 반환되지
않고 `ConversationParticipant`도 안 건드린다. 즉 여기서 거르는 것은 **이 메시지의 알림/발송
대상**뿐이고 **대화 참가자 관계**는 그대로다. 참가자 목록·읽기 권한(list_messages/
`_authorize_message_read`)은 이 함수를 전혀 거치지 않는 별도 경로라 안 끊긴다.

fail-open도 `#2814`와 같은 결로 — 조회 실패해도 라우팅 자체는 안 막는다(대화 전송을 부수
조회 하나 때문에 죽이지 않는 동일 트레이드오프).

## 검증

```
$ pytest backend/tests/test_2349_user_blocks_realdb.py -q                      → 16 passed
$ pytest backend/tests/test_channel_router_multiproject_sender.py -q           → 1 passed
$ pytest backend/tests/test_1994_backlink_api_realdb.py -q                     → 40 passed
$ pytest backend/tests/test_authz_project_scope_coverage.py -q                 → 13 passed
$ pytest backend/tests/test_conversations.py -q                                → 15 passed
```

뮤테이션: exclusion 비활성화(`if False and ...`) → 정확히
`test_route_message_excludes_recipient_who_blocked_sender` 1건만 RED, 나머지 84건 무영향
확認 → 복원 → 전체 85 GREEN.

## 라이브 재검증(고친 뒤 — 예정)

`#2814`처럼 events/pending만 보던 실수를 반복 안 함 — 이번엔 **events/pending과 webhook
deliveries 둘 다** 보면서 차단 중/해제 후 왕복을 다시 밟는다.

## Test plan

- [x] 위 5개 명령 전부 pass(85건)
- [x] 뮤테이션(sabotage→정확히 1건 RED→복원→GREEN)
- [x] recipient_ids가 참가자 관계/읽기 권한에 영향 없음 확認(PO 요청)
- [ ] 라이브 재검증(events/pending + webhook deliveries 둘 다, 배포 후)
- [x] CI(lint/type-check/pytest)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
