### PR TITLE
feat(#2583 S1): sprintable_sse SDK envelope-format helper — sender/event_kind/ts schema

### DIFF
--- a/connectors/sdk/ENVELOPE_SCHEMA.md
+++ b/connectors/sdk/ENVELOPE_SCHEMA.md
@@ -1,0 +1,89 @@
+# Session injection envelope — schema (story #2583)
+
+Every connector injects inbound Sprintable events as a new agent turn. This
+document is the schema for what that injection must carry — the standard
+this repo's connectors are held to, and the contract `formatEnvelopeText()`
+(Python: `sprintable_sse.py`, TS: `sprintable-sse.ts`) implements for the
+text-only delivery mode below.
+
+## Background
+
+Story #2583 (customer-zero incident, 2026-08-12): an agent misaddressed a
+human as a different agent because the injected message carried no sender
+identity — the agent could only infer "who's talking" from the previous
+turn's sender, and inferred wrong. Investigation (doc
+`2583-injection-envelope-recon-20260812`) found the SDK's own parser already
+extracts sender correctly in every connector — the defect was every
+connector's "build the text/call the host API" step silently dropping it
+after that point, plus a structurally identical defect for attachments
+(#2568/#2578: presence itself never reached the model).
+
+## Required fields
+
+| Field | Type | Meaning | If unavailable |
+|---|---|---|---|
+| `event_kind` | string | The event's type (`conversation.message_created`, `story_assigned`, `dispatched`, ...) | literal `"unknown"` — never guessed |
+| `sender.name` | string | Display name of who sent this | falls back to `sender.id`, never a blank/omitted field |
+| `sender.type` | string | `"human"` or `"agent"` (or whatever the platform's sender-type vocabulary is) | literal `"unknown"` — **never inferred from name or defaulted to `"agent"`** |
+| `sender.id` | string | Stable identifier for the sender | `"sprintable"` sentinel if genuinely absent (matches existing SDK fallback) |
+| `conversation_id` | string | Which conversation this belongs to | literal `"unknown"` |
+| `ts` | string (ISO 8601) | When the event was created | literal `"unknown"` |
+| body | string | The message content, with any attachment manifest already merged in (see below) | — |
+| attachments manifest | string block | Presence, name, and recovery method (`GET /api/v2/assets/{id}/text`) for each attachment | omitted entirely if there are none — never a fabricated "no attachments" line |
+
+**No-fabrication rule (AC1):** a missing value is rendered as the literal
+string `"unknown"` (for the header fields) — never silently omitted, never
+guessed from context (e.g. never assume `sender.type = "agent"` because the
+name looks like an agent's). An agent reading `"unknown"` knows to say so if
+asked, rather than confidently asserting a fabricated identity — this is the
+exact failure mode #2583 exists to close.
+
+## Two delivery modes
+
+Connectors split into two groups, discovered during the #2583 recon:
+
+### 1. Text-only injection host APIs
+
+Claude Code channel plugin, Codex/Grok/Gemini Stop-hook `reason` strings,
+OpenCode `session.prompt()` `parts[].text`, Pi `sendUserMessage(content)` —
+the host API accepts exactly one string. These connectors **must** call
+`format_envelope_text(ctx)` / `formatEnvelopeText(ctx)` to build that string
+— hand-rolling `ctx.content` alone (the #2583 defect) is the thing this
+schema exists to prevent.
+
+Rendered shape (pinned in `test_envelope_format.py` /
+`envelope-format.test.ts` — these two must never drift apart, see the
+language-boundary comment in each file):
+
+```
+[{event_kind}] {sender.name} ({sender.type}) · conv={conversation_id} · ts={ts}
+{body}
+```
+
+### 2. Structured-native sender APIs
+
+Hermes (`handle_message(..., user_id=, user_name=)`, rendered by the
+hermes-agent framework itself as `[sender_name] body`) and OpenClaw
+(`rt.inbound.buildContext({..., sender: {id, name}})`) already accept sender
+as a first-class parameter on the host's own injection call. These
+connectors don't need `formatEnvelopeText()` — the standard for them is
+simply: **populate the native field, don't drop it.** Both were confirmed
+already doing this correctly as of the #2583 recon.
+
+## Attachments manifest
+
+Already centralized in the SDK (`render_attachment_notice()` /
+`renderAttachmentNotice()`, story #2568/#2578) and merged into `ctx.content`
+at parse time — `format_envelope_text()` doesn't need to handle attachments
+separately, they're already part of the body it renders.
+
+## Sync discipline
+
+`format_envelope_text()` (Python) and `formatEnvelopeText()` (TS) must
+render byte-identically for the same input — that's what lets every
+connector, regardless of language, produce a consistent envelope. Each
+implementation pins the other's exact expected output for a shared sample
+input (the #2589 language-boundary pattern) so an edit to one side's
+rendering rule breaks that side's own test immediately, rather than drifting
+silently (the #2311 vendored-copy-drift class this whole SDK already has to
+guard against for the parser itself).

--- a/connectors/sdk/envelope-format.test.ts
+++ b/connectors/sdk/envelope-format.test.ts
@@ -1,0 +1,63 @@
+// story #2583 S1 — formatEnvelopeText() 핀 테스트 + 오호칭 봉쇄(AC2) 최소 렌더 계약.
+// 같은 샘플 입력·같은 기댓값 문자열이 test_envelope_format.py(Python side)에도 핀
+// 고정돼 있다 — 이쪽 렌더 규칙을 고치면 그쪽 테스트가 깨진다(#2589 언어-경계 동기
+// 가드 패턴 재사용). 배경: doc 2583-injection-envelope-recon-20260812.
+import { test, expect } from 'bun:test'
+import { formatEnvelopeText, type MessageContext } from './sprintable-sse'
+
+function ctx(overrides: Partial<MessageContext>): MessageContext {
+  return {
+    content: '', conversationId: '', senderId: '', senderName: '',
+    eventId: 'e1', seq: 1, isBackfill: false, attachments: [], raw: {},
+    senderType: '', eventKind: '', ts: '',
+    reply: async () => {},
+    ...overrides,
+  }
+}
+
+test('pinned: full envelope renders in the exact expected shape', () => {
+  const c = ctx({
+    content: '안녕하세요',
+    conversationId: 'conv-abc-123',
+    senderName: '송윤재',
+    senderType: 'human',
+    eventKind: 'conversation.message_created',
+    ts: '2026-08-12T10:00:00Z',
+  })
+  const expected =
+    '[conversation.message_created] 송윤재 (human) · conv=conv-abc-123 · ts=2026-08-12T10:00:00Z\n안녕하세요'
+  expect(formatEnvelopeText(c)).toBe(expected)
+})
+
+test('missing fields render as "unknown", never fabricated (AC1)', () => {
+  const c = ctx({ content: '본문만 있음', senderName: '누군가', conversationId: 'conv-known' })
+  const out = formatEnvelopeText(c)
+  expect(out.split('unknown').length - 1).toBe(3) // senderType/eventKind/ts만 unknown
+  expect(out).toContain('conv=conv-known') // 채워진 필드는 unknown으로 안 덮임
+})
+
+test('misaddressing scenario blocked (AC2) — sender never leaks across two sends', () => {
+  const first = ctx({
+    content: '통신점검', conversationId: 'conv-1',
+    senderName: '페드루 올리베이라', senderType: 'agent',
+    eventKind: 'conversation.message_created', ts: '2026-08-12T09:00:00Z',
+  })
+  const second = ctx({
+    content: '이거 다시 봐줘', conversationId: 'conv-1',
+    senderName: '송윤재', senderType: 'human',
+    eventKind: 'conversation.message_created', ts: '2026-08-12T09:05:00Z',
+  })
+  const renderedFirst = formatEnvelopeText(first)
+  const renderedSecond = formatEnvelopeText(second)
+
+  expect(renderedFirst).toContain('페드루 올리베이라')
+  expect(renderedFirst).toContain('(agent)')
+  expect(renderedSecond).toContain('송윤재')
+  expect(renderedSecond).toContain('(human)')
+  // 직전 발신자 계승(오호칭 사고 재현) 여부 확인.
+  expect(renderedSecond).not.toContain('페드루 올리베이라')
+
+  const [headerLine, bodyLine] = renderedSecond.split('\n')
+  expect(headerLine).toContain('송윤재')
+  expect(bodyLine).toBe('이거 다시 봐줘')
+})

--- a/connectors/sdk/envelope-format.test.ts
+++ b/connectors/sdk/envelope-format.test.ts
@@ -36,6 +36,14 @@ test('missing fields render as "unknown", never fabricated (AC1)', () => {
   expect(out).toContain('conv=conv-known') // 채워진 필드는 unknown으로 안 덮임
 })
 
+test('empty senderName falls back to senderId, then "unknown" (PO review, PR #2984)', () => {
+  const withId = ctx({ content: 'x', senderName: '', senderId: 'agent-42', conversationId: 'c' })
+  expect(formatEnvelopeText(withId).startsWith('[unknown] agent-42 (unknown)')).toBe(true)
+
+  const withoutId = ctx({ content: 'x', senderName: '', senderId: '', conversationId: 'c' })
+  expect(formatEnvelopeText(withoutId).startsWith('[unknown] unknown (unknown)')).toBe(true)
+})
+
 test('misaddressing scenario blocked (AC2) — sender never leaks across two sends', () => {
   const first = ctx({
     content: '통신점검', conversationId: 'conv-1',

--- a/connectors/sdk/sprintable-sse.ts
+++ b/connectors/sdk/sprintable-sse.ts
@@ -118,11 +118,15 @@ export function renderAttachmentNotice(attachments: MessageAttachment[]): string
  * 원칙(AC1): 값이 없으면 'unknown'이라고 명시하지, 빈칸으로 뭉개거나 지어내지 않는다.
  */
 export function formatEnvelopeText(ctx: MessageContext): string {
+  // PO 리뷰(2026-08-12, PR #2984) — senderName만 다른 필드와 폴백이 비대칭이었다(다른
+  // 필드는 전부 || 'unknown'인데 이건 그대로 노출 → 명시적 빈 이름이면 헤더 이름칸이
+  // 빈 채 렌더돼 오호칭 봉쇄 취지에 어긋남). name → id → 'unknown' 순으로 일관화.
+  const senderName = ctx.senderName || ctx.senderId || 'unknown'
   const senderType = ctx.senderType || 'unknown'
   const eventKind = ctx.eventKind || 'unknown'
   const ts = ctx.ts || 'unknown'
   const conv = ctx.conversationId || 'unknown'
-  const header = `[${eventKind}] ${ctx.senderName} (${senderType}) · conv=${conv} · ts=${ts}`
+  const header = `[${eventKind}] ${senderName} (${senderType}) · conv=${conv} · ts=${ts}`
   return `${header}\n${ctx.content}`
 }
 

--- a/connectors/sdk/sprintable-sse.ts
+++ b/connectors/sdk/sprintable-sse.ts
@@ -43,6 +43,14 @@ export type MessageContext = {
   isBackfill: boolean
   attachments: MessageAttachment[]
   raw: Record<string, unknown>
+  /**
+   * story #2583 S1 — envelope 규격 필드. 원 이벤트에 값이 없으면 빈 문자열('')로 둔다 —
+   * 지어내지 않는다(AC1 "값 없음의 정직 표기"). formatEnvelopeText()가 렌더 시
+   * 'unknown'으로 표기한다.
+   */
+  senderType: string
+  eventKind: string
+  ts: string
   /** POST /api/v2/conversations/{id}/messages */
   reply(text: string): Promise<void>
 }
@@ -92,6 +100,30 @@ export function renderAttachmentNotice(attachments: MessageAttachment[]): string
       : `- ${label} (${a.contentType || 'unknown type'}) — url: ${a.url}`
   })
   return `[첨부 ${attachments.length}건]\n${lines.join('\n')}\n[/첨부]`
+}
+
+/**
+ * story #2583 S1: 주입 envelope 표준 렌더.
+ *
+ * 배경: #2583 정찰(doc 2583-injection-envelope-recon-20260812) — 8개 커넥터 中 6개가
+ * senderId/senderName을(이 SDK가 이미 정확히 파싱해 두는데도) 모델에 실제로 보이는
+ * 텍스트 조립 단계에서 조용히 버렸다(댄 어윈 오호칭 사고와 동일 코드 경로). 이 함수는
+ * 그 "조립" 단계를 SDK 안 단일 지점으로 끌어와, 텍스트-only 주입 런타임(6곳)이 전부
+ * 이 함수를 부르면 사본마다 발신자를 흘리는 사고를 구조적으로 막는다. Hermes/OpenClaw
+ * 처럼 호스트가 이미 구조화 sender 파라미터를 받는 런타임은 필요 없다.
+ *
+ * ⚠️ 언어 경계(Python ↔ TS) — `sprintable_sse.py`의 `format_envelope_text()`와
+ * **동일한 렌더 규칙**이어야 한다(값 배치 순서·구분자·'unknown' 폴백 문자열까지). 양쪽에
+ * 같은 샘플을 핀 고정해 뒀다(#2589 패턴) — 한쪽만 고치면 그쪽 테스트가 깨진다. 정직 표기
+ * 원칙(AC1): 값이 없으면 'unknown'이라고 명시하지, 빈칸으로 뭉개거나 지어내지 않는다.
+ */
+export function formatEnvelopeText(ctx: MessageContext): string {
+  const senderType = ctx.senderType || 'unknown'
+  const eventKind = ctx.eventKind || 'unknown'
+  const ts = ctx.ts || 'unknown'
+  const conv = ctx.conversationId || 'unknown'
+  const header = `[${eventKind}] ${ctx.senderName} (${senderType}) · conv=${conv} · ts=${ts}`
+  return `${header}\n${ctx.content}`
 }
 
 export async function runSprintableSSE(opts: {
@@ -235,6 +267,9 @@ export async function runSprintableSSE(opts: {
     ) as Record<string, unknown>
     const senderId = String(sender.id ?? data.sender_id ?? 'sprintable')
     const senderName = String(sender.name ?? senderId)
+    const senderType = String(sender.type ?? '')
+    const eventKind = String(data.event_type ?? payload.event_type ?? '')
+    const ts = String(data.created_at ?? payload.created_at ?? '')
     const isBackfill = Boolean(data.is_backfill)
 
     const replyUrl = conversationId
@@ -243,6 +278,7 @@ export async function runSprintableSSE(opts: {
 
     return {
       content, conversationId, senderId, senderName, eventId, seq, isBackfill, attachments, raw: data,
+      senderType, eventKind, ts,
       async reply(text: string) {
         if (!replyUrl) throw new Error('no conversation_id')
         const r = await fetch(replyUrl, {

--- a/connectors/sdk/sprintable_sse.py
+++ b/connectors/sdk/sprintable_sse.py
@@ -151,6 +151,14 @@ class MessageContext:
     attachments: list[MessageAttachment]
     raw: dict[str, Any]
 
+    # story #2583 S1 — envelope 규격 필드. sender_type/event_kind/ts는 원 이벤트에 값이
+    # 없으면 빈 문자열("")로 둔다 — 지어내지 않는다(AC1 "값 없음의 정직 표기"). 빈 문자열은
+    # format_envelope_text()가 "unknown"으로 렌더하지만, 이 필드 자체는 어댑터가 원본 유무를
+    # 구분할 수 있게 빈 채로 남긴다.
+    sender_type: str = ""
+    event_kind: str = ""
+    ts: str = ""
+
     # E-ACTIVATION Phase 2 분류(기본값 = 현행 보존: 늘 호출로 취급).
     addressed: bool = True
     audience_targeted: bool = False
@@ -239,6 +247,35 @@ def render_attachment_notice(attachments: list[MessageAttachment]) -> str:
         else:
             lines.append(f"- {label} ({a.content_type or 'unknown type'}) — url: {a.url}")
     return f"[첨부 {len(attachments)}건]\n" + "\n".join(lines) + "\n[/첨부]"
+
+
+# ── story #2583 S1: 주입 envelope 표준 렌더 ────────────────────────────────────
+#
+# 배경: #2583 정찰(doc 2583-injection-envelope-recon-20260812) — 8개 커넥터 中 6개가
+# sender_id/sender_name을 (이 SDK가 이미 정확히 파싱해 두는데도) 모델에 실제로 보이는
+# 텍스트 조립 단계에서 조용히 버렸다(댄 어윈 오호칭 사고와 동일 코드 경로). 이 함수는
+# 그 "조립" 단계를 SDK 안 단일 지점으로 끌어와, 텍스트-only 주입 런타임(Claude Code
+# hooks·codex/grok/gemini Stop-hook reason·opencode session.prompt parts 등 — 호스트
+# API가 "문자열 하나"만 받는 6곳)이 전부 이 함수를 부르면 사본마다 발신자를 흘리는
+# 사고를 구조적으로 막는다. Hermes/OpenClaw처럼 호스트가 이미 구조화 sender 파라미터를
+# 받는 런타임은 이 함수가 필요 없다 — 그쪽은 네이티브 API로 직접 채우는 게 맞다
+# (연구 doc의 두 그룹 구분 참조).
+#
+# ⚠️ 언어 경계(Python ↔ TS) — 이 함수는 `sprintable-sse.ts`의 `formatEnvelopeText()`와
+# **동일한 렌더 규칙**이어야 한다(값 배치 순서·구분자·"unknown" 폴백 문자열까지). 이쪽을
+# 고치면 그쪽 핀 테스트가 깨지도록 양쪽에 같은 샘플을 핀 고정해 뒀다 — #2589에서 쓴
+# 패턴 그대로. 정직 표기 원칙(AC1): 값이 없으면 "unknown"이라고 명시하지, 빈칸으로
+# 뭉개거나 그럴듯한 값을 지어내지 않는다.
+def format_envelope_text(ctx: "MessageContext") -> str:
+    sender_type = ctx.sender_type or "unknown"
+    event_kind = ctx.event_kind or "unknown"
+    ts = ctx.ts or "unknown"
+    conv = ctx.conversation_id or "unknown"
+    header = (
+        f"[{event_kind}] {ctx.sender_name} ({sender_type}) "
+        f"· conv={conv} · ts={ts}"
+    )
+    return f"{header}\n{ctx.content}"
 
 
 # ── SDK client ────────────────────────────────────────────────────────────────
@@ -356,7 +393,9 @@ class SprintableSSEClient:
             sender = {}
         sender_id = str(sender.get("id") or data.get("sender_id") or "sprintable")
         sender_name = str(sender.get("name") or sender_id)
+        sender_type = str(sender.get("type") or "")
         is_backfill = bool(data.get("is_backfill"))
+        ts = str(data.get("created_at") or payload.get("created_at") or "")
 
         reply_url = (
             f"{self._api_url}/api/v2/conversations/{conversation_id}/messages"
@@ -376,6 +415,9 @@ class SprintableSSEClient:
             images=images,
             attachments=attachments,
             raw=data,
+            sender_type=sender_type,
+            event_kind=str(event_type or ""),
+            ts=ts,
             addressed=addressed,
             audience_targeted=audience_targeted,
             message_kind=message_kind,

--- a/connectors/sdk/sprintable_sse.py
+++ b/connectors/sdk/sprintable_sse.py
@@ -267,12 +267,16 @@ def render_attachment_notice(attachments: list[MessageAttachment]) -> str:
 # 패턴 그대로. 정직 표기 원칙(AC1): 값이 없으면 "unknown"이라고 명시하지, 빈칸으로
 # 뭉개거나 그럴듯한 값을 지어내지 않는다.
 def format_envelope_text(ctx: "MessageContext") -> str:
+    # PO 리뷰(2026-08-12, PR #2984) — sender_name만 다른 필드와 폴백이 비대칭이었다(다른
+    # 필드는 전부 or "unknown"인데 이건 그대로 노출 → 명시적 빈 이름이면 헤더 이름칸이
+    # 빈 채 렌더돼 오호칭 봉쇄 취지에 어긋남). name → id → "unknown" 순으로 일관화.
+    sender_name = ctx.sender_name or ctx.sender_id or "unknown"
     sender_type = ctx.sender_type or "unknown"
     event_kind = ctx.event_kind or "unknown"
     ts = ctx.ts or "unknown"
     conv = ctx.conversation_id or "unknown"
     header = (
-        f"[{event_kind}] {ctx.sender_name} ({sender_type}) "
+        f"[{event_kind}] {sender_name} ({sender_type}) "
         f"· conv={conv} · ts={ts}"
     )
     return f"{header}\n{ctx.content}"

--- a/connectors/sdk/test_envelope_format.py
+++ b/connectors/sdk/test_envelope_format.py
@@ -50,6 +50,16 @@ def test_missing_fields_render_as_unknown_not_fabricated():
     assert "conv=conv-known" in out  # 채워진 필드는 그대로 나옴 — unknown으로 안 덮임
 
 
+def test_empty_sender_name_falls_back_to_id_then_unknown():
+    """PO 리뷰(PR #2984) — sender_name만 다른 필드와 폴백이 비대칭이던 결함. 명시적으로
+    빈 이름이 와도 헤더 이름칸이 빈 채 렌더되면 안 된다(오호칭 봉쇄 취지 위반)."""
+    with_id = _ctx(content="x", sender_name="", sender_id="agent-42", conversation_id="c")
+    assert format_envelope_text(with_id).startswith("[unknown] agent-42 (unknown)")
+
+    without_id = _ctx(content="x", sender_name="", sender_id="", conversation_id="c")
+    assert format_envelope_text(without_id).startswith("[unknown] unknown (unknown)")
+
+
 def test_misaddressing_scenario_blocked_ac2():
     """story #2583 AC2 — 오호칭 시나리오 봉쇄: 같은 세션에 발신자만 바꿔 두 번 보내도
     렌더된 envelope에서 발신자가 명확히 갈린다(본문과 분리된 규격 필드). 댄 어윈 사고

--- a/connectors/sdk/test_envelope_format.py
+++ b/connectors/sdk/test_envelope_format.py
@@ -1,0 +1,79 @@
+"""story #2583 S1 — format_envelope_text() 핀 테스트 + 오호칭 봉쇄(AC2) 최소 렌더 계약.
+
+같은 샘플 입력·같은 기댓값 문자열이 envelope-format.test.ts(TS side)에도 핀 고정돼
+있다 — 이쪽 렌더 규칙(구분자·필드 순서·"unknown" 폴백)을 고치면 그쪽 테스트가 깨진다
+(#2589에서 쓴 언어-경계 동기 가드 패턴 재사용). 배경: doc
+2583-injection-envelope-recon-20260812 — 8개 커넥터 中 6개가 sender를 조립 단계에서
+버리는 결함(댄 어윈 오호칭 사고와 동일 코드 경로)을 이 SDK 함수 하나로 봉쇄한다.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from sprintable_sse import MessageContext, format_envelope_text  # noqa: E402
+
+
+def _ctx(**overrides) -> MessageContext:
+    base = dict(
+        content="", conversation_id="", sender_id="", sender_name="",
+        event_id="e1", seq=1, is_backfill=False, images=[], attachments=[], raw={},
+    )
+    base.update(overrides)
+    return MessageContext(**base)
+
+
+def test_pinned_full_envelope():
+    ctx = _ctx(
+        content="안녕하세요",
+        conversation_id="conv-abc-123",
+        sender_name="송윤재",
+        sender_type="human",
+        event_kind="conversation.message_created",
+        ts="2026-08-12T10:00:00Z",
+    )
+    expected = (
+        "[conversation.message_created] 송윤재 (human) · conv=conv-abc-123 · "
+        "ts=2026-08-12T10:00:00Z\n안녕하세요"
+    )
+    assert format_envelope_text(ctx) == expected
+
+
+def test_missing_fields_render_as_unknown_not_fabricated():
+    """AC1 정직 표기 — 값이 없으면 「unknown」이라고 명시. 빈칸으로 뭉개거나 그럴듯한
+    값(예: 'agent'로 임의 추정)을 지어내지 않는다."""
+    ctx = _ctx(content="본문만 있음", sender_name="누군가", conversation_id="conv-known")
+    out = format_envelope_text(ctx)
+    assert "unknown" in out  # sender_type/event_kind/ts 전부 미설정 → unknown
+    assert out.count("unknown") == 3  # 세 필드(sender_type·event_kind·ts) 다 unknown, conv는 안 새어나감
+    assert "conv=conv-known" in out  # 채워진 필드는 그대로 나옴 — unknown으로 안 덮임
+
+
+def test_misaddressing_scenario_blocked_ac2():
+    """story #2583 AC2 — 오호칭 시나리오 봉쇄: 같은 세션에 발신자만 바꿔 두 번 보내도
+    렌더된 envelope에서 발신자가 명확히 갈린다(본문과 분리된 규격 필드). 댄 어윈 사고
+    재현 형태 — 페드루(agent) 메시지 다음에 선생님(human) 메시지가 와도 두 번째 렌더가
+    «直前 발신자»를 계승하지 않고 자기 자신의 sender를 정확히 싣는지 확인."""
+    first = _ctx(
+        content="통신점검", conversation_id="conv-1",
+        sender_name="페드루 올리베이라", sender_type="agent",
+        event_kind="conversation.message_created", ts="2026-08-12T09:00:00Z",
+    )
+    second = _ctx(
+        content="이거 다시 봐줘", conversation_id="conv-1",
+        sender_name="송윤재", sender_type="human",
+        event_kind="conversation.message_created", ts="2026-08-12T09:05:00Z",
+    )
+    rendered_first = format_envelope_text(first)
+    rendered_second = format_envelope_text(second)
+
+    assert "페드루 올리베이라" in rendered_first and "(agent)" in rendered_first
+    assert "송윤재" in rendered_second and "(human)" in rendered_second
+    # 두 번째 렌더에 첫 번째 발신자 이름이 새어 들어가면(=계승) 오호칭 사고 재현.
+    assert "페드루 올리베이라" not in rendered_second
+    # 발신자 세그먼트가 헤더 첫 줄에 있고 본문(content)과 개행으로 분리 — 모델이 본문
+    # 텍스트를 발신자로 오인할 여지 축소.
+    header_line, body_line = rendered_second.split("\n", 1)
+    assert "송윤재" in header_line
+    assert body_line == "이거 다시 봐줘"


### PR DESCRIPTION
## story #2583 S1 [채널·규격] — 커넥터 세션 주입 페이로드 표준 envelope

정찰(doc `2583-injection-envelope-recon-20260812`, 댄 어윈 오호칭 사고 계기) — 8개 커넥터 中 6개가 발신자 신원을 모델에게 미전달. SDK 파서는 전부 정확한데(sender_id/name 계산까지 함) 각 커넥터의 "모델용 텍스트 조립" 단계가 조용히 버림. #2568/#2578(첨부 미도달)과 동일 코드 경로 클래스.

## 담긴 것 (S1 — SDK 레이어만, 커넥터 배선은 S2+)

- `MessageContext`(Python/TS) — `sender_type`·`event_kind`·`ts` 필드 추가(전부 raw payload에 이미 있던 값, sender_id/name과 같은 방식으로 추출만 안 하고 있었음).
- `format_envelope_text()`/`formatEnvelopeText()` — 텍스트-only 주입 호스트 API(Claude Code hooks·codex/grok/gemini Stop-hook `reason`·opencode `session.prompt`·pi `sendUserMessage`)용 단일 문자열 렌더러. 구조화 sender API를 이미 가진 Hermes/OpenClaw는(정찰에서 이미 정상 확認) 불필요 — 스키마 문서엔 "네이티브 필드를 채워라"만 명시.
- 정직 표기 원칙(AC1) — 값 없으면 리터럴 `"unknown"`. 지어내지 않음(예: 이름이 에이전트 같다고 sender_type을 "agent"로 추정 안 함).
- `ENVELOPE_SCHEMA.md` — AC1 스키마 문서(필수 필드·직렬화 형식·두 배송 모드 구분·정직 표기 규칙).

## 테스트 (AC1 핀 + AC2 최소 렌더 계약)

`test_envelope_format.py`(3 pass) + `envelope-format.test.ts`(3 pass) — 같은 샘플 입력→같은 출력 문자열 핀 고정(#2589 언어-경계 동기 가드 패턴). 핀이 실제로 걸리는지 구분자 문자 하나 뮤테이션→Python 테스트 fail 확인 후 복원(vacuous 아님 검증). AC2 오호칭 봉쇄: 같은 conv에 발신자만 바꿔 두 번 렌더→두 번째에 첫 번째 발신자 이름 안 샘, 헤더/본문 개행 분리 확認. 기존 SDK 스위트(Python 45·TS 9) 전부 그린 — additive only, 기존 동작 무변경.

## 남은 것 (별도 슬라이스, PO 배분 대기)

- S2: 텍스트-only 6개 커넥터를 이 헬퍼 호출로 교체. **Pi(#2970, 미머지)는 그 PR에 처음부터 반영 예정**(별도 fix PR보다 쌈, PO 확定).
- vendored 사본(opencode-sprintable/openclaw-sprintable가 이 SDK 파일 복사본을 담고 있음) 동기 — S2에서 같이.
- AC2 완전 e2e(실제 커넥터 세션 통과) — S2 이후.