### PR TITLE
[SID:2539] command_center에 hypothesis_falsified 결과 통보 신호 추가

### DIFF
--- a/backend/app/routers/command_center.py
+++ b/backend/app/routers/command_center.py
@@ -37,6 +37,13 @@ router = APIRouter(prefix="/api/v2/command-center", tags=["command-center", "Wor
 _AGENT_STUCK_MINUTES = 30
 _STORY_STALLED_DAYS = 3
 _BLOCKER_UNANSWERED_DAYS = 2
+# story #2539: 최근 반증(falsified)된 가설 — story_stalled와 동형 시간창 패턴.
+# ⛔in-flight 이상감지(측정 중 목표 이탈)가 아니다 — hypothesis_scorer.py 실측 확認:
+# outcome_result는 status가 verified/falsified로 "종결"되는 순간에만 채워진다("measuring
+# 이면서 outcome_result가 있는" 상태는 데이터 구조상 존재 안 함). 그래서 이 신호는 "방금
+# 반증으로 종결된 가설" 결과 통보이지, "진행 중 이상 조짐" 경고가 아니다 — 카피/타입명에
+# "이상감지" 뉘앙스를 쓰지 않는다(story_stalled 카피 오라벨링 재발 방지, PO/선생님 결).
+_HYPOTHESIS_FALSIFIED_DAYS = 7
 _PENDING = {"status": "pending_data"}  # mock-0: 미구현 집계 — 가짜 수치 대신 명시.
 # recent_changes 의미 이벤트 allowlist(저신호 conversation.* 등 제외·unknown 기본 제외).
 _MEANINGFUL_VERB_PREFIXES = ("story.", "gate.", "pr.", "epic.", "sprint.", "dependency.", "merge")
@@ -415,6 +422,30 @@ async def my_actions(
             "blocked_story_id": str(blocked_id), "blocker_id": str(blocker_id),
             "blocked_story_title": blocked_title,
             "age_days": (now - created_at).days if created_at else None,
+        })
+    # 4) story #2539: 최근 반증(falsified) 가설 — 결과 통보(in-flight 감지 아님, 위 주석 참조).
+    falsified_hyps = (
+        await session.execute(
+            select(
+                Hypothesis.id, Hypothesis.statement, Hypothesis.outcome_result,
+                Hypothesis.updated_at, Hypothesis.superseded_by_hypothesis_id,
+            )
+            .where(
+                Hypothesis.org_id == org_id,
+                Hypothesis.status == "falsified",
+                Hypothesis.updated_at >= now - timedelta(days=_HYPOTHESIS_FALSIFIED_DAYS),
+            )
+            .order_by(Hypothesis.updated_at.desc())
+            .limit(20)
+        )
+    ).all()
+    for hyp_id, statement, outcome_result, updated_at, superseded_by in falsified_hyps:
+        attention_items.append({
+            "type": "hypothesis_falsified", "severity": "info", "auto_detected": True,
+            "hypothesis_id": str(hyp_id), "statement": statement,
+            "outcome_result": outcome_result,
+            "falsified_days": (now - updated_at).days if updated_at else None,
+            "superseded_by_hypothesis_id": str(superseded_by) if superseded_by else None,
         })
 
     return JSONResponse(content={

--- a/backend/tests/test_2539_command_center_hypothesis_falsified_realdb.py
+++ b/backend/tests/test_2539_command_center_hypothesis_falsified_realdb.py
@@ -1,0 +1,174 @@
+"""story #2539(2026-08-09, PO (가) 결·선생님 승인) — command_center의 hypothesis_falsified
+결과 통보 신호를 실PG로 검증한다. 기존 test_command_center.py는 mock 세션이라 SELECT 절이
+실제로 유효한지·superseded_by_hypothesis_id 조인이 동작하는지는 증명 못한다.
+
+⛔이 신호는 in-flight 이상감지가 아니다(그라운딩 확認: outcome_result는 status가 verified/
+falsified로 종결되는 순간에만 채워짐 — "measuring이면서 outcome_result 있음"은 데이터
+구조상 존재 안 함). "방금 falsified로 종결된 가설" 결과 통보일 뿐이라 severity=info다."""
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import update
+
+from tests.test_1994_backlink_api_realdb import (
+    _client_for,
+    _make_org,
+    _make_project,
+    _session_factory,
+)
+from tests.test_2288_command_center_gate_type_waiting_realdb import (
+    _make_member,
+    _setup_app_human,
+)
+from tests.test_2301_story_body_mentions_realdb import _REAL_DB_URL
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+_METRIC = {"metric": "signups", "source": "db", "target": 100, "direction": "increase"}
+
+
+async def _make_hypothesis(session, org_id, project_id, owner_id, *, statement="Hyp", status="proposed"):
+    from app.models.hypothesis import Hypothesis
+    hyp = Hypothesis(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, owner_member_id=owner_id,
+        statement=statement, metric_definition=_METRIC,
+        measure_after=datetime(2026, 1, 1, tzinfo=UTC), status=status,
+    )
+    session.add(hyp)
+    await session.commit()
+    return hyp
+
+
+async def _falsify_hypothesis(session, hyp_id, *, outcome_result=None, superseded_by=None, updated_at):
+    """updated_at은 onupdate=func.now()라 Core update()로 명시값을 강제한다(story #2538과 동형)."""
+    from app.models.hypothesis import Hypothesis
+    await session.execute(
+        update(Hypothesis).where(Hypothesis.id == hyp_id).values(
+            status="falsified", outcome_result=outcome_result,
+            superseded_by_hypothesis_id=superseded_by, updated_at=updated_at,
+        )
+    )
+    await session.commit()
+
+
+async def test_hypothesis_falsified_signal_carries_real_outcome_realdb():
+    """⭐핵심 — hypothesis_falsified 항목이 실제 statement/outcome_result와 일치하고
+    severity=info(결과 통보, 경고 아님)인지 실PG로 확認."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_member(s, org.id, project.id)
+            hyp = await _make_hypothesis(s, org.id, project.id, caller_id, statement="2단계 체크아웃 가설")
+            outcome = {"metric": "signups", "target": 100.0, "actual": 42.0, "direction": "increase"}
+            await _falsify_hypothesis(
+                s, hyp.id, outcome_result=outcome, updated_at=datetime.now(UTC) - timedelta(days=2),
+            )
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/command-center/my-actions")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()["attention"]["items"]
+            hf = next(i for i in items if i["type"] == "hypothesis_falsified" and i["hypothesis_id"] == str(hyp.id))
+            assert hf["statement"] == "2단계 체크아웃 가설"
+            assert hf["outcome_result"] == outcome
+            assert hf["severity"] == "info", "결과 통보라 warn 아닌 info여야 하는 — story_stalled와 의도적으로 다른 톤"
+            assert isinstance(hf["falsified_days"], int) and hf["falsified_days"] >= 1
+            assert hf["superseded_by_hypothesis_id"] is None
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+async def test_hypothesis_falsified_exposes_superseded_by_when_confirmed_realdb():
+    """AC — 확認된 대체 가설(superseded_by_hypothesis_id)이 있으면 그대로 노출(정반합 톤 재료),
+    지어내지 않는다 원칙상 확認 안 되면 이전 테스트처럼 None."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_member(s, org.id, project.id)
+            falsified_hyp = await _make_hypothesis(s, org.id, project.id, caller_id, statement="원래 가설")
+            successor = await _make_hypothesis(s, org.id, project.id, caller_id, statement="대체 가설")
+            await _falsify_hypothesis(
+                s, falsified_hyp.id, superseded_by=successor.id,
+                updated_at=datetime.now(UTC) - timedelta(days=1),
+            )
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/command-center/my-actions")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()["attention"]["items"]
+            hf = next(
+                i for i in items
+                if i["type"] == "hypothesis_falsified" and i["hypothesis_id"] == str(falsified_hyp.id)
+            )
+            assert hf["superseded_by_hypothesis_id"] == str(successor.id)
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+async def test_hypothesis_falsified_excludes_old_and_other_status_realdb():
+    """AC — _HYPOTHESIS_FALSIFIED_DAYS 밖으로 오래된 falsified·status가 falsified 아닌
+    가설은 신호에 안 뜬다(false positive 0)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_member(s, org.id, project.id)
+            old_falsified = await _make_hypothesis(s, org.id, project.id, caller_id, statement="오래된 반증")
+            await _falsify_hypothesis(s, old_falsified.id, updated_at=datetime.now(UTC) - timedelta(days=30))
+            still_active = await _make_hypothesis(
+                s, org.id, project.id, caller_id, statement="진행중", status="active",
+            )
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/command-center/my-actions")
+            assert resp.status_code == 200, resp.text
+            ids = {
+                i["hypothesis_id"] for i in resp.json()["attention"]["items"]
+                if i["type"] == "hypothesis_falsified"
+            }
+            assert str(old_falsified.id) not in ids
+            assert str(still_active.id) not in ids
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_command_center.py
+++ b/backend/tests/test_command_center.py
@@ -94,7 +94,7 @@ def _data(resp):
 # my_blockers를 채운 테스트만 다음 호출들이 전부 밀려 엉뚱한 mock을 받는다).
 def _ma_seq(
     approvals=(), reviews=(), my_blockers=(), waiting=(), stuck=(), stalled=(), unanswered=(),
-    my_tasks=(), approval_group_counts=(), blocker_weight_counts=(),
+    my_tasks=(), approval_group_counts=(), blocker_weight_counts=(), falsified=(),
 ):
     seq = [_r_all(approvals)]
     if approvals:
@@ -108,6 +108,7 @@ def _ma_seq(
     seq.append(_r_scalars(stuck))
     seq.append(_r_all(stalled))
     seq.append(_r_all(unanswered))
+    seq.append(_r_all(falsified))  # story #2539
     return seq
 
 
@@ -246,6 +247,40 @@ async def test_my_actions_stalled_and_unanswered_blocker_enum_only():
     ub = next(i for i in items if i["type"] == "unanswered_blocker")
     assert ub["blocked_story_title"] == "막힌 스토리"
     assert ub["blocked_story_id"] == str(blocked_id) and isinstance(ub["age_days"], int)
+
+
+@pytest.mark.anyio
+async def test_my_actions_hypothesis_falsified_result_notification():
+    """story #2539: 최근 falsified 가설 결과 통보(in-flight 이상감지 아님 — severity=info,
+    story_stalled/unanswered_blocker의 severity=warn과 의도적으로 다름)."""
+    hyp_id, succ_id = uuid.uuid4(), uuid.uuid4()
+    outcome = {"metric": "signups", "target": 100, "actual": 42, "direction": "increase"}
+    resp, session, resolver = await _get(
+        "/api/v2/command-center/my-actions",
+        execute_seq=_ma_seq(falsified=[(hyp_id, "체크아웃 2단계면 가입 늘 것", outcome, _OLD, succ_id)]))
+    assert resp.status_code == 200
+    items = _data(resp)["attention"]["items"]
+    hf = next(i for i in items if i["type"] == "hypothesis_falsified")
+    assert hf["severity"] == "info"
+    assert hf["hypothesis_id"] == str(hyp_id)
+    assert hf["statement"] == "체크아웃 2단계면 가입 늘 것"
+    assert hf["outcome_result"] == outcome
+    assert isinstance(hf["falsified_days"], int)
+    assert hf["superseded_by_hypothesis_id"] == str(succ_id)
+
+
+@pytest.mark.anyio
+async def test_my_actions_hypothesis_falsified_superseded_by_null_when_unconfirmed():
+    """AC — 확認된 대체 페어 없으면 superseded_by_hypothesis_id는 None(지어내지 않는다)."""
+    hyp_id = uuid.uuid4()
+    resp, session, resolver = await _get(
+        "/api/v2/command-center/my-actions",
+        execute_seq=_ma_seq(falsified=[(hyp_id, "S", None, _OLD, None)]))
+    assert resp.status_code == 200
+    items = _data(resp)["attention"]["items"]
+    hf = next(i for i in items if i["type"] == "hypothesis_falsified")
+    assert hf["superseded_by_hypothesis_id"] is None
+    assert hf["outcome_result"] is None
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
v4 «가설 축척»에서 홈 «이상 신호»가 실제로는 가설과 무관한 `story_stalled`뿐이었다(#2936/#2937/#2938에서 카피 오라벨링 정정 완료). 이 PR은 진짜 가설 관련 신호를 추가한다.

## ⭐그라운딩 확認(중요 — 스코프를 결정한 근거)
"진행 중인 가설이 목표에서 벗어나는 조짐"(in-flight 이상감지)은 **데이터 구조상 원천 불가**로 확認됨: `hypothesis_scorer.py`는 `hyp.outcome_result = scoring["outcome_result"]`를 `new_status is not None`(hit→verified/miss→falsified, 즉 **종결**) 분기 안에서만 실행한다. status가 measuring으로 "유지"되는 분기는 outcome_result를 항상 None으로 남긴다 — "measuring이면서 outcome_result가 채워진" 상태는 코드상 존재하지 않는다.

PO/선생님 결(가): `story_stalled` 카피 오라벨링과 같은 함정을 반복하지 않기 위해 "방금 falsified로 종결된 가설" **결과 통보**로 정직하게 스코프를 좁힌다 — `severity="info"`(warn 아님), "이상감지" 뉘앙스 배제.

## 변경
`story_stalled`/`unanswered_blocker`와 동형 패턴으로 4번째 attention type `hypothesis_falsified` 추가:
- 감지: `Hypothesis.org_id`, `status='falsified'`, `updated_at >= now - 7일`(`_HYPOTHESIS_FALSIFIED_DAYS` 상수, limit 20)
- **FE가 읽을 필드명**(#2938 교훈): `hypothesis_id`, `statement`, `outcome_result`(이미 존재하는 `{metric,target,actual,direction}` 형태), `falsified_days`, `superseded_by_hypothesis_id`(nullable — #2533 self-FK, 확認된 페어만 채워짐·지어내지 않는다)

## 스코프 밖
FE 측 카피 톤(정반합 — "가설이 반증됨 → 대체 가설로")·dedup·UI는 미르코 몫. (나)(측정 중간 스냅샷 신설 — 진짜 in-flight 감지)는 별도 백로그.

## Test plan
- [x] `test_2539_command_center_hypothesis_falsified_realdb.py`(신규 3건) — 실PG로 statement/outcome_result 일치·severity=info·superseded_by 노출/None 정확성·N일 밖 제외 pin
- [x] mutation self-check: `superseded_by_hypothesis_id` 필드 제거 → RED(KeyError) 확認 후 복원 GREEN
- [x] mock 회귀 37/37(`test_command_center.py` 21건 + `test_2288_command_center_gate_type_waiting_realdb.py` + `test_2538_...` + 신규)
- [x] ruff clean(신규 파일 0건, 기존 파일 pre-existing debt와 동일 클래스 패턴만 비례 증가)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>