### PR TITLE
fix(#2445): PgBouncer 앱 풀 사이징 backwards 교정 (2/1→25/10) — 최소화가 08-03 사고 재현

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -51,10 +51,15 @@ class Settings(BaseSettings):
     # PgBouncer ④: 사이드카(localhost:6432·pool_mode=transaction) 경유 여부(env DB_PGBOUNCER).
     # off(기본): 직접 Cloud SQL — 현 동작 100% 유지(사이드카 없어도 다운 X).
     # on: statement_cache 비활성(pooled conn 간 prepared statement reuse 깨짐 방지) +
-    #     app-side pool 최소화(PgBouncer default_pool_size가 실 풀 역할).
+    #     ⭐app-side pool 을 «충분히 크게»(인스턴스당 동시성 수용). PgBouncer 가 이 클라이언트
+    #     커넥션들을 «적은 Cloud SQL 서버커넥션(default_pool_size)»으로 묶으므로 큰 앱 풀이 안전하다.
+    #     ⛔2026-08-03 부하테스트 교훈(#2445): 앱 풀을 2로 «최소화」했더니 부하(200/s)에서 앱 내부
+    #     QueuePool 큐잉→30s 타임아웃→92% 500(08-03 사고 재현·단 PgBouncer/Cloud SQL 은 건강했음).
+    #     앱 풀은 «인스턴스당 동시성」을 정하지 PgBouncer 가 대신하지 않는다 — 최소화는 backwards고
+    #     PgBouncer 도입 취지(큰 앱 풀을 안전하게)를 무력화한다. (재테스트로 실측 튜닝.)
     db_pgbouncer: bool = False
-    db_pgbouncer_pool_size: int = 2  # flag on 時 app-side pool(PgBouncer가 실 풀)
-    db_pgbouncer_max_overflow: int = 1
+    db_pgbouncer_pool_size: int = 25   # ⭐앱 동시성 수용(크게). PgBouncer가 Cloud SQL 커넥션을 묶어 안전.
+    db_pgbouncer_max_overflow: int = 10
 
     # JWT
     jwt_secret: str = ""

--- a/backend/tests/test_pgbouncer_config.py
+++ b/backend/tests/test_pgbouncer_config.py
@@ -4,7 +4,9 @@ engine은 import-time 단일 생성이라 flag별 재생성이 어렵다 → 분
 database._build_engine_kwargs()로 추출해 settings 토글 → 인자 검증으로 커버한다.
 
 - off(기본): pool_size=3/overflow=1(rollout-safe·앱최소 4·ee7794eb) + connect_args 비움(statement_cache_size 없음)
-- on:        pool_size=2/overflow=1 + connect_args={"statement_cache_size": 0}
+- on:        pool_size=25/overflow=10 + connect_args={"statement_cache_size": 0}
+             (2026-08-03 #2836: 앱 풀 최소화(2/1)는 backwards — 부하에서 QueuePool 고갈. PgBouncer 가
+              멀티플렉싱하니 앱 풀을 «크게» 잡는 게 도입 취지. 자세히=config.py db_pgbouncer_pool_size 주석)
 """
 from __future__ import annotations
 
@@ -16,8 +18,8 @@ from app.core import database
 def test_settings_defaults_flag_off():
     s = Settings()
     assert s.db_pgbouncer is False
-    assert s.db_pgbouncer_pool_size == 2
-    assert s.db_pgbouncer_max_overflow == 1
+    assert s.db_pgbouncer_pool_size == 25
+    assert s.db_pgbouncer_max_overflow == 10
     assert s.db_pool_size == 3  # ee7794eb: rollout-safe·앱최소(≥4=3+1) default
     assert s.db_max_overflow == 1
 


### PR DESCRIPTION
## 부하테스트가 잡은 설계 결함 (prod cutover 前)
dev 부하(200/s·5분)에서 **92% 500 에러**. 진단:
```
sqlalchemy.exc.TimeoutError: QueuePool limit of size 2 overflow 1 reached, timeout 30s
```
= 백엔드 자체 SQLAlchemy 풀 고갈(08-03 #2442 사고와 같은 클래스). **PgBouncer/Cloud SQL 은 건강**했다(멀티플렉싱 실측: cl 24 → sv 17/20·cl_waiting 0·Cloud SQL 23/200).

## 근본
`config.py` 가 `DB_PGBOUNCER=true` 時 앱 풀을 **`db_pgbouncer_pool_size=2` 로 최소화**(주석 「PgBouncer가 실 풀」). 이게 **backwards**:
- 앱 풀(app→PgBouncer 클라이언트 커넥션) = «인스턴스당 동시성」을 정한다.
- PgBouncer = 그 클라이언트 커넥션들을 «적은 Cloud SQL 서버커넥션」으로 묶는다(그게 이점).
- 앱 풀을 2로 줄이면 앱이 3개 넘는 동시작업에서 내부 QueuePool 큐잉→30s 타임아웃→500. **PgBouncer 도입 취지 자체를 무력화.**

## ⛔ prod 함의
이 config 그대로 prod cutover 하면 prod 풀도 2/1로 줄어 **08-03 사고 재발**(거짓 확신까지). 부하테스트가 이걸 prod 前에 잡았다 = 게이트의 값.

## 고침
`db_pgbouncer_pool_size: 2→25`, `db_pgbouncer_max_overflow: 1→10`(PgBouncer 가 Cloud SQL 을 묶으니 큰 앱 풀이 안전). 머지→dev 재배포→재테스트로 «감당」 실측(카디르 MAX_VUS 1000/3000 준비됨).