### PR TITLE
docs(connect-guide): Claude Code 실제 연결 절차 — 공개 어댑터 경로 채움

### DIFF
--- a/apps/web/public/connect-guide.txt
+++ b/apps/web/public/connect-guide.txt
@@ -88,9 +88,28 @@ MCP는 «에이전트가 Sprintable을 부르는 길»입니다. 반대 방향 �
 
 채용 완료 화면의 ②「깨우기」 칸에도 같은 내용이 런타임별로 표시됩니다.
 
-지금 이 어댑터들을 받을 수 있는 경로는 아직 제공하지 않습니다. 위 표의 경로는
-저장소 안의 위치이고, 내려받는 길은 화면·문서 어디에도 없습니다 — 이 단계는 지금
-끝낼 수 없습니다.
+### Claude Code — fakechat 채널 어댑터 (공개)
+
+Claude Code는 Anthropic 공인 `fakechat` 채널 플러그인 슬롯에 Sprintable 어댑터를
+얹어 실시간 세션 주입을 받습니다. 어댑터는 공개돼 있습니다 —
+**https://github.com/moonklabs/sprintable-claude-connector**
+
+1. 공인 fakechat 설치: `/plugin install fakechat@claude-plugins-official`
+2. 설치 슬롯의 `server.ts`를 위 저장소 것으로 교체하고 `inject-allowlist.ts`를
+   추가합니다. 공인 슬롯의 `plugin.json`·`package.json`은 그대로 둡니다 — 원본 실행
+   스크립트가 교체된 어댑터를 그대로 구동합니다.
+3. 자격증명과 함께 실행:
+
+```bash
+export AGENT_API_KEY=<0단계에서 발급한 키>
+claude --channels plugin:fakechat@claude-plugins-official
+```
+
+저장소 README에 단계별 상세와 성공 확認법이 있습니다. 이것이 Sprintable 팀
+에이전트가 실제로 붙는 방법과 동일합니다.
+
+> 그 밖의 채널 플러그인 런타임(Hermes·OpenClaw·OpenCode)의 공개 어댑터는 준비
+> 중이며, 준비되는 대로 이 자리에 링크가 붙습니다.
 
 ---
 


### PR DESCRIPTION
## 무엇을
connect-guide §2에 Claude Code 실제 연결 3단계를 **공개 어댑터 경로와 함께** 채운다.

## 왜
#2894가 3단계를 담았으나 "어댑터 받을 경로 없음 — 이 단계는 끝낼 수 없음"이라 완수 불가였고, revert(#2921)로 정직본을 prod에 복원했다. 이제 어댑터를 실제로 공개했으므로 «경로 있는 완성본»을 넣는다.

- 공개 어댑터: **https://github.com/moonklabs/sprintable-claude-connector** (server.ts·inject-allowlist.ts·README·MIT, 하드코딩 secret 0)
- 절차: 공인 `fakechat` 설치 → 슬롯의 server.ts를 공개 어댑터로 교체 → `AGENT_API_KEY` + `claude --channels plugin:fakechat@claude-plugins-official`
- **Sprintable 팀 에이전트가 실제로 붙는 방법과 동일** (launch 스크립트 실측 기반)
- 다른 채널 플러그인 런타임(Hermes·OpenClaw·OpenCode)은 "준비 중" 정직 표기 유지

## 범위
- `apps/web/public/connect-guide.txt` 1파일. `끝낼 수 없습니다` 제거·CC 절차 추가.

## 계획
dev 검증 → prod. (prod는 현재 revert된 131줄 정직본 서빙 중이라, 이 완성본이 dev 검증 후 별도 릴리스)