### PR TITLE
fix(#2156): merge-type 게이트에 실 CI/PR 증거 반영 + requires_human 정합화(critical)

### DIFF
--- a/backend/alembic/versions/0236_gate_requires_human_backfill.py
+++ b/backend/alembic/versions/0236_gate_requires_human_backfill.py
@@ -1,0 +1,32 @@
+"""story #2156 AC3/AC4(2026-08-07) — 기존 status=pending·requires_human=false gate 정합화.
+
+`create_gate`가 여태 `requires_human`을 대입하지 않아(merge-type만 `evaluate_merge_gate`가
+사후에 채움) DB 컬럼 기본값 False가 그대로 남은 기존 행들 — status는 disposition대로 정확히
+pending인데 requires_human=False가 "안 봐도 됨"으로 잘못 신호를 내 인박스에 안 떴다. 코드
+수정(create_gate)은 신규 행부터만 맞게 만들 뿐 기존 행은 그대로라, 배포해도 지금 쌓인 pending
+게이트들은 여전히 인박스에 안 뜬다 — 이 백필이 없으면 스토리 목표(pending인데 사람에게 안
+보이는 문제 해소) 미달이다(카디르 QA, PR#2902④).
+
+status='pending'인 행만 대상(auto_passed는 이미 requires_human=False가 맞다 — 사람이 볼 필요
+없는 게 사실). downgrade는 되돌릴 수 없다(백필 前 값이 진짜 False였는지 코드 버그로 인한
+False였는지 구분할 근거가 없음 — no-op).
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0236"
+down_revision = "0235"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "UPDATE gate SET requires_human = true "
+        "WHERE status = 'pending' AND requires_human = false"
+    )
+
+
+def downgrade() -> None:
+    pass  # 백필은 원 상태 구분 불가라 되돌리지 않는다(위 docstring 참조).

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -26,6 +26,10 @@ from app.models.github_installation import GithubInstallation, GithubWebhookDeli
 from app.models.pm import Story
 from app.routers.cron import CRON_SECRET, _err, _ok, verify_cron
 from app.services.github_app import get_installation_token
+from app.services.merge_verdict_gate import (
+    merge_gate_active,
+    reconcile_merge_gate_with_real_evidence,
+)
 from app.services.pr_story_link import merge_link_evidence, resolve_story_for_pr
 from app.services.verdict_capture import (
     capture_pr_ci_verdict,
@@ -441,6 +445,24 @@ async def _process_webhook_event(
     )
     if native_ci_state is not None:
         result = {**result, "native_ci": {"state": native_ci_state, "reason": native_ci_reason}}
+
+    # story #2156 AC2(2026-08-07) — 위 capture_pr_ci_verdict가 Verdict(신뢰축)엔 이미 실
+    # 증거를 정확히 기록했는데, resolve_gate_from_verdict(capture_pr_ci_verdict 내부)의
+    # _SOURCE_TO_GATE_TYPE엔 merge 매핑이 없어 그 증거가 merge-type 게이트엔 안 닿았다 —
+    # pending merge 게이트가 있을 때만 evaluate_merge_gate를 실 증거로 재호출해 반영한다.
+    # ⚠️capture_pr_ci_verdict 리턴 後 별도 호출(evaluate_merge_gate가 내부에서 capture_pr_
+    # ci_verdict를 다시 부르므로, 그 함수 안에서 이걸 부르면 무한 재귀가 된다).
+    if merge_gate_active(org_id):
+        try:
+            await reconcile_merge_gate_with_real_evidence(
+                session, org_id, story_id,
+                pr_number=pr_number, repo=repo, ci_result=ci_conclusion, merged=merged,
+            )
+        except Exception:
+            logger.warning(
+                "merge gate reconcile failed story=%s (swallowed·best-effort)",
+                story_id, exc_info=True,
+            )
 
     # ⭐story #2327 후속(PO 판정, 2026-07-30, PR#2685 실 웹훅 시험대가 드러낸 갭) — merge 시
     # PullRequestStoryLink 에도 쓴다. `Verdict`(record_verdict, 위 capture_pr_ci_verdict 안)에도

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -449,20 +449,19 @@ async def _process_webhook_event(
     # story #2156 AC2(2026-08-07) — 위 capture_pr_ci_verdict가 Verdict(신뢰축)엔 이미 실
     # 증거를 정확히 기록했는데, resolve_gate_from_verdict(capture_pr_ci_verdict 내부)의
     # _SOURCE_TO_GATE_TYPE엔 merge 매핑이 없어 그 증거가 merge-type 게이트엔 안 닿았다 —
-    # pending merge 게이트가 있을 때만 evaluate_merge_gate를 실 증거로 재호출해 반영한다.
-    # ⚠️capture_pr_ci_verdict 리턴 後 별도 호출(evaluate_merge_gate가 내부에서 capture_pr_
-    # ci_verdict를 다시 부르므로, 그 함수 안에서 이걸 부르면 무한 재귀가 된다).
+    # pending/auto_passed merge 게이트가 있을 때만 evaluate_merge_gate를 실 증거로 재호출해
+    # 반영한다. ⚠️capture_pr_ci_verdict 리턴 後 별도 호출(evaluate_merge_gate가 내부에서
+    # capture_pr_ci_verdict를 다시 부르므로, 그 함수 안에서 이걸 부르면 무한 재귀가 된다).
+    #
+    # ⭐카디르 QA(PR#2902, 2026-08-07)③: try/except로 여기서 삼키면 일시적 DB 오류가 "이번
+    # 배달은 영구 no-op(processed로 커밋)"이 돼 GitHub 재시도를 못 받는다(delivery 모델
+    # 자체 계약 — "실패=rollback→retry 보존"). 이 함수 밖(github_webhook)이 이미 예외를
+    # 전체 rollback+500으로 처리해 GitHub가 재시도하므로, 여기서 삼키지 않고 그대로 올린다.
     if merge_gate_active(org_id):
-        try:
-            await reconcile_merge_gate_with_real_evidence(
-                session, org_id, story_id,
-                pr_number=pr_number, repo=repo, ci_result=ci_conclusion, merged=merged,
-            )
-        except Exception:
-            logger.warning(
-                "merge gate reconcile failed story=%s (swallowed·best-effort)",
-                story_id, exc_info=True,
-            )
+        await reconcile_merge_gate_with_real_evidence(
+            session, org_id, story_id,
+            pr_number=pr_number, repo=repo, ci_result=ci_conclusion, merged=merged,
+        )
 
     # ⭐story #2327 후속(PO 판정, 2026-07-30, PR#2685 실 웹훅 시험대가 드러낸 갭) — merge 시
     # PullRequestStoryLink 에도 쓴다. `Verdict`(record_verdict, 위 capture_pr_ci_verdict 안)에도

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -436,6 +436,14 @@ async def create_gate(
         work_item_type=work_item_type,
         gate_type=gate_type,
         status=status,
+        # #2156 AC3(2026-08-07) — merge-type만 evaluate_merge_gate가 이후 이 필드를 정확히
+        # 채웠고(decision 기반), 그 외 gate_type(qa·pr_review·deploy 등)은 create_gate가 여태
+        # requires_human을 아예 대입하지 않아 DB 컬럼 기본값 False가 그대로 남았다 — status는
+        # disposition대로 정확히 pending인데 requires_human=False가 "안 봐도 됨"으로 잘못
+        # 신호를 내 인박스에 안 뜨는 원인이었다(유나 실측 "축 없음 4건"). status==pending이면
+        # 사람 결재가 필요하다는 뜻이니 그대로 반영 — merge-type은 evaluate_merge_gate가 바로
+        # 뒤에서 더 정확한 값(decision != AUTO_MERGE)으로 덮어써 이 기본값은 초기값일 뿐이다.
+        requires_human=(status == "pending"),
         # #2249: 신규 행이라 값 비교(set_gate_status)가 필요 없다 — 생성 시점이 곧 최초 진입 시각.
         status_entered_at=datetime.now(timezone.utc),
         neutral_facts=neutral_facts,

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -21,7 +21,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.models.gate import set_gate_evidence_status, set_gate_status
+from app.models.gate import Gate, set_gate_evidence_status, set_gate_status
 from app.models.participation import ParticipationRole
 from app.services.gate_resolver import (
     SOURCE_MEMBER_OVERRIDE,
@@ -455,4 +455,51 @@ async def evaluate_merge_gate(
         outcome_pending=outcome.pending,
         outcome_lower_bound=round(outcome.lower_bound, 4),
         outcome_regret=outcome.regret,
+    )
+
+
+async def reconcile_merge_gate_with_real_evidence(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    story_id: uuid.UUID,
+    *,
+    pr_number: int,
+    repo: str,
+    ci_result: str | None,
+    merged: bool,
+) -> MergeGateDecision | None:
+    """story #2156 AC2(2026-08-07) — GitHub 웹훅이 잡은 실 CI/PR verdict를 merge-type
+    게이트에 반영한다.
+
+    그라운딩(디디, 2026-08-07 라이브 DB 조회): SID/#번호 해소(story #2327, 07-30)는 이미
+    완결이라 `Verdict`엔 실 증거가 정확히 쌓이는데(dev 118건 ci/pr pass 확認), `resolve_
+    gate_from_verdict`의 `_SOURCE_TO_GATE_TYPE`엔 ci/pr→pr_review 매핑만 있고 **merge는
+    없다** — 그래서 그 증거가 done 전이를 막는 merge-type 게이트엔 한 번도 안 닿았다
+    (`_preflight_merge_gate`/board-done 경로는 컨텍스트가 없어 ci_result=None으로만 게이트를
+    만드니 매번 "CI unknown (self-report only)"로 굳는 게 근본).
+
+    pending인 merge-type 게이트가 있을 때만 `evaluate_merge_gate`를 실 증거로 재호출 —
+    새 판정 로직 0개, 기존 `_decide()`/trust/outcome을 그대로 재사용한다. story가 이미
+    board-done으로 먼저 넘어가 있어도 이 재평가는 gate row(audit) 갱신만 하고 story.status는
+    건드리지 않는다 — advisory(관측)/enforcing(집행) 축과 분리(그건 선생님 판단 축).
+
+    ⚠️호출 위치 주의 — `evaluate_merge_gate` 자신이 내부에서 `capture_pr_ci_verdict`를 이미
+    부른다. 이 함수를 `capture_pr_ci_verdict` 본문 안에서 부르면 무한 재귀가 된다 — 반드시
+    그 호출부(웹훅 핸들러 등) 쪽에서, `capture_pr_ci_verdict` 리턴 後에 별도로 부를 것.
+    """
+    existing = await session.execute(
+        select(Gate).where(
+            Gate.org_id == org_id,
+            Gate.work_item_id == story_id,
+            Gate.work_item_type == "story",
+            Gate.gate_type == MERGE_GATE_TYPE,
+            Gate.status == "pending",
+        ).limit(1)
+    )
+    if existing.scalar_one_or_none() is None:
+        return None
+    return await evaluate_merge_gate(
+        session, org_id, story_id,
+        pr_number=pr_number, repo=repo, ci_result=ci_result,
+        pr_result=("pass" if merged else None),
     )

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -478,10 +478,20 @@ async def reconcile_merge_gate_with_real_evidence(
     (`_preflight_merge_gate`/board-done 경로는 컨텍스트가 없어 ci_result=None으로만 게이트를
     만드니 매번 "CI unknown (self-report only)"로 굳는 게 근본).
 
-    pending인 merge-type 게이트가 있을 때만 `evaluate_merge_gate`를 실 증거로 재호출 —
-    새 판정 로직 0개, 기존 `_decide()`/trust/outcome을 그대로 재사용한다. story가 이미
-    board-done으로 먼저 넘어가 있어도 이 재평가는 gate row(audit) 갱신만 하고 story.status는
-    건드리지 않는다 — advisory(관측)/enforcing(집행) 축과 분리(그건 선생님 판단 축).
+    pending 또는 auto_passed인 merge-type 게이트가 있을 때만 `evaluate_merge_gate`를 실
+    증거로 재호출 — 새 판정 로직 0개, 기존 `_decide()`/trust/outcome을 그대로 재사용한다.
+    story가 이미 board-done으로 먼저 넘어가 있어도 이 재평가는 gate row(audit) 갱신만 하고
+    story.status는 건드리지 않는다 — advisory(관측)/enforcing(집행) 축과 분리(그건 선생님
+    판단 축).
+
+    ⭐카디르 QA(PR#2902, 2026-08-07)②: `status` 축(정책 disposition)과 `requires_human` 축
+    (증거 기반 decision)이 서로 다른 필드다 — `create_gate` 시점 `status="auto_passed"`(정책이
+    allow_auto)였어도 이후 `evaluate_merge_gate`가 self-report(ci=None) 등으로 재평가하며
+    `requires_human=True`(decision=ask_human)를 남겼을 수 있다. `status=="pending"`만 보면
+    이런 "auto_passed인데 실은 사람이 봐야 하는" 게이트를 놓친다 — `status IN
+    (pending, auto_passed)`로 넓힌다. `rejected`/`voided`/`held`는 의도적으로 제외한다(사람이
+    이미 명시 결정했거나 일시정지한 것을 CI 이벤트로 조용히 재오픈/간섭하면 안 된다 —
+    `create_gate`의 rejected 멱등 재오픈 분기가 웹훅 이벤트로 우발 트리거되는 것을 막는다).
 
     ⚠️호출 위치 주의 — `evaluate_merge_gate` 자신이 내부에서 `capture_pr_ci_verdict`를 이미
     부른다. 이 함수를 `capture_pr_ci_verdict` 본문 안에서 부르면 무한 재귀가 된다 — 반드시
@@ -493,7 +503,7 @@ async def reconcile_merge_gate_with_real_evidence(
             Gate.work_item_id == story_id,
             Gate.work_item_type == "story",
             Gate.gate_type == MERGE_GATE_TYPE,
-            Gate.status == "pending",
+            Gate.status.in_(("pending", "auto_passed")),
         ).limit(1)
     )
     if existing.scalar_one_or_none() is None:

--- a/backend/tests/test_2156_merge_gate_evidence_realdb.py
+++ b/backend/tests/test_2156_merge_gate_evidence_realdb.py
@@ -1,0 +1,311 @@
+"""story #2156(critical) — 결재 게이트가 실사용에서 아무것도 막지 않고 열 수도 없는 문제.
+
+그라운딩(디디, 2026-08-07):
+  AC1(왜 안 막혔나) — dev live env H1_MERGE_GATE_ADVISORY=true(선생님/PO 판단 축, 이 PR 스코프 밖).
+  AC2(evidence 20건 전원 insufficient) — `_preflight_merge_gate`(board PATCH→done, 팀이 실제로
+    쓰는 유일한 done 경로)가 `evaluate_merge_gate(ci_result=None, pr_result=None)`을 하드코딩으로
+    부른다. GitHub 웹훅은 실제로 살아 있고(dev 38,410건 전체·118 verdict 정확 기록) SID/#번호
+    해소도 이미 완결(#2327, 2026-07-30)인데, `resolve_gate_from_verdict`의 `_SOURCE_TO_GATE_TYPE`
+    에 ci/pr→pr_review 매핑만 있고 **merge 매핑이 없어** 그 실 증거가 merge-type 게이트엔 한 번도
+    안 닿았다. 이 PR은 그 매핑 갭을 새 판정 로직 없이 `evaluate_merge_gate` 재호출로 메운다.
+  AC3(축 없음 4건) — `create_gate`가 `gate.requires_human`을 애초에 대입 안 해(merge-type만
+    evaluate_merge_gate가 사후에 채움) DB 컬럼 기본값 False가 non-merge gate_type에 그대로
+    남았다. status는 disposition대로 정확한데 requires_human만 틀려 인박스에 안 뜬 것.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.destructive_schema,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    import app.models  # noqa: F401 — 전 모델 메타데이터 로드
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_story_with_participation(session):
+    from app.models.organization import Organization
+    from app.models.participation import Participation, ParticipationRole
+    from app.models.pm import Story
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Merge gate target")
+    session.add(story)
+    await session.commit()
+
+    role = ParticipationRole(id=uuid.uuid4(), org_id=org.id, key="dev", label="Dev", is_default=True)
+    session.add(role)
+    await session.commit()
+
+    member_id = uuid.uuid4()
+    participation = Participation(
+        id=uuid.uuid4(), org_id=org.id, story_id=story.id, role_id=role.id, member_id=member_id,
+    )
+    session.add(participation)
+    await session.commit()
+
+    return {"org_id": org.id, "story_id": story.id, "member_id": member_id}
+
+
+async def _gate_row(session, story_id):
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+
+    result = await session.execute(
+        select(Gate).where(Gate.work_item_id == story_id, Gate.gate_type == "merge")
+    )
+    return result.scalar_one_or_none()
+
+
+@pytest.mark.anyio
+async def test_board_preflight_style_call_creates_insufficient_evidence_gate_realdb():
+    """근본 재현 — `_preflight_merge_gate`가 실제로 하는 그 호출(ci=None·pr_number=0)을 그대로
+    재현하면 decision_basis가 정확히 "CI unknown (self-report only)"로 고정됨을 먼저 고정한다."""
+    from app.services.merge_verdict_gate import evaluate_merge_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_story_with_participation(s)
+
+            with (
+                patch(
+                    "app.services.merge_verdict_gate.resolve_disposition",
+                    AsyncMock(return_value=("ask", "org_policy")),
+                ),
+                patch(
+                    "app.services.merge_verdict_gate._is_meaningfully_explicit_ask",
+                    AsyncMock(return_value=True),
+                ),
+            ):
+                decision = await evaluate_merge_gate(
+                    s, seeded["org_id"], seeded["story_id"],
+                    pr_number=0, repo="", ci_result=None, pr_result=None,
+                )
+            await s.commit()
+
+            assert decision.reason == "CI unknown (self-report only)"
+            gate = await _gate_row(s, seeded["story_id"])
+            assert gate is not None
+            assert gate.status == "pending"
+            assert gate.evidence_status == "insufficient"
+            assert gate.decision_basis == "CI unknown (self-report only)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_capture_pr_ci_verdict_alone_does_not_touch_merge_gate_confirms_root_cause_realdb():
+    """⭐근본 확認(양성대조 대응) — 이 PR의 새 배선 없이(capture_pr_ci_verdict만) 실 증거를
+    기록해도 merge-type 게이트는 전혀 안 바뀐다(그것이 애초에 이 스토리의 근본이었다).
+    `_SOURCE_TO_GATE_TYPE`에 merge 매핑이 없다는 코드 사실을 실측으로 고정."""
+    from app.services.merge_verdict_gate import evaluate_merge_gate
+    from app.services.verdict_capture import capture_pr_ci_verdict
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_story_with_participation(s)
+            with (
+                patch(
+                    "app.services.merge_verdict_gate.resolve_disposition",
+                    AsyncMock(return_value=("ask", "org_policy")),
+                ),
+                patch(
+                    "app.services.merge_verdict_gate._is_meaningfully_explicit_ask",
+                    AsyncMock(return_value=True),
+                ),
+            ):
+                await evaluate_merge_gate(
+                    s, seeded["org_id"], seeded["story_id"],
+                    pr_number=0, repo="", ci_result=None, pr_result=None,
+                )
+            await s.commit()
+
+            # 이 PR이 고치는 배선(reconcile_merge_gate_with_real_evidence) 없이, 실 웹훅이 매번
+            # 부르던 그 함수(capture_pr_ci_verdict) 하나만으로 실 증거를 기록.
+            await capture_pr_ci_verdict(
+                s, org_id=seeded["org_id"], story_id=seeded["story_id"],
+                pr_number=42, repo="moonklabs/sprintable", merged=True, ci_result="pass",
+            )
+            await s.commit()
+
+            gate = await _gate_row(s, seeded["story_id"])
+            assert gate.decision_basis == "CI unknown (self-report only)", (
+                "capture_pr_ci_verdict만으로 merge 게이트가 바뀌면 안 된다 — "
+                "_SOURCE_TO_GATE_TYPE에 merge 매핑이 없다는 게 이 스토리의 근본이다."
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reconcile_updates_pending_merge_gate_with_real_evidence_realdb():
+    """⭐핵심 — reconcile_merge_gate_with_real_evidence가 실 ci/pr 증거로 pending merge 게이트를
+    재평가한다. cold-start(outcome 표본 0<3)라 최종 decision은 여전히 ask_human이지만, 그
+    reason이 "CI unknown"에서 "outcome sample insufficient"로 바뀐다 — 실 증거가 게이트에
+    도달했다는 관측 가능한 증거."""
+    from app.services.merge_verdict_gate import evaluate_merge_gate, reconcile_merge_gate_with_real_evidence
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_story_with_participation(s)
+            with (
+                patch(
+                    "app.services.merge_verdict_gate.resolve_disposition",
+                    AsyncMock(return_value=("ask", "org_policy")),
+                ),
+                patch(
+                    "app.services.merge_verdict_gate._is_meaningfully_explicit_ask",
+                    AsyncMock(return_value=True),
+                ),
+            ):
+                await evaluate_merge_gate(
+                    s, seeded["org_id"], seeded["story_id"],
+                    pr_number=0, repo="", ci_result=None, pr_result=None,
+                )
+                await s.commit()
+
+                decision = await reconcile_merge_gate_with_real_evidence(
+                    s, seeded["org_id"], seeded["story_id"],
+                    pr_number=42, repo="moonklabs/sprintable", ci_result="pass", merged=True,
+                )
+            await s.commit()
+
+            assert decision is not None
+            assert "CI unknown" not in decision.reason
+            assert "outcome sample insufficient" in decision.reason
+
+            # neutral_facts는 create_gate의 멱등 분기(기존 gate 재사용)가 새 값으로 안 덮는다
+            # (별건 — 이 PR 스코프 밖). decision_basis/evidence_status는 evaluate_merge_gate가
+            # 재평가마다 gate 객체에 직접 대입하므로 여기서 확実히 갱신된다(이게 이 fix의 계약).
+            gate = await _gate_row(s, seeded["story_id"])
+            assert gate.decision_basis != "CI unknown (self-report only)"
+            assert gate.decision_basis == decision.reason
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reconcile_is_noop_when_no_pending_merge_gate_exists_realdb():
+    """게이트가 없으면(또는 이미 terminal이면) 새로 만들지 않는다 — reconcile은 «반영»이지
+    「생성」이 아니다."""
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+    from app.services.merge_verdict_gate import reconcile_merge_gate_with_real_evidence
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_story_with_participation(s)
+
+            decision = await reconcile_merge_gate_with_real_evidence(
+                s, seeded["org_id"], seeded["story_id"],
+                pr_number=42, repo="moonklabs/sprintable", ci_result="pass", merged=True,
+            )
+            await s.commit()
+
+            assert decision is None
+            rows = (
+                await s.execute(select(Gate).where(Gate.work_item_id == seeded["story_id"]))
+            ).scalars().all()
+            assert len(rows) == 0, "pending gate가 없는데 reconcile이 새 게이트를 만들었다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_gate_sets_requires_human_true_for_pending_non_merge_gate_realdb():
+    """AC3 핵심 — qa/pr_review 등 merge 아닌 gate_type도 status=pending이면 requires_human=True
+    가 생성 시점에 채워진다(전엔 DB 기본값 False가 그대로 남아 인박스에 안 떴다)."""
+    from app.services.gate_service import create_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_story_with_participation(s)
+
+            with patch(
+                "app.services.gate_service.resolve_disposition",
+                AsyncMock(return_value=("ask", "org_policy")),
+            ):
+                gate = await create_gate(
+                    s, seeded["org_id"], seeded["story_id"], "story", "qa",
+                    seeded["member_id"], uuid.uuid4(),
+                )
+            await s.commit()
+
+            assert gate.status == "pending"
+            assert gate.requires_human is True, (
+                "status=pending인데 requires_human=False — 인박스에 결재 필요로 안 뜬다"
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_gate_sets_requires_human_false_for_auto_passed_gate_realdb():
+    """회귀 0 — disposition=allow_auto(status=auto_passed)면 requires_human=False가 여전히
+    맞다(사람이 볼 필요 없는 게 사실)."""
+    from app.services.gate_service import create_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_story_with_participation(s)
+
+            with patch(
+                "app.services.gate_service.resolve_disposition",
+                AsyncMock(return_value=("allow_auto", "org_policy")),
+            ):
+                gate = await create_gate(
+                    s, seeded["org_id"], seeded["story_id"], "story", "qa",
+                    seeded["member_id"], uuid.uuid4(),
+                )
+            await s.commit()
+
+            assert gate.status == "auto_passed"
+            assert gate.requires_human is False
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2156_merge_gate_evidence_realdb.py
+++ b/backend/tests/test_2156_merge_gate_evidence_realdb.py
@@ -285,6 +285,108 @@ async def test_create_gate_sets_requires_human_true_for_pending_non_merge_gate_r
 
 
 @pytest.mark.anyio
+async def test_reconcile_picks_up_auto_passed_gate_with_requires_human_true_realdb():
+    """⭐카디르 QA(PR#2902, 2026-08-07)② — status="pending"만 보면 "정책은 allow_auto(status=
+    auto_passed)였는데 이후 self-report 재평가가 requires_human=True를 남긴" 게이트를
+    reconcile이 놓친다. 이 케이스를 실제로 재현(disposition=allow_auto+pr_number>0으로
+    status=auto_passed 게이트 생성 → ci=None 재평가로 requires_human=True만 남음)하고,
+    reconcile이 그런 게이트도 실 증거로 갱신함을 고정한다."""
+    from app.services.merge_verdict_gate import evaluate_merge_gate, reconcile_merge_gate_with_real_evidence
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_story_with_participation(s)
+
+            with patch(
+                "app.services.gate_service.resolve_disposition",
+                AsyncMock(return_value=("allow_auto", "org_policy")),
+            ):
+                # pr_number>0(no-substance 단축 회피) + ci=None → status=auto_passed로
+                # 생성되지만 _decide()는 ci=None이라 무조건 ASK_HUMAN → requires_human=True.
+                # ⚠️patch 대상은 create_gate가 실제로 부르는 gate_service.py의 자기 바인딩
+                # (merge_verdict_gate.py의 no-substance 체크용 바인딩과 다르다 — pr_number>0
+                # 이라 그 체크는 안 거친다).
+                await evaluate_merge_gate(
+                    s, seeded["org_id"], seeded["story_id"],
+                    pr_number=99, repo="moonklabs/sprintable", ci_result=None, pr_result=None,
+                )
+                await s.commit()
+
+                gate = await _gate_row(s, seeded["story_id"])
+                assert gate.status == "auto_passed"
+                assert gate.requires_human is True, "카디르가 짚은 그 불일치 상태 재현 실패"
+
+                decision = await reconcile_merge_gate_with_real_evidence(
+                    s, seeded["org_id"], seeded["story_id"],
+                    pr_number=99, repo="moonklabs/sprintable", ci_result="pass", merged=True,
+                )
+            await s.commit()
+
+            assert decision is not None, (
+                "status=='pending'만 보면 auto_passed+requires_human=True 게이트를 놓친다"
+            )
+            gate = await _gate_row(s, seeded["story_id"])
+            assert gate.decision_basis != "CI unknown (self-report only)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_process_webhook_event_does_not_swallow_reconcile_exception():
+    """⭐카디르 QA(PR#2902, 2026-08-07)③ — reconcile 실패를 이 함수 안에서 삼키면 일시 DB
+    오류가 그 배달을 "processed"로 영구 커밋시켜 GitHub 재시도를 못 받는다. github_webhook
+    (바깥 핸들러)이 이미 예외를 rollback+500으로 처리해 GitHub가 재시도하므로, 여기선 그대로
+    올려야 한다."""
+    from app.models.github_installation import GithubInstallation, GithubWebhookDelivery
+    from app.routers.verdict_capture import _process_webhook_event
+    from app.services.pr_story_link import ResolvedLink
+
+    story_id = uuid.uuid4()
+    org_id = uuid.uuid4()
+    installation = GithubInstallation(
+        id=uuid.uuid4(), installation_id=123, org_id=org_id, account_login="moonklabs",
+    )
+    delivery = GithubWebhookDelivery(
+        id=uuid.uuid4(), source="app", delivery_id="d1", event="pull_request", status="received",
+    )
+    payload = {
+        "repository": {"full_name": "moonklabs/sprintable"},
+        "pull_request": {
+            "number": 42, "merged": True, "title": "fix(#1): x",
+            "head": {"ref": "fix/1-x", "sha": "abc"},
+        },
+        "action": "closed",
+        "installation": {"id": 123},
+    }
+
+    session = AsyncMock()
+    exec_result = AsyncMock()
+    exec_result.scalar_one_or_none = lambda: installation
+    session.execute = AsyncMock(return_value=exec_result)
+
+    with (
+        patch(
+            "app.routers.verdict_capture.resolve_story_for_pr",
+            AsyncMock(return_value=ResolvedLink(story_id, org_id, "sid", "high", True, "sid_exact")),
+        ),
+        patch(
+            "app.routers.verdict_capture.capture_pr_ci_verdict",
+            AsyncMock(return_value={"recorded": ["pr"], "skipped_reason": None}),
+        ),
+        patch("app.routers.verdict_capture.merge_link_evidence", AsyncMock()),
+        patch("app.routers.verdict_capture.get_installation_token", AsyncMock(return_value=None)),
+        patch("app.routers.verdict_capture.merge_gate_active", lambda _org_id: True),
+        patch(
+            "app.routers.verdict_capture.reconcile_merge_gate_with_real_evidence",
+            AsyncMock(side_effect=RuntimeError("transient db error")),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="transient db error"):
+            await _process_webhook_event(session, "app", "pull_request", payload, 123, delivery)
+
+
+@pytest.mark.anyio
 async def test_create_gate_sets_requires_human_false_for_auto_passed_gate_realdb():
     """회귀 0 — disposition=allow_auto(status=auto_passed)면 requires_human=False가 여전히
     맞다(사람이 볼 필요 없는 게 사실)."""


### PR DESCRIPTION
## 배경
#2156(critical) — 결재 게이트가 실사용에서 아무것도 막지 않고 열 수도 없다. 유나 실측 24건(현재 46건)이 전부 `evidence_status=insufficient`.

## 그라운딩(디디, 2026-08-07 라이브)
- dev Cloud Run env 실측: `H1_MERGE_GATE_ADVISORY=true` — done 차단(409)이 매번 스킵되는 이유. **인프라 토글이라 이 PR 스코프 밖**(PO가 선생님께 별도 판단 요청 중).
- GitHub 웹훅은 살아있고(전체 38,410건, 최근 실시간 확인) SID/#번호 기반 story 해소도 이미 완결(story #2327, 2026-07-30) — `pull_request_story_link` 312건·`verdict` 118건(ci/pr pass) 정확히 기록 중.
- 그런데 `resolve_gate_from_verdict`의 `_SOURCE_TO_GATE_TYPE`엔 `ci→pr_review`/`pr→pr_review`/`qa→qa`/`design→deploy`만 있고 **`merge` 매핑이 없음** — 실 증거가 아무리 잘 기록돼도 done 전이를 막는 merge-type 게이트엔 도달할 길이 없었다. `_preflight_merge_gate`(board PATCH→done, 팀이 실제로 쓰는 유일한 done 경로)는 `evaluate_merge_gate(ci_result=None, pr_result=None)`을 하드코딩으로 부르니 매번 `"CI unknown (self-report only)"`로 굳는다.
- 별건(AC3): `create_gate`가 `gate.requires_human`을 애초에 대입하지 않아(merge-type만 `evaluate_merge_gate`가 사후에 채움) 다른 gate_type(qa 등)은 DB 컬럼 기본값 `False`가 그대로 남았다 — `status`는 disposition대로 정확히 `pending`인데 `requires_human=False`가 "안 봐도 됨"으로 잘못 신호를 내 인박스에 안 뜬 것.

## 처방
- **AC2**: `merge_verdict_gate.reconcile_merge_gate_with_real_evidence()` 신설. pending merge-type 게이트가 있을 때만 `evaluate_merge_gate`를 실 ci/pr 증거로 재호출 — 새 판정 로직 0개, 기존 `_decide()`/trust/outcome 재사용. `verdict_capture.py` 웹훅 핸들러가 `capture_pr_ci_verdict` 리턴 **後**에 호출(그 함수 내부에서 부르면 `evaluate_merge_gate`가 다시 `capture_pr_ci_verdict`를 부르는 무한 재귀가 되므로 반드시 바깥에서).
- **AC3**: `create_gate`가 모든 gate_type에 대해 생성 시점에 `requires_human = (status == "pending")`을 채움. merge-type은 `evaluate_merge_gate`가 곧바로 더 정확한 값(decision 기반)으로 덮어써 무해.
- **AC1**(advisory→enforcing flip)은 인프라 lane이라 스코프 밖.

## 검증(실PG)
`test_2156_merge_gate_evidence_realdb.py` 신규 6건:
- 근본 재현(board-preflight 호출 패턴 → decision_basis="CI unknown (self-report only)" 고정)
- ⭐양성대조: `capture_pr_ci_verdict` 단독으로는 merge 게이트가 안 바뀜을 실측으로 고정(이게 이 스토리의 근본이었다는 증거)
- `reconcile_merge_gate_with_real_evidence` 핵심 동작(실 증거로 decision_basis 갱신, cold-start라 최종 decision은 ask_human이지만 reason이 "outcome sample insufficient"로 바뀜)
- no-op 안전성(pending 게이트 없으면 새로 안 만듦)
- `requires_human` 정합화 양방향(pending→True, auto_passed→False 회귀 없음)

6/6 pass. 양성대조(② ③ 각각 sabotage→fail 확인→restore→pass) 완료. 인접 gate/merge-gate 스위트(gate_entered_at·request_verification·gate_create_project_scope·merge_verdict_gate·h1_s4/s5/s10·merge_gate_reject_resubmit·explicit_ask_gate·edg_s5·gate_project_id_threading) 85/87 pass — 2건은 `create_all` 스키마 갭(`projects.violation_level` NOT NULL)으로 이 PR과 무관, `git stash`로 수정 前 origin/develop에서도 동일 실패 확인.

## Test plan
- [x] 실PG(로컬) 6/6 pass
- [x] 양성대조(AC2/AC3 각각) 완료
- [x] 인접 gate 스위트 회귀 없음(85/87, 2건 pre-existing 무관 확인)