### PR TITLE
[SID:2469] /register 회원가입 페이지 100% 영문 → 한국어화

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -716,6 +716,26 @@
     "invalidProvider": "Invalid OAuth provider.",
     "oauthNativeIssueFailed": "Failed to hand off your login to the app. Please try again."
   },
+  "register": {
+    "subtitle": "Create your account",
+    "namePlaceholder": "Name",
+    "emailPlaceholder": "Email",
+    "passwordPlaceholder": "Password",
+    "ruleLength": "At least 8 characters",
+    "ruleCategories": "At least 3 of: uppercase, lowercase, digit, special character ({count}/3)",
+    "tosPrefix": "I agree to the",
+    "termsOfService": "Terms of Service",
+    "and": "and",
+    "privacyPolicy": "Privacy Policy",
+    "creatingAccount": "Creating account...",
+    "submit": "Sign up",
+    "orContinueWith": "or continue with",
+    "continueWithGoogle": "Continue with Google",
+    "tosRequiredError": "Please agree to the Terms of Service and Privacy Policy first.",
+    "registrationFailed": "Registration failed. Please try again.",
+    "alreadyHaveAccount": "Already have an account?",
+    "signIn": "Sign in"
+  },
   "onboarding": {
     "createOrg": "Create Organization",
     "welcome": "Welcome to Sprintable!",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -716,6 +716,26 @@
     "invalidProvider": "유효하지 않은 OAuth 제공자입니다.",
     "oauthNativeIssueFailed": "앱으로 로그인 정보를 전달하는 데 실패했습니다. 다시 시도해 주세요."
   },
+  "register": {
+    "subtitle": "계정 만들기",
+    "namePlaceholder": "이름",
+    "emailPlaceholder": "이메일",
+    "passwordPlaceholder": "비밀번호",
+    "ruleLength": "8자 이상",
+    "ruleCategories": "대문자·소문자·숫자·특수문자 중 3가지 이상 ({count}/3)",
+    "tosPrefix": "다음에 동의합니다:",
+    "termsOfService": "이용약관",
+    "and": "및",
+    "privacyPolicy": "개인정보처리방침",
+    "creatingAccount": "계정 만드는 중...",
+    "submit": "회원가입",
+    "orContinueWith": "또는 다음으로 계속",
+    "continueWithGoogle": "Google로 계속",
+    "tosRequiredError": "먼저 이용약관과 개인정보처리방침에 동의해 주세요.",
+    "registrationFailed": "가입에 실패했습니다. 다시 시도해 주세요.",
+    "alreadyHaveAccount": "이미 계정이 있으신가요?",
+    "signIn": "로그인"
+  },
   "onboarding": {
     "createOrg": "조직 만들기",
     "welcome": "Sprintable에 오신 것을 환영합니다!",

--- a/apps/web/src/app/register/page.test.tsx
+++ b/apps/web/src/app/register/page.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+//
+// story #2469(P1, 2026-08-06 PO 라이브 재현) — /login은 한국어인데 /register는 100% 영문
+// 하드코딩("Create your account/Name/Email/Password/Sign up/...")이었다. 신규 유저 전원이
+// 첫 화면에서 만나는 결함. 소스매칭(문자열이 파일에 "있는지")만으론 안 잡힌다 — next-intl
+// 미배선이면 raw key가 그대로 뜨거나 런타임에서 죽을 수 있어(login/page.test.tsx와 동형
+// 패턴) 실제로 마운트해 DOM 텍스트를 확認한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import enMessages from '../../../messages/en.json';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(locale: 'ko' | 'en', node: React.ReactNode) {
+  const messages = locale === 'ko' ? koMessages : enMessages;
+  return (
+    <NextIntlClientProvider locale={locale} messages={messages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.resetModules();
+});
+
+async function mount(locale: 'ko' | 'en' = 'ko') {
+  const { default: RegisterPage } = await import('./page');
+  await act(async () => { root.render(wrap(locale, <RegisterPage />)); });
+}
+
+function setNativeValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+  setter.call(el, value);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe('RegisterPage (story #2469) — ko locale이 실제로 렌더된다(raw 영문 회귀가드)', () => {
+  it('placeholder·CTA·ToS 문구가 전부 한국어로 실제 DOM에 뜬다', async () => {
+    await mount('ko');
+    expect(container.querySelector('input[placeholder="이름"]')).not.toBeNull();
+    expect(container.querySelector('input[placeholder="이메일"]')).not.toBeNull();
+    expect(container.querySelector('input[placeholder="비밀번호"]')).not.toBeNull();
+    expect(container.textContent).toContain('계정 만들기');
+    expect(container.textContent).toContain('회원가입');
+    expect(container.textContent).toContain('이용약관');
+    expect(container.textContent).toContain('개인정보처리방침');
+    expect(container.textContent).toContain('이미 계정이 있으신가요?');
+    expect(container.textContent).toContain('로그인');
+  });
+
+  it('예전 raw 영문 문구가 하나도 안 남아있다(회귀가드 — "Create your account" 등)', async () => {
+    await mount('ko');
+    for (const legacy of [
+      'Create your account', 'Sign up', 'Already have an account', 'Sign in',
+      'I agree to the', 'Terms of Service', 'Privacy Policy', 'or continue with',
+    ]) {
+      expect(container.textContent).not.toContain(legacy);
+    }
+    // placeholder 속성도 별도 확認(textContent엔 안 잡힘)
+    expect(container.querySelector('input[placeholder="Name"]')).toBeNull();
+    expect(container.querySelector('input[placeholder="Email"]')).toBeNull();
+    expect(container.querySelector('input[placeholder="Password"]')).toBeNull();
+  });
+
+  it('비밀번호 규칙 카운트({count}/3)가 실제 값으로 보간된다 — 빈 자리표시자로 안 남는다', async () => {
+    await mount('ko');
+    const pwInput = container.querySelector('input[type="password"]') as HTMLInputElement;
+    await act(async () => { setNativeValue(pwInput, 'Abc123!!'); });
+    expect(container.textContent).toContain('4/3'); // upper+lower+digit+special 전부 충족
+    expect(container.textContent).not.toContain('{count}');
+  });
+
+  it('en locale에선 영문 그대로 렌더된다(회귀 없음 — ko만 고치고 en을 안 깨뜨렸는지)', async () => {
+    await mount('en');
+    expect(container.textContent).toContain('Create your account');
+    expect(container.textContent).toContain('Sign up');
+  });
+});

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
 
 function checkPasswordRules(pw: string) {
@@ -20,6 +21,7 @@ function countCategories(rules: ReturnType<typeof checkPasswordRules>) {
 }
 
 export default function RegisterPage() {
+  const t = useTranslations('register');
   const router = useRouter();
   const [displayName, setDisplayName] = useState('');
   const [email, setEmail] = useState('');
@@ -50,7 +52,7 @@ export default function RegisterPage() {
       });
       const json = await res.json() as { data?: { ok: boolean }; error?: { message: string } };
       if (!res.ok || !json.data?.ok) {
-        setError(json.error?.message ?? 'Registration failed. Please try again.');
+        setError(json.error?.message ?? t('registrationFailed'));
         return;
       }
       const meRes = await fetch('/api/me');
@@ -58,7 +60,7 @@ export default function RegisterPage() {
       router.push(meJson.data?.org_id ? '/inbox' : '/onboarding');
       router.refresh();
     } catch {
-      setError('Registration failed. Please try again.');
+      setError(t('registrationFailed'));
     } finally {
       setLoading(false);
     }
@@ -76,13 +78,13 @@ export default function RegisterPage() {
             markClassName="h-14"
             wordmarkClassName="h-5"
           />
-          <p className="text-sm text-muted-foreground">Create your account</p>
+          <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
         </div>
 
         <div className="space-y-3">
           <input
             type="text"
-            placeholder="Name"
+            placeholder={t('namePlaceholder')}
             autoComplete="name"
             className="w-full rounded-lg border border-border px-4 py-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-brand"
             value={displayName}
@@ -92,7 +94,7 @@ export default function RegisterPage() {
           />
           <input
             type="email"
-            placeholder="Email"
+            placeholder={t('emailPlaceholder')}
             autoComplete="email"
             className="w-full rounded-lg border border-border px-4 py-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-brand"
             value={email}
@@ -102,7 +104,7 @@ export default function RegisterPage() {
           />
           <input
             type="password"
-            placeholder="Password"
+            placeholder={t('passwordPlaceholder')}
             autoComplete="new-password"
             className={`w-full rounded-lg border px-4 py-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-brand ${
               showRules && !isPasswordValid ? 'border-destructive' : 'border-border'
@@ -114,10 +116,10 @@ export default function RegisterPage() {
           />
           {showRules && (
             <ul className="space-y-1 text-xs">
-              <RuleItem met={rules.length} label="At least 8 characters" />
+              <RuleItem met={rules.length} label={t('ruleLength')} />
               <li className={`flex items-center gap-1.5 ${categoriesMet >= 3 ? 'text-success' : 'text-muted-foreground/60'}`}>
                 <span>{categoriesMet >= 3 ? '✓' : '○'}</span>
-                <span>At least 3 of: uppercase, lowercase, digit, special character ({categoriesMet}/3)</span>
+                <span>{t('ruleCategories', { count: categoriesMet })}</span>
               </li>
             </ul>
           )}
@@ -131,13 +133,13 @@ export default function RegisterPage() {
               disabled={loading}
             />
             <span className="text-xs text-muted-foreground">
-              I agree to the{' '}
+              {t('tosPrefix')}{' '}
               <Link href="/terms" target="_blank" className="font-medium text-brand hover:text-brand/80">
-                Terms of Service
+                {t('termsOfService')}
               </Link>{' '}
-              and{' '}
+              {t('and')}{' '}
               <Link href="/privacy" target="_blank" className="font-medium text-brand hover:text-brand/80">
-                Privacy Policy
+                {t('privacyPolicy')}
               </Link>
             </span>
           </label>
@@ -152,7 +154,7 @@ export default function RegisterPage() {
             disabled={loading || !displayName.trim() || !email.trim() || !password.trim() || !tosAccepted}
             className="flex w-full min-h-[44px] items-center justify-center rounded-lg bg-brand px-4 py-3 text-sm font-medium text-brand-foreground transition hover:bg-brand/90 disabled:opacity-50"
           >
-            {loading ? 'Creating account...' : 'Sign up'}
+            {loading ? t('creatingAccount') : t('submit')}
           </button>
         </div>
 
@@ -160,13 +162,13 @@ export default function RegisterPage() {
           <div className="space-y-3">
             <div className="relative flex items-center">
               <div className="flex-grow border-t border-border/50" />
-              <span className="mx-3 flex-shrink text-xs text-muted-foreground/60">or continue with</span>
+              <span className="mx-3 flex-shrink text-xs text-muted-foreground/60">{t('orContinueWith')}</span>
               <div className="flex-grow border-t border-border/50" />
             </div>
 
             <a
               href={tosAccepted ? '/auth/login?provider=google&tos_accepted=true' : undefined}
-              onClick={!tosAccepted ? (e) => { e.preventDefault(); setError('Please agree to the Terms of Service and Privacy Policy first.'); } : undefined}
+              onClick={!tosAccepted ? (e) => { e.preventDefault(); setError(t('tosRequiredError')); } : undefined}
               className={`flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-border bg-background px-4 py-3 text-sm font-medium text-foreground/80 transition hover:bg-muted/50 ${!tosAccepted ? 'opacity-50 cursor-not-allowed' : ''}`}
             >
               <svg className="h-5 w-5" viewBox="0 0 24 24">
@@ -175,15 +177,15 @@ export default function RegisterPage() {
                 <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
                 <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
               </svg>
-              Continue with Google
+              {t('continueWithGoogle')}
             </a>
           </div>
         )}
 
         <p className="text-center text-sm text-muted-foreground">
-          Already have an account?{' '}
+          {t('alreadyHaveAccount')}{' '}
           <Link href="/login" className="font-medium text-brand hover:text-brand/80">
-            Sign in
+            {t('signIn')}
           </Link>
         </p>
       </div>


### PR DESCRIPTION
## 요약
PO 라이브 재현(2026-08-06) — `/login`은 한국어인데 `/register`는 100% 영문 하드코딩("Create your account/Name/Email/Password/Sign up/or continue with/Already have an account? Sign in"). 신규 유저 전원이 첫 화면에서 만나는 locale 결함.

## 변경
- 신규 `register` i18n 네임스페이스(ko/en) 도입, `useTranslations('register')`로 전체 문구 교체.
- placeholder 3종(이름/이메일/비밀번호)·비밀번호 규칙 힌트 2종·ToS 동의문·제출 버튼(회원가입/계정 만드는 중…)·Google continue·로그인 링크·에러 문구까지 raw 영문 0.
- `login` 네임스페이스와 동일 컨벤션(`termsOfService`/`and`/`privacyPolicy` 등 키 이름 정합) — 팀 관례를 그대로 재사용.

## 검증
- vitest 4/4 신규(실 마운트 — ko 문구 실제 DOM 확認 · 구 raw 영문 잔존 0 회귀가드 · 비밀번호 규칙 `{count}` 보간 확認 · en locale 무회귀)
- `tsc --noEmit` 클린 · eslint 클린 · i18n phrase-collision 신규 0건
- 뮤테이션 셀프체크(ko subtitle을 영문으로 되돌려 RED 확認 → 복원 → GREEN)
- `pnpm build` exit 0

## 스크린샷
dev 배포 후 라이브 확認 예정(카디르군 QA + 유나신 design gate 카피 톤 확認).

🤖 Generated with [Claude Code](https://claude.com/claude-code)