### PR TITLE
fix(agents): stop gating agent-management endpoints on tab X-Project-Id

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -499,17 +499,14 @@ def require_api_scope(required_scope: str):
     return _check
 
 
-async def get_verified_org_id(
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
-    x_project_id: str | None = Header(default=None, alias="X-Project-Id"),
-    request: Request = None,
+async def _resolve_verified_org_id(
+    auth: AuthContext,
+    x_org_id: str | None,
+    request: Request | None,
 ) -> uuid.UUID:
-    """org_id 추출 — X-Org-Id 헤더 fallback 시 DB membership 검증, X-Project-Id 헤더 시 project 소속 검증.
-    API Key 경로는 HTTP method 기반 scope 자동 체크.
-
-    story #2459(§6 봉합①): 요청-수명 ``Depends(get_db)`` 대신 검증마다 전용 단명 세션 —
-    get_current_user와 동일 근거(호출 대상이 전부 읽기 전용, #2457로 이미 성립)."""
+    """``get_verified_org_id``/``get_verified_org_id_no_project_gate`` 공유 atom — X-Org-Id 헤더
+    fallback 시 DB membership 검증까지의 org_id 해소. X-Project-Id 프로젝트-멤버십 체크는
+    여기 없다(호출부가 필요할 때만 추가로 얹는다 — 아래 두 함수 참고)."""
     # API Key scope 체크 (request 있을 때만 — 직접 단위 테스트 호출 시 스킵)
     if request is not None:
         _check_api_key_scope(auth, request.method, request.url.path)
@@ -531,6 +528,43 @@ async def get_verified_org_id(
         # 헤더 사용 시 항상 membership 검증 (JWT org_id와 다를 수 있음)
         async with async_session_factory() as db:
             await _verify_org_membership(auth.user_id, org_id, db, request)
+
+    return org_id
+
+
+async def get_verified_org_id_no_project_gate(
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    request: Request = None,
+) -> uuid.UUID:
+    """org_id 추출 — ``get_verified_org_id``와 org 해소/membership 검증은 동일하나,
+    X-Project-Id 헤더가 있어도 project-membership 을 검사하지 **않는다**.
+
+    story #2486 그라운딩(2026-08-06) — role_templates 에 이어 ``agents.py`` 라우터에서도
+    재현: BFF(``fastapi-proxy.ts``)가 모든 프록시 호출에 브라우저 탭의 "effective project"를
+    X-Project-Id 로 무조건 실어 보내는데, ``agents.py`` 6개 엔드포인트(생성/recruit/
+    connection-artifact/verify-connection/verification-status/access-matrix)는 전부 agent_id
+    소유권(``assert_agent_owner``)·요청 body(scope_mode/project_ids)·org owner/admin 여부로
+    인가를 자체 판정한다 — "지금 탭이 보고 있는 프로젝트"와는 무관하다. 그런데
+    ``get_verified_org_id``를 그대로 썼던 탓에, org owner라도 탭이 자신이 속하지 않은
+    프로젝트를 가리키고 있으면 이 엔드포인트들이 project-access 403으로 막혔다(라이브 재현:
+    채용 위저드 1단계 role-catalog 다음, 2단계 "채용하기"에서 재발). project 스코프가 실제로
+    필요한 호출은 (이 함수가 아니라) ``get_verified_org_id``를 그대로 쓴다."""
+    return await _resolve_verified_org_id(auth, x_org_id, request)
+
+
+async def get_verified_org_id(
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    x_project_id: str | None = Header(default=None, alias="X-Project-Id"),
+    request: Request = None,
+) -> uuid.UUID:
+    """org_id 추출 — X-Org-Id 헤더 fallback 시 DB membership 검증, X-Project-Id 헤더 시 project 소속 검증.
+    API Key 경로는 HTTP method 기반 scope 자동 체크.
+
+    story #2459(§6 봉합①): 요청-수명 ``Depends(get_db)`` 대신 검증마다 전용 단명 세션 —
+    get_current_user와 동일 근거(호출 대상이 전부 읽기 전용, #2457로 이미 성립)."""
+    org_id = await _resolve_verified_org_id(auth, x_org_id, request)
 
     # X-Project-Id 헤더 = per-request 프로젝트 스코프 **override**(d802da27/85614dd9).
     # JWT project_id 는 탭 공유라, 같은 유저가 여러 프로젝트 탭을 열어도 mutation 이 JWT 의 단일

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id_no_project_gate
 from app.dependencies.database import get_db
 from app.dependencies.ownership import assert_agent_owner
 from app.models.project import Project
@@ -91,7 +91,7 @@ async def create_org_agent(
     body: OrgAgentCreate,
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
-    org_id: uuid.UUID = Depends(get_verified_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id_no_project_gate),
 ) -> dict:
     """org-level 에이전트 생성 + scope_mode 프로젝트 집합 grant. 응답에 api_key 1회 노출."""
     # 권한: create_team_member 와 동일 규칙 재사용(agent actor 제약).
@@ -186,7 +186,7 @@ async def get_agent_connection_artifact(
     accept_language: str | None = Header(None, alias="Accept-Language"),
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
-    org_id: uuid.UUID = Depends(get_verified_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id_no_project_gate),
 ) -> dict:
     """OB-1 AC3 + E-RECRUIT S5(story 4fca5a3e): 에이전트 activation 번들 — 同 SSOT generator 소비.
 
@@ -356,7 +356,7 @@ async def recruit_agent_endpoint(
     accept_language: str | None = Header(None, alias="Accept-Language"),
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
-    org_id: uuid.UUID = Depends(get_verified_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id_no_project_gate),
 ) -> dict:
     """E-RECRUIT S3(story ff2996d0): role_template + runtime → 자율 운영 지침 합성(S2) + persona
     upsert(G7) + role-derived scope 로 키 회전(G2/G3) + 활성화 번들(``.mcp.json`` + 실 key 1회) 반환.
@@ -449,7 +449,7 @@ async def verify_agent_connection(
     transport: str | None = None,
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
-    org_id: uuid.UUID = Depends(get_verified_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id_no_project_gate),
 ) -> dict:
     """OB-2 AC1: 합성 connection_test Event 를 **실 SSE 경로**로 발사 → 라운드트립 verify 시작.
 
@@ -512,7 +512,7 @@ async def agent_verification_status(
     transport: str = "stdio",
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
-    org_id: uuid.UUID = Depends(get_verified_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id_no_project_gate),
 ) -> dict:
     """OB-2 AC2: 레일 폴링/조회(BE↔FE 계약 락). SSE 우선·이 poll 은 fallback.
 
@@ -537,14 +537,14 @@ async def agent_verification_status(
 async def get_agent_access_matrix(
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
-    org_id: uuid.UUID = Depends(get_verified_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id_no_project_gate),
 ) -> list[dict]:
     """[에이전트 관리 IA·Phase 2] org-wide 에이전트×프로젝트 접근권한 매트릭스 시드(story da4c6b2d).
 
     PO crux 승인(2026-07-07): 후보 A 채택 — 프로젝트별 fan-out(N agents × M projects 왕복) 대신
     단일 인덱스드 쿼리로 org 전체 grant 를 한 번에 반환. FE 는 이미 별도로 가진 org 에이전트
     전체 목록·org 프로젝트 전체 목록에 이 sparse grant 목록만 겹쳐 매트릭스 셀 상태를 정한다
-    (record_id 있음=허용, 없음=차단). 경로에 org path-param 을 안 둔다 — `get_verified_org_id` 로
+    (record_id 있음=허용, 없음=차단). 경로에 org path-param 을 안 둔다 — `get_verified_org_id_no_project_gate` 로
     caller 의 검증된 org 만 암묵 사용(클라이언트가 org id 조작해 타org 조회하는 경로 원천 차단).
 
     **에이전트 격리(PO 승인조건 #1)**: `project_access.member_id` 는 에이전트 전용이 아니다 —

--- a/backend/tests/test_2486_agents_router_project_gate.py
+++ b/backend/tests/test_2486_agents_router_project_gate.py
@@ -1,0 +1,163 @@
+"""story #2486(두 번째 문): agents.py 6개 엔드포인트를 ``get_verified_org_id``에서
+``get_verified_org_id_no_project_gate``로 스왑한 회귀 고정.
+
+role_templates(#2875)와 동일 근본 — BFF가 모든 프록시 호출에 브라우저 탭의 X-Project-Id를
+무조건 실어 보내는데, agents.py는 자체 인가(org owner/admin·agent 소유권·body.project_ids)를
+쓰지 탭이 지금 보고 있는 프로젝트와는 무관하다. PO 조건(2026-08-06):
+① 각 엔드포인트의 실제 인가는 그대로 — X-Project-Id 부작용만 제거.
+② 엔드포인트별 양성(비접근 X-Project-Id→200/201)·음성(진짜 무권한→403·unauth→401) 대조.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.conftest import override_db_and_read
+
+
+def _mock_agent_member(*, org_id: uuid.UUID, project_id: uuid.UUID) -> MagicMock:
+    m = MagicMock()
+    m.id = uuid.uuid4()
+    m.project_id = project_id
+    m.org_id = org_id
+    m.user_id = None
+    m.type = "agent"
+    m.name = "probe-agent"
+    m.role = "member"
+    m.avatar_url = None
+    m.agent_config = None
+    m.is_active = True
+    m.color = "#3385f8"
+    m.agent_role = None
+    m.runtime_type = None
+    m.created_by = None
+    m.can_manage_members = False
+    m.created_at = datetime(2026, 8, 6, tzinfo=timezone.utc)
+    m.updated_at = datetime(2026, 8, 6, tzinfo=timezone.utc)
+    m.last_seen_at = None
+    m.active_story_id = None
+    m.agent_status = None
+    m.active_story = None
+    m.fakechat_port = None
+    return m
+
+
+@pytest.mark.anyio
+async def test_create_org_agent_ignores_inaccessible_x_project_id_when_org_admin(
+    test_client, mock_session, monkeypatch, org_id
+):
+    """양성대조: org owner/admin이면 탭이 비접근 프로젝트를 가리켜도 201(과거엔 403)."""
+    import app.routers.agents as agents_router
+    import app.routers.team_members as team_members_router
+    import app.services.project_auth as project_auth
+
+    project_id = uuid.uuid4()
+    monkeypatch.setattr(
+        agents_router, "_resolve_org_project_ids", AsyncMock(return_value=[project_id])
+    )
+    monkeypatch.setattr(team_members_router, "_resolve_actor", AsyncMock(return_value=None))
+    monkeypatch.setattr(project_auth, "is_org_owner_or_admin", AsyncMock(return_value=True))
+
+    member = _mock_agent_member(org_id=org_id, project_id=project_id)
+    monkeypatch.setattr(
+        agents_router, "create_org_level_agent", AsyncMock(return_value=(member, "sk_live_probe"))
+    )
+    monkeypatch.setattr(
+        agents_router, "emit_onboarding_event", AsyncMock(return_value=None)
+    )
+    mock_session.commit = AsyncMock(return_value=None)
+
+    inaccessible_project_id = str(uuid.uuid4())
+    resp = await test_client.post(
+        "/api/v2/agents",
+        json={"name": "probe-agent", "role": "member", "scope_mode": "org"},
+        headers={"X-Project-Id": inaccessible_project_id},
+    )
+    assert resp.status_code == 201
+
+
+@pytest.mark.anyio
+async def test_create_org_agent_still_403_for_genuine_non_admin(
+    test_client, mock_session, monkeypatch, org_id
+):
+    """음성대조: 진짜 org owner/admin이 아니면(비-owner) 여전히 403 — 단 메시지는
+    project-access가 아니라 실제 authz 실패("org admin/owner role required")여야
+    project-gate 제거가 인가 자체를 열어버린 게 아님을 증명한다."""
+    import app.routers.agents as agents_router
+    import app.routers.team_members as team_members_router
+    import app.services.project_auth as project_auth
+
+    project_id = uuid.uuid4()
+    monkeypatch.setattr(
+        agents_router, "_resolve_org_project_ids", AsyncMock(return_value=[project_id])
+    )
+    monkeypatch.setattr(team_members_router, "_resolve_actor", AsyncMock(return_value=None))
+    monkeypatch.setattr(project_auth, "is_org_owner_or_admin", AsyncMock(return_value=False))
+
+    resp = await test_client.post(
+        "/api/v2/agents",
+        json={"name": "probe-agent", "role": "member", "scope_mode": "org"},
+    )
+    assert resp.status_code == 403
+    assert "admin" in resp.json()["error"]["message"].lower()
+
+
+@pytest.mark.anyio
+async def test_get_agent_access_matrix_ignores_inaccessible_x_project_id_when_org_admin(
+    test_client, mock_session, monkeypatch
+):
+    """양성대조 — access-matrix(가장 가벼운 엔드포인트)로도 동일 패턴 재확인."""
+    import app.services.project_auth as project_auth
+
+    monkeypatch.setattr(project_auth, "is_org_owner_or_admin", AsyncMock(return_value=True))
+    res = MagicMock()
+    res.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=res)
+
+    inaccessible_project_id = str(uuid.uuid4())
+    resp = await test_client.get(
+        "/api/v2/agents/access-matrix", headers={"X-Project-Id": inaccessible_project_id}
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_get_agent_access_matrix_still_403_for_genuine_non_admin(
+    test_client, mock_session, monkeypatch
+):
+    """음성대조 — access-matrix도 진짜 무권한이면 여전히 403."""
+    import app.services.project_auth as project_auth
+
+    monkeypatch.setattr(project_auth, "is_org_owner_or_admin", AsyncMock(return_value=False))
+
+    resp = await test_client.get("/api/v2/agents/access-matrix")
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_agents_router_still_401_without_auth_http(mock_session):
+    """unauth→401 — role_templates(#2875) 회귀 패턴 재사용. 이 라우터도 로그인 자체는
+    여전히 필수임을 pin(대표로 create+access-matrix 2개)."""
+    from httpx import ASGITransport, AsyncClient
+
+    from app.main import app
+
+    async def _override_db():
+        yield mock_session
+
+    override_db_and_read(app, _override_db)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            create_resp = await client.post(
+                "/api/v2/agents",
+                json={"name": "probe-agent", "role": "member", "scope_mode": "org"},
+            )
+            matrix_resp = await client.get("/api/v2/agents/access-matrix")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert create_resp.status_code == 401
+    assert matrix_resp.status_code == 401

--- a/backend/tests/test_2486_agents_router_project_gate.py
+++ b/backend/tests/test_2486_agents_router_project_gate.py
@@ -138,6 +138,183 @@ async def test_get_agent_access_matrix_still_403_for_genuine_non_admin(
 
 
 @pytest.mark.anyio
+async def test_recruit_ignores_inaccessible_x_project_id_when_owner(
+    test_client, mock_session, monkeypatch, org_id
+):
+    """양성대조 — POST /{agent_id}/recruit (위저드 2단계, 라이브 재현 지점)."""
+    import app.routers.agents as agents_router
+
+    agent_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    member = _mock_agent_member(org_id=org_id, project_id=project_id)
+    monkeypatch.setattr(agents_router, "assert_agent_owner", AsyncMock(return_value=member))
+
+    role_template = MagicMock()
+    role_template.slug = "backend-dev"
+    monkeypatch.setattr(
+        agents_router, "get_published_role_template", AsyncMock(return_value=role_template)
+    )
+
+    persona = MagicMock()
+    persona.id = uuid.uuid4()
+    persona.system_prompt = "probe prompt"
+    monkeypatch.setattr(
+        agents_router,
+        "recruit_agent",
+        AsyncMock(
+            return_value={
+                "persona": persona,
+                "api_key_plaintext": "sk_live_probe",
+                "tool_allowlist": ["stories", "chat"],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        agents_router,
+        "build_agent_mcp_config_bundle",
+        MagicMock(return_value={"mcp_config": {}, "default_transport": "stdio", "mcp_config_alternatives": {}}),
+    )
+    monkeypatch.setattr(agents_router, "emit_onboarding_event", AsyncMock(return_value=None))
+    mock_session.commit = AsyncMock(return_value=None)
+
+    inaccessible_project_id = str(uuid.uuid4())
+    resp = await test_client.post(
+        f"/api/v2/agents/{agent_id}/recruit",
+        json={"role_template_slug": "backend-dev", "runtime": "claude-code"},
+        headers={"X-Project-Id": inaccessible_project_id},
+    )
+    assert resp.status_code == 201
+
+
+@pytest.mark.anyio
+async def test_recruit_still_403_for_genuine_non_owner(test_client, mock_session, monkeypatch):
+    """음성대조 — recruit도 진짜 non-owner/non-admin이면 여전히 403(assert_agent_owner 그대로)."""
+    from fastapi import HTTPException
+
+    import app.routers.agents as agents_router
+
+    agent_id = uuid.uuid4()
+    monkeypatch.setattr(
+        agents_router,
+        "assert_agent_owner",
+        AsyncMock(side_effect=HTTPException(status_code=403, detail="Not the owner of this agent")),
+    )
+
+    resp = await test_client.post(
+        f"/api/v2/agents/{agent_id}/recruit",
+        json={"role_template_slug": "backend-dev", "runtime": "claude-code"},
+    )
+    assert resp.status_code == 403
+    assert "owner" in resp.json()["error"]["message"].lower()
+
+
+@pytest.mark.anyio
+async def test_verify_connection_ignores_inaccessible_x_project_id_when_owner(
+    test_client, mock_session, monkeypatch, org_id
+):
+    """양성대조 — POST /{agent_id}/verify-connection (transport=http, SSE 우회 최단경로)."""
+    import app.routers.agents as agents_router
+
+    agent_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    member = _mock_agent_member(org_id=org_id, project_id=project_id)
+    monkeypatch.setattr(agents_router, "assert_agent_owner", AsyncMock(return_value=member))
+    monkeypatch.setattr(
+        agents_router,
+        "get_verification_state",
+        AsyncMock(return_value={"verified": False, "rail": []}),
+    )
+
+    inaccessible_project_id = str(uuid.uuid4())
+    resp = await test_client.post(
+        f"/api/v2/agents/{agent_id}/verify-connection",
+        params={"transport": "http"},
+        headers={"X-Project-Id": inaccessible_project_id},
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_verification_status_ignores_inaccessible_x_project_id_when_owner(
+    test_client, mock_session, monkeypatch, org_id
+):
+    """양성대조 — GET /{agent_id}/verification-status."""
+    import app.routers.agents as agents_router
+
+    agent_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    member = _mock_agent_member(org_id=org_id, project_id=project_id)
+    monkeypatch.setattr(agents_router, "_fetch_org_agent", AsyncMock(return_value=member))
+    monkeypatch.setattr(
+        agents_router,
+        "get_verification_state",
+        AsyncMock(return_value={"verified": False, "rail": [], "verify_seq": None}),
+    )
+
+    inaccessible_project_id = str(uuid.uuid4())
+    resp = await test_client.get(
+        f"/api/v2/agents/{agent_id}/verification-status",
+        headers={"X-Project-Id": inaccessible_project_id},
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_connection_artifact_ignores_inaccessible_x_project_id_when_owner(
+    test_client, mock_session, monkeypatch, org_id
+):
+    """양성대조 — GET /{agent_id}/connection-artifact (org-scope anti-IDOR 조회, ownership 무관)."""
+    import app.routers.agents as agents_router
+    from app.repositories.agent_persona import AgentPersonaRepository
+
+    agent_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    member = _mock_agent_member(org_id=org_id, project_id=project_id)
+    res = MagicMock()
+    res.scalar_one_or_none.return_value = member
+    mock_session.execute = AsyncMock(return_value=res)
+    monkeypatch.setattr(AgentPersonaRepository, "list", AsyncMock(return_value=[]))
+    monkeypatch.setattr(
+        agents_router,
+        "build_agent_mcp_config",
+        MagicMock(return_value={"mcpServers": {}}),
+    )
+    monkeypatch.setattr(agents_router, "emit_onboarding_event", AsyncMock(return_value=None))
+    mock_session.commit = AsyncMock(return_value=None)
+
+    inaccessible_project_id = str(uuid.uuid4())
+    resp = await test_client.get(
+        f"/api/v2/agents/{agent_id}/connection-artifact",
+        headers={"X-Project-Id": inaccessible_project_id},
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_no_project_gate_dependency_still_enforces_org_membership(monkeypatch, org_id):
+    """PO 리뷰 급소①(2026-08-06): ``get_verified_org_id_no_project_gate``가 project-gate만
+    뺐지 org membership 검증까지 열어버린 건 아님을 직접(dependency 단위) 확인 —
+    X-Org-Id 헤더로 실제 비멤버 org를 지정하면 여전히 403이어야 한다."""
+    from fastapi import HTTPException
+
+    import app.dependencies.auth as auth_module
+    from app.dependencies.auth import AuthContext, get_verified_org_id_no_project_gate
+
+    auth = AuthContext(user_id=str(uuid.uuid4()), email=None, claims={}, org_id=None)
+
+    async def _not_a_member(*args, **kwargs):
+        raise HTTPException(status_code=403, detail="해당 조직의 멤버가 아닌")
+
+    monkeypatch.setattr(auth_module, "_verify_org_membership", _not_a_member)
+
+    with pytest.raises(HTTPException) as ei:
+        await get_verified_org_id_no_project_gate(
+            auth=auth, x_org_id=str(org_id), request=None
+        )
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.anyio
 async def test_agents_router_still_401_without_auth_http(mock_session):
     """unauth→401 — role_templates(#2875) 회귀 패턴 재사용. 이 라우터도 로그인 자체는
     여전히 필수임을 pin(대표로 create+access-matrix 2개)."""


### PR DESCRIPTION
## Summary
Second door of story #2486 (same root cause as #2875 / role_templates, now hit on the recruit flow itself):

- `POST /api/v2/agents` (create) 403'd with `"No access to the specified project"` for an org owner whose browser tab's effective project (forwarded via `X-Project-Id` by `fastapi-proxy.ts`) wasn't a project they belong to — even with `scope_mode: "org"` chosen in the wizard.
- All 6 endpoints in `agents.py` (create, recruit, connection-artifact, verify-connection, verification-status, access-matrix) depend on `get_verified_org_id` purely for `org_id`. Their actual authorization is self-contained and never reads the tab's project:
  - create → `is_org_owner_or_admin` (human) or `has_project_role` over `body.project_ids` (agent actor)
  - recruit / verify-connection → `assert_agent_owner` (creator-or-org-admin)
  - connection-artifact / verification-status → org-scoped agent lookup
  - access-matrix → `is_org_owner_or_admin`
- Fixing `create` alone would have just moved the 403 to the next wizard step (`recruit`), since `assert_agent_owner` has the identical gap.

## Fix
- Added `get_verified_org_id_no_project_gate` in `auth.py` — same org resolution + `X-Org-Id` membership verification as `get_verified_org_id` (factored into a shared `_resolve_verified_org_id` atom), minus the `X-Project-Id` → `has_project_access` side effect.
- `get_verified_org_id` itself is untouched — genuinely project-scoped routers keep enforcing project membership exactly as before.
- Swapped all 6 `agents.py` endpoints to the new dependency.

## Test plan
- [x] New `backend/tests/test_2486_agents_router_project_gate.py` (create + access-matrix, representative of the pattern):
  - positive: org admin + inaccessible `X-Project-Id` → 201/200 (previously 403)
  - negative: genuine non-admin → still 403, with the *real* authz message ("org admin/owner role required"), not the removed project-access one
  - unauth → still 401 for both endpoints
- [x] Full related battery (19 files touching `agents.py`/`get_verified_org_id`): 186 passed, 35 skipped (realdb), 1 xfailed
- [x] `scripts/lint_project_access_403.py` — 0 new violations
- [x] `scripts/lint_dependency_override_get_read_db.py` — 0 new violations (uses `tests.conftest.override_db_and_read`, per #2875 lesson)

🤖 Generated with [Claude Code](https://claude.com/claude-code)