### PR TITLE
[SID:2535] 지구→대륙→도시 드릴다운 — 있는 것 재사용, 진짜 갭만 최소 구현

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -492,6 +492,7 @@
     "narrativeActual": "Actual",
     "narrativeTarget": "Target",
     "narrativeGate": "Gate",
+    "narrativeGoalDrilldownHint": "View branch",
     "narrativeEvidence": "Evidence",
     "narrativeMissedTarget": "Missed target",
     "narrativeKilledReason": "Killed — {reason}",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -492,6 +492,7 @@
     "narrativeActual": "실측",
     "narrativeTarget": "목표",
     "narrativeGate": "결재",
+    "narrativeGoalDrilldownHint": "갈래 보기",
     "narrativeEvidence": "증거",
     "narrativeMissedTarget": "목표 미달",
     "narrativeKilledReason": "종료 사유 — {reason}",

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.test.tsx
@@ -46,10 +46,11 @@ vi.mock('@/components/flow/hypothesis-earth-layer', () => ({
 
 // story #2533 — 서사 패널 스텁(자기 fetch를 exercise 안 함, hypothesisId threading만 검증).
 vi.mock('@/components/flow/hypothesis-narrative-panel', () => ({
-  HypothesisNarrativePanel: ({ hypothesisId, onClose }: { hypothesisId: string; onClose: () => void }) => (
+  HypothesisNarrativePanel: ({ hypothesisId, onClose, onNavigateToGoal }: { hypothesisId: string; onClose: () => void; onNavigateToGoal?: (goalId: string) => void }) => (
     <div data-testid="hypothesis-narrative-panel-stub">
       <span data-testid="narrative-hypothesis-id">{hypothesisId}</span>
       <button type="button" onClick={onClose}>close-narrative</button>
+      <button type="button" onClick={() => onNavigateToGoal?.('goal-xyz')}>navigate-to-goal</button>
     </div>
   ),
 }));
@@ -89,9 +90,10 @@ vi.mock('@/hooks/use-mobile', () => ({
 
 // NextMakerScreen 스텁 — onSelectStory 호출 버튼 + selectedNodeId를 텍스트로 노출(threading 검증용).
 vi.mock('@/components/flow/next-maker-screen', () => ({
-  NextMakerScreen: ({ onSelectStory, selectedNodeId }: { onSelectStory: (id: string) => void; selectedNodeId?: string | null }) => (
+  NextMakerScreen: ({ onSelectStory, selectedNodeId, focusGoalId }: { onSelectStory: (id: string) => void; selectedNodeId?: string | null; focusGoalId?: string | null }) => (
     <div data-testid="next-maker-screen-stub">
       <span data-testid="selected-node-id">{selectedNodeId ?? 'none'}</span>
+      <span data-testid="focus-goal-id">{focusGoalId ?? 'none'}</span>
       <button type="button" onClick={() => onSelectStory('story-abc')}>select-node</button>
     </div>
   ),
@@ -465,5 +467,60 @@ describe('FlowPageClient — story #2533 가설 카드 클릭이 서사 패널�
     await renderFlowClient();
 
     expect(container.querySelector('[data-testid="hypothesis-narrative-panel-stub"]')).toBeNull();
+  });
+});
+
+// story #2535(E-FLOW-V4 S5) — 지구→대륙→도시 드릴다운.
+describe('FlowPageClient — story #2535 지구→대륙→도시 드릴다운', () => {
+  it('?goal=<id>가 URL에 있으면 NextMakerScreen에 focusGoalId로 흘러간다', async () => {
+    currentSearch = 'view=flow&goal=goal-123';
+    await renderFlowClient();
+
+    expect(container.querySelector('[data-testid="focus-goal-id"]')?.textContent).toBe('goal-123');
+  });
+
+  it('?goal= 없으면 focusGoalId가 null(기존 동작 무회귀)', async () => {
+    currentSearch = 'view=flow';
+    await renderFlowClient();
+
+    expect(container.querySelector('[data-testid="focus-goal-id"]')?.textContent).toBe('none');
+  });
+
+  it('가설 패널의 "목표로 이동"을 누르면 view=flow&goal=<id>로 이동하고 hypothesis 파라미터는 지운다', async () => {
+    currentSearch = 'hypothesis=hyp-abc';
+    await renderFlowClient();
+
+    const navButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'navigate-to-goal');
+    expect(navButton).toBeTruthy();
+    await act(async () => {
+      navButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const pushedUrl = pushMock.mock.calls[0]?.[0] as string;
+    expect(pushedUrl).toContain('view=flow');
+    expect(pushedUrl).toContain('goal=goal-xyz');
+    expect(pushedUrl).not.toContain('hypothesis=');
+  });
+
+  it('축척 브레드크럼은 가설 뷰에서는 flow-client 레벨에서 안 뜬다(HypothesisEarthLayer가 자기 안에서 이미 그림, 중복 방지)', async () => {
+    await renderFlowClient();
+    // HypothesisEarthLayer는 얇은 스텁이라 사다리를 자체적으로 안 그린다 — 그런데도 사다리
+    // 특유 라벨(대륙/건물)이 뜨면 flow-client.tsx가 중복으로 그리고 있다는 뜻이다.
+    expect(container.textContent).not.toContain(koMessages.flow.ladderName_continent);
+    expect(container.textContent).not.toContain(koMessages.flow.ladderName_building);
+  });
+
+  it('갈래(view=flow) 뷰에서는 축척 브레드크럼이 "도시"를 활성으로 보인다', async () => {
+    currentSearch = 'view=flow';
+    await renderFlowClient();
+
+    expect(container.textContent).toContain(koMessages.flow.ladderName_city);
+  });
+
+  it('목록(view=list) 뷰에서는 축척 브레드크럼이 "건물"을 활성으로 보인다', async () => {
+    currentSearch = 'view=list';
+    await renderFlowClient();
+
+    expect(container.textContent).toContain(koMessages.flow.ladderName_building);
   });
 });

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
@@ -14,6 +14,7 @@ import { NextMakerScreen } from '@/components/flow/next-maker-screen';
 import { FlowNodeStoryPanel } from '@/components/flow/flow-node-story-panel';
 import { HypothesisEarthLayer } from '@/components/flow/hypothesis-earth-layer';
 import { HypothesisNarrativePanel } from '@/components/flow/hypothesis-narrative-panel';
+import { ScaleLadder } from '@/components/flow/scale-ladder';
 
 interface FlowPageClientProps {
   projectId: string;
@@ -156,6 +157,19 @@ export default function FlowPageClient({ projectId, wsSlug, projSlug }: FlowPage
     router.push(`/${wsSlug}/${projSlug}/flow${qs ? `?${qs}` : ''}`, { scroll: false });
   }, [router, searchParams, wsSlug, projSlug]);
 
+  // story #2535(E-FLOW-V4 S5) — 지구→대륙→도시 드릴다운. `?goal=<id>`가 착지점(NextMakerScreen
+  // focusGoalId로 흘러가 그 레인만 강제 펼침+스크롤+하이라이트, next-maker-screen.tsx 문서
+  // 참고). 가설 패널에서 넘어오는 경로라 `hypothesis` 파라미터는 지우고 view=flow로 간다
+  // (지구층에 남아있으면 도시층 레인이 안 보인다).
+  const focusGoalId = searchParams.get('goal');
+  const handleNavigateToGoal = useCallback((goalId: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete('hypothesis');
+    params.set('view', 'flow');
+    params.set('goal', goalId);
+    router.push(`/${wsSlug}/${projSlug}/flow?${params.toString()}`, { scroll: false });
+  }, [router, searchParams, wsSlug, projSlug]);
+
   const exceptionItems = useMemo(() => {
     if (!data) return [];
     const labels: ExceptionLabels = {
@@ -224,6 +238,11 @@ export default function FlowPageClient({ projectId, wsSlug, projSlug }: FlowPage
           </div>
         )}
 
+        {/* story #2535(E-FLOW-V4 S5) — 축척 브레드크럼. 가설 뷰는 HypothesisEarthLayer가
+            자기 안에서 이미 사다리를 그리므로(지구=활성) 여기서 중복 안 그린다. 갈래=도시·
+            목록=건물 — 「지금 보는 층 = 묻는 질문 전환」을 탭 전환마다 같은 자리에서 보인다. */}
+        {view !== 'hypothesis' ? <ScaleLadder activeLevel={view === 'flow' ? 'city' : 'building'} /> : null}
+
         {view === 'hypothesis' ? (
           // story #2531(E-FLOW-V4 S1) — 새 기본 랜딩. 가설(질문)을 최상위 조직 단위로 삼는
           // 지구 층. 드릴다운(가설→갈래)은 S5 몫이라 지금은 독립 탭으로만 존재한다.
@@ -252,6 +271,7 @@ export default function FlowPageClient({ projectId, wsSlug, projSlug }: FlowPage
               memberMap={data?.memberMap ?? {}}
               onSelectStory={handleSelectStory}
               selectedNodeId={selectedStoryId}
+              focusGoalId={focusGoalId}
             />
           )
         )}
@@ -273,7 +293,7 @@ export default function FlowPageClient({ projectId, wsSlug, projSlug }: FlowPage
         {/* story #2533(E-FLOW-V4 S3) — 가설 생애 수직 서사. 가설 뷰에서만(다른 탭엔 가설 카드
             자체가 없어 selectedHypothesisId가 그 탭에서 생길 일이 없다) */}
         {view === 'hypothesis' && selectedHypothesisId ? (
-          <HypothesisNarrativePanel key={selectedHypothesisId} hypothesisId={selectedHypothesisId} onClose={handleCloseHypothesisPanel} />
+          <HypothesisNarrativePanel key={selectedHypothesisId} hypothesisId={selectedHypothesisId} onClose={handleCloseHypothesisPanel} onNavigateToGoal={handleNavigateToGoal} />
         ) : null}
 
         {/* ③ 관제 서랍 — 보기 무관 고정, 접힘 기본(IA §2). ExceptionStream = #2100 예외 스트림

--- a/apps/web/src/components/flow/flow-map-canvas.test.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.test.tsx
@@ -152,6 +152,42 @@ describe('FlowMapCanvas — node click → open story panel (선생님 지적 20
   });
 });
 
+// story #2535(E-FLOW-V4 S5) — 지구→대륙→도시 드릴다운 착지. focusGoalId가 가리키는 레인만
+// 고리로 강조하고 스크롤한다 — 다른 레인은 손대지 않는다(카드 폭발 회피를 구조로).
+describe('FlowMapCanvas — story #2535 focusGoalId(드릴다운 착지 레인 강조)', () => {
+  it('renders data-lane-epic-id on every lane so the focus effect can target it', async () => {
+    const lanes = [makeLane({ epicId: 'e-a' }), makeLane({ epicId: 'e-b' })];
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={lanes} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
+    expect(container.querySelector('[data-lane-epic-id="e-a"]')).not.toBeNull();
+    expect(container.querySelector('[data-lane-epic-id="e-b"]')).not.toBeNull();
+  });
+
+  it('highlights ONLY the lane matching focusGoalId with a ring, not the other lane', async () => {
+    const lanes = [makeLane({ epicId: 'e-a' }), makeLane({ epicId: 'e-b' })];
+    await act(async () => {
+      root.render(wrap(<FlowMapCanvas lanes={lanes} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} focusGoalId="e-b" />));
+    });
+    expect(container.querySelector('[data-lane-epic-id="e-a"]')?.className).not.toContain('ring-2');
+    expect(container.querySelector('[data-lane-epic-id="e-b"]')?.className).toContain('ring-2');
+  });
+
+  it('highlights no lane when focusGoalId is omitted (default behavior unchanged)', async () => {
+    const lanes = [makeLane({ epicId: 'e-a' })];
+    await act(async () => { root.render(wrap(<FlowMapCanvas lanes={lanes} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} />)); });
+    expect(container.querySelector('[data-lane-epic-id="e-a"]')?.className).not.toContain('ring-2');
+  });
+
+  it('calls scrollIntoView on the target lane when focusGoalId matches', async () => {
+    const lanes = [makeLane({ epicId: 'e-a' }), makeLane({ epicId: 'e-b' })];
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    await act(async () => {
+      root.render(wrap(<FlowMapCanvas lanes={lanes} onSelectStory={() => {}} onTogglePastBundle={() => {}} loadingPastBundleEpicIds={EMPTY_EPIC_ID_SET} onCreateLink={NOOP_CREATE_LINK} onDeleteLink={NOOP_DELETE_LINK} onRejectLink={NOOP_REJECT_LINK} memberMap={{}} focusGoalId="e-b" />));
+    });
+    expect(scrollIntoViewMock).toHaveBeenCalled();
+  });
+});
+
 describe('FlowMapCanvas — 노드 카드 한 줄 + 행 간격 32(story #2224 AC17-C)', () => {
   it('renders exactly one line per node — no status text label (border-l color is now the sole status signal, §4-4)', async () => {
     const lane = makeLane({ nowNodes: [makeNode({ id: 'n1', storyNumber: 42, title: '어떤 스토리', status: 'in-progress' })] });

--- a/apps/web/src/components/flow/flow-map-canvas.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.tsx
@@ -17,6 +17,7 @@ import {
   Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
 // 카드 실측(FlowMapNodeCard): w-[110px] · 높이 24px(한 줄) — 선은 카드 "왼쪽 가장자리
 // 중앙"→"오른쪽 가장자리 중앙"을 잇는다.
@@ -102,6 +103,10 @@ interface FlowMapCanvasProps {
    * 항상 보인다). 콜백이 없으면(단일-레인 호출부, flow-epic-nodes.tsx — 세로 클리핑 조상이
    * 아예 없다) 기존 그대로 이 컴포넌트 안에서 그린다. */
   onOffscreenCountChange?: (count: number) => void;
+  /** story #2535(E-FLOW-V4 S5) — 지구(가설)→대륙(목표)→도시(갈래) 드릴다운 착지점. 마운트
+   * 시(또는 값이 바뀔 때) 해당 레인으로 스크롤하고 짧게 고리로 강조한다 — 다른 레인은
+   * 손대지 않는다(카드 폭발 회피를 구조로: 숨기지 않고 시선만 유도). */
+  focusGoalId?: string | null;
 }
 
 export type CreateLinkResult = { ok: true } | { ok: false; error: string };
@@ -286,7 +291,7 @@ export function FlowCanvasOffscreenHint({ count }: { count: number }) {
  */
 export function FlowMapCanvas({
   lanes, onSelectStory, onTogglePastBundle, loadingPastBundleEpicIds, selectedNodeId = null, onCreateLink, onDeleteLink, onRejectLink, memberMap,
-  onOffscreenCountChange,
+  onOffscreenCountChange, focusGoalId = null,
 }: FlowMapCanvasProps) {
   const t = useTranslations('flow');
   const { currentTeamMemberId } = useDashboardContext();
@@ -357,6 +362,19 @@ export function FlowMapCanvas({
     if (NOW_CLUSTER_X + NODE_CARD_WIDTH <= el.clientWidth) return;
     el.scrollLeft = Math.max(0, NOW_CLUSTER_X - el.clientWidth / 2);
   }, [hasLanes]);
+
+  // story #2535(E-FLOW-V4 S5) — 지구→대륙→도시 드릴다운 착지. FlowCanvasResizePane(세로
+  // 클리핑 조상, 이 컴포넌트 밖)이든 이 컴포넌트 자신의 overflow-x-auto든, scrollIntoView는
+  // 가장 가까운 스크롤 가능 조상을 알아서 찾아 스크롤한다 — 어느 호출부(단일/멀티레인)든
+  // 안전하다. lanes가 로드된 «후»에 타겟 레인 DOM이 실재해야 하므로 lanes를 의존성에 둔다.
+  // CSS.escape 기반 셀렉터 대신 속성값을 직접 비교한다(flow-node-story-panel.tsx와 동형
+  // 관례 — CSS.escape 전역이 없는 실행환경(jsdom 테스트 등)에도 안 깨진다).
+  useEffect(() => {
+    if (!focusGoalId) return;
+    const el = Array.from(document.querySelectorAll('[data-lane-epic-id]'))
+      .find((node) => node.getAttribute('data-lane-epic-id') === focusGoalId);
+    el?.scrollIntoView?.({ behavior: 'smooth', block: 'start' });
+  }, [focusGoalId, lanes]);
 
   const allEdges = useMemo(() => lanes.flatMap((l) => l.edges), [lanes]);
   const nodesById = useMemo(() => {
@@ -605,7 +623,16 @@ export function FlowMapCanvas({
             const height = computeLaneHeight(lane, NODE_ROW_HEIGHT, LANE_MIN_HEIGHT);
             const supersededIds = computeSupersededNodeIds(lane.edges);
             return (
-              <div key={lane.epicId} className="relative flex border-b border-border last:border-b-0" style={{ height }}>
+              <div
+                key={lane.epicId}
+                data-lane-epic-id={lane.epicId}
+                className={cn(
+                  'relative flex border-b border-border last:border-b-0',
+                  // story #2535 — 착지 레인만 고리 강조(다른 레인은 그대로, 카드 폭발 회피).
+                  focusGoalId === lane.epicId && 'ring-2 ring-inset ring-brand',
+                )}
+                style={{ height }}
+              >
                 {/* 위 헤더 칸과 같은 사정 — LANE_LABEL_WIDTH 하나에서 나온다(사본 없음). */}
                 <div className="shrink-0 border-r border-border px-2 py-1.5" style={{ width: LANE_LABEL_WIDTH }}>
                   <p className="truncate text-[11px] font-semibold text-foreground">{lane.title}</p>

--- a/apps/web/src/components/flow/flow-multi-lane-canvas.tsx
+++ b/apps/web/src/components/flow/flow-multi-lane-canvas.tsx
@@ -28,6 +28,9 @@ interface FlowMultiLaneCanvasProps {
   /** story #2353 되돌리기 다이얼로그의 「{이름}이 만든 연결입니다」 이름 조회용(goal-stem-card.tsx
    * 참고 — 새 fetch 아님, 호출부가 이미 들고 있는 값을 그대로 흘려보낸다). */
   memberMap?: Record<string, { name: string }>;
+  /** story #2535(E-FLOW-V4 S5) — 드릴다운 착지점. 순수 통과(FlowMapCanvas가 실제 스크롤+
+   * 하이라이트를 한다, next-maker-screen.tsx 문서 참고). */
+  focusGoalId?: string | null;
 }
 
 interface RawStoryListPage {
@@ -112,7 +115,7 @@ type LoadState =
  * 컴포넌트와 같은 안전성).
  */
 export function FlowMultiLaneCanvas({
-  projectId, expandGoals, foldedCount, onSelectStory, selectedNodeId = null, memberMap = {},
+  projectId, expandGoals, foldedCount, onSelectStory, selectedNodeId = null, memberMap = {}, focusGoalId = null,
 }: FlowMultiLaneCanvasProps) {
   const t = useTranslations('flow');
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
@@ -334,6 +337,7 @@ export function FlowMultiLaneCanvas({
           onRejectLink={handleRejectLink}
           memberMap={memberMap}
           onOffscreenCountChange={setOffscreenCardCount}
+          focusGoalId={focusGoalId}
         />
       </FlowCanvasResizePane>
       {/* 접힘 줄(목업 그대로) — "숨긴 것이 아니라 접은 것입니다". 오늘은 펼치기 인터랙션이

--- a/apps/web/src/components/flow/hypothesis-earth-layer.tsx
+++ b/apps/web/src/components/flow/hypothesis-earth-layer.tsx
@@ -5,6 +5,7 @@ import { useTranslations, useLocale } from 'next-intl';
 import { Loader2 } from 'lucide-react';
 import type { Hypothesis } from '@sprintable/core-storage';
 import { HypothesisStatusBadge } from '@/components/hypotheses/hypothesis-status-badge';
+import { ScaleLadder } from '@/components/flow/scale-ladder';
 import { cn } from '@/lib/utils';
 
 /**
@@ -19,38 +20,6 @@ import { cn } from '@/lib/utils';
  *   Hypothesis 타입에 task_ids 필드 자체가 없어 스킵 — 없는 데이터를 지어내지 않는다.
  * - 드릴다운(가설→갈래 이동)은 S5(축척 전환) 몫 — 이 카드는 지금은 순수 표시.
  */
-
-const LADDER_LEVELS = ['earth', 'continent', 'city', 'street', 'building'] as const;
-
-function ScaleLadder() {
-  const t = useTranslations('flow');
-  return (
-    <div className="flex overflow-hidden rounded-xl border border-border bg-card">
-      {LADDER_LEVELS.map((level) => {
-        const active = level === 'earth';
-        return (
-          <div
-            key={level}
-            className={cn(
-              'relative flex-1 border-r border-border px-3 py-2.5 last:border-r-0',
-              active && 'bg-gradient-to-b from-brand/10 to-transparent',
-            )}
-          >
-            <div className={cn('text-[10px] font-semibold tracking-wide text-muted-foreground', active && 'text-brand')}>
-              {t(`ladderLevel_${level}`)}
-            </div>
-            <div className="mt-0.5 text-sm font-semibold text-foreground">{t(`ladderName_${level}`)}</div>
-            <div className="mt-1 text-[11px] leading-snug text-muted-foreground">{t(`ladderQuestion_${level}`)}</div>
-            <span
-              aria-hidden="true"
-              className={cn('absolute top-2.5 right-2.5 size-2 rounded-full bg-border', active && 'bg-brand')}
-            />
-          </div>
-        );
-      })}
-    </div>
-  );
-}
 
 function HypothesisCard({
   hypothesis,

--- a/apps/web/src/components/flow/hypothesis-narrative-panel.test.tsx
+++ b/apps/web/src/components/flow/hypothesis-narrative-panel.test.tsx
@@ -65,10 +65,14 @@ afterEach(async () => {
   vi.unstubAllGlobals();
 });
 
-async function renderPanel(fetchImpl: typeof fetch, onClose: () => void = vi.fn()) {
+async function renderPanel(
+  fetchImpl: typeof fetch,
+  onClose: () => void = vi.fn(),
+  onNavigateToGoal?: (goalId: string) => void,
+) {
   vi.stubGlobal('fetch', fetchImpl);
   await act(async () => {
-    root.render(wrap(<HypothesisNarrativePanel hypothesisId="h1" onClose={onClose} />));
+    root.render(wrap(<HypothesisNarrativePanel hypothesisId="h1" onClose={onClose} onNavigateToGoal={onNavigateToGoal} />));
     await new Promise((r) => setTimeout(r, 0));
   });
 }
@@ -101,6 +105,32 @@ describe('HypothesisNarrativePanel — story #2533, lifecycle 단일 응답 소�
   it('goals가 비어있으면 목표 절이 정직한 "아직"을 보인다', async () => {
     await renderPanel(rawFetch(makeLifecycle({ goals: [] })));
     expect(document.body.textContent).toContain(koMessages.flow.narrativeNotYet);
+  });
+
+  // story #2535(E-FLOW-V4 S5) — 지구→대륙 다리. onNavigateToGoal이 주어지면 목표 항목이
+  // 클릭 가능해지고, 누르면 그 목표 id로 콜백이 온다(네비게이션 자체는 호출부 책임).
+  it('onNavigateToGoal이 있으면 목표 항목이 클릭 가능하고, 누르면 goalId로 호출된다', async () => {
+    const onNavigateToGoal = vi.fn();
+    await renderPanel(
+      rawFetch(makeLifecycle({ goals: [{ id: 'g1', title: '결제 전환 목표', status: 'active' }] })),
+      vi.fn(),
+      onNavigateToGoal,
+    );
+
+    const goalButton = Array.from(document.querySelectorAll('button')).find((b) => b.textContent?.includes('결제 전환 목표'));
+    expect(goalButton).toBeTruthy();
+    await act(async () => {
+      goalButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onNavigateToGoal).toHaveBeenCalledWith('g1');
+  });
+
+  it('onNavigateToGoal이 없으면(옵셔널) 목표 항목은 그냥 텍스트로만 렌더된다(회귀 없음)', async () => {
+    await renderPanel(rawFetch(makeLifecycle({ goals: [{ id: 'g1', title: '결제 전환 목표', status: 'active' }] })));
+
+    expect(document.body.textContent).toContain('결제 전환 목표');
+    const goalButton = Array.from(document.querySelectorAll('button')).find((b) => b.textContent?.includes('결제 전환 목표'));
+    expect(goalButton).toBeUndefined();
   });
 
   it('검증(stories[].title)이 렌더된다', async () => {

--- a/apps/web/src/components/flow/hypothesis-narrative-panel.tsx
+++ b/apps/web/src/components/flow/hypothesis-narrative-panel.tsx
@@ -99,9 +99,14 @@ function NarrativeStep({
 export function HypothesisNarrativePanel({
   hypothesisId,
   onClose,
+  onNavigateToGoal,
 }: {
   hypothesisId: string;
   onClose: () => void;
+  /** story #2535(E-FLOW-V4 S5) — 지구→대륙 다리. 목표 항목을 누르면 그 목표의 갈래(도시
+   * 층)로 이동한다 — 호출부(flow-client.tsx)가 네비게이션을 책임진다(onSelectStory와
+   * 같은 원칙, 이 컴포넌트는 순수 프레젠테이션). */
+  onNavigateToGoal?: (goalId: string) => void;
 }) {
   const t = useTranslations('flow');
   const locale = useLocale();
@@ -149,7 +154,17 @@ export function HypothesisNarrativePanel({
               {state.data.goals.length > 0 ? (
                 <ul className="space-y-1">
                   {state.data.goals.map((g) => (
-                    <li key={g.id}>{g.title}</li>
+                    <li key={g.id}>
+                      {onNavigateToGoal ? (
+                        <button
+                          type="button"
+                          onClick={() => onNavigateToGoal(g.id)}
+                          className="text-left text-brand underline-offset-2 hover:underline"
+                        >
+                          {g.title} <span aria-hidden="true">→</span> {t('narrativeGoalDrilldownHint')}
+                        </button>
+                      ) : g.title}
+                    </li>
                   ))}
                 </ul>
               ) : (

--- a/apps/web/src/components/flow/next-maker-screen.test.tsx
+++ b/apps/web/src/components/flow/next-maker-screen.test.tsx
@@ -205,6 +205,37 @@ describe('NextMakerScreen — real fetch orchestration + lane grouping', () => {
     expect(container.querySelector('[data-testid="folded-count"]')?.textContent).toBe('1');
   });
 
+  // story #2535(E-FLOW-V4 S5) — 지구→대륙→도시 드릴다운 착지. focusGoalId가 fold 쪽에
+  // 떨어진 목표(e-stale)를 가리키면 «그 목표 하나만» 강제로 expand로 옮긴다 — 다른 레인은
+  // 안 건드린다(카드 폭발 회피를 구조로).
+  it('focusGoalId — a normally-folded goal is force-expanded when it matches, and only that one', async () => {
+    const calledUrls: string[] = [];
+    vi.stubGlobal('fetch', buildFetchMock(calledUrls));
+
+    await act(async () => {
+      root.render(wrap(<NextMakerScreen projectId="p1" memberMap={{}} onSelectStory={() => {}} focusGoalId="e-stale" />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const expandTitles = container.querySelector('[data-testid="expand-titles"]')?.textContent;
+    expect(expandTitles).toContain('E-Recent');
+    expect(expandTitles).toContain('E-Stale');
+    expect(container.querySelector('[data-testid="folded-count"]')?.textContent).toBe('0');
+  });
+
+  it('focusGoalId that matches an already-expanded goal changes nothing(no duplicate)', async () => {
+    const calledUrls: string[] = [];
+    vi.stubGlobal('fetch', buildFetchMock(calledUrls));
+
+    await act(async () => {
+      root.render(wrap(<NextMakerScreen projectId="p1" memberMap={{}} onSelectStory={() => {}} focusGoalId="e-recent" />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(container.querySelector('[data-testid="expand-titles"]')?.textContent).toBe('E-Recent');
+    expect(container.querySelector('[data-testid="folded-count"]')?.textContent).toBe('1');
+  });
+
   // 유나 라이브 실측(2026-07-31, AC17-B 재정정 — 선생님 직접 지적) — "지도가 가장 높은
   // 블록"으로만 재던 판정이 «자리»(어디에 있는가)를 안 물어, 캔버스 y=2108(뷰포트
   // 900) — 레인이 한 조각도 첫 화면에 없는 사고가 났다. 캔버스가 DOM에서 헤드라인보다

--- a/apps/web/src/components/flow/next-maker-screen.tsx
+++ b/apps/web/src/components/flow/next-maker-screen.tsx
@@ -24,6 +24,10 @@ interface NextMakerScreenProps {
   onSelectStory: (storyId: string) => void;
   /** story #2354 — 순수 통과 prop(FlowMapCanvas 참고, 노드 선택 고리 강조). */
   selectedNodeId?: string | null;
+  /** story #2535(E-FLOW-V4 S5) — 지구(가설)→대륙(목표)→도시(갈래) 드릴다운의 착지점.
+   * 이 목표가 30일 무변화로 접힘 대상이었어도 강제로 펼침(카드 폭발 회피를 «구조»로 —
+   * 다른 레인은 안 건드리고 이 레인 «하나»만 예외로 편다) + 그 레인으로 스크롤+하이라이트. */
+  focusGoalId?: string | null;
 }
 
 interface Envelope<T> { data: T; meta?: unknown }
@@ -101,7 +105,7 @@ type LoadState =
  *
  * ⛔done 스토리는 이 화면에서 fetch하지 않는다(goals.total_stories/done_stories로 충분).
  */
-export function NextMakerScreen({ projectId, memberMap, onSelectStory, selectedNodeId = null }: NextMakerScreenProps) {
+export function NextMakerScreen({ projectId, memberMap, onSelectStory, selectedNodeId = null, focusGoalId = null }: NextMakerScreenProps) {
   const t = useTranslations('flow');
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
   // 스토리 하나가 승격(backlog→ready-for-dev)되거나 목표가 전이(done/archived)되면, 전체
@@ -246,11 +250,22 @@ export function NextMakerScreen({ projectId, memberMap, onSelectStory, selectedN
 
   // story #2224 AC1 — 스토리가 «정말 0건»인 목표는 레인 자체를 안 그린다(PO 정정: 접힘과
   // 0건은 다른 사정이라 섞으면 뜻이 흐려진다). 나머지만 30일-변화 성질로 펼침/접힘을 가른다.
+  //
+  // story #2535(E-FLOW-V4 S5) — focusGoalId가 30일 무변화로 fold 쪽에 떨어졌으면 그 목표
+  // «하나»만 강제로 expand로 옮긴다(다른 레인은 그대로 접힌 채 — 카드 폭발 회피를 구조로
+  // 지킨다). 지구→대륙→도시 드릴다운으로 왔는데 목표가 안 보이면 다리가 끊긴 것이다.
   const laneGrouping = useMemo(() => {
     if (state.kind !== 'ready') return { expand: [], fold: [] };
     const goalsWithStories = effectiveGoals.filter((g) => g.totalStories > 0);
-    return deriveActiveLaneGoals(goalsWithStories, effectiveActiveStories, nowMs);
-  }, [state, effectiveGoals, effectiveActiveStories, nowMs]);
+    const base = deriveActiveLaneGoals(goalsWithStories, effectiveActiveStories, nowMs);
+    if (!focusGoalId || base.expand.some((g) => g.id === focusGoalId)) return base;
+    const foldedTarget = base.fold.find((g) => g.id === focusGoalId);
+    if (!foldedTarget) return base;
+    return {
+      expand: [...base.expand, foldedTarget],
+      fold: base.fold.filter((g) => g.id !== focusGoalId),
+    };
+  }, [state, effectiveGoals, effectiveActiveStories, nowMs, focusGoalId]);
 
   if (state.kind === 'loading') {
     return (
@@ -279,6 +294,7 @@ export function NextMakerScreen({ projectId, memberMap, onSelectStory, selectedN
         onSelectStory={onSelectStory}
         selectedNodeId={selectedNodeId}
         memberMap={memberMap}
+        focusGoalId={focusGoalId}
       />
 
       <NextMakerHeader headline={headline} zeroStage={zeroStage} />

--- a/apps/web/src/components/flow/scale-ladder.test.tsx
+++ b/apps/web/src/components/flow/scale-ladder.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+//
+// story #2535(E-FLOW-V4 S5) — S1에서 지구층 전용이던 ScaleLadder를 재사용 컴포넌트로 분리.
+// activeLevel prop이 어느 rung을 강조하는지만 값으로 잰다(기본값=지구, S1 회귀 없음).
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { ScaleLadder } from './scale-ladder';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+describe('ScaleLadder', () => {
+  it('5단(지구·대륙·도시·거리·건물)이 전부 렌더된다', () => {
+    act(() => { root.render(wrap(<ScaleLadder />)); });
+    expect(container.textContent).toContain(koMessages.flow.ladderName_earth);
+    expect(container.textContent).toContain(koMessages.flow.ladderName_continent);
+    expect(container.textContent).toContain(koMessages.flow.ladderName_city);
+    expect(container.textContent).toContain(koMessages.flow.ladderName_street);
+    expect(container.textContent).toContain(koMessages.flow.ladderName_building);
+  });
+
+  it('activeLevel 기본값은 지구(S1 회귀 없음 — 이전엔 하드코딩이었다)', () => {
+    act(() => { root.render(wrap(<ScaleLadder />)); });
+    // 사다리는 5개 direct child rung — 텍스트 포함 검색은 바깥 flex 컨테이너까지 걸리므로
+    // 자식 목록에서만 찾는다.
+    const rungs = Array.from(container.querySelector('.flex.overflow-hidden')?.children ?? []);
+    const earthRung = rungs.find((d) => d.textContent?.includes(koMessages.flow.ladderName_earth));
+    expect(earthRung?.className).toContain('bg-gradient-to-b');
+  });
+
+  it('activeLevel="city"를 주면 도시 rung만 강조되고 지구는 강조되지 않는다', () => {
+    act(() => { root.render(wrap(<ScaleLadder activeLevel="city" />)); });
+    const rungs = Array.from(container.querySelector('.flex.overflow-hidden')?.children ?? []);
+    const cityRung = rungs.find((d) => d.textContent?.includes(koMessages.flow.ladderName_city));
+    const earthRung = rungs.find((d) => d.textContent?.includes(koMessages.flow.ladderName_earth));
+    expect(cityRung?.className).toContain('bg-gradient-to-b');
+    expect(earthRung?.className).not.toContain('bg-gradient-to-b');
+  });
+});

--- a/apps/web/src/components/flow/scale-ladder.tsx
+++ b/apps/web/src/components/flow/scale-ladder.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+
+/**
+ * story #2531(E-FLOW-V4 S1)에서 지구층 전용으로 태어났다가, story #2535(S5)에서 다른 층
+ * (갈래·목록)에도 재사용하도록 분리됐다 — «지금 보는 층 = 묻는 질문 전환»(doc
+ * flow-board-v4-hypothesis-scale §2)을 어느 뷰에서도 같은 자리에서 보여준다.
+ */
+export const LADDER_LEVELS = ['earth', 'continent', 'city', 'street', 'building'] as const;
+export type LadderLevel = (typeof LADDER_LEVELS)[number];
+
+export function ScaleLadder({ activeLevel = 'earth' }: { activeLevel?: LadderLevel }) {
+  const t = useTranslations('flow');
+  return (
+    <div className="flex overflow-hidden rounded-xl border border-border bg-card">
+      {LADDER_LEVELS.map((level) => {
+        const active = level === activeLevel;
+        return (
+          <div
+            key={level}
+            className={cn(
+              'relative flex-1 border-r border-border px-3 py-2.5 last:border-r-0',
+              active && 'bg-gradient-to-b from-brand/10 to-transparent',
+            )}
+          >
+            <div className={cn('text-[10px] font-semibold tracking-wide text-muted-foreground', active && 'text-brand')}>
+              {t(`ladderLevel_${level}`)}
+            </div>
+            <div className="mt-0.5 text-sm font-semibold text-foreground">{t(`ladderName_${level}`)}</div>
+            <div className="mt-1 text-[11px] leading-snug text-muted-foreground">{t(`ladderQuestion_${level}`)}</div>
+            <span
+              aria-hidden="true"
+              className={cn('absolute top-2.5 right-2.5 size-2 rounded-full bg-border', active && 'bg-brand')}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
⚠️ **Stacked PR — base는 develop이 아니라 #2930(S3)**. S5가 HypothesisNarrativePanel(S3에서 신설)을 수정하므로 S3 위에 쌓았습니다. S3가 develop에 머지되면 이 PR의 base도 develop으로 자동 정리됩니다(GitHub가 처리) — diff는 S5분(파일 14개)만 보시면 됩니다.

## 요약
- story #2535(E-FLOW-V4 S5) — 축척 사다리 드릴다운(지구→대륙→도시→거리→건물).
- **그라운딩**: 5층 중 도시→거리→건물은 이미 연결돼 있었음(NextMakerScreen 노드클릭→FlowNodeStoryPanel→StoryDetailPanel 작업목록, story #2354/#2224). v3.4 "문 레이어"·"침묵 정체"는 doc의 이론 모델이 아니라 이미 다른 이름(`ExceptionStream` 3신호·`stem.priority==='about-to-stall'`)으로 shipped돼 있음을 코드로 직접 확認. **진짜 갭은 지구(가설)→대륙(목표)→도시(갈래) 구간 하나**였음.
- PO 확認: 완전 새 화면 대신 **«이미 연결된 것 재사용 + 진짜 갭만 최소 구현»**.

## 변경
- `NextMakerScreen`: `focusGoalId` prop 신설 — 30일 무변화로 fold 대상이던 목표도 매치되면 그 하나만 강제 expand(카드 폭발 회피를 구조로, 다른 레인은 손 안 댐).
- `FlowMapCanvas`: `data-lane-epic-id` 속성 + focusGoalId 매칭 레인에 `scrollIntoView`+고리 강조. **CSS.escape 대신 속성값 직접 비교**(flow-node-story-panel.tsx와 동형 관례 — CSS.escape 전역이 없는 jsdom 등에도 안 깨짐. 로컬 재현으로 직접 발견한 함정, 처음엔 CSS.escape로 짰다가 테스트에서 실측).
- `HypothesisNarrativePanel`: 목표 항목에 `onNavigateToGoal` 콜백(옵셔널) — 있으면 클릭 가능한 링크, 없으면 기존 텍스트 그대로(회귀 없음).
- `flow-client.tsx`: `?goal=<id>` 파싱→focusGoalId 배선. 가설 패널 "목표로 이동" 클릭 시 `hypothesis` 파라미터 지우고 `view=flow&goal=<id>`로 이동.
- `ScaleLadder`를 지구층 전용에서 재사용 컴포넌트로 분리(`activeLevel` prop) — 갈래=도시·목록=건물로 "지금 보는 층=묻는 질문 전환"을 탭마다 같은 자리에서. 가설 뷰는 `HypothesisEarthLayer`가 자기 안에서 이미 그려 중복 방지.
- 거리~건물(도시 진입 이후)·문 레이어·침묵 정체는 전부 기존 그대로(무회귀).

## 게이트
- [x] tsc --noEmit: 0
- [x] eslint: 0 errors(기존 무관 경고 3건 제외)
- [x] i18n 문구충돌 신규 0 · tint-color-text 신규 0(로컬 사전실행)
- [x] vitest 전체 394파일/2982건 pass(회귀 0)
- [x] pnpm build: EXIT 0(실측)
- [x] 뮤테이션 self-check: 핵심 배선 6파일 되돌리면 신규 9건 정확히 RED → 원복 GREEN

## Test plan
- [ ] 페드루군 AC 리뷰
- [ ] 유나양 design:pass
- [ ] 카디르군 dev 라이브 QA — 가설 카드→목표 클릭→그 갈래 레인 강조+스크롤, 각 탭(가설/갈래/목록) 브레드크럼, 거리~건물 무회귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)