### PR TITLE
fix(#2527): waiting_on_others 쿼럼 승인자 겸 assignee 오노출 수정

### DIFF
--- a/backend/app/routers/command_center.py
+++ b/backend/app/routers/command_center.py
@@ -270,6 +270,25 @@ async def my_actions(
     # 「나의 것」 정의(AC2 명시 요구): 지금은 **담당(assignee_id)** 하나만 — 결재자·멘션·claim
     # 은 포함 안 함(추측으로 넓히지 않는다, 대조표가 곧 명세라는 PO 지시 그대로).
     _WaitingStory = aliased(Story)
+    # story #2527(까심 QA 확認 대기, PO 오르테가 AC 락 2026-08-08): S9 쿼럼 gate(한 approval_group_id에
+    # approver row N개)에서 member_id 가 assignee 이면서 동시에 그 gate의 pending blocking 승인자
+    # 중 한 명이면, 위 `approver_member_id != member_id` 필터는 «내» row만 걸러낼 뿐 «다른»
+    # 승인자 row는 그대로 남아 story가 waiting_on_others로 잡혔다(내 승인 행동이 실제로 남아
+    # 있는데도 "행동 없음"으로 오분류 — 그 행동은 이미 위 gate_approval 큐에 별도로 뜬다).
+    # NOT EXISTS로 "이 step_run에 내 pending blocking 승인 row가 하나라도 있으면" 그 story
+    # 자체를 이 버킷에서 제외한다(단일승인자·비쿼럼 케이스는 기존에도 애초에 이 row가 없어 무회귀).
+    # ⚠️outer join이 이미 (별칭 없는) WorkflowLineStepApproval을 FROM에 물고 있어, 이 서브쿼리가
+    # 같은 클래스를 맨 클래스 그대로 참조하면 SQLAlchemy 자동상관이 그것까지 상관관계로 착각해
+    # FROM 자체를 통째로 비워버린다(`no FROM clauses due to auto-correlation`) — 별도 alias로
+    # "이건 다른 row를 찾는 별개 서브쿼리"임을 명시해야 한다.
+    _MyApproval = aliased(WorkflowLineStepApproval)
+    _my_pending_approval_on_step = select(_MyApproval.id).where(
+        _MyApproval.org_id == org_id,
+        _MyApproval.step_run_id == WorkflowLineStepRun.id,
+        _MyApproval.approver_member_id == member_id,
+        _MyApproval.status == "pending",
+        _MyApproval.blocking.is_(True),
+    )
     waiting_rows = (
         await session.execute(
             select(
@@ -297,6 +316,7 @@ async def my_actions(
                 _WaitingStory.assignee_id == member_id,
                 _WaitingStory.deleted_at.is_(None),
                 WorkflowLineStepApproval.approver_member_id != member_id,
+                ~exists(_my_pending_approval_on_step),
             )
             .order_by(_WaitingStory.updated_at.desc())
             .limit(100)

--- a/backend/tests/test_2288_command_center_gate_type_waiting_realdb.py
+++ b/backend/tests/test_2288_command_center_gate_type_waiting_realdb.py
@@ -241,6 +241,62 @@ async def test_waiting_on_others_absent_when_not_assignee_realdb():
         await engine.dispose()
 
 
+async def test_waiting_on_others_absent_when_i_am_quorum_approver_among_others_realdb():
+    """story #2527(까심 QA 확認 대기, PO 오르테가 AC 락 2026-08-08): 내가 assignee 이면서
+    동시에 쿼럼(멀티어프루버) gate의 pending blocking 승인자 중 한 명이면 — 다른 승인자의
+    pending row가 waiting_on_others를 오노출시키면 안 된다(내 승인 행동이 실제로 남아있으므로
+    gate_approval로만 떠야 한다). quorum_policy.type(all/any/count) 무관하게 동일해야 한다 —
+    개별 approver row의 pending 여부는 quorum 집계 타입과 무관한 축이기 때문.
+
+    ⛔뮤테이션 자가검증(2026-08-08): command_center.py의 `~exists(_my_pending_approval_on_step)`
+    가드를 실제로 지우고 이 테스트를 돌려 RED 確認함(waiting_on_others에 이 story가 새는 것을
+    직접 관측 — 재현조건 그대로) → 복원 → GREEN 재확認."""
+    from app.main import app
+
+    for qtype in ("all", "any", "count"):
+        engine, Session = await _session_factory()
+        try:
+            async with Session() as s:
+                org = await _make_org(s)
+                project = await _make_project(s, org.id)
+                caller_id, caller_user_id = await _make_member(s, org.id, project.id)
+                other_id, _ = await _make_member(s, org.id, project.id)
+                story = await _make_story(s, org.id, project.id, title=f"QuorumIAmApprover-{qtype}")
+                story.assignee_id = caller_id
+                await s.commit()
+                run = await _make_step_run(s, org.id, project.id, entity_type="story", entity_id=story.id)
+                run.quorum_policy = {"type": qtype, "count": 2 if qtype == "count" else None}
+                await s.commit()
+                group_id = uuid.uuid4()
+                await _make_approval(
+                    s, org.id, project.id, step_run_id=run.id, approver_member_id=caller_id,
+                    approval_group_id=group_id,
+                )
+                await _make_approval(
+                    s, org.id, project.id, step_run_id=run.id, approver_member_id=other_id,
+                    approval_group_id=group_id,
+                )
+
+            await _setup_app_human(app, Session, caller_user_id, org.id)
+            client = _client_for(app)
+            try:
+                resp = await client.get("/api/v2/command-center/my-actions")
+                assert resp.status_code == 200, resp.text
+                items = resp.json()["action_queue"]["items"]
+                assert not any(
+                    i["type"] == "waiting_on_others" and i["context"]["story_id"] == str(story.id)
+                    for i in items
+                ), f"quorum type={qtype}: waiting_on_others falsely surfaced (story #2527 regression)"
+                assert any(i["type"] == "gate_approval" for i in items), (
+                    f"quorum type={qtype}: gate_approval missing — my own pending approval should still surface there"
+                )
+            finally:
+                await client.aclose()
+        finally:
+            app.dependency_overrides.clear()
+            await engine.dispose()
+
+
 async def test_waiting_on_others_dedupes_multi_approver_quorum_realdb():
     from app.main import app
 


### PR DESCRIPTION
## Summary
- 산티아고 08-06 prod 에스컬레이션(prod Sprintable #47) 후속 그라운딩에서 확인된 BE 분류 버그 수정.
- `command_center.py` `my_actions()`의 `waiting_on_others` 절이 row 단위 필터(`approver_member_id != member_id`)라, 내가 assignee이면서 동시에 그 story의 pending blocking 쿼럼(S9 멀티어프루버, `approval_group_id`) 승인자 중 한 명이면 다른 승인자의 pending row가 남아 story가 "행동 없음"으로 오분류됐다. 내 승인 행동은 이미 `gate_approval` 큐에 별도로 뜨는데도.
- `WorkflowLineStepRun.id`에 correlate하는 `NOT EXISTS` 가드(`_MyApproval` alias로 outer join과 분리)를 추가해, 내가 그 step_run의 pending blocking 승인자로 하나라도 포함돼 있으면 `waiting_on_others`에서 제외.

## AC (story #2527)
- [x] `waiting_on_others` 쿼리에 NOT EXISTS 가드 추가.
- [x] 양성대조: 재현조건(assign+쿼럼 승인자 포함 pending)에서 가드 前 RED → 가드 後 GREEN 직접 실증(로컬 alembic-migrated 실PG, 가드 라인 제거→재추가 사이클 2회 반복 확인).
- [x] 회귀 0: 단일 승인자·비assignee·비approver 케이스 — 기존 realdb 스위트(`test_2288_command_center_gate_type_waiting_realdb.py`) 전체 + mock 스위트(`test_command_center.py`) 30개 전부 GREEN.
- [x] 쿼럼 타입 all/any/count 커버 — 신규 테스트가 3개 타입 전부 파라미터화. 가드는 개별 approver row의 pending 여부만 보므로 `quorum_policy.type`(집계 축)과 무관하게 동일하게 동작함을 확인(known-gap 아님, 설계상 orthogonal).

## Test plan
- [x] `pytest tests/test_2288_command_center_gate_type_waiting_realdb.py tests/test_command_center.py` — 30 passed (로컬 alembic-migrated PG16+pgvector, 신선 disposable 컨테이너)
- [x] 뮤테이션 셀프체크: 가드 라인 제거 → 신규 테스트 RED 확인 → 복원 → GREEN 재확인 (2회, alias 버그 수정 전후 각각)
- [x] ruff check: 변경 라인엔 신규 이슈 0 (파일 기존 이슈는 무관 pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)