### PR TITLE
fix(#2439): codex 커넥터 turn 재진입 race 근본 수정 — turn_id pending-map + 직렬화

### DIFF
--- a/connectors/codex-sprintable/host.py
+++ b/connectors/codex-sprintable/host.py
@@ -89,29 +89,52 @@ class CodexAppServer:
         logger.info("codex app-server initialized")
 
     async def _read_loop(self) -> None:
-        """stdout JSON-RPC 라인 파싱 → response 매칭 + notification 처리."""
+        """stdout JSON-RPC 라인 파싱 → response 매칭 + notification 처리.
+
+        #2439 QA(카디르) — codex 프로세스가 turn 도중 죽으면(stdout EOF) completion도 error도
+        다시는 안 온다 — 그 경로는 _on_notification의 error 분기에 닿지 않는다. finally에서
+        루프 종료(EOF든 예외든) 시 남은 모든 pending turn/RPC를 fail-fast로 풀어 orphan hang을
+        막는다(그 hang이 self._turn_lock을 쥔 채라 이후 요청까지 막히는 것도 같이 막는다 —
+        예외가 run_turn의 `async with self._turn_lock:` 밖으로 전파되며 lock이 정상 해제된다).
+        """
         assert self._proc and self._proc.stdout
-        while True:
-            line = await self._proc.stdout.readline()
-            if not line:
-                break
-            try:
-                msg = json.loads(line.decode("utf-8"))
-            except json.JSONDecodeError:
-                continue
-            # response (id 있음 + result/error)
-            if "id" in msg and ("result" in msg or "error" in msg):
-                fut = self._pending.pop(msg["id"], None)
-                if fut and not fut.done():
-                    if "error" in msg:
-                        fut.set_exception(RuntimeError(str(msg["error"])))
-                    else:
-                        fut.set_result(msg.get("result"))
-                continue
-            # notification (method 있음, id 없음)
-            method = msg.get("method")
-            if method:
-                self._on_notification(method, msg.get("params") or {})
+        try:
+            while True:
+                line = await self._proc.stdout.readline()
+                if not line:
+                    break
+                try:
+                    msg = json.loads(line.decode("utf-8"))
+                except json.JSONDecodeError:
+                    continue
+                # response (id 있음 + result/error)
+                if "id" in msg and ("result" in msg or "error" in msg):
+                    fut = self._pending.pop(msg["id"], None)
+                    if fut and not fut.done():
+                        if "error" in msg:
+                            fut.set_exception(RuntimeError(str(msg["error"])))
+                        else:
+                            fut.set_result(msg.get("result"))
+                    continue
+                # notification (method 있음, id 없음)
+                method = msg.get("method")
+                if method:
+                    self._on_notification(method, msg.get("params") or {})
+        finally:
+            self._fail_all_pending("codex app-server stdout closed (process exited mid-turn?)")
+
+    def _fail_all_pending(self, reason: str) -> None:
+        """읽기 루프가 어떤 경로로든 끝나면(EOF·예외) 남은 pending turn/RPC를 전부 fail-fast."""
+        exc = RuntimeError(reason)
+        for turn_id, fut in list(self._pending_turns.items()):
+            if not fut.done():
+                fut.set_exception(exc)
+            self._pending_turns.pop(turn_id, None)
+            self._turn_texts.pop(turn_id, None)
+        for rid, fut in list(self._pending.items()):
+            if not fut.done():
+                fut.set_exception(exc)
+            self._pending.pop(rid, None)
 
     def _on_notification(self, method: str, params: dict) -> None:
         """ServerNotification 처리 — turn_id로 올바른 run_turn() 호출에 라우팅(#2439)."""
@@ -149,7 +172,7 @@ class CodexAppServer:
         assert self._proc and self._proc.stdin
         self._req_id += 1
         rid = self._req_id
-        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
         self._pending[rid] = fut
         payload = {"jsonrpc": "2.0", "id": rid, "method": method}
         if params is not None:
@@ -201,7 +224,7 @@ class CodexAppServer:
             if not turn_id:
                 raise RuntimeError(f"turn/start returned no turn id: {result}")
 
-            fut: asyncio.Future = asyncio.get_event_loop().create_future()
+            fut: asyncio.Future = asyncio.get_running_loop().create_future()
             self._pending_turns[turn_id] = fut
             self._turn_texts[turn_id] = []
             try:

--- a/connectors/codex-sprintable/host.py
+++ b/connectors/codex-sprintable/host.py
@@ -13,6 +13,16 @@ gemini/pi/grok이 이 패턴을 동형으로 따라간다.
 실측 프로토콜 (codex app-server generate-ts, codex-cli 0.124.0):
   initialize → initialized(notify) → thread/start → turn/start
   ServerNotification: item/completed {item:{type:"agentMessage",text}}, turn/completed
+
+story #2439(2026-08-03, #2438 진단의 근본수정) — 재진입(겹침) race 제거:
+  turn/start 호출을 self._turn_lock(asyncio.Lock)으로 직렬화해 «이전 turn이 아직 active인
+  동안 새 turn/start를 codex에 절대 보내지 않는다» — 겹침 자체가 안 생기므로 codex가
+  겹친 turn/start에 내주는 phantom turn(응답은 오지만 다시는 완료 신호가 없는 turn_id, 라이브
+  실측 확認)이 발생할 여지가 없다. 방어적으로 완료 라우팅도 turn_id 키 pending-map으로 바꿔
+  (기존의 단일 self._turn_done Event 통째-교체 방식은 재진입 시 첫 호출이 기다리던 옛 Event가
+  다시는 set되지 않아 영원히 hang했다 — 정확히 #2438이 재현한 "간헐적 자동주입 실패") 설령
+  어떤 경로로든 두 turn이 겹치더라도 각 run_turn()이 "자기 turn_id"의 완료만 기다리게 한다.
+  타임아웃/재시도로 덮지 않음 — orphan 자체가 구조적으로 불가능해야 한다는 원칙.
 """
 from __future__ import annotations
 
@@ -44,9 +54,14 @@ class CodexAppServer:
         self._proc: asyncio.subprocess.Process | None = None
         self._req_id = 0
         self._pending: dict[int, asyncio.Future] = {}
-        # turn 응답 수집: turn 진행 중 agentMessage 텍스트 누적
-        self._turn_messages: list[str] = []
-        self._turn_done: asyncio.Event | None = None
+        # turn_id → (완료 Future, 그 turn의 agentMessage 텍스트 누적) — #2439: 겹침이 생겨도
+        # 각 run_turn()이 «자기 turn_id»의 완료만 기다리도록 turn_id로 라우팅한다.
+        self._pending_turns: dict[str, asyncio.Future] = {}
+        self._turn_texts: dict[str, list[str]] = {}
+        # #2439: turn/start를 직렬화 — 이전 turn이 아직 active인 동안 새 turn/start를 codex에
+        # 절대 보내지 않는다(라이브 실측: 겹치면 codex가 phantom turn을 내주고 실제 처리는
+        # 기존 turn에 merge — 겹침 자체를 없애는 것이 근본 처방).
+        self._turn_lock = asyncio.Lock()
         self._reader_task: asyncio.Task | None = None
         self._thread_id: str | None = None
 
@@ -99,20 +114,35 @@ class CodexAppServer:
                 self._on_notification(method, msg.get("params") or {})
 
     def _on_notification(self, method: str, params: dict) -> None:
-        """ServerNotification 처리 — turn 응답 수집."""
+        """ServerNotification 처리 — turn_id로 올바른 run_turn() 호출에 라우팅(#2439)."""
         if method == "item/completed":
             item = params.get("item") or {}
             if item.get("type") == "agentMessage":
                 text = item.get("text", "")
-                if text:
-                    self._turn_messages.append(text)
+                turn_id = params.get("turnId")
+                if text and turn_id in self._turn_texts:
+                    self._turn_texts[turn_id].append(text)
         elif method == "turn/completed":
-            if self._turn_done and not self._turn_done.is_set():
-                self._turn_done.set()
+            turn = params.get("turn") or {}
+            turn_id = turn.get("id")
+            fut = self._pending_turns.pop(turn_id, None)
+            if fut and not fut.done():
+                fut.set_result(list(self._turn_texts.pop(turn_id, [])))
         elif method == "error":
             logger.warning("codex error notification: %s", params)
-            if self._turn_done and not self._turn_done.is_set():
-                self._turn_done.set()
+            # threadId/turnId가 없는 전역 에러 — 지금 대기 중인 모든 turn을 fail-fast로
+            # 풀어준다(#2438과 같은 결의 재발 방지 — "아무 신호도 안 와서 hang"을 만들지 않음).
+            turn_id = params.get("turnId") or (params.get("turn") or {}).get("id")
+            if turn_id:
+                fut = self._pending_turns.pop(turn_id, None)
+                if fut and not fut.done():
+                    fut.set_exception(RuntimeError(f"codex error: {params}"))
+            else:
+                for pending_id, fut in list(self._pending_turns.items()):
+                    if not fut.done():
+                        fut.set_exception(RuntimeError(f"codex error (no turnId): {params}"))
+                    self._pending_turns.pop(pending_id, None)
+                    self._turn_texts.pop(pending_id, None)
 
     async def _request(self, method: str, params: dict | None) -> dict:
         """JSON-RPC request 송신 + response 대기."""
@@ -153,18 +183,34 @@ class CodexAppServer:
         return self._thread_id
 
     async def run_turn(self, text: str) -> str:
-        """turn/start로 주입 → turn/completed까지 agentMessage 수집 → 응답 반환."""
-        thread_id = await self.ensure_thread()
-        self._turn_messages = []
-        self._turn_done = asyncio.Event()
+        """turn/start로 주입 → «자기 turn_id»의 turn/completed까지 agentMessage 수집 → 응답 반환.
 
-        await self._request("turn/start", {
-            "threadId": thread_id,
-            "input": [{"type": "text", "text": text, "text_elements": []}],
-        })
-        # turn/completed 대기 (응답 스트림 수집 완료)
-        await self._turn_done.wait()
-        return "\n".join(self._turn_messages).strip()
+        #2439: self._turn_lock으로 직렬화 — 이전 turn이 아직 active인 동안은 이 turn/start
+        자체가 codex로 안 나간다(겹침 발생 원천 차단). 그 위에 turn_id 키 pending-map으로
+        완료 신호도 정확히 "자기 turn"만 받게 해 이중으로 막는다(설령 겹침이 다른 경로로
+        생겨도 orphan 없음).
+        """
+        thread_id = await self.ensure_thread()
+        async with self._turn_lock:
+            result = await self._request("turn/start", {
+                "threadId": thread_id,
+                "input": [{"type": "text", "text": text, "text_elements": []}],
+            })
+            turn = (result or {}).get("turn") or {}
+            turn_id = turn.get("id")
+            if not turn_id:
+                raise RuntimeError(f"turn/start returned no turn id: {result}")
+
+            fut: asyncio.Future = asyncio.get_event_loop().create_future()
+            self._pending_turns[turn_id] = fut
+            self._turn_texts[turn_id] = []
+            try:
+                texts = await fut
+            finally:
+                # 타임아웃/취소 등 어떤 경로로 빠져나가도 맵에 orphan 항목이 안 남게 정리.
+                self._pending_turns.pop(turn_id, None)
+                self._turn_texts.pop(turn_id, None)
+            return "\n".join(texts).strip()
 
     async def stop(self) -> None:
         """자식 프로세스 graceful 종료 (SIGTERM → kill)."""

--- a/connectors/codex-sprintable/test_host_turn_race.py
+++ b/connectors/codex-sprintable/test_host_turn_race.py
@@ -1,0 +1,175 @@
+"""story #2439 — codex 커넥터 재진입 race(간헐 주입 실패, #2438 진단) 회귀 방지.
+
+라이브 재현(2026-08-03, 디디, codex-cli 0.144.2)에서 실측한 정확한 서버 거동을 페이크
+app-server로 재현한다: 이미 active인 turn 중에 새 turn/start가 오면 codex는 즉시 200으로
+«가짜 turn»(다시는 안 나타나는 phantom turn_id)을 돌려주고, 실제 두 번째 메시지는 첫 번째
+turn에 조용히 merge해 그 turn 하나의 turn/completed로만 끝낸다.
+
+버그(수정 전 host.py): run_turn()이 self._turn_done(단일 Event)을 매 호출 통째 교체 →
+재진입 시 첫 호출이 기다리던 옛 Event가 다시는 set되지 않아 영원히 hang.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class _FakeWriter:
+    def __init__(self, on_line) -> None:
+        self._on_line = on_line
+        self._buf = b""
+
+    def write(self, data: bytes) -> None:
+        self._buf += data
+        while b"\n" in self._buf:
+            line, self._buf = self._buf.split(b"\n", 1)
+            if line:
+                self._on_line(json.loads(line.decode("utf-8")))
+
+    async def drain(self) -> None:
+        return None
+
+
+class _FakeReader:
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+    def push(self, obj: dict) -> None:
+        self._queue.put_nowait((json.dumps(obj) + "\n").encode("utf-8"))
+
+    async def readline(self) -> bytes:
+        return await self._queue.get()
+
+
+class FakeCodexAppServer:
+    """실측(2026-08-03) 그대로: 겹쳐 들어온 turn/start는 phantom turn_id를 반환하고,
+    실제 처리는 활성 turn에 merge — 그 turn 하나의 turn/completed로만 신호를 보낸다."""
+
+    def __init__(self, *, turn_delay: float = 0.05) -> None:
+        self.stdout = _FakeReader()
+        self.stdin = _FakeWriter(self._on_line)
+        self.stderr = _FakeReader()
+        self.returncode: int | None = None
+        self._turn_delay = turn_delay
+        self._active_turn_id: str | None = None
+        self._active_turn_texts: list[str] = []
+        self._turn_seq = 0
+        self._merged_calls = 0  # 겹쳐 merge된 횟수(뮤테이션/검증용 카운터)
+
+    def _on_line(self, msg: dict) -> None:
+        method = msg.get("method")
+        rid = msg.get("id")
+        if method == "initialize":
+            self.stdout.push({"id": rid, "result": {}})
+        elif method == "initialized":
+            pass
+        elif method == "thread/start":
+            self.stdout.push({"id": rid, "result": {"thread": {"id": "thread-1"}}})
+        elif method == "turn/start":
+            text = msg["params"]["input"][0]["text"]
+            if self._active_turn_id is None:
+                # 새 turn — 정상 시작
+                self._turn_seq += 1
+                turn_id = f"turn-{self._turn_seq}"
+                self._active_turn_id = turn_id
+                self._active_turn_texts = [text]
+                self.stdout.push({"id": rid, "result": {"turn": {"id": turn_id, "status": "inProgress"}}})
+                asyncio.get_event_loop().create_task(self._finish_active_turn())
+            else:
+                # ⭐실측 재현: active turn 중 겹쳐 들어온 turn/start — phantom turn_id 반환,
+                # 실제로는 활성 turn 텍스트 목록에 merge(다시는 이 phantom turn_id로 신호 없음).
+                self._turn_seq += 1
+                phantom_id = f"turn-{self._turn_seq}-phantom"
+                self._active_turn_texts.append(text)
+                self._merged_calls += 1
+                self.stdout.push({"id": rid, "result": {"turn": {"id": phantom_id, "status": "inProgress"}}})
+
+    async def _finish_active_turn(self) -> None:
+        await asyncio.sleep(self._turn_delay)
+        turn_id = self._active_turn_id
+        texts = list(self._active_turn_texts)
+        # merge된 각 텍스트마다 agentMessage 하나씩(실측처럼 순차 item/completed)
+        for t in texts:
+            self.stdout.push({
+                "method": "item/completed",
+                "params": {"item": {"type": "agentMessage", "text": f"echo:{t}"},
+                           "threadId": "thread-1", "turnId": turn_id},
+            })
+        self.stdout.push({
+            "method": "turn/completed",
+            "params": {"threadId": "thread-1", "turn": {"id": turn_id, "status": "completed"}},
+        })
+        self._active_turn_id = None
+        self._active_turn_texts = []
+
+    async def wait(self):
+        return 0
+
+    def terminate(self):
+        pass
+
+    def kill(self):
+        pass
+
+
+async def _install_fake(monkeypatch, fake: FakeCodexAppServer):
+    async def _fake_create_subprocess_exec(*args, **kwargs):
+        return fake
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+
+
+@pytest.mark.anyio
+async def test_overlapping_run_turn_both_resolve_without_hang(monkeypatch):
+    """핵심 회귀 테스트 — turn1이 아직 끝나기 전에 turn2를 겹쳐 호출해도 «둘 다» 유한 시간 내 반환.
+    수정 전(버그 있음): 첫 호출이 옛 Event를 기다리다 절대 안 풀려 타임아웃(hang) — RED.
+    수정 후: 직렬화(lock)로 codex 겹침 자체가 안 생기거나, turn_id map으로 각자 정확히 반환 — GREEN."""
+    import host
+
+    fake = FakeCodexAppServer(turn_delay=0.1)
+    await _install_fake(monkeypatch, fake)
+
+    codex = host.CodexAppServer(cwd="/tmp")
+    await codex.start()
+    try:
+        t1 = asyncio.create_task(codex.run_turn("msg-A"))
+        await asyncio.sleep(0.02)  # msg-A가 아직 active인 사이 msg-B 겹쳐 호출
+        t2 = asyncio.create_task(codex.run_turn("msg-B"))
+
+        done, pending = await asyncio.wait({t1, t2}, timeout=3.0)
+        assert not pending, "겹쳐 호출한 run_turn 중 하나 이상이 hang(타임아웃) — orphan Event 회귀"
+
+        r1, r2 = await t1, await t2
+        assert r1 == "echo:msg-A", f"turn1 응답이 오염됨: {r1!r}"
+        assert r2 == "echo:msg-B", f"turn2 응답이 오염됨: {r2!r}"
+    finally:
+        await codex.stop()
+
+
+@pytest.mark.anyio
+async def test_sequential_run_turn_unaffected(monkeypatch):
+    """양성대조 — 겹치지 않는 정상 순차 호출은 무회귀."""
+    import host
+
+    fake = FakeCodexAppServer(turn_delay=0.05)
+    await _install_fake(monkeypatch, fake)
+
+    codex = host.CodexAppServer(cwd="/tmp")
+    await codex.start()
+    try:
+        r1 = await codex.run_turn("one")
+        r2 = await codex.run_turn("two")
+        assert r1 == "echo:one"
+        assert r2 == "echo:two"
+    finally:
+        await codex.stop()

--- a/connectors/codex-sprintable/test_host_turn_race.py
+++ b/connectors/codex-sprintable/test_host_turn_race.py
@@ -44,11 +44,19 @@ class _FakeWriter:
 class _FakeReader:
     def __init__(self) -> None:
         self._queue: asyncio.Queue[bytes] = asyncio.Queue()
+        self._closed = False
 
     def push(self, obj: dict) -> None:
         self._queue.put_nowait((json.dumps(obj) + "\n").encode("utf-8"))
 
+    def close(self) -> None:
+        """#2439 QA(카디르) 재현용 — codex 프로세스가 죽어 stdout이 EOF되는 것을 흉내낸다."""
+        self._closed = True
+        self._queue.put_nowait(b"")  # 대기 중인 readline()을 즉시 깨움
+
     async def readline(self) -> bytes:
+        if self._closed and self._queue.empty():
+            return b""
         return await self._queue.get()
 
 
@@ -85,7 +93,7 @@ class FakeCodexAppServer:
                 self._active_turn_id = turn_id
                 self._active_turn_texts = [text]
                 self.stdout.push({"id": rid, "result": {"turn": {"id": turn_id, "status": "inProgress"}}})
-                asyncio.get_event_loop().create_task(self._finish_active_turn())
+                asyncio.get_running_loop().create_task(self._finish_active_turn())
             else:
                 # ⭐실측 재현: active turn 중 겹쳐 들어온 turn/start — phantom turn_id 반환,
                 # 실제로는 활성 turn 텍스트 목록에 merge(다시는 이 phantom turn_id로 신호 없음).
@@ -123,6 +131,16 @@ class FakeCodexAppServer:
         pass
 
 
+class FakeCodexAppServerDiesMidTurn(FakeCodexAppServer):
+    """#2439 QA(카디르) 재현 — turn/start 응답만 주고, completion/error «둘 다» 영원히 안 오는
+    채로 stdout이 죽는다(codex 프로세스가 turn 도중 크래시하는 것과 동형)."""
+
+    async def _finish_active_turn(self) -> None:
+        await asyncio.sleep(self._turn_delay)
+        # completion도 error도 안 보내고 그냥 프로세스가 죽는다 — stdout EOF.
+        self.stdout.close()
+
+
 async def _install_fake(monkeypatch, fake: FakeCodexAppServer):
     async def _fake_create_subprocess_exec(*args, **kwargs):
         return fake
@@ -154,6 +172,59 @@ async def test_overlapping_run_turn_both_resolve_without_hang(monkeypatch):
         assert r2 == "echo:msg-B", f"turn2 응답이 오염됨: {r2!r}"
     finally:
         await codex.stop()
+
+
+@pytest.mark.anyio
+async def test_process_death_mid_turn_fails_fast_not_hang(monkeypatch):
+    """#2439 QA(카디르) 재현 — codex 프로세스가 turn 진행 중 죽으면(stdout EOF, completion도
+    error도 다시는 안 옴) run_turn()이 그 자리서 즉시 실패해야 한다(hang 0).
+
+    수정 전(read_loop이 EOF에 그냥 break만 하고 _pending_turns를 아무도 안 풂): hang — RED.
+    수정 후(read_loop 종료 시 남은 pending turn 전부 fail-fast): 즉시 예외 — GREEN."""
+    import host
+
+    fake = FakeCodexAppServerDiesMidTurn(turn_delay=0.05)
+    await _install_fake(monkeypatch, fake)
+
+    codex = host.CodexAppServer(cwd="/tmp")
+    await codex.start()
+    try:
+        task = asyncio.create_task(codex.run_turn("msg-death"))
+        done, pending = await asyncio.wait({task}, timeout=2.0)
+        assert not pending, "codex 프로세스가 turn 중 죽었는데 run_turn이 hang — orphan 회귀"
+        with pytest.raises(Exception):
+            await task
+    finally:
+        await codex.stop()
+
+
+@pytest.mark.anyio
+async def test_turn_id_routing_is_defense_in_depth_correct():
+    """㉡ 카디르 QA 기록 — self._turn_lock이 겹침을 원천 차단하므로 정상 경로(run_turn 경유)
+    에서는 turn_id map의 라우팅 분기가 도달 불가(unreachable)하다. 그래도 그 층 자체가 옳게
+    동작하는지는 lock을 우회해 turn_id 두 개를 직접 등록·완료시켜 검증한다 — 방어적 설계가
+    "무엇으로부터" 방어하는지 그 층만 따로 고정한다(향후 lock이 우회/약화돼도 이 층이 산다)."""
+    import host
+
+    codex = host.CodexAppServer(cwd="/tmp")
+    fut_a: asyncio.Future = asyncio.get_running_loop().create_future()
+    fut_b: asyncio.Future = asyncio.get_running_loop().create_future()
+    codex._pending_turns["turn-A"] = fut_a
+    codex._turn_texts["turn-A"] = []
+    codex._pending_turns["turn-B"] = fut_b
+    codex._turn_texts["turn-B"] = []
+
+    codex._on_notification(
+        "item/completed", {"item": {"type": "agentMessage", "text": "for-A"}, "turnId": "turn-A"},
+    )
+    codex._on_notification(
+        "item/completed", {"item": {"type": "agentMessage", "text": "for-B"}, "turnId": "turn-B"},
+    )
+    codex._on_notification("turn/completed", {"turn": {"id": "turn-B"}})
+    codex._on_notification("turn/completed", {"turn": {"id": "turn-A"}})
+
+    assert await fut_a == ["for-A"], "turn-A 텍스트가 turn-B와 섞임 — turn_id 라우팅 회귀"
+    assert await fut_b == ["for-B"], "turn-B 텍스트가 turn-A와 섞임 — turn_id 라우팅 회귀"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## 배경
#2438 진단의 근본 수정(선생님 착수 승인 07:51Z). 원인: `connectors/codex-sprintable/host.py`의 `run_turn()`이 `self._turn_done`(단일 `asyncio.Event`)을 매 호출 통째 교체 — 재진입(겹침) 호출 시 첫 호출이 기다리던 옛 Event가 다시는 `set()`되지 않아 영원히 hang한다. 이것이 #2438이 재현한 "간헐적 자동주입 실패"의 정확한 코드 원인이다.

라이브 실측(codex-cli 0.144.2): 이전 turn이 아직 active인 동안 새 `turn/start`를 보내면 codex는 에러 없이 즉시 200으로 "phantom turn"(응답은 오지만 다시는 완료 신호가 없는 turn_id)을 반환하고, 실제 두 번째 메시지는 기존 active turn에 조용히 merge한다.

## 수정 — 두 겹 방어(반창고 아님)
1. `self._turn_lock`(`asyncio.Lock`)으로 `turn/start` 자체를 직렬화 — 이전 turn이 active인 동안 새 `turn/start`가 codex로 **절대 안 나간다**. 겹침의 발생 원천을 차단(AC3).
2. 완료 라우팅을 turn_id 키 pending-map(`dict[turn_id, Future]`)으로 교체 — 설령 다른 경로로 겹침이 생겨도 각 `run_turn()`이 "자기 turn_id"의 완료만 기다린다. `item/completed` 텍스트도 turn_id로 정확히 라우팅해 다른 호출로 안 샌다(AC1·AC2).
3. 전역 `error` 알림 시 대기 중인 모든 turn을 fail-fast로 풀어 새로운 hang 경로를 만들지 않음.

타임아웃/재시도 없음 — orphan이 구조적으로 불가능해지는 방향(AC5).

## 검증(AC4)
`test_host_turn_race.py` — 겹쳐 호출(turn1 진행 중 turn2 주입) 시나리오를 페이크 app-server(라이브 실측 그대로: 겹치면 phantom turn_id 반환 + 기존 turn에 merge)로 재현.

- 수정 전 코드에 대해 먼저 실행 → **RED 확認**(첫 호출이 실제로 hang·타임아웃)
- 수정 적용 후 → **GREEN 재확認**
- **뮤테이션 검증**: 직렬화 Lock만 제거(turn_id map은 유지)한 재-sabotage 버전 → 테스트가 다시 정확히 **RED**(이번엔 두 번째 호출이 hang — lock이 막던 겹침이 실제로 재발함을 그대로 보여줌) → 복원 → 재전체 GREEN
- 양성대조(겹치지 않는 정상 순차 호출) 포함 — 무회귀 확認

로컬 실행: `uv run --with pytest --with anyio --with pytest-asyncio --with httpx pytest connectors/codex-sprintable/test_host_turn_race.py`(connectors/에 아직 CI 워크플로 연결이 없어 수동 실행 — 별도 발견, 이 PR 스코프 밖).

## 스코프(AC6) — codex-sprintable만
grep/diff로 나머지 셋의 실제 패턴을 정확히 갈랐다:
- **pi-sprintable**: `_turn_done = asyncio.Event()` 동일 패턴 — **같은 Event-orphan hang 버그**에 노출.
- **gemini-sprintable·grok-sprintable**: ACP `session/prompt`는 request/response 자체가 완료 신호(별도 notification 대기 없음)라 Event-orphan hang은 없다. 다만 `self._turn_messages`가 turn-scope 없는 공유 리스트라 겹쳐 호출 시 응답 텍스트가 다른 호출로 섞일 수 있는 **다른(더 약한) race**가 있다.

셋 다 이 PR 범위 밖 — 별건으로 남긴다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)