### PR TITLE
[SID:2484] error.code raw 영문 노출 하드닝 Phase 1 (최초경험 경로)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -758,6 +758,15 @@ jobs:
       - name: "Verify muted-foreground contrast (story #2480 regression guard)"
         run: pnpm --filter web verify:muted-foreground-contrast
 
+      # story #2484 advisory 넛지(⛔blocker 아님·PO 確定) — FE가 error.code를 안 갈라
+      # 서버 raw message/json.detail을 그대로 노출하는 병이 #2441·#2470·create-org로
+      # 3번 반복됐다. 이 스텝은 그 병의 단순형(주변에 .code 분기가 없는 경우)만 잡아
+      # 로그로 알린다. baseline(raw-error-message-baseline.json) 밖의 새 자리가 있어도
+      # 이 스텝 자체는 항상 성공한다(스크립트가 always exit 0) — 리뷰어가 로그를 보고
+      # 판단하는 넛지이지 머지 게이트가 아니다.
+      - name: "Verify no new raw error.message exposure (story #2484 advisory nudge)"
+        run: pnpm --filter web verify:no-raw-error-message
+
       # story #2420 AC7 회귀가드: AC3(위)는 globals.css 정의만 본다 — 사용처(컴포넌트 파일)는
       # 전혀 안 읽는다. 실제로 사용처 하나(goals-client.tsx:615)를 계열색으로 되돌려도 AC3·
       # type-check·lint·해당 vitest 전부 그대로 초록이었다(실측, 디디). 이 스텝은 같은

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -112,6 +112,7 @@
     "createOrgSlugLabel": "Slug",
     "createOrgSlugPlaceholder": "my-company",
     "createOrgSlugError": "Only lowercase letters, numbers, and hyphens are allowed (must start/end with a letter or number)",
+    "createOrgSlugTaken": "This slug is already taken.",
     "createOrgGenericError": "Couldn't create the organization. Please try again in a moment."
   },
   "storage": {
@@ -723,7 +724,15 @@
     "csrfMismatch": "Security check failed. Please try again.",
     "oauthNoToken": "Authentication token not received. Please try again.",
     "invalidProvider": "Invalid OAuth provider.",
-    "oauthNativeIssueFailed": "Failed to hand off your login to the app. Please try again."
+    "oauthNativeIssueFailed": "Failed to hand off your login to the app. Please try again.",
+    "loginInvalidCredentials": "Incorrect email or password.",
+    "loginAccountLocked": "Too many attempts. Please try again in a moment.",
+    "loginTotpLocked": "Too many failed attempts. Please try again in a moment.",
+    "loginInvalidTotpCode": "Invalid authentication code.",
+    "loginTotpReplayed": "This code has already been used. Enter a new one.",
+    "firebaseNetworkError": "Couldn't sign in due to a network error. Please try again.",
+    "firebaseSignInFailed": "Sign-in failed. Please check your email and password.",
+    "firebaseDisabled": "This sign-in method isn't available right now."
   },
   "register": {
     "subtitle": "Create your account",
@@ -742,6 +751,8 @@
     "continueWithGoogle": "Continue with Google",
     "tosRequiredError": "Please agree to the Terms of Service and Privacy Policy first.",
     "registrationFailed": "Registration failed. Please try again.",
+    "registerEmailTaken": "This email is already registered.",
+    "registerTosRequired": "You must accept the Terms of Service.",
     "alreadyHaveAccount": "Already have an account?",
     "signIn": "Sign in"
   },
@@ -784,6 +795,9 @@
     "resendSent": "Verification email sent again.",
     "resendRateLimited": "Too many requests — please try again shortly.",
     "resendFailed": "Failed to resend the verification email.",
+    "resendUserNotFound": "We couldn't find your account.",
+    "projectLimitExceededError": "The free plan allows up to {limit} project(s). Upgrade your plan to continue.",
+    "createAgentFailed": "Couldn't create the agent.",
     "networkError": "Network error — please check your connection and try again",
     "apiKeyFailedMembers": "API key generation failed. Go to Settings > Members > Agents to issue one manually.",
     "goToMembersAgents": "Manage in Members > Agents",
@@ -1942,6 +1956,11 @@
     "acceptFailed": "Failed to accept invitation.",
     "accepting": "Accepting invitation...",
     "authFailed": "Authentication failed. Please try again.",
+    "inviteNotFound": "We couldn't find that invite.",
+    "inviteAlreadyAccepted": "This invite has already been accepted.",
+    "inviteExpired": "This invite has expired.",
+    "inviteEmailMismatch": "This invite was sent to a different email address.",
+    "inviteCannotAccept": "This invite can't be accepted.",
     "backToLogin": "Go to login →",
     "joinedOrg": "You've joined {org}",
     "joinHeading": "Join <b>{org}</b>",
@@ -1965,7 +1984,9 @@
     "invalidLink": "This link has expired or is invalid.",
     "strengthHint": "At least 3 of: uppercase, lowercase, number, symbol ({met}/3)",
     "lengthHint": "At least 8 characters",
-    "submitFailed": "Couldn't change the password. Please try again in a moment."
+    "submitFailed": "Couldn't change the password. Please try again in a moment.",
+    "resetInvalidToken": "This reset link is invalid or has expired.",
+    "resetUserNotFound": "We couldn't find that account."
   },
   "meeting": {
     "title": "Meetings",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -112,6 +112,7 @@
     "createOrgSlugLabel": "Slug",
     "createOrgSlugPlaceholder": "my-company",
     "createOrgSlugError": "영소문자, 숫자, 하이픈만 사용 가능합니다 (시작/끝은 영소문자 또는 숫자)",
+    "createOrgSlugTaken": "이미 사용 중인 슬러그입니다.",
     "createOrgGenericError": "Organization을 만들지 못했습니다. 잠시 후 다시 시도해 주세요."
   },
   "storage": {
@@ -723,7 +724,15 @@
     "csrfMismatch": "보안 검증에 실패했습니다. 다시 시도해 주세요.",
     "oauthNoToken": "인증 토큰을 받지 못했습니다. 다시 시도해 주세요.",
     "invalidProvider": "유효하지 않은 OAuth 제공자입니다.",
-    "oauthNativeIssueFailed": "앱으로 로그인 정보를 전달하는 데 실패했습니다. 다시 시도해 주세요."
+    "oauthNativeIssueFailed": "앱으로 로그인 정보를 전달하는 데 실패했습니다. 다시 시도해 주세요.",
+    "loginInvalidCredentials": "이메일 또는 비밀번호가 올바르지 않습니다.",
+    "loginAccountLocked": "너무 많은 시도로 계정이 잠겼습니다. 잠시 후 다시 시도해 주세요.",
+    "loginTotpLocked": "인증 실패가 너무 많아 잠겼습니다. 잠시 후 다시 시도해 주세요.",
+    "loginInvalidTotpCode": "인증 코드가 올바르지 않습니다.",
+    "loginTotpReplayed": "이미 사용된 인증 코드입니다. 새 코드를 입력해 주세요.",
+    "firebaseNetworkError": "네트워크 오류로 로그인할 수 없습니다. 다시 시도해 주세요.",
+    "firebaseSignInFailed": "로그인에 실패했습니다. 이메일과 비밀번호를 확인해 주세요.",
+    "firebaseDisabled": "이 로그인 방식은 현재 사용할 수 없습니다."
   },
   "register": {
     "subtitle": "계정 만들기",
@@ -742,6 +751,8 @@
     "continueWithGoogle": "Google로 계속",
     "tosRequiredError": "먼저 이용약관과 개인정보처리방침에 동의해 주세요.",
     "registrationFailed": "가입에 실패했습니다. 다시 시도해 주세요.",
+    "registerEmailTaken": "이미 가입된 이메일입니다.",
+    "registerTosRequired": "서비스 이용약관에 동의해야 합니다.",
     "alreadyHaveAccount": "이미 계정이 있으신가요?",
     "signIn": "로그인"
   },
@@ -784,6 +795,9 @@
     "resendSent": "인증 메일을 다시 보냈습니다.",
     "resendRateLimited": "너무 자주 요청했습니다 — 잠시 후 다시 시도해 주세요.",
     "resendFailed": "인증 메일 재전송에 실패했습니다.",
+    "resendUserNotFound": "사용자를 찾을 수 없습니다.",
+    "projectLimitExceededError": "무료 플랜은 프로젝트를 {limit}개까지 만들 수 있습니다. 계속하려면 요금제를 업그레이드해 주세요.",
+    "createAgentFailed": "에이전트 생성에 실패했습니다.",
     "networkError": "네트워크 오류 — 연결을 확인하고 다시 시도해 주세요",
     "apiKeyFailedMembers": "API Key 발급에 실패했습니다. Settings > Members > Agents에서 수동으로 발급하세요.",
     "goToMembersAgents": "Members > Agents에서 관리하기",
@@ -1942,6 +1956,11 @@
     "acceptFailed": "초대 수락에 실패했습니다.",
     "accepting": "수락 중...",
     "authFailed": "인증에 실패했습니다. 다시 시도해주세요.",
+    "inviteNotFound": "초대를 찾을 수 없습니다.",
+    "inviteAlreadyAccepted": "이미 수락된 초대입니다.",
+    "inviteExpired": "초대가 만료되었습니다.",
+    "inviteEmailMismatch": "가입한 이메일이 초대받은 이메일과 다릅니다.",
+    "inviteCannotAccept": "이 초대는 수락할 수 없습니다.",
     "backToLogin": "로그인 페이지로 →",
     "joinedOrg": "{org}에 합류했어요",
     "joinHeading": "<b>{org}</b>에 합류하세요",
@@ -1965,7 +1984,9 @@
     "invalidLink": "링크가 만료되었거나 유효하지 않습니다.",
     "strengthHint": "대문자·소문자·숫자·특수문자 중 3가지 이상 ({met}/3)",
     "lengthHint": "8자 이상",
-    "submitFailed": "비밀번호를 변경하지 못했습니다. 잠시 후 다시 시도해 주세요."
+    "submitFailed": "비밀번호를 변경하지 못했습니다. 잠시 후 다시 시도해 주세요.",
+    "resetInvalidToken": "재설정 링크가 유효하지 않거나 만료되었습니다.",
+    "resetUserNotFound": "사용자를 찾을 수 없습니다."
   },
   "meeting": {
     "title": "회의록",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "verify:tint-foreground-contrast": "tsx scripts/verify-tint-foreground-contrast.ts",
     "verify:no-new-tint-color-text": "tsx scripts/verify-no-new-tint-color-text.ts",
     "verify:muted-foreground-contrast": "tsx scripts/verify-muted-foreground-contrast.ts",
+    "verify:no-raw-error-message": "tsx scripts/verify-no-raw-error-message.ts",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
     "e2e:report": "playwright show-report"

--- a/apps/web/scripts/raw-error-message-baseline.json
+++ b/apps/web/scripts/raw-error-message-baseline.json
@@ -1,0 +1,40 @@
+{
+  "_comment": "story #2484 — verify-no-raw-error-message.ts의 baseline. 여기 등재된 파일은 '.code 분기 없이 error.message/json.detail을 노출'하는 기존 채무로 알려져 있다. #2485(Phase 2)에서 정리 예정. 새 파일/새 자리만 넛지 대상이다.",
+  "knownDebt": [
+    "src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx",
+    "src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx",
+    "src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx",
+    "src/app/(authenticated)/organization/workforce/[id]/page.tsx",
+    "src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx",
+    "src/app/(authenticated)/settings/page.tsx",
+    "src/components/agents/agent-management-tab.tsx",
+    "src/components/agents/agent-run-detail.tsx",
+    "src/components/agents/messaging-policy-section.tsx",
+    "src/components/kanban/kanban-board.tsx",
+    "src/components/kanban/story-detail-panel.tsx",
+    "src/components/loops/loop-create-dialog.tsx",
+    "src/components/loops/variant-gallery.tsx",
+    "src/components/settings/add-member-modal.tsx",
+    "src/components/settings/ai-settings.tsx",
+    "src/components/settings/byom-key-management.tsx",
+    "src/components/settings/mcp-connection-settings.tsx",
+    "src/components/settings/my-notification-channel-section.tsx",
+    "src/components/settings/org-members-section.tsx",
+    "src/components/settings/set-password-section.tsx",
+    "src/components/settings/slack-integration-settings.tsx",
+    "src/components/settings/two-factor-section.tsx"
+  ],
+  "deliberateByDesign": [
+    "src/components/epics/epic-status-transition.tsx"
+  ],
+  "deadFieldFalsePositive": [
+    "src/components/shared/rejected-relations-section.tsx",
+    "src/components/flow/flow-epic-nodes.tsx",
+    "src/components/flow/flow-multi-lane-canvas.tsx"
+  ],
+  "reviewedSafe": [
+    "src/components/agents/agent-api-key-manager.tsx",
+    "src/components/ui/route-error-state.tsx"
+  ],
+  "_reviewedSafeNote": "agent-api-key-manager.tsx: error.message은 하드코딩 클라 literal(throw new Error('Failed to load API keys'))이지 서버 응답이 아니다. route-error-state.tsx: Next.js 라우트 에러 바운더리 fallback — 특정 fetch 응답을 렌더하는 게 아니라 임의 JS Error를 보여주는 다른 버그 클래스(#2484 그라운딩에서 확認)."
+}

--- a/apps/web/scripts/verify-no-raw-error-message.test.ts
+++ b/apps/web/scripts/verify-no-raw-error-message.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { findRawErrorSites } from './verify-no-raw-error-message';
+
+describe('findRawErrorSites — 양성대조: .code 분기 없는 raw 노출은 잡혀야 한다', () => {
+  it('error?.message가 근처 .code 없이 쓰이면 잡힌다', () => {
+    const content = `
+function f() {
+  setError(json.error?.message ?? t('fallback'));
+}
+`;
+    const findings = findRawErrorSites([{ relPath: 'src/app/x.tsx', content }]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.relPath).toBe('src/app/x.tsx');
+  });
+
+  it('json.detail이 근처 .code 없이 쓰이면 잡힌다', () => {
+    const content = `
+function f() {
+  throw new Error(json?.detail?.message ?? 'x');
+}
+`;
+    const findings = findRawErrorSites([{ relPath: 'src/app/y.tsx', content }]);
+    expect(findings).toHaveLength(1);
+  });
+
+  it('음성대조 — 근처(15줄 이내)에 .code 분기가 있으면 안 잡힌다(code로 갈랐다고 봄)', () => {
+    const content = `
+function f() {
+  if (json.error?.code === 'KNOWN') {
+    setError(t('known'));
+    return;
+  }
+  setError(json.error?.message ?? t('fallback'));
+}
+`;
+    const findings = findRawErrorSites([{ relPath: 'src/app/z.tsx', content }]);
+    expect(findings).toHaveLength(0);
+  });
+
+  it('.code 분기가 15줄보다 멀리 있으면 다시 잡힌다(창 밖)', () => {
+    const filler = Array.from({ length: 20 }, () => '  // filler').join('\n');
+    const content = `
+function f() {
+  if (json.error?.code === 'KNOWN') {
+    return;
+  }
+${filler}
+  setError(json.error?.message ?? t('fallback'));
+}
+`;
+    const findings = findRawErrorSites([{ relPath: 'src/app/w.tsx', content }]);
+    expect(findings).toHaveLength(1);
+  });
+});

--- a/apps/web/scripts/verify-no-raw-error-message.ts
+++ b/apps/web/scripts/verify-no-raw-error-message.ts
@@ -1,0 +1,106 @@
+/**
+ * story #2484 — advisory 넛지(⛔blocker 아님, PO 확定): FE가 `error?.code`를 안 갈라
+ * 서버 raw `error.message`/`json.detail`을 그대로 화면에 노출하는 자리가 #2441·#2470·
+ * create-organization-dialog로 3번 반복됐다(같은 병).
+ *
+ * 이 스크립트는 그 병의 «85% 단순형»(주변에 `.code` 토큰이 아예 없는 경우)만 정밀하게
+ * 잡는 grep tripwire다. 나머지 15%(code 체크는 있는데 그 분기 자체가 raw를 쓰는 경우·
+ * 의도적 raw 노출 정책·구조상 절대 안 새는 죽은 필드 오탐)는 grep으로 못 가른다 —
+ * `raw-error-message-baseline.json`에 그 파일들을 등재해 놓쳐도 되는 것으로 다룬다.
+ *
+ * ⛔이 스크립트는 CI를 실패시키지 않는다(항상 exit 0) — PO 확定: "advisory 넛지, blocker
+ * 아님". baseline 밖의 «새» 자리가 나오면 로그로만 알린다. baseline에 없는 새 파일이
+ * 이 패턴으로 새로 생기면, 리뷰어가 이 로그를 보고 판단한다(#2441/#2470/create-org와
+ * 같은 병인지 사람이 확認).
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src');
+const BASELINE_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), './raw-error-message-baseline.json');
+
+const RAW_PATTERN = /\berror\??\.\s*message\b|\bjson\??\.\s*detail\b/;
+const CODE_TOKEN = /\.code\b/;
+const CONTEXT_WINDOW = 15;
+
+interface Baseline {
+  knownDebt: string[];
+  deliberateByDesign: string[];
+  deadFieldFalsePositive: string[];
+  reviewedSafe: string[];
+}
+
+function loadBaseline(): Set<string> {
+  const raw = JSON.parse(readFileSync(BASELINE_PATH, 'utf-8')) as Baseline;
+  return new Set([...raw.knownDebt, ...raw.deliberateByDesign, ...raw.deadFieldFalsePositive, ...raw.reviewedSafe]);
+}
+
+function listTsxFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      if (entry === 'node_modules' || entry === '.next') continue;
+      out.push(...listTsxFiles(full));
+    } else if (/\.tsx$/.test(entry) && !entry.endsWith('.test.tsx')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+export interface RawErrorFinding {
+  relPath: string;
+  line: number;
+}
+
+export function findRawErrorSites(files: { relPath: string; content: string }[]): RawErrorFinding[] {
+  const findings: RawErrorFinding[] = [];
+  for (const { relPath, content } of files) {
+    const lines = content.split('\n');
+    for (let i = 0; i < lines.length; i += 1) {
+      if (!RAW_PATTERN.test(lines[i]!)) continue;
+      const start = Math.max(0, i - CONTEXT_WINDOW);
+      const end = Math.min(lines.length, i + CONTEXT_WINDOW);
+      const window = lines.slice(start, end).join('\n');
+      if (CODE_TOKEN.test(window)) continue; // 근처에 .code 분기가 있으면 85% 형태가 아니다 — 넘어간다.
+      findings.push({ relPath, line: i + 1 });
+    }
+  }
+  return findings;
+}
+
+function main(): number {
+  const baseline = loadBaseline();
+  const appDir = path.join(SRC_ROOT, 'app');
+  const componentsDir = path.join(SRC_ROOT, 'components');
+  const files = [...listTsxFiles(appDir), ...listTsxFiles(componentsDir)].map((abs) => ({
+    relPath: `src/${path.relative(SRC_ROOT, abs)}`,
+    content: readFileSync(abs, 'utf-8'),
+  }));
+
+  const findings = findRawErrorSites(files);
+  const newFindings = findings.filter((f) => !baseline.has(f.relPath));
+  const baselineHits = new Set(findings.filter((f) => baseline.has(f.relPath)).map((f) => f.relPath));
+
+  console.log(`[story #2484 advisory] error.code 미분기 raw 노출 패턴(단순형) 스캔 — 파일 ${files.length}개`);
+  console.log(`  baseline 등재 ${baselineHits.size}개 파일(알려진 채무, #2485에서 정리 예정) — 넛지 대상 아님`);
+
+  if (newFindings.length === 0) {
+    console.log('OK: baseline 밖의 새 자리 0건.');
+    return 0;
+  }
+
+  console.log(`\n⚠️  ${newFindings.length}건 — baseline 밖의 새 자리(리뷰어 확認 권장, blocker 아님):`);
+  for (const f of newFindings) {
+    console.log(`  - ${f.relPath}:${f.line}`);
+  }
+  console.log('\n#2441/#2470/create-organization-dialog와 같은 병(error.code 미분기 raw 노출)인지 리뷰에서 사람이 판단한다.');
+  return 0; // advisory — CI를 절대 실패시키지 않는다(PO 確定).
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main());
+}

--- a/apps/web/src/app/invite/accept/invite-accept-client.test.tsx
+++ b/apps/web/src/app/invite/accept/invite-accept-client.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+//
+// story #2484 — 초대 수락 실패가 error.code 분기 없이 json.error?.message(raw 서버 영문)를
+// 그대로 노출하던 자리. invite/page.tsx의 acceptInvite와 같은 shared helper
+// (inviteErrorMessage)를 재사용한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { InviteAcceptClient } from './invite-accept-client';
+import koMessages from '../../../../messages/ko.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function mountAndAccept(fetchImpl: () => Promise<unknown>) {
+  vi.stubGlobal('fetch', vi.fn(fetchImpl));
+  await act(async () => {
+    root.render(
+      <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+        <InviteAcceptClient token="tok-1" orgName="뭉클랩" role="member" email="a@b.com" projects={[]} />
+      </NextIntlClientProvider>,
+    );
+  });
+  const acceptBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.invite.accept);
+  await act(async () => {
+    acceptBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+  });
+}
+
+describe('InviteAcceptClient — error.code 분기 (story #2484)', () => {
+  it('HTTP_410(만료) — raw 영문 대신 번역 문구', async () => {
+    await mountAndAccept(async () => ({
+      ok: false,
+      json: async () => ({ error: { code: 'HTTP_410', message: 'Invite has expired' } }),
+    }));
+    expect(container.textContent).not.toContain('Invite has expired');
+    expect(container.textContent).toContain(koMessages.invite.inviteExpired);
+  });
+
+  it('FORBIDDEN(이메일 불일치) — raw 영문 대신 번역 문구', async () => {
+    await mountAndAccept(async () => ({
+      ok: false,
+      json: async () => ({ error: { code: 'FORBIDDEN', message: 'Email does not match invite' } }),
+    }));
+    expect(container.textContent).not.toContain('Email does not match invite');
+    expect(container.textContent).toContain(koMessages.invite.inviteEmailMismatch);
+  });
+
+  it('알려지지 않은 code — 안전 폴백, raw message 미노출', async () => {
+    await mountAndAccept(async () => ({
+      ok: false,
+      json: async () => ({ error: { code: 'SOME_NEW_CODE', message: 'brand new raw string' } }),
+    }));
+    expect(container.textContent).not.toContain('brand new raw string');
+    expect(container.textContent).toContain(koMessages.invite.acceptFailed);
+  });
+});

--- a/apps/web/src/app/invite/accept/invite-accept-client.tsx
+++ b/apps/web/src/app/invite/accept/invite-accept-client.tsx
@@ -59,6 +59,8 @@ export function InviteAcceptClient({ token, orgName, role, email, projects }: In
 
         <div className="rounded-lg border border-border bg-muted px-4 py-3">
           <div className="flex items-center justify-between text-sm">
+            {/* ⚠️Phase2 i18n·#2485 — "Organization" 라벨이 하드코딩 영문이다(t() 아님, 서버
+                응답과 무관 — raw 서버 누수는 아님). #2484 스코프 밖, 유나 design 확認. */}
             <span className="text-muted-foreground">Organization</span>
             <span className="font-medium text-foreground/85">{orgName}</span>
           </div>

--- a/apps/web/src/app/invite/accept/invite-accept-client.tsx
+++ b/apps/web/src/app/invite/accept/invite-accept-client.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
+import { inviteErrorMessage } from '@/lib/invite-error-message';
 
 interface InviteAcceptClientProps {
   token: string;
@@ -31,9 +32,11 @@ export function InviteAcceptClient({ token, orgName, role, email, projects }: In
     setAccepting(true);
     try {
       const res = await fetch(`/api/invites/${token}/accept`, { method: 'POST' });
-      const json = await res.json() as { error?: { message?: string } };
+      const json = await res.json() as { error?: { code?: string; message?: string } };
       if (!res.ok) {
-        setResult({ type: 'error', text: json.error?.message ?? tInvite('acceptFailed') });
+        // story #2484 — code로 분기(invite/page.tsx의 acceptInvite와 같은 백엔드·같은
+        // 매핑 재사용, 2벌 방지).
+        setResult({ type: 'error', text: inviteErrorMessage(tInvite, json.error?.code, 'acceptFailed') });
       } else {
         setResult({ type: 'success', text: `${tInvite('success')} ${tInvite('redirecting')}` });
         setTimeout(() => { window.location.href = '/dashboard'; }, 1500);

--- a/apps/web/src/app/invite/page.test.tsx
+++ b/apps/web/src/app/invite/page.test.tsx
@@ -95,9 +95,12 @@ describe('InvitePage — joinHeading t.rich() 렌더 (story #2084)', () => {
 // invalidLink와 달리) aria-live 대상이다.
 describe('InvitePage — 결과 피드백 접근성(story #2105 2차)', () => {
   it('프리뷰 로드 실패 시 role="alert" aria-live="assertive"로 사유가 렌더된다', async () => {
+    // story #2484 — 이 preview 엔드포인트가 실제로 낼 수 있는 유일한 코드는 NOT_FOUND지만,
+    // 여기선 code 기반 분기 자체가 동작하는지(raw message 대신 번역 문구)가 핵심이라 임의
+    // 코드로 대표 검증한다.
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
       if (url.includes('/api/invites/tok-1') && !url.includes('accept')) {
-        return { ok: false, json: async () => ({ error: { message: '초대가 만료되었습니다.' } }) };
+        return { ok: false, json: async () => ({ error: { code: 'NOT_FOUND', message: 'Invite not found' } }) };
       }
       throw new Error('unexpected fetch: ' + url);
     }));
@@ -106,7 +109,8 @@ describe('InvitePage — 결과 피드백 접근성(story #2105 2차)', () => {
 
     const alertEl = container.querySelector('[role="alert"]');
     expect(alertEl).not.toBeNull();
-    expect(alertEl?.textContent).toContain('초대가 만료되었습니다.');
+    expect(alertEl?.textContent).not.toContain('Invite not found');
+    expect(alertEl?.textContent).toContain(koMessages.invite.inviteNotFound);
     expect(alertEl?.getAttribute('aria-live')).toBe('assertive');
   });
 
@@ -146,5 +150,85 @@ describe('InvitePage — 결과 피드백 접근성(story #2105 2차)', () => {
     expect(statusEl).not.toBeNull();
     expect(statusEl?.getAttribute('aria-live')).toBe('polite');
     expect(statusEl?.textContent).toContain('뭉클랩');
+  });
+});
+
+// story #2484 — acceptInvite·handleSubmit 둘 다 error.code 분기 없이 raw message를 쓰던
+// 자리. code별 번역 문구가 뜨고, 알려지지 않은 code는 안전 폴백만 뜬다(raw 미노출).
+describe('InvitePage — error.code 분기 (story #2484)', () => {
+  it('초대 수락 실패 CONFLICT — raw 영문 대신 번역 문구(로그인 경로에서 acceptInvite 호출)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string, opts?: RequestInit) => {
+      if (url.includes('/api/invites/tok-1') && !url.includes('accept')) {
+        return { ok: true, json: async () => ({ data: PREVIEW }) };
+      }
+      if (url === '/api/me') return { ok: false } as Response;
+      if (url === '/api/auth/login' && opts?.method === 'POST') {
+        return { ok: true, json: async () => ({}) };
+      }
+      if (url.includes('/accept')) {
+        return { ok: false, json: async () => ({ error: { code: 'CONFLICT', message: 'Invite already accepted' } }) };
+      }
+      throw new Error('unexpected fetch: ' + url);
+    }));
+    await act(async () => { root.render(wrap('ko', <InvitePage />)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    const emailInput = container.querySelector('input[type="email"]') as HTMLInputElement;
+    const passwordInput = container.querySelector('input[type="password"]') as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+    // 기본 탭이 signup이라 login으로 전환
+    const loginTab = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.login.signIn);
+    await act(async () => { loginTab?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => {
+      setter.call(emailInput, 'a@b.com');
+      emailInput.dispatchEvent(new Event('input', { bubbles: true }));
+      setter.call(passwordInput, 'password123!');
+      passwordInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    const submitBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.invite.submit);
+    await act(async () => {
+      submitBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl?.textContent).not.toContain('Invite already accepted');
+    expect(alertEl?.textContent).toContain(koMessages.invite.inviteAlreadyAccepted);
+  });
+
+  it('가입 실패 EMAIL_TAKEN — raw 영문 대신 register 네임스페이스 문구 재사용', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string, opts?: RequestInit) => {
+      if (url.includes('/api/invites/tok-1') && !url.includes('accept')) {
+        return { ok: true, json: async () => ({ data: PREVIEW }) };
+      }
+      if (url === '/api/me') return { ok: false } as Response;
+      if (url === '/api/auth/register' && opts?.method === 'POST') {
+        return { ok: false, json: async () => ({ error: { code: 'EMAIL_TAKEN', message: 'Email already registered' } }) };
+      }
+      throw new Error('unexpected fetch: ' + url);
+    }));
+    await act(async () => { root.render(wrap('ko', <InvitePage />)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
+    const passwordInput = container.querySelector('input[type="password"]') as HTMLInputElement;
+    const tosCheckbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(nameInput, '홍길동');
+      nameInput.dispatchEvent(new Event('input', { bubbles: true }));
+      setter.call(passwordInput, 'password123!');
+      passwordInput.dispatchEvent(new Event('input', { bubbles: true }));
+      tosCheckbox.click();
+    });
+    const submitBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.invite.submit);
+    await act(async () => {
+      submitBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl?.textContent).not.toContain('Email already registered');
+    expect(alertEl?.textContent).toBe(koMessages.register.registerEmailTaken);
   });
 });

--- a/apps/web/src/app/invite/page.tsx
+++ b/apps/web/src/app/invite/page.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl';
 import { Loader2 } from 'lucide-react';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
 import { cn } from '@/lib/utils';
+import { InviteError, inviteErrorMessage } from '@/lib/invite-error-message';
 
 // d3619e80: invite_accept canonical InvitePreviewResponse 정합(org_name·role·status·expires_at·email).
 // inviter_name/email은 canonical 미제공(optional·미제공 시 generic 안내로 graceful degrade).
@@ -25,6 +26,7 @@ type PageState = 'preview-loading' | 'preview-error' | 'auth' | 'accepting' | 's
 export default function InvitePage() {
   const t = useTranslations('invite');
   const t2 = useTranslations('login');
+  const t3 = useTranslations('register');
   const searchParams = useSearchParams();
   const router = useRouter();
   const token = searchParams.get('token');
@@ -50,8 +52,10 @@ export default function InvitePage() {
     fetch(`/api/invites/${encodeURIComponent(token)}`)
       .then(async (res) => {
         if (!res.ok) {
-          const json = await res.json().catch(() => null) as { error?: { message?: string } } | null;
-          throw new Error(json?.error?.message ?? 'preview failed');
+          const json = await res.json().catch(() => null) as { error?: { code?: string; message?: string } } | null;
+          // story #2484 — 미리보기 실패는 사실상 NOT_FOUND뿐이지만(backend
+          // invite_accept.py get_invite_preview), 코드 기반 분기를 그대로 적용.
+          throw new InviteError(json?.error?.code);
         }
         const json = await res.json() as { data: InvitePreview };
         setPreview(json.data);
@@ -63,9 +67,9 @@ export default function InvitePage() {
           setPageState('auth');
         }
       })
-      .catch((err: Error) => {
+      .catch((err: InviteError) => {
         setPageState('preview-error');
-        setErrorMsg(err.message);
+        setErrorMsg(inviteErrorMessage(t, err.code, 'invalidToken'));
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [token]);
@@ -80,9 +84,9 @@ export default function InvitePage() {
       setPageState('success');
       setTimeout(() => router.push('/dashboard'), 1500);
     } else {
-      const json = await res.json().catch(() => null) as { error?: { message?: string } } | null;
+      const json = await res.json().catch(() => null) as { error?: { code?: string; message?: string } } | null;
       setPageState('preview-error');
-      setErrorMsg(json?.error?.message ?? t('acceptFailed'));
+      setErrorMsg(inviteErrorMessage(t, json?.error?.code, 'acceptFailed'));
     }
   };
 
@@ -111,9 +115,20 @@ export default function InvitePage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       });
-      const json = await res.json().catch(() => null) as { error?: { message?: string } } | null;
+      const json = await res.json().catch(() => null) as { error?: { code?: string; message?: string } } | null;
       if (!res.ok) {
-        setErrorMsg(json?.error?.message ?? t('authFailed'));
+        // story #2484 — code로 분기. authMode에 따라 register/login 각자의 안정 코드 재사용
+        // (신규 키 대신 register/login 페이지와 같은 키 — 2벌 번역 갈림 방지).
+        const code = json?.error?.code;
+        if (authMode === 'signup' && code === 'EMAIL_TAKEN') {
+          setErrorMsg(t3('registerEmailTaken'));
+        } else if (authMode === 'login' && code === 'INVALID_CREDENTIALS') {
+          setErrorMsg(t2('loginInvalidCredentials'));
+        } else if (authMode === 'login' && code === 'ACCOUNT_LOCKED') {
+          setErrorMsg(t2('loginAccountLocked'));
+        } else {
+          setErrorMsg(t('authFailed'));
+        }
         return;
       }
       if (authMode === 'signup') {

--- a/apps/web/src/app/login/page.test.tsx
+++ b/apps/web/src/app/login/page.test.tsx
@@ -99,3 +99,47 @@ describe('LoginPage — 실패 사유 접근성 (story #2105 1차)', () => {
     expect(first).not.toBe(second);
   });
 });
+
+// story #2484 — code로 분기하지 않으면 result.error.message(서버/BFF raw 영문)가 그대로
+// 뜬다. 각 케이스에서 raw 영문 message는 화면에 없어야 하고, 대신 번역된 한국어 문구가
+// 떠야 한다(메시지를 일부러 실제와 다른 raw 영문으로 줘서 "raw가 새면 바로 드러나게" 함).
+describe('LoginPage — error.code 분기 (story #2484)', () => {
+  it('ACCOUNT_LOCKED — raw 영문 대신 번역 문구', async () => {
+    loginWithPasswordMock.mockResolvedValue({ error: { code: 'ACCOUNT_LOCKED', message: 'Account locked. Try again in 287 seconds' } });
+    await mount();
+    await submit();
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl?.textContent).not.toContain('Account locked');
+    expect(alertEl?.textContent).toBe(koMessages.login.loginAccountLocked);
+  });
+
+  it('TOTP_LOCKED — raw 영문 대신 번역 문구', async () => {
+    loginWithPasswordMock.mockResolvedValue({ error: { code: 'TOTP_LOCKED', message: 'Too many failures. Retry after 300s' } });
+    await mount();
+    await submit();
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl?.textContent).not.toContain('Too many failures');
+    expect(alertEl?.textContent).toBe(koMessages.login.loginTotpLocked);
+  });
+
+  it('INVALID_TOTP — raw 영문 대신 번역 문구', async () => {
+    loginWithPasswordMock.mockResolvedValue({ error: { code: 'INVALID_TOTP', message: 'Invalid TOTP code' } });
+    await mount();
+    await submit();
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl?.textContent).not.toContain('Invalid TOTP');
+    expect(alertEl?.textContent).toBe(koMessages.login.loginInvalidTotpCode);
+  });
+
+  it('알려지지 않은 code — 안전 폴백(loginFailed), raw message 미노출', async () => {
+    loginWithPasswordMock.mockResolvedValue({ error: { code: 'SOME_NEW_BACKEND_CODE', message: 'a brand new raw server string' } });
+    await mount();
+    await submit();
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl?.textContent).not.toContain('brand new raw server string');
+    expect(alertEl?.textContent).toBe(koMessages.login.loginFailed);
+  });
+
+  // 양성대조(AC) — 가드 없이 raw message를 그대로 쓰면 이 테스트가 RED여야 한다.
+  // (수동 mutation self-check로 확認 — 아래 PR 설명 참고. 이 테스트 자체가 그 반례 역할.)
+});

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -56,7 +56,15 @@ export default function LoginPage() {
     try {
       const result = await signInAndExchangeFirebaseSession(email.trim(), password);
       if (result.error) {
-        setError(result.error.message);
+        // story #2484 — result.error.message는 BFF/클라 SDK가 만든 raw 영문 문자열이라
+        // code로 분기(코드 자체는 신원 열거를 피하려 이미 소수·중립으로 설계돼 있음).
+        if (result.error.code === 'NETWORK_ERROR') {
+          setError(t('firebaseNetworkError'));
+        } else if (result.error.code === 'FIREBASE_DISABLED') {
+          setError(t('firebaseDisabled'));
+        } else {
+          setError(t('firebaseSignInFailed'));
+        }
         return;
       }
       // story #1959(P2-S3) AC: 로그인 복귀 후 /login history 잔존 0 — push 는 스택에 남아
@@ -80,7 +88,21 @@ export default function LoginPage() {
           setError(t('totpRequired'));
           return;
         }
-        setError(result.error.message);
+        // story #2484 — 나머지 code는 backend _err()가 직접 발급하는 안정 값이라(auth.py
+        // login()) 전부 분기한다. 알려지지 않은 code만 안전 폴백(raw message 미노출).
+        if (result.error.code === 'INVALID_CREDENTIALS') {
+          setError(t('loginInvalidCredentials'));
+        } else if (result.error.code === 'ACCOUNT_LOCKED') {
+          setError(t('loginAccountLocked'));
+        } else if (result.error.code === 'TOTP_LOCKED') {
+          setError(t('loginTotpLocked'));
+        } else if (result.error.code === 'INVALID_TOTP') {
+          setError(t('loginInvalidTotpCode'));
+        } else if (result.error.code === 'TOTP_REPLAYED') {
+          setError(t('loginTotpReplayed'));
+        } else {
+          setError(t('loginFailed'));
+        }
         return;
       }
       // story #1959(P2-S3): 위와 동일 사유 — replace 로 /login history 잔존 방지.

--- a/apps/web/src/app/mfa/page.test.tsx
+++ b/apps/web/src/app/mfa/page.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+//
+// story #2484 — 검증 실패가 error.code 분기 없이 json.error?.message(raw 서버 영문)를
+// 그대로 노출하던 자리. 이 페이지는 전체 하드코딩 영문(next-intl 미배선)이라 우리 자체
+// 영문 카피로 code별 분기한다(서버 문자열을 그대로 쓰지 않는 것이 핵심).
+// ⚠️그라운딩(#2484) 확認: 이 라우트는 현재 앱 내 어떤 링크·리다이렉트도 가리키지 않는
+// 고아 경로다 — 그래도 요청 스코프대로 동일 원칙을 적용한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+function setNativeValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+  setter.call(el, value);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+async function mountAndSubmit() {
+  const { default: MfaPage } = await import('./page');
+  await act(async () => { root.render(<MfaPage />); });
+  const codeInput = container.querySelector('input[type="text"]') as HTMLInputElement;
+  await act(async () => { setNativeValue(codeInput, '123456'); });
+  const verifyBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === 'Verify');
+  await act(async () => {
+    verifyBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+  });
+}
+
+describe('MfaPage — error.code 분기 (story #2484)', () => {
+  it('INVALID_TOTP — raw 영문 대신 자체 카피', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      json: async () => ({ error: { code: 'INVALID_TOTP', message: 'Invalid TOTP code' } }),
+    })));
+    await mountAndSubmit();
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl?.textContent).not.toBe('Invalid TOTP code');
+    expect(alertEl?.textContent).toContain('did not match');
+  });
+
+  it('TOTP_NOT_SETUP — raw 영문 대신 자체 카피', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      json: async () => ({ error: { code: 'TOTP_NOT_SETUP', message: 'TOTP not initialized' } }),
+    })));
+    await mountAndSubmit();
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl?.textContent).not.toBe('TOTP not initialized');
+    expect(alertEl?.textContent).toContain('not been set up');
+  });
+
+  it('알려지지 않은 code — 안전 폴백, raw message 미노출', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      json: async () => ({ error: { code: 'SOME_NEW_CODE', message: 'brand new raw string' } }),
+    })));
+    await mountAndSubmit();
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl?.textContent).not.toContain('brand new raw string');
+    expect(alertEl?.textContent).toBe('Invalid verification code. Please try again.');
+  });
+});

--- a/apps/web/src/app/mfa/page.tsx
+++ b/apps/web/src/app/mfa/page.tsx
@@ -26,6 +26,9 @@ export default function MfaPage() {
         // 안정 값). 알려지지 않은 code만 안전 폴백(raw message 미노출). ⚠️이 라우트는
         // 현재 앱 내 어떤 링크·리다이렉트도 가리키지 않는 고아 경로로 그라운딩됨(#2484) —
         // 동작 검증 실익이 낮지만 요청 스코프대로 동일 원칙 적용.
+        // ⚠️Phase2 i18n·#2485 — 이 페이지 전체(제목·라벨·버튼 포함)가 next-intl 미배선이라
+        // 아래 문구도 자체 하드코딩 영문이다(raw 서버 누수는 아님·i18n 완성도 축). #2484는
+        // "raw 서버 노출 제거"만 스코프라 여기서 전면 i18n 전환은 안 함 — 유나 design 확認.
         if (json.error?.code === 'USER_NOT_FOUND') {
           setError('We could not find your account. Please sign in again.');
         } else if (json.error?.code === 'TOTP_NOT_SETUP') {

--- a/apps/web/src/app/mfa/page.tsx
+++ b/apps/web/src/app/mfa/page.tsx
@@ -20,9 +20,21 @@ export default function MfaPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ code: code.trim() }),
       });
-      const json = await res.json() as { data?: { ok: boolean }; error?: { message: string } };
+      const json = await res.json() as { data?: { ok: boolean }; error?: { code?: string; message: string } };
       if (!res.ok || !json.data?.ok) {
-        setError(json.error?.message ?? 'Invalid verification code. Please try again.');
+        // story #2484 — code로 분기(backend auth.py totp_verify()가 _err()로 직접 발급하는
+        // 안정 값). 알려지지 않은 code만 안전 폴백(raw message 미노출). ⚠️이 라우트는
+        // 현재 앱 내 어떤 링크·리다이렉트도 가리키지 않는 고아 경로로 그라운딩됨(#2484) —
+        // 동작 검증 실익이 낮지만 요청 스코프대로 동일 원칙 적용.
+        if (json.error?.code === 'USER_NOT_FOUND') {
+          setError('We could not find your account. Please sign in again.');
+        } else if (json.error?.code === 'TOTP_NOT_SETUP') {
+          setError('Two-factor authentication has not been set up yet.');
+        } else if (json.error?.code === 'INVALID_TOTP') {
+          setError('That code did not match. Please try again.');
+        } else {
+          setError('Invalid verification code. Please try again.');
+        }
         return;
       }
       router.push('/dashboard');

--- a/apps/web/src/app/onboarding/onboarding-form.email-verify.test.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.email-verify.test.tsx
@@ -179,7 +179,10 @@ describe('OnboardingForm — EMAIL_VERIFICATION_REQUIRED (story #2441)', () => {
     await act(async () => { submitButton().click(); });
     await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
 
-    expect(container.textContent).toContain('Slug already exists');
+    // story #2484 — 유나 design:changes(2026-08-06): 이 폴백은 raw 서버 message를 그대로
+    // 노출했었다(같은 병). 지금은 generic 번역 문구로 간다 — raw는 절대 안 보여야 한다.
+    expect(container.textContent).not.toContain('Slug already exists');
+    expect(container.textContent).toContain('조직 생성에 실패했습니다');
     const resendBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '인증 메일 재전송');
     expect(resendBtn).toBeUndefined();
   });

--- a/apps/web/src/app/onboarding/onboarding-form.org-limit.test.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.org-limit.test.tsx
@@ -145,7 +145,10 @@ describe('OnboardingForm — PLAN_LIMIT_EXCEEDED (story #2470)', () => {
     await act(async () => { submitButton().click(); });
     await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
 
-    expect(container.textContent).toContain('Slug already exists');
+    // story #2484 — 유나 design:changes(2026-08-06): 이 폴백은 raw 서버 message를 그대로
+    // 노출했었다(같은 병). 지금은 generic 번역 문구로 간다 — raw는 절대 안 보여야 한다.
+    expect(container.textContent).not.toContain('Slug already exists');
+    expect(container.textContent).toContain('조직 생성에 실패했습니다');
     expect(document.body.querySelector('a[href="/dashboard/settings"]')).toBeNull();
   });
 });

--- a/apps/web/src/app/onboarding/onboarding-form.test.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+//
+// story #2484 — 세 자리가 error.code 분기 없이(또는 존재하지 않는 코드를 보고) raw 서버
+// 영문을 노출하던 자리:
+//  ① resend-verification 비-429 실패 — code 미분기.
+//  ② create-project — 'UPGRADE_REQUIRED'를 보는데 backend는 그 코드를 절대 안 낸다
+//     (실제로는 'PLAN_LIMIT_EXCEEDED'). 이 분기는 지금껏 한 번도 안 탄 죽은 코드였다.
+//  ③ create-agent — code 미분기 + 하드코딩 영문 폴백.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { OnboardingForm } from './onboarding-form';
+import koMessages from '../../../messages/ko.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+function setNativeValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+  setter.call(el, value);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+async function flush() {
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('OnboardingForm — error.code 분기 (story #2484)', () => {
+  it('resend-verification 비-429 실패(USER_NOT_FOUND) — raw 영문 대신 번역 문구', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/onboarding/events') return { ok: true, json: async () => ({}) };
+      if (url === '/api/organizations') {
+        return { ok: false, json: async () => ({ error: { code: 'EMAIL_VERIFICATION_REQUIRED', message: 'x' } }) };
+      }
+      if (url === '/api/auth/resend-verification') {
+        return { ok: false, status: 400, json: async () => ({ error: { code: 'USER_NOT_FOUND', message: 'User not found' } }) };
+      }
+      throw new Error('unexpected fetch: ' + url);
+    }));
+    await act(async () => { root.render(wrap(<OnboardingForm />)); });
+
+    const nameInput = container.querySelector('input') as HTMLInputElement;
+    await act(async () => { setNativeValue(nameInput, 'My Org'); });
+    const createBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.onboarding.createOrg);
+    await act(async () => { createBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    const resendBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.onboarding.resendVerificationCta);
+    expect(resendBtn).not.toBeUndefined();
+    await act(async () => { resendBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    expect(container.textContent).not.toContain('User not found');
+    expect(container.textContent).toContain(koMessages.onboarding.resendUserNotFound);
+  });
+
+  it('create-project PLAN_LIMIT_EXCEEDED(resource=project) — UpgradeModal이 실제로 뜬다(구 코드는 죽은 분기였음)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/onboarding/events') return { ok: true, json: async () => ({}) };
+      if (url === '/api/projects') {
+        return {
+          ok: false,
+          json: async () => ({ error: { code: 'PLAN_LIMIT_EXCEEDED', resource: 'project', limit: 1, tier: 'free', upgrade_required: true, message: 'Free plan project limit (1) reached. Upgrade to Team or Pro.' } }),
+        };
+      }
+      throw new Error('unexpected fetch: ' + url);
+    }));
+    await act(async () => {
+      root.render(wrap(<OnboardingForm initialStep="project" initialOrgId="org-1" />));
+    });
+
+    const nameInput = container.querySelector('input') as HTMLInputElement;
+    await act(async () => { setNativeValue(nameInput, 'My Project'); });
+    const createBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.onboarding.createProjectAction);
+    await act(async () => { createBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    // story #2484 핵심 회귀가드 — 예전엔 이 분기가 절대 안 탔다(코드명이 틀려서).
+    // UpgradeModal은 Dialog(base-ui) 기반이라 body에 portal된다 — container 밖에서 찾는다.
+    expect(document.body.textContent).not.toContain('Free plan project limit');
+    expect(document.body.textContent).toContain('무료 플랜은 프로젝트를 1개까지 만들 수 있습니다');
+  });
+
+  it('create-agent 실패 — raw/하드코딩 영문 대신 번역 문구(#2484)', async () => {
+    // initialStep="project" prop은 컴포넌트 자체 로직상 "새로고침 재개"를 뜻해 프로젝트
+    // 생성 성공 時 agent 단계로 안 가고 바로 대시보드로 finishToDashboard()한다 — agent
+    // 단계에 실제 projectId를 갖고 도달하려면 org→project 전 과정을 그대로 밟아야 한다.
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/onboarding/events') return { ok: true, json: async () => ({}) };
+      if (url === '/api/organizations') return { ok: true, json: async () => ({ data: { id: 'org-1' } }) };
+      if (url === '/api/auth/refresh') return { ok: true, json: async () => ({}) };
+      if (url === '/api/projects') return { ok: true, json: async () => ({ data: { id: 'proj-1' } }) };
+      if (url === '/api/current-project') return { ok: true, json: async () => ({}) };
+      if (url === '/api/team-members') {
+        return { ok: false, json: async () => ({ error: { code: 'SOME_CODE', message: 'raw server text' } }) };
+      }
+      throw new Error('unexpected fetch: ' + url);
+    }));
+    await act(async () => { root.render(wrap(<OnboardingForm />)); });
+
+    const orgNameInput = container.querySelector('input') as HTMLInputElement;
+    await act(async () => { setNativeValue(orgNameInput, 'My Org'); });
+    const createOrgBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.onboarding.createOrg);
+    await act(async () => { createOrgBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    const projectNameInput = container.querySelector('input') as HTMLInputElement;
+    await act(async () => { setNativeValue(projectNameInput, 'My Project'); });
+    const createProjectBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.onboarding.createProjectAction);
+    await act(async () => { createProjectBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    const agentNameInput = container.querySelector('input') as HTMLInputElement;
+    await act(async () => { setNativeValue(agentNameInput, 'My Agent'); });
+    const createAgentBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.onboarding.createAgentAction);
+    await act(async () => { createAgentBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    expect(container.textContent).not.toContain('raw server text');
+    expect(container.textContent).not.toContain('Failed to create agent');
+    expect(container.textContent).toContain(koMessages.onboarding.createAgentFailed);
+  });
+});

--- a/apps/web/src/app/onboarding/onboarding-form.test.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.test.tsx
@@ -50,6 +50,26 @@ async function flush() {
 }
 
 describe('OnboardingForm — error.code 분기 (story #2484)', () => {
+  it('create-org 알려지지 않은 code — 안전 폴백, raw message 미노출(유나 design:changes 델타)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/onboarding/events') return { ok: true, json: async () => ({}) };
+      if (url === '/api/organizations') {
+        return { ok: false, json: async () => ({ error: { code: 'SOME_NEW_CODE', message: 'brand new raw string' } }) };
+      }
+      throw new Error('unexpected fetch: ' + url);
+    }));
+    await act(async () => { root.render(wrap(<OnboardingForm />)); });
+
+    const nameInput = container.querySelector('input') as HTMLInputElement;
+    await act(async () => { setNativeValue(nameInput, 'My Org'); });
+    const createBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.onboarding.createOrg);
+    await act(async () => { createBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    expect(container.textContent).not.toContain('brand new raw string');
+    expect(container.textContent).toContain(koMessages.onboarding.createOrgFailed);
+  });
+
   it('resend-verification 비-429 실패(USER_NOT_FOUND) — raw 영문 대신 번역 문구', async () => {
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
       if (url === '/api/onboarding/events') return { ok: true, json: async () => ({}) };

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -106,7 +106,11 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
           setShowUpgrade(true);
           return;
         }
-        setError(json?.error?.message ?? t('createOrgFailed'));
+        // story #2484 — 유나 design:changes(2026-08-06): 위 두 code는 분기하지만 그 «외»
+        // code는 raw 서버 message가 그대로 샜다(형제 3핸들러(resend/create-project/
+        // create-agent)만 고치고 이 자리를 놓친 것 — 가드도 위에 .code 토큰이 있어 못 잡는
+        // 사각이었다). 알려지지 않은 code는 다른 핸들러와 동일하게 generic 폴백만 쓴다.
+        setError(t('createOrgFailed'));
         return;
       }
 
@@ -357,6 +361,8 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
                 placeholder={t('slugPlaceholder')}
               />
               {orgSlug && !slugValid ? (
+                // ⚠️Phase2 i18n·#2485 — 클라 측 정규식 검증 문구가 하드코딩 한국어다(t() 아님,
+                // 서버 응답과 무관 — raw 서버 누수는 아님). #2484 스코프 밖, 유나 design 확認.
                 <p className="text-xs text-destructive">영소문자, 숫자, 하이픈만 사용 가능합니다</p>
               ) : (
                 <p className="text-xs text-muted-foreground">sprintable.app/{orgSlug || '...'}</p>

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -138,8 +138,14 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
         return;
       }
       if (!res.ok) {
+        // story #2484 — code로 분기(backend auth.py resend_verification()이 _err()로
+        // 직접 발급하는 안정 값). 알려지지 않은 code만 안전 폴백.
         setResendState('error');
-        setResendError(json?.error?.message ?? t('resendFailed'));
+        if (json?.error?.code === 'USER_NOT_FOUND') {
+          setResendError(t('resendUserNotFound'));
+        } else {
+          setResendError(t('resendFailed'));
+        }
         return;
       }
       setResendState('sent');
@@ -172,12 +178,19 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
       const json = await res.json();
 
       if (!res.ok) {
-        if (json?.error?.code === 'UPGRADE_REQUIRED') {
-          setUpgradeReason(json.error.message);
+        // story #2484 — 실측(#2484 그라운딩): 이 분기는 'UPGRADE_REQUIRED'를 봤으나 backend
+        // projects.py create_project()는 그 코드를 절대 내지 않는다(존재하지 않는 문자열이라
+        // FastAPI 어디에도 없음 grep 확認) — organizations.py의 PLAN_LIMIT_EXCEEDED와 정확히
+        // 같은 클래스(resource:"project")를 실제로 낸다. 그래서 이 UpgradeModal 경로는 지금껏
+        // 한 번도 안 탄 죽은 분기였다(항상 아래 raw fallback으로 샜음). 코드를 바로잡는다.
+        if (json?.error?.code === 'PLAN_LIMIT_EXCEEDED') {
+          setUpgradeReason(t('projectLimitExceededError', { limit: json.error.limit ?? 1 }));
           setShowUpgrade(true);
           return;
         }
-        setError(json?.error?.message ?? t('createProjectFailed'));
+        // 그 외(400 Invalid slug format·409 Slug already exists 등 — 온보딩은 explicit slug를
+        // 안 보내 실질 도달 희박하나 방어적으로) code만 보고 raw message는 안 씀.
+        setError(t('createProjectFailed'));
         return;
       }
 
@@ -227,15 +240,17 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
           role: agentRole,
         }),
       });
-      const memberJson = await memberRes.json() as { data?: { id: string; api_key?: string }; error?: { message?: string } };
+      const memberJson = await memberRes.json() as { data?: { id: string; api_key?: string }; error?: { code?: string; message?: string } };
+      // story #2484 — 이 정확한 호출 형태(온보딩·human 호출자·user_id 없음)에서 도달 가능한
+      // 고유 code가 없어(그라운딩 확認) raw message 대신 통일된 안전 폴백만 사용.
       if (!memberRes.ok) {
-        setError(memberJson?.error?.message ?? 'Failed to create agent');
+        setError(t('createAgentFailed'));
         return;
       }
 
       const newAgentId = memberJson.data?.id;
       if (!newAgentId) {
-        setError('Failed to create agent');
+        setError(t('createAgentFailed'));
         return;
       }
       setAgentId(newAgentId);

--- a/apps/web/src/app/register/page.test.tsx
+++ b/apps/web/src/app/register/page.test.tsx
@@ -96,3 +96,53 @@ describe('RegisterPage (story #2469) — ko locale이 실제로 렌더된다(raw
     expect(container.textContent).toContain('Sign up');
   });
 });
+
+// story #2484 — error.code 분기 없이 json.error?.message를 그대로 쓰면 raw 서버 문자열이
+// 샌다. code가 있으면 번역 문구, 없으면 안전 폴백(registrationFailed)만 떠야 한다.
+describe('RegisterPage — error.code 분기 (story #2484)', () => {
+  async function fillAndSubmit() {
+    const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
+    const emailInput = container.querySelector('input[type="email"]') as HTMLInputElement;
+    const pwInput = container.querySelector('input[type="password"]') as HTMLInputElement;
+    const tosCheckbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    await act(async () => {
+      setNativeValue(nameInput, 'Test User');
+      setNativeValue(emailInput, 'a@b.com');
+      setNativeValue(pwInput, 'Abc123!!');
+      tosCheckbox.click();
+    });
+    const submitBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.register.submit);
+    await act(async () => {
+      submitBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('EMAIL_TAKEN — raw 영문 대신 번역 문구', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      json: async () => ({ error: { code: 'EMAIL_TAKEN', message: 'Email already registered' } }),
+    })));
+    await mount('ko');
+    await fillAndSubmit();
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl?.textContent).not.toContain('Email already registered');
+    expect(alertEl?.textContent).toBe(koMessages.register.registerEmailTaken);
+  });
+
+  it('알려지지 않은 code — 안전 폴백, raw message 미노출', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      json: async () => ({ error: { code: 'SOME_NEW_CODE', message: 'brand new raw string' } }),
+    })));
+    await mount('ko');
+    await fillAndSubmit();
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl?.textContent).not.toContain('brand new raw string');
+    expect(alertEl?.textContent).toBe(koMessages.register.registrationFailed);
+  });
+});

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -50,9 +50,17 @@ export default function RegisterPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email: email.trim(), password, display_name: displayName.trim(), tos_accepted: true }),
       });
-      const json = await res.json() as { data?: { ok: boolean }; error?: { message: string } };
+      const json = await res.json() as { data?: { ok: boolean }; error?: { code?: string; message: string } };
       if (!res.ok || !json.data?.ok) {
-        setError(json.error?.message ?? t('registrationFailed'));
+        // story #2484 — code로 분기(backend auth.py register()가 _err()로 직접 발급하는
+        // 안정 값). 알려지지 않은 code(pydantic 422 등)만 안전 폴백.
+        if (json.error?.code === 'EMAIL_TAKEN') {
+          setError(t('registerEmailTaken'));
+        } else if (json.error?.code === 'TOS_NOT_ACCEPTED') {
+          setError(t('registerTosRequired'));
+        } else {
+          setError(t('registrationFailed'));
+        }
         return;
       }
       const meRes = await fetch('/api/me');

--- a/apps/web/src/app/reset-password/page.test.tsx
+++ b/apps/web/src/app/reset-password/page.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+//
+// story #2484 — 재설정 실패가 error.code 분기 없이 json.error?.message(raw 서버 영문)를
+// 그대로 노출하던 자리. code별 번역 문구, 알려지지 않은 code는 안전 폴백만 떠야 한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams('token=tok-1'),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+async function mount() {
+  const { default: ResetPasswordPage } = await import('./page');
+  await act(async () => { root.render(wrap(<ResetPasswordPage />)); });
+}
+
+function setNativeValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+  setter.call(el, value);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+async function submit() {
+  const pwInput = container.querySelector('input[type="password"]') as HTMLInputElement;
+  await act(async () => { setNativeValue(pwInput, 'Abc123!!'); });
+  const submitBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.resetPassword.submit);
+  await act(async () => {
+    submitBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+  });
+}
+
+describe('ResetPasswordPage — error.code 분기 (story #2484)', () => {
+  it('INVALID_TOKEN — raw 영문 대신 번역 문구', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      json: async () => ({ error: { code: 'INVALID_TOKEN', message: 'Reset token is invalid or expired' } }),
+    })));
+    await mount();
+    await submit();
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl?.textContent).not.toContain('Reset token is invalid');
+    expect(alertEl?.textContent).toBe(koMessages.resetPassword.resetInvalidToken);
+  });
+
+  it('USER_NOT_FOUND — raw 영문 대신 번역 문구', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      json: async () => ({ error: { code: 'USER_NOT_FOUND', message: 'User not found' } }),
+    })));
+    await mount();
+    await submit();
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl?.textContent).not.toContain('User not found');
+    expect(alertEl?.textContent).toBe(koMessages.resetPassword.resetUserNotFound);
+  });
+
+  it('알려지지 않은 code — 안전 폴백, raw message 미노출', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      json: async () => ({ error: { code: 'SOME_NEW_CODE', message: 'brand new raw string' } }),
+    })));
+    await mount();
+    await submit();
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl?.textContent).not.toContain('brand new raw string');
+    expect(alertEl?.textContent).toBe(koMessages.resetPassword.submitFailed);
+  });
+});

--- a/apps/web/src/app/reset-password/page.tsx
+++ b/apps/web/src/app/reset-password/page.tsx
@@ -52,9 +52,17 @@ export default function ResetPasswordPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ token, new_password: password }),
       });
-      const json = await res.json() as { data?: { message: string; totp_enabled?: boolean }; error?: { message: string } };
+      const json = await res.json() as { data?: { message: string; totp_enabled?: boolean }; error?: { code?: string; message: string } };
       if (!res.ok) {
-        setError(json.error?.message ?? t('submitFailed'));
+        // story #2484 — code로 분기(backend auth.py reset_password()가 _err()로 직접
+        // 발급하는 안정 값). 알려지지 않은 code만 안전 폴백.
+        if (json.error?.code === 'INVALID_TOKEN') {
+          setError(t('resetInvalidToken'));
+        } else if (json.error?.code === 'USER_NOT_FOUND') {
+          setError(t('resetUserNotFound'));
+        } else {
+          setError(t('submitFailed'));
+        }
         return;
       }
       setTotpReenrollNeeded(shouldPromptTotpReenroll(FIREBASE_AUTH_ENABLED, json.data?.totp_enabled));

--- a/apps/web/src/app/verify-email/page.test.tsx
+++ b/apps/web/src/app/verify-email/page.test.tsx
@@ -38,6 +38,24 @@ async function mountAndWait() {
 }
 
 describe('VerifyEmailPage — error.code 분기 (story #2484)', () => {
+  it('성공(신규 인증) — raw 서버 문구 대신 한국어 문구(유나 design:changes 델타)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      json: async () => ({ data: { message: 'Email verified successfully' } }),
+    })));
+    await mountAndWait();
+    expect(container.textContent).not.toContain('Email verified successfully');
+    expect(container.textContent).toContain('이메일 인증이 완료되었습니다.');
+  });
+
+  it('성공(이미 인증됨) — raw 서버 문구 대신 동일 한국어 문구(유나 design:changes 델타)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      json: async () => ({ data: { message: 'Email already verified' } }),
+    })));
+    await mountAndWait();
+    expect(container.textContent).not.toContain('Email already verified');
+    expect(container.textContent).toContain('이메일 인증이 완료되었습니다.');
+  });
+
   it('INVALID_TOKEN — raw 영문 대신 한국어 문구', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({
       json: async () => ({ error: { code: 'INVALID_TOKEN', message: 'Verification link is invalid or expired' } }),

--- a/apps/web/src/app/verify-email/page.test.tsx
+++ b/apps/web/src/app/verify-email/page.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+//
+// story #2484 — 인증 실패가 error.code 분기 없이 json.error?.message(raw 서버 영문)를
+// 그대로 노출하던 자리. 이 페이지는 next-intl 미배선(전체 하드코딩 한국어)이라 인라인
+// 한국어 문자열로 code별 분기한다 — i18n 전면 전환은 이 스토리 스코프 밖(별도 관찰로 보고).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams('token=tok-1'),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+async function mountAndWait() {
+  const { default: VerifyEmailPage } = await import('./page');
+  await act(async () => { root.render(<VerifyEmailPage />); });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('VerifyEmailPage — error.code 분기 (story #2484)', () => {
+  it('INVALID_TOKEN — raw 영문 대신 한국어 문구', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      json: async () => ({ error: { code: 'INVALID_TOKEN', message: 'Verification link is invalid or expired' } }),
+    })));
+    await mountAndWait();
+    expect(container.textContent).not.toContain('Verification link is invalid');
+    expect(container.textContent).toContain('인증 링크가 유효하지 않거나 만료되었습니다.');
+  });
+
+  it('USER_NOT_FOUND — raw 영문 대신 한국어 문구', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      json: async () => ({ error: { code: 'USER_NOT_FOUND', message: 'User not found' } }),
+    })));
+    await mountAndWait();
+    expect(container.textContent).not.toContain('User not found');
+    expect(container.textContent).toContain('사용자를 찾을 수 없습니다.');
+  });
+
+  it('알려지지 않은 code — 안전 폴백, raw message 미노출', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      json: async () => ({ error: { code: 'SOME_NEW_CODE', message: 'brand new raw string' } }),
+    })));
+    await mountAndWait();
+    expect(container.textContent).not.toContain('brand new raw string');
+    expect(container.textContent).toContain('인증에 실패했습니다.');
+  });
+});

--- a/apps/web/src/app/verify-email/page.tsx
+++ b/apps/web/src/app/verify-email/page.tsx
@@ -26,13 +26,21 @@ export default function VerifyEmailPage() {
       body: JSON.stringify({ token }),
     })
       .then((res) => res.json())
-      .then((json: { data?: { message: string }; error?: { message: string } }) => {
+      .then((json: { data?: { message: string }; error?: { code?: string; message: string } }) => {
         if (json.data) {
           setStatus('success');
           setMessage(json.data.message);
         } else {
           setStatus('error');
-          setMessage(json.error?.message ?? '인증에 실패했습니다.');
+          // story #2484 — code로 분기(backend auth.py verify_email()이 _err()로 직접
+          // 발급하는 안정 값). 알려지지 않은 code만 안전 폴백(raw message 미노출).
+          if (json.error?.code === 'INVALID_TOKEN') {
+            setMessage('인증 링크가 유효하지 않거나 만료되었습니다.');
+          } else if (json.error?.code === 'USER_NOT_FOUND') {
+            setMessage('사용자를 찾을 수 없습니다.');
+          } else {
+            setMessage('인증에 실패했습니다.');
+          }
         }
       })
       .catch(() => {

--- a/apps/web/src/app/verify-email/page.tsx
+++ b/apps/web/src/app/verify-email/page.tsx
@@ -29,11 +29,18 @@ export default function VerifyEmailPage() {
       .then((json: { data?: { message: string }; error?: { code?: string; message: string } }) => {
         if (json.data) {
           setStatus('success');
-          setMessage(json.data.message);
+          // story #2484 — 유나 design:changes(2026-08-06): 성공 분기도 raw 서버 message를
+          // 그대로 노출했다("Email verified successfully"/"Email already verified" 둘
+          // 다 하드코딩 영문). 성공은 code가 없어 분기 불가하니 우리 자체 한국어 문구
+          // 하나로 통일한다(신규/기존 인증 둘 다 "인증됨" 결과는 동일하므로 구분 불요).
+          setMessage('이메일 인증이 완료되었습니다.');
         } else {
           setStatus('error');
           // story #2484 — code로 분기(backend auth.py verify_email()이 _err()로 직접
           // 발급하는 안정 값). 알려지지 않은 code만 안전 폴백(raw message 미노출).
+          // ⚠️Phase2 i18n·#2485 — 이 페이지가 next-intl 미배선이라 아래 문구도 하드코딩
+          // 한국어다(t() 아님, raw 서버 누수는 아님). #2484는 "raw 서버 노출 제거"만
+          // 스코프라 여기서 전면 i18n 전환은 안 함 — 유나 design 확認.
           if (json.error?.code === 'INVALID_TOKEN') {
             setMessage('인증 링크가 유효하지 않거나 만료되었습니다.');
           } else if (json.error?.code === 'USER_NOT_FOUND') {

--- a/apps/web/src/components/nav/create-organization-dialog.test.tsx
+++ b/apps/web/src/components/nav/create-organization-dialog.test.tsx
@@ -116,8 +116,25 @@ describe('CreateOrganizationDialog — PLAN_LIMIT_EXCEEDED envelope (story #2470
     await mount();
     await fillAndSubmit();
 
-    expect(document.body.textContent).toContain('Slug already exists');
+    // story #2484 — CONFLICT(=슬러그 중복)도 이제 code로 분기해 raw 영문 대신 번역 문구를
+    // 쓴다(이전엔 여기서 raw message가 그대로 노출됐음 — 회귀가드 겸함).
+    expect(document.body.textContent).not.toContain('Slug already exists');
+    expect(document.body.textContent).toContain('이미 사용 중인 슬러그입니다');
     expect(document.body.textContent).not.toContain('업그레이드가 필요합니다');
+  });
+
+  it('알려지지 않은 code — 안전 폴백, raw message 미노출 (story #2484)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      json: async () => ({ data: null, error: { code: 'SOME_NEW_CODE', message: 'brand new raw string' }, meta: null }),
+    })));
+
+    await mount();
+    await fillAndSubmit();
+
+    expect(document.body.textContent).not.toContain('brand new raw string');
+    expect(document.body.textContent).toContain('Organization을 만들지 못했습니다');
   });
 
   it('en locale에선 영문 배너로 렌더된다(회귀 없음)', async () => {

--- a/apps/web/src/components/nav/create-organization-dialog.tsx
+++ b/apps/web/src/components/nav/create-organization-dialog.tsx
@@ -105,7 +105,17 @@ export function CreateOrganizationDialog({
           setPlanLimitHit(true);
           return;
         }
-        setError(json.error?.message ?? (typeof json.detail === 'string' ? json.detail : null) ?? t('createOrgGenericError'));
+        // story #2484 — 잔여 폴백도 code로 분기(organizations.py create_organization()이
+        // 낼 수 있는 나머지: 400 "Invalid slug format"/409 "Slug already exists", 둘 다
+        // plain-string detail이라 제네릭 매핑됨). 알려지지 않은 code만 안전 폴백.
+        const code = json.error?.code ?? detail?.code;
+        if (code === 'CONFLICT') {
+          setError(t('createOrgSlugTaken'));
+        } else if (code === 'BAD_REQUEST') {
+          setError(t('createOrgSlugError'));
+        } else {
+          setError(t('createOrgGenericError'));
+        }
         return;
       }
       if (!json.data) {

--- a/apps/web/src/lib/invite-error-message.ts
+++ b/apps/web/src/lib/invite-error-message.ts
@@ -1,0 +1,38 @@
+/**
+ * story #2484 — 초대 수락/미리보기 실패의 error.code → i18n 문구 매핑을 한 곳에 둔다.
+ * invite/page.tsx(미리보기+수락)·invite-accept-client.tsx(수락) 세 자리가 같은 백엔드
+ * (backend/app/routers/invite_accept.py, plain-string HTTPException → 제네릭 코드로
+ * 매핑됨)를 보므로, 여기서 한 번만 갈라 2벌 번역 갈림을 막는다.
+ */
+import type { useTranslations } from 'next-intl';
+
+/** invite_accept.py가 실제로 낼 수 있는 코드 — 전부 plain-string detail이라 http_exception_handler가
+ * HTTP 상태로 제네릭 매핑한다(404→NOT_FOUND·409→CONFLICT·410→HTTP_410·403→FORBIDDEN·400→BAD_REQUEST). */
+export class InviteError extends Error {
+  readonly code: string | undefined;
+  constructor(code: string | undefined) {
+    super(code ?? 'INVITE_ERROR');
+    this.code = code;
+  }
+}
+
+export function inviteErrorMessage(
+  t: ReturnType<typeof useTranslations>,
+  code: string | undefined,
+  fallbackKey: string,
+): string {
+  switch (code) {
+    case 'NOT_FOUND':
+      return t('inviteNotFound');
+    case 'CONFLICT':
+      return t('inviteAlreadyAccepted');
+    case 'HTTP_410':
+      return t('inviteExpired');
+    case 'FORBIDDEN':
+      return t('inviteEmailMismatch');
+    case 'BAD_REQUEST':
+      return t('inviteCannotAccept');
+    default:
+      return t(fallbackKey);
+  }
+}


### PR DESCRIPTION
## 요약
FE가 서버 `error.code`를 안 갈라 raw 영문 `error.message`/`json.detail`을 그대로 화면에 노출하는 클래스가 #2441·#2470·create-organization-dialog로 **3번 반복**됨을 확인. 전수 그라운딩(30파일·55콜사이트 UNSAFE) 후 PO 결정대로 **Phase 1(최초경험·고가시성 경로)**만 이 PR에서 닫는다. Phase 2(설정/에이전트/칸반 등 40콜사이트 + 죽은 detail-필드)는 별건 #2485.

## 대상 (15콜사이트 / 9파일)
- `login/page.tsx` — Firebase 로그인·비밀번호 로그인(INVALID_CREDENTIALS·ACCOUNT_LOCKED·TOTP_LOCKED·INVALID_TOTP·TOTP_REPLAYED)
- `register/page.tsx` — EMAIL_TAKEN·TOS_NOT_ACCEPTED
- `reset-password/page.tsx` — INVALID_TOKEN·USER_NOT_FOUND
- `verify-email/page.tsx`·`mfa/page.tsx` — 동일 원칙(두 페이지는 next-intl 미배선이라 각자 기존 톤의 인라인 문자열로 분기)
- `invite/page.tsx` + `invite-accept-client.tsx` — 신규 공유 헬퍼 `src/lib/invite-error-message.ts`로 통일(NOT_FOUND/CONFLICT/HTTP_410/FORBIDDEN/BAD_REQUEST)
- `onboarding-form.tsx` — resend-verification 분기 + **create-agent i18n화**
- `create-organization-dialog.tsx` — #2470/#2482가 고친 PLAN_LIMIT_EXCEEDED 외 잔여(CONFLICT/BAD_REQUEST)

## ⭐그라운딩 중 발견한 실제 버그 (부수 발견)
`onboarding-form.tsx`의 create-project 분기가 `'UPGRADE_REQUIRED'`를 체크하고 있었으나, **backend는 그 코드를 절대 내지 않는다**(전체 FastAPI에 해당 문자열 자체가 없음 — grep 확인). 실제로는 `organizations.py`의 `PLAN_LIMIT_EXCEEDED`와 정확히 같은 클래스(`resource:"project"`)를 낸다. 이 UpgradeModal 경로는 **지금껏 한 번도 탄 적 없는 죽은 분기**였다 — 코드명을 바로잡았다.

⚠️ 그라운딩 중 `mfa/page.tsx`가 앱 내 어떤 링크·리다이렉트도 가리키지 않는 **고아 라우트**임을 확인(요청 스코프대로 동일 원칙은 적용).

## 재발가드 — advisory 넛지 (PO 確定: blocker 아님)
`verify-no-raw-error-message.ts` 신설 — `error.code` 분기 없이 raw message/detail을 쓰는 "단순형"(85%)을 grep으로 탐지. `raw-error-message-baseline.json`에 Phase 2 잔여 26개 파일(알려진 채무·의도적 예외·죽은 필드 오탐)을 등재해 제외. **항상 exit 0** — CI를 실패시키지 않고 로그로만 리뷰어에게 알린다.

## 게이트
- 신규/확장 vitest **47개**(9개 대상 파일 43개 + 가드 자체 4개) 전부 GREEN
- 뮤테이션 셀프체크 2건 — login raw-leak 재도입 → RED 확인 → 복원 / onboarding 죽은 코드명 재도입 → RED 확인 → 복원
- tsc/eslint 클린
- i18n missing-key 0, phrase-collision 신규 0
- **전체 apps/web vitest 372파일/2773개 GREEN(회귀 0)**
- `pnpm build` exit 0

## 스코프 밖
- Phase 2(#2485): settings/agents/kanban 등 40콜사이트 + 죽은 detail-필드(`rejected-relations-section`·`flow-epic-nodes`·`flow-multi-lane-canvas`)
- `epic-status-transition.tsx` — 의도적 raw 노출 정책(침묵 실패 방지), 건드리지 않음. 가드 baseline에만 등재.

🤖 Generated with [Claude Code](https://claude.com/claude-code)