### PR TITLE
fix(#2511): checkout 진행중 서버 claim — 다른 tier/cycle 동시 재제출 이중청구 방어

### DIFF
--- a/backend/alembic/versions/0234_org_subscriptions_checkout_claimed_at.py
+++ b/backend/alembic/versions/0234_org_subscriptions_checkout_claimed_at.py
@@ -1,0 +1,33 @@
+"""#2511(결제②-D후속) — org_subscriptions에 checkout_claimed_at(nullable timestamptz) 추가.
+
+카디르 #2890 결함사냥 재QA 발견(2026-08-07): checkout 진행 中(응답 대기)에 같은 org가
+다른 tier/cycle로 재제출하면 order_id가 달라(결정적 키가 offering_version_id를 포함)
+#2493의 원자적 claim이 서로 다른 두 시도를 막지 못해 이론적 이중 청구가 가능했다.
+
+이 컬럼이 org당 "진행 중 checkout" 서버 정본 — checkout_subscription()이 실 청구
+전에 `WHERE checkout_claimed_at IS NULL OR checkout_claimed_at < now-STALE` 가드가
+걸린 UPSERT로 원자적 claim하고(같은 org의 동시 다른 tier/cycle 요청은 이 단일 UPDATE
+문에서 자연히 하나만 이기고 나머지는 rowcount=0로 즉시 거부 — advisory lock이 아니라
+Postgres 자체의 행단위 원자성이 직렬화 소스), 성공/거절/예외 어느 경로든 finally에서
+NULL로 되돌려 해제한다. staleness 윈도(코드 상수, 이 마이그는 그릇만)는 프로세스가
+release 前에 죽어도 org가 영구히 막히지 않게 하는 자기치유 장치."""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0234"
+down_revision = "0233"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "org_subscriptions",
+        sa.Column("checkout_claimed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("org_subscriptions", "checkout_claimed_at")

--- a/backend/app/models/org_subscription.py
+++ b/backend/app/models/org_subscription.py
@@ -32,6 +32,10 @@ class OrgSubscription(Base):
     current_period_end: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     # S8 Phase 2: 80% storage 경고 메일 dedup 마커(마지막 발송 시각·NULL=미발송).
     storage_warn_notified_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # #2511: 진행 중 checkout의 서버 정본 claim 마커(org_subscription_checkout.py 참고).
+    # NULL=진행 중 아님·값 있음=그 시각에 어떤 checkout이 이 org를 claim했다는 뜻(원자적
+    # UPSERT WHERE 가드로 동시 다른 tier/cycle 재제출의 이중청구를 막는다).
+    checkout_claimed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     # E-ADMIN B1: grandfather — 가입(플랜변경)시점 pricing_version 참조. free tier·백필 전
     # 기존 구독은 NULL(0146은 구조만, 값 백필은 가격 확정 후 별도 마이그).
     pricing_version_id: Mapped[uuid.UUID | None] = mapped_column(

--- a/backend/app/routers/org_subscription_checkout.py
+++ b/backend/app/routers/org_subscription_checkout.py
@@ -18,6 +18,7 @@ from app.models.org_subscription import OrgSubscription
 from app.services.org_subscription_checkout import (
     CheckoutDeclined,
     CheckoutError,
+    CheckoutInProgress,
     checkout_subscription,
 )
 
@@ -73,6 +74,10 @@ async def checkout(
         )
     except CheckoutDeclined as exc:
         return _to_response(exc.subscription, declined_reason=str(exc))
+    except CheckoutInProgress as exc:
+        # #2511 — 같은 org의 다른 checkout이 진행 中. 사용자 입력·내부 상태 오류가 아니라
+        # 타이밍 충돌이라 409(재시도 가능함을 뜻함).
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except CheckoutError as exc:
         # 이 지점 도달 시 tier/billing_cycle 자체는 이미 Pydantic Literal이 걸렀다 —
         # 남은 원인은 offering_version 카탈로그 갭 같은 내부 상태 문제(사용자 입력 오류

--- a/backend/app/services/billing_scheduler.py
+++ b/backend/app/services/billing_scheduler.py
@@ -35,6 +35,7 @@ from app.services.billing_charge import (
     _mark_failed_if_not_confirmed,
     charge_org,
 )
+from app.services.org_subscription_checkout import STALE_CLAIM_WINDOW
 from app.services.payment.toss_adapter import TossAdapter
 
 logger = logging.getLogger(__name__)
@@ -114,7 +115,27 @@ async def downgrade_to_free(session: AsyncSession, org_id: uuid.UUID, order_id: 
         )
     ).first() is not None
 
-    if not (has_newer_confirmed_order or has_newly_issued_billing_key):
+    # PO 지적(#2896 리뷰, 2026-08-07) — #2511이 만든 checkout_claimed_at도 같은 「claim
+    # 정합」 축이라 이 함수도 존중해야 한다. 위 두 신호(has_newer_confirmed_order·
+    # has_newly_issued_billing_key)는 checkout이 이미 뭔가를 "완성"했을 때만 감지한다 —
+    # claim은 성공했지만 아직 issue_billing_key/charge_org가 끝나기 前인(아무 새 증거도
+    # 아직 없는) 딱 그 창에서는 둘 다 놓친다. 그 창에 이 스윕이 끼어들면 free upsert가
+    # checkout이 진행 中인 org의 tier를 조용히 덮어써 — 나중에 그 checkout의 charge가
+    # 실제로 confirmed돼도(#2511 step④ CAS는 통과— 이 함수가 checkout_claimed_at 자체는
+    # 안 건드리므로) "유료청구는 됐는데 tier는 free"라는 영구 오염이 남는다. staleness
+    # 윈도(#2511과 동일 SSOT)를 넘긴 claim은 죽은/멈춘 걸로 보고 무시한다(자기치유 그대로).
+    now = datetime.now(timezone.utc)
+    has_active_checkout_claim = (
+        await session.execute(
+            select(OrgSubscription.id).where(
+                OrgSubscription.org_id == org_id,
+                OrgSubscription.checkout_claimed_at.is_not(None),
+                OrgSubscription.checkout_claimed_at >= now - STALE_CLAIM_WINDOW,
+            ).limit(1)
+        )
+    ).first() is not None
+
+    if not (has_newer_confirmed_order or has_newly_issued_billing_key or has_active_checkout_claim):
         free_offering = (
             await session.execute(
                 select(OfferingVersion).where(

--- a/backend/app/services/billing_scheduler.py
+++ b/backend/app/services/billing_scheduler.py
@@ -22,7 +22,7 @@ import logging
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import func, select, update
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -135,6 +135,12 @@ async def downgrade_to_free(session: AsyncSession, org_id: uuid.UUID, order_id: 
         )
     ).first() is not None
 
+    # ⚠️카디르 재QA(codex, #2896 리뷰, 2026-08-07) — 위 has_active_checkout_claim은 SELECT
+    # 一 write-time 가드가 아니다. SELECT 시점엔 claim이 없었어도 그 뒤(offering 조회 등
+    # await 2번) 새 claim이 서면 이 조건은 이미 지나간 값을 보고 있어 무시된다. 이 early-
+    # return SELECT는 "명백히 막힌 경우 Toss/offering 조회 낭비를 피하는" 최적화일 뿐,
+    # 실제 안전장치는 아래 UPSERT 자체의 WHERE(원래 checkout claim UPSERT와 동일 패턴)다
+    # — SELECT-then-write가 아니라 write-time 원자적 가드로 이 창을 완전히 닫는다.
     if not (has_newer_confirmed_order or has_newly_issued_billing_key or has_active_checkout_claim):
         free_offering = (
             await session.execute(
@@ -156,6 +162,10 @@ async def downgrade_to_free(session: AsyncSession, org_id: uuid.UUID, order_id: 
                 "tier": "free", "status": "active",
                 "offering_version_id": free_offering.id if free_offering else None,
             },
+            where=or_(
+                OrgSubscription.checkout_claimed_at.is_(None),
+                OrgSubscription.checkout_claimed_at < now - STALE_CLAIM_WINDOW,
+            ),
         )
         await session.execute(stmt)
 

--- a/backend/app/services/org_subscription_checkout.py
+++ b/backend/app/services/org_subscription_checkout.py
@@ -161,9 +161,22 @@ async def checkout_subscription(
 
         # ④ 청구 성공 時에만 active — 그 외(pending=경쟁 중·failed 도달 안 함, 위에서 잡힘)는
         # active로 안 올린다.
+        #
+        # 카디르 결함사냥(codex, #2896 리뷰, 2026-08-07) CRITICAL — 이 UPDATE가 org_id로만
+        # 매칭하면 이 호출의 claim이 STALE_CLAIM_WINDOW를 넘겨 이미 다른 요청에게 뺏긴
+        # 뒤(자기는 안 죽고 그냥 느렸을 뿐 — Toss charge 65초+issue 15초 정상 왕복만으로도
+        # 합이 STALE_CLAIM_WINDOW에 근접·초과할 수 있다, 이론이 아니라 실 타임아웃 스펙)
+        # 늦게 도착한 confirmed 결과가, 그 사이 새로 claim을 쥐고 아직 자기 charge를
+        # confirm받지 못한(status='pending') 다른 요청의 tier 행을 소유권 재확認 없이
+        # active로 밀어버릴 수 있었다 — release와 동일한 CAS(checkout_claimed_at==이
+        # 호출이 claim한 그 값)를 걸어, 이미 뺏긴 뒤라면(rowcount==0) active로 안 올린다
+        # (이 호출 자신의 charge_org 청구 자체는 이미 confirmed로 남아 있다 — 그 청구를
+        # 취소하는 건 이 fix의 범위 밖, C4/화불 축).
         if order.status == "confirmed":
             await session.execute(
-                update(OrgSubscription).where(OrgSubscription.org_id == org_id).values(status="active")
+                update(OrgSubscription)
+                .where(OrgSubscription.org_id == org_id, OrgSubscription.checkout_claimed_at == now)
+                .values(status="active")
             )
             await session.commit()
 

--- a/backend/app/services/org_subscription_checkout.py
+++ b/backend/app/services/org_subscription_checkout.py
@@ -14,13 +14,28 @@
 ⚠️issue_billing_key가 내부에서 자체 commit하는 기존 코드(C1, 이미 리뷰 통과)를 이 스토리
 때문에 리팩터하지 않는다(PO 확定) — ①②가 별도 커밋되는 2단계지만, ③에서 구독 active
 게이트가 걸려 있어 그 사이 크래시나도 유료 권리가 새지 않는다(무해 — issue_billing_key
-자체도 재호출 시 기존 customer_key 재사용이라 안전하게 재시도됨)."""
+자체도 재호출 시 기존 customer_key 재사용이라 안전하게 재시도됨).
+
+#2511(카디르 #2890 결함사냥 재QA, 2026-08-07) — 위 상태기계는 "같은" tier/cycle 재시도
+(더블클릭)만 방어했다(결정적 order_id + C2 원자적 claim). 같은 org가 checkout **진행
+中**(Toss 응답 대기)에 **다른** tier/cycle로 재제출하면 offering_version_id가 달라
+order_id도 달라져(§_checkout_order_id) 서로 다른 claim이 둘 다 성공 — 이중 청구가
+가능했다. advisory_xact_lock은 이 함수처럼 여러 번 commit하는 흐름 전체를 못 덮는다
+(중간 commit마다 락이 풀려 그 틈에 경쟁자가 끼어들 수 있음 — 재획득해도 "재획득 시도
+자체"가 다시 경쟁이라 완전 직렬화가 안 됨, 실측 확認). 그래서 이 fix는 advisory lock이
+아니라 **org_subscriptions 행 자체를 서버 정본 claim으로** 쓴다(story #2511 AC 옵션①)
+— `checkout_claimed_at` 가드가 걸린 단일 원자적 UPSERT(Postgres 자체의 행단위 write
+직렬화가 소스, 별도 락 메커니즘 불요)로 동시 다른 tier/cycle 요청 중 **정확히 하나만**
+claim에 성공하고, 나머지는 Toss를 한 번도 부르기 전에(issue_billing_key조차 호출
+안 함) rowcount=0으로 즉시 거부된다. 성공/거절(CheckoutDeclined)/예상 밖 예외 어느
+경로든 `finally`에서 claim을 해제(NULL)한다 — 프로세스가 해제 前에 죽어도 STALE_CLAIM_
+WINDOW가 지나면 다음 요청이 claim을 훔쳐가 org가 영구히 막히지 않는다(자기치유)."""
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import select, update
+from sqlalchemy import or_, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -35,9 +50,21 @@ from app.services.payment.toss_adapter import TossApiError
 PAID_TIERS = frozenset({"starter", "team", "business"})
 BILLING_CYCLES = frozenset({"monthly", "annual"})
 
+# #2511 — claim이 release 전에 프로세스 크래시로 영영 안 풀리는 경우의 자기치유 윈도.
+# Toss billing-key 발급+청구 왕복은 정상적으로 수 초~수십 초 내 끝난다(참고: C4의 Toss
+# webhook 재시도 최대 7회/~3일19시간과는 별개 축 — 이건 "이 요청 자체"의 처리시간 상한).
+STALE_CLAIM_WINDOW = timedelta(minutes=3)
+
 
 class CheckoutError(Exception):
     """체크아웃을 진행할 수 없는 상태 — 명시 실패."""
+
+
+class CheckoutInProgress(CheckoutError):
+    """#2511 — 같은 org의 다른 checkout이 이미 진행 中(claim 보유)이라 이 요청은 Toss를
+    한 번도 부르지 않고 즉시 거부됨. 사용자 입력 오류가 아니라 타이밍 충돌 — 라우터가
+    409로 매핑(카드 거절인 CheckoutDeclined의 200과도, 내부 상태 오류인 다른
+    CheckoutError의 500과도 다른 자리)."""
 
 
 class CheckoutDeclined(Exception):
@@ -84,50 +111,73 @@ async def checkout_subscription(
     if offering is None:
         raise CheckoutError(f"tier={tier!r}의 활성 offering_version(krw)을 찾을 수 없음")
 
-    # ① 빌링키 발급(C1 재사용) — 카드 인증 완료.
-    await issue_billing_key(session, org_id=org_id, auth_key=auth_key)
-
-    # ② 구독을 'pending'으로 생성/전이 — 아직 active 아님.
     now = datetime.now(timezone.utc)
     period_start, period_end = new_subscription_period(now=now, billing_cycle=billing_cycle)
-    stmt = pg_insert(OrgSubscription).values(
+
+    # ⭐#2511 — 원자적 claim(=② 구독을 'pending'으로 생성/전이를 겸한다). WHERE 가드가
+    # 걸린 단일 UPSERT라 동시에 여러 tier/cycle이 도착해도 Postgres 행단위 write
+    # 직렬화상 정확히 하나만 rowcount=1(claim 성공)이고 나머지는 0(거부) — Toss를 부르기
+    # 前이라 issue_billing_key조차 낭비되지 않는다.
+    claim_stmt = pg_insert(OrgSubscription).values(
         id=uuid.uuid4(), org_id=org_id, tier=tier, billing_cycle=billing_cycle, status="pending",
         provider="toss", currency="krw", offering_version_id=offering.id,
         current_period_start=period_start, current_period_end=period_end,
+        checkout_claimed_at=now,
     ).on_conflict_do_update(
         index_elements=["org_id"],
         set_={
             "tier": tier, "billing_cycle": billing_cycle, "status": "pending",
             "provider": "toss", "currency": "krw", "offering_version_id": offering.id,
             "current_period_start": period_start, "current_period_end": period_end,
+            "checkout_claimed_at": now,
         },
+        where=or_(
+            OrgSubscription.checkout_claimed_at.is_(None),
+            OrgSubscription.checkout_claimed_at < now - STALE_CLAIM_WINDOW,
+        ),
     )
-    await session.execute(stmt)
+    claim_result = await session.execute(claim_stmt)
     await session.commit()
-
-    # ③ 즉시 1차 청구(#2500 계산 + C2 집행) — 전액·프로레이션 없음(PO 확定).
-    amount_minor, currency = await compute_charge_amount(session, org_id=org_id)
-    order_id = _checkout_order_id(org_id, offering.id, now)
+    if claim_result.rowcount == 0:
+        raise CheckoutInProgress(f"org_id={org_id}에 다른 checkout이 이미 진행 中 — 완료 후 재시도")
 
     try:
-        order = await charge_org(
-            session, org_id=org_id, order_id=order_id, amount_minor=amount_minor,
-            currency=currency, order_name=f"Sprintable {tier} 구독 시작",
-        )
-    except TossApiError as exc:
-        # 카드 거절 등 비즈니스 사유 — 시스템 오류 아님. 구독은 pending인 채(재시도 가능).
-        sub = await _refetch_subscription(session, org_id)
-        raise CheckoutDeclined(str(exc), subscription=sub) from exc
+        # ① 빌링키 발급(C1 재사용) — 카드 인증 완료.
+        await issue_billing_key(session, org_id=org_id, auth_key=auth_key)
 
-    # ④ 청구 성공 時에만 active — 그 외(pending=경쟁 중·failed 도달 안 함, 위에서 잡힘)는
-    # active로 안 올린다.
-    if order.status == "confirmed":
+        # ③ 즉시 1차 청구(#2500 계산 + C2 집행) — 전액·프로레이션 없음(PO 확定).
+        amount_minor, currency = await compute_charge_amount(session, org_id=org_id)
+        order_id = _checkout_order_id(org_id, offering.id, now)
+
+        try:
+            order = await charge_org(
+                session, org_id=org_id, order_id=order_id, amount_minor=amount_minor,
+                currency=currency, order_name=f"Sprintable {tier} 구독 시작",
+            )
+        except TossApiError as exc:
+            # 카드 거절 등 비즈니스 사유 — 시스템 오류 아님. 구독은 pending인 채(재시도 가능).
+            sub = await _refetch_subscription(session, org_id)
+            raise CheckoutDeclined(str(exc), subscription=sub) from exc
+
+        # ④ 청구 성공 時에만 active — 그 외(pending=경쟁 중·failed 도달 안 함, 위에서 잡힘)는
+        # active로 안 올린다.
+        if order.status == "confirmed":
+            await session.execute(
+                update(OrgSubscription).where(OrgSubscription.org_id == org_id).values(status="active")
+            )
+            await session.commit()
+
+        return await _refetch_subscription(session, org_id)
+    finally:
+        # #2511 — claim 해제. checkout_claimed_at이 여전히 "우리가 세팅한 그 값"일 때만
+        # 지운다 — STALE_CLAIM_WINDOW를 넘겨 다른 요청이 이미 훔쳐간 claim을 우리가 뒤늦게
+        # 돌아와 실수로 지워버리는 것(그 다른 요청의 상호배제가 깨짐)을 막는다.
         await session.execute(
-            update(OrgSubscription).where(OrgSubscription.org_id == org_id).values(status="active")
+            update(OrgSubscription)
+            .where(OrgSubscription.org_id == org_id, OrgSubscription.checkout_claimed_at == now)
+            .values(checkout_claimed_at=None)
         )
         await session.commit()
-
-    return await _refetch_subscription(session, org_id)
 
 
 async def _refetch_subscription(session: AsyncSession, org_id: uuid.UUID) -> OrgSubscription:

--- a/backend/tests/test_e_2494_c3_scheduler.py
+++ b/backend/tests/test_e_2494_c3_scheduler.py
@@ -66,18 +66,24 @@ def _stale_order_row(created_at):
 
 
 def _no_recovery_evidence_side_effects(order_created_at, free_offering):
-    """회복 증거(더 나중 confirmed order·더 나중 발급 billing_key) 둘 다 없는 표준 경로."""
+    """회복 증거(더 나중 confirmed order·더 나중 발급 billing_key·#2511 진행 中 checkout
+    claim) 셋 다 없는 표준 경로."""
     order_result = MagicMock()
     order_result.scalar_one_or_none.return_value = _stale_order_row(order_created_at)
     confirmed_check = MagicMock()
     confirmed_check.first.return_value = None
     key_check = MagicMock()
     key_check.first.return_value = None
+    checkout_claim_check = MagicMock()
+    checkout_claim_check.first.return_value = None
     offering_result = MagicMock()
     offering_result.scalar_one_or_none.return_value = free_offering
     upsert_result = MagicMock()
     close_order_result = MagicMock()
-    return [order_result, confirmed_check, key_check, offering_result, upsert_result, close_order_result]
+    return [
+        order_result, confirmed_check, key_check, checkout_claim_check,
+        offering_result, upsert_result, close_order_result,
+    ]
 
 
 @pytest.mark.anyio
@@ -98,7 +104,7 @@ async def test_downgrade_to_free_upserts_free_tier(monkeypatch):
 
     await downgrade_to_free(session, org_id, order_id)
 
-    upsert_call = session.execute.call_args_list[4]
+    upsert_call = session.execute.call_args_list[5]
     compiled = upsert_call.args[0].compile().params
     assert compiled["org_id"] == org_id
     assert compiled["tier"] == "free"
@@ -120,7 +126,7 @@ async def test_downgrade_to_free_handles_missing_offering_gracefully(monkeypatch
 
     await downgrade_to_free(session, uuid.uuid4(), "ord-downgrade-2")
 
-    upsert_call = session.execute.call_args_list[4]
+    upsert_call = session.execute.call_args_list[5]
     compiled = upsert_call.args[0].compile().params
     assert compiled["offering_version_id"] is None
 
@@ -144,8 +150,8 @@ async def test_downgrade_to_free_closes_the_order_po_blocker_fix(monkeypatch):
 
     await downgrade_to_free(session, org_id, order_id)
 
-    # 마지막(6번째) 호출이 billing_orders를 'downgraded'로 닫는 UPDATE여야.
-    close_call = session.execute.call_args_list[5]
+    # 마지막(7번째) 호출이 billing_orders를 'downgraded'로 닫는 UPDATE여야.
+    close_call = session.execute.call_args_list[6]
     compiled = close_call.args[0].compile().params
     assert compiled["status"] == "downgraded"
 
@@ -167,17 +173,21 @@ async def test_downgrade_to_free_skips_upsert_when_newer_confirmed_order_exists_
     confirmed_check.first.return_value = (uuid.uuid4(),)  # 더 나중 confirmed order 존재
     key_check = MagicMock()
     key_check.first.return_value = None
+    checkout_claim_check = MagicMock()
+    checkout_claim_check.first.return_value = None
     close_order_result = MagicMock()
 
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[order_result, confirmed_check, key_check, close_order_result])
+    session.execute = AsyncMock(
+        side_effect=[order_result, confirmed_check, key_check, checkout_claim_check, close_order_result]
+    )
     session.commit = AsyncMock()
 
     await downgrade_to_free(session, org_id, order_id)
 
-    # execute가 4번만 불렸다 = offering 조회·upsert가 스킵됐다(회복 증거로 free upsert 건너뜀).
-    assert session.execute.await_count == 4
-    close_call = session.execute.call_args_list[3]
+    # execute가 5번만 불렸다 = offering 조회·upsert가 스킵됐다(회복 증거로 free upsert 건너뜀).
+    assert session.execute.await_count == 5
+    close_call = session.execute.call_args_list[4]
     assert close_call.args[0].compile().params["status"] == "downgraded"
 
 
@@ -197,15 +207,55 @@ async def test_downgrade_to_free_skips_upsert_when_newly_issued_billing_key_exis
     confirmed_check.first.return_value = None
     key_check = MagicMock()
     key_check.first.return_value = (uuid.uuid4(),)  # 더 나중 발급된 활성 billing_key 존재
+    checkout_claim_check = MagicMock()
+    checkout_claim_check.first.return_value = None
     close_order_result = MagicMock()
 
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[order_result, confirmed_check, key_check, close_order_result])
+    session.execute = AsyncMock(
+        side_effect=[order_result, confirmed_check, key_check, checkout_claim_check, close_order_result]
+    )
     session.commit = AsyncMock()
 
     await downgrade_to_free(session, org_id, order_id)
 
-    assert session.execute.await_count == 4
+    assert session.execute.await_count == 5
+
+
+@pytest.mark.anyio
+async def test_downgrade_to_free_skips_upsert_when_checkout_claim_in_progress():
+    """#2511/#2896 PO 지적(2026-08-07) — 「유료청구는 됐는데 tier free」 오염 방지: 다른
+    두 신호(더 나중 confirmed order·더 나중 발급 billing_key) 둘 다 없어도, org에 진행
+    中인(=staleness 안 넘긴) checkout_claimed_at이 있으면 free upsert를 건너뛴다. claim은
+    성공했지만 issue_billing_key/charge_org가 아직 안 끝나 다른 두 신호가 아직 안 생긴
+    딱 그 창을 이 신호가 커버한다."""
+    from app.services.billing_scheduler import downgrade_to_free
+
+    org_id = uuid.uuid4()
+    order_id = "ord-stale-3"
+    now = datetime(2026, 8, 15, tzinfo=timezone.utc)
+
+    order_result = MagicMock()
+    order_result.scalar_one_or_none.return_value = _stale_order_row(now - timedelta(days=9))
+    confirmed_check = MagicMock()
+    confirmed_check.first.return_value = None
+    key_check = MagicMock()
+    key_check.first.return_value = None
+    checkout_claim_check = MagicMock()
+    checkout_claim_check.first.return_value = (uuid.uuid4(),)  # 진행 中인 checkout claim 존재
+    close_order_result = MagicMock()
+
+    session = AsyncMock()
+    session.execute = AsyncMock(
+        side_effect=[order_result, confirmed_check, key_check, checkout_claim_check, close_order_result]
+    )
+    session.commit = AsyncMock()
+
+    await downgrade_to_free(session, org_id, order_id)
+
+    assert session.execute.await_count == 5  # offering 조회·upsert가 스킵됨
+    close_call = session.execute.call_args_list[4]
+    assert close_call.args[0].compile().params["status"] == "downgraded"
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_e_2506_subscription_checkout.py
+++ b/backend/tests/test_e_2506_subscription_checkout.py
@@ -74,6 +74,12 @@ async def test_checkout_raises_when_offering_not_found():
 
 # ─── checkout_subscription — 상태기계 happy path ────────────────────────────
 
+def _claim_result(rowcount=1):
+    r = MagicMock()
+    r.rowcount = rowcount
+    return r
+
+
 @pytest.mark.anyio
 async def test_checkout_activates_subscription_when_charge_confirmed():
     from app.services.org_subscription_checkout import checkout_subscription
@@ -85,9 +91,10 @@ async def test_checkout_activates_subscription_when_charge_confirmed():
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[
         _exec_result(offering),   # ① offering lookup
-        MagicMock(),              # ② upsert pending
+        _claim_result(1),         # #2511 claim(=구독 pending 전이 겸함) — 성공
         MagicMock(),              # ④ update active
         _exec_result(active_sub), # 최종 refetch
+        MagicMock(),              # #2511 finally — claim 해제
     ])
 
     confirmed_order = MagicMock()
@@ -107,12 +114,40 @@ async def test_checkout_activates_subscription_when_charge_confirmed():
     assert charge_kwargs["amount_minor"] == 59_000
     assert charge_kwargs["currency"] == "krw"
 
-    # ② upsert pending 확認 — 두 번째 execute 호출.
-    upsert_call = session.execute.call_args_list[1]
-    compiled = upsert_call.args[0].compile().params
+    # claim(=구독 pending 전이 겸함) 확認 — 두 번째 execute 호출.
+    claim_call = session.execute.call_args_list[1]
+    compiled = claim_call.args[0].compile().params
     assert compiled["status"] == "pending"
     assert compiled["tier"] == "team"
     assert compiled["billing_cycle"] == "monthly"
+
+
+@pytest.mark.anyio
+async def test_checkout_rejects_when_another_checkout_already_in_progress():
+    """#2511 — claim UPSERT의 WHERE 가드에 걸려 rowcount=0(다른 checkout이 이미
+    checkout_claimed_at을 쥐고 있음) — Toss를 한 번도 부르지 않고(issue_billing_key조차)
+    즉시 CheckoutInProgress로 거부돼야 한다."""
+    from app.services.org_subscription_checkout import CheckoutInProgress, checkout_subscription
+
+    org_id = uuid.uuid4()
+    offering = _offering(tier="team")
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[
+        _exec_result(offering),  # ① offering lookup
+        _claim_result(0),        # #2511 claim 실패 — 다른 요청이 진행 中
+    ])
+
+    with patch("app.services.org_subscription_checkout.issue_billing_key", new=AsyncMock()) as mock_issue, \
+         patch("app.services.org_subscription_checkout.charge_org", new=AsyncMock()) as mock_charge:
+        with pytest.raises(CheckoutInProgress, match="진행"):
+            await checkout_subscription(
+                session, org_id=org_id, auth_key="ak-x", tier="team", billing_cycle="monthly",
+            )
+
+    mock_issue.assert_not_awaited()
+    mock_charge.assert_not_awaited()
+    assert session.execute.await_count == 2  # offering + claim뿐, finally release도 없음(claim 자체가 실패)
 
 
 @pytest.mark.anyio
@@ -146,8 +181,9 @@ async def test_checkout_declined_leaves_subscription_pending_not_active():
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[
         _exec_result(offering),    # ① offering lookup
-        MagicMock(),               # ② upsert pending
+        _claim_result(1),          # #2511 claim 성공
         _exec_result(pending_sub), # except 블록 안 refetch
+        MagicMock(),               # #2511 finally — claim 해제(CheckoutDeclined도 거친다)
     ])
 
     with patch("app.services.org_subscription_checkout.issue_billing_key", new=AsyncMock()), \
@@ -162,8 +198,8 @@ async def test_checkout_declined_leaves_subscription_pending_not_active():
             )
 
     assert exc_info.value.subscription.status == "pending"
-    # 4번째(active로 올리는) execute가 없어야 — 즉, 딱 3번만 불렸다.
-    assert session.execute.await_count == 3
+    # 4번째(active로 올리는) execute가 없어야 — offering+claim+refetch+release 딱 4번.
+    assert session.execute.await_count == 4
 
 
 @pytest.mark.anyio
@@ -179,8 +215,9 @@ async def test_checkout_does_not_activate_when_order_not_confirmed_race_loss():
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[
         _exec_result(offering),
-        MagicMock(),
-        _exec_result(pending_sub),  # 최종 refetch(active-update 없음 — 3번만 호출)
+        _claim_result(1),
+        _exec_result(pending_sub),  # 최종 refetch(active-update 없음)
+        MagicMock(),                # #2511 finally — claim 해제
     ])
 
     racing_order = MagicMock()
@@ -194,4 +231,4 @@ async def test_checkout_does_not_activate_when_order_not_confirmed_race_loss():
         )
 
     assert result.status == "pending"
-    assert session.execute.await_count == 3
+    assert session.execute.await_count == 4

--- a/backend/tests/test_e_2506_subscription_checkout.py
+++ b/backend/tests/test_e_2506_subscription_checkout.py
@@ -121,6 +121,13 @@ async def test_checkout_activates_subscription_when_charge_confirmed():
     assert compiled["tier"] == "team"
     assert compiled["billing_cycle"] == "monthly"
 
+    # 카디르 CRITICAL fix(codex, #2896 리뷰) — ④ activate UPDATE도 release와 동일한
+    # CAS(checkout_claimed_at==이 호출이 claim한 값)가 걸려 있어야 한다. 세 번째 execute
+    # 호출(claim 다음).
+    activate_call = session.execute.call_args_list[2]
+    activate_where_literal = str(activate_call.args[0].whereclause)
+    assert "checkout_claimed_at" in activate_where_literal
+
 
 @pytest.mark.anyio
 async def test_checkout_rejects_when_another_checkout_already_in_progress():

--- a/backend/tests/test_e_2506_subscription_checkout_realdb.py
+++ b/backend/tests/test_e_2506_subscription_checkout_realdb.py
@@ -263,6 +263,61 @@ async def test_checkout_concurrent_different_tier_charges_at_most_once_realdb():
 
 
 @pytest.mark.anyio
+async def test_checkout_unexpected_exception_mid_flow_still_releases_claim_realdb():
+    """#2511 — PO/카디르가 못박은 핵심 질문: "claim 성공 요청이 실패하면 claimed_at이
+    풀려 재시도되나(락 영구 점유 함정)?" TossApiError(CheckoutDeclined로 잡히는 경로)
+    말고 «완전히 예상 밖» 예외(여기선 compute_charge_amount가 던지는 RuntimeError로
+    시뮬레이트 — issue_billing_key 다음·charge_org 前, 어떤 명시 except 절도 안 잡는
+    지점)가 나도 finally가 release를 보장하는지, 그리고 release된 뒤 즉시 재시도가
+    실제로 성공하는지까지 실DB로 실증한다."""
+    from app.services.org_subscription_checkout import checkout_subscription
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session1:
+            org_id = await _seed_org_with_members(session1, human_seats=3)
+
+            toss_billing_key_response = {
+                "billingKey": "billing-key-unexpected-1",
+                "card": {"issuerCode": "61", "acquirerCode": "31", "number": "12345678****000*", "cardType": "신용", "ownerType": "개인"},
+                "authenticatedAt": "2026-08-07T00:00:00+09:00",
+            }
+
+            with patch("app.services.payment.toss_adapter.TossAdapter._post", new=AsyncMock(
+                side_effect=[toss_billing_key_response]
+            )), patch(
+                "app.services.org_subscription_checkout.compute_charge_amount",
+                new=AsyncMock(side_effect=RuntimeError("simulated unexpected mid-flow failure")),
+            ):
+                with pytest.raises(RuntimeError, match="simulated unexpected"):
+                    await checkout_subscription(
+                        session1, org_id=org_id, auth_key="ak-unexpected", tier="starter", billing_cycle="monthly",
+                    )
+
+            # 예외가 명시 except 어디에도 안 잡혔어도 claim은 release돼야 한다.
+            claim_state = (
+                await session1.execute(
+                    text("SELECT checkout_claimed_at FROM org_subscriptions WHERE org_id=:oid"), {"oid": org_id}
+                )
+            ).scalar_one()
+            assert claim_state is None
+
+        # release가 실제로 "다음 요청을 막지 않는지"까지 — 새 세션으로 즉시 재시도.
+        async with Session() as session2:
+            toss_charge_response = {"paymentKey": f"pay-{uuid.uuid4()}", "totalAmount": 5_000}
+            with patch("app.services.payment.toss_adapter.TossAdapter._post", new=AsyncMock(
+                side_effect=[toss_billing_key_response, toss_charge_response]
+            )):
+                retried = await checkout_subscription(
+                    session2, org_id=org_id, auth_key="ak-retry", tier="starter", billing_cycle="monthly",
+                )
+            assert retried.status == "active"  # 영구 점유 함정 없음 — 재시도가 정상 완결됨
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_checkout_sequential_different_tier_after_completion_not_blocked_realdb():
     """#2511 AC2 — 정상 순차(1차 완결 後 다른 tier로 재구독)는 막지 않는다. 진행 中
     claim은 1차가 finally에서 해제하므로, 겹치지 않는 순차 2차 checkout은 정상 성공해야

--- a/backend/tests/test_e_2506_subscription_checkout_realdb.py
+++ b/backend/tests/test_e_2506_subscription_checkout_realdb.py
@@ -263,6 +263,127 @@ async def test_checkout_concurrent_different_tier_charges_at_most_once_realdb():
 
 
 @pytest.mark.anyio
+async def test_checkout_stale_reclaimed_late_confirm_does_not_premature_activate_realdb():
+    """#2511 — 카디르 재QA(codex, #2896 리뷰, 2026-08-07) CRITICAL 재현+fix 검증.
+
+    시나리오: A(starter)가 claim한 直後 STALE_CLAIM_WINDOW를 넘겨(Toss charge 65초+
+    issue 15초 정상 왕복만으로도 합이 근접·초과할 수 있음 — A는 죽은 게 아니라 그냥
+    느린 것) B(team)가 claim을 정당하게 뺏어 자기 흐름을 진행 中(아직 자기 charge는
+    confirm 前, status='pending')인데, 그 사이 A의 원래 charge가 뒤늦게 confirmed로
+    돌아온다. fix 前엔 step④ activate UPDATE가 org_id로만 매칭해 A의 뒤늦은 confirm이
+    B의 아직 미확定 tier 행을 소유권 재확認 없이 곧장 active로 밀어버렸다 — 그 뒤 B의
+    실제 charge가 카드 거절로 실패해도(TossApiError) declined 경로는 status를 다시
+    되돌리지 않으므로, "확정된 결제가 하나도 없는데 active"라는 영구 오염이 남는다.
+
+    이 테스트는 정확히 그 타이밍을 asyncio.Event 2개로 결정론적으로 강제한다(진짜
+    시간 경과 대신 STALE_CLAIM_WINDOW를 음수로 monkeypatch해 "이미 지남" 조건만
+    재현 — 3분을 실제로 기다리지 않는다)."""
+    import asyncio
+    from datetime import timedelta
+
+    import app.services.org_subscription_checkout as checkout_module
+    from app.services.org_subscription_checkout import CheckoutDeclined, checkout_subscription
+    from app.services.payment.toss_adapter import TossApiError
+
+    org_id = uuid.uuid4()
+    engine_a = create_async_engine(_ASYNC)
+    engine_b = create_async_engine(_ASYNC)
+    Session_a = async_sessionmaker(engine_a, expire_on_commit=False)
+    Session_b = async_sessionmaker(engine_b, expire_on_commit=False)
+
+    seed_engine = create_async_engine(_ASYNC)
+    try:
+        async with async_sessionmaker(seed_engine, expire_on_commit=False)() as seed_session:
+            # _seed_org_with_members는 매번 새 org_id를 만들어버리므로(여기선 미리 정한
+            # org_id가 필요) 직접 멤버만 심는다.
+            for _ in range(3):
+                await seed_session.execute(
+                    text("INSERT INTO org_members (id, org_id, user_id, role) VALUES (:id, :org_id, :uid, 'member')"),
+                    {"id": uuid.uuid4(), "org_id": org_id, "uid": uuid.uuid4()},
+                )
+            await seed_session.commit()
+    finally:
+        await seed_engine.dispose()
+
+    b_ready = asyncio.Event()   # B가 claim(뺏기)+issuance까지 끝냈다 — A는 이제 진행해도 됨
+    a_done = asyncio.Event()    # A가 자기 흐름(step④ 포함)을 완전히 끝냈다 — B는 이제 charge해도 됨
+    charge_call_count = {"n": 0}
+
+    async def _post_mock(self, path, *, json, timeout, op_label, idempotency_key=None):
+        auth = json.get("authKey")
+        if op_label == "billing key issuance" and auth == "ak-b-fast":
+            b_ready.set()
+            await a_done.wait()  # B는 A가 완전히 끝날 때까지 자기 charge를 미룬다.
+            return {
+                "billingKey": "billing-key-B", "card": {"issuerCode": "61", "acquirerCode": "31", "number": "12345678****000*", "cardType": "신용", "ownerType": "개인"},
+                "authenticatedAt": "2026-08-07T00:00:00+09:00",
+            }
+        if op_label == "billing key issuance" and auth == "ak-a-slow":
+            await b_ready.wait()  # A는 B가 claim을 뺏어갈 시간을 번다(=STALE_CLAIM_WINDOW 초과 흉내).
+            return {
+                "billingKey": "billing-key-A", "card": {"issuerCode": "61", "acquirerCode": "31", "number": "12345678****000*", "cardType": "신용", "ownerType": "개인"},
+                "authenticatedAt": "2026-08-07T00:00:00+09:00",
+            }
+        if op_label == "charge":
+            charge_call_count["n"] += 1
+            if charge_call_count["n"] == 1:
+                return {"paymentKey": f"pay-a-{uuid.uuid4()}", "totalAmount": json["amount"]}  # A — 뒤늦게 confirmed.
+            raise TossApiError("CARD_DECLINED", "카드 거절", status_code=400)  # B — 실제로는 거절.
+        raise AssertionError(f"unexpected _post call: op_label={op_label!r} json={json!r}")
+
+    async def _run_a():
+        result = await checkout_subscription(
+            Session_a(), org_id=org_id, auth_key="ak-a-slow", tier="starter", billing_cycle="monthly",
+        )
+        a_done.set()
+        return result
+
+    async def _run_b():
+        with pytest.raises(CheckoutDeclined) as exc_info:
+            await checkout_subscription(
+                Session_b(), org_id=org_id, auth_key="ak-b-fast", tier="team", billing_cycle="monthly",
+            )
+        return exc_info.value
+
+    try:
+        with patch.object(checkout_module, "STALE_CLAIM_WINDOW", timedelta(seconds=-60)), \
+             patch("app.services.payment.toss_adapter.TossAdapter._post", new=_post_mock):
+            result_a, declined_b = await asyncio.gather(_run_a(), _run_b())
+
+        # A 자신의 반환값도 «현재 org의 실제 상태»(pending — 더 이상 A 소유 아님)를 정직히
+        # 반영한다. A의 charge_org 청구 자체는 confirmed로 남아 있고(별도 축, C4/환불
+        # 대상) — 아래에서 billing_orders로 직접 확認한다.
+        assert result_a.status == "pending"
+
+        verify_engine = create_async_engine(_ASYNC)
+        try:
+            async with async_sessionmaker(verify_engine, expire_on_commit=False)() as verify_session:
+                row = (
+                    await verify_session.execute(
+                        text("SELECT tier, status FROM org_subscriptions WHERE org_id=:oid"), {"oid": org_id}
+                    )
+                ).first()
+                # 핵심 단정 — B의 실제 charge는 거절됐으므로 org의 최종 상태는 «확정된 결제
+                # 없음»을 정직하게 반영해야 한다. A의 뒤늦은 confirm이 여기 status를
+                # active로 밀어버리면(fix 前 버그) 이 assert가 깨진다.
+                assert row.tier == "team"  # B의 claim이 마지막으로 쥔 tier(오염 없음)
+                assert row.status == "pending"  # active로 오염되지 않음(fix 검증 핵심)
+
+                confirmed_orders = (
+                    await verify_session.execute(
+                        text("SELECT COUNT(*) FROM billing_orders WHERE org_id=:oid AND status='confirmed'"),
+                        {"oid": org_id},
+                    )
+                ).scalar_one()
+                assert confirmed_orders == 1  # A의 charge 자체는 실제로 confirmed(별도 축)
+        finally:
+            await verify_engine.dispose()
+    finally:
+        await engine_a.dispose()
+        await engine_b.dispose()
+
+
+@pytest.mark.anyio
 async def test_checkout_unexpected_exception_mid_flow_still_releases_claim_realdb():
     """#2511 — PO/카디르가 못박은 핵심 질문: "claim 성공 요청이 실패하면 claimed_at이
     풀려 재시도되나(락 영구 점유 함정)?" TossApiError(CheckoutDeclined로 잡히는 경로)

--- a/backend/tests/test_e_2506_subscription_checkout_realdb.py
+++ b/backend/tests/test_e_2506_subscription_checkout_realdb.py
@@ -275,9 +275,16 @@ async def test_checkout_stale_reclaimed_late_confirm_does_not_premature_activate
     실제 charge가 카드 거절로 실패해도(TossApiError) declined 경로는 status를 다시
     되돌리지 않으므로, "확정된 결제가 하나도 없는데 active"라는 영구 오염이 남는다.
 
-    이 테스트는 정확히 그 타이밍을 asyncio.Event 2개로 결정론적으로 강제한다(진짜
+    이 테스트는 정확히 그 타이밍을 asyncio.Event 3개로 결정론적으로 강제한다(진짜
     시간 경과 대신 STALE_CLAIM_WINDOW를 음수로 monkeypatch해 "이미 지남" 조건만
-    재현 — 3분을 실제로 기다리지 않는다)."""
+    재현 — 3분을 실제로 기다리지 않는다).
+
+    카디르 재QA(codex, #2896 리뷰, 2026-08-07) — CI 20% 플레이키 재현+fix: 원래는
+    billing-key issuance 단계만 코디네이션해 "A가 먼저 claim한다"는 전제를 코드가
+    강제하지 않았다(asyncio.gather가 두 태스크의 claim UPSERT 순서까지 보장하진
+    않음 — B가 먼저 claim하면 시나리오가 뒤집혀 assert가 반대로 실패). a_claimed
+    이벤트로 "A의 claim이 이미 커밋됐다"를 B가 시작하기 前에 명시 확인시켜 claim
+    경쟁 자체를 결정화한다(레이스에 안 기대는 재현)."""
     import asyncio
     from datetime import timedelta
 
@@ -305,6 +312,7 @@ async def test_checkout_stale_reclaimed_late_confirm_does_not_premature_activate
     finally:
         await seed_engine.dispose()
 
+    a_claimed = asyncio.Event()  # A의 claim UPSERT가 이미 커밋됐다(issue_billing_key는 claim 커밋 後에만 호출됨).
     b_ready = asyncio.Event()   # B가 claim(뺏기)+issuance까지 끝냈다 — A는 이제 진행해도 됨
     a_done = asyncio.Event()    # A가 자기 흐름(step④ 포함)을 완전히 끝냈다 — B는 이제 charge해도 됨
     charge_call_count = {"n": 0}
@@ -319,6 +327,9 @@ async def test_checkout_stale_reclaimed_late_confirm_does_not_premature_activate
                 "authenticatedAt": "2026-08-07T00:00:00+09:00",
             }
         if op_label == "billing key issuance" and auth == "ak-a-slow":
+            # issue_billing_key는 claim UPSERT+commit이 끝난 뒤에만 호출되므로, 여기
+            # 도달했다는 것 자체가 "A의 claim이 이미 DB에 커밋됐다"는 명시 증거다.
+            a_claimed.set()
             await b_ready.wait()  # A는 B가 claim을 뺏어갈 시간을 번다(=STALE_CLAIM_WINDOW 초과 흉내).
             return {
                 "billingKey": "billing-key-A", "card": {"issuerCode": "61", "acquirerCode": "31", "number": "12345678****000*", "cardType": "신용", "ownerType": "개인"},
@@ -339,6 +350,11 @@ async def test_checkout_stale_reclaimed_late_confirm_does_not_premature_activate
         return result
 
     async def _run_b():
+        # #2511 CI 플레이키 fix(카디르/codex) — A의 claim이 이미 커밋된 뒤에야 B 자신의
+        # claim 시도를 시작한다. claim UPSERT 순서 자체를 asyncio.gather의 스케줄링
+        # 우연에 맡기지 않고 명시 이벤트로 결정화 — "B가 먼저 claim"하는 경우가 원천
+        # 배제돼 시나리오가 뒤집힐 수 없다.
+        await a_claimed.wait()
         with pytest.raises(CheckoutDeclined) as exc_info:
             await checkout_subscription(
                 Session_b(), org_id=org_id, auth_key="ak-b-fast", tier="team", billing_cycle="monthly",

--- a/backend/tests/test_e_2506_subscription_checkout_realdb.py
+++ b/backend/tests/test_e_2506_subscription_checkout_realdb.py
@@ -166,3 +166,154 @@ async def test_checkout_retry_same_day_does_not_double_charge_realdb():
             assert ledger_count == 1  # 이중청구 안 됨
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_checkout_concurrent_different_tier_charges_at_most_once_realdb():
+    """#2511 — 카디르 #2890 결함사냥 재QA 발견 재현+fix 검증: 같은 org에 «다른» tier/cycle
+    로 진짜 동시(asyncio.gather, 완전히 독립된 두 커넥션) checkout이 도착해도 charge는
+    최대 1회·구독은 1개로 수렴해야 한다(story #2511 AC1, "카디르 #2890 동시성 하네스"
+    재사용 — 진짜 크로스-커넥션 레이스, 같은 세션 mock이 아니다)."""
+    import asyncio
+
+    from app.services.org_subscription_checkout import CheckoutInProgress, checkout_subscription
+
+    engine_a = create_async_engine(_ASYNC)
+    engine_b = create_async_engine(_ASYNC)
+    Session_a = async_sessionmaker(engine_a, expire_on_commit=False)
+    Session_b = async_sessionmaker(engine_b, expire_on_commit=False)
+
+    seed_engine = create_async_engine(_ASYNC)
+    try:
+        async with async_sessionmaker(seed_engine, expire_on_commit=False)() as seed_session:
+            org_id = await _seed_org_with_members(seed_session, human_seats=3)
+    finally:
+        await seed_engine.dispose()
+
+    # 승자만 Toss를 부른다(billing-key 발급 1회 + charge 1회) — 패자는 claim 실패로
+    # issue_billing_key조차 도달 못 해야 하므로, 이 응답 목록이 2번 넘게 쓰이면(=패자도
+    # Toss를 불렀다는 뜻) 즉시 StopIteration으로 실패한다.
+    toss_billing_key_response = {
+        "billingKey": "billing-key-plaintext-concurrent",
+        "card": {"issuerCode": "61", "acquirerCode": "31", "number": "12345678****000*", "cardType": "신용", "ownerType": "개인"},
+        "authenticatedAt": "2026-08-07T00:00:00+09:00",
+    }
+    toss_charge_response = {"paymentKey": f"pay-{uuid.uuid4()}", "totalAmount": 59_000}
+
+    async def _checkout_starter():
+        async with Session_a() as session:
+            try:
+                return await checkout_subscription(
+                    session, org_id=org_id, auth_key="ak-starter", tier="starter", billing_cycle="monthly",
+                )
+            except CheckoutInProgress:
+                return "rejected"
+
+    async def _checkout_team():
+        async with Session_b() as session:
+            try:
+                return await checkout_subscription(
+                    session, org_id=org_id, auth_key="ak-team", tier="team", billing_cycle="annual",
+                )
+            except CheckoutInProgress:
+                return "rejected"
+
+    try:
+        with patch("app.services.payment.toss_adapter.TossAdapter._post", new=AsyncMock(
+            side_effect=[toss_billing_key_response, toss_charge_response]
+        )):
+            result_a, result_b = await asyncio.gather(_checkout_starter(), _checkout_team())
+
+        results = [result_a, result_b]
+        winners = [r for r in results if r != "rejected"]
+        losers = [r for r in results if r == "rejected"]
+        assert len(winners) == 1  # 정확히 하나만 성공
+        assert len(losers) == 1   # 정확히 하나만 거부(CheckoutInProgress)
+        assert winners[0].status == "active"
+
+        verify_engine = create_async_engine(_ASYNC)
+        try:
+            async with async_sessionmaker(verify_engine, expire_on_commit=False)() as verify_session:
+                ledger_count = (
+                    await verify_session.execute(
+                        text("SELECT COUNT(*) FROM billing_ledger_entries WHERE org_id=:oid AND entry_type='charge'"),
+                        {"oid": org_id},
+                    )
+                ).scalar_one()
+                assert ledger_count == 1  # 이중청구 안 됨(AC1 핵심)
+
+                sub_count = (
+                    await verify_session.execute(
+                        text("SELECT COUNT(*) FROM org_subscriptions WHERE org_id=:oid"), {"oid": org_id}
+                    )
+                ).scalar_one()
+                assert sub_count == 1  # 구독도 1개로 수렴
+
+                claim_state = (
+                    await verify_session.execute(
+                        text("SELECT checkout_claimed_at FROM org_subscriptions WHERE org_id=:oid"), {"oid": org_id}
+                    )
+                ).scalar_one()
+                assert claim_state is None  # 승자의 finally가 claim을 해제함(다음 checkout 안 막힘)
+        finally:
+            await verify_engine.dispose()
+    finally:
+        await engine_a.dispose()
+        await engine_b.dispose()
+
+
+@pytest.mark.anyio
+async def test_checkout_sequential_different_tier_after_completion_not_blocked_realdb():
+    """#2511 AC2 — 정상 순차(1차 완결 後 다른 tier로 재구독)는 막지 않는다. 진행 中
+    claim은 1차가 finally에서 해제하므로, 겹치지 않는 순차 2차 checkout은 정상 성공해야
+    한다(회귀 0 — «미완결 진행 중»에만 걸리는 락)."""
+    from app.services.org_subscription_checkout import checkout_subscription
+
+    # 두 호출에 별개 세션을 쓴다 — 실제로도 서로 다른 HTTP 요청은 각자 새 세션을 받는다
+    # (같은 세션을 재사용하면 expire_on_commit=False identity map이 1차 refetch 시
+    # 캐싱한 객체를 2차 조회에서도 그대로 돌려줘 "진짜 DB 상태"가 아니라 "세션이 기억하는
+    # 상태"를 검증하게 되는 착시가 생긴다 — 이 테스트가 검증하려는 건 claim 해제 그 자체).
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session1:
+            org_id = await _seed_org_with_members(session1, human_seats=3)
+
+            toss_billing_key_response = {
+                "billingKey": "billing-key-seq-1",
+                "card": {"issuerCode": "61", "acquirerCode": "31", "number": "12345678****000*", "cardType": "신용", "ownerType": "개인"},
+                "authenticatedAt": "2026-08-07T00:00:00+09:00",
+            }
+            toss_charge_response_1 = {"paymentKey": f"pay-{uuid.uuid4()}", "totalAmount": 5_000}
+
+            with patch("app.services.payment.toss_adapter.TossAdapter._post", new=AsyncMock(
+                side_effect=[toss_billing_key_response, toss_charge_response_1]
+            )):
+                sub1 = await checkout_subscription(
+                    session1, org_id=org_id, auth_key="ak-seq-1", tier="starter", billing_cycle="monthly",
+                )
+            assert sub1.status == "active"
+            assert sub1.tier == "starter"
+
+        # 1차가 완전히 끝난 後(claim 해제됨) — 다른 tier로 순차 재구독(새 세션, 새 요청
+        # 흉내). 막히면 안 된다.
+        async with Session() as session2:
+            toss_charge_response_2 = {"paymentKey": f"pay-{uuid.uuid4()}", "totalAmount": 59_000}
+            with patch("app.services.payment.toss_adapter.TossAdapter._post", new=AsyncMock(
+                side_effect=[toss_billing_key_response, toss_charge_response_2]
+            )):
+                sub2 = await checkout_subscription(
+                    session2, org_id=org_id, auth_key="ak-seq-2", tier="team", billing_cycle="monthly",
+                )
+            assert sub2.status == "active"
+            assert sub2.tier == "team"
+
+            charge_count = (
+                await session2.execute(
+                    text("SELECT COUNT(*) FROM billing_ledger_entries WHERE org_id=:oid AND entry_type='charge'"),
+                    {"oid": org_id},
+                )
+            ).scalar_one()
+            assert charge_count == 2  # 둘 다 정당한 별개 청구(순차·비중첩)
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_e_2511_downgrade_checkout_claim_realdb.py
+++ b/backend/tests/test_e_2511_downgrade_checkout_claim_realdb.py
@@ -1,0 +1,124 @@
+"""#2511 후속(PO 지적, #2896 리뷰, 2026-08-07) real-DB — downgrade_to_free가 진행 中인
+checkout claim(checkout_claimed_at)을 존중하는지 실 org_subscriptions/billing_orders
+위에서 검증. "유료청구는 됐는데 tier=free"라는 영구 오염을 막는 게 목적.
+
+DB env(ALEMBIC_DATABASE_URL) 없으면 skip — 로컬 PG(alembic upgrade head 적용된 DB) 전제."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _seed_stale_failed_order(session, *, org_id, now):
+    """8일 전 실패한 order — dunning §12.1 케이던스상 downgrade_to_free 대상."""
+    order_id = f"ord-stale-{uuid.uuid4()}"
+    await session.execute(
+        text(
+            "INSERT INTO billing_orders (id, org_id, order_id, amount_minor, currency, status, created_at, updated_at) "
+            "VALUES (:id, :org_id, :order_id, 29000, 'krw', 'failed', :created_at, :created_at)"
+        ),
+        {"id": uuid.uuid4(), "org_id": org_id, "order_id": order_id, "created_at": now - timedelta(days=9)},
+    )
+    await session.commit()
+    return order_id
+
+
+@pytest.mark.anyio
+async def test_downgrade_to_free_does_not_clobber_org_with_active_checkout_claim_realdb():
+    """진행 中인(staleness 안 넘긴) checkout claim이 있으면 free upsert를 건너뛴다 —
+    claim이 성공했지만 issue_billing_key/charge_org가 아직 안 끝나 다른 두 회복증거
+    (더 나중 confirmed order·더 나중 발급 billing_key)가 아직 없는 그 창을 재현."""
+    from app.services.billing_scheduler import downgrade_to_free
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = uuid.uuid4()
+            now = datetime.now(timezone.utc)
+            order_id = await _seed_stale_failed_order(session, org_id=org_id, now=now)
+
+            # 진행 中인 checkout claim 재현 — claim만 성공하고 아직 charge_org 前인 상태
+            # (tier='starter', status='pending', checkout_claimed_at=방금).
+            await session.execute(
+                text(
+                    "INSERT INTO org_subscriptions (id, org_id, tier, status, provider, currency, checkout_claimed_at) "
+                    "VALUES (:id, :org_id, 'starter', 'pending', 'toss', 'krw', :claimed_at)"
+                ),
+                {"id": uuid.uuid4(), "org_id": org_id, "claimed_at": now},
+            )
+            await session.commit()
+
+            await downgrade_to_free(session, org_id, order_id)
+
+            row = (
+                await session.execute(
+                    text("SELECT tier, status FROM org_subscriptions WHERE org_id=:oid"), {"oid": org_id}
+                )
+            ).first()
+            assert row.tier == "starter"  # free로 오염 안 됨(fix 검증 핵심)
+            assert row.status == "pending"  # checkout이 아직 진행 中이라는 사실 그대로
+
+            # order는 여전히 닫힌다(재처리 방지 목적은 유지).
+            order_status = (
+                await session.execute(
+                    text("SELECT status FROM billing_orders WHERE order_id=:oid"), {"oid": order_id}
+                )
+            ).scalar_one()
+            assert order_status == "downgraded"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_downgrade_to_free_proceeds_when_checkout_claim_is_stale_realdb():
+    """staleness를 넘긴(=죽은/멈춘) claim은 무시하고 정상 downgrade — 자기치유 회귀 없음."""
+    from app.services.billing_scheduler import downgrade_to_free
+    from app.services.org_subscription_checkout import STALE_CLAIM_WINDOW
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = uuid.uuid4()
+            now = datetime.now(timezone.utc)
+            order_id = await _seed_stale_failed_order(session, org_id=org_id, now=now)
+
+            stale_claim_at = now - STALE_CLAIM_WINDOW - timedelta(minutes=1)
+            await session.execute(
+                text(
+                    "INSERT INTO org_subscriptions (id, org_id, tier, status, provider, currency, checkout_claimed_at) "
+                    "VALUES (:id, :org_id, 'starter', 'pending', 'toss', 'krw', :claimed_at)"
+                ),
+                {"id": uuid.uuid4(), "org_id": org_id, "claimed_at": stale_claim_at},
+            )
+            await session.commit()
+
+            await downgrade_to_free(session, org_id, order_id)
+
+            row = (
+                await session.execute(
+                    text("SELECT tier, status FROM org_subscriptions WHERE org_id=:oid"), {"oid": org_id}
+                )
+            ).first()
+            assert row.tier == "free"  # 죽은 claim은 회복 증거로 안 쳐줌 — 정상 downgrade
+            assert row.status == "active"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_e_2511_downgrade_checkout_claim_realdb.py
+++ b/backend/tests/test_e_2511_downgrade_checkout_claim_realdb.py
@@ -88,6 +88,74 @@ async def test_downgrade_to_free_does_not_clobber_org_with_active_checkout_claim
 
 
 @pytest.mark.anyio
+async def test_downgrade_to_free_write_time_where_catches_claim_landing_after_select_realdb():
+    """카디르 재QA(codex, #2896 리뷰, 2026-08-07) 잔여 TOCTOU 재현+fix 검증 —
+    has_active_checkout_claim SELECT 시점엔 claim이 없었지만, 그 뒤(offering 조회로
+    가는 await 사이) 다른 커넥션이 새 claim을 세우면, SELECT 결과만 믿는 게 아니라
+    free-upsert 자체의 write-time WHERE(원자적 UPSERT 가드)가 이를 잡아야 한다."""
+    from app.services.billing_scheduler import downgrade_to_free
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    claim_engine = create_async_engine(_ASYNC)
+    ClaimSession = async_sessionmaker(claim_engine, expire_on_commit=False)
+
+    try:
+        async with Session() as session:
+            org_id = uuid.uuid4()
+            now = datetime.now(timezone.utc)
+            order_id = await _seed_stale_failed_order(session, org_id=org_id, now=now)
+
+            # claim 없는 상태로 org_subscriptions 행을 먼저 만든다 — has_active_checkout_
+            # claim SELECT는 여기서 False를 본다(TOCTOU의 "SELECT 시점" 스냅샷).
+            await session.execute(
+                text(
+                    "INSERT INTO org_subscriptions (id, org_id, tier, status, provider, currency) "
+                    "VALUES (:id, :org_id, 'starter', 'active', 'toss', 'krw')"
+                ),
+                {"id": uuid.uuid4(), "org_id": org_id},
+            )
+            await session.commit()
+
+            real_execute = session.execute
+            claim_landed = {"done": False}
+
+            async def _paused_execute(stmt, *args, **kwargs):
+                # offering_versions 조회(SELECT 통과 後·UPSERT 前) 직전에 다른 커넥션이
+                # 끼어들어 claim을 세운다 — 정확히 codex가 지적한 그 창.
+                if not claim_landed["done"] and "offering_versions" in str(stmt):
+                    claim_landed["done"] = True
+                    async with ClaimSession() as claim_session:
+                        await claim_session.execute(
+                            text("UPDATE org_subscriptions SET checkout_claimed_at=:t WHERE org_id=:oid"),
+                            {"t": datetime.now(timezone.utc), "oid": org_id},
+                        )
+                        await claim_session.commit()
+                return await real_execute(stmt, *args, **kwargs)
+
+            session.execute = _paused_execute
+            try:
+                await downgrade_to_free(session, org_id, order_id)
+            finally:
+                session.execute = real_execute
+
+            assert claim_landed["done"]  # 정말로 그 창에서 claim이 섰는지 확인(테스트 자체 검증)
+
+            row = (
+                await session.execute(
+                    text("SELECT tier, status, checkout_claimed_at FROM org_subscriptions WHERE org_id=:oid"),
+                    {"oid": org_id},
+                )
+            ).first()
+            # 핵심 단정 — SELECT는 놓쳤어도(TOCTOU) write-time WHERE가 잡아 free로 안 덮였다.
+            assert row.tier == "starter"
+            assert row.checkout_claimed_at is not None  # 새로 선 claim도 그대로 살아있다(안 지워짐)
+    finally:
+        await engine.dispose()
+        await claim_engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_downgrade_to_free_proceeds_when_checkout_claim_is_stale_realdb():
     """staleness를 넘긴(=죽은/멈춘) claim은 무시하고 정상 downgrade — 자기치유 회귀 없음."""
     from app.services.billing_scheduler import downgrade_to_free


### PR DESCRIPTION
## Summary
- 카디르 #2890 결함사냥 재QA 발견: 같은 org의 checkout이 진행 中(Toss 응답 대기)일 때 **다른** tier/cycle로 재제출하면 결정적 order_id가 offering_version_id를 포함해 서로 다른 order_id가 생성되고, C2의 원자적 claim(order_id 단위)이 이 둘을 막지 못해 이론적 이중 청구가 가능했음 (같은 tier/cycle 재시도는 기존에도 안전 — 결정적 order_id로 수렴).
- advisory_xact_lock은 checkout_subscription처럼 여러 번 commit하는 흐름 전체를 못 덮는다(중간 commit마다 락이 풀려 그 틈에 경쟁자가 끼어들 수 있음 — 실측으로 확인). 대신 story #2511 AC 옵션①(서버 정본 pending intent)로 구현: `org_subscriptions.checkout_claimed_at`(마이그 0234, nullable timestamptz)을 WHERE 가드가 걸린 단일 원자적 UPSERT로 claim — 동시 다른 tier/cycle 요청 중 정확히 하나만 성공하고 나머지는 Toss를 한 번도 부르기 전에(issue_billing_key조차) `CheckoutInProgress`(409)로 즉시 거부된다.
- 성공/거절(CheckoutDeclined)/예상 밖 예외 어느 경로든 `finally`에서 claim 해제. `STALE_CLAIM_WINDOW`(3분)가 프로세스 크래시로 인한 영구 락을 자기치유.

## Test plan
- [x] 유닛(mock): claim 성공/rowcount=0 거부(issue_billing_key·charge_org 미호출 확인) — `tests/test_e_2506_subscription_checkout.py`
- [x] 실DB AC1: `asyncio.gather` 진짜 크로스-커넥션(다른 tier/cycle, 카디르 #2890 하네스 재사용) — charge 최대 1회·구독 1개 수렴, 5x 반복 확인
- [x] positive-control: WHERE 가드 임시 제거 → 5/5 재현 실패(양쪽 다 Toss 호출·mock 응답 충돌 KeyError) 확인 後 복원
- [x] 실DB AC2: 순차(비중첩) 다른 tier 재구독은 안 막힘(회귀 0)
- [x] 전체 배터리(mock 128 + realdb 9) + `lint_project_access_403` + `lint_dependency_override_get_read_db` + `test_migrate_env` + `app.main` import + `alembic heads`(단일 head) 전부 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)