### PR TITLE
fix(#2974 QA blocker): DocCreate missing is_folder field

### DIFF
--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -238,7 +238,10 @@ async def create_doc(
         created_by=created_by,
         icon=body.icon,
         sort_order=body.sort_order,
-        doc_type=body.doc_type,
+        # story #2974 — is_folder는 doc_type=="folder"의 shorthand(Doc.is_folder derived
+        # property와 대칭). True면 doc_type을 강제 — explicit body.doc_type과 충돌해도
+        # is_folder가 우선(둘 다 명시된 경우는 없고, is_folder는 신설 편의 필드).
+        doc_type="folder" if body.is_folder else body.doc_type,
         content_format=body.content_format,
         tags=body.tags,
     )

--- a/backend/app/schemas/doc.py
+++ b/backend/app/schemas/doc.py
@@ -17,6 +17,12 @@ class DocCreate(BaseModel):
     doc_type: str = "page"
     content_format: str = "markdown"
     tags: list[str] = []
+    # story #2974 QA(카디르) — Doc.is_folder(models/doc.py)는 저장 컬럼이 아니라
+    # doc_type=="folder"의 derived property다. FE(apps/web/src/app/api/docs/route.ts)가
+    # 요청에 is_folder를 실어 보내는데 이 스키마엔 그 필드가 없어 Pydantic이 조용히 버렸다 —
+    # 클라가 true를 보내도 항상 doc_type="page"(폴더 아님)로 생성됐다. 라우터가 True면
+    # doc_type을 "folder"로 강제한다(create_doc 참고).
+    is_folder: bool = False
 
 
 class DocUpdate(BaseModel):

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -137,6 +137,72 @@ async def test_create_doc_201():
 
 
 @pytest.mark.anyio
+async def test_create_doc_is_folder_true_sets_doc_type_folder():
+    """story #2974(카디르 QA) — DocCreate에 is_folder 필드가 없어 Pydantic이 요청의
+    is_folder:true를 조용히 버리고 doc_type이 항상 기본값("page")으로 생성되던 결함.
+    is_folder:true를 보내면 repo.create()에 doc_type="folder"가 실제로 전달되는지 고정한다
+    (Doc.is_folder는 저장 컬럼이 아니라 doc_type=="folder" derived property — models/doc.py)."""
+    doc = _mock_doc()
+    doc.doc_type = "folder"
+    with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create, \
+         patch("app.routers.docs._resolve_doc_member_id", new_callable=AsyncMock) as mock_resolve, \
+         patch("app.routers.docs.canonicalize_member_id", new_callable=AsyncMock) as mock_canon, \
+         patch("app.services.mention_parser.reconcile_doc_mentions", new_callable=AsyncMock) as mock_reconcile:
+        mock_create.return_value = doc
+        mock_resolve.return_value = doc.created_by
+        mock_canon.return_value = doc.created_by
+        mock_reconcile.return_value = None
+
+        client, session, app = await _client()
+        try:
+            async with client as c:
+                resp = await c.post("/api/v2/docs", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "My Folder",
+                    "slug": "my-folder",
+                    "is_folder": True,
+                })
+        finally:
+            app.dependency_overrides.clear()
+
+    assert resp.status_code == 201
+    # 핵심 회귀가드 — is_folder:true가 repo.create()의 doc_type="folder"로 실제 전달됐는지.
+    # is_folder 자체는 Doc 생성자 kwarg가 아니므로(derived property) 이 호출에 실려선 안 된다.
+    assert mock_create.call_args.kwargs["doc_type"] == "folder"
+    assert "is_folder" not in mock_create.call_args.kwargs
+
+
+@pytest.mark.anyio
+async def test_create_doc_is_folder_omitted_defaults_to_page():
+    """음성대조 — is_folder 미지정(기본 False)이면 기존 동작(doc_type="page") 그대로."""
+    doc = _mock_doc()
+    with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create, \
+         patch("app.routers.docs._resolve_doc_member_id", new_callable=AsyncMock) as mock_resolve, \
+         patch("app.routers.docs.canonicalize_member_id", new_callable=AsyncMock) as mock_canon, \
+         patch("app.services.mention_parser.reconcile_doc_mentions", new_callable=AsyncMock) as mock_reconcile:
+        mock_create.return_value = doc
+        mock_resolve.return_value = doc.created_by
+        mock_canon.return_value = doc.created_by
+        mock_reconcile.return_value = None
+
+        client, session, app = await _client()
+        try:
+            async with client as c:
+                resp = await c.post("/api/v2/docs", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "Getting Started",
+                    "slug": "getting-started-2",
+                })
+        finally:
+            app.dependency_overrides.clear()
+
+    assert resp.status_code == 201
+    assert mock_create.call_args.kwargs["doc_type"] == "page"
+
+
+@pytest.mark.anyio
 async def test_get_doc_200():
     client, session, app = await _client()
     try:


### PR DESCRIPTION
## Story #2974 QA blocker (카디르 특定)

\`Doc.is_folder\` (\`models/doc.py\`) is not a stored column — it's a derived property (\`doc_type == "folder"\`). The response schema (\`DocSummaryResponse\`) exposes it, but the request schema (\`DocCreate\`) never had it, so when a client sent \`is_folder: true\`, Pydantic silently stripped the undeclared field and the doc was always created with the default \`doc_type="page"\`. FE was correct — the write axis was just missing on the create schema.

## Fix

\`DocCreate\` gets \`is_folder: bool = False\`. \`create_doc()\` router translates it: \`doc_type="folder" if body.is_folder else body.doc_type\` — \`is_folder\` itself is never passed to \`repo.create()\` (not a real column).

Swept \`DocCreate\` against \`Doc\`'s other writable columns for the same silent-drop class per QA's request — \`assignee_id\`/\`status\`/\`slug_locked\`/\`superseded_by\` are all legitimately absent (DB defaults or set later via \`DocUpdate\`/dedicated lifecycle actions, not at creation) — \`is_folder\` was the only genuine gap.

## Verification

New test (POST \`is_folder:true\` → \`repo.create()\` called with \`doc_type="folder"\`, \`is_folder\` not forwarded) confirmed **RED** against pre-fix code, **GREEN** after. Negative control (\`is_folder\` omitted → \`doc_type="page"\` unchanged) pins the existing default path. 23/23 pass across \`test_docs.py\` (+2 new), \`test_doc_slug_enrich.py\`, \`test_doc_payload_enrich.py\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)