### PR TITLE
feat(#2500): 결제② 청구액 계산 엔진 — offering_version × 사람좌석 × 팩

### DIFF
--- a/backend/app/services/billing_charge_amount.py
+++ b/backend/app/services/billing_charge_amount.py
@@ -1,0 +1,114 @@
+"""결제②(story #2500) — 청구액 계산 엔진. offering_version(불변 가격표) × «사람 좌석» ×
+명시적으로 산 팩 → org의 이번 결제 주기 청구액. C3(#2494) trigger_due_charges가 이 값을
+얻어 C2(#2493) charge_org에 amount로 넘길 소스가 된다(C2/C3와 마찬가지로 "메커니즘만" —
+"누가 오늘 청구대상인지" 판정은 여기 책임이 아니다, #2502).
+
+⛔순수 read-only 계산 — Toss를 호출하지도 원장에 기입하지도 않는다.
+
+좌석 = «사람(human) 멤버»만(org_members, PO 확認 2026-08-07·pricing-policy-v2-3) —
+등록 에이전트는 별개 축(feature-gate)이라 좌석 계산에 넣지 않는다.
+
+팩분은 billing_ledger_entries(entry_type='pack_purchase') 기간집계로 읽는다 — "팩 구매
+트리거"(관리자 명시 확認 후 원장 기입) 자체는 아직 코드 어디에도 없어(그라운딩 grep 0건,
+story #2505로 별도 추적) 지금은 항상 0을 반환한다. current_period_start/end가 없는 org
+(Toss 신규 유료 전환 진입점이 아직 없다 — #2502)는 팩분을 0으로 취급(기간을 특정할 수
+없으니 집계 자체를 건너뛴다)."""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.billing_ledger_entry import BillingLedgerEntry
+from app.models.offering_version import OfferingVersion
+from app.models.org_subscription import OrgSubscription
+from app.models.project import OrgMember
+
+
+class ChargeAmountError(Exception):
+    """청구액을 계산할 수 없는 상태(구독/카탈로그 불변식 위반) — 잘못된 금액으로 조용히
+    진행하는 대신 명시적으로 실패한다."""
+
+
+async def count_human_seats(session: AsyncSession, org_id: uuid.UUID) -> int:
+    """이 org의 현재 실 «사람» 좌석 수. org_subscriptions에는 이 값을 담는 컬럼이 없다
+    (그라운딩 확認) — org_members에서 매번 파생한다(get_impact/check_member_invite_limit과
+    동일 쿼리 — SSOT 재사용, 새 카운팅 개념 발명 아님)."""
+    return (
+        await session.execute(
+            select(func.count()).select_from(OrgMember).where(
+                OrgMember.org_id == org_id,
+                OrgMember.deleted_at.is_(None),
+            )
+        )
+    ).scalar_one()
+
+
+async def compute_pack_charge_minor(
+    session: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    subscription_id: uuid.UUID,
+    period_start,
+    period_end,
+) -> int:
+    """이번 결제 주기 동안 명시적으로 구매된 팩의 합계(minor unit). 주기 경계가 없으면
+    (current_period_start/end 미세팅 — #2502 갭) 집계 범위를 특정할 수 없으니 0."""
+    if period_start is None or period_end is None:
+        return 0
+    return (
+        await session.execute(
+            select(func.coalesce(func.sum(BillingLedgerEntry.amount_minor), 0)).where(
+                BillingLedgerEntry.org_id == org_id,
+                BillingLedgerEntry.subscription_id == subscription_id,
+                BillingLedgerEntry.entry_type == "pack_purchase",
+                BillingLedgerEntry.ts >= period_start,
+                BillingLedgerEntry.ts < period_end,
+            )
+        )
+    ).scalar_one()
+
+
+async def compute_charge_amount(session: AsyncSession, *, org_id: uuid.UUID) -> tuple[int, str]:
+    """(amount_minor, currency) 반환. 기저가(월/연) + 좌석초과분 + 팩분."""
+    sub = (
+        await session.execute(select(OrgSubscription).where(OrgSubscription.org_id == org_id))
+    ).scalar_one_or_none()
+    if sub is None:
+        raise ChargeAmountError(f"no org_subscription row for org_id={org_id}")
+    if sub.offering_version_id is None:
+        raise ChargeAmountError(
+            f"org_subscription(org_id={org_id})에 offering_version_id가 바인딩되지 않음"
+        )
+
+    offering = await session.get(OfferingVersion, sub.offering_version_id)
+    if offering is None:
+        raise ChargeAmountError(f"offering_version {sub.offering_version_id}를 찾을 수 없음")
+
+    base_amount = (
+        offering.annual_price_minor if sub.billing_cycle == "annual" else offering.monthly_price_minor
+    )
+
+    seat_count = await count_human_seats(session, org_id)
+    seat_overage = max(0, seat_count - offering.included_seats)
+    if seat_overage > 0:
+        if offering.extra_seat_price_minor is None:
+            raise ChargeAmountError(
+                f"org_id={org_id} tier={offering.tier!r}가 included_seats를 {seat_overage}석 "
+                "초과했으나 이 offering은 추가좌석을 팔지 않음(정책상 상위 티어 전환 후에만 "
+                "가능한 상태 — 초과 상태로 청구를 계산하면 안 됨)"
+            )
+        seat_amount = seat_overage * offering.extra_seat_price_minor
+    else:
+        seat_amount = 0
+
+    pack_amount = await compute_pack_charge_minor(
+        session,
+        org_id=org_id,
+        subscription_id=sub.id,
+        period_start=sub.current_period_start,
+        period_end=sub.current_period_end,
+    )
+
+    return base_amount + seat_amount + pack_amount, offering.currency

--- a/backend/tests/test_e_2500_charge_amount.py
+++ b/backend/tests/test_e_2500_charge_amount.py
@@ -1,0 +1,265 @@
+"""#2500(청구②) — 청구액 계산 엔진. offering_version × 사람좌석 × 팩 → org 청구액.
+PO 계약(2026-08-07): 좌석=사람만(org_members)·팩분=billing_ledger_entries 기간집계(현재는
+트리거 없어 항상 0)·숫자는 offering_version에서(하드코딩 금지)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _subscription(*, billing_cycle="monthly", offering_version_id=None, period_start=None, period_end=None):
+    sub = MagicMock()
+    sub.id = uuid.uuid4()
+    sub.org_id = uuid.uuid4()
+    sub.billing_cycle = billing_cycle
+    sub.offering_version_id = offering_version_id or uuid.uuid4()
+    sub.current_period_start = period_start
+    sub.current_period_end = period_end
+    return sub
+
+
+def _offering(
+    *, tier="team", currency="krw", monthly=59_000, annual=590_000,
+    included_seats=5, extra_seat_price_minor=11_000,
+):
+    o = MagicMock()
+    o.id = uuid.uuid4()
+    o.tier = tier
+    o.currency = currency
+    o.monthly_price_minor = monthly
+    o.annual_price_minor = annual
+    o.included_seats = included_seats
+    o.extra_seat_price_minor = extra_seat_price_minor
+    return o
+
+
+def _exec_result(scalar_value):
+    r = MagicMock()
+    r.scalar_one.return_value = scalar_value
+    r.scalar_one_or_none.return_value = scalar_value
+    return r
+
+
+# ─── count_human_seats ──────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_count_human_seats_queries_org_members_only():
+    from app.services.billing_charge_amount import count_human_seats
+
+    org_id = uuid.uuid4()
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_exec_result(3))
+
+    count = await count_human_seats(session, org_id)
+
+    assert count == 3
+    compiled = session.execute.call_args.args[0].compile()
+    assert "org_members" in str(compiled).lower()
+
+
+# ─── compute_pack_charge_minor ──────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_compute_pack_charge_minor_zero_when_no_period_bounds():
+    from app.services.billing_charge_amount import compute_pack_charge_minor
+
+    session = AsyncMock()
+    session.execute = AsyncMock()
+
+    amount = await compute_pack_charge_minor(
+        session, org_id=uuid.uuid4(), subscription_id=uuid.uuid4(),
+        period_start=None, period_end=None,
+    )
+
+    assert amount == 0
+    session.execute.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_compute_pack_charge_minor_sums_ledger_entries_in_period():
+    from app.services.billing_charge_amount import compute_pack_charge_minor
+
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_exec_result(15_000))
+    now = datetime(2026, 8, 15, tzinfo=timezone.utc)
+
+    amount = await compute_pack_charge_minor(
+        session, org_id=uuid.uuid4(), subscription_id=uuid.uuid4(),
+        period_start=now - timedelta(days=30), period_end=now,
+    )
+
+    assert amount == 15_000
+    session.execute.assert_awaited_once()
+
+
+# ─── compute_charge_amount ───────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_compute_charge_amount_base_only_no_overage_no_packs():
+    from app.services.billing_charge_amount import compute_charge_amount
+
+    org_id = uuid.uuid4()
+    sub = _subscription(billing_cycle="monthly")
+    offering = _offering(monthly=59_000, included_seats=5, extra_seat_price_minor=11_000)
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_exec_result(sub), _exec_result(5)])
+    session.get = AsyncMock(return_value=offering)
+
+    amount, currency = await compute_charge_amount(session, org_id=org_id)
+
+    assert amount == 59_000
+    assert currency == "krw"
+
+
+@pytest.mark.anyio
+async def test_compute_charge_amount_uses_annual_price_for_annual_cycle():
+    from app.services.billing_charge_amount import compute_charge_amount
+
+    org_id = uuid.uuid4()
+    sub = _subscription(billing_cycle="annual")
+    offering = _offering(monthly=59_000, annual=590_000, included_seats=5, extra_seat_price_minor=11_000)
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_exec_result(sub), _exec_result(5)])
+    session.get = AsyncMock(return_value=offering)
+
+    amount, _ = await compute_charge_amount(session, org_id=org_id)
+
+    assert amount == 590_000
+
+
+@pytest.mark.anyio
+async def test_compute_charge_amount_adds_seat_overage_at_extra_seat_price():
+    from app.services.billing_charge_amount import compute_charge_amount
+
+    org_id = uuid.uuid4()
+    sub = _subscription(billing_cycle="monthly")
+    offering = _offering(tier="team", monthly=59_000, included_seats=5, extra_seat_price_minor=11_000)
+
+    session = AsyncMock()
+    # 5 included, 7 실좌석 → 2석 초과 * 11,000
+    session.execute = AsyncMock(side_effect=[_exec_result(sub), _exec_result(7)])
+    session.get = AsyncMock(return_value=offering)
+
+    amount, _ = await compute_charge_amount(session, org_id=org_id)
+
+    assert amount == 59_000 + 2 * 11_000
+
+
+@pytest.mark.anyio
+async def test_compute_charge_amount_business_tier_uses_its_own_extra_seat_price():
+    from app.services.billing_charge_amount import compute_charge_amount
+
+    org_id = uuid.uuid4()
+    sub = _subscription(billing_cycle="monthly")
+    offering = _offering(tier="business", monthly=219_000, included_seats=15, extra_seat_price_minor=9_900)
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_exec_result(sub), _exec_result(16)])
+    session.get = AsyncMock(return_value=offering)
+
+    amount, _ = await compute_charge_amount(session, org_id=org_id)
+
+    assert amount == 219_000 + 1 * 9_900
+
+
+@pytest.mark.anyio
+async def test_compute_charge_amount_raises_when_starter_seat_overage_has_no_extra_seat_price():
+    """Starter는 추가좌석을 팔지 않는다(정책) — 초과 상태는 상위 티어 전환 후에만 유효,
+    이 계산기가 만나면 안 되는 불변식 위반이라 조용히 0으로 넘기지 않고 명시적으로 실패."""
+    from app.services.billing_charge_amount import ChargeAmountError, compute_charge_amount
+
+    org_id = uuid.uuid4()
+    sub = _subscription(billing_cycle="monthly")
+    offering = _offering(tier="starter", monthly=29_000, included_seats=3, extra_seat_price_minor=None)
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_exec_result(sub), _exec_result(4)])
+    session.get = AsyncMock(return_value=offering)
+
+    with pytest.raises(ChargeAmountError, match="starter"):
+        await compute_charge_amount(session, org_id=org_id)
+
+
+@pytest.mark.anyio
+async def test_compute_charge_amount_includes_pack_charge_when_period_bounds_set():
+    from app.services.billing_charge_amount import compute_charge_amount
+
+    org_id = uuid.uuid4()
+    now = datetime(2026, 8, 15, tzinfo=timezone.utc)
+    sub = _subscription(
+        billing_cycle="monthly",
+        period_start=now - timedelta(days=10), period_end=now,
+    )
+    offering = _offering(monthly=59_000, included_seats=5, extra_seat_price_minor=11_000)
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_exec_result(sub), _exec_result(5), _exec_result(7_000)])
+    session.get = AsyncMock(return_value=offering)
+
+    amount, _ = await compute_charge_amount(session, org_id=org_id)
+
+    assert amount == 59_000 + 7_000
+    assert session.execute.await_count == 3
+
+
+@pytest.mark.anyio
+async def test_compute_charge_amount_pack_charge_zero_without_period_bounds():
+    """current_period_start/end 미세팅(#2502 갭 — Toss 신규전환 진입점 아직 없음)이면 팩분
+    집계 자체를 건너뛴다(추가 execute 호출 없음)."""
+    from app.services.billing_charge_amount import compute_charge_amount
+
+    org_id = uuid.uuid4()
+    sub = _subscription(billing_cycle="monthly", period_start=None, period_end=None)
+    offering = _offering(monthly=59_000, included_seats=5, extra_seat_price_minor=11_000)
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_exec_result(sub), _exec_result(5)])
+    session.get = AsyncMock(return_value=offering)
+
+    amount, _ = await compute_charge_amount(session, org_id=org_id)
+
+    assert amount == 59_000
+    assert session.execute.await_count == 2
+
+
+@pytest.mark.anyio
+async def test_compute_charge_amount_raises_when_no_subscription_row():
+    from app.services.billing_charge_amount import ChargeAmountError, compute_charge_amount
+
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_exec_result(None))
+
+    with pytest.raises(ChargeAmountError, match="no org_subscription"):
+        await compute_charge_amount(session, org_id=uuid.uuid4())
+
+
+@pytest.mark.anyio
+async def test_compute_charge_amount_raises_when_offering_version_id_is_none():
+    from app.services.billing_charge_amount import ChargeAmountError, compute_charge_amount
+
+    sub = _subscription()
+    sub.offering_version_id = None
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_exec_result(sub))
+
+    with pytest.raises(ChargeAmountError, match="offering_version_id"):
+        await compute_charge_amount(session, org_id=uuid.uuid4())
+
+
+@pytest.mark.anyio
+async def test_compute_charge_amount_raises_when_offering_version_dangling():
+    """offering_version_id는 있는데 FK 대상 행이 없는(비정상) 상태 — 조용히 넘기지 않는다."""
+    from app.services.billing_charge_amount import ChargeAmountError, compute_charge_amount
+
+    sub = _subscription()
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_exec_result(sub))
+    session.get = AsyncMock(return_value=None)
+
+    with pytest.raises(ChargeAmountError, match="찾을 수 없음"):
+        await compute_charge_amount(session, org_id=uuid.uuid4())

--- a/backend/tests/test_e_2500_charge_amount_realdb.py
+++ b/backend/tests/test_e_2500_charge_amount_realdb.py
@@ -1,0 +1,152 @@
+"""#2500 real-DB — compute_charge_amount이 실제 seed된 offering_versions(krw_v1) +
+org_members + org_subscriptions 위에서 정확히 도는지 증명.
+
+DB env(ALEMBIC_DATABASE_URL) 없으면 skip — 로컬 PG(alembic upgrade head 적용된 DB) 전제."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _seed_org(session, *, tier: str, billing_cycle: str, human_seats: int):
+    org_id = uuid.uuid4()
+    offering_id = (
+        await session.execute(
+            text("SELECT id FROM offering_versions WHERE tier=:t AND version_label='krw_v1'"),
+            {"t": tier},
+        )
+    ).scalar_one()
+    sub_id = uuid.uuid4()
+    await session.execute(
+        text(
+            "INSERT INTO org_subscriptions (id, org_id, tier, billing_cycle, status, currency, "
+            "provider, offering_version_id) VALUES "
+            "(:id, :org_id, :tier, :cycle, 'active', 'krw', 'toss', :offering_id)"
+        ),
+        {"id": sub_id, "org_id": org_id, "tier": tier, "cycle": billing_cycle, "offering_id": offering_id},
+    )
+    for _ in range(human_seats):
+        await session.execute(
+            text(
+                "INSERT INTO org_members (id, org_id, user_id, role) "
+                "VALUES (:id, :org_id, :user_id, 'member')"
+            ),
+            {"id": uuid.uuid4(), "org_id": org_id, "user_id": uuid.uuid4()},
+        )
+    await session.commit()
+    return org_id
+
+
+@pytest.mark.anyio
+async def test_team_tier_no_overage_realdb():
+    from app.services.billing_charge_amount import compute_charge_amount
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session, tier="team", billing_cycle="monthly", human_seats=5)
+            amount, currency = await compute_charge_amount(session, org_id=org_id)
+            assert amount == 59_000
+            assert currency == "krw"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_team_tier_seat_overage_realdb():
+    from app.services.billing_charge_amount import compute_charge_amount
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            # included_seats=5, 7명 실좌석 → 2석 초과 * 11,000
+            org_id = await _seed_org(session, tier="team", billing_cycle="monthly", human_seats=7)
+            amount, currency = await compute_charge_amount(session, org_id=org_id)
+            assert amount == 59_000 + 2 * 11_000
+            assert currency == "krw"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_business_tier_annual_cycle_realdb():
+    from app.services.billing_charge_amount import compute_charge_amount
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session, tier="business", billing_cycle="annual", human_seats=15)
+            amount, currency = await compute_charge_amount(session, org_id=org_id)
+            assert amount == 2_190_000
+            assert currency == "krw"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_starter_seat_overage_raises_realdb():
+    from app.services.billing_charge_amount import ChargeAmountError, compute_charge_amount
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session, tier="starter", billing_cycle="monthly", human_seats=4)
+            with pytest.raises(ChargeAmountError, match="starter"):
+                await compute_charge_amount(session, org_id=org_id)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_pack_purchase_ledger_entries_included_when_period_set_realdb():
+    from app.services.billing_ledger import record_ledger_entry
+    from app.services.billing_charge_amount import compute_charge_amount
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session, tier="team", billing_cycle="monthly", human_seats=5)
+            sub_id = (
+                await session.execute(
+                    text("SELECT id FROM org_subscriptions WHERE org_id=:oid"), {"oid": org_id}
+                )
+            ).scalar_one()
+            await session.execute(
+                text(
+                    "UPDATE org_subscriptions SET current_period_start = now() - interval '10 days', "
+                    "current_period_end = now() + interval '20 days' WHERE org_id=:oid"
+                ),
+                {"oid": org_id},
+            )
+            await session.commit()
+            await record_ledger_entry(
+                session, org_id=org_id, entry_type="pack_purchase", amount_minor=7_000,
+                currency="krw", direction="debit", subscription_id=sub_id,
+                provider_ref=f"pack-{uuid.uuid4()}",
+            )
+
+            amount, _ = await compute_charge_amount(session, org_id=org_id)
+            assert amount == 59_000 + 7_000
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- `compute_charge_amount(session, org_id)` — C3(#2494) `trigger_due_charges`가 C2(#2493) `charge_org`에 넘길 amount 소스. C2/C3와 동형("메커니즘만") — "누가 오늘 청구대상인지" 판정은 범위 밖(#2502).
- 좌석 = **사람(human) 좌석**만(`org_members` 카운트 — `get_impact`/`check_member_invite_limit`과 동일 쿼리 재사용, 새 카운팅 개념 발명 안 함). 에이전트는 별개 축(feature-gate)이라 제외 — PO 정정(2026-08-07)·`pricing-policy-v2-3` 문서 확定.
- 팩분은 `billing_ledger_entries(entry_type='pack_purchase')` 기간집계. `current_period_start/end` 없으면(Toss 신규전환 진입점 부재, #2502 갭) 0.
- 숫자는 `offering_version`에서 읽음 — 하드코딩 0(선생님 04:09Z 요건).
- Starter+좌석초과처럼 정책상 있으면 안 되는 상태는 `ChargeAmountError`로 명시 실패(잘못된 금액으로 조용히 진행 안 함).

## 그라운딩에서 발견한 갭 (스코프 밖으로 명시 분리)
- **팩 구매 트리거** 자체(원장에 pack_purchase를 기입하는 엔드포인트)가 코드 어디에도 없음(전수 grep 0건) → story #2505로 별도 추적.
- **#2502(구독주기)**: 그라운딩 중 "org가 Toss 구독을 시작하는 백엔드 체크아웃 엔드포인트" 자체가 없다는 것도 확인 — PO가 선생님 steer 받아 별도 확定 예정, 이 PR과 무관.

## Test plan
- [x] 13 unit tests(mock) — `tests/test_e_2500_charge_amount.py`
- [x] 5 real-DB tests — `tests/test_e_2500_charge_amount_realdb.py`(로컬 실PG, seed된 krw_v1 offering_versions 위에서 team/business/starter 시나리오 + pack 기간집계 검증)
- [x] 기존 C1/C2/C3/A1/A2 배터리 재실행 — 회귀 0
- [x] 3 lint 가드 그린 + `app.main` import OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)