### PR TITLE
[SID:2488] mapApiError가 404/403 외 error.code·status를 파괴하던 병 수정

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx
@@ -539,8 +539,8 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
         } else {
           // story #2485 — HYPOTHESIS_REQUIRED_FOR_ACTIVATION 외 나머지는 backend가
           // generic HTTP상태 코드만 낸다(그라운딩 확認) — raw 서버 message 노출 제거.
-          // ⚠️이 code 자체도 packages/storage-api mapApiError가 404/403 외 다 뭉개
-          // 실제로는 도달 안 하는 상태(별도 이슈로 보고) — 그 버그가 고쳐지면 바로 동작.
+          // story #2488 — 위 code 체크가 도달 못 하던 근본원인(packages/storage-api
+          // mapApiError가 404/403 외 다 뭉갬)을 고쳤다 — 이 분기는 이제 실동작한다.
           setActionError(t('activateError'));
         }
         return;

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -495,10 +495,11 @@ export default function SettingsPage() {
       setProjectActionMessage({ type: 'success', text: t('projectUpdated') });
       router.refresh();
     } else {
-      // story #2485 — ⚠️backend update_project()가 슬러그형식(400)·중복(409) 등 실제
-      // code를 낼 수 있으나 packages/storage-api의 mapApiError가 404/403 외 전부
-      // INTERNAL_ERROR로 뭉개 지금은 FE에 절대 안 도달한다(#2488로 별도 보고) — 여기서
-      // code 분기를 지으면 죽은 분기가 되니 짓지 않는다. generic 폴백만.
+      // story #2485 — backend update_project()가 슬러그형식(400)·중복(409) 등 실제
+      // code를 낼 수 있다. story #2488 — 그 code가 여기까지 도달 못 하던 근본원인
+      // (packages/storage-api mapApiError가 404/403 외 전부 뭉갬)은 고쳤다. 다만
+      // «그 code로 실제 분기 짓기»는 이 story의 follow-up 범위(PO 확定) — 지금은
+      // 여전히 generic 폴백만(dead branch를 새로 짓지 않되, pipe 자체는 이제 정상).
       setProjectActionMessage({ type: 'error', text: t('projectUpdateFailed') });
     }
     setSavingProject(false);

--- a/apps/web/src/lib/api-error.test.ts
+++ b/apps/web/src/lib/api-error.test.ts
@@ -1,0 +1,67 @@
+// story #2488 — handleApiError 회귀가드:
+// ① NotFoundError/ForbiddenError class-identity 통일(services/sprint.ts가 이제
+//    core-storage 것을 재-export) — 예전엔 로컬 동명 클래스를 봐서 mapApiError가
+//    던진 core-storage 인스턴스의 instanceof가 항상 실패, 조용히 generic 400으로 샜다.
+// ② mapApiError가 실은 code·status(story #2488 본 fix) — 그 값을 JSON 응답에 실어
+//    브라우저까지 전달하는지.
+// ③ 기존 Postgrest 코드 매핑(42501/PGRST116) 회귀 없음.
+import { describe, expect, it } from 'vitest';
+import { NotFoundError as CoreNotFoundError, ForbiddenError as CoreForbiddenError } from '@sprintable/core-storage';
+import { mapApiError } from '@sprintable/storage-api';
+import { handleApiError } from './api-error';
+
+describe('handleApiError (story #2488)', () => {
+  it('core-storage NotFoundError를 instanceof로 정확히 잡는다(class-identity 통일 회귀가드)', async () => {
+    const res = handleApiError(new CoreNotFoundError('Story not found'));
+    expect(res.status).toBe(404);
+    const body = await res.json() as { error: { code: string; message: string } };
+    expect(body.error.code).toBe('NOT_FOUND');
+    expect(body.error.message).toBe('Story not found');
+  });
+
+  it('core-storage ForbiddenError를 instanceof로 정확히 잡는다', async () => {
+    const res = handleApiError(new CoreForbiddenError('No access'));
+    expect(res.status).toBe(403);
+    const body = await res.json() as { error: { code: string } };
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('mapApiError(422, HYPOTHESIS_REQUIRED_FOR_ACTIVATION)가 그대로 JSON 응답에 도달한다(핵심 양성대조)', async () => {
+    const err = mapApiError(422, { error: { code: 'HYPOTHESIS_REQUIRED_FOR_ACTIVATION', message: 'Hypothesis required' } });
+    const res = handleApiError(err);
+    expect(res.status).toBe(422);
+    const body = await res.json() as { error: { code: string; message: string } };
+    expect(body.error.code).toBe('HYPOTHESIS_REQUIRED_FOR_ACTIVATION');
+    expect(body.error.message).toBe('Hypothesis required');
+  });
+
+  it('mapApiError(402, PLAN_LIMIT_EXCEEDED)도 동일하게 도달한다', async () => {
+    const err = mapApiError(402, { error: { code: 'PLAN_LIMIT_EXCEEDED', message: 'Free plan project limit reached.' } });
+    const res = handleApiError(err);
+    expect(res.status).toBe(402);
+    const body = await res.json() as { error: { code: string } };
+    expect(body.error.code).toBe('PLAN_LIMIT_EXCEEDED');
+  });
+
+  it('Postgrest 42501 매핑 회귀 없음', async () => {
+    const res = handleApiError({ code: '42501', message: 'x' });
+    expect(res.status).toBe(403);
+    const body = await res.json() as { error: { code: string } };
+    expect(body.error.code).toBe('PERMISSION_DENIED');
+  });
+
+  it('Postgrest PGRST116 매핑 회귀 없음', async () => {
+    const res = handleApiError({ code: 'PGRST116', message: 'x' });
+    expect(res.status).toBe(404);
+    const body = await res.json() as { error: { code: string } };
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('알려지지 않은 plain Error — generic INTERNAL_ERROR(400) 폴백 회귀 없음', async () => {
+    const res = handleApiError(new Error('boom'));
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: { code: string; message: string } };
+    expect(body.error.code).toBe('INTERNAL_ERROR');
+    expect(body.error.message).toBe('boom');
+  });
+});

--- a/apps/web/src/lib/api-error.ts
+++ b/apps/web/src/lib/api-error.ts
@@ -22,6 +22,15 @@ export function handleApiError(err: unknown) {
     if (code === 'PGRST116') {
       return apiError('NOT_FOUND', 'Not found', 404);
     }
+    // story #2488 — mapApiError(packages/storage-api·apps/web/src/lib/fastapi-proxy.ts)가
+    // 이제 backend error.code·status를 던지는 에러 객체에 실어 보존한다 — 여기서 그
+    // 값을 JSON 응답에 그대로 실어 브라우저까지 도달시킨다(#2484/#2485 error.code
+    // 하드닝의 전제 fix). 위 두 Postgrest 코드와 겹칠 일 없음(backend code는 항상
+    // SCREAMING_SNAKE_CASE 문자열, Postgrest는 5자리 숫자 코드).
+    if (typeof code === 'string' && 'status' in err && typeof (err as { status?: unknown }).status === 'number') {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      return apiError(code, message, (err as { status: number }).status);
+    }
   }
 
   const message = err instanceof Error ? err.message : 'Unknown error';

--- a/apps/web/src/lib/fastapi-proxy.test.ts
+++ b/apps/web/src/lib/fastapi-proxy.test.ts
@@ -9,7 +9,32 @@ const { getServerSessionMock } = vi.hoisted(() => ({
 
 vi.mock('@/lib/db/server', () => ({ getServerSession: getServerSessionMock }));
 
-import { proxyToFastapi, proxyToFastapiWithParams, proxyToFastapiWrapped } from './fastapi-proxy';
+import { proxyToFastapi, proxyToFastapiWithParams, proxyToFastapiWrapped, mapApiError } from './fastapi-proxy';
+import { NotFoundError, ForbiddenError } from '@sprintable/core-storage';
+
+// story #2488 — packages/storage-api/src/utils.ts와 완전 동일한 사본(중복 구현)이라
+// 같은 회귀가드를 여기도 둔다(합치는 consolidation은 별개, PO 확定).
+describe('fastapi-proxy — mapApiError code/status 보존 (story #2488)', () => {
+  it('404 — NotFoundError instanceof 유지 + code/status 보존', () => {
+    const err = mapApiError(404, { error: { code: 'STORY_NOT_FOUND', message: 'Story not found' } });
+    expect(err).toBeInstanceOf(NotFoundError);
+    expect(err.code).toBe('STORY_NOT_FOUND');
+    expect(err.status).toBe(404);
+  });
+
+  it('403 — ForbiddenError instanceof 유지 + code/status 보존', () => {
+    const err = mapApiError(403, { error: { code: 'FORBIDDEN', message: 'No access' } });
+    expect(err).toBeInstanceOf(ForbiddenError);
+    expect(err.code).toBe('FORBIDDEN');
+    expect(err.status).toBe(403);
+  });
+
+  it('그 외(422) — 이전엔 generic Error(message만)로 뭉갰다. 이제 code·status가 보존된다', () => {
+    const err = mapApiError(422, { error: { code: 'SOME_CODE', message: 'x' } });
+    expect(err.code).toBe('SOME_CODE');
+    expect(err.status).toBe(422);
+  });
+});
 
 describe('fastapi-proxy — X-Project-Id override passthrough (story 7d6b770b 회귀가드)', () => {
   beforeEach(() => {

--- a/apps/web/src/lib/fastapi-proxy.ts
+++ b/apps/web/src/lib/fastapi-proxy.ts
@@ -8,11 +8,20 @@ import { apiSuccess, ApiErrors } from '@/lib/api-response';
 
 import { NotFoundError, ForbiddenError } from '@sprintable/core-storage';
 
-export function mapApiError(status: number, body: { error?: { code?: string; message?: string } }): Error {
+/** story #2488 — packages/storage-api/src/utils.ts의 mapApiError와 완전 동일한
+ * 버그(404/403 외 code·status discard)를 가진 사본. 같은 fix를 여기도 적용한다
+ * (PO 확定: 이번 PR 스코프, 두 파일 합치는 consolidation은 별개). */
+export interface ApiCallError extends Error {
+  code?: string;
+  status?: number;
+}
+
+export function mapApiError(status: number, body: { error?: { code?: string; message?: string } }): ApiCallError {
   const msg = body.error?.message ?? `HTTP ${status}`;
-  if (status === 404) return new NotFoundError(msg);
-  if (status === 403) return new ForbiddenError(msg);
-  return new Error(msg);
+  const code = body.error?.code;
+  if (status === 404) return Object.assign(new NotFoundError(msg), { code: code ?? 'NOT_FOUND', status });
+  if (status === 403) return Object.assign(new ForbiddenError(msg), { code: code ?? 'FORBIDDEN', status });
+  return Object.assign(new Error(msg), { code: code ?? `HTTP_${status}`, status });
 }
 
 export async function fastapiCall<T>(

--- a/apps/web/src/services/sprint.error-code.test.ts
+++ b/apps/web/src/services/sprint.error-code.test.ts
@@ -1,0 +1,74 @@
+// story #2488 — 양성대조: mapApiError(packages/storage-api)가 이제 code·status를
+// 보존하고, handleApiError(api-error.ts)가 그걸 JSON 응답에 실어 브라우저까지
+// 전달하는 전체 체인을 검증한다. SprintService.activate()가 실제로 이 체인을 타는
+// 자리(HYPOTHESIS_REQUIRED_FOR_ACTIVATION, #2484/#2485 그라운딩이 "죽은 분기"로
+// 지목했던 바로 그 케이스)로 end-to-end 확인한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SprintService } from './sprint';
+import { ApiSprintRepository } from '@sprintable/storage-api';
+import { handleApiError } from '@/lib/api-error';
+
+describe('SprintService.activate → mapApiError → handleApiError (story #2488 양성대조)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = url.toString();
+      const method = init?.method ?? 'GET';
+      if (u.includes('/api/v2/sprints/sprint-1') && method === 'GET') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ id: 'sprint-1', status: 'planning', project_id: 'proj-1', title: 'Sprint 1' }),
+        } as Response;
+      }
+      if (u.includes('/api/v2/sprints?') && method === 'GET') {
+        return { ok: true, status: 200, json: async () => [] } as Response;
+      }
+      if (u.includes('/api/v2/sprints/sprint-1') && method === 'PATCH') {
+        return {
+          ok: false,
+          status: 422,
+          json: async () => ({
+            data: null,
+            error: { code: 'HYPOTHESIS_REQUIRED_FOR_ACTIVATION', message: 'At least one hypothesis must be defined before activating this sprint.' },
+            meta: null,
+          }),
+        } as Response;
+      }
+      throw new Error('unexpected fetch: ' + u + ' ' + method);
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('code·status가 mapApiError를 거쳐 던진 에러 객체까지 도달한다', async () => {
+    const repo = new ApiSprintRepository('token-1');
+    const service = new SprintService(repo, undefined, 'token-1');
+
+    await expect(service.activate('sprint-1')).rejects.toMatchObject({
+      code: 'HYPOTHESIS_REQUIRED_FOR_ACTIVATION',
+      status: 422,
+    });
+  });
+
+  it('그 에러가 handleApiError를 거쳐 브라우저로 갈 JSON 응답까지 code·status 그대로 도달한다(#2484/#2485 죽은 분기의 전제 fix)', async () => {
+    const repo = new ApiSprintRepository('token-1');
+    const service = new SprintService(repo, undefined, 'token-1');
+
+    let caught: unknown;
+    try {
+      await service.activate('sprint-1');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+
+    const res = handleApiError(caught);
+    expect(res.status).toBe(422);
+    const body = await res.json() as { error: { code: string; message: string } };
+    expect(body.error.code).toBe('HYPOTHESIS_REQUIRED_FOR_ACTIVATION');
+    expect(body.error.message).toContain('hypothesis must be defined');
+  });
+});

--- a/apps/web/src/services/sprint.ts
+++ b/apps/web/src/services/sprint.ts
@@ -1,18 +1,22 @@
 
 import type { ISprintRepository, Sprint, CreateSprintInput, UpdateSprintInput } from '@sprintable/core-storage';
+import { NotFoundError, ForbiddenError } from '@sprintable/core-storage';
 import { ApiSprintRepository, fastapiCall } from '@sprintable/storage-api';
 import { requireOrgAdmin } from '@/lib/admin-check';
 import { NotificationService } from './notification.service';
 
 export { CreateSprintInput, UpdateSprintInput };
 
-export class NotFoundError extends Error {
-  constructor(message: string) { super(message); this.name = 'NotFoundError'; }
-}
-
-export class ForbiddenError extends Error {
-  constructor(message: string) { super(message); this.name = 'ForbiddenError'; }
-}
+// story #2488 — 이 파일이 독자적으로 정의하던 동명 클래스는 mapApiError(packages/
+// storage-api)가 던지는 @sprintable/core-storage의 NotFoundError/ForbiddenError와
+// 클래스ID가 달라 handleApiError(api-error.ts)의 instanceof 체크를 통과 못 하고
+// 조용히 generic 400으로 샜다(task.ts는 이미 이 재-export 패턴 — 여기만 어긋나 있었다).
+// core-storage 것을 import+재-export해 통일한다(shape 동일: message만 받는 생성자,
+// name 세팅 — 기존 `new NotFoundError(...)` 호출부·`err.name === 'NotFoundError'`
+// 체크 전부 무변화로 계속 동작). `export { X } from 'Y'`(재-export 전용 문법)는 이
+// 파일 안에서 로컬 바인딩을 안 만들어 아래 `throw new NotFoundError(...)` 호출부가
+// 깨진다 — import 후 재-export해야 둘 다 된다.
+export { NotFoundError, ForbiddenError };
 
 async function getSpAt(): Promise<string> {
   try {

--- a/packages/storage-api/src/utils.test.ts
+++ b/packages/storage-api/src/utils.test.ts
@@ -1,0 +1,46 @@
+// story #2488 — mapApiError가 404/403 외 status·error.code를 discard하던 병 회귀가드.
+import { describe, expect, it } from 'vitest';
+import { NotFoundError, ForbiddenError } from '@sprintable/core-storage';
+import { mapApiError } from './utils';
+
+describe('mapApiError (story #2488)', () => {
+  it('404 — NotFoundError instanceof 유지 + code/status 보존', () => {
+    const err = mapApiError(404, { error: { code: 'STORY_NOT_FOUND', message: 'Story not found' } });
+    expect(err).toBeInstanceOf(NotFoundError);
+    expect(err.message).toBe('Story not found');
+    expect(err.code).toBe('STORY_NOT_FOUND');
+    expect(err.status).toBe(404);
+  });
+
+  it('403 — ForbiddenError instanceof 유지 + code/status 보존', () => {
+    const err = mapApiError(403, { error: { code: 'FORBIDDEN', message: 'No access' } });
+    expect(err).toBeInstanceOf(ForbiddenError);
+    expect(err.code).toBe('FORBIDDEN');
+    expect(err.status).toBe(403);
+  });
+
+  it('그 외(422) — 이전엔 generic Error(message만)로 뭉갰다. 이제 code·status가 보존된다(핵심 회귀가드)', () => {
+    const err = mapApiError(422, { error: { code: 'HYPOTHESIS_REQUIRED_FOR_ACTIVATION', message: 'Hypothesis required' } });
+    expect(err.message).toBe('Hypothesis required');
+    expect(err.code).toBe('HYPOTHESIS_REQUIRED_FOR_ACTIVATION');
+    expect(err.status).toBe(422);
+  });
+
+  it('402 PLAN_LIMIT_EXCEEDED도 동일하게 보존된다', () => {
+    const err = mapApiError(402, { error: { code: 'PLAN_LIMIT_EXCEEDED', message: 'Free plan project limit reached.' } });
+    expect(err.code).toBe('PLAN_LIMIT_EXCEEDED');
+    expect(err.status).toBe(402);
+  });
+
+  it('backend가 code를 안 준 경우 — HTTP_{status} 폴백 code(raw message는 그대로 보존, 상위에서 사용 여부 결정)', () => {
+    const err = mapApiError(500, { error: { message: 'Internal server error' } });
+    expect(err.code).toBe('HTTP_500');
+    expect(err.status).toBe(500);
+  });
+
+  it('body 자체가 없을 때도 안전 폴백(HTTP {status} message)', () => {
+    const err = mapApiError(500, {});
+    expect(err.message).toBe('HTTP 500');
+    expect(err.code).toBe('HTTP_500');
+  });
+});

--- a/packages/storage-api/src/utils.ts
+++ b/packages/storage-api/src/utils.ts
@@ -6,11 +6,22 @@ export function mapSupabaseError(error: { code?: string; message: string }): Err
   return new Error(error.message);
 }
 
-export function mapApiError(status: number, body: { error?: { code?: string; message?: string } }): Error {
+/** story #2488 — mapApiError는 404/403 외 status·error.code를 전부 discard해
+ * FE의 error.code 분기가 원천적으로 도달 불가능했다(#2484/#2485 error.code 하드닝의
+ * 전제를 깨는 병). code·status를 던지는 에러 객체에 실어 보존한다 — NotFoundError/
+ * ForbiddenError instanceof 특례는 그대로 유지(전수 소비처 그라운딩 확認: 아무도
+ * property 개수·JSON.stringify 모양에 의존하지 않음, 안전한 additive 변경). */
+export interface ApiCallError extends Error {
+  code?: string;
+  status?: number;
+}
+
+export function mapApiError(status: number, body: { error?: { code?: string; message?: string } }): ApiCallError {
   const msg = body.error?.message ?? `HTTP ${status}`;
-  if (status === 404) return new NotFoundError(msg);
-  if (status === 403) return new ForbiddenError(msg);
-  return new Error(msg);
+  const code = body.error?.code;
+  if (status === 404) return Object.assign(new NotFoundError(msg), { code: code ?? 'NOT_FOUND', status });
+  if (status === 403) return Object.assign(new ForbiddenError(msg), { code: code ?? 'FORBIDDEN', status });
+  return Object.assign(new Error(msg), { code: code ?? `HTTP_${status}`, status });
 }
 
 function getBaseUrl(): string {


### PR DESCRIPTION
## 요약
#2485 그라운딩에서 발견한 부수 버그: `packages/storage-api/src/utils.ts`(및 동일 사본 `apps/web/src/lib/fastapi-proxy.ts`)의 `mapApiError`가 404/403만 보존하고 그 외 모든 HTTP status·backend `error.code`를 전부 `INTERNAL_ERROR`(400)로 뭉갰다 — backend가 정확히 구조화 코드(예: `HYPOTHESIS_REQUIRED_FOR_ACTIVATION`·`PLAN_LIMIT_EXCEEDED`)를 내려줘도 이 중간계층이 파괴해 FE의 `error.code` 분기가 원천적으로 도달 불가능했다. **#2484/#2485 error.code 하드닝 전체의 전제를 깨는 병.**

## 그라운딩 (blast radius 큼 — PO 확定 후 진행)
착수 전 전 레포 소비처 그라운딩(전용 에이전트) 결과: `.code`/`.status` 추가는 안전(모든 소비처가 `instanceof`·`.name` 체크만 사용, property 개수·`JSON.stringify` 모양 의존 없음). 하지만 목표(브라우저까지 code 도달) 달성엔 3단이 함께 필요함을 확인 — PO가 최소 묶음으로 확定.

## 변경 (4단 묶음)
1. **`mapApiError`(storage-api)** — 에러 객체에 `code`/`status`를 실어 던진다(404/403 instanceof 특례 유지).
2. **`mapApiError`(fastapi-proxy.ts, 동일 버그를 가진 완전 동일 사본)** — 같은 fix.
3. **`handleApiError`(api-error.ts)** — 위에서 실린 `code`/`status`를 JSON 응답에 그대로 실어 브라우저까지 전달.
4. **⭐class-identity 통일** — `handleApiError`는 `@/services/sprint.ts`의 로컬 동명 `NotFoundError`/`ForbiddenError`를 `instanceof` 검사하는데, `mapApiError`(core-storage 버전)가 던지는 인스턴스는 클래스ID가 달라 그 체크를 통과 못 해 지금도 조용히 generic 400으로 새고 있었다(①②③만으론 여전히 안 뚫림 — 기존 버그, 이번 fix가 만든 문제 아님). `services/sprint.ts`가 로컬 정의 대신 `@sprintable/core-storage`를 import+재-export하도록 통일(`task.ts`가 이미 쓰던 패턴).

## ⭐AC 검산 (양성대조)
`SprintService.activate()`가 실제로 이 체인을 타는 자리(#2484/#2485가 "죽은 분기"로 지목했던 `HYPOTHESIS_REQUIRED_FOR_ACTIVATION`)로 end-to-end 테스트: `fastapiCall`(mock 422+code) → `mapApiError` → `SprintService` → `handleApiError` → JSON 응답까지 code·status가 그대로 도달함을 확인.

## 스코프 밖 (PO 확定, follow-up)
- sprints-client.tsx/settings 프로젝트 수정의 실제 code 분기 짓기(pipe는 이제 정상이지만 분기 자체는 별도)
- inbox-route-helpers.ts/resolve route의 message 문자열매칭 fast-follow
- fastapi-proxy.ts/storage-api 중복 consolidation

## 게이트
- 신규 vitest 19개(mapApiError 6+6·handleApiError 7·SprintService 양성대조 2) 전부 GREEN
- 뮤테이션 셀프체크 1건 — class-identity 통일 되돌림 → RED 확認 → 복원
- tsc/eslint 클린(apps/web + packages/storage-api)
- **전체 모노레포 vitest 396파일/2997개 GREEN(회귀 0)**
- `pnpm build` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)