### PR TITLE
[SID:2262] 참조 카드 PR① — 사실성·표면·지점 표기 + 모달 status 배선

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -107,6 +107,44 @@ describe('ChatBubble — story #2263 AC6 유령 칩(stored 참조 대조)', () =
   });
 });
 
+describe('ChatBubble — story #2262 AC1(사실성·표면·지점 표기, doc flow-map-blueprint-v1 §2-3)', () => {
+  it('stored 참조가 form·referenced_at을 실으면 칩에 "관찰됨 · {표면} · {지점}"이 표기된다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{
+            ...baseMessage,
+            references: [{ target_type: 'doc', target_id: DOC_ID, form: 'mention', referenced_at: '2026-07-26T00:00:00.000Z' }],
+          }}
+          isMine={false}
+        />,
+      ));
+    });
+    expect(container.textContent).toContain('관찰됨');
+    expect(container.textContent).toContain('멘션');
+    expect(container.textContent).toContain('7/26');
+  });
+
+  it('매칭되는 stored 참조가 있어도 form·referenced_at이 없으면(구서버 폴백) 표기를 지어내지 않는다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, references: [{ target_type: 'doc', target_id: DOC_ID }] }}
+          isMine={false}
+        />,
+      ));
+    });
+    expect(container.textContent).not.toContain('관찰됨');
+  });
+
+  it('유령 칩(매칭 없음)에는 사실성·표면·지점을 표기하지 않는다', async () => {
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={{ ...baseMessage, references: [] }} isMine={false} />));
+    });
+    expect(container.textContent).not.toContain('관찰됨');
+  });
+});
+
 describe('ChatBubble — story #2319 tombstone(메시지 삭제) 렌더', () => {
   it('deleted_at이 있으면 원문 대신 placeholder를 그린다', async () => {
     const deletedMsg: ChatMessage = { ...baseMessage, content: '', deleted_at: '2026-08-02T00:00:00.000Z' };

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -64,6 +64,24 @@ function isGhostReference(
   return !references.some((r) => r.target_type.toLowerCase() === type && r.target_id.toLowerCase() === id);
 }
 
+// story #2262 AC1(2026-08-08) — doc `flow-map-blueprint-v1` §2-3 「사실성 · 표면 · 지점」의
+// «표면·지점» 재료. isGhostReference와 같은 대조를 한 번 더 해 form·referenced_at까지
+// 끌어온다(스토리 자신의 AC1 정의: 표면=form('mention'|'embed'|'proof'), 지점=referenced_at —
+// "이 참조가 «언제 생겼나»"이지 대상이 「언제 만들어졌나」가 아니다). 매칭 없으면(유령이거나
+// references 자체가 없으면) null — 그때는 칩에 표기하지 않는다(모르는 것을 지어내지 않는다).
+function findReferenceMeta(
+  references: ChatMessage['references'],
+  targetType: string,
+  targetId: string,
+): { form: string; referencedAt: string } | null {
+  if (!references) return null;
+  const type = targetType.toLowerCase();
+  const id = targetId.toLowerCase();
+  const match = references.find((r) => r.target_type.toLowerCase() === type && r.target_id.toLowerCase() === id);
+  if (!match || !match.form || !match.referenced_at) return null;
+  return { form: match.form, referencedAt: match.referenced_at };
+}
+
 // Convert @name tokens to markdown links so react-markdown v10 can render them via the `a` component.
 // Uses negative lookbehind to skip already-linked mentions (e.g. inside [...]).
 function prepareMentions(content: string): string {
@@ -193,7 +211,17 @@ function ChatMarkdown({ content, isMine, references }: { content: string; isMine
           return <AssetEmbedCard entityId={m[2]!} label={String(children)} ownMessage={isMine} />;
         }
         const ghost = isGhostReference(references, m[1]!, m[2]!);
-        return <EntityChip entityType={m[1]!} entityId={m[2]!} label={String(children)} href={getEntityHref(m[1]!, m[2]!)} ghost={ghost} />;
+        const referenceMeta = ghost ? null : findReferenceMeta(references, m[1]!, m[2]!);
+        return (
+          <EntityChip
+            entityType={m[1]!}
+            entityId={m[2]!}
+            label={String(children)}
+            href={getEntityHref(m[1]!, m[2]!)}
+            ghost={ghost}
+            referenceMeta={referenceMeta}
+          />
+        );
       }
       return <a href={href} target="_blank" rel="noopener noreferrer" className={`underline underline-offset-2 ${text}`}>{children}</a>;
     },

--- a/apps/web/src/components/chat/embed-card.link-states.test.tsx
+++ b/apps/web/src/components/chat/embed-card.link-states.test.tsx
@@ -173,3 +173,45 @@ describe('AC4 — 조회 실패(대상 사라짐)는 "대상이 없습니다"로
     expect(document.body.textContent).not.toContain('열 수 있는 화면이 없습니다');
   });
 });
+
+describe('story #2262 AC2(2026-08-08, 쉬운 절반) — 모달이 자기 fetch한 detail.status를 물린다', () => {
+  // entity_type="task"를 쓴다 — EntityDetail이 story/epic에는 자기 status 뱃지(MdBadge)를
+  // 이미 body에 그리지만 task엔 그 분기가 없어(embed-card.tsx EntityDetail), 헤더 배선만
+  // 값으로 깨끗하게 격리해 잰다.
+  it('status prop이 null(EntityChip 호출부처럼 status를 모름)이어도 fetch한 detail.status를 헤더 뱃지로 보인다', async () => {
+    stubFetch(async (url) => {
+      expect(url).toContain('/api/tasks/');
+      return { ok: true, json: async () => ({ data: { status: 'in-review', story_id: 's-parent' } }) };
+    });
+    await act(async () => {
+      root.render(<EmbedCard entity_type="task" entity_id="t1" title="작업 A" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(document.body.textContent).toContain('in-review');
+  });
+
+  it('status prop이 이미 실려 있으면(EmbedCard 자신의 write-response 경로) 그 값을 헤더가 우선한다', async () => {
+    stubFetch(async () => ({ ok: true, json: async () => ({ data: { status: 'done', story_id: 's-parent' } }) }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="task" entity_id="t1" title="작업 A" status="ready-for-dev" />);
+    });
+    await openCard();
+    await flush();
+    // 헤더는 카드 자체에도 뜨고(inner) 모달에도 뜬다 — 둘 다 prop 값이어야 하고, fetch가 준
+    // "done"은 헤더 어디에도 안 나타나야 한다(task는 EntityDetail 자기 status 표시가 없다).
+    const readyForDevCount = (document.body.textContent!.match(/ready-for-dev/g) ?? []).length;
+    expect(readyForDevCount).toBeGreaterThanOrEqual(2);
+    expect(document.body.textContent).not.toContain('done');
+  });
+
+  it('fetch가 실패해도(대상 없음) status 뱃지를 지어내지 않는다 — 모르는 것을 단정하지 않는다', async () => {
+    stubFetch(async () => ({ ok: false, json: async () => ({}) }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="task" entity_id="t-gone" title="사라진 작업" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(document.body.textContent).toContain('대상이 없습니다');
+  });
+});

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -293,6 +293,12 @@ function EntityPreviewModal({
 
   const colorClass = ENTITY_COLORS[entityType] ?? GRAY_STATE_COLOR;
   const label = title ?? entityId;
+  // story #2262 AC2(2026-08-08, 쉬운 절반) — 호출부(EntityChip)는 status를 모르고 항상
+  // null을 넘긴다(칩 자체는 fetch를 안 하므로). 이 모달은 이미 자기 detail을 fetch하므로
+  // (위 effect) 그 안의 status를 물린다 — prop이 실려 오면(EmbedCard 경로처럼 이미 아는
+  // 값이 있으면) 그걸 우선한다. 칩 자체(모달 열기 前)에 상태를 보이는 건 별건(PR②,
+  // 타입별 배치조회 인프라 필요 — references 사이드밴드엔 status가 없다).
+  const resolvedStatus = status ?? (typeof (detail as { status?: unknown } | null)?.status === 'string' ? (detail as { status: string }).status : null);
 
   // story #2302 AC3 — ①own-href(정적) / ②via-parent(레코드 fetch 필요) / ③없음, 세 갈래를
   // "카드 전체를 죽이지 않는다"(AC4) 원칙대로 여기서만 계산 — 헤더의 아이콘·제목·상태는 이 값과
@@ -353,8 +359,8 @@ function EntityPreviewModal({
           <div className={`flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm ${colorClass} flex-1 min-w-0`}>
             <EntityGlyph Icon={resolveEntityIcon(entityType)} label={label} />
             <DialogTitle className="font-semibold truncate text-sm">{label}</DialogTitle>
-            {status ? (
-              <span className="ml-auto shrink-0 rounded px-1.5 py-0.5 text-xs bg-black/10 dark:bg-white/10">{status}</span>
+            {resolvedStatus ? (
+              <span className="ml-auto shrink-0 rounded px-1.5 py-0.5 text-xs bg-black/10 dark:bg-white/10">{resolvedStatus}</span>
             ) : null}
           </div>
           <button
@@ -518,12 +524,30 @@ export function EmbedCard({ entity_type, entity_id, title, status }: EmbedCardDa
   );
 }
 
+// story #2262 AC1(2026-08-08) — doc `flow-map-blueprint-v1` §2-3 표기 세 조각의 「표면」.
+// 스토리 본문의 AC1 정의 그대로: form은 'mention'|'embed'|'proof' 셋뿐(FORMS,
+// backend/app/models/reference.py) — 채팅 멘션 파서는 오늘 "mention"만 낸다(다른 값은
+// 문서·증빙 경로가 낼 수 있어 표는 셋 다 갖춘다).
+const FORM_LABELS: Record<string, string> = { mention: '멘션', embed: '임베드', proof: '근거' };
+
+// 「지점」 — referenced_at(이 참조가 «언제 생겼나»)을 짧게. 블루프린트 예시("7/26 스레드")와
+// 같은 월/일 압축 표기 — 채팅 칩은 그 자체가 스레드 맥락이라 별도 "스레드" 접미어를 안 붙인다.
+function formatReferencePoint(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  // Intl 로케일 포맷("7. 26.")은 블루프린트 예시("7/26")와 안 맞다 — 직접 M/D로 고정한다.
+  // UTC 기준(로컬 타임존에 따라 날짜가 하루 밀리는 것을 피한다 — referenced_at은 대략적인
+  // 「언제」 지표라 타임존 정밀도가 필요 없다).
+  return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`;
+}
+
 export function EntityChip({
   entityType,
   entityId,
   label,
   href,
   ghost = false,
+  referenceMeta = null,
 }: {
   entityType: string;
   entityId?: string;
@@ -534,6 +558,9 @@ export function EntityChip({
    * 회색 하나(GRAY_STATE_COLOR)·행동 0(클릭·모달 없음)·기본 커서·문구는 이미 선 "대상이
    * 없습니다"(신규 문구 발명 금지). */
   ghost?: boolean;
+  /** story #2262 AC1 — 「사실성 · 표면 · 지점」. null이면(유령이거나 references 자체가
+   * 없는 경로) 표기하지 않는다 — 모르는 것을 지어내지 않는다(가디언 §H-2와 같은 원칙). */
+  referenceMeta?: { form: string; referencedAt: string } | null;
 }) {
   const [showModal, setShowModal] = useState(false);
   const colorClass = ghost ? GRAY_STATE_COLOR : (ENTITY_COLORS[entityType] ?? GRAY_STATE_COLOR);
@@ -542,6 +569,13 @@ export function EntityChip({
     <span className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs font-medium ${colorClass}`}>
       <EntityGlyph Icon={resolveEntityIcon(entityType)} label={label} className="size-3 shrink-0" />
       <span>{ghost ? '대상이 없습니다' : label}</span>
+      {/* AC1 — 사실성(상수 "관찰됨": entity_references 자체가 관찰됨 tier) · 표면 · 지점.
+          ⛔색으로만 구분하지 않고 글자로 적는다(가디언 규율 재사용). */}
+      {referenceMeta ? (
+        <span className="opacity-70">
+          · 관찰됨 · {FORM_LABELS[referenceMeta.form] ?? referenceMeta.form} · {formatReferencePoint(referenceMeta.referencedAt)}
+        </span>
+      ) : null}
     </span>
   );
 

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -39,7 +39,11 @@ export interface ChatMessage {
    * 자체가 없음 — SSE 디스패치·전송 직후 응답 등 이 필드를 안 주는 경로)와 `[]`(읽기 경로가
    * 실제로 0건을 확認)를 구분한다 — 전자는 "판단 재료 없음"이라 유령 판정을 보류(폴백,
    * 기존처럼 그대로 그린다)하고, 후자는 본문 토큰과 대조해 유령을 가른다. */
-  references?: Array<{ target_type: string; target_id: string }>;
+  /** story #2262 AC1(2026-08-08) — `form`·`referenced_at`는 `fetch_stored_references()`가
+   * 이미 실어 오던 필드인데(mention_parser.py) 이 타입이 `target_type`·`target_id`만 받아
+   * 그동안 버려지고 있었다. `form`: 'mention'|'embed'|'proof'(표면) · `referenced_at`:
+   * ISO8601(이 참조가 «언제 생겼나» — 대상이 언제 만들어졌나가 아니다). */
+  references?: Array<{ target_type: string; target_id: string; form?: string; referenced_at?: string }>;
   /** story #2349 — 「내가 이 메시지의 보낸이를 차단했는가」(주어=나). references와 같은 축:
    * 서버가 내려주되(tombstone처럼 안 내려주는 게 아니다) 가리는 건 클라 몫이다. `undefined`는
    * "판단 재료 없음"(이 필드를 안 주는 경로)이라 마스킹을 보류한다 — false로 기본값을 주면


### PR DESCRIPTION
## 배경

`[C-4·핵심·베끼지 않는 자리] 참조가 «지금 상태와 다음 행동»을 들고 온다` — 13pt 대형 스토리를 4개 PR로 쪼갠 첫 번째(PO 승인). AC1(사실성·표면·지점)+AC2 쉬운 절반(모달 status 배선)만 스코프.

## ⭐착수 전 그라운딩에서 나온 정정

원래 "PR①=AC9③(읽기 응답에 stored 참조 싣기)"로 스코프를 잡았으나, 실물 코드(`chat-bubble.tsx`/`embed-card.tsx`)를 통째로 읽어보니 **이미 #2263 AC6이 그 작업(유령 칩 판별 포함)을 전부 끝내놓았음**을 발견 — `isGhostReference()`·`EntityChip`의 `ghost` prop이 이미 존재. 이 발견으로 PR①의 실제 스코프를 AC1+AC2(쉬운 절반)로 좁혔다(PO 승인).

## 구현

**AC1 — doc `flow-map-blueprint-v1` §2-3 「사실성 · 표면 · 지점」**
- BE(`fetch_stored_references`, mention_parser.py)는 이미 `form`·`referenced_at`을 실어 오는데 FE 타입(`use-chat-sse.ts:42`)이 `target_type`·`target_id`만 받아 버리고 있었다 — 타입 확장.
- `findReferenceMeta()`(chat-bubble.tsx) — 본문 토큰을 stored 참조와 대조해 form·referenced_at을 끌어온다. 매칭 없음(유령)·구서버 폴백(form/referenced_at 자체가 없음)이면 `null` — 표기를 지어내지 않는다.
- `EntityChip`(embed-card.tsx) — 사실성(상수 "관찰됨": entity_references 자체가 관찰됨 tier) · 표면(`FORM_LABELS`: mention→멘션, embed→임베드, proof→근거) · 지점(`formatReferencePoint`, referenced_at을 UTC 기준 M/D로).

**AC2(쉬운 절반) — `EntityPreviewModal`의 `status={null}` 하드코딩**
- 모달은 이미 자체 fetch하는 `detail`을 갖고 있다 — 헤더 배지가 `status` prop(있으면 우선, `EmbedCard`의 write-response 경로 그대로 유지) 또는 `detail.status`(fetch한 값)를 보이도록 배선.
- 칩 자체(모달 열기 前)의 상태 표시는 **PR②로 분리**(PO 승인) — `references` 사이드밴드엔 status가 없어 엔티티 타입별 배치조회 인프라가 새로 필요하다(story/doc/artifact/hypothesis 등 API 형태·상태 어휘가 다 다름).

## 검증

```
✅ pnpm exec tsc --noEmit — clean
✅ pnpm run lint — 0 errors(경고 3개는 이 PR과 무관한 기존 파일)
✅ pnpm run build — 성공(EXIT 0)
✅ vitest run(전체) — 383 files / 2841 tests 전부 PASS(신규 6건: AC1 3건 + AC2 3건)
```

## 회귀 가드 — mutation self-check 2건

1. `findReferenceMeta`의 form/referenced_at 존재 가드 완화 → RED(폴백 케이스에서 표기를 지어냄) → 원복 → GREEN
2. `resolvedStatus`의 `detail.status` 폴백 제거 → RED(EntityChip 경로에서 헤더 status가 다시 항상 빈다) → 원복 → GREEN

## 하지 않은 것 (범위 밖)

- AC2 나머지(칩 자체 상태, 배치조회 인프라) — PR②
- AC3(다음 행동)·형태 구분(작업 vs 자료) — PR③④

## Test plan
- [x] tsc / lint / build / vitest(전체 2841) 전부 그린
- [x] 뮤테이션 self-check 2건(RED→GREEN)
- [ ] 라이브 dev에서 실제 form/referenced_at 있는 메시지로 칩 표기 확인(마크다운 링크 형식 `[title](entity:type:id)`으로 보낸 메시지 필요 — 평문 "#번호" 멘션은 stored 참조가 안 생긴다는 것도 이번에 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)