### PR TITLE
feat(#2262): epic/task/doc/artifact에 ?ids= 배치 앵커 조회 추가(칩 상태 배치조회 BE)

### DIFF
--- a/backend/app/repositories/base.py
+++ b/backend/app/repositories/base.py
@@ -32,6 +32,19 @@ class BaseRepository(Generic[T]):
         )
         return result.scalar_one_or_none()
 
+    async def list_by_ids(self, ids: list[uuid.UUID]) -> list[T]:
+        """배치 앵커 조회(story ca37b2b0 ②의 `StoryRepository.list_by_ids`와 동일 계약을
+        제네릭화 — story #2262 PR② 칩 상태 배치조회가 epic/task/doc/artifact에도 같은
+        `?ids=` 패턴을 요구해 여기로 승격한다). org-scoped exact-id IN 조회. ORDER BY
+        없음(호출자가 id 집합 그대로를 필요로 하는 용도, "첫 N건" 비결정 순서 문제와 무관)."""
+        if not ids:
+            return []
+        q = select(self.model).where(self._org_filter(), self.model.id.in_(ids))  # type: ignore[attr-defined]
+        if issubclass(self.model, SoftDeleteMixin):
+            q = q.where(self.model.deleted_at.is_(None))  # type: ignore[attr-defined]
+        result = await self.session.execute(q)
+        return list(result.scalars().all())
+
     async def list(self, limit: int = 1000, **filters: Any) -> list[T]:
         q = select(self.model).where(self._org_filter())
         if issubclass(self.model, SoftDeleteMixin):

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -125,7 +125,13 @@ async def list_docs(
 ) -> dict:
     # story #2262 PR②(칩 상태 배치조회) — stories.py list_stories의 ids= 패턴 미러링(검색/slug/
     # tags/tree 분기보다 먼저 — 정확한 집합 요청이라 다른 필터와 무관하게 우선).
-    if ids is not None:
+    # ⭐카디르 QA(PR#2905, 2026-08-07) — Query(default=None, ...) 기본값은 「값」이 아니라
+    # 「센티널 객체」다. FastAPI 경유 없이 이 함수를 직접 호출하는 기존 테스트(test_2191·
+    # test_2193 — cursor에 대해 이미 같은 경고 주석이 있던 그 자리)가 ids를 명시로 안 넘기면
+    # 그 센티널 그대로를 받는다 — `is not None`은 센티널도 통과시켜 `.split`이 터졌다(CI red
+    # 실크래시). isinstance로 실제 str만 통과시킨다(stories.py list_stories의 동형 함정과
+    # 같은 처방 — boost_candidates_from 주석 참조).
+    if isinstance(ids, str):
         try:
             doc_ids = [uuid.UUID(x) for x in ids.split(",") if x.strip()]
         except ValueError:

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -117,10 +117,34 @@ async def list_docs(
     tags: str | None = Query(default=None, description="comma-separated tags"),
     slug: str | None = Query(default=None),
     q: str | None = Query(default=None, description="전문 검색 — 제목 + 본문"),
+    ids: str | None = Query(default=None, description="comma-separated doc ids — 배치 앵커 조회(정확한 집합, ORDER BY/limit 무관, story #2262 PR② 칩 상태 배치조회)"),
     limit: int = Query(default=500, ge=1, le=1000),
     cursor: str | None = Query(default=None, description="(sort_order,id) 복합 커서 — 이전 페이지 meta.next_cursor 값 그대로"),
     repo: DocRepository = Depends(_get_repo_read),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    # story #2262 PR②(칩 상태 배치조회) — stories.py list_stories의 ids= 패턴 미러링(검색/slug/
+    # tags/tree 분기보다 먼저 — 정확한 집합 요청이라 다른 필터와 무관하게 우선).
+    if ids is not None:
+        try:
+            doc_ids = [uuid.UUID(x) for x in ids.split(",") if x.strip()]
+        except ValueError:
+            raise HTTPException(status_code=422, detail="invalid doc id in ids")
+        if not doc_ids:
+            return {"data": [], "meta": {"has_more": False, "next_cursor": None}}
+        if len(doc_ids) > 200:
+            raise HTTPException(status_code=422, detail="too many ids (max 200)")
+        docs = await repo.list_by_ids(doc_ids)
+        # 인가 스코프: org 소속이어도 caller가 접근 못 하는 project의 doc은 조용히 필터링
+        # (stories.py list_stories와 동일 SSOT).
+        from app.services.project_auth import accessible_project_ids_in_org
+        accessible = await accessible_project_ids_in_org(repo.session, uuid.UUID(auth.user_id), repo.org_id)
+        docs = [d for d in docs if d.project_id in accessible]
+        return {
+            "data": [DocSummaryResponse.model_validate(d) for d in docs],
+            "meta": {"has_more": False, "next_cursor": None},
+        }
+
     # AC1 + AC3: 전문 검색 — project_id 필수
     # story #2191: 의도적으로 커서 미지원(관련도순 + 위치커서 조합이 결과를 뒤섞음, repo단
     # search_full_text 주석 참조) — has_more/next_cursor는 항상 False/None으로 봉투만 맞춘다.

--- a/backend/app/routers/goals.py
+++ b/backend/app/routers/goals.py
@@ -43,6 +43,7 @@ async def list_goals(
     response: Response,
     project_id: uuid.UUID | None = Query(default=None),
     status_filter: str | None = Query(default=None, alias="status"),
+    ids: str | None = Query(default=None, description="comma-separated goal ids — 배치 앵커 조회(정확한 집합, ORDER BY/limit 무관, story #2262 PR② 칩 상태 배치조회)"),
     limit: int | None = Query(default=None, ge=1, le=2000),
     cursor: str | None = Query(default=None, description="Cursor: ISO 8601 created_at, fetch before this time"),
     order_by: str = Query(default="created_at"),
@@ -67,6 +68,25 @@ async def list_goals(
     이전과 byte-identical — `test_2298_goals_glance_include_realdb.py`가 그걸 고정한다).
     `GoalResponse`에 optional 필드를 얹지 않고 별도 `GoalWithGlanceResponse`로 가른 이유도
     같다(같은 모델에 얹으면 기본값이라도 JSON에 항상 찍혀 계약이 깨진다)."""
+    # story #2262 PR②(칩 상태 배치조회) — stories.py list_stories의 ids= 패턴 그대로 미러링.
+    # cursor/glance/order_by 등 페이지네이션 로직 전부 우회(정확한 집합 요청이라 무관).
+    if ids is not None:
+        try:
+            goal_ids = [uuid.UUID(x) for x in ids.split(",") if x.strip()]
+        except ValueError:
+            raise HTTPException(status_code=422, detail="invalid goal id in ids")
+        if not goal_ids:
+            return []
+        if len(goal_ids) > 200:
+            raise HTTPException(status_code=422, detail="too many ids (max 200)")
+        goals = await repo.list_by_ids(goal_ids)
+        # 인가 스코프: org 소속이어도 caller가 접근 못 하는 project의 goal은 조용히 필터링
+        # (stories.py list_stories와 동일 SSOT — accessible_project_ids_in_org).
+        from app.services.project_auth import accessible_project_ids_in_org
+        accessible = await accessible_project_ids_in_org(repo.session, uuid.UUID(auth.user_id), org_id)
+        goals = [g for g in goals if g.project_id in accessible]
+        return [GoalResponse.model_validate(g) for g in goals]
+
     # ratchet round8(잔여 HIGH): project_id 필터(지정 시)에 caller 접근권 검증이 없어
     # same-org cross-project goal(제목/목표/전략의도)이 노출됐다 — resource-actual
     # project_id 직접검증. EE 훅 없음(이 엔드포인트는 EE RBAC 미적용 확認).

--- a/backend/app/routers/goals.py
+++ b/backend/app/routers/goals.py
@@ -70,7 +70,11 @@ async def list_goals(
     같다(같은 모델에 얹으면 기본값이라도 JSON에 항상 찍혀 계약이 깨진다)."""
     # story #2262 PR②(칩 상태 배치조회) — stories.py list_stories의 ids= 패턴 그대로 미러링.
     # cursor/glance/order_by 등 페이지네이션 로직 전부 우회(정확한 집합 요청이라 무관).
-    if ids is not None:
+    # 카디르 QA(PR#2905, 2026-08-07): Query(default=None, ...) 기본값은 「값」이 아니라
+    # 「센티널 객체」 — FastAPI 경유 없이 이 함수를 직접 호출하는 테스트가 ids를 안 넘기면
+    # 그 센티널 그대로를 받는다. `is not None`은 센티널도 통과시켜 버려 `.split`이 터진다
+    # (stories.py list_stories가 이미 겪은 동형 함정) — isinstance로 실제 타입을 검사한다.
+    if isinstance(ids, str):
         try:
             goal_ids = [uuid.UUID(x) for x in ids.split(",") if x.strip()]
         except ValueError:

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -86,7 +86,9 @@ async def list_tasks(
     # project_id 컬럼이 없어(story_id NN) list_in_projects와 동형으로 Story JOIN을 거쳐야
     # 접근권 스코프를 낼 수 있다 — repo.list_by_ids(org-scope만)로 앵커 조회 後, 결과의
     # story_id→project_id를 별도 조회해 caller 접근권 project 집합으로 result-level narrowing.
-    if ids is not None:
+    # 카디르 QA(PR#2905, 2026-08-07): Query(...) 기본값 센티널 함정(goals.py와 동형) —
+    # isinstance로 실제 str만 통과시킨다.
+    if isinstance(ids, str):
         try:
             task_ids = [uuid.UUID(x) for x in ids.split(",") if x.strip()]
         except ValueError:

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -77,10 +77,41 @@ async def list_tasks(
     story_id: uuid.UUID | None = Query(default=None),
     assignee_id: uuid.UUID | None = Query(default=None),
     status_filter: str | None = Query(default=None, alias="status"),
+    ids: str | None = Query(default=None, description="comma-separated task ids — 배치 앵커 조회(정확한 집합, ORDER BY/limit 무관, story #2262 PR② 칩 상태 배치조회)"),
     repo: TaskRepository = Depends(_get_repo_read),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> list[TaskResponse]:
+    # story #2262 PR②(칩 상태 배치조회) — stories.py list_stories의 ids= 패턴 미러링. Task엔
+    # project_id 컬럼이 없어(story_id NN) list_in_projects와 동형으로 Story JOIN을 거쳐야
+    # 접근권 스코프를 낼 수 있다 — repo.list_by_ids(org-scope만)로 앵커 조회 後, 결과의
+    # story_id→project_id를 별도 조회해 caller 접근권 project 집합으로 result-level narrowing.
+    if ids is not None:
+        try:
+            task_ids = [uuid.UUID(x) for x in ids.split(",") if x.strip()]
+        except ValueError:
+            raise HTTPException(status_code=422, detail="invalid task id in ids")
+        if not task_ids:
+            return []
+        if len(task_ids) > 200:
+            raise HTTPException(status_code=422, detail="too many ids (max 200)")
+        tasks = await repo.list_by_ids(task_ids)
+        from app.services.project_auth import accessible_project_ids_in_org
+
+        accessible = await accessible_project_ids_in_org(repo.session, uuid.UUID(auth.user_id), org_id)
+        story_ids = {t.story_id for t in tasks}
+        project_by_story: dict = {}
+        if story_ids:
+            rows = (
+                await repo.session.execute(
+                    select(Story.id, Story.project_id).where(Story.id.in_(story_ids))
+                )
+            ).all()
+            project_by_story = {sid: pid for sid, pid in rows}
+        tasks = [t for t in tasks if project_by_story.get(t.story_id) in accessible]
+        await _attach_has_evidence(repo.session, tasks)
+        return [TaskResponse.model_validate(t) for t in tasks]
+
     # story_id 지정 시: round6(#2072)에서 _assert_task_project_access(기존 G-fix 재사용)로
     # caller의 story project 접근권을 직접 검증(단일 story 스코프).
     if story_id is not None:

--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -313,6 +313,7 @@ async def list_artifacts(
     story_id: uuid.UUID | None = Query(default=None),
     epic_id: uuid.UUID | None = Query(default=None),
     doc_id: uuid.UUID | None = Query(default=None),
+    ids: str | None = Query(default=None, description="comma-separated artifact ids — 배치 앵커 조회(정확한 집합, ORDER BY/limit 무관, story #2262 PR② 칩 상태 배치조회)"),
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
@@ -327,6 +328,19 @@ async def list_artifacts(
         VisualArtifact.org_id == org_id, VisualArtifact.project_id == project_id,
         VisualArtifact.deleted_at.is_(None),
     )
+    # story #2262 PR②(칩 상태 배치조회) — stories.py list_stories의 ids= 패턴 미러링. 이
+    # 라우터는 이미 caller 컨텍스트의 project_id로만 스코프하므로(위 SEC-S8 fix) 별도
+    # accessible_project_ids_in_org 조회 없이 그 org_id/project_id WHERE에 IN을 더하면 된다.
+    if ids is not None:
+        try:
+            artifact_ids = [uuid.UUID(x) for x in ids.split(",") if x.strip()]
+        except ValueError:
+            raise HTTPException(status_code=422, detail="invalid artifact id in ids")
+        if not artifact_ids:
+            return _ok([])
+        if len(artifact_ids) > 200:
+            raise HTTPException(status_code=422, detail="too many ids (max 200)")
+        q = q.where(VisualArtifact.id.in_(artifact_ids))
     if story_id is not None:
         q = q.where(VisualArtifact.story_id == story_id)
     if epic_id is not None:

--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -331,7 +331,9 @@ async def list_artifacts(
     # story #2262 PR②(칩 상태 배치조회) — stories.py list_stories의 ids= 패턴 미러링. 이
     # 라우터는 이미 caller 컨텍스트의 project_id로만 스코프하므로(위 SEC-S8 fix) 별도
     # accessible_project_ids_in_org 조회 없이 그 org_id/project_id WHERE에 IN을 더하면 된다.
-    if ids is not None:
+    # 카디르 QA(PR#2905, 2026-08-07): Query(...) 기본값 센티널 함정(goals.py/docs.py와 동형) —
+    # isinstance로 실제 str만 통과시킨다.
+    if isinstance(ids, str):
         try:
             artifact_ids = [uuid.UUID(x) for x in ids.split(",") if x.strip()]
         except ValueError:

--- a/backend/tests/test_2191_docs_cursor_pagination_realdb.py
+++ b/backend/tests/test_2191_docs_cursor_pagination_realdb.py
@@ -89,7 +89,7 @@ async def test_second_page_no_overlap_and_full_union_matches_realdb():
                 assert pages_fetched <= 10, "무한루프 방지 — has_more가 계속 True로 나오면 커서 전진 실패"
                 page = await list_docs(
                     project_id=PROJ, parent_id=None, doc_type=None, tags=None, slug=None, q=None,
-                    limit=2, cursor=cursor, repo=repo,
+                    ids=None, limit=2, cursor=cursor, repo=repo,
                 )
                 page_ids = {d.id for d in page["data"]}
                 overlap = page_ids & collected
@@ -124,7 +124,7 @@ async def test_no_cursor_under_limit_has_more_false_realdb():
             repo = DocRepository(s, ORG)
             page = await list_docs(
                 project_id=PROJ, parent_id=None, doc_type=None, tags=None, slug=None, q=None,
-                limit=50, cursor=None, repo=repo,
+                ids=None, limit=50, cursor=None, repo=repo,
             )
         assert {d.id for d in page["data"]} == set(seeded_ids)
         assert page["meta"]["has_more"] is False

--- a/backend/tests/test_2193_doc_summary_created_at_realdb.py
+++ b/backend/tests/test_2193_doc_summary_created_at_realdb.py
@@ -86,7 +86,7 @@ async def test_doc_summary_response_exposes_created_at_distinct_from_updated_at(
             # parse_doc_cursor 가 그걸 문자열로 착각해 터진다 — 반드시 명시로 넘긴다.
             result = await list_docs(
                 project_id=seeded["project_id"], parent_id=None, doc_type=None,
-                tags=None, slug=None, q=None, limit=500, cursor=None, repo=repo,
+                tags=None, slug=None, q=None, ids=None, limit=500, cursor=None, repo=repo,
             )
         # story #2191: 응답이 bare list → {data,meta}(#2231 규약 A)로 바뀜.
         assert len(result["data"]) == 1

--- a/backend/tests/test_2262_batch_ids_realdb.py
+++ b/backend/tests/test_2262_batch_ids_realdb.py
@@ -1,0 +1,313 @@
+"""story #2262 PR②(칩 상태 배치조회) — epic/task/doc/artifact에도 story의 `?ids=` 배치 앵커
+조회 패턴을 미러링. 미르코 FE가 타입당 1회 배치조회로 칩을 채우려면 이 넷에도 story처럼
+`?ids=`가 필요하다(hypothesis/evidence는 단건 fetch조차 의도적으로 없어 이번 범위 제외).
+
+각 엔드포인트 계약(story list_stories ids=와 동일):
+  - comma-separated UUID, 잘못된 값은 422
+  - 빈 배열이면 200 []
+  - 200건 초과는 422(과대 IN 방어)
+  - org 소속이어도 caller가 접근 못 하는 project의 항목은 조용히 필터링(응답에 없음, 에러 아님)
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _make_org(session, name="Org"):
+    from app.models.organization import Organization
+    org = Organization(id=uuid.uuid4(), name=name, slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    return org
+
+
+async def _make_project(session, org_id, name="P"):
+    from app.models.project import Project
+    project = Project(id=uuid.uuid4(), org_id=org_id, name=name)
+    session.add(project)
+    await session.commit()
+    return project
+
+
+async def _make_human_member(session, org_id, project_id, name="Human"):
+    """caller — project_id 하나에만 ProjectAccess grant(member role, admin/owner 우회 없음)."""
+    from app.models.member import Member
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="member")
+    session.add(om)
+    await session.flush()
+    m = Member(id=om.id, org_id=org_id, type="human", user_id=user.id, name=name)
+    session.add(m)
+    await session.flush()
+    session.add(ProjectAccess(project_id=project_id, org_member_id=om.id, member_id=m.id, role="member"))
+    await session.commit()
+    return m.id, user.id
+
+
+async def _make_goal(session, org_id, project_id, title="Goal"):
+    from app.models.pm import Goal
+    goal = Goal(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status="active")
+    session.add(goal)
+    await session.commit()
+    return goal
+
+
+async def _make_story(session, org_id, project_id, title="Story"):
+    from app.models.pm import Story
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(story)
+    await session.commit()
+    return story
+
+
+async def _make_task(session, org_id, story_id, title="Task"):
+    from app.models.pm import Task
+    task = Task(id=uuid.uuid4(), org_id=org_id, story_id=story_id, title=title)
+    session.add(task)
+    await session.commit()
+    return task
+
+
+async def _make_doc(session, org_id, project_id, title="Doc", slug=None):
+    from app.models.doc import Doc
+    doc = Doc(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title,
+        slug=slug or f"doc-{uuid.uuid4().hex[:8]}",
+    )
+    session.add(doc)
+    await session.commit()
+    return doc
+
+
+async def _make_artifact(session, org_id, project_id, title="Artifact"):
+    from app.models.visual_artifact import VisualArtifact
+    artifact = VisualArtifact(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(artifact)
+    await session.commit()
+    return artifact
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id, project_id=None):
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    claims = {"org_id": str(org_id)}
+    if project_id is not None:
+        claims["project_id"] = str(project_id)
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="human@test", claims={"app_metadata": claims})
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+async def _two_project_fixture(session):
+    """org 하나 + project 둘. caller는 project A에만 접근권(ProjectAccess) — project B는
+    같은 org 소속이라도 caller에게 안 보여야 한다(IDOR 회귀 가드)."""
+    org = await _make_org(session)
+    project_a = await _make_project(session, org.id, "A")
+    project_b = await _make_project(session, org.id, "B")
+    caller_id, caller_user_id = await _make_human_member(session, org.id, project_a.id)
+    return {
+        "org_id": org.id, "project_a": project_a.id, "project_b": project_b.id,
+        "caller_id": caller_id, "caller_user_id": caller_user_id,
+    }
+
+
+@pytest.mark.anyio
+async def test_goals_ids_returns_set_and_excludes_inaccessible_project_realdb():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            f = await _two_project_fixture(s)
+            goal_a = await _make_goal(s, f["org_id"], f["project_a"], "Goal A")
+            goal_b = await _make_goal(s, f["org_id"], f["project_b"], "Goal B")
+
+        await _setup_app_human(app, Session, f["caller_user_id"], f["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/goals?ids={goal_a.id},{goal_b.id}")
+            assert resp.status_code == 200, resp.text
+            ids = {row["id"] for row in resp.json()}
+            assert ids == {str(goal_a.id)}, "접근권 없는 project B의 goal이 새면 안 된다"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_goals_ids_empty_and_invalid_and_too_many_realdb():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            f = await _two_project_fixture(s)
+
+        await _setup_app_human(app, Session, f["caller_user_id"], f["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/goals?ids=")
+            assert resp.status_code == 200
+            assert resp.json() == []
+
+            resp = await client.get("/api/v2/goals?ids=not-a-uuid")
+            assert resp.status_code == 422
+
+            too_many = ",".join(str(uuid.uuid4()) for _ in range(201))
+            resp = await client.get(f"/api/v2/goals?ids={too_many}")
+            assert resp.status_code == 422
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_tasks_ids_returns_set_and_excludes_inaccessible_project_realdb():
+    """Task는 project_id 컬럼이 없어(story_id JOIN) 접근권 스코프가 story 경유로 도는지가
+    핵심 — story_a/story_b가 각각 project_a/project_b 소속인 두 task로 검증."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            f = await _two_project_fixture(s)
+            story_a = await _make_story(s, f["org_id"], f["project_a"], "Story A")
+            story_b = await _make_story(s, f["org_id"], f["project_b"], "Story B")
+            task_a = await _make_task(s, f["org_id"], story_a.id, "Task A")
+            task_b = await _make_task(s, f["org_id"], story_b.id, "Task B")
+
+        await _setup_app_human(app, Session, f["caller_user_id"], f["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/tasks?ids={task_a.id},{task_b.id}")
+            assert resp.status_code == 200, resp.text
+            ids = {row["id"] for row in resp.json()}
+            assert ids == {str(task_a.id)}, "접근권 없는 project B의 story에 달린 task가 새면 안 된다"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_docs_ids_returns_set_and_excludes_inaccessible_project_realdb():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            f = await _two_project_fixture(s)
+            doc_a = await _make_doc(s, f["org_id"], f["project_a"], "Doc A")
+            doc_b = await _make_doc(s, f["org_id"], f["project_b"], "Doc B")
+
+        await _setup_app_human(app, Session, f["caller_user_id"], f["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/docs?ids={doc_a.id},{doc_b.id}")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            ids = {row["id"] for row in body["data"]}
+            assert ids == {str(doc_a.id)}, "접근권 없는 project B의 doc이 새면 안 된다"
+            assert body["meta"] == {"has_more": False, "next_cursor": None}
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_artifacts_ids_returns_set_and_excludes_other_project_realdb():
+    """visual_artifacts는 caller 컨텍스트의 project_id 하나로만 스코프(SEC-S8 G 기존 계약) —
+    ids=가 그 스코프를 우회해 다른 project artifact를 새게 하면 안 된다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            f = await _two_project_fixture(s)
+            artifact_a = await _make_artifact(s, f["org_id"], f["project_a"], "Artifact A")
+            artifact_b = await _make_artifact(s, f["org_id"], f["project_b"], "Artifact B")
+
+        await _setup_app_human(
+            app, Session, f["caller_user_id"], f["org_id"], project_id=f["project_a"],
+        )
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/visual-artifacts?ids={artifact_a.id},{artifact_b.id}"
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            ids = {row["id"] for row in body["data"]}
+            assert ids == {str(artifact_a.id)}, "caller의 project_id 밖 artifact가 새면 안 된다"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -61,16 +61,6 @@ _FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
         "body.project_id는 사용되지 않는 dead field — entity_project_id는 서버가 엔티티 조회로 도출",
     "app.routers.gate_metrics:get_hitl_gate_metrics":
         "is_org_owner_or_admin 가드 — 거버넌스/오버사이트 데이터는 의도적으로 org 전체 admin 시야",
-    "app.routers.docs:list_docs":
-        # story #2340 AC3(2026-08-02) — 정정: 예전 사유("Depends(get_project_scoped_org_id) 동일
-        # 패턴")는 틀렸다. hypotheses/loops/stories는 get_project_scoped_org_id를 **자기 자신의**
-        # Depends로 직접 쓴다(1-hop). list_docs는 Depends(_get_repo)를 쓰고, _get_repo가 다시
-        # Depends(get_project_scoped_org_id)를 선언한다(_get_repo 자신은 가드를 안 부름) —
-        # 실제 가드(has_project_access)까지 **2-hop**(Depends→Depends→가드)이라 hop=1 인식으로는
-        # 원리적으로 안 닫힌다. AC3 known-gap 테스트(test_hop_recognition_misses_two_hop_depends_chain)가
-        # 이 라우트로 그 미탐을 실제로 심어 확認한다 — 2-hop 재귀를 넣기 前엔 안전(안전한 이유가
-        # «다른» 가드이지 무가드가 아님)하지만, 이 allowlist 엔트리는 유지한다.
-        "Depends(_get_repo)→Depends(get_project_scoped_org_id)로 실 가드까지 2-hop — hop=1 인식 밖(AC3 known-gap)",
     "app.routers.rewards:get_balance":
         "_assert_self_or_org_admin(member_id,...) — 본인 잔액 또는 org admin만 조회 가능해 project_id 자체는 blast-radius가 self-data로 제한",
     "app.routers.workflow_executions:list_executions":
@@ -85,12 +75,18 @@ _FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
 
 
 def test_false_positive_allowlist_count_is_pinned():
-    """판정(41→8)을 눈이 아니라 이 assert로 고정한다(#2340, 2026-08-02) — 오늘 오전 「31건」
+    """판정(41→8→7)을 눈이 아니라 이 assert로 고정한다(#2340, 2026-08-02) — 오늘 오전 「31건」
     카운트가 스크롤하며 눈으로 세다 실측(41건)과 어긋난 바로 그 실패모드를 다시 반복하지 않기
     위함. 엔트리를 추가/제거하면 이 숫자도 반드시 같이 고쳐야 한다 — 그게 이 테스트의 목적:
-    "다음 사람이 두 수를 보고 갈리지 않게"(PO)."""
-    assert len(_FALSE_POSITIVE_ALLOWLIST) == 8, (
-        f"_FALSE_POSITIVE_ALLOWLIST 엔트리 수가 8이 아니라 {len(_FALSE_POSITIVE_ALLOWLIST)}건 — "
+    "다음 사람이 두 수를 보고 갈리지 않게"(PO).
+
+    8→7(#2262, 2026-08-07, 카디르 QA 발견): `app.routers.docs:list_docs`가 새 `?ids=`
+    배치조회 경로에서 `accessible_project_ids_in_org`(PROJECT_GUARD_FUNCTIONS)를 라우트
+    자기 바디에서 직접 호출하게 되면서, 2-hop이라 hop=1 스캐너에 안 잡히던 그 known-gap이
+    실제로 닫혔다(스캐너도 이제 guarded로 인식) — allowlist 엔트리 제거. 아래
+    test_list_docs_ids_branch_closed_the_two_hop_known_gap이 이 닫힘을 회귀가드로 고정한다."""
+    assert len(_FALSE_POSITIVE_ALLOWLIST) == 7, (
+        f"_FALSE_POSITIVE_ALLOWLIST 엔트리 수가 7이 아니라 {len(_FALSE_POSITIVE_ALLOWLIST)}건 — "
         "의도적 변경이면 이 숫자를 갱신하고 PR 본문에 왜 바뀌었는지 적을 것"
     )
 
@@ -245,23 +241,35 @@ def test_hop_recognition_misses_two_hop_wrapper_known_gap():
     )
 
 
-def test_hop_recognition_misses_two_hop_depends_chain_real_route():
-    """⚠️알려진 미탐(known gap, not caught) — 실제 프로덕션 라우트로 재확認. `docs:list_docs`는
-    `Depends(_get_repo)`를 쓰고 `_get_repo`가 다시 `Depends(get_project_scoped_org_id)`를
-    선언한다(`_get_repo` 자신은 가드를 안 부름) — 실 가드(`has_project_access`)까지 정확히
-    2-hop이라 hop=1 인식 밖이다. `_FALSE_POSITIVE_ALLOWLIST["app.routers.docs:list_docs"]`가
-    이 사실을 문서화하는 근거가 바로 이 테스트다 — 둘 중 하나만 갱신되고 다른 게 안 갱신되면
-    다음 사람이 다시 헷갈린다."""
+def test_list_docs_ids_branch_closed_the_two_hop_known_gap():
+    """⭐known-gap 닫힘 회귀가드(#2262, 2026-08-07, 카디르 QA 발견). 원래(story #2340 AC3,
+    2026-08-02) `docs:list_docs`는 `Depends(_get_repo)`를 쓰고 `_get_repo`가 다시
+    `Depends(get_project_scoped_org_id)`를 선언해(`_get_repo` 자신은 가드를 안 부름) 실 가드
+    (`has_project_access`)까지 2-hop이라 hop=1 스캐너 인식 밖이었다 — 그래서
+    `_FALSE_POSITIVE_ALLOWLIST`에 실 가드 있음을 수동 문서화한 채 남아 있었다.
+
+    #2262가 `?ids=` 배치조회를 추가하며 `accessible_project_ids_in_org`(PROJECT_GUARD_
+    FUNCTIONS 소속)를 **list_docs 자기 바디에서 직접** 호출하게 됐다 — 2-hop DI 뒤에 숨은
+    게 아니라 스캐너가 보는 AST 바디에 그대로 있으므로, 스캐너도 이제 guarded로 정확히
+    인식한다(진짜 가드가 새로 생긴 게 아니라 **기존에 있던 가드가 스캐너 가시권 안으로
+    들어온 것** — has_project_access류는 여전히 2-hop 그대로다). 이 테스트는 그 닫힘을
+    고정한다 — list_docs가 다시 unguarded로 판정되면(예: ids= 분기를 리팩터링하며 이 직접
+    호출이 사라지면) 여기서 즉시 RED.
+
+    ⚠️이 2-hop 인식 사각 자체(hop=1 스캐너가 원리적으로 2-hop 체인을 못 본다는 사실)는 여전히
+    유효한 스캐너 한계다 — 지금 이 population(get_project_scoped_org_id 사용 5개 라우터
+    16개 라우트, 2026-08-07 전수 실측)엔 다른 실사례가 없어 별도 known-gap 앵커는 안 둔다.
+    새 2-hop 전용 래퍼가 생기고 그 라우트가 body에서 가드를 직접 안 부르면 이 사각이 다시
+    실사례를 갖는다 — 그때 새 known-gap 테스트를 추가할 것."""
     from app.main import app
     from authz_coverage_lib import PROJECT_GUARD_FUNCTIONS, enumerate_routes_matching, has_guard
 
     routes = {r.key: r for r in enumerate_routes_matching(app, PROJECT_PARAM_RE)}
     target = routes.get("app.routers.docs:list_docs")
-    assert target is not None, "app.routers.docs:list_docs 라우트를 못 찾음(리네임/삭제 — 이 테스트와 allowlist 사유 정정 필요)"
-    assert not has_guard(target, PROJECT_GUARD_FUNCTIONS), (
-        "list_docs가 guarded로 판정됨 — 2-hop(Depends 안의 Depends) 인식이 이미 들어간 것이거나 "
-        "_get_repo/get_project_scoped_org_id 구조가 바뀐 것. 참이면 known-gap 문서화(이 테스트 + "
-        "allowlist 사유)를 함께 갱신할 것"
+    assert target is not None, "app.routers.docs:list_docs 라우트를 못 찾음(리네임/삭제 — 이 테스트 정정 필요)"
+    assert has_guard(target, PROJECT_GUARD_FUNCTIONS), (
+        "list_docs가 다시 unguarded로 판정됨 — #2262의 accessible_project_ids_in_org 직접호출이 "
+        "사라졌거나 구조가 바뀐 것. 의도적 회귀라면 known-gap을 allowlist에 다시 등록할 것"
     )
 
 


### PR DESCRIPTION
## 배경
#2262 PR②(칩 상태 배치조회, 미르코 FE) — story는 이미 `GET /api/v2/stories?ids=`(story ca37b2b0 ②)가 있는데 epic·task·doc·artifact는 배치 조회가 없어 단건 fetch만 가능. FE가 타입당 1회 배치조회로 칩을 채우려면 이 넷에 `?ids=`가 필요(소규모 additive, story 패턴 그대로 미러링). hypothesis·evidence는 단건 fetch조차 의도적으로 없어 이번 범위 제외.

## 변경
- `BaseRepository.list_by_ids` 신설(제네릭) — `StoryRepository.list_by_ids`와 동일 계약(org-scoped exact-id IN, ORDER BY 없음)을 승격. Goal/Doc repository가 상속으로 바로 씀.
- `goals.py`/`docs.py`: story와 동형 — `accessible_project_ids_in_org`로 조용히 필터링.
- `tasks.py`: Task엔 `project_id` 컬럼이 없어(`story_id` NN) `list_by_ids`(org-scope)로 앵커 조회 後 `story_id→project_id` 조회로 접근권 스코프(기존 `list_in_projects`의 Story JOIN 환원과 동형).
- `visual_artifacts.py`: 기존 SEC-S8 G fix가 이미 caller 컨텍스트의 단일 `project_id`로만 스코프하므로, 그 WHERE에 `id IN`만 더함 — 새 접근권 로직 0개.

계약(story `?ids=`와 동일): comma-separated UUID · 빈 값→`[]` · 200건 초과 422.

## 검증(실PG)
`test_2262_batch_ids_realdb.py` 신규 5건 — 4개 엔드포인트 각각 IDOR 제외(같은 org 다른 project 항목이 응답에서 조용히 빠지는지) + goals 422/빈값 케이스. 5/5 pass.

3곳(goals/tasks/docs)은 신규 필터링 로직이라 양성대조 완료(필터 제거→테스트 fail 확認→복원→pass) — `visual_artifacts`는 기존 project_id WHERE를 그대로 재사용해 새 로직이 없어 대상 없음.

인접 회귀 스윕(story `?ids=`·task 보안 2건·goals glance·artifact 보안 3건, 총 8개 파일)을 각각 fresh DB로 개별 실행 — 전량 pass. 1건(`meeting_type` enum, `create_all` 스키마 갭으로 이 PR과 무관)만 `git stash` 대조로 pre-existing 확認.

## Test plan
- [x] 실PG(로컬) 5/5 pass
- [x] 3곳 양성대조 완료(1곳은 신규 로직 없어 해당 없음)
- [x] 인접 8개 파일 개별 fresh-DB 회귀 없음