### PR TITLE
feat(#2583 S2a): wire opencode-sprintable's injection through formatEnvelopeText()

### DIFF
--- a/connectors/opencode-sprintable/index.test.ts
+++ b/connectors/opencode-sprintable/index.test.ts
@@ -7,7 +7,7 @@
 import { test, expect } from "bun:test"
 import { plugin } from "./index.js"
 
-function startMockSseServer(dataLine: string) {
+function startMockSseServer(dataLines: string[]) {
   return Bun.serve({
     port: 0,
     fetch(req) {
@@ -15,7 +15,9 @@ function startMockSseServer(dataLine: string) {
         const stream = new ReadableStream({
           start(controller) {
             const enc = new TextEncoder()
-            controller.enqueue(enc.encode(`event: message\nid: 1\ndata: ${dataLine}\n\n`))
+            dataLines.forEach((dataLine, i) => {
+              controller.enqueue(enc.encode(`event: message\nid: ${i + 1}\ndata: ${dataLine}\n\n`))
+            })
           },
         })
         return new Response(stream, { headers: { "content-type": "text/event-stream" } })
@@ -45,11 +47,11 @@ function makeFakeClient() {
 }
 
 test("inbound SSE message injects via session.prompt(formatEnvelopeText(msg))", async () => {
-  const server = startMockSseServer(JSON.stringify({
+  const server = startMockSseServer([JSON.stringify({
     event_type: "dispatched", event_id: "evt-1",
     content: "hello from sprintable",
     payload: { conversation_id: "conv-test-1", sender: { id: "s1", name: "tester" } },
-  }))
+  })])
   process.env.SPRINTABLE_API_KEY = "test-key"
   process.env.SPRINTABLE_API_URL = `http://localhost:${server.port}`
 
@@ -65,6 +67,46 @@ test("inbound SSE message injects via session.prompt(formatEnvelopeText(msg))", 
   expect(text).toBe(
     "[dispatched] tester (unknown) · conv=conv-test-1 · ts=unknown\nhello from sprintable",
   )
+
+  server.stop(true)
+})
+
+test("story #2583 S3 — misaddressing blocked end-to-end: sender switch across two real SSE deliveries never leaks", async () => {
+  // Reproduces the Dan Irwin incident shape through the ACTUAL connector pipeline (real mock
+  // SSE server -> onMessage -> session.prompt), not just the pure formatEnvelopeText()
+  // function in isolation (already pinned in envelope-format.test.ts) — this is what "e2e"
+  // means for S3: prove the value the whole S2 body of work exists to deliver.
+  const server = startMockSseServer([
+    JSON.stringify({
+      event_type: "dispatched", event_id: "evt-a",
+      content: "통신점검", recipient_seq: 1,
+      payload: { conversation_id: "conv-shared", sender: { id: "p1", name: "페드루 올리베이라", type: "agent" } },
+    }),
+    JSON.stringify({
+      event_type: "dispatched", event_id: "evt-b",
+      content: "이거 다시 봐줘", recipient_seq: 2,
+      payload: { conversation_id: "conv-shared", sender: { id: "u1", name: "송윤재", type: "human" } },
+    }),
+  ])
+  process.env.SPRINTABLE_API_KEY = "test-key"
+  process.env.SPRINTABLE_API_URL = `http://localhost:${server.port}`
+
+  const client = makeFakeClient()
+  await plugin({ client } as never)
+
+  await new Promise((resolve) => setTimeout(resolve, 400))
+
+  expect(client.promptCalls).toHaveLength(2)
+  const first = client.promptCalls[0].body.parts[0].text
+  const second = client.promptCalls[1].body.parts[0].text
+
+  expect(first).toContain("페드루 올리베이라")
+  expect(first).toContain("(agent)")
+  expect(second).toContain("송윤재")
+  expect(second).toContain("(human)")
+  // 핵심 단정 — 두 번째 전달(사람이 보낸 메시지)의 렌더 텍스트에 «직전 발신자»(페드루)
+  // 이름이 조금이라도 새어 들어가면 오호칭 사고가 재현된 것.
+  expect(second).not.toContain("페드루")
 
   server.stop(true)
 })

--- a/connectors/opencode-sprintable/index.test.ts
+++ b/connectors/opencode-sprintable/index.test.ts
@@ -1,0 +1,70 @@
+// story #2583 — regression pin: opencode-sprintable's session.prompt() must carry the
+// standard envelope (sender/event_kind/ts), not bare msg.content. Before this fix, the
+// SDK parsed sender correctly but this connector's injection call dropped it — the same
+// assembly-stage defect class as pi-sprintable's #2574/#2583 fix (index.test.ts there).
+// Real mock SSE server (real sockets/HTTP, no real Sprintable backend) + a fake OpenCode
+// client (no real opencode binary) — same boundary methodology as the pi connector's test.
+import { test, expect } from "bun:test"
+import { plugin } from "./index.js"
+
+function startMockSseServer(dataLine: string) {
+  return Bun.serve({
+    port: 0,
+    fetch(req) {
+      if (req.url.includes("/api/v2/agent/stream")) {
+        const stream = new ReadableStream({
+          start(controller) {
+            const enc = new TextEncoder()
+            controller.enqueue(enc.encode(`event: message\nid: 1\ndata: ${dataLine}\n\n`))
+          },
+        })
+        return new Response(stream, { headers: { "content-type": "text/event-stream" } })
+      }
+      if (req.url.includes("/messages") && req.method === "POST") {
+        return new Response("{}", { status: 200 })
+      }
+      return new Response("{}", { headers: { "content-type": "application/json" } })
+    },
+  })
+}
+
+function makeFakeClient() {
+  const promptCalls: { path: { id: string }; body: { parts: Array<{ type: string; text: string }> } }[] = []
+  return {
+    promptCalls,
+    session: {
+      async create() {
+        return { data: { id: "session-1" } }
+      },
+      async prompt(args: { path: { id: string }; body: { parts: Array<{ type: string; text: string }> } }) {
+        promptCalls.push(args)
+        return { data: { parts: [{ type: "text", text: "MOCKED_REPLY" }] } }
+      },
+    },
+  }
+}
+
+test("inbound SSE message injects via session.prompt(formatEnvelopeText(msg))", async () => {
+  const server = startMockSseServer(JSON.stringify({
+    event_type: "dispatched", event_id: "evt-1",
+    content: "hello from sprintable",
+    payload: { conversation_id: "conv-test-1", sender: { id: "s1", name: "tester" } },
+  }))
+  process.env.SPRINTABLE_API_KEY = "test-key"
+  process.env.SPRINTABLE_API_URL = `http://localhost:${server.port}`
+
+  const client = makeFakeClient()
+  await plugin({ client } as never)
+
+  // give the SSE connection + onMessage callback a moment to actually run
+  await new Promise((resolve) => setTimeout(resolve, 300))
+
+  expect(client.promptCalls).toHaveLength(1)
+  const text = client.promptCalls[0].body.parts[0].text
+  // story #2583 — sender ("tester") must reach the model, not just the bare content.
+  expect(text).toBe(
+    "[dispatched] tester (unknown) · conv=conv-test-1 · ts=unknown\nhello from sprintable",
+  )
+
+  server.stop(true)
+})

--- a/connectors/opencode-sprintable/index.ts
+++ b/connectors/opencode-sprintable/index.ts
@@ -6,14 +6,12 @@
  */
 
 import type { Plugin } from "@opencode-ai/plugin"
-import { runSprintableSSE } from "./sprintable-sse.js"
+import { runSprintableSSE, formatEnvelopeText } from "./sprintable-sse.js"
 
 // #2568-style npm-publish fix: this file used to import ../sdk/sprintable-sse.js — a path
 // that only resolves inside the monorepo. Published standalone, node_modules/opencode-sprintable
 // has no sibling ../sdk directory, so that import would 404 at runtime for every real install.
 // The SDK is now vendored into this package (sprintable-sse.ts, same directory) instead.
-const API_URL = (process.env.SPRINTABLE_API_URL ?? "https://app.sprintable.ai").replace(/\/$/, "")
-const API_KEY = (process.env.SPRINTABLE_API_KEY ?? process.env.AGENT_API_KEY ?? "").trim()
 
 /**
  * Sprintable Gateway OpenCode plugin.
@@ -24,6 +22,15 @@ const API_KEY = (process.env.SPRINTABLE_API_KEY ?? process.env.AGENT_API_KEY ?? 
  * 3. session.prompt 응답 → POST /api/v2/conversations/{id}/messages (ack는 SDK 처리)
  */
 export const plugin: Plugin = async ({ client }) => {
+  // story #2583 (found while writing this story's regression test) — API_URL/API_KEY used
+  // to be module-level consts, frozen at import time. Real deployments happen to survive
+  // this (env vars are set before the process starts, so the freeze already sees the right
+  // value) — but it's a latent trap the sibling pi-sprintable connector's own comment
+  // explicitly calls out and avoids ("a module-level const would freeze at first import
+  // rather than reflecting the environment at actual extension-load time"). Resolved fresh
+  // per plugin-init call instead, matching that pattern.
+  const API_URL = (process.env.SPRINTABLE_API_URL ?? "https://app.sprintable.ai").replace(/\/$/, "")
+  const API_KEY = (process.env.SPRINTABLE_API_KEY ?? process.env.AGENT_API_KEY ?? "").trim()
   if (!API_KEY) {
     console.error("[sprintable] SPRINTABLE_API_KEY or AGENT_API_KEY not set — plugin disabled")
     return {}
@@ -58,13 +65,15 @@ export const plugin: Plugin = async ({ client }) => {
         sessionMap.set(conversationId, sessionId)
       }
 
-      // Turn 주입 — session.prompt는 AI 응답 완성까지 대기
+      // Turn 주입 — session.prompt는 AI 응답 완성까지 대기.
+      // story #2583 — 발신자/이벤트종류/ts를 표준 envelope로 렌더해 실음(msg.content만
+      // 보내면 모델이 발신자를 모른 채 진행 — 댄 어윈 오호칭 사고와 동일 코드 경로였다).
       let responseText = ""
       try {
         const promptResp = await client.session.prompt({
           path: { id: sessionId },
           body: {
-            parts: [{ type: "text", text: msg.content }],
+            parts: [{ type: "text", text: formatEnvelopeText(msg) }],
           },
         })
         // 응답에서 텍스트 추출

--- a/connectors/opencode-sprintable/sprintable-sse.ts
+++ b/connectors/opencode-sprintable/sprintable-sse.ts
@@ -43,6 +43,14 @@ export type MessageContext = {
   isBackfill: boolean
   attachments: MessageAttachment[]
   raw: Record<string, unknown>
+  /**
+   * story #2583 S1 — envelope 규격 필드. 원 이벤트에 값이 없으면 빈 문자열('')로 둔다 —
+   * 지어내지 않는다(AC1 "값 없음의 정직 표기"). formatEnvelopeText()가 렌더 시
+   * 'unknown'으로 표기한다.
+   */
+  senderType: string
+  eventKind: string
+  ts: string
   /** POST /api/v2/conversations/{id}/messages */
   reply(text: string): Promise<void>
 }
@@ -92,6 +100,34 @@ export function renderAttachmentNotice(attachments: MessageAttachment[]): string
       : `- ${label} (${a.contentType || 'unknown type'}) — url: ${a.url}`
   })
   return `[첨부 ${attachments.length}건]\n${lines.join('\n')}\n[/첨부]`
+}
+
+/**
+ * story #2583 S1: 주입 envelope 표준 렌더.
+ *
+ * 배경: #2583 정찰(doc 2583-injection-envelope-recon-20260812) — 8개 커넥터 中 6개가
+ * senderId/senderName을(이 SDK가 이미 정확히 파싱해 두는데도) 모델에 실제로 보이는
+ * 텍스트 조립 단계에서 조용히 버렸다(댄 어윈 오호칭 사고와 동일 코드 경로). 이 함수는
+ * 그 "조립" 단계를 SDK 안 단일 지점으로 끌어와, 텍스트-only 주입 런타임(6곳)이 전부
+ * 이 함수를 부르면 사본마다 발신자를 흘리는 사고를 구조적으로 막는다. Hermes/OpenClaw
+ * 처럼 호스트가 이미 구조화 sender 파라미터를 받는 런타임은 필요 없다.
+ *
+ * ⚠️ 언어 경계(Python ↔ TS) — `sprintable_sse.py`의 `format_envelope_text()`와
+ * **동일한 렌더 규칙**이어야 한다(값 배치 순서·구분자·'unknown' 폴백 문자열까지). 양쪽에
+ * 같은 샘플을 핀 고정해 뒀다(#2589 패턴) — 한쪽만 고치면 그쪽 테스트가 깨진다. 정직 표기
+ * 원칙(AC1): 값이 없으면 'unknown'이라고 명시하지, 빈칸으로 뭉개거나 지어내지 않는다.
+ */
+export function formatEnvelopeText(ctx: MessageContext): string {
+  // PO 리뷰(2026-08-12, PR #2984) — senderName만 다른 필드와 폴백이 비대칭이었다(다른
+  // 필드는 전부 || 'unknown'인데 이건 그대로 노출 → 명시적 빈 이름이면 헤더 이름칸이
+  // 빈 채 렌더돼 오호칭 봉쇄 취지에 어긋남). name → id → 'unknown' 순으로 일관화.
+  const senderName = ctx.senderName || ctx.senderId || 'unknown'
+  const senderType = ctx.senderType || 'unknown'
+  const eventKind = ctx.eventKind || 'unknown'
+  const ts = ctx.ts || 'unknown'
+  const conv = ctx.conversationId || 'unknown'
+  const header = `[${eventKind}] ${senderName} (${senderType}) · conv=${conv} · ts=${ts}`
+  return `${header}\n${ctx.content}`
 }
 
 export async function runSprintableSSE(opts: {
@@ -235,6 +271,9 @@ export async function runSprintableSSE(opts: {
     ) as Record<string, unknown>
     const senderId = String(sender.id ?? data.sender_id ?? 'sprintable')
     const senderName = String(sender.name ?? senderId)
+    const senderType = String(sender.type ?? '')
+    const eventKind = String(data.event_type ?? payload.event_type ?? '')
+    const ts = String(data.created_at ?? payload.created_at ?? '')
     const isBackfill = Boolean(data.is_backfill)
 
     const replyUrl = conversationId
@@ -243,6 +282,7 @@ export async function runSprintableSSE(opts: {
 
     return {
       content, conversationId, senderId, senderName, eventId, seq, isBackfill, attachments, raw: data,
+      senderType, eventKind, ts,
       async reply(text: string) {
         if (!replyUrl) throw new Error('no conversation_id')
         const r = await fetch(replyUrl, {

--- a/connectors/sdk/ENVELOPE_SCHEMA.md
+++ b/connectors/sdk/ENVELOPE_SCHEMA.md
@@ -87,3 +87,29 @@ input (the #2589 language-boundary pattern) so an edit to one side's
 rendering rule breaks that side's own test immediately, rather than drifting
 silently (the #2311 vendored-copy-drift class this whole SDK already has to
 guard against for the parser itself).
+
+### Cross-repo port list — where to look if the render rule ever changes
+
+This SDK (`connectors/sdk/sprintable_sse.py` / `sprintable-sse.ts`, this
+repo) is the canonical implementation. Every other copy below is a **hand
+port or a manually-synced vendored copy** — none of them import this file
+directly (either a different repo entirely, or a standalone npm/pip package
+that can't have a `../sdk` relative import survive publishing). There is no
+automated cross-repo guard tying them together; this list *is* the guard.
+Changing the render shape (field order, separators, the `"unknown"`
+fallback string) means updating **all** of these, not just this file:
+
+| Location | Repo | Kind |
+|---|---|---|
+| `connectors/sdk/sprintable_sse.py` / `sprintable-sse.ts` | `moonklabs/sprintable` | canonical |
+| `connectors/opencode-sprintable/sprintable-sse.ts` | `moonklabs/sprintable` | vendored copy (npm-publish standalone) |
+| `connectors/pi-sprintable/sprintable-sse.ts` | `moonklabs/sprintable` | vendored copy (npm-publish standalone) |
+| `plugins/sprintable/envelope.ts` | `moonklabs/sprintable-agent-plugins` | hand port (Claude Code channel plugin — no SDK dependency at all) |
+| `plugins/sprintable-codex/scripts/envelope.py` | `moonklabs/sprintable-agent-plugins` | hand port |
+| `plugins/sprintable-grok/scripts/envelope.py` | `moonklabs/sprintable-agent-plugins` | hand port, itself a manually-synced copy of the codex one (same repo, per-folder packaging boundary — see that file's own comment) |
+| `scripts/envelope.py` | `moonklabs/sprintable-gemini` | hand port |
+
+Hermes and OpenClaw are **not** in this list — they use their host runtime's
+native structured sender API instead of this text-render contract (see
+"Structured-native sender APIs" above), so a render-shape change here
+doesn't touch them.

--- a/connectors/sdk/ENVELOPE_SCHEMA.md
+++ b/connectors/sdk/ENVELOPE_SCHEMA.md
@@ -62,13 +62,58 @@ language-boundary comment in each file):
 
 ### 2. Structured-native sender APIs
 
-Hermes (`handle_message(..., user_id=, user_name=)`, rendered by the
-hermes-agent framework itself as `[sender_name] body`) and OpenClaw
-(`rt.inbound.buildContext({..., sender: {id, name}})`) already accept sender
-as a first-class parameter on the host's own injection call. These
-connectors don't need `formatEnvelopeText()` — the standard for them is
-simply: **populate the native field, don't drop it.** Both were confirmed
-already doing this correctly as of the #2583 recon.
+Hermes and OpenClaw's host runtimes accept sender as a first-class,
+**typed** parameter on their own injection call — verified against the
+actual installed/published type definitions, not assumed. These connectors
+don't need `formatEnvelopeText()` — the standard for them is: **populate the
+native field, don't drop it.** Both confirmed already doing this correctly
+(S4, story #2583).
+
+**Hermes** (`connectors/hermes-sprintable/adapter.py`) — the contract is
+three calls deep, confirmed by reading `~/.hermes/hermes-agent` directly
+(gateway/platforms/base.py, gateway/session.py):
+
+```python
+source = self.build_source(         # BasePlatformAdapter.build_source(...)
+    chat_id=conversation_id, chat_type="thread", thread_id=conversation_id,
+    user_id=sender_id, user_name=sender_name,
+) -> SessionSource
+message_event = MessageEvent(text=content, source=source, ...)
+await self.handle_message(message_event)
+```
+
+The framework renders `source.user_name` into the turn context verbatim —
+`gateway/session.py`: `f"**User:** {_format_untrusted_prompt_value(source.user_name)}"`
+for a single sender, or `"messages are prefixed with [sender name]"` for a
+multi-user thread (the Sprintable case — every adapter call uses
+`chat_type="thread"`). **Gap identified, not fixed here (S4 is docs +
+verification, not new code):** `build_source` also accepts `is_bot: bool`,
+but the adapter's call site doesn't pass it — Hermes has no rendered
+human/agent distinction today even though the field exists. Worth a future
+slice; out of scope for #2583 S4.
+
+**OpenClaw** (`connectors/openclaw-sprintable/src/channel.ts`) — confirmed
+against the actual published `openclaw` npm package's `.d.ts`
+(`BuildChannelInboundEventContextParams`, this repo's node_modules were
+never meant to ship this connector's own tests against a fake type):
+
+```ts
+type SenderFacts = { id?: string; name?: string; username?: string; tag?: string;
+                      roles?: string[]; isBot?: boolean; isSelf?: boolean; displayLabel?: string }
+type BuildChannelInboundEventContextParams = { ...; sender: SenderFacts; ... }  // required, not optional
+
+rt.inbound.buildContext({
+  ..., sender: { id: msg.senderId, name: msg.senderName }, ...
+})
+```
+
+`sender` is a **required** field on the params type (not optional) — this
+connector correctly populates it. **Same gap as Hermes:** `SenderFacts` has
+no `type: "human"|"agent"` field at all (only `isBot`, which the connector
+doesn't populate), so OpenClaw has no native human/agent distinction to
+surface either. Both frameworks converge on the same structural limitation
+independently — worth flagging together in any future slice, not fixed
+here.
 
 ## Attachments manifest
 


### PR DESCRIPTION
## story #2583 S2a — OpenCode leg

정찰(doc `2583-injection-envelope-recon-20260812`)이 특定한 조립 단계 결함 fix — `session.prompt()`가 `msg.content`만 보내던 것을 `formatEnvelopeText(msg)`로 교체(#2984/S1 헬퍼, develop에 이미 머지됨).

## 담긴 것

- `sprintable-sse.ts`(vendored SDK 사본, 이 패키지는 standalone 배포라 `../sdk` 상대경로 못 씀) — 정본과 재동기(S1 반영).
- `index.ts` — `formatEnvelopeText` import+주입 지점 교체.
- **부수 발견·수정**: `API_URL`/`API_KEY`가 모듈 레벨 const로 import 시점에 고정돼 있었음(이 스토리의 회귀 테스트 작성 中 발견 — 이 커넥터엔 기존 테스트가 아예 없었음). 실 배포는 프로세스 시작 前에 env가 이미 설정돼 있어 우연히 무사하지만, sibling pi-sprintable 커넥터가 이미 피해 가고 있는 정확히 그 함정(주석 인용: "a module-level const would freeze at first import rather than reflecting the environment at actual extension-load time") — 같은 패턴(plugin-init 호출마다 fresh 계산)으로 맞춤.
- `index.test.ts`(신설 — 기존 테스트 0개였음) — mock SSE 서버(실 소켓/HTTP)+fake OpenCode client, pi-sprintable 테스트와 동형 경계.

## 검증

RED→GREEN: `formatEnvelopeText(msg)`를 일시적으로 `msg.content`로 되돌려 테스트가 정확한 diff(발신자 줄 누락)로 실패하는 것 확認 후 복원.