### PR TITLE
fix(openclaw-sprintable): add channel.test.ts + fix real strict-typecheck bugs

### DIFF
--- a/connectors/openclaw-sprintable/package.json
+++ b/connectors/openclaw-sprintable/package.json
@@ -52,6 +52,7 @@
     "openclaw": ">=2026.7.1"
   },
   "devDependencies": {
+    "bun-types": "^1.3.14",
     "openclaw": "^2026.7.1-2",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"

--- a/connectors/openclaw-sprintable/src/channel.test.ts
+++ b/connectors/openclaw-sprintable/src/channel.test.ts
@@ -1,0 +1,122 @@
+// Kadir QA catch on PR #2968: package.json's test script referenced this file before it
+// existed. Pins two things: (1) account resolution (config OR env dual fallback, matching
+// this connector family's convention) — same pattern as OpenClaw's own acme-chat doc
+// example test. (2) stopAccount actually aborts the SSE connection it started — the
+// "declared dispose vs actual dispose" class of bug this session hit for real in #2578/S7
+// QA (dispose() that didn't wire signal into fetch()), verified here against a real mock
+// SSE server so this is a live behavioral proof, not just a type-shape check.
+import { test, expect, beforeEach } from 'bun:test'
+import { sprintablePlugin, CHANNEL_ID } from './channel.js'
+
+type FakeConfig = { channels?: Record<string, unknown> }
+
+test('resolveAccount reads apiKey/apiUrl from config when present', () => {
+  const cfg: FakeConfig = {
+    channels: { [CHANNEL_ID]: { apiKey: 'sk_live_from_config', apiUrl: 'https://custom.example.com' } },
+  }
+  const account = sprintablePlugin.config.resolveAccount(cfg as any, undefined)
+  expect(account.apiKey).toBe('sk_live_from_config')
+  expect(account.apiUrl).toBe('https://custom.example.com')
+  expect(account.configured).toBe(true)
+})
+
+test('resolveAccount falls back to SPRINTABLE_API_KEY env when config is absent', () => {
+  const prevKey = process.env.SPRINTABLE_API_KEY
+  const prevUrl = process.env.SPRINTABLE_API_URL
+  process.env.SPRINTABLE_API_KEY = 'sk_live_from_env'
+  delete process.env.SPRINTABLE_API_URL
+  try {
+    const account = sprintablePlugin.config.resolveAccount({ channels: {} } as any, undefined)
+    expect(account.apiKey).toBe('sk_live_from_env')
+    expect(account.apiUrl).toBe('https://app.sprintable.ai')
+    expect(account.configured).toBe(true)
+  } finally {
+    if (prevKey === undefined) delete process.env.SPRINTABLE_API_KEY
+    else process.env.SPRINTABLE_API_KEY = prevKey
+    if (prevUrl !== undefined) process.env.SPRINTABLE_API_URL = prevUrl
+  }
+})
+
+test('inspectAccount reports unconfigured when no key is present anywhere', () => {
+  const prevKey = process.env.SPRINTABLE_API_KEY
+  const prevAgentKey = process.env.AGENT_API_KEY
+  delete process.env.SPRINTABLE_API_KEY
+  delete process.env.AGENT_API_KEY
+  try {
+    const result = sprintablePlugin.config.inspectAccount!({ channels: {} } as any, undefined) as {
+      configured: boolean
+      apiKeyStatus: string
+    }
+    expect(result.configured).toBe(false)
+    expect(result.apiKeyStatus).toBe('missing')
+  } finally {
+    if (prevKey !== undefined) process.env.SPRINTABLE_API_KEY = prevKey
+    if (prevAgentKey !== undefined) process.env.AGENT_API_KEY = prevAgentKey
+  }
+})
+
+// ── gateway.stopAccount actually tears down the SSE connection ──────────────
+
+function startMockSseServer() {
+  let sawAbort = false
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      if (req.url.includes('/api/v2/agent/stream')) {
+        const stream = new ReadableStream({
+          start(controller) {
+            const enc = new TextEncoder()
+            controller.enqueue(enc.encode(': connected\n\n'))
+            req.signal.addEventListener('abort', () => {
+              sawAbort = true
+              try { controller.close() } catch {}
+            })
+          },
+        })
+        return new Response(stream, { headers: { 'content-type': 'text/event-stream' } })
+      }
+      return new Response('{}', { headers: { 'content-type': 'application/json' } })
+    },
+  })
+  return { server, sawAbort: () => sawAbort }
+}
+
+function fakeGatewayContext(apiUrl: string, abortSignal: AbortSignal) {
+  return {
+    account: { accountId: 'default', configured: true, apiKey: 'test-key', apiUrl },
+    cfg: { agents: { accounts: {} } },
+    abortSignal,
+    log: { info: () => {}, warn: () => {} },
+    setStatus: () => {},
+    channelRuntime: {
+      inbound: {
+        buildContext: (_x: unknown) => ({}),
+        dispatchReply: async (_x: unknown) => {},
+      },
+    },
+  }
+}
+
+test('stopAccount aborts the SSE connection startAccount opened (real socket, not just a type check)', async () => {
+  const { server, sawAbort } = startMockSseServer()
+  const gatewayAbort = new AbortController()
+
+  const startPromise = sprintablePlugin.gateway!.startAccount!(
+    fakeGatewayContext(`http://localhost:${server.port}`, gatewayAbort.signal) as any,
+  )
+
+  // give the SSE connection a moment to actually open
+  await new Promise((resolve) => setTimeout(resolve, 200))
+  expect(sawAbort()).toBe(false)
+
+  await sprintablePlugin.gateway!.stopAccount!(
+    fakeGatewayContext(`http://localhost:${server.port}`, gatewayAbort.signal) as any,
+  )
+
+  await new Promise((resolve) => setTimeout(resolve, 200))
+  expect(sawAbort()).toBe(true)
+
+  gatewayAbort.abort()
+  await startPromise.catch(() => {})
+  server.stop(true)
+})

--- a/connectors/openclaw-sprintable/src/channel.ts
+++ b/connectors/openclaw-sprintable/src/channel.ts
@@ -82,15 +82,28 @@ export const sprintablePlugin: ChannelPlugin<SprintableAccount> = createChatChan
       },
     },
     setup: {
-      applyAccountConfig: ({ cfg, input }) => ({
-        ...cfg,
-        channels: {
-          ...(cfg as Record<string, unknown>).channels,
-          [CHANNEL_ID]: { ...((cfg as Record<string, unknown>).channels as any)?.[CHANNEL_ID], ...input },
-        },
-      }),
+      applyAccountConfig: ({ cfg, input }) => {
+        const existingChannels = (cfg as Record<string, unknown>).channels as Record<string, unknown> | undefined
+        const existingSection = (existingChannels?.[CHANNEL_ID] ?? {}) as Record<string, unknown>
+        const inputSection = (input ?? {}) as Record<string, unknown>
+        return {
+          ...cfg,
+          channels: {
+            ...existingChannels,
+            [CHANNEL_ID]: { ...existingSection, ...inputSection },
+          },
+        }
+      },
     },
     reload: { configPrefixes: [`channels.${CHANNEL_ID}`] },
+    // #2563 QA fix: this connector's own reply path (`msg.reply()` inside gateway.startAccount)
+    // doesn't go through outbound target resolution at all — `messaging` here only helps OTHER
+    // channels forward a message *to* sprintable (e.g. `sprintable:<conv-id>` targets), a
+    // cross-channel-forwarding use case this package doesn't need for the verified dial-out
+    // path. `resolveOutboundSessionRoute` was ported from the old pre-SDK code with the wrong
+    // param shape (`{to}` — real signature takes `{cfg, agentId, target, ...}` and must return
+    // a full ChannelOutboundSessionRoute, not `{agentId, sessionKey}`) — dropped rather than
+    // hand-guessed, since it's optional and unexercised by any verified path.
     messaging: {
       targetPrefixes: [CHANNEL_ID],
       normalizeTarget: (target: string) => target.replace(/^sprintable:/, ''),
@@ -98,10 +111,6 @@ export const sprintablePlugin: ChannelPlugin<SprintableAccount> = createChatChan
         looksLikeId: (target: string) => target.startsWith('sprintable:') || target.includes('/'),
         hint: 'sprintable:<conversation_id>',
       },
-      resolveOutboundSessionRoute: ({ to }: { to: string }) => ({
-        agentId: DEFAULT_ACCOUNT_ID,
-        sessionKey: to.replace(/^sprintable:/, ''),
-      }),
     },
     gateway: {
       startAccount: async (ctx) => {
@@ -142,7 +151,7 @@ export const sprintablePlugin: ChannelPlugin<SprintableAccount> = createChatChan
               channel: CHANNEL_ID,
               accountId: account.accountId,
               messageId: msg.eventId,
-              timestamp: new Date(),
+              timestamp: Date.now(),
               from: `sprintable:${msg.conversationId || msg.senderId}`,
               sender: { id: msg.senderId, name: msg.senderName },
               conversation: { kind: 'group', id: msg.conversationId, label: msg.conversationId },
@@ -162,7 +171,14 @@ export const sprintablePlugin: ChannelPlugin<SprintableAccount> = createChatChan
               cfg: ctx.cfg,
               agentId,
               routeSessionKey: msg.conversationId,
-              storePath: undefined,
+              // `AssembledChannelTurn.storePath` is typed as required `string`, but this
+              // dispatch goes through the loosely-typed `PluginRuntime['channel']` compat
+              // surface (per docs/plugins/sdk-channel-inbound.md — "gateway startup supplies
+              // a richer untyped runtime object" than the narrow public type). Live-verified
+              // (#2563/S8 isolated gateway e2e): passing undefined here does not crash —
+              // dispatchReply proceeds through to the agent-turn attempt correctly. Cast
+              // rather than fabricate a fake path that could silently change real behavior.
+              storePath: undefined as unknown as string,
               ctxPayload,
               recordInboundSession: rt.session?.recordInboundSession,
               dispatchReplyWithBufferedBlockDispatcher: rt.reply?.dispatchReplyWithBufferedBlockDispatcher,
@@ -187,7 +203,10 @@ export const sprintablePlugin: ChannelPlugin<SprintableAccount> = createChatChan
   outbound: {
     deliveryMode: 'direct',
     textChunkLimit: 4000,
-    resolveTarget: ({ to }: { to: string }) => ({ ok: true, target: to.replace(/^sprintable:/, '') }),
+    resolveTarget: ({ to }: { to?: string }) =>
+      to
+        ? { ok: true as const, to: to.replace(/^sprintable:/, '') }
+        : { ok: false as const, error: new Error('missing target') },
     deliveryCapabilities: { durableFinal: { text: true } },
   },
 })


### PR DESCRIPTION
## Summary
Kadir QA catch on merged #2968: `package.json`'s `"test"` script referenced `src/channel.test.ts`, which didn't exist. Adding it surfaced real bugs that `tsup`'s dts bundling had been silently accepting — a real gap in this session's earlier "build clean, zero type errors" verification claim. `tsup`'s declaration build is apparently not equivalent to `tsc --noEmit --strict` on the actual implementation.

## Real bugs found and fixed
- **`messaging.resolveOutboundSessionRoute`** — ported from the old pre-SDK code with the wrong param shape (`{to: string}`; real signature is `{cfg, agentId, target, currentSessionKey, ...}` and must return a full `ChannelOutboundSessionRoute`, not `{agentId, sessionKey}`). Dropped rather than hand-guessed: it's optional, and this connector's own reply path (`msg.reply()` inside `gateway.startAccount`) never goes through outbound target resolution — it only matters for a different, unneeded use case (another channel forwarding *to* sprintable).
- **`outbound.resolveTarget`** — same class of bug: `to` is optional in the real params (`to?: string`) but the old code required it; fixed to handle the undefined case and return the real `{ok, to}` shape (was `{ok, target}` — wrong field name too).
- **`buildContext`'s `timestamp`** — real type is `number` (epoch ms); old code passed `new Date()`.
- **`setup.applyAccountConfig`** — a spread-from-non-object-type error; narrowed `input`/existing channel section through explicit `Record<string, unknown>` casts.
- **`dispatchReply`'s `storePath`** — typed as required `string` in the bundled-channel-facing type, but this dispatch goes through the loosely-typed `PluginRuntime['channel']` compat surface docs describe as "richer, untyped" than that type. Live-verified: passing `undefined` here does not crash, `dispatchReply` proceeds correctly — cast explicitly rather than fabricate a fake path that could silently change real behavior.

## New test file
`src/channel.test.ts` (`bun:test`, matching this connector's existing `"test": "bun test src/channel.test.ts"` convention):
- `resolveAccount`'s config/env dual-fallback (mirrors OpenClaw's own acme-chat doc example test).
- `inspectAccount`'s unconfigured-state report.
- The one that matters most: a **live** test proving `gateway.stopAccount` genuinely aborts the SSE connection `startAccount` opened, using a real mock SSE server observing `req.signal`'s abort event — not just a type-shape check. Same "declared dispose vs actual dispose" rigor as #2578/S7 QA.

## Verification
- 4/4 `bun test` pass.
- `tsc --noEmit --strict` now clean across `channel.ts`/`channel.test.ts`/`index.ts`/`setup-entry.ts` (verified with `bun-types` installed locally — first time this exact combination was actually checked).
- **Re-ran the full isolated gateway e2e from #2968** after all fixes (same isolated `HOME`, zero contact with any real environment): reinstalled the repacked tarball, restarted the gateway, sent a real Sprintable message. Identical outcome to the original evidence — real SSE connect, real inbound dispatch (`seq=54`), real ack, same out-of-scope `ProviderAuthError` boundary. Confirms none of these fixes changed the proven-working runtime behavior.

## Test plan
- [x] `bun test` 4/4 pass
- [x] `tsc --noEmit --strict` clean
- [x] Re-verified isolated live gateway e2e post-fix, identical outcome to #2968's evidence
- [ ] Kadir QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)