### PR TITLE
fix(#2449): /refresh 해소 허용창 grace→chain_resolve_window(180s) — main 포트(#2839 cherry-pick)

### DIFF
--- a/backend/alembic/versions/0226_refresh_token_replaced_by.py
+++ b/backend/alembic/versions/0226_refresh_token_replaced_by.py
@@ -1,0 +1,44 @@
+"""refresh_tokens.replaced_by — story #2449 로그인 세션 풀림 근본(successor chain 계보 컬럼)
+
+Revision ID: 0226
+Revises: 0225
+Create Date: 2026-08-04
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0226"
+down_revision = "0225"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "refresh_tokens",
+        sa.Column("replaced_by", UUID(as_uuid=True), nullable=True),
+    )
+    # 현재 앱 로직(app/routers/auth.py)은 replaced_by를 새 row가 실제 INSERT+commit된 «後»
+    # 별개 UPDATE로만 기록하므로 이 시점엔 참조 대상이 이미 존재 — DEFERRABLE INITIALLY
+    # DEFERRED가 판정에 필수는 아니다. 다만 폐기된 v1 설계(원자 revoke UPDATE와 «같은» 문장에
+    # 미리생성 id를 얹어, revoke 성공 直後 다른 이유로 조기반환하면 deferred FK가 커밋 시점에
+    # 위반돼 그 revoke까지 롤백되는 회귀를 냈다 — 카디르 QA REQUEST_CHANGES 2026-08-04)에서
+    # 이 옵션이 정확히 그 실패를 잡아준 이력이 있어, 방어적으로 유지한다(무해·재발 방지 여지).
+    op.create_foreign_key(
+        "fk_refresh_tokens_replaced_by",
+        "refresh_tokens",
+        "refresh_tokens",
+        ["replaced_by"],
+        ["id"],
+        ondelete="SET NULL",
+        deferrable=True,
+        initially="DEFERRED",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_refresh_tokens_replaced_by", "refresh_tokens", type_="foreignkey")
+    op.drop_column("refresh_tokens", "replaced_by")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -275,12 +275,17 @@ class Settings(BaseSettings):
     # (REFRESH_GRACE_MS=5000, proxy.ts)을 BE로 옮겨 인스턴스 개수/라우팅과 무관하게 만든다
     # (오르테가·미르코 판단: Redis로 FE 상태공유는 proxy.ts가 edge 런타임이라 과한 인프라 —
     # 배제. DB-only fork-rotation이 근본이면서 인프라 안 키우는 정공법).
-    # 2026-08-04 5→30 (#2449): 5초는 복귀 시 «병렬 refresh 다발»의 실 spread 를 다 못 덮었다 —
-    # FE 가 single-flight 없이(멀티인스턴스서 무의미해 제거) 매 요청 직접 refresh 하므로, 복귀 시
-    # N 병렬요청이 같은 RT 로 동시회전 → grace 밖 race-loser 가 하드 401 → clearAuthCookies(성공한
-    # 요청이 방금 심은 쿠키까지 삭제) → 로그아웃(선생님 실측 로그아웃 로그 01:41Z). 30초로 fork 창을
-    # 넓혀 완화. ⚠️완치 아님(근본=서버 successor-chaining or FE cross-tab single-flight·#2449).
-    auth_refresh_grace_seconds: int = 30
+    # story #2449(2026-08-04) 갱신 — #2838 즉효패치가 main에 직접 심은 auth_refresh_grace_
+    # seconds(기본 30, prod rev 00262 손값 SSOT 반영)를 폐지·단일화. 애초 이 필드는 "제시된
+    # (구) RT 자신의 revoked_at 기준 해소 허용창" 하나뿐이었다(다른 경로 미사용, grep 확認) —
+    # 「successor-chaining」 설계 검토 중 깊이-무제한 체인 walk 자체가 판정 결과에 영향이 없고
+    # (제시 토큰 자신의 revoked_at 하나만 이 창과 비교하면 다단계 walk와 결론이 같다) 오히려
+    # 아직 아무도 안 쓴 살아있는 successor를 straggler가 먼저 소비해 정당한 소유자를 다음
+    # rotation에서 되레 401내는 하자가 있어(디디 분석·PO 승인 2026-08-04) 「창 넓히기 + winner
+    # 경로 승계기록(감사용, 판정엔 미사용)」으로 수렴했다. 창 안이면 오늘처럼 독립적인 새
+    # 토큰을 fork(다른 row 무접촉) — 노출창은 여전히 «분» 오더(토큰 수명 30일 아님).
+    # N=180초(3분)는 선생님 확定값(2026-08-04, PR #2839 머지 게이트 통과).
+    auth_refresh_chain_resolve_window_seconds: int = 180
 
     firebase_project_id: str = ""  # Firebase/Identity Platform GCP 프로젝트 ID(dev/prod 분리)
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -58,6 +58,22 @@ class RefreshToken(Base):
     project_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # story #2449: 원자 rotation 승자 경로에서, 새 row가 실제로 INSERT+commit된 «後» 별개
+    # UPDATE로 old row에 그 새 row의 id를 기록 — winner rotation 계보 추적/향후 family-revoke
+    # 훅용. NULL=아직 회전 안 됐거나 logout 등 dead-end(승계자 없는 명시적 종료).
+    #
+    # ⛔v1 설계(폐기, 카디르 QA REQUEST_CHANGES 2026-08-04)는 이 id를 원자 revoke UPDATE와
+    # «같은» 문장에 미리 얹었다 — revoke 성공 直後 user 조회가 실패(예: 그새 계정 비활성화)해
+    # 새 row INSERT 前에 401로 조기반환하면, deferred FK가 커밋 시점에 위반돼 트랜잭션 전체
+    # (방금 성공한 revoke 포함)가 롤백되는 회귀였다(e5225c0a P0 single-use 불변식 재파손).
+    # 지금은 별도 post-INSERT UPDATE라 그 결합 자체가 없다 — deferrable=True/initially=
+    # "DEFERRED"는 이제 판정에 필수는 아니지만(참조 대상이 이미 커밋된 뒤에만 이 UPDATE가
+    # 실행됨) 방어적으로 유지한다(카디르 확認, 마이그 0226 무접촉이 더 안전).
+    replaced_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("refresh_tokens.id", ondelete="SET NULL", deferrable=True, initially="DEFERRED"),
+        nullable=True,
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -537,7 +537,7 @@ async def _store_refresh_token(
     user: User,
     raw_token: str,
     expires_at: datetime,
-) -> None:
+) -> uuid.UUID:
     row = RefreshToken(
         user_id=user.id,
         token_hash=hash_token(raw_token),
@@ -547,6 +547,7 @@ async def _store_refresh_token(
     )
     session.add(row)
     await session.commit()
+    return row.id
 
 
 # ─── POST /api/v2/auth/register ───────────────────────────────────────────────
@@ -764,6 +765,16 @@ async def refresh_token(
     # 비원자라 Cloud Run 멀티 인스턴스 간 동시 refresh가 둘 다 "아직 안 revoke"로 통과하는 race의
     # 근본 원인이었다(산티아고 prod 로그 실측: /auth/refresh 239건 중 230건 401). 검증+revoke를
     # 단일 UPDATE...WHERE revoked_at IS NULL...RETURNING으로 묶어 동시 요청 중 정확히 1건만 매치.
+    #
+    # ⛔story #2449 회귀(카디르 QA REQUEST_CHANGES, 2026-08-04): 이 원자 UPDATE에 replaced_by=
+    # <미리 생성한 새 id>를 «같은» 문장으로 얹었던 1차 구현은, revoke 직후 user 조회가 실패
+    # (예: 그새 계정 비활성화)해 새 row INSERT 前에 401로 조기 반환하면 — deferred FK가 커밋
+    # 시점에 "그 id를 가진 row가 없다"로 위반돼 «트랜잭션 전체»(이 revoke 포함)가 롤백됐다.
+    # 즉 진짜 승자의 원자 revoke 자체가 무효화되어 같은 RT가 재사용 가능한 상태로 되돌아가는
+    # — e5225c0a P0가 막으려던 바로 그 single-use 불변식 파손을 재도입하는 회귀였다. 감사기록
+    # (replaced_by)의 성패가 anti-replay 불변식의 성패에 영향을 줘선 안 된다 — 그래서 이 revoke
+    # UPDATE는 replaced_by 없이 «독립적으로» 커밋되고, replaced_by는 새 row가 실제로 INSERT+
+    # commit된 «후에» 별개 문장으로 기록한다(아래 _store_refresh_token 호출부 이후).
     revoked_user_id = (await session.execute(
         update(RefreshToken)
         .where(
@@ -774,21 +785,33 @@ async def refresh_token(
         .values(revoked_at=datetime.now(timezone.utc))
         .returning(RefreshToken.user_id)
     )).scalar_one_or_none()
+    won_atomic_rotation = revoked_user_id is not None
     if revoked_user_id is None:
-        # ⛔P0 신 클래스(#1887 쿠키-Domain no-op과 별개 — config.py auth_refresh_grace_seconds
-        # 주석 참조): proxy.ts 의 FE 인스턴스-로컬 single-flight dedupe 는 Cloud Run 멀티인스턴스
-        # 간 공유가 안 돼, 하드리프레시의 병렬 인증요청이 인스턴스 분산되면 같은 RT 로 동시
-        # rotate 경합이 남는다 — 진 쪽은 방금(grace window 내) 이미 소비된 RT 를 만난 것뿐,
-        # 진짜 stale/탈취 replay 가 아니다. grace window 내 revoke 된 토큰이면 하드 401 로 FE
-        # clearAuthCookies()(강제 로그아웃)를 유발하는 대신 독립적인 새 rotation 을 한 번 더
-        # 발급(fork)한다 — 이미 소비된 old RT 를 재사용하는 게 아니라 그 자신만의 새 RT 를
-        # 새로 발급받을 뿐이라 원자 single-use 불변식 자체는 안 깨진다.
-        grace_cutoff = datetime.now(timezone.utc) - timedelta(seconds=settings.auth_refresh_grace_seconds)
+        # ⛔P0 신 클래스(#1887 쿠키-Domain no-op과 별개) — proxy.ts 의 FE 인스턴스-로컬
+        # single-flight dedupe 는 Cloud Run 멀티인스턴스 간 공유가 안 돼, 하드리프레시의 병렬
+        # 인증요청이 인스턴스 분산되면 같은 RT 로 동시 rotate 경합이 남는다 — 진 쪽은 방금(창
+        # 내) 이미 소비된 RT 를 만난 것뿐, 진짜 stale/탈취 replay 가 아니다.
+        #
+        # story #2449 설계 확定(2026-08-04, 디디 분석·PO 승인): 처음엔 replaced_by 체인을
+        # 끝까지 walk 해 "아직 아무도 안 쓴 살아있는 successor"까지 수렴시키는 안을 검토했으나,
+        # (a) 그 walk 깊이는 판정 결과에 영향이 없다 — 제시된 old RT «자신»의 revoked_at 하나만
+        # 이 창과 비교해도 몇 세대 뒤든 결론이 같다. (b) 오히려 그 살아있는 successor 는 아직
+        # 자기 소유자(그 rotation 을 실제로 받은 탭)가 한 번도 안 쓴 토큰이라, straggler 가
+        # 먼저 소비(walk-and-fork)해버리면 정당한 소유자가 나중에(다음 access-token 만료 시,
+        # 최대 60분 뒤) 그 토큰을 처음 쓸 때 되레 하드 401 — 문제를 근절이 아니라 한 세대
+        # 뒤로 떠넘기는 꼴이었다. (c) raw RT 는 hash-only 보관이라 애초에 "현재 살아있는 tip
+        # 의 실제 값"을 straggler 에게 돌려줄 방법도 없다. 그래서 설계는 「창 넓히기(grace_
+        # seconds→chain_resolve_window_seconds) + 통과 시 오늘과 동일한 독립 fork(다른 row
+        # 무접촉)」로 수렴했다 — replaced_by 는 «승자 경로에서만» 기록해 감사열(정상 회전 死
+        # vs logout 같은 명시적 dead-end 구분)·향후 family-revoke 훅 기반으로만 쓴다.
+        resolve_cutoff = datetime.now(timezone.utc) - timedelta(
+            seconds=settings.auth_refresh_chain_resolve_window_seconds
+        )
         revoked_user_id = (await session.execute(
             select(RefreshToken.user_id).where(
                 RefreshToken.token_hash == token_hash,
                 RefreshToken.revoked_at.is_not(None),
-                RefreshToken.revoked_at > grace_cutoff,
+                RefreshToken.revoked_at > resolve_cutoff,
                 RefreshToken.expires_at > datetime.now(timezone.utc),
             )
         )).scalar_one_or_none()
@@ -797,8 +820,8 @@ async def refresh_token(
             # 0이라 "누가 이 루프에 빠졌는지" 못 쫓았다(prod 실측: 같은 key가 ~20초 간격으로
             # 수십 회 반복 — "가끔 풀린다"가 아니라 "빠지면 못 나온다"). row 자체(만료/폐기든)가
             # 있으면 user_id를 읽기만(best-effort, 인가 판정에 영향 0 — 이미 위에서 거부 확定
-            # 後의 순수 로깅 조회) 해 로그에 싣는다. 새 규칙 발명 0 — grace_reuse가 이미 로깅하는
-            # user_id 축을 실패 로그에도 동일하게 확장하는 것뿐.
+            # 後의 순수 로깅 조회) 해 로그에 싣는다. 새 규칙 발명 0 — window_reuse가 이미
+            # 로깅하는 user_id 축을 실패 로그에도 동일하게 확장하는 것뿐.
             _diag_user_id = (await session.execute(
                 select(RefreshToken.user_id).where(RefreshToken.token_hash == token_hash)
             )).scalar_one_or_none()
@@ -808,7 +831,8 @@ async def refresh_token(
             )
             return _err("TOKEN_REVOKED", "Refresh token revoked or expired", 401)
         logger.info(
-            "auth.refresh grace_reuse key=%s user_id=%s reason=multi_instance_race_loser_fork_rotation",
+            "auth.refresh chain_resolve_window_reuse key=%s user_id=%s "
+            "reason=multi_instance_race_loser_fork_rotation",
             correlation_key, revoked_user_id,
         )
 
@@ -824,7 +848,17 @@ async def refresh_token(
         _persist_resolved_context(user, _md)  # 908075db 단계2: side-effect 호출부 이관
     tokens = create_tokens(str(user.id), email=user.email, app_metadata=_md)
     _, refresh_exp = create_refresh_token(str(user.id), expires_delta=timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS))
-    await _store_refresh_token(session, user, tokens["refresh_token"], refresh_exp)
+    new_token_id = await _store_refresh_token(session, user, tokens["refresh_token"], refresh_exp)
+    if won_atomic_rotation:
+        # story #2449(회귀 수정): 이 시점엔 새 row가 이미 INSERT+commit 완료라(_store_refresh_
+        # token 내부), old row의 이 UPDATE가 실패하거나 프로세스가 죽어도 원자 revoke(위)는
+        # 이미 별개로 확定돼 있어 anti-replay 불변식과 무관 — 순수 감사기록일 뿐이다.
+        await session.execute(
+            update(RefreshToken)
+            .where(RefreshToken.token_hash == token_hash)
+            .values(replaced_by=new_token_id)
+        )
+        await session.commit()
     # #2124(관측성 보강): 성공 회전도 old_key→new_key로 로깅 — 지금까지 성공 경로엔 로그가
     # 아예 없어(까심발견류 '침묵이 결함을 오래 살린다'와 동형) "회전은 성공했는데 클라가 새
     # 토큰을 저장 못 했는가(㉮)"를 훗날 old_key의 하드 401과 new_key의 미사용 여부로 대조

--- a/backend/tests/test_e5225c0a_refresh_atomic_realdb.py
+++ b/backend/tests/test_e5225c0a_refresh_atomic_realdb.py
@@ -8,12 +8,22 @@ refresh_token으로 동시 2요청을 쏴 원자 single-use rotation(switch_acco
 ⛔story cd10e123(P0, e5225c0a와 별개 신 클래스) 갱신: 원자 rotation 자체는 여전히
 single-use(위 불변식 유지)이나, "진 쪽에게 무엇을 응답하는지"가 바뀌었다 — 예전엔 하드
 401(TOKEN_REVOKED)로 FE가 clearAuthCookies() 실행해 강제 로그아웃됐다(멀티인스턴스 in-memory
-dedup 미공유 때문에 이게 진짜 race의 정상 경로로 발생). 이제는 grace window(config.py
-auth_refresh_grace_seconds, 기본 5s) 내 revoke된 토큰이면 진짜 stale/replay가 아니라 race
-패자로 판정해 독립적인 새 rotation(fork)을 발급, 200으로 응답한다 — 그래서 아래
+dedup 미공유 때문에 이게 진짜 race의 정상 경로로 발생). 이제는 해소 허용창(config.py
+auth_refresh_chain_resolve_window_seconds, 기본 180s) 내 revoke된 토큰이면 진짜 stale/replay가
+아니라 race 패자로 판정해 독립적인 새 rotation(fork)을 발급, 200으로 응답한다 — 그래서 아래
 `test_concurrent_refresh_same_token_exactly_one_succeeds_realdb`는 [200,401]이 아니라
 [200,200](양쪽 다 독립적으로 유효한, 그러나 서로 다른 토큰)을 기대하도록 갱신됐다.
-grace window 밖(진짜 stale)은 여전히 401 — 아래 `_after_grace` 테스트가 그 경계를 증명한다.
+창 밖(진짜 stale)은 여전히 401 — 아래 `_after_window` 테스트가 그 경계를 증명한다.
+
+story #2449(2026-08-04): 옛 이름 auth_refresh_grace_seconds(기본 5s)를
+auth_refresh_chain_resolve_window_seconds(기본 180s)로 단일화 — 「successor-chaining」(깊이
+무제한 replaced_by 체인 walk) 설계 검토 중 그 walk가 판정 결과엔 영향이 없고(제시 토큰
+자신의 revoked_at 하나만 창과 비교하면 다단계 walk와 결론이 같음) 오히려 아직 아무도 안 쓴
+살아있는 successor를 straggler가 먼저 소비해 정당한 소유자를 되레 401내는 하자가 있어
+「창 넓히기 + 승자 경로 replaced_by 감사기록(판정엔 미사용)」으로 수렴했다(디디 분석·PO
+승인). 아래 `test_refresh_success_records_replaced_by_on_winner_realdb`가 그 감사기록만
+검증한다 — 하나의 판정 로직도 안 바뀌었다는 뜻으로, 이 파일의 기존 테스트는 이름만
+`_grace_window`→`_window`로 바뀌고 기대값은 그대로다.
 """
 from __future__ import annotations
 
@@ -110,7 +120,7 @@ async def _setup_app(app, Session):
 @pytest.mark.anyio
 async def test_concurrent_refresh_same_token_exactly_one_succeeds_realdb():
     """까심 race 재현 — 갱신(story cd10e123): 동일 refresh_token 동시 2요청 → 이제 둘 다 200
-    (grace-window fork). 원자성 불변식은 "둘이 서로 다른 독립 토큰을 받는지"로 증명한다 —
+    (chain_resolve_window fork). 원자성 불변식은 "둘이 서로 다른 독립 토큰을 받는지"로 증명한다 —
     같은 토큰을 공유해 받으면 그건 그것대로 버그(양쪽이 같은 세션을 오인)."""
     from app.main import app
 
@@ -128,7 +138,7 @@ async def test_concurrent_refresh_same_token_exactly_one_succeeds_realdb():
             )
             statuses = sorted(r.status_code for r in results)
             assert statuses == [200, 200], (
-                f"grace-window fork 실패 — 동시 2요청 결과가 [200,200]이 아님: {statuses} "
+                f"chain_resolve_window fork 실패 — 동시 2요청 결과가 [200,200]이 아님: {statuses} "
                 f"(1건이라도 401이면 멀티인스턴스 race 강제로그아웃 재발)"
             )
             rt_a = results[0].json()["data"]["refresh_token"]
@@ -142,9 +152,10 @@ async def test_concurrent_refresh_same_token_exactly_one_succeeds_realdb():
 
 
 @pytest.mark.anyio
-async def test_refresh_replay_within_grace_window_forks_new_session_realdb():
-    """story cd10e123: grace window(기본 5s) 내 순차 재사용 → 200(fork) — race 패자가 강제
-    로그아웃되지 않고 독립적인 새 세션을 받는다는 게 이 신 클래스 fix의 핵심 계약."""
+async def test_refresh_replay_within_chain_resolve_window_forks_new_session_realdb():
+    """story cd10e123: 해소 허용창(기본 180s, story #2449 이전엔 5s) 내 순차 재사용 → 200(fork)
+    — race 패자가 강제 로그아웃되지 않고 독립적인 새 세션을 받는다는 게 이 신 클래스 fix의
+    핵심 계약."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -168,9 +179,12 @@ async def test_refresh_replay_within_grace_window_forks_new_session_realdb():
 
 
 @pytest.mark.anyio
-async def test_refresh_replay_after_grace_window_still_401_realdb():
-    """회귀 0(갱신): grace window *밖*의 진짜 stale replay는 여전히 401 — grace가 무기한
-    재사용을 허용하는 게 아님을 경계값으로 증명(revoked_at을 grace+1s 과거로 직접 backdate)."""
+async def test_refresh_replay_after_chain_resolve_window_still_401_realdb():
+    """회귀 0(갱신): 해소 허용창 *밖*의 진짜 stale replay는 여전히 401 — 창이 무기한 재사용을
+    허용하는 게 아님을 경계값으로 증명(revoked_at을 window+1s 과거로 직접 backdate). story
+    #2449: 이 assert는 auth_refresh_chain_resolve_window_seconds 값을 직접 읽어 경계를 잡으므로
+    값이 바뀌면(예: 선생님이 180→다른 값 확認) 이 테스트가 그 새 값 기준으로 재현된다 — 손값
+    하드코딩이면 값이 바뀌어도 조용히 안 잡히는 자리라 일부러 settings에서 읽는다."""
     from app.main import app
     from app.core.config import settings
 
@@ -188,7 +202,9 @@ async def test_refresh_replay_after_grace_window_still_401_realdb():
             from app.core.security import hash_token
             from app.models.user import RefreshToken
             from sqlalchemy import update as sa_update
-            stale_at = datetime.now(timezone.utc) - timedelta(seconds=settings.auth_refresh_grace_seconds + 1)
+            stale_at = datetime.now(timezone.utc) - timedelta(
+                seconds=settings.auth_refresh_chain_resolve_window_seconds + 1
+            )
             async with Session() as s:
                 await s.execute(
                     sa_update(RefreshToken)
@@ -209,8 +225,8 @@ async def test_refresh_replay_after_grace_window_still_401_realdb():
 
 @pytest.mark.anyio
 async def test_refresh_failure_logs_reason_and_correlation_key_realdb(caplog):
-    """산티아고 관측성 요구(item 3): grace window 밖 실패 시 reason+상관키가 로그에 남는지 실증
-    (story cd10e123 갱신: grace 안쪽은 이제 성공이라 이 테스트는 grace 밖 시나리오로 검증)."""
+    """산티아고 관측성 요구(item 3): 해소 허용창 밖 실패 시 reason+상관키가 로그에 남는지 실증
+    (story cd10e123 갱신: 창 안쪽은 이제 성공이라 이 테스트는 창 밖 시나리오로 검증)."""
     import logging
     from app.main import app
     from app.core.config import settings
@@ -229,7 +245,9 @@ async def test_refresh_failure_logs_reason_and_correlation_key_realdb(caplog):
             from app.core.security import hash_token
             from app.models.user import RefreshToken
             from sqlalchemy import update as sa_update
-            stale_at = datetime.now(timezone.utc) - timedelta(seconds=settings.auth_refresh_grace_seconds + 1)
+            stale_at = datetime.now(timezone.utc) - timedelta(
+                seconds=settings.auth_refresh_chain_resolve_window_seconds + 1
+            )
             async with Session() as s:
                 await s.execute(
                     sa_update(RefreshToken)
@@ -289,6 +307,169 @@ async def test_refresh_success_logs_rotation_old_new_key_realdb(caplog):
                 and f"user_id={seeded['user_id']}" in r.message
                 for r in caplog.records
             ), f"rotation 관측성 로그 누락: {[r.message for r in caplog.records]}"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_refresh_user_inactive_after_win_does_not_undo_atomic_revoke_realdb():
+    """story #2449 회귀(카디르 QA REQUEST_CHANGES, 2026-08-04): 1차 구현은 원자 revoke UPDATE에
+    replaced_by=<미리 생성한 새 id>를 «같은» 문장으로 얹었다 — 승자가 revoke까지 성공한 뒤
+    user 조회가 실패(예: 그새 계정 비활성화)해 새 row INSERT 前에 401로 조기 반환하면, deferred
+    FK가 커밋 시점에 위반되어 «트랜잭션 전체»(방금 성공한 revoke 포함)가 롤백됐다 — 같은 RT가
+    재사용 가능한 상태로 되돌아가는, e5225c0a P0가 막으려던 바로 그 single-use 불변식 파손을
+    재도입하는 회귀였다. 이 테스트는 그 정확한 시퀀스(원자 revoke 승 → user 비활성 → 401)를
+    재현해, old row가 USER_NOT_FOUND 응답 後에도 «계속 revoke된 채로» 남아있는지(재사용 불가)
+    직접 검증한다 — revoked_at이 NULL로 복귀하면 이 회귀가 재발한 것."""
+    from app.main import app
+    from app.core.security import hash_token
+    from app.models.user import RefreshToken, User
+    from sqlalchemy import select as sa_select, update as sa_update
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_user_with_refresh_token(s)
+            # 원자 revoke가 «성공한 뒤에» user 조회가 실패하는 상황을 재현 — 삭제(FK CASCADE로
+            # refresh_tokens까지 같이 날아가 이 시나리오 자체를 못 만든다)가 아니라 비활성화로,
+            # _get_user_by_id(is_active=True 필터)가 None을 반환하게 만든다.
+            await s.execute(
+                sa_update(User).where(User.id == seeded["user_id"]).values(is_active=False)
+            )
+            await s.commit()
+
+        await _setup_app(app, Session)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/auth/refresh", json={"refresh_token": seeded["raw_refresh"]},
+            )
+            assert resp.status_code == 401
+            assert resp.json()["error"]["code"] == "USER_NOT_FOUND"
+
+            async with Session() as s:
+                old_row = (await s.execute(
+                    sa_select(RefreshToken).where(
+                        RefreshToken.token_hash == hash_token(seeded["raw_refresh"])
+                    )
+                )).scalar_one()
+            assert old_row.revoked_at is not None, (
+                "회귀 재발 — 원자 revoke가 조용히 롤백돼 old RT가 재사용 가능한 상태로 복귀함"
+            )
+
+            # 이중 확인: 같은 RT로 다시 refresh를 쏴도 여전히 거부돼야 한다(회귀 시엔 마치
+            # 한 번도 안 쓴 토큰처럼 통과해버렸다).
+            replay = await client.post(
+                "/api/v2/auth/refresh", json={"refresh_token": seeded["raw_refresh"]},
+            )
+            assert replay.status_code == 401
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_refresh_success_records_replaced_by_on_winner_realdb():
+    """story #2449: 원자 rotation 승자 경로에서 old row.replaced_by가 새 row.id로 정확히
+    채워지는지 실증 — 이 값이 없으면 「정상 회전 死(승계자 有) vs logout 같은 명시적
+    dead-end(승계자 無)」를 구분할 감사열 자체가 비어 이 changeset의 핵심 주장(판정 로직은
+    안 바꾸고 감사기록만 추가)이 근거 없는 선언이 된다."""
+    from app.main import app
+    from app.core.security import hash_token
+    from app.models.user import RefreshToken
+    from sqlalchemy import select as sa_select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_user_with_refresh_token(s)
+
+        await _setup_app(app, Session)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/auth/refresh", json={"refresh_token": seeded["raw_refresh"]},
+            )
+            assert resp.status_code == 200, resp.text
+            new_raw = resp.json()["data"]["refresh_token"]
+
+            async with Session() as s:
+                old_row = (await s.execute(
+                    sa_select(RefreshToken).where(
+                        RefreshToken.token_hash == hash_token(seeded["raw_refresh"])
+                    )
+                )).scalar_one()
+                new_row = (await s.execute(
+                    sa_select(RefreshToken).where(RefreshToken.token_hash == hash_token(new_raw))
+                )).scalar_one()
+
+            assert old_row.revoked_at is not None, "승자 rotation인데 old row가 revoke 안 됨"
+            assert old_row.replaced_by == new_row.id, (
+                f"replaced_by 미기록/불일치 — old.replaced_by={old_row.replaced_by} "
+                f"new.id={new_row.id}"
+            )
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_refresh_chain_resolve_window_fork_leaves_replaced_by_null_realdb():
+    """story #2449: 해소 허용창 안 fork(loser) 경로는 replaced_by를 «절대» 안 건드린다는 걸
+    실증한다 — 이게 이 changeset이 피한 하자(살아있는 successor를 straggler가 먼저 소비)의
+    반대증명: fork된 새 row 자신의 replaced_by는 NULL(아직 아무도 그걸 회전 안 함), 그리고
+    승자가 만든 old→new 링크는 loser 응답과 무관하게 그대로 유지된다."""
+    from app.main import app
+    from app.core.security import hash_token
+    from app.models.user import RefreshToken
+    from sqlalchemy import select as sa_select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_user_with_refresh_token(s)
+
+        await _setup_app(app, Session)
+        client = _client_for(app)
+        try:
+            winner = await client.post(
+                "/api/v2/auth/refresh", json={"refresh_token": seeded["raw_refresh"]},
+            )
+            assert winner.status_code == 200, winner.text
+            winner_new_raw = winner.json()["data"]["refresh_token"]
+
+            # 원 토큰으로 재사용(창 안) — loser fork 경로를 태운다.
+            loser = await client.post(
+                "/api/v2/auth/refresh", json={"refresh_token": seeded["raw_refresh"]},
+            )
+            assert loser.status_code == 200, loser.text
+            loser_new_raw = loser.json()["data"]["refresh_token"]
+            assert loser_new_raw != winner_new_raw
+
+            async with Session() as s:
+                old_row = (await s.execute(
+                    sa_select(RefreshToken).where(
+                        RefreshToken.token_hash == hash_token(seeded["raw_refresh"])
+                    )
+                )).scalar_one()
+                winner_row = (await s.execute(
+                    sa_select(RefreshToken).where(RefreshToken.token_hash == hash_token(winner_new_raw))
+                )).scalar_one()
+                loser_row = (await s.execute(
+                    sa_select(RefreshToken).where(RefreshToken.token_hash == hash_token(loser_new_raw))
+                )).scalar_one()
+
+            assert old_row.replaced_by == winner_row.id, "승자 링크가 loser fork로 덮어써짐"
+            assert loser_row.replaced_by is None, (
+                "loser fork row에 replaced_by가 채워짐 — 살아있는 노드를 건드리는 하자가 재발했을 수 있는 신호"
+            )
         finally:
             await client.aclose()
     finally:


### PR DESCRIPTION
## 요약
#2839(develop, N=180 확定·머지 완료)를 prod(main)에 도달시키기 위한 포트. develop이 main보다 174 커밋 뒤진 곁가지라 merge/rebase 대신 **squash 커밋(a57598b0b) cherry-pick**으로 올렸다(오래된 base를 되살리지 않기 위해).

## 충돌 해소
main에는 #2838(즉효패치 `auth_refresh_grace_seconds=30`)이 직접 들어가 있어 `backend/app/core/config.py`에서 충돌. #2839가 grace를 **대체**하는 설계이므로 해소 = **#2839 채택**(main에 `auth_refresh_grace_seconds` 잔존 0, `auth_refresh_chain_resolve_window_seconds=180`으로 수렴). `backend/app/routers/auth.py`·마이그 0226은 main의 0225 위에 무충돌로 적용됨.

## auth 동작이 바뀌는 자리
#2839와 동일 — 요약: `/refresh` 원자 rotation 경합에서 진 요청(loser)의 fork 허용창이 30초(#2838) → 180초(N=180, **선생님 확定값**)로 넓어짐. 판정 로직 자체는 무변경(1-hop, 제시된 old RT 자신의 revoked_at만 봄). 원자 rotation 승자 경로에서 `replaced_by`를 **새 row가 실제 INSERT+commit된 後** 별개 UPDATE로 기록(감사열, 판정 로직과 무관 — 카디르 QA가 잡은 회귀를 이미 #2839에서 수정 완료).

## 검증(main 기준 재확인)
- 로컬 pgvector/pg15, main 브랜치 기준 `alembic upgrade heads`(0225 위에 0226 무충돌 적용) 확認
- `ci_alembic_single_step_promotion_check`(기존 DB에 마지막 리비전 1개만 얹는 실배포 경로) 통과
- realdb 테스트 9개 全통과(#2839에서 검증된 신규 replaced_by pin·회귀 재현 테스트 포함)
- `auth_refresh_grace_seconds` 필드가 main 코드베이스에 완전히 제거됐는지 grep으로 확認(잔존 0)

## 머지 게이트
⚠️ 카디르 QA는 develop base였으므로 **main base로 재QA 필요**(검사를 어디서 돌렸는가도 값). PO 리뷰 + 카디르 재QA 後 올리베이라군이 main 머지 → prod 배포·서빙 확認. #2838 grace-30이 완화 中이라 급하진 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)