### PR TITLE
fix(#2207): 잘못된 스토리 커서는 500 대신 400 — URL-unsafe 원시 ISO 커서 함정

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -92,6 +92,32 @@ def _get_repo_read(
     return StoryRepository(session, org_id)
 
 
+def _parse_stories_cursor(cursor: str | None) -> datetime | None:
+    """story #2207 근본수정(2026-08-07) — list_stories의 board/generic 두 분기가 각자
+    `datetime.fromisoformat(cursor)`를 예외처리 없이 불렀다. 원시 ISO 커서 값이 `+`를
+    포함하는데(timezone offset) URL 쿼리스트링에서 인코딩되지 않은 `+`는 공백으로 디코드
+    되는 것이 웹의 오래된 규칙 — FE 다섯 호출부 중 둘이 실제로 이 인코딩을 잊었다(까심
+    발견, dev 라이브 스택트레이스로 확定). 그 결과 `ValueError`가 그대로 500으로 올라갔다
+    (잘못된 커서는 클라이언트 잘못이라 400이어야 함 — 500은 "서버가 깨졌다"는 뜻이라
+    장애 지표를 오염시킨다).
+
+    ⛔커서 포맷 자체(원시 ISO·URL-unsafe)를 바꾸는 근본안은 이 fix에서 채택하지 않는다
+    (판단·근거, story #2207 AC2) — 서버+FE+MCP+모바일 등 모든 커서 소비처가 함께
+    움직여야 하는 비용 큰 변경이고, 진행 중이던 커서가 전부 무효화된다(일회성이라 무해
+    하다곤 해도). 이 400 검증만으로 지금 증상(500·조용한 무반응)은 완전히 사라진다 —
+    "인코딩을 한 번 잊는" 실수 자체를 originate 못 하게 막는 것(포맷 변경)은 비용 대비
+    이 스토리 스코프에서 이득이 작다고 판단(①②만으로 충분, PO 승인 없이 포맷을 바꾸면
+    다른 클라이언트를 조용히 깨뜨릴 위험도 있음)."""
+    if not cursor:
+        return None
+    try:
+        return datetime.fromisoformat(cursor)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400, detail="invalid cursor: expected ISO 8601 datetime",
+        ) from exc
+
+
 @router.get("", response_model=list[StoryResponse])
 async def list_stories(
     project_id: uuid.UUID | None = Query(default=None),
@@ -165,7 +191,7 @@ async def list_stories(
     # story #2188: sprint_id/assignee_id만 넘기고 epic_id/story_number/q는 조용히 빠뜨리던
     # 자리 — 이 분기로 빠지는 조합에서도 제네릭 블록(:148 이하)과 동일하게 전 필터를 넘긴다.
     if status_filter and project_id:
-        cursor_dt = datetime.fromisoformat(cursor) if cursor else None
+        cursor_dt = _parse_stories_cursor(cursor)
         stories, total = await repo.list_board(
             project_id=project_id,
             status=status_filter,
@@ -201,7 +227,7 @@ async def list_stories(
     # story #2189: 이 분기도 board 분기(:131)와 동형으로 cursor를 파싱해 넘긴다 — 안 넘기면
     # FE(buildCursorPageMeta)가 계산한 nextCursor가 다음 요청에서 조용히 무시돼 같은 페이지가
     # 반복된다(sprints/standup "더 보기" 중복 누적의 원인).
-    cursor_dt = datetime.fromisoformat(cursor) if cursor else None
+    cursor_dt = _parse_stories_cursor(cursor)
     stories = await repo.list(limit=limit, q=q, cursor=cursor_dt, **filters)
     await _attach_assignee_ids(repo.session, repo.org_id, stories)
     await _attach_has_evidence(repo.session, stories)

--- a/backend/tests/test_2207_stories_cursor_plus_400_realdb.py
+++ b/backend/tests/test_2207_stories_cursor_plus_400_realdb.py
@@ -1,0 +1,182 @@
+"""story #2207([근본]) — 실 PG.
+
+근본: list_stories(board/generic 두 분기)가 `datetime.fromisoformat(cursor)`를 예외처리 없이
+불러 잘못된 커서가 500으로 올라갔다. 실제 dev 스택트레이스(까심 발견)에서 잡힌 값은
+`2026-07-24T09:47:33.640536 00:00`(원래 `+00:00`인데, URL 쿼리스트링에서 인코딩 안 된 `+`가
+공백으로 디코드된 것 — 웹의 오래된 규칙, FE 다섯 호출부 중 둘이 실제로 인코딩을 잊었다).
+
+AC4 규율 그대로 — `+`가 없는 정상 커서로만 도는 테스트는 이 결함을 못 잡는다. 아래는 그
+malformed 값(공백 버전) 자체로 검증한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+# 실제 dev 스택트레이스에서 잡힌 malformed 값 그대로(원래 '+00:00'이던 자리가 ' 00:00'으로
+# 디코드된 것) — AC4: "결함이 있던 값으로 걸어야 판별력이 생긴다".
+_MALFORMED_CURSOR = "2026-07-24T09:47:33.640536 00:00"
+_VALID_CURSOR_WITH_PLUS = "2026-07-24T09:47:33.640536+00:00"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def test_parse_stories_cursor_raises_400_not_500_for_malformed_value():
+    """⭐단위 검증 — malformed 값(공백판)에 ValueError가 그대로 안 올라가고 HTTPException(400)
+    으로 변환됨을 고정. AC1 본체."""
+    from fastapi import HTTPException
+
+    from app.routers.stories import _parse_stories_cursor
+
+    with pytest.raises(HTTPException) as exc_info:
+        _parse_stories_cursor(_MALFORMED_CURSOR)
+    assert exc_info.value.status_code == 400
+
+
+def test_parse_stories_cursor_accepts_valid_iso_with_plus():
+    """회귀 0 — 정상 ISO(+00:00 포함, 제대로 디코드된 경우)는 그대로 파싱된다."""
+    from datetime import timezone
+
+    from app.routers.stories import _parse_stories_cursor
+
+    result = _parse_stories_cursor(_VALID_CURSOR_WITH_PLUS)
+    assert result is not None
+    assert result.tzinfo is not None
+    assert result.utcoffset().total_seconds() == 0
+
+
+def test_parse_stories_cursor_none_passthrough():
+    from app.routers.stories import _parse_stories_cursor
+
+    assert _parse_stories_cursor(None) is None
+    assert _parse_stories_cursor("") is None
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="S", status="backlog")
+    session.add(story)
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id}
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(uuid.uuid4()), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_generic_branch_raw_unencoded_plus_round_trip_returns_400_not_500_realdb():
+    """⭐AC4/AC5 핵심 — httpx로 **인코딩 없이** `+`를 URL에 그대로 심어 실제 서버 요청을
+    보낸다. 표준 쿼리스트링 디코딩 규칙대로 서버에 도착할 때 `+`가 공백이 되는 것까지
+    포함한 실제 왕복(코드만 보고 닫지 않는다 — AC5). ⚠️project_id는 의도적으로 안 준다 —
+    `get_project_scoped_org_id`가 project_id 지정 시 별도 단명 세션(전역 엔진, 이 테스트의
+    스크래치 DB override 밖)으로 조회해 이 격리 테스트 환경에서 커넥션이 안 열린다(무관
+    인프라 제약) — project_id 없이도 generic 분기의 cursor 파싱(:~230, board 분기와 동일
+    `_parse_stories_cursor` 공유 헬퍼)은 그대로 탄다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app_human(app, Session, seeded["org_id"])
+        client = _client_for(app)
+        try:
+            # httpx는 문자열 URL을 이미-인코딩된 것으로 취급해 그대로 보낸다 — '+'가 인코딩
+            # 안 된 채(브라우저 버그와 동일 모양) 서버에 도달, 표준 x-www-form-urlencoded
+            # 규칙(+→공백)으로 디코드된다.
+            resp = await client.get(f"/api/v2/stories?cursor={_VALID_CURSOR_WITH_PLUS}")
+            assert resp.status_code == 400, (
+                f"malformed cursor(+ 미인코딩 왕복)가 400이 아니라 {resp.status_code} — "
+                f"body: {resp.text}"
+            )
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+def test_board_branch_reuses_same_cursor_parser_source():
+    """board 분기(status_filter+project_id 조합)도 generic 분기와 **같은** `_parse_stories_
+    cursor` 헬퍼를 쓰는지 소스 검사로 고정 — 위 HTTP 왕복 테스트가 project_id 의존성 때문에
+    board 분기까지 직접 못 도는 것을 이걸로 보강한다(발행 지점이 갈라지면 한쪽만 고쳐지는
+    #2131류 결함 재발 방지와 동형 규율)."""
+    import inspect
+
+    from app.routers.stories import list_stories
+
+    source = inspect.getsource(list_stories)
+    assert source.count("_parse_stories_cursor(cursor)") == 2, (
+        "board·generic 두 분기가 같은 헬퍼를 부르지 않으면 한쪽만 고쳐진 것 — "
+        f"실제 호출 횟수: {source.count('_parse_stories_cursor(cursor)')}"
+    )


### PR DESCRIPTION
## 배경
#2207([근본]) — 까심이 #2190 AC3 라이브 검증 중 백로그 「더 보기」가 끝에 도달 못 하는 것을 발견. PO가 dev 백엔드 로그에서 스택트레이스로 근본을 확定: `list_stories`가 `datetime.fromisoformat(cursor)`를 예외처리 없이 불러, 커서 값의 `+`(timezone offset)가 URL에서 인코딩 안 된 채 오면(표준 x-www-form-urlencoded 규칙 — `+`→공백) `ValueError`가 그대로 500으로 올라갔다. FE는 `res.ok` 가드가 그 500을 삼켜 화면이 조용히 아무 반응도 안 했다.

## 처방
- `_parse_stories_cursor()` 공용 헬퍼 신설 — board·generic 두 분기(각자 따로 `datetime.fromisoformat` 호출하던 곳)가 공유. `ValueError` → `HTTPException(400)`.
- **AC2(커서 포맷 자체를 URL-safe로 바꿀지) 판단**: 이번 스코프에서 **채택 안 함** — 서버+FE+MCP+모바일 등 모든 커서 소비처가 함께 움직여야 하는 비용 큰 변경이고, 400 검증만으로 지금 증상(500·조용한 무반응)은 완전히 사라진다. 근거는 헬퍼 docstring에 남김.
- FE 두 자리 인코딩 누락 fix(①, sprints-client.tsx)는 **#2190 스코프**(이 PR 밖).

## 검증(실PG)
- 단위 3건: malformed(dev 스택트레이스의 실제 값, 공백판) → 400 / 정상(+포함) → 파싱 성공 / None·빈문자열 → None
- ⭐httpx 실 HTTP 왕복 1건 — URL에 `+`를 **인코딩 없이** 심어 표준 쿼리스트링 디코딩(`+`→공백)까지 포함한 실제 요청, 400 확認(AC5 "코드만 보고 닫지 않는다")
- board 분기가 같은 헬퍼를 쓰는지 소스검사 1건(발행 지점 분리 방지)
- 5/5 pass. 양성대조(sabotage→ValueError 재현→복원→pass) 완료. 인접 회귀(test_2189 generic 분기 커서 페이지네이션) 6/6 무회귀.

## Test plan
- [x] 실PG(로컬) 5/5 pass
- [x] 양성대조 완료
- [x] 인접 회귀 없음(test_2189)