### PR TITLE
fix(#2449): refresh grace 5→30초 — 복귀 시 병렬 refresh 로그아웃 완화

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -275,7 +275,12 @@ class Settings(BaseSettings):
     # (REFRESH_GRACE_MS=5000, proxy.ts)을 BE로 옮겨 인스턴스 개수/라우팅과 무관하게 만든다
     # (오르테가·미르코 판단: Redis로 FE 상태공유는 proxy.ts가 edge 런타임이라 과한 인프라 —
     # 배제. DB-only fork-rotation이 근본이면서 인프라 안 키우는 정공법).
-    auth_refresh_grace_seconds: int = 5
+    # 2026-08-04 5→30 (#2449): 5초는 복귀 시 «병렬 refresh 다발»의 실 spread 를 다 못 덮었다 —
+    # FE 가 single-flight 없이(멀티인스턴스서 무의미해 제거) 매 요청 직접 refresh 하므로, 복귀 시
+    # N 병렬요청이 같은 RT 로 동시회전 → grace 밖 race-loser 가 하드 401 → clearAuthCookies(성공한
+    # 요청이 방금 심은 쿠키까지 삭제) → 로그아웃(선생님 실측 로그아웃 로그 01:41Z). 30초로 fork 창을
+    # 넓혀 완화. ⚠️완치 아님(근본=서버 successor-chaining or FE cross-tab single-flight·#2449).
+    auth_refresh_grace_seconds: int = 30
 
     firebase_project_id: str = ""  # Firebase/Identity Platform GCP 프로젝트 ID(dev/prod 분리)
 


### PR DESCRIPTION
## 무엇 (#2449 즉효분)
`auth_refresh_grace_seconds` 기본값 **5→30초**. 선생님 실사용 「자리 비우고 복귀 시 거의 항상 로그아웃」의 즉효 완화.

## 진상규명 (선생님 01:41Z 로그아웃 순간 prod 로그로 확定)
```
01:40:40  refresh 4× 200 (원자회전+grace fork)
01:41:30  refresh 3× 401 (같은 key·revoked > grace 5초)
01:41:52  refresh 4× 401
```
- access token 60분 만료 → 복귀 시 FE 가 **병렬 인증요청 다발**을 쏘고, single-flight 가 없어(멀티인스턴스서 무의미해 제거·proxy.ts:329 주석) 각 요청이 **같은 RT 로 동시 refresh**.
- 서버 원자회전은 1건만 통과, 나머지는 「이미 회전된 RT」 → **grace 5초 밖이면 하드 401** → FE `clearAuthCookies`(성공한 요청이 방금 심은 쿠키까지 삭제) → **강제 로그아웃**.
- 복귀 요청 spread 가 5초보다 넓으면(느린 로드/다탭) 로그아웃. cutover 무관(refresh 0.02-0.11s).

## 변경
- `config.py` `auth_refresh_grace_seconds: 5 → 30`. fork 창을 넓혀 spread 를 덮음.
- 즉효는 prod rev 00261 에 `AUTH_REFRESH_GRACE_SECONDS=30` env 로 선반영됨 — 이 PR 병합 후 그 env 드리프트 제거(기본값이 SSOT).

## 한계 (완치는 #2449 별건)
grace 는 완화지 완치 아님. 근본 = ①서버 successor-chaining(revoked→후속 유효토큰 해소·FE 무관 robust) 또는 ②FE cross-tab single-flight. + stuck-loop(stale vault 토큰 sp_acct_rt_* 미삭제)도 별도.

## 테스트
`test_e5225c0a_refresh_atomic_realdb.py` 는 `settings.auth_refresh_grace_seconds`를 상대 참조(하드코딩 5 아님) — 무회귀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)