### PR TITLE
fix(openclaw-sprintable): unscope package name to match what's published

### DIFF
--- a/connectors/openclaw-sprintable/README.md
+++ b/connectors/openclaw-sprintable/README.md
@@ -5,13 +5,13 @@ Sprintable Gateway channel plugin for [OpenClaw](https://github.com/openclaw/ope
 ## Install
 
 ```bash
-openclaw plugins install npm:@moonklabs/openclaw-sprintable
+openclaw plugins install npm:openclaw-sprintable
 ```
 
 Or via [ClawHub](https://clawhub.dev) (the primary discovery surface for OpenClaw plugins):
 
 ```bash
-openclaw plugins install clawhub:@moonklabs/openclaw-sprintable
+openclaw plugins install clawhub:openclaw-sprintable
 ```
 
 **Restart the gateway after install** — plugin installation alone does not start serving:

--- a/connectors/openclaw-sprintable/package.json
+++ b/connectors/openclaw-sprintable/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@moonklabs/openclaw-sprintable",
+  "name": "openclaw-sprintable",
   "version": "0.1.0",
   "description": "Sprintable Gateway channel plugin for OpenClaw — real-time team chat via SSE dial-out (no inbound webhook required).",
   "keywords": [
@@ -44,8 +44,8 @@
       "pluginApi": ">=2026.7.1"
     },
     "install": {
-      "clawhubSpec": "@moonklabs/openclaw-sprintable",
-      "npmSpec": "@moonklabs/openclaw-sprintable"
+      "clawhubSpec": "openclaw-sprintable",
+      "npmSpec": "openclaw-sprintable"
     }
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- Published as unscoped `openclaw-sprintable@0.1.0` (PO decision — @moonklabs npm org deleted), but repo source still declared `@moonklabs/openclaw-sprintable`.
- Renames `package.json`'s `name` + `openclaw.install.{clawhubSpec,npmSpec}`, and both install commands in README, to match what actually shipped.
- Grepped repo-wide for `@moonklabs/openclaw-sprintable` after the change: zero remaining references. Other `connectors/openclaw-sprintable/` mentions (connect-guide.txt, onboarding-guide.txt, recruit.ts, agent_onboarding_config.py) are directory-path labels, not the npm package name — confirmed unaffected, left untouched.

## Test plan
- [x] `npm install` + `npm run build` — DTS build succeeds (tsconfig.json from #2971 still holds after the rename).
- [x] `npm test` (channel.test.ts) — 4/4 pass.
- [x] Repo-wide grep for `@moonklabs/openclaw-sprintable` — 0 hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)