### PR TITLE
[SID:2542] 가설 guided 생성 API — ②첫 가설(v4 「가설 축척」 최대 가치 갭)

### DIFF
--- a/backend/app/routers/hypotheses.py
+++ b/backend/app/routers/hypotheses.py
@@ -27,6 +27,7 @@ from app.schemas.hypothesis import (
     HypothesisCreate,
     HypothesisDraftRequest,
     HypothesisDraftResponse,
+    HypothesisGuidedCreate,
     HypothesisLifecycleResponse,
     HypothesisLinkRequest,
     HypothesisResponse,
@@ -61,6 +62,7 @@ _ADMIN_ROLES = frozenset({"owner", "admin"})
 _ERROR_STATUS: dict[str, int] = {
     "HUMAN_OWNER_REQUIRED": 400,
     "HUMAN_CONFIRM_REQUIRED": 403,
+    "HUMAN_ONLY": 403,  # story #2542 — guided 생성은 휴먼 전용.
     "INVALID_CREATE_STATUS": 422,
     "INVALID_STATUS": 422,
     "OUTCOME_RESULT_REQUIRED": 422,  # story #2038
@@ -153,6 +155,25 @@ async def create_hypothesis(
     caller = await resolve_member(auth, org_id, session, project_id=body.project_id)
     try:
         return await svc.create_hypothesis(session, org_id, caller, body)
+    except svc.HypothesisServiceError as err:
+        _raise(err)
+
+
+# story #2542(v4 «가설 축척» ②첫 가설, 유나 SSOT ae75a8ff): /draft와 동일 이유로 /{id}
+# 계열보다 먼저 선언 — "guided"가 hypothesis_id UUID로 오파싱되는 걸 막는다.
+@router.post("/guided", response_model=HypothesisResponse, status_code=201)
+async def create_hypothesis_guided(
+    body: HypothesisGuidedCreate,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> HypothesisResponse:
+    """guided 3부 폼(statement·metric·target·direction) → status=measuring까지 1콜.
+    응답은 표준 HypothesisResponse(FE가 읽을 필드는 다른 생성 경로와 동일 — id/statement/
+    metric_definition/status/measure_after 등, status가 "measuring"으로 확定됨)."""
+    caller = await resolve_member(auth, org_id, session, project_id=body.project_id)
+    try:
+        return await svc.create_hypothesis_guided(session, org_id, caller, body)
     except svc.HypothesisServiceError as err:
         _raise(err)
 

--- a/backend/app/schemas/hypothesis.py
+++ b/backend/app/schemas/hypothesis.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, computed_field, field_validator, model_validator
 
-from app.schemas.story import _validate_metric_definition
+from app.schemas.story import _METRIC_DIRECTIONS, _validate_metric_definition
 
 # §2.5 상태 7종 (모델 HYPOTHESIS_STATUSES와 동기)
 HYPOTHESIS_STATUSES = (
@@ -42,6 +42,28 @@ class HypothesisCreate(BaseModel):
     def _check_metric(cls, v: dict[str, Any]) -> dict[str, Any]:
         # NOT NULL — None은 Pydantic 타입에서 이미 거부. 구조는 Story validator 재사용.
         return _validate_metric_definition(v)  # type: ignore[return-value]
+
+
+class HypothesisGuidedCreate(BaseModel):
+    """story #2542(v4 «가설 축척» ②첫 가설, 유나 SSOT ae75a8ff) — guided 3부 폼 전용 생성.
+
+    HypothesisCreate의 얇은 특수화: statement + {metric,target,direction} 3부만 받는다
+    (source·measure_after는 폼에 없음 — 서버가 source="manual"·measure_after=+14일로
+    보완). 생성 즉시 status=measuring까지 간다(빈 마찰 없는 «첫 성공») — _CREATE_STATUSES
+    를 넓히는 대신 기존 검증된 상태기계를 그대로 두 단계(active 생성 → measuring 전이)
+    재사용한다(app/services/hypothesis.py의 create_hypothesis_guided 참고)."""
+    project_id: uuid.UUID
+    statement: str
+    metric: str
+    target: float
+    direction: str
+
+    @field_validator("direction")
+    @classmethod
+    def _check_direction(cls, v: str) -> str:
+        if v not in _METRIC_DIRECTIONS:
+            raise ValueError(f"direction must be one of {sorted(_METRIC_DIRECTIONS)}")
+        return v
 
 
 class HypothesisUpdate(BaseModel):

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -29,6 +29,7 @@ from app.schemas.hypothesis import (
     HypothesisCreate,
     HypothesisDraftRequest,
     HypothesisDraftResponse,
+    HypothesisGuidedCreate,
     HypothesisLifecycleGoal,
     HypothesisLifecycleResponse,
     HypothesisLifecycleStory,
@@ -232,6 +233,46 @@ async def create_hypothesis(
     )
 
     return await _to_response(repo, hyp)
+
+
+async def create_hypothesis_guided(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    caller: ResolvedMember,
+    payload: HypothesisGuidedCreate,
+) -> HypothesisResponse:
+    """story #2542(v4 «가설 축척» ②첫 가설, 유나 SSOT ae75a8ff) — guided 3부 폼 →
+    status=measuring까지 낮은 마찰 1콜. _CREATE_STATUSES를 넓히지 않고(measuring은
+    여전히 transition 전용) 기존 검증된 상태기계를 그대로 두 단계 재사용한다:
+    create_hypothesis(status="active", 게이트 오버레이 없음 — proposed→active
+    workflow-line 오버레이는 transition 경로에만 있고 create에는 없다) →
+    transition_hypothesis(active→measuring, 게이트/outcome_result 요건 없는 단순 전이).
+
+    폼엔 없는 필드는 서버가 정직하게 보완한다: source="manual"(guided 3부가 GA4/
+    internal_ops 계측을 안 묻는다 — 지어내지 않는다), measure_after=+_DEFAULT_MEASURE_DAYS일
+    (draft() 자동초안과 동일 기본값, story #2038 계열과 동형)."""
+    if caller.type != "human":
+        raise HypothesisServiceError(
+            "HUMAN_ONLY", "guided 가설 생성은 휴먼 전용입니다."
+        )
+
+    metric_definition = {
+        "metric": payload.metric, "source": "manual",
+        "target": payload.target, "direction": payload.direction,
+    }
+    measure_after = datetime.now(timezone.utc) + timedelta(days=_DEFAULT_MEASURE_DAYS)
+
+    created = await create_hypothesis(
+        session, org_id, caller,
+        HypothesisCreate(
+            project_id=payload.project_id, statement=payload.statement,
+            metric_definition=metric_definition, measure_after=measure_after,
+            owner_member_id=caller.id, status="active",
+        ),
+    )
+    return await transition_hypothesis(
+        session, org_id, caller, created.id, HypothesisTransition(status="measuring"),
+    )
 
 
 async def get_hypothesis(

--- a/backend/tests/test_2542_hypothesis_guided_create_realdb.py
+++ b/backend/tests/test_2542_hypothesis_guided_create_realdb.py
@@ -1,0 +1,147 @@
+"""story #2542(v4 «가설 축척» ②첫 가설, 유나 SSOT ae75a8ff) — guided 3부 폼(statement·
+metric·target·direction) → 가설 생성·status=measuring까지 1콜을 실PG로 검증한다.
+
+_CREATE_STATUSES는 그대로(proposed|active만) — measuring은 create_hypothesis(active,
+게이트 오버레이 없음) → transition_hypothesis(active→measuring, 단순 전이) 두 단계
+합성으로 도달한다. 이 파일은 그 합성이 실제로 끝까지 도는지 pin한다."""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from tests.test_1994_backlink_api_realdb import (
+    _client_for,
+    _make_org,
+    _make_project,
+    _session_factory,
+)
+from tests.test_2288_command_center_gate_type_waiting_realdb import (
+    _make_member,
+    _setup_app_human,
+)
+from tests.test_2301_story_body_mentions_realdb import _REAL_DB_URL
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def test_guided_create_reaches_measuring_with_manual_source_realdb():
+    """⭐핵심 — guided 3부만 보내면 status=measuring까지 도달·source는 서버가 "manual"로
+    보완·measure_after는 서버 기본값(+14일 근방)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _caller_id, caller_user_id = await _make_member(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/hypotheses/guided",
+                json={
+                    "project_id": str(project.id),
+                    "statement": "리뷰 에이전트를 붙이면 결함이 준다",
+                    "metric": "결함 건수",
+                    "target": 5,
+                    "direction": "down",
+                },
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["status"] == "measuring"
+            assert body["statement"] == "리뷰 에이전트를 붙이면 결함이 준다"
+            assert body["metric_definition"] == {
+                "metric": "결함 건수", "source": "manual", "target": 5.0, "direction": "down",
+            }
+            measure_after = datetime.fromisoformat(body["measure_after"])
+            expected = datetime.now(UTC) + timedelta(days=14)
+            assert abs((measure_after - expected).total_seconds()) < 60, (
+                f"measure_after가 +14일 기본값과 어긋난다: {measure_after}"
+            )
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+async def test_guided_create_rejects_invalid_direction_realdb():
+    """AC — direction이 up/down이 아니면 422(스키마 레벨 거부, 서비스까지 안 감)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _caller_id, caller_user_id = await _make_member(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/hypotheses/guided",
+                json={
+                    "project_id": str(project.id),
+                    "statement": "S",
+                    "metric": "M",
+                    "target": 1,
+                    "direction": "increase",  # up/down 아님
+                },
+            )
+            assert resp.status_code == 422, resp.text
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+async def test_guided_create_rejects_agent_caller_realdb():
+    """AC — guided 생성은 휴먼 전용(빈 지도 초대는 사람 온보딩 흐름) — agent caller는
+    HUMAN_ONLY로 거부. `_setup_app_agent`(api_key_id 클레임)로 is_api_key 분기를 태운다
+    (bare AuthContext.user_id만으론 legacy resolver가 human으로 fail-closed 취급 —
+    실측으로 확認됨, actor_type fail-closed 관례와 동형)."""
+    from app.main import app
+    from tests.test_1994_backlink_api_realdb import _make_agent_member, _setup_app_agent
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_agent = await _make_agent_member(s, org.id, project.id)
+
+        await _setup_app_agent(app, Session, caller_agent, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/hypotheses/guided",
+                json={
+                    "project_id": str(project.id),
+                    "statement": "S", "metric": "M", "target": 1, "direction": "up",
+                },
+            )
+            assert resp.status_code == 403, resp.text
+            assert resp.json()["error"]["code"] == "HUMAN_ONLY"
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
v4 「가설 축척」 가치 여정 ②첫 가설(최대 갭)의 BE 몫. 빈 지도(가설 0건)를 "첫 질문 심어보세요" 초대 → guided 3부 폼 → 심으면 지구층에 measuring 카드로 나타나는 첫 성공. 디자인 SSOT: 유나 아티팩트 `ae75a8ff`.

`POST /api/v2/hypotheses/guided` 신설 — statement + `metric_definition{metric,target,direction}` 3부만 받아 낮은 마찰로 **status=measuring**까지 1콜에 도달한다.

## 설계 근거
`_CREATE_STATUSES`(proposed|active만 허용)를 넓히지 않았다 — 대신 기존 검증된 상태기계를 두 단계 합성으로 재사용:
1. `create_hypothesis(status="active")` — create 경로엔 gate 오버레이가 없다(proposed→active workflow-line 오버레이는 **transition** 경로 전용, 그라운딩으로 확認)
2. `transition_hypothesis(active→measuring)` — outcome_result 요건 없는 단순 전이(verified/falsified 전용 가드는 안 걸림)

폼엔 없는 필드는 서버가 정직하게 보완한다(지어내지 않는다):
- `source="manual"`(GA4/internal_ops 계측을 guided 폼이 안 묻는다)
- `measure_after` = 생성 시각 + 14일(`_DEFAULT_MEASURE_DAYS` — `draft()` 자동초안과 동일 기본값 재사용, 신규 상수 안 만듦)

guided 생성은 **휴먼 전용**(`HUMAN_ONLY`, 403) — 빈 지도 초대는 사람 온보딩 흐름.

## FE가 읽을 응답 필드(#2938 교훈)
응답은 **표준 `HypothesisResponse`**(다른 생성 경로와 동일 스키마) — 신규 필드 없음. 확認 포인트: `status`가 항상 `"measuring"`, `metric_definition`이 `{metric, source:"manual", target, direction}` 형태.

## Test plan
- [x] `test_2542_hypothesis_guided_create_realdb.py`(신규 3건) — 3부 폼→measuring 도달·metric_definition 정확성·measure_after 기본값 pin / direction 오입력 422 / agent caller 403(HUMAN_ONLY)
- [x] mutation self-check: `HUMAN_ONLY` 가드 제거 → RED 확認 후 복원 GREEN
- [x] 회귀 73/73(`test_hypothesis_service`, `test_hypotheses_router`, `test_2038_hypothesis_outcome_result_enforce` + 신규)
- [x] ruff clean(신규 파일 0건, 기존 파일은 동일 pre-existing 스타일 debt만 비례 증가)
- [x] 무관한 큰 배치 스윕에서 관측된 실패(`team_members` VIEW 관련)가 기존 병합된 무관 테스트에서도 동일 클래스로 재현됨을 확認 — pre-existing 멀티엔진 테스트-인프라 한계(#2533 선례와 동형), 이 PR과 무관

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>