### PR TITLE
fix(#2358): declare+relation-kind 원자화 — 순차 호출 실패 시 영구 고아 방지(HIGH)

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -912,16 +912,34 @@ async def declare_new_story_reference_candidate(
     }
 
 
+class DeclareStoryReferenceCandidateRequest(BaseModel):
+    """#2358 QA(카디르, 2026-08-07 HIGH) — declare와 relation-kind가 독립된 두 커밋이라,
+    FE가 순차 호출(declare 성공→relation-kind 실패)하면 candidate가 status=declared·
+    relation_kind=NULL로 영구 고아가 된다(관계 훑기 큐가 relation_kind IS NULL 걸린 후보만
+    보여주므로 다시 안 뜬다). relation_kind는 옵션 — 생략하면 기존 계약(declare만, 「종류는
+    나중에」)이 그대로 유지된다(#2223 오르테가군 판정 "한 클릭에 안 묶는다"를 어기지 않음
+    — 이 필드는 강제가 아니라 「같이 낼 값이 이미 있으면 같은 트랜잭션에 실어 보내는」
+    선택지)."""
+
+    relation_kind: str | None = None
+
+
 @router.post("/{id}/reference-candidates/{candidate_id}/declare")
 async def declare_story_reference_candidate(
     id: uuid.UUID,
     candidate_id: uuid.UUID,
+    body: DeclareStoryReferenceCandidateRequest = DeclareStoryReferenceCandidateRequest(),
     repo: StoryRepository = Depends(_get_repo),
     auth: AuthContext = Depends(get_current_user),
 ) -> dict:
     """POST .../declare — AC5: 사람이 후보를 골라 「선언됨」으로 승격. ⛔AC4: 이 엔드포인트가
     바꾸는 것은 candidate.status/declared_by/declared_at 셋뿐이다 — 막힘·대기·종료·에이전트
-    실행 등 다른 어떤 부수효과도 일으키지 않는다(회귀 테스트가 이 계약을 지킨다)."""
+    실행 등 다른 어떤 부수효과도 일으키지 않는다(회귀 테스트가 이 계약을 지킨다).
+
+    #2358 QA 원자화(2026-08-07) — body.relation_kind가 실려 오면 같은 트랜잭션(같은
+    session, 커밋 1회)에서 relation_kind도 함께 쓴다. 둘 중 하나라도 실패하면(404·400) 커밋
+    전이라 아무것도 안 남는다(전부 아니면 전무) — status=declared인데 relation_kind만 못
+    쓴 반쪽 상태가 생기지 않는다."""
     story = await repo.get(id)
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")
@@ -929,7 +947,9 @@ async def declare_story_reference_candidate(
 
     from app.services.reference_semantic_candidates import (
         CandidateNotFoundError,
+        InvalidRelationKindError,
         declare_candidate,
+        set_candidate_relation_kind,
     )
 
     actor_id = await _resolve_team_member_id(auth, repo.org_id, repo.session)
@@ -938,12 +958,20 @@ async def declare_story_reference_candidate(
             repo.session, org_id=repo.org_id, source_id=id, candidate_id=candidate_id,
             declared_by=actor_id,
         )
+        if body.relation_kind is not None:
+            candidate = await set_candidate_relation_kind(
+                repo.session, org_id=repo.org_id, source_id=id, candidate_id=candidate_id,
+                relation_kind=body.relation_kind,
+            )
     except CandidateNotFoundError:
         raise HTTPException(status_code=404, detail="Reference candidate not found")
+    except InvalidRelationKindError:
+        raise HTTPException(status_code=400, detail="Invalid relation_kind")
     await repo.session.commit()
     return {
         "id": str(candidate.id),
         "status": candidate.status,
+        "relation_kind": candidate.relation_kind,
         "declared_by": str(candidate.declared_by) if candidate.declared_by else None,
         "declared_at": candidate.declared_at.isoformat() if candidate.declared_at else None,
     }

--- a/backend/tests/test_2328_reference_semantic_candidates_realdb.py
+++ b/backend/tests/test_2328_reference_semantic_candidates_realdb.py
@@ -369,6 +369,159 @@ async def test_declare_only_changes_status_declared_by_declared_at():
         await engine.dispose()
 
 
+# story #2358 QA(카디르, 2026-08-07 HIGH) — declare/relation-kind가 독립된 두 커밋이라 FE의
+# 순차 호출(declare 성공→relation-kind 실패)이 status=declared·relation_kind=NULL 영구 고아를
+# 만든다(관계 훑기 큐는 relation_kind IS NULL인 estimated만 다시 보여준다 — buildReviewQueue).
+# declare에 relation_kind를 옵션으로 실어 같은 트랜잭션(커밋 1회)으로 묶는다. 아래 셋이 그
+# 원자성을 실PG로 고정한다 — 특히 세 번째가 핵심(전부 아니면 전무).
+
+
+async def test_declare_with_relation_kind_atomically_sets_both():
+    """relation_kind가 body에 실리면 한 번의 POST·한 번의 커밋으로 status=declared와
+    relation_kind가 동시에 반영된다(중간 상태 없음)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 5010
+            await s.commit()
+            story = await _make_story(s, org.id, project.id, title="Source")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": "#5010 아무 단서 없음"},
+            )
+            assert resp.status_code == 200, resp.text
+            candidate_id = (
+                await client.get(f"/api/v2/stories/{story.id}/reference-candidates")
+            ).json()[0]["id"]
+
+            declare_resp = await client.post(
+                f"/api/v2/stories/{story.id}/reference-candidates/{candidate_id}/declare",
+                json={"relation_kind": "spawned"},
+            )
+            assert declare_resp.status_code == 200, declare_resp.text
+            body = declare_resp.json()
+            assert body["status"] == "declared"
+            assert body["relation_kind"] == "spawned"
+            assert body["declared_by"] is not None
+
+            async with Session() as s:
+                cands = await _candidates(s, org.id, story.id, source_field="description")
+                assert cands[0].status == "declared"
+                assert cands[0].relation_kind == "spawned"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_declare_without_relation_kind_body_stays_declare_only():
+    """회귀 0 — body 자체를 안 보내는 기존 호출부(순서 강제 없음 계약)는 그대로 declare만
+    한다. relation_kind는 손대지 않는다(None인 채)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 5011
+            await s.commit()
+            story = await _make_story(s, org.id, project.id, title="Source")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": "#5011 아무 단서 없음"},
+            )
+            assert resp.status_code == 200, resp.text
+            candidate_id = (
+                await client.get(f"/api/v2/stories/{story.id}/reference-candidates")
+            ).json()[0]["id"]
+
+            declare_resp = await client.post(
+                f"/api/v2/stories/{story.id}/reference-candidates/{candidate_id}/declare"
+            )
+            assert declare_resp.status_code == 200, declare_resp.text
+            body = declare_resp.json()
+            assert body["status"] == "declared"
+            assert body["relation_kind"] is None
+
+            async with Session() as s:
+                cands = await _candidates(s, org.id, story.id, source_field="description")
+                assert cands[0].status == "declared"
+                assert cands[0].relation_kind is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_declare_with_invalid_relation_kind_rolls_back_declare_too():
+    """⭐핵심 — relation_kind가 잘못돼(400) 원자화 전이었다면 declare(status→declared)만
+    먼저 커밋되고 kind만 실패하는 «반쪽 고아»가 생겼을 자리. 한 트랜잭션·한 커밋이면 kind
+    검증 실패 시 declare까지 전부 안 남는다(status는 estimated 그대로) — #2358 QA가 지적한
+    그 고아 상태가 애초에 만들어지지 않음을 실PG로 고정한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            target = await _make_story(s, org.id, project.id, title="Target")
+            target.story_number = 5012
+            await s.commit()
+            story = await _make_story(s, org.id, project.id, title="Source")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story.id}",
+                json={"description": "#5012 아무 단서 없음"},
+            )
+            assert resp.status_code == 200, resp.text
+            candidate_id = (
+                await client.get(f"/api/v2/stories/{story.id}/reference-candidates")
+            ).json()[0]["id"]
+
+            declare_resp = await client.post(
+                f"/api/v2/stories/{story.id}/reference-candidates/{candidate_id}/declare",
+                json={"relation_kind": "not_a_real_kind"},
+            )
+            assert declare_resp.status_code == 400, declare_resp.text
+
+            async with Session() as s:
+                cands = await _candidates(s, org.id, story.id, source_field="description")
+                # ⭐고아 방지 핵심 단언 — declare도 함께 롤백돼 estimated 그대로다.
+                assert cands[0].status == "estimated"
+                assert cands[0].declared_by is None
+                assert cands[0].declared_at is None
+                assert cands[0].relation_kind is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
 # story #2223(2026-07-30, 오르테가군 판정) — relation_kind 지정은 declare와 «다른 질문»이라
 # 별도 엔드포인트로 분리됐다. 아래 넷이 그 계약을 실PG로 고정한다.
 


### PR DESCRIPTION
## 배경
카디르 QA(#2358, 2026-08-07 HIGH) — `declare`(status→declared)와 `relation-kind`(kind 지정)가 독립된 두 커밋(`stories.py:943`/`988`)이라, FE의 순차 호출(declare 성공 → relation-kind만 실패)이 candidate를 `status=declared`·`relation_kind=NULL`로 영구 고아 상태로 만든다. `관계 훑기 큐`(`buildReviewQueue`/`selectUnconfirmedCandidates`)는 `relation_kind IS NULL` && `status=estimated`인 후보만 다시 보여주므로, 이 고아는 큐에서 영영 재노출되지 않는다.

그라운딩: `apps/web/.../flow-relation-review-queue.tsx`(미르코 WIP 브랜치 `feat/2358-relation-review-flow`, `handleDeclareWithKind`)가 정확히 이 순서(declare fetch → 성공 시 relation-kind fetch)로 구현돼 있음을 코드로 확인 — 아직 develop 미병합이라 실제 영향은 없었지만, 병합 시점에 바로 재현되는 구조였다.

## 처방
`POST .../declare`에 `relation_kind`를 옵션 필드로 추가. 실리면 같은 트랜잭션(같은 session, 커밋 1회)에서 declare + relation_kind를 함께 쓴다 — 둘 중 하나라도 실패하면 커밋 전이라 아무것도 안 남는다(전부 아니면 전무). 생략하면 기존 계약(declare만) 그대로 — `#2223`(오르테가군 판정 "한 클릭에 안 묶는다")을 어기지 않는다. `relation-kind` 단독 엔드포인트도 그대로 유지 — 순서 무관 호출 지원 불변.

## 검증(실PG)
- `test_2328_reference_semantic_candidates_realdb.py`에 3건 추가:
  - `test_declare_with_relation_kind_atomically_sets_both` — 한 번의 POST로 둘 다 반영
  - `test_declare_without_relation_kind_body_stays_declare_only` — 회귀 0(body 생략 시 기존 동작)
  - `test_declare_with_invalid_relation_kind_rolls_back_declare_too` — ⭐핵심(양성대조 완료): kind가 잘못돼 400이면 declare도 함께 롤백돼 `status=estimated` 그대로임을 고정. 원자화 前 코드(commit을 declare 직후로 되돌리는 sabotage)로는 이 테스트가 실패함을 직접 확인 후 복원 — 3/3 clean pass.
- 같은 파일 전체 23/23 pass, 인접 `test_2355`/`test_2363` 26/26 pass(회귀 없음).
- 무관 사전 실패(`test_2245_*`/`test_2288_*`/`test_2328_dependency_picker_candidate_boost_realdb.py` 6건) — 로컬 env에 `ALEMBIC_DATABASE_URL`(포트 54322 프록시) 미기동이 원인, 이 fix와 무관함을 `git stash`로 확인(수정 前 origin/develop에서도 동일 실패).

## FE 후속(별건, 이 PR 스코프 밖)
`flow-relation-review-queue.tsx`(`handleDeclareWithKind`)가 이 새 옵션 필드를 쓰도록 두 번의 fetch를 한 번으로 합치면 이 fix의 이득을 실제로 누린다 — 미르코 FE WIP 브랜치 쪽 후속으로 남김(이 PR은 BE 원자성 보장까지만, 안 바꿔도 기존 2-fetch 방식이 깨지지는 않음).

## Test plan
- [x] 실PG(로컬) 23/23 pass
- [x] 양성대조(sabotage→fail 확인→restore→pass) 완료
- [x] 인접 declare/relation-kind 소비 테스트(2355/2363) 회귀 없음