### PR TITLE
feat(#2445 Phase1): prod PgBouncer cutover — DB_PGBOUNCER=true + VIP 시크릿 재바인딩

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -79,6 +79,9 @@ jobs:
             # main 배포 빈도가 낮아 감수(PO 확認 필요, 재검토 트리거는 위 문서 참고).
             echo "db_pool_size=20" >> "$GITHUB_OUTPUT"
             echo "db_max_overflow=10" >> "$GITHUB_OUTPUT"
+            # story #2445(2026-08-03) — prod는 PgBouncer 미도입(#2442에서 앱 풀 20/10으로
+            # 대응, 별건 스코프). 명시 false로 다른 플래그들과 동일 컨벤션 유지.
+            echo "backend_db_pgbouncer=false" >> "$GITHUB_OUTPUT"
             # story #2005: PO 라이브 gcloud 실측(2026-07-17) — backend-prod 현재 유효 Cloud Run
             # 요청 타임아웃=300s. 지금까지 `cloudbuild.yaml`에 `--timeout` 플래그가 없어 이
             # 값은 인프라 기본값이었을 뿐 어디에도 명시돼 있지 않았다 — 이제 이 워크플로우가
@@ -189,6 +192,14 @@ jobs:
             # 덮어써버린다 — ga4_measurement_id가 dev에서 빈 문자열을 명시하는 것과 같은 이유).
             echo "db_pool_size=3" >> "$GITHUB_OUTPUT"
             echo "db_max_overflow=1" >> "$GITHUB_OUTPUT"
+            # story #2445 Phase1(2026-08-03, 페드루 인프라 VM PgBouncer 라이브 검증+시크릿
+            # DATABASE_URL_DEV_PGBOUNCER/DATABASE_URL_DIRECT_DEV 생성 완료) — dev만 true.
+            # 이 값이 true인 배포는 반드시 cloudbuild.yaml deploy-backend의 --update-secrets
+            # (DATABASE_URL/DATABASE_URL_DIRECT 재바인딩)와 같은 배포에서 동반돼야 한다 —
+            # 시크릿만 바뀌고 이 값이 false거나, 이 값만 true고 시크릿이 안 바뀌면 앱이
+            # PgBouncer 위에서 statement_cache 미비활성 상태로 붙어 prepared statement reuse
+            # 깨짐(#1314류) 또는 direct DSN 그대로 PgBouncer를 거치지 않는 반쪽 상태가 된다.
+            echo "backend_db_pgbouncer=true" >> "$GITHUB_OUTPUT"
             # story #2005: PO 라이브 gcloud 실측(2026-07-17) — backend-dev 현재 유효 Cloud Run
             # 요청 타임아웃=3600s(Cloud Run 요청 타임아웃 상한). cloudbuild.yaml의
             # `_BACKEND_TIMEOUT` 기본값(3600)과 동일값이라 이 output이 없어도 기본값으로
@@ -291,6 +302,7 @@ jobs:
           V_BACKEND_MAX_INSTANCES: ${{ steps.env.outputs.backend_max_instances }}
           V_DB_POOL_SIZE: ${{ steps.env.outputs.db_pool_size }}
           V_DB_MAX_OVERFLOW: ${{ steps.env.outputs.db_max_overflow }}
+          V_BACKEND_DB_PGBOUNCER: ${{ steps.env.outputs.backend_db_pgbouncer }}
           V_BACKEND_TIMEOUT: ${{ steps.env.outputs.backend_timeout }}
           V_GA4_MEASUREMENT_ID: ${{ steps.env.outputs.ga4_measurement_id }}
           V_REALTIME_MIN_INSTANCES: ${{ steps.env.outputs.realtime_min_instances }}
@@ -311,7 +323,7 @@ jobs:
           V_FRONTEND_MAX_INSTANCES: ${{ steps.env.outputs.frontend_max_instances }}
           V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED: ${{ steps.env.outputs.backend_sse_transient_replay_enabled }}
         run: |
-          SUBST="_DEPLOY_ENV=\"${V_DEPLOY_ENV}\",_FASTAPI_URL=\"${V_FASTAPI_URL}\",_BACKEND_MIN_INSTANCES=\"${V_BACKEND_MIN_INSTANCES}\",_BACKEND_MAX_INSTANCES=\"${V_BACKEND_MAX_INSTANCES}\",_DB_POOL_SIZE=\"${V_DB_POOL_SIZE}\",_DB_MAX_OVERFLOW=\"${V_DB_MAX_OVERFLOW}\",_BACKEND_TIMEOUT=\"${V_BACKEND_TIMEOUT}\",_GA4_MEASUREMENT_ID=\"${V_GA4_MEASUREMENT_ID}\",_REALTIME_MIN_INSTANCES=\"${V_REALTIME_MIN_INSTANCES}\",_REALTIME_MAX_INSTANCES=\"${V_REALTIME_MAX_INSTANCES}\",_REALTIME_TIMEOUT=\"${V_REALTIME_TIMEOUT}\",_REALTIME_URL=\"${V_REALTIME_URL}\",_BACKEND_PG_LISTEN_ENABLED=\"${V_BACKEND_PG_LISTEN_ENABLED}\",_BACKEND_REDIS_CONSUME_ENABLED=\"${V_BACKEND_REDIS_CONSUME_ENABLED}\",_BACKEND_REDIS_DISPATCH_ENABLED=\"${V_BACKEND_REDIS_DISPATCH_ENABLED}\",_REDIS_URL=\"${V_REDIS_URL}\",_BACKEND_REDIS_DUAL_PUBLISH_ENABLED=\"${V_BACKEND_REDIS_DUAL_PUBLISH_ENABLED}\",_BACKEND_FANOUT_WAKE_REDIS_ENABLED=\"${V_BACKEND_FANOUT_WAKE_REDIS_ENABLED}\",_SSE_MULTIPLEX_ENABLED=\"${V_SSE_MULTIPLEX_ENABLED}\",_BACKEND_PRESENCE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_REDIS_ENABLED}\",_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED}\",_BACKEND_SSE_LEASE_REDIS_ENABLED=\"${V_BACKEND_SSE_LEASE_REDIS_ENABLED}\",_FRONTEND_MIN_INSTANCES=\"${V_FRONTEND_MIN_INSTANCES}\",_FRONTEND_MAX_INSTANCES=\"${V_FRONTEND_MAX_INSTANCES}\",_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED=\"${V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}\""
+          SUBST="_DEPLOY_ENV=\"${V_DEPLOY_ENV}\",_FASTAPI_URL=\"${V_FASTAPI_URL}\",_BACKEND_MIN_INSTANCES=\"${V_BACKEND_MIN_INSTANCES}\",_BACKEND_MAX_INSTANCES=\"${V_BACKEND_MAX_INSTANCES}\",_DB_POOL_SIZE=\"${V_DB_POOL_SIZE}\",_DB_MAX_OVERFLOW=\"${V_DB_MAX_OVERFLOW}\",_BACKEND_DB_PGBOUNCER=\"${V_BACKEND_DB_PGBOUNCER}\",_BACKEND_TIMEOUT=\"${V_BACKEND_TIMEOUT}\",_GA4_MEASUREMENT_ID=\"${V_GA4_MEASUREMENT_ID}\",_REALTIME_MIN_INSTANCES=\"${V_REALTIME_MIN_INSTANCES}\",_REALTIME_MAX_INSTANCES=\"${V_REALTIME_MAX_INSTANCES}\",_REALTIME_TIMEOUT=\"${V_REALTIME_TIMEOUT}\",_REALTIME_URL=\"${V_REALTIME_URL}\",_BACKEND_PG_LISTEN_ENABLED=\"${V_BACKEND_PG_LISTEN_ENABLED}\",_BACKEND_REDIS_CONSUME_ENABLED=\"${V_BACKEND_REDIS_CONSUME_ENABLED}\",_BACKEND_REDIS_DISPATCH_ENABLED=\"${V_BACKEND_REDIS_DISPATCH_ENABLED}\",_REDIS_URL=\"${V_REDIS_URL}\",_BACKEND_REDIS_DUAL_PUBLISH_ENABLED=\"${V_BACKEND_REDIS_DUAL_PUBLISH_ENABLED}\",_BACKEND_FANOUT_WAKE_REDIS_ENABLED=\"${V_BACKEND_FANOUT_WAKE_REDIS_ENABLED}\",_SSE_MULTIPLEX_ENABLED=\"${V_SSE_MULTIPLEX_ENABLED}\",_BACKEND_PRESENCE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_REDIS_ENABLED}\",_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED}\",_BACKEND_SSE_LEASE_REDIS_ENABLED=\"${V_BACKEND_SSE_LEASE_REDIS_ENABLED}\",_FRONTEND_MIN_INSTANCES=\"${V_FRONTEND_MIN_INSTANCES}\",_FRONTEND_MAX_INSTANCES=\"${V_FRONTEND_MAX_INSTANCES}\",_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED=\"${V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}\""
           echo "substitutions=${SUBST}" >> "$GITHUB_OUTPUT"
 
       - name: Submit Cloud Build

--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -83,9 +83,13 @@ jobs:
             # main 배포 빈도가 낮아 감수(PO 확認 필요, 재검토 트리거는 위 문서 참고).
             echo "db_pool_size=20" >> "$GITHUB_OUTPUT"
             echo "db_max_overflow=10" >> "$GITHUB_OUTPUT"
-            # story #2445(2026-08-03) — prod는 PgBouncer 미도입(#2442에서 앱 풀 20/10으로
-            # 대응, 별건 스코프). 명시 false로 다른 플래그들과 동일 컨벤션 유지.
-            echo "backend_db_pgbouncer=false" >> "$GITHUB_OUTPUT"
+            # story #2445 Phase1(2026-08-04, 페드루) — prod PgBouncer cutover. dev 라이브 검증 + 부하테스트로
+            # 사이징 결함 둘(앱풀 2→25/10 · PgBouncer 서버풀 20/200→60/500)을 cutover 前에 교정, DB/PgBouncer
+            # 층 검증(60커넥션에 Cloud SQL CPU 9-21% idle). prod 중앙 PgBouncer HA(Regional MIG≥2 + Internal LB
+            # VIP 10.178.0.111:6432) 구축·「돌려서」 검증(SELECT 1 왕복·LB HEALTHY×2). 이 true는 아래
+            # cloudbuild.yaml deploy-backend의 prod --update-secrets(DATABASE_URL→VIP경유·DATABASE_URL_DIRECT→
+            # 직결)와 «같은 배포»에서 동반된다(짝이 깨지면 반쪽 상태 — dev 주석 참고).
+            echo "backend_db_pgbouncer=true" >> "$GITHUB_OUTPUT"
             # story #2005: PO 라이브 gcloud 실측(2026-07-17) — backend-prod 현재 유효 Cloud Run
             # 요청 타임아웃=300s. 지금까지 `cloudbuild.yaml`에 `--timeout` 플래그가 없어 이
             # 값은 인프라 기본값이었을 뿐 어디에도 명시돼 있지 않았다 — 이제 이 워크플로우가

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -51,10 +51,15 @@ class Settings(BaseSettings):
     # PgBouncer ④: 사이드카(localhost:6432·pool_mode=transaction) 경유 여부(env DB_PGBOUNCER).
     # off(기본): 직접 Cloud SQL — 현 동작 100% 유지(사이드카 없어도 다운 X).
     # on: statement_cache 비활성(pooled conn 간 prepared statement reuse 깨짐 방지) +
-    #     app-side pool 최소화(PgBouncer default_pool_size가 실 풀 역할).
+    #     ⭐app-side pool 을 «충분히 크게»(인스턴스당 동시성 수용). PgBouncer 가 이 클라이언트
+    #     커넥션들을 «적은 Cloud SQL 서버커넥션(default_pool_size)»으로 묶으므로 큰 앱 풀이 안전하다.
+    #     ⛔2026-08-03 부하테스트 교훈(#2445): 앱 풀을 2로 «최소화」했더니 부하(200/s)에서 앱 내부
+    #     QueuePool 큐잉→30s 타임아웃→92% 500(08-03 사고 재현·단 PgBouncer/Cloud SQL 은 건강했음).
+    #     앱 풀은 «인스턴스당 동시성」을 정하지 PgBouncer 가 대신하지 않는다 — 최소화는 backwards고
+    #     PgBouncer 도입 취지(큰 앱 풀을 안전하게)를 무력화한다. (재테스트로 실측 튜닝.)
     db_pgbouncer: bool = False
-    db_pgbouncer_pool_size: int = 2  # flag on 時 app-side pool(PgBouncer가 실 풀)
-    db_pgbouncer_max_overflow: int = 1
+    db_pgbouncer_pool_size: int = 25   # ⭐앱 동시성 수용(크게). PgBouncer가 Cloud SQL 커넥션을 묶어 안전.
+    db_pgbouncer_max_overflow: int = 10
 
     # JWT
     jwt_secret: str = ""

--- a/backend/tests/test_deploy_backend_redis_secret_conflict.py
+++ b/backend/tests/test_deploy_backend_redis_secret_conflict.py
@@ -40,7 +40,7 @@ _CLOUDBUILD_YAML = _REPO_ROOT / "cloudbuild.yaml"
 # story #2421 핫픽스 테스트가 이 목록 밖의 `${...}` 참조를 전부 "이스케이프 안 된 셸 변수"로 간주한다.
 _DECLARED_SUBSTITUTIONS = {
     "_AR_REGION", "_AR_REPO", "_DEPLOY_ENV", "_FASTAPI_URL", "_BACKEND_MIN_INSTANCES",
-    "_BACKEND_MAX_INSTANCES", "_DB_POOL_SIZE", "_DB_MAX_OVERFLOW", "_BACKEND_TIMEOUT", "_REALTIME_MIN_INSTANCES",
+    "_BACKEND_MAX_INSTANCES", "_DB_POOL_SIZE", "_DB_MAX_OVERFLOW", "_BACKEND_DB_PGBOUNCER", "_BACKEND_TIMEOUT", "_REALTIME_MIN_INSTANCES",
     "_REALTIME_MAX_INSTANCES", "_REALTIME_TIMEOUT", "_REALTIME_URL", "_FRONTEND_TIMEOUT",
     "_BACKEND_PG_LISTEN_ENABLED", "_BACKEND_REDIS_CONSUME_ENABLED",
     "_BACKEND_REDIS_DISPATCH_ENABLED", "_BACKEND_REDIS_DUAL_PUBLISH_ENABLED", "_REDIS_URL",
@@ -100,6 +100,7 @@ def _run_env_vars_assembly(deploy_env: str, redis_url: str) -> str:
         "_FASTAPI_URL": "https://example.run.app",
         "_DB_POOL_SIZE": "3",
         "_DB_MAX_OVERFLOW": "1",
+        "_BACKEND_DB_PGBOUNCER": "false",
         "_BACKEND_PG_LISTEN_ENABLED": "true",
         "_BACKEND_REDIS_CONSUME_ENABLED": "false",
         "_BACKEND_REDIS_DISPATCH_ENABLED": "false",
@@ -181,6 +182,7 @@ def test_deploy_backend_dev_env_vars_unchanged_by_prod_branch():
     result = _run_env_vars_assembly("dev", "redis://10.164.120.243:6379")
     assert result == (
         "FASTAPI_URL=https://example.run.app,DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1,"
+        "DB_PGBOUNCER=false,"
         "PG_LISTEN_ENABLED=true,EVENT_BROKER_REDIS_CONSUME_ENABLED=false,"
         "EVENT_BROKER_REDIS_DISPATCH_ENABLED=false,EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=false,"
         "FANOUT_WAKE_REDIS_ENABLED=false,PRESENCE_REDIS_ENABLED=false,"

--- a/backend/tests/test_pgbouncer_config.py
+++ b/backend/tests/test_pgbouncer_config.py
@@ -4,7 +4,9 @@ engine은 import-time 단일 생성이라 flag별 재생성이 어렵다 → 분
 database._build_engine_kwargs()로 추출해 settings 토글 → 인자 검증으로 커버한다.
 
 - off(기본): pool_size=3/overflow=1(rollout-safe·앱최소 4·ee7794eb) + connect_args 비움(statement_cache_size 없음)
-- on:        pool_size=2/overflow=1 + connect_args={"statement_cache_size": 0}
+- on:        pool_size=25/overflow=10 + connect_args={"statement_cache_size": 0}
+             (2026-08-03 #2836: 앱 풀 최소화(2/1)는 backwards — 부하에서 QueuePool 고갈. PgBouncer 가
+              멀티플렉싱하니 앱 풀을 «크게» 잡는 게 도입 취지. 자세히=config.py db_pgbouncer_pool_size 주석)
 """
 from __future__ import annotations
 
@@ -16,8 +18,8 @@ from app.core import database
 def test_settings_defaults_flag_off():
     s = Settings()
     assert s.db_pgbouncer is False
-    assert s.db_pgbouncer_pool_size == 2
-    assert s.db_pgbouncer_max_overflow == 1
+    assert s.db_pgbouncer_pool_size == 25
+    assert s.db_pgbouncer_max_overflow == 10
     assert s.db_pool_size == 3  # ee7794eb: rollout-safe·앱최소(≥4=3+1) default
     assert s.db_max_overflow == 1
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -37,6 +37,14 @@ substitutions:
   #    산식(2×N×per_instance, N=동시생존 리비전수)으로 보면 2×5×31=310>200. main 배포 빈도가
   #    develop보다 훨씬 낮아 롤아웃 중첩 창이 짧다는 판단으로 이 잔여 리스크를 감수한다(PO 확認
   #    필요 — 재검토 트리거: num_backends가 150에 근접하거나 main 연속배포가 잦아질 때).
+  # story #2445 Phase1(2026-08-03, 페드루 인프라) — dev VM PgBouncer(10.178.0.63:6432,
+  # transaction-mode) 라이브 검증 완료. dev-safe 기본값 'false'(현 동작 유지 — PgBouncer
+  # 미경유 시 database.py의 db_pgbouncer 코드 기본값과 동일). prod override는 없음(prod는
+  # #2442에서 이미 앱 풀 20/10으로 대응 — PgBouncer 도입은 이 스토리 스코프 밖, 별건).
+  # true 전환은 GHA cloud-build.yml dev 분기에서만(DATABASE_URL/DATABASE_URL_DIRECT 시크릿
+  # 재바인딩과 반드시 같은 배포에 동반 — 시크릿만 바뀌고 이 값이 false면 statement_cache
+  # 미비활성으로 PgBouncer 아래서 prepared statement reuse 깨짐, #1314류 재발).
+  _BACKEND_DB_PGBOUNCER: 'false'
   _GA4_MEASUREMENT_ID: ""  # dev 기본값 빈 문자열 — prod 트리거에서 G-RYHFE7XM3X 주입
   # story #2078(E-ARCH 0단계) — SSE 멀티플렉서 롤백 플래그. dev-safe 기본값 'false'(수동
   # `gcloud builds submit` override 없을 때 안전). GHA가 dev 브랜치에서만 'true' 주입 —
@@ -355,7 +363,7 @@ steps:
         # 에서 정정(구 `REDIS_CONSUME_ENABLED`는 Settings 필드와 안 맞아 무시되던 키) — 구 키는
         # --remove-env-vars로 명시 제거(안 지우면 두 키 공존, additive 함정).
         # story #2123 S0-b: FANOUT_WAKE_REDIS_ENABLED(dev만 true, prod는 손대지 않음).
-        ENV_VARS="FASTAPI_URL=${_FASTAPI_URL},DB_POOL_SIZE=${_DB_POOL_SIZE},DB_MAX_OVERFLOW=${_DB_MAX_OVERFLOW},PG_LISTEN_ENABLED=${_BACKEND_PG_LISTEN_ENABLED},EVENT_BROKER_REDIS_CONSUME_ENABLED=${_BACKEND_REDIS_CONSUME_ENABLED},EVENT_BROKER_REDIS_DISPATCH_ENABLED=${_BACKEND_REDIS_DISPATCH_ENABLED},EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=${_BACKEND_REDIS_DUAL_PUBLISH_ENABLED},FANOUT_WAKE_REDIS_ENABLED=${_BACKEND_FANOUT_WAKE_REDIS_ENABLED},PRESENCE_REDIS_ENABLED=${_BACKEND_PRESENCE_REDIS_ENABLED},PRESENCE_ONLINE_REDIS_ENABLED=${_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED},SSE_LEASE_REDIS_ENABLED=${_BACKEND_SSE_LEASE_REDIS_ENABLED},SSE_TRANSIENT_REPLAY_ENABLED=${_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}"
+        ENV_VARS="FASTAPI_URL=${_FASTAPI_URL},DB_POOL_SIZE=${_DB_POOL_SIZE},DB_MAX_OVERFLOW=${_DB_MAX_OVERFLOW},DB_PGBOUNCER=${_BACKEND_DB_PGBOUNCER},PG_LISTEN_ENABLED=${_BACKEND_PG_LISTEN_ENABLED},EVENT_BROKER_REDIS_CONSUME_ENABLED=${_BACKEND_REDIS_CONSUME_ENABLED},EVENT_BROKER_REDIS_DISPATCH_ENABLED=${_BACKEND_REDIS_DISPATCH_ENABLED},EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=${_BACKEND_REDIS_DUAL_PUBLISH_ENABLED},FANOUT_WAKE_REDIS_ENABLED=${_BACKEND_FANOUT_WAKE_REDIS_ENABLED},PRESENCE_REDIS_ENABLED=${_BACKEND_PRESENCE_REDIS_ENABLED},PRESENCE_ONLINE_REDIS_ENABLED=${_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED},SSE_LEASE_REDIS_ENABLED=${_BACKEND_SSE_LEASE_REDIS_ENABLED},SSE_TRANSIENT_REPLAY_ENABLED=${_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}"
         # ⛔story #2141(2026-07-23, prod Redis Memorystore 전환): REDIS_URL을 여기서 이 스텝이
         # 예전엔 dev/prod 공용으로 plain env 넘겼다 — prod는 Secret Manager 바인딩(REDIS_URL_PROD,
         # AUTH 필요)으로 전환하는데, 같은 배포에 plain REDIS_URL 키까지 넘기면 Cloud Run이
@@ -376,6 +384,14 @@ steps:
         if [ "${_DEPLOY_ENV}" != "prod" ]; then
           ENV_VARS="$${ENV_VARS},REDIS_URL=${_REDIS_URL}"
         fi
+        # story #2445 Phase1(2026-08-03) — dev만 DATABASE_URL/DATABASE_URL_DIRECT를 PgBouncer
+        # 경유 시크릿으로 재바인딩(--update-secrets=additive, 기존 다른 시크릿 preserve — REDIS_URL_
+        # PROD 등과 동일 컨벤션). prod는 이 플래그 자체를 안 넘겨 현재 DATABASE_URL_PROD 바인딩
+        # 무변경. 시크릿 자체(DATABASE_URL_DEV_PGBOUNCER/DATABASE_URL_DIRECT_DEV)는 PO가 생성.
+        SECRETS_FLAG=""
+        if [ "${_DEPLOY_ENV}" == "dev" ]; then
+          SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_DEV_PGBOUNCER:latest,DATABASE_URL_DIRECT=DATABASE_URL_DIRECT_DEV:latest"
+        fi
         gcloud run deploy sprintable-backend-${_DEPLOY_ENV} \
           --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA} \
           --region=${_AR_REGION} \
@@ -384,6 +400,7 @@ steps:
           --timeout=${_BACKEND_TIMEOUT} \
           --allow-unauthenticated \
           --update-env-vars="$${ENV_VARS}" \
+          $${SECRETS_FLAG} \
           --remove-env-vars=REDIS_CONSUME_ENABLED \
           --quiet
     # story dbda0baf: push-backend → run-migrate-job(위) 로 변경 — 신규 코드가 마이그 안 된

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -391,6 +391,11 @@ steps:
         SECRETS_FLAG=""
         if [ "${_DEPLOY_ENV}" == "dev" ]; then
           SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_DEV_PGBOUNCER:latest,DATABASE_URL_DIRECT=DATABASE_URL_DIRECT_DEV:latest"
+        elif [ "${_DEPLOY_ENV}" == "prod" ]; then
+          # story #2445 Phase1(2026-08-04) — prod cutover: DATABASE_URL→PgBouncer VIP(DATABASE_URL_PROD_PGBOUNCER,
+          # =10.178.0.111:6432), DATABASE_URL_DIRECT→직결(DATABASE_URL_PROD). _BACKEND_DB_PGBOUNCER=true와 짝.
+          # 시크릿은 PO 생성·backend-prod SA(cloudrun-runtime-prod)에 secretAccessor 부여됨.
+          SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_PROD_PGBOUNCER:latest,DATABASE_URL_DIRECT=DATABASE_URL_PROD:latest"
         fi
         gcloud run deploy sprintable-backend-${_DEPLOY_ENV} \
           --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA} \

--- a/infra/pgbouncer/deploy_prod.sh
+++ b/infra/pgbouncer/deploy_prod.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# infra/pgbouncer/deploy_prod.sh   ⚠️DRAFT — 리뷰 + dev 부하테스트(#2446) 통과 «後» 실행.
+# 인프라 Phase 1 (story #2445, 승인문서 doc:3dc965f4, 방향 B) — prod 중앙 PgBouncer (HA).
+#
+# dev(deploy_dev.sh, 단일 VM·검증 완료)와의 차이 = «HA»:
+#   - 단일 VM → Regional MIG(≥2, 존 분산)
+#   - VM 직결 → Internal TCP passthrough LB(:6432, VIP) 앞단
+#   - 헬스체크 기반 auto-healing
+# ⚠️이 스크립트는 «idle 인프라」만 만든다 — backend-prod 전환(DB_PGBOUNCER=true)은 별건이고,
+#   dev+prod 부하테스트 통과가 그 gate. 즉 이걸 돌려도 prod 트래픽엔 무영향(아무도 안 가리킴).
+#
+# 풀 사이징(핵심): transaction mode 라 «클라이언트 다수 ↔ 서버 소수».
+#   Cloud SQL prod max_connections=200. PgBouncer 인스턴스 2 × default_pool_size 80 = 160 서버커넥션
+#   (≤200·20% 헤드룸). max_client_conn 은 크게(backend Cloud Run 인스턴스들이 클라이언트).
+#   ⇒ backend 가 여러 인스턴스로 늘어도 Cloud SQL 은 160 안에서 유지 = #2442 사고의 근본 해소.
+set -euo pipefail
+
+PROJECT=sprintable-494803
+REGION=asia-northeast3
+NETWORK=default
+SUBNET=default
+CLOUDSQL_PROD_IP=10.110.0.5
+DB_NAME=sprintable
+DB_USER=postgres
+SECRET_NAME=DATABASE_URL_PROD       # VM SA 가 런타임에 읽어 비번 파싱
+MACHINE=e2-medium                    # prod: dev(e2-small)보다 여유
+MIG_SIZE=2                           # HA(≥2·존 분산)
+LISTEN_PORT=6432
+POOL_MODE=transaction
+DEFAULT_POOL_SIZE=80                 # ×2 인스턴스 = 160 서버커넥션(≤200)
+MAX_CLIENT_CONN=1000
+
+TMPL=pgbouncer-prod-tmpl
+MIG=pgbouncer-prod-mig
+HC=pgbouncer-prod-hc
+BES=pgbouncer-prod-bes
+FR=pgbouncer-prod-fr
+SA_NAME=pgbouncer-prod-sa
+SA_EMAIL="${SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+TAG=pgbouncer-prod
+
+echo ">>> [1/7] 서비스계정 + 시크릿(DATABASE_URL_PROD) 최소권한 accessor"
+gcloud iam service-accounts describe "$SA_EMAIL" --project "$PROJECT" >/dev/null 2>&1 || \
+  gcloud iam service-accounts create "$SA_NAME" --project "$PROJECT" --display-name="PgBouncer prod MIG (reads DATABASE_URL_PROD)"
+gcloud secrets add-iam-policy-binding "$SECRET_NAME" --project "$PROJECT" \
+  --member="serviceAccount:${SA_EMAIL}" --role="roles/secretmanager.secretAccessor" >/dev/null
+
+echo ">>> [2/7] Cloud NAT (dev 에서 이미 생성됨 — 없으면 생성; region 공용)"
+gcloud compute routers describe pgbouncer-nat-router --region "$REGION" --project "$PROJECT" >/dev/null 2>&1 || \
+  gcloud compute routers create pgbouncer-nat-router --network="$NETWORK" --region="$REGION" --project "$PROJECT"
+gcloud compute routers nats describe pgbouncer-nat --router=pgbouncer-nat-router --region "$REGION" --project "$PROJECT" >/dev/null 2>&1 || \
+  gcloud compute routers nats create pgbouncer-nat --router=pgbouncer-nat-router --region="$REGION" --project "$PROJECT" \
+    --auto-allocate-nat-external-ips --nat-all-subnet-ip-ranges
+
+echo ">>> [3/7] 방화벽 — (a)헬스체크 범위→:${LISTEN_PORT} (b)백엔드 egress 대역→:${LISTEN_PORT}"
+# GCP 내부 LB 헬스체크 범위: 130.211.0.0/22, 35.191.0.0/16
+gcloud compute firewall-rules describe allow-hc-pgbouncer-prod --project "$PROJECT" >/dev/null 2>&1 || \
+  gcloud compute firewall-rules create allow-hc-pgbouncer-prod --project "$PROJECT" --network="$NETWORK" \
+    --direction=INGRESS --action=ALLOW --rules="tcp:${LISTEN_PORT}" \
+    --source-ranges="130.211.0.0/22,35.191.0.0/16" --target-tags="$TAG" \
+    --description="Phase1 #2445: LB health check → PgBouncer prod"
+gcloud compute firewall-rules describe allow-pgbouncer-prod --project "$PROJECT" >/dev/null 2>&1 || \
+  gcloud compute firewall-rules create allow-pgbouncer-prod --project "$PROJECT" --network="$NETWORK" \
+    --direction=INGRESS --action=ALLOW --rules="tcp:${LISTEN_PORT}" \
+    --source-ranges="10.178.0.0/20" --target-tags="$TAG" \
+    --description="Phase1 #2445: VPC(backend egress) → PgBouncer prod :${LISTEN_PORT}"
+
+echo ">>> [4/7] startup-script 렌더 (prod Cloud SQL·prod 풀 사이징)"
+# ⚠️prod 인증: dev 와 동일 plain+userlist(VPC 내부·잠금 VM·시크릿 런타임 fetch). SCRAM/auth_query
+#   하드닝은 follow-up(별건) — 첫 cutover 는 VPC-internal plain 으로 가고, 그 뒤 강화.
+STARTUP=$(cat <<STARTUP_EOF
+#!/usr/bin/env bash
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y pgbouncer postgresql-client jq
+TOKEN=\$(curl -s -H "Metadata-Flavor: Google" "http://metadata/computeMetadata/v1/instance/service-accounts/default/token" | jq -r .access_token)
+DBURL=\$(curl -s -H "Authorization: Bearer \$TOKEN" "https://secretmanager.googleapis.com/v1/projects/${PROJECT}/secrets/${SECRET_NAME}/versions/latest:access" | jq -r .payload.data | base64 -d)
+export DBURL
+DBUSER=\$(python3 -c 'import urllib.parse,os;print(urllib.parse.urlparse(os.environ["DBURL"]).username or "")')
+DBPASS=\$(python3 -c 'import urllib.parse,os;print(urllib.parse.urlparse(os.environ["DBURL"]).password or "")')
+cat > /etc/pgbouncer/pgbouncer.ini <<INI
+[databases]
+${DB_NAME} = host=${CLOUDSQL_PROD_IP} port=5432 dbname=${DB_NAME}
+
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = ${LISTEN_PORT}
+auth_type = plain
+auth_file = /etc/pgbouncer/userlist.txt
+pool_mode = ${POOL_MODE}
+max_client_conn = ${MAX_CLIENT_CONN}
+default_pool_size = ${DEFAULT_POOL_SIZE}
+ignore_startup_parameters = extra_float_digits
+server_tls_sslmode = require
+admin_users = \$DBUSER
+INI
+printf '"%s" "%s"\n' "\$DBUSER" "\$DBPASS" > /etc/pgbouncer/userlist.txt
+chown postgres:postgres /etc/pgbouncer/userlist.txt
+chmod 600 /etc/pgbouncer/userlist.txt
+systemctl enable pgbouncer
+systemctl restart pgbouncer
+echo "pgbouncer-prod startup done: :${LISTEN_PORT} → Cloud SQL ${CLOUDSQL_PROD_IP} (pool ${DEFAULT_POOL_SIZE})"
+STARTUP_EOF
+)
+# --metadata-from-file: gcloud --metadata=K=V splits on ',' and '=', which the startup script
+# contains (e.g. `import urllib.parse,os`, INI `key = val`). A file sidesteps that parsing entirely.
+STARTUP_FILE=$(mktemp /tmp/pgb-prod-startup.XXXXXX)
+printf '%s' "$STARTUP" > "$STARTUP_FILE"
+
+echo ">>> [5/7] 인스턴스 템플릿"
+gcloud compute instance-templates describe "$TMPL" --project "$PROJECT" >/dev/null 2>&1 || \
+  gcloud compute instance-templates create "$TMPL" --project "$PROJECT" \
+    --machine-type="$MACHINE" --network="$NETWORK" --subnet="projects/${PROJECT}/regions/${REGION}/subnetworks/${SUBNET}" --no-address \
+    --service-account="$SA_EMAIL" --scopes="https://www.googleapis.com/auth/cloud-platform" \
+    --tags="$TAG" --image-family=debian-12 --image-project=debian-cloud \
+    --metadata-from-file=startup-script="$STARTUP_FILE"
+
+echo ">>> [6/7] Regional MIG(≥${MIG_SIZE}·존 분산) + 헬스체크 auto-healing"
+# Internal passthrough LB requires a REGIONAL health check (global HC rejected by regional backend-service).
+gcloud compute health-checks describe "$HC" --region="$REGION" --project "$PROJECT" >/dev/null 2>&1 || \
+  gcloud compute health-checks create tcp "$HC" --region="$REGION" --project "$PROJECT" --port="$LISTEN_PORT" \
+    --check-interval=10s --timeout=5s --healthy-threshold=2 --unhealthy-threshold=3
+gcloud compute instance-groups managed describe "$MIG" --region "$REGION" --project "$PROJECT" >/dev/null 2>&1 || \
+  gcloud compute instance-groups managed create "$MIG" --project "$PROJECT" --region="$REGION" \
+    --template="$TMPL" --size="$MIG_SIZE" \
+    --health-check="projects/${PROJECT}/regions/${REGION}/healthChecks/${HC}" --initial-delay=120
+
+echo ">>> [7/7] Internal TCP passthrough LB (:${LISTEN_PORT} VIP)"
+gcloud compute backend-services describe "$BES" --region "$REGION" --project "$PROJECT" >/dev/null 2>&1 || \
+  gcloud compute backend-services create "$BES" --project "$PROJECT" --region="$REGION" \
+    --load-balancing-scheme=INTERNAL --protocol=TCP --health-checks="$HC" --health-checks-region="$REGION"
+gcloud compute backend-services add-backend "$BES" --project "$PROJECT" --region="$REGION" \
+  --instance-group="$MIG" --instance-group-region="$REGION" 2>/dev/null || true
+gcloud compute forwarding-rules describe "$FR" --region "$REGION" --project "$PROJECT" >/dev/null 2>&1 || \
+  gcloud compute forwarding-rules create "$FR" --project "$PROJECT" --region="$REGION" \
+    --load-balancing-scheme=INTERNAL --network="$NETWORK" --subnet="projects/${PROJECT}/regions/${REGION}/subnetworks/${SUBNET}" \
+    --ip-protocol=TCP --ports="$LISTEN_PORT" --backend-service="$BES" --backend-service-region="$REGION"
+
+echo ">>> 완료. Internal LB VIP(=backend-prod 가 가리킬 주소):"
+gcloud compute forwarding-rules describe "$FR" --region "$REGION" --project "$PROJECT" --format="value(IPAddress)"
+echo "다음(gate: dev+prod 부하테스트 통과 後): DATABASE_URL_PROD_PGBOUNCER 시크릿(=VIP:6432) 생성 →"
+echo "     cloudbuild prod 분기 DB_PGBOUNCER=true + --update-secrets(prod) 배선(디디) → backend-prod 전환."


### PR DESCRIPTION
## 무엇 (prod PgBouncer cutover · 방향 B · 선생님 승인 doc:3dc965f4)

prod backend를 중앙 PgBouncer(HA) 경유로 전환 — 08-03 DB 커넥션 풀 고갈 사고(#2442) 계열의 근본 해소.

**develop 머지(2커밋, pgbouncer 전용)**:
- #2836 앱풀 backwards 교정 (config.py 2/1→25/10) — PgBouncer 앞에선 앱 풀을 «크게»
- #2835 dev cutover 배선 (cloud-build.yml / cloudbuild.yaml DB_PGBOUNCER + 시크릿 재바인딩)

**prod 플립(이 PR)**:
- `cloud-build.yml`: prod `backend_db_pgbouncer` false→true
- `cloudbuild.yaml`: prod `--update-secrets`(DATABASE_URL→`DATABASE_URL_PROD_PGBOUNCER`[VIP 10.178.0.111:6432]·DATABASE_URL_DIRECT→`DATABASE_URL_PROD`[직결])
- `infra/pgbouncer/deploy_prod.sh`: prod 중앙 PgBouncer HA SSOT

## 인프라 (구축·검증 완료, 이 PR 前)
- Regional MIG≥2(존 분산) + Internal TCP LB VIP **10.178.0.111:6432** + 리전 HC(auto-heal) + 최소권한 SA(런타임 시크릿 fetch)
- 사이징: default_pool_size 80×2=160 서버커넥션(≤Cloud SQL 200)·max_client_conn 1000
- 「돌려서」 검증: **SELECT 1 왕복 성공**(pgbouncer→Cloud SQL prod, user=sprintable)·**LB HEALTHY×2**
- 시크릿 `DATABASE_URL_PROD_PGBOUNCER` 생성·backend-prod SA(cloudrun-runtime-prod) secretAccessor 부여됨

## 부하테스트가 cutover 前에 잡은 것 (게이트의 값)
- 앱풀 최소화(2/1)→부하에 QueuePool 고갈 → 25/10 교정
- PgBouncer 서버풀 사이징(dev 20/200→60/500)
- 진짜 처리량 천장 = Cloud Run 앱티어(max-instances) — DB/PgBouncer 아님(60커넥션에 Cloud SQL CPU 9-21% idle). 별개 축(§6)
- 구축 中 IaC 함정 4개 근본고침(서브넷 리전·HC 글로벌↔리전 LB·자원 의존 삭제순서·메타데이터 콤마)·prod DB user=sprintable 런타임 파싱

## 롤백
`backend_db_pgbouncer=false` 되돌리고 재배포(또는 revert) → DATABASE_URL이 직결로 복귀. prod 저트래픽 창에서 cutover, health/prepared-stmt 에러 실시간 감시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)