### PR TITLE
fix(#2459): 인증 dependency 체인을 요청-수명 get_db 대신 전용 단명 세션으로

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -346,11 +346,21 @@ async def get_current_user(
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
     x_agent_api_key: str | None = Header(default=None, alias="x-agent-api-key"),
     x_mcp_transport: str | None = Header(default=None, alias="X-MCP-Transport"),
-    db: AsyncSession = Depends(get_db),
 ) -> AuthContext:
+    """story #2459(§6 봉합①): 요청-수명 ``Depends(get_db)`` 대신 브랜치별 전용 단명 세션 —
+    get_current_user_streaming(SSE 전용 변형, 아래)과 동일 패턴을 기본 경로에도 적용한다.
+
+    ⚠️ 이 전환이 안전한 전제(story #2457로 이미 성립): 이 함수가 건드리는 모든 DB 접근
+    (``_resolve_api_key``·``_reject_if_before_cutover``·``_resolve_firebase_session``)이
+    현재 순수 읽기 전용이다 — `_resolve_api_key`의 ``last_used_at`` 갱신은 #2457로 이미
+    ``_touch_api_key_last_used``(별도 committed 세션)로 분리되어 caller 세션에 write가 없다.
+    caller 세션에 write가 남아있었다면 여기서 명시 커밋 없이 `async with`만 쓰는 건 그 write를
+    조용히 롤백시키는 회귀였을 것 — 이 순서(② #2457 → #2459) 자체가 안전장치다.
+    """
     # x-agent-api-key 헤더 우선 처리 (SSE 브릿지 직접 연결용)
     if x_agent_api_key and x_agent_api_key.startswith("sk_live_"):
-        return await _resolve_api_key(x_agent_api_key, db, transport=x_mcp_transport)
+        async with async_session_factory() as db:
+            return await _resolve_api_key(x_agent_api_key, db, transport=x_mcp_transport)
 
     if credentials is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing Authorization header")
@@ -359,7 +369,8 @@ async def get_current_user(
 
     # sk_live_* prefix → API key 경로 (DB 조회)
     if token.startswith("sk_live_"):
-        return await _resolve_api_key(token, db, transport=x_mcp_transport)
+        async with async_session_factory() as db:
+            return await _resolve_api_key(token, db, transport=x_mcp_transport)
 
     # story 455e528d(E-AUTH-REBUILD Phase1-S2·doc §4.2): Firebase 세션(RS256)은 alg 헤더로
     # 정확 분기 — 순차 fallback 아님. FIREBASE_AUTH_ACCEPT_SESSION=false(기본)면 이 분기는
@@ -368,7 +379,8 @@ async def get_current_user(
     from app.services.firebase_verifier import looks_like_rs256
 
     if _settings.firebase_auth_accept_session and looks_like_rs256(token):
-        return await _resolve_firebase_session(token, db)
+        async with async_session_factory() as db:
+            return await _resolve_firebase_session(token, db)
 
     # JWT 경로 (기존)
     try:
@@ -389,7 +401,8 @@ async def get_current_user(
     if not user_id:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token missing sub claim")
 
-    await _reject_if_before_cutover(user_id, payload.get("iat"), db)
+    async with async_session_factory() as db:
+        await _reject_if_before_cutover(user_id, payload.get("iat"), db)
 
     org_id: str | None = payload.get("app_metadata", {}).get("org_id")
 
@@ -490,11 +503,13 @@ async def get_verified_org_id(
     auth: AuthContext = Depends(get_current_user),
     x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
     x_project_id: str | None = Header(default=None, alias="X-Project-Id"),
-    db: AsyncSession = Depends(get_db),
     request: Request = None,
 ) -> uuid.UUID:
     """org_id 추출 — X-Org-Id 헤더 fallback 시 DB membership 검증, X-Project-Id 헤더 시 project 소속 검증.
-    API Key 경로는 HTTP method 기반 scope 자동 체크."""
+    API Key 경로는 HTTP method 기반 scope 자동 체크.
+
+    story #2459(§6 봉합①): 요청-수명 ``Depends(get_db)`` 대신 검증마다 전용 단명 세션 —
+    get_current_user와 동일 근거(호출 대상이 전부 읽기 전용, #2457로 이미 성립)."""
     # API Key scope 체크 (request 있을 때만 — 직접 단위 테스트 호출 시 스킵)
     if request is not None:
         _check_api_key_scope(auth, request.method, request.url.path)
@@ -514,7 +529,8 @@ async def get_verified_org_id(
 
     if x_org_id:
         # 헤더 사용 시 항상 membership 검증 (JWT org_id와 다를 수 있음)
-        await _verify_org_membership(auth.user_id, org_id, db, request)
+        async with async_session_factory() as db:
+            await _verify_org_membership(auth.user_id, org_id, db, request)
 
     # X-Project-Id 헤더 = per-request 프로젝트 스코프 **override**(d802da27/85614dd9).
     # JWT project_id 는 탭 공유라, 같은 유저가 여러 프로젝트 탭을 열어도 mutation 이 JWT 의 단일
@@ -532,7 +548,9 @@ async def get_verified_org_id(
         except ValueError:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid X-Project-Id format")
         from app.services.project_auth import has_project_access
-        if not await has_project_access(db, uuid.UUID(auth.user_id), header_project_id, org_id):
+        async with async_session_factory() as db:
+            allowed = await has_project_access(db, uuid.UUID(auth.user_id), header_project_id, org_id)
+        if not allowed:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="No access to the specified project",
@@ -546,7 +564,6 @@ async def get_project_scoped_org_id(
     project_id: uuid.UUID | None = Query(default=None),
     auth: AuthContext = Depends(get_current_user),
     x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
-    db: AsyncSession = Depends(get_db),
     request: Request = None,
 ) -> uuid.UUID:
     """project_id query param 으로 project 스코프 org_id를 해소.
@@ -557,18 +574,21 @@ async def get_project_scoped_org_id(
     project_id(JWT 스코프와 불일치)는 거부한다(403).
 
     has_project_access(team_member ∪ grant ∪ owner/admin) 로 project 멤버십 검증.
-    project_id 가 없으면 get_verified_org_id 동작과 동일."""
+    project_id 가 없으면 get_verified_org_id 동작과 동일.
+
+    story #2459(§6 봉합①): 요청-수명 ``Depends(get_db)`` 대신 검증마다 전용 단명 세션."""
     base_org_id = await get_verified_org_id(
-        auth=auth, x_org_id=x_org_id, x_project_id=None, db=db, request=request
+        auth=auth, x_org_id=x_org_id, x_project_id=None, request=request
     )
     if not project_id:
         return base_org_id
 
     from app.models.project import Project
-    result = await db.execute(
-        select(Project.org_id).where(Project.id == project_id)
-    )
-    project_org_id = result.scalar_one_or_none()
+    async with async_session_factory() as db:
+        result = await db.execute(
+            select(Project.org_id).where(Project.id == project_id)
+        )
+        project_org_id = result.scalar_one_or_none()
     if not project_org_id:
         return base_org_id
 
@@ -589,7 +609,9 @@ async def get_project_scoped_org_id(
     #   - grant-only 휴먼(project_access)도 project 접근 허용 (740e3b7e 에픽403 해소)
     #   - 동일 org 내 다른 project 미멤버 우회 방지(project 스코프)는 그대로 유지
     from app.services.project_auth import has_project_access
-    if not await has_project_access(db, uuid.UUID(auth.user_id), project_id, project_org_id):
+    async with async_session_factory() as db:
+        allowed = await has_project_access(db, uuid.UUID(auth.user_id), project_id, project_org_id)
+    if not allowed:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="해당 프로젝트의 멤버가 아닌",
@@ -729,12 +751,14 @@ async def get_scope_context(
     auth: AuthContext = Depends(get_current_user),
     x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
     x_project_id: str | None = Header(default=None, alias="X-Project-Id"),
-    db: AsyncSession = Depends(get_db),
     request: Request = None,
 ) -> dict:
-    """org_id + project_id 컨텍스트를 한번에 추출 — 헤더 fallback 시 membership/소속 검증."""
+    """org_id + project_id 컨텍스트를 한번에 추출 — 헤더 fallback 시 membership/소속 검증.
+
+    story #2459(§6 봉합①): get_verified_org_id가 이제 자체 단명 세션을 쓰므로 이 함수는
+    db 의존 자체가 불요."""
     # x_project_id를 get_verified_org_id에 전달해서 project 소속 검증도 위임
-    org_id = await get_verified_org_id(auth=auth, x_org_id=x_org_id, x_project_id=x_project_id, db=db, request=request)
+    org_id = await get_verified_org_id(auth=auth, x_org_id=x_org_id, x_project_id=x_project_id, request=request)
     jwt_project_id = auth.claims.get("app_metadata", {}).get("project_id")
     project_id_raw = jwt_project_id or x_project_id
     project_id = uuid.UUID(str(project_id_raw)) if project_id_raw else None

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -197,6 +197,28 @@ def project_id() -> uuid.UUID:
     return uuid.uuid4()
 
 
+class FakeAsyncSessionCtx:
+    """story #2459(§6 봉합①): get_current_user/get_verified_org_id/get_project_scoped_org_id가
+    이제 요청-수명 Depends(get_db) 대신 함수 내부 `async with async_session_factory()` 단명
+    세션을 쓴다 — FastAPI dependency_overrides로는 이걸 가로챌 수 없다(Depends 그래프를 안
+    타므로). 이 함수들을 직접 호출하는 테스트는 대신 이 패턴으로 패치한다:
+
+        with patch.object(auth, "async_session_factory", return_value=FakeAsyncSessionCtx(mock_db)):
+            result = await get_verified_org_id(auth=..., x_org_id=..., x_project_id=..., request=...)
+
+    (test_sse_conn_leak.py의 _FakeSession과 동형 — 여러 파일이 필요로 해 conftest로 공용화.)
+    """
+
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, *exc):
+        return False
+
+
 @pytest.fixture
 def mock_session() -> AsyncMock:
     session = AsyncMock()

--- a/backend/tests/test_bea25062_verifier_cutover_realdb.py
+++ b/backend/tests/test_bea25062_verifier_cutover_realdb.py
@@ -131,6 +131,9 @@ async def test_legacy_token_rejected_when_issued_before_cutover(monkeypatch):
     # 지역 import로 매번 새로 참조한다 — 소스 모듈 쪽을 패치해야 이 테스트 DB를 실제로 본다
     # (app.dependencies.auth 쪽 바인딩과는 별개 지점 — 소스 vs 소비 모듈 패치 구분 주의).
     monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    # story #2459: get_current_user 본체가 이제 자체 단명 세션(async_session_factory())을
+    # 쓰므로, 그 소비처인 app.dependencies.auth 쪽 바인딩도 이 테스트 DB로 패치해야 한다.
+    monkeypatch.setattr("app.dependencies.auth.async_session_factory", Session)
     try:
         async with Session() as s:
             user_id = await _seed_legacy_user(s)
@@ -141,10 +144,9 @@ async def test_legacy_token_rejected_when_issued_before_cutover(monkeypatch):
             await _set_auth_valid_after(s, user_id, cutover)
 
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
-        async with Session() as s:
-            with pytest.raises(HTTPException) as exc_info:
-                await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
-            assert exc_info.value.status_code == 401
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None)
+        assert exc_info.value.status_code == 401
     finally:
         await engine.dispose()
 
@@ -156,6 +158,7 @@ async def test_legacy_token_accepted_when_issued_after_cutover(monkeypatch):
 
     engine, Session = await _session_factory()
     monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    monkeypatch.setattr("app.dependencies.auth.async_session_factory", Session)
     try:
         async with Session() as s:
             user_id = await _seed_legacy_user(s)
@@ -164,8 +167,7 @@ async def test_legacy_token_accepted_when_issued_after_cutover(monkeypatch):
 
         token = create_access_token(str(user_id))
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
-        async with Session() as s:
-            auth = await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
+        auth = await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None)
         assert auth.user_id == str(user_id)
     finally:
         await engine.dispose()
@@ -179,14 +181,14 @@ async def test_legacy_token_unaffected_when_no_migration_row(monkeypatch):
 
     engine, Session = await _session_factory()
     monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    monkeypatch.setattr("app.dependencies.auth.async_session_factory", Session)
     try:
         async with Session() as s:
             user_id = await _seed_legacy_user(s)
 
         token = create_access_token(str(user_id))
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
-        async with Session() as s:
-            auth = await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
+        auth = await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None)
         assert auth.user_id == str(user_id)
     finally:
         await engine.dispose()
@@ -210,6 +212,7 @@ async def test_firebase_session_rejected_when_auth_time_before_cutover(monkeypat
 
     engine, Session = await _session_factory()
     monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    monkeypatch.setattr("app.dependencies.auth.async_session_factory", Session)
     try:
         async with Session() as s:
             user_id, firebase_uid = await _seed_firebase_user(s)
@@ -219,10 +222,9 @@ async def test_firebase_session_rejected_when_auth_time_before_cutover(monkeypat
         auth_time = int(time.time())
         cookie = _make_session_cookie(key_pem, firebase_uid, auth_time)
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=cookie)
-        async with Session() as s:
-            with pytest.raises(HTTPException) as exc_info:
-                await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
-            assert exc_info.value.status_code == 401
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None)
+        assert exc_info.value.status_code == 401
     finally:
         await engine.dispose()
 
@@ -243,6 +245,7 @@ async def test_firebase_session_accepted_when_auth_time_after_cutover(monkeypatc
 
     engine, Session = await _session_factory()
     monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    monkeypatch.setattr("app.dependencies.auth.async_session_factory", Session)
     try:
         async with Session() as s:
             user_id, firebase_uid = await _seed_firebase_user(s)
@@ -252,8 +255,7 @@ async def test_firebase_session_accepted_when_auth_time_after_cutover(monkeypatc
         auth_time = int(time.time())
         cookie = _make_session_cookie(key_pem, firebase_uid, auth_time)
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=cookie)
-        async with Session() as s:
-            auth = await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
+        auth = await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None)
         assert auth.user_id == str(user_id)
     finally:
         await engine.dispose()
@@ -290,8 +292,10 @@ async def test_sse_streaming_legacy_rejected_when_before_cutover(monkeypatch):
 async def test_legacy_token_fails_closed_when_migration_lookup_raises(monkeypatch):
     """조건 ①: 캐시 제거 후 DB 조회 자체가 실패하면(콜드 스타트/장애) 예외가 그대로
     전파돼야 한다 — 절대 "허용"으로 떨어지면 안 된다(이전 캐시의 fail-open 반대편 증명)."""
+    import app.dependencies.auth as auth_module
     from app.core.security import create_access_token
     from app.dependencies.auth import get_current_user
+    from tests.conftest import FakeAsyncSessionCtx
 
     user_id = uuid.uuid4()
     token = create_access_token(str(user_id))
@@ -301,9 +305,12 @@ async def test_legacy_token_fails_closed_when_migration_lookup_raises(monkeypatc
         async def get(self, *a, **kw):
             raise ConnectionError("simulated DB outage")
 
+    monkeypatch.setattr(
+        auth_module, "async_session_factory", lambda: FakeAsyncSessionCtx(_ExplodingDb())
+    )
     with pytest.raises(ConnectionError):
         await get_current_user(
-            credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=_ExplodingDb()
+            credentials=credentials, x_agent_api_key=None, x_mcp_transport=None
         )
 
 
@@ -316,6 +323,7 @@ async def test_legacy_token_rejected_when_state_reset_required_even_without_epoc
     from app.models.auth_identity import AuthMigration
 
     engine, Session = await _session_factory()
+    monkeypatch.setattr("app.dependencies.auth.async_session_factory", Session)
     try:
         async with Session() as s:
             user_id = await _seed_legacy_user(s)
@@ -324,10 +332,9 @@ async def test_legacy_token_rejected_when_state_reset_required_even_without_epoc
 
         token = create_access_token(str(user_id))
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
-        async with Session() as s:
-            with pytest.raises(HTTPException) as exc_info:
-                await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
-            assert exc_info.value.status_code == 401
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None)
+        assert exc_info.value.status_code == 401
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_c_s5.py
+++ b/backend/tests/test_c_s5.py
@@ -142,7 +142,9 @@ def test_require_project_access_allows_legacy_token_without_project_ids():
 
 @pytest.mark.anyio
 async def test_get_scope_context_returns_org_and_project():
+    from app.dependencies import auth as auth_module
     from app.dependencies.auth import get_scope_context
+    from tests.conftest import FakeAsyncSessionCtx
     org = uuid.uuid4()
     proj = uuid.uuid4()
     uid = str(uuid.uuid4())
@@ -155,10 +157,11 @@ async def test_get_scope_context_returns_org_and_project():
     mock_request = MagicMock()
     mock_request.state = types.SimpleNamespace()
 
-    ctx = await get_scope_context(
-        auth=auth, x_org_id=None, x_project_id=str(proj),
-        db=mock_db, request=mock_request,
-    )
+    with patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(mock_db)):
+        ctx = await get_scope_context(
+            auth=auth, x_org_id=None, x_project_id=str(proj),
+            request=mock_request,
+        )
     assert ctx["org_id"] == org
     assert ctx["project_id"] == proj
     assert ctx["user_id"] == uid
@@ -169,7 +172,7 @@ async def test_get_scope_context_project_none_when_not_provided():
     from app.dependencies.auth import get_scope_context
     org = uuid.uuid4()
     auth = _make_auth(org_id=str(org))
-    ctx = await get_scope_context(auth=auth, x_org_id=None, x_project_id=None, db=None, request=None)
+    ctx = await get_scope_context(auth=auth, x_org_id=None, x_project_id=None, request=None)
     assert ctx["org_id"] == org
     assert ctx["project_id"] is None
 
@@ -179,7 +182,9 @@ async def test_get_scope_context_project_none_when_not_provided():
 @pytest.mark.anyio
 async def test_get_verified_org_id_403_on_foreign_org():
     """X-Org-Id 헤더로 비소속 org 접근 시 403."""
+    from app.dependencies import auth as auth_module
     from app.dependencies.auth import get_verified_org_id
+    from tests.conftest import FakeAsyncSessionCtx
     caller_id = str(uuid.uuid4())
     auth = _make_auth(org_id=None, user_id=caller_id)  # JWT에 org_id 없음 → 헤더 fallback
 
@@ -190,21 +195,23 @@ async def test_get_verified_org_id_403_on_foreign_org():
     mock_request = MagicMock()
     mock_request.state = types.SimpleNamespace()
 
-    with pytest.raises(HTTPException) as exc_info:
-        await get_verified_org_id(
-            auth=auth,
-            x_org_id=str(uuid.uuid4()),
-            x_project_id=None,
-            db=mock_db,
-            request=mock_request,
-        )
+    with patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(mock_db)):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_verified_org_id(
+                auth=auth,
+                x_org_id=str(uuid.uuid4()),
+                x_project_id=None,
+                request=mock_request,
+            )
     assert exc_info.value.status_code == 403
 
 
 @pytest.mark.anyio
 async def test_get_verified_org_id_pass_when_member():
     """X-Org-Id 헤더로 소속 org 접근 시 정상 통과."""
+    from app.dependencies import auth as auth_module
     from app.dependencies.auth import get_verified_org_id
+    from tests.conftest import FakeAsyncSessionCtx
     org = uuid.uuid4()
     caller_id = str(uuid.uuid4())
     auth = _make_auth(org_id=None, user_id=caller_id)
@@ -216,20 +223,22 @@ async def test_get_verified_org_id_pass_when_member():
     mock_request = MagicMock()
     mock_request.state = types.SimpleNamespace()
 
-    result = await get_verified_org_id(
-        auth=auth,
-        x_org_id=str(org),
-        x_project_id=None,
-        db=mock_db,
-        request=mock_request,
-    )
+    with patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(mock_db)):
+        result = await get_verified_org_id(
+            auth=auth,
+            x_org_id=str(org),
+            x_project_id=None,
+            request=mock_request,
+        )
     assert result == org
 
 
 @pytest.mark.anyio
 async def test_get_verified_org_id_jwt_org_skips_db():
     """JWT에 org_id 있으면 DB 조회 없이 통과 (N+1 방지 경로 확인)."""
+    from app.dependencies import auth as auth_module
     from app.dependencies.auth import get_verified_org_id
+    from tests.conftest import FakeAsyncSessionCtx
     org = uuid.uuid4()
     auth = _make_auth(org_id=str(org))
 
@@ -237,9 +246,10 @@ async def test_get_verified_org_id_jwt_org_skips_db():
     mock_request = MagicMock()
     mock_request.state = types.SimpleNamespace()
 
-    result = await get_verified_org_id(
-        auth=auth, x_org_id=None, x_project_id=None, db=mock_db, request=mock_request,
-    )
+    with patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(mock_db)):
+        result = await get_verified_org_id(
+            auth=auth, x_org_id=None, x_project_id=None, request=mock_request,
+        )
     assert result == org
     mock_db.execute.assert_not_called()
 
@@ -247,7 +257,9 @@ async def test_get_verified_org_id_jwt_org_skips_db():
 @pytest.mark.anyio
 async def test_get_verified_org_id_403_on_foreign_project():
     """X-Project-Id 헤더로 비소속(has_project_access=False) project 접근 시 403."""
+    from app.dependencies import auth as auth_module
     from app.dependencies.auth import get_verified_org_id
+    from tests.conftest import FakeAsyncSessionCtx
     org = uuid.uuid4()
     auth = _make_auth(org_id=str(org), user_id=str(uuid.uuid4()))  # JWT에 org_id 있음 (org 검증 skip)
 
@@ -258,14 +270,14 @@ async def test_get_verified_org_id_403_on_foreign_project():
     mock_request = MagicMock()
     mock_request.state = types.SimpleNamespace()
 
-    with pytest.raises(HTTPException) as exc_info:
-        await get_verified_org_id(
-            auth=auth,
-            x_org_id=None,
-            x_project_id=str(uuid.uuid4()),
-            db=mock_db,
-            request=mock_request,
-        )
+    with patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(mock_db)):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_verified_org_id(
+                auth=auth,
+                x_org_id=None,
+                x_project_id=str(uuid.uuid4()),
+                request=mock_request,
+            )
     assert exc_info.value.status_code == 403
 
 
@@ -360,9 +372,13 @@ def test_auth_context_includes_org_id_from_jwt():
     mock_db.get = AsyncMock(return_value=None)
 
     import asyncio
-    with patch.dict("os.environ", {"JWT_SECRET": "test-secret"}):
+
+    from app.dependencies import auth as auth_module
+    from tests.conftest import FakeAsyncSessionCtx
+    with patch.dict("os.environ", {"JWT_SECRET": "test-secret"}), \
+         patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(mock_db)):
         from app.dependencies.auth import get_current_user
-        ctx = asyncio.run(get_current_user(credentials=creds, x_agent_api_key=None, db=mock_db))
+        ctx = asyncio.run(get_current_user(credentials=creds, x_agent_api_key=None))
 
     assert ctx.org_id == "org-abc"
     assert ctx.user_id == user_id

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -82,8 +82,14 @@ async def test_list_docs_200():
         mock_result.scalar_one_or_none.return_value = ORG_ID
         session.execute = AsyncMock(return_value=mock_result)
 
-        async with client as c:
-            resp = await c.get(f"/api/v2/docs?project_id={PROJECT_ID}")
+        # story #2459: get_project_scoped_org_id가 이제 요청-수명 get_db 대신 전용 단명
+        # 세션(async_session_factory())을 쓴다 — override_db_and_read(get_db/get_read_db)로는
+        # 못 가로채므로 별도 patch 필요.
+        from app.dependencies import auth as auth_module
+        from tests.conftest import FakeAsyncSessionCtx
+        with patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(session)):
+            async with client as c:
+                resp = await c.get(f"/api/v2/docs?project_id={PROJECT_ID}")
 
         assert resp.status_code == 200
         # story #2191: #2231 정본 규약 A — bare array → {data,meta} 봉투.
@@ -222,8 +228,11 @@ async def test_list_docs_with_parent_id_200():
         mock_result.scalar_one_or_none.return_value = ORG_ID
         session.execute = AsyncMock(return_value=mock_result)
 
-        async with client as c:
-            resp = await c.get(f"/api/v2/docs?project_id={PROJECT_ID}&parent_id={DOC_ID}")
+        from app.dependencies import auth as auth_module
+        from tests.conftest import FakeAsyncSessionCtx
+        with patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(session)):
+            async with client as c:
+                resp = await c.get(f"/api/v2/docs?project_id={PROJECT_ID}&parent_id={DOC_ID}")
 
         assert resp.status_code == 200
     finally:

--- a/backend/tests/test_e_auth_rebuild_phase1_s2_authcontext_realdb.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s2_authcontext_realdb.py
@@ -126,6 +126,9 @@ async def test_admin_firebase_user_gets_real_role_not_default_member_realdb(monk
     monkeypatch.setattr(fv, "_fetch_public_keys", fake_fetch)
 
     engine, Session = await _session_factory()
+    # story #2459: get_current_user가 이제 자체 단명 세션(async_session_factory())을 쓴다 —
+    # app.dependencies.auth 모듈 바인딩을 패치해야 이 테스트 DB를 실제로 본다.
+    monkeypatch.setattr("app.dependencies.auth.async_session_factory", Session)
     try:
         async with Session() as s:
             seeded = await _seed(s, org_role="admin")
@@ -133,8 +136,7 @@ async def test_admin_firebase_user_gets_real_role_not_default_member_realdb(monk
         cookie = _make_session_cookie(key_pem, seeded["firebase_uid"])
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=cookie)
 
-        async with Session() as s:
-            auth = await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
+        auth = await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None)
 
         assert auth.user_id == str(seeded["user_id"])
         assert auth.org_id == str(seeded["org_id"])
@@ -166,6 +168,7 @@ async def test_member_firebase_user_rejected_by_require_admin_realdb(monkeypatch
     monkeypatch.setattr(fv, "_fetch_public_keys", fake_fetch)
 
     engine, Session = await _session_factory()
+    monkeypatch.setattr("app.dependencies.auth.async_session_factory", Session)
     try:
         async with Session() as s:
             seeded = await _seed(s, org_role="member")
@@ -173,8 +176,7 @@ async def test_member_firebase_user_rejected_by_require_admin_realdb(monkeypatch
         cookie = _make_session_cookie(key_pem, seeded["firebase_uid"])
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=cookie)
 
-        async with Session() as s:
-            auth = await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
+        auth = await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None)
 
         assert auth.claims["app_metadata"]["role"] == "member"
         with pytest.raises(HTTPException) as exc_info:
@@ -199,6 +201,7 @@ async def test_get_org_scope_reads_live_org_id_realdb(monkeypatch):
     monkeypatch.setattr(fv, "_fetch_public_keys", fake_fetch)
 
     engine, Session = await _session_factory()
+    monkeypatch.setattr("app.dependencies.auth.async_session_factory", Session)
     try:
         async with Session() as s:
             seeded = await _seed(s, org_role="member")
@@ -206,8 +209,7 @@ async def test_get_org_scope_reads_live_org_id_realdb(monkeypatch):
         cookie = _make_session_cookie(key_pem, seeded["firebase_uid"])
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=cookie)
 
-        async with Session() as s:
-            auth = await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
+        auth = await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None)
 
         org_id = get_org_scope(auth=auth, x_org_id=None)
         assert str(org_id) == str(seeded["org_id"])
@@ -232,6 +234,7 @@ async def test_disabled_user_rejected_despite_valid_firebase_token_realdb(monkey
     monkeypatch.setattr(fv, "_fetch_public_keys", fake_fetch)
 
     engine, Session = await _session_factory()
+    monkeypatch.setattr("app.dependencies.auth.async_session_factory", Session)
     try:
         async with Session() as s:
             seeded = await _seed(s, user_active=False)
@@ -239,10 +242,9 @@ async def test_disabled_user_rejected_despite_valid_firebase_token_realdb(monkey
         cookie = _make_session_cookie(key_pem, seeded["firebase_uid"])
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=cookie)
 
-        async with Session() as s:
-            with pytest.raises(HTTPException) as exc_info:
-                await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
-            assert exc_info.value.status_code == 401
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None)
+        assert exc_info.value.status_code == 401
     finally:
         await engine.dispose()
 
@@ -268,13 +270,13 @@ async def test_unmapped_firebase_identity_rejected_realdb():
         mp.setattr(settings, "firebase_auth_accept_session", True)
         mp.setattr(settings, "firebase_project_id", PROJECT_ID)
         mp.setattr(fv, "_fetch_public_keys", fake_fetch)
+        mp.setattr("app.dependencies.auth.async_session_factory", Session)
         try:
             cookie = _make_session_cookie(key_pem, "never-provisioned-uid")
             credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=cookie)
-            async with Session() as s:
-                with pytest.raises(HTTPException) as exc_info:
-                    await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
-                assert exc_info.value.status_code == 401
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None)
+            assert exc_info.value.status_code == 401
         finally:
             mp.undo()
     finally:

--- a/backend/tests/test_e_mcp_opt_s5_hardening.py
+++ b/backend/tests/test_e_mcp_opt_s5_hardening.py
@@ -125,12 +125,14 @@ async def test_persist_first_auth_seen_falls_back_to_stdio_when_no_header():
 
 @pytest.mark.anyio
 async def test_get_current_user_passes_x_mcp_transport_header_through():
+    from app.dependencies import auth as auth_module
     from app.dependencies.auth import get_current_user
+    from tests.conftest import FakeAsyncSessionCtx
 
-    with patch("app.dependencies.auth._resolve_api_key", new=AsyncMock()) as resolve:
+    with patch("app.dependencies.auth._resolve_api_key", new=AsyncMock()) as resolve, \
+         patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(AsyncMock())):
         await get_current_user(
             credentials=None, x_agent_api_key="sk_live_abc", x_mcp_transport="http",
-            db=AsyncMock(),
         )
     resolve.assert_awaited_once_with("sk_live_abc", resolve.await_args.args[1], transport="http")
 

--- a/backend/tests/test_e_security_sec_s5_token_type_confusion.py
+++ b/backend/tests/test_e_security_sec_s5_token_type_confusion.py
@@ -33,22 +33,37 @@ def _mock_db_no_migration_row() -> AsyncMock:
 
 
 @pytest.mark.anyio
-async def test_access_token_passes_get_current_user():
+async def test_access_token_passes_get_current_user(monkeypatch):
+    """story #2459: get_current_user도 이제 자체 단명 세션(async_session_factory) —
+    streaming 변형 테스트와 동일 패턴."""
+    import app.dependencies.auth as auth_module
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return _mock_db_no_migration_row()
+
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr(auth_module, "async_session_factory", lambda: _FakeSession())
+
     user_id = str(uuid.uuid4())
     token = create_access_token(user_id, app_metadata={"org_id": str(uuid.uuid4())})
     ctx = await get_current_user(
-        credentials=_creds(token), x_agent_api_key=None, x_mcp_transport=None, db=_mock_db_no_migration_row()
+        credentials=_creds(token), x_agent_api_key=None, x_mcp_transport=None,
     )
     assert ctx.user_id == user_id
 
 
 @pytest.mark.anyio
 async def test_refresh_token_rejected_by_get_current_user():
-    """까심 재현 시나리오의 정확한 봉인 대상 — refresh 토큰이 Bearer로 더 이상 안 먹힌다."""
+    """까심 재현 시나리오의 정확한 봉인 대상 — refresh 토큰이 Bearer로 더 이상 안 먹힌다.
+
+    type!=access 거부는 DB 접근(async_session_factory) 이전 분기라 패치 불요."""
     user_id = str(uuid.uuid4())
     token, _exp = create_refresh_token(user_id, app_metadata={"org_id": str(uuid.uuid4())})
     with pytest.raises(HTTPException) as exc_info:
-        await get_current_user(credentials=_creds(token), x_agent_api_key=None, x_mcp_transport=None, db=AsyncMock())
+        await get_current_user(credentials=_creds(token), x_agent_api_key=None, x_mcp_transport=None)
     assert exc_info.value.status_code == 401
 
 

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -60,7 +60,12 @@ async def test_docs_list_via_conftest(test_client, mock_session, project_id, org
     mock_result.scalar_one_or_none.return_value = org_id
     mock_session.execute = AsyncMock(return_value=mock_result)
 
-    resp = await test_client.get(f"/api/v2/docs?project_id={project_id}")
+    # story #2459: get_project_scoped_org_id가 전용 단명 세션(async_session_factory())을
+    # 쓰므로 test_client fixture의 get_db override로는 못 가로챈다 — 별도 patch.
+    from app.dependencies import auth as auth_module
+    from tests.conftest import FakeAsyncSessionCtx
+    with patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(mock_session)):
+        resp = await test_client.get(f"/api/v2/docs?project_id={project_id}")
     assert resp.status_code == 200
     assert resp.json()["data"] == []
 

--- a/backend/tests/test_member_ssot_ac2_2.py
+++ b/backend/tests/test_member_ssot_ac2_2.py
@@ -38,7 +38,9 @@ def test_notification_preferences_member_id_has_no_team_members_fk():
 @pytest.mark.anyio
 async def test_get_project_scoped_grant_only_allows():
     """grant-only 휴먼(team_member 없음, has_project_access=True)도 project org 접근 허용."""
+    from app.dependencies import auth as auth_module
     from app.dependencies.auth import get_project_scoped_org_id
+    from tests.conftest import FakeAsyncSessionCtx
 
     project_id = uuid.uuid4()
     project_org = uuid.uuid4()
@@ -52,9 +54,10 @@ async def test_get_project_scoped_grant_only_allows():
     db.execute = AsyncMock(return_value=proj_result)
 
     with patch("app.dependencies.auth.get_verified_org_id", new=AsyncMock(return_value=project_org)), \
-         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)), \
+         patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(db)):
         result = await get_project_scoped_org_id(
-            project_id=project_id, auth=ctx, x_org_id=None, db=db, request=None
+            project_id=project_id, auth=ctx, x_org_id=None, request=None
         )
     assert result == project_org
 
@@ -62,7 +65,9 @@ async def test_get_project_scoped_grant_only_allows():
 @pytest.mark.anyio
 async def test_get_project_scoped_no_access_403():
     """team_member·grant·owner/admin 어디에도 없으면 403."""
+    from app.dependencies import auth as auth_module
     from app.dependencies.auth import get_project_scoped_org_id
+    from tests.conftest import FakeAsyncSessionCtx
 
     project_id = uuid.uuid4()
     project_org = uuid.uuid4()
@@ -76,10 +81,11 @@ async def test_get_project_scoped_no_access_403():
     db.execute = AsyncMock(return_value=proj_result)
 
     with patch("app.dependencies.auth.get_verified_org_id", new=AsyncMock(return_value=project_org)), \
-         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=False)):
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=False)), \
+         patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(db)):
         with pytest.raises(HTTPException) as exc:
             await get_project_scoped_org_id(
-                project_id=project_id, auth=ctx, x_org_id=None, db=db, request=None
+                project_id=project_id, auth=ctx, x_org_id=None, request=None
             )
     assert exc.value.status_code == 403
 
@@ -93,7 +99,9 @@ async def test_get_project_scoped_cross_org_without_header_rejected():
     0-project org 로 switch 직후 옛 프로젝트 query(stale)가 옛 org 로 재진입(leak)하던
     경로 차단. has_project_access=True 여도 cross-org 가드가 먼저 거부함을 증명.
     """
+    from app.dependencies import auth as auth_module
     from app.dependencies.auth import get_project_scoped_org_id
+    from tests.conftest import FakeAsyncSessionCtx
 
     project_id = uuid.uuid4()
     project_org = uuid.uuid4()      # project 가 속한 (옛) org
@@ -109,10 +117,11 @@ async def test_get_project_scoped_cross_org_without_header_rejected():
 
     has_access = AsyncMock(return_value=True)
     with patch("app.dependencies.auth.get_verified_org_id", new=AsyncMock(return_value=scoped_org)), \
-         patch("app.services.project_auth.has_project_access", new=has_access):
+         patch("app.services.project_auth.has_project_access", new=has_access), \
+         patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(db)):
         with pytest.raises(HTTPException) as exc:
             await get_project_scoped_org_id(
-                project_id=project_id, auth=ctx, x_org_id=None, db=db, request=None
+                project_id=project_id, auth=ctx, x_org_id=None, request=None
             )
     assert exc.value.status_code == 403
     has_access.assert_not_awaited()  # cross-org 가드가 access 체크보다 먼저 차단
@@ -122,7 +131,9 @@ async def test_get_project_scoped_cross_org_without_header_rejected():
 async def test_get_project_scoped_cross_org_with_matching_header_allowed():
     """X-Org-Id 헤더로 cross-org 가 명시 요청되면(=get_verified_org_id 가 그 org 로 해소)
     project_org 와 일치하므로 허용 — unified-switcher cross-org 프리뷰 보존."""
+    from app.dependencies import auth as auth_module
     from app.dependencies.auth import get_project_scoped_org_id
+    from tests.conftest import FakeAsyncSessionCtx
 
     project_id = uuid.uuid4()
     project_org = uuid.uuid4()
@@ -137,9 +148,10 @@ async def test_get_project_scoped_cross_org_with_matching_header_allowed():
 
     # X-Org-Id=project_org 명시 → get_verified_org_id 가 membership 검증 후 project_org 반환
     with patch("app.dependencies.auth.get_verified_org_id", new=AsyncMock(return_value=project_org)), \
-         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)), \
+         patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(db)):
         result = await get_project_scoped_org_id(
-            project_id=project_id, auth=ctx, x_org_id=str(project_org), db=db, request=None
+            project_id=project_id, auth=ctx, x_org_id=str(project_org), request=None
         )
     assert result == project_org
 

--- a/backend/tests/test_project_context_override.py
+++ b/backend/tests/test_project_context_override.py
@@ -3,7 +3,7 @@ X-Project-Id 를 JWT project_id 보다 우선(override) 적용하는지 + 권한
 from __future__ import annotations
 
 import uuid
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -34,7 +34,9 @@ def _access_result(member: bool):
 @pytest.mark.anyio
 async def test_x_project_id_overrides_jwt_when_member():
     """헤더 프로젝트 멤버십 OK → effective project 가 헤더로 override(JWT project_id 덮어씀)."""
+    from app.dependencies import auth as auth_module
     from app.dependencies.auth import get_verified_org_id
+    from tests.conftest import FakeAsyncSessionCtx
 
     org = uuid.uuid4()
     jwt_proj = uuid.uuid4()
@@ -44,9 +46,10 @@ async def test_x_project_id_overrides_jwt_when_member():
     db = AsyncMock()
     db.execute = AsyncMock(return_value=_access_result(True))
 
-    out = await get_verified_org_id(
-        auth=auth, x_org_id=None, x_project_id=str(header_proj), db=db, request=None
-    )
+    with patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(db)):
+        out = await get_verified_org_id(
+            auth=auth, x_org_id=None, x_project_id=str(header_proj), request=None
+        )
     assert out == org
     # downstream(48 라우트)이 읽는 app_metadata.project_id 가 헤더 프로젝트로 교체됨
     assert auth.claims["app_metadata"]["project_id"] == str(header_proj)
@@ -57,7 +60,9 @@ async def test_x_project_id_non_member_403_no_override():
     """헤더 프로젝트 멤버십 미달 → 403(권한상승 차단)·override 안 함."""
     from fastapi import HTTPException
 
+    from app.dependencies import auth as auth_module
     from app.dependencies.auth import get_verified_org_id
+    from tests.conftest import FakeAsyncSessionCtx
 
     org = uuid.uuid4()
     jwt_proj = uuid.uuid4()
@@ -66,10 +71,11 @@ async def test_x_project_id_non_member_403_no_override():
     db = AsyncMock()
     db.execute = AsyncMock(return_value=_access_result(False))
 
-    with pytest.raises(HTTPException) as ei:
-        await get_verified_org_id(
-            auth=auth, x_org_id=None, x_project_id=str(uuid.uuid4()), db=db, request=None
-        )
+    with patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(db)):
+        with pytest.raises(HTTPException) as ei:
+            await get_verified_org_id(
+                auth=auth, x_org_id=None, x_project_id=str(uuid.uuid4()), request=None
+            )
     assert ei.value.status_code == 403
     assert auth.claims["app_metadata"]["project_id"] == str(jwt_proj)  # 미override
 
@@ -87,7 +93,7 @@ async def test_no_x_project_id_keeps_jwt_project_id():
     db.execute = AsyncMock()
 
     out = await get_verified_org_id(
-        auth=auth, x_org_id=None, x_project_id=None, db=db, request=None
+        auth=auth, x_org_id=None, x_project_id=None, request=None
     )
     assert out == org
     assert auth.claims["app_metadata"]["project_id"] == str(jwt_proj)
@@ -133,11 +139,9 @@ async def test_x_project_id_invalid_format_400():
 
     org = uuid.uuid4()
     auth = _auth(org, project_id=uuid.uuid4())
-    db = AsyncMock()
-    db.execute = AsyncMock()
 
     with pytest.raises(HTTPException) as ei:
         await get_verified_org_id(
-            auth=auth, x_org_id=None, x_project_id="not-a-uuid", db=db, request=None
+            auth=auth, x_org_id=None, x_project_id="not-a-uuid", request=None
         )
     assert ei.value.status_code == 400

--- a/backend/tests/test_ss4_security_regression.py
+++ b/backend/tests/test_ss4_security_regression.py
@@ -284,13 +284,17 @@ async def test_auth_me_valid_api_key_200():
     async def override_db():
         yield mock_session
 
+    from app.dependencies import auth as auth_module
+    from tests.conftest import FakeAsyncSessionCtx
+
     app.dependency_overrides[get_db] = override_db
     try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-            resp = await c.get(
-                "/api/v2/auth/me",
-                headers={"Authorization": f"Bearer {_TEST_VALID}"},
-            )
+        with patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(mock_session)):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.get(
+                    "/api/v2/auth/me",
+                    headers={"Authorization": f"Bearer {_TEST_VALID}"},
+                )
         assert resp.status_code == 200
         data = resp.json()
         assert data["member_id"] == str(member_id)
@@ -315,13 +319,17 @@ async def test_auth_me_invalid_api_key_401():
     async def override_db():
         yield mock_session
 
+    from app.dependencies import auth as auth_module
+    from tests.conftest import FakeAsyncSessionCtx
+
     app.dependency_overrides[get_db] = override_db
     try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-            resp = await c.get(
-                "/api/v2/auth/me",
-                headers={"Authorization": f"Bearer {_TEST_INVALID}"},
-            )
+        with patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(mock_session)):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.get(
+                    "/api/v2/auth/me",
+                    headers={"Authorization": f"Bearer {_TEST_INVALID}"},
+                )
         assert resp.status_code == 401
     finally:
         app.dependency_overrides.clear()
@@ -343,13 +351,17 @@ async def test_auth_me_expired_api_key_401():
     async def override_db():
         yield mock_session
 
+    from app.dependencies import auth as auth_module
+    from tests.conftest import FakeAsyncSessionCtx
+
     app.dependency_overrides[get_db] = override_db
     try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-            resp = await c.get(
-                "/api/v2/auth/me",
-                headers={"Authorization": f"Bearer {_TEST_EXPIRED}"},
-            )
+        with patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(mock_session)):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.get(
+                    "/api/v2/auth/me",
+                    headers={"Authorization": f"Bearer {_TEST_EXPIRED}"},
+                )
         assert resp.status_code == 401
     finally:
         app.dependency_overrides.clear()
@@ -371,13 +383,17 @@ async def test_auth_me_revoked_api_key_401():
     async def override_db():
         yield mock_session
 
+    from app.dependencies import auth as auth_module
+    from tests.conftest import FakeAsyncSessionCtx
+
     app.dependency_overrides[get_db] = override_db
     try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-            resp = await c.get(
-                "/api/v2/auth/me",
-                headers={"Authorization": f"Bearer {_TEST_REVOKED}"},
-            )
+        with patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(mock_session)):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.get(
+                    "/api/v2/auth/me",
+                    headers={"Authorization": f"Bearer {_TEST_REVOKED}"},
+                )
         assert resp.status_code == 401
     finally:
         app.dependency_overrides.clear()

--- a/backend/tests/test_sse_conn_leak.py
+++ b/backend/tests/test_sse_conn_leak.py
@@ -67,6 +67,23 @@ def test_streaming_auth_deps_do_not_depend_on_get_db():
         assert "async_session_factory()" in src, f"{fn_name}은 자체 단명 세션을 써야 함"
 
 
+def test_default_auth_deps_do_not_depend_on_get_db():
+    """story #2459(§6 봉합①) 회귀 가드: get_current_user/get_verified_org_id/
+    get_project_scoped_org_id/get_scope_context — SSE 전용이 아닌 **기본** 경로도 이제
+    요청-수명 get_db를 점유하면 안 된다(§6 primary 풀 고갈의 구조적 root — read-routing을
+    깔아도 이 auth 세션이 따로 primary를 물어 무력화했다, PO probe로 44세션 락경합 실측
+    확定 후 last_used_at 부터·이 스토리에서 auth 세션 자체를 근절)."""
+    from app.dependencies import auth
+    for fn_name in (
+        "get_current_user", "get_verified_org_id", "get_project_scoped_org_id", "get_scope_context",
+    ):
+        fn = getattr(auth, fn_name)
+        params = inspect.signature(fn).parameters
+        for p in params.values():
+            dep_str = repr(p.default)
+            assert "get_db" not in dep_str, f"{fn_name}.{p.name} 가 get_db를 점유하면 안 됨"
+
+
 # ─── CP1: API key 경로에서 세션이 즉시 close 되는지 (점유 0) ───────────────────
 
 @pytest.mark.anyio

--- a/backend/tests/test_stories.py
+++ b/backend/tests/test_stories.py
@@ -99,8 +99,13 @@ async def test_list_stories_200():
         mock_result.scalar_one_or_none.return_value = ORG_ID
         session.execute = AsyncMock(return_value=mock_result)
 
-        async with client as c:
-            resp = await c.get(f"/api/v2/stories?project_id={PROJECT_ID}")
+        # story #2459: get_project_scoped_org_id가 전용 단명 세션(async_session_factory())을
+        # 쓰므로 override_db_and_read로는 못 가로챈다 — 별도 patch.
+        from app.dependencies import auth as auth_module
+        from tests.conftest import FakeAsyncSessionCtx
+        with patch.object(auth_module, "async_session_factory", return_value=FakeAsyncSessionCtx(session)):
+            async with client as c:
+                resp = await c.get(f"/api/v2/stories?project_id={PROJECT_ID}")
 
         assert resp.status_code == 200
         data = resp.json()


### PR DESCRIPTION
## Summary
- §6 primary DB 풀 고갈 클래스 감사(codex, doc `s6-primary-pool-class-audit-v1`)의 봉합①: `get_current_user`/`get_verified_org_id`/`get_project_scoped_org_id`/`get_scope_context`가 전부 `Depends(get_db)`로 **요청 전체 동안** primary 세션을 물고 있었다 — read-routing(#2846/#2848 read replica 배선)을 깔아도 이 auth 세션이 별도로 primary 커넥션을 요청 수명 내내 점유해 무력화시키는 구조적 root였다.
- `get_current_user_streaming`/`get_verified_org_id_streaming`(SSE 전용, #abaf6279 P0 connection leak fix)이 이미 검증된 "함수 내부 `async with async_session_factory()` 단명 세션" 패턴을 갖고 있어, 그 패턴을 기본 경로 4개 함수에 동일 적용했다.
- #2457(last_used_at UPDATE row-lock 제거)이 선행되어 이 함수들의 DB 접근이 이미 전부 읽기 전용이라, 명시 커밋 없는 단명 세션 전환이 안전하다 — 순서(#2457→#2459) 자체가 안전장치.

## #2449(로그인 자꾸 풀림) 연계 진단
prod Cloud Logging(read-only, 7일)에서 `sqlalchemy.exc.TimeoutError: QueuePool limit ... timeout 30.00`이 1948건(최근 발생 포함) 확인됐고, `/auth/refresh`에서도 정확히 30.0x초 latency의 500이 여러 건 관측됨 — primary 풀 고갈이 인증 쿼리 timeout→500→(추정)로그아웃으로 이어지는 경로가 실측으로 확인됐다. 회전-경쟁(rotation race) 401은 별개로 잔존(#2449 자체 스토리 스코프).

## 테스트 호환성 노트
FastAPI `dependency_overrides`는 `Depends` 그래프만 가로채므로, 함수 내부에서 직접 호출하는 `async_session_factory()`는 못 잡는다 — 관련 테스트 9개 파일을 `patch.object(auth, "async_session_factory", ...)` 패턴(기존 streaming 테스트가 이미 쓰던 것)으로 이관했다. `conftest.py`에 공용 `FakeAsyncSessionCtx` 헬퍼 추가.

기존 pin 테스트(`test_ob4b_funnel_seams.py`, #2457에서 이미 재스코프)는 무영향. `test_sse_conn_leak.py`에 기본 경로 4개 함수가 `get_db`를 점유하지 않는다는 신규 회귀 pin 추가 — 양성대조(get_current_user에 `Depends(get_db)` 재삽입 → RED 확인 후 원복)로 검증했다.

## Test plan
- [x] `uv run pytest tests/*.py`(realdb 제외, 508파일) — 4370 passed(신규 pin 1건 포함)·7 failed(로컬 `.mcp.json` 환경차 — #2457에서도 동일 확인된 무관 실패, stash 재확인 없이도 동일 패턴)
- [x] 신규 회귀 pin 양성대조(sabotage→RED→원복) 확인
- [ ] dev 배포 後 PO probe(pgstat-probe-dev)로 before/after auth 세션 hold 실측 + Run B(write-heavy) 100rps 붕괴 개선폭 재측정

story #2459. epic 2f14e1f9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)