### PR TITLE
[SID:2497] fetch 인터셉터 X-Org-Id 누락 — fire #2486 진짜 근본원인 수정

### DIFF
--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -7,6 +7,7 @@ import {
   installProjectHeaderInterceptor,
   resolveEffectiveProjectId,
   setEffectiveProjectId,
+  setEffectiveOrgId,
 } from '@/lib/project-context-client';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
@@ -272,6 +273,11 @@ export function DashboardShell({
   // story #2093 — 경로(`[ws]/[proj]`) resolve 결과가 최우선(화면이 실제로 그리는 것의 정본).
   // 계정 상태(orgId, server prop)는 flat 라우트(경로에 org/project가 없는 화면)에서만 쓰인다.
   const effectiveOrgId = pathOrgId ?? orgId;
+  // story #2497 — 인터셉터가 X-Project-Id 옆에 X-Org-Id도 함께 실어야 하는 자리(fire #2486
+  // 근본원인: 멀티-org 유저의 stale JWT org가 탭의 실제 org와 달라 has_project_access가
+  // 엉뚱한 org로 검증됨). setEffectiveProjectId와 동일하게 렌더 단계에서 동기화 —
+  // 인터셉터 설치(useProjectSsot 내부)보다 먼저 ref가 채워져 있어야 첫 자식 fetch도 커버된다.
+  setEffectiveOrgId(effectiveOrgId);
   // R2: URL `?p=` = flat 라우트의 탭별 SSOT. pathProjectId(경로 resolve)가 있으면 그게 최우선.
   const effectiveProjectId = useProjectSsot(projectId, projectMemberships, pathProjectId);
   const effectiveProjectName = projectMemberships.find((m) => m.projectId === effectiveProjectId)?.projectName ?? projectName;

--- a/apps/web/src/lib/project-context-client.test.ts
+++ b/apps/web/src/lib/project-context-client.test.ts
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { TAB_PROJECT_STORAGE_KEY, resolveEffectiveProjectId } from './project-context-client';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  TAB_PROJECT_STORAGE_KEY,
+  resolveEffectiveProjectId,
+  installProjectHeaderInterceptor,
+  setEffectiveProjectId,
+  setEffectiveOrgId,
+} from './project-context-client';
 
 describe('resolveEffectiveProjectId (hydrated 게이팅 — SSR/첫 CSR 렌더 divergence 방지, 2026-07-11 라이브 재현)', () => {
   beforeEach(() => {
@@ -88,5 +94,67 @@ describe('resolveEffectiveProjectId — pathProjectId 최우선 (story #2093, �
   it('pathProjectId가 없는(flat 라우트) 경우엔 기존 ?p= 우선순위 체인이 그대로 동작한다', () => {
     const accessible = new Set(['url-id', 'server-id']);
     expect(resolveEffectiveProjectId('url-id', 'server-id', accessible, true, undefined)).toBe('url-id');
+  });
+});
+
+// story #2497 — fire #2486 근본원인(라이브 실증): 인터셉터가 X-Project-Id만 보내고 X-Org-Id는
+// 안 보내, 멀티-org 유저의 stale JWT org가 backend get_verified_org_id의 org_id 스코프로
+// 새 has_project_access가 엉뚱한 org로 검증돼 정당한 프로젝트도 403 났다. 이 describe는
+// «하나만 실으면 RED»가 되는 회귀가드다 — window.fetch를 한 번만 패치(모듈 싱글턴)하고
+// 매 테스트는 ref 값만 바꿔 검증한다.
+describe('installProjectHeaderInterceptor — X-Project-Id 옆에 X-Org-Id가 항상 함께 실린다 (story #2497)', () => {
+  const baseFetch = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => new Response(null, { status: 200 }));
+
+  beforeAll(() => {
+    window.fetch = baseFetch as unknown as typeof window.fetch;
+    installProjectHeaderInterceptor();
+  });
+
+  beforeEach(() => {
+    baseFetch.mockClear();
+    setEffectiveProjectId(undefined);
+    setEffectiveOrgId(undefined);
+  });
+
+  it('핵심 회귀가드 — X-Project-Id와 X-Org-Id를 함께 주입한다', async () => {
+    setEffectiveProjectId('proj-1');
+    setEffectiveOrgId('org-1');
+    await window.fetch('/api/projects');
+
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+    const [, init] = baseFetch.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Headers;
+    expect(headers.get('X-Project-Id')).toBe('proj-1');
+    expect(headers.get('X-Org-Id')).toBe('org-1');
+  });
+
+  it('effective org가 아직 없으면(초기 렌더 등) X-Org-Id 없이 X-Project-Id만 실린다(회귀 없음)', async () => {
+    setEffectiveProjectId('proj-1');
+    await window.fetch('/api/projects');
+
+    const [, init] = baseFetch.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Headers;
+    expect(headers.get('X-Project-Id')).toBe('proj-1');
+    expect(headers.has('X-Org-Id')).toBe(false);
+  });
+
+  it('요청이 이미 X-Project-Id/X-Org-Id를 명시하면 인터셉터가 덮지 않는다(switcher cross-org 로드 회귀 없음)', async () => {
+    setEffectiveProjectId('proj-1');
+    setEffectiveOrgId('org-1');
+    await window.fetch('/api/projects', { headers: { 'X-Project-Id': 'explicit-proj', 'X-Org-Id': 'explicit-org' } });
+
+    const [, init] = baseFetch.mock.calls[0] as [string, RequestInit];
+    const headers = new Headers(init.headers);
+    expect(headers.get('X-Project-Id')).toBe('explicit-proj');
+    expect(headers.get('X-Org-Id')).toBe('explicit-org');
+  });
+
+  it('/api/switch-* 는 주입 대상에서 제외된다(회귀 없음)', async () => {
+    setEffectiveProjectId('proj-1');
+    setEffectiveOrgId('org-1');
+    await window.fetch('/api/switch-project');
+
+    const [, init] = baseFetch.mock.calls[0] as [string, RequestInit | undefined];
+    expect(init?.headers).toBeUndefined();
   });
 });

--- a/apps/web/src/lib/project-context-client.ts
+++ b/apps/web/src/lib/project-context-client.ts
@@ -22,15 +22,31 @@ export function setEffectiveProjectId(id: string | undefined): void {
   effectiveProjectIdRef.current = id;
 }
 
+// story #2497 — fire #2486 근본원인(라이브 실증): 인터셉터가 X-Project-Id만 보내고
+// X-Org-Id는 안 보내, backend get_verified_org_id가 org_id=(X-Org-Id ?? JWT
+// app_metadata.org_id)로 스코프하는 자리에서 멀티-org 유저의 stale JWT org가 현재
+// 탭의 실제 org와 달라 has_project_access가 엉뚱한 org로 검증돼 정당한 프로젝트도
+// 403 났다(#2490의 "25d3a6df는 out-of-org stale" 전제는 틀렸음 — in-org·정당 접근권,
+// 진짜 원인은 이 헤더 누락). effectiveProjectIdRef와 대칭으로 탭의 effective org도
+// 추적해 같이 실어 보낸다.
+const effectiveOrgIdRef: { current: string | undefined } = { current: undefined };
+
+export function setEffectiveOrgId(id: string | undefined): void {
+  effectiveOrgIdRef.current = id;
+}
+
 let interceptorInstalled = false;
 
 /**
- * same-origin `/api/*` 요청에 `X-Project-Id`(탭 effective project)를 주입하는 단일 chokepoint.
- * 호출부 전수 마이그레이션 대신 window.fetch 1점 패치 — raw fetch 호출까지 빠짐없이 커버.
+ * same-origin `/api/*` 요청에 `X-Project-Id`+`X-Org-Id`(탭 effective project/org)를
+ * 주입하는 단일 chokepoint. 호출부 전수 마이그레이션 대신 window.fetch 1점 패치 —
+ * raw fetch 호출까지 빠짐없이 커버.
  *
  * - string/URL input 만 처리(코드베이스 호출 패턴). Request input 은 body 유실 방지 위해 무가공 통과.
  * - 이미 `X-Project-Id`/`X-Org-Id` 를 명시한 요청(예: switcher 의 cross-org 프로젝트 로드)은
  *   스킵 — 명시 스코프를 덮지 않는다.
+ * - story #2497 — 둘을 항상 «함께» 싣는다(하나만 실으면 멀티-org 유저에서 org_id가
+ *   JWT stale org로 새는 이 fire의 정확한 재발 형태다).
  */
 export function installProjectHeaderInterceptor(): void {
   if (interceptorInstalled || typeof window === 'undefined') return;
@@ -43,12 +59,14 @@ export function installProjectHeaderInterceptor(): void {
         const url = typeof input === 'string' ? input : input.href;
         const path = url.startsWith('http') ? new URL(url).pathname : url.split('?')[0];
         const projectId = effectiveProjectIdRef.current;
+        const orgId = effectiveOrgIdRef.current;
         // 컨텍스트 제어 엔드포인트(`/api/switch-*`)는 자체 컨텍스트를 관리하므로 주입 제외.
         const isApi = path.startsWith('/api/') && !path.startsWith('/api/switch-');
         if (isApi && projectId) {
           const headers = new Headers(init?.headers);
           if (!headers.has('X-Project-Id') && !headers.has('X-Org-Id')) {
             headers.set('X-Project-Id', projectId);
+            if (orgId) headers.set('X-Org-Id', orgId);
             return originalFetch(input, { ...init, headers });
           }
         }


### PR DESCRIPTION
## 요약
PO 라이브 통제실험(송윤재 휴먼 로그인·dev, 2026-08-06)으로 확定된 fire #2486의 진짜 근본원인 — `installProjectHeaderInterceptor`가 `/api/*` 요청에 **X-Project-Id만 싣고 X-Org-Id는 안 실었다**. backend `get_verified_org_id`는 `org_id=(X-Org-Id ?? JWT app_metadata.org_id)`로 스코프해 `has_project_access`를 검증하는데, 멀티-org 유저(송윤재)의 JWT org가 현재 탭의 실제 org와 달라 정당하게 grant된 프로젝트도 엉뚱한 org로 검증돼 403이 났다.

## ⚠️#2490 전제 정정
#2490("25d3a6df는 out-of-org stale 프로젝트") 전제는 이번 실험으로 **틀렸음이 확認**됨 — 25d3a6df는 in-org·DB에 정당하게 grant된 프로젝트였다. #2490 자체는 독립적으로 안전하고 유효한 fix(다른 방어층 — serverProjectId 멤버십 미검증 버그는 실재했음)지만, 이 fire의 실제 원인은 아니었다.

## 증거 (통제실험, 유일 변수=X-Org-Id)
- A) X-Project-Id만 → **403**
- B) X-Project-Id + X-Org-Id → **200**
- C) X-Org-Id만 → **200**

## 변경
- `effectiveOrgIdRef`+`setEffectiveOrgId` 신설(`effectiveProjectIdRef`와 대칭).
- 인터셉터가 X-Project-Id 주입 시 X-Org-Id도 함께 실음(가드 동일 — 둘 다 명시 안 됐을 때만, 명시된 요청은 안 덮음).
- `dashboard-shell.tsx`가 이미 계산 중이던 `effectiveOrgId`(경로 resolve 결과 우선·서버 prop 폴백)를 `setEffectiveOrgId`로 렌더 단계에 동기화 — 활성 project는 항상 활성 org 소속이라 쌍이 자연히 정합.

## 게이트
- 신규 vitest 4개(핵심 회귀가드: 둘 다 함께 주입 · org 없을 때 project만 · 명시 헤더 안 덮음 · switch-* 제외 회귀) 전부 GREEN
- 뮤테이션 셀프체크 1건 — X-Org-Id 주입 제거 → RED 확認(fire의 정확한 재발 형태로 재현) → 복원
- tsc/eslint 클린
- 전체 모노레포 vitest 396파일/3003개 GREEN(회귀 0)
- `pnpm build` exit 0

머지→dev배포 후 PO가 퍼펫티어로 "송윤재 탭 org-wide 엔드포인트 200 · 설정에 뭉클랩 프로젝트 8개+멤버 표시 · 채용 완주 · 신규 에이전트 chat 4종 왕복" 최종 실증 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)