### PR TITLE
fix(sdk): port #2568 attachment fix to the TS SDK (#2578)

### DIFF
--- a/connectors/opencode-sprintable/sprintable-sse.ts
+++ b/connectors/opencode-sprintable/sprintable-sse.ts
@@ -20,6 +20,19 @@
  * ```
  */
 
+/**
+ * 일반 첨부(이미지 포함 전체) — #2578: Python SDK(#2568)만 첨부 정규화를 갖고 있었고
+ * 이 TS SDK엔 처음부터 없었다(images 개념 자체도 없음 — 그건 별개의, 여전히 남은 갭).
+ * 백엔드는 payload.attachments에 이미 이걸 싣는다(mime 필터 없음 — 첨부는 전 타입 대상).
+ */
+export type MessageAttachment = {
+  url: string
+  name: string
+  contentType: string
+  size: number | null
+  assetId: string
+}
+
 export type MessageContext = {
   content: string
   conversationId: string
@@ -28,6 +41,7 @@ export type MessageContext = {
   eventId: string
   seq: number
   isBackfill: boolean
+  attachments: MessageAttachment[]
   raw: Record<string, unknown>
   /** POST /api/v2/conversations/{id}/messages */
   reply(text: string): Promise<void>
@@ -42,6 +56,42 @@ const DEDUP_TTL_MS = 300_000
 
 function _authHeaders(apiKey: string): Record<string, string> {
   return { Authorization: `Bearer ${apiKey}`, 'x-agent-api-key': apiKey }
+}
+
+/** #2578: Python _normalize_attachments 이식. mime 필터 없음 — 전 타입 대상. */
+export function normalizeAttachments(value: unknown): MessageAttachment[] {
+  if (!Array.isArray(value)) return []
+  const out: MessageAttachment[] = []
+  for (const item of value) {
+    if (typeof item !== 'object' || item === null) continue
+    const rec = item as Record<string, unknown>
+    const url = String(rec.url ?? '').trim()
+    if (!url) continue
+    const rawSize = rec.size
+    const size = typeof rawSize === 'number' && Number.isFinite(rawSize) ? rawSize : null
+    out.push({
+      url,
+      name: String(rec.name ?? ''),
+      contentType: String(rec.content_type ?? ''),
+      size,
+      assetId: String(rec.asset_id ?? ''),
+    })
+  }
+  return out
+}
+
+/**
+ * #2578 AC1: 첨부 존재+회수 경로(asset text API)를 에이전트가 알 수 있게 텍스트로 안내.
+ * asset_id가 있으면(정상 케이스) 그 경로를, 없으면(레거시/미등록) url을 안내.
+ */
+export function renderAttachmentNotice(attachments: MessageAttachment[]): string {
+  const lines = attachments.map((a) => {
+    const label = a.name || a.url
+    return a.assetId
+      ? `- ${label} (${a.contentType || 'unknown type'}) — 본문 회수: GET /api/v2/assets/${a.assetId}/text`
+      : `- ${label} (${a.contentType || 'unknown type'}) — url: ${a.url}`
+  })
+  return `[첨부 ${attachments.length}건]\n${lines.join('\n')}\n[/첨부]`
 }
 
 export async function runSprintableSSE(opts: {
@@ -157,8 +207,15 @@ export async function runSprintableSSE(opts: {
       typeof data.payload === 'object' && data.payload !== null ? data.payload : {}
     ) as Record<string, unknown>
 
-    const content = ((data.content ?? payload.content ?? '') as string).trim()
-    if (!content) return null
+    let content = ((data.content ?? payload.content ?? '') as string).trim()
+    const attachments = normalizeAttachments(data.attachments ?? payload.attachments)
+    if (!content && attachments.length === 0) return null
+    // #2578 AC1/AC2: 첨부가 있으면 안내 블록을 content에 병합 — 어댑터마다 따로 렌더하게
+    // 하지 않고 SDK 단일 지점에서 처리(Python SDK #2568과 동형, 어댑터 코드 수정 0으로 전파).
+    if (attachments.length > 0) {
+      const notice = renderAttachmentNotice(attachments)
+      content = content ? `${content}\n\n${notice}` : notice
+    }
 
     const eventId = String(data.event_id ?? payload.id ?? evId ?? crypto.randomUUID())
     if (isDup(eventId)) return null
@@ -185,7 +242,7 @@ export async function runSprintableSSE(opts: {
       : ''
 
     return {
-      content, conversationId, senderId, senderName, eventId, seq, isBackfill, raw: data,
+      content, conversationId, senderId, senderName, eventId, seq, isBackfill, attachments, raw: data,
       async reply(text: string) {
         if (!replyUrl) throw new Error('no conversation_id')
         const r = await fetch(replyUrl, {

--- a/connectors/sdk/sprintable-sse.test.ts
+++ b/connectors/sdk/sprintable-sse.test.ts
@@ -1,0 +1,137 @@
+// #2578: 웹 첨부가 에이전트 SSE 주입에 안 실림 — 회귀 방지 pin (TS side).
+// Python SDK(#2568)의 test_attachment_injection.py와 동형 커버리지. bun:test — 이 디렉토리는
+// package.json 없는 reference SDK라 부속 Python 테스트들과 같은 무설정 관례를 따른다.
+import { test, expect } from 'bun:test'
+import { normalizeAttachments, renderAttachmentNotice, runSprintableSSE, type MessageContext } from './sprintable-sse'
+
+const ATTACHMENT = {
+  url: 'https://storage.googleapis.com/bucket/notes.md',
+  name: 'notes.md',
+  content_type: 'text/markdown',
+  size: 1234,
+  asset_id: '5c1e1e1e-1111-2222-3333-444455556666',
+}
+
+test('normalizeAttachments has no mime filter (unlike an images-style filter)', () => {
+  const out = normalizeAttachments([ATTACHMENT])
+  expect(out).toHaveLength(1)
+  expect(out[0].name).toBe('notes.md')
+  expect(out[0].contentType).toBe('text/markdown')
+  expect(out[0].assetId).toBe('5c1e1e1e-1111-2222-3333-444455556666')
+})
+
+test('normalizeAttachments drops items without a url', () => {
+  expect(normalizeAttachments([{ name: 'no-url.md' }])).toEqual([])
+})
+
+test('normalizeAttachments returns [] for non-array input', () => {
+  expect(normalizeAttachments(undefined)).toEqual([])
+  expect(normalizeAttachments(null)).toEqual([])
+  expect(normalizeAttachments('not-an-array')).toEqual([])
+})
+
+test('renderAttachmentNotice uses the asset-text endpoint when assetId present', () => {
+  const notice = renderAttachmentNotice([
+    { url: 'https://x/y.md', name: 'y.md', contentType: 'text/markdown', size: null, assetId: 'abc-123' },
+  ])
+  expect(notice).toContain('GET /api/v2/assets/abc-123/text')
+  expect(notice).toContain('y.md')
+})
+
+test('renderAttachmentNotice falls back to url when assetId absent', () => {
+  const notice = renderAttachmentNotice([
+    { url: 'https://x/y.md', name: 'y.md', contentType: 'text/markdown', size: null, assetId: '' },
+  ])
+  expect(notice).toContain('url: https://x/y.md')
+  expect(notice).not.toContain('/text')
+})
+
+// ── Integration: real runSprintableSSE against a mock SSE server ─────────────
+// parseEvent() is a private closure inside runSprintableSSE (not exported), so this is the
+// only way to pin its actual wiring (content merge + drop-check widening), not just the
+// standalone helpers above.
+
+function startMockSseServer(dataLine: string) {
+  return Bun.serve({
+    port: 0,
+    fetch(req) {
+      if (req.url.includes('/api/v2/agent/stream')) {
+        const stream = new ReadableStream({
+          start(controller) {
+            const enc = new TextEncoder()
+            controller.enqueue(enc.encode(`event: message\nid: 1\ndata: ${dataLine}\n\n`))
+          },
+        })
+        return new Response(stream, { headers: { 'content-type': 'text/event-stream' } })
+      }
+      return new Response('{}', { headers: { 'content-type': 'application/json' } })
+    },
+  })
+}
+
+async function receiveOne(dataLine: string): Promise<MessageContext> {
+  const server = startMockSseServer(dataLine)
+  const controller = new AbortController()
+  const received = await new Promise<MessageContext>((resolve) => {
+    runSprintableSSE({
+      apiUrl: `http://localhost:${server.port}`,
+      apiKey: 'test-key',
+      signal: controller.signal,
+      onMessage: async (ctx) => {
+        controller.abort()
+        resolve(ctx)
+      },
+    }).catch(() => {})
+  })
+  server.stop(true)
+  return received
+}
+
+test('parseEvent populates attachments and merges notice into content', async () => {
+  const ctx = await receiveOne(JSON.stringify({
+    event_type: 'dispatched', event_id: 'evt-attach',
+    content: '여기 파일 첨부했음', attachments: [ATTACHMENT],
+  }))
+  expect(ctx.attachments).toHaveLength(1)
+  expect(ctx.attachments[0].name).toBe('notes.md')
+  expect(ctx.content).toContain('여기 파일 첨부했음')
+  expect(ctx.content).toContain('notes.md')
+  expect(ctx.content).toContain('GET /api/v2/assets/5c1e1e1e-1111-2222-3333-444455556666/text')
+})
+
+test('parseEvent is not dropped when only an attachment is present, no text', async () => {
+  const ctx = await receiveOne(JSON.stringify({
+    event_type: 'dispatched', event_id: 'evt-attach-only',
+    content: '', attachments: [ATTACHMENT],
+  }))
+  expect(ctx.content).toContain('notes.md')
+})
+
+test('parseEvent reads attachments from the payload fallback (real backend shape)', async () => {
+  const ctx = await receiveOne(JSON.stringify({
+    event_type: 'dispatched', event_id: 'evt-payload-attach',
+    payload: { content: '본문', attachments: [ATTACHMENT] },
+  }))
+  expect(ctx.attachments).toHaveLength(1)
+  expect(ctx.content).toContain('notes.md')
+})
+
+test('parseEvent still drops truly empty events (no content, no attachments)', async () => {
+  const server = startMockSseServer(JSON.stringify({
+    event_type: 'dispatched', event_id: 'evt-empty', content: '',
+  }))
+  const controller = new AbortController()
+  let gotMessage = false
+  const timeout = new Promise<void>((resolve) => setTimeout(resolve, 300))
+  const run = runSprintableSSE({
+    apiUrl: `http://localhost:${server.port}`,
+    apiKey: 'test-key',
+    signal: controller.signal,
+    onMessage: async () => { gotMessage = true },
+  }).catch(() => {})
+  await timeout
+  controller.abort()
+  await run
+  server.stop(true)
+  expect(gotMessage).toBe(false)
+})

--- a/connectors/sdk/sprintable-sse.ts
+++ b/connectors/sdk/sprintable-sse.ts
@@ -20,6 +20,19 @@
  * ```
  */
 
+/**
+ * 일반 첨부(이미지 포함 전체) — #2578: Python SDK(#2568)만 첨부 정규화를 갖고 있었고
+ * 이 TS SDK엔 처음부터 없었다(images 개념 자체도 없음 — 그건 별개의, 여전히 남은 갭).
+ * 백엔드는 payload.attachments에 이미 이걸 싣는다(mime 필터 없음 — 첨부는 전 타입 대상).
+ */
+export type MessageAttachment = {
+  url: string
+  name: string
+  contentType: string
+  size: number | null
+  assetId: string
+}
+
 export type MessageContext = {
   content: string
   conversationId: string
@@ -28,6 +41,7 @@ export type MessageContext = {
   eventId: string
   seq: number
   isBackfill: boolean
+  attachments: MessageAttachment[]
   raw: Record<string, unknown>
   /** POST /api/v2/conversations/{id}/messages */
   reply(text: string): Promise<void>
@@ -42,6 +56,42 @@ const DEDUP_TTL_MS = 300_000
 
 function _authHeaders(apiKey: string): Record<string, string> {
   return { Authorization: `Bearer ${apiKey}`, 'x-agent-api-key': apiKey }
+}
+
+/** #2578: Python _normalize_attachments 이식. mime 필터 없음 — 전 타입 대상. */
+export function normalizeAttachments(value: unknown): MessageAttachment[] {
+  if (!Array.isArray(value)) return []
+  const out: MessageAttachment[] = []
+  for (const item of value) {
+    if (typeof item !== 'object' || item === null) continue
+    const rec = item as Record<string, unknown>
+    const url = String(rec.url ?? '').trim()
+    if (!url) continue
+    const rawSize = rec.size
+    const size = typeof rawSize === 'number' && Number.isFinite(rawSize) ? rawSize : null
+    out.push({
+      url,
+      name: String(rec.name ?? ''),
+      contentType: String(rec.content_type ?? ''),
+      size,
+      assetId: String(rec.asset_id ?? ''),
+    })
+  }
+  return out
+}
+
+/**
+ * #2578 AC1: 첨부 존재+회수 경로(asset text API)를 에이전트가 알 수 있게 텍스트로 안내.
+ * asset_id가 있으면(정상 케이스) 그 경로를, 없으면(레거시/미등록) url을 안내.
+ */
+export function renderAttachmentNotice(attachments: MessageAttachment[]): string {
+  const lines = attachments.map((a) => {
+    const label = a.name || a.url
+    return a.assetId
+      ? `- ${label} (${a.contentType || 'unknown type'}) — 본문 회수: GET /api/v2/assets/${a.assetId}/text`
+      : `- ${label} (${a.contentType || 'unknown type'}) — url: ${a.url}`
+  })
+  return `[첨부 ${attachments.length}건]\n${lines.join('\n')}\n[/첨부]`
 }
 
 export async function runSprintableSSE(opts: {
@@ -157,8 +207,15 @@ export async function runSprintableSSE(opts: {
       typeof data.payload === 'object' && data.payload !== null ? data.payload : {}
     ) as Record<string, unknown>
 
-    const content = ((data.content ?? payload.content ?? '') as string).trim()
-    if (!content) return null
+    let content = ((data.content ?? payload.content ?? '') as string).trim()
+    const attachments = normalizeAttachments(data.attachments ?? payload.attachments)
+    if (!content && attachments.length === 0) return null
+    // #2578 AC1/AC2: 첨부가 있으면 안내 블록을 content에 병합 — 어댑터마다 따로 렌더하게
+    // 하지 않고 SDK 단일 지점에서 처리(Python SDK #2568과 동형, 어댑터 코드 수정 0으로 전파).
+    if (attachments.length > 0) {
+      const notice = renderAttachmentNotice(attachments)
+      content = content ? `${content}\n\n${notice}` : notice
+    }
 
     const eventId = String(data.event_id ?? payload.id ?? evId ?? crypto.randomUUID())
     if (isDup(eventId)) return null
@@ -185,7 +242,7 @@ export async function runSprintableSSE(opts: {
       : ''
 
     return {
-      content, conversationId, senderId, senderName, eventId, seq, isBackfill, raw: data,
+      content, conversationId, senderId, senderName, eventId, seq, isBackfill, attachments, raw: data,
       async reply(text: string) {
         if (!replyUrl) throw new Error('no conversation_id')
         const r = await fetch(replyUrl, {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
       '**/e2e/**',
       // QA worktrees are transient PR review directories, excluded from main test runs
       '.qa-worktrees/**',
+      // connectors/ is a no-package.json reference-SDK area (bun/pytest, unconfigured
+      // convention shared with the sibling Python tests) — its *.test.ts files use
+      // bun:test, not vitest, and vitest crashes trying to resolve that import (#2578 QA).
+      'connectors/**',
       // EE billing tests require EE-specific infrastructure (payment/factory, monthly-agent-usage-dashboard)
       // that is not available in the OSS vitest setup. These require a separate EE vitest config.
       'ee/apps/web/src/services/billing-limit-enforcer.test.ts',


### PR DESCRIPTION
## Summary
Kadir QA finding during S7 (#2562) QA: the Python SDK's #2568 fix (attachment normalization with no mime filter + asset-text retrieval notice merged into content) was never ported to the TS SDK (`connectors/sdk/sprintable-sse.ts`) — it had **no attachment handling at all** from the start, not even the `images` concept the Python side has. Every TS-SDK-based connector (opencode today, openclaw/S8 next) was silently dropping non-image web attachments exactly like #2568.

## Changes
- `MessageAttachment` type + `normalizeAttachments()` (no mime filter — every attachment type, not just images) + `renderAttachmentNotice()` (points the agent at `GET /api/v2/assets/{assetId}/text` when an `assetId` is present, falls back to the raw url otherwise) — same shape as the Python dataclasses/functions, TS idioms.
- Widened `parseEvent`'s drop-check from `!content` to `!content && attachments.length === 0` so an attachment-only message (no text) isn't silently discarded.
- Notice merged into `content` at the single SDK choke point (same as Python — zero per-adapter code changes needed downstream).
- Synced the vendored `opencode-sprintable` copy (byte-identical to canonical) — it's the only other TS copy that currently exists.

## Verification
**Live e2e (real credentials, real backend, not a mock)** — sent a real Sprintable chat message with a real uploaded attachment through the vendored `opencode-sprintable/sprintable-sse.ts`'s actual `runSprintableSSE`, confirmed the received `MessageContext` carries the attachment (name, contentType, backend-assigned assetId) and that `content` includes the retrieval notice with the *real* assetId — then independently `GET`'d that exact asset-text URL and confirmed it returns the uploaded content verbatim (`"# test notes\nhello world"`). Full round trip, not just a shape check.

**New `sprintable-sse.test.ts`** (`bun:test`, matching this directory's no-package.json reference-SDK convention, same as the sibling Python pytest files): unit coverage for `normalizeAttachments`/`renderAttachmentNotice` mirroring `test_attachment_injection.py`'s cases, plus integration tests against a real mock SSE server proving `parseEvent`'s actual wiring (content merge, drop-check widening, payload-fallback attachment reads, and a negative test confirming truly-empty events are still dropped). **9/9 pass.**

`tsc --noEmit --strict` clean on both files (verified with `bun-types` in an isolated scratch install, since this reference-SDK directory intentionally carries no `package.json`/`tsconfig` of its own).

## Explicitly out of scope
Full `images` support (mime-filtered image attachments) doesn't exist in the TS SDK either, and wasn't part of #2568/#2578's ask — that's a separate, still-acknowledged gap.

## Test plan
- [x] Live e2e round trip (real backend, real upload, real retrieval)
- [x] `bun test` — 9/9 pass
- [x] `tsc --noEmit --strict` clean
- [x] Vendored copy sync confirmed byte-identical
- [ ] Kadir QA independent reproduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)