### PR TITLE
[SID:2598] A2A discovery endpoint docs + unauth/PoC staleness fix

### DIFF
--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -375,21 +375,26 @@ Retry policy: 3 total attempts
 
 ### A2A Protocol (dev PoC)
 External [A2A](https://a2a-protocol.org/)-compatible agents/systems can discover and delegate to
-a Sprintable agent without a Sprintable API key of their own — an alternative to the MCP/gateway
-integrations above, for callers that already speak A2A.
+a Sprintable agent — an alternative to the MCP/gateway integrations above, for callers that
+already speak A2A. All A2A endpoints require the same Sprintable credential as every other
+endpoint in this doc (`Authorization: Bearer sk_live_...`), scoped to the caller's org.
 
 ```
-GET /api/v2/a2a/members/{member_id}/agent-card.json   (unauth, https)
-  → AgentCard: capabilities (streaming=false), protocol_version 1.0,
+GET /api/v2/a2a/members?skill=<query>                 (authed, org-scoped)
+  → list your org's agents as AgentCards; ?skill= matches a skill's id exactly,
+    or as a substring of its tag/name/description (case-insensitive)
+
+GET /api/v2/a2a/members/{member_id}/agent-card.json   (authed, org-scoped)
+  → AgentCard: capabilities (streaming=true), protocol_version 1.0,
     securitySchemes (Bearer), skills (from role_template, or persona-slug fallback)
 
 POST /api/v2/a2a/members/{member_id}/rpc               (JSON-RPC, org-scoped)
   SendMessage → creates an A2A Task, state=WORKING
   GetTask     → polls task state; reply-thread convention resolves it to
                 COMPLETED + artifact once the delegate replies in-thread
-  ListTasks   → implemented, live/SDK-verified pending
+  ListTasks   → implemented, live/SDK-verified
 
-Cross-org calls are rejected (IDOR-blocked, org-scoped auth on /rpc).
+Cross-org calls are rejected (IDOR-blocked, org-scoped auth on all three endpoints above).
 ```
 
 Verified in dev with the real `a2a-sdk`: discovery → SendMessage → delegate reply → GetTask
@@ -397,11 +402,13 @@ Verified in dev with the real `a2a-sdk`: discovery → SendMessage → delegate 
 carries an embedded completion hint (reply-thread id) so the delegate model can complete the
 round-trip — this makes completion **model-mediated**, not a deterministic server-side hook.
 
-**PoC-level, dev only — do not treat as GA:**
-- `streaming=false` (no SendStreamingMessage/SSE)
-- No `AUTH_REQUIRED` state/flow (Bearer is advertised but there's no challenge flow)
-- HITL (human-in-the-loop) gate integration is forward-work, not wired
-- Not yet served in production — dev-only endpoint
+**Still PoC-labeled (`AgentCard.version = "0.1.0-poc"`), not yet GA:**
+- `streaming=true` and `AUTH_REQUIRED` (via explicit delegate declaration, not automatic
+  detection) have shipped and are promoted to main
+- HITL gate integration is wired (explicit `linked_gate` declaration, not automatic detection)
+- Routes respond live in prod (confirmed: unauthenticated calls get 401, not 404 — the routes
+  exist), but the formal prod E2E validation pass hasn't landed — treat as reachable, not yet
+  fully validated
 
 ---
 

--- a/apps/web/public/onboarding-guide.txt
+++ b/apps/web/public/onboarding-guide.txt
@@ -391,12 +391,16 @@ Send a message into a conversation the agent belongs to; it arrives over SSE, an
 ## Alternative: A2A protocol (dev PoC)
 
 If your agent/system already speaks [A2A](https://a2a-protocol.org/) instead of implementing
-the gateway above, Sprintable agents are discoverable and delegable over A2A directly — no
-Sprintable API key required on the caller side.
+the gateway above, Sprintable agents are discoverable and delegable over A2A directly.
+Discovery and delegation both require the same Sprintable credential as everywhere else in this
+guide (`Authorization: Bearer sk_live_...`) and are scoped to the caller's org.
 
 ```
-GET  /api/v2/a2a/members/{member_id}/agent-card.json   — unauth AgentCard discovery
-POST /api/v2/a2a/members/{member_id}/rpc                — SendMessage / GetTask / ListTasks
+GET  /api/v2/a2a/members?skill=<query>                 — list your org's agents; ?skill= matches an
+                                                           AgentCard skill's id exactly, or as a substring
+                                                           of its tag/name/description (case-insensitive)
+GET  /api/v2/a2a/members/{member_id}/agent-card.json   — single-agent AgentCard (authed, same-org)
+POST /api/v2/a2a/members/{member_id}/rpc                — SendMessage / GetTask / ListTasks (authed, same-org)
 ```
 
 `SendMessage` creates a Task (`state=WORKING`); the delegate agent replies in the originating
@@ -405,8 +409,11 @@ round-trip (discovery → delegate → reply → completed) is verified in dev w
 `a2a-sdk`, fully automated — but completion is **model-mediated** (the delegate model reads an
 embedded reply-thread hint and acts on it; there's no deterministic completion hook).
 
-**Dev PoC only** — `streaming=false`, no `AUTH_REQUIRED` flow, HITL gating not wired, and this
-is not yet served in production. Don't rely on it as a stable integration surface yet.
+**Still labeled PoC** (`AgentCard.version = "0.1.0-poc"`) — `streaming`, `AUTH_REQUIRED`, and HITL
+gating (via explicit delegate declaration, not automatic detection) have since shipped and
+promoted to main; the routes respond live in prod (confirmed: unauthenticated calls get 401, not
+404 — the routes exist). Formal prod E2E validation hasn't landed yet, so treat this as reachable
+but not yet a fully validated, stable integration surface.
 
 ---
 


### PR DESCRIPTION
## Summary
- **Gap B**: documented `GET /api/v2/a2a/members?skill=` (the actual discovery/list endpoint) in both `onboarding-guide.txt` and `llms-full.txt` — previously only the single-member `agent-card.json` + `/rpc` were mentioned, so a new agent following the guide never encountered "discovery" as a concept.
- **Gap C**: corrected `agent-card.json` from "unauth" to authed+same-org — grounded in code (`get_verified_org_id` + `get_current_user` deps, SEC-S2 story 48ff642a). Following the old doc literally 401s today.
- Corrected the "Dev PoC only" caveat list, which had drifted since the 2026-07-09 checklist snapshot:
  - `streaming=false` → `streaming=true` (confirmed in `_build_agent_card`, S-A4, commit e4fdcf3a0)
  - "no AUTH_REQUIRED flow" → AUTH_REQUIRED exists via explicit delegate declaration (S-A5, commit 33389c3ce)
  - "HITL gating not wired" → wired via explicit `linked_gate` declaration (S-A3, commit 636e4a35f) — all three promoted to `main` in `2ce42dee2`
  - "not yet served in production" → verified false by curling prod directly: `GET /api/v2/a2a/members` on `sprintable-backend-prod-...run.app` returns **401, not 404** — the routes exist and respond live. Kept appropriate caution since the formal prod E2E validation pass (S-A6) hasn't landed.

## Grounding (no guessing)
- Read `backend/app/routers/a2a.py` directly for both endpoints' actual `Depends()` and the `_skill_matches` matching semantics (id = exact, tag/name/description = substring, case-insensitive).
- Checked `a2a-completion-checklist` + `a2a-completion-blueprint` docs for the S-A1..A6 breakdown, then cross-checked against `git log` commit dates (S-A4/S-A5 landed 2026-07-09, after the checklist doc's last update) to confirm the checklist snapshot itself was stale, not the code.
- Confirmed prod liveness with a real unauthenticated curl against the prod backend (401, not 404).
- Checked `connect-guide.en/ko.txt` for A2A mentions — none, so no bilingual pair to keep in sync (AC4 is N/A for this change).

## Test plan
- [x] `mcp-url-guard.test.ts` + `proxy.test.ts` (reference these two files) — 76 tests pass
- [x] `recruiter-client.test.tsx` (links to `onboarding-guide.txt`) — 44 tests pass
- [x] No pinned-text test references the replaced strings (grepped `apps/web/src` for the old phrasing)
- [x] Pure docs — no code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)