### PR TITLE
fix(connectors): web attachments never reached agent SSE injection (#2568)

### DIFF
--- a/connectors/hermes-sprintable/adapter.py
+++ b/connectors/hermes-sprintable/adapter.py
@@ -147,6 +147,43 @@ def _normalize_image_items(images: Any) -> list[dict[str, str]]:
     return normalized
 
 
+def _normalize_attachment_items(attachments: Any) -> list[dict[str, str]]:
+    """#2568: general (non-image-filtered) attachment metadata — unlike
+    ``_normalize_image_items`` this keeps every content_type (e.g. .md), since
+    the server's ``payload.attachments`` was already confirmed to include them
+    and this adapter (unlike ``connectors/sdk``, which it deliberately does not
+    import — see the module docstring) had its own independent copy of this gap."""
+    if not isinstance(attachments, list):
+        return []
+    normalized: list[dict[str, str]] = []
+    for idx, item in enumerate(attachments, start=1):
+        if not isinstance(item, dict):
+            continue
+        url = str(item.get("url") or "").strip()
+        if not url:
+            continue
+        normalized.append({
+            "url": url,
+            "name": str(item.get("name") or f"sprintable-attachment-{idx}").strip(),
+            "content_type": str(item.get("content_type") or "").strip(),
+            "asset_id": str(item.get("asset_id") or "").strip(),
+        })
+    return normalized
+
+
+def _render_attachment_notice(attachments: list[dict[str, str]]) -> str:
+    """#2568 AC3: attachment 존재+회수 경로(asset text API)를 에이전트에 안내."""
+    lines = []
+    for a in attachments:
+        label = a["name"] or a["url"]
+        ctype = a["content_type"] or "unknown type"
+        if a["asset_id"]:
+            lines.append(f"- {label} ({ctype}) — 본문 회수: GET /api/v2/assets/{a['asset_id']}/text")
+        else:
+            lines.append(f"- {label} ({ctype}) — url: {a['url']}")
+    return f"[첨부 {len(attachments)}건]\n" + "\n".join(lines) + "\n[/첨부]"
+
+
 DEFAULT_API_URL = "https://sprintable-backend-dev-57iommnikq-du.a.run.app"
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 STREAM_READ_TIMEOUT = 90  # gateway heartbeats keep the stream alive
@@ -357,6 +394,7 @@ class SprintableAdapter(BasePlatformAdapter):
             return  # not a recommended inject type (e.g. status_changed FYI)
         content = (data.get("content") or payload.get("content") or "").strip()
         images = _normalize_image_items(data.get("images") or payload.get("images"))
+        attachments = _normalize_attachment_items(data.get("attachments") or payload.get("attachments"))
 
         # seq for ack + reconnect cursor — check SSE id, then several data locations.
         # Computed before the content/images guard below so the empty-content branch
@@ -372,7 +410,7 @@ class SprintableAdapter(BasePlatformAdapter):
         if ev_id:
             self._last_event_id = ev_id
 
-        if not content and not images:
+        if not content and not images and not attachments:
             # #2375 AC5 — a content-less injectable event is "nothing to show", not a
             # delivery failure. Returning here without acking used to leave seq
             # unconfirmed forever, so every reconnect re-sent the same event via
@@ -428,6 +466,12 @@ class SprintableAdapter(BasePlatformAdapter):
         media_urls, media_types, attachment_notes = await self._fetch_image_attachments(images)
         if attachment_notes:
             content = "\n".join(attachment_notes + ([content] if content else []))
+        # #2568 AC2/AC3: 일반(비-이미지) 첨부 — 실제 바이트는 안 가져오고(이미지처럼 로컬
+        # 캐시할 필요 없음) 존재+회수 경로만 안내. 순수 첨부만 온 메시지(content="")도 이
+        # notice 자체가 content가 돼 위 드롭체크를 통과한다.
+        if attachments:
+            notice = _render_attachment_notice(attachments)
+            content = f"{content}\n\n{notice}" if content else notice
 
         # E-ACTIVATION Phase 2 (X): 이 대화에 쌓인 관찰을 활성화 턴 context 로 hydrate("다 봄" 보존).
         if noninvoke:

--- a/connectors/hermes-sprintable/test_attachment_injection.py
+++ b/connectors/hermes-sprintable/test_attachment_injection.py
@@ -1,0 +1,58 @@
+"""#2568: 웹 첨부가 에이전트 SSE 주입에 안 실림 — hermes adapter 회귀 방지 pin.
+
+hermes-sprintable/adapter.py는 의도적으로 connectors/sdk를 import하지 않는 vendored
+사본(모듈 docstring 참조 — standalone fresh-install에서 ImportError 0 보장 목적)이라
+SDK 쪽 수정과 별개로 이 파일 자체에 동일 결함이 있었고, 동일하게 고쳤다. gateway.*
+프레임워크(hermes-agent)가 로컬에 있을 때만 이 파일이 import 가능 — 없으면 skip
+(CI가 hermes-agent 소스를 안 갖고 있을 수 있어 이식성 위해 importorskip).
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+_HERMES_AGENT = os.path.expanduser("~/.hermes/hermes-agent")
+if os.path.isdir(_HERMES_AGENT):
+    sys.path.insert(0, _HERMES_AGENT)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+adapter = pytest.importorskip(
+    "adapter", reason="hermes-agent gateway.* framework not available on this machine",
+)
+
+_ATTACHMENT = {
+    "url": "https://storage.googleapis.com/bucket/notes.md",
+    "name": "notes.md",
+    "content_type": "text/markdown",
+    "size": 1234,
+    "asset_id": "5c1e1e1e-1111-2222-3333-444455556666",
+}
+
+
+def test_normalize_attachment_items_no_mime_filter():
+    # _normalize_image_items would drop this (not image/*) — attachments must not.
+    out = adapter._normalize_attachment_items([_ATTACHMENT])
+    assert len(out) == 1
+    assert out[0]["name"] == "notes.md"
+    assert out[0]["content_type"] == "text/markdown"
+    assert out[0]["asset_id"] == "5c1e1e1e-1111-2222-3333-444455556666"
+
+
+def test_normalize_attachment_items_drops_items_without_url():
+    assert adapter._normalize_attachment_items([{"name": "no-url.md"}]) == []
+
+
+def test_render_attachment_notice_uses_asset_text_endpoint():
+    notice = adapter._render_attachment_notice(adapter._normalize_attachment_items([_ATTACHMENT]))
+    assert "GET /api/v2/assets/5c1e1e1e-1111-2222-3333-444455556666/text" in notice
+    assert "notes.md" in notice
+
+
+def test_render_attachment_notice_falls_back_to_url_without_asset_id():
+    item = dict(_ATTACHMENT)
+    item["asset_id"] = ""
+    notice = adapter._render_attachment_notice(adapter._normalize_attachment_items([item]))
+    assert "url: https://storage.googleapis.com/bucket/notes.md" in notice
+    assert "/text" not in notice

--- a/connectors/sdk/sprintable_sse.py
+++ b/connectors/sdk/sprintable_sse.py
@@ -125,6 +125,19 @@ class MessageImage:
 
 
 @dataclass
+class MessageAttachment:
+    """일반 첨부(이미지 포함 전체) — #2568: 서버는 payload.attachments에 이미 이걸 싣지만
+    이 SDK가 `images`(mime.startswith("image/") 필터)만 읽고 있어 .md 등 비-이미지
+    첨부가 여기서 조용히 사라졌다(백엔드 _msg_payload/_dispatch_conversation_event는
+    attachments를 정상 포함 — 실측 확認, 드롭 지점은 여기뿐)."""
+    url: str
+    name: str = ""
+    content_type: str = ""
+    size: int | None = None
+    asset_id: str = ""
+
+
+@dataclass
 class MessageContext:
     """어댑터 `on_message` 콜백에 전달되는 메시지 컨텍스트."""
     content: str
@@ -135,6 +148,7 @@ class MessageContext:
     seq: int
     is_backfill: bool
     images: list[MessageImage]
+    attachments: list[MessageAttachment]
     raw: dict[str, Any]
 
     # E-ACTIVATION Phase 2 분류(기본값 = 현행 보존: 늘 호출로 취급).
@@ -183,6 +197,48 @@ def _normalize_images(value: Any) -> list[MessageImage]:
             mime=mime,
         ))
     return images
+
+
+def _normalize_attachments(value: Any) -> list[MessageAttachment]:
+    """`images`와 달리 mime 필터 없음 — 첨부는 전 타입(.md 등)이 대상(#2568)."""
+    if not isinstance(value, list):
+        return []
+    out: list[MessageAttachment] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        url = str(item.get("url") or "").strip()
+        if not url:
+            continue
+        size = item.get("size")
+        try:
+            size = int(size) if size is not None else None
+        except (TypeError, ValueError):
+            size = None
+        out.append(MessageAttachment(
+            url=url,
+            name=str(item.get("name") or ""),
+            content_type=str(item.get("content_type") or ""),
+            size=size,
+            asset_id=str(item.get("asset_id") or ""),
+        ))
+    return out
+
+
+def render_attachment_notice(attachments: list[MessageAttachment]) -> str:
+    """#2568 AC3: 첨부 존재+회수 경로(asset text API)를 에이전트가 알 수 있게 텍스트로
+    안내. asset_id가 있으면(정상 케이스) 그 경로를, 없으면(레거시/미등록) url을 안내."""
+    lines = []
+    for a in attachments:
+        label = a.name or a.url
+        if a.asset_id:
+            lines.append(
+                f"- {label} ({a.content_type or 'unknown type'}) — "
+                f"본문 회수: GET /api/v2/assets/{a.asset_id}/text"
+            )
+        else:
+            lines.append(f"- {label} ({a.content_type or 'unknown type'}) — url: {a.url}")
+    return f"[첨부 {len(attachments)}건]\n" + "\n".join(lines) + "\n[/첨부]"
 
 
 # ── SDK client ────────────────────────────────────────────────────────────────
@@ -265,8 +321,14 @@ class SprintableSSEClient:
             return None
         content = (data.get("content") or payload.get("content") or "").strip()
         images = _normalize_images(data.get("images") or payload.get("images"))
-        if not content and not images:
+        attachments = _normalize_attachments(data.get("attachments") or payload.get("attachments"))
+        if not content and not images and not attachments:
             return None
+        # #2568 AC2/AC3: 첨부가 있으면 안내 블록을 content에 병합 — 어댑터마다 따로
+        # 렌더하게 하지 않고 SDK 단일 지점에서 처리(어댑터 코드 수정 0으로 전파).
+        if attachments:
+            notice = render_attachment_notice(attachments)
+            content = f"{content}\n\n{notice}" if content else notice
 
         event_id = str(data.get("event_id") or payload.get("id") or ev_id or uuid.uuid4())
         if self._is_dup(event_id):
@@ -312,6 +374,7 @@ class SprintableSSEClient:
             seq=seq,
             is_backfill=is_backfill,
             images=images,
+            attachments=attachments,
             raw=data,
             addressed=addressed,
             audience_targeted=audience_targeted,

--- a/connectors/sdk/test_attachment_injection.py
+++ b/connectors/sdk/test_attachment_injection.py
@@ -1,0 +1,112 @@
+"""#2568: 웹 첨부가 에이전트 SSE 주입에 안 실림 — 회귀 방지 pin.
+
+백엔드(_msg_payload/_dispatch_conversation_event)는 payload.attachments를 정상 포함
+(실측 확認, 코드 read) — 이 SDK의 `_parse_event`가 `images`(mime.startswith("image/")
+필터)만 읽고 `attachments`는 아예 안 읽어 .md 등 비-이미지 첨부가 여기서 사라졌었다.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from sprintable_sse import (  # noqa: E402
+    MessageAttachment,
+    SprintableSSEClient,
+    _normalize_attachments,
+    render_attachment_notice,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _data(event_type="dispatched", content="", attachments=None, **extra):
+    payload = {"event_type": event_type, "content": content, "event_id": "evt-attach"}
+    if attachments is not None:
+        payload["attachments"] = attachments
+    payload.update(extra)
+    return json.dumps(payload)
+
+
+_ATTACHMENT = {
+    "url": "https://storage.googleapis.com/bucket/notes.md",
+    "name": "notes.md",
+    "content_type": "text/markdown",
+    "size": 1234,
+    "asset_id": "5c1e1e1e-1111-2222-3333-444455556666",
+}
+
+
+def test_normalize_attachments_no_mime_filter():
+    # _normalize_images would drop this (not image/*) — attachments must not.
+    out = _normalize_attachments([_ATTACHMENT])
+    assert len(out) == 1
+    assert out[0].name == "notes.md"
+    assert out[0].content_type == "text/markdown"
+    assert out[0].asset_id == "5c1e1e1e-1111-2222-3333-444455556666"
+
+
+def test_normalize_attachments_drops_items_without_url():
+    out = _normalize_attachments([{"name": "no-url.md"}])
+    assert out == []
+
+
+def test_render_notice_uses_asset_text_endpoint_when_asset_id_present():
+    a = MessageAttachment(url="https://x/y.md", name="y.md", content_type="text/markdown",
+                           asset_id="abc-123")
+    notice = render_attachment_notice([a])
+    assert "GET /api/v2/assets/abc-123/text" in notice
+    assert "y.md" in notice
+
+
+def test_render_notice_falls_back_to_url_without_asset_id():
+    a = MessageAttachment(url="https://x/y.md", name="y.md", content_type="text/markdown")
+    notice = render_attachment_notice([a])
+    assert "url: https://x/y.md" in notice
+    assert "/text" not in notice
+
+
+@pytest.mark.anyio
+async def test_parse_event_populates_attachments_and_merges_notice_into_content():
+    c = SprintableSSEClient(api_key="x")
+    ctx = await c._parse_event(
+        "message", "1", _data(content="여기 파일 첨부했음", attachments=[_ATTACHMENT]),
+    )
+    assert ctx is not None
+    assert len(ctx.attachments) == 1
+    assert ctx.attachments[0].name == "notes.md"
+    # AC2/AC3: content에 첨부 안내가 병합돼 에이전트가 존재+회수 경로를 안다.
+    assert "여기 파일 첨부했음" in ctx.content
+    assert "notes.md" in ctx.content
+    assert "GET /api/v2/assets/5c1e1e1e-1111-2222-3333-444455556666/text" in ctx.content
+
+
+@pytest.mark.anyio
+async def test_parse_event_not_dropped_when_only_attachment_no_text():
+    # 순수 텍스트 없이 첨부만 보낸 메시지 — content-only 드롭체크에 안 걸려야 함.
+    c = SprintableSSEClient(api_key="x")
+    ctx = await c._parse_event(
+        "message", "1", _data(content="", attachments=[_ATTACHMENT]),
+    )
+    assert ctx is not None
+    assert "notes.md" in ctx.content
+
+
+@pytest.mark.anyio
+async def test_parse_event_attachments_read_from_payload_fallback():
+    # 백엔드 실제 shape: attachments가 top-level data가 아니라 payload 안에 있음(_msg_payload).
+    c = SprintableSSEClient(api_key="x")
+    raw = json.dumps({
+        "event_type": "dispatched", "event_id": "evt-payload-attach",
+        "payload": {"content": "본문", "attachments": [_ATTACHMENT]},
+    })
+    ctx = await c._parse_event("message", "1", raw)
+    assert ctx is not None
+    assert len(ctx.attachments) == 1
+    assert "notes.md" in ctx.content


### PR DESCRIPTION
## Summary
Story #2568 — PO discovered live (2026-08-11): sending a `.md` attachment from the web sends fine and stores fine, but the agent never sees it — the channel block injected into the agent's session has zero attachment info.

**Root cause, pinned by layer (AC1):**
1. **Backend serializer** (`_msg_payload` / `_dispatch_conversation_event`, `backend/app/routers/conversations.py`) — includes `attachments` in the event payload correctly. Not the drop point.
2. **`connectors/sdk/sprintable_sse.py`'s `_parse_event`** — this is the actual drop point. It only ever read `images` (filtered to `mime.startswith("image/")`), never `attachments` at all. A `.md` file was invisible by construction, not by accident.
3. **`connectors/hermes-sprintable/adapter.py`** — a deliberately standalone vendored copy of the SDK's parsing logic (so a fresh single-folder install doesn't ImportError — see its own module docstring), so it had the identical gap independently and needed its own fix.

**Fix (AC2/AC3):** both files now normalize `attachments` (no mime filter, unlike images) and merge a "here's what's attached + how to fetch it" notice directly into `ctx.content` / `content` — using `GET /api/v2/assets/{asset_id}/text` (the endpoint PO already confirmed works with an agent key today). Because the notice is merged into `content` itself rather than left as a separate structured field, every downstream consumer gets this fix automatically just by picking up the updated file — no per-adapter rendering code needed. A message that's *only* an attachment (no text body) is no longer dropped either, since the notice itself becomes non-empty content.

`connectors/{codex,grok,gemini,pi,cursor}-sprintable` all `import sprintable_sse` directly, so this one SDK fix covers all of them — confirmed by grep, no separate changes needed there.

## Test plan
- [x] `connectors/sdk/test_attachment_injection.py` (7 new tests): mime-filter-free normalization, asset_id→endpoint rendering, url-fallback when no asset_id, content merge, attachment-only message not dropped, payload-nested attachments (matches real backend shape)
- [x] Full existing SDK suite (35 tests) — zero regressions
- [x] `connectors/hermes-sprintable/test_attachment_injection.py` (new, `importorskip`-guarded for CI portability) + direct verification against the real `~/.hermes/hermes-agent` framework (zero-live-impact harness) — all assertions pass

## Not included (flagged, follow-up)
`sprintable-agent-plugins` repo's own local `sprintable_sse.py` copies (codex/grok plugins, plus the not-yet-merged gemini plugin) are not touched by this PR — they need the same file synced in, which is a low-risk follow-up since the fix is embedded in `content` and needs no plugin-side logic changes.