### PR TITLE
feat(#2491): Toss Payments Settings fields (결제②-C0)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -242,6 +242,18 @@ class Settings(BaseSettings):
     polar_sandbox: bool = True  # dev=True(sandbox), prod=False
     polar_webhook_secret: str = ""  # HMAC signature 검증용
 
+    # 결제②-C0(story #2491): Toss Payments — 원화 정기결제(빌링키) 어댑터(TossAdapter, story C1~).
+    # provider = 통화의 함수(원화→Toss·달러→Polar, billing-arch-modular-pg-ledger-v0-1 §2) — polar_*와
+    # 동형 패턴. dev는 Secret Manager에 TOSS_PAYMENTS_SECRET_KEY_DEV 등으로 등록·Cloud Run env
+    # TOSS_PAYMENTS_SECRET_KEY(이 필드명 대문자화)로 secretKeyRef 매핑(PO, 2026-08-06 — 인프라 lane,
+    # DATABASE_URL_DIRECT/GITHUB_APP_CLIENT_SECRET 등과 동일 바인딩 컨벤션). prod(live_*)는 정식출시
+    # 확認 전까지 미배선 — 값이 비어 있으면 PolarAdapter의 "토큰 없으면 mock" 분기와 동형으로 TossAdapter
+    # 도 fail-safe해야 한다(C1 구현 시 준수).
+    toss_payments_secret_key: str = ""
+    toss_payments_client_key: str = ""
+    toss_payments_crypto_key: str = ""
+    toss_merchant_id: str = "bill_sprint1d9"  # 비민감 — Secret Manager 대상 아님(PO 확認)
+
     # E-H1-S6: GitHub webhook(PR/CI verdict 캡처) HMAC 검증 시크릿. 미설정이면 webhook 거부(inert).
     github_webhook_secret: str = ""
 

--- a/backend/tests/test_check_env_drift_settings_coverage.py
+++ b/backend/tests/test_check_env_drift_settings_coverage.py
@@ -152,8 +152,14 @@ def test_settings_field_env_keys_works_without_pydantic_settings_importable(monk
     # #2461(§6 봉합③ part2, PO 승인 2026-08-05): worker_db_pool_size/worker_db_max_overflow
     # 필드 신설로 85→87(WORKER_DB_POOL_SIZE·WORKER_DB_MAX_OVERFLOW 포함) — L2/배치워커 전용
     # worker_engine 풀 크기 설정. 가드가 신규 필드를 설계대로 잡은 것.
+    # #2491(결제②-C0, PO 승인 2026-08-06): toss_payments_secret_key/toss_payments_client_key/
+    # toss_payments_crypto_key/toss_merchant_id 필드 신설로 87→91(TOSS_PAYMENTS_SECRET_KEY·
+    # TOSS_PAYMENTS_CLIENT_KEY·TOSS_PAYMENTS_CRYPTO_KEY·TOSS_MERCHANT_ID 포함) — TossAdapter
+    # (story C1~) 원화 정기결제용 시크릿, polar_* 동형. 가드가 신규 필드를 설계대로 잡은 것.
     assert "PRESENCE_REDIS_ENABLED" in keys and "SSE_TRANSIENT_REPLAY_ENABLED" in keys
     assert "REQUIRE_VERIFIED_EMAIL_FOR_ORG_CREATE" in keys
     assert "DATABASE_URL_READ" in keys
     assert "WORKER_DB_POOL_SIZE" in keys and "WORKER_DB_MAX_OVERFLOW" in keys
-    assert len(keys) == 87
+    assert "TOSS_PAYMENTS_SECRET_KEY" in keys and "TOSS_PAYMENTS_CLIENT_KEY" in keys
+    assert "TOSS_PAYMENTS_CRYPTO_KEY" in keys and "TOSS_MERCHANT_ID" in keys
+    assert len(keys) == 91


### PR DESCRIPTION
## Summary
C0 of 결제②-C (TossAdapter) — infra-wiring prerequisite for C1~C4.

- Adds `toss_payments_secret_key`/`toss_payments_client_key`/`toss_payments_crypto_key`/`toss_merchant_id` to `Settings`, mirroring the existing `polar_*` pattern (plain string fields, empty default, standard pydantic-settings env mapping — no custom `env_prefix`).
- `toss_merchant_id` defaults to `bill_sprint1d9` (non-sensitive, per PO — not a Secret Manager value).
- The three secret fields default to `""` — `TossAdapter` (story C1+) must fail-safe the same way `PolarAdapter` does when a token isn't configured (mock/no-op path), not assume presence.

## Not in scope (infra lane)
- Dev Secret Manager entries (`TOSS_PAYMENTS_SECRET_KEY_DEV` etc.) are already provisioned (PO, 2026-08-06).
- Wiring the Cloud Run env vars (`TOSS_PAYMENTS_SECRET_KEY` etc.) to those secrets via `secretKeyRef` is a live Cloud Run service binding, not a `cloudbuild.yaml` declaration — confirmed by inspecting the live dev service: `DATABASE_URL_DIRECT`, `GITHUB_APP_CLIENT_SECRET`, etc. are all bound directly on the service (redeploys preserve them via the absence of `--set-secrets`/`--set-env-vars` on the `gcloud run deploy` step). This PR doesn't touch that — it's PO/infra lane.
- prod (`live_*`) secrets are intentionally not provisioned yet, deferred until real launch approval.

## Test plan
- [x] `python -c "from app.core.config import settings; ..."` — new fields load with expected defaults
- [x] `pytest backend/tests/test_e_2478_b_payment_adapter.py backend/tests/test_e_org_multi_s5_3_polar_checkout.py` — 26 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)