### PR TITLE
docs(#onboarding): fix 6 doc↔code drift items in onboarding-guide.txt + hermes README

### DIFF
--- a/apps/web/public/onboarding-guide.txt
+++ b/apps/web/public/onboarding-guide.txt
@@ -22,10 +22,12 @@ Only the injection last mile (into the running agent's control loop) is per-runt
 A Sprintable login (JWT) is a *human* session token — an agent cannot mint one for itself.
 Ask the person who runs you to do the following once and hand you the resulting API key.
 
-> Any organization **member can do this — admin is not required**
-> (`POST /api/v2/team-members` and `POST /api/v2/agents/{id}/api-keys` both authorize with a
-> normal member session). Admin is only needed for *project-level* API keys (`POST /api/v2/api-keys`),
-> which are a different thing.
+> **Project admin/owner is required for Step 1-1** (`POST /api/v2/team-members` — registering the
+> agent): the route gates unconditionally on `has_project_role(min_role="admin")` for every caller
+> (a normal member session gets a 403). Step 1-2 (`POST /api/v2/agents/{id}/api-keys` — issuing the
+> key) allows either the agent's creator or an org admin/owner — in practice the same admin who
+> did Step 1-1 satisfies this too. Admin is also needed for *project-level* API keys
+> (`POST /api/v2/api-keys`), which are a different thing (org/project-scoped, not agent-scoped).
 
 | Item | Description |
 |------|-------------|
@@ -48,7 +50,7 @@ curl -s -X POST "$BASE_URL/api/v2/team-members" \
   -H "Authorization: Bearer $MEMBER_TOKEN" \
   -H "X-Org-Id: $ORG_ID" \
   -H "Content-Type: application/json" \
-  -d '{"type":"agent","name":"my-agent","role":"member","project_id":"'"$PROJECT_ID"'"}' \
+  -d '{"type":"agent","name":"my-agent","role":"member","project_id":"'"$PROJECT_ID"'","org_id":"'"$ORG_ID"'"}' \
   | tee /tmp/agent.json
 
 export AGENT_ID=$(jq -r '.id' /tmp/agent.json)
@@ -66,7 +68,7 @@ curl -s -X POST "$BASE_URL/api/v2/agents/$AGENT_ID/api-keys" \
 export AGENT_API_KEY=$(jq -r '.api_key' /tmp/apikey.json)
 ```
 
-> Key format: `sk_live_<32 random chars>`. Returned in plaintext **only once** — store it safely.
+> Key format: `sk_live_<64 hex chars>`. Returned in plaintext **only once** — store it safely.
 > The operator hands this key to the agent. From Step 2 on, the agent uses **only the API key**
 > (org and agent identity are derived from the key — no `X-Org-Id` needed).
 
@@ -89,10 +91,11 @@ curl -N \
 A connected stream yields SSE frames (RFC 8895):
 
 ```
-: connected
+event: heartbeat
+data: {}
 
 event: conversation.message_created
-id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+id: 42
 data: {"event_id":"3fa85f64-...","event_type":"conversation.message_created","recipient_seq":42,"is_backfill":false,"sender_id":"0caee743-...","content":"hello","source":{"type":"member","id":"0caee743-..."},"payload":{"conversation_id":"...","content":"hello"},"created_at":"2026-01-01T00:00:00Z"}
 ```
 
@@ -101,12 +104,17 @@ Key points:
   are at the **top level of `data`**; the original event fields (e.g. `conversation_id`) are nested
   inside the `payload` object, and `content` is also hoisted to the top level (connector-drop guard).
   `sender_id` is the sender's member id — a flat UUID, not a nested object.
-- The SSE `id:` field is the `event_id` UUID — distinct from `recipient_seq` (the integer cursor).
-  Deduplicate on `event_id`.
-- Ignore `event: heartbeat` frames (keep-alive).
-- To reconnect, send the last received `id:` value as the `Last-Event-ID` header; the server
-  backfills missed events (`is_backfill: true`). The same `event_id` is never sent twice
-  (server-side dedup).
+- **The SSE `id:` field is the `recipient_seq` integer — NOT the `event_id` UUID.** Send it back
+  verbatim as `Last-Event-ID` on reconnect. Sending a UUID there fails integer parsing and
+  silently degrades the reconnect to `header_seq=0` (full-history replay) — fixed at the root in
+  story #2143, but only on the server side; a client that copies `event_id` into `Last-Event-ID`
+  still hits this. `event_id` (a separate UUID inside `data`) is a stable per-event identifier —
+  use it for your own application-level dedup, not for the reconnect cursor.
+- Ignore `event: heartbeat` frames (keep-alive) — this is also the very first frame sent on connect.
+- To reconnect, send the last received `id:` value (the integer `recipient_seq`, not `event_id`)
+  as the `Last-Event-ID` header; the server backfills missed events (`is_backfill: true`) from
+  there. Non-durable/legacy direct-push events omit `id:` entirely (no `recipient_seq` to report)
+  rather than fabricating one — don't assume every frame carries an `id:`.
 
 ---
 
@@ -139,8 +147,9 @@ curl -s -X POST "$BASE_URL/api/v2/conversations/$CONVERSATION_ID/messages" \
   -d '{"content": "Done."}'
 ```
 
-`$CONVERSATION_ID` comes from the Step 2 event's `conversation_id`. Replies are idempotent and
-safe to retry.
+`$CONVERSATION_ID` comes from the Step 2 event's `conversation_id`. **This endpoint has no
+idempotency key** — a naive retry after a client-side timeout creates a duplicate message.
+Track whether your own POST completed before retrying.
 
 ---
 
@@ -172,11 +181,13 @@ and backoff are handled by the shared SDK; you only supply the runtime's injecti
 ### Example: Hermes
 
 > **The gateway adapter is not the MCP server.** A successful `sprintable` MCP
-> `ping` only proves the PM API tools are reachable — it does NOT mean the agent
+> `ping` only proves the tool-call channel is reachable — it does NOT mean the agent
 > is *receiving* conversation messages. Receiving requires this plugin loaded and
-> dialed out; verify with the checklist below, not with an MCP ping. The two
-> channels use different env vars: gateway = `AGENT_API_KEY`, MCP =
-> `PM_API_KEY`/`PM_API_URL`/`PM_PROJECT_ID`.
+> dialed out; verify with the checklist below, not with an MCP ping. Despite being
+> two separate channels, they currently read the **same** env vars —
+> `SPRINTABLE_API_URL` and `AGENT_API_KEY` (`backend/sprintable_mcp/config.py`) —
+> not the `PM_API_KEY`/`PM_API_URL`/`PM_PROJECT_ID` names an earlier version of this
+> doc claimed; those don't exist in this codebase.
 
 The plugin folder is **self-contained** (the inject allow-list is vendored), so
 copying just the folder is enough — no separate `connectors/sdk` step. Requires

--- a/connectors/hermes-sprintable/README.md
+++ b/connectors/hermes-sprintable/README.md
@@ -24,7 +24,7 @@ one working does not mean the other is:
 |---|---|---|
 | Purpose | **Receives** messages, **replies** | Calls PM API tools (create story, send chat, …) |
 | Transport | Outbound SSE `GET /api/v2/agent/stream` | MCP stdio / tool calls |
-| Auth env | `AGENT_API_KEY` (`sk_live_…`) | `PM_API_KEY`, `PM_API_URL`, `PM_PROJECT_ID` |
+| Auth env | `AGENT_API_KEY` (`sk_live_…`) | `AGENT_API_KEY`, `SPRINTABLE_API_URL` (same names — see below) |
 | "It works" signal | `stream open` in `gateway.log` + a real reply round-trip | `ping` returns ok |
 
 > **A successful MCP `ping` does NOT mean the agent is connected to the gateway.**
@@ -124,11 +124,16 @@ side by side. It is keyed entirely on `SPRINTABLE_PROD_*`
 cron delivery never cross with dev. See
 [`../hermes-sprintable-prod/README.md`](../hermes-sprintable-prod/README.md).
 
-### Group 3 — MCP server (PM API tools — a different channel)
+### Group 3 — MCP server (tool-call channel — a different channel)
 
-`PM_API_URL`, `PM_API_KEY`, `PM_PROJECT_ID`. These configure the `sprintable`
-MCP tools, **not** this adapter. Setting them does nothing for message delivery;
-setting `AGENT_API_KEY` does nothing for the MCP tools.
+The `sprintable` MCP tools are configured by `SPRINTABLE_API_URL` and
+`AGENT_API_KEY` (`backend/sprintable_mcp/config.py`) — the **same env var
+names** as this gateway adapter, not the separate `PM_API_URL`/`PM_API_KEY`/
+`PM_PROJECT_ID` an earlier version of this doc named (those don't exist in the
+codebase). They are still a functionally separate channel from this adapter
+(different process, different purpose — tool calls vs. message delivery), so
+confirm both independently rather than assuming one working implies the other
+does.
 
 ---
 


### PR DESCRIPTION
## 요약

온보딩 문서-코드 대조 감사(2026-08-03, PO 지시) 결과 중 위험도 상위 6건을 고칩니다. 새 코드/구조 변경 없음 — 문서만 실제 코드 동작에 맞춥니다.

## 무엇을 왜 고쳤는지 (파일:줄)

1. **`apps/web/public/onboarding-guide.txt:94-109`(⭐가장 위험)** — 문서는 SSE `id:` 필드가 `event_id` UUID라 서술했으나, 실제(`backend/app/routers/agent_gateway.py:513-516`)는 `recipient_seq` 정수입니다. 문서대로 UUID를 `Last-Event-ID`로 되돌려 보내면 `int()` 파싱 실패 → `header_seq=0`으로 조용히 강등 → 재연결마다 전체 이력 재생. 이 클래스의 버그는 서버 쪽에서 이미 story #2143이 근본수정했는데, 문서가 그 수정 전 동작을 그대로 서술해 클라이언트 쪽에서 같은 버그를 재도입시킬 수 있었습니다. 예시 프레임의 자기모순(`recipient_seq:42`인데 `id:`는 UUID)과 존재하지 않는 `: connected` 프레임(실제 첫 프레임은 `event: heartbeat`)도 같이 고쳤습니다.

2. **`onboarding-guide.txt:25-28`** — "member면 충분, admin 불요"라 서술했으나 실제(`backend/app/routers/team_members.py:221`)는 `has_project_role(min_role="admin")`을 무조건 요구합니다(SEC-S8 보안수정 — 예전엔 우회 가능했음). 실제 요구사항(1-1은 admin/owner 필수, 1-2는 생성자 또는 admin)으로 정정.

3. **`onboarding-guide.txt:47-52`** — 예시 curl body에 `org_id`가 빠져 있는데 `TeamMemberCreate`(`backend/app/schemas/team_member.py:18`)는 필수 필드입니다 — 그대로 실행하면 **422**. 필드 추가.

4. **`onboarding-guide.txt:69`** — 키 포맷을 `sk_live_<32 random chars>`로 서술했으나 실제 생성(`backend/app/repositories/api_key.py:16`)은 `secrets.token_hex(32)` = 64 hex자. `sk_live_<64 hex chars>`로 정정.

5. **`onboarding-guide.txt:142`** — "idempotent하니 재시도 안전"이라 서술했으나 `POST /api/v2/conversations/{id}/messages`에 idempotency key가 없습니다(grep 0건) — 재시도 시 실제로 중복 메시지가 생깁니다. 경고 문구로 정정.

6. **`onboarding-guide.txt:174-179` + `connectors/hermes-sprintable/README.md:27,129`** — 둘 다 MCP 서버가 `PM_API_KEY`/`PM_API_URL`/`PM_PROJECT_ID`를 쓴다고 서술했으나, 이 env var들은 `backend/sprintable_mcp` 어디에도 없습니다. 실제(`backend/sprintable_mcp/config.py`)는 gateway와 **같은 이름**(`SPRINTABLE_API_URL`·`AGENT_API_KEY`)을 씁니다. 같은 오문구가 두 파일에 복제돼 있어 둘 다 고쳤습니다.

## 이번 판에 의도적으로 안 넣은 것

- connect-guide.txt의 stdio/http 정본 예시 문제 — 구조 변경과 함께 처리 예정(다음 판)
- A2A 섹션 3건(인증/streaming/HITL 서술이 구버전) — 코드가 앞서 있는 것이라 문서 결함이 아닌 별개 스토리
- `TeamMemberCreate.org_id`가 스키마엔 필수인데 핸들러가 안 읽는 죽은 필드 — BE 결함, 별건
- `connectors/` 공식 어댑터가 npm 퍼블리시 파이프라인이 없어 SaaS 독자에게 `git pull` 레포 clone을 강요하는 구조적 문제 — 배포 파이프라인 부재, 문서 수정 범위 밖

## 검증

의도적으로 셀프검증 안 함 — 이 문서를 감사한 에이전트가 그대로 검증하면 같은 사각이 남습니다(PO 지시). 디디군 검증 요청.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>