### PR TITLE
[SID:2522] EmbedCard status 뱃지 원시값 노출 fix — 엔티티별 번역 맵으로

### DIFF
--- a/apps/web/src/components/chat/chat-input.test.tsx
+++ b/apps/web/src/components/chat/chat-input.test.tsx
@@ -210,4 +210,33 @@ describe('ChatInput — `#` 엔티티 피커 종류별 그룹화(story #2263 ㉠
     expect(text).toContain('sprint');
     expect(text).toContain('스프린트 하나');
   });
+
+  // story #2522 — EmbedCard와 같은 클래스의 같은 gap(close-the-class, PO 지시 2026-08-08):
+  // `#` 피커도 entity.status 원시값을 그대로 노출하고 있었다.
+  it('후보 status가 번역된 말로 뜬다(원시값 in-review 노출 금지)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/entities/search')) {
+        return new Response(JSON.stringify({
+          data: [{ entity_type: 'story', entity_id: 's1', title: '스토리 하나', status: 'in-review' }],
+        }));
+      }
+      return new Response(JSON.stringify({ data: [] }));
+    }));
+
+    await act(async () => {
+      root.render(withIntl(<ChatInput threadId="c1" projectId="p1" onSend={vi.fn()} />));
+    });
+    const el = textarea();
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(el, '#');
+      el.selectionStart = 1;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => { await new Promise((r) => setTimeout(r, 260)); });
+
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox!.textContent).toContain('검토 중');
+    expect(listbox!.textContent).not.toContain('in-review');
+  });
 });

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -19,6 +19,7 @@ import type { SendAttachment } from '@/hooks/use-chat-sse';
 import type { Asset } from '@/lib/storage/types';
 import { imageFilesFromClipboard } from '@/lib/clipboard-image';
 import { ENTITY_ICONS } from './embed-card';
+import { translateEntityStatus } from './entity-status-labels';
 import { AssetPickerPopover } from './asset-picker-popover';
 import {
   applyEntity, entityTypeLabel, escapeMarkdownLinkText, getEntityQuery, groupEntitiesByType, type EntityResult,
@@ -572,6 +573,9 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
             {entityPicker.entityResults.map((entity, idx) => {
               const EntityIcon = ENTITY_ICONS[entity.entity_type] ?? Hash;
               const isNewGroup = idx === 0 || entityPicker.entityResults[idx - 1]!.entity_type !== entity.entity_type;
+              // story #2522 — 원시값(in-review 등) 노출 금지, EmbedCard와 같은 클래스의 같은
+              // fix(# 피커도 같은 처방이 통한다·close-the-class).
+              const statusLabel = entity.status ? translateEntityStatus(entity.entity_type, entity.status) : null;
               return (
               <li key={`${entity.entity_type}:${entity.entity_id}`}>
                 {isNewGroup && (
@@ -590,8 +594,8 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
                   {/* ㉠: 종류는 위 머리글의 «글자»가 1차 신호 — 이 아이콘은 어디까지나 보조. */}
                   <EntityIcon className="mr-1.5 size-3.5 shrink-0" aria-hidden />
                   <span className="font-medium">{entity.title}</span>
-                  {entity.status ? (
-                    <span className="ml-2 rounded px-1.5 py-0.5 text-xs bg-muted text-muted-foreground">{entity.status}</span>
+                  {statusLabel ? (
+                    <span className="ml-2 rounded px-1.5 py-0.5 text-xs bg-muted text-muted-foreground">{statusLabel}</span>
                   ) : null}
                 </button>
               </li>

--- a/apps/web/src/components/chat/embed-card.link-states.test.tsx
+++ b/apps/web/src/components/chat/embed-card.link-states.test.tsx
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { EmbedCard, getEntityHref } from './embed-card';
+import { translateEntityStatus } from './entity-status-labels';
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
@@ -178,31 +179,36 @@ describe('story #2262 AC2(2026-08-08, 쉬운 절반) — 모달이 자기 fetch�
   // entity_type="task"를 쓴다 — EntityDetail이 story/epic에는 자기 status 뱃지(MdBadge)를
   // 이미 body에 그리지만 task엔 그 분기가 없어(embed-card.tsx EntityDetail), 헤더 배선만
   // 값으로 깨끗하게 격리해 잰다.
-  it('status prop이 null(EntityChip 호출부처럼 status를 모름)이어도 fetch한 detail.status를 헤더 뱃지로 보인다', async () => {
+  // story #2522 — resolvedStatus는 이제 translateEntityStatus를 반드시 거친다(원시값 노출
+  // 금지). 그래서 아래 두 테스트는 원시값 문자열이 아니라 「번역된」 사람 말을 검증한다.
+  it('status prop이 null(EntityChip 호출부처럼 status를 모름)이어도 fetch한 detail.status를 번역해 헤더 뱃지로 보인다', async () => {
     stubFetch(async (url) => {
       expect(url).toContain('/api/tasks/');
-      return { ok: true, json: async () => ({ data: { status: 'in-review', story_id: 's-parent' } }) };
+      return { ok: true, json: async () => ({ data: { status: 'in-progress', story_id: 's-parent' } }) };
     });
     await act(async () => {
       root.render(<EmbedCard entity_type="task" entity_id="t1" title="작업 A" status={null} />);
     });
     await openCard();
     await flush();
-    expect(document.body.textContent).toContain('in-review');
+    expect(document.body.textContent).toContain('진행 중');
+    expect(document.body.textContent).not.toContain('in-progress');
   });
 
-  it('status prop이 이미 실려 있으면(EmbedCard 자신의 write-response 경로) 그 값을 헤더가 우선한다', async () => {
+  it('status prop이 이미 실려 있으면(EmbedCard 자신의 write-response 경로) 그 값을 번역해 헤더가 우선한다', async () => {
     stubFetch(async () => ({ ok: true, json: async () => ({ data: { status: 'done', story_id: 's-parent' } }) }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="task" entity_id="t1" title="작업 A" status="ready-for-dev" />);
+      root.render(<EmbedCard entity_type="task" entity_id="t1" title="작업 A" status="todo" />);
     });
     await openCard();
     await flush();
-    // 헤더는 카드 자체에도 뜨고(inner) 모달에도 뜬다 — 둘 다 prop 값이어야 하고, fetch가 준
-    // "done"은 헤더 어디에도 안 나타나야 한다(task는 EntityDetail 자기 status 표시가 없다).
-    const readyForDevCount = (document.body.textContent!.match(/ready-for-dev/g) ?? []).length;
-    expect(readyForDevCount).toBeGreaterThanOrEqual(2);
-    expect(document.body.textContent).not.toContain('done');
+    // 헤더는 카드 자체에도 뜨고(inner) 모달에도 뜬다 — 둘 다 prop 값(todo→"할 일")이어야
+    // 하고, fetch가 준 "done"(→"완료")은 헤더 어디에도 안 나타나야 한다(task는 EntityDetail
+    // 자기 status 표시가 없다).
+    const label = translateEntityStatus('task', 'todo')!;
+    const labelCount = (document.body.textContent!.match(new RegExp(label, 'g')) ?? []).length;
+    expect(labelCount).toBeGreaterThanOrEqual(2);
+    expect(document.body.textContent).not.toContain(translateEntityStatus('task', 'done'));
   });
 
   it('fetch가 실패해도(대상 없음) status 뱃지를 지어내지 않는다 — 모르는 것을 단정하지 않는다', async () => {
@@ -213,5 +219,44 @@ describe('story #2262 AC2(2026-08-08, 쉬운 절반) — 모달이 자기 fetch�
     await openCard();
     await flush();
     expect(document.body.textContent).toContain('대상이 없습니다');
+  });
+});
+
+// story #2522 — EntityDetail(모달 본문)의 story/epic 자기 status 뱃지도 「클래스 전체」에
+// 포함된다(위 describe는 task 헤더 배선만 격리해 쟀다 — task는 EntityDetail 자기 status
+// 뱃지 분기가 아예 없다). 여기서 story·epic 본문 뱃지를 직접 잰다.
+describe('story #2522 — EntityDetail(모달 본문) story·epic 자기 status 뱃지도 원시값 노출 금지', () => {
+  it('story 본문 status 뱃지가 번역된 말로 뜬다(원시값 in-review 안 남음)', async () => {
+    stubFetch(async () => ({ ok: true, json: async () => ({ data: { status: 'in-review', description: '설명' } }) }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="story" entity_id="s1" title="스토리 A" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(document.body.textContent).toContain('검토 중');
+    expect(document.body.textContent).not.toContain('in-review');
+  });
+
+  it('epic 본문 status 뱃지가 번역된 말로 뜬다(원시값 active 자체는 겹치므로 archived로 격리해 확認)', async () => {
+    stubFetch(async () => ({ ok: true, json: async () => ({ data: { status: 'archived', objective: '목표' } }) }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="epic" entity_id="e1" title="에픽 A" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(document.body.textContent).toContain('보관');
+    expect(document.body.textContent).not.toContain('archived');
+  });
+
+  // AC — 「미매핑 status는 빈칸(지어내지 않음)」. 맵에 없는 신규 status가 서빙돼도 원시값이
+  // 새지 않는다는 fail-safe 계약을 값으로 고정한다.
+  it('맵에 없는(미매핑) status는 원시값도 새 라벨도 안 뜬다 — 빈칸', async () => {
+    stubFetch(async () => ({ ok: true, json: async () => ({ data: { status: 'some-brand-new-status', description: '설명' } }) }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="story" entity_id="s2" title="스토리 B" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(document.body.textContent).not.toContain('some-brand-new-status');
   });
 });

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -12,7 +12,7 @@ import {
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { docViewUrl } from '@/components/docs/lib/doc-project-url';
 import { initials } from '@/lib/storage/format';
-import { renderEntityStatusLabel, type EntityStatusFetchState } from './entity-status-labels';
+import { renderEntityStatusLabel, translateEntityStatus, type EntityStatusFetchState } from './entity-status-labels';
 
 // story #2302 — 이 8종은 BE reference_registry.py ENTITY_RESOLVERS 와 키 집합이 같아야 한다
 // (AC2·AC5, entity-icons.registry-parity.test.ts 가 코드스캔으로 대조). `asset`은 registry
@@ -164,10 +164,11 @@ const MdBody = ({ content }: { content: string }) => (
 function EntityDetail({ entityType, detail }: { entityType: string; detail: Record<string, unknown> }) {
   if (entityType === 'story') {
     const d = detail as { status?: string; priority?: string; story_points?: number; description?: string; acceptance_criteria?: string };
+    const statusLabel = d.status ? translateEntityStatus('story', d.status) : null;
     return (
       <div className="space-y-3">
         <div className="flex flex-wrap gap-1.5">
-          {d.status && <MdBadge label={d.status} />}
+          {statusLabel && <MdBadge label={statusLabel} />}
           {d.priority && <MdBadge label={d.priority} />}
           {d.story_points != null && <MdBadge label={`${d.story_points} SP`} />}
         </div>
@@ -184,10 +185,11 @@ function EntityDetail({ entityType, detail }: { entityType: string; detail: Reco
 
   if (entityType === 'epic') {
     const d = detail as { status?: string; priority?: string; objective?: string; description?: string; target_date?: string; story_points_target?: number };
+    const statusLabel = d.status ? translateEntityStatus('epic', d.status) : null;
     return (
       <div className="space-y-3">
         <div className="flex flex-wrap gap-1.5">
-          {d.status && <MdBadge label={d.status} />}
+          {statusLabel && <MdBadge label={statusLabel} />}
           {d.priority && <MdBadge label={d.priority} />}
           {d.story_points_target != null && <MdBadge label={`목표 ${d.story_points_target} SP`} />}
           {d.target_date && <MdBadge label={d.target_date} />}
@@ -300,6 +302,10 @@ function EntityPreviewModal({
   // 값이 있으면) 그걸 우선한다. 칩 자체(모달 열기 前)에 상태를 보이는 건 별건(PR②,
   // 타입별 배치조회 인프라 필요 — references 사이드밴드엔 status가 없다).
   const resolvedStatus = status ?? (typeof (detail as { status?: unknown } | null)?.status === 'string' ? (detail as { status: string }).status : null);
+  // story #2522 — 원시값(raw status enum, 예: "in-review")을 그대로 뱃지에 노출하던 기존
+  // gap(#2903 design review 발견). translateEntityStatus로 반드시 통과시킨다 — 맵에 없으면
+  // (미매핑 status) null이 나와 뱃지 자체를 안 그린다(원시값 폴백 절대 금지, 빈칸이 정답).
+  const resolvedStatusLabel = resolvedStatus ? translateEntityStatus(entityType, resolvedStatus) : null;
 
   // story #2302 AC3 — ①own-href(정적) / ②via-parent(레코드 fetch 필요) / ③없음, 세 갈래를
   // "카드 전체를 죽이지 않는다"(AC4) 원칙대로 여기서만 계산 — 헤더의 아이콘·제목·상태는 이 값과
@@ -360,8 +366,8 @@ function EntityPreviewModal({
           <div className={`flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm ${colorClass} flex-1 min-w-0`}>
             <EntityGlyph Icon={resolveEntityIcon(entityType)} label={label} />
             <DialogTitle className="font-semibold truncate text-sm">{label}</DialogTitle>
-            {resolvedStatus ? (
-              <span className="ml-auto shrink-0 rounded px-1.5 py-0.5 text-xs bg-black/10 dark:bg-white/10">{resolvedStatus}</span>
+            {resolvedStatusLabel ? (
+              <span className="ml-auto shrink-0 rounded px-1.5 py-0.5 text-xs bg-black/10 dark:bg-white/10">{resolvedStatusLabel}</span>
             ) : null}
           </div>
           <button
@@ -420,6 +426,9 @@ export function EmbedCard({ entity_type, entity_id, title, status }: EmbedCardDa
   const colorClass = ENTITY_COLORS[entity_type] ?? GRAY_STATE_COLOR;
   const href = getEntityHref(entity_type, entity_id);
   const label = title ?? entity_id;
+  // story #2522 — EmbedCard 자신의 인라인 카드(모달과 별개 렌더 경로)도 원시값을 그대로
+  // 노출하던 같은 클래스의 gap. translateEntityStatus로 통과시킨다(미매핑=null=뱃지 안 그림).
+  const statusLabel = status ? translateEntityStatus(entity_type, status) : null;
 
   const handleDocClick = useCallback(async () => {
     setNavigating(true);
@@ -451,8 +460,8 @@ export function EmbedCard({ entity_type, entity_id, title, status }: EmbedCardDa
     <div className={`flex items-center gap-2 rounded-md border px-3 py-2 text-sm ${colorClass}`}>
       <EntityGlyph Icon={resolveEntityIcon(entity_type)} label={label} />
       <span className="font-medium">{label}</span>
-      {status ? (
-        <span className="ml-auto rounded px-1.5 py-0.5 text-xs bg-black/10 dark:bg-white/10">{status}</span>
+      {statusLabel ? (
+        <span className="ml-auto rounded px-1.5 py-0.5 text-xs bg-black/10 dark:bg-white/10">{statusLabel}</span>
       ) : null}
       {navigating && <span className="ml-auto h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />}
     </div>
@@ -473,8 +482,8 @@ export function EmbedCard({ entity_type, entity_id, title, status }: EmbedCardDa
           >
             <EntityGlyph Icon={resolveEntityIcon(entity_type)} label={label} />
             <span className="min-w-0 flex-1 truncate font-medium">{label}</span>
-            {status ? (
-              <span className="shrink-0 rounded px-1.5 py-0.5 text-xs bg-black/10 dark:bg-white/10">{status}</span>
+            {statusLabel ? (
+              <span className="shrink-0 rounded px-1.5 py-0.5 text-xs bg-black/10 dark:bg-white/10">{statusLabel}</span>
             ) : null}
             {navigating && <span className="h-3 w-3 shrink-0 animate-spin rounded-full border-2 border-current border-t-transparent" />}
           </button>

--- a/apps/web/src/components/chat/entity-status-labels.test.ts
+++ b/apps/web/src/components/chat/entity-status-labels.test.ts
@@ -31,7 +31,17 @@ describe('translateEntityStatus — 원시값 노출 금지(gate_type 사고 재
   // (파일 상단 주석 참고) — hypothesis는 칩 렌더에선 no-status-concept("상태 없음")이지만,
   // 어휘 맵 자체는 있어서 rawStatus가 (미래의 다른 경로로) 주어지면 이 함수는 정상 번역한다.
   it('hypothesis는 칩 렌더 관점에선 no-status-concept이지만 어휘 맵 번역 자체는 독립적으로 동작한다', () => {
-    expect(translateEntityStatus('hypothesis', 'falsified')).toBe('반증됨');
+    expect(translateEntityStatus('hypothesis', 'falsified')).toBe('반증');
+  });
+
+  // story #2522 — hypothesis.active와 sprint/epic.active는 원시값(raw)은 같지만 다른 말이다
+  // (유나양 스펙 명시 지점). 이 구분이 실수로 뭉개지면(예: hypothesis도 "진행 중"으로 번역)
+  // "가설이 진행 중"이라는 모호한 문구가 뜬다 — 「검증」이 본질이라는 것을 잃는다.
+  it('hypothesis.active="검증 중"·epic/sprint.active="진행 중" — 같은 원시값, 엔티티별로 다른 말', () => {
+    expect(translateEntityStatus('hypothesis', 'active')).toBe('검증 중');
+    expect(translateEntityStatus('epic', 'active')).toBe('진행 중');
+    expect(translateEntityStatus('sprint', 'active')).toBe('진행 중');
+    expect(translateEntityStatus('hypothesis', 'active')).not.toBe(translateEntityStatus('epic', 'active'));
   });
 
   it('매핑에 없는 값(신규 status 추가 등)은 원시값을 그대로 내지 않고 null이다', () => {

--- a/apps/web/src/components/chat/entity-status-labels.ts
+++ b/apps/web/src/components/chat/entity-status-labels.ts
@@ -24,18 +24,24 @@ const PR2_V1_FETCHABLE_TYPES: ReadonlySet<string> = new Set(['story', 'task', 'd
 /** ⛔맵에 없는 값이 오면(신규 status 추가 등) 칸을 비운다 — 원시값을 그대로 노출하지 않는다
  * (gate_type 사고 재발 방지, #2156 requires_human/gate_type 교훈 재사용). "terminal" 개념이
  * 이 제품에 없다는 판정(파울로, 2026-07-30)이 이미 서 있어 done류 라벨에 시각 차등(흐리게·
- * 취소선)을 안 준다 — 번역은 문구만 바꾸고 무게는 그대로다. */
+ * 취소선)을 안 준다 — 번역은 문구만 바꾸고 무게는 그대로다.
+ *
+ * story #2522(유나양 DS 어휘 규격, doc ds-entity-status-label-map-2522, 2026-08-07) 그대로 —
+ * 이 스토리 이전 값과 몇 군데 다르다(예: story.backlog은 "백로그"가 아니라 "대기", hypothesis
+ * 는 명사 어미 "됨"을 전부 뗀다). ⛔hypothesis.active="검증 중"은 sprint/epic.active="진행 중"과
+ * **원시값(active)은 같지만 다른 말**이 되도록 스펙이 명시한 지점 — hypothesis는 「검증」이
+ * 본질이라 "진행 중"으로 뭉개면 모호해진다(엔티티별 맵이라 이 구분이 가능하다). */
 const STATUS_LABELS: Record<StatusBearingEntityType, Record<string, string>> = {
   story: {
-    done: '완료', backlog: '백로그', 'in-review': '검토 중', 'in-progress': '진행 중', 'ready-for-dev': '착수 대기',
+    backlog: '대기', 'ready-for-dev': '착수 대기', 'in-progress': '진행 중', 'in-review': '검토 중', done: '완료',
   },
-  task: { todo: '할 일', done: '완료', 'in-progress': '진행 중' },
-  doc: { draft: '초안', confirmed: '확定', pending: '검토 대기' },
+  task: { todo: '할 일', 'in-progress': '진행 중', done: '완료' },
+  doc: { draft: '초안', pending: '검토 중', confirmed: '확定' },
   hypothesis: {
-    proposed: '제안됨', archived: '보관됨', active: '진행 중', measuring: '측정 중', falsified: '반증됨', verified: '검증됨',
+    proposed: '제안', active: '검증 중', measuring: '측정 중', verified: '입증', falsified: '반증', archived: '보관',
   },
-  sprint: { closed: '종료', active: '진행 중', planning: '계획 중' },
-  epic: { archived: '보관됨', done: '완료', active: '진행 중' },
+  sprint: { planning: '계획', active: '진행 중', closed: '종료' },
+  epic: { active: '진행 중', done: '완료', archived: '보관' },
 };
 
 /** 「지금 상태」를 **PR② v1이 실제로 채울 수 있는** 타입인가(구조적 판정, AC2/AC7의

--- a/apps/web/src/components/chat/thread-panel.test.tsx
+++ b/apps/web/src/components/chat/thread-panel.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+//
+// story #2262 PR②(2026-08-08, 카디르 QA 지적·PR#2911에 곁들임) — ThreadPanel이 자기
+// (스레드 답글) messages를 useEntityStatusBatchFetch에 실제로 넘기는지 아무 테스트도
+// 안 잡고 있었다. use-entity-status-batch.test.tsx는 훅 자체(순수 harness)만 검증해
+// ThreadPanel 컴포넌트가 그 훅을 «제대로 배선했는지»는 뮤테이션으로 배선을 끊어도
+// 아무 테스트도 안 걸렸다 — 라이브 코드는 정확했지만 미래 리팩터로 이 배선이 끊기면
+// "스레드 고착 스피너"(#2262 PR② 본체가 고친 바로 그 결함)가 조용히 재발해도 CI가
+//못 잡는 사각이었다. 이 테스트는 ThreadPanel을 실제로 마운트해 그 배선을 왕복 검증한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, useRef, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { ThreadPanel } from './thread-panel';
+import type { ChatMessage } from '@/hooks/use-chat-sse';
+import type { EntityStatusFetchState } from './entity-status-labels';
+import koMessages from '../../../messages/ko.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => ({ projectId: 'proj-1', currentTeamMemberId: 'member-1' }),
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+const TASK_ID = '33333333-3333-3333-3333-333333333333';
+
+const parentMessage: ChatMessage = {
+  id: 'parent-1',
+  memo_id: 'conv-1',
+  created_by: 'agent-1',
+  sender_name: '오르테가',
+  sender_type: 'agent',
+  content: '원본 메시지',
+  attachments: [],
+  created_at: '2026-08-08T00:00:00.000Z',
+};
+
+// ThreadPanel의 own state(requestedEntityStatusKeysRef·setEntityStatusByKey)를 실제로
+// 소유하는 하니스 — chat-view.tsx의 역할을 흉내낸다(props로 내려주는 쪽).
+function Harness() {
+  const [entityStatusByKey, setEntityStatusByKey] = useState<Record<string, EntityStatusFetchState>>({});
+  const requestedKeysRef = useRef<Set<string>>(new Set());
+  return (
+    <ThreadPanel
+      parentMessage={parentMessage}
+      conversationId="conv-1"
+      currentTeamMemberId="member-1"
+      projectId="proj-1"
+      onClose={() => {}}
+      entityStatusByKey={entityStatusByKey}
+      requestedEntityStatusKeysRef={requestedKeysRef}
+      setEntityStatusByKey={setEntityStatusByKey}
+    />
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  // jsdom엔 scrollIntoView 구현이 없다 — ThreadPanel의 "로드 후 바닥 스크롤" 이펙트가
+  // 이 테스트의 관심사가 아니므로 무해하게 스텁만 한다.
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function flush(times = 6) {
+  await act(async () => {
+    for (let i = 0; i < times; i++) await Promise.resolve();
+  });
+}
+
+describe('ThreadPanel — 스레드 답글 전용 참조가 실제로 배치조회 훅에 넘어간다(#2262 PR② 배선 왕복)', () => {
+  it('스레드 답글에서만 처음 보이는 참조가 resolved로 채워져 칩에 번역된 상태가 뜬다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/messages?thread_id=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: [{
+              id: 'reply-1',
+              created_by: 'agent-2',
+              sender: { id: 'agent-2', name: '유나', type: 'agent' },
+              content: `[작업 A](entity:task:${TASK_ID})`,
+              created_at: '2026-08-08T00:01:00.000Z',
+              references: [{ target_type: 'task', target_id: TASK_ID }],
+            }],
+          }),
+        };
+      }
+      if (url.includes('/api/tasks?ids=')) {
+        expect(url).toContain(TASK_ID);
+        return { ok: true, json: async () => ({ data: [{ id: TASK_ID, status: 'in-progress' }] }) };
+      }
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+
+    await act(async () => {
+      root.render(wrap(<Harness />));
+    });
+    await flush();
+
+    expect(container.textContent).toContain('진행 중');
+    expect(container.textContent).not.toContain('아직 모름');
+  });
+});

--- a/apps/web/src/components/shared/entity-aware-textarea.test.tsx
+++ b/apps/web/src/components/shared/entity-aware-textarea.test.tsx
@@ -113,4 +113,26 @@ describe('EntityAwareTextarea — story #2264', () => {
     expect(listbox).not.toBeNull();
     expect(listbox!.className).toContain('focus-inset');
   });
+
+  // story #2522 — EmbedCard와 같은 클래스의 같은 gap(close-the-class, PO 지시 2026-08-08):
+  // `#` 피커도 entity.status 원시값을 그대로 노출하고 있었다.
+  it('후보 status가 번역된 말로 뜬다(원시값 in-review 노출 금지)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      data: [{ entity_type: 'story', entity_id: '11111111-1111-1111-1111-111111111111', title: '제목', status: 'in-review' }],
+    }))));
+    await act(async () => {
+      root.render(<ControlledHarness initial="" projectId="p1" onValueChange={() => {}} />);
+    });
+    const el = textarea();
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(el, '#');
+      el.selectionStart = 1;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => { await new Promise((r) => setTimeout(r, 260)); });
+
+    expect(container.textContent).toContain('검토 중');
+    expect(container.textContent).not.toContain('in-review');
+  });
 });

--- a/apps/web/src/components/shared/entity-aware-textarea.tsx
+++ b/apps/web/src/components/shared/entity-aware-textarea.tsx
@@ -4,6 +4,7 @@ import { useRef, type ClipboardEvent, type KeyboardEvent } from 'react';
 import { Hash } from 'lucide-react';
 import { ENTITY_ICONS } from '@/components/chat/embed-card';
 import { entityTypeLabel, getEntityQuery, type EntityResult } from '@/components/chat/chat-input-entity-tokens';
+import { translateEntityStatus } from '@/components/chat/entity-status-labels';
 import { useEntityPicker } from '@/hooks/use-entity-picker';
 
 interface EntityAwareTextareaProps {
@@ -79,6 +80,9 @@ export function EntityAwareTextarea({ value, onChange, projectId, placeholder, c
           {entityPicker.entityResults.map((entity, idx) => {
             const EntityIcon = ENTITY_ICONS[entity.entity_type] ?? Hash;
             const isNewGroup = idx === 0 || entityPicker.entityResults[idx - 1]!.entity_type !== entity.entity_type;
+            // story #2522 — 원시값(in-review 등) 노출 금지, EmbedCard와 같은 클래스의 같은
+            // fix(# 피커도 같은 처방이 통한다·close-the-class).
+            const statusLabel = entity.status ? translateEntityStatus(entity.entity_type, entity.status) : null;
             return (
               <li key={`${entity.entity_type}:${entity.entity_id}`}>
                 {isNewGroup && (
@@ -99,8 +103,8 @@ export function EntityAwareTextarea({ value, onChange, projectId, placeholder, c
                 >
                   <EntityIcon className="mr-1.5 size-3.5 shrink-0" aria-hidden />
                   <span className="font-medium">{entity.title}</span>
-                  {entity.status ? (
-                    <span className="ml-2 rounded px-1.5 py-0.5 text-xs bg-muted text-muted-foreground">{entity.status}</span>
+                  {statusLabel ? (
+                    <span className="ml-2 rounded px-1.5 py-0.5 text-xs bg-muted text-muted-foreground">{statusLabel}</span>
                   ) : null}
                 </button>
               </li>


### PR DESCRIPTION
## Summary
- 발견: 유나양 #2903(#2262 PR①) design review — 모달 status를 `MdBadge label={d.status}`로 원시값(`in-review`·`backlog` 등) 그대로 노출. merge-base에 이미 있던 EmbedCard 패턴 기존 gap(#2903이 도입한 게 아니라 인스턴스 확대).
- 유나양 DS 어휘 규격(doc `ds-entity-status-label-map-2522`, 2026-08-07) 그대로 `STATUS_LABELS`(entity-status-labels.ts) 배선 — 9곳 값이 스펙과 달라 정정: `story.backlog` "백로그"→"대기", `doc.pending` "검토 대기"→"검토 중", hypothesis 전체 명사 어미 "됨" 제거, `sprint.planning` "계획 중"→"계획", `epic.archived` "보관됨"→"보관". ⛔`hypothesis.active`="검증 중"(원시값은 `sprint`/`epic.active`="진행 중"과 같지만 다른 말로 — 스펙이 명시한 지점).
- **EmbedCard 「클래스 전체」에 적용**(AC 그대로, 인스턴스 하나 아님) — 4개 렌더 지점 전부 `translateEntityStatus` 통과:
  1. `EntityPreviewModal` 헤더의 `resolvedStatus`
  2. `EntityDetail`(모달 본문) story 자기 status 뱃지
  3. `EntityDetail`(모달 본문) epic 자기 status 뱃지
  4. `EmbedCard` 자신의 인라인 카드(비doc·doc 두 분기 다) status 뱃지
- 미매핑 status는 전부 빈칸(원시값 폴백 절대 금지, fail-safe).
- **렌더테스트로 스코프 누락을 직접 잡음** — 모달 헤더만 먼저 고치고 실행했더니 "status prop이 실려 있으면..." 테스트가 라벨 매치 수 1개(카드+모달 둘 다 나와야 하니 기대 2개)로 실패, `EmbedCard` 자기 인라인 카드도 안 고쳤다는 걸 즉시 발견 → grep 재확認 후 나머지 2곳 마저 수정.
- **PO 지시로 편입(2026-08-08)**: `chat-input.tsx`·`entity-aware-textarea.tsx`의 `#` 엔티티 피커 드롭다운도 같은 클래스의 같은 gap이라 판정 — `EntityResult`에 이미 `entity_type`+`status` 둘 다 있어 같은 `translateEntityStatus`로 함께 닫음(close-the-class, 발산 아님).

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm run lint` 0 error(무관 warning 3개만)
- [x] `pnpm exec vitest run` 387 files / 2907 tests all green
- [x] `pnpm run build` exit 0
- [x] 신규 테스트: story·epic 본문 status 뱃지 번역 확認 2건, 미매핑 status→빈칸 가드 1건, `hypothesis.active` vs `epic`/`sprint.active` 원시값 동일·번역 다름 회귀가드 1건, `#` 피커 두 곳(chat-input·entity-aware-textarea) 원시값 미노출 렌더 검증 2건
- [x] 기존 PR①(#2903) 테스트 2건 갱신(원시값 직접검증 → 번역값 검증 — 구 동작이 이 스토리가 고치는 버그 그 자체였음)
- [x] 뮤테이션 self-check 2건(EmbedCard story statusLabel·chat-input statusLabel 각각 원시값 폴백으로 되돌림 → RED 확認 → 원복 → GREEN)
- [ ] 라이브 배포 後 픽셀 검증(유나 경유) — 원시값 enum이 화면 어디에도 안 남는지(모달·인라인 카드·# 피커 전부)

⚠️ 스택 — base를 PR②(#2909, 아직 미머지)의 브랜치로 잡았다. `entity-status-labels.ts`가 그쪽에만 존재해서다. #2909가 develop에 머지되면 이 PR도 재조준 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
