### PR TITLE
[SID:2526] Agent 설정 API Keys 권한 칩 overflow — flex-wrap + min-w-0 + max-width

### DIFF
--- a/apps/web/src/components/agents/agent-api-key-manager.test.tsx
+++ b/apps/web/src/components/agents/agent-api-key-manager.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { AgentApiKeyManager } from './agent-api-key-manager';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+const LONG_SCOPES = ['read', 'write', 'admin', 'stories', 'tasks', 'epics', 'sprints', 'memos', 'notifications', 'standups'];
+
+function apiKeyFixture(scope: string[]) {
+  return {
+    id: 'key-1',
+    key_prefix: 'sk_live_abcd1234',
+    created_at: '2026-08-01T00:00:00Z',
+    last_used_at: null,
+    revoked_at: null,
+    expires_at: null,
+    scope,
+  };
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// story #2526 — scope 개수가 늘면 권한 칩이 카드/화면 밖으로 overflow 되던 결함.
+// jsdom은 실제 overflow를 계산하지 않으므로, wrap/shrink 계약(flex-wrap·min-w-0·max-width)이
+// DOM 클래스로 고정돼 있는지를 검증한다. 실제 시각 회귀는 라이브 QA 몫.
+describe('AgentApiKeyManager — #2526 scope chip overflow', () => {
+  it('scope 다수(10개)일 때도 칩 행이 flex-wrap으로 감싸진다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api-key')) {
+        return new Response(JSON.stringify({ data: [apiKeyFixture(LONG_SCOPES)] }), { status: 200 });
+      }
+      return new Response('not found', { status: 404 });
+    }));
+
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages}>
+          <AgentApiKeyManager agentId="agent-1" agentName="테스트 에이전트" />
+        </NextIntlClientProvider>,
+      );
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    const adminChip = Array.from(document.querySelectorAll('span')).find((s) => s.textContent === 'admin');
+    expect(adminChip).toBeTruthy();
+    const chipRow = adminChip?.parentElement;
+    expect(chipRow?.className).toContain('flex-wrap');
+
+    const cardRow = chipRow?.closest('div.border.rounded-md');
+    const leftCol = chipRow?.closest('div.min-w-0');
+    expect(leftCol).toBeTruthy();
+    expect(leftCol?.className).toContain('flex-1');
+    expect(cardRow?.className).toContain('flex-wrap');
+  });
+
+  it('scope 텍스트가 길어도 칩 자체는 max-w-full + truncate로 잘린다(카드 밖 삐져나가지 않음)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api-key')) {
+        return new Response(JSON.stringify({ data: [apiKeyFixture(['a-very-long-scope-group-key-name-that-could-overflow'])] }), { status: 200 });
+      }
+      return new Response('not found', { status: 404 });
+    }));
+
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages}>
+          <AgentApiKeyManager agentId="agent-1" agentName="테스트 에이전트" />
+        </NextIntlClientProvider>,
+      );
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    const chip = Array.from(document.querySelectorAll('span'))
+      .find((s) => s.textContent === 'a-very-long-scope-group-key-name-that-could-overflow');
+    expect(chip).toBeTruthy();
+    expect(chip?.className).toContain('truncate');
+    expect(chip?.className).toContain('max-w-full');
+    expect(chip?.getAttribute('title')).toBe('a-very-long-scope-group-key-name-that-could-overflow');
+  });
+
+  it('scope 짧은(기존) 케이스도 회귀 없이 렌더된다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api-key')) {
+        return new Response(JSON.stringify({ data: [apiKeyFixture(['read', 'write'])] }), { status: 200 });
+      }
+      return new Response('not found', { status: 404 });
+    }));
+
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages}>
+          <AgentApiKeyManager agentId="agent-1" agentName="테스트 에이전트" />
+        </NextIntlClientProvider>,
+      );
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(Array.from(document.querySelectorAll('span')).some((s) => s.textContent === 'read')).toBe(true);
+    expect(Array.from(document.querySelectorAll('span')).some((s) => s.textContent === 'write')).toBe(true);
+  });
+});

--- a/apps/web/src/components/agents/agent-api-key-manager.tsx
+++ b/apps/web/src/components/agents/agent-api-key-manager.tsx
@@ -259,13 +259,19 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
           {apiKeys.map((key) => (
             <div
               key={key.id}
-              className="flex items-center justify-between p-3 border rounded-md"
+              className="flex flex-wrap items-center justify-between gap-2 p-3 border rounded-md"
             >
-              <div>
-                <div className="flex items-center gap-2">
-                  <p className="font-mono text-sm">{key.key_prefix}...</p>
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="font-mono text-sm shrink-0">{key.key_prefix}...</p>
                   {(key.scope ?? ['read', 'write']).map((s) => (
-                    <span key={s} className={`text-xs px-1.5 py-0.5 rounded font-medium ${s === 'admin' ? 'bg-orange-100 text-orange-700' : 'bg-muted text-muted-foreground'}`}>{s}</span>
+                    <span
+                      key={s}
+                      title={s}
+                      className={`max-w-full truncate rounded px-1.5 py-0.5 text-xs font-medium ${s === 'admin' ? 'bg-orange-100 text-orange-700' : 'bg-muted text-muted-foreground'}`}
+                    >
+                      {s}
+                    </span>
                   ))}
                 </div>
                 <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
## 변경 사항
prod 에스컬레이션(산티아고 08-06) — `agent-api-key-manager.tsx`의 scope 권한 칩 행이 `flex items-center gap-2`뿐이라 `flex-wrap`이 없고, 부모 열도 `min-w-0`/`flex-1`이 없어(flex 아이템 기본 `min-width:auto`) scope 개수가 늘면 카드·화면 밖으로 그대로 삐져나갔다.

- 카드 행 자체를 `flex-wrap`으로 — 좁은 폭에서 Revoke 버튼이 다음 줄로 자연스럽게 감싸짐
- 좌측 열(prefix+칩)에 `min-w-0 flex-1` — flex 아이템이 실제로 줄어들 수 있게
- 칩 행에 `flex-wrap` — scope 다수면 줄바꿈
- 칩 자체에 `max-w-full truncate` + `title` — 개별 scope 텍스트가 길어도 카드 밖으로 안 삐져나가고 hover로 전체 값 확인 가능

## 검증
- 신규 렌더테스트 3건(`agent-api-key-manager.test.tsx`) — scope 10개 wrap 계약, 긴 scope 텍스트 truncate+title 계약, 짧은 scope 회귀
- 뮤테이션 self-check: fix를 되돌리면 신규 테스트 2건이 정확히 RED(flex-wrap/truncate 클래스 부재 검출) → 원복 후 GREEN 재확認
- 게이트 전부 그린: `tsc --noEmit`(EXIT 0), `eslint`(EXIT 0, 무관 파일 warning 3건만), `vitest`(3/3 pass), `next build`(EXIT 0)

⚠️jsdom은 실제 CSS wrap/overflow를 계산하지 않아 실제 화면에서 칩이 줄바꿈되는지는 라이브 확認 필요 — 카디르 QA에서 scope 다수 케이스(양성대조)+모바일 폭 실측 요청.

## Test plan
- [ ] 카디르 QA: dev 배포 後 scope 여러 개(예: 5개+) 발급된 에이전트에서 칩이 카드 폭 안에서 줄바꿈되는지 확認
- [ ] 모바일 폭에서 카드 자체가 가로 overflow 없이 Revoke 버튼이 자연스럽게 배치되는지 확認
- [ ] scope 1~2개(기존) 케이스 회귀 없는지 확認

Closes #2526

🤖 Generated with [Claude Code](https://claude.com/claude-code)