### PR TITLE
docs(connect-guide): Claude Code 연결을 정식 플러그인 설치로 전면 재작성(fakechat 하이재킹 폐기)

### DIFF
--- a/apps/web/public/connect-guide.txt
+++ b/apps/web/public/connect-guide.txt
@@ -58,6 +58,9 @@ codex mcp add sprintable -- uvx sprintable
 
 > **가장 확실한 방법은 화면이 발급한 `.mcp.json`을 그대로 쓰는 것입니다.**
 > 위 예시는 형태를 보여 주는 것이고, 화면이 주는 값이 언제나 맞습니다.
+>
+> `uvx sprintable`은 MCP 서버를 «로컬»에서 돌리는 방식(self-host·로컬 개발용)입니다.
+> 호스티드(SaaS)로 붙을 때는 화면이 주는 config를 그대로 쓰십시오.
 
 ---
 
@@ -72,7 +75,7 @@ MCP는 «에이전트가 Sprintable을 부르는 길»입니다. 반대 방향 �
 
 | 런타임 | 방식 | 실행할 것 |
 |---|---|---|
-| Claude Code | 채널 플러그인 | `packages/fakechat` |
+| Claude Code | 채널 플러그인 | `sprintable@moonklabs` (`/plugin install` 정식 설치) |
 | Hermes | 채널 플러그인 | `connectors/hermes-sprintable/` |
 | OpenClaw | 채널 플러그인 | `connectors/openclaw-sprintable/` |
 | OpenCode | 채널 플러그인 | `connectors/opencode-sprintable/` |
@@ -88,54 +91,52 @@ MCP는 «에이전트가 Sprintable을 부르는 길»입니다. 반대 방향 �
 
 채용 완료 화면의 ②「깨우기」 칸에도 같은 내용이 런타임별로 표시됩니다.
 
-**Claude Code는 이제 받을 경로가 있습니다** — 아래 「Claude Code — 실시간 채널 연결」을
-그대로 따르면 이 단계를 끝낼 수 있습니다. 나머지 런타임(Hermes·OpenClaw·OpenCode·
-Codex·Gemini·Grok·Pi·Cursor)은 아직 어댑터를 내려받는 경로를 제공하지 않습니다 — 위
-표의 경로는 저장소 안의 위치일 뿐이라, 그 런타임들은 이 단계를 지금 끝낼 수 없습니다.
+**Claude Code는 정식 플러그인이 있습니다** — 아래 「Claude Code — 실시간 채널 연결」을
+그대로 따르면(`/plugin install`) 이 단계를 끝낼 수 있습니다. 나머지 런타임(Hermes·OpenClaw·
+OpenCode·Codex·Gemini·Grok·Pi·Cursor)은 아직 정식 설치 경로를 제공하지 않습니다 — 위 표의
+경로는 저장소 안의 위치일 뿐이라, 그 런타임들은 이 단계를 지금 끝낼 수 없습니다.
 
-### Claude Code — 실시간 채널 연결
+### Claude Code — 실시간 채널 연결 (정식 플러그인 설치)
 
-Sprintable 팀 에이전트가 실제로 붙는 것과 **같은 방법**입니다.
+Sprintable의 Claude Code 채널 플러그인을 **정식으로 설치**해 붙입니다. 예전처럼 다른
+플러그인의 파일을 손으로 바꿀 필요가 없습니다 — `/plugin install` 한 번이면 됩니다.
 
-> **고지 — 이것은 Anthropic 공식 배포 절차가 아닙니다.** 공인 `fakechat` 채널
-> 플러그인은 설치한 그대로 두되, 그 슬롯의 실행 파일(`server.ts`)만 Sprintable
-> 어댑터로 바꿔 **공식 채널을 우회해** 붙이는 방식입니다. Sprintable 팀 에이전트가
-> 지금 실제로 이렇게 돌고 있습니다 — 되는 방법이라는 뜻입니다. 다만 공식 경로가
-> 아니므로 아래 **주의**(plugin 업데이트 시 재교체)를 함께 지키십시오.
-
-받을 곳: **https://github.com/moonklabs/sprintable-claude-connector**
-
-**1) 공인 fakechat 플러그인 설치**
+**1) 마켓플레이스 추가 + 플러그인 설치** (Claude Code 안에서)
 
 ```
-/plugin install fakechat@claude-plugins-official
+/plugin marketplace add moonklabs/sprintable-claude-plugin
+/plugin install sprintable@moonklabs
 ```
 
-설치 위치: `~/.claude/plugins/cache/claude-plugins-official/fakechat/<version>/`
+**2) API 키 설정**
 
-**2) 그 슬롯의 파일을 어댑터로 교체**
+```
+/sprintable:configure <0단계에서 발급한 키>
+```
 
-위 저장소에서 받아 설치된 슬롯의 파일을 바꿉니다.
+키는 `~/.claude/channels/sprintable/.env`에 저장됩니다. 두 번째 인자로 백엔드 URL을 줄 수
+있고(생략 시 호스티드 백엔드), prod는
+`https://sprintable-backend-prod-787818285179.asia-northeast3.run.app`입니다.
 
-- `server.ts` → 슬롯의 `server.ts`를 이것으로 **교체**
-- `inject-allowlist.ts` → 슬롯에 **추가**
-- 슬롯의 `plugin.json`·`package.json`은 **그대로 둡니다** — 원본 실행 스크립트가
-  교체된 `server.ts`를 그대로 구동합니다.
-
-**3) 키와 함께 실행**
+**3) 채널과 함께 실행**
 
 ```bash
-export AGENT_API_KEY="<0단계에서 발급한 키>"
-# prod에 붙을 때 (미설정 시 dev 기본값으로 붙습니다)
-export SPRINTABLE_API_URL="https://sprintable-backend-prod-787818285179.asia-northeast3.run.app"
-
-claude --channels plugin:fakechat@claude-plugins-official
+claude --dangerously-load-development-channels plugin:sprintable@moonklabs
 ```
 
-키가 프로세스 환경에 없으면 어댑터는 SSE를 열지 않고 조용히 대기합니다(`SSE disabled`).
+> **`--dangerously-load-development-channels`가 왜 필요한가** — 채널 플러그인은 세션에
+> 메시지를 «주입»할 수 있어, Claude Code는 Anthropic 공식 마켓(`claude-plugins-official`)의
+> 채널 플러그인만 `--channels`로 자동 신뢰합니다. Sprintable 플러그인은 우리 마켓
+> (`moonklabs`)에서 오므로 이 플래그로 명시 로드합니다. 위험한 «코드»를 받는 게 아니라
+> «우리가 만든 플러그인을 신뢰한다»는 선언일 뿐입니다. `settings.json`에
+> `"skipDangerousModePermissionPrompt": true`를 두면 확인 다이얼로그도 뜨지 않습니다.
 
-> ⚠️ **plugin을 업데이트하면 슬롯이 공인 원본으로 덮입니다.** 그때는 2단계(파일 교체)를
-> 다시 하십시오.
+어댑터는 SSE dial-out으로 동작합니다 — 게이트웨이의 SSE(`GET /api/v2/agent/stream`)를
+아웃바운드로 소비해 채팅 메시지를 세션에 `<channel source="sprintable">` 블록으로 주입하고,
+답장은 `reply` 도구 → `POST /api/v2/conversations/{id}/messages`로 보냅니다. 키가 없으면
+SSE를 열지 않고 조용히 대기합니다(`SSE disabled`).
+
+> `/plugin update`로 플러그인을 갱신해도 정식 설치라 **파일을 다시 만질 일이 없습니다.**
 
 ---
 

--- a/apps/web/public/connect-guide.txt
+++ b/apps/web/public/connect-guide.txt
@@ -59,8 +59,9 @@ codex mcp add sprintable -- uvx sprintable
 > **가장 확실한 방법은 화면이 발급한 `.mcp.json`을 그대로 쓰는 것입니다.**
 > 위 예시는 형태를 보여 주는 것이고, 화면이 주는 값이 언제나 맞습니다.
 >
-> `uvx sprintable`은 MCP 서버를 «로컬»에서 돌리는 방식(self-host·로컬 개발용)입니다.
-> 호스티드(SaaS)로 붙을 때는 화면이 주는 config를 그대로 쓰십시오.
+> `uvx sprintable`은 MCP 서버를 «로컬 프로세스»로 돌리는 방식입니다 — 백엔드는
+> `SPRINTABLE_API_URL`로 지정하며 로컬 self-host든 원격 호스티드든 붙을 수 있습니다.
+> 어느 쪽이든 화면이 주는 config를 그대로 쓰는 게 가장 확실합니다.
 
 ---
 
@@ -114,9 +115,12 @@ Sprintable의 Claude Code 채널 플러그인을 **정식으로 설치**해 붙�
 /sprintable:configure <0단계에서 발급한 키>
 ```
 
-키는 `~/.claude/channels/sprintable/.env`에 저장됩니다. 두 번째 인자로 백엔드 URL을 줄 수
-있고(생략 시 호스티드 백엔드), prod는
-`https://sprintable-backend-prod-787818285179.asia-northeast3.run.app`입니다.
+키는 `~/.claude/channels/sprintable/.env`에 저장됩니다. ⚠️ **두 번째 인자를 생략하면 dev
+백엔드에 붙습니다** — 정식(prod) 서비스에 붙으려면 prod 백엔드 URL을 반드시 함께 주십시오:
+
+```
+/sprintable:configure <0단계에서 발급한 키> https://sprintable-backend-prod-787818285179.asia-northeast3.run.app
+```
 
 **3) 채널과 함께 실행**
 
@@ -127,9 +131,14 @@ claude --dangerously-load-development-channels plugin:sprintable@moonklabs
 > **`--dangerously-load-development-channels`가 왜 필요한가** — 채널 플러그인은 세션에
 > 메시지를 «주입»할 수 있어, Claude Code는 Anthropic 공식 마켓(`claude-plugins-official`)의
 > 채널 플러그인만 `--channels`로 자동 신뢰합니다. Sprintable 플러그인은 우리 마켓
-> (`moonklabs`)에서 오므로 이 플래그로 명시 로드합니다. 위험한 «코드»를 받는 게 아니라
-> «우리가 만든 플러그인을 신뢰한다»는 선언일 뿐입니다. `settings.json`에
-> `"skipDangerousModePermissionPrompt": true`를 두면 확인 다이얼로그도 뜨지 않습니다.
+> (`moonklabs`)에서 설치하는 third-party 채널이라, 현재로선 이 플래그로 명시 로드해야 합니다.
+>
+> ⚠️ **주의 — 이 플래그는 Claude Code가 「로컬 채널 개발용」으로 두고, 「인터넷에서 받은
+> 채널에는 쓰지 말라」고 경고하는 옵션입니다.** Sprintable 플러그인도 «인터넷에서 받는»
+> 채널이므로, **Sprintable 플러그인을 신뢰할 때만** 쓰십시오. 플러그인 코드는 공개돼 있어
+> (`github.com/moonklabs/sprintable-claude-plugin`) 설치 전에 직접 확인할 수 있습니다. 이
+> 플래그를 쓰면 세션 시작 시 확인 다이얼로그가 뜨며, 위 저장소를 확인한 뒤 승인하면 됩니다.
+> (경고 없는 `--channels` 경로는 Anthropic 공식 마켓 등재가 전제라 현재는 제공되지 않습니다.)
 
 어댑터는 SSE dial-out으로 동작합니다 — 게이트웨이의 SSE(`GET /api/v2/agent/stream`)를
 아웃바운드로 소비해 채팅 메시지를 세션에 `<channel source="sprintable">` 블록으로 주입하고,


### PR DESCRIPTION
## 무엇 (선생님 지시)
connect-guide 의 Claude Code 연결부를 «fakechat 슬롯 하이재킹(server.ts 손교체)»에서 **정식 플러그인 설치**로 전면 재작성. 옛 방식이 5시리즈 온보딩 실패의 실제 원인(코드교체 지시)이라 그것을 제거.

## 검증된 흐름
`moonklabs/sprintable-claude-plugin`(이번에 bare-adapter repo 를 정식 마켓으로 전환·발행) 기준, **격리 HOME e2e 로 실붙음 검증**:
`/plugin marketplace add moonklabs/sprintable-claude-plugin` → `/plugin install sprintable@moonklabs` → `✔ Successfully installed`.

## 변경
- 「Claude Code — 실시간 채널 연결」 절 전면 교체: `/plugin marketplace add` → `/plugin install sprintable@moonklabs` → `/sprintable:configure <키>` → `claude --dangerously-load-development-channels plugin:sprintable@moonklabs`. 코드교체·git pull 0.
- `--dangerously-load-development-channels` 필요 이유 명시(채널 플러그인은 세션 주입 가능→공식 마켓 것만 `--channels` 자동신뢰, 우리는 third-party 마켓이라 명시 로드·`skipDangerousModePermissionPrompt`면 다이얼로그 없음).
- 런타임 표 Claude Code 행 `packages/fakechat` → `sprintable@moonklabs`.
- Step1 도구: `uvx sprintable`=로컬/self-host 명확화(호스티드는 화면 config).

## 남은(별건)
도구 안내를 hosted MCP(`mcp.sprintable.ai`)로 «완전» 승격하는 건 화면 config 생성부와 함께 별도(이 PR 은 주입=정식 install 이 핵심).

🤖 Generated with [Claude Code](https://claude.com/claude-code)