### PR TITLE
feat(activation): Phase 2 X — system-side non-invoke (관찰=턴안열기) [flag-gated]

### DIFF
--- a/connectors/hermes-sprintable-prod/adapter.py
+++ b/connectors/hermes-sprintable-prod/adapter.py
@@ -72,6 +72,51 @@ try:  # pragma: no cover - prefer the canonical SDK copy when it is on the path
 except ImportError:
     pass
 
+# ── E-ACTIVATION Phase 2 (X · system-side non-invoke · dev 어댑터와 동기) ────────
+# 관찰(비지정)이면 모델을 «아예 안 깨우고» 버퍼에 쌓아 다음 활성화 때 hydrate 한다.
+# 설계문서 agent-agent-loop-termination-research §3·§4·§7. 게이트는
+# SPRINTABLE_NONINVOKE_OBSERVATIONS=1 일 때만 — 기본 OFF = 라이브 fleet 무영향.
+# 분류 로직은 SDK(sprintable_sse.classify_activation)가 정본. vendored 사본은 fresh
+# single-folder install(SDK 미임포트) 대비 — SDK 가 path 에 있으면 그 사본을 선호.
+NONINVOKE_FLAG_ENV = "SPRINTABLE_NONINVOKE_OBSERVATIONS"
+OBS_BUFFER_MAX = 20
+OBS_ENTRY_MAXLEN = 500
+
+
+def classify_activation(data, payload):
+    """이벤트를 «관찰 vs 호출»로 분류 → (audience_targeted, addressed, message_kind, expects_response).
+    audience 미지정=broadcast → addressed=True(현행 보존). audience 지정 & recipient_id ∈ audience →
+    addressed=True(나를 호출). 그 외 → addressed=False(관찰). vendored copy — SDK 가 정본."""
+    audience = data.get("audience") or payload.get("audience")
+    message_kind = data.get("message_kind") or payload.get("message_kind")
+    expects_response = data.get("expects_response")
+    if expects_response is None:
+        expects_response = payload.get("expects_response")
+    recipient_id = data.get("recipient_id") or payload.get("recipient_id")
+    audience_targeted = bool(audience)
+    addressed = (not audience_targeted) or (
+        recipient_id is not None and str(recipient_id) in {str(a) for a in audience}
+    )
+    return audience_targeted, addressed, message_kind, expects_response
+
+
+def render_observation_block(entries) -> str:
+    """버퍼된 관찰들을 다음 활성화 턴에 붙일 context 블록으로 렌더."""
+    lines = "\n".join(f"- {e}" for e in entries)
+    return (
+        f"[읽음 · 당신이 대상이 아니어서 응답하지 않은 메시지 {len(entries)}건]\n"
+        f"{lines}\n[/읽음]"
+    )
+
+
+try:  # pragma: no cover - prefer the canonical SDK copy when it is on the path
+    from sprintable_sse import (  # noqa: F811
+        classify_activation,
+        render_observation_block,
+    )
+except ImportError:
+    pass
+
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -124,6 +169,23 @@ class SprintableProdAdapter(BasePlatformAdapter):
         self._last_event_id: str = ""       # SSE Last-Event-ID for reconnect
         self._last_acked: int = 0           # highest seq acked
         self._seen: Dict[str, float] = {}   # event_id -> ts (dedup)
+        # E-ACTIVATION Phase 2 (X): conversation_id -> 관찰 버퍼(다음 활성화 때 hydrate).
+        self._obs_buffer: Dict[str, list] = {}
+
+    # -- E-ACTIVATION Phase 2 (X) buffer helpers ----------------------------
+
+    def _buffer_observation(self, conversation_id: str, sender_name: str, content: str) -> None:
+        buf = self._obs_buffer.setdefault(conversation_id, [])
+        buf.append(f"{sender_name}: {content}"[:OBS_ENTRY_MAXLEN])
+        if len(buf) > OBS_BUFFER_MAX:
+            del buf[:-OBS_BUFFER_MAX]
+
+    def _flush_observations(self, conversation_id: str, content: str) -> str:
+        buf = self._obs_buffer.pop(conversation_id, None)
+        if not buf:
+            return content
+        block = render_observation_block(buf)
+        return f"{block}\n{content}" if content else block
 
     # -- lifecycle ----------------------------------------------------------
 
@@ -273,6 +335,18 @@ class SprintableProdAdapter(BasePlatformAdapter):
         sender_id = sender.get("id") or data.get("sender_id") or "sprintable"
         sender_name = sender.get("name") or sender_id
 
+        # E-ACTIVATION Phase 2 (X · flag-gated · dev 어댑터와 동기): 관찰 vs 호출 분류.
+        audience_targeted, addressed, message_kind, expects_response = classify_activation(data, payload)
+        noninvoke = os.getenv(NONINVOKE_FLAG_ENV) == "1"
+        if noninvoke and not addressed:
+            # 관찰 → 모델을 «아예 안 깨운다». 버퍼에 쌓아 다음 활성화 때 hydrate + seq ack.
+            self._buffer_observation(conversation_id, sender_name, content)
+            logger.info("[%s] observation (non-invoke) seq=%s conv=%s from=%s",
+                        self.name, seq, conversation_id, sender_name)
+            if seq:
+                await self._send_ack(seq)
+            return
+
         # AC2: model a Sprintable conversation as a shared Hermes *thread*, not a
         # regular group chat.  Hermes splits regular groups into per-sender
         # sessions when ``group_sessions_per_user`` is enabled; a Sprintable
@@ -288,21 +362,17 @@ class SprintableProdAdapter(BasePlatformAdapter):
             user_id=sender_id,
             user_name=sender_name,
         )
+        # E-ACTIVATION Phase 2 (X): 이 대화에 쌓인 관찰을 활성화 턴 context 로 hydrate("다 봄" 보존).
+        if noninvoke:
+            content = self._flush_observations(conversation_id, content)
+
         # E-ACTIVATION S1 (Y · flag-gated · dev 어댑터와 동기): typed-activation 메타를 구조화 헤더로 주입.
         # 기본 OFF → 라이브 fleet 무영향. SPRINTABLE_ACTIVATION_HEADER=1 인 인스턴스만 헤더를 본다.
+        # 분류는 위 classify_activation 결과 재사용(X 게이트와 단일 출처).
         if os.getenv("SPRINTABLE_ACTIVATION_HEADER") == "1":
-            audience = data.get("audience") or payload.get("audience")
-            message_kind = data.get("message_kind") or payload.get("message_kind")
-            expects_response = data.get("expects_response")
-            if expects_response is None:
-                expects_response = payload.get("expects_response")
-            recipient_id = data.get("recipient_id") or payload.get("recipient_id")
-            addressed = (not audience) or (
-                recipient_id is not None and str(recipient_id) in {str(a) for a in audience}
-            )
             header = (
                 f"[sprintable] from={sender_name}"
-                f" · audience={'all' if not audience else 'targeted'}"
+                f" · audience={'all' if not audience_targeted else 'targeted'}"
                 f" · addressed_to_you={'yes' if addressed else 'no'}"
                 f" · kind={message_kind or '-'}"
                 f" · expects_response={'-' if expects_response is None else str(bool(expects_response)).lower()}"

--- a/connectors/hermes-sprintable/adapter.py
+++ b/connectors/hermes-sprintable/adapter.py
@@ -68,6 +68,51 @@ try:  # pragma: no cover - prefer the canonical SDK copy when it is on the path
 except ImportError:
     pass
 
+# ── E-ACTIVATION Phase 2 (X · system-side non-invoke) ─────────────────────────
+# 관찰(비지정)이면 모델을 «아예 안 깨우고» 버퍼에 쌓아 다음 활성화 때 hydrate 한다.
+# 설계문서 agent-agent-loop-termination-research §3·§4·§7. 게이트는
+# SPRINTABLE_NONINVOKE_OBSERVATIONS=1 일 때만 — 기본 OFF = 라이브 fleet 무영향.
+# 분류 로직은 SDK(sprintable_sse.classify_activation)가 정본. 단일-폴더 fresh install
+# (SDK 미임포트) 대비 vendored 사본을 두고, SDK 가 path 에 있으면 그 사본을 선호(drift 0).
+NONINVOKE_FLAG_ENV = "SPRINTABLE_NONINVOKE_OBSERVATIONS"
+OBS_BUFFER_MAX = 20
+OBS_ENTRY_MAXLEN = 500
+
+
+def classify_activation(data, payload):
+    """이벤트를 «관찰 vs 호출»로 분류 → (audience_targeted, addressed, message_kind, expects_response).
+    audience 미지정=broadcast → addressed=True(현행 보존). audience 지정 & recipient_id ∈ audience →
+    addressed=True(나를 호출). 그 외 → addressed=False(관찰). vendored copy — SDK 가 정본."""
+    audience = data.get("audience") or payload.get("audience")
+    message_kind = data.get("message_kind") or payload.get("message_kind")
+    expects_response = data.get("expects_response")
+    if expects_response is None:
+        expects_response = payload.get("expects_response")
+    recipient_id = data.get("recipient_id") or payload.get("recipient_id")
+    audience_targeted = bool(audience)
+    addressed = (not audience_targeted) or (
+        recipient_id is not None and str(recipient_id) in {str(a) for a in audience}
+    )
+    return audience_targeted, addressed, message_kind, expects_response
+
+
+def render_observation_block(entries) -> str:
+    """버퍼된 관찰들을 다음 활성화 턴에 붙일 context 블록으로 렌더."""
+    lines = "\n".join(f"- {e}" for e in entries)
+    return (
+        f"[읽음 · 당신이 대상이 아니어서 응답하지 않은 메시지 {len(entries)}건]\n"
+        f"{lines}\n[/읽음]"
+    )
+
+
+try:  # pragma: no cover - prefer the canonical SDK copy when it is on the path
+    from sprintable_sse import (  # noqa: F811
+        classify_activation,
+        render_observation_block,
+    )
+except ImportError:
+    pass
+
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -144,6 +189,23 @@ class SprintableAdapter(BasePlatformAdapter):
         self._last_event_id: str = ""       # SSE Last-Event-ID for reconnect
         self._last_acked: int = 0           # highest seq acked
         self._seen: Dict[str, float] = {}   # event_id -> ts (dedup)
+        # E-ACTIVATION Phase 2 (X): conversation_id -> 관찰 버퍼(다음 활성화 때 hydrate).
+        self._obs_buffer: Dict[str, list] = {}
+
+    # -- E-ACTIVATION Phase 2 (X) buffer helpers ----------------------------
+
+    def _buffer_observation(self, conversation_id: str, sender_name: str, content: str) -> None:
+        buf = self._obs_buffer.setdefault(conversation_id, [])
+        buf.append(f"{sender_name}: {content}"[:OBS_ENTRY_MAXLEN])
+        if len(buf) > OBS_BUFFER_MAX:
+            del buf[:-OBS_BUFFER_MAX]
+
+    def _flush_observations(self, conversation_id: str, content: str) -> str:
+        buf = self._obs_buffer.pop(conversation_id, None)
+        if not buf:
+            return content
+        block = render_observation_block(buf)
+        return f"{block}\n{content}" if content else block
 
     # -- lifecycle ----------------------------------------------------------
 
@@ -335,6 +397,19 @@ class SprintableAdapter(BasePlatformAdapter):
         sender_id = sender.get("id") or data.get("sender_id") or "sprintable"
         sender_name = sender.get("name") or sender_id
 
+        # E-ACTIVATION Phase 2 (X · flag-gated): 관찰 vs 호출 분류.
+        audience_targeted, addressed, message_kind, expects_response = classify_activation(data, payload)
+        noninvoke = os.getenv(NONINVOKE_FLAG_ENV) == "1"
+        if noninvoke and not addressed:
+            # 관찰 → 모델을 «아예 안 깨운다». 버퍼에 쌓아 다음 활성화 때 hydrate + seq ack
+            # (재범람 방지). handle_message 를 부르지 않으므로 이 turn 은 열리지 않는다.
+            self._buffer_observation(conversation_id, sender_name, content)
+            logger.info("[%s] observation (non-invoke) seq=%s conv=%s from=%s",
+                        self.name, seq, conversation_id, sender_name)
+            if seq:
+                await self._send_ack(seq)
+            return
+
         # AC2: model a Sprintable conversation as a shared Hermes *thread*, not a
         # regular group chat.  Hermes splits regular groups into per-sender
         # sessions when ``group_sessions_per_user`` is enabled; a Sprintable
@@ -354,22 +429,18 @@ class SprintableAdapter(BasePlatformAdapter):
         if attachment_notes:
             content = "\n".join(attachment_notes + ([content] if content else []))
 
+        # E-ACTIVATION Phase 2 (X): 이 대화에 쌓인 관찰을 활성화 턴 context 로 hydrate("다 봄" 보존).
+        if noninvoke:
+            content = self._flush_observations(conversation_id, content)
+
         # E-ACTIVATION S1 (Y · flag-gated): typed-activation 메타를 «구조화 헤더»로 주입한다.
         # 기본 OFF → 라이브 fleet 무영향. SPRINTABLE_ACTIVATION_HEADER=1 인 인스턴스만 헤더를 본다.
         # 헤더가 「너를 향한 메시지인지·응답 요구인지」를 명시 → 비지정 에이전트가 난입 안 하도록.
+        # 분류는 위 classify_activation 결과 재사용(X 게이트와 단일 출처).
         if os.getenv("SPRINTABLE_ACTIVATION_HEADER") == "1":
-            audience = data.get("audience") or payload.get("audience")
-            message_kind = data.get("message_kind") or payload.get("message_kind")
-            expects_response = data.get("expects_response")
-            if expects_response is None:
-                expects_response = payload.get("expects_response")
-            recipient_id = data.get("recipient_id") or payload.get("recipient_id")
-            addressed = (not audience) or (
-                recipient_id is not None and str(recipient_id) in {str(a) for a in audience}
-            )
             header = (
                 f"[sprintable] from={sender_name}"
-                f" · audience={'all' if not audience else 'targeted'}"
+                f" · audience={'all' if not audience_targeted else 'targeted'}"
                 f" · addressed_to_you={'yes' if addressed else 'no'}"
                 f" · kind={message_kind or '-'}"
                 f" · expects_response={'-' if expects_response is None else str(bool(expects_response)).lower()}"

--- a/connectors/sdk/sprintable_sse.py
+++ b/connectors/sdk/sprintable_sse.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -59,6 +60,60 @@ INJECTABLE_EVENT_TYPES = frozenset({
     "handoff",
 })
 
+# ── E-ACTIVATION Phase 2 (X · system-side non-invoke) ─────────────────────────
+# 배달을 «관찰(observation)»과 «호출(activation)»로 가른다. 활성화 프로토콜(설계문서
+# agent-agent-loop-termination-research §3·§4·§7)의 X: 「관찰」로 온 메시지는 모델을
+# «아예 안 돌린다» → 비지정 에이전트가 난입할 «기회 자체»가 없다(자제 의존 아님).
+#
+# 판정(모델 불요·결정적):
+#   audience 미지정(broadcast) → addressed=True  (전체 대상 = 현행 보존)
+#   audience 지정 & 내 recipient_id ∈ audience → addressed=True  (나를 호출)
+#   audience 지정 & 내 recipient_id ∉ audience → addressed=False (관찰 = non-invoke)
+# 백엔드가 이벤트에 audience/recipient_id 를 실어 보낸다(Y 스파인 #2953). recipient_id 는
+# per-recipient fan-out 이라 «이 스트림 소유자(나)»다 — 별도 신원 주입 불필요.
+#
+# 순수 드롭이면 설계문서 §6-B(강등된 problem B)로 회귀한다("안 깨운 메시지는 hydrate
+# 안 해 다음에도 못 봄"). 그래서 X 는 관찰을 «버퍼»에 쌓아 두고 다음 «활성화» 턴에
+# context 로 hydrate 한다("다 봄"은 보존, "즉답 강제"만 제거). seq 는 ack 해 backfill
+# 재범람(#2375)을 막는다.
+#
+# 게이트는 SPRINTABLE_NONINVOKE_OBSERVATIONS=1 일 때만 작동 — 기본 OFF = 라이브 fleet
+# 무영향(모든 이벤트 현행대로 주입). Y(SPRINTABLE_ACTIVATION_HEADER)와 독립·조합 가능.
+NONINVOKE_FLAG_ENV = "SPRINTABLE_NONINVOKE_OBSERVATIONS"
+OBS_BUFFER_MAX = 20          # 대화별 버퍼 최대 항목(오래된 것부터 폐기)
+OBS_ENTRY_MAXLEN = 500       # 항목 1건 최대 길이
+
+
+def classify_activation(
+    data: dict[str, Any], payload: dict[str, Any]
+) -> tuple[bool, bool, Any, Any]:
+    """이벤트를 «관찰 vs 호출»로 분류. 단일 출처(Y 헤더 + X 게이트가 공유).
+
+    Returns ``(audience_targeted, addressed, message_kind, expects_response)``.
+    - ``audience_targeted``: audience 가 지정됐는가(비어있지 않은가).
+    - ``addressed``: 이 이벤트가 나를 «호출»하는가(True) / 단순 «관찰»인가(False).
+    """
+    audience = data.get("audience") or payload.get("audience")
+    message_kind = data.get("message_kind") or payload.get("message_kind")
+    expects_response = data.get("expects_response")
+    if expects_response is None:
+        expects_response = payload.get("expects_response")
+    recipient_id = data.get("recipient_id") or payload.get("recipient_id")
+    audience_targeted = bool(audience)
+    addressed = (not audience_targeted) or (
+        recipient_id is not None and str(recipient_id) in {str(a) for a in audience}
+    )
+    return audience_targeted, addressed, message_kind, expects_response
+
+
+def render_observation_block(entries: list[str]) -> str:
+    """버퍼된 관찰들을 다음 활성화 턴에 붙일 context 블록으로 렌더."""
+    lines = "\n".join(f"- {e}" for e in entries)
+    return (
+        f"[읽음 · 당신이 대상이 아니어서 응답하지 않은 메시지 {len(entries)}건]\n"
+        f"{lines}\n[/읽음]"
+    )
+
 
 # ── Public types ─────────────────────────────────────────────────────────────
 
@@ -81,6 +136,12 @@ class MessageContext:
     is_backfill: bool
     images: list[MessageImage]
     raw: dict[str, Any]
+
+    # E-ACTIVATION Phase 2 분류(기본값 = 현행 보존: 늘 호출로 취급).
+    addressed: bool = True
+    audience_targeted: bool = False
+    message_kind: Any = None
+    expects_response: Any = None
 
     # reply() 지원을 위해 내부 주입
     _reply_url: str = field(default="", repr=False)
@@ -142,9 +203,26 @@ class SprintableSSEClient:
         self._last_event_id = ""
         self._last_acked = 0
         self._seen: dict[str, float] = {}
+        # E-ACTIVATION Phase 2 (X): conversation_id -> 관찰 메시지 버퍼(다음 활성화 때 hydrate).
+        self._obs_buffer: dict[str, list[str]] = {}
 
     def _auth(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {self._api_key}", "x-agent-api-key": self._api_key}
+
+    def _buffer_observation(self, ctx: "MessageContext") -> None:
+        """관찰 이벤트를 대화별 버퍼에 쌓는다(오래된 것부터 폐기)."""
+        buf = self._obs_buffer.setdefault(ctx.conversation_id, [])
+        buf.append(f"{ctx.sender_name}: {ctx.content}"[:OBS_ENTRY_MAXLEN])
+        if len(buf) > OBS_BUFFER_MAX:
+            del buf[:-OBS_BUFFER_MAX]
+
+    def _flush_observations_into(self, ctx: "MessageContext") -> None:
+        """이 대화의 버퍼된 관찰을 활성화 ctx.content 앞에 context 로 hydrate 후 비운다."""
+        buf = self._obs_buffer.pop(ctx.conversation_id, None)
+        if not buf:
+            return
+        block = render_observation_block(buf)
+        ctx.content = f"{block}\n{ctx.content}" if ctx.content else block
 
     def _is_dup(self, event_id: str) -> bool:
         now = time.time()
@@ -223,6 +301,8 @@ class SprintableSSEClient:
             if conversation_id else ""
         )
 
+        audience_targeted, addressed, message_kind, expects_response = classify_activation(data, payload)
+
         return MessageContext(
             content=content,
             conversation_id=conversation_id,
@@ -233,10 +313,36 @@ class SprintableSSEClient:
             is_backfill=is_backfill,
             images=images,
             raw=data,
+            addressed=addressed,
+            audience_targeted=audience_targeted,
+            message_kind=message_kind,
+            expects_response=expects_response,
             _reply_url=reply_url,
             _api_key=self._api_key,
             _http=self._http,
         )
+
+    async def _dispatch_event(self, ctx: "MessageContext", on_message: MessageHandler) -> None:
+        """E-ACTIVATION Phase 2 (X): 관찰이면 버퍼+ack(모델 미주입), 호출이면 버퍼 flush 후 주입+ack.
+
+        SPRINTABLE_NONINVOKE_OBSERVATIONS=1 일 때만 게이팅 — 기본 OFF = 모든 이벤트 현행대로 주입.
+        """
+        if os.getenv(NONINVOKE_FLAG_ENV) == "1":
+            if not ctx.addressed:
+                # 관찰 → 모델을 «아예 안 깨운다». 버퍼에 쌓고 seq 만 ack(backfill 재범람 방지).
+                self._buffer_observation(ctx)
+                logger.info("observation (non-invoke) seq=%d conv=%s from=%s",
+                            ctx.seq, ctx.conversation_id, ctx.sender_name)
+                if ctx.seq:
+                    await self._ack(ctx.seq)
+                return
+            # 호출 → 쌓인 관찰을 context 로 hydrate 후 정상 주입.
+            self._flush_observations_into(ctx)
+        logger.info("inbound seq=%d conv=%s: %s",
+                    ctx.seq, ctx.conversation_id, ctx.content[:80])
+        await on_message(ctx)
+        if ctx.seq:
+            await self._ack(ctx.seq)
 
     async def _consume(self, on_message: MessageHandler) -> None:
         assert self._http is not None
@@ -257,11 +363,7 @@ class SprintableSSEClient:
                     if data_lines:
                         ctx = await self._parse_event(ev_type, ev_id, "\n".join(data_lines))
                         if ctx is not None:
-                            logger.info("inbound seq=%d conv=%s: %s",
-                                        ctx.seq, ctx.conversation_id, ctx.content[:80])
-                            await on_message(ctx)
-                            if ctx.seq:
-                                await self._ack(ctx.seq)
+                            await self._dispatch_event(ctx, on_message)
                     ev_type, ev_id, data_lines = "message", "", []
                 elif line.startswith(":"):
                     pass

--- a/connectors/sdk/test_noninvoke_observations.py
+++ b/connectors/sdk/test_noninvoke_observations.py
@@ -66,6 +66,16 @@ def test_classify_missing_recipient_targeted_is_observation():
     assert at is True and addressed is False
 
 
+def test_classify_int_str_recipient_normalized_is_addressed():
+    # str() 정규화가 «매칭을 성사»시키는 True-분기 실증 — 양성대조가 «틀릴 수 있어야».
+    # 코드가 str() 없이 `recipient_id in audience` 였다면 int↔str 불일치로 addressed=False 가
+    # 되어 이 테스트가 빨개진다 → 정규화 축을 «실제로» 잰다(카디르 QA Note 1 반영).
+    at, addressed, _, _ = classify_activation({"audience": [123], "recipient_id": "123"}, {})
+    assert at is True and addressed is True
+    _, addressed, _, _ = classify_activation({"audience": ["123"], "recipient_id": 123}, {})
+    assert addressed is True
+
+
 # ── _parse_event 가 분류 결과를 MessageContext 에 실음 ─────────────────────────
 
 @pytest.mark.anyio
@@ -225,7 +235,8 @@ _CASES = [
     ({"audience": ["other"], "recipient_id": "me"}, {}),
     ({"recipient_id": "me"}, {"audience": ["me"], "message_kind": "request", "expects_response": True}),
     ({"audience": ["A", "B"]}, {}),
-    ({"audience": ["me"], "recipient_id": 123}, {}),  # 타입 혼합(int) — str() 정규화 확認
+    ({"audience": [123], "recipient_id": "123"}, {}),  # int audience ↔ str recipient: 정규화로 매칭(addressed=True)
+    ({"audience": ["me"], "recipient_id": 123}, {}),   # 타입 혼합·관찰(밖) 유지(addressed=False)
 ]
 
 

--- a/connectors/sdk/test_noninvoke_observations.py
+++ b/connectors/sdk/test_noninvoke_observations.py
@@ -1,0 +1,249 @@
+"""E-ACTIVATION Phase 2 (X · system-side non-invoke) — 관찰=턴안열기 검증.
+
+설계문서 agent-agent-loop-termination-research §3·§4·§7. 배달을 «관찰 vs 호출»로 갈라
+비지정(관찰) 이벤트면 모델을 «아예 안 깨우고» 버퍼에 쌓아 다음 활성화 때 hydrate 한다.
+게이트는 SPRINTABLE_NONINVOKE_OBSERVATIONS=1 일 때만 — 기본 OFF = 현행 보존.
+
+SDK(sprintable_sse)가 분류 로직 정본. hermes 어댑터는 vendored 사본 — drift 가드 포함.
+"""
+from __future__ import annotations
+
+import ast
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from sprintable_sse import (  # noqa: E402
+    NONINVOKE_FLAG_ENV,
+    OBS_BUFFER_MAX,
+    SprintableSSEClient,
+    classify_activation,
+    render_observation_block,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── classify_activation (정본 분류기) ─────────────────────────────────────────
+
+def test_classify_broadcast_is_addressed():
+    # audience 미지정(broadcast) → 전체 대상 = 호출(현행 보존)
+    at, addressed, kind, exp = classify_activation({"content": "hi"}, {})
+    assert at is False and addressed is True
+
+
+def test_classify_targeted_in_audience_is_addressed():
+    at, addressed, _, _ = classify_activation(
+        {"audience": ["me"], "recipient_id": "me"}, {}
+    )
+    assert at is True and addressed is True
+
+
+def test_classify_targeted_out_of_audience_is_observation():
+    at, addressed, _, _ = classify_activation(
+        {"audience": ["someone-else"], "recipient_id": "me"}, {}
+    )
+    assert at is True and addressed is False
+
+
+def test_classify_reads_payload_fallback_and_meta():
+    at, addressed, kind, exp = classify_activation(
+        {"recipient_id": "me"},
+        {"audience": ["me"], "message_kind": "request", "expects_response": True},
+    )
+    assert (at, addressed, kind, exp) == (True, True, "request", True)
+
+
+def test_classify_missing_recipient_targeted_is_observation():
+    # audience 지정인데 내 recipient_id 를 모르면 «나를 향한 것»이라 단정 못 함 → 관찰
+    at, addressed, _, _ = classify_activation({"audience": ["A", "B"]}, {})
+    assert at is True and addressed is False
+
+
+# ── _parse_event 가 분류 결과를 MessageContext 에 실음 ─────────────────────────
+
+@pytest.mark.anyio
+async def test_parse_event_sets_activation_fields():
+    c = SprintableSSEClient(api_key="x")
+    ctx = await c._parse_event("message", "1", json.dumps({
+        "event_type": "conversation.message_created", "content": "hi", "event_id": "e-fields",
+        "audience": ["A"], "recipient_id": "me", "message_kind": "request",
+        "expects_response": True, "conversation_id": "c1",
+        "sender": {"id": "A", "name": "Alice"},
+    }))
+    assert ctx is not None
+    assert ctx.addressed is False and ctx.audience_targeted is True
+    assert ctx.message_kind == "request" and ctx.expects_response is True
+
+
+@pytest.mark.anyio
+async def test_parse_event_broadcast_defaults_addressed_true():
+    c = SprintableSSEClient(api_key="x")
+    ctx = await c._parse_event("message", "2", json.dumps({
+        "event_type": "conversation.message_created", "content": "hi all", "event_id": "e-bcast",
+        "conversation_id": "c1", "sender": {"id": "A", "name": "Alice"},
+    }))
+    assert ctx is not None and ctx.addressed is True and ctx.audience_targeted is False
+
+
+# ── _dispatch_event: 관찰=미주입+버퍼 / 호출=flush+주입 (핵심 X 동작) ──────────
+
+def _obs(event_id, seq, content="background chatter"):
+    # SDK _parse_event 는 sender 를 payload.sender 에서 읽는다(실 SSE frame 형태).
+    return json.dumps({
+        "event_type": "conversation.message_created", "content": content,
+        "audience": ["agent-A"], "recipient_id": "me", "event_id": event_id,
+        "recipient_seq": seq, "conversation_id": "c1",
+        "payload": {"sender": {"id": "agent-A", "name": "Alice"}, "conversation_id": "c1"},
+    })
+
+
+def _act(event_id, seq, content="please do X"):
+    return json.dumps({
+        "event_type": "conversation.message_created", "content": content,
+        "audience": ["me"], "recipient_id": "me", "event_id": event_id,
+        "recipient_seq": seq, "conversation_id": "c1",
+        "payload": {"sender": {"id": "boss", "name": "Boss"}, "conversation_id": "c1"},
+    })
+
+
+@pytest.mark.anyio
+async def test_observation_not_invoked_but_buffered(monkeypatch):
+    monkeypatch.setenv(NONINVOKE_FLAG_ENV, "1")
+    c = SprintableSSEClient(api_key="x")
+    delivered = []
+
+    async def on_msg(ctx):
+        delivered.append(ctx.content)
+
+    obs = await c._parse_event("message", "1", _obs("o1", 3))
+    assert obs.addressed is False
+    await c._dispatch_event(obs, on_msg)
+    assert delivered == []                                   # 모델 «안 깨움»
+    assert c._obs_buffer["c1"] == ["Alice: background chatter"]  # 버퍼에 보존
+
+
+@pytest.mark.anyio
+async def test_activation_flushes_buffer_into_context(monkeypatch):
+    monkeypatch.setenv(NONINVOKE_FLAG_ENV, "1")
+    c = SprintableSSEClient(api_key="x")
+    delivered = []
+
+    async def on_msg(ctx):
+        delivered.append(ctx.content)
+
+    await c._dispatch_event(await c._parse_event("message", "1", _obs("o1", 3)), on_msg)
+    await c._dispatch_event(await c._parse_event("message", "2", _obs("o2", 4, "more chatter")), on_msg)
+    assert delivered == []                                   # 관찰 2건 모두 미주입
+    # 나를 향한 활성화 도착 → 쌓인 관찰이 context 로 hydrate 되어 «한 번» 주입
+    await c._dispatch_event(await c._parse_event("message", "3", _act("a1", 5)), on_msg)
+    assert len(delivered) == 1
+    body = delivered[0]
+    assert "please do X" in body                             # 활성화 본문
+    assert "background chatter" in body and "more chatter" in body  # 다 봄(hydrate)
+    assert "읽음" in body                                     # 관찰 블록 라벨
+    assert "c1" not in c._obs_buffer                          # flush 후 비워짐
+
+
+@pytest.mark.anyio
+async def test_flag_off_observation_still_invoked_no_regression(monkeypatch):
+    monkeypatch.delenv(NONINVOKE_FLAG_ENV, raising=False)
+    c = SprintableSSEClient(api_key="x")
+    delivered = []
+
+    async def on_msg(ctx):
+        delivered.append(ctx.content)
+
+    obs = await c._parse_event("message", "1", _obs("o1", 3))
+    await c._dispatch_event(obs, on_msg)
+    assert delivered == ["background chatter"]                # 게이트 OFF = 현행대로 주입
+    assert c._obs_buffer == {}                                # 버퍼 안 씀
+
+
+@pytest.mark.anyio
+async def test_broadcast_invoked_even_with_flag_on(monkeypatch):
+    # audience 미지정 broadcast 는 X ON 이어도 «전체 대상»이라 정상 주입(현행 보존)
+    monkeypatch.setenv(NONINVOKE_FLAG_ENV, "1")
+    c = SprintableSSEClient(api_key="x")
+    delivered = []
+
+    async def on_msg(ctx):
+        delivered.append(ctx.content)
+
+    ctx = await c._parse_event("message", "1", json.dumps({
+        "event_type": "conversation.message_created", "content": "hi all",
+        "event_id": "b1", "recipient_seq": 2, "conversation_id": "c1",
+        "sender": {"id": "A", "name": "Alice"},
+    }))
+    await c._dispatch_event(ctx, on_msg)
+    assert delivered == ["hi all"]
+
+
+# ── 버퍼 경계 ─────────────────────────────────────────────────────────────────
+
+def test_buffer_is_bounded():
+    from types import SimpleNamespace
+    c = SprintableSSEClient(api_key="x")
+    for i in range(OBS_BUFFER_MAX + 5):
+        c._buffer_observation(SimpleNamespace(conversation_id="c", sender_name="S", content=f"m{i}"))
+    buf = c._obs_buffer["c"]
+    assert len(buf) == OBS_BUFFER_MAX                         # 오래된 것부터 폐기
+    assert buf[-1] == f"S: m{OBS_BUFFER_MAX + 4}"             # 최신 보존
+
+
+def test_render_observation_block_shape():
+    block = render_observation_block(["Alice: a", "Bob: b"])
+    assert "2건" in block and "- Alice: a" in block and "- Bob: b" in block
+
+
+# ── vendored 분류기 drift 가드 (hermes 어댑터) ────────────────────────────────
+# 어댑터는 gateway 패키지를 import 하므로 통째로는 import 불가 → classify_activation
+# FunctionDef 만 AST 로 뽑아 격리 exec 후, SDK 정본과 «동일 표본에 동일 결과»인지 대조.
+# (INJECTABLE_EVENT_TYPES 의 test_adapter_vendored_allowlist_matches_sdk 와 같은 취지.)
+
+def _extract_func(adapter_path, name):
+    tree = ast.parse(open(adapter_path, encoding="utf-8").read())
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            mod = ast.Module(body=[node], type_ignores=[])
+            ast.fix_missing_locations(mod)
+            ns: dict = {}
+            exec(compile(mod, adapter_path, "exec"), ns)
+            return ns[name]
+    raise AssertionError(f"{name} not found in {adapter_path}")
+
+
+_CASES = [
+    ({"content": "x"}, {}),
+    ({"audience": ["me"], "recipient_id": "me"}, {}),
+    ({"audience": ["other"], "recipient_id": "me"}, {}),
+    ({"recipient_id": "me"}, {"audience": ["me"], "message_kind": "request", "expects_response": True}),
+    ({"audience": ["A", "B"]}, {}),
+    ({"audience": ["me"], "recipient_id": 123}, {}),  # 타입 혼합(int) — str() 정규화 확認
+]
+
+
+@pytest.mark.parametrize("adapter", ["hermes-sprintable", "hermes-sprintable-prod"])
+def test_adapter_vendored_classifier_matches_sdk(adapter):
+    here = os.path.dirname(os.path.abspath(__file__))
+    adapter_path = os.path.join(here, "..", adapter, "adapter.py")
+    vendored = _extract_func(adapter_path, "classify_activation")
+    for data, payload in _CASES:
+        assert vendored(data, payload) == classify_activation(data, payload), (adapter, data, payload)
+
+
+@pytest.mark.parametrize("adapter", ["hermes-sprintable", "hermes-sprintable-prod"])
+def test_adapter_has_noninvoke_gate(adapter):
+    # X 게이트가 두 사본에 «다 있는지» 트립와이어 — 한 사본이 X 를 빠뜨리면 빨강.
+    here = os.path.dirname(os.path.abspath(__file__))
+    src = open(os.path.join(here, "..", adapter, "adapter.py"), encoding="utf-8").read()
+    assert "SPRINTABLE_NONINVOKE_OBSERVATIONS" in src
+    assert "_buffer_observation" in src and "_flush_observations" in src
+    # 관찰이면 handle_message 전에 return 하는 조기-이탈이 존재해야 함
+    assert "observation (non-invoke)" in src


### PR DESCRIPTION
## 무엇 · 왜

typed-activation **Phase 2 (X · system-side non-invoke)**. Y(LLM-side 헤더주입·#2953)는 「깨운 뒤」 신호라 «호출 자체»는 못 막는다(codex는 헤더 봐도 깨어나 생성 시도). X는 **배달을 «관찰 vs 호출»로 갈라 비지정(관찰)이면 모델을 아예 안 깨운다** — 오지랖을 «자제»로 막는 게 아니라 «안 부르니 안 나옴»(설계문서 §4).

순수 드롭이면 설계문서 §6-B(강등된 problem B: "안 깨운 메시지는 hydrate 안 해 다음에도 못 봄")로 회귀 → 그래서 X는 관찰을 **대화별 버퍼**에 쌓아 다음 «활성화» 턴에 context로 hydrate("다 봄" 보존·"즉답 강제"만 제거) + seq ack(backfill 재범람 방지·#2375).

## 판정(모델 불요·결정적)

백엔드가 이벤트에 `audience`·`recipient_id`를 실어 보낸다(Y 스파인 #2953·dev 증명 끝). `recipient_id`는 per-recipient fan-out이라 «이 스트림 소유자(나)» — 별도 신원 주입 불필요.

- audience 미지정(broadcast) → `addressed=True` (전체 대상 = **현행 보존**)
- audience 지정 & 내 recipient_id ∈ audience → `addressed=True` (나를 호출)
- audience 지정 & 내 recipient_id ∉ audience → `addressed=False` (**관찰 = non-invoke**)

## 변경

- **SDK `connectors/sdk/sprintable_sse.py`**: `classify_activation()` 정본 분류기 + `MessageContext.addressed/audience_targeted/message_kind/expects_response` + 클라이언트 `_dispatch_event` 게이트 + 대화별 관찰 버퍼(bounded 20).
- **hermes 어댑터 dev+prod**: vendored `classify_activation`(prefer-import·SDK 정본) + X 게이트(관찰이면 `handle_message` 전에 조기 return) + 버퍼/flush + **Y 헤더를 공유 분류로 리팩터**(단일 출처·중복 계산 제거).
- 게이트 = **`SPRINTABLE_NONINVOKE_OBSERVATIONS=1`** 일 때만. **기본 OFF = 라이브 fleet 무영향**. Y(`SPRINTABLE_ACTIVATION_HEADER`)와 독립·조합 가능.

## 테스트 (34 통과 · `connectors/sdk`)

`test_noninvoke_observations.py` 신설: 분류(broadcast/targeted-in/targeted-out/payload fallback/int 정규화) · `_parse_event` 필드 · **non-invoke+버퍼**(관찰 미주입·on_message 안 불림) · **활성화 flush hydrate**(쌓인 관찰이 context로 한 번 주입) · **flag OFF 무회귀**(현행대로 주입) · broadcast 무억압 · 버퍼 경계 · **vendored drift 가드**(어댑터 `classify_activation`을 AST로 뽑아 SDK와 동일 표본 동일 결과 대조 + X 게이트 존재 트립와이어). 기존 `test_inject_allowlist.py` 무회귀.

## 범위 밖(별건 후속·침묵 컷 아님)

- **TS 스파인(fakechat/TS SDK) X**: 측정·파일럿 = hermes(선생님 지정). Claude 런타임(fakechat/plugin)은 종결 잘 됨(설계문서 §2)이라 X pilot 가치 낮음 → 별건.
- expects_response=false 기반 추가 억압(result/ack) — 보수적으로 audience 기반만. 후속 판단.

설계문서: [에이전트 간 무한 대화 종결 — 메커니즘 리서치 & 설계](https://app.sprintable.ai) §3·§4·§7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)