### PR TITLE
docs(#2564): fix pairing-default-deny + SPRINTABLE_ALLOWED_USERS drift, document /sethome friction

### DIFF
--- a/connectors/hermes-sprintable-prod/README.md
+++ b/connectors/hermes-sprintable-prod/README.md
@@ -31,10 +31,14 @@ tail -f ~/.hermes/gateway.log                        # watch [sprintable_prod] d
 |-----|-----|---------|
 | `SPRINTABLE_PROD_AGENT_API_KEY` | ✅ | Prod agent API key (Bearer) |
 | `SPRINTABLE_PROD_API_URL` | — | Prod backend base URL (default: prod backend) |
-| `SPRINTABLE_PROD_ALLOWED_USERS` | — | Comma-sep member IDs allowed. Unset = all |
+| `SPRINTABLE_PROD_ALLOWED_USERS` | — | Comma-sep member IDs allowed |
 | `SPRINTABLE_PROD_ALLOW_ALL_USERS` | — | `1` = explicit allow-all |
 | `SPRINTABLE_PROD_HOME_CHANNEL` | — | Default conversation_id for cron/notify (`/sethome`) |
 | `SPRINTABLE_PROD_HOME_CHANNEL_THREAD_ID` | — | Thread id for the prod home channel |
+
+> Unset `SPRINTABLE_PROD_ALLOWED_USERS` is **not** "all senders allowed" — see
+> the dev README's `SPRINTABLE_ALLOWED_USERS` note below (same default-deny
+> `pairing` policy applies here with `sprintable_prod` in the log lines).
 
 Platform name: `sprintable_prod`. Cron delivery target: `deliver=sprintable_prod`.
 

--- a/connectors/hermes-sprintable/README.md
+++ b/connectors/hermes-sprintable/README.md
@@ -110,10 +110,24 @@ interchangeable.
 |-----|-----|---------|
 | `AGENT_API_KEY` | ✅ | Agent API key (Bearer), `sk_live_…` |
 | `SPRINTABLE_API_URL` | — | Backend base URL (default: dev backend) |
-| `SPRINTABLE_ALLOWED_USERS` | — | Comma-sep member IDs allowed to trigger. **Unset = all** |
-| `SPRINTABLE_ALLOW_ALL_USERS` | — | `1` = explicit allow-all (same as unset) |
+| `SPRINTABLE_ALLOWED_USERS` | — | Comma-sep member IDs allowed to trigger |
+| `SPRINTABLE_ALLOW_ALL_USERS` | — | `1` = explicit allow-all |
 | `SPRINTABLE_HOME_CHANNEL` | — | Default conversation_id for cron/notify. Usually set via `/sethome` |
 | `SPRINTABLE_HOME_CHANNEL_THREAD_ID` | — | Thread id for the home channel |
+
+> **`SPRINTABLE_ALLOWED_USERS` unset does NOT mean "all senders allowed"** —
+> this doc previously said so and that was wrong (S9 e2e caught it, #2564).
+> With no allowlist env var set, the gateway's default per-sender policy is
+> **pairing** (deny-until-approved), not open — see `_is_user_authorized` in
+> `hermes-agent/gateway/authz_mixin.py`. On a fresh install/profile, a sender
+> who has never gone through `hermes gateway pairing approve` gets rejected
+> with `Unauthorized user: <id> (<name>) on sprintable` in `gateway.log`, even
+> though `inbound seq=N` and `ack seq=N` both look fine — the message *arrives*
+> and *acks*, it just never opens an agent turn. Fix by either pairing the
+> sender, or setting `SPRINTABLE_ALLOW_ALL_USERS=1` (this plugin only) or
+> `GATEWAY_ALLOW_ALL_USERS=true` (all plugins on this gateway) — the latter is
+> the fastest unblock for a disposable/isolated test profile, but scope it to
+> that profile's env, never the live fleet gateway.
 
 ### Group 2 — prod gateway adapter (separate `hermes-sprintable-prod` plugin)
 
@@ -161,6 +175,14 @@ If you see `dial-out` but never `stream open`, the API key/URL is wrong. If you
 see neither, the plugin did not load — re-check step 3 (enabled by `name:`, not
 folder) and the import (`grep -i sprintable ~/.hermes/gateway.log` for a
 traceback).
+
+> **"No home channel is set… `/sethome`" reply on the first message.** If
+> `SPRINTABLE_HOME_CHANNEL` isn't set yet, the agent's first reply in a new
+> conversation may just be a `/sethome` prompt instead of an actual answer —
+> this is expected on a fresh install (there's no default home channel to
+> route cron/notify to), not a broken round-trip. Either run `/sethome` in
+> that conversation once, or set `SPRINTABLE_HOME_CHANNEL` up front (see the
+> env table above) if you already know the target conversation_id.
 
 ---
 


### PR DESCRIPTION
## story #2564 (S9) — AC3

격리 `hermes plugins install` e2e(AC2) 왕복 검증 中 실제로 겪은 두 가지 온보딩 마찰을 README에 반영.

**① `SPRINTABLE_ALLOWED_USERS` 문서 오류.** 기존 문서는 "Unset = all"이라 적혀 있었지만, `hermes-agent/gateway/authz_mixin.py`의 `_is_user_authorized`를 직접 대조하면 allowlist env가 아예 없을 때 기본 정책은 `pairing`(승인 전 deny)이지 open이 아니다. 이번 AC2 첫 트리거가 정확히 이 케이스로 막혔음 — inbound seq/ack는 정상인데 `Unauthorized user: <id> on sprintable`로 에이전트 턴 자체가 안 열림. 신규 설치자가 이 문서를 곧이곧대로 따르면 똑같이 막히고 원인을 오인하기 쉬움. `sprintable-prod`쪽 README에도 동일 오기 있어 같이 고침.

**② `/sethome` 프롬프트.** `SPRINTABLE_HOME_CHANNEL` 미설정 상태에서 받는 첫 응답이 실제 답변이 아니라 `/sethome` 안내인 것 — 신선 설치의 정상 동작이지만 "왕복이 깨졌나?"로 오인하기 쉬워 명시.

## 근거

두 항목 다 이번 세션 실제 격리 e2e 로그/코드 대조로 확인(가설 아님) — 상세는 #2564 진행 스레드 참조.

## 관련

- 별개 PR #2980 (`fix(#2564): SprintableAdapter.connect() is_reconnect kwarg`) — 같은 AC2 라운드에서 발견된 라이브 인시던트 fix, 이 PR과는 독립.