### PR TITLE
feat(E-CONNECT-PKG S1): sprintable-connectors 패키지 1단계 — codex, repo-clone 없이 실측 완료

### DIFF
--- a/connectors/connectors-pkg/README.md
+++ b/connectors/connectors-pkg/README.md
@@ -1,25 +1,71 @@
-# sprintable-connectors (작업용, 1단계 완료)
+# sprintable-connectors
 
-"레포 클론 없이 pip 설치 → 실행 → SSE 연결"이 실제로 서는지 검증하는 1단계. 5종 전부 등록
-(codex·cursor·gemini·grok·pi). 이름·PyPI 등록·최종 사용자 안내문은 아직 확定하지 않았다(배포
-수단은 형태가 실측으로 선 뒤 정한다).
+Sprintable Gateway 에이전트 커넥터(codex·cursor·gemini·grok·pi) — **레포 클론 없이** 설치·실행.
 
-## 로컬 검증
+기존 `connectors/*-sprintable/README.md`들은 설치 첫 줄이 `git pull origin develop`이라 BYOA
+SaaS 사용자(우리 레포를 clone할 이유가 없는 사람)를 온보딩 완료화면에서 막았다. 이 패키지가
+그 경계를 없앤다 — 필요한 건 wheel 하나(추후 PyPI 배포)뿐이다.
+
+## 설치 — 레포 없이
+
+> ⚠️ **PyPI publish는 아직 안 했다**(이름 등록은 되돌릴 수 없어 확認 대기 중). 배포 전 검증은
+> 아래 "로컬/QA 검증"으로 한다 — 이때도 **레포 clone은 필요 없다**, wheel 파일 하나면 된다.
+
+배포 후(예정):
+```bash
+pip install sprintable-connectors      # 또는: uvx --from sprintable-connectors sprintable-connector
+```
+
+## 실행
 
 ```bash
-uv venv /tmp/venv-sprintable-connectors
-source /tmp/venv-sprintable-connectors/bin/activate
-uv pip install ./connectors/connectors-pkg   # 레포 안에서, 레포 클론 흉내
+export SPRINTABLE_RUNTIME=codex        # codex | cursor | gemini | grok | pi 중 하나 — 필수
+export AGENT_API_KEY=sk_live_...       # Sprintable agent API key — 필수
+export SPRINTABLE_API_URL=https://...  # 미설정 시 dev 백엔드 기본값
+# 런타임별 추가 요구사항(해당 CLI/서비스는 BYOA 사용자가 이미 보유):
+#   codex   → codex CLI 설치(`codex --version`), 선택 CODEX_BIN
+#   gemini  → gemini-cli 설치(`gemini --version`), 선택 GEMINI_BIN
+#   grok    → Grok Build CLI 설치(`grok --version`), 선택 GROK_BIN
+#   pi      → pi CLI 설치(`pi --version`), 선택 PI_BIN
+#   cursor  → CURSOR_API_KEY(Cursor 클라우드), 선택 CURSOR_REPO_URL/CURSOR_API_BASE
 
-export SPRINTABLE_RUNTIME=codex   # 또는 cursor / gemini / grok / pi
-export AGENT_API_KEY=sk_live_...
-export SPRINTABLE_API_URL=https://sprintable-backend-dev-57iommnikq-du.a.run.app
-# cursor는 CURSOR_API_KEY도 필요(플레이스홀더로도 SSE 연결 자체는 확認 가능 — 실 턴 주입 시에만 쓰임)
 sprintable-connector
 ```
 
-`stream open` 로그가 뜨면 SSE dial-out 성공 — repo 밖(별도 venv, git repo 아닌 디렉터리)에서
-이 패키지만으로 붙는지가 판정선이다. codex·cursor는 실측 완료(HTTP 200 stream open).
-gemini·grok·pi는 이 저장소 개발 환경에 해당 CLI 바이너리가 없어 SSE 연결 전 단계
-(subprocess spawn, `FileNotFoundError`)에서 멈춘다 — 원본 커넥터도 동일 전제이며 패키징
-결함이 아님을 실패 지점으로 확認했다. 해당 CLI가 설치된 환경에서 추가 검증 필요.
+`SPRINTABLE_RUNTIME`은 auto-detect하지 않는다 — 명시 선택만 받는다. 값을 비우거나 오타(예:
+`codx`)를 내면 즉시 에러로 종료한다(조용히 기본값으로 넘어가지 않음, 실측 확認됨):
+
+```
+$ SPRINTABLE_RUNTIME=codx sprintable-connector
+Error: unknown SPRINTABLE_RUNTIME='codx'.
+  Available: codex, cursor, gemini, grok, pi
+```
+
+## 로컬/QA 검증 (레포 clone 없이, wheel만으로)
+
+```bash
+uv build ./connectors/connectors-pkg              # wheel 산출(개발자 쪽, 1회)
+# --- 아래부터는 wheel 파일 하나만 있으면 되는 부분(QA/최종 사용자 재현 경로) ---
+uv venv /tmp/venv-sprintable-connectors
+uv pip install --python /tmp/venv-sprintable-connectors/bin/python \
+    /path/to/sprintable_connectors-*.whl
+cd /tmp/some/empty/dir                            # git repo 아닌 곳 — 판정선
+export SPRINTABLE_RUNTIME=codex AGENT_API_KEY=sk_live_... SPRINTABLE_API_URL=https://...
+/tmp/venv-sprintable-connectors/bin/sprintable-connector
+```
+
+`stream open`(HTTP 200) 로그가 뜨면 성공. `codex`·`cursor`는 이 절차로 실측 완료(`cursor`는
+`CURSOR_API_KEY`에 아무 non-empty 값이나 있으면 됨 — 그 값이 비어 있으면 `main()`이
+`SprintableSSEClient`를 만들기 *전에* 조기 종료한다(`cursor.py` L203-204). 실제 검증엔
+**플레이스홀더**를 썼다 — Sprintable 게이트웨이 SSE 연결은 진짜지만, 그 키로 실제 turn을
+주입하면 Cursor Cloud API(`api.cursor.com`)가 401을 낸다 — 그 라운드트립은 별도 검증 필요).
+`gemini`·`grok`·`pi`는 해당 CLI가 설치된 환경에서 마저 확認 필요(이 개발 환경엔 그 CLI들이 없어
+`FileNotFoundError`로 멈춘다 — `ImportError`가 아니므로 패키징 결함이 아니라 CLI 부재임을
+구별할 수 있다. 원본 커넥터 README도 동일 전제).
+
+## 구조
+
+- `sprintable_connectors/sdk.py` — SSE 소비·dedup·ack·backoff 공통부(정본, vendor 복제 없음)
+- `sprintable_connectors/{codex,cursor,gemini,grok,pi}.py` — 런타임별 injection(프로토콜 로직은
+  각 원본 커넥터와 byte-identical, 유일한 차이는 SDK를 패키지 상대 import로 받는 것뿐)
+- `sprintable_connectors/__main__.py` — `SPRINTABLE_RUNTIME` 기반 진입점 선택

--- a/connectors/connectors-pkg/README.md
+++ b/connectors/connectors-pkg/README.md
@@ -1,0 +1,20 @@
+# sprintable-connectors (작업용, 1단계)
+
+Stage 1 — `codex` 슬라이스 하나만 담아 "레포 클론 없이 pip 설치 → 실행 → SSE 연결"이 실제로
+서는지 검증하는 단계. 이름·PyPI 등록·최종 사용자 안내문은 이 단계가 선 뒤 확定한다.
+
+## 로컬 검증
+
+```bash
+uv venv /tmp/venv-sprintable-connectors
+source /tmp/venv-sprintable-connectors/bin/activate
+uv pip install ./connectors/connectors-pkg   # 레포 안에서, 레포 클론 흉내
+
+export SPRINTABLE_RUNTIME=codex
+export AGENT_API_KEY=sk_live_...
+export SPRINTABLE_API_URL=https://sprintable-backend-dev-57iommnikq-du.a.run.app
+sprintable-connector
+```
+
+`stream open` 로그가 뜨면 SSE dial-out 성공 — repo 밖(별도 venv)에서 이 패키지만으로 붙는지가
+1단계의 판정선이다.

--- a/connectors/connectors-pkg/README.md
+++ b/connectors/connectors-pkg/README.md
@@ -1,7 +1,8 @@
-# sprintable-connectors (작업용, 1단계)
+# sprintable-connectors (작업용, 1단계 완료)
 
-Stage 1 — `codex` 슬라이스 하나만 담아 "레포 클론 없이 pip 설치 → 실행 → SSE 연결"이 실제로
-서는지 검증하는 단계. 이름·PyPI 등록·최종 사용자 안내문은 이 단계가 선 뒤 확定한다.
+"레포 클론 없이 pip 설치 → 실행 → SSE 연결"이 실제로 서는지 검증하는 1단계. 5종 전부 등록
+(codex·cursor·gemini·grok·pi). 이름·PyPI 등록·최종 사용자 안내문은 아직 확定하지 않았다(배포
+수단은 형태가 실측으로 선 뒤 정한다).
 
 ## 로컬 검증
 
@@ -10,11 +11,15 @@ uv venv /tmp/venv-sprintable-connectors
 source /tmp/venv-sprintable-connectors/bin/activate
 uv pip install ./connectors/connectors-pkg   # 레포 안에서, 레포 클론 흉내
 
-export SPRINTABLE_RUNTIME=codex
+export SPRINTABLE_RUNTIME=codex   # 또는 cursor / gemini / grok / pi
 export AGENT_API_KEY=sk_live_...
 export SPRINTABLE_API_URL=https://sprintable-backend-dev-57iommnikq-du.a.run.app
+# cursor는 CURSOR_API_KEY도 필요(플레이스홀더로도 SSE 연결 자체는 확認 가능 — 실 턴 주입 시에만 쓰임)
 sprintable-connector
 ```
 
-`stream open` 로그가 뜨면 SSE dial-out 성공 — repo 밖(별도 venv)에서 이 패키지만으로 붙는지가
-1단계의 판정선이다.
+`stream open` 로그가 뜨면 SSE dial-out 성공 — repo 밖(별도 venv, git repo 아닌 디렉터리)에서
+이 패키지만으로 붙는지가 판정선이다. codex·cursor는 실측 완료(HTTP 200 stream open).
+gemini·grok·pi는 이 저장소 개발 환경에 해당 CLI 바이너리가 없어 SSE 연결 전 단계
+(subprocess spawn, `FileNotFoundError`)에서 멈춘다 — 원본 커넥터도 동일 전제이며 패키징
+결함이 아님을 실패 지점으로 확認했다. 해당 CLI가 설치된 환경에서 추가 검증 필요.

--- a/connectors/connectors-pkg/pyproject.toml
+++ b/connectors/connectors-pkg/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+# E-CONNECT-PKG S1(2026-08-03): 배포 단위 이름·PyPI 등록은 아직 미확定(페드루 지시 — 1단계가
+# 실측으로 서기 전엔 정하지 않는다, uvx 실수 재발 방지). "sprintable-connectors"는 작업용 임시명.
+name = "sprintable-connectors"
+version = "0.0.1"
+description = "Sprintable Gateway agent connectors (codex/gemini/grok/pi/cursor) — no repo clone required."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "Proprietary" }
+authors = [{ name = "Sprintable" }]
+keywords = ["sprintable", "agent", "gateway", "sse"]
+dependencies = [
+    "httpx>=0.27",
+]
+
+[project.scripts]
+sprintable-connector = "sprintable_connectors.__main__:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["sprintable_connectors"]

--- a/connectors/connectors-pkg/pyproject.toml
+++ b/connectors/connectors-pkg/pyproject.toml
@@ -3,8 +3,13 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-# E-CONNECT-PKG S1(2026-08-03): 배포 단위 이름·PyPI 등록은 아직 미확定(페드루 지시 — 1단계가
-# 실측으로 서기 전엔 정하지 않는다, uvx 실수 재발 방지). "sprintable-connectors"는 작업용 임시명.
+# E-CONNECT-PKG S1(2026-08-03): 배포 수단은 PyPI로 정해졌다(기존 sprintable_mcp 파이프라인
+# 재사용 — .github/workflows/publish-mcp.yml, sprintable 0.1.2 실물). 다만 «실제 publish는
+# 아직»(페드루 지시) — PyPI 이름 등록은 되돌릴 수 없어 선생님 확認 뒤. 지금은 "빌드되는 상태"
+# 까지만. 이 `name`("sprintable-connectors")은 후보들 중 하나일 뿐 미확定 — 다른 후보:
+#   sprintable-agent-connectors / sprintable-connect / sprintable-runtime-bridge
+# 어느 것을 쓰든 [project.scripts] 진입점 이름(`sprintable-connector`)과 무관하게 바꿀 수 있다
+# (sprintable_mcp가 dist명="sprintable"≠모듈명=sprintable_mcp로 이미 분리해 둔 선례와 동형).
 name = "sprintable-connectors"
 version = "0.0.1"
 description = "Sprintable Gateway agent connectors (codex/gemini/grok/pi/cursor) — no repo clone required."
@@ -12,13 +17,22 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "Proprietary" }
 authors = [{ name = "Sprintable" }]
-keywords = ["sprintable", "agent", "gateway", "sse"]
+keywords = ["sprintable", "agent", "gateway", "sse", "byoa"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Operating System :: OS Independent",
+    "Intended Audience :: Developers",
+]
 dependencies = [
     "httpx>=0.27",
 ]
 
 [project.scripts]
 sprintable-connector = "sprintable_connectors.__main__:main"
+
+[project.urls]
+Homepage = "https://sprintable.ai"
 
 [tool.hatch.build.targets.wheel]
 packages = ["sprintable_connectors"]

--- a/connectors/connectors-pkg/sprintable_connectors/__init__.py
+++ b/connectors/connectors-pkg/sprintable_connectors/__init__.py
@@ -4,7 +4,16 @@ E-CONNECT-PKG S1(2026-08-03): 5개 자식-프로세스/사이드카 커넥터(co
 한 pip 패키지에 담는다. SDK는 이 패키지 안에 정본 하나(`sprintable_connectors.sdk`) — vendor 복제
 없음. 런타임 선택은 `SPRINTABLE_RUNTIME` env 하나(auto-detect 안 함, `__main__.py` 참조).
 
-⚠️Stage 1(현재)은 codex 슬라이스 하나만 담는다 — "1이 서는지" 먼저 확認 후 나머지 4개(gemini·
-grok·pi·cursor)를 같은 틀로 얹는다(페드루 지시, 스레드 7256d5cc). hermes×2(호스트 플러그인 —
-자체 배포 모델)·openclaw/opencode(ts, 별도 npm)는 이 패키지의 대상이 아니다(구조상 제외 확認됨).
+Stage 1(2026-08-03) 완료 — 5종 전부 등록: codex·cursor(1차)·gemini·grok·pi(2차, cursor 먼저
+검증 후 나머지). 각 모듈은 원본(connectors/*-sprintable/*.py)의 프로토콜 로직과 byte-identical
+(diff 확認 완료) — 유일한 변경은 sys.path 상대깊이 해킹 → 패키지 상대 import(`.sdk`).
+hermes×2(호스트 플러그인 — 자체 배포 모델)·openclaw/opencode(ts, 별도 npm)는 이 패키지의
+대상이 아니다(구조상 제외 확認됨, 페드루 지시, 스레드 7256d5cc).
+
+실측(레포 밖 완전히 빈 디렉터리, 새 venv, wheel만 설치):
+  codex·cursor — 실 AGENT_API_KEY로 SSE dial-out "stream open" 확認(HTTP 200)
+  gemini·grok·pi — 패키지 import·SPRINTABLE_RUNTIME 라우팅까지 정상, 이후 각자 CLI 바이너리
+    (gemini/grok/pi) 부재로 FileNotFoundError — 이 환경에 해당 CLI가 없어 발생하는 예상된
+    실패이며 원본 커넥터도 동일 전제(README "◯◯-cli 설치 필수"). 패키징/import 결함 아님을
+    정확한 실패 지점(subprocess spawn, ImportError 아님)으로 확認.
 """

--- a/connectors/connectors-pkg/sprintable_connectors/__init__.py
+++ b/connectors/connectors-pkg/sprintable_connectors/__init__.py
@@ -1,0 +1,10 @@
+"""Sprintable Gateway agent connectors — single deployable unit.
+
+E-CONNECT-PKG S1(2026-08-03): 5개 자식-프로세스/사이드카 커넥터(codex·gemini·grok·pi·cursor)를
+한 pip 패키지에 담는다. SDK는 이 패키지 안에 정본 하나(`sprintable_connectors.sdk`) — vendor 복제
+없음. 런타임 선택은 `SPRINTABLE_RUNTIME` env 하나(auto-detect 안 함, `__main__.py` 참조).
+
+⚠️Stage 1(현재)은 codex 슬라이스 하나만 담는다 — "1이 서는지" 먼저 확認 후 나머지 4개(gemini·
+grok·pi·cursor)를 같은 틀로 얹는다(페드루 지시, 스레드 7256d5cc). hermes×2(호스트 플러그인 —
+자체 배포 모델)·openclaw/opencode(ts, 별도 npm)는 이 패키지의 대상이 아니다(구조상 제외 확認됨).
+"""

--- a/connectors/connectors-pkg/sprintable_connectors/__main__.py
+++ b/connectors/connectors-pkg/sprintable_connectors/__main__.py
@@ -1,0 +1,54 @@
+"""python -m sprintable_connectors — SPRINTABLE_RUNTIME 선택형 진입점.
+
+auto-detect 안 함(2026-08-03 조사 결론 — 같은 머신에 여러 CLI가 공존해도 사용자가 이미
+어느 host.py를 실행할지로 명시 선택하던 것과 동형, 자동감지는 과설계).
+
+Stage 1: "codex"만 등록. gemini·grok·pi·cursor는 이 딕셔너리에 같은 방식으로 추가될 예정
+(각자 모듈의 `main()` 코루틴만 등록 — 프로토콜 로직은 계열별로 그대로 둔다, 4계열 반증 결론).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+_RUNTIMES: dict[str, str] = {
+    "codex": "sprintable_connectors.codex",
+}
+
+
+def _resolve_main(runtime: str):
+    import importlib
+
+    module_path = _RUNTIMES[runtime]
+    module = importlib.import_module(module_path)
+    return module.main
+
+
+def main() -> None:
+    runtime = (os.getenv("SPRINTABLE_RUNTIME") or "").strip().lower()
+    if not runtime:
+        print(
+            "Error: SPRINTABLE_RUNTIME environment variable required.\n"
+            f"  Available: {', '.join(sorted(_RUNTIMES))}\n"
+            "  Example: export SPRINTABLE_RUNTIME=codex",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if runtime not in _RUNTIMES:
+        print(
+            f"Error: unknown SPRINTABLE_RUNTIME={runtime!r}.\n"
+            f"  Available: {', '.join(sorted(_RUNTIMES))}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    runtime_main = _resolve_main(runtime)
+    try:
+        asyncio.run(runtime_main())
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/connectors/connectors-pkg/sprintable_connectors/__main__.py
+++ b/connectors/connectors-pkg/sprintable_connectors/__main__.py
@@ -3,8 +3,9 @@
 auto-detect 안 함(2026-08-03 조사 결론 — 같은 머신에 여러 CLI가 공존해도 사용자가 이미
 어느 host.py를 실행할지로 명시 선택하던 것과 동형, 자동감지는 과설계).
 
-Stage 1: "codex"만 등록. gemini·grok·pi·cursor는 이 딕셔너리에 같은 방식으로 추가될 예정
-(각자 모듈의 `main()` 코루틴만 등록 — 프로토콜 로직은 계열별로 그대로 둔다, 4계열 반증 결론).
+Stage 1(2026-08-03) — 5종 전부 등록 완료: codex·cursor·gemini·grok·pi. 각자 모듈의 `main()`
+코루틴만 등록 — 프로토콜 로직은 계열별로 그대로 둔다(4계열 반증 결론, 원본과 byte-identical
+diff 확認 완료).
 """
 from __future__ import annotations
 
@@ -14,6 +15,10 @@ import sys
 
 _RUNTIMES: dict[str, str] = {
     "codex": "sprintable_connectors.codex",
+    "cursor": "sprintable_connectors.cursor",
+    "gemini": "sprintable_connectors.gemini",
+    "grok": "sprintable_connectors.grok",
+    "pi": "sprintable_connectors.pi",
 }
 
 

--- a/connectors/connectors-pkg/sprintable_connectors/codex.py
+++ b/connectors/connectors-pkg/sprintable_connectors/codex.py
@@ -1,0 +1,220 @@
+"""Sprintable Gateway adapter host for Codex — E-INJECT-ADAPTERS (카테고리 B).
+
+카테고리 B 첫 어댑터 — stdio JSON-RPC 자식 프로세스 호스트 패턴 확립.
+gemini/pi/grok이 이 패턴을 동형으로 따라간다.
+
+구조:
+  - 공통 SDK(sprintable_connectors.sdk) 재사용 — SSE 소비·dedup·ack·backoff
+  - codex app-server (JSON-RPC/stdio)를 spawn/own
+  - SSE 이벤트마다 thread/start(최초) + turn/start로 turn 주입
+  - item/completed(agentMessage) 스트림 수집 → turn/completed에서 응답 확정
+  - 응답 → ctx.reply() → POST /api/v2/conversations/{id}/messages
+
+실측 프로토콜 (codex app-server generate-ts, codex-cli 0.124.0):
+  initialize → initialized(notify) → thread/start → turn/start
+  ServerNotification: item/completed {item:{type:"agentMessage",text}}, turn/completed
+
+connectors/codex-sprintable/host.py와 프로토콜 로직(CodexAppServer 본문)은 동일 — 유일한 차이는
+`sys.path` 상대깊이 해킹 대신 패키지 상대 import(`.sdk`)를 쓴다는 것뿐(E-CONNECT-PKG S1).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+
+from .sdk import MessageContext, SprintableSSEClient
+
+logger = logging.getLogger("codex-sprintable")
+
+CODEX_BIN = os.getenv("CODEX_BIN", "codex")
+DEFAULT_API_URL = "https://sprintable-backend-dev-57iommnikq-du.a.run.app"
+
+
+class CodexAppServer:
+    """codex app-server JSON-RPC/stdio 자식 프로세스 호스트.
+
+    한 번 spawn해서 lifetime 동안 own. AbortSignal/shutdown 시 SIGTERM.
+    """
+
+    def __init__(self, cwd: str | None = None) -> None:
+        self._cwd = cwd or os.getcwd()
+        self._proc: asyncio.subprocess.Process | None = None
+        self._req_id = 0
+        self._pending: dict[int, asyncio.Future] = {}
+        # turn 응답 수집: turn 진행 중 agentMessage 텍스트 누적
+        self._turn_messages: list[str] = []
+        self._turn_done: asyncio.Event | None = None
+        self._reader_task: asyncio.Task | None = None
+        self._thread_id: str | None = None
+
+    async def start(self) -> None:
+        """codex app-server spawn + initialize 핸드셰이크."""
+        self._proc = await asyncio.create_subprocess_exec(
+            CODEX_BIN, "app-server",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self._cwd,
+        )
+        self._reader_task = asyncio.create_task(self._read_loop())
+
+        # initialize 핸드셰이크
+        await self._request("initialize", {
+            "clientInfo": {
+                "name": "sprintable-codex-adapter",
+                "title": "Sprintable Gateway",
+                "version": "0.1.0",
+            },
+            "capabilities": None,
+        })
+        await self._notify("initialized", None)
+        logger.info("codex app-server initialized")
+
+    async def _read_loop(self) -> None:
+        """stdout JSON-RPC 라인 파싱 → response 매칭 + notification 처리."""
+        assert self._proc and self._proc.stdout
+        while True:
+            line = await self._proc.stdout.readline()
+            if not line:
+                break
+            try:
+                msg = json.loads(line.decode("utf-8"))
+            except json.JSONDecodeError:
+                continue
+            # response (id 있음 + result/error)
+            if "id" in msg and ("result" in msg or "error" in msg):
+                fut = self._pending.pop(msg["id"], None)
+                if fut and not fut.done():
+                    if "error" in msg:
+                        fut.set_exception(RuntimeError(str(msg["error"])))
+                    else:
+                        fut.set_result(msg.get("result"))
+                continue
+            # notification (method 있음, id 없음)
+            method = msg.get("method")
+            if method:
+                self._on_notification(method, msg.get("params") or {})
+
+    def _on_notification(self, method: str, params: dict) -> None:
+        """ServerNotification 처리 — turn 응답 수집."""
+        if method == "item/completed":
+            item = params.get("item") or {}
+            if item.get("type") == "agentMessage":
+                text = item.get("text", "")
+                if text:
+                    self._turn_messages.append(text)
+        elif method == "turn/completed":
+            if self._turn_done and not self._turn_done.is_set():
+                self._turn_done.set()
+        elif method == "error":
+            logger.warning("codex error notification: %s", params)
+            if self._turn_done and not self._turn_done.is_set():
+                self._turn_done.set()
+
+    async def _request(self, method: str, params: dict | None) -> dict:
+        """JSON-RPC request 송신 + response 대기."""
+        assert self._proc and self._proc.stdin
+        self._req_id += 1
+        rid = self._req_id
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._pending[rid] = fut
+        payload = {"jsonrpc": "2.0", "id": rid, "method": method}
+        if params is not None:
+            payload["params"] = params
+        self._proc.stdin.write((json.dumps(payload) + "\n").encode("utf-8"))
+        await self._proc.stdin.drain()
+        return await fut
+
+    async def _notify(self, method: str, params: dict | None) -> None:
+        """JSON-RPC notification 송신 (response 없음)."""
+        assert self._proc and self._proc.stdin
+        payload = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            payload["params"] = params
+        self._proc.stdin.write((json.dumps(payload) + "\n").encode("utf-8"))
+        await self._proc.stdin.drain()
+
+    async def ensure_thread(self) -> str:
+        """thread/start (최초 1회) → thread_id 캐시."""
+        if self._thread_id:
+            return self._thread_id
+        result = await self._request("thread/start", {
+            "experimentalRawEvents": False,
+            "persistExtendedHistory": False,
+        })
+        thread = result.get("thread") or {}
+        self._thread_id = thread.get("id")
+        if not self._thread_id:
+            raise RuntimeError(f"thread/start returned no id: {result}")
+        logger.info("codex thread started: %s", self._thread_id)
+        return self._thread_id
+
+    async def run_turn(self, text: str) -> str:
+        """turn/start로 주입 → turn/completed까지 agentMessage 수집 → 응답 반환."""
+        thread_id = await self.ensure_thread()
+        self._turn_messages = []
+        self._turn_done = asyncio.Event()
+
+        await self._request("turn/start", {
+            "threadId": thread_id,
+            "input": [{"type": "text", "text": text, "text_elements": []}],
+        })
+        # turn/completed 대기 (응답 스트림 수집 완료)
+        await self._turn_done.wait()
+        return "\n".join(self._turn_messages).strip()
+
+    async def stop(self) -> None:
+        """자식 프로세스 graceful 종료 (SIGTERM → kill)."""
+        if self._reader_task:
+            self._reader_task.cancel()
+        if self._proc and self._proc.returncode is None:
+            try:
+                self._proc.terminate()
+                await asyncio.wait_for(self._proc.wait(), timeout=5.0)
+            except (asyncio.TimeoutError, ProcessLookupError):
+                try:
+                    self._proc.kill()
+                except ProcessLookupError:
+                    pass
+
+
+async def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[codex-sprintable] %(levelname)s %(message)s",
+        stream=sys.stderr,
+    )
+    api_url = (os.getenv("SPRINTABLE_API_URL", DEFAULT_API_URL) or DEFAULT_API_URL).rstrip("/")
+    api_key = os.getenv("SPRINTABLE_API_KEY") or os.getenv("AGENT_API_KEY") or ""
+    if not api_key:
+        logger.error("SPRINTABLE_API_KEY or AGENT_API_KEY not set — host disabled")
+        return
+
+    codex = CodexAppServer()
+    await codex.start()
+
+    sse = SprintableSSEClient(api_url=api_url, api_key=api_key)
+
+    async def inject(ctx: MessageContext) -> None:
+        try:
+            response = await codex.run_turn(ctx.content)
+        except Exception as exc:
+            logger.warning("turn error conv=%s: %s", ctx.conversation_id, exc)
+            return
+        if response:
+            await ctx.reply(response)
+
+    try:
+        await sse.run(inject)
+    finally:
+        await codex.stop()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/connectors/connectors-pkg/sprintable_connectors/cursor.py
+++ b/connectors/connectors-pkg/sprintable_connectors/cursor.py
@@ -1,0 +1,231 @@
+"""Sprintable Gateway adapter sidecar for Cursor — E-INJECT-ADAPTERS (카테고리 C).
+
+마지막·유일 카테고리 C — **자식 프로세스 없음**. Cursor Cloud Agents API HTTP 호출.
+B(stdio 자식 프로세스 lifetime)와 달리 **run 상태 관리**가 핵심.
+
+구조:
+  - 공통 SDK(sprintable_connectors.sdk) 재사용 — SSE 소비·dedup·ack·backoff (A/B 동일)
+  - 주입 = HTTP POST (spawn 없음):
+    - conversation 첫 메시지 → POST /v1/agents (launch) → {agent.id, run.id}
+    - 이후 메시지 → POST /v1/agents/{id}/runs (followup) → {run.id}
+  - 응답 = GET /v1/agents/{id}/runs/{runId}/stream (Cursor SSE) 수집 → assistant/result 텍스트
+  - 응답 → ctx.reply() → POST /api/v2/conversations/{id}/messages
+
+**1-active-run 가드 (C 핵심):** run당 1개만 active(409 agent_busy).
+  SDK가 onMessage를 순차 await하므로 한 turn의 stream 완료 전 다음 SSE 이벤트 미처리 →
+  자연 직렬화. 추가로 launch/followup 409 시 완료 폴링 후 재시도.
+
+⚠️ 로컬 Cursor 에디터 세션은 외부 주입 경로 없음 → **클라우드 에이전트 한정**.
+
+실측 API (docs.cursor.com/cloud-agent, api.cursor.com, /v1):
+  POST /v1/agents {prompt:{text}, repos?} → {agent:{id}, run:{id}}
+  POST /v1/agents/{id}/runs {prompt:{text}} → {run:{id, status}}
+  GET  /v1/agents/{id}/runs/{runId}/stream → SSE: assistant{text}, result{text}, done
+  status: CREATING/RUNNING/FINISHED/ERROR/CANCELLED/EXPIRED
+  409 agent_busy: run 1개만 active
+
+connectors/cursor-sprintable/sidecar.py와 프로토콜 로직(CursorCloudClient 본문)은 동일 — 유일한
+차이는 `sys.path` 상대깊이 해킹 대신 패키지 상대 import(`.sdk`)를 쓴다는 것뿐(E-CONNECT-PKG S1).
+넷 중 가장 형태가 안 맞는 계열(자식 프로세스 없음·HTTP cloud·run-state 관리)이라 먼저 검증한다
+(페드루 지시 — 여기서 깨지면 일찍 안다).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+
+import httpx
+
+from .sdk import MessageContext, SprintableSSEClient
+
+logger = logging.getLogger("cursor-sprintable")
+
+CURSOR_API_BASE = os.getenv("CURSOR_API_BASE", "https://api.cursor.com").rstrip("/")
+CURSOR_API_KEY = os.getenv("CURSOR_API_KEY", "")
+# Cursor 클라우드 에이전트는 repo 기반 — 선택 env (미설정 시 launch body에서 생략)
+CURSOR_REPO_URL = os.getenv("CURSOR_REPO_URL", "")
+DEFAULT_API_URL = "https://sprintable-backend-dev-57iommnikq-du.a.run.app"
+_ACTIVE = {"CREATING", "RUNNING"}
+_TERMINAL = {"FINISHED", "ERROR", "CANCELLED", "EXPIRED"}
+
+
+class CursorCloudClient:
+    """Cursor Cloud Agents API HTTP 클라이언트.
+
+    conversation_id → cursor agent_id 매핑으로 stateful 에이전트 유지.
+    자식 프로세스 없음 — run 상태 관리로 1-active-run 직렬화.
+    """
+
+    def __init__(self) -> None:
+        self._http: httpx.AsyncClient | None = None
+        # conversation_id → cursor agent_id
+        self._agents: dict[str, str] = {}
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {CURSOR_API_KEY}",
+            "Content-Type": "application/json",
+        }
+
+    async def start(self) -> None:
+        self._http = httpx.AsyncClient(timeout=None)
+        logger.info("cursor cloud client ready (base=%s)", CURSOR_API_BASE)
+
+    async def _launch(self, text: str) -> tuple[str, str]:
+        """POST /v1/agents — 첫 turn (agent 생성). → (agent_id, run_id)."""
+        body: dict = {"prompt": {"text": text}}
+        if CURSOR_REPO_URL:
+            body["repos"] = [{"url": CURSOR_REPO_URL}]
+        resp = await self._http.post(
+            f"{CURSOR_API_BASE}/v1/agents", headers=self._headers(), json=body, timeout=30.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        agent_id = (data.get("agent") or {}).get("id")
+        run_id = (data.get("run") or {}).get("id")
+        if not agent_id or not run_id:
+            raise RuntimeError(f"launch returned no agent/run id: {data}")
+        return agent_id, run_id
+
+    async def _followup(self, agent_id: str, text: str) -> str:
+        """POST /v1/agents/{id}/runs — 이후 turn. → run_id. 409 시 완료 대기 후 재시도."""
+        for attempt in range(6):
+            resp = await self._http.post(
+                f"{CURSOR_API_BASE}/v1/agents/{agent_id}/runs",
+                headers=self._headers(), json={"prompt": {"text": text}}, timeout=30.0,
+            )
+            if resp.status_code == 409:
+                # agent_busy — 이전 run 완료 대기 후 재시도
+                logger.info("agent_busy (attempt %d) — waiting for active run", attempt + 1)
+                await self._wait_idle(agent_id)
+                continue
+            resp.raise_for_status()
+            run_id = (resp.json().get("run") or {}).get("id")
+            if not run_id:
+                raise RuntimeError(f"followup returned no run id: {resp.json()}")
+            return run_id
+        raise RuntimeError("followup failed after retries (agent persistently busy)")
+
+    async def _wait_idle(self, agent_id: str) -> None:
+        """active run이 terminal 될 때까지 폴링 (1-active-run 가드)."""
+        for _ in range(120):  # 최대 ~2분
+            resp = await self._http.get(
+                f"{CURSOR_API_BASE}/v1/agents/{agent_id}/runs",
+                headers=self._headers(), timeout=15.0,
+            )
+            if resp.status_code != 200:
+                return
+            runs = resp.json().get("runs") or resp.json().get("data") or []
+            if not any((r.get("status") in _ACTIVE) for r in runs):
+                return
+            await asyncio.sleep(1.0)
+
+    async def _collect_stream(self, agent_id: str, run_id: str) -> str:
+        """GET /v1/agents/{id}/runs/{runId}/stream (Cursor SSE) → assistant/result 텍스트."""
+        url = f"{CURSOR_API_BASE}/v1/agents/{agent_id}/runs/{run_id}/stream"
+        assistant_parts: list[str] = []
+        result_text = ""
+        ev_type, data_lines = "message", []
+        async with self._http.stream(
+            "GET", url,
+            headers={**self._headers(), "Accept": "text/event-stream"},
+            timeout=httpx.Timeout(connect=15.0, read=300.0, write=15.0, pool=15.0),
+        ) as resp:
+            resp.raise_for_status()
+            async for raw in resp.aiter_lines():
+                line = raw.rstrip("\n")
+                if line == "":
+                    if data_lines:
+                        self._handle_stream_event(ev_type, "\n".join(data_lines),
+                                                  assistant_parts)
+                        # result/done 은 terminal
+                        if ev_type in ("result", "done"):
+                            try:
+                                rt = json.loads("\n".join(data_lines)).get("text")
+                                if rt:
+                                    result_text = rt
+                            except (json.JSONDecodeError, AttributeError):
+                                pass
+                            if ev_type == "done":
+                                break
+                    ev_type, data_lines = "message", []
+                elif line.startswith(":"):
+                    pass
+                elif line.startswith("event:"):
+                    ev_type = line[6:].strip()
+                elif line.startswith("data:"):
+                    v = line[5:]
+                    data_lines.append(v[1:] if v.startswith(" ") else v)
+        # result.text 우선, 없으면 assistant 델타 합성
+        return (result_text or "".join(assistant_parts)).strip()
+
+    @staticmethod
+    def _handle_stream_event(ev_type: str, data_str: str, assistant_parts: list[str]) -> None:
+        if ev_type != "assistant":
+            return
+        try:
+            text = json.loads(data_str).get("text", "")
+            if text:
+                assistant_parts.append(text)
+        except (json.JSONDecodeError, AttributeError):
+            pass
+
+    async def run_turn(self, conversation_id: str, text: str) -> str:
+        """conversation별 launch-or-followup → stream 수집 → 응답."""
+        agent_id = self._agents.get(conversation_id)
+        if agent_id is None:
+            agent_id, run_id = await self._launch(text)
+            self._agents[conversation_id] = agent_id
+        else:
+            run_id = await self._followup(agent_id, text)
+        return await self._collect_stream(agent_id, run_id)
+
+    async def stop(self) -> None:
+        if self._http:
+            await self._http.aclose()
+            self._http = None
+
+
+async def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[cursor-sprintable] %(levelname)s %(message)s",
+        stream=sys.stderr,
+    )
+    api_url = (os.getenv("SPRINTABLE_API_URL", DEFAULT_API_URL) or DEFAULT_API_URL).rstrip("/")
+    api_key = os.getenv("SPRINTABLE_API_KEY") or os.getenv("AGENT_API_KEY") or ""
+    if not api_key:
+        logger.error("SPRINTABLE_API_KEY or AGENT_API_KEY not set — sidecar disabled")
+        return
+    if not CURSOR_API_KEY:
+        logger.error("CURSOR_API_KEY not set — sidecar disabled")
+        return
+
+    cursor = CursorCloudClient()
+    await cursor.start()
+
+    sse = SprintableSSEClient(api_url=api_url, api_key=api_key)
+
+    async def inject(ctx: MessageContext) -> None:
+        try:
+            response = await cursor.run_turn(ctx.conversation_id, ctx.content)
+        except Exception as exc:
+            logger.warning("turn error conv=%s: %s", ctx.conversation_id, exc)
+            return
+        if response:
+            await ctx.reply(response)
+
+    try:
+        await sse.run(inject)
+    finally:
+        await cursor.stop()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/connectors/connectors-pkg/sprintable_connectors/gemini.py
+++ b/connectors/connectors-pkg/sprintable_connectors/gemini.py
@@ -1,0 +1,213 @@
+"""Sprintable Gateway adapter host for Gemini — E-INJECT-ADAPTERS (카테고리 B).
+
+카테고리 B 둘째 — codex 호스트(sprintable_connectors.codex)와 동형 골격.
+차이 = RPC 레이어: gemini는 `gemini --acp` (Agent Client Protocol, 표준 JSON-RPC/stdio).
+codex app-server의 자체 RPC와 달리 ACP는 표준이라 향후 ACP 런타임에 재사용 가능.
+
+구조 (codex와 동일):
+  - 공통 SDK(sprintable_connectors.sdk) 재사용 — SSE 소비·dedup·ack·backoff
+  - gemini --acp (JSON-RPC/stdio)를 spawn/own
+  - SSE 이벤트마다 session/new(최초) + session/prompt로 turn 주입
+  - session/update(agent_message_chunk) 스트림 수집 → session/prompt 응답(stopReason)에서 확정
+  - 응답 → ctx.reply() → POST /api/v2/conversations/{id}/messages
+
+실측 ACP (@zed-industries/agent-client-protocol 0.4.5, PROTOCOL_VERSION=1):
+  initialize({protocolVersion, clientCapabilities}) → session/new({cwd, mcpServers})
+  → session/prompt({sessionId, prompt:[ContentBlock]}) → {stopReason}
+  client notification: session/update {sessionId, update:{sessionUpdate:"agent_message_chunk", content}}
+
+connectors/gemini-sprintable/host.py와 프로토콜 로직(GeminiAcpServer 본문)은 동일 — 유일한
+차이는 `sys.path` 상대깊이 해킹 대신 패키지 상대 import(`.sdk`)를 쓴다는 것뿐(E-CONNECT-PKG S1).
+grok과 byte-identical 쌍(같은 ACP 프로토콜) — 구조 조사에서 확認됨.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+
+from .sdk import MessageContext, SprintableSSEClient
+
+logger = logging.getLogger("gemini-sprintable")
+
+GEMINI_BIN = os.getenv("GEMINI_BIN", "gemini")
+DEFAULT_API_URL = "https://sprintable-backend-dev-57iommnikq-du.a.run.app"
+ACP_PROTOCOL_VERSION = 1
+
+
+class GeminiAcpServer:
+    """gemini --acp JSON-RPC/stdio 자식 프로세스 호스트 (ACP 표준).
+
+    한 번 spawn해서 lifetime 동안 own. shutdown 시 SIGTERM→kill.
+    codex host와 동형 — RPC 메서드만 ACP 표준으로 교체.
+    """
+
+    def __init__(self, cwd: str | None = None) -> None:
+        self._cwd = cwd or os.getcwd()
+        self._proc: asyncio.subprocess.Process | None = None
+        self._req_id = 0
+        self._pending: dict[int, asyncio.Future] = {}
+        # turn 응답 수집: session/update agent_message_chunk 누적
+        self._turn_messages: list[str] = []
+        self._reader_task: asyncio.Task | None = None
+        self._session_id: str | None = None
+
+    async def start(self) -> None:
+        """gemini --acp spawn + initialize 핸드셰이크."""
+        self._proc = await asyncio.create_subprocess_exec(
+            GEMINI_BIN, "--acp",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self._cwd,
+        )
+        self._reader_task = asyncio.create_task(self._read_loop())
+
+        # ACP initialize
+        await self._request("initialize", {
+            "protocolVersion": ACP_PROTOCOL_VERSION,
+            "clientCapabilities": {
+                "fs": {"readTextFile": False, "writeTextFile": False},
+                "terminal": False,
+            },
+        })
+        logger.info("gemini ACP initialized")
+
+    async def _read_loop(self) -> None:
+        """stdout JSON-RPC 라인 파싱 → response 매칭 + notification 처리."""
+        assert self._proc and self._proc.stdout
+        while True:
+            line = await self._proc.stdout.readline()
+            if not line:
+                break
+            try:
+                msg = json.loads(line.decode("utf-8"))
+            except json.JSONDecodeError:
+                continue
+            # response (id 있음 + result/error)
+            if "id" in msg and ("result" in msg or "error" in msg):
+                fut = self._pending.pop(msg["id"], None)
+                if fut and not fut.done():
+                    if "error" in msg:
+                        fut.set_exception(RuntimeError(str(msg["error"])))
+                    else:
+                        fut.set_result(msg.get("result"))
+                continue
+            # notification (method 있음, id 없음)
+            method = msg.get("method")
+            if method:
+                self._on_notification(method, msg.get("params") or {})
+
+    def _on_notification(self, method: str, params: dict) -> None:
+        """ACP client notification 처리 — session/update agent 응답 수집."""
+        if method == "session/update":
+            update = params.get("update") or {}
+            if update.get("sessionUpdate") == "agent_message_chunk":
+                content = update.get("content") or {}
+                # ContentBlock text variant
+                if content.get("type") == "text":
+                    text = content.get("text", "")
+                    if text:
+                        self._turn_messages.append(text)
+
+    async def _request(self, method: str, params: dict | None) -> dict:
+        """JSON-RPC request 송신 + response 대기."""
+        assert self._proc and self._proc.stdin
+        self._req_id += 1
+        rid = self._req_id
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._pending[rid] = fut
+        payload = {"jsonrpc": "2.0", "id": rid, "method": method}
+        if params is not None:
+            payload["params"] = params
+        self._proc.stdin.write((json.dumps(payload) + "\n").encode("utf-8"))
+        await self._proc.stdin.drain()
+        return await fut
+
+    async def ensure_session(self) -> str:
+        """session/new (최초 1회) → sessionId 캐시.
+
+        thread 매핑은 단일 session (후속 ef2603d8서 B 일괄 conversation→session 보강).
+        """
+        if self._session_id:
+            return self._session_id
+        result = await self._request("session/new", {
+            "cwd": self._cwd,
+            "mcpServers": [],
+        })
+        self._session_id = result.get("sessionId")
+        if not self._session_id:
+            raise RuntimeError(f"session/new returned no sessionId: {result}")
+        logger.info("gemini session created: %s", self._session_id)
+        return self._session_id
+
+    async def run_turn(self, text: str) -> str:
+        """session/prompt로 주입 → 응답(stopReason)까지 agent_message_chunk 수집.
+
+        ACP는 session/prompt가 turn 완료(stopReason) 시점에 반환 →
+        그때까지 수집된 agent_message_chunk를 응답으로 사용.
+        """
+        session_id = await self.ensure_session()
+        self._turn_messages = []
+
+        await self._request("session/prompt", {
+            "sessionId": session_id,
+            "prompt": [{"type": "text", "text": text}],
+        })
+        # session/prompt 반환 = turn 완료 → 수집된 메시지 확정
+        return "".join(self._turn_messages).strip()
+
+    async def stop(self) -> None:
+        """자식 프로세스 graceful 종료 (SIGTERM → kill). codex와 동형."""
+        if self._reader_task:
+            self._reader_task.cancel()
+        if self._proc and self._proc.returncode is None:
+            try:
+                self._proc.terminate()
+                await asyncio.wait_for(self._proc.wait(), timeout=5.0)
+            except (asyncio.TimeoutError, ProcessLookupError):
+                try:
+                    self._proc.kill()
+                except ProcessLookupError:
+                    pass
+
+
+async def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[gemini-sprintable] %(levelname)s %(message)s",
+        stream=sys.stderr,
+    )
+    api_url = (os.getenv("SPRINTABLE_API_URL", DEFAULT_API_URL) or DEFAULT_API_URL).rstrip("/")
+    api_key = os.getenv("SPRINTABLE_API_KEY") or os.getenv("AGENT_API_KEY") or ""
+    if not api_key:
+        logger.error("SPRINTABLE_API_KEY or AGENT_API_KEY not set — host disabled")
+        return
+
+    gemini = GeminiAcpServer()
+    await gemini.start()
+
+    sse = SprintableSSEClient(api_url=api_url, api_key=api_key)
+
+    async def inject(ctx: MessageContext) -> None:
+        try:
+            response = await gemini.run_turn(ctx.content)
+        except Exception as exc:
+            logger.warning("turn error conv=%s: %s", ctx.conversation_id, exc)
+            return
+        if response:
+            await ctx.reply(response)
+
+    try:
+        await sse.run(inject)
+    finally:
+        await gemini.stop()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/connectors/connectors-pkg/sprintable_connectors/grok.py
+++ b/connectors/connectors-pkg/sprintable_connectors/grok.py
@@ -1,0 +1,213 @@
+"""Sprintable Gateway adapter host for Grok (xAI Grok Build) — E-INJECT-ADAPTERS (카테고리 B).
+
+xAI Grok Build CLI — **Zed ACP** 에이전트 (zed.dev/acp/agent/grok-build 등재).
+gemini 호스트와 **완전 동형** — 동일 Zed Agent Client Protocol 사용.
+차이는 spawn 명령뿐: `gemini --acp` → `grok agent stdio`.
+
+구조 (gemini/codex와 동일):
+  - 공통 SDK(sprintable_connectors.sdk) 재사용 — SSE 소비·dedup·ack·backoff
+  - grok agent stdio (ACP JSON-RPC/stdio)를 spawn/own
+  - SSE 이벤트마다 session/new(최초) + session/prompt로 turn 주입
+  - session/update(agent_message_chunk) 스트림 수집 → session/prompt 응답(stopReason) 확정
+  - 응답 → ctx.reply() → POST /api/v2/conversations/{id}/messages
+
+실측 ACP (@zed-industries/agent-client-protocol 0.4.5, PROTOCOL_VERSION=1 — gemini와 동일 스키마):
+  initialize({protocolVersion, clientCapabilities}) → session/new({cwd, mcpServers})
+  → session/prompt({sessionId, prompt:[ContentBlock]}) → {stopReason}
+  client notification: session/update {sessionId, update:{sessionUpdate:"agent_message_chunk", content}}
+
+인터페이스 분기 근거 (추측 0):
+  - zed.dev/acp/agent/grok-build — Grok Build이 Zed ACP 공식 에이전트로 등재
+  - `grok agent stdio` = JSON-RPC 2.0 over stdio (Zed ACP)
+  - xAI 공식: API(api.x.ai)도 있으나 코딩 에이전트는 ACP stdio 제공 → 카테고리 B
+
+connectors/grok-sprintable/host.py와 프로토콜 로직(GrokAcpServer 본문)은 동일 — 유일한 차이는
+`sys.path` 상대깊이 해킹 대신 패키지 상대 import(`.sdk`)를 쓴다는 것뿐(E-CONNECT-PKG S1).
+gemini와 byte-identical 쌍(같은 ACP 프로토콜) — 구조 조사에서 확認됨.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+
+from .sdk import MessageContext, SprintableSSEClient
+
+logger = logging.getLogger("grok-sprintable")
+
+GROK_BIN = os.getenv("GROK_BIN", "grok")
+DEFAULT_API_URL = "https://sprintable-backend-dev-57iommnikq-du.a.run.app"
+ACP_PROTOCOL_VERSION = 1
+
+
+class GrokAcpServer:
+    """grok agent stdio JSON-RPC/stdio 자식 프로세스 호스트 (Zed ACP).
+
+    한 번 spawn해서 lifetime 동안 own. shutdown 시 SIGTERM→kill.
+    gemini host와 완전 동형 — spawn 명령만 차이.
+    """
+
+    def __init__(self, cwd: str | None = None) -> None:
+        self._cwd = cwd or os.getcwd()
+        self._proc: asyncio.subprocess.Process | None = None
+        self._req_id = 0
+        self._pending: dict[int, asyncio.Future] = {}
+        # turn 응답 수집: session/update agent_message_chunk 누적
+        self._turn_messages: list[str] = []
+        self._reader_task: asyncio.Task | None = None
+        self._session_id: str | None = None
+
+    async def start(self) -> None:
+        """grok agent stdio spawn + ACP initialize 핸드셰이크."""
+        self._proc = await asyncio.create_subprocess_exec(
+            GROK_BIN, "agent", "stdio",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self._cwd,
+        )
+        self._reader_task = asyncio.create_task(self._read_loop())
+
+        # ACP initialize
+        await self._request("initialize", {
+            "protocolVersion": ACP_PROTOCOL_VERSION,
+            "clientCapabilities": {
+                "fs": {"readTextFile": False, "writeTextFile": False},
+                "terminal": False,
+            },
+        })
+        logger.info("grok ACP initialized")
+
+    async def _read_loop(self) -> None:
+        """stdout JSON-RPC 라인 파싱 → response 매칭 + notification 처리."""
+        assert self._proc and self._proc.stdout
+        while True:
+            line = await self._proc.stdout.readline()
+            if not line:
+                break
+            try:
+                msg = json.loads(line.decode("utf-8"))
+            except json.JSONDecodeError:
+                continue
+            # response (id 있음 + result/error)
+            if "id" in msg and ("result" in msg or "error" in msg):
+                fut = self._pending.pop(msg["id"], None)
+                if fut and not fut.done():
+                    if "error" in msg:
+                        fut.set_exception(RuntimeError(str(msg["error"])))
+                    else:
+                        fut.set_result(msg.get("result"))
+                continue
+            # notification (method 있음, id 없음)
+            method = msg.get("method")
+            if method:
+                self._on_notification(method, msg.get("params") or {})
+
+    def _on_notification(self, method: str, params: dict) -> None:
+        """ACP client notification 처리 — session/update agent 응답 수집."""
+        if method == "session/update":
+            update = params.get("update") or {}
+            if update.get("sessionUpdate") == "agent_message_chunk":
+                content = update.get("content") or {}
+                if content.get("type") == "text":
+                    text = content.get("text", "")
+                    if text:
+                        self._turn_messages.append(text)
+
+    async def _request(self, method: str, params: dict | None) -> dict:
+        """JSON-RPC request 송신 + response 대기."""
+        assert self._proc and self._proc.stdin
+        self._req_id += 1
+        rid = self._req_id
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._pending[rid] = fut
+        payload = {"jsonrpc": "2.0", "id": rid, "method": method}
+        if params is not None:
+            payload["params"] = params
+        self._proc.stdin.write((json.dumps(payload) + "\n").encode("utf-8"))
+        await self._proc.stdin.drain()
+        return await fut
+
+    async def ensure_session(self) -> str:
+        """session/new (최초 1회) → sessionId 캐시.
+
+        thread 매핑은 단일 session (후속 ef2603d8서 B 일괄 conversation→session 보강).
+        """
+        if self._session_id:
+            return self._session_id
+        result = await self._request("session/new", {
+            "cwd": self._cwd,
+            "mcpServers": [],
+        })
+        self._session_id = result.get("sessionId")
+        if not self._session_id:
+            raise RuntimeError(f"session/new returned no sessionId: {result}")
+        logger.info("grok session created: %s", self._session_id)
+        return self._session_id
+
+    async def run_turn(self, text: str) -> str:
+        """session/prompt로 주입 → 응답(stopReason)까지 agent_message_chunk 수집."""
+        session_id = await self.ensure_session()
+        self._turn_messages = []
+
+        await self._request("session/prompt", {
+            "sessionId": session_id,
+            "prompt": [{"type": "text", "text": text}],
+        })
+        # session/prompt 반환 = turn 완료 → 수집된 메시지 확정
+        return "".join(self._turn_messages).strip()
+
+    async def stop(self) -> None:
+        """자식 프로세스 graceful 종료 (SIGTERM → kill). gemini/codex 동형."""
+        if self._reader_task:
+            self._reader_task.cancel()
+        if self._proc and self._proc.returncode is None:
+            try:
+                self._proc.terminate()
+                await asyncio.wait_for(self._proc.wait(), timeout=5.0)
+            except (asyncio.TimeoutError, ProcessLookupError):
+                try:
+                    self._proc.kill()
+                except ProcessLookupError:
+                    pass
+
+
+async def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[grok-sprintable] %(levelname)s %(message)s",
+        stream=sys.stderr,
+    )
+    api_url = (os.getenv("SPRINTABLE_API_URL", DEFAULT_API_URL) or DEFAULT_API_URL).rstrip("/")
+    api_key = os.getenv("SPRINTABLE_API_KEY") or os.getenv("AGENT_API_KEY") or ""
+    if not api_key:
+        logger.error("SPRINTABLE_API_KEY or AGENT_API_KEY not set — host disabled")
+        return
+
+    grok = GrokAcpServer()
+    await grok.start()
+
+    sse = SprintableSSEClient(api_url=api_url, api_key=api_key)
+
+    async def inject(ctx: MessageContext) -> None:
+        try:
+            response = await grok.run_turn(ctx.content)
+        except Exception as exc:
+            logger.warning("turn error conv=%s: %s", ctx.conversation_id, exc)
+            return
+        if response:
+            await ctx.reply(response)
+
+    try:
+        await sse.run(inject)
+    finally:
+        await grok.stop()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/connectors/connectors-pkg/sprintable_connectors/pi.py
+++ b/connectors/connectors-pkg/sprintable_connectors/pi.py
@@ -1,0 +1,170 @@
+"""Sprintable Gateway adapter host for Pi — E-INJECT-ADAPTERS (카테고리 B).
+
+카테고리 B 셋째 — codex/gemini 호스트와 동형 골격.
+차이 = 메시지 레이어: pi는 `pi --mode rpc` (JSONL/stdio — JSON-RPC 아닌 줄단위 JSON).
+명령은 stdin JSONL, 이벤트/응답은 stdout JSONL.
+
+구조 (codex/gemini와 동일):
+  - 공통 SDK(sprintable_connectors.sdk) 재사용 — SSE 소비·dedup·ack·backoff
+  - pi --mode rpc (JSONL/stdio)를 spawn/own
+  - SSE 이벤트마다 {"type":"prompt", message} 주입 (steer로 mid-stream 가능)
+  - agent_end 이벤트의 assistant 메시지 텍스트 수집 → 응답 확정
+  - 응답 → ctx.reply() → POST /api/v2/conversations/{id}/messages
+
+실측 스키마 (@earendil-works/pi-coding-agent@0.78.0, dist/modes/rpc/rpc-types.d.ts):
+  RpcCommand: {type:"prompt", message, streamingBehavior?:"steer"|"followUp"}
+              {type:"steer", message}  — mid-stream 주입 (pi 강점)
+  stdout JSONL: RpcResponse {type:"response", command:"prompt", success} = ack
+                AgentSessionEvent (session.subscribe) — agent_end {messages:[AgentMessage]}
+  AgentMessage(assistant).content: (TextContent{type:"text",text} | ...)
+
+connectors/pi-sprintable/host.py와 프로토콜 로직(PiRpcServer 본문)은 동일 — 유일한 차이는
+`sys.path` 상대깊이 해킹 대신 패키지 상대 import(`.sdk`)를 쓴다는 것뿐(E-CONNECT-PKG S1).
+codex/gemini/grok과 다른 3번째 계열(request/response id 매칭 없는 fire-and-forget JSONL) —
+구조 조사에서 확認됨.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+
+from .sdk import MessageContext, SprintableSSEClient
+
+logger = logging.getLogger("pi-sprintable")
+
+PI_BIN = os.getenv("PI_BIN", "pi")
+DEFAULT_API_URL = "https://sprintable-backend-dev-57iommnikq-du.a.run.app"
+
+
+class PiRpcServer:
+    """pi --mode rpc JSONL/stdio 자식 프로세스 호스트.
+
+    한 번 spawn해서 lifetime 동안 own. shutdown 시 SIGTERM→kill.
+    codex/gemini host와 동형 — 메시지 레이어만 JSONL로 교체.
+    """
+
+    def __init__(self, cwd: str | None = None) -> None:
+        self._cwd = cwd or os.getcwd()
+        self._proc: asyncio.subprocess.Process | None = None
+        self._reader_task: asyncio.Task | None = None
+        # turn 응답 수집: agent_end 의 assistant 텍스트
+        self._turn_messages: list[str] = []
+        self._turn_done: asyncio.Event | None = None
+
+    async def start(self) -> None:
+        """pi --mode rpc spawn. (JSONL은 별도 initialize 핸드셰이크 없음)"""
+        self._proc = await asyncio.create_subprocess_exec(
+            PI_BIN, "--mode", "rpc",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self._cwd,
+        )
+        self._reader_task = asyncio.create_task(self._read_loop())
+        logger.info("pi --mode rpc started")
+
+    async def _read_loop(self) -> None:
+        """stdout JSONL 라인 파싱 → 이벤트/응답 처리."""
+        assert self._proc and self._proc.stdout
+        while True:
+            line = await self._proc.stdout.readline()
+            if not line:
+                break
+            try:
+                msg = json.loads(line.decode("utf-8"))
+            except json.JSONDecodeError:
+                continue
+            self._on_message(msg)
+
+    def _on_message(self, msg: dict) -> None:
+        """JSONL stdout 메시지 처리.
+
+        - AgentSessionEvent: agent_end {messages} → assistant 텍스트 수집 + turn 완료
+        - RpcResponse {type:"response"}: ack (별도 처리 불필요)
+        """
+        mtype = msg.get("type")
+        if mtype == "agent_end":
+            for am in msg.get("messages") or []:
+                if am.get("role") == "assistant":
+                    for block in am.get("content") or []:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            text = block.get("text", "")
+                            if text:
+                                self._turn_messages.append(text)
+            if self._turn_done and not self._turn_done.is_set():
+                self._turn_done.set()
+
+    async def _send(self, cmd: dict) -> None:
+        """JSONL 명령 stdin 송신."""
+        assert self._proc and self._proc.stdin
+        self._proc.stdin.write((json.dumps(cmd) + "\n").encode("utf-8"))
+        await self._proc.stdin.drain()
+
+    async def run_turn(self, text: str) -> str:
+        """{type:"prompt", message} 주입 → agent_end까지 assistant 텍스트 수집.
+
+        thread 매핑은 단일 세션 (후속 ef2603d8서 B 일괄 보강).
+        """
+        self._turn_messages = []
+        self._turn_done = asyncio.Event()
+
+        await self._send({"type": "prompt", "message": text})
+        # agent_end 대기 (turn 완료 + 응답 수집)
+        await self._turn_done.wait()
+        return "".join(self._turn_messages).strip()
+
+    async def stop(self) -> None:
+        """자식 프로세스 graceful 종료 (SIGTERM → kill). codex/gemini 동형."""
+        if self._reader_task:
+            self._reader_task.cancel()
+        if self._proc and self._proc.returncode is None:
+            try:
+                self._proc.terminate()
+                await asyncio.wait_for(self._proc.wait(), timeout=5.0)
+            except (asyncio.TimeoutError, ProcessLookupError):
+                try:
+                    self._proc.kill()
+                except ProcessLookupError:
+                    pass
+
+
+async def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[pi-sprintable] %(levelname)s %(message)s",
+        stream=sys.stderr,
+    )
+    api_url = (os.getenv("SPRINTABLE_API_URL", DEFAULT_API_URL) or DEFAULT_API_URL).rstrip("/")
+    api_key = os.getenv("SPRINTABLE_API_KEY") or os.getenv("AGENT_API_KEY") or ""
+    if not api_key:
+        logger.error("SPRINTABLE_API_KEY or AGENT_API_KEY not set — host disabled")
+        return
+
+    pi = PiRpcServer()
+    await pi.start()
+
+    sse = SprintableSSEClient(api_url=api_url, api_key=api_key)
+
+    async def inject(ctx: MessageContext) -> None:
+        try:
+            response = await pi.run_turn(ctx.content)
+        except Exception as exc:
+            logger.warning("turn error conv=%s: %s", ctx.conversation_id, exc)
+            return
+        if response:
+            await ctx.reply(response)
+
+    try:
+        await sse.run(inject)
+    finally:
+        await pi.stop()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/connectors/connectors-pkg/sprintable_connectors/sdk.py
+++ b/connectors/connectors-pkg/sprintable_connectors/sdk.py
@@ -1,0 +1,298 @@
+"""Sprintable Gateway SSE Reference SDK — Python.
+
+공통부: SSE 소비 · 파서 · dedup · ack(contiguous, min-1 앵커링) · backoff 재연결.
+어댑터는 `on_message` 콜백(주입부)만 구현하면 된다.
+
+Usage:
+    from sprintable_sse import SprintableSSEClient, MessageContext
+
+    async def inject(ctx: MessageContext) -> None:
+        # runtime-specific turn injection
+        response = await my_agent.handle(ctx.content)
+        await ctx.reply(response)
+
+    client = SprintableSSEClient(
+        api_url="https://sprintable-backend-dev-57iommnikq-du.a.run.app",
+        api_key="sk_live_...",
+    )
+    await client.run(inject)   # blocks forever, auto-reconnects
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable
+
+try:
+    import httpx
+    HTTPX_AVAILABLE = True
+except ImportError:
+    HTTPX_AVAILABLE = False  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_API_URL = "https://sprintable-backend-dev-57iommnikq-du.a.run.app"
+RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
+STREAM_READ_TIMEOUT = 90
+DEDUP_MAX_SIZE = 1000
+DEDUP_TTL_SECONDS = 300.0
+
+# ── E-EVENT-INJECT S2: 주입 허용 event_type (중앙 상수, recommended ONLY) ──────────
+# 이 목록 밖의 event_type은 content가 실려있어도 work-turn으로 주입하지 않고 드롭한다
+# (FYI poisoning 방지: status_changed/task_completed/agent_joined/sprint_closed/file_conflict 등).
+# 워크플로 트리거(kickoff/review_request/qa_request/deploy_request/handoff)는 현재 백엔드가
+# dispatched 이벤트로 전달하나, 향후 직접 event_type emit 대비해 명시 포함.
+# ⚠️ 단일 출처 — hermes adapter.py가 이 상수를 import해서 사용(분기 중복 금지).
+INJECTABLE_EVENT_TYPES = frozenset({
+    "dispatched",
+    "story_assigned",
+    "conversation.message_created",
+    "conversation:mention",
+    "kickoff",
+    "review_request",
+    "qa_request",
+    "deploy_request",
+    "handoff",
+})
+
+
+# ── Public types ─────────────────────────────────────────────────────────────
+
+@dataclass
+class MessageImage:
+    url: str
+    name: str = ""
+    mime: str = ""
+
+
+@dataclass
+class MessageContext:
+    """어댑터 `on_message` 콜백에 전달되는 메시지 컨텍스트."""
+    content: str
+    conversation_id: str
+    sender_id: str
+    sender_name: str
+    event_id: str
+    seq: int
+    is_backfill: bool
+    images: list[MessageImage]
+    raw: dict[str, Any]
+
+    # reply() 지원을 위해 내부 주입
+    _reply_url: str = field(default="", repr=False)
+    _api_key: str = field(default="", repr=False)
+    _http: Any = field(default=None, repr=False)
+
+    async def reply(self, text: str) -> None:
+        """POST /api/v2/conversations/{id}/messages."""
+        if not self._reply_url or not self._http:
+            raise RuntimeError("reply_url not available")
+        resp = await self._http.post(
+            self._reply_url,
+            headers={"Authorization": f"Bearer {self._api_key}", "x-agent-api-key": self._api_key},
+            json={"content": text},
+            timeout=15.0,
+        )
+        resp.raise_for_status()
+
+
+MessageHandler = Callable[[MessageContext], Awaitable[None]]
+
+
+def _normalize_images(value: Any) -> list[MessageImage]:
+    if not isinstance(value, list):
+        return []
+    images: list[MessageImage] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        url = str(item.get("url") or "").strip()
+        if not url:
+            continue
+        mime = str(item.get("mime") or item.get("mime_type") or "").strip()
+        if mime and not mime.startswith("image/"):
+            continue
+        images.append(MessageImage(
+            url=url,
+            name=str(item.get("name") or ""),
+            mime=mime,
+        ))
+    return images
+
+
+# ── SDK client ────────────────────────────────────────────────────────────────
+
+class SprintableSSEClient:
+    """Sprintable Gateway SSE dial-out 클라이언트.
+
+    `run(on_message)` 한 번 호출로 SSE 스트림 소비 + ack 처리 + 재연결을 담당.
+    어댑터는 `on_message(MessageContext)` 콜백만 구현.
+    """
+
+    def __init__(self, api_url: str = DEFAULT_API_URL, api_key: str = "") -> None:
+        if not HTTPX_AVAILABLE:
+            raise ImportError("httpx is required: pip install httpx")
+        self._api_url = api_url.rstrip("/")
+        self._api_key = api_key
+        self._http: httpx.AsyncClient | None = None
+        self._last_event_id = ""
+        self._last_acked = 0
+        self._seen: dict[str, float] = {}
+
+    def _auth(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._api_key}", "x-agent-api-key": self._api_key}
+
+    def _is_dup(self, event_id: str) -> bool:
+        now = time.time()
+        if len(self._seen) > DEDUP_MAX_SIZE:
+            self._seen = {k: v for k, v in self._seen.items() if v > now - DEDUP_TTL_SECONDS}
+        if event_id in self._seen:
+            return True
+        self._seen[event_id] = now
+        return False
+
+    async def _ack(self, seq: int) -> None:
+        """contiguous-ack: seq <= _last_acked 이면 skip."""
+        if seq <= self._last_acked or not self._http:
+            return
+        try:
+            await self._http.post(
+                f"{self._api_url}/api/v2/agent/events/ack",
+                headers=self._auth(), json={"seq": seq}, timeout=10.0,
+            )
+            self._last_acked = seq
+            logger.debug("ack seq=%d", seq)
+        except Exception as exc:
+            logger.warning("ack error seq=%d: %s", seq, exc)
+
+    async def _parse_event(self, ev_type: str, ev_id: str, data_str: str) -> MessageContext | None:
+        """SSE 이벤트 → MessageContext. heartbeat / no-content 는 None."""
+        if ev_type == "heartbeat":
+            return None
+        try:
+            data: dict[str, Any] = json.loads(data_str)
+        except json.JSONDecodeError:
+            return None
+
+        payload = data.get("payload") or {}
+        if isinstance(payload, str):
+            payload = {}
+        # E-EVENT-INJECT S2: recommended ONLY allow-list (content 체크 전). FYI 등은 드롭.
+        event_type = data.get("event_type") or payload.get("event_type")
+        if event_type not in INJECTABLE_EVENT_TYPES:
+            return None
+        content = (data.get("content") or payload.get("content") or "").strip()
+        images = _normalize_images(data.get("images") or payload.get("images"))
+        if not content and not images:
+            return None
+
+        event_id = str(data.get("event_id") or payload.get("id") or ev_id or uuid.uuid4())
+        if self._is_dup(event_id):
+            return None
+        if ev_id:
+            self._last_event_id = ev_id
+
+        # seq: data 최상위 → payload fallback
+        seq = 0
+        for cand in (data.get("recipient_seq"), payload.get("recipient_seq")):
+            try:
+                n = int(cand)  # type: ignore[arg-type]
+                if n > 0:
+                    seq = n
+                    break
+            except (TypeError, ValueError):
+                pass
+
+        conversation_id = str(
+            payload.get("conversation_id") or payload.get("thread_id")
+            or data.get("conversation_id") or ""
+        )
+        sender = payload.get("sender") or {}
+        if isinstance(sender, str):
+            sender = {}
+        sender_id = str(sender.get("id") or data.get("sender_id") or "sprintable")
+        sender_name = str(sender.get("name") or sender_id)
+        is_backfill = bool(data.get("is_backfill"))
+
+        reply_url = (
+            f"{self._api_url}/api/v2/conversations/{conversation_id}/messages"
+            if conversation_id else ""
+        )
+
+        return MessageContext(
+            content=content,
+            conversation_id=conversation_id,
+            sender_id=sender_id,
+            sender_name=sender_name,
+            event_id=event_id,
+            seq=seq,
+            is_backfill=is_backfill,
+            images=images,
+            raw=data,
+            _reply_url=reply_url,
+            _api_key=self._api_key,
+            _http=self._http,
+        )
+
+    async def _consume(self, on_message: MessageHandler) -> None:
+        assert self._http is not None
+        headers = {**self._auth(), "Accept": "text/event-stream", "Cache-Control": "no-cache"}
+        if self._last_event_id:
+            headers["Last-Event-ID"] = self._last_event_id
+
+        ev_type, ev_id, data_lines = "message", "", []
+        async with self._http.stream(
+            "GET", f"{self._api_url}/api/v2/agent/stream", headers=headers,
+            timeout=httpx.Timeout(connect=15.0, read=STREAM_READ_TIMEOUT, write=15.0, pool=15.0),
+        ) as resp:
+            resp.raise_for_status()
+            logger.info("stream open")
+            async for raw in resp.aiter_lines():
+                line = raw.rstrip("\n")
+                if line == "":
+                    if data_lines:
+                        ctx = await self._parse_event(ev_type, ev_id, "\n".join(data_lines))
+                        if ctx is not None:
+                            logger.info("inbound seq=%d conv=%s: %s",
+                                        ctx.seq, ctx.conversation_id, ctx.content[:80])
+                            await on_message(ctx)
+                            if ctx.seq:
+                                await self._ack(ctx.seq)
+                    ev_type, ev_id, data_lines = "message", "", []
+                elif line.startswith(":"):
+                    pass
+                elif line.startswith("event:"):
+                    ev_type = line[6:].strip()
+                elif line.startswith("id:"):
+                    ev_id = line[3:].strip()
+                elif line.startswith("data:"):
+                    v = line[5:]
+                    data_lines.append(v[1:] if v.startswith(" ") else v)
+        logger.info("stream closed")
+
+    async def run(self, on_message: MessageHandler) -> None:
+        """SSE 스트림 소비 + ack + backoff 재연결. 무한 루프."""
+        self._http = httpx.AsyncClient(timeout=None)
+        backoff_idx = 0
+        try:
+            while True:
+                t0 = time.monotonic()
+                try:
+                    await self._consume(on_message)
+                except asyncio.CancelledError:
+                    return
+                except Exception as exc:
+                    logger.warning("stream error: %s", exc)
+                if time.monotonic() - t0 >= 60.0:
+                    backoff_idx = 0
+                delay = RECONNECT_BACKOFF[min(backoff_idx, len(RECONNECT_BACKOFF) - 1)]
+                logger.info("reconnecting in %ds", delay)
+                await asyncio.sleep(delay)
+                backoff_idx += 1
+        finally:
+            await self._http.aclose()
+            self._http = None


### PR DESCRIPTION
## 배경
BYOA SaaS 온보딩 완료화면이 「connectors/codex-sprintable/를 실행하세요」라 안내하지만 그 경로를 어디서 구하는지가 문서에 없고, 커넥터 README는 `git pull origin develop`을 시킨다 — repo clone을 요구한다. self-host 사용자에겐 정상이지만, SaaS BYOA 사용자는 여기서 막힌다(스레드 7256d5cc, 2026-08-03 온보딩 구조 조사 후속).

## 이번 PR — 1단계 완료(5종 전부)
판별선: **「이 형태를 우리 레포를 한 번도 안 본 사람이 손에 넣을 수 있는가」**

- `sprintable_connectors/sdk.py` = `connectors/sdk/sprintable_sse.py` 정본을 그대로 복사(재구현/vendor drift 없음)
- `sprintable_connectors/{codex,cursor,gemini,grok,pi}.py` = 각 원본(`connectors/*-sprintable/*.py`)의 프로토콜 로직 원본 그대로(diff로 byte-identical 확認) — 유일한 변경은 `sys.path` 상대깊이 해킹 → 패키지 상대 import(`.sdk`)
- `SPRINTABLE_RUNTIME=codex|cursor|gemini|grok|pi` env로 런타임 선택(auto-detect 없음 — 이미 사용자가 스크립트 선택으로 고르던 것과 동형, 과설계 회피)
- `hermes-sprintable`/`hermes-sprintable-prod`(호스트 플러그인 클래스, 자체 vendor 완료)·`openclaw-sprintable`/`opencode-sprintable`(TS, 별도 npm)는 구조상 제외 — 같은 스레드 구조 조사에서 확認된 근거

## 실측 (레포 밖에서, wheel만 설치)
```
1. uv build → wheel(sprintable_connectors-0.0.1-py3-none-any.whl)
2. 완전히 새 venv에 그 wheel만 pip install (site-packages 안에만 존재, 레포 경로 참조 0)
3. git repo가 아닌 빈 디렉터리(/tmp/nowhere-not-a-repo, `git rev-parse` 확認)에서 실행
```

- **codex**: 실 AGENT_API_KEY로 dev backend SSE dial-out → "stream open"(HTTP 200) 확認(로컬 codex CLI로 app-server spawn까지 성공)
- **cursor**: 동일하게 "stream open" 확認(자식 프로세스 없는 계열도 판별선 통과 — 넷 중 가장 형태가 안 맞는 계열이라 먼저 검증). ⚠️**카디르 QA 재확認(2026-08-03)** — `cursor.py`의 `main()`은 `CURSOR_API_KEY`가 비어 있으면 `SprintableSSEClient`를 만들기 *전에* 조기 종료한다(L203-204). 이 테스트는 **플레이스홀더 값**(`CURSOR_API_KEY=placeholder-not-real`, 실제 Cursor 키 아님)으로 그 가드만 통과시켜 SSE dial-out을 확認한 것 — Sprintable 게이트웨이 SSE 연결 자체는 진짜지만, Cursor Cloud API(`_launch`/`_followup`/`_collect_stream`, api.cursor.com 호출)까지의 전체 라운드트립은 **검증하지 않았다**(실 CURSOR_API_KEY 없으면 401로 실패할 것). codex와 같은 스코프(SSE 연결까지만, 실 turn 주입은 별건)로 명시한다.
- **gemini/grok/pi**: 패키지 import·`SPRINTABLE_RUNTIME` 라우팅까지 정상 확認, 이후 각자 CLI 바이너리(gemini/grok/pi) 부재로 `FileNotFoundError`(subprocess spawn 단계)에서 멈춤 — 이 개발 환경에 해당 CLI가 설치돼 있지 않아 발생하는 예상된 실패이며(원본 커넥터도 동일 전제, 각 README "◯◯-cli 설치 필수") **`ImportError`가 아님을 확認**해 패키징 결함이 아님을 실증. 해당 CLI가 설치된 환경에서의 전체 SSE 연결 확認은 이 세션 스코프 밖.

레포 클론 0회로 5종 전부 판별선 통과(2종 완전 실측, 3종은 패키징 계층까지 실측 + 외부 바이너리 부재만 남은 축).

## 다음 단계(이 PR 스코프 밖, 페드루 지시)
- 배포 수단(PyPI 이름·버전 정책)은 형태가 실측으로 다 선 지금 시점에 한 번에 결정(`uvx sprintable` 시행착오 재발 방지)
- QA는 카디르군 문서 작업이 안정된 뒤 한 번에 — 그때까지 이 PR은 열어 둠(머지 보류)
- 완료화면에 걸 최종 한 줄(설치 명령)도 배포 수단 확定 후

🤖 Generated with [Claude Code](https://claude.com/claude-code)

