### PR TITLE
[SID:2510] Toss 결제위젯 CSP 차단 fix — dev 라이브 실측 중 발견

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -6,13 +6,17 @@ const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
 const _CSP = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+  // story #2510 — Toss 결제위젯 SDK(js.tosspayments.com)가 script-src에 없으면 카드
+  // 인증창 자체가 CSP로 막힌다(라이브 실측 중 실물 확認 — 유닛테스트는 브라우저 CSP를
+  // 실행하지 않아 이 클래스를 못 잡는다).
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.tosspayments.com",
   "style-src 'self' 'unsafe-inline'",
   // GCS 파일, Google/GitHub 아바타 이미지
   "img-src 'self' data: blob: https://storage.googleapis.com https://*.googleusercontent.com https://avatars.githubusercontent.com",
   "font-src 'self' data:",
-  // API 호출 (self = Next.js rewrites 경유, googleapis = Cloud KMS/AI)
-  "connect-src 'self' https://*.googleapis.com",
+  // API 호출 (self = Next.js rewrites 경유, googleapis = Cloud KMS/AI, tosspayments = 결제
+  // 위젯 SDK 자체 통신 — story #2510)
+  "connect-src 'self' https://*.googleapis.com https://*.tosspayments.com",
   // story #2083 — 채팅 첨부 영상(GCS 서명 URL)이 <video>로 로드될 때 media-src에
   // storage.googleapis.com이 없어 CSP가 통째로 차단하고 있었다(콘솔 실측). img-src에는
   // 이미 같은 호스트가 허용돼 있다(story #2050, 서명 URL·노출 축 동일) — 새 origin을

--- a/apps/web/src/ee/components/billing/toss-checkout.test.ts
+++ b/apps/web/src/ee/components/billing/toss-checkout.test.ts
@@ -54,8 +54,11 @@ describe('startBillingAuth — 위젯 인증 시작(story #2510)', () => {
     await startBillingAuth({ tier: 'starter', cycle: 'yearly' });
 
     expect(requestBillingAuthMock).toHaveBeenCalledTimes(1);
-    const arg = requestBillingAuthMock.mock.calls[0]?.[0] as { method: string; successUrl: string; failUrl: string };
+    const arg = requestBillingAuthMock.mock.calls[0]?.[0] as { method: string; windowTarget: string; successUrl: string; failUrl: string };
     expect(arg.method).toBe('CARD');
+    // 라이브 실측(2026-08-07) — SDK 기본값(PC=iframe)이 CSP frame-src 'none'과 충돌해
+    // 실제로 막혔다. 'self' 고정으로 frame-src를 열지 않고 우회.
+    expect(arg.windowTarget).toBe('self');
     // billing_cycle API 값은 yearly(FE 내부 표기) -> annual(BE 계약, #2890)로 변환돼야 한다.
     expect(arg.successUrl).toBe(`${ORIGIN}/settings?tab=billing&tier=starter&cycle=annual&checkout=success`);
     expect(arg.failUrl).toBe(`${ORIGIN}/settings?tab=billing&tier=starter&cycle=annual&checkout=fail`);

--- a/apps/web/src/ee/components/billing/toss-checkout.ts
+++ b/apps/web/src/ee/components/billing/toss-checkout.ts
@@ -57,6 +57,10 @@ export async function startBillingAuth({ tier, cycle }: BillingCycleParam): Prom
 
   await payment.requestBillingAuth({
     method: 'CARD',
+    // windowTarget 명시 — SDK 기본값(PC=iframe)은 CSP frame-src 'none'과 충돌한다(라이브
+    // 실측 확認). 'self'로 고정해 데스크톱/모바일 모두 전체페이지 리다이렉트로 통일 —
+    // frame-src를 열지 않고도 동작(더 좁은 CSP 변경, script-src/connect-src만 확장).
+    windowTarget: 'self',
     successUrl: `${origin}/settings?${returnParams.toString()}&checkout=success`,
     failUrl: `${origin}/settings?${returnParams.toString()}&checkout=fail`,
   });


### PR DESCRIPTION
## Summary
#2893(결제②-D Toss 위젯 배선) 머지 後 dev 라이브 왕복 실측 도중 실 브라우저에서 발견한 결함 — 로그인·`POST /api/billing/customer-key`(200, 멱등 확認)까지는 정상이었으나, Toss SDK(`js.tosspayments.com`) 스크립트 로드 자체가 CSP `script-src`에 없어 차단됨.

## 근본 원인
`apps/web/next.config.ts`의 CSP가 신규 결제 SDK 도메인을 반영하지 않았음:
- `script-src`에 `js.tosspayments.com` 부재 → SDK 로드 자체 차단
- `connect-src`에 `tosspayments.com` 부재 → SDK 내부 통신 차단
- `frame-src 'none'` — SDK 기본 데스크톱 동작(`windowTarget` 기본값 `iframe`)과 충돌

유닛테스트는 브라우저 CSP를 실행하지 않는 축이라 이 클래스를 구조적으로 못 잡는다 — 이번 라이브 실측이 아니었으면 "머지+배포 성공"만 보고 done 판정했을 자리(#2893은 design:pass·qa:pass·CI green 전부 통과했었음).

## 수정
- `script-src`에 `https://js.tosspayments.com` 추가(최소 — SDK 로드 도메인 하나만)
- `connect-src`에 `https://*.tosspayments.com` 추가(SDK 내부 API 통신 — 정확한 서브도메인 목록을 사전에 전부 확定하기 어려워 기존 CSP 관례(`https://*.googleapis.com` 등)와 동일하게 와일드카드 사용)
- `frame-src`는 건드리지 않음 — 대신 `requestBillingAuth({windowTarget:'self'})`로 명시해 데스크톱도 전체페이지 리다이렉트로 통일(기존 모바일 기본 동작과 일치시켜 더 좁은 CSP 확장으로 우회)

## 카디르 QA·유나 design 확認 요청 (PO 지정)
- CSP 범위가 최소인지 — `script-src`/`connect-src` 확장이 Toss 공식 필요 도메인 범위를 벗어나지 않는지, 와일드카드가 과도 개방은 아닌지
- `windowTarget:'self'` 우회가 `frame-src 'none'`을 유지하며 안전한지
- 데스크톱에서도 전체페이지 리다이렉트로 통일되는 UX 변화가 유나 시안 v2(리다이렉트 왕복)와 정합인지

## Test plan
- [x] `pnpm build` 성공, `tsc --noEmit` 0 errors
- [x] 신규/수정 유닛테스트(`toss-checkout.test.ts` — windowTarget:'self' 어서션 추가) 29개 GREEN
- [ ] dev 배포 後 라이브 왕복 재개(customer-key→위젯 실오픈→카드인증→checkout→구독성립→즉시청구) — 이 fix가 착지해야 왕복이 이어짐

🤖 Generated with [Claude Code](https://claude.com/claude-code)