### PR TITLE
promo/20260803-3: P0 파이프라인 3라운드 근본고침(#2832) → prod 배포 복구

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -45,8 +45,14 @@ jobs:
 
       - name: Set deploy environment
         id: env
+        # #2829 후속(P0): github.ref_name을 env: 매핑으로 빼 이 run 블록의 GH 표현식을 0개로 만든다.
+        # run 블록이 GH 표현식을 하나라도 품으면 GitHub이 블록 전체를 하나로 템플릿 컴파일하는데,
+        # 이 스텝은 prod 승격 주석까지 포함해 큰 텍스트(main에서 24k+자)라 그 컴파일 단위가 파서
+        # 상한을 넘어 startup_failure가 난다. 표현식 0개면 컴파일 안 돼 크기와 무관해진다.
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [[ "${{ github.ref_name }}" == "main" ]]; then
+          if [[ "$REF_NAME" == "main" ]]; then
             echo "target=prod" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-prod-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
             # ⚠️ minScale 1→3 (prod 콜드스타트 durable 봉합, 오르테가군 PO 2026-07-22): dev #2074 응급대응


### PR DESCRIPTION
## 목적
re-promo #2830의 main 배포가 계속 startup_failure였던 **진짜 근본원인**(「Set deploy environment」 스텝이 inline `github.ref_name` 1개+거대주석으로 main 24533자 → GitHub이 블록 전체 템플릿 컴파일 시 상한 초과)을 #2832로 고쳐 승격한다.

⭐ delta = **#2832 하나**(REF_NAME을 env:로 빼 그 스텝 표현식 0개화 = 크기 무관). main은 이미 27커밋+#2829+#2826 보유 — 이 promo의 main 배포가 파싱에 성공해 **전부 prod에 처음 싣는다**.

## 검증
- #2832: PO PASS + qa:pass(바이트 동일 출력 확認) + CI green + **파싱 3회 독립확認**(내 fix-branch·main-크기 24576자·카디르).

머지 후 main 배포로 라이브 파싱 최종 확認 → prod 검증(health·풀 20/10 SSOT·에러0·#2826 AC5).