### PR TITLE
fix(openclaw-sprintable): tsconfig.json for isolated DTS build (S8/#2563)

### DIFF
--- a/connectors/openclaw-sprintable/tsconfig.json
+++ b/connectors/openclaw-sprintable/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["*.ts", "src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- Isolated fresh-install → `npm pack` (via `prepack: npm run build`) failed at the `tsup --dts` step: `Cannot find module 'openclaw/plugin-sdk/channel-core' ... set 'moduleResolution' to 'nodenext'`.
- Root cause: the connector had no `tsconfig.json` of its own — earlier verification only passed because it rode the monorepo root's `tsconfig.json` (`moduleResolution: bundler`), which isn't shipped in the npm package and isn't present for a real standalone install.
- Fix: added `connectors/openclaw-sprintable/tsconfig.json` with the same `compilerOptions` as the monorepo root, so tsup's DTS build is self-contained.

## Test plan
- [x] Reproduced in a clean isolated dir with no monorepo tsconfig reachable — DTS build failed with the exact reported error before this fix.
- [x] After adding tsconfig.json: DTS build succeeds, `dist/index.d.ts` + `dist/setup-entry.d.ts` produced.
- [x] Full fresh-install → `npm pack` ships all 4 expected files: `dist/index.js`, `dist/setup-entry.js`, `dist/index.d.ts`, `dist/setup-entry.d.ts`.
- [x] Existing `channel.test.ts` unaffected: 4/4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)