### PR TITLE
feat(#2461): §6 봉합③ 2/2 — L2/배치워커 전용 워커풀(안 A)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -41,13 +41,25 @@ class Settings(BaseSettings):
     # ⚠️ 배포 rollout 時 old+new 리비전이 **동시 점유(2×)** — steady 산식만 쓰면 배포 중 max_connections
     #    초과(2026-06-29 dev TooManyConnections·#1766 rollout 전요청 500). **인스턴스당 실 커넥션은 pool
     #    밖의 raw 연결까지** 포함해야 한다(까심 적출): pg_pubsub.listen_loop = raw asyncpg **상시 1개**(pool
-    #    미점유). (l2_worker 는 engine.connect→pool 내·추가 0.) → **per_instance = (pool+overflow) + RAW(1) = 5.**
-    #    rollout-aware 산식: **2 × maxScale × ((pool+overflow) + RAW) + admin/migration headroom ≤ max_connections.**
+    #    미점유).
+    #    ⛔story #2461(§6 봉합③ part2, 2026-08-05) 갱신 — "l2_worker는 engine.connect→pool 내·
+    #    추가 0"이던 예전 문장은 더 이상 사실이 아니다. L2 advisory-lock 영구연결 + embedding_backlog/
+    #    workflow_sla_processor/workflow_handoff_watchdog/event_broker outbox의 claim/finalize 세션이
+    #    이제 `worker_engine`(별도 소형 풀, 기본 worker_db_pool_size+worker_db_max_overflow=2+1=3)으로
+    #    옮겨갔다 — **새 budget line으로 추가**해야 한다(RAW처럼 "pool 밖"은 아니지만 별개 풀이라
+    #    기존 primary pool 항과 합산 불가, 독립 항으로 더해야 함).
+    #    → **per_instance = (pool+overflow) + RAW(1) + (worker_pool+worker_overflow) = 4 + 1 + 3 = 8**
+    #    (기존 5에서 +3).
+    #    rollout-aware 산식: **2 × maxScale × per_instance + admin/migration headroom ≤ max_connections.**
     #   ① 앱 최소요구(실측): pool+overflow ≥ 4 (total 3 이면 send_message pool_timeout). ∴ pool 3/1=4 고정(밑으로 불가).
-    #   ② dev(f1-micro ~25·maxScale 실측 10→PO **1** 적용 rev 01240-hkc): 2×1×5+5 = 15 ≤ 25 (여유 10).
-    #      (maxScale 2 면 25/25 한계·1 로 여유 확보. 10 이면 2×10×5+5=105≫25 → pool 4 단독 불가·maxScale↓ 필수.)
-    #   ③ prod(g1-small 100·maxScale **실측 필수**): 2×10×5+20=120 > 100(가정 10이면 초과). 안전 상한 maxScale≤8
-    #      (2×8×5+20=100·여유 0). **prod 승격 前 PgBouncer(durable·연결 decouple) 또는 tier↑ 필수**(maxScale 캡만으론 0 headroom).
+    #   ② dev(f1-micro ~25·maxScale 실측 10→PO **1** 적용 rev 01240-hkc): 2×1×8+5 = 21 ≤ 25 (여유 4 — 기존
+    #      10에서 6 줄었다. maxScale 2로 올리면 2×2×8+5=37>25 → 즉시 초과, 이 풀 신설 前엔 여유 있었다).
+    #   ③ prod(g1-small 100·maxScale **실측 필수**·⛔디디는 prod 접근 없어 이 값 직접 확인 불가):
+    #      per_instance=8 기준 안전 상한 maxScale은 «옛 계산(per_instance=5, maxScale≤8)보다 낮아진다」
+    #      — **PO/infra가 이 변경을 prod 배포 前 반드시 재검산**할 것(옛 maxScale≤8 그대로 두면
+    #      2×8×8+20=148>100으로 즉시 초과 가능성). 이 워커풀을 쓰는 3개 cron 엔드포인트
+    #      (/embed-backlog·/workflow-sla·/workflow-handoff-watchdog)가 prod에서 이미 Cloud
+    #      Scheduler로 불리고 있다면 이 재검산이 **배포 前 필수**다.
     # ⚠️ 향후 always-on LISTEN/raw 연결 추가 시 RAW 카운트 ++ 동반(산식 누락 = 이번 false-PASS 재발).
     # ⚠️ --concurrency=80 과 별개: 풀은 DB op 점유 구간만 잡고 즉시 반납·초과분 pool_timeout 대기(실패 아님).
     db_pool_size: int = 3
@@ -65,6 +77,11 @@ class Settings(BaseSettings):
     db_pgbouncer: bool = False
     db_pgbouncer_pool_size: int = 25   # ⭐앱 동시성 수용(크게). PgBouncer가 Cloud SQL 커넥션을 묶어 안전.
     db_pgbouncer_max_overflow: int = 10
+
+    # story #2461(§6 봉합③ part2, PO 승인 2026-08-05): worker_engine(app/core/database.py)
+    # 전용 풀 크기 — 위 db_pool_size 산식 갱신 주석 참조(신규 budget line, prod 재검산 필요).
+    worker_db_pool_size: int = 2
+    worker_db_max_overflow: int = 1
 
     # JWT
     jwt_secret: str = ""

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -79,6 +79,32 @@ read_session_factory = async_sessionmaker(
     class_=AsyncSession,
 )
 
+# story #2461(§6 봉합③ part2, PO 승인 2026-08-05): 요청 경로(engine/async_session_factory)와
+# 완전 분리된 전용 「워커풀」 — L2TriggerWorker의 advisory-lock 영구연결(finding #6) +
+# embedding_backlog/workflow_sla_processor/workflow_handoff_watchdog/event_broker outbox의
+# claim/finalize 세션(finding #5)이 여기로 옮겨간다. `pg_pubsub.listen_loop()`가 이미 쓰는
+# "요청 풀 밖 전용 연결" 원칙과 같은 결 — 단 listen_loop은 raw 커넥션 1개, 이건 여러 워커가
+# 나눠 쓰는 작은 풀(pool_size+max_overflow, 기본 2+1=3)이라는 차이만 있다.
+# ⛔이 풀도 db_application_name()에 별도 suffix("worker")를 달아 pg_stat_activity에서
+# 요청 세션(suffix 없음)·raw LISTEN(":listen")과 분리 집계되게 한다(SID f2fe1c5e/#2040 AC2
+# 관례 재사용 — 이 풀의 실제 커넥션 점유를 "요청과 무관"함을 관측으로 증명하는 축).
+worker_engine = create_async_engine(
+    settings.database_url,
+    pool_size=settings.worker_db_pool_size,
+    max_overflow=settings.worker_db_max_overflow,
+    pool_pre_ping=True,
+    echo=settings.debug,
+    connect_args={
+        **({"statement_cache_size": 0} if settings.db_pgbouncer else {}),
+        "server_settings": {"application_name": db_application_name("worker")},
+    },
+)
+worker_session_factory = async_sessionmaker(
+    worker_engine,
+    expire_on_commit=False,
+    class_=AsyncSession,
+)
+
 
 class Base(DeclarativeBase):
     pass
@@ -86,6 +112,21 @@ class Base(DeclarativeBase):
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
     async with async_session_factory() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+
+async def get_worker_db() -> AsyncGenerator[AsyncSession, None]:
+    """story #2461(§6 봉합③ part2) — 배치워커 cron 엔드포인트(embed-backlog·workflow-sla·
+    workflow-handoff-watchdog) 전용. 요청 primary 풀이 아니라 `worker_engine`에서 세션을
+    뜬다 — FOR UPDATE SKIP LOCKED 락을 쥔 채 외부 서비스(Vertex AI 등)를 기다리는 구간이
+    요청풀이 아닌 이 전용 풀에서만 소모되게 한다(embedding_backlog.py의 잔여 pool-hold를
+    이 풀로 옮겨 해소 — PO 판단 2026-08-05, lease 마이그 불요·SKIP LOCKED dedup 보존)."""
+    async with worker_session_factory() as session:
         try:
             yield session
             await session.commit()

--- a/backend/app/dependencies/database.py
+++ b/backend/app/dependencies/database.py
@@ -1,3 +1,3 @@
-from app.core.database import get_db, get_read_db
+from app.core.database import get_db, get_read_db, get_worker_db
 
-__all__ = ["get_db", "get_read_db"]
+__all__ = ["get_db", "get_read_db", "get_worker_db"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -43,7 +43,7 @@ _logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     from app.core import shutdown as shutdown_module
-    from app.core.database import engine, read_engine
+    from app.core.database import engine, read_engine, worker_engine
     from app.routers.auth_firebase_internal import check_internal_secret_config
     from app.routers.cron import check_cron_secret_config
     from app.routers.verdict_capture import warn_if_webhook_secret_misconfigured
@@ -202,6 +202,11 @@ async def lifespan(app: FastAPI):
             # 미설정이면 read_engine is engine 이라 위 dispose 로 이미 정리됨(중복 dispose 방지).
             if read_engine is not engine:
                 await read_engine.dispose()
+            # story #2461(§6 봉합③ part2): worker_engine도 별도 풀 객체라 독립 dispose 필요
+            # (read_engine과 동일 근거 — 안 하면 워커풀 쪽에서 좀비-연결 클래스 S:33e0c681 재발).
+            # L2의 advisory-lock 커넥션 자체는 l2_task.cancel→run finally에서 이미 반납되지만,
+            # 그건 "풀에 반납"이지 "풀 자체를 닫음"이 아니다 — 이 dispose가 그 나머지를 정리.
+            await worker_engine.dispose()
 
 
 from app.routers import a2a, account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, deeplink_manifest, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, device_installations, dispatch, docs, entities, goals, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, judgments, labels, loops, mcp, me, meetings, members, merge_gate, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, project_access, project_settings, projects, public_docs, reference_candidates, references, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, session_context, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, usage, user_blocks, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -15,7 +15,7 @@ from sqlalchemy import func, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.dependencies.database import get_db
+from app.dependencies.database import get_db, get_worker_db
 from app.models.agent_run import AgentRun
 from app.models.agent_session import AgentSession
 from app.models.asset import Asset
@@ -217,7 +217,10 @@ async def onboarding_abandoned_sweep(
 @router.get("/workflow-handoff-watchdog")
 async def workflow_handoff_watchdog(
     request: Request,
-    session: AsyncSession = Depends(get_db),
+    # story #2461(§6 봉합③ part2, PO 승인 2026-08-05): get_db(요청 primary 풀) 대신
+    # get_worker_db(전용 워커풀) — reconcile_handoffs()의 FOR UPDATE SKIP LOCKED 트랜잭션이
+    # 요청 경로 풀 예산을 소모하지 않는다.
+    session: AsyncSession = Depends(get_worker_db),
 ) -> JSONResponse:
     verify_cron(request)
     try:
@@ -236,7 +239,8 @@ async def workflow_handoff_watchdog(
 @router.get("/workflow-sla")
 async def workflow_sla(
     request: Request,
-    session: AsyncSession = Depends(get_db),
+    # story #2461(§6 봉합③ part2): 위 workflow_handoff_watchdog와 동일 근거 — 전용 워커풀.
+    session: AsyncSession = Depends(get_worker_db),
 ) -> JSONResponse:
     verify_cron(request)
     try:
@@ -589,7 +593,12 @@ async def score_hypotheses_cron(
 @router.post("/embed-backlog")
 async def embed_backlog_cron(
     request: Request,
-    session: AsyncSession = Depends(get_db),
+    # story #2461(§6 봉합③ part2, PO 승인 2026-08-05): get_db 대신 get_worker_db — 이 함수
+    # 안에서 FOR UPDATE SKIP LOCKED 락을 쥔 채 동기 Vertex AI 호출(asyncio.to_thread로
+    # 이벤트루프는 안 막지만 세션/락 자체는 그 구간 내내 열려 있음, 유료 API 중복호출 방지
+    # 위해 의도적으로 유지 — embedding_backlog.py docstring 참조)이 요청 primary 풀이 아닌
+    # 전용 워커풀에서만 그 시간을 소모하게 한다.
+    session: AsyncSession = Depends(get_worker_db),
 ) -> JSONResponse:
     """E-LOOP-LEDGER P1-S3: embeddings 백로그(status pending/failed) 배치 임베딩(블루프린트 §P1).
 

--- a/backend/app/services/event_broker.py
+++ b/backend/app/services/event_broker.py
@@ -519,13 +519,16 @@ _OUTBOX_POLL_INTERVAL = 1.0
 async def _claim_outbox_batch(limit: int = _OUTBOX_BATCH_SIZE) -> list[dict]:
     """FOR UPDATE SKIP LOCKED로 미발행 batch를 골라 즉시 commit(락을 짧게만 쥔다 — 발행은
     여기서 안 함). 반환은 세션-독립적인 순수 dict라 다음 단계가 이 세션을 물고 다닐 필요가
-    없다(story #2461, §6 봉합③ — delivery_dispatcher.py와 동형 claim/work/finalize 분리)."""
+    없다(story #2461, §6 봉합③ — delivery_dispatcher.py와 동형 claim/work/finalize 분리).
+
+    §6 봉합③ part2(PO 승인 2026-08-05): 요청 primary 풀이 아니라 전용 `worker_session_factory`
+    사용 — 이 claim 트랜잭션이 요청 경로 풀 예산과 완전 무관해진다."""
     from sqlalchemy import select
 
-    from app.core.database import async_session_factory
+    from app.core.database import worker_session_factory
     from app.models.event_outbox import EventOutbox
 
-    async with async_session_factory() as session:
+    async with worker_session_factory() as session:
         rows = (
             await session.execute(
                 select(EventOutbox)
@@ -582,18 +585,18 @@ async def _publish_outbox_batch(claimed: list[dict]) -> list[uuid.UUID]:
 
 
 async def _finalize_outbox_published(published_ids: list[uuid.UUID]) -> None:
-    """발행 성공 row를 published_at으로 마킹(짧은 세션 — story #2461)."""
+    """발행 성공 row를 published_at으로 마킹(짧은 세션 — story #2461, 전용 워커풀 사용)."""
     from datetime import datetime, timezone
 
     from sqlalchemy import update
 
-    from app.core.database import async_session_factory
+    from app.core.database import worker_session_factory
     from app.models.event_outbox import EventOutbox
 
     if not published_ids:
         return
     now = datetime.now(timezone.utc)
-    async with async_session_factory() as session:
+    async with worker_session_factory() as session:
         await session.execute(
             update(EventOutbox).where(EventOutbox.id.in_(published_ids)).values(published_at=now)
         )

--- a/backend/app/services/l2_trigger_worker.py
+++ b/backend/app/services/l2_trigger_worker.py
@@ -149,9 +149,13 @@ class L2TriggerWorker:
                         await asyncio.sleep(self.poll_interval_s)
                         continue
 
-                    from app.core.database import async_session_factory
+                    # story #2461(§6 봉합③ part2, PO 승인 2026-08-05 안 A): per-tick 처리
+                    # 세션을 요청 primary 풀이 아니라 전용 워커풀에서 뜬다(finding #6 인접
+                    # 이슈 — _fire_one()이 이 세션 안에서 deliver_injected_event_webhook
+                    # 웹훅 POST를 await하는 구간이 요청풀이 아닌 여기서만 소모되게).
+                    from app.core.database import worker_session_factory
 
-                    async with async_session_factory() as db:
+                    async with worker_session_factory() as db:
                         await self._poll_once(db)
                         now_mono = time.monotonic()
                         if now_mono - last_deadline_scan >= self.deadline_scan_interval_s:
@@ -174,15 +178,23 @@ class L2TriggerWorker:
 
     # ── advisory lock (AC③) ──────────────────────────────────────────────────────
     async def _ensure_lock(self) -> bool:
-        """advisory lock 미사용 시 항상 True. 사용 시 holder만 True(전용 커넥션·AUTOCOMMIT)."""
+        """advisory lock 미사용 시 항상 True. 사용 시 holder만 True(전용 커넥션·AUTOCOMMIT).
+
+        story #2461(§6 봉합③ part2, PO 승인 2026-08-05 안 A — finding #6): 이 커넥션은 leader인
+        동안 절대 반납되지 않는다(session-level advisory lock의 생명주기가 곧 이 연결의 생명주기
+        — 이게 페일오버가 즉시·자동인 이유이기도 하다, 안 B 검토 문서 참조). 예전엔 요청
+        primary 엔진(`engine`)에서 checkout해 요청풀 예산을 영구히 1만큼 깎았다 — 이제 전용
+        `worker_engine`(pg_pubsub.listen_loop()과 같은 "요청 풀 밖 전용 연결" 원칙)에서 뜬다.
+        메커니즘·시맨틱스(pg_try_advisory_lock·크래시 시 자동해제·standby ≤poll_interval 승계)는
+        완전히 그대로 — 어느 풀에서 커넥션이 나오는지만 바뀐다."""
         if not self.use_advisory_lock:
             return True
         if self._holds_lock:
             return True
         if self._lock_conn is None:
-            from app.core.database import engine
+            from app.core.database import worker_engine
 
-            self._lock_conn = await engine.connect()
+            self._lock_conn = await worker_engine.connect()
             await self._lock_conn.execution_options(isolation_level="AUTOCOMMIT")
         got = (
             await self._lock_conn.execute(

--- a/backend/tests/test_2078_event_outbox_realdb.py
+++ b/backend/tests/test_2078_event_outbox_realdb.py
@@ -90,6 +90,9 @@ async def test_resolve_org_id_agent_target_falls_back_to_org_members_lookup(monk
 
     engine, Session = await _session_factory()
     monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    # story #2461(§6 봉합③ part2): outbox_dispatcher_loop의 claim/finalize가 이제
+    # worker_session_factory를 쓴다 — 이 테스트의 격리 엔진이 그쪽에도 걸리게 함께 patch.
+    monkeypatch.setattr("app.core.database.worker_session_factory", Session)
     try:
         org_id, member_id = await _seed_org_member(Session)
         resolved = await eb._resolve_org_id("agent", str(member_id), {})
@@ -108,6 +111,9 @@ async def test_resolve_org_id_unresolvable_returns_none(monkeypatch):
 
     engine, Session = await _session_factory()
     monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    # story #2461(§6 봉합③ part2): outbox_dispatcher_loop의 claim/finalize가 이제
+    # worker_session_factory를 쓴다 — 이 테스트의 격리 엔진이 그쪽에도 걸리게 함께 patch.
+    monkeypatch.setattr("app.core.database.worker_session_factory", Session)
     try:
         resolved = await eb._resolve_org_id("agent", str(uuid.uuid4()), {})
         assert resolved is None
@@ -128,6 +134,9 @@ async def test_insert_outbox_row_creates_pending_row(monkeypatch):
 
     engine, Session = await _session_factory()
     monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    # story #2461(§6 봉합③ part2): outbox_dispatcher_loop의 claim/finalize가 이제
+    # worker_session_factory를 쓴다 — 이 테스트의 격리 엔진이 그쪽에도 걸리게 함께 patch.
+    monkeypatch.setattr("app.core.database.worker_session_factory", Session)
     try:
         org_id = uuid.uuid4()
         await eb._insert_outbox_row("org", str(org_id), "story.status_changed", {"entity_id": "s1"})
@@ -157,6 +166,9 @@ async def test_insert_outbox_row_skips_silently_when_org_id_unresolvable(monkeyp
 
     engine, Session = await _session_factory()
     monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    # story #2461(§6 봉합③ part2): outbox_dispatcher_loop의 claim/finalize가 이제
+    # worker_session_factory를 쓴다 — 이 테스트의 격리 엔진이 그쪽에도 걸리게 함께 patch.
+    monkeypatch.setattr("app.core.database.worker_session_factory", Session)
     try:
         await eb._insert_outbox_row("agent", str(uuid.uuid4()), "x", {})  # raise 안 해야
         async with Session() as s:
@@ -183,6 +195,9 @@ async def test_outbox_dispatcher_publishes_pending_rows_and_marks_published(monk
 
     engine, Session = await _session_factory()
     monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    # story #2461(§6 봉합③ part2): outbox_dispatcher_loop의 claim/finalize가 이제
+    # worker_session_factory를 쓴다 — 이 테스트의 격리 엔진이 그쪽에도 걸리게 함께 patch.
+    monkeypatch.setattr("app.core.database.worker_session_factory", Session)
     monkeypatch.setattr("app.core.config.settings.redis_url", "redis://fake:6379/0")
 
     published = []

--- a/backend/tests/test_2461_worker_pool_engine.py
+++ b/backend/tests/test_2461_worker_pool_engine.py
@@ -1,0 +1,78 @@
+"""story #2461(§6 봉합③ part2, PO 승인 2026-08-05): 전용 워커풀 엔진 배선 검증.
+
+L2TriggerWorker의 advisory-lock 영구연결(finding #6) + embedding_backlog/
+workflow_sla_processor/workflow_handoff_watchdog/event_broker outbox의 claim/finalize
+세션(finding #5)을 요청 primary 풀(`app.core.database.engine`)과 완전 분리된
+`worker_engine`으로 옮겼다. 이 파일은 그 배선 자체(엔진이 진짜 별개 객체인지·cron 라우터가
+정확히 get_worker_db를 쓰는지)를 검증 — 실제 커넥션 독립성 실증은
+`test_2461_worker_pool_engine_realdb.py` 참조. ⛔공유 dev 백엔드 접속 없음.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def test_worker_engine_is_distinct_from_request_engine():
+    """worker_engine이 request 경로 engine과 별개 객체(= 별개 풀)여야 한다."""
+    from app.core.database import engine, worker_engine
+
+    assert worker_engine is not engine
+    assert worker_engine.pool is not engine.pool
+
+
+def test_worker_engine_pool_size_from_settings():
+    from app.core.config import settings
+    from app.core.database import worker_engine
+
+    assert worker_engine.pool.size() == settings.worker_db_pool_size
+
+
+def test_worker_session_factory_binds_to_worker_engine():
+    from app.core.database import worker_engine, worker_session_factory
+
+    assert worker_session_factory.kw["bind"] is worker_engine
+
+
+@pytest.mark.anyio
+async def test_get_worker_db_yields_session_bound_to_worker_engine():
+    from app.core.database import get_worker_db, worker_engine
+
+    gen = get_worker_db()
+    session = await gen.__anext__()
+    try:
+        assert session.bind is worker_engine
+    finally:
+        await gen.aclose()
+
+
+def test_cron_batch_endpoints_use_get_worker_db_not_get_db():
+    """§6 봉합③ part2가 요구하는 정확한 3개 엔드포인트만 get_worker_db로 전환됐는지 —
+    다른 cron 엔드포인트(get_db 나머지 19개)는 무변경이어야 한다(과확장 방지 pin)."""
+    import inspect
+
+    from app.core.database import get_db, get_worker_db
+    from app.routers import cron
+
+    target_funcs = {
+        "workflow_handoff_watchdog": cron.workflow_handoff_watchdog,
+        "workflow_sla": cron.workflow_sla,
+        "embed_backlog_cron": cron.embed_backlog_cron,
+    }
+    for name, fn in target_funcs.items():
+        sig = inspect.signature(fn)
+        default = sig.parameters["session"].default
+        # Depends(get_worker_db) — default.dependency가 get_worker_db 함수 그 자체.
+        assert default.dependency is get_worker_db, f"{name}가 get_worker_db를 안 씀"
+        assert default.dependency is not get_db
+
+
+def test_l2_lock_uses_worker_engine_not_request_engine():
+    """l2_trigger_worker.py의 _ensure_lock 소스에 요청 engine 참조가 남아있지 않은지
+    (회귀 방지 — 가장 직접적인 pin)."""
+    import inspect
+
+    from app.services.l2_trigger_worker import L2TriggerWorker
+
+    source = inspect.getsource(L2TriggerWorker._ensure_lock)
+    assert "worker_engine" in source
+    assert "from app.core.database import engine" not in source

--- a/backend/tests/test_2461_worker_pool_engine_realdb.py
+++ b/backend/tests/test_2461_worker_pool_engine_realdb.py
@@ -1,0 +1,78 @@
+"""story #2461(§6 봉합③ part2) realdb 검증 — 워커풀과 요청풀의 진짜 독립성 실측.
+
+PO 지시(2026-08-05): 검증="워커가 요청풀 안 먹나". #2460/#2461 파트1의 pin들은 "세션이 제때
+반납되는가"(단일 풀 안에서의 생명주기)를 쟀다 — 이 파일은 **더 근본적인 축**을 잰다: 워커풀
+자체가 요청풀과 물리적으로 다른 풀이라, **한쪽이 완전히 고갈돼도 다른 쪽은 무영향**임을
+pool_size=1 두 엔진으로 실측한다(SHOW POOLS/pg_stat_activity가 실제로 보여줄 그 분리를
+그대로 재현). ⛔공유 dev 백엔드 접속 없음 — 로컬 Postgres만 사용.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="realdb 테스트는 로컬 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+@pytest.mark.anyio
+async def test_worker_pool_exhaustion_does_not_block_request_pool():
+    """「요청풀」을 완전히 고갈시켜 놓은 채(pool_size=1, 그 1개 커넥션을 계속 쥠) 「워커풀」
+    (별개 엔진, 역시 pool_size=1)로 새 세션을 여는 것이 **안 막혀야** 한다 — 두 풀이 같은
+    엔진/풀 객체를 공유했다면 이 요청이 pool_timeout으로 실패했을 것."""
+    request_engine = create_async_engine(_async_url(), pool_size=1, max_overflow=0, pool_timeout=3)
+    worker_engine = create_async_engine(_async_url(), pool_size=1, max_overflow=0, pool_timeout=3)
+    try:
+        # 요청풀의 유일한 커넥션을 계속 쥔 채(고갈 상태 고정).
+        held_request_session = AsyncSession(request_engine)
+        await held_request_session.execute(select(1))
+        try:
+            # 워커풀은 완전히 별개 엔진이라 요청풀 고갈과 무관하게 즉시 성공해야 한다.
+            async with AsyncSession(worker_engine) as worker_session:
+                result = await worker_session.execute(select(1))
+                assert result.scalar() == 1
+        finally:
+            await held_request_session.close()
+    finally:
+        await request_engine.dispose()
+        await worker_engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_request_pool_exhaustion_does_not_block_worker_pool():
+    """역방향 — 워커풀을 고갈시켜도 요청풀은 무영향(대칭성 확認, 한쪽만 쟀다는 비판 방지)."""
+    request_engine = create_async_engine(_async_url(), pool_size=1, max_overflow=0, pool_timeout=3)
+    worker_engine = create_async_engine(_async_url(), pool_size=1, max_overflow=0, pool_timeout=3)
+    try:
+        held_worker_session = AsyncSession(worker_engine)
+        await held_worker_session.execute(select(1))
+        try:
+            async with AsyncSession(request_engine) as request_session:
+                result = await request_session.execute(select(1))
+                assert result.scalar() == 1
+        finally:
+            await held_worker_session.close()
+    finally:
+        await request_engine.dispose()
+        await worker_engine.dispose()
+
+

--- a/backend/tests/test_2461_worker_pool_separation_realdb.py
+++ b/backend/tests/test_2461_worker_pool_separation_realdb.py
@@ -54,6 +54,10 @@ async def test_outbox_publish_phase_holds_no_connection_from_claim_phase(monkeyp
         await _clean_event_outbox(engine)
         factory = async_sessionmaker(engine, expire_on_commit=False)
         monkeypatch.setattr("app.core.database.async_session_factory", factory)
+        # story #2461 part2: outbox claim/publish/finalize가 이제 worker_session_factory를
+        # 쓴다 — 이 테스트의 격리 엔진이 그쪽에도 걸리게 함께 patch(안 하면 CI의 실 DATABASE_URL
+        # 로 새 나가 "attached to a different loop" — 로컬 재현 완료).
+        monkeypatch.setattr("app.core.database.worker_session_factory", factory)
 
         async with AsyncSession(engine, expire_on_commit=False) as session:
             session.add(EventOutbox(
@@ -95,6 +99,10 @@ async def test_outbox_claim_commits_atomically(monkeypatch):
         await _clean_event_outbox(engine)
         factory = async_sessionmaker(engine, expire_on_commit=False)
         monkeypatch.setattr("app.core.database.async_session_factory", factory)
+        # story #2461 part2: outbox claim/publish/finalize가 이제 worker_session_factory를
+        # 쓴다 — 이 테스트의 격리 엔진이 그쪽에도 걸리게 함께 patch(안 하면 CI의 실 DATABASE_URL
+        # 로 새 나가 "attached to a different loop" — 로컬 재현 완료).
+        monkeypatch.setattr("app.core.database.worker_session_factory", factory)
 
         row_id = uuid.uuid4()
         async with AsyncSession(engine, expire_on_commit=False) as session:
@@ -126,6 +134,10 @@ async def test_outbox_finalize_marks_published(monkeypatch):
         await _clean_event_outbox(engine)
         factory = async_sessionmaker(engine, expire_on_commit=False)
         monkeypatch.setattr("app.core.database.async_session_factory", factory)
+        # story #2461 part2: outbox claim/publish/finalize가 이제 worker_session_factory를
+        # 쓴다 — 이 테스트의 격리 엔진이 그쪽에도 걸리게 함께 patch(안 하면 CI의 실 DATABASE_URL
+        # 로 새 나가 "attached to a different loop" — 로컬 재현 완료).
+        monkeypatch.setattr("app.core.database.worker_session_factory", factory)
 
         row_id = uuid.uuid4()
         async with AsyncSession(engine, expire_on_commit=False) as session:

--- a/backend/tests/test_check_env_drift_settings_coverage.py
+++ b/backend/tests/test_check_env_drift_settings_coverage.py
@@ -149,7 +149,11 @@ def test_settings_field_env_keys_works_without_pydantic_settings_importable(monk
     # Settings 필드를 실제로 잡아낸 것 — 개수 자체가 늘어난 게 아니라 늘어난 게 정답이다.
     # #2451(§6 Phase3 read replica): database_url_read 필드 신설로 84→85(DATABASE_URL_READ 포함).
     # 미설정이면 primary 폴백·설정 시 read replica 라우팅. 가드가 신규 필드를 설계대로 잡은 것.
+    # #2461(§6 봉합③ part2, PO 승인 2026-08-05): worker_db_pool_size/worker_db_max_overflow
+    # 필드 신설로 85→87(WORKER_DB_POOL_SIZE·WORKER_DB_MAX_OVERFLOW 포함) — L2/배치워커 전용
+    # worker_engine 풀 크기 설정. 가드가 신규 필드를 설계대로 잡은 것.
     assert "PRESENCE_REDIS_ENABLED" in keys and "SSE_TRANSIENT_REPLAY_ENABLED" in keys
     assert "REQUIRE_VERIFIED_EMAIL_FOR_ORG_CREATE" in keys
     assert "DATABASE_URL_READ" in keys
-    assert len(keys) == 85
+    assert "WORKER_DB_POOL_SIZE" in keys and "WORKER_DB_MAX_OVERFLOW" in keys
+    assert len(keys) == 87

--- a/backend/tests/test_l2_trigger_worker.py
+++ b/backend/tests/test_l2_trigger_worker.py
@@ -106,6 +106,9 @@ async def test_ensure_lock_disabled_always_true():
 
 @pytest.mark.anyio
 async def test_ensure_lock_holder_true_standby_false():
+    # story #2461(§6 봉합③ part2): _ensure_lock의 락 커넥션은 이제 요청 primary 엔진
+    # (app.core.database.engine)이 아니라 전용 worker_engine에서 나온다 — mock 대상도 그에
+    # 맞춰 patch한다(아니면 실 DB로 connect 시도해 OSError).
     # holder: pg_try_advisory_lock → True.
     w = L2TriggerWorker(use_advisory_lock=True)
     conn = AsyncMock()
@@ -113,7 +116,7 @@ async def test_ensure_lock_holder_true_standby_false():
     lock_res.scalar.return_value = True
     conn.execute = AsyncMock(return_value=lock_res)
     conn.execution_options = AsyncMock()
-    with patch("app.core.database.engine") as eng:
+    with patch("app.core.database.worker_engine") as eng:
         eng.connect = AsyncMock(return_value=conn)
         assert await w._ensure_lock() is True
         assert w._holds_lock is True
@@ -129,7 +132,7 @@ async def test_ensure_lock_holder_true_standby_false():
     res2.scalar.return_value = False
     conn2.execute = AsyncMock(return_value=res2)
     conn2.execution_options = AsyncMock()
-    with patch("app.core.database.engine") as eng2:
+    with patch("app.core.database.worker_engine") as eng2:
         eng2.connect = AsyncMock(return_value=conn2)
         assert await w2._ensure_lock() is False
         assert w2._holds_lock is False
@@ -328,7 +331,7 @@ async def test_run_cancels_gracefully_and_releases_lock():
          patch.object(w, "_poll_once", AsyncMock(return_value=[])), \
          patch.object(w, "_scan_deadlines", AsyncMock(return_value=[])), \
          patch.object(w, "_release_lock", AsyncMock()) as rel, \
-         patch("app.core.database.async_session_factory") as sf:
+         patch("app.core.database.worker_session_factory") as sf:  # story #2461: per-tick 세션도 전용 워커풀로
         sf.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
         sf.return_value.__aexit__ = AsyncMock(return_value=False)
         task = asyncio.create_task(w.run())


### PR DESCRIPTION
## Summary
- finding #6(L2 advisory-lock 영구연결이 요청 primary 풀 점유) + finding #5 잔여(embedding_backlog의 Vertex AI 호출 中 세션보유)를 요청 경로와 완전 분리된 전용 `worker_engine`/`worker_session_factory`(기본 pool_size=2/overflow=1)로 해소.
- L2 설계 제안서(안 A, PO 승인) 그대로: `pg_try_advisory_lock` 메커니즘·세션-생명주기=페일오버 시맨틱스 100% 무변경, 커넥션이 나오는 풀만 교체.
- `app/core/database.py`: `worker_engine`/`worker_session_factory`/`get_worker_db` 신설 — `pg_pubsub.listen_loop()`의 "요청 풀 밖 전용 연결" 원칙 재사용.
- `l2_trigger_worker.py`: advisory-lock 커넥션 + per-tick 처리세션 모두 워커풀로.
- `event_broker.py`: outbox claim/finalize도 워커풀로(요청 경로 insert는 무변경).
- `routers/cron.py`: `/embed-backlog`·`/workflow-sla`·`/workflow-handoff-watchdog` 3개만 `get_worker_db`로 전환(나머지 19개 cron 엔드포인트는 무변경 — 과확장 방지 pin 포함).
- `main.py`: `worker_engine.dispose()` lifespan 배선.
- ⛔**prod 배포 前 필수**: 커넥션 budget 산식이 `per_instance=5→8`로 바뀜(config.py 주석에 재검산 항목 기록) — 디디는 prod 접근이 없어 실제 maxScale 기준 재검산은 PO/infra 몫.

## Test plan
- [x] 신규 유닛 6종 — 엔진 독립성·풀사이즈·세션바인딩·cron 3개만 전환됐는지(sabotage로 discriminating 확認)·L2 소스 pin
- [x] 신규 realdb 2종 — pool_size=1 두 엔진으로 상호 고갈 무영향 실측(양방향), sabotage로 discriminating 확認
- [x] env-drift settings 필드 카운터 갱신(85→87)
- [x] 기존 L2/cron/embedding/SLA/watchdog 테스트 전체 green
- [x] 전체 non-realdb 스위트 4387 passed(신규 실패 0)
- [ ] Qadir QA
- [ ] PO/infra: prod maxScale 재검산(배포 前)

🤖 Generated with [Claude Code](https://claude.com/claude-code)