### PR TITLE
[SID:2262] 참조 카드 PR② — 상태 배치조회(EntityChip 「지금 상태」)

### DIFF
--- a/apps/web/src/app/api/docs/route.test.ts
+++ b/apps/web/src/app/api/docs/route.test.ts
@@ -11,11 +11,14 @@ const { createDbServerClient, createAdminClient, getAuthContext } = vi.hoisted((
 const listMock = vi.fn();
 const searchMock = vi.fn();
 const getDocMock = vi.fn();
+const listByIdsMock = vi.fn();
 
 vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
 vi.mock('@/lib/db/admin', () => ({ createAdminClient }));
 vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
-vi.mock('@/services/docs', () => ({ DocsService: class { list = listMock; search = searchMock; getDoc = getDocMock; } }));
+vi.mock('@/services/docs', () => ({
+  DocsService: class { list = listMock; search = searchMock; getDoc = getDocMock; listByIds = listByIdsMock; },
+}));
 
 import { GET } from './route';
 
@@ -124,5 +127,42 @@ describe('GET /api/docs', () => {
     getAuthContext.mockResolvedValue({ ...mockAuth, rateLimitExceeded: true, rateLimitRemaining: 0, rateLimitResetAt: 9999 });
     const response = await GET(new Request('http://localhost/api/docs?project_id=project-1'));
     expect(response.status).toBe(429);
+  });
+});
+
+// story #2262 PR②(BE #2905) — ids 배치 lookup 분기. ⛔project_id 필수 검사(다른 모든 분기의
+// 전제)보다 먼저 갈라져야 한다 — org 전체에서 조회하는 게 계약이다(stories와 동일 축).
+describe('GET /api/docs — ids 배치 lookup 분기(#2262 PR②)', () => {
+  beforeEach(() => {
+    createDbServerClient.mockReset();
+    createAdminClient.mockReset();
+    getAuthContext.mockReset();
+    listMock.mockReset();
+    listByIdsMock.mockReset();
+    getAuthContext.mockResolvedValue(mockAuth);
+  });
+
+  it('project_id 없이 ids만 있어도 400이 아니라 배치 경로를 탄다(project_id 필수 검사를 우회)', async () => {
+    listByIdsMock.mockResolvedValue({ items: [{ id: 'd1' }, { id: 'd2' }], hasMore: false, nextCursor: null });
+    const res = await GET(new Request('http://localhost/api/docs?ids=d1,d2'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(2);
+    expect(listByIdsMock).toHaveBeenCalledWith(['d1', 'd2']);
+    expect(listMock).not.toHaveBeenCalled();
+  });
+
+  it('caps ids at 200 before calling the service', async () => {
+    listByIdsMock.mockResolvedValue({ items: [], hasMore: false, nextCursor: null });
+    const manyIds = Array.from({ length: 250 }, (_, i) => `id${i}`).join(',');
+    await GET(new Request(`http://localhost/api/docs?ids=${manyIds}`));
+    const calledWith = listByIdsMock.mock.calls[0]![0] as string[];
+    expect(calledWith).toHaveLength(200);
+  });
+
+  it('no ids param → project_id required error stays intact(회귀 없음)', async () => {
+    const res = await GET(new Request('http://localhost/api/docs'));
+    expect(res.status).toBe(400);
+    expect(listByIdsMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/docs/route.ts
+++ b/apps/web/src/app/api/docs/route.ts
@@ -14,6 +14,20 @@ export async function GET(request: Request) {
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const dbClient = undefined;
     const { searchParams } = new URL(request.url);
+
+    // story #2262 PR②(BE #2905) — ids 배치 lookup은 project_id 없이 org 전체에서 조회한다
+    // (stories/goals/tasks route.ts의 ids 분기와 동일 패턴) — 그래서 project_id 필수 검사
+    // 前에 먼저 갈라야 한다.
+    const IDS_BATCH_CAP = 200;
+    const idsParam = searchParams.get('ids');
+    const parsedIds = idsParam ? idsParam.split(',').map((id) => id.trim()).filter(Boolean).slice(0, IDS_BATCH_CAP) : [];
+    if (parsedIds.length > 0) {
+      const repo = await createDocRepository();
+      const service = new DocsService(repo, dbClient);
+      const result = await service.listByIds(parsedIds);
+      return apiSuccess(result.items);
+    }
+
     const projectId = searchParams.get('project_id');
     if (!projectId) return ApiErrors.badRequest('project_id required');
     const repo = await createDocRepository();

--- a/apps/web/src/app/api/goals/route.test.ts
+++ b/apps/web/src/app/api/goals/route.test.ts
@@ -40,3 +40,38 @@ describe('/api/goals GET — include(story #2298 glance 옵트인) forwarding', 
     expect(calledWith.include).toBeUndefined();
   });
 });
+
+// story #2262 PR②(BE #2905) — ids 배치 lookup 분기. stories/route.test.ts(ca37b2b0)와
+// 동일한 회귀가드 패턴 — project_id 없이도 배치 경로를 타는지가 핵심(다른 축이라는 것을
+// 값으로 고정한다).
+describe('/api/goals GET — ids 배치 lookup 분기(#2262 PR②)', () => {
+  beforeEach(() => {
+    Object.values(h).forEach((m) => m.mockReset());
+    h.getAuthContext.mockResolvedValue(agent());
+    h.createGoalRepository.mockResolvedValue({});
+  });
+
+  it('no ids param → existing cursor-paginated path, ids not sent', async () => {
+    h.list.mockResolvedValue([]);
+    await GET(new Request('http://localhost/api/goals?project_id=p'));
+    const calledWith = h.list.mock.calls[0]![0] as { ids?: string[] };
+    expect(calledWith.ids).toBeUndefined();
+  });
+
+  it('ids param present → batch lookup WITHOUT project_id, ids forwarded verbatim', async () => {
+    h.list.mockResolvedValue([{ id: 'e1' }, { id: 'e2' }]);
+    const res = await GET(new Request('http://localhost/api/goals?ids=e1,e2'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(2);
+    expect(h.list).toHaveBeenCalledWith({ ids: ['e1', 'e2'], limit: 2 });
+  });
+
+  it('caps ids at 200 before calling the service(BE 200개 cap 방어, 422 회피)', async () => {
+    h.list.mockResolvedValue([]);
+    const manyIds = Array.from({ length: 250 }, (_, i) => `id${i}`).join(',');
+    await GET(new Request(`http://localhost/api/goals?ids=${manyIds}`));
+    const calledWith = h.list.mock.calls[0]![0] as { ids: string[] };
+    expect(calledWith.ids).toHaveLength(200);
+  });
+});

--- a/apps/web/src/app/api/goals/route.ts
+++ b/apps/web/src/app/api/goals/route.ts
@@ -7,6 +7,9 @@ import { getAuthContext } from '@/lib/auth-helpers';
 import { buildCursorPageMeta, parseCursorPageInput } from '@/lib/pagination';
 import { createGoalRepository } from '@/lib/storage/factory';
 
+// story #2262 PR②(BE #2905) — story ca37b2b0과 동일 상한, FE에서 먼저 잘라 BE 422를 피한다.
+const IDS_BATCH_CAP = 200;
+
 export async function GET(request: Request) {
   try {
     const me = await getAuthContext(request);
@@ -14,6 +17,18 @@ export async function GET(request: Request) {
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
     const { searchParams } = new URL(request.url);
+
+    // story #2262 PR② — ids 배치 lookup은 커서 페이지네이션과 무관한 고정 집합 조회
+    // (stories/route.ts의 ids 분기와 동일 패턴 — project_id 없이도 org 전체에서 조회한다).
+    const idsParam = searchParams.get('ids');
+    const parsedIds = idsParam ? idsParam.split(',').map((id) => id.trim()).filter(Boolean).slice(0, IDS_BATCH_CAP) : [];
+    if (parsedIds.length > 0) {
+      const repo = await createGoalRepository();
+      const service = new GoalService(repo);
+      const epics = await service.list({ ids: parsedIds, limit: parsedIds.length });
+      return apiSuccess(epics);
+    }
+
     const orderBy = searchParams.get('order_by') ?? undefined;
     // 로드맵 조타(wedge #2): order_by="position"은 복합 정렬((position IS NULL) ASC, position ASC,
     // created_at DESC)이라 BE가 X-Next-Cursor를 내지 않는다 → 커서 이어달리기 불가. 이 모드는

--- a/apps/web/src/app/api/tasks/route.test.ts
+++ b/apps/web/src/app/api/tasks/route.test.ts
@@ -79,3 +79,37 @@ describe('/api/tasks (직접 서비스 TaskService)', () => {
     expect((await res.json()).data).toMatchObject({ id: 't1' });
   });
 });
+
+// story #2262 PR②(BE #2905) — ids 배치 lookup(task 자신의 id로) 분기. ⛔story_ids(부모
+// story로 묶어 자식 task들을 찾는 기존 기능)와 다른 축이라는 것도 값으로 고정한다.
+describe('/api/tasks GET — ids 배치 lookup 분기(#2262 PR②, task 자신의 id)', () => {
+  beforeEach(() => {
+    Object.values(h).forEach((m) => m.mockReset());
+    h.getAuthContext.mockResolvedValue(agent());
+    h.createTaskRepository.mockResolvedValue({});
+  });
+
+  it('no ids param → existing path, ids not sent', async () => {
+    h.list.mockResolvedValue([]);
+    await GET(new Request('http://localhost/api/tasks?story_id=s1'));
+    const calledWith = h.list.mock.calls[0]![0] as { ids?: string[] };
+    expect(calledWith.ids).toBeUndefined();
+  });
+
+  it('ids param present → batch lookup by task id, distinct from story_ids', async () => {
+    h.list.mockResolvedValue([task('t1'), task('t2')]);
+    const res = await GET(new Request('http://localhost/api/tasks?ids=t1,t2'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(2);
+    expect(h.list).toHaveBeenCalledWith({ ids: ['t1', 't2'], limit: 2 });
+  });
+
+  it('caps ids at 200 before calling the service', async () => {
+    h.list.mockResolvedValue([]);
+    const manyIds = Array.from({ length: 250 }, (_, i) => `id${i}`).join(',');
+    await GET(new Request(`http://localhost/api/tasks?ids=${manyIds}`));
+    const calledWith = h.list.mock.calls[0]![0] as { ids: string[] };
+    expect(calledWith.ids).toHaveLength(200);
+  });
+});

--- a/apps/web/src/app/api/tasks/route.ts
+++ b/apps/web/src/app/api/tasks/route.ts
@@ -47,6 +47,19 @@ export async function GET(request: Request) {
     const dbClient = undefined as DbClient | undefined;
 
     const { searchParams } = new URL(request.url);
+    // story #2262 PR②(BE #2905) — ids는 task 자신의 id로 배치 lookup(story ca37b2b0과
+    // 동일 계약). ⛔story_ids(아래, 부모 story로 묶어 자식 task들을 찾는 기존 기능)와
+    // 다른 축이다 — 이건 "이 id들 자체가 task다"라는 뜻.
+    const IDS_BATCH_CAP = 200;
+    const idsParam = searchParams.get('ids');
+    const parsedIds = idsParam ? idsParam.split(',').map((id) => id.trim()).filter(Boolean).slice(0, IDS_BATCH_CAP) : [];
+    if (parsedIds.length > 0) {
+      const repo = await createTaskRepository();
+      const service = new TaskService(repo);
+      const tasks = await service.list({ ids: parsedIds, limit: parsedIds.length });
+      return apiSuccess(tasks);
+    }
+
     const storyId = searchParams.get('story_id') ?? undefined;
     const storyIdsRaw = searchParams.get('story_ids');
     const storyIds = storyIdsRaw ? storyIdsRaw.split(',').map((s) => s.trim()).filter(Boolean) : undefined;

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -145,6 +145,38 @@ describe('ChatBubble — story #2262 AC1(사실성·표면·지점 표기, doc f
   });
 });
 
+describe('ChatBubble — story #2262 AC2 PR② 1단계(2026-08-07 유나양 카피 판정, BE 배치조회 前 하드코딩)', () => {
+  it('has-status 타입(doc) 칩은 실 배치조회가 없는 오늘은 "아직 모름"을 보인다', async () => {
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={{ ...baseMessage, references: undefined }} isMine={false} />));
+    });
+    expect(container.textContent).toContain('아직 모름');
+    expect(container.textContent).not.toContain('상태 없음');
+  });
+
+  it('no-status-concept 타입(hypothesis) 칩은 "상태 없음"을 보인다(로딩이 아니라 구조적 부재)', async () => {
+    const hypothesisId = '22222222-2222-2222-2222-222222222222';
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, content: `[가설 A](entity:hypothesis:${hypothesisId})`, references: undefined }}
+          isMine={false}
+        />,
+      ));
+    });
+    expect(container.textContent).toContain('상태 없음');
+    expect(container.textContent).not.toContain('아직 모름');
+  });
+
+  it('유령 칩에는 상태 라벨을 안 보인다(대상 자체가 없는데 상태를 말할 수 없다)', async () => {
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={{ ...baseMessage, references: [] }} isMine={false} />));
+    });
+    expect(container.textContent).not.toContain('아직 모름');
+    expect(container.textContent).not.toContain('상태 없음');
+  });
+});
+
 describe('ChatBubble — story #2319 tombstone(메시지 삭제) 렌더', () => {
   it('deleted_at이 있으면 원문 대신 placeholder를 그린다', async () => {
     const deletedMsg: ChatMessage = { ...baseMessage, content: '', deleted_at: '2026-08-02T00:00:00.000Z' };

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -177,6 +177,61 @@ describe('ChatBubble — story #2262 AC2 PR② 1단계(2026-08-07 유나양 카�
   });
 });
 
+describe('ChatBubble — story #2262 AC2 PR② 2단계(chat-view.tsx 실 배치조회 결과 prop 소비)', () => {
+  it('entityStatusByKey에 resolved 항목이 있으면 하드코딩 loading 대신 번역된 실 상태를 보인다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, references: undefined }}
+          isMine={false}
+          entityStatusByKey={{ [`doc:${DOC_ID}`]: { kind: 'resolved', raw: 'confirmed' } }}
+        />,
+      ));
+    });
+    expect(container.textContent).toContain('확定');
+    expect(container.textContent).not.toContain('아직 모름');
+  });
+
+  it('entityId가 대문자 UUID 토큰이어도 소문자로 정규화해 캐시 키와 매칭한다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, content: `[제안서.md](entity:doc:${DOC_ID.toUpperCase()})`, references: undefined }}
+          isMine={false}
+          entityStatusByKey={{ [`doc:${DOC_ID}`]: { kind: 'resolved', raw: 'draft' } }}
+        />,
+      ));
+    });
+    expect(container.textContent).toContain('초안');
+  });
+
+  it('entityStatusByKey에 그 키가 아직 없으면(다른 타입 fetch 진행 중) 폴백과 동일하게 "아직 모름"이다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, references: undefined }}
+          isMine={false}
+          entityStatusByKey={{ 'story:다른-엔티티': { kind: 'resolved', raw: 'done' } }}
+        />,
+      ));
+    });
+    expect(container.textContent).toContain('아직 모름');
+  });
+
+  it('배치조회가 error로 끝나면 loading과 같은 급인 "아직 모름"을 보인다(가짜 "확認 중" 아님)', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, references: undefined }}
+          isMine={false}
+          entityStatusByKey={{ [`doc:${DOC_ID}`]: { kind: 'error' } }}
+        />,
+      ));
+    });
+    expect(container.textContent).toContain('아직 모름');
+  });
+});
+
 describe('ChatBubble — story #2319 tombstone(메시지 삭제) 렌더', () => {
   it('deleted_at이 있으면 원문 대신 placeholder를 그린다', async () => {
     const deletedMsg: ChatMessage = { ...baseMessage, content: '', deleted_at: '2026-08-02T00:00:00.000Z' };

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -9,6 +9,7 @@ import { useTranslations } from 'next-intl';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
 import { commandName, dequoteLiteral, isCommand } from '@/lib/command-classifier';
 import { EntityChip, getEntityHref } from '@/components/chat/embed-card';
+import type { EntityStatusFetchState } from '@/components/chat/entity-status-labels';
 import { AssetEmbedCard } from '@/components/chat/asset-embed-card';
 import { getFileIcon } from '@/lib/file-icon';
 import { AttachmentImage } from './attachment-image';
@@ -42,6 +43,10 @@ interface ChatBubbleProps {
   isCiteAnchor?: boolean;
   isCiteInRange?: boolean;
   citeAction?: CiteAction;
+  /** story #2262 AC2 PR② — chat-view.tsx가 배치조회한 「타입:id → 상태」 캐시(대화 전체
+   * 메시지에 걸쳐 하나만 존재 — 같은 엔티티를 여러 메시지가 참조해도 fetch는 타입당 1회).
+   * 생략하면(undefined) `EntityChip`이 기존처럼 `{kind:'loading'}`으로 안전 폴백한다. */
+  entityStatusByKey?: Record<string, EntityStatusFetchState>;
 }
 
 interface ContextMenuState {
@@ -142,7 +147,10 @@ function CopyableCode({ raw, inline, className }: { raw: string; inline: boolean
   );
 }
 
-function ChatMarkdown({ content, isMine, references }: { content: string; isMine: boolean; references: ChatMessage['references'] }) {
+function ChatMarkdown({ content, isMine, references, entityStatusByKey }: {
+  content: string; isMine: boolean; references: ChatMessage['references'];
+  entityStatusByKey?: Record<string, EntityStatusFetchState>;
+}) {
   const text = isMine ? 'text-primary-foreground' : 'text-foreground';
   const muted = isMine ? 'text-primary-foreground/70' : 'text-muted-foreground';
   const codeBg = isMine ? 'bg-primary-foreground/10 text-primary-foreground' : 'bg-muted text-foreground';
@@ -220,12 +228,13 @@ function ChatMarkdown({ content, isMine, references }: { content: string; isMine
             href={getEntityHref(m[1]!, m[2]!)}
             ghost={ghost}
             referenceMeta={referenceMeta}
+            entityStatus={entityStatusByKey?.[`${m[1]!.toLowerCase()}:${m[2]!.toLowerCase()}`]}
           />
         );
       }
       return <a href={href} target="_blank" rel="noopener noreferrer" className={`underline underline-offset-2 ${text}`}>{children}</a>;
     },
-  }), [text, muted, codeBg, border, isMine, references]);
+  }), [text, muted, codeBg, border, isMine, references, entityStatusByKey]);
 
   if (!hasMarkdown && !hasMention) {
     return (
@@ -254,7 +263,7 @@ const LONG_PRESS_MS = 500;
 
 export function ChatBubble({
   message, isMine, isGrouped = false, onOpenThread, onDelete, onBlockUser, presenceStatus, isWorking = false,
-  highlight = false, projectId, isCiteAnchor = false, isCiteInRange = false, citeAction,
+  highlight = false, projectId, isCiteAnchor = false, isCiteInRange = false, citeAction, entityStatusByKey,
 }: ChatBubbleProps) {
   const t = useTranslations('chats');
   const isAgent = message.sender_type === 'agent';
@@ -443,7 +452,7 @@ export function ChatBubble({
                 ? 'rounded-tr-sm bg-primary text-primary-foreground'
                 : 'rounded-tl-sm bg-muted text-foreground'
             }`}>
-              <ChatMarkdown content={displayContent} isMine={isMine} references={message.references} />
+              <ChatMarkdown content={displayContent} isMine={isMine} references={message.references} entityStatusByKey={entityStatusByKey} />
             </div>
           )}
 

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -13,9 +13,8 @@ import { ThreadPanel } from './thread-panel';
 import type { ChatMessage, SendAttachment } from '@/hooks/use-chat-sse';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { normalizeToMessage, useChatSse, type SseWorkingPayload } from '@/hooks/use-chat-sse';
-import {
-  groupUnresolvedReferencesByType, ENTITY_STATUS_BATCH_API_PATH, type EntityStatusFetchState,
-} from '@/components/chat/entity-status-labels';
+import type { EntityStatusFetchState } from '@/components/chat/entity-status-labels';
+import { useEntityStatusBatchFetch } from '@/hooks/use-entity-status-batch';
 import { useMessageRangeSelection } from '@/hooks/use-message-range-selection';
 import { CitationComposeBar, type CitationSaveState } from './citation-compose-bar';
 import { StoryPickerDialog } from '@/components/canvas/story-picker-dialog';
@@ -154,49 +153,11 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
     }
   }, [initialLastReadAt, markerBoundary]);
 
-  // story #2262 PR② — 참조 칩 「지금 상태」 배치조회. 대화에 보이는 모든 메시지의
-  // references를 훑어 has-status 타입(entityStatusAvailability)만, 타입별로 묶어 `?ids=`
-  // 배치 endpoint를 한 번씩 부른다(메시지마다 N+1 아님 — 대화 전체에서 타입당 1회, 새
-  // 메시지가 로드되면(SSE·더보기) 그 메시지가 처음 들여온 아직 안 본 참조만 추가로 부른다).
-  useEffect(() => {
-    const idsByType = groupUnresolvedReferencesByType(messages, requestedEntityStatusKeysRef.current);
-    if (idsByType.size === 0) return;
-
-    setEntityStatusByKey((prev) => {
-      const next = { ...prev };
-      for (const [type, ids] of idsByType) {
-        for (const id of ids) next[`${type}:${id}`.toLowerCase()] = { kind: 'loading' };
-      }
-      return next;
-    });
-
-    let cancelled = false;
-    for (const [type, ids] of idsByType) {
-      fetch(`${ENTITY_STATUS_BATCH_API_PATH[type]}?ids=${ids.map(encodeURIComponent).join(',')}`)
-        .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`status ${res.status}`))))
-        .then((body: { data?: Array<{ id: string; status?: string | null }> }) => {
-          if (cancelled) return;
-          const items = body.data ?? [];
-          setEntityStatusByKey((prev) => {
-            const next = { ...prev };
-            for (const id of ids) {
-              const found = items.find((it) => it.id === id);
-              next[`${type}:${id}`.toLowerCase()] = { kind: 'resolved', raw: found?.status ?? null };
-            }
-            return next;
-          });
-        })
-        .catch(() => {
-          if (cancelled) return;
-          setEntityStatusByKey((prev) => {
-            const next = { ...prev };
-            for (const id of ids) next[`${type}:${id}`.toLowerCase()] = { kind: 'error' };
-            return next;
-          });
-        });
-    }
-    return () => { cancelled = true; };
-  }, [messages]);
+  // story #2262 PR② — 참조 칩 「지금 상태」 배치조회(메인 채널 메시지 담당). requestedEntityStatusKeysRef·
+  // setEntityStatusByKey를 ThreadPanel에도 그대로 물려줘(아래 렌더부) 스레드 답글 전용 참조도
+  // 같은 장부·같은 캐시로 잡힌다(PO 지적 2026-08-08 — 이전엔 스레드 전용 참조가 영원히
+  // "아직 모름"에 고착됐었다).
+  useEntityStatusBatchFetch(messages, requestedEntityStatusKeysRef, setEntityStatusByKey);
   // story #1977: mark-read 중복 POST 가드 — 이미 이 up_to까지 보냈으면 재전송 안 함(멱등이라
   // 서버는 안전하지만, 스크롤/신규메시지마다 매번 쏘는 낭비 방지).
   const markedReadUpToRef = useRef<string | null>(null);
@@ -930,6 +891,8 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
               incomingMessage={threadIncoming?.parent_id === activeThread.id ? threadIncoming : null}
               onReplyAdded={handleReplyAdded}
               entityStatusByKey={entityStatusByKey}
+              requestedEntityStatusKeysRef={requestedEntityStatusKeysRef}
+              setEntityStatusByKey={setEntityStatusByKey}
             />
           </div>
         )}

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -13,6 +13,9 @@ import { ThreadPanel } from './thread-panel';
 import type { ChatMessage, SendAttachment } from '@/hooks/use-chat-sse';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { normalizeToMessage, useChatSse, type SseWorkingPayload } from '@/hooks/use-chat-sse';
+import {
+  groupUnresolvedReferencesByType, ENTITY_STATUS_BATCH_API_PATH, type EntityStatusFetchState,
+} from '@/components/chat/entity-status-labels';
 import { useMessageRangeSelection } from '@/hooks/use-message-range-selection';
 import { CitationComposeBar, type CitationSaveState } from './citation-compose-bar';
 import { StoryPickerDialog } from '@/components/canvas/story-picker-dialog';
@@ -87,6 +90,13 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   // 적재(commandHints와 동일 ephemeral 패턴 — persist 안 함·reload 시 소멸, 저장 성공/실패
   // 자체는 이미 DB에 반영돼 있어 잃을 정보가 없다).
   const [referenceDropHints, setReferenceDropHints] = useState<Record<string, DroppedReference[]>>({});
+  // story #2262 PR② — 참조 칩 「지금 상태」 배치조회 캐시. 대화 전체에서 하나(같은 엔티티를
+  // 여러 메시지가 참조해도 fetch는 「타입:id」당 1회) — 키는 `${entityType}:${entityId}`(소문자).
+  const [entityStatusByKey, setEntityStatusByKey] = useState<Record<string, EntityStatusFetchState>>({});
+  // fetch 이미 시작한 키(loading/resolved/error 무관) — React state가 아니라 ref인 이유는
+  // 이 값을 읽어 effect의 재실행 여부를 판단하지 않기 때문(state로 하면 setState가 effect를
+  // 재트리거해 순환 위험). messages만 dependency로 두고 "새로 보인 참조가 있는가"만 본다.
+  const requestedEntityStatusKeysRef = useRef<Set<string>>(new Set());
   // 1aeecdde P2: 답장 생성 중 에이전트 typing — #1353 GET /working 폴링(BE 45s TTL) 결과.
   const [typingAgents, setTypingAgents] = useState<{ id: string; name: string }[]>([]);
   // Deeplink (ade2d6d5): 진입 메시지를 일시적으로 하이라이트(ring). null이면 미표시.
@@ -143,6 +153,50 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
       setMarkerBoundary(initialLastReadAt);
     }
   }, [initialLastReadAt, markerBoundary]);
+
+  // story #2262 PR② — 참조 칩 「지금 상태」 배치조회. 대화에 보이는 모든 메시지의
+  // references를 훑어 has-status 타입(entityStatusAvailability)만, 타입별로 묶어 `?ids=`
+  // 배치 endpoint를 한 번씩 부른다(메시지마다 N+1 아님 — 대화 전체에서 타입당 1회, 새
+  // 메시지가 로드되면(SSE·더보기) 그 메시지가 처음 들여온 아직 안 본 참조만 추가로 부른다).
+  useEffect(() => {
+    const idsByType = groupUnresolvedReferencesByType(messages, requestedEntityStatusKeysRef.current);
+    if (idsByType.size === 0) return;
+
+    setEntityStatusByKey((prev) => {
+      const next = { ...prev };
+      for (const [type, ids] of idsByType) {
+        for (const id of ids) next[`${type}:${id}`.toLowerCase()] = { kind: 'loading' };
+      }
+      return next;
+    });
+
+    let cancelled = false;
+    for (const [type, ids] of idsByType) {
+      fetch(`${ENTITY_STATUS_BATCH_API_PATH[type]}?ids=${ids.map(encodeURIComponent).join(',')}`)
+        .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`status ${res.status}`))))
+        .then((body: { data?: Array<{ id: string; status?: string | null }> }) => {
+          if (cancelled) return;
+          const items = body.data ?? [];
+          setEntityStatusByKey((prev) => {
+            const next = { ...prev };
+            for (const id of ids) {
+              const found = items.find((it) => it.id === id);
+              next[`${type}:${id}`.toLowerCase()] = { kind: 'resolved', raw: found?.status ?? null };
+            }
+            return next;
+          });
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setEntityStatusByKey((prev) => {
+            const next = { ...prev };
+            for (const id of ids) next[`${type}:${id}`.toLowerCase()] = { kind: 'error' };
+            return next;
+          });
+        });
+    }
+    return () => { cancelled = true; };
+  }, [messages]);
   // story #1977: mark-read 중복 POST 가드 — 이미 이 up_to까지 보냈으면 재전송 안 함(멱등이라
   // 서버는 안전하지만, 스크롤/신규메시지마다 매번 쏘는 낭비 방지).
   const markedReadUpToRef = useRef<string | null>(null);
@@ -762,6 +816,7 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
                             isWorking={typingAgents.some((a) => a.id === msg.created_by)}
                             highlight={msg.id === highlightId}
                             projectId={projectId}
+                            entityStatusByKey={entityStatusByKey}
                             isCiteAnchor={citeSelection.isAnchor(msg.id)}
                             isCiteInRange={citeSelection.isInRange(msg.id, orderedMessageIds)}
                             citeAction={
@@ -874,6 +929,7 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
               onClose={closeThread}
               incomingMessage={threadIncoming?.parent_id === activeThread.id ? threadIncoming : null}
               onReplyAdded={handleReplyAdded}
+              entityStatusByKey={entityStatusByKey}
             />
           </div>
         )}

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -12,6 +12,7 @@ import {
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { docViewUrl } from '@/components/docs/lib/doc-project-url';
 import { initials } from '@/lib/storage/format';
+import { renderEntityStatusLabel } from './entity-status-labels';
 
 // story #2302 — 이 8종은 BE reference_registry.py ENTITY_RESOLVERS 와 키 집합이 같아야 한다
 // (AC2·AC5, entity-icons.registry-parity.test.ts 가 코드스캔으로 대조). `asset`은 registry
@@ -565,6 +566,14 @@ export function EntityChip({
   const [showModal, setShowModal] = useState(false);
   const colorClass = ghost ? GRAY_STATE_COLOR : (ENTITY_COLORS[entityType] ?? GRAY_STATE_COLOR);
 
+  // story #2262 AC2(PR② 1단계, 2026-08-07 유나양 카피 판정 반영) — 실 배치조회(BE `?ids=`,
+  // 디디군 대기)가 아직 없어 오늘은 항상 `{kind:'loading'}`으로 판정한다. has-status 타입은
+  // "아직 모름"(로딩 중과 미래의 조회 실패를 같은 문구로 다룬다는 판정), no-status-concept
+  // 타입(hypothesis·evidence·artifact)은 "상태 없음" — 둘 다 «모르는 것을 단정하지 않는다»
+  // 원칙의 표현이지 실패가 아니다. BE 착지 後 이 하드코딩 state를 실제 배치조회 결과로
+  // 바꾸기만 하면 된다(카피·판정 로직은 이미 최종형).
+  const statusLabel = ghost ? null : renderEntityStatusLabel(entityType, { kind: 'loading' });
+
   const inner = (
     <span className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs font-medium ${colorClass}`}>
       <EntityGlyph Icon={resolveEntityIcon(entityType)} label={label} className="size-3 shrink-0" />
@@ -576,6 +585,7 @@ export function EntityChip({
           · 관찰됨 · {FORM_LABELS[referenceMeta.form] ?? referenceMeta.form} · {formatReferencePoint(referenceMeta.referencedAt)}
         </span>
       ) : null}
+      {statusLabel ? <span className="opacity-70">· {statusLabel}</span> : null}
     </span>
   );
 

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -12,7 +12,7 @@ import {
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { docViewUrl } from '@/components/docs/lib/doc-project-url';
 import { initials } from '@/lib/storage/format';
-import { renderEntityStatusLabel } from './entity-status-labels';
+import { renderEntityStatusLabel, type EntityStatusFetchState } from './entity-status-labels';
 
 // story #2302 — 이 8종은 BE reference_registry.py ENTITY_RESOLVERS 와 키 집합이 같아야 한다
 // (AC2·AC5, entity-icons.registry-parity.test.ts 가 코드스캔으로 대조). `asset`은 registry
@@ -549,6 +549,7 @@ export function EntityChip({
   href,
   ghost = false,
   referenceMeta = null,
+  entityStatus,
 }: {
   entityType: string;
   entityId?: string;
@@ -562,17 +563,16 @@ export function EntityChip({
   /** story #2262 AC1 — 「사실성 · 표면 · 지점」. null이면(유령이거나 references 자체가
    * 없는 경로) 표기하지 않는다 — 모르는 것을 지어내지 않는다(가디언 §H-2와 같은 원칙). */
   referenceMeta?: { form: string; referencedAt: string } | null;
+  /** story #2262 AC2 PR② — 배치조회(chat-view.tsx) 결과. 호출부가 안 넘기면(undefined,
+   * 배치조회 배선이 없는 기존 호출부 — 예: 과거 테스트) `{kind:'loading'}`으로 안전하게
+   * 폴백한다(has-status면 "아직 모름", no-status-concept이면 "상태 없음" — renderEntityStatusLabel이
+   * entityType으로 그 둘을 이미 가른다). */
+  entityStatus?: EntityStatusFetchState;
 }) {
   const [showModal, setShowModal] = useState(false);
   const colorClass = ghost ? GRAY_STATE_COLOR : (ENTITY_COLORS[entityType] ?? GRAY_STATE_COLOR);
 
-  // story #2262 AC2(PR② 1단계, 2026-08-07 유나양 카피 판정 반영) — 실 배치조회(BE `?ids=`,
-  // 디디군 대기)가 아직 없어 오늘은 항상 `{kind:'loading'}`으로 판정한다. has-status 타입은
-  // "아직 모름"(로딩 중과 미래의 조회 실패를 같은 문구로 다룬다는 판정), no-status-concept
-  // 타입(hypothesis·evidence·artifact)은 "상태 없음" — 둘 다 «모르는 것을 단정하지 않는다»
-  // 원칙의 표현이지 실패가 아니다. BE 착지 後 이 하드코딩 state를 실제 배치조회 결과로
-  // 바꾸기만 하면 된다(카피·판정 로직은 이미 최종형).
-  const statusLabel = ghost ? null : renderEntityStatusLabel(entityType, { kind: 'loading' });
+  const statusLabel = ghost ? null : renderEntityStatusLabel(entityType, entityStatus ?? { kind: 'loading' });
 
   const inner = (
     <span className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs font-medium ${colorClass}`}>

--- a/apps/web/src/components/chat/entity-status-labels.test.ts
+++ b/apps/web/src/components/chat/entity-status-labels.test.ts
@@ -2,15 +2,18 @@ import { describe, expect, it } from 'vitest';
 import { entityStatusAvailability, translateEntityStatus } from './entity-status-labels';
 
 describe('entityStatusAvailability — 「아직 모름」↔「없음」을 가르는 구조적 판정(AC2·AC7)', () => {
-  it.each(['story', 'task', 'doc', 'hypothesis', 'sprint', 'epic'])(
-    '%s는 has-status(실측된 status 어휘가 있다)',
+  it.each(['story', 'task', 'doc', 'sprint', 'epic'])(
+    '%s는 has-status(PR② v1이 실제로 배치조회할 타입)',
     (type) => {
       expect(entityStatusAvailability(type)).toBe('has-status');
     },
   );
 
-  it.each(['artifact', 'evidence', 'asset', 'unknown-type'])(
-    '%s는 no-status-concept(status 컬럼·fetch 경로 자체가 없다)',
+  // hypothesis는 AC2 어휘(STATUS_LABELS)엔 있지만 오늘 fetch 경로가 없어(ENTITY_API 부재)
+  // PR② v1 칩 렌더 관점에선 no-status-concept다 — 「어휘 있음」≠「지금 채울 수 있음」(두 축이
+  // 다르다는 것을 값으로 고정, 이 구분을 놓치면 hypothesis 칩이 영원히 "아직 모름"에 갇힌다).
+  it.each(['hypothesis', 'evidence', 'artifact', 'asset', 'unknown-type'])(
+    '%s는 no-status-concept(PR② v1 fetch 경로 자체가 없다·hypothesis는 어휘는 있어도 fetch가 없다)',
     (type) => {
       expect(entityStatusAvailability(type)).toBe('no-status-concept');
     },
@@ -21,6 +24,12 @@ describe('translateEntityStatus — 원시값 노출 금지(gate_type 사고 재
   it('has-status 타입의 매핑된 값은 사람이 읽는 한 줄로 번역된다', () => {
     expect(translateEntityStatus('story', 'in-review')).toBe('검토 중');
     expect(translateEntityStatus('epic', 'active')).toBe('진행 중');
+  });
+
+  // translateEntityStatus는 entityStatusAvailability(PR② v1 fetch 가능 여부)와 별개 축이다
+  // (파일 상단 주석 참고) — hypothesis는 칩 렌더에선 no-status-concept("상태 없음")이지만,
+  // 어휘 맵 자체는 있어서 rawStatus가 (미래의 다른 경로로) 주어지면 이 함수는 정상 번역한다.
+  it('hypothesis는 칩 렌더 관점에선 no-status-concept이지만 어휘 맵 번역 자체는 독립적으로 동작한다', () => {
     expect(translateEntityStatus('hypothesis', 'falsified')).toBe('반증됨');
   });
 

--- a/apps/web/src/components/chat/entity-status-labels.test.ts
+++ b/apps/web/src/components/chat/entity-status-labels.test.ts
@@ -1,19 +1,20 @@
 import { describe, expect, it } from 'vitest';
-import { entityStatusAvailability, translateEntityStatus } from './entity-status-labels';
+import { entityStatusAvailability, translateEntityStatus, groupUnresolvedReferencesByType } from './entity-status-labels';
 
 describe('entityStatusAvailability — 「아직 모름」↔「없음」을 가르는 구조적 판정(AC2·AC7)', () => {
-  it.each(['story', 'task', 'doc', 'sprint', 'epic'])(
-    '%s는 has-status(PR② v1이 실제로 배치조회할 타입)',
+  it.each(['story', 'task', 'doc', 'epic'])(
+    '%s는 has-status(PR② v1이 실제로 배치조회할 타입 — BE #2905가 ids= 를 낸 넷)',
     (type) => {
       expect(entityStatusAvailability(type)).toBe('has-status');
     },
   );
 
-  // hypothesis는 AC2 어휘(STATUS_LABELS)엔 있지만 오늘 fetch 경로가 없어(ENTITY_API 부재)
-  // PR② v1 칩 렌더 관점에선 no-status-concept다 — 「어휘 있음」≠「지금 채울 수 있음」(두 축이
-  // 다르다는 것을 값으로 고정, 이 구분을 놓치면 hypothesis 칩이 영원히 "아직 모름"에 갇힌다).
-  it.each(['hypothesis', 'evidence', 'artifact', 'asset', 'unknown-type'])(
-    '%s는 no-status-concept(PR② v1 fetch 경로 자체가 없다·hypothesis는 어휘는 있어도 fetch가 없다)',
+  // hypothesis·sprint는 AC2 어휘(STATUS_LABELS)엔 있지만 오늘 fetch 경로가 없어 PR② v1
+  // 칩 렌더 관점에선 no-status-concept다 — 「어휘 있음」≠「지금 채울 수 있음」(두 축이 다르다는
+  // 것을 값으로 고정, 이 구분을 놓치면 그 타입 칩이 영원히 "아직 모름"에 갇힌다). sprint는
+  // hypothesis보다 더 심하다 — ENTITY_API에 **단건조차** 없다(embed-card.tsx 재확認).
+  it.each(['hypothesis', 'sprint', 'evidence', 'artifact', 'asset', 'unknown-type'])(
+    '%s는 no-status-concept(PR② v1 fetch 경로 자체가 없다)',
     (type) => {
       expect(entityStatusAvailability(type)).toBe('no-status-concept');
     },
@@ -52,5 +53,54 @@ describe('translateEntityStatus — 원시값 노출 금지(gate_type 사고 재
   it('done류 라벨도 다른 상태와 같은 평문 형식이다(터미널 강조 접두어 없음)', () => {
     expect(translateEntityStatus('story', 'done')).toBe('완료');
     expect(translateEntityStatus('story', 'done')).not.toMatch(/[✅⭐️!]/);
+  });
+});
+
+describe('groupUnresolvedReferencesByType — chat-view.tsx 배치조회 effect의 순수 로직(#2262 PR②)', () => {
+  it('has-status 타입만 타입별로 묶는다(no-status-concept은 배치 대상에서 제외)', () => {
+    const messages = [{
+      references: [
+        { target_type: 'story', target_id: 's1' },
+        { target_type: 'hypothesis', target_id: 'h1' },
+        { target_type: 'epic', target_id: 'e1' },
+      ],
+    }];
+    const grouped = groupUnresolvedReferencesByType(messages, new Set());
+    expect(Array.from(grouped.keys()).sort()).toEqual(['epic', 'story']);
+    expect(grouped.get('story')).toEqual(['s1']);
+    expect(grouped.get('epic')).toEqual(['e1']);
+  });
+
+  it('여러 메시지가 같은 엔티티를 참조해도(대화 전체 기준) 한 번만 담긴다', () => {
+    const messages = [
+      { references: [{ target_type: 'task', target_id: 't1' }] },
+      { references: [{ target_type: 'task', target_id: 't1' }] },
+    ];
+    const grouped = groupUnresolvedReferencesByType(messages, new Set());
+    expect(grouped.get('task')).toEqual(['t1']);
+  });
+
+  it('alreadyRequestedKeys에 이미 있으면 재요청 대상에서 빠진다(SSE로 새 메시지 도착 시 중복 fetch 방지)', () => {
+    const messages = [{ references: [{ target_type: 'doc', target_id: 'd1' }, { target_type: 'doc', target_id: 'd2' }] }];
+    const grouped = groupUnresolvedReferencesByType(messages, new Set(['doc:d1']));
+    expect(grouped.get('doc')).toEqual(['d2']);
+  });
+
+  it('전부 이미 요청됐으면 빈 Map(size 0) — 호출부가 이걸로 fetch 스킵 여부를 판단한다', () => {
+    const messages = [{ references: [{ target_type: 'story', target_id: 's1' }] }];
+    const grouped = groupUnresolvedReferencesByType(messages, new Set(['story:s1']));
+    expect(grouped.size).toBe(0);
+  });
+
+  it('전달된 alreadyRequestedKeys Set을 직접 변형한다(호출부 ref 재사용 계약)', () => {
+    const seen = new Set<string>();
+    const messages = [{ references: [{ target_type: 'story', target_id: 's1' }] }];
+    groupUnresolvedReferencesByType(messages, seen);
+    expect(seen.has('story:s1')).toBe(true);
+  });
+
+  it('references가 undefined인 메시지는 안전하게 스킵된다', () => {
+    const grouped = groupUnresolvedReferencesByType([{ references: undefined }], new Set());
+    expect(grouped.size).toBe(0);
   });
 });

--- a/apps/web/src/components/chat/entity-status-labels.test.ts
+++ b/apps/web/src/components/chat/entity-status-labels.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { entityStatusAvailability, translateEntityStatus } from './entity-status-labels';
+
+describe('entityStatusAvailability — 「아직 모름」↔「없음」을 가르는 구조적 판정(AC2·AC7)', () => {
+  it.each(['story', 'task', 'doc', 'hypothesis', 'sprint', 'epic'])(
+    '%s는 has-status(실측된 status 어휘가 있다)',
+    (type) => {
+      expect(entityStatusAvailability(type)).toBe('has-status');
+    },
+  );
+
+  it.each(['artifact', 'evidence', 'asset', 'unknown-type'])(
+    '%s는 no-status-concept(status 컬럼·fetch 경로 자체가 없다)',
+    (type) => {
+      expect(entityStatusAvailability(type)).toBe('no-status-concept');
+    },
+  );
+});
+
+describe('translateEntityStatus — 원시값 노출 금지(gate_type 사고 재발 방지)', () => {
+  it('has-status 타입의 매핑된 값은 사람이 읽는 한 줄로 번역된다', () => {
+    expect(translateEntityStatus('story', 'in-review')).toBe('검토 중');
+    expect(translateEntityStatus('epic', 'active')).toBe('진행 중');
+    expect(translateEntityStatus('hypothesis', 'falsified')).toBe('반증됨');
+  });
+
+  it('매핑에 없는 값(신규 status 추가 등)은 원시값을 그대로 내지 않고 null이다', () => {
+    expect(translateEntityStatus('story', 'some-brand-new-status')).toBeNull();
+  });
+
+  it('no-status-concept 타입은 rawStatus가 뭐든 null이다(그 타입엔 번역 자체가 성립 안 함)', () => {
+    expect(translateEntityStatus('artifact', 'done')).toBeNull();
+  });
+
+  it('rawStatus 자체가 없으면(아직 안 왔다) null이다', () => {
+    expect(translateEntityStatus('story', null)).toBeNull();
+    expect(translateEntityStatus('story', undefined)).toBeNull();
+  });
+
+  // 회귀 가드 — done류를 다르게 번역하려는 시도(터미널 개념 없음 판정, 파울로 2026-07-30)를
+  // 잡는다. 색/굵기 차등은 이 함수 책임이 아니지만(렌더 쪽 몫), 문구 자체가 다른 done류와
+  // 「같은 급」으로 평평해야 한다 — 예: done을 "✅ 완료"처럼 특수 접두어로 튀게 하지 않는다.
+  it('done류 라벨도 다른 상태와 같은 평문 형식이다(터미널 강조 접두어 없음)', () => {
+    expect(translateEntityStatus('story', 'done')).toBe('완료');
+    expect(translateEntityStatus('story', 'done')).not.toMatch(/[✅⭐️!]/);
+  });
+});

--- a/apps/web/src/components/chat/entity-status-labels.ts
+++ b/apps/web/src/components/chat/entity-status-labels.ts
@@ -1,0 +1,56 @@
+/**
+ * story #2262 PR②(AC2 나머지) — 참조 칩 자체(모달 열기 前)에 보일 「지금 상태」의 번역·판정
+ * 로직. 배치조회 배선(chat-view.tsx, BE `?ids=` 대기 — 디디군 협업 중)보다 먼저 짜는 순수
+ * 로직 골격(PO 지시 2026-08-07: "번역맵·prop 스레딩 골격은 미리 짜둬도 되고, BE 계약은
+ * story `?ids=` 형태 그대로일 테니").
+ */
+
+/** AC2 실측(2026-07-30, sprintable-verify-oneoff) 그대로의 실 DB 값 어휘 — 이 여섯 타입만
+ * "상태 개념이 있다"(has-status). epic의 내부 모델명은 Goal이나(pm.py:47 계층 리네이밍
+ * B1) 참조 축 공개 타입명은 "epic"이다(reference_registry.ENTITY_RESOLVERS) — 그래서 여기
+ * 키는 "epic"으로 둔다(story #2262 PO 판정 — "epic 카드 한 벌만 그린다"와 같은 이유). */
+export type StatusBearingEntityType = 'story' | 'task' | 'doc' | 'hypothesis' | 'sprint' | 'epic';
+
+const STATUS_BEARING_TYPES: ReadonlySet<string> = new Set<StatusBearingEntityType>([
+  'story', 'task', 'doc', 'hypothesis', 'sprint', 'epic',
+]);
+
+/** ⛔맵에 없는 값이 오면(신규 status 추가 등) 칸을 비운다 — 원시값을 그대로 노출하지 않는다
+ * (gate_type 사고 재발 방지, #2156 requires_human/gate_type 교훈 재사용). "terminal" 개념이
+ * 이 제품에 없다는 판정(파울로, 2026-07-30)이 이미 서 있어 done류 라벨에 시각 차등(흐리게·
+ * 취소선)을 안 준다 — 번역은 문구만 바꾸고 무게는 그대로다. */
+const STATUS_LABELS: Record<StatusBearingEntityType, Record<string, string>> = {
+  story: {
+    done: '완료', backlog: '백로그', 'in-review': '검토 중', 'in-progress': '진행 중', 'ready-for-dev': '착수 대기',
+  },
+  task: { todo: '할 일', done: '완료', 'in-progress': '진행 중' },
+  doc: { draft: '초안', confirmed: '확定', pending: '검토 대기' },
+  hypothesis: {
+    proposed: '제안됨', archived: '보관됨', active: '진행 중', measuring: '측정 중', falsified: '반증됨', verified: '검증됨',
+  },
+  sprint: { closed: '종료', active: '진행 중', planning: '계획 중' },
+  epic: { archived: '보관됨', done: '완료', active: '진행 중' },
+};
+
+/** 「지금 상태」가 존재할 수 있는 타입인가(구조적 판정, AC2/AC7의 「아직 모름」↔「없음」을
+ * 가르는 재료). `has-status`(status 개념이 있는 여섯 타입) 밖은 전부 `no-status-concept` —
+ * artifact는 status 컬럼 자체가 없다(대신 `unresolved_comment_count`로 미결을 센다, PR②
+ * v1이 짊어지지 않는 AC3의 재료). hypothesis·evidence는 오늘 fetch 경로 자체가 없다
+ * (`ENTITY_API`에 의도적으로 빠져있음 — embed-card.tsx `ENTITY_API`/`EntityPreviewModal`
+ * 주석 참고) — PR② v1은 이 둘을 배치조회 대상에서 뺀다(갭으로 문서화, 회귀 없음). asset은
+ * FE 전용 타입이라 reference_registry 밖(원래 이 판정 대상이 아니다). */
+export function entityStatusAvailability(entityType: string): 'has-status' | 'no-status-concept' {
+  return STATUS_BEARING_TYPES.has(entityType) ? 'has-status' : 'no-status-concept';
+}
+
+/** rawStatus를 사람이 읽는 한 줄로 평평하게 바꾼다. has-status 타입이 아니거나, 매핑에 없는
+ * 값이거나, rawStatus 자체가 없으면(아직 안 왔다) null — 호출부가 null을 "아직 모름"으로
+ * 표시할지 "없음"으로 표시할지는 `entityStatusAvailability`로 미리 가른 뒤에 결정한다(이
+ * 함수 혼자서는 그 둘을 구분할 재료가 없다 — status bearing 타입인데 rawStatus가 아직 없는
+ * 것과, 애초에 status 개념이 없는 것은 다른 함수(entityStatusAvailability)가 가른다). */
+export function translateEntityStatus(entityType: string, rawStatus: string | null | undefined): string | null {
+  if (!rawStatus) return null;
+  if (entityStatusAvailability(entityType) === 'no-status-concept') return null;
+  const map = STATUS_LABELS[entityType as StatusBearingEntityType];
+  return map[rawStatus] ?? null;
+}

--- a/apps/web/src/components/chat/entity-status-labels.ts
+++ b/apps/web/src/components/chat/entity-status-labels.ts
@@ -12,12 +12,14 @@
 export type StatusBearingEntityType = 'story' | 'task' | 'doc' | 'hypothesis' | 'sprint' | 'epic';
 
 /** ⛔이 배치조회 가능 여부(PR② v1 스코프)와 「AC2가 정의한 status 어휘가 있는 타입」은
- * 다른 축이다 — hypothesis는 어휘는 있지만(STATUS_LABELS에 있음, 미래의 실 데이터 소비를
- * 위해 유지) 오늘 FE엔 fetch 경로 자체가 없어(ENTITY_API에 없음) PR② v1이 배치조회 대상에서
- * 뺀다(설계 문서 그대로). `entityStatusAvailability`(칩 렌더 판정)는 이 「지금 채울 수
- * 있는가」 축을 써야 한다 — 안 그러면 hypothesis 칩이 영원히 안 채워질 "아직 모름"에 갇힌다
- * (실제로는 "이 판에선 원래 없음"이 맞는 그림이다). */
-const PR2_V1_FETCHABLE_TYPES: ReadonlySet<string> = new Set(['story', 'task', 'doc', 'sprint', 'epic']);
+ * 다른 축이다 — hypothesis·sprint는 어휘는 있지만(STATUS_LABELS에 있음, 미래의 실 데이터
+ * 소비를 위해 유지) 오늘 FE엔 fetch 경로 자체가 없어 PR② v1이 배치조회 대상에서 뺀다.
+ * hypothesis는 ENTITY_API에 의도적으로 없고(embed-card.tsx 주석), sprint는 **단건조차**
+ * 없다(ENTITY_API에 키 자체가 없음 — grep 재확認, BE #2905도 epic·task·doc·artifact
+ * 넷만 배치 endpoint를 냈지 sprint는 범위 밖이었다). `entityStatusAvailability`(칩 렌더
+ * 판정)는 이 「지금 채울 수 있는가」 축을 써야 한다 — 안 그러면 그 타입 칩이 영원히 안
+ * 채워질 "아직 모름"에 갇힌다(실제로는 "이 판에선 원래 없음"이 맞는 그림이다). */
+const PR2_V1_FETCHABLE_TYPES: ReadonlySet<string> = new Set(['story', 'task', 'doc', 'epic']);
 
 /** ⛔맵에 없는 값이 오면(신규 status 추가 등) 칸을 비운다 — 원시값을 그대로 노출하지 않는다
  * (gate_type 사고 재발 방지, #2156 requires_human/gate_type 교훈 재사용). "terminal" 개념이
@@ -97,4 +99,41 @@ export function renderEntityStatusLabel(entityType: string, state: EntityStatusF
   if (entityStatusAvailability(entityType) === 'no-status-concept') return ENTITY_STATUS_NO_CONCEPT_LABEL;
   if (state.kind === 'loading' || state.kind === 'error') return ENTITY_STATUS_UNKNOWN_LABEL;
   return translateEntityStatus(entityType, state.raw);
+}
+
+/** story #2262 PR② — chat-view.tsx의 배치조회가 타입별로 부를 `?ids=` 엔드포인트.
+ * PR2_V1_FETCHABLE_TYPES와 정확히 같은 네 타입만 키를 가진다(그 밖 타입은 애초에 이
+ * 맵을 조회할 일이 없다 — entityStatusAvailability가 먼저 걸러준다). */
+export type BatchFetchableEntityType = 'story' | 'task' | 'doc' | 'epic';
+export const ENTITY_STATUS_BATCH_API_PATH: Record<BatchFetchableEntityType, string> = {
+  story: '/api/stories',
+  task: '/api/tasks',
+  doc: '/api/docs',
+  epic: '/api/goals',
+};
+
+/** story #2262 PR② — chat-view.tsx의 배치조회 effect가 매 렌더 훑는 「메시지 목록 →
+ * 타입별 아직 안 부른 id 묶음」 순수 로직만 분리했다(fetch·setState 없음 — React/SSE/네트워크
+ * 전부 안 건드리는 순수함수라 chat-view.tsx 전체를 마운트하지 않고도 유닛테스트 가능,
+ * flow-relation-review.ts와 같은 이유의 같은 패턴). `alreadyRequestedKeys`는 호출부가
+ * 관리하는 ref의 Set — 이 함수는 그 Set을 직접 변형(mutate)해 다음 호출에서 중복을
+ * 막는다(호출부가 매번 새 Set을 만들 필요 없게). */
+export function groupUnresolvedReferencesByType(
+  messages: Array<{ references?: Array<{ target_type: string; target_id: string }> }>,
+  alreadyRequestedKeys: Set<string>,
+): Map<BatchFetchableEntityType, string[]> {
+  const idsByType = new Map<BatchFetchableEntityType, string[]>();
+  for (const msg of messages) {
+    for (const ref of msg.references ?? []) {
+      if (entityStatusAvailability(ref.target_type) !== 'has-status') continue;
+      const type = ref.target_type as BatchFetchableEntityType;
+      const key = `${type}:${ref.target_id}`.toLowerCase();
+      if (alreadyRequestedKeys.has(key)) continue;
+      alreadyRequestedKeys.add(key);
+      const list = idsByType.get(type) ?? [];
+      list.push(ref.target_id);
+      idsByType.set(type, list);
+    }
+  }
+  return idsByType;
 }

--- a/apps/web/src/components/chat/entity-status-labels.ts
+++ b/apps/web/src/components/chat/entity-status-labels.ts
@@ -54,3 +54,21 @@ export function translateEntityStatus(entityType: string, rawStatus: string | nu
   const map = STATUS_LABELS[entityType as StatusBearingEntityType];
   return map[rawStatus] ?? null;
 }
+
+/** story #2262 PR② — `EntityChip`이 받을 「칩 자체 상태」 prop의 예정 계약(타입만, 미배선).
+ * PO 지시(2026-08-07): 카피(㉠no-status-concept "비었다고 말한다"·㉡loading "아직 모름"의
+ * 정확한 문구)는 유나양 디자인 판정 대기, 배치조회는 BE `?ids=`(디디군) 대기 — 둘 다 오면
+ * 한 번에 배선한다(지금 카피를 지어 배선하면 판정과 어긋나 다시 갈아엎을 위험). 이 타입은
+ * 그 배선이 맞춰 낄 자리를 미리 정해 두는 것 — `EntityChip`은 아직 이 prop을 안 받는다.
+ *
+ * `undefined`(prop 자체를 안 넘김) = 이 호출부에서 칩 상태 기능이 아직 안 켜짐(오늘의
+ * 기본, 회귀 없음). 값이 오면:
+ *   `{ kind: 'loading' }`        — 배치fetch 진행 중(has-status 타입에서만 의미 있음)
+ *   `{ kind: 'resolved', raw }`  — 배치fetch 완료, raw를 `translateEntityStatus`로 번역해 쓴다
+ *   `{ kind: 'error' }`          — 배치fetch 실패(네트워크 등) — "아직 모름"과 같은 급으로 다룬다
+ * no-status-concept 타입(entityStatusAvailability로 미리 가른다)엔 이 prop 자체를 안 넘기는
+ * 것을 호출부 관례로 삼는다(구조적으로 없는 것과 "아직 못 잰 것"을 prop 유무로도 가른다). */
+export type EntityStatusFetchState =
+  | { kind: 'loading' }
+  | { kind: 'resolved'; raw: string | null }
+  | { kind: 'error' };

--- a/apps/web/src/components/chat/entity-status-labels.ts
+++ b/apps/web/src/components/chat/entity-status-labels.ts
@@ -11,9 +11,13 @@
  * 키는 "epic"으로 둔다(story #2262 PO 판정 — "epic 카드 한 벌만 그린다"와 같은 이유). */
 export type StatusBearingEntityType = 'story' | 'task' | 'doc' | 'hypothesis' | 'sprint' | 'epic';
 
-const STATUS_BEARING_TYPES: ReadonlySet<string> = new Set<StatusBearingEntityType>([
-  'story', 'task', 'doc', 'hypothesis', 'sprint', 'epic',
-]);
+/** ⛔이 배치조회 가능 여부(PR② v1 스코프)와 「AC2가 정의한 status 어휘가 있는 타입」은
+ * 다른 축이다 — hypothesis는 어휘는 있지만(STATUS_LABELS에 있음, 미래의 실 데이터 소비를
+ * 위해 유지) 오늘 FE엔 fetch 경로 자체가 없어(ENTITY_API에 없음) PR② v1이 배치조회 대상에서
+ * 뺀다(설계 문서 그대로). `entityStatusAvailability`(칩 렌더 판정)는 이 「지금 채울 수
+ * 있는가」 축을 써야 한다 — 안 그러면 hypothesis 칩이 영원히 안 채워질 "아직 모름"에 갇힌다
+ * (실제로는 "이 판에선 원래 없음"이 맞는 그림이다). */
+const PR2_V1_FETCHABLE_TYPES: ReadonlySet<string> = new Set(['story', 'task', 'doc', 'sprint', 'epic']);
 
 /** ⛔맵에 없는 값이 오면(신규 status 추가 등) 칸을 비운다 — 원시값을 그대로 노출하지 않는다
  * (gate_type 사고 재발 방지, #2156 requires_human/gate_type 교훈 재사용). "terminal" 개념이
@@ -32,34 +36,33 @@ const STATUS_LABELS: Record<StatusBearingEntityType, Record<string, string>> = {
   epic: { archived: '보관됨', done: '완료', active: '진행 중' },
 };
 
-/** 「지금 상태」가 존재할 수 있는 타입인가(구조적 판정, AC2/AC7의 「아직 모름」↔「없음」을
- * 가르는 재료). `has-status`(status 개념이 있는 여섯 타입) 밖은 전부 `no-status-concept` —
- * artifact는 status 컬럼 자체가 없다(대신 `unresolved_comment_count`로 미결을 센다, PR②
- * v1이 짊어지지 않는 AC3의 재료). hypothesis·evidence는 오늘 fetch 경로 자체가 없다
- * (`ENTITY_API`에 의도적으로 빠져있음 — embed-card.tsx `ENTITY_API`/`EntityPreviewModal`
- * 주석 참고) — PR② v1은 이 둘을 배치조회 대상에서 뺀다(갭으로 문서화, 회귀 없음). asset은
- * FE 전용 타입이라 reference_registry 밖(원래 이 판정 대상이 아니다). */
+/** 「지금 상태」를 **PR② v1이 실제로 채울 수 있는** 타입인가(구조적 판정, AC2/AC7의
+ * 「아직 모름」↔「없음」을 가르는 재료 — 칩 렌더링이 이 함수로 판정한다). ⛔"AC2가 정의한
+ * status 어휘가 있나"와는 다른 축이다(STATUS_LABELS 주석 참고) — hypothesis는 어휘는
+ * 있어도 fetch 경로가 없어 여기선 no-status-concept다. artifact는 status 컬럼 자체가
+ * 없다(대신 unresolved_comment_count로 미결을 센다, PR②가 짊어지지 않는 AC3의 재료).
+ * evidence·asset도 마찬가지로 no-status-concept. */
 export function entityStatusAvailability(entityType: string): 'has-status' | 'no-status-concept' {
-  return STATUS_BEARING_TYPES.has(entityType) ? 'has-status' : 'no-status-concept';
+  return PR2_V1_FETCHABLE_TYPES.has(entityType) ? 'has-status' : 'no-status-concept';
 }
 
-/** rawStatus를 사람이 읽는 한 줄로 평평하게 바꾼다. has-status 타입이 아니거나, 매핑에 없는
- * 값이거나, rawStatus 자체가 없으면(아직 안 왔다) null — 호출부가 null을 "아직 모름"으로
- * 표시할지 "없음"으로 표시할지는 `entityStatusAvailability`로 미리 가른 뒤에 결정한다(이
- * 함수 혼자서는 그 둘을 구분할 재료가 없다 — status bearing 타입인데 rawStatus가 아직 없는
- * 것과, 애초에 status 개념이 없는 것은 다른 함수(entityStatusAvailability)가 가른다). */
+/** rawStatus를 사람이 읽는 한 줄로 평평하게 바꾼다. STATUS_LABELS에 그 타입 맵 자체가
+ * 없거나, 매핑에 없는 값이거나, rawStatus 자체가 없으면(아직 안 왔다) null — ⛔이 함수는
+ * `entityStatusAvailability`(PR② v1 fetch 가능 여부)와 별도다: hypothesis처럼 오늘 fetch
+ * 경로는 없어도 어휘 맵은 있는 타입에 실제 rawStatus가 (미래에 다른 경로로) 들어오면 이
+ * 함수는 정상 번역한다 — 「지금 채울 수 있나」는 칩 렌더 쪽(entityStatusAvailability) 책임,
+ * 「번역할 수 있나」는 이 함수 책임으로 나눈다. */
 export function translateEntityStatus(entityType: string, rawStatus: string | null | undefined): string | null {
   if (!rawStatus) return null;
-  if (entityStatusAvailability(entityType) === 'no-status-concept') return null;
   const map = STATUS_LABELS[entityType as StatusBearingEntityType];
+  if (!map) return null;
   return map[rawStatus] ?? null;
 }
 
-/** story #2262 PR② — `EntityChip`이 받을 「칩 자체 상태」 prop의 예정 계약(타입만, 미배선).
- * PO 지시(2026-08-07): 카피(㉠no-status-concept "비었다고 말한다"·㉡loading "아직 모름"의
- * 정확한 문구)는 유나양 디자인 판정 대기, 배치조회는 BE `?ids=`(디디군) 대기 — 둘 다 오면
- * 한 번에 배선한다(지금 카피를 지어 배선하면 판정과 어긋나 다시 갈아엎을 위험). 이 타입은
- * 그 배선이 맞춰 낄 자리를 미리 정해 두는 것 — `EntityChip`은 아직 이 prop을 안 받는다.
+/** story #2262 PR② — `EntityChip`이 받을 「칩 자체 상태」 prop의 예정 계약. 배치조회
+ * 배선(chat-view.tsx, BE `?ids=` — 디디군 대기)만 아직 안 됐다 — 카피는 유나양 판정
+ * 완료(2026-08-07)로 아래 세 상수에 이미 반영. `EntityChip`은 아직 이 prop을 안 받는다
+ * (BE 오면 그때 prop 추가+`renderEntityStatusLabel` 호출을 한 번에 배선).
  *
  * `undefined`(prop 자체를 안 넘김) = 이 호출부에서 칩 상태 기능이 아직 안 켜짐(오늘의
  * 기본, 회귀 없음). 값이 오면:
@@ -72,3 +75,26 @@ export type EntityStatusFetchState =
   | { kind: 'loading' }
   | { kind: 'resolved'; raw: string | null }
   | { kind: 'error' };
+
+/** 유나양 카피 판정(2026-08-07, #2262 AC2):
+ * ① 상태 개념 자체가 없는 타입(hypothesis·evidence·artifact) → "상태 없음"
+ *    (「없음」과 「아직 모름」이 나란히 렌더될 때 시각적으로 안 갈리면 "해당 없음"으로 대체
+ *    검토 — 라이브 배선 後 유나 재확認 필요, 아직 미확定).
+ * ② 배치조회 미완(loading) **또는 실패(error)** → "아직 모름" — ⛔"확認 중"은 쓰지 않는다
+ *    (fetch가 실패한 순간엔 "확認 중"이 거짓이 된다 — 미완이든 실패든 "지금 모름"인 것은
+ *    같은 사실이라 문구를 하나로 통일한다).
+ * ③ has-status 타입인데 rawStatus가 매핑에 없음(신규 status 미반영 등) → 빈칸(문구 없음,
+ *    `translateEntityStatus`가 이미 null을 낸다 — 새 문구를 안 만든다). */
+export const ENTITY_STATUS_NO_CONCEPT_LABEL = '상태 없음';
+export const ENTITY_STATUS_UNKNOWN_LABEL = '아직 모름';
+
+/** `EntityStatusFetchState`(배치조회 결과)를 칩에 그대로 쓸 한 줄로 접는다. 반환 null은
+ * "이 칩엔 상태 관련 문구를 아예 안 그린다"는 뜻(③ 매핑 안 된 값 — 빈칸도 「아직 모름」과는
+ * 다르다, 매핑 자체가 없는 것은 새 status 추가를 놓친 FE 버그 신호이지 사용자에게 알릴
+ * 정보가 아니다). state가 `undefined`(호출부가 기능 자체를 안 켬)면 이 함수를 안 부르는
+ * 것이 호출부 관례 — 이 함수는 state가 실제로 있을 때만 호출된다는 전제다. */
+export function renderEntityStatusLabel(entityType: string, state: EntityStatusFetchState): string | null {
+  if (entityStatusAvailability(entityType) === 'no-status-concept') return ENTITY_STATUS_NO_CONCEPT_LABEL;
+  if (state.kind === 'loading' || state.kind === 'error') return ENTITY_STATUS_UNKNOWN_LABEL;
+  return translateEntityStatus(entityType, state.raw);
+}

--- a/apps/web/src/components/chat/thread-panel.tsx
+++ b/apps/web/src/components/chat/thread-panel.tsx
@@ -1,12 +1,18 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
 import { X } from 'lucide-react';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
 import { normalizeToMessage } from '@/hooks/use-chat-sse';
 import { ChatBubble } from './chat-bubble';
 import { ChatInput } from './chat-input';
 import type { EntityStatusFetchState } from '@/components/chat/entity-status-labels';
+import { useEntityStatusBatchFetch } from '@/hooks/use-entity-status-batch';
+
+// story #2262 PR② — 배치조회가 꺼진(구 호출부) 경우 훅에 넘길 안정적인 빈 배열 참조(매
+// 렌더 새 배열을 만들면 useEntityStatusBatchFetch의 effect가 messages 변경으로 오인해
+// 매번 재실행된다 — 어차피 빈 배열이라 fetch는 안 나가지만 불필요한 재실행 자체를 막는다).
+const EMPTY_THREAD_MESSAGES: ChatMessage[] = [];
 
 interface ThreadPanelProps {
   parentMessage: ChatMessage;
@@ -18,9 +24,15 @@ interface ThreadPanelProps {
   incomingMessage?: ChatMessage | null;
   // P2 RC: notify parent to increment reply_count when own reply sent
   onReplyAdded?: (parentId: string) => void;
-  /** story #2262 AC2 PR② — ChatView가 배치조회한 캐시를 그대로 물려받는다(스레드 패널도
-   * 같은 EntityChip을 그리므로 같은 캐시를 공유해야 일관된다·별도 fetch 안 함). */
+  /** story #2262 AC2 PR② — ChatView가 만든 「대화 전체 1개」 캐시·요청장부를 그대로
+   * 물려받는다(별도로 안 만든다) — 부모 메시지는 이미 채워진 캐시를 그리기만 하지만,
+   * 스레드 답글 자신의 참조는 이 훅으로 직접 배치조회한다(같은 requestedKeysRef를
+   * 공유해 중복 fetch 방지, PO 지적 2026-08-08 — 스레드 전용 참조가 예전엔 영원히
+   * "아직 모름"에 고착됐었다). 둘 다 생략하면(undefined) 스레드 패널 배치조회 자체가
+   * 꺼진다(기존 회귀 없음 — 옛 테스트 호출부 대비). */
   entityStatusByKey?: Record<string, EntityStatusFetchState>;
+  requestedEntityStatusKeysRef?: RefObject<Set<string>>;
+  setEntityStatusByKey?: (updater: (prev: Record<string, EntityStatusFetchState>) => Record<string, EntityStatusFetchState>) => void;
 }
 
 export function ThreadPanel({
@@ -32,12 +44,25 @@ export function ThreadPanel({
   incomingMessage,
   onReplyAdded,
   entityStatusByKey,
+  requestedEntityStatusKeysRef,
+  setEntityStatusByKey,
 }: ThreadPanelProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [loading, setLoading] = useState(true);
   const bottomRef = useRef<HTMLDivElement>(null);
   // AC6: CB-S8 패턴 — render 후 DOM 반영된 직후 스크롤 보장
   const shouldScrollToBottomRef = useRef(false);
+
+  // story #2262 PR② — ChatView가 안 물려주면(구 호출부·테스트) 배치조회 기능 자체를 끈다
+  // (fetch 자체가 안 나가게 messages를 빈 배열로 훅에 넘긴다 — hook 자체는 rules-of-hooks
+  // 때문에 조건부 호출 불가라 항상 부르되 입력으로 무력화한다).
+  const localRequestedKeysRef = useRef<Set<string>>(new Set());
+  const noopSetEntityStatusByKey = useCallback(() => {}, []);
+  useEntityStatusBatchFetch(
+    setEntityStatusByKey ? messages : EMPTY_THREAD_MESSAGES,
+    requestedEntityStatusKeysRef ?? localRequestedKeysRef,
+    setEntityStatusByKey ?? noopSetEntityStatusByKey,
+  );
 
   const fetchThreadMessages = useCallback(async () => {
     try {

--- a/apps/web/src/components/chat/thread-panel.tsx
+++ b/apps/web/src/components/chat/thread-panel.tsx
@@ -6,6 +6,7 @@ import type { ChatMessage } from '@/hooks/use-chat-sse';
 import { normalizeToMessage } from '@/hooks/use-chat-sse';
 import { ChatBubble } from './chat-bubble';
 import { ChatInput } from './chat-input';
+import type { EntityStatusFetchState } from '@/components/chat/entity-status-labels';
 
 interface ThreadPanelProps {
   parentMessage: ChatMessage;
@@ -17,6 +18,9 @@ interface ThreadPanelProps {
   incomingMessage?: ChatMessage | null;
   // P2 RC: notify parent to increment reply_count when own reply sent
   onReplyAdded?: (parentId: string) => void;
+  /** story #2262 AC2 PR② — ChatView가 배치조회한 캐시를 그대로 물려받는다(스레드 패널도
+   * 같은 EntityChip을 그리므로 같은 캐시를 공유해야 일관된다·별도 fetch 안 함). */
+  entityStatusByKey?: Record<string, EntityStatusFetchState>;
 }
 
 export function ThreadPanel({
@@ -27,6 +31,7 @@ export function ThreadPanel({
   onClose,
   incomingMessage,
   onReplyAdded,
+  entityStatusByKey,
 }: ThreadPanelProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [loading, setLoading] = useState(true);
@@ -120,6 +125,7 @@ export function ThreadPanel({
           isMine={parentMessage.created_by === currentTeamMemberId}
           isGrouped={false}
           projectId={projectId}
+          entityStatusByKey={entityStatusByKey}
         />
       </div>
 
@@ -141,6 +147,7 @@ export function ThreadPanel({
                   isMine={msg.created_by === currentTeamMemberId}
                   isGrouped={isGrouped}
                   projectId={projectId}
+                  entityStatusByKey={entityStatusByKey}
                 />
               );
             })}

--- a/apps/web/src/hooks/use-entity-status-batch.test.tsx
+++ b/apps/web/src/hooks/use-entity-status-batch.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+//
+// story #2262 PR②(2026-08-08, PO 지적) — chat-view.tsx와 thread-panel.tsx가 「같은
+// requestedKeysRef·같은 setEntityStatusByKey」를 공유하며 이 훅을 각자의 messages로
+// 부르는 계약을 고정한다. 이전엔 스레드 답글에서만 처음 보이는 참조가 chat-view의
+// messages(루트 메시지만)에 한 번도 안 잡혀 영원히 "아직 모름"에 고착됐다 — 이 훅을
+// 두 번째 messages 목록으로 한 번 더 부르면 그 참조도 정확히 잡힌다는 것을 직접
+// 렌더로 검증한다(정적 로직 주장이 아니라 실제 effect 왕복).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, useRef, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useEntityStatusBatchFetch } from './use-entity-status-batch';
+import type { EntityStatusFetchState } from '@/components/chat/entity-status-labels';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+type Ref = { target_type: string; target_id: string };
+type Msg = { references?: Ref[] };
+
+function Harness({ mainMessages, threadMessages }: { mainMessages: Msg[]; threadMessages: Msg[] }) {
+  const [entityStatusByKey, setEntityStatusByKey] = useState<Record<string, EntityStatusFetchState>>({});
+  const requestedKeysRef = useRef<Set<string>>(new Set());
+  // chat-view.tsx 역할
+  useEntityStatusBatchFetch(mainMessages, requestedKeysRef, setEntityStatusByKey);
+  // thread-panel.tsx 역할 — 같은 ref·같은 setter를 공유
+  useEntityStatusBatchFetch(threadMessages, requestedKeysRef, setEntityStatusByKey);
+  return <div data-testid="dump">{JSON.stringify(entityStatusByKey)}</div>;
+}
+
+async function flush(times = 4) {
+  await act(async () => {
+    for (let i = 0; i < times; i++) await Promise.resolve();
+  });
+}
+
+describe('useEntityStatusBatchFetch — 메인+스레드 두 messages를 같은 캐시로 공유(#2262 PR②)', () => {
+  it('스레드 답글 전용 참조(메인 messages엔 없음)도 잡혀 resolved로 채워진다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      expect(url).toContain('/api/tasks?ids=thread-only-1');
+      return { ok: true, json: async () => ({ data: [{ id: 'thread-only-1', status: 'done' }] }) };
+    }));
+
+    await act(async () => {
+      root.render(
+        <Harness
+          mainMessages={[]}
+          threadMessages={[{ references: [{ target_type: 'task', target_id: 'thread-only-1' }] }]}
+        />,
+      );
+    });
+    await flush();
+
+    expect(container.querySelector('[data-testid="dump"]')?.textContent).toContain('"task:thread-only-1":{"kind":"resolved","raw":"done"}');
+  });
+
+  it('메인·스레드 양쪽이 같은 엔티티를 참조해도 fetch는 한 번만 나간다(공유 requestedKeysRef)', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({ data: [{ id: 's1', status: 'done' }] }) }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await act(async () => {
+      root.render(
+        <Harness
+          mainMessages={[{ references: [{ target_type: 'story', target_id: 's1' }] }]}
+          threadMessages={[{ references: [{ target_type: 'story', target_id: 's1' }] }]}
+        />,
+      );
+    });
+    await flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/hooks/use-entity-status-batch.ts
+++ b/apps/web/src/hooks/use-entity-status-batch.ts
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect, type RefObject } from 'react';
+import {
+  groupUnresolvedReferencesByType, ENTITY_STATUS_BATCH_API_PATH, type EntityStatusFetchState,
+} from '@/components/chat/entity-status-labels';
+
+/** story #2262 PR② — 참조 칩 「지금 상태」 배치조회 effect를 훅으로 뽑았다. chat-view.tsx
+ * (메인 채널)와 thread-panel.tsx(스레드 답글) 양쪽이 이 훅을 각자의 `messages`로 부르고,
+ * `requestedKeysRef`·`setEntityStatusByKey`는 부모(chat-view.tsx)가 만든 **같은 객체**를
+ * 그대로 물려받는다(ThreadPanel은 자기 것을 새로 안 만든다) — 그래야 두 effect가 같은
+ * 「이미 요청한 키」 장부를 공유해 중복 fetch가 안 나고, 스레드에서만 처음 보이는 참조도
+ * 이 훅이 있는 한 반드시 한쪽 effect가 집어간다(⛔이전엔 스레드 답글 전용 참조가 어느
+ * effect의 messages에도 없어 영원히 "아직 모름"에 고착됐다 — PO 지적, 2026-08-08).
+ * 타입별로 묶어 `?ids=` 배치 endpoint를 한 번씩만 부른다(메시지마다 N+1 아님). */
+export function useEntityStatusBatchFetch(
+  messages: Array<{ references?: Array<{ target_type: string; target_id: string }> }>,
+  requestedKeysRef: RefObject<Set<string>>,
+  setEntityStatusByKey: (updater: (prev: Record<string, EntityStatusFetchState>) => Record<string, EntityStatusFetchState>) => void,
+) {
+  useEffect(() => {
+    const idsByType = groupUnresolvedReferencesByType(messages, requestedKeysRef.current);
+    if (idsByType.size === 0) return;
+
+    setEntityStatusByKey((prev) => {
+      const next = { ...prev };
+      for (const [type, ids] of idsByType) {
+        for (const id of ids) next[`${type}:${id}`.toLowerCase()] = { kind: 'loading' };
+      }
+      return next;
+    });
+
+    let cancelled = false;
+    for (const [type, ids] of idsByType) {
+      fetch(`${ENTITY_STATUS_BATCH_API_PATH[type]}?ids=${ids.map(encodeURIComponent).join(',')}`)
+        .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`status ${res.status}`))))
+        .then((body: { data?: Array<{ id: string; status?: string | null }> }) => {
+          if (cancelled) return;
+          const items = body.data ?? [];
+          setEntityStatusByKey((prev) => {
+            const next = { ...prev };
+            for (const id of ids) {
+              const found = items.find((it) => it.id === id);
+              next[`${type}:${id}`.toLowerCase()] = { kind: 'resolved', raw: found?.status ?? null };
+            }
+            return next;
+          });
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setEntityStatusByKey((prev) => {
+            const next = { ...prev };
+            for (const id of ids) next[`${type}:${id}`.toLowerCase()] = { kind: 'error' };
+            return next;
+          });
+        });
+    }
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- requestedKeysRef·setEntityStatusByKey는 부모가 안정적으로 물려주는 참조(ref·useState setter)다.
+  }, [messages]);
+}

--- a/apps/web/src/services/docs.ts
+++ b/apps/web/src/services/docs.ts
@@ -19,6 +19,13 @@ export class DocsService {
     return this.repo.list({ project_id: projectId, limit: input?.limit, cursor: input?.cursor ?? undefined, tags: input?.tags });
   }
 
+  /** story #2262 PR②(BE #2905) — ids 배치 lookup은 project_id 없이 org 전체에서
+   * exact-id IN 조회한다(list()와 별도 메서드로 둔다 — projectId 필수 계약을 안 건드리기
+   * 위해서다, 호출부가 안 헷갈리게 "이건 project 무관"임을 이름으로도 밝힌다). */
+  async listByIds(ids: string[]) {
+    return this.repo.list({ ids, limit: ids.length });
+  }
+
   async getDoc(projectId: string, slug: string) {
     return this.repo.getBySlug(projectId, slug);
   }

--- a/apps/web/src/services/goal.ts
+++ b/apps/web/src/services/goal.ts
@@ -12,7 +12,7 @@ export class GoalService {
     return this.repository.create(input);
   }
 
-  async list(filters: { project_id?: string; limit?: number; cursor?: string | null; order_by?: string; include?: string }) {
+  async list(filters: { project_id?: string; limit?: number; cursor?: string | null; order_by?: string; include?: string; ids?: string[] }) {
     return this.repository.list(filters);
   }
 

--- a/packages/core-storage/src/interfaces/IDocRepository.ts
+++ b/packages/core-storage/src/interfaces/IDocRepository.ts
@@ -59,9 +59,14 @@ export interface UpdateDocInput {
 }
 
 export interface DocListFilters extends PaginationOptions {
-  project_id: string;
+  // story #2262 PR②(BE #2905) — ids 배치 lookup은 project_id 없이 org 전체에서 exact-id
+  // IN 조회한다(story ca37b2b0과 동일 계약) — 그래서 project_id를 optional로 넓힌다.
+  // ids가 없는 기존 호출부는 지금처럼 project_id를 계속 필수로 넘겨야 한다(BE가 그 경로엔
+  // project_id를 그대로 요구한다 — 타입만 넓어졌지 기존 계약은 안 바뀐다).
+  project_id?: string;
   tags?: string[];
   q?: string;
+  ids?: string[];
 }
 
 // story #2191(#2231 규약 A) — BE가 has_more/next_cursor를 body meta로 직접 계산해 낸다

--- a/packages/core-storage/src/interfaces/IEpicRepository.ts
+++ b/packages/core-storage/src/interfaces/IEpicRepository.ts
@@ -60,6 +60,10 @@ export interface EpicListFilters extends PaginationOptions {
    * (story #2298 옵트인). 이 필드가 없어 route.ts→GoalService→ApiEpicRepository 4단 체인
    * 전체가 이 파라미터를 한 번도 BE까지 실어 나르지 못했다(#2224 초점 스트립 결함의 진짜 근본). */
   include?: string;
+  /** story #2262 PR②(BE #2905) — 배치 lookup(comma-separated로 ApiEpicRepository가 그대로
+   * 전달). story `ids`(ca37b2b0)와 동일 계약: project_id 없이도 org 전체에서 exact-id IN
+   * 조회, accessible_project_ids_in_org로 접근권만 걸린다. */
+  ids?: string[];
 }
 
 /** 로드맵 조타 재정렬(wedge #2·BE `PATCH /api/v2/epics/bulk`). 큐레이션한 에픽만 position 세팅. */

--- a/packages/core-storage/src/interfaces/ITaskRepository.ts
+++ b/packages/core-storage/src/interfaces/ITaskRepository.ts
@@ -37,6 +37,9 @@ export interface TaskListFilters extends PaginationOptions {
   status?: string;
   status_ne?: string;
   days_since?: number;
+  /** story #2262 PR②(BE #2905) — 배치 lookup(comma-separated). Task엔 project_id 컬럼이
+   * 없어(story_id NN) BE가 org-scope lookup 後 story_id→project_id로 접근권을 건다. */
+  ids?: string[];
 }
 
 export interface ITaskRepository {

--- a/packages/storage-api/src/ApiDocRepository.ts
+++ b/packages/storage-api/src/ApiDocRepository.ts
@@ -19,6 +19,10 @@ export class ApiDocRepository implements IDocRepository {
         cursor: filters.cursor ?? undefined,
         tags: filters.tags?.join(','),
         q: filters.q,
+        // story #2262 PR②(BE #2905) — ids 분기는 project_id 없이도 {data,meta} 봉투로 온다
+        // (docs.py list_docs 실측 — 다른 분기와 같은 envelope, has_more/next_cursor는
+        // 항상 false/null이라 이 함수의 기존 res.meta 읽기 코드가 그대로 안전하다).
+        ids: filters.ids?.join(','),
       },
     });
     return { items: res.data, hasMore: res.meta.has_more, nextCursor: res.meta.next_cursor };

--- a/packages/storage-api/src/ApiEpicRepository.ts
+++ b/packages/storage-api/src/ApiEpicRepository.ts
@@ -25,6 +25,8 @@ export class ApiEpicRepository implements IEpicRepository {
         limit: filters.limit,
         order_by: filters.order_by,
         include: filters.include,
+        // story #2262 PR②(BE #2905) — story ids(ca37b2b0)와 동일 계약, comma-separated.
+        ids: filters.ids?.join(','),
       },
     });
   }

--- a/packages/storage-api/src/ApiTaskRepository.ts
+++ b/packages/storage-api/src/ApiTaskRepository.ts
@@ -10,7 +10,11 @@ export class ApiTaskRepository implements ITaskRepository {
 
   async list(filters: TaskListFilters): Promise<Task[]> {
     return fastapiCall<Task[]>('GET', '/api/v2/tasks', this.accessToken, {
-      query: { story_id: filters.story_id, assignee_id: filters.assignee_id, status: filters.status },
+      query: {
+        story_id: filters.story_id, assignee_id: filters.assignee_id, status: filters.status,
+        // story #2262 PR②(BE #2905) — story ids(ca37b2b0)와 동일 계약, comma-separated.
+        ids: filters.ids?.join(','),
+      },
     });
   }
 


### PR DESCRIPTION
## Summary
- 참조 칩(EntityChip)에 「지금 상태」 표기를 추가한다(AC2 나머지). BE #2905(`GET /api/v2/{epics,tasks,docs,visual-artifacts}?ids=`)를 소비해 대화에 보이는 모든 참조를 타입별로 묶어 배치조회하고, `chat-view.tsx`/`thread-panel.tsx`가 공유하는 캐시(`entityStatusByKey`, 대화 전체 1개·타입:id 키)를 `ChatBubble` 렌더 경로에 물린다.
- 유나양 카피 판정(2026-08-07) 그대로: has-status 타입(story/task/doc/epic) 로딩·실패 = "아직 모름", no-status-concept 타입(hypothesis/sprint/evidence/artifact/asset) = "상태 없음", 매핑 안 된 값 = 빈칸.
- **⛔착수 前 소비파일 통독 중 2번째 발견**: `sprint`가 PR2_V1_FETCHABLE_TYPES에 있었으나 `ENTITY_API`엔 단건조회조차 없다(hypothesis급이 아니라 그보다 아예 없음) — BE #2905도 epic·task·doc·artifact 넷만 배치 endpoint를 냈지 sprint는 범위 밖. hypothesis 때와 같은 축의 같은 버그를 착수 전에 잡아 제거했다(sprint 칩은 이제 정확히 "상태 없음").
- `groupUnresolvedReferencesByType()`으로 배치조회 effect의 핵심 로직(메시지→타입별 미요청 id 묶음)을 순수함수로 분리 — fetch/React 없이 유닛테스트 가능(#2358 `flow-relation-review.ts`와 동일 패턴).
- **⛔PO 리뷰 지적 fix(2026-08-08)**: 스레드 답글에서만 처음 보이는 참조가 `chat-view.tsx`의 메인 채널 effect(루트 messages만 훑음)에 안 잡혀 영원히 "아직 모름"에 고착되는 결함을 발견 — 배치조회 effect를 `useEntityStatusBatchFetch` 훅으로 분리해 `chat-view.tsx`·`thread-panel.tsx`가 **같은** `requestedKeysRef`·`setEntityStatusByKey`를 공유해 부르도록 고쳐 구조적으로 폐쇄(미조회 키를 중립 라벨로 덮는 밴드에이드는 기각 — 메인 채널도 마운트 직후엔 같은 구분불가 문제가 생겨 새 깜빡임을 만들 뿐이라 판단).
- "이미 요청한 키" 추적은 React state가 아니라 ref(Set)로 — messages를 effect dependency로 두면서도 setState가 effect를 재트리거하는 순환을 원천 차단.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm run lint` 0 error(기존과 동일한 무관 warning 3개만)
- [x] `pnpm exec vitest run` 387 files / 2901 tests all green(develop 리베이스 後 기준)
- [x] `pnpm run build` exit 0
- [x] `groupUnresolvedReferencesByType` 뮤테이션 self-check(dedup guard 제거→RED→원복→GREEN)
- [x] `ChatBubble`의 `entityStatus` prop 전달 뮤테이션 self-check(제거→RED→원복→GREEN)
- [x] goals/tasks/docs `ids=` 라우트 분기 뮤테이션 self-check(분기 disable→RED→원복→GREEN, 별도 커밋)
- [x] `useEntityStatusBatchFetch` 공유 뮤테이션 self-check(메인·스레드에 별도 ref를 줘 공유를 깨봄→dedup 테스트 RED→원복→GREEN)
- [ ] 라이브 배포 後 픽셀 검증(유나 경유) — 실제 story/task/doc/epic 상태가 칩에 정확히 뜨는지, 스레드 답글 전용 참조도 정확히 resolved되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)
