### PR TITLE
fix(#2349): resolve_conversation_webhook_targets에 user_blocker_ids 배선 — 실 webhook 배달 SSOT 갭

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -2239,6 +2239,12 @@ async def send_message(
             if conv.created_by:
                 agent_ids.add(str(conv.created_by))
 
+            # story #2349 AC3 — 카디르 QA 재발견(2026-08-03): 이 WS 브로드캐스트가 msg.content
+            # 원문을 필터 없이 agent 참가자 room 전원에게 보내고 있었다 — user_blocker_ids
+            # (위 L2049~2053, send_message 요청 트랜잭션서 이미 계산된 값) 미적용. #2814/#2817과
+            # 같은 결로 여기서도 뺀다(새 쿼리 없음, caller의 값 재사용).
+            agent_ids -= {str(bid) for bid in user_blocker_ids}
+
             if agent_ids:
                 ws_payload = json.dumps({
                     "id": str(msg.id),

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -2069,6 +2069,7 @@ async def send_message(
                 project_id=conv.project_id,
                 sender_id=sender.id,
                 mentioned_ids=list(msg.mentioned_ids) if msg.mentioned_ids else None,
+                blocker_member_ids=user_blocker_ids,
             )
         except Exception:
             logger.warning(

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -180,6 +180,7 @@ async def resolve_conversation_webhook_targets(
     project_id: uuid.UUID,
     sender_id: uuid.UUID | None,
     mentioned_ids: list[uuid.UUID] | None,
+    blocker_member_ids: set[uuid.UUID] | None = None,
 ) -> list[_WebhookTarget]:
     """conversation.message_created 의 실 전달 대상 webhook 을 결정하는 SSOT.
 
@@ -191,15 +192,30 @@ async def resolve_conversation_webhook_targets(
     authorized = mentioned 우선(**sender 제외**)·없으면 참가자 전원(sender 제외). member-bound
     webhook 은 그 멤버가 authorized 일 때만, member_id=null 브로드캐스트는 무조건 포함(참가자
     게이팅 c2dfb823). sender 제외로 자기 self-mention webhook 비대칭도 제거(Finding 2).
+
+    story #2349 AC3 — 라이브 검증(2026-08-03, PO+디디, 스레드 7256d5cc)에서 실측으로 발견:
+    이 함수가 실제 agent 게이트웨이 webhook 배달(ConversationWebhookDelivery)의 SSOT인데,
+    「이 발신자를 차단한 수신자」exclusion(user_blocker_ids, #2814)이 conversations.py의
+    _dispatch_conversation_event(Event/SSE)·mention_targets에만 흘러가고 여기(실 webhook 배달
+    대상 산출)엔 한 번도 안 걸렸다 — #2817(channel_router.py::route_message, discord-channel
+    WebhookConfig 아웃바운드용)과는 완전히 별개 지점이라 그 수정도 이 갭을 안 덮었다. PO 재확認
+    (2026-08-03, origin/develop 실측): 값이 없던 게 아니라 caller(conversations.py:2049~2053)가
+    바로 옆에서 이미 계산해두고도 «전달을 안 했던» 것 — 그래서 여기서 재조회하지 않고
+    `blocker_member_ids` 파라미터로 caller의 값을 그대로 받는다(TOCTOU-safe한 단일 snapshot
+    원칙 유지, 이 함수 안에서 새 쿼리를 추가하지 않는다).
     """
     from sqlalchemy import select
 
     from app.models.conversation import ConversationParticipant
 
+    blocker_member_ids = blocker_member_ids or set()
+
     if mentioned_ids:
         # 멘션 있으면 멘션 대상만 — sender 제외(자기 메시지를 자기 webhook 으로 되받지 않도록·
         # SSE mention 경로[conversations.py]와 authorized set 통일). 멘션이 sender 뿐이면 전달 0.
-        member_ids_for_webhook: list[uuid.UUID] = [m for m in mentioned_ids if m != sender_id]
+        member_ids_for_webhook: list[uuid.UUID] = [
+            m for m in mentioned_ids if m != sender_id and m not in blocker_member_ids
+        ]
     else:
         participant_member_ids = (await db.execute(
             select(ConversationParticipant.member_id).where(
@@ -207,7 +223,7 @@ async def resolve_conversation_webhook_targets(
                 *([ConversationParticipant.member_id != sender_id] if sender_id else []),
             )
         )).scalars().all()
-        member_ids_for_webhook = list(participant_member_ids)
+        member_ids_for_webhook = [m for m in participant_member_ids if m not in blocker_member_ids]
 
     authorized_member_ids: set[uuid.UUID] = {
         mid for mid in member_ids_for_webhook if mid is not None

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -180,7 +180,7 @@ async def resolve_conversation_webhook_targets(
     project_id: uuid.UUID,
     sender_id: uuid.UUID | None,
     mentioned_ids: list[uuid.UUID] | None,
-    blocker_member_ids: set[uuid.UUID] | None = None,
+    blocker_member_ids: set[uuid.UUID],
 ) -> list[_WebhookTarget]:
     """conversation.message_created 의 실 전달 대상 webhook 을 결정하는 SSOT.
 
@@ -203,12 +203,13 @@ async def resolve_conversation_webhook_targets(
     바로 옆에서 이미 계산해두고도 «전달을 안 했던» 것 — 그래서 여기서 재조회하지 않고
     `blocker_member_ids` 파라미터로 caller의 값을 그대로 받는다(TOCTOU-safe한 단일 snapshot
     원칙 유지, 이 함수 안에서 새 쿼리를 추가하지 않는다).
+
+    카디르 QA 재발견(2026-08-03) — 필수 키워드 인자로 승격: 옵셔널(기본값 None)이면 다음 caller가
+    또 "값은 있는데 전달을 잊는" 실수를 반복할 수 있다 — 타입 체커가 누락을 잡게 강제한다.
     """
     from sqlalchemy import select
 
     from app.models.conversation import ConversationParticipant
-
-    blocker_member_ids = blocker_member_ids or set()
 
     if mentioned_ids:
         # 멘션 있으면 멘션 대상만 — sender 제외(자기 메시지를 자기 webhook 으로 되받지 않도록·
@@ -286,6 +287,20 @@ async def deliver_conversation_message_webhook(
     async with async_session_factory() as db:
         try:
             if targets is None:
+                # targets 미전달(구 호출자/방어) 경로 — 위 SSOT 호출부(conversations.py)처럼
+                # 미리 계산된 snapshot이 없으므로 여기서 직접 조회(fail-open, #2814/#2817과 동일 결).
+                blocker_member_ids: set[uuid.UUID] = set()
+                if sender_id:
+                    try:
+                        from app.models.user_block import UserBlock
+                        blocker_member_ids = set((await db.execute(
+                            select(UserBlock.blocker_member_id).where(UserBlock.blocked_member_id == sender_id)
+                        )).scalars().all())
+                    except Exception:
+                        logger.warning(
+                            "user_blocker_ids lookup failed conversation_id=%s — fail-open(no exclusion)",
+                            conversation_id, exc_info=True,
+                        )
                 targets = await resolve_conversation_webhook_targets(
                     db,
                     conversation_id=conversation_id,
@@ -293,6 +308,7 @@ async def deliver_conversation_message_webhook(
                     project_id=project_id,
                     sender_id=sender_id,
                     mentioned_ids=mentioned_ids,
+                    blocker_member_ids=blocker_member_ids,
                 )
 
             if not targets:

--- a/backend/tests/test_2349_user_blocks_realdb.py
+++ b/backend/tests/test_2349_user_blocks_realdb.py
@@ -11,6 +11,22 @@
   ②_msg_payload.is_blocked_sender — 읽기 경로(list_messages/get_message)에서 차단 여부 반영
   ③알림 감산 — conversations.py::send_message의 3개 제외 체인(SSE dispatch·mention_targets·
     candidate_targets)이 차단한 수신자에게 알림을 안 보낸다(실 HTTP POST로 실증)
+
+send_message 배달 경로 «전수» — 2026-08-03 라이브 자국표로 확定(dev DB 직접 조회, 페드루):
+  ①Event/SSE        → test_blocker_gets_no_notification_for_blocked_sender_mention
+  ②webhook targets  → test_send_message_webhook_delivery_excludes_blocker
+  ③ws 브로드캐스트   → test_send_message_ws_chat_broadcast_excludes_blocker
+  ④인앱 알림        → test_blocker_gets_no_notification_for_blocked_sender_plain_message
+⛔send_message에 dispatch를 더하면 이 표에 «줄을 먼저 더하라».
+
+⚠️events=0을 「차단이 먹었다」로 읽지 말 것 — 수신자가 webhook 커버면 SSE는 skip되어(E-EVENT-
+1CONFIG, webhook_covered_ids) events는 «원래» 0이다. 실측(2026-08-03, 페드루, dev DB 직접
+조회): 차단 中 발송 두 건(be57a797·d8745bca) 모두 events=0·webhook_deliveries=1 — events=0은
+차단의 증거가 아니라 그 수신자가 애초에 webhook 채널로 커버된다는 뜻일 뿐이다. 양성대조(차단
+없는 메시지 3건: 45fe87f7 events=0/webhook=1, 215ea7c1 events=1/webhook=0, 3febd22a events=0/
+webhook=1)가 events↔webhook 배타 관계(둘 중 하나만 1)를 보여준다 — 라이브 재검증 1차에서
+「events/pending 0건 → 차단이 막혔다」로 읽은 판단이 바로 이 오독이었다. 차단 여부는 반드시
+webhook_deliveries로 재라.
 """
 from __future__ import annotations
 

--- a/backend/tests/test_2349_user_blocks_realdb.py
+++ b/backend/tests/test_2349_user_blocks_realdb.py
@@ -12,12 +12,22 @@
   ③알림 감산 — conversations.py::send_message의 3개 제외 체인(SSE dispatch·mention_targets·
     candidate_targets)이 차단한 수신자에게 알림을 안 보낸다(실 HTTP POST로 실증)
 
-send_message 배달 경로 «전수» — 2026-08-03 라이브 자국표로 확定(dev DB 직접 조회, 페드루):
-  ①Event/SSE        → test_blocker_gets_no_notification_for_blocked_sender_mention
-  ②webhook targets  → test_send_message_webhook_delivery_excludes_blocker
-  ③ws 브로드캐스트   → test_send_message_ws_chat_broadcast_excludes_blocker
-  ④인앱 알림        → test_blocker_gets_no_notification_for_blocked_sender_plain_message
+send_message 배달 경로 «전수» (2026-08-03, 카디르 QA 뮤테이션 재발견 후 정정):
+  ①Event/SSE          events 테이블                     → test_blocker_gets_no_notification_for_blocked_sender_plain_message·
+                                                            test_blocker_gets_no_notification_for_blocked_sender_mention(둘 다 events 직접 쿼리)
+  ②webhook targets    conversation_webhook_deliveries   → test_send_message_webhook_delivery_excludes_blocker
+  ③인앱 알림          notifications                      → test_blocker_gets_no_notification_for_blocked_sender_plain_message
+  ④ws 브로드캐스트     «테이블 없음»(순수 인메모리 WS)    → test_send_message_ws_chat_broadcast_excludes_blocker
+
+⛔inbox_items는 이 표에 «없다» — InboxItem 생성자 호출이 코드베이스 전체 0건(에이전트 의사결정용
+별개 기능, grep 확認).
+⭐⭐「저장소 축(DB를 훑는 법)」은 ④를 «원리상 못 본다» — DB row를 안 남기는지라. ④는 «코드 축
+(호출 그래프)»으로만 보인다 — 두 축이 서로의 사각을 덮는다.
 ⛔send_message에 dispatch를 더하면 이 표에 «줄을 먼저 더하라».
+⛔표에 «이름만» 거는 것을 조심 — 각 줄은 「그 테스트가 «그 저장소»를 실제로 쿼리하는가」로
+검산한다(카디르 뮤테이션: ①의 user_blocker_ids exclusion을 죽여도 처음엔 0/18 RED였다 — 이름만
+걸려 있고 실제로 events 테이블을 쿼리하는 assertion이 없었기 때문. 지금은 events를 직접
+쿼리하고, 뮤테이션으로 정확히 그 테스트만 RED가 되는 것까지 재확認했다).
 
 ⚠️events=0을 「차단이 먹었다」로 읽지 말 것 — 수신자가 webhook 커버면 SSE는 skip되어(E-EVENT-
 1CONFIG, webhook_covered_ids) events는 «원래» 0이다. 실측(2026-08-03, 페드루, dev DB 직접
@@ -402,6 +412,19 @@ async def _notification_count_for(session, user_id, event_type):
     )).scalar_one()
 
 
+async def _event_count_for(session, recipient_id, event_type):
+    """카디르 QA 뮤테이션 재발견(2026-08-03) — ①Event/SSE 자리는 표에 테스트 «이름만» 걸려
+    있었다(그 테스트는 Notification만 보고 events는 안 봄, _dispatch_conversation_event의
+    user_blocker_ids exclusion을 죽여도 0/18 RED였다). 이 헬퍼로 events 테이블을 직접 쿼리한다."""
+    from sqlalchemy import func, select
+    from app.models.event import Event
+    return (await session.execute(
+        select(func.count()).select_from(Event).where(
+            Event.recipient_id == recipient_id, Event.event_type == event_type,
+        )
+    )).scalar_one()
+
+
 async def test_blocker_gets_no_notification_for_blocked_sender_plain_message():
     """candidate_targets 축(conversation.message 알림) — 차단한 발신자의 평범한 메시지에는
     알림이 안 간다. 양성대조로 미차단 3자는 정상 수신하는지도 같은 사건에서 본다."""
@@ -437,21 +460,34 @@ async def test_blocker_gets_no_notification_for_blocked_sender_plain_message():
             other_count = await _notification_count_for(session, other_user, "conversation.message")
         assert blocker_count == 0, "차단한 발신자의 메시지 알림이 갔음 — 감산 실패"
         assert other_count == 1, "미차단 3자는 정상 수신해야 함(양성대조 — 전체가 죽은 게 아님을 확認)"
+
+        # ①Event/SSE 자리 — _dispatch_conversation_event의 user_blocker_ids exclusion을 events
+        # 테이블에서 직접 검산(카디르 QA 뮤테이션 재발견, 위 Notification assertion만으로는 이
+        # 지점을 안 지켰다: 그 exclusion을 죽여도 이 테스트를 포함한 18건 전부 GREEN이었다).
+        async with Session() as session:
+            blocker_events = await _event_count_for(session, blocker_id, "conversation.message_created")
+            other_events = await _event_count_for(session, other_id, "conversation.message_created")
+        assert blocker_events == 0, "차단한 발신자의 메시지 Event가 남음 — _dispatch_conversation_event 감산 실패"
+        assert other_events == 1, "미차단 3자는 Event도 정상 생성돼야 함(양성대조)"
     finally:
         await engine.dispose()
 
 
 async def test_blocker_gets_no_notification_for_blocked_sender_mention():
     """mention_targets 축(conversation.mention 알림 + SSE) — 차단한 발신자가 나를 멘션해도
-    알림이 안 간다."""
+    알림이 안 간다. other_id를 같이 멘션해 events 테이블 양성대조까지 같은 사건에서 본다
+    (카디르 QA 뮤테이션 재발견 — _dispatch_mention_events도 events를 직접 쿼리해 검산)."""
     engine, Session = await _session_factory()
     try:
         async with Session() as session:
             org = await _make_org(session)
             project = await _make_project(session, org.id)
             blocker_id, blocker_user = await _make_human_member(session, org.id, project.id)
+            other_id, _ = await _make_human_member(session, org.id, project.id)
             sender_id, sender_user = await _make_human_member(session, org.id, project.id)
-            conv_id = await _make_conversation(session, org.id, project.id, [blocker_id, sender_id], sender_id)
+            conv_id = await _make_conversation(
+                session, org.id, project.id, [blocker_id, other_id, sender_id], sender_id,
+            )
 
         from app.main import app
         await _setup_app_human(app, Session, blocker_user, org.id)
@@ -464,7 +500,7 @@ async def test_blocker_gets_no_notification_for_blocked_sender_mention():
         async with _client_for(app) as client:
             send_resp = await client.post(
                 f"/api/v2/conversations/{conv_id}/messages",
-                json={"content": "hey @you", "mentioned_ids": [str(blocker_id)]},
+                json={"content": "hey @you @other", "mentioned_ids": [str(blocker_id), str(other_id)]},
             )
         app.dependency_overrides.clear()
         assert send_resp.status_code == 201, send_resp.text
@@ -472,6 +508,13 @@ async def test_blocker_gets_no_notification_for_blocked_sender_mention():
         async with Session() as session:
             mention_count = await _notification_count_for(session, blocker_user, "conversation.mention")
         assert mention_count == 0, "차단한 발신자의 멘션 알림이 갔음 — 감산 실패(mention_targets 축)"
+
+        # ①Event/SSE 형제 경로(_dispatch_mention_events) — events 테이블 직접 검산.
+        async with Session() as session:
+            blocker_mention_events = await _event_count_for(session, blocker_id, "conversation:mention")
+            other_mention_events = await _event_count_for(session, other_id, "conversation:mention")
+        assert blocker_mention_events == 0, "차단한 발신자의 멘션 Event가 남음 — _dispatch_mention_events 감산 실패"
+        assert other_mention_events == 1, "미차단 3자는 멘션 Event도 정상 생성돼야 함(양성대조)"
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_2349_user_blocks_realdb.py
+++ b/backend/tests/test_2349_user_blocks_realdb.py
@@ -23,6 +23,7 @@ import pytest
 from tests.test_1994_backlink_api_realdb import (
     _add_message,
     _client_for,
+    _make_agent_member,
     _make_conversation,
     _make_human_member,
     _make_org,
@@ -549,5 +550,125 @@ async def test_route_message_no_block_all_recipients_present():
             decisions = await route_message(msg.id, session)
 
         assert {d.member_id for d in decisions} == {a_id, b_id}
+    finally:
+        await engine.dispose()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# ⑤ 실 webhook 배달 SSOT(resolve_conversation_webhook_targets) + ws_chat WS 브로드캐스트
+#
+# 라이브 재검증(2026-08-03, PO+디디, 스레드 7256d5cc) 후속 — ④(route_message)를 고친 뒤에도
+# 실 agent 게이트웨이 webhook 배달(ConversationWebhookDelivery의 SSOT인
+# conversation_webhook.py::resolve_conversation_webhook_targets)엔 exclusion이 안 걸려
+# 있었다(디디 발견) + ws_chat WebSocket 브로드캐스트(agent 참가자 room에 msg.content 원문
+# 실시간 전달)도 필터가 아예 없었다(카디르 QA 재발견). 둘 다 실 HTTP POST(send_message)로
+# 직접 재현·고정한다.
+# ═══════════════════════════════════════════════════════════════════════════
+
+async def test_send_message_webhook_delivery_excludes_blocker():
+    """resolve_conversation_webhook_targets가 실제 webhook 배달 대상에서 sender를 차단한
+    수신자를 뺀다 — send_message가 자체 계산한 webhook_targets를 통해 실증(HTTP POST 경유)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as session:
+            org = await _make_org(session)
+            project = await _make_project(session, org.id)
+            blocker_agent = await _make_agent_member(session, org.id, project.id)
+            other_agent = await _make_agent_member(session, org.id, project.id)
+            sender_id, sender_user = await _make_human_member(session, org.id, project.id)
+            conv_id = await _make_conversation(
+                session, org.id, project.id, [blocker_agent, other_agent, sender_id], sender_id,
+            )
+            from app.models.user_block import UserBlock
+            session.add(UserBlock(id=uuid.uuid4(), blocker_member_id=blocker_agent, blocked_member_id=sender_id))
+            await session.commit()
+
+            from app.models.webhook_config import WebhookConfig
+            session.add(WebhookConfig(
+                id=uuid.uuid4(), org_id=org.id, project_id=project.id, member_id=blocker_agent,
+                url=f"https://example.invalid/{uuid.uuid4()}", is_active=True, events=["conversation.message_created"],
+            ))
+            session.add(WebhookConfig(
+                id=uuid.uuid4(), org_id=org.id, project_id=project.id, member_id=other_agent,
+                url=f"https://example.invalid/{uuid.uuid4()}", is_active=True, events=["conversation.message_created"],
+            ))
+            await session.commit()
+
+        captured: list = []
+
+        async def _fake_deliver(*args, **kwargs):
+            captured.append(kwargs.get("targets"))
+
+        from app.services import conversation_webhook as conversation_webhook_module
+        original_deliver = conversation_webhook_module.deliver_conversation_message_webhook
+        conversation_webhook_module.deliver_conversation_message_webhook = _fake_deliver
+        # conversations.py는 함수 내부에서 `from app.services.conversation_webhook import
+        # deliver_conversation_message_webhook`을 매 호출 직전 새로 임포트하므로(top-level
+        # 캐시 없음) 모듈 속성만 바꿔도 background_tasks.add_task가 이 fake를 받는다.
+        try:
+            from app.main import app
+            await _setup_app_human(app, Session, sender_user, org.id)
+            async with _client_for(app) as client:
+                send_resp = await client.post(
+                    f"/api/v2/conversations/{conv_id}/messages", json={"content": "webhook 배달 실증"},
+                )
+            app.dependency_overrides.clear()
+            assert send_resp.status_code == 201, send_resp.text
+        finally:
+            conversation_webhook_module.deliver_conversation_message_webhook = original_deliver
+
+        assert captured, "deliver_conversation_message_webhook이 호출 안 됨 — 테스트 배선 확認 필요"
+        target_member_ids = {t.member_id for t in captured[0]}
+        assert blocker_agent not in target_member_ids, "sender를 차단한 수신자의 webhook이 배달 대상에 남음"
+        assert other_agent in target_member_ids, "차단 안 한 agent까지 같이 빠짐(양성대조 실패)"
+    finally:
+        await engine.dispose()
+
+
+async def test_send_message_ws_chat_broadcast_excludes_blocker():
+    """ws_chat WebSocket 브로드캐스트(agent room에 msg.content 원문 실시간 전달)가 sender를
+    차단한 agent 수신자를 뺀다 — _rooms/_broadcast를 실 WebSocket 없이 in-process로 실증
+    (모듈 전역 dict·함수라 conversations.py의 지연 import가 같은 객체를 참조한다)."""
+    from unittest.mock import AsyncMock
+
+    from app.routers import ws_chat as ws_chat_module
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as session:
+            org = await _make_org(session)
+            project = await _make_project(session, org.id)
+            blocker_agent = await _make_agent_member(session, org.id, project.id)
+            other_agent = await _make_agent_member(session, org.id, project.id)
+            sender_id, sender_user = await _make_human_member(session, org.id, project.id)
+            conv_id = await _make_conversation(
+                session, org.id, project.id, [blocker_agent, other_agent, sender_id], sender_id,
+            )
+            from app.models.user_block import UserBlock
+            session.add(UserBlock(id=uuid.uuid4(), blocker_member_id=blocker_agent, blocked_member_id=sender_id))
+            await session.commit()
+
+        blocker_key, other_key = str(blocker_agent), str(other_agent)
+        ws_chat_module._rooms[blocker_key] = {object()}
+        ws_chat_module._rooms[other_key] = {object()}
+        original_broadcast = ws_chat_module._broadcast
+        ws_chat_module._broadcast = AsyncMock()
+        try:
+            from app.main import app
+            await _setup_app_human(app, Session, sender_user, org.id)
+            async with _client_for(app) as client:
+                send_resp = await client.post(
+                    f"/api/v2/conversations/{conv_id}/messages", json={"content": "ws 브로드캐스트 실증"},
+                )
+            app.dependency_overrides.clear()
+            assert send_resp.status_code == 201, send_resp.text
+
+            broadcast_targets = {call.args[0] for call in ws_chat_module._broadcast.call_args_list}
+            assert blocker_key not in broadcast_targets, "sender를 차단한 agent의 room에 WS 브로드캐스트가 감"
+            assert other_key in broadcast_targets, "차단 안 한 agent까지 같이 빠짐(양성대조 실패)"
+        finally:
+            ws_chat_module._broadcast = original_broadcast
+            ws_chat_module._rooms.pop(blocker_key, None)
+            ws_chat_module._rooms.pop(other_key, None)
     finally:
         await engine.dispose()

--- a/backend/tests/test_event1config_webhook_targets.py
+++ b/backend/tests/test_event1config_webhook_targets.py
@@ -55,7 +55,7 @@ async def test_sender_excluded_from_mentioned_finding2():
 
     targets = await resolve_conversation_webhook_targets(
         db, conversation_id=uuid.uuid4(), org_id=org, project_id=proj,
-        sender_id=sender, mentioned_ids=[sender, agent_a],
+        sender_id=sender, mentioned_ids=[sender, agent_a], blocker_member_ids=set(),
     )
     member_ids = {t.member_id for t in targets}
     assert sender not in member_ids, "sender self-mention 제외(Finding 2)"
@@ -79,7 +79,7 @@ async def test_mention_only_sender_yields_no_member_target():
 
     targets = await resolve_conversation_webhook_targets(
         db, conversation_id=uuid.uuid4(), org_id=org, project_id=proj,
-        sender_id=sender, mentioned_ids=[sender],
+        sender_id=sender, mentioned_ids=[sender], blocker_member_ids=set(),
     )
     assert {t.member_id for t in targets} == {None}, "broadcast 만 — sender member webhook 제외"
 
@@ -98,7 +98,7 @@ async def test_no_mention_uses_participants_minus_sender():
 
     targets = await resolve_conversation_webhook_targets(
         db, conversation_id=conv_id, org_id=org, project_id=proj,
-        sender_id=sender, mentioned_ids=None,
+        sender_id=sender, mentioned_ids=None, blocker_member_ids=set(),
     )
     assert {t.member_id for t in targets} == {agent_a}
 
@@ -192,7 +192,7 @@ async def test_resolve_predicate_realdb():
             try:
                 targets = await resolve_conversation_webhook_targets(
                     db, conversation_id=uuid.uuid4(), org_id=org, project_id=proj_x,
-                    sender_id=sender, mentioned_ids=[sender, agent_a],
+                    sender_id=sender, mentioned_ids=[sender, agent_a], blocker_member_ids=set(),
                 )
                 member_ids = {t.member_id for t in targets}
                 assert agent_a in member_ids, "타 프로젝트 member-bound 도 union 으로 covered(project 독립)"

--- a/backend/tests/test_event1config_webhook_targets.py
+++ b/backend/tests/test_event1config_webhook_targets.py
@@ -103,6 +103,29 @@ async def test_no_mention_uses_participants_minus_sender():
     assert {t.member_id for t in targets} == {agent_a}
 
 
+@pytest.mark.anyio
+async def test_blocker_member_ids_excludes_recipient_who_blocked_sender():
+    """story #2349 — 라이브 검증(2026-08-03)서 발견한 갭: sender를 차단한 수신자는 webhook 대상에서
+    빠져야 한다. caller(conversations.py)가 이미 계산한 user_blocker_ids를 그대로 받아 거른다 —
+    이 함수 안에서 새 쿼리를 추가하지 않는다(파라미터 미전달 시 기본 동작은 기존과 동일)."""
+    org, proj, conv_id, sender, blocker, agent_a = (uuid.uuid4() for _ in range(6))
+    wh_a = _wh(agent_a)
+
+    db = SimpleNamespace(execute=AsyncMock(side_effect=[
+        _scalars([blocker, agent_a]),  # participant query (sender 제외 — blocker·agent_a 참가)
+        _scalars([wh_a]),              # project-scope — blocker webhook은 애초에 대상 아님
+        _scalars([wh_a]),              # member-global union
+    ]))
+
+    targets = await resolve_conversation_webhook_targets(
+        db, conversation_id=conv_id, org_id=org, project_id=proj,
+        sender_id=sender, mentioned_ids=None, blocker_member_ids={blocker},
+    )
+    member_ids = {t.member_id for t in targets}
+    assert blocker not in member_ids, "sender를 차단한 수신자는 webhook 대상에서 제외"
+    assert agent_a in member_ids, "차단과 무관한 수신자는 그대로 대상"
+
+
 # ─── 실DB 전체 predicate (project 독립·sender 제외·broadcast) ──────────────────
 
 _ASYNCPG_URL = (


### PR DESCRIPTION
## 요약
#2817 후속. 라이브 재검증(2026-08-03, PO+디디, 스레드 7256d5cc)에서 실측으로 발견: `#2817`이 고친 `channel_router.py::route_message`는 discord-channel `WebhookConfig` 아웃바운드용이고, 실제 agent 게이트웨이 webhook 배달(`ConversationWebhookDelivery`)의 SSOT는 완전히 별개인 `conversation_webhook.py::resolve_conversation_webhook_targets`다 — 여기엔 `user_blocker_ids` exclusion이 한 번도 안 걸려 있었다.

이어서 카디르 QA가 `ws_chat` WebSocket 브로드캐스트(agent 참가자 room에 `msg.content` 원문 실시간 전달)도 필터가 아예 없는 것을 재발견, 뮤테이션 재실행으로 `①Event/SSE` 자리(표에 이름만 걸려 있고 실제로 `events` 테이블을 검산하는 테스트가 없었다)까지 드러나 각각 수정·보강했다.

## 접근 방식(PO 정정 반영)
`resolve_conversation_webhook_targets`는 값이 없던 게 아니라 `conversations.py::send_message`가 바로 옆에서 `user_blocker_ids`를 이미 계산해두고도 전달을 안 했던 것 — 함수 안에서 새로 `UserBlock`을 재조회하지 않고 `blocker_member_ids`를 **필수** 키워드 인자로 caller 값을 그대로 받는다(TOCTOU-safe 단일 snapshot 원칙 유지). `ws_chat` 브로드캐스트도 같은 원칙(caller가 이미 계산한 `user_blocker_ids` 재사용, 새 쿼리 없음).

## send_message 배달 경로 전수표(저장소 축, 2026-08-03 최종)
| # | 경로 | 저장소 | 검산 테스트 |
|---|---|---|---|
| ① | Event/SSE | `events` 테이블 | `test_blocker_gets_no_notification_for_blocked_sender_plain_message` / `_mention`(둘 다 `events` 직접 쿼리) |
| ② | webhook targets | `conversation_webhook_deliveries` | `test_send_message_webhook_delivery_excludes_blocker` |
| ③ | 인앱 알림 | `notifications` | `test_blocker_gets_no_notification_for_blocked_sender_plain_message` |
| ④ | ws 브로드캐스트 | **테이블 없음**(순수 인메모리 WS) | `test_send_message_ws_chat_broadcast_excludes_blocker` |

- `inbox_items`는 표에서 제외 — `InboxItem` 생성자 호출이 코드베이스 전체 0건(에이전트 의사결정용 별개 기능, grep 확認).
- `event_outbox`(`event_broker` 경유)도 gap 아님 — `conversations.py` 직접 참조 0건, `_push_to_agent`의 per-member 전송 트랜스포트일 뿐 별도 recipient 계산 없음.
- ⚠️「저장소 축(DB를 훑는 법)」은 ④를 원리상 못 본다(DB row를 안 남김) — ④는 「코드 축(호출 그래프)」으로만 보인다. 두 축이 서로의 사각을 덮는다.
- ⚠️`events=0`을 「차단이 먹었다」로 읽지 말 것 — 수신자가 webhook 커버면 SSE는 skip되어(E-EVENT-1CONFIG) `events`는 원래 0이다. 라이브 재검증 1차의 오판이 정확히 이 오독이었다(실측: dev DB에서 차단 中 발송 두 건 모두 `events=0`·`webhook_deliveries=1`).

## 알려진 미검증 지점(블로커 아님, 카디르 전수 확認)
`deliver_conversation_message_webhook`의 `targets is None` 폴백 분기(자체 `UserBlock` 재조회) — 호출자 전수 확認 결과 `conversations.py:2267`은 항상 `targets`를 미리 산출해 넘기고, `a2a.py:716`은 `sender_id=None`이라 이 분기의 `if sender_id:` 가드에 막힌다. 즉 **이 분기는 지금 어떤 호출자도 안 타는 죽은 방어 코드**다. 정당성(방어적 fail-open 패턴)은 서 있으나 실행 경로로 검증되지는 않았다 — 명시해둔다.

## 검증
- realdb 스위트(`test_2349_user_blocks_realdb.py`) 18 pass(로컬 pg@16, alembic head=0225로 직접 검증 — 웹훅 배달 SSOT·ws 브로드캐스트·Event/SSE 세 지점 모두 실 HTTP POST + 실 PG로 재현)
- 관련 mock 스위트(conversation·webhook·2349·event1config·channel_router·ws_chat·2216 매치) 215 pass, 89 skip(로컬 PG 미가동인 별도 파일 — 위 realdb 스위트가 실질적으로 커버), 회귀 없음
- **뮤테이션 검증**: 이번 PR이 새로 배선한 4개 지점(webhook targets 필터·ws_chat 필터·Event/SSE exclude_ids·mention_targets exclude_ids) 각각 개별 sabotage → 매번 정확히 그 지점을 검산하는 테스트 1건만 RED(나머지 17건 무영향) → 복원 → 전체 18 pass 재확認(카디르 QA가 독립적으로 재실행, 디디가 이 PR 작업 중에도 재현)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
