### PR TITLE
[SID:2480] --muted-foreground 라이트 대비 AA 미달 — 토큰 시스템 fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -751,6 +751,13 @@ jobs:
       - name: "Verify tint background × foreground contrast (story #2420 regression guard)"
         run: pnpm --filter web verify:tint-foreground-contrast
 
+      # story #2480(유나 규격) 회귀가드: `--muted-foreground`는 bg-muted·background·card
+      # 위에서 전부 쓰인다(테이블 헤더·플레이스홀더·칩·보조텍스트 도처). 라이트 bg-muted 위
+      # 실측 4.39:1로 AA 미달이 발견돼(#2866 가디언 리뷰 중) 토큰을 L 0.552→0.52로 조정했다.
+      # 이 스텝이 재도입(값이 다시 4.39 쪽으로 밀림)을 정의 시점에 잡는다.
+      - name: "Verify muted-foreground contrast (story #2480 regression guard)"
+        run: pnpm --filter web verify:muted-foreground-contrast
+
       # story #2420 AC7 회귀가드: AC3(위)는 globals.css 정의만 본다 — 사용처(컴포넌트 파일)는
       # 전혀 안 읽는다. 실제로 사용처 하나(goals-client.tsx:615)를 계열색으로 되돌려도 AC3·
       # type-check·lint·해당 vitest 전부 그대로 초록이었다(실측, 디디). 이 스텝은 같은

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "verify:reserved-first-segments-sync": "tsx scripts/verify-reserved-first-segments-sync.ts",
     "verify:tint-foreground-contrast": "tsx scripts/verify-tint-foreground-contrast.ts",
     "verify:no-new-tint-color-text": "tsx scripts/verify-no-new-tint-color-text.ts",
+    "verify:muted-foreground-contrast": "tsx scripts/verify-muted-foreground-contrast.ts",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
     "e2e:report": "playwright show-report"

--- a/apps/web/scripts/verify-muted-foreground-contrast.test.ts
+++ b/apps/web/scripts/verify-muted-foreground-contrast.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { computeMutedForegroundContrasts } from './verify-muted-foreground-contrast';
+
+const GLOBALS_CSS_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src/app/globals.css');
+
+// story #2480 AC6과 같은 규율(#2420) — 양성대조: 이 검사가 «실패할 수 있어야» 한다.
+describe('computeMutedForegroundContrasts — 양성대조: 미달 정의는 빨간불이어야 한다', () => {
+  it('구 값(L 0.552, #2866이 발견한 실 미달치)은 bg-muted 위에서 FAIL로 잡힌다', () => {
+    const oldCss = `
+:root {
+  --background: oklch(1 0 0);
+  --card: oklch(1 0 0);
+  --muted: oklch(0.967 0.001 286.375);
+  --muted-foreground: oklch(0.552 0.016 285.938);
+}
+.dark {
+  --background: oklch(0.18 0.005 285.823);
+  --card: oklch(0.21 0.006 285.885);
+  --muted: oklch(0.274 0.006 286.033);
+  --muted-foreground: oklch(0.705 0.015 286.067);
+}
+`;
+    const results = computeMutedForegroundContrasts(oldCss);
+    const lightOnMuted = results.find((r) => r.theme === 'light' && r.bgVar === 'muted')!;
+    expect(lightOnMuted.ratio).toBeLessThan(4.5);
+  });
+
+  it('신 값(L 0.52, story #2480 fix)은 전 조합에서 통과한다', () => {
+    const fixedCss = `
+:root {
+  --background: oklch(1 0 0);
+  --card: oklch(1 0 0);
+  --muted: oklch(0.967 0.001 286.375);
+  --muted-foreground: oklch(0.52 0.016 285.938);
+}
+.dark {
+  --background: oklch(0.18 0.005 285.823);
+  --card: oklch(0.21 0.006 285.885);
+  --muted: oklch(0.274 0.006 286.033);
+  --muted-foreground: oklch(0.705 0.015 286.067);
+}
+`;
+    const results = computeMutedForegroundContrasts(fixedCss);
+    for (const r of results) {
+      expect(r.ratio, `${r.theme}/--${r.bgVar}`).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+});
+
+describe('real repo globals.css — story #2480: muted-foreground가 muted/background/card 전 조합에서 AA(4.5)를 통과한다', () => {
+  const css = readFileSync(GLOBALS_CSS_PATH, 'utf-8');
+  const results = computeMutedForegroundContrasts(css);
+
+  it('checks all 6 combinations (3 backgrounds × 2 themes)', () => {
+    expect(results).toHaveLength(6);
+  });
+
+  it('every background × theme combination passes 4.5 with muted-foreground', () => {
+    for (const r of results) {
+      expect(r.ratio, `${r.theme}/--${r.bgVar}`).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
+  it('light on bg-muted lands at ~5.02 (story #2480 실측치 — 회귀 시 이 값이 4.39 쪽으로 움직인다)', () => {
+    const lightOnMuted = results.find((r) => r.theme === 'light' && r.bgVar === 'muted')!;
+    expect(lightOnMuted.ratio).toBeCloseTo(5.02, 1);
+  });
+});

--- a/apps/web/scripts/verify-muted-foreground-contrast.ts
+++ b/apps/web/scripts/verify-muted-foreground-contrast.ts
@@ -1,0 +1,80 @@
+/**
+ * story #2480(유나 규격) 회귀가드 — `--muted-foreground`는 `--muted`·`--background`·`--card`
+ * 위에서 전부 쓰인다(테이블 헤더·플레이스홀더·칩·보조텍스트 도처). 라이트 테마 실측(2026-08-06)
+ * 에서 `--muted-foreground` on `--muted` = 4.39:1로 AA(4.5) 미달이 발견됐다(#2866 가디언 리뷰
+ * 중 유나 발견). 개별 컴포넌트가 아니라 토큰 자체를 L 0.552→0.52로 조정해 시스템 fix했다.
+ *
+ * 이 스크립트는 `--muted-foreground` × {`--muted`, `--background`, `--card`} × {light, dark}
+ * 6쌍을 globals.css 정의 시점에 재계산해 다시 4.5 밑으로 떨어지면 CI에서 잡는다 — #2420
+ * AC3(tint-foreground-contrast)와 같은 검증된 oklch→sRGB 변환을 재사용한다(브라우저 불요).
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseOklchToRgba, compositeOver } from '../src/lib/oklch-contrast';
+import { contrastRatio } from '../src/lib/color-contrast';
+import { extractCssVarBlock } from './verify-tint-foreground-contrast';
+
+const GLOBALS_CSS_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src/app/globals.css');
+const AA_THRESHOLD = 4.5;
+const BG_VARS = ['muted', 'background', 'card'] as const;
+
+export interface MutedForegroundContrastResult {
+  theme: 'light' | 'dark';
+  bgVar: (typeof BG_VARS)[number];
+  ratio: number;
+}
+
+export function computeMutedForegroundContrasts(css: string): MutedForegroundContrastResult[] {
+  const results: MutedForegroundContrastResult[] = [];
+  for (const [theme, selector] of [['light', ':root'], ['dark', '.dark']] as const) {
+    const { vars } = extractCssVarBlock(css, selector);
+    const pageBgRaw = vars.get('background');
+    if (!pageBgRaw) throw new Error(`--background not defined in ${selector}`);
+    const pageBg = parseOklchToRgba(pageBgRaw);
+    if (!pageBg) throw new Error(`--background = "${pageBgRaw}" in ${selector} is not a plain oklch() value`);
+    const pageBgRgb: [number, number, number] = [pageBg.r, pageBg.g, pageBg.b];
+
+    const fgRaw = vars.get('muted-foreground');
+    if (!fgRaw) throw new Error(`--muted-foreground not defined in ${selector}`);
+    const fg = parseOklchToRgba(fgRaw);
+    if (!fg) throw new Error(`--muted-foreground = "${fgRaw}" in ${selector} is not a plain oklch() value`);
+    const fgOnPage = compositeOver(fg, pageBgRgb);
+
+    for (const bgVar of BG_VARS) {
+      const bgRaw = vars.get(bgVar);
+      if (!bgRaw) throw new Error(`--${bgVar} not defined in ${selector}`);
+      const bg = parseOklchToRgba(bgRaw);
+      if (!bg) throw new Error(`--${bgVar} = "${bgRaw}" in ${selector} is not a plain oklch() value`);
+      const bgOnPage = compositeOver(bg, pageBgRgb);
+      const ratio = contrastRatio(fgOnPage, bgOnPage);
+      results.push({ theme, bgVar, ratio });
+    }
+  }
+  return results;
+}
+
+function main(): number {
+  const css = readFileSync(GLOBALS_CSS_PATH, 'utf-8');
+  const results = computeMutedForegroundContrasts(css);
+
+  console.log(`[story #2480] --muted-foreground × {${BG_VARS.join('·')}} × 테마 2 = ${results.length}쌍`);
+
+  let failed = 0;
+  for (const r of results) {
+    const status = r.ratio >= AA_THRESHOLD ? 'OK' : 'FAIL';
+    if (status === 'FAIL') failed += 1;
+    console.log(`  ${status === 'OK' ? '✅' : '❌'} ${r.theme}/--${r.bgVar}: muted-foreground on = ${r.ratio.toFixed(2)}`);
+  }
+
+  if (failed > 0) {
+    console.error(`\n❌ FAIL: ${failed}쌍이 AA(${AA_THRESHOLD}) 미달 — muted-foreground 또는 배경 토큰을 다시 본다.`);
+    return 1;
+  }
+  console.log(`\nOK: 전 조합(${results.length}쌍) AA 통과.`);
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main());
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -240,7 +240,9 @@
   --secondary: oklch(0.967 0.001 286.375);
   --secondary-foreground: oklch(0.21 0.006 285.885);
   --muted: oklch(0.967 0.001 286.375);
-  --muted-foreground: oklch(0.552 0.016 285.938);
+  /* story #2480(유나 규격): bg-muted 위 작은 글자 AA 미달(4.39:1) 실측 — L만 0.552→0.52
+     하향(chroma/hue 불변)해 bg-muted 5.02:1·background/card 5.53:1(상향, 회귀 없음). */
+  --muted-foreground: oklch(0.52 0.016 285.938);
   --accent: oklch(0.967 0.001 286.375);
   --accent-foreground: oklch(0.21 0.006 285.885);
   --destructive: oklch(0.577 0.245 27.325);


### PR DESCRIPTION
## 요약
- 발견 경로: 결제 UI D(PR #2866) 가디언 리뷰 중 유나 대비 점검.
- 라이트 `--muted-foreground`(oklch L 0.552) on `--muted` 조합이 4.39:1로 WCAG AA(4.5) 미달.
- `bg-muted` + `text-muted-foreground`는 코드베이스 도처의 표준 조합(테이블 헤더·플레이스홀더·칩·보조텍스트)이라 개별 컴포넌트가 아니라 **토큰 자체**를 고치는 시스템 fix(유나 규격, PO 지시로 별건 분리).

## 변경
`apps/web/src/app/globals.css` `:root` — `--muted-foreground` L만 조정(chroma/hue 불변):
```
oklch(0.552 0.016 285.938) → oklch(0.52 0.016 285.938)
```
- bg-muted 위: 4.39 → **5.01**(AA 통과)
- background/card 위: 4.83 → **5.51**(상향 — 회귀 없음, 안전 방향)
- `.dark` 블록은 무변경(다크는 이미 통과 — 5.68~7.19)

## 회귀가드 신설
`#2420`(tint-foreground-contrast)과 동일한 검증된 oklch→sRGB 변환(`src/lib/oklch-contrast.ts`)을 재사용해 `verify-muted-foreground-contrast` 스크립트를 신설하고 CI에 배선했음 — `--muted-foreground` × {muted/background/card} × 양테마 6쌍을 globals.css **정의 시점**에 검사, 재발(값이 다시 4.39 쪽으로 밀리면) CI에서 잡힘.

## 게이트
- 신규 vitest 5/5 — 양성대조(구 값 0.552는 bg-muted 위에서 RED로 잡히는 것 확認·신 값 0.52는 6쌍 전부 PASS·실 globals.css 값이 정확히 ~5.02 근방인지 pin)
- 뮤테이션 셀프체크 — 토큰을 구 값으로 되돌려 신규 가드 스크립트가 실제로 FAIL(exit 1)하는 것 확認 → 복원 PASS
- tsc/eslint 클린
- 기존 `verify:tint-foreground-contrast` 10/10 무영향(별개 계열 검사)
- `pnpm build` exit 0

## 스코프 밖
- `--chart-2`가 우연히 같은 구 oklch 수치(0.552 0.016 285.938)를 갖고 있으나 `--muted-foreground`와 무관한 별개 토큰이라 손대지 않음.
- `.dark` 블록, 그 외 파일 무변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)