### PR TITLE
[SID:2528] 스토리 상세 패널 본문 스크롤바 가시성 — .scrollbar-visible 적용

### DIFF
--- a/apps/web/src/components/kanban/story-detail-panel.test.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.test.tsx
@@ -100,3 +100,28 @@ describe('StoryDetailPanel — overlayPosition (story #2354, 지도 위에 겹�
     expect(container.textContent).toContain('겹침 패널 시험용 스토리');
   });
 });
+
+// story #2528 — 전역 스크롤바 숨김(#2165) 하에 상세패널 본문 스크롤 컨테이너가 예외 목록에
+// 없어 스크롤바가 안 보이던 결함. globals.css 범용 옵트인 `.scrollbar-visible` 클래스 적용
+// 계약을 고정한다. jsdom은 실 스크롤바 렌더를 계산하지 않으므로 실제 가시성은 라이브 QA 몫
+// (스토리 AC의 "라이브 픽셀 양성대조"가 결정적 게이트).
+describe('StoryDetailPanel — #2528 본문 스크롤바 가시성', () => {
+  it('본문 overflow-y-auto 컨테이너에 scrollbar-visible 클래스가 적용된다', async () => {
+    await act(async () => {
+      root.render(wrap(<StoryDetailPanel story={makeStory()} tasks={[]} onClose={() => {}} />));
+    });
+    const body = Array.from(container.querySelectorAll('div')).find((d) => d.className.includes('overflow-y-auto'));
+    expect(body).toBeTruthy();
+    expect(body?.className).toContain('scrollbar-visible');
+  });
+
+  it('겹침 팝오버 모드에서도 본문 스크롤 컨테이너의 클래스는 회귀 없이 유지된다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <StoryDetailPanel story={makeStory()} tasks={[]} onClose={() => {}} overlayPosition={{ top: 0, heightPx: 300 }} />,
+      ));
+    });
+    const body = Array.from(container.querySelectorAll('div')).find((d) => d.className.includes('overflow-y-auto'));
+    expect(body?.className).toContain('scrollbar-visible');
+  });
+});

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -1242,7 +1242,10 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
             <button type="button" onClick={onClose} className="rounded-md border border-border px-3 py-2 text-muted-foreground transition hover:text-foreground hover:bg-muted/50">✕</button>
           </div>
         </div>
-        <div className="flex-1 overflow-y-auto p-5">
+        {/* story #2528 — 전역 스크롤바 숨김(#2165) 하에선 스크롤은 되나 바가 안 보여 하단
+            (완료조건·댓글)을 인지할 신호가 없었다. .scrollbar-visible은 globals.css의 범용
+            옵트인(신규 CSS 아님) — .tableWrapper(#2203)가 이미 라이브 양성으로 검증한 패턴. */}
+        <div className="scrollbar-visible flex-1 overflow-y-auto p-5">
           <div className="space-y-5">
             {/* E-UI-DAEGBYEON P0 — Workcell 4층 데뷔(최소 실화면 배선, story `e5310d1b`).
                 Evidence는 null(정직한 "아직 증거 없음" — EvidenceSection/StoryMergeGate 실


### PR DESCRIPTION
## 변경 사항
prod 에스컬레이션(산티아고 08-06) — `story-detail-panel.tsx`의 본문 `overflow-y-auto` 컨테이너가 전역 스크롤바 숨김(#2165) 하에서 `.scrollbar-visible` 예외 목록에 없어, 내용이 길어도(완료조건·댓글 등) 스크롤바가 안 보여 "더 있음" 신호가 없었다.

`globals.css`에 이미 있는 범용 옵트인 클래스 `.scrollbar-visible`(`.tableWrapper`·`.doc-renderer pre`와 공유 메커니즘, `.tableWrapper`는 #2203에서 라이브 양성 검증 완료)을 그대로 적용 — 신규 CSS 없음.

⚠️ **#2214(코드블록·ProseMirror)는 건드리지 않았다** — 그 스토리는 스코프가 닫혀있고(AC1 "이 판정 다시 열지 않는다"), 사람 실 Chrome 재확認 대기 中인 미해결 렌더 이슈(computed style은 맞는데 스크롤바가 실제로 안 보임)가 있다. 본 PR은 그 미해결 이슈와 별개로, 구조적으로 `.tableWrapper`에 더 가까운(일반 div, ProseMirror 아님) `story-detail-panel`에 이미 검증된 패턴을 적용한다.

## 검증
- 신규 렌더테스트 2건(기존 3건 + 신규 2건 = 5/5 pass) — 기본 드로어·겹침 팝오버 두 렌더 경로 모두 `scrollbar-visible` 클래스 적용 계약 고정
- 뮤테이션 self-check: fix를 되돌리면 신규 테스트 2건이 정확히 RED(`scrollbar-visible` 클래스 부재 검출) → 원복 후 GREEN 재확認
- 게이트 전부 그린: `tsc --noEmit`(EXIT 0), `eslint`(EXIT 0, 무관 파일 warning 3건만), `vitest`(5/5 pass), `next build`(EXIT 0)

## ⚠️ 핵심 게이트 — 라이브 픽셀 양성대조 (jsdom으로 검증 불가)
이 스토리의 AC는 이것을 "결정적" 게이트로 명시한다:
1. dev 배포 後 상세패널에 긴 내용(완료조건·댓글 다수)을 넣고, 적용 前에는 스크롤바가 안 보이고 **적용 後에는 실제로 보이는지** 확認
2. **⚠️만약 적용 後에도 안 보이면 이건 #2214와 동종 렌더 미스터리(computed style은 맞는데 시각적으로 안 보임)다 — 억지로 done 처리하지 말고 멈춰서 에스컬레이션한다.**

## Test plan
- [ ] 카디르 QA: dev 배포 後 완료조건·댓글이 많은 스토리를 열어 상세패널 스크롤바가 실제로 보이는지 라이브 확認(양성대조: 적용 前/後 스크린샷 대조)
- [ ] 짧은 내용 케이스 회귀 없는지 확認
- [ ] 겹침 팝오버 모드(`overlayPosition`)에서도 정상 동작하는지 확認
- [ ] ⚠️만약 스크롤바가 여전히 안 보이면 — done 처리 금지, #2214 동종 이슈로 에스컬레이션

Closes #2528

🤖 Generated with [Claude Code](https://claude.com/claude-code)