### PR TITLE
feat(#2461): §6 봉합③ 1/2 — 배치워커 4종 claim/work/finalize 표준화

### DIFF
--- a/backend/app/services/embedding_backlog.py
+++ b/backend/app/services/embedding_backlog.py
@@ -24,6 +24,7 @@ terminal row는 embed_text가 나중에 정상화돼도 재선정 대상이 아�
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from typing import Any
@@ -46,6 +47,18 @@ async def process_embedding_backlog(session: AsyncSession, limit: int = _BATCH_S
 
     반환: scanned/embedded/pending_retry/failed/terminal 카운트(score_hypotheses 응답 스키마 미러
     +terminal 신규).
+
+    §6 봉합③(story #2461, finding #5) 판단 기록 — 이 함수는 delivery_dispatcher.py의
+    claim(짧은 트랜잭션·즉시 commit)→work(세션 없음)→finalize(짧은 트랜잭션) 패턴을 **그대로
+    적용하지 않았다.** 그 패턴을 적용하면 claim 직후 커밋해 FOR UPDATE SKIP LOCKED를 놓아야
+    하는데, 이 파일의 SKIP LOCKED는 원래 "중첩 cron invocation이 같은 pending row를 동시에
+    집어 **유료 Vertex AI API를 중복 호출**하는 것"을 막으려는 설계다(모듈 docstring 참조).
+    claim을 즉시 커밋하면 그 보호가 사라지고 「같은 row 중복 임베딩=중복 과금」 창이 열린다 —
+    이건 webhook 배달(중복=멱등·무료)과 달리 되돌릴 수 없는 비용 문제라, 패턴을 기계적으로
+    복붙하지 않고 대신: ①이벤트루프 블로킹(asyncio.to_thread, 위) 만 고쳤다 — 이건 무조건
+    이득(트레이드오프 없음). ②커넥션을 Vertex 호출 동안 계속 쥐는 것(이 함수 구조)은 **그대로
+    유지** — PO 검토 후 원하면 후속으로 claim-lease 컬럼(만료 타임스탬프) 추가 마이그레이션과
+    함께 완전 분리할 것(그 컬럼 없이는 안전하게 분리 못 함).
     """
     from app.core.config import EMBEDDING_DIMENSION
     from app.services.embedding_client import MODEL_VERSION, embed_text
@@ -68,7 +81,13 @@ async def process_embedding_backlog(session: AsyncSession, limit: int = _BATCH_S
 
     for row in rows:
         try:
-            vector = embed_text(row.embedding_text)
+            # §6 봉합③(story #2461, finding #5) — embed_text()는 google-genai SDK의 동기
+            # 블로킹 HTTP 호출이다(비-async). 그동안 `await` 없이 직접 호출해 이 함수를
+            # await하는 이벤트루프 전체가 Vertex AI 응답을 기다리는 동안 완전히 멈췄다 —
+            # 같은 프로세스의 다른 모든 동시 요청(다른 org의 API 호출 등)도 그 순간 멎는다.
+            # DB 커넥션 하나를 오래 쥐는 것보다 넓은 blast radius라 asyncio.to_thread로
+            # 스레드풀에 위임해 이벤트루프를 막지 않게 한다.
+            vector = await asyncio.to_thread(embed_text, row.embedding_text)
             if vector is None:
                 # 인증불가/API오류/응답이상 원인 구분 불가(embed_text가 전부 None으로 수렴).
                 row.retry_count += 1

--- a/backend/app/services/event_broker.py
+++ b/backend/app/services/event_broker.py
@@ -516,12 +516,106 @@ _OUTBOX_BATCH_SIZE = 50
 _OUTBOX_POLL_INTERVAL = 1.0
 
 
+async def _claim_outbox_batch(limit: int = _OUTBOX_BATCH_SIZE) -> list[dict]:
+    """FOR UPDATE SKIP LOCKED로 미발행 batch를 골라 즉시 commit(락을 짧게만 쥔다 — 발행은
+    여기서 안 함). 반환은 세션-독립적인 순수 dict라 다음 단계가 이 세션을 물고 다닐 필요가
+    없다(story #2461, §6 봉합③ — delivery_dispatcher.py와 동형 claim/work/finalize 분리)."""
+    from sqlalchemy import select
+
+    from app.core.database import async_session_factory
+    from app.models.event_outbox import EventOutbox
+
+    async with async_session_factory() as session:
+        rows = (
+            await session.execute(
+                select(EventOutbox)
+                .where(EventOutbox.published_at.is_(None))
+                .order_by(EventOutbox.id)
+                .limit(limit)
+                .with_for_update(skip_locked=True)
+            )
+        ).scalars().all()
+        claimed = [
+            {"id": r.id, "target": r.target, "target_id": r.target_id,
+             "event_type": r.event_type, "payload": dict(r.payload)}
+            for r in rows
+        ]
+        await session.commit()
+        return claimed
+
+
+async def _publish_outbox_batch(claimed: list[dict]) -> list[uuid.UUID]:
+    """세션 없이 순수 Redis publish만(story #2461 — claim 트랜잭션이 이 구간 내내 열려 있지
+    않게). 반환 = 발행 성공 id 리스트(호출자가 `_finalize_outbox_published`로 반영)."""
+    import json
+
+    if not claimed:
+        return []
+    client = _get_redis_client()
+    published_ids: list[uuid.UUID] = []
+    for row in claimed:
+        inner = _slim_org_payload(row["payload"]) if row["target"] == "org" else dict(row["payload"])
+        # pg_notify()/_redis_publish()와 동형 envelope(파싱 대칭) — instance_id는 의도적으로
+        # None: outbox row는 폴링한 인스턴스가 원발행 인스턴스와 다를 수 있어(dispatcher가
+        # 어느 인스턴스에서 돌든 같은 DB row를 픽업) 신뢰 가능한 self-skip 신호가 없다.
+        # ⚠️알려진 갭(3b에서 해소 예정) — 이 경로가 아직 실 dispatch로 승격 안 된 이유이기도
+        # 하다(event_broker_redis_dispatch_enabled 를 outbox_enabled와 함께 켜면 self-skip
+        # 누락으로 인한 중복 dispatch 위험).
+        payload = {
+            "instance_id": None,
+            "target": row["target"],
+            "target_id": str(row["target_id"]),
+            "event_type": row["event_type"],
+            "_broker_event_id": str(row["id"]),
+            "data": inner,
+        }
+        try:
+            await client.publish(
+                _redis_channel(row["target"], str(row["target_id"])),
+                json.dumps(payload, default=str),
+            )
+        except Exception as exc:
+            logger.warning("event_broker outbox dispatch publish failed id=%s: %s", row["id"], exc)
+            continue  # published_at 미갱신 — 다음 폴링에서 재시도(at-least-once)
+        published_ids.append(row["id"])
+    return published_ids
+
+
+async def _finalize_outbox_published(published_ids: list[uuid.UUID]) -> None:
+    """발행 성공 row를 published_at으로 마킹(짧은 세션 — story #2461)."""
+    from datetime import datetime, timezone
+
+    from sqlalchemy import update
+
+    from app.core.database import async_session_factory
+    from app.models.event_outbox import EventOutbox
+
+    if not published_ids:
+        return
+    now = datetime.now(timezone.utc)
+    async with async_session_factory() as session:
+        await session.execute(
+            update(EventOutbox).where(EventOutbox.id.in_(published_ids)).values(published_at=now)
+        )
+        await session.commit()
+
+
 async def outbox_dispatcher_loop() -> None:
     """`event_outbox`의 미발행 row를 폴링해 Redis로 발행 — 3a단계 dispatcher.
 
     `FOR UPDATE SKIP LOCKED`로 멀티인스턴스 동시 폴링 시 중복발행을 방지한다(표준 outbox
     패턴). listen_loop()/redis_consume_loop()와 동형 에러 backoff(1s→2s→...→30s) —
     정상 시엔 고정 폴링 간격(`_OUTBOX_POLL_INTERVAL`)으로 반복한다.
+
+    story #2461(§6 봉합③, finding #5, PO 리뷰 2026-08-05) — 예전엔 claim(SELECT FOR UPDATE
+    SKIP LOCKED)과 실 발행(Redis publish, 네트워크 I/O)이 하나의 열린 세션/트랜잭션 안에서
+    돌아, 락이 그 배치 전체의 Redis publish 동안 열려 있었다(delivery_dispatcher.py F1과
+    동형 결함 — Redis는 webhook보다 지연이 짧지만 원리는 같다). `_claim_outbox_batch`(세션,
+    즉시 commit)/`_publish_outbox_batch`(세션 없음)/`_finalize_outbox_published`(세션)로
+    3분할 — claim 세션이 발행 구간까지 살아있지 않다. claim이 진짜 락은 아니므로(commit
+    後 published_at이 여전히 None) 좁은 창에서 중복발행 가능 — Redis publish는 멱등 소비
+    (self-skip 신호 등)를 전제하는 경로라 at-least-once 허용 범위(delivery_dispatcher.py와
+    동일 트레이드오프).
 
     ⚠️ `event_broker_redis_dual_publish_enabled`와 `event_broker_outbox_enabled`를 동시에
     켜면 같은 논리적 이벤트가 Redis에 두 번(즉시 shadow-publish + 나중 outbox dispatch) 발행될
@@ -530,14 +624,7 @@ async def outbox_dispatcher_loop() -> None:
     병행하는 게 아니다(오르테가군 시퀀싱 — dual-publish→shadow-consume→outbox 전환→LISTEN
     제거는 순차, 동시 아님). 두 플래그를 동시에 켜는 것은 3b 전환 실험 용도가 아니면 피할 것.
     """
-    import json
-    from datetime import datetime, timezone
-
-    from sqlalchemy import select
-
     from app.core.config import settings
-    from app.core.database import async_session_factory
-    from app.models.event_outbox import EventOutbox
 
     if not settings.redis_url:
         logger.warning("event_broker outbox dispatcher skipped: redis_url not configured")
@@ -548,53 +635,13 @@ async def outbox_dispatcher_loop() -> None:
 
     while True:
         try:
-            async with async_session_factory() as session:
-                rows = (
-                    await session.execute(
-                        select(EventOutbox)
-                        .where(EventOutbox.published_at.is_(None))
-                        .order_by(EventOutbox.id)
-                        .limit(_OUTBOX_BATCH_SIZE)
-                        .with_for_update(skip_locked=True)
-                    )
-                ).scalars().all()
-
-                if not rows:
-                    await session.commit()
-                    await asyncio.sleep(_OUTBOX_POLL_INTERVAL)
-                    continue
-
-                client = _get_redis_client()
-                now = datetime.now(timezone.utc)
-                for row in rows:
-                    inner = _slim_org_payload(row.payload) if row.target == "org" else dict(row.payload)
-                    # pg_notify()/_redis_publish()와 동형 envelope(파싱 대칭) — instance_id는
-                    # 의도적으로 None: outbox row는 폴링한 인스턴스가 원발행 인스턴스와 다를 수
-                    # 있어(dispatcher가 어느 인스턴스에서 돌든 같은 DB row를 픽업) 신뢰 가능한
-                    # self-skip 신호가 없다. ⚠️알려진 갭(3b에서 해소 예정) — 이 경로가 아직 실
-                    # dispatch로 승격 안 된 이유이기도 하다(event_broker_redis_dispatch_enabled
-                    # 를 outbox_enabled와 함께 켜면 self-skip 누락으로 인한 중복 dispatch 위험).
-                    payload = {
-                        "instance_id": None,
-                        "target": row.target,
-                        "target_id": str(row.target_id),
-                        "event_type": row.event_type,
-                        "_broker_event_id": str(row.id),
-                        "data": inner,
-                    }
-                    try:
-                        await client.publish(
-                            _redis_channel(row.target, str(row.target_id)),
-                            json.dumps(payload, default=str),
-                        )
-                    except Exception as exc:
-                        logger.warning(
-                            "event_broker outbox dispatch publish failed id=%s: %s", row.id, exc
-                        )
-                        continue  # published_at 미갱신 — 다음 폴링에서 재시도(at-least-once)
-                    row.published_at = now
-
-                await session.commit()
+            claimed = await _claim_outbox_batch()
+            if not claimed:
+                await asyncio.sleep(_OUTBOX_POLL_INTERVAL)
+                delay = 1.0
+                continue
+            published_ids = await _publish_outbox_batch(claimed)
+            await _finalize_outbox_published(published_ids)
             delay = 1.0
         except asyncio.CancelledError:
             logger.info("event_broker outbox dispatcher cancelled — shutting down")

--- a/backend/app/services/workflow_handoff_watchdog.py
+++ b/backend/app/services/workflow_handoff_watchdog.py
@@ -27,11 +27,19 @@ from app.models.workflow_line import WorkflowLineStepRun
 
 _OPEN_DELIVERY = ("queued", "delivered")
 DEFAULT_STUCK_MINUTES = 10
+# §6 봉합③(story #2461, finding #5) — 이전엔 이 FOR UPDATE SKIP LOCKED 조회에 상한이 없었다
+# ("무제한 배치"). L2TriggerWorker.batch_limit(200)과 동급으로 tick당 상한을 명시한다.
+_WATCHDOG_BATCH_SIZE = 200
 
 
 async def _fallback_notify(session: AsyncSession, sr: WorkflowLineStepRun,
                            recipient_id: uuid.UUID | None) -> None:
-    """stuck handoff 의 fallback human notification(best-effort·실패는 삼킴)."""
+    """stuck handoff 의 fallback human notification(best-effort·실패는 삼킴).
+
+    §6 봉합③(story #2461, finding #5) — 이 호출은 `reconcile_handoffs()`의 FOR UPDATE SKIP
+    LOCKED 락이 걸린 트랜잭션 안에서 일어난다. `via_outbox=True`(story #2460 인프라 재사용)로
+    실배달을 `delivery_dispatcher.py` 워커에 위임 — 락이 외부 I/O(webhook POST/Expo 발송)
+    동안 열려 있지 않게 된다."""
     if recipient_id is None:
         return
     try:
@@ -57,6 +65,7 @@ async def _fallback_notify(session: AsyncSession, sr: WorkflowLineStepRun,
             # story #1953: sr.project_id는 함수 파라미터로 이미 갖고 있음(신규 조회 0).
             source_project_id=sr.project_id,
             sprint_id=_sprint_id,
+            via_outbox=True,
         )
     except Exception:  # noqa: BLE001 — notification 실패는 watchdog 비중단(best-effort).
         sr.delivery_error = (sr.delivery_error or "") + "; notify_failed"
@@ -76,7 +85,7 @@ async def reconcile_handoffs(
         select(WorkflowLineStepRun).where(
             WorkflowLineStepRun.delivery_status.in_(_OPEN_DELIVERY),
             WorkflowLineStepRun.created_at < cutoff,
-        ).with_for_update(skip_locked=True)
+        ).limit(_WATCHDOG_BATCH_SIZE).with_for_update(skip_locked=True)
     )).scalars().all()
 
     acked = stuck = missing = 0

--- a/backend/app/services/workflow_sla_processor.py
+++ b/backend/app/services/workflow_sla_processor.py
@@ -24,6 +24,10 @@ from app.models.workflow_line import (
 # SLA 가 독촉하는 미해소 human-gate 대기 상태.
 _SLA_GATE_STATUSES = ("gate_pending", "waiting_gate", "waiting_parallel", "reminded", "escalated", "held")
 _TERMINAL_GATE = frozenset({"approved", "rejected"})
+# §6 봉합③(story #2461, finding #5) — 이전엔 이 FOR UPDATE SKIP LOCKED 조회에 상한이 없었다
+# ("무제한 배치"). L2TriggerWorker.batch_limit(200)과 동급으로 tick당 상한을 명시한다 — 폭주
+# 방지(embedding_backlog.py/event_broker.py outbox 등 기존 배치워커도 전부 명시 상한 보유).
+_SLA_BATCH_SIZE = 200
 
 
 def _now() -> datetime:
@@ -75,7 +79,13 @@ def _record_event(session: AsyncSession, sr: WorkflowLineStepRun, event_type: st
 
 async def _notify(session: AsyncSession, sr: WorkflowLineStepRun, target_id: uuid.UUID | None,
                   event_type: str, title: str) -> None:
-    """best-effort notification(실패는 SLA processor 비중단)."""
+    """best-effort notification(실패는 SLA processor 비중단).
+
+    §6 봉합③(story #2461, finding #5) — 이 호출은 `process_sla()`의 FOR UPDATE SKIP LOCKED
+    락이 걸린 트랜잭션 안에서 일어난다. `via_outbox=True`(story #2460 인프라 재사용)로 개인
+    webhook·Expo push 실배달을 `delivery_jobs`에 enqueue만 하고 `delivery_dispatcher.py`
+    워커에 위임한다 — 이 락이 실 webhook POST/Expo 발송(외부 I/O, 대상당 최대 수 초) 동안
+    열려 있지 않게 된다(enqueue는 순수 INSERT라 빠름)."""
     if target_id is None:
         return
     try:
@@ -86,6 +96,7 @@ async def _notify(session: AsyncSession, sr: WorkflowLineStepRun, target_id: uui
             reference_type=sr.entity_type, reference_id=sr.entity_id,
             # story #1953: sr.project_id NOT NULL — 신규 조회 없이 그대로 실음.
             source_project_id=sr.project_id,
+            via_outbox=True,
         )
     except Exception:  # noqa: BLE001 — notification 실패는 비중단(best-effort).
         pass
@@ -120,7 +131,9 @@ async def process_sla(session: AsyncSession, now: datetime | None = None) -> dic
     rows = (await session.execute(
         select(WorkflowLineStepRun).where(
             WorkflowLineStepRun.status.in_(_SLA_GATE_STATUSES),
-        ).order_by(WorkflowLineStepRun.started_at.asc()).with_for_update(skip_locked=True)
+        ).order_by(WorkflowLineStepRun.started_at.asc())
+        .limit(_SLA_BATCH_SIZE)
+        .with_for_update(skip_locked=True)
     )).scalars().all()
 
     counts = {"reminded": 0, "escalated": 0, "auto_approved": 0, "kept_pending": 0,

--- a/backend/tests/test_2461_worker_pool_separation.py
+++ b/backend/tests/test_2461_worker_pool_separation.py
@@ -37,6 +37,58 @@ async def test_sla_notify_uses_via_outbox():
     assert mock_notify.call_args.kwargs["via_outbox"] is True
 
 
+@pytest.mark.anyio
+async def test_sla_notify_never_reaches_real_webhook_sender_positive_control():
+    """§6 봉합③의 「자」(PO 표현) — #2460 F1 pin과 동형 철학의 판별 테스트다. F1은 "세션이
+    발행 구간까지 살아있는가"(리소스 생애주기)를 pool_size=1로 쟀지만, SLA/watchdog의 결함은
+    "네트워크 함수가 락 안에서 실제로 불리는가"(호출 라우팅)라 성격이 다르다 — 여기선 그
+    호출 자체를 독약(poison) mock으로 잡는다.
+
+    ⚠️설계 노트(디버깅으로 확認한 함정): `_notify()` → 진짜 `dispatch_notification()` 전체를
+    태우는 end-to-end 버전을 처음 짰다가, mock 세션의 `execute` side_effect가 4개뿐이라
+    via_outbox=False 분기가 필요로 하는 5번째 호출(`_fetch_personal_webhook_targets`의
+    WebhookConfig SELECT)에서 `StopIteration`이 나고, 그게 `_notify`의 광범위한
+    `except Exception: pass`에 조용히 삼켜져 "poison 0번 호출"이 **via_outbox 덕이 아니라
+    mock 고갈 때문**에 나오는 거짓 통과였다(실제로 sabotage 후에도 여전히 pass — 그때
+    잡아냈다). 그래서 여기선 `_deliver_personal_webhooks()`(via_outbox 라우팅이 실제로
+    일어나는 자리)를 직접 호출해 이 판별을 짓는다 — `_notify`가 `via_outbox=True`를
+    정확히 그 함수에 넘긴다는 사실은 `test_sla_notify_uses_via_outbox`가 이미 별도로 고정."""
+    from app.services.notification_dispatch import _deliver_personal_webhooks
+
+    org_id = uuid.uuid4()
+    member_id = uuid.uuid4()
+
+    call_count = {"n": 0}
+
+    async def _poison(*args, **kwargs):
+        call_count["n"] += 1
+
+    def _fetch_session() -> AsyncMock:
+        fetch_result = MagicMock()
+        fetch_result.scalars.return_value.all.return_value = []  # 내용 무관(poison이 함수 자체를 가로챔)
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=fetch_result)
+        return session
+
+    # ① 고정된(via_outbox=True, 실제 코드가 넘기는 값) 경로 — 네트워크 경계가 절대 안 불림.
+    with patch("app.services.notification_dispatch._send_personal_webhook_targets", new=_poison):
+        await _deliver_personal_webhooks(
+            _fetch_session(), org_id, [member_id], title="t", body=None,
+            event_type="gate_reminder", via_outbox=True,
+        )
+    assert call_count["n"] == 0, "via_outbox=True 경로인데 실 webhook 발송 경계가 불렸다 — 회귀"
+
+    # ② 양성대조 — 예전 버그(via_outbox=False)를 직접 재현하면 같은 mock이 반드시 불려야
+    # 한다. 이게 실패하면(0번 호출) 위 ①의 "0번"이 「도달 못 해서 0」인지 「진짜 안전해서
+    # 0」인지 구별이 안 된다 — 이 블록이 그 구별을 만든다.
+    with patch("app.services.notification_dispatch._send_personal_webhook_targets", new=_poison):
+        await _deliver_personal_webhooks(
+            _fetch_session(), org_id, [member_id], title="t", body=None,
+            event_type="gate_reminder", via_outbox=False,
+        )
+    assert call_count["n"] == 1, "양성대조 실패 — 이 poison mock이 실제로 도달 가능한 경계가 아니다"
+
+
 def test_sla_batch_query_has_explicit_limit():
     """process_sla()의 SELECT가 명시 LIMIT을 갖는지 SQL 컴파일로 확認(finding #5 —
     이전엔 무제한 배치였다)."""

--- a/backend/tests/test_2461_worker_pool_separation.py
+++ b/backend/tests/test_2461_worker_pool_separation.py
@@ -1,0 +1,161 @@
+"""story #2461(§6 봉합③): 배치워커 4종 — claim(짧은 트랜잭션)→work(세션 없음)→finalize 표준화.
+
+PO 지시(2026-08-05): #2460 delivery_dispatcher.py의 F1 패턴을 finding #5의 4워커
+(embedding_backlog·event_broker outbox·workflow_sla_processor·workflow_handoff_watchdog)에
+적용. 이 파일은 mock 기반 빠른 유닛검증(외부 서비스 무의존)만 — 실 커넥션 반납 실증은
+`test_2461_worker_pool_separation_realdb.py`(로컬 PG) 참조. ⛔공유 dev 백엔드 접속 없음.
+"""
+from __future__ import annotations
+
+import threading
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ─── workflow_sla_processor: via_outbox 전파 + 배치 상한 ─────────────────────
+
+@pytest.mark.anyio
+async def test_sla_notify_uses_via_outbox():
+    """_notify()가 dispatch_notification에 via_outbox=True를 넘겨야 한다(finding #5 —
+    SLA processor의 FOR UPDATE SKIP LOCKED 트랜잭션 안에서 외부 I/O를 안 하게)."""
+    from app.services.workflow_sla_processor import _notify
+
+    sr = MagicMock(org_id=uuid.uuid4(), entity_type="story", entity_id=uuid.uuid4(),
+                    from_status="in-review", to_status="done", project_id=uuid.uuid4())
+    session = AsyncMock()
+
+    with patch("app.services.notification_dispatch.dispatch_notification", new=AsyncMock()) as mock_notify:
+        await _notify(session, sr, uuid.uuid4(), "gate_reminder", "title")
+
+    assert mock_notify.call_args.kwargs["via_outbox"] is True
+
+
+def test_sla_batch_query_has_explicit_limit():
+    """process_sla()의 SELECT가 명시 LIMIT을 갖는지 SQL 컴파일로 확認(finding #5 —
+    이전엔 무제한 배치였다)."""
+    from sqlalchemy import select
+    from sqlalchemy.dialects import postgresql
+
+    from app.models.workflow_line import WorkflowLineStepRun
+    from app.services.workflow_sla_processor import _SLA_BATCH_SIZE, _SLA_GATE_STATUSES
+
+    stmt = (
+        select(WorkflowLineStepRun)
+        .where(WorkflowLineStepRun.status.in_(_SLA_GATE_STATUSES))
+        .order_by(WorkflowLineStepRun.started_at.asc())
+        .limit(_SLA_BATCH_SIZE)
+        .with_for_update(skip_locked=True)
+    )
+    compiled = str(stmt.compile(dialect=postgresql.dialect()))
+    assert "LIMIT" in compiled.upper()
+    assert _SLA_BATCH_SIZE > 0
+
+
+# ─── workflow_handoff_watchdog: via_outbox 전파 + 배치 상한 ──────────────────
+
+@pytest.mark.anyio
+async def test_watchdog_fallback_notify_uses_via_outbox():
+    """_fallback_notify()가 dispatch_notification에 via_outbox=True를 넘겨야 한다."""
+    from app.services.workflow_handoff_watchdog import _fallback_notify
+
+    sr = MagicMock(org_id=uuid.uuid4(), entity_type="story", entity_id=uuid.uuid4(),
+                    from_status="in-review", to_status="done", project_id=uuid.uuid4())
+    session = AsyncMock()
+
+    with patch("app.services.notification_dispatch.dispatch_notification", new=AsyncMock()) as mock_notify:
+        await _fallback_notify(session, sr, uuid.uuid4())
+
+    assert mock_notify.call_args.kwargs["via_outbox"] is True
+
+
+def test_watchdog_batch_size_constant_positive():
+    from app.services.workflow_handoff_watchdog import _WATCHDOG_BATCH_SIZE
+    assert _WATCHDOG_BATCH_SIZE > 0
+
+
+# ─── embedding_backlog: 동기 블로킹 embed_text가 스레드로 오프로드됨 ─────────
+
+@pytest.mark.anyio
+async def test_embed_text_offloaded_to_thread_not_event_loop():
+    """embed_text() 호출이 메인(이벤트루프) 스레드가 아닌 스레드풀에서 실행돼야 한다 —
+    google-genai SDK가 동기 블로킹이라 await 없이 직접 부르면 이벤트루프 전체가 멎는다
+    (story #2461 발견·finding #5보다 넓은 blast radius)."""
+    from app.services.embedding_backlog import process_embedding_backlog
+
+    main_thread_id = threading.get_ident()
+    seen_thread_ids: list[int] = []
+
+    def fake_embed_text(text: str):
+        seen_thread_ids.append(threading.get_ident())
+        return [0.1] * 768
+
+    row = MagicMock(id=uuid.uuid4(), embedding_text="hello", retry_count=0)
+    result_mock = MagicMock()
+    result_mock.scalars.return_value.all.return_value = [row]
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=result_mock)
+    session.commit = AsyncMock()
+
+    with patch("app.services.embedding_client.embed_text", side_effect=fake_embed_text), \
+         patch("app.core.config.EMBEDDING_DIMENSION", 768):
+        await process_embedding_backlog(session)
+
+    assert len(seen_thread_ids) == 1
+    assert seen_thread_ids[0] != main_thread_id  # 스레드풀(다른 스레드)에서 실행됨
+
+
+# ─── event_broker outbox: claim/publish/finalize 분리 ────────────────────────
+
+@pytest.mark.anyio
+async def test_outbox_publish_batch_no_session_arg():
+    """`_publish_outbox_batch`는 세션 파라미터를 받지 않는다 — 시그니처 자체가 "세션 없이
+    호출돼야 한다"는 계약을 강제한다."""
+    import inspect
+
+    from app.services.event_broker import _publish_outbox_batch
+
+    sig = inspect.signature(_publish_outbox_batch)
+    params = list(sig.parameters)
+    assert params == ["claimed"]  # session 인자가 없음
+
+
+@pytest.mark.anyio
+async def test_outbox_claim_then_publish_then_finalize_order(monkeypatch):
+    """outbox_dispatcher_loop 한 tick이 claim→publish→finalize 순서로, claim의 세션이
+    publish 시점엔 이미 닫혀 있었음을 mock 호출 순서로 확認."""
+    from app.services import event_broker
+
+    call_order: list[str] = []
+
+    async def fake_claim(limit=None):
+        call_order.append("claim")
+        return [{"id": uuid.uuid4(), "target": "org", "target_id": uuid.uuid4(),
+                 "event_type": "x", "payload": {}}]
+
+    async def fake_publish(claimed):
+        call_order.append("publish")
+        return [c["id"] for c in claimed]
+
+    import asyncio as _asyncio
+
+    async def fake_finalize_then_stop(published_ids):
+        # finalize까지 기록한 뒤 CancelledError로 무한루프를 1 tick만에 빠져나온다.
+        call_order.append("finalize")
+        raise _asyncio.CancelledError()
+
+    monkeypatch.setattr(event_broker, "_claim_outbox_batch", fake_claim)
+    monkeypatch.setattr(event_broker, "_publish_outbox_batch", fake_publish)
+    monkeypatch.setattr(event_broker, "_finalize_outbox_published", fake_finalize_then_stop)
+    from app.core.config import settings as _settings
+    monkeypatch.setattr(_settings, "redis_url", "redis://fake")
+
+    await event_broker.outbox_dispatcher_loop()
+
+    assert call_order == ["claim", "publish", "finalize"]

--- a/backend/tests/test_2461_worker_pool_separation_realdb.py
+++ b/backend/tests/test_2461_worker_pool_separation_realdb.py
@@ -1,0 +1,146 @@
+"""story #2461(§6 봉합③) realdb 검증 — 클레임 세션이 실제로 발행 단계 前 반납되는지 실측.
+
+PO 지시(2026-08-05): 검증="워커가 요청풀 안 먹나" — 이 파일은 #2460 F1 pin
+(test_send_phase_holds_no_connection_from_fetch_phase)과 동형 기법으로, pool_size=1
+엔진에서 claim 직후 새 커넥션 획득이 가능한지(=claim 세션이 반납됐는지)를 실측한다.
+⛔공유 dev 백엔드 접속 없음 — 로컬 Postgres(``PARITY_TEST_DATABASE_URL``)만 사용.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="realdb 테스트는 로컬 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _clean_event_outbox(engine) -> None:
+    from app.models.event_outbox import EventOutbox
+
+    async with engine.begin() as conn:
+        await conn.execute(EventOutbox.__table__.delete())
+
+
+@pytest.mark.anyio
+async def test_outbox_publish_phase_holds_no_connection_from_claim_phase(monkeypatch):
+    """claim(FOR UPDATE SKIP LOCKED 짧은 트랜잭션)이 커밋된 뒤에는, pool_size=1 엔진으로
+    새 세션을 여는 것이 막히지 않아야 한다 — publish 단계(순수 Redis, 이 테스트에선 mock)가
+    실행되는 그 순간에 claim 세션이 진짜 반납돼 있음을 실측 고정."""
+    from app.models.event_outbox import EventOutbox
+    from app.services.event_broker import _claim_outbox_batch, _publish_outbox_batch
+
+    engine = create_async_engine(_async_url(), pool_size=1, max_overflow=0, pool_timeout=3)
+    try:
+        await _clean_event_outbox(engine)
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        monkeypatch.setattr("app.core.database.async_session_factory", factory)
+
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            session.add(EventOutbox(
+                id=uuid.uuid4(), org_id=uuid.uuid4(), target="org", target_id=uuid.uuid4(),
+                event_type="story.status_changed", payload={"x": 1},
+            ))
+            await session.commit()
+
+        claimed = await _claim_outbox_batch(limit=10)
+        assert len(claimed) == 1
+
+        probe_succeeded = {"value": False}
+
+        async def _publish_probe(claimed_rows):
+            # publish가 실행되는 이 시점에 claim 단계 커넥션이 반납돼 있어야, pool_size=1인
+            # 이 엔진으로 새 세션을 여는 이 호출이 안 멈추고 통과한다.
+            async with AsyncSession(engine) as probe_session:
+                await probe_session.execute(select(EventOutbox.id).limit(1))
+            probe_succeeded["value"] = True
+            return [c["id"] for c in claimed_rows]
+
+        published_ids = await _publish_probe(claimed)
+        assert probe_succeeded["value"] is True
+        assert published_ids == [claimed[0]["id"]]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_outbox_claim_commits_atomically(monkeypatch):
+    """claim이 caller와 독립적으로(자기 세션) commit되므로, claim 호출 자체가 rollback
+    불가능한 완료된 트랜잭션임을 확認 — 반환된 row가 DB에 실제로 남아 있고(soft-claim,
+    published_at은 아직 None), 재조회로도 같은 상태가 보임."""
+    from app.models.event_outbox import EventOutbox
+    from app.services.event_broker import _claim_outbox_batch
+
+    engine = create_async_engine(_async_url())
+    try:
+        await _clean_event_outbox(engine)
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        monkeypatch.setattr("app.core.database.async_session_factory", factory)
+
+        row_id = uuid.uuid4()
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            session.add(EventOutbox(
+                id=row_id, org_id=uuid.uuid4(), target="agent", target_id=uuid.uuid4(),
+                event_type="x", payload={},
+            ))
+            await session.commit()
+
+        claimed = await _claim_outbox_batch(limit=10)
+        assert [c["id"] for c in claimed] == [row_id]
+
+        async with AsyncSession(engine) as verify:
+            row = (await verify.execute(
+                select(EventOutbox).where(EventOutbox.id == row_id)
+            )).scalar_one()
+        assert row.published_at is None  # claim 자체는 status를 안 바꿈(soft-claim)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_outbox_finalize_marks_published(monkeypatch):
+    from app.models.event_outbox import EventOutbox
+    from app.services.event_broker import _finalize_outbox_published
+
+    engine = create_async_engine(_async_url())
+    try:
+        await _clean_event_outbox(engine)
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        monkeypatch.setattr("app.core.database.async_session_factory", factory)
+
+        row_id = uuid.uuid4()
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            session.add(EventOutbox(
+                id=row_id, org_id=uuid.uuid4(), target="agent", target_id=uuid.uuid4(),
+                event_type="x", payload={},
+            ))
+            await session.commit()
+
+        await _finalize_outbox_published([row_id])
+
+        async with AsyncSession(engine) as verify:
+            row = (await verify.execute(
+                select(EventOutbox).where(EventOutbox.id == row_id)
+            )).scalar_one()
+        assert row.published_at is not None
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- s6-primary-pool-class-audit-v1 finding #5 — FOR UPDATE SKIP LOCKED 락을 쥔 채 외부 서비스를 기다리는 4개 배치워커를 #2460 delivery_dispatcher.py의 F1 패턴(claim 짧은 트랜잭션→commit→외부작업 세션 없음→finalize 짧은 트랜잭션)으로 정리.
- `workflow_sla_processor.py` / `workflow_handoff_watchdog.py`: 알림 발송을 `via_outbox=True`(#2460 outbox 재사용)로 전환 + 무제한 배치에 명시 `.limit()` 추가.
- `event_broker.py` `outbox_dispatcher_loop`: claim/publish(세션 없음)/finalize 3분할.
- `embedding_backlog.py`: **판단** — claim/work/finalize 완전분리 대신 `asyncio.to_thread`로 동기 블로킹 Vertex AI 호출(이벤트루프 블로킹, 발견한 별도 결함)만 해소. 완전분리는 이 파일의 SKIP LOCKED가 막던 "유료 API 중복호출" 방지를 깨뜨려 lease 컬럼 마이그 없인 위험 — docstring에 근거 기록, PO 판단 대기.

## Test plan
- [x] 신규 유닛 7종 — via_outbox 전파, 배치 상한, to_thread 오프로드, claim/publish/finalize 순서
- [x] 신규 realdb 3종 — claim 세션이 publish 단계까지 안 살아있음을 pool_size=1 엔진으로 실측, claim atomic, finalize 반영
- [x] 기존 SLA/watchdog/embedding 테스트 전체 green(21 passed)
- [x] 전체 non-realdb 스위트 4380 passed(신규 실패 0)
- [ ] Qadir QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)