### PR TITLE
chore(#2456): pin deploy SSOT — backend maxScale 18 + DATABASE_URL_READ durable

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -66,21 +66,24 @@ jobs:
             # conn-safe: min 3 × per-instance 5 = 15 ≤ 200(maxScale 5·rollout 70 예산 불변·SSOT db-connection-budget.md).
             # 근본(커넥션 풀링/아키텍처 재검토)은 #2074 별도 — 이건 응급 봉합의 prod 반영분.
             echo "backend_min_instances=3" >> "$GITHUB_OUTPUT"
-            # ⚠️ maxScale 5 (ee7794eb ③·선생님 right-size): prod g1-small. per-instance 5(pool
-            # 3/1=4 + pg_pubsub raw 1). rollout(old+new 2×): 2×5×5+20(admin)=70.
-            # ⚠️ story #2040(2026-07-20) PO gcloud 실측 갱신 — max_connections=**200**(과거 100 가정 낡음,
-            # codex #2074 조사가 재적발). 70 ≤ 200(여유 65%). SSOT는 `docs/db-connection-budget.md`.
-            # (PgBouncer 풀러 불필요/불가 — Cloud Run raw TCP 미지원으로 중앙 PgBouncer 불가·관리형 풀링은
-            # Enterprise Plus 전용(#1779 폐기 이력). 트래픽↑ 시 아키텍처 재검토(#2074) 필요.)
-            echo "backend_max_instances=5" >> "$GITHUB_OUTPUT"
+            # ⚠️ maxScale 18 (#2448 앱티어 right-size, 2026-08-04) — §6 규모 검증 부하테스트(warm18)와
+            # 라이브(rev 00274 수동복원)에서 실증된 값. 과거 maxScale 5 는 앱→primary «직결» 커넥션 예산
+            # (5×(pool+overflow)+raw ≤ max_conn 200)에서 나온 값이었으나, 그 전제는 #2445 Phase1 prod
+            # PgBouncer cutover(아래 backend_db_pgbouncer=true)로 폐기됐다 — 지금은 앱→primary 가 «전부
+            # PgBouncer 경유»(client_addr=PgBouncer VM·직결 raw 0)라 primary max_conn 200 은 PgBouncer
+            # 서버풀(default_pool_size 80×2=160 ≤ 200)이 maxScale «무관»하게 보호한다. maxScale 의 예산은
+            # 이제 PgBouncer max_client_conn(3000)에 걸린다: client conn 18×70≈1260 ≤ 3000(#2448 실측·
+            # rollout 2×=2520 도 ≤ 3000). SSOT 미등재라 배포마다 5로 «명시» 덮여(§6 1차 테스트가 maxScale
+            # 5 로 돈 원인) 검증값이 회귀했다 — 여기 못박아 durable화("손 값은 배포가 덮는다").
+            echo "backend_max_instances=18" >> "$GITHUB_OUTPUT"
             # story #2442(P0, 2026-08-03) — prod DB 커넥션 풀 고갈 인시던트(08:44Z, QueuePool
             # 타임아웃·/api/v2/health 전면 실패). PgBouncer가 prod에 없거나 무력해(db_pgbouncer=
             # False 코드+배포 양쪽 기본값 — 위 "PgBouncer 풀러 불가" 참고) tiny 앱 풀(3+1=4)이
             # Cloud SQL에 직결돼 즉시 고갈. PO가 gcloud로 20/10(rev 00257-wdz)까지 올려 즉시 회복
             # 확認(health 8/8 200) — 그 손 값을 SSOT로 durable화("손 값은 배포가 덮는다" 교훈).
-            # 안전식(롤아웃 배수 없이): maxScale(5)×(pool+overflow)+raw(1)=5×30+1=151≤200(25%여유).
-            # ⚠️잔여 리스크(docs/db-connection-budget.md 롤아웃 산식 2×N×5로는 2×5×31=310>200) —
-            # main 배포 빈도가 낮아 감수(PO 확認 필요, 재검토 트리거는 위 문서 참고).
+            # ⚠️ 이 pool/overflow(20/10)의 커넥션 예산은 위 maxScale 주석대로 이제 primary «직결»이 아니라
+            # PgBouncer max_client_conn(3000) 기준이다(backend_db_pgbouncer=true). primary max_conn 200 은
+            # PgBouncer 서버풀(≤160)이 maxScale 무관 보호 — 과거 5×30≤200 직결 산식은 cutover 로 폐기됐다.
             echo "db_pool_size=20" >> "$GITHUB_OUTPUT"
             echo "db_max_overflow=10" >> "$GITHUB_OUTPUT"
             # story #2445 Phase1(2026-08-04, 페드루) — prod PgBouncer cutover. dev 라이브 검증 + 부하테스트로

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -395,7 +395,11 @@ steps:
           # story #2445 Phase1(2026-08-04) — prod cutover: DATABASE_URL→PgBouncer VIP(DATABASE_URL_PROD_PGBOUNCER,
           # =10.178.0.111:6432), DATABASE_URL_DIRECT→직결(DATABASE_URL_PROD). _BACKEND_DB_PGBOUNCER=true와 짝.
           # 시크릿은 PO 생성·backend-prod SA(cloudrun-runtime-prod)에 secretAccessor 부여됨.
-          SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_PROD_PGBOUNCER:latest,DATABASE_URL_DIRECT=DATABASE_URL_PROD:latest"
+          # + DATABASE_URL_READ(#2451 §6 읽기 라우팅, rev 00266 라이브 flip): read replica DSN(PgBouncer
+          #   sprintable_read 풀 경유). 지금까지 라이브 «수동 바인딩»이라 배포 SSOT 어디에도 선언이 없어
+          #   env-drift-guard 축①이 매일 빨강이었다(additive --update-secrets 라 값은 보존됐으나 미선언=fragile:
+          #   --set-secrets 리팩터·서비스 재생성 時 조용히 소실→reads가 primary 로 새 병목 악화). 여기 편입해 durable화.
+          SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_PROD_PGBOUNCER:latest,DATABASE_URL_DIRECT=DATABASE_URL_PROD:latest,DATABASE_URL_READ=DATABASE_URL_READ:latest"
         fi
         gcloud run deploy sprintable-backend-${_DEPLOY_ENV} \
           --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA} \


### PR DESCRIPTION
## 배경 (story #2456 · epic §6)
§6 검증 부하테스트가 드러낸 **배포 SSOT 드리프트 2건** root-fix.

### ① maxScale — 매 배포가 검증값을 회귀시킴
라이브 prod = **maxScale 18**(#2448 앱티어·rev 00274 수동복원, §6 부하테스트 warm18 실증값)인데 배포 SSOT `.github/workflows/cloud-build.yml`은 `backend_max_instances=5`. 매 main 배포가 `--max-instances=5`로 «명시» 덮어 검증값이 회귀했다(§6 1차 테스트가 maxScale 5로 돈 원인).
- maxScale 5 주석은 앱→primary **직결** 커넥션 예산(`5×(pool+overflow)+raw ≤ max_conn 200`)이 전제였으나, 그 전제는 #2445 Phase1 PgBouncer cutover로 **폐기**됨 — 주석이 같은 블록 `backend_db_pgbouncer=true`(92행)와 자기모순이었다.
- 지금은 앱→primary가 «전부 PgBouncer 경유»라 primary max_conn 200은 PgBouncer 서버풀(default_pool_size 80×2=160 ≤ 200)이 **maxScale 무관** 보호. maxScale 예산은 PgBouncer `max_client_conn`(3000)에 걸림(18×70≈1260 ≤ 3000·#2448 실측). 주석을 이 PgBouncer-fronted 예산으로 교정.

### ② DATABASE_URL_READ — 배포 SSOT 미선언 = 상시 빨강 + fragile
라이브 prod가 secret `DATABASE_URL_READ`(§6 읽기 라우팅 #2451·rev 00266 flip)에 바인딩됐으나 배포 SSOT 어디에도 「선언」이 없어 `env-drift-guard` 축①(키집합 대조)이 상시 빨강(배경음화). additive `--update-secrets`라 값은 보존됐으나 미선언=fragile(`--set-secrets` 리팩터·서비스 재생성 時 조용히 소실 → reads가 primary로 새 병목 악화).
- `cloudbuild.yaml` prod `SECRETS_FLAG`에 `DATABASE_URL_READ=DATABASE_URL_READ:latest` 편입 — 매 배포 명시 바인딩(durable) + 가드 green. allowlist로 침묵시키지 않고 파이프라인에 편입(가드 자신의 권고).

## 변경
- `.github/workflows/cloud-build.yml`: prod `backend_max_instances` 5→18 + 폐기된 직결-primary 예산 주석 교정.
- `cloudbuild.yaml`: prod `SECRETS_FLAG`에 `DATABASE_URL_READ` 편입.

## 검증 (돌려서)
- `python3 infra/check_env_drift.py --only-env prod` — 편집 前 ❌(`DATABASE_URL_READ`) → 편집 後 **✅ 드리프트 없음(exit 0)**.
- deploy/drift-guard 테스트 **55 passed**(substitution 스캐너·deploy-backend 파싱·settings coverage·service subset·migrate wiring).
- YAML 양쪽 유효. cloudbuild.yaml 추가줄에 `$` 전무(substitution 스캐너 무관).
- ⚠️값 자체는 라이브·§6에서 이미 실증된 값을 SSOT에 «못박는» 것 — 새 처리량 주장 아님(200-300 관문은 별건 #2457 쓰기경로 진단).

## 머지 게이트
CI green → **카디르 QA** → admin-merge(⛔자가머지 금지) → prod 배포 후 검증(maxScale 18 유지·DATABASE_URL_READ 바인딩 유지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)