### PR TITLE
feat(#2494): 결제②-C3 — dunning 재시도 상태기계 + pending 대사(reconciliation)

### DIFF
--- a/backend/alembic/versions/0232_billing_orders_downgraded_status.py
+++ b/backend/alembic/versions/0232_billing_orders_downgraded_status.py
@@ -1,0 +1,35 @@
+"""#2494(C3) — billing_orders.status에 'downgraded' 종결 상태 추가.
+
+PO 리뷰 블로커(2026-08-07, #2884) — "상태 자가회수 부재": +8일 Free 강제전환 후에도 그
+failed order를 닫지 않으면 (a) 매 스윕마다 재처리되고 (b) 그 org가 나중에 재구독(유료
+전환)해도 이 옛 failed order(age≫8)가 다음 스윕에서 다시 골라져 «새 유료 구독을
+clobber»한다. 'failed'를 재사용하지 않고 별도 종결 상태를 두는 이유 — 'confirmed'로
+쓰면 "charge 성공"이라는 원장 의미와 충돌(실제로는 Toss 승인 없이 강제 강등된 것이라
+감사·재무 관점에서 구분돼야 한다).
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0232"
+down_revision = "0231"
+branch_labels = None
+depends_on = None
+
+_STATUSES = ["pending", "confirmed", "failed", "downgraded"]
+
+
+def upgrade() -> None:
+    op.drop_constraint("billing_orders_status_check", "billing_orders", type_="check")
+    op.create_check_constraint(
+        "billing_orders_status_check", "billing_orders",
+        f"status IN ({','.join(repr(s) for s in _STATUSES)})",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("billing_orders_status_check", "billing_orders", type_="check")
+    op.create_check_constraint(
+        "billing_orders_status_check", "billing_orders",
+        "status IN ('pending','confirmed','failed')",
+    )

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -872,3 +872,24 @@ async def db_connection_stats(
     except Exception as exc:
         logger.exception("db-connection-stats cron error: %s", exc)
         return _err("INTERNAL_ERROR", "Internal server error", 500)
+
+
+# ─── GET /api/v2/internal/cron/toss-billing-maintenance ───────────────────────
+# 결제②-C3(story #2494): dunning 재시도(pricing-policy-proposal-v1 §12.1) + pending
+# 대사(reconciliation). "신규 결제 주기 도래" 트리거는 스코프 밖(story #2502 대기) —
+# billing_scheduler.trigger_due_charges()가 그 자리를 NotImplementedError로 명시해둔다.
+@router.get("/toss-billing-maintenance")
+async def toss_billing_maintenance(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    verify_cron(request)
+    try:
+        from app.services.billing_scheduler import sweep_dunning_retries, sweep_stale_pending_orders
+
+        dunning_result = await sweep_dunning_retries(session)
+        reconciliation_result = await sweep_stale_pending_orders(session)
+        return _ok({"dunning": dunning_result, "reconciliation": reconciliation_result})
+    except Exception as exc:
+        logger.exception("toss-billing-maintenance cron error: %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)

--- a/backend/app/services/billing_scheduler.py
+++ b/backend/app/services/billing_scheduler.py
@@ -22,7 +22,7 @@ import logging
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import select
+from sqlalchemy import func, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -64,10 +64,18 @@ def next_dunning_action(order: BillingOrder, *, now: datetime) -> str:
     return "wait"
 
 
-async def downgrade_to_free(session: AsyncSession, org_id: uuid.UUID) -> None:
+async def downgrade_to_free(session: AsyncSession, org_id: uuid.UUID, order_id: str) -> None:
     """§12.1 +8일 — Free 권리로 전환. 기존 데이터는 절대 지우지 않는다(정책 명시) — 이
     함수는 구독 tier만 되돌린다, 데이터 삭제/에이전트 강제해제는 정책상 없음(§12.1 원문:
-    "이미 등록된 에이전트를 강제 해제하지 않는다")."""
+    "이미 등록된 에이전트를 강제 해제하지 않는다").
+
+    PO 리뷰 블로커(#2884, 2026-08-07) — "상태 자가회수 부재": org_subscriptions만 바꾸고
+    이 order를 'failed'로 그대로 두면 ①매 스윕마다 같은 order가 다시 골라져 재처리되고
+    ②더 심각하게, 이 org가 나중에 카드 고쳐 재구독(유료)해도 다음 스윕이 이 옛 order
+    (age≫8)를 보고 org를 다시 free로 upsert해 **새 유료 구독을 clobber**한다. order를
+    종결 상태 'downgraded'로 전이시켜(status!='confirmed' 가드) failed-스윕 대상에서
+    영구히 뺀다 — 'failed' 그대로 두거나 'confirmed'를 재사용하지 않는 이유는 이게 실제
+    Toss 승인이 아니라 강제 강등이라 원장 의미가 다르기 때문(0232 마이그로 CHECK 확장)."""
     free_offering = (
         await session.execute(
             select(OfferingVersion).where(
@@ -90,6 +98,11 @@ async def downgrade_to_free(session: AsyncSession, org_id: uuid.UUID) -> None:
         },
     )
     await session.execute(stmt)
+    await session.execute(
+        update(BillingOrder)
+        .where(BillingOrder.order_id == order_id, BillingOrder.status != "confirmed")
+        .values(status="downgraded", updated_at=func.now())
+    )
     await session.commit()
 
 
@@ -116,7 +129,7 @@ async def sweep_dunning_retries(session: AsyncSession, *, now: datetime | None =
                 logger.exception("dunning retry failed for order_id=%s", order.order_id)
             retried += 1
         elif action == "downgrade_to_free":
-            await downgrade_to_free(session, order.org_id)
+            await downgrade_to_free(session, order.org_id, order.order_id)
             downgraded += 1
 
     return {"failed_orders_seen": len(failed_orders), "retried": retried, "downgraded": downgraded}
@@ -134,14 +147,17 @@ async def sweep_stale_pending_orders(session: AsyncSession, *, now: datetime | N
         )
     ).scalars().all()
 
-    confirmed = failed = 0
+    confirmed = failed = skipped = 0
     for order in stale_orders:
         try:
             lookup = await TossAdapter().get_payment_by_order_id(order_id=order.order_id)
         except Exception:
-            logger.exception("stale pending reconciliation lookup failed for order_id=%s", order.order_id)
-            await _mark_failed_if_not_confirmed(session, order.order_id, "reconciliation lookup failed")
-            failed += 1
+            # PO fix-forward(#2884 리뷰) — 조회 자체가 실패(네트워크 일시 장애 등)한 것과
+            # "Toss가 이 주문을 모른다/실패로 안다"는 다른 신호다. 전자를 failed로 찍으면
+            # 실은 성공했을 수도 있는 charge를 오분류한다 — pending 그대로 두고 다음
+            # 스윕이 다시 조회하게 한다(무한 대기 아님 — lookup이 언젠가 성공하면 정리됨).
+            logger.exception("stale pending reconciliation lookup failed for order_id=%s — leaving pending", order.order_id)
+            skipped += 1
             continue
 
         if lookup.get("status") == "DONE" and lookup.get("paymentKey"):
@@ -157,7 +173,10 @@ async def sweep_stale_pending_orders(session: AsyncSession, *, now: datetime | N
             )
             failed += 1
 
-    return {"stale_pending_seen": len(stale_orders), "confirmed": confirmed, "failed": failed}
+    return {
+        "stale_pending_seen": len(stale_orders), "confirmed": confirmed,
+        "failed": failed, "skipped_lookup_error": skipped,
+    }
 
 
 async def trigger_due_charges(session: AsyncSession) -> dict:

--- a/backend/app/services/billing_scheduler.py
+++ b/backend/app/services/billing_scheduler.py
@@ -1,0 +1,172 @@
+"""결제②-C3(story #2494) — 정기결제 재시도 상태기계 + 대사(reconciliation) 골격.
+
+PO 계약(2026-08-07, this thread) — **(b)-narrowed**: "오늘 누구를 얼마 청구할지"(신규
+결제 주기 도래 판정)는 이 스토리 밖이다. 그라운딩 결과 `org_subscriptions.
+current_period_start/end`가 Toss 구독에는 애초에 채워지는 경로가 없다는 걸 확認했고
+(Polar 웹훅 경로에서만 쓰임) — 그 갭은 별도 스토리([#2502](entity:story:089a6cc5-fd10-47a1-8322-cac89b1359d9))로 적어뒀다.
+`trigger_due_charges()`가 그 훅 자리(NotImplementedError로 명시 — PolarAdapter/TossAdapter
+의 미구현 메서드 관례와 동형).
+
+이 스토리가 실제로 구현하는 것 — 데이터 소스가 **이미 있는** 두 축:
+1. **dunning 재시도**: C2(#2493)가 만든 `billing_orders`의 `failed` 행을 스윕. 케이던스는
+   지어내지 않고 정책 문서에서 짚었다(PO 가드①) — `pricing-policy-proposal-v1` §12.1을
+   2026-08-07 직접 재확認: 최초실패(과금 유지)→+1일 1차 재결제→+3일 2차→+5일 3차→
+   +7일 유예종료알림(재시도 아님)→+8일 Free 강제전환.
+2. **대사(reconciliation)**: `pending`으로 너무 오래 멈춘 order(C2가 크래시/타임아웃
+   대비로 만든 그 상태) — Toss 조회(`get_payment_by_order_id`)로 실 상태를 확認해 정합.
+   C2가 "스코프 밖"으로 남긴 그 자리(§2 step8 "일일 대사").
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.billing_order import BillingOrder
+from app.models.offering_version import OfferingVersion
+from app.models.org_subscription import OrgSubscription
+from app.services.billing_charge import (
+    _confirm_with_ledger,
+    _mark_failed_if_not_confirmed,
+    charge_org,
+)
+from app.services.payment.toss_adapter import TossAdapter
+
+logger = logging.getLogger(__name__)
+
+# pricing-policy-proposal-v1 §12.1(2026-08-07 재확認) — 지어내지 않음, 문서 원문 그대로.
+_DUNNING_RETRY_DAYS = frozenset({1, 3, 5})
+_DUNNING_DOWNGRADE_DAY = 8
+
+# Toss charge는 최대 60초(공식 문서) — 그보다 넉넉히 오래 pending이면 크래시/타임아웃으로
+# 간주해 대사 대상.
+PENDING_STALE_AFTER = timedelta(minutes=5)
+
+
+def next_dunning_action(order: BillingOrder, *, now: datetime) -> str:
+    """failed order 하나에 대해 지금 뭘 해야 하는지 — 순수 함수(DB/네트워크 접촉 없음).
+    "wait" | "retry" | "downgrade_to_free" 중 하나.
+
+    같은 날 중복 재시도 방지: `updated_at`이 오늘 이미 갱신됐으면(=오늘 이미 시도함) 또
+    재시도하지 않는다 — cron이 하루에 여러 번 돌아도(예: */10분) 하루 1회만 재결제한다."""
+    if order.status != "failed":
+        return "wait"
+    age_days = (now.date() - order.created_at.date()).days
+    if age_days >= _DUNNING_DOWNGRADE_DAY:
+        return "downgrade_to_free"
+    already_attempted_today = order.updated_at.date() >= now.date()
+    if age_days in _DUNNING_RETRY_DAYS and not already_attempted_today:
+        return "retry"
+    return "wait"
+
+
+async def downgrade_to_free(session: AsyncSession, org_id: uuid.UUID) -> None:
+    """§12.1 +8일 — Free 권리로 전환. 기존 데이터는 절대 지우지 않는다(정책 명시) — 이
+    함수는 구독 tier만 되돌린다, 데이터 삭제/에이전트 강제해제는 정책상 없음(§12.1 원문:
+    "이미 등록된 에이전트를 강제 해제하지 않는다")."""
+    free_offering = (
+        await session.execute(
+            select(OfferingVersion).where(
+                OfferingVersion.tier == "free",
+                OfferingVersion.currency == "krw",
+                OfferingVersion.effective_to.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+
+    stmt = pg_insert(OrgSubscription).values(
+        id=uuid.uuid4(), org_id=org_id, tier="free", status="active",
+        provider="toss", currency="krw", billing_cycle=None,
+        offering_version_id=free_offering.id if free_offering else None,
+    ).on_conflict_do_update(
+        index_elements=["org_id"],
+        set_={
+            "tier": "free", "status": "active",
+            "offering_version_id": free_offering.id if free_offering else None,
+        },
+    )
+    await session.execute(stmt)
+    await session.commit()
+
+
+async def sweep_dunning_retries(session: AsyncSession, *, now: datetime | None = None) -> dict:
+    """failed billing_orders를 스윕 — §12.1 케이던스대로 재시도하거나 Free로 전환."""
+    now = now or datetime.now(timezone.utc)
+    failed_orders = (
+        await session.execute(select(BillingOrder).where(BillingOrder.status == "failed"))
+    ).scalars().all()
+
+    retried = downgraded = 0
+    for order in failed_orders:
+        action = next_dunning_action(order, now=now)
+        if action == "retry":
+            try:
+                # charge_org 자체가 이미 claim/멱등/원장 불변식을 다 지킨다(#2493) — 여기서는
+                # 그냥 같은 order_id/amount로 재호출만 한다. 실패해도 charge_org 내부에서
+                # 이미 failed로 재기록됐으니 여기선 로깅만(다음 스윕이 또 판단).
+                await charge_org(
+                    session, org_id=order.org_id, order_id=order.order_id,
+                    amount_minor=order.amount_minor, currency=order.currency,
+                )
+            except Exception:
+                logger.exception("dunning retry failed for order_id=%s", order.order_id)
+            retried += 1
+        elif action == "downgrade_to_free":
+            await downgrade_to_free(session, order.org_id)
+            downgraded += 1
+
+    return {"failed_orders_seen": len(failed_orders), "retried": retried, "downgraded": downgraded}
+
+
+async def sweep_stale_pending_orders(session: AsyncSession, *, now: datetime | None = None) -> dict:
+    """PENDING_STALE_AFTER보다 오래 pending인 order를 Toss 조회로 대사한다 — C2가 "일일
+    대사" 스코프 밖으로 남긴 그 자리(orderId-먼저-기록 설계의 짝: 기록은 됐는데 Toss 응답을
+    못 받은 채 죽은 프로세스를 여기서 회수한다)."""
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - PENDING_STALE_AFTER
+    stale_orders = (
+        await session.execute(
+            select(BillingOrder).where(BillingOrder.status == "pending", BillingOrder.created_at < cutoff)
+        )
+    ).scalars().all()
+
+    confirmed = failed = 0
+    for order in stale_orders:
+        try:
+            lookup = await TossAdapter().get_payment_by_order_id(order_id=order.order_id)
+        except Exception:
+            logger.exception("stale pending reconciliation lookup failed for order_id=%s", order.order_id)
+            await _mark_failed_if_not_confirmed(session, order.order_id, "reconciliation lookup failed")
+            failed += 1
+            continue
+
+        if lookup.get("status") == "DONE" and lookup.get("paymentKey"):
+            await _confirm_with_ledger(
+                session, org_id=order.org_id, order_id=order.order_id,
+                amount_minor=order.amount_minor, currency=order.currency,
+                payment_key=lookup["paymentKey"],
+            )
+            confirmed += 1
+        else:
+            await _mark_failed_if_not_confirmed(
+                session, order.order_id, f"stale pending — lookup status={lookup.get('status')}"
+            )
+            failed += 1
+
+    return {"stale_pending_seen": len(stale_orders), "confirmed": confirmed, "failed": failed}
+
+
+async def trigger_due_charges(session: AsyncSession) -> dict:
+    """오늘 신규 결제 주기가 도래한 org를 찾아 charge_org를 트리거하는 자리 — 이 스토리
+    스코프 밖(PO 확認, 2026-08-07). `org_subscriptions.current_period_start/end`가 Toss
+    구독에 세팅되는 경로 자체가 아직 없다(story #2502가 그 전제를 채운다). #2502 완료
+    후 이 함수를 채운다."""
+    raise NotImplementedError(
+        "trigger_due_charges — blocked on story #2502(Toss 구독 주기 확定). "
+        "org_subscriptions.current_period_start/end가 Toss 경로에 세팅되지 않아 "
+        "\"누가 오늘 청구 대상인지\" 판단할 데이터 소스가 없다."
+    )

--- a/backend/tests/test_e_2494_c3_scheduler.py
+++ b/backend/tests/test_e_2494_c3_scheduler.py
@@ -62,6 +62,7 @@ async def test_downgrade_to_free_upserts_free_tier(monkeypatch):
     from app.services.billing_scheduler import downgrade_to_free
 
     org_id = uuid.uuid4()
+    order_id = "ord-downgrade-1"
     free_offering = MagicMock()
     free_offering.id = uuid.uuid4()
 
@@ -69,10 +70,11 @@ async def test_downgrade_to_free_upserts_free_tier(monkeypatch):
     offering_result = MagicMock()
     offering_result.scalar_one_or_none.return_value = free_offering
     upsert_result = MagicMock()
-    session.execute = AsyncMock(side_effect=[offering_result, upsert_result])
+    close_order_result = MagicMock()
+    session.execute = AsyncMock(side_effect=[offering_result, upsert_result, close_order_result])
     session.commit = AsyncMock()
 
-    await downgrade_to_free(session, org_id)
+    await downgrade_to_free(session, org_id, order_id)
 
     upsert_call = session.execute.call_args_list[1]
     compiled = upsert_call.args[0].compile().params
@@ -90,14 +92,38 @@ async def test_downgrade_to_free_handles_missing_offering_gracefully(monkeypatch
     session = AsyncMock()
     offering_result = MagicMock()
     offering_result.scalar_one_or_none.return_value = None
-    session.execute = AsyncMock(side_effect=[offering_result, MagicMock()])
+    session.execute = AsyncMock(side_effect=[offering_result, MagicMock(), MagicMock()])
     session.commit = AsyncMock()
 
-    await downgrade_to_free(session, uuid.uuid4())
+    await downgrade_to_free(session, uuid.uuid4(), "ord-downgrade-2")
 
     upsert_call = session.execute.call_args_list[1]
     compiled = upsert_call.args[0].compile().params
     assert compiled["offering_version_id"] is None
+
+
+@pytest.mark.anyio
+async def test_downgrade_to_free_closes_the_order_po_blocker_fix(monkeypatch):
+    """PO 리뷰 블로커(#2884, 2026-08-07) 회귀 고정 — "상태 자가회수 부재": order를
+    'downgraded'(종결)로 전이시켜 failed-스윕 집합에서 영구히 뺀다. 이걸 안 하면(예전
+    버그) ①매 스윕 재처리 ②org가 나중에 재구독해도 옛 failed order가 다시 골라져
+    새 유료 구독을 free로 clobber — 둘 다 이 전이 하나로 막힌다."""
+    from app.services.billing_scheduler import downgrade_to_free
+
+    org_id = uuid.uuid4()
+    order_id = "ord-downgrade-3"
+    session = AsyncMock()
+    offering_result = MagicMock()
+    offering_result.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(side_effect=[offering_result, MagicMock(), MagicMock()])
+    session.commit = AsyncMock()
+
+    await downgrade_to_free(session, org_id, order_id)
+
+    # 3번째 호출이 billing_orders를 'downgraded'로 닫는 UPDATE여야.
+    close_call = session.execute.call_args_list[2]
+    compiled = close_call.args[0].compile().params
+    assert compiled["status"] == "downgraded"
 
 
 # ─── sweep_dunning_retries ──────────────────────────────────────────────────
@@ -128,7 +154,7 @@ async def test_sweep_dunning_retries_retries_and_downgrades(monkeypatch):
         session, org_id=retry_order.org_id, order_id=retry_order.order_id,
         amount_minor=retry_order.amount_minor, currency=retry_order.currency,
     )
-    downgrade_mock.assert_awaited_once_with(session, downgrade_order.org_id)
+    downgrade_mock.assert_awaited_once_with(session, downgrade_order.org_id, downgrade_order.order_id)
 
 
 @pytest.mark.anyio
@@ -177,7 +203,7 @@ async def test_sweep_stale_pending_confirms_when_toss_lookup_done(monkeypatch):
 
     result = await sched.sweep_stale_pending_orders(session, now=now)
 
-    assert result == {"stale_pending_seen": 1, "confirmed": 1, "failed": 0}
+    assert result == {"stale_pending_seen": 1, "confirmed": 1, "failed": 0, "skipped_lookup_error": 0}
     confirm_mock.assert_awaited_once_with(
         session, org_id=stale_order.org_id, order_id=stale_order.order_id,
         amount_minor=stale_order.amount_minor, currency=stale_order.currency,
@@ -209,13 +235,16 @@ async def test_sweep_stale_pending_marks_failed_when_toss_lookup_not_done(monkey
 
     result = await sched.sweep_stale_pending_orders(session, now=now)
 
-    assert result == {"stale_pending_seen": 1, "confirmed": 0, "failed": 1}
+    assert result == {"stale_pending_seen": 1, "confirmed": 0, "failed": 1, "skipped_lookup_error": 0}
     confirm_mock.assert_not_awaited()
     fail_mock.assert_awaited_once()
 
 
 @pytest.mark.anyio
-async def test_sweep_stale_pending_marks_failed_when_lookup_errors(monkeypatch):
+async def test_sweep_stale_pending_leaves_pending_on_transient_lookup_error(monkeypatch):
+    """PO fix-forward(#2884 리뷰) — 조회 자체가 실패(네트워크 등)한 것과 "Toss가 실패로
+    안다"는 다른 신호다. 실제로는 성공했을 charge를 failed로 오분류하지 않도록, 조회
+    예외는 order를 건드리지 않고 그냥 skip(다음 스윕이 재조회)."""
     import app.services.billing_scheduler as sched
 
     now = datetime(2026, 8, 15, tzinfo=timezone.utc)
@@ -231,13 +260,15 @@ async def test_sweep_stale_pending_marks_failed_when_lookup_errors(monkeypatch):
         AsyncMock(side_effect=RuntimeError("Cannot reach Toss API")),
     )
     fail_mock = AsyncMock()
+    confirm_mock = AsyncMock()
     monkeypatch.setattr(sched, "_mark_failed_if_not_confirmed", fail_mock)
-    monkeypatch.setattr(sched, "_confirm_with_ledger", AsyncMock())
+    monkeypatch.setattr(sched, "_confirm_with_ledger", confirm_mock)
 
     result = await sched.sweep_stale_pending_orders(session, now=now)
 
-    assert result["failed"] == 1
-    fail_mock.assert_awaited_once()
+    assert result == {"stale_pending_seen": 1, "confirmed": 0, "failed": 0, "skipped_lookup_error": 1}
+    fail_mock.assert_not_awaited()
+    confirm_mock.assert_not_awaited()
 
 
 # ─── trigger_due_charges — 명시 스코프 밖 ───────────────────────────────────

--- a/backend/tests/test_e_2494_c3_scheduler.py
+++ b/backend/tests/test_e_2494_c3_scheduler.py
@@ -1,0 +1,280 @@
+"""#2494(C3) — dunning 재시도 상태기계(pricing-policy-proposal-v1 §12.1) + pending 대사.
+PO 계약(2026-08-07): (b)-narrowed — "신규 결제 주기 도래" 판정은 스코프 밖(#2502 대기)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _order(*, status: str, created_days_ago: int, updated_days_ago: int, now: datetime):
+    o = MagicMock()
+    o.status = status
+    o.created_at = now - timedelta(days=created_days_ago)
+    o.updated_at = now - timedelta(days=updated_days_ago)
+    o.org_id = uuid.uuid4()
+    o.order_id = f"ord-{uuid.uuid4()}"
+    o.amount_minor = 29000
+    o.currency = "krw"
+    return o
+
+
+# ─── next_dunning_action — 순수 함수(§12.1 케이던스) ───────────────────────
+
+@pytest.mark.parametrize(
+    "status,age_days,updated_days_ago,expected",
+    [
+        ("confirmed", 3, 3, "wait"),          # confirmed는 애초에 대상 아님
+        ("pending", 3, 3, "wait"),             # pending도 dunning 대상 아님(대사 몫)
+        ("failed", 0, 0, "wait"),              # 최초 실패 당일 — §12.1 "기능 유지"만, 재시도 없음
+        ("failed", 1, 1, "retry"),             # +1일 1차 재결제
+        ("failed", 2, 2, "wait"),              # +2일 — 케이던스에 없는 날
+        ("failed", 3, 3, "retry"),             # +3일 2차
+        ("failed", 5, 5, "retry"),             # +5일 3차
+        ("failed", 7, 7, "wait"),              # +7일 = 유예종료 "알림"이지 재시도 아님
+        ("failed", 8, 7, "downgrade_to_free"), # +8일 Free 전환
+        ("failed", 10, 7, "downgrade_to_free"),# 8일 지나면 계속 downgrade(멱등)
+    ],
+)
+def test_next_dunning_action_follows_policy_cadence(status, age_days, updated_days_ago, expected):
+    from app.services.billing_scheduler import next_dunning_action
+
+    now = datetime(2026, 8, 15, tzinfo=timezone.utc)
+    order = _order(status=status, created_days_ago=age_days, updated_days_ago=updated_days_ago, now=now)
+    assert next_dunning_action(order, now=now) == expected
+
+
+def test_next_dunning_action_same_day_retry_not_repeated():
+    """cron이 하루에 여러 번 돌아도(*/10분 등) 이미 오늘 시도한 order는 또 재시도하지 않는다."""
+    from app.services.billing_scheduler import next_dunning_action
+
+    now = datetime(2026, 8, 15, 14, 0, tzinfo=timezone.utc)
+    order = _order(status="failed", created_days_ago=1, updated_days_ago=0, now=now)  # 오늘 이미 갱신됨
+    assert next_dunning_action(order, now=now) == "wait"
+
+
+# ─── downgrade_to_free ──────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_downgrade_to_free_upserts_free_tier(monkeypatch):
+    from app.services.billing_scheduler import downgrade_to_free
+
+    org_id = uuid.uuid4()
+    free_offering = MagicMock()
+    free_offering.id = uuid.uuid4()
+
+    session = AsyncMock()
+    offering_result = MagicMock()
+    offering_result.scalar_one_or_none.return_value = free_offering
+    upsert_result = MagicMock()
+    session.execute = AsyncMock(side_effect=[offering_result, upsert_result])
+    session.commit = AsyncMock()
+
+    await downgrade_to_free(session, org_id)
+
+    upsert_call = session.execute.call_args_list[1]
+    compiled = upsert_call.args[0].compile().params
+    assert compiled["org_id"] == org_id
+    assert compiled["tier"] == "free"
+    assert compiled["offering_version_id"] == free_offering.id
+    session.commit.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_downgrade_to_free_handles_missing_offering_gracefully(monkeypatch):
+    """free offering_version 시드가 없어도(방어) crash하지 않고 offering_version_id=None으로 진행."""
+    from app.services.billing_scheduler import downgrade_to_free
+
+    session = AsyncMock()
+    offering_result = MagicMock()
+    offering_result.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(side_effect=[offering_result, MagicMock()])
+    session.commit = AsyncMock()
+
+    await downgrade_to_free(session, uuid.uuid4())
+
+    upsert_call = session.execute.call_args_list[1]
+    compiled = upsert_call.args[0].compile().params
+    assert compiled["offering_version_id"] is None
+
+
+# ─── sweep_dunning_retries ──────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_sweep_dunning_retries_retries_and_downgrades(monkeypatch):
+    import app.services.billing_scheduler as sched
+
+    now = datetime(2026, 8, 15, tzinfo=timezone.utc)
+    retry_order = _order(status="failed", created_days_ago=1, updated_days_ago=1, now=now)
+    downgrade_order = _order(status="failed", created_days_ago=9, updated_days_ago=8, now=now)
+    wait_order = _order(status="failed", created_days_ago=2, updated_days_ago=2, now=now)
+
+    session = AsyncMock()
+    orders_result = MagicMock()
+    orders_result.scalars.return_value.all.return_value = [retry_order, downgrade_order, wait_order]
+    session.execute = AsyncMock(return_value=orders_result)
+
+    charge_mock = AsyncMock()
+    downgrade_mock = AsyncMock()
+    monkeypatch.setattr(sched, "charge_org", charge_mock)
+    monkeypatch.setattr(sched, "downgrade_to_free", downgrade_mock)
+
+    result = await sched.sweep_dunning_retries(session, now=now)
+
+    assert result == {"failed_orders_seen": 3, "retried": 1, "downgraded": 1}
+    charge_mock.assert_awaited_once_with(
+        session, org_id=retry_order.org_id, order_id=retry_order.order_id,
+        amount_minor=retry_order.amount_minor, currency=retry_order.currency,
+    )
+    downgrade_mock.assert_awaited_once_with(session, downgrade_order.org_id)
+
+
+@pytest.mark.anyio
+async def test_sweep_dunning_retries_charge_exception_does_not_abort_sweep(monkeypatch):
+    """한 order의 재시도가 예외를 던져도(charge_org가 내부에서 이미 failed로 기록했을
+    것이므로) 스윕 전체가 죽지 않고 카운트만 반영한다."""
+    import app.services.billing_scheduler as sched
+
+    now = datetime(2026, 8, 15, tzinfo=timezone.utc)
+    retry_order = _order(status="failed", created_days_ago=1, updated_days_ago=1, now=now)
+
+    session = AsyncMock()
+    orders_result = MagicMock()
+    orders_result.scalars.return_value.all.return_value = [retry_order]
+    session.execute = AsyncMock(return_value=orders_result)
+
+    monkeypatch.setattr(sched, "charge_org", AsyncMock(side_effect=RuntimeError("toss down")))
+    monkeypatch.setattr(sched, "downgrade_to_free", AsyncMock())
+
+    result = await sched.sweep_dunning_retries(session, now=now)
+    assert result["retried"] == 1
+
+
+# ─── sweep_stale_pending_orders ─────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_sweep_stale_pending_confirms_when_toss_lookup_done(monkeypatch):
+    import app.services.billing_scheduler as sched
+
+    now = datetime(2026, 8, 15, tzinfo=timezone.utc)
+    stale_order = _order(status="pending", created_days_ago=1, updated_days_ago=1, now=now)
+
+    session = AsyncMock()
+    orders_result = MagicMock()
+    orders_result.scalars.return_value.all.return_value = [stale_order]
+    session.execute = AsyncMock(return_value=orders_result)
+
+    monkeypatch.setattr(
+        sched.TossAdapter, "get_payment_by_order_id",
+        AsyncMock(return_value={"status": "DONE", "paymentKey": "pay_recovered"}),
+    )
+    confirm_mock = AsyncMock()
+    fail_mock = AsyncMock()
+    monkeypatch.setattr(sched, "_confirm_with_ledger", confirm_mock)
+    monkeypatch.setattr(sched, "_mark_failed_if_not_confirmed", fail_mock)
+
+    result = await sched.sweep_stale_pending_orders(session, now=now)
+
+    assert result == {"stale_pending_seen": 1, "confirmed": 1, "failed": 0}
+    confirm_mock.assert_awaited_once_with(
+        session, org_id=stale_order.org_id, order_id=stale_order.order_id,
+        amount_minor=stale_order.amount_minor, currency=stale_order.currency,
+        payment_key="pay_recovered",
+    )
+    fail_mock.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_sweep_stale_pending_marks_failed_when_toss_lookup_not_done(monkeypatch):
+    import app.services.billing_scheduler as sched
+
+    now = datetime(2026, 8, 15, tzinfo=timezone.utc)
+    stale_order = _order(status="pending", created_days_ago=1, updated_days_ago=1, now=now)
+
+    session = AsyncMock()
+    orders_result = MagicMock()
+    orders_result.scalars.return_value.all.return_value = [stale_order]
+    session.execute = AsyncMock(return_value=orders_result)
+
+    monkeypatch.setattr(
+        sched.TossAdapter, "get_payment_by_order_id",
+        AsyncMock(return_value={"status": "ABORTED"}),
+    )
+    confirm_mock = AsyncMock()
+    fail_mock = AsyncMock()
+    monkeypatch.setattr(sched, "_confirm_with_ledger", confirm_mock)
+    monkeypatch.setattr(sched, "_mark_failed_if_not_confirmed", fail_mock)
+
+    result = await sched.sweep_stale_pending_orders(session, now=now)
+
+    assert result == {"stale_pending_seen": 1, "confirmed": 0, "failed": 1}
+    confirm_mock.assert_not_awaited()
+    fail_mock.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_sweep_stale_pending_marks_failed_when_lookup_errors(monkeypatch):
+    import app.services.billing_scheduler as sched
+
+    now = datetime(2026, 8, 15, tzinfo=timezone.utc)
+    stale_order = _order(status="pending", created_days_ago=1, updated_days_ago=1, now=now)
+
+    session = AsyncMock()
+    orders_result = MagicMock()
+    orders_result.scalars.return_value.all.return_value = [stale_order]
+    session.execute = AsyncMock(return_value=orders_result)
+
+    monkeypatch.setattr(
+        sched.TossAdapter, "get_payment_by_order_id",
+        AsyncMock(side_effect=RuntimeError("Cannot reach Toss API")),
+    )
+    fail_mock = AsyncMock()
+    monkeypatch.setattr(sched, "_mark_failed_if_not_confirmed", fail_mock)
+    monkeypatch.setattr(sched, "_confirm_with_ledger", AsyncMock())
+
+    result = await sched.sweep_stale_pending_orders(session, now=now)
+
+    assert result["failed"] == 1
+    fail_mock.assert_awaited_once()
+
+
+# ─── trigger_due_charges — 명시 스코프 밖 ───────────────────────────────────
+
+@pytest.mark.anyio
+async def test_trigger_due_charges_not_implemented_pending_story_2502():
+    from app.services.billing_scheduler import trigger_due_charges
+
+    with pytest.raises(NotImplementedError, match="#2502"):
+        await trigger_due_charges(AsyncMock())
+
+
+# ─── cron endpoint ───────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_toss_billing_maintenance_cron_requires_verify_cron(monkeypatch):
+    """다른 cron 엔드포인트와 동일 인증 관례(verify_cron) — CRON_SECRET 불일치면 거부.
+    #2072 교훈: CRON_SECRET 미설정 시 로컬 dev는 fail-open이라(is_really_local) 그 분기를
+    피하려면 실제 시크릿을 명시로 설정해야 진짜 검증 경로를 태운다."""
+    from httpx import ASGITransport, AsyncClient
+
+    from app.main import app
+    from tests.conftest import override_db_and_read
+
+    monkeypatch.setattr("app.routers.cron.CRON_SECRET", "real-secret")
+
+    async def _override_db():
+        yield AsyncMock()
+
+    override_db_and_read(app, _override_db)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get(
+                "/api/v2/internal/cron/toss-billing-maintenance",
+                headers={"Authorization": "Bearer wrong-secret"},
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code in (401, 403)


### PR DESCRIPTION
## Summary
C3 of 결제②-C (TossAdapter). (b)-narrowed per PO's scope call (2026-08-07, [conversation](entity:story:none) thread) — "누가 오늘 청구 대상인지" (new billing-cycle trigger) is out of scope.

Grounded before building: `org_subscriptions.current_period_start/end` is only ever written by the Polar webhook path (`ee/routers/billing.py`) — Toss subscriptions have no event that sets it yet (no D-stage payment UI, so "Toss로 신규 유료 전환" never fires in code). Filed that gap as [#2502](entity:story:089a6cc5-fd10-47a1-8322-cac89b1359d9) (Toss subscription-cycle wiring) instead of guessing at a design for it here.

## What this story builds
The two axes that already have a real data source (`billing_orders`, from C2/#2493):

- **`next_dunning_action()`** — pure function, no DB/network. Cadence is not invented: pulled directly from `pricing-policy-proposal-v1` §12.1 (re-verified against the doc today, not memory/an earlier note) — initial failure keeps access, +1d/+3d/+5d are retry attempts, +7d is a grace-period *notice* (not a retry), +8d is forced Free downgrade. Same-day retries are suppressed via `updated_at` so a `*/10min` cron doesn't double-charge within a day.
- **`sweep_dunning_retries()`** — sweeps `failed` `billing_orders`, calls the existing `charge_org()` (C2 already owns claim/idempotency/ledger invariants — this just re-invokes it with the order's own recorded `amount_minor`/`currency`) or `downgrade_to_free()`.
- **`sweep_stale_pending_orders()`** — reconciles orders stuck in `pending` past Toss's 60s window (crash/timeout) via a new `TossAdapter.get_payment_by_order_id` (`GET /v1/payments/orders/{orderId}`, verified against Toss's docs), reusing C2's `_confirm_with_ledger`/`_mark_failed_if_not_confirmed` so the same "confirmed implies ledger exists" invariant holds here too.
- **`downgrade_to_free()`** — flips `org_subscriptions` to the active `krw` free `offering_version`. Policy (§12.1) is explicit this never touches existing data or force-disconnects agents — this function only does the tier flip.
- **`trigger_due_charges()`** — stubbed `NotImplementedError` pointing at #2502, same convention as `PolarAdapter`/`TossAdapter`'s unimplemented methods (explicit failure over silent wrong behavior).
- **`GET /api/v2/internal/cron/toss-billing-maintenance`** — thin cron endpoint (`verify_cron`, same pattern as the ~12 other jobs in `cron.py`) that runs both sweeps.

## Test plan
- [x] `next_dunning_action` — table-driven across all §12.1 days (0/1/2/3/5/7/8/10) for `confirmed`/`pending`/`failed`, plus same-day-no-repeat
- [x] `downgrade_to_free` — with and without a seeded free `offering_version`
- [x] `sweep_dunning_retries` — happy path (retry + downgrade + wait counted correctly) and one order's exception not aborting the sweep
- [x] `sweep_stale_pending_orders` — Toss lookup DONE / not-DONE / erroring, all three paths
- [x] `trigger_due_charges` raises with the #2502 pointer
- [x] cron endpoint auth (real `CRON_SECRET` mismatch → 401/403, per #2072's fail-open lesson)
- [x] `pytest tests/test_e_2494_c3_scheduler.py tests/test_e_2493_c2_charge_ledger.py tests/test_e_2492_c1_billing_key.py tests/test_e_2478_b_payment_adapter.py tests/test_e_org_multi_s5_3_polar_checkout.py tests/test_check_env_drift_settings_coverage.py tests/test_2072_cron_secret_failopen.py tests/test_e_2472_a2_billing_ledger_realdb.py` — 94 passed, 6 skipped (realdb)
- [x] `lint_project_access_403.py` / `lint_dependency_override_get_read_db.py` — 0 new violations
- [x] `python -c "import app.main"` — clean
- [x] Full backend suite (background run) — no regressions beyond the known pre-existing environment-dependent failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)