### PR TITLE
feat(#2471): 결제② A1 — TierEnum 4티어 + offering_versions 카탈로그 + grandfather_policies + provider-agnostic pricing

### DIFF
--- a/backend/alembic/versions/0228_billing_v2_3_tier_model_offering_catalog.py
+++ b/backend/alembic/versions/0228_billing_v2_3_tier_model_offering_catalog.py
@@ -1,0 +1,347 @@
+"""#2471(A1) — 결제② 모델 재편: TierEnum 4티어 + offering_versions 카탈로그(어드민 편집 가능·
+불변 버전=히스토리) + grandfather_policies(org↔offering_version 묶임+규칙) + provider-agnostic pricing.
+
+설계문서 billing-arch-modular-pg-ledger-v0-1 §2·§4, 정책 pricing-policy-v2-3 Part3 기준.
+PG 호출/웹훅 로직은 손대지 않는다(범위는 B/C) — 이 마이그는 스키마/카탈로그 시드만 다룬다.
+
+## 이 마이그가 하는 것
+1. offering_versions 신설 — 티어·통화·가격·좌석·한도·팩을 하나의 불변 행에 스냅샷(v2.1 §13.1
+   판정: pricing_versions+plan_tier_limits로 흩어진 개념을 원자적 카탈로그로 교체). krw_v1
+   4티어(free/starter/team/business) 시드값은 «초기값»일 뿐 — 이 테이블 자체가 이미 어드민이
+   UPDATE/신규 INSERT로 편집 가능한 데이터다(코드 하드코딩 아님). 값이 바뀌면 새 행 + 이전
+   행 effective_to로 "닫기"만(append-only) — 그게 곧 요금제 히스토리. 선생님 04:11Z 추가 요건.
+1-1. grandfather_policies 신설 — 어떤 org가 어떤 offering_version에 묶였는지(offering_version_id)
+   + 그 묶임을 다루는 규칙(auto_migrate_on_new_version·grace_period_days)을 데이터로. org_
+   subscriptions.offering_version_id(아래 3)가 "지금 실제로 쓰는 버전"의 단순 포인터라면,
+   이 테이블은 그 위의 정책 계층 — 새 버전이 나와도 자동 이전할지/얼마나 고정할지. 어드민
+   API/UI 자체는 후속 별 스토리, 이 마이그는 데이터 모델만. ⚠️이번 Free 좌석 5→3은 grandfather
+   미사용(강제) — 이 테이블에 아무 행도 만들지 않는다(아래 §Free 좌석 참조).
+2. pricing_versions — polar_price_id(NOT NULL) → provider_price_ref(nullable) + provider
+   (NOT NULL, toss/polar) + provider=f(currency) CHECK. tier CHECK에서 'pro' 은퇴(테이블
+   0행이라 무손실). 이 테이블은 조회 경로(billing.py._current_pricing_version_id)만 있고
+   ORM에서 옛 컬럼명을 직접 read하는 곳이 없어 rename 안전.
+3. org_subscriptions — polar_customer_id를 nullable로(Toss 구독은 Polar customer가 없음).
+   currency·provider 컬럼 신설(둘 다 nullable, provider=f(currency) CHECK) — 실제 값 기입은
+   B단계 어댑터가 담당, 이 마이그는 그릇만.
+4. plan_tier_limits — starter/business 행 추가(ON CONFLICT DO NOTHING, 0140 선례와 동일
+   패턴). 기존 free/team/pro 행은 건드리지 않는다 — 'pro' CHECK/데이터 전환은 B단계에서
+   billing.py 웹훅이 더는 'pro'를 쓰지 않게 될 때 함께(지금 지우면 아직 살아있는 Polar
+   웹훅 쓰기 경로가 "캡 미정의 tier=무제한" 사각지대로 빠진다 — 회귀).
+
+## 이 마이그가 «하지 않는» 것 (명시적 스코프 아웃)
+- org_subscriptions.tier CHECK 신설 — billing.py 웹훅이 여전히 tier="pro"를 쓰는 채로 CHECK를
+  걸면 다음 Polar 웹훅에서 즉시 위반한다. B단계(PolarAdapter 이관)에서 웹훅 코드와 함께 묶어
+  간다.
+- USD offering_versions 시드 — v2.3 정책 문서는 KRW 전용(적용 시장 한국)이다. USD 연납/추가좌석
+  가격은 어디에도 결재된 숫자가 없어 이 마이그에서 발명하지 않는다. B단계가 기존 하드코딩
+  Polar 카탈로그(_PLAN_CATALOG/_POLAR_PRICE_IDS)를 이관하며 채운다.
+- tier2 "legacy subscriptions/plan_tiers"(SaaS overlay 소유, docs/pk-triage-orm-unmodeled.md
+  분류상 drop=선생님 승인 필수) 통합 — PO 확認 대기 중(#2471 Discord 04:03Z 스레드), 별도
+  후속.
+
+## Free 좌석 3캡(선생님 確定 04:00Z)
+offering_versions.free.included_seats=3으로 정책 목표를 반영한다. 기존 5명 초과 Free org를
+서버가 강제로 축소하지는 않는다 — ee/plan_limits.py의 FREE_LIMITS만 3으로 낮춰 **신규 초대만
+차단**한다(기존 멤버는 유지). storage/agent 등 이 코드베이스의 다른 모든 초과 자원과 동일한
+패턴(check_storage_capacity: 신규 업로드만 차단·기존 파일 유지)이라 새 정책이 아니라 기존
+관례를 그대로 적용한 것 — 데이터 삭제 마이그가 필요 없다. PR 본문에 이 판단 근거를 남긴다.
+"""
+from __future__ import annotations
+
+import uuid
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0228"
+down_revision = "0227"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # ---------------------------------------------------------------
+    # 1. offering_versions 신설
+    # ---------------------------------------------------------------
+    if not inspector.has_table("offering_versions"):
+        op.create_table(
+            "offering_versions",
+            sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+            sa.Column("tier", sa.Text(), nullable=False),
+            sa.Column("currency", sa.Text(), nullable=False),
+            sa.Column("version_label", sa.Text(), nullable=False),
+            sa.Column("monthly_price_minor", sa.BigInteger(), nullable=False),
+            sa.Column("annual_price_minor", sa.BigInteger(), nullable=False),
+            sa.Column("included_seats", sa.Integer(), nullable=False),
+            sa.Column("extra_seat_price_minor", sa.BigInteger(), nullable=True),
+            sa.Column("max_agents", sa.Integer(), nullable=True),
+            sa.Column("au_limit", sa.BigInteger(), nullable=False),
+            sa.Column("realtime_connection_limit", sa.Integer(), nullable=False),
+            sa.Column("storage_mb_limit", sa.BigInteger(), nullable=False),
+            sa.Column("max_file_mb", sa.Integer(), nullable=False),
+            sa.Column("lab_credit_minor", sa.BigInteger(), nullable=False),
+            sa.Column("rate_limit_per_min", sa.Integer(), nullable=False),
+            sa.Column("automation_rule_limit", sa.Integer(), nullable=False),
+            sa.Column("webhook_limit", sa.Integer(), nullable=False),
+            sa.Column("event_replay_days", sa.Integer(), nullable=False),
+            sa.Column("overage_allowed", sa.Boolean(), nullable=False),
+            sa.Column("pack_catalog", postgresql.JSONB(), nullable=True),
+            sa.Column("effective_from", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("effective_to", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("created_by", sa.Text(), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+            sa.CheckConstraint("tier IN ('free','starter','team','business')", name="offering_versions_tier_check"),
+            sa.CheckConstraint("currency IN ('usd','krw')", name="offering_versions_currency_check"),
+        )
+        op.create_index(
+            "uq_offering_versions_active_tier_currency",
+            "offering_versions",
+            ["tier", "currency"],
+            unique=True,
+            postgresql_where=sa.text("effective_to IS NULL"),
+        )
+
+    _seed_offering_versions_krw_v1(bind)
+
+    # ---------------------------------------------------------------
+    # 2. pricing_versions — provider-agnostic화
+    # ---------------------------------------------------------------
+    pv_cols = {c["name"] for c in inspector.get_columns("pricing_versions")}
+    if "polar_price_id" in pv_cols and "provider_price_ref" not in pv_cols:
+        op.alter_column(
+            "pricing_versions", "polar_price_id",
+            new_column_name="provider_price_ref", nullable=True,
+        )
+    if "provider" not in pv_cols:
+        op.add_column("pricing_versions", sa.Column("provider", sa.Text(), nullable=True))
+        bind.execute(sa.text(
+            "UPDATE pricing_versions SET provider = CASE currency "
+            "WHEN 'krw' THEN 'toss' WHEN 'usd' THEN 'polar' END WHERE provider IS NULL"
+        ))
+        op.alter_column("pricing_versions", "provider", nullable=False)
+        op.create_check_constraint(
+            "pricing_versions_provider_check", "pricing_versions", "provider IN ('toss','polar')"
+        )
+        op.create_check_constraint(
+            "pricing_versions_provider_currency_fn", "pricing_versions",
+            "(currency = 'krw' AND provider = 'toss') OR (currency = 'usd' AND provider = 'polar')",
+        )
+
+    pv_checks = {c["name"] for c in inspector.get_check_constraints("pricing_versions")}
+    if "pricing_versions_tier_check" in pv_checks:
+        # #2471 A1 실측(로컬 fresh-DB 재현, 0146→0147 진짜 이력을 타는 환경): 0147(live seed)이
+        # team/pro × monthly/yearly × usd/krw 10건을 이미 심어둔 채로 이 리비전에 도달할 수
+        # 있다(prod의 실제 경로는 0147을 건너뛰어 비어있지만, CI alembic-fresh-db·신규 dev DB는
+        # 진짜 이력을 그대로 타 0147을 통과한다 — #2397이 문서화한 바로 그 이력 분기). "테이블이
+        # 0행"이라는 가정은 prod 한정 사실이었다 — 여기서 직접 데이터를 다뤄 두 이력 모두 안전.
+        # 'pro'는 은퇴하고 'business'가 대신한다(v2.3 D12) — 실 Polar live price row는 그대로
+        # 보존하고 tier 값만 재라벨링(가격/식별자 무손실, 정책대로 재설정). 옛 CHECK가 'business'를
+        # 허용 안 하므로 반드시 constraint 교체 → UPDATE 순서.
+        op.drop_constraint("pricing_versions_tier_check", "pricing_versions", type_="check")
+        bind.execute(sa.text("UPDATE pricing_versions SET tier = 'business' WHERE tier = 'pro'"))
+        op.create_check_constraint(
+            "pricing_versions_tier_check", "pricing_versions",
+            "tier IN ('starter','team','business','overage')",
+        )
+
+    # ---------------------------------------------------------------
+    # 3. org_subscriptions — provider-agnostic 컬럼 + polar_customer_id nullable
+    # ---------------------------------------------------------------
+    os_cols = {c["name"] for c in inspector.get_columns("org_subscriptions")}
+    op.alter_column("org_subscriptions", "polar_customer_id", nullable=True)
+    if "currency" not in os_cols:
+        op.add_column("org_subscriptions", sa.Column("currency", sa.Text(), nullable=True))
+        op.create_check_constraint(
+            "org_subscriptions_currency_check", "org_subscriptions",
+            "currency IS NULL OR currency IN ('usd','krw')",
+        )
+    if "provider" not in os_cols:
+        op.add_column("org_subscriptions", sa.Column("provider", sa.Text(), nullable=True))
+        op.create_check_constraint(
+            "org_subscriptions_provider_check", "org_subscriptions",
+            "provider IS NULL OR provider IN ('toss','polar')",
+        )
+        op.create_check_constraint(
+            "org_subscriptions_provider_currency_fn", "org_subscriptions",
+            "(currency IS NULL AND provider IS NULL) OR "
+            "(currency = 'krw' AND provider = 'toss') OR (currency = 'usd' AND provider = 'polar')",
+        )
+    if "offering_version_id" not in os_cols:
+        op.add_column(
+            "org_subscriptions",
+            sa.Column("offering_version_id", postgresql.UUID(as_uuid=True), nullable=True),
+        )
+        op.create_foreign_key(
+            "fk_org_subscriptions_offering_version_id", "org_subscriptions", "offering_versions",
+            ["offering_version_id"], ["id"],
+        )
+
+    # ---------------------------------------------------------------
+    # 3-1. grandfather_policies 신설 — org↔offering_version 묶임 + 정책 규칙(데이터)
+    # ---------------------------------------------------------------
+    if not inspector.has_table("grandfather_policies"):
+        op.create_table(
+            "grandfather_policies",
+            sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+            sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+            sa.Column("offering_version_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("offering_versions.id"), nullable=False),
+            sa.Column("auto_migrate_on_new_version", sa.Boolean(), nullable=False, server_default=sa.false()),
+            sa.Column("grace_period_days", sa.Integer(), nullable=True),
+            sa.Column("reason", sa.Text(), nullable=False),
+            sa.Column("effective_from", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("effective_to", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("created_by", sa.Text(), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        )
+        op.create_index(
+            "uq_grandfather_policies_active_org",
+            "grandfather_policies",
+            ["org_id"],
+            unique=True,
+            postgresql_where=sa.text("effective_to IS NULL"),
+        )
+        op.create_index("ix_grandfather_policies_org_id", "grandfather_policies", ["org_id"])
+
+    # ---------------------------------------------------------------
+    # 4. plan_tier_limits — starter/business 행 추가(additive, 기존 행 무변경)
+    # ---------------------------------------------------------------
+    for tier, storage_mb, file_mb in [
+        ("starter", 10 * 1024, 300),
+        ("business", 250 * 1024, 1000),
+    ]:
+        bind.execute(
+            sa.text(
+                "INSERT INTO plan_tier_limits (tier, max_storage_mb, max_file_mb) "
+                "VALUES (:t, :s, :f) ON CONFLICT (tier) DO NOTHING"
+            ),
+            {"t": tier, "s": storage_mb, "f": file_mb},
+        )
+
+
+# pricing-policy-v2-3 Part3(가격/한도) + pricing-policy-proposal-v1 §7.1(Team/Business 팩 —
+# v2.3이 승계) 수치를 그대로 옮긴다. 모듈 레벨 상수로 둬 DB 없이도 pytest가 이 값 자체를
+# 정책 문서와 대조할 수 있게 한다(판정을 코드로 pin — #2178 관례).
+KRW_V1_OFFERINGS = [
+    dict(
+        tier="free", monthly=0, annual=0, seats=3, extra_seat=None, max_agents=3,
+        au=50_000, conn=10, storage_mb=5 * 1024, file_mb=100, lab_credit=500,
+        rate=120, rules=3, webhooks=0, replay=7, overage=False, packs=None,
+    ),
+    dict(
+        tier="starter", monthly=29_000, annual=290_000, seats=3, extra_seat=None, max_agents=None,
+        au=150_000, conn=12, storage_mb=10 * 1024, file_mb=300, lab_credit=1_000,
+        rate=300, rules=20, webhooks=3, replay=30, overage=True,
+        packs={
+            "au": {"unit": 150_000, "price_minor": 5_000, "max_packs": 5},
+            "storage_gb": {"unit": 10, "price_minor": 3_000, "max_packs": 3},
+        },
+    ),
+    dict(
+        tier="team", monthly=59_000, annual=590_000, seats=5, extra_seat=11_000, max_agents=None,
+        au=1_000_000, conn=50, storage_mb=50 * 1024, file_mb=500, lab_credit=5_000,
+        rate=1_200, rules=100, webhooks=10, replay=90, overage=True,
+        packs={
+            "au": {"unit": 1_000_000, "price_minor": 20_000, "max_packs": 5},
+            "realtime_connections": {"unit": 50, "price_minor": 30_000, "max_packs": 1},
+            "storage_gb": {"unit": 100, "price_minor": 15_000, "max_packs": 1},
+            "lab_credit": {"unit": 5_000, "price_minor": 10_000, "max_packs": None},
+        },
+    ),
+    dict(
+        tier="business", monthly=219_000, annual=2_190_000, seats=15, extra_seat=9_900, max_agents=None,
+        au=10_000_000, conn=250, storage_mb=250 * 1024, file_mb=1_000, lab_credit=20_000,
+        rate=6_000, rules=1_000, webhooks=100, replay=365, overage=True,
+        packs={
+            "au": {"unit": 10_000_000, "price_minor": 100_000, "max_packs": 10},
+            "realtime_connections": {"unit": 100, "price_minor": 50_000, "max_packs": 10},
+            "storage_gb": {"unit": 250, "price_minor": 40_000, "max_packs": 10},
+            "lab_credit": {"unit": 10_000, "price_minor": 18_000, "max_packs": None},
+        },
+    ),
+]
+
+
+def _seed_offering_versions_krw_v1(bind) -> None:
+    """이미 krw_v1 행이 있으면 재삽입하지 않는다(append-only 원칙 — 가격 재조정은 새 버전
+    행으로, 기존 행 UPDATE 아님)."""
+    existing = bind.execute(
+        sa.text("SELECT COUNT(*) FROM offering_versions WHERE version_label = 'krw_v1'")
+    ).scalar()
+    if existing:
+        return
+
+    import json as _json
+
+    for r in KRW_V1_OFFERINGS:
+        bind.execute(
+            sa.text(
+                "INSERT INTO offering_versions "
+                "(id, tier, currency, version_label, monthly_price_minor, annual_price_minor, "
+                "included_seats, extra_seat_price_minor, max_agents, au_limit, "
+                "realtime_connection_limit, storage_mb_limit, max_file_mb, lab_credit_minor, "
+                "rate_limit_per_min, automation_rule_limit, webhook_limit, event_replay_days, "
+                "overage_allowed, pack_catalog, effective_from, created_by) "
+                "VALUES (:id, :tier, 'krw', 'krw_v1', :monthly, :annual, :seats, :extra_seat, "
+                ":max_agents, :au, :conn, :storage_mb, :file_mb, :lab_credit, :rate, :rules, "
+                ":webhooks, :replay, :overage, :packs, now(), 'migration:0228')"
+            ),
+            {
+                "id": uuid.uuid4(),
+                "tier": r["tier"],
+                "monthly": r["monthly"],
+                "annual": r["annual"],
+                "seats": r["seats"],
+                "extra_seat": r["extra_seat"],
+                "max_agents": r["max_agents"],
+                "au": r["au"],
+                "conn": r["conn"],
+                "storage_mb": r["storage_mb"],
+                "file_mb": r["file_mb"],
+                "lab_credit": r["lab_credit"],
+                "rate": r["rate"],
+                "rules": r["rules"],
+                "webhooks": r["webhooks"],
+                "replay": r["replay"],
+                "overage": r["overage"],
+                "packs": _json.dumps(r["packs"]) if r["packs"] is not None else None,
+            },
+        )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_grandfather_policies_org_id", table_name="grandfather_policies")
+    op.drop_index("uq_grandfather_policies_active_org", table_name="grandfather_policies")
+    op.drop_table("grandfather_policies")
+
+    op.drop_constraint("fk_org_subscriptions_offering_version_id", "org_subscriptions", type_="foreignkey")
+    op.drop_column("org_subscriptions", "offering_version_id")
+
+    op.drop_constraint("org_subscriptions_provider_currency_fn", "org_subscriptions", type_="check")
+    op.drop_constraint("org_subscriptions_provider_check", "org_subscriptions", type_="check")
+    op.drop_column("org_subscriptions", "provider")
+    op.drop_constraint("org_subscriptions_currency_check", "org_subscriptions", type_="check")
+    op.drop_column("org_subscriptions", "currency")
+    op.alter_column("org_subscriptions", "polar_customer_id", nullable=False)
+
+    op.drop_constraint("pricing_versions_tier_check", "pricing_versions", type_="check")
+    op.execute("UPDATE pricing_versions SET tier = 'pro' WHERE tier = 'business'")
+    op.create_check_constraint(
+        "pricing_versions_tier_check", "pricing_versions",
+        "tier IN ('team','pro','overage')",
+    )
+    op.drop_constraint("pricing_versions_provider_currency_fn", "pricing_versions", type_="check")
+    op.drop_constraint("pricing_versions_provider_check", "pricing_versions", type_="check")
+    op.drop_column("pricing_versions", "provider")
+    op.alter_column(
+        "pricing_versions", "provider_price_ref",
+        new_column_name="polar_price_id", nullable=False,
+    )
+
+    op.drop_index("uq_offering_versions_active_tier_currency", table_name="offering_versions")
+    op.drop_table("offering_versions")
+
+    op.execute("DELETE FROM plan_tier_limits WHERE tier IN ('starter', 'business')")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -28,6 +28,8 @@ from app.models.workflow_version import WorkflowVersion
 from app.models.api_key import ApiKey
 from app.models.org_subscription import OrgSubscription
 from app.models.pricing_version import PricingVersion
+from app.models.offering_version import OfferingVersion
+from app.models.grandfather_policy import GrandfatherPolicy
 from app.models.plan_tier_limit import PlanTierLimit
 from app.models.policy_document import PolicyDocument
 from app.models.audit import AuditLog
@@ -138,6 +140,8 @@ __all__ = [
     "ApiKey",
     "OrgSubscription",
     "PricingVersion",
+    "OfferingVersion",
+    "GrandfatherPolicy",
     "PlanTierLimit",
     "PolicyDocument",
     "AuditLog",

--- a/backend/app/models/grandfather_policy.py
+++ b/backend/app/models/grandfather_policy.py
@@ -1,0 +1,45 @@
+"""grandfather 정책 — 어떤 org가 어떤 offering_version에 «묶였는지» + 그 묶임을 다루는
+규칙을 데이터로 표현한다(#2471 A1, 선생님 04:11Z 추가 요건).
+
+org_subscriptions.offering_version_id는 "지금 이 org가 실제로 쓰는 offering_version"을
+가리키는 단순 현재값 포인터다(pricing_version_id와 동일 패턴). 이 테이블은 그 위의 정책
+계층이다 — "이 org를 새 offering_version이 나와도 자동으로 옮길지, 언제까지 옛 버전에
+묶어 둘지"를 어드민이 편집 가능한 데이터로 관리한다(어드민 API/UI 자체는 후속 별 스토리).
+
+append-only 이력 — 정책이 바뀌면 새 행, effective_to로 이전 행을 "닫는다"(pricing_versions·
+offering_versions와 동일 규약).
+
+⛔이 스토리는 그릇만 만든다. 어떤 트리거로 이 테이블을 읽고/쓰고 실제로 org를 이전시키는
+로직은 범위 밖(B 이후 · 어드민 API 스토리)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class GrandfatherPolicy(Base):
+    __tablename__ = "grandfather_policies"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    offering_version_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("offering_versions.id"), nullable=False
+    )
+    # 새 offering_version(같은 tier·currency)이 발행돼도 이 org를 자동으로 옮길지.
+    auto_migrate_on_new_version: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    # NULL = 무기한 고정(수동 개입 전까지 옛 버전 유지). N일 = 새 버전 발행 후 N일 뒤 강제 이전.
+    grace_period_days: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # signup·plan_change·admin_grandfather_grant·forced_migration 등 — 왜 이 정책이 생겼는지.
+    reason: Mapped[str] = mapped_column(Text, nullable=False)
+    effective_from: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    effective_to: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_by: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/models/offering_version.py
+++ b/backend/app/models/offering_version.py
@@ -1,0 +1,72 @@
+"""요금제 v2.3 오퍼링 카탈로그 스냅샷(#2471 A1, doc pricing-policy-v2-3·billing-arch-modular-pg-ledger-v0-1 §4).
+
+v2.1 §13.1의 판정을 그대로 따른다 — pricing_versions(가격만) + plan_tier_limits(저장만)로
+흩어져 있던 "티어가 뭘 의미하는가"를 하나의 불변 행에 원자적으로 스냅샷한다: 가격·좌석·
+한도(AU·저장·연결·에이전트·웹훅·규칙·레이트·재생)·팩 단위가 같은 offering_version 행 안에서
+함께 버전 관리된다. append-only 정신은 pricing_versions와 동일 — 값이 바뀌면 새 행, 기존
+행은 절대 UPDATE하지 않는다(effective_to로 "닫기"만).
+
+⛔대표 승인 前이므로 이 표의 가격은 확定가가 아니다. 대외 노출/가격 화면에 쓰지 않는다
+(내부 카탈로그 한정).
+
+⚠️A1 스코프: krw_v1(4티어: free/starter/team/business)만 시드한다. USD/Polar 카탈로그는
+그대로 기존 하드코딩 상수(ee/routers/billing.py _PLAN_CATALOG/_POLAR_PRICE_IDS)로 운영
+중이며, 이 스토리에서 임의의 USD 연납/추가좌석 숫자를 발명하지 않는다 — 그 이관은 B단계
+(PolarAdapter)의 몫이다.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import BigInteger, Boolean, CheckConstraint, DateTime, Integer, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class OfferingVersion(Base):
+    __tablename__ = "offering_versions"
+    __table_args__ = (
+        CheckConstraint(
+            "tier IN ('free','starter','team','business')", name="offering_versions_tier_check"
+        ),
+        CheckConstraint("currency IN ('usd','krw')", name="offering_versions_currency_check"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tier: Mapped[str] = mapped_column(Text, nullable=False)
+    currency: Mapped[str] = mapped_column(Text, nullable=False)
+    # 정책 버전 라벨(예: "krw_v1") — pricing-policy-v2-3 문서의 버전 문자열과 1:1.
+    version_label: Mapped[str] = mapped_column(Text, nullable=False)
+
+    monthly_price_minor: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    annual_price_minor: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    included_seats: Mapped[int] = mapped_column(Integer, nullable=False)
+    # NULL = 추가 좌석을 판매하지 않음(v2.3 Starter).
+    extra_seat_price_minor: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    # NULL = 무제한(Starter 이상). Free만 유한값(사람 좌석과 연동 — v2.1 §4.4).
+    max_agents: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    au_limit: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    realtime_connection_limit: Mapped[int] = mapped_column(Integer, nullable=False)
+    storage_mb_limit: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    max_file_mb: Mapped[int] = mapped_column(Integer, nullable=False)
+    lab_credit_minor: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    rate_limit_per_min: Mapped[int] = mapped_column(Integer, nullable=False)
+    automation_rule_limit: Mapped[int] = mapped_column(Integer, nullable=False)
+    webhook_limit: Mapped[int] = mapped_column(Integer, nullable=False)
+    event_replay_days: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    # 포함량 도달 시 팩 구매로 이어갈 수 있는지(Free=false=멈춘다·나머지=true).
+    overage_allowed: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    # 팩 카탈로그 스냅샷(자원별 {unit, price_minor, max_packs}) — NULL=팩 없음(Free).
+    pack_catalog: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    effective_from: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    effective_to: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_by: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/models/org_subscription.py
+++ b/backend/app/models/org_subscription.py
@@ -15,11 +15,19 @@ class OrgSubscription(Base):
     org_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), nullable=False, unique=True
     )
-    polar_customer_id: Mapped[str] = mapped_column(Text, nullable=False)
+    # #2471(A1): provider-agnostic화 — Toss(원화) 구독은 Polar customer가 없다(v2.1 §13.1
+    # "버린다" 판정). NOT NULL이던 시절엔 Free/Toss 조직이 빈 문자열을 넣어야 했다.
+    polar_customer_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     polar_subscription_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     tier: Mapped[str] = mapped_column(Text, nullable=False, default="free")
     billing_cycle: Mapped[str | None] = mapped_column(Text, nullable=True)
     status: Mapped[str] = mapped_column(Text, nullable=False, default="active")
+    # #2471(A1): provider = 통화의 함수(원화→toss·달러→polar, per-org, 03:41Z 確定). 두
+    # 컬럼 다 nullable — 기존 행·아직 어댑터가 안 채우는 행은 NULL. CHECK(provider_currency_fn)
+    # 로 "provider는 currency로부터만 파생된다" 불변식을 DB가 직접 강제한다. 실제 값 기입은
+    # B단계(PolarAdapter/TossAdapter)에서 — 이 스토리는 그릇만 만든다.
+    currency: Mapped[str | None] = mapped_column(Text, nullable=True)
+    provider: Mapped[str | None] = mapped_column(Text, nullable=True)
     current_period_start: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     current_period_end: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     # S8 Phase 2: 80% storage 경고 메일 dedup 마커(마지막 발송 시각·NULL=미발송).
@@ -28,6 +36,12 @@ class OrgSubscription(Base):
     # 기존 구독은 NULL(0146은 구조만, 값 백필은 가격 확정 후 별도 마이그).
     pricing_version_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("pricing_versions.id"), nullable=True
+    )
+    # #2471(A1): 이 구독이 지금 실제로 묶인 offering_version(가격·좌석·한도·팩 원자 스냅샷).
+    # pricing_version_id와 동일 grandfather 패턴 — nullable(기존 행·아직 어댑터 미기입 행은
+    # NULL). "언제 자동 이전할지" 같은 정책 규칙은 grandfather_policies가 별도로 진다.
+    offering_version_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("offering_versions.id"), nullable=True
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/models/plan_feature.py
+++ b/backend/app/models/plan_feature.py
@@ -8,7 +8,11 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
 
-TierEnum = Enum("free", "team", "pro", name="plan_feature_tier")
+# v2.3(#2471 A1): free/starter/team/business로 재편(기존 free/team/pro 대체). solo/pro
+# enum은 신설하지 않는다(v2.3 D12) — pro는 은퇴, business가 그 자리를 대신한다. 이 Enum은
+# 어떤 컬럼에도 바인딩되지 않은 선언뿐이라(plan_feature.tier는 String(16)) 실제 DB CHECK는
+# 각 테이블(offering_versions·pricing_versions)이 개별로 가진다.
+TierEnum = Enum("free", "starter", "team", "business", name="plan_feature_tier")
 
 
 class PlanFeature(Base):

--- a/backend/app/models/pricing_version.py
+++ b/backend/app/models/pricing_version.py
@@ -9,9 +9,15 @@ free tier는 가격이 항상 0이라 버전 이력 대상에서 제외(tier CHE
 grandfather: org_subscriptions.pricing_version_id가 가입(플랜변경) 시점의 이 테이블 행을
 참조 — 이후 가격이 바뀌어도 기존 구독은 그 시점 행의 price_cents를 유지한다.
 
-currency: Polar가 USD/KRW를 별개 price 객체(각자 polar_price_id)로 관리해 (tier,
+currency: PG가 USD/KRW를 별개 price 객체(각자 provider_price_ref)로 관리해 (tier,
 billing_cycle, currency)가 계보 키다 — 통화별 독립 grandfather. price_cents는 그 통화의
-최소단위 그대로(USD=센트·KRW=원, Polar 자체 규칙과 동일)."""
+최소단위 그대로(USD=센트·KRW=원, Polar 자체 규칙과 동일).
+
+#2471(A1) provider-agnostic화: polar_price_id(NOT NULL) → provider_price_ref(nullable) +
+provider(NOT NULL, toss/polar). provider는 currency로부터만 파생된다는 불변식을 CHECK
+제약으로 DB가 직접 강제(krw→toss·usd→polar, 03:41Z 確定). tier CHECK에서 'pro'는 은퇴하고
+'starter'/'business'가 대신한다(v2.3 D12) — 이 테이블은 마이그 시점에 0행이라 무손실
+전환이다."""
 from __future__ import annotations
 
 import uuid
@@ -32,7 +38,8 @@ class PricingVersion(Base):
     billing_cycle: Mapped[str] = mapped_column(Text, nullable=False)
     currency: Mapped[str] = mapped_column(Text, nullable=False, default="usd")
     price_cents: Mapped[int] = mapped_column(Integer, nullable=False)
-    polar_price_id: Mapped[str] = mapped_column(Text, nullable=False)
+    provider: Mapped[str] = mapped_column(Text, nullable=False)
+    provider_price_ref: Mapped[str | None] = mapped_column(Text, nullable=True)
     effective_from: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     effective_to: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_by: Mapped[str] = mapped_column(Text, nullable=False)

--- a/backend/ee/plan_limits.py
+++ b/backend/ee/plan_limits.py
@@ -3,7 +3,9 @@
 Free 플랜 제한:
   - Org: 사용자당 1개 (owner 기준)
   - Project: org당 1개
-  - Member: org당 5명
+  - Member: org당 3명 (#2471 A1 — v2.3 정책·선생님 確定 2026-08-06 04:00Z. 강제 마이그
+    아님: 기존 3명 초과 Free org는 멤버를 그대로 두고 신규 초대만 막는다 — 이 파일의 다른
+    모든 초과-자원 처리(storage: 신규 업로드만 차단·기존 파일 유지)와 동일한 패턴.)
 
 Team/Pro: 제한 없음.
 """
@@ -14,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 FREE_LIMITS: dict[str, int] = {
     "max_orgs_owned": 1,
     "max_projects": 1,
-    "max_members": 5,
+    "max_members": 3,
 }
 
 # API 초과 과금 정책 (per call, USD)

--- a/backend/tests/test_e_2471_a1_billing_model.py
+++ b/backend/tests/test_e_2471_a1_billing_model.py
@@ -1,0 +1,112 @@
+"""#2471(A1) — DB 없이 도는 단위 테스트. TierEnum 재편·FREE_LIMITS 5→3·krw_v1 시드값이
+pricing-policy-v2-3 Part3(+ pricing-policy-proposal-v1 §7.1 팩)와 일치하는지 pin한다.
+값이 문서와 어긋나면(오타·단위 실수) 이 테스트가 즉시 빨간불 — "판정 선언은 테스트로 pin"."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_migration_0228():
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "alembic" / "versions" / "0228_billing_v2_3_tier_model_offering_catalog.py"
+    )
+    spec = importlib.util.spec_from_file_location("mig_0228", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_tier_enum_is_v2_3_four_tier():
+    from app.models.plan_feature import TierEnum
+
+    assert list(TierEnum.enums) == ["free", "starter", "team", "business"]
+    assert "pro" not in TierEnum.enums
+    assert "solo" not in TierEnum.enums  # v2.3 D12: solo enum 신설 금지
+
+
+def test_free_limits_seats_capped_at_3():
+    from ee.plan_limits import FREE_LIMITS
+
+    assert FREE_LIMITS["max_members"] == 3  # 선생님 確定 2026-08-06 04:00Z(강제, 그랜드파더링 없음)
+    assert FREE_LIMITS["max_orgs_owned"] == 1
+    assert FREE_LIMITS["max_projects"] == 1
+
+
+def _by_tier(rows):
+    return {r["tier"]: r for r in rows}
+
+
+def test_krw_v1_seed_matches_pricing_policy_v2_3_part3():
+    """pricing-policy-v2-3 Part3 표(가격·좌석·한도)와 1:1 대조."""
+    mod = _load_migration_0228()
+    rows = _by_tier(mod.KRW_V1_OFFERINGS)
+    assert set(rows) == {"free", "starter", "team", "business"}
+
+    free, starter, team, business = rows["free"], rows["starter"], rows["team"], rows["business"]
+
+    # 가격(공급가, 원)
+    assert (free["monthly"], free["annual"]) == (0, 0)
+    assert (starter["monthly"], starter["annual"]) == (29_000, 290_000)
+    assert (team["monthly"], team["annual"]) == (59_000, 590_000)
+    assert (business["monthly"], business["annual"]) == (219_000, 2_190_000)
+
+    # 좌석 — D13: Free/Starter 3, Team 5, Business 15. "뒤로 가는 칸" 없음(단조 증가 검증).
+    seats = [free["seats"], starter["seats"], team["seats"], business["seats"]]
+    assert seats == [3, 3, 5, 15]
+    assert all(a <= b for a, b in zip(seats, seats[1:])), "좌석 수가 티어 상승에서 감소하면 안 됨(D13)"
+    assert starter["extra_seat"] is None  # 판매하지 않음
+    assert team["extra_seat"] == 11_000
+    assert business["extra_seat"] == 9_900
+
+    # 등록 에이전트 — Free만 유한(3, 좌석과 연동), 나머지 무제한(None)
+    assert free["max_agents"] == 3
+    assert starter["max_agents"] is None
+    assert team["max_agents"] is None
+    assert business["max_agents"] is None
+
+    # 한도표(Part3)
+    assert [free["au"], starter["au"], team["au"], business["au"]] == [50_000, 150_000, 1_000_000, 10_000_000]
+    assert [free["conn"], starter["conn"], team["conn"], business["conn"]] == [10, 12, 50, 250]
+    assert [free["storage_mb"], starter["storage_mb"], team["storage_mb"], business["storage_mb"]] == [
+        5 * 1024, 10 * 1024, 50 * 1024, 250 * 1024,
+    ]
+    assert [free["file_mb"], starter["file_mb"], team["file_mb"], business["file_mb"]] == [100, 300, 500, 1000]
+    assert [free["lab_credit"], starter["lab_credit"], team["lab_credit"], business["lab_credit"]] == [
+        500, 1_000, 5_000, 20_000,
+    ]
+    assert [free["rate"], starter["rate"], team["rate"], business["rate"]] == [120, 300, 1_200, 6_000]
+    assert [free["rules"], starter["rules"], team["rules"], business["rules"]] == [3, 20, 100, 1_000]
+    assert [free["webhooks"], starter["webhooks"], team["webhooks"], business["webhooks"]] == [0, 3, 10, 100]
+    assert [free["replay"], starter["replay"], team["replay"], business["replay"]] == [7, 30, 90, 365]
+
+    # 포함량 도달 시 동작 — Free만 멈춘다(팩 구매 불가)
+    assert free["overage"] is False
+    assert starter["overage"] is team["overage"] is business["overage"] is True
+    assert free["packs"] is None
+
+
+def test_krw_v1_pack_catalog_matches_d14_and_v2_1_section_7_1():
+    mod = _load_migration_0228()
+    rows = _by_tier(mod.KRW_V1_OFFERINGS)
+
+    starter_packs = rows["starter"]["packs"]
+    assert starter_packs["au"] == {"unit": 150_000, "price_minor": 5_000, "max_packs": 5}
+    assert starter_packs["storage_gb"] == {"unit": 10, "price_minor": 3_000, "max_packs": 3}
+    # D14: Starter는 연결·Lab·좌석 팩을 팔지 않는다.
+    assert "realtime_connections" not in starter_packs
+    assert "lab_credit" not in starter_packs
+
+    team_packs = rows["team"]["packs"]
+    assert team_packs["au"] == {"unit": 1_000_000, "price_minor": 20_000, "max_packs": 5}
+    assert team_packs["realtime_connections"] == {"unit": 50, "price_minor": 30_000, "max_packs": 1}
+    assert team_packs["storage_gb"] == {"unit": 100, "price_minor": 15_000, "max_packs": 1}
+    assert team_packs["lab_credit"] == {"unit": 5_000, "price_minor": 10_000, "max_packs": None}
+
+    business_packs = rows["business"]["packs"]
+    assert business_packs["au"] == {"unit": 10_000_000, "price_minor": 100_000, "max_packs": 10}
+    assert business_packs["realtime_connections"] == {"unit": 100, "price_minor": 50_000, "max_packs": 10}
+    assert business_packs["storage_gb"] == {"unit": 250, "price_minor": 40_000, "max_packs": 10}
+    assert business_packs["lab_credit"] == {"unit": 10_000, "price_minor": 18_000, "max_packs": None}
+

--- a/backend/tests/test_e_2471_a1_billing_model_realdb.py
+++ b/backend/tests/test_e_2471_a1_billing_model_realdb.py
@@ -1,0 +1,218 @@
+"""#2471(A1) real-DB — 0228 마이그가 실제로 만든 제약이 «잡는다»는 것을 직접 증명한다.
+
+DB env(ALEMBIC_DATABASE_URL) 없으면 skip — CI alembic-fresh-db 잡 env에서 실행/로컬 PG
+(alembic upgrade head 가 이미 적용된 DB를 전제한다)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_offering_versions_seeded_with_four_krw_v1_tiers():
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            rows = (
+                await session.execute(
+                    text(
+                        "SELECT tier, monthly_price_minor, included_seats, au_limit "
+                        "FROM offering_versions WHERE version_label = 'krw_v1' AND currency = 'krw' "
+                        "ORDER BY monthly_price_minor"
+                    )
+                )
+            ).all()
+            assert [r[0] for r in rows] == ["free", "starter", "team", "business"]
+            assert [r[1] for r in rows] == [0, 29_000, 59_000, 219_000]
+            assert [r[2] for r in rows] == [3, 3, 5, 15]
+            assert [r[3] for r in rows] == [50_000, 150_000, 1_000_000, 10_000_000]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_offering_versions_reject_second_active_row_same_tier_currency():
+    """양성대조 — unique partial index(tier,currency) WHERE effective_to IS NULL이 실제로 잡는가."""
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            with pytest.raises(IntegrityError, match="uq_offering_versions_active_tier_currency"):
+                await session.execute(
+                    text(
+                        "INSERT INTO offering_versions "
+                        "(tier, currency, version_label, monthly_price_minor, annual_price_minor, "
+                        "included_seats, au_limit, realtime_connection_limit, storage_mb_limit, "
+                        "max_file_mb, lab_credit_minor, rate_limit_per_min, automation_rule_limit, "
+                        "webhook_limit, event_replay_days, overage_allowed, effective_from, created_by) "
+                        "VALUES ('free','krw','krw_v2_test',0,0,3,50000,10,5120,100,500,120,3,0,7,"
+                        "false,now(),'test')"
+                    )
+                )
+                await session.commit()
+            await session.rollback()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_subscriptions_provider_must_match_currency():
+    """양성대조 — provider=f(currency) 불변식(krw→toss·usd→polar)을 DB CHECK가 실제로 강제."""
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = uuid.uuid4()
+            with pytest.raises(IntegrityError, match="org_subscriptions_provider_currency_fn"):
+                await session.execute(
+                    text(
+                        "INSERT INTO org_subscriptions (id, org_id, currency, provider) "
+                        "VALUES (gen_random_uuid(), :oid, 'krw', 'polar')"
+                    ),
+                    {"oid": org_id},
+                )
+                await session.commit()
+            await session.rollback()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_subscriptions_polar_customer_id_now_nullable():
+    """provider-agnostic화 — Toss(원화) 구독은 Polar customer가 없어도 저장 가능해야 한다."""
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = uuid.uuid4()
+            await session.execute(
+                text("INSERT INTO org_subscriptions (id, org_id) VALUES (gen_random_uuid(), :oid)"),
+                {"oid": org_id},
+            )
+            await session.commit()
+            row = (
+                await session.execute(
+                    text("SELECT polar_customer_id FROM org_subscriptions WHERE org_id = :oid"),
+                    {"oid": org_id},
+                )
+            ).first()
+            assert row[0] is None
+            await session.execute(text("DELETE FROM org_subscriptions WHERE org_id = :oid"), {"oid": org_id})
+            await session.commit()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_plan_tier_limits_has_starter_and_business_without_touching_existing_rows():
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            rows = dict(
+                (r[0], (r[1], r[2]))
+                for r in (await session.execute(text("SELECT tier, max_storage_mb, max_file_mb FROM plan_tier_limits"))).all()
+            )
+            assert rows["starter"] == (10 * 1024, 300)
+            assert rows["business"] == (250 * 1024, 1000)
+            # 기존 free/team/pro 행 — 0140 결재값 그대로, A1이 건드리지 않았음을 증명.
+            assert rows["free"] == (5 * 1024, 100)
+            assert rows["team"] == (50 * 1024, 500)
+            assert rows["pro"] == (250 * 1024, 500)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_grandfather_policies_rejects_second_active_policy_same_org():
+    """양성대조 — org당 active grandfather_policy는 1건만(unique partial index)."""
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = uuid.uuid4()
+            offering_id = (
+                await session.execute(
+                    text(
+                        "SELECT id FROM offering_versions WHERE tier='free' AND currency='krw' "
+                        "AND version_label='krw_v1'"
+                    )
+                )
+            ).scalar_one()
+            await session.execute(
+                text(
+                    "INSERT INTO grandfather_policies "
+                    "(org_id, offering_version_id, reason, effective_from, created_by) "
+                    "VALUES (:oid, :ov, 'signup', now(), 'test')"
+                ),
+                {"oid": org_id, "ov": offering_id},
+            )
+            await session.commit()
+            try:
+                with pytest.raises(IntegrityError, match="uq_grandfather_policies_active_org"):
+                    await session.execute(
+                        text(
+                            "INSERT INTO grandfather_policies "
+                            "(org_id, offering_version_id, reason, effective_from, created_by) "
+                            "VALUES (:oid, :ov, 'plan_change', now(), 'test')"
+                        ),
+                        {"oid": org_id, "ov": offering_id},
+                    )
+                    await session.commit()
+                await session.rollback()
+            finally:
+                await session.execute(text("DELETE FROM grandfather_policies WHERE org_id = :oid"), {"oid": org_id})
+                await session.commit()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_pricing_versions_pro_remapped_to_business_no_data_loss():
+    """0147 live seed(team/pro×monthly/yearly×usd/krw 10건)가 A1 후 business로 재라벨링되고
+    provider_price_ref(실 Polar/Toss price id)는 그대로 보존됐는지 — 무손실 전환 증명."""
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            tiers = (
+                await session.execute(text("SELECT DISTINCT tier FROM pricing_versions"))
+            ).scalars().all()
+            assert "pro" not in tiers
+            business_count = (
+                await session.execute(text("SELECT COUNT(*) FROM pricing_versions WHERE tier = 'business'"))
+            ).scalar()
+            # 다른 realdb 테스트(test_e_admin_b1_grandfather_wiring_realdb)가 자기 격리를 위해
+            # 특정 (tier,billing_cycle,currency) 행을 지웠다 다시 채우기도 하므로 정확한 개수
+            # 대신 "0건이 아니다"만 본다 — 이 테스트가 확인할 것은 'pro' 잔존 여부와 재라벨링된
+            # 행의 provider_price_ref 무손실이지, 다른 테스트의 격리 delete까지 막는 게 아니다.
+            assert business_count > 0
+            null_refs = (
+                await session.execute(
+                    text(
+                        "SELECT COUNT(*) FROM pricing_versions WHERE tier = 'business' "
+                        "AND provider_price_ref IS NULL"
+                    )
+                )
+            ).scalar()
+            assert null_refs == 0  # business로 옮겨진 행도 원래 Polar/Toss price id를 유지
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_e_admin_b1_grandfather_wiring_realdb.py
+++ b/backend/tests/test_e_admin_b1_grandfather_wiring_realdb.py
@@ -29,16 +29,20 @@ def anyio_backend():
 
 async def _reset(session):
     # 0147 마이그가 team/pro × monthly/yearly × usd/krw 실 시드를 이미 넣어두므로, 이 테스트가
-    # 쓰는 정확히 같은 계보(team/monthly/usd·pro/monthly/usd·pro/yearly/usd)를 명시적으로
-    # 비워야 테스트가 격리된다(안 그러면 실 시드 행이 effective_from 최신이라 테스트 행을
-    # 이겨버림 — 코드 버그가 아니라 테스트 격리 버그였음, 실증 중 발견해 수정).
+    # 쓰는 정확히 같은 계보(team/monthly/usd·business/monthly/usd·business/yearly/usd)를
+    # 명시적으로 비워야 테스트가 격리된다(안 그러면 실 시드 행이 effective_from 최신이라
+    # 테스트 행을 이겨버림 — 코드 버그가 아니라 테스트 격리 버그였음, 실증 중 발견해 수정).
+    # #2471(A1): pricing_versions.tier CHECK가 'pro'를 더는 허용하지 않아(은퇴, D12) 이
+    # 테스트의 tier 값도 'business'로 옮긴다 — _update_subscription 자체(ee/billing.py)는
+    # 이 스토리에서 안 건드렸으니 여기서 검증하는 건 여전히 "임의 tier 문자열에 대해 grandfather
+    # FK가 맞게 채워지는가"라는 일반 로직이다.
     for sql in [
         f"DELETE FROM org_subscriptions WHERE org_id='{ORG}'",
         f"DELETE FROM organizations WHERE id='{ORG}'",
         f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','B1Org','b1org','free')",
-        "DELETE FROM pricing_versions WHERE polar_price_id LIKE 'test-b1-%'",
+        "DELETE FROM pricing_versions WHERE provider_price_ref LIKE 'test-b1-%'",
         "DELETE FROM pricing_versions WHERE (tier,billing_cycle,currency) IN "
-        "(('team','monthly','usd'),('pro','monthly','usd'),('pro','yearly','usd'))",
+        "(('team','monthly','usd'),('business','monthly','usd'),('business','yearly','usd'))",
     ]:
         await session.execute(text(sql))
     await session.commit()
@@ -60,8 +64,8 @@ async def test_update_subscription_sets_current_pricing_version_id():
             await session.execute(
                 text(
                     "INSERT INTO pricing_versions (id, tier, billing_cycle, currency, price_cents, "
-                    "polar_price_id, effective_from, created_by) VALUES "
-                    "(:id, 'team', 'monthly', 'usd', 4900, 'test-b1-team-monthly', :eff, 'test')"
+                    "provider, provider_price_ref, effective_from, created_by) VALUES "
+                    "(:id, 'team', 'monthly', 'usd', 4900, 'polar', 'test-b1-team-monthly', :eff, 'test')"
                 ),
                 {"id": pv_id, "eff": now - timedelta(days=1)},
             )
@@ -88,8 +92,8 @@ async def test_update_subscription_none_when_no_pricing_version_exists():
         async with Session() as session:
             await _reset(session)
 
-            # pro/yearly에 대해 아무 pricing_version도 시드하지 않음 — FK는 NULL이어야(에러 아님).
-            await _update_subscription(session, ORG, "pro", "yearly", "cus_test2", "sub_test2", "active")
+            # business/yearly에 대해 아무 pricing_version도 시드하지 않음 — FK는 NULL이어야(에러 아님).
+            await _update_subscription(session, ORG, "business", "yearly", "cus_test2", "sub_test2", "active")
 
             row = (
                 await session.execute(select(OrgSubscription).where(OrgSubscription.org_id == ORG))
@@ -115,23 +119,23 @@ async def test_update_subscription_plan_change_refreshes_pricing_version_id():
             await session.execute(
                 text(
                     "INSERT INTO pricing_versions (id, tier, billing_cycle, currency, price_cents, "
-                    "polar_price_id, effective_from, created_by) VALUES "
-                    "(:id, 'team', 'monthly', 'usd', 4900, 'test-b1-team-monthly-2', :eff, 'test')"
+                    "provider, provider_price_ref, effective_from, created_by) VALUES "
+                    "(:id, 'team', 'monthly', 'usd', 4900, 'polar', 'test-b1-team-monthly-2', :eff, 'test')"
                 ),
                 {"id": team_pv, "eff": now - timedelta(days=1)},
             )
             await session.execute(
                 text(
                     "INSERT INTO pricing_versions (id, tier, billing_cycle, currency, price_cents, "
-                    "polar_price_id, effective_from, created_by) VALUES "
-                    "(:id, 'pro', 'monthly', 'usd', 14900, 'test-b1-pro-monthly', :eff, 'test')"
+                    "provider, provider_price_ref, effective_from, created_by) VALUES "
+                    "(:id, 'business', 'monthly', 'usd', 14900, 'polar', 'test-b1-pro-monthly', :eff, 'test')"
                 ),
                 {"id": pro_pv, "eff": now - timedelta(days=1)},
             )
             await session.commit()
 
             await _update_subscription(session, ORG, "team", "monthly", "cus_test3", "sub_test3", "active")
-            await _update_subscription(session, ORG, "pro", "monthly", "cus_test3", "sub_test3", "active")
+            await _update_subscription(session, ORG, "business", "monthly", "cus_test3", "sub_test3", "active")
 
             row = (
                 await session.execute(select(OrgSubscription).where(OrgSubscription.org_id == ORG))

--- a/backend/tests/test_e_org_multi_s5_5_plan_limits.py
+++ b/backend/tests/test_e_org_multi_s5_5_plan_limits.py
@@ -2,7 +2,7 @@
 
 AC1: Plan limit 정책은 EE/SaaS 환경에서만 로드
 AC2: OSS 환경에서는 plan limit 미들웨어가 로드되지 않아 제한 없음
-AC3: Free 플랜 — org 1개, project 1개, member 5명 제한
+AC3: Free 플랜 — org 1개, project 1개, member 3명 제한(#2471 A1: v2.3, 5→3)
 AC4: Team/Pro는 제한 없음
 AC5: 제한 초과 시 402 + upgrade_required=True
 AC6: API 과금 정책 기록 (Team $0.001, Pro $0.0005)
@@ -69,7 +69,7 @@ def test_free_limits_defined():
     from ee.plan_limits import FREE_LIMITS
     assert FREE_LIMITS["max_orgs_owned"] == 1
     assert FREE_LIMITS["max_projects"] == 1
-    assert FREE_LIMITS["max_members"] == 5
+    assert FREE_LIMITS["max_members"] == 3  # #2471(A1): v2.3 정책, 5→3(선생님 確定 04:00Z)
 
 
 def test_free_limits_org_check_exists():


### PR DESCRIPTION
## 요약
정책 v2.3(doc `billing-arch-modular-pg-ledger-v0-1` §2·§4, doc `pricing-policy-v2-3`) 를 코드가 표현할 수 있게 결제 도메인 모델을 재편. PG 호출/웹훅 로직은 손대지 않음(B/C 범위) — 이 PR은 스키마/모델만.

Story: [#2471](entity:story:f5400d18-2c1b-42f1-8a49-335d907a60cb)

## 변경 사항
- **TierEnum**: `free/team/pro` → `free/starter/team/business` (v2.3 D12, `pro` 은퇴). 이 Enum은 어떤 컬럼에도 바인딩 안 된 선언뿐이라 순수 문서화 변경.
- **`offering_versions` 신설** — 어드민이 편집 가능한 **데이터**로 가격·좌석·한도(AU·저장·연결·에이전트·웹훅·규칙·레이트·재생)·팩 단위를 하나의 불변 행에 원자적으로 스냅샷(v2.1 §13.1 판정: pricing_versions+plan_tier_limits로 흩어진 개념을 대체). 버전 자체는 **불변** — 값이 바뀌면 새 행 + 이전 행 `effective_to`로 닫기 = 요금제 히스토리. `krw_v1` 4티어 초기 시드(`pricing-policy-v2-3` Part3 + `pricing-policy-proposal-v1` §7.1 팩 수치 그대로).
- **`grandfather_policies` 신설** — 어떤 org가 어떤 `offering_version`에 묶였는지 + 그 묶임을 다루는 규칙(`auto_migrate_on_new_version`·`grace_period_days`)을 데이터로. 어드민 API/UI 자체는 후속 별 스토리 — 이 PR은 데이터 모델만.
- **`pricing_versions`**: `polar_price_id`(NOT NULL) → `provider_price_ref`(nullable) + `provider`(toss/polar, NOT NULL) + `provider = f(currency)` CHECK(원화→toss·달러→polar, DB가 직접 강제). `tier` CHECK에서 `pro` 은퇴 → `starter/team/business/overage`.
- **`org_subscriptions`**: `polar_customer_id` nullable화(Toss 구독은 Polar customer가 없음) + `currency`/`provider`(동일 `provider=f(currency)` CHECK)/`offering_version_id` 컬럼 신설.
- **`plan_tier_limits`**: `starter`(10GB/300MB)·`business`(250GB/1000MB) 행 추가(additive, ON CONFLICT DO NOTHING). 기존 `free/team/pro` 행은 **무변경**.
- **`ee/plan_limits.py`**: `FREE_LIMITS.max_members` 5→3.

## ⚠️ 동작이 달라지는 지점(리뷰 포인트)

1. **`pricing_versions` 실 데이터 재라벨링**: 로컬 fresh-DB로 실제 마이그를 구동해보니 (prod와 달리) 0146→0147 진짜 이력을 타는 환경(CI `alembic-fresh-db` 잡·신규 dev DB)은 0147(live seed)이 team/pro × monthly/yearly × usd/krw **10건**을 이미 심어둔 채로 이 리비전에 도달한다(`#2397`이 문서화한 dual-history 분기 — prod는 0147을 건너뛰어 비어있지만 fresh 체인은 통과). 마이그가 `tier='pro'` 행을 `tier='business'`로 **재라벨링**(가격/Polar price ID 등 나머지 값은 무손실 보존)한다. 실측으로 이 갭을 잡아 마이그에 반영함.
2. **Free 좌석 5→3** (선생님 確定 2026-08-06 04:00Z, 강제·그랜드파더링 없음): 서버가 기존 3명 초과 Free org의 멤버를 **강제로 축소하지 않는다** — `FREE_LIMITS`만 낮춰 **신규 초대만 차단**한다(기존 멤버 유지). 이 코드베이스의 다른 모든 초과-자원 처리(storage: 신규 업로드만 차단·기존 파일 유지)와 동일한 기존 관례 — 데이터 삭제 마이그 불필요. dev DB 실측(3명 초과 org 수)은 이 세션에서 gcloud ADC가 `invalid_rapt`로 막혀 직접 조회하지 못함 — 정책이 count-무관 설계(기존 유지+신규 차단)라 게이팅되지 않았으나, PO/QA가 실측 카운트를 원하면 별도 조회 요청 바람.
3. **`org_subscriptions.tier` CHECK 신설 안 함(의도적 스코프 아웃)**: `billing.py` 웹훅이 여전히 `tier="pro"`를 방출 중이라(실측 확인) 지금 CHECK를 걸면 다음 Polar 웹훅에서 즉시 위반한다. B단계(PolarAdapter 이관)에서 웹훅 코드 리네이밍과 함께 묶어 간다.

## 스코프 아웃(별도 트래킹)
- **USD `offering_versions` 시드 안 함** — v2.3 정책 문서는 KRW 전용(적용 시장 한국)이다. USD 연납/추가좌석 가격은 어디에도 결재된 숫자가 없어 이 PR에서 발명하지 않음. B단계가 기존 하드코딩 Polar 카탈로그(`_PLAN_CATALOG`/`_POLAR_PRICE_IDS`)를 이관하며 채운다.
- **"두 구독 스키마 통합"(AC 원문의 tier1 `org_subscriptions` ↔ tier2 legacy `subscriptions`) 미포함** — grounding 중 tier2(`backend/alembic/baseline/schema.sql`의 `subscriptions`/`plan_tiers`)가 OSS 코드 참조 0건이며 `docs/pk-triage-orm-unmodeled.md` 감사에서 이미 「SaaS overlay(비공개 `@moonklabs/sprintable-saas`) 라이브(subscriptions 206 refs·plan_tiers 61 refs)·drop=선생님 승인 필수」로 기분류돼있음을 발견 — OSS 스토리 권한 밖. Discord로 PO에 에스컬레이트했고(04:03Z 스레드) 아직 명시적 확認 대기 중.

## 검증
로컬 `pgvector/pgvector:pg15` 컨테이너에 baseline→head(0228) 전체 체인을 실제로 구동:
- `alembic upgrade head` 정상 완료(228개 리비전 전체 재생, 0147 live seed 통과 포함)
- `alembic downgrade -1` → `alembic upgrade head` 라운드트립 정상(재적용 시 중복 삽입 없음 — idempotent 가드 확인)
- 4개 양성대조 직접 실행해 제약이 **실제로 위반을 잡는지** 확인:
  - `org_subscriptions_provider_currency_fn` — krw+polar 조합 INSERT → REJECTED
  - `uq_offering_versions_active_tier_currency` — 동일 tier+currency 두 번째 활성 행 INSERT → REJECTED
  - `pricing_versions_provider_currency_fn` — krw+polar 조합 INSERT → REJECTED
  - `uq_grandfather_policies_active_org` — 동일 org 두 번째 활성 정책 INSERT → REJECTED
  - (positive) `polar_customer_id` 없는 org_subscriptions INSERT → SUCCEEDED

pytest: 신규 11건(단위 4 + realdb 7) + 관련 기존 19건(plan_limits·grandfather-wiring) 전부 통과. `pytest --collect-only`(전체 6419건)·`import app.main` 모두 에러 없음.

## Test plan
- [ ] CI green 확인
- [ ] PO가 tier2 SaaS overlay 통합 스코프 아웃에 동의하는지 확認
- [ ] (선택) dev DB에서 Free 3명 초과 org 실측 카운트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)