### PR TITLE
chore(#2067): update_story의 도달 불가능한 status=done merge-gate dead code 제거

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -1801,8 +1801,12 @@ async def update_story(
     # 즉 `data.get("status")`는 이 함수 안에서 항상 None이라 이 if는 절대 True가 될 수 없었다
     # (git 이력 전체에서 StoryUpdate에 status가 있던 적이 없다 — "은퇴한 게 아니라 애초에
     # 살아 있던 적이 없는" dead code). PATCH /{id}는 구조적으로 status를 못 바꾸므로 이
-    # 게이트는 지킬 것이 없다 — status 전이는 오직 PATCH /{id}/status(update_story_status,
-    # 이미 자기 게이트 보유)와 PATCH /bulk(#2131, 이미 자기 게이트 보유)로만 일어난다.
+    # 게이트는 지킬 것이 없다 — status 전이는 PATCH /{id}/status(update_story_status, 이미
+    # 자기 게이트 보유)와 PATCH /bulk(bulk_update_stories)로 일어난다.
+    # ⚠️카디르 QA(PR#2906, 2026-08-07) 정정 — PATCH /bulk은 merge-gate를 **안 거친다**(setattr로
+    # status를 그대로 씀, #2131은 status_changed **emit** 갭만 닫았지 게이트 자체는 다른 축).
+    # 단건은 게이트를 거치는데 bulk는 안 거쳐 사람 승인을 우회할 수 있는 별건 갭 — #2521로
+    # 후속 분리(#2156 advisory→enforcing flip 前에 닫아야 flip이 실효).
     story = await repo.update(id, **data)
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -1792,28 +1792,17 @@ async def update_story(
                         "if intentional, resend with allow_shrink=true"
                     ),
                 )
-    # H1-S5: PATCH /{id} 로 status=done 전이 시도도 board 경로와 동일하게 preflight 게이트(AC②).
-    if data.get("status") == "done":
-        gate_story = story_before or await repo.get(id)
-        await _preflight_merge_gate(db, repo.org_id, gate_story, "done")
-        # S-GATE-2: config 게이트 집행(done) — flag-off면 no-op(무회귀). block→409·ask→HitlRequest park.
-        if gate_story is not None:
-            from app.services.gate_enforce import enforce_gate
-            # HIGH②: actor_type 은 인증 컨텍스트에서 신뢰 도출 — API 키(app_metadata.api_key_id)=agent,
-            # 아니면 human(JWT). 보안 결정 신호라 fragile DB resolve-then-swallow(None→human) 지양.
-            _g_actor_type = (
-                "agent" if auth.claims.get("app_metadata", {}).get("api_key_id") else "human"
-            )
-            _g_actor_id: uuid.UUID | None = None
-            try:  # actor_id 는 HitlRequest 귀속용(비보안)·best-effort.
-                _g_actor_id = await _resolve_team_member_id(auth, repo.org_id, db)
-            except Exception:
-                pass
-            await enforce_gate(
-                db, org_id=repo.org_id, project_id=getattr(gate_story, "project_id", None),
-                work_type="done", actor_type=_g_actor_type, actor_id=_g_actor_id,
-                work_item_id=gate_story.id, work_item_title=getattr(gate_story, "title", None),
-            )
+    # story #2067(2026-08-07 근본수정 — 죽은 주소 정리): 이 블록(H1-S5, 원래 "PATCH /{id}로
+    # status=done 전이 시도도 board 경로와 동일하게 preflight 게이트") 은 실측으로 **애초에
+    # 도달 불가능한 dead code**였다 — `StoryUpdate`(이 엔드포인트의 body 스키마)에 `status`
+    # 필드 자체가 없어 Pydantic이 조용히 드롭한다(extra=ignore 기본값):
+    #   StoryUpdate(**{"status": "done", "title": "x"}).model_dump(exclude_unset=True)
+    #   → {"title": "x"}  — status 없음.
+    # 즉 `data.get("status")`는 이 함수 안에서 항상 None이라 이 if는 절대 True가 될 수 없었다
+    # (git 이력 전체에서 StoryUpdate에 status가 있던 적이 없다 — "은퇴한 게 아니라 애초에
+    # 살아 있던 적이 없는" dead code). PATCH /{id}는 구조적으로 status를 못 바꾸므로 이
+    # 게이트는 지킬 것이 없다 — status 전이는 오직 PATCH /{id}/status(update_story_status,
+    # 이미 자기 게이트 보유)와 PATCH /bulk(#2131, 이미 자기 게이트 보유)로만 일어난다.
     story = await repo.update(id, **data)
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")


### PR DESCRIPTION
## 배경
#2067 그라운딩(AC1 시도) 중 발견 — `update_story`(generic `PATCH /{id}`)의 `data.get("status") == "done"` merge-gate preflight 블록이 **애초에 도달 불가능한 dead code**였다.

## 근거(실측)
```python
StoryUpdate(**{"status": "done", "title": "x"}).model_dump(exclude_unset=True)
→ {"title": "x"}  # status 조용히 드롭됨(Pydantic v2 기본 extra=ignore)
```
`StoryUpdate`(이 엔드포인트 body 스키마)에 `status` 필드 자체가 없다 — git 이력 전체에서도 있던 적이 없다. 즉 `data`(=`body.model_dump(exclude_unset=True)`)엔 `"status"` 키가 절대 안 들어가고, 그 위의 `if data.get("status") == "done":`은 항상 False다.

## 처방
22줄(gate preflight + config gate enforce 전체 블록) 제거. `_preflight_merge_gate` 함수 자체는 `update_story_status`(PATCH /{id}/status)가 여전히 정상 사용 중이라 손대지 않음.

## #2067 본 스토리와의 관계
이 발견은 #2067(단건/bulk PATCH가 status_changed emit을 누락한다는 결함)의 그라운딩 중 나온 부산물 — PATCH /{id}는 애초에 status를 못 바꾸므로 "조용히 바뀌는 경로"가 아니라 "그 경로로는 안 바뀌는" 것이었다. #2067 본체(진짜 흔한 경로였던 workflow_report.py 스테이지 전이 emit 누락)는 이미 PR #2345로 별도 해결됨(git log 확認) — #2067은 별도로 done 처리 예정.

## 검증
실PG 회귀 스윕(test_2301·test_2322·test_2346) — test_2346의 8건은 create_all 모델 등록 누락(activity_log 등)으로 인한 무관 pre-existing 실패, `git stash` 대조로 내 변경과 무관 확認. 나머지 전량 pass.

## Test plan
- [x] 실PG 회귀 스윕(무관 pre-existing 제외 전량 pass, stash 대조)
- [x] `_preflight_merge_gate` 다른 콜사이트(update_story_status) 무영향 확認