### PR TITLE
fix(#2520): 웹훅 merge-gate reconcile이 H1 플래그로만 게이팅돼 라인 merge-gate 경로를 놓치던 결함

### DIFF
--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -26,10 +26,7 @@ from app.models.github_installation import GithubInstallation, GithubWebhookDeli
 from app.models.pm import Story
 from app.routers.cron import CRON_SECRET, _err, _ok, verify_cron
 from app.services.github_app import get_installation_token
-from app.services.merge_verdict_gate import (
-    merge_gate_active,
-    reconcile_merge_gate_with_real_evidence,
-)
+from app.services.merge_verdict_gate import reconcile_merge_gate_with_real_evidence
 from app.services.pr_story_link import merge_link_evidence, resolve_story_for_pr
 from app.services.verdict_capture import (
     capture_pr_ci_verdict,
@@ -453,15 +450,29 @@ async def _process_webhook_event(
     # 반영한다. ⚠️capture_pr_ci_verdict 리턴 後 별도 호출(evaluate_merge_gate가 내부에서
     # capture_pr_ci_verdict를 다시 부르므로, 그 함수 안에서 이걸 부르면 무한 재귀가 된다).
     #
+    # story #2520(2026-08-08) 근본수정 — 이전엔 이 호출을 `merge_gate_active(org_id)`(H1
+    # 레거시 플래그+allowlist)로 게이팅했는데, merge-type Gate row는 H1 경로(board preflight·
+    # report-done)뿐 아니라 workflow_line_engine._merge_gate_wrapper(라인엔진 merge-gate step,
+    # `line_merge_gate_active()` — H1과 **완전히 별개**인 runtime_mode+published_config
+    # 활성판정)에서도 만들어진다(evaluate_merge_gate→create_gate가 둘의 단일 chokepoint,
+    # gate_type="merge" 공유). H1_MERGE_GATE_ENABLED=False인 org라도 라인 merge-gate step이
+    # enforcing이면 실제 Gate row가 생기는데, 그 org는 merge_gate_active()가 항상 False라
+    # 이 reconcile이 영원히 스킵됐다 — #2156이 고치려던 "증거 기록됐는데 게이트에 CI unknown"
+    # 증상이 라인 경로서 그대로 재현(카디르 #2902 QA·codex 019fdc4f 적출). reconcile 자신의
+    # 쿼리(아래 existing Gate row: org_id+story_id+gate_type="merge"+status pending/auto_passed)가
+    # 이미 "이 story에 실제로 반영할 게이트가 있는가"를 정확히 판별하므로(없으면 즉시 None
+    # 반환, 저렴한 단건 조회) 바깥에서 org-level 활성판정으로 다시 게이팅할 필요가 없다 —
+    # H1도 라인도 「Gate row 존재」라는 같은 사실로 자연히 커버된다(두 활성판정 통합 = 애초에
+    # 이 바깥 게이트가 불필요했다는 것).
+    #
     # ⭐카디르 QA(PR#2902, 2026-08-07)③: try/except로 여기서 삼키면 일시적 DB 오류가 "이번
     # 배달은 영구 no-op(processed로 커밋)"이 돼 GitHub 재시도를 못 받는다(delivery 모델
     # 자체 계약 — "실패=rollback→retry 보존"). 이 함수 밖(github_webhook)이 이미 예외를
     # 전체 rollback+500으로 처리해 GitHub가 재시도하므로, 여기서 삼키지 않고 그대로 올린다.
-    if merge_gate_active(org_id):
-        await reconcile_merge_gate_with_real_evidence(
-            session, org_id, story_id,
-            pr_number=pr_number, repo=repo, ci_result=ci_conclusion, merged=merged,
-        )
+    await reconcile_merge_gate_with_real_evidence(
+        session, org_id, story_id,
+        pr_number=pr_number, repo=repo, ci_result=ci_conclusion, merged=merged,
+    )
 
     # ⭐story #2327 후속(PO 판정, 2026-07-30, PR#2685 실 웹훅 시험대가 드러낸 갭) — merge 시
     # PullRequestStoryLink 에도 쓴다. `Verdict`(record_verdict, 위 capture_pr_ci_verdict 안)에도

--- a/backend/tests/test_2156_merge_gate_evidence_realdb.py
+++ b/backend/tests/test_2156_merge_gate_evidence_realdb.py
@@ -376,7 +376,6 @@ async def test_process_webhook_event_does_not_swallow_reconcile_exception():
         ),
         patch("app.routers.verdict_capture.merge_link_evidence", AsyncMock()),
         patch("app.routers.verdict_capture.get_installation_token", AsyncMock(return_value=None)),
-        patch("app.routers.verdict_capture.merge_gate_active", lambda _org_id: True),
         patch(
             "app.routers.verdict_capture.reconcile_merge_gate_with_real_evidence",
             AsyncMock(side_effect=RuntimeError("transient db error")),

--- a/backend/tests/test_2520_line_merge_gate_reconcile.py
+++ b/backend/tests/test_2520_line_merge_gate_reconcile.py
@@ -1,0 +1,207 @@
+"""story #2520([결재게이트·후속], high) — workflow_line merge-gate 경로도 웹훅 evidence
+reconcile을 안 거치던 결함(#2156과 같은 근본의 라인 게이트판).
+
+그라운딩(디디, 2026-08-08): `workflow_line_engine._merge_gate_wrapper`는 H1과 완전히 별개인
+`line_merge_gate_active()`(runtime_mode+published_config rollout_mode+step 매칭)로 활성
+판정하지만, `evaluate_merge_gate()`를 그대로 호출해 **동일한** `gate_type="merge"` Gate row를
+만든다(evaluate_merge_gate가 H1/라인 두 트리거의 단일 chokepoint, merge_verdict_gate.py 주석
+"3 트리거(board preflight·report-done·line-engine) 모두 이 단일 chokepoint를 거쳐 일관 적용"
+그대로). 그런데 웹훅 핸들러(`_process_webhook_event`)는 `reconcile_merge_gate_with_real_
+evidence` 호출을 `merge_gate_active(org_id)`(H1_MERGE_GATE_ENABLED 플래그+allowlist)로
+게이팅했다 — H1이 꺼진(라인 게이트만 쓰는) org는 실제 merge Gate row가 있어도 이 reconcile이
+영원히 스킵됐다(#2156이 고치려던 "증거 기록됐는데 게이트에 CI unknown" 증상의 라인판).
+
+수정: 그 바깥 `merge_gate_active(org_id)` 가드를 제거 — reconcile 자신의 쿼리(Gate row:
+org_id+story_id+gate_type="merge"+status pending/auto_passed 존재 여부)가 이미 "이 story에
+반영할 게이트가 있는가"를 정확히 판별하므로(없으면 즉시 None, 저렴한 단건 조회) 바깥에서
+org-level 활성판정으로 다시 게이팅할 필요가 없었다 — H1도 라인도 「Gate row 존재」라는 같은
+사실로 자연히 커버된다(AC "두 활성판정을 통합" = 이 바깥 게이트가 애초에 불필요했다는 것).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.destructive_schema,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    import app.models  # noqa: F401 — 전 모델 메타데이터 로드
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_story_with_participation(session):
+    from app.models.organization import Organization
+    from app.models.participation import Participation, ParticipationRole
+    from app.models.pm import Story
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Line merge gate target")
+    session.add(story)
+    await session.commit()
+
+    role = ParticipationRole(id=uuid.uuid4(), org_id=org.id, key="dev", label="Dev", is_default=True)
+    session.add(role)
+    await session.commit()
+
+    member_id = uuid.uuid4()
+    participation = Participation(
+        id=uuid.uuid4(), org_id=org.id, story_id=story.id, role_id=role.id, member_id=member_id,
+    )
+    session.add(participation)
+    await session.commit()
+
+    return {"org_id": org.id, "story_id": story.id, "member_id": member_id}
+
+
+async def _gate_row(session, story_id):
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+
+    result = await session.execute(
+        select(Gate).where(Gate.work_item_id == story_id, Gate.gate_type == "merge")
+    )
+    return result.scalar_one_or_none()
+
+
+@pytest.mark.anyio
+async def test_process_webhook_event_reconciles_even_when_h1_merge_gate_disabled():
+    """⭐본체 — H1_MERGE_GATE_ENABLED=False(라인 merge-gate만 쓰는 org의 정상 상태)여도
+    `_process_webhook_event`가 reconcile_merge_gate_with_real_evidence를 호출해야 한다.
+    merge-type Gate row는 H1 경로뿐 아니라 workflow_line_engine._merge_gate_wrapper에서도
+    생기므로(evaluate_merge_gate→create_gate, gate_type="merge" 공유), org-level H1 플래그로
+    reconcile을 게이팅하면 라인전용 org의 실 CI/PR 증거가 영원히 그 게이트에 안 닿는다."""
+    from app.core.config import settings
+    from app.models.github_installation import GithubInstallation, GithubWebhookDelivery
+    from app.routers.verdict_capture import _process_webhook_event
+    from app.services.pr_story_link import ResolvedLink
+
+    story_id = uuid.uuid4()
+    org_id = uuid.uuid4()
+    installation = GithubInstallation(
+        id=uuid.uuid4(), installation_id=123, org_id=org_id, account_login="moonklabs",
+    )
+    delivery = GithubWebhookDelivery(
+        id=uuid.uuid4(), source="app", delivery_id="d1", event="pull_request", status="received",
+    )
+    payload = {
+        "repository": {"full_name": "moonklabs/sprintable"},
+        "pull_request": {
+            "number": 42, "merged": True, "title": "fix(#1): x",
+            "head": {"ref": "fix/1-x", "sha": "abc"},
+        },
+        "action": "closed",
+        "installation": {"id": 123},
+    }
+
+    session = AsyncMock()
+    exec_result = AsyncMock()
+    exec_result.scalar_one_or_none = lambda: installation
+    session.execute = AsyncMock(return_value=exec_result)
+
+    with (
+        # ⭐라인전용 org의 정상 상태 — H1 레거시 플래그는 꺼짐. 옛 코드는 이 값으로
+        # merge_gate_active(org_id)를 계산해 reconcile 호출 자체를 건너뛰었다.
+        patch.object(settings, "h1_merge_gate_enabled", False),
+        patch(
+            "app.routers.verdict_capture.resolve_story_for_pr",
+            AsyncMock(return_value=ResolvedLink(story_id, org_id, "sid", "high", True, "sid_exact")),
+        ),
+        patch(
+            "app.routers.verdict_capture.capture_pr_ci_verdict",
+            AsyncMock(return_value={"recorded": ["pr"], "skipped_reason": None}),
+        ),
+        patch("app.routers.verdict_capture.merge_link_evidence", AsyncMock()),
+        patch("app.routers.verdict_capture.get_installation_token", AsyncMock(return_value=None)),
+        patch(
+            "app.routers.verdict_capture.reconcile_merge_gate_with_real_evidence", AsyncMock(return_value=None),
+        ) as reconcile_spy,
+    ):
+        await _process_webhook_event(session, "app", "pull_request", payload, 123, delivery)
+
+    reconcile_spy.assert_awaited_once(), "H1 꺼진 org라고 reconcile이 스킵되면 라인 게이트 증거가 영원히 안 닿는다 — #2520 미수복"
+
+
+@pytest.mark.anyio
+async def test_reconcile_updates_line_style_gate_regardless_of_h1_flag_realdb():
+    """⭐실PG 대응 — reconcile_merge_gate_with_real_evidence 자신은 H1 플래그를 아예 참조하지
+    않는다(쿼리 조건이 org_id+story_id+gate_type="merge"+status뿐). H1_MERGE_GATE_ENABLED=False
+    로 명시해도(라인전용 org 재현) 라인 wrapper가 만드는 것과 동일한 모양의 pending merge
+    게이트가 실 CI 증거로 정확히 갱신됨을 실PG로 고정 — "line gate만 있는(H1=False) org에서
+    CI verdict가 그 gate에 실제 반영되는지"(AC) 그 자체."""
+    from app.core.config import settings
+    from app.services.merge_verdict_gate import evaluate_merge_gate, reconcile_merge_gate_with_real_evidence
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_story_with_participation(s)
+            with (
+                patch.object(settings, "h1_merge_gate_enabled", False),
+                patch(
+                    "app.services.merge_verdict_gate.resolve_disposition",
+                    AsyncMock(return_value=("ask", "org_policy")),
+                ),
+                patch(
+                    "app.services.merge_verdict_gate._is_meaningfully_explicit_ask",
+                    AsyncMock(return_value=True),
+                ),
+            ):
+                # 라인 wrapper가 만드는 것과 동형(ci=None·pr_number=0 self-report shell).
+                await evaluate_merge_gate(
+                    s, seeded["org_id"], seeded["story_id"],
+                    pr_number=0, repo="", ci_result=None, pr_result=None,
+                )
+                await s.commit()
+
+                decision = await reconcile_merge_gate_with_real_evidence(
+                    s, seeded["org_id"], seeded["story_id"],
+                    pr_number=42, repo="moonklabs/sprintable", ci_result="pass", merged=True,
+                )
+                await s.commit()
+
+            assert decision is not None, "H1=False라고 reconcile 자신이 no-op되면 안 된다"
+            assert decision.reason != "CI unknown (self-report only)", (
+                "실 CI 증거가 게이트에 반영 안 됨 — #2520(라인 게이트판) 미수복"
+            )
+            gate = await _gate_row(s, seeded["story_id"])
+            assert gate.decision_basis != "CI unknown (self-report only)"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_bot_l1_pr_story_link.py
+++ b/backend/tests/test_bot_l1_pr_story_link.py
@@ -390,6 +390,10 @@ async def _merge_webhook(*, should_close: bool):
     rl = ResolvedLink(STORY_ID, ORG_A, "sid", "high", should_close, "sid_exact")
     try:
         async with AsyncClient(transport=ASGITransport(app=fastapi_app), base_url="http://test") as c:
+            # story #2520 후속(카디르 QA, 2026-08-08): reconcile이 이제 무조건 호출돼(#2520) 이
+            # 테스트의 무관 대상(close-on-merge 배선)까지 evaluate_merge_gate 내부 session.execute
+            # 체인을 실제로 타게 만든다 — 이 파일의 얕은 session mock은 그 내부 쿼리를 감당하도록
+            # 설계되지 않았다. 이 테스트의 관심사가 아니므로 patch.
             with patch.object(vmod.settings, "github_webhook_secret", _WH_SECRET), \
                  patch.object(vmod.settings, "github_app_webhook_secret", ""), \
                  patch.object(vmod, "_resolve_legacy_org_by_repo_owner",
@@ -397,6 +401,7 @@ async def _merge_webhook(*, should_close: bool):
                  patch.object(vmod, "resolve_story_for_pr", new=AsyncMock(return_value=rl)), \
                  patch.object(vmod, "capture_pr_ci_verdict",
                               new=AsyncMock(return_value={"recorded": ["pr"], "skipped_reason": None})), \
+                 patch.object(vmod, "reconcile_merge_gate_with_real_evidence", new=AsyncMock()), \
                  patch.object(vmod.logger, "info") as info_log:
                 resp = await c.post("/api/v2/internal/verdict/github-webhook", content=body, headers=headers)
         return resp, session, info_log
@@ -442,12 +447,14 @@ async def test_process_webhook_event_legacy_repo_owner_org_feeds_resolver():
     rl = ResolvedLink(STORY_ID, ORG_A, "sid", "high", True, "sid_exact_by_number")
     payload = {"action": "closed", "repository": {"full_name": "moonklabs/sprintable"},
                "pull_request": {"number": 9, "merged": True, "title": "fix(#2288): x"}}
+    # story #2520 후속: reconcile 무조건 호출(#2520)이 이 테스트 무관 내부 쿼리를 실제로 태우니 patch.
     with patch.object(vmod, "_resolve_legacy_org_by_repo_owner",
                        new=AsyncMock(return_value=(ORG_A, "org_resolved_via_repo_owner"))), \
          patch.object(vmod, "resolve_story_for_pr", new=AsyncMock(return_value=rl)) as resolver, \
          patch.object(vmod, "capture_pr_ci_verdict",
                        new=AsyncMock(return_value={"recorded": ["pr"]})), \
          patch.object(vmod, "merge_link_evidence", new=AsyncMock()), \
+         patch.object(vmod, "reconcile_merge_gate_with_real_evidence", new=AsyncMock()), \
          patch.object(vmod.logger, "info"):
         await vmod._process_webhook_event(session, "legacy", "pull_request", payload, None, delivery)
     resolver.assert_awaited_once()
@@ -557,12 +564,14 @@ async def test_process_webhook_event_merge_writes_link_with_sid_label():
     rl = ResolvedLink(STORY_ID, ORG_A, "sid", "high", True, "sid_exact_by_number")
     payload = {"action": "closed", "repository": {"full_name": "moonklabs/sprintable"},
                "pull_request": {"number": 2685, "merged": True, "title": "[SID:2224] x"}}
+    # story #2520 후속: reconcile 무조건 호출(#2520)이 이 테스트 무관 내부 쿼리를 실제로 태우니 patch.
     with patch.object(vmod, "_resolve_legacy_org_by_repo_owner",
                        new=AsyncMock(return_value=(ORG_A, "org_resolved_via_repo_owner"))), \
          patch.object(vmod, "resolve_story_for_pr", new=AsyncMock(return_value=rl)), \
          patch.object(vmod, "capture_pr_ci_verdict",
                        new=AsyncMock(return_value={"recorded": ["pr", "ci"]})), \
          patch.object(vmod, "merge_link_evidence", new=AsyncMock()) as link_write, \
+         patch.object(vmod, "reconcile_merge_gate_with_real_evidence", new=AsyncMock()), \
          patch.object(vmod.logger, "info"):
         await vmod._process_webhook_event(session, "legacy", "pull_request", payload, None, delivery)
     link_write.assert_awaited_once()
@@ -584,12 +593,14 @@ async def test_process_webhook_event_ci_only_does_not_write_link():
     payload = {"repository": {"full_name": "moonklabs/sprintable"},
                "workflow_run": {"conclusion": "failure", "head_sha": "sha1",
                                 "head_branch": "feat-[SID:2224]", "pull_requests": [{"number": 2685}]}}
+    # story #2520 후속: reconcile 무조건 호출(#2520)이 이 테스트 무관 내부 쿼리를 실제로 태우니 patch.
     with patch.object(vmod, "_resolve_legacy_org_by_repo_owner",
                        new=AsyncMock(return_value=(ORG_A, "org_resolved_via_repo_owner"))), \
          patch.object(vmod, "resolve_story_for_pr", new=AsyncMock(return_value=rl)), \
          patch.object(vmod, "capture_pr_ci_verdict",
                        new=AsyncMock(return_value={"recorded": ["ci"]})), \
          patch.object(vmod, "merge_link_evidence", new=AsyncMock()) as link_write, \
+         patch.object(vmod, "reconcile_merge_gate_with_real_evidence", new=AsyncMock()), \
          patch.object(vmod.logger, "info"):
         await vmod._process_webhook_event(session, "legacy", "workflow_run", payload, None, delivery)
     link_write.assert_not_awaited()


### PR DESCRIPTION
## Summary
- `#2156` 후속(카디르 QA·codex 019fdc4f 적출) — `workflow_line_engine._merge_gate_wrapper`는 H1과 완전히 별개인 `line_merge_gate_active()`(runtime_mode+published_config)로 활성 판정하지만 `evaluate_merge_gate()`를 그대로 호출해 동일한 `gate_type="merge"` Gate row를 만든다.
- 웹훅 핸들러(`_process_webhook_event`)는 `reconcile_merge_gate_with_real_evidence` 호출을 `merge_gate_active(org_id)`(H1_MERGE_GATE_ENABLED 플래그+allowlist)로 게이팅했다 — H1이 꺼진(라인 게이트만 쓰는) org의 실 CI/PR 증거가 영원히 그 게이트에 안 닿았다(`#2156`이 고치려던 "증거 기록됐는데 게이트에 CI unknown" 증상의 라인판).
- `reconcile_merge_gate_with_real_evidence` 자신의 쿼리(Gate row: org_id+story_id+gate_type="merge"+status pending/auto_passed 존재 여부)가 이미 정확한 판별 기준이므로, 바깥의 org-level H1 활성판정 가드를 제거 — H1도 라인도 "Gate row 존재"라는 같은 사실로 자연히 커버된다.
- `stories.py`/`workflow_report.py`의 `merge_gate_active` 사용(H1 자신의 게이트 트리거 여부 판정)은 그대로 — 이 PR은 reconcile 호출부만 바뀜.

## Test plan
- [x] 실PG(pg@16+pgvector, alembic upgrade head to 0236) — `test_2520_line_merge_gate_reconcile.py` 2/2, `test_2156_merge_gate_evidence_realdb.py` 8/8 GREEN.
- [x] 양성대조 — reconcile 호출을 `merge_gate_active(org_id)`로 재게이팅(구 동작 재현) 시 신규 테스트 1개 + 기존 QA③ 테스트 1개 모두 RED, 복구 後 10/10 GREEN.
- [x] `py_compile` 통과.