### PR TITLE
fix(#2524): _reopen_rejected_gate가 재오픈 時 requires_human을 안 갱신하던 결함

### DIFF
--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -340,6 +340,16 @@ async def _reopen_rejected_gate(
         new_status = "pending"
 
     set_gate_status(gate, new_status, now=datetime.now(timezone.utc))
+    # story #2524(2026-08-08, codex 지적·#2520 QA 파생) — create_gate()의 신규 생성 분기는
+    # requires_human=(status=="pending")을 채우는데(#2156 AC3), 이 재오픈 분기는 여태 status만
+    # 갱신하고 requires_human은 안 건드렸다. rejected 게이트는 항상 requires_human이 "그
+    # rejected가 되던 시점의" 값을 그대로 물려받으므로(대개 창설 시 deny 정책이면 애초에
+    # False) — 정책이 그 사이(deny→ask 등) 바뀌어 재오픈이 pending으로 열리면 「status=pending
+    # (사람 승인 필요)인데 requires_human=False(안 필요로 표기)」로 어긋난다. merge-type은
+    # evaluate_merge_gate가 재오픈 직후 이 필드를 다시 정확히 덮어써(decision 기반) 이 갭이
+    # 안 보였지만(#2520 조사로 non-issue 확인), qa 등 non-merge gate_type은 이 재오픈이
+    # requires_human의 유일한 갱신 지점이라 여기서 직접 재기록한다(create_gate와 동일 규칙).
+    gate.requires_human = (new_status == "pending")
     gate.resolver_id = None
     gate.resolution_note = None
     gate.resolved_at = datetime.now(timezone.utc) if new_status != "pending" else None

--- a/backend/tests/test_2524_gate_reopen_requires_human.py
+++ b/backend/tests/test_2524_gate_reopen_requires_human.py
@@ -1,0 +1,152 @@
+"""story #2524([조사·게이트], low) — `_reopen_rejected_gate`가 재오픈 時 requires_human을
+갱신하지 않던 결함(codex 지적·#2520 QA 파생).
+
+그라운딩(디디, 2026-08-08): AC1(non-merge gate_type이 실제로 reopen되는 경로가 있는가) —
+`gate_type="qa"`가 `_ALWAYS_MANUAL_GATE_TYPES`(doc_approval·loop_decision·artifact_canonicalize,
+disposition 무관 항상 pending 강제)에 없어 disposition=deny 時 status="rejected"로 창설될 수
+있고, `stories.py`(POST .../verify-request)가 명시적으로 "재요청 시 기존 pending 재사용,
+rejected는 자동 재오픈"이라 create_gate()를 같은 work_item에 재호출하는 실 경로다 — 0이 아니다.
+
+AC2 재현: qa 게이트를 disposition=deny(status=rejected→requires_human=False, create_gate
+창설 시 규칙대로)로 만든 뒤, 그 사이 조직 정책이 ask로 바뀐 상태에서 재요청 — 재오픈이
+status를 pending으로 올리는데 requires_human은 여전히 False로 남는다(수정 前).
+
+AC3: `_reopen_rejected_gate`가 new_status 계산 직후 `gate.requires_human = (new_status ==
+"pending")`을 직접 재기록(merge-type의 evaluate_merge_gate와 동일 chokepoint 원칙)."""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.destructive_schema,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    import app.models  # noqa: F401 — 전 모델 메타데이터 로드
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_and_story(session):
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Gate reopen target")
+    session.add(story)
+    await session.commit()
+
+    return {"org_id": org.id, "story_id": story.id}
+
+
+@pytest.mark.anyio
+async def test_reopen_rejected_qa_gate_refreshes_requires_human_to_true_realdb():
+    """⭐본체 — deny 정책으로 rejected(requires_human=False)로 창설된 qa 게이트가, 그 사이
+    정책이 ask로 바뀐 뒤 재요청(create_gate 재호출)되면 status=pending과 함께
+    requires_human도 True로 갱신돼야 한다(수정 前엔 False로 고정돼 「사람 승인 필요한데
+    안 필요로 표기」됐다)."""
+    from app.services.gate_service import create_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_and_story(s)
+            member_id, role_id = uuid.uuid4(), uuid.uuid4()
+
+            with patch(
+                "app.services.gate_service.resolve_disposition",
+                AsyncMock(return_value=("deny", "org_policy")),
+            ):
+                gate = await create_gate(
+                    s, seeded["org_id"], seeded["story_id"], "story", "qa", member_id, role_id,
+                )
+                await s.commit()
+
+            assert gate.status == "rejected"
+            assert gate.requires_human is False, "deny 창설 직후엔 False가 맞다(사람이 볼 게 없음)"
+
+            # 그 사이 조직이 정책을 ask로 완화 — 재요청(같은 work_item, create_gate 재호출).
+            with patch(
+                "app.services.gate_service.resolve_disposition",
+                AsyncMock(return_value=("ask", "org_policy")),
+            ):
+                reopened = await create_gate(
+                    s, seeded["org_id"], seeded["story_id"], "story", "qa", member_id, role_id,
+                )
+                await s.commit()
+
+            assert reopened.id == gate.id, "재오픈은 같은 row 재사용(신규 row 생성 안 함)"
+            assert reopened.status == "pending"
+            assert reopened.requires_human is True, (
+                "status=pending인데 requires_human=False로 남음 — #2524 미수복"
+                "(사람 승인 필요한데 인박스에 안 뜬다)"
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reopen_still_rejected_when_policy_unchanged_requires_human_stays_false_realdb():
+    """회귀 0 — 정책이 여전히 deny면 재오픈해도 다시 rejected로 떨어지고(#2150 AC③ 그대로),
+    requires_human도 False 그대로 유지돼야 한다(멀쩡한 rejected를 이 수정이 잘못 True로
+    뒤집으면 그것도 다른 방향의 결함)."""
+    from app.services.gate_service import create_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_and_story(s)
+            member_id, role_id = uuid.uuid4(), uuid.uuid4()
+
+            with patch(
+                "app.services.gate_service.resolve_disposition",
+                AsyncMock(return_value=("deny", "org_policy")),
+            ):
+                gate = await create_gate(
+                    s, seeded["org_id"], seeded["story_id"], "story", "qa", member_id, role_id,
+                )
+                await s.commit()
+                reopened = await create_gate(
+                    s, seeded["org_id"], seeded["story_id"], "story", "qa", member_id, role_id,
+                )
+                await s.commit()
+
+            assert reopened.status == "rejected"
+            assert reopened.requires_human is False
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- codex 지적(#2520 QA 파생, 낮은 우선순위 조사 스토리) — `create_gate()`의 신규 생성 분기는 `requires_human=(status=="pending")`을 채우지만(#2156 AC3), 재오픈 분기(`_reopen_rejected_gate`)는 `status`만 갱신하고 `requires_human`은 그대로 뒀다.
- **AC1 그라운딩 결과 — 0이 아님**: `gate_type="qa"`가 `_ALWAYS_MANUAL_GATE_TYPES`(doc_approval/loop_decision/artifact_canonicalize) 밖이라, `disposition=deny`면 창설 時 `rejected`+`requires_human=False`가 된다. `stories.py`의 `POST .../verify-request`가 "재요청 시 기존 pending 재사용, rejected는 자동 재오픈"이라 명시하는 실제 재호출 경로.
- **AC2 재현**: deny로 창설(rejected, requires_human=False) 後 조직 정책이 ask로 완화된 상태에서 재요청 → `_reopen_rejected_gate`가 status를 pending으로 올리지만 requires_human은 False로 고정(양성대조로 실증, 테스트 참조).
- **AC3 fix**: `new_status` 계산 직후 `gate.requires_human = (new_status == "pending")` 직접 재기록 — `create_gate`의 창설-시 규칙과 동일, 새 판정 로직 0개.
- merge-type은 `evaluate_merge_gate`가 재오픈 직후 이 필드를 decision 기반으로 다시 정확히 덮어써 이 갭이 안 보였다(#2520 조사로 non-issue 확인 완료) — 이 PR은 merge를 건드리지 않는다.

## Test plan
- [x] 실PG(pg@16+pgvector, alembic upgrade head to 0236) — 신규 2개 GREEN(재현 확인 + 정책불변 회귀 0).
- [x] 양성대조 — `gate.requires_human = (new_status == "pending")` 라인 제거 시 재현 테스트 RED("status=pending인데 requires_human=False로 남음"), 복구 後 GREEN.
- [x] gate 관련 테스트 파일 12개 clean A/B(fresh DB, with-fix vs without-fix) 비교 — 동일한 12개 실패가 fix 유무와 무관하게 동일 재현(전부 사전-기존/환경 이슈, port 54322 미스매치 등, 이 diff와 무관 확인).
- [x] `py_compile` 통과.