### PR TITLE
chore(#2829): cloud-build.yml 재파싱 강제 (GitHub stale 파싱 캐시 무효화)

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -1,5 +1,9 @@
 name: Cloud Build (GCP)
 
+# 2026-08-03 #2829(P0): substitutions 값은 별도 "Assemble Cloud Build substitutions" 스텝에서
+# 조립한다 — 단일 run 블록에 GH 표현식을 다수 담으면 GitHub 파서 상한(startup_failure)에 걸린다.
+# Submit 스텝에 인라인 나열 금지. 주석에도 리터럴 표현식 토큰 쓰지 말 것.
+
 on:
   push:
     branches: [main, develop]


### PR DESCRIPTION
## 목적
main의 cloud-build.yml은 #2829(re-promo #2830)로 이미 fix됐으나 — **GitHub이 #2828 시점(파일이 깨졌던)의 파싱 캐시를 계속 서빙**해 prod 배포가 startup_failure로 막혔다.

API 직접 확認: main 파일 = 표현식 33개·라인당 최대 2·Assemble 스텝 有·27-표현식 라인 없음 = 완전 정상. 그런데 push run(30809713857)·workflow_dispatch 둘 다 `Exceeded max expression length 21000`(옛 버전 에러) 반환.

이 PR은 워크플로 파일에 안전한 주석 1줄(리터럴 표현식 토큰 없음)을 더해 **GitHub 재파싱을 강제**한다 — develop이 #2829 squash로 캐시 갱신에 성공했던 경로와 동형. 머지 후 main 배포가 정상 파싱되어야 한다.

부수 효과: 「substitutions는 별도 Assemble 스텝에서 조립」 규율을 파일 상단에 문서화.