### PR TITLE
feat(#2472): 결제② A2 — billing_ledger_entries append-only 원장 + 멱등 기입 API + 잔액 파생 뷰

### DIFF
--- a/backend/alembic/versions/0229_billing_ledger_entries.py
+++ b/backend/alembic/versions/0229_billing_ledger_entries.py
@@ -1,0 +1,120 @@
+"""#2472(A2) — billing_ledger_entries: append-only 결제 원장 + 잔액 파생 뷰.
+
+설계문서 billing-arch-modular-pg-ledger-v0-1 §3. PG 웹훅 「수신」·한도 「집행」은 범위 밖
+(A3/B/C) — 이 마이그는 원장 스키마 + 불변성 가드 + 파생 뷰만.
+
+## 불변성 강제 방식
+UPDATE/DELETE를 애플리케이션 관례로만 막지 않는다 — `billing_ledger_entries_block_mutation()`
+트리거 함수가 BEFORE UPDATE OR DELETE에서 예외를 던진다. 이 코드베이스에 선례가 없는 첫
+DB-트리거 불변성 가드라 pytest(양성대조: 실제 UPDATE/DELETE가 거부되는지)로 직접 증명한다
+(app/services/billing_ledger.py의 멱등 기입 헬퍼는 ON CONFLICT DO NOTHING만 쓰고 DO UPDATE는
+쓰지 않는다 — 그 자체가 이 트리거에 걸리기 때문).
+
+## 멱등
+provider_ref UNIQUE(nullable) — 내부전용 엔트리(provider 없음)는 유일성 제약 밖. 웹훅발
+엔트리끼리만 충돌 → 기입 API가 ON CONFLICT DO NOTHING 후 재조회로 기존 행을 반환(no-op).
+
+## 잔액/사용량 파생
+org_ledger_balances 뷰 — direction에 따라 credit(+)/debit(-)로 합산해 (org_id, currency)별
+순잔액을 원장에서 파생한다. 별도 잔액 컬럼을 어디에도 두지 않는다(원장이 정본).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0229"
+down_revision = "0228"
+branch_labels = None
+depends_on = None
+
+_ENTRY_TYPES = ["charge", "refund", "pack_purchase", "credit_grant", "credit_consume", "adjustment"]
+_DIRECTIONS = ["debit", "credit"]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not inspector.has_table("billing_ledger_entries"):
+        op.create_table(
+            "billing_ledger_entries",
+            sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+            sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+            sa.Column("ts", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+            sa.Column("entry_type", sa.Text(), nullable=False),
+            sa.Column("amount_minor", sa.BigInteger(), nullable=False),
+            sa.Column("currency", sa.Text(), nullable=False),
+            sa.Column("direction", sa.Text(), nullable=False),
+            sa.Column("provider", sa.Text(), nullable=True),
+            sa.Column("provider_ref", sa.Text(), nullable=True),
+            sa.Column("subscription_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("org_subscriptions.id"), nullable=True),
+            sa.Column("metadata", postgresql.JSONB(), nullable=True),
+            sa.CheckConstraint(
+                f"entry_type IN ({','.join(repr(t) for t in _ENTRY_TYPES)})",
+                name="billing_ledger_entries_entry_type_check",
+            ),
+            sa.CheckConstraint(
+                f"direction IN ({','.join(repr(d) for d in _DIRECTIONS)})",
+                name="billing_ledger_entries_direction_check",
+            ),
+            sa.CheckConstraint("currency IN ('usd','krw')", name="billing_ledger_entries_currency_check"),
+            sa.CheckConstraint("provider IS NULL OR provider IN ('toss','polar')", name="billing_ledger_entries_provider_check"),
+            sa.CheckConstraint("amount_minor > 0", name="billing_ledger_entries_amount_positive_check"),
+            sa.UniqueConstraint("provider_ref", name="uq_billing_ledger_entries_provider_ref"),
+        )
+        op.create_index("ix_billing_ledger_entries_org_id_ts", "billing_ledger_entries", ["org_id", "ts"])
+        op.create_index("ix_billing_ledger_entries_subscription_id", "billing_ledger_entries", ["subscription_id"])
+
+    # ---------------------------------------------------------------
+    # 불변성 트리거 — UPDATE/DELETE 예외로 거부
+    # ---------------------------------------------------------------
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION billing_ledger_entries_block_mutation()
+        RETURNS trigger AS $$
+        BEGIN
+            RAISE EXCEPTION 'billing_ledger_entries is append-only — % not allowed (id=%)',
+                TG_OP, COALESCE(OLD.id, NULL)
+                USING ERRCODE = 'raise_exception';
+            RETURN NULL;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+    op.execute("DROP TRIGGER IF EXISTS trg_billing_ledger_entries_block_mutation ON billing_ledger_entries")
+    op.execute(
+        """
+        CREATE TRIGGER trg_billing_ledger_entries_block_mutation
+        BEFORE UPDATE OR DELETE ON billing_ledger_entries
+        FOR EACH ROW EXECUTE FUNCTION billing_ledger_entries_block_mutation();
+        """
+    )
+
+    # ---------------------------------------------------------------
+    # 잔액 파생 뷰
+    # ---------------------------------------------------------------
+    op.execute("DROP VIEW IF EXISTS org_ledger_balances")
+    op.execute(
+        """
+        CREATE VIEW org_ledger_balances AS
+        SELECT
+            org_id,
+            currency,
+            SUM(CASE WHEN direction = 'credit' THEN amount_minor ELSE -amount_minor END) AS balance_minor,
+            COUNT(*) AS entry_count,
+            MAX(ts) AS last_entry_at
+        FROM billing_ledger_entries
+        GROUP BY org_id, currency;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS org_ledger_balances")
+    op.execute("DROP TRIGGER IF EXISTS trg_billing_ledger_entries_block_mutation ON billing_ledger_entries")
+    op.execute("DROP FUNCTION IF EXISTS billing_ledger_entries_block_mutation()")
+    op.drop_index("ix_billing_ledger_entries_subscription_id", table_name="billing_ledger_entries")
+    op.drop_index("ix_billing_ledger_entries_org_id_ts", table_name="billing_ledger_entries")
+    op.drop_table("billing_ledger_entries")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -30,6 +30,7 @@ from app.models.org_subscription import OrgSubscription
 from app.models.pricing_version import PricingVersion
 from app.models.offering_version import OfferingVersion
 from app.models.grandfather_policy import GrandfatherPolicy
+from app.models.billing_ledger_entry import BillingLedgerEntry
 from app.models.plan_tier_limit import PlanTierLimit
 from app.models.policy_document import PolicyDocument
 from app.models.audit import AuditLog
@@ -142,6 +143,7 @@ __all__ = [
     "PricingVersion",
     "OfferingVersion",
     "GrandfatherPolicy",
+    "BillingLedgerEntry",
     "PlanTierLimit",
     "PolicyDocument",
     "AuditLog",

--- a/backend/app/models/billing_ledger_entry.py
+++ b/backend/app/models/billing_ledger_entry.py
@@ -1,0 +1,45 @@
+"""append-only 결제 원장(#2472 A2, 설계문서 billing-arch-modular-pg-ledger-v0-1 §3).
+
+모든 돈/크레딧 이동의 «정본». PG-무관 — provider/provider_ref는 멱등 식별용이지 이 테이블의
+존재 이유가 아니다. 잔액/사용량은 이 테이블에서 파생(뷰 org_ledger_balances) — 별도 잔액
+컬럼을 어디에도 두지 않는다.
+
+불변성은 DB 트리거(billing_ledger_entries_block_mutation, 0229 마이그)가 강제한다 — UPDATE/
+DELETE 시도는 예외로 거부된다. 정정이 필요하면 반대 방향 entry(refund/adjustment)를 새로
+추가한다."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class BillingLedgerEntry(Base):
+    __tablename__ = "billing_ledger_entries"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    ts: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    entry_type: Mapped[str] = mapped_column(Text, nullable=False)
+    amount_minor: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    currency: Mapped[str] = mapped_column(Text, nullable=False)
+    direction: Mapped[str] = mapped_column(Text, nullable=False)
+    # PG-무관 원칙 — 내부전용 이동(예: 어드민 goodwill credit_grant)은 provider가 없을 수
+    # 있다. nullable.
+    provider: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # 웹훅/중복 요청 멱등키. UNIQUE(nullable) — Postgres는 NULL을 서로 다른 값으로 취급하니
+    # provider_ref 없는(내부전용) 엔트리는 유일성 제약 밖이고, 있는 엔트리끼리만 충돌한다.
+    provider_ref: Mapped[str | None] = mapped_column(Text, unique=True, nullable=True)
+    subscription_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("org_subscriptions.id"), nullable=True
+    )
+    # DB 컬럼명은 AC 원문대로 "metadata" — Python 속성명만 entry_metadata(Base.metadata와
+    # 충돌 방지, SQLAlchemy 예약명).
+    entry_metadata: Mapped[dict | None] = mapped_column("metadata", JSONB, nullable=True)

--- a/backend/app/services/billing_ledger.py
+++ b/backend/app/services/billing_ledger.py
@@ -1,0 +1,90 @@
+"""결제 원장 기입 API(#2472 A2). billing_ledger_entries는 append-only — 이 모듈이 유일한
+쓰기 경로가 되어야 한다(직접 INSERT/UPDATE 산발 금지).
+
+멱등: provider_ref가 있는 호출은 UNIQUE 충돌 시 새로 쓰지 않고 기존 엔트리를 반환한다(no-op).
+반드시 ON CONFLICT DO NOTHING만 쓴다 — DO UPDATE는 트리거(billing_ledger_entries_block_
+mutation, 0229)가 거부한다(append-only 위반이므로 의도된 실패).
+
+⛔이 모듈은 PG 웹훅을 «수신»하지 않는다 — 호출자가 이미 검증된 이벤트를 record_ledger_entry로
+넘길 뿐이다(웹훅 수신 배선은 B/C 범위). ⛔pack_purchase entry_type을 자동 생성하는 호출부는
+이 스토리 기준 어디에도 없다 — v2.3 「자동 초과청구 없음」 원칙상 향후에도 명시적 구매 확인
+경로에서만 호출되어야 한다(코드 리뷰 감시 대상)."""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.billing_ledger_entry import BillingLedgerEntry
+
+ENTRY_TYPES = frozenset({"charge", "refund", "pack_purchase", "credit_grant", "credit_consume", "adjustment"})
+DIRECTIONS = frozenset({"debit", "credit"})
+
+
+async def record_ledger_entry(
+    session: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    entry_type: str,
+    amount_minor: int,
+    currency: str,
+    direction: str,
+    provider: str | None = None,
+    provider_ref: str | None = None,
+    subscription_id: uuid.UUID | None = None,
+    metadata: dict | None = None,
+) -> BillingLedgerEntry:
+    """원장에 1건 기입. provider_ref가 이미 존재하면(멱등 충돌) 새로 쓰지 않고 기존 행을
+    반환한다 — 호출자는 성공/재시도를 구분할 필요 없이 항상 유효한 엔트리를 받는다."""
+    if entry_type not in ENTRY_TYPES:
+        raise ValueError(f"invalid entry_type: {entry_type!r}")
+    if direction not in DIRECTIONS:
+        raise ValueError(f"invalid direction: {direction!r}")
+    if amount_minor <= 0:
+        raise ValueError(f"amount_minor must be positive: {amount_minor!r}")
+
+    entry_id = uuid.uuid4()
+    stmt = pg_insert(BillingLedgerEntry).values(
+        id=entry_id,
+        org_id=org_id,
+        entry_type=entry_type,
+        amount_minor=amount_minor,
+        currency=currency,
+        direction=direction,
+        provider=provider,
+        provider_ref=provider_ref,
+        subscription_id=subscription_id,
+        entry_metadata=metadata,
+    )
+    if provider_ref is not None:
+        stmt = stmt.on_conflict_do_nothing(index_elements=["provider_ref"])
+    result = await session.execute(stmt)
+    await session.commit()
+
+    if provider_ref is not None and result.rowcount == 0:
+        # 멱등 충돌 — 기존 행을 재조회해 반환(no-op, 조용히 삼키지 않고 명시적으로 알려준다).
+        existing = (
+            await session.execute(
+                select(BillingLedgerEntry).where(BillingLedgerEntry.provider_ref == provider_ref)
+            )
+        ).scalar_one()
+        return existing
+
+    return (
+        await session.execute(select(BillingLedgerEntry).where(BillingLedgerEntry.id == entry_id))
+    ).scalar_one()
+
+
+async def get_org_balance(session: AsyncSession, org_id: uuid.UUID, currency: str) -> int:
+    """org_ledger_balances 뷰에서 순잔액(minor unit) 조회. 엔트리 0건이면 0(적자/흑자 아님)."""
+    from sqlalchemy import text
+
+    row = (
+        await session.execute(
+            text("SELECT balance_minor FROM org_ledger_balances WHERE org_id = :oid AND currency = :cur"),
+            {"oid": str(org_id), "cur": currency},
+        )
+    ).first()
+    return int(row[0]) if row else 0

--- a/backend/tests/test_e_2472_a2_billing_ledger_realdb.py
+++ b/backend/tests/test_e_2472_a2_billing_ledger_realdb.py
@@ -1,0 +1,176 @@
+"""#2472(A2) real-DB — billing_ledger_entries 불변성·멱등·파생 잔액이 실제로 도는지 증명.
+
+DB env(ALEMBIC_DATABASE_URL) 없으면 skip — CI alembic-fresh-db 잡 env에서 실행/로컬 PG
+(alembic upgrade head 가 이미 적용된 DB를 전제한다)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.services.billing_ledger import get_org_balance, record_ledger_entry
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# 정리(cleanup) 없음 — append-only 테이블이라 DELETE 자체가 거부된다(그게 이 스토리가
+# 증명하려는 것). org_id를 매 테스트 uuid4()로 무작위 생성해 교차 오염 없이 흘려보낸다.
+
+
+@pytest.mark.anyio
+async def test_record_entry_and_balance_derivation():
+    """양성대조 — 기입 N건 → 파생 잔액 정확성(AC 명시 요구)."""
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    org_id = uuid.uuid4()
+    try:
+        async with Session() as session:
+            await record_ledger_entry(
+                session, org_id=org_id, entry_type="charge", amount_minor=59_000,
+                currency="krw", direction="credit", provider="toss", provider_ref=f"ref-{uuid.uuid4()}",
+            )
+            await record_ledger_entry(
+                session, org_id=org_id, entry_type="refund", amount_minor=10_000,
+                currency="krw", direction="debit", provider="toss", provider_ref=f"ref-{uuid.uuid4()}",
+            )
+            await record_ledger_entry(
+                session, org_id=org_id, entry_type="credit_grant", amount_minor=5_000,
+                currency="krw", direction="credit",  # provider 없음 — 내부전용 엔트리
+            )
+            balance = await get_org_balance(session, org_id, "krw")
+            assert balance == 59_000 - 10_000 + 5_000  # = 54,000
+
+            row = (
+                await session.execute(
+                    text(
+                        "SELECT entry_count FROM org_ledger_balances WHERE org_id = :oid AND currency = 'krw'"
+                    ),
+                    {"oid": org_id},
+                )
+            ).scalar_one()
+            assert row == 3
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_record_entry_idempotent_on_provider_ref_conflict():
+    """양성대조 — 같은 provider_ref 재기입은 새 행을 만들지 않고 기존 엔트리를 반환(no-op)."""
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    org_id = uuid.uuid4()
+    ref = f"webhook-{uuid.uuid4()}"
+    try:
+        async with Session() as session:
+            first = await record_ledger_entry(
+                session, org_id=org_id, entry_type="charge", amount_minor=1_000,
+                currency="krw", direction="credit", provider="toss", provider_ref=ref,
+            )
+            second = await record_ledger_entry(
+                session, org_id=org_id, entry_type="charge", amount_minor=1_000,
+                currency="krw", direction="credit", provider="toss", provider_ref=ref,
+            )
+            assert first.id == second.id  # 새 행 아님 — 기존 엔트리 반환
+
+            count = (
+                await session.execute(
+                    text("SELECT COUNT(*) FROM billing_ledger_entries WHERE provider_ref = :ref"),
+                    {"ref": ref},
+                )
+            ).scalar()
+            assert count == 1  # 재시도해도 1건만
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_append_only_rejects_update():
+    """양성대조 — 0229 트리거가 실제 UPDATE를 거부하는가."""
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    org_id = uuid.uuid4()
+    try:
+        async with Session() as session:
+            entry = await record_ledger_entry(
+                session, org_id=org_id, entry_type="adjustment", amount_minor=100,
+                currency="krw", direction="credit",
+            )
+            with pytest.raises(DBAPIError, match="append-only"):
+                await session.execute(
+                    text("UPDATE billing_ledger_entries SET amount_minor = 999 WHERE id = :id"),
+                    {"id": entry.id},
+                )
+                await session.commit()
+            await session.rollback()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_append_only_rejects_delete():
+    """양성대조 — 0229 트리거가 실제 DELETE를 거부하는가."""
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    org_id = uuid.uuid4()
+    try:
+        async with Session() as session:
+            entry = await record_ledger_entry(
+                session, org_id=org_id, entry_type="adjustment", amount_minor=100,
+                currency="krw", direction="credit",
+            )
+            with pytest.raises(DBAPIError, match="append-only"):
+                await session.execute(
+                    text("DELETE FROM billing_ledger_entries WHERE id = :id"), {"id": entry.id}
+                )
+                await session.commit()
+            await session.rollback()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_record_entry_rejects_invalid_entry_type_and_negative_amount():
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    org_id = uuid.uuid4()
+    try:
+        async with Session() as session:
+            with pytest.raises(ValueError):
+                await record_ledger_entry(
+                    session, org_id=org_id, entry_type="bogus_type", amount_minor=100,
+                    currency="krw", direction="credit",
+                )
+            with pytest.raises(ValueError):
+                await record_ledger_entry(
+                    session, org_id=org_id, entry_type="charge", amount_minor=0,
+                    currency="krw", direction="credit",
+                )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_entries_org_balance_is_zero():
+    """양성대조(음성 기준선) — 원장에 없는 org는 0(적자/흑자 아님)."""
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            balance = await get_org_balance(session, uuid.uuid4(), "krw")
+            assert balance == 0
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 요약
설계문서 `billing-arch-modular-pg-ledger-v0-1` §3 기준 append-only 결제 원장. PG 웹훅 「수신」·한도 「집행」은 범위 밖(A3/B/C) — 원장 스키마 + 불변성 가드 + 기입 API + 파생 뷰만.

Story: [#2472](entity:story:70baba66-4aa3-4c0c-b2c3-d500f351dc4e) (A1 [#2471](entity:story:f5400d18-2c1b-42f1-8a49-335d907a60cb) 위에 얹음, base=develop은 A1 머지 후 최신 상태)

## 변경 사항
- **`billing_ledger_entries`**: `id·org_id·ts·entry_type·amount_minor·currency·direction·provider·provider_ref·subscription_id·metadata`(AC 원문 그대로). `entry_type`(charge/refund/pack_purchase/credit_grant/credit_consume/adjustment)·`direction`(debit/credit)·`currency`(usd/krw)·`provider`(NULL 또는 toss/polar) CHECK + `amount_minor > 0` CHECK.
- **불변성**: `BEFORE UPDATE OR DELETE` 트리거(`billing_ledger_entries_block_mutation`)가 예외로 거부. 이 코드베이스에 선례가 없는 첫 DB-트리거 불변성 가드라 — 관례가 아니라 구조로 막음.
- **멱등**: `provider_ref UNIQUE`(nullable — 내부전용 엔트리는 유일성 제약 밖). `app/services/billing_ledger.py`의 `record_ledger_entry()`가 `ON CONFLICT DO NOTHING` 후 재조회로 기존 엔트리를 반환한다(`DO UPDATE`는 애초에 못 씀 — 위 트리거가 막으므로).
- **`org_ledger_balances` 뷰**: `direction` 기준 credit(+)/debit(-) 합산으로 `(org_id, currency)`별 순잔액을 원장에서 파생. 별도 잔액 컬럼 없음 — 원장이 정본.

## 검증
로컬 `pgvector/pgvector:pg15`로 baseline→0229 전체 체인 실구동:
- `alembic upgrade head` 정상(0228→0229 포함)
- `downgrade -1` → `upgrade head` 라운드트립 정상
- 양성대조 직접 실행:
  - `UPDATE billing_ledger_entries ...` → **REJECTED**("append-only — UPDATE not allowed")
  - `DELETE FROM billing_ledger_entries ...` → **REJECTED**("append-only — DELETE not allowed")
  - 동일 `provider_ref` 중복 INSERT → **REJECTED**(unique violation, raw SQL 기준)
  - `record_ledger_entry()` 동일 `provider_ref` 재호출 → 새 행 생성 안 하고 기존 엔트리 반환(앱 계층 멱등 확인)
  - 기입 3건(charge 59,000 credit·refund 10,000 debit·credit_grant 5,000 credit) → `org_ledger_balances` 파생 잔액 54,000 정확히 일치

pytest 6건 전부 통과(균형 파생·멱등·UPDATE 거부·DELETE 거부·유효성 검증·0건 기준선). `pytest --collect-only`(전체 6425건)·`import app.main` 에러 없음.

## 스코프 아웃
- **`pack_purchase` entry_type 자동 생성 producer 없음** — v2.3 「자동 초과청구 없음」 원칙상 명시적 구매 확인 경로에서만 호출돼야 하지만, A2 기준 이 entry_type을 호출하는 코드가 어디에도 없어 기계적으로 테스트할 대상 자체가 없다. B/C/D 코드 리뷰 시 감시 대상으로 남겨둠.
- PG 웹훅 수신 배선(B/C) — 이 PR의 `record_ledger_entry()`는 이미 검증된 이벤트를 받아 기입만 한다.

## Test plan
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)