### PR TITLE
fix(#2509): 결제② C단계 카디르 결함사냥 3건 — dunning 클로버·billing_cycle 10배저청구·통화 불일치

### DIFF
--- a/backend/app/services/billing_charge_amount.py
+++ b/backend/app/services/billing_charge_amount.py
@@ -86,6 +86,15 @@ async def compute_charge_amount(session: AsyncSession, *, org_id: uuid.UUID) -> 
     if offering is None:
         raise ChargeAmountError(f"offering_version {sub.offering_version_id}를 찾을 수 없음")
 
+    # 카디르 결함사냥(#2509, 2026-08-07) — org_subscriptions.billing_cycle에 DB CHECK가
+    # 없어(Text nullable) NULL·'Annual'·'yearly'·오타가 조용히 monthly로 폴백해 annual
+    # 구독을 10배 저청구할 수 있었다. "annual 아니면 monthly=안전한 기본값"이라는 판단
+    # 자체가 틀렸다 — 불명확한 값은 명시 실패로.
+    if sub.billing_cycle not in ("monthly", "annual"):
+        raise ChargeAmountError(
+            f"org_subscription(org_id={org_id}).billing_cycle={sub.billing_cycle!r}이 "
+            "'monthly'/'annual' 둘 다 아님 — monthly로 조용히 폴백하지 않는다"
+        )
     base_amount = (
         offering.annual_price_minor if sub.billing_cycle == "annual" else offering.monthly_price_minor
     )
@@ -110,5 +119,14 @@ async def compute_charge_amount(session: AsyncSession, *, org_id: uuid.UUID) -> 
         period_start=sub.current_period_start,
         period_end=sub.current_period_end,
     )
+
+    # 카디르 결함사냥(#2509) — offering.currency와 sub.currency 사이엔 FK만 있고 값 일치
+    # 제약이 없다(구조적 갭). 반환 직전 대조해 불일치를 명시 실패로 잡는다(예: USD
+    # offering이 KRW sub에 잘못 바인딩된 상태로 조용히 금액만 나가는 것 방지).
+    if offering.currency != sub.currency:
+        raise ChargeAmountError(
+            f"offering_version.currency={offering.currency!r} != "
+            f"org_subscription.currency={sub.currency!r} for org_id={org_id}"
+        )
 
     return base_amount + seat_amount + pack_amount, offering.currency

--- a/backend/app/services/billing_scheduler.py
+++ b/backend/app/services/billing_scheduler.py
@@ -28,6 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.billing_order import BillingOrder
 from app.models.offering_version import OfferingVersion
+from app.models.org_billing_key import OrgBillingKey
 from app.models.org_subscription import OrgSubscription
 from app.services.billing_charge import (
     _confirm_with_ledger,
@@ -75,29 +76,70 @@ async def downgrade_to_free(session: AsyncSession, org_id: uuid.UUID, order_id: 
     (age≫8)를 보고 org를 다시 free로 upsert해 **새 유료 구독을 clobber**한다. order를
     종결 상태 'downgraded'로 전이시켜(status!='confirmed' 가드) failed-스윕 대상에서
     영구히 뺀다 — 'failed' 그대로 두거나 'confirmed'를 재사용하지 않는 이유는 이게 실제
-    Toss 승인이 아니라 강제 강등이라 원장 의미가 다르기 때문(0232 마이그로 CHECK 확장)."""
-    free_offering = (
-        await session.execute(
-            select(OfferingVersion).where(
-                OfferingVersion.tier == "free",
-                OfferingVersion.currency == "krw",
-                OfferingVersion.effective_to.is_(None),
-            )
-        )
-    ).scalar_one_or_none()
+    Toss 승인이 아니라 강제 강등이라 원장 의미가 다르기 때문(0232 마이그로 CHECK 확장).
 
-    stmt = pg_insert(OrgSubscription).values(
-        id=uuid.uuid4(), org_id=org_id, tier="free", status="active",
-        provider="toss", currency="krw", billing_cycle=None,
-        offering_version_id=free_offering.id if free_offering else None,
-    ).on_conflict_do_update(
-        index_elements=["org_id"],
-        set_={
-            "tier": "free", "status": "active",
-            "offering_version_id": free_offering.id if free_offering else None,
-        },
-    )
-    await session.execute(stmt)
+    카디르 결함사냥(#2509, 2026-08-07) — "다른-order 재구독 클로버": 이 함수가 org의
+    현재 상태를 안 보고 무조건 free upsert했다. cron이 여러 org를 Toss 콜 포함해 순회하는
+    동안(창이 실재) org가 다른 order_id로 재구독(pro)을 성공시키면, 뒤늦게 처리되는 이
+    stale order가 방금 성립한 pro 구독을 free로 덮어썼다. 재확認: 이 stale order보다
+    "나중에" confirmed된 order가 있거나, 이 stale order 생성 이후 새로 발급된 활성
+    billing_key가 있으면(재인증 진행 중 — 아직 charge는 안 끝났을 수 있는 그 race
+    윈도) 이미 다른 경로로 회복 중/완료된 것이니 free upsert를 건너뛴다.
+    ⚠️"활성 billing_key 존재" 자체는 쓰지 않는다 — dunning 재시도(+1/+3/+5일)는 원래
+    billing_key로 하므로 실패 시퀀스 내내 키가 active인 게 정상이라, 그것만으로 걸면
+    진짜 8일 지난 미해결 delinquent도 영원히 강등 안 되는 회귀가 난다. 반드시 order.
+    created_at *이후* 시점(newer)으로 앵커링된 신호만 "회복 증거"로 인정한다."""
+    order = (
+        await session.execute(select(BillingOrder).where(BillingOrder.order_id == order_id))
+    ).scalar_one_or_none()
+    if order is None:
+        return  # 이미 존재 안 함(동시 처리 등) — 할 일 없음.
+
+    has_newer_confirmed_order = (
+        await session.execute(
+            select(BillingOrder.id).where(
+                BillingOrder.org_id == org_id,
+                BillingOrder.status == "confirmed",
+                BillingOrder.created_at > order.created_at,
+            ).limit(1)
+        )
+    ).first() is not None
+    has_newly_issued_billing_key = (
+        await session.execute(
+            select(OrgBillingKey.id).where(
+                OrgBillingKey.org_id == org_id,
+                OrgBillingKey.status == "active",
+                OrgBillingKey.issued_at > order.created_at,
+            ).limit(1)
+        )
+    ).first() is not None
+
+    if not (has_newer_confirmed_order or has_newly_issued_billing_key):
+        free_offering = (
+            await session.execute(
+                select(OfferingVersion).where(
+                    OfferingVersion.tier == "free",
+                    OfferingVersion.currency == "krw",
+                    OfferingVersion.effective_to.is_(None),
+                )
+            )
+        ).scalar_one_or_none()
+
+        stmt = pg_insert(OrgSubscription).values(
+            id=uuid.uuid4(), org_id=org_id, tier="free", status="active",
+            provider="toss", currency="krw", billing_cycle=None,
+            offering_version_id=free_offering.id if free_offering else None,
+        ).on_conflict_do_update(
+            index_elements=["org_id"],
+            set_={
+                "tier": "free", "status": "active",
+                "offering_version_id": free_offering.id if free_offering else None,
+            },
+        )
+        await session.execute(stmt)
+
+    # 회복 증거가 있어 free upsert는 건너뛰었어도, 이 stale order 자체는 여전히 닫는다
+    # (재처리 방지 목적은 그대로 달성 — 매 스윕마다 같은 order가 다시 안 골라지게).
     await session.execute(
         update(BillingOrder)
         .where(BillingOrder.order_id == order_id, BillingOrder.status != "confirmed")

--- a/backend/tests/test_e_2494_c3_scheduler.py
+++ b/backend/tests/test_e_2494_c3_scheduler.py
@@ -56,6 +56,29 @@ def test_next_dunning_action_same_day_retry_not_repeated():
 
 
 # ─── downgrade_to_free ──────────────────────────────────────────────────────
+# 호출 순서(#2509 가드 fix 後): ①order 조회 ②newer-confirmed-order 체크 ③newer-billing-key
+# 체크 ④(회복증거 없을 때만)offering 조회 ⑤(동일)upsert ⑥order 종결 UPDATE.
+
+def _stale_order_row(created_at):
+    o = MagicMock()
+    o.created_at = created_at
+    return o
+
+
+def _no_recovery_evidence_side_effects(order_created_at, free_offering):
+    """회복 증거(더 나중 confirmed order·더 나중 발급 billing_key) 둘 다 없는 표준 경로."""
+    order_result = MagicMock()
+    order_result.scalar_one_or_none.return_value = _stale_order_row(order_created_at)
+    confirmed_check = MagicMock()
+    confirmed_check.first.return_value = None
+    key_check = MagicMock()
+    key_check.first.return_value = None
+    offering_result = MagicMock()
+    offering_result.scalar_one_or_none.return_value = free_offering
+    upsert_result = MagicMock()
+    close_order_result = MagicMock()
+    return [order_result, confirmed_check, key_check, offering_result, upsert_result, close_order_result]
+
 
 @pytest.mark.anyio
 async def test_downgrade_to_free_upserts_free_tier(monkeypatch):
@@ -63,20 +86,19 @@ async def test_downgrade_to_free_upserts_free_tier(monkeypatch):
 
     org_id = uuid.uuid4()
     order_id = "ord-downgrade-1"
+    now = datetime(2026, 8, 15, tzinfo=timezone.utc)
     free_offering = MagicMock()
     free_offering.id = uuid.uuid4()
 
     session = AsyncMock()
-    offering_result = MagicMock()
-    offering_result.scalar_one_or_none.return_value = free_offering
-    upsert_result = MagicMock()
-    close_order_result = MagicMock()
-    session.execute = AsyncMock(side_effect=[offering_result, upsert_result, close_order_result])
+    session.execute = AsyncMock(
+        side_effect=_no_recovery_evidence_side_effects(now - timedelta(days=9), free_offering)
+    )
     session.commit = AsyncMock()
 
     await downgrade_to_free(session, org_id, order_id)
 
-    upsert_call = session.execute.call_args_list[1]
+    upsert_call = session.execute.call_args_list[4]
     compiled = upsert_call.args[0].compile().params
     assert compiled["org_id"] == org_id
     assert compiled["tier"] == "free"
@@ -89,15 +111,16 @@ async def test_downgrade_to_free_handles_missing_offering_gracefully(monkeypatch
     """free offering_version 시드가 없어도(방어) crash하지 않고 offering_version_id=None으로 진행."""
     from app.services.billing_scheduler import downgrade_to_free
 
+    now = datetime(2026, 8, 15, tzinfo=timezone.utc)
     session = AsyncMock()
-    offering_result = MagicMock()
-    offering_result.scalar_one_or_none.return_value = None
-    session.execute = AsyncMock(side_effect=[offering_result, MagicMock(), MagicMock()])
+    session.execute = AsyncMock(
+        side_effect=_no_recovery_evidence_side_effects(now - timedelta(days=9), None)
+    )
     session.commit = AsyncMock()
 
     await downgrade_to_free(session, uuid.uuid4(), "ord-downgrade-2")
 
-    upsert_call = session.execute.call_args_list[1]
+    upsert_call = session.execute.call_args_list[4]
     compiled = upsert_call.args[0].compile().params
     assert compiled["offering_version_id"] is None
 
@@ -112,18 +135,95 @@ async def test_downgrade_to_free_closes_the_order_po_blocker_fix(monkeypatch):
 
     org_id = uuid.uuid4()
     order_id = "ord-downgrade-3"
+    now = datetime(2026, 8, 15, tzinfo=timezone.utc)
     session = AsyncMock()
-    offering_result = MagicMock()
-    offering_result.scalar_one_or_none.return_value = None
-    session.execute = AsyncMock(side_effect=[offering_result, MagicMock(), MagicMock()])
+    session.execute = AsyncMock(
+        side_effect=_no_recovery_evidence_side_effects(now - timedelta(days=9), None)
+    )
     session.commit = AsyncMock()
 
     await downgrade_to_free(session, org_id, order_id)
 
-    # 3번째 호출이 billing_orders를 'downgraded'로 닫는 UPDATE여야.
-    close_call = session.execute.call_args_list[2]
+    # 마지막(6번째) 호출이 billing_orders를 'downgraded'로 닫는 UPDATE여야.
+    close_call = session.execute.call_args_list[5]
     compiled = close_call.args[0].compile().params
     assert compiled["status"] == "downgraded"
+
+
+@pytest.mark.anyio
+async def test_downgrade_to_free_skips_upsert_when_newer_confirmed_order_exists_po_2509_fix():
+    """카디르 결함사냥(#2509①) 회귀 고정 — "다른-order 재구독 클로버": 이 stale order보다
+    나중에 confirmed된 order가 있으면(=이미 다른 경로로 재구독 성공) free upsert를
+    건너뛴다. 재처리 방지 목적은 그대로 유지(order는 여전히 닫음)."""
+    from app.services.billing_scheduler import downgrade_to_free
+
+    org_id = uuid.uuid4()
+    order_id = "ord-stale-1"
+    now = datetime(2026, 8, 15, tzinfo=timezone.utc)
+
+    order_result = MagicMock()
+    order_result.scalar_one_or_none.return_value = _stale_order_row(now - timedelta(days=9))
+    confirmed_check = MagicMock()
+    confirmed_check.first.return_value = (uuid.uuid4(),)  # 더 나중 confirmed order 존재
+    key_check = MagicMock()
+    key_check.first.return_value = None
+    close_order_result = MagicMock()
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[order_result, confirmed_check, key_check, close_order_result])
+    session.commit = AsyncMock()
+
+    await downgrade_to_free(session, org_id, order_id)
+
+    # execute가 4번만 불렸다 = offering 조회·upsert가 스킵됐다(회복 증거로 free upsert 건너뜀).
+    assert session.execute.await_count == 4
+    close_call = session.execute.call_args_list[3]
+    assert close_call.args[0].compile().params["status"] == "downgraded"
+
+
+@pytest.mark.anyio
+async def test_downgrade_to_free_skips_upsert_when_newly_issued_billing_key_exists():
+    """order 생성 이후 새로 발급된 활성 billing_key가 있으면(재인증 진행 중 race
+    윈도) 마찬가지로 free upsert를 건너뛴다."""
+    from app.services.billing_scheduler import downgrade_to_free
+
+    org_id = uuid.uuid4()
+    order_id = "ord-stale-2"
+    now = datetime(2026, 8, 15, tzinfo=timezone.utc)
+
+    order_result = MagicMock()
+    order_result.scalar_one_or_none.return_value = _stale_order_row(now - timedelta(days=9))
+    confirmed_check = MagicMock()
+    confirmed_check.first.return_value = None
+    key_check = MagicMock()
+    key_check.first.return_value = (uuid.uuid4(),)  # 더 나중 발급된 활성 billing_key 존재
+    close_order_result = MagicMock()
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[order_result, confirmed_check, key_check, close_order_result])
+    session.commit = AsyncMock()
+
+    await downgrade_to_free(session, org_id, order_id)
+
+    assert session.execute.await_count == 4
+
+
+@pytest.mark.anyio
+async def test_downgrade_to_free_returns_early_when_order_missing():
+    """order가 이미 존재하지 않으면(동시처리 등) 아무 것도 안 하고 조용히 리턴 —
+    org_subscriptions를 건드리지 않는다."""
+    from app.services.billing_scheduler import downgrade_to_free
+
+    order_result = MagicMock()
+    order_result.scalar_one_or_none.return_value = None
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=order_result)
+    session.commit = AsyncMock()
+
+    await downgrade_to_free(session, uuid.uuid4(), "ord-gone")
+
+    assert session.execute.await_count == 1
+    session.commit.assert_not_awaited()
 
 
 # ─── sweep_dunning_retries ──────────────────────────────────────────────────

--- a/backend/tests/test_e_2500_charge_amount.py
+++ b/backend/tests/test_e_2500_charge_amount.py
@@ -10,11 +10,15 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 
-def _subscription(*, billing_cycle="monthly", offering_version_id=None, period_start=None, period_end=None):
+def _subscription(
+    *, billing_cycle="monthly", currency="krw", offering_version_id=None,
+    period_start=None, period_end=None,
+):
     sub = MagicMock()
     sub.id = uuid.uuid4()
     sub.org_id = uuid.uuid4()
     sub.billing_cycle = billing_cycle
+    sub.currency = currency
     sub.offering_version_id = offering_version_id or uuid.uuid4()
     sub.current_period_start = period_start
     sub.current_period_end = period_end
@@ -263,3 +267,40 @@ async def test_compute_charge_amount_raises_when_offering_version_dangling():
 
     with pytest.raises(ChargeAmountError, match="찾을 수 없음"):
         await compute_charge_amount(session, org_id=uuid.uuid4())
+
+
+# ─── #2509 카디르 결함사냥 — billing_cycle 비검증·currency 불일치 ───────────────
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("bogus_cycle", [None, "Annual", "yearly", "", "MONTHLY"])
+async def test_compute_charge_amount_raises_on_non_monthly_annual_billing_cycle(bogus_cycle):
+    """조용히 monthly로 폴백해 annual 구독을 10배 저청구하던 결함(#2509①) — 명시 실패로."""
+    from app.services.billing_charge_amount import ChargeAmountError, compute_charge_amount
+
+    org_id = uuid.uuid4()
+    sub = _subscription(billing_cycle=bogus_cycle)
+    offering = _offering()
+
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_exec_result(sub))
+    session.get = AsyncMock(return_value=offering)
+
+    with pytest.raises(ChargeAmountError, match="billing_cycle"):
+        await compute_charge_amount(session, org_id=org_id)
+
+
+@pytest.mark.anyio
+async def test_compute_charge_amount_raises_when_offering_currency_mismatches_subscription():
+    """offering.currency와 sub.currency 사이 값 일치 제약이 없던 구조적 갭(#2509②)."""
+    from app.services.billing_charge_amount import ChargeAmountError, compute_charge_amount
+
+    org_id = uuid.uuid4()
+    sub = _subscription(billing_cycle="monthly", currency="usd")
+    offering = _offering(currency="krw", included_seats=5, extra_seat_price_minor=11_000)
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_exec_result(sub), _exec_result(5)])
+    session.get = AsyncMock(return_value=offering)
+
+    with pytest.raises(ChargeAmountError, match="currency"):
+        await compute_charge_amount(session, org_id=org_id)

--- a/backend/tests/test_e_2500_charge_amount_realdb.py
+++ b/backend/tests/test_e_2500_charge_amount_realdb.py
@@ -150,3 +150,81 @@ async def test_pack_purchase_ledger_entries_included_when_period_set_realdb():
             assert amount == 59_000 + 7_000
     finally:
         await engine.dispose()
+
+
+# ─── #2509 카디르 결함사냥 — billing_cycle 비검증·currency 불일치(실PG) ─────────
+
+@pytest.mark.anyio
+async def test_null_billing_cycle_raises_instead_of_silent_monthly_realdb():
+    """실측(카디르, 2026-08-07): business annual 2,190,000 → billing_cycle이 NULL이면
+    조용히 monthly(219,000)로 10배 저청구되던 결함. 이제 명시 실패."""
+    from app.services.billing_charge_amount import ChargeAmountError, compute_charge_amount
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session, tier="business", billing_cycle="annual", human_seats=15)
+            await session.execute(
+                text("UPDATE org_subscriptions SET billing_cycle = NULL WHERE org_id=:oid"),
+                {"oid": org_id},
+            )
+            await session.commit()
+            with pytest.raises(ChargeAmountError, match="billing_cycle"):
+                await compute_charge_amount(session, org_id=org_id)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_typo_billing_cycle_raises_realdb():
+    from app.services.billing_charge_amount import ChargeAmountError, compute_charge_amount
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session, tier="business", billing_cycle="Annual", human_seats=15)
+            with pytest.raises(ChargeAmountError, match="billing_cycle"):
+                await compute_charge_amount(session, org_id=org_id)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_offering_currency_mismatch_raises_realdb():
+    """offering.currency ↔ sub.currency 사이 FK만 있고 값 일치 제약이 없던 구조적 갭 —
+    (provider→currency CHECK가 sub.currency 자체의 오염은 막아주지만, offering_version_id
+    가 다른 통화의 offering을 가리키는 «바인딩 실수»는 아무것도 막지 않는다. 그 실제
+    시나리오를 재현: krw/toss sub는 그대로 두고 offering_version_id만 usd offering으로
+    돌린다)."""
+    from app.services.billing_charge_amount import ChargeAmountError, compute_charge_amount
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session, tier="team", billing_cycle="monthly", human_seats=5)
+
+            usd_offering_id = uuid.uuid4()
+            await session.execute(
+                text(
+                    "INSERT INTO offering_versions (id, tier, currency, version_label, "
+                    "monthly_price_minor, annual_price_minor, included_seats, extra_seat_price_minor, "
+                    "au_limit, realtime_connection_limit, storage_mb_limit, max_file_mb, "
+                    "lab_credit_minor, rate_limit_per_min, automation_rule_limit, webhook_limit, "
+                    "event_replay_days, overage_allowed, effective_from, created_by) VALUES "
+                    "(:id, 'team', 'usd', 'usd_v1_test', 4900, 49000, 5, 1100, 100000, 10, 1000, "
+                    "100, 0, 60, 10, 10, 7, true, now(), 'test')"
+                ),
+                {"id": usd_offering_id},
+            )
+            await session.execute(
+                text("UPDATE org_subscriptions SET offering_version_id = :oid2 WHERE org_id=:oid"),
+                {"oid2": usd_offering_id, "oid": org_id},
+            )
+            await session.commit()
+            with pytest.raises(ChargeAmountError, match="currency"):
+                await compute_charge_amount(session, org_id=org_id)
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_e_2509_dunning_clobber_guard_realdb.py
+++ b/backend/tests/test_e_2509_dunning_clobber_guard_realdb.py
@@ -1,0 +1,163 @@
+"""#2509① real-DB — downgrade_to_free의 "다른-order 재구독 클로버" 결함 fix 실증.
+카디르 결함사냥(2026-08-07): stale failed order 스윕이 org의 현재 상태를 안 보고
+무조건 free upsert해, 다른 order로 이미 재구독(pro) 성공한 org를 덮어썼다.
+
+DB env(ALEMBIC_DATABASE_URL) 없으면 skip — 로컬 PG(alembic upgrade head 적용된 DB) 전제."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _seed_paid_org(session, *, tier="team"):
+    org_id = uuid.uuid4()
+    offering_id = (
+        await session.execute(
+            text("SELECT id FROM offering_versions WHERE tier=:t AND version_label='krw_v1'"),
+            {"t": tier},
+        )
+    ).scalar_one()
+    await session.execute(
+        text(
+            "INSERT INTO org_subscriptions (id, org_id, tier, billing_cycle, status, currency, "
+            "provider, offering_version_id) VALUES "
+            "(:id, :org_id, :tier, 'monthly', 'active', 'krw', 'toss', :offering_id)"
+        ),
+        {"id": uuid.uuid4(), "org_id": org_id, "tier": tier, "offering_id": offering_id},
+    )
+    await session.commit()
+    return org_id
+
+
+async def _seed_stale_failed_order(session, *, org_id, created_days_ago=9):
+    order_id = f"ord-stale-{uuid.uuid4()}"
+    created_at = datetime.now(timezone.utc) - timedelta(days=created_days_ago)
+    await session.execute(
+        text(
+            "INSERT INTO billing_orders (id, org_id, order_id, amount_minor, currency, status, "
+            "created_at, updated_at) VALUES "
+            "(:id, :org_id, :order_id, 59000, 'krw', 'failed', :created_at, :created_at)"
+        ),
+        {"id": uuid.uuid4(), "org_id": org_id, "order_id": order_id, "created_at": created_at},
+    )
+    await session.commit()
+    return order_id
+
+
+async def _get_tier(session, org_id):
+    return (
+        await session.execute(
+            text("SELECT tier FROM org_subscriptions WHERE org_id=:oid"), {"oid": org_id}
+        )
+    ).scalar_one()
+
+
+async def _get_order_status(session, order_id):
+    return (
+        await session.execute(
+            text("SELECT status FROM billing_orders WHERE order_id=:oid"), {"oid": order_id}
+        )
+    ).scalar_one()
+
+
+@pytest.mark.anyio
+async def test_stale_order_does_not_clobber_org_that_already_resubscribed_via_other_order():
+    """실측 — org가 stale order(order_A, 9일 전 failed)와 별개로 order_B(신규, confirmed)
+    로 이미 재구독 성공한 상태. downgrade_to_free(order_A)가 뒤늦게 돌아도 tier=pro가
+    유지돼야 한다(클로버 안 됨) — order_A는 여전히 닫혀야(재처리 방지)."""
+    from app.services.billing_scheduler import downgrade_to_free
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_paid_org(session, tier="team")
+            stale_order_id = await _seed_stale_failed_order(session, org_id=org_id, created_days_ago=9)
+
+            # order_A보다 "나중에" 생성된 confirmed order_B — 재구독 성공 증거.
+            newer_order_id = f"ord-newer-{uuid.uuid4()}"
+            await session.execute(
+                text(
+                    "INSERT INTO billing_orders (id, org_id, order_id, amount_minor, currency, "
+                    "status, payment_key, created_at, updated_at) VALUES "
+                    "(:id, :org_id, :order_id, 59000, 'krw', 'confirmed', :pk, now(), now())"
+                ),
+                {"id": uuid.uuid4(), "org_id": org_id, "order_id": newer_order_id, "pk": f"pay-{uuid.uuid4()}"},
+            )
+            await session.commit()
+
+            await downgrade_to_free(session, org_id, stale_order_id)
+
+            assert await _get_tier(session, org_id) == "team"  # clobber 안 됨
+            assert await _get_order_status(session, stale_order_id) == "downgraded"  # 그래도 닫힘
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_stale_order_downgrades_when_no_recovery_evidence_positive_control():
+    """양성대조 — 회복 증거(더 나중 confirmed order·더 나중 billing_key)가 전혀 없으면
+    가드가 정상적으로 free 강등을 수행해야 한다(가드가 과하게 걸려 정당한 다운그레이드를
+    막지 않는지 실증)."""
+    from app.services.billing_scheduler import downgrade_to_free
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_paid_org(session, tier="team")
+            stale_order_id = await _seed_stale_failed_order(session, org_id=org_id, created_days_ago=9)
+
+            await downgrade_to_free(session, org_id, stale_order_id)
+
+            assert await _get_tier(session, org_id) == "free"
+            assert await _get_order_status(session, stale_order_id) == "downgraded"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_stale_order_does_not_clobber_when_newly_issued_billing_key_exists():
+    """order_A보다 나중에 발급된 활성 billing_key가 있으면(재인증 진행 중 race 윈도)
+    마찬가지로 free 강등을 건너뛴다."""
+    from app.services.billing_scheduler import downgrade_to_free
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_paid_org(session, tier="team")
+            stale_order_id = await _seed_stale_failed_order(session, org_id=org_id, created_days_ago=9)
+
+            await session.execute(
+                text(
+                    "INSERT INTO org_billing_keys (id, org_id, customer_key, encrypted_billing_key, "
+                    "status, issued_at) VALUES (:id, :org_id, :ck, 'enc-placeholder', 'active', now())"
+                ),
+                {"id": uuid.uuid4(), "org_id": org_id, "ck": f"cust-{uuid.uuid4()}"},
+            )
+            await session.commit()
+
+            await downgrade_to_free(session, org_id, stale_order_id)
+
+            assert await _get_tier(session, org_id) == "team"
+            assert await _get_order_status(session, stale_order_id) == "downgraded"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
카디르 결함 사냥 재QA(디스포저블 PG 실측, 2026-08-07)에서 나온 결제② C단계 3건. 실배선 코드(cron `/toss-billing-maintenance`·청구 엔진)라 즉시 fix.

**① `downgrade_to_free` 다른-order 재구독 클로버 (#2884, MED-HIGH)**: stale failed order 스윕이 org 현재 상태를 안 보고 무조건 free upsert — cron이 여러 org를 Toss 콜 포함 순회하는 동안 org가 다른 order_id로 재구독(pro) 성공하면, 뒤늦은 스윕이 방금 성립한 pro를 free로 덮어썼다. fix: 이 stale order보다 "나중에" confirmed된 order가 있거나, 이 stale order 생성 이후 새로 발급된 활성 billing_key가 있으면 free upsert를 건너뛴다(order는 여전히 닫아 재처리 방지). ⚠️"활성 billing_key 존재" 자체는 판단축으로 안 씀 — dunning 재시도가 원래 키로 진행되므로 그것만 보면 진짜 delinquent도 영원히 강등 안 되는 회귀가 남.

**② `compute_charge_amount` billing_cycle 비검증 10배 저청구 (#2886, MED-HIGH)**: "annual 아니면 monthly"가 `org_subscriptions.billing_cycle`의 DB CHECK 부재(NULL·'Annual'·오타 통과)를 놓쳤다. fix: `billing_cycle not in ("monthly","annual")` → `ChargeAmountError`.

**③ `compute_charge_amount` offering↔subscription 통화 불일치 무검증 (#2886, MED·구조적)**: `offering.currency` ↔ `sub.currency` 사이 FK만 있고 값 일치 제약 없음. fix: 반환 직전 `offering.currency == sub.currency` assert.

## 실측 정정 (PR 본문에 남겨둠)
③ 재현 중 `org_subscriptions_provider_currency_fn` DB CHECK를 실제로 발견 — `sub.currency`를 직접 `usd`로 오염시키는 건 그 자체로 DB가 거부한다(provider=toss와 모순되는 조합 원천 차단). 그래서 재현 시나리오를 "offering_version_id를 usd offering으로 잘못 바인딩(currency/provider는 그대로 krw/toss)"으로 정정 — 이게 DB가 못 막는 진짜 갭.

## Test plan
- [x] 43 unit tests(mock, #2494/#2500 갱신+신규) — 클로버 가드 3종·billing_cycle 5종·currency 불일치
- [x] 11 real-DB tests(로컬 실PG) — 클로버 시나리오(양성대조 포함)·billing_cycle NULL/오타·currency 바인딩 불일치
- [x] 기존 C1~C4/B 배터리 125 passed, 3 lint 가드 그린, `app.main` import OK, 회귀 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)