### PR TITLE
chore(prod): 연결방식 문서·어댑터 prod 승격 (#2924/#2949/#2950/#2951)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -286,20 +286,18 @@ sprintable_add_story({
 
 ## 에이전트 채팅 (fakechat)
 
-fakechat은 에이전트를 Sprintable의 실시간 WebSocket 채팅 채널에 연결하는 MCP 플러그인입니다. 설정을 마치면, 에이전트에게 보낸 메시지가 세션 안에 `<channel source="fakechat" ...>` 태그로 나타나고, 답장도 같은 채널로 돌아갑니다.
+fakechat은 에이전트를 Sprintable의 실시간 채팅에 연결하는 MCP **채널 플러그인**입니다. 설정을 마치면, 에이전트에게 보낸 메시지가 세션 안에 `<channel source="fakechat" ...>` 태그로 나타나고, 답장도 같은 채널로 돌아갑니다.
+
+**SSE dial-out** 어댑터로 동작합니다 — 플러그인이 Sprintable Agent Gateway로 아웃바운드 스트림을 열어 이벤트를 받으며, 인바운드 포트나 로컬 WebSocket 서버는 없습니다.
 
 ### 사전 요구사항
 
 - Sprintable 실행 중 (`docker compose up -d --build`)
 - Sprintable에 등록된 에이전트 (에이전트(Agents) → 채용(Recruit))
 
-### 1단계 — Agent ID와 API Key 확인
+### 1단계 — Agent API Key 확인
 
-Sprintable에서: **에이전트(Agents) → [에이전트]**
-
-복사할 항목:
-- **Agent ID** — 에이전트 상세 페이지에 표시되는 UUID
-- **API Key** — `sk_live_...` 토큰 (한 번만 발급되므로 안전하게 보관)
+Sprintable에서: **에이전트(Agents) → [에이전트]**. **API Key**(`sk_live_...` 토큰, 한 번만 발급되므로 안전하게 보관)를 복사합니다. 키가 에이전트를 식별하며, 스트림과 답장은 그 키에 귀속됩니다.
 
 ### 2단계 — MCP 설정에 fakechat 추가
 
@@ -313,16 +311,15 @@ Sprintable에서: **에이전트(Agents) → [에이전트]**
       "command": "bun",
       "args": ["packages/fakechat/server.ts"],
       "env": {
-        "SPRINTABLE_AGENT_ID": "YOUR_AGENT_UUID",
         "SPRINTABLE_API_KEY": "sk_live_...",
-        "SPRINTABLE_WS_URL": "ws://localhost:8000"
+        "SPRINTABLE_API_URL": "http://localhost:8000"
       }
     }
   }
 }
 ```
 
-> 에이전트가 Docker 네트워크 **내부**에서 실행된다면 `SPRINTABLE_WS_URL=ws://backend:8000`으로 설정하세요.
+> `SPRINTABLE_API_URL`은 앱 도메인이 아니라 **백엔드** 주소입니다 — SSE 스트림은 백엔드로 직접 붙어야 합니다. 에이전트가 Docker 네트워크 **내부**에서 실행된다면 `http://backend:8000`을 사용하세요.
 
 ### 3단계 — 채팅 시작
 
@@ -330,28 +327,26 @@ Sprintable과 fakechat이 둘 다 실행 중이라면, Sprintable UI의 **채널
 
 ```
 Sprintable UI / API
-      │  POST /api/v2/channel/deliver
+      │  에이전트로 이벤트 적재
       ▼
-Backend WebSocket Hub (/ws/chat/{agent_id})
-      │  broadcast
+Agent Gateway  GET /api/v2/agent/stream   (SSE, dial-out)
+      │  server-sent event
       ▼
-fakechat (WS client) → mcp.notification → Claude Code <channel> tag
+fakechat (SSE client) → mcp.notification → Claude Code <channel source="fakechat"> tag
 ```
 
 응답 경로 (에이전트 → UI):
 
 ```
 Claude Code reply tool
-      │  ws.send({ content })
+      │  POST /api/v2/conversations/{id}/messages
       ▼
-Backend WebSocket Hub → broadcast to all room members
-      ▼
-Sprintable UI / other WS clients
+Agent Gateway → Sprintable UI / 다른 채널 참여자
 ```
 
 ### 재연결
 
-백엔드가 재시작되면 fakechat은 exponential backoff(1초 → 30초)로 자동 재연결합니다.
+연결이 끊기거나 백엔드가 재시작되면 fakechat은 SSE 스트림을 exponential backoff로 자동 재연결합니다. 호스트 세션이 끝나면 깔끔하게 종료되어, 스트림 슬롯을 문 채 고아로 남지 않습니다.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -301,20 +301,18 @@ sprintable_add_story({
 
 ## Agent Chat (fakechat)
 
-fakechat is the MCP plugin that connects your agent to the Sprintable real-time WebSocket chat channel. Once configured, messages sent to your agent appear as `<channel source="fakechat" ...>` tags in your agent's session, and replies go back through the same channel.
+fakechat is the MCP **channel plugin** that connects your agent to Sprintable's real-time chat. Once configured, messages sent to your agent appear as `<channel source="fakechat" ...>` tags in your agent's session, and replies go back through the same channel.
+
+It runs as an **SSE dial-out** adapter: the plugin opens an outbound stream to the Sprintable Agent Gateway and receives events — there is no inbound port or local WebSocket server.
 
 ### Prerequisites
 
 - Sprintable running (`docker compose up -d --build`)
 - An agent registered in Sprintable (Agents → Recruit)
 
-### Step 1 — Get your Agent ID and API Key
+### Step 1 — Get your Agent API Key
 
-In Sprintable: **Agents → [Your Agent]**
-
-Copy:
-- **Agent ID** — UUID shown in the agent detail page
-- **API Key** — `sk_live_...` token (generated once, store safely)
+In Sprintable: **Agents → [Your Agent]**. Copy the **API Key** — an `sk_live_...` token (generated once, store safely). The key identifies the agent; the stream and replies are scoped to it.
 
 ### Step 2 — Add fakechat to your MCP config
 
@@ -328,16 +326,15 @@ Copy:
       "command": "bun",
       "args": ["packages/fakechat/server.ts"],
       "env": {
-        "SPRINTABLE_AGENT_ID": "YOUR_AGENT_UUID",
         "SPRINTABLE_API_KEY": "sk_live_...",
-        "SPRINTABLE_WS_URL": "ws://localhost:8000"
+        "SPRINTABLE_API_URL": "http://localhost:8000"
       }
     }
   }
 }
 ```
 
-> If your agent runs **inside** a Docker network, set `SPRINTABLE_WS_URL=ws://backend:8000` instead.
+> `SPRINTABLE_API_URL` is the **backend** address, not the app domain — the SSE stream must reach the backend directly. If your agent runs **inside** a Docker network, use `http://backend:8000` instead.
 
 ### Step 3 — Start chatting
 
@@ -345,28 +342,26 @@ With both Sprintable and fakechat running, open the **Channel** page in the Spri
 
 ```
 Sprintable UI / API
-      │  POST /api/v2/channel/deliver
+      │  event queued for the agent
       ▼
-Backend WebSocket Hub (/ws/chat/{agent_id})
-      │  broadcast
+Agent Gateway  GET /api/v2/agent/stream   (SSE, dial-out)
+      │  server-sent event
       ▼
-fakechat (WS client) → mcp.notification → Claude Code <channel> tag
+fakechat (SSE client) → mcp.notification → Claude Code <channel source="fakechat"> tag
 ```
 
 Reply path (agent → UI):
 
 ```
 Claude Code reply tool
-      │  ws.send({ content })
+      │  POST /api/v2/conversations/{id}/messages
       ▼
-Backend WebSocket Hub → broadcast to all room members
-      ▼
-Sprintable UI / other WS clients
+Agent Gateway → Sprintable UI / other channel members
 ```
 
 ### Reconnection
 
-fakechat reconnects automatically with exponential backoff (1 s → 30 s) if the backend restarts.
+fakechat re-opens the SSE stream automatically with exponential backoff if the connection drops or the backend restarts. It exits cleanly when the host session ends, so it never lingers as an orphan holding a stream slot.
 
 ---
 

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -71,12 +71,11 @@ const nextConfig: NextConfig = {
     return [
       { source: '/memos', destination: '/inbox', permanent: true },
       { source: '/memos/:path*', destination: '/inbox', permanent: true },
-      // 단일 도메인 위생(45a5a006): 호스티드 app.sprintable.ai의 공개 LLM 문서는 랜딩(canonical)으로 301.
-      // host 스코프로 한정해 self-hosted/dev 인스턴스는 영향받지 않고 자체 public 파일을 계속 서빙한다
-      // (onboarding-form 등이 getAppOrigin()/llms.txt를 참조하므로 파일 자체는 유지). onboarding-guide.txt는
-      // app(한)↔랜딩(영) 내용 상이로 별도 콘텐츠 스토리에서 처리한다.
-      { source: '/llms.txt', destination: 'https://sprintable.ai/llms.txt', statusCode: 301, has: [{ type: 'host', value: 'app.sprintable.ai' }] },
-      { source: '/llms-full.txt', destination: 'https://sprintable.ai/llms-full.txt', statusCode: 301, has: [{ type: 'host', value: 'app.sprintable.ai' }] },
+      // 문서 단일화(2026-08-10 선생님 지시): 에이전트 공개 문서(llms.txt·llms-full.txt·
+      // connect-guide.txt·onboarding-guide.txt)의 유일 canonical 은 «앱 안»(apps/web/public)이다.
+      // 랜딩(sprintable.ai)은 의도적으로 분리된 별도 레포라, 이전의 app→랜딩 301 을 제거해
+      // app 이 자기 public 파일을 직접(canonical) 서빙한다 — 랜딩의 옛 사본으로 넘기지 않는다.
+      // (제거 前엔 llms.txt/llms-full.txt 만 랜딩으로 301 하던 반쪽 통일이라 오히려 갈렸다.)
       // story c4980e70(조직 1급화 IA·doc org-1st-class-surface-ia-design-b §1): 에이전트 관리가
       // /agents → /organization/workforce(조직=1급 구역)로 승격. 서브라우트 전체(상세·runs·recruiter 등) 보존.
       { source: '/agents', destination: '/organization/workforce', permanent: true },

--- a/apps/web/public/connect-guide.txt
+++ b/apps/web/public/connect-guide.txt
@@ -58,6 +58,10 @@ codex mcp add sprintable -- uvx sprintable
 
 > **가장 확실한 방법은 화면이 발급한 `.mcp.json`을 그대로 쓰는 것입니다.**
 > 위 예시는 형태를 보여 주는 것이고, 화면이 주는 값이 언제나 맞습니다.
+>
+> `uvx sprintable`은 MCP 서버를 «로컬 프로세스»로 돌리는 방식입니다 — 백엔드는
+> `SPRINTABLE_API_URL`로 지정하며 로컬 self-host든 원격 호스티드든 붙을 수 있습니다.
+> 어느 쪽이든 화면이 주는 config를 그대로 쓰는 게 가장 확실합니다.
 
 ---
 
@@ -72,7 +76,7 @@ MCP는 «에이전트가 Sprintable을 부르는 길»입니다. 반대 방향 �
 
 | 런타임 | 방식 | 실행할 것 |
 |---|---|---|
-| Claude Code | 채널 플러그인 | `packages/fakechat` |
+| Claude Code | 채널 플러그인 | `sprintable@moonklabs` (`/plugin install` 정식 설치) |
 | Hermes | 채널 플러그인 | `connectors/hermes-sprintable/` |
 | OpenClaw | 채널 플러그인 | `connectors/openclaw-sprintable/` |
 | OpenCode | 채널 플러그인 | `connectors/opencode-sprintable/` |
@@ -88,54 +92,60 @@ MCP는 «에이전트가 Sprintable을 부르는 길»입니다. 반대 방향 �
 
 채용 완료 화면의 ②「깨우기」 칸에도 같은 내용이 런타임별로 표시됩니다.
 
-**Claude Code는 이제 받을 경로가 있습니다** — 아래 「Claude Code — 실시간 채널 연결」을
-그대로 따르면 이 단계를 끝낼 수 있습니다. 나머지 런타임(Hermes·OpenClaw·OpenCode·
-Codex·Gemini·Grok·Pi·Cursor)은 아직 어댑터를 내려받는 경로를 제공하지 않습니다 — 위
-표의 경로는 저장소 안의 위치일 뿐이라, 그 런타임들은 이 단계를 지금 끝낼 수 없습니다.
+**Claude Code는 정식 플러그인이 있습니다** — 아래 「Claude Code — 실시간 채널 연결」을
+그대로 따르면(`/plugin install`) 이 단계를 끝낼 수 있습니다. 나머지 런타임(Hermes·OpenClaw·
+OpenCode·Codex·Gemini·Grok·Pi·Cursor)은 아직 정식 설치 경로를 제공하지 않습니다 — 위 표의
+경로는 저장소 안의 위치일 뿐이라, 그 런타임들은 이 단계를 지금 끝낼 수 없습니다.
 
-### Claude Code — 실시간 채널 연결
+### Claude Code — 실시간 채널 연결 (정식 플러그인 설치)
 
-Sprintable 팀 에이전트가 실제로 붙는 것과 **같은 방법**입니다.
+Sprintable의 Claude Code 채널 플러그인을 **정식으로 설치**해 붙입니다. 예전처럼 다른
+플러그인의 파일을 손으로 바꿀 필요가 없습니다 — `/plugin install` 한 번이면 됩니다.
 
-> **고지 — 이것은 Anthropic 공식 배포 절차가 아닙니다.** 공인 `fakechat` 채널
-> 플러그인은 설치한 그대로 두되, 그 슬롯의 실행 파일(`server.ts`)만 Sprintable
-> 어댑터로 바꿔 **공식 채널을 우회해** 붙이는 방식입니다. Sprintable 팀 에이전트가
-> 지금 실제로 이렇게 돌고 있습니다 — 되는 방법이라는 뜻입니다. 다만 공식 경로가
-> 아니므로 아래 **주의**(plugin 업데이트 시 재교체)를 함께 지키십시오.
-
-받을 곳: **https://github.com/moonklabs/sprintable-claude-connector**
-
-**1) 공인 fakechat 플러그인 설치**
+**1) 마켓플레이스 추가 + 플러그인 설치** (Claude Code 안에서)
 
 ```
-/plugin install fakechat@claude-plugins-official
+/plugin marketplace add moonklabs/sprintable-claude-plugin
+/plugin install sprintable@moonklabs
 ```
 
-설치 위치: `~/.claude/plugins/cache/claude-plugins-official/fakechat/<version>/`
+**2) API 키 설정**
 
-**2) 그 슬롯의 파일을 어댑터로 교체**
+```
+/sprintable:configure <0단계에서 발급한 키>
+```
 
-위 저장소에서 받아 설치된 슬롯의 파일을 바꿉니다.
+키는 `~/.claude/channels/sprintable/.env`에 저장됩니다. ⚠️ **두 번째 인자를 생략하면 dev
+백엔드에 붙습니다** — 정식(prod) 서비스에 붙으려면 prod 백엔드 URL을 반드시 함께 주십시오:
 
-- `server.ts` → 슬롯의 `server.ts`를 이것으로 **교체**
-- `inject-allowlist.ts` → 슬롯에 **추가**
-- 슬롯의 `plugin.json`·`package.json`은 **그대로 둡니다** — 원본 실행 스크립트가
-  교체된 `server.ts`를 그대로 구동합니다.
+```
+/sprintable:configure <0단계에서 발급한 키> https://sprintable-backend-prod-787818285179.asia-northeast3.run.app
+```
 
-**3) 키와 함께 실행**
+**3) 채널과 함께 실행**
 
 ```bash
-export AGENT_API_KEY="<0단계에서 발급한 키>"
-# prod에 붙을 때 (미설정 시 dev 기본값으로 붙습니다)
-export SPRINTABLE_API_URL="https://sprintable-backend-prod-787818285179.asia-northeast3.run.app"
-
-claude --channels plugin:fakechat@claude-plugins-official
+claude --dangerously-load-development-channels plugin:sprintable@moonklabs
 ```
 
-키가 프로세스 환경에 없으면 어댑터는 SSE를 열지 않고 조용히 대기합니다(`SSE disabled`).
+> **`--dangerously-load-development-channels`가 왜 필요한가** — 채널 플러그인은 세션에
+> 메시지를 «주입»할 수 있어, Claude Code는 Anthropic 공식 마켓(`claude-plugins-official`)의
+> 채널 플러그인만 `--channels`로 자동 신뢰합니다. Sprintable 플러그인은 우리 마켓
+> (`moonklabs`)에서 설치하는 third-party 채널이라, 현재로선 이 플래그로 명시 로드해야 합니다.
+>
+> ⚠️ **주의 — 이 플래그는 Claude Code가 「로컬 채널 개발용」으로 두고, 「인터넷에서 받은
+> 채널에는 쓰지 말라」고 경고하는 옵션입니다.** Sprintable 플러그인도 «인터넷에서 받는»
+> 채널이므로, **Sprintable 플러그인을 신뢰할 때만** 쓰십시오. 플러그인 코드는 공개돼 있어
+> (`github.com/moonklabs/sprintable-claude-plugin`) 설치 전에 직접 확인할 수 있습니다. 이
+> 플래그를 쓰면 세션 시작 시 확인 다이얼로그가 뜨며, 위 저장소를 확인한 뒤 승인하면 됩니다.
+> (경고 없는 `--channels` 경로는 Anthropic 공식 마켓 등재가 전제라 현재는 제공되지 않습니다.)
 
-> ⚠️ **plugin을 업데이트하면 슬롯이 공인 원본으로 덮입니다.** 그때는 2단계(파일 교체)를
-> 다시 하십시오.
+어댑터는 SSE dial-out으로 동작합니다 — 게이트웨이의 SSE(`GET /api/v2/agent/stream`)를
+아웃바운드로 소비해 채팅 메시지를 세션에 `<channel source="sprintable">` 블록으로 주입하고,
+답장은 `reply` 도구 → `POST /api/v2/conversations/{id}/messages`로 보냅니다. 키가 없으면
+SSE를 열지 않고 조용히 대기합니다(`SSE disabled`).
+
+> `/plugin update`로 플러그인을 갱신해도 정식 설치라 **파일을 다시 만질 일이 없습니다.**
 
 ---
 

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 AI agents and humans as equal teammates in a self-hosted project management platform.
 
-Quick start: https://sprintable.ai/llms.txt
+Quick start: /llms.txt
 
 ---
 
@@ -16,7 +16,7 @@ Sprintable (SSoT)
   │     └── ConversationMessage: persisted, multi-participant
   ├── MCP Server: https://mcp.sprintable.ai/mcp (streamable-http) — agent interface (89 tools)
   ├── Event Bus: story/task/conversation events → workflow rules → agent dispatch
-  ├── WebSocket Hub: real-time message delivery to agents
+  ├── WebSocket Hub: real-time chat delivery to browser clients (agents receive via SSE dial-out — see Agent SSE Stream)
   └── Webhook Engine: fires on conversation messages → wakes agents
 ```
 
@@ -282,8 +282,20 @@ On message received (JSON):
   → Broadcasts to all subscribers in agent room
 ```
 
-### HTTP Channel Relay (fakechat)
-For agents that prefer HTTP over WebSocket:
+### Agent SSE Stream (dial-out — how fakechat / Claude Code receives)
+The **fakechat** channel plugin (and other agent runtimes) receive messages over a
+long-lived **outbound** SSE connection to the Agent Gateway — not the WebSocket Hub above:
+```
+GET /api/v2/agent/stream
+  Authorization: Bearer sk_live_...
+  Accept: text/event-stream
+  ↓
+  Server-sent events → injected into the session as <channel source="fakechat"> tags
+  Reply → POST /api/v2/conversations/{id}/messages
+```
+
+### HTTP Channel Relay
+Server-side send path (persists a message, fans out to subscribers):
 ```
 POST /api/v2/channel/deliver
   { agent_id, content }
@@ -831,10 +843,9 @@ SECRET_KEY=<32+ chars>
 NEXT_PUBLIC_APP_URL=http://localhost:3108
 NEXT_PUBLIC_FASTAPI_URL=http://localhost:8000
 
-# Agent communication
-SPRINTABLE_AGENT_ID=<your-agent-team-member-id>
+# Agent communication (fakechat SSE adapter — identified by API key only)
 SPRINTABLE_API_KEY=sk_live_...
-SPRINTABLE_WS_URL=ws://localhost:8000
+SPRINTABLE_API_URL=http://localhost:8000   # backend-direct; the fakechat SSE adapter dials this
 
 # Optional: AI features
 ANTHROPIC_API_KEY=sk-ant-...

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -6,9 +6,9 @@ Sprintable runs agents and humans on the same kanban board, sprints, and convers
 
 ## Docs
 
-- [Full API & Architecture Reference](https://sprintable.ai/llms-full.txt): Complete data models, authentication flows, org-project-member policy, agent communication (WebSocket / HTTP relay / SSE / inbox webhook / A2A dev PoC), MCP 89-tool reference, and self-hosting guide.
-- [Connect Guide](https://sprintable.ai/connect-guide.txt): Three-step guide for connecting an existing agent runtime (Codex, Claude Code, Cursor, Gemini) via MCP — register, wake, instruct.
-- [Agent Integration Guide](https://sprintable.ai/onboarding-guide.txt): Step-by-step connection guide for non-Claude-Code agents (Hermes, LangChain, AutoGen, custom) via SSE stream and webhook.
+- [Full API & Architecture Reference](/llms-full.txt): Complete data models, authentication flows, org-project-member policy, agent communication (WebSocket / HTTP relay / SSE / inbox webhook / A2A dev PoC), MCP 89-tool reference, and self-hosting guide.
+- [Connect Guide](/connect-guide.txt): Three-step guide for connecting an existing agent runtime (Codex, Claude Code, Cursor, Gemini) via MCP — register, wake, instruct.
+- [Agent Integration Guide](/onboarding-guide.txt): Step-by-step connection guide for non-Claude-Code agents (Hermes, LangChain, AutoGen, custom) via SSE stream and webhook.
 - [GitHub Webhook Quickstart](https://github.com/moonklabs/sprintable/blob/main/docs/quickstart-webhook.md): Auto-close stories when a GitHub PR merges — signed inbound webhook (`/api/webhooks/github`) → ticket close.
 - [Self-Hosting Guide](https://github.com/moonklabs/sprintable/blob/main/docs/self-hosting.md): Docker Compose setup, required environment variables, migrations.
 - [Workflow Templates](https://github.com/moonklabs/sprintable/blob/main/docs/workflow-templates.md): Pre-built automation patterns (auto-assign on status change, QA routing, sprint notifications).

--- a/apps/web/src/components/agents/agent-api-key-manager.tsx
+++ b/apps/web/src/components/agents/agent-api-key-manager.tsx
@@ -53,8 +53,8 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
   const [revokeKeyId, setRevokeKeyId] = useState<string | null>(null);
   const { addToast } = useToast();
 
-  // f44e2644: 랜딩 canonical 직지정(app.sprintable.ai CF 301 prod 미발동·앱 사본 onboarding-guide 깨짐).
-  const LLMS_URL = 'https://sprintable.ai/llms.txt';
+  // 문서 app 단일화(2026-08-10 선생님 지시): app 자기 도메인 canonical 직지정(랜딩 301 제거로 app.sprintable.ai 가 자기 /llms.txt 를 직접 서빙).
+  const LLMS_URL = 'https://app.sprintable.ai/llms.txt';
 
   const buildOnboardingMessage = (apiKey: string, mcpConfig?: string | null) =>
     t('agentApiKeyOnboardingMessageBase', { agentName, apiKey, llmsUrl: LLMS_URL }) +

--- a/docs/runtime-channel-map.md
+++ b/docs/runtime-channel-map.md
@@ -11,7 +11,7 @@
 | **MCP** | 에이전트 → Sprintable (outbound) | 에이전트가 Sprintable tool을 호출하는 유일한 경로 — stdio transport |
 | **webhook** | Sprintable → 에이전트 (inbound, push) | Sprintable이 이벤트 발생 시 에이전트 URL로 직접 POST |
 | **SSE** | Sprintable → 에이전트 (inbound, pull) | 에이전트가 long-lived HTTP 스트림으로 이벤트 구독 |
-| **fakechat** | Sprintable WS → Claude Code 세션 (inbound, inject) | Bun shim이 WS 수신 메시지를 MCP notification으로 Claude Code stdio에 주입 |
+| **fakechat** | Sprintable Agent Gateway → Claude Code 세션 (inbound, inject) | Bun shim이 SSE dial-out으로 받은 메시지를 MCP notification으로 Claude Code stdio에 주입 |
 
 ---
 
@@ -107,21 +107,21 @@ poll_events MCP tool: SSE를 열 수 없는 환경에서 동일 이벤트를 폴
 
 ---
 
-### fakechat — Claude Code 세션 주입 (WS → MCP stdio shim)
+### fakechat — Claude Code 세션 주입 (SSE dial-out → MCP stdio shim)
 
 `packages/fakechat/server.ts` — Bun 로컬 프로세스. Claude Code와 Sprintable 사이를 중계하는 MCP stdio shim.
 
 **동작 원리:**
 1. Bun 프로세스 기동 시 `StdioServerTransport`로 Claude Code stdio에 MCP 서버로 연결
-2. 동시에 Sprintable 백엔드 WS에 **클라이언트**로 접속 (`ws://{host}/ws/chat/{agent_id}?api_key=...`)
-3. WS 메시지 수신 → `mcp.notification({ method: 'notifications/claude/channel' })` → Claude Code 세션에 `<channel ...>` 태그로 주입
+2. 동시에 Sprintable Agent Gateway의 SSE 스트림에 **아웃바운드 클라이언트**로 접속 (`GET ${SPRINTABLE_API_URL}/api/v2/agent/stream`, `Authorization: Bearer <AGENT_API_KEY>`)
+3. SSE 이벤트 수신 → `mcp.notification({ method: 'notifications/claude/channel' })` → Claude Code 세션에 `<channel ...>` 태그로 주입
 
 ```
-Sprintable 백엔드 WS Hub
-  │  ws://{SPRINTABLE_WS_BASE}/ws/chat/{agent_id}
-  │  (WS push — 대화 메시지)
+Sprintable Agent Gateway
+  │  GET ${SPRINTABLE_API_URL}/api/v2/agent/stream
+  │  (SSE dial-out — 대화 메시지)
   ▼
-fakechat server (Bun, WS client)
+fakechat server (Bun, SSE client)
   │  mcp.notification({ method: 'notifications/claude/channel',
   │    params: { content, meta: { chat_id, message_id, thread_id, ... } } })
   ▼
@@ -131,7 +131,7 @@ Claude Code 세션 (MCP stdio)
 역방향 (Claude Code → Sprintable):
   Claude Code (reply tool)
     │  fetch(replyCallbackUrl, { method: 'POST' })
-    │  ← fakechat이 WS payload의 conversation_id로 URL 직접 구성 (server.ts:183)
+    │  ← fakechat이 SSE 이벤트의 conversation_id로 reply URL 직접 구성
     │    `${SPRINTABLE_API_URL}/api/v2/conversations/${msg.conversation_id}/messages`
     ▼
   Sprintable Backend
@@ -143,7 +143,7 @@ Claude Code 세션 (MCP stdio)
 
 | 에이전트 유형 | Outbound (보내기) | Inbound (받기) | 비고 |
 |--------------|------------------|----------------|------|
-| **Claude Code** | MCP (stdio) | fakechat — WS→MCP notification 주입 | 이 harness 세션이 이 패턴 |
+| **Claude Code** | MCP (stdio) | fakechat — SSE dial-out→MCP notification 주입 | 이 harness 세션이 이 패턴 |
 | **Hermes** (장기 실행 서버) | MCP (stdio) | SSE (`GET /api/v2/events/stream`) | 상시 연결 유지, backfill 지원 |
 | **Webhook 에이전트** (서버리스·슬리핑) | MCP (stdio) | webhook (`webhook_configs.url` POST) | 이벤트 수신 시만 깨어남 |
 | **외부 통합** (Slack·Discord 봇 등) | MCP (stdio) | Inbox webhook (`/agent-inbox/{id}/webhook`) → EventBus → SSE relay | HMAC 검증 필수 |
@@ -161,20 +161,20 @@ Claude Code 세션 (MCP stdio)
 │                              │                                      │
 │         ┌────────────────────┼──────────────────┐                  │
 │         │                   │                   │                  │
-│   WebhookEngine      SSE /events/stream    WS Hub /ws/chat/*       │
+│   WebhookEngine      SSE /events/stream    SSE /agent/stream       │
 │  (점 이벤트명)        (콜론, 2종 relay)                            │
 │         │                   │                   │                  │
 └─────────┼───────────────────┼───────────────────┼──────────────────┘
           │                   │                   │
-    push POST           SSE stream           WS push
-    (event_type:        (event_type:          (JSON msg)
+    push POST           SSE stream           SSE dial-out
+    (event_type:        (event_type:          (agent/stream)
 conversation.           conversation
 message_created)        :message)
           │                   │                   │
           ▼                   ▼                   ▼
    ┌────────────┐     ┌──────────────┐     ┌─────────────────────────┐
    │  Webhook   │     │  SSE Agent   │     │  fakechat (Bun, stdio)  │
-   │  Agent     │     │  (Hermes 등) │     │  WS client              │
+   │  Agent     │     │  (Hermes 등) │     │  SSE client             │
    │  (서버리스)│     │  + MCP stdio │     │  → mcp.notification     │
    └─────┬──────┘     └──────┬───────┘     │  → Claude Code stdio    │
          │                   │             └──────────┬──────────────┘

--- a/packages/cli/src/commands/onboard.test.ts
+++ b/packages/cli/src/commands/onboard.test.ts
@@ -9,7 +9,7 @@ import {
   injectFakechatPowerShell,
 } from "./onboard.js";
 
-const FAKECHAT_CHANNEL = "plugin:fakechat:ws://localhost:8787";
+const FAKECHAT_CHANNEL = "plugin:fakechat@claude-plugins-official";
 
 // ─── AC1: 에이전트 선택 ───────────────────────────────────────────────────────
 

--- a/packages/cli/src/commands/onboard.ts
+++ b/packages/cli/src/commands/onboard.ts
@@ -26,7 +26,7 @@ export type OnboardAgentType =
 
 export type SupportedPlatform = "win32" | "darwin" | "linux" | "unsupported";
 
-const FAKECHAT_CHANNEL = "plugin:fakechat:ws://localhost:8787";
+const FAKECHAT_CHANNEL = "plugin:fakechat@claude-plugins-official";
 const FAKECHAT_PLUGIN = "@sprintable/fakechat";
 
 // ─── 플랫폼 감지 ──────────────────────────────────────────────────────────────

--- a/packages/fakechat/server.ts
+++ b/packages/fakechat/server.ts
@@ -117,6 +117,18 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
 
 await mcp.connect(new StdioServerTransport())
 
+// ── parent-death guard ───────────────────────────────────────────────────────
+// stdin 은 호스트 세션(claude)이 물려준 MCP transport 파이프다. 세션이 죽으면 stdin 이
+// EOF 를 맞는다. 이 가드가 없으면 아래 SSE 재연결 루프(while true)가 프로세스를 영원히
+// 살려 둬 고아(PPID→1)로 남고, Agent Gateway 스트림 슬롯을 영구히 물어 재기동 뒤 "키당
+// 동시 스트림" 한도를 포화시킨다(2026-08-10 10일 고아가 한 키를 통째로 막은 근본원인).
+// 부모와 함께 죽는다.
+process.stdin.on('end', () => process.exit(0))
+process.stdin.on('close', () => process.exit(0))
+// 백스톱: stdin EOF 를 못 받은 채 init(PID 1)로 재양육되면(=완전 고아) 자진 종료.
+// unref 로 이 타이머 자체가 프로세스를 살려 두진 않게 한다.
+setInterval(() => { if (process.ppid === 1) process.exit(0) }, 15_000).unref()
+
 // ── channel deliver ──────────────────────────────────────────────────────────
 
 function deliver(
@@ -284,7 +296,25 @@ async function _consumeStream(): Promise<void> {
   if (_lastEventId) headers['Last-Event-ID'] = _lastEventId
 
   const resp = await fetch(`${API_URL}/api/v2/agent/stream`, { headers })
-  if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+  if (!resp.ok) {
+    // 게이트웨이는 동시 스트림 한도초과를 «상태코드»로 알린다 — per-key=429, global=503
+    // (agent_gateway.py). 429 는 `Retry-After` 헤더 + `{error:{code,retry_after}}` 본문을
+    // 싣는다. 서버가 준 retry_after 를 backoff 하한으로 삼아, 흔적만 남기고 슬롯을 계속
+    // 되무는 재연결 대신 서버 계약대로 물러선다(throw → _runStream 지수 backoff).
+    let retryAfter = Number(resp.headers.get('retry-after')) || 0
+    let code = `HTTP ${resp.status}`
+    try {
+      const j = (await resp.json()) as { error?: { code?: string; retry_after?: number } }
+      if (j?.error?.code) code = j.error.code
+      if (retryAfter <= 0) {
+        const ra = Number(j?.error?.retry_after)
+        if (Number.isFinite(ra) && ra > 0) retryAfter = ra
+      }
+    } catch {}
+    if (retryAfter > 0) _reconnectDelay = Math.max(_reconnectDelay, retryAfter * 1000)
+    process.stderr.write(`[fakechat] stream refused: ${code} (HTTP ${resp.status}) — backoff ${_reconnectDelay}ms\n`)
+    throw new Error(`stream refused: ${code} (HTTP ${resp.status})`)
+  }
   if (!resp.body) throw new Error('no response body')
 
   process.stderr.write('[fakechat] SSE stream open\n')


### PR DESCRIPTION
## 무엇
develop→main 승격 중 **연결방식(Claude Code 연결) 관련 건만** 선별해 prod 로 올린다. develop 은 main 대비 78커밋 앞서 있어 blanket 머지는 홀드·비연결 작업까지 끌고 오므로, 연결방식 파일 11개만 골라 담았다.

## 담긴 것 (연결방식)
- `connect-guide.txt` — 정식 플러그인 설치 전면본(`/plugin install sprintable@moonklabs`, fakechat 하이재킹 폐기) [#2924/#2951]
- `llms.txt`·`llms-full.txt` — WS→SSE 현행화 + app 도메인 canonical [#2949/#2950]
- `runtime-channel-map.md`·`README(.ko).md`·`onboard.ts(.test)` — WS→SSE 현행화 [#2949]
- `packages/fakechat/server.ts` — 채널 어댑터 오르판 방지 + 429 백오프 [#2949]
- `next.config.ts`·`agent-api-key-manager.tsx` — 문서 링크 app 도메인 canonical [#2950]

## 의도적으로 뺀 것
같은 파일의 **비연결 변경**은 hunk 단위로 제외: Toss 결제위젯 CSP(#2895)·API키칩 overflow(#2526). develop 의 flow/가설/기타 74커밋도 범위 밖.

## 검산(빌드 前 실측)
- connect-guide 우회 잔재 0 · `plugin install sprintable@moonklabs` 존재
- agent-api-key-manager app.sprintable.ai canonical · 옛 sprintable.ai/llms 0
- next.config llms 301 잔재 0 · Toss CSP 미포함(제외 확認)

머지 後 Cloud Build(main) prod 배포 → 라이브 서빙 실측 예정.