### PR TITLE
fix(#2466): stream_connected 퍼널 runtime 하드코딩 제거

### DIFF
--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -30,6 +30,7 @@ from app.models.event import Event
 from app.models.organization import Organization
 from app.models.team import TeamMember
 from app.routers.events import _agent_connections, _event_to_payload
+from app.services.agent_onboarding_config import DEFAULT_RUNTIME
 
 logger = logging.getLogger(__name__)
 
@@ -485,11 +486,17 @@ async def agent_stream(
                 # OB-4b seam(stream_connected): V2 /agent/stream 연결 establish 1회(presence online과 동일
                 # tx). begin_nested 격리·non-blocking·fail-silent — savepoint라 emit 실패가 presence/세션
                 # write를 poison 안 함(단일경로·presence 무회귀). funnel mcp_reachable 직전 reachability.
+                # spec-2377 §3/§6 fix(2026-08-05, story #2466 별건): 이 리터럴 "claude-code"가
+                # 실제 연결 런타임과 무관하게 항상 찍혀 퍼널 raw 이 그 에이전트의 진짜 runtime_type
+                # 을 반영 못 했다 — tm(위에서 이미 로드된 TeamMember, 추가 쿼리 0)의 실제
+                # runtime_type을 쓴다. 이 엔드포인트 자체는 stdio 전용(AGENT_GATEWAY_V2 브리지가
+                # sse_bridge.py=stdio만 구동) — transport="stdio"는 하드코딩이 아니라 이 경로의
+                # 실제 불변 사실(무회귀).
                 from app.services.onboarding_funnel import emit_onboarding_event
                 await emit_onboarding_event(
                     _pdb, "stream_connected", agent_id=agent_id,
                     org_id=uuid.UUID(org_id_str), session_id=session_id,
-                    runtime="claude-code", transport="stdio",
+                    runtime=tm.runtime_type or DEFAULT_RUNTIME, transport="stdio",
                 )
                 await _pdb.commit()
             _presence_wired = True

--- a/backend/tests/test_ob4b_funnel_seams.py
+++ b/backend/tests/test_ob4b_funnel_seams.py
@@ -111,6 +111,20 @@ def test_stream_connected_wired_one_time_isolated():
     assert "emit_onboarding_event(" in src
 
 
+def test_stream_connected_runtime_not_hardcoded_to_claude_code():
+    """spec-2377 §3/§6(story #2466 별건 c 스코프): `stream_connected`가 실제 연결 에이전트의
+    `runtime_type`과 무관하게 항상 `runtime="claude-code"`로 찍히던 하드코딩을 걷어냄 — 이제
+    이미 로드된 team_member(`tm`)의 실제 `runtime_type`을 쓴다(추가 쿼리 0). sabotage: 이 문자열
+    리터럴이 다시 생기면 이 테스트가 잡는다."""
+    from app.routers import agent_gateway
+    src = inspect.getsource(agent_gateway)
+    assert 'runtime="claude-code", transport="stdio"' not in src
+    assert "runtime=tm.runtime_type" in src
+    # transport="stdio"는 하드코딩 버그가 아니라 이 엔드포인트(AGENT_GATEWAY_V2, sse_bridge.py=
+    # stdio 전용)의 실제 불변 사실 — 그대로 유지돼야 한다(무회귀).
+    assert 'transport="stdio"' in src
+
+
 # ─── RC-1(산티아고): 전용 세션·api_key 무접촉·event 존재 dedup·advisory lock ──────
 
 def _sess_cm(exists_row):


### PR DESCRIPTION
## Summary
- spec-2377 §3/§6 — `/agent/stream`(agent_gateway.py) 연결 시 `emit_onboarding_event(..., runtime="claude-code", ...)`가 실제 연결 에이전트의 `runtime_type`과 무관하게 항상 리터럴 하드코딩이었음
- 이미 로드된 `TeamMember`(`tm`)의 실제 `runtime_type`을 쓰도록 수정(추가 쿼리 0, `DEFAULT_RUNTIME` fallback)
- `transport="stdio"`는 그대로 유지 — 이 엔드포인트는 AGENT_GATEWAY_V2 전용(`sse_bridge.py`가 stdio만 구동)이라 하드코딩이 아니라 실제 불변 사실

## Context — "별건 C" 스코프 축소
PO가 story #2466 곁다리로 배정한 "별건 C"(spec-2377이 지목한 "실 호출 도착 이력 부재")를 조사하던 중, `agent_verify.py`의 기존 heartbeat 기반 verification rail(`agent_project_profiles.last_seen_at`, `sprintable_mcp/server.py`의 모든 tool wrapper에서 transport 무관하게 발화)이 이미 이 문제를 상당 부분 해결하고 있음을 발견 — 라이브 실측(`dev-mcp.sprintable.ai/mcp`에 직접 `tools/call ping` 실행 후 `last_seen_at` 갱신 확인)으로 검증. PO 판단으로 신규 이력 테이블/컬럼은 짓지 않고, 이 퍼널 라벨 하드코딩만 정정하는 것으로 스코프 확정.

## Test plan
- [x] `test_ob4b_funnel_seams.py`에 신규 회귀가드(`test_stream_connected_runtime_not_hardcoded_to_claude_code`) — sabotage로 실제 discriminating 확인(하드코딩 복원 시 FAIL 재현 후 원복)
- [x] 로컬 pytest 105개(agent_gateway/funnel/onboarding 연관 스위트) green, 0 regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)