### PR TITLE
fix(#2481): webhook E2E 테스트 거짓-green — is_ee_enabled import-timing 404 이스케이프 제거

### DIFF
--- a/backend/tests/test_e_2478_b_payment_adapter.py
+++ b/backend/tests/test_e_2478_b_payment_adapter.py
@@ -128,13 +128,42 @@ async def test_polar_adapter_create_checkout_error_status_raises_runtime_error()
 
 
 # ─── 엔드투엔드: 실 HTTP 파이프라인이 어댑터까지 관통하는지 ─────────────────
+# #2481(B후속, 카디르 QA 거짓-green 지적): CI「Backend pytest」job env엔 LICENSE_CONSENT가
+# 없다(ci.yml backend-test job) — settings.is_ee_enabled는 app.main import 시점(모듈
+# 스코프 `if settings.is_ee_enabled:`)에 이미 확定돼 billing 라우터가 app.routes에 아예
+# 안 실린다. 그 뒤 아무리 settings를 patch해도 이미 안 실린 라우터는 안 돌아온다 —
+# 원래 테스트는 그래서 항상 404로 새고 "401 실증"이 거짓이었다(HMAC 로직 자체의 정확성은
+# test_verify_signature_* 가 별도로 실증하므로 기능 갭은 없었지만, 이 테스트의 "관통"
+# 주장은 공허했다). 처방: import-time 게이트를 우회해 라우터를 직접 마운트하고 진짜
+# 401을 받는다 — LICENSE_CONSENT env 주입/앱 재기동보다 훨씬 결정적이고 CI job 설정을
+# 안 건드린다.
+
+
+def _ensure_billing_router_mounted(app) -> None:
+    from ee.routers import billing as billing_module
+
+    if not any(getattr(r, "path", "").startswith("/api/v2/billing") for r in app.routes):
+        app.include_router(billing_module.router, prefix="/api/v2/billing")
+
+
+async def _post_webhook_with_signature(app, signature: str | None) -> "httpx.Response":
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        headers = {"X-Polar-Webhook-Signature": signature} if signature is not None else {}
+        return await c.post(
+            "/api/v2/billing/webhook",
+            content=b'{"type":"checkout.completed"}',
+            headers=headers,
+        )
+
 
 @pytest.mark.anyio
 async def test_webhook_endpoint_rejects_invalid_signature_through_adapter():
-    """POST /api/v2/billing/webhook — 잘못된 서명이면 401. 라우터→factory→PolarAdapter.
-    verify_webhook 전체 파이프라인이 실제로 관통해야 실패(mock 아님)."""
+    """POST /api/v2/billing/webhook — 잘못된 서명이면 실제로 401. 라우터→factory→
+    PolarAdapter.verify_webhook 전체 파이프라인이 관통한다(mock 아님) — 404 이스케이프
+    없음(#2481)."""
     from app.main import app
-    from httpx import ASGITransport, AsyncClient
 
     from tests.conftest import override_db_and_read
 
@@ -144,21 +173,50 @@ async def test_webhook_endpoint_rejects_invalid_signature_through_adapter():
         yield mock_session
 
     override_db_and_read(app, override_db)
+    _ensure_billing_router_mounted(app)
 
-    from app.core.config import Settings
     try:
-        with patch.object(type(Settings()), "is_ee_enabled", new_callable=MagicMock, create=True):
-            with patch("app.services.payment.polar_adapter.settings") as mock_settings:
-                mock_settings.polar_webhook_secret = "real_secret"
-                mock_settings.is_ee_enabled = True
-                with patch("ee.routers.billing.settings") as mock_router_settings:
-                    mock_router_settings.is_ee_enabled = True
-                    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                        resp = await c.post(
-                            "/api/v2/billing/webhook",
-                            content=b'{"type":"checkout.completed"}',
-                            headers={"X-Polar-Webhook-Signature": "sha256=wrongsignature"},
-                        )
-        assert resp.status_code in (401, 404)  # 404면 EE 라우터 미등록(무관), 401이 목표 증명
+        with patch("app.services.payment.polar_adapter.settings") as mock_settings:
+            mock_settings.polar_webhook_secret = "real_secret"
+            with patch("ee.routers.billing.settings") as mock_router_settings:
+                mock_router_settings.is_ee_enabled = True
+                resp = await _post_webhook_with_signature(app, "sha256=wrongsignature")
+        assert resp.status_code == 401
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_webhook_endpoint_accepts_valid_signature_positive_control():
+    """양성대조 — HMAC 검증을 실제로 깨면(서명 미검증) 위 테스트가 RED 나야 한다는 것을
+    증명하기 위해, 반대로 «올바른» 서명은 401 없이 통과해야 한다(#2481 AC). 이 테스트가
+    통과 + 위 테스트가 wrong-signature로 401 → 둘 다 서야 "서명 검증이 실제로 갈린다"가
+    증명된다(둘 다 같은 응답이면 그게 바로 거짓-green)."""
+    import hashlib
+    import hmac
+
+    from app.main import app
+
+    from tests.conftest import override_db_and_read
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    override_db_and_read(app, override_db)
+    _ensure_billing_router_mounted(app)
+
+    secret = "real_secret"
+    body = b'{"type":"checkout.completed"}'
+    valid_sig = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+    try:
+        with patch("app.services.payment.polar_adapter.settings") as mock_settings:
+            mock_settings.polar_webhook_secret = secret
+            with patch("ee.routers.billing.settings") as mock_router_settings:
+                mock_router_settings.is_ee_enabled = True
+                resp = await _post_webhook_with_signature(app, valid_sig)
+        assert resp.status_code != 401  # 서명 검증은 통과 — 이후 JSON payload 처리로 진행
     finally:
         app.dependency_overrides.clear()


### PR DESCRIPTION
## 요약
카디르 QA([#2867](https://github.com/moonklabs/sprintable/pull/2867) B)가 발견한 거짓-green을 정리한다.

Story: [#2481](entity:story:e3256364-cefa-4f47-8e98-f4d757bb826b)

`test_webhook_endpoint_rejects_invalid_signature_through_adapter`가 "실 HTTP 파이프라인 관통(mock 아님)"이라고 주장했지만, 실제론 목표인 401이 아니라 404 이스케이프로 통과하고 있었다.

## 근본 원인
`settings.is_ee_enabled`는 `app/main.py` **import 시점**(모듈 스코프 `if settings.is_ee_enabled: app.include_router(billing.router, ...)`)에 라우터 등록 여부를 이미 확定한다. CI의 「Backend pytest」job env(`ci.yml` backend-test)엔 `LICENSE_CONSENT`가 없어 이 시점에 항상 `False` → billing 라우터가 `app.routes`에 아예 안 실린다. 그 뒤 테스트 안에서 아무리 `settings`를 patch해도 **이미 안 실린 라우터는 안 돌아온다** — patch는 request-time 값만 바꿀 뿐 import-time 결정을 되돌리지 못한다. 원래 테스트는 그래서 항상 404로 새고, `in (401, 404)` assert가 그 실패를 숨겼다.

⚠️HMAC 서명검증 로직 자체는 `test_verify_signature_correct/wrong/no_secret_skips`(단위 테스트)가 이미 정확히 실증하고 있어 **기능 갭은 0**이었다 — 문제는 이 특정 E2E 테스트의 "관통" 주장이 공허했다는 것.

## 처방 (AC 택일 (a) — 진짜 401을 타게)
LICENSE_CONSENT env 주입이나 앱 프로세스 재기동 대신, import-time 게이트를 우회해 **라우터를 테스트에서 직접 마운트**한다(`_ensure_billing_router_mounted`). 라우터 자체의 endpoint 로직(`_require_ee` 의존성·서명검증)은 request-time에 다시 확認하므로, 마운트만으로 실제 401 경로가 정확히 재현된다 — CI job 설정을 안 건드리고 결정적이다.

- `assert resp.status_code in (401, 404)` → `assert resp.status_code == 401`로 이스케이프 제거.
- **양성대조 신설**(`test_webhook_endpoint_accepts_valid_signature_positive_control`): 올바른 서명은 401 없이 통과, 잘못된 서명은 401로 거부 — 둘이 실제로 갈려야 "서명 검증이 도는" 증명이 선다(AC 명시 요구).

## 뮤테이션 셀프체크 (AC 명시 요구 — 직접 확인함)
`PolarAdapter.verify_webhook`을 `return True`(항상 통과)로 강제 깨고 재실행 → `test_webhook_endpoint_rejects_invalid_signature_through_adapter`가 **실제로 RED**(200 vs 기대 401)로 떨어지는 것을 확인했다. 파일 복원 후 GREEN 재확인.

## 검증
로컬에서 billing 관련 4개 파일(`test_e_2478_b_payment_adapter`·`test_e_org_multi_s5_1/3/4`) 49개를 **같은 pytest 세션**으로 함께 실행 — 라우터를 테스트 중 마운트하는 부수효과가 다른 테스트(특히 `test_billing_status_403_when_ee_disabled`의 404/403 양쪽 허용 분기)와 충돌하지 않음을 확인. `LICENSE_CONSENT` env를 명시적으로 unset한 채 실행해 CI의 정확한 조건을 재현했다.

guard lint(`scripts/lint_dependency_override_get_read_db.py`)·`pytest --collect-only`(전체 6439건)·`import app.main` 전부 클린.

## Test plan
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)