### PR TITLE
fix(#2564): SprintableAdapter.connect() is_reconnect kwarg — live dev gateway incident

### DIFF
--- a/connectors/hermes-sprintable/adapter.py
+++ b/connectors/hermes-sprintable/adapter.py
@@ -246,7 +246,15 @@ class SprintableAdapter(BasePlatformAdapter):
 
     # -- lifecycle ----------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        # story #2564(S9) — 격리 hermes-agent(v0.18.2) 실 왕복 中 실측: BasePlatformAdapter.
+        # connect()가 이제 keyword-only is_reconnect(cold-boot=False/outage 후 재연결=True)를
+        # 받는데(gateway/platforms/base.py) 이 오버라이드가 파라미터 없이 정의돼 있어 매
+        # 연결(최초든 재연결이든)이 TypeError로 죽었다 — hermes plugins install 정식 경로로
+        # 처음 실행해서야 드러난 결함(라이브 사본은 낡아 이 시그니처 변경 前 버전이라 아직
+        # 안 겪었을 뿐). 파라미터는 무시해도 안전 — 이 어댑터는 서버측 Last-Event-ID+backfill로
+        # 재연결을 이미 감당하고(_run_stream의 백오프 루프) 클라이언트 버퍼 큐가 없어 base
+        # docstring의 "no such queue may ignore the flag" 케이스에 정확히 해당한다.
         if not HTTPX_AVAILABLE:
             logger.warning("[%s] httpx not installed", self.name)
             return False

--- a/connectors/hermes-sprintable/test_connect_is_reconnect_signature.py
+++ b/connectors/hermes-sprintable/test_connect_is_reconnect_signature.py
@@ -1,0 +1,39 @@
+"""story #2564(S9) — SprintableAdapter.connect()가 BasePlatformAdapter의
+keyword-only `is_reconnect` 인자를 못 받아 매 연결(최초든 재연결이든)이
+TypeError로 죽던 라이브 인시던트(2026-08-12 13:20:04~16:28:46 KST, ~3h8m
+dev sprintable 채널 다운) 회귀 가드.
+
+이 결함은 `hermes plugins install` 정식 경로로 처음 실행한 격리 e2e에서만
+드러났다 — 라이브 사본은 이 시그니처 변경 이전 hermes-agent 버전에 맞춰
+수동 복사된 채 멈춰 있었을 뿐. mock/import-only 테스트로는 실제 프레임워크가
+호출부에서 넘기는 kwarg 불일치를 못 잡는다(connect()가 존재하는지만 보고
+실제 호출 시그니처 정합은 안 봄) — 그래서 inspect.signature로 바인딩
+자체를 고정한다.
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+
+import pytest
+
+_HERMES_AGENT = os.path.expanduser("~/.hermes/hermes-agent")
+if os.path.isdir(_HERMES_AGENT):
+    sys.path.insert(0, _HERMES_AGENT)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+adapter = pytest.importorskip(
+    "adapter", reason="hermes-agent gateway.* framework not available on this machine",
+)
+
+
+def test_connect_accepts_is_reconnect_kwarg():
+    sig = inspect.signature(adapter.SprintableAdapter.connect)
+    sig.bind(object(), is_reconnect=True)
+    sig.bind(object(), is_reconnect=False)
+
+
+def test_connect_accepts_no_args_for_cold_boot():
+    sig = inspect.signature(adapter.SprintableAdapter.connect)
+    sig.bind(object())


### PR DESCRIPTION
## 배경 — story #2564 (S9: hermes plugins install 정식화)

S9 AC2(격리 환경에서 `hermes plugins install`로 최초 설치→실 gateway round-trip 검증) 진행 중, 격리 profile에서 `hermes gateway run` 최초 실행 시 아래 에러로 sprintable 연결이 매번 죽는 걸 발견:

```
SprintableAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

`BasePlatformAdapter.connect()`(현재 hermes-agent)는 항상 keyword-only `is_reconnect`를 넘기는데, 이 vendored 어댑터의 override는 파라미터 없이 정의돼 있었다.

## 서사 3축

**① 3h8m 라이브 인시던트.** 이 결함은 가설이 아니라 실제로 라이브였다 — 로컬 `~/.hermes` 기본 프로필의 실 gateway(launchd 상시 supervise)가 이 신호를 이미 그대로 맞고 있었다. `gateway.log` 실측: 2026-08-12 13:20:04부터 40회 연속 재연결 실패(동일 TypeError), 16:26:16 마지막 실패 후 이번 fix를 라이브 사본(`~/.hermes/plugins/sprintable/adapter.py`)에 동기하고 `hermes gateway restart` 실행 → 16:28:46 `[Sprintable] Connected` → `stream open`. **dev sprintable 채널 다운 시간 ~3h8m.**

복구 전 영향 표면을 실측으로 닫음 — 이 gateway의 dev sprintable 홈채널(`SPRINTABLE_HOME_CHANNEL=794c9771-...`)은 이 PR 작업에 쓰인 대화(다른 conversation_id)와 무관한 채널이고, outage 구간 로그에 해당 채널로의 메시지 수신/dispatch 라인은 0건(connect/disconnect 스래싱만) — 그 시간대 이 채널로 유실된 인바운드 흔적은 없음. 복구는 `hermes gateway restart`(launchd 단일 프로세스)로 수행 — discord/sprintable_prod도 같이 수 초 순단했으나 둘 다 자기 코드는 무결함이라 즉시 재연결.

**② prod 사본 우연 생존.** `~/.hermes/plugins/sprintable_prod/adapter.py`는 이미 `is_reconnect` 파라미터가 있는 fixed 형태였다 — 별도로 고쳐진 게 아니라, 두 사본이 서로 다른 시점에 수동 복사돼 온 버전 비대칭 때문에 우연히 이번 결함을 피해 간 것. "우연히 살았다"와 "애초 이 결함과 무관했다"는 다른 문장이고, 이건 앞엣것 — 사본 동기화 자체가 원인 계열([[project_vendored_sdk_sync_debt]]와 동형: 여러 위치에 흩어진 사본은 매번 "이번엔 어느 게 최신인가" 사고를 만든다)이라 이번 건 하나를 고친다고 그 병이 나은 게 아님을 여기 남겨둔다.

**③ 격리 검증만이 드러낸 결함.** 이 신호가 라이브에서 3시간 넘게 살아 있었는데도 아무도 몰랐던 이유 — 라이브 gateway는 `is_reconnect` 시그니처 변경 이전 hermes-agent 버전에 맞춰 수동 복사된 채 한 번도 "cold reconnect 경로"를 다시 통과하지 않았다(연결이 끊기기 전까진 조용히 살아 있었으므로). S9 AC2가 처음부터 다시 `hermes plugins install`로 신선 설치→신선 gateway 기동을 강제했기 때문에만 이 프레임워크-호출부 시그니처 skew가 드러났다. "라이브가 지금 돌고 있다"는 아티팩트 해시 비교 같은 폴백 방식으로는 이 결함 클래스를 원천적으로 못 잡는다는 게 이번 S9의 핵심 근거.

## Fix

`connect(self, *, is_reconnect: bool = False) -> bool` — 파라미터는 안전하게 무시. 이 어댑터는 서버측 Last-Event-ID + backfill로 재연결을 이미 감당하고 클라이언트 버퍼 큐가 없어, `BasePlatformAdapter` 자체 docstring의 "no such queue may ignore the flag" 케이스에 정확히 해당한다.

## 테스트

`connectors/hermes-sprintable/test_connect_is_reconnect_signature.py` — `inspect.signature` 바인딩으로 호출 시그니처를 고정. 이 결함 클래스(프레임워크 호출부 kwarg 불일치)는 import-only/mock 테스트로 못 잡히므로 실제 bind 검증:

```
RED  (구 시그니처): TypeError: got an unexpected keyword argument 'is_reconnect'
GREEN (fix 後)     : 2 passed
```

CI는 이 파일을 자동 실행하지 않음(hermes-agent 프레임워크가 CI에 없어 `pytest.importorskip` — 기존 `test_attachment_injection.py`와 동일 컨벤션) — 로컬에서 `~/.hermes/hermes-agent/venv` + `--import-mode=importlib`로 RED→GREEN 직접 확인.

## 별개 트래킹 — 라이브 사본 동기

이 fix는 이미 라이브(`~/.hermes/plugins/sprintable/adapter.py`)에 동기 완료·incident 종결(PO 승인 하 운영 조치로 PR 게이트와 별도 진행). 이 PR은 develop에 소스를 남기는 것 — 배포 파이프라인([[project_deploy_pipeline_v2]]) 정상 진행.