### PR TITLE
feat(openclaw-sprintable): npm-publish readiness (S8/#2563)

### DIFF
--- a/connectors/openclaw-sprintable/README.md
+++ b/connectors/openclaw-sprintable/README.md
@@ -1,28 +1,34 @@
-# Sprintable Adapter for OpenClaw
+# openclaw-sprintable
 
-OpenClaw용 Sprintable Gateway dial-out 어댑터 (카테고리 A).
-SSE dial-out → inbound turn 주입 → 응답 → ack. 인바운드 도메인·웹훅·터널 불필요.
+Sprintable Gateway channel plugin for [OpenClaw](https://github.com/openclaw/openclaw) — real-time team chat via SSE dial-out. No inbound webhook, domain, or tunnel required.
 
-Tlon 채널 어댑터(`extensions/tlon/`)와 동형 구조.
-
-## 설치
+## Install
 
 ```bash
-# 1. git pull
-git pull origin develop
-
-# 2. openclaw extensions 폴더에 링크
-ln -sf "$(pwd)/connectors/openclaw-sprintable" ~/.openclaw/extensions/sprintable
-
-# 3. 환경 변수 설정
-export AGENT_API_KEY=sk_live_...
-export SPRINTABLE_API_URL=https://...   # 미설정 시 dev 기본값
-
-# 4. OpenClaw 재시작
-openclaw restart
+openclaw plugins install npm:@moonklabs/openclaw-sprintable
 ```
 
-또는 `~/.openclaw/openclaw.json`에 직접 설정:
+Or via [ClawHub](https://clawhub.dev) (the primary discovery surface for OpenClaw plugins):
+
+```bash
+openclaw plugins install clawhub:@moonklabs/openclaw-sprintable
+```
+
+**Restart the gateway after install** — plugin installation alone does not start serving:
+
+```bash
+openclaw daemon restart   # or: openclaw restart, depending on your setup
+```
+
+Verify the plugin is actually loaded and running (install success ≠ serving):
+
+```bash
+openclaw plugins inspect sprintable --runtime
+```
+
+## Configure
+
+Set credentials in `~/.openclaw/openclaw.json`:
 
 ```json
 {
@@ -30,17 +36,19 @@ openclaw restart
     "sprintable": {
       "enabled": true,
       "apiKey": "sk_live_...",
-      "apiUrl": "https://sprintable-backend-dev-57iommnikq-du.a.run.app"
+      "apiUrl": "https://app.sprintable.ai"
     }
   }
 }
 ```
 
-## 동작 원리
+Or via environment variables (`SPRINTABLE_API_KEY` / `AGENT_API_KEY`, `SPRINTABLE_API_URL`) — config takes precedence over env when both are set.
+
+## How it works
 
 ```
 GET /api/v2/agent/stream (SSE)
-  → runSprintableSSE (SDK)
+  → runSprintableSSE (vendored SDK)
   → onMessage()
   → runtime.channel.inbound.buildContext(...)
   → runtime.channel.inbound.dispatchReply(...)
@@ -48,5 +56,28 @@ GET /api/v2/agent/stream (SSE)
   → ack: POST /api/v2/agent/events/ack
 ```
 
-공통 SDK(`connectors/sdk/sprintable-sse.ts`) 재사용 — SSE 소비·dedup·ack·backoff 담당.
-어댑터는 `gateway.startAccount` + inbound turn 주입부만 구현.
+- Started via `gateway.startAccount` — OpenClaw's documented seam for channels that
+  dial out to fetch messages rather than receive an inbound webhook (native ChannelPlugin,
+  gateway-daemon-resident, same category as WhatsApp/Telegram).
+- `gateway.stopAccount` tears the SSE loop down on channel stop/restart — wired through both
+  OpenClaw's own `ctx.abortSignal` and an explicit per-account `AbortController`, matching the
+  actual-not-just-declared dispose contract this session's #2578/S7 QA required for the sibling
+  OpenCode connector's SDK.
+- SSE consumption, dedup, ack, backoff, and attachment handling live in the vendored
+  `sprintable-sse.ts` (SDK original: `connectors/sdk/sprintable-sse.ts` — published packages
+  can't resolve a monorepo-relative `../sdk/...` import, so a copy ships in this package;
+  keep it synced with the canonical SDK when it changes — see [`project_vendored_sdk_sync_debt`]
+  for the tracked follow-up to end this vendoring pattern via an SDK-as-npm-package extraction).
+
+## Packaging notes
+
+- **Pure JS ship, no postinstall build.** `openclaw plugins install` runs
+  `npm install --ignore-scripts` — this package ships pre-built `dist/*.js` + `.d.ts`
+  (via `tsup`), not raw TypeScript. `openclaw.extensions`/`openclaw.setupEntry` point at the
+  TS sources (for bundled/dev loads); `openclaw.runtimeExtensions`/`openclaw.runtimeSetupEntry`
+  point at the built JS (what installed packages actually load).
+- **`openclaw.compat.pluginApi`** is pinned to the exact version this package was built and
+  ground-truthed against (`>=2026.7.1`) — a stale/looser floor is what lets a compat gate
+  silently install an old, incompatible version instead of failing closed.
+- Setup entry (`setup-entry.ts`) exports the plugin object only — no listeners, clients, or
+  transport runtimes start from it, per OpenClaw's setup-entry contract.

--- a/connectors/openclaw-sprintable/index.ts
+++ b/connectors/openclaw-sprintable/index.ts
@@ -1,192 +1,33 @@
 /**
- * Sprintable Gateway adapter for OpenClaw — E-INJECT-ADAPTERS (카테고리 A).
+ * Sprintable Gateway channel plugin for OpenClaw — main entry point.
  *
- * SSE dial-out 패턴: /api/v2/agent/stream 소비 → inbound turn 주입 → 응답 → ack.
- * 공통 SDK(connectors/sdk/sprintable-sse.ts) 재사용.
- * Tlon 채널 어댑터(extensions/tlon/)와 동형 구조.
+ * Uses `defineChannelPluginEntry` (the current, documented entry helper — ground-truthed
+ * against openclaw@2026.7.1-2's docs/plugins/sdk-channel-plugins.md walkthrough) instead of
+ * exporting the ChannelPlugin object directly. `registerCliMetadata` is safe to run on every
+ * CLI invocation (help text, status scans) without starting the SSE dial-out; the actual
+ * listener only starts via `plugin.gateway.startAccount`, which OpenClaw calls once the
+ * channel is configured and the full gateway runtime boots — never from CLI-metadata-only
+ * paths. This is the trap S8's research doc flagged: don't load listeners from the setup
+ * entry, only from full-runtime registration.
  */
+import { defineChannelPluginEntry } from 'openclaw/plugin-sdk/channel-core'
+import { sprintablePlugin, CHANNEL_ID } from './src/channel.js'
 
-import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
-import { createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
-import type { ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
-import type { PluginRuntime } from "openclaw/plugin-sdk";
-import { runSprintableSSE } from "../sdk/sprintable-sse.js";
-
-const CHANNEL_ID = "sprintable" as const;
-const DEFAULT_API_URL = "https://sprintable-backend-dev-57iommnikq-du.a.run.app";
-
-// ── Account shape ─────────────────────────────────────────────────────────────
-
-type SprintableAccount = {
-  accountId: string;
-  enabled: boolean;
-  configured: boolean;
-  apiKey: string;
-  apiUrl: string;
-};
-
-function resolveAccount(cfg: Record<string, unknown>, accountId?: string): SprintableAccount {
-  const section = (cfg.channels as Record<string, unknown>)?.[CHANNEL_ID] as Record<string, unknown> | undefined;
-  const id = accountId ?? DEFAULT_ACCOUNT_ID;
-  return {
-    accountId: id,
-    enabled: section?.enabled !== false,
-    configured: Boolean(section?.apiKey ?? process.env.AGENT_API_KEY),
-    apiKey: String(section?.apiKey ?? process.env.AGENT_API_KEY ?? ""),
-    apiUrl: String(section?.apiUrl ?? process.env.SPRINTABLE_API_URL ?? DEFAULT_API_URL),
-  };
-}
-
-// ── Sprintable channel plugin ─────────────────────────────────────────────────
-
-export const sprintablePlugin: ChannelPlugin<SprintableAccount> = createChatChannelPlugin({
-  base: {
-    id: CHANNEL_ID,
-    meta: {
-      id: CHANNEL_ID,
-      label: "Sprintable",
-      selectionLabel: "Sprintable Agent Gateway",
-      docsPath: "/channels/sprintable",
-      docsLabel: "sprintable",
-      blurb: "Sprintable project management — dial-out SSE gateway",
-      aliases: ["sprintable"],
-      order: 95,
-    },
-    capabilities: {
-      chatTypes: ["direct", "group"],
-      media: false,
-      reply: true,
-      threads: false,
-    },
-    setup: {
-      isConfigured: (account: SprintableAccount) => account.configured,
-      describeAccount: (account: SprintableAccount) => ({
-        accountId: account.accountId,
-        configured: account.configured,
-        enabled: account.enabled,
-      }),
-    },
-    reload: { configPrefixes: [`channels.${CHANNEL_ID}`] },
-    config: {
-      listAccountIds: (cfg) => {
-        const section = (cfg.channels as Record<string, unknown>)?.[CHANNEL_ID];
-        return section ? [DEFAULT_ACCOUNT_ID] : [];
+export default defineChannelPluginEntry({
+  id: CHANNEL_ID,
+  name: 'Sprintable',
+  description: 'Sprintable channel — real-time Agent Gateway events (SSE dial-out) + reply.',
+  plugin: sprintablePlugin,
+  registerCliMetadata(api) {
+    api.registerCli(
+      ({ program }) => {
+        program.command('sprintable').description('Sprintable channel management')
       },
-      resolveAccount: (cfg, accountId) => resolveAccount(cfg as Record<string, unknown>, accountId),
-      isConfigured: (account: SprintableAccount) => account.configured,
-      describeAccount: (account: SprintableAccount) => ({
-        accountId: account.accountId,
-        configured: account.configured,
-        enabled: account.enabled,
-      }),
-    },
-    messaging: {
-      targetPrefixes: [CHANNEL_ID],
-      normalizeTarget: (target: string) => target.replace(/^sprintable:/, ""),
-      targetResolver: {
-        looksLikeId: (target: string) => target.startsWith("sprintable:") || target.includes("/"),
-        hint: "sprintable:<conversation_id>",
+      {
+        descriptors: [
+          { name: 'sprintable', description: 'Sprintable channel management', hasSubcommands: false },
+        ],
       },
-      resolveOutboundSessionRoute: ({ to }: { to: string }) => ({
-        agentId: DEFAULT_ACCOUNT_ID,
-        sessionKey: to.replace(/^sprintable:/, ""),
-      }),
-    },
-    gateway: {
-      startAccount: async (ctx) => {
-        const account = ctx.account;
-        if (!account.configured || !account.apiKey) {
-          ctx.log?.warn?.(`[sprintable] account ${account.accountId} not configured — skipping`);
-          return;
-        }
-        ctx.setStatus({
-          accountId: account.accountId,
-          configured: true,
-          enabled: account.enabled,
-        });
-        ctx.log?.info?.(`[sprintable] starting gateway dial-out for account ${account.accountId}`);
-
-        // channelRuntime 접근 (optional —외부 플러그인 호환)
-        const rt = ctx.channelRuntime as unknown as PluginRuntime["channel"] | undefined;
-        if (!rt?.inbound) {
-          ctx.log?.warn?.("[sprintable] channelRuntime.inbound unavailable — skipping turn dispatch");
-          return;
-        }
-
-        // 기본 agentId: cfg.agents.accounts의 첫 번째 에이전트 또는 "main"
-        const agentsCfg = (ctx.cfg as Record<string, unknown>).agents as
-          | { accounts?: Record<string, unknown> } | undefined;
-        const agentId =
-          Object.keys(agentsCfg?.accounts ?? {})[0] ?? DEFAULT_ACCOUNT_ID;
-
-        await runSprintableSSE({
-          apiUrl: account.apiUrl,
-          apiKey: account.apiKey,
-          signal: ctx.abortSignal,
-          onMessage: async (msg) => {
-            const ctxPayload = rt.inbound.buildContext({
-              channel: CHANNEL_ID,
-              accountId: account.accountId,
-              messageId: msg.eventId,
-              timestamp: new Date(),
-              from: `sprintable:${msg.conversationId || msg.senderId}`,
-              sender: {
-                id: msg.senderId,
-                name: msg.senderName,
-              },
-              conversation: {
-                kind: "group",
-                id: msg.conversationId,
-                label: msg.conversationId,
-              },
-              route: {
-                agentId,
-                accountId: account.accountId,
-                routeSessionKey: msg.conversationId,
-              },
-              reply: {
-                to: `sprintable:${msg.conversationId}`,
-              },
-              message: {
-                body: msg.content,
-                bodyForAgent: msg.content,
-                rawBody: msg.content,
-                commandBody: msg.content,
-              },
-            });
-
-            await rt.inbound.dispatchReply({
-              channel: CHANNEL_ID,
-              accountId: account.accountId,
-              cfg: ctx.cfg,
-              agentId,
-              routeSessionKey: msg.conversationId,
-              storePath: undefined,
-              ctxPayload,
-              recordInboundSession: rt.session?.recordInboundSession,
-              dispatchReplyWithBufferedBlockDispatcher:
-                rt.reply?.dispatchReplyWithBufferedBlockDispatcher,
-              delivery: {
-                durable: () => ({ to: `sprintable:${msg.conversationId}` }),
-                deliver: async (payload: { text?: string }) => {
-                  if (payload.text) await msg.reply(payload.text);
-                },
-              },
-            });
-          },
-        });
-      },
-    },
+    )
   },
-  outbound: {
-    deliveryMode: "direct",
-    textChunkLimit: 4000,
-    resolveTarget: ({ to }: { to: string }) => ({
-      ok: true,
-      target: to.replace(/^sprintable:/, ""),
-    }),
-    deliveryCapabilities: {
-      durableFinal: { text: true },
-    },
-  },
-});
+})

--- a/connectors/openclaw-sprintable/openclaw.plugin.json
+++ b/connectors/openclaw-sprintable/openclaw.plugin.json
@@ -1,0 +1,33 @@
+{
+  "id": "sprintable",
+  "channels": ["sprintable"],
+  "name": "Sprintable",
+  "description": "Sprintable Gateway channel — real-time team chat (SSE dial-out, no inbound webhook).",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  },
+  "channelConfigs": {
+    "sprintable": {
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "apiKey": { "type": "string" },
+          "apiUrl": { "type": "string" }
+        }
+      },
+      "uiHints": {
+        "apiKey": {
+          "label": "Sprintable Agent API Key",
+          "sensitive": true
+        },
+        "apiUrl": {
+          "label": "Sprintable API URL",
+          "sensitive": false
+        }
+      }
+    }
+  }
+}

--- a/connectors/openclaw-sprintable/package.json
+++ b/connectors/openclaw-sprintable/package.json
@@ -1,11 +1,58 @@
 {
-  "name": "@sprintable/openclaw-adapter",
+  "name": "@moonklabs/openclaw-sprintable",
   "version": "0.1.0",
-  "description": "Sprintable Gateway adapter for OpenClaw",
+  "description": "Sprintable Gateway channel plugin for OpenClaw — real-time team chat via SSE dial-out (no inbound webhook required).",
+  "keywords": [
+    "openclaw-plugin",
+    "sprintable",
+    "channel"
+  ],
   "type": "module",
-  "main": "./index.ts",
-  "peerDependencies": {
-    "openclaw": ">=2026.1.0"
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "openclaw.plugin.json",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/moonklabs/sprintable.git",
+    "directory": "connectors/openclaw-sprintable"
   },
-  "dependencies": {}
+  "license": "MIT",
+  "scripts": {
+    "build": "tsup index.ts setup-entry.ts --format esm --dts --out-dir dist --clean",
+    "test": "bun test src/channel.test.ts"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "runtimeExtensions": [
+      "./dist/index.js"
+    ],
+    "setupEntry": "./setup-entry.ts",
+    "runtimeSetupEntry": "./dist/setup-entry.js",
+    "channel": {
+      "id": "sprintable",
+      "label": "Sprintable",
+      "blurb": "Sprintable project management — dial-out SSE gateway"
+    },
+    "compat": {
+      "pluginApi": ">=2026.7.1"
+    },
+    "install": {
+      "clawhubSpec": "@moonklabs/openclaw-sprintable",
+      "npmSpec": "@moonklabs/openclaw-sprintable"
+    }
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.7.1"
+  },
+  "devDependencies": {
+    "openclaw": "^2026.7.1-2",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3"
+  }
 }

--- a/connectors/openclaw-sprintable/package.json
+++ b/connectors/openclaw-sprintable/package.json
@@ -23,6 +23,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsup index.ts setup-entry.ts --format esm --dts --out-dir dist --clean",
+    "prepack": "npm run build",
     "test": "bun test src/channel.test.ts"
   },
   "openclaw": {

--- a/connectors/openclaw-sprintable/setup-entry.ts
+++ b/connectors/openclaw-sprintable/setup-entry.ts
@@ -1,0 +1,11 @@
+/**
+ * Lightweight setup entry — loaded during onboarding, deferred channel startup, and
+ * read-only status/SecretRef scans. Must NOT start clients, listeners, or transport
+ * runtimes (per docs/plugins/sdk-channel-plugins.md's explicit warning) — this only
+ * exports the plugin object itself, same as the main index.ts's `plugin` field, so
+ * OpenClaw can answer "is sprintable configured?" without booting the SSE dial-out.
+ */
+import { defineSetupPluginEntry } from 'openclaw/plugin-sdk/channel-core'
+import { sprintablePlugin } from './src/channel.js'
+
+export default defineSetupPluginEntry(sprintablePlugin)

--- a/connectors/openclaw-sprintable/sprintable-sse.ts
+++ b/connectors/openclaw-sprintable/sprintable-sse.ts
@@ -1,0 +1,278 @@
+/**
+ * Sprintable Gateway SSE Reference SDK — TypeScript/Bun
+ *
+ * 공통부: SSE 소비 · 파서 · dedup · ack(contiguous, min-1 앵커링) · backoff 재연결.
+ * 어댑터는 `onMessage` 콜백(주입부)만 구현하면 된다.
+ *
+ * @example
+ * ```ts
+ * import { runSprintableSSE } from './sprintable-sse'
+ *
+ * await runSprintableSSE({
+ *   apiUrl: 'https://sprintable-backend-dev-57iommnikq-du.a.run.app',
+ *   apiKey: process.env.AGENT_API_KEY!,
+ *   async onMessage(ctx) {
+ *     // runtime-specific injection
+ *     const response = await myAgent.handle(ctx.content)
+ *     await ctx.reply(response)
+ *   },
+ * })
+ * ```
+ */
+
+/**
+ * 일반 첨부(이미지 포함 전체) — #2578: Python SDK(#2568)만 첨부 정규화를 갖고 있었고
+ * 이 TS SDK엔 처음부터 없었다(images 개념 자체도 없음 — 그건 별개의, 여전히 남은 갭).
+ * 백엔드는 payload.attachments에 이미 이걸 싣는다(mime 필터 없음 — 첨부는 전 타입 대상).
+ */
+export type MessageAttachment = {
+  url: string
+  name: string
+  contentType: string
+  size: number | null
+  assetId: string
+}
+
+export type MessageContext = {
+  content: string
+  conversationId: string
+  senderId: string
+  senderName: string
+  eventId: string
+  seq: number
+  isBackfill: boolean
+  attachments: MessageAttachment[]
+  raw: Record<string, unknown>
+  /** POST /api/v2/conversations/{id}/messages */
+  reply(text: string): Promise<void>
+}
+
+export type OnMessage = (ctx: MessageContext) => Promise<void>
+
+const DEFAULT_API_URL = 'https://sprintable-backend-dev-57iommnikq-du.a.run.app'
+const RECONNECT_BACKOFF = [2000, 5000, 10000, 30000, 60000]
+const DEDUP_MAX = 1000
+const DEDUP_TTL_MS = 300_000
+
+function _authHeaders(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}`, 'x-agent-api-key': apiKey }
+}
+
+/** #2578: Python _normalize_attachments 이식. mime 필터 없음 — 전 타입 대상. */
+export function normalizeAttachments(value: unknown): MessageAttachment[] {
+  if (!Array.isArray(value)) return []
+  const out: MessageAttachment[] = []
+  for (const item of value) {
+    if (typeof item !== 'object' || item === null) continue
+    const rec = item as Record<string, unknown>
+    const url = String(rec.url ?? '').trim()
+    if (!url) continue
+    const rawSize = rec.size
+    const size = typeof rawSize === 'number' && Number.isFinite(rawSize) ? rawSize : null
+    out.push({
+      url,
+      name: String(rec.name ?? ''),
+      contentType: String(rec.content_type ?? ''),
+      size,
+      assetId: String(rec.asset_id ?? ''),
+    })
+  }
+  return out
+}
+
+/**
+ * #2578 AC1: 첨부 존재+회수 경로(asset text API)를 에이전트가 알 수 있게 텍스트로 안내.
+ * asset_id가 있으면(정상 케이스) 그 경로를, 없으면(레거시/미등록) url을 안내.
+ */
+export function renderAttachmentNotice(attachments: MessageAttachment[]): string {
+  const lines = attachments.map((a) => {
+    const label = a.name || a.url
+    return a.assetId
+      ? `- ${label} (${a.contentType || 'unknown type'}) — 본문 회수: GET /api/v2/assets/${a.assetId}/text`
+      : `- ${label} (${a.contentType || 'unknown type'}) — url: ${a.url}`
+  })
+  return `[첨부 ${attachments.length}건]\n${lines.join('\n')}\n[/첨부]`
+}
+
+export async function runSprintableSSE(opts: {
+  apiUrl?: string
+  apiKey: string
+  onMessage: OnMessage
+  signal?: AbortSignal
+}): Promise<void> {
+  const { apiKey, onMessage } = opts
+  const apiUrl = (opts.apiUrl ?? DEFAULT_API_URL).replace(/\/$/, '')
+
+  let lastEventId = ''
+  let lastAcked = 0
+  let backoffIdx = 0
+  const seen = new Map<string, number>()
+
+  function isDup(eventId: string): boolean {
+    const now = Date.now()
+    if (seen.size > DEDUP_MAX) {
+      for (const [k, v] of seen) if (now - v > DEDUP_TTL_MS) seen.delete(k)
+    }
+    if (seen.has(eventId)) return true
+    seen.set(eventId, now)
+    return false
+  }
+
+  async function ack(seq: number): Promise<void> {
+    if (seq <= lastAcked) return
+    try {
+      const resp = await fetch(`${apiUrl}/api/v2/agent/events/ack`, {
+        method: 'POST',
+        headers: { ..._authHeaders(apiKey), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ seq }),
+      })
+      if (resp.ok) {
+        lastAcked = seq
+        process.stderr.write(`[sprintable-sse] ack seq=${seq}\n`)
+      }
+    } catch (e) {
+      process.stderr.write(`[sprintable-sse] ack error seq=${seq}: ${e}\n`)
+    }
+  }
+
+  async function consume(): Promise<void> {
+    const headers: Record<string, string> = {
+      ..._authHeaders(apiKey),
+      Accept: 'text/event-stream',
+      'Cache-Control': 'no-cache',
+    }
+    if (lastEventId) headers['Last-Event-ID'] = lastEventId
+
+    const resp = await fetch(`${apiUrl}/api/v2/agent/stream`, { headers, signal: opts.signal })
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+    if (!resp.body) throw new Error('no body')
+
+    process.stderr.write('[sprintable-sse] stream open\n')
+    backoffIdx = 0
+
+    const reader = resp.body.getReader()
+    const dec = new TextDecoder()
+    let buf = ''
+    let evType = 'message', evId = '', dataLines: string[] = []
+
+    while (true) {
+      if (opts.signal?.aborted) {
+        await reader.cancel()
+        return
+      }
+      const { done, value } = await reader.read()
+      if (done) break
+      buf += dec.decode(value, { stream: true })
+      const lines = buf.split('\n')
+      buf = lines.pop() ?? ''
+
+      for (const raw of lines) {
+        const line = raw.replace(/\r$/, '')
+        if (line === '') {
+          if (dataLines.length) {
+            const ctx = await parseEvent(evType, evId, dataLines.join('\n'), apiUrl, apiKey)
+            if (ctx) {
+              process.stderr.write(
+                `[sprintable-sse] inbound seq=${ctx.seq} conv=${ctx.conversationId}: ${ctx.content.slice(0, 80)}\n`
+              )
+              await onMessage(ctx)
+              if (ctx.seq) await ack(ctx.seq)
+            }
+          }
+          evType = 'message'; evId = ''; dataLines = []
+        } else if (line.startsWith(':')) {
+          // comment
+        } else if (line.startsWith('event:')) {
+          evType = line.slice(6).trim()
+        } else if (line.startsWith('id:')) {
+          evId = line.slice(3).trim()
+        } else if (line.startsWith('data:')) {
+          const v = line.slice(5)
+          dataLines.push(v.startsWith(' ') ? v.slice(1) : v)
+        }
+      }
+    }
+    process.stderr.write('[sprintable-sse] stream closed\n')
+  }
+
+  async function parseEvent(
+    evType: string, evId: string, dataStr: string,
+    apiUrl: string, apiKey: string,
+  ): Promise<MessageContext | null> {
+    if (evType === 'heartbeat') return null
+    let data: Record<string, unknown>
+    try { data = JSON.parse(dataStr) } catch { return null }
+
+    const payload = (
+      typeof data.payload === 'object' && data.payload !== null ? data.payload : {}
+    ) as Record<string, unknown>
+
+    let content = ((data.content ?? payload.content ?? '') as string).trim()
+    const attachments = normalizeAttachments(data.attachments ?? payload.attachments)
+    if (!content && attachments.length === 0) return null
+    // #2578 AC1/AC2: 첨부가 있으면 안내 블록을 content에 병합 — 어댑터마다 따로 렌더하게
+    // 하지 않고 SDK 단일 지점에서 처리(Python SDK #2568과 동형, 어댑터 코드 수정 0으로 전파).
+    if (attachments.length > 0) {
+      const notice = renderAttachmentNotice(attachments)
+      content = content ? `${content}\n\n${notice}` : notice
+    }
+
+    const eventId = String(data.event_id ?? payload.id ?? evId ?? crypto.randomUUID())
+    if (isDup(eventId)) return null
+    if (evId) lastEventId = evId
+
+    let seq = 0
+    for (const cand of [data.recipient_seq, payload.recipient_seq]) {
+      const n = Number(cand)
+      if (Number.isFinite(n) && n > 0) { seq = n; break }
+    }
+
+    const conversationId = String(
+      payload.conversation_id ?? payload.thread_id ?? data.conversation_id ?? ''
+    )
+    const sender = (
+      typeof payload.sender === 'object' && payload.sender !== null ? payload.sender : {}
+    ) as Record<string, unknown>
+    const senderId = String(sender.id ?? data.sender_id ?? 'sprintable')
+    const senderName = String(sender.name ?? senderId)
+    const isBackfill = Boolean(data.is_backfill)
+
+    const replyUrl = conversationId
+      ? `${apiUrl}/api/v2/conversations/${conversationId}/messages`
+      : ''
+
+    return {
+      content, conversationId, senderId, senderName, eventId, seq, isBackfill, attachments, raw: data,
+      async reply(text: string) {
+        if (!replyUrl) throw new Error('no conversation_id')
+        const r = await fetch(replyUrl, {
+          method: 'POST',
+          headers: { ..._authHeaders(apiKey), 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content: text }),
+        })
+        if (!r.ok) throw new Error(`reply HTTP ${r.status}`)
+      },
+    }
+  }
+
+  // main loop
+  while (true) {
+    if (opts.signal?.aborted) return
+    const t0 = Date.now()
+    try {
+      await consume()
+    } catch (e) {
+      if (opts.signal?.aborted) return
+      process.stderr.write(`[sprintable-sse] error: ${e}\n`)
+    }
+    if (opts.signal?.aborted) return
+    if (Date.now() - t0 >= 60_000) backoffIdx = 0
+    const delay = RECONNECT_BACKOFF[Math.min(backoffIdx, RECONNECT_BACKOFF.length - 1)]
+    process.stderr.write(`[sprintable-sse] reconnecting in ${delay}ms\n`)
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, delay)
+      opts.signal?.addEventListener('abort', () => { clearTimeout(timer); resolve() }, { once: true })
+    })
+    backoffIdx++
+  }
+}

--- a/connectors/openclaw-sprintable/src/channel.ts
+++ b/connectors/openclaw-sprintable/src/channel.ts
@@ -56,6 +56,7 @@ export const sprintablePlugin: ChannelPlugin<SprintableAccount> = createChatChan
     meta: {
       id: CHANNEL_ID,
       label: 'Sprintable',
+      selectionLabel: 'Sprintable Agent Gateway',
       docsPath: '/channels/sprintable',
       blurb: 'Sprintable project management — dial-out SSE gateway',
     },

--- a/connectors/openclaw-sprintable/src/channel.ts
+++ b/connectors/openclaw-sprintable/src/channel.ts
@@ -1,0 +1,192 @@
+/**
+ * Sprintable channel plugin for OpenClaw — ChannelPlugin object.
+ *
+ * SSE dial-out pattern (matches every other Sprintable connector): outbound-only
+ * consumption of GET /api/v2/agent/stream, no inbound webhook. `gateway.startAccount`
+ * is OpenClaw's documented seam for exactly this ("Channel plugins that need... AI-powered
+ * response generation and delivery", @since Plugin SDK 2026.2.19) — ground-truthed against
+ * the real openclaw@2026.7.1-2 npm package's shipped .d.ts (not assumed from older code).
+ *
+ * `base` is built as a plain object (not via the `createChannelPluginBase(...)` helper) —
+ * that helper's own option type does not accept a `gateway` field at all, while `base`'s
+ * type (`Omit<ChannelPlugin, "security"|"pairing"|"threading"|"outbound"> & Partial<...>`)
+ * does allow it since `gateway` is optional on the full `ChannelPlugin` type and isn't
+ * excluded by that Omit. A plain object is simplest and fully type-correct here.
+ */
+import { createChatChannelPlugin } from 'openclaw/plugin-sdk/channel-core'
+import type { ChannelPlugin, OpenClawConfig, PluginRuntime } from 'openclaw/plugin-sdk/channel-core'
+import { DEFAULT_ACCOUNT_ID } from 'openclaw/plugin-sdk/account-id'
+import { runSprintableSSE } from '../sprintable-sse.js'
+
+export const CHANNEL_ID = 'sprintable'
+const DEFAULT_API_URL = 'https://app.sprintable.ai'
+
+type SprintableAccount = {
+  accountId: string
+  configured: boolean
+  apiKey: string
+  apiUrl: string
+}
+
+function resolveAccount(cfg: OpenClawConfig, accountId?: string | null): SprintableAccount {
+  const section = (cfg.channels as Record<string, unknown>)?.[CHANNEL_ID] as
+    | Record<string, unknown>
+    | undefined
+  // Dual resolution (config OR env), matching the doc's channelEnvVars pattern and this
+  // connector family's existing convention (opencode/grok/gemini all read AGENT_API_KEY too).
+  const apiKey = String(section?.apiKey ?? process.env.SPRINTABLE_API_KEY ?? process.env.AGENT_API_KEY ?? '')
+  const apiUrl = String(section?.apiUrl ?? process.env.SPRINTABLE_API_URL ?? DEFAULT_API_URL)
+  return {
+    accountId: accountId ?? DEFAULT_ACCOUNT_ID,
+    configured: Boolean(apiKey),
+    apiKey,
+    apiUrl,
+  }
+}
+
+// One AbortController per running account — stopAccount() must be able to reach the
+// exact controller startAccount() created, not rely on ctx.abortSignal alone (that
+// signal already fires on gateway stop, but stopAccount is also OpenClaw's own explicit
+// per-account teardown seam — wiring both keeps behavior correct under either trigger).
+const runningControllers = new Map<string, AbortController>()
+
+export const sprintablePlugin: ChannelPlugin<SprintableAccount> = createChatChannelPlugin({
+  base: {
+    id: CHANNEL_ID,
+    meta: {
+      id: CHANNEL_ID,
+      label: 'Sprintable',
+      docsPath: '/channels/sprintable',
+      blurb: 'Sprintable project management — dial-out SSE gateway',
+    },
+    capabilities: {
+      chatTypes: ['direct', 'group'],
+      media: false,
+      reply: true,
+      threads: false,
+    },
+    config: {
+      listAccountIds: (cfg) => {
+        const section = (cfg.channels as Record<string, unknown>)?.[CHANNEL_ID]
+        return section ? [DEFAULT_ACCOUNT_ID] : []
+      },
+      resolveAccount,
+      inspectAccount(cfg, accountId) {
+        const account = resolveAccount(cfg, accountId)
+        return {
+          enabled: account.configured,
+          configured: account.configured,
+          apiKeyStatus: account.configured ? 'available' : 'missing',
+        }
+      },
+    },
+    setup: {
+      applyAccountConfig: ({ cfg, input }) => ({
+        ...cfg,
+        channels: {
+          ...(cfg as Record<string, unknown>).channels,
+          [CHANNEL_ID]: { ...((cfg as Record<string, unknown>).channels as any)?.[CHANNEL_ID], ...input },
+        },
+      }),
+    },
+    reload: { configPrefixes: [`channels.${CHANNEL_ID}`] },
+    messaging: {
+      targetPrefixes: [CHANNEL_ID],
+      normalizeTarget: (target: string) => target.replace(/^sprintable:/, ''),
+      targetResolver: {
+        looksLikeId: (target: string) => target.startsWith('sprintable:') || target.includes('/'),
+        hint: 'sprintable:<conversation_id>',
+      },
+      resolveOutboundSessionRoute: ({ to }: { to: string }) => ({
+        agentId: DEFAULT_ACCOUNT_ID,
+        sessionKey: to.replace(/^sprintable:/, ''),
+      }),
+    },
+    gateway: {
+      startAccount: async (ctx) => {
+        const account = ctx.account
+        if (!account.configured) {
+          ctx.log?.warn?.(`[sprintable] account ${account.accountId} not configured — skipping`)
+          return
+        }
+        ctx.setStatus({ accountId: account.accountId, configured: true, enabled: true })
+        ctx.log?.info?.(`[sprintable] starting SSE dial-out for account ${account.accountId}`)
+
+        const rt = ctx.channelRuntime as unknown as PluginRuntime['channel'] | undefined
+        if (!rt?.inbound) {
+          ctx.log?.warn?.('[sprintable] channelRuntime.inbound unavailable — skipping turn dispatch')
+          return
+        }
+
+        // Own controller, chained to ctx.abortSignal — either the gateway-level signal
+        // firing OR an explicit stopAccount() call tears the SSE loop down (see #2578/S7
+        // QA: dispose must actually abort the in-flight fetch, not just skip reconnects —
+        // runSprintableSSE's own signal wiring already handles that correctly; this just
+        // makes sure something actually calls abort() on both triggers).
+        const controller = new AbortController()
+        ctx.abortSignal.addEventListener('abort', () => controller.abort(), { once: true })
+        runningControllers.set(account.accountId, controller)
+
+        const agentsCfg = (ctx.cfg as Record<string, unknown>).agents as
+          | { accounts?: Record<string, unknown> }
+          | undefined
+        const agentId = Object.keys(agentsCfg?.accounts ?? {})[0] ?? DEFAULT_ACCOUNT_ID
+
+        await runSprintableSSE({
+          apiUrl: account.apiUrl,
+          apiKey: account.apiKey,
+          signal: controller.signal,
+          onMessage: async (msg) => {
+            const ctxPayload = rt.inbound.buildContext({
+              channel: CHANNEL_ID,
+              accountId: account.accountId,
+              messageId: msg.eventId,
+              timestamp: new Date(),
+              from: `sprintable:${msg.conversationId || msg.senderId}`,
+              sender: { id: msg.senderId, name: msg.senderName },
+              conversation: { kind: 'group', id: msg.conversationId, label: msg.conversationId },
+              route: { agentId, accountId: account.accountId, routeSessionKey: msg.conversationId },
+              reply: { to: `sprintable:${msg.conversationId}` },
+              message: {
+                body: msg.content,
+                bodyForAgent: msg.content,
+                rawBody: msg.content,
+                commandBody: msg.content,
+              },
+            })
+
+            await rt.inbound.dispatchReply({
+              channel: CHANNEL_ID,
+              accountId: account.accountId,
+              cfg: ctx.cfg,
+              agentId,
+              routeSessionKey: msg.conversationId,
+              storePath: undefined,
+              ctxPayload,
+              recordInboundSession: rt.session?.recordInboundSession,
+              dispatchReplyWithBufferedBlockDispatcher: rt.reply?.dispatchReplyWithBufferedBlockDispatcher,
+              delivery: {
+                durable: () => ({ to: `sprintable:${msg.conversationId}` }),
+                deliver: async (payload: { text?: string }) => {
+                  if (payload.text) await msg.reply(payload.text)
+                },
+              },
+            })
+          },
+        })
+      },
+      stopAccount: async (ctx) => {
+        const controller = runningControllers.get(ctx.account.accountId)
+        controller?.abort()
+        runningControllers.delete(ctx.account.accountId)
+        ctx.log?.info?.(`[sprintable] stopped SSE dial-out for account ${ctx.account.accountId}`)
+      },
+    },
+  },
+  outbound: {
+    deliveryMode: 'direct',
+    textChunkLimit: 4000,
+    resolveTarget: ({ to }: { to: string }) => ({ ok: true, target: to.replace(/^sprintable:/, '') }),
+    deliveryCapabilities: { durableFinal: { text: true } },
+  },
+})


### PR DESCRIPTION
## Summary
Rebuilds `connectors/openclaw-sprintable` for real npm-publish + install via `openclaw plugins install npm:@moonklabs/openclaw-sprintable`. The old code (#1151, E-INJECT-ADAPTERS era) was never publish-ready — monorepo-relative SDK import (same bug already fixed for opencode-sprintable in #2562), no `openclaw.plugin.json`, no `package.json#openclaw` block, no real entry-point wiring. This is a from-scratch packaging pass, ground-truthed against the real `openclaw@2026.7.1-2` npm package's shipped `.d.ts` and bundled docs — not assumed from the old code or public docs alone.

## What's grounded (with sources)
- `defineChannelPluginEntry`/`defineSetupPluginEntry` (`openclaw/plugin-sdk/channel-core`) are the current documented entry helpers — `docs/plugins/sdk-channel-plugins.md`'s full walkthrough.
- `gateway.startAccount`/`stopAccount` on `ChannelPlugin` is still correct for dial-out (no webhook) channels — confirmed via the shipped `.d.ts`'s own doc comment + example (`@since Plugin SDK 2026.2.19`). It must live *inside* `base`, not as a sibling to `outbound` — the old code's shape would type-error against the current SDK.
- `runtime.channel.inbound.buildContext`/`.dispatchReply` (what the old code already used) are confirmed current via `docs/plugins/sdk-channel-inbound.md`'s own migration section.
- `openclaw.compat.pluginApi` — the version-floor gate research doc trap #1 — pinned to `>=2026.7.1`, the exact version this was built/verified against.
- `npm install --ignore-scripts` (how `openclaw plugins install` actually installs — trap #2) means no postinstall build. Ships pre-built `dist/*.js`+`.d.ts` via `tsup`; `openclaw.extensions`/`setupEntry` → TS sources (dev/bundled), `runtimeExtensions`/`runtimeSetupEntry` → built JS (what installed packages load).
- Added `gateway.stopAccount` (didn't exist before), wired through both `ctx.abortSignal` and an explicit per-account `AbortController` — same actual-not-just-declared dispose lesson as #2578/S7 QA.
- README documents `openclaw plugins inspect <id> --runtime` as the real install-succeeded-≠-serving check and ClawHub as the primary discovery surface (traps #3/#4).
- Vendored `sprintable-sse.ts` with the #2578 attachment fix already applied, byte-identical to canonical/opencode-sprintable.

## Verification — now includes a full isolated live gateway run
All isolated (`HOME=<scratch>` override — zero contact with any real `~/.openclaw` or global `node`, per PO's explicit "격리는 우회가 아니라 정공법" directive):

1. **Build**: `tsup` clean, zero type errors, `openclaw` stays external, vendored SDK compiles to plain JS.
2. **`npm pack`**: correct 8-file tarball.
3. **Isolated install**: `openclaw plugins install <tarball>` — clean install into an isolated `HOME`, zero contact with any real environment.
4. **`openclaw plugins inspect sprintable --runtime`**: `Status: loaded`, `Source: ~/.openclaw/extensions/sprintable/dist/index.js` (confirms it loaded the **built JS**, not raw TS — proves the `runtimeExtensions` wiring actually works for a real installed package), `Capabilities: channel: sprintable` (confirms `registerChannel({plugin})` fired automatically via `defineChannelPluginEntry`). One diagnostic caught (missing `selectionLabel`) and fixed in the same pass.
5. **Isolated live gateway run** (`openclaw gateway run`, isolated `HOME`, isolated port): real gateway boot logs show:
   - `[sprintable] starting SSE dial-out for account default` — `gateway.startAccount` fired for real.
   - `[sprintable-sse] stream open` — a genuine SSE connection to the real Sprintable dev backend.
   - Sent a real Sprintable chat message → `[sprintable-sse] inbound seq=52 conv=...: <message text>` — the message was received and dispatched into `runtime.channel.inbound.dispatchReply`, which correctly attempted a real agent turn.
   - `[sprintable-sse] ack seq=52` — the ack round-trip completed.
   - The agent turn itself then failed with `ProviderAuthError: No API key found for provider "openai"` — this isolated test environment has no real LLM provider credentials (expected, out of scope). This is the exact same boundary PO drew for the OpenCode connector (#2562): this plugin's job ends at correctly receiving the message and invoking the agent turn; whether the underlying LLM provider is authenticated is not this plugin's or this PR's responsibility.

**Net: the full plugin-owned chain (install → load → configure → SSE connect → inbound receive → dispatch → agent-turn invocation → ack) is proven live.** Only the LLM-provider-auth step beyond the plugin's boundary was not exercised (needs real provider credentials, unrelated to this package).

## Unrelated incident disclosure (transparency, resolved)
Earlier in this session, `brew install node@24` (intended as non-linking) triggered a shared-dependency version bump that broke the linked global `node`. Reported live, escalated, and resolved by 선생님 (`brew reinstall node` → v26.7.0). Fully unrelated to this PR's code; all verification above happened after recovery, using a scratch-directory-installed `openclaw` + `HOME` override, never touching the real environment.

## Test plan
- [x] `tsup` build clean
- [x] `npm pack` correct file set
- [x] Isolated install (`openclaw plugins install`)
- [x] `openclaw plugins inspect --runtime` — loaded, correct capabilities
- [x] Isolated live gateway run — real SSE connect + real inbound message dispatch + ack, confirmed via logs
- [ ] Kadir QA
- [ ] `npm publish` (approved, still held for tomorrow morning per granular npm token fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)