### PR TITLE
feat(pi-sprintable): new in-process ExtensionAPI extension (S7b/#2574)

### DIFF
--- a/connectors/pi-sprintable/README.md
+++ b/connectors/pi-sprintable/README.md
@@ -1,78 +1,79 @@
-# Sprintable Adapter for Pi
+# sprintable-pi
 
-Pi용 Sprintable Gateway dial-out 어댑터 (카테고리 B — JSONL/stdio 호스트).
+Sprintable Gateway extension for [Pi](https://github.com/earendil-works/pi) — real-time team chat via SSE dial-out (no inbound webhook required). In-process `ExtensionAPI`, Category A — the same shape as every other Sprintable connector's real npm package (opencode-sprintable, openclaw-sprintable), not the standalone-host pattern `host.py` in this same directory uses (see [Legacy: `host.py`](#legacy-hostpy) below).
 
-**codex/gemini 호스트와 동형 골격** (자식 프로세스 spawn/own + lifetime 관리).
-차이 = 메시지 레이어: pi는 **`pi --mode rpc`** (JSONL/stdio — JSON-RPC 아닌 **줄단위 JSON**).
-`steer`로 mid-stream 주입이 pi 강점.
-
-## 요구사항
-
-- **pi 설치 필수** (`pi --mode rpc` 사용).
-  ```bash
-  npm install -g @earendil-works/pi-coding-agent   # bin: pi
-  pi --version
-  ```
-- Python 3.10+ (asyncio subprocess)
-- `httpx` (공통 SDK 의존)
-
-## 설치 및 실행
+## Install
 
 ```bash
-# 1. git pull
-git pull origin develop
-
-# 2. 환경 변수 설정
-export AGENT_API_KEY=sk_live_...            # Sprintable agent API key (필수)
-export SPRINTABLE_API_URL=https://...       # Backend URL (미설정 시 dev 기본값)
-# export PI_BIN=/path/to/pi                  # pi 바이너리 경로 (기본: PATH의 pi)
-
-# 3. 호스트 실행
-python connectors/pi-sprintable/host.py
+pi install npm:sprintable-pi
 ```
 
-## 동작 원리
+Or from a local checkout during development:
 
-```
-host.py 시작
-  → PiRpcServer.start(): pi --mode rpc spawn (JSONL은 별도 initialize 핸드셰이크 없음)
-  → SprintableSSEClient.run(inject) (공통 SDK)
-  → 이벤트마다 inject(ctx):
-    → pi.run_turn(ctx.content):
-      → stdin JSONL: {"type":"prompt", "message": text}
-      → stdout JSONL: AgentSessionEvent 스트림 (session.subscribe)
-      → agent_end {messages:[AgentMessage]} 에서 assistant 텍스트 수집
-    → ctx.reply(response) → POST /api/v2/conversations/{id}/messages
-    → ack: SDK 처리
+```bash
+pi install ./connectors/pi-sprintable -l   # -l installs project-locally into .pi/settings.json
 ```
 
-## 메시지 레이어 (JSONL — JSON-RPC와 차이)
+Then set your Sprintable agent credentials before starting `pi`:
 
-codex/gemini는 JSON-RPC(id/method/params/result)지만, pi는 **줄단위 JSON 명령/이벤트**:
-- 명령(stdin): `{"type":"prompt", "message", "streamingBehavior"?:"steer"|"followUp"}`
-- mid-stream 주입(stdin): `{"type":"steer", "message"}` — pi 강점
-- 응답(stdout): `{"type":"response", "command":"prompt", "success":true}` = ack
-- 이벤트(stdout): `AgentSessionEvent` — `agent_end {messages}`, `turn_end {message}`, `message_update {...}` 등
+```bash
+export SPRINTABLE_API_KEY=sk_live_...       # Sprintable agent API key (required)
+export SPRINTABLE_API_URL=https://...       # Backend URL (defaults to https://app.sprintable.ai)
+```
 
-## 프로세스 관리 (카테고리 B 핵심 — codex/gemini 동형)
+Without a key set, the extension registers no handlers at all and does nothing observable — safe to install ahead of configuring credentials.
 
-- `PiRpcServer`가 자식 프로세스를 spawn/own
-- `stop()`: SIGTERM(`terminate`) → 5s timeout → `kill` — 좀비 방지
-- `host.py` 종료 시 `finally: pi.stop()` 보장 + reader_task cancel
+## How it works
 
-## 실측 스키마
+```
+pi session starts
+  → session_start event
+    → runSprintableSSE (vendored SDK) opens GET /api/v2/agent/stream
+  → inbound Sprintable message arrives
+    → pi.sendUserMessage(content, {deliverAs: "steer"})   — injects as a new turn,
+      correctly whether the agent is idle or already mid-turn (Pi's own doc comment:
+      "When the agent is streaming, use deliverAs to specify how to queue the message")
+  → agent_end event (the turn settles)
+    → last assistant message's text extracted → POST /api/v2/conversations/{id}/messages
+  → session_shutdown event
+    → AbortController.abort() closes the SSE connection
+```
 
-`@earendil-works/pi-coding-agent@0.78.0` `dist/modes/rpc/rpc-types.d.ts`:
-- `RpcCommand: {type:"prompt"|"steer"|"follow_up", message, streamingBehavior?}`
-- `RpcResponse: {type:"response", command, success}`
+- **No idle-wake problem.** Every other Sprintable connector (codex, grok, gemini) spawns
+  a *fresh CLI process* to wake an idle session (`<cli> -r <session_id> -p "<msg>"`), which is
+  why each of those has had to solve its own idle-wake mechanism (and, in gemini's case, get
+  it wrong the first time — see #2561's `--resume` fix). Pi's extension runs **in-process**,
+  inside the same running session the whole time, so `sendUserMessage(..., {deliverAs:
+  "steer"})` just works uniformly — there's no separate process to wake up.
+- Single active conversation tracked per process (mirrors every sibling connector's own
+  single-active-conversation pattern) — this extension replies to whichever Sprintable
+  conversation most recently sent it a message.
+- SSE consumption, dedup, ack, backoff, and attachment handling live in the vendored
+  `sprintable-sse.ts` (SDK original: `connectors/sdk/sprintable-sse.ts` — published packages
+  can't resolve a monorepo-relative `../sdk/...` import, so a copy ships in this package; see
+  [`project_vendored_sdk_sync_debt`] for the tracked follow-up to end this vendoring pattern).
 
-`@earendil-works/pi-agent-core@0.78.0` `dist/types.d.ts`:
-- `AgentEvent: agent_end {messages:[AgentMessage]}`, `turn_end {message}`, ...
+## Verification status
 
-`@earendil-works/pi-ai@0.78.0`:
-- `AssistantMessage.content: (TextContent{type:"text",text} | ...)[]`
+- **Live-verified**: real `pi` CLI, real extension load (isolated project-local install,
+  `.pi/settings.json`, zero contact with any global `pi` config), real SSE connection to the
+  Sprintable dev backend (`[sprintable-sse] stream open` observed).
+- **Boundary-tested, not live end-to-end**: this session's free-tier Google API quota was
+  fully exhausted (shared across every tool touching that key today) before a real LLM turn
+  could complete through `pi` — same boundary already established for the OpenCode (#2562)
+  and OpenClaw (#2563) connectors: this extension's responsibility ends at correctly
+  receiving a message and injecting it via `sendUserMessage`; whether the underlying model
+  provider is authenticated and actually responds is out of scope. `index.test.ts` proves the
+  full logic (SSE receive → `sendUserMessage(steer)` injection → `agent_end` → reply POST)
+  against a fake `ExtensionAPI` and a real mock SSE server — no real `pi` binary or LLM call
+  needed, and the mocked assistant response round-trips through the exact same `ctx.reply()`
+  code path a real turn would use.
 
-## 단일 세션 주의
+## Legacy: `host.py`
 
-현재 모든 conversation을 단일 pi 세션에 주입 (codex/gemini와 동일).
-멀티 conversation 컨텍스트 분리는 후속(ef2603d8)에서 B 어댑터 일괄 보강.
+`host.py` (Category B — spawns and owns `pi --mode rpc` as a child process) predates the
+discovery that Pi's real extension system is in-process (Category A) — this in-process
+extension is the correct, publishable shape and the one documented above. `host.py` is kept
+as a preserved alternative rather than deleted (same call made for the codex plugin's own
+`host.py`-equivalent precedent) — see its own docstring for the JSONL/stdio protocol details
+if that standalone-host pattern is ever needed again.

--- a/connectors/pi-sprintable/index.test.ts
+++ b/connectors/pi-sprintable/index.test.ts
@@ -89,7 +89,12 @@ test('inbound SSE message injects via sendUserMessage(deliverAs: steer), then ag
   await new Promise((resolve) => setTimeout(resolve, 300))
 
   expect(api.sentMessages).toHaveLength(1)
-  expect(api.sentMessages[0].content).toBe('hello from sprintable')
+  // story #2583 — sendUserMessage now carries formatEnvelopeText(ctx), not bare ctx.content,
+  // so the sender ("tester") reaches the model instead of being dropped at this exact point
+  // (the line the #2583 recon identified as pi's assembly-stage defect).
+  expect(api.sentMessages[0].content).toBe(
+    '[dispatched] tester (unknown) · conv=conv-test-1 · ts=unknown\nhello from sprintable',
+  )
   expect(api.sentMessages[0].options).toEqual({ deliverAs: 'steer' })
 
   // Simulate agent_end with a mocked assistant response — bypasses the real LLM entirely,

--- a/connectors/pi-sprintable/index.test.ts
+++ b/connectors/pi-sprintable/index.test.ts
@@ -1,0 +1,131 @@
+// #2574 boundary test (same methodology as #2562's OpenCode mock-reply-path test): today's
+// free-tier Google quota is fully exhausted (shared across gemini + pi, confirmed live — both
+// hit 429 independently), so a real `pi` process can't complete an LLM turn. This proves the
+// piece that's actually this extension's responsibility — SSE receive -> sendUserMessage
+// injection, and agent_end -> reply POST — using a fake ExtensionAPI (no real pi binary) and a
+// real mock SSE server (no real Sprintable backend, but real sockets/HTTP). Whether the
+// underlying model can respond is explicitly out of scope, same boundary PO drew for #2562/#2563.
+import { test, expect } from 'bun:test'
+import sprintableExtension from './index.js'
+
+type FakeApi = {
+  handlers: Record<string, ((event: unknown) => void)[]>
+  on(event: string, handler: (event: unknown) => void): void
+  sentMessages: { content: string; options: unknown }[]
+  sendUserMessage(content: string, options?: unknown): void
+  fire(event: string, payload: unknown): void
+}
+
+function makeFakeApi(): FakeApi {
+  const handlers: Record<string, ((event: unknown) => void)[]> = {}
+  return {
+    handlers,
+    on(event, handler) {
+      ;(handlers[event] ??= []).push(handler)
+    },
+    sentMessages: [],
+    sendUserMessage(content, options) {
+      this.sentMessages.push({ content, options })
+    },
+    fire(event, payload) {
+      for (const h of handlers[event] ?? []) h(payload)
+    },
+  }
+}
+
+function startMockSseServer(dataLine: string) {
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      if (req.url.includes('/api/v2/agent/stream')) {
+        const stream = new ReadableStream({
+          start(controller) {
+            const enc = new TextEncoder()
+            controller.enqueue(enc.encode(`event: message\nid: 1\ndata: ${dataLine}\n\n`))
+          },
+        })
+        return new Response(stream, { headers: { 'content-type': 'text/event-stream' } })
+      }
+      if (req.url.includes('/messages') && req.method === 'POST') {
+        return new Response('{}', { status: 200 })
+      }
+      return new Response('{}', { headers: { 'content-type': 'application/json' } })
+    },
+  })
+  return server
+}
+
+test('no-op when SPRINTABLE_API_KEY is unset (AC3)', () => {
+  const prevKey = process.env.SPRINTABLE_API_KEY
+  const prevAgentKey = process.env.AGENT_API_KEY
+  delete process.env.SPRINTABLE_API_KEY
+  delete process.env.AGENT_API_KEY
+  try {
+    const api = makeFakeApi()
+    sprintableExtension(api as never)
+    expect(Object.keys(api.handlers)).toHaveLength(0)
+  } finally {
+    if (prevKey !== undefined) process.env.SPRINTABLE_API_KEY = prevKey
+    if (prevAgentKey !== undefined) process.env.AGENT_API_KEY = prevAgentKey
+  }
+})
+
+test('inbound SSE message injects via sendUserMessage(deliverAs: steer), then agent_end reply posts back', async () => {
+  const server = startMockSseServer(JSON.stringify({
+    event_type: 'dispatched', event_id: 'evt-1',
+    content: 'hello from sprintable',
+    payload: { conversation_id: 'conv-test-1', sender: { id: 's1', name: 'tester' } },
+  }))
+  process.env.SPRINTABLE_API_KEY = 'test-key'
+  process.env.SPRINTABLE_API_URL = `http://localhost:${server.port}`
+
+  const api = makeFakeApi()
+  sprintableExtension(api as never)
+  expect(Object.keys(api.handlers).sort()).toEqual(['agent_end', 'session_shutdown', 'session_start'])
+
+  api.fire('session_start', { type: 'session_start', reason: 'startup' })
+
+  // give the SSE connection + onMessage callback a moment to actually run
+  await new Promise((resolve) => setTimeout(resolve, 300))
+
+  expect(api.sentMessages).toHaveLength(1)
+  expect(api.sentMessages[0].content).toBe('hello from sprintable')
+  expect(api.sentMessages[0].options).toEqual({ deliverAs: 'steer' })
+
+  // Simulate agent_end with a mocked assistant response — bypasses the real LLM entirely,
+  // exercising the exact same ctx.reply() code path index.ts's agent_end handler calls.
+  let replyReceived: string | null = null
+  const origFetch = globalThis.fetch
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    if (String(url).includes('/messages') && init?.method === 'POST') {
+      const body = JSON.parse(String(init.body))
+      replyReceived = body.content
+      return new Response('{}', { status: 200 })
+    }
+    return origFetch(url as never, init)
+  }) as typeof fetch
+
+  try {
+    api.fire('agent_end', {
+      type: 'agent_end',
+      messages: [
+        { role: 'user', content: 'hello from sprintable', timestamp: Date.now() },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'MOCKED_MODEL_RESPONSE: pi extension reply path confirmed working' }],
+          api: 'anthropic-messages', provider: 'anthropic', model: 'test',
+          usage: { totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+          stopReason: 'stop', timestamp: Date.now(),
+        },
+      ],
+    })
+    await new Promise((resolve) => setTimeout(resolve, 200))
+  } finally {
+    globalThis.fetch = origFetch
+  }
+
+  expect(replyReceived as string | null).toBe('MOCKED_MODEL_RESPONSE: pi extension reply path confirmed working')
+
+  api.fire('session_shutdown', { type: 'session_shutdown', reason: 'quit' })
+  server.stop(true)
+})

--- a/connectors/pi-sprintable/index.ts
+++ b/connectors/pi-sprintable/index.ts
@@ -1,0 +1,101 @@
+/**
+ * Sprintable Gateway extension for Pi — in-process ExtensionAPI (E-AGENT-ONBOARD S7b, #2574).
+ *
+ * Category A (in-process), NOT a rewrite of the sibling host.py, which is Category B
+ * (host spawns/owns pi as a child process) — the opposite shape from what Pi's own
+ * extension system requires. host.py is kept as-is, a preserved alternative (same
+ * "keep the old pattern around" call as the codex plugin's own host.py precedent) —
+ * this file is the real, publishable `sprintable-pi` npm package entry.
+ *
+ * Ground-truthed against the real `@earendil-works/pi-coding-agent`@0.84.1 npm
+ * package's shipped .d.ts (not assumed from the story description alone — that
+ * description's own `sendUserMessage(steer, triggerTurn)` phrasing turned out to be
+ * slightly imprecise: `sendUserMessage` only takes `deliverAs`, not `triggerTurn`
+ * — its doc comment says "Always triggers a turn", so no separate flag is needed;
+ * `triggerTurn` is a `sendMessage` option instead, for the *custom*-message API this
+ * extension doesn't use).
+ *
+ * Pi is architecturally simpler here than every other Sprintable connector: it's
+ * in-process (the extension factory runs inside the same process as the running
+ * session), so there's no separate-CLI-invocation idle-wake problem to solve at all
+ * (unlike codex/grok/gemini, which all spawn a fresh `<cli> -r <session> -p <msg>`
+ * process to wake an idle session). `sendUserMessage(..., {deliverAs: "steer"})`
+ * injects correctly whether the agent is idle or mid-turn — the SDK's own doc
+ * comment: "When the agent is streaming, use deliverAs to specify how to queue the
+ * message."
+ */
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
+import { runSprintableSSE, type MessageContext } from './sprintable-sse.js'
+
+/**
+ * Pi's extension factory. Per the SDK's own documented discipline (and this
+ * story's own trap list, #2574 AC3): do NOT start background resources — sockets,
+ * listeners, timers — directly in the factory body. Only register `pi.on(...)`
+ * handlers here; the actual SSE connection opens inside the `session_start`
+ * handler, which is the correct lifecycle hook for it.
+ *
+ * Credentials are resolved fresh on each factory call, not cached as module-level
+ * constants — a module-level `const API_KEY = process.env...` would freeze at
+ * first import (whenever that happens to occur) rather than reflecting the
+ * environment at actual extension-load time. Matches the per-call resolution
+ * pattern the other connectors already use (e.g. openclaw-sprintable's
+ * `resolveAccount`), and is what makes this factory unit-testable at all.
+ */
+export default function sprintableExtension(pi: ExtensionAPI): void {
+  const API_URL = (process.env.SPRINTABLE_API_URL ?? 'https://app.sprintable.ai').replace(/\/$/, '')
+  const API_KEY = (process.env.SPRINTABLE_API_KEY ?? process.env.AGENT_API_KEY ?? '').trim()
+  if (!API_KEY) {
+    // AC3: credentials unset -> completely silent no-op, no handlers registered
+    // that would do anything observable. Matches every sibling connector's
+    // "safe until configured" contract.
+    return
+  }
+
+  const controller = new AbortController()
+  // Single-session extension (in-process, one Pi session per process) — this
+  // extension only ever talks to whichever Sprintable conversation most recently
+  // sent it a message, mirroring the "most recent context wins" pattern the other
+  // connectors already use for their own single-active-conversation tracking.
+  let lastCtx: MessageContext | null = null
+
+  pi.on('session_start', () => {
+    runSprintableSSE({
+      apiUrl: API_URL,
+      apiKey: API_KEY,
+      signal: controller.signal,
+      onMessage: async (ctx) => {
+        lastCtx = ctx
+        pi.sendUserMessage(ctx.content, { deliverAs: 'steer' })
+      },
+    }).catch((err) => {
+      if (!controller.signal.aborted) {
+        process.stderr.write(`[sprintable] SSE fatal error: ${err}\n`)
+      }
+    })
+  })
+
+  pi.on('session_shutdown', () => {
+    controller.abort()
+  })
+
+  // Auto-reply, same pattern as every other Sprintable connector (gemini's
+  // AfterAgent, codex's Stop hook): post the agent's own response back to
+  // Sprintable without requiring the agent to remember to call a tool.
+  pi.on('agent_end', (event) => {
+    if (!lastCtx) return
+    const assistantMessages = event.messages.filter(
+      (m): m is Extract<typeof m, { role: 'assistant' }> => m.role === 'assistant',
+    )
+    const last = assistantMessages[assistantMessages.length - 1]
+    if (!last) return
+    const text = last.content
+      .filter((c): c is Extract<typeof c, { type: 'text' }> => c.type === 'text')
+      .map((c) => c.text)
+      .join('')
+      .trim()
+    if (!text) return
+    void lastCtx.reply(text).catch((err) => {
+      process.stderr.write(`[sprintable] reply failed: ${err}\n`)
+    })
+  })
+}

--- a/connectors/pi-sprintable/index.ts
+++ b/connectors/pi-sprintable/index.ts
@@ -25,7 +25,7 @@
  * message."
  */
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
-import { runSprintableSSE, type MessageContext } from './sprintable-sse.js'
+import { runSprintableSSE, formatEnvelopeText, type MessageContext } from './sprintable-sse.js'
 
 /**
  * Pi's extension factory. Per the SDK's own documented discipline (and this
@@ -65,7 +65,9 @@ export default function sprintableExtension(pi: ExtensionAPI): void {
       signal: controller.signal,
       onMessage: async (ctx) => {
         lastCtx = ctx
-        pi.sendUserMessage(ctx.content, { deliverAs: 'steer' })
+        // story #2583 — 발신자/이벤트종류/ts를 조립 단계에서 버리지 않고 표준 envelope로
+        // 렌더(ctx.content만 보내면 모델이 발신자를 모른 채 진행 — 댄 어윈 오호칭 사고 클래스).
+        pi.sendUserMessage(formatEnvelopeText(ctx), { deliverAs: 'steer' })
       },
     }).catch((err) => {
       if (!controller.signal.aborted) {

--- a/connectors/pi-sprintable/package.json
+++ b/connectors/pi-sprintable/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "sprintable-pi",
+  "version": "0.1.0",
+  "description": "Sprintable Gateway extension for Pi — real-time team chat via SSE dial-out, in-process ExtensionAPI (no inbound webhook required).",
+  "keywords": ["pi-coding-agent", "pi-package", "sprintable"],
+  "type": "module",
+  "files": ["index.ts", "sprintable-sse.ts", "README.md"],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/moonklabs/sprintable.git",
+    "directory": "connectors/pi-sprintable"
+  },
+  "license": "MIT",
+  "pi": {
+    "extensions": ["./index.ts"]
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-agent-core": ">=0.84.0",
+    "@earendil-works/pi-ai": ">=0.84.0",
+    "@earendil-works/pi-coding-agent": ">=0.84.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-agent-core": ">=0.84.0",
+    "@earendil-works/pi-ai": ">=0.84.0",
+    "@earendil-works/pi-coding-agent": ">=0.84.0",
+    "@types/node": "*",
+    "typescript": "^5.9.0"
+  }
+}

--- a/connectors/pi-sprintable/sprintable-sse.ts
+++ b/connectors/pi-sprintable/sprintable-sse.ts
@@ -1,0 +1,278 @@
+/**
+ * Sprintable Gateway SSE Reference SDK — TypeScript/Bun
+ *
+ * 공통부: SSE 소비 · 파서 · dedup · ack(contiguous, min-1 앵커링) · backoff 재연결.
+ * 어댑터는 `onMessage` 콜백(주입부)만 구현하면 된다.
+ *
+ * @example
+ * ```ts
+ * import { runSprintableSSE } from './sprintable-sse'
+ *
+ * await runSprintableSSE({
+ *   apiUrl: 'https://sprintable-backend-dev-57iommnikq-du.a.run.app',
+ *   apiKey: process.env.AGENT_API_KEY!,
+ *   async onMessage(ctx) {
+ *     // runtime-specific injection
+ *     const response = await myAgent.handle(ctx.content)
+ *     await ctx.reply(response)
+ *   },
+ * })
+ * ```
+ */
+
+/**
+ * 일반 첨부(이미지 포함 전체) — #2578: Python SDK(#2568)만 첨부 정규화를 갖고 있었고
+ * 이 TS SDK엔 처음부터 없었다(images 개념 자체도 없음 — 그건 별개의, 여전히 남은 갭).
+ * 백엔드는 payload.attachments에 이미 이걸 싣는다(mime 필터 없음 — 첨부는 전 타입 대상).
+ */
+export type MessageAttachment = {
+  url: string
+  name: string
+  contentType: string
+  size: number | null
+  assetId: string
+}
+
+export type MessageContext = {
+  content: string
+  conversationId: string
+  senderId: string
+  senderName: string
+  eventId: string
+  seq: number
+  isBackfill: boolean
+  attachments: MessageAttachment[]
+  raw: Record<string, unknown>
+  /** POST /api/v2/conversations/{id}/messages */
+  reply(text: string): Promise<void>
+}
+
+export type OnMessage = (ctx: MessageContext) => Promise<void>
+
+const DEFAULT_API_URL = 'https://sprintable-backend-dev-57iommnikq-du.a.run.app'
+const RECONNECT_BACKOFF = [2000, 5000, 10000, 30000, 60000]
+const DEDUP_MAX = 1000
+const DEDUP_TTL_MS = 300_000
+
+function _authHeaders(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}`, 'x-agent-api-key': apiKey }
+}
+
+/** #2578: Python _normalize_attachments 이식. mime 필터 없음 — 전 타입 대상. */
+export function normalizeAttachments(value: unknown): MessageAttachment[] {
+  if (!Array.isArray(value)) return []
+  const out: MessageAttachment[] = []
+  for (const item of value) {
+    if (typeof item !== 'object' || item === null) continue
+    const rec = item as Record<string, unknown>
+    const url = String(rec.url ?? '').trim()
+    if (!url) continue
+    const rawSize = rec.size
+    const size = typeof rawSize === 'number' && Number.isFinite(rawSize) ? rawSize : null
+    out.push({
+      url,
+      name: String(rec.name ?? ''),
+      contentType: String(rec.content_type ?? ''),
+      size,
+      assetId: String(rec.asset_id ?? ''),
+    })
+  }
+  return out
+}
+
+/**
+ * #2578 AC1: 첨부 존재+회수 경로(asset text API)를 에이전트가 알 수 있게 텍스트로 안내.
+ * asset_id가 있으면(정상 케이스) 그 경로를, 없으면(레거시/미등록) url을 안내.
+ */
+export function renderAttachmentNotice(attachments: MessageAttachment[]): string {
+  const lines = attachments.map((a) => {
+    const label = a.name || a.url
+    return a.assetId
+      ? `- ${label} (${a.contentType || 'unknown type'}) — 본문 회수: GET /api/v2/assets/${a.assetId}/text`
+      : `- ${label} (${a.contentType || 'unknown type'}) — url: ${a.url}`
+  })
+  return `[첨부 ${attachments.length}건]\n${lines.join('\n')}\n[/첨부]`
+}
+
+export async function runSprintableSSE(opts: {
+  apiUrl?: string
+  apiKey: string
+  onMessage: OnMessage
+  signal?: AbortSignal
+}): Promise<void> {
+  const { apiKey, onMessage } = opts
+  const apiUrl = (opts.apiUrl ?? DEFAULT_API_URL).replace(/\/$/, '')
+
+  let lastEventId = ''
+  let lastAcked = 0
+  let backoffIdx = 0
+  const seen = new Map<string, number>()
+
+  function isDup(eventId: string): boolean {
+    const now = Date.now()
+    if (seen.size > DEDUP_MAX) {
+      for (const [k, v] of seen) if (now - v > DEDUP_TTL_MS) seen.delete(k)
+    }
+    if (seen.has(eventId)) return true
+    seen.set(eventId, now)
+    return false
+  }
+
+  async function ack(seq: number): Promise<void> {
+    if (seq <= lastAcked) return
+    try {
+      const resp = await fetch(`${apiUrl}/api/v2/agent/events/ack`, {
+        method: 'POST',
+        headers: { ..._authHeaders(apiKey), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ seq }),
+      })
+      if (resp.ok) {
+        lastAcked = seq
+        process.stderr.write(`[sprintable-sse] ack seq=${seq}\n`)
+      }
+    } catch (e) {
+      process.stderr.write(`[sprintable-sse] ack error seq=${seq}: ${e}\n`)
+    }
+  }
+
+  async function consume(): Promise<void> {
+    const headers: Record<string, string> = {
+      ..._authHeaders(apiKey),
+      Accept: 'text/event-stream',
+      'Cache-Control': 'no-cache',
+    }
+    if (lastEventId) headers['Last-Event-ID'] = lastEventId
+
+    const resp = await fetch(`${apiUrl}/api/v2/agent/stream`, { headers, signal: opts.signal })
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+    if (!resp.body) throw new Error('no body')
+
+    process.stderr.write('[sprintable-sse] stream open\n')
+    backoffIdx = 0
+
+    const reader = resp.body.getReader()
+    const dec = new TextDecoder()
+    let buf = ''
+    let evType = 'message', evId = '', dataLines: string[] = []
+
+    while (true) {
+      if (opts.signal?.aborted) {
+        await reader.cancel()
+        return
+      }
+      const { done, value } = await reader.read()
+      if (done) break
+      buf += dec.decode(value, { stream: true })
+      const lines = buf.split('\n')
+      buf = lines.pop() ?? ''
+
+      for (const raw of lines) {
+        const line = raw.replace(/\r$/, '')
+        if (line === '') {
+          if (dataLines.length) {
+            const ctx = await parseEvent(evType, evId, dataLines.join('\n'), apiUrl, apiKey)
+            if (ctx) {
+              process.stderr.write(
+                `[sprintable-sse] inbound seq=${ctx.seq} conv=${ctx.conversationId}: ${ctx.content.slice(0, 80)}\n`
+              )
+              await onMessage(ctx)
+              if (ctx.seq) await ack(ctx.seq)
+            }
+          }
+          evType = 'message'; evId = ''; dataLines = []
+        } else if (line.startsWith(':')) {
+          // comment
+        } else if (line.startsWith('event:')) {
+          evType = line.slice(6).trim()
+        } else if (line.startsWith('id:')) {
+          evId = line.slice(3).trim()
+        } else if (line.startsWith('data:')) {
+          const v = line.slice(5)
+          dataLines.push(v.startsWith(' ') ? v.slice(1) : v)
+        }
+      }
+    }
+    process.stderr.write('[sprintable-sse] stream closed\n')
+  }
+
+  async function parseEvent(
+    evType: string, evId: string, dataStr: string,
+    apiUrl: string, apiKey: string,
+  ): Promise<MessageContext | null> {
+    if (evType === 'heartbeat') return null
+    let data: Record<string, unknown>
+    try { data = JSON.parse(dataStr) } catch { return null }
+
+    const payload = (
+      typeof data.payload === 'object' && data.payload !== null ? data.payload : {}
+    ) as Record<string, unknown>
+
+    let content = ((data.content ?? payload.content ?? '') as string).trim()
+    const attachments = normalizeAttachments(data.attachments ?? payload.attachments)
+    if (!content && attachments.length === 0) return null
+    // #2578 AC1/AC2: 첨부가 있으면 안내 블록을 content에 병합 — 어댑터마다 따로 렌더하게
+    // 하지 않고 SDK 단일 지점에서 처리(Python SDK #2568과 동형, 어댑터 코드 수정 0으로 전파).
+    if (attachments.length > 0) {
+      const notice = renderAttachmentNotice(attachments)
+      content = content ? `${content}\n\n${notice}` : notice
+    }
+
+    const eventId = String(data.event_id ?? payload.id ?? evId ?? crypto.randomUUID())
+    if (isDup(eventId)) return null
+    if (evId) lastEventId = evId
+
+    let seq = 0
+    for (const cand of [data.recipient_seq, payload.recipient_seq]) {
+      const n = Number(cand)
+      if (Number.isFinite(n) && n > 0) { seq = n; break }
+    }
+
+    const conversationId = String(
+      payload.conversation_id ?? payload.thread_id ?? data.conversation_id ?? ''
+    )
+    const sender = (
+      typeof payload.sender === 'object' && payload.sender !== null ? payload.sender : {}
+    ) as Record<string, unknown>
+    const senderId = String(sender.id ?? data.sender_id ?? 'sprintable')
+    const senderName = String(sender.name ?? senderId)
+    const isBackfill = Boolean(data.is_backfill)
+
+    const replyUrl = conversationId
+      ? `${apiUrl}/api/v2/conversations/${conversationId}/messages`
+      : ''
+
+    return {
+      content, conversationId, senderId, senderName, eventId, seq, isBackfill, attachments, raw: data,
+      async reply(text: string) {
+        if (!replyUrl) throw new Error('no conversation_id')
+        const r = await fetch(replyUrl, {
+          method: 'POST',
+          headers: { ..._authHeaders(apiKey), 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content: text }),
+        })
+        if (!r.ok) throw new Error(`reply HTTP ${r.status}`)
+      },
+    }
+  }
+
+  // main loop
+  while (true) {
+    if (opts.signal?.aborted) return
+    const t0 = Date.now()
+    try {
+      await consume()
+    } catch (e) {
+      if (opts.signal?.aborted) return
+      process.stderr.write(`[sprintable-sse] error: ${e}\n`)
+    }
+    if (opts.signal?.aborted) return
+    if (Date.now() - t0 >= 60_000) backoffIdx = 0
+    const delay = RECONNECT_BACKOFF[Math.min(backoffIdx, RECONNECT_BACKOFF.length - 1)]
+    process.stderr.write(`[sprintable-sse] reconnecting in ${delay}ms\n`)
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, delay)
+      opts.signal?.addEventListener('abort', () => { clearTimeout(timer); resolve() }, { once: true })
+    })
+    backoffIdx++
+  }
+}

--- a/connectors/pi-sprintable/sprintable-sse.ts
+++ b/connectors/pi-sprintable/sprintable-sse.ts
@@ -43,6 +43,14 @@ export type MessageContext = {
   isBackfill: boolean
   attachments: MessageAttachment[]
   raw: Record<string, unknown>
+  /**
+   * story #2583 S1 — envelope 규격 필드. 원 이벤트에 값이 없으면 빈 문자열('')로 둔다 —
+   * 지어내지 않는다(AC1 "값 없음의 정직 표기"). formatEnvelopeText()가 렌더 시
+   * 'unknown'으로 표기한다.
+   */
+  senderType: string
+  eventKind: string
+  ts: string
   /** POST /api/v2/conversations/{id}/messages */
   reply(text: string): Promise<void>
 }
@@ -92,6 +100,34 @@ export function renderAttachmentNotice(attachments: MessageAttachment[]): string
       : `- ${label} (${a.contentType || 'unknown type'}) — url: ${a.url}`
   })
   return `[첨부 ${attachments.length}건]\n${lines.join('\n')}\n[/첨부]`
+}
+
+/**
+ * story #2583 S1: 주입 envelope 표준 렌더.
+ *
+ * 배경: #2583 정찰(doc 2583-injection-envelope-recon-20260812) — 8개 커넥터 中 6개가
+ * senderId/senderName을(이 SDK가 이미 정확히 파싱해 두는데도) 모델에 실제로 보이는
+ * 텍스트 조립 단계에서 조용히 버렸다(댄 어윈 오호칭 사고와 동일 코드 경로). 이 함수는
+ * 그 "조립" 단계를 SDK 안 단일 지점으로 끌어와, 텍스트-only 주입 런타임(6곳)이 전부
+ * 이 함수를 부르면 사본마다 발신자를 흘리는 사고를 구조적으로 막는다. Hermes/OpenClaw
+ * 처럼 호스트가 이미 구조화 sender 파라미터를 받는 런타임은 필요 없다.
+ *
+ * ⚠️ 언어 경계(Python ↔ TS) — `sprintable_sse.py`의 `format_envelope_text()`와
+ * **동일한 렌더 규칙**이어야 한다(값 배치 순서·구분자·'unknown' 폴백 문자열까지). 양쪽에
+ * 같은 샘플을 핀 고정해 뒀다(#2589 패턴) — 한쪽만 고치면 그쪽 테스트가 깨진다. 정직 표기
+ * 원칙(AC1): 값이 없으면 'unknown'이라고 명시하지, 빈칸으로 뭉개거나 지어내지 않는다.
+ */
+export function formatEnvelopeText(ctx: MessageContext): string {
+  // PO 리뷰(2026-08-12, PR #2984) — senderName만 다른 필드와 폴백이 비대칭이었다(다른
+  // 필드는 전부 || 'unknown'인데 이건 그대로 노출 → 명시적 빈 이름이면 헤더 이름칸이
+  // 빈 채 렌더돼 오호칭 봉쇄 취지에 어긋남). name → id → 'unknown' 순으로 일관화.
+  const senderName = ctx.senderName || ctx.senderId || 'unknown'
+  const senderType = ctx.senderType || 'unknown'
+  const eventKind = ctx.eventKind || 'unknown'
+  const ts = ctx.ts || 'unknown'
+  const conv = ctx.conversationId || 'unknown'
+  const header = `[${eventKind}] ${senderName} (${senderType}) · conv=${conv} · ts=${ts}`
+  return `${header}\n${ctx.content}`
 }
 
 export async function runSprintableSSE(opts: {
@@ -235,6 +271,9 @@ export async function runSprintableSSE(opts: {
     ) as Record<string, unknown>
     const senderId = String(sender.id ?? data.sender_id ?? 'sprintable')
     const senderName = String(sender.name ?? senderId)
+    const senderType = String(sender.type ?? '')
+    const eventKind = String(data.event_type ?? payload.event_type ?? '')
+    const ts = String(data.created_at ?? payload.created_at ?? '')
     const isBackfill = Boolean(data.is_backfill)
 
     const replyUrl = conversationId
@@ -243,6 +282,7 @@ export async function runSprintableSSE(opts: {
 
     return {
       content, conversationId, senderId, senderName, eventId, seq, isBackfill, attachments, raw: data,
+      senderType, eventKind, ts,
       async reply(text: string) {
         if (!replyUrl) throw new Error('no conversation_id')
         const r = await fetch(replyUrl, {

--- a/connectors/pi-sprintable/sprintable-sse.ts
+++ b/connectors/pi-sprintable/sprintable-sse.ts
@@ -211,8 +211,21 @@ export async function runSprintableSSE(opts: {
               process.stderr.write(
                 `[sprintable-sse] inbound seq=${ctx.seq} conv=${ctx.conversationId}: ${ctx.content.slice(0, 80)}\n`
               )
-              await onMessage(ctx)
-              if (ctx.seq) await ack(ctx.seq)
+              // story #2580 — isDup() claims ctx.eventId *before* onMessage runs (needed to
+              // survive a same-event redelivery arriving mid-processing). If onMessage throws
+              // (reply POST failed, LLM call failed, etc.), the event never gets acked, so the
+              // backend backfills the identical event_id on reconnect — but isDup() would keep
+              // rejecting it as already-seen forever (bounded only by the opportunistic TTL
+              // sweep at DEDUP_MAX overflow), silently losing the message. Same defect class as
+              // codex PR#7's claim-before-POST bug — release the claim on failure so redelivery
+              // can retry, same as codex's `_release_claim`.
+              try {
+                await onMessage(ctx)
+                if (ctx.seq) await ack(ctx.seq)
+              } catch (e) {
+                seen.delete(ctx.eventId)
+                throw e
+              }
             }
           }
           evType = 'message'; evId = ''; dataLines = []


### PR DESCRIPTION
## Summary
Split off #2562 (S7) once `host.py` turned out to be the wrong shape (discovered live during S7's own research): `host.py` is Category B (host spawns/owns `pi` as a child process) — the opposite of what Pi's real extension system requires. Pi wants an **in-process** extension factory that runs inside the same process as the running session; `host.py` can't be adapted into that, hence this from-scratch TS rewrite. `host.py` is kept as a preserved Category-B alternative rather than deleted (same call made for the codex plugin's own `host.py`-equivalent precedent).

## Ground-truthing
Against the real `@earendil-works/pi-coding-agent`@0.84.1 npm package's shipped `.d.ts`, and a real published pi-package (`pi-spark`, via `npm pack`) for the `package.json` shape — not assumed from the story description alone, which had one small inaccuracy: `sendUserMessage(content, {deliverAs, triggerTurn})` isn't the real signature. `sendUserMessage` only takes `deliverAs` (its own doc comment: "Always triggers a turn", no separate flag needed); `triggerTurn` belongs to the *different* `sendMessage` custom-message API this extension doesn't use.

**Pi is architecturally simpler here than every other Sprintable connector**: in-process means no idle-wake problem exists at all. Every other connector (codex/grok/gemini) spawns a fresh CLI process to wake an idle session and has had to solve idle-wake as its own mechanism (gemini got it wrong on the first attempt — see #2561's `--resume` fix). `sendUserMessage(..., {deliverAs: "steer"})` injects correctly whether the agent is idle or mid-turn, per the SDK's own doc comment — no separate wake path needed.

`package.json` ships raw `.ts` (confirmed via the real `pi-spark` package's own `files` field — Pi consumes TypeScript directly, no `ignore-scripts` prebuild constraint like OpenClaw's npm install has).

## Verification
- Real isolated `pi install <path> -l` (project-local `.pi/settings.json`, zero contact with any global `pi` config) — extension registers correctly (`pi list --approve` shows it).
- `tsc --noEmit --strict` clean on `index.ts`/`index.test.ts`/`sprintable-sse.ts` (re-confirmed 2026-08-17 post-rebase via a correctly-scoped isolated tsconfig — `skipLibCheck`+`ES2022` lib; a bare unscoped `tsc` invocation false-positives on unrelated transitive monorepo-root `node_modules` types, not a real issue with this package).
- **New `index.test.ts`** (`bun:test`): a fake `ExtensionAPI` (no real `pi` binary) + a real mock SSE server prove the full logic this extension owns — SSE receive → `sendUserMessage(deliverAs:"steer")` injection with the correct content → `agent_end` → last-assistant-text extraction → real POST to a (mocked) reply endpoint, plus the AC3 silent-no-op case when credentials are unset. **2/2 pass** (re-confirmed post-rebase).
- **Real bug caught and fixed by writing that test**: `API_KEY`/`API_URL` were module-level `const`s evaluated once at import time, before any env var could realistically be set for a fresh import — moved credential resolution inside the factory function (also matches every other connector's own per-call resolution pattern, e.g. `openclaw-sprintable`'s `resolveAccount`).

## Full live round trip (2026-08-17) — AC2 complete
Real `pi` (built via `npm pack` → tarball unpack → `pi install <dir> -l` in a fully isolated `$HOME`, zero contact with any global `pi`/Sprintable config), `--provider google --model gemini-flash-latest`, `SPRINTABLE_API_KEY` = a dedicated test-only agent identity (`hermes-test`, not a real team member's live key — avoids double-consuming a real SSE slot), against the real Sprintable dev backend and a disposable test conversation:

```
[sprintable-sse] stream open
[sprintable-sse] inbound seq=84 conv=5f234804-…: PR2970 왕복 e2e 격리테스트: … 정확히 "PONG-2970"이라고만 답해주는.
[sprintable-sse] ack seq=84
PONG-2970
```
— and the reply landed for real in the Sprintable conversation (posted by `hermes-test`, matching the requested exact string). Process exited gracefully on its own after the turn (`-p` mode's own exit path — no `SIGKILL`, no orphaned SSE slot). Confirms `session_start`→SSE-open→inbound-steer-injection→`agent_end`→reply-POST→`session_shutdown` end to end, with a real Gemini model turn in between — not just the mocked-logic path `index.test.ts` already covered.

Model-name note: `gemini-2.5-flash` 404s on the currently-live API surface; `gemini-flash-latest` is the working current name (matches the connector's own model catalog).

## Test plan
- [x] `tsc --noEmit --strict` clean
- [x] Isolated project-local install, real `pi list` confirms registration
- [x] Real SSE connect confirmed live
- [x] Mock-chain test (SSE → inject → agent_end → reply) 2/2 pass
- [x] Full live LLM round trip (real Gemini turn, real Sprintable reply) — see above
- [ ] Kadir QA
- [ ] `npm publish sprintable-pi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
