### PR TITLE
feat(#2451 §6 Phase3): read replica — foundation + analytics 읽기 라우팅 + prod PgBouncer read풀 IaC

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -21,6 +21,11 @@ class Settings(BaseSettings):
     # Cloud SQL URL 별도**로 우회. 미설정 시 database_url 폴백(non-PgBouncer 환경). on+미설정 = startup
     # fail-closed(pg_pubsub.check_listen_config·main lifespan).
     database_url_direct: str = ""
+    # Phase3(§6 read replica): 읽기 전용 DSN — DATABASE_URL_READ. 미설정이면 database_url(primary)로
+    # 폴백(replica 없거나 준비 前 «무해»). PgBouncer 경유 시 dbname=sprintable_read → replica 라우팅.
+    # ⚠️ get_read_db 는 «read-your-writes lag 허용» 읽기(목록·대시보드·타인 데이터)에만 — 방금 쓴 걸
+    #    즉시 읽는 경로는 get_db(primary) 유지(replica lag 로 «내 write 안 보임» 방지).
+    database_url_read: str = ""
 
     # Cloud SQL (D-S1: Phase D GCP 인프라)
     cloud_sql_instance_dev: str = "sprintable-494803:asia-northeast3:sprintable-dev"

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -65,6 +65,20 @@ async_session_factory = async_sessionmaker(
     class_=AsyncSession,
 )
 
+# Phase3(§6 read replica): 읽기 전용 엔진/세션. DATABASE_URL_READ 설정 時 read replica(PgBouncer
+# dbname=sprintable_read)로 라우팅, 미설정 時 primary engine 재사용(폴백 — 별도 커넥션 안 늘림·«무해»).
+# ⚠️ get_read_db 는 lag-tolerant 읽기에만 (아래 docstring).
+read_engine = (
+    create_async_engine(settings.database_url_read, **_build_engine_kwargs())
+    if settings.database_url_read
+    else engine
+)
+read_session_factory = async_sessionmaker(
+    read_engine,
+    expire_on_commit=False,
+    class_=AsyncSession,
+)
+
 
 class Base(DeclarativeBase):
     pass
@@ -75,6 +89,23 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
         try:
             yield session
             await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+
+async def get_read_db() -> AsyncGenerator[AsyncSession, None]:
+    """Phase3(§6): 읽기 전용 세션 — read replica(DATABASE_URL_READ 설정 時) 또는 primary(폴백).
+
+    ⚠️ «read-your-writes lag 허용» 읽기(목록·대시보드·타인 데이터·집계)에만 쓴다 — 방금 쓴 걸
+    즉시 조회하는 경로(POST 直後 GET 등)는 get_db(primary)를 유지해야 replica lag 로 «내 write 가
+    안 보이는» 버그를 막는다. 라우터별 라우팅은 careful 판정(#2450).
+
+    커밋하지 않는다(읽기 전용) — 예외 時 rollback, 정상 時 세션 정리만.
+    """
+    async with read_session_factory() as session:
+        try:
+            yield session
         except Exception:
             await session.rollback()
             raise

--- a/backend/app/dependencies/database.py
+++ b/backend/app/dependencies/database.py
@@ -1,3 +1,3 @@
-from app.core.database import get_db
+from app.core.database import get_db, get_read_db
 
-__all__ = ["get_db"]
+__all__ = ["get_db", "get_read_db"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,7 +42,7 @@ _logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     from app.core import shutdown as shutdown_module
-    from app.core.database import engine
+    from app.core.database import engine, read_engine
     from app.routers.auth_firebase_internal import check_internal_secret_config
     from app.routers.cron import check_cron_secret_config
     from app.routers.verdict_capture import warn_if_webhook_secret_misconfigured
@@ -167,6 +167,11 @@ async def lifespan(app: FastAPI):
             # raw 커넥션은 task.cancel→listen_loop finally 에서 이미 close. L2 워커는
             # l2_task.cancel→run finally 에서 advisory lock 해제·전용 커넥션 close.
             await engine.dispose()
+            # Phase3(#2451): DATABASE_URL_READ 설정 시 read_engine 은 primary 와 «다른» 객체(별도 replica
+            # 커넥션풀)라 별도 dispose 필요 — 안 하면 위 좀비-연결 클래스(S:33e0c681)가 replica 쪽에서 재발.
+            # 미설정이면 read_engine is engine 이라 위 dispose 로 이미 정리됨(중복 dispose 방지).
+            if read_engine is not engine:
+                await read_engine.dispose()
 
 
 from app.routers import a2a, account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, deeplink_manifest, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, device_installations, dispatch, docs, entities, goals, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, judgments, labels, loops, mcp, me, meetings, members, merge_gate, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, project_access, project_settings, projects, public_docs, reference_candidates, references, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, session_context, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, usage, user_blocks, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -5,7 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
-from app.dependencies.database import get_db
+from app.dependencies.database import get_read_db
 from app.models.pm import Sprint
 from app.repositories.analytics import AnalyticsRepository
 from app.schemas.analytics import (
@@ -31,8 +31,10 @@ from app.services.project_auth import has_project_access
 router = APIRouter(prefix="/api/v2", tags=["analytics", "Work"])
 
 
+# Phase3(#2451): analytics 전 엔드포인트는 순수 집계/대시보드(이 파일 write 0·read-your-writes 기대 없음)
+# → read replica(get_read_db)로 라우팅해 primary 부하를 던다. DATABASE_URL_READ 미설정이면 primary 폴백(무해).
 def _get_repo(
-    session: AsyncSession = Depends(get_db),
+    session: AsyncSession = Depends(get_read_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> AnalyticsRepository:
     return AnalyticsRepository(session, org_id)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -203,7 +203,7 @@ def auth_ctx(org_id: uuid.UUID) -> MagicMock:
 async def test_client(mock_session: AsyncMock, auth_ctx: MagicMock):
     """AsyncClient with mocked DB session + auth. Clears dependency_overrides on teardown."""
     from app.dependencies.auth import get_current_user
-    from app.dependencies.database import get_db
+    from app.dependencies.database import get_db, get_read_db
     from app.main import app
 
     async def _override_db():
@@ -213,6 +213,7 @@ async def test_client(mock_session: AsyncMock, auth_ctx: MagicMock):
         return auth_ctx
 
     app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_read_db] = _override_db
     app.dependency_overrides[get_current_user] = _override_auth
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -35,9 +35,10 @@ async def _client():
         return ctx
 
     from app.dependencies.auth import get_current_user
-    from app.dependencies.database import get_db
+    from app.dependencies.database import get_db, get_read_db
 
     app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_read_db] = override_db
     app.dependency_overrides[get_current_user] = override_auth
 
     from httpx import ASGITransport, AsyncClient

--- a/backend/tests/test_check_env_drift_settings_coverage.py
+++ b/backend/tests/test_check_env_drift_settings_coverage.py
@@ -147,6 +147,9 @@ def test_settings_field_env_keys_works_without_pydantic_settings_importable(monk
     # 신설로 83→84 — 이메일 provider 미설정 셀프호스트에서 org 생성이 인증을 무조건 요구하던
     # 것을 완화하는 신규 설정(기본 True, 호스티드/prod 동작 불변). 이 가드가 설계대로 새
     # Settings 필드를 실제로 잡아낸 것 — 개수 자체가 늘어난 게 아니라 늘어난 게 정답이다.
+    # #2451(§6 Phase3 read replica): database_url_read 필드 신설로 84→85(DATABASE_URL_READ 포함).
+    # 미설정이면 primary 폴백·설정 시 read replica 라우팅. 가드가 신규 필드를 설계대로 잡은 것.
     assert "PRESENCE_REDIS_ENABLED" in keys and "SSE_TRANSIENT_REPLAY_ENABLED" in keys
     assert "REQUIRE_VERIFIED_EMAIL_FOR_ORG_CREATE" in keys
-    assert len(keys) == 84
+    assert "DATABASE_URL_READ" in keys
+    assert len(keys) == 85

--- a/backend/tests/test_e_security_sec_s8_dd_analytics_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_dd_analytics_scope_realdb.py
@@ -95,7 +95,7 @@ def _client_for(app):
 
 async def _setup_app(app, Session, user_id, org_id):
     from app.dependencies.auth import AuthContext, get_current_user
-    from app.dependencies.database import get_db
+    from app.dependencies.database import get_db, get_read_db
 
     async def _db():
         async with Session() as s:
@@ -113,6 +113,7 @@ async def _setup_app(app, Session, user_id, org_id):
         )
 
     app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_read_db] = _db
     app.dependency_overrides[get_current_user] = _auth
 
 

--- a/infra/pgbouncer/deploy_prod.sh
+++ b/infra/pgbouncer/deploy_prod.sh
@@ -20,6 +20,7 @@ REGION=asia-northeast3
 NETWORK=default
 SUBNET=default
 CLOUDSQL_PROD_IP=10.110.0.5
+CLOUDSQL_PROD_REPLICA_IP=10.110.0.16  # Phase3(#2451·§6): read replica sprintable-prod-replica(private·RUNNABLE)
 DB_NAME=sprintable
 DB_USER=postgres
 SECRET_NAME=DATABASE_URL_PROD       # VM SA 가 런타임에 읽어 비번 파싱
@@ -82,6 +83,10 @@ DBPASS=\$(python3 -c 'import urllib.parse,os;print(urllib.parse.urlparse(os.envi
 cat > /etc/pgbouncer/pgbouncer.ini <<INI
 [databases]
 ${DB_NAME} = host=${CLOUDSQL_PROD_IP} port=5432 dbname=${DB_NAME}
+# Phase3(#2451): read replica 풀 — 클라이언트가 dbname=${DB_NAME}_read 로 붙으면 replica 로 라우팅.
+# get_read_db(lag-tolerant 읽기)만 이 풀을 탄다. 풀당 default_pool_size(80)×MIG2 = 160 서버커넥션 → replica
+# max_connections(master 상속·200 가정, cutover 前 SHOW 로 確認) 안. primary 풀은 그대로(무영향·additive).
+${DB_NAME}_read = host=${CLOUDSQL_PROD_REPLICA_IP} port=5432 dbname=${DB_NAME}
 
 [pgbouncer]
 listen_addr = 0.0.0.0


### PR DESCRIPTION
## 무엇
§6 규모 critical path(부하테스트가 「read 부하는 DB 가 벽」 실증). read replica 로 primary read 부하를 던다. app-side 첫 슬라이스.

## ⚙️ 동작이 바뀌는 자리 (명시)
- `app/dependencies/database.py`: get_read_db re-export(라우터 공용 import 경로).
- `app/routers/analytics.py`: `_get_repo` 세션 get_db→**get_read_db**. 즉 analytics 13개(overview·workload·velocity·burndown·epic-progress·agent-stats·health…)가 read_engine 을 탄다.
  - read_engine = **DATABASE_URL_READ 설정 時 replica·미설정이면 primary 폴백(무해)**. ⇒ 이 PR 배포만으론 동작 무변화(env 켜기 前 primary). 활성화 = prod env flip, 롤백 = env unset.
- foundation(이미 이 브랜치 커밋): config `database_url_read`, database.py `read_engine`/`get_read_db`(lag-tolerant 전용).
- `infra/pgbouncer/deploy_prod.sh`: prod PgBouncer `sprintable_read` 풀 IaC — **이미 prod 라이브 적용됨**(rev-r2·SELECT pg_is_in_recovery=t@10.110.0.16 검증). 이 커밋은 SSOT 동기화.

## 왜 analytics 부터
순수 read-only(이 파일 write 0)·집계/대시보드라 «방금 쓴 것 즉시» 기대가 없다 = read-your-writes 위험 0. 기본은 primary 유지, 명백 lag 허용만 점진 확대.

## QA 초점 (⚠️ main base)
- analytics 13개 정상(폴백 primary 로도·env 설정 시 replica 로도) 무회귀.
- get_read_db 커밋 안 함(읽기 전용) — analytics 가 write 안 하는지 재확認.
- CI green.

## 활성화(머지·배포 後 PO)
prod backend DATABASE_URL_READ env flip → analytics 요청이 sprintable_read 풀 실히트(SHOW POOLS cl>0) 라이브 확認 → read-your-writes 회귀 0 관찰.