### PR TITLE
docs(connect-guide): omitting URL arg = SaaS default, not dev

### DIFF
--- a/apps/web/public/connect-guide.txt
+++ b/apps/web/public/connect-guide.txt
@@ -122,11 +122,12 @@ Sprintable의 Claude Code 채널 플러그인을 **정식으로 설치**해 붙�
 /sprintable:configure <0단계에서 발급한 키>
 ```
 
-키는 `~/.claude/channels/sprintable/.env`에 저장됩니다. ⚠️ **두 번째 인자를 생략하면 dev
-백엔드에 붙습니다** — 정식(prod) 서비스에 붙으려면 prod 백엔드 URL을 반드시 함께 주십시오:
+키는 `~/.claude/channels/sprintable/.env`에 저장됩니다. **두 번째 인자를 생략하면
+SaaS(`https://app.sprintable.ai`)에 붙습니다** — dev나 self-host 백엔드에 붙으려면
+그 URL을 반드시 함께 주십시오:
 
 ```
-/sprintable:configure <0단계에서 발급한 키> https://sprintable-backend-prod-787818285179.asia-northeast3.run.app
+/sprintable:configure <0단계에서 발급한 키> https://sprintable-backend-dev-57iommnikq-du.a.run.app
 ```
 
 **3) 채널과 함께 실행**
@@ -171,6 +172,9 @@ codex plugin add sprintable-codex@moonklabs
 ```
 /sprintable:configure <0단계에서 발급한 키>
 ```
+
+**두 번째 인자를 생략하면 SaaS(`https://app.sprintable.ai`)에 붙습니다** — dev나
+self-host 백엔드에 붙으려면 그 URL을 함께 주십시오.
 
 키가 저장되는 위치는 우선순위대로: `$SPRINTABLE_STATE_DIR/.env`(명시했다면 그것만,
 자동 폴백 없음) → `<프로젝트 경로>/.sprintable/.env`(있으면) → `$CODEX_HOME/sprintable/.env`


### PR DESCRIPTION
## Summary

Follow-up to `moonklabs/sprintable-agent-plugins#5` (prod default fix — all 5 plugin default-URL sites now point at `https://app.sprintable.ai` instead of dev). This guide's Claude Code and Codex sections both said the inverse ("omit the URL arg → connects to dev, must pass prod URL explicitly") — corrected to state the actual new default (SaaS) and moved dev/self-host to the explicit-URL path, symmetric across both sections.

**Sequencing**: needed for S4 (prod promotion) so prod never serves a doc contradicting the shipped default.

## Test plan

- [x] Dev server + curl (same method as #2956's AC2 checks) — grep for "기본=dev"-style residue = 0 after the edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)