### PR TITLE
[SID:2489] #2488 후속 — settings 프로젝트 수정 error.code 분기 활성화

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1137,6 +1137,8 @@
     },
     "projectUpdated": "Project updated.",
     "projectUpdateFailed": "Failed to update project.",
+    "projectSlugTaken": "This slug is already taken.",
+    "projectSlugInvalid": "The slug format is invalid.",
     "deleteProject": "Delete",
     "projectDeleted": "Project deleted.",
     "projectDeleteFailed": "Failed to delete project.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1137,6 +1137,8 @@
     },
     "projectUpdated": "프로젝트가 업데이트되었습니다.",
     "projectUpdateFailed": "프로젝트 업데이트에 실패했습니다.",
+    "projectSlugTaken": "이미 사용 중인 슬러그입니다.",
+    "projectSlugInvalid": "슬러그 형식이 올바르지 않습니다.",
     "deleteProject": "삭제",
     "projectDeleted": "프로젝트를 삭제했습니다.",
     "projectDeleteFailed": "프로젝트 삭제에 실패했습니다.",

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -495,12 +495,19 @@ export default function SettingsPage() {
       setProjectActionMessage({ type: 'success', text: t('projectUpdated') });
       router.refresh();
     } else {
-      // story #2485 — backend update_project()가 슬러그형식(400)·중복(409) 등 실제
-      // code를 낼 수 있다. story #2488 — 그 code가 여기까지 도달 못 하던 근본원인
-      // (packages/storage-api mapApiError가 404/403 외 전부 뭉갬)은 고쳤다. 다만
-      // «그 code로 실제 분기 짓기»는 이 story의 follow-up 범위(PO 확定) — 지금은
-      // 여전히 generic 폴백만(dead branch를 새로 짓지 않되, pipe 자체는 이제 정상).
-      setProjectActionMessage({ type: 'error', text: t('projectUpdateFailed') });
+      // story #2485 — backend update_project()는 슬러그형식(400→BAD_REQUEST)·중복
+      // (409→CONFLICT) plain-string 에러를 낸다(dict-coded 아니라 진짜 business code는
+      // 없음, generic HTTP상태 매핑만). story #2488 전엔 packages/storage-api의
+      // mapApiError가 404/403 외 전부 뭉개 이 code 자체가 여기 도달 못 했다 — 그 pipe를
+      // #2488이 고쳐 이제 실분기 가능(#2489, 이 story가 그 follow-up).
+      const json = await res.json().catch(() => null) as { error?: { code?: string } } | null;
+      if (json?.error?.code === 'CONFLICT') {
+        setProjectActionMessage({ type: 'error', text: t('projectSlugTaken') });
+      } else if (json?.error?.code === 'BAD_REQUEST') {
+        setProjectActionMessage({ type: 'error', text: t('projectSlugInvalid') });
+      } else {
+        setProjectActionMessage({ type: 'error', text: t('projectUpdateFailed') });
+      }
     }
     setSavingProject(false);
   };


### PR DESCRIPTION
## 요약
#2488(mapApiError 파이프 fix)이 머지되면서 #2485가 "죽은 분기라 못 짓는다"로 미뤄뒀던 자리를 그라운딩 후 실분기화. PO 지시(idle-슬롯 페이스) — error.code 이니셔티브를 end-to-end로 닫는 작은 마무리 PR.

## 그라운딩 결과 & 변경
- **settings/page.tsx handleSaveProject(프로젝트 수정)** — backend `update_project()`가 400 "Invalid slug format"·409 "Slug already exists" plain-string 에러(→ generic `BAD_REQUEST`/`CONFLICT` 코드 매핑)를 낸다. #2488 전엔 이 code 자체가 여기 도달 못 했다 — 이제 `CONFLICT`→`projectSlugTaken`, `BAD_REQUEST`→`projectSlugInvalid`로 분기(신규 i18n 키 2개, create-organization-dialog #2470/#2482의 동일 클래스 문구 재사용 톤).
- **sprints-client.tsx handleActivate** — 코드 변경 없음. `HYPOTHESIS_REQUIRED_FOR_ACTIVATION` 체크는 #2485에서 이미 작성돼 있었고, #2488이 파이프를 고쳐 이제 실동작한다(재검증만, #2488 PR에서 주석 이미 갱신 완료).
- **settings/page.tsx handleDeleteProject(프로젝트 삭제)** — 그라운딩 결과 스코프 제외: backend `delete_project()`는 404·403(두 원인, 구분 코드 없음)만 내고 이 경로는 mapApiError 버그의 영향을 받은 적이 없다(항상 instanceof로 정상 도달) — 분기 추가 불필요, 현행 generic 폴백이 맞다.

## 게이트
- tsc/eslint 클린
- i18n missing 0 / phrase-collision 신규 0
- 전체 모노레포 vitest 396파일/2997개 GREEN(회귀 0)
- `pnpm build` exit 0

settings/page.tsx는 기존 테스트 하네스가 전혀 없는 대형 컴포넌트라(신규 하네스 구축은 이 좁은 변경 대비 불균형) 전용 유닛테스트는 생략 — #2470/#2482에서 이미 검증된 동일 패턴(code 분기 + 기존 i18n 키 재사용 톤)의 반복 적용이라 라이브 QA로 확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)