### PR TITLE
chore: env-drift allowlist에 결제② Toss/암호화키 4개 등재

### DIFF
--- a/infra/manual-env-allowlist.yml
+++ b/infra/manual-env-allowlist.yml
@@ -167,9 +167,28 @@ services:
           "값 자체가 무의미·재시작 트리거용 더미"로 추정(키 이름상) — 값 비교 자체가 무의미해
           skip. 존재 여부만 추적.
         owner: TBD
+      - key: ORG_BILLING_KEY_ENCRYPTION_KEY
+        reason: >-
+          결제②-C1(#2492) MultiFernet 암호화 키 — org_billing_keys.encrypted_billing_key
+          봉인용(billing_key_crypto.py). Secret Manager 등록·Cloud Run env 배선 PO 수동
+          프로비저닝(2026-08-06, C1 착수 GO 메시지) — 부트스트랩 스크립트 미편입.
+        owner: TBD
       - key: STORAGE_PROVIDER
         value_check: skip
         reason: 스토리지 프로바이더 선택 플래그 — 수동 토글.
+        owner: TBD
+      - key: TOSS_PAYMENTS_CLIENT_KEY
+        reason: >-
+          결제②-C0(#2491) Toss Payments 클라이언트 키 — state/shared/credentials/
+          toss-payments-keys.md(dev=test_ck)에 이미 발급돼 있던 값. app/core/config.py
+          Settings.toss_payments_client_key로 읽음. Secret Manager 등록 PO 수동
+          프로비저닝(2026-08-06) — 부트스트랩 스크립트 미편입.
+        owner: TBD
+      - key: TOSS_PAYMENTS_CRYPTO_KEY
+        reason: dev와 동일 사유(TOSS_PAYMENTS_CLIENT_KEY 참고) — test_crypto 값, Settings.toss_payments_crypto_key.
+        owner: TBD
+      - key: TOSS_PAYMENTS_SECRET_KEY
+        reason: dev와 동일 사유(TOSS_PAYMENTS_CLIENT_KEY 참고) — test_sk 값, Settings.toss_payments_secret_key.
         owner: TBD
 
   sprintable-backend-prod:


### PR DESCRIPTION
## Summary
- 결제②-C0(#2491)·C1(#2492)에서 PO가 Cloud Run env에 수동 바인딩한 `TOSS_PAYMENTS_SECRET_KEY`/`CLIENT_KEY`/`CRYPTO_KEY`·`ORG_BILLING_KEY_ENCRYPTION_KEY`가 `infra/manual-env-allowlist.yml`에 미등재 상태였음 — `env-drift-guard`(daily 워크플로우)가 다음 스케줄 실행에서 `sprintable-backend-dev`를 ①키집합 축 FAIL로 잡을 상태였음.
- 4개 키를 `sprintable-backend-dev` 블록에 알파벳 순 등재. `TOSS_MERCHANT_ID`는 비민감이라 애초 env로 안 올라가 있어(gcloud describe 실측) 등재 불필요. prod는 이 4개 키 자체가 아직 안 올라가 있어(Toss dev-only 진행 중) 등재 불필요.

## Test plan
- [x] `gcloud run services describe sprintable-backend-dev` 라이브 실측으로 정확한 env var 이름 확인(추측 아님)
- [x] positive control — 등재 전 `python3 infra/check_env_drift.py --only-env dev` 가 정확히 이 4개 키를 ①키집합 FAIL로 잡음(exit=1) 확인 후 등재 → 재실행 exit=0으로 사라짐 확인
- [x] prod도 동일 스크립트로 실측 — 4개 키 모두 라이브에 없음(등재 불필요 판단의 근거)
- [x] YAML 파싱 정상 + `test_check_env_drift_*` 5개 파일 66건 전부 pass, 회귀 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)