### PR TITLE
feat(activation): typed-activation 스파인 + hermes 헤더 주입(Y·flag-gated)

### DIFF
--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -284,6 +284,7 @@ async def _fetch_events(
                 e.source_entity_type,
                 e.source_entity_id::text AS source_entity_id,
                 e.sender_id::text     AS sender_id,
+                e.recipient_id::text  AS recipient_id,
                 e.payload,
                 e.created_at,
                 e.project_id::text    AS project_id,
@@ -331,6 +332,12 @@ def _row_to_payload(row: object) -> dict:
         "org_id": getattr(row, "org_id", None),
         "conversation_title": getattr(row, "conversation_title", None),
         "sender_name": getattr(row, "sender_name", None),
+        # E-ACTIVATION S1: typed-activation top-level 노출(wake-rescan 경로도 direct-push와 동형).
+        # audience/message_kind/expects_response 는 저장된 event payload(_msg_payload) 안에서 온다.
+        "audience": (_payload or {}).get("audience"),
+        "message_kind": (_payload or {}).get("message_kind"),
+        "expects_response": (_payload or {}).get("expects_response"),
+        "recipient_id": getattr(row, "recipient_id", None),
     }
 
 

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -441,7 +441,41 @@ def _msg_payload(
     # 모르는 SSE/write-response 경로는 넘기지 않아 키 자체가 없다(기존 references 규율 재사용).
     if blocked_sender_ids is not None:
         payload["is_blocked_sender"] = bool(sender and sender.id in blocked_sender_ids)
+    # E-ACTIVATION S1: typed activation 필드 top-level 노출(없으면 None). connector 헤더 주입용.
+    payload.update(_activation_payload(msg))
     return payload
+
+
+_ACTIVATION_KINDS = frozenset({"request", "handoff", "result", "ack"})
+
+
+def _activation_meta(req: "SendMessageRequest") -> dict | None:
+    """E-ACTIVATION S1: typed-activation 필드 → msg_metadata['activation']. 없으면 None(완전 additive).
+    audience는 빈/None이면 저장 안 함(=all·현행) — 서버가 org 필터한 값을 받는다(호출부).
+    message_kind는 4개 enum만 수용(개행/자유텍스트 헤더 오염 차단 — 까디르 QA)."""
+    act: dict = {}
+    if req.audience:
+        act["audience"] = [str(a) for a in req.audience]
+    if req.message_kind in _ACTIVATION_KINDS:
+        act["kind"] = req.message_kind
+    if req.expects_response is not None:
+        act["expects_response"] = bool(req.expects_response)
+    return {"activation": act} if act else None
+
+
+def _activation_payload(msg: "ConversationMessage") -> dict:
+    """msg_metadata['activation'] → payload top-level(audience/message_kind/expects_response).
+    ⚠️ __dict__ 로 «이미 로드된 값만» 읽는다 — `getattr(msg, 'msg_metadata')`는 미로드 컬럼에
+    async lazy-load(refresh)를 유발해 sync _msg_payload 안에서 greenlet_spawn 크래시(realdb GET/list).
+    __dict__.get = 로드 안 됐으면 None·SimpleNamespace fake 안전·dispatch 경로는 방금 set해 값 있음."""
+    meta = (getattr(msg, "__dict__", None) or {}).get("msg_metadata")
+    act = meta.get("activation") if isinstance(meta, dict) else None
+    act = act or {}
+    return {
+        "audience": act.get("audience"),
+        "message_kind": act.get("kind"),
+        "expects_response": act.get("expects_response"),
+    }
 
 
 async def _viewer_blocked_sender_ids(auth: AuthContext, org_id: uuid.UUID, db: AsyncSession) -> set[uuid.UUID]:
@@ -548,7 +582,7 @@ async def _dispatch_conversation_event(
     from app.services.activity_stream import extract_activities_best_effort
     await extract_activities_best_effort(db, [event.id for _, event in events_to_push])
     return [(pid_str, {"event_id": str(event.id), "event_type": "conversation.message_created", **payload,
-                       "recipient_seq": event.recipient_seq})
+                       "recipient_seq": event.recipient_seq, "recipient_id": pid_str})
             for pid_str, event in events_to_push]
 
 
@@ -610,7 +644,11 @@ async def _dispatch_mention_events(
     # L1 BE-3: mention fan-out N행 → activity_events 1행 수렴(best-effort·delivery 무영향).
     from app.services.activity_stream import extract_activities_best_effort
     await extract_activities_best_effort(db, [event.id for _, event in events_to_push])
-    return [(pid_str, {"event_id": str(event.id), "event_type": "conversation:mention", **payload})
+    # E-ACTIVATION S1(까디르 QA blocker): 멘션 반환도 recipient_seq/recipient_id를 실어야
+    # direct-push↔wake-rescan 활성화 판정이 동형이 된다(안 실으면 대상 본인한테도 addressed_to_you=no로 새고
+    # 리플레이 시 뒤집힘 — 이 기능이 막으려던 과소/과잉참여를 오히려 만든다).
+    return [(pid_str, {"event_id": str(event.id), "event_type": "conversation:mention", **payload,
+                       "recipient_seq": event.recipient_seq, "recipient_id": pid_str})
             for pid_str, event in events_to_push]
 
 
@@ -842,6 +880,12 @@ class SendMessageRequest(BaseModel):
     mentioned_ids: list[uuid.UUID] = []
     thread_id: uuid.UUID | None = None
     attachments: list[MessageAttachment] = []
+    # E-ACTIVATION S1 (typed activation · additive): 발신자가 «응답 의무»를 구조로 선언.
+    # audience=응답 대상 member_ids(빈/None=all·현행 유지·서버가 org 필터) · message_kind=의미유형
+    # (라우팅 event_type과 별개인 새 의미 필드·4개 enum만 저장) · expects_response. connector가 헤더로 주입(Y).
+    audience: list[uuid.UUID] | None = None
+    message_kind: str | None = None  # request | handoff | result | ack
+    expects_response: bool | None = None
 
     @field_validator("attachments")
     @classmethod
@@ -1891,6 +1935,13 @@ async def send_message(
                 _seen.add(mid)
                 valid_mentioned_ids.append(mid)
 
+    # E-ACTIVATION S1(까디르 QA): audience 도 cross-org/삭제 id 차단 — mentioned_ids 와 동형 org 필터.
+    # 안 하면 삭제·타조직 member_id 를 audience 에 넣어 «실 수신자 전원이 addressed=no» 메시지를 만들 수 있다.
+    # 전량 필터돼 []가 되면 어댑터에서 `not audience`=True → all-addressed(현행)로 안전 degrade.
+    if body.audience:
+        _aud_ok = await filter_org_member_ids(set(body.audience), org_id, db)
+        body.audience = [a for a in body.audience if a in _aud_ok]
+
     # CB-S2: DM + 비참여자 멘션 → 자동 그룹 conversation fork (AC1, AC2)
     fork_info: dict | None = None
     if conv.type == "dm" and valid_mentioned_ids:
@@ -1978,6 +2029,8 @@ async def send_message(
         # E-FILE S1: 첨부 메타(URL+name+content_type+size)를 0093 attachments JSONB에 저장.
         # S7: client 제공 asset_id 는 strip(서버 권위·drift 방지·까심)·아래 sync url_map 으로만 역기입.
         attachments=[{**a.model_dump(), "asset_id": None} for a in body.attachments],
+        # E-ACTIVATION S1: typed-activation(audience/kind/expects_response) → metadata(additive·마이그레이션 불요).
+        msg_metadata=_activation_meta(body),
     )
     db.add(msg)
 

--- a/connectors/hermes-sprintable-prod/adapter.py
+++ b/connectors/hermes-sprintable-prod/adapter.py
@@ -288,6 +288,27 @@ class SprintableProdAdapter(BasePlatformAdapter):
             user_id=sender_id,
             user_name=sender_name,
         )
+        # E-ACTIVATION S1 (Y · flag-gated · dev 어댑터와 동기): typed-activation 메타를 구조화 헤더로 주입.
+        # 기본 OFF → 라이브 fleet 무영향. SPRINTABLE_ACTIVATION_HEADER=1 인 인스턴스만 헤더를 본다.
+        if os.getenv("SPRINTABLE_ACTIVATION_HEADER") == "1":
+            audience = data.get("audience") or payload.get("audience")
+            message_kind = data.get("message_kind") or payload.get("message_kind")
+            expects_response = data.get("expects_response")
+            if expects_response is None:
+                expects_response = payload.get("expects_response")
+            recipient_id = data.get("recipient_id") or payload.get("recipient_id")
+            addressed = (not audience) or (
+                recipient_id is not None and str(recipient_id) in {str(a) for a in audience}
+            )
+            header = (
+                f"[sprintable] from={sender_name}"
+                f" · audience={'all' if not audience else 'targeted'}"
+                f" · addressed_to_you={'yes' if addressed else 'no'}"
+                f" · kind={message_kind or '-'}"
+                f" · expects_response={'-' if expects_response is None else str(bool(expects_response)).lower()}"
+            )
+            content = f"{header}\n{content}" if content else header
+
         message_event = MessageEvent(
             text=content,
             message_type=MessageType.TEXT,

--- a/connectors/hermes-sprintable/adapter.py
+++ b/connectors/hermes-sprintable/adapter.py
@@ -354,6 +354,28 @@ class SprintableAdapter(BasePlatformAdapter):
         if attachment_notes:
             content = "\n".join(attachment_notes + ([content] if content else []))
 
+        # E-ACTIVATION S1 (Y · flag-gated): typed-activation 메타를 «구조화 헤더»로 주입한다.
+        # 기본 OFF → 라이브 fleet 무영향. SPRINTABLE_ACTIVATION_HEADER=1 인 인스턴스만 헤더를 본다.
+        # 헤더가 「너를 향한 메시지인지·응답 요구인지」를 명시 → 비지정 에이전트가 난입 안 하도록.
+        if os.getenv("SPRINTABLE_ACTIVATION_HEADER") == "1":
+            audience = data.get("audience") or payload.get("audience")
+            message_kind = data.get("message_kind") or payload.get("message_kind")
+            expects_response = data.get("expects_response")
+            if expects_response is None:
+                expects_response = payload.get("expects_response")
+            recipient_id = data.get("recipient_id") or payload.get("recipient_id")
+            addressed = (not audience) or (
+                recipient_id is not None and str(recipient_id) in {str(a) for a in audience}
+            )
+            header = (
+                f"[sprintable] from={sender_name}"
+                f" · audience={'all' if not audience else 'targeted'}"
+                f" · addressed_to_you={'yes' if addressed else 'no'}"
+                f" · kind={message_kind or '-'}"
+                f" · expects_response={'-' if expects_response is None else str(bool(expects_response)).lower()}"
+            )
+            content = f"{header}\n{content}" if content else header
+
         message_event = MessageEvent(
             text=content,
             message_type=MessageType.PHOTO if media_urls else MessageType.TEXT,


### PR DESCRIPTION
## 목표
에이전트 간 무한 대화 종결 설계([doc](https://app.sprintable.ai))의 **Y-first 슬라이스**. 발신자가 «응답 의무»를 구조로 선언(`audience`/`message_kind`/`expects_response`)하고, connector가 이를 «구조화 헤더»로 주입해 **비지정 에이전트가 그룹챗에 난입하지 않도록** 한다. 측정·파일럿 = hermes(선생님 지정).

## 변경 (전부 additive · 마이그레이션 불요)
**백엔드**
- `SendMessageRequest`: `audience`(응답 대상 member_ids·빈/None=all·현행 유지)·`message_kind`(request|handoff|result|ack)·`expects_response` 필드 (default None)
- `send_message`: `msg_metadata['activation']`에 저장(기존 JSONB 재사용·`_activation_meta`)
- `_msg_payload`/`_row_to_payload`: activation + `recipient_id` payload top-level 노출 (direct-push + wake-rescan 대칭)
- `_fetch_events` SELECT에 `recipient_id` 컬럼

**hermes 어댑터 (dev+prod 사본 둘 다 동기)**
- `SPRINTABLE_ACTIVATION_HEADER=1` 일 때만 헤더 prepend — **기본 OFF → 라이브 fleet 무영향**
- 헤더: `[sprintable] from · audience(all|targeted) · addressed_to_you(yes|no) · kind · expects_response`

## 안전
- 신 필드 전부 optional·default None → 기존 호출자·payload 소비자 무영향
- 행동 변화(헤더)는 **env 플래그 뒤** → 플래그 없는 라이브 fleet은 오늘과 동일
- 이름 함정: 라우팅 `event_type`(dispatched…)과 별개인 «새 의미 필드»

## 검증
- byte-compile 4파일 OK · addressed/header 순수 로직 셀프체크(targeted→비대상 = addressed_to_you=no 확認)
- 머지·dev 배포 後: dev에서 audience 지정 메시지 → 비지정 hermes 헤더가 addressed_to_you=no 인지 라이브 실측 + 과잉참여 before/after 측정