### PR TITLE
fix(#2406 AC2): team-members 목록이 include_inactive 파라미터를 무시하던 결함(critical)

### DIFF
--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -136,6 +136,7 @@ async def list_team_members(
     project_id: uuid.UUID | None = Query(default=None),
     type_filter: str | None = Query(default=None, alias="type"),
     is_active: bool | None = Query(default=True),
+    include_inactive: bool = Query(default=False),
     user_id: uuid.UUID | None = Query(default=None),
     repo: TeamMemberRepository = Depends(_get_repo_read),
     session: AsyncSession = Depends(get_read_db),
@@ -146,6 +147,18 @@ async def list_team_members(
     # (team_members 뷰=members⋈project_access 비의존 → project_access.member_id NULL 인
     # grant-only/owner 휴먼도 포함, 곱연산 0). 에이전트는 기존 뷰(type=agent) 그대로.
     # project-scoped(project_id 지정)는 기존 뷰 경로 무변경 → 다른 consumer 무회귀(AC3).
+    #
+    # story #2406 AC2(critical, 미르코 라이브 실측 2026-08-07) — FE는 AC1 커밋 이전부터
+    # `?type=agent&include_inactive=true`를 이미 보내고 있었는데, 이 함수는 그 파라미터
+    # 자체를 몰랐다(FastAPI는 선언 안 된 쿼리파라미터를 조용히 무시 — 200은 나오되 아무
+    # 효과가 없다). 결과: is_active가 Query(default=True)라 include_inactive 값과 무관하게
+    # 항상 활성만 반환(16→15건 실측) — 비활성화한 에이전트가 목록에서 완전히 사라져
+    # "재활성화" 토글 자체를 누를 행이 없는, 원래 사고("한 번 잘못 누르면 영영 못
+    # 되돌림")가 그대로 살아있는 상태였다. include_inactive=True면 is_active 필터 자체를
+    # 안 건다(기존 is_active 파라미터 값과 무관 — FE가 실제로 보내는 값 그대로 존중).
+    # include_inactive 생략/False(기본)면 기존 동작 완전 동일(회귀 0).
+    effective_is_active = None if include_inactive else is_active
+
     if project_id is None:
         result: list[TeamMemberResponse] = []
         if type_filter in (None, "human"):
@@ -153,8 +166,8 @@ async def list_team_members(
             result.extend(_build_org_human_response(r, org_id) for r in human_rows)
         if type_filter in (None, "agent"):
             agent_filters: dict = {"type": "agent"}
-            if is_active is not None:
-                agent_filters["is_active"] = is_active
+            if effective_is_active is not None:
+                agent_filters["is_active"] = effective_is_active
             if user_id:
                 agent_filters["user_id"] = user_id
             agents = await repo.list(**agent_filters)
@@ -170,8 +183,8 @@ async def list_team_members(
     filters: dict = {"project_id": project_id}
     if type_filter:
         filters["type"] = type_filter
-    if is_active is not None:
-        filters["is_active"] = is_active
+    if effective_is_active is not None:
+        filters["is_active"] = effective_is_active
     if user_id:
         filters["user_id"] = user_id
     members = await repo.list(**filters)

--- a/backend/tests/test_e_2406_team_members_include_inactive_realdb.py
+++ b/backend/tests/test_e_2406_team_members_include_inactive_realdb.py
@@ -1,0 +1,176 @@
+"""story #2406 AC2(critical) real-DB — GET /api/v2/team-members?type=agent&include_inactive=true
+가 비활성 에이전트를 실제로 포함해 반환하는지 실 organizations/members/project_access 위에서
+검증. PO 지시(2026-08-07) "검산" — include_inactive=true/false(또는 생략) 두 번 호출해 반환
+건수가 실제로 다른지 확認한다(미르코 라이브 실측 16→15의 축소판).
+
+DB env(PARITY_TEST_DATABASE_URL 또는 ALEMBIC_DATABASE_URL) 없으면 skip."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org + human(caller) + agent_active(project grant) + agent_inactive(project grant,
+    is_active=False) — 둘 다 org-level type=agent 조회 대상."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    agent_active = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent Active", is_active=True)
+    agent_inactive = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent Inactive", is_active=False)
+    session.add_all([agent_active, agent_inactive])
+    await session.commit()
+    session.add_all([
+        ProjectAccess(id=uuid.uuid4(), project_id=project.id, member_id=agent_active.id, permission="granted", role="member"),
+        ProjectAccess(id=uuid.uuid4(), project_id=project.id, member_id=agent_inactive.id, permission="granted", role="member"),
+    ])
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"human-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    session.add(OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="owner"))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "human_user_id": human_user_id,
+        "agent_active_id": agent_active.id, "agent_inactive_id": agent_inactive.id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_include_inactive_true_returns_both_false_or_omitted_returns_only_active_realdb():
+    """검산(PO 지시) — 같은 org에 include_inactive=true/생략 두 번 호출, 반환 건수가
+    실제로 다른지(1건 vs 2건) 확認. 미르코 라이브 실측(16→15)의 축소판 재현."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            # ① include_inactive 생략(기본) — 활성만.
+            resp_default = await client.get("/api/v2/team-members?type=agent")
+            assert resp_default.status_code == 200, resp_default.text
+            ids_default = {item["id"] for item in resp_default.json()}
+            assert ids_default == {str(seeded["agent_active_id"])}
+
+            # ② include_inactive=false 명시 — ①과 동일해야(회귀 0).
+            resp_false = await client.get("/api/v2/team-members?type=agent&include_inactive=false")
+            assert resp_false.status_code == 200, resp_false.text
+            ids_false = {item["id"] for item in resp_false.json()}
+            assert ids_false == ids_default
+
+            # ③ include_inactive=true — 비활성 포함 둘 다(fix 핵심).
+            resp_true = await client.get("/api/v2/team-members?type=agent&include_inactive=true")
+            assert resp_true.status_code == 200, resp_true.text
+            ids_true = {item["id"] for item in resp_true.json()}
+            assert ids_true == {str(seeded["agent_active_id"]), str(seeded["agent_inactive_id"])}
+
+            # 검산 핵심 — 두 값이 실제로 다르다(1건 vs 2건, PO "검산" 지시 그대로).
+            assert len(ids_true) > len(ids_default)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_typo_param_ignored_confirms_root_cause_realdb():
+    """PO 진단 판별 축(실DB) — 오타(`include_inactivee`)는 FastAPI가 조용히 무시해
+    200은 나오지만 효과가 없다(=기본 활성만). 이게 원래 결함의 근본원인이었다는 진단을
+    실측으로 고정."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/team-members?type=agent&include_inactivee=true")
+            assert resp.status_code == 200
+            ids = {item["id"] for item in resp.json()}
+            assert ids == {str(seeded["agent_active_id"])}  # 오타라 무시됨 — 활성만
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_team_members.py
+++ b/backend/tests/test_team_members.py
@@ -106,6 +106,104 @@ async def test_list_filter_by_type_200():
         app.dependency_overrides.clear()
 
 
+# ─── #2406 AC2(critical) — include_inactive 파라미터 존중 ────────────────────
+
+@pytest.mark.anyio
+async def test_list_team_members_include_inactive_true_omits_is_active_filter_org_level():
+    """org-level(project_id 없음, FE 실 호출 형태 — ?type=agent&include_inactive=true).
+    fix 前엔 이 파라미터를 몰라 조용히 무시하고 is_active=True(기본)만 걸었다 — 비활성
+    에이전트가 응답서 완전히 빠져(16→15건 미르코 실측) 재활성화 토글을 누를 행 자체가
+    없었다. fix 後엔 is_active 필터 자체를 안 걸어야(agent_filters에 키 부재) 한다."""
+    from app.routers.team_members import _get_repo_read
+
+    client, session, app = await _client()
+    try:
+        mock_repo = MagicMock()
+        mock_repo.list = AsyncMock(return_value=[_mock_member(type_="agent"), _mock_member(type_="agent", is_active=False)])
+        app.dependency_overrides[_get_repo_read] = lambda: mock_repo
+
+        async with client as c:
+            resp = await c.get("/api/v2/team-members?type=agent&include_inactive=true")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2  # 활성+비활성 둘 다
+        mock_repo.list.assert_awaited_once()
+        call_kwargs = mock_repo.list.await_args.kwargs
+        assert "is_active" not in call_kwargs  # 필터 자체를 안 걸었다(=DB에서 전부 반환)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_team_members_include_inactive_omitted_preserves_default_active_only():
+    """include_inactive 생략(기본 False) — 기존 동작 완전 동일(회귀 0). is_active=True가
+    그대로 걸려야 한다."""
+    from app.routers.team_members import _get_repo_read
+
+    client, session, app = await _client()
+    try:
+        mock_repo = MagicMock()
+        mock_repo.list = AsyncMock(return_value=[_mock_member(type_="agent")])
+        app.dependency_overrides[_get_repo_read] = lambda: mock_repo
+
+        async with client as c:
+            resp = await c.get("/api/v2/team-members?type=agent")
+
+        assert resp.status_code == 200
+        call_kwargs = mock_repo.list.await_args.kwargs
+        assert call_kwargs.get("is_active") is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_team_members_typo_param_silently_ignored_confirms_root_cause():
+    """PO 진단 판별 축 — 존재하지 않는 쿼리파라미터(오타 등)를 보내도 FastAPI가 200으로
+    조용히 무시하는 것(=선언 안 된 쿼리파라미터가 효과 없이 사라지는 것 자체가 원래
+    결함의 근본원인이었다는 진단을 실증). 이건 FastAPI 표준 동작이라 "버그 fix" 대상이
+    아니라 「그래서 include_inactive를 명시 선언해야 한다」는 이 PR의 근거를 고정하는
+    회귀 anchor."""
+    from app.routers.team_members import _get_repo_read
+
+    client, session, app = await _client()
+    try:
+        mock_repo = MagicMock()
+        mock_repo.list = AsyncMock(return_value=[_mock_member(type_="agent")])
+        app.dependency_overrides[_get_repo_read] = lambda: mock_repo
+
+        async with client as c:
+            resp = await c.get("/api/v2/team-members?type=agent&include_inactivee=true")  # 오타
+
+        assert resp.status_code == 200  # 조용히 무시 — 에러 안 남(오타를 잡아주지 않음)
+        call_kwargs = mock_repo.list.await_args.kwargs
+        assert call_kwargs.get("is_active") is True  # 오타라 include_inactive 미인식 → 기본(활성만) 그대로
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_team_members_include_inactive_true_omits_is_active_filter_project_scoped():
+    """project_id 지정 분기도 동일 — include_inactive=true면 is_active 필터를 안 건다."""
+    from app.routers.team_members import _get_repo_read
+
+    client, session, app = await _client()
+    try:
+        mock_repo = MagicMock()
+        mock_repo.list = AsyncMock(return_value=[_mock_member(), _mock_member(is_active=False)])
+        app.dependency_overrides[_get_repo_read] = lambda: mock_repo
+
+        with patch("app.routers.team_members.has_project_access", new=AsyncMock(return_value=True)):
+            async with client as c:
+                resp = await c.get(f"/api/v2/team-members?project_id={PROJECT_ID}&include_inactive=true")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+        call_kwargs = mock_repo.list.await_args.kwargs
+        assert "is_active" not in call_kwargs
+    finally:
+        app.dependency_overrides.clear()
+
+
 @pytest.mark.anyio
 async def test_create_team_member_201():
     client, session, app = await _client()


### PR DESCRIPTION
## Summary
- 미르코 라이브 실측(2026-08-07): FE는 이미 `GET /api/v2/team-members?type=agent&include_inactive=true`를 보내고 있었는데, BE가 `include_inactive`를 선언하지 않아 FastAPI가 조용히 무시(200이지만 무효과) — `is_active`가 `Query(default=True)`라 항상 활성만 반환(16→15건 실측). 비활성화한 에이전트가 목록에서 완전히 사라져 재활성화 토글을 누를 행 자체가 없었다 — 원래 사고("한 번 비활성화하면 영영 못 되돌림")가 그대로 살아있었다.
- fix: `include_inactive: bool = Query(default=False)` 신설. True면 `is_active` 필터 자체를 안 걸어(기존 `is_active` 파라미터 값과 무관) 활성+비활성 둘 다 반환. 생략/False(기본)는 기존 동작 완전 동일(회귀 0) — org-level·project-scoped 두 분기 다 동일 적용.

## Test plan
- [x] mock 4개(신규) — org-level/project-scoped include_inactive=true가 `is_active` 필터를 안 거는지, 생략 시 기존 동작 유지되는지, 오타 파라미터(`include_inactivee`)가 여전히 조용히 무시되는지(근본원인 anchor)
- [x] 기존 team_members 테스트 14개 무회귀
- [x] realdb: 활성1+비활성1 시드 → include_inactive 생략/false=1건, true=2건(미르코 16→15 실측 축소 재현, PO "검산" 지시대로 두 번 호출) + 오타 파라미터 실측
- [x] positive-control(fix 되돌림) — mock+realdb 각 3/3 원래 결함 재현 확인 후 복원
- [x] `lint_project_access_403` / `lint_dependency_override_get_read_db` / `app.main` import 전부 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)