### PR TITLE
[SID:2537] unattached 버킷 X-Total-Count 미설정 fix(제네릭 repo.list() 분기)

### DIFF
--- a/backend/app/repositories/story.py
+++ b/backend/app/repositories/story.py
@@ -64,8 +64,17 @@ class StoryRepository(BaseRepository[Story]):
     async def list(
         self, limit: int = 1000, *, q: str | None = None, cursor: datetime | None = None,
         unattached: bool = False, **filters,
-    ) -> list[Story]:
-        """story 083176e8(까심 #2148 QA 적출): 갤러리 피커 실검색 — `q`는 title ILIKE 부분일치로
+    ) -> tuple[list[Story], int]:
+        """story #2537(카디르 QA #2932 실측, 2026-08-09) — `list_board()`와 동형으로
+        `(stories, total)` 튜플을 반환한다. 이전엔 `list[Story]`만 반환해 이 분기(status
+        없이 project_id+unattached=true 등으로 오는 generic 필터 경로)로 빠지는 요청은
+        X-Total-Count를 아예 못 냈다 — unattached-bucket이 정확히 이 경로를 타는데
+        FE(meta.total)가 항상 undefined를 받아 HIGH로 보고됐다. count는 board 분기와
+        동형으로 필터 適用 後·limit 適用 前에 계산한다(cursor 필터까지 포함해야 "이 필터
+        조건에서 남은 전체 건수"가 정확하다). 실 콜러는 `app/routers/stories.py`(제네릭
+        분기) 단 1곳뿐이라(grep 확認, 직접-호출 테스트 0건) 시그니처 변경이 안전하다.
+
+        story 083176e8(까심 #2148 QA 적출): 갤러리 피커 실검색 — `q`는 title ILIKE 부분일치로
         기존 동등비교 필터(**filters, base.list() 상속)와 AND 결합. BaseRepository.list()는
         범용(모든 리포지토리 공유)이라 q ILIKE 개념을 거기 얹지 않고 story 전용으로 오버라이드
         (list_board/list_by_ids와 동일하게 자체 쿼리 구성 — 기존 관례).
@@ -102,9 +111,13 @@ class StoryRepository(BaseRepository[Story]):
             query = query.where(Story.created_at < cursor)
         if unattached:
             query = query.where(_unattached_clause())
+
+        count_q = select(func.count()).select_from(query.subquery())
+        total = (await self.session.execute(count_q)).scalar_one()
+
         query = query.order_by(Story.created_at.desc(), Story.id.desc()).limit(limit)
         result = await self.session.execute(query)
-        return list(result.scalars().all())
+        return list(result.scalars().all()), total
 
     async def list_by_ids(self, ids: list[uuid.UUID], *, unattached: bool = False) -> list[Story]:
         """배치 앵커 조회(story ca37b2b0 ② — 갤러리 등 정확한 story 집합 필요 소비자용).

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -255,7 +255,9 @@ async def list_stories(
     # FE(buildCursorPageMeta)가 계산한 nextCursor가 다음 요청에서 조용히 무시돼 같은 페이지가
     # 반복된다(sprints/standup "더 보기" 중복 누적의 원인).
     cursor_dt = _parse_stories_cursor(cursor)
-    stories = await repo.list(limit=limit, q=q, cursor=cursor_dt, unattached=unattached, **filters)
+    stories, total = await repo.list(limit=limit, q=q, cursor=cursor_dt, unattached=unattached, **filters)
+    if response is not None:
+        response.headers["X-Total-Count"] = str(total)
     await _attach_assignee_ids(repo.session, repo.org_id, stories)
     await _attach_has_evidence(repo.session, stories)
     # ⛔일반 함정(2026-07-29, PO 지적 — "측정 경로 ≠ 실행 경로"): `Query(default=None, ...)`

--- a/backend/tests/test_2188_no_sprint_alone_contract_pin.py
+++ b/backend/tests/test_2188_no_sprint_alone_contract_pin.py
@@ -65,7 +65,9 @@ async def test_actual_behavior_no_sprint_without_project_id_falls_through_to_gen
     repo.org_id = "org-1"
     repo.session = MagicMock()
     repo.list_backlog = AsyncMock(side_effect=AssertionError("backlog 분기가 호출되면 안 됨"))
-    repo.list = AsyncMock(return_value=[])
+    # story #2537: repo.list()가 (stories, total) 튜플을 반환하도록 계약 변경(X-Total-Count
+    # 미설정 결함 fix) — 이 mock도 새 계약을 반영해야 언패킹이 안 깨진다.
+    repo.list = AsyncMock(return_value=([], 0))
 
     async def _noop(*args, **kwargs):
         return None

--- a/backend/tests/test_2537_unattached_generic_xtotalcount_realdb.py
+++ b/backend/tests/test_2537_unattached_generic_xtotalcount_realdb.py
@@ -1,0 +1,131 @@
+"""story #2537(카디르 QA #2932 실측, 2026-08-09) — unattached-bucket이 실제로 타는 요청
+형태(`project_id`+`unattached=true`, **status 없음** → 제네릭 `repo.list()` 분기)에서
+X-Total-Count가 실제로 나는지 실PG로 pin한다.
+
+⛔mock 기반 FE route.test.ts는 헤더를 인위 반환해 이 결함을 못 잡는다(미르코 FE 배선 자체는
+정확했다) — 진짜 방어는 이 real-DB 테스트뿐이다. story #2532의
+test_unattached_filter_is_sql_where_level_not_post_page_realdb는 `status=backlog`를 줘서
+board 분기(list_board, 이미 X-Total-Count 정상)를 태우므로 이 결함을 못 잡았다 — 그게 카디르가
+105건 라이브에서 잡을 때까지 CI가 초록이었던 이유."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tests.test_1994_backlink_api_realdb import (
+    _client_for,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _session_factory,
+    _setup_app_human,
+)
+from tests.test_2301_story_body_mentions_realdb import _REAL_DB_URL, _make_story
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _make_goal(session, org_id, project_id, title="Goal"):
+    from app.models.pm import Goal
+    goal = Goal(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(goal)
+    await session.commit()
+    return goal
+
+
+async def test_unattached_generic_branch_sets_xtotalcount_realdb():
+    """⭐핵심 — status 없이 project_id+unattached=true(카디르가 105건서 재현한 정확한 그
+    요청 형태)로 부르면 제네릭 repo.list() 분기를 타는데, 예전엔 X-Total-Count가 아예 안
+    실렸다(응답 자체는 200 정상이라 FE 눈엔 "느리게 조용히 깨진" 결함). limit보다 적은
+    unattached 3건을 심어 total=3이 정확히 나는지 확認."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _caller_id, caller_user = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id)
+
+            attached = await _make_story(s, org.id, project.id, title="attached")
+            attached.epic_id = goal.id
+            unattached_1 = await _make_story(s, org.id, project.id, title="u1")
+            unattached_2 = await _make_story(s, org.id, project.id, title="u2")
+            unattached_3 = await _make_story(s, org.id, project.id, title="u3")
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user, org.id)
+        async with _client_for(app) as client:
+            # ⛔status 파라미터를 안 준다 — 이게 카디르가 105건서 재현한 정확한 요청 형태다.
+            resp = await client.get(
+                f"/api/v2/stories?project_id={project.id}&unattached=true&limit=100"
+            )
+            assert resp.status_code == 200, resp.text
+            items = resp.json()
+            ids = {item["id"] for item in items}
+            assert str(unattached_1.id) in ids
+            assert str(unattached_2.id) in ids
+            assert str(unattached_3.id) in ids
+            assert str(attached.id) not in ids
+
+            assert "x-total-count" in resp.headers, (
+                "제네릭 repo.list() 분기가 X-Total-Count를 안 낸다 — 카디르 QA #2932 재발"
+            )
+            assert resp.headers["x-total-count"] == "3", (
+                f"필터 後 정확한 count(3)여야 하는데 {resp.headers['x-total-count']!r}"
+            )
+        app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_unattached_generic_branch_xtotalcount_respects_limit_boundary_realdb():
+    """⭐AC — X-Total-Count는 limit 適用 前(필터 後 전체 건수), 응답 바디는 limit 適用 後.
+    limit=1보다 unattached가 많을 때 바디는 1건이지만 헤더는 실제 전체 건수(2)여야
+    한다(story #2532의 board-분기 pin과 동형 원칙을 generic 분기에도 적용)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _caller_id, caller_user = await _make_human_member(s, org.id, project.id)
+
+            await _make_story(s, org.id, project.id, title="u1")
+            await _make_story(s, org.id, project.id, title="u2")
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user, org.id)
+        async with _client_for(app) as client:
+            resp = await client.get(
+                f"/api/v2/stories?project_id={project.id}&unattached=true&limit=1"
+            )
+            assert resp.status_code == 200, resp.text
+            assert len(resp.json()) == 1
+            assert resp.headers["x-total-count"] == "2", (
+                f"바디는 limit=1로 잘려도 헤더는 필터 後 전체(2)여야 하는데 "
+                f"{resp.headers['x-total-count']!r}"
+            )
+        app.dependency_overrides.clear()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
카디르 QA #2932 실측(105건) — 미르코 FE 배선(route.ts proxy·meta.total 읽기·헤더 forward)은 정확한데, unattached-bucket 요청(`status` 없이 `project_id`+`unattached=true`)이 제네릭 `repo.list()` 분기를 타는데 그 분기엔 count 쿼리도 X-Total-Count 세팅도 없었다.

- `StoryRepository.list()`가 `list_board()`와 동형으로 `(stories, total)` 튜플을 반환하도록 변경(count는 필터 適用 後·limit 適用 前)
- 라우터 제네릭 분기에서 `X-Total-Count` 헤더 세팅
- `_unattached_clause()`(story #2532)는 이미 SQL WHERE 레벨이라 그대로 재사용

## Blast radius
`StoryRepository.list()`의 실 콜러는 `app/routers/stories.py`(제네릭 분기) 단 1곳뿐(grep 확認 + Explore 에이전트 재확인, 직접-호출 테스트 0건). 유일하게 조정이 필요했던 곳은 mock 기반 `test_2188_no_sprint_alone_contract_pin.py`의 `repo.list = AsyncMock(return_value=[])` → `return_value=([], 0)`.

## Test plan
- [x] `test_2537_unattached_generic_xtotalcount_realdb.py`(신규 2건) — 카디르가 105건서 재현한 정확한 요청 형태(`status` 없음) pin, limit 경계에서도 헤더가 필터 後 전체 건수인지 확認
- [x] mutation self-check: 헤더 세팅 라인 제거 → RED(2 failed) 확認 후 복원 GREEN
- [x] 회귀 44/44 (`test_2189_generic_branch_cursor_pagination`, `test_083176e8_story_search_q`, `test_2188_board_branch_filter_drop`, `test_2188_list_backlog_filter_drop`, `test_2532_hypothesis_goal_attachment`, `test_2188_no_sprint_alone_contract_pin`, `test_ca37b2b0_stories_ids_batch` + 신규)
- [x] ruff clean(신규/변경 파일 기준 — story.py/stories.py는 pre-existing 105건 그대로, 신규 0건)
- [x] 무관한 `-k "story or stories"` 대량 스윕(6700+건)에서 209건 실패가 관측됐으나, 클린 origin/develop(내 변경 0건) 동일 스윕에서 **동일하게 209건 실패** 재현 — pre-existing 멀티파일 realdb 테스트 인프라 한계(별개 이슈)로 확認, 이 PR과 무관

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>