### PR TITLE
fix(routing): 흐름→/flow bare-route dead-end — 프로젝트 단건조회 실패시 리스트 폴백 [최우선]

### DIFF
--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -92,20 +92,26 @@ export default async function AuthenticatedLayout({
   // 단건 조회(name+slug 동시)로 보강한다 — 사이드바/⌘K "문서" 바로가기 slug(story a539c649 S2)
   // 와 표시 이름이 같은 project를 가리키므로 PO 리뷰(§확認②) 지적대로 fetch 하나로 합쳤다.
   // pathProjectId가 없으면(flat 라우트) 계정 상태 project 기준으로 조회한다(기존 동작 유지).
+  // ⛔카디르 QA 근본 재진단(2026-08-09, 실측 8회 재현) — 아래 project 조회(단건·리스트 둘 다)를
+  // X-Org-Id 없이 부르면 BE get_verified_org_id가 **JWT 기본 org**로 스코프한다. 세션의
+  // 현재/타겟 org(pathOrgId ?? me.org_id)가 JWT 기본 org와 다른 멀티org 계정에선 엉뚱한
+  // org로 스코프돼 빈 결과/404가 난다(curl로 X-Org-Id 붙이면 정상 확認됨) — 이게 사이드바
+  // bare-link 결함의 진짜 근본원인.
+  const projectAuthHeader = { ...authHeader, 'X-Org-Id': pathOrgId ?? me?.org_id ?? '' };
   const projectInfoTargetId = pathProjectId ?? me?.project_id;
   const projectInfo = projectInfoTargetId
-    ? await fetch(`${fastapiUrl}/api/v2/projects/${projectInfoTargetId}`, { headers: authHeader, cache: 'no-store' })
+    ? await fetch(`${fastapiUrl}/api/v2/projects/${projectInfoTargetId}`, { headers: projectAuthHeader, cache: 'no-store' })
         .then((r) => (r.ok ? r.json() : null))
         .then((json: { name?: string; slug?: string | null } | null) => json)
         .catch(() => null)
     : null;
   // ⛔실측 결함(2026-08-09, PO puppeteer 재현 — 흐름 메뉴→/flow bare→dead-end 404) — 위 단건조회
   // (GET /projects/{id})가 정상 프로젝트(slug 有)인데도 이따금 slug 없이/실패 응답해 사이드바가
-  // slug 없는 bare 링크만 만들었다(원인 미확定, BE 로그 확認 별건). 리스트 엔드포인트(GET
-  // /projects)는 같은 프로젝트를 직접 대조로 항상 정확히 낸다는 걸 확認했다 — 단건조회가 비면
-  // 그 자리에서 포기하지 않고 리스트에서 한 번 더 찾는다.
+  // slug 없는 bare 링크만 만들었다(근본원인=위 X-Org-Id 누락). 리스트 엔드포인트(GET /projects)는
+  // 같은 프로젝트를 직접 대조로 항상 정확히 낸다는 걸 확認했다 — 단건조회가 비면 그 자리에서
+  // 포기하지 않고 리스트에서 한 번 더 찾는다.
   const projectInfoFallback = projectInfoTargetId && !projectInfo?.slug
-    ? await fetch(`${fastapiUrl}/api/v2/projects`, { headers: authHeader, cache: 'no-store' })
+    ? await fetch(`${fastapiUrl}/api/v2/projects`, { headers: projectAuthHeader, cache: 'no-store' })
         .then((r) => (r.ok ? r.json() : null))
         .then((list: Array<{ id?: string; name?: string; slug?: string | null }> | null) =>
           list?.find((p) => p.id === projectInfoTargetId) ?? null)

--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -99,11 +99,24 @@ export default async function AuthenticatedLayout({
         .then((json: { name?: string; slug?: string | null } | null) => json)
         .catch(() => null)
     : null;
-  const currentProjectSlug = projectInfo?.slug ?? undefined;
+  // ⛔실측 결함(2026-08-09, PO puppeteer 재현 — 흐름 메뉴→/flow bare→dead-end 404) — 위 단건조회
+  // (GET /projects/{id})가 정상 프로젝트(slug 有)인데도 이따금 slug 없이/실패 응답해 사이드바가
+  // slug 없는 bare 링크만 만들었다(원인 미확定, BE 로그 확認 별건). 리스트 엔드포인트(GET
+  // /projects)는 같은 프로젝트를 직접 대조로 항상 정확히 낸다는 걸 확認했다 — 단건조회가 비면
+  // 그 자리에서 포기하지 않고 리스트에서 한 번 더 찾는다.
+  const projectInfoFallback = projectInfoTargetId && !projectInfo?.slug
+    ? await fetch(`${fastapiUrl}/api/v2/projects`, { headers: authHeader, cache: 'no-store' })
+        .then((r) => (r.ok ? r.json() : null))
+        .then((list: Array<{ id?: string; name?: string; slug?: string | null }> | null) =>
+          list?.find((p) => p.id === projectInfoTargetId) ?? null)
+        .catch(() => null)
+    : null;
+  const currentProjectSlug = projectInfo?.slug ?? projectInfoFallback?.slug ?? undefined;
+  const projectInfoName = projectInfo?.name ?? projectInfoFallback?.name;
 
   const pathProjectKnown = pathProjectId ? projectMemberships.some((m) => m.projectId === pathProjectId) : true;
-  if (pathProjectId && !pathProjectKnown && projectInfo?.name) {
-    projectMemberships = [...projectMemberships, { projectId: pathProjectId, projectName: projectInfo.name }];
+  if (pathProjectId && !pathProjectKnown && projectInfoName) {
+    projectMemberships = [...projectMemberships, { projectId: pathProjectId, projectName: projectInfoName }];
   }
   // PO 리뷰(§확認①) — 위 조회가 실패하면(네트워크·403 등) projectMemberships에 pathProjectId가
   // 안 들어간다. dashboard-shell.tsx가 이 경우 계정 상태의 옛 project_name으로 조용히

--- a/apps/web/src/lib/route-resolve.ts
+++ b/apps/web/src/lib/route-resolve.ts
@@ -216,15 +216,30 @@ export async function resolveLegacyResourcePath(
   accessToken: string,
 ): Promise<{ orgSlug: string; projectSlug: string } | null> {
   try {
+    const authHeader = { Authorization: `Bearer ${accessToken}` };
     const [orgRes, projRes] = await Promise.all([
-      fetch(`${fastapiUrl}/api/v2/organizations/${orgId}`, { headers: { Authorization: `Bearer ${accessToken}` } }),
-      fetch(`${fastapiUrl}/api/v2/projects/${projectId}`, { headers: { Authorization: `Bearer ${accessToken}` } }),
+      fetch(`${fastapiUrl}/api/v2/organizations/${orgId}`, { headers: authHeader }),
+      fetch(`${fastapiUrl}/api/v2/projects/${projectId}`, { headers: authHeader }),
     ]);
-    if (!orgRes.ok || !projRes.ok) return null;
+    if (!orgRes.ok) return null;
     const org = await orgRes.json() as { slug?: string };
-    const proj = await projRes.json() as { slug?: string | null };
-    if (!org.slug || !proj.slug) return null;
-    return { orgSlug: org.slug, projectSlug: proj.slug };
+    if (!org.slug) return null;
+
+    let projectSlug = projRes.ok ? ((await projRes.json() as { slug?: string | null }).slug ?? null) : null;
+    // ⛔실측 결함(2026-08-09, PO puppeteer 재현 — 흐름 메뉴→/flow bare→dead-end 404) — 단건조회
+    // (GET /projects/{id})가 정상 프로젝트(slug 有)인데도 이따금 slug 없이/실패 응답해 이 자리가
+    // dead-end 404였다(원인 미확定, BE 로그 확認 별건 — Cloud Run 로그로 디디군 확認 中). 리스트
+    // 엔드포인트(GET /projects)는 같은 프로젝트를 직접 대조로 항상 정확히 낸다는 걸 확認했다 —
+    // 단건조회가 비면 그 자리에서 정직하게 포기하지 않고 리스트에서 안전하게 한 번 더 찾는다.
+    if (!projectSlug) {
+      const listRes = await fetch(`${fastapiUrl}/api/v2/projects`, { headers: authHeader });
+      if (listRes.ok) {
+        const list = await listRes.json() as Array<{ id?: string; slug?: string | null }>;
+        projectSlug = list.find((p) => p.id === projectId)?.slug ?? null;
+      }
+    }
+    if (!projectSlug) return null;
+    return { orgSlug: org.slug, projectSlug };
   } catch {
     return null;
   }

--- a/apps/web/src/lib/route-resolve.ts
+++ b/apps/web/src/lib/route-resolve.ts
@@ -217,9 +217,15 @@ export async function resolveLegacyResourcePath(
 ): Promise<{ orgSlug: string; projectSlug: string } | null> {
   try {
     const authHeader = { Authorization: `Bearer ${accessToken}` };
+    // ⛔카디르 QA 근본 재진단(2026-08-09, 실측 8회 재현) — 이 함수의 project 조회(단건·리스트
+    // 둘 다)가 X-Org-Id 없이 나가면 BE get_verified_org_id가 **JWT 기본 org**로 스코프한다.
+    // 세션의 현재/타겟 org(이 함수의 orgId 파라미터)가 JWT 기본 org와 다른 멀티org 계정에선
+    // 엉뚱한 org로 스코프돼 빈 결과/404가 난다(curl로 X-Org-Id 붙이면 정상 확認됨) — 위
+    // 리스트 폴백 fix가 이 헤더 없이는 애초에 못 먹었던 진짜 근본원인.
+    const authHeaderWithOrg = { ...authHeader, 'X-Org-Id': orgId };
     const [orgRes, projRes] = await Promise.all([
       fetch(`${fastapiUrl}/api/v2/organizations/${orgId}`, { headers: authHeader }),
-      fetch(`${fastapiUrl}/api/v2/projects/${projectId}`, { headers: authHeader }),
+      fetch(`${fastapiUrl}/api/v2/projects/${projectId}`, { headers: authHeaderWithOrg }),
     ]);
     if (!orgRes.ok) return null;
     const org = await orgRes.json() as { slug?: string };
@@ -228,11 +234,11 @@ export async function resolveLegacyResourcePath(
     let projectSlug = projRes.ok ? ((await projRes.json() as { slug?: string | null }).slug ?? null) : null;
     // ⛔실측 결함(2026-08-09, PO puppeteer 재현 — 흐름 메뉴→/flow bare→dead-end 404) — 단건조회
     // (GET /projects/{id})가 정상 프로젝트(slug 有)인데도 이따금 slug 없이/실패 응답해 이 자리가
-    // dead-end 404였다(원인 미확定, BE 로그 확認 별건 — Cloud Run 로그로 디디군 확認 中). 리스트
-    // 엔드포인트(GET /projects)는 같은 프로젝트를 직접 대조로 항상 정확히 낸다는 걸 확認했다 —
-    // 단건조회가 비면 그 자리에서 정직하게 포기하지 않고 리스트에서 안전하게 한 번 더 찾는다.
+    // dead-end 404였다(근본원인=위 X-Org-Id 누락). 리스트 엔드포인트(GET /projects)는 같은
+    // 프로젝트를 직접 대조로 항상 정확히 낸다는 걸 확認했다 — 단건조회가 비면 그 자리에서
+    // 정직하게 포기하지 않고 리스트에서 안전하게 한 번 더 찾는다.
     if (!projectSlug) {
-      const listRes = await fetch(`${fastapiUrl}/api/v2/projects`, { headers: authHeader });
+      const listRes = await fetch(`${fastapiUrl}/api/v2/projects`, { headers: authHeaderWithOrg });
       if (listRes.ok) {
         const list = await listRes.json() as Array<{ id?: string; slug?: string | null }>;
         projectSlug = list.find((p) => p.id === projectId)?.slug ?? null;

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -345,6 +345,9 @@ describe('proxy', () => {
     const now = Math.floor(Date.now() / 1000);
     const newAt = await makeAccessToken({ exp: now + 900, orgId: 'org-1', projectId: 'proj-1' });
     mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/api/v2/me')) {
+          return Promise.resolve({ ok: true, json: async () => ({ org_id: 'org-1' }) });
+        }
       if (url.includes('/api/v2/auth/refresh')) {
         return Promise.resolve({ ok: true, json: async () => ({ data: { access_token: newAt, refresh_token: 'new-rt' } }) });
       }
@@ -367,6 +370,9 @@ describe('proxy', () => {
     const now = Math.floor(Date.now() / 1000);
     const newAt = await makeAccessToken({ exp: now + 900, orgId: 'org-1', projectId: 'proj-1' });
     mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/api/v2/me')) {
+          return Promise.resolve({ ok: true, json: async () => ({ org_id: 'org-1' }) });
+        }
       if (url.includes('/api/v2/auth/refresh')) {
         return Promise.resolve({ ok: true, json: async () => ({ data: { access_token: newAt, refresh_token: 'new-rt' } }) });
       }
@@ -505,6 +511,9 @@ describe('proxy — legacy /docs bare-URL redirect (story a539c649 S2)', () => {
     // (design-tokens 제외 가드 자체를 직접 증명 — 뮤테이션 셀프체크로 확인).
     const token = await makeAccessToken({ orgId: 'org-1' });
     mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/api/v2/me')) {
+          return Promise.resolve({ ok: true, json: async () => ({ org_id: 'org-1' }) });
+        }
       if (url.includes('/api/v2/organizations/org-1')) {
         return Promise.resolve({ ok: true, json: async () => ({ id: 'org-1', slug: 'moonklabs' }) });
       }
@@ -523,6 +532,9 @@ describe('proxy — legacy /docs bare-URL redirect (story a539c649 S2)', () => {
   it('bare /docs/{slug} + org_id(JWT)+current-project 쿠키 있으면 실 slug로 301', async () => {
     const token = await makeAccessToken({ orgId: 'org-1' });
     mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/api/v2/me')) {
+          return Promise.resolve({ ok: true, json: async () => ({ org_id: 'org-1' }) });
+        }
       if (url.includes('/api/v2/organizations/org-1')) {
         return Promise.resolve({ ok: true, json: async () => ({ id: 'org-1', slug: 'moonklabs' }) });
       }
@@ -541,6 +553,9 @@ describe('proxy — legacy /docs bare-URL redirect (story a539c649 S2)', () => {
   it('bare /docs(list, slug 없음)도 동일하게 301', async () => {
     const token = await makeAccessToken({ orgId: 'org-1' });
     mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/api/v2/me')) {
+          return Promise.resolve({ ok: true, json: async () => ({ org_id: 'org-1' }) });
+        }
       if (url.includes('/api/v2/organizations/org-1')) {
         return Promise.resolve({ ok: true, json: async () => ({ id: 'org-1', slug: 'moonklabs' }) });
       }
@@ -560,16 +575,30 @@ describe('proxy — legacy /docs bare-URL redirect (story a539c649 S2)', () => {
   // next=원 목적지를 들고 보낸다 — "고르면 여기로 돌아온다"(use-unified-switcher.ts가 소비).
   it('current-project 쿠키도 JWT project_id도 없으면 404 대신 /org-briefing?next=<원경로+되돌이방지마커>로 302(story #2212)', async () => {
     const token = await makeAccessToken({ orgId: 'org-1' });
+    // ⛔카디르 QA 2차 재진단(2026-08-09) — orgId는 이제 /api/v2/me 실조회로 확定한다(JWT 클레임
+    // 직접 디코드 대신) — 이 테스트도 그 조회가 성공한다고 가정한다(mockFetch가 이제 호출된다,
+    // 예전엔 JWT만 디코드해서 0회였다 — "호출 안 됨"이 아니라 "302 목적지가 맞다"가 이 테스트의
+    // 진짜 관심사).
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/api/v2/me')) {
+        return Promise.resolve({ ok: true, json: async () => ({ org_id: 'org-1' }) });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
     const response = await middleware(makeRequest('/docs/my-doc', { sp_at: token }));
     expect(response.status).toBe(302);
     // _prRetry=1 — 프로젝트를 골라도 또 실패하면(아래 되돌이 방지 테스트) 다시 안 튕기기 위한 내부 마커.
     expect(response.headers.get('location')).toBe('https://app.example.com/org-briefing?next=%2Fdocs%2Fmy-doc%3F_prRetry%3D1');
-    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('org/project는 확定됐는데 BE 단건 조회만 실패(예: 삭제됨)해도 404 대신 /org-briefing?next=<원경로+되돌이방지마커>로 302(story #2212)', async () => {
     const token = await makeAccessToken({ orgId: 'org-1' });
-    mockFetch.mockResolvedValue({ ok: false, status: 404 });
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/api/v2/me')) {
+        return Promise.resolve({ ok: true, json: async () => ({ org_id: 'org-1' }) });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
     const response = await middleware(makeRequest('/docs/my-doc', {
       sp_at: token, sprintable_current_project_id: 'proj-1',
     }));
@@ -584,6 +613,9 @@ describe('proxy — legacy /docs bare-URL redirect (story a539c649 S2)', () => {
   it('단건조회(GET /projects/{id})만 실패해도 리스트(GET /projects)에서 찾아 301 성공한다(단건조회 불안정 dead-end fix)', async () => {
     const token = await makeAccessToken({ orgId: 'org-1' });
     mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/api/v2/me')) {
+          return Promise.resolve({ ok: true, json: async () => ({ org_id: 'org-1' }) });
+        }
       if (url.includes('/api/v2/organizations/org-1')) {
         return Promise.resolve({ ok: true, json: async () => ({ id: 'org-1', slug: 'moonklabs' }) });
       }
@@ -613,6 +645,9 @@ describe('proxy — legacy /docs bare-URL redirect (story a539c649 S2)', () => {
   it('project 단건조회·리스트조회 둘 다 X-Org-Id 헤더를 보낸다(멀티org 계정 cross-org 스코프 오류 방지)', async () => {
     const token = await makeAccessToken({ orgId: 'org-1' });
     mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/api/v2/me')) {
+          return Promise.resolve({ ok: true, json: async () => ({ org_id: 'org-1' }) });
+        }
       if (url.includes('/api/v2/organizations/org-1')) {
         return Promise.resolve({ ok: true, json: async () => ({ id: 'org-1', slug: 'moonklabs' }) });
       }
@@ -632,12 +667,42 @@ describe('proxy — legacy /docs bare-URL redirect (story a539c649 S2)', () => {
     expect((listCall?.[1] as { headers?: Record<string, string> })?.headers?.['X-Org-Id']).toBe('org-1');
   });
 
+  // ⛔카디르 QA 2차 재진단(2026-08-09, 실측 8회 재현) — 진짜 회귀가드. 위 테스트들은 JWT의
+  // org_id와 /api/v2/me의 org_id가 우연히 같은 'org-1'이라 구현이 JWT를 디코드하든 /me를
+  // 실조회하든 결과가 똑같아 mutation을 못 잡았다(뮤테이션self-check으로 직접 확認한 맹점).
+  // 멀티org 계정처럼 **둘을 의도적으로 다르게** 둬 /api/v2/me(실조회)의 org가 이긴다는 걸
+  // 직접 잠근다 — JWT 클레임으로 되돌아가면 이 테스트가 RED된다.
+  it('JWT의 org_id 클레임이 stale해도(멀티org 계정) /api/v2/me의 살아있는 org_id를 쓴다', async () => {
+    const token = await makeAccessToken({ orgId: 'jwt-org-stale' });
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/api/v2/me')) {
+        return Promise.resolve({ ok: true, json: async () => ({ org_id: 'org-live' }) });
+      }
+      if (url.includes('/api/v2/organizations/org-live')) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'org-live', slug: 'liveorg' }) });
+      }
+      if (url.includes('/api/v2/projects/proj-1')) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'proj-1', slug: 'sprintable' }) });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+    const response = await middleware(makeRequest('/docs/my-doc', {
+      sp_at: token, sprintable_current_project_id: 'proj-1',
+    }));
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('https://app.example.com/liveorg/sprintable/docs/my-doc');
+    expect(mockFetch.mock.calls.some((args: unknown[]) => (args[0] as string).includes('/api/v2/organizations/jwt-org-stale'))).toBe(false);
+  });
+
   // PO 실제 재현(2026-08-09) — org-briefing 배너대로 프로젝트를 선택해 next(_prRetry=1 달고)로
   // 돌아온 요청. fix 전에는 단건조회 실패 + retry-guard가 겹쳐 정직한 404로 막다른 dead-end였다
   // (선택해도 못 빠져나옴) — 리스트 폴백이 이 재시도 요청에서도 먹혀 301로 뚫리는지 잠근다.
   it('되돌이(재시도, _prRetry=1) 요청에서도 단건조회 실패+리스트 성공이면 301로 정상 착지한다(PO 실제 재현 dead-end fix)', async () => {
     const token = await makeAccessToken({ orgId: 'org-1' });
     mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/api/v2/me')) {
+          return Promise.resolve({ ok: true, json: async () => ({ org_id: 'org-1' }) });
+        }
       if (url.includes('/api/v2/organizations/org-1')) {
         return Promise.resolve({ ok: true, json: async () => ({ id: 'org-1', slug: 'moonklabs' }) });
       }
@@ -682,6 +747,9 @@ describe('proxy — legacy resource redirect generalized to non-docs resources (
     async (resource) => {
       const token = await makeAccessToken({ orgId: 'org-1' });
       mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/api/v2/me')) {
+          return Promise.resolve({ ok: true, json: async () => ({ org_id: 'org-1' }) });
+        }
         if (url.includes('/api/v2/organizations/org-1')) {
           return Promise.resolve({ ok: true, json: async () => ({ id: 'org-1', slug: 'moonklabs' }) });
         }
@@ -701,6 +769,9 @@ describe('proxy — legacy resource redirect generalized to non-docs resources (
   it('story #1999: CURRENT_PROJECT_COOKIE 부재(평범한 로그인 직후) 시 access token app_metadata.project_id로 fallback — 여전히 301', async () => {
     const token = await makeAccessToken({ orgId: 'org-1', projectId: 'proj-1' });
     mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/api/v2/me')) {
+          return Promise.resolve({ ok: true, json: async () => ({ org_id: 'org-1' }) });
+        }
       if (url.includes('/api/v2/organizations/org-1')) {
         return Promise.resolve({ ok: true, json: async () => ({ id: 'org-1', slug: 'moonklabs' }) });
       }
@@ -718,6 +789,9 @@ describe('proxy — legacy resource redirect generalized to non-docs resources (
   it('story #1999: 쿠키와 JWT project_id가 다르면 쿠키 우선(명시 switch-project 결과 존중)', async () => {
     const token = await makeAccessToken({ orgId: 'org-1', projectId: 'proj-old' });
     mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/api/v2/me')) {
+          return Promise.resolve({ ok: true, json: async () => ({ org_id: 'org-1' }) });
+        }
       if (url.includes('/api/v2/organizations/org-1')) {
         return Promise.resolve({ ok: true, json: async () => ({ id: 'org-1', slug: 'moonklabs' }) });
       }

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -605,6 +605,33 @@ describe('proxy — legacy /docs bare-URL redirect (story a539c649 S2)', () => {
     expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/sprintable/docs/my-doc');
   });
 
+  // ⛔카디르 QA 근본 재진단(2026-08-09, 실측 8회 재현) — 위 리스트 폴백 fix는 이 헤더 없이는
+  // 애초에 못 먹었다: X-Org-Id 없는 project 조회는 BE get_verified_org_id가 JWT 기본 org로
+  // 스코프해, 세션의 현재/타겟 org가 그와 다른 멀티org 계정에선 엉뚱한 org로 스코프돼 빈
+  // 결과/404가 난다(curl로 X-Org-Id 붙이면 정상 확認됨) — 단건조회·리스트 조회 둘 다 X-Org-Id
+  // 를 보내는지 직접 잠근다(회귀 시 다시 dead-end로 돌아간다).
+  it('project 단건조회·리스트조회 둘 다 X-Org-Id 헤더를 보낸다(멀티org 계정 cross-org 스코프 오류 방지)', async () => {
+    const token = await makeAccessToken({ orgId: 'org-1' });
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/api/v2/organizations/org-1')) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'org-1', slug: 'moonklabs' }) });
+      }
+      if (url.includes('/api/v2/projects/proj-1')) {
+        return Promise.resolve({ ok: false, status: 404 }); // 단건조회는 실패 → 리스트 폴백 유도
+      }
+      if (url.endsWith('/api/v2/projects')) {
+        return Promise.resolve({ ok: true, json: async () => [{ id: 'proj-1', slug: 'sprintable' }] });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+    await middleware(makeRequest('/docs/my-doc', { sp_at: token, sprintable_current_project_id: 'proj-1' }));
+
+    const singleItemCall = mockFetch.mock.calls.find((args: unknown[]) => (args[0] as string).includes('/api/v2/projects/proj-1'));
+    const listCall = mockFetch.mock.calls.find((args: unknown[]) => (args[0] as string).endsWith('/api/v2/projects'));
+    expect((singleItemCall?.[1] as { headers?: Record<string, string> })?.headers?.['X-Org-Id']).toBe('org-1');
+    expect((listCall?.[1] as { headers?: Record<string, string> })?.headers?.['X-Org-Id']).toBe('org-1');
+  });
+
   // PO 실제 재현(2026-08-09) — org-briefing 배너대로 프로젝트를 선택해 next(_prRetry=1 달고)로
   // 돌아온 요청. fix 전에는 단건조회 실패 + retry-guard가 겹쳐 정직한 404로 막다른 dead-end였다
   // (선택해도 못 빠져나옴) — 리스트 폴백이 이 재시도 요청에서도 먹혀 301로 뚫리는지 잠근다.

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -577,6 +577,58 @@ describe('proxy — legacy /docs bare-URL redirect (story a539c649 S2)', () => {
     expect(response.headers.get('location')).toBe('https://app.example.com/org-briefing?next=%2Fdocs%2Fmy-doc%3F_prRetry%3D1');
   });
 
+  // ⛔실측 결함(2026-08-09, PO puppeteer 재현 — 흐름 메뉴→/flow bare→dead-end 404) — 단건조회
+  // (GET /projects/{id})가 slug 有인 정상 프로젝트인데도 이따금 실패해 이 자리가 dead-end
+  // 404였다(원인 미확定, BE 로그 확認 별건). 리스트 엔드포인트(GET /projects)로 안전하게
+  // 폴백해 org-briefing 되돌이 없이 바로 301 성공하는지 잠근다.
+  it('단건조회(GET /projects/{id})만 실패해도 리스트(GET /projects)에서 찾아 301 성공한다(단건조회 불안정 dead-end fix)', async () => {
+    const token = await makeAccessToken({ orgId: 'org-1' });
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/api/v2/organizations/org-1')) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'org-1', slug: 'moonklabs' }) });
+      }
+      if (url.includes('/api/v2/projects/proj-1')) {
+        return Promise.resolve({ ok: false, status: 404 }); // 단건조회는 실패
+      }
+      if (url.endsWith('/api/v2/projects')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: 'other-proj', slug: 'other' }, { id: 'proj-1', slug: 'sprintable' }],
+        });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+    const response = await middleware(makeRequest('/docs/my-doc', {
+      sp_at: token, sprintable_current_project_id: 'proj-1',
+    }));
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/sprintable/docs/my-doc');
+  });
+
+  // PO 실제 재현(2026-08-09) — org-briefing 배너대로 프로젝트를 선택해 next(_prRetry=1 달고)로
+  // 돌아온 요청. fix 전에는 단건조회 실패 + retry-guard가 겹쳐 정직한 404로 막다른 dead-end였다
+  // (선택해도 못 빠져나옴) — 리스트 폴백이 이 재시도 요청에서도 먹혀 301로 뚫리는지 잠근다.
+  it('되돌이(재시도, _prRetry=1) 요청에서도 단건조회 실패+리스트 성공이면 301로 정상 착지한다(PO 실제 재현 dead-end fix)', async () => {
+    const token = await makeAccessToken({ orgId: 'org-1' });
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/api/v2/organizations/org-1')) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'org-1', slug: 'moonklabs' }) });
+      }
+      if (url.includes('/api/v2/projects/proj-1')) {
+        return Promise.resolve({ ok: false, status: 404 });
+      }
+      if (url.endsWith('/api/v2/projects')) {
+        return Promise.resolve({ ok: true, json: async () => [{ id: 'proj-1', slug: 'sprintable' }] });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+    const response = await middleware(makeRequest('/docs/my-doc?_prRetry=1', {
+      sp_at: token, sprintable_current_project_id: 'proj-1',
+    }));
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/sprintable/docs/my-doc');
+  });
+
   // story #2212(오르테가 지적, 되돌이 방지) — 프로젝트를 골라 next로 돌아왔는데도(=이 요청 자체가
   // _prRetry=1을 달고 옴) 여전히 해소가 실패하면, 다시 /org-briefing으로 튕기지 않고 정직하게
   // 멈춘다(Next 자체 404) — 무한 왕복 대신 "여기서 안 된다"는 신호.

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -83,11 +83,18 @@ async function verifyAccessToken(token: string): Promise<{ exp?: number } | null
 // 복제(둘 다 이 문자열이 바뀔 일은 없음 — 서버-발급 세션 쿠키 이름).
 const CURRENT_PROJECT_COOKIE = 'sprintable_current_project_id';
 
-async function getOrgIdFromAccessToken(token: string): Promise<string | null> {
+// ⛔카디르 QA 2차 재진단(2026-08-09, 실측 8회 재현 — bare /flow·되돌이 전부 여전히 org-briefing
+// 튕김) — 옛 getOrgIdFromAccessToken()이 JWT app_metadata.org_id 클레임을 직접 디코드했는데,
+// 멀티org 계정은 이 클레임이 **로그인 시점 org로 고정**돼 세션이 실제로 일하는 org(=/api/v2/me
+// 검증값)와 달라질 수 있다(curl 대조: JWT org로 X-Org-Id 조회→404, me.org_id로 조회→200 —
+// layout.tsx는 이미 /api/v2/me를 써서 이 함정을 안 밟았다). 같은 SSOT(/api/v2/me)로 맞춘다 —
+// JWT 클레임 직접 디코드 대신 실 조회.
+async function getVerifiedOrgId(fastapiUrl: string, accessToken: string): Promise<string | null> {
   try {
-    const { payload } = await jwtVerify(token, getJwtSecretBytes());
-    const orgId = (payload['app_metadata'] as Record<string, unknown> | undefined)?.['org_id'];
-    return typeof orgId === 'string' ? orgId : null;
+    const res = await fetch(`${fastapiUrl}/api/v2/me`, { headers: { Authorization: `Bearer ${accessToken}` } });
+    if (!res.ok) return null;
+    const me = await res.json() as { org_id?: string };
+    return typeof me.org_id === 'string' ? me.org_id : null;
   } catch {
     return null;
   }
@@ -136,7 +143,8 @@ async function redirectLegacyResourcePath(
   const excluded = MIGRATED_RESOURCES[resourceName] ?? [];
   if (excluded.some((sub) => pathname.startsWith(`/${resourceName}/${sub}`))) return null;
 
-  const orgId = await getOrgIdFromAccessToken(accessToken);
+  const fastapiUrl = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+  const orgId = await getVerifiedOrgId(fastapiUrl, accessToken);
   // story #1998: 쿠키 우선(명시 switch-project 결과) — 없으면 JWT app_metadata.project_id로 fallback.
   const projectId = request.cookies.get(CURRENT_PROJECT_COOKIE)?.value
     ?? await getProjectIdFromAccessToken(accessToken);
@@ -157,7 +165,6 @@ async function redirectLegacyResourcePath(
     return redirectToProjectPicker(request, pathname);
   }
 
-  const fastapiUrl = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
   const slugs = await resolveLegacyResourcePath(fastapiUrl, orgId, projectId, accessToken);
   // org/project는 둘 다 확定됐는데 BE 해소만 실패한 경우(예: 그 project가 삭제/접근철회)도
   // 같은 안내로 보낸다(AC4: "404가 맞는 경우에도 다음 발이 붙는다") — 단, 이것도 되돌이 방지 적용.


### PR DESCRIPTION
## ⚠️ 최우선 — PO 실사용 확定 dead-end

## 요약
흐름 메뉴를 눌러도 축척 지도에 못 닿는 결함. PO가 puppeteer로 실제 유저 경로를 재현:

1. 흐름 클릭 → `/flow`(slug 없음) → 「프로젝트를 선택하면 원래 보려던 화면으로 이동합니다」 배너 + 조직 브리핑 복귀.
2. 배너대로 프로젝트 선택 → **진짜 404**(Next.js 자체 404, org-briefing도 아님) — 정상 안내를 따라가도 못 빠져나오는 dead-end.

내가 멤버인 프로젝트(제로고)에서도 재현돼 권한 문제가 아니라 **모든 유저가 겪는 도달 결함**임을 확認.

## 그라운딩
React fiber 직접 조회 + BE 코드 대조로 근본원인을 좁혔다 — `GET /api/v2/projects/{id}`(단건조회)가 slug 有인 정상 프로젝트에도 이따금 slug 없이/실패 응답한다(정확한 원인은 Cloud Run 로그 확認이 필요 — BE 쪽 별건으로 넘김). 이 단건조회가 두 곳에서 쓰인다:
- `route-resolve.ts`의 `resolveLegacyResourcePath` — 미들웨어의 bare 경로(`/flow` 등) 해소.
- `(authenticated)/layout.tsx`의 `currentProjectSlug` — 사이드바 「흐름」 링크가 slug 경로(`/{ws}/{proj}/flow`)를 만드는 데 씀. 이게 비면 사이드바가 항상 bare `/flow`를 만들어 위 dead-end 체인이 시작된다.

같은 프로젝트를 `GET /api/v2/projects`(리스트)로 조회하면 **항상** 정확한 slug를 낸다는 걸 직접 대조로 확認했다.

## 변경
단건조회가 비면(실패/slug 없음) 포기하지 않고 리스트에서 한 번 더 찾도록 두 곳 모두 폴백 추가. 단건조회가 성공하는 정상 케이스는 동작 무변경(회귀 0).

## 게이트
- [x] tsc --noEmit: 0
- [x] eslint: 0
- [x] i18n 문구충돌·tint-color-text 신규 0
- [x] vitest 전체 395파일/3016건 pass(회귀 0) — 신규 회귀가드 2건 포함(단건조회 실패+리스트 성공 시 301, `_prRetry=1` 되돌이 경로까지 잠금)
- [x] pnpm build: EXIT 0(실측)
- [x] 뮤테이션 self-check: 핵심 2파일 되돌리면 신규 2건 정확히 RED → GREEN

## Test plan
- [ ] 카디르군 dev 라이브 QA — PO 재현 경로(흐름 클릭→선택→도달) 전체 통과 확認
- [ ] 디디군 — 단건조회 자체가 왜 불안정한지 Cloud Run 로그 확認(이 PR과 별건, 근본 조사)

🤖 Generated with [Claude Code](https://claude.com/claude-code)