### PR TITLE
[SID:2468] 새 프로젝트 «무반응» = 조용한 403 fix — stale project_id 클리어 + 실패 명시

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -103,7 +103,8 @@
     "switcherOptionalLabel": "(optional)",
     "switcherProjectDescPlaceholder": "A short description of the project",
     "switcherCreating": "Creating…",
-    "switcherCreateButton": "Create"
+    "switcherCreateButton": "Create",
+    "switcherCreateProjectError": "Couldn't create the project. Please try again in a moment."
   },
   "storage": {
     "title": "Storage",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -103,7 +103,8 @@
     "switcherOptionalLabel": "(선택)",
     "switcherProjectDescPlaceholder": "프로젝트에 대한 간단한 설명",
     "switcherCreating": "생성 중…",
-    "switcherCreateButton": "만들기"
+    "switcherCreateButton": "만들기",
+    "switcherCreateProjectError": "프로젝트를 만들지 못했습니다. 잠시 후 다시 시도해 주세요."
   },
   "storage": {
     "title": "스토리지",

--- a/apps/web/src/components/nav/context-switcher-chip.tsx
+++ b/apps/web/src/components/nav/context-switcher-chip.tsx
@@ -224,6 +224,10 @@ export function ContextSwitcherChip({ orgs, currentOrgId, projects, currentProje
                 onChange={(e) => s.setNewProjectDesc(e.target.value)}
               />
             </div>
+            {/* story #2468(b) — 실패를 침묵하지 않는다("버튼 무반응"의 정체가 이 자리였다). */}
+            {s.createProjectError && (
+              <p role="alert" className="text-sm text-destructive">{s.createProjectError}</p>
+            )}
             <DialogFooter>
               <DialogClose render={<Button type="button" variant="ghost" disabled={s.creating}>{tCommon('cancel')}</Button>} />
               <Button type="submit" disabled={!s.newProjectName.trim() || s.creating}>

--- a/apps/web/src/components/nav/unified-switcher.tsx
+++ b/apps/web/src/components/nav/unified-switcher.tsx
@@ -229,6 +229,10 @@ export function UnifiedSwitcher({
                 onChange={(e) => s.setNewProjectDesc(e.target.value)}
               />
             </div>
+            {/* story #2468(b) — 실패를 침묵하지 않는다("버튼 무반응"의 정체가 이 자리였다). */}
+            {s.createProjectError && (
+              <p role="alert" className="text-sm text-destructive">{s.createProjectError}</p>
+            )}
             <DialogFooter>
               <DialogClose render={<Button type="button" variant="ghost" disabled={s.creating}>{tCommon('cancel')}</Button>} />
               <Button type="submit" disabled={!s.newProjectName.trim() || s.creating}>

--- a/apps/web/src/hooks/use-unified-switcher.test.tsx
+++ b/apps/web/src/hooks/use-unified-switcher.test.tsx
@@ -8,7 +8,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, useEffect } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
 import { useUnifiedSwitcher, type OrgSwitcherItem, type ProjectSwitcherItem } from './use-unified-switcher';
+import { TAB_PROJECT_STORAGE_KEY } from '@/lib/project-context-client';
+import koMessages from '../../messages/ko.json';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -39,10 +42,20 @@ const MOONKLABS_PROJECTS = [{ id: 'proj-sprintable', name: 'sprintable' }];
 
 let result: ReturnType<typeof useUnifiedSwitcher> | null = null;
 
-function TestComp() {
+function InnerTestComp() {
   const hook = useUnifiedSwitcher({ orgs: ORGS, currentOrgId: 'org-moonklabs', projects: STALE_PROJECTS, currentProjectId: undefined });
   useEffect(() => { result = hook; });
   return null;
+}
+
+// story #2468 — useUnifiedSwitcher가 이제 useTranslations('nav')를 쓴다(에러 문구).
+// NextIntlClientProvider 없이 렌더하면 "context ... was not found"로 즉시 죽는다.
+function TestComp() {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      <InnerTestComp />
+    </NextIntlClientProvider>
+  );
 }
 
 beforeEach(() => {
@@ -52,6 +65,7 @@ beforeEach(() => {
   result = null;
   routerPushMock.mockClear();
   searchParamsValueRef.current = '';
+  window.sessionStorage.clear(); // story #2468 — 테스트 간 stale project_id 오염 방지
 });
 
 afterEach(async () => {
@@ -127,5 +141,77 @@ describe('useUnifiedSwitcher — switchProject의 ?next= 복귀 (story #2212)', 
       const dest = String(call[0]);
       expect(dest.startsWith('/moonklabs/sprintable/board')).toBe(true); // 목적지 자체는 항상 내부 경로
     }
+  });
+});
+
+// story #2468(a)(2026-08-06 미르코 라이브 재현) — "새 프로젝트" 버튼 무반응의 정체는 조용한
+// 403이었다: org 전환 後에도 sessionStorage(TAB_PROJECT_STORAGE_KEY)가 전환 前 org의
+// project_id를 그대로 들고 있어, 전역 fetch 인터셉터(project-context-client.ts)가 그 stale
+// id를 X-Project-Id로 계속 실어 보내고 — 새 org엔 그 프로젝트가 없어 BE가 403을 낸다.
+describe('useUnifiedSwitcher — switchOrg의 stale sessionStorage 클리어 (story #2468 a)', () => {
+  it('org 전환 성공 시 TAB_PROJECT_STORAGE_KEY sessionStorage를 지운다(다음 org에 없는 project_id를 안 실어 보내게)', async () => {
+    window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, 'proj-from-previous-org');
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: { ok: true } }) })));
+    await act(async () => { root.render(<TestComp />); });
+
+    await act(async () => { await result?.switchOrg('org-dogfood'); });
+
+    expect(window.sessionStorage.getItem(TAB_PROJECT_STORAGE_KEY)).toBeNull();
+  });
+
+  it('org 전환 실패(응답 실패) 時엔 sessionStorage를 안 건드린다 — 롤백된 org 그대로면 그 project_id는 여전히 유효하다', async () => {
+    window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, 'proj-still-valid');
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, json: async () => ({ error: { code: 'SWITCH_FAILED' } }) })));
+    await act(async () => { root.render(<TestComp />); });
+
+    await act(async () => { await result?.switchOrg('org-dogfood'); });
+
+    expect(window.sessionStorage.getItem(TAB_PROJECT_STORAGE_KEY)).toBe('proj-still-valid');
+  });
+});
+
+// story #2468(b, 근본) — 실패를 침묵하지 않는다. 예전엔 createProject가 !res.ok에 그냥 false만
+// 반환했고, 호출부(unified-switcher.tsx·context-switcher-chip.tsx)가 그 값을 void로 버려
+// "버튼 무반응"으로 보였다. 원인이 뭐든(403/기타) 화면에 명시 에러가 뜨는지를 고정한다.
+describe('useUnifiedSwitcher — createProject 실패 표시 (story #2468 b)', () => {
+  it('생성 실패(403 등) 時 createProjectError가 채워지고, 다이얼로그는 안 닫히고, false를 반환한다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      json: async () => ({ error: { code: 'FORBIDDEN', message: 'No access to the specified project' } }),
+    })));
+    await act(async () => { root.render(<TestComp />); });
+    await act(async () => { result?.setCreateProjectOpen(true); });
+
+    let returned: boolean | undefined;
+    await act(async () => { returned = await result?.createProject('새 프로젝트', ''); });
+
+    expect(returned).toBe(false);
+    expect(result?.createProjectError).toBeTruthy();
+    expect(result?.createProjectOpen).toBe(true); // 조용히 닫히지 않는다 — 사용자가 에러를 본다
+  });
+
+  it('생성 성공 時엔 createProjectError가 null이고 다이얼로그가 닫힌다(회귀가드)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/projects') return { ok: true, json: async () => ({ data: { id: 'proj-new' } }) };
+      return { ok: true, json: async () => ({ data: { ok: true } }) }; // switch-project 등
+    }));
+    await act(async () => { root.render(<TestComp />); });
+    await act(async () => { result?.setCreateProjectOpen(true); });
+
+    await act(async () => { await result?.createProject('새 프로젝트', ''); });
+
+    expect(result?.createProjectError).toBeNull();
+    expect(result?.createProjectOpen).toBe(false);
+  });
+
+  it('다이얼로그를 다시 열면(setCreateProjectOpen) 이전 실패 문구가 지워진다 — 낡은 에러가 새 시도처럼 안 보인다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, json: async () => ({ error: { code: 'FORBIDDEN' } }) })));
+    await act(async () => { root.render(<TestComp />); });
+    await act(async () => { result?.setCreateProjectOpen(true); });
+    await act(async () => { await result?.createProject('새 프로젝트', ''); });
+    expect(result?.createProjectError).toBeTruthy();
+
+    await act(async () => { result?.setCreateProjectOpen(false); });
+    expect(result?.createProjectError).toBeNull();
   });
 });

--- a/apps/web/src/hooks/use-unified-switcher.ts
+++ b/apps/web/src/hooks/use-unified-switcher.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { TAB_PROJECT_STORAGE_KEY } from '@/lib/project-context-client';
 
 export interface OrgSwitcherItem {
@@ -69,6 +70,7 @@ export function withSwitchedSlugs(
  * 훅이 들고 있지만 그 값을 어느 UI 프리미티브의 open/onOpenChange에 묶을지는 호출부 몫이다.
  */
 export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjectId }: UseUnifiedSwitcherArgs) {
+  const tSwitcher = useTranslations('nav');
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -82,6 +84,10 @@ export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjec
 
   const [otherOrgProjects, setOtherOrgProjects] = useState<Record<string, ProjectSwitcherItem[]>>({});
   const [loadingOrgIds, setLoadingOrgIds] = useState<Set<string>>(new Set());
+  // story #2468(P0, 2026-08-06 미르코 라이브 재현) — 프로젝트 생성 「무반응」의 정체는 조용한
+  // 403이었다. 실패를 담아 다이얼로그에 명시로 보여준다(어떤 실패든 침묵하지 않는 게 근본 — a
+  // 만으론 다음 다른 실패가 또 조용히 묻힌다).
+  const [createProjectError, setCreateProjectError] = useState<string | null>(null);
 
   const [localOrgId, setLocalOrgId] = useState<string | undefined>(currentOrgId);
 
@@ -147,6 +153,12 @@ export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjec
       });
       const json = await res.json().catch(() => null) as { data?: { ok?: boolean } } | null;
       if (res.ok && json?.data?.ok) {
+        // story #2468(a) — 이 경로는 대상 org의 특정 프로젝트를 아직 모른다(그건 이후
+        // switchProject/createProject가 정한다). 전환 前 org의 project_id를 그대로 두면
+        // fetch 인터셉터(project-context-client.ts)가 그 stale id를 X-Project-Id로 계속
+        // 실어 보내 — 새 org엔 없는 프로젝트라 BE가 403(멤버십 검증 실패)을 낸다. 실측:
+        // 0-프로젝트 org로 전환 후 "새 프로젝트" 생성 시도가 이 stale 헤더 때문에 조용히 막혔다.
+        if (typeof window !== 'undefined') window.sessionStorage.removeItem(TAB_PROJECT_STORAGE_KEY);
         router.refresh();
       } else {
         setLocalOrgId(prevOrgId);
@@ -238,6 +250,7 @@ export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjec
   async function createProject(name: string, description: string): Promise<boolean> {
     if (!name.trim() || creating) return false;
     setCreating(true);
+    setCreateProjectError(null);
     try {
       const res = await fetch('/api/projects', {
         method: 'POST',
@@ -248,15 +261,27 @@ export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjec
           ...(currentOrgId ? { org_id: currentOrgId } : {}),
         }),
       });
-      if (!res.ok) return false;
+      if (!res.ok) {
+        // story #2468(b, 근본) — 예전엔 여기서 그냥 false만 반환했다. 호출부(unified-switcher.tsx·
+        // context-switcher-chip.tsx)는 그 결과를 `void`로 버려 실패가 화면 어디에도 안 뜨고
+        // 다이얼로그만 그대로 남았다 — "버튼 무반응"으로 보인 정체. 원인이 뭐든(403/기타) 침묵
+        // 하지 않는다: (a)가 이번 원인(stale project_id 헤더)은 없앴지만, 다음 다른 실패가 또
+        // 조용히 묻히지 않도록 실패 표시 자체를 근본으로 남긴다.
+        setCreateProjectError(tSwitcher('switcherCreateProjectError'));
+        return false;
+      }
       const data = await res.json() as { id?: string; data?: { id: string } };
       const newId = data.id ?? data.data?.id;
       setCreateProjectOpen(false);
       setNewProjectName('');
       setNewProjectDesc('');
+      setCreateProjectError(null);
       if (newId) await switchProject(newId);
       else router.refresh();
       return true;
+    } catch {
+      setCreateProjectError(tSwitcher('switcherCreateProjectError'));
+      return false;
     } finally {
       setCreating(false);
     }
@@ -266,11 +291,19 @@ export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjec
     window.location.href = `/onboarding?step=project&orgId=${orgId}`;
   }
 
+  // story #2468(b) — 다이얼로그를 열고 닫을 때마다 이전 실패 문구를 지운다. 안 지우면 재시도
+  // 성공 뒤 다시 열었을 때(취소→재오픈) 낡은 에러가 새 시도처럼 보일 수 있다.
+  function setCreateProjectOpenAndClearError(nextOpen: boolean) {
+    setCreateProjectError(null);
+    setCreateProjectOpen(nextOpen);
+  }
+
   return {
     pending,
     open, setOpen,
     createOrgOpen, setCreateOrgOpen,
-    createProjectOpen, setCreateProjectOpen,
+    createProjectOpen, setCreateProjectOpen: setCreateProjectOpenAndClearError,
+    createProjectError,
     newProjectName, setNewProjectName,
     newProjectDesc, setNewProjectDesc,
     creating,


### PR DESCRIPTION
## 요약
온보딩 "완주 불가" gate③의 정체를 라이브 재현으로 잡아 고쳤는(2026-08-06). "+ 새 프로젝트" → 모달 입력 → "만들기" 클릭 시 모달이 안 닫히고 아무 반응 없던 것 = **조용한 403**.

## Root cause
`POST /api/projects` → `403 {"code":"FORBIDDEN","message":"No access to the specified project"}`.
- BE `dependencies/auth.py::get_verified_org_id`가 `X-Project-Id` 헤더의 멤버십을 검증.
- 이 헤더는 FE `project-context-client.ts` 전역 fetch 인터셉터가 `sessionStorage['sprintable_tab_project_id']`에서 주입.
- **org 전환 後에도 전환 前 조직의 project_id를 그대로 들고 있어**(실측 확認: `25d3a6df-...`) — 0-프로젝트 org 등 그 프로젝트가 없는 곳에선 BE가 403.
- FE가 이 실패를 화면에 안 띄워 "무반응"으로 보였다.

## Fix (FE 단독, BE 무변경) — 2중, 둘 다
1. **(a) stale 클리어**: `useUnifiedSwitcher.switchOrg` — 전환 성공 時 `TAB_PROJECT_STORAGE_KEY` sessionStorage를 지운다. 실패 時엔 롤백된 org의 project_id가 여전히 유효하므로 안 건드림.
2. **(b, 근본) 실패 표시**: `createProject`가 실패를 `createProjectError`로 담아 다이얼로그에 명시 표시(원인이 뭐든 침묵하지 않는다 — (a)만으론 다음 다른 실패가 또 조용히 묻힌다). 다이얼로그 재오픈 時 낡은 에러 클리어.

`unified-switcher.tsx`(데스크톱)·`context-switcher-chip.tsx`(모바일) 둘 다 같은 훅(`useUnifiedSwitcher`)을 공유하므로 한 번의 수정으로 동일 반영됩니다.

## 검증
- vitest 23/23(신규 5개: switchOrg 클리어 2 + createProject 실패표시 3)
- `tsc --noEmit` 클린 · eslint 클린 · i18n phrase-collision 신규 0건
- 뮤테이션 셀프체크 2건(sessionStorage 클리어·에러표시 각각 되돌려 RED 확認 → 복원 → GREEN)
- `pnpm build` exit 0

## 라이브 검증 계획
dev 배포 후 카디르군 QA: (1) 0-프로젝트 org에서 "새 프로젝트" 버튼 → 실제 생성 성공 (2) 강제 실패 시 에러 문구 노출. 에러 토스트 문안은 유나신 글랜스.

🤖 Generated with [Claude Code](https://claude.com/claude-code)