### PR TITLE
feat(#2532): 「가설 OR 목표」 매달림 요구 + 자동제안 + 미매달림 판정 BE 재료

### DIFF
--- a/backend/app/repositories/story.py
+++ b/backend/app/repositories/story.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import case, func, select
+from sqlalchemy import case, exists, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.hypothesis import HypothesisStoryLink
 from app.models.pm import Story
 from app.repositories.base import BaseRepository
 from app.schemas.story import STATUS_TRANSITIONS
@@ -17,6 +18,19 @@ _PRIORITY_ORDER = case(
     (Story.priority == "low", 3),
     else_=4,
 )
+
+
+def _unattached_clause():
+    """story #2532(카디르 QA REQUEST_CHANGES, 2026-08-09) — unattached 필터는 반드시 SQL
+    WHERE 레벨이어야 한다. 최초 구현(라우터의 Python 후필터 `_filter_unattached`)은 SQL
+    limit 後 필터라 ①페이지 경계 밖 유실(SQL이 20건만 뽑았는데 그중 3건만 unattached면 3건만
+    반환 — 다음 페이지에 더 있어도 판단 근거가 없다) ②X-Total-Count/X-Next-Cursor가 필터 前
+    값이라 거짓 신호(board 분기에서 재현)를 냈다. «미매달림=뷰 결부 재료» 자체가 정확해야
+    하는 값이라 이 결함은 못 넘긴다 — WHERE 절로 옮겨 페이지네이션·헤더가 전부 필터 後
+    진실을 말하게 한다."""
+    return Story.epic_id.is_(None) & ~exists(
+        select(HypothesisStoryLink.id).where(HypothesisStoryLink.story_id == Story.id)
+    )
 
 
 async def allocate_story_number(session: AsyncSession, project_id: uuid.UUID) -> int:
@@ -48,7 +62,8 @@ class StoryRepository(BaseRepository[Story]):
         return await super().create(story_number=story_number, **data)
 
     async def list(
-        self, limit: int = 1000, *, q: str | None = None, cursor: datetime | None = None, **filters,
+        self, limit: int = 1000, *, q: str | None = None, cursor: datetime | None = None,
+        unattached: bool = False, **filters,
     ) -> list[Story]:
         """story 083176e8(까심 #2148 QA 적출): 갤러리 피커 실검색 — `q`는 title ILIKE 부분일치로
         기존 동등비교 필터(**filters, base.list() 상속)와 AND 결합. BaseRepository.list()는
@@ -85,11 +100,13 @@ class StoryRepository(BaseRepository[Story]):
             query = query.where(Story.title.ilike(f"%{q}%"))
         if cursor:
             query = query.where(Story.created_at < cursor)
+        if unattached:
+            query = query.where(_unattached_clause())
         query = query.order_by(Story.created_at.desc(), Story.id.desc()).limit(limit)
         result = await self.session.execute(query)
         return list(result.scalars().all())
 
-    async def list_by_ids(self, ids: list[uuid.UUID]) -> list[Story]:
+    async def list_by_ids(self, ids: list[uuid.UUID], *, unattached: bool = False) -> list[Story]:
         """배치 앵커 조회(story ca37b2b0 ② — 갤러리 등 정확한 story 집합 필요 소비자용).
 
         org-scoped exact-id IN 조회. ORDER BY 없음 — 호출자가 id 집합 그대로를 필요로 하는
@@ -97,11 +114,12 @@ class StoryRepository(BaseRepository[Story]):
         """
         if not ids:
             return []
-        result = await self.session.execute(
-            select(Story).where(
-                self._org_filter(), Story.id.in_(ids), Story.deleted_at.is_(None),
-            )
+        query = select(Story).where(
+            self._org_filter(), Story.id.in_(ids), Story.deleted_at.is_(None),
         )
+        if unattached:
+            query = query.where(_unattached_clause())
+        result = await self.session.execute(query)
         return list(result.scalars().all())
 
     async def list_board(
@@ -115,6 +133,7 @@ class StoryRepository(BaseRepository[Story]):
         epic_id: uuid.UUID | None = None,
         story_number: int | None = None,
         q_text: str | None = None,
+        unattached: bool = False,
     ) -> tuple[list[Story], int]:
         """CB-S4: 보드 상태별 쿼리 — created_at DESC + priority 보조 정렬 + cursor 페이징.
 
@@ -142,6 +161,8 @@ class StoryRepository(BaseRepository[Story]):
             q = q.where(Story.story_number == story_number)
         if q_text:
             q = q.where(Story.title.ilike(f"%{q_text}%"))
+        if unattached:
+            q = q.where(_unattached_clause())
 
         # done: 최근 7일 제한
         if status == "done":
@@ -169,6 +190,7 @@ class StoryRepository(BaseRepository[Story]):
         status: str | None = None,
         story_number: int | None = None,
         q: str | None = None,
+        unattached: bool = False,
     ) -> list[Story]:
         """sprint 미배정 + 삭제되지 않은 스토리만 서버사이드 필터.
 
@@ -203,6 +225,8 @@ class StoryRepository(BaseRepository[Story]):
             query = query.where(Story.story_number == story_number)
         if q:
             query = query.where(Story.title.ilike(f"%{q}%"))
+        if unattached:
+            query = query.where(_unattached_clause())
         result = await self.session.execute(query.limit(limit))
         return list(result.scalars().all())
 

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -137,8 +137,10 @@ async def list_stories(
     unattached: bool = Query(
         default=False,
         description=(
-            "story #2532(E-FLOW-V4 S2) — 가설·목표 둘 다 안 매달린 story만 반환(기존 필터와 "
-            "AND 결합, has_hypothesis_or_goal 계산 後 후필터라 다른 필터의 SQL 최적화엔 무영향)."
+            "story #2532(E-FLOW-V4 S2) — 가설·목표 둘 다 안 매달린 story만 반환. SQL WHERE "
+            "레벨 필터(epic_id IS NULL AND NOT EXISTS hypothesis_story_links)라 limit/cursor/"
+            "X-Total-Count 전부 필터 後 값을 정확히 반영한다(카디르 QA REQUEST_CHANGES,\n"
+            "2026-08-09 — 최초 구현이던 Python 후필터는 페이지 경계 밖 유실+헤더 거짓값 결함)."
         ),
     ),
     ids: str | None = Query(default=None, description="comma-separated story ids — 배치 앵커 조회(정확한 집합, ORDER BY/limit 무관)"),
@@ -177,7 +179,7 @@ async def list_stories(
             return []
         if len(story_ids) > 200:  # 워크플로우-라인 배치와 동형 방어(과대 IN 금지).
             raise HTTPException(status_code=422, detail="too many ids (max 200)")
-        stories = await repo.list_by_ids(story_ids)
+        stories = await repo.list_by_ids(story_ids, unattached=unattached)
         # 인가 스코프: org 소속이어도 caller가 접근 못 하는 project의 story는 조용히 필터링
         # (타 project id가 섞여 들어와도 유출 0 — has_project_access와 동일 SSOT 배치 버전 재사용).
         from app.services.project_auth import accessible_project_ids_in_org
@@ -186,7 +188,6 @@ async def list_stories(
         await _attach_assignee_ids(repo.session, repo.org_id, stories)
         await _attach_has_evidence(repo.session, stories)
         await _attach_has_hypothesis_or_goal(repo.session, stories)
-        stories = _filter_unattached(stories, unattached)
         return [StoryResponse.model_validate(s) for s in stories]
 
     # story #2188 ④-b(2026-07-25, 오르테가군 판정 — 의도된 제약, 코드 고칠 이유 없음):
@@ -204,12 +205,11 @@ async def list_stories(
         # board 분기로 감).
         stories = await repo.list_backlog(
             project_id, limit=limit, epic_id=epic_id, assignee_id=assignee_id,
-            status=status_filter, story_number=story_number, q=q,
+            status=status_filter, story_number=story_number, q=q, unattached=unattached,
         )
         await _attach_assignee_ids(repo.session, repo.org_id, stories)
         await _attach_has_evidence(repo.session, stories)
         await _attach_has_hypothesis_or_goal(repo.session, stories)
-        stories = _filter_unattached(stories, unattached)
         return [StoryResponse.model_validate(s) for s in stories]
 
     # CB-S4: status + project_id 조합 시 board 쿼리 (order_by + cursor + done 7일 제한)
@@ -227,6 +227,7 @@ async def list_stories(
             epic_id=epic_id,
             story_number=story_number,
             q_text=q,
+            unattached=unattached,
         )
         if response is not None:
             response.headers["X-Total-Count"] = str(total)
@@ -235,7 +236,6 @@ async def list_stories(
         await _attach_assignee_ids(repo.session, repo.org_id, stories)
         await _attach_has_evidence(repo.session, stories)
         await _attach_has_hypothesis_or_goal(repo.session, stories)
-        stories = _filter_unattached(stories, unattached)
         return [StoryResponse.model_validate(s) for s in stories]
 
     filters: dict = {}
@@ -255,7 +255,7 @@ async def list_stories(
     # FE(buildCursorPageMeta)가 계산한 nextCursor가 다음 요청에서 조용히 무시돼 같은 페이지가
     # 반복된다(sprints/standup "더 보기" 중복 누적의 원인).
     cursor_dt = _parse_stories_cursor(cursor)
-    stories = await repo.list(limit=limit, q=q, cursor=cursor_dt, **filters)
+    stories = await repo.list(limit=limit, q=q, cursor=cursor_dt, unattached=unattached, **filters)
     await _attach_assignee_ids(repo.session, repo.org_id, stories)
     await _attach_has_evidence(repo.session, stories)
     # ⛔일반 함정(2026-07-29, PO 지적 — "측정 경로 ≠ 실행 경로"): `Query(default=None, ...)`
@@ -272,7 +272,6 @@ async def list_stories(
             repo.session, repo.org_id, stories, boost_candidates_from,
         )
     await _attach_has_hypothesis_or_goal(repo.session, stories)
-    stories = _filter_unattached(stories, unattached)
     return [StoryResponse.model_validate(s) for s in stories]
 
 
@@ -384,15 +383,6 @@ async def _attach_has_hypothesis_or_goal(session: AsyncSession, stories: list[St
         if s.epic_id is not None or s.id in ids_with_hypothesis:
             s.has_hypothesis_or_goal = True
 
-
-def _filter_unattached(stories: list[Story], unattached: bool) -> list[Story]:
-    """story #2532: unattached=true 필터 — has_hypothesis_or_goal이 세팅 안 된(=None,
-    미매달림) story만 남긴다. _attach_has_hypothesis_or_goal 호출 後에만 의미 있다(호출
-    전이면 전부 미설정이라 전부 통과 — 호출 순서 오류를 조용히 숨기지 않도록 호출부에서
-    항상 attach 직후 이 함수를 쓴다)."""
-    if not unattached:
-        return stories
-    return [s for s in stories if not getattr(s, "has_hypothesis_or_goal", False)]
 
 async def _assert_story_project_access(
     session: AsyncSession, auth: AuthContext, org_id: uuid.UUID, project_id: uuid.UUID

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -22,7 +22,15 @@ from app.routers.agent_gateway import wake_agent
 from app.routers.gates import GateResponse
 from app.services import mcp_attachment_upload
 from app.services.asset_registry import DEFAULT_CONTAINER, sync_attachment_assets
-from app.schemas.story import StoryAttachment, StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
+from app.schemas.story import (
+    AttachmentCandidate,
+    AttachmentSuggestionResponse,
+    StoryAttachment,
+    StoryCreate,
+    StoryResponse,
+    StoryStatusUpdate,
+    StoryUpdate,
+)
 from app.services.member_resolver import canonicalize_member_id, filter_org_member_ids, resolve_member
 from app.services.merge_verdict_gate import (
     AUTO_MERGE,
@@ -126,6 +134,13 @@ async def list_stories(
     assignee_id: uuid.UUID | None = Query(default=None),
     status_filter: str | None = Query(default=None, alias="status"),
     no_sprint: bool = Query(default=False, description="sprint 미배정 스토리만 반환"),
+    unattached: bool = Query(
+        default=False,
+        description=(
+            "story #2532(E-FLOW-V4 S2) — 가설·목표 둘 다 안 매달린 story만 반환(기존 필터와 "
+            "AND 결합, has_hypothesis_or_goal 계산 後 후필터라 다른 필터의 SQL 최적화엔 무영향)."
+        ),
+    ),
     ids: str | None = Query(default=None, description="comma-separated story ids — 배치 앵커 조회(정확한 집합, ORDER BY/limit 무관)"),
     story_number: int | None = Query(default=None, description="프로젝트 내 사람-읽는 #N(project_id와 함께 사용 — N은 project 내에서만 유일)"),
     q: str | None = Query(default=None, description="title 부분검색(ILIKE) — 기존 필터와 AND 결합"),
@@ -144,6 +159,12 @@ async def list_stories(
     auth: AuthContext = Depends(get_current_user),
 ) -> list[StoryResponse]:
     from datetime import datetime
+
+    # story #2532: 아래 :247 주석과 동일 Query(...) 센티널 함정 — FastAPI 경유 없이 이
+    # 함수를 직접 호출하는 기존 테스트가 `unattached`를 안 넘기면 bool 대신 센티널 객체가
+    # 오는데, 센티널은 항상 truthy라 `if unattached:`가 무조건 참이 돼 기존 테스트 전부가
+    # 조용히 필터링당한다 — `isinstance` 가드로 실제 bool일 때만 필터를 켠다.
+    unattached = unattached if isinstance(unattached, bool) else False
 
     if ids is not None:
         # story ca37b2b0 ②: 갤러리 등 정확한 story 집합이 필요한 소비자용 — base.list()의
@@ -164,6 +185,8 @@ async def list_stories(
         stories = [s for s in stories if s.project_id in accessible]
         await _attach_assignee_ids(repo.session, repo.org_id, stories)
         await _attach_has_evidence(repo.session, stories)
+        await _attach_has_hypothesis_or_goal(repo.session, stories)
+        stories = _filter_unattached(stories, unattached)
         return [StoryResponse.model_validate(s) for s in stories]
 
     # story #2188 ④-b(2026-07-25, 오르테가군 판정 — 의도된 제약, 코드 고칠 이유 없음):
@@ -185,6 +208,8 @@ async def list_stories(
         )
         await _attach_assignee_ids(repo.session, repo.org_id, stories)
         await _attach_has_evidence(repo.session, stories)
+        await _attach_has_hypothesis_or_goal(repo.session, stories)
+        stories = _filter_unattached(stories, unattached)
         return [StoryResponse.model_validate(s) for s in stories]
 
     # CB-S4: status + project_id 조합 시 board 쿼리 (order_by + cursor + done 7일 제한)
@@ -209,6 +234,8 @@ async def list_stories(
                 response.headers["X-Next-Cursor"] = stories[-1].created_at.isoformat()
         await _attach_assignee_ids(repo.session, repo.org_id, stories)
         await _attach_has_evidence(repo.session, stories)
+        await _attach_has_hypothesis_or_goal(repo.session, stories)
+        stories = _filter_unattached(stories, unattached)
         return [StoryResponse.model_validate(s) for s in stories]
 
     filters: dict = {}
@@ -244,6 +271,8 @@ async def list_stories(
         stories = await _boost_reference_candidates(
             repo.session, repo.org_id, stories, boost_candidates_from,
         )
+    await _attach_has_hypothesis_or_goal(repo.session, stories)
+    stories = _filter_unattached(stories, unattached)
     return [StoryResponse.model_validate(s) for s in stories]
 
 
@@ -339,6 +368,31 @@ async def _attach_has_evidence(session: AsyncSession, stories: list[Story]) -> N
             s.human_verified_by = verified.created_by
             s.human_verified_at = verified.created_at
 
+
+async def _attach_has_hypothesis_or_goal(session: AsyncSession, stories: list[Story]) -> None:
+    """story #2532(E-FLOW-V4 S2, doc flow-board-v4-hypothesis-scale §4-1): 「가설 OR 목표
+    매달림」 신호(transient attr) — epic_id 존재 OR hypothesis_story_links 존재 시에만 True,
+    없으면 미설정(StoryResponse 기본값 None 유지, positive 단방향·부정 신호 0 — has_evidence와
+    동형 규율). _attach_has_evidence와 동형 배치 패턴."""
+    if not stories:
+        return
+    from app.services.hypothesis import batch_stories_with_hypothesis_link
+
+    story_ids = [s.id for s in stories]
+    ids_with_hypothesis = await batch_stories_with_hypothesis_link(session, story_ids)
+    for s in stories:
+        if s.epic_id is not None or s.id in ids_with_hypothesis:
+            s.has_hypothesis_or_goal = True
+
+
+def _filter_unattached(stories: list[Story], unattached: bool) -> list[Story]:
+    """story #2532: unattached=true 필터 — has_hypothesis_or_goal이 세팅 안 된(=None,
+    미매달림) story만 남긴다. _attach_has_hypothesis_or_goal 호출 後에만 의미 있다(호출
+    전이면 전부 미설정이라 전부 통과 — 호출 순서 오류를 조용히 숨기지 않도록 호출부에서
+    항상 attach 직후 이 함수를 쓴다)."""
+    if not unattached:
+        return stories
+    return [s for s in stories if not getattr(s, "has_hypothesis_or_goal", False)]
 
 async def _assert_story_project_access(
     session: AsyncSession, auth: AuthContext, org_id: uuid.UUID, project_id: uuid.UUID
@@ -723,6 +777,11 @@ async def create_story(
         check_description=True, check_acceptance_criteria=True,
         mention_actor_id=_mention_actor_id,
     )
+    # story #2532: 생성 시점엔 hypothesis_story_links가 있을 수 없다(별도 링크 API라 방금
+    # 생성된 story.id를 아직 아무도 못 건다) — DB 쿼리 없이 epic_id만으로 판정(_attach_
+    # has_hypothesis_or_goal의 배치쿼리는 목록/재조회 경로 전용, 여기선 불필요).
+    if story.epic_id is not None:
+        story.has_hypothesis_or_goal = True
     return StoryResponse.model_validate(story)
 
 
@@ -790,7 +849,68 @@ async def get_story(
     await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
     await _attach_assignee_ids(repo.session, repo.org_id, [story])
     await _attach_has_evidence(repo.session, [story])
+    await _attach_has_hypothesis_or_goal(repo.session, [story])
     return StoryResponse.model_validate(story)
+
+
+# story #2532(E-FLOW-V4 S2, doc flow-board-v4-hypothesis-scale §4-1): 무거운 가설 생성
+# (metric_definition NOT NULL)을 강요하지 않는다 — 이 엔드포인트는 **기존** open goal/
+# hypothesis 후보만 제시한다. 새 가설이 필요하면 클라이언트가 기존 `/hypotheses/draft`
+# (AI 초안 경로)를 재사용한다(마찰 0 — v3.4 §3-3 "매번 폼 금지"와 정합).
+_ATTACHMENT_SUGGESTION_TOP_N = 5
+_OPEN_GOAL_STATUSES = ("draft", "active")
+_OPEN_HYPOTHESIS_STATUSES = ("proposed", "active", "measuring")
+
+
+@router.get("/{id}/attachment-suggestions", response_model=AttachmentSuggestionResponse)
+async def get_story_attachment_suggestions(
+    id: uuid.UUID,
+    repo: StoryRepository = Depends(_get_repo_read),
+    auth: AuthContext = Depends(get_current_user),
+) -> AttachmentSuggestionResponse:
+    from app.models.hypothesis import Hypothesis
+    from app.services.attachment_suggestion import (
+        RankableCandidate,
+        classify_attachment_type,
+        rank_candidates,
+    )
+
+    story = await repo.get(id)
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+    await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
+
+    goal_rows = (await repo.session.execute(
+        select(Goal.id, Goal.title).where(
+            Goal.project_id == story.project_id, Goal.status.in_(_OPEN_GOAL_STATUSES),
+        )
+    )).all()
+    hyp_rows = (await repo.session.execute(
+        select(Hypothesis.id, Hypothesis.statement).where(
+            Hypothesis.project_id == story.project_id,
+            Hypothesis.status.in_(_OPEN_HYPOTHESIS_STATUSES),
+        )
+    )).all()
+
+    goal_candidates = rank_candidates(
+        story.title, story.description,
+        [RankableCandidate(id=r.id, text=r.title) for r in goal_rows],
+        top_n=_ATTACHMENT_SUGGESTION_TOP_N,
+    )
+    hypothesis_candidates = rank_candidates(
+        story.title, story.description,
+        [RankableCandidate(id=r.id, text=r.statement) for r in hyp_rows],
+        top_n=_ATTACHMENT_SUGGESTION_TOP_N,
+    )
+    return AttachmentSuggestionResponse(
+        suggested_type=classify_attachment_type(story.title, story.description),
+        goal_candidates=[
+            AttachmentCandidate(id=c.id, text=c.text, score=c.score) for c in goal_candidates
+        ],
+        hypothesis_candidates=[
+            AttachmentCandidate(id=c.id, text=c.text, score=c.score) for c in hypothesis_candidates
+        ],
+    )
 
 
 # ─── Backlinks (story #2266·C-8·E-CONNECT — target_type 일반화의 첫 사용처) ─────
@@ -1705,6 +1825,7 @@ async def bulk_update_stories(
     # refresh 後 transient assignee_ids 세팅(refresh 는 매핑 컬럼만 reload·transient 보존).
     await _attach_assignee_ids(db, repo.org_id, updated)
     await _attach_has_evidence(db, updated)
+    await _attach_has_hypothesis_or_goal(db, updated)
 
     # 응답(violation flag 포함) + violation 이벤트 페이로드를 commit 前에 빌드(commit 시 attr expire→
     # MissingGreenlet 방지·기존 results 빌드와 동일 시점). 이벤트 발화는 commit 後(/status 와 동일 순서).
@@ -2045,6 +2166,7 @@ async def update_story(
 
     await _attach_assignee_ids(db, repo.org_id, [story])
     await _attach_has_evidence(db, [story])
+    await _attach_has_hypothesis_or_goal(db, [story])
     # story #2459 prod 회귀(2026-08-05): model_validate는 동기 호출이라 story의 어떤 컬럼이
     # unloaded 상태면(원인 미확定 — repo.update()가 flush+refresh 直後인데도 관측됨)
     # MissingGreenlet 500(await_only 호출 불가 — sync 컨텍스트에서 lazy load 시도)으로
@@ -2315,6 +2437,7 @@ async def update_story_status(
 
     await _attach_assignee_ids(db, repo.org_id, [story])
     await _attach_has_evidence(db, [story])
+    await _attach_has_hypothesis_or_goal(db, [story])
     # story #2459 prod 회귀(2026-08-05): update_story와 동형 — model_validate 直前 명시
     # refresh로 unloaded 컬럼(예: updated_at) MissingGreenlet 500을 막는다.
     await db.refresh(story)

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -278,6 +278,19 @@ class StoryResponse(BaseModel):
         # (_coerce_attachments 와 동형). 실제 flag 는 라우터가 model_validate 後 dict 로 할당한다.
         return v if isinstance(v, dict) else None
 
+    # story #2532(E-FLOW-V4 S2): 「가설 OR 목표 매달림」 신호(positive 단방향 — has_evidence와
+    # 동형 규율). epic_id 존재 OR hypothesis_story_links 존재 시에만 True, 그 외엔 미설정
+    # (기본값 None 유지 — False 절대 안 씀). ORM 컬럼 아님·라우터가 model_validate 前 transient
+    # attr로 세팅(_attach_has_hypothesis_or_goal, has_evidence 패턴 동형). v4 조직원리(doc
+    # flow-board-v4-hypothesis-scale §4-1)의 「미매달림」 판정 SSOT — FE가 이 필드로 지도·추천·
+    # 서사에서 뺄지 판단한다(block 아님, 자연 유도).
+    has_hypothesis_or_goal: bool | None = None
+
+    @field_validator("has_hypothesis_or_goal", mode="before")
+    @classmethod
+    def _coerce_has_hypothesis_or_goal(cls, v):
+        return v if isinstance(v, bool) else None
+
     # E-VERIFY V0-S2(story 3fbd048d): evidence-backed 신호(positive 단방향) — True(있음) 또는
     # None(신호 부재, violation과 동형 — 부정값 False 절대 안 씀). ORM 컬럼 아님·라우터가
     # model_validate 前 transient attr로 세팅(assignee_ids 패턴 동형).
@@ -342,3 +355,20 @@ class StoryResponse(BaseModel):
     def next_action_category(self) -> str | None:
         from app.services.next_action import next_action_category
         return next_action_category(self.next_action_code)
+
+
+# story #2532(E-FLOW-V4 S2): GET /{id}/attachment-suggestions 응답 모형.
+
+
+class AttachmentCandidate(BaseModel):
+    id: uuid.UUID
+    # goal이면 title, hypothesis면 statement — 후보 카드에 바로 보여줄 텍스트.
+    text: str
+    score: int
+
+
+class AttachmentSuggestionResponse(BaseModel):
+    # fix/infra→goal · 실험/검증→hypothesis · 매치 없거나 둘 다 매치→ambiguous(양성대조: 둘 다 채움).
+    suggested_type: str
+    goal_candidates: list[AttachmentCandidate] = []
+    hypothesis_candidates: list[AttachmentCandidate] = []

--- a/backend/app/services/attachment_suggestion.py
+++ b/backend/app/services/attachment_suggestion.py
@@ -1,0 +1,105 @@
+"""story #2532(E-FLOW-V4 S2): 작업(스토리)이 «가설 OR 목표» 중 무엇에 매달릴지 자동제안.
+
+조직 원리 doc `flow-board-v4-hypothesis-scale` §4-1(v3 「구조적 결부」) — 명시적 block은
+안 한다. 대신 작업 생성/조회 時 «어느 쪽에 매달릴지» 자동제안해 마찰 0으로 유도한다
+(v3.4 §3-3 "매번 폼 금지").
+
+이 모듈은 `model_family.py`와 동형으로 **결정론적**이다 — LLM 호출·네트워크·DB 접근 0.
+분류(`classify_attachment_type`)는 순수 키워드 매칭, 랭킹(`rank_candidates`)은 순수 토큰
+overlap 카운트다. 후보 데이터(project 내 open goal/hypothesis 목록)는 라우터가 조회해
+넘긴다 — 이 모듈은 그 리스트를 스코어링만 한다(DB 접근 0 유지).
+
+⛔PO 판정(2026-08-08, story #2532 AC 락): v1은 키워드 overlap으로 GO — ①결정론·재현가능·
+LLM 0(model_family.py 스타일 일관) ②후보는 「제안」이지 정답이 아니라 사람이 한 번
+확認하면 됨(완벽 불요) ③정교한 매칭(임베딩/의미)은 실사용 데이터가 쌓인 뒤 개선(지금
+지어내면 검증 못 함). overlap 0인 후보는 내지 않는다(빈 제안 금지 — 억지 후보보다 "후보
+없음"이 정직하다).
+"""
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass, field
+from typing import Literal
+
+# 유지보수·결함·인프라 신호 → 목표(에픽)로 분류. 정공법: 「모든 작업이 가설」은 부자연
+# (버그fix는 가설이 아니다 — doc §4-1).
+_GOAL_KEYWORDS: frozenset[str] = frozenset({
+    "fix", "bug", "hotfix", "patch", "infra", "infrastructure", "outage", "incident",
+    "버그", "수정", "고침", "인프라", "유지보수", "핫픽스", "패치", "오류", "장애",
+    "안정화", "복구", "결함", "회귀", "regression",
+})
+
+# 탐구·실험 신호 → 가설로 분류.
+_HYPOTHESIS_KEYWORDS: frozenset[str] = frozenset({
+    "experiment", "hypothesis", "test", "ab test", "a/b", "validate", "measure",
+    "실험", "가설", "테스트", "검증", "측정", "조사", "리서치", "research", "가정",
+})
+
+_TOKEN_RE = re.compile(r"[\w가-힣]+")
+# 순수 토큰이라 봐도 의미 없는 흔한 조사/기능어 — overlap 점수를 오염시키지 않게 제외.
+_STOPWORDS: frozenset[str] = frozenset({
+    "the", "a", "an", "of", "to", "in", "on", "for", "and", "or", "is", "it",
+    "이", "가", "을", "를", "은", "는", "의", "에", "와", "과", "도", "및", "그",
+})
+
+AttachmentType = Literal["goal", "hypothesis", "ambiguous"]
+
+_MIN_TOKEN_LEN = 2  # 1글자 토큰(조사 파편 등)은 과매칭을 낳아 제외.
+
+
+def _tokenize(text: str | None) -> set[str]:
+    if not text:
+        return set()
+    return {
+        t for t in _TOKEN_RE.findall(text.lower())
+        if t not in _STOPWORDS and len(t) >= _MIN_TOKEN_LEN
+    }
+
+
+def classify_attachment_type(title: str, description: str | None = None) -> AttachmentType:
+    """제목+설명의 키워드로 goal/hypothesis/ambiguous 셋 중 하나를 판정한다.
+
+    둘 다 매치되거나(예: "실험 인프라 정비") 아무것도 안 매치되면 ambiguous — 이 경우
+    라우터가 goal_candidates·hypothesis_candidates 둘 다 채운다(AC 양성대조: 애매한
+    작업엔 두 후보 리스트 다 나와야 한다)."""
+    haystack = f"{title} {description or ''}".lower()
+    goal_hit = any(kw in haystack for kw in _GOAL_KEYWORDS)
+    hyp_hit = any(kw in haystack for kw in _HYPOTHESIS_KEYWORDS)
+    if goal_hit and not hyp_hit:
+        return "goal"
+    if hyp_hit and not goal_hit:
+        return "hypothesis"
+    return "ambiguous"
+
+
+@dataclass(frozen=True)
+class RankableCandidate:
+    """랭킹 대상 1건 — goal이면 title, hypothesis면 statement를 text로 넘긴다."""
+    id: uuid.UUID
+    text: str
+
+
+@dataclass(frozen=True)
+class ScoredCandidate:
+    id: uuid.UUID
+    text: str
+    score: int = field(compare=False)
+
+
+def rank_candidates(
+    story_title: str, story_description: str | None,
+    candidates: list[RankableCandidate], *, top_n: int = 5,
+) -> list[ScoredCandidate]:
+    """토큰 overlap 개수로 후보를 스코어링해 상위 top_n만 반환한다. overlap 0인 후보는
+    아예 내지 않는다(빈 제안 금지 — PO 판정, 억지 후보보다 정직한 "후보 없음")."""
+    story_tokens = _tokenize(story_title) | _tokenize(story_description)
+    if not story_tokens:
+        return []
+    scored = [
+        ScoredCandidate(id=c.id, text=c.text, score=len(story_tokens & _tokenize(c.text)))
+        for c in candidates
+    ]
+    scored = [c for c in scored if c.score > 0]
+    scored.sort(key=lambda c: c.score, reverse=True)
+    return scored[:top_n]

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -18,7 +18,7 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.hypothesis import HYPOTHESIS_STATUSES, Hypothesis, is_valid_transition
+from app.models.hypothesis import HYPOTHESIS_STATUSES, Hypothesis, HypothesisStoryLink, is_valid_transition
 from app.models.pm import Goal, Sprint, Story
 
 logger = logging.getLogger(__name__)
@@ -68,6 +68,22 @@ def _has_valid_outcome_evidence(outcome_result: dict | None) -> bool:
         return False
     reason = outcome_result.get("reason")
     return isinstance(reason, str) and bool(reason.strip())
+
+
+async def batch_stories_with_hypothesis_link(
+    session: AsyncSession, story_ids: list[uuid.UUID]
+) -> set[uuid.UUID]:
+    """story #2532(E-FLOW-V4 S2): hypothesis_story_links가 1건이라도 있는 story_id 집합
+    (N+1 회피 배치 조회) — `StoryResponse.has_hypothesis_or_goal`(positive 단방향)의
+    한 축. `evidence_service.batch_has_evidence`와 동형 패턴."""
+    if not story_ids:
+        return set()
+    result = await session.execute(
+        select(HypothesisStoryLink.story_id.distinct()).where(
+            HypothesisStoryLink.story_id.in_(story_ids)
+        )
+    )
+    return set(result.scalars().all())
 
 
 def map_legacy_outcome_status(outcome_status: str | None) -> str | None:

--- a/backend/tests/test_2188_no_sprint_alone_contract_pin.py
+++ b/backend/tests/test_2188_no_sprint_alone_contract_pin.py
@@ -81,6 +81,9 @@ async def test_actual_behavior_no_sprint_without_project_id_falls_through_to_gen
             project_id=None, epic_id=None, sprint_id=None, assignee_id=None,
             status_filter=None, no_sprint=True, ids=None, story_number=None, q=None,
             limit=1000, cursor=None, response=None, repo=repo, auth=auth,
+            # story #2532: 신규 Query 파라미터 — sentinel lint(scripts/lint_query_sentinel_
+            # direct_calls.py) baseline과 missing-set을 맞추기 위해 명시.
+            unattached=False,
         )
         assert result == []
         repo.list.assert_awaited_once()

--- a/backend/tests/test_2532_attachment_suggestion.py
+++ b/backend/tests/test_2532_attachment_suggestion.py
@@ -1,0 +1,92 @@
+"""story #2532(E-FLOW-V4 S2): `attachment_suggestion.py` 순수 함수 — I/O 0.
+
+classify_attachment_type: fix/infra→goal, 실험→hypothesis, 애매하면 ambiguous.
+rank_candidates: 토큰 overlap 스코어링, overlap 0인 후보는 안 낸다(빈 제안 금지).
+"""
+from __future__ import annotations
+
+import uuid
+
+from app.services.attachment_suggestion import (
+    RankableCandidate,
+    classify_attachment_type,
+    rank_candidates,
+)
+
+
+# --- classify_attachment_type ------------------------------------------------------
+
+
+def test_fix_keyword_classifies_as_goal():
+    assert classify_attachment_type("로그인 버그 fix") == "goal"
+
+
+def test_infra_keyword_classifies_as_goal():
+    assert classify_attachment_type("DB 커넥션 풀 인프라 안정화") == "goal"
+
+
+def test_experiment_keyword_classifies_as_hypothesis():
+    assert classify_attachment_type("온보딩 이메일 제목 A/B 실험") == "hypothesis"
+
+
+def test_validation_keyword_classifies_as_hypothesis():
+    assert classify_attachment_type("신규 가설 검증 착수") == "hypothesis"
+
+
+def test_no_keyword_match_is_ambiguous():
+    """⭐AC 양성대조: 어느 쪽 키워드도 안 걸리면 ambiguous — 라우터가 두 후보 리스트
+    다 채우는 근거가 되는 케이스."""
+    assert classify_attachment_type("사용자 프로필 페이지 개편") == "ambiguous"
+
+
+def test_both_keywords_match_is_ambiguous():
+    """⭐AC 양성대조: goal·hypothesis 키워드가 둘 다 걸려도 ambiguous(어느 한쪽으로
+    강제 안 함) — "실험 인프라 정비"류 혼합 작업."""
+    assert classify_attachment_type("실험 환경 인프라 정비") == "ambiguous"
+
+
+def test_description_alone_can_trigger_classification():
+    assert classify_attachment_type("제목만 봐선 모름", description="이건 버그 수정입니다") == "goal"
+
+
+def test_empty_description_does_not_crash():
+    assert classify_attachment_type("제목만 있음", description=None) == "ambiguous"
+
+
+# --- rank_candidates ----------------------------------------------------------------
+
+
+def test_rank_candidates_orders_by_token_overlap_desc():
+    high = RankableCandidate(id=uuid.uuid4(), text="결제 시스템 안정화 목표")
+    low = RankableCandidate(id=uuid.uuid4(), text="완전히 무관한 다른 주제")
+    ranked = rank_candidates("결제 시스템 오류 수정", None, [low, high])
+    assert [c.id for c in ranked] == [high.id]  # low는 overlap 0 → 아예 안 나옴
+
+
+def test_rank_candidates_excludes_zero_overlap_candidates():
+    """⭐빈 제안 금지 원칙 — overlap 0인 후보는 억지로라도 안 낸다(PO 판정)."""
+    unrelated = RankableCandidate(id=uuid.uuid4(), text="전혀 다른 이야기")
+    ranked = rank_candidates("결제 시스템 오류 수정", None, [unrelated])
+    assert ranked == []
+
+
+def test_rank_candidates_respects_top_n():
+    candidates = [
+        RankableCandidate(id=uuid.uuid4(), text=f"결제 시스템 후보{i}")
+        for i in range(10)
+    ]
+    ranked = rank_candidates("결제 시스템 오류", None, candidates, top_n=3)
+    assert len(ranked) == 3
+
+
+def test_rank_candidates_empty_story_text_returns_empty():
+    """스토리 제목·설명 둘 다 토큰이 없으면(공백뿐 등) overlap 계산 불가 — 빈 리스트로
+    안전 폴백(에러 아님)."""
+    candidates = [RankableCandidate(id=uuid.uuid4(), text="아무 후보")]
+    assert rank_candidates("   ", None, candidates) == []
+
+
+def test_rank_candidates_uses_description_tokens_too():
+    cand = RankableCandidate(id=uuid.uuid4(), text="정산 배치 재처리")
+    ranked = rank_candidates("제목만 봐선 모름", "정산 배치 재처리가 필요합니다", [cand])
+    assert [c.id for c in ranked] == [cand.id]

--- a/backend/tests/test_2532_hypothesis_goal_attachment_realdb.py
+++ b/backend/tests/test_2532_hypothesis_goal_attachment_realdb.py
@@ -212,6 +212,59 @@ async def test_unattached_filter_returns_only_unlinked_stories_realdb():
         await engine.dispose()
 
 
+async def test_unattached_filter_is_sql_where_level_not_post_page_realdb():
+    """⭐카디르 QA REQUEST_CHANGES(2026-08-09) 재현+회귀방지 — unattached 필터가 SQL limit
+    後 Python 후필터였을 때의 두 결함을 정확히 겨눈다:
+    ①페이지 경계 밖 유실 — board 분기(status+project_id)에서 attached 2건이 SQL 순서상
+      먼저 오고 unattached 1건이 뒤에 있을 때, limit=1(SQL이 attached만 1건 뽑음)이면
+      후필터는 0건을 반환했을 것이다(실제로 unattached가 있는데도). WHERE 레벨이면 SQL
+      자체가 unattached 1건만 대상으로 삼아 정확히 1건을 반환해야 한다.
+    ②X-Total-Count 거짓값 — 후필터였다면 total이 «필터 前»(3건)이었을 것. WHERE
+      레벨이면 total도 필터 後 값(1건)이어야 한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id)
+            # SQL 정렬(created_at DESC)상 attached 둘이 먼저 오게 순서를 맞춘다(unattached
+            # 가 가장 나중에 생성 → created_at 최댓값 → DESC 정렬에서 맨 앞). 이러면 반대로
+            # unattached가 SQL 상단에 와 버려 결함이 안 드러나므로, 대신 status/필터로 board
+            # 분기를 타면서 limit=1로 강제해 "SQL이 딱 1건만 실제로 스캔·반환"하는 경계를
+            # 만든다 — 그 1건이 정확히 unattached여야 한다(후필터였다면 attached가 먼저 SQL
+            # 결과에 담겨 0건을 냈을 자리).
+            attached_1 = await _make_story(s, org.id, project.id, title="A1")
+            attached_1.status = "backlog"
+            attached_1.epic_id = goal.id
+            attached_2 = await _make_story(s, org.id, project.id, title="A2")
+            attached_2.status = "backlog"
+            attached_2.epic_id = goal.id
+            unattached_story = await _make_story(s, org.id, project.id, title="U1")
+            unattached_story.status = "backlog"
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user, org.id)
+        async with _client_for(app) as client:
+            resp = await client.get(
+                f"/api/v2/stories?project_id={project.id}&status=backlog&unattached=true&limit=1"
+            )
+            assert resp.status_code == 200, resp.text
+            items = resp.json()
+            assert len(items) == 1, "SQL WHERE 레벨이면 unattached 1건이 SQL 자체에서 걸러져 정확히 1건이어야 한다"
+            assert items[0]["id"] == str(unattached_story.id)
+            # ⭐X-Total-Count가 필터 後 값(1)인지 — 필터 前(3)이면 거짓 신호(카디르가 잡은 결함).
+            assert resp.headers.get("x-total-count") == "1", (
+                f"X-Total-Count가 필터 後 값이 아니다: {resp.headers.get('x-total-count')!r}"
+            )
+        app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
 # ─── ③ attachment-suggestions ───────────────────────────────────────────────────
 
 

--- a/backend/tests/test_2532_hypothesis_goal_attachment_realdb.py
+++ b/backend/tests/test_2532_hypothesis_goal_attachment_realdb.py
@@ -1,0 +1,320 @@
+"""story #2532(E-FLOW-V4 S2, PO 오르테가 AC 락 2026-08-08) — 「가설 OR 목표」 매달림
+BE 재료를 실PG로 검증한다.
+
+AC 락 확인 항목:
+  ①has_hypothesis_or_goal — epic_id 존재 OR hypothesis_story_links 존재 시에만 True(positive
+    단방향, False 없음). 양성대조 4케이스(목표만·가설만·둘 다·둘 없음).
+  ②unattached=true — 기존 list 엔드포인트에 얹은 필터, 미매달림만 반환.
+  ③attachment-suggestions — open goal/hypothesis만 후보(closed/archived 제외), ambiguous
+    시 둘 다 채움, overlap 0 후보는 안 냄.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from tests.test_1994_backlink_api_realdb import (
+    _client_for,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _session_factory,
+    _setup_app_human,
+)
+from tests.test_2301_story_body_mentions_realdb import _REAL_DB_URL, _make_story
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+_METRIC = {"metric": "signups", "source": "db", "target": 100, "direction": "increase"}
+
+
+async def _make_goal(session, org_id, project_id, title="Goal", status="active"):
+    from app.models.pm import Goal
+    goal = Goal(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status=status)
+    session.add(goal)
+    await session.commit()
+    return goal
+
+
+async def _make_hypothesis(session, org_id, project_id, owner_id, statement="Hyp", status="proposed"):
+    from app.models.hypothesis import Hypothesis
+    hyp = Hypothesis(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, owner_member_id=owner_id,
+        statement=statement, metric_definition=_METRIC,
+        measure_after=datetime(2026, 6, 1, tzinfo=timezone.utc), status=status,
+    )
+    session.add(hyp)
+    await session.commit()
+    return hyp
+
+
+async def _link_hypothesis_story(session, hypothesis_id, story_id):
+    from app.models.hypothesis import HypothesisStoryLink
+    session.add(HypothesisStoryLink(hypothesis_id=hypothesis_id, story_id=story_id, link_type="supports"))
+    await session.commit()
+
+
+# ─── ① has_hypothesis_or_goal — 양성대조 4케이스 ─────────────────────────────────
+
+
+async def test_goal_only_sets_true_realdb():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, title="Goal-only")
+            story.epic_id = goal.id
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user, org.id)
+        async with _client_for(app) as client:
+            resp = await client.get(f"/api/v2/stories/{story.id}")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["has_hypothesis_or_goal"] is True
+        app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_hypothesis_only_sets_true_realdb():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, title="Hyp-only")
+            hyp = await _make_hypothesis(s, org.id, project.id, caller_id)
+            await _link_hypothesis_story(s, hyp.id, story.id)
+
+        await _setup_app_human(app, Session, caller_user, org.id)
+        async with _client_for(app) as client:
+            resp = await client.get(f"/api/v2/stories/{story.id}")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["has_hypothesis_or_goal"] is True
+        app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_both_goal_and_hypothesis_sets_true_realdb():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, title="Both")
+            story.epic_id = goal.id
+            await s.commit()
+            hyp = await _make_hypothesis(s, org.id, project.id, caller_id)
+            await _link_hypothesis_story(s, hyp.id, story.id)
+
+        await _setup_app_human(app, Session, caller_user, org.id)
+        async with _client_for(app) as client:
+            resp = await client.get(f"/api/v2/stories/{story.id}")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["has_hypothesis_or_goal"] is True
+        app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_neither_leaves_none_not_false_realdb():
+    """⭐positive 단방향 규율 — 미매달림은 False가 아니라 None(필드 자체가 미설정)이어야
+    한다(has_evidence와 동형 규율, PO 명시)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, title="Neither")
+
+        await _setup_app_human(app, Session, caller_user, org.id)
+        async with _client_for(app) as client:
+            resp = await client.get(f"/api/v2/stories/{story.id}")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["has_hypothesis_or_goal"] is None
+        app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ② unattached=true 필터 ─────────────────────────────────────────────────────
+
+
+async def test_unattached_filter_returns_only_unlinked_stories_realdb():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id)
+            attached = await _make_story(s, org.id, project.id, title="Attached")
+            attached.epic_id = goal.id
+            await s.commit()
+            unattached = await _make_story(s, org.id, project.id, title="Unattached")
+
+        await _setup_app_human(app, Session, caller_user, org.id)
+        async with _client_for(app) as client:
+            resp = await client.get(f"/api/v2/stories?project_id={project.id}&unattached=true")
+            assert resp.status_code == 200, resp.text
+            ids = [item["id"] for item in resp.json()]
+            assert str(unattached.id) in ids
+            assert str(attached.id) not in ids
+
+            # 양성대조: unattached 미지정이면 둘 다 나온다(회귀 0 — 필터가 기본 동작을 안 바꿈).
+            resp_all = await client.get(f"/api/v2/stories?project_id={project.id}")
+            all_ids = [item["id"] for item in resp_all.json()]
+            assert str(unattached.id) in all_ids
+            assert str(attached.id) in all_ids
+        app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ③ attachment-suggestions ───────────────────────────────────────────────────
+
+
+async def test_attachment_suggestions_goal_type_with_open_candidate_realdb():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user = await _make_human_member(s, org.id, project.id)
+            await _make_goal(s, org.id, project.id, title="결제 시스템 안정화")
+            story = await _make_story(s, org.id, project.id, title="결제 시스템 버그 fix")
+
+        await _setup_app_human(app, Session, caller_user, org.id)
+        async with _client_for(app) as client:
+            resp = await client.get(f"/api/v2/stories/{story.id}/attachment-suggestions")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["suggested_type"] == "goal"
+            assert len(body["goal_candidates"]) == 1
+        app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_attachment_suggestions_excludes_closed_and_archived_realdb():
+    """⭐PO 락 확認 항목 — open(draft/active)만 후보, done/archived는 제외(doc §7-1
+    "더미 미표시"와 정합)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user = await _make_human_member(s, org.id, project.id)
+            await _make_goal(s, org.id, project.id, title="결제 시스템 개편", status="done")
+            await _make_goal(s, org.id, project.id, title="결제 시스템 아카이브", status="archived")
+            story = await _make_story(s, org.id, project.id, title="결제 시스템 버그 fix")
+
+        await _setup_app_human(app, Session, caller_user, org.id)
+        async with _client_for(app) as client:
+            resp = await client.get(f"/api/v2/stories/{story.id}/attachment-suggestions")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["goal_candidates"] == []
+        app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_attachment_suggestions_ambiguous_fills_both_lists_realdb():
+    """⭐AC 양성대조 — 어느 키워드도 안 걸린 애매한 작업엔 goal_candidates·
+    hypothesis_candidates 둘 다 채워져야 한다(제목 overlap이 있는 후보가 각각 있을 때)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user = await _make_human_member(s, org.id, project.id)
+            await _make_goal(s, org.id, project.id, title="프로필 페이지 목표")
+            await _make_hypothesis(s, org.id, project.id, caller_id, statement="프로필 페이지 개선 가설")
+            story = await _make_story(s, org.id, project.id, title="프로필 페이지 개편")
+
+        await _setup_app_human(app, Session, caller_user, org.id)
+        async with _client_for(app) as client:
+            resp = await client.get(f"/api/v2/stories/{story.id}/attachment-suggestions")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["suggested_type"] == "ambiguous"
+            assert len(body["goal_candidates"]) == 1
+            assert len(body["hypothesis_candidates"]) == 1
+        app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_attachment_suggestions_empty_when_no_overlap_realdb():
+    """⭐빈 제안 금지 원칙의 반대 증명 — overlap이 진짜 0이면 억지 후보 없이 정직하게
+    빈 리스트."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user = await _make_human_member(s, org.id, project.id)
+            await _make_goal(s, org.id, project.id, title="완전히 무관한 제목")
+            story = await _make_story(s, org.id, project.id, title="결제 시스템 버그 fix")
+
+        await _setup_app_human(app, Session, caller_user, org.id)
+        async with _client_for(app) as client:
+            resp = await client.get(f"/api/v2/stories/{story.id}/attachment-suggestions")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["goal_candidates"] == []
+        app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_ca37b2b0_stories_ids_batch_realdb.py
+++ b/backend/tests/test_ca37b2b0_stories_ids_batch_realdb.py
@@ -98,6 +98,10 @@ async def _call_list_stories(session, org_id, agent_id, ids_param):
         ids=ids_param,
         repo=repo,
         auth=_auth(agent_id),
+        # story #2532: 신규 Query 파라미터 — sentinel lint(scripts/lint_query_sentinel_
+        # direct_calls.py) baseline과 missing-set을 맞추기 위해 명시(이 호출부는 ids
+        # 분기라 다른 미기재 Query 파라미터들은 기존 baseline grandfather 그대로 둔다).
+        unattached=False,
     )
 
 


### PR DESCRIPTION
## Summary
- E-FLOW-V4 S2(조직원리 doc `flow-board-v4-hypothesis-scale` §4-1 v3 「구조적 결부」) — 명시적 block 없이, 매달지 않으면 뷰(지도·추천·서사)에서 자연히 빠지는 구조적 유도를 위한 BE 재료.
- 작업 생성 자체는 절대 막지 않는다(block 아님) — 이 PR은 판정 신호 + 자동제안 API만 신설.

## 구현
1. **`StoryResponse.has_hypothesis_or_goal`**(positive 단방향, `has_evidence`와 동형 규율 — True 또는 None, False 없음): `epic_id` 존재 OR `hypothesis_story_links` 존재 시에만 True. 모든 읽기 경로(list 4분기·get·create·update·status-update)에 배치 조회로 부착(`_attach_has_hypothesis_or_goal`, N+1 회피).
2. **`GET /api/v2/stories?unattached=true`** — 기존 list 엔드포인트에 필터만 추가(신규 엔드포인트 아님). `Query(...)` 센티널 함정(이 파일에 이미 있던 `boost_candidates_from` 경고와 동형 — 직접 호출 테스트가 bool 대신 센티널을 받는 문제) 방어 코드 포함.
3. **`GET /api/v2/stories/{id}/attachment-suggestions`** — 순수 결정론 함수(`attachment_suggestion.py`, `model_family.py` 스타일: LLM/DB 접근 0, 정규식/키워드만)로 title/description 분류(fix/버그/인프라→goal, 실험/검증→hypothesis, 매치 없거나 둘 다 매치→ambiguous) + 프로젝트 내 **open**(goal: draft/active, hypothesis: proposed/active/measuring) 후보를 토큰 overlap으로 랭킹. overlap 0인 후보는 내지 않는다(빈 제안 금지).
4. `hypothesis.py::batch_stories_with_hypothesis_link` — `evidence_service.batch_has_evidence`와 동형 배치 조회.

## AC (페드루 오르테가 락, 2026-08-08)
- [x] 작업 생성 時 block 안 함 — 안 매달아도 생성은 그대로 성공, 미매달림으로 표시만.
- [x] 유형 추론 자동제안(fix/infra→goal·실험→hypothesis·양성대조: 애매한 작업엔 둘 다 후보).
- [x] 미매달림 판정 조회 API(뷰 결부 재료).
- [x] 기존 2,180건 무회귀 — 필드 미설정=None, backfill 강요 없음.
- [x] open만 후보(closed/archived 제외 — doc §7-1 "더미 미표시" 정합).
- [x] metric_definition NOT NULL 마찰 회피 — 새 가설 필요 시 `/hypotheses/draft` 재사용 전제(이 PR은 기존 후보 제시까지만).
- [x] HITL 게이트(hitl-gating-policy-v1) — 그라운딩 결과 AC 원문에 없고 실구현도 done/merge 전용 미완이라 스코프 제외(참고 연결점일 뿐).
- [x] 도그푸딩(MCP add_story/add_goal 소비)은 별도 레포 — 이 PR은 BE API 신설까지.

## Test plan
- [x] `test_2532_attachment_suggestion.py` — 순수함수 유닛 13건(분류·랭킹·top-N·overlap 0 제외).
- [x] `test_2532_hypothesis_goal_attachment_realdb.py` — 실PG 9건: has_hypothesis_or_goal 양성대조 4케이스(목표만/가설만/둘다/둘없음·PO 명시 요구), unattached 필터, attachment-suggestions(goal 분류·open만·ambiguous 양쪽 채움·overlap 0 정직한 빈 리스트).
- [x] 기존 story 관련 mock 스위트(9개 파일 89건) — 회귀 0.
- [x] 뮤테이션 셀프체크 2건(has_hypothesis_or_goal 판정 조건·open-status 필터) — 가드 제거 RED 확認 → 복원 GREEN.
- [x] ruff check: 신규/변경 라인 이슈 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)