### PR TITLE
fix: rename hosted MCP server key sprintable -> sprintable-mcp everywhere (#2577)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -171,7 +171,7 @@ Sprintable에서: **에이전트(Agents) → 채용(Recruit) → API 키 복사*
 ```json
 {
   "mcpServers": {
-    "sprintable": {
+    "sprintable-mcp": {
       "type": "http",
       "url": "http://localhost:3108/mcp",
       "headers": {
@@ -186,7 +186,7 @@ Sprintable에서: **에이전트(Agents) → 채용(Recruit) → API 키 복사*
 ```json
 {
   "mcpServers": {
-    "sprintable": {
+    "sprintable-mcp": {
       "url": "http://localhost:3108/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_AGENT_API_KEY"
@@ -232,7 +232,7 @@ Sprintable은 로컬 서버 없이도 외부 클라이언트(예: [Poke](https:/
 ```json
 {
   "mcpServers": {
-    "sprintable": {
+    "sprintable-mcp": {
       "type": "http",
       "url": "https://dev-mcp.sprintable.ai/mcp",
       "headers": {

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Add Sprintable as an MCP server in your agent's config. This gives the agent acc
 ```json
 {
   "mcpServers": {
-    "sprintable": {
+    "sprintable-mcp": {
       "type": "http",
       "url": "http://localhost:3108/mcp",
       "headers": {
@@ -197,7 +197,7 @@ Add Sprintable as an MCP server in your agent's config. This gives the agent acc
 ```json
 {
   "mcpServers": {
-    "sprintable": {
+    "sprintable-mcp": {
       "url": "http://localhost:3108/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_AGENT_API_KEY"
@@ -247,7 +247,7 @@ Sprintable also runs a **hosted Streamable HTTP MCP** so external clients (e.g. 
 ```json
 {
   "mcpServers": {
-    "sprintable": {
+    "sprintable-mcp": {
       "type": "http",
       "url": "https://dev-mcp.sprintable.ai/mcp",
       "headers": {

--- a/apps/web/public/connect-guide.txt
+++ b/apps/web/public/connect-guide.txt
@@ -27,11 +27,15 @@
 
 ```bash
 # Codex — 실제로 밟아 확인한 명령(호스티드 MCP, 로컬 프로세스 없음)
-codex mcp add sprintable --url https://mcp.sprintable.ai/mcp --bearer-token-env-var SPRINTABLE_API_KEY
+codex mcp add sprintable-mcp --url https://mcp.sprintable.ai/mcp --bearer-token-env-var SPRINTABLE_API_KEY
 export SPRINTABLE_API_KEY=<0단계에서 발급한 키>   # codex mcp가 이 env var를 직접 읽습니다
 ```
 
-`codex mcp get sprintable`로 등록을 확인할 수 있습니다(`transport: streamable_http`).
+> 등록명이 `sprintable-mcp`인 이유: Claude Code 채널 플러그인이 별도로 쓰는 MCP 서버
+> (`sprintable-channel`)와 이름이 같으면 `/mcp` 목록·로그에서 분간이 안 됩니다(#2577).
+> 이 문서의 예시는 항상 이 개명 이후 이름을 씁니다.
+
+`codex mcp get sprintable-mcp`로 등록을 확인할 수 있습니다(`transport: streamable_http`).
 클론도, 로컬에서 띄울 프로세스도 없습니다 — self-host로 직접 서버를 돌리는 경우만
 아래(다른 런타임과 같은 패턴)의 `uvx sprintable`로 자신의 백엔드를 가리키면 됩니다.
 
@@ -42,7 +46,7 @@ export SPRINTABLE_API_KEY=<0단계에서 발급한 키>   # codex mcp가 이 env
 ```json
 {
   "mcpServers": {
-    "sprintable": {
+    "sprintable-mcp": {
       "type": "stdio",
       "command": "uvx",
       "args": ["sprintable"],
@@ -224,7 +228,7 @@ self-host 백엔드에 붙으려면 그 URL을 함께 주십시오.
 **「Added」나 `enabled: true`는 1단계가 된 것이지, 에이전트가 깨어난 것이 아닙니다.**
 
 ```bash
-codex mcp get sprintable      # → enabled: true   ← 1단계만 확인됨
+codex mcp get sprintable-mcp   # → enabled: true   ← 1단계만 확인됨
 ```
 
 실제로 확인하는 법:

--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.equip-warning-mount.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.equip-warning-mount.test.tsx
@@ -48,7 +48,7 @@ describe('RecruiterClient equip-skip — PATCH 실패 시 경고 배너 실제 �
 
       if (url === '/api/agents' && method === 'POST') {
         return jsonResponse({
-          data: { id: 'agent-under-test', mcp_config: { mcpServers: { sprintable: {} } }, api_key: 'sk_test_placeholder' },
+          data: { id: 'agent-under-test', mcp_config: { mcpServers: { 'sprintable-mcp': {} } }, api_key: 'sk_test_placeholder' },
         });
       }
 
@@ -131,7 +131,7 @@ describe('RecruiterClient equip-skip — PATCH 실패 시 경고 배너 실제 �
       if (url === '/api/runtime-capabilities') return jsonResponse({ data: [] });
       if (url.startsWith('/api/team-members?')) return jsonResponse({ data: [] });
       if (url === '/api/agents' && method === 'POST') {
-        return jsonResponse({ data: { id: 'agent-2', mcp_config: { mcpServers: { sprintable: {} } }, api_key: 'sk_test' } });
+        return jsonResponse({ data: { id: 'agent-2', mcp_config: { mcpServers: { 'sprintable-mcp': {} } }, api_key: 'sk_test' } });
       }
       if (url === '/api/team-members/agent-2' && method === 'PATCH') return jsonResponse({ data: {} }, true, 200);
       throw new Error(`unmocked fetch: ${method} ${url}`);

--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.test.tsx
@@ -10,24 +10,24 @@ import koMessages from '../../../../../../messages/ko.json';
 describe('spliceApiKey (까심 QA RC HIGH① — transport별 키 위치)', () => {
   it('replaces the key in headers.Authorization for the http (hosted) shape', () => {
     const bundle: McpConfigBundle = {
-      mcpServers: { sprintable: { type: 'http', url: 'https://mcp.sprintable.ai/mcp', headers: { Authorization: 'Bearer sk_live_old', 'X-Project-Id': 'p1' } } },
+      mcpServers: { 'sprintable-mcp': { type: 'http', url: 'https://mcp.sprintable.ai/mcp', headers: { Authorization: 'Bearer sk_live_old', 'X-Project-Id': 'p1' } } },
     };
     const result = spliceApiKey(bundle, 'sk_live_new');
-    expect(result?.mcpServers.sprintable.headers?.Authorization).toBe('Bearer sk_live_new');
-    expect(result?.mcpServers.sprintable.headers?.['X-Project-Id']).toBe('p1'); // 다른 필드 보존
+    expect(result?.mcpServers['sprintable-mcp'].headers?.Authorization).toBe('Bearer sk_live_new');
+    expect(result?.mcpServers['sprintable-mcp'].headers?.['X-Project-Id']).toBe('p1'); // 다른 필드 보존
   });
 
   it('replaces the key in env.AGENT_API_KEY for the stdio (local) shape — the bug 까심 caught', () => {
     const bundle: McpConfigBundle = {
-      mcpServers: { sprintable: { type: 'stdio', command: 'uvx', args: ['sprintable-mcp'], env: { SPRINTABLE_API_URL: 'https://api.example.com', AGENT_API_KEY: 'sk_live_old' } } },
+      mcpServers: { 'sprintable-mcp': { type: 'stdio', command: 'uvx', args: ['sprintable-mcp'], env: { SPRINTABLE_API_URL: 'https://api.example.com', AGENT_API_KEY: 'sk_live_old' } } },
     };
     const result = spliceApiKey(bundle, 'sk_live_new');
-    expect(result?.mcpServers.sprintable.env?.AGENT_API_KEY).toBe('sk_live_new');
-    expect(result?.mcpServers.sprintable.env?.SPRINTABLE_API_URL).toBe('https://api.example.com'); // 다른 필드 보존
+    expect(result?.mcpServers['sprintable-mcp'].env?.AGENT_API_KEY).toBe('sk_live_new');
+    expect(result?.mcpServers['sprintable-mcp'].env?.SPRINTABLE_API_URL).toBe('https://api.example.com'); // 다른 필드 보존
   });
 
   it('returns null (never silently stale) when neither key location is present', () => {
-    const bundle: McpConfigBundle = { mcpServers: { sprintable: { type: 'stdio', command: 'uvx' } } };
+    const bundle: McpConfigBundle = { mcpServers: { 'sprintable-mcp': { type: 'stdio', command: 'uvx' } } };
     expect(spliceApiKey(bundle, 'sk_live_new')).toBeNull();
   });
 });

--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
@@ -39,18 +39,18 @@ const CATEGORY_ICON: Record<string, typeof Palette> = {
  * stale(회전된 옛 키 그대로 노출)해진다 — 둘 다 처리하고, 어느 쪽도 못 찾으면 null(호출부가 에러로 취급).
  */
 export function spliceApiKey(bundle: McpConfigBundle, newKey: string): McpConfigBundle | null {
-  const server = bundle.mcpServers.sprintable;
+  const server = bundle.mcpServers['sprintable-mcp'];
   if (server.headers && 'Authorization' in server.headers) {
     return {
       mcpServers: {
-        sprintable: { ...server, headers: { ...server.headers, Authorization: `Bearer ${newKey}` } },
+        'sprintable-mcp': { ...server, headers: { ...server.headers, Authorization: `Bearer ${newKey}` } },
       },
     };
   }
   if (server.env && 'AGENT_API_KEY' in server.env) {
     return {
       mcpServers: {
-        sprintable: { ...server, env: { ...server.env, AGENT_API_KEY: newKey } },
+        'sprintable-mcp': { ...server, env: { ...server.env, AGENT_API_KEY: newKey } },
       },
     };
   }

--- a/apps/web/src/app/onboarding/connect-step.test.tsx
+++ b/apps/web/src/app/onboarding/connect-step.test.tsx
@@ -5,14 +5,14 @@ import { RAIL_ORDER, HTTP_RAIL_ORDER } from './verify-rail';
 describe('inferTransport (E-MCP-OPT S3 — transport 미지정 default-resolve 응답 판별)', () => {
   it('reads type:"http" from a hosted artifact', () => {
     const content = JSON.stringify({
-      mcpServers: { sprintable: { type: 'http', url: 'https://mcp.sprintable.ai/mcp', headers: {} } },
+      mcpServers: { 'sprintable-mcp': { type: 'http', url: 'https://mcp.sprintable.ai/mcp', headers: {} } },
     });
     expect(inferTransport(content)).toBe('http');
   });
 
   it('reads type:"stdio" from a local artifact', () => {
     const content = JSON.stringify({
-      mcpServers: { sprintable: { type: 'stdio', command: 'uvx', args: ['sprintable-mcp'] } },
+      mcpServers: { 'sprintable-mcp': { type: 'stdio', command: 'uvx', args: ['sprintable-mcp'] } },
     });
     expect(inferTransport(content)).toBe('stdio');
   });

--- a/apps/web/src/app/onboarding/connect-step.tsx
+++ b/apps/web/src/app/onboarding/connect-step.tsx
@@ -18,12 +18,13 @@ import { emitOnboardingEvent, beaconOnboardingEvent } from './onboarding-telemet
 // 하위호환 자리 — 새 소비자는 verify-rail에서 바로 import한다.
 export type { Transport };
 
-/** connection-artifact content(JSON)의 `mcpServers.sprintable.type` 필드만 읽는다(재조립 아님) —
- * transport 미지정 최초 요청은 BE edition 기본을 반환하므로, 어느 탭을 pre-select할지 이걸로 판별. */
+/** connection-artifact content(JSON)의 `mcpServers['sprintable-mcp'].type` 필드만 읽는다(재조립 아님) —
+ * transport 미지정 최초 요청은 BE edition 기본을 반환하므로, 어느 탭을 pre-select할지 이걸로 판별.
+ * #2577: 서버키 sprintable -> sprintable-mcp (BE agent_onboarding_config.py SSOT). */
 export function inferTransport(content: string): Transport {
   try {
-    const parsed = JSON.parse(content) as { mcpServers?: { sprintable?: { type?: string } } };
-    return parsed?.mcpServers?.sprintable?.type === 'http' ? 'http' : 'stdio';
+    const parsed = JSON.parse(content) as { mcpServers?: { 'sprintable-mcp'?: { type?: string } } };
+    return parsed?.mcpServers?.['sprintable-mcp']?.type === 'http' ? 'http' : 'stdio';
   } catch {
     return 'stdio';
   }
@@ -54,9 +55,9 @@ function renderArtifact(baseContent: string | null, apiKey: string, mask: boolea
   const key = mask ? maskApiKey(apiKey) : apiKey;
   try {
     const parsed = JSON.parse(baseContent) as {
-      mcpServers?: { sprintable?: { env?: Record<string, string> } };
+      mcpServers?: { 'sprintable-mcp'?: { env?: Record<string, string> } };
     };
-    const env = parsed?.mcpServers?.sprintable?.env;
+    const env = parsed?.mcpServers?.['sprintable-mcp']?.env;
     if (env && 'AGENT_API_KEY' in env) {
       env.AGENT_API_KEY = key;
       return JSON.stringify(parsed, null, 2);

--- a/apps/web/src/services/recruit.ts
+++ b/apps/web/src/services/recruit.ts
@@ -29,7 +29,8 @@ export interface McpServerConfig {
 }
 
 export interface McpConfigBundle {
-  mcpServers: { sprintable: McpServerConfig };
+  // #2577: server key renamed sprintable -> sprintable-mcp (BE agent_onboarding_config.py SSOT).
+  mcpServers: { 'sprintable-mcp': McpServerConfig };
 }
 
 export type Transport = 'http' | 'stdio';

--- a/backend/app/services/agent_onboarding_config.py
+++ b/backend/app/services/agent_onboarding_config.py
@@ -323,10 +323,14 @@ def _build_stdio_config(api_key_plaintext: str | None) -> dict:
         env["AGENT_API_KEY"] = api_key_plaintext
     return {
         "mcpServers": {
-            "sprintable": {
+            # #2577: server key sprintable -> sprintable-mcp (this is always the
+            # hosted-*tools* MCP, never the channel — collided with the Claude Code
+            # plugin's separate bundled channel MCP, which is also named sprintable
+            # there; distinct keys now).
+            "sprintable-mcp": {
                 "type": "stdio",
                 "command": "uvx",
-                "args": ["sprintable"],
+                "args": ["sprintable"],  # PyPI package/console-script name — unchanged.
                 "env": env,
             }
         }
@@ -348,7 +352,8 @@ def _build_http_config(api_key_plaintext: str | None) -> dict | None:
         headers["Authorization"] = f"Bearer {api_key_plaintext}"
     return {
         "mcpServers": {
-            "sprintable": {
+            # #2577: same rename as the stdio variant above.
+            "sprintable-mcp": {
                 "type": "http",
                 "url": url,
                 "headers": headers,
@@ -452,12 +457,12 @@ def build_hermes_mcp_cli_setup(
     그대로 가져와 hermes CLI 인자로 재구성한다(값 자체를 새로 만들지 않음 — SSOT 단일화).
     """
     text = _HTTP_MCP_CLI_SETUP_TEXT[resolve_locale(locale)]
-    server = mcp_config["mcpServers"]["sprintable"]
+    server = mcp_config["mcpServers"]["sprintable-mcp"]  # #2577: renamed from "sprintable"
     if server["type"] == HTTP:
-        command = f"hermes mcp add sprintable --url {server['url']} --auth header"
+        command = f"hermes mcp add sprintable-mcp --url {server['url']} --auth header"
     else:
         args = " ".join(server.get("args", []))
-        command = f"hermes mcp add sprintable --command {server['command']} --args {args}"
+        command = f"hermes mcp add sprintable-mcp --command {server['command']} --args {args}"
     lines = [
         text["title"], "", text["intro"], "",
         text["command_heading"], "```", command, "```", text["command_note"],

--- a/backend/sprintable_mcp/.mcp.json.example
+++ b/backend/sprintable_mcp/.mcp.json.example
@@ -1,7 +1,7 @@
 {
   "_note": "이 값의 정본은 «화면이 발급하는 .mcp.json» 입니다 — 조직 → 워크포스 → 에이전트 → API 키 에서 받으십시오. 이 파일은 그 형태를 미리 보여 주는 사본이며, 갈리면 화면이 준 쪽이 맞습니다. 따라 하는 절차는 앱의 /connect-guide.txt 를 보십시오.",
   "mcpServers": {
-    "sprintable": {
+    "sprintable-mcp": {
       "type": "stdio",
       "command": "uvx",
       "args": ["sprintable"],

--- a/backend/tests/test_2466_hermes_http_reclassification.py
+++ b/backend/tests/test_2466_hermes_http_reclassification.py
@@ -44,7 +44,7 @@ def test_build_agent_mcp_config_hermes_http(monkeypatch):
     monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp")
     cfg = gen.build_agent_mcp_config(api_key_plaintext="sk_test", runtime="hermes", transport="http")
     assert cfg is not None
-    server = cfg["mcpServers"]["sprintable"]
+    server = cfg["mcpServers"]["sprintable-mcp"]
     assert server["type"] == "http"
     assert server["url"] == "https://mcp.sprintable.ai/mcp"
     assert server["headers"]["Authorization"] == "Bearer sk_test"
@@ -53,7 +53,7 @@ def test_build_agent_mcp_config_hermes_http(monkeypatch):
 def test_build_agent_mcp_config_hermes_stdio():
     cfg = gen.build_agent_mcp_config(api_key_plaintext="sk_test", runtime="hermes", transport="stdio")
     assert cfg is not None
-    server = cfg["mcpServers"]["sprintable"]
+    server = cfg["mcpServers"]["sprintable-mcp"]
     assert server["type"] == "stdio"
     assert server["command"] == "uvx"
     assert server["args"] == ["sprintable"]
@@ -71,18 +71,18 @@ def test_build_agent_mcp_config_bundle_hermes_includes_both_transports(monkeypat
     monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp")
     bundle = gen.build_agent_mcp_config_bundle(api_key_plaintext="sk_test", runtime="hermes")
     assert bundle["default_transport"] == "http"
-    assert bundle["mcp_config"]["mcpServers"]["sprintable"]["type"] == "http"
+    assert bundle["mcp_config"]["mcpServers"]["sprintable-mcp"]["type"] == "http"
     assert "stdio" in bundle["mcp_config_alternatives"]
 
 
 def test_build_hermes_mcp_cli_setup_http_command():
-    cfg = {"mcpServers": {"sprintable": {
+    cfg = {"mcpServers": {"sprintable-mcp": {
         "type": "http", "url": "https://mcp.sprintable.ai/mcp",
         "headers": {"Authorization": "Bearer sk_test"},
     }}}
     text = gen.build_hermes_mcp_cli_setup(cfg, "sk_test")
     command_line = next(line for line in text.splitlines() if line.startswith("hermes mcp add"))
-    assert command_line == "hermes mcp add sprintable --url https://mcp.sprintable.ai/mcp --auth header"
+    assert command_line == "hermes mcp add sprintable-mcp --url https://mcp.sprintable.ai/mcp --auth header"
     assert "sk_test" in text
     # 실행 커맨드 자체는 파일 드롭인이 아니다 — .mcp.json은 설명 문구에만 등장해야지
     # 커맨드로 오인될 자리(등록 명령 코드블록)엔 나오면 안 된다(§0 재발 방지).
@@ -91,11 +91,11 @@ def test_build_hermes_mcp_cli_setup_http_command():
 
 
 def test_build_hermes_mcp_cli_setup_stdio_command():
-    cfg = {"mcpServers": {"sprintable": {
+    cfg = {"mcpServers": {"sprintable-mcp": {
         "type": "stdio", "command": "uvx", "args": ["sprintable"], "env": {},
     }}}
     text = gen.build_hermes_mcp_cli_setup(cfg, None)
-    assert "hermes mcp add sprintable --command uvx --args sprintable" in text
+    assert "hermes mcp add sprintable-mcp --command uvx --args sprintable" in text
 
 
 def test_list_runtime_capabilities_hermes_has_both_axes(monkeypatch):
@@ -131,10 +131,10 @@ async def test_connection_artifact_hermes_emits_mcp_setup_and_connector_setup(mo
     assert filenames == {"HERMES_MCP_SETUP.md", "CONNECTOR_SETUP.md"}
     assert ".mcp.json" not in filenames  # hermes는 파일 드롭인이 아니므로 이 이름이 나오면 안 됨
     assert out["mcp_config"] is not None
-    assert out["mcp_config"]["mcpServers"]["sprintable"]["type"] in ("http", "stdio")
+    assert out["mcp_config"]["mcpServers"]["sprintable-mcp"]["type"] in ("http", "stdio")
 
     mcp_setup = next(f for f in out["files"] if f["filename"] == "HERMES_MCP_SETUP.md")
-    assert "hermes mcp add sprintable" in mcp_setup["content"]
+    assert "hermes mcp add sprintable-mcp" in mcp_setup["content"]
     connector_setup = next(f for f in out["files"] if f["filename"] == "CONNECTOR_SETUP.md")
     assert "connectors/" in connector_setup["content"]
 

--- a/backend/tests/test_e_mcp_opt_s3_hosted_transport.py
+++ b/backend/tests/test_e_mcp_opt_s3_hosted_transport.py
@@ -32,7 +32,7 @@ def anyio_backend():
 def test_stdio_default_unchanged_when_no_transport_kwarg():
     """기존 호출부(회귀0) — transport 미지정이면 여전히 stdio."""
     out = cfg.build_agent_mcp_config(api_key_plaintext="k")
-    assert out["mcpServers"]["sprintable"]["type"] == "stdio"
+    assert out["mcpServers"]["sprintable-mcp"]["type"] == "stdio"
 
 
 def test_http_variant_none_when_mcp_public_url_unset(monkeypatch):
@@ -45,7 +45,7 @@ def test_http_variant_shape_with_key(monkeypatch):
     monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp/")
     assert cfg.resolve_mcp_public_url() == "https://mcp.sprintable.ai/mcp"  # trailing slash 제거
     out = cfg.build_agent_mcp_config(api_key_plaintext="sk_live_abc", transport="http")
-    server = out["mcpServers"]["sprintable"]
+    server = out["mcpServers"]["sprintable-mcp"]
     assert server == {
         "type": "http",
         "url": "https://mcp.sprintable.ai/mcp",
@@ -56,7 +56,7 @@ def test_http_variant_shape_with_key(monkeypatch):
 def test_http_variant_no_auth_header_when_key_absent(monkeypatch):
     monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp")
     out = cfg.build_agent_mcp_config(api_key_plaintext=None, transport="http")
-    assert out["mcpServers"]["sprintable"]["headers"] == {}
+    assert out["mcpServers"]["sprintable-mcp"]["headers"] == {}
 
 
 def test_default_transport_for_hosting(monkeypatch):
@@ -71,7 +71,7 @@ def test_bundle_hosted_with_mcp_public_url_set(monkeypatch):
     monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp")
     bundle = cfg.build_agent_mcp_config_bundle(api_key_plaintext="k")
     assert bundle["default_transport"] == "http"
-    assert bundle["mcp_config"]["mcpServers"]["sprintable"]["type"] == "http"
+    assert bundle["mcp_config"]["mcpServers"]["sprintable-mcp"]["type"] == "http"
     assert set(bundle["mcp_config_alternatives"]) == {"stdio"}
 
 
@@ -80,7 +80,7 @@ def test_bundle_self_hosted_no_mcp_public_url_defaults_stdio(monkeypatch):
     monkeypatch.delenv("MCP_PUBLIC_URL", raising=False)
     bundle = cfg.build_agent_mcp_config_bundle(api_key_plaintext="k")
     assert bundle["default_transport"] == "stdio"
-    assert bundle["mcp_config"]["mcpServers"]["sprintable"]["type"] == "stdio"
+    assert bundle["mcp_config"]["mcpServers"]["sprintable-mcp"]["type"] == "stdio"
     assert bundle["mcp_config_alternatives"] == {}
 
 
@@ -183,7 +183,7 @@ async def test_connection_artifact_transport_http_returns_http_content(monkeypat
         )
     mcp_file = next(f for f in out["files"] if f["filename"] == ".mcp.json")
     parsed = json.loads(mcp_file["content"])
-    assert parsed["mcpServers"]["sprintable"]["type"] == "http"
+    assert parsed["mcpServers"]["sprintable-mcp"]["type"] == "http"
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_e_recruit_s3_recruit_endpoint.py
+++ b/backend/tests/test_e_recruit_s3_recruit_endpoint.py
@@ -133,7 +133,7 @@ async def test_recruit_success_response_shape():
     }
     bundle = {
         "default_transport": "stdio",
-        "mcp_config": {"mcpServers": {"sprintable": {"type": "stdio"}}},
+        "mcp_config": {"mcpServers": {"sprintable-mcp": {"type": "stdio"}}},
         "mcp_config_alternatives": {},
     }
 
@@ -229,7 +229,7 @@ async def test_recruit_success_hermes_http_capable_returns_real_mcp_config(monke
 
     assert response["default_transport"] in ("http", "stdio")
     assert response["mcp_config"] is not None
-    assert response["mcp_config"]["mcpServers"]["sprintable"]["type"] in ("http", "stdio")
+    assert response["mcp_config"]["mcpServers"]["sprintable-mcp"]["type"] in ("http", "stdio")
     session.commit.assert_awaited_once()
 
 

--- a/backend/tests/test_e_recruit_s5_connection_artifact_realdb.py
+++ b/backend/tests/test_e_recruit_s5_connection_artifact_realdb.py
@@ -98,7 +98,7 @@ async def test_connection_artifact_emits_persona_file_real_decorate_path():
         assert "백엔드 엔지니어" in instruction["content"]
         mcp_file = next(f for f in out["files"] if f["filename"] == ".mcp.json")
         parsed = json.loads(mcp_file["content"])
-        assert parsed["mcpServers"]["sprintable"]["type"] in ("stdio", "http")
+        assert parsed["mcpServers"]["sprintable-mcp"]["type"] in ("stdio", "http")
         assert out["mcp_config"] == parsed
         assert out["api_key"] is None
     finally:
@@ -192,7 +192,7 @@ async def test_connection_artifact_hermes_http_capable_real_db():
             )
 
         assert out["mcp_config"] is not None
-        assert out["mcp_config"]["mcpServers"]["sprintable"]["type"] in ("http", "stdio")
+        assert out["mcp_config"]["mcpServers"]["sprintable-mcp"]["type"] in ("http", "stdio")
         filenames = {f["filename"] for f in out["files"]}
         assert filenames == {"SPRINTABLE_ONBOARDING.md", "HERMES_MCP_SETUP.md", "CONNECTOR_SETUP.md"}
         assert ".mcp.json" not in filenames  # hermes는 파일 드롭인이 아님(§0 재발 방지)

--- a/backend/tests/test_ob1_agent_onboarding_config.py
+++ b/backend/tests/test_ob1_agent_onboarding_config.py
@@ -18,7 +18,7 @@ from app.services import agent_onboarding_config as gen
 
 def test_stdio_shape_with_key():
     cfg = gen.build_agent_mcp_config(api_key_plaintext="sk_live_abc")
-    server = cfg["mcpServers"]["sprintable"]
+    server = cfg["mcpServers"]["sprintable-mcp"]
     assert server["type"] == "stdio"
     assert server["command"] == "uvx"
     assert server["args"] == ["sprintable"]
@@ -32,14 +32,14 @@ def test_no_phantom_keys():
     blob = json.dumps(cfg)
     for phantom in ("SPRINTABLE_AGENT_ID", "WS_URL", "WEBSOCKET", "\"port\"", "fakechat"):
         assert phantom not in blob, f"{phantom} 가 아티팩트에 노출되면 안 됨"
-    server = cfg["mcpServers"]["sprintable"]
+    server = cfg["mcpServers"]["sprintable-mcp"]
     assert set(server.keys()) == {"type", "command", "args", "env"}
 
 
 def test_key_omitted_when_absent():
     """api_key 없으면 AGENT_API_KEY 키 생략(미발급 시 비노출·AC4 호환)."""
     cfg = gen.build_agent_mcp_config(api_key_plaintext=None)
-    env = cfg["mcpServers"]["sprintable"]["env"]
+    env = cfg["mcpServers"]["sprintable-mcp"]["env"]
     assert "AGENT_API_KEY" not in env
     assert "SPRINTABLE_API_URL" in env  # URL 은 항상
 
@@ -48,7 +48,7 @@ def test_url_from_fastapi_url_env(monkeypatch):
     """backend-direct URL = FASTAPI_URL env(배포 주입)·trailing slash 제거."""
     monkeypatch.setenv("FASTAPI_URL", "https://sprintable-backend-dev-x.run.app/")
     cfg = gen.build_agent_mcp_config(api_key_plaintext="k")
-    assert cfg["mcpServers"]["sprintable"]["env"]["SPRINTABLE_API_URL"] == \
+    assert cfg["mcpServers"]["sprintable-mcp"]["env"]["SPRINTABLE_API_URL"] == \
         "https://sprintable-backend-dev-x.run.app"
 
 
@@ -103,7 +103,7 @@ async def test_connection_artifact_returns_stdio_with_placeholder():
     assert mcp_file["filename"] == ".mcp.json"
     assert isinstance(mcp_file["content"], str), "content 는 paste-ready json 문자열이어야(dict 아님)"
     parsed = json.loads(mcp_file["content"])
-    server = parsed["mcpServers"]["sprintable"]
+    server = parsed["mcpServers"]["sprintable-mcp"]
     assert server["type"] == "stdio"
     assert server["env"]["AGENT_API_KEY"] == "<YOUR_AGENT_API_KEY>"  # placeholder
     assert out["mcp_config"] == parsed

--- a/backend/tests/test_ob2align_v2_transport.py
+++ b/backend/tests/test_ob2align_v2_transport.py
@@ -11,18 +11,18 @@ from app.services.agent_onboarding_config import build_agent_mcp_config
 
 def test_artifact_pins_agent_gateway_v2():
     """신규 아티팩트 env에 AGENT_GATEWAY_V2='1' — 신규 에이전트 V2(/agent/stream) 통일."""
-    env = build_agent_mcp_config(api_key_plaintext="k")["mcpServers"]["sprintable"]["env"]
+    env = build_agent_mcp_config(api_key_plaintext="k")["mcpServers"]["sprintable-mcp"]["env"]
     assert env["AGENT_GATEWAY_V2"] == "1"
 
 
 def test_v2_flag_present_even_without_key():
     """키 미발급(connection-artifact placeholder 경로)에도 V2 flag는 항상 — 전 신규 에이전트 V2."""
-    env = build_agent_mcp_config(api_key_plaintext=None)["mcpServers"]["sprintable"]["env"]
+    env = build_agent_mcp_config(api_key_plaintext=None)["mcpServers"]["sprintable-mcp"]["env"]
     assert env["AGENT_GATEWAY_V2"] == "1"
     assert env["SPRINTABLE_API_URL"]  # backend-direct 도 항상
 
 
 def test_v2_flag_value_is_truthy_for_sse_bridge():
     """sse_bridge `_use_v2`(os.getenv not in ('0','false',''))가 truthy로 보는 값이어야 V2 발효."""
-    env = build_agent_mcp_config(api_key_plaintext="k")["mcpServers"]["sprintable"]["env"]
+    env = build_agent_mcp_config(api_key_plaintext="k")["mcpServers"]["sprintable-mcp"]["env"]
     assert env["AGENT_GATEWAY_V2"] not in ("0", "false", "")

--- a/docs/agent-integration-guide.md
+++ b/docs/agent-integration-guide.md
@@ -185,7 +185,7 @@ http POST "$BASE_URL/api/v2/conversations/$CONVERSATION_ID/messages" \
 ```yaml
 # ~/.hermes/config.yaml  (또는 프로젝트 루트 hermes.config.yaml)
 mcpServers:
-  sprintable:
+  sprintable-mcp:
     command: python
     args:
       - -m
@@ -206,7 +206,7 @@ Claude Code `.mcp.json` 형식이라면:
 ```json
 {
   "mcpServers": {
-    "sprintable": {
+    "sprintable-mcp": {
       "command": "python",
       "args": ["-m", "sprintable_mcp"],
       "env": {

--- a/docs/quickstart-oss.md
+++ b/docs/quickstart-oss.md
@@ -51,7 +51,7 @@ To use the MCP server with Claude Code, Codex, Windsurf, or Cursor:
 ```json
 {
   "mcpServers": {
-    "sprintable": {
+    "sprintable-mcp": {
       "type": "http",
       "url": "http://localhost:3108/mcp",
       "headers": {

--- a/packages/cli/src/adapters/registry.ts
+++ b/packages/cli/src/adapters/registry.ts
@@ -19,13 +19,13 @@ function makeAdapter(
     hasExistingServer: () => {
       const cfg = readJsonFile(configPath);
       if (mode === "mcpServers") {
-        return !!(cfg.mcpServers as Record<string, unknown> | undefined)?.["sprintable"];
+        return !!(cfg.mcpServers as Record<string, unknown> | undefined)?.["sprintable-mcp"];
       }
       return !!(
         (cfg.mcp as Record<string, unknown> | undefined)?.servers as
           | Record<string, unknown>
           | undefined
-      )?.["sprintable"];
+      )?.["sprintable-mcp"];
     },
   };
 }

--- a/packages/cli/src/adapters/types.ts
+++ b/packages/cli/src/adapters/types.ts
@@ -17,7 +17,7 @@ export function writeMcpServersFormat(
 ): void {
   const config = readJsonFile(configPath);
   const servers = (config.mcpServers ?? {}) as Record<string, unknown>;
-  servers["sprintable"] = {
+  servers["sprintable-mcp"] = {
     command: "uvx",
     args: ["sprintable-mcp"],
     env: {
@@ -38,7 +38,7 @@ export function writeMcpSectionFormat(
   const config = readJsonFile(configPath);
   const mcp = (config.mcp ?? {}) as Record<string, unknown>;
   const servers = (mcp.servers ?? {}) as Record<string, unknown>;
-  servers["sprintable"] = {
+  servers["sprintable-mcp"] = {
     command: "uvx",
     args: ["sprintable-mcp"],
     env: {

--- a/packages/cli/src/commands/connect.test.ts
+++ b/packages/cli/src/commands/connect.test.ts
@@ -53,7 +53,7 @@ describe("pingApi — fetch 동작", () => {
 describe("writeMcpConfig — 구조 검증", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("기존 mcpServers에 sprintable 항목 추가", () => {
+  it("기존 mcpServers에 sprintable-mcp 항목 추가", () => {
     mockExistsSync.mockReturnValue(true);
     mockReadFileSync.mockReturnValue(
       JSON.stringify({ mcpServers: { other: { command: "other" } } }) as unknown as ReturnType<typeof readFileSync>
@@ -63,7 +63,8 @@ describe("writeMcpConfig — 구조 검증", () => {
     const existing = JSON.parse(
       JSON.stringify({ mcpServers: { other: { command: "other" } } })
     );
-    existing.mcpServers["sprintable"] = {
+    // #2577: 서버키 sprintable -> sprintable-mcp
+    existing.mcpServers["sprintable-mcp"] = {
       command: "uvx",
       args: ["sprintable-mcp"],
       env: {
@@ -71,9 +72,9 @@ describe("writeMcpConfig — 구조 검증", () => {
         AGENT_API_KEY: "sk_test",
       },
     };
-    expect(existing.mcpServers).toHaveProperty("sprintable");
+    expect(existing.mcpServers).toHaveProperty("sprintable-mcp");
     expect(existing.mcpServers).toHaveProperty("other");
-    expect(existing.mcpServers.sprintable.command).toBe("uvx");
+    expect(existing.mcpServers["sprintable-mcp"].command).toBe("uvx");
   });
 
   it("API URL 후행 슬래시 제거", () => {

--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -130,7 +130,7 @@ export async function connectCommand(opts: ConnectOptions = {}): Promise<void> {
   // ── 8. 설정 파일 기록 ────────────────────────────────────────────────────
   if (adapter.hasExistingServer()) {
     const overwrite = await confirm({
-      message: `${adapter.configPath}에 이미 'sprintable' 서버가 있습니다. 덮어쓰시겠습니까?`,
+      message: `${adapter.configPath}에 이미 'sprintable-mcp' 서버가 있습니다. 덮어쓰시겠습니까?`,
       default: true,
     });
     if (!overwrite) {
@@ -144,7 +144,7 @@ export async function connectCommand(opts: ConnectOptions = {}): Promise<void> {
 }
 
 function _printSuccess(configPath: string, agent: string): void {
-  console.log(`\n✅ ${configPath}에 'sprintable' 서버가 추가되었습니다.`);
+  console.log(`\n✅ ${configPath}에 'sprintable-mcp' 서버가 추가되었습니다.`);
   console.log("\n다음 단계:");
   const clientName =
     agent === "claude-code" ? "Claude Code"


### PR DESCRIPTION
## Summary
Second half of #2577's name split (plugin-repo half already merged: `sprintable-agent-plugins#11`). The hosted tools MCP server (`mcp.sprintable.ai`, 95 story/task/doc tools) and the Claude Code channel plugin's separate bundled MCP both registered under the server key `sprintable` — same name, different endpoints — so `/mcp` listing and logs couldn't tell them apart (a real customer-reported defect). PO-confirmed split: bundled channel MCP → `sprintable-channel` (done in the plugin PR), hosted tools MCP → `sprintable-mcp` (this PR).

## Why this got big
"앱 내 유도 전체" (PO's framing) turned out to be literally that — not just the SSOT generator. Grepping the whole repo surfaced every place a `"sprintable"` mcpServers key was either generated or hardcoded:

- **`backend/app/services/agent_onboarding_config.py`** — the real SSOT. `build_agent_mcp_config()`'s stdio/http variants and `build_hermes_mcp_cli_setup()`'s generated `hermes mcp add ...` command text both used the key. Renamed both. The `uvx` console-script name (`args: ["sprintable"]`) is **unchanged** — that's the PyPI package name, a different thing ("설치명 유지").
- **6 backend test files** asserting on that generator's output shape.
- **`apps/web`**: `connect-step.tsx` (reads `mcpServers['sprintable-mcp'].type`/`.env` from a connection-artifact) + `recruiter-client.tsx`'s `spliceApiKey` (writes a rotated key back into the same shape) + the `recruit.ts` `McpConfigBundle` type + their tests.
- **`packages/cli`** — the separate published npm `sprintable` CLI (`sprintable connect`). `adapters/types.ts`/`registry.ts` read/wrote the same bare `sprintable` key into a user's local `.mcp.json`; renamed + user-facing CLI strings updated.
- **Static guide content the SSOT never touches**: `apps/web/public/connect-guide.txt` (hardcoded `codex mcp add sprintable` + a JSON example), `README.md`, `README.ko.md`, `docs/quickstart-oss.md`, `docs/agent-integration-guide.md` (including its Hermes `config.yaml` example) — all had their own hand-written `sprintable` mcpServers examples that a generator fix alone would never have updated.

## Explicitly NOT touched (different namespace — confirmed by reading each site, not just grep-matching "sprintable")
- `uvx sprintable` / `args: ["sprintable"]` — PyPI console-script name.
- `<channel source="sprintable">` in guides/`server.ts` — the channel plugin's inbound-message tag identifier, unrelated to MCP server keys (that plugin's *MCP server key* is `sprintable-channel` now, per the merged plugin PR — this is a separate string).
- `connectors/openclaw-sprintable`'s `channels: { sprintable: {...} }` and `aliases: ["sprintable"]` — OpenClaw's own channel-plugin registry, a separate system.
- `redis_shared.py`'s `sprintable:{env}:{domain}:...` key namespace — Redis key prefix, unrelated.

## Verification
- Repo-wide grep sweep (AC3's "0건" requirement) for every remaining bare-`sprintable` MCP server-key/command pattern, run **after** all edits — zero hits outside the confirmed-unrelated sites above.
- 75 backend unit tests pass (`test_ob1_agent_onboarding_config`, `test_ob2align_v2_transport`, `test_e_mcp_opt_s3_hosted_transport`, `test_2466_hermes_http_reclassification`, `test_s_comm_06`).
- `test_e_recruit_s3_recruit_endpoint`: 14 pass. `test_e_recruit_s5_connection_artifact_realdb`: skips cleanly (needs a real DB, same as CI's separate destructive-schema job — not this rename's concern).
- FE: 104 vitest tests pass across the full recruiter+onboarding surface, `tsc --noEmit` clean.
- CLI package: 42 vitest tests pass, `tsc --noEmit` clean.

## FE review note
`recruit.ts`/`recruiter-client.tsx`/`connect-step.tsx` are in 미르코's frontend scope. Per PO's call, this stays one PR (splitting a single-axis rename risks a "half-renamed" state) — flagging so FE gets a review pass on those files specifically.

## Test plan
- [x] Backend unit tests (75 + 14 pass, 9 skip on missing real DB)
- [x] FE vitest (104 pass) + `tsc --noEmit` clean
- [x] CLI package vitest (42 pass) + `tsc --noEmit` clean
- [x] Repo-wide zero-remaining-reference grep sweep
- [ ] Kadir QA independent reproduction
- [ ] dev serving → prod promotion (AC5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)