### PR TITLE
release(P0): send_message 메시지 유실 fix prod 반영 (#2926 develop→main cherry-pick)

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -2028,11 +2028,17 @@ async def send_message(
             await db.flush()
 
     # AC10: Discord 수신자 파악 → SSE dispatch에서 제외 (동일 db 세션, flush 완료 상태)
+    # ⛔P0(message-loss, 2026-08-08 diagnosed): 이 블록이 SAVEPOINT 없이 bare except였을 때는
+    # 실패 시 Postgres 트랜잭션이 ABORTED로 남고, 그 뒤 최종 commit()이 예외 없이 조용히
+    # ROLLBACK 처리되어(asyncpg 실측 확認) msg insert까지 통째로 사라졌다 — "성공 id 반환하는데
+    # 저장 안 됨" 증상의 근본. `_dispatch_conversation_event` 호출부와 동형으로 begin_nested()
+    # SAVEPOINT 격리 — 여기서 실패해도 이 nested만 롤백되고 바깥 트랜잭션(msg insert)은 안전.
     discord_exclude_ids: set[uuid.UUID] = set()
     try:
-        from app.services.channel_router import ChannelRouterError, route_message as _route
-        decisions = await _route(msg.id, db)
-        discord_exclude_ids = {d.member_id for d in decisions if d.channel == "discord"}
+        async with db.begin_nested():
+            from app.services.channel_router import ChannelRouterError, route_message as _route
+            decisions = await _route(msg.id, db)
+            discord_exclude_ids = {d.member_id for d in decisions if d.channel == "discord"}
     except Exception:
         logger.warning("ChannelRouter pre-check failed message_id=%s — no SSE exclusion", msg.id)
 
@@ -2047,11 +2053,14 @@ async def send_message(
     # 이 조회 하나가 실패했다고 메시지 전송 자체가 막히면 안 된다 — 아래 채널라우터 pre-check·
     # 웹훅 타겟·멘션/알림 dispatch가 전부 같은 철학(best-effort, try/except+warning)이라 이
     # 조회도 그 옆에 맞춘다(실패 시 fail-open=차단 미반영, 메시지 전송은 계속).
+    # P0 message-loss savepoint 격리(위 discord_exclude_ids 블록과 동일 근거) — 이 SELECT 자체는
+    # 저위험이나 실패 시 트랜잭션을 poison하지 않도록 통일.
     user_blocker_ids: set[uuid.UUID] = set()
     try:
-        user_blocker_ids = set((await db.execute(
-            select(UserBlock.blocker_member_id).where(UserBlock.blocked_member_id == sender.id)
-        )).scalars().all())
+        async with db.begin_nested():
+            user_blocker_ids = set((await db.execute(
+                select(UserBlock.blocker_member_id).where(UserBlock.blocked_member_id == sender.id)
+            )).scalars().all())
     except Exception:
         logger.warning("user_blocker_ids lookup failed message_id=%s — fail-open(no exclusion)", msg.id, exc_info=True)
 
@@ -2063,15 +2072,17 @@ async def send_message(
     webhook_targets: list = []
     if conv.project_id:
         try:
-            webhook_targets = await resolve_conversation_webhook_targets(
-                db,
-                conversation_id=conversation_id,
-                org_id=org_id,
-                project_id=conv.project_id,
-                sender_id=sender.id,
-                mentioned_ids=list(msg.mentioned_ids) if msg.mentioned_ids else None,
-                blocker_member_ids=user_blocker_ids,
-            )
+            # P0 message-loss savepoint 격리 — 위 blocks와 동일 근거.
+            async with db.begin_nested():
+                webhook_targets = await resolve_conversation_webhook_targets(
+                    db,
+                    conversation_id=conversation_id,
+                    org_id=org_id,
+                    project_id=conv.project_id,
+                    sender_id=sender.id,
+                    mentioned_ids=list(msg.mentioned_ids) if msg.mentioned_ids else None,
+                    blocker_member_ids=user_blocker_ids,
+                )
         except Exception:
             logger.warning(
                 "webhook target resolve failed conversation_id=%s — SSE 유지(skip 0·fail-open)",
@@ -2119,24 +2130,27 @@ async def send_message(
         # best-effort.
         if mention_targets:
             try:
-                human_mention_rows = (await db.execute(
-                    select(TeamMember.id).where(
-                        TeamMember.id.in_(mention_targets), TeamMember.type == "human",
-                    )
-                )).all()
-                human_mention_targets = [r[0] for r in human_mention_rows]
-                if human_mention_targets:
-                    from app.services.notification_dispatch import dispatch_notification
-                    await dispatch_notification(
-                        db, org_id=org_id, event_type="conversation.mention",
-                        target_member_ids=human_mention_targets,
-                        title=f"{sender.name}님이 회원님을 멘션했습니다",
-                        body=(msg.content or "")[:200],
-                        reference_type="conversation", reference_id=conversation_id,
-                        source_project_id=conv.project_id,
-                        # story #2460(§6 봉합②): 개인 webhook·Expo push 실배달을 요청 트랜잭션 밖으로.
-                        via_outbox=True,
-                    )
+                # P0 message-loss savepoint 격리 — dispatch_notification 이 실제 write(outbox)를
+                # 하는 유력 용의자 지점(위 blocks와 동일 근거).
+                async with db.begin_nested():
+                    human_mention_rows = (await db.execute(
+                        select(TeamMember.id).where(
+                            TeamMember.id.in_(mention_targets), TeamMember.type == "human",
+                        )
+                    )).all()
+                    human_mention_targets = [r[0] for r in human_mention_rows]
+                    if human_mention_targets:
+                        from app.services.notification_dispatch import dispatch_notification
+                        await dispatch_notification(
+                            db, org_id=org_id, event_type="conversation.mention",
+                            target_member_ids=human_mention_targets,
+                            title=f"{sender.name}님이 회원님을 멘션했습니다",
+                            body=(msg.content or "")[:200],
+                            reference_type="conversation", reference_id=conversation_id,
+                            source_project_id=conv.project_id,
+                            # story #2460(§6 봉합②): 개인 webhook·Expo push 실배달을 요청 트랜잭션 밖으로.
+                            via_outbox=True,
+                        )
             except Exception:
                 logger.warning(
                     "conversation.mention notification failed conversation_id=%s", conversation_id, exc_info=True,
@@ -2148,33 +2162,37 @@ async def send_message(
     # 이미 conversation.mention으로 알림 받은 대상은 제외(중복 push 방지 — 멘션이 더 구체적).
     # best-effort.
     try:
-        participant_rows = (await db.execute(
-            select(ConversationParticipant.member_id)
-            .where(ConversationParticipant.conversation_id == conversation_id)
-        )).all()
-        candidate_targets = (
-            {r[0] for r in participant_rows}
-            - {sender.id} - discord_exclude_ids - blocked_agent_ids - user_blocker_ids - set(msg.mentioned_ids or [])
-        )
-        if candidate_targets:
-            human_message_rows = (await db.execute(
-                select(TeamMember.id).where(
-                    TeamMember.id.in_(candidate_targets), TeamMember.type == "human",
-                )
+        # P0 message-loss savepoint 격리 — dispatch_notification 이 실제 write(outbox)를
+        # 하는 유력 용의자 지점(위 blocks와 동일 근거). 이 블록이 4곳 중 처음엔 빠져 있었다 —
+        # PR 셀프게이트 뮤테이션 체크(테스트 파일 참조) 중 발견해 즉시 보강.
+        async with db.begin_nested():
+            participant_rows = (await db.execute(
+                select(ConversationParticipant.member_id)
+                .where(ConversationParticipant.conversation_id == conversation_id)
             )).all()
-            message_targets = [r[0] for r in human_message_rows]
-            if message_targets:
-                from app.services.notification_dispatch import dispatch_notification
-                await dispatch_notification(
-                    db, org_id=org_id, event_type="conversation.message",
-                    target_member_ids=message_targets,
-                    title=f"{sender.name}님의 새 메시지",
-                    body=(msg.content or "")[:200],
-                    reference_type="conversation", reference_id=conversation_id,
-                    source_project_id=conv.project_id,
-                    # story #2460(§6 봉합②): 개인 webhook·Expo push 실배달을 요청 트랜잭션 밖으로.
-                    via_outbox=True,
-                )
+            candidate_targets = (
+                {r[0] for r in participant_rows}
+                - {sender.id} - discord_exclude_ids - blocked_agent_ids - user_blocker_ids - set(msg.mentioned_ids or [])
+            )
+            if candidate_targets:
+                human_message_rows = (await db.execute(
+                    select(TeamMember.id).where(
+                        TeamMember.id.in_(candidate_targets), TeamMember.type == "human",
+                    )
+                )).all()
+                message_targets = [r[0] for r in human_message_rows]
+                if message_targets:
+                    from app.services.notification_dispatch import dispatch_notification
+                    await dispatch_notification(
+                        db, org_id=org_id, event_type="conversation.message",
+                        target_member_ids=message_targets,
+                        title=f"{sender.name}님의 새 메시지",
+                        body=(msg.content or "")[:200],
+                        reference_type="conversation", reference_id=conversation_id,
+                        source_project_id=conv.project_id,
+                        # story #2460(§6 봉합②): 개인 webhook·Expo push 실배달을 요청 트랜잭션 밖으로.
+                        via_outbox=True,
+                    )
     except Exception:
         logger.warning("conversation.message notification failed conversation_id=%s", conversation_id, exc_info=True)
 

--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -262,243 +262,251 @@ async def dispatch_notification(
         return
 
     try:
-        # notification_settings 조회 (해당 member + event_type + in_app)
-        settings_result = await db.execute(
-            select(NotificationSetting.member_id, NotificationSetting.enabled).where(
-                NotificationSetting.org_id == org_id,
-                NotificationSetting.member_id.in_(target_member_ids),
-                NotificationSetting.event_type == event_type,
-                NotificationSetting.channel == "in_app",
-            )
-        )
-        settings = {row.member_id: row.enabled for row in settings_result.all()}
-
-        # 설정 없으면 기본 enabled → enabled인 member만 필터
-        enabled_member_ids = [
-            mid for mid in target_member_ids
-            if settings.get(mid, True)
-        ]
-
-        if not enabled_member_ids:
-            return
-
-        # 활성 webhook_configs가 있는 멤버 집합 — 웹훅 채널로 전달되므로 내장 알림 스킵.
-        # E-EVENT-1CONFIG: 메시지 경로 SSE-skip과 공용 SSOT(active_webhook_member_ids) —
-        # member-bound(project-독립) 활성 webhook 보유 멤버. fail-open(조회 실패=빈 집합).
-        webhook_member_ids = await active_webhook_member_ids(
-            db, org_id, enabled_member_ids
-        )
-        # story 75570ab8: mute+webhook 동시보유 재판정 — active_webhook_member_ids는 mute를
-        # 모른다. 그래서 muted 에이전트가 "webhook이 커버한다"고 오판돼 Event insert도 스킵되고,
-        # 뒤이어 _deliver_personal_webhooks 자체 mute 체크로 webhook도 스킵돼 **총 무전달**이었다
-        # (그라운딩 0f428e1e 때 확인한 dispatch_notification 경로 지식 재사용). mute의 옳은
-        # 의미론 = "능동 push(webhook)만 끔" — 수동 backlog(Event/poll_events로 나중에 발견 가능)
-        # 까지 지우면 안 됨(webhook_targeting.py 자체가 명시한 "silent loss 방지" 설계 철학과
-        # 정합). 따라서 muted 멤버는 webhook-covered 취급에서 제외해 Event insert 경로로 폴백.
-        muted_member_ids = await _query_muted_member_ids(db, list(webhook_member_ids))
-        event_skip_member_ids = webhook_member_ids - muted_member_ids
-
-        # BUG-2 수정: user_id.isnot(None) 필터 제거 — agent는 user_id=NULL이므로 제외됐던 문제
-        # type 및 project_id도 함께 조회
-        members_result = await db.execute(
-            select(TeamMember.id, TeamMember.user_id, TeamMember.type, TeamMember.project_id).where(
-                TeamMember.id.in_(enabled_member_ids),
-                TeamMember.org_id == org_id,
-            )
-        )
-        members = list(members_result.all())
-
-        # E-MEMBER-SSOT AC2-2: grant-only 휴먼(team_member 없음)은 org_member로 해소해
-        # in-app Notification 누락(silent drop) 방지. org_member는 project 스코프가 없으므로
-        # human Notification만 생성(Event는 project_id 필요 → skip). Notification은 user_id
-        # 기반이고 FK가 없어 org_member.id 사용에 제약 없음.
-        matched_ids = {m.id for m in members}
-        missing_ids = [mid for mid in enabled_member_ids if mid not in matched_ids]
-        if missing_ids:
-            from types import SimpleNamespace
-
-            from app.models.project import OrgMember
-            om_result = await db.execute(
-                select(OrgMember.id, OrgMember.user_id).where(
-                    OrgMember.id.in_(missing_ids),
-                    OrgMember.org_id == org_id,
-                    OrgMember.deleted_at.is_(None),
+        # P0(message-loss class fix, 2026-08-08): 이 함수 전체를 SAVEPOINT로 감싼다 — 이전엔
+        # 이 try 가 caller의 ambient 트랜잭션에서 그대로 도는데, agent Event insert(db.add) 등
+        # 일부 write가 개별 begin_nested 없이 실행되다 실패하면 Postgres 트랜잭션이 ABORTED로
+        # 남고, 그 뒤 caller의 최종 commit()이 예외 없이 조용히 ROLLBACK 처리되어(asyncpg 실측
+        # 확認) caller가 방금 flush한 write(예: conversations.py send_message의 메시지 insert)
+        # 까지 통째로 사라졌다 — "성공 응답인데 저장 안 됨" 클래스의 근본. 14+ 콜사이트 전체를
+        # 한 번에 보호하는 게 개별 콜사이트를 매번 감싸는 것보다 근본적이다(클래스를 닫는다).
+        async with db.begin_nested():
+            # notification_settings 조회 (해당 member + event_type + in_app)
+            settings_result = await db.execute(
+                select(NotificationSetting.member_id, NotificationSetting.enabled).where(
+                    NotificationSetting.org_id == org_id,
+                    NotificationSetting.member_id.in_(target_member_ids),
+                    NotificationSetting.event_type == event_type,
+                    NotificationSetting.channel == "in_app",
                 )
             )
-            for om in om_result.all():
-                members.append(
-                    SimpleNamespace(id=om.id, user_id=om.user_id, type="human", project_id=None)
+            settings = {row.member_id: row.enabled for row in settings_result.all()}
+
+            # 설정 없으면 기본 enabled → enabled인 member만 필터
+            enabled_member_ids = [
+                mid for mid in target_member_ids
+                if settings.get(mid, True)
+            ]
+
+            if not enabled_member_ids:
+                return
+
+            # 활성 webhook_configs가 있는 멤버 집합 — 웹훅 채널로 전달되므로 내장 알림 스킵.
+            # E-EVENT-1CONFIG: 메시지 경로 SSE-skip과 공용 SSOT(active_webhook_member_ids) —
+            # member-bound(project-독립) 활성 webhook 보유 멤버. fail-open(조회 실패=빈 집합).
+            webhook_member_ids = await active_webhook_member_ids(
+                db, org_id, enabled_member_ids
+            )
+            # story 75570ab8: mute+webhook 동시보유 재판정 — active_webhook_member_ids는 mute를
+            # 모른다. 그래서 muted 에이전트가 "webhook이 커버한다"고 오판돼 Event insert도 스킵되고,
+            # 뒤이어 _deliver_personal_webhooks 자체 mute 체크로 webhook도 스킵돼 **총 무전달**이었다
+            # (그라운딩 0f428e1e 때 확인한 dispatch_notification 경로 지식 재사용). mute의 옳은
+            # 의미론 = "능동 push(webhook)만 끔" — 수동 backlog(Event/poll_events로 나중에 발견 가능)
+            # 까지 지우면 안 됨(webhook_targeting.py 자체가 명시한 "silent loss 방지" 설계 철학과
+            # 정합). 따라서 muted 멤버는 webhook-covered 취급에서 제외해 Event insert 경로로 폴백.
+            muted_member_ids = await _query_muted_member_ids(db, list(webhook_member_ids))
+            event_skip_member_ids = webhook_member_ids - muted_member_ids
+
+            # BUG-2 수정: user_id.isnot(None) 필터 제거 — agent는 user_id=NULL이므로 제외됐던 문제
+            # type 및 project_id도 함께 조회
+            members_result = await db.execute(
+                select(TeamMember.id, TeamMember.user_id, TeamMember.type, TeamMember.project_id).where(
+                    TeamMember.id.in_(enabled_member_ids),
+                    TeamMember.org_id == org_id,
                 )
+            )
+            members = list(members_result.all())
 
-        # 회귀 버그 fix: team_members는 0088 이후 projection VIEW라 멤버당 **프로젝트별 1행**(동일 id)을
-        # 반환한다. dedup 없이 루프하면 멀티프로젝트 멤버에게 알림이 **프로젝트 수만큼 중복 생성**됨
-        # (Story Assign 시 Inbox 알림 3개 증상 = 담당자가 3개 프로젝트 소속). member id로 dedup해
-        # 멤버당 1 알림/이벤트만 생성. (view-cutover multi-row 트랩)
-        # source_project_id 주어지면 그 프로젝트 행을 우선(멀티프로젝트 에이전트 = 트리거 프로젝트로
-        # 정확 라우팅). 미지정 시 첫 행(기존 거동). 어느 경우든 member당 정확히 1행 → 휴먼 N-알림 무회귀.
-        _picked: dict[uuid.UUID, object] = {}
-        for _m in members:
-            cur = _picked.get(_m.id)
-            if cur is None:
-                _picked[_m.id] = _m
-            elif source_project_id is not None and getattr(_m, "project_id", None) == source_project_id:
-                _picked[_m.id] = _m  # 트리거 프로젝트 행으로 교체
-        members = list(_picked.values())
+            # E-MEMBER-SSOT AC2-2: grant-only 휴먼(team_member 없음)은 org_member로 해소해
+            # in-app Notification 누락(silent drop) 방지. org_member는 project 스코프가 없으므로
+            # human Notification만 생성(Event는 project_id 필요 → skip). Notification은 user_id
+            # 기반이고 FK가 없어 org_member.id 사용에 제약 없음.
+            matched_ids = {m.id for m in members}
+            missing_ids = [mid for mid in enabled_member_ids if mid not in matched_ids]
+            if missing_ids:
+                from types import SimpleNamespace
 
-        # story #1953: Expo push data payload용 project_id 해소. source_project_id가 명시되면
-        # 그대로 우선 사용(신뢰 가능한 트리거 프로젝트). 없으면 위에서 이미 조회한 members의
-        # project_id가 전부 동일할 때만(모호성 0) 그 값으로 폴백 — 신규 쿼리 없이 기존 조회
-        # 결과만 재사용. 여러 프로젝트가 섞여 있으면(org-wide 브로드캐스트 등) None으로 둬
-        # 오라우팅(잘못된 프로젝트로 딥링크) 방지.
-        _push_project_id = source_project_id
-        if _push_project_id is None:
-            _member_project_ids = {
-                getattr(_m, "project_id", None) for _m in members
-            } - {None}
-            if len(_member_project_ids) == 1:
-                _push_project_id = next(iter(_member_project_ids))
-
-        inserted = False
-        created_events: list[Event] = []  # L1 BE-3: fan-out 수렴용 event 수집
-        for member_row in members:
-            if member_row.type == "agent":
-                # 활성 웹훅 있는 에이전트 → 외부 채널로 전달되므로 내장 Event 스킵(단, muted면
-                # webhook도 안 나가므로 Event insert로 폴백 — 위 event_skip_member_ids 참고).
-                if member_row.id in event_skip_member_ids:
-                    logger.debug(
-                        "dispatch_notification: skip agent %s — has active webhook", member_row.id
+                from app.models.project import OrgMember
+                om_result = await db.execute(
+                    select(OrgMember.id, OrgMember.user_id).where(
+                        OrgMember.id.in_(missing_ids),
+                        OrgMember.org_id == org_id,
+                        OrgMember.deleted_at.is_(None),
                     )
-                    continue
-                # BUG-3 수정: agent → Notification 대신 events 테이블 INSERT.
-                # 트리거 프로젝트(source_project_id) 우선 — 멀티프로젝트 에이전트가 임의 프로젝트로
-                # 이벤트 받는 오라우팅 방지. 미지정 시 뷰 행의 project_id(기존 거동).
-                _agent_proj = source_project_id or member_row.project_id
-                if _agent_proj:
-                    event = Event(
-                        project_id=_agent_proj,
-                        org_id=org_id,
-                        event_type="dispatched",
-                        source_entity_type=reference_type,
-                        source_entity_id=reference_id,
-                        sender_id=None,
-                        recipient_id=member_row.id,
-                        recipient_type="agent",
-                        # #2375: content 키 없으면 SSE 어댑터(fakechat/server.ts·hermes adapter.py)가
-                        # 둘 다 ack 前에 조용히 드롭해 영구 pending — E-EVENT-INJECT S1이 만든
-                        # "content를 SSE top-level로 노출"(agent_gateway.py _row_to_payload) 방지장치가
-                        # 여기(생성부)에서 그 키를 안 채워 안 맞물려 있었다. body 없으면 title로
-                        # 폴백(title은 필수 파라미터라 항상 non-empty) — 절대 빈 content로 두지 않는다.
-                        payload={
-                            "title": title, "body": body, "event_type": event_type,
-                            "content": body or title,
-                        },
-                        status="pending",
+                )
+                for om in om_result.all():
+                    members.append(
+                        SimpleNamespace(id=om.id, user_id=om.user_id, type="human", project_id=None)
                     )
-                    db.add(event)
-                    created_events.append(event)
-                    inserted = True
-            elif member_row.user_id:
-                # human: Notification + Event 각각 독립 savepoint — 하나 실패해도 다른 쪽 롤백 방지
-                try:
-                    async with db.begin_nested():
-                        notification = Notification(
-                            org_id=org_id,
-                            user_id=member_row.user_id,
-                            type=event_type,
-                            title=title,
-                            body=body,
-                            is_read=False,
-                            reference_type=reference_type,
-                            reference_id=reference_id,
+
+            # 회귀 버그 fix: team_members는 0088 이후 projection VIEW라 멤버당 **프로젝트별 1행**(동일 id)을
+            # 반환한다. dedup 없이 루프하면 멀티프로젝트 멤버에게 알림이 **프로젝트 수만큼 중복 생성**됨
+            # (Story Assign 시 Inbox 알림 3개 증상 = 담당자가 3개 프로젝트 소속). member id로 dedup해
+            # 멤버당 1 알림/이벤트만 생성. (view-cutover multi-row 트랩)
+            # source_project_id 주어지면 그 프로젝트 행을 우선(멀티프로젝트 에이전트 = 트리거 프로젝트로
+            # 정확 라우팅). 미지정 시 첫 행(기존 거동). 어느 경우든 member당 정확히 1행 → 휴먼 N-알림 무회귀.
+            _picked: dict[uuid.UUID, object] = {}
+            for _m in members:
+                cur = _picked.get(_m.id)
+                if cur is None:
+                    _picked[_m.id] = _m
+                elif source_project_id is not None and getattr(_m, "project_id", None) == source_project_id:
+                    _picked[_m.id] = _m  # 트리거 프로젝트 행으로 교체
+            members = list(_picked.values())
+
+            # story #1953: Expo push data payload용 project_id 해소. source_project_id가 명시되면
+            # 그대로 우선 사용(신뢰 가능한 트리거 프로젝트). 없으면 위에서 이미 조회한 members의
+            # project_id가 전부 동일할 때만(모호성 0) 그 값으로 폴백 — 신규 쿼리 없이 기존 조회
+            # 결과만 재사용. 여러 프로젝트가 섞여 있으면(org-wide 브로드캐스트 등) None으로 둬
+            # 오라우팅(잘못된 프로젝트로 딥링크) 방지.
+            _push_project_id = source_project_id
+            if _push_project_id is None:
+                _member_project_ids = {
+                    getattr(_m, "project_id", None) for _m in members
+                } - {None}
+                if len(_member_project_ids) == 1:
+                    _push_project_id = next(iter(_member_project_ids))
+
+            inserted = False
+            created_events: list[Event] = []  # L1 BE-3: fan-out 수렴용 event 수집
+            for member_row in members:
+                if member_row.type == "agent":
+                    # 활성 웹훅 있는 에이전트 → 외부 채널로 전달되므로 내장 Event 스킵(단, muted면
+                    # webhook도 안 나가므로 Event insert로 폴백 — 위 event_skip_member_ids 참고).
+                    if member_row.id in event_skip_member_ids:
+                        logger.debug(
+                            "dispatch_notification: skip agent %s — has active webhook", member_row.id
                         )
-                        db.add(notification)
-                    inserted = True
-                except Exception:
-                    logger.warning("Notification INSERT failed member_id=%s event_type=%s", member_row.id, event_type)
-                if member_row.project_id:
-                    try:
-                        async with db.begin_nested():
-                            # story #2380: 이 분기는 human Event를 생성 즉시 status="delivered"로
-                            # 박는다(human은 agent SSE ack 사이클을 안 타므로 pending을 안 거치는
-                            # 것 자체는 맞다) — 그런데 delivered_at을 한 번도 안 채워 왔다. dev
-                            # 실측(2026-08-01): 이 경로로 난 human Event의 74%가 status=delivered
-                            # 인데 delivered_at=NULL — "배달됐다"만 있고 "언제"가 없어, 이 값을
-                            # coalesce(delivered_at, now())로 지연을 재려던 첫 시도가 「p50 9.4일」
-                            # 이라는 거짓 수치를 냈다(실제로는 그 행들 나이가 now()로 치환된 것).
-                            event = Event(
-                                project_id=member_row.project_id,
-                                org_id=org_id,
-                                event_type="dispatched",
-                                source_entity_type=reference_type,
-                                source_entity_id=reference_id,
-                                sender_id=None,
-                                recipient_id=member_row.id,
-                                recipient_type="human",
-                                payload={"title": title, "body": body, "event_type": event_type},
-                                status="delivered",
-                                # ⛔이 순간이 "배달 시도 순간"과 같다고 볼 수 있는 건 이 분기가
-                                # 지금 동기라서다 — 바로 다음 줄들이 실제 배달 행위(Notification
-                                # INSERT·개인 webhook 시도)를 같은 호출 안에서 한다. 이 경로가
-                                # 나중에 진짜 비동기(예: webhook 배달확認 콜백)가 되면 이 값도
-                                # 그 확認 시점으로 옮겨야 한다 — 여기 그대로 둔 채 비동기화하면
-                                # #2380이 고친 문제(delivered_at이 실제 배달 시점을 안 가리킴)가
-                                # 값이 없는 대신 "틀린 값"으로 재발한다.
-                                delivered_at=datetime.now(timezone.utc),
-                            )
-                            db.add(event)
+                        continue
+                    # BUG-3 수정: agent → Notification 대신 events 테이블 INSERT.
+                    # 트리거 프로젝트(source_project_id) 우선 — 멀티프로젝트 에이전트가 임의 프로젝트로
+                    # 이벤트 받는 오라우팅 방지. 미지정 시 뷰 행의 project_id(기존 거동).
+                    _agent_proj = source_project_id or member_row.project_id
+                    if _agent_proj:
+                        event = Event(
+                            project_id=_agent_proj,
+                            org_id=org_id,
+                            event_type="dispatched",
+                            source_entity_type=reference_type,
+                            source_entity_id=reference_id,
+                            sender_id=None,
+                            recipient_id=member_row.id,
+                            recipient_type="agent",
+                            # #2375: content 키 없으면 SSE 어댑터(fakechat/server.ts·hermes adapter.py)가
+                            # 둘 다 ack 前에 조용히 드롭해 영구 pending — E-EVENT-INJECT S1이 만든
+                            # "content를 SSE top-level로 노출"(agent_gateway.py _row_to_payload) 방지장치가
+                            # 여기(생성부)에서 그 키를 안 채워 안 맞물려 있었다. body 없으면 title로
+                            # 폴백(title은 필수 파라미터라 항상 non-empty) — 절대 빈 content로 두지 않는다.
+                            payload={
+                                "title": title, "body": body, "event_type": event_type,
+                                "content": body or title,
+                            },
+                            status="pending",
+                        )
+                        db.add(event)
                         created_events.append(event)
                         inserted = True
+                elif member_row.user_id:
+                    # human: Notification + Event 각각 독립 savepoint — 하나 실패해도 다른 쪽 롤백 방지
+                    try:
+                        async with db.begin_nested():
+                            notification = Notification(
+                                org_id=org_id,
+                                user_id=member_row.user_id,
+                                type=event_type,
+                                title=title,
+                                body=body,
+                                is_read=False,
+                                reference_type=reference_type,
+                                reference_id=reference_id,
+                            )
+                            db.add(notification)
+                        inserted = True
                     except Exception:
-                        logger.warning("Event INSERT failed member_id=%s event_type=%s", member_row.id, event_type)
+                        logger.warning("Notification INSERT failed member_id=%s event_type=%s", member_row.id, event_type)
+                    if member_row.project_id:
+                        try:
+                            async with db.begin_nested():
+                                # story #2380: 이 분기는 human Event를 생성 즉시 status="delivered"로
+                                # 박는다(human은 agent SSE ack 사이클을 안 타므로 pending을 안 거치는
+                                # 것 자체는 맞다) — 그런데 delivered_at을 한 번도 안 채워 왔다. dev
+                                # 실측(2026-08-01): 이 경로로 난 human Event의 74%가 status=delivered
+                                # 인데 delivered_at=NULL — "배달됐다"만 있고 "언제"가 없어, 이 값을
+                                # coalesce(delivered_at, now())로 지연을 재려던 첫 시도가 「p50 9.4일」
+                                # 이라는 거짓 수치를 냈다(실제로는 그 행들 나이가 now()로 치환된 것).
+                                event = Event(
+                                    project_id=member_row.project_id,
+                                    org_id=org_id,
+                                    event_type="dispatched",
+                                    source_entity_type=reference_type,
+                                    source_entity_id=reference_id,
+                                    sender_id=None,
+                                    recipient_id=member_row.id,
+                                    recipient_type="human",
+                                    payload={"title": title, "body": body, "event_type": event_type},
+                                    status="delivered",
+                                    # ⛔이 순간이 "배달 시도 순간"과 같다고 볼 수 있는 건 이 분기가
+                                    # 지금 동기라서다 — 바로 다음 줄들이 실제 배달 행위(Notification
+                                    # INSERT·개인 webhook 시도)를 같은 호출 안에서 한다. 이 경로가
+                                    # 나중에 진짜 비동기(예: webhook 배달확認 콜백)가 되면 이 값도
+                                    # 그 확認 시점으로 옮겨야 한다 — 여기 그대로 둔 채 비동기화하면
+                                    # #2380이 고친 문제(delivered_at이 실제 배달 시점을 안 가리킴)가
+                                    # 값이 없는 대신 "틀린 값"으로 재발한다.
+                                    delivered_at=datetime.now(timezone.utc),
+                                )
+                                db.add(event)
+                            created_events.append(event)
+                            inserted = True
+                        except Exception:
+                            logger.warning("Event INSERT failed member_id=%s event_type=%s", member_row.id, event_type)
 
-        if inserted:
-            await db.flush()
-            # #2375 후속 — agent 수신 Event가 recipient_seq를 한 번도 배정받지 못했다(이 함수
-            # 어디에도 assign_recipient_seq() 호출이 없었다). agent_gateway.py의 /stream 쿼리는
-            # `recipient_seq > :after_seq`로 커서 필터링하는데 NULL은 그 비교를 절대 통과 못 해
-            # 라이브 스트림에도 backfill 재연결에도 안 잡힌다 — content 키를 채운 뒤에도(#2375
-            # 본 fix) agent 쪽 delivered=0건이 이어진 진짜 근본원인. agent_dispatch.py의
-            # _finalize_dispatch()가 이미 쓰는 패턴(Event INSERT+flush 後·commit 前)을 그대로
-            # 재사용한다 — 여기도 "flush 후" 시점이라 그 불변식을 만족한다.
-            from app.services.event_seq import assign_recipient_seq
-            for _ev in created_events:
-                if _ev.recipient_type == "agent":
-                    await assign_recipient_seq(db, _ev)
-            # L1 BE-3: multi-recipient dispatch fan-out N행 → activity_events 1행 수렴
-            # (best-effort·savepoint 격리라 추출 실패해도 delivery·Notification 무영향).
-            from app.services.activity_stream import extract_activities_best_effort
-            await extract_activities_best_effort(db, [e.id for e in created_events])
+            if inserted:
+                await db.flush()
+                # #2375 후속 — agent 수신 Event가 recipient_seq를 한 번도 배정받지 못했다(이 함수
+                # 어디에도 assign_recipient_seq() 호출이 없었다). agent_gateway.py의 /stream 쿼리는
+                # `recipient_seq > :after_seq`로 커서 필터링하는데 NULL은 그 비교를 절대 통과 못 해
+                # 라이브 스트림에도 backfill 재연결에도 안 잡힌다 — content 키를 채운 뒤에도(#2375
+                # 본 fix) agent 쪽 delivered=0건이 이어진 진짜 근본원인. agent_dispatch.py의
+                # _finalize_dispatch()가 이미 쓰는 패턴(Event INSERT+flush 後·commit 前)을 그대로
+                # 재사용한다 — 여기도 "flush 후" 시점이라 그 불변식을 만족한다.
+                from app.services.event_seq import assign_recipient_seq
+                for _ev in created_events:
+                    if _ev.recipient_type == "agent":
+                        await assign_recipient_seq(db, _ev)
+                # L1 BE-3: multi-recipient dispatch fan-out N행 → activity_events 1행 수렴
+                # (best-effort·savepoint 격리라 추출 실패해도 delivery·Notification 무영향).
+                from app.services.activity_stream import extract_activities_best_effort
+                await extract_activities_best_effort(db, [e.id for e in created_events])
 
-        # 96af343e(옵션 C) + C0-S2(8bace49e 부활): 개인 webhook 발송 — 휴먼 + agent(활성 webhook).
-        # ⭐agent(활성 webhook)는 위에서 Event INSERT를 스킵했다("외부 채널로 전달" 전제). 그런데 그
-        # webhook을 여기서 실제로 쏘지 않으면 Event도 스킵·webhook도 미발송 = comment.created가
-        # webhook-agent에 미도달(죽은 경로). 이 경로를 부활시켜 에이전트 반응 왕복을 잇는다 —
-        # member-bound WebhookConfig·mute(NotificationPreference)·SSRF 재검증 기존 SSOT 재사용·
-        # Event-skip 유지라 이중배달 0(webhook 단일 채널).
-        webhook_deliver_ids = [
-            m.id for m in members
-            if (m.type != "agent" and getattr(m, "user_id", None))
-            or (m.type == "agent" and m.id in webhook_member_ids)
-        ]
-        await _deliver_personal_webhooks(
-            db, org_id, webhook_deliver_ids, title=title, body=body, event_type=event_type,
-            reference_type=reference_type, reference_id=reference_id, context=context,
-            muted_member_ids=muted_member_ids, via_outbox=via_outbox,
-        )
-
-        # E-MOBILE M0·S3: EE 푸시 채널(웹훅과 나란한 별개 채널) — 등록 push_devices 로 Expo 발송.
-        # 대상 = enabled(설정 통과) − mute 멤버(deliver_expo_push 내부 필터). 웹훅 유무와 독립.
-        # EE 게이트(비-EE 무동작·core 무영향)·best-effort(발송 실패가 파이프라인 안 되돌림).
-        from app.core.config import settings as _settings
-        if _settings.is_ee_enabled:
-            from ee.services.expo_push import deliver_expo_push
-            await deliver_expo_push(
-                db, org_id, enabled_member_ids, title=title, body=body, event_type=event_type,
+            # 96af343e(옵션 C) + C0-S2(8bace49e 부활): 개인 webhook 발송 — 휴먼 + agent(활성 webhook).
+            # ⭐agent(활성 webhook)는 위에서 Event INSERT를 스킵했다("외부 채널로 전달" 전제). 그런데 그
+            # webhook을 여기서 실제로 쏘지 않으면 Event도 스킵·webhook도 미발송 = comment.created가
+            # webhook-agent에 미도달(죽은 경로). 이 경로를 부활시켜 에이전트 반응 왕복을 잇는다 —
+            # member-bound WebhookConfig·mute(NotificationPreference)·SSRF 재검증 기존 SSOT 재사용·
+            # Event-skip 유지라 이중배달 0(webhook 단일 채널).
+            webhook_deliver_ids = [
+                m.id for m in members
+                if (m.type != "agent" and getattr(m, "user_id", None))
+                or (m.type == "agent" and m.id in webhook_member_ids)
+            ]
+            await _deliver_personal_webhooks(
+                db, org_id, webhook_deliver_ids, title=title, body=body, event_type=event_type,
                 reference_type=reference_type, reference_id=reference_id, context=context,
-                muted_member_ids=muted_member_ids,
-                project_id=_push_project_id, story_id=story_id, sprint_id=sprint_id,
-                via_outbox=via_outbox,
+                muted_member_ids=muted_member_ids, via_outbox=via_outbox,
             )
+
+            # E-MOBILE M0·S3: EE 푸시 채널(웹훅과 나란한 별개 채널) — 등록 push_devices 로 Expo 발송.
+            # 대상 = enabled(설정 통과) − mute 멤버(deliver_expo_push 내부 필터). 웹훅 유무와 독립.
+            # EE 게이트(비-EE 무동작·core 무영향)·best-effort(발송 실패가 파이프라인 안 되돌림).
+            from app.core.config import settings as _settings
+            if _settings.is_ee_enabled:
+                from ee.services.expo_push import deliver_expo_push
+                await deliver_expo_push(
+                    db, org_id, enabled_member_ids, title=title, body=body, event_type=event_type,
+                    reference_type=reference_type, reference_id=reference_id, context=context,
+                    muted_member_ids=muted_member_ids,
+                    project_id=_push_project_id, story_id=story_id, sprint_id=sprint_id,
+                    via_outbox=via_outbox,
+                )
 
     except Exception:
         # BUG-1 수정: 에러 삼킴 제거 → 스택 트레이스 로깅

--- a/backend/tests/test_2460_delivery_outbox.py
+++ b/backend/tests/test_2460_delivery_outbox.py
@@ -32,6 +32,17 @@ def mock_session():
     session.add = MagicMock()
     session.execute = AsyncMock()
     session.commit = AsyncMock()
+    # P0(message-loss class fix, 2026-08-08): dispatch_notification()이 이제 본문 전체를
+    # begin_nested() SAVEPOINT로 감싸는데(app/services/notification_dispatch.py), 이 fixture는
+    # 그걸 async context manager로 안 만들어 bare AsyncMock이 coroutine을 반환 —
+    # `async with db.begin_nested():`가 TypeError로 죽어 이 파일의 두 테스트가 dispatch_notification
+    # 본문 전체를 건너뛰었다(이전엔 그 예외가 human-branch 내부 try/except에 삼켜져 우연히
+    # 안 드러났을 뿐 — RuntimeWarning으로 이미 징후가 있었다). test_notification_dispatch.py의
+    # 검증된 패턴 그대로 맞춘다.
+    nested_cm = AsyncMock()
+    nested_cm.__aenter__ = AsyncMock(return_value=None)
+    nested_cm.__aexit__ = AsyncMock(return_value=False)
+    session.begin_nested = MagicMock(return_value=nested_cm)
     return session
 
 

--- a/backend/tests/test_p0_message_loss_savepoint_isolation_realdb.py
+++ b/backend/tests/test_p0_message_loss_savepoint_isolation_realdb.py
@@ -1,0 +1,220 @@
+"""P0(prod-impact, 2026-08-08, 페드루 오르테가 AC 락) — 「send_chat_message가 성공 id를
+반환하는데 그 메시지가 conv에 저장 안 되는」 간헐적 유실 근본수정 검증.
+
+근본 메커니즘(로컬 asyncpg+SQLAlchemy 실증·이 파일 test_aborted_transaction_commit_silently_*
+이 실PG로 pin): `conversations.py::send_message()`가 메시지를 flush(uncommitted)한 뒤, 그 함수
+안에서 나중에 실행되는 다른 DB statement(route_message·resolve_conversation_webhook_targets·
+dispatch_notification 등)가 SAVEPOINT(`begin_nested()`) 없이 bare `except Exception:
+logger.warning(...)`로만 감싸져 있으면 — 그 statement가 SQL 레벨에서 실패할 때 Postgres
+트랜잭션이 ABORTED 상태가 되고, 그 뒤 최종 `db.commit()`은 **예외를 던지지 않고 정상 반환**
+하지만 실제로는 Postgres가 그 COMMIT을 ROLLBACK으로 처리해 트랜잭션의 모든 write(먼저 flush한
+메시지 insert 포함)가 통째로 사라진다. fix: 위험한 보조 write들을 `_dispatch_conversation_event`
+(같은 파일)가 이미 쓰던 패턴대로 `async with db.begin_nested():`(SAVEPOINT)로 격리 —
+`dispatch_notification()` 자체도 본문 전체를 SAVEPOINT로 감싸 14+ 콜사이트를 한 번에 보호(클래스
+전수 fix, 인스턴스만 닫지 않음).
+
+AC(페드루 지시, 2026-08-08):
+  ①양성대조 — 취약 블록이 실패해도 메시지는 살아남는다(fix 後 GREEN).
+  ②정상 메시지 저장 회귀 0.
+  ③가드 — "aborted 트랜잭션에 commit이 조용히 성공반환+rollback" 되는 실PG 사실 자체를 pin.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import text
+
+from tests.test_1994_backlink_api_realdb import (
+    _client_for,
+    _make_conversation,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _session_factory,
+    _setup_app_human,
+)
+from tests.test_2301_story_body_mentions_realdb import _REAL_DB_URL
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _message_exists(session, message_id: uuid.UUID) -> bool:
+    from app.models.conversation import ConversationMessage
+    from sqlalchemy import select
+    row = (await session.execute(
+        select(ConversationMessage.id).where(ConversationMessage.id == message_id)
+    )).scalar_one_or_none()
+    return row is not None
+
+
+# ─── AC① 양성대조: 취약 블록이 실패해도 메시지는 살아남는다 ──────────────────────
+
+
+async def _dispatch_notification_with_real_sql_failure(db, **_kwargs):
+    """dispatch_notification()의 대역 — ⛔순수 Python 예외(AsyncMock side_effect=RuntimeError)는
+    Postgres 트랜잭션을 조금도 건드리지 않아 이 버그 클래스를 전혀 재현 못 한다(bare except가
+    아무 문제 없이 잡아내는 「무해한」 예외라 SAVEPOINT 유무와 무관하게 항상 통과 — 공허 양성대조).
+    실제 위험은 "SQL 레벨"에서 실패해야 재현된다 — 그래서 caller의 실 세션으로 진짜 실패하는
+    statement(0으로 나누기, DivisionByZero)를 보내 Postgres 트랜잭션을 실제로 ABORT시킨다."""
+    await db.execute(text("select 1/0"))
+
+
+async def test_message_survives_when_dispatch_notification_raises_realdb():
+    """dispatch_notification()(conversations.py send_message의 candidate_targets 알림 콜사이트)이
+    SQL 레벨에서 실패하는 조건을 실제로 재현 — begin_nested() 격리 前이었다면 이 실패가
+    Postgres 트랜잭션 전체를 ABORT시켜 최종 commit이 조용히 ROLLBACK되고 메시지가 통째로
+    사라졌을 자리다. fix 後엔 SAVEPOINT가 이 실패만 롤백하고 메시지 insert는 살아남아야 한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as session:
+            org = await _make_org(session)
+            project = await _make_project(session, org.id)
+            sender_id, sender_user = await _make_human_member(session, org.id, project.id)
+            other_id, other_user = await _make_human_member(session, org.id, project.id)
+            conv_id = await _make_conversation(
+                session, org.id, project.id, [sender_id, other_id], sender_id,
+            )
+
+        await _setup_app_human(app, Session, sender_user, org.id)
+        with patch(
+            "app.services.notification_dispatch.dispatch_notification",
+            new=_dispatch_notification_with_real_sql_failure,
+        ):
+            async with _client_for(app) as client:
+                resp = await client.post(
+                    f"/api/v2/conversations/{conv_id}/messages",
+                    json={"content": "이 메시지는 알림 write 실패에도 살아남아야 한다"},
+                )
+        app.dependency_overrides.clear()
+
+        # ⭐본 판정: 성공 응답이면서 실제로 저장까지 됐는지 — 응답만 보고 "성공"이라 믿지 않는다
+        # (이 P0 증상 자체가 정확히 "성공 응답인데 저장 안 됨"이었다).
+        assert resp.status_code == 201, resp.text
+        msg_id = uuid.UUID(resp.json()["data"]["id"])
+
+        async with Session() as check_session:
+            assert await _message_exists(check_session, msg_id), (
+                "메시지가 201로 응답됐는데 DB에 없다 — SAVEPOINT 격리가 안 먹힌 것(회귀)"
+            )
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── AC② 회귀 0: 정상 메시지 저장은 그대로 ────────────────────────────────────
+
+
+async def test_normal_message_still_persists_and_is_readable_realdb():
+    """실패 주입 없는 정상 경로 — fix가 정상 케이스를 안 건드렸는지 왕복(write_ok→read_success)
+    으로 확인."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as session:
+            org = await _make_org(session)
+            project = await _make_project(session, org.id)
+            sender_id, sender_user = await _make_human_member(session, org.id, project.id)
+            other_id, _ = await _make_human_member(session, org.id, project.id)
+            conv_id = await _make_conversation(
+                session, org.id, project.id, [sender_id, other_id], sender_id,
+            )
+
+        await _setup_app_human(app, Session, sender_user, org.id)
+        async with _client_for(app) as client:
+            resp = await client.post(
+                f"/api/v2/conversations/{conv_id}/messages", json={"content": "정상 메시지"},
+            )
+            assert resp.status_code == 201, resp.text
+            msg_id = resp.json()["data"]["id"]
+
+            list_resp = await client.get(f"/api/v2/conversations/{conv_id}/messages")
+            assert list_resp.status_code == 200
+            ids = [m["id"] for m in list_resp.json()["data"]]
+            assert msg_id in ids
+        app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── AC③ 가드: aborted 트랜잭션 + commit 조용한 성공반환+rollback 를 실PG로 pin ──────
+
+
+async def test_aborted_transaction_commit_silently_succeeds_and_rolls_back_realdb():
+    """근본 메커니즘 자체를 실PG로 고정한다 — 이 테스트가 없으면 미래에 같은 클래스 결함이
+    재발해도 또 조용히 지나간다(페드루 AC③ 명시 요구). 순서: ①정상 insert(flush) ②SAVEPOINT
+    없이 실행된 statement가 실패(bare except로 삼킴, 회귀 재현 그대로) ③commit()이 예외를
+    안 던지는지 ④그런데도 insert가 사라졌는지 — 넷 다 확인해야 "메커니즘 확定"이라 부를 수 있다."""
+    from app.core.database import async_session_factory
+
+    async with async_session_factory() as session:
+        table_name = f"p0_probe_{uuid.uuid4().hex[:8]}"
+        await session.execute(text(f"create temporary table {table_name} (id int primary key, v text)"))
+        await session.commit()
+
+        await session.execute(text(f"insert into {table_name} (id, v) values (1, 'should-vanish')"))
+
+        try:
+            # 의도적 실패 — bare except로만 삼킴(begin_nested 없음), 이 파일이 고친 4블록의
+            # "고치기 전" 상태 그대로 재현.
+            await session.execute(text(f"insert into {table_name} (id, v) values (1, 'dup')"))
+            pytest.fail("unique violation이 안 났다 — 픽스처가 잘못됐다")
+        except Exception:
+            pass  # bare except — 실제 코드의 위험 패턴과 동형(rollback도 savepoint도 없음)
+
+        # 판정①: commit()이 예외 없이 정상 반환되는가(=위험의 핵심 — 실패를 숨긴다)
+        await session.commit()  # 예외가 났으면 이 테스트 자체가 여기서 실패해 그 사실을 드러낸다
+
+        # 판정②: 그런데도 먼저 insert한 row는 사라졌는가(=조용한 데이터 유실 그 자체)
+        result = await session.execute(text(f"select count(*) from {table_name}"))
+        assert result.scalar_one() == 0, (
+            "aborted 트랜잭션에서 commit()이 예외 없이 row를 살렸다 — 이 판정 전제가 바뀌었다면"
+            " conversations.py::send_message의 SAVEPOINT 격리가 왜 필요한지도 다시 검토할 것"
+        )
+
+
+async def test_savepoint_protects_prior_insert_from_later_failure_realdb():
+    """위 위험 시나리오를 begin_nested()로 감쌌을 때 실제로 방어되는지 — fix가 쓰는 패턴 자체의
+    정당성을 실PG로 pin(대조 실험 — 위 테스트가 「위험」을, 이 테스트가 「방어」를 각각 고정)."""
+    from app.core.database import async_session_factory
+
+    async with async_session_factory() as session:
+        table_name = f"p0_probe_ok_{uuid.uuid4().hex[:8]}"
+        await session.execute(text(f"create temporary table {table_name} (id int primary key, v text)"))
+        await session.commit()
+
+        await session.execute(text(f"insert into {table_name} (id, v) values (1, 'should-survive')"))
+
+        try:
+            async with session.begin_nested():
+                await session.execute(text(f"insert into {table_name} (id, v) values (1, 'dup')"))
+        except Exception:
+            pass  # SAVEPOINT 격리 — 여기서 실패해도 begin_nested()가 SAVEPOINT까지만 롤백
+
+        await session.commit()
+
+        result = await session.execute(text(f"select id, v from {table_name}"))
+        rows = result.all()
+        assert rows == [(1, "should-survive")], (
+            "begin_nested() 로 감쌌는데도 먼저 insert한 row가 사라졌다 — SAVEPOINT 격리가 깨졌다"
+        )


### PR DESCRIPTION
## 무엇을
develop #2926(send_message aborted 트랜잭션 COMMIT 무음 rollback = 메시지 유실 근본 fix)의 **prod 승격**. develop squash 2fbb9d86 → main 1:1 cherry-pick(충돌 0).

## 왜 prod
선생님 「메시지 유실은 prod 까지 영향·모든 수정 진압 완료 時 승격」 지시. connectivity(제품 심장) 유실이라 prod 필수.

## 근본 (develop 검증분)
- conversations.py::send_message 의 5블록(route_message·resolve_conversation_webhook_targets·dispatch_notification×2·user_blocker)이 SAVEPOINT 없이 bare except → SQL 실패 時 트랜잭션 ABORTED → 최종 commit 이 예외 없이 반환하나 실제 통째 rollback. → begin_nested SAVEPOINT 격리 + notification_dispatch.py 함수 내부까지(25 콜사이트 커버).
- 실PG 가드 test 신설(test_p0_message_loss_savepoint_isolation_realdb).

## 검증 (develop서 완료)
- 디디 근본 fix + 카디르 **독립 QA APPROVE**(disposable 실PG 직접 재현: 양성대조 공허 아님[select 1/0]·뮤테이션 self-check RED→GREEN·회귀 43 passed·콜사이트 25건) + CI 전항목 green + qa:pass.

## 비차단(승격 무관)
ruff I001(conversations.py:2143 import-wrap 코스메틱·CI 게이트 아님) = 디디 후속 정리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)