### PR TITLE
fix(org-briefing): story_stalled/unanswered_blocker 제네릭 /board 폴백 결함

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -397,7 +397,7 @@
     "gateGeneric": "approval",
     "signalAgentStuckTitle": "An agent is waiting to proceed",
     "signalAgentStuckContext": "Waiting on approval — needs a look",
-    "signalStalledTitle": "A hypothesis is going differently than expected",
+    "signalStalledTitle": "A story hasn't moved in a while",
     "signalStalledContext": "Needs a look",
     "signalBlockerTitle": "A blocked item is waiting on a response",
     "signalBlockerContext": "Needs a look",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -397,7 +397,7 @@
     "gateGeneric": "승인",
     "signalAgentStuckTitle": "에이전트가 다음 단계를 기다립니다",
     "signalAgentStuckContext": "승인을 기다리고 있습니다 — 확인이 필요합니다",
-    "signalStalledTitle": "가설이 예상과 다르게 진행됩니다",
+    "signalStalledTitle": "스토리가 오래 멈춰 있습니다",
     "signalStalledContext": "확인이 필요합니다",
     "signalBlockerTitle": "막힌 업무가 응답을 기다립니다",
     "signalBlockerContext": "확인이 필요합니다",

--- a/apps/web/src/components/org-briefing/derive-now-face.test.ts
+++ b/apps/web/src/components/org-briefing/derive-now-face.test.ts
@@ -44,12 +44,26 @@ describe('parseMyActions', () => {
     const raw = parseMyActions({
       action_queue: { items: [] },
       attention: { items: [
-        { type: 'story_stalled', entity_id: 's3' },
-        { type: 'unanswered_blocker', entity_id: 's4' },
+        { type: 'story_stalled', story_id: 's3' },
+        { type: 'unanswered_blocker', blocked_story_id: 's4' },
       ] },
     });
     expect(raw.attention).toHaveLength(2);
     expect(raw.attention.map((a) => a.type)).toEqual(['story_stalled', 'unanswered_blocker']);
+  });
+
+  // PO 실측 결함(2026-08-09) — story_stalled/unanswered_blocker는 entity_type/entity_id를
+  // 아예 안 낸다(command_center.py:379-406). story_id/blocked_story_id/title을 읽어야 한다.
+  it('reads story_id/title for story_stalled and blocked_story_id for unanswered_blocker (not entity_id — BE never sends it for these two types)', () => {
+    const raw = parseMyActions({
+      action_queue: { items: [] },
+      attention: { items: [
+        { type: 'story_stalled', story_id: 's3', stalled_days: 5, title: '결제 완료율 개선' },
+        { type: 'unanswered_blocker', blocked_story_id: 's4', blocker_id: 's5', age_days: 3 },
+      ] },
+    });
+    expect(raw.attention[0]).toMatchObject({ type: 'story_stalled', story_id: 's3', title: '결제 완료율 개선' });
+    expect(raw.attention[1]).toMatchObject({ type: 'unanswered_blocker', blocked_story_id: 's4' });
   });
 
   it('returns empty arrays for malformed shapes (no-fiction, throw 0)', () => {
@@ -97,9 +111,9 @@ describe('buildNowFace', () => {
         { type: 'my_blockers', priority: null, title: null, context: { blocked_story_id: 's2' } },
       ],
       attention: [
-        { type: 'agent_stuck', entity_type: 'story', entity_id: 's3', gate_type: 'merge' },
-        { type: 'story_stalled', entity_type: null, entity_id: 's4', gate_type: null },
-        { type: 'unanswered_blocker', entity_type: null, entity_id: 's5', gate_type: null },
+        { type: 'agent_stuck', entity_type: 'story', entity_id: 's3', gate_type: 'merge', story_id: null, blocked_story_id: null, title: null },
+        { type: 'story_stalled', entity_type: null, entity_id: null, gate_type: null, story_id: 's4', blocked_story_id: null, title: null },
+        { type: 'unanswered_blocker', entity_type: null, entity_id: null, gate_type: null, story_id: null, blocked_story_id: 's5', title: null },
       ],
     };
     const notifications = [{ id: 'n1', title: 'Contract done', body: 'evidence attached', href: '/inbox' }];
@@ -110,10 +124,50 @@ describe('buildNowFace', () => {
     expect(items.filter((i) => i.kind === 'done')).toHaveLength(1);
   });
 
+  it('PO 실측 결함 fix — story_stalled href/id는 story_id 기반이고, title은 BE값 있으면 그걸 쓴다', () => {
+    const raw: RawMyActions = {
+      queue: [],
+      attention: [
+        { type: 'story_stalled', entity_type: null, entity_id: null, gate_type: null, story_id: 's9', blocked_story_id: null, title: '결제 완료율 개선' },
+      ],
+    };
+    const items = buildNowFace(raw, [], t);
+    const signal = items.find((i) => i.kind === 'signal');
+    expect(signal?.href).toBe('/board?story=s9');
+    expect(signal?.id).toBe('story_stalled-s9');
+    expect(signal?.title).toBe('결제 완료율 개선');
+  });
+
+  it('story_stalled title이 아직 없으면(디디 BE 배선 前) 스토리-주제 폴백 문구를 쓴다(가설 문구 아님)', () => {
+    const raw: RawMyActions = {
+      queue: [],
+      attention: [
+        { type: 'story_stalled', entity_type: null, entity_id: null, gate_type: null, story_id: 's9', blocked_story_id: null, title: null },
+      ],
+    };
+    const items = buildNowFace(raw, [], t);
+    const signal = items.find((i) => i.kind === 'signal');
+    expect(signal?.title).not.toContain('가설');
+    expect(signal?.title).toBe('스토리가 오래 멈춰 있습니다');
+  });
+
+  it('unanswered_blocker href/id는 blocked_story_id 기반이다(entity_id는 BE가 안 준다)', () => {
+    const raw: RawMyActions = {
+      queue: [],
+      attention: [
+        { type: 'unanswered_blocker', entity_type: null, entity_id: null, gate_type: null, story_id: null, blocked_story_id: 's7', title: null },
+      ],
+    };
+    const items = buildNowFace(raw, [], t);
+    const signal = items.find((i) => i.kind === 'signal');
+    expect(signal?.href).toBe('/board?story=s7');
+    expect(signal?.id).toBe('unanswered_blocker-s7');
+  });
+
   it('never leaks raw elapsed-time text into signal context copy (surveillance framing ban — doc §1.5/§1.7)', () => {
     const raw: RawMyActions = {
       queue: [],
-      attention: [{ type: 'agent_stuck', entity_type: 'story', entity_id: 's1', gate_type: 'merge' }],
+      attention: [{ type: 'agent_stuck', entity_type: 'story', entity_id: 's1', gate_type: 'merge', story_id: null, blocked_story_id: null, title: null }],
     };
     const items = buildNowFace(raw, [], t);
     const signal = items.find((i) => i.kind === 'signal');
@@ -137,7 +191,7 @@ describe('buildNowFace', () => {
   });
 
   it('produces no primary action when there are no decide items', () => {
-    const raw: RawMyActions = { queue: [], attention: [{ type: 'agent_stuck', entity_type: null, entity_id: 's1', gate_type: null }] };
+    const raw: RawMyActions = { queue: [], attention: [{ type: 'agent_stuck', entity_type: null, entity_id: 's1', gate_type: null, story_id: null, blocked_story_id: null, title: null }] };
     const items = buildNowFace(raw, [], t);
     expect(items.every((i) => i.actionTone === 'ghost')).toBe(true);
   });
@@ -145,7 +199,7 @@ describe('buildNowFace', () => {
   it('sorts decide before signal before done', () => {
     const raw: RawMyActions = {
       queue: [{ type: 'review_merge', priority: 'info', title: 'x', context: {} }],
-      attention: [{ type: 'agent_stuck', entity_type: null, entity_id: 's1', gate_type: null }],
+      attention: [{ type: 'agent_stuck', entity_type: null, entity_id: 's1', gate_type: null, story_id: null, blocked_story_id: null, title: null }],
     };
     const items = buildNowFace(raw, [{ id: 'n1', title: 'done', body: null, href: null }], t);
     expect(items.map((i) => i.kind)).toEqual(['decide', 'signal', 'done']);

--- a/apps/web/src/components/org-briefing/derive-now-face.ts
+++ b/apps/web/src/components/org-briefing/derive-now-face.ts
@@ -56,6 +56,15 @@ interface RawAttentionItem {
   entity_type: string | null;
   entity_id: string | null;
   gate_type: string | null;
+  // ⛔PO 실측 결함(2026-08-09, 디디 그라운딩) — story_stalled/unanswered_blocker는
+  // entity_type/entity_id를 아예 안 낸다(backend/app/routers/command_center.py:379-406).
+  // story_stalled = {story_id, stalled_days} · unanswered_blocker = {blocked_story_id,
+  // blocker_id, age_days} — 별개 키명이라 위 entity_id 파싱은 이 둘에선 항상 null이었고,
+  // href가 매번 제네릭 /board로 떨어지고 id도 배열 index로 새 렌더마다 안 안정됐다.
+  story_id: string | null;
+  blocked_story_id: string | null;
+  // title은 story_stalled 전용(디디 BE 후속 추가 예정, 아직 미배선) — 없으면 폴백 문구.
+  title: string | null;
 }
 
 export interface RawMyActions {
@@ -97,6 +106,9 @@ export function parseMyActions(json: unknown): RawMyActions {
         entity_type: str(raw['entity_type']),
         entity_id: str(raw['entity_id']),
         gate_type: str(raw['gate_type']),
+        story_id: str(raw['story_id']),
+        blocked_story_id: str(raw['blocked_story_id']),
+        title: str(raw['title']),
       });
     }
   }
@@ -192,22 +204,24 @@ export function buildNowFace(raw: RawMyActions, notifications: RawCompletionNoti
       });
     } else if (a.type === 'story_stalled') {
       items.push({
-        id: `story_stalled-${a.entity_id ?? items.length}`,
+        id: `story_stalled-${a.story_id ?? items.length}`,
         kind: 'signal', kindLabel: t('kindSignal'),
-        title: t('signalStalledTitle'),
+        // title은 BE가 아직 안 보내면(디디 후속 배선 전) 폴백 문구 — surveillance framing
+        // ban(§1.5/§1.7, derive-now-face.test.ts)이 아직 유효해 날짜/기간 수치는 안 붙인다.
+        title: a.title ?? t('signalStalledTitle'),
         context: t('signalStalledContext'),
         actionLabel: t('actionOpen'), actionTone: 'ghost',
-        href: a.entity_id ? `/board?story=${a.entity_id}` : '/board',
+        href: a.story_id ? `/board?story=${a.story_id}` : '/board',
         priority: 21,
       });
     } else if (a.type === 'unanswered_blocker') {
       items.push({
-        id: `unanswered_blocker-${a.entity_id ?? items.length}`,
+        id: `unanswered_blocker-${a.blocked_story_id ?? items.length}`,
         kind: 'signal', kindLabel: t('kindSignal'),
         title: t('signalBlockerTitle'),
         context: t('signalBlockerContext'),
         actionLabel: t('actionOpen'), actionTone: 'ghost',
-        href: a.entity_id ? `/board?story=${a.entity_id}` : '/board',
+        href: a.blocked_story_id ? `/board?story=${a.blocked_story_id}` : '/board',
         priority: 22,
       });
     }


### PR DESCRIPTION
## 요약
PO 실측(디디 그라운딩, 2026-08-09) — 홈 "이상 신호"의 클릭 도달·항목 구별이 막혀 있었음. `derive-now-face.ts`의 `RawAttentionItem` 파서가 `entity_type`/`entity_id`만 읽는데, BE `story_stalled`/`unanswered_blocker` 페이로드(`backend/app/routers/command_center.py:379-406`)는 그 필드를 아예 안 낸다.

- `story_stalled` = `{story_id, stalled_days}`
- `unanswered_blocker` = `{blocked_story_id, blocker_id, age_days}`

`entity_id`가 항상 null이라 href가 매번 제네릭 `/board`로 떨어지고, id도 배열 index 기반이라 재렌더마다 안정되지 않았음.

## 변경
- `story_id`/`blocked_story_id`/`title`을 새로 읽어 href·id를 정확한 스토리로 연결.
- `title`은 디디 BE 후속 배선 전까지 폴백 문구 사용 — 그 폴백 문구 자체도 버그였음(기존 "가설이 예상과 다르게 진행됩니다"는 스토리 정체 신호에 가설 문구가 붙어있던 주제 불일치 → "스토리가 오래 멈춰 있습니다"로 정정).
- `unanswered_blocker`도 같은 파싱 버그(entity_id 대신 blocked_story_id 필요)를 그라운딩 중 발견해 함께 fix(요청 스코프 밖이었지만 같은 버그 클래스라 방치 안 함).

## ⚠️ 범위 조정
PO 원 요청은 "제목+N일 구별"이었으나, 이 화면엔 기존에 테스트로 고정된 **surveillance framing ban**(§1.5/§1.7, `derive-now-face.test.ts`의 "no digit-based duration phrasing" 검증)이 있어 `stalled_days`를 화면 텍스트로 노출하지 않았음 — story_id 기반 정확한 href+title(스토리 실명)만으로 "구별·도달" 문제는 해소되고, 날짜 수치 노출 여부는 별도 판단 필요해 보류.

## Didi 쪽(별도 BE PR)
- `story_stalled`에 `title` 필드 추가
- dedup

## 게이트
- [x] tsc --noEmit: 0
- [x] eslint: 0
- [x] i18n 문구충돌·tint-color-text 신규 0
- [x] vitest 전체 395파일/3012건 pass(회귀 0)
- [x] pnpm build: EXIT 0(실측)
- [x] 뮤테이션 self-check: 핵심 파일 되돌리면 신규 4건 정확히 RED → GREEN

## Test plan
- [ ] 디디군 BE title 필드 배선 후 통합 확인
- [ ] 카디르군 dev 라이브 QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)