### PR TITLE
feat(#2493): 결제②-C2 — TossAdapter.charge + billing_orders + A2 원장 연동

### DIFF
--- a/backend/alembic/versions/0231_billing_orders.py
+++ b/backend/alembic/versions/0231_billing_orders.py
@@ -1,0 +1,54 @@
+"""#2493(C2) — billing_orders: charge 시도의 orderId-먼저-기록 pending/confirmed/failed 상태.
+
+설계문서 toss-adapter-c-plan-v0-1 §4 ⓐ(PO 확定). billing_ledger_entries(A2)는 append-only라
+"승인 대기 중" 상태를 담을 수 없다 — 이 테이블이 그 자리. 결제 성공 확定 시점에만
+billing_ledger_entries에 charge entry가 append된다(원장은 여전히 「정본」, 이 테이블은
+Toss 호출의 진행상태 기록일 뿐).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0231"
+down_revision = "0230"
+branch_labels = None
+depends_on = None
+
+_STATUSES = ["pending", "confirmed", "failed"]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not inspector.has_table("billing_orders"):
+        op.create_table(
+            "billing_orders",
+            sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+            sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+            # Toss 요구: 영문 대소문자·숫자·-·_ 6~64자.
+            sa.Column("order_id", sa.Text(), nullable=False),
+            sa.Column("amount_minor", sa.BigInteger(), nullable=False),
+            sa.Column("currency", sa.Text(), nullable=False),
+            sa.Column("status", sa.Text(), nullable=False, server_default="pending"),
+            # confirmed 시에만 채워짐 — billing_ledger_entries.provider_ref로 그대로 쓰인다.
+            sa.Column("payment_key", sa.Text(), nullable=True),
+            sa.Column("failure_reason", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+            sa.CheckConstraint(
+                f"status IN ({','.join(repr(s) for s in _STATUSES)})",
+                name="billing_orders_status_check",
+            ),
+            sa.CheckConstraint("currency IN ('usd','krw')", name="billing_orders_currency_check"),
+            sa.CheckConstraint("amount_minor > 0", name="billing_orders_amount_positive_check"),
+            sa.UniqueConstraint("order_id", name="uq_billing_orders_order_id"),
+        )
+        op.create_index("ix_billing_orders_org_id", "billing_orders", ["org_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_billing_orders_org_id", table_name="billing_orders")
+    op.drop_table("billing_orders")

--- a/backend/app/models/billing_order.py
+++ b/backend/app/models/billing_order.py
@@ -1,0 +1,26 @@
+"""결제②-C2(story #2493) — orderId-먼저-기록 pending/confirmed/failed. 되돌릴 수 없는 Toss
+호출 前에 의도를 먼저 남겨 크래시/타임아웃도 복구 가능하게 한다(C1 authKey nit과 동일 규율).
+billing_ledger_entries(A2, append-only)는 「승인 대기」 상태를 못 담아 이 테이블이 따로 있다."""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import BigInteger, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+from app.models.base import OrgScopedMixin, TimestampMixin
+
+
+class BillingOrder(Base, TimestampMixin, OrgScopedMixin):
+    __tablename__ = "billing_orders"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    # org_id: OrgScopedMixin(index만 — 한 org가 여러 주문을 가지므로 unique 아님, org_billing_keys와 다름).
+    order_id: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    amount_minor: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    currency: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="pending")
+    payment_key: Mapped[str | None] = mapped_column(Text, nullable=True)
+    failure_reason: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/services/billing_charge.py
+++ b/backend/app/services/billing_charge.py
@@ -2,6 +2,22 @@
 billing_ledger_entries 원장 기입. PO 계약(2026-08-07, `toss-adapter-c-plan-v0-1` §8 C2):
 **메커니즘만** — amount/currency/order_id는 파라미터로 받는다(「얼마 청구할지」 계산은
 별도 pricing-calc 스토리, offering_version×좌석×팩이 아직 배선 안 됨).
+
+PO 정밀 리뷰(#2882, 2026-08-07) — 「돈 움직이는」 스토리가 지켜야 할 crash/동시성
+무결성 불변식 둘을 여기서 강제한다:
+⛔블로커1(레이스) — confirmed를 failed가 절대 덮어쓰지 않는다. `_mark_failed_if_not_confirmed`
+   가 모든 실패 경로의 유일한 실패-기록 통로(status!='confirmed' 가드). 근본은 그 위:
+   pending을 **원자적으로 claim**(INSERT..ON CONFLICT DO NOTHING)해 애초에 같은 order_id를
+   두 세션이 동시에 Toss로 보내는 상황 자체를 구조적으로 차단한다 — advisory lock 불요,
+   UNIQUE 제약 자체가 락이다.
+⛔블로커2(비원자 saga) — confirmed ⟹ 원장 존재 불변식. 원장 기입을 confirmed-update
+   **前**에 먼저 한다(record_ledger_entry는 provider_ref UNIQUE로 그 자체가 멱등이라
+   먼저 해도 안전). 크래시가 원장-기입과 confirmed-update 사이에 나도, 재시도는 Toss의
+   DUPLICATED_ORDER_ID를 통해 이 함수로 다시 들어와 `_reconcile_duplicated_order`가
+   같은 provider_ref로 no-op 기입 후 confirmed로 정합시킨다.
+⚠️DUPLICATED_ORDER_ID(재시도가 이미 성공한 charge를 다시 침) — 진짜 실패가 아니라
+   "이미 성공"이라는 신호다. Toss 에러 응답엔 원 paymentKey가 없어(공식 문서 확認)
+   `get_payment_by_order_id` 조회로 확인 후 confirmed+원장으로 매핑한다.
 """
 from __future__ import annotations
 
@@ -15,7 +31,65 @@ from app.models.billing_order import BillingOrder
 from app.models.org_billing_key import OrgBillingKey
 from app.services.billing_key_crypto import decrypt_billing_key, ensure_configured
 from app.services.billing_ledger import record_ledger_entry
-from app.services.payment.toss_adapter import TossAdapter
+from app.services.payment.toss_adapter import DUPLICATED_ORDER_ID, TossAdapter, TossApiError
+
+
+async def _mark_failed_if_not_confirmed(session: AsyncSession, order_id: str, reason: str) -> None:
+    """⛔블로커1 최소-fix 가드(근본은 claim — 아래) — 이미 confirmed인 order를 failed가
+    절대 덮어쓰지 못한다."""
+    await session.execute(
+        update(BillingOrder)
+        .where(BillingOrder.order_id == order_id, BillingOrder.status != "confirmed")
+        .values(status="failed", failure_reason=reason[:500], updated_at=func.now())
+    )
+    await session.commit()
+
+
+async def _refetch(session: AsyncSession, order_id: str) -> BillingOrder:
+    return (
+        await session.execute(select(BillingOrder).where(BillingOrder.order_id == order_id))
+    ).scalar_one()
+
+
+async def _confirm_with_ledger(
+    session: AsyncSession, *, org_id: uuid.UUID, order_id: str,
+    amount_minor: int, currency: str, payment_key: str,
+) -> BillingOrder:
+    """⛔블로커2 fix — 원장을 confirmed-update **前**에 먼저(멱등 provider_ref)."""
+    await record_ledger_entry(
+        session, org_id=org_id, entry_type="charge", amount_minor=amount_minor,
+        currency=currency, direction="credit", provider="toss", provider_ref=payment_key,
+    )
+    await session.execute(
+        update(BillingOrder)
+        .where(BillingOrder.order_id == order_id, BillingOrder.status != "confirmed")
+        .values(status="confirmed", payment_key=payment_key, updated_at=func.now())
+    )
+    await session.commit()
+    return await _refetch(session, order_id)
+
+
+async def _reconcile_duplicated_order(
+    session: AsyncSession, *, org_id: uuid.UUID, order_id: str, amount_minor: int, currency: str,
+) -> BillingOrder:
+    """Toss가 DUPLICATED_ORDER_ID를 낸 경우 — 실 상태를 조회해 정합시킨다. DONE이면
+    "이미 성공"이었던 것(진짜 실패 아님) — confirmed+원장. 그 외(취소 등)면 failed."""
+    lookup = await TossAdapter().get_payment_by_order_id(order_id=order_id)
+    if lookup.get("status") != "DONE":
+        await _mark_failed_if_not_confirmed(
+            session, order_id, f"duplicated order lookup status={lookup.get('status')}"
+        )
+        return await _refetch(session, order_id)
+
+    payment_key = lookup.get("paymentKey")
+    if not payment_key:
+        await _mark_failed_if_not_confirmed(session, order_id, "duplicated order lookup missing paymentKey")
+        return await _refetch(session, order_id)
+
+    return await _confirm_with_ledger(
+        session, org_id=org_id, order_id=order_id, amount_minor=amount_minor,
+        currency=currency, payment_key=payment_key,
+    )
 
 
 async def charge_org(
@@ -28,22 +102,39 @@ async def charge_org(
     order_name: str = "Sprintable 정기결제",
 ) -> BillingOrder:
     """org의 활성 빌링키로 결제를 승인한다. 호출자(story C3 스케줄러)가 amount/currency/
-    order_id를 이미 계산해 넘긴다 — 여기는 그 값을 안전하게 집행하는 메커니즘만 진다.
-
-    같은 order_id로 재호출 시(재시도) — 이미 confirmed면 Toss를 다시 안 부르고 그대로
-    반환한다(진짜 멱등, ledger provider_ref UNIQUE와 동일 정신). pending/failed였던 order는
-    재시도로 다시 charge를 시도한다."""
+    order_id를 이미 계산해 넘긴다 — 여기는 그 값을 안전하게 집행하는 메커니즘만 진다."""
     if amount_minor <= 0:
         raise ValueError(f"amount_minor must be positive: {amount_minor!r}")
 
-    existing = (
-        await session.execute(select(BillingOrder).where(BillingOrder.order_id == order_id))
-    ).scalar_one_or_none()
-    if existing is not None and existing.status == "confirmed":
-        return existing
+    # ⭐블로커1 근본fix — 원자적 claim. ON CONFLICT DO NOTHING이 성공(rowcount==1)한
+    # 호출만 이 order_id의 charge 시도를 "소유"한다.
+    claim_stmt = pg_insert(BillingOrder).values(
+        id=uuid.uuid4(), org_id=org_id, order_id=order_id,
+        amount_minor=amount_minor, currency=currency, status="pending",
+    ).on_conflict_do_nothing(index_elements=["order_id"])
+    claim_result = await session.execute(claim_stmt)
+    await session.commit()
+    owns_attempt = claim_result.rowcount == 1
+
+    if not owns_attempt:
+        existing = await _refetch(session, order_id)
+        if existing.status in ("confirmed", "pending"):
+            # confirmed = 진짜 멱등(Toss 재호출 없이 반환). pending = 다른 호출이 지금
+            # 처리 중이거나 이전 크래시로 멈춘 것 — 이 호출은 소유권이 없으니 끼어들어
+            # 동시 Toss 호출을 만들지 않는다(재시도/대사는 C3/C4 스케줄러 몫).
+            return existing
+        # status == "failed" — 재시도 허용. CAS(failed→pending)에 성공한 호출만 소유한다.
+        reclaim = await session.execute(
+            update(BillingOrder)
+            .where(BillingOrder.order_id == order_id, BillingOrder.status == "failed")
+            .values(status="pending", updated_at=func.now())
+        )
+        await session.commit()
+        if reclaim.rowcount == 0:
+            return await _refetch(session, order_id)  # 레이스 패배 — 다른 호출이 이미 처리 중.
 
     # PO nit①과 동일 규율(C1 리뷰, #2880) — 되돌릴 수 없는 Toss charge 前에 암호화 키
-    # 가용성부터 확認. 여기선 charge 자체가 그 "되돌릴 수 없는 호출"이다.
+    # 가용성부터 확認(malformed 키까지 실제 구성해 검증).
     ensure_configured()
 
     billing_key_row = (
@@ -54,21 +145,8 @@ async def charge_org(
         )
     ).scalar_one_or_none()
     if billing_key_row is None:
+        await _mark_failed_if_not_confirmed(session, order_id, f"no active billing key for org {org_id}")
         raise RuntimeError(f"no active billing key for org {org_id}")
-
-    # ⭐orderId-먼저-기록 — Toss 호출 前에 pending으로 기록해 크래시/타임아웃(최대 60초)도
-    # 복구 가능하게 한다. amount/currency는 최초 기록 값을 정본으로 유지(재시도 시 덮어쓰지
-    # 않음 — 같은 order_id로 다른 금액이 들어오면 그건 호출자 버그이지 이 함수가 침묵하고
-    # 받아줄 자리가 아니다).
-    stmt = pg_insert(BillingOrder).values(
-        id=uuid.uuid4(), org_id=org_id, order_id=order_id,
-        amount_minor=amount_minor, currency=currency, status="pending",
-    )
-    stmt = stmt.on_conflict_do_update(
-        index_elements=["order_id"], set_={"status": "pending", "updated_at": func.now()},
-    )
-    await session.execute(stmt)
-    await session.commit()
 
     billing_key_plaintext = decrypt_billing_key(billing_key_row.encrypted_billing_key)
     try:
@@ -79,38 +157,28 @@ async def charge_org(
             amount_minor=amount_minor,
             order_name=order_name,
         )
-    except RuntimeError as exc:
-        await session.execute(
-            update(BillingOrder)
-            .where(BillingOrder.order_id == order_id)
-            .values(status="failed", failure_reason=str(exc)[:500], updated_at=func.now())
-        )
-        await session.commit()
+    except TossApiError as exc:
+        if exc.code == DUPLICATED_ORDER_ID:
+            # ⚠️진짜 실패 아님 — 이 orderId는 이미 처리된 적 있다는 뜻(Toss orderId 멱등).
+            return await _reconcile_duplicated_order(
+                session, org_id=org_id, order_id=order_id,
+                amount_minor=amount_minor, currency=currency,
+            )
+        await _mark_failed_if_not_confirmed(session, order_id, str(exc)[:500])
+        raise
+    except RuntimeError as exc:  # 네트워크 등 Toss API 도달 자체 실패
+        await _mark_failed_if_not_confirmed(session, order_id, str(exc)[:500])
         raise
     finally:
         # ⛔PO guard② — 평문 스코프 최소화(best-effort, 이 함수 프레임을 벗어나지 않는다).
         billing_key_plaintext = None  # noqa: F841
 
-    payment_key = result["paymentKey"]
-    await session.execute(
-        update(BillingOrder)
-        .where(BillingOrder.order_id == order_id)
-        .values(status="confirmed", payment_key=payment_key, updated_at=func.now())
-    )
-    await session.commit()
+    payment_key = result.get("paymentKey")
+    if not payment_key:
+        await _mark_failed_if_not_confirmed(session, order_id, "Toss charge response missing paymentKey")
+        raise RuntimeError("Toss charge response missing paymentKey")
 
-    # A2 원장 — 여기가 첫 실 producer(provider_ref=paymentKey UNIQUE가 이중 안전망).
-    await record_ledger_entry(
-        session,
-        org_id=org_id,
-        entry_type="charge",
-        amount_minor=amount_minor,
-        currency=currency,
-        direction="credit",
-        provider="toss",
-        provider_ref=payment_key,
+    return await _confirm_with_ledger(
+        session, org_id=org_id, order_id=order_id, amount_minor=amount_minor,
+        currency=currency, payment_key=payment_key,
     )
-
-    return (
-        await session.execute(select(BillingOrder).where(BillingOrder.order_id == order_id))
-    ).scalar_one()

--- a/backend/app/services/billing_charge.py
+++ b/backend/app/services/billing_charge.py
@@ -1,0 +1,116 @@
+"""결제②-C2(story #2493) — charge 오케스트레이션: orderId-먼저-기록 → TossAdapter.charge →
+billing_ledger_entries 원장 기입. PO 계약(2026-08-07, `toss-adapter-c-plan-v0-1` §8 C2):
+**메커니즘만** — amount/currency/order_id는 파라미터로 받는다(「얼마 청구할지」 계산은
+별도 pricing-calc 스토리, offering_version×좌석×팩이 아직 배선 안 됨).
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import func, select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.billing_order import BillingOrder
+from app.models.org_billing_key import OrgBillingKey
+from app.services.billing_key_crypto import decrypt_billing_key, ensure_configured
+from app.services.billing_ledger import record_ledger_entry
+from app.services.payment.toss_adapter import TossAdapter
+
+
+async def charge_org(
+    session: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    order_id: str,
+    amount_minor: int,
+    currency: str,
+    order_name: str = "Sprintable 정기결제",
+) -> BillingOrder:
+    """org의 활성 빌링키로 결제를 승인한다. 호출자(story C3 스케줄러)가 amount/currency/
+    order_id를 이미 계산해 넘긴다 — 여기는 그 값을 안전하게 집행하는 메커니즘만 진다.
+
+    같은 order_id로 재호출 시(재시도) — 이미 confirmed면 Toss를 다시 안 부르고 그대로
+    반환한다(진짜 멱등, ledger provider_ref UNIQUE와 동일 정신). pending/failed였던 order는
+    재시도로 다시 charge를 시도한다."""
+    if amount_minor <= 0:
+        raise ValueError(f"amount_minor must be positive: {amount_minor!r}")
+
+    existing = (
+        await session.execute(select(BillingOrder).where(BillingOrder.order_id == order_id))
+    ).scalar_one_or_none()
+    if existing is not None and existing.status == "confirmed":
+        return existing
+
+    # PO nit①과 동일 규율(C1 리뷰, #2880) — 되돌릴 수 없는 Toss charge 前에 암호화 키
+    # 가용성부터 확認. 여기선 charge 자체가 그 "되돌릴 수 없는 호출"이다.
+    ensure_configured()
+
+    billing_key_row = (
+        await session.execute(
+            select(OrgBillingKey).where(
+                OrgBillingKey.org_id == org_id, OrgBillingKey.status == "active"
+            )
+        )
+    ).scalar_one_or_none()
+    if billing_key_row is None:
+        raise RuntimeError(f"no active billing key for org {org_id}")
+
+    # ⭐orderId-먼저-기록 — Toss 호출 前에 pending으로 기록해 크래시/타임아웃(최대 60초)도
+    # 복구 가능하게 한다. amount/currency는 최초 기록 값을 정본으로 유지(재시도 시 덮어쓰지
+    # 않음 — 같은 order_id로 다른 금액이 들어오면 그건 호출자 버그이지 이 함수가 침묵하고
+    # 받아줄 자리가 아니다).
+    stmt = pg_insert(BillingOrder).values(
+        id=uuid.uuid4(), org_id=org_id, order_id=order_id,
+        amount_minor=amount_minor, currency=currency, status="pending",
+    )
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["order_id"], set_={"status": "pending", "updated_at": func.now()},
+    )
+    await session.execute(stmt)
+    await session.commit()
+
+    billing_key_plaintext = decrypt_billing_key(billing_key_row.encrypted_billing_key)
+    try:
+        result = await TossAdapter().charge(
+            billing_key=billing_key_plaintext,
+            customer_key=billing_key_row.customer_key,
+            order_id=order_id,
+            amount_minor=amount_minor,
+            order_name=order_name,
+        )
+    except RuntimeError as exc:
+        await session.execute(
+            update(BillingOrder)
+            .where(BillingOrder.order_id == order_id)
+            .values(status="failed", failure_reason=str(exc)[:500], updated_at=func.now())
+        )
+        await session.commit()
+        raise
+    finally:
+        # ⛔PO guard② — 평문 스코프 최소화(best-effort, 이 함수 프레임을 벗어나지 않는다).
+        billing_key_plaintext = None  # noqa: F841
+
+    payment_key = result["paymentKey"]
+    await session.execute(
+        update(BillingOrder)
+        .where(BillingOrder.order_id == order_id)
+        .values(status="confirmed", payment_key=payment_key, updated_at=func.now())
+    )
+    await session.commit()
+
+    # A2 원장 — 여기가 첫 실 producer(provider_ref=paymentKey UNIQUE가 이중 안전망).
+    await record_ledger_entry(
+        session,
+        org_id=org_id,
+        entry_type="charge",
+        amount_minor=amount_minor,
+        currency=currency,
+        direction="credit",
+        provider="toss",
+        provider_ref=payment_key,
+    )
+
+    return (
+        await session.execute(select(BillingOrder).where(BillingOrder.order_id == order_id))
+    ).scalar_one()

--- a/backend/app/services/billing_key_crypto.py
+++ b/backend/app/services/billing_key_crypto.py
@@ -46,8 +46,14 @@ def ensure_configured() -> None:
     """PO nit①(C1 리뷰, #2880 — 2026-08-07): 되돌릴 수 없는 외부 호출(Toss authKey 소모·
     charge 승인) 前에 암호화 키 가용성을 먼저 확認한다 — 호출 後에야 encrypt 실패로 502가
     나면 1회용 authKey/승인 시도를 헛되이 태운 것이 된다. C1의 issue_billing_key와 C2의
-    charge_org 둘 다 Toss 호출 直前에 이 함수를 먼저 부른다."""
-    _parse_keys(settings.org_billing_key_encryption_key)
+    charge_org 둘 다 Toss 호출 直前에 이 함수를 먼저 부른다.
+
+    PO 재지적(#2882 C2 리뷰, 2026-08-07 — 얕은 가드): 예전엔 ``_parse_keys``(문자열
+    존재 여부)만 봤다 — 키가 「있지만 malformed」(Fernet이 기대하는 base64 형식이 아님)면
+    이 가드를 통과한 뒤 Toss 호출 後 ``_get_multi_fernet()``에서야 터졌다(가드가 지키려던
+    바로 그 순서 위반이 malformed 키 케이스에서 그대로 재발). ``_get_multi_fernet()``을
+    실제로 구성해 Fernet 파싱 자체까지 이 시점에 검증한다."""
+    _get_multi_fernet()
 
 
 def encrypt_billing_key(plaintext: str) -> str:

--- a/backend/app/services/billing_key_crypto.py
+++ b/backend/app/services/billing_key_crypto.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-from cryptography.fernet import Fernet, InvalidToken, MultiFernet
+from cryptography.fernet import Fernet, MultiFernet
 
 from app.core.config import settings
 
@@ -42,6 +42,14 @@ def _get_multi_fernet() -> MultiFernet:
     return MultiFernet([Fernet(k) for k in keys])
 
 
+def ensure_configured() -> None:
+    """PO nit①(C1 리뷰, #2880 — 2026-08-07): 되돌릴 수 없는 외부 호출(Toss authKey 소모·
+    charge 승인) 前에 암호화 키 가용성을 먼저 확認한다 — 호출 後에야 encrypt 실패로 502가
+    나면 1회용 authKey/승인 시도를 헛되이 태운 것이 된다. C1의 issue_billing_key와 C2의
+    charge_org 둘 다 Toss 호출 直前에 이 함수를 먼저 부른다."""
+    _parse_keys(settings.org_billing_key_encryption_key)
+
+
 def encrypt_billing_key(plaintext: str) -> str:
     """평문 빌링키 → Fernet 토큰(맨 앞 키로 암호화). DB 저장용."""
     token = _get_multi_fernet().encrypt(plaintext.encode())
@@ -51,8 +59,5 @@ def encrypt_billing_key(plaintext: str) -> str:
 def decrypt_billing_key(token: str) -> str:
     """Fernet 토큰 → 평문 빌링키. ⛔호출자는 이 반환값을 charge 요청 구성에만 즉시 쓰고
     변수를 더 들고 있거나 로깅하지 않는다. 등록된 키 어느 것으로도 복호 실패 시
-    ``InvalidToken``을 그대로 전파(회전 중 옛 키가 빠졌다는 신호 — 조용히 삼키지 않는다)."""
-    try:
-        return _get_multi_fernet().decrypt(token.encode()).decode()
-    except InvalidToken:
-        raise
+    ``InvalidToken``이 그대로 전파된다(회전 중 옛 키가 빠졌다는 신호 — 조용히 삼키지 않는다)."""
+    return _get_multi_fernet().decrypt(token.encode()).decode()

--- a/backend/app/services/org_billing_key.py
+++ b/backend/app/services/org_billing_key.py
@@ -8,12 +8,12 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.org_billing_key import OrgBillingKey
-from app.services.billing_key_crypto import encrypt_billing_key
+from app.services.billing_key_crypto import encrypt_billing_key, ensure_configured
 from app.services.payment.toss_adapter import TossAdapter
 
 
@@ -32,6 +32,11 @@ async def issue_billing_key(
     기존 행이 있으면(재발급 = 카드 교체) 그 customer_key를 재사용 — Toss 쪽 고객 식별을
     유지한다. 새 billingKey로 UPDATE(이전 빌링키의 Toss측 폐기는 story C4 대상, 여기서는
     저장 갱신만)."""
+    # PO nit①(#2880 리뷰, 2026-08-07 — C2에서 함께 정리): 되돌릴 수 없는 authKey 소모(아래
+    # create_billing_key) 前에 암호화 키 가용성부터 확認 — 순서를 바꾸면 authKey를 태우고도
+    # encrypt 단계에서 502가 나는 낭비가 생긴다.
+    ensure_configured()
+
     existing = (
         await session.execute(select(OrgBillingKey).where(OrgBillingKey.org_id == org_id))
     ).scalar_one_or_none()
@@ -63,7 +68,13 @@ async def issue_billing_key(
     stmt = pg_insert(OrgBillingKey).values(id=uuid.uuid4(), **values)
     stmt = stmt.on_conflict_do_update(
         index_elements=["org_id"],
-        set_={k: v for k, v in values.items() if k not in ("org_id", "customer_key")},
+        # 재발급(UPDATE 경로) — TimestampMixin의 onupdate=func.now()는 ORM UPDATE 문에만
+        # 붙는 파이썬 레벨 훅이라 raw INSERT..ON CONFLICT DO UPDATE는 안 거친다(PO nit②,
+        # #2880 리뷰). updated_at을 SET 절에 명시로 넣어 재발급 시에도 갱신되게 한다.
+        set_={
+            **{k: v for k, v in values.items() if k not in ("org_id", "customer_key")},
+            "updated_at": func.now(),
+        },
     )
     await session.execute(stmt)
     await session.commit()

--- a/backend/app/services/payment/toss_adapter.py
+++ b/backend/app/services/payment/toss_adapter.py
@@ -22,7 +22,7 @@ from app.services.payment.base import PaymentProvider
 logger = logging.getLogger(__name__)
 
 _API_BASE = "https://api.tosspayments.com"
-# docs.tosspayments.com/reference — 빌링키 발급(2026-08-07 공식 문서 직접 대조).
+# docs.tosspayments.com/reference — 2026-08-07 공식 문서 직접 대조(훈련데이터만 안 믿음).
 _ISSUE_BILLING_KEY_PATH = "/v1/billing/authorizations/issue"
 
 
@@ -36,32 +36,34 @@ class TossAdapter(PaymentProvider):
         token = base64.b64encode(f"{settings.toss_payments_secret_key}:".encode()).decode()
         return {"Authorization": f"Basic {token}", "Content-Type": "application/json"}
 
+    async def _post(self, path: str, *, json: dict, timeout: float, op_label: str) -> dict:
+        """공용 POST 왕복 — create_billing_key/charge가 공유하는 에러 처리(⛔응답 바디를
+        그대로 로깅하지 않는다 — Toss 에러 응답이 요청 파라미터를 echo하는 경우가 있어
+        customerKey 등 민감정보 유출 표면을 늘릴 수 있다. code/status만 남긴다)."""
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                resp = await client.post(f"{_API_BASE}{path}", headers=self._auth_header(), json=json)
+        except httpx.RequestError as exc:
+            logger.exception("Toss %s request failed", op_label)
+            raise RuntimeError("Cannot reach Toss API") from exc
+
+        if resp.status_code not in (200, 201):
+            body = resp.json() if resp.headers.get("content-type", "").startswith("application/json") else {}
+            logger.error("Toss %s error: status=%s code=%s", op_label, resp.status_code, body.get("code"))
+            raise RuntimeError(f"Toss {op_label} failed: {body.get('code', resp.status_code)}")
+
+        return resp.json()
+
     async def create_billing_key(self, *, auth_key: str, customer_key: str) -> dict:
         """POST /v1/billing/authorizations/issue — FE 위젯이 넘긴 authKey + customerKey로
         재사용 가능한 billingKey를 발급받는다. 응답 그대로 반환(billingKey 평문 포함 —
         호출자가 즉시 암호화해 저장하고 이 dict를 더 들고 있지 않아야 한다, 로깅 금지)."""
-        try:
-            async with httpx.AsyncClient(timeout=15) as client:
-                resp = await client.post(
-                    f"{_API_BASE}{_ISSUE_BILLING_KEY_PATH}",
-                    headers=self._auth_header(),
-                    json={"authKey": auth_key, "customerKey": customer_key},
-                )
-        except httpx.RequestError as exc:
-            logger.exception("Toss billing key issuance request failed")
-            raise RuntimeError("Cannot reach Toss API") from exc
-
-        if resp.status_code not in (200, 201):
-            # ⛔응답 바디를 그대로 로깅하지 않는다 — Toss 에러 응답이 요청 파라미터를 echo하는
-            # 경우가 있어(예: customerKey) 민감정보 유출 표면을 늘릴 수 있다. code/status만.
-            body = resp.json() if resp.headers.get("content-type", "").startswith("application/json") else {}
-            logger.error(
-                "Toss billing key issuance error: status=%s code=%s",
-                resp.status_code, body.get("code"),
-            )
-            raise RuntimeError(f"Toss billing key issuance failed: {body.get('code', resp.status_code)}")
-
-        return resp.json()
+        return await self._post(
+            _ISSUE_BILLING_KEY_PATH,
+            json={"authKey": auth_key, "customerKey": customer_key},
+            timeout=15,
+            op_label="billing key issuance",
+        )
 
     async def create_customer(self, **kwargs: Any) -> dict:
         raise NotImplementedError(
@@ -75,8 +77,28 @@ class TossAdapter(PaymentProvider):
             "위젯 플로우(create_billing_key 참고). 해당 없음."
         )
 
-    async def charge(self, **kwargs: Any) -> dict:
-        raise NotImplementedError("TossAdapter.charge — story C2 대상(billing_orders+원장 연동).")
+    async def charge(
+        self, *, billing_key: str, customer_key: str, order_id: str, amount_minor: int, order_name: str,
+    ) -> dict:
+        """POST /v1/billing/{billingKey} — 빌링키 자동결제 승인(story #2493 C2). 성공 웹훅이
+        없으므로(§0) **이 동기 응답이 정본**. 최대 60초 소요 가능(Toss 문서 명시) — 호출자
+        (org_billing_key.py의 charge_org 등)가 이 함수를 부르기 前에 billing_orders를
+        pending으로 먼저 기록해둬야 타임아웃/크래시에도 복구 가능하다(이 어댑터 자체는 그
+        규율을 강제하지 않는다 — 순수 PG 왕복 레이어).
+
+        amount_minor: KRW는 무소수 통화라 minor unit이 곧 원 단위 정수 — Toss의 `amount`
+        필드에 그대로 넘긴다(달러처럼 /100 환산 불요)."""
+        return await self._post(
+            f"/v1/billing/{billing_key}",
+            json={
+                "customerKey": customer_key,
+                "orderId": order_id,
+                "amount": amount_minor,
+                "orderName": order_name,
+            },
+            timeout=65,  # Toss 문서: 최대 60초 소요 가능 — 여유 5초.
+            op_label="charge",
+        )
 
     def verify_webhook(self, raw_body: bytes, signature: str | None) -> bool:
         raise NotImplementedError("TossAdapter.verify_webhook — story C4 대상(BILLING_DELETED 보조 이벤트).")

--- a/backend/app/services/payment/toss_adapter.py
+++ b/backend/app/services/payment/toss_adapter.py
@@ -25,6 +25,22 @@ _API_BASE = "https://api.tosspayments.com"
 # docs.tosspayments.com/reference — 2026-08-07 공식 문서 직접 대조(훈련데이터만 안 믿음).
 _ISSUE_BILLING_KEY_PATH = "/v1/billing/authorizations/issue"
 
+# PO 리뷰 블로커(2026-08-07, #2882) — orderId 중복(재시도가 이미 성공한 charge를 다시
+# 침) 시 실제 Toss 에러 코드. "ALREADY_PROCESSED_PAYMENT"는 구어체 표기였고 공식 문서
+# 재대조 결과 정확한 코드는 이것 — charge_org가 이 값으로 분기(재확認 필요).
+DUPLICATED_ORDER_ID = "DUPLICATED_ORDER_ID"
+
+
+class TossApiError(RuntimeError):
+    """Toss 에러 응답(code/message) 구조화 — 호출자가 특정 code(예: DUPLICATED_ORDER_ID)로
+    분기해야 하는 경우(charge_org의 중복 재시도 처리) bare RuntimeError 문자열 매칭보다
+    안전하다."""
+
+    def __init__(self, code: str, message: str, *, status_code: int):
+        self.code = code
+        self.status_code = status_code
+        super().__init__(f"{code}: {message}" if message else code)
+
 
 class TossAdapter(PaymentProvider):
     def _auth_header(self) -> dict[str, str]:
@@ -49,8 +65,26 @@ class TossAdapter(PaymentProvider):
 
         if resp.status_code not in (200, 201):
             body = resp.json() if resp.headers.get("content-type", "").startswith("application/json") else {}
-            logger.error("Toss %s error: status=%s code=%s", op_label, resp.status_code, body.get("code"))
-            raise RuntimeError(f"Toss {op_label} failed: {body.get('code', resp.status_code)}")
+            code = body.get("code", str(resp.status_code))
+            logger.error("Toss %s error: status=%s code=%s", op_label, resp.status_code, code)
+            raise TossApiError(code, f"Toss {op_label} failed", status_code=resp.status_code)
+
+        return resp.json()
+
+    async def _get(self, path: str, *, timeout: float, op_label: str) -> dict:
+        """공용 GET 왕복 — 결제 조회(get_payment_by_order_id)용. _post와 동일 에러 처리."""
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                resp = await client.get(f"{_API_BASE}{path}", headers=self._auth_header())
+        except httpx.RequestError as exc:
+            logger.exception("Toss %s request failed", op_label)
+            raise RuntimeError("Cannot reach Toss API") from exc
+
+        if resp.status_code != 200:
+            body = resp.json() if resp.headers.get("content-type", "").startswith("application/json") else {}
+            code = body.get("code", str(resp.status_code))
+            logger.error("Toss %s error: status=%s code=%s", op_label, resp.status_code, code)
+            raise TossApiError(code, f"Toss {op_label} failed", status_code=resp.status_code)
 
         return resp.json()
 
@@ -98,6 +132,16 @@ class TossAdapter(PaymentProvider):
             },
             timeout=65,  # Toss 문서: 최대 60초 소요 가능 — 여유 5초.
             op_label="charge",
+        )
+
+    async def get_payment_by_order_id(self, *, order_id: str) -> dict:
+        """GET /v1/payments/orders/{orderId} — PaymentProvider 8메서드 밖의 보조 조회
+        (story #2493 C2, PO 리뷰 권장). charge가 `DUPLICATED_ORDER_ID`로 실패했을 때(=
+        이 orderId가 이미 처리된 적이 있다는 뜻이지 신규 실패가 아니다) 실제 결제 상태·
+        paymentKey를 여기서 확認한다 — Toss 에러 응답 자체엔 그 정보가 없어(공식 문서
+        확認) 조회가 유일한 경로."""
+        return await self._get(
+            f"/v1/payments/orders/{order_id}", timeout=15, op_label="payment lookup",
         )
 
     def verify_webhook(self, raw_body: bytes, signature: str | None) -> bool:

--- a/backend/tests/test_e_2492_c1_billing_key.py
+++ b/backend/tests/test_e_2492_c1_billing_key.py
@@ -159,6 +159,15 @@ def test_billing_key_crypto_not_configured_raises(monkeypatch):
         crypto.encrypt_billing_key("x")
 
 
+def test_ensure_configured_catches_malformed_key_not_just_missing(monkeypatch):
+    """PO 재지적(#2882 C2 리뷰) — 「있지만 malformed」 키(Fernet이 기대하는 base64 형식이
+    아님)도 ensure_configured()가 실제 MultiFernet 구성까지 해봐서 이 시점에 잡아야 한다
+    (문자열 존재 여부만 보는 얕은 체크였으면 여길 통과하고 Toss 호출 後에야 터졌을 것)."""
+    crypto = _fresh_crypto_module_with_keys(monkeypatch, "not-a-valid-fernet-key")
+    with pytest.raises(ValueError, match="Fernet key"):
+        crypto.ensure_configured()
+
+
 # ─── org_billing_key.issue_billing_key — 오케스트레이션 ────────────────────
 
 @pytest.mark.anyio

--- a/backend/tests/test_e_2492_c1_billing_key.py
+++ b/backend/tests/test_e_2492_c1_billing_key.py
@@ -19,7 +19,7 @@ from tests.conftest import override_db_and_read
     [
         ("create_customer", {}),
         ("create_checkout", {}),
-        ("charge", {}),
+        # charge는 #2493(C2)로 실 구현됨 — test_e_2493_c2_charge_ledger.py로 이동.
         ("refund", {}),
         ("open_portal", {}),
         ("cancel", {}),
@@ -175,6 +175,7 @@ async def test_issue_billing_key_new_org_generates_customer_key_and_persists(mon
     session.execute = AsyncMock(side_effect=[no_existing, MagicMock(), persisted])
     session.commit = AsyncMock()
 
+    monkeypatch.setattr(svc, "ensure_configured", MagicMock())
     monkeypatch.setattr(
         svc.TossAdapter, "create_billing_key",
         AsyncMock(return_value={
@@ -209,6 +210,7 @@ async def test_issue_billing_key_reuses_existing_customer_key(monkeypatch):
     session.execute = AsyncMock(side_effect=[existing_result, MagicMock(), persisted])
     session.commit = AsyncMock()
 
+    monkeypatch.setattr(svc, "ensure_configured", MagicMock())
     create_billing_key_mock = AsyncMock(return_value={
         "billingKey": "plaintext_bk2", "authenticatedAt": "2026-08-07T00:00:00+09:00", "card": {},
     })
@@ -218,6 +220,59 @@ async def test_issue_billing_key_reuses_existing_customer_key(monkeypatch):
     await svc.issue_billing_key(session, org_id=org_id, auth_key="auth_y")
 
     create_billing_key_mock.assert_awaited_once_with(auth_key="auth_y", customer_key="org-existing-key")
+
+
+@pytest.mark.anyio
+async def test_issue_billing_key_checks_crypto_before_consuming_auth_key(monkeypatch):
+    """PO nit①(#2880 리뷰) 회귀 고정 — 암호화 키 미설정이면 1회용 authKey를 소모하는
+    create_billing_key 호출 자체를 하지 않는다(호출 순서 증명)."""
+    from app.services import org_billing_key as svc
+    from app.services.billing_key_crypto import BillingKeyEncryptionNotConfigured
+
+    session = AsyncMock()
+    monkeypatch.setattr(
+        svc, "ensure_configured", MagicMock(side_effect=BillingKeyEncryptionNotConfigured("x"))
+    )
+    create_billing_key_mock = AsyncMock()
+    monkeypatch.setattr(svc.TossAdapter, "create_billing_key", create_billing_key_mock)
+
+    with pytest.raises(BillingKeyEncryptionNotConfigured):
+        await svc.issue_billing_key(session, org_id=uuid.uuid4(), auth_key="auth_never_used")
+
+    create_billing_key_mock.assert_not_awaited()
+    session.execute.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_issue_billing_key_reissue_bumps_updated_at(monkeypatch):
+    """PO nit②(#2880 리뷰) 회귀 고정 — ON CONFLICT DO UPDATE 재발급 경로도 updated_at을
+    명시로 갱신한다(ORM onupdate는 raw INSERT..ON CONFLICT를 안 거쳐 무력했던 것)."""
+    from app.services import org_billing_key as svc
+
+    org_id = uuid.uuid4()
+    existing_row = MagicMock()
+    existing_row.customer_key = "org-existing-key"
+    session = AsyncMock()
+    existing_result = MagicMock()
+    existing_result.scalar_one_or_none.return_value = existing_row
+    persisted = MagicMock()
+    session.execute = AsyncMock(side_effect=[existing_result, MagicMock(), persisted])
+    session.commit = AsyncMock()
+
+    monkeypatch.setattr(svc, "ensure_configured", MagicMock())
+    monkeypatch.setattr(
+        svc.TossAdapter, "create_billing_key",
+        AsyncMock(return_value={"billingKey": "bk3", "authenticatedAt": "2026-08-07T00:00:00+09:00", "card": {}}),
+    )
+    monkeypatch.setattr(svc, "encrypt_billing_key", MagicMock(return_value="enc-token3"))
+
+    await svc.issue_billing_key(session, org_id=org_id, auth_key="auth_z")
+
+    insert_call = session.execute.call_args_list[1]
+    stmt = insert_call.args[0]
+    on_conflict_set = stmt._post_values_clause.update_values_to_set
+    set_columns = {c if isinstance(c, str) else c.name for c, _ in on_conflict_set}
+    assert "updated_at" in set_columns
 
 
 # ─── POST /api/v2/org-billing-keys — 엔드포인트(양성/음성/unauth/X-Project-Id 무관) ──

--- a/backend/tests/test_e_2493_c2_charge_ledger.py
+++ b/backend/tests/test_e_2493_c2_charge_ledger.py
@@ -1,0 +1,260 @@
+"""#2493(C2) — TossAdapter.charge + billing_orders(orderId-먼저-기록) + A2 원장 연동.
+PO 계약(2026-08-07): C2는 메커니즘만 — amount/currency/order_id는 파라미터."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ─── TossAdapter.charge — 실 HTTP 파이프라인 ───────────────────────────────
+
+@pytest.mark.anyio
+async def test_toss_charge_success():
+    from app.services.payment.toss_adapter import TossAdapter
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "paymentKey": "pay_key_123", "status": "DONE", "totalAmount": 29000,
+        "approvedAt": "2026-08-07T00:00:00+09:00",
+        "orderId": "ord-abc123", "orderName": "Sprintable 정기결제",
+        "card": {"issuerCode": "61", "number": "1234********5678"},
+        "receipt": {"url": "https://dashboard.tosspayments.com/receipt/abc"},
+    }
+
+    with patch("app.services.payment.toss_adapter.settings") as mock_settings:
+        mock_settings.toss_payments_secret_key = "test_sk_dummy"
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value.post = AsyncMock(return_value=mock_resp)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            adapter = TossAdapter()
+            result = await adapter.charge(
+                billing_key="billing_key_plain", customer_key="cust_x",
+                order_id="ord-abc123", amount_minor=29000, order_name="Sprintable 정기결제",
+            )
+
+    assert result["paymentKey"] == "pay_key_123"
+    assert result["totalAmount"] == 29000
+    call_args = mock_client.__aenter__.return_value.post.call_args
+    assert call_args.args[0].endswith("/v1/billing/billing_key_plain")
+    assert call_args.kwargs["json"] == {
+        "customerKey": "cust_x", "orderId": "ord-abc123", "amount": 29000,
+        "orderName": "Sprintable 정기결제",
+    }
+
+
+@pytest.mark.anyio
+async def test_toss_charge_error_status_raises_runtime_error():
+    from app.services.payment.toss_adapter import TossAdapter
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 400
+    mock_resp.headers = {"content-type": "application/json"}
+    mock_resp.json.return_value = {"code": "REJECT_CARD_COMPANY", "message": "..."}
+
+    with patch("app.services.payment.toss_adapter.settings") as mock_settings:
+        mock_settings.toss_payments_secret_key = "test_sk_dummy"
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value.post = AsyncMock(return_value=mock_resp)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            adapter = TossAdapter()
+            with pytest.raises(RuntimeError, match="REJECT_CARD_COMPANY"):
+                await adapter.charge(
+                    billing_key="bk", customer_key="cust_x", order_id="ord-x",
+                    amount_minor=1000, order_name="test",
+                )
+
+
+@pytest.mark.anyio
+async def test_toss_charge_no_secret_fails_closed():
+    from app.services.payment.toss_adapter import TossAdapter
+
+    with patch("app.services.payment.toss_adapter.settings") as mock_settings:
+        mock_settings.toss_payments_secret_key = ""
+        adapter = TossAdapter()
+        with pytest.raises(RuntimeError, match="TOSS_PAYMENTS_SECRET_KEY"):
+            await adapter.charge(
+                billing_key="bk", customer_key="cust_x", order_id="ord-x",
+                amount_minor=1000, order_name="test",
+            )
+
+
+# ─── charge_org — orderId-먼저-기록 오케스트레이션 ──────────────────────────
+
+def _mock_billing_key_row(*, org_id: uuid.UUID):
+    row = MagicMock()
+    row.org_id = org_id
+    row.status = "active"
+    row.customer_key = "cust_existing"
+    row.encrypted_billing_key = "enc-token"
+    return row
+
+
+@pytest.mark.anyio
+async def test_charge_org_rejects_non_positive_amount():
+    from app.services.billing_charge import charge_org
+
+    session = AsyncMock()
+    with pytest.raises(ValueError, match="amount_minor"):
+        await charge_org(session, org_id=uuid.uuid4(), order_id="ord-x", amount_minor=0, currency="krw")
+    session.execute.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_charge_org_confirmed_order_short_circuits_no_toss_call(monkeypatch):
+    """진짜 멱등 — 이미 confirmed면 Toss를 다시 안 부른다."""
+    from app.models.billing_order import BillingOrder
+    import app.services.billing_charge as svc
+
+    confirmed_row = MagicMock(spec=BillingOrder)
+    confirmed_row.status = "confirmed"
+    session = AsyncMock()
+    existing_result = MagicMock()
+    existing_result.scalar_one_or_none.return_value = confirmed_row
+    session.execute = AsyncMock(return_value=existing_result)
+
+    charge_mock = AsyncMock()
+    monkeypatch.setattr(svc.TossAdapter, "charge", charge_mock)
+
+    result = await svc.charge_org(session, org_id=uuid.uuid4(), order_id="ord-dup", amount_minor=29000, currency="krw")
+
+    assert result is confirmed_row
+    charge_mock.assert_not_awaited()
+    session.execute.assert_awaited_once()  # existing-check만, pending insert도 안 함
+
+
+@pytest.mark.anyio
+async def test_charge_org_no_active_billing_key_raises(monkeypatch):
+    import app.services.billing_charge as svc
+
+    org_id = uuid.uuid4()
+    session = AsyncMock()
+    no_existing_order = MagicMock()
+    no_existing_order.scalar_one_or_none.return_value = None
+    no_billing_key = MagicMock()
+    no_billing_key.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(side_effect=[no_existing_order, no_billing_key])
+
+    monkeypatch.setattr(svc, "ensure_configured", MagicMock())
+
+    with pytest.raises(RuntimeError, match="no active billing key"):
+        await svc.charge_org(session, org_id=org_id, order_id="ord-x", amount_minor=29000, currency="krw")
+
+
+@pytest.mark.anyio
+async def test_charge_org_checks_crypto_before_calling_toss(monkeypatch):
+    """PO nit①과 동형 규율 — charge도 되돌릴 수 없는 외부호출 前에 crypto 가용성 확認."""
+    import app.services.billing_charge as svc
+    from app.services.billing_key_crypto import BillingKeyEncryptionNotConfigured
+
+    org_id = uuid.uuid4()
+    session = AsyncMock()
+    no_existing_order = MagicMock()
+    no_existing_order.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=no_existing_order)
+
+    monkeypatch.setattr(
+        svc, "ensure_configured", MagicMock(side_effect=BillingKeyEncryptionNotConfigured("x"))
+    )
+    charge_mock = AsyncMock()
+    monkeypatch.setattr(svc.TossAdapter, "charge", charge_mock)
+
+    with pytest.raises(BillingKeyEncryptionNotConfigured):
+        await svc.charge_org(session, org_id=org_id, order_id="ord-x", amount_minor=29000, currency="krw")
+
+    charge_mock.assert_not_awaited()
+    # existing-check(1)만 — billing key 조회·pending insert 전부 crypto 확認보다 먼저 안 감.
+    assert session.execute.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_charge_org_writes_pending_before_calling_toss(monkeypatch):
+    """⭐orderId-먼저-기록 — Toss charge 호출 前에 billing_orders가 pending으로 먼저
+    기록되는지 순서를 직접 증명한다."""
+    import app.services.billing_charge as svc
+
+    org_id = uuid.uuid4()
+    order_id = "ord-order1"
+    session = AsyncMock()
+
+    no_existing_order = MagicMock()
+    no_existing_order.scalar_one_or_none.return_value = None
+    billing_key_result = MagicMock()
+    billing_key_result.scalar_one_or_none.return_value = _mock_billing_key_row(org_id=org_id)
+    pending_insert_result = MagicMock()
+    confirmed_update_result = MagicMock()
+    final_select_result = MagicMock()
+    final_row = MagicMock()
+    final_select_result.scalar_one.return_value = final_row
+
+    session.execute = AsyncMock(side_effect=[
+        no_existing_order, billing_key_result, pending_insert_result,
+        confirmed_update_result, final_select_result,
+    ])
+    session.commit = AsyncMock()
+
+    monkeypatch.setattr(svc, "ensure_configured", MagicMock())
+    monkeypatch.setattr(svc, "decrypt_billing_key", MagicMock(return_value="plaintext_bk"))
+
+    async def _toss_charge(*args, **kwargs):
+        return {"paymentKey": "pay_key_xyz"}
+
+    monkeypatch.setattr(svc.TossAdapter, "charge", _toss_charge)
+    monkeypatch.setattr(svc, "record_ledger_entry", AsyncMock())
+
+    result = await svc.charge_org(session, org_id=org_id, order_id=order_id, amount_minor=29000, currency="krw")
+
+    assert result is final_row
+    # 3번째 session.execute 호출(pending insert)이 pg_insert INSERT..ON CONFLICT문이었는지.
+    pending_insert_call = session.execute.call_args_list[2]
+    compiled = pending_insert_call.args[0].compile().params
+    assert compiled["order_id"] == order_id
+    assert compiled["status"] == "pending"
+    # 4번째 호출(confirmed update)이 결제 성공 뒤에야 실행됨 — call_args_list 순서 자체가
+    # pending(2번째 인덱스)이 먼저, Toss 결과 반영 update(3번째 인덱스)가 그 다음임을 보증
+    # (mock side_effect가 순서대로 소비되므로 이 assert가 실패하면 순서가 깨진 것).
+    confirmed_update_call = session.execute.call_args_list[3]
+    update_compiled = confirmed_update_call.args[0].compile().params
+    assert update_compiled["status"] == "confirmed"
+    assert update_compiled["payment_key"] == "pay_key_xyz"
+
+    svc.record_ledger_entry.assert_awaited_once()
+    ledger_kwargs = svc.record_ledger_entry.call_args.kwargs
+    assert ledger_kwargs["provider_ref"] == "pay_key_xyz"
+    assert ledger_kwargs["entry_type"] == "charge"
+
+
+@pytest.mark.anyio
+async def test_charge_org_toss_failure_marks_order_failed_and_reraises(monkeypatch):
+    import app.services.billing_charge as svc
+
+    org_id = uuid.uuid4()
+    session = AsyncMock()
+    no_existing_order = MagicMock()
+    no_existing_order.scalar_one_or_none.return_value = None
+    billing_key_result = MagicMock()
+    billing_key_result.scalar_one_or_none.return_value = _mock_billing_key_row(org_id=org_id)
+    pending_insert_result = MagicMock()
+    failed_update_result = MagicMock()
+    session.execute = AsyncMock(side_effect=[
+        no_existing_order, billing_key_result, pending_insert_result, failed_update_result,
+    ])
+    session.commit = AsyncMock()
+
+    monkeypatch.setattr(svc, "ensure_configured", MagicMock())
+    monkeypatch.setattr(svc, "decrypt_billing_key", MagicMock(return_value="plaintext_bk"))
+    monkeypatch.setattr(
+        svc.TossAdapter, "charge", AsyncMock(side_effect=RuntimeError("Toss charge failed: EXCEED_MAX_DAILY_PAYMENT_COUNT"))
+    )
+    monkeypatch.setattr(svc, "record_ledger_entry", AsyncMock())
+
+    with pytest.raises(RuntimeError, match="EXCEED_MAX_DAILY_PAYMENT_COUNT"):
+        await svc.charge_org(session, org_id=org_id, order_id="ord-fail", amount_minor=29000, currency="krw")
+
+    failed_call = session.execute.call_args_list[3]
+    compiled = failed_call.args[0].compile().params
+    assert compiled["status"] == "failed"
+    assert "EXCEED_MAX_DAILY_PAYMENT_COUNT" in compiled["failure_reason"]
+    svc.record_ledger_entry.assert_not_awaited()

--- a/backend/tests/test_e_2493_c2_charge_ledger.py
+++ b/backend/tests/test_e_2493_c2_charge_ledger.py
@@ -81,7 +81,30 @@ async def test_toss_charge_no_secret_fails_closed():
             )
 
 
-# ─── charge_org — orderId-먼저-기록 오케스트레이션 ──────────────────────────
+# ─── TossAdapter.get_payment_by_order_id ───────────────────────────────────
+
+@pytest.mark.anyio
+async def test_toss_get_payment_by_order_id_success():
+    from app.services.payment.toss_adapter import TossAdapter
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"paymentKey": "pay_key_recovered", "status": "DONE", "totalAmount": 29000}
+
+    with patch("app.services.payment.toss_adapter.settings") as mock_settings:
+        mock_settings.toss_payments_secret_key = "test_sk_dummy"
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value.get = AsyncMock(return_value=mock_resp)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            adapter = TossAdapter()
+            result = await adapter.get_payment_by_order_id(order_id="ord-dup1")
+
+    assert result["paymentKey"] == "pay_key_recovered"
+    call_args = mock_client.__aenter__.return_value.get.call_args
+    assert call_args.args[0].endswith("/v1/payments/orders/ord-dup1")
+
+
+# ─── charge_org — 원자적 claim + orderId-먼저-기록 오케스트레이션 ──────────
 
 def _mock_billing_key_row(*, org_id: uuid.UUID):
     row = MagicMock()
@@ -90,6 +113,19 @@ def _mock_billing_key_row(*, org_id: uuid.UUID):
     row.customer_key = "cust_existing"
     row.encrypted_billing_key = "enc-token"
     return row
+
+
+def _claimed_result(rowcount: int) -> MagicMock:
+    r = MagicMock()
+    r.rowcount = rowcount
+    return r
+
+
+def _row_result(row) -> MagicMock:
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = row
+    r.scalar_one.return_value = row
+    return r
 
 
 @pytest.mark.anyio
@@ -104,16 +140,14 @@ async def test_charge_org_rejects_non_positive_amount():
 
 @pytest.mark.anyio
 async def test_charge_org_confirmed_order_short_circuits_no_toss_call(monkeypatch):
-    """진짜 멱등 — 이미 confirmed면 Toss를 다시 안 부른다."""
+    """진짜 멱등 — claim이 conflict(rowcount=0)나고 기존 행이 confirmed면 Toss를 안 부른다."""
     from app.models.billing_order import BillingOrder
     import app.services.billing_charge as svc
 
     confirmed_row = MagicMock(spec=BillingOrder)
     confirmed_row.status = "confirmed"
     session = AsyncMock()
-    existing_result = MagicMock()
-    existing_result.scalar_one_or_none.return_value = confirmed_row
-    session.execute = AsyncMock(return_value=existing_result)
+    session.execute = AsyncMock(side_effect=[_claimed_result(0), _row_result(confirmed_row)])
 
     charge_mock = AsyncMock()
     monkeypatch.setattr(svc.TossAdapter, "charge", charge_mock)
@@ -122,7 +156,87 @@ async def test_charge_org_confirmed_order_short_circuits_no_toss_call(monkeypatc
 
     assert result is confirmed_row
     charge_mock.assert_not_awaited()
-    session.execute.assert_awaited_once()  # existing-check만, pending insert도 안 함
+    assert session.execute.await_count == 2  # claim(conflict) + 기존행 조회. 그 이상 안 감.
+
+
+@pytest.mark.anyio
+async def test_charge_org_pending_owned_by_other_returns_without_toss_call(monkeypatch):
+    """블로커1 근본fix 확인 — claim에 지고 기존 행이 pending이면(다른 호출이 소유 중) 이
+    호출은 끼어들지 않고 그대로 반환한다(동시 Toss 이중호출 원천 차단)."""
+    from app.models.billing_order import BillingOrder
+    import app.services.billing_charge as svc
+
+    pending_row = MagicMock(spec=BillingOrder)
+    pending_row.status = "pending"
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_claimed_result(0), _row_result(pending_row)])
+
+    charge_mock = AsyncMock()
+    monkeypatch.setattr(svc.TossAdapter, "charge", charge_mock)
+
+    result = await svc.charge_org(session, org_id=uuid.uuid4(), order_id="ord-inflight", amount_minor=29000, currency="krw")
+
+    assert result is pending_row
+    charge_mock.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_charge_org_failed_order_reclaimed_and_retried(monkeypatch):
+    """failed였던 order는 CAS(failed→pending)로 재claim에 성공하면 재시도한다."""
+    import app.services.billing_charge as svc
+
+    org_id = uuid.uuid4()
+    order_id = "ord-retry"
+    failed_row = MagicMock()
+    failed_row.status = "failed"
+    billing_key_row = _mock_billing_key_row(org_id=org_id)
+    confirmed_row = MagicMock()
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[
+        _claimed_result(0),           # claim insert — 이미 존재(conflict)
+        _row_result(failed_row),      # 기존 행 조회 — failed
+        _claimed_result(1),           # CAS(failed→pending) 성공
+        _row_result(billing_key_row),  # billing key 조회
+        _row_result(confirmed_row),   # _confirm_with_ledger의 update
+        _row_result(confirmed_row),   # _confirm_with_ledger의 refetch
+    ])
+
+    monkeypatch.setattr(svc, "ensure_configured", MagicMock())
+    monkeypatch.setattr(svc, "decrypt_billing_key", MagicMock(return_value="plaintext_bk"))
+    monkeypatch.setattr(svc.TossAdapter, "charge", AsyncMock(return_value={"paymentKey": "pay_retry_1"}))
+    monkeypatch.setattr(svc, "record_ledger_entry", AsyncMock())
+
+    result = await svc.charge_org(session, org_id=org_id, order_id=order_id, amount_minor=29000, currency="krw")
+
+    assert result is confirmed_row
+    svc.TossAdapter.charge.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_charge_org_failed_reclaim_race_lost_returns_existing(monkeypatch):
+    """failed→pending CAS가 레이스에서 졌으면(다른 호출이 먼저 낚아챔) 이 호출은 포기하고
+    현재 상태를 그대로 반환한다 — Toss를 부르지 않는다."""
+    import app.services.billing_charge as svc
+
+    other_owned_row = MagicMock()
+    other_owned_row.status = "pending"
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[
+        _claimed_result(0),
+        _row_result(MagicMock(status="failed")),
+        _claimed_result(0),  # CAS 레이스 패배
+        _row_result(other_owned_row),
+    ])
+
+    charge_mock = AsyncMock()
+    monkeypatch.setattr(svc.TossAdapter, "charge", charge_mock)
+
+    result = await svc.charge_org(session, org_id=uuid.uuid4(), order_id="ord-race", amount_minor=29000, currency="krw")
+
+    assert result is other_owned_row
+    charge_mock.assert_not_awaited()
 
 
 @pytest.mark.anyio
@@ -131,11 +245,11 @@ async def test_charge_org_no_active_billing_key_raises(monkeypatch):
 
     org_id = uuid.uuid4()
     session = AsyncMock()
-    no_existing_order = MagicMock()
-    no_existing_order.scalar_one_or_none.return_value = None
-    no_billing_key = MagicMock()
-    no_billing_key.scalar_one_or_none.return_value = None
-    session.execute = AsyncMock(side_effect=[no_existing_order, no_billing_key])
+    session.execute = AsyncMock(side_effect=[
+        _claimed_result(1),       # claim 성공(신규)
+        _row_result(None),        # billing key 없음
+        _claimed_result(0),       # _mark_failed_if_not_confirmed의 update
+    ])
 
     monkeypatch.setattr(svc, "ensure_configured", MagicMock())
 
@@ -145,15 +259,13 @@ async def test_charge_org_no_active_billing_key_raises(monkeypatch):
 
 @pytest.mark.anyio
 async def test_charge_org_checks_crypto_before_calling_toss(monkeypatch):
-    """PO nit①과 동형 규율 — charge도 되돌릴 수 없는 외부호출 前에 crypto 가용성 확認."""
+    """PO nit①과 동형 규율 — claim에 성공한 뒤에도, Toss 호출 前에 crypto 가용성부터 확認."""
     import app.services.billing_charge as svc
     from app.services.billing_key_crypto import BillingKeyEncryptionNotConfigured
 
     org_id = uuid.uuid4()
     session = AsyncMock()
-    no_existing_order = MagicMock()
-    no_existing_order.scalar_one_or_none.return_value = None
-    session.execute = AsyncMock(return_value=no_existing_order)
+    session.execute = AsyncMock(side_effect=[_claimed_result(1)])
 
     monkeypatch.setattr(
         svc, "ensure_configured", MagicMock(side_effect=BillingKeyEncryptionNotConfigured("x"))
@@ -165,33 +277,26 @@ async def test_charge_org_checks_crypto_before_calling_toss(monkeypatch):
         await svc.charge_org(session, org_id=org_id, order_id="ord-x", amount_minor=29000, currency="krw")
 
     charge_mock.assert_not_awaited()
-    # existing-check(1)만 — billing key 조회·pending insert 전부 crypto 확認보다 먼저 안 감.
-    assert session.execute.await_count == 1
+    assert session.execute.await_count == 1  # claim(성공)만 — billing key 조회도 안 감.
 
 
 @pytest.mark.anyio
 async def test_charge_org_writes_pending_before_calling_toss(monkeypatch):
-    """⭐orderId-먼저-기록 — Toss charge 호출 前에 billing_orders가 pending으로 먼저
-    기록되는지 순서를 직접 증명한다."""
+    """⭐orderId-먼저-기록 — 원자적 claim(INSERT) 자체가 Toss charge 호출 前에 커밋되는지
+    순서를 직접 증명한다."""
     import app.services.billing_charge as svc
 
     org_id = uuid.uuid4()
     order_id = "ord-order1"
-    session = AsyncMock()
-
-    no_existing_order = MagicMock()
-    no_existing_order.scalar_one_or_none.return_value = None
-    billing_key_result = MagicMock()
-    billing_key_result.scalar_one_or_none.return_value = _mock_billing_key_row(org_id=org_id)
-    pending_insert_result = MagicMock()
-    confirmed_update_result = MagicMock()
-    final_select_result = MagicMock()
+    billing_key_row = _mock_billing_key_row(org_id=org_id)
     final_row = MagicMock()
-    final_select_result.scalar_one.return_value = final_row
 
+    session = AsyncMock()
     session.execute = AsyncMock(side_effect=[
-        no_existing_order, billing_key_result, pending_insert_result,
-        confirmed_update_result, final_select_result,
+        _claimed_result(1),          # ⭐claim insert(성공) — 가장 먼저.
+        _row_result(billing_key_row),
+        _row_result(final_row),      # _confirm_with_ledger의 confirmed update
+        _row_result(final_row),      # _confirm_with_ledger의 refetch
     ])
     session.commit = AsyncMock()
 
@@ -207,54 +312,147 @@ async def test_charge_org_writes_pending_before_calling_toss(monkeypatch):
     result = await svc.charge_org(session, org_id=org_id, order_id=order_id, amount_minor=29000, currency="krw")
 
     assert result is final_row
-    # 3번째 session.execute 호출(pending insert)이 pg_insert INSERT..ON CONFLICT문이었는지.
-    pending_insert_call = session.execute.call_args_list[2]
-    compiled = pending_insert_call.args[0].compile().params
+    # 1번째 호출(claim)이 pg_insert INSERT..ON CONFLICT DO NOTHING이었는지 — Toss charge
+    # 는 그 뒤에야(mock side_effect 순서가 이를 강제) 호출됨.
+    claim_call = session.execute.call_args_list[0]
+    compiled = claim_call.args[0].compile().params
     assert compiled["order_id"] == order_id
     assert compiled["status"] == "pending"
-    # 4번째 호출(confirmed update)이 결제 성공 뒤에야 실행됨 — call_args_list 순서 자체가
-    # pending(2번째 인덱스)이 먼저, Toss 결과 반영 update(3번째 인덱스)가 그 다음임을 보증
-    # (mock side_effect가 순서대로 소비되므로 이 assert가 실패하면 순서가 깨진 것).
-    confirmed_update_call = session.execute.call_args_list[3]
-    update_compiled = confirmed_update_call.args[0].compile().params
-    assert update_compiled["status"] == "confirmed"
-    assert update_compiled["payment_key"] == "pay_key_xyz"
 
+    # ⛔블로커2 순서 확인 — record_ledger_entry가 confirmed-update보다 먼저 불려야(코드
+    # 순서상 항상 그렇지만, AsyncMock 호출 자체가 일어났는지+kwargs로 재확認).
     svc.record_ledger_entry.assert_awaited_once()
     ledger_kwargs = svc.record_ledger_entry.call_args.kwargs
     assert ledger_kwargs["provider_ref"] == "pay_key_xyz"
     assert ledger_kwargs["entry_type"] == "charge"
 
+    confirmed_update_call = session.execute.call_args_list[2]
+    update_compiled = confirmed_update_call.args[0].compile().params
+    assert update_compiled["status"] == "confirmed"
+    assert update_compiled["payment_key"] == "pay_key_xyz"
+
 
 @pytest.mark.anyio
 async def test_charge_org_toss_failure_marks_order_failed_and_reraises(monkeypatch):
     import app.services.billing_charge as svc
+    from app.services.payment.toss_adapter import TossApiError
 
     org_id = uuid.uuid4()
+    billing_key_row = _mock_billing_key_row(org_id=org_id)
     session = AsyncMock()
-    no_existing_order = MagicMock()
-    no_existing_order.scalar_one_or_none.return_value = None
-    billing_key_result = MagicMock()
-    billing_key_result.scalar_one_or_none.return_value = _mock_billing_key_row(org_id=org_id)
-    pending_insert_result = MagicMock()
-    failed_update_result = MagicMock()
     session.execute = AsyncMock(side_effect=[
-        no_existing_order, billing_key_result, pending_insert_result, failed_update_result,
+        _claimed_result(1), _row_result(billing_key_row), _claimed_result(1),
     ])
-    session.commit = AsyncMock()
 
     monkeypatch.setattr(svc, "ensure_configured", MagicMock())
     monkeypatch.setattr(svc, "decrypt_billing_key", MagicMock(return_value="plaintext_bk"))
     monkeypatch.setattr(
-        svc.TossAdapter, "charge", AsyncMock(side_effect=RuntimeError("Toss charge failed: EXCEED_MAX_DAILY_PAYMENT_COUNT"))
+        svc.TossAdapter, "charge",
+        AsyncMock(side_effect=TossApiError("EXCEED_MAX_DAILY_PAYMENT_COUNT", "too many", status_code=400)),
     )
     monkeypatch.setattr(svc, "record_ledger_entry", AsyncMock())
 
-    with pytest.raises(RuntimeError, match="EXCEED_MAX_DAILY_PAYMENT_COUNT"):
+    with pytest.raises(TossApiError, match="EXCEED_MAX_DAILY_PAYMENT_COUNT"):
         await svc.charge_org(session, org_id=org_id, order_id="ord-fail", amount_minor=29000, currency="krw")
 
-    failed_call = session.execute.call_args_list[3]
+    failed_call = session.execute.call_args_list[2]
     compiled = failed_call.args[0].compile().params
     assert compiled["status"] == "failed"
     assert "EXCEED_MAX_DAILY_PAYMENT_COUNT" in compiled["failure_reason"]
+    svc.record_ledger_entry.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_charge_org_missing_payment_key_marks_failed(monkeypatch):
+    """PO nit — Toss 응답에 paymentKey가 없으면(malformed) crash 대신 명시 failed."""
+    import app.services.billing_charge as svc
+
+    org_id = uuid.uuid4()
+    billing_key_row = _mock_billing_key_row(org_id=org_id)
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[
+        _claimed_result(1), _row_result(billing_key_row), _claimed_result(1),
+    ])
+
+    monkeypatch.setattr(svc, "ensure_configured", MagicMock())
+    monkeypatch.setattr(svc, "decrypt_billing_key", MagicMock(return_value="plaintext_bk"))
+    monkeypatch.setattr(svc.TossAdapter, "charge", AsyncMock(return_value={"status": "DONE"}))  # paymentKey 없음
+    monkeypatch.setattr(svc, "record_ledger_entry", AsyncMock())
+
+    with pytest.raises(RuntimeError, match="missing paymentKey"):
+        await svc.charge_org(session, org_id=org_id, order_id="ord-malformed", amount_minor=29000, currency="krw")
+
+    svc.record_ledger_entry.assert_not_awaited()
+
+
+# ─── DUPLICATED_ORDER_ID — 재시도가 이미 성공한 charge를 다시 치는 케이스 ──
+
+@pytest.mark.anyio
+async def test_charge_org_duplicated_order_id_reconciles_as_success(monkeypatch):
+    """⚠️PO 권장 처리 — DUPLICATED_ORDER_ID는 진짜 실패가 아니다. 조회해서 DONE이면
+    confirmed+원장으로 매핑(failed로 오마킹하지 않는다)."""
+    import app.services.billing_charge as svc
+    from app.services.payment.toss_adapter import TossApiError
+
+    org_id = uuid.uuid4()
+    billing_key_row = _mock_billing_key_row(org_id=org_id)
+    confirmed_row = MagicMock()
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[
+        _claimed_result(1), _row_result(billing_key_row),
+        _row_result(confirmed_row),  # _confirm_with_ledger의 update
+        _row_result(confirmed_row),  # _confirm_with_ledger의 refetch
+    ])
+
+    monkeypatch.setattr(svc, "ensure_configured", MagicMock())
+    monkeypatch.setattr(svc, "decrypt_billing_key", MagicMock(return_value="plaintext_bk"))
+    monkeypatch.setattr(
+        svc.TossAdapter, "charge",
+        AsyncMock(side_effect=TossApiError("DUPLICATED_ORDER_ID", "dup", status_code=400)),
+    )
+    monkeypatch.setattr(
+        svc.TossAdapter, "get_payment_by_order_id",
+        AsyncMock(return_value={"status": "DONE", "paymentKey": "pay_recovered"}),
+    )
+    monkeypatch.setattr(svc, "record_ledger_entry", AsyncMock())
+
+    result = await svc.charge_org(session, org_id=org_id, order_id="ord-dup2", amount_minor=29000, currency="krw")
+
+    assert result is confirmed_row
+    svc.record_ledger_entry.assert_awaited_once()
+    assert svc.record_ledger_entry.call_args.kwargs["provider_ref"] == "pay_recovered"
+
+
+@pytest.mark.anyio
+async def test_charge_org_duplicated_order_id_not_done_marks_failed(monkeypatch):
+    """조회 결과가 DONE이 아니면(취소 등) — 이번엔 진짜 failed로 정합."""
+    import app.services.billing_charge as svc
+    from app.services.payment.toss_adapter import TossApiError
+
+    org_id = uuid.uuid4()
+    billing_key_row = _mock_billing_key_row(org_id=org_id)
+    failed_row = MagicMock()
+    failed_row.status = "failed"
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[
+        _claimed_result(1), _row_result(billing_key_row),
+        _claimed_result(1),  # _mark_failed_if_not_confirmed
+        _row_result(failed_row),  # refetch
+    ])
+
+    monkeypatch.setattr(svc, "ensure_configured", MagicMock())
+    monkeypatch.setattr(svc, "decrypt_billing_key", MagicMock(return_value="plaintext_bk"))
+    monkeypatch.setattr(
+        svc.TossAdapter, "charge",
+        AsyncMock(side_effect=TossApiError("DUPLICATED_ORDER_ID", "dup", status_code=400)),
+    )
+    monkeypatch.setattr(
+        svc.TossAdapter, "get_payment_by_order_id",
+        AsyncMock(return_value={"status": "CANCELED"}),
+    )
+    monkeypatch.setattr(svc, "record_ledger_entry", AsyncMock())
+
+    result = await svc.charge_org(session, org_id=org_id, order_id="ord-dup3", amount_minor=29000, currency="krw")
+
+    assert result.status == "failed"
     svc.record_ledger_entry.assert_not_awaited()


### PR DESCRIPTION
## Summary
C2 of 결제②-C (TossAdapter). Mechanism-only per PO's scope call (2026-08-07, this thread) — `amount`/`currency`/`order_id` come in as parameters. Computing "how much to charge" (offering_version × seats × packs) is a separate pricing-calc story: verified before building (not assumed) that none of that data is wired yet — no live seat count on `org_subscriptions`, no pack-purchase tracking anywhere (`billing_ledger.py`'s own docstring says so).

- **`billing_orders`** (migration 0231): orderId-recorded-first `pending`/`confirmed`/`failed`. `billing_ledger_entries` (A2) is append-only and can't hold "in-flight" state — this table exists purely for that gap. Verified against a real local Postgres: upgrade/downgrade, `unique(order_id)`, `status`/`currency`/`amount_minor>0` CHECKs all enforced.
- **`TossAdapter.charge`** — `POST /v1/billing/{billingKey}` (endpoint/request/response fields verified against Toss's current docs before implementing, same discipline as C1). 65s timeout (Toss docs: approval can take up to 60s). Shares the `create_billing_key` error-handling path via a new `_post()` helper.
- **`billing_charge.py`**: `charge_org()` — checks for an existing `confirmed` order first (true idempotency: no Toss call on retry-after-success), writes `billing_orders` as `pending` *before* calling Toss (crash/timeout recoverable), marks `failed` with the reason on error and re-raises, marks `confirmed` + appends the A2 ledger entry (`provider_ref=paymentKey`, itself idempotent) on success.

### Folds in both non-blocking nits from #2880 review
PO: "nit①은 C2 crypto 핵심경로서 같이 정리 권장."
- `billing_key_crypto.ensure_configured()` — checks encryption-key availability *before* any irreversible external call. `issue_billing_key` (C1) now calls it before consuming the one-time `authKey`; `charge_org` calls it before the charge itself. Previously `issue_billing_key` could burn an `authKey` and only then fail at the encrypt step.
- `decrypt_billing_key`'s pointless `except InvalidToken: raise` removed — propagates naturally (nit②).
- `org_billing_keys` reissue (`ON CONFLICT DO UPDATE`) now sets `updated_at` explicitly — the ORM's `onupdate` hook doesn't fire on raw `INSERT..ON CONFLICT` statements (nit②).

## Test plan
- [x] Migration verified against a real local Postgres (Operations-API direct-drive, zero FK deps)
- [x] New `test_e_2493_c2_charge_ledger.py` (9 tests): `TossAdapter.charge` success/error/fail-closed; `charge_org` positive-amount validation, idempotent short-circuit, no-active-billing-key error, crypto-before-Toss ordering, pending-before-Toss write ordering (direct call-sequence proof), failure path marks the order failed without a ledger entry
- [x] New regression tests in `test_e_2492_c1_billing_key.py` for both C1 nits (crypto-checked-before-authKey-consumption, reissue bumps `updated_at`)
- [x] `pytest tests/test_e_2493_c2_charge_ledger.py tests/test_e_2492_c1_billing_key.py tests/test_e_2478_b_payment_adapter.py tests/test_e_org_multi_s5_3_polar_checkout.py tests/test_check_env_drift_settings_coverage.py tests/test_e_2472_a2_billing_ledger_realdb.py tests/test_e_recruit_s1_role_templates.py tests/test_2486_agents_router_project_gate.py` — 83 passed, 17 skipped (realdb)
- [x] `lint_project_access_403.py` / `lint_dependency_override_get_read_db.py` — 0 new violations
- [x] `python -c "import app.main"` — clean
- [x] Full backend suite (background run) — no regressions beyond the known pre-existing environment-dependent failures (local Postgres/live MCP tool count/git-ref-freshness class, unrelated to this diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)