### PR TITLE
feat(#2446): §6 결승선 부하테스트 harness — 생성기 self-check + A1/A2 endpoint 믹스

### DIFF
--- a/backend/scripts/loadtest/.gitignore
+++ b/backend/scripts/loadtest/.gitignore
@@ -1,0 +1,1 @@
+loadtest_creds.json

--- a/backend/scripts/loadtest/README.md
+++ b/backend/scripts/loadtest/README.md
@@ -1,0 +1,44 @@
+# story #2446 — dev capacity gate (DB axis)
+
+Drives a high *rate* of DB-touching REST calls against `sprintable-backend-dev` using a small,
+reused set of pre-seeded identities — not maximum concurrent agents/connections. See
+`dev_db_capacity_test.js` header for why (08-03 incident was request-rate pool exhaustion, not
+connection count; SSE concurrency caps are a separate story).
+
+## Usage
+
+```bash
+BASE_URL=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app \
+CREDS_FILE=./loadtest_creds.json \
+TARGET_RATE=200 \
+RAMP_TIME=2m \
+HOLD_TIME=30m \
+k6 run dev_db_capacity_test.js
+```
+
+## `loadtest_creds.json` shape
+
+A JSON array, each entry an already-seeded (DB-direct, not HTTP signup) agent identity scoped
+to one org/project:
+
+```json
+[
+  { "api_key": "sk_live_...", "org_id": "<uuid>", "project_id": "<uuid>" },
+  ...
+]
+```
+
+API-key auth gets its own rate-limit bucket (`Bearer sk_live_` prefix,
+`backend/app/core/rate_limit.py`), so entries are reused for the whole run — no re-login, no
+`/auth/token` rate-limit exposure. No `X-Org-Id`/`X-Project-Id` headers are sent — org/project
+resolve from the key's own JWT `app_metadata` by default
+(`get_verified_org_id`/`get_project_scoped_org_id`, `backend/app/dependencies/auth.py`); those
+headers are only an optional per-request override this test doesn't need. `org_id`/`project_id`
+in each entry must match what the key is actually scoped to (`enforce_body_context` rejects a
+mismatch on `POST /stories`).
+
+## Gate (§6)
+
+`options.thresholds` in the script encode the pass/fail gate directly: `p(95)<500ms`,
+error rate `<0.1%`. Run summary reports PASS/FAIL per threshold; k6 exits non-zero on any
+threshold breach.

--- a/backend/scripts/loadtest/README.md
+++ b/backend/scripts/loadtest/README.md
@@ -1,25 +1,110 @@
-# story #2446 — dev capacity gate (DB axis)
+# story #2446 — §6 결승선 부하테스트
 
-Drives a high *rate* of DB-touching REST calls against `sprintable-backend-dev` using a small,
-reused set of pre-seeded identities — not maximum concurrent agents/connections. See
-`dev_db_capacity_test.js` header for why (08-03 incident was request-rate pool exhaustion, not
-connection count; SSE concurrency caps are a separate story).
+`sprintable-backend-dev`가 read-replica offload(#2451 A1/A2) 이후 200-300 req/s를 실제로
+버티는지 증명하는 harness. Run 1(2026-08-03, `dev_db_capacity_test.js` 단독, DB axis만)의
+확장이다 — 스코프를 A1/A2가 `get_read_db`로 라우팅한 엔드포인트 전체로 넓히고, 생성기
+자신의 상한을 먼저 증명하는 positive-control 단계를 앞에 붙였다.
 
-## Usage
+⛔ **prod 실행 금지 — 이 harness는 dev 전용**. prod 실행은 선생님의 명시적 창(window)과
+go 승인 없이는 하지 않는다(BASE_URL을 prod로 바꿔서 돌리는 것도 포함 — 코드가 막진
+않으니 실행 전 사람이 검토). dev 실행은 지금 자유롭게 가능.
 
+## 구성
+
+| 파일 | 역할 |
+|---|---|
+| `generator_selfcheck.js` | **Phase 1** — k6 생성기 자신이 목표 rps를 뽑을 수 있는지 무부하 엔드포인트(`GET /api/v2/ping`)로 증명 |
+| `endpoint_mix_test.js` | **Phase 2** — A1/A2 read-routed 엔드포인트 믹스에 한 ramp 스테이지를 쏨(오케스트레이터가 rate별로 반복 호출) |
+| `dev_db_capacity_test.js` | Run 1 원본(DB axis, `/stories`만) — 참고/단독 재현용으로 보존 |
+| `ramp_expected.py` | k6 `ramping-arrival-rate` 프로파일의 기대 iteration 개수 계산(아래 「측정 방법론」 참조) |
+| `run_loadtest.sh` | 오케스트레이터 — Phase 1 게이트 통과 시에만 Phase 2 ramp 스테이지를 순차 실행, 스테이지 간 kill-switch |
+
+## 측정 방법론 — 왜 raw `iterations.rate`를 안 쓰는가
+
+**실측으로 발견(2026-08-04)**: k6 summary export의 `iterations.rate`는 **런 전체 시간**
+(램프업+hold+램프다운) 평균이다. `ramping-arrival-rate`는 램프 구간 동안 rate를 선형
+보간하므로 그 구간의 평균 실효 rate는 (시작+끝)/2 — hold 구간의 목표 rate보다 항상
+낮다. 실제로 `TARGET_RATE=300`(self-check rate=360, ramp 5s+hold 20s+ramp 3s)을 dev에
+직접 돌린 결과, `iterations.rate`(전체평균) = 308/s로 attempted(360) 대비 86%처럼
+보였지만, **achieved iteration 개수(8639)는 램프 사다리꼴 적분 기대치(8640)의 99.98%**
+로 사실상 완벽했다 — raw rate 비교만 썼다면 정상 생성기를 「기아」로 오판해 kill했을
+자리다.
+
+⇒ `ramp_expected.py`가 사다리꼴 적분(`rate*(0.5*ramp_up + hold + 0.5*ramp_down)`)으로
+기대 iteration 개수를 계산하고, `run_loadtest.sh`는 achieved 개수를 그 기대치와
+비교한다(>=95% = pass). 「achieved rps」로 보고하는 값도 이 개수비로 스케일한
+`target * achieved_count/expected_count`(ramp-adjusted) — raw 전체평균은 참고용으로만
+같이 찍는다.
+
+## Phase 1 — 생성기 self-check (positive control, ⭐가장 중요)
+
+Run 1이 실측한 실패모드: k6 `MAX_VUS=400` 천장을 14초 만에 쳐서
+`dropped_iterations=63,573`(완주 건수 압도)가 났는데, 그 순간 DB pool은 전혀 바쁘지
+않았다(`cl_active=24`) — 즉 「서버가 200/s에서 캡」이 아니라 「k6 생성기 자체가 200/s를
+못 뽑았다」였다. 이 오판을 원천 차단하기 위해, 본 테스트 前에 반드시 무부하 엔드포인트
+(`GET /api/v2/ping` — 인증 불필요·DB 미접속)로 생성기 단독 상한을 증명한다.
+`run_loadtest.sh`가 이 게이트를 통과 못 하면 **Phase 2를 아예 돌리지 않는다**.
+
+단독 실행:
 ```bash
 BASE_URL=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app \
-CREDS_FILE=./loadtest_creds.json \
-TARGET_RATE=200 \
-RAMP_TIME=2m \
-HOLD_TIME=30m \
-k6 run dev_db_capacity_test.js
+TARGET_RATE=300 SELFCHECK_DURATION=20s \
+k6 run --summary-export=/tmp/selfcheck.json generator_selfcheck.js
 ```
+
+## Phase 2 — endpoint 믹스 ramp 스테이지
+
+`endpoint_mix_test.js`가 한 rate로 한 스테이지를 쏜다(RATE env). 엔드포인트 구성:
+
+- **목록형 8종(A2, 60% 가중)** — `/stories` `/docs` `/tasks` `/goals` `/sprints`
+  `/standups` `/meetings` `/hypotheses` (project_id 스코프, `get_read_db` 확인됨 #2451 A2)
+- **가벼운 카운터/로스터(A1, 30% 가중)** — `/notifications/count` `/team-members`
+  `/org-members` `/projects` `/activity-logs` `/glance/attention` (`get_read_db` 확인됨
+  #2451 A1)
+- **쓰기(10% 가중)** — `POST /stories` (원본 dev_db_capacity_test.js와 동형 — 08-03
+  인시던트가 「평범한 mutation 버스트」였으므로 write 축을 완전히 빼면 그 회귀를 이
+  harness가 다시 못 잡는다)
+
+각 엔드포인트별 지연(p50/p90/p95/p99)·에러율·요청수를 `endpoint_duration_*`
+`endpoint_error_rate_*` `endpoint_requests_*` 커스텀 메트릭으로 개별 노출(k6 summary는
+태그별 자동 분해가 없어서 직접 추가).
+
+⛔**v1 제외**: `GET /dashboard` — `member_id`가 필수 쿼리파라미터인데 seeded identity에
+member_id가 없다. `GET /me`로 bootstrap 가능(api-key 인증 시 `auth.user_id`=`team_member.id`)
+하나 k6 `setup()` 단계에서 신원마다 사전 호출이 필요해 이번 스코프 밖으로 미룬다 — 후속
+후보.
+
+## 오케스트레이터
+
+```bash
+CREDS_FILE=./loadtest_creds.json ./run_loadtest.sh
+# 커스터마이즈:
+STAGES="50 100 200 300" STAGE_DURATION=60s ./run_loadtest.sh
+```
+
+순서: Phase 1(self-check) 게이트 → 통과 시에만 `STAGES`(기본 `50 100 200 300`)를 순차
+실행. 스테이지 사이 kill-switch — `error_rate > KILL_ERROR_RATE`(기본 5%) 또는
+`p95 > KILL_P95_MS`(기본 2000ms) 위반 시 **다음(더 높은) 스테이지로 안 올라가고 즉시
+중단**(exit 3). 결과는 `$OUT_DIR/summary_with_header.csv`(attempted/achieved rps·
+error_rate·p50/p95/p99), 스테이지별 raw k6 summary JSON·log도 `$OUT_DIR`에 보존.
+
+Kill-switch 자체는 2026-08-04 dev에서 실측 검증됨 — dead credentials로 강제
+error_rate=100% 상황을 만들어 exit code 3으로 정확히 중단하는 것을 확인(주입 실패
+케이스로 self-verify하는 팀 관례).
+
+## 생성기가 단일 머신 CPU/네트워크에 병목이면(분산)
+
+Phase 1이 fail하면 우선 `PRE_ALLOCATED_VUS`/`MAX_VUS`를 늘려보고, 그래도 부족하면 여러
+워커(별도 머신 또는 Cloud Run Job 여러 개)로 트래픽을 분산해 각자 `RATE`의 부분집합을
+쏘고 결과를 합산하는 방식으로 확장한다(이 커밋엔 분산 실행 스크립트 자체는 없음 — Phase
+1이 실제로 fail할 때 필요분만 만드는 게 낫다고 판단, YAGNI).
 
 ## `loadtest_creds.json` shape
 
-A JSON array, each entry an already-seeded (DB-direct, not HTTP signup) agent identity scoped
-to one org/project:
+DB-direct 시더(`scripts/jobs/seed_loadtest_identities.py`) 출력. gitignore됨(실 API
+key). 각 항목 `{api_key, org_id, project_id}`(org-level agent, `x-agent-api-key` 헤더로
+인증 — `Bearer sk_live_`가 아님, `dev_db_capacity_test.js`/`endpoint_mix_test.js` 헤더
+구현 참조).
 
 ```json
 [
@@ -28,17 +113,22 @@ to one org/project:
 ]
 ```
 
-API-key auth gets its own rate-limit bucket (`Bearer sk_live_` prefix,
-`backend/app/core/rate_limit.py`), so entries are reused for the whole run — no re-login, no
-`/auth/token` rate-limit exposure. No `X-Org-Id`/`X-Project-Id` headers are sent — org/project
-resolve from the key's own JWT `app_metadata` by default
-(`get_verified_org_id`/`get_project_scoped_org_id`, `backend/app/dependencies/auth.py`); those
-headers are only an optional per-request override this test doesn't need. `org_id`/`project_id`
-in each entry must match what the key is actually scoped to (`enforce_body_context` rejects a
-mismatch on `POST /stories`).
+⚠️ **재시딩 필요(2026-08-04 확인)**: Run 1이 남긴 `loadtest_creds.json`의 20개 신원은
+현재 전부 `401 API key member not found`로 dev에서 죽어 있다(원인 미조사 — dev DB가
+이후 재구축/정리됐을 가능성). 재시딩은 `python -m scripts.jobs.seed_loadtest_identities`
+(`SEED_N` env로 개수 조절)이나, `scripts/jobs/README.md`에 명시된 대로 이건
+**PO/infra-lane**(`gcloud run jobs execute sprintable-verify-oneoff`) — 이 harness를
+실제 rate로 돌리려면 그 실행이 먼저 필요하다.
 
-## Gate (§6)
+API-key 인증은 자체 rate-limit 버킷(`x-agent-api-key`, `backend/app/core/rate_limit.py`)
+이라 재로그인/`/auth/token` 소모 없이 신원을 런 내내 재사용한다. `X-Org-Id`/
+`X-Project-Id` 헤더는 보내지 않는다 — org/project는 키의 grant에서 서버가 직접
+해소한다.
 
-`options.thresholds` in the script encode the pass/fail gate directly: `p(95)<500ms`,
-error rate `<0.1%`. Run summary reports PASS/FAIL per threshold; k6 exits non-zero on any
-threshold breach.
+## Gate(§6)
+
+`endpoint_mix_test.js`의 `options.thresholds`는 `http_req_failed<0.05`(정보용, 완화) —
+실제 pass/fail 판정과 kill-switch는 `run_loadtest.sh`가 스테이지 사이에 수행한다(위
+「오케스트레이터」 참조). 최종 목표 rps(200-300)에서의 p50/p95/p99·에러율은 `summary_
+with_header.csv`로 보고 — 절대 임계치(200/300 어느 쪽이 결승선인지)는 선생님 확定 대기
+(§6 스토리 스펙에 "200-300 잠정"으로 명시).

--- a/backend/scripts/loadtest/README.md
+++ b/backend/scripts/loadtest/README.md
@@ -58,9 +58,10 @@ k6 run --summary-export=/tmp/selfcheck.json generator_selfcheck.js
 
 - **목록형 8종(A2, 60% 가중)** — `/stories` `/docs` `/tasks` `/goals` `/sprints`
   `/standups` `/meetings` `/hypotheses` (project_id 스코프, `get_read_db` 확인됨 #2451 A2)
-- **가벼운 카운터/로스터(A1, 30% 가중)** — `/notifications/count` `/team-members`
-  `/org-members` `/projects` `/activity-logs` `/glance/attention` (`get_read_db` 확인됨
-  #2451 A1)
+- **가벼운 카운터/로스터/집계 10종(A1, 30% 가중)** — `/notifications/count`
+  `/team-members` `/org-members` `/projects` `/activity-logs` `/glance/attention`
+  `/audit-logs` `/command-center/overview` `/conversations/unread-count`
+  `/event-notifications/unread-count` (`get_read_db` 확인됨 #2451 A1)
 - **쓰기(10% 가중)** — `POST /stories` (원본 dev_db_capacity_test.js와 동형 — 08-03
   인시던트가 「평범한 mutation 버스트」였으므로 write 축을 완전히 빼면 그 회귀를 이
   harness가 다시 못 잡는다)
@@ -69,10 +70,15 @@ k6 run --summary-export=/tmp/selfcheck.json generator_selfcheck.js
 `endpoint_error_rate_*` `endpoint_requests_*` 커스텀 메트릭으로 개별 노출(k6 summary는
 태그별 자동 분해가 없어서 직접 추가).
 
-⛔**v1 제외**: `GET /dashboard` — `member_id`가 필수 쿼리파라미터인데 seeded identity에
-member_id가 없다. `GET /me`로 bootstrap 가능(api-key 인증 시 `auth.user_id`=`team_member.id`)
-하나 k6 `setup()` 단계에서 신원마다 사전 호출이 필요해 이번 스코프 밖으로 미룬다 — 후속
-후보.
+⛔ **이건 A1/A2 «전체»가 아니라 seeded identity(`{api_key, org_id, project_id}`)만으로
+호출 가능한 부분집합이다**(카디르 QA 2026-08-04 — 이전 README가 「A1 전체 커버」로
+과대주장했던 것 정정). v1 제외:
+- `GET /dashboard` — `member_id`가 필수 쿼리파라미터, seeded identity엔 없음. `GET /me`로
+  bootstrap 가능(api-key 인증 시 `auth.user_id`=`team_member.id`)하나 k6 `setup()`
+  단계에서 신원마다 사전 호출이 필요해 스코프 밖 — 후속 후보.
+- `GET /glance/hero` — `story_id`가 필수 쿼리파라미터, seeded identity엔 특정 story
+  참조가 없음(dashboard와 동일한 구조적 이유). bootstrap하려면 story를 먼저 만들거나
+  목록에서 골라야 해서 스코프 밖 — 후속 후보.
 
 ## 오케스트레이터
 
@@ -88,9 +94,27 @@ STAGES="50 100 200 300" STAGE_DURATION=60s ./run_loadtest.sh
 중단**(exit 3). 결과는 `$OUT_DIR/summary_with_header.csv`(attempted/achieved rps·
 error_rate·p50/p95/p99), 스테이지별 raw k6 summary JSON·log도 `$OUT_DIR`에 보존.
 
-Kill-switch 자체는 2026-08-04 dev에서 실측 검증됨 — dead credentials로 강제
-error_rate=100% 상황을 만들어 exit code 3으로 정확히 중단하는 것을 확인(주입 실패
-케이스로 self-verify하는 팀 관례).
+Kill-switch(스테이지 «사이», run_loadtest.sh) 자체는 2026-08-04 dev에서 실측 검증됨 —
+dead credentials로 강제 error_rate=100% 상황을 만들어 exit code 3으로 정확히 중단하는
+것을 확인(주입 실패 케이스로 self-verify하는 팀 관례).
+
+### 스테이지 «내부» 방어(k6 native `abortOnFail`)
+
+⛔**카디르 QA 2026-08-04 REQUEST_CHANGES의 핵심 발견**: 위 kill-switch는 `run_loadtest.sh`
+«안에만» 있었다 — `endpoint_mix_test.js`/`generator_selfcheck.js`를 오케스트레이터 없이
+`k6 run`으로 «단독 실행»하면 안전장치가 0이었다(당시 threshold는 `http_req_failed<0.05`
+정보용 하나뿐, abort 없음). 이게 바로 같은 날 PO가 오케스트레이터 없이 맨손 k6로
+blast해 dev를 wedge시킨 사고의 «구조적 원인» 그 자체였다.
+
+⇒ 두 k6 스크립트에 **native `abortOnFail: true` threshold**(`http_req_failed`,
+`http_req_duration p(95)`, `KILL_ERROR_RATE`/`KILL_P95_MS`와 동일 SSOT — env var 공유)를
+직접 걸어, 오케스트레이터 유무와 무관하게 스크립트 자체가 급붕괴 시 즉시 멈추게 했다.
+
+실측 검증(2026-08-04, dev): `endpoint_mix_test.js`를 존재하지 않는 URL prefix로 강제
+100% 실패시켜 단독 실행 — 계획된 18초 중 **11.9초(66%)만에 자동 중단**, k6 로그에
+`"thresholds ... abortOnFail enabled, stopping test prematurely"` 확인, 프로세스 종료
+코드 **99**(k6의 threshold-abort 표준 코드), `--summary-export` JSON도 정상 기록됨(215
+iterations) — 오케스트레이터의 후속 분석과도 호환 확인.
 
 ## 생성기가 단일 머신 CPU/네트워크에 병목이면(분산)
 
@@ -113,12 +137,13 @@ key). 각 항목 `{api_key, org_id, project_id}`(org-level agent, `x-agent-api-k
 ]
 ```
 
-⚠️ **재시딩 필요(2026-08-04 확인)**: Run 1이 남긴 `loadtest_creds.json`의 20개 신원은
-현재 전부 `401 API key member not found`로 dev에서 죽어 있다(원인 미조사 — dev DB가
-이후 재구축/정리됐을 가능성). 재시딩은 `python -m scripts.jobs.seed_loadtest_identities`
-(`SEED_N` env로 개수 조절)이나, `scripts/jobs/README.md`에 명시된 대로 이건
-**PO/infra-lane**(`gcloud run jobs execute sprintable-verify-oneoff`) — 이 harness를
-실제 rate로 돌리려면 그 실행이 먼저 필요하다.
+재시딩은 `python -m scripts.jobs.seed_loadtest_identities`(`SEED_N` env로 개수 조절)이나,
+`scripts/jobs/README.md`에 명시된 대로 이건 **PO/infra-lane**
+(`gcloud run jobs execute sprintable-verify-oneoff`) — dev 크리덴셜이 만료/재구축으로
+죽으면(2026-08-04에 한 번 있었음 — Run 1의 신원 20개가 401로 죽어 있었고, PO가
+재시딩해 언블록함) 이 실행이 다시 필요하다. `loadtest_creds.json`은 gitignore되므로
+harness 코드 자체엔 만료 여부가 기록되지 않는다 — 돌리기 전 identity 1개를 curl로
+찔러 200이 오는지 먼저 확인하는 습관을 권장.
 
 API-key 인증은 자체 rate-limit 버킷(`x-agent-api-key`, `backend/app/core/rate_limit.py`)
 이라 재로그인/`/auth/token` 소모 없이 신원을 런 내내 재사용한다. `X-Org-Id`/
@@ -127,8 +152,9 @@ API-key 인증은 자체 rate-limit 버킷(`x-agent-api-key`, `backend/app/core/
 
 ## Gate(§6)
 
-`endpoint_mix_test.js`의 `options.thresholds`는 `http_req_failed<0.05`(정보용, 완화) —
-실제 pass/fail 판정과 kill-switch는 `run_loadtest.sh`가 스테이지 사이에 수행한다(위
+`endpoint_mix_test.js`의 `options.thresholds`는 3중 방어 — 정보용 관측(`http_req_failed
+<0.05`, abort 없음) + native abortOnFail(스테이지 «내부» 급붕괴 즉시 중단, 위 「스테이지
+내부 방어」 참조) + `run_loadtest.sh`의 kill-switch(스테이지 «사이» 판정, 위
 「오케스트레이터」 참조). 최종 목표 rps(200-300)에서의 p50/p95/p99·에러율은 `summary_
 with_header.csv`로 보고 — 절대 임계치(200/300 어느 쪽이 결승선인지)는 선생님 확定 대기
 (§6 스토리 스펙에 "200-300 잠정"으로 명시).

--- a/backend/scripts/loadtest/dev_db_capacity_test.js
+++ b/backend/scripts/loadtest/dev_db_capacity_test.js
@@ -1,0 +1,83 @@
+// story #2446 — dev PgBouncer capacity gate, DB axis.
+// Scope (PO 2026-08-03 redesign): the 08-03 incident was concurrent REST requests exhausting
+// a small per-instance DB pool, not SSE connection count — so this test drives a high RATE of
+// DB-touching REST calls with a handful of reused identities, not maximum concurrent agents.
+// SSE concurrency (per-key/global caps) is a separate story; this script does not touch it.
+//
+// Identities: CREDS_FILE holds pre-seeded {api_key, org_id, project_id} entries (org/project
+// creation bypassed — DB-direct/factory seed, not HTTP signup). API-key auth gets its own
+// rate-limit bucket (backend/app/core/rate_limit.py, Bearer sk_live_ prefix), so no
+// login-rate-limit concern; entries are reused for the whole run, never re-authenticated
+// mid-test. No X-Org-Id/X-Project-Id headers needed — get_verified_org_id/StoryCreate resolve
+// org/project from the key's own JWT app_metadata by default (backend/app/dependencies/auth.py);
+// those headers are only an optional per-request override this test doesn't use.
+
+import http from 'k6/http';
+import { check } from 'k6';
+import { SharedArray } from 'k6/data';
+
+const BASE_URL = __ENV.BASE_URL || 'https://sprintable-backend-dev-57iommnikq-du.a.run.app';
+const CREDS_FILE = __ENV.CREDS_FILE || './loadtest_creds.json';
+const TARGET_RATE = Number(__ENV.TARGET_RATE || 200); // requests/sec, steady-state
+const RAMP_TIME = __ENV.RAMP_TIME || '2m';
+const HOLD_TIME = __ENV.HOLD_TIME || '30m';
+// Run 1 (2026-08-03, 200/s·5m): hit MAX_VUS=400 ceiling 14s into ramp, well before steady
+// state — iteration_duration then spiraled toward the 60s default timeout while DB-pool
+// telemetry (PO, same window) showed cl_active=24/sv=17 (nowhere near pool exhaustion) and
+// dropped_iterations=63,573 far exceeded completed ones. That mismatch means most of the
+// nominal 200/s never reached the backend at all — raising these ceilings removes k6's own
+// VU-starvation as a confound before re-testing.
+const PRE_ALLOCATED_VUS = Number(__ENV.PRE_ALLOCATED_VUS || 1000);
+const MAX_VUS = Number(__ENV.MAX_VUS || 3000);
+
+// Each entry: { api_key, org_id, project_id }. See loadtest/README.md for how PO's seed
+// produces this file (DB-direct — no HTTP signup, no per-org/agent SSE provisioning needed
+// for this axis).
+const creds = new SharedArray('rest identities', () => JSON.parse(open(CREDS_FILE)));
+
+export const options = {
+  scenarios: {
+    db_rest_traffic: {
+      executor: 'ramping-arrival-rate',
+      startRate: 0,
+      timeUnit: '1s',
+      preAllocatedVUs: PRE_ALLOCATED_VUS,
+      maxVUs: MAX_VUS,
+      stages: [
+        { duration: RAMP_TIME, target: TARGET_RATE },
+        { duration: HOLD_TIME, target: TARGET_RATE },
+        { duration: '30s', target: 0 },
+      ],
+    },
+  },
+  thresholds: {
+    http_req_duration: ['p(95)<500'],
+    http_req_failed: ['rate<0.001'],
+  },
+};
+
+export default function () {
+  const cred = creds[Math.floor(Math.random() * creds.length)];
+  const headers = {
+    'x-agent-api-key': cred.api_key,
+    'Content-Type': 'application/json',
+  };
+
+  // Mixed read/write against the DB pool per iteration — matches the incident's actual
+  // failure mode (a burst of ordinary mutations exhausting a tiny per-instance pool), not a
+  // single hot endpoint. GET /stories joins assignee data (heavier read than a plain list);
+  // POST /stories is project-scoped so it avoids conversation-participant seeding entirely.
+  const listRes = http.get(`${BASE_URL}/api/v2/stories?project_id=${cred.project_id}`, { headers });
+  check(listRes, { 'stories list 200': (r) => r.status === 200 });
+
+  const createRes = http.post(
+    `${BASE_URL}/api/v2/stories`,
+    JSON.stringify({
+      project_id: cred.project_id,
+      org_id: cred.org_id,
+      title: `loadtest ${Date.now()}`,
+    }),
+    { headers },
+  );
+  check(createRes, { 'story create 201': (r) => r.status === 201 });
+}

--- a/backend/scripts/loadtest/endpoint_mix_test.js
+++ b/backend/scripts/loadtest/endpoint_mix_test.js
@@ -17,7 +17,12 @@
 // 기아인지 이 파일만 보고는 못 가른다(Run 1이 정확히 이 함정에 빠질 뻔했다). 반드시
 // generator_selfcheck.js 로 «생성기 단독 상한이 목표보다 높다»를 먼저 증명한 뒤에만
 // 이 스크립트의 achieved rate 부족을 「서버 캡」으로 해석한다 — run_loadtest.sh가 이
-// 순서를 강제한다.
+// 순서를 강제한다. ⚠️이 파일을 오케스트레이터 없이 `k6 run`으로 단독 실행해도 아래
+// `abortOnFail` threshold는 걸린다(카디르 QA 2026-08-04 지적 — 원인: 페드루가
+// 오케스트레이터 없이 맨손 k6로 이 축을 blast해 dev를 wedge시킨 실사고. run_loadtest.sh의
+// «스테이지 간» kill-switch만으론 스테이지 «내부»의 급붕괴를 못 막는다) — 그러나 이
+// native threshold는 「명백한 붕괴」만 잡는 last-resort고, 정밀한 rate 달성 여부 판정은
+// 여전히 run_loadtest.sh(+ramp_expected.py)의 몫이다.
 //
 // 실행(단독, 오케스트레이터 없이 한 스테이지만 보고 싶을 때):
 //   BASE_URL=... CREDS_FILE=./loadtest_creds.json RATE=200 STAGE_DURATION=60s \
@@ -27,12 +32,16 @@ import http from 'k6/http';
 import { check } from 'k6';
 import { SharedArray } from 'k6/data';
 
-const BASE_URL = __ENV.BASE_URL || 'https://sprintable-backend-dev-57iommnikq-du.a.run.app';
+const BASE_URL = __ENV.BASE_URL || 'https://sprintable-backend-dev-787818285179.asia-northeast3.run.app';
 const CREDS_FILE = __ENV.CREDS_FILE || './loadtest_creds.json';
 const RATE = Number(__ENV.RATE || 100); // 이 스테이지의 목표 rps(오케스트레이터가 ramp 단계마다 바꿔 호출)
 const STAGE_DURATION = __ENV.STAGE_DURATION || '60s';
 const RAMP_UP = __ENV.RAMP_UP || '10s';
 const RAMP_DOWN = __ENV.RAMP_DOWN || '5s';
+// run_loadtest.sh의 kill-switch와 동일 SSOT(env var 공유) — 오케스트레이터 없이 단독
+// 실행해도 같은 급붕괴 기준으로 abort(카디르 QA MUST①, dev wedge 사고의 구조적 원인 봉합).
+const KILL_ERROR_RATE = Number(__ENV.KILL_ERROR_RATE || 0.05);
+const KILL_P95_MS = Number(__ENV.KILL_P95_MS || 2000);
 // generator_selfcheck.js와 동일 근거(Run 1 VU 기아) — 이 스크립트도 넉넉하게 잡는다.
 // RATE가 커지면(최대 300 예상) 필요 VU도 늘어야 하므로 RATE에 비례한 하한을 둔다.
 const PRE_ALLOCATED_VUS = Number(__ENV.PRE_ALLOCATED_VUS || Math.max(1000, RATE * 5));
@@ -59,7 +68,13 @@ export const options = {
   // 엔드포인트별로 못 쪼개는 한계를 태그로 보완: k6 summary는 태그별 자동 분해를
   // 안 해줘서, 엔드포인트 이름별 http_req_duration을 별도 Trend 메트릭으로 직접 낸다).
   thresholds: {
-    http_req_failed: ['rate<0.05'], // 정보용 완화 게이트 — 실 kill-switch는 오케스트레이터가 스테이지 간에 검사
+    http_req_failed: [
+      { threshold: 'rate<0.05', abortOnFail: false }, // 정보용 — 진행 중 관측용
+      { threshold: `rate<${KILL_ERROR_RATE}`, abortOnFail: true, delayAbortEval: '10s' },
+    ],
+    http_req_duration: [
+      { threshold: `p(95)<${KILL_P95_MS}`, abortOnFail: true, delayAbortEval: '10s' },
+    ],
   },
   summaryTrendStats: ['avg', 'min', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'],
 };
@@ -74,7 +89,8 @@ for (const name of [
   'stories_list', 'docs_list', 'tasks_list', 'goals_list', 'sprints_list',
   'standups_list', 'meetings_list', 'hypotheses_list',
   'notifications_count', 'team_members_list', 'org_members_list', 'projects_list',
-  'activity_logs_list', 'glance_attention', 'story_create',
+  'activity_logs_list', 'glance_attention', 'audit_logs_list', 'command_center_overview',
+  'conversations_unread_count', 'event_notifications_unread_count', 'story_create',
 ]) {
   _endpointDuration[name] = new Trend(`endpoint_duration_${name}`, true);
   _endpointErrors[name] = new Rate(`endpoint_error_rate_${name}`);
@@ -100,9 +116,17 @@ const _LIST_ENDPOINTS = [
   { name: 'meetings_list', path: (c) => `/api/v2/meetings?project_id=${c.project_id}` },
   { name: 'hypotheses_list', path: (c) => `/api/v2/hypotheses?project_id=${c.project_id}` },
 ];
-// story #2451 A1이 get_read_db로 옮긴 것 중 이 harness가 다루는 부분집합(대시보드 제외,
-// 위 docstring 참조). 카운터·로스터·집계는 목록형보다 가볍지만 고빈도라 A1 확認 당시
-// SHOW POOLS에서 즉시 replica hit이 뜬 자리 — 섞어야 실사용 트래픽 구성에 가깝다.
+// story #2451 A1이 get_read_db로 옮긴 것 중 seeded identity({api_key,org_id,project_id})
+// 만으로 호출 가능한 부분집합(카디르 QA 2026-08-04 반영 — audit_logs/command_center/
+// conversations/event_notifications 4개 추가). 카운터·로스터·집계는 목록형보다 가볍지만
+// 고빈도라 A1 확認 당시 SHOW POOLS에서 즉시 replica hit이 뜬 자리 — 섞어야 실사용
+// 트래픽 구성에 가깝다.
+//
+// ⛔A1 전체가 아니라 «호출 가능한 부분집합»이다(README 과대주장 정정, 카디르 QA③) —
+// 제외: `GET /dashboard`(member_id 필수, 파일 상단 docstring), `GET /glance/hero`
+// (story_id: uuid.UUID = Query(...) 필수 — seeded identity엔 특정 story 참조가 없어
+// dashboard와 동일한 구조적 이유로 호출 불가. bootstrap하려면 먼저 story를 만들거나
+// 목록에서 하나 골라야 해서 스코프 밖).
 const _LIGHT_ENDPOINTS = [
   { name: 'notifications_count', path: () => `/api/v2/notifications/count` },
   { name: 'team_members_list', path: () => `/api/v2/team-members` },
@@ -110,6 +134,10 @@ const _LIGHT_ENDPOINTS = [
   { name: 'projects_list', path: () => `/api/v2/projects` },
   { name: 'activity_logs_list', path: () => `/api/v2/activity-logs` },
   { name: 'glance_attention', path: (c) => `/api/v2/glance/attention?project_id=${c.project_id}` },
+  { name: 'audit_logs_list', path: () => `/api/v2/audit-logs` },
+  { name: 'command_center_overview', path: () => `/api/v2/command-center/overview` },
+  { name: 'conversations_unread_count', path: () => `/api/v2/conversations/unread-count` },
+  { name: 'event_notifications_unread_count', path: () => `/api/v2/event-notifications/unread-count` },
 ];
 
 export default function () {

--- a/backend/scripts/loadtest/endpoint_mix_test.js
+++ b/backend/scripts/loadtest/endpoint_mix_test.js
@@ -1,0 +1,139 @@
+// story #2446 — §6 결승선 부하테스트: A1/A2가 read replica로 옮긴 실 offload 경로를
+// 목표 rps(파라미터, 기본 200-300 잠정 — 선생님 확定 대기)로 검증한다.
+//
+// dev_db_capacity_test.js(§6 Phase1, DB-axis — POST/GET /stories만)의 확장이다: 스코프를
+// A1(카운터·대시보드류 일부·로스터·append-only)·A2(목록형 8종: stories·docs·tasks·goals·
+// sprints·standups·meetings·hypotheses)가 실제로 get_read_db 로 라우팅한 엔드포인트
+// 세트로 넓힌다 — 그게 우리가 검증할 실제 offload 경로다(PO 지시 2026-08-04).
+//
+// ⛔제외(v1, 후속 후보): GET /dashboard — member_id가 필수 쿼리파라미터인데
+// loadtest_creds.json(seed_loadtest_identities 출력)엔 api_key/org_id/project_id만
+// 있고 member_id가 없다. api-key 인증 시 auth.user_id가 곧 team_member.id라 GET /me로
+// bootstrap 가능하나(app/routers/me.py), k6 setup() 단계에서 신원마다 사전 호출이 필요해
+// 이 커밋 스코프 밖으로 미룬다(README에 명시).
+//
+// ⛔이 스크립트 «단독»으로는 목표 rps를 «달성」했는지 증명 못 한다 — attempted(설정한
+// rate)와 achieved(iterations.rate) 가 다르면 그 차이가 서버 병목인지 k6 생성기
+// 기아인지 이 파일만 보고는 못 가른다(Run 1이 정확히 이 함정에 빠질 뻔했다). 반드시
+// generator_selfcheck.js 로 «생성기 단독 상한이 목표보다 높다»를 먼저 증명한 뒤에만
+// 이 스크립트의 achieved rate 부족을 「서버 캡」으로 해석한다 — run_loadtest.sh가 이
+// 순서를 강제한다.
+//
+// 실행(단독, 오케스트레이터 없이 한 스테이지만 보고 싶을 때):
+//   BASE_URL=... CREDS_FILE=./loadtest_creds.json RATE=200 STAGE_DURATION=60s \
+//     k6 run --summary-export=/tmp/stage_200.json endpoint_mix_test.js
+
+import http from 'k6/http';
+import { check } from 'k6';
+import { SharedArray } from 'k6/data';
+
+const BASE_URL = __ENV.BASE_URL || 'https://sprintable-backend-dev-57iommnikq-du.a.run.app';
+const CREDS_FILE = __ENV.CREDS_FILE || './loadtest_creds.json';
+const RATE = Number(__ENV.RATE || 100); // 이 스테이지의 목표 rps(오케스트레이터가 ramp 단계마다 바꿔 호출)
+const STAGE_DURATION = __ENV.STAGE_DURATION || '60s';
+const RAMP_UP = __ENV.RAMP_UP || '10s';
+const RAMP_DOWN = __ENV.RAMP_DOWN || '5s';
+// generator_selfcheck.js와 동일 근거(Run 1 VU 기아) — 이 스크립트도 넉넉하게 잡는다.
+// RATE가 커지면(최대 300 예상) 필요 VU도 늘어야 하므로 RATE에 비례한 하한을 둔다.
+const PRE_ALLOCATED_VUS = Number(__ENV.PRE_ALLOCATED_VUS || Math.max(1000, RATE * 5));
+const MAX_VUS = Number(__ENV.MAX_VUS || Math.max(3000, RATE * 15));
+
+const creds = new SharedArray('identities', () => JSON.parse(open(CREDS_FILE)));
+
+export const options = {
+  scenarios: {
+    endpoint_mix: {
+      executor: 'ramping-arrival-rate',
+      startRate: 0,
+      timeUnit: '1s',
+      preAllocatedVUs: PRE_ALLOCATED_VUS,
+      maxVUs: MAX_VUS,
+      stages: [
+        { duration: RAMP_UP, target: RATE },
+        { duration: STAGE_DURATION, target: RATE },
+        { duration: RAMP_DOWN, target: 0 },
+      ],
+    },
+  },
+  // per-endpoint 관측 — 커스텀 tag로 breakdown(run_loadtest.sh가 summary JSON을
+  // 엔드포인트별로 못 쪼개는 한계를 태그로 보완: k6 summary는 태그별 자동 분해를
+  // 안 해줘서, 엔드포인트 이름별 http_req_duration을 별도 Trend 메트릭으로 직접 낸다).
+  thresholds: {
+    http_req_failed: ['rate<0.05'], // 정보용 완화 게이트 — 실 kill-switch는 오케스트레이터가 스테이지 간에 검사
+  },
+  summaryTrendStats: ['avg', 'min', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'],
+};
+
+import { Trend, Rate, Counter } from 'k6/metrics';
+
+// 엔드포인트별 지연/에러 분해 — README 「측정: 엔드포인트별 분해」 요구사항.
+const _endpointDuration = {};
+const _endpointErrors = {};
+const _endpointCount = {};
+for (const name of [
+  'stories_list', 'docs_list', 'tasks_list', 'goals_list', 'sprints_list',
+  'standups_list', 'meetings_list', 'hypotheses_list',
+  'notifications_count', 'team_members_list', 'org_members_list', 'projects_list',
+  'activity_logs_list', 'glance_attention', 'story_create',
+]) {
+  _endpointDuration[name] = new Trend(`endpoint_duration_${name}`, true);
+  _endpointErrors[name] = new Rate(`endpoint_error_rate_${name}`);
+  _endpointCount[name] = new Counter(`endpoint_requests_${name}`);
+}
+
+function _record(name, res, expectedStatus) {
+  _endpointDuration[name].add(res.timings.duration);
+  _endpointErrors[name].add(res.status !== expectedStatus);
+  _endpointCount[name].add(1);
+  check(res, { [`${name} ${expectedStatus}`]: (r) => r.status === expectedStatus });
+}
+
+// story #2451 A2가 get_read_db로 옮긴 목록형 8종. project_id 스코프(실사용 패턴 — 「내
+// 프로젝트 보드」가 org-wide 무필터보다 압도적으로 흔하다).
+const _LIST_ENDPOINTS = [
+  { name: 'stories_list', path: (c) => `/api/v2/stories?project_id=${c.project_id}` },
+  { name: 'docs_list', path: (c) => `/api/v2/docs?project_id=${c.project_id}` },
+  { name: 'tasks_list', path: () => `/api/v2/tasks` },
+  { name: 'goals_list', path: (c) => `/api/v2/goals?project_id=${c.project_id}` },
+  { name: 'sprints_list', path: (c) => `/api/v2/sprints?project_id=${c.project_id}` },
+  { name: 'standups_list', path: (c) => `/api/v2/standups?project_id=${c.project_id}` },
+  { name: 'meetings_list', path: (c) => `/api/v2/meetings?project_id=${c.project_id}` },
+  { name: 'hypotheses_list', path: (c) => `/api/v2/hypotheses?project_id=${c.project_id}` },
+];
+// story #2451 A1이 get_read_db로 옮긴 것 중 이 harness가 다루는 부분집합(대시보드 제외,
+// 위 docstring 참조). 카운터·로스터·집계는 목록형보다 가볍지만 고빈도라 A1 확認 당시
+// SHOW POOLS에서 즉시 replica hit이 뜬 자리 — 섞어야 실사용 트래픽 구성에 가깝다.
+const _LIGHT_ENDPOINTS = [
+  { name: 'notifications_count', path: () => `/api/v2/notifications/count` },
+  { name: 'team_members_list', path: () => `/api/v2/team-members` },
+  { name: 'org_members_list', path: () => `/api/v2/org-members` },
+  { name: 'projects_list', path: () => `/api/v2/projects` },
+  { name: 'activity_logs_list', path: () => `/api/v2/activity-logs` },
+  { name: 'glance_attention', path: (c) => `/api/v2/glance/attention?project_id=${c.project_id}` },
+];
+
+export default function () {
+  const cred = creds[Math.floor(Math.random() * creds.length)];
+  const headers = { 'x-agent-api-key': cred.api_key, 'Content-Type': 'application/json' };
+
+  // 가중 선택: 목록형(무거움·A2 hotspot)이 read 트래픽의 다수, 가벼운 A1 세트가 소수,
+  // 쓰기가 드물게(원본 dev_db_capacity_test.js와 동형 — 실 인시던트가 「평범한 mutation
+  // 버스트」였으므로 write 축을 아예 빼면 그 축의 회귀는 이 harness가 다시 못 잡는다).
+  const roll = Math.random();
+  if (roll < 0.6) {
+    const ep = _LIST_ENDPOINTS[Math.floor(Math.random() * _LIST_ENDPOINTS.length)];
+    const res = http.get(`${BASE_URL}${ep.path(cred)}`, { headers });
+    _record(ep.name, res, 200);
+  } else if (roll < 0.9) {
+    const ep = _LIGHT_ENDPOINTS[Math.floor(Math.random() * _LIGHT_ENDPOINTS.length)];
+    const res = http.get(`${BASE_URL}${ep.path(cred)}`, { headers });
+    _record(ep.name, res, 200);
+  } else {
+    const res = http.post(
+      `${BASE_URL}/api/v2/stories`,
+      JSON.stringify({ project_id: cred.project_id, org_id: cred.org_id, title: `loadtest ${Date.now()}` }),
+      { headers },
+    );
+    _record('story_create', res, 201);
+  }
+}

--- a/backend/scripts/loadtest/generator_selfcheck.js
+++ b/backend/scripts/loadtest/generator_selfcheck.js
@@ -1,0 +1,75 @@
+// story #2446 — 「생성기 자체가 목표 rps를 뽑을 수 있는가」positive control.
+//
+// 왜 이게 따로 필요한가(PO 지시, 2026-08-04): Run 1(2026-08-03, dev_db_capacity_test.js,
+// 200/s·5m)이 정확히 이 실패모드를 실측했다 — k6 executor가 MAX_VUS=400 천장을
+// 14초 만에 쳐서 dropped_iterations=63,573(완주 건수를 압도)가 났는데, 그 순간 DB pool
+// 텔레메트리(cl_active=24)는 전혀 바쁘지 않았다. 즉 「서버가 200/s에서 캡됐다」가 아니라
+// 「k6 생성기 자체가 200/s를 못 뽑았다」였다 — 그런데 얼핏 보면 http_req_failed 같은
+// 서버쪽 지표만 보고 "서버가 느리다"로 오판하기 쉽다(자가 정확해도 틀린 걸 재는 병).
+//
+// 이 스크립트는 그 오판을 원천 차단한다 — 서버에 «전혀 부담을 주지 않는» 엔드포인트
+// (GET /api/v2/ping: 인증 불필요·DB 미접속·핸들러가 딕셔너리 하나 반환하는 게 전부,
+// backend/app/routers/health.py)를 목표 rps의 1.2배로 짧게 쏴서, 생성기 자체가 그 이상을
+// 뽑아낼 수 있는지만 격리해서 잰다. 서버 부하가 0에 가까운 엔드포인트이므로 achieved rate가
+// attempted(target) 에 못 미치면 그 원인은 100% 생성기(k6 VU 수·로컬 머신 CPU/네트워크)다.
+//
+// 통과 기준: achieved iteration «개수» >= ramp_expected.py가 계산한 기대 개수(램프
+// 사다리꼴 적분) * 0.95. iterations.rate(전체구간 평균)를 target과 직접 비교하지
+// «않는다» — 램프업/다운 구간이 평균을 구조적으로 깎아 정상 생성기도 fail로 오판하게
+// 만든다(실측: TARGET=300에서 rate=308/s vs attempted=360/s는 86%로 보이지만 실제
+// iteration 개수는 기대치의 99.98%). 실패하면 본 테스트를 돌리지 말 것 — 그 결과는
+// 「서버가 X에서 캡」이 아니라 「생성기가 X 밖에 못 쏨」일 뿐이다.
+//
+// 실행:
+//   BASE_URL=https://sprintable-backend-dev-... TARGET_RATE=300 k6 run generator_selfcheck.js
+// 오케스트레이터(run_loadtest.sh)가 본 테스트 前에 자동으로 이걸 먼저 돌리고 게이트한다 —
+// 수동으로 이 파일만 돌릴 때도 동일한 통과 기준이 적용된다(별도 로직 없음).
+
+import http from 'k6/http';
+import { check } from 'k6';
+
+const BASE_URL = __ENV.BASE_URL || 'https://sprintable-backend-dev-57iommnikq-du.a.run.app';
+// 본 테스트가 목표할 rps보다 «높게» 잡아야 「생성기가 목표보다 여유 있게 뽑을 수 있다」는
+// 걸 증명한다 — 자기 자신의 목표치를 간신히 맞추는 정도로는 다음 실 부하(추가 지연·재시도)
+// 아래서 재현 안 될 위험이 있다(20% 헤드룸).
+const TARGET_RATE = Number(__ENV.TARGET_RATE || 300);
+const SELFCHECK_RATE = Math.ceil(TARGET_RATE * 1.2);
+const DURATION = __ENV.SELFCHECK_DURATION || '20s';
+// run_loadtest.sh가 ramp_expected.py로 기대 iteration 개수를 계산할 때 이 두 값을
+// 그대로 참조한다(하드코딩 값이 여기와 오케스트레이터 양쪽에 따로 있으면 드리프트) —
+// 바꿀 땐 run_loadtest.sh의 SELFCHECK_RAMP_UP/SELFCHECK_RAMP_DOWN 기본값도 같이.
+const RAMP_UP = __ENV.SELFCHECK_RAMP_UP || '5s';
+const RAMP_DOWN = __ENV.SELFCHECK_RAMP_DOWN || '3s';
+// Run 1의 400 천장이 14초 만에 밟혔던 것 — 이번엔 훨씬 큰 여유치로 시작(생성기 자체
+// 상한을 재는 게 목적이라 서버 부하 걱정 없이 넉넉하게 잡아도 무해, GET /ping이 받는다).
+const PRE_ALLOCATED_VUS = Number(__ENV.SELFCHECK_PRE_ALLOCATED_VUS || 2000);
+const MAX_VUS = Number(__ENV.SELFCHECK_MAX_VUS || 5000);
+
+export const options = {
+  scenarios: {
+    generator_ceiling: {
+      executor: 'ramping-arrival-rate',
+      startRate: 0,
+      timeUnit: '1s',
+      preAllocatedVUs: PRE_ALLOCATED_VUS,
+      maxVUs: MAX_VUS,
+      stages: [
+        { duration: RAMP_UP, target: SELFCHECK_RATE },
+        { duration: DURATION, target: SELFCHECK_RATE },
+        { duration: RAMP_DOWN, target: 0 },
+      ],
+    },
+  },
+  // 여기 threshold는 「생성기가 스스로도 못 뽑는지」를 last-resort로 잡는다 — 진짜 판정은
+  // run_loadtest.sh가 summary JSON의 achieved rate를 직접 계산해서 한다(threshold만으론
+  // "시도 대비 달성 비율"을 못 표현함, http_req_duration/failed는 서버 응답 지표라 이
+  // 무부하 엔드포인트에선 항상 통과할 것 — dropped_iterations만이 생성기 기아의 신호).
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+export default function () {
+  const res = http.get(`${BASE_URL}/api/v2/ping`);
+  check(res, { 'ping 200': (r) => r.status === 200 });
+}

--- a/backend/scripts/loadtest/generator_selfcheck.js
+++ b/backend/scripts/loadtest/generator_selfcheck.js
@@ -22,13 +22,22 @@
 //
 // 실행:
 //   BASE_URL=https://sprintable-backend-dev-... TARGET_RATE=300 k6 run generator_selfcheck.js
-// 오케스트레이터(run_loadtest.sh)가 본 테스트 前에 자동으로 이걸 먼저 돌리고 게이트한다 —
-// 수동으로 이 파일만 돌릴 때도 동일한 통과 기준이 적용된다(별도 로직 없음).
+// 오케스트레이터(run_loadtest.sh)가 본 테스트 前에 자동으로 이걸 먼저 돌리고 ramp_expected.py
+// 기반 정밀 판정(achieved 개수 >= 기대개수*0.95)을 한다. ⚠️**이 파일을 k6로 단독 실행하면
+// 그 정밀 판정은 «없다»** — 아래 `abortOnFail` threshold(카디르 QA 2026-08-04 지적, 원인:
+// 오케스트레이터 없이 endpoint_mix_test.js를 맨손 k6로 blast해 dev를 wedge시킨 실사고)는
+// «명백한 급붕괴»만 잡는 last-resort 그물이지, 「생성기가 목표 rps를 정확히 달성했는가」의
+// 답은 아니다 — 정밀 판정이 필요하면 반드시 run_loadtest.sh를 통해 돌리거나, summary export
+// JSON을 ramp_expected.py로 직접 대조할 것.
 
 import http from 'k6/http';
 import { check } from 'k6';
 
-const BASE_URL = __ENV.BASE_URL || 'https://sprintable-backend-dev-57iommnikq-du.a.run.app';
+const BASE_URL = __ENV.BASE_URL || 'https://sprintable-backend-dev-787818285179.asia-northeast3.run.app';
+// run_loadtest.sh의 kill-switch(KILL_ERROR_RATE/KILL_P95_MS)와 동일 SSOT — 오케스트레이터
+// 없이 이 파일만 단독 실행해도 같은 급붕괴 기준으로 abort되게(카디르 QA MUST①).
+const KILL_ERROR_RATE = Number(__ENV.KILL_ERROR_RATE || 0.05);
+const KILL_P95_MS = Number(__ENV.KILL_P95_MS || 2000);
 // 본 테스트가 목표할 rps보다 «높게» 잡아야 「생성기가 목표보다 여유 있게 뽑을 수 있다」는
 // 걸 증명한다 — 자기 자신의 목표치를 간신히 맞추는 정도로는 다음 실 부하(추가 지연·재시도)
 // 아래서 재현 안 될 위험이 있다(20% 헤드룸).
@@ -60,12 +69,18 @@ export const options = {
       ],
     },
   },
-  // 여기 threshold는 「생성기가 스스로도 못 뽑는지」를 last-resort로 잡는다 — 진짜 판정은
-  // run_loadtest.sh가 summary JSON의 achieved rate를 직접 계산해서 한다(threshold만으론
-  // "시도 대비 달성 비율"을 못 표현함, http_req_duration/failed는 서버 응답 지표라 이
-  // 무부하 엔드포인트에선 항상 통과할 것 — dropped_iterations만이 생성기 기아의 신호).
+  // native abortOnFail — k6 프로세스 자체가 급붕괴 시 즉시 중단한다(오케스트레이터
+  // 유무 무관, 카디르 QA MUST①). GET /ping은 무부하 엔드포인트라 정상 상황에선 이 임계에
+  // 절대 안 걸린다 — 걸린다면 dev 자체가 죽었거나 네트워크가 끊긴 것. delayAbortEval로
+  // 램프업 구간의 초기 노이즈(워밍업 전 튐)로 인한 오탐 중단을 피한다.
   thresholds: {
-    http_req_failed: ['rate<0.01'],
+    http_req_failed: [
+      { threshold: 'rate<0.01', abortOnFail: false },
+      { threshold: `rate<${KILL_ERROR_RATE}`, abortOnFail: true, delayAbortEval: '5s' },
+    ],
+    http_req_duration: [
+      { threshold: `p(95)<${KILL_P95_MS}`, abortOnFail: true, delayAbortEval: '5s' },
+    ],
   },
 };
 

--- a/backend/scripts/loadtest/ramp_expected.py
+++ b/backend/scripts/loadtest/ramp_expected.py
@@ -1,0 +1,47 @@
+"""story #2446 — k6 ramping-arrival-rate 프로파일의 기대 iteration 개수 계산.
+
+왜 필요한가(실측으로 발견, 2026-08-04): k6 summary export의 `iterations.rate` 는
+**런 전체 시간**(램프업+hold+램프다운) 평균이다. ramping-arrival-rate 는 램프 구간
+동안 rate를 선형 보간하므로 그 구간의 평균 실효 rate는 (시작+끝)/2 — hold 구간의
+목표 rate보다 항상 낮다. 그래서 hold 구간에서 생성기가 목표를 «정확히» 달성해도
+`iterations.rate`(전체평균)는 목표보다 20~30% 낮게 찍힌다 — 이걸 그대로
+「생성기 기아」로 오판하면 정상 생성기를 잘못 kill한다(실측: TARGET=300 self-check,
+achieved rate=308/s(전체평균) vs attempted=360/s → naive 비교로는 86%로 FAIL, 그러나
+실제 iteration 개수는 기대치의 99.98%로 사실상 완벽했다).
+
+⇒ rate 대 rate 비교 대신, achieved iteration **개수**를 이 함수가 계산한 «기대
+개수»(램프 사다리꼴 적분)와 비교한다.
+"""
+from __future__ import annotations
+
+import sys
+
+
+def parse_duration_seconds(s: str) -> float:
+    s = s.strip()
+    if s.endswith("ms"):
+        return float(s[:-2]) / 1000
+    if s.endswith("s"):
+        return float(s[:-1])
+    if s.endswith("m"):
+        return float(s[:-1]) * 60
+    if s.endswith("h"):
+        return float(s[:-1]) * 3600
+    return float(s)
+
+
+def expected_iterations(ramp_up_s: float, hold_s: float, ramp_down_s: float, rate: float) -> float:
+    """0→rate(램프업) + rate 상수(hold) + rate→0(램프다운) 사다리꼴 적분."""
+    return rate * (0.5 * ramp_up_s + hold_s + 0.5 * ramp_down_s)
+
+
+if __name__ == "__main__":
+    ramp_up, hold, ramp_down, rate = sys.argv[1:5]
+    print(
+        expected_iterations(
+            parse_duration_seconds(ramp_up),
+            parse_duration_seconds(hold),
+            parse_duration_seconds(ramp_down),
+            float(rate),
+        )
+    )

--- a/backend/scripts/loadtest/run_loadtest.sh
+++ b/backend/scripts/loadtest/run_loadtest.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# story #2446 — §6 결승선 오케스트레이터.
+#
+# 순서를 코드로 강제한다(사람이 순서를 지키는 게 아니라):
+#   1. generator_selfcheck.js 로 «생성기 단독 상한»이 이 런의 최대 목표 rps보다 높은지
+#      먼저 증명. achieved < target*0.95 면 **여기서 즉시 중단** — 뒤 단계를 아예 안 돈다.
+#      (생성기가 못 뽑는데 서버 결과를 재는 건 Run 1이 빠질 뻔한 그 오판을 다시 만드는 것)
+#   2. 통과 시에만 endpoint_mix_test.js 를 ramp 스테이지(기본 50→100→200→300)로 순차 실행.
+#      스테이지 사이에 kill-switch(에러율·p95 임계) 검사 — breach 시 다음 스테이지 «중단».
+#
+# 실행 대상: dev 만(BASE_URL 기본값이 dev). prod 는 선생님 창+go 전까지 이 스크립트로
+# 실행 금지 — BASE_URL 을 prod 로 바꿔서 돌리는 것도 포함(경계는 사람 판단, 코드가 막진
+# 않음 — 실행 전 review 필수).
+#
+# 사용:
+#   CREDS_FILE=./loadtest_creds.json ./run_loadtest.sh
+#   STAGES="50 100 200 300" STAGE_DURATION=60s ./run_loadtest.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+BASE_URL="${BASE_URL:-https://sprintable-backend-dev-57iommnikq-du.a.run.app}"
+CREDS_FILE="${CREDS_FILE:-./loadtest_creds.json}"
+STAGES="${STAGES:-50 100 200 300}"
+STAGE_DURATION="${STAGE_DURATION:-60s}"
+RAMP_UP="${RAMP_UP:-10s}"
+RAMP_DOWN="${RAMP_DOWN:-5s}"
+# kill-switch 임계 — README §Gate와 동일 기준(p95<500ms, error<0.1%)을 스테이지 사이에도
+# 적용한다. 이 값을 넘기면 다음(더 높은) 스테이지로 올라가지 않고 즉시 멈춘다.
+KILL_ERROR_RATE="${KILL_ERROR_RATE:-0.05}"    # 5% — 개별 스테이지 완주는 허용하되 다음 스테이지 진입은 막는 보수적 값
+KILL_P95_MS="${KILL_P95_MS:-2000}"            # 2s — 정상 가동 목표(500ms)의 4배, "명백히 무너짐"만 감지
+OUT_DIR="${OUT_DIR:-/tmp/loadtest-run-$(date +%s 2>/dev/null || echo run)}"
+
+mkdir -p "$OUT_DIR"
+echo "[run_loadtest] BASE_URL=$BASE_URL OUT_DIR=$OUT_DIR"
+
+if [[ ! -f "$CREDS_FILE" ]]; then
+  echo "[run_loadtest] FATAL: CREDS_FILE not found: $CREDS_FILE" >&2
+  echo "  seed with: python -m scripts.jobs.seed_loadtest_identities (see README)" >&2
+  exit 2
+fi
+
+MAX_TARGET=0
+for s in $STAGES; do
+  (( s > MAX_TARGET )) && MAX_TARGET=$s
+done
+
+# ---- Phase 1: generator self-check (positive control) ----------------------------------
+# ramp_expected.py: iterations.rate(전체구간 평균)를 target과 직접 비교하지 않는다 —
+# 램프업/다운이 평균을 구조적으로 깎아 정상 생성기도 오판-fail한다(실측, 스크립트
+# 헤더 참조). achieved iteration «개수»를 기대 개수(사다리꼴 적분)와 비교한다.
+SELFCHECK_RAMP_UP="${SELFCHECK_RAMP_UP:-5s}"
+SELFCHECK_RAMP_DOWN="${SELFCHECK_RAMP_DOWN:-3s}"
+SELFCHECK_DURATION="${SELFCHECK_DURATION:-20s}"
+
+echo "[run_loadtest] Phase 1/2: generator self-check (target=$MAX_TARGET rps ceiling, +20% headroom)"
+SELFCHECK_JSON="$OUT_DIR/selfcheck.json"
+SELFCHECK_TARGET=$(python3 -c "import math; print(math.ceil(int('$MAX_TARGET') * 1.2))")
+BASE_URL="$BASE_URL" TARGET_RATE="$MAX_TARGET" SELFCHECK_DURATION="$SELFCHECK_DURATION" \
+  SELFCHECK_RAMP_UP="$SELFCHECK_RAMP_UP" SELFCHECK_RAMP_DOWN="$SELFCHECK_RAMP_DOWN" \
+  k6 run --summary-export="$SELFCHECK_JSON" generator_selfcheck.js | tee "$OUT_DIR/selfcheck.log"
+
+SELFCHECK_ACHIEVED_COUNT=$(python3 -c "
+import json
+d = json.load(open('$SELFCHECK_JSON'))
+print(d['metrics']['iterations']['count'])
+")
+SELFCHECK_EXPECTED_COUNT=$(python3 ramp_expected.py "$SELFCHECK_RAMP_UP" "$SELFCHECK_DURATION" "$SELFCHECK_RAMP_DOWN" "$SELFCHECK_TARGET")
+SELFCHECK_PASS=$(python3 -c "
+achieved = $SELFCHECK_ACHIEVED_COUNT
+expected = $SELFCHECK_EXPECTED_COUNT
+print('yes' if achieved >= expected * 0.95 else 'no')
+")
+SELFCHECK_PCT=$(python3 -c "print(round(100 * $SELFCHECK_ACHIEVED_COUNT / $SELFCHECK_EXPECTED_COUNT, 1))")
+
+echo "[run_loadtest] self-check: achieved=${SELFCHECK_ACHIEVED_COUNT} iterations, expected=${SELFCHECK_EXPECTED_COUNT} (${SELFCHECK_PCT}%), attempted_rate=${SELFCHECK_TARGET} rps, pass=${SELFCHECK_PASS}"
+if [[ "$SELFCHECK_PASS" != "yes" ]]; then
+  echo "[run_loadtest] FATAL: generator itself cannot sustain ${MAX_TARGET} rps (achieved ${SELFCHECK_PCT}% of expected iterations, need >=95%)." >&2
+  echo "  이 상태로 endpoint_mix_test.js 를 돌려도 achieved-rate 부족이 «서버 캡」인지 «생성기 기아」인지 못 가른다 — 중단." >&2
+  echo "  대책: 단일 머신 CPU/네트워크가 병목이면 여러 워커/Cloud Run Job으로 분산해 재시도(README §분산 참조)." >&2
+  exit 1
+fi
+echo "[run_loadtest] self-check PASS — proceeding to ramp stages."
+
+# ---- Phase 2: ramp stages ----------------------------------------------------------------
+echo "[run_loadtest] Phase 2/2: ramp stages [$STAGES], stage duration=$STAGE_DURATION"
+PREV_STATUS=0
+for RATE in $STAGES; do
+  STAGE_JSON="$OUT_DIR/stage_${RATE}.json"
+  echo "[run_loadtest] --- stage rate=${RATE} rps ---"
+  set +e
+  BASE_URL="$BASE_URL" CREDS_FILE="$CREDS_FILE" RATE="$RATE" \
+    STAGE_DURATION="$STAGE_DURATION" RAMP_UP="$RAMP_UP" RAMP_DOWN="$RAMP_DOWN" \
+    k6 run --summary-export="$STAGE_JSON" endpoint_mix_test.js | tee "$OUT_DIR/stage_${RATE}.log"
+  set -e
+
+  ATTEMPTED="$RATE"
+  # 원시(전체구간 평균) rate — 참고용으로만 보고한다. 램프업/다운이 이 값을 구조적으로
+  # 깎으므로(selfcheck와 동일 이유) kill-switch/판정에는 쓰지 않는다.
+  ACHIEVED_RAW_RATE=$(python3 -c "
+import json
+d = json.load(open('$STAGE_JSON'))
+print(d['metrics']['iterations']['rate'])
+")
+  ACHIEVED_COUNT=$(python3 -c "
+import json
+d = json.load(open('$STAGE_JSON'))
+print(d['metrics']['iterations']['count'])
+")
+  EXPECTED_COUNT=$(python3 ramp_expected.py "$RAMP_UP" "$STAGE_DURATION" "$RAMP_DOWN" "$RATE")
+  # 램프 프로파일 기준 「실효 achieved rps」 — target을 achieved/expected 개수비로 스케일.
+  # selfcheck와 동일 원리(rate 대 rate 비교는 램프에 오염됨) — 이게 실제 「달성 vs 시도」 수치.
+  ACHIEVED=$(python3 -c "print(round($RATE * $ACHIEVED_COUNT / $EXPECTED_COUNT, 2))")
+  ERROR_RATE=$(python3 -c "
+import json
+d = json.load(open('$STAGE_JSON'))
+m = d['metrics'].get('http_req_failed', {})
+print(m.get('rate', m.get('value', 0)))
+")
+  P95=$(python3 -c "
+import json
+d = json.load(open('$STAGE_JSON'))
+m = d['metrics'].get('http_req_duration', {})
+print(m.get('p(95)', 0))
+")
+  P50=$(python3 -c "
+import json
+d = json.load(open('$STAGE_JSON'))
+m = d['metrics'].get('http_req_duration', {})
+print(m.get('med', 0))
+")
+  P99=$(python3 -c "
+import json
+d = json.load(open('$STAGE_JSON'))
+m = d['metrics'].get('http_req_duration', {})
+print(m.get('p(99)', 0))
+")
+
+  echo "[run_loadtest] stage=${RATE} attempted=${ATTEMPTED} achieved(ramp-adjusted)=${ACHIEVED} achieved(raw avg)=${ACHIEVED_RAW_RATE} error_rate=${ERROR_RATE} p50=${P50}ms p95=${P95}ms p99=${P99}ms"
+  echo "${ATTEMPTED},${ACHIEVED},${ACHIEVED_RAW_RATE},${ERROR_RATE},${P50},${P95},${P99}" >> "$OUT_DIR/summary.csv"
+
+  BREACH=$(python3 -c "
+err = $ERROR_RATE
+p95 = $P95
+print('yes' if (err > $KILL_ERROR_RATE or p95 > $KILL_P95_MS) else 'no')
+")
+  if [[ "$BREACH" == "yes" ]]; then
+    echo "[run_loadtest] KILL-SWITCH: stage ${RATE} breached (error_rate=${ERROR_RATE} > ${KILL_ERROR_RATE} or p95=${P95}ms > ${KILL_P95_MS}ms) — aborting remaining stages." >&2
+    echo "attempted_rps,achieved_rps_ramp_adjusted,achieved_rps_raw_avg,error_rate,p50_ms,p95_ms,p99_ms" | cat - "$OUT_DIR/summary.csv" > "$OUT_DIR/summary_with_header.csv" 2>/dev/null || true
+    exit 3
+  fi
+done
+
+echo "attempted_rps,achieved_rps_ramp_adjusted,achieved_rps_raw_avg,error_rate,p50_ms,p95_ms,p99_ms" | cat - "$OUT_DIR/summary.csv" > "$OUT_DIR/summary_with_header.csv"
+echo "[run_loadtest] all stages complete, no kill-switch breach. summary: $OUT_DIR/summary_with_header.csv"
+cat "$OUT_DIR/summary_with_header.csv"

--- a/backend/scripts/loadtest/run_loadtest.sh
+++ b/backend/scripts/loadtest/run_loadtest.sh
@@ -20,16 +20,19 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-BASE_URL="${BASE_URL:-https://sprintable-backend-dev-57iommnikq-du.a.run.app}"
+BASE_URL="${BASE_URL:-https://sprintable-backend-dev-787818285179.asia-northeast3.run.app}"
 CREDS_FILE="${CREDS_FILE:-./loadtest_creds.json}"
 STAGES="${STAGES:-50 100 200 300}"
 STAGE_DURATION="${STAGE_DURATION:-60s}"
 RAMP_UP="${RAMP_UP:-10s}"
 RAMP_DOWN="${RAMP_DOWN:-5s}"
-# kill-switch 임계 — README §Gate와 동일 기준(p95<500ms, error<0.1%)을 스테이지 사이에도
-# 적용한다. 이 값을 넘기면 다음(더 높은) 스테이지로 올라가지 않고 즉시 멈춘다.
-KILL_ERROR_RATE="${KILL_ERROR_RATE:-0.05}"    # 5% — 개별 스테이지 완주는 허용하되 다음 스테이지 진입은 막는 보수적 값
-KILL_P95_MS="${KILL_P95_MS:-2000}"            # 2s — 정상 가동 목표(500ms)의 4배, "명백히 무너짐"만 감지
+# kill-switch 임계 — 「명백히 무너짐」만 감지하는 보수적 값(§6 Gate의 정상가동 목표인
+# p95<500ms·error<0.1%보다 훨씬 느슨: 그 목표는 «pass/fail 판정» 기준이고, 이건 「계속
+# 진행해도 안전한가」의 kill 기준이라 다르다). 스테이지 «사이»(run_loadtest.sh)와 스테이지
+# «내부»(endpoint_mix_test.js/generator_selfcheck.js의 k6 native abortOnFail) 둘 다 이
+# 값을 env var로 공유(카디르 QA 2026-08-04 — SSOT 하나, 드리프트 방지).
+KILL_ERROR_RATE="${KILL_ERROR_RATE:-0.05}"    # 5%
+KILL_P95_MS="${KILL_P95_MS:-2000}"            # 2s
 OUT_DIR="${OUT_DIR:-/tmp/loadtest-run-$(date +%s 2>/dev/null || echo run)}"
 
 mkdir -p "$OUT_DIR"
@@ -59,6 +62,7 @@ SELFCHECK_JSON="$OUT_DIR/selfcheck.json"
 SELFCHECK_TARGET=$(python3 -c "import math; print(math.ceil(int('$MAX_TARGET') * 1.2))")
 BASE_URL="$BASE_URL" TARGET_RATE="$MAX_TARGET" SELFCHECK_DURATION="$SELFCHECK_DURATION" \
   SELFCHECK_RAMP_UP="$SELFCHECK_RAMP_UP" SELFCHECK_RAMP_DOWN="$SELFCHECK_RAMP_DOWN" \
+  KILL_ERROR_RATE="$KILL_ERROR_RATE" KILL_P95_MS="$KILL_P95_MS" \
   k6 run --summary-export="$SELFCHECK_JSON" generator_selfcheck.js | tee "$OUT_DIR/selfcheck.log"
 
 SELFCHECK_ACHIEVED_COUNT=$(python3 -c "
@@ -92,6 +96,7 @@ for RATE in $STAGES; do
   set +e
   BASE_URL="$BASE_URL" CREDS_FILE="$CREDS_FILE" RATE="$RATE" \
     STAGE_DURATION="$STAGE_DURATION" RAMP_UP="$RAMP_UP" RAMP_DOWN="$RAMP_DOWN" \
+    KILL_ERROR_RATE="$KILL_ERROR_RATE" KILL_P95_MS="$KILL_P95_MS" \
     k6 run --summary-export="$STAGE_JSON" endpoint_mix_test.js | tee "$OUT_DIR/stage_${RATE}.log"
   set -e
 


### PR DESCRIPTION
## Summary
- story #2446 §6 결승선 부하테스트 harness. Run 1(WIP, DB axis 단독)을 재작성 없이 확장.
- Phase1 `generator_selfcheck.js`: 무부하 엔드포인트(`GET /api/v2/ping`)로 k6 생성기 자신이 목표 rps를 뽑을 수 있는지 증명(positive control) — Run 1이 겪은 VU-starvation 오판을 원천 차단.
- Phase2 `endpoint_mix_test.js`: A2 목록형 8종(stories/docs/tasks/goals/sprints/standups/meetings/hypotheses) + A1 카운터·로스터 6종(notifications/count, team-members, org-members, projects, activity-logs, glance/attention) + write 10% 가중 믹스. 엔드포인트별 지연/에러 커스텀 메트릭.
- `ramp_expected.py`: dev 실측으로 발견한 방법론 버그 수정 — k6 `iterations.rate`(전체구간 평균)는 램프업/다운 때문에 정상 생성기도 오판-fail시킨다(실측: TARGET=300에서 raw rate 비교론 86%로 보였으나 실제 iteration 개수는 기대치의 99.98%). 사다리꼴 적분 기대 개수와 비교하도록 수정.
- `run_loadtest.sh`: Phase1 게이트(>=95%) 통과 시에만 Phase2 ramp 스테이지(기본 50→100→200→300) 순차 실행, 스테이지 간 kill-switch(error_rate>5% 또는 p95>2000ms).
- ⛔ v1 제외: `GET /dashboard`(member_id 필수 쿼리파라미터, seeded identity에 없음 — bootstrap 필요, 후속 후보로 README에 명시).
- ⛔ prod 실행 범위 밖(선생님 창+go 대기). 이 PR은 harness 코드만, dev에서 자유 실행 가능.

## 실측 검증 (dev)
- self-check 실 런(TARGET_RATE=300): achieved iteration=8639, 기대=8640(99.98%) — 방법론 버그를 여기서 발견·수정.
- kill-switch 실측: dead credentials로 강제 error_rate=100% 상황을 만들어 exit code 3으로 정확히 중단하는 것을 확인(주입 실패 케이스 self-verify).
- ⚠️ Phase2의 「목표 rps 달성」 실증은 아직 미완료 — Run 1이 남긴 `loadtest_creds.json` 20개 신원이 전부 dev에서 `401 API key member not found`(재시딩 필요). 재시딩은 PO/infra-lane(`gcloud run jobs execute sprintable-verify-oneoff` → `python -m scripts.jobs.seed_loadtest_identities`) — README에 명시.

## Test plan
- [x] `bash -n run_loadtest.sh` 통과
- [x] `python3 -m py_compile ramp_expected.py` 통과
- [x] self-check dev 실 런(TARGET_RATE=300) — 방법론 검증 완료
- [x] kill-switch dev 실 런(dead creds) — exit 3 확인
- [ ] Phase2 실 rate 부하 dev 런 — 신원 재시딩(PO/infra-lane) 후 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)