### PR TITLE
docs(connect-guide): Codex 절을 정식 플러그인 설치로 재작성 (E-CODEX-CHANNEL S3, #2558)

### DIFF
--- a/apps/web/public/connect-guide.txt
+++ b/apps/web/public/connect-guide.txt
@@ -26,12 +26,18 @@
 에이전트가 Sprintable의 도구(작업 조회·댓글·상태 변경 등)를 쓸 수 있게 합니다.
 
 ```bash
-# Codex — 실제로 밟아 확인한 명령
-codex mcp add sprintable -- uvx sprintable
+# Codex — 실제로 밟아 확인한 명령(호스티드 MCP, 로컬 프로세스 없음)
+codex mcp add sprintable --url https://mcp.sprintable.ai/mcp --bearer-token-env-var SPRINTABLE_API_KEY
+export SPRINTABLE_API_KEY=<0단계에서 발급한 키>   # codex mcp가 이 env var를 직접 읽습니다
 ```
 
-**다른 런타임은 MCP 등록 명령이 각각 다릅니다.** 그 런타임의 문서를 따르되, 등록할
-값은 아래 셋으로 같습니다 — 실행 명령 `uvx sprintable`, 그리고 환경변수 둘.
+`codex mcp get sprintable`로 등록을 확인할 수 있습니다(`transport: streamable_http`).
+클론도, 로컬에서 띄울 프로세스도 없습니다 — self-host로 직접 서버를 돌리는 경우만
+아래(다른 런타임과 같은 패턴)의 `uvx sprintable`로 자신의 백엔드를 가리키면 됩니다.
+
+**다른 런타임은 MCP 등록 명령이 각각 다릅니다.** 그 런타임의 문서를 따르되, SaaS를
+쓴다면 등록할 값은 아래 셋으로 같습니다 — 실행 명령 `uvx sprintable`, 그리고
+환경변수 둘.
 
 ```json
 {
@@ -77,10 +83,10 @@ MCP는 «에이전트가 Sprintable을 부르는 길»입니다. 반대 방향 �
 | 런타임 | 방식 | 실행할 것 |
 |---|---|---|
 | Claude Code | 채널 플러그인 | `sprintable@moonklabs` (`/plugin install` 정식 설치) |
+| Codex | 채널 플러그인 | `sprintable-codex@moonklabs` (`codex plugin add` 정식 설치) |
 | Hermes | 채널 플러그인 | `connectors/hermes-sprintable/` |
 | OpenClaw | 채널 플러그인 | `connectors/openclaw-sprintable/` |
 | OpenCode | 채널 플러그인 | `connectors/opencode-sprintable/` |
-| Codex | 커넥터 호스트 | `connectors/codex-sprintable/` |
 | Gemini | 커넥터 호스트 | `connectors/gemini-sprintable/` |
 | Grok | 커넥터 호스트 | `connectors/grok-sprintable/` |
 | Pi | 커넥터 호스트 | `connectors/pi-sprintable/` |
@@ -92,10 +98,11 @@ MCP는 «에이전트가 Sprintable을 부르는 길»입니다. 반대 방향 �
 
 채용 완료 화면의 ②「깨우기」 칸에도 같은 내용이 런타임별로 표시됩니다.
 
-**Claude Code는 정식 플러그인이 있습니다** — 아래 「Claude Code — 실시간 채널 연결」을
-그대로 따르면(`/plugin install`) 이 단계를 끝낼 수 있습니다. 나머지 런타임(Hermes·OpenClaw·
-OpenCode·Codex·Gemini·Grok·Pi·Cursor)은 아직 정식 설치 경로를 제공하지 않습니다 — 위 표의
-경로는 저장소 안의 위치일 뿐이라, 그 런타임들은 이 단계를 지금 끝낼 수 없습니다.
+**Claude Code와 Codex는 정식 플러그인이 있습니다** — 아래 각 절을 그대로 따르면
+(`/plugin install` 또는 `codex plugin add`) 이 단계를 끝낼 수 있습니다. 나머지
+런타임(Hermes·OpenClaw·OpenCode·Gemini·Grok·Pi·Cursor)은 아직 정식 설치 경로를
+제공하지 않습니다 — 위 표의 경로는 저장소 안의 위치일 뿐이라, 그 런타임들은 이
+단계를 지금 끝낼 수 없습니다.
 
 ### Claude Code — 실시간 채널 연결 (정식 플러그인 설치)
 
@@ -105,7 +112,7 @@ Sprintable의 Claude Code 채널 플러그인을 **정식으로 설치**해 붙�
 **1) 마켓플레이스 추가 + 플러그인 설치** (Claude Code 안에서)
 
 ```
-/plugin marketplace add moonklabs/sprintable-claude-plugin
+/plugin marketplace add moonklabs/sprintable-agent-plugins
 /plugin install sprintable@moonklabs
 ```
 
@@ -136,7 +143,7 @@ claude --dangerously-load-development-channels plugin:sprintable@moonklabs
 > ⚠️ **주의 — 이 플래그는 Claude Code가 「로컬 채널 개발용」으로 두고, 「인터넷에서 받은
 > 채널에는 쓰지 말라」고 경고하는 옵션입니다.** Sprintable 플러그인도 «인터넷에서 받는»
 > 채널이므로, **Sprintable 플러그인을 신뢰할 때만** 쓰십시오. 플러그인 코드는 공개돼 있어
-> (`github.com/moonklabs/sprintable-claude-plugin`) 설치 전에 직접 확인할 수 있습니다. 이
+> (`github.com/moonklabs/sprintable-agent-plugins`) 설치 전에 직접 확인할 수 있습니다. 이
 > 플래그를 쓰면 세션 시작 시 확인 다이얼로그가 뜨며, 위 저장소를 확인한 뒤 승인하면 됩니다.
 > (경고 없는 `--channels` 경로는 Anthropic 공식 마켓 등재가 전제라 현재는 제공되지 않습니다.)
 
@@ -146,6 +153,58 @@ claude --dangerously-load-development-channels plugin:sprintable@moonklabs
 SSE를 열지 않고 조용히 대기합니다(`SSE disabled`).
 
 > `/plugin update`로 플러그인을 갱신해도 정식 설치라 **파일을 다시 만질 일이 없습니다.**
+
+### Codex — 실시간 채널 연결 (정식 플러그인 설치)
+
+Sprintable의 Codex 채널 플러그인을 **정식으로 설치**해 붙입니다. 로컬에 저장소를
+clone하거나 스크립트를 직접 띄울 필요가 없습니다 — 2명령이면 됩니다.
+
+**1) 마켓플레이스 추가 + 플러그인 설치** (터미널에서)
+
+```bash
+codex plugin marketplace add moonklabs/sprintable-agent-plugins
+codex plugin add sprintable-codex@moonklabs
+```
+
+**2) API 키 설정**
+
+```
+/sprintable:configure <0단계에서 발급한 키>
+```
+
+키가 저장되는 위치는 우선순위대로: `$SPRINTABLE_STATE_DIR/.env`(명시했다면 그것만,
+자동 폴백 없음) → `<프로젝트 경로>/.sprintable/.env`(있으면) → `$CODEX_HOME/sprintable/.env`
+(기본값, `$CODEX_HOME`은 보통 `~/.codex`). 한 머신에 Codex 에이전트를 여러 개 붙이고
+각자 `CODEX_HOME`을 이미 분리해 쓰고 있다면 격리가 자동으로 됩니다 — 따로 손댈 것
+없습니다.
+
+**3) `codex` 정상 실행**
+
+추가 플래그가 필요 없습니다 — `codex`를 평소처럼 실행하십시오.
+
+> **처음 한 번, hook 신뢰 승인 프롬프트가 뜹니다.** 이 플러그인은 세션에 메시지를
+> «주입»하기 위해 Codex의 hooks 기능(`SessionStart`/`Stop`/`UserPromptSubmit`)을
+> 씁니다 — Codex는 플러그인이 등록한 hook을 처음 실행하기 전에 신뢰 여부를 묻습니다.
+> 플러그인 코드는 공개돼 있어(`github.com/moonklabs/sprintable-agent-plugins`) 승인
+> 전에 직접 확인할 수 있습니다. 승인하면 그다음부터는 묻지 않습니다.
+>
+> ⚠️ **hooks는 Codex 쪽에서도 비교적 새로운 기능입니다.** 이 채널은 실제 세션(headless·
+> 인터랙티브 TUI 모두)에서 왕복 검증을 마쳤지만(E-CODEX-CHANNEL S1/S2), Codex CLI
+> 자체의 hooks 지원 표면이 넓게 굳어진 상태는 아닙니다 — Codex 버전에 따라 동작이
+> 달라질 수 있습니다.
+
+> **MCP 도구는 별도로 인증해야 합니다.** 위 `/sprintable:configure`가 저장하는 키는
+> «채널»(hooks 스크립트)만 읽습니다. Sprintable MCP 도구(작업 조회·댓글 등)까지 쓰려면
+> 같은 키를 Codex 프로세스 자체 환경변수로도 노출해야 합니다:
+> ```bash
+> export SPRINTABLE_API_KEY=<0단계에서 발급한 키>
+> ```
+> 노출하지 않아도 채널(메시지 왕복)은 정상 동작합니다 — 이 둘은 별개 경로입니다.
+
+채널은 `SessionStart` hook이 백그라운드 SSE 리스너를 띄우고(`GET /api/v2/agent/stream`),
+`Stop` hook이 매 턴 끝에 큐를 확인해 밀린 메시지를 하나로 합쳐 다음 턴으로 주입한 뒤,
+응답을 `POST /api/v2/conversations/{id}/messages`로 돌려보내는 방식으로 동작합니다.
+키가 없으면 모든 hook이 조용히 아무 것도 하지 않습니다 — 기존 Codex 사용에 영향 없음.
 
 ---
 
@@ -179,6 +238,7 @@ codex mcp get sprintable      # → enabled: true   ← 1단계만 확인됨
 | 도구는 보이는데 세션이 안 깨어남 | **2단계** — MCP는 문제가 아닙니다 |
 | 인증 오류 | `AGENT_API_KEY`가 그 에이전트의 것인지 · 키는 에이전트마다 다릅니다 |
 | 연결이 자꾸 끊김 | `SPRINTABLE_API_URL`이 앱 도메인이 아니라 백엔드 주소인지 |
+| Codex: 채널(메시지 왕복)은 되는데 Sprintable MCP 도구 호출이 `AuthRequired`로 실패 | `SPRINTABLE_API_KEY`를 Codex 프로세스 자체 환경변수로 export했는지 — `.env` 파일과는 별개 경로입니다 |
 
 ---
 

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -282,15 +282,16 @@ On message received (JSON):
   → Broadcasts to all subscribers in agent room
 ```
 
-### Agent SSE Stream (dial-out — how fakechat / Claude Code receives)
-The **fakechat** channel plugin (and other agent runtimes) receive messages over a
-long-lived **outbound** SSE connection to the Agent Gateway — not the WebSocket Hub above:
+### Agent SSE Stream (dial-out — how the Sprintable channel plugin receives)
+The **Sprintable channel plugin** (Claude Code, Codex, and other agent runtimes) receives
+messages over a long-lived **outbound** SSE connection to the Agent Gateway — not the
+WebSocket Hub above:
 ```
 GET /api/v2/agent/stream
   Authorization: Bearer sk_live_...
   Accept: text/event-stream
   ↓
-  Server-sent events → injected into the session as <channel source="fakechat"> tags
+  Server-sent events → injected into the session as <channel source="sprintable"> tags
   Reply → POST /api/v2/conversations/{id}/messages
 ```
 
@@ -843,9 +844,9 @@ SECRET_KEY=<32+ chars>
 NEXT_PUBLIC_APP_URL=http://localhost:3108
 NEXT_PUBLIC_FASTAPI_URL=http://localhost:8000
 
-# Agent communication (fakechat SSE adapter — identified by API key only)
+# Agent communication (Sprintable agent SSE adapter — identified by API key only)
 SPRINTABLE_API_KEY=sk_live_...
-SPRINTABLE_API_URL=http://localhost:8000   # backend-direct; the fakechat SSE adapter dials this
+SPRINTABLE_API_URL=http://localhost:8000   # backend-direct; the Sprintable SSE adapter dials this
 
 # Optional: AI features
 ANTHROPIC_API_KEY=sk-ant-...

--- a/apps/web/public/onboarding-guide.txt
+++ b/apps/web/public/onboarding-guide.txt
@@ -166,7 +166,7 @@ and backoff are handled by the shared SDK; you only supply the runtime's injecti
 | **Hermes Agent** | A (platform plugin) | `connectors/hermes-sprintable/` | `handle_message()` |
 | **OpenClaw** | A (ChannelPlugin) | `connectors/openclaw-sprintable/` | `runtime.channel.inbound` |
 | **OpenCode** | A (plugin SDK) | `connectors/opencode-sprintable/` | `client.session.prompt()` |
-| **Codex** | B (stdio JSON-RPC host) | `connectors/codex-sprintable/` | spawns & owns `codex app-server`, injects via stdio JSON-RPC |
+| **Codex** | A (channel plugin) | `sprintable-codex@moonklabs` (`moonklabs/sprintable-agent-plugins`) | Codex hooks (`SessionStart`/`Stop`/`UserPromptSubmit`) — see `connect-guide.txt` |
 | **Gemini** | B (ACP stdio JSON-RPC host) | `connectors/gemini-sprintable/` | spawns `gemini --acp` (Agent Client Protocol) |
 | **Grok** (xAI Grok Build) | B (Zed ACP stdio host) | `connectors/grok-sprintable/` | spawns `grok agent stdio` (same ACP as Gemini) |
 | **Pi** | B (JSONL/stdio host) | `connectors/pi-sprintable/` | spawns `pi --mode rpc` (line-delimited JSON, supports mid-stream `steer`) |
@@ -177,6 +177,12 @@ and backoff are handled by the shared SDK; you only supply the runtime's injecti
 > run), not a local interactive editor session — e.g. the Cursor adapter only reaches
 > Cursor's Cloud (Background) Agents API, not a local Cursor editor. Each adapter's own
 > README states exactly what it does and doesn't reach.
+
+> **Codex also has a Category B option**, `connectors/codex-sprintable/` — spawns &
+> owns `codex app-server`, injects via stdio JSON-RPC. It predates the channel plugin
+> above and is a genuine architectural alternative (headless app-server automation you
+> drive yourself), not a deprecated path — use it if you specifically need that shape
+> rather than an interactive Codex session with the plugin's hooks attached.
 
 ### Example: Hermes
 

--- a/apps/web/public/onboarding-guide.txt
+++ b/apps/web/public/onboarding-guide.txt
@@ -162,7 +162,7 @@ and backoff are handled by the shared SDK; you only supply the runtime's injecti
 
 | Runtime | Category | Adapter | Injection |
 |---------|----------|---------|-----------|
-| **Claude Code** | A (channel plugin) | `packages/fakechat` | `notifications/claude/channel` (requires fakechat pairing) |
+| **Claude Code** | A (channel plugin) | `sprintable@moonklabs` (`moonklabs/sprintable-agent-plugins`) | Claude Code channel plugin — see `connect-guide.txt` |
 | **Hermes Agent** | A (platform plugin) | `connectors/hermes-sprintable/` | `handle_message()` |
 | **OpenClaw** | A (ChannelPlugin) | `connectors/openclaw-sprintable/` | `runtime.channel.inbound` |
 | **OpenCode** | A (plugin SDK) | `connectors/opencode-sprintable/` | `client.session.prompt()` |


### PR DESCRIPTION
## Summary

S2(#2557)가 `sprintable-codex` 플러그인을 실제로 출하했으므로 connect-guide.txt의 Codex 절을 그 위에 맞춰 재작성. Claude Code 절 재작성(#2951, fakechat 하이재킹 폐기) 전례를 그대로 따름 — experimental 표면도 정직히 예고.

- §1 MCP 등록: `uvx sprintable`(로컬 프로세스) → hosted MCP `--url` + `--bearer-token-env-var`로 교체. uvx는 self-host 전용으로 명확히.
- §2 깨우기 표: Codex를 "커넥터 호스트"에서 "채널 플러그인"으로 이동(Claude Code와 동일 취급).
- 신규 "### Codex — 실시간 채널 연결" 절: 2명령 설치·configure·credential 격리 체인·hook 신뢰승인 경고·MCP 도구 별도인증 경고(S2 실측 갭)·hooks가 상대적으로 새 기능이라는 정직한 caveat.
- onboarding-guide.txt: Codex 어댑터 카테고리 B→A 갱신, 기존 `connectors/codex-sprintable/`은 Category B 대안으로 유지(제거 아님).
- repo rename(`sprintable-claude-plugin`→`sprintable-agent-plugins`) 반영.

## Test plan

- [x] **AC1**: 완전 신규 CODEX_HOME + 실제 GitHub repo로 가이드 명령 그대로 실행 — MCP 등록 → 마켓플레이스+플러그인 설치 → `/sprintable:configure <key>`(실제 skill 호출, 수동 파일 시딩 아님) → 왕복 성공. 이탈 스텝 0.
- [x] **AC2**: 로컬 dev 서버로 `curl localhost:3199/connect-guide.txt` 실측 — HTTP 200, 소스와 바이트 동일. 이 과정에서 onboarding-guide.txt의 구 repo명 잔존을 curl이 직접 잡아냄(grep만으론 놓쳤던 것 — 같이 수정).
- [x] **AC3**: hook 신뢰승인·hooks 상대적 신규기능 caveat·MCP 별도인증 필요성 모두 문서 명시.
- [x] **AC4**: connect-guide·onboarding-guide 간 codex 서술 일관. llms-full.txt는 codex 언급 자체가 없어 변경 불요(확認함).

## 비차단 발견 (스코프 밖, 별도 보고)

onboarding-guide.txt의 Claude Code 행이 여전히 `packages/fakechat`/"fakechat pairing"으로 남아 있어 connect-guide의 #2951 재작성과 어긋남 — 내가 만진 Codex 행 바로 위인데 이 PR 스코프가 아니라 손대지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)