### PR TITLE
[SID:2503] 에러 배너/토스트 초장문 overflow — overflow-wrap:anywhere

### DIFF
--- a/apps/web/src/components/ui/alert.test.tsx
+++ b/apps/web/src/components/ui/alert.test.tsx
@@ -14,7 +14,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { Alert, AlertDescription } from './alert';
+import { Alert, AlertDescription, AlertTitle } from './alert';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -86,5 +86,22 @@ describe('Alert 접근성 (story #2149)', () => {
     });
     expect(container.querySelector('[role="alert"]')).not.toBeNull();
     expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+
+  // 유나 지적(error-display 폴리시) — 공백 없는 초장문(토큰·URL 등)이 grid 1fr 트랙을
+  // 넘어 넘쳐흘렀다. AlertTitle/AlertDescription 둘 다 anywhere로 어디서나 끊을 여지를 준다.
+  it('AlertTitle/AlertDescription이 overflow-wrap:anywhere를 갖는다(초장문 overflow 회귀가드)', async () => {
+    await act(async () => {
+      root.render(
+        <Alert variant="destructive">
+          <AlertTitle>제목</AlertTitle>
+          <AlertDescription>본문</AlertDescription>
+        </Alert>,
+      );
+    });
+    const title = container.querySelector('p');
+    const description = container.querySelectorAll('p')[1];
+    expect(title?.className).toContain('[overflow-wrap:anywhere]');
+    expect(description?.className).toContain('[overflow-wrap:anywhere]');
   });
 });

--- a/apps/web/src/components/ui/alert.tsx
+++ b/apps/web/src/components/ui/alert.tsx
@@ -52,13 +52,17 @@ const Alert = React.forwardRef<
 ));
 Alert.displayName = 'Alert';
 
+// 유나 지적(error-display 폴리시) — 공백 없는 초장문(토큰·URL·해시 등)이 grid의
+// 1fr 트랙을 넘어 넘쳐흘렀다. grid/flex 아이템은 기본 min-width:auto라 트랙 크기
+// 지정만으론 안 막히고, 텍스트에 실제로 줄바꿈 여지를 줘야 한다 — break-word 대신
+// anywhere(공백 없어도 어디서나 끊음, min-content 계산에도 안전)를 쓴다.
 const AlertTitle = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn('col-start-2 font-medium leading-5', className)}
+    className={cn('col-start-2 font-medium leading-5 [overflow-wrap:anywhere]', className)}
     {...props}
   />
 ));
@@ -70,7 +74,7 @@ const AlertDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn('col-start-2 text-xs leading-relaxed opacity-90', className)}
+    className={cn('col-start-2 text-xs leading-relaxed opacity-90 [overflow-wrap:anywhere]', className)}
     {...props}
   />
 ));

--- a/apps/web/src/components/ui/toast.test.tsx
+++ b/apps/web/src/components/ui/toast.test.tsx
@@ -91,4 +91,17 @@ describe('Toast 접근성 (story #2096)', () => {
     expect(container.querySelectorAll('[role="status"]').length).toBe(1);
     expect(container.querySelectorAll('[role="alert"]').length).toBe(1);
   });
+
+  // 유나 지적(error-display 폴리시) — 공백 없는 초장문(토큰·URL 등)이 토스트 폭을 넘어
+  // 넘쳐흘렀다. 텍스트 wrapper에 min-w-0(flex 아이템 기본 min-width:auto 트랩 해제)+
+  // 텍스트 자체에 anywhere(어디서나 끊음)가 함께 있어야 실제로 줄바꿈된다.
+  it('제목/본문 텍스트가 overflow-wrap:anywhere를 갖고, wrapper가 min-w-0이다(초장문 overflow 회귀가드)', async () => {
+    await act(async () => {
+      root.render(wrap(<ToastContainer toasts={[toast({ body: '본문' })]} onDismiss={() => {}} />));
+    });
+    const paragraphs = container.querySelectorAll('p');
+    expect(paragraphs.length).toBe(2);
+    paragraphs.forEach((p) => expect(p.className).toContain('[overflow-wrap:anywhere]'));
+    expect(container.querySelector('.min-w-0')).not.toBeNull();
+  });
 });

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -60,10 +60,14 @@ function Toast({ item, onDismiss }: ToastProps) {
       className={`animate-slide-in rounded-lg border border-border bg-popover p-4 shadow-lg ${borderColor}`}
     >
       <div className="flex items-start justify-between">
-        <div>
-          <p className="text-sm font-semibold text-popover-foreground">{item.title}</p>
+        {/* 유나 지적(error-display 폴리시) — 공백 없는 초장문(토큰·URL 등)이 토스트 폭을
+            넘어 넘쳐흘렀다. flex 아이템은 기본 min-width:auto라 min-w-0 없이는 안 줄어들고,
+            텍스트 자체도 anywhere로 어디서나 끊을 여지를 줘야 한다(break-word는 min-content
+            계산에서 여전히 안 줄어드는 경우가 있다). */}
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-popover-foreground [overflow-wrap:anywhere]">{item.title}</p>
           {item.body && (
-            <p className="mt-1 text-xs text-muted-foreground">{item.body}</p>
+            <p className="mt-1 text-xs text-muted-foreground [overflow-wrap:anywhere]">{item.body}</p>
           )}
         </div>
         <div className="ml-3 flex shrink-0 items-center gap-3">


### PR DESCRIPTION
## 요약
유나양 지적(error-display 폴리시) — 공백 없는 초장문(토큰·URL·해시 등)이 공용 `Alert`(grid `1fr` 트랙)·`Toast`(flex 아이템) 폭을 넘어 넘쳐흘렀다. grid/flex 아이템은 기본 `min-width:auto`라 트랙/컨테이너 크기 지정만으론 안 막히고, 텍스트 자체에 줄바꿈 여지를 줘야 한다 — `break-word` 대신 `anywhere`(공백 없어도 어디서나 끊고 min-content 계산에도 안전)를 썼다.

## 변경
- `components/ui/alert.tsx` — `AlertTitle`/`AlertDescription`에 `[overflow-wrap:anywhere]`.
- `components/ui/toast.tsx` — 제목/본문 `<p>`에 `[overflow-wrap:anywhere]` + 텍스트 wrapper에 `min-w-0`(flex 아이템 기본 `min-width:auto` 트랩 해제 — 이게 없으면 `overflow-wrap`만으론 실제로 안 줄어든다).

공용 컴포넌트 2곳만 고쳐 이 두 컴포넌트를 쓰는 모든 에러/토스트 노출 자리를 한 번에 커버(개별 호출부 전수 수정 아님 — 좁은 경계).

## 게이트
- 신규 vitest 2개(overflow-wrap 클래스 존재 확認) GREEN
- 뮤테이션 셀프체크 1건 — AlertDescription 클래스 제거 → RED 확認 → 복원
- 기존 테스트(alert 10 + toast 9) 회귀 없음
- tsc/eslint 클린
- 전체 모노레포 vitest 399파일/3012개 GREEN(회귀 0)
- `pnpm build` exit 0

⚠️CSS 전용 좁은 변경이라 로컬 dev 서버/브라우저 라이브 픽셀 확認은 이번엔 생략했는 — 유나신 design 리뷰에서 시각 확認 부탁드리는.

🤖 Generated with [Claude Code](https://claude.com/claude-code)