### PR TITLE
feat(opencode-sprintable): npm-publish readiness (S7/#2562)

### DIFF
--- a/connectors/opencode-sprintable/README.md
+++ b/connectors/opencode-sprintable/README.md
@@ -1,45 +1,38 @@
-# Sprintable Adapter for OpenCode
+# opencode-sprintable
 
-OpenCode용 Sprintable Gateway dial-out 어댑터 (카테고리 A).
-SSE dial-out → session.prompt 주입 → 응답 → ack. 인바운드 도메인·웹훅·터널 불필요.
+Sprintable Gateway channel plugin for [OpenCode](https://opencode.ai) — two-way chat between an OpenCode session and its Sprintable team. SSE dial-out (no inbound domain/webhook/tunnel required).
 
-## 설치
+## Install
 
 ```bash
-# 1. git pull
-git pull origin develop
-
-# 2. opencode plugin 설정 (~/.config/opencode/package.json)
-{
-  "dependencies": {
-    "@sprintable/opencode-adapter": "file:./connectors/opencode-sprintable"
-  }
-}
-
-# 또는 심링크
-ln -sf "$(pwd)/connectors/opencode-sprintable" ~/.config/opencode/plugins/sprintable
-
-# 3. 환경 변수 설정
-export AGENT_API_KEY=sk_live_...            # Sprintable agent API key (필수)
-export SPRINTABLE_API_URL=https://...       # Backend URL (미설정 시 dev 기본값)
-export SPRINTABLE_ALLOWED_USERS=...        # 허용 member_id (comma-sep)
-
-# 4. OpenCode 재시작
-opencode
+opencode plugin opencode-sprintable
 ```
+
+One command — OpenCode fetches the npm package (Bun-installed automatically on next startup) and updates your `opencode.json`/`opencode.jsonc` plugin config. No manual `package.json` editing or symlinking needed.
+
+Then set your Sprintable agent credentials before starting `opencode`:
+
+```bash
+export AGENT_API_KEY=sk_live_...            # Sprintable agent API key (required)
+export SPRINTABLE_API_URL=https://...       # Backend URL (defaults to https://app.sprintable.ai)
+```
+
+Without a key set, the plugin loads and does nothing (no error, no SSE connection) — safe to install ahead of configuring credentials.
 
 ## 동작 원리
 
 ```
 Plugin 초기화
-  → background runSprintableSSE (SDK, AbortController)
+  → background runSprintableSSE (vendored SDK, AbortController)
   → 이벤트마다:
     → client.session.create() 또는 기존 session 재사용
     → client.session.prompt({path:{id}, body:{parts:[{type:"text",text}]}})
     → 응답 → POST /api/v2/conversations/{id}/messages
     → POST /agent/events/ack (SDK 처리)
+  → dispose(): AbortController.abort()로 SSE 루프 정지(플러그인 unload/reload 시)
 ```
 
 - Conversation → OpenCode session 매핑 캐시 (재사용)
-- AbortController로 graceful shutdown
-- SSE·dedup·ack·backoff는 공통 SDK(`connectors/sdk/sprintable-sse.ts`) 담당
+- `dispose` hook으로 SSE 스트림 정리 — `@opencode-ai/plugin`의 실제 `Hooks.dispose`에 배선(설치 시 실 타입 확認, 초안의 "shutdown hook 없음" 가정은 틀렸음).
+- SSE·dedup·ack·backoff는 이 패키지에 vendored된 `sprintable-sse.ts`(SDK 원본은 `connectors/sdk/sprintable-sse.ts` — publish된 패키지엔 monorepo 상대경로가 안 살아서 복사본을 담음, drift 방지 위해 SDK 갱신 시 함께 동기화 필요)가 담당.
+- **수명 = OpenCode 프로세스 정직 서술**: SSE 연결은 plugin이 로드된 OpenCode 프로세스가 살아있는 동안만 유지된다. OpenCode를 닫으면(또는 플러그인이 disable/reload되면) 연결도 끊긴다 — 별도 데몬/백그라운드 상주 없음. 그 사이 도착한 메시지는 다음 세션 시작 시 backfill로 회수된다(백엔드 seq-cursor 기반, 유실 아님 — 다만 실시간성은 프로세스가 떠 있는 동안만 보장).

--- a/connectors/opencode-sprintable/index.ts
+++ b/connectors/opencode-sprintable/index.ts
@@ -6,9 +6,13 @@
  */
 
 import type { Plugin } from "@opencode-ai/plugin"
-import { runSprintableSSE } from "../sdk/sprintable-sse.js"
+import { runSprintableSSE } from "./sprintable-sse.js"
 
-const API_URL = (process.env.SPRINTABLE_API_URL ?? "https://sprintable-backend-dev-57iommnikq-du.a.run.app").replace(/\/$/, "")
+// #2568-style npm-publish fix: this file used to import ../sdk/sprintable-sse.js — a path
+// that only resolves inside the monorepo. Published standalone, node_modules/opencode-sprintable
+// has no sibling ../sdk directory, so that import would 404 at runtime for every real install.
+// The SDK is now vendored into this package (sprintable-sse.ts, same directory) instead.
+const API_URL = (process.env.SPRINTABLE_API_URL ?? "https://app.sprintable.ai").replace(/\/$/, "")
 const API_KEY = (process.env.SPRINTABLE_API_KEY ?? process.env.AGENT_API_KEY ?? "").trim()
 
 /**
@@ -87,8 +91,14 @@ export const plugin: Plugin = async ({ client }) => {
   })
 
   return {
-    // plugin 종료 시 SSE stream 정리
-    // (opencode plugin lifecycle에 shutdown hook이 없으므로 process 종료 시 자동 정리)
+    // #2562 QA fix: Hooks.dispose *does* exist in the real @opencode-ai/plugin type
+    // (confirmed against the installed 1.18.16 types — the old comment claiming no
+    // shutdown hook exists was wrong) — wire it to actually stop the SSE loop instead
+    // of leaving it to process exit, so a plugin reload/disable doesn't leak a
+    // dangling long-lived stream connection.
+    dispose: async () => {
+      controller.abort()
+    },
   }
 }
 

--- a/connectors/opencode-sprintable/package.json
+++ b/connectors/opencode-sprintable/package.json
@@ -1,11 +1,19 @@
 {
-  "name": "@sprintable/opencode-adapter",
+  "name": "opencode-sprintable",
   "version": "0.1.0",
-  "description": "Sprintable Gateway adapter for OpenCode",
+  "description": "Sprintable Gateway channel plugin for OpenCode — two-way chat between an OpenCode session and its Sprintable team, dial-out (no inbound domain/webhook/tunnel required).",
+  "keywords": ["opencode-plugin", "sprintable"],
   "type": "module",
   "main": "./index.ts",
+  "files": ["index.ts", "sprintable-sse.ts", "README.md"],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/moonklabs/sprintable.git",
+    "directory": "connectors/opencode-sprintable"
+  },
+  "license": "MIT",
   "peerDependencies": {
-    "@opencode-ai/plugin": ">=1.0.0",
-    "@opencode-ai/sdk": ">=1.0.0"
+    "@opencode-ai/plugin": "^1.18.0",
+    "@opencode-ai/sdk": "^1.18.0"
   }
 }

--- a/connectors/opencode-sprintable/sprintable-sse.ts
+++ b/connectors/opencode-sprintable/sprintable-sse.ts
@@ -1,0 +1,217 @@
+/**
+ * Sprintable Gateway SSE Reference SDK — TypeScript/Bun
+ *
+ * 공통부: SSE 소비 · 파서 · dedup · ack(contiguous, min-1 앵커링) · backoff 재연결.
+ * 어댑터는 `onMessage` 콜백(주입부)만 구현하면 된다.
+ *
+ * @example
+ * ```ts
+ * import { runSprintableSSE } from './sprintable-sse'
+ *
+ * await runSprintableSSE({
+ *   apiUrl: 'https://sprintable-backend-dev-57iommnikq-du.a.run.app',
+ *   apiKey: process.env.AGENT_API_KEY!,
+ *   async onMessage(ctx) {
+ *     // runtime-specific injection
+ *     const response = await myAgent.handle(ctx.content)
+ *     await ctx.reply(response)
+ *   },
+ * })
+ * ```
+ */
+
+export type MessageContext = {
+  content: string
+  conversationId: string
+  senderId: string
+  senderName: string
+  eventId: string
+  seq: number
+  isBackfill: boolean
+  raw: Record<string, unknown>
+  /** POST /api/v2/conversations/{id}/messages */
+  reply(text: string): Promise<void>
+}
+
+export type OnMessage = (ctx: MessageContext) => Promise<void>
+
+const DEFAULT_API_URL = 'https://sprintable-backend-dev-57iommnikq-du.a.run.app'
+const RECONNECT_BACKOFF = [2000, 5000, 10000, 30000, 60000]
+const DEDUP_MAX = 1000
+const DEDUP_TTL_MS = 300_000
+
+function _authHeaders(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}`, 'x-agent-api-key': apiKey }
+}
+
+export async function runSprintableSSE(opts: {
+  apiUrl?: string
+  apiKey: string
+  onMessage: OnMessage
+  signal?: AbortSignal
+}): Promise<void> {
+  const { apiKey, onMessage } = opts
+  const apiUrl = (opts.apiUrl ?? DEFAULT_API_URL).replace(/\/$/, '')
+
+  let lastEventId = ''
+  let lastAcked = 0
+  let backoffIdx = 0
+  const seen = new Map<string, number>()
+
+  function isDup(eventId: string): boolean {
+    const now = Date.now()
+    if (seen.size > DEDUP_MAX) {
+      for (const [k, v] of seen) if (now - v > DEDUP_TTL_MS) seen.delete(k)
+    }
+    if (seen.has(eventId)) return true
+    seen.set(eventId, now)
+    return false
+  }
+
+  async function ack(seq: number): Promise<void> {
+    if (seq <= lastAcked) return
+    try {
+      const resp = await fetch(`${apiUrl}/api/v2/agent/events/ack`, {
+        method: 'POST',
+        headers: { ..._authHeaders(apiKey), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ seq }),
+      })
+      if (resp.ok) {
+        lastAcked = seq
+        process.stderr.write(`[sprintable-sse] ack seq=${seq}\n`)
+      }
+    } catch (e) {
+      process.stderr.write(`[sprintable-sse] ack error seq=${seq}: ${e}\n`)
+    }
+  }
+
+  async function consume(): Promise<void> {
+    const headers: Record<string, string> = {
+      ..._authHeaders(apiKey),
+      Accept: 'text/event-stream',
+      'Cache-Control': 'no-cache',
+    }
+    if (lastEventId) headers['Last-Event-ID'] = lastEventId
+
+    const resp = await fetch(`${apiUrl}/api/v2/agent/stream`, { headers })
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+    if (!resp.body) throw new Error('no body')
+
+    process.stderr.write('[sprintable-sse] stream open\n')
+    backoffIdx = 0
+
+    const reader = resp.body.getReader()
+    const dec = new TextDecoder()
+    let buf = ''
+    let evType = 'message', evId = '', dataLines: string[] = []
+
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buf += dec.decode(value, { stream: true })
+      const lines = buf.split('\n')
+      buf = lines.pop() ?? ''
+
+      for (const raw of lines) {
+        const line = raw.replace(/\r$/, '')
+        if (line === '') {
+          if (dataLines.length) {
+            const ctx = await parseEvent(evType, evId, dataLines.join('\n'), apiUrl, apiKey)
+            if (ctx) {
+              process.stderr.write(
+                `[sprintable-sse] inbound seq=${ctx.seq} conv=${ctx.conversationId}: ${ctx.content.slice(0, 80)}\n`
+              )
+              await onMessage(ctx)
+              if (ctx.seq) await ack(ctx.seq)
+            }
+          }
+          evType = 'message'; evId = ''; dataLines = []
+        } else if (line.startsWith(':')) {
+          // comment
+        } else if (line.startsWith('event:')) {
+          evType = line.slice(6).trim()
+        } else if (line.startsWith('id:')) {
+          evId = line.slice(3).trim()
+        } else if (line.startsWith('data:')) {
+          const v = line.slice(5)
+          dataLines.push(v.startsWith(' ') ? v.slice(1) : v)
+        }
+      }
+    }
+    process.stderr.write('[sprintable-sse] stream closed\n')
+  }
+
+  async function parseEvent(
+    evType: string, evId: string, dataStr: string,
+    apiUrl: string, apiKey: string,
+  ): Promise<MessageContext | null> {
+    if (evType === 'heartbeat') return null
+    let data: Record<string, unknown>
+    try { data = JSON.parse(dataStr) } catch { return null }
+
+    const payload = (
+      typeof data.payload === 'object' && data.payload !== null ? data.payload : {}
+    ) as Record<string, unknown>
+
+    const content = ((data.content ?? payload.content ?? '') as string).trim()
+    if (!content) return null
+
+    const eventId = String(data.event_id ?? payload.id ?? evId ?? crypto.randomUUID())
+    if (isDup(eventId)) return null
+    if (evId) lastEventId = evId
+
+    let seq = 0
+    for (const cand of [data.recipient_seq, payload.recipient_seq]) {
+      const n = Number(cand)
+      if (Number.isFinite(n) && n > 0) { seq = n; break }
+    }
+
+    const conversationId = String(
+      payload.conversation_id ?? payload.thread_id ?? data.conversation_id ?? ''
+    )
+    const sender = (
+      typeof payload.sender === 'object' && payload.sender !== null ? payload.sender : {}
+    ) as Record<string, unknown>
+    const senderId = String(sender.id ?? data.sender_id ?? 'sprintable')
+    const senderName = String(sender.name ?? senderId)
+    const isBackfill = Boolean(data.is_backfill)
+
+    const replyUrl = conversationId
+      ? `${apiUrl}/api/v2/conversations/${conversationId}/messages`
+      : ''
+
+    return {
+      content, conversationId, senderId, senderName, eventId, seq, isBackfill, raw: data,
+      async reply(text: string) {
+        if (!replyUrl) throw new Error('no conversation_id')
+        const r = await fetch(replyUrl, {
+          method: 'POST',
+          headers: { ..._authHeaders(apiKey), 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content: text }),
+        })
+        if (!r.ok) throw new Error(`reply HTTP ${r.status}`)
+      },
+    }
+  }
+
+  // main loop
+  while (true) {
+    if (opts.signal?.aborted) return
+    const t0 = Date.now()
+    try {
+      await consume()
+    } catch (e) {
+      if (opts.signal?.aborted) return
+      process.stderr.write(`[sprintable-sse] error: ${e}\n`)
+    }
+    if (opts.signal?.aborted) return
+    if (Date.now() - t0 >= 60_000) backoffIdx = 0
+    const delay = RECONNECT_BACKOFF[Math.min(backoffIdx, RECONNECT_BACKOFF.length - 1)]
+    process.stderr.write(`[sprintable-sse] reconnecting in ${delay}ms\n`)
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, delay)
+      opts.signal?.addEventListener('abort', () => { clearTimeout(timer); resolve() }, { once: true })
+    })
+    backoffIdx++
+  }
+}

--- a/connectors/opencode-sprintable/sprintable-sse.ts
+++ b/connectors/opencode-sprintable/sprintable-sse.ts
@@ -93,7 +93,7 @@ export async function runSprintableSSE(opts: {
     }
     if (lastEventId) headers['Last-Event-ID'] = lastEventId
 
-    const resp = await fetch(`${apiUrl}/api/v2/agent/stream`, { headers })
+    const resp = await fetch(`${apiUrl}/api/v2/agent/stream`, { headers, signal: opts.signal })
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
     if (!resp.body) throw new Error('no body')
 
@@ -106,6 +106,10 @@ export async function runSprintableSSE(opts: {
     let evType = 'message', evId = '', dataLines: string[] = []
 
     while (true) {
+      if (opts.signal?.aborted) {
+        await reader.cancel()
+        return
+      }
       const { done, value } = await reader.read()
       if (done) break
       buf += dec.decode(value, { stream: true })

--- a/connectors/sdk/sprintable-sse.ts
+++ b/connectors/sdk/sprintable-sse.ts
@@ -93,7 +93,7 @@ export async function runSprintableSSE(opts: {
     }
     if (lastEventId) headers['Last-Event-ID'] = lastEventId
 
-    const resp = await fetch(`${apiUrl}/api/v2/agent/stream`, { headers })
+    const resp = await fetch(`${apiUrl}/api/v2/agent/stream`, { headers, signal: opts.signal })
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
     if (!resp.body) throw new Error('no body')
 
@@ -106,6 +106,10 @@ export async function runSprintableSSE(opts: {
     let evType = 'message', evId = '', dataLines: string[] = []
 
     while (true) {
+      if (opts.signal?.aborted) {
+        await reader.cancel()
+        return
+      }
       const { done, value } = await reader.read()
       if (done) break
       buf += dec.decode(value, { stream: true })


### PR DESCRIPTION
## Summary
- Renames `@sprintable/opencode-adapter` → bare `opencode-sprintable` (required for the 1-command `opencode plugin opencode-sprintable` install path — OpenCode's install convention needs a bare package name, scoped names don't work with the short form).
- Vendors `sprintable-sse.ts` into the package itself. The old `../sdk/sprintable-sse.js` relative import only resolves inside this monorepo — published standalone, `node_modules/opencode-sprintable` has no sibling `../sdk`, so every real install would 404 at runtime. Caught before any real install shipped, via direct tarball inspection.
- Fixes `files[]` in package.json — it omitted the vendored SDK file, so the first `npm pack` genuinely shipped a broken 3-file tarball missing the file `index.ts` imports.
- Wires the `dispose` hook to actually `AbortController.abort()` the SSE loop. The old code's comment claimed "no shutdown hook exists in opencode plugin lifecycle" — false, confirmed against the real installed `@opencode-ai/plugin`@1.18.16 types (`Hooks.dispose?: () => Promise<void>`). Previously a reload/disable would leak a dangling long-lived SSE connection.
- Fixes the default backend URL fallback (was a stale dev Cloud Run URL, now `https://app.sprintable.ai`).
- README rewritten for the real 1-command install, plus an honest lifecycle disclosure: SSE connection lifetime = OpenCode process lifetime (no daemon/background persistence); gaps are recovered via backend seq-cursor backfill on next session start.

## Verification (live, real testing — not just code review)
All done against an isolated OpenCode sandbox (`XDG_CONFIG_HOME` override + pre-seeded local `opencode.json`, per the isolation recipe agreed after an earlier global-config touch incident — see PR discussion history / team conv for detail) with a real installed npm-pack tarball, not just `bun test`.

**1. Packaging correctness** — `npm pack` tarball inspected directly (`tar -tzf`) before any install attempt: confirmed all 4 required files present (`index.ts`, `sprintable-sse.ts`, `README.md`, `package.json`). Type-checked clean against the real installed `@opencode-ai/plugin`@1.18.16 + `@opencode-ai/sdk`@1.18.16 + `@types/node` (zero errors).

**2. Install + plugin load** — extracted-tarball local-directory install via `opencode plugin <dir>` (raw `.tgz` path is NOT accepted by `opencode plugin` — directory or registry spec only, confirmed by testing) in the isolated sandbox. Plugin loaded, `dispose` wired.

**3. session.prompt call chain (external message → OpenCode session)** — confirmed via real `opencode serve` logs: an inbound Sprintable SSE message correctly triggers `client.session.create()` (`message=created id=ses_...`) followed by `client.session.prompt()` (`message=process session.id=...`). The LLM call itself then fails with `Token refresh failed: 401` on this test machine (expired/misconfigured OpenAI provider token) — **this is the explicit boundary of what this plugin is responsible for.** The plugin's job ends at correctly invoking `session.prompt`; whether the underlying model provider is authenticated and actually answers is the user's own OpenCode/provider configuration, not something this plugin can or should own.

**4. Reply-posting path (session response → Sprintable conv), independent of the LLM** — to close the loop without depending on a working model provider, wrote a standalone script that imports the exact same vendored `runSprintableSSE`/`ctx.reply()` used by `index.ts`, and in `onMessage` skips `client.session.prompt()` entirely, calling `ctx.reply("MOCKED_MODEL_RESPONSE: ...")` directly — exercising the identical POST-back code path `index.ts`'s `await msg.reply(responseText)` calls. Ran live against a real Sprintable test conversation: sent a trigger message, confirmed `[mock-test] reply() completed without throwing` in the script log, and confirmed the mocked reply text actually landed in the Sprintable conversation (received back via the live channel event).

**Net: full round-trip through a real LLM provider was not exercised on this machine** (blocked by an unrelated, out-of-scope 401 token refresh failure in this test machine's OpenCode/OpenAI config) — but every piece of code this plugin owns (packaging, install, session creation, prompt injection call, and reply-posting) is verified live and working. Full LLM-round-trip re-verification deferred to Kadir QA's environment or a machine with valid provider credentials.

## Test plan
- [x] `npm pack` tarball content verified (4/4 files)
- [x] Type-check clean against real installed OpenCode SDK types
- [x] Isolated local install via extracted tarball, plugin loads
- [x] Live log evidence: inbound SSE message → `session.create` → `session.prompt` call chain
- [x] Live mocked-reply-path test: reply-posting code confirmed working independent of LLM provider
- [ ] Full LLM round-trip (needs valid provider auth) — deferred to QA
- [ ] `npm publish opencode-sprintable` (approved by PO, pending this PR + QA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)