### PR TITLE
[SID:2525] 스토리지 자산 삭제 모달 footer sticky — usage list 길면 삭제 CTA 밀리던 결함

### DIFF
--- a/apps/web/src/components/storage/storage-delete-dialog.test.tsx
+++ b/apps/web/src/components/storage/storage-delete-dialog.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { StorageDeleteDialog } from './storage-delete-dialog';
+import type { Asset, AssetSourceLink } from '@/lib/storage/types';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+function makeAsset(sourceLinkCount: number): Asset {
+  const source_links: AssetSourceLink[] = Array.from({ length: sourceLinkCount }, (_, i) => ({
+    type: 'story',
+    id: `story-${i}`,
+    title: `사용처 ${i}`,
+    deeplink: { story_id: `story-${i}` },
+  }));
+  return {
+    id: 'asset-1',
+    org_id: 'org-1',
+    project_id: 'proj-1',
+    folder_id: null,
+    container: 'c',
+    object_path: 'p',
+    name: 'design.png',
+    content_type: 'image/png',
+    size_bytes: 1024,
+    created_at: '2026-08-01T00:00:00Z',
+    updated_at: '2026-08-01T00:00:00Z',
+    created_by: null,
+    source_links,
+  };
+}
+
+function renderDialog(asset: Asset) {
+  act(() => {
+    root.render(
+      <NextIntlClientProvider locale="ko" messages={koMessages}>
+        <StorageDeleteDialog asset={asset} open onOpenChange={() => {}} onDeleted={() => {}} />
+      </NextIntlClientProvider>,
+    );
+  });
+}
+
+// story #2525 — footer(삭제 CTA)가 본문(usage list) 스크롤에 밀려 화면 밖으로 나가던 결함.
+// jsdom은 실제 overflow/clipping을 계산하지 않으므로, footer가 스크롤 영역 밖(shrink-0)에
+// 구조적으로 고정돼 있는지 + body가 스스로 스크롤(overflow-y-auto)하는지를 클래스 계약으로 고정한다.
+// 실제 시각 확인(usage list가 viewport를 넘겨도 버튼이 보이는지)은 라이브 QA 몫.
+describe('StorageDeleteDialog — #2525 footer sticky', () => {
+  // base-ui Dialog는 document.body에 portal 렌더된다(container 안이 아님) — document에서 쿼리.
+  it('usage list가 길어도 footer가 스크롤 영역 밖(shrink-0)에 고정된다', () => {
+    renderDialog(makeAsset(50));
+    const deleteButton = Array.from(document.querySelectorAll('button'))
+      .find((b) => b.textContent === '삭제');
+    expect(deleteButton).toBeTruthy();
+    const footer = deleteButton?.closest('div.border-t');
+    expect(footer?.className).toContain('shrink-0');
+  });
+
+  it('body 영역이 자체 overflow-y-auto로 내부 스크롤한다(footer와 분리)', () => {
+    renderDialog(makeAsset(50));
+    const body = Array.from(document.querySelectorAll('div'))
+      .find((d) => d.className.includes('leading-[1.55]'));
+    expect(body?.className).toContain('overflow-y-auto');
+    expect(body?.className).toContain('min-h-0');
+    expect(body?.className).toContain('flex-1');
+  });
+
+  it('짧은 usage list 케이스도 회귀 없이 렌더된다(기존 동작 유지)', () => {
+    renderDialog(makeAsset(1));
+    const deleteButton = Array.from(document.querySelectorAll('button'))
+      .find((b) => b.textContent === '삭제');
+    expect(deleteButton).toBeTruthy();
+  });
+
+  it('usage 0건이면 impact 배너가 안 뜬다(기존 동작 유지)', () => {
+    renderDialog(makeAsset(0));
+    expect(document.body.textContent).not.toContain('곳에서 사용 중');
+  });
+});

--- a/apps/web/src/components/storage/storage-delete-dialog.tsx
+++ b/apps/web/src/components/storage/storage-delete-dialog.tsx
@@ -47,20 +47,20 @@ export function StorageDeleteDialog({ asset, open, onOpenChange, onDeleted }: St
       <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent
           showCloseButton={false}
-          className="w-[440px] max-w-[calc(100%-2rem)] gap-0 overflow-hidden rounded-xl p-0 sm:max-w-[440px]"
+          className="flex w-[440px] max-w-[calc(100%-2rem)] flex-col gap-0 overflow-hidden rounded-xl p-0 sm:max-w-[440px]"
         >
           {asset ? (
             <>
-              {/* Header */}
-              <div className="flex items-center gap-[9px] px-[18px] pb-[6px] pt-[18px] text-[15px] font-[650] text-foreground">
+              {/* Header — 고정(scroll 영역 밖) */}
+              <div className="flex shrink-0 items-center gap-[9px] px-[18px] pb-[6px] pt-[18px] text-[15px] font-[650] text-foreground">
                 <span className="grid size-[30px] shrink-0 place-items-center rounded-full bg-destructive/10 text-destructive">
                   <AlertTriangle className="size-[15px]" />
                 </span>
                 {t('deleteTitle')}
               </div>
 
-              {/* Body */}
-              <div className="px-[18px] pb-[14px] pt-[4px] text-[13px] leading-[1.55] text-muted-foreground">
+              {/* Body — usage list가 길면 이 영역만 내부 스크롤(footer는 항상 노출) */}
+              <div className="min-h-0 flex-1 overflow-y-auto px-[18px] pb-[14px] pt-[4px] text-[13px] leading-[1.55] text-muted-foreground">
                 {t.rich('deleteBody', {
                   name: asset.name,
                   b: (chunks) => <b className="font-semibold text-foreground">{chunks}</b>,
@@ -79,8 +79,8 @@ export function StorageDeleteDialog({ asset, open, onOpenChange, onDeleted }: St
                 ) : null}
               </div>
 
-              {/* Footer */}
-              <div className="flex justify-end gap-2 border-t border-border px-[18px] py-3">
+              {/* Footer — shrink-0로 스크롤 영역 밖에 고정, 항상 노출 */}
+              <div className="flex shrink-0 justify-end gap-2 border-t border-border px-[18px] py-3">
                 <DialogClose
                   render={
                     <Button variant="ghost" size="sm">


### PR DESCRIPTION
## 변경 사항
prod 에스컬레이션(산티아고 08-06) — `storage-delete-dialog.tsx`의 `DialogContent`가 `max-h-[calc(100dvh-2rem)]`+`overflow-y-auto` 한 블록인데, 로컬 `className`의 `overflow-hidden`이 `cn()`(twMerge)에 의해 그 `overflow-y-auto`를 덮어써 실제로는 **스크롤조차 되지 않고 클리핑**되는 상태였음 — "이 자산이 쓰이는 곳" usage list가 길면 삭제 CTA가 완전히 도달 불가했다.

- header/footer를 `shrink-0`로 스크롤 영역 밖에 고정
- body(usage list 포함)만 `flex-1 min-h-0 overflow-y-auto`로 내부 스크롤
- 짧은 usage 케이스·0건 케이스는 기존 동작 그대로(회귀 없음)

## 검증
- 신규 렌더테스트 4건(`storage-delete-dialog.test.tsx`) — footer `shrink-0` 클래스 계약, body `overflow-y-auto`/`min-h-0`/`flex-1` 계약, 짧은 리스트 회귀, 0건 케이스 회귀
- 뮤테이션 self-check: fix를 되돌리면 신규 테스트 2건이 정확히 RED(shrink-0/overflow-y-auto 클래스 부재 검출) → 원복 후 GREEN 재확認
- 게이트 전부 그린: `tsc --noEmit`(EXIT 0), `eslint`(EXIT 0, 무관 파일 warning 3건만), `vitest`(4/4 pass), `next build`(EXIT 0)

⚠️jsdom은 실제 CSS overflow/clipping을 계산하지 않아 "usage list가 viewport를 넘겨도 버튼이 실제로 보이는지"는 라이브 픽셀 확認이 필요 — 카디르 QA에서 긴 usage 케이스(양성대조) 실측 요청.

## Test plan
- [ ] 카디르 QA: dev 배포 後 실제로 usage 링크 다수(예: 20건+)인 자산 삭제 시도 → 삭제/취소 버튼이 스크롤 없이 항상 보이는지 라이브 확認
- [ ] 짧은 usage(1~2건)·0건 케이스 회귀 없는지 확認
- [ ] 모바일 폭에서도 CTA가 화면 밖으로 안 밀리는지 확認

Closes #2525

🤖 Generated with [Claude Code](https://claude.com/claude-code)