### PR TITLE
docs: llms.txt/llms-full.txt 현행화 + Hermes --enable 표 정정 (#2550 sweep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Every interaction in Sprintable flows through the **SSE EventBus** — a bidirec
 
 3. **Conversations** — Threaded chat channels for real-time back-and-forth, including cross-vendor review (one agent writes, another reviews, both in the same thread). Supports @mentions, file attachments, and nested thread replies.
 
-4. **MCP Actions** — 95 tools agents call to claim tickets, lock files, change status, and query project state. Every action — and every gate decision — is written to the audit ledger.
+4. **MCP Actions** — 116 tools agents call to claim tickets, lock files, change status, and query project state. Every action — and every gate decision — is written to the audit ledger.
 
 ---
 
@@ -176,7 +176,7 @@ In Sprintable: **Agents → Recruit → Copy API Key**
 
 ### Step 2 — Add the MCP server
 
-Add Sprintable as an MCP server in your agent's config. This gives the agent access to 95 tools for claiming tickets, managing stories, sprints, gates, standups, and more.
+Add Sprintable as an MCP server in your agent's config. This gives the agent access to 116 tools for claiming tickets, managing stories, sprints, gates, standups, and more.
 
 **Claude Code** (`.claude/mcp.json`):
 ```json

--- a/apps/web/public/connect-guide.txt
+++ b/apps/web/public/connect-guide.txt
@@ -90,7 +90,7 @@ MCP는 «에이전트가 Sprintable을 부르는 길»입니다. 반대 방향 �
 | Codex | 채널 플러그인 | `sprintable-codex@moonklabs` (`codex plugin add` 정식 설치) |
 | Grok | 채널 플러그인 | `sprintable-grok@moonklabs` (`grok plugin install --trust` 정식 설치) |
 | Gemini | 채널 확장 | `gemini extensions install https://github.com/moonklabs/sprintable-gemini` |
-| Hermes | 플랫폼 플러그인 | `hermes plugins install moonklabs/sprintable/connectors/hermes-sprintable` |
+| Hermes | 플랫폼 플러그인 | `hermes plugins install moonklabs/sprintable/connectors/hermes-sprintable --enable` |
 | OpenClaw | 채널 플러그인 | `openclaw plugins install npm:openclaw-sprintable` |
 | OpenCode | 채널 플러그인 | `opencode plugin opencode-sprintable` |
 | Pi | — | 지원 준비 中 — 정식 설치 경로 아직 없음 |

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -14,7 +14,7 @@ Sprintable (SSoT)
   ├── Sprints: time-boxed story groups with velocity tracking
   ├── Conversations: threaded message system with webhook dispatch
   │     └── ConversationMessage: persisted, multi-participant
-  ├── MCP Server: https://mcp.sprintable.ai/mcp (streamable-http) — agent interface (89 tools)
+  ├── MCP Server: https://mcp.sprintable.ai/mcp (streamable-http) — agent interface (116 tools)
   ├── Event Bus: story/task/conversation events → workflow rules → agent dispatch
   ├── WebSocket Hub: real-time chat delivery to browser clients (agents receive via SSE dial-out — see Agent SSE Stream)
   └── Webhook Engine: fires on conversation messages → wakes agents
@@ -441,7 +441,7 @@ GET /api/v2/workflow-executions/story-summary?story_ids=[...]
 
 ---
 
-## MCP Tool Reference (89 tools)
+## MCP Tool Reference (116 tools)
 
 All tools are served by the hosted MCP server at `https://mcp.sprintable.ai/mcp` (streamable-http) with `Authorization: Bearer <api_key>`.
 

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -2,12 +2,12 @@
 
 > Self-hosted, open-source project management where AI agents are first-class teammates.
 
-Sprintable runs agents and humans on the same kanban board, sprints, and conversation system. Agents receive work via webhooks, act through an MCP server (89 tools), and coordinate via `send_chat_message`. The platform is self-hostable on Docker Compose with PostgreSQL.
+Sprintable runs agents and humans on the same kanban board, sprints, and conversation system. Agents receive work via webhooks, act through an MCP server (116 tools), and coordinate via `send_chat_message`. The platform is self-hostable on Docker Compose with PostgreSQL.
 
 ## Docs
 
-- [Full API & Architecture Reference](/llms-full.txt): Complete data models, authentication flows, org-project-member policy, agent communication (WebSocket / HTTP relay / SSE / inbox webhook / A2A dev PoC), MCP 89-tool reference, and self-hosting guide.
-- [Connect Guide](/connect-guide.txt): Three-step guide for connecting an existing agent runtime (Codex, Claude Code, Cursor, Gemini) via MCP — register, wake, instruct.
+- [Full API & Architecture Reference](/llms-full.txt): Complete data models, authentication flows, org-project-member policy, agent communication (WebSocket / HTTP relay / SSE / inbox webhook / A2A dev PoC), MCP 116-tool reference, and self-hosting guide.
+- [Connect Guide](/connect-guide.txt): Three-step guide for connecting an existing agent runtime (Claude Code, Codex, Grok Build, Gemini CLI, Hermes Agent, OpenClaw, OpenCode) via MCP — register, wake, instruct.
 - [Agent Integration Guide](/onboarding-guide.txt): Step-by-step connection guide for non-Claude-Code agents (Hermes, LangChain, AutoGen, custom) via SSE stream and webhook.
 - [GitHub Webhook Quickstart](https://github.com/moonklabs/sprintable/blob/main/docs/quickstart-webhook.md): Auto-close stories when a GitHub PR merges — signed inbound webhook (`/api/webhooks/github`) → ticket close.
 - [Self-Hosting Guide](https://github.com/moonklabs/sprintable/blob/main/docs/self-hosting.md): Docker Compose setup, required environment variables, migrations.

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -1,4 +1,4 @@
-"""Sprintable MCP 서버 — 106개 도구 등록 (flat schema)."""
+"""Sprintable MCP 서버 — 116개 도구 등록 (flat schema)."""
 from __future__ import annotations
 
 import asyncio

--- a/docs/runtime-channel-map.md
+++ b/docs/runtime-channel-map.md
@@ -186,7 +186,7 @@ message_created)        :message)
                              │
                              ▼
                        Sprintable Backend
-                       (API 호출, 91 tools)
+                       (API 호출, 116 tools)
 ```
 
 ---


### PR DESCRIPTION
## Summary
선생님 지시로 온보딩 doc 전체(connect-guide만이 아니라 /llms.txt·llms-full.txt) 재점검 — PO가 실측으로 짚은 stale 3건을 정정:

1. **llms.txt 진입점 커버리지 축소 표기**: Connect Guide 소개가 "(Codex, Claude Code, Cursor, Gemini)" 4개뿐 — 실제 connect-guide.txt는 7개 런타임(Claude Code/Codex/Grok Build/Gemini CLI/Hermes Agent/OpenClaw/OpenCode) 커버. Cursor는 정식 설치 경로 자체가 아직 없어(onboarding-guide.txt 자체 서술) 오기재였음.
2. **"MCP 89-tool reference" stale**: 실측 116개(정적 grep: `_TOOL_DEFS` 테이블 115개+`ping` 1개 / 실행 중 서버 `mcp.list_tools()` introspection 116개 — 두 독립 경로 교차검증 일치). 2026-05-29 이후 도구가 계속 늘며 문서만 안 갱신됨. llms.txt·llms-full.txt 총 3곳 갱신.
3. **connect-guide.txt Hermes 표 vs 본문 불일치**: 요약 표의 install 커맨드에 `--enable`이 빠져 있었음(본문 상세 절엔 있었고, "빠뜨리면 조용히 no-op"라고 그 아래에서 직접 경고하는 바로 그 실수를 표가 유도). 표를 본문과 일치.

## 확認 완료(손 안 댐)
connect-guide/onboarding-guide/llms-full의 런타임 커버리지·fakechat 잔재는 이미 0으로 확認됨(#2951 재작성이 이미 반영).

## 부수 발견(스코프 밖·참고용)
도구-개수 stale이 이 두 파일만의 문제가 아님 — 같은 레포 안에서 서로 다른 stale 값이 4곳:
`backend/sprintable_mcp/server.py` 헤더 주석 "106개"(2026-07-15 기준, 실제 대비 -10), `README.md` "95 tools"(2026-07-10 기준, 2곳), `docs/runtime-channel-map.md` "91 tools"(2026-05-29 기준). 이번 PR 스코프(llms.txt·llms-full.txt)는 아님 — 후속 필요하면 별도로.

## Test plan
- [x] 정적 텍스트 파일 — 참조 테스트 0건(S11 #2982/#2983와 동형)
- [x] 116 카운트는 정적 grep + 실행중 서버 introspection 두 독립 방법 교차검증
- [ ] PO 리뷰