### PR TITLE
fix(fastapi-proxy): null-body status(204 등) 재구성 시 빈문자열 대신 null

### DIFF
--- a/apps/web/src/lib/fastapi-proxy.test.ts
+++ b/apps/web/src/lib/fastapi-proxy.test.ts
@@ -9,7 +9,7 @@ const { getServerSessionMock } = vi.hoisted(() => ({
 
 vi.mock('@/lib/db/server', () => ({ getServerSession: getServerSessionMock }));
 
-import { proxyToFastapi, proxyToFastapiWithParams } from './fastapi-proxy';
+import { proxyToFastapi, proxyToFastapiWithParams, proxyToFastapiWrapped } from './fastapi-proxy';
 
 describe('fastapi-proxy — X-Project-Id override passthrough (story 7d6b770b 회귀가드)', () => {
   beforeEach(() => {
@@ -115,5 +115,45 @@ describe('fastapi-proxy — 응답 헤더 allowlist forward(story #2190)', () =>
     expect(res.headers.get('x-total-count')).toBeNull();
     expect(res.headers.get('x-next-cursor')).toBeNull();
     expect(res.headers.get('content-type')).toBe('application/json');
+  });
+});
+
+// story #2349 라이브 검증(미르코, 2026-08-03) 실측 — DELETE /api/user-blocks/{id}가 매번 500을
+// 냈다(빈 목록 API로는 실제로 지워진 것을 확認했으니 BE는 성공했다). 근본원인: BE가 spec대로
+// 204+빈 바디를 내는데, 이 프록시가 `new Response(resBody, {status:204})`로 재구성할 때
+// resBody가 null이 아니라 빈 문자열이라 Node/undici가 "Invalid response status code 204"로
+// 던졌다 — 사용자는 실패로 보지만 서버 쪽 작업은 이미 끝난 상태(차단은 풀렸는데 에러 토스트).
+describe('fastapi-proxy — null-body status(204 등) 재구성이 안 던진다(story #2349 회귀가드)', () => {
+  beforeEach(() => {
+    getServerSessionMock.mockReset();
+    getServerSessionMock.mockResolvedValue({ access_token: 'token-1', org_id: 'org-1', project_id: 'proj-1' });
+  });
+
+  it('BE가 204(spec대로 빈 바디)를 내도 던지지 않고 그대로 204를 돌려준다', async () => {
+    global.fetch = vi.fn(async () => new Response(null, { status: 204 }));
+    const request = new Request('http://localhost/api/user-blocks/member-1', { method: 'DELETE' });
+
+    const res = await proxyToFastapi(request, '/api/v2/user-blocks/member-1');
+
+    expect(res.status).toBe(204);
+  });
+
+  it('proxyToFastapiWrapped도 204를 그대로 통과시킨다(안 던짐)', async () => {
+    global.fetch = vi.fn(async () => new Response(null, { status: 204 }));
+    const request = new Request('http://localhost/api/user-blocks/member-1', { method: 'DELETE' });
+
+    const res = await proxyToFastapiWrapped(request, '/api/v2/user-blocks/member-1');
+
+    expect(res.status).toBe(204);
+  });
+
+  it('200(본문 있음)은 여전히 그대로 통과한다(회귀 없음 — null-body 처리가 일반 응답을 안 건드림)', async () => {
+    global.fetch = vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    const request = new Request('http://localhost/api/user-blocks', { method: 'POST', body: '{}' });
+
+    const res = await proxyToFastapi(request, '/api/v2/user-blocks');
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
   });
 });

--- a/apps/web/src/lib/fastapi-proxy.ts
+++ b/apps/web/src/lib/fastapi-proxy.ts
@@ -135,7 +135,13 @@ export async function proxyToFastapi(
     const v = res.headers.get(h);
     if (v) resHeaders[h] = v;
   }
-  return new Response(resBody, {
+  // story #2349 라이브 검증(미르코) 실측 — null-body status(101/103/204/205/304)에는 Response
+  // 생성자가 bodyInit을 null/undefined 대신 빈 문자열('')로 받으면 던진다("Invalid response
+  // status code 204" — Node 25/undici). BE가 spec대로 204+빈 바디를 내면 이 프록시가 그걸
+  // 그대로 500으로 바꿔버리던 것 — 사용자는 "실패"로 보지만 실제로는 BE 쪽 작업이 이미 끝난
+  // 상태(예: DELETE user-blocks — 차단 해제는 됐는데 화면엔 에러 토스트가 뜨는 사고).
+  const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);
+  return new Response(NULL_BODY_STATUSES.has(res.status) ? null : resBody, {
     status: res.status,
     headers: resHeaders,
   });


### PR DESCRIPTION
## 무엇

`#2349` 라이브 검증(④ 차단 해제) 중 발견 — `DELETE /api/user-blocks/{id}`가 매번 500을
반환했는데, GET으로 재확認하면 실제로는 이미 정상적으로 삭제돼 있었다.

## 근본원인

BE가 spec대로 `204`+빈 바디를 내는데(`@router.delete(..., status_code=204) -> None`),
`fastapi-proxy.ts`의 `proxyToFastapi`가 `new Response(resBody, {status: res.status, ...})`로
응답을 재구성할 때 `resBody`가 `null`이 아니라 빈 문자열(`''`)이라 Node/undici가
`TypeError: Response constructor: Invalid response status code 204`를 던진다 — 사용자에겐
"실패"로 보이지만 서버 쪽 작업은 이미 끝나 있는 사고(성공이 실패로 보이는 자리).

로컬 재현:
```js
new Response('', { status: 204 })       // throws
new Response(null, { status: 204 })     // OK
```

## 수정 범위 — 최소

`null-body status`(101/103/204/205/304)면 body를 `null`로 넘긴다. 이것 하나만 — 프록시의
다른 동작은 안 건드렸다.

## 영향 범위 — 두 수를 구분한다(각각 무엇의 수인지)

버그·수정 둘 다 위치가 개별 route.ts가 아니라 공유 `proxyToFastapi` 함수 내부다 — 아래
「영향권」 수가 실제 노출 범위이고, 「오늘 확認분」은 그중 로컬에 204 분기가 있어 사후
관찰하기 쉬웠던 서브셋일 뿐이다.

```bash
# 영향권 — proxyToFastapi(/WithParams/Wrapped)를 타는 route.ts 전수 = 242개
grep -rlE "proxyToFastapi\(|proxyToFastapiWithParams\(|proxyToFastapiWrapped\(" \
  apps/web/src/app/api --include="route.ts" | sort | wc -l

# 오늘 확認분 — 그중 자기 파일에 "===204" 명시 분기까지 있는 것 = 83개
comm -12 \
  <(grep -rlE "proxyToFastapi\(|proxyToFastapiWithParams\(|proxyToFastapiWrapped\(" \
      apps/web/src/app/api --include="route.ts" | sort) \
  <(grep -rlE "(status|\.status)\s*===\s*204" apps/web/src/app/api --include="route.ts" | sort)
```

```
영향권        242개 — 공유 proxyToFastapi 계열을 타는 route.ts 전수. BE가 해당 엔드포인트에서
              204를 내는 순간 전부 이 버그에 노출된다(그 route.ts에 204 분기 코드가 있는지와 무관).
오늘 확認분   83개 — 그중 자기 파일에 `===204` 명시 분기까지 있어 「지금 204를 다루는 중」이라
              사후에 관찰·재현하기 쉬웠던 것. PR 최초본엔 이 83을 "전부"로 잘못 적었다(정정).
커버 범위    242개 전부 — 수정이 공유 함수 한 줄이라 83에 없는 나머지 159개도 동일하게 고쳐진다.
```
→ 실제로 `me/route.ts`·`account/delete/route.ts`(둘 다 83에 포함)에서 영향 확認. 나머지
159개는 「BE가 아직 204를 낸 적 없거나 로컬에 그 분기가 없던」 라우트라 오늘은 증상이
안 보였을 뿐 — 이 수정으로 잠재 노출이 같이 닫힌다.

## 오늘 같은 병의 세 번째

```
route_message    공용 라우터가 "한 경로"만 보고 만들어져 웹훅 축에 차단 exclusion이 안 닿음
fastapi-proxy    공용 프록시가 "본문 있는 응답"만 보고 만들어져 204가 깨짐
```
둘 다 "공용 헬퍼가 자기가 아는 경우만 다룬" 같은 클래스 — 다음에 이 프록시를 만질 사람은
이 축을 참고할 것.

## 검증
- 로컬 재현(빈 문자열+204 → throw, null+204 → OK)
- 유닛 테스트 3개 추가(204 안 던짐·`proxyToFastapiWrapped`도 안 던짐·200은 무회귀)
- 뮤테이션 셀프체크: 옛 코드로 되돌려 정확히 같은 에러로 RED 확認 후 복원
- `pnpm --filter web type-check` 0에러 · `lint`(대상 파일) 0경고 · `build` EXIT 0

## Test plan
- [x] 204(spec대로 빈 바디) → 안 던지고 그대로 통과
- [x] `proxyToFastapiWrapped`도 동일
- [x] 200(본문 있음) 무회귀
- [ ] `#2349` ④ 라이브 재검증(차단 해제) — 이 PR 머지 후

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
