### PR TITLE
[SID:2470] 조직 한도 에러 raw 영문 → error.code 분기 + 한국어 + 업그레이드 CTA

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -768,6 +768,7 @@
     "skip": "Skip",
     "stepOf": "{current} / {total}",
     "createOrgFailed": "Failed to create organization",
+    "orgLimitExceededError": "The free plan allows up to {limit} organization(s). Upgrade your plan to continue.",
     "emailVerifyRequiredError": "Email verification is required — please verify your email before creating an organization.",
     "emailVerifyGuidance": "Check your inbox (including spam) for the address you signed up with, and click the verification link. If you don't see it, you can resend it below.",
     "resendVerificationCta": "Resend verification email",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -104,7 +104,9 @@
     "switcherProjectDescPlaceholder": "A short description of the project",
     "switcherCreating": "Creating…",
     "switcherCreateButton": "Create",
-    "switcherCreateProjectError": "Couldn't create the project. Please try again in a moment."
+    "switcherCreateProjectError": "Couldn't create the project. Please try again in a moment.",
+    "orgLimitBannerTitle": "Upgrade required",
+    "orgLimitUpgradeLink": "Upgrade plan →"
   },
   "storage": {
     "title": "Storage",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -104,7 +104,9 @@
     "switcherProjectDescPlaceholder": "프로젝트에 대한 간단한 설명",
     "switcherCreating": "생성 중…",
     "switcherCreateButton": "만들기",
-    "switcherCreateProjectError": "프로젝트를 만들지 못했습니다. 잠시 후 다시 시도해 주세요."
+    "switcherCreateProjectError": "프로젝트를 만들지 못했습니다. 잠시 후 다시 시도해 주세요.",
+    "orgLimitBannerTitle": "업그레이드가 필요합니다",
+    "orgLimitUpgradeLink": "요금제 업그레이드 →"
   },
   "storage": {
     "title": "스토리지",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -768,6 +768,7 @@
     "skip": "건너뛰기",
     "stepOf": "{current} / {total}",
     "createOrgFailed": "조직 생성에 실패했습니다",
+    "orgLimitExceededError": "무료 플랜은 조직을 {limit}개까지 만들 수 있습니다. 계속하려면 요금제를 업그레이드해 주세요.",
     "emailVerifyRequiredError": "이메일 인증이 필요합니다 — 조직을 만들려면 먼저 이메일 인증을 완료해 주세요.",
     "emailVerifyGuidance": "가입하신 이메일 받은편지함(스팸함 포함)을 확인하고, 인증 링크를 클릭해 주세요. 메일이 안 보이면 아래에서 다시 보낼 수 있습니다.",
     "resendVerificationCta": "인증 메일 재전송",

--- a/apps/web/src/app/onboarding/onboarding-form.org-limit.test.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.org-limit.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+//
+// story #2470 — 미르코 라이브 재현(2026-08-06): Free plan 계정이 새 조직 생성 時 raw 영문
+// `Free plan org limit (1) reached. Upgrade to Team or Pro.`가 그대로 노출됐다. BE는 이미
+// 구조화 에러(code:PLAN_LIMIT_EXCEEDED·limit·upgrade_required)를 주는데 FE가 그 code로 안
+// 갈라 raw message를 그대로 찍은 게 원인(#2441과 동일 클래스). 소스매칭이 아니라 실제로 폼을
+// 마운트하고 fetch를 스텁해 UpgradeModal이 실제로 뜨는지·raw 영문이 안 뜨는지를 단언한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { OnboardingForm } from './onboarding-form';
+import koMessages from '../../../messages/ko.json';
+import enMessages from '../../../messages/en.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(locale: 'ko' | 'en') {
+  const messages = locale === 'ko' ? koMessages : enMessages;
+  return (
+    <NextIntlClientProvider locale={locale} messages={messages} timeZone="Asia/Seoul">
+      <OnboardingForm />
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function fillOrgForm() {
+  const nameInput = container.querySelector('input') as HTMLInputElement;
+  const setNative = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+  await act(async () => {
+    setNative.call(nameInput, 'Test Org');
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+function submitButton(): HTMLButtonElement {
+  const btns = Array.from(container.querySelectorAll('button'));
+  return btns.find((b) => /조직 만들기|Create Organization/.test(b.textContent ?? '')) as HTMLButtonElement;
+}
+
+function planLimitFetchStub(url: string) {
+  if (url === '/api/onboarding/events') return { ok: true, json: async () => ({}) } as Response;
+  if (url === '/api/organizations') {
+    return {
+      ok: false,
+      status: 402,
+      json: async () => ({
+        data: null,
+        error: {
+          code: 'PLAN_LIMIT_EXCEEDED',
+          message: 'Free plan org limit (1) reached. Upgrade to Team or Pro.',
+          resource: 'org', limit: 1, tier: 'free', upgrade_required: true,
+        },
+        meta: null,
+      }),
+    } as Response;
+  }
+  throw new Error('unexpected fetch: ' + url);
+}
+
+describe('OnboardingForm — PLAN_LIMIT_EXCEEDED (story #2470)', () => {
+  it('ko: code로 분기해 UpgradeModal(한국어 안내+업그레이드 버튼)을 실제로 렌더한다 — raw 영문 노출 없음', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => planLimitFetchStub(url)));
+
+    await act(async () => { root.render(wrap('ko')); });
+    await fillOrgForm();
+    await act(async () => { submitButton().click(); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    // ⚠️UpgradeModal은 base-ui Dialog(portal)라 container 밖 document.body에 렌더된다
+    // (E-UI-DAEGBYEON P1-01 교훈 — "base-ui Dialog portal은 document.body 렌더"). container만
+    // 보면 항상 실패하는 게 실제로 처음 겪은 함정이라 여기 박아둔다.
+    // #2470에서 실제로 겪은 raw 영문 원문이 화면에 그대로 노출되면 안 된다.
+    expect(document.body.textContent).not.toContain('Free plan org limit (1) reached');
+    expect(document.body.textContent).not.toContain('Upgrade to Team or Pro');
+    expect(document.body.textContent).toContain('무료 플랜');
+    expect(document.body.textContent).toContain('1개');
+    expect(document.body.textContent).toContain('업그레이드');
+    const upgradeLink = document.body.querySelector('a[href="/dashboard/settings"]');
+    expect(upgradeLink).not.toBeNull();
+  });
+
+  it('en: 같은 code에 대해 영문 UpgradeModal을 렌더한다(en/ko 정합)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => planLimitFetchStub(url)));
+
+    await act(async () => { root.render(wrap('en')); });
+    await fillOrgForm();
+    await act(async () => { submitButton().click(); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    expect(document.body.textContent).toContain('The free plan allows up to 1 organization');
+    expect(document.body.querySelector('a[href="/dashboard/settings"]')).not.toBeNull();
+  });
+
+  it('limit이 1이 아닌 값이면 그 값 그대로 보간된다(하드코딩 아님)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/onboarding/events') return { ok: true, json: async () => ({}) } as Response;
+      if (url === '/api/organizations') {
+        return {
+          ok: false, status: 402,
+          json: async () => ({ data: null, error: { code: 'PLAN_LIMIT_EXCEEDED', message: 'x', limit: 3, upgrade_required: true }, meta: null }),
+        } as Response;
+      }
+      throw new Error('unexpected fetch: ' + url);
+    }));
+
+    await act(async () => { root.render(wrap('ko')); });
+    await fillOrgForm();
+    await act(async () => { submitButton().click(); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    expect(document.body.textContent).toContain('3개');
+  });
+
+  it('다른 402/코드는 기존 일반 에러 배너로 가고, UpgradeModal은 안 뜬다(회귀 없음)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/onboarding/events') return { ok: true, json: async () => ({}) } as Response;
+      if (url === '/api/organizations') {
+        return {
+          ok: false, status: 409,
+          json: async () => ({ data: null, error: { code: 'CONFLICT', message: 'Slug already exists' }, meta: null }),
+        } as Response;
+      }
+      throw new Error('unexpected fetch: ' + url);
+    }));
+
+    await act(async () => { root.render(wrap('ko')); });
+    await fillOrgForm();
+    await act(async () => { submitButton().click(); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).toContain('Slug already exists');
+    expect(document.body.querySelector('a[href="/dashboard/settings"]')).toBeNull();
+  });
+});

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -96,6 +96,16 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
           setError(t('emailVerifyRequiredError'));
           return;
         }
+        // story #2470 — #2441과 같은 클래스: BE는 이미 구조화 에러(code:PLAN_LIMIT_EXCEEDED·
+        // limit·upgrade_required)를 주는데 이전엔 여기서 raw 영문 message를 그대로 찍었다
+        // ("Free plan org limit (1) reached. Upgrade to Team or Pro."). upgrade_required가
+        // 있으면 UpgradeModal(이미 존재·다른 한도 케이스에서 재사용 중인 컴포넌트)로 안내한다 —
+        // showUpgrade/upgradeReason state는 이 스토리 前엔 세팅부가 없어 죽어있던 자리였다.
+        if (json?.error?.code === 'PLAN_LIMIT_EXCEEDED' && json?.error?.upgrade_required) {
+          setUpgradeReason(t('orgLimitExceededError', { limit: json.error.limit ?? 1 }));
+          setShowUpgrade(true);
+          return;
+        }
         setError(json?.error?.message ?? t('createOrgFailed'));
         return;
       }

--- a/apps/web/src/components/nav/create-organization-dialog.test.tsx
+++ b/apps/web/src/components/nav/create-organization-dialog.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+//
+// story #2470 — 실측(2026-08-06): 이 다이얼로그의 PLAN_LIMIT_EXCEEDED 감지가
+// `json.detail?.code`를 봤는데, 실제 응답 envelope은 `{error:{code,...}}`다(BE
+// HTTPException(detail=...)이 exception handler를 거쳐 `error`로 재포장된다 — 직접
+// `/api/organizations` 라이브 호출로 확認). `json.detail`은 실제 응답에 없는 필드라 이
+// 분기가 항상 죽어있었고, 한도 초과여도 매번 raw `error.message`(영문) 폴백으로 샜다.
+// 소스매칭(코드가 "있는지")만으론 이 결함이 안 잡힌다 — 실제로 마운트해 배너가 뜨는지 본다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { CreateOrganizationDialog } from './create-organization-dialog';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+function setNativeValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+  setter.call(el, value);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+async function mount() {
+  const onOpenChange = vi.fn();
+  const onCreated = vi.fn();
+  // Dialog(base-ui)는 body에 portal되므로 container 밖(document.body)에서 내용을 찾는다
+  // (create-organization-dialog는 <Dialog open> 자체가 portal 루트라 여기서도 동일 함정).
+  await act(async () => {
+    root.render(<CreateOrganizationDialog open onOpenChange={onOpenChange} onCreated={onCreated} />);
+  });
+  return { onOpenChange, onCreated };
+}
+
+async function fillAndSubmit() {
+  const nameInput = document.body.querySelector('#org-name') as HTMLInputElement;
+  await act(async () => { setNativeValue(nameInput, 'Test Org'); });
+  const form = document.body.querySelector('form') as HTMLFormElement;
+  await act(async () => { form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true })); });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('CreateOrganizationDialog — PLAN_LIMIT_EXCEEDED envelope (story #2470)', () => {
+  it('실제 응답 envelope({error:{code}})으로 한도 배너가 실제로 뜬다 — raw 영문 message 노출 없음', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 402,
+      json: async () => ({
+        data: null,
+        error: {
+          code: 'PLAN_LIMIT_EXCEEDED',
+          message: 'Free plan org limit (1) reached. Upgrade to Team or Pro.',
+          resource: 'org', limit: 1, tier: 'free', upgrade_required: true,
+        },
+        meta: null,
+      }),
+    })));
+
+    await mount();
+    await fillAndSubmit();
+
+    expect(document.body.textContent).not.toContain('Free plan org limit (1) reached');
+    expect(document.body.textContent).toContain('Free 플랜 Organization 한도 초과');
+    expect(document.body.querySelector('a[href="/settings?tab=billing"]')).not.toBeNull();
+  });
+
+  it('구 shape({detail:{code}})로 응답이 와도(과거 BE) 여전히 배너가 뜬다 — 하위호환 폴백', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 402,
+      json: async () => ({ detail: { code: 'PLAN_LIMIT_EXCEEDED', message: 'x' } }),
+    })));
+
+    await mount();
+    await fillAndSubmit();
+
+    expect(document.body.textContent).toContain('Free 플랜 Organization 한도 초과');
+  });
+
+  it('다른 에러는 기존 일반 배너로 간다(회귀 없음)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 409,
+      json: async () => ({ data: null, error: { code: 'CONFLICT', message: 'Slug already exists' }, meta: null }),
+    })));
+
+    await mount();
+    await fillAndSubmit();
+
+    expect(document.body.textContent).toContain('Slug already exists');
+    expect(document.body.textContent).not.toContain('Free 플랜 Organization 한도 초과');
+  });
+});

--- a/apps/web/src/components/nav/create-organization-dialog.test.tsx
+++ b/apps/web/src/components/nav/create-organization-dialog.test.tsx
@@ -6,11 +6,19 @@
 // `/api/organizations` 라이브 호출로 확認). `json.detail`은 실제 응답에 없는 필드라 이
 // 분기가 항상 죽어있었고, 한도 초과여도 매번 raw `error.message`(영문) 폴백으로 샜다.
 // 소스매칭(코드가 "있는지")만으론 이 결함이 안 잡힌다 — 실제로 마운트해 배너가 뜨는지 본다.
+//
+// story #2470 후속(유나 홀름 design:changes) — 한도 배너 문구가 하드코딩 영한혼용
+// ("Free 플랜 Organization 한도 초과")이었다가 온보딩 wizard와 같은 i18n 키
+// (`onboarding.orgLimitExceededError`)를 공유하도록 정정 — useTranslations를 쓰므로
+// NextIntlClientProvider 없이 마운트하면 "context ... was not found"로 즉시 죽는다.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
 import { CreateOrganizationDialog } from './create-organization-dialog';
+import koMessages from '../../../messages/ko.json';
+import enMessages from '../../../messages/en.json';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -35,13 +43,18 @@ function setNativeValue(el: HTMLInputElement, value: string) {
   el.dispatchEvent(new Event('input', { bubbles: true }));
 }
 
-async function mount() {
+async function mount(locale: 'ko' | 'en' = 'ko') {
   const onOpenChange = vi.fn();
   const onCreated = vi.fn();
+  const messages = locale === 'ko' ? koMessages : enMessages;
   // Dialog(base-ui)는 body에 portal되므로 container 밖(document.body)에서 내용을 찾는다
   // (create-organization-dialog는 <Dialog open> 자체가 portal 루트라 여기서도 동일 함정).
   await act(async () => {
-    root.render(<CreateOrganizationDialog open onOpenChange={onOpenChange} onCreated={onCreated} />);
+    root.render(
+      <NextIntlClientProvider locale={locale} messages={messages} timeZone="Asia/Seoul">
+        <CreateOrganizationDialog open onOpenChange={onOpenChange} onCreated={onCreated} />
+      </NextIntlClientProvider>,
+    );
   });
   return { onOpenChange, onCreated };
 }
@@ -74,7 +87,8 @@ describe('CreateOrganizationDialog — PLAN_LIMIT_EXCEEDED envelope (story #2470
     await fillAndSubmit();
 
     expect(document.body.textContent).not.toContain('Free plan org limit (1) reached');
-    expect(document.body.textContent).toContain('Free 플랜 Organization 한도 초과');
+    expect(document.body.textContent).toContain('업그레이드가 필요합니다');
+    expect(document.body.textContent).toContain('무료 플랜은 조직을 1개까지 만들 수 있습니다');
     expect(document.body.querySelector('a[href="/settings?tab=billing"]')).not.toBeNull();
   });
 
@@ -88,7 +102,8 @@ describe('CreateOrganizationDialog — PLAN_LIMIT_EXCEEDED envelope (story #2470
     await mount();
     await fillAndSubmit();
 
-    expect(document.body.textContent).toContain('Free 플랜 Organization 한도 초과');
+    expect(document.body.textContent).toContain('업그레이드가 필요합니다');
+    expect(document.body.textContent).toContain('무료 플랜은 조직을 1개까지 만들 수 있습니다');
   });
 
   it('다른 에러는 기존 일반 배너로 간다(회귀 없음)', async () => {
@@ -102,6 +117,24 @@ describe('CreateOrganizationDialog — PLAN_LIMIT_EXCEEDED envelope (story #2470
     await fillAndSubmit();
 
     expect(document.body.textContent).toContain('Slug already exists');
-    expect(document.body.textContent).not.toContain('Free 플랜 Organization 한도 초과');
+    expect(document.body.textContent).not.toContain('업그레이드가 필요합니다');
+  });
+
+  it('en locale에선 영문 배너로 렌더된다(회귀 없음)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 402,
+      json: async () => ({
+        data: null,
+        error: { code: 'PLAN_LIMIT_EXCEEDED', message: 'x', limit: 1, upgrade_required: true },
+        meta: null,
+      }),
+    })));
+
+    await mount('en');
+    await fillAndSubmit();
+
+    expect(document.body.textContent).toContain('Upgrade required');
+    expect(document.body.textContent).toContain('The free plan allows up to 1 organization');
   });
 });

--- a/apps/web/src/components/nav/create-organization-dialog.tsx
+++ b/apps/web/src/components/nav/create-organization-dialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useTranslations } from 'next-intl';
 import {
   Dialog,
   DialogContent,
@@ -34,6 +35,13 @@ export function CreateOrganizationDialog({
   onOpenChange,
   onCreated,
 }: CreateOrganizationDialogProps) {
+  const t = useTranslations('nav');
+  // story #2470 후속(유나 홀름 design:changes) — 온보딩 wizard 경로(#2470 본체)는 완전
+  // i18n인데 이 dialog의 한도 배너 본문은 별도로 하드코딩 영한혼용이었다("Free 플랜
+  // Organization 한도 초과"). 같은 개념(무료 플랜 조직 한도)을 두 곳에서 따로 번역해 두면
+  // 나중에 한쪽만 고쳐지는 갈림이 재발하므로, 온보딩과 같은 키(orgLimitExceededError)를
+  // 재사용한다 — 문구가 실제로 하나의 출처를 갖는다.
+  const tOnboarding = useTranslations('onboarding');
   const [name, setName] = useState('');
   const [slug, setSlug] = useState('');
   const [slugTouched, setSlugTouched] = useState(false);
@@ -121,14 +129,14 @@ export function CreateOrganizationDialog({
         <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
           {planLimitHit && (
             <div key={planLimitNonce} role="alert" aria-live="assertive" aria-atomic="true" className="rounded-md border border-amber-200 bg-amber-50 px-3 py-3 text-sm space-y-1">
-              <p className="font-medium text-amber-800">Free 플랜 Organization 한도 초과</p>
-              <p className="text-amber-700">Free 플랜은 Organization 1개까지만 생성할 수 있습니다.</p>
+              <p className="font-medium text-amber-800">{t('orgLimitBannerTitle')}</p>
+              <p className="text-amber-700">{tOnboarding('orgLimitExceededError', { limit: 1 })}</p>
               {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- story a539c649 S2 오탐, invite-accept-client.tsx 주석 참고 */}
               <a
                 href="/settings?tab=billing"
                 className="inline-block mt-1 text-xs font-medium text-amber-800 underline underline-offset-2 hover:text-amber-900"
               >
-                Team 또는 Pro로 업그레이드하기 →
+                {t('orgLimitUpgradeLink')}
               </a>
             </div>
           )}

--- a/apps/web/src/components/nav/create-organization-dialog.tsx
+++ b/apps/web/src/components/nav/create-organization-dialog.tsx
@@ -83,10 +83,15 @@ export function CreateOrganizationDialog({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: name.trim(), slug: slug.trim() }),
       });
-      const json = await res.json() as { data?: { id: string; name: string; slug: string }; error?: { message?: string }; detail?: { code?: string; message?: string } | string };
+      const json = await res.json() as { data?: { id: string; name: string; slug: string }; error?: { code?: string; message?: string }; detail?: { code?: string; message?: string } | string };
       if (!res.ok) {
+        // story #2470 — 실측(2026-08-06): 응답 envelope은 `{error:{code,...}}`다(BE
+        // HTTPException(detail=...)이 exception handler를 거쳐 `error`로 재포장된다).
+        // `json.detail`만 보던 이전 체크는 실제 응답에 그 필드가 없어 항상 죽은 분기였고
+        // (한도 초과여도 이 브랜치를 못 타 raw 영문 message로 계속 폴백) — `error.code`를
+        // 1순위로, `detail`은 하위호환 폴백으로 남긴다.
         const detail = typeof json.detail === 'object' ? json.detail : null;
-        if (res.status === 402 && detail?.code === 'PLAN_LIMIT_EXCEEDED') {
+        if (res.status === 402 && (json.error?.code === 'PLAN_LIMIT_EXCEEDED' || detail?.code === 'PLAN_LIMIT_EXCEEDED')) {
           bumpPlanLimitNonce();
           setPlanLimitHit(true);
           return;


### PR DESCRIPTION
## 요약
라이브 재현(2026-08-06) — Free plan 계정이 새 조직 생성 시 raw 영문 `Free plan org limit (1) reached. Upgrade to Team or Pro.` 그대로 노출. BE는 이미 구조화 에러(`POST /api/organizations` → 402 `{"error":{"code":"PLAN_LIMIT_EXCEEDED","message":"...","tier":"free","upgrade_required":true}}`)를 반환하는데 FE가 `error.code`로 안 갈라 raw `message`를 그대로 찍은 게 원인(#2441과 정확히 같은 클래스).

## ⚠️ 두 조직생성 경로 다 고쳤습니다 (카디르군 QA 둘 다 부탁)

1. **온보딩 wizard**(`onboarding-form.tsx`, `/onboarding` — 신규가입 후 첫 조직 생성 경로): `PLAN_LIMIT_EXCEEDED` + `upgrade_required` 분기 신설 → 이미 존재하던(다른 한도 케이스에서 재사용 중인) `UpgradeModal`로 한국어 안내 + 업그레이드 버튼. `showUpgrade`/`upgradeReason` state는 이 스토리 前엔 세팅부가 없어 죽어있던 자리였습니다.
2. **사이드바 조직생성 dialog**(`create-organization-dialog.tsx`, 부수 발견): 이미 `PLAN_LIMIT_EXCEEDED` 처리 코드가 있었으나 `json.detail?.code`를 봤습니다 — 실측 확認 결과 실제 응답 envelope은 `{error:{code,...}}`이지 `detail`이 아닙니다(BE `HTTPException(detail=…)`이 exception handler를 거쳐 `error`로 재포장됨). `json.detail`은 실제 응답에 없는 필드라 이 분기가 항상 죽어있었고, 한도 초과여도 매번 raw `error.message`(영문) 폴백으로 샜습니다. `error.code`를 1순위로 고치고 `detail`은 하위호환 폴백으로 남겼습니다.

## 검증
- vitest 38/38(신규 7개: 온보딩 wizard 4 + 사이드바 dialog 3, 모두 실 마운트 — base-ui Dialog가 `document.body`에 portal되는 점까지 반영해 검증)
- `tsc --noEmit` 클린 · eslint 클린 · i18n phrase-collision 신규 0건
- 뮤테이션 셀프체크 2건(두 파일 각각 code-분기를 꺼서 RED 확認 → 복원 → GREEN)
- `pnpm build` exit 0

## 라이브 검증 계획
dev 배포 후 카디르군 QA: 두 경로(온보딩 wizard + 사이드바 dialog) 모두 조직 한도 초과 시 한국어 안내 + 업그레이드 버튼 노출 확認. 유나신 카피 톤 확認.

🤖 Generated with [Claude Code](https://claude.com/claude-code)