### PR TITLE
fix(role-templates): stop gating org-wide catalog on project-access

### DIFF
--- a/backend/app/routers/role_templates.py
+++ b/backend/app/routers/role_templates.py
@@ -26,7 +26,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import get_current_user, get_verified_org_id
+from app.dependencies.auth import get_current_user
 from app.dependencies.database import get_db
 from app.models.role_template import RoleTemplate
 from app.schemas.a2a import AgentSkill
@@ -122,10 +122,18 @@ async def list_role_templates(
     locale: str | None = None,
     accept_language: str | None = Header(None, alias="Accept-Language"),
     session: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(get_verified_org_id),
     _auth=Depends(get_current_user),
 ) -> list[RoleTemplateSummary]:
     """발행된(is_published) role_template 카탈로그 — org/project 무관 전역 조회.
+
+    story #2486 후속(그라운딩 2026-08-06): ``get_verified_org_id``를 썼었는데, 이 엔드포인트는
+    org_id를 실제로 쓰지 않는다(RoleTemplate 모델 자체가 org_id/project_id 없는 전역 카탈로그 —
+    pricing_versions와 동형). 그런데 ``get_verified_org_id``는 ``X-Project-Id`` 헤더가 오면
+    project 멤버십을 강제하는 부작용이 있어(FE ``fastapi-proxy.ts``가 모든 BFF 프록시 호출에
+    브라우저 탭의 "effective project"를 무조건 실어 보냄), org owner라도 그 탭이 자기가 속하지
+    않은 프로젝트를 가리키고 있으면 이 org-wide 카탈로그 조회가 403으로 막혔다(라이브 재현:
+    org owner가 role-catalog를 못 열어 채용 위저드 1단계 자체가 막힘). ``get_current_user``만
+    남겨 로그인 여부만 확인 — org/project 스코프는 애초에 이 리소스와 무관.
 
     Header() DI 마커는 라우트 경계에서만 받고 실 로직은 ``_list_role_templates()``(plain
     str만)로 위임 — 직접-호출 realdb 테스트가 ASGI 파이프라인 없이도 Header sentinel leak
@@ -153,11 +161,11 @@ async def get_role_template(
     locale: str | None = None,
     accept_language: str | None = Header(None, alias="Accept-Language"),
     session: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(get_verified_org_id),
     _auth=Depends(get_current_user),
 ) -> RoleTemplateDetail:
     """단건 조회 — Header() DI 마커는 라우트 경계에서만, 실 로직은 ``_get_role_template()``
-    (plain str)로 위임(위 list와 동일 이유)."""
+    (plain str)로 위임(위 list와 동일 이유). org_id 미의존 사유는 ``list_role_templates``
+    docstring 참고(동일 근본)."""
     return await _get_role_template(slug, session=session, locale=locale, accept_language=accept_language)
 
 

--- a/backend/tests/test_e_recruit_s1_role_templates.py
+++ b/backend/tests/test_e_recruit_s1_role_templates.py
@@ -495,14 +495,13 @@ async def test_role_templates_still_401_without_auth_http(mock_session):
     ``get_current_user``(Authorization 헤더 없으면 401)를 그대로 태운다."""
     from httpx import ASGITransport, AsyncClient
 
-    from app.dependencies.database import get_db, get_read_db
     from app.main import app
+    from tests.conftest import override_db_and_read
 
     async def _override_db():
         yield mock_session
 
-    app.dependency_overrides[get_db] = _override_db
-    app.dependency_overrides[get_read_db] = _override_db
+    override_db_and_read(app, _override_db)
     try:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             list_resp = await client.get("/api/v2/role-templates")

--- a/backend/tests/test_e_recruit_s1_role_templates.py
+++ b/backend/tests/test_e_recruit_s1_role_templates.py
@@ -468,3 +468,20 @@ async def test_list_role_templates_ignores_inaccessible_x_project_id_http(test_c
         "/api/v2/role-templates", headers={"X-Project-Id": inaccessible_project_id}
     )
     assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_get_role_template_ignores_inaccessible_x_project_id_http(test_client, mock_session):
+    """위 list 회귀 테스트의 단건-조회 짝 — PO 확인 요청(2026-08-06): «role_templates 두
+    엔드포인트 다 커버됐는지». ``/{slug}``도 동일하게 ``get_verified_org_id``를 뺐으니
+    비접근 X-Project-Id로도 200이어야 한다."""
+    import uuid
+    from unittest.mock import AsyncMock
+
+    rt = _mock_role_template()
+    mock_session.execute = AsyncMock(return_value=_scalar_result(rt))
+    inaccessible_project_id = str(uuid.uuid4())
+    resp = await test_client.get(
+        "/api/v2/role-templates/http-probe", headers={"X-Project-Id": inaccessible_project_id}
+    )
+    assert resp.status_code == 200

--- a/backend/tests/test_e_recruit_s1_role_templates.py
+++ b/backend/tests/test_e_recruit_s1_role_templates.py
@@ -447,3 +447,24 @@ async def test_list_role_templates_locale_query_param_http(test_client, mock_ses
     body = resp.json()
     assert body[0]["division"] == "엔지니어링"
     assert body[0]["description"] == "한글 설명"
+
+
+@pytest.mark.anyio
+async def test_list_role_templates_ignores_inaccessible_x_project_id_http(test_client, mock_session):
+    """story #2486 그라운딩(2026-08-06) 회귀 고정 — org owner라도 브라우저 탭의 effective
+    project(X-Project-Id)가 자기가 속하지 않은 프로젝트를 가리키면 이 org-wide 카탈로그가
+    403으로 막혔다(``get_verified_org_id``의 project-membership 부작용). role_templates는
+    org_id/project_id 없는 전역 카탈로그라 이 헤더와 무관해야 — 임의(비접근) project_id를
+    실어 보내도 여전히 200이어야 한다."""
+    import uuid
+    from unittest.mock import AsyncMock, MagicMock
+
+    rt = _mock_role_template()
+    res = MagicMock()
+    res.scalars.return_value.all.return_value = [rt]
+    mock_session.execute = AsyncMock(return_value=res)
+    inaccessible_project_id = str(uuid.uuid4())
+    resp = await test_client.get(
+        "/api/v2/role-templates", headers={"X-Project-Id": inaccessible_project_id}
+    )
+    assert resp.status_code == 200

--- a/backend/tests/test_e_recruit_s1_role_templates.py
+++ b/backend/tests/test_e_recruit_s1_role_templates.py
@@ -485,3 +485,30 @@ async def test_get_role_template_ignores_inaccessible_x_project_id_http(test_cli
         "/api/v2/role-templates/http-probe", headers={"X-Project-Id": inaccessible_project_id}
     )
     assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_role_templates_still_401_without_auth_http(mock_session):
+    """PO QA 급소 지적(2026-08-06): ``get_verified_org_id``를 뺀 게 project-gating만 제거한
+    것이지 로그인 자체를 열어버린 게 아님을 pin — ``test_client`` fixture는 ``get_current_user``
+    를 항상 override하므로 이 케이스를 못 본다. 여기서만 그 override를 빼고 실제
+    ``get_current_user``(Authorization 헤더 없으면 401)를 그대로 태운다."""
+    from httpx import ASGITransport, AsyncClient
+
+    from app.dependencies.database import get_db, get_read_db
+    from app.main import app
+
+    async def _override_db():
+        yield mock_session
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_read_db] = _override_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            list_resp = await client.get("/api/v2/role-templates")
+            detail_resp = await client.get("/api/v2/role-templates/http-probe")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert list_resp.status_code == 401
+    assert detail_resp.status_code == 401


### PR DESCRIPTION
## Summary
- `GET /api/v2/role-templates` and `GET /api/v2/role-templates/{slug}` depended on `get_verified_org_id` purely to obtain `org_id`, which the query never uses — `RoleTemplate` has no `org_id`/`project_id` column (a global catalog, same as `pricing_versions`).
- `get_verified_org_id` enforces `has_project_access` whenever an `X-Project-Id` header is present, and the web BFF (`fastapi-proxy.ts`) always forwards the browser tab's "effective project" header on every proxied call.
- Result: an org owner/admin whose active tab pointed at a project they don't belong to got 403 `"No access to the specified project"` on the role catalog — blocking step 1 of the agent-recruit wizard entirely. Live-reproduced 2026-08-06 (story #2486 grounding, dev).
- Fix: drop the dependency, keep `get_current_user` only (same pattern already used by `release_notes.py`, another org/project-agnostic catalog router).

## Test plan
- [x] `pytest backend/tests/test_e_recruit_s1_role_templates.py` — 10 passed, 11 skipped (realdb-only)
- [x] New regression test `test_list_role_templates_ignores_inaccessible_x_project_id_http` — asserts 200 even with an inaccessible `X-Project-Id` header
- [x] `pytest backend/tests/test_role_template_catalog_s1_schema.py backend/tests/test_role_templates_marketing_roster.py backend/tests/test_e_recruit_s3_recruit_endpoint.py` — 25 passed
- [x] `python scripts/lint_project_access_403.py` — 0 new violations (baseline unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)