### PR TITLE
[SID:2433] 채용 위저드 런타임 미저장(A) + 역할없이 런타임단계 스킵(B)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3277,6 +3277,7 @@
     "equipCreatedTitle": "{name} created",
     "equipKeyOnceLabel": "API key — shown only once.",
     "equipMcpConfigLabel": "MCP Config",
+    "equipRuntimeSaveWarning": "Failed to save the runtime — please set it again from the management screen. Your key and connection info are still valid.",
     "roleQuestion": "Which role are you hiring for?",
     "roleLoading": "Loading role catalog…",
     "roleLoadError": "Couldn't load the role catalog.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3277,6 +3277,7 @@
     "equipCreatedTitle": "{name} 생성 완료",
     "equipKeyOnceLabel": "API Key — 지금만 표시됩니다.",
     "equipMcpConfigLabel": "MCP Config",
+    "equipRuntimeSaveWarning": "런타임 저장에 실패했습니다 — 관리 화면에서 다시 설정해 주세요. 키·연결 정보는 그대로 유효합니다.",
     "roleQuestion": "어떤 직무로 채용하나요?",
     "roleLoading": "직무 카탈로그를 불러오는 중…",
     "roleLoadError": "직무 카탈로그를 불러오지 못했습니다.",

--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.equip-warning-mount.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.equip-warning-mount.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+//
+// 카디르 QA(#2822, 2026-08-03) — story #2433(B) 「PATCH 실패 시 경고 배너가 실제로 뜨는가」를
+// 소스텍스트 패턴매칭이 아니라 실제 마운트+렌더로 검증한다. 이 컴포넌트 파일에는 지금까지
+// 마운트 테스트가 0건이었다(전부 source regex 관례) — PATCH를 진짜로 실패시켜 배너 DOM이
+// 실제로 나타나는지가 이번 판의 성패축이라(PO 지시) 새 테스트 형태로 직접 만든다.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { RecruiterClient } from './recruiter-client';
+
+vi.mock('next-intl', () => ({
+  useTranslations: (ns: string) => (key: string, vars?: Record<string, unknown>) =>
+    vars ? `${ns}.${key}(${JSON.stringify(vars)})` : `${ns}.${key}`,
+  useLocale: () => 'ko',
+}));
+
+vi.mock('@/app/onboarding/onboarding-telemetry', () => ({
+  emitOnboardingEvent: vi.fn(),
+  beaconOnboardingEvent: vi.fn(),
+}));
+
+function jsonResponse(body: unknown, ok = true, status = ok ? 200 : 500) {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+describe('RecruiterClient equip-skip — PATCH 실패 시 경고 배너 실제 렌더(마운트 테스트)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      const method = init?.method ?? 'GET';
+
+      if (url.startsWith('/api/role-templates')) return jsonResponse({ data: [] });
+      if (url === '/api/projects') return jsonResponse({ data: [{ id: 'proj-1', name: 'Proj 1' }] });
+      if (url === '/api/runtime-capabilities') return jsonResponse({ data: [] });
+      if (url.startsWith('/api/team-members?')) return jsonResponse({ data: [] });
+
+      if (url === '/api/agents' && method === 'POST') {
+        return jsonResponse({
+          data: { id: 'agent-under-test', mcp_config: { mcpServers: { sprintable: {} } }, api_key: 'sk_test_placeholder' },
+        });
+      }
+
+      if (url === '/api/team-members/agent-under-test' && method === 'PATCH') {
+        // story #2433(B) — 여기가 이번 QA의 성패: 이 PATCH를 실제로 실패시킨다.
+        return jsonResponse({ error: 'boom' }, false, 500);
+      }
+
+      throw new Error(`unmocked fetch: ${method} ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('POST /api/agents 성공 + PATCH /api/team-members/{id} 실패 → equipRuntimeSaveWarning 배너가 DOM에 실제로 나타난다', async () => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<RecruiterClient projectId="proj-1" showTopBar={false} />);
+    });
+    // 마운트 시점 useEffect(role-templates/projects/runtime-capabilities) flush.
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    // STEP1: "역할 없이(키만)" 카드 클릭 → equipSkip=true.
+    const skipButtons = Array.from(container.querySelectorAll('button')).filter((b) =>
+      b.textContent?.includes('recruiter.equipSkipCardTitle'),
+    );
+    expect(skipButtons.length).toBe(1);
+    await act(async () => { skipButtons[0].dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    // "다음" 버튼 클릭 → STEP2.
+    const nextButtons = Array.from(container.querySelectorAll('button')).filter((b) =>
+      b.textContent === 'recruiter.next',
+    );
+    expect(nextButtons.length).toBeGreaterThan(0);
+    await act(async () => { nextButtons[0].dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    // STEP2: 이름 입력(handleEquipCreate가 빈 이름이면 조기 return하므로 필수).
+    const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement | null;
+    expect(nameInput).not.toBeNull();
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+      setter.call(nameInput, 'QA Mount Test Agent');
+      nameInput!.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    // "생성" CTA 클릭 → handleEquipCreate() 실행(POST 성공 → PATCH 실패 경로).
+    const createButtons = Array.from(container.querySelectorAll('button')).filter((b) =>
+      b.textContent === 'recruiter.equipCreateCta',
+    );
+    expect(createButtons.length).toBe(1);
+    expect((createButtons[0] as HTMLButtonElement).disabled).toBe(false);
+    await act(async () => { createButtons[0].dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    // handleEquipCreate 내부 await 체인(POST → PATCH → 상태갱신) flush.
+    await act(async () => {
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+
+    // 실제로 불린 fetch 호출을 확認(경로 실측 — 추측 아님).
+    const calledUrls = fetchMock.mock.calls.map((c) => `${(c[1] as RequestInit | undefined)?.method ?? 'GET'} ${c[0]}`);
+    expect(calledUrls).toContain('POST /api/agents');
+    expect(calledUrls).toContain('PATCH /api/team-members/agent-under-test');
+
+    // ⭐성패: 경고 배너가 실제 DOM에 렌더됐는가.
+    expect(container.textContent).toContain('recruiter.equipRuntimeSaveWarning');
+    const banner = container.querySelector('[role="alert"]');
+    expect(banner?.textContent).toContain('recruiter.equipRuntimeSaveWarning');
+  });
+
+  it('음성대조 — PATCH가 성공하면 배너가 안 뜬다(과잉 배너 아님)', async () => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      const method = init?.method ?? 'GET';
+      if (url.startsWith('/api/role-templates')) return jsonResponse({ data: [] });
+      if (url === '/api/projects') return jsonResponse({ data: [{ id: 'proj-1', name: 'Proj 1' }] });
+      if (url === '/api/runtime-capabilities') return jsonResponse({ data: [] });
+      if (url.startsWith('/api/team-members?')) return jsonResponse({ data: [] });
+      if (url === '/api/agents' && method === 'POST') {
+        return jsonResponse({ data: { id: 'agent-2', mcp_config: { mcpServers: { sprintable: {} } }, api_key: 'sk_test' } });
+      }
+      if (url === '/api/team-members/agent-2' && method === 'PATCH') return jsonResponse({ data: {} }, true, 200);
+      throw new Error(`unmocked fetch: ${method} ${url}`);
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<RecruiterClient projectId="proj-1" showTopBar={false} />);
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    const skipButtons = Array.from(container.querySelectorAll('button')).filter((b) =>
+      b.textContent?.includes('recruiter.equipSkipCardTitle'),
+    );
+    await act(async () => { skipButtons[0].dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const nextButtons = Array.from(container.querySelectorAll('button')).filter((b) => b.textContent === 'recruiter.next');
+    await act(async () => { nextButtons[0].dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+      setter.call(nameInput, 'QA Mount Test Agent 2');
+      nameInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    const createButtons = Array.from(container.querySelectorAll('button')).filter((b) => b.textContent === 'recruiter.equipCreateCta');
+    await act(async () => { createButtons[0].dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).not.toContain('recruiter.equipRuntimeSaveWarning');
+  });
+});

--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.test.tsx
@@ -310,3 +310,52 @@ describe('recruiter-client STEP5 — story #2410 ③-1(verifiedBanner)', () => {
     expect(source).toMatch(/\{verified && \([\s\S]{0,700}tOnboarding\('verifiedBanner'\)/);
   });
 });
+
+// story #2433(A/B) — 미르코 실측(codex 표본, 2026-08-03): 위저드에서 런타임을 골라 채용해도
+// 관리화면엔 "런타임 타입: 미설정"으로 떴다(A) + "역할 없이(키만)"는 실행환경(런타임) 단계
+// 자체가 스킵됐다(B). 소스 텍스트 수준으로 pin(이 파일의 기존 관례 — 컴포넌트 전체 마운트
+// 테스트가 없다). BE(recruit_agent → members.runtime_type anchor write)는
+// backend/tests/test_e_recruit_s3_recruit_service_realdb.py::test_recruit_persists_runtime_type_to_member
+// 가 실 Postgres로 커버한다(뮤테이션 셀프체크: 그 write 줄을 되돌려 RED 확認 후 복원).
+describe('recruiter-client equip-skip("역할 없이") 런타임 — story #2433(B) 소스 회귀가드', () => {
+  const source = readFileSync(fileURLToPath(new URL('./recruiter-client.tsx', import.meta.url)), 'utf-8');
+
+  it('equip-skip 폼(STEP2)이 Full 경로 STEP3과 같은 renderRuntimePicker()를 렌더한다 — 스킵되지 않는다', () => {
+    const start = source.indexOf('{equipSkip ? (');
+    const end = source.indexOf(') : null}', start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const equipBlock = source.slice(start, end);
+    expect(equipBlock).toContain('{renderRuntimePicker()}');
+  });
+
+  it('Full 경로 STEP3도 같은 renderRuntimePicker() 호출로 통일됐다(그리드 마크업 중복 없음)', () => {
+    const step3Block = /step === 3 && !equipSkip[\s\S]{0,200}?\{renderRuntimePicker\(\)\}/.exec(source);
+    expect(step3Block).not.toBeNull();
+  });
+
+  it('handleEquipCreate가 생성 성공 직후 PATCH /api/team-members/{id}로 runtime_type을 반영한다(관리화면과 같은 anchor 경로)', () => {
+    const handlerMatch = /const handleEquipCreate = async \(\) => \{[\s\S]*?\n  \};/.exec(source);
+    expect(handlerMatch).not.toBeNull();
+    const body = handlerMatch![0];
+    expect(body).toContain('/api/team-members/${agentId}');
+    expect(body).toContain("method: 'PATCH'");
+    expect(body).toContain('runtime_type: runtime');
+  });
+
+  it('PATCH 실패해도 결과 화면을 막지 않되(키는 이미 유효) 반쪽 상태를 조용히 숨기지 않는다', () => {
+    const handlerMatch = /const handleEquipCreate = async \(\) => \{[\s\S]*?\n  \};/.exec(source);
+    const body = handlerMatch![0];
+    expect(body).toContain('setEquipRuntimeSaveWarning(true)');
+    expect(body).toContain('setStep(3)'); // PATCH 실패 분기에서도 결과 화면 진입은 유지
+    expect(source).toContain("equipRuntimeSaveWarning && (");
+    expect(source).toContain("t('equipRuntimeSaveWarning')");
+  });
+
+  it('equipRuntimeSaveWarning 번역키가 ko/en 둘 다 있다', () => {
+    const en = (enMessages as { recruiter: Record<string, string> }).recruiter.equipRuntimeSaveWarning;
+    const ko = (koMessages as { recruiter: Record<string, string> }).recruiter.equipRuntimeSaveWarning;
+    expect(en).toBeTruthy();
+    expect(ko).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
@@ -1028,7 +1028,7 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
               <div role="status" aria-live="polite" aria-atomic="true" className="space-y-3 rounded-md border border-success-border bg-success-tint p-4">
                 <p className="text-sm font-semibold text-success">{t('equipCreatedTitle', { name: equipResult.name })}</p>
                 {equipRuntimeSaveWarning && (
-                  <p role="alert" className="flex items-start gap-1.5 rounded-md border border-warning-border bg-warning-tint p-2 text-xs text-warning">
+                  <p role="alert" className="flex items-start gap-1.5 rounded-md border border-warning-border bg-warning-tint p-2 text-xs text-foreground">
                     <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
                     {t('equipRuntimeSaveWarning')}
                   </p>

--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
@@ -291,6 +291,11 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
     api_key: string | null;
   } | null>(null);
   const [equipMcpCopied, setEquipMcpCopied] = useState(false);
+  // story #2433(B) — OrgAgentCreate(POST /api/agents) 스키마엔 runtime_type이 없어(recruit 경로와
+  // 달리 생성 호출 하나로 못 묶는다) 생성 직후 PATCH /api/team-members/{id}(관리화면이 쓰는 것과
+  // 같은 경로)로 반영한다. 이 PATCH가 실패해도 키·MCP config는 이미 유효하므로 결과 화면 자체는
+  // 막지 않되, "반쪽으로 끝났다"를 숨기지 않고 알린다.
+  const [equipRuntimeSaveWarning, setEquipRuntimeSaveWarning] = useState(false);
 
   const handleEquipCreate = async () => {
     const name = equipName.trim();
@@ -298,6 +303,7 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
     if (scopeMode === 'projects' && scopeProjectIds.length === 0) return;
     setEquipCreating(true);
     setEquipError(null);
+    setEquipRuntimeSaveWarning(false);
     try {
       const res = await fetch('/api/agents', {
         method: 'POST',
@@ -311,8 +317,23 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
       });
       if (res.ok) {
         const json = (await res.json()) as {
-          data?: { mcp_config?: Record<string, unknown> | null; api_key?: string | null };
+          data?: { id?: string; mcp_config?: Record<string, unknown> | null; api_key?: string | null };
         };
+        const agentId = json.data?.id;
+        if (agentId) {
+          try {
+            const runtimeRes = await fetch(`/api/team-members/${agentId}`, {
+              method: 'PATCH',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ runtime_type: runtime }),
+            });
+            if (!runtimeRes.ok) setEquipRuntimeSaveWarning(true);
+          } catch {
+            setEquipRuntimeSaveWarning(true);
+          }
+        } else {
+          setEquipRuntimeSaveWarning(true);
+        }
         setEquipResult({
           name,
           mcp_config: json.data?.mcp_config ?? null,
@@ -401,6 +422,85 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
     const rc = runtimeCapabilities?.find((r) => r.slug === runtime);
     return rc ? runtimeDisplayName(rc) : runtime;
   })();
+
+  // story #2433(B) — equip-skip("역할 없이(키만)")도 STEP3(실행환경) 자체가 스킵돼 런타임을
+  // 고를 길이 없었다(equip-skip은 STEP2 이후 바로 생성). Full 경로 STEP3의 런타임 그리드를
+  // 공유 렌더러로 추출해 equip-skip 폼에도 배치한다 — 그리드 마크업 중복 방지.
+  const renderRuntimePicker = () => (
+    <div className="space-y-2">
+      <p className="text-sm font-semibold text-foreground">{t('runtimeQuestion')}</p>
+      {!runtimeCapabilities ? (
+        <div className="space-y-1">
+          <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{t('runtimeSupportedLabel')}</p>
+          <div className="grid grid-cols-3 gap-2">
+            {[0, 1, 2].map((i) => <Skeleton key={i} className="h-14 rounded-xl" />)}
+          </div>
+        </div>
+      ) : runtimeCapabilitiesError ? (
+        <div role="alert" aria-live="assertive" aria-atomic="true" className="space-y-2 rounded-xl border border-border bg-muted/30 p-3">
+          <p className="text-sm font-medium text-foreground">{t('runtimeLoadError')}</p>
+          <p className="text-xs text-muted-foreground">{t('runtimeLoadErrorNote')}</p>
+          <Button variant="ghost" size="sm" onClick={() => void fetchRuntimeCapabilities()}>{t('retry')}</Button>
+        </div>
+      ) : (
+        <>
+          <div className="space-y-1">
+            <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{t('runtimeSupportedLabel')}</p>
+            <div className="grid grid-cols-3 gap-2">
+              {displayedSupportedRuntimes.map((rc) => {
+                const sel = runtime === rc.slug;
+                return (
+                  <button
+                    key={rc.slug}
+                    type="button"
+                    onClick={() => setRuntime(rc.slug)}
+                    className={cn(
+                      'relative flex flex-col items-start gap-1 rounded-xl border p-2.5 text-left transition-colors',
+                      sel ? 'border-primary/60 ring-1 ring-primary/40' : 'border-border hover:border-primary/30',
+                    )}
+                  >
+                    {sel && <Check className="absolute right-2 top-2 h-3.5 w-3.5 text-primary" aria-hidden />}
+                    <span className={cn(
+                      'flex h-6 w-6 items-center justify-center rounded-md bg-muted text-xs font-bold text-muted-foreground',
+                      sel && 'bg-primary/15 text-primary',
+                    )}>
+                      {rc.icon ?? runtimeDisplayName(rc).charAt(0).toUpperCase()}
+                    </span>
+                    <span className="text-xs font-bold text-foreground">{runtimeDisplayName(rc)}</span>
+                    {rc.tier === 'experimental' && <Badge variant="info" className="text-[9px]">{t('runtimeExperimental')}</Badge>}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+          <div className="space-y-1">
+            <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{t('runtimeComingSoonLabel')}</p>
+            <div className="grid grid-cols-3 gap-2">
+              {comingSoonRuntimes.map((rc) => (
+                <button key={rc.slug} type="button" disabled className="flex cursor-not-allowed flex-col items-start gap-1 rounded-xl border border-border bg-muted/40 p-2.5 text-left opacity-55">
+                  <span className="flex h-6 w-6 items-center justify-center rounded-md bg-muted text-xs font-bold text-muted-foreground">
+                    {rc.icon ?? runtimeDisplayName(rc).charAt(0).toUpperCase()}
+                  </span>
+                  <span className="text-xs font-bold text-foreground">{runtimeDisplayName(rc)}</span>
+                  <Badge variant="chip" className="text-[9px]">{t('runtimeComingSoonBadge')}</Badge>
+                </button>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+      <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
+        <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+        {t('runtimeGuide')}
+      </p>
+      {runtime === 'connector' && (
+        <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
+          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+          {t('runtimeCustomOtherGuide')}
+        </p>
+      )}
+    </div>
+  );
 
   // story #2377 §2(규격 A) — 「깨우기」 축. MCP 연결(①)과 지침 전달(③)만으로는 «어떤 런타임도»
   // 안 깨어난다(유나양 규격 §0, 실측 5/5) — 그 사이에 빠져 있던 ②를 명시한다.
@@ -829,6 +929,10 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
                       <option value="admin">{tSettings('agentRoleAdmin')}</option>
                     </select>
                   </div>
+                  {/* story #2433(B) — "역할 없이(키만)"도 STEP3(실행환경)이 스킵돼 런타임을 고를
+                      길이 없었다(equip-skip은 STEP2 이후 바로 생성). 키만 받는 사람도 런타임은
+                      골라야 하므로 여기서도 노출한다(Full 경로 STEP3과 동일 렌더러 공유). */}
+                  {renderRuntimePicker()}
                   {equipError && <p role="alert" aria-live="assertive" aria-atomic="true" className="text-xs text-destructive">{equipError}</p>}
                 </div>
               ) : null}
@@ -859,82 +963,7 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
           {/* ── STEP 3(Full 경로) : 실행환경 + 에이전트(G1) ── */}
           {step === 3 && !equipSkip && (
             <div className="space-y-4">
-              <div className="space-y-2">
-                <p className="text-sm font-semibold text-foreground">{t('runtimeQuestion')}</p>
-                {!runtimeCapabilities ? (
-                  <div className="space-y-1">
-                    <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{t('runtimeSupportedLabel')}</p>
-                    <div className="grid grid-cols-3 gap-2">
-                      {[0, 1, 2].map((i) => <Skeleton key={i} className="h-14 rounded-xl" />)}
-                    </div>
-                  </div>
-                ) : runtimeCapabilitiesError ? (
-                  // story #2105 2차 — fetchRuntimeCapabilities가 재시도 전 setRuntimeCapabilitiesError(false)를
-                  // 먼저 호출해(위 정의) 매 시도마다 언마운트→리마운트된다.
-                  <div role="alert" aria-live="assertive" aria-atomic="true" className="space-y-2 rounded-xl border border-border bg-muted/30 p-3">
-                    <p className="text-sm font-medium text-foreground">{t('runtimeLoadError')}</p>
-                    <p className="text-xs text-muted-foreground">{t('runtimeLoadErrorNote')}</p>
-                    <Button variant="ghost" size="sm" onClick={() => void fetchRuntimeCapabilities()}>{t('retry')}</Button>
-                  </div>
-                ) : (
-                  <>
-                    <div className="space-y-1">
-                      <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{t('runtimeSupportedLabel')}</p>
-                      <div className="grid grid-cols-3 gap-2">
-                        {displayedSupportedRuntimes.map((rc) => {
-                          const sel = runtime === rc.slug;
-                          return (
-                            <button
-                              key={rc.slug}
-                              type="button"
-                              onClick={() => setRuntime(rc.slug)}
-                              className={cn(
-                                'relative flex flex-col items-start gap-1 rounded-xl border p-2.5 text-left transition-colors',
-                                sel ? 'border-primary/60 ring-1 ring-primary/40' : 'border-border hover:border-primary/30',
-                              )}
-                            >
-                              {sel && <Check className="absolute right-2 top-2 h-3.5 w-3.5 text-primary" aria-hidden />}
-                              <span className={cn(
-                                'flex h-6 w-6 items-center justify-center rounded-md bg-muted text-xs font-bold text-muted-foreground',
-                                sel && 'bg-primary/15 text-primary',
-                              )}>
-                                {rc.icon ?? runtimeDisplayName(rc).charAt(0).toUpperCase()}
-                              </span>
-                              <span className="text-xs font-bold text-foreground">{runtimeDisplayName(rc)}</span>
-                              {rc.tier === 'experimental' && <Badge variant="info" className="text-[9px]">{t('runtimeExperimental')}</Badge>}
-                            </button>
-                          );
-                        })}
-                      </div>
-                    </div>
-                    {/* 지원 예정(레지스트리 supported=false) — dimmed·disabled */}
-                    <div className="space-y-1">
-                      <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{t('runtimeComingSoonLabel')}</p>
-                      <div className="grid grid-cols-3 gap-2">
-                        {comingSoonRuntimes.map((rc) => (
-                          <button key={rc.slug} type="button" disabled className="flex cursor-not-allowed flex-col items-start gap-1 rounded-xl border border-border bg-muted/40 p-2.5 text-left opacity-55">
-                            <span className="flex h-6 w-6 items-center justify-center rounded-md bg-muted text-xs font-bold text-muted-foreground">
-                              {rc.icon ?? runtimeDisplayName(rc).charAt(0).toUpperCase()}
-                            </span>
-                            <span className="text-xs font-bold text-foreground">{runtimeDisplayName(rc)}</span>
-                            <Badge variant="chip" className="text-[9px]">{t('runtimeComingSoonBadge')}</Badge>
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                  </>
-                )}
-                <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
-                  <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
-                  {t('runtimeGuide')}
-                </p>
-                {runtime === 'connector' && (
-                  <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
-                    <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
-                    {t('runtimeCustomOtherGuide')}
-                  </p>
-                )}
-              </div>
+              {renderRuntimePicker()}
 
               <div className="space-y-2">
                 <p className="text-sm font-semibold text-foreground">{t('agentQuestion')}</p>
@@ -998,6 +1027,12 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
                   가드에서 최초 1회만 non-null이 되므로 polite 낭독으로 충분(흐름 차단 아님). */}
               <div role="status" aria-live="polite" aria-atomic="true" className="space-y-3 rounded-md border border-success-border bg-success-tint p-4">
                 <p className="text-sm font-semibold text-success">{t('equipCreatedTitle', { name: equipResult.name })}</p>
+                {equipRuntimeSaveWarning && (
+                  <p role="alert" className="flex items-start gap-1.5 rounded-md border border-warning-border bg-warning-tint p-2 text-xs text-warning">
+                    <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+                    {t('equipRuntimeSaveWarning')}
+                  </p>
+                )}
                 {equipResult.api_key ? (
                   <div className="space-y-1">
                     <p className="text-xs font-medium text-foreground">{t('equipKeyOnceLabel')}</p>

--- a/backend/app/services/recruit_service.py
+++ b/backend/app/services/recruit_service.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.role_template import RoleTemplate
 from app.repositories.agent_persona import AgentPersonaRepository
 from app.repositories.api_key import ApiKeyRepository
+from app.repositories.team_member import TeamMemberRepository
 from app.schemas.agent_persona import PersonaSummaryResponse
 from app.services.agent_recruiter import compose_kit, validate_tool_groups
 from app.services.model_family import render_kit_for_family, resolve_model_family
@@ -99,6 +100,17 @@ async def recruit_agent(
     "family 미지정 시 기존 동작과 사실상 동일"이라는 회귀 요건도 자연히 충족한다.
     """
     await acquire_agent_mutation_lock(session, agent_member.id)
+
+    # story #2433(A, PO 예외 승인 2026-08-03 — 담당경계는 backend/=디디군이나 이 한 자리만
+    # 예외로 미르코가 고침, 근거는 PR 본문 참고): recruit 은 runtime 을 받아 compose_kit·
+    # resolve_model_family 에만 쓰고 member 레코드엔 한 번도 쓰지 않았다 — 그래서 위저드에서
+    # 런타임을 골라 채용해도 관리화면엔 "런타임 타입: 미설정"으로 떴다(PATCH /team-members/{id}
+    # 로 나중에 따로 골라야만 반영). PATCH 가 쓰는 것과 같은 anchor-routing 경로
+    # (TeamMemberRepository.apply_anchor_update → members.runtime_type)를 그대로 재사용해
+    # recruit 한 번의 호출로 같이 반영한다 — 새 write 경로를 만들지 않는다.
+    await TeamMemberRepository(session, org_id).apply_anchor_update(
+        agent_member, {"runtime_type": runtime}
+    )
 
     tool_allowlist = list(role_template.default_tool_groups)
     validate_tool_groups(tool_allowlist)  # fail-closed — ValueError 전파, 호출부가 400 매핑

--- a/backend/tests/test_e_recruit_s3_recruit_service_realdb.py
+++ b/backend/tests/test_e_recruit_s3_recruit_service_realdb.py
@@ -474,3 +474,46 @@ async def test_recruit_vs_standalone_rotate_cross_endpoint_race_no_crash():
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)
         await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_recruit_persists_runtime_type_to_member():
+    """story #2433(A): recruit이 받은 runtime을 compose_kit에만 쓰고 member.runtime_type엔
+    한 번도 안 써서, 위저드에서 런타임을 골라 채용해도 관리화면(PATCH /team-members/{id}가
+    읽는 members.runtime_type)엔 "미설정"으로 남았다 — 실측(미르코, 2026-08-03, codex 표본)
+    으로 재현된 결함. recruit이 PATCH와 같은 anchor-routing(TeamMemberRepository.
+    apply_anchor_update → members.runtime_type)으로 직접 반영하는지 실 Postgres로 검증.
+
+    baseline은 team_members가 VIEW(members 위임)라 여기(destructive_schema, create_all 자체
+    스키마)는 TeamMember/Member가 분리된 실 테이블 — apply_anchor_update가 쓰는 members 행을
+    별도로 심어야 실 저장 여부를 읽어낼 수 있다(TeamMember만 심으면 update가 0행에 no-op해도
+    조용히 통과해버려 결함을 못 잡는 자리)."""
+    from sqlalchemy import select, text as _text
+    from app.core.database import Base
+    from app.models.member import Member
+    from app.services.recruit_service import recruit_agent
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            agent, backend_rt, _qa_rt, _bogus_rt, org_id = await _seed_agent_and_role_templates(s)
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add(Member(id=agent.id, org_id=org_id, type="agent", name=agent.name))
+            await s.commit()
+
+            await recruit_agent(
+                s, agent_member=agent, org_id=org_id, role_template=backend_rt,
+                runtime="codex", actor_id=uuid.uuid4(),
+            )
+            await s.commit()
+
+        async with Session() as s:
+            member = (await s.execute(
+                select(Member).where(Member.id == agent.id)
+            )).scalar_one()
+            assert member.runtime_type == "codex"
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()


### PR DESCRIPTION
## 무엇

실측(미르코, `#2349` 온보딩 판 — codex 표본으로 채용 위저드를 처음부터 밟음)에서 발견한 두 결함.

```
A. 위저드 3실행환경에서 런타임(예: Codex)을 골라 채용해도, 관리화면엔
   "런타임 타입: 미설정" — "런타임이 설정되지 않았다. 커맨드 미지원으로 처리된다"
B. "역할 없이(키만)"을 고르면 브레드크럼이 5단계→3단계로 축소되며
   3실행환경(런타임 선택) 단계 자체가 스킵됨 — 키만 받는 사람도 런타임은 골라야 하는데
```

## 근본원인

```
recruit_agent(backend/app/services/recruit_service.py)이 받은 runtime을
compose_kit·resolve_model_family(=kit 텍스트 합성)에만 쓰고, member 레코드
(members.runtime_type)엔 한 번도 쓴 적이 없었다.

관리화면 "런타임 타입"이 읽는/쓰는 필드(PATCH /api/team-members/{id}
→ TeamMemberRepository.apply_anchor_update → members.runtime_type)와
recruit이 받는 필드(RecruitRequest.runtime)는 이름부터 다르고(runtime vs
runtime_type), recruit 경로는 후자를 쓴 적이 없다 — "받아서 kit만 만들고
멤버에는 안 쓰는" 것.

equip-skip("역할 없이") 생성 API(POST /api/v2/agents, OrgAgentCreate 스키마)엔
애초에 runtime_type 필드 자체가 없다.
```

## 수정 — A(BE) + B(FE), 같은 화면의 같은 결함이라 한 PR

```
A  recruit_agent 안에서, PATCH가 쓰는 것과 같은 anchor-routing
   (TeamMemberRepository.apply_anchor_update({runtime_type: runtime}))을
   그대로 재사용 — recruit 한 번의 호출로 kit 합성과 member 저장이 같이 된다.
   새 write 경로를 만들지 않았다(기존 PATCH 경로는 그대로 남김 — 관리화면에서
   나중에 바꾸는 길은 계속 필요).

B  Full 경로 STEP3의 런타임 그리드를 renderRuntimePicker()로 추출해
   equip-skip 폼(STEP2)에도 배치 — 마크업 중복 없이 공유. equip 생성 API엔
   runtime_type 필드가 없어(스키마 자체에 없음) 생성 성공 직후
   PATCH /api/team-members/{agentId}(관리화면과 동일 경로)로 반영한다.
   그 PATCH가 실패해도 키·MCP config는 이미 유효하므로 결과 화면은 막지 않되,
   "반쪽으로 끝났다"를 숨기지 않고 경고 배너로 알린다(equipRuntimeSaveWarning).
```

### ⛔ B에 남은 부채 — 왜 여기서 안 끝냈는지

B의 "생성 성공 후 PATCH 체이닝"은 A(recruit)가 피한 바로 그 패턴("호출 둘로 갈려 뒤엣것 실패
시 반쪽")과 형태가 같다. 다만 A와 달리 equip 생성 API(`OrgAgentCreate`)엔 애초에
`runtime_type` 필드가 없어(스키마 자체에) 한 호출로 못 묶는다 — 그래서 실패해도 "조용한
반쪽"이 아니라 "보이는 반쪽"(경고 배너)으로 최소한 정직하게는 만들었다. **진짜 근본은
`OrgAgentCreate`에 `runtime_type`을 넣어 A와 같은 단일-호출 형태로 만드는 것**인데, 그러면
이 PR에서 또 BE 스키마를 만지게 되어(A도 이미 담당경계 예외였다) 범위가 는다 — 별건(`#2435`)
으로 미룬다.

### CI가 잡은 것 — story #2420(tint-배경×계열색-글자) 회귀 가드

경고 배너 첫 시도가 `bg-warning-tint` 위에 `text-warning`을 써 `verify:no-new-tint-color-text`
guard에 걸렸다(#2420 AC7 규칙: tint 배경 위 글자는 계열색이 아니라 `text-foreground`) —
`text-foreground`로 교체해 통과.

## ⚠️ 담당 경계 예외 — backend/ 변경 이유

원래 담당범위(FE만, backend/는 디디군)를 이 건 하나만 PO가 명시로 풀었다.
근거: ①디디군이 지금 만지는 축(connectors/, sprintable_connectors)은
recruit_service.py와 겹치지 않아 충돌 위험 0 ②A/B가 같은 화면의 같은 결함이라
한 PR로 보는 게 검증도 정확 ③FE에서 "생성 성공 후 PATCH를 또 부르는" 체이닝은
반창고(호출이 둘로 갈려 뒤엣것 실패 시 반쪽 상태가 남고, 다른 생성 경로가 생기면
또 빠뜨림) — recruit은 runtime을 이미 받고 있으니 그 자리에서 쓰는 게 근본.
BE 변경은 조건대로 그 한 자리(recruit 경로 → members.runtime_type)만.

## 확認(사전 체크, PO 요청)

```
① members.runtime_type 어휘 = recruit runtime 값 어휘 — 9종 RuntimeType enum과
   claude-code/codex/gemini/cursor/opencode/openclaw/hermes/grok/pi 정확히 일치.
   단 "connector"(BYO 버킷, Custom/Other)는 9종 enum에 없음 — 쓰면
   get_runtime_capability가 안전하게 UNSUPPORTED로 처리하지만(예외 안 던짐),
   관리화면 런타임 드롭다운도 애초에 "connector"를 옵션으로 안 준다(9종만
   노출) — 그 값이 저장되면 관리화면 드롭다운에서 매칭 안 되는 코스메틱
   불일치가 있을 수 있음(둘 다 pre-existing gap, 이 PR 스코프 밖으로 남김).
② runtime_type을 쓰는 다른 경로 존재 여부 — grep 전수 확認, PATCH
   /team-members/{id}(TeamMemberUpdate) 하나뿐이었다. 충돌 없음.
```

## 검증

```
BE  실 Postgres(alembic upgrade heads, sprintable_test DB)로
    test_e_recruit_s3_recruit_service_realdb.py 8/8 통과(기존 7 + 신규 1)
    신규 test_recruit_persists_runtime_type_to_member: 뮤테이션 셀프체크
    (저장 줄 제거 → "assert None == 'codex'"로 정확히 RED 확認 후 복원)
    test_e_recruit_s3_recruit_endpoint.py 14/14 무회귀

FE  pnpm --filter web type-check   0에러
    pnpm --filter web lint         0경고(무관 파일 기존 warning 3건만)
    pnpm --filter web build        EXIT 0
    vitest recruiter-client.test.tsx  39/39(기존 34 + 신규 5)
    신규 가드 뮤테이션 셀프체크(PATCH body runtime_type→null 치환 →
    정확히 RED 확認 후 복원)
```

## 머지 후 남은 것

배포 dev FE에 puppeteer로 라이브 재검증 — A: 신규 채용 후 관리화면에
런타임이 실제로 반영되는지, B: "역할 없이" 경로에서도 런타임 그리드가
노출·저장되는지. 로컬 pre-merge 라이브는 dev BE와 JWT_SECRET 불일치로
불가([[reference-live-fe-verify-deployed-only]] 동일 원칙) — 머지·배포
확認되는 대로 밟는다.

재현 재료: 몽클랩 > sprintable > 워크포스 > "Acceptance Validator 채용
1호"(실측 중 생성) — 정리하지 않고 대조군으로 유지했다.

## Test plan
- [x] BE realdb 회귀 스위트 + 신규 뮤테이션 셀프체크
- [x] FE type-check/lint/build/vitest + 신규 가드 뮤테이션 셀프체크
- [ ] 배포 dev FE 라이브 재검증(머지 후)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
