### PR TITLE
ci: publish-connectors.yml — OIDC trusted publishing for npm connectors

### DIFF
--- a/.github/workflows/publish-connectors.yml
+++ b/.github/workflows/publish-connectors.yml
@@ -1,0 +1,37 @@
+# OIDC trusted publishing for the npm connector packages (opencode-sprintable,
+# openclaw-sprintable) — no token/OTP needed once this matches the npm-side trust
+# config exactly. Filename must stay `publish-connectors.yml` (npm's registered
+# trust is keyed on repo + this exact filename): trust IDs `b7ec4cef`
+# (opencode-sprintable) and `953c8d1e` (openclaw-sprintable), repo
+# moonklabs/sprintable, no environment configured on the npm side — so this
+# workflow intentionally has no `environment:` key (adding one would break the
+# OIDC subject match). `id-token: write` below is what lets npm verify this run's
+# identity in place of a token.
+name: publish-connectors
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 발행할 커넥터
+        required: true
+        type: choice
+        options: [opencode-sprintable, openclaw-sprintable]
+permissions:
+  contents: read
+  id-token: write        # OIDC — trusted publishing의 핵심
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: https://registry.npmjs.org
+      - run: npm install -g npm@latest          # trusted publishing은 npm >= 11.5.1
+      - name: install deps
+        working-directory: connectors/${{ inputs.package }}
+        run: npm install --no-audit --no-fund
+      - name: publish ${{ inputs.package }}
+        working-directory: connectors/${{ inputs.package }}
+        run: npm publish --provenance --access public   # 토큰/OTP 없음·OIDC 신원증명


### PR DESCRIPTION
## Summary
- PO registered npm trusted publishers keyed on this exact filename (`publish-connectors.yml`), repo `moonklabs/sprintable`, no environment: trust `b7ec4cef` for `opencode-sprintable`, trust `953c8d1e` for `openclaw-sprintable`.
- Adds the matching workflow: `workflow_dispatch` with a `package` choice input, `id-token: write` (OIDC), `npm publish --provenance --access public` — no token/OTP needed once npm's trust config matches this file.
- No `environment:` key by design — the npm-side trust has none configured; adding one would break the OIDC subject match.

## Test plan
- [x] `actionlint` — clean, no findings.
- [x] Manual YAML parse — structure matches spec exactly (permissions, no environment, inputs, steps).
- [ ] Real publish dispatch — not triggered in this PR (per PO: workflow existing + trust matching is what matters now; verified live at the next actual connector publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)