### PR TITLE
fix(#2381): finish remaining ACs — live delivery proof (AC4) + single-rule wake consolidation (AC5)

### DIFF
--- a/backend/app/services/agent_dispatch.py
+++ b/backend/app/services/agent_dispatch.py
@@ -19,8 +19,6 @@ from app.models.doc import Doc
 from app.models.event import Event, EventType
 from app.models.hypothesis import Hypothesis
 from app.models.pm import Goal, Sprint, Story
-from app.routers.agent_gateway import wake_agent
-from app.routers.events import _event_to_payload, _push_to_agent
 from app.services.activity_stream import extract_activities_best_effort
 from app.services.event_seq import assign_recipient_seq
 from app.services.member_resolver import resolve_member_identity
@@ -189,12 +187,15 @@ async def _finalize_dispatch(
         )
 
     if commit:
-        await db.commit()  # commit 후 seq 확정
-        if member_type == "agent":
-            if event.recipient_seq is not None:
-                wake_agent(str(recipient_id), event.recipient_seq)
-            else:
-                _push_to_agent(str(recipient_id), _event_to_payload(event))
+        await db.commit()  # commit 후 seq 확정 — agent recipient wake는 assign_recipient_seq()의
+        # after-commit 자동예약(event_seq.py)이 이미 발화한다(story #2381 AC5: 이 함수가 따로
+        # wake_agent()를 불렀던 예전 경로는 assign_recipient_seq() 자신의 계약이 아니라 각
+        # 호출부가 "commit 후에 불러야 한다"를 스스로 지켜야 하는 조건부 규칙이었다 — 그 규칙이
+        # dispatch_notification()의 ~20개 호출부에서는 통째로 빠져있던 것이 이 스토리의 근본
+        # 원인. 두 경로(이 함수 vs dispatch_notification())가 서로 다른 방식으로 wake하면 다음에
+        # 또 어긋난다 — assign_recipient_seq() 한 곳으로 판정을 모은다. `event.recipient_seq`는
+        # 위에서 이미 assign_recipient_seq()가 채웠으므로(agent 경로 무조건 호출) None-fallback은
+        # 항상 죽은 분기였다.
 
     response = DispatchResponse(
         dispatched=True,
@@ -232,8 +233,8 @@ async def dispatch_entity_to_assignee(
     """entity의 assignee에게 dispatched 이벤트 생성 + 알림 전달 + (agent) wake.
 
     순서(기존 라우터와 동일): assignee resolve → resolve_dispatch_anchor → Event(dispatched) →
-    flush → agent면 assign_recipient_seq → L1 활동 추출(best-effort) → human이면
-    dispatch_notification → commit → agent면 commit 후 wake_agent.
+    flush → agent면 assign_recipient_seq(commit 후 wake 자동예약까지 포함, story #2381) → L1
+    활동 추출(best-effort) → human이면 dispatch_notification → commit.
 
     반환: (DispatchResponse, delivery). delivery는 dispatched=True일 때 CC 릴레이 webhook
     파라미터(없으면 None) — 호출자(라우터는 background_tasks, L2 워커는 직접 await)가 스케줄한다.

--- a/backend/tests/test_2381_ac4_live_wake_delivery_realdb.py
+++ b/backend/tests/test_2381_ac4_live_wake_delivery_realdb.py
@@ -1,0 +1,241 @@
+"""story #2381 AC4 — 라이브 양성대조: 고치기 前엔 연결 中인 에이전트가 새 이벤트를 못 받고,
+고친 뒤엔 즉시(수로 측정) 받는 것을 실제 `agent_stream()` SSE 제너레이터로 보인다.
+
+AC3(`test_2381_wake_after_commit_race_realdb.py`)는 `assign_recipient_seq()`가 예약한
+`wake_agent()`가 commit 後 정확히 한 번 발화되는 것만 검증했다(단위 수준 — 발화 자체).
+AC4는 그 발화가 실제로 **연결 中인 `/agent/stream` 소비자에게 새 이벤트로 도달**하는지,
+그리고 그게 "몇 초 안에"인지까지를 실제 스트림 제너레이터(`agent_gateway.agent_stream`)로
+직접 확認한다 — story #2201의 "ASGI/HTTP 트랜스포트 전부 우회, 라우터 함수 직접 호출 +
+body_iterator 직접 순회" 패턴을 그대로 재사용.
+
+- **before 대조군**: `wake_agent`를 no-op으로 치환해 "커밋됐지만 wake가 없다"는 이 스토리의
+  근본 증상을 그대로 재현 — 연결 中인 스트림이 짧은 관찰 구간 안에 아무것도 못 받는 것을 보인다
+  (실제로는 다음 heartbeat(`_SSE_HEARTBEAT`, 기본 30s)나 재연결까지 무기한 — 여기선 결정론적
+  종료를 위해 수 초의 관찰 구간만 사용, "무기한 대기"를 직접 굶기지 않는다).
+- **after**: 실제 코드(패치 없음) — `assign_recipient_seq()`의 after-commit 자동 wake가
+  이 큐로 실제로 흘러들어와 스트림이 새 이벤트를 즉시 yield하는 것을, 측정한 초 단위 경과로 보인다.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.destructive_schema,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    import app.models  # noqa: F401 — 전 모델 메타데이터 로드(app/models/__init__.py 참조).
+    from app.core.database import Base
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_agent(Session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.team import TeamMember
+
+    org_id, project_id, agent_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    async with Session() as s:
+        s.add(Organization(id=org_id, name="t", slug=f"t-{org_id}", plan="free"))
+        s.add(Project(id=project_id, org_id=org_id, name="p"))
+        await s.flush()
+        s.add(TeamMember(
+            id=agent_id, org_id=org_id, project_id=project_id, type="agent",
+            name="agent", role="member", is_active=True, runtime_type="claude-code",
+        ))
+        await s.commit()
+    return org_id, project_id, agent_id
+
+
+def _patch_side_effects(monkeypatch):
+    """agent_stream() generate()가 스트림 본체(backfill/wake/cursor)와 무관하게 태우는 부수효과
+    (presence/onboarding/lease) — 이 테스트의 관측대상이 아니므로 test_2143 선례와 동일하게 no-op."""
+    monkeypatch.setattr(
+        "app.services.agent_anchor_sync.sync_agent_profile_presence", AsyncMock()
+    )
+    monkeypatch.setattr(
+        "app.services.onboarding_funnel.emit_onboarding_event", AsyncMock()
+    )
+    monkeypatch.setattr("app.services.presence_online.mark_online", AsyncMock())
+    monkeypatch.setattr("app.services.presence_events.emit_presence", AsyncMock())
+    monkeypatch.setattr("app.services.sse_lease.acquire", AsyncMock(return_value=None))
+    monkeypatch.setattr("app.services.sse_lease.refresh", AsyncMock())
+    monkeypatch.setattr("app.services.sse_lease.release", AsyncMock())
+
+
+class _FakeRequest:
+    """test_2128_sse_lifespan_cap.py 선례 — real ASGI Request는 receive 채널 없이 `is_disconnected()`
+    호출 시 RuntimeError. 이 스트림 제너레이터의 while-루프가 매 tick 그걸 부르므로 최소 스텁 필요."""
+    headers: dict = {}
+
+    async def is_disconnected(self) -> bool:
+        return False
+
+
+async def _open_stream(ag, Session, agent_id: uuid.UUID, org_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+
+    auth = AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {"api_key_id": "test-key", "org_id": str(org_id)}},
+    )
+    resp = await ag.agent_stream(_FakeRequest(), auth=auth)
+    assert resp.status_code == 200
+    return resp
+
+
+async def _dispatch_agent_event(Session, *, org_id: uuid.UUID, project_id: uuid.UUID, agent_id: uuid.UUID) -> None:
+    """실 프로덕션 경로 그대로: Event 생성 → assign_recipient_seq (agent 가시성의 유일한 관문,
+    #2375) → commit. 이 함수 자체는 wake_agent()를 부르지 않는다 — event_seq.py의 after-commit
+    자동예약이 유일한 발화 경로(이 테스트가 증명하려는 바로 그것)."""
+    from app.models.event import Event
+    from app.services.event_seq import assign_recipient_seq
+
+    async with Session() as s:
+        event = Event(
+            project_id=project_id, org_id=org_id, event_type="dispatched",
+            recipient_id=agent_id, recipient_type="agent",
+            payload={"content": "AC4 라이브 배달 검증"}, status="pending",
+        )
+        s.add(event)
+        await s.flush()
+        await assign_recipient_seq(s, event)
+        await s.commit()
+
+
+@pytest.mark.anyio
+async def test_before_no_wake_connected_agent_gets_nothing_in_short_window(monkeypatch):
+    """AC4 before-대조군: wake_agent()가 발화되지 않으면(이 스토리의 근본 증상을 직접 재현),
+    연결 中인 스트림은 커밋된 새 이벤트를 짧은 관찰 구간(1.5s) 안에 전혀 못 받는다 — 다음
+    heartbeat(기본 30s)나 재연결(backfill)까지 발견 경로가 없다는 것이 이 스토리의 본체다."""
+    import app.routers.agent_gateway as ag
+
+    _patch_side_effects(monkeypatch)
+    # ⛔근본 증상 재현: wake_agent를 no-op으로 — "commit 됐지만 아무도 안 깨운다".
+    monkeypatch.setattr(ag, "wake_agent", lambda *a, **kw: None)
+
+    engine, Session = await _session_factory()
+    try:
+        org_id, project_id, agent_id = await _seed_agent(Session)
+        monkeypatch.setattr(ag, "async_session_factory", lambda: Session())
+
+        resp = await _open_stream(ag, Session, agent_id, org_id)
+        agen = resp.body_iterator
+        try:
+            first = await agen.__anext__()
+            assert "event: heartbeat" in first
+
+            # ⭐backfill(빈 결과)을 지나 queue.get() 블로킹까지 제너레이터를 먼저 진행시켜야
+            # "연결 中(이미 backfill 다 돈 뒤)에 새 이벤트가 온다"는 이 AC의 전제가 성립한다 —
+            # 이 진행 전에 dispatch하면 backfill이 그걸 주워 담아 "wake 없이도 왔다"는 거짓
+            # 양성이 된다(이 테스트 작성 중 실제로 재현·수정한 함정).
+            next_frame_task = asyncio.create_task(agen.__anext__())
+            await asyncio.sleep(0.05)
+
+            await _dispatch_agent_event(Session, org_id=org_id, project_id=project_id, agent_id=agent_id)
+
+            # ⛔`asyncio.wait_for`는 안 쓴다 — 타임아웃 시 task를 취소하는데, 그 취소가 스트림의
+            # `except (asyncio.CancelledError, GeneratorExit): pass`에 그대로 삼켜져 제너레이터가
+            # "정상 종료"해 버린다(`StopAsyncIteration`) — "안 왔다"가 아니라 "스트림이 끊겼다"를
+            # 관측하는 거짓 시그널이 된다(이 테스트 작성 중 직접 재현). `asyncio.wait`는 타임아웃
+            # 시 task를 취소하지 않으므로 "아직 pending"이라는 진짜 신호를 그대로 남긴다.
+            done, pending = await asyncio.wait({next_frame_task}, timeout=1.5)
+            assert next_frame_task in pending, (
+                f"wake 없이도 새 이벤트가 도달함(레이스/우회 경로 존재) — 받은 프레임: "
+                f"{next_frame_task.result() if next_frame_task in done else None!r}"
+            )
+            next_frame_task.cancel()
+            with pytest.raises((asyncio.CancelledError, StopAsyncIteration)):
+                await next_frame_task
+        finally:
+            await agen.aclose()
+    finally:
+        ag._agent_connections.pop(str(agent_id), None)
+        await engine.dispose()
+        # test_2128_sse_lifespan_cap.py 선례: generate()가 module-singleton shutdown_event를
+        # 이 테스트의 이벤트루프에 바인딩시킨다 — 안 풀면 다음 테스트(다른 루프)가 cross-loop
+        # RuntimeError.
+        from app.core import shutdown as _shutdown_module
+        _shutdown_module.reset_shutdown_event()
+
+
+@pytest.mark.anyio
+async def test_after_wake_connected_agent_gets_new_event_immediately(monkeypatch):
+    """AC4 after: 패치 없는 실제 코드 경로 — assign_recipient_seq()의 after-commit 자동 wake가
+    실제로 이 스트림의 큐까지 흘러들어와, 연결 中인 에이전트가 새 이벤트를 즉시(수로 측정)
+    받는다. AC4가 요구하는 "몇 초 안에"의 실측값이 assert 메시지에 그대로 남는다."""
+    import app.routers.agent_gateway as ag
+
+    _patch_side_effects(monkeypatch)
+    # wake_agent는 손대지 않는다 — 이게 바로 이 스토리가 고친 실제 경로.
+
+    engine, Session = await _session_factory()
+    try:
+        org_id, project_id, agent_id = await _seed_agent(Session)
+        monkeypatch.setattr(ag, "async_session_factory", lambda: Session())
+
+        resp = await _open_stream(ag, Session, agent_id, org_id)
+        agen = resp.body_iterator
+        try:
+            first = await agen.__anext__()
+            assert "event: heartbeat" in first
+
+            next_frame_task = asyncio.create_task(agen.__anext__())
+            # 스트림이 이미 queue.get()에서 블로킹 中인 것을 보장(다음 tick 양보) — 그 뒤에
+            # dispatch해야 "연결 中에 새 이벤트가 온다"는 이 AC의 전제가 실제로 성립한다.
+            await asyncio.sleep(0.05)
+
+            t_commit_start = time.monotonic()
+            await _dispatch_agent_event(Session, org_id=org_id, project_id=project_id, agent_id=agent_id)
+
+            chunk = await asyncio.wait_for(next_frame_task, timeout=5.0)
+            elapsed = time.monotonic() - t_commit_start
+
+            assert "event: dispatched" in chunk, f"기대한 dispatched 프레임이 아님: {chunk!r}"
+            data_line = next(line for line in chunk.splitlines() if line.startswith("data: "))
+            payload = json.loads(data_line[len("data: "):])
+            assert payload["content"] == "AC4 라이브 배달 검증"
+            assert payload["is_backfill"] is False, "wake 경로가 아니라 backfill로 온 것처럼 보임"
+            assert elapsed < 2.0, (
+                f"AC4: commit 後 새 이벤트가 연결 中인 스트림에 도달하는 데 {elapsed:.4f}초 걸림"
+                f" — 즉시(<2s)가 아님"
+            )
+            print(f"\n[AC4 실측] commit → 연결 中인 스트림 수신까지: {elapsed:.4f}초")
+        finally:
+            await agen.aclose()
+    finally:
+        ag._agent_connections.pop(str(agent_id), None)
+        await engine.dispose()
+        from app.core import shutdown as _shutdown_module
+        _shutdown_module.reset_shutdown_event()

--- a/backend/tests/test_agent_dispatch.py
+++ b/backend/tests/test_agent_dispatch.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import uuid
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -35,7 +35,6 @@ def _patches():
         patch.object(svc, "assign_recipient_seq", _assign_seq),
         patch.object(svc, "extract_activities_best_effort", AsyncMock()),
         patch.object(svc, "dispatch_notification", AsyncMock()),
-        patch.object(svc, "wake_agent", MagicMock()),
         patch("app.services.hypothesis.resolve_dispatch_anchor", AsyncMock(return_value=None)),
         patch("app.services.hypothesis.resolve_dispatch_context_pack", AsyncMock(return_value=None)),
     ]

--- a/backend/tests/test_e_event_inject_s4_e2e.py
+++ b/backend/tests/test_e_event_inject_s4_e2e.py
@@ -43,7 +43,7 @@ from sprintable_sse import INJECTABLE_EVENT_TYPES  # noqa: E402
 
 
 async def _run_dispatch(member_type: str):
-    """POST /api/v2/dispatch for an agent/human assignee; return (resp, wake_mock, dispatch_mock, added)."""
+    """POST /api/v2/dispatch for an agent/human assignee; return (resp, assign_seq_mock, dispatch_mock, added)."""
     from httpx import ASGITransport, AsyncClient
 
     from app.dependencies.auth import get_current_user
@@ -88,9 +88,7 @@ async def _run_dispatch(member_type: str):
             return_value=assignee_member,
         ), patch(
             "app.services.agent_dispatch.assign_recipient_seq", side_effect=_seq
-        ), patch(
-            "app.services.agent_dispatch.wake_agent"
-        ) as mock_wake, patch(
+        ) as mock_assign_seq, patch(
             "app.services.agent_dispatch.dispatch_notification", new_callable=AsyncMock
         ) as mock_dispatch:
             transport = ASGITransport(app=app)
@@ -104,14 +102,23 @@ async def _run_dispatch(member_type: str):
                         "message": "please pick this up",
                     },
                 )
-            return resp, mock_wake, mock_dispatch, added
+            return resp, mock_assign_seq, mock_dispatch, added
     finally:
         app.dependency_overrides.clear()
 
 
 @pytest.mark.anyio
 async def test_dispatch_agent_emits_dispatched_event_with_content_seq_and_wakes():
-    resp, mock_wake, mock_dispatch, added = await _run_dispatch("agent")
+    """story #2381 AC5: `_finalize_dispatch()` no longer calls `wake_agent()` itself — wake is
+    scheduled solely by `assign_recipient_seq()`'s after-commit hook (event_seq.py), the single
+    choke point every agent-recipient Event already has to go through (#2375's own invariant).
+    That the wake actually fires post-commit is covered live (real Postgres, real SSE stream) by
+    test_2381_wake_after_commit_race_realdb.py and test_2381_ac4_live_wake_delivery_realdb.py —
+    this router-level test (mocked `db`, `assign_recipient_seq` replaced by a `_seq` stub) can't
+    observe that hook at all (it's guarded to no-op on non-real `Session` objects by design). What
+    it *can* still verify at this layer: `assign_recipient_seq` — the sole gate to wake-eligibility
+    — is invoked for the agent path and not the human path."""
+    resp, mock_assign_seq, mock_dispatch, added = await _run_dispatch("agent")
     assert resp.status_code == 200
     body = resp.json()
     assert body["dispatched"] is True
@@ -125,20 +132,20 @@ async def test_dispatch_agent_emits_dispatched_event_with_content_seq_and_wakes(
     assert ev.payload["content"].startswith("[story] Build login")
     assert ev.payload["content"].endswith("please pick this up")
     assert ev.recipient_seq == 42  # per-recipient dense seq assigned for agent
-    mock_wake.assert_called_once()
+    mock_assign_seq.assert_called_once()
     mock_dispatch.assert_not_called()  # agent path does not double-deliver via notification
 
 
 @pytest.mark.anyio
 async def test_dispatch_human_uses_notification_no_wake():
-    resp, mock_wake, mock_dispatch, added = await _run_dispatch("human")
+    resp, mock_assign_seq, mock_dispatch, added = await _run_dispatch("human")
     assert resp.status_code == 200
     events = [e for e in added if getattr(e, "event_type", None) == "dispatched"]
     assert len(events) == 1
     ev = events[0]
     assert ev.recipient_type == "human"
     assert ev.recipient_seq is None  # no gateway seq for human recipients
-    mock_wake.assert_not_called()
+    mock_assign_seq.assert_not_called()  # human recipients never go through the wake gate
     mock_dispatch.assert_called_once()
 
 

--- a/backend/tests/test_e_loop_ledger_p1_s11_dispatch_context_pack.py
+++ b/backend/tests/test_e_loop_ledger_p1_s11_dispatch_context_pack.py
@@ -159,7 +159,6 @@ def _patches(context_pack_value):
         patch.object(svc, "assign_recipient_seq", _assign_seq),
         patch.object(svc, "extract_activities_best_effort", AsyncMock()),
         patch.object(svc, "dispatch_notification", AsyncMock()),
-        patch.object(svc, "wake_agent", MagicMock()),
         patch("app.services.hypothesis.resolve_dispatch_anchor", AsyncMock(return_value=None)),
         patch("app.services.hypothesis.resolve_dispatch_context_pack", AsyncMock(return_value=context_pack_value)),
     ]

--- a/backend/tests/test_l2_e2e_status_changed.py
+++ b/backend/tests/test_l2_e2e_status_changed.py
@@ -74,9 +74,15 @@ def _chain_patches(worker, added, *, claim_results):
         patch.object(dispatch_mod, "resolve_member_identity",
                      AsyncMock(return_value=SimpleNamespace(id=ASSIGNEE, type="agent")))
     )
-    stack.enter_context(patch.object(dispatch_mod, "assign_recipient_seq", _assign_seq))
+    # story #2381 AC5: wake_agent()는 더 이상 _finalize_dispatch()가 직접 부르지 않는다 —
+    # assign_recipient_seq()(event_seq.py)의 after-commit 자동예약이 유일한 발화 경로다. 그
+    # 실제 발화(post-commit)는 realdb 스트림 테스트(test_2381_wake_after_commit_race_realdb.py·
+    # test_2381_ac4_live_wake_delivery_realdb.py)가 커버 — 여기(mocked db)선 "wake 게이트인
+    # assign_recipient_seq가 정확히 한 번 불렸다"까지만 관측한다.
+    wake = stack.enter_context(
+        patch.object(dispatch_mod, "assign_recipient_seq", AsyncMock(side_effect=_assign_seq))
+    )
     stack.enter_context(patch.object(dispatch_mod, "extract_activities_best_effort", AsyncMock()))
-    wake = stack.enter_context(patch.object(dispatch_mod, "wake_agent", MagicMock()))
     stack.enter_context(patch("app.services.hypothesis.resolve_dispatch_anchor", AsyncMock(return_value=None)))
     stack.enter_context(patch.object(webhook_mod, "deliver_injected_event_webhook", AsyncMock()))
     return stack, wake
@@ -103,10 +109,12 @@ async def test_status_changed_produces_exactly_one_dispatched_event_and_wake():
     ev = dispatched[0]
     assert ev.recipient_type == "agent" and ev.recipient_id == ASSIGNEE
 
-    # AC②: recipient_seq 有 + commit 후 wake_agent 1회.
+    # AC②: recipient_seq 有 + wake 게이트(assign_recipient_seq) 정확히 1회 — 그 게이트를
+    # 통과하면 commit 후 wake_agent가 자동 발화된다는 것은 event_seq.py 자체의 realdb 테스트가
+    # 증명(story #2381 AC5, 위 _chain_patches 주석 참조).
     assert ev.recipient_seq == 42
     wake.assert_called_once()
-    assert wake.call_args.args[0] == str(ASSIGNEE) and wake.call_args.args[1] == 42
+    assert wake.call_args.args[1] is ev  # assign_recipient_seq(db, event) — 바로 이 event로 호출
 
     # AC③: payload에 trigger_metadata(L2 출처) + anchor(entity).
     tm = ev.payload["trigger_metadata"]


### PR DESCRIPTION
## Summary

Story #2381's root defect — `dispatch_notification()`'s ~20 call sites never called `wake_agent()`, so an already-connected agent had no way to learn about a new event until its next reconnect — was already fixed and merged via **#2772** on 2026-08-01: `assign_recipient_seq()` (`event_seq.py`) now auto-schedules a post-commit `wake_agent()` for every agent-recipient `Event`, structurally (transaction-boundary guaranteed, not call-site discipline). That PR covered AC1–AC3.

This PR closes the ACs that were left open when the story stayed `in-progress` on the board.

## AC1 — already measured (carried forward, not re-run)

PO's dev-session measurement (recorded in #2772's description) found events arrived 22s–4min late via periodic-reconnect backfill luck, not "never" — confirming the defect was "comes late" rather than "never comes" *before* the fix. That measurement predates the fix and isn't re-creatable live now that the bug is gone; AC4 below substitutes a structural before/after live proof instead.

## AC4 — live positive control, quantified (new)

`backend/tests/test_2381_ac4_live_wake_delivery_realdb.py` drives the real `agent_stream()` SSE generator end-to-end (no HTTP/ASGI transport, same route-function-direct pattern as #2201) against a real Postgres:

- **before**: `wake_agent` no-op'd (the exact pre-#2772 symptom — commit succeeds, nobody wakes anyone) — a connected agent gets nothing in a bounded 1.5s window.
- **after**: unpatched code — the same connected agent receives the new `dispatched` frame in **~7ms**, measured (`elapsed < 2.0` asserted, actual value printed).

## AC5 — single rule, not two (new)

`_finalize_dispatch()` (`agent_dispatch.py`) — the "already correct" path the story explicitly contrasted against `dispatch_notification()`'s missing wake — still called `wake_agent()` manually after its own commit. Now that `assign_recipient_seq()` auto-wakes (and `_finalize_dispatch()` itself calls `assign_recipient_seq()` for every agent recipient), that manual call was 100% redundant — exactly the divergent-rule case AC5 warns about ("두 경로가 서로 다른 방식으로 wake하면 다음에 또 어긋난다").

Removed the manual call and its dead `recipient_seq is None` fallback (`assign_recipient_seq()` always sets it — the fallback could never fire). Updated the 4 test files that asserted on the old direct-call contract (`test_agent_dispatch.py`, `test_e_event_inject_s4_e2e.py`, `test_e_loop_ledger_p1_s11_dispatch_context_pack.py`, `test_l2_e2e_status_changed.py`) to assert on `assign_recipient_seq` invocation instead — the actual post-commit firing is what the realdb tests (AC3 + AC4) verify; these mocked-`db` tests structurally can't observe the real hook (it no-ops on non-real `Session` objects by design).

## AC6 — exhaustive count

`assign_recipient_seq()` has **7 call sites across 6 distinct event types**, all structurally covered by the single hook (not enumerated per-type, guaranteed by #2375's own invariant that this function is the only gate to agent-visible `recipient_seq`):

| call site | event_type |
|---|---|
| `notification_dispatch.py` | `dispatched` |
| `agent_dispatch.py` (`_finalize_dispatch`) | `dispatched` |
| `story_assignee_events.py` | `story_assigned` |
| `a2a.py` | `a2a.task_message` |
| `conversations.py` ×2 | conversation message / mention |
| `agent_verify.py` | `connection_test` |

## AC7 — known gaps

- 5 other call sites (`a2a.py`, `gates.py`'s relay delivery, `stories.py`'s relay wake, `story_assignee_events.py`, `agents.py`/`agent_verify` caller) still carry the same now-redundant manual `wake_agent()` pattern `_finalize_dispatch()` had. Left alone this pass — out of the story's explicitly named scope (`_finalize_dispatch()`), and #2772 already established "harmless duplicate, defer" as acceptable precedent for exactly this shape. A full sweep to remove all 5 would be a small, low-risk follow-up.
- No dev/prod DB access this session — verified against a disposable local scratch Postgres only.
- The CC/member-webhook relay delivery channel (`deliver_injected_event_webhook`) is unaffected by and orthogonal to this fix — `wake_agent()`/SSE doesn't reach CC sessions at all (separate, pre-existing gap, not in scope here).

## Verification

Disposable local Postgres (fresh container, not shared/reused). Full dispatch/wake/gateway-adjacent surface green:
`test_agent_dispatch`, `test_e_event_inject_s4_e2e`, `test_edg_s7_handoff_relay`, `test_ccbcd9da_gate_wake_wiring_realdb`, `test_l2_e2e_status_changed`, `test_e_event_inject_s3_assignment_wake`, `test_notification_dispatch`, `test_e_loop_ledger_p1_s11_dispatch_context_pack{,_realdb}`, `test_edg_s25_epic_overlay`, `test_edg_s22_doc_overlay`, `test_2381_wake_after_commit_race_realdb`, `test_2381_ac4_live_wake_delivery_realdb` (new), `test_gateway_realdb_race`, `test_gateway_ack_realdb`, `test_2143_agent_stream_legacy_push_id_omission`, `test_2128_sse_lifespan_cap` (1 pre-existing env-only failure, port 54322 pg_notify — confirmed identical on unmodified `feat/2310` checkout), `test_a2a`, `test_agent_gateway`, `test_dispatch_reason_7f8066a3`, `test_e_event_inject_s1_dispatch_content`.

5 unrelated failures (`test_2375_dispatched_content_key_realdb` ×4, `test_l2_trigger_worker::test_concurrent_dedup_exactly_one_winner`) confirmed identical on unmodified `origin/develop` — pre-existing local scratch-schema gaps (create_all doesn't provision everything an alembic-migrated baseline would), not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)