### PR TITLE
feat(#2599): role_templates.skills 최소 백필 — qa-automation+backend/frontend/pm

### DIFF
--- a/backend/alembic/versions/0240_role_templates_skills_minimal_backfill.py
+++ b/backend/alembic/versions/0240_role_templates_skills_minimal_backfill.py
@@ -1,0 +1,88 @@
+"""E-AGENT-ONBOARD·A2A발견 P1(story #2599, 문서 e-a2a-discovery-spike-design 갭 D):
+role_templates.skills 최소 백필 — qa-automation + 원 builtin 3종(backend/frontend/pm).
+
+Revision ID: 0240
+Revises: 0239
+Create Date: 2026-08-12
+
+[[no-pr-for-data]] 게이트: 이 마이그는 role_templates.skills(app.schemas.a2a.AgentSkill 형태,
+0161이 "A2A 발견 키"로 도입)에 실 콘텐츠를 채운다 — 데이터 마이그레이션이라 병합 前 선생님
+명시 승인 필요(0166/0167 선례와 동일 규칙).
+
+배경(#2584 스파이크 갭 D): skills 컬럼은 0161 도입 이래 전 24개 seed 카탈로그가 `[]`째
+방치돼 있었다 — `_build_agent_card`(app/routers/a2a.py:366)가 매번 persona.slug/name 파생
+단일 skill로 폴백해, 오늘 모든 AgentCard의 skill이 예외 없이 1개짜리였다. 찰스 시나리오
+(#2584)가 `?skill=qa`로 QA 적임자를 발견하려면 최소한 qa-automation 카드에 구조화 skill이
+있어야 한다 — 원 builtin 3종(backend/frontend/pm, 0156)도 같은 이유로 최소 백필한다(이
+팀의 실 채용 role과 가장 가까운 4종). 전체 24 카탈로그 백필은 스코프 밖(별도 스토리, ~300직군
+트랙 연계) — 여기서는 "발견 신호가 이름 문자열 하나뿐"이라는 갭만 최소로 해소한다.
+
+콘텐츠는 새로 짓지 않고 0156이 이미 seed한 role_templates.description을 AgentSkill(id/name/
+description/tags) shape로 재구성만 한다(신규 주장 0건 — 기존 승인된 카탈로그 문구 재사용).
+tags는 `_skill_matches`(a2a.py:459, name/description/tags substring)가 `?skill=` 매칭에
+쓰는 실 검색어 — 각 role의 실사용 관례 키워드로 채운다.
+"""
+from __future__ import annotations
+
+import json
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0240"
+down_revision = "0239"
+branch_labels = None
+depends_on = None
+
+_SKILLS: dict[str, list[dict]] = {
+    "qa-automation": [
+        {
+            "id": "qa-automation",
+            "name": "QA Automation Engineer",
+            "description": "테스트 자동화 구축과 회귀 방지를 자율적으로 운영하는 QA 자동화 엔지니어.",
+            "tags": ["qa", "testing", "test-automation", "regression", "quality-assurance"],
+        }
+    ],
+    "backend": [
+        {
+            "id": "backend",
+            "name": "Backend Engineer",
+            "description": "API·데이터 모델·서버 로직 구현을 자율적으로 운영하는 백엔드 엔지니어.",
+            "tags": ["backend", "api", "database", "server"],
+        }
+    ],
+    "frontend": [
+        {
+            "id": "frontend",
+            "name": "Frontend Engineer",
+            "description": "UI/UX 구현과 프론트엔드 버그 수정을 자율적으로 운영하는 프론트엔드 엔지니어.",
+            "tags": ["frontend", "ui", "ux", "react"],
+        }
+    ],
+    "pm": [
+        {
+            "id": "pm",
+            "name": "Product Manager",
+            "description": "스토리/에픽 기획과 스프린트·가설 운영을 자율적으로 운영하는 PM/PO.",
+            "tags": ["pm", "product", "planning", "roadmap"],
+        }
+    ],
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    for slug, skills in _SKILLS.items():
+        bind.execute(
+            sa.text("UPDATE role_templates SET skills = :skills WHERE slug = :slug"),
+            {"skills": json.dumps(skills), "slug": slug},
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    for slug in _SKILLS:
+        bind.execute(
+            sa.text("UPDATE role_templates SET skills = '[]'::jsonb WHERE slug = :slug"),
+            {"slug": slug},
+        )

--- a/backend/tests/test_2599_role_template_skills_backfill.py
+++ b/backend/tests/test_2599_role_template_skills_backfill.py
@@ -1,0 +1,140 @@
+"""story #2599(E-AGENT-ONBOARD·A2A발견 P1, 문서 e-a2a-discovery-spike-design 갭 D):
+role_templates.skills 최소 백필(qa-automation + backend/frontend/pm) 검증.
+
+realdb 파트는 DB env 없으면 skip(0166 realdb 패턴과 동형). 순수 SELECT — destructive_schema
+마커 사용 금지(0163 CI 회귀 교훈).
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+_BACKFILLED_SLUGS = {"qa-automation", "backend", "frontend", "pm"}
+
+
+def _load_migration_0240():
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "alembic" / "versions" / "0240_role_templates_skills_minimal_backfill.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_0240", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+# ── AC1/AC2: 콘텐츠 형태 — AgentSkill 스키마 정합 ──────────────────────────────
+
+def test_migration_skills_cover_exactly_the_minimal_set():
+    mod = _load_migration_0240()
+    assert set(mod._SKILLS.keys()) == _BACKFILLED_SLUGS
+
+
+def test_migration_skills_validate_as_agent_skill():
+    from app.schemas.a2a import AgentSkill
+
+    mod = _load_migration_0240()
+    for slug, skills in mod._SKILLS.items():
+        assert len(skills) >= 1, f"{slug}: skills 비어있음"
+        for raw in skills:
+            skill = AgentSkill(**raw)
+            assert skill.id, f"{slug}: id 비어있음"
+            assert skill.name, f"{slug}: name 비어있음"
+            assert skill.tags, f"{slug}: tags 비어있음(발견 매칭 재료 없음)"
+
+
+# ── AC4: `?skill=` 필터가 구조화 skills의 tags/id에도 매치(name뿐 아니라) ────────────
+
+def test_skill_filter_matches_via_tags_not_just_name():
+    """`_skill_matches`(a2a.py)는 name/description/tags substring OR 매칭이다 — 백필된
+    tags로만 검색해도(예: qa-automation은 name에 "test-automation"이 없음) 걸려야 한다."""
+    from app.routers.a2a import _skill_matches
+    from app.schemas.a2a import AgentCapabilities, AgentCard, AgentInterface, AgentSkill
+
+    mod = _load_migration_0240()
+
+    def _card_for(slug: str) -> AgentCard:
+        skills = [AgentSkill(**s) for s in mod._SKILLS[slug]]
+        return AgentCard(
+            name=slug,
+            description="test",
+            supported_interfaces=[
+                AgentInterface(url="http://x", protocol_binding="JSONRPC", protocol_version="1.0")
+            ],
+            version="0.1.0-poc",
+            capabilities=AgentCapabilities(),
+            default_input_modes=["text/plain"],
+            default_output_modes=["text/plain"],
+            skills=skills,
+        )
+
+    # 각 role의 tags 중 name에는 없는(순수 tag-only) 검색어로 매칭 확인.
+    assert _skill_matches(_card_for("qa-automation"), "test-automation")
+    assert _skill_matches(_card_for("backend"), "database")
+    assert _skill_matches(_card_for("frontend"), "react")
+    assert _skill_matches(_card_for("pm"), "roadmap")
+    # 교차 매칭은 없어야(qa 태그가 backend 카드엔 없음).
+    assert not _skill_matches(_card_for("backend"), "test-automation")
+
+
+# ── AC3/AC5: 실 Postgres — 백필 슬러그는 구조화, 그 외는 `[]` 그대로 ────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_backfilled_slugs_have_structured_skills_in_db():
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    engine = create_async_engine(_async_url())
+    try:
+        async with engine.connect() as conn:
+            rows = (await conn.execute(text(
+                "SELECT slug, skills FROM role_templates WHERE slug = ANY(:slugs)"
+            ), {"slugs": list(_BACKFILLED_SLUGS)})).mappings().all()
+        found = {r["slug"] for r in rows}
+        assert found == _BACKFILLED_SLUGS, f"백필 슬러그 일부 DB에 없음: {_BACKFILLED_SLUGS - found}"
+        empty = [r["slug"] for r in rows if not r["skills"]]
+        assert not empty, f"백필됐어야 할 슬러그가 여전히 빈 skills: {empty}"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_non_backfilled_slugs_remain_empty_skills():
+    """⛔범위 가드 — 전체 24 백필이 아니라 최소 셋만이라는 것을 실측으로 고정. 이 카운트가
+    24로 늘면(누군가 다른 마이그에서 전량 백필) 이 테스트가 빨개져 스코프 확대를 알린다."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    engine = create_async_engine(_async_url())
+    try:
+        async with engine.connect() as conn:
+            total = (await conn.execute(text("SELECT count(*) FROM role_templates"))).scalar_one()
+            non_empty = (await conn.execute(text(
+                "SELECT count(*) FROM role_templates WHERE skills != '[]'::jsonb"
+            ))).scalar_one()
+        assert total >= 24, f"role_templates seed 미적용?(count={total})"
+        assert non_empty == len(_BACKFILLED_SLUGS), (
+            f"skills 비어있지 않은 role_template 수={non_empty}, 기대={len(_BACKFILLED_SLUGS)} — "
+            "최소 백필 스코프를 벗어났을 수 있음(의도적이면 이 테스트도 같이 갱신)"
+        )
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
E-AGENT-ONBOARD·A2A발견 P1(스파이크 doc [e-a2a-discovery-spike-design](entity:doc:e7a23552-3f46-4164-a754-3729ad468778) 갭 D). `skills` 컬럼(`role_templates.py:69`, 0161이 "A2A 발견 키"로 도입)은 도입 이래 전 24개 seed 카탈로그가 `[]`째 방치돼 있어, `_build_agent_card`가 매번 persona.slug/name 파생 단일 skill로 폴백했다 — 오늘 모든 AgentCard의 skill이 예외 없이 1개짜리였다. 찰스 시나리오(#2584)가 `?skill=qa`로 QA 적임자를 발견하려면 최소한 `qa-automation` 카드에 구조화 skill이 있어야 한다.

- migration `0240`: `qa-automation`(AC1) + 이 팀의 실 채용 role과 가장 가까운 builtin 3종(`backend`/`frontend`/`pm`)만 백필 — 나머지 20개는 `[]` 그대로 (⛔전체 24 백필은 스코프 밖, 별도 스토리)
- `description`은 0156이 이미 seed한 문구를 그대로 재사용(신규 저작 아님). **`tags`(qa/testing 등)는 검색키로 새로 파생** — 완전 재구성은 아니라는 점을 승인 상신에 명시(페드루군 지적, 2026-08-12)
- 로컬 disposable pg(`pgvector/pgvector:pg16`)로 `upgrade head`/`downgrade` 왕복 확인(24 seed 무회귀, 백필 4종 외 전부 `[]` 그대로)

## [[no-pr-for-data]] 게이트 — 선생님 승인 완료
role_templates.skills는 콘텐츠 데이터라 0166/0167 선례와 동일 규칙 적용 대상이었음. **선생님 명시 승인 완료(2026-08-12, tags 파생 포함)** — ready로 전환.

## AC 대조
1. ✅ `qa-automation` skills 구조화 백필
2. ✅ 실사용 핵심 role(backend/frontend/pm) 최소 백필
3. ✅ `_build_agent_card`가 백필 role에서 구조화 skills 반환 확認(기존 mock 단위테스트가 분기 로직 자체는 이미 커버 — 이 PR은 실 데이터 내용을 realdb로 확認)
4. ✅ `?skill=` 필터가 tags/id에도 매치(name뿐 아니라) — 신규 테스트로 교차매칭 없음까지 확認
5. ✅ 마이그레이션 + 테스트(백필 vs 미백필 role 각각)
⛔ 범위: 전체 24 백필 아님(최소 4종). P0(#2597)와 독립 병렬.

## Test plan
- [x] `tests/test_2599_role_template_skills_backfill.py` 5/5 green(스키마 정합·skill-matches tags·realdb 백필/비백필)
- [x] `tests/test_a2a.py`·`test_e_recruit_s1_role_templates.py`·`test_e_recruit_s14_catalog_buildout.py`·`test_037a8aa8_agent_discoverability.py` 무회귀(65 passed)
- [x] alembic upgrade head / downgrade -1 로컬 disposable pg 왕복 확인
- [x] 선생님 명시 승인 (no-pr-for-data 게이트)
- [ ] 카디르 QA — 마이그 데이터 정합·pg upgrade/downgrade 왕복·`_build_agent_card` 폴백 대신 구조화 skills 반환·`?skill=` tags/id 매치
