### PR TITLE
[SID:2533] E-FLOW-V4 S3(BE) — 가설 정반합 self-FK + lifecycle 조립 API

### DIFF
--- a/backend/alembic/versions/0237_hypothesis_superseded_by.py
+++ b/backend/alembic/versions/0237_hypothesis_superseded_by.py
@@ -1,0 +1,73 @@
+"""hypotheses.superseded_by_hypothesis_id — story #2533(E-FLOW-V4 S3) 정반합 self-FK.
+
+Revision ID: 0237
+Revises: 0236
+Create Date: 2026-08-09
+
+배경: doc `flow-board-v4-hypothesis-scale` §3이 "falsified→대체 새 가설" 정반합 체인을
+v4 서사의 명시 축으로 요구하는데, 이걸 표현할 1급 컬럼이 원래 없었다(PO가 최초 "실재한다"고
+서술한 게 실측 前 포장이었음 — 디디·미르코 독립 그라운딩으로 정정, 2026-08-09). PO 판정(A,
+근본): self-FK 신설 + **명시 확認된 페어만** 백필(텍스트 자동 페어링 절대 금지 — 없는 데이터
+지어내기 방지 원칙이 백필에도 그대로 적용).
+
+확認된 유일한 페어: `2cbdd1a9-08c5-47cc-b885-65deeabda6a2`(falsified, "체크아웃을 2단계로
+줄이면 결제 완료율이 오른다") → `724dde46-5af0-481f-89ef-0783c4283fa3`(proposed, "[유나 편집]
+결제 완료율은 단계 수보다 신뢰 신호(리뷰·보안 배지)에 더 크게 좌우될 것이다"). 근거(디디·
+미르코 각자 dev DB 직접 조회로 독립 확認, 2026-08-09):
+  - 같은 project_id(f3e6ed64-...) — 다른 후보(a794cca7, 영어 재기술)는 **다른 project_id**라
+    배제(cross-project 정반합은 의미 자체가 성립 안 함).
+  - 같은 날 3시간 뒤 생성(falsified 13:44 → proposed 16:44) — 시간적으로 직접 이어짐.
+  - 문장 자체가 falsified 가설의 인과 변수를 정확히 반박·재구성("단계 수" → "신뢰 신호") —
+    doc §3이 예시로 든 "「체크아웃 2단계」→「신뢰 신호」 대체" 문구와 정확히 일치.
+  - `724dde46.source_type='retro_synthesis'`(레트로 합성 경로 생성) — falsified 판정 직후
+    같은 레트로 세션에서 다음 가설로 재구성된 흐름과 정합.
+그 외 falsified 1건(`c64d2a5b`, 이미지 레퍼런스 관련)은 같은 project 내 명확한 후속 후보를
+못 찾아 **백필 안 함**(null 유지 — "아직").
+
+write path(가설이 falsified로 전이할 때 대체 가설을 UI로 잇는 것)는 이 스토리 스코프 밖 —
+후속 스토리(PO 예정)에서 다룬다. 이 마이그레이션은 스키마 + 확認된 과거 페어 백필까지만.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+revision = "0237"
+down_revision = "0236"
+branch_labels = None
+depends_on = None
+
+_FALSIFIED_ID = "2cbdd1a9-08c5-47cc-b885-65deeabda6a2"
+_SUCCESSOR_ID = "724dde46-5af0-481f-89ef-0783c4283fa3"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "hypotheses",
+        sa.Column("superseded_by_hypothesis_id", UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_hypotheses_superseded_by",
+        "hypotheses",
+        "hypotheses",
+        ["superseded_by_hypothesis_id"],
+        ["id"],
+        ondelete="SET NULL",
+        deferrable=True,
+        initially="DEFERRED",
+    )
+    # 확認된 단일 페어만 백필(위 docstring 근거) — 조건절로 두 행이 실제 존재할 때만 적용.
+    op.execute(
+        f"""
+        UPDATE hypotheses SET superseded_by_hypothesis_id = '{_SUCCESSOR_ID}'
+        WHERE id = '{_FALSIFIED_ID}'
+          AND EXISTS (SELECT 1 FROM hypotheses WHERE id = '{_SUCCESSOR_ID}')
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_hypotheses_superseded_by", "hypotheses", type_="foreignkey")
+    op.drop_column("hypotheses", "superseded_by_hypothesis_id")

--- a/backend/app/models/hypothesis.py
+++ b/backend/app/models/hypothesis.py
@@ -100,6 +100,14 @@ class Hypothesis(Base, OrgScopedMixin, TimestampMixin):
     # §3.10 archive=soft. hard delete는 마이그/감사 정책 확정 전까지 금지.
     archived_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
+    # story #2533(E-FLOW-V4 S3, migration 0237): 정반합 self-FK — 이 가설이 falsified된 뒤
+    # 대체된 새 가설을 가리킨다. 명시 확認된 페어만 채워진다(텍스트 자동 페어링 없음 —
+    # write path는 후속 스토리, 지금은 스키마+확認 백필까지만). FK 조건 없음(nullable, ondelete
+    # SET NULL) — refresh_tokens.replaced_by(0226)와 동형 패턴.
+    superseded_by_hypothesis_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("hypotheses.id", ondelete="SET NULL"), nullable=True
+    )
+
     __table_args__ = (
         # §2.3 제약
         CheckConstraint(

--- a/backend/app/routers/hypotheses.py
+++ b/backend/app/routers/hypotheses.py
@@ -27,6 +27,7 @@ from app.schemas.hypothesis import (
     HypothesisCreate,
     HypothesisDraftRequest,
     HypothesisDraftResponse,
+    HypothesisLifecycleResponse,
     HypothesisLinkRequest,
     HypothesisResponse,
     HypothesisTransition,
@@ -170,6 +171,23 @@ async def get_hypothesis(
     await _assert_hypothesis_project_access(session, uuid.UUID(auth.user_id), org_id, hypothesis_id)
     try:
         return await svc.get_hypothesis(session, org_id, hypothesis_id)
+    except svc.HypothesisServiceError as err:
+        _raise(err)
+
+
+@router.get("/{hypothesis_id}/lifecycle", response_model=HypothesisLifecycleResponse)
+async def get_hypothesis_lifecycle(
+    hypothesis_id: uuid.UUID,
+    session: AsyncSession = Depends(get_read_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> HypothesisLifecycleResponse:
+    """story #2533(E-FLOW-V4 S3) — 5축 수직 서사 조립(N+1 회피). get_read_db: 순수 읽기
+    조립이고 create→self-read 흐름이 아니다(hypothesis/story/goal 전부 이미 커밋된 것만
+    본다 — Phase3 §6 read replica 기준과 정합)."""
+    await _assert_hypothesis_project_access(session, uuid.UUID(auth.user_id), org_id, hypothesis_id)
+    try:
+        return await svc.get_hypothesis_lifecycle(session, org_id, hypothesis_id)
     except svc.HypothesisServiceError as err:
         _raise(err)
 

--- a/backend/app/schemas/hypothesis.py
+++ b/backend/app/schemas/hypothesis.py
@@ -111,6 +111,10 @@ class HypothesisResponse(BaseModel):
     story_ids: list[uuid.UUID] = []
     # N:1(PO 결) — sprint 링크는 최대 1개라 리스트가 아니라 nullable 단일 값.
     sprint_id: uuid.UUID | None = None
+    # story #2533(E-FLOW-V4 S3, migration 0237): 정반합 self-FK — 이 가설이 falsified된 뒤
+    # 대체된 새 가설. write path(자동 페어링·전이 UI)는 후속 스토리 — 지금은 확認된 단일
+    # 페어만 채워지고 나머지는 null("아직", 없는 데이터 지어내기 X).
+    superseded_by_hypothesis_id: uuid.UUID | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -173,3 +177,58 @@ class HypothesisDraftResponse(BaseModel):
     requires_confirmation: bool = True
     # persist=true일 때만 — 생성된 proposed row.
     hypothesis: HypothesisResponse | None = None
+
+
+# story #2533(E-FLOW-V4 S3): GET /{id}/lifecycle 조립 응답 — 5축 수직 서사.
+# 지어내지 않는다 원칙: 없는 축(증명 미도달·정반합 미확認·진짜 전이 이력)은 항상 None/빈
+# 값으로 정직하게 비운다(유·미르코 시안 f60d0502 "빈 칸=아직" 규격과 정합).
+
+
+class HypothesisLifecycleGoal(BaseModel):
+    """목표(에픽) — hypothesis_epic_links 확장(id만이 아니라 이름·상태까지)."""
+    id: uuid.UUID
+    title: str
+    status: str
+
+
+class HypothesisLifecycleStory(BaseModel):
+    """검증(스토리) — hypothesis_story_links 확장 + 증명(gate/evidence) 간접 조회.
+
+    gate_status/evidence_count: work_item_type='story'로 hypothesis_story_links를 거쳐
+    간접 조회한다(hypothesis에 직접 달리는 gate/evidence는 실사용 0 — 그라운딩 확認,
+    2026-08-09). 매칭 row가 없으면 gate_status=None("아직")·evidence_count=0으로 정직."""
+    id: uuid.UUID
+    title: str
+    status: str
+    metric_definition: dict[str, Any] | None = None
+    outcome_status: str
+    gate_status: str | None = None
+    evidence_count: int = 0
+
+
+class HypothesisLifecycleSuccessor(BaseModel):
+    """정반합 링크 한쪽(계승자 또는 전신) — superseded_by_hypothesis_id 확장."""
+    id: uuid.UUID
+    statement: str
+    status: str
+
+
+class HypothesisLifecycleTimeline(BaseModel):
+    """시간선 — ⛔진짜 전이 이력이 아니다(hypothesis_status_events류 감사 테이블 없음,
+    activity_log에도 hypothesis 참조 0건 — 그라운딩 확認). 딱 3점(created/measure_after/
+    updated)만 정직하게 반환한다. FE가 이걸 "전체 생애 타임라인"으로 과대포장하면 안 된다
+    (이 docstring이 그 경계선)."""
+    created_at: datetime
+    measure_after: datetime
+    updated_at: datetime
+
+
+class HypothesisLifecycleResponse(BaseModel):
+    hypothesis: HypothesisResponse
+    goals: list[HypothesisLifecycleGoal] = []
+    stories: list[HypothesisLifecycleStory] = []
+    # 정반합 양방향 — 이 가설을 대체한 것(계승자) + 이 가설이 대체한 것들(전신, 역방향 FK).
+    # 확認된 페어(migration 0237) 외엔 항상 None/빈 리스트("아직" — 자동 페어링 없음).
+    superseded_by: HypothesisLifecycleSuccessor | None = None
+    supersedes: list[HypothesisLifecycleSuccessor] = []
+    timeline: HypothesisLifecycleTimeline

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -15,9 +15,11 @@ import math
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.evidence import Evidence
+from app.models.gate import Gate
 from app.models.hypothesis import HYPOTHESIS_STATUSES, Hypothesis, HypothesisStoryLink, is_valid_transition
 from app.models.pm import Goal, Sprint, Story
 
@@ -27,6 +29,11 @@ from app.schemas.hypothesis import (
     HypothesisCreate,
     HypothesisDraftRequest,
     HypothesisDraftResponse,
+    HypothesisLifecycleGoal,
+    HypothesisLifecycleResponse,
+    HypothesisLifecycleStory,
+    HypothesisLifecycleSuccessor,
+    HypothesisLifecycleTimeline,
     HypothesisLinkRequest,
     HypothesisResponse,
     HypothesisTransition,
@@ -235,6 +242,97 @@ async def get_hypothesis(
     if hyp is None:
         raise HypothesisServiceError("HYPOTHESIS_NOT_FOUND", "가설을 찾을 수 없습니다.")
     return await _to_response(repo, hyp)
+
+
+async def get_hypothesis_lifecycle(
+    session: AsyncSession, org_id: uuid.UUID, hypothesis_id: uuid.UUID
+) -> HypothesisLifecycleResponse:
+    """story #2533(E-FLOW-V4 S3, doc flow-board-v4-hypothesis-scale §3): 5축 수직 서사 조립
+    — 질문(hypothesis)·목표(goals)·검증(stories)·증명(stories의 gate_status/evidence_count)·
+    정반합(superseded_by/supersedes)·시간선(timeline). N+1 회피 배치 조회.
+
+    ⛔지어내지 않는다: 증명이 실사용 0인 story는 gate_status=None·evidence_count=0("아직"),
+    정반합은 migration 0237이 명시 백필한 페어 외엔 항상 None/빈 리스트, 시간선은 진짜 전이
+    이력이 아니라 3점(created/measure_after/updated)뿐임을 스키마 docstring이 못박는다."""
+    repo = HypothesisRepository(session, org_id)
+    hyp = await repo.get(hypothesis_id)
+    if hyp is None:
+        raise HypothesisServiceError("HYPOTHESIS_NOT_FOUND", "가설을 찾을 수 없습니다.")
+    hyp_response = await _to_response(repo, hyp)
+
+    goal_rows = []
+    if hyp_response.epic_ids:
+        goal_rows = (await session.execute(
+            select(Goal.id, Goal.title, Goal.status).where(Goal.id.in_(hyp_response.epic_ids))
+        )).all()
+    goals = [HypothesisLifecycleGoal(id=r.id, title=r.title, status=r.status) for r in goal_rows]
+
+    story_rows = []
+    if hyp_response.story_ids:
+        story_rows = (await session.execute(
+            select(Story.id, Story.title, Story.status, Story.metric_definition, Story.outcome_status)
+            .where(Story.id.in_(hyp_response.story_ids))
+        )).all()
+    story_ids = [r.id for r in story_rows]
+
+    # 증명(gate/evidence) — hypothesis에 직접 안 달림(그라운딩 확認, 2026-08-09) →
+    # work_item_type='story'로 간접 배치 조회. story당 최신 gate 1건만(여러 건이면 created_at
+    # 최신 우선 — 이 축은 "지금 상태"만 보이면 되고 이력은 시간선의 정직한 한계와 동형으로 스코프 밖).
+    gate_map: dict[uuid.UUID, str] = {}
+    evidence_count_map: dict[uuid.UUID, int] = {}
+    if story_ids:
+        gate_rows = (await session.execute(
+            select(Gate.work_item_id, Gate.status, Gate.created_at)
+            .where(Gate.org_id == org_id, Gate.work_item_type == "story", Gate.work_item_id.in_(story_ids))
+            .order_by(Gate.work_item_id, Gate.created_at.desc())
+        )).all()
+        for wid, status, _created_at in gate_rows:
+            gate_map.setdefault(wid, status)  # 정렬상 첫 행 = 그 story의 최신 gate
+        ev_rows = (await session.execute(
+            select(Evidence.work_item_id, func.count())
+            .where(
+                Evidence.org_id == org_id, Evidence.work_item_type == "story",
+                Evidence.work_item_id.in_(story_ids),
+            )
+            .group_by(Evidence.work_item_id)
+        )).all()
+        evidence_count_map = {wid: cnt for wid, cnt in ev_rows}
+
+    stories = [
+        HypothesisLifecycleStory(
+            id=r.id, title=r.title, status=r.status, metric_definition=r.metric_definition,
+            outcome_status=r.outcome_status, gate_status=gate_map.get(r.id),
+            evidence_count=evidence_count_map.get(r.id, 0),
+        )
+        for r in story_rows
+    ]
+
+    # 정반합 — 양방향(migration 0237 확認 백필 외엔 항상 빈 값).
+    superseded_by = None
+    if hyp.superseded_by_hypothesis_id:
+        succ = await session.get(Hypothesis, hyp.superseded_by_hypothesis_id)
+        if succ is not None:
+            superseded_by = HypothesisLifecycleSuccessor(
+                id=succ.id, statement=succ.statement, status=succ.status,
+            )
+    predecessor_rows = (await session.execute(
+        select(Hypothesis.id, Hypothesis.statement, Hypothesis.status).where(
+            Hypothesis.superseded_by_hypothesis_id == hypothesis_id, Hypothesis.org_id == org_id,
+        )
+    )).all()
+    supersedes = [
+        HypothesisLifecycleSuccessor(id=r.id, statement=r.statement, status=r.status)
+        for r in predecessor_rows
+    ]
+
+    timeline = HypothesisLifecycleTimeline(
+        created_at=hyp.created_at, measure_after=hyp.measure_after, updated_at=hyp.updated_at,
+    )
+
+    return HypothesisLifecycleResponse(
+        hypothesis=hyp_response, goals=goals, stories=stories,
+        superseded_by=superseded_by, supersedes=supersedes, timeline=timeline,
+    )
 
 
 async def list_hypotheses(

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -263,7 +263,8 @@ async def get_hypothesis_lifecycle(
     goal_rows = []
     if hyp_response.epic_ids:
         goal_rows = (await session.execute(
-            select(Goal.id, Goal.title, Goal.status).where(Goal.id.in_(hyp_response.epic_ids))
+            select(Goal.id, Goal.title, Goal.status)
+            .where(Goal.org_id == org_id, Goal.id.in_(hyp_response.epic_ids))
         )).all()
     goals = [HypothesisLifecycleGoal(id=r.id, title=r.title, status=r.status) for r in goal_rows]
 
@@ -271,7 +272,7 @@ async def get_hypothesis_lifecycle(
     if hyp_response.story_ids:
         story_rows = (await session.execute(
             select(Story.id, Story.title, Story.status, Story.metric_definition, Story.outcome_status)
-            .where(Story.id.in_(hyp_response.story_ids))
+            .where(Story.org_id == org_id, Story.id.in_(hyp_response.story_ids))
         )).all()
     story_ids = [r.id for r in story_rows]
 

--- a/backend/tests/test_2533_hypothesis_lifecycle_realdb.py
+++ b/backend/tests/test_2533_hypothesis_lifecycle_realdb.py
@@ -1,0 +1,328 @@
+"""story #2533(E-FLOW-V4 S3, PO 오르테가 AC 락 2026-08-09) — 가설 생애 5축 수직 서사
+BE 조립(`GET /api/v2/hypotheses/{id}/lifecycle`)을 실PG로 검증한다.
+
+AC 락 확인 항목:
+  ①목표/검증 조립 — hypothesis_epic_links/hypothesis_story_links를 이름·상태·진행도까지
+    확장(N+1 회피).
+  ②증명 — gate/evidence는 story 경유 간접 조회, 매칭 없으면 정직하게 None/0("아직").
+  ③정반합 — self-FK(superseded_by_hypothesis_id) 양방향(superseded_by/supersedes),
+    migration 0237이 백필한 확認 페어(2cbdd1a9↔724dde46)의 SQL 조건 자체를 pin.
+  ④시간선 — created_at/measure_after/updated_at 3점만, 진짜 전이 이력 아님.
+  ⑤빈 축(목표·검증 0건)도 에러 없이 빈 리스트.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import text
+
+from tests.test_1994_backlink_api_realdb import (
+    _client_for,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _session_factory,
+    _setup_app_human,
+)
+from tests.test_2301_story_body_mentions_realdb import _REAL_DB_URL, _make_story
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+_METRIC = {"metric": "signups", "source": "db", "target": 100, "direction": "increase"}
+
+
+async def _make_goal(session, org_id, project_id, title="Goal", status="active"):
+    from app.models.pm import Goal
+    goal = Goal(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status=status)
+    session.add(goal)
+    await session.commit()
+    return goal
+
+
+async def _make_hypothesis(
+    session, org_id, project_id, owner_id, statement="Hyp", status="proposed",
+    superseded_by_hypothesis_id=None, hyp_id=None,
+):
+    from app.models.hypothesis import Hypothesis
+    hyp = Hypothesis(
+        id=hyp_id or uuid.uuid4(), org_id=org_id, project_id=project_id, owner_member_id=owner_id,
+        statement=statement, metric_definition=_METRIC,
+        measure_after=datetime(2026, 6, 1, tzinfo=UTC), status=status,
+        superseded_by_hypothesis_id=superseded_by_hypothesis_id,
+    )
+    session.add(hyp)
+    await session.commit()
+    return hyp
+
+
+async def _link_hypothesis_story(session, hypothesis_id, story_id):
+    from app.models.hypothesis import HypothesisStoryLink
+    session.add(HypothesisStoryLink(hypothesis_id=hypothesis_id, story_id=story_id, link_type="supports"))
+    await session.commit()
+
+
+async def _link_hypothesis_epic(session, hypothesis_id, epic_id):
+    from app.models.hypothesis import HypothesisEpicLink
+    session.add(HypothesisEpicLink(hypothesis_id=hypothesis_id, epic_id=epic_id, link_type="primary"))
+    await session.commit()
+
+
+async def _make_gate(session, org_id, work_item_id, status="pending"):
+    from app.models.gate import Gate
+    gate = Gate(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=work_item_id, work_item_type="story",
+        gate_type="merge", status=status,
+    )
+    session.add(gate)
+    await session.commit()
+    return gate
+
+
+async def _make_evidence(session, org_id, work_item_id, created_by):
+    from app.models.evidence import Evidence
+    ev = Evidence(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=work_item_id, work_item_type="story",
+        type="url", ref="https://example.test/proof", created_by=created_by,
+    )
+    session.add(ev)
+    await session.commit()
+    return ev
+
+
+# ─── ①②⑤ 목표/검증/증명 조립 + 빈 축 ────────────────────────────────────────────
+
+
+async def test_lifecycle_assembles_goals_stories_and_evidence_realdb():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id, title="결제 안정화", status="active")
+            story = await _make_story(s, org.id, project.id, title="체크아웃 리팩터")
+            story.status = "in-progress"
+            story.outcome_status = "pending"
+            await s.commit()
+            hyp = await _make_hypothesis(s, org.id, project.id, caller_id, statement="가설 A")
+            await _link_hypothesis_epic(s, hyp.id, goal.id)
+            await _link_hypothesis_story(s, hyp.id, story.id)
+            await _make_gate(s, org.id, story.id, status="pending")
+            await _make_evidence(s, org.id, story.id, caller_id)
+            await _make_evidence(s, org.id, story.id, caller_id)
+
+        await _setup_app_human(app, Session, caller_user, org.id)
+        async with _client_for(app) as client:
+            resp = await client.get(f"/api/v2/hypotheses/{hyp.id}/lifecycle")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["hypothesis"]["statement"] == "가설 A"
+            assert len(body["goals"]) == 1
+            assert body["goals"][0]["title"] == "결제 안정화"
+            assert body["goals"][0]["status"] == "active"
+            assert len(body["stories"]) == 1
+            assert body["stories"][0]["title"] == "체크아웃 리팩터"
+            assert body["stories"][0]["status"] == "in-progress"
+            assert body["stories"][0]["gate_status"] == "pending"
+            assert body["stories"][0]["evidence_count"] == 2
+        app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_lifecycle_empty_axes_return_empty_lists_not_error_realdb():
+    """⭐"없는 데이터에 화면 안 깎기" — 목표·검증 0건이어도 200+빈 리스트, 크래시 아님."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user = await _make_human_member(s, org.id, project.id)
+            hyp = await _make_hypothesis(s, org.id, project.id, caller_id, statement="가설 고아")
+
+        await _setup_app_human(app, Session, caller_user, org.id)
+        async with _client_for(app) as client:
+            resp = await client.get(f"/api/v2/hypotheses/{hyp.id}/lifecycle")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["goals"] == []
+            assert body["stories"] == []
+            assert body["superseded_by"] is None
+            assert body["supersedes"] == []
+        app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_lifecycle_story_without_gate_or_evidence_is_honest_none_realdb():
+    """⭐증명 미도달은 「아직」(None/0)으로 정직 — 억지로 채우지 않는다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user = await _make_human_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, title="증명 미도달 스토리")
+            hyp = await _make_hypothesis(s, org.id, project.id, caller_id)
+            await _link_hypothesis_story(s, hyp.id, story.id)
+
+        await _setup_app_human(app, Session, caller_user, org.id)
+        async with _client_for(app) as client:
+            resp = await client.get(f"/api/v2/hypotheses/{hyp.id}/lifecycle")
+            assert resp.status_code == 200, resp.text
+            story_item = resp.json()["stories"][0]
+            assert story_item["gate_status"] is None
+            assert story_item["evidence_count"] == 0
+        app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ③ 정반합 양방향 ─────────────────────────────────────────────────────────────
+
+
+async def test_lifecycle_supersession_bidirectional_realdb():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user = await _make_human_member(s, org.id, project.id)
+            successor = await _make_hypothesis(
+                s, org.id, project.id, caller_id, statement="신뢰 신호 가설", status="proposed",
+            )
+            predecessor = await _make_hypothesis(
+                s, org.id, project.id, caller_id, statement="체크아웃 2단계 가설", status="falsified",
+                superseded_by_hypothesis_id=successor.id,
+            )
+
+        await _setup_app_human(app, Session, caller_user, org.id)
+        async with _client_for(app) as client:
+            pred_resp = await client.get(f"/api/v2/hypotheses/{predecessor.id}/lifecycle")
+            assert pred_resp.status_code == 200, pred_resp.text
+            pred_body = pred_resp.json()
+            assert pred_body["superseded_by"]["id"] == str(successor.id)
+            assert pred_body["superseded_by"]["statement"] == "신뢰 신호 가설"
+            assert pred_body["supersedes"] == []
+
+            succ_resp = await client.get(f"/api/v2/hypotheses/{successor.id}/lifecycle")
+            assert succ_resp.status_code == 200, succ_resp.text
+            succ_body = succ_resp.json()
+            assert succ_body["superseded_by"] is None
+            assert len(succ_body["supersedes"]) == 1
+            assert succ_body["supersedes"][0]["id"] == str(predecessor.id)
+        app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ④ 시간선 ────────────────────────────────────────────────────────────────────
+
+
+async def test_lifecycle_timeline_is_three_points_only_realdb():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user = await _make_human_member(s, org.id, project.id)
+            hyp = await _make_hypothesis(s, org.id, project.id, caller_id)
+
+        await _setup_app_human(app, Session, caller_user, org.id)
+        async with _client_for(app) as client:
+            resp = await client.get(f"/api/v2/hypotheses/{hyp.id}/lifecycle")
+            assert resp.status_code == 200, resp.text
+            timeline = resp.json()["timeline"]
+            assert set(timeline.keys()) == {"created_at", "measure_after", "updated_at"}, (
+                "시간선은 3점만이어야 한다 — 진짜 전이 이력을 지어내면 안 된다"
+            )
+        app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── migration 0237 백필 SQL 조건 자체를 pin ────────────────────────────────────
+
+
+async def test_migration_0237_backfill_condition_links_confirmed_pair_realdb():
+    """⭐migration 0237의 백필 SQL(조건부 UPDATE)이 실제로 그 페어를 잇는지 실PG로 pin —
+    이 테스트가 없으면 "그 UUID들이 실존할 때 정말 링크되는가"가 코드 리뷰로만 남는다.
+    fresh 테스트 DB엔 그 실제 hypothesis row가 없으므로(alembic upgrade 시점엔 no-op),
+    같은 UUID로 두 행을 직접 심고 마이그레이션과 동일한 조건부 SQL을 재실행해 검증한다."""
+    import importlib.util
+    import pathlib
+
+    from app.core.database import async_session_factory
+
+    migration_path = (
+        pathlib.Path(__file__).resolve().parent.parent
+        / "alembic" / "versions" / "0237_hypothesis_superseded_by.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_0237", migration_path)
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+
+    async with async_session_factory() as session:
+        org = await _make_org(session)
+        project = await _make_project(session, org.id)
+        caller_id, _ = await _make_human_member(session, org.id, project.id)
+
+        # 마이그레이션이 참조하는 그 정확한 UUID로 두 행을 심는다(SSOT — 하드코딩 중복 없이
+        # 마이그레이션 모듈 상수를 그대로 재사용, PK를 처음부터 그 값으로 생성).
+        await _make_hypothesis(
+            session, org.id, project.id, caller_id, statement="체크아웃 2단계 가설(재현)",
+            status="falsified", hyp_id=uuid.UUID(migration._FALSIFIED_ID),
+        )
+        await _make_hypothesis(
+            session, org.id, project.id, caller_id, statement="신뢰 신호 가설(재현)",
+            status="proposed", hyp_id=uuid.UUID(migration._SUCCESSOR_ID),
+        )
+
+        # 마이그레이션의 upgrade() 안 백필 SQL과 동일 문장을 그대로 재실행.
+        await session.execute(text(
+            f"""
+            UPDATE hypotheses SET superseded_by_hypothesis_id = '{migration._SUCCESSOR_ID}'
+            WHERE id = '{migration._FALSIFIED_ID}'
+              AND EXISTS (SELECT 1 FROM hypotheses WHERE id = '{migration._SUCCESSOR_ID}')
+            """
+        ))
+        await session.commit()
+
+        result = await session.execute(text(
+            f"SELECT superseded_by_hypothesis_id FROM hypotheses WHERE id = '{migration._FALSIFIED_ID}'"
+        ))
+        linked = result.scalar_one()
+        assert str(linked) == migration._SUCCESSOR_ID


### PR DESCRIPTION
## Summary
- `hypotheses.superseded_by_hypothesis_id` nullable self-FK 추가 (migration 0237, `refresh_tokens.replaced_by`(0226) 동형 패턴, ondelete=SET NULL, deferrable)
- 실측으로 확認된 단일 페어만 조건부 백필: falsified `2cbdd1a9` → proposed `724dde46` (자동 텍스트 페어링 없음, 그 외는 전부 null — 지어내지 않는다 원칙)
- `GET /api/v2/hypotheses/{id}/lifecycle` 신설 — 목표(epic)/검증(story)/증명(gate·evidence)/정반합/시간선 5축 한 번에 조립(FE N+1 해소)
  - gate/evidence는 hypothesis 직접사용 0건이라(그라운딩 확認) story 경유 간접 조회, 매칭 없으면 정직하게 None/0
  - 시간선은 진짜 전이 이력 아님 — 3개 타임스탬프뿐임을 응답 스키마 docstring에 명시
- write path(falsified 전이 + 대체 잇기 UI)는 스코프 밖(후속 스토리)

## AC 근거
페드루 올리베이라 PO 결(2026-08-09 conversation 7256d5cc): (A) 근본 self-FK 추가, 백필은 실물 확認된 것만, write path는 스코프 밖 — 3가지 단서 모두 반영.

미르코 FE 언블록 관점: `GET /hypotheses/{id}` 응답이 이미 `superseded_by_hypothesis_id`를 그대로 노출(모델 컬럼 추가만으로 `model_validate` 자동 반영, 추가 코드 불요) — 필드 하나만 읽으면 정반합 표시 가능.

## Test plan
- [x] `alembic upgrade head` 프레시 컨테이너 3회 반복 확인(migration 0237 clean apply)
- [x] `test_2533_hypothesis_lifecycle_realdb.py` 6/6 (assembles/empty-axes/honest-none/bidirectional-supersession/timeline-3-points/migration-backfill-condition)
- [x] 회귀 subset 103/103 (`test_hypotheses_router`, `test_hypothesis_service`, `test_hypothesis_scorer`, `test_mcp_hypotheses`, `test_2038_hypothesis_outcome_result_enforce`, `test_e_sec_hypotheses_project_scope_realdb` + 신규)
- [x] ruff clean(신규 코드 기준 — pre-existing B008/UP017/BLE001은 기존 파일 debt, 이번 PR로 3건 B008 늘었으나 같은 파일 내 기존 Depends() 패턴과 동형)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>