### PR TITLE
fix(billing): honor paid org entitlement on org creation

### DIFF
--- a/backend/app/repositories/organization.py
+++ b/backend/app/repositories/organization.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 
-from sqlalchemy import func, select, text
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy import case, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.organization import Organization
+from app.models.org_subscription import OrgSubscription
 from app.models.participation import ParticipationRole
 from app.models.project import OrgMember, Project
 
@@ -98,15 +98,29 @@ class OrganizationRepository:
 
     async def list_for_user(self, user_id: uuid.UUID) -> list[OrganizationWithRole]:
         """사용자가 org_members로 속한 Organization 목록 반환 (name ASC)."""
+        effective_plan = case(
+            (
+                OrgSubscription.status == "active",
+                case(
+                    (
+                        OrgSubscription.tier.in_(("team", "pro")),
+                        OrgSubscription.tier,
+                    ),
+                    else_="free",
+                ),
+            ),
+            else_="free",
+        ).label("plan")
         result = await self.session.execute(
             select(
                 Organization.id,
                 Organization.name,
                 Organization.slug,
-                Organization.plan,
+                effective_plan,
                 OrgMember.role,
             )
             .join(OrgMember, OrgMember.org_id == Organization.id)
+            .outerjoin(OrgSubscription, OrgSubscription.org_id == Organization.id)
             .where(
                 OrgMember.user_id == user_id,
                 OrgMember.deleted_at.is_(None),

--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -15,7 +15,7 @@ import time
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import delete, select, text, update
@@ -27,9 +27,9 @@ from app.core import shutdown as _shutdown_module
 from app.dependencies.database import get_db
 from app.models.agent_gateway import AgentEventCursor, AgentGatewaySession
 from app.models.event import Event
-from app.models.organization import Organization
+from app.models.org_subscription import OrgSubscription
 from app.models.team import TeamMember
-from app.routers.events import _agent_connections, _event_to_payload
+from app.routers.events import _agent_connections
 
 logger = logging.getLogger(__name__)
 
@@ -380,9 +380,15 @@ async def agent_stream(
         if tm is None:
             raise HTTPException(status_code=404, detail="Agent not found")
 
-        # E-INFRA S5: tier(=org.plan) 해소 — per-key 동시 스트림 cap 산정용 (free<paid)
+        # E-INFRA S5: active subscription tier 해소 — per-key 동시 스트림 cap 산정용
+        # (free<paid). organizations.plan 은 결제 갱신과 분리된 legacy 값이라 entitlement SSOT로
+        # 사용하지 않는다. inactive/unknown/missing subscription 은 fail-closed free.
         org_plan = (await db.execute(
-            select(Organization.plan).where(Organization.id == tm.org_id)
+            select(OrgSubscription.tier).where(
+                OrgSubscription.org_id == tm.org_id,
+                OrgSubscription.status == "active",
+                OrgSubscription.tier.in_(("team", "pro")),
+            )
         )).scalar_one_or_none() or "free"
         org_id_str = str(tm.org_id)  # R2: presence SSE 발행용(generate 클로저 캡처).
 

--- a/backend/ee/plan_limits.py
+++ b/backend/ee/plan_limits.py
@@ -39,9 +39,13 @@ def _plan_limit_error(resource: str, limit: int) -> HTTPException:
 
 
 async def _get_org_tier(session: AsyncSession, org_id) -> str:
-    """org_subscriptions에서 tier 조회. 레코드 없으면 free."""
+    """active org_subscriptions에서 paid tier 조회. 그 외는 fail-closed free."""
     result = await session.execute(
-        text("SELECT tier FROM org_subscriptions WHERE org_id = :oid"),
+        text(
+            "SELECT tier FROM org_subscriptions"
+            " WHERE org_id = :oid AND status = 'active'"
+            " AND tier IN ('team', 'pro')"
+        ),
         {"oid": str(org_id)},
     )
     row = result.first()
@@ -49,7 +53,26 @@ async def _get_org_tier(session: AsyncSession, org_id) -> str:
 
 
 async def check_org_create_limit(session: AsyncSession, user_id) -> None:
-    """Free: 사용자당 owner org 1개 제한."""
+    """Free: 사용자당 owner org 1개 제한.
+
+    활성 Team/Pro 조직의 owner/admin은 유료 entitlement를 상속해 제한을 스킵한다. Organization
+    생성은 아직 새 org_id가 없으므로 현재 조직을 인자로 받을 수 없다. 따라서 caller의 활성
+    org membership과 org_subscriptions를 조인하는 것이 이 경로의 paid SSOT다.
+    """
+    paid_result = await session.execute(
+        text(
+            "SELECT 1 FROM org_members om"
+            " JOIN org_subscriptions os ON os.org_id = om.org_id"
+            " WHERE om.user_id = :uid AND om.deleted_at IS NULL"
+            " AND om.role IN ('owner', 'admin')"
+            " AND os.status = 'active' AND os.tier IN ('team', 'pro')"
+            " LIMIT 1"
+        ),
+        {"uid": str(user_id)},
+    )
+    if paid_result.first() is not None:
+        return
+
     result = await session.execute(
         text(
             "SELECT COUNT(*) FROM org_members"

--- a/backend/tests/test_e_infra_s5_agent_stream_rate_limit.py
+++ b/backend/tests/test_e_infra_s5_agent_stream_rate_limit.py
@@ -21,11 +21,17 @@ def anyio_backend():
 
 
 def _patch(monkeypatch, agent_id, org_plan="free"):
-    db = AsyncMock(); db.add = MagicMock(); db.commit = AsyncMock()
-    tm = MagicMock(); tm.org_id = uuid.uuid4()
-    res_agent = MagicMock(); res_agent.scalar_one_or_none.return_value = tm
-    res_plan = MagicMock(); res_plan.scalar_one_or_none.return_value = org_plan
-    res_cursor = MagicMock(); res_cursor.scalar_one_or_none.return_value = None
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    tm = MagicMock()
+    tm.org_id = uuid.uuid4()
+    res_agent = MagicMock()
+    res_agent.scalar_one_or_none.return_value = tm
+    res_plan = MagicMock()
+    res_plan.scalar_one_or_none.return_value = org_plan
+    res_cursor = MagicMock()
+    res_cursor.scalar_one_or_none.return_value = None
     db.execute = AsyncMock(side_effect=[res_agent, res_plan, res_cursor])
 
     class _Ctx:
@@ -36,7 +42,9 @@ def _patch(monkeypatch, agent_id, org_plan="free"):
 
     monkeypatch.setattr(ag, "async_session_factory", lambda: _Ctx())
     monkeypatch.setattr(ag, "_agent_sse_connection_count", 0)  # global cap 여유
-    req = MagicMock(); req.headers = {}
+    req = MagicMock()
+    req.headers = {}
+    req._test_db = db
     auth = AuthContext(user_id=str(agent_id), email=None,
                        claims={"app_metadata": {"api_key_id": "k"}}, org_id=None)
     return req, auth, str(agent_id)
@@ -89,5 +97,10 @@ async def test_tier_aware_paid_allows_more(monkeypatch):
     try:
         resp = await ag.agent_stream(req, auth=auth)  # pro라 허용(free였으면 429)
         assert isinstance(resp, StreamingResponse)
+        tier_stmt = str(req._test_db.execute.await_args_list[1].args[0])
+        assert "org_subscriptions" in tier_stmt
+        assert "org_subscriptions.status" in tier_stmt
+        assert "org_subscriptions.tier" in tier_stmt
+        assert "organizations.plan" not in tier_stmt
     finally:
         ag._agent_connections.pop(aid_str, None)

--- a/backend/tests/test_e_org_multi_s1_1_list_organizations.py
+++ b/backend/tests/test_e_org_multi_s1_1_list_organizations.py
@@ -187,6 +187,18 @@ def test_list_for_user_filters_deleted_at():
     assert "deleted_at" in source
 
 
+def test_list_for_user_plan_uses_active_subscription_ssot():
+    """일반 설정 UI의 plan은 legacy organizations.plan이 아니라 active subscription에서 온다."""
+    import inspect
+    from app.repositories.organization import OrganizationRepository
+
+    source = inspect.getsource(OrganizationRepository.list_for_user)
+    assert "OrgSubscription" in source
+    assert 'OrgSubscription.status == "active"' in source
+    assert 'OrgSubscription.tier.in_(("team", "pro"))' in source
+    assert "Organization.plan" not in source
+
+
 @pytest.mark.anyio
 async def test_user_b_sees_only_own_org():
     """USER_B의 요청에는 USER_B의 Organization만 반환됨."""

--- a/backend/tests/test_e_org_multi_s5_5_plan_limits.py
+++ b/backend/tests/test_e_org_multi_s5_5_plan_limits.py
@@ -155,16 +155,18 @@ def test_api_overage_rates_defined():
 
 @pytest.mark.asyncio
 async def test_check_org_create_limit_raises_when_over():
-    """owner org 1개 이상 시 check_org_create_limit → 402 HTTPException."""
+    """paid membership 없이 owner org 1개 이상이면 402."""
     import uuid
-    from unittest.mock import AsyncMock, MagicMock, patch
+    from unittest.mock import AsyncMock, MagicMock
     from fastapi import HTTPException
     from ee.plan_limits import check_org_create_limit
 
     mock_session = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalar.return_value = 1  # owner org 1개 이미 존재
-    mock_session.execute = AsyncMock(return_value=mock_result)
+    paid_result = MagicMock()
+    paid_result.first.return_value = None
+    count_result = MagicMock()
+    count_result.scalar.return_value = 1  # owner org 1개 이미 존재
+    mock_session.execute = AsyncMock(side_effect=[paid_result, count_result])
 
     with pytest.raises(HTTPException) as exc_info:
         await check_org_create_limit(mock_session, uuid.uuid4())
@@ -175,17 +177,72 @@ async def test_check_org_create_limit_raises_when_over():
 
 @pytest.mark.asyncio
 async def test_check_org_create_limit_passes_when_zero():
-    """owner org 0개 시 check_org_create_limit → 통과."""
+    """paid membership 없고 owner org 0개면 통과."""
     import uuid
     from unittest.mock import AsyncMock, MagicMock
     from ee.plan_limits import check_org_create_limit
 
     mock_session = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalar.return_value = 0
-    mock_session.execute = AsyncMock(return_value=mock_result)
+    paid_result = MagicMock()
+    paid_result.first.return_value = None
+    count_result = MagicMock()
+    count_result.scalar.return_value = 0
+    mock_session.execute = AsyncMock(side_effect=[paid_result, count_result])
 
     await check_org_create_limit(mock_session, uuid.uuid4())  # 예외 없어야 함
+
+
+@pytest.mark.asyncio
+async def test_check_org_create_limit_paid_org_admin_skips_owner_limit():
+    """active Team/Pro org owner/admin은 별도 owner-count 조회 없이 생성 제한을 스킵."""
+    import uuid
+    from unittest.mock import AsyncMock, MagicMock
+    from ee.plan_limits import check_org_create_limit
+
+    mock_session = AsyncMock()
+    paid_result = MagicMock()
+    paid_result.first.return_value = (1,)
+    mock_session.execute = AsyncMock(return_value=paid_result)
+
+    await check_org_create_limit(mock_session, uuid.uuid4())
+
+    assert mock_session.execute.await_count == 1
+    sql = str(mock_session.execute.await_args.args[0])
+    assert "org_subscriptions" in sql
+    assert "om.role IN ('owner', 'admin')" in sql
+    assert "os.status = 'active'" in sql
+    assert "os.tier IN ('team', 'pro')" in sql
+
+
+@pytest.mark.asyncio
+async def test_get_org_tier_uses_active_paid_subscription_only():
+    import uuid
+    from unittest.mock import AsyncMock, MagicMock
+    from ee.plan_limits import _get_org_tier
+
+    session = AsyncMock()
+    result = MagicMock()
+    result.first.return_value = ("pro",)
+    session.execute = AsyncMock(return_value=result)
+
+    assert await _get_org_tier(session, uuid.uuid4()) == "pro"
+    sql = str(session.execute.await_args.args[0])
+    assert "status = 'active'" in sql
+    assert "tier IN ('team', 'pro')" in sql
+
+
+@pytest.mark.asyncio
+async def test_get_org_tier_missing_or_inactive_fails_closed_free():
+    import uuid
+    from unittest.mock import AsyncMock, MagicMock
+    from ee.plan_limits import _get_org_tier
+
+    session = AsyncMock()
+    result = MagicMock()
+    result.first.return_value = None
+    session.execute = AsyncMock(return_value=result)
+
+    assert await _get_org_tier(session, uuid.uuid4()) == "free"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- make active `org_subscriptions` the entitlement SSOT for organization-list plan display, Agent Gateway stream tier, project/member/storage limits, and organization-create quota
- allow an active Team/Pro organization owner/admin to create another organization while preserving the Free one-owned-org limit for everyone else
- fail closed to Free for missing, inactive, cancelled, Free, or unknown subscriptions

## Production context
Moonklabs internal dogfooding had split state: `organizations.plan=free` while `org_subscriptions.tier=pro,status=active`. A guarded one-off production update synchronized the legacy row to `pro`; this hotfix prevents the runtime/UI entitlement paths from depending on that legacy column and fixes the separate organization-create quota defect.

## Authorization boundary
Organization-create bypass requires:
- active `org_members` membership
- role `owner` or `admin`
- matching organization subscription with `status=active`
- tier `team` or `pro`

Ordinary members, deleted memberships, inactive/cancelled subscriptions, Free subscriptions, and unknown tiers do not bypass the limit. Newly created organizations still start on Free; paid entitlement is not copied.

## Verification
- `uv run --frozen pytest -q tests/test_e_org_multi_s5_5_plan_limits.py tests/test_e_org_multi_s1_1_list_organizations.py tests/test_e_infra_s5_agent_stream_rate_limit.py tests/test_2143_agent_stream_legacy_push_id_omission.py` → 35 passed
- changed-file Ruff → passed
- `git diff --check` → passed

## Risk
Contained to EE entitlement reads and organization-create quota evaluation. No migration.
