### PR TITLE
[SID:2538] story_stalled·unanswered_blocker 이상 신호에 title 추가

### DIFF
--- a/backend/app/routers/command_center.py
+++ b/backend/app/routers/command_center.py
@@ -360,9 +360,13 @@ async def my_actions(
             "stuck_since": r.started_at.isoformat() if r.started_at else None,
         })
     # 2) CC-BE.2 스토리 N일 정체(org-visible 필드만).
+    # story #2538(2026-08-09): title 추가 — FE ko.json "가설이 예상과 다르게 진행됩니다"
+    # 카피가 이 신호(가설과 무관한 제네릭 story 정체 감지)에 잘못 매핑돼 있었다(PO 그라운딩
+    # 확認). 카피 정정+dedup+개별 구별("제목+N일")은 FE 몫, 그 구별에 필요한 title을 여기서
+    # additive로 채운다.
     stalled = (
         await session.execute(
-            select(Story.id, Story.updated_at)
+            select(Story.id, Story.updated_at, Story.title)
             .where(
                 Story.org_id == org_id,
                 Story.status.not_in(("done", "backlog")),
@@ -374,17 +378,22 @@ async def my_actions(
             .limit(20)
         )
     ).all()
-    for sid, updated_at in stalled:
+    for sid, updated_at, title in stalled:
         attention_items.append({
             "type": "story_stalled", "severity": "warn", "auto_detected": True,
+            "title": title,
             "story_id": str(sid),
             "stalled_days": (now - updated_at).days if updated_at else None,
         })
     # 3) CC-BE.2 답없는 블로커(enum/ids/age — raw blocker text 0).
+    # story #2538: story_stalled와 동형으로 title 추가(막힌 story 제목) — FE 구별용.
     _BlockedU = aliased(Story)
     unanswered = (
         await session.execute(
-            select(ItemDependency.from_id, ItemDependency.to_id, ItemDependency.created_at)
+            select(
+                ItemDependency.from_id, ItemDependency.to_id, ItemDependency.created_at,
+                _BlockedU.title,
+            )
             .select_from(ItemDependency)
             .join(_BlockedU, _BlockedU.id == ItemDependency.to_id)
             .where(
@@ -400,10 +409,11 @@ async def my_actions(
             .limit(20)
         )
     ).all()
-    for blocker_id, blocked_id, created_at in unanswered:
+    for blocker_id, blocked_id, created_at, blocked_title in unanswered:
         attention_items.append({
             "type": "unanswered_blocker", "severity": "warn", "auto_detected": True,
             "blocked_story_id": str(blocked_id), "blocker_id": str(blocker_id),
+            "blocked_story_title": blocked_title,
             "age_days": (now - created_at).days if created_at else None,
         })
 

--- a/backend/tests/test_2538_command_center_stalled_blocker_title_realdb.py
+++ b/backend/tests/test_2538_command_center_stalled_blocker_title_realdb.py
@@ -1,0 +1,127 @@
+"""story #2538(2026-08-09, PO 그라운딩 정정) — story_stalled/unanswered_blocker 이상 신호에
+title이 실제로 SQL 조인/셀렉트에서 나오는지 실PG로 검증한다. 기존 test_command_center.py는
+mock 세션이라 SELECT 절에 title이 실제로 들어가는지·조인이 유효한지는 증명 못한다.
+
+배경: ko.json "가설이 예상과 다르게 진행됩니다" 카피가 story_stalled(가설과 무관한 제네릭
+스토리 정체 감지)에 잘못 매핑돼 있었다 — 카피 정정+dedup+개별 구별("제목+N일")은 FE 몫,
+그 구별에 필요한 title을 이 스토리가 additive로 채운다."""
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import update
+
+from tests.test_1994_backlink_api_realdb import (
+    _client_for,
+    _make_org,
+    _make_project,
+    _session_factory,
+)
+from tests.test_2288_command_center_gate_type_waiting_realdb import (
+    _make_member,
+    _setup_app_human,
+)
+from tests.test_2301_story_body_mentions_realdb import _REAL_DB_URL, _make_story
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+_OLD = datetime.now(UTC) - timedelta(days=10)
+
+
+async def _backdate_story(session, story_id, *, status="in-progress"):
+    """updated_at은 onupdate=func.now()라 ORM 경유 커밋은 값을 덮어쓴다 — Core update()로
+    명시값을 강제한다."""
+    from app.models.pm import Story
+    await session.execute(
+        update(Story).where(Story.id == story_id).values(status=status, updated_at=_OLD)
+    )
+    await session.commit()
+
+
+async def test_story_stalled_title_matches_real_story_realdb():
+    """⭐핵심 — story_stalled 항목의 title이 실제 Story.title과 일치하는지(SQL SELECT에
+    Story.title이 실제로 들어갔는지) 실PG로 확認."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _caller_id, caller_user_id = await _make_member(s, org.id, project.id)
+            story = await _make_story(s, org.id, project.id, title="결제 리팩터링")
+            await _backdate_story(s, story.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/command-center/my-actions")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()["attention"]["items"]
+            stalled = next(i for i in items if i["type"] == "story_stalled" and i["story_id"] == str(story.id))
+            assert stalled["title"] == "결제 리팩터링", (
+                f"title이 실제 스토리 제목과 다르다: {stalled['title']!r}"
+            )
+            assert isinstance(stalled["stalled_days"], int) and stalled["stalled_days"] >= 9
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+async def test_unanswered_blocker_title_matches_blocked_story_realdb():
+    """⭐핵심 — unanswered_blocker의 blocked_story_title이 실제 막힌 story의 제목과
+    일치하는지(_BlockedU 조인 별칭에서 title 추출이 실제로 동작하는지) 실PG로 확認."""
+    from app.main import app
+    from app.models.dependency import ItemDependency
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _caller_id, caller_user_id = await _make_member(s, org.id, project.id)
+            blocker_story = await _make_story(s, org.id, project.id, title="선행 작업")
+            blocked_story = await _make_story(s, org.id, project.id, title="막힌 작업")
+            old_created = datetime.now(UTC) - timedelta(days=5)
+            s.add(ItemDependency(
+                id=uuid.uuid4(), org_id=org.id, item_type="story", dep_type="blocks",
+                from_id=blocker_story.id, to_id=blocked_story.id, created_at=old_created,
+            ))
+            await s.commit()
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/command-center/my-actions")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()["attention"]["items"]
+            ub = next(
+                i for i in items
+                if i["type"] == "unanswered_blocker" and i["blocked_story_id"] == str(blocked_story.id)
+            )
+            assert ub["blocked_story_title"] == "막힌 작업", (
+                f"blocked_story_title이 실제 막힌 스토리 제목과 다르다: {ub['blocked_story_title']!r}"
+            )
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_command_center.py
+++ b/backend/tests/test_command_center.py
@@ -225,18 +225,26 @@ async def test_my_actions_my_blockers_member_private():
 
 @pytest.mark.anyio
 async def test_my_actions_stalled_and_unanswered_blocker_enum_only():
-    """CC-BE.2 이상감지: story_stalled + unanswered_blocker(org attention·enum/ids/age·raw text 0)."""
+    """CC-BE.2 이상감지: story_stalled + unanswered_blocker(org attention·enum/ids/age·raw text 0).
+
+    story #2538: title 추가(FE "제목+N일" 구별용) — 가설과 무관한 카피 오라벨링 정정의
+    전제 데이터."""
     sid, blocker_id, blocked_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
     resp, session, resolver = await _get(
         "/api/v2/command-center/my-actions",
-        execute_seq=_ma_seq(stalled=[(sid, _OLD)], unanswered=[(blocker_id, blocked_id, _OLD)]))
+        execute_seq=_ma_seq(
+            stalled=[(sid, _OLD, "정체된 스토리")],
+            unanswered=[(blocker_id, blocked_id, _OLD, "막힌 스토리")],
+        ))
     assert resp.status_code == 200
     types = {i["type"] for i in _data(resp)["attention"]["items"]}
     assert {"story_stalled", "unanswered_blocker"} <= types
     items = _data(resp)["attention"]["items"]
     stalled_item = next(i for i in items if i["type"] == "story_stalled")
     assert stalled_item["story_id"] == str(sid) and isinstance(stalled_item["stalled_days"], int)
+    assert stalled_item["title"] == "정체된 스토리"
     ub = next(i for i in items if i["type"] == "unanswered_blocker")
+    assert ub["blocked_story_title"] == "막힌 스토리"
     assert ub["blocked_story_id"] == str(blocked_id) and isinstance(ub["age_days"], int)
 
 


### PR DESCRIPTION
## Summary
홈(조직 브리핑) "받은 요청"에 "가설이 예상과 다르게 진행됩니다·확인 필요"가 동일 문구 20건 대량 노출되는 문제를 그라운딩한 결과, 이 카피(ko.json `signalStalledTitle`/`signalStalledContext`)는 `story_stalled`(org 전체 3일+ 미변경 story 제네릭 감지, `command_center.py`)에 매핑돼 있는데 — story_stalled는 **가설과 완전 무관**(`command_center.py` 전체에 가설별 이상감지 로직 0건). "가설" 단어 자체가 카피 오라벨링이었다.

PO 결(A) 근본 fix: 카피 정정+dedup(N건 묶기)+스토리 구별("제목+N일")로 확定. 이 PR은 그 중 **BE 몫**: `story_stalled` + `unanswered_blocker`(동형 결함 — title 없음) 양쪽 attention item에 title을 additive로 추가해 FE가 "제목+N일"을 렌더할 수 있게 한다.

- `story_stalled`: `Story.title`을 SELECT에 추가
- `unanswered_blocker`: 이미 조인 중인 `_BlockedU`(막힌 story alias)에서 `title`만 추가 SELECT
- 기존 필드(story_id/stalled_days/blocked_story_id/blocker_id/age_days/type/severity/auto_detected) 전부 유지

## 스코프 밖
FE 측 인접 결함(`RawAttentionItem` 파서가 `entity_type`/`entity_id`/`gate_type`만 읽고 `story_stalled`/`unanswered_blocker`의 실제 키(`story_id`/`stalled_days`/`blocked_story_id`)를 안 읽어 href가 항상 제네릭 `/board`로 폴백)는 미르코 FE 몫으로 별도 배분(PO 확認). 카피 정정·dedup·UI도 FE 몫.

## Test plan
- [x] `test_2538_command_center_stalled_blocker_title_realdb.py`(신규 2건) — 실PG로 title이 실제 SELECT/JOIN에서 나오는지 pin
- [x] mutation self-check: title 필드 제거(양쪽 다) → RED(KeyError) 확認 후 복원 GREEN
- [x] mock 회귀 32/32(`test_command_center.py` 19건 + `test_2288_command_center_gate_type_waiting_realdb.py` + 신규)
- [x] ruff clean(신규 파일 0건, 기존 command_center.py/test_command_center.py 사전 debt 그대로·신규 0건)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>