### PR TITLE
fix(#2544): org switcher silently keeps stale org on network failure (AC1 measured, partial)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -105,6 +105,7 @@
     "switcherCreating": "Creating…",
     "switcherCreateButton": "Create",
     "switcherCreateProjectError": "Couldn't create the project. Please try again in a moment.",
+    "switcherSwitchOrgError": "Couldn't switch organizations. Please try again in a moment.",
     "orgLimitBannerTitle": "Upgrade required",
     "orgLimitUpgradeLink": "Upgrade plan →",
     "createOrgNameLabel": "Name",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -105,6 +105,7 @@
     "switcherCreating": "생성 중…",
     "switcherCreateButton": "만들기",
     "switcherCreateProjectError": "프로젝트를 만들지 못했습니다. 잠시 후 다시 시도해 주세요.",
+    "switcherSwitchOrgError": "조직을 전환하지 못했습니다. 잠시 후 다시 시도해 주세요.",
     "orgLimitBannerTitle": "업그레이드가 필요합니다",
     "orgLimitUpgradeLink": "요금제 업그레이드 →",
     "createOrgNameLabel": "이름",

--- a/apps/web/src/components/nav/unified-switcher.tsx
+++ b/apps/web/src/components/nav/unified-switcher.tsx
@@ -190,6 +190,12 @@ export function UnifiedSwitcher({
         </DropdownMenuContent>
       </DropdownMenu>
 
+      {/* story #2544 — org 전환 실패를 명시(침묵 실패 금지, #2468과 동일 원칙). DropdownMenuItem
+          클릭이 메뉴를 즉시 닫으므로 메뉴 바깥(트리거 인접)에 둬 닫힌 뒤에도 보이게 한다. */}
+      {s.switchOrgError && (
+        <p role="alert" className="mt-1 px-1 text-xs text-destructive">{s.switchOrgError}</p>
+      )}
+
       <CreateOrganizationDialog
         open={s.createOrgOpen}
         onOpenChange={s.setCreateOrgOpen}

--- a/apps/web/src/hooks/use-unified-switcher.test.tsx
+++ b/apps/web/src/hooks/use-unified-switcher.test.tsx
@@ -215,3 +215,55 @@ describe('useUnifiedSwitcher — createProject 실패 표시 (story #2468 b)', (
     expect(result?.createProjectError).toBeNull();
   });
 });
+
+// story #2544 — switchOrg/switchOrgAndProject는 localOrgId를 optimistic으로 먼저 찍고(클릭
+// 즉시 "전환됨"으로 보임) try에 catch가 없었다: fetch 자체가 던지면(네트워크 실패 등) else의
+// revert를 절대 못 타 — 실제 전환은 실패했는데 드롭다운은 "전환됨"으로 영구 고정된다. 카디르
+// QA 라이브 재현("선택·체크까지 되고... 실제론 안 됨")과 정확히 같은 모양 — 이 테스트는
+// pre-fix에서 RED(localOrgId가 실패 후에도 nextOrgId로 고정), fix 後 GREEN을 고정한다.
+describe('useUnifiedSwitcher — switchOrg 네트워크 실패 시 optimistic 상태 복구 (story #2544)', () => {
+  it('switchOrg 中 fetch가 던지면(네트워크 실패) localOrgId를 되돌리고 switchOrgError를 채운다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new TypeError('Failed to fetch'); }));
+    await act(async () => { root.render(<TestComp />); });
+    expect(result?.currentOrg?.orgId).toBe('org-moonklabs');
+
+    await act(async () => { await result?.switchOrg('org-dogfood'); });
+
+    // ⛔fix 前엔 여기서 'org-dogfood'로 영구 고정됐다(되돌아오지 않음) — 이게 바로
+    // "선택·체크는 되는데 실제 org는 안 바뀐" 카디르 QA 재현의 근본.
+    expect(result?.currentOrg?.orgId).toBe('org-moonklabs');
+    expect(result?.switchOrgError).toBeTruthy();
+    expect(result?.pending).toBe(false); // finally는 원래도 돌아 stuck-pending은 아니었다
+  });
+
+  it('switchOrgAndProject 中 switch-org 자체가 던지면 switchOrgError를 채운다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new TypeError('Failed to fetch'); }));
+    await act(async () => { root.render(<TestComp />); });
+
+    await act(async () => { await result?.switchOrgAndProject('org-dogfood', 'proj-dogfood'); });
+
+    expect(result?.switchOrgError).toBeTruthy();
+    expect(routerPushMock).not.toHaveBeenCalled();
+  });
+
+  it('정상 전환 성공 時엔 switchOrgError가 null이다(회귀가드)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: { ok: true } }) })));
+    await act(async () => { root.render(<TestComp />); });
+
+    await act(async () => { await result?.switchOrg('org-dogfood'); });
+
+    expect(result?.switchOrgError).toBeNull();
+    expect(result?.currentOrg?.orgId).toBe('org-dogfood');
+  });
+
+  it('재시도 시작 時 이전 switchOrgError가 지워진다(낡은 에러가 새 시도처럼 안 보임)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new TypeError('Failed to fetch'); }));
+    await act(async () => { root.render(<TestComp />); });
+    await act(async () => { await result?.switchOrg('org-dogfood'); });
+    expect(result?.switchOrgError).toBeTruthy();
+
+    vi.stubGlobal('fetch', vi.fn(async () => new Promise(() => {}))); // 두 번째 시도는 아직 안 끝남
+    await act(async () => { void result?.switchOrg('org-dogfood'); });
+    expect(result?.switchOrgError).toBeNull();
+  });
+});

--- a/apps/web/src/hooks/use-unified-switcher.ts
+++ b/apps/web/src/hooks/use-unified-switcher.ts
@@ -88,6 +88,12 @@ export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjec
   // 403이었다. 실패를 담아 다이얼로그에 명시로 보여준다(어떤 실패든 침묵하지 않는 게 근본 — a
   // 만으론 다음 다른 실패가 또 조용히 묻힌다).
   const [createProjectError, setCreateProjectError] = useState<string | null>(null);
+  // story #2544 — switchOrg/switchOrgAndProject는 `localOrgId`를 optimistic으로 먼저 찍고
+  // (아래 참고) try에 catch 없이 finally만 있었다. `fetch` 자체가 던지면(네트워크 실패 등)
+  // else 분기(revert)를 절대 못 타 — 실제 전환은 실패했는데 드롭다운은 "전환됨"으로 영구
+  // 고정된다(카디르 QA 라이브 재현의 정확한 모양: 선택·체크는 되는데 다음 org로 실제 안 감).
+  // #2468이 프로젝트 생성 경로에서 이미 고친 것과 같은 클래스(침묵 실패) — 여기 재발.
+  const [switchOrgError, setSwitchOrgError] = useState<string | null>(null);
 
   const [localOrgId, setLocalOrgId] = useState<string | undefined>(currentOrgId);
 
@@ -144,6 +150,7 @@ export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjec
     if (!nextOrgId || nextOrgId === localOrgId || pending) return;
     const prevOrgId = localOrgId;
     setPending(true);
+    setSwitchOrgError(null);
     setLocalOrgId(nextOrgId);
     try {
       const res = await fetch('/api/switch-org', {
@@ -162,7 +169,13 @@ export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjec
         router.refresh();
       } else {
         setLocalOrgId(prevOrgId);
+        setSwitchOrgError(tSwitcher('switcherSwitchOrgError'));
       }
+    } catch {
+      // story #2544 — fetch 자체 실패(네트워크 등)도 실패다. catch 없이 finally만 있으면
+      // 위 optimistic setLocalOrgId(nextOrgId)가 절대 안 풀린다(핵심 재현 지점).
+      setLocalOrgId(prevOrgId);
+      setSwitchOrgError(tSwitcher('switcherSwitchOrgError'));
     } finally {
       setPending(false);
     }
@@ -172,6 +185,7 @@ export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjec
     if (pending) return;
     const prevOrgId = localOrgId;
     setPending(true);
+    setSwitchOrgError(null);
     setLocalOrgId(nextOrgId);
     try {
       const orgRes = await fetch('/api/switch-org', {
@@ -181,6 +195,7 @@ export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjec
       });
       if (!orgRes.ok) {
         setLocalOrgId(prevOrgId);
+        setSwitchOrgError(tSwitcher('switcherSwitchOrgError'));
         return;
       }
       await fetch('/api/switch-project', {
@@ -206,6 +221,12 @@ export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjec
       const switchedPath = newOrgSlug && newSlug ? withSwitchedSlugs(pathname, currentOrg?.orgSlug, newOrgSlug, newSlug) : null;
       router.push(`${switchedPath ?? pathname}?${sp.toString()}`);
       router.refresh();
+    } catch {
+      // story #2544 — switchOrg와 동일 함정: orgRes 이후(switch-project/slug 해소/router.push)
+      // 어디서든 던지면 org는 이미 전환됐는데 UI만 이전 상태로 안 돌아가는 반쪽짜리 실패가 된다.
+      // org 전환 자체는 이미 성공했을 수 있어 prevOrgId로 되돌리지 않는다 — 다음 router.refresh
+      // (사용자가 재시도·재진입 시)가 실제 서버 상태를 다시 반영하게 둔다. 에러만 명시한다.
+      setSwitchOrgError(tSwitcher('switcherSwitchOrgError'));
     } finally {
       setPending(false);
     }
@@ -304,6 +325,7 @@ export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjec
     createOrgOpen, setCreateOrgOpen,
     createProjectOpen, setCreateProjectOpen: setCreateProjectOpenAndClearError,
     createProjectError,
+    switchOrgError,
     newProjectName, setNewProjectName,
     newProjectDesc, setNewProjectDesc,
     creating,


### PR DESCRIPTION
## Summary

AC1 asked to measure all 3 candidate break-points before picking a fix. Did that with code reads + a read-only dev DB probe (`pgstat-probe-dev` Cloud Run Job) + Cloud Run request logs — not guesswork — and it reframes the story.

## AC1 — measured, not guessed

**(a) Does login always mint a home-org token?** Confirmed, by design. `X-Org-Id` header is the intended per-request override (`_resolve_verified_org_id` in `auth.py`), not itself a defect.

**(b) Does org-switch fail to reissue a token?** Ruled out **for the backend endpoint itself**. `POST /api/v2/auth/switch-org` correctly re-verifies `org_members`, builds a freshly org-scoped `app_metadata`, and issues new tokens — when actually called.

But: **Cloud Run request logs show zero calls to `/api/v2/auth/switch-org` during today's QA session** (last successful call was 2026-08-06). And DB confirms `users.last_org_id` for `sellerking` is still the home org — `switch_organization()`'s commit sets `user.last_org_id = body.org_id`, so it would've changed had a switch actually landed. **The switch never reached the backend at all.**

**(c) Does backend org-scope ignore `X-Org-Id` and only read the JWT top-level claim?** Ruled out. `_resolve_verified_org_id` prioritizes the header (`raw = x_org_id or jwt_org_id`) and always re-verifies DB membership when it's present. `sellerking` has a real, active `org_members` row for 뭉클랩 (role=admin, since 2026-05-20) — membership isn't the gap either.

⇒ **The break is pre-backend.**

## Found it

`switchOrg`/`switchOrgAndProject` (`use-unified-switcher.ts`) set `localOrgId` **optimistically before** the `try` block, but the `try` only had `finally` — no `catch`. Any throw from the `/api/switch-org` fetch (network failure, etc.) skips the `else` revert path entirely — the dropdown shows "switched" forever, the real org context never changes, and (consistent with the logs above) the backend never even sees a subsequent legitimate request.

This is the exact shape of QA's repro: *"선택·체크까지 되고... 그런데도 거부"* — and it's the same silent-failure class `#2468` already fixed once for project creation (*"어떤 실패든 침묵하지 않는 게 근본"*), never applied here.

## Fix

- `catch` added to both functions: `switchOrg` reverts `localOrgId`; both set a new `switchOrgError` (i18n'd, en/ko).
- Error rendered **outside** `DropdownMenuContent` — a `DropdownMenuItem` click closes the menu immediately, so an alert placed inside would vanish with it.
- 4 new tests in `use-unified-switcher.test.tsx` (`story #2544`) pin this. **RED confirmed** against the pre-fix code via `git stash` (uncaught `TypeError` propagates, `localOrgId` stuck on the failed target, `switchOrgError` stays `undefined`); **GREEN** after.

## What this does NOT close yet (honest gap — AC2/AC4)

This fixes a confirmed, real defect matching the failure class exactly, but I can't reproduce QA's exact live browser session — no human-credential impersonation (sellerking's login is off-limits per team policy). Requesting a fresh QA re-test: open Network tab, filter to `/api/switch-org`, click a cross-org project in the switcher, confirm (a) the request actually fires now, and (b) either it succeeds or `switchOrgError` visibly appears instead of a silent no-op. If it fires and still fails, that visible failure reason is the next lead — this PR makes that failure visible for the first time; it doesn't claim to have found every possible cause of a fetch throwing.

**AC3** (single SSOT: header vs JWT claim) — already satisfied by existing code, no change needed. `_resolve_verified_org_id` already treats `X-Org-Id` as the sole override, uniformly re-verified against `org_members`.

**AC5** — QA cred provisioning (moving `sellerking` to 뭉클랩 as home org, or a separate QA account) is explicitly a separate track per the story's own note.

## Verification

- `npx vitest run apps/web/src/hooks/use-unified-switcher.test.tsx` — 16/16 pass (4 new).
- `npx vitest run apps/web/src/components/nav/unified-switcher.test.ts` — 6/6 pass (unaffected).
- `tsc --noEmit` — clean.
- `eslint` on touched files — clean.
- `node scripts/check-i18n-keys.js` — no key mismatch.
- Dev DB read via `pgstat-probe-dev` (read-only diagnostic job, no schema/data changes) and Cloud Run request-log read (`gcloud logging read`) — no infra changes made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)