### PR TITLE
fix(#2420): warning/success/info badge variants use text-foreground on tint (AA)

### DIFF
--- a/apps/web/src/components/org-briefing/loop-face.test.tsx
+++ b/apps/web/src/components/org-briefing/loop-face.test.tsx
@@ -82,7 +82,15 @@ describe('LoopFace', () => {
     // (27e339bc 공허-통과 테스트 버그 클래스). 양성 어서션(현재 올바른 info 클래스가 실제로 있다)과
     // 진짜 존재하는 위험 클래스명(text-destructive)에 대한 음성 어서션으로 교체 — variant가
     // destructive로 바뀌면 이 테스트가 실제로 실패한다.
-    expect(container.innerHTML).toContain('text-info');
+    // story #2420 v3 — badge.tsx info variant가 text-info→text-foreground로 이행(tint 배경
+    // 위 글자는 계열색이 아니라 text-foreground라는 규칙, badge.tsx 참고). 단 text-foreground는
+    // 페이지 어디서나 흔한 클래스라 container.innerHTML 통짜 검사로는 다시 공허-통과가 된다
+    // (badge 아닌 다른 엘리먼트의 text-foreground가 어서션을 살릴 수 있음) — bg-info-tint를
+    // 가진 그 배지 엘리먼트 자체의 className을 골라 검사한다.
+    const infoBadge = container.querySelector('[class*="bg-info-tint"]');
+    expect(infoBadge).not.toBeNull();
+    expect(infoBadge?.className).toContain('text-foreground');
+    expect(infoBadge?.className).not.toContain('text-info');
     expect(container.innerHTML).not.toContain('text-destructive');
   });
 

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -23,9 +23,15 @@ const badgeVariants = cva(
         ghost:
           "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
         link: "text-primary underline-offset-4 hover:underline",
-        success: "border-success-border bg-success-tint text-success",
-        info: "border-info-border bg-info-tint text-info",
-        warning: "border-warning-border bg-warning-tint text-warning",
+        // story #2420 v3 규칙(계열별 토큰 대신 규칙 하나) — destructive와 동일: tint 배경 위
+        // 글자는 text-foreground다(계열색 아님). 계열은 border/bg로 전한다. 유나 라이브 실측
+        // (2026-08-10, dev): text-warning on bg-warning-tint = 2.06(라이트, AA 4.5 미달) →
+        // text-foreground로 이행 시 18.44(라이트·success 17.47·info 17.38·전 계열 AA,
+        // scripts/verify-tint-foreground-contrast.ts가 정의 시점에 검증). --foreground가
+        // 테마마다 값을 가지므로 dark: 짝이 따로 필요 없다.
+        success: "border-success-border bg-success-tint text-foreground",
+        info: "border-info-border bg-info-tint text-foreground",
+        warning: "border-warning-border bg-warning-tint text-foreground",
         chip: "border-border/80 bg-muted/70 text-muted-foreground",
         counter: "border-transparent bg-destructive text-destructive-foreground",
       },


### PR DESCRIPTION
## What
The `warning` / `success` / `info` Badge variants rendered series-color text on their tint backgrounds (`text-warning` on `bg-warning-tint`, and the equivalents), which fails WCAG AA in light theme.

Live measurement (dev, 2026-08-10): the `측정 중` badge (`<Badge variant="warning">`) rendered amber text (rgb 220,164,0) on a light-amber tint (rgb 251,245,229) = **2.06:1**, below the 4.5 AA threshold. `success` / `info` share the same defect class.

## Fix
Apply the v3 rule already adopted for `destructive` (#2419): tint-background text uses `--foreground`; the semantic color is carried by `border` + `bg`. One rule, no per-family foreground tokens; `--foreground` carries its own per-theme value so no `dark:` pair is needed.

## Evidence — definition guard (AC3)
`verify-tint-foreground-contrast.ts`, text-foreground on each `-tint`, series-color (before) -> foreground (after):

| pair | before | after |
|---|---|---|
| light/warning | 2.08 | 18.44 |
| light/success | 4.00 | 17.47 |
| light/info | 4.20 | 17.38 |

All 10 family x theme pairs pass AA. `verify-no-new-tint-color-text.ts` baseline is unaffected (these variant definitions were not in the grandfathered inline-usage set). Guard test suite: 23 passed.

## Scope
Badge variant definitions only. The ~87 grandfathered inline `text-<series>` usages remain the AC7 block-new baseline and are a separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
