### PR TITLE
[SID:2501] raw 에러-매칭 전수 스윕 — 4개 실재 버그 수정

### DIFF
--- a/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
@@ -120,3 +120,33 @@ describe('GateDetailPage — can_approve 게이팅 (story #2091)', () => {
     expect(buttons.some((t) => t?.includes(koMessages.cage.gateApprove))).toBe(false);
   });
 });
+
+// story #2500 — `body.detail`은 실 envelope({data,error,meta})에 없는 필드라 이 분기는
+// 항상 죽어있었다(그라운딩 확認) — #2027의 "고위험 승인 사유 필수" 서버 거부 문구가 한 번도
+// 실제로 화면에 뜬 적 없이 항상 "HTTP 422"만 보였다. error.message로 교정.
+describe('GateDetailPage — transition 실패 사유 노출 (story #2500)', () => {
+  it('422 거부 사유(#2027 고위험 승인 사유 필수)가 raw "HTTP 422" 대신 실 메시지로 뜬다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === '/api/gates/gate-1' && !init) return { ok: true, status: 200, json: async () => ({ data: gate({ can_approve: true, risk_grade: 'low' }) }) };
+      if (url === '/api/gates/gate-1/transition') {
+        return {
+          ok: false,
+          status: 422,
+          json: async () => ({ data: null, error: { code: 'UNPROCESSABLE_ENTITY', message: '고위험(risk_grade=high) 게이트 승인은 사유(note) 입력이 필수입니다.' }, meta: null }),
+        };
+      }
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+    const { default: GateDetailPage } = await import('./page');
+    const { TopBarProvider } = await import('@/components/nav/top-bar-context');
+    await act(async () => { root.render(wrap(<GateDetailPage />, TopBarProvider)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    const approveBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes(koMessages.cage.gateApprove));
+    await act(async () => { approveBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).not.toContain('HTTP 422');
+    expect(container.textContent).toContain('고위험(risk_grade=high) 게이트 승인은 사유(note) 입력이 필수입니다.');
+  });
+});

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -121,9 +121,12 @@ export default function GateDetailPage() {
         return;
       }
       // story #2043 AC3: 서버 거부(예: #2027 — 고위험 승인은 note 필수, 422)를 사람이 읽을
-      // 문구로 보여준다. BE HTTPException(detail=...)은 평문 문자열을 반환(gates.py:553-556).
-      const body = await res.json().catch(() => null) as { detail?: unknown } | null;
-      const reason = typeof body?.detail === 'string' ? body.detail : `HTTP ${res.status}`;
+      // 문구로 보여준다. story #2500 — `body.detail`은 실 envelope({data,error,meta})에
+      // 없는 필드라 이 분기는 항상 죽어있었다(그라운딩 확認 — BE HTTPException(detail=...)은
+      // 평문 문자열이지만 handler가 error.message로 재포장한다, gates.py:885). 올바른
+      // 필드로 교정 — #2027의 "고위험 승인 사유 필수" 문구가 실제로 화면에 뜨게 된다.
+      const body = await res.json().catch(() => null) as { error?: { message?: string } } | null;
+      const reason = body?.error?.message ?? `HTTP ${res.status}`;
       setTransitionError(reason);
     } finally {
       setResolving(false);

--- a/apps/web/src/app/api/integrations/github/connect/route.test.ts
+++ b/apps/web/src/app/api/integrations/github/connect/route.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment node
+//
+// story #2500 — `err.message.includes('403')`가 실제 403 사유 메시지("Admin role
+// required")엔 "403"이라는 부분문자열이 없어 항상 false였다(그라운딩 확認) — 진짜
+// 403(admin 권한 필요)도 조용히 400으로 격하되던 버그. ForbiddenError instanceof로 교정.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ForbiddenError, NotFoundError } from '@sprintable/core-storage';
+
+const { getServerSessionMock, fastapiCallMock } = vi.hoisted(() => ({
+  getServerSessionMock: vi.fn(),
+  fastapiCallMock: vi.fn(),
+}));
+
+vi.mock('@/lib/db/server', () => ({ getServerSession: getServerSessionMock }));
+vi.mock('@/lib/fastapi-proxy', () => ({ fastapiCall: fastapiCallMock }));
+
+import { GET } from './route';
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('GET /api/integrations/github/connect (story #2500)', () => {
+  it('ForbiddenError(admin 권한 필요) — 403으로 정확히 응답한다(핵심 회귀가드)', async () => {
+    getServerSessionMock.mockResolvedValue({ access_token: 'tok' });
+    fastapiCallMock.mockRejectedValue(new ForbiddenError('Admin role required'));
+
+    const res = await GET();
+    expect(res.status).toBe(403);
+  });
+
+  it('그 외 에러(예: NotFoundError)는 400으로 응답한다(회귀 없음)', async () => {
+    getServerSessionMock.mockResolvedValue({ access_token: 'tok' });
+    fastapiCallMock.mockRejectedValue(new NotFoundError('not found'));
+
+    const res = await GET();
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/src/app/api/integrations/github/connect/route.ts
+++ b/apps/web/src/app/api/integrations/github/connect/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { fastapiCall } from '@/lib/fastapi-proxy';
 import { ApiErrors } from '@/lib/api-response';
 import { getServerSession } from '@/lib/db/server';
+import { ForbiddenError } from '@sprintable/core-storage';
 
 // E-GHAPP Bot-S: GitHub App(봇) 설치 시작 — org admin이 여기로 오면 backend가 org-bound signed state로
 // GitHub App install URL을 발급하고, 그 URL로 302 리다이렉트한다(설치는 GitHub에서 진행). Route Handler
@@ -18,7 +19,11 @@ export async function GET() {
     );
     return NextResponse.redirect(result.install_url);
   } catch (err: unknown) {
-    const status = err instanceof Error && err.message.includes('403') ? 403 : 400;
+    // story #2500 — 그라운딩 확認: fastapiCall(→packages/storage-api)의 mapApiError는
+    // 403을 이미 ForbiddenError instanceof로 정확히 분류해 던진다(require_admin이 raise
+    // 하는 실제 메시지 "Admin role required"는 "403"이라는 부분문자열을 포함 안 해
+    // .includes('403')는 항상 false — 진짜 403도 조용히 400으로 격하되던 버그).
+    const status = err instanceof ForbiddenError ? 403 : 400;
     return NextResponse.json(
       { data: null, error: { code: 'FAILED', message: String(err) }, meta: null },
       { status },

--- a/apps/web/src/app/api/integrations/slack/connect/route.test.ts
+++ b/apps/web/src/app/api/integrations/slack/connect/route.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment node
+//
+// story #2500 — `err.message.includes('403')`가 실제 403 사유 메시지("Admin access
+// required")엔 "403"이라는 부분문자열이 없어 항상 false였다(그라운딩 확認) — 진짜
+// 403(admin 권한 필요)도 조용히 400으로 격하되던 버그. ForbiddenError instanceof로 교정.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ForbiddenError, NotFoundError } from '@sprintable/core-storage';
+
+const { getServerSessionMock, fastapiCallMock } = vi.hoisted(() => ({
+  getServerSessionMock: vi.fn(),
+  fastapiCallMock: vi.fn(),
+}));
+
+vi.mock('@/lib/db/server', () => ({ getServerSession: getServerSessionMock }));
+vi.mock('@/lib/fastapi-proxy', () => ({ fastapiCall: fastapiCallMock }));
+
+import { GET } from './route';
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('GET /api/integrations/slack/connect (story #2500)', () => {
+  it('ForbiddenError(admin 권한 필요) — 403으로 정확히 응답한다(핵심 회귀가드)', async () => {
+    getServerSessionMock.mockResolvedValue({ access_token: 'tok' });
+    fastapiCallMock.mockRejectedValue(new ForbiddenError('Admin access required'));
+
+    const res = await GET();
+    expect(res.status).toBe(403);
+  });
+
+  it('그 외 에러(예: NotFoundError)는 400으로 응답한다(회귀 없음)', async () => {
+    getServerSessionMock.mockResolvedValue({ access_token: 'tok' });
+    fastapiCallMock.mockRejectedValue(new NotFoundError('not found'));
+
+    const res = await GET();
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/src/app/api/integrations/slack/connect/route.ts
+++ b/apps/web/src/app/api/integrations/slack/connect/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { fastapiCall } from '@/lib/fastapi-proxy';
 import { ApiErrors } from '@/lib/api-response';
 import { getServerSession } from '@/lib/db/server';
+import { ForbiddenError } from '@sprintable/core-storage';
 
 export async function GET() {
   const session = await getServerSession();
@@ -15,7 +16,11 @@ export async function GET() {
     );
     return NextResponse.redirect(result.data.url);
   } catch (err: unknown) {
-    const status = err instanceof Error && err.message.includes('403') ? 403 : 400;
+    // story #2500 — 그라운딩 확認: fastapiCall(→packages/storage-api)의 mapApiError는
+    // 403을 이미 ForbiddenError instanceof로 정확히 분류해 던진다(slack_connect의
+    // _err("FORBIDDEN","Admin access required",403) 메시지도 "403"이라는 부분문자열을
+    // 포함 안 해 .includes('403')는 항상 false — 진짜 403도 조용히 400으로 격하되던 버그).
+    const status = err instanceof ForbiddenError ? 403 : 400;
     return NextResponse.json(
       { data: null, error: { code: 'FAILED', message: String(err) }, meta: null },
       { status },

--- a/apps/web/src/components/settings/workflow-template-gallery-section.test.tsx
+++ b/apps/web/src/components/settings/workflow-template-gallery-section.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+//
+// story #2501 — `data.detail`은 실 envelope({data,error,meta})에 없는 필드라 이 분기는
+// 항상 죽어있었다(그라운딩 확認 — backend apply_template()은 generic HTTP상태 코드만
+// 낸다) — 적용 실패 사유가 한 번도 화면에 안 뜨고 항상 '적용 실패'만 보여줬다.
+// `error.message`로 교정한 회귀가드.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { WorkflowTemplateGallerySection } from './workflow-template-gallery-section';
+import koMessages from '../../../messages/ko.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function flush() {
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+// role_ref가 있는 step이 하나도 없어 requiredSteps가 비고, "적용하기" 버튼이 role
+// 매핑 없이 바로 활성화된다 — 이 테스트가 검증하려는 건 apply 실패 응답 처리이지
+// 역할매핑 UI가 아니므로 최소 fixture로 그 표면만 자른다.
+const TEMPLATE = {
+  slug: 'tmpl-1',
+  name: '테스트 템플릿',
+  description: '설명',
+  chain_length: 1,
+  steps: [],
+  presets: {},
+  rules_template: [],
+  is_system: true,
+};
+
+describe('WorkflowTemplateGallerySection — error.code 분기 (story #2501)', () => {
+  it('적용 실패 사유가 raw "적용 실패" 폴백 대신 실 서버 메시지로 뜬다(핵심 회귀가드)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === '/api/workflow-templates' && !init) return { ok: true, json: async () => [TEMPLATE] };
+      if (url.includes('/api/team-members')) return { ok: true, json: async () => ({ data: [] }) };
+      if (url.includes('/api/v1/agent-routing-rules')) return { ok: true, json: async () => ({ data: [] }) };
+      if (url === '/api/workflow-templates/tmpl-1' && (!init || init.method === undefined)) {
+        return { ok: true, json: async () => TEMPLATE };
+      }
+      if (url === '/api/workflow-templates/tmpl-1/apply') {
+        return {
+          ok: false,
+          json: async () => ({
+            data: null,
+            error: { code: 'UNPROCESSABLE_ENTITY', message: 'agent(s) not found in this org: abc' },
+            meta: null,
+          }),
+        };
+      }
+      throw new Error('unexpected fetch: ' + url);
+    }));
+
+    await act(async () => { root.render(wrap(<WorkflowTemplateGallerySection projectId="proj-1" />)); });
+    await flush();
+
+    const tmplBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('테스트 템플릿'));
+    await act(async () => { tmplBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    const applyBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '적용하기');
+    expect(applyBtn).not.toBeUndefined();
+    await act(async () => { applyBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    expect(container.textContent).not.toContain('적용 실패');
+    expect(container.textContent).toContain('agent(s) not found in this org: abc');
+  });
+
+  it('backend가 error.message를 안 주면(네트워크 계층 등) 안전 폴백 "적용 실패"로 간다(회귀 없음)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === '/api/workflow-templates' && !init) return { ok: true, json: async () => [TEMPLATE] };
+      if (url.includes('/api/team-members')) return { ok: true, json: async () => ({ data: [] }) };
+      if (url.includes('/api/v1/agent-routing-rules')) return { ok: true, json: async () => ({ data: [] }) };
+      if (url === '/api/workflow-templates/tmpl-1' && (!init || init.method === undefined)) {
+        return { ok: true, json: async () => TEMPLATE };
+      }
+      if (url === '/api/workflow-templates/tmpl-1/apply') {
+        return { ok: false, json: async () => ({ data: null, error: {}, meta: null }) };
+      }
+      throw new Error('unexpected fetch: ' + url);
+    }));
+
+    await act(async () => { root.render(wrap(<WorkflowTemplateGallerySection projectId="proj-1" />)); });
+    await flush();
+
+    const tmplBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('테스트 템플릿'));
+    await act(async () => { tmplBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    const applyBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '적용하기');
+    await act(async () => { applyBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    expect(container.textContent).toContain('적용 실패');
+  });
+});

--- a/apps/web/src/components/settings/workflow-template-gallery-section.tsx
+++ b/apps/web/src/components/settings/workflow-template-gallery-section.tsx
@@ -141,13 +141,17 @@ export function WorkflowTemplateGallerySection({
           overwrite_existing: overwrite || !!appliedSlug,
         }),
       });
-      const data = await res.json() as { ok?: boolean; rules_created?: number; detail?: string };
+      // story #2500 — `data.detail`은 실 envelope({data,error,meta})에 없는 필드라 이
+      // 분기는 항상 죽어있었다(그라운딩 확認 — backend apply_template()은 generic
+      // HTTP상태 코드만 낸다, dict-coded 아님) — 실패 사유가 한 번도 화면에 안 뜨고
+      // 항상 '적용 실패'만 보여줬다. 올바른 필드(error.message)로 교정.
+      const data = await res.json() as { ok?: boolean; rules_created?: number; error?: { message?: string } };
       if (res.ok && data.ok) {
         setApplyResult({ ok: true, message: `규칙 ${String(data.rules_created ?? 0)}개 생성 완료` });
         setAppliedSlug(selected.slug);
         setOverwriteConfirm(false);
       } else {
-        setApplyResult({ ok: false, message: (data.detail as string | undefined) ?? '적용 실패' });
+        setApplyResult({ ok: false, message: data.error?.message ?? '적용 실패' });
       }
     } catch {
       setApplyResult({ ok: false, message: '네트워크 오류' });


### PR DESCRIPTION
## 요약
error.code 하드닝 에픽(#2484~#2499) 마무리 스윕(PO 지시) — 전용 에이전트로 남은 raw 에러-매칭 자리를 찾고, 각각 backend를 grep해 그 조건이 실제로 발생 가능한지 확認 후에만 손을 댔다.

## ⚠️그라운딩 함정 catch
1차 스윕 결과 중 3건(story-detail-panel.tsx 사이클 감지·rejected-relations-section.tsx·flow-epic-nodes.tsx+flow-multi-lane-canvas.tsx 6곳)은 **오탐**이었다 — 그라운딩에 쓰인 checkout이 `origin/develop`이 아닌 오래된 stale 브랜치(`feat/2310-web-content-painted-signal`)였음을 뒤늦게 발견, fresh worktree로 재확認해 전부 이미 #2485에서 고쳐져 있음을 확인하고 스코프에서 제외했다(거짓 회귀 보고를 막음).

## 실재 확認된 4건만 수정
- **`app/api/integrations/github/connect/route.ts`·`slack/connect/route.ts`** — `err.message.includes('403')`가 실제 403 사유 메시지("Admin role required"/"Admin access required")엔 "403"이라는 부분문자열이 아예 없어 항상 false였다 — 진짜 403(admin 권한 필요)도 조용히 400으로 격하되던 버그. `err instanceof ForbiddenError`로 교정(mapApiError가 이미 정확히 분류해 던짐, #2488/#2499 연장선).
- **`components/settings/workflow-template-gallery-section.tsx`** — `data.detail`은 실 envelope에 없는 필드라 항상 죽어있었다. backend `apply_template()`은 generic HTTP상태 코드만 내는데 실패 사유가 한 번도 안 뜨고 항상 '적용 실패'만 보여줬다 — `error.message`로 교정.
- **`app/(authenticated)/gates/[id]/page.tsx`** — `body?.detail`도 같은 병. #2027이 추가한 "고위험 게이트 승인은 사유 입력 필수"(422) 서버 거부 문구가 한 번도 화면에 안 뜨고 항상 "HTTP 422"만 보였다 — `error.message`로 교정.

## ⛔손대지 않은 것
`components/meetings/audio-recorder.tsx` — STT 업그레이드-필요 감지(`errMsg.includes('UPGRADE_REQUIRED')`)는 대상 backend 엔드포인트(`POST /meetings/{id}/transcribe`)가 501 하드코딩 스텁이라 이 조건 자체가 발생 불가 — backend 갭으로만 기록, 손 안 댐.

## 게이트
- 신규 vitest 5개(gates 1 · connect route 4) 전부 GREEN
- 뮤테이션 셀프체크 1건 — github connect ForbiddenError→string-match 되돌림 → RED 확認 → 복원
- tsc/eslint 클린
- 전체 모노레포 vitest 398파일/3008개 GREEN(회귀 0)
- `pnpm build` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)