### PR TITLE
[P0][SID:2092] 조직 삭제 — 영향도 조회 실패 시 진행 차단 (FE, 서버 방어선은 #2898 기배포)

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/org-delete-gate.test.ts
+++ b/apps/web/src/app/(authenticated)/settings/org-delete-gate.test.ts
@@ -1,0 +1,59 @@
+// story #2092(P0, 유나 실사용 발견) — 조직 삭제 "지금 진행해도 되는가" 판정 회귀가드.
+//
+// 원 결함: 영향도 조회가 실패해도(orgImpact===null) has_active_subscription 기본값이
+// false라 삭제 버튼이 그대로 활성화됐다 — 화면이 "계속 진행해도 됩니다"를 말 그대로
+// 실천했다. 서버(#2898, 이미 배포)가 최종 방어선이지만, 이 테스트는 화면 쪽 "안내"(AC2/AC3)
+// 축이 실제로 막는지를 고정한다.
+import { describe, it, expect } from 'vitest';
+import { canSubmitOrgDelete } from './org-delete-gate';
+
+const base = {
+  orgName: 'Acme Corp',
+  confirmName: 'Acme Corp',
+  deletingOrg: false,
+  orgImpactLoading: false,
+  hasActiveSubscription: false,
+  orgImpactFailed: false,
+  confirmWithoutImpact: false,
+};
+
+describe('canSubmitOrgDelete', () => {
+  it('정상 경로 — 영향도 조회 성공+이름 일치면 허용된다(AC4)', () => {
+    expect(canSubmitOrgDelete(base)).toBe(true);
+  });
+
+  it('이름 미일치면 막힌다', () => {
+    expect(canSubmitOrgDelete({ ...base, confirmName: 'wrong' })).toBe(false);
+  });
+
+  it('로딩/삭제-진행중이면 막힌다', () => {
+    expect(canSubmitOrgDelete({ ...base, deletingOrg: true })).toBe(false);
+    expect(canSubmitOrgDelete({ ...base, orgImpactLoading: true })).toBe(false);
+  });
+
+  it('활성 구독이 있으면 막힌다', () => {
+    expect(canSubmitOrgDelete({ ...base, hasActiveSubscription: true })).toBe(false);
+  });
+
+  it('원결함 회귀가드 — 영향도 조회 실패 + 이름 일치만으로는 «절대» 통과 못 한다(AC2)', () => {
+    // 이 케이스가 과거엔 true였다(has_active_subscription 기본값 false로 새는 경로).
+    expect(canSubmitOrgDelete({ ...base, orgImpactFailed: true })).toBe(false);
+  });
+
+  it('탈출구 — 조회 실패라도 명시 인정(체크박스)하면 통과한다(AC3)', () => {
+    expect(canSubmitOrgDelete({ ...base, orgImpactFailed: true, confirmWithoutImpact: true })).toBe(true);
+  });
+
+  it('탈출구도 이름 불일치면 여전히 막힌다(체크박스가 이름확認을 우회하지 않음)', () => {
+    expect(canSubmitOrgDelete({
+      ...base, confirmName: 'wrong', orgImpactFailed: true, confirmWithoutImpact: true,
+    })).toBe(false);
+  });
+
+  it('조회가 아직 성공한 적 없어도 실패 플래그가 없으면(초기 로딩 前 상태) 이름만으로 열리지 않음 — orgImpactLoading이 커버', () => {
+    // orgImpactLoading=true인 동안은 위 케이스에서 이미 커버(로딩 중 막힘). 여기는
+    // "실패도 로딩도 아닌데 아직 값이 없는" 프레이밍 자체가 呼출부에서 안 나오게(항상 셋 중
+    // 하나) 설계됐음을 문서화 — orgImpact는 loading→(성공|실패) 상태기계.
+    expect(canSubmitOrgDelete({ ...base, hasActiveSubscription: false, orgImpactFailed: false })).toBe(true);
+  });
+});

--- a/apps/web/src/app/(authenticated)/settings/org-delete-gate.test.ts
+++ b/apps/web/src/app/(authenticated)/settings/org-delete-gate.test.ts
@@ -44,7 +44,7 @@ describe('canSubmitOrgDelete', () => {
     expect(canSubmitOrgDelete({ ...base, orgImpactFailed: true, confirmWithoutImpact: true })).toBe(true);
   });
 
-  it('탈출구도 이름 불일치면 여전히 막힌다(체크박스가 이름확認을 우회하지 않음)', () => {
+  it('탈출구도 이름 불일치면 여전히 막힌다(체크박스가 이름확인을 우회하지 않음)', () => {
     expect(canSubmitOrgDelete({
       ...base, confirmName: 'wrong', orgImpactFailed: true, confirmWithoutImpact: true,
     })).toBe(false);

--- a/apps/web/src/app/(authenticated)/settings/org-delete-gate.ts
+++ b/apps/web/src/app/(authenticated)/settings/org-delete-gate.ts
@@ -1,0 +1,23 @@
+// story #2092(P0) — 조직 삭제 다이얼로그의 "지금 진행해도 되는가" 판정을 순수함수로 뽑는다.
+// 이전엔 이 판정이 JSX의 disabled= 표현식 안에 직접 있어 테스트 대상이 될 수 없었다
+// (전체 페이지를 렌더해야만 검증 가능·컨텍스트 의존 과다) — 회귀가 나도 잡을 방법이
+// 없었다는 뜻. page.tsx가 아닌 별도 파일인 이유: Next.js Page 모듈은 default export 외의
+// named export를 "유효한 Page export field"로 인정하지 않아 빌드 타입체크가 거부한다.
+//
+// 서버(#2898)가 최종 방어선이라는 점은 그대로다 — 이 함수는 "안내"쪽(AC2/AC3)만 담당한다.
+export function canSubmitOrgDelete(input: {
+  orgName: string;
+  confirmName: string;
+  deletingOrg: boolean;
+  orgImpactLoading: boolean;
+  hasActiveSubscription: boolean;
+  orgImpactFailed: boolean;
+  confirmWithoutImpact: boolean;
+}): boolean {
+  if (input.confirmName !== input.orgName) return false;
+  if (input.deletingOrg || input.orgImpactLoading) return false;
+  if (input.hasActiveSubscription) return false;
+  // AC2/AC3 — 영향도 조회가 실패한 채면 사용자가 명시로 인정(체크박스)하기 전엔 막는다.
+  if (input.orgImpactFailed && !input.confirmWithoutImpact) return false;
+  return true;
+}

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -28,6 +28,7 @@ import { GateLevelMatrix } from '@/components/settings/gate-level-matrix';
 import { TwoFactorSection } from '@/components/settings/two-factor-section';
 import { SetPasswordSection } from '@/components/settings/set-password-section';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { canSubmitOrgDelete } from './org-delete-gate';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
@@ -145,6 +146,15 @@ export default function SettingsPage() {
   const [deletingOrg, setDeletingOrg] = useState(false);
   const [orgImpact, setOrgImpact] = useState<{ project_count: number; member_count: number; has_active_subscription: boolean } | null>(null);
   const [orgImpactLoading, setOrgImpactLoading] = useState(false);
+  // story #2092(P0) — orgImpact===null 하나로는 "아직 안 물었다"와 "물었는데 실패했다"를
+  // 구분 못 해, 조회 실패가 곧 "영향도 없음"인 것처럼 버튼을 열어줬다(has_active_subscription
+  // 기본값 false가 실패 케이스에도 그대로 적용). 이 플래그로 실패 상태를 명시적으로 갈라
+  // 삭제 진행을 1차로 막는다(AC2) — 서버 거부(#2898, 이미 배포됨)가 최종 방어선이지만
+  // 화면도 "안내이지 방어가 아니다"에서 "안내"쪽은 최소한 정확해야 한다.
+  const [orgImpactFailed, setOrgImpactFailed] = useState(false);
+  // AC3 탈출구 — 조회 실패가 계속될 때만 의미를 갖는 명시적 인정 체크. 재조회가 성공하면
+  // (fetchOrgImpact 재호출) 무의미해지므로 그때마다 초기화한다.
+  const [confirmWithoutImpact, setConfirmWithoutImpact] = useState(false);
   const [projectMemberships] = useState<Array<{ projectId: string; projectName: string }>>([]);
   const [settings, setSettings] = useState<NotificationSetting[]>([]);
   // story #2272 — 알림 설정(형제: 이벤트타입별 채널토글, 위 settings)과 같은 자리에 선다.
@@ -184,31 +194,67 @@ export default function SettingsPage() {
   const ctxRole = orgMemberships.find(o => o.orgId === (orgId ?? ctxOrgId))?.role;
   const currentOrgRole = (orgInfo?.role ?? ctxRole ?? 'member') as string;
 
-  const handleOpenDeleteOrg = async () => {
+  // story #2092(P0) — 삭제 다이얼로그를 열 때·재시도할 때 공통으로 쓰는 영향도 조회.
+  // 실패(네트워크 에러든 non-2xx든)를 orgImpactFailed로 명시 구분 — orgImpact===null은
+  // 더 이상 "실패"의 대리 신호가 아니다(위 상태 선언 주석 참고).
+  const fetchOrgImpact = async () => {
     if (!orgInfo) return;
-    setShowDeleteOrgConfirm(true);
-    setDeleteOrgConfirmName('');
-    setOrgImpact(null);
     setOrgImpactLoading(true);
+    setOrgImpactFailed(false);
+    setConfirmWithoutImpact(false);
     try {
       const res = await fetch(`/api/organizations/${orgInfo.id}/impact`).catch(() => null);
-      if (res?.ok) {
-        const json = await res.json() as { data?: { project_count: number; member_count: number; has_active_subscription: boolean } };
-        setOrgImpact(json.data ?? null);
+      if (!res?.ok) {
+        setOrgImpact(null);
+        setOrgImpactFailed(true);
+        return;
       }
+      const json = await res.json() as { data?: { project_count: number; member_count: number; has_active_subscription: boolean } };
+      if (!json.data) {
+        setOrgImpact(null);
+        setOrgImpactFailed(true);
+        return;
+      }
+      setOrgImpact(json.data);
     } finally {
       setOrgImpactLoading(false);
     }
   };
 
+  const handleOpenDeleteOrg = async () => {
+    if (!orgInfo) return;
+    setShowDeleteOrgConfirm(true);
+    setDeleteOrgConfirmName('');
+    setOrgImpact(null);
+    setOrgImpactFailed(false);
+    setConfirmWithoutImpact(false);
+    await fetchOrgImpact();
+  };
+
   const handleDeleteOrg = async () => {
-    if (!orgInfo || deleteOrgConfirmName !== orgInfo.name || deletingOrg) return;
+    if (!orgInfo) return;
+    if (!canSubmitOrgDelete({
+      orgName: orgInfo.name,
+      confirmName: deleteOrgConfirmName,
+      deletingOrg,
+      orgImpactLoading,
+      hasActiveSubscription: orgImpact?.has_active_subscription ?? false,
+      orgImpactFailed,
+      confirmWithoutImpact,
+    })) return;
     setDeletingOrg(true);
     try {
       const res = await fetch(`/api/organizations/${orgInfo.id}`, {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ confirmation: orgInfo.name }),
+        // story #2092 AC3 — 영향도 조회가 실패한 채로 사용자가 명시 인정했을 때만 true.
+        // 서버(#2898)가 이 신호와 무관하게 자체 재조회로 최종 판정한다 — 이 필드는
+        // "재조회도 실패하면 그때 이 인정을 참고하라"는 사용자 신호일 뿐, 화면이 서버를
+        // 대신 판정하지 않는다.
+        body: JSON.stringify({
+          confirmation: orgInfo.name,
+          confirm_without_impact: orgImpactFailed && confirmWithoutImpact,
+        }),
       });
       if (res.ok) {
         window.location.href = '/onboarding';
@@ -1403,7 +1449,35 @@ export default function SettingsPage() {
                 </ul>
               </div>
             ) : (
-              <p className="text-sm text-muted-foreground">영향도 정보를 불러올 수 없습니다. 계속 진행해도 됩니다.</p>
+              // story #2092(P0) — 예전엔 "계속 진행해도 됩니다"로 되돌릴 수 없는 삭제를
+              // 권했다(동작 결함, 문구만으로 안 닫힘). 이제 1차로 진행을 막고(버튼 disabled,
+              // 아래), 재시도 또는 명시 인정(탈출구)만 남긴다. 서버(#2898)가 최종 방어선.
+              <Alert variant="warning">
+                <AlertDescription className="space-y-3">
+                  <p>영향 범위를 확認할 수 없습니다. 지금은 삭제를 진행할 수 없습니다.</p>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void fetchOrgImpact()}
+                    disabled={orgImpactLoading}
+                  >
+                    다시 시도
+                  </Button>
+                  <label className="flex items-start gap-2 pt-1">
+                    <input
+                      type="checkbox"
+                      className="mt-0.5"
+                      checked={confirmWithoutImpact}
+                      onChange={(e) => setConfirmWithoutImpact(e.target.checked)}
+                    />
+                    <span className="space-y-0.5">
+                      <span className="block">영향 범위를 확認하지 못한 상태로 삭제합니다.</span>
+                      <span className="block text-xs">확認 없이 삭제한 것으로 기록됩니다.</span>
+                    </span>
+                  </label>
+                </AlertDescription>
+              </Alert>
             )}
 
             <div className="space-y-1.5">
@@ -1432,7 +1506,15 @@ export default function SettingsPage() {
                 variant="destructive"
                 className="flex-1"
                 onClick={() => void handleDeleteOrg()}
-                disabled={deleteOrgConfirmName !== orgInfo.name || deletingOrg || (orgImpact?.has_active_subscription ?? false)}
+                disabled={!canSubmitOrgDelete({
+                  orgName: orgInfo.name,
+                  confirmName: deleteOrgConfirmName,
+                  deletingOrg,
+                  orgImpactLoading,
+                  hasActiveSubscription: orgImpact?.has_active_subscription ?? false,
+                  orgImpactFailed,
+                  confirmWithoutImpact,
+                })}
               >
                 {deletingOrg ? '삭제 중…' : '영구 삭제'}
               </Button>

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -1454,7 +1454,7 @@ export default function SettingsPage() {
               // 아래), 재시도 또는 명시 인정(탈출구)만 남긴다. 서버(#2898)가 최종 방어선.
               <Alert variant="warning">
                 <AlertDescription className="space-y-3">
-                  <p>영향 범위를 확認할 수 없습니다. 지금은 삭제를 진행할 수 없습니다.</p>
+                  <p>영향 범위를 확인할 수 없습니다. 지금은 삭제를 진행할 수 없습니다.</p>
                   <Button
                     type="button"
                     variant="outline"
@@ -1472,8 +1472,8 @@ export default function SettingsPage() {
                       onChange={(e) => setConfirmWithoutImpact(e.target.checked)}
                     />
                     <span className="space-y-0.5">
-                      <span className="block">영향 범위를 확認하지 못한 상태로 삭제합니다.</span>
-                      <span className="block text-xs">확認 없이 삭제한 것으로 기록됩니다.</span>
+                      <span className="block">영향 범위를 확인하지 못한 상태로 삭제합니다.</span>
+                      <span className="block text-xs">확인 없이 삭제한 것으로 기록됩니다.</span>
                     </span>
                   </label>
                 </AlertDescription>


### PR DESCRIPTION
## 요약
유나 실사용 발견(2026-07-22): 조직 삭제 다이얼로그가 영향도 조회(`GET .../impact`)에 실패해도 **"영향도 정보를 불러올 수 없습니다. 계속 진행해도 됩니다"**라며 삭제 버튼을 그대로 열어뒀다 — `has_active_subscription` 기본값 `false`가 실패 케이스에도 그대로 적용돼 disabled 조건에서 새는 경로였다. 서버 방어선(#2898, `confirm_without_impact` + 재조회, **이미 develop에 배포됨**)은 있었지만 화면 "안내"쪽이 여전히 위험을 가볍게 권했다.

## 변경
- `orgImpact===null`이 "아직 안 물음"과 "실패함"을 함께 가리키던 걸 `orgImpactFailed`로 명시 분리.
- 실패 상태: "계속 진행해도 됩니다" 문구를 걷어내고, [다시 시도] + 명시 인정 체크박스("영향 범위를 확認하지 못한 상태로 삭제합니다" / "확認 없이 삭제한 것으로 기록됩니다")만 노출 — 체크 전엔 삭제 버튼 자체가 비활성(AC2/AC3).
- 체크 시에만 `DELETE` 요청에 `confirm_without_impact:true`를 실어 서버(#2898)의 override 경로로 감 — 화면이 서버 판정을 대신하지 않는다.
- `canSubmitOrgDelete` 판정 로직을 `page.tsx` 밖 순수함수로 분리(Next.js Page 모듈이 named export 불허 — `org-delete-gate.ts` 신설)해 회귀테스트 대상으로 만듦.
- **AC6(같은 클래스 전수 확認)**: `delete_project`(프로젝트 삭제)·`deactivate_team_member`(멤버 비활성화) 둘 다 grep 확認 — 애초에 impact-preview fetch 자체가 없다(직접 삭제+감사로그만). "조회 실패 시 진행 권유" 결함의 전제(선행 조회)가 없어 같은 클래스 인스턴스 **0건**.

## 검증
- [x] `pnpm type-check` / `pnpm build` exit 0, `pnpm lint`(eslint 대상 파일) 0
- [x] 신규 회귀테스트 8건(`org-delete-gate.test.ts`) — 원결함(조회실패+이름일치만으로 통과)을 그대로 재현해 고정. 가드를 임시 삭제해 실FAIL 확認 후 복원.
- [x] `settings` 디렉토리 전체 테스트 24/24 PASS(회귀 없음)
- [x] tint-foreground-contrast·no-new-tint-color-text 가드 통과(Alert variant="warning" 사용, 신규 계열색-tint 위반 0)
- [ ] **dev 라이브**: 조회 실패 강제 재현(네트워크 차단 등)→버튼 비활성→체크박스→삭제 왕복, 정상 경로 무회귀 — 로컬 FE가 인증 붙은 백엔드를 가리킬 수 없어(카디르 throwaway 풀스택 셋업은 아직 미확認) dev 배포 후 별도 확認해 PR 코멘트로 남기겠음. P0 긴급도 고려해 리뷰는 먼저 태우는 편이 낫다고 판단.

## 스크린샷
로컬 FE가 인증 백엔드에 못 붙어 before/after 스크린샷은 dev 배포 후 첨부 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)