### PR TITLE
feat(#2445 Phase1): dev backend를 PgBouncer로 전환 — SSOT 배선

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -79,6 +79,9 @@ jobs:
             # main 배포 빈도가 낮아 감수(PO 확認 필요, 재검토 트리거는 위 문서 참고).
             echo "db_pool_size=20" >> "$GITHUB_OUTPUT"
             echo "db_max_overflow=10" >> "$GITHUB_OUTPUT"
+            # story #2445(2026-08-03) — prod는 PgBouncer 미도입(#2442에서 앱 풀 20/10으로
+            # 대응, 별건 스코프). 명시 false로 다른 플래그들과 동일 컨벤션 유지.
+            echo "backend_db_pgbouncer=false" >> "$GITHUB_OUTPUT"
             # story #2005: PO 라이브 gcloud 실측(2026-07-17) — backend-prod 현재 유효 Cloud Run
             # 요청 타임아웃=300s. 지금까지 `cloudbuild.yaml`에 `--timeout` 플래그가 없어 이
             # 값은 인프라 기본값이었을 뿐 어디에도 명시돼 있지 않았다 — 이제 이 워크플로우가
@@ -189,6 +192,14 @@ jobs:
             # 덮어써버린다 — ga4_measurement_id가 dev에서 빈 문자열을 명시하는 것과 같은 이유).
             echo "db_pool_size=3" >> "$GITHUB_OUTPUT"
             echo "db_max_overflow=1" >> "$GITHUB_OUTPUT"
+            # story #2445 Phase1(2026-08-03, 페드루 인프라 VM PgBouncer 라이브 검증+시크릿
+            # DATABASE_URL_DEV_PGBOUNCER/DATABASE_URL_DIRECT_DEV 생성 완료) — dev만 true.
+            # 이 값이 true인 배포는 반드시 cloudbuild.yaml deploy-backend의 --update-secrets
+            # (DATABASE_URL/DATABASE_URL_DIRECT 재바인딩)와 같은 배포에서 동반돼야 한다 —
+            # 시크릿만 바뀌고 이 값이 false거나, 이 값만 true고 시크릿이 안 바뀌면 앱이
+            # PgBouncer 위에서 statement_cache 미비활성 상태로 붙어 prepared statement reuse
+            # 깨짐(#1314류) 또는 direct DSN 그대로 PgBouncer를 거치지 않는 반쪽 상태가 된다.
+            echo "backend_db_pgbouncer=true" >> "$GITHUB_OUTPUT"
             # story #2005: PO 라이브 gcloud 실측(2026-07-17) — backend-dev 현재 유효 Cloud Run
             # 요청 타임아웃=3600s(Cloud Run 요청 타임아웃 상한). cloudbuild.yaml의
             # `_BACKEND_TIMEOUT` 기본값(3600)과 동일값이라 이 output이 없어도 기본값으로
@@ -291,6 +302,7 @@ jobs:
           V_BACKEND_MAX_INSTANCES: ${{ steps.env.outputs.backend_max_instances }}
           V_DB_POOL_SIZE: ${{ steps.env.outputs.db_pool_size }}
           V_DB_MAX_OVERFLOW: ${{ steps.env.outputs.db_max_overflow }}
+          V_BACKEND_DB_PGBOUNCER: ${{ steps.env.outputs.backend_db_pgbouncer }}
           V_BACKEND_TIMEOUT: ${{ steps.env.outputs.backend_timeout }}
           V_GA4_MEASUREMENT_ID: ${{ steps.env.outputs.ga4_measurement_id }}
           V_REALTIME_MIN_INSTANCES: ${{ steps.env.outputs.realtime_min_instances }}
@@ -311,7 +323,7 @@ jobs:
           V_FRONTEND_MAX_INSTANCES: ${{ steps.env.outputs.frontend_max_instances }}
           V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED: ${{ steps.env.outputs.backend_sse_transient_replay_enabled }}
         run: |
-          SUBST="_DEPLOY_ENV=\"${V_DEPLOY_ENV}\",_FASTAPI_URL=\"${V_FASTAPI_URL}\",_BACKEND_MIN_INSTANCES=\"${V_BACKEND_MIN_INSTANCES}\",_BACKEND_MAX_INSTANCES=\"${V_BACKEND_MAX_INSTANCES}\",_DB_POOL_SIZE=\"${V_DB_POOL_SIZE}\",_DB_MAX_OVERFLOW=\"${V_DB_MAX_OVERFLOW}\",_BACKEND_TIMEOUT=\"${V_BACKEND_TIMEOUT}\",_GA4_MEASUREMENT_ID=\"${V_GA4_MEASUREMENT_ID}\",_REALTIME_MIN_INSTANCES=\"${V_REALTIME_MIN_INSTANCES}\",_REALTIME_MAX_INSTANCES=\"${V_REALTIME_MAX_INSTANCES}\",_REALTIME_TIMEOUT=\"${V_REALTIME_TIMEOUT}\",_REALTIME_URL=\"${V_REALTIME_URL}\",_BACKEND_PG_LISTEN_ENABLED=\"${V_BACKEND_PG_LISTEN_ENABLED}\",_BACKEND_REDIS_CONSUME_ENABLED=\"${V_BACKEND_REDIS_CONSUME_ENABLED}\",_BACKEND_REDIS_DISPATCH_ENABLED=\"${V_BACKEND_REDIS_DISPATCH_ENABLED}\",_REDIS_URL=\"${V_REDIS_URL}\",_BACKEND_REDIS_DUAL_PUBLISH_ENABLED=\"${V_BACKEND_REDIS_DUAL_PUBLISH_ENABLED}\",_BACKEND_FANOUT_WAKE_REDIS_ENABLED=\"${V_BACKEND_FANOUT_WAKE_REDIS_ENABLED}\",_SSE_MULTIPLEX_ENABLED=\"${V_SSE_MULTIPLEX_ENABLED}\",_BACKEND_PRESENCE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_REDIS_ENABLED}\",_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED}\",_BACKEND_SSE_LEASE_REDIS_ENABLED=\"${V_BACKEND_SSE_LEASE_REDIS_ENABLED}\",_FRONTEND_MIN_INSTANCES=\"${V_FRONTEND_MIN_INSTANCES}\",_FRONTEND_MAX_INSTANCES=\"${V_FRONTEND_MAX_INSTANCES}\",_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED=\"${V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}\""
+          SUBST="_DEPLOY_ENV=\"${V_DEPLOY_ENV}\",_FASTAPI_URL=\"${V_FASTAPI_URL}\",_BACKEND_MIN_INSTANCES=\"${V_BACKEND_MIN_INSTANCES}\",_BACKEND_MAX_INSTANCES=\"${V_BACKEND_MAX_INSTANCES}\",_DB_POOL_SIZE=\"${V_DB_POOL_SIZE}\",_DB_MAX_OVERFLOW=\"${V_DB_MAX_OVERFLOW}\",_BACKEND_DB_PGBOUNCER=\"${V_BACKEND_DB_PGBOUNCER}\",_BACKEND_TIMEOUT=\"${V_BACKEND_TIMEOUT}\",_GA4_MEASUREMENT_ID=\"${V_GA4_MEASUREMENT_ID}\",_REALTIME_MIN_INSTANCES=\"${V_REALTIME_MIN_INSTANCES}\",_REALTIME_MAX_INSTANCES=\"${V_REALTIME_MAX_INSTANCES}\",_REALTIME_TIMEOUT=\"${V_REALTIME_TIMEOUT}\",_REALTIME_URL=\"${V_REALTIME_URL}\",_BACKEND_PG_LISTEN_ENABLED=\"${V_BACKEND_PG_LISTEN_ENABLED}\",_BACKEND_REDIS_CONSUME_ENABLED=\"${V_BACKEND_REDIS_CONSUME_ENABLED}\",_BACKEND_REDIS_DISPATCH_ENABLED=\"${V_BACKEND_REDIS_DISPATCH_ENABLED}\",_REDIS_URL=\"${V_REDIS_URL}\",_BACKEND_REDIS_DUAL_PUBLISH_ENABLED=\"${V_BACKEND_REDIS_DUAL_PUBLISH_ENABLED}\",_BACKEND_FANOUT_WAKE_REDIS_ENABLED=\"${V_BACKEND_FANOUT_WAKE_REDIS_ENABLED}\",_SSE_MULTIPLEX_ENABLED=\"${V_SSE_MULTIPLEX_ENABLED}\",_BACKEND_PRESENCE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_REDIS_ENABLED}\",_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED}\",_BACKEND_SSE_LEASE_REDIS_ENABLED=\"${V_BACKEND_SSE_LEASE_REDIS_ENABLED}\",_FRONTEND_MIN_INSTANCES=\"${V_FRONTEND_MIN_INSTANCES}\",_FRONTEND_MAX_INSTANCES=\"${V_FRONTEND_MAX_INSTANCES}\",_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED=\"${V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}\""
           echo "substitutions=${SUBST}" >> "$GITHUB_OUTPUT"
 
       - name: Submit Cloud Build

--- a/backend/tests/test_deploy_backend_redis_secret_conflict.py
+++ b/backend/tests/test_deploy_backend_redis_secret_conflict.py
@@ -40,7 +40,7 @@ _CLOUDBUILD_YAML = _REPO_ROOT / "cloudbuild.yaml"
 # story #2421 핫픽스 테스트가 이 목록 밖의 `${...}` 참조를 전부 "이스케이프 안 된 셸 변수"로 간주한다.
 _DECLARED_SUBSTITUTIONS = {
     "_AR_REGION", "_AR_REPO", "_DEPLOY_ENV", "_FASTAPI_URL", "_BACKEND_MIN_INSTANCES",
-    "_BACKEND_MAX_INSTANCES", "_DB_POOL_SIZE", "_DB_MAX_OVERFLOW", "_BACKEND_TIMEOUT", "_REALTIME_MIN_INSTANCES",
+    "_BACKEND_MAX_INSTANCES", "_DB_POOL_SIZE", "_DB_MAX_OVERFLOW", "_BACKEND_DB_PGBOUNCER", "_BACKEND_TIMEOUT", "_REALTIME_MIN_INSTANCES",
     "_REALTIME_MAX_INSTANCES", "_REALTIME_TIMEOUT", "_REALTIME_URL", "_FRONTEND_TIMEOUT",
     "_BACKEND_PG_LISTEN_ENABLED", "_BACKEND_REDIS_CONSUME_ENABLED",
     "_BACKEND_REDIS_DISPATCH_ENABLED", "_BACKEND_REDIS_DUAL_PUBLISH_ENABLED", "_REDIS_URL",
@@ -100,6 +100,7 @@ def _run_env_vars_assembly(deploy_env: str, redis_url: str) -> str:
         "_FASTAPI_URL": "https://example.run.app",
         "_DB_POOL_SIZE": "3",
         "_DB_MAX_OVERFLOW": "1",
+        "_BACKEND_DB_PGBOUNCER": "false",
         "_BACKEND_PG_LISTEN_ENABLED": "true",
         "_BACKEND_REDIS_CONSUME_ENABLED": "false",
         "_BACKEND_REDIS_DISPATCH_ENABLED": "false",
@@ -181,6 +182,7 @@ def test_deploy_backend_dev_env_vars_unchanged_by_prod_branch():
     result = _run_env_vars_assembly("dev", "redis://10.164.120.243:6379")
     assert result == (
         "FASTAPI_URL=https://example.run.app,DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1,"
+        "DB_PGBOUNCER=false,"
         "PG_LISTEN_ENABLED=true,EVENT_BROKER_REDIS_CONSUME_ENABLED=false,"
         "EVENT_BROKER_REDIS_DISPATCH_ENABLED=false,EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=false,"
         "FANOUT_WAKE_REDIS_ENABLED=false,PRESENCE_REDIS_ENABLED=false,"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -37,6 +37,14 @@ substitutions:
   #    산식(2×N×per_instance, N=동시생존 리비전수)으로 보면 2×5×31=310>200. main 배포 빈도가
   #    develop보다 훨씬 낮아 롤아웃 중첩 창이 짧다는 판단으로 이 잔여 리스크를 감수한다(PO 확認
   #    필요 — 재검토 트리거: num_backends가 150에 근접하거나 main 연속배포가 잦아질 때).
+  # story #2445 Phase1(2026-08-03, 페드루 인프라) — dev VM PgBouncer(10.178.0.63:6432,
+  # transaction-mode) 라이브 검증 완료. dev-safe 기본값 'false'(현 동작 유지 — PgBouncer
+  # 미경유 시 database.py의 db_pgbouncer 코드 기본값과 동일). prod override는 없음(prod는
+  # #2442에서 이미 앱 풀 20/10으로 대응 — PgBouncer 도입은 이 스토리 스코프 밖, 별건).
+  # true 전환은 GHA cloud-build.yml dev 분기에서만(DATABASE_URL/DATABASE_URL_DIRECT 시크릿
+  # 재바인딩과 반드시 같은 배포에 동반 — 시크릿만 바뀌고 이 값이 false면 statement_cache
+  # 미비활성으로 PgBouncer 아래서 prepared statement reuse 깨짐, #1314류 재발).
+  _BACKEND_DB_PGBOUNCER: 'false'
   _GA4_MEASUREMENT_ID: ""  # dev 기본값 빈 문자열 — prod 트리거에서 G-RYHFE7XM3X 주입
   # story #2078(E-ARCH 0단계) — SSE 멀티플렉서 롤백 플래그. dev-safe 기본값 'false'(수동
   # `gcloud builds submit` override 없을 때 안전). GHA가 dev 브랜치에서만 'true' 주입 —
@@ -355,7 +363,7 @@ steps:
         # 에서 정정(구 `REDIS_CONSUME_ENABLED`는 Settings 필드와 안 맞아 무시되던 키) — 구 키는
         # --remove-env-vars로 명시 제거(안 지우면 두 키 공존, additive 함정).
         # story #2123 S0-b: FANOUT_WAKE_REDIS_ENABLED(dev만 true, prod는 손대지 않음).
-        ENV_VARS="FASTAPI_URL=${_FASTAPI_URL},DB_POOL_SIZE=${_DB_POOL_SIZE},DB_MAX_OVERFLOW=${_DB_MAX_OVERFLOW},PG_LISTEN_ENABLED=${_BACKEND_PG_LISTEN_ENABLED},EVENT_BROKER_REDIS_CONSUME_ENABLED=${_BACKEND_REDIS_CONSUME_ENABLED},EVENT_BROKER_REDIS_DISPATCH_ENABLED=${_BACKEND_REDIS_DISPATCH_ENABLED},EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=${_BACKEND_REDIS_DUAL_PUBLISH_ENABLED},FANOUT_WAKE_REDIS_ENABLED=${_BACKEND_FANOUT_WAKE_REDIS_ENABLED},PRESENCE_REDIS_ENABLED=${_BACKEND_PRESENCE_REDIS_ENABLED},PRESENCE_ONLINE_REDIS_ENABLED=${_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED},SSE_LEASE_REDIS_ENABLED=${_BACKEND_SSE_LEASE_REDIS_ENABLED},SSE_TRANSIENT_REPLAY_ENABLED=${_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}"
+        ENV_VARS="FASTAPI_URL=${_FASTAPI_URL},DB_POOL_SIZE=${_DB_POOL_SIZE},DB_MAX_OVERFLOW=${_DB_MAX_OVERFLOW},DB_PGBOUNCER=${_BACKEND_DB_PGBOUNCER},PG_LISTEN_ENABLED=${_BACKEND_PG_LISTEN_ENABLED},EVENT_BROKER_REDIS_CONSUME_ENABLED=${_BACKEND_REDIS_CONSUME_ENABLED},EVENT_BROKER_REDIS_DISPATCH_ENABLED=${_BACKEND_REDIS_DISPATCH_ENABLED},EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=${_BACKEND_REDIS_DUAL_PUBLISH_ENABLED},FANOUT_WAKE_REDIS_ENABLED=${_BACKEND_FANOUT_WAKE_REDIS_ENABLED},PRESENCE_REDIS_ENABLED=${_BACKEND_PRESENCE_REDIS_ENABLED},PRESENCE_ONLINE_REDIS_ENABLED=${_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED},SSE_LEASE_REDIS_ENABLED=${_BACKEND_SSE_LEASE_REDIS_ENABLED},SSE_TRANSIENT_REPLAY_ENABLED=${_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}"
         # ⛔story #2141(2026-07-23, prod Redis Memorystore 전환): REDIS_URL을 여기서 이 스텝이
         # 예전엔 dev/prod 공용으로 plain env 넘겼다 — prod는 Secret Manager 바인딩(REDIS_URL_PROD,
         # AUTH 필요)으로 전환하는데, 같은 배포에 plain REDIS_URL 키까지 넘기면 Cloud Run이
@@ -376,6 +384,14 @@ steps:
         if [ "${_DEPLOY_ENV}" != "prod" ]; then
           ENV_VARS="$${ENV_VARS},REDIS_URL=${_REDIS_URL}"
         fi
+        # story #2445 Phase1(2026-08-03) — dev만 DATABASE_URL/DATABASE_URL_DIRECT를 PgBouncer
+        # 경유 시크릿으로 재바인딩(--update-secrets=additive, 기존 다른 시크릿 preserve — REDIS_URL_
+        # PROD 등과 동일 컨벤션). prod는 이 플래그 자체를 안 넘겨 현재 DATABASE_URL_PROD 바인딩
+        # 무변경. 시크릿 자체(DATABASE_URL_DEV_PGBOUNCER/DATABASE_URL_DIRECT_DEV)는 PO가 생성.
+        SECRETS_FLAG=""
+        if [ "${_DEPLOY_ENV}" == "dev" ]; then
+          SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_DEV_PGBOUNCER:latest,DATABASE_URL_DIRECT=DATABASE_URL_DIRECT_DEV:latest"
+        fi
         gcloud run deploy sprintable-backend-${_DEPLOY_ENV} \
           --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA} \
           --region=${_AR_REGION} \
@@ -384,6 +400,7 @@ steps:
           --timeout=${_BACKEND_TIMEOUT} \
           --allow-unauthenticated \
           --update-env-vars="$${ENV_VARS}" \
+          $${SECRETS_FLAG} \
           --remove-env-vars=REDIS_CONSUME_ENABLED \
           --quiet
     # story dbda0baf: push-backend → run-migrate-job(위) 로 변경 — 신규 코드가 마이그 안 된


### PR DESCRIPTION
## 배경

story #2445 Phase1 — 페드루가 dev VM PgBouncer(10.178.0.63:6432, transaction-mode)를 세우고 라이브 검증 완료(Cloud SQL 쿼리 OK, 직결 10.110.0.3:5432 OK), 시크릿 `DATABASE_URL_DEV_PGBOUNCER`/`DATABASE_URL_DIRECT_DEV` 생성 완료. backend-dev를 PgBouncer로 전환하는 SSOT 배선(cloudbuild 도메인).

## 변경

- `cloudbuild.yaml`: `_BACKEND_DB_PGBOUNCER` substitution 신규(dev-safe 기본값 `false`), `deploy-backend` ENV_VARS에 `DB_PGBOUNCER` 추가. dev 전용 게이트로 `--update-secrets=DATABASE_URL=DATABASE_URL_DEV_PGBOUNCER:latest,DATABASE_URL_DIRECT=DATABASE_URL_DIRECT_DEV:latest`(additive, 기존 다른 시크릿 preserve) — prod는 이 플래그를 아예 안 넘겨 `DATABASE_URL_PROD` 바인딩 무변경.
- `.github/workflows/cloud-build.yml`: dev 분기 `backend_db_pgbouncer=true`, prod 분기 명시 `false`. **오늘 P0(#2827/#2829/#2832) 교훈 그대로 준수** — 새 값도 `Assemble Cloud Build substitutions` 스텝의 `env:` 매핑 패턴으로만 추가, `run:` 블록에 GH 표현식을 섞지 않음(run 블록 표현식 0개 유지).
- `backend/tests/test_deploy_backend_redis_secret_conflict.py`: `_DECLARED_SUBSTITUTIONS`/env dict/리터럴 단정 테스트 3곳에 `_BACKEND_DB_PGBOUNCER` 동기화 — 오늘 아침 겪은 "새 substitution 추가 시 테스트 하네스 동기화 누락" 함정을 선제 반영.

값이 반드시 같은 배포에 동반되어야 하는 이유: 시크릿만 재바인딩되고 `DB_PGBOUNCER=false`면 앱이 PgBouncer 위에서 `statement_cache_size` 미비활성 상태로 붙어 prepared statement reuse가 깨진다(#1314류 재발). 반대로 `DB_PGBOUNCER=true`인데 시크릿이 안 바뀌면 direct DSN 그대로 PgBouncer를 거치지 않는 반쪽 상태가 된다 — 둘 다 이 PR 하나로 원자적으로 묶었다.

## 검증

- YAML 문법 양쪽 파일 통과, `cloudbuild.yaml` bash 로직 확認(SECRETS_FLAG 조건부 렌더링)
- PyYAML로 `Set deploy environment`/`Assemble Cloud Build substitutions` 두 스텝 모두 `run:` 블록 표현식 0개 재확認
- dev/prod 양쪽 브랜치 로컬 bash 시뮬레이션 — `_BACKEND_DB_PGBOUNCER` dev=`true`/prod=`false`, `_DB_POOL_SIZE` 등 기존 값 무변경 확認
- `test_deploy_backend_redis_secret_conflict.py` + `test_e_infra_s2_pool.py` 11/11 pass
- **실 dispatch 검증**: `gh workflow run 268908504 --ref feat/2445-dev-pgbouncer-cutover` 422 없이 수락(run 30816355038) → 즉시 cancel, Checkout도 못 돌고 정지 확認(배포 없음)

## Test plan
- [ ] Pedro 리뷰
- [ ] Qadir QA
- [ ] Pedro 머지 → dev 배포 파싱/성공 재확認(P0 재발 감시) → Pedro 앱 검증(statement_cache 0·LISTEN 직결·prepared stmt·VM failover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)