### PR TITLE
[SID:2490] 탭 effective-project 비멤버 프로젝트 스코프 버그 수정

### DIFF
--- a/apps/web/src/lib/project-context-client.test.ts
+++ b/apps/web/src/lib/project-context-client.test.ts
@@ -39,6 +39,21 @@ describe('resolveEffectiveProjectId (hydrated 게이팅 — SSR/첫 CSR 렌더 d
     expect(resolveEffectiveProjectId(null, 'server-id', accessible, true)).toBe('server-id');
   });
 
+  // story #2490 — fire #2486 재현(PO 퍼펫티어, 2026-08-06)에서 발견: serverProjectId(=me.
+  // project_id, 쿠키/JWT 유래)만 accessibleIds 체크가 빠져있어, stale해 비멤버 프로젝트를
+  // 가리켜도 무검증 채택됐다. 다른 멤버 프로젝트로 조용히 점프하지 않고 undefined(미선택)로
+  // 떨어뜨린다 — 호출부 대부분이 이미 `!projectId` 가드로 graceful 폴백을 갖고 있다.
+  it('양성대조 — serverProjectId가 비멤버 프로젝트를 가리키면 undefined로 떨어진다(다른 프로젝트로 조용히 점프하지 않는다)', () => {
+    const accessible = new Set(['some-other-member-project']);
+    expect(resolveEffectiveProjectId(null, 'non-member-project', accessible, true)).toBeUndefined();
+  });
+
+  it('sessionStorage에 남은 비멤버 stale 값도 undefined로 떨어진다(자기강화 루프의 시작점 차단)', () => {
+    window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, 'non-member-project');
+    const accessible = new Set(['some-other-member-project']);
+    expect(resolveEffectiveProjectId(null, 'non-member-project', accessible, true)).toBeUndefined();
+  });
+
   it('rejects an inaccessible stored value even when hydrated', () => {
     window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, 'not-a-member-project');
     const accessible = new Set(['server-id']);

--- a/apps/web/src/lib/project-context-client.ts
+++ b/apps/web/src/lib/project-context-client.ts
@@ -98,5 +98,11 @@ export function resolveEffectiveProjectId(
     const stored = window.sessionStorage.getItem(TAB_PROJECT_STORAGE_KEY);
     if (stored && accessibleIds.has(stored)) return stored;
   }
-  return serverProjectId;
+  // story #2490 — 이전엔 이 마지막 폴백(serverProjectId, me.project_id=쿠키/JWT 유래)만
+  // accessibleIds 체크가 없었다. stale한 값이 비멤버 프로젝트를 가리키면 무검증으로
+  // 채택돼(fire #2486 재현, 퍼펫티어 실측) X-Project-Id로 실려 project-gated 엔드포인트를
+  // 오작동시켰다 — 다른 멤버 프로젝트로 «조용히 점프»하지 않고 미선택(undefined) 상태로
+  // 떨어뜨린다(호출부 대부분이 이미 `!projectId` 가드로 graceful 폴백 UI를 갖고 있다).
+  if (serverProjectId && accessibleIds.has(serverProjectId)) return serverProjectId;
+  return undefined;
 }


### PR DESCRIPTION
## 요약
fire #2486 재현(PO 퍼펫티어 실측, 2026-08-06) — org admin으로 로그인해도 탭의 effective project(`sessionStorage.sprintable_tab_project_id`)가 멤버가 아닌 프로젝트를 가리켰다. 리로드해도 되돌아오고, sessionStorage를 수동으로 고쳐도 즉시 재오염되는 자기강화 루프였다.

## 그라운딩 (PO 승인 후 진행 — 두 갈래를 하나 근본으로 좁힘)
- **`resolveEffectiveProjectId()`**(`project-context-client.ts`)는 `urlProjectId`·sessionStorage `stored` 값 둘 다 `accessibleIds` 멤버십 체크를 받는데, 마지막 폴백인 **`serverProjectId`(=`me.project_id`, 쿠키/JWT 유래)만 그 체크가 빠져 있었다.** stale한 값이 비멤버 프로젝트를 가리키면 무검증으로 채택됐다.
- `dashboard-shell.tsx`의 `useProjectSsot`가 매 렌더 resolve된 값을 무조건 sessionStorage에 재기록 — serverProjectId(비멤버)가 채택될 때마다 덮어써 수동 수정이 다음 렌더에서 즉시 지워지는 루프였다. (기존 `if (!effectiveProjectId ...) return` 가드는 이미 있었음, 코드 변경 불요.)
- 채용 위저드(`recruiter-client.tsx`)의 "전체 프로젝트" 스코프에 비멤버 project_id가 실리는 것처럼 보인 증상도 **별개 버그가 아니라 위 근본원인의 하류**(초기 `scopeProjectIds`가 탭의 오염된 effective project로 프리필됨) — 이 fix로 함께 해소된다(호출부 `agents-page-tabs.tsx`가 이미 `!projectId` 가드로 위저드 자체를 숨기는 폴백 UI를 갖고 있어 별도 UI 작업 불요).

## 변경
`resolveEffectiveProjectId`의 `serverProjectId` 폴백에도 동일한 `accessibleIds.has(...)` 체크 추가. 최종 폴백은 `undefined`(미선택 상태) — 다른 멤버 프로젝트로 조용히 점프하지 않는다(사용자가 선택 안 한 프로젝트로 이동시키는 게 더 위험하다는 판단, PO 확定).

## 게이트
- 신규 vitest 2개(양성대조: 비멤버 serverProjectId→undefined · sessionStorage stale 값도 undefined) GREEN
- 뮤테이션 셀프체크 1건 — 체크 제거 → RED 확認 → 복원
- tsc/eslint 클린
- 전체 모노레포 vitest 396파일/2999개 GREEN(회귀 0)
- `pnpm build` exit 0

머지→dev배포 후 PO가 퍼펫티어로 "송윤재 탭이 25d3a6df로 안 튐 + 유효 프로젝트 선택 뒤 채용 완주+chat 4종" 재실증 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)