### PR TITLE
feat(#2597): MCP 발견 도구 신설 — sprintable_list_agent_cards

### DIFF
--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -105,6 +105,13 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # 가능해진다(pm/scrum-master 전용이던 걸 22개 role 전체로 확대 = 회귀 아닌 기능 추가).
     "sprintable_get_standup", "sprintable_save_standup", "sprintable_list_standup_entries",
     "sprintable_standup_history", "sprintable_standup_missing",
+    # story #2597(E-AGENT-ONBOARD·A2A발견 P0-1, 문서 e-a2a-discovery-spike-design 갭 A):
+    # list_agent_cards — sprintable_list_team_members와 동형(read-only·org-scope 로스터
+    # 조회) core 취급. "누구에게 청할지" 발견은 role_template.default_tool_groups 유무와
+    # 무관하게 어떤 role이든 필요한 cross-cutting 협업 유틸 — 여기 안 두면 대부분의
+    # 스코프 키가 이 도구를 403으로 못 본다. vendored 사본과 동기화 필수
+    # (sprintable_mcp/toolset.py).
+    "sprintable_list_agent_cards",
 })
 
 # scope 토큰: 그룹명 외에 read/write(레거시·전체 비파괴 의미), admin/destructive(파괴적 허용)
@@ -354,8 +361,8 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_update_hypothesis", "sprintable_link_hypothesis", "sprintable_confirm_hypothesis",
     # loops (E-LOOP-LEDGER P1-S12)
     "sprintable_get_loop_context",
-    # a2a HITL writer (E-A2A-완성 S-A3)
-    "sprintable_link_gate_to_task",
+    # a2a HITL writer (E-A2A-완성 S-A3) + 발견 (story #2597, E-AGENT-ONBOARD·A2A발견 P0-1)
+    "sprintable_link_gate_to_task", "sprintable_list_agent_cards",
     # evidence (E-VERIFY V0-S1)
     "sprintable_add_evidence",
     # 판단 칸 (story #2268, D단계)

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -28,7 +28,9 @@ from .schemas import SprintableInput
 # E-MCP S4: 독립 패키지 디탱글 — backend(app/*) import 제거. 규칙은 vendored .toolset 사용
 # (백엔드 app/services/mcp_toolset.py와 동일 규칙 유지·SSOT는 백엔드 매니페스트).
 from .toolset import is_tool_allowed
-from .tools.a2a import LinkGateToTaskInput, link_gate_to_task
+from .tools.a2a import (
+    LinkGateToTaskInput, ListAgentCardsInput, link_gate_to_task, list_agent_cards,
+)
 from .tools.evidence import AddEvidenceInput, add_evidence
 from .tools.judgments import AddJudgmentInput, ListJudgmentsInput, add_judgment, list_judgments
 from .tools.session_context import SessionContextInput, get_session_context
@@ -625,6 +627,13 @@ _TOOL_DEFS: list[tuple] = [
      "이 gate가 이 A2A task를 블록한다고 명시 선언 — 외부 GetTask가 INPUT_REQUIRED로 승격되고,"
      " 사람이 gate를 승인/거부하면 task가 자동으로 WORKING/REJECTED 복귀한다.",
      LinkGateToTaskInput, link_gate_to_task),
+    # A2A 발견 (1) — E-AGENT-ONBOARD·A2A발견 P0-1(story #2597)
+    ("sprintable_list_agent_cards",
+     "org 내 활성 agent 전원의 A2A AgentCard 열거 — «누구에게 청할지» 발견. optional"
+     " skill(예: \"qa\")로 필터해 적임자 후보만 조회. 지시받지 않은 담당자를 스스로 찾아"
+     " 위임할 때(예: PR 완료 후 QA 담당 조회) 이 도구로 먼저 발견한 뒤"
+     " sprintable_send_chat_message로 청한다.",
+     ListAgentCardsInput, list_agent_cards),
     # Evidence 자기증명 (1) — E-VERIFY V0-S1
     ("sprintable_add_evidence",
      "done을 스스로 증명하는 자기 서명 첨부(PR·배포·지표·발행물 링크 등) — story/task에 evidence"

--- a/backend/sprintable_mcp/tools/a2a.py
+++ b/backend/sprintable_mcp/tools/a2a.py
@@ -1,4 +1,12 @@
-"""A2A HITL writer MCP 도구 (1개) — E-A2A-완성 S-A3(story 6d0454c3) + S-A5(story c140977f)."""
+"""A2A MCP 도구(2개) — E-A2A-완성 S-A3(story 6d0454c3) + S-A5(story c140977f) +
+E-AGENT-ONBOARD·A2A발견 P0-1(story #2597, 문서 e-a2a-discovery-spike-design 갭 A).
+
+story #2597: 발견 도구(list_agent_cards) 신설 전엔 이 파일에 `link_gate_to_task` 1개뿐이었다
+— `GET /api/v2/a2a/members`(백엔드 `app/routers/a2a.py:471`, story 5578a8e2 S3)는 이미
+org 내 활성 agent 전원의 AgentCard(+`?skill=` 필터)를 정확히 반환하는데, 이를 감싸는 MCP
+도구가 없어 MCP만 쓰는 에이전트는 "누가 QA인지" 같은 발견을 할 방법이 구조적으로 없었다
+(스파이크 doc 갭 A). 백엔드 라우터/스키마는 변경하지 않는다 — 이미 spec 정합(story 480e81fb).
+"""
 from __future__ import annotations
 
 from mcp.types import TextContent
@@ -29,6 +37,30 @@ async def link_gate_to_task(args: LinkGateToTaskInput) -> list[TextContent]:
             f"/api/v2/a2a/tasks/{args.task_id}/link-gate",
             json=payload,
         )
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))
+
+
+class ListAgentCardsInput(SprintableInput):
+    # story #2597 AC3: 서버측 `_skill_matches`(a2a.py) 로 그대로 전달 — id/tags/name/
+    # description 부분일치(대소문자 무시). 생략 시 org 내 활성 agent 전원 반환.
+    skill: str | None = None
+
+
+async def list_agent_cards(args: ListAgentCardsInput) -> list[TextContent]:
+    """지금 이 org에서 "누구에게 청할지" 발견한다 — org 내 활성 agent 전원의 A2A AgentCard
+    (표준 규격: name/skills/security 등)를 열거한다. `skill`을 주면(예: "qa", "backend")
+    서버가 각 카드의 skill id/name/description/tags를 부분일치로 걸러 후보만 돌려준다 —
+    "이 작업엔 누가 적임자인가"를 사람이 미리 알려주지 않아도 스스로 찾을 때 쓴다(예: PR을
+    올린 뒤 QA 담당을 모를 때 `skill="qa"`로 조회해 반환된 member_id에게
+    sprintable_send_chat_message 로 청한다). 자기 자신의 크리덴셜(org 스코프)로만 조회되며,
+    타 org의 카드는 보이지 않는다."""
+    try:
+        params: dict = {}
+        if args.skill:
+            params["skill"] = args.skill
+        result = await client.get("/api/v2/a2a/members", params=params or None)
         return ok(result)
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/toolset.py
+++ b/backend/sprintable_mcp/toolset.py
@@ -89,6 +89,12 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # app/services/mcp_toolset.py 참고 — role_template 특정 대신 범용 업무로 core 승격).
     "sprintable_get_standup", "sprintable_save_standup", "sprintable_list_standup_entries",
     "sprintable_standup_history", "sprintable_standup_missing",
+    # story #2597(E-AGENT-ONBOARD·A2A발견 P0-1): list_agent_cards — sprintable_list_team_members와
+    # 동형(read-only·org-scope 로스터 조회) core 취급. 특정 역할의 default_tool_groups 유무와
+    # 무관하게 "누구에게 청할지" 발견은 어떤 role이든 필요한 cross-cutting 협업 유틸이라 여기
+    # 안 두면 스코프 키(대부분의 role_template)에서 403으로 안 보인다. 백엔드 SSOT와 동기화
+    # (app/services/mcp_toolset.py).
+    "sprintable_list_agent_cards",
 })
 
 _LEGACY_SCOPES: frozenset[str] = frozenset({"read", "write"})

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -91,6 +91,8 @@ EXPECTED_TOOLS = {
     "sprintable_lock_files", "sprintable_unlock_files",
     # a2a HITL writer (1) — E-A2A-완성 S-A3
     "sprintable_link_gate_to_task",
+    # a2a 발견 (1) — E-AGENT-ONBOARD·A2A발견 P0-1(story #2597)
+    "sprintable_list_agent_cards",
     # evidence (1) — E-VERIFY V0-S1
     "sprintable_add_evidence",
     # 판단 칸 (2) — story #2268(D단계, E-CONNECT)
@@ -121,7 +123,9 @@ def test_total_tool_count():
     # 전용) — 112→113. story #2268(D단계): sprintable_add_judgment/list_judgments 2종 신설
     # (판단 칸 pull 진입점 MCP 노출) — 113→115. story #2268(C-10): sprintable_get_session_context
     # 1종 신설(세션 시작 컨텍스트 REST를 MCP로 노출 — PO 판정: REST뿐이면 못 쓴다) — 115→116.
-    assert len(_TOOLS) == 116
+    # story #2597(E-AGENT-ONBOARD·A2A발견 P0-1): sprintable_list_agent_cards 1종 신설
+    # (A2A AgentCard 발견 — 「누구에게 청할지」를 스스로 찾는 MCP 도구) — 116→117.
+    assert len(_TOOLS) == 117
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_2412_mcp_unknown_arg_rejection.py
+++ b/backend/tests/test_2412_mcp_unknown_arg_rejection.py
@@ -69,12 +69,13 @@ async def test_registered_standup_history_tool_still_accepts_known_args():
 
 
 def test_all_registered_tools_share_the_same_lockdown():
-    """AC2 카운트 — `_TOOL_DEFS` 115개 + ping 1개 = 116개 전부 arg_model이 extra=forbid로
-    잠겨 있어야 한다(상속 갈래 SprintableInput/BaseModel 안 가리고 전부)."""
+    """AC2 카운트 — `_TOOL_DEFS` 116개 + ping 1개 = 117개(story #2597: list_agent_cards 추가로
+    115→116) 전부 arg_model이 extra=forbid로 잠겨 있어야 한다(상속 갈래 SprintableInput/
+    BaseModel 안 가리고 전부)."""
     from sprintable_mcp import server as srv
 
     tools = srv.mcp._tool_manager.list_tools()
-    assert len(tools) == 116
+    assert len(tools) == 117
     unlocked = [
         t.name for t in tools
         if t.fn_metadata.arg_model.model_config.get("extra") != "forbid"

--- a/backend/tests/test_2597_mcp_list_agent_cards.py
+++ b/backend/tests/test_2597_mcp_list_agent_cards.py
@@ -1,0 +1,111 @@
+"""story #2597(E-AGENT-ONBOARD·A2A발견 P0-1, 문서 e-a2a-discovery-spike-design 갭 A):
+MCP sprintable_list_agent_cards — GET /api/v2/a2a/members 래퍼(순수 배선, 신규 백엔드
+로직 없음). AC1(도구 존재)·AC3(skill 필터 전달)·AC5(unit test)를 이 파일이 커버한다.
+AC2(agent 크리덴셜 org 스코프)는 기존 client 인증 배선을 그대로 타므로 재검증 대상 아님
+(client.get이 이미 sk_live_ Bearer를 항상 싣는다, 다른 모든 MCP 도구와 동형)."""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_list_agent_cards_without_skill_calls_bare_endpoint():
+    from sprintable_mcp.tools.a2a import ListAgentCardsInput, list_agent_cards
+
+    cards = [
+        {"name": "카디르", "skills": [{"id": "qa-automation", "name": "QA Automation 엔지니어",
+                                       "description": "...", "tags": []}]},
+    ]
+    calls: list[tuple[str, dict | None]] = []
+
+    async def fake_get(path, params=None):
+        calls.append((path, params))
+        return cards
+
+    with patch("sprintable_mcp.tools.a2a.client") as mock_client:
+        mock_client.get = AsyncMock(side_effect=fake_get)
+        out = await list_agent_cards(ListAgentCardsInput())
+
+    assert calls == [("/api/v2/a2a/members", None)]
+    parsed = json.loads(out[0].text)
+    assert parsed == cards
+
+
+@pytest.mark.anyio
+async def test_list_agent_cards_with_skill_passes_filter_param():
+    from sprintable_mcp.tools.a2a import ListAgentCardsInput, list_agent_cards
+
+    calls: list[tuple[str, dict | None]] = []
+
+    async def fake_get(path, params=None):
+        calls.append((path, params))
+        return []
+
+    with patch("sprintable_mcp.tools.a2a.client") as mock_client:
+        mock_client.get = AsyncMock(side_effect=fake_get)
+        await list_agent_cards(ListAgentCardsInput(skill="qa"))
+
+    assert calls == [("/api/v2/a2a/members", {"skill": "qa"})]
+
+
+@pytest.mark.anyio
+async def test_list_agent_cards_empty_skill_string_treated_as_no_filter():
+    """빈 문자열("")은 필터 의도가 아니다 — None과 동일하게 취급(서버 쿼리파람 오염 방지)."""
+    from sprintable_mcp.tools.a2a import ListAgentCardsInput, list_agent_cards
+
+    calls: list[tuple[str, dict | None]] = []
+
+    async def fake_get(path, params=None):
+        calls.append((path, params))
+        return []
+
+    with patch("sprintable_mcp.tools.a2a.client") as mock_client:
+        mock_client.get = AsyncMock(side_effect=fake_get)
+        await list_agent_cards(ListAgentCardsInput(skill=""))
+
+    assert calls == [("/api/v2/a2a/members", None)]
+
+
+@pytest.mark.anyio
+async def test_list_agent_cards_error_surfaces():
+    from sprintable_mcp.tools.a2a import ListAgentCardsInput, list_agent_cards
+
+    with patch("sprintable_mcp.tools.a2a.client") as mock_client:
+        mock_client.get = AsyncMock(side_effect=Exception("401 Unauthorized"))
+        out = await list_agent_cards(ListAgentCardsInput())
+
+    assert "error" in out[0].text.lower()
+
+
+def test_tool_registered_in_mcp_server():
+    from sprintable_mcp.server import _TOOL_DEFS
+
+    names = {name for name, *_ in _TOOL_DEFS}
+    assert "sprintable_list_agent_cards" in names
+
+
+def test_tool_always_allowed_regardless_of_scoped_key():
+    """role_template.default_tool_groups가 이 도구의 그룹을 안 가진 스코프 키(예: qa-automation의
+    ["stories","tasks","chat","docs","retro"])로도 호출 가능해야 한다 — 「누구에게 청할지」
+    발견은 어떤 role이든 필요한 cross-cutting 유틸이라 _ALWAYS_ALLOWED(core) 취급이 필수."""
+    from app.services.mcp_toolset import is_tool_allowed
+
+    narrow_scope = ["stories", "tasks", "chat", "docs", "retro"]
+    assert is_tool_allowed("sprintable_list_agent_cards", narrow_scope) is True
+
+
+def test_backend_and_vendored_toolset_stay_in_sync():
+    from app.services import mcp_toolset as backend
+    from sprintable_mcp import toolset as vendored
+
+    assert "sprintable_list_agent_cards" in backend._ALWAYS_ALLOWED
+    assert "sprintable_list_agent_cards" in vendored._ALWAYS_ALLOWED
+    assert "sprintable_list_agent_cards" in backend.ALL_TOOL_NAMES

--- a/backend/tests/test_mcp_axis_prefix_b_surface.py
+++ b/backend/tests/test_mcp_axis_prefix_b_surface.py
@@ -23,6 +23,9 @@ _CORE_NO_PREFIX = {
     "sprintable_add_evidence", "sprintable_list_projects", "sprintable_set_default_project",
     "sprintable_add_judgment", "sprintable_list_judgments",
     "sprintable_get_session_context",
+    # story #2597: list_agent_cards — mcp_toolset.py _ALWAYS_ALLOWED와 동기화(core 취급 사유는
+    # 거기 주석 참조 — 어떤 role이든 필요한 cross-cutting 발견 유틸, 단일 축 아님).
+    "sprintable_list_agent_cards",
 }
 
 
@@ -45,7 +48,7 @@ def test_core_tools_have_no_axis_prefix():
 
 
 def test_bidirectional_coverage_no_silent_gap():
-    """전체 106개 중 core 제외 전부가 프리픽스 대상 — 한쪽만 확인하면 신규 툴 누락을 못 잡는다."""
+    """전체 도구 중 core 제외 전부가 프리픽스 대상 — 한쪽만 확인하면 신규 툴 누락을 못 잡는다."""
     prefixed = {n for n, d in _TOOLS.items() if d.startswith(_VALID_PREFIXES)}
     expected_prefixed = set(_TOOLS.keys()) - _CORE_NO_PREFIX
     assert prefixed == expected_prefixed
@@ -68,6 +71,7 @@ def test_tool_names_and_param_models_untouched():
     sprintable_delete_artifact 1종 신설(artifact soft delete, 생성자 전용) — 111→112. story #2268
     (D단계): sprintable_add_judgment/list_judgments 2종 신설(판단 칸 pull 진입점) — 112→114.
     story #2268(C-10): sprintable_get_session_context 1종 신설(세션 시작 컨텍스트 MCP 노출) —
-    114→115."""
-    assert len(_TOOL_DEFS) == 115
+    114→115. story #2597(E-AGENT-ONBOARD·A2A발견 P0-1): sprintable_list_agent_cards 1종
+    신설(A2A AgentCard 발견) — 115→116."""
+    assert len(_TOOL_DEFS) == 116
     assert all(name.startswith("sprintable_") for name in _TOOLS)


### PR DESCRIPTION
## Summary
E-AGENT-ONBOARD·A2A발견 P0-1(스파이크 doc [e-a2a-discovery-spike-design](entity:doc:e7a23552-3f46-4164-a754-3729ad468778) 갭 A). `GET /api/v2/a2a/members`(`?skill=` 필터, 이미 spec-정합 구현된 `a2a.py:471 list_agent_cards`)를 감싸는 MCP 도구가 0개였다 — MCP만 쓰는 에이전트는 "누구에게 청할지" 발견을 할 방법이 구조적으로 없었다(찰스 시나리오 갭 A). **신규 백엔드 로직 없음, 순수 MCP 배선.**

- `tools/a2a.py`: `ListAgentCardsInput` + `list_agent_cards` 핸들러 추가
- `server.py`: `_TOOL_DEFS` 등록
- `mcp_toolset.py`/`toolset.py`: `_ALWAYS_ALLOWED`(core) + `ALL_TOOL_NAMES` 등록 — 이거 없으면 role_template.default_tool_groups가 이 도구의 그룹을 안 가진 스코프 키(대부분의 role)가 403으로 못 본다. `sprintable_list_team_members`와 동형(cross-cutting read-only 발견 유틸)
- 테스트 카운트 계약(`test_contract.py`/`test_2412`/`test_mcp_axis_prefix_b_surface.py`) 동기화

## AC 대조
1. ✅ 발견 MCP 도구 1개 추가 — `GET /api/v2/a2a/members`(optional skill 필터) 호출, AgentCard 열거 반환
2. ✅ 에이전트 크리덴셜(sk_live_ Bearer/x-agent-api-key)로 caller org 스코프 조회 — 기존 client 인증 배선 그대로 재사용(다른 모든 MCP 도구와 동형, 별도 배선 불요)
3. ✅ `?skill=qa`류 필터가 서버측 `_skill_matches`로 전달
4. ✅ 도구 설명이 "누구에게 청할지 발견" 용도 명시
5. ✅ 단위 테스트(skill 필터 유/무 각각) + `_ALWAYS_ALLOWED`/vendor-sync 회귀가드
⛔ 범위: 백엔드 라우터/스키마 변경 없음(이미 정합) — 실제로 무변경.

## Test plan
- [x] `tests/test_2597_mcp_list_agent_cards.py` 7/7 green(필터 유/무·에러 서페이스·도구 등록·always-allowed 스코프·vendor sync)
- [x] `tests/mcp/test_contract.py`·`test_2412_mcp_unknown_arg_rejection.py`·`test_mcp_axis_prefix_b_surface.py`·`test_s2311_vendor_const_sync.py`·`test_s2304_ping_tool_name_registry_match.py` 전부 green(카운트 116→117 동기화)
- [x] 전체 백엔드 테스트(4700+): 신규 실패 0건. 17건 실패는 전부 clean develop 베이스라인에서도 재현되거나(로컬 DB env/`.mcp.json` 경로 의존) 격리 재실행 시 전부 green(순서-의존 flakiness) — 이 PR과 무관 확認
- [ ] 카디르 QA