### PR TITLE
[SID:2579] CLI stdio MCP uvx 패키지명 sprintable-mcp→sprintable

### DIFF
--- a/packages/cli/src/adapters/types.test.ts
+++ b/packages/cli/src/adapters/types.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { writeMcpServersFormat, writeMcpSectionFormat } from "./types.js";
+
+// engines floor is node>=20.0.0 — import.meta.dirname needs 20.11+, so derive it the
+// portable way instead.
+const currentDir = dirname(fileURLToPath(import.meta.url));
+
+// story #2579 — server key ("sprintable-mcp") and the uvx package/console-script name
+// ("sprintable", the actual PyPI name) are two different strings this file previously
+// conflated: both writers put the server key into `args` too, so `uvx sprintable-mcp`
+// looked up a package that doesn't exist on PyPI and stdio registration failed. These
+// tests exercise the real writer functions against a real temp file (not a hand-built
+// literal standing in for the implementation, story #2965 QA note) so a regression in
+// either writer actually fails the test.
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "sprintable-cli-test-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("writeMcpServersFormat — mcpServers 형식", () => {
+  it("uvx 패키지명은 sprintable(PyPI 실명), 서버키는 sprintable-mcp(#2577)", () => {
+    const configPath = join(dir, ".mcp.json");
+    writeMcpServersFormat(configPath, "https://api.sprintable.ai/", "sk_test");
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    const server = config.mcpServers["sprintable-mcp"];
+    expect(server.command).toBe("uvx");
+    expect(server.args).toEqual(["sprintable"]);
+  });
+
+  it("SSOT(backend agent_onboarding_config.py::_build_stdio_config) 필드와 정합 — AGENT_GATEWAY_V2 누락 없음", () => {
+    const configPath = join(dir, ".mcp.json");
+    writeMcpServersFormat(configPath, "https://api.sprintable.ai", "sk_test");
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    const server = config.mcpServers["sprintable-mcp"];
+    expect(server.type).toBe("stdio");
+    expect(server.env).toEqual({
+      SPRINTABLE_API_URL: "https://api.sprintable.ai",
+      AGENT_GATEWAY_V2: "1",
+      AGENT_API_KEY: "sk_test",
+    });
+  });
+
+  it("기존 mcpServers 항목은 보존한다", () => {
+    const configPath = join(dir, ".mcp.json");
+    writeMcpServersFormat(configPath, "https://api.sprintable.ai", "sk_first");
+    // 기존 파일에 다른 서버가 있다고 가정하고 그 위에 다시 쓴다
+    const before = JSON.parse(readFileSync(configPath, "utf-8"));
+    before.mcpServers.other = { command: "other" };
+    writeFileSync(configPath, JSON.stringify(before, null, 2) + "\n");
+
+    writeMcpServersFormat(configPath, "https://api.sprintable.ai", "sk_second");
+    const after = JSON.parse(readFileSync(configPath, "utf-8"));
+    expect(after.mcpServers).toHaveProperty("other");
+    expect(after.mcpServers["sprintable-mcp"].env.AGENT_API_KEY).toBe("sk_second");
+  });
+});
+
+describe("writeMcpSectionFormat — VS Code mcp.servers 형식", () => {
+  it("uvx 패키지명은 sprintable, 서버키는 sprintable-mcp", () => {
+    const configPath = join(dir, "settings.json");
+    writeMcpSectionFormat(configPath, "https://api.sprintable.ai", "sk_test");
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    const server = config.mcp.servers["sprintable-mcp"];
+    expect(server.args).toEqual(["sprintable"]);
+    expect(server.env.AGENT_GATEWAY_V2).toBe("1");
+  });
+});
+
+// story #2579 AC3 — 이 파일이 SSOT(backend)에서 발산해도 잡을 방법이 없으면 이 버그가
+// 재발한다. TS 쪽만 정확해도 backend가 나중에 uvx 패키지명을 바꾸면 다시 어긋난다 —
+// backend 소스 리터럴을 직접 읽어 여기서 하드코딩한 기대값과 대조한다(빌드 산출물이 아닌
+// 소스라 배포 여부와 무관하게 항상 최신).
+describe("backend SSOT와 uvx 패키지명 일치(회귀가드)", () => {
+  it("backend/app/services/agent_onboarding_config.py의 _build_stdio_config args와 일치", () => {
+    const backendPath = join(
+      currentDir, "..", "..", "..", "..",
+      "backend", "app", "services", "agent_onboarding_config.py",
+    );
+    const source = readFileSync(backendPath, "utf-8");
+    // _build_stdio_config() 안의 정확히 이 리터럴만 매치 — 다른 args:[...] 오탐 방지.
+    expect(source).toContain('"args": ["sprintable"],  # PyPI package/console-script name');
+  });
+});

--- a/packages/cli/src/adapters/types.ts
+++ b/packages/cli/src/adapters/types.ts
@@ -17,14 +17,7 @@ export function writeMcpServersFormat(
 ): void {
   const config = readJsonFile(configPath);
   const servers = (config.mcpServers ?? {}) as Record<string, unknown>;
-  servers["sprintable-mcp"] = {
-    command: "uvx",
-    args: ["sprintable-mcp"],
-    env: {
-      SPRINTABLE_API_URL: apiUrl.replace(/\/$/, ""),
-      AGENT_API_KEY: apiKey,
-    },
-  };
+  servers["sprintable-mcp"] = buildStdioServerEntry(apiUrl, apiKey);
   config.mcpServers = servers;
   writeJsonFile(configPath, config);
 }
@@ -38,17 +31,37 @@ export function writeMcpSectionFormat(
   const config = readJsonFile(configPath);
   const mcp = (config.mcp ?? {}) as Record<string, unknown>;
   const servers = (mcp.servers ?? {}) as Record<string, unknown>;
-  servers["sprintable-mcp"] = {
-    command: "uvx",
-    args: ["sprintable-mcp"],
-    env: {
-      SPRINTABLE_API_URL: apiUrl.replace(/\/$/, ""),
-      AGENT_API_KEY: apiKey,
-    },
-  };
+  servers["sprintable-mcp"] = buildStdioServerEntry(apiUrl, apiKey);
   mcp.servers = servers;
   config.mcp = mcp;
   writeJsonFile(configPath, config);
+}
+
+/**
+ * stdio MCP server entry — single source shared by both writer formats above.
+ *
+ * story #2579: server key ("sprintable-mcp", #2577 rename) and the `uvx` package/
+ * console-script name ("sprintable", the actual PyPI name) are two different strings
+ * that this file previously conflated — both writers passed the server key into
+ * `args` too, so `uvx sprintable-mcp` looked up a package that doesn't exist on PyPI
+ * (only `sprintable` is published) and stdio registration failed outright. Also
+ * brings this generator to parity with the backend SSOT
+ * (`backend/app/services/agent_onboarding_config.py::_build_stdio_config`) which this
+ * had silently drifted from: `AGENT_GATEWAY_V2` was missing (sse_bridge falls back to
+ * the legacy `/api/v2/events/stream` path without it — tools list fine, messages never
+ * arrive) and `type: "stdio"` was omitted.
+ */
+function buildStdioServerEntry(apiUrl: string, apiKey: string): Record<string, unknown> {
+  return {
+    type: "stdio",
+    command: "uvx",
+    args: ["sprintable"],
+    env: {
+      SPRINTABLE_API_URL: apiUrl.replace(/\/$/, ""),
+      AGENT_GATEWAY_V2: "1",
+      AGENT_API_KEY: apiKey,
+    },
+  };
 }
 
 export function readJsonFile(path: string): Record<string, unknown> {

--- a/packages/cli/src/commands/connect.test.ts
+++ b/packages/cli/src/commands/connect.test.ts
@@ -64,11 +64,17 @@ describe("writeMcpConfig — 구조 검증", () => {
       JSON.stringify({ mcpServers: { other: { command: "other" } } })
     );
     // #2577: 서버키 sprintable -> sprintable-mcp
+    // story #2579: uvx 패키지명은 서버키와 별개로 PyPI 실명("sprintable")이어야 한다 —
+    // 이 값을 서버키와 같게 적으면(구 "sprintable-mcp") 실제 구현(adapters/types.ts)이
+    // 그렇게 회귀했을 때도 이 자리는 계속 통과한다(공허-통과), 진짜 검증은
+    // adapters/types.test.ts가 real writer 함수를 호출해서 한다 — 여기는 그 값과
+    // 어긋나지 않게만 맞춰둔다.
     existing.mcpServers["sprintable-mcp"] = {
       command: "uvx",
-      args: ["sprintable-mcp"],
+      args: ["sprintable"],
       env: {
         SPRINTABLE_API_URL: "https://api.sprintable.ai",
+        AGENT_GATEWAY_V2: "1",
         AGENT_API_KEY: "sk_test",
       },
     };


### PR DESCRIPTION
## 요약
- `packages/cli`의 stdio MCP config writer 2개(mcpServers/mcp.servers 형식)가 서버키(`sprintable-mcp`, #2577)와 uvx 패키지명(`sprintable`, 실제 PyPI 배포명)을 혼동해 `args`에도 서버키를 그대로 써서, `uvx sprintable-mcp`가 PyPI에 없는 패키지를 찾아 `sprintable connect`의 stdio 등록이 항상 실패했음(카디르 발견 #2965 QA·origin/develop 선행 버그, PO git diff로 귀속 확定).
- 두 writer를 `buildStdioServerEntry()`로 통합하고 backend SSOT(`agent_onboarding_config.py::_build_stdio_config`)와 필드까지 정합 — `args:["sprintable"]`, 누락돼 있던 `AGENT_GATEWAY_V2:"1"`(빠지면 sse_bridge가 구 경로 폴백 → 도구는 보이는데 메시지가 안 옴), `type:"stdio"` 추가.

## 검증
- [x] `types.test.ts` 신설 — 실제 writer 함수를 임시 파일에 호출해 검증(기존 `connect.test.ts`의 손조립 리터럴은 구현을 안 거치는 공허-통과라 값 정정 + 진짜 커버리지는 새 파일로 이관). 구 값으로 되돌려 실패 재현 확認 후 복원.
- [x] backend SSOT 소스 리터럴을 직접 읽어 CLI 값과 대조하는 회귀가드(AC3) — 어느 한쪽만 발산해도 잡힘.
- [x] 격리 HOME(`homedir()` 오버라이드)에서 실제 `getAdapter("claude-code").writeConfig()` 호출 → `.mcp.json` 생성 → 그 값 그대로 `uvx sprintable` 기동해 실 PyPI resolve+인증+SSE 연결까지 e2e 실증(AC2). 더미키=401, 실 발급키=200+SSE connected 양쪽 확認.
- [x] `packages/cli`: `tsc --noEmit` exit 0, `tsc` build exit 0, `vitest run` 47/47 pass

## AC4(카디르 QA 독립 재현)
CI green 확認되는 대로 카디르 QA 라우팅 요청 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)