### PR TITLE
fix(#2442): prod DB pool 20/10 SSOT durable화 + PgBouncer 전제 폐기

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -63,6 +63,16 @@ jobs:
             # (PgBouncer 풀러 불필요/불가 — Cloud Run raw TCP 미지원으로 중앙 PgBouncer 불가·관리형 풀링은
             # Enterprise Plus 전용(#1779 폐기 이력). 트래픽↑ 시 아키텍처 재검토(#2074) 필요.)
             echo "backend_max_instances=5" >> "$GITHUB_OUTPUT"
+            # story #2442(P0, 2026-08-03) — prod DB 커넥션 풀 고갈 인시던트(08:44Z, QueuePool
+            # 타임아웃·/api/v2/health 전면 실패). PgBouncer가 prod에 없거나 무력해(db_pgbouncer=
+            # False 코드+배포 양쪽 기본값 — 위 "PgBouncer 풀러 불가" 참고) tiny 앱 풀(3+1=4)이
+            # Cloud SQL에 직결돼 즉시 고갈. PO가 gcloud로 20/10(rev 00257-wdz)까지 올려 즉시 회복
+            # 확認(health 8/8 200) — 그 손 값을 SSOT로 durable화("손 값은 배포가 덮는다" 교훈).
+            # 안전식(롤아웃 배수 없이): maxScale(5)×(pool+overflow)+raw(1)=5×30+1=151≤200(25%여유).
+            # ⚠️잔여 리스크(docs/db-connection-budget.md 롤아웃 산식 2×N×5로는 2×5×31=310>200) —
+            # main 배포 빈도가 낮아 감수(PO 확認 필요, 재검토 트리거는 위 문서 참고).
+            echo "db_pool_size=20" >> "$GITHUB_OUTPUT"
+            echo "db_max_overflow=10" >> "$GITHUB_OUTPUT"
             # story #2005: PO 라이브 gcloud 실측(2026-07-17) — backend-prod 현재 유효 Cloud Run
             # 요청 타임아웃=300s. 지금까지 `cloudbuild.yaml`에 `--timeout` 플래그가 없어 이
             # 값은 인프라 기본값이었을 뿐 어디에도 명시돼 있지 않았다 — 이제 이 워크플로우가
@@ -166,6 +176,13 @@ jobs:
             # 로 durable(lingering env 덮어씀).
             # (dev/prod는 별도 Cloud SQL 인스턴스로 확認됨(story #2040 PO gcloud 재확認) — 합산 불필요.)
             echo "backend_max_instances=8" >> "$GITHUB_OUTPUT"
+            # story #2442(P0) — cloudbuild.yaml `_DB_POOL_SIZE`/`_DB_MAX_OVERFLOW` 기본값(3/1)과
+            # 동일값. #2040에서 이미 검증된 dev 예산 그대로 — 값을 바꾸는 게 아니라
+            # `backend_max_instances`/`backend_timeout`과 동일하게 대칭 배선하는 것뿐(이 output이
+            # --substitutions= 에서 무조건 참조되므로 비워두면 빈 문자열로 cloudbuild.yaml 기본값을
+            # 덮어써버린다 — ga4_measurement_id가 dev에서 빈 문자열을 명시하는 것과 같은 이유).
+            echo "db_pool_size=3" >> "$GITHUB_OUTPUT"
+            echo "db_max_overflow=1" >> "$GITHUB_OUTPUT"
             # story #2005: PO 라이브 gcloud 실측(2026-07-17) — backend-dev 현재 유효 Cloud Run
             # 요청 타임아웃=3600s(Cloud Run 요청 타임아웃 상한). cloudbuild.yaml의
             # `_BACKEND_TIMEOUT` 기본값(3600)과 동일값이라 이 output이 없어도 기본값으로
@@ -257,6 +274,6 @@ jobs:
           gcloud builds submit \
             --config=cloudbuild.yaml \
             --project="${{ secrets.GCP_PROJECT_ID }}" \
-            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}",_BACKEND_MIN_INSTANCES="${{ steps.env.outputs.backend_min_instances }}",_BACKEND_MAX_INSTANCES="${{ steps.env.outputs.backend_max_instances }}",_BACKEND_TIMEOUT="${{ steps.env.outputs.backend_timeout }}",_GA4_MEASUREMENT_ID="${{ steps.env.outputs.ga4_measurement_id }}",_REALTIME_MIN_INSTANCES="${{ steps.env.outputs.realtime_min_instances }}",_REALTIME_MAX_INSTANCES="${{ steps.env.outputs.realtime_max_instances }}",_REALTIME_TIMEOUT="${{ steps.env.outputs.realtime_timeout }}",_REALTIME_URL="${{ steps.env.outputs.realtime_url }}",_BACKEND_PG_LISTEN_ENABLED="${{ steps.env.outputs.backend_pg_listen_enabled }}",_BACKEND_REDIS_CONSUME_ENABLED="${{ steps.env.outputs.backend_redis_consume_enabled }}",_BACKEND_REDIS_DISPATCH_ENABLED="${{ steps.env.outputs.backend_redis_dispatch_enabled }}",_REDIS_URL="${{ steps.env.outputs.redis_url }}",_BACKEND_REDIS_DUAL_PUBLISH_ENABLED="${{ steps.env.outputs.backend_redis_dual_publish_enabled }}",_BACKEND_FANOUT_WAKE_REDIS_ENABLED="${{ steps.env.outputs.backend_fanout_wake_redis_enabled }}",_SSE_MULTIPLEX_ENABLED="${{ steps.env.outputs.sse_multiplex_enabled }}",_BACKEND_PRESENCE_REDIS_ENABLED="${{ steps.env.outputs.backend_presence_redis_enabled }}",_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED="${{ steps.env.outputs.backend_presence_online_redis_enabled }}",_BACKEND_SSE_LEASE_REDIS_ENABLED="${{ steps.env.outputs.backend_sse_lease_redis_enabled }}",_FRONTEND_MIN_INSTANCES="${{ steps.env.outputs.frontend_min_instances }}",_FRONTEND_MAX_INSTANCES="${{ steps.env.outputs.frontend_max_instances }}",_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED="${{ steps.env.outputs.backend_sse_transient_replay_enabled }}" \
+            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}",_BACKEND_MIN_INSTANCES="${{ steps.env.outputs.backend_min_instances }}",_BACKEND_MAX_INSTANCES="${{ steps.env.outputs.backend_max_instances }}",_DB_POOL_SIZE="${{ steps.env.outputs.db_pool_size }}",_DB_MAX_OVERFLOW="${{ steps.env.outputs.db_max_overflow }}",_BACKEND_TIMEOUT="${{ steps.env.outputs.backend_timeout }}",_GA4_MEASUREMENT_ID="${{ steps.env.outputs.ga4_measurement_id }}",_REALTIME_MIN_INSTANCES="${{ steps.env.outputs.realtime_min_instances }}",_REALTIME_MAX_INSTANCES="${{ steps.env.outputs.realtime_max_instances }}",_REALTIME_TIMEOUT="${{ steps.env.outputs.realtime_timeout }}",_REALTIME_URL="${{ steps.env.outputs.realtime_url }}",_BACKEND_PG_LISTEN_ENABLED="${{ steps.env.outputs.backend_pg_listen_enabled }}",_BACKEND_REDIS_CONSUME_ENABLED="${{ steps.env.outputs.backend_redis_consume_enabled }}",_BACKEND_REDIS_DISPATCH_ENABLED="${{ steps.env.outputs.backend_redis_dispatch_enabled }}",_REDIS_URL="${{ steps.env.outputs.redis_url }}",_BACKEND_REDIS_DUAL_PUBLISH_ENABLED="${{ steps.env.outputs.backend_redis_dual_publish_enabled }}",_BACKEND_FANOUT_WAKE_REDIS_ENABLED="${{ steps.env.outputs.backend_fanout_wake_redis_enabled }}",_SSE_MULTIPLEX_ENABLED="${{ steps.env.outputs.sse_multiplex_enabled }}",_BACKEND_PRESENCE_REDIS_ENABLED="${{ steps.env.outputs.backend_presence_redis_enabled }}",_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED="${{ steps.env.outputs.backend_presence_online_redis_enabled }}",_BACKEND_SSE_LEASE_REDIS_ENABLED="${{ steps.env.outputs.backend_sse_lease_redis_enabled }}",_FRONTEND_MIN_INSTANCES="${{ steps.env.outputs.frontend_min_instances }}",_FRONTEND_MAX_INSTANCES="${{ steps.env.outputs.frontend_max_instances }}",_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED="${{ steps.env.outputs.backend_sse_transient_replay_enabled }}" \
             --suppress-logs \
             .

--- a/backend/scripts/deploy_realtime_gce.sh
+++ b/backend/scripts/deploy_realtime_gce.sh
@@ -296,8 +296,14 @@ PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}GITHUB_APP_CLIENT_ID=${GITHUB_APP_
 PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}GITHUB_APP_SLUG=${GITHUB_APP_SLUG}"
 PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}FASTAPI_URL=${FASTAPI_URL}"
 PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}STORAGE_PROVIDER=gcs"
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}DB_POOL_SIZE=3"
-PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}DB_MAX_OVERFLOW=1"
+# story #2442(P0, 2026-08-03) — PO forensic 적발: 이 값이 cloudbuild.yaml(backend·
+# deploy-realtime)과 나란히 「세 번째 하드코딩」이었다(SSOT 원칙상 우연히 같은 값≠명시로
+# 같은 값). 이 스택은 아직 prod 게이트 pending(#2185 dev만 완료, project 메모 참고)이라
+# 오늘의 20/10 승격은 안 닿지만, 미래에 prod로 승격될 때 이 리터럴만 남아 있으면 그 시점의
+# 판단(이 파일 위쪽 REDIS_URL과 동일 클래스 함정)없이 3/1이 조용히 굳는다 — 다른 값들과
+# 같은 `${VAR:-default}` 오버라이드 컨벤션으로 맞춰 최소한 명시적 손 override는 가능하게 한다.
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}DB_POOL_SIZE=${DB_POOL_SIZE:-3}"
+PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}DB_MAX_OVERFLOW=${DB_MAX_OVERFLOW:-1}"
 # story #2115(S6): 앱 per-instance SSE 소프트캡(events.py MAX_SSE_CONNECTIONS·기본 100)을 상향.
 # GCE는 Cloud Run concurrency 제약이 없어 실질 상한은 노드 fd/mem이고, 이 캡은 그 전에 걸리는
 # 앱 자체 소프트캡이라 env로 무료 확장 가능. 500으로 올려 ceiling이 실제 확장됨을 실증(3노드=1500 이론).
@@ -390,7 +396,8 @@ else
     PLAIN_ENV_SPEC="${PLAIN_ENV_SPEC}${_PLAIN_SEP}REDIS_URL=${REDIS_URL_VALUE}"
     SECRET_PAIRS_REDIS=""
 fi
-# DB_POOL_SIZE/DB_MAX_OVERFLOW는 위에서 이미 3/1로 명시(Cloud Run realtime과 동일).
+# DB_POOL_SIZE/DB_MAX_OVERFLOW는 위에서 dev-safe 기본값 3/1(env override 가능, story #2442) —
+# Cloud Run realtime과 동일 값. prod 승격 시 cloudbuild.yaml과 같은 근거로 재검토할 것.
 #
 # ⚠️의도적 제외(50개 라이브 실측 중 1개, 침묵 누락 아님) — OPS_RESTART_TS=1784527154:
 # Cloud Run 전용 "재배포 강제 트리거" 값(값 자체를 바꿔야 신규 리비전이 뜨는 그 서비스만의

--- a/backend/tests/test_deploy_backend_redis_secret_conflict.py
+++ b/backend/tests/test_deploy_backend_redis_secret_conflict.py
@@ -40,7 +40,7 @@ _CLOUDBUILD_YAML = _REPO_ROOT / "cloudbuild.yaml"
 # story #2421 핫픽스 테스트가 이 목록 밖의 `${...}` 참조를 전부 "이스케이프 안 된 셸 변수"로 간주한다.
 _DECLARED_SUBSTITUTIONS = {
     "_AR_REGION", "_AR_REPO", "_DEPLOY_ENV", "_FASTAPI_URL", "_BACKEND_MIN_INSTANCES",
-    "_BACKEND_MAX_INSTANCES", "_BACKEND_TIMEOUT", "_REALTIME_MIN_INSTANCES",
+    "_BACKEND_MAX_INSTANCES", "_DB_POOL_SIZE", "_DB_MAX_OVERFLOW", "_BACKEND_TIMEOUT", "_REALTIME_MIN_INSTANCES",
     "_REALTIME_MAX_INSTANCES", "_REALTIME_TIMEOUT", "_REALTIME_URL", "_FRONTEND_TIMEOUT",
     "_BACKEND_PG_LISTEN_ENABLED", "_BACKEND_REDIS_CONSUME_ENABLED",
     "_BACKEND_REDIS_DISPATCH_ENABLED", "_BACKEND_REDIS_DUAL_PUBLISH_ENABLED", "_REDIS_URL",
@@ -98,6 +98,8 @@ def _run_env_vars_assembly(deploy_env: str, redis_url: str) -> str:
         **os.environ,
         "_DEPLOY_ENV": deploy_env,
         "_FASTAPI_URL": "https://example.run.app",
+        "_DB_POOL_SIZE": "3",
+        "_DB_MAX_OVERFLOW": "1",
         "_BACKEND_PG_LISTEN_ENABLED": "true",
         "_BACKEND_REDIS_CONSUME_ENABLED": "false",
         "_BACKEND_REDIS_DISPATCH_ENABLED": "false",

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,6 +22,21 @@ substitutions:
   #    (PgBouncer 풀러: Cloud Run raw TCP 미지원으로 중앙 불가·관리형 풀링 Enterprise Plus 전용 → #1779
   #    폐기 이력 있음. 트래픽↑ 時 아키텍처 재검토(#2074) 필요.)
   _BACKEND_MAX_INSTANCES: '1'
+  _DB_POOL_SIZE: '3'
+  _DB_MAX_OVERFLOW: '1'
+  # ⚠️ story #2442(2026-08-03 P0) — dev-safe fallback(위와 동일 컨벤션, #2040에서 이미 검증된
+  #    dev 예산 그대로). prod override는 GHA cloud-build.yml에서 온다(_BACKEND_MAX_INSTANCES와
+  #    동일 배선 패턴). prod가 겪은 실제 P0(08:44Z, QueuePool 고갈·/api/v2/health 전면 타임아웃):
+  #    Cloud SQL sprintable-prod(max_connections 200)는 RUNNABLE·건강했으나, PgBouncer가 prod에
+  #    없거나 무력해(db_pgbouncer=False가 코드+배포 양쪽 기본값 — 위 주석의 "PgBouncer 풀러 불가"
+  #    참고) 인스턴스당 3+1=4로 tiny한 앱 풀이 Cloud SQL에 직결돼 실 동시성을 못 버텼다. PO가
+  #    gcloud로 20/10(rev 00257-wdz)까지 올려 즉시 회복 확認(health 8/8 200) — 그 손 값을 SSOT로
+  #    durable화한다("손 값은 다음 배포가 덮는다" 교훈 재적용).
+  #    안전식(AC4, 롤아웃 배수 없이): maxScale(5)×(pool+overflow)+raw(1) = 5×30+1 = 151 ≤ 200
+  #    (25% 여유). ⚠️잔여 리스크(문서화, 미해소) — `docs/db-connection-budget.md`의 롤아웃-인식
+  #    산식(2×N×per_instance, N=동시생존 리비전수)으로 보면 2×5×31=310>200. main 배포 빈도가
+  #    develop보다 훨씬 낮아 롤아웃 중첩 창이 짧다는 판단으로 이 잔여 리스크를 감수한다(PO 확認
+  #    필요 — 재검토 트리거: num_backends가 150에 근접하거나 main 연속배포가 잦아질 때).
   _GA4_MEASUREMENT_ID: ""  # dev 기본값 빈 문자열 — prod 트리거에서 G-RYHFE7XM3X 주입
   # story #2078(E-ARCH 0단계) — SSE 멀티플렉서 롤백 플래그. dev-safe 기본값 'false'(수동
   # `gcloud builds submit` override 없을 때 안전). GHA가 dev 브랜치에서만 'true' 주입 —
@@ -327,11 +342,12 @@ steps:
         # → 신규/리셋 시 allUsers invoker 유실로 403(2026-06-21 prod promotion 사건).
         # OB-1: 에이전트 onboarding generator 가 읽는 backend-direct URL 을 런타임 env 로 주입.
         # ⚠️ 반드시 --update-env-vars(additive·기존 backend env[DATABASE_URL 등] 보존).
-        # --set-env-vars 금지(전체 wipe). DB_POOL_SIZE=3/DB_MAX_OVERFLOW=1: config.py 기본과
-        # 동일하나 명시 주입으로 durable(과거 수동 설정·lingering env 가 기본을 덮는 것 방지).
-        # rollout 산식: 2×maxScale×(pool+overflow+pg_pubsub raw 1) ≤ DB max_conn (dev maxScale 8:
-        # 2×8×5=80 · prod maxScale 5: 2×5×5=50+admin). 변경 시 cloud-build.yml maxScale 와 짝으로
-        # 검토(PO rev 01256 dev 429 right-size durable 화).
+        # --set-env-vars 금지(전체 wipe). DB_POOL_SIZE/DB_MAX_OVERFLOW: story #2442(P0)부터
+        # env별 substitution(_DB_POOL_SIZE/_DB_MAX_OVERFLOW, GHA per-env override, 위
+        # _BACKEND_MAX_INSTANCES와 동일 배선 패턴) — dev는 #2040 검증값(3/1) 그대로, prod는
+        # P0 완화값(20/10) durable화. 근거·안전식은 위 substitutions 섹션 주석 참고.
+        # rollout 산식: 2×maxScale×(pool+overflow+pg_pubsub raw 1) ≤ DB max_conn — 값 바꿀 때
+        # cloud-build.yml maxScale·db_pool_size/db_max_overflow output과 짝으로 검토.
         # E-ARCH 1단계(story #2078): PG_LISTEN_ENABLED durable화(dev=false·prod=true, GHA per-env).
         # ⛔E-ARCH S2 정리(story #2078) 정정(#2123): EVENT_BROKER_REDIS_CONSUME_ENABLED/_DISPATCH_
         # ENABLED durable화 — "api는 SSE 미서빙" 전제가 틀렸음이 드러나 값을 true로 정정(에이전트
@@ -339,7 +355,7 @@ steps:
         # 에서 정정(구 `REDIS_CONSUME_ENABLED`는 Settings 필드와 안 맞아 무시되던 키) — 구 키는
         # --remove-env-vars로 명시 제거(안 지우면 두 키 공존, additive 함정).
         # story #2123 S0-b: FANOUT_WAKE_REDIS_ENABLED(dev만 true, prod는 손대지 않음).
-        ENV_VARS="FASTAPI_URL=${_FASTAPI_URL},DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1,PG_LISTEN_ENABLED=${_BACKEND_PG_LISTEN_ENABLED},EVENT_BROKER_REDIS_CONSUME_ENABLED=${_BACKEND_REDIS_CONSUME_ENABLED},EVENT_BROKER_REDIS_DISPATCH_ENABLED=${_BACKEND_REDIS_DISPATCH_ENABLED},EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=${_BACKEND_REDIS_DUAL_PUBLISH_ENABLED},FANOUT_WAKE_REDIS_ENABLED=${_BACKEND_FANOUT_WAKE_REDIS_ENABLED},PRESENCE_REDIS_ENABLED=${_BACKEND_PRESENCE_REDIS_ENABLED},PRESENCE_ONLINE_REDIS_ENABLED=${_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED},SSE_LEASE_REDIS_ENABLED=${_BACKEND_SSE_LEASE_REDIS_ENABLED},SSE_TRANSIENT_REPLAY_ENABLED=${_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}"
+        ENV_VARS="FASTAPI_URL=${_FASTAPI_URL},DB_POOL_SIZE=${_DB_POOL_SIZE},DB_MAX_OVERFLOW=${_DB_MAX_OVERFLOW},PG_LISTEN_ENABLED=${_BACKEND_PG_LISTEN_ENABLED},EVENT_BROKER_REDIS_CONSUME_ENABLED=${_BACKEND_REDIS_CONSUME_ENABLED},EVENT_BROKER_REDIS_DISPATCH_ENABLED=${_BACKEND_REDIS_DISPATCH_ENABLED},EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=${_BACKEND_REDIS_DUAL_PUBLISH_ENABLED},FANOUT_WAKE_REDIS_ENABLED=${_BACKEND_FANOUT_WAKE_REDIS_ENABLED},PRESENCE_REDIS_ENABLED=${_BACKEND_PRESENCE_REDIS_ENABLED},PRESENCE_ONLINE_REDIS_ENABLED=${_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED},SSE_LEASE_REDIS_ENABLED=${_BACKEND_SSE_LEASE_REDIS_ENABLED},SSE_TRANSIENT_REPLAY_ENABLED=${_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}"
         # ⛔story #2141(2026-07-23, prod Redis Memorystore 전환): REDIS_URL을 여기서 이 스텝이
         # 예전엔 dev/prod 공용으로 plain env 넘겼다 — prod는 Secret Manager 바인딩(REDIS_URL_PROD,
         # AUTH 필요)으로 전환하는데, 같은 배포에 plain REDIS_URL 키까지 넘기면 Cloud Run이
@@ -459,6 +475,11 @@ steps:
         # 바뀌어 에이전트가 realtime-dev에도 붙게 되면 이 판정 전체를 재검토할 것** — 오늘 이
         # 사달(#2178)의 근본원인이 정확히 "전제가 어디에도 안 적혀 있었던 것"이라, 판정 근거뿐
         # 아니라 판정이 무너지는 조건까지 여기 남긴다.
+        # story #2442(P0) — 이 스텝은 위에서 이미 dev 아니면 skip 하므로 prod 값(20/10)은
+        # 여기 닿지 않는다(_DEPLOY_ENV=prod면 함수 진입 전에 exit 0). 그래도 하드코딩
+        # DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1을 그대로 뒀었다(PO forensic 적발 — 3곳 하드코딩 중
+        # 하나) — SSOT 원칙상 "우연히 같은 값"과 "명시로 같은 값"은 다르다. deploy-backend와
+        # 동일한 substitution으로 교체(dev 기본값 3/1 그대로 — 값 변경 아님, 배선만 정정).
         gcloud run deploy sprintable-realtime-${_DEPLOY_ENV} \
           --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA} \
           --region=${_AR_REGION} \
@@ -466,7 +487,7 @@ steps:
           --max-instances=${_REALTIME_MAX_INSTANCES} \
           --timeout=${_REALTIME_TIMEOUT} \
           --allow-unauthenticated \
-          --update-env-vars=FASTAPI_URL=${_REALTIME_URL},DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1,PG_LISTEN_ENABLED=false,EVENT_BROKER_REDIS_CONSUME_ENABLED=true,REDIS_URL=${_REDIS_URL},EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=true,EVENT_BROKER_REDIS_DISPATCH_ENABLED=true,SSE_TRANSIENT_REPLAY_ENABLED=true,SSE_LEASE_REDIS_ENABLED=true \
+          --update-env-vars=FASTAPI_URL=${_REALTIME_URL},DB_POOL_SIZE=${_DB_POOL_SIZE},DB_MAX_OVERFLOW=${_DB_MAX_OVERFLOW},PG_LISTEN_ENABLED=false,EVENT_BROKER_REDIS_CONSUME_ENABLED=true,REDIS_URL=${_REDIS_URL},EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=true,EVENT_BROKER_REDIS_DISPATCH_ENABLED=true,SSE_TRANSIENT_REPLAY_ENABLED=true,SSE_LEASE_REDIS_ENABLED=true \
           --remove-env-vars=REDIS_CONSUME_ENABLED \
           --quiet
     waitFor: [run-migrate-job]

--- a/docs/db-connection-budget.md
+++ b/docs/db-connection-budget.md
@@ -329,3 +329,89 @@ rollout_worst_case(env) = 2 × maxScale(env) × 5                          (좀�
 
 AC2(SSE 평시 수명 상한 추가 조정)는 "이 timeout이 종료 시점 상한을 이미 강제해 재연결 폭증
 대가를 감수할 근거가 없다"는 판단으로 조치 없음(오르테가군 확인) — story #2060 done.
+
+## story #2442 — prod P0(2026-08-03) 후속: pool 3/1 → 20/10 승격 + "PgBouncer 전제" 폐기
+
+**사고**: 08:44Z prod가 DB 커넥션 풀 고갈로 뻗음(QueuePool 타임아웃·`/api/v2/health` 전면
+실패). PO가 gcloud로 `DB_POOL_SIZE=20,DB_MAX_OVERFLOW=10`(rev 00257-wdz)을 즉시 적용해
+회복(health 8/8 200) — 임시값, 다음 배포가 config 기본(3/1)으로 덮어 재발하는 상태였다.
+
+**AC1 — prod 실 DB 경로(페드루 인프라 실측, 2026-08-03 09:09Z)**: `DB_PGBOUNCER` 미설정(코드
+기본 `db_pgbouncer=False`) · prod Cloud Run **단일 컨테이너**(PgBouncer 사이드카 0) · GCE에는
+realtime-gateway VM만(pgbouncer VM 0) · 프로젝트에 pgbouncer Cloud Run 서비스 0. 직전 prod
+rev 00255 = `DB_POOL_SIZE=3·DB_MAX_OVERFLOW=1`(=4/인스턴스, Cloud SQL 직결) — **"PgBouncer가
+실 풀"이라는 이 문서 상단 산식의 전제가 prod에서 «성립한 적이 없었다».** 이 문서의 §1(2026-07-20
+작성 시점)도 이미 "PgBouncer 풀러: Cloud Run raw TCP 미지원으로 중앙 불가·관리형 풀링 Enterprise
+Plus 전용 → #1779 폐기 이력"이라 명시했었다 — prod 인시던트가 그 폐기 이력이 여전히 유효함을
+실물로 재확認한 셈이다.
+
+**AC2 — 결정: (b) app 풀을 실사용에 맞게 승격(PgBouncer 사이드카 신설 (a)는 기각)**:
+- (a) 기각 근거: Cloud Run은 인스턴스별 사이드카라 "PgBouncer 사이드카"를 세워도 **인스턴스마다
+  자기 풀만 갖는 구조**(중앙/공유 풀이 아님 — 이 문서 §1의 "Cloud Run raw TCP 미지원으로 중앙
+  불가"와 동형 함정) → 진짜 중앙 풀러는 별도 상시 VM/서비스(GCE Auth Proxy 프론트 등) 또는 Cloud
+  SQL Enterprise Plus 관리형 풀링(tier 업그레이드, 과금 변경)이 필요한 **더 큰 인프라 프로젝트**다.
+  P0 SSOT 고정이라는 이 스토리 스코프를 넘는다 — 별건 아키텍처 스토리로 분리 권고(SRE lane).
+- (b) 채택 근거(신규 도출, PO 급조값 20/10을 그대로 베끼지 않고 독립 재검증):
+  1. **안전식**(story #2442 AC4, 롤아웃 배수 없이, RAW=0 — 정정 ⑤ 참고): `maxScale(5)×
+     (pool+overflow)+raw(0) < 200` → `pool+overflow < 40`. 25% 여유선(`여유0` 회피, 이 문서가
+     dev/prod 전반에서 지켜온 관례)을 적용하면 `5×(pool+overflow) ≤ 150` → `pool+overflow ≤ 30`.
+  2. **웜/콜드 커넥션 재구성**: SQLAlchemy `QueuePool`은 `pool_size`(상시 유지·웜)와
+     `max_overflow`(수요 시 신규 오픈·콜드, 반납 시 보통 닫힘)의 성격이 다르다 — 이번 사고의
+     증상(부하 급증 시 타임아웃)은 **콜드 커넥션 신규 수립 지연**이 정확히 악화시키는 유형이다.
+     `pool_size`를 낮추고 `max_overflow`를 올리는 배분(예: 10/20)은 유휴 시 커넥션 수를 줄이는
+     장점은 있으나, 정확히 이 사고를 재현하는 부하 급증 구간에서 "웜 커넥션 부족→콜드 신규 수립
+     지연"을 오히려 늘린다 — **`pool_size`를 상대적으로 높게 유지하는 배분이 이 사고 유형에는
+     더 안전하다.**
+  3. **실측 정합**: PO의 20/10(합 30)이 라이브에서 실제로 회복시켰다는 것 자체가 "이 정도
+     동시성이면 충분하다"는 유일한 실 데이터 포인트다 — 위 1·2의 독립 추론이 **같은 총합(30)에
+     정확히 수렴**한다(RAW=0 정정 後 25% 여유선 상한이 정확히 30 — 우연한 근접이 아니라 상한
+     그 자체·웜 커넥션 우선 배분 논리가 20/10 분배와 합치).
+  4. **미확인 축(정직한 한계)**: 인스턴스당 실제 동시 DB-쿼리 개수를 실시간으로 측정할 prod
+     접근이 없다(디디는 prod 키/ADC/MCP 미보유 — 정책). 위 도출은 코드로 확認 가능한 사실
+     (`--concurrency=80` 플랫폼 상한, SSE는 대기 구간 풀 미점유, `pool_timeout` 대기가 실패가
+     아니라는 설계 의도)과 라이브 실측 1개 데이터 포인트의 조합이지 완전한 부하 모델링이 아니다 —
+     배포 후 라이브 재확認(AC7)이 최종 검증이다.
+  5. **⚠️정정(페드루 지적, 2026-08-03 09:18Z)**: 최초 초안이 이 문서 §1의 `RAW_LISTEN=1`
+     (`pg_pubsub.listen_loop` 상시 raw 연결) 산식을 그대로 가져다 썼으나, 그 산식은 **PG_LISTEN이
+     살아있던 시절 가정**이다 — prod는 이미 #2123/#2141 cutover로 `PG_LISTEN_ENABLED=false`
+     (backend-prod·realtime-prod·GCE realtime 셋 다 확認, `.github/workflows/cloud-build.yml`
+     의 `backend_pg_listen_enabled=false` prod 분기 + `deploy_realtime_gce.sh`의 `PG_LISTEN_
+     ENABLED=false` 하드코딩 참고)이고 Redis(MemoryStore)가 유일한 dispatch 경로다 ⇒
+     **prod 인스턴스당 RAW≈0**(LISTEN이 아예 안 뜬다). 아래 산식을 RAW=0으로 정정 — 실제로는
+     문서화한 것보다 여유가 조금 더 있다는 뜻이라 결론(20/10 채택)에 영향은 없다.
+
+**⇒ 채택값: `DB_POOL_SIZE=20 · DB_MAX_OVERFLOW=10`**(prod만 — dev는 #2040에서 이미 검증된
+3/1 유지, 조정 안 함). SSOT는 `cloudbuild.yaml`(`_DB_POOL_SIZE`/`_DB_MAX_OVERFLOW` 신규
+substitution) + `.github/workflows/cloud-build.yml`(prod 분기 `db_pool_size=20`/
+`db_max_overflow=10` output) — "손 값은 배포가 덮는다" 교훈 재적용.
+
+```
+per_instance(prod) = (20 + 10) + RAW_LISTEN(0, PG_LISTEN_ENABLED=false — 정정 ⑤) = 30
+안전식(AC4, 롤아웃 배수 없이) = maxScale(5) × 30 + 0 = 150 ≤ 200 (25% 여유)
+```
+
+**⚠️잔여 리스크(문서화, 미해소)** — 이 문서 §1의 롤아웃-인식 산식(`2×maxScale×per_instance`,
+old+new 리비전 동시 생존 대비)으로 다시 재면 `2×5×30=300>200`, 즉 **main 배포 rollout 창에서
+old+new 리비전이 동시에 풀스케일(5)이면 이론상 한도를 넘는다.** 이 리스크를 감수하는 근거:
+① main(prod) 배포 빈도가 develop(dev)보다 훨씬 낮아(dev의 §"AC6" 실측처럼 연속배포 5회가
+겹치는 상황이 prod에서는 드물다) 롤아웃 중첩 창 자체가 짧다. ② 지금 당장은 steady-state
+고갈(사고 원인)을 막는 것이 우선이고, 롤아웃 중첩은 "짧은 창의 낮은 확률" 리스크다. **재검토
+트리거**: prod `num_backends`가 150에 근접하거나, main 연속배포가 짧은 시간 내 여러 번 겹치는
+패턴이 관측되면 즉시 재조정(maxScale 축소 또는 PgBouncer/tier 업그레이드 프로젝트 착수).
+
+**⛔AC7 라이브 재확認 방법론(페드루 검증-함정 지적, 2026-08-03 09:14Z)**: 과거 #2040/#2060
+검증이 `pg_stat_activity` **총 커넥션 수(17/200)만** 재고 "여유 있음"으로 닫았는데, 그 판정이
+정확히 오늘 사고가 재현한 **인스턴스당 4-풀(pool 3/1) 고갈**을 놓쳤다(총합은 낮아도 burst가 한
+인스턴스에 몰리면 그 인스턴스만 즉시 타임아웃 — 총합 지표가 이 실패모드를 가린다). 같은 함정
+반복 금지 — 배포 후 재확認은 총합이 아니라 **`application_name`(`db_application_name()` 태그,
+`K_SERVICE:K_REVISION` 형식)별로 `pg_stat_activity`를 그룹핑해 인스턴스별 동시 커넥션 수를
+직접 재고**, 그 값이 `pool_size+max_overflow`(=30) 근처까지 붙는 인스턴스가 있는지로 판정한다
+(총합이 낮아도 특정 인스턴스가 30에 붙으면 그 인스턴스는 여전히 위험 — "여유 있음"의 기준은
+총합이 아니라 최댓값 인스턴스).
+
+**후속(별건 권고, 이 스토리 스코프 밖)** — 페드루 정정(2026-08-03 09:14Z): "중앙 PgBouncer
+사이드카"(a)는 Cloud Run이 raw TCP(:6432)를 지원하지 않아 2026-06-29 이미 **폐기 확定**된
+죽은 길(#1779·커밋 `e704d5154`) — 재시도 대상 아님. 진짜 근본 대안은 **(a') Cloud SQL
+Enterprise Plus 관리형 커넥션 풀링**(내부 아키텍처 평가 문서 `939f9cd5`가 "사이드카 PgBouncer
+트랩"의 해법으로 권고) — 트래픽 성장 시 이 tradeoff 자체를 없애는 tier 업그레이드·과금 변경
+프로젝트. SRE lane, 이 스토리 스코프 밖. (`2b0a75ac` = 폐기된 옛 blueprint, 참고만.)


### PR DESCRIPTION
## 배경 (story #2442, P0)

08:44Z prod가 DB 커넥션 풀 고갈로 뻗음(QueuePool 타임아웃, `/api/v2/health` 전면 실패). PO가 gcloud로 `DB_POOL_SIZE=20,DB_MAX_OVERFLOW=10`(rev 00257-wdz)을 즉시 적용해 회복했으나, 임시값이라 다음 배포가 config 기본값(3/1)으로 덮어 재발하는 상태였다.

## AC 진행 상황

- **AC1 (prod DB 경로 확인)**: 완료. 페드루 라이브 인프라 실측 — prod에 PgBouncer 사이드카/VM/Cloud Run 서비스 0개. `db_pgbouncer=False`가 코드+배포 양쪽 기본값. "PgBouncer가 실 풀"이라는 `docs/db-connection-budget.md` 상단 전제가 prod에서 성립한 적이 없었음을 확定.
- **AC2 (PgBouncer vs app 풀 사이징 결정)**: 완료, (b) app 풀 채택. PgBouncer 사이드카 재시도는 Cloud Run raw TCP 미지원으로 이미 폐기(#1779) — 진짜 대안은 Cloud SQL Enterprise Plus 관리형 풀링이나 별건(SRE lane). PO의 20/10을 그대로 베끼지 않고 안전식+웜/콜드 커넥션 재구성 논리로 독립 재도출, 같은 총합(30)에 수렴 확認. RAW_LISTEN 가정도 정정 — prod는 이미 `PG_LISTEN_ENABLED=false`(Redis 유일 dispatch)라 인스턴스당 RAW≈0(기존 산식이 가정한 raw(1)은 낡은 전제).
- **AC3 (SSOT 배선)**: 완료. `cloudbuild.yaml`(`_DB_POOL_SIZE`/`_DB_MAX_OVERFLOW` 신규 substitution, dev 기본값 3/1) + `.github/workflows/cloud-build.yml`(prod 분기 20/10, dev 분기 3/1 대칭 배선) + `--substitutions=` 라인에 두 키 추가. 잔여 하드코딩 2곳(`cloudbuild.yaml`의 `deploy-realtime` 스텝·`backend/scripts/deploy_realtime_gce.sh`)도 페드루 forensic 적발 반영해 동일 컨벤션으로 정리(둘 다 dev-only 경로라 값 변경 없음, 배선만 SSOT화).
- **AC4 (안전식)**: 완료. `maxScale(5)×(pool+overflow)+RAW(0) = 5×30 = 150 ≤ 200`(25% 여유). 잔여 리스크(롤아웃-인식 산식 `2×5×30=300>200`)는 `docs/db-connection-budget.md`에 감수 근거+재검토 트리거와 함께 명시 문서화(숨기지 않음).
- **AC5 (prod 배포 금지)**: 준수. 이 PR은 코드/문서 변경만 — prod에 아무 것도 배포하지 않았다. 머지·QA·prod 배포는 표준 워크플로우(Pedro 리뷰 → Qadir QA → Pedro 머지 → prod 배포) 그대로.
- **AC6 (근본원인 문서화)**: 완료. `docs/db-connection-budget.md`에 사고 서술 + AC1~AC4 근거 + AC7 라이브 재확認 방법론(과거 #2040/#2060이 총 커넥션만 재 인스턴스당 풀 고갈을 놓쳤던 검증 함정 명시 회피 — `application_name`별 그룹핑으로 인스턴스당 동시 커넥션 직접 재는 방식으로 교정) 전부 추가.
- **AC7 (배포 후 라이브 재확認)**: 이 PR 스코프 밖 — 머지·prod 배포 이후 별도 확認 필요(방법론은 문서화 완료).

## 변경 파일

- `cloudbuild.yaml` — `_DB_POOL_SIZE`/`_DB_MAX_OVERFLOW` substitution 신규(dev 기본 3/1), `deploy-backend`/`deploy-realtime` 두 스텝 모두 리터럴 대신 이 변수 참조
- `.github/workflows/cloud-build.yml` — prod 분기 `db_pool_size=20`/`db_max_overflow=10`, dev 분기 `db_pool_size=3`/`db_max_overflow=1`(대칭 배선), `--substitutions=`에 두 키 추가
- `backend/scripts/deploy_realtime_gce.sh` — `DB_POOL_SIZE`/`DB_MAX_OVERFLOW` 하드코딩을 `${VAR:-default}` 오버라이드 컨벤션으로 정리(값 변경 없음)
- `docs/db-connection-budget.md` — story #2442 후속 섹션 신규(사고·AC1-AC7·안전식·잔여 리스크·후속 권고)

## 검증

- YAML 문법: `ruby -ryaml` 양쪽 파일 통과
- bash 문법: `bash -n deploy_realtime_gce.sh` 통과, `DRY_RUN=1` 실행으로 `DB_POOL_SIZE=3`/`DB_MAX_OVERFLOW=1` 정상 해석 확認
- actionlint: 기존 SC2129/SC2140 스타일 경고 클래스에서 신규 substitution 키 2개분(동일 패턴)만 늘어남 — 새 카테고리 경고 0건
- `backend/tests/test_e_infra_s2_pool.py` 6/6 pass (회귀 없음, Settings 코드 기본값 미변경 확認)

## Test plan
- [ ] Pedro 코드리뷰
- [ ] Qadir QA
- [ ] Pedro 머지
- [ ] prod 배포 후 AC7 방법론대로 라이브 재확認(인스턴스별 `pg_stat_activity` 그룹핑)

🤖 Generated with [Claude Code](https://claude.com/claude-code)