### PR TITLE
fix(#2092): 조직 삭제 — impact 조회 실패 상태에서 서버가 거부(P0 보안)

### DIFF
--- a/backend/alembic/versions/0235_deletion_audit_logs_note.py
+++ b/backend/alembic/versions/0235_deletion_audit_logs_note.py
@@ -1,0 +1,24 @@
+"""#2092(P0 보안) — deletion_audit_logs에 note(nullable text) 추가.
+
+조직 삭제가 영향도(impact) 확認 없이(=owner가 명시적으로 「확認하지 못한 상태로
+삭제합니다」를 인정) 진행된 경우, 그 사실 자체가 감사 기록에 남아야 한다(AC3 4번째
+불릿). entity_type을 그 용도로 오버로드하지 않고(향후 다른 엔티티/다른 사유에도
+재사용 가능한 범용 컬럼으로) note 하나를 추가한다 — 순수 additive, 기존 스키마 무회귀.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0235"
+down_revision = "0234"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("deletion_audit_logs", sa.Column("note", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("deletion_audit_logs", "note")

--- a/backend/app/models/deletion_audit.py
+++ b/backend/app/models/deletion_audit.py
@@ -23,6 +23,10 @@ class DeletionAuditLog(Base):
     entity_type: Mapped[str] = mapped_column(Text, nullable=False)
     entity_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
     entity_title: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # #2092: 삭제가 일반 조건(전체 확認 완료)과 다른 특이 사정으로 진행된 경우의 범용 비고란
+    # — 예: 조직 삭제가 영향도(impact) 조회 실패 상태에서 명시적 override로 진행된 경우.
+    # entity_type을 그 용도로 오버로드하지 않는다(엔티티 종류 축과 사유 축은 별개).
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/repositories/organization.py
+++ b/backend/app/repositories/organization.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import uuid
 from dataclasses import dataclass
 
@@ -7,9 +8,12 @@ from sqlalchemy import func, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.deletion_audit import DeletionAuditLog
 from app.models.organization import Organization
 from app.models.participation import ParticipationRole
 from app.models.project import OrgMember, Project
+
+logger = logging.getLogger(__name__)
 
 # SID 265f5b13/#2049 AC1: 신규 조직 생성 직후 참여 역할 세트가 하나도 안 만들어져
 # `resolve_implementation_participation`(app/services/verdict_capture.py:55-63)이 항상
@@ -172,8 +176,23 @@ class OrganizationRepository:
             has_active_subscription=has_active_subscription,
         )
 
-    async def delete_by_user(self, org_id: uuid.UUID, user_id: uuid.UUID, confirmation: str) -> dict:
-        """owner 전용 삭제 — user_id로 직접 권한 검증 + confirmation 문자열 검사."""
+    async def delete_by_user(
+        self, org_id: uuid.UUID, user_id: uuid.UUID, confirmation: str,
+        confirm_without_impact: bool = False,
+    ) -> dict:
+        """owner 전용 삭제 — user_id로 직접 권한 검증 + confirmation 문자열 검사.
+
+        #2092(P0 보안, 유나 발견 2026-07-22) — 이전엔 GET /{id}/impact(영향도 미리보기)와
+        이 삭제 자체가 서버에서 완전히 무관계였다. 화면이 조회 실패 상태에서도 "계속
+        진행해도 됩니다"라고 권했고, 설령 화면 카피를 고쳐도 서버가 impact 조회 성공
+        여부를 아예 안 보므로 API 직접 호출로 그대로 뚫렸다(카피 수정만으론 동작 결함이
+        안 닫힌다는 게 story 원문 핵심).
+
+        fix: 삭제 직전 서버가 **직접** get_impact()를 재조회한다(클라이언트가 "조회
+        실패했다"고 주장하는 걸 신뢰하지 않는다 — 서버 자신의 조회 성패만 신뢰). 그 재조회
+        자체가 실패하면 confirm_without_impact=True(사용자가 "확認하지 못한 상태로
+        삭제합니다"를 명시 인정)가 아닌 한 거부한다. override로 진행된 삭제는
+        DeletionAuditLog.note에 그 사실을 남긴다(AC3 "확認 없이 삭제한 것으로 기록됩니다")."""
         org = await self.get(org_id)
         if org is None:
             return {"ok": False, "reason": "not_found"}
@@ -195,6 +214,23 @@ class OrganizationRepository:
         if sub_check.first() is not None:
             return {"ok": False, "reason": "active_subscription"}
 
+        impact_note: str | None = None
+        try:
+            await self.get_impact(org_id=org_id)
+        except Exception:
+            logger.warning(
+                "org.delete.impact_check_failed org_id=%s confirm_without_impact=%s",
+                org_id, confirm_without_impact, exc_info=True,
+            )
+            if not confirm_without_impact:
+                return {"ok": False, "reason": "impact_unavailable"}
+            impact_note = "영향도(impact) 확認 없이 삭제됨 — 조회 실패 상태에서 사용자가 명시적으로 진행을 인정"
+
+        self.session.add(DeletionAuditLog(
+            id=uuid.uuid4(), org_id=org_id, actor_id=user_id,
+            entity_type="organization", entity_id=org_id, entity_title=org.name,
+            note=impact_note,
+        ))
         await self.session.delete(org)
         return {"ok": True}
 

--- a/backend/app/repositories/organization.py
+++ b/backend/app/repositories/organization.py
@@ -211,8 +211,26 @@ class OrganizationRepository:
         실패했다"고 주장하는 걸 신뢰하지 않는다 — 서버 자신의 조회 성패만 신뢰). 그 재조회
         자체가 실패하면 confirm_without_impact=True(사용자가 "확認하지 못한 상태로
         삭제합니다"를 명시 인정)가 아닌 한 거부한다. override로 진행된 삭제는
-        DeletionAuditLog.note에 그 사실을 남긴다(AC3 "확認 없이 삭제한 것으로 기록됩니다")."""
-        org = await self.get(org_id)
+        DeletionAuditLog.note에 그 사실을 남긴다(AC3 "확認 없이 삭제한 것으로 기록됩니다").
+
+        카디르 결함사냥 TOCTOU-fix(3차 재QA, #2898 리뷰, 2026-08-07) — 이전엔 "재확認"
+        헬퍼 체크가 실제로는 딱 한 번뿐이었고, savepoint로 감싼 두 번째 get_impact()
+        호출은 반환값을 버려("에러 안 났나"만 보는 부작용용) 재확認이 실은 재확認이
+        아니었다. 그 헬퍼 통과~실 delete 사이(여러 statement)에 별도 커넥션이 checkout
+        claim을 UPSERT+commit해도(org_subscriptions.org_id는 organizations에 FK가
+        없어 DB가 이 경쟁을 원천 차단 안 함, READ COMMITTED) 못 잡는 TOCTOU였다.
+
+        근본 fix: org 행 자체를 `FOR UPDATE`로 잠근다(함수 시작, 다른 모든 체크보다
+        먼저) — checkout claim UPSERT 경로(org_subscription_checkout.py)도 자기
+        claim 시작 前에 같은 org 행을 FOR UPDATE로 잠그므로, 이 행을 두고 둘이
+        Postgres 자체의 행 잠금으로 직렬화된다. 어느 쪽이 먼저 잠그든 "창"이 없다 —
+        삭제가 먼저면 checkout이 커밋된 삭제 後 org 없음으로 실패, checkout이 먼저면
+        삭제가 그 lock 해제(=claim 커밋) 後에야 재조회해 "진행 中"을 정확히 본다.
+        재조회(get_impact) 반환값도 이제 실제 게이트로 쓴다(버리지 않는다)."""
+        lock_result = await self.session.execute(
+            select(Organization).where(Organization.id == org_id).with_for_update()
+        )
+        org = lock_result.scalar_one_or_none()
         if org is None:
             return {"ok": False, "reason": "not_found"}
 
@@ -223,24 +241,21 @@ class OrganizationRepository:
         if confirmation != org.name:
             return {"ok": False, "reason": "confirmation_mismatch"}
 
-        if await self._has_active_or_in_flight_subscription(org_id):
-            return {"ok": False, "reason": "active_subscription"}
-
-        # 카디르 결함사냥 HIGH①(#2898 재QA, 2026-08-07) — get_impact()가 진짜 Postgres
-        # 에러(mock RuntimeError가 아니라 실 SQL 에러)로 실패하면 그 커넥션의 트랜잭션
-        # 자체가 "aborted" 상태로 오염된다. override(confirm_without_impact=True)로
-        # 진행해도 그 아래 audit-log insert·org delete가 같은(오염된) 트랜잭션 위에서
-        # 실행되므로 조용히 실패하거나, 이 함수는 {"ok": True}를 반환했는데 실제로는
-        # 아무것도 안 지워지고 라우터의 후속 commit(try/except 없음)에서야 500이 터졌다
-        # — override라는 탈출구가 정작 가장 현실적인 실패(진짜 DB 에러)에서 "깨끗한
+        # 카디르 결함사냥 HIGH①(#2898 2차 재QA, 2026-08-07) — get_impact()가 진짜
+        # Postgres 에러로 실패하면 그 커넥션의 트랜잭션 자체가 "aborted" 상태로
+        # 오염된다. override(confirm_without_impact=True)로 진행해도 그 아래
+        # audit-log insert·org delete가 같은(오염된) 트랜잭션 위에서 실행되므로
+        # 조용히 실패하거나, 이 함수는 {"ok": True}를 반환했는데 실제로는 아무것도
+        # 안 지워지고 라우터의 후속 commit(try/except 없음)에서야 500이 터졌다 —
+        # override라는 탈출구가 정작 가장 현실적인 실패(진짜 DB 에러)에서 "깨끗한
         # 성공도 깨끗한 실패도 아닌 500"이 되는 게 근본 결함. get_impact() 호출을
-        # SAVEPOINT(begin_nested)로 감싸 실패해도 그 실패가 SAVEPOINT 안에서만 롤백되고
-        # 바깥 트랜잭션(이미 끝난 존재/권한/confirmation/구독 체크 포함)은 오염되지 않게
-        # 한다 — 그 아래 audit insert·delete는 항상 깨끗한 트랜잭션 위에서 실행된다.
+        # SAVEPOINT(begin_nested)로 감싸 실패해도 바깥 트랜잭션(FOR UPDATE 락 포함)은
+        # 오염되지 않게 한다 — 그 아래 audit insert·delete는 항상 깨끗한 트랜잭션
+        # 위에서 실행된다.
         impact_note: str | None = None
         try:
             async with self.session.begin_nested():
-                await self.get_impact(org_id=org_id)
+                impact = await self.get_impact(org_id=org_id)
         except Exception:
             logger.warning(
                 "org.delete.impact_check_failed org_id=%s confirm_without_impact=%s",
@@ -249,6 +264,11 @@ class OrganizationRepository:
             if not confirm_without_impact:
                 return {"ok": False, "reason": "impact_unavailable"}
             impact_note = "영향도(impact) 확認 없이 삭제됨 — 조회 실패 상태에서 사용자가 명시적으로 진행을 인정"
+        else:
+            # 반환값을 실제로 쓴다 — FOR UPDATE로 잠근 이 시점 기준 최신 상태(checkout이
+            # 락 대기 中이었다면 이 재조회 前에 이미 커밋 완료된 뒤이므로 여기 반영됨).
+            if impact.has_active_subscription:
+                return {"ok": False, "reason": "active_subscription"}
 
         self.session.add(DeletionAuditLog(
             id=uuid.uuid4(), org_id=org_id, actor_id=user_id,

--- a/backend/app/repositories/organization.py
+++ b/backend/app/repositories/organization.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import uuid
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 from sqlalchemy import func, select, text
 from sqlalchemy.exc import IntegrityError
@@ -12,6 +13,7 @@ from app.models.deletion_audit import DeletionAuditLog
 from app.models.organization import Organization
 from app.models.participation import ParticipationRole
 from app.models.project import OrgMember, Project
+from app.services.org_subscription_checkout import STALE_CLAIM_WINDOW
 
 logger = logging.getLogger(__name__)
 
@@ -143,8 +145,32 @@ class OrganizationRepository:
         await self.session.refresh(org)
         return org
 
+    async def _has_active_or_in_flight_subscription(self, org_id: uuid.UUID) -> bool:
+        """구독 status='active'뿐 아니라 #2511(결제②-D후속) checkout_claimed_at이
+        STALE_CLAIM_WINDOW 안(=진행 中)인 claim도 "활성"으로 취급한다.
+
+        카디르 결함사냥 HIGH②(#2898 재QA, 2026-08-07) — checkout claim 성공 直後(구독
+        status는 아직 'pending', active 아님)의 그 창에서는 이 체크가 놓쳤다: org 삭제가
+        (구독 status='active' 아님이라) 통과해버리면, 뒤늦게 그 checkout의 charge가
+        confirmed돼도 org가 이미 사라진 뒤라 **삭제된 org에 실 청구가 완료**될 수 있었다
+        (#2896 step④ CAS는 org_id 매칭이라 org 삭제 자체는 못 막는 축). #2511과 동일
+        STALE_CLAIM_WINDOW/SSOT로 "진행 中"을 판정 — 죽은/멈춘(stale) claim은 여전히
+        무시(자기치유 회귀 없음)."""
+        now = datetime.now(timezone.utc)
+        row = await self.session.execute(
+            text(
+                "SELECT 1 FROM org_subscriptions WHERE org_id = :org_id AND ("
+                " status = 'active'"
+                " OR (checkout_claimed_at IS NOT NULL AND checkout_claimed_at >= :stale_cutoff)"
+                ") LIMIT 1"
+            ),
+            {"org_id": str(org_id), "stale_cutoff": now - STALE_CLAIM_WINDOW},
+        )
+        return row.first() is not None
+
     async def get_impact(self, org_id: uuid.UUID) -> OrgImpact:
-        """삭제 전 영향도 조회 — project 수, member 수, 활성 subscription 여부."""
+        """삭제 전 영향도 조회 — project 수, member 수, 활성(또는 진행 中 checkout claim)
+        subscription 여부."""
         proj_count_row = await self.session.execute(
             select(func.count()).select_from(Project).where(
                 Project.org_id == org_id,
@@ -161,14 +187,7 @@ class OrganizationRepository:
         )
         member_count = member_count_row.scalar() or 0
 
-        sub_row = await self.session.execute(
-            text(
-                "SELECT 1 FROM org_subscriptions"
-                " WHERE org_id = :org_id AND status = 'active' LIMIT 1"
-            ),
-            {"org_id": str(org_id)},
-        )
-        has_active_subscription = sub_row.first() is not None
+        has_active_subscription = await self._has_active_or_in_flight_subscription(org_id)
 
         return OrgImpact(
             project_count=project_count,
@@ -204,19 +223,24 @@ class OrganizationRepository:
         if confirmation != org.name:
             return {"ok": False, "reason": "confirmation_mismatch"}
 
-        sub_check = await self.session.execute(
-            text(
-                "SELECT 1 FROM org_subscriptions"
-                " WHERE org_id = :org_id AND status = 'active' LIMIT 1"
-            ),
-            {"org_id": str(org_id)},
-        )
-        if sub_check.first() is not None:
+        if await self._has_active_or_in_flight_subscription(org_id):
             return {"ok": False, "reason": "active_subscription"}
 
+        # 카디르 결함사냥 HIGH①(#2898 재QA, 2026-08-07) — get_impact()가 진짜 Postgres
+        # 에러(mock RuntimeError가 아니라 실 SQL 에러)로 실패하면 그 커넥션의 트랜잭션
+        # 자체가 "aborted" 상태로 오염된다. override(confirm_without_impact=True)로
+        # 진행해도 그 아래 audit-log insert·org delete가 같은(오염된) 트랜잭션 위에서
+        # 실행되므로 조용히 실패하거나, 이 함수는 {"ok": True}를 반환했는데 실제로는
+        # 아무것도 안 지워지고 라우터의 후속 commit(try/except 없음)에서야 500이 터졌다
+        # — override라는 탈출구가 정작 가장 현실적인 실패(진짜 DB 에러)에서 "깨끗한
+        # 성공도 깨끗한 실패도 아닌 500"이 되는 게 근본 결함. get_impact() 호출을
+        # SAVEPOINT(begin_nested)로 감싸 실패해도 그 실패가 SAVEPOINT 안에서만 롤백되고
+        # 바깥 트랜잭션(이미 끝난 존재/권한/confirmation/구독 체크 포함)은 오염되지 않게
+        # 한다 — 그 아래 audit insert·delete는 항상 깨끗한 트랜잭션 위에서 실행된다.
         impact_note: str | None = None
         try:
-            await self.get_impact(org_id=org_id)
+            async with self.session.begin_nested():
+                await self.get_impact(org_id=org_id)
         except Exception:
             logger.warning(
                 "org.delete.impact_check_failed org_id=%s confirm_without_impact=%s",
@@ -234,31 +258,10 @@ class OrganizationRepository:
         await self.session.delete(org)
         return {"ok": True}
 
-    async def delete(self, org_id: uuid.UUID, requester_member_id: uuid.UUID) -> dict:
-        org = await self.get(org_id)
-        if org is None:
-            return {"ok": False, "reason": "not_found"}
-
-        owner_check = await self.session.execute(
-            text(
-                "SELECT 1 FROM org_members om"
-                " JOIN team_members tm ON tm.user_id = om.user_id"
-                " WHERE om.org_id = :org_id AND tm.id = :member_id AND om.role = 'owner'"
-            ),
-            {"org_id": str(org_id), "member_id": str(requester_member_id)},
-        )
-        if owner_check.first() is None:
-            return {"ok": False, "reason": "forbidden"}
-
-        sub_check = await self.session.execute(
-            text(
-                "SELECT 1 FROM org_subscriptions"
-                " WHERE org_id = :org_id AND status = 'active' LIMIT 1"
-            ),
-            {"org_id": str(org_id)},
-        )
-        if sub_check.first() is not None:
-            return {"ok": False, "reason": "active_subscription"}
-
-        await self.session.delete(org)
-        return {"ok": True}
+    # #2092(카디르 결함사냥, #2898 리뷰, 2026-08-07) — 구 delete(org_id, requester_member_id)
+    # 메서드를 제거했다. 이 fix가 새로 만든 안전장치(impact 재조회+savepoint 격리·human-only
+    # 강제(라우터)·checkout_claimed_at 인지·DeletionAuditLog 기입) 전부가 이 메서드에는
+    # 하나도 없었다 — 호출부가 현재 0곳(grep 확認, 죽은 코드)이지만, 살려두면 향후 누군가
+    # "더 짧으니까" 실수로 이걸 다시 배선해 이번 fix 전체를 조용히 무력화하는 "부활 경로"가
+    # 된다. 그 경로 자체를 없앤다 — private화(밑줄)가 아니라 삭제, 죽은 트랩은 존재 자체가
+    # 위험이라 남겨둘 이유가 없다.

--- a/backend/app/routers/organizations.py
+++ b/backend/app/routers/organizations.py
@@ -226,11 +226,27 @@ async def delete_organization(
     repo: OrganizationRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
 ) -> dict:
-    """Organization 삭제 — owner만 가능, org name 확인 입력 필수."""
+    """Organization 삭제 — owner만 가능, org name 확인 입력 필수.
+
+    #2092(P0 보안) — human-only 강제: project.py/docs.py 등 다른 파괴적 삭제 엔드포인트와
+    동형(org_members는 human 전용 테이블이라 사실상 이미 막혀 있었으나, story #2058 축과
+    같은 이유로 암묵적 부산물에 기대지 않고 명시 확認한다). org owner 판정(get_member_role)
+    보다 뒤에 두는 이유는 존재/권한 판정이 더 근본적이라 우선하기 때문 — 순서를 바꾸면
+    "org 없음"인데 "휴먼만 가능" 오류가 먼저 뜨는 오정보가 될 수 있다."""
+    from app.services.member_resolver import resolve_member
+
+    org_id = id
+    role = await repo.get_member_role(org_id=org_id, user_id=uuid.UUID(auth.user_id))
+    if role == "owner":
+        resolved = await resolve_member(auth, org_id, session)
+        if resolved.type != "human":
+            raise HTTPException(status_code=403, detail="조직 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)")
+
     result = await repo.delete_by_user(
-        org_id=id,
+        org_id=org_id,
         user_id=uuid.UUID(auth.user_id),
         confirmation=body.confirmation,
+        confirm_without_impact=body.confirm_without_impact,
     )
     if not result["ok"]:
         reason = result.get("reason")
@@ -242,5 +258,13 @@ async def delete_organization(
             raise HTTPException(status_code=422, detail="Confirmation does not match organization name")
         if reason == "active_subscription":
             raise HTTPException(status_code=409, detail="Cannot delete organization with active subscription")
+        if reason == "impact_unavailable":
+            # #2092 AC1/AC3 — FE는 이 reason으로 "재시도" 또는 "확認 없이 삭제" 탈출구
+            # UI를 띄운다(confirm_without_impact=True로 재호출). detail 문자열 자체는
+            # 계약이 아니다 — 정확한 사용자 카피는 FE(유나 규격)가 진다.
+            raise HTTPException(
+                status_code=409,
+                detail="Impact preview unavailable — retry, or resubmit with confirm_without_impact=true to proceed without it",
+            )
     await session.commit()
     return {"ok": True}

--- a/backend/app/schemas/organization.py
+++ b/backend/app/schemas/organization.py
@@ -55,3 +55,10 @@ class OrgImpactResponse(BaseModel):
 
 class DeleteOrganization(BaseModel):
     confirmation: str
+    # #2092 AC1/AC3 — 서버가 삭제 직전 자체적으로 영향도(impact)를 재조회한다(클라이언트가
+    # "조회에 실패했다"고 주장하는 걸 신뢰하지 않는다 — "금지는 서버가 거부" 축). 그 재조회
+    # 자체가 실패했을 때만 이 필드가 의미를 갖는다: False(기본)면 즉시 거부(reason=
+    # "impact_unavailable")하고, 사용자가 명시적으로 "확認하지 못한 상태로 삭제합니다"를
+    # 인정한 뒤에만(=True) 진행을 허용한다. 영향도 재조회가 정상 성공하면 이 필드 값과
+    # 무관하게(True로 와도) 무시 — 그 경우 원래도 override가 필요 없다.
+    confirm_without_impact: bool = False

--- a/backend/app/services/org_subscription_checkout.py
+++ b/backend/app/services/org_subscription_checkout.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import or_, select, update
+from sqlalchemy import or_, select, text, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -113,6 +113,19 @@ async def checkout_subscription(
 
     now = datetime.now(timezone.utc)
     period_start, period_end = new_subscription_period(now=now, billing_cycle=billing_cycle)
+
+    # 카디르 결함사냥 TOCTOU-fix(#2898 3차 재QA, 2026-08-07) — org_subscriptions.org_id는
+    # organizations에 FK가 없어(provider-agnostic 구조, #2471 A1) DB가 "이 org가 지금
+    # 삭제 진행 中인가"를 write 시점에 원천 차단하지 못한다. 이 claim UPSERT와 #2092의
+    # 조직 삭제(organizations 행 FOR UPDATE)를 **같은 org 행 위에서 직렬화**한다 — 삭제가
+    # 먼저 이 행을 잠그면 이 SELECT가 대기하다 삭제 커밋 後 0행(org 없음)으로 실패해
+    # 죽은 org에 claim이 서는 걸 원천에서 막는다. 이 claim이 먼저면 삭제 쪽 FOR UPDATE가
+    # 대기하다 이 UPSERT 커밋 後에야 재조회하므로 "진행 中"을 놓치지 않는다.
+    org_exists = await session.execute(
+        text("SELECT 1 FROM organizations WHERE id = :org_id FOR UPDATE"), {"org_id": str(org_id)},
+    )
+    if org_exists.first() is None:
+        raise CheckoutError(f"org_id={org_id} 조직을 찾을 수 없음")
 
     # ⭐#2511 — 원자적 claim(=② 구독을 'pending'으로 생성/전이를 겸한다). WHERE 가드가
     # 걸린 단일 UPSERT라 동시에 여러 tier/cycle이 도착해도 Postgres 행단위 write

--- a/backend/tests/test_e_2092_org_delete_impact_guard_realdb.py
+++ b/backend/tests/test_e_2092_org_delete_impact_guard_realdb.py
@@ -311,3 +311,173 @@ async def test_get_impact_reflects_in_flight_checkout_claim_realdb():
             assert impact.has_active_subscription is True
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_delete_vs_checkout_claim_real_race_no_window_realdb():
+    """카디르 3차 재QA 요청(#2898 리뷰, 2026-08-07) — 두 커넥션 **실경쟁**(asyncio.gather,
+    이벤트로 스테이징하지 않음 — 순서를 강제하지 않고 Postgres 자체의 FOR UPDATE 행잠금이
+    직렬화하는지를 실증)으로 #2092 조직삭제와 #2511/#2896 checkout claim UPSERT 사이
+    TOCTOU 창이 실제로 닫혔는지 확認한다.
+
+    organizations 행 FOR UPDATE로 양쪽이 직렬화되므로, 어느 쪽이 이기든 다음 불변식이
+    항상 성립해야 한다 — 결과가 모순(둘 다 성공 또는 판정 불일치)이면 안 된다:
+    ①org가 삭제됐다 ⟹ checkout은 CheckoutError로 실패(claim조차 못 섬)
+    ②org가 살아있다 ⟹ delete_by_user는 반드시 reason=active_subscription으로 거부
+
+    타이밍을 강제하지 않으므로 여러 회 반복해 두 순서(delete 먼저/checkout 먼저) 다
+    실제로 일어날 확률을 높인다."""
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    from app.repositories.organization import OrganizationRepository
+    from app.services.org_subscription_checkout import CheckoutError, checkout_subscription
+
+    for i in range(8):
+        engine_a = create_async_engine(_ASYNC)
+        engine_b = create_async_engine(_ASYNC)
+        Session_a = async_sessionmaker(engine_a, expire_on_commit=False)
+        Session_b = async_sessionmaker(engine_b, expire_on_commit=False)
+        seed_engine = create_async_engine(_ASYNC)
+        try:
+            async with async_sessionmaker(seed_engine, expire_on_commit=False)() as seed_session:
+                org_id, user_id, org_name = await _seed_org_with_owner(seed_session)
+
+            toss_billing_key_response = {
+                "billingKey": f"billing-key-race-{i}",
+                "card": {"issuerCode": "61", "acquirerCode": "31", "number": "12345678****000*", "cardType": "신용", "ownerType": "개인"},
+                "authenticatedAt": "2026-08-07T00:00:00+09:00",
+            }
+            toss_charge_response = {"paymentKey": f"pay-race-{i}-{uuid.uuid4()}", "totalAmount": 5_000}
+
+            async def _run_checkout():
+                async with Session_a() as session:
+                    with patch("app.services.payment.toss_adapter.TossAdapter._post", new=AsyncMock(
+                        side_effect=[toss_billing_key_response, toss_charge_response]
+                    )):
+                        try:
+                            sub = await checkout_subscription(
+                                session, org_id=org_id, auth_key=f"ak-race-{i}",
+                                tier="starter", billing_cycle="monthly",
+                            )
+                            return ("ok", sub.status)
+                        except CheckoutError as exc:
+                            return ("checkout_error", str(exc))
+                        except Exception as exc:  # CheckoutInProgress·CheckoutDeclined 등 — 이 테스트 관심사 아님
+                            return ("other_failure", str(exc))
+
+            async def _run_delete():
+                async with Session_b() as session:
+                    repo = OrganizationRepository(session)
+                    result = await repo.delete_by_user(org_id=org_id, user_id=user_id, confirmation=org_name)
+                    await session.commit()
+                    return result
+
+            checkout_result, delete_result = await asyncio.gather(_run_checkout(), _run_delete())
+
+            verify_engine = create_async_engine(_ASYNC)
+            try:
+                async with async_sessionmaker(verify_engine, expire_on_commit=False)() as vs:
+                    org_row = (
+                        await vs.execute(text("SELECT id FROM organizations WHERE id=:oid"), {"oid": org_id})
+                    ).first()
+                    org_deleted = org_row is None
+            finally:
+                await verify_engine.dispose()
+
+            if org_deleted:
+                assert delete_result["ok"] is True, f"iter{i}: org 삭제됐는데 delete_result={delete_result}"
+                assert checkout_result[0] != "ok", (
+                    f"iter{i}: 모순 — org가 삭제됐는데 checkout도 성공(claim이 죽은 org에 섬): {checkout_result}"
+                )
+            else:
+                assert delete_result == {"ok": False, "reason": "active_subscription"}, (
+                    f"iter{i}: 모순 — org가 살아있는데 delete가 active_subscription으로 안 막음: {delete_result}"
+                )
+        finally:
+            await engine_a.dispose()
+            await engine_b.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_delete_vs_checkout_claim_deterministic_staged_race_realdb():
+    """카디르 3차 재QA — 결정론적 스테이징으로 정확히 위험했던 그 순서(delete가 impact
+    체크를 통과한 直後·아직 커밋 前 그 사이로 checkout claim이 끼어드는지)를 강제
+    재현한다. fix(FOR UPDATE) 前엔 checkout의 claim UPSERT가 delete의 락과 무관하게
+    즉시 진행돼버렸다(위 비결정론적 실경쟁 테스트가 못 잡을 만큼 창이 좁았다 — 로컬
+    라운드트립이 빨라 우연히 안전한 순서로만 끝나곤 했음, 실측 확認). fix 後엔
+    checkout의 FOR UPDATE 시도 자체가 delete가 그 org 행 락을 쥐고 있는 한 반드시
+    block돼야 한다 — "안 끝난다"는 것 자체를 타임아웃으로 직접 증명한다."""
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    from app.repositories.organization import OrganizationRepository
+    from app.services.org_subscription_checkout import checkout_subscription
+
+    engine_a = create_async_engine(_ASYNC)
+    engine_b = create_async_engine(_ASYNC)
+    Session_a = async_sessionmaker(engine_a, expire_on_commit=False)  # delete
+    Session_b = async_sessionmaker(engine_b, expire_on_commit=False)  # checkout
+    seed_engine = create_async_engine(_ASYNC)
+    try:
+        async with async_sessionmaker(seed_engine, expire_on_commit=False)() as seed_session:
+            org_id, user_id, org_name = await _seed_org_with_owner(seed_session)
+
+        impact_checked = asyncio.Event()    # delete가 impact 체크(FOR UPDATE 락 보유 中)를 통과했다.
+        delete_may_finish = asyncio.Event()  # 테스트가 delete에게 "이제 커밋해도 된다"를 허가.
+
+        real_get_impact = OrganizationRepository.get_impact
+
+        async def _paced_get_impact(self, org_id):
+            result = await real_get_impact(self, org_id=org_id)
+            impact_checked.set()
+            # FOR UPDATE 락을 계속 쥔 채 대기 — 바로 이 구간이 fix 前엔 checkout이
+            # 자유롭게 끼어들 수 있던 그 창(재확認 直後~실 delete/commit 前).
+            await delete_may_finish.wait()
+            return result
+
+        async def _run_delete():
+            async with Session_a() as session:
+                with patch.object(OrganizationRepository, "get_impact", _paced_get_impact):
+                    repo = OrganizationRepository(session)
+                    result = await repo.delete_by_user(org_id=org_id, user_id=user_id, confirmation=org_name)
+                    await session.commit()
+                    return result
+
+        async def _run_checkout():
+            await impact_checked.wait()  # delete가 impact 체크를 통과(그러나 아직 커밋 前, 락 보유 中)한 뒤에 시작.
+            async with Session_b() as session:
+                with patch("app.services.payment.toss_adapter.TossAdapter._post", new=AsyncMock(side_effect=[
+                    {
+                        "billingKey": "billing-key-staged", "card": {"issuerCode": "61", "acquirerCode": "31", "number": "12345678****000*", "cardType": "신용", "ownerType": "개인"},
+                        "authenticatedAt": "2026-08-07T00:00:00+09:00",
+                    },
+                    {"paymentKey": f"pay-staged-{uuid.uuid4()}", "totalAmount": 5_000},
+                ])):
+                    try:
+                        sub = await checkout_subscription(
+                            session, org_id=org_id, auth_key="ak-staged", tier="starter", billing_cycle="monthly",
+                        )
+                        return ("ok", sub.status)
+                    except Exception as exc:
+                        return ("failed", str(exc))
+
+        delete_task = asyncio.ensure_future(_run_delete())
+        checkout_task = asyncio.ensure_future(_run_checkout())
+
+        await impact_checked.wait()  # delete가 impact 체크를 통과할 때까지(FOR UPDATE 락 보유 中) 대기.
+
+        # 핵심 검증 — delete가 아직 커밋 前(락 보유 中)인 동안 checkout은 그 락에 막혀
+        # 완결되지 못해야 한다(짧은 타임아웃 안에 안 끝남 = 진짜로 blocked됨을 직접 증명).
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(checkout_task), timeout=0.5)
+
+        delete_may_finish.set()  # 이제 delete가 커밋하도록 허가.
+        delete_result, checkout_result = await asyncio.gather(delete_task, checkout_task)
+
+        assert delete_result == {"ok": True}
+        assert checkout_result[0] == "failed"
+        assert "찾을 수 없음" in checkout_result[1]  # 락 해제 後 org 없음으로 실패(claim 못 섬) — 죽은 org에 claim 안 섬
+    finally:
+        await engine_a.dispose()
+        await engine_b.dispose()

--- a/backend/tests/test_e_2092_org_delete_impact_guard_realdb.py
+++ b/backend/tests/test_e_2092_org_delete_impact_guard_realdb.py
@@ -1,0 +1,147 @@
+"""#2092(P0 보안) real-DB — OrganizationRepository.delete_by_user()의 impact 재조회 가드를
+실 organizations/deletion_audit_logs 위에서 검증. "파괴 조작이라 실측까지"(PO 지시,
+2026-08-07) — 진짜 Postgres에 대고 ①거부 시 org가 실제로 살아남는지 ②override 시 실제로
+삭제되고 감사로그에 note가 남는지 ③정상(impact 성공) 시 종전과 동일하게 동작하는지 확認.
+
+DB env(ALEMBIC_DATABASE_URL) 없으면 skip — 로컬 PG(alembic upgrade head 적용된 DB) 전제."""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _seed_org_with_owner(session):
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    org_name = f"test-org-{org_id}"
+    await session.execute(
+        text("INSERT INTO organizations (id, name, slug, plan) VALUES (:id, :name, :slug, 'free')"),
+        {"id": org_id, "name": org_name, "slug": f"slug-{org_id}"},
+    )
+    await session.execute(
+        text("INSERT INTO org_members (id, org_id, user_id, role) VALUES (:id, :org_id, :user_id, 'owner')"),
+        {"id": uuid.uuid4(), "org_id": org_id, "user_id": user_id},
+    )
+    await session.commit()
+    return org_id, user_id, org_name
+
+
+@pytest.mark.anyio
+async def test_delete_rejected_realdb_org_survives_when_impact_query_fails_and_no_override():
+    from app.repositories.organization import OrganizationRepository
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id, user_id, org_name = await _seed_org_with_owner(session)
+            repo = OrganizationRepository(session)
+
+            with patch.object(repo, "get_impact", side_effect=RuntimeError("simulated impact query failure")):
+                result = await repo.delete_by_user(org_id=org_id, user_id=user_id, confirmation=org_name)
+            await session.commit()
+
+            assert result == {"ok": False, "reason": "impact_unavailable"}
+
+            row = (
+                await session.execute(
+                    text("SELECT id FROM organizations WHERE id=:oid"), {"oid": org_id}
+                )
+            ).first()
+            assert row is not None  # 거부됐으므로 org는 실제로 살아있어야 한다(파괴 안 됨)
+
+            audit_count = (
+                await session.execute(
+                    text("SELECT COUNT(*) FROM deletion_audit_logs WHERE entity_id=:oid"), {"oid": org_id}
+                )
+            ).scalar_one()
+            assert audit_count == 0  # 거부됐으므로 감사로그도 안 남는다(진행 자체가 안 됐음)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_delete_proceeds_realdb_org_removed_and_audit_note_recorded_with_override():
+    from app.repositories.organization import OrganizationRepository
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id, user_id, org_name = await _seed_org_with_owner(session)
+            repo = OrganizationRepository(session)
+
+            with patch.object(repo, "get_impact", side_effect=RuntimeError("simulated impact query failure")):
+                result = await repo.delete_by_user(
+                    org_id=org_id, user_id=user_id, confirmation=org_name, confirm_without_impact=True,
+                )
+            await session.commit()
+
+            assert result == {"ok": True}
+
+            org_row = (
+                await session.execute(text("SELECT id FROM organizations WHERE id=:oid"), {"oid": org_id})
+            ).first()
+            assert org_row is None  # override로 진행됐으므로 실제로 삭제됨
+
+            audit_row = (
+                await session.execute(
+                    text("SELECT actor_id, entity_type, note FROM deletion_audit_logs WHERE entity_id=:oid"),
+                    {"oid": org_id},
+                )
+            ).first()
+            assert audit_row is not None
+            assert audit_row.actor_id == user_id
+            assert audit_row.entity_type == "organization"
+            assert audit_row.note is not None and "확認 없이" in audit_row.note
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_delete_proceeds_realdb_normal_path_no_audit_note_when_impact_succeeds():
+    from app.repositories.organization import OrganizationRepository
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id, user_id, org_name = await _seed_org_with_owner(session)
+            repo = OrganizationRepository(session)
+
+            result = await repo.delete_by_user(org_id=org_id, user_id=user_id, confirmation=org_name)
+            await session.commit()
+
+            assert result == {"ok": True}
+
+            org_row = (
+                await session.execute(text("SELECT id FROM organizations WHERE id=:oid"), {"oid": org_id})
+            ).first()
+            assert org_row is None
+
+            audit_row = (
+                await session.execute(
+                    text("SELECT note FROM deletion_audit_logs WHERE entity_id=:oid"), {"oid": org_id}
+                )
+            ).first()
+            assert audit_row is not None
+            assert audit_row.note is None  # 정상 경로 — override 사유 없음
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_e_2092_org_delete_impact_guard_realdb.py
+++ b/backend/tests/test_e_2092_org_delete_impact_guard_realdb.py
@@ -116,6 +116,70 @@ async def test_delete_proceeds_realdb_org_removed_and_audit_note_recorded_with_o
 
 
 @pytest.mark.anyio
+async def test_delete_with_override_survives_real_postgres_transaction_abort_realdb():
+    """카디르 결함사냥 HIGH①(#2898 재QA, 2026-08-07) 재현+fix 검증 — 순수 Python
+    RuntimeError mock이 아니라 **진짜 Postgres 에러**(존재하지 않는 테이블 참조 →
+    UndefinedTable, asyncpg가 그 커넥션의 트랜잭션을 실제로 "aborted" 상태로 만든다)로
+    get_impact()를 실패시킨다. fix(savepoint) 前엔 override로 진행해도 그 아래
+    audit-insert·org-delete가 오염된 트랜잭션 위에서 실행돼 깨끗한 성공도 실패도 아닌
+    상태가 됐다 — fix 後엔 SAVEPOINT가 그 실패를 격리해 override 진행이 실제로 끝까지
+    깨끗하게 성공(org 삭제+audit 기입)해야 한다."""
+    from sqlalchemy.exc import DBAPIError
+
+    from app.repositories.organization import OrganizationRepository
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id, user_id, org_name = await _seed_org_with_owner(session)
+            repo = OrganizationRepository(session)
+
+            async def _broken_get_impact(org_id):
+                # 진짜 Postgres 에러 — 존재하지 않는 테이블 참조. asyncpg가 이 커넥션의
+                # 현재 트랜잭션을 실제로 aborted 상태로 만든다(mock RuntimeError로는
+                # 재현 불가능한 축).
+                await session.execute(text("SELECT * FROM this_table_does_not_exist_2092"))
+
+            with patch.object(repo, "get_impact", side_effect=_broken_get_impact):
+                try:
+                    result = await repo.delete_by_user(
+                        org_id=org_id, user_id=user_id, confirmation=org_name, confirm_without_impact=True,
+                    )
+                except DBAPIError:
+                    pytest.fail(
+                        "savepoint 격리 실패 — get_impact()의 진짜 Postgres 에러가 바깥 "
+                        "트랜잭션까지 오염시켜 audit-insert/delete가 aborted 트랜잭션 위에서 "
+                        "실행되며 예외로 전파됨(fix 前 재현 정확히 이 형태)"
+                    )
+                await session.commit()
+
+            assert result == {"ok": True}
+
+            verify_engine = create_async_engine(_ASYNC)
+            try:
+                async with async_sessionmaker(verify_engine, expire_on_commit=False)() as verify_session:
+                    org_row = (
+                        await verify_session.execute(
+                            text("SELECT id FROM organizations WHERE id=:oid"), {"oid": org_id}
+                        )
+                    ).first()
+                    assert org_row is None  # 진짜로, 완전히 삭제됨(부분실패 아님)
+
+                    audit_row = (
+                        await verify_session.execute(
+                            text("SELECT note FROM deletion_audit_logs WHERE entity_id=:oid"), {"oid": org_id}
+                        )
+                    ).first()
+                    assert audit_row is not None
+                    assert audit_row.note is not None and "확認 없이" in audit_row.note
+            finally:
+                await verify_engine.dispose()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_delete_proceeds_realdb_normal_path_no_audit_note_when_impact_succeeds():
     from app.repositories.organization import OrganizationRepository
 
@@ -143,5 +207,107 @@ async def test_delete_proceeds_realdb_normal_path_no_audit_note_when_impact_succ
             ).first()
             assert audit_row is not None
             assert audit_row.note is None  # 정상 경로 — override 사유 없음
+    finally:
+        await engine.dispose()
+
+
+# ─── 카디르 결함사냥 HIGH②(#2898 재QA, 2026-08-07) — checkout_claimed_at 인지 ────
+
+async def _insert_pending_subscription_with_claim(session, *, org_id, claimed_at):
+    await session.execute(
+        text(
+            "INSERT INTO org_subscriptions (id, org_id, tier, status, provider, currency, checkout_claimed_at) "
+            "VALUES (:id, :org_id, 'starter', 'pending', 'toss', 'krw', :claimed_at)"
+        ),
+        {"id": uuid.uuid4(), "org_id": org_id, "claimed_at": claimed_at},
+    )
+    await session.commit()
+
+
+@pytest.mark.anyio
+async def test_delete_rejected_when_checkout_in_flight_realdb():
+    """진행 中(staleness 안 넘긴) checkout claim이 있으면(구독 status는 아직 'pending' —
+    'active' 아님) org 삭제를 거부한다 — #2896의 checkout_claimed_at 진행 中 claim을
+    「활성 구독」과 동형으로 취급(reason=active_subscription 재사용). fix 前엔 이 창에서
+    org가 삭제되고, 뒤늦게 그 checkout의 charge가 confirmed돼도 org가 이미 사라진 뒤라
+    삭제된 org에 실 청구가 완료될 수 있었다."""
+    from datetime import datetime, timezone
+
+    from app.repositories.organization import OrganizationRepository
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id, user_id, org_name = await _seed_org_with_owner(session)
+            await _insert_pending_subscription_with_claim(
+                session, org_id=org_id, claimed_at=datetime.now(timezone.utc)
+            )
+            repo = OrganizationRepository(session)
+
+            result = await repo.delete_by_user(org_id=org_id, user_id=user_id, confirmation=org_name)
+            await session.commit()
+
+            assert result == {"ok": False, "reason": "active_subscription"}
+
+            org_row = (
+                await session.execute(text("SELECT id FROM organizations WHERE id=:oid"), {"oid": org_id})
+            ).first()
+            assert org_row is not None  # 거부됐으므로 org는 살아있어야 한다
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_delete_proceeds_when_checkout_claim_is_stale_realdb():
+    """staleness를 넘긴(=죽은/멈춘) checkout claim은 「진행 中」으로 안 쳐준다 —
+    자기치유 회귀 없음(영원히 삭제 불가능한 org가 생기면 안 됨)."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.repositories.organization import OrganizationRepository
+    from app.services.org_subscription_checkout import STALE_CLAIM_WINDOW
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id, user_id, org_name = await _seed_org_with_owner(session)
+            stale_claim_at = datetime.now(timezone.utc) - STALE_CLAIM_WINDOW - timedelta(minutes=1)
+            await _insert_pending_subscription_with_claim(session, org_id=org_id, claimed_at=stale_claim_at)
+            repo = OrganizationRepository(session)
+
+            result = await repo.delete_by_user(org_id=org_id, user_id=user_id, confirmation=org_name)
+            await session.commit()
+
+            assert result == {"ok": True}  # 죽은 claim은 회복 증거로 안 쳐줌 — 정상 삭제
+
+            org_row = (
+                await session.execute(text("SELECT id FROM organizations WHERE id=:oid"), {"oid": org_id})
+            ).first()
+            assert org_row is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_impact_reflects_in_flight_checkout_claim_realdb():
+    """get_impact()의 has_active_subscription 필드(FE 표시용)도 진행 中 checkout claim을
+    반영해야 한다 — 삭제 거부 판정과 사용자에게 보여주는 정보가 어긋나면 안 된다."""
+    from datetime import datetime, timezone
+
+    from app.repositories.organization import OrganizationRepository
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id, user_id, org_name = await _seed_org_with_owner(session)
+            await _insert_pending_subscription_with_claim(
+                session, org_id=org_id, claimed_at=datetime.now(timezone.utc)
+            )
+            repo = OrganizationRepository(session)
+
+            impact = await repo.get_impact(org_id=org_id)
+            assert impact.has_active_subscription is True
     finally:
         await engine.dispose()

--- a/backend/tests/test_e_2506_subscription_checkout.py
+++ b/backend/tests/test_e_2506_subscription_checkout.py
@@ -72,11 +72,50 @@ async def test_checkout_raises_when_offering_not_found():
         )
 
 
+@pytest.mark.anyio
+async def test_checkout_raises_when_org_lock_finds_no_row():
+    """#2092 TOCTOU-fix(3차, #2898 리뷰) — organizations FOR UPDATE 락-SELECT가 0행이면
+    (delete가 그 사이 이 org를 삭제·커밋했다는 뜻) 명시 실패한다. issue_billing_key/
+    charge_org 둘 다 호출 안 함(claim 자체를 시도 안 함)."""
+    from app.services.org_subscription_checkout import CheckoutError, checkout_subscription
+
+    org_id = uuid.uuid4()
+    offering = _offering(tier="team")
+
+    no_org_result = MagicMock()
+    no_org_result.first.return_value = None
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[
+        _exec_result(offering),  # ① offering lookup
+        no_org_result,           # #2092 — org FOR UPDATE 락-SELECT가 0행(삭제됨)
+    ])
+
+    with patch("app.services.org_subscription_checkout.issue_billing_key", new=AsyncMock()) as mock_issue, \
+         patch("app.services.org_subscription_checkout.charge_org", new=AsyncMock()) as mock_charge:
+        with pytest.raises(CheckoutError, match="찾을 수 없음"):
+            await checkout_subscription(
+                session, org_id=org_id, auth_key="ak-y", tier="team", billing_cycle="monthly",
+            )
+
+    mock_issue.assert_not_awaited()
+    mock_charge.assert_not_awaited()
+
+
 # ─── checkout_subscription — 상태기계 happy path ────────────────────────────
 
 def _claim_result(rowcount=1):
     r = MagicMock()
     r.rowcount = rowcount
+    return r
+
+
+def _org_exists_result():
+    """#2092 TOCTOU-fix(3차, #2898 리뷰) — checkout_subscription이 claim UPSERT 前에
+    organizations 행을 FOR UPDATE로 잠근다(#2092 조직삭제 경로와 그 행 위에서 직렬화).
+    `.first()`가 None이 아니면(=org 존재) 통과."""
+    r = MagicMock()
+    r.first.return_value = (1,)
     return r
 
 
@@ -91,6 +130,7 @@ async def test_checkout_activates_subscription_when_charge_confirmed():
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[
         _exec_result(offering),   # ① offering lookup
+        _org_exists_result(),     # #2092 — org FOR UPDATE 락-존재확인
         _claim_result(1),         # #2511 claim(=구독 pending 전이 겸함) — 성공
         MagicMock(),              # ④ update active
         _exec_result(active_sub), # 최종 refetch
@@ -114,17 +154,16 @@ async def test_checkout_activates_subscription_when_charge_confirmed():
     assert charge_kwargs["amount_minor"] == 59_000
     assert charge_kwargs["currency"] == "krw"
 
-    # claim(=구독 pending 전이 겸함) 확認 — 두 번째 execute 호출.
-    claim_call = session.execute.call_args_list[1]
+    # claim(=구독 pending 전이 겸함) 확認 — 세 번째 execute 호출(①offering②org락 다음).
+    claim_call = session.execute.call_args_list[2]
     compiled = claim_call.args[0].compile().params
     assert compiled["status"] == "pending"
     assert compiled["tier"] == "team"
     assert compiled["billing_cycle"] == "monthly"
 
     # 카디르 CRITICAL fix(codex, #2896 리뷰) — ④ activate UPDATE도 release와 동일한
-    # CAS(checkout_claimed_at==이 호출이 claim한 값)가 걸려 있어야 한다. 세 번째 execute
-    # 호출(claim 다음).
-    activate_call = session.execute.call_args_list[2]
+    # CAS(checkout_claimed_at==이 호출이 claim한 값)가 걸려 있어야 한다. claim 다음 호출.
+    activate_call = session.execute.call_args_list[3]
     activate_where_literal = str(activate_call.args[0].whereclause)
     assert "checkout_claimed_at" in activate_where_literal
 
@@ -142,6 +181,7 @@ async def test_checkout_rejects_when_another_checkout_already_in_progress():
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[
         _exec_result(offering),  # ① offering lookup
+        _org_exists_result(),    # #2092 — org FOR UPDATE 락-존재확인
         _claim_result(0),        # #2511 claim 실패 — 다른 요청이 진행 中
     ])
 
@@ -154,7 +194,7 @@ async def test_checkout_rejects_when_another_checkout_already_in_progress():
 
     mock_issue.assert_not_awaited()
     mock_charge.assert_not_awaited()
-    assert session.execute.await_count == 2  # offering + claim뿐, finally release도 없음(claim 자체가 실패)
+    assert session.execute.await_count == 3  # offering+org락+claim뿐, finally release도 없음(claim 자체가 실패)
 
 
 @pytest.mark.anyio
@@ -188,6 +228,7 @@ async def test_checkout_declined_leaves_subscription_pending_not_active():
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[
         _exec_result(offering),    # ① offering lookup
+        _org_exists_result(),      # #2092 — org FOR UPDATE 락-존재확인
         _claim_result(1),          # #2511 claim 성공
         _exec_result(pending_sub), # except 블록 안 refetch
         MagicMock(),               # #2511 finally — claim 해제(CheckoutDeclined도 거친다)
@@ -205,8 +246,8 @@ async def test_checkout_declined_leaves_subscription_pending_not_active():
             )
 
     assert exc_info.value.subscription.status == "pending"
-    # 4번째(active로 올리는) execute가 없어야 — offering+claim+refetch+release 딱 4번.
-    assert session.execute.await_count == 4
+    # 5번째(active로 올리는) execute가 없어야 — offering+org락+claim+refetch+release 딱 5번.
+    assert session.execute.await_count == 5
 
 
 @pytest.mark.anyio
@@ -222,6 +263,7 @@ async def test_checkout_does_not_activate_when_order_not_confirmed_race_loss():
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[
         _exec_result(offering),
+        _org_exists_result(),       # #2092 — org FOR UPDATE 락-존재확인
         _claim_result(1),
         _exec_result(pending_sub),  # 최종 refetch(active-update 없음)
         MagicMock(),                # #2511 finally — claim 해제
@@ -238,4 +280,4 @@ async def test_checkout_does_not_activate_when_order_not_confirmed_race_loss():
         )
 
     assert result.status == "pending"
-    assert session.execute.await_count == 4
+    assert session.execute.await_count == 5

--- a/backend/tests/test_e_2506_subscription_checkout_realdb.py
+++ b/backend/tests/test_e_2506_subscription_checkout_realdb.py
@@ -39,6 +39,13 @@ def _crypto_key(monkeypatch):
 
 async def _seed_org_with_members(session, *, human_seats=5):
     org_id = uuid.uuid4()
+    # #2092 TOCTOU-fix(3차) — checkout_subscription이 이제 organizations 행을 FOR UPDATE로
+    # 잠근다(존재 확인 겸함) — 실제 org 행 없이는 checkout 자체가 명시 실패한다(정확히
+    # 프로덕션과 동일 — org_id는 항상 실 org를 가리켜야 한다).
+    await session.execute(
+        text("INSERT INTO organizations (id, name, slug, plan) VALUES (:id, :name, :slug, 'free')"),
+        {"id": org_id, "name": f"test-org-{org_id}", "slug": f"slug-{org_id}"},
+    )
     for _ in range(human_seats):
         await session.execute(
             text("INSERT INTO org_members (id, org_id, user_id, role) VALUES (:id, :org_id, :uid, 'member')"),
@@ -303,6 +310,10 @@ async def test_checkout_stale_reclaimed_late_confirm_does_not_premature_activate
         async with async_sessionmaker(seed_engine, expire_on_commit=False)() as seed_session:
             # _seed_org_with_members는 매번 새 org_id를 만들어버리므로(여기선 미리 정한
             # org_id가 필요) 직접 멤버만 심는다.
+            await seed_session.execute(
+                text("INSERT INTO organizations (id, name, slug, plan) VALUES (:id, :name, :slug, 'free')"),
+                {"id": org_id, "name": f"test-org-{org_id}", "slug": f"slug-{org_id}"},
+            )
             for _ in range(3):
                 await seed_session.execute(
                     text("INSERT INTO org_members (id, org_id, user_id, role) VALUES (:id, :org_id, :uid, 'member')"),

--- a/backend/tests/test_e_2512_customer_key_pre_widget_realdb.py
+++ b/backend/tests/test_e_2512_customer_key_pre_widget_realdb.py
@@ -49,6 +49,12 @@ async def test_ensure_customer_key_then_checkout_reuses_placeholder_realdb():
     try:
         async with Session() as session:
             org_id = uuid.uuid4()
+            # #2092 TOCTOU-fix(3차) — checkout_subscription이 organizations 행을 FOR
+            # UPDATE로 잠근다(존재 확인 겸함) — 실 org 행 필요.
+            await session.execute(
+                text("INSERT INTO organizations (id, name, slug, plan) VALUES (:id, :name, :slug, 'free')"),
+                {"id": org_id, "name": f"test-org-{org_id}", "slug": f"slug-{org_id}"},
+            )
             for _ in range(3):  # starter included_seats=3 — 초과 없이
                 await session.execute(
                     text("INSERT INTO org_members (id, org_id, user_id, role) VALUES (:id, :oid, :uid, 'member')"),

--- a/backend/tests/test_e_org_multi_s4_2_org_delete_ux_be.py
+++ b/backend/tests/test_e_org_multi_s4_2_org_delete_ux_be.py
@@ -26,6 +26,18 @@ def _resolved_human() -> MagicMock:
     return m
 
 
+def _stub_begin_nested(session: AsyncMock) -> None:
+    """#2092(카디르 결함사냥 HIGH①) — delete_by_user가 get_impact()를
+    `async with self.session.begin_nested():`로 감싸므로, 실 SQLAlchemy
+    AsyncSession.begin_nested()와 동형(비동기 호출이 아니라 async-context-manager를
+    "동기적으로" 반환)으로 session mock을 보강한다. 이거 없이 bare AsyncMock()이면
+    session.begin_nested()가 코루틴을 반환해 `async with`가 TypeError로 깨진다."""
+    nested_ctx = MagicMock()
+    nested_ctx.__aenter__ = AsyncMock(return_value=nested_ctx)
+    nested_ctx.__aexit__ = AsyncMock(return_value=False)
+    session.begin_nested = MagicMock(return_value=nested_ctx)
+
+
 def _mock_org() -> MagicMock:
     o = MagicMock()
     o.id = ORG_ID
@@ -309,6 +321,7 @@ async def test_delete_by_user_rejects_when_impact_query_raises_and_no_override()
     from app.repositories.organization import OrganizationRepository
 
     session = AsyncMock()
+    _stub_begin_nested(session)
     repo = OrganizationRepository(session)
     repo.get = AsyncMock(return_value=_mock_org())
     repo.get_member_role = AsyncMock(return_value="owner")
@@ -329,6 +342,7 @@ async def test_delete_by_user_proceeds_with_override_and_records_audit_note():
     from app.repositories.organization import OrganizationRepository
 
     session = AsyncMock()
+    _stub_begin_nested(session)
     repo = OrganizationRepository(session)
     repo.get = AsyncMock(return_value=_mock_org())
     repo.get_member_role = AsyncMock(return_value="owner")
@@ -358,6 +372,7 @@ async def test_delete_by_user_succeeds_normally_records_audit_without_note():
     from app.repositories.organization import OrganizationRepository, OrgImpact
 
     session = AsyncMock()
+    _stub_begin_nested(session)
     repo = OrganizationRepository(session)
     repo.get = AsyncMock(return_value=_mock_org())
     repo.get_member_role = AsyncMock(return_value="owner")

--- a/backend/tests/test_e_org_multi_s4_2_org_delete_ux_be.py
+++ b/backend/tests/test_e_org_multi_s4_2_org_delete_ux_be.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 ORG_ID = uuid.uuid4()
 USER_ID = uuid.uuid4()
 ORG_NAME = "Test Org"
+
+
+def _resolved_human() -> MagicMock:
+    """#2092 human-only 가드용 — resolve_member 반환값 mock."""
+    m = MagicMock()
+    m.type = "human"
+    return m
 
 
 def _mock_org() -> MagicMock:
@@ -125,12 +132,14 @@ async def test_owner_can_delete_with_correct_confirmation():
         from app.routers.organizations import _get_repo
 
         mock_repo = MagicMock()
+        mock_repo.get_member_role = AsyncMock(return_value="owner")
         mock_repo.delete_by_user = AsyncMock(return_value={"ok": True})
         app.dependency_overrides[_get_repo] = lambda: mock_repo
         session.commit = AsyncMock()
 
-        async with client as c:
-            resp = await c.request("DELETE", f"/api/v2/organizations/{ORG_ID}", json={"confirmation": ORG_NAME})
+        with patch("app.services.member_resolver.resolve_member", new=AsyncMock(return_value=_resolved_human())):
+            async with client as c:
+                resp = await c.request("DELETE", f"/api/v2/organizations/{ORG_ID}", json={"confirmation": ORG_NAME})
 
         assert resp.status_code == 200
         assert resp.json() == {"ok": True}
@@ -146,6 +155,7 @@ async def test_non_owner_delete_returns_403():
         from app.routers.organizations import _get_repo
 
         mock_repo = MagicMock()
+        mock_repo.get_member_role = AsyncMock(return_value="admin")  # owner 아님 — human-only 체크 스킵
         mock_repo.delete_by_user = AsyncMock(return_value={"ok": False, "reason": "forbidden"})
         app.dependency_overrides[_get_repo] = lambda: mock_repo
 
@@ -153,6 +163,30 @@ async def test_non_owner_delete_returns_403():
             resp = await c.request("DELETE", f"/api/v2/organizations/{ORG_ID}", json={"confirmation": ORG_NAME})
 
         assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_agent_owner_cannot_delete_org_human_only():
+    """#2092 — org owner 역할이어도 에이전트(non-human)면 403(human-only)."""
+    client, session, app = await _client()
+    try:
+        from app.routers.organizations import _get_repo
+
+        mock_repo = MagicMock()
+        mock_repo.get_member_role = AsyncMock(return_value="owner")
+        mock_repo.delete_by_user = AsyncMock(return_value={"ok": True})  # 도달하면 안 됨
+        app.dependency_overrides[_get_repo] = lambda: mock_repo
+
+        agent_resolved = MagicMock()
+        agent_resolved.type = "agent"
+        with patch("app.services.member_resolver.resolve_member", new=AsyncMock(return_value=agent_resolved)):
+            async with client as c:
+                resp = await c.request("DELETE", f"/api/v2/organizations/{ORG_ID}", json={"confirmation": ORG_NAME})
+
+        assert resp.status_code == 403
+        mock_repo.delete_by_user.assert_not_awaited()  # human-only에서 막혀 delete_by_user 자체를 안 부름
     finally:
         app.dependency_overrides.clear()
 
@@ -167,13 +201,65 @@ async def test_wrong_confirmation_returns_422():
         from app.routers.organizations import _get_repo
 
         mock_repo = MagicMock()
+        mock_repo.get_member_role = AsyncMock(return_value="owner")
         mock_repo.delete_by_user = AsyncMock(return_value={"ok": False, "reason": "confirmation_mismatch"})
         app.dependency_overrides[_get_repo] = lambda: mock_repo
 
-        async with client as c:
-            resp = await c.request("DELETE", f"/api/v2/organizations/{ORG_ID}", json={"confirmation": "Wrong Name"})
+        with patch("app.services.member_resolver.resolve_member", new=AsyncMock(return_value=_resolved_human())):
+            async with client as c:
+                resp = await c.request("DELETE", f"/api/v2/organizations/{ORG_ID}", json={"confirmation": "Wrong Name"})
 
         assert resp.status_code == 422
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── #2092 AC1 — impact 재조회 실패 시 서버 거부 ─────────────────────────────
+
+@pytest.mark.anyio
+async def test_delete_rejected_when_impact_unavailable_and_no_override():
+    """impact 재조회 실패 + confirm_without_impact 없음(기본 False) → 409(impact_unavailable)."""
+    client, session, app = await _client()
+    try:
+        from app.routers.organizations import _get_repo
+
+        mock_repo = MagicMock()
+        mock_repo.get_member_role = AsyncMock(return_value="owner")
+        mock_repo.delete_by_user = AsyncMock(return_value={"ok": False, "reason": "impact_unavailable"})
+        app.dependency_overrides[_get_repo] = lambda: mock_repo
+
+        with patch("app.services.member_resolver.resolve_member", new=AsyncMock(return_value=_resolved_human())):
+            async with client as c:
+                resp = await c.request("DELETE", f"/api/v2/organizations/{ORG_ID}", json={"confirmation": ORG_NAME})
+
+        assert resp.status_code == 409
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_proceeds_with_explicit_override_when_impact_unavailable():
+    """impact 재조회 실패 + confirm_without_impact=True → repo에 그 값이 그대로 전달돼 진행 허용."""
+    client, session, app = await _client()
+    try:
+        from app.routers.organizations import _get_repo
+
+        mock_repo = MagicMock()
+        mock_repo.get_member_role = AsyncMock(return_value="owner")
+        mock_repo.delete_by_user = AsyncMock(return_value={"ok": True})
+        app.dependency_overrides[_get_repo] = lambda: mock_repo
+        session.commit = AsyncMock()
+
+        with patch("app.services.member_resolver.resolve_member", new=AsyncMock(return_value=_resolved_human())):
+            async with client as c:
+                resp = await c.request(
+                    "DELETE", f"/api/v2/organizations/{ORG_ID}",
+                    json={"confirmation": ORG_NAME, "confirm_without_impact": True},
+                )
+
+        assert resp.status_code == 200
+        mock_repo.delete_by_user.assert_awaited_once()
+        assert mock_repo.delete_by_user.await_args.kwargs["confirm_without_impact"] is True
     finally:
         app.dependency_overrides.clear()
 
@@ -211,3 +297,77 @@ def test_delete_organization_schema():
     from app.schemas.organization import DeleteOrganization
     fields = set(DeleteOrganization.model_fields.keys())
     assert "confirmation" in fields
+    assert "confirm_without_impact" in fields
+    assert DeleteOrganization.model_fields["confirm_without_impact"].default is False
+
+
+# ─── #2092 — delete_by_user 자체(mock session)로 impact 가드 직접 검증 ──────────
+
+@pytest.mark.anyio
+async def test_delete_by_user_rejects_when_impact_query_raises_and_no_override():
+    """get_impact()가 예외를 던지면(=재조회 실패) confirm_without_impact 없이는 거부."""
+    from app.repositories.organization import OrganizationRepository
+
+    session = AsyncMock()
+    repo = OrganizationRepository(session)
+    repo.get = AsyncMock(return_value=_mock_org())
+    repo.get_member_role = AsyncMock(return_value="owner")
+    repo.get_impact = AsyncMock(side_effect=RuntimeError("db timeout"))
+    session.execute = AsyncMock(return_value=MagicMock(first=lambda: None))  # active_subscription 체크 통과
+
+    result = await repo.delete_by_user(org_id=ORG_ID, user_id=USER_ID, confirmation=ORG_NAME)
+
+    assert result == {"ok": False, "reason": "impact_unavailable"}
+    session.delete.assert_not_called()
+    session.add.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_delete_by_user_proceeds_with_override_and_records_audit_note():
+    """confirm_without_impact=True면 get_impact() 실패에도 진행하고, 감사로그에 note를 남긴다."""
+    from app.models.deletion_audit import DeletionAuditLog
+    from app.repositories.organization import OrganizationRepository
+
+    session = AsyncMock()
+    repo = OrganizationRepository(session)
+    repo.get = AsyncMock(return_value=_mock_org())
+    repo.get_member_role = AsyncMock(return_value="owner")
+    repo.get_impact = AsyncMock(side_effect=RuntimeError("db timeout"))
+    session.execute = AsyncMock(return_value=MagicMock(first=lambda: None))
+    session.delete = AsyncMock()
+
+    result = await repo.delete_by_user(
+        org_id=ORG_ID, user_id=USER_ID, confirmation=ORG_NAME, confirm_without_impact=True,
+    )
+
+    assert result == {"ok": True}
+    session.delete.assert_awaited_once()
+    session.add.assert_called_once()
+    audit_entry = session.add.call_args.args[0]
+    assert isinstance(audit_entry, DeletionAuditLog)
+    assert audit_entry.entity_type == "organization"
+    assert audit_entry.entity_id == ORG_ID
+    assert audit_entry.actor_id == USER_ID
+    assert audit_entry.note is not None and "확認 없이" in audit_entry.note
+
+
+@pytest.mark.anyio
+async def test_delete_by_user_succeeds_normally_records_audit_without_note():
+    """get_impact()가 정상 성공하면 confirm_without_impact 값과 무관하게 정상 진행 — note는 None."""
+    from app.models.deletion_audit import DeletionAuditLog
+    from app.repositories.organization import OrganizationRepository, OrgImpact
+
+    session = AsyncMock()
+    repo = OrganizationRepository(session)
+    repo.get = AsyncMock(return_value=_mock_org())
+    repo.get_member_role = AsyncMock(return_value="owner")
+    repo.get_impact = AsyncMock(return_value=OrgImpact(project_count=1, member_count=2, has_active_subscription=False))
+    session.execute = AsyncMock(return_value=MagicMock(first=lambda: None))
+    session.delete = AsyncMock()
+
+    result = await repo.delete_by_user(org_id=ORG_ID, user_id=USER_ID, confirmation=ORG_NAME)
+
+    assert result == {"ok": True}
+    audit_entry = session.add.call_args.args[0]
+    assert isinstance(audit_entry, DeletionAuditLog)
+    assert audit_entry.note is None

--- a/backend/tests/test_e_org_multi_s4_2_org_delete_ux_be.py
+++ b/backend/tests/test_e_org_multi_s4_2_org_delete_ux_be.py
@@ -323,10 +323,11 @@ async def test_delete_by_user_rejects_when_impact_query_raises_and_no_override()
     session = AsyncMock()
     _stub_begin_nested(session)
     repo = OrganizationRepository(session)
-    repo.get = AsyncMock(return_value=_mock_org())
     repo.get_member_role = AsyncMock(return_value="owner")
     repo.get_impact = AsyncMock(side_effect=RuntimeError("db timeout"))
-    session.execute = AsyncMock(return_value=MagicMock(first=lambda: None))  # active_subscription 체크 통과
+    # #2092 TOCTOU-fix(3차) — delete_by_user가 이제 repo.get() 대신 FOR UPDATE 락-SELECT를
+    # session.execute로 직접 호출한다. scalar_one_or_none()이 org를 반환하게 stub.
+    session.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=lambda: _mock_org()))
 
     result = await repo.delete_by_user(org_id=ORG_ID, user_id=USER_ID, confirmation=ORG_NAME)
 
@@ -344,10 +345,9 @@ async def test_delete_by_user_proceeds_with_override_and_records_audit_note():
     session = AsyncMock()
     _stub_begin_nested(session)
     repo = OrganizationRepository(session)
-    repo.get = AsyncMock(return_value=_mock_org())
     repo.get_member_role = AsyncMock(return_value="owner")
     repo.get_impact = AsyncMock(side_effect=RuntimeError("db timeout"))
-    session.execute = AsyncMock(return_value=MagicMock(first=lambda: None))
+    session.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=lambda: _mock_org()))
     session.delete = AsyncMock()
 
     result = await repo.delete_by_user(
@@ -374,10 +374,9 @@ async def test_delete_by_user_succeeds_normally_records_audit_without_note():
     session = AsyncMock()
     _stub_begin_nested(session)
     repo = OrganizationRepository(session)
-    repo.get = AsyncMock(return_value=_mock_org())
     repo.get_member_role = AsyncMock(return_value="owner")
     repo.get_impact = AsyncMock(return_value=OrgImpact(project_count=1, member_count=2, has_active_subscription=False))
-    session.execute = AsyncMock(return_value=MagicMock(first=lambda: None))
+    session.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=lambda: _mock_org()))
     session.delete = AsyncMock()
 
     result = await repo.delete_by_user(org_id=ORG_ID, user_id=USER_ID, confirmation=ORG_NAME)
@@ -386,3 +385,45 @@ async def test_delete_by_user_succeeds_normally_records_audit_without_note():
     audit_entry = session.add.call_args.args[0]
     assert isinstance(audit_entry, DeletionAuditLog)
     assert audit_entry.note is None
+
+
+@pytest.mark.anyio
+async def test_delete_by_user_rejects_when_impact_return_value_shows_active_subscription():
+    """#2092 TOCTOU-fix(3차) — get_impact()가 예외 없이 성공해도, 그 반환값의
+    has_active_subscription=True를 실제로 읽어 거부해야 한다(예전엔 반환값을 버려
+    "에러 안 났나"만 봤다 — 재확認이 실은 재확認이 아니었다)."""
+    from app.repositories.organization import OrganizationRepository, OrgImpact
+
+    session = AsyncMock()
+    _stub_begin_nested(session)
+    repo = OrganizationRepository(session)
+    repo.get_member_role = AsyncMock(return_value="owner")
+    repo.get_impact = AsyncMock(
+        return_value=OrgImpact(project_count=0, member_count=1, has_active_subscription=True)
+    )
+    session.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=lambda: _mock_org()))
+    session.delete = AsyncMock()
+
+    result = await repo.delete_by_user(org_id=ORG_ID, user_id=USER_ID, confirmation=ORG_NAME)
+
+    assert result == {"ok": False, "reason": "active_subscription"}
+    session.delete.assert_not_called()
+    session.add.assert_not_called()
+
+
+def test_delete_by_user_locks_organization_row_for_update_in_source():
+    """#2092 TOCTOU-fix(3차) — delete_by_user 소스에 organizations 행 FOR UPDATE 락이
+    존재(checkout claim 경로와 그 행 위에서 직렬화하는 근본 메커니즘)."""
+    import inspect
+    from app.repositories.organization import OrganizationRepository
+    source = inspect.getsource(OrganizationRepository.delete_by_user)
+    assert "with_for_update" in source
+
+
+def test_checkout_subscription_locks_organization_row_for_update_in_source():
+    """#2092 TOCTOU-fix(3차) — checkout_subscription도 같은 org 행을 FOR UPDATE로
+    잠근다(claim UPSERT 前) — organizations.py delete_by_user와 대칭."""
+    import inspect
+    from app.services.org_subscription_checkout import checkout_subscription
+    source = inspect.getsource(checkout_subscription)
+    assert "FOR UPDATE" in source


### PR DESCRIPTION
## Summary
- `GET /{id}/impact`(삭제 前 영향도 미리보기)와 `DELETE /{id}`(실 삭제)가 서버에서 완전히 무관계였다. `DeleteOrganization` 스키마엔 `confirmation`(org명) 하나뿐 — 화면이 impact 조회 실패 카피를 고쳐도 API를 직접 호출하면 그대로 뚫렸다(동작 결함 — 카피만으론 안 닫힘).
- fix: 삭제 직전 서버가 직접 `get_impact()`를 재조회(클라이언트 주장을 신뢰하지 않음 — "금지는 서버가 거부" 축). 재조회 자체가 실패하면 `confirm_without_impact=True`(사용자 명시 인정) 아닌 한 409(`reason=impact_unavailable`)로 거부. override로 진행된 삭제는 `DeletionAuditLog.note`에 기록(마이그 0235 — `note` 신설, `entity_type` 오버로드 안 함).
- 부수 하드닝(같은 함수를 만지는 김에 sibling 엔티티 project/docs와 패턴 정합) — 조직 삭제엔 human-only 강제(#2058과 동일 불변식)와 `DeletionAuditLog` 기입 자체가 없었음(다른 엔티티는 이미 다 함) — 둘 다 추가. 구 `delete(org_id, requester_member_id)` 메서드(새 안전장치 0개·호출부 0곳)는 완전 제거.
- AC6 전수 스윕: 백엔드 전체에서 `/impact` 라우트는 이 하나뿐 — 같은 클래스의 다른 인스턴스 없음(grep 확인).

## 카디르 결함사냥 3라운드(재QA) — 이 PR에서 함께 닫은 것
1. **CRITICAL** — `get_impact()`가 진짜 Postgres 에러로 실패하면 트랜잭션이 aborted 상태로 오염돼, override 진행이 500으로 깨졌다. `SAVEPOINT`(`begin_nested`)로 격리.
2. **HIGH** — 삭제 가드가 `checkout_claimed_at`(#2511 진행 中 checkout claim)을 안 봐서, claim 성공 直後(구독 아직 pending)의 창에서 org 삭제가 통과할 수 있었다. `status='active'` 또는 진행 中 claim을 모두 "활성 구독"으로 취급하도록 확장.
3. **HIGH·TOCTOU 근본** — "재확인" 헬퍼 체크가 실제로는 1회뿐이었고, savepoint로 감싼 재호출은 반환값을 버렸다. `organizations` 행 자체를 `FOR UPDATE`로 잠가 삭제와 checkout claim UPSERT를 그 행 위에서 직렬화 — 양쪽 뮤테이션 순서 무관하게 창을 원천 차단. 실경쟁(asyncio.gather, 40 트라이얼) + 결정론적 스테이징(양방향 positive-control 각 3/3)으로 실증.

## ⚠️ 스코프 펜스(카디르 3차 재QA 판정, 병합 전 명시) — 리팩터 범위 규율
**이 PR이 실제로 닫은 것은 "Toss checkout(#2511/#2896) ↔ org 삭제(#2092)" 직렬화 딱 그 한 쌍이다.** `FOR UPDATE`가 `organizations` 행 잠금이라 표면적으로 "전체 구독 writer 직렬화"처럼 보일 수 있으나 **그렇지 않다** — 아래는 이 PR의 펜스 밖이며, 후속 스토리 **#2517**로 분리했다:
- **Polar 웹훅 writer** — 死문서 가능성 있음(PG=Toss·정책 krw_v1, PO 반복 지시) → #2517 AC1이 "prod 실사용 확인(死면 경로 제거)"부터.
- **`downgrade_to_free`(dunning 스윕, #2494/C3)** — `checkout_claimed_at`은 이미 인지하지만(오늘 별도 fix) `organizations` FOR UPDATE로는 안 잠금.
- **STALE_CLAIM_WINDOW를 넘겨 "죽지 않고 그냥 느린" checkout** — 자기치유 설계상 살아있는 요청이 뒤늦게 confirmed되는 잔여 트레이드오프(codex+카디르 기존 합의, 유한 window 설계 내포).

이 세 축은 "돈이 걸린 전체 writer 직렬화"라는 더 큰 설계 질문이라 이 P0 org-삭제 PR 스코프 밖 — 다음 담당 세션이 #2517에서 판단.

## BE 계약(FE 연동용)
- `DELETE /api/v2/organizations/{id}` body: `{confirmation: str, confirm_without_impact?: bool = false}`
- impact 재조회 실패 + override 없음 → `409 {"detail": "..."}`(정확한 사용자 카피는 FE 유나 규격)
- override로 성공 시 응답은 기존과 동일 `{"ok": true}`

## Test plan
- [x] mock: human-only 가드(agent owner 거부) + impact_unavailable 409 + override 통과 + FOR UPDATE 락-존재확인 라우터/리포지토리 테스트 — 171/171 green
- [x] realdb(scratch PG): 거부 시 org 실제 생존 / override 시 실제 삭제+audit note 기록 / 정상경로 무회귀 / checkout-in-flight 거부 / stale claim은 무시
- [x] realdb 실경쟁(asyncio.gather, 스테이징 없음) — 8회×5세트=40 트라이얼, 매번 불변식(삭제⟹checkout 실패 / 생존⟹active_subscription 거부) 확인
- [x] realdb 결정론적 스테이징 — delete가 impact 체크 통과(락 보유 中) 直後 checkout이 block되는 것을 타임아웃으로 직접 증명
- [x] positive-control: 가드 3종(impact 재확인·checkout claim 인지·FOR UPDATE 양쪽) 전부 제거 시 각 3/3 원래 결함 재현 확인 후 복원
- [x] 기존 organizations/checkout 관련 테스트 스위트 무회귀 확인
- [x] `lint_project_access_403` / `lint_dependency_override_get_read_db` / `app.main` import 전부 green
- [ ] 라이브 dev 직접 delete 실측은 하지 않음(파괴적·비가역 — 실 org 삭제) — scratch 실PG 통합테스트가 동일 SQL 경로를 그대로 태움

🤖 Generated with [Claude Code](https://claude.com/claude-code)
