### PR TITLE
[SID:2536] E-FLOW-V4 S4(BE) — 일별 unattached_count 스냅샷 테이블 + cron

### DIFF
--- a/apps/web/src/app/api/cron/unattached-snapshot/route.ts
+++ b/apps/web/src/app/api/cron/unattached-snapshot/route.ts
@@ -1,0 +1,9 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function POST(request: Request) {
+  const _r = await proxyToFastapi(request, '/api/v2/internal/cron/unattached-snapshot');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
+}

--- a/backend/alembic/versions/0237_unattached_story_snapshots.py
+++ b/backend/alembic/versions/0237_unattached_story_snapshots.py
@@ -1,0 +1,44 @@
+"""story #2536(E-FLOW-V4 S4) — 프로젝트별 unattached_count 일별 스냅샷 테이블.
+
+append-only(org_member_trust_snapshots 0135류와 동형). v4 강제(S2, #2532)가 신규 story의
+가설/목표 부착을 요구하므로 기존 미매달림 총량이 시간에 걸쳐 줄어야 하고, 그 추세를 재는
+«측정 도구»가 이 테이블 — 과거 소급 불가라 오늘부터 쌓아야 한다.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+revision = "0237"
+down_revision = "0236"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "unattached_story_snapshots",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "project_id", UUID(as_uuid=True),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"), nullable=False,
+        ),
+        sa.Column("unattached_count", sa.Integer(), nullable=False),
+        sa.Column(
+            "computed_at", sa.DateTime(timezone=True),
+            server_default=sa.text("now()"), nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_unattached_snapshot_org_project_time",
+        "unattached_story_snapshots",
+        ["org_id", "project_id", "computed_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_unattached_snapshot_org_project_time", table_name="unattached_story_snapshots")
+    op.drop_table("unattached_story_snapshots")

--- a/backend/alembic/versions/0238_unattached_story_snapshots.py
+++ b/backend/alembic/versions/0238_unattached_story_snapshots.py
@@ -11,8 +11,8 @@ from sqlalchemy.dialects.postgresql import UUID
 
 from alembic import op
 
-revision = "0237"
-down_revision = "0236"
+revision = "0238"
+down_revision = "0237"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -84,6 +84,7 @@ from app.models.role_template import RoleTemplate
 # "등재를 미루는 것"이 아니라 "파일마다 전체 스키마를 create_all/drop_all하는 구조 자체를
 # 먼저 손보는 것"이 그 스토리의 실제 과제.
 from app.models.trust_snapshot import OrgMemberTrustSnapshot
+from app.models.unattached_snapshot import UnattachedStorySnapshot
 from app.models.visual_artifact import ArtifactNode, ArtifactVersion, VisualArtifact
 # fix(2026-07-20, #2058 후속 CI 적출): 이 두 모듈이 여기 없어 `import app.models`만으로는
 # Base.metadata에 등록 안 됐다 — participation_role을 참조하는 FK(hitl_config.OrgGateOverride/
@@ -184,6 +185,7 @@ __all__ = [
     "StoryAssignee",
     "Task",
     "TeamMember",
+    "UnattachedStorySnapshot",
     "LoginAuditLog",
     "RefreshToken",
     "User",

--- a/backend/app/models/unattached_snapshot.py
+++ b/backend/app/models/unattached_snapshot.py
@@ -1,0 +1,35 @@
+"""story #2536(E-FLOW-V4 S4): 프로젝트별 unattached_count 일별 스냅샷.
+
+append-only(org_member_trust_snapshots·entity_slug_history와 동형: update 없음·
+upsert 없음). v4 강제(S2)가 신규 story에 가설/목표 부착을 요구하므로 기존
+미매달림(unattached) 총량이 시간에 걸쳐 줄어야 하고, 그 추세를 그리는 «측정
+도구»가 이 테이블이다 — 오늘부터 쌓여야 하는 시계열(과거 소급 불가)."""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+from app.models.base import OrgScopedMixin
+
+
+class UnattachedStorySnapshot(Base, OrgScopedMixin):
+    __tablename__ = "unattached_story_snapshots"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False
+    )
+    unattached_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    computed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_unattached_snapshot_org_project_time",
+            "org_id", "project_id", "computed_at",
+        ),
+    )

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -645,6 +645,32 @@ async def embed_backfill_cron(
         return _err("INTERNAL_ERROR", "Internal server error", 500)
 
 
+# ─── POST /api/v2/internal/cron/unattached-snapshot ────────────────────────────
+
+@router.post("/unattached-snapshot")
+async def unattached_snapshot_cron(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """story #2536(E-FLOW-V4 S4): 프로젝트별 unattached_count 일별 스냅샷 append.
+
+    v4 강제(S2, #2532)가 신규 story의 가설/목표 부착을 요구하므로 기존 미매달림 총량이
+    시간에 걸쳐 줄어야 하고, 그 추세(스파크라인)를 그리려면 시계열이 필요 — 이 cron이
+    매일 실행되며 그 시계열을 쌓는다. append-only(재실행해도 새 행만 추가, upsert 없음).
+    """
+    verify_cron(request)
+
+    from app.services.unattached_snapshot import compute_and_record_unattached_snapshots
+
+    try:
+        results = await compute_and_record_unattached_snapshots(session)
+        await session.commit()
+        return _ok({"projects": len(results), "results": results})
+    except Exception as exc:
+        logger.exception("unattached-snapshot cron error: %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)
+
+
 # ─── S8: storage capacity lifecycle crons ─────────────────────────────────────
 
 _ASSET_GRACE_DAYS = 7

--- a/backend/app/services/unattached_snapshot.py
+++ b/backend/app/services/unattached_snapshot.py
@@ -1,0 +1,54 @@
+"""story #2536(E-FLOW-V4 S4): 프로젝트별 unattached_count 일별 스냅샷 계산+기록.
+
+`_unattached_clause()`(app/repositories/story.py, story #2532)를 그대로 재사용 —
+"미매달림"의 정의를 두 곳에서 따로 유지하지 않는다(정의가 갈라지면 스파크라인이
+실제 필터 결과와 다른 숫자를 그리게 된다)."""
+from __future__ import annotations
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.pm import Story
+from app.models.project import Project
+from app.models.unattached_snapshot import UnattachedStorySnapshot
+from app.repositories.story import _unattached_clause
+
+
+async def compute_and_record_unattached_snapshots(
+    session: AsyncSession,
+) -> list[dict[str, str | int]]:
+    """soft-delete 안 된 전 프로젝트를 순회해 프로젝트별 unattached_count를 계산하고
+    append-only로 한 행씩 남긴다. 결과 없는 프로젝트(스토리 0건 등)도 count=0으로 기록
+    ("아직 미매달림 없음"과 "측정 안 됨"을 구분하려면 0도 명시적으로 남아야 한다).
+
+    반환값의 id들은 str — JSONResponse가 uuid.UUID를 직접 직렬화 못 하는 문제를
+    cron.py의 기존 관례(workflow_grandfather_backfill의 `str(oid)`)와 동형으로 방지."""
+    project_rows = (
+        await session.execute(
+            select(Project.id, Project.org_id).where(Project.deleted_at.is_(None))
+        )
+    ).all()
+
+    results: list[dict[str, str | int]] = []
+    for project_id, org_id in project_rows:
+        count = (
+            await session.execute(
+                select(func.count())
+                .select_from(Story)
+                .where(
+                    Story.org_id == org_id,
+                    Story.project_id == project_id,
+                    Story.deleted_at.is_(None),
+                    _unattached_clause(),
+                )
+            )
+        ).scalar_one()
+        snapshot = UnattachedStorySnapshot(
+            org_id=org_id, project_id=project_id, unattached_count=count,
+        )
+        session.add(snapshot)
+        results.append(
+            {"project_id": str(project_id), "org_id": str(org_id), "unattached_count": count}
+        )
+    await session.flush()
+    return results

--- a/backend/tests/test_2536_unattached_snapshot_realdb.py
+++ b/backend/tests/test_2536_unattached_snapshot_realdb.py
@@ -1,0 +1,218 @@
+"""story #2536(E-FLOW-V4 S4) — 일별 unattached_count 스냅샷 cron 실PG 검증.
+
+⛔monkeypatch.setattr(cron.CRON_SECRET) 패턴 — #2274(story #2072 근본수정) 때 확立된 관례.
+직접 대입+복원누락으로 CI 전역 401을 냈던 사고가 재발하지 않게 pytest 자동복원에 맡긴다.
+"""
+from __future__ import annotations
+
+import json
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.flush()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.flush()
+    return org, project
+
+
+def _cron_request():
+    from starlette.requests import Request as StarletteRequest
+    return StarletteRequest(scope={
+        "type": "http", "headers": [(b"authorization", b"Bearer the-real-secret")],
+    })
+
+
+@pytest.mark.anyio
+async def test_unattached_snapshot_endpoint_rejects_missing_auth(monkeypatch):
+    """AC — 다른 cron 엔드포인트와 같은 verify_cron() 게이트(새 인증 발명 없음)."""
+    from fastapi import HTTPException
+    from starlette.requests import Request as StarletteRequest
+
+    import app.routers.cron as cron_module
+    from app.routers.cron import unattached_snapshot_cron
+
+    monkeypatch.setattr(cron_module, "CRON_SECRET", "the-real-secret")
+
+    request = StarletteRequest(scope={"type": "http", "headers": []})
+    with pytest.raises(HTTPException) as exc_info:
+        await unattached_snapshot_cron(request, session=None)
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_unattached_snapshot_counts_match_unattached_clause(monkeypatch):
+    """⭐핵심 — _unattached_clause()가 실제로 세는 것과 스냅샷 count가 정확히 일치해야
+    한다(정의가 두 곳에서 갈라지면 스파크라인이 거짓말을 한다). epic 부착 1건·hypothesis
+    링크 부착 1건·완전 미매달림 2건을 심어 count=2를 확認."""
+    from sqlalchemy import select
+
+    import app.routers.cron as cron_module
+    from app.models.hypothesis import Hypothesis, HypothesisStoryLink
+    from app.models.pm import Goal, Story
+    from app.models.unattached_snapshot import UnattachedStorySnapshot
+    from app.routers.cron import unattached_snapshot_cron
+
+    monkeypatch.setattr(cron_module, "CRON_SECRET", "the-real-secret")
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project = await _seed_org_project(session)
+
+            goal = Goal(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="G")
+            session.add(goal)
+            await session.flush()
+
+            story_with_epic = Story(
+                id=uuid.uuid4(), org_id=org.id, project_id=project.id,
+                title="attached-via-epic", epic_id=goal.id,
+            )
+            story_with_hyp = Story(
+                id=uuid.uuid4(), org_id=org.id, project_id=project.id,
+                title="attached-via-hypothesis",
+            )
+            unattached_1 = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="unattached-1")
+            unattached_2 = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="unattached-2")
+            session.add_all([story_with_epic, story_with_hyp, unattached_1, unattached_2])
+            await session.flush()
+
+            hyp = Hypothesis(
+                id=uuid.uuid4(), org_id=org.id, project_id=project.id,
+                owner_member_id=uuid.uuid4(), statement="S",
+                metric_definition={"metric": "m", "source": "db", "target": 1, "direction": "increase"},
+                measure_after=__import__("datetime").datetime(2026, 1, 1, tzinfo=__import__("datetime").UTC),
+            )
+            session.add(hyp)
+            await session.flush()
+            session.add(HypothesisStoryLink(
+                id=uuid.uuid4(), hypothesis_id=hyp.id, story_id=story_with_hyp.id,
+            ))
+            await session.commit()
+
+            resp = await unattached_snapshot_cron(_cron_request(), session=session)
+            body = json.loads(resp.body)
+            assert body["error"] is None
+            row = next(r for r in body["data"]["results"] if r["project_id"] == str(project.id))
+            assert row["unattached_count"] == 2, (
+                f"epic 부착·hypothesis 부착 각 1건은 빠지고 미매달림 2건만 세야 하는데 "
+                f"{row['unattached_count']}건 — _unattached_clause 정의와 어긋남"
+            )
+
+            snapshot_rows = (
+                await session.execute(
+                    select(UnattachedStorySnapshot).where(UnattachedStorySnapshot.project_id == project.id)
+                )
+            ).scalars().all()
+            assert len(snapshot_rows) == 1
+            assert snapshot_rows[0].unattached_count == 2
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unattached_snapshot_is_append_only(monkeypatch):
+    """AC — 재실행 시 기존 행을 갱신(upsert)하지 않고 새 행을 추가한다(append-only)."""
+    from sqlalchemy import select
+
+    import app.routers.cron as cron_module
+    from app.models.pm import Story
+    from app.models.unattached_snapshot import UnattachedStorySnapshot
+    from app.routers.cron import unattached_snapshot_cron
+
+    monkeypatch.setattr(cron_module, "CRON_SECRET", "the-real-secret")
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            org, project = await _seed_org_project(session)
+            session.add(Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="s1"))
+            await session.commit()
+
+            await unattached_snapshot_cron(_cron_request(), session=session)
+            await unattached_snapshot_cron(_cron_request(), session=session)
+
+            rows = (
+                await session.execute(
+                    select(UnattachedStorySnapshot).where(UnattachedStorySnapshot.project_id == project.id)
+                )
+            ).scalars().all()
+            assert len(rows) == 2, f"append-only라 2회 실행이면 2행이어야 하는데 {len(rows)}행"
+            assert all(r.unattached_count == 1 for r in rows)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unattached_snapshot_zero_is_recorded_explicitly(monkeypatch):
+    """AC — 스토리가 하나도 없거나 전부 부착된 프로젝트도 count=0으로 명시 기록한다
+    ("아직 미매달림 없음"과 "측정 안 됨"을 구분 — 프로젝트를 아예 건너뛰지 않는다)."""
+    from sqlalchemy import select
+
+    import app.routers.cron as cron_module
+    from app.models.unattached_snapshot import UnattachedStorySnapshot
+    from app.routers.cron import unattached_snapshot_cron
+
+    monkeypatch.setattr(cron_module, "CRON_SECRET", "the-real-secret")
+
+    engine, factory = await _session_factory()
+    try:
+        async with factory() as session:
+            _org, project = await _seed_org_project(session)
+            await session.commit()
+
+            resp = await unattached_snapshot_cron(_cron_request(), session=session)
+            body = json.loads(resp.body)
+            row = next(r for r in body["data"]["results"] if r["project_id"] == str(project.id))
+            assert row["unattached_count"] == 0
+
+            rows = (
+                await session.execute(
+                    select(UnattachedStorySnapshot).where(UnattachedStorySnapshot.project_id == project.id)
+                )
+            ).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].unattached_count == 0
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- `unattached_story_snapshots` 테이블 신설(org+project 스코프, append-only, `org_member_trust_snapshots` 패턴과 동형 — update/upsert 없음)
- `app/services/unattached_snapshot.py`: `_unattached_clause()`(story #2532, `app/repositories/story.py`)를 그대로 재사용해 프로젝트별 미매달림 카운트 계산 — 정의를 두 곳에서 따로 유지하지 않는다(갈라지면 스파크라인이 실제 필터 결과와 다른 숫자를 그리게 된다)
- `POST /api/v2/internal/cron/unattached-snapshot`: 기존 `verify_cron()` 게이트 그대로 재사용(story #2072 근본수정 기준 — 새 인증 발명 안 함) + Next.js 프록시 라우트(`hitl-timeouts` 패턴)
- 마이그레이션 0238은 #2931(0237 self-FK) 위에 체이닝

## 배경
v4 강제(S2, #2532)가 신규 story의 가설/목표 부착을 요구하므로 기존 미매달림(org 전체 약 2,180건)이 시간에 걸쳐 줄어야 하는데, 그 추세(S4 「0수렴 스파크라인」)를 그릴 시계열 자체가 없었다(grep 0건 — 미르코 FE 확認). "오늘부터 쌓아야" 하는 값이라 과거 소급이 불가능 — PO(페드루 올리베이라) 결(conversation 7256d5cc, 2026-08-09), 스냅샷 shape·주기는 담당(디디) 판단으로 위임.

## 스코프 밖
실제 스케줄(빈도·트리거) 배선(예: Vercel Cron 설정)은 인프라 lane — 이 PR은 엔드포인트+테이블+계산 로직까지.

## Test plan
- [x] `alembic upgrade head` 프레시 컨테이너에서 0236→0237→0238 체인 clean apply
- [x] `test_2536_unattached_snapshot_realdb.py` 4/4 (인증 게이트·`_unattached_clause` 일치·append-only·count=0 명시 기록)
- [x] mutation self-check: `_unattached_clause()` 제거 시 RED(4건 vs 기대 2건) 확認 후 복원 GREEN
- [x] 회귀 24/24 (`test_2533_hypothesis_lifecycle_realdb`, `test_2532_hypothesis_goal_attachment_realdb`, `test_2274_cron_orphan_check_realdb`, `test_cron_retry_dry_run` + 신규)
- [x] ruff clean(신규 파일 4개 단독 기준 all checks passed)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>