### PR TITLE
fix(#2521): PATCH /stories/bulk이 status→done 전이 時 merge-gate를 아예 안 거치던 결함

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -1611,6 +1611,11 @@ async def bulk_update_stories(
     # "미배정→배정"의 유효한 old값이라 .get() 대신 멤버십(`in`)으로 "실제 변경 있었음"을 판정한다
     # (status_by_id는 status가 None일 수 없어 .get()만으로 충분했던 것과 다른 지점).
     old_assignee_by_id: dict[uuid.UUID, uuid.UUID | None] = {}
+    # story #2521 후속(카디르 QA③, PO 2026-08-08 확정 — (a)안): 게이트 차단 item도 결과에
+    # 남기되 원래 status 유지 + StoryResponse.violation(신규 필드 아님·#2173이 이미 세운
+    # 「이례적」 표기 그 필드 재사용)에 차단 사유를 담는다. has_project_access 미충족(존재
+    # 비노출)과 달리 이건 「존재하고 접근권도 있는데 승인 대기」라 조용하면 #2067 재현.
+    gate_pending_by_id: dict[uuid.UUID, dict] = {}
     for item in payload.items:
         # E-SECURITY SEC-S8(story 83ea3d6a) W(까심 QA, CRITICAL·실HTTP 확定): 이 raw 쿼리가
         # org_id 필터 자체가 없어(정상 repo.get()은 self._org_filter() 명시·RLS도 0002서 off)
@@ -1638,9 +1643,14 @@ async def bulk_update_stories(
         #
         # 차단 시 처리: 단건은 HTTPException(409)로 요청 전체를 거절하지만, bulk는 한 item이
         # 막혔다고 나머지 정당한 item까지 통째로 실패시키면 안 된다(다건성 — #2173이 emit 쪽에
-        # 이미 세운 그 원칙과 동형). has_project_access 미충족 item과 동일하게 **그 item만
-        # continue로 조용히 스킵**(status뿐 아니라 그 item의 다른 필드 변경도 함께 스킵 —
-        # "게이트가 막은 전이를 일부만 우회해 다른 필드로 들여보내는" 여지를 안 남긴다).
+        # 이미 세운 그 원칙과 동형). has_project_access 미충족 item(존재 비노출 규율)과 달리
+        # ⭐이건 응답에서까지 조용하면 안 된다(PO 지적, 2026-08-07) — "5개 done 했는데 2개가
+        # 조용히 안 바뀌면" 사용자가 「됐겠지」 오해하는 게 #2067(조용한 경로)의 또 다른 얼굴이다.
+        # story는 그대로 `updated`에 포함(현재 상태 그대로 응답에 보이게)하되 status/다른 필드
+        # 변경은 스킵하고, 사유를 `gate_pending_by_id`에 담아 아래서 응답의 기존 `violation`
+        # 필드로 노출한다(신규 필드 아님, PO 확정 2026-08-08 — 단건 409 body와 같은 shape:
+        # code/message/decision/gate_id/requires_human).
+        gate_blocked_reason: dict | None = None
         if "status" in update_data and update_data["status"] != story.status:
             _line_owns_done_gate = False
             try:
@@ -1665,19 +1675,26 @@ async def bulk_update_stories(
                             work_type="done", actor_type=_g_actor_type, actor_id=actor_id,
                             work_item_id=story.id, work_item_title=story.title,
                         )
-                except HTTPException:
-                    continue  # 게이트 차단/park — 이 item 전체 스킵(다른 정당 item은 계속 진행).
-        # status 변경이면 전이 前 old_status 포착(violation 판정용·setattr 前).
-        if "status" in update_data and update_data["status"] != story.status:
-            old_status_by_id[story.id] = story.status
-        if "assignee_id" in update_data and update_data["assignee_id"] != story.assignee_id:
-            old_assignee_by_id[story.id] = story.assignee_id
-        for k, v in update_data.items():
-            setattr(story, k, v)
-        # E-BOARD S5: 단일 assignee_id 변경 시 join 미러(단일↔복수 공존 정합)
-        if "assignee_id" in update_data:
-            single = [story.assignee_id] if story.assignee_id else []
-            await StoryAssigneeRepository(db, repo.org_id).set_for_story(story.id, single)
+                except HTTPException as exc:
+                    gate_blocked_reason = (
+                        exc.detail if isinstance(exc.detail, dict)
+                        else {"code": "MERGE_GATE_PENDING", "message": str(exc.detail), "requires_human": True}
+                    )
+
+        if gate_blocked_reason is not None:
+            gate_pending_by_id[story.id] = gate_blocked_reason
+        else:
+            # status 변경이면 전이 前 old_status 포착(violation 판정용·setattr 前).
+            if "status" in update_data and update_data["status"] != story.status:
+                old_status_by_id[story.id] = story.status
+            if "assignee_id" in update_data and update_data["assignee_id"] != story.assignee_id:
+                old_assignee_by_id[story.id] = story.assignee_id
+            for k, v in update_data.items():
+                setattr(story, k, v)
+            # E-BOARD S5: 단일 assignee_id 변경 시 join 미러(단일↔복수 공존 정합)
+            if "assignee_id" in update_data:
+                single = [story.assignee_id] if story.assignee_id else []
+                await StoryAssigneeRepository(db, repo.org_id).set_for_story(story.id, single)
         updated.append(story)
     # P0/MissingGreenlet: setattr 후 server-onupdate `updated_at` 등은 flush 시 expire 되어,
     # model_validate(sync)가 lazy-reload 를 async greenlet 밖에서 시도 → MissingGreenlet 500.
@@ -1697,7 +1714,9 @@ async def bulk_update_stories(
         r = StoryResponse.model_validate(s)
         old = old_status_by_id.get(s.id)
         flag = build_violation_flag(old, s.status) if old is not None else None
-        r.violation = flag
+        # 게이트 차단 item은 old_status_by_id에 애초에 안 담겨(위 setattr 스킵) flag가 항상
+        # None이라 겹칠 일이 없다 — gate_pending_by_id가 있으면 그걸 violation으로 노출.
+        r.violation = gate_pending_by_id.get(s.id, flag)
         results.append(r)
         if flag is not None:
             _ev = build_violation_event(

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -1629,6 +1629,44 @@ async def bulk_update_stories(
         if not await has_project_access(db, uuid.UUID(auth.user_id), story.project_id, repo.org_id):
             continue
         update_data = item.model_dump(exclude={"id"}, exclude_none=True)
+        # story #2521(2026-08-07, 카디르 QA 적출) 근본수정 — bulk가 status를 setattr로 그대로
+        # 써 merge-gate(H1 Cage)를 아예 안 거쳤다. 단건 PATCH /{id}/status(update_story_status)
+        # 와 동일하게 line_merge_gate_active(라인 엔진이 이 전이를 이미 거버닝하면 이중평가
+        # 방지) → _preflight_merge_gate(H1 merge verdict gate) → enforce_gate(S-GATE-2 config
+        # 게이트) 순으로 지나게 한다. ⛔#2067 판정(PO 2026-08-07) 그대로 — ②emit_story_status_
+        # changed는 #2131이 이미 닫아 여기서 안 건드림(아래 emit 블록 무변경), ①게이트만 스코프.
+        #
+        # 차단 시 처리: 단건은 HTTPException(409)로 요청 전체를 거절하지만, bulk는 한 item이
+        # 막혔다고 나머지 정당한 item까지 통째로 실패시키면 안 된다(다건성 — #2173이 emit 쪽에
+        # 이미 세운 그 원칙과 동형). has_project_access 미충족 item과 동일하게 **그 item만
+        # continue로 조용히 스킵**(status뿐 아니라 그 item의 다른 필드 변경도 함께 스킵 —
+        # "게이트가 막은 전이를 일부만 우회해 다른 필드로 들여보내는" 여지를 안 남긴다).
+        if "status" in update_data and update_data["status"] != story.status:
+            _line_owns_done_gate = False
+            try:
+                from app.services.workflow_line_engine import line_merge_gate_active
+                _line_owns_done_gate = await line_merge_gate_active(
+                    db, org_id=repo.org_id, project_id=story.project_id,
+                    entity_type="story", from_status=story.status, to_status=update_data["status"],
+                )
+            except Exception:  # noqa: BLE001 — 불명 시 현행 게이트 유지(skip 안 함, 단건과 동형).
+                _line_owns_done_gate = False
+            if not _line_owns_done_gate:
+                try:
+                    await _preflight_merge_gate(db, repo.org_id, story, update_data["status"])
+                    if update_data["status"] == "done":
+                        from app.services.gate_enforce import enforce_gate
+                        _g_actor_type = (
+                            "agent" if auth.claims.get("app_metadata", {}).get("api_key_id")
+                            else "human"
+                        )
+                        await enforce_gate(
+                            db, org_id=repo.org_id, project_id=story.project_id,
+                            work_type="done", actor_type=_g_actor_type, actor_id=actor_id,
+                            work_item_id=story.id, work_item_title=story.title,
+                        )
+                except HTTPException:
+                    continue  # 게이트 차단/park — 이 item 전체 스킵(다른 정당 item은 계속 진행).
         # status 변경이면 전이 前 old_status 포착(violation 판정용·setattr 前).
         if "status" in update_data and update_data["status"] != story.status:
             old_status_by_id[story.id] = story.status

--- a/backend/tests/test_2521_bulk_merge_gate.py
+++ b/backend/tests/test_2521_bulk_merge_gate.py
@@ -70,19 +70,26 @@ def _common_patches():
 
 @pytest.mark.anyio
 async def test_bulk_status_done_blocked_by_preflight_merge_gate_item_skipped():
-    """⭐본체 — _preflight_merge_gate가 차단(HTTPException)하면 그 item은 조용히 스킵되고
-    (setattr 미적용·결과 리스트에 없음) 나머지 요청은 안 죽는다(다건성, #2173과 동형 원칙)."""
+    """⭐본체(PO 확정 2026-08-08, 카디르 QA③) — _preflight_merge_gate가 차단(HTTPException)하면
+    그 item은 status 변경만 스킵(setattr 미적용)되고, 결과 리스트에는 «그대로 남아»
+    StoryResponse.violation에 차단 사유가 표기된다. 예전 「결과에서 통째로 사라짐」(result==[])은
+    #2067과 동형인 조용한 실패였다 — 이제는 사용자가 응답만 보고도 "이 item은 승인 필요라
+    안 바뀌었다"를 알 수 있어야 한다."""
     story = _story(status="in-review")
     db = _mock_db(story)
     repo = MagicMock()
     repo.org_id = story.org_id
 
+    gate_detail = {
+        "code": "MERGE_GATE_PENDING", "message": "human approval required",
+        "decision": "ASK_HUMAN", "gate_id": str(uuid.uuid4()), "requires_human": True,
+    }
     patches = _common_patches()
     with (
         patches[0], patches[1], patches[2], patches[3], patches[4],
         patch.object(
             stories_mod, "_preflight_merge_gate",
-            AsyncMock(side_effect=HTTPException(status_code=409, detail="blocked")),
+            AsyncMock(side_effect=HTTPException(status_code=409, detail=gate_detail)),
         ) as preflight_spy,
         patch("app.services.gate_enforce.enforce_gate", AsyncMock()) as enforce_spy,
     ):
@@ -95,7 +102,9 @@ async def test_bulk_status_done_blocked_by_preflight_merge_gate_item_skipped():
 
     preflight_spy.assert_awaited_once()
     enforce_spy.assert_not_awaited()  # 차단됐으니 그 뒤 enforce_gate까지 안 감.
-    assert result == [], "게이트가 차단했는데 status가 그대로 적용/반환됨 — #2521 미수복"
+    assert len(result) == 1, "차단된 item이 응답에서 통째로 사라짐 — #2067과 동형인 조용한 실패"
+    assert result[0].status == "in-review", "차단된 item의 status가 바뀌어 응답에 나가면 승인 우회"
+    assert result[0].violation == gate_detail, "차단 사유가 violation에 표기되지 않음 — #2067 재현"
     assert story.status == "in-review", "차단된 item의 story.status가 setattr로 바뀌면 안 됨"
 
 
@@ -131,7 +140,9 @@ async def test_bulk_status_done_passes_preflight_then_calls_enforce_gate():
 @pytest.mark.anyio
 async def test_bulk_status_done_blocked_by_enforce_gate_item_skipped():
     """⭐본체 — _preflight_merge_gate는 통과했는데 enforce_gate(S-GATE-2)가 차단하면 그
-    item도 동일하게 스킵된다(둘 다 게이트 축이라 어느 쪽이 막든 같은 결과여야 함)."""
+    item도 동일하게(결과에 남고 violation 표기) 처리된다 — 어느 쪽 게이트가 막든 응답
+    계약은 같아야 한다. detail이 str(비-dict)이면 라우터가 code/message/requires_human
+    dict로 정규화하는 것까지 함께 확認."""
     story = _story(status="in-review")
     db = _mock_db(story)
     repo = MagicMock()
@@ -153,7 +164,11 @@ async def test_bulk_status_done_blocked_by_enforce_gate_item_skipped():
             ),
         )
 
-    assert result == []
+    assert len(result) == 1
+    assert result[0].status == "in-review"
+    assert result[0].violation == {
+        "code": "MERGE_GATE_PENDING", "message": "parked", "requires_human": True,
+    }
     assert story.status == "in-review"
 
 

--- a/backend/tests/test_2521_bulk_merge_gate.py
+++ b/backend/tests/test_2521_bulk_merge_gate.py
@@ -1,0 +1,195 @@
+"""#2521(카디르 QA 적출, PR#2905/#2906 파생): bulk_update_stories가 status 전이 時 merge-gate
+(_preflight_merge_gate·enforce_gate)를 아예 안 거치고 setattr로 그대로 쓰던 결함.
+
+근본: PATCH /{id}/status(update_story_status)는 게이트를 거치는데 PATCH /bulk(칸반 드래그·
+컬럼메뉴가 실제로 타는 그 경로)는 안 거쳐 사람 승인을 우회할 수 있었다(#2156 advisory→
+enforcing flip이 실효를 가지려면 이 우회로부터 먼저 닫혀야 함).
+
+②emit_story_status_changed는 #2131이 이미 닫아서 스코프 밖(#2067 판정 그대로, PO 확認) —
+이 테스트는 ①게이트 축만 검증한다. `_preflight_merge_gate`/`enforce_gate` 자신의 내부
+정확성은 test_h1_s5_board_gate.py가 이미 고정하므로, 여기선 "bulk가 그 둘을 실제로
+부르고 그 판정(차단/park)을 존중하는가"만 스파이로 확認한다(#2131의 emit 테스트와 동형
+분리 — 각 계층은 자기 계약만 잰다)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.routers import stories as stories_mod
+from app.routers.stories import BulkUpdateRequest, bulk_update_stories
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _story(status="in-review", **overrides):
+    now = datetime(2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc)
+    base = dict(
+        id=uuid.uuid4(), project_id=uuid.uuid4(), org_id=uuid.uuid4(), epic_id=None,
+        sprint_id=None, assignee_id=None, assignee_ids=[], attachments=[], meeting_id=None,
+        title="t", status=status, priority="medium", story_points=None, description=None,
+        acceptance_criteria=None, position=None, success_hypothesis=None, metric_definition=None,
+        measure_after=None, outcome_status="n_a", outcome_result=None, is_excluded=False,
+        created_at=now, updated_at=now,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _mock_db(story):
+    async def _execute(stmt, *a, **kw):
+        m = MagicMock()
+        m.scalar_one_or_none = MagicMock(return_value=story)
+        return m
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=_execute)
+    db.flush = AsyncMock()
+    db.refresh = AsyncMock()
+    db.commit = AsyncMock()
+    db.add = MagicMock()
+    return db
+
+
+def _common_patches():
+    """bulk_update_stories 본문이 거치는 project-scope/actor 해소 등 무관 의존성 공용 스텁."""
+    return (
+        patch.object(stories_mod, "_attach_assignee_ids", AsyncMock()),
+        patch.object(stories_mod, "_attach_has_evidence", AsyncMock()),
+        patch.object(stories_mod, "_resolve_team_member_id", AsyncMock(return_value=None)),
+        patch("app.services.project_auth.has_project_access", AsyncMock(return_value=True)),
+        patch("app.services.workflow_line_engine.line_merge_gate_active", AsyncMock(return_value=False)),
+    )
+
+
+@pytest.mark.anyio
+async def test_bulk_status_done_blocked_by_preflight_merge_gate_item_skipped():
+    """⭐본체 — _preflight_merge_gate가 차단(HTTPException)하면 그 item은 조용히 스킵되고
+    (setattr 미적용·결과 리스트에 없음) 나머지 요청은 안 죽는다(다건성, #2173과 동형 원칙)."""
+    story = _story(status="in-review")
+    db = _mock_db(story)
+    repo = MagicMock()
+    repo.org_id = story.org_id
+
+    patches = _common_patches()
+    with (
+        patches[0], patches[1], patches[2], patches[3], patches[4],
+        patch.object(
+            stories_mod, "_preflight_merge_gate",
+            AsyncMock(side_effect=HTTPException(status_code=409, detail="blocked")),
+        ) as preflight_spy,
+        patch("app.services.gate_enforce.enforce_gate", AsyncMock()) as enforce_spy,
+    ):
+        payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": "done"}])
+        result = await bulk_update_stories(
+            payload, MagicMock(), db, repo, auth=MagicMock(
+                user_id=str(uuid.uuid4()), claims={"app_metadata": {}},
+            ),
+        )
+
+    preflight_spy.assert_awaited_once()
+    enforce_spy.assert_not_awaited()  # 차단됐으니 그 뒤 enforce_gate까지 안 감.
+    assert result == [], "게이트가 차단했는데 status가 그대로 적용/반환됨 — #2521 미수복"
+    assert story.status == "in-review", "차단된 item의 story.status가 setattr로 바뀌면 안 됨"
+
+
+@pytest.mark.anyio
+async def test_bulk_status_done_passes_preflight_then_calls_enforce_gate():
+    """⭐본체 — _preflight_merge_gate가 통과(AUTO_MERGE 등, 예외 無)하면 enforce_gate까지
+    호출되고, 그것도 통과하면 status가 정상 적용된다."""
+    story = _story(status="in-review")
+    db = _mock_db(story)
+    repo = MagicMock()
+    repo.org_id = story.org_id
+
+    patches = _common_patches()
+    with (
+        patches[0], patches[1], patches[2], patches[3], patches[4],
+        patch.object(stories_mod, "_preflight_merge_gate", AsyncMock(return_value=None)) as preflight_spy,
+        patch("app.services.gate_enforce.enforce_gate", AsyncMock(return_value=None)) as enforce_spy,
+        patch.object(stories_mod, "emit_story_status_changed", AsyncMock()),
+    ):
+        payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": "done"}])
+        result = await bulk_update_stories(
+            payload, MagicMock(), db, repo, auth=MagicMock(
+                user_id=str(uuid.uuid4()), claims={"app_metadata": {}},
+            ),
+        )
+
+    preflight_spy.assert_awaited_once()
+    enforce_spy.assert_awaited_once()
+    assert len(result) == 1 and result[0].status == "done"
+    assert story.status == "done"
+
+
+@pytest.mark.anyio
+async def test_bulk_status_done_blocked_by_enforce_gate_item_skipped():
+    """⭐본체 — _preflight_merge_gate는 통과했는데 enforce_gate(S-GATE-2)가 차단하면 그
+    item도 동일하게 스킵된다(둘 다 게이트 축이라 어느 쪽이 막든 같은 결과여야 함)."""
+    story = _story(status="in-review")
+    db = _mock_db(story)
+    repo = MagicMock()
+    repo.org_id = story.org_id
+
+    patches = _common_patches()
+    with (
+        patches[0], patches[1], patches[2], patches[3], patches[4],
+        patch.object(stories_mod, "_preflight_merge_gate", AsyncMock(return_value=None)),
+        patch(
+            "app.services.gate_enforce.enforce_gate",
+            AsyncMock(side_effect=HTTPException(status_code=409, detail="parked")),
+        ),
+    ):
+        payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": "done"}])
+        result = await bulk_update_stories(
+            payload, MagicMock(), db, repo, auth=MagicMock(
+                user_id=str(uuid.uuid4()), claims={"app_metadata": {}},
+            ),
+        )
+
+    assert result == []
+    assert story.status == "in-review"
+
+
+@pytest.mark.anyio
+async def test_bulk_non_done_status_transition_skips_gate_calls():
+    """회귀 0 — done이 아닌 전이(예: todo→in-progress)는 게이트 자체를 안 부른다
+    (_preflight_merge_gate 자신도 new_status!="done"이면 즉시 no-op이지만, bulk가 아예
+    호출을 스킵하는지까지 — 무해한 호출 낭비 자체는 회귀는 아니나 의도를 명시)."""
+    story = _story(status="todo")
+    db = _mock_db(story)
+    repo = MagicMock()
+    repo.org_id = story.org_id
+
+    patches = _common_patches()
+    with (
+        patches[0], patches[1], patches[2], patches[3], patches[4],
+        patch.object(stories_mod, "_preflight_merge_gate", AsyncMock(return_value=None)) as preflight_spy,
+        patch("app.services.gate_enforce.enforce_gate", AsyncMock()) as enforce_spy,
+        patch.object(stories_mod, "emit_story_status_changed", AsyncMock()),
+    ):
+        payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": "in-progress"}])
+        result = await bulk_update_stories(
+            payload, MagicMock(), db, repo, auth=MagicMock(
+                user_id=str(uuid.uuid4()), claims={"app_metadata": {}},
+            ),
+        )
+
+    assert len(result) == 1 and result[0].status == "in-progress"
+    enforce_spy.assert_not_awaited()  # done 아니므로 enforce_gate 자체는 안 부름.
+
+
+def test_bulk_calls_shared_preflight_merge_gate_and_enforce_gate_source():
+    """소스 검사 — bulk가 _preflight_merge_gate/enforce_gate를 update_story_status와 동일
+    이름으로 실제 호출하는지(발행/게이트 지점을 갈라놓지 않았는지) 회귀 고정."""
+    import inspect
+
+    source = inspect.getsource(stories_mod.bulk_update_stories)
+    assert "await _preflight_merge_gate(" in source
+    assert "await enforce_gate(" in source


### PR DESCRIPTION
## 배경
#2521(카디르 QA 적출, PR#2905/#2906 리뷰 파생) — `bulk_update_stories`(칸반 드래그·컬럼메뉴가 실제로 타는 `PATCH /stories/bulk`)가 status를 `setattr`로 그대로 써 merge-gate(H1 Cage)를 전혀 거치지 않았다. `PATCH /{id}/status`(update_story_status)는 이미 게이트를 거치는데 bulk만 안 거쳐 **사람 승인을 우회**할 수 있는 보안 갭 — #2156의 advisory→enforcing flip이 실효를 가지려면 이 우회부터 닫혀야 한다.

②`emit_story_status_changed`(보드/알림/웹훅)는 #2131이 이미 닫아서 이 PR 스코프 밖(#2067/PO 판정 2026-08-07로 재확認됨) — 이 PR은 ①게이트 축만.

## 처방
단건 `/status`와 동일 순서를 per-item으로 반복: `line_merge_gate_active`(라인 엔진 이중평가 방지 스킵판정) → `_preflight_merge_gate`(H1 merge verdict gate) → `enforce_gate`(S-GATE-2 config 게이트).

차단 시: 단건은 요청 전체를 409로 거절하지만, bulk는 한 item이 막혔다고 나머지 정당한 item까지 실패시키면 안 된다(다건성 — #2173이 emit 쪽에 이미 세운 원칙과 동형). `has_project_access` 미충족 item과 동일하게 **그 item만 조용히 스킵**(status뿐 아니라 그 item의 다른 필드 변경도 함께 스킵 — 게이트가 막은 전이를 일부 필드로 우회해 들여보내는 여지를 안 남김).

## 검증
mock 5건 — 차단 시 스킵+story 상태 무변경 · 통과 시 정상 적용(enforce_gate까지 호출 확認) · enforce_gate 자체가 막는 축도 동일 스킵 · done이 아닌 전이는 게이트 미호출 · 소스검사(발행 지점 안 갈림). 5/5 pass.

양성대조(게이트 체크 블록 자체를 비활성화 → 관련 3개 테스트 정확히 fail 확認 → 복원 → pass) 완료.

인접 회귀 — #2131(emit) · h1_s5(게이트 단위) · cross-org IDOR bulk(alembic-migrated 디스포저블 PG로 재확認, create_all 아님) 무회귀.

## Test plan
- [x] mock 5/5 pass
- [x] 양성대조 완료
- [x] 인접 회귀 없음(alembic-migrated DB로 확認)