### PR TITLE
chore(docs): 에이전트 문서 app 단일화(랜딩 301 제거) + connect-guide 현행화

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -75,12 +75,11 @@ const nextConfig: NextConfig = {
     return [
       { source: '/memos', destination: '/inbox', permanent: true },
       { source: '/memos/:path*', destination: '/inbox', permanent: true },
-      // 단일 도메인 위생(45a5a006): 호스티드 app.sprintable.ai의 공개 LLM 문서는 랜딩(canonical)으로 301.
-      // host 스코프로 한정해 self-hosted/dev 인스턴스는 영향받지 않고 자체 public 파일을 계속 서빙한다
-      // (onboarding-form 등이 getAppOrigin()/llms.txt를 참조하므로 파일 자체는 유지). onboarding-guide.txt는
-      // app(한)↔랜딩(영) 내용 상이로 별도 콘텐츠 스토리에서 처리한다.
-      { source: '/llms.txt', destination: 'https://sprintable.ai/llms.txt', statusCode: 301, has: [{ type: 'host', value: 'app.sprintable.ai' }] },
-      { source: '/llms-full.txt', destination: 'https://sprintable.ai/llms-full.txt', statusCode: 301, has: [{ type: 'host', value: 'app.sprintable.ai' }] },
+      // 문서 단일화(2026-08-10 선생님 지시): 에이전트 공개 문서(llms.txt·llms-full.txt·
+      // connect-guide.txt·onboarding-guide.txt)의 유일 canonical 은 «앱 안»(apps/web/public)이다.
+      // 랜딩(sprintable.ai)은 의도적으로 분리된 별도 레포라, 이전의 app→랜딩 301 을 제거해
+      // app 이 자기 public 파일을 직접(canonical) 서빙한다 — 랜딩의 옛 사본으로 넘기지 않는다.
+      // (제거 前엔 llms.txt/llms-full.txt 만 랜딩으로 301 하던 반쪽 통일이라 오히려 갈렸다.)
       // story c4980e70(조직 1급화 IA·doc org-1st-class-surface-ia-design-b §1): 에이전트 관리가
       // /agents → /organization/workforce(조직=1급 구역)로 승격. 서브라우트 전체(상세·runs·recruiter 등) 보존.
       { source: '/agents', destination: '/organization/workforce', permanent: true },

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 AI agents and humans as equal teammates in a self-hosted project management platform.
 
-Quick start: https://sprintable.ai/llms.txt
+Quick start: /llms.txt
 
 ---
 

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -6,9 +6,9 @@ Sprintable runs agents and humans on the same kanban board, sprints, and convers
 
 ## Docs
 
-- [Full API & Architecture Reference](https://sprintable.ai/llms-full.txt): Complete data models, authentication flows, org-project-member policy, agent communication (WebSocket / HTTP relay / SSE / inbox webhook / A2A dev PoC), MCP 89-tool reference, and self-hosting guide.
-- [Connect Guide](https://sprintable.ai/connect-guide.txt): Three-step guide for connecting an existing agent runtime (Codex, Claude Code, Cursor, Gemini) via MCP — register, wake, instruct.
-- [Agent Integration Guide](https://sprintable.ai/onboarding-guide.txt): Step-by-step connection guide for non-Claude-Code agents (Hermes, LangChain, AutoGen, custom) via SSE stream and webhook.
+- [Full API & Architecture Reference](/llms-full.txt): Complete data models, authentication flows, org-project-member policy, agent communication (WebSocket / HTTP relay / SSE / inbox webhook / A2A dev PoC), MCP 89-tool reference, and self-hosting guide.
+- [Connect Guide](/connect-guide.txt): Three-step guide for connecting an existing agent runtime (Codex, Claude Code, Cursor, Gemini) via MCP — register, wake, instruct.
+- [Agent Integration Guide](/onboarding-guide.txt): Step-by-step connection guide for non-Claude-Code agents (Hermes, LangChain, AutoGen, custom) via SSE stream and webhook.
 - [GitHub Webhook Quickstart](https://github.com/moonklabs/sprintable/blob/main/docs/quickstart-webhook.md): Auto-close stories when a GitHub PR merges — signed inbound webhook (`/api/webhooks/github`) → ticket close.
 - [Self-Hosting Guide](https://github.com/moonklabs/sprintable/blob/main/docs/self-hosting.md): Docker Compose setup, required environment variables, migrations.
 - [Workflow Templates](https://github.com/moonklabs/sprintable/blob/main/docs/workflow-templates.md): Pre-built automation patterns (auto-assign on status change, QA routing, sprint notifications).

--- a/apps/web/src/components/agents/agent-api-key-manager.tsx
+++ b/apps/web/src/components/agents/agent-api-key-manager.tsx
@@ -53,8 +53,8 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
   const [revokeKeyId, setRevokeKeyId] = useState<string | null>(null);
   const { addToast } = useToast();
 
-  // f44e2644: 랜딩 canonical 직지정(app.sprintable.ai CF 301 prod 미발동·앱 사본 onboarding-guide 깨짐).
-  const LLMS_URL = 'https://sprintable.ai/llms.txt';
+  // 문서 app 단일화(2026-08-10 선생님 지시): app 자기 도메인 canonical 직지정(랜딩 301 제거로 app.sprintable.ai 가 자기 /llms.txt 를 직접 서빙).
+  const LLMS_URL = 'https://app.sprintable.ai/llms.txt';
 
   const buildOnboardingMessage = (apiKey: string, mcpConfig?: string | null) =>
     t('agentApiKeyOnboardingMessageBase', { agentName, apiKey, llmsUrl: LLMS_URL }) +


### PR DESCRIPTION
## 무엇 (선생님 지시 2026-08-10)
문서 단일화 — 에이전트 공개 문서(llms.txt·llms-full.txt·connect-guide.txt·onboarding-guide.txt)의 유일 canonical 을 «앱 안»(apps/web/public)으로. 랜딩(sprintable.ai)은 의도적으로 분리된 별도 레포라 건드리지 않음.

## 변경
- **apps/web/next.config.ts**: `app.sprintable.ai/llms.txt`·`/llms-full.txt` → `sprintable.ai` 로 보내던 301 리다이렉트 «제거». 이전엔 이 두 파일만 랜딩으로 넘겨 오히려 dev(앱 자기 public)↔랜딩(옛 사본)이 갈렸음. 제거로 app 이 자기 public 을 직접 canonical 서빙.
- **apps/web/public/connect-guide.txt**: 「Sprintable 팀 에이전트가 지금 fakechat 슬롯 server.ts 교체 우회로 돈다」는 stale 서술 정정 — fleet 은 이번에 정식 채널 플러그인(`sprintable@moonklabs`)으로 이관됨. 해당 절을 «외부 사용자가 지금 쓸 공개 경로»로 명확화 + SSE dial-out(`GET /api/v2/agent/stream`·`<channel source="fakechat">`·reply `POST /conversations/{id}/messages`) 명시. 우회 설치 스텝 자체는 유지(정식 public 설치 경로 미제공이라 현 공개 경로).

## 검증(머지 후)
dev 배포 후 `curl https://dev-app.sprintable.ai/{llms-full,connect-guide}.txt` 로 서빙 실측 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)