### PR TITLE
fix(story #2580): reply-claim audit — release inbound dedup claim on onMessage failure (opencode/openclaw)

### DIFF
--- a/connectors/openclaw-sprintable/package.json
+++ b/connectors/openclaw-sprintable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-sprintable",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Sprintable Gateway channel plugin for OpenClaw — real-time team chat via SSE dial-out (no inbound webhook required).",
   "keywords": [
     "openclaw-plugin",

--- a/connectors/openclaw-sprintable/sprintable-sse.ts
+++ b/connectors/openclaw-sprintable/sprintable-sse.ts
@@ -175,8 +175,21 @@ export async function runSprintableSSE(opts: {
               process.stderr.write(
                 `[sprintable-sse] inbound seq=${ctx.seq} conv=${ctx.conversationId}: ${ctx.content.slice(0, 80)}\n`
               )
-              await onMessage(ctx)
-              if (ctx.seq) await ack(ctx.seq)
+              // story #2580 — isDup() claims ctx.eventId *before* onMessage runs (needed to
+              // survive a same-event redelivery arriving mid-processing). If onMessage throws
+              // (reply POST failed, LLM call failed, etc.), the event never gets acked, so the
+              // backend backfills the identical event_id on reconnect — but isDup() would keep
+              // rejecting it as already-seen forever (bounded only by the opportunistic TTL
+              // sweep at DEDUP_MAX overflow), silently losing the message. Same defect class as
+              // codex PR#7's claim-before-POST bug — release the claim on failure so redelivery
+              // can retry, same as codex's `_release_claim`.
+              try {
+                await onMessage(ctx)
+                if (ctx.seq) await ack(ctx.seq)
+              } catch (e) {
+                seen.delete(ctx.eventId)
+                throw e
+              }
             }
           }
           evType = 'message'; evId = ''; dataLines = []

--- a/connectors/opencode-sprintable/package.json
+++ b/connectors/opencode-sprintable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-sprintable",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Sprintable Gateway channel plugin for OpenCode — two-way chat between an OpenCode session and its Sprintable team, dial-out (no inbound domain/webhook/tunnel required).",
   "keywords": ["opencode-plugin", "sprintable"],
   "type": "module",

--- a/connectors/opencode-sprintable/sprintable-sse.ts
+++ b/connectors/opencode-sprintable/sprintable-sse.ts
@@ -175,8 +175,21 @@ export async function runSprintableSSE(opts: {
               process.stderr.write(
                 `[sprintable-sse] inbound seq=${ctx.seq} conv=${ctx.conversationId}: ${ctx.content.slice(0, 80)}\n`
               )
-              await onMessage(ctx)
-              if (ctx.seq) await ack(ctx.seq)
+              // story #2580 — isDup() claims ctx.eventId *before* onMessage runs (needed to
+              // survive a same-event redelivery arriving mid-processing). If onMessage throws
+              // (reply POST failed, LLM call failed, etc.), the event never gets acked, so the
+              // backend backfills the identical event_id on reconnect — but isDup() would keep
+              // rejecting it as already-seen forever (bounded only by the opportunistic TTL
+              // sweep at DEDUP_MAX overflow), silently losing the message. Same defect class as
+              // codex PR#7's claim-before-POST bug — release the claim on failure so redelivery
+              // can retry, same as codex's `_release_claim`.
+              try {
+                await onMessage(ctx)
+                if (ctx.seq) await ack(ctx.seq)
+              } catch (e) {
+                seen.delete(ctx.eventId)
+                throw e
+              }
             }
           }
           evType = 'message'; evId = ''; dataLines = []

--- a/connectors/sdk/sprintable-sse.test.ts
+++ b/connectors/sdk/sprintable-sse.test.ts
@@ -135,3 +135,59 @@ test('parseEvent still drops truly empty events (no content, no attachments)', a
   server.stop(true)
   expect(gotMessage).toBe(false)
 })
+
+// story #2580 — reply-claim audit: codex PR#7 fixed a "claim committed before the operation,
+// never released on failure → same-key retry silently skipped forever → permanent message
+// loss" bug in the Python plugins' outbound reply dedup (`_claim_reply_once`/`_release_claim`).
+// This TS SDK has no outbound reply-claim table, but `isDup()` plays the structurally
+// equivalent role on the INBOUND side: it claims `eventId` before `onMessage` runs, and — pre-
+// fix — never released it if `onMessage` threw. Since a thrown onMessage means the event never
+// gets acked, the backend backfills the identical event_id on the next connection, and isDup()
+// silently rejected it as already-seen forever. Same defect class, different mechanism.
+test('#2580: a redelivered same-event_id retry (after onMessage throws) reaches onMessage again instead of being silently deduped', async () => {
+  let requestCount = 0
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      if (req.url.includes('/api/v2/agent/stream')) {
+        requestCount++
+        const stream = new ReadableStream({
+          start(controller) {
+            const enc = new TextEncoder()
+            // Same "id:"/event_id every connection — backend backfill re-sends an un-acked
+            // event with its original id, it doesn't mint a new one.
+            controller.enqueue(enc.encode(
+              `event: message\nid: 1\ndata: ${JSON.stringify({
+                event_type: 'dispatched', event_id: 'evt-2580-repro', content: 'hello',
+              })}\n\n`,
+            ))
+          },
+        })
+        return new Response(stream, { headers: { 'content-type': 'text/event-stream' } })
+      }
+      return new Response('{}', { headers: { 'content-type': 'application/json' } })
+    },
+  })
+
+  const controller = new AbortController()
+  let calls = 0
+  const run = runSprintableSSE({
+    apiUrl: `http://localhost:${server.port}`,
+    apiKey: 'test-key',
+    signal: controller.signal,
+    onMessage: async () => {
+      calls++
+      if (calls === 1) throw new Error('simulated reply POST failure')
+    },
+  }).catch(() => {})
+
+  // 1st connection: onMessage throws → stays un-acked → reconnect after backoff[0]=2000ms →
+  // 2nd connection backfills the identical event_id.
+  await new Promise((r) => setTimeout(r, 2600))
+  controller.abort()
+  await run
+  server.stop(true)
+
+  expect(requestCount).toBeGreaterThanOrEqual(2) // the reconnect+redelivery actually happened
+  expect(calls).toBe(2) // pre-fix: calls stayed 1 — isDup() silently ate the redelivery
+})

--- a/connectors/sdk/sprintable-sse.ts
+++ b/connectors/sdk/sprintable-sse.ts
@@ -175,8 +175,21 @@ export async function runSprintableSSE(opts: {
               process.stderr.write(
                 `[sprintable-sse] inbound seq=${ctx.seq} conv=${ctx.conversationId}: ${ctx.content.slice(0, 80)}\n`
               )
-              await onMessage(ctx)
-              if (ctx.seq) await ack(ctx.seq)
+              // story #2580 — isDup() claims ctx.eventId *before* onMessage runs (needed to
+              // survive a same-event redelivery arriving mid-processing). If onMessage throws
+              // (reply POST failed, LLM call failed, etc.), the event never gets acked, so the
+              // backend backfills the identical event_id on reconnect — but isDup() would keep
+              // rejecting it as already-seen forever (bounded only by the opportunistic TTL
+              // sweep at DEDUP_MAX overflow), silently losing the message. Same defect class as
+              // codex PR#7's claim-before-POST bug — release the claim on failure so redelivery
+              // can retry, same as codex's `_release_claim`.
+              try {
+                await onMessage(ctx)
+                if (ctx.seq) await ack(ctx.seq)
+              } catch (e) {
+                seen.delete(ctx.eventId)
+                throw e
+              }
             }
           }
           evType = 'message'; evId = ''; dataLines = []


### PR DESCRIPTION
## Story #2580 — 포팅 커넥터 회신-클레임 fix 역적용 감사

Scope per kickoff: audit the npm-published TS reply path (`sprintable-sse.ts`, shared by `opencode-sprintable`/`openclaw-sprintable`/`connectors/sdk`) for the same defect class as codex PR#7 (`_claim_reply_once`/`_release_claim`/`post_reply` 3-value return) — claim committed before an operation that can fail, never released on failure, causing same-key retries to be silently skipped forever.

## Finding — AC1

The TS SDK has **no outbound reply-claim table** (no equivalent of `_claim_reply_once`), so nothing there mirrors codex's exact shape. But `isDup(eventId)` in `runSprintableSSE`'s SSE-consume loop plays the **structurally equivalent role on the inbound side**:

- `isDup()` commits `ctx.eventId` to the in-memory `seen` dedup map **before** `onMessage(ctx)` runs (needed so a same-event redelivery arriving mid-processing on the *same* connection doesn't double-fire).
- Pre-fix, if `onMessage` threw (reply POST failed, LLM call failed, etc.), the event was never acked. The backend backfills the identical `event_id` on the next connection (`recipient_seq > last_acked` still includes it — verified against `backend/app/routers/agent_gateway.py`'s backfill query).
- But `isDup()` kept rejecting that redelivered event as already-seen **forever** (`seen` is only opportunistically swept past `DEDUP_TTL_MS` once it exceeds `DEDUP_MAX` entries — under normal per-process volume that eviction may never trigger) — silently losing the message. Same defect class as codex's bug, different mechanism (inbound dedup instead of outbound reply-claim).

**Both published npm packages carry the defect** — verified against the actual tarballs (`npm pack opencode-sprintable@0.1.0` / `openclaw-sprintable@0.1.0`), not just repo source (repo and publish matched exactly in this case, but confirmed per kickoff instruction to check both).

## Fix — AC2

```ts
try {
  await onMessage(ctx)
  if (ctx.seq) await ack(ctx.seq)
} catch (e) {
  seen.delete(ctx.eventId)
  throw e
}
```

Mirrors codex's `_release_claim`: release the claim on failure, keep it on success. The outer reconnect/backoff catch is unchanged — this only adds the release-before-rethrow.

Applied byte-identically to all three vendored copies (`connectors/sdk`, `connectors/opencode-sprintable`, `connectors/openclaw-sprintable`) per the existing manual-vendoring convention (all three were byte-identical before this change too).

## Verification (force-fail repro, Kadir S5 method)

Mock SSE server redelivers the same `event_id` on reconnect (simulating backend backfill of an un-acked event). `onMessage` throws on the 1st delivery (simulated reply-POST failure).

- **RED** (pre-fix): `onMessage` called once — the redelivered retry is silently dropped by `isDup()`.
- **GREEN** (post-fix): `onMessage` called twice — the redelivered retry reaches `onMessage` again.

Pinned as a permanent regression test in `connectors/sdk/sprintable-sse.test.ts` (`#2580: a redelivered same-event_id retry (after onMessage throws) reaches onMessage again instead of being silently deduped`).

- `bun test` on `connectors/sdk/sprintable-sse.test.ts` — 10/10 pass.
- `openclaw-sprintable`: `npm run build` (tsup + dts) clean, `npm test` (`channel.test.ts`) — 4/4 pass.
- `opencode-sprintable`: `bun build index.ts` clean (this package publishes raw `.ts`, no bundler).

## AC3 — version bump for republish

`opencode-sprintable` and `openclaw-sprintable` both bumped `0.1.0` → `0.1.1`. Once merged, republish via the `publish-connectors.yml` workflow_dispatch (OIDC trusted publishing, no token) for each package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)