### PR TITLE
fix(#2457): api_key.last_used_at를 caller primary 세션에서 분리 — read-path row-lock 제거

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import logging
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Literal
 
 from fastapi import Depends, Header, HTTPException, Query, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from sqlalchemy import func, select, union
+from sqlalchemy import func, select, union, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import async_session_factory
@@ -44,12 +44,15 @@ async def _persist_first_auth_seen(
     emit 은 rollback 으로 미persist(V2 통일로 에이전트 첫 인증이 ``/agent/stream`` 인 게 가장 흔함) →
     **전용 committed 세션**에서 persist.
 
-    ⚠️ RC-1(산티아고 concurrency): caller ``_resolve_api_key`` 는 ``api_key.last_used_at = now`` 로
-    api_key row 를 dirty 로 들고 있고(autoflush 가 다음 조회 시 그 row lock 획득), 이 _persist 가 같은
-    api_key row 를 건드리면 **cross-connection 데드락**(전용 세션이 caller lock 대기 ↔ caller 는 이
-    await 끝나야 close). → **api_key row 를 일절 건드리지 않는다.** dedup 은 ``onboarding_events`` 존재로
-    판정하고, 동시 첫 인증은 agent-scoped advisory xact lock 으로 직렬화(TOCTOU 중복 emit 방지).
-    인증 무중단(fail-silent).
+    ⚠️ RC-1(산티아고 concurrency, story #2457 이전 히스토리): 과거엔 caller ``_resolve_api_key``
+    가 caller ``db`` 세션에서 api_key row 를 dirty 로 들고 있어(``last_used_at`` 갱신, autoflush
+    가 다음 조회 시 그 row lock 획득), 이 _persist 가 같은 api_key row 를 건드리면 **cross-connection
+    데드락**(전용 세션이 caller lock 대기 ↔ caller 는 이 await 끝나야 close) 위험이 있었다 →
+    **api_key row 를 일절 건드리지 않는다.** dedup 은 ``onboarding_events`` 존재로 판정하고,
+    동시 첫 인증은 agent-scoped advisory xact lock 으로 직렬화(TOCTOU 중복 emit 방지). 인증
+    무중단(fail-silent). (story #2457로 caller ``db`` 세션의 api_key dirty-set 자체가 없어져
+    이 데드락 전제는 현재 존재하지 않지만, api_key row 무접촉은 이 함수의 최소 책임 원칙으로도
+    유지한다 — 실 last_used_at 갱신은 아래 ``_touch_api_key_last_used`` 전담.)
     """
     from app.core.database import async_session_factory
     from app.models.onboarding_event import OnboardingEvent
@@ -79,6 +82,31 @@ async def _persist_first_auth_seen(
         logger.warning("first_auth_seen persist failed agent=%s", member_id, exc_info=True)
 
 
+_LAST_USED_AT_THROTTLE = timedelta(minutes=5)
+
+
+async def _touch_api_key_last_used(api_key_id: uuid.UUID) -> None:
+    """story #2457(§6 primary 풀 고갈 근본원인): 부하 中 pg_stat_activity 실측(PO probe,
+    2026-08-05) — ``last_used_at`` 갱신을 caller ``db``(primary) 세션에서 dirty-set 하면
+    그 row-lock 이 caller 트랜잭션 커밋(=응답 전체 완료)까지 유지된다. 20개 시드 identity가
+    공유되는 부하테스트에서 ~44 세션이 이 row-lock 대기로 막혀 있었다(같은 row 재사용이
+    prod 보다 과장되긴 하나, «읽기 요청도 last_used_at UPDATE 로 primary 커넥션을 응답
+    끝까지 문다»는 구조 자체는 prod에도 동일).
+
+    ``_persist_first_auth_seen``(OB-4b)과 동형으로 전용 세션 + 단독 짧은 트랜잭션으로
+    분리 — lock hold를 이 UPDATE 자체의 찰나로 줄인다. 인증 무중단(fail-silent).
+    """
+    from app.models.api_key import ApiKey
+    try:
+        async with async_session_factory() as s:
+            await s.execute(
+                update(ApiKey).where(ApiKey.id == api_key_id).values(last_used_at=datetime.now(timezone.utc))
+            )
+            await s.commit()
+    except Exception:
+        logger.warning("_touch_api_key_last_used failed api_key_id=%s", api_key_id, exc_info=True)
+
+
 async def _resolve_api_key(
     raw_key: str, db: AsyncSession, transport: str | None = None,
 ) -> AuthContext:
@@ -102,8 +130,11 @@ async def _resolve_api_key(
     # OB-4b seam(first_auth_seen): 이 키의 최초 인증(last_used_at None)을 갱신 전 캡처 — 1회 dedup.
     # api_key 경로 = 에이전트 인증(휴먼은 JWT). 실제 emit 은 member_id/org_id 해소 후(return 직전).
     _first_auth_seen = api_key.last_used_at is None
-    # fire-and-forget last_used_at 업데이트
-    api_key.last_used_at = now
+    # story #2457: caller `db`(primary) 세션에서 더 이상 dirty-set 하지 않는다(autoflush가
+    # 다음 SELECT 前 UPDATE를 내보내 caller 커밋까지 row-lock을 물던 것이 primary 풀 고갈의
+    # 지배 원인이었다 — pg_stat_activity 실측 확認). 스로틀(5분)도 여기서 메모리 값으로
+    # 판정해 대부분의 요청은 아래 _touch_api_key_last_used 호출 자체를 스킵한다.
+    _needs_touch = api_key.last_used_at is None or (now - api_key.last_used_at) > _LAST_USED_AT_THROTTLE
     scope: list[str] = api_key.scope or ["read", "write"]
 
     # AC3-1: 신원 해소를 플래그로 cut. ⚠️ 생명선 — 0075 1:1(member.id=team_member.id)로
@@ -191,6 +222,8 @@ async def _resolve_api_key(
     # 미persist + dedup 깨짐(까심 RC-1) → 전용 committed 세션에서 atomic 처리(경로 무관·race-safe·무중단).
     if _first_auth_seen:
         await _persist_first_auth_seen(member_id, org_id, project_id, transport=transport)
+    if _needs_touch:
+        await _touch_api_key_last_used(api_key.id)
 
     return AuthContext(
         user_id=str(member_id),

--- a/backend/scripts/loadtest/endpoint_mix_test.js
+++ b/backend/scripts/loadtest/endpoint_mix_test.js
@@ -38,6 +38,8 @@ const RATE = Number(__ENV.RATE || 100); // 이 스테이지의 목표 rps(오케
 const STAGE_DURATION = __ENV.STAGE_DURATION || '60s';
 const RAMP_UP = __ENV.RAMP_UP || '10s';
 const RAMP_DOWN = __ENV.RAMP_DOWN || '5s';
+// story #2457 진단 전용 파라미터 — 원본(10%)과 다르게 쓰기 비중을 올려 (a)/(b) 후보를 분리.
+const WRITE_RATIO = Number(__ENV.WRITE_RATIO || 0.1);
 // run_loadtest.sh의 kill-switch와 동일 SSOT(env var 공유) — 오케스트레이터 없이 단독
 // 실행해도 같은 급붕괴 기준으로 abort(카디르 QA MUST①, dev wedge 사고의 구조적 원인 봉합).
 const KILL_ERROR_RATE = Number(__ENV.KILL_ERROR_RATE || 0.05);
@@ -147,12 +149,16 @@ export default function () {
   // 가중 선택: 목록형(무거움·A2 hotspot)이 read 트래픽의 다수, 가벼운 A1 세트가 소수,
   // 쓰기가 드물게(원본 dev_db_capacity_test.js와 동형 — 실 인시던트가 「평범한 mutation
   // 버스트」였으므로 write 축을 아예 빼면 그 축의 회귀는 이 harness가 다시 못 잡는다).
+  // story #2457 진단: WRITE_RATIO env로 쓰기 비중 조절(기본 0.1=원본 동치) — (a)advisory_lock
+  // vs (b)/last_used_at 후보 분리용. LIGHT_RATIO는 남은 구간을 목록형:가벼움 6:3 비율로 나눔.
   const roll = Math.random();
-  if (roll < 0.6) {
+  const listBoundary = (1 - WRITE_RATIO) * (6 / 9);
+  const lightBoundary = 1 - WRITE_RATIO;
+  if (roll < listBoundary) {
     const ep = _LIST_ENDPOINTS[Math.floor(Math.random() * _LIST_ENDPOINTS.length)];
     const res = http.get(`${BASE_URL}${ep.path(cred)}`, { headers });
     _record(ep.name, res, 200);
-  } else if (roll < 0.9) {
+  } else if (roll < lightBoundary) {
     const ep = _LIGHT_ENDPOINTS[Math.floor(Math.random() * _LIGHT_ENDPOINTS.length)];
     const res = http.get(`${BASE_URL}${ep.path(cred)}`, { headers });
     _record(ep.name, res, 200);

--- a/backend/tests/test_ob4b_funnel_seams.py
+++ b/backend/tests/test_ob4b_funnel_seams.py
@@ -96,11 +96,21 @@ def test_first_auth_seen_wired_with_dedup_and_isolation():
     assert "_first_auth_seen = api_key.last_used_at is None" in src  # 첫인증 dedup 캡처
     # 까심 RC-1: streaming auth(commit 없음) 미persist 차단 — 전용 committed 세션.
     assert "_persist_first_auth_seen" in src and '"first_auth_seen"' in src
-    # 산티아고 RC-1(deadlock): api_key row 무접촉(caller dirty와 cross-conn 데드락 회피) +
-    # onboarding_events 존재 dedup + advisory lock 직렬화(TOCTOU).
-    assert "update(ApiKey)" not in src               # api_key row UPDATE 금지(데드락 회피)
-    assert "pg_advisory_xact_lock" in src            # 동시 첫인증 직렬화
-    assert "OnboardingEvent" in src                  # 이벤트 존재 dedup
+    # 산티아고 RC-1(deadlock): _persist_first_auth_seen 전용 세션은 api_key row 무접촉
+    # (caller dirty와 cross-conn 데드락 회피) + onboarding_events 존재 dedup + advisory
+    # lock 직렬화(TOCTOU). 이 가드는 _persist_first_auth_seen 함수 자체로 스코프한다 —
+    # story #2457로 신설된 _touch_api_key_last_used(별도 함수, 아래 assert)는 api_key row를
+    # UPDATE하지만, 데드락 전제 자체(caller db 세션이 같은 row를 dirty로 들고 있는 것)가
+    # story #2457에서 제거됐다(caller는 더 이상 `api_key.last_used_at = now`를 하지 않는다
+    # — 아래 assert로 그 전제 부재를 같이 고정).
+    persist_src = inspect.getsource(auth._persist_first_auth_seen)
+    assert "update(ApiKey)" not in persist_src        # api_key row UPDATE 금지(데드락 회피)
+    assert "pg_advisory_xact_lock" in persist_src     # 동시 첫인증 직렬화
+    assert "OnboardingEvent" in persist_src           # 이벤트 존재 dedup
+    # story #2457: caller db 세션은 api_key row를 dirty-set 하지 않는다(데드락 전제 제거 —
+    # 부재 시 _touch_api_key_last_used의 update(ApiKey)가 caller와 충돌할 수 없다).
+    assert "api_key.last_used_at = now" not in src
+    assert "update(ApiKey)" in inspect.getsource(auth._touch_api_key_last_used)
 
 
 def test_stream_connected_wired_one_time_isolated():


### PR DESCRIPTION
## Summary
- §6 부하테스트 목표 미달(prod 캡 ~100-150rps·목표 200-300)의 근본원인 진단(#2457) 결과, dev read-only 부하(write 0%)만으로도 primary DB 풀이 100rps에서 고갈되는 것을 재현했고, PO의 pg_stat_activity probe(부하 中)로 `UPDATE agent_api_keys SET last_used_at=$1 WHERE id=$2` row-lock 대기(~44 세션)가 지배 병목임을 실측 확인했습니다.
- `_resolve_api_key`가 매 인증 요청(읽기 포함)마다 caller `db`(primary) 세션에서 `api_key.last_used_at`을 dirty-set → autoflush UPDATE를 발생시키고, 그 row-lock이 caller 트랜잭션 커밋(=응답 전체 완료)까지 유지되어 동시 요청이 같은 api_key row에서 직렬화되고 있었습니다.
- `_persist_first_auth_seen`(OB-4b)과 동형 패턴으로 전용 세션 + 짧은 단독 트랜잭션으로 분리(`_touch_api_key_last_used`)하고, 5분 스로틀(메모리 값으로 판정, 대부분 요청은 DB 왕복 자체를 스킵)을 추가했습니다.
- 부수: 진단 harness(`endpoint_mix_test.js`)에 `WRITE_RATIO` env를 추가(기본값 0.1=원본과 동치, 무회귀) — 향후 read/write 후보 분리 재현에 재사용.

## Root cause (실측)
- Run A(dev, read-only, WRITE_RATIO=0, 쓰기 0건): 100rps 목표에서 이미 kill-switch(p95=2.06s, err=0%) — write 경로 없이도 재현.
- PO probe(pg_stat_activity, 부하 中 4프레임 지속 동일): ~44 세션이 `agent_api_keys` row-lock 대기, advisory_xact_lock(story.py:22)은 경합 없음(idle 2건).
- Run B(write_ratio=0.5)는 read-only보다 더 나쁨(err 12.8%·p95 30s) — 별도 병목이 아니라 write 요청이 같은 primary 세션을 더 오래(추가 쿼리) 물어 1번 병목을 증폭시키는 것으로 해석.

## Test plan
- [x] `uv run pytest tests/test_ob4b_funnel_seams.py tests/test_s35.py tests/test_org_agent_apikey_project_ids.py tests/test_ss4_security_regression.py` — 42 passed
- [x] `uv run pytest tests/*.py`(realdb 제외, 508개 파일) — 4369 passed, 7 failed(로컬 `.mcp.json` 환경차 — 수정 前후 동일하게 실패함을 stash로 확인, 무관)
- [ ] dev 배포 後 PO probe(pgstat-probe-dev)로 before/after 락경합 소멸 실측 + write-heavy 재현 rps 상한 재측정

story #2457. 진단 스토리이나 원인 확定 後 PO 지시로 처방까지 동일 스토리에서 진행(2026-08-05 대화 합의).

🤖 Generated with [Claude Code](https://claude.com/claude-code)