### PR TITLE
fix(#2829 후속): Set-deploy-env run 블록 표현식 0개화 — main-크기 startup_failure 해소 (P0)

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -45,8 +45,14 @@ jobs:
 
       - name: Set deploy environment
         id: env
+        # #2829 후속(P0): github.ref_name을 env: 매핑으로 빼 이 run 블록의 GH 표현식을 0개로 만든다.
+        # run 블록이 GH 표현식을 하나라도 품으면 GitHub이 블록 전체를 하나로 템플릿 컴파일하는데,
+        # 이 스텝은 prod 승격 주석까지 포함해 큰 텍스트(main에서 24k+자)라 그 컴파일 단위가 파서
+        # 상한을 넘어 startup_failure가 난다. 표현식 0개면 컴파일 안 돼 크기와 무관해진다.
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [[ "${{ github.ref_name }}" == "main" ]]; then
+          if [[ "$REF_NAME" == "main" ]]; then
             echo "target=prod" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-prod-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
             # ⚠️ minScale 1→3 (prod 콜드스타트 durable 봉합, 오르테가군 PO 2026-07-22): dev #2074 응급대응


### PR DESCRIPTION
## 근본원인
#2829가 substitutions 조립을 별도 Assemble 스텝으로 뺐으나, **'Set deploy environment' 스텝은 여전히 inline `${{ github.ref_name }}` 1개를 품었다.** GitHub은 GH 표현식을 하나라도 품은 `run:` 블록 **전체를 하나로 템플릿 컴파일**하는데, 이 스텝은 prod 승격 주석까지 포함해 크다:

- **main: 24533자 / develop: 23214자** (측정). main은 prod 전용 `realtime_url`(#2142/#2439) 등이 더 있어 더 크다.

그 컴파일 단위가 파서 상한을 넘어 `Exceeded max expression length 21000` → **startup_failure**. develop은 아슬아슬 아래라 통과했을 뿐 — **둘 다 취약**했다. 이것이 re-promo #2830의 main 배포가 계속 죽던 진짜 원인(캐시 아님 — cachebust 커밋으로 재파싱 강제해도 실패해 확認).

## 고침
`github.ref_name`을 `env:` 매핑으로 빼 run 블록 표현식을 **0개**로 만든다(Assemble과 동일 패턴). 표현식 0개면 GitHub이 그 블록을 템플릿 컴파일하지 않아 **크기와 무관**해진다.

## 검증 (읽지 않고 돌림)
- fix 브랜치 dispatch: 422 없이 수락·job 생성(파싱 OK).
- ⭐**main-크기 검증**: 동일 패턴을 main 기반 브랜치(realtime_url 포함·**24576자**)에 얹어 dispatch → **파싱 OK**. 즉 24k+자에서도 성립.
- Set-deploy-env·Assemble 둘 다 run 블록 표현식 0개, Submit만 소량(2~3개).

진단·패턴: 디캄포 은두카쿠. 이 클린 PR: 페드루(디디 브랜치가 develop 대비 갈라져 있어 develop 기반 단일 커밋으로 재작성).