### PR TITLE
feat(#2460): 웹훅/푸시 배달 트랜잭셔널 아웃박스 — §6 봉합②

### DIFF
--- a/backend/alembic/versions/0227_delivery_jobs_table.py
+++ b/backend/alembic/versions/0227_delivery_jobs_table.py
@@ -1,0 +1,48 @@
+"""story #2460(§6 봉합②) — 웹훅/푸시 배달 트랜잭셔널 아웃박스 테이블. request 경로가 동기
+HTTP 배달(웹훅 3회재시도·10s·Expo push)을 caller 세션 위에서 하던 것을 이 테이블 insert로
+대체 — 실 배달은 delivery_dispatcher.py 워커가 자기 세션으로 수행한다.
+
+Revision ID: 0227
+Revises: 0226
+Create Date: 2026-08-05
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0227"
+down_revision = "0226"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "delivery_jobs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("kind", sa.Text(), nullable=False),
+        sa.Column("payload", postgresql.JSONB(), nullable=False, server_default="{}"),
+        sa.Column("status", sa.Text(), nullable=False, server_default="pending"),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("delivered_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "kind IN ('org_webhook', 'personal_webhook', 'expo_push')", name="ck_delivery_jobs_kind"
+        ),
+        sa.CheckConstraint("status IN ('pending', 'delivered', 'failed')", name="ck_delivery_jobs_status"),
+    )
+    op.create_index("ix_delivery_jobs_org_id", "delivery_jobs", ["org_id"])
+    op.create_index(
+        "ix_delivery_jobs_pending", "delivery_jobs", ["id"],
+        postgresql_where=sa.text("status = 'pending'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_delivery_jobs_pending", table_name="delivery_jobs")
+    op.drop_index("ix_delivery_jobs_org_id", table_name="delivery_jobs")
+    op.drop_table("delivery_jobs")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -128,9 +128,24 @@ async def lifespan(app: FastAPI):
     # send_message가 via_outbox=True로 무조건 enqueue하므로(플래그 없음, 두 콜사이트 하드코딩),
     # 이 워커도 무조건 기동해야 그 job들이 드레인된다(옵션 아님 — listen_loop과 동형으로 조건부
     # 게이팅 없이 기동).
-    from app.services.delivery_dispatcher import delivery_dispatcher_loop
+    # story #2460(§6 봉합②): delivery_jobs 워커 — story_status_events.py/conversations.py
+    # send_message가 via_outbox=True로 무조건 enqueue하므로(플래그 없음, 두 콜사이트 하드코딩),
+    # 이 워커도 실배포에선 무조건 기동해야 그 job들이 드레인된다(listen_loop과 동형으로 조건부
+    # 게이팅 없이 기동 — 단, listen_loop과 달리 이 워커는 SQLAlchemy 공용 풀(async_session_factory)
+    # 을 물기 때문에 pytest 하에서는 예외적으로 안 띄운다. pytest는 TestClient(app)로 lifespan을
+    # 매 테스트마다 «서로 다른 이벤트루프»로 반복 기동하는 관례가 있어(shutdown.py 모듈독스트링
+    # 참조), 이 워커의 폴링 루프가 그 사이를 가로질러 살아있으면 전역 커넥션 풀에 다른 루프의
+    # Future가 섞여 "attached to a different loop" 로 실측됐다(#2852 CI 첫 push에서 재현·
+    # 태스크 비활성화 시 24/24 재통과로 원인 확定 — listen_loop은 SQLAlchemy 풀을 안 쓰는
+    # raw asyncpg 전용 커넥션이라 이 클래스에 안 걸림, 이 워커와 다른 지점). `PYTEST_CURRENT_TEST`
+    # 는 신규 발명이 아니라 이 파일의 `is_really_local`이 이미 쓰는 같은 pytest 탐지 관례.
+    import os as _os
 
-    delivery_dispatcher_task = asyncio.create_task(delivery_dispatcher_loop())
+    delivery_dispatcher_task = None
+    if not _os.environ.get("PYTEST_CURRENT_TEST"):
+        from app.services.delivery_dispatcher import delivery_dispatcher_loop
+
+        delivery_dispatcher_task = asyncio.create_task(delivery_dispatcher_loop())
     try:
         yield
     finally:
@@ -146,7 +161,8 @@ async def lifespan(app: FastAPI):
             redis_shadow_task.cancel()
         if outbox_dispatcher_task is not None:
             outbox_dispatcher_task.cancel()
-        delivery_dispatcher_task.cancel()
+        if delivery_dispatcher_task is not None:
+            delivery_dispatcher_task.cancel()
         try:
             if task is not None:
                 try:
@@ -168,10 +184,11 @@ async def lifespan(app: FastAPI):
                     await outbox_dispatcher_task
                 except asyncio.CancelledError:
                     pass
-            try:
-                await delivery_dispatcher_task
-            except asyncio.CancelledError:
-                pass
+            if delivery_dispatcher_task is not None:
+                try:
+                    await delivery_dispatcher_task
+                except asyncio.CancelledError:
+                    pass
         finally:
             # 좀비 연결 박멸(S:33e0c681): SIGTERM(Cloud Run 인스턴스 교체·스케일다운·리비전 삭제)
             # 시 SQLAlchemy 풀의 전 DB 연결을 정상 종료. dispose 누락 시 구 인스턴스가 연결을 안

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -124,6 +124,13 @@ async def lifespan(app: FastAPI):
         from app.services.event_broker import outbox_dispatcher_loop
 
         outbox_dispatcher_task = asyncio.create_task(outbox_dispatcher_loop())
+    # story #2460(§6 봉합②): delivery_jobs 워커 — story_status_events.py/conversations.py
+    # send_message가 via_outbox=True로 무조건 enqueue하므로(플래그 없음, 두 콜사이트 하드코딩),
+    # 이 워커도 무조건 기동해야 그 job들이 드레인된다(옵션 아님 — listen_loop과 동형으로 조건부
+    # 게이팅 없이 기동).
+    from app.services.delivery_dispatcher import delivery_dispatcher_loop
+
+    delivery_dispatcher_task = asyncio.create_task(delivery_dispatcher_loop())
     try:
         yield
     finally:
@@ -139,6 +146,7 @@ async def lifespan(app: FastAPI):
             redis_shadow_task.cancel()
         if outbox_dispatcher_task is not None:
             outbox_dispatcher_task.cancel()
+        delivery_dispatcher_task.cancel()
         try:
             if task is not None:
                 try:
@@ -160,6 +168,10 @@ async def lifespan(app: FastAPI):
                     await outbox_dispatcher_task
                 except asyncio.CancelledError:
                     pass
+            try:
+                await delivery_dispatcher_task
+            except asyncio.CancelledError:
+                pass
         finally:
             # 좀비 연결 박멸(S:33e0c681): SIGTERM(Cloud Run 인스턴스 교체·스케일다운·리비전 삭제)
             # 시 SQLAlchemy 풀의 전 DB 연결을 정상 종료. dispose 누락 시 구 인스턴스가 연결을 안

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -17,6 +17,7 @@ from app.models.embedding import Embedding
 from app.models.evidence import Evidence
 from app.models.event import Event
 from app.models.event_outbox import EventOutbox
+from app.models.delivery_job import DeliveryJob
 from app.models.gate import Gate
 from app.models.github_installation import GithubInstallation, GithubInstallNonce, GithubWebhookDelivery
 from app.models.hitl import HitlPolicy, HitlRequest
@@ -121,6 +122,7 @@ __all__ = [
     "BridgeUserMapping",
     "Embedding",
     "EventOutbox",
+    "DeliveryJob",
     "Gate",
     "GithubInstallation",
     "GithubInstallNonce",

--- a/backend/app/models/delivery_job.py
+++ b/backend/app/models/delivery_job.py
@@ -1,0 +1,43 @@
+"""story #2460(§6 봉합②): 웹훅/푸시 배달 트랜잭셔널 아웃박스.
+
+`fire_webhooks`/`_deliver_personal_webhooks`/`deliver_expo_push`(request 경로)가 caller의
+AsyncSession 을 물고 동기 HTTP 배달(웹훅 3회재시도·10s·Expo push)을 하던 것을 이 테이블
+insert 로 대체한다 — 실 배달은 `delivery_dispatcher.py`의 워커 루프가 자기 세션으로 수행한다.
+`app/models/event_outbox.py`(SSE/PG NOTIFY 전용, story #2078)와는 목적이 다른 별개 테이블이다.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, DateTime, Index, Integer, Text, func, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class DeliveryJob(Base):
+    __tablename__ = "delivery_jobs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    kind: Mapped[str] = mapped_column(Text, nullable=False)
+    payload: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="pending", server_default="pending")
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    delivered_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        CheckConstraint(
+            "kind IN ('org_webhook', 'personal_webhook', 'expo_push')", name="ck_delivery_jobs_kind"
+        ),
+        CheckConstraint("status IN ('pending', 'delivered', 'failed')", name="ck_delivery_jobs_status"),
+        # 워커 폴링 축 — pending 부분 인덱스(event_outbox.ix_event_outbox_pending과 동형: 대부분의
+        # row가 곧 delivered/failed로 빠지므로 미해결 row는 항상 소수, 부분 인덱스로 스캔 최소화).
+        Index("ix_delivery_jobs_pending", "id", postgresql_where=text("status = 'pending'")),
+    )

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -2134,6 +2134,8 @@ async def send_message(
                         body=(msg.content or "")[:200],
                         reference_type="conversation", reference_id=conversation_id,
                         source_project_id=conv.project_id,
+                        # story #2460(§6 봉합②): 개인 webhook·Expo push 실배달을 요청 트랜잭션 밖으로.
+                        via_outbox=True,
                     )
             except Exception:
                 logger.warning(
@@ -2170,6 +2172,8 @@ async def send_message(
                     body=(msg.content or "")[:200],
                     reference_type="conversation", reference_id=conversation_id,
                     source_project_id=conv.project_id,
+                    # story #2460(§6 봉합②): 개인 webhook·Expo push 실배달을 요청 트랜잭션 밖으로.
+                    via_outbox=True,
                 )
     except Exception:
         logger.warning("conversation.message notification failed conversation_id=%s", conversation_id, exc_info=True)

--- a/backend/app/services/delivery_dispatcher.py
+++ b/backend/app/services/delivery_dispatcher.py
@@ -1,0 +1,180 @@
+"""story #2460(§6 봉합②): delivery_jobs 워커 — outbox(claim)와 배달(외부 I/O)을 분리한다.
+
+PO 확定 설계(2026-08-05): enqueue는 caller의 요청 트랜잭션에 원자적으로 실리고(at-least-once
+계약은 app/models/delivery_job.py·webhook_dispatch.py/notification_dispatch.py/expo_push.py의
+``via_outbox=True`` 경로 참고), 이 워커가 commit 後 별도 폴링으로 실제 webhook POST/Expo push를
+수행한다.
+
+⚠️embedding_backlog.py/event_broker.outbox_dispatcher_loop()와 달리 이 워커는 claim(FOR UPDATE
+SKIP LOCKED)과 실 배달(외부 I/O)을 **분리**한다 — claim은 즉시 commit해 lock을 놓고, 각 job은
+자기 세션으로 배달+상태갱신까지 짧게 마친다. 다건 webhook POST를 하나의 열린 트랜잭션 아래서
+순회하지 않는다 — 개별 webhook당 최대 10s 타임아웃이 걸릴 수 있어, 그걸 열린 트랜잭션 안에서
+하면 §6이 막 닫은 "커넥션을 오래 쥔 채 외부 I/O" 클래스를 이 워커 자신이 재현하게 된다(PO
+2026-08-05 명시 지시 — "worker loop은 세션 짧게 잡고, 외부 I/O 中 트랜잭션 안 잡게").
+
+claim은 진짜 락이 아니다(attempts만 증가시키고 status는 pending 그대로 둔다) — FOR UPDATE
+SKIP LOCKED는 claim 트랜잭션이 열려 있는 "그 순간"의 동시 폴링만 막고, 그 트랜잭션이 끝난
+뒤 재폴링까지는 못 막는다. 즉 두 인스턴스가 좁은 창 안에서 겹치면 같은 job을 중복 배달할 수
+있다 — AC가 명시 허용하는 범위(at-least-once, exactly-once 아님)라 의도적으로 더 무거운 락은
+안 쓴다.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select, update
+
+logger = logging.getLogger(__name__)
+
+_BATCH_SIZE = 20
+_POLL_INTERVAL = 2.0  # AC "near-real-time cadence" — event_broker.outbox_dispatcher_loop() 1s와 동급대.
+_MAX_ATTEMPTS = 5
+_CONCURRENCY = 5  # 배치 내 job들을 짧은 세션끼리 병렬 배달(커넥션 풀 예산 고려한 상한).
+
+
+async def _claim_batch(limit: int = _BATCH_SIZE) -> list[dict]:
+    """FOR UPDATE SKIP LOCKED로 pending job 배치를 골라 attempts만 증가시키고 바로 commit —
+    lock을 짧게만 쥔다(배달은 여기서 안 함). 반환은 세션-독립적인 순수 dict라 다음 단계가 이
+    세션을 물고 다닐 필요가 없다."""
+    from app.core.database import async_session_factory
+    from app.models.delivery_job import DeliveryJob
+
+    async with async_session_factory() as session:
+        rows = (await session.execute(
+            select(DeliveryJob)
+            .where(DeliveryJob.status == "pending")
+            .order_by(DeliveryJob.created_at.asc())
+            .limit(limit)
+            .with_for_update(skip_locked=True)
+        )).scalars().all()
+        if not rows:
+            await session.commit()
+            return []
+        claimed = [
+            {"id": r.id, "org_id": r.org_id, "kind": r.kind, "payload": dict(r.payload), "attempts": r.attempts}
+            for r in rows
+        ]
+        await session.execute(
+            update(DeliveryJob)
+            .where(DeliveryJob.id.in_([r["id"] for r in claimed]))
+            .values(attempts=DeliveryJob.attempts + 1)
+        )
+        await session.commit()
+        return claimed
+
+
+def _uuid_or_none(v: str | None) -> uuid.UUID | None:
+    return uuid.UUID(v) if v else None
+
+
+def _uuid_set_or_none(v: list[str] | None) -> set[uuid.UUID] | None:
+    return {uuid.UUID(m) for m in v} if v is not None else None
+
+
+async def _deliver_one(job: dict) -> None:
+    """claim된 job 하나를 자기 세션으로 배달 + 상태갱신(이 함수 호출 동안만 커넥션 보유).
+
+    개별 webhook/push target 실패는 각 ``_now`` 함수 내부가 이미 삼킨다(기존 in-request 동작과
+    동일 best-effort — per-target 실패는 job 레벨에는 안 보임). 여기서 "실패"로 잡는 경우는 이
+    함수 자체가 예외를 낸 경우뿐(DB 조회 실패·payload 역직렬화 오류·미지원 kind 등)."""
+    from app.core.database import async_session_factory
+    from app.models.delivery_job import DeliveryJob
+
+    job_id = job["id"]
+    org_id = job["org_id"]
+    kind = job["kind"]
+    payload = job["payload"]
+    attempts = job["attempts"] + 1  # claim에서 이미 +1 커밋됨 — 로컬에서도 동일 값 반영.
+
+    try:
+        async with async_session_factory() as session:
+            if kind == "org_webhook":
+                from app.services.webhook_dispatch import _fire_webhooks_now
+
+                await _fire_webhooks_now(
+                    session, org_id, payload["event"], payload["data"],
+                    recipient_member_ids=_uuid_set_or_none(payload.get("recipient_member_ids")),
+                    preserve_broadcast=payload.get("preserve_broadcast", True),
+                )
+            elif kind == "personal_webhook":
+                from app.services.notification_dispatch import _deliver_personal_webhooks_now
+
+                await _deliver_personal_webhooks_now(
+                    session, org_id, [uuid.UUID(m) for m in payload["member_ids"]],
+                    title=payload["title"], body=payload.get("body"), event_type=payload["event_type"],
+                    reference_type=payload.get("reference_type"),
+                    reference_id=_uuid_or_none(payload.get("reference_id")),
+                    context=payload.get("context"),
+                    muted_member_ids=_uuid_set_or_none(payload.get("muted_member_ids")),
+                )
+            elif kind == "expo_push":
+                from ee.services.expo_push import _deliver_expo_push_now
+
+                await _deliver_expo_push_now(
+                    session, org_id, [uuid.UUID(m) for m in payload["member_ids"]],
+                    title=payload["title"], body=payload.get("body"), event_type=payload["event_type"],
+                    reference_type=payload.get("reference_type"),
+                    reference_id=_uuid_or_none(payload.get("reference_id")),
+                    context=payload.get("context"),
+                    muted_member_ids=_uuid_set_or_none(payload.get("muted_member_ids")),
+                    project_id=_uuid_or_none(payload.get("project_id")),
+                    story_id=_uuid_or_none(payload.get("story_id")),
+                    sprint_id=_uuid_or_none(payload.get("sprint_id")),
+                )
+            else:
+                raise ValueError(f"unknown delivery_job kind: {kind}")
+
+            await session.execute(
+                update(DeliveryJob).where(DeliveryJob.id == job_id).values(
+                    status="delivered", delivered_at=datetime.now(timezone.utc),
+                )
+            )
+            await session.commit()
+    except Exception as exc:
+        logger.warning("delivery_dispatcher: job %s (kind=%s) delivery attempt failed: %s", job_id, kind, exc)
+        try:
+            async with async_session_factory() as session:
+                # embedding_backlog.py의 retry_count 임계값과 동형 — _MAX_ATTEMPTS 도달 시
+                # terminal(다음 tick부터 status='pending' SELECT에서 영구 제외).
+                next_status = "pending" if attempts < _MAX_ATTEMPTS else "failed"
+                await session.execute(
+                    update(DeliveryJob).where(DeliveryJob.id == job_id).values(
+                        status=next_status, last_error=str(exc)[:1000],
+                    )
+                )
+                await session.commit()
+        except Exception:
+            logger.exception("delivery_dispatcher: job %s status update after failure also failed", job_id)
+
+
+async def delivery_dispatcher_loop() -> None:
+    """claim(짧은 트랜잭션) → 배달(짧은 세션, 외부 I/O) → 상태갱신을 tick마다 반복.
+
+    정상 tick 사이 ``_POLL_INTERVAL`` 고정 폴링. listen_loop()/event_broker.outbox_dispatcher_loop()
+    와 동형 에러 backoff(1s→2s→...→30s)."""
+    logger.info(
+        "delivery_dispatcher starting (poll_interval=%.1fs batch=%d concurrency=%d)",
+        _POLL_INTERVAL, _BATCH_SIZE, _CONCURRENCY,
+    )
+    delay = 1.0
+    while True:
+        try:
+            claimed = await _claim_batch()
+            if not claimed:
+                await asyncio.sleep(_POLL_INTERVAL)
+                delay = 1.0
+                continue
+            for i in range(0, len(claimed), _CONCURRENCY):
+                chunk = claimed[i:i + _CONCURRENCY]
+                await asyncio.gather(*(_deliver_one(j) for j in chunk))
+            delay = 1.0
+        except asyncio.CancelledError:
+            logger.info("delivery_dispatcher cancelled — shutting down")
+            break
+        except Exception as exc:
+            logger.warning("delivery_dispatcher error: %s — retrying in %.1fs", exc, delay)
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, 30)

--- a/backend/app/services/delivery_dispatcher.py
+++ b/backend/app/services/delivery_dispatcher.py
@@ -75,11 +75,21 @@ def _uuid_set_or_none(v: list[str] | None) -> set[uuid.UUID] | None:
 
 
 async def _deliver_one(job: dict) -> None:
-    """claim된 job 하나를 자기 세션으로 배달 + 상태갱신(이 함수 호출 동안만 커넥션 보유).
+    """claim된 job 하나를 배달 + 상태갱신.
 
-    개별 webhook/push target 실패는 각 ``_now`` 함수 내부가 이미 삼킨다(기존 in-request 동작과
-    동일 best-effort — per-target 실패는 job 레벨에는 안 보임). 여기서 "실패"로 잡는 경우는 이
-    함수 자체가 예외를 낸 경우뿐(DB 조회 실패·payload 역직렬화 오류·미지원 kind 등)."""
+    story #2460 PO 리뷰(2026-08-05, F1 — 머지 前 필수수정): 예전엔 이 함수 전체가 하나의
+    `async with async_session_factory() as session:` 블록 안에서 fetch도 하고 실제
+    webhook POST/Expo 발송(외부 I/O, 타깃당 최대 10s)까지 다 했다 — POST 자체는 session을
+    안 건드리지만 그 세션(커넥션)이 POST 루프 내내 idle-in-transaction으로 열려 있었다("배달
+    中 트랜잭션 안 잡는다"는 클래스 docstring 계약과 실제가 어긋난 한 겹 얕은 원본). 지금은
+    kind별로 **fetch(짧은 세션, 즉시 commit)→send(세션 없음, 순수 외부 I/O)→[expo_push만:
+    finalize(짧은 세션)]** 세 단계로 명시 분리 — 세션이 열려 있는 구간과 외부 I/O 구간이
+    절대 겹치지 않는다.
+
+    개별 webhook/push target 실패는 각 ``_send_*`` 함수 내부가 이미 삼킨다(기존 in-request
+    동작과 동일 best-effort — per-target 실패는 job 레벨에는 안 보임). 여기서 "실패"로 잡는
+    경우는 fetch/finalize의 DB 오류·payload 역직렬화 오류·미지원 kind 등 이 함수 자체가
+    예외를 낸 경우뿐."""
     from app.core.database import async_session_factory
     from app.models.delivery_job import DeliveryJob
 
@@ -90,43 +100,65 @@ async def _deliver_one(job: dict) -> None:
     attempts = job["attempts"] + 1  # claim에서 이미 +1 커밋됨 — 로컬에서도 동일 값 반영.
 
     try:
-        async with async_session_factory() as session:
-            if kind == "org_webhook":
-                from app.services.webhook_dispatch import _fire_webhooks_now
+        if kind == "org_webhook":
+            from app.services.webhook_dispatch import _fetch_webhook_targets, _send_webhook_targets
 
-                await _fire_webhooks_now(
-                    session, org_id, payload["event"], payload["data"],
+            async with async_session_factory() as session:
+                targets = await _fetch_webhook_targets(
+                    session, org_id, payload["event"],
                     recipient_member_ids=_uuid_set_or_none(payload.get("recipient_member_ids")),
                     preserve_broadcast=payload.get("preserve_broadcast", True),
                 )
-            elif kind == "personal_webhook":
-                from app.services.notification_dispatch import _deliver_personal_webhooks_now
+                await session.commit()
+            # ⬇ 이 구간은 세션이 닫혀 있다(커넥션 풀에 반납됨) — 외부 I/O만.
+            await _send_webhook_targets(targets, payload["event"], payload["data"])
+        elif kind == "personal_webhook":
+            from app.services.notification_dispatch import (
+                _fetch_personal_webhook_targets,
+                _send_personal_webhook_targets,
+            )
 
-                await _deliver_personal_webhooks_now(
+            async with async_session_factory() as session:
+                targets = await _fetch_personal_webhook_targets(
                     session, org_id, [uuid.UUID(m) for m in payload["member_ids"]],
-                    title=payload["title"], body=payload.get("body"), event_type=payload["event_type"],
-                    reference_type=payload.get("reference_type"),
-                    reference_id=_uuid_or_none(payload.get("reference_id")),
-                    context=payload.get("context"),
                     muted_member_ids=_uuid_set_or_none(payload.get("muted_member_ids")),
                 )
-            elif kind == "expo_push":
-                from ee.services.expo_push import _deliver_expo_push_now
+                await session.commit()
+            await _send_personal_webhook_targets(
+                targets, title=payload["title"], body=payload.get("body"),
+                event_type=payload["event_type"], reference_type=payload.get("reference_type"),
+                reference_id=_uuid_or_none(payload.get("reference_id")), context=payload.get("context"),
+            )
+        elif kind == "expo_push":
+            from ee.services.expo_push import (
+                _fetch_expo_push_targets,
+                _finalize_expo_push_dead_tokens,
+                _send_expo_push_targets,
+            )
 
-                await _deliver_expo_push_now(
+            async with async_session_factory() as session:
+                targets = await _fetch_expo_push_targets(
                     session, org_id, [uuid.UUID(m) for m in payload["member_ids"]],
-                    title=payload["title"], body=payload.get("body"), event_type=payload["event_type"],
-                    reference_type=payload.get("reference_type"),
-                    reference_id=_uuid_or_none(payload.get("reference_id")),
-                    context=payload.get("context"),
                     muted_member_ids=_uuid_set_or_none(payload.get("muted_member_ids")),
-                    project_id=_uuid_or_none(payload.get("project_id")),
-                    story_id=_uuid_or_none(payload.get("story_id")),
-                    sprint_id=_uuid_or_none(payload.get("sprint_id")),
                 )
-            else:
-                raise ValueError(f"unknown delivery_job kind: {kind}")
+                await session.commit()
+            dead_tokens = await _send_expo_push_targets(
+                targets, title=payload["title"], body=payload.get("body"),
+                event_type=payload["event_type"], org_id=org_id,
+                reference_type=payload.get("reference_type"),
+                reference_id=_uuid_or_none(payload.get("reference_id")),
+                project_id=_uuid_or_none(payload.get("project_id")),
+                story_id=_uuid_or_none(payload.get("story_id")),
+                sprint_id=_uuid_or_none(payload.get("sprint_id")),
+            )
+            if dead_tokens:
+                async with async_session_factory() as session:
+                    await _finalize_expo_push_dead_tokens(session, org_id, dead_tokens)
+                    await session.commit()
+        else:
+            raise ValueError(f"unknown delivery_job kind: {kind}")
 
+        async with async_session_factory() as session:
             await session.execute(
                 update(DeliveryJob).where(DeliveryJob.id == job_id).values(
                     status="delivered", delivered_at=datetime.now(timezone.utc),

--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -57,32 +57,44 @@ async def _deliver_personal_webhooks(
     reference_id: uuid.UUID | None = None,
     context: dict | None = None,
     muted_member_ids: set[uuid.UUID] | None = None,
+    via_outbox: bool = False,
 ) -> None:
-    """story #2460(§6 봉합②): 개인 webhook 실배달을 즉시 POST하지 않고 `delivery_jobs`에 job
-    row만 insert(caller 세션·트랜잭션에 실림, commit은 caller 책임) — 실 배달은
-    `delivery_dispatcher.py` 워커가 `_deliver_personal_webhooks_now()`로 수행한다. 호출부
-    (dispatch_notification)는 이미 fire-and-forget이라 무변경."""
+    """story #2460(§6 봉합②, PO 스코프 확定 2026-08-05): outbox 경유는 **opt-in**이다
+    (``via_outbox=True``) — dispatch_notification 호출부 중 story_status_events.py·
+    conversations.py send_message(멘션·메시지 알림) 둘만 켠다. 나머지 dispatch_notification
+    호출부는 기본값 False로 기존과 동일하게 즉시 POST한다(behavior 무변경).
+    ``via_outbox=True``면 즉시 POST 대신 `delivery_jobs`에 job row만 insert(caller
+    세션·트랜잭션에 실림, commit은 caller 책임 — at-least-once) — 실 배달은
+    `delivery_dispatcher.py` 워커가 자기 세션으로 `_deliver_personal_webhooks_now()`를
+    수행한다(요청 트랜잭션 밖에서 외부 I/O)."""
     if not member_ids:
         return
-    from app.models.delivery_job import DeliveryJob
+    if via_outbox:
+        from app.models.delivery_job import DeliveryJob
 
-    db.add(
-        DeliveryJob(
-            org_id=org_id,
-            kind="personal_webhook",
-            payload={
-                "member_ids": [str(m) for m in member_ids],
-                "title": title,
-                "body": body,
-                "event_type": event_type,
-                "reference_type": reference_type,
-                "reference_id": str(reference_id) if reference_id else None,
-                "context": context,
-                "muted_member_ids": (
-                    [str(m) for m in muted_member_ids] if muted_member_ids is not None else None
-                ),
-            },
+        db.add(
+            DeliveryJob(
+                org_id=org_id,
+                kind="personal_webhook",
+                payload={
+                    "member_ids": [str(m) for m in member_ids],
+                    "title": title,
+                    "body": body,
+                    "event_type": event_type,
+                    "reference_type": reference_type,
+                    "reference_id": str(reference_id) if reference_id else None,
+                    "context": context,
+                    "muted_member_ids": (
+                        [str(m) for m in muted_member_ids] if muted_member_ids is not None else None
+                    ),
+                },
+            )
         )
+        return
+    await _deliver_personal_webhooks_now(
+        db, org_id, member_ids, title=title, body=body, event_type=event_type,
+        reference_type=reference_type, reference_id=reference_id, context=context,
+        muted_member_ids=muted_member_ids,
     )
 
 
@@ -181,8 +193,16 @@ async def dispatch_notification(
     context: dict | None = None,
     story_id: uuid.UUID | None = None,
     sprint_id: uuid.UUID | None = None,
+    via_outbox: bool = False,
 ) -> None:
     """notification_settings 필터 후 enabled member에게 알림 발송.
+
+    ``via_outbox``(story #2460, §6 봉합②): True면 개인 webhook·Expo push 실배달을 이 호출
+    안에서 하지 않고 outbox(`delivery_jobs`)에 적재만 한다 — in-app Notification/Event
+    INSERT(아래 본문)는 원래도 순수 DB write라 이 플래그와 무관하게 그대로 caller의
+    트랜잭션에 실린다(바꿀 이유 없음). opt-in 스코프는 story_status_events.py·
+    conversations.py send_message 두 콜사이트뿐(PO 확定) — 기본 False로 다른 12+ 콜사이트는
+    behavior 무변경.
 
     human 멤버: Notification 테이블 INSERT (in-app 알림)
     agent 멤버: events 테이블 INSERT (event_type=dispatched, status=pending)
@@ -428,7 +448,7 @@ async def dispatch_notification(
         await _deliver_personal_webhooks(
             db, org_id, webhook_deliver_ids, title=title, body=body, event_type=event_type,
             reference_type=reference_type, reference_id=reference_id, context=context,
-            muted_member_ids=muted_member_ids,
+            muted_member_ids=muted_member_ids, via_outbox=via_outbox,
         )
 
         # E-MOBILE M0·S3: EE 푸시 채널(웹훅과 나란한 별개 채널) — 등록 push_devices 로 Expo 발송.
@@ -442,6 +462,7 @@ async def dispatch_notification(
                 reference_type=reference_type, reference_id=reference_id, context=context,
                 muted_member_ids=muted_member_ids,
                 project_id=_push_project_id, story_id=story_id, sprint_id=sprint_id,
+                via_outbox=via_outbox,
             )
 
     except Exception:

--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -119,12 +119,30 @@ async def _deliver_personal_webhooks_now(
 
     muted_member_ids: story 75570ab8 — 호출자가 이미 계산한 mute 집합을 넘기면 재조회 생략
     (Event-skip 판정과 동일 SSOT 재사용, 드리프트 방지). None이면 이 함수가 자체 조회.
-    """
-    if not member_ids:
-        return
-    from app.core.ssrf import validate_webhook_url_async
-    from app.services.dispatch_router import _post_with_retry
 
+    story #2460 PO 리뷰(2026-08-05, F1) — 예전엔 이 함수가 조회 直後 같은 함수 안에서 POST
+    루프를 돌아, 호출자(`_deliver_one`)의 세션이 POST 내내 idle-in-transaction으로 열려
+    있었다(webhook_dispatch.py `_fire_webhooks_now`와 동형 결함). `_fetch_personal_webhook_targets`
+    (세션 필요)/`_send_personal_webhook_targets`(세션 불요)로 쪼개 이 함수는 얇은 래퍼로
+    남긴다 — 기존 호출부(via_outbox=False) 시그니처·거동 무변경."""
+    targets = await _fetch_personal_webhook_targets(db, org_id, member_ids, muted_member_ids=muted_member_ids)
+    await _send_personal_webhook_targets(
+        targets, title=title, body=body, event_type=event_type,
+        reference_type=reference_type, reference_id=reference_id, context=context,
+    )
+
+
+async def _fetch_personal_webhook_targets(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    member_ids: list[uuid.UUID],
+    *,
+    muted_member_ids: set[uuid.UUID] | None = None,
+) -> list[dict]:
+    """활성 개인 WebhookConfig를 조회해 mute 필터까지 마친 순수 dict 리스트로 반환한다.
+    세션 I/O는 이 함수에서 끝(story #2460 PO 리뷰 F1)."""
+    if not member_ids:
+        return []
     wh_rows = await db.execute(
         select(WebhookConfig).where(
             WebhookConfig.org_id == org_id,
@@ -135,7 +153,7 @@ async def _deliver_personal_webhooks_now(
     )
     configs = list(wh_rows.scalars().all())
     if not configs:
-        return
+        return []
 
     # global mute 멤버 skip (CP②: 채널 막론 mute 우선)
     if muted_member_ids is None:
@@ -143,19 +161,37 @@ async def _deliver_personal_webhooks_now(
     else:
         muted = muted_member_ids
 
-    for cfg in configs:
-        if cfg.member_id in muted:
-            continue
+    return [
+        {"url": cfg.url, "secret": cfg.secret, "member_id": cfg.member_id}
+        for cfg in configs if cfg.member_id not in muted
+    ]
+
+
+async def _send_personal_webhook_targets(
+    targets: list[dict],
+    *,
+    title: str,
+    body: str | None,
+    event_type: str,
+    reference_type: str | None = None,
+    reference_id: uuid.UUID | None = None,
+    context: dict | None = None,
+) -> None:
+    """세션 없이 순수 HTTP POST만(story #2460 PO 리뷰 F1)."""
+    if not targets:
+        return
+    from app.core.ssrf import validate_webhook_url_async
+    from app.services.dispatch_router import _post_with_retry
+
+    for t in targets:
+        url, secret, member_id = t["url"], t["secret"], t["member_id"]
         # SSRF 재검증 (저장 후 DNS rebinding 방지)
         try:
-            await validate_webhook_url_async(cfg.url)
+            await validate_webhook_url_async(url)
         except Exception:
-            logger.warning("personal webhook SSRF reject member=%s", cfg.member_id)
+            logger.warning("personal webhook SSRF reject member=%s", member_id)
             continue
-        is_discord = (
-            "discord.com/api/webhooks" in cfg.url
-            or "discordapp.com/api/webhooks" in cfg.url
-        )
+        is_discord = "discord.com/api/webhooks" in url or "discordapp.com/api/webhooks" in url
         if is_discord:
             text = f"[{event_type}] {title}" + (f"\n{body}" if body else "")
             payload = {"content": text}
@@ -172,11 +208,10 @@ async def _deliver_personal_webhooks_now(
                 "reference_id": str(reference_id) if reference_id else None,
                 "context": context or {},
             }
-            secret = cfg.secret
         try:
-            await _post_with_retry(cfg.url, payload, secret, str(cfg.member_id))
+            await _post_with_retry(url, payload, secret, str(member_id))
         except Exception:
-            logger.warning("personal webhook POST failed (swallowed) member=%s", cfg.member_id)
+            logger.warning("personal webhook POST failed (swallowed) member=%s", member_id)
 
 
 async def dispatch_notification(

--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -58,16 +58,55 @@ async def _deliver_personal_webhooks(
     context: dict | None = None,
     muted_member_ids: set[uuid.UUID] | None = None,
 ) -> None:
-    """96af343e: 활성 개인(member-scoped) WebhookConfig 보유 휴먼에게 알림 webhook POST.
+    """story #2460(§6 봉합②): 개인 webhook 실배달을 즉시 POST하지 않고 `delivery_jobs`에 job
+    row만 insert(caller 세션·트랜잭션에 실림, commit은 caller 책임) — 실 배달은
+    `delivery_dispatcher.py` 워커가 `_deliver_personal_webhooks_now()`로 수행한다. 호출부
+    (dispatch_notification)는 이미 fire-and-forget이라 무변경."""
+    if not member_ids:
+        return
+    from app.models.delivery_job import DeliveryJob
 
-    in-app Notification 과 동일 flush 타이밍(best-effort·옵션 C). global mute 멤버는 skip
-    (채널 막론 mute 우선). SSRF 검증·HMAC 서명·Discord URL 포맷·retry 는
-    dispatch_router._post_with_retry / app.core.ssrf 재사용. agent SSE 경로
+    db.add(
+        DeliveryJob(
+            org_id=org_id,
+            kind="personal_webhook",
+            payload={
+                "member_ids": [str(m) for m in member_ids],
+                "title": title,
+                "body": body,
+                "event_type": event_type,
+                "reference_type": reference_type,
+                "reference_id": str(reference_id) if reference_id else None,
+                "context": context,
+                "muted_member_ids": (
+                    [str(m) for m in muted_member_ids] if muted_member_ids is not None else None
+                ),
+            },
+        )
+    )
+
+
+async def _deliver_personal_webhooks_now(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    member_ids: list[uuid.UUID],
+    *,
+    title: str,
+    body: str | None,
+    event_type: str,
+    reference_type: str | None = None,
+    reference_id: uuid.UUID | None = None,
+    context: dict | None = None,
+    muted_member_ids: set[uuid.UUID] | None = None,
+) -> None:
+    """96af343e: 활성 개인(member-scoped) WebhookConfig 보유 휴먼에게 알림 webhook 실POST.
+
+    `delivery_dispatcher.py` 워커 전용(자기 세션으로 호출). SSRF 검증·HMAC 서명·Discord URL
+    포맷·retry 는 dispatch_router._post_with_retry / app.core.ssrf 재사용. agent SSE 경로
     (route_dispatch_event)는 미변경(무회귀). 개별 POST 실패는 swallow → in-app 무영향.
 
-    muted_member_ids: story 75570ab8 — 호출자(dispatch_notification)가 이미 계산한 mute
-    집합을 넘기면 재조회 생략(Event-skip 판정과 동일 SSOT 재사용, 드리프트 방지). None이면
-    이 함수가 자체 조회(단독 호출 하위호환).
+    muted_member_ids: story 75570ab8 — 호출자가 이미 계산한 mute 집합을 넘기면 재조회 생략
+    (Event-skip 판정과 동일 SSOT 재사용, 드리프트 방지). None이면 이 함수가 자체 조회.
     """
     if not member_ids:
         return

--- a/backend/app/services/story_status_events.py
+++ b/backend/app/services/story_status_events.py
@@ -239,9 +239,11 @@ async def emit_story_status_changed(
     try:
         # AC2: story.status_changed 의 member-bound webhook 은 관련자(notify_ids)만 수신 → org-wide
         # 과다 fan-out 차단. member_id=null 진짜 activity-feed 브로드캐스트는 보존(preserve_broadcast).
+        # story #2460(§6 봉합②): 외부 I/O(webhook POST)를 요청 트랜잭션 밖으로 — outbox 경유.
         await fire_webhooks(
             db, org_id, "story.status_changed", event_data,
             recipient_member_ids=notify_ids,
+            via_outbox=True,
         )
     except Exception:
         pass
@@ -275,6 +277,8 @@ async def emit_story_status_changed(
                 reference_id=story.id,
                 # S2: 멀티프로젝트 에이전트 assignee를 스토리 프로젝트로 정확 라우팅
                 source_project_id=story.project_id,
+                # story #2460(§6 봉합②): 개인 webhook·Expo push 실배달을 요청 트랜잭션 밖으로.
+                via_outbox=True,
             )
         except Exception:
             pass

--- a/backend/app/services/webhook_dispatch.py
+++ b/backend/app/services/webhook_dispatch.py
@@ -37,29 +37,38 @@ async def fire_webhooks(
     *,
     recipient_member_ids: set[uuid.UUID] | None = None,
     preserve_broadcast: bool = True,
+    via_outbox: bool = False,
 ) -> None:
-    """org webhook 발화 — story #2460(§6 봉합②): 이제 즉시 POST하지 않고 `delivery_jobs`에
-    job row만 insert한다(caller의 세션·트랜잭션에 그대로 실림, commit은 caller 책임). 실제
-    HTTP 배달은 `delivery_dispatcher.py` 워커가 `_fire_webhooks_now()`로 수행한다.
+    """org webhook 발화 (c60dd33c).
 
-    호출부(file_conflict·assignee_changed·workflow_violation·story_status_events 등)는 이미
-    전부 fire-and-forget(반환값 미사용·예외 삼킴)로 호출하고 있어 시그니처·호출 방식 무변경
-    (지연 배달만 새로 생김 — 워커 폴링 주기만큼, 초 단위)."""
-    from app.models.delivery_job import DeliveryJob
+    story #2460(§6 봉합②, PO 스코프 확定 2026-08-05): outbox 경유는 **opt-in**이다
+    (``via_outbox=True``) — story_status_events.py 단 한 콜사이트만 켠다. 나머지 호출부
+    (file_conflict·assignee_changed·workflow_violation 등)는 기본값 False로 기존과 동일하게
+    이 함수 안에서 즉시 POST한다(behavior 무변경). ``via_outbox=True``면 즉시 POST 대신
+    `delivery_jobs`에 job row만 insert(caller의 세션·트랜잭션에 그대로 실림 — commit은
+    caller 책임, at-least-once) — 실제 HTTP 배달은 `delivery_dispatcher.py` 워커가 자기
+    세션으로 `_fire_webhooks_now()`를 부른다(요청 트랜잭션 밖에서 외부 I/O)."""
+    if via_outbox:
+        from app.models.delivery_job import DeliveryJob
 
-    session.add(
-        DeliveryJob(
-            org_id=org_id,
-            kind="org_webhook",
-            payload={
-                "event": event,
-                "data": data,
-                "recipient_member_ids": (
-                    [str(m) for m in recipient_member_ids] if recipient_member_ids is not None else None
-                ),
-                "preserve_broadcast": preserve_broadcast,
-            },
+        session.add(
+            DeliveryJob(
+                org_id=org_id,
+                kind="org_webhook",
+                payload={
+                    "event": event,
+                    "data": data,
+                    "recipient_member_ids": (
+                        [str(m) for m in recipient_member_ids] if recipient_member_ids is not None else None
+                    ),
+                    "preserve_broadcast": preserve_broadcast,
+                },
+            )
         )
+        return
+    await _fire_webhooks_now(
+        session, org_id, event, data,
+        recipient_member_ids=recipient_member_ids, preserve_broadcast=preserve_broadcast,
     )
 
 

--- a/backend/app/services/webhook_dispatch.py
+++ b/backend/app/services/webhook_dispatch.py
@@ -38,7 +38,41 @@ async def fire_webhooks(
     recipient_member_ids: set[uuid.UUID] | None = None,
     preserve_broadcast: bool = True,
 ) -> None:
-    """org webhook 발화 (c60dd33c).
+    """org webhook 발화 — story #2460(§6 봉합②): 이제 즉시 POST하지 않고 `delivery_jobs`에
+    job row만 insert한다(caller의 세션·트랜잭션에 그대로 실림, commit은 caller 책임). 실제
+    HTTP 배달은 `delivery_dispatcher.py` 워커가 `_fire_webhooks_now()`로 수행한다.
+
+    호출부(file_conflict·assignee_changed·workflow_violation·story_status_events 등)는 이미
+    전부 fire-and-forget(반환값 미사용·예외 삼킴)로 호출하고 있어 시그니처·호출 방식 무변경
+    (지연 배달만 새로 생김 — 워커 폴링 주기만큼, 초 단위)."""
+    from app.models.delivery_job import DeliveryJob
+
+    session.add(
+        DeliveryJob(
+            org_id=org_id,
+            kind="org_webhook",
+            payload={
+                "event": event,
+                "data": data,
+                "recipient_member_ids": (
+                    [str(m) for m in recipient_member_ids] if recipient_member_ids is not None else None
+                ),
+                "preserve_broadcast": preserve_broadcast,
+            },
+        )
+    )
+
+
+async def _fire_webhooks_now(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    event: str,
+    data: dict[str, Any],
+    *,
+    recipient_member_ids: set[uuid.UUID] | None = None,
+    preserve_broadcast: bool = True,
+) -> None:
+    """org webhook 실배달(c60dd33c) — `delivery_dispatcher.py` 워커 전용, 자기 세션으로 호출.
 
     **Discord 정규화(AC1)**: discord URL 에는 raw envelope 대신 ``{content|embeds}`` 변환
     (``to_discord_event_payload``)을 보낸다 — 기존엔 raw envelope POST 라 discord 전원 400.
@@ -47,8 +81,7 @@ async def fire_webhooks(
     **타겟 게이팅(AC2·opt-in)**: ``recipient_member_ids`` 가 주어지면 member-bound webhook
     (``member_id`` != null)은 그 집합의 멤버만 수신해 story/activity 의 org-wide 과다 fan-out 을
     차단한다. ``member_id IS NULL`` 진짜 activity-feed 브로드캐스트는 ``preserve_broadcast`` 시
-    보존. **``recipient_member_ids`` 가 None(기본)이면 게이팅 없음 = 기존 fan-out 동작**이라 타
-    호출부(file_conflict·assignee_changed·workflow_violation)는 무회귀.
+    보존. **``recipient_member_ids`` 가 None(기본)이면 게이팅 없음 = 기존 fan-out 동작**.
     """
     result = await session.execute(
         select(

--- a/backend/app/services/webhook_dispatch.py
+++ b/backend/app/services/webhook_dispatch.py
@@ -91,7 +91,34 @@ async def _fire_webhooks_now(
     (``member_id`` != null)은 그 집합의 멤버만 수신해 story/activity 의 org-wide 과다 fan-out 을
     차단한다. ``member_id IS NULL`` 진짜 activity-feed 브로드캐스트는 ``preserve_broadcast`` 시
     보존. **``recipient_member_ids`` 가 None(기본)이면 게이팅 없음 = 기존 fan-out 동작**.
-    """
+
+    story #2460 PO 리뷰(2026-08-05, F1) — 예전엔 이 함수가 ``session.execute`` 조회 直後
+    같은 함수 안에서 httpx POST 루프를 돌았다. POST 자체는 session을 안 건드리지만, 호출자
+    (`_deliver_one`)가 `async with async_session_factory() as session:` 로 세션을 물고
+    이 함수를 부르는 구조라 **세션(커넥션)이 POST 루프 내내 idle-in-transaction으로 열려
+    있었다** — 배달 中 트랜잭션을 안 잡는다는 docstring 계약과 실제가 어긋난 한 겹 얕은
+    원본. `_fetch_webhook_targets`(세션 필요) / `_send_webhook_targets`(세션 불요, 순수
+    httpx)로 쪼개 이 함수는 둘을 순차 호출하는 얇은 래퍼로 남긴다 — 기존 호출부
+    (via_outbox=False 12+ 콜사이트)는 시그니처·거동 무변경. 워커는 이제 이 함수를 안 부르고
+    fetch/send를 직접 호출해 그 사이에 세션을 반납한다(delivery_dispatcher.py 참조)."""
+    targets = await _fetch_webhook_targets(
+        session, org_id, event,
+        recipient_member_ids=recipient_member_ids, preserve_broadcast=preserve_broadcast,
+    )
+    await _send_webhook_targets(targets, event, data)
+
+
+async def _fetch_webhook_targets(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    event: str,
+    *,
+    recipient_member_ids: set[uuid.UUID] | None = None,
+    preserve_broadcast: bool = True,
+) -> list[dict[str, Any]]:
+    """활성 WebhookConfig를 조회해 이벤트/타겟 게이팅까지 마친 순수 dict 리스트로 반환한다.
+    세션 I/O는 이 함수에서 끝 — 반환 直後 호출자가 세션을 커밋/반납해야 한다(story #2460
+    PO 리뷰 F1, 위 `_fire_webhooks_now` docstring 참조)."""
     result = await session.execute(
         select(
             WebhookConfig.url,
@@ -100,24 +127,32 @@ async def _fire_webhooks_now(
             WebhookConfig.member_id,
         ).where(WebhookConfig.org_id == org_id, WebhookConfig.is_active.is_(True))
     )
-    configs = result.all()
-    if not configs:
-        return
+    targets: list[dict[str, Any]] = []
+    for url, secret, events, member_id in result.all():
+        if events and event not in events:
+            continue
+        # AC2 게이팅(opt-in): recipient_member_ids 주어진 경우만 적용. None=기존 동작.
+        if recipient_member_ids is not None:
+            if member_id is None:
+                if not preserve_broadcast:
+                    continue  # broadcast 인데 보존 끄면 drop
+            elif member_id not in recipient_member_ids:
+                continue  # member-bound 인데 관련자 아님 → drop(과다 fan-out 차단)
+        targets.append({"url": url, "secret": secret})
+    return targets
 
+
+async def _send_webhook_targets(targets: list[dict[str, Any]], event: str, data: dict[str, Any]) -> None:
+    """세션 없이 순수 HTTP POST만(story #2460 PO 리뷰 F1) — SSRF 재검증도 이 자리(발송
+    직전 재검증이 목적이라 fetch 단계로 옮기면 안 됨 — DNS rebinding 방지 의도가 죽는다)."""
+    if not targets:
+        return
     envelope_body = json.dumps({"event": event, "data": data})
     discord_body = json.dumps(to_discord_event_payload(event, data))
 
     async with httpx.AsyncClient(timeout=10.0, follow_redirects=False) as client:
-        for url, secret, events, member_id in configs:
-            if events and event not in events:
-                continue
-            # AC2 게이팅(opt-in): recipient_member_ids 주어진 경우만 적용. None=기존 동작.
-            if recipient_member_ids is not None:
-                if member_id is None:
-                    if not preserve_broadcast:
-                        continue  # broadcast 인데 보존 끄면 drop
-                elif member_id not in recipient_member_ids:
-                    continue  # member-bound 인데 관련자 아님 → drop(과다 fan-out 차단)
+        for t in targets:
+            url, secret = t["url"], t["secret"]
             # dispatch 시 IP 재검증 (DNS rebinding 방지)
             try:
                 await validate_webhook_url_async(url)

--- a/backend/ee/services/expo_push.py
+++ b/backend/ee/services/expo_push.py
@@ -176,93 +176,144 @@ async def _deliver_expo_push_now(
     - DeviceNotRegistered ticket → 그 토큰 is_active=false(자동 만료). 재발송 대상서 제외됨.
     - story #1953(P1a-S3): project_id/story_id/sprint_id는 딥링크 매니페스트 Layer 2 계약
       보강 필드 — dispatch_notification()이 이미 아는 값을 그대로 흘려보낸다(신규 조회 없음).
-    """
+
+    story #2460 PO 리뷰(2026-08-05, F1) — 예전엔 이 함수가 DB 조회 直後 같은 함수 안에서
+    Expo 발송(청크별 네트워크 I/O)까지 돌아, 호출자(`_deliver_one`)의 세션이 그 내내
+    idle-in-transaction으로 열려 있었다(webhook_dispatch.py `_fire_webhooks_now`와 동형
+    결함). `_fetch_expo_push_targets`(세션)/`_send_expo_push_targets`(세션 불요, dead_tokens
+    반환)/`_finalize_expo_push_dead_tokens`(세션, 발송 後 토큰 비활성화)로 3분할 — 이 함수는
+    셋을 순차 호출 + best-effort try/except로 감싸는 얇은 래퍼로 남긴다(기존 호출부
+    via_outbox=False 시그니처·거동 무변경). 워커는 이 함수를 안 부르고 세 조각을 직접
+    호출해 fetch/finalize 사이(발송 구간)엔 세션을 안 쥔다."""
     try:
-        if not member_ids:
-            return
-        muted = muted_member_ids or set()
-        targets = [m for m in member_ids if m not in muted]
-        if not targets:
-            return
-
-        rows = await db.execute(
-            select(PushDevice).where(
-                PushDevice.org_id == org_id,
-                PushDevice.member_id.in_(targets),
-                PushDevice.is_active.is_(True),
-            )
-        )
-        devices = list(rows.scalars().all())
-        if not devices:
-            return
-
-        # 딥링크용 data(4096B 상한 고려 최소 필드만 — 탭→화면 착지에 필요한 것).
-        data_payload = _build_push_data_payload(
-            event_type=event_type, org_id=org_id, project_id=project_id,
+        targets = await _fetch_expo_push_targets(db, org_id, member_ids, muted_member_ids=muted_member_ids)
+        dead_tokens = await _send_expo_push_targets(
+            targets, title=title, body=body, event_type=event_type, org_id=org_id,
             reference_type=reference_type, reference_id=reference_id,
-            story_id=story_id, sprint_id=sprint_id,
+            project_id=project_id, story_id=story_id, sprint_id=sprint_id,
         )
-
-        messages = [
-            {
-                "to": d.expo_push_token,
-                "title": title,
-                "body": body or "",
-                "data": data_payload,
-                "sound": "default",
-                "priority": "high",
-                # story 1934/1935 후속(2026-07-17): Android 8+는 notification channel의
-                # importance가 실제 헤드업/소리 여부를 결정(priority:"high"는 FCM 배달
-                # 우선순위일 뿐 UI 표시와 무관) — 민 앱이 HIGH importance로 등록하는 채널
-                # ID와 정확히 일치해야 한다(Expo 관례 "default"). 앱측 채널 ID가 다르면
-                # 여기도 맞춰야 함.
-                "channelId": "default",
-            }
-            for d in devices
-        ]
-
-        dead_tokens: list[str] = []
-        ok_count = 0
-        error_count = 0
-        error_reasons: dict[str, int] = {}
-        for i in range(0, len(messages), _EXPO_MAX_BATCH):
-            chunk = messages[i : i + _EXPO_MAX_BATCH]
-            chunk_devices = devices[i : i + _EXPO_MAX_BATCH]
-            tickets = await _expo_send_chunk(chunk)
-            # ticket 은 메시지와 동순서. 개수 불일치(부분 응답) 시 zip 이 짧은 쪽 기준(안전).
-            for dev, ticket in zip(chunk_devices, tickets):
-                if isinstance(ticket, dict) and ticket.get("status") == "error":
-                    error_count += 1
-                    err = (ticket.get("details") or {}).get("error") or ticket.get("message") or "unknown"
-                    error_reasons[err] = error_reasons.get(err, 0) + 1
-                    if err == "DeviceNotRegistered":
-                        dead_tokens.append(dev.expo_push_token)
-                elif isinstance(ticket, dict) and ticket.get("status") == "ok":
-                    ok_count += 1
-
-        # 2026-07-28(#2289): 성공 티켓은 이전까지 어디에도 안 남아 "서버가 쐈는데 실패" vs
-        # "서버가 아예 안 쐈다"를 로그만으로 못 갈랐다(둘 다 조용함) — 매 발송마다 요약을 남긴다.
-        # error_reasons는 Expo의 고정 에러 코드(DeviceNotRegistered·InvalidCredentials 등)만
-        # 담는다 — 토큰 값은 절대 안 남긴다(시크릿에 준하는 취급).
-        logger.info(
-            "expo push: sent org=%s event=%s devices=%d ok=%d error=%d reasons=%s",
-            org_id, event_type, len(devices), ok_count, error_count, error_reasons or None,
-        )
-
-        if dead_tokens:
-            await db.execute(
-                update(PushDevice)
-                .where(
-                    PushDevice.org_id == org_id,
-                    PushDevice.expo_push_token.in_(dead_tokens),
-                )
-                .values(is_active=False)
-            )
-            await db.flush()
-            logger.info("expo push: deactivated %d DeviceNotRegistered token(s)", len(dead_tokens))
+        await _finalize_expo_push_dead_tokens(db, org_id, dead_tokens)
     except Exception:
         # best-effort — 발송 실패가 알림 파이프라인을 되돌리지 않는다(AC: 비중단).
         logger.warning(
             "deliver_expo_push failed (swallowed·best-effort) org=%s event=%s",
             org_id, event_type, exc_info=True,
         )
+
+
+async def _fetch_expo_push_targets(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    member_ids: list[uuid.UUID],
+    *,
+    muted_member_ids: set[uuid.UUID] | None = None,
+) -> list[dict]:
+    """활성 push_devices를 조회해 mute 필터까지 마친 순수 dict 리스트로 반환한다. 세션 I/O는
+    이 함수에서 끝(story #2460 PO 리뷰 F1)."""
+    if not member_ids:
+        return []
+    muted = muted_member_ids or set()
+    targets = [m for m in member_ids if m not in muted]
+    if not targets:
+        return []
+
+    rows = await db.execute(
+        select(PushDevice).where(
+            PushDevice.org_id == org_id,
+            PushDevice.member_id.in_(targets),
+            PushDevice.is_active.is_(True),
+        )
+    )
+    return [{"expo_push_token": d.expo_push_token} for d in rows.scalars().all()]
+
+
+async def _send_expo_push_targets(
+    devices: list[dict],
+    *,
+    title: str,
+    body: str | None,
+    event_type: str,
+    org_id: uuid.UUID,
+    reference_type: str | None = None,
+    reference_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    story_id: uuid.UUID | None = None,
+    sprint_id: uuid.UUID | None = None,
+) -> list[str]:
+    """세션 없이 순수 Expo 발송만(story #2460 PO 리뷰 F1). 반환값 = dead_tokens(호출자가
+    `_finalize_expo_push_dead_tokens`로 반영)."""
+    if not devices:
+        return []
+
+    # 딥링크용 data(4096B 상한 고려 최소 필드만 — 탭→화면 착지에 필요한 것).
+    data_payload = _build_push_data_payload(
+        event_type=event_type, org_id=org_id, project_id=project_id,
+        reference_type=reference_type, reference_id=reference_id,
+        story_id=story_id, sprint_id=sprint_id,
+    )
+
+    messages = [
+        {
+            "to": d["expo_push_token"],
+            "title": title,
+            "body": body or "",
+            "data": data_payload,
+            "sound": "default",
+            "priority": "high",
+            # story 1934/1935 후속(2026-07-17): Android 8+는 notification channel의
+            # importance가 실제 헤드업/소리 여부를 결정(priority:"high"는 FCM 배달
+            # 우선순위일 뿐 UI 표시와 무관) — 민 앱이 HIGH importance로 등록하는 채널
+            # ID와 정확히 일치해야 한다(Expo 관례 "default"). 앱측 채널 ID가 다르면
+            # 여기도 맞춰야 함.
+            "channelId": "default",
+        }
+        for d in devices
+    ]
+
+    dead_tokens: list[str] = []
+    ok_count = 0
+    error_count = 0
+    error_reasons: dict[str, int] = {}
+    for i in range(0, len(messages), _EXPO_MAX_BATCH):
+        chunk = messages[i:i + _EXPO_MAX_BATCH]
+        chunk_devices = devices[i:i + _EXPO_MAX_BATCH]
+        tickets = await _expo_send_chunk(chunk)
+        # ticket 은 메시지와 동순서. 개수 불일치(부분 응답) 시 zip 이 짧은 쪽 기준(안전).
+        for dev, ticket in zip(chunk_devices, tickets):
+            if isinstance(ticket, dict) and ticket.get("status") == "error":
+                error_count += 1
+                err = (ticket.get("details") or {}).get("error") or ticket.get("message") or "unknown"
+                error_reasons[err] = error_reasons.get(err, 0) + 1
+                if err == "DeviceNotRegistered":
+                    dead_tokens.append(dev["expo_push_token"])
+            elif isinstance(ticket, dict) and ticket.get("status") == "ok":
+                ok_count += 1
+
+    # 2026-07-28(#2289): 성공 티켓은 이전까지 어디에도 안 남아 "서버가 쐈는데 실패" vs
+    # "서버가 아예 안 쐈다"를 로그만으로 못 갈랐다(둘 다 조용함) — 매 발송마다 요약을 남긴다.
+    # error_reasons는 Expo의 고정 에러 코드(DeviceNotRegistered·InvalidCredentials 등)만
+    # 담는다 — 토큰 값은 절대 안 남긴다(시크릿에 준하는 취급).
+    logger.info(
+        "expo push: sent org=%s event=%s devices=%d ok=%d error=%d reasons=%s",
+        org_id, event_type, len(devices), ok_count, error_count, error_reasons or None,
+    )
+    return dead_tokens
+
+
+async def _finalize_expo_push_dead_tokens(
+    db: AsyncSession, org_id: uuid.UUID, dead_tokens: list[str],
+) -> None:
+    """발송 後 확인된 DeviceNotRegistered 토큰을 비활성화(story #2460 PO 리뷰 F1 — 발송
+    구간과 분리된 별도 짧은 세션에서 호출하는 것을 전제)."""
+    if not dead_tokens:
+        return
+    await db.execute(
+        update(PushDevice)
+        .where(
+            PushDevice.org_id == org_id,
+            PushDevice.expo_push_token.in_(dead_tokens),
+        )
+        .values(is_active=False)
+    )
+    await db.flush()
+    logger.info("expo push: deactivated %d DeviceNotRegistered token(s)", len(dead_tokens))

--- a/backend/ee/services/expo_push.py
+++ b/backend/ee/services/expo_push.py
@@ -106,35 +106,48 @@ async def deliver_expo_push(
     project_id: uuid.UUID | None = None,
     story_id: uuid.UUID | None = None,
     sprint_id: uuid.UUID | None = None,
+    via_outbox: bool = False,
 ) -> None:
-    """story #2460(§6 봉합②): Expo push 실발송을 즉시 하지 않고 `delivery_jobs`에 job row만
-    insert(caller 세션·트랜잭션에 실림, commit은 caller 책임) — 실 발송은
-    `delivery_dispatcher.py` 워커가 `_deliver_expo_push_now()`로 수행한다. 호출부
-    (dispatch_notification)는 이미 fire-and-forget이라 무변경."""
+    """story #2460(§6 봉합②, PO 스코프 확定 2026-08-05): outbox 경유는 **opt-in**이다
+    (``via_outbox=True``) — dispatch_notification 호출부 중 story_status_events.py·
+    conversations.py send_message 둘만 켠다. 나머지 dispatch_notification 호출부는 기본값
+    False로 기존과 동일하게 이 함수 안에서 즉시 발송한다(behavior 무변경).
+    ``via_outbox=True``면 즉시 발송 대신 `delivery_jobs`에 job row만 insert(caller
+    세션·트랜잭션에 실림, commit은 caller 책임 — at-least-once) — 실 발송은
+    `delivery_dispatcher.py` 워커가 자기 세션으로 `_deliver_expo_push_now()`를 수행한다
+    (요청 트랜잭션 밖에서 외부 I/O)."""
     if not member_ids:
         return
-    from app.models.delivery_job import DeliveryJob
+    if via_outbox:
+        from app.models.delivery_job import DeliveryJob
 
-    db.add(
-        DeliveryJob(
-            org_id=org_id,
-            kind="expo_push",
-            payload={
-                "member_ids": [str(m) for m in member_ids],
-                "title": title,
-                "body": body,
-                "event_type": event_type,
-                "reference_type": reference_type,
-                "reference_id": str(reference_id) if reference_id else None,
-                "context": context,
-                "muted_member_ids": (
-                    [str(m) for m in muted_member_ids] if muted_member_ids is not None else None
-                ),
-                "project_id": str(project_id) if project_id else None,
-                "story_id": str(story_id) if story_id else None,
-                "sprint_id": str(sprint_id) if sprint_id else None,
-            },
+        db.add(
+            DeliveryJob(
+                org_id=org_id,
+                kind="expo_push",
+                payload={
+                    "member_ids": [str(m) for m in member_ids],
+                    "title": title,
+                    "body": body,
+                    "event_type": event_type,
+                    "reference_type": reference_type,
+                    "reference_id": str(reference_id) if reference_id else None,
+                    "context": context,
+                    "muted_member_ids": (
+                        [str(m) for m in muted_member_ids] if muted_member_ids is not None else None
+                    ),
+                    "project_id": str(project_id) if project_id else None,
+                    "story_id": str(story_id) if story_id else None,
+                    "sprint_id": str(sprint_id) if sprint_id else None,
+                },
+            )
         )
+        return
+    await _deliver_expo_push_now(
+        db, org_id, member_ids, title=title, body=body, event_type=event_type,
+        reference_type=reference_type, reference_id=reference_id, context=context,
+        muted_member_ids=muted_member_ids, project_id=project_id, story_id=story_id,
+        sprint_id=sprint_id,
     )
 
 

--- a/backend/ee/services/expo_push.py
+++ b/backend/ee/services/expo_push.py
@@ -107,7 +107,55 @@ async def deliver_expo_push(
     story_id: uuid.UUID | None = None,
     sprint_id: uuid.UUID | None = None,
 ) -> None:
-    """활성 push_devices 로 Expo push 발송(웹훅과 나란한 별개 채널).
+    """story #2460(§6 봉합②): Expo push 실발송을 즉시 하지 않고 `delivery_jobs`에 job row만
+    insert(caller 세션·트랜잭션에 실림, commit은 caller 책임) — 실 발송은
+    `delivery_dispatcher.py` 워커가 `_deliver_expo_push_now()`로 수행한다. 호출부
+    (dispatch_notification)는 이미 fire-and-forget이라 무변경."""
+    if not member_ids:
+        return
+    from app.models.delivery_job import DeliveryJob
+
+    db.add(
+        DeliveryJob(
+            org_id=org_id,
+            kind="expo_push",
+            payload={
+                "member_ids": [str(m) for m in member_ids],
+                "title": title,
+                "body": body,
+                "event_type": event_type,
+                "reference_type": reference_type,
+                "reference_id": str(reference_id) if reference_id else None,
+                "context": context,
+                "muted_member_ids": (
+                    [str(m) for m in muted_member_ids] if muted_member_ids is not None else None
+                ),
+                "project_id": str(project_id) if project_id else None,
+                "story_id": str(story_id) if story_id else None,
+                "sprint_id": str(sprint_id) if sprint_id else None,
+            },
+        )
+    )
+
+
+async def _deliver_expo_push_now(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    member_ids: list[uuid.UUID],
+    *,
+    title: str,
+    body: str | None,
+    event_type: str,
+    reference_type: str | None = None,
+    reference_id: uuid.UUID | None = None,
+    context: dict | None = None,
+    muted_member_ids: set[uuid.UUID] | None = None,
+    project_id: uuid.UUID | None = None,
+    story_id: uuid.UUID | None = None,
+    sprint_id: uuid.UUID | None = None,
+) -> None:
+    """활성 push_devices 로 Expo push 실발송(웹훅과 나란한 별개 채널) —
+    `delivery_dispatcher.py` 워커 전용(자기 세션으로 호출).
 
     - 대상 = enabled 멤버(설정 통과) − global mute(능동 push off). 웹훅 유무와 독립.
     - 디바이스당 1발(이중발송 0). 배치 ≤100·메시지 최소화(≤4096B).

--- a/backend/tests/test_2460_delivery_outbox.py
+++ b/backend/tests/test_2460_delivery_outbox.py
@@ -1,0 +1,237 @@
+"""story #2460(§6 봉합②): 웹훅/푸시 배달 트랜잭셔널 아웃박스 테스트.
+
+PO 확定 스코프(2026-08-05): ①story_status_events ②conversations send_message 두 콜사이트만
+outbox 경유(via_outbox=True) — 나머지 12+ dispatch_notification/fire_webhooks 콜사이트는
+기본값 False로 즉시 배달(behavior 무변경). 이 파일은 그 opt-in 라우팅 자체와, 워커
+(delivery_dispatcher.py)의 claim/배달/재시도 FSM을 correctness 축(중복·유실·순서·재시도)으로
+검증한다. ⛔공유 dev 백엔드에 대한 부하테스트는 이 파일 스코프 밖(PO 명시 금지) — 전부
+mock 세션 또는 로컬 PG로만 검증한다.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+def org_id():
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def mock_session():
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.execute = AsyncMock()
+    session.commit = AsyncMock()
+    return session
+
+
+# ─── fire_webhooks: via_outbox opt-in 라우팅 ─────────────────────────────────
+
+@pytest.mark.anyio
+async def test_fire_webhooks_default_delivers_immediately_no_enqueue(mock_session, org_id):
+    """via_outbox 미지정(기본 False) — DeliveryJob enqueue 없이 즉시 WebhookConfig 조회 경로를
+    탄다(behavior 무변경 — 12+ 기존 콜사이트가 전제하는 계약)."""
+    from app.services.webhook_dispatch import fire_webhooks
+
+    empty_result = MagicMock()
+    empty_result.all.return_value = []  # WebhookConfig 0건 → 즉시 return(httpx 불요)
+    mock_session.execute.return_value = empty_result
+
+    await fire_webhooks(mock_session, org_id, "story.status_changed", {"x": 1})
+
+    mock_session.execute.assert_called_once()  # WebhookConfig SELECT가 실제로 돔
+    mock_session.add.assert_not_called()  # DeliveryJob enqueue 안 함
+
+
+@pytest.mark.anyio
+async def test_fire_webhooks_via_outbox_enqueues_without_immediate_query(mock_session, org_id):
+    """via_outbox=True — WebhookConfig 즉시 조회(session.execute) 없이 DeliveryJob만 add."""
+    from app.models.delivery_job import DeliveryJob
+    from app.services.webhook_dispatch import fire_webhooks
+
+    await fire_webhooks(
+        mock_session, org_id, "story.status_changed", {"story_id": "s1"},
+        recipient_member_ids={uuid.uuid4()}, via_outbox=True,
+    )
+
+    mock_session.execute.assert_not_called()  # 즉시 배달 경로 안 탐(외부 I/O 0)
+    mock_session.add.assert_called_once()
+    job = mock_session.add.call_args[0][0]
+    assert isinstance(job, DeliveryJob)
+    assert job.kind == "org_webhook"
+    assert job.org_id == org_id
+    assert job.payload["event"] == "story.status_changed"
+
+
+# ─── dispatch_notification: via_outbox가 두 배달 채널 모두에 전파 ────────────
+
+@pytest.mark.anyio
+async def test_dispatch_notification_via_outbox_propagates_to_both_channels(mock_session, org_id):
+    """via_outbox=True로 부르면 _deliver_personal_webhooks·deliver_expo_push 둘 다
+    via_outbox=True로 호출돼야 한다(story_status_events/conversations 콜사이트가 기대하는
+    계약 — 한쪽만 새면 그 채널만 여전히 요청 트랜잭션 안에서 외부 I/O를 한다)."""
+    from app.services.notification_dispatch import dispatch_notification
+
+    member_id = uuid.uuid4()
+    settings_result = MagicMock()
+    settings_result.all.return_value = []  # 설정 없음 → 기본 enabled
+    webhook_member_result = MagicMock()
+    webhook_member_result.scalars.return_value.all.return_value = []
+    muted_result = MagicMock()
+    muted_result.scalars.return_value.all.return_value = []
+    members_result = MagicMock()
+    member_row = MagicMock(id=member_id, user_id=uuid.uuid4(), type="human", project_id=None)
+    members_result.all.return_value = [member_row]
+
+    mock_session.execute.side_effect = [settings_result, webhook_member_result, muted_result, members_result]
+
+    with patch("app.services.notification_dispatch._deliver_personal_webhooks", new=AsyncMock()) as mock_wh, \
+         patch("app.core.config.settings.license_consent", "agreed"), \
+         patch("ee.services.expo_push.deliver_expo_push", new=AsyncMock()) as mock_push:
+        await dispatch_notification(
+            mock_session, org_id=org_id, event_type="conversation.message",
+            target_member_ids=[member_id], title="t", via_outbox=True,
+        )
+
+    assert mock_wh.call_args.kwargs["via_outbox"] is True
+    assert mock_push.call_args.kwargs["via_outbox"] is True
+
+
+@pytest.mark.anyio
+async def test_dispatch_notification_default_via_outbox_false(mock_session, org_id):
+    """기본값(via_outbox 미지정)이 기존 12+ 콜사이트 계약대로 False로 전파돼야 한다."""
+    from app.services.notification_dispatch import dispatch_notification
+
+    member_id = uuid.uuid4()
+    settings_result = MagicMock()
+    settings_result.all.return_value = []
+    webhook_member_result = MagicMock()
+    webhook_member_result.scalars.return_value.all.return_value = []
+    muted_result = MagicMock()
+    muted_result.scalars.return_value.all.return_value = []
+    members_result = MagicMock()
+    member_row = MagicMock(id=member_id, user_id=uuid.uuid4(), type="human", project_id=None)
+    members_result.all.return_value = [member_row]
+
+    mock_session.execute.side_effect = [settings_result, webhook_member_result, muted_result, members_result]
+
+    with patch("app.services.notification_dispatch._deliver_personal_webhooks", new=AsyncMock()) as mock_wh:
+        await dispatch_notification(
+            mock_session, org_id=org_id, event_type="conversation.message",
+            target_member_ids=[member_id], title="t",
+        )
+
+    assert mock_wh.call_args.kwargs["via_outbox"] is False
+
+
+# ─── delivery_dispatcher: kind별 라우팅 + 성공/실패 FSM ──────────────────────
+
+def _job(kind: str, **payload) -> dict:
+    return {
+        "id": uuid.uuid4(), "org_id": uuid.uuid4(), "kind": kind,
+        "payload": payload, "attempts": 0,
+    }
+
+
+def _update_values(update_stmt) -> dict:
+    """update(...).values(...) 호출에서 컬럼명→바인딩값 dict 추출(테스트 검증용)."""
+    return {col.name: bind.value for col, bind in update_stmt._values.items()}
+
+
+@pytest.mark.anyio
+async def test_deliver_one_org_webhook_routes_to_now_and_marks_delivered():
+    from app.services.delivery_dispatcher import _deliver_one
+
+    job = _job("org_webhook", event="story.status_changed", data={"a": 1}, preserve_broadcast=True)
+
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    session.commit = AsyncMock()
+    factory_cm = AsyncMock()
+    factory_cm.__aenter__ = AsyncMock(return_value=session)
+    factory_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.core.database.async_session_factory", return_value=factory_cm), \
+         patch("app.services.webhook_dispatch._fire_webhooks_now", new=AsyncMock()) as mock_now:
+        await _deliver_one(job)
+
+    mock_now.assert_awaited_once()
+    values = _update_values(session.execute.call_args[0][0])
+    assert values["status"] == "delivered"
+    assert values["delivered_at"] is not None
+
+
+@pytest.mark.anyio
+async def test_deliver_one_unknown_kind_raises_and_retries():
+    """미지원 kind — 예외로 잡혀 attempts<MAX면 status='pending'로 되돌아간다(다음 tick 재시도)."""
+    from app.services.delivery_dispatcher import _deliver_one
+
+    job = _job("bogus_kind")
+
+    delivery_session = AsyncMock()
+    delivery_session.execute = AsyncMock(side_effect=RuntimeError("should not reach update"))
+
+    status_session = AsyncMock()
+    status_session.execute = AsyncMock()
+    status_session.commit = AsyncMock()
+
+    sessions = [delivery_session, status_session]
+
+    class _FakeFactory:
+        def __call__(self):
+            return self
+
+        async def __aenter__(self):
+            return sessions.pop(0)
+
+        async def __aexit__(self, *a):
+            return False
+
+    with patch("app.core.database.async_session_factory", _FakeFactory()):
+        await _deliver_one(job)
+
+    # status_session에서 status='pending' + last_error 세팅 UPDATE가 실행됐어야 한다.
+    status_session.execute.assert_awaited_once()
+    status_session.commit.assert_awaited_once()
+    values = _update_values(status_session.execute.call_args[0][0])
+    assert values["status"] == "pending"
+    assert "bogus_kind" in values["last_error"]
+
+
+@pytest.mark.anyio
+async def test_deliver_one_terminal_after_max_attempts():
+    """attempts가 이미 _MAX_ATTEMPTS-1(claim에서 +1되면 MAX)이면 실패 시 status='failed'(terminal)."""
+    from app.services.delivery_dispatcher import _MAX_ATTEMPTS, _deliver_one
+
+    job = _job("bogus_kind")
+    job["attempts"] = _MAX_ATTEMPTS - 1  # _deliver_one 내부에서 +1 → _MAX_ATTEMPTS 도달
+
+    status_session = AsyncMock()
+    status_session.execute = AsyncMock()
+    status_session.commit = AsyncMock()
+
+    class _FakeFactory:
+        def __call__(self):
+            return self
+
+        async def __aenter__(self):
+            return status_session
+
+        async def __aexit__(self, *a):
+            return False
+
+    with patch("app.core.database.async_session_factory", _FakeFactory()):
+        await _deliver_one(job)
+
+    values = _update_values(status_session.execute.call_args[0][0])
+    assert values["status"] == "failed"  # terminal — 다음 tick부터 pending SELECT에서 영구 제외

--- a/backend/tests/test_2460_delivery_outbox.py
+++ b/backend/tests/test_2460_delivery_outbox.py
@@ -150,22 +150,31 @@ def _update_values(update_stmt) -> dict:
 
 @pytest.mark.anyio
 async def test_deliver_one_org_webhook_routes_to_now_and_marks_delivered():
+    """story #2460 PO 리뷰(F1) 후: _deliver_one이 fetch(세션)→send(세션 없음)로 쪼개졌으므로
+    fetch 단계의 session.execute가 빈 targets를 내도록 두고, send가 실제로 호출되는지만
+    확인 — 세션·send가 서로 다른 단계에서 불린다는 것 자체가 이 테스트의 핵심 계약."""
     from app.services.delivery_dispatcher import _deliver_one
 
     job = _job("org_webhook", event="story.status_changed", data={"a": 1}, preserve_broadcast=True)
 
+    fetch_result = MagicMock()
+    fetch_result.all.return_value = []  # WebhookConfig 0건 — send는 빈 targets로 호출됨
+
     session = AsyncMock()
-    session.execute = AsyncMock()
+    session.execute = AsyncMock(return_value=fetch_result)
     session.commit = AsyncMock()
     factory_cm = AsyncMock()
     factory_cm.__aenter__ = AsyncMock(return_value=session)
     factory_cm.__aexit__ = AsyncMock(return_value=False)
 
     with patch("app.core.database.async_session_factory", return_value=factory_cm), \
-         patch("app.services.webhook_dispatch._fire_webhooks_now", new=AsyncMock()) as mock_now:
+         patch("app.services.webhook_dispatch._send_webhook_targets", new=AsyncMock()) as mock_send:
         await _deliver_one(job)
 
-    mock_now.assert_awaited_once()
+    mock_send.assert_awaited_once()
+    assert mock_send.call_args[0][0] == []  # fetch가 빈 리스트를 그대로 send에 넘김
+    # 마지막 session.execute 호출이 status='delivered' UPDATE여야 한다(fetch의 SELECT는
+    # 첫 호출 — 두 호출 다 같은 mock session을 거치므로 call_args는 마지막 호출을 가리킨다).
     values = _update_values(session.execute.call_args[0][0])
     assert values["status"] == "delivered"
     assert values["delivered_at"] is not None
@@ -173,31 +182,24 @@ async def test_deliver_one_org_webhook_routes_to_now_and_marks_delivered():
 
 @pytest.mark.anyio
 async def test_deliver_one_unknown_kind_raises_and_retries():
-    """미지원 kind — 예외로 잡혀 attempts<MAX면 status='pending'로 되돌아간다(다음 tick 재시도)."""
+    """미지원 kind — 예외로 잡혀 attempts<MAX면 status='pending'로 되돌아간다(다음 tick 재시도).
+
+    story #2460 PO 리뷰(F1) 후: bogus_kind는 org_webhook/personal_webhook/expo_push
+    어느 분기에도 안 걸려 fetch용 세션 자체가 안 열린다(kind 판별이 전부 session-open 분기
+    「안」이라) — `ValueError`가 세션 밖에서 즉시 발생하므로 `async_session_factory()`는
+    except 블록의 상태갱신용 1회만 불린다(구조 변경 전엔 delivery용+상태갱신용 2회)."""
     from app.services.delivery_dispatcher import _deliver_one
 
     job = _job("bogus_kind")
 
-    delivery_session = AsyncMock()
-    delivery_session.execute = AsyncMock(side_effect=RuntimeError("should not reach update"))
-
     status_session = AsyncMock()
     status_session.execute = AsyncMock()
     status_session.commit = AsyncMock()
+    factory_cm = AsyncMock()
+    factory_cm.__aenter__ = AsyncMock(return_value=status_session)
+    factory_cm.__aexit__ = AsyncMock(return_value=False)
 
-    sessions = [delivery_session, status_session]
-
-    class _FakeFactory:
-        def __call__(self):
-            return self
-
-        async def __aenter__(self):
-            return sessions.pop(0)
-
-        async def __aexit__(self, *a):
-            return False
-
-    with patch("app.core.database.async_session_factory", _FakeFactory()):
+    with patch("app.core.database.async_session_factory", return_value=factory_cm):
         await _deliver_one(job)
 
     # status_session에서 status='pending' + last_error 세팅 UPDATE가 실행됐어야 한다.

--- a/backend/tests/test_2460_delivery_outbox_realdb.py
+++ b/backend/tests/test_2460_delivery_outbox_realdb.py
@@ -1,0 +1,219 @@
+"""story #2460(§6 봉합②) realdb 검증 — mock으로는 못 잡는 트랜잭션/락 시맨틱스.
+
+PO 확定 축(2026-08-05): 「중복·유실·순서·재시도」. 실 Postgres 없이는 다음이 검증 불가능:
+  ①원자성 — enqueue insert가 caller 트랜잭션 rollback과 함께 진짜 사라지는가(mock session은
+    rollback을 흉내만 낼 뿐 실제 미반영을 증명 못 한다).
+  ②FOR UPDATE SKIP LOCKED — 두 동시 claim이 정말 겹치지 않는가(mock으로는 SQL 자체의 락
+    시맨틱스를 못 잰다).
+  ③생성 순서(created_at ASC) — SELECT 정렬이 실제로 그 순서를 내는가.
+⛔공유 dev 백엔드 접속 없음 — 로컬 Postgres(``PARITY_TEST_DATABASE_URL``)만 사용. 미설정 시
+skip(CI에 로컬 PG가 없으면 이 파일 전체가 조용히 스킵 — non-realdb 스위트와 동일 관례).
+
+⚠️engine/session은 fixture가 아니라 매 테스트 함수 본문 안에서 직접 만든다(story #2459
+realdb 테스트 관례 그대로 재사용) — async-generator fixture로 만들면 pytest-asyncio/anyio의
+loop 관리가 갈려 asyncpg가 "attached to a different loop"로 죽는 것을 이 세션에서 직접
+재현했다(engine이 한 fixture의 loop에서 만들어지고 테스트 본문은 다른 loop에서 돎).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="realdb 테스트는 로컬 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _clean_delivery_jobs(engine) -> None:
+    from app.models.delivery_job import DeliveryJob
+
+    async with engine.begin() as conn:
+        await conn.execute(DeliveryJob.__table__.delete())
+
+
+# ─── ①원자성: caller 트랜잭션 rollback = outbox row도 사라짐 ────────────────
+
+@pytest.mark.anyio
+async def test_enqueue_rolls_back_with_caller_transaction():
+    from app.models.delivery_job import DeliveryJob
+    from app.services.webhook_dispatch import fire_webhooks
+
+    engine = create_async_engine(_async_url())
+    try:
+        await _clean_delivery_jobs(engine)
+        org_id = uuid.uuid4()
+        async with AsyncSession(engine) as session:
+            await fire_webhooks(session, org_id, "story.status_changed", {"x": 1}, via_outbox=True)
+            # commit 없이 rollback — get_db()의 except 분기(session.rollback())와 동형.
+            await session.rollback()
+
+        async with AsyncSession(engine) as verify:
+            rows = (await verify.execute(
+                select(DeliveryJob).where(DeliveryJob.org_id == org_id)
+            )).scalars().all()
+        assert rows == []  # rollback 됐으면 진짜로 안 남아야 한다 — "원자적"의 핵심 증거.
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_enqueue_persists_with_caller_commit():
+    from app.models.delivery_job import DeliveryJob
+    from app.services.webhook_dispatch import fire_webhooks
+
+    engine = create_async_engine(_async_url())
+    try:
+        await _clean_delivery_jobs(engine)
+        org_id = uuid.uuid4()
+        async with AsyncSession(engine) as session:
+            await fire_webhooks(session, org_id, "story.status_changed", {"x": 1}, via_outbox=True)
+            await session.commit()
+
+        async with AsyncSession(engine) as verify:
+            rows = (await verify.execute(
+                select(DeliveryJob).where(DeliveryJob.org_id == org_id)
+            )).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].status == "pending"
+        assert rows[0].kind == "org_webhook"
+    finally:
+        await engine.dispose()
+
+
+# ─── ②FOR UPDATE SKIP LOCKED: 동시 claim이 겹치지 않음(중복배달 최소화) ─────
+
+@pytest.mark.anyio
+async def test_concurrent_claims_do_not_overlap():
+    """두 워커 인스턴스가 동시에 폴링해도(락이 열려 있는 동안은) 같은 job을 안 집는다 —
+    at-least-once의 "least"가 실제로 SKIP LOCKED로 담보되는지의 핵심 증거."""
+    from app.models.delivery_job import DeliveryJob
+
+    engine = create_async_engine(_async_url())
+    try:
+        await _clean_delivery_jobs(engine)
+        org_id = uuid.uuid4()
+        # expire_on_commit=False: commit 後 job_objs 속성 접근이 지금 여기서 딱 재현한
+        # #2459류 MissingGreenlet(동기 컨텍스트 lazy-load)에 걸리지 않게.
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            job_objs = [
+                DeliveryJob(org_id=org_id, kind="org_webhook", payload={"event": "x", "data": {}})
+                for _ in range(10)
+            ]
+            for j in job_objs:
+                session.add(j)
+            await session.commit()
+            all_ids = {j.id for j in job_objs}
+
+        session_a = AsyncSession(engine)
+        session_b = AsyncSession(engine)
+        try:
+            rows_a = (await session_a.execute(
+                select(DeliveryJob.id).where(DeliveryJob.status == "pending")
+                .order_by(DeliveryJob.created_at.asc()).limit(5).with_for_update(skip_locked=True)
+            )).scalars().all()
+            rows_b = (await session_b.execute(
+                select(DeliveryJob.id).where(DeliveryJob.status == "pending")
+                .order_by(DeliveryJob.created_at.asc()).limit(5).with_for_update(skip_locked=True)
+            )).scalars().all()
+            ids_a, ids_b = set(rows_a), set(rows_b)
+
+            assert ids_a & ids_b == set()  # 핵심 단정: 겹치는 job이 하나도 없어야 한다.
+            assert len(ids_a) == 5 and len(ids_b) == 5  # 10개를 5+5로 정확히 나눠 가짐(유실 0).
+            assert ids_a | ids_b == all_ids  # 합쳐서 전체를 커버(스킵으로 인한 누락도 0).
+            await session_a.commit()
+            await session_b.commit()
+        finally:
+            await session_a.close()
+            await session_b.close()
+    finally:
+        await engine.dispose()
+
+
+# ─── ③순서: created_at ASC로 선정됨 ──────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_claim_batch_orders_by_created_at(monkeypatch):
+    from app.models.delivery_job import DeliveryJob
+    from app.services.delivery_dispatcher import _claim_batch
+
+    engine = create_async_engine(_async_url())
+    try:
+        await _clean_delivery_jobs(engine)
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        monkeypatch.setattr("app.core.database.async_session_factory", factory)
+
+        org_id = uuid.uuid4()
+        ids_in_order = []
+        async with AsyncSession(engine) as session:
+            for i in range(3):
+                job = DeliveryJob(org_id=org_id, kind="org_webhook", payload={"seq": i})
+                session.add(job)
+                await session.flush()
+                ids_in_order.append(job.id)
+            await session.commit()
+
+        claimed = await _claim_batch(limit=10)
+        claimed_ids = [j["id"] for j in claimed if j["org_id"] == org_id]
+        assert claimed_ids == ids_in_order
+    finally:
+        await engine.dispose()
+
+
+# ─── 전 사이클: enqueue → claim → 배달(mock _now) → status='delivered' ──────
+
+@pytest.mark.anyio
+async def test_full_cycle_enqueue_claim_deliver_marks_delivered(monkeypatch):
+    from unittest.mock import AsyncMock
+
+    from app.models.delivery_job import DeliveryJob
+    from app.services.delivery_dispatcher import _claim_batch, _deliver_one
+    from app.services.webhook_dispatch import fire_webhooks
+
+    engine = create_async_engine(_async_url())
+    try:
+        await _clean_delivery_jobs(engine)
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        monkeypatch.setattr("app.core.database.async_session_factory", factory)
+
+        org_id = uuid.uuid4()
+        async with AsyncSession(engine) as session:
+            await fire_webhooks(session, org_id, "story.status_changed", {"story_id": "s1"}, via_outbox=True)
+            await session.commit()
+
+        claimed = await _claim_batch(limit=10)
+        mine = [j for j in claimed if j["org_id"] == org_id]
+        assert len(mine) == 1
+
+        mock_now = AsyncMock()
+        monkeypatch.setattr("app.services.webhook_dispatch._fire_webhooks_now", mock_now)
+        await _deliver_one(mine[0])
+
+        mock_now.assert_awaited_once()  # 실 HTTP 미발신(mock) — job 상태전이만 검증.
+        async with AsyncSession(engine) as verify:
+            row = (await verify.execute(
+                select(DeliveryJob).where(DeliveryJob.id == mine[0]["id"])
+            )).scalar_one()
+        assert row.status == "delivered"
+        assert row.delivered_at is not None
+        assert row.attempts == 1  # claim에서 1회 증가, 배달 성공은 attempts를 더 안 건드림.
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2460_delivery_outbox_realdb.py
+++ b/backend/tests/test_2460_delivery_outbox_realdb.py
@@ -178,6 +178,52 @@ async def test_claim_batch_orders_by_created_at(monkeypatch):
         await engine.dispose()
 
 
+# ─── F1(PO 리뷰 2026-08-05, 머지 前 필수수정 pin): send 단계에 커넥션이 안 잡혀 있음 ─────
+
+@pytest.mark.anyio
+async def test_send_phase_holds_no_connection_from_fetch_phase(monkeypatch):
+    """PO 리뷰 F1 — 예전엔 fetch(SELECT)를 문 세션이 send(httpx POST 루프) 내내 idle-in
+    -transaction으로 열려 있었다(POST 자체는 세션을 안 건드리지만 세션 객체가 안 닫혀
+    있었다는 게 문제). 이걸 «docstring 주장」이 아니라 실측으로 고정한다: 엔진 풀을
+    `pool_size=1, max_overflow=0`으로 좁혀놓고, `_send_webhook_targets`가 실행되는 그
+    순간 **같은 엔진**으로 새 쿼리를 하나 더 띄운다 — fetch 단계 커넥션이 반납 안 됐으면
+    풀 고갈로 이 새 쿼리가 타임아웃(멈춤)한다. 반납됐으면 즉시 통과한다."""
+    from app.models.delivery_job import DeliveryJob
+    from app.services.delivery_dispatcher import _claim_batch, _deliver_one
+    from app.services.webhook_dispatch import fire_webhooks
+
+    engine = create_async_engine(_async_url(), pool_size=1, max_overflow=0, pool_timeout=3)
+    try:
+        await _clean_delivery_jobs(engine)
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        monkeypatch.setattr("app.core.database.async_session_factory", factory)
+
+        org_id = uuid.uuid4()
+        async with AsyncSession(engine) as session:
+            await fire_webhooks(session, org_id, "story.status_changed", {"story_id": "s1"}, via_outbox=True)
+            await session.commit()
+
+        claimed = await _claim_batch(limit=10)
+        mine = [j for j in claimed if j["org_id"] == org_id]
+        assert len(mine) == 1
+
+        probe_succeeded = {"value": False}
+
+        async def _send_probe(targets, event, data):
+            # send가 실행되는 이 시점에 fetch 단계 커넥션이 반납돼 있어야, pool_size=1인
+            # 이 엔진으로 새 세션을 여는 이 호출이 안 멈추고 통과한다.
+            async with AsyncSession(engine) as probe_session:
+                await probe_session.execute(select(DeliveryJob.id).limit(1))
+            probe_succeeded["value"] = True
+
+        monkeypatch.setattr("app.services.webhook_dispatch._send_webhook_targets", _send_probe)
+        await _deliver_one(mine[0])
+
+        assert probe_succeeded["value"] is True  # 풀 고갈로 멈췄다면 여기 도달 자체가 실패(pytest timeout).
+    finally:
+        await engine.dispose()
+
+
 # ─── 전 사이클: enqueue → claim → 배달(mock _now) → status='delivered' ──────
 
 @pytest.mark.anyio
@@ -203,11 +249,14 @@ async def test_full_cycle_enqueue_claim_deliver_marks_delivered(monkeypatch):
         mine = [j for j in claimed if j["org_id"] == org_id]
         assert len(mine) == 1
 
-        mock_now = AsyncMock()
-        monkeypatch.setattr("app.services.webhook_dispatch._fire_webhooks_now", mock_now)
+        # story #2460 PO 리뷰(F1): _deliver_one의 fetch 단계는 실 PG로 그대로 태우고(빈
+        # WebhookConfig 목록을 실제로 조회), send 단계(순수 외부 I/O)만 mock — fetch/send가
+        # 서로 다른 세션 경계에 있다는 것 자체를 실 DB 라운드트립으로 실증한다.
+        mock_send = AsyncMock()
+        monkeypatch.setattr("app.services.webhook_dispatch._send_webhook_targets", mock_send)
         await _deliver_one(mine[0])
 
-        mock_now.assert_awaited_once()  # 실 HTTP 미발신(mock) — job 상태전이만 검증.
+        mock_send.assert_awaited_once()  # 실 HTTP 미발신(mock) — job 상태전이만 검증.
         async with AsyncSession(engine) as verify:
             row = (await verify.execute(
                 select(DeliveryJob).where(DeliveryJob.id == mine[0]["id"])


### PR DESCRIPTION
## Summary
- §6 봉합② — story_status_events/conversations.send_message 두 콜사이트의 웹훅 POST·Expo push를 요청 트랜잭션 밖으로(`delivery_jobs` outbox + 별도 워커).
- 스코프는 PO 확定(2026-08-05) 그대로 두 콜사이트만: 나머지 12+ `dispatch_notification`/`fire_webhooks` 콜사이트는 `via_outbox` 기본값 False로 즉시 배달 유지(behavior 무변경).
- 워커(`delivery_dispatcher.py`)는 claim(FOR UPDATE SKIP LOCKED, 짧은 트랜잭션)과 실 배달(외부 I/O)을 분리 — 배달 中 트랜잭션을 안 잡는다(PO 명시 지시, embedding_backlog.py/outbox_dispatcher_loop()와 다른 설계).
- at-least-once + attempts 기반 재시도(최대 5회, 초과 시 terminal `failed`).

## Test plan
- [x] mock 세션 유닛테스트 7종(`tests/test_2460_delivery_outbox.py`) — opt-in 라우팅, via_outbox 양채널 전파, kind별 배달 라우팅, 재시도/terminal FSM
- [x] 로컬 PG 5종(`tests/test_2460_delivery_outbox_realdb.py`) — 원자성(rollback/commit), FOR UPDATE SKIP LOCKED 무중복 실증, 순서, 전체 사이클
- [x] 전체 non-realdb 스위트 4372 passed(신규 실패 0)
- [x] `alembic upgrade head` 로컬 全체인 적용 확認 + 테이블 스키마 모델과 일치 확認
- [ ] Qadir QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)