### PR TITLE
[SID:2499] fastapi-proxy.ts ↔ storage-api mapApiError/fastapiCall 중복 사본 단일화

### DIFF
--- a/apps/web/src/lib/fastapi-proxy.ts
+++ b/apps/web/src/lib/fastapi-proxy.ts
@@ -6,59 +6,12 @@
 import { getServerSession } from '@/lib/db/server';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 
-import { NotFoundError, ForbiddenError } from '@sprintable/core-storage';
-
-/** story #2488 — packages/storage-api/src/utils.ts의 mapApiError와 완전 동일한
- * 버그(404/403 외 code·status discard)를 가진 사본. 같은 fix를 여기도 적용한다
- * (PO 확定: 이번 PR 스코프, 두 파일 합치는 consolidation은 별개). */
-export interface ApiCallError extends Error {
-  code?: string;
-  status?: number;
-}
-
-export function mapApiError(status: number, body: { error?: { code?: string; message?: string } }): ApiCallError {
-  const msg = body.error?.message ?? `HTTP ${status}`;
-  const code = body.error?.code;
-  if (status === 404) return Object.assign(new NotFoundError(msg), { code: code ?? 'NOT_FOUND', status });
-  if (status === 403) return Object.assign(new ForbiddenError(msg), { code: code ?? 'FORBIDDEN', status });
-  return Object.assign(new Error(msg), { code: code ?? `HTTP_${status}`, status });
-}
-
-export async function fastapiCall<T>(
-  method: 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'PUT',
-  path: string,
-  accessToken: string,
-  options?: {
-    body?: unknown;
-    query?: Record<string, string | number | boolean | null | undefined>;
-    orgId?: string;
-  },
-): Promise<T> {
-  const url = new URL(path, FASTAPI_URL());
-  if (options?.query) {
-    for (const [k, v] of Object.entries(options.query)) {
-      if (v != null) url.searchParams.set(k, String(v));
-    }
-  }
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-  if (accessToken) headers['Authorization'] = `Bearer ${accessToken}`;
-  if (options?.orgId) headers['X-Org-Id'] = options.orgId;
-
-  const res = await fetch(url.toString(), {
-    method,
-    headers,
-    body: options?.body !== undefined ? JSON.stringify(options.body) : undefined,
-  });
-
-  if (!res.ok) {
-    let errBody: { error?: { code?: string; message?: string } } = {};
-    try { errBody = await res.json(); } catch { /* ignore */ }
-    throw mapApiError(res.status, errBody);
-  }
-
-  if (res.status === 204) return undefined as T;
-  return res.json() as Promise<T>;
-}
+// story #2499 — 이 파일이 packages/storage-api/src/utils.ts와 완전 동일한 mapApiError/
+// fastapiCall 사본을 따로 갖고 있어(#2488에서 같은 버그를 두 곳에 각각 고쳐야 했다),
+// 다음 소비처가 조용히 옛 버그를 다시 밟을 위험이 있었다. 단일 구현으로 합친다 —
+// storage-api 쪽이 더 견고함(AbortSignal.timeout(30s) 포함)도 이 자리에서 얻는다.
+export { fastapiCall, mapApiError } from '@sprintable/storage-api';
+export type { ApiCallError } from '@sprintable/storage-api';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 

--- a/packages/storage-api/src/index.ts
+++ b/packages/storage-api/src/index.ts
@@ -1,4 +1,5 @@
 export { fastapiCall, mapApiError } from './utils';
+export type { ApiCallError } from './utils';
 
 // FastAPI(/api/v2/*) 직타 레포지토리. 과거 `Supabase*Repository` 명명은 실동작(FastAPI HTTP)
 // 과 어긋나 'Supabase 직접 경로' 헛가설을 유발했다 → fc7bce47에서 Api* 단일 명명으로 정정.


### PR DESCRIPTION
## 요약
#2488 그라운딩 부수발견 4 — `apps/web/src/lib/fastapi-proxy.ts`와 `packages/storage-api/src/utils.ts`에 완전 동일한 `mapApiError`/`fastapiCall` 구현이 각각 존재해(#2488에서 같은 버그를 두 곳에 반복 fix), 다음 소비처가 조용히 옛 버그를 다시 밟을 위험이 있었다. PO 지시(error.code 에픽 유휴 후속) — 저우선이나 유휴보단 나은 작업으로 진행.

## 변경
`fastapi-proxy.ts`가 자체 정의 대신 `@sprintable/storage-api`의 것을 재-export하도록 단일화. 실 소비처(github/slack connect route의 `fastapiCall<T>('GET', path, token)`)는 시그니처 완전 호환이라 변경 불요. 부수 이득: storage-api 쪽 구현이 더 견고함(`AbortSignal.timeout(30s)` 포함, fastapi-proxy.ts 버전엔 타임아웃이 아예 없었음)도 함께 얻는다.

`packages/storage-api/src/index.ts`에 `ApiCallError` 타입도 함께 export(기존엔 `fastapiCall`/`mapApiError` 값만 export).

## 게이트
- 기존 테스트(`fastapi-proxy.test.ts`의 `mapApiError` describe·`utils.test.ts`) 재-export로도 그대로 GREEN
- tsc/eslint 클린
- 전체 모노레포 vitest 396파일/3003개 GREEN(회귀 0)
- `pnpm build` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)