### PR TITLE
promote: A2A 발견 축(#2597+#2599+#2598) 격리 승격 — 선생님 확認 대기

### DIFF
--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -375,21 +375,26 @@ Retry policy: 3 total attempts
 
 ### A2A Protocol (dev PoC)
 External [A2A](https://a2a-protocol.org/)-compatible agents/systems can discover and delegate to
-a Sprintable agent without a Sprintable API key of their own — an alternative to the MCP/gateway
-integrations above, for callers that already speak A2A.
+a Sprintable agent — an alternative to the MCP/gateway integrations above, for callers that
+already speak A2A. All A2A endpoints require the same Sprintable credential as every other
+endpoint in this doc (`Authorization: Bearer sk_live_...`), scoped to the caller's org.
 
 ```
-GET /api/v2/a2a/members/{member_id}/agent-card.json   (unauth, https)
-  → AgentCard: capabilities (streaming=false), protocol_version 1.0,
+GET /api/v2/a2a/members?skill=<query>                 (authed, org-scoped)
+  → list your org's agents as AgentCards; ?skill= matches a skill's id exactly,
+    or as a substring of its tag/name/description (case-insensitive)
+
+GET /api/v2/a2a/members/{member_id}/agent-card.json   (authed, org-scoped)
+  → AgentCard: capabilities (streaming=true), protocol_version 1.0,
     securitySchemes (Bearer), skills (from role_template, or persona-slug fallback)
 
 POST /api/v2/a2a/members/{member_id}/rpc               (JSON-RPC, org-scoped)
   SendMessage → creates an A2A Task, state=WORKING
   GetTask     → polls task state; reply-thread convention resolves it to
                 COMPLETED + artifact once the delegate replies in-thread
-  ListTasks   → implemented, live/SDK-verified pending
+  ListTasks   → implemented, live/SDK-verified
 
-Cross-org calls are rejected (IDOR-blocked, org-scoped auth on /rpc).
+Cross-org calls are rejected (IDOR-blocked, org-scoped auth on all three endpoints above).
 ```
 
 Verified in dev with the real `a2a-sdk`: discovery → SendMessage → delegate reply → GetTask
@@ -397,11 +402,13 @@ Verified in dev with the real `a2a-sdk`: discovery → SendMessage → delegate 
 carries an embedded completion hint (reply-thread id) so the delegate model can complete the
 round-trip — this makes completion **model-mediated**, not a deterministic server-side hook.
 
-**PoC-level, dev only — do not treat as GA:**
-- `streaming=false` (no SendStreamingMessage/SSE)
-- No `AUTH_REQUIRED` state/flow (Bearer is advertised but there's no challenge flow)
-- HITL (human-in-the-loop) gate integration is forward-work, not wired
-- Not yet served in production — dev-only endpoint
+**Still PoC-labeled (`AgentCard.version = "0.1.0-poc"`), not yet GA:**
+- `streaming=true` and `AUTH_REQUIRED` (via explicit delegate declaration, not automatic
+  detection) have shipped and are promoted to main
+- HITL gate integration is wired (explicit `linked_gate` declaration, not automatic detection)
+- Routes respond live in prod (confirmed: unauthenticated calls get 401, not 404 — the routes
+  exist), but the formal prod E2E validation pass hasn't landed — treat as reachable, not yet
+  fully validated
 
 ---
 

--- a/apps/web/public/onboarding-guide.txt
+++ b/apps/web/public/onboarding-guide.txt
@@ -391,12 +391,16 @@ Send a message into a conversation the agent belongs to; it arrives over SSE, an
 ## Alternative: A2A protocol (dev PoC)
 
 If your agent/system already speaks [A2A](https://a2a-protocol.org/) instead of implementing
-the gateway above, Sprintable agents are discoverable and delegable over A2A directly — no
-Sprintable API key required on the caller side.
+the gateway above, Sprintable agents are discoverable and delegable over A2A directly.
+Discovery and delegation both require the same Sprintable credential as everywhere else in this
+guide (`Authorization: Bearer sk_live_...`) and are scoped to the caller's org.
 
 ```
-GET  /api/v2/a2a/members/{member_id}/agent-card.json   — unauth AgentCard discovery
-POST /api/v2/a2a/members/{member_id}/rpc                — SendMessage / GetTask / ListTasks
+GET  /api/v2/a2a/members?skill=<query>                 — list your org's agents; ?skill= matches an
+                                                           AgentCard skill's id exactly, or as a substring
+                                                           of its tag/name/description (case-insensitive)
+GET  /api/v2/a2a/members/{member_id}/agent-card.json   — single-agent AgentCard (authed, same-org)
+POST /api/v2/a2a/members/{member_id}/rpc                — SendMessage / GetTask / ListTasks (authed, same-org)
 ```
 
 `SendMessage` creates a Task (`state=WORKING`); the delegate agent replies in the originating
@@ -405,8 +409,11 @@ round-trip (discovery → delegate → reply → completed) is verified in dev w
 `a2a-sdk`, fully automated — but completion is **model-mediated** (the delegate model reads an
 embedded reply-thread hint and acts on it; there's no deterministic completion hook).
 
-**Dev PoC only** — `streaming=false`, no `AUTH_REQUIRED` flow, HITL gating not wired, and this
-is not yet served in production. Don't rely on it as a stable integration surface yet.
+**Still labeled PoC** (`AgentCard.version = "0.1.0-poc"`) — `streaming`, `AUTH_REQUIRED`, and HITL
+gating (via explicit delegate declaration, not automatic detection) have since shipped and
+promoted to main; the routes respond live in prod (confirmed: unauthenticated calls get 401, not
+404 — the routes exist). Formal prod E2E validation hasn't landed yet, so treat this as reachable
+but not yet a fully validated, stable integration surface.
 
 ---
 

--- a/backend/alembic/versions/0240_role_templates_skills_minimal_backfill.py
+++ b/backend/alembic/versions/0240_role_templates_skills_minimal_backfill.py
@@ -1,0 +1,88 @@
+"""E-AGENT-ONBOARD·A2A발견 P1(story #2599, 문서 e-a2a-discovery-spike-design 갭 D):
+role_templates.skills 최소 백필 — qa-automation + 원 builtin 3종(backend/frontend/pm).
+
+Revision ID: 0240
+Revises: 0239
+Create Date: 2026-08-12
+
+[[no-pr-for-data]] 게이트: 이 마이그는 role_templates.skills(app.schemas.a2a.AgentSkill 형태,
+0161이 "A2A 발견 키"로 도입)에 실 콘텐츠를 채운다 — 데이터 마이그레이션이라 병합 前 선생님
+명시 승인 필요(0166/0167 선례와 동일 규칙).
+
+배경(#2584 스파이크 갭 D): skills 컬럼은 0161 도입 이래 전 24개 seed 카탈로그가 `[]`째
+방치돼 있었다 — `_build_agent_card`(app/routers/a2a.py:366)가 매번 persona.slug/name 파생
+단일 skill로 폴백해, 오늘 모든 AgentCard의 skill이 예외 없이 1개짜리였다. 찰스 시나리오
+(#2584)가 `?skill=qa`로 QA 적임자를 발견하려면 최소한 qa-automation 카드에 구조화 skill이
+있어야 한다 — 원 builtin 3종(backend/frontend/pm, 0156)도 같은 이유로 최소 백필한다(이
+팀의 실 채용 role과 가장 가까운 4종). 전체 24 카탈로그 백필은 스코프 밖(별도 스토리, ~300직군
+트랙 연계) — 여기서는 "발견 신호가 이름 문자열 하나뿐"이라는 갭만 최소로 해소한다.
+
+콘텐츠는 새로 짓지 않고 0156이 이미 seed한 role_templates.description을 AgentSkill(id/name/
+description/tags) shape로 재구성만 한다(신규 주장 0건 — 기존 승인된 카탈로그 문구 재사용).
+tags는 `_skill_matches`(a2a.py:459, name/description/tags substring)가 `?skill=` 매칭에
+쓰는 실 검색어 — 각 role의 실사용 관례 키워드로 채운다.
+"""
+from __future__ import annotations
+
+import json
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0240"
+down_revision = "0239"
+branch_labels = None
+depends_on = None
+
+_SKILLS: dict[str, list[dict]] = {
+    "qa-automation": [
+        {
+            "id": "qa-automation",
+            "name": "QA Automation Engineer",
+            "description": "테스트 자동화 구축과 회귀 방지를 자율적으로 운영하는 QA 자동화 엔지니어.",
+            "tags": ["qa", "testing", "test-automation", "regression", "quality-assurance"],
+        }
+    ],
+    "backend": [
+        {
+            "id": "backend",
+            "name": "Backend Engineer",
+            "description": "API·데이터 모델·서버 로직 구현을 자율적으로 운영하는 백엔드 엔지니어.",
+            "tags": ["backend", "api", "database", "server"],
+        }
+    ],
+    "frontend": [
+        {
+            "id": "frontend",
+            "name": "Frontend Engineer",
+            "description": "UI/UX 구현과 프론트엔드 버그 수정을 자율적으로 운영하는 프론트엔드 엔지니어.",
+            "tags": ["frontend", "ui", "ux", "react"],
+        }
+    ],
+    "pm": [
+        {
+            "id": "pm",
+            "name": "Product Manager",
+            "description": "스토리/에픽 기획과 스프린트·가설 운영을 자율적으로 운영하는 PM/PO.",
+            "tags": ["pm", "product", "planning", "roadmap"],
+        }
+    ],
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    for slug, skills in _SKILLS.items():
+        bind.execute(
+            sa.text("UPDATE role_templates SET skills = :skills WHERE slug = :slug"),
+            {"skills": json.dumps(skills), "slug": slug},
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    for slug in _SKILLS:
+        bind.execute(
+            sa.text("UPDATE role_templates SET skills = '[]'::jsonb WHERE slug = :slug"),
+            {"slug": slug},
+        )

--- a/backend/alembic/versions/0240_role_templates_skills_minimal_backfill.py
+++ b/backend/alembic/versions/0240_role_templates_skills_minimal_backfill.py
@@ -2,12 +2,16 @@
 role_templates.skills 최소 백필 — qa-automation + 원 builtin 3종(backend/frontend/pm).
 
 Revision ID: 0240
-Revises: 0239
+Revises: 0236 (prod 승격 재접합 — develop 원본은 0239. main엔 0228~0239 파일 자체가 없어
+  (결제 등 제외 커밋), 0236 파일 자신의 선례(develop 0235 → main 0227 재접합)와 동일 패턴으로
+  main 실제 head(0236)에 재접합했다. 콘텐츠(UPDATE 대상 role_templates.skills)는 develop판과
+  byte-identical — down_revision 한 줄만 다름)
 Create Date: 2026-08-12
 
 [[no-pr-for-data]] 게이트: 이 마이그는 role_templates.skills(app.schemas.a2a.AgentSkill 형태,
 0161이 "A2A 발견 키"로 도입)에 실 콘텐츠를 채운다 — 데이터 마이그레이션이라 병합 前 선생님
-명시 승인 필요(0166/0167 선례와 동일 규칙).
+명시 승인 필요(0166/0167 선례와 동일 규칙). develop판은 이미 승인 완료(PR#2993) — 이 prod
+승격은 그 승인된 콘텐츠를 그대로 옮기는 것뿐, 새 콘텐츠 승인 대상 아님.
 
 배경(#2584 스파이크 갭 D): skills 컬럼은 0161 도입 이래 전 24개 seed 카탈로그가 `[]`째
 방치돼 있었다 — `_build_agent_card`(app/routers/a2a.py:366)가 매번 persona.slug/name 파생
@@ -30,7 +34,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = "0240"
-down_revision = "0239"
+down_revision = "0236"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -105,6 +105,13 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # 가능해진다(pm/scrum-master 전용이던 걸 22개 role 전체로 확대 = 회귀 아닌 기능 추가).
     "sprintable_get_standup", "sprintable_save_standup", "sprintable_list_standup_entries",
     "sprintable_standup_history", "sprintable_standup_missing",
+    # story #2597(E-AGENT-ONBOARD·A2A발견 P0-1, 문서 e-a2a-discovery-spike-design 갭 A):
+    # list_agent_cards — sprintable_list_team_members와 동형(read-only·org-scope 로스터
+    # 조회) core 취급. "누구에게 청할지" 발견은 role_template.default_tool_groups 유무와
+    # 무관하게 어떤 role이든 필요한 cross-cutting 협업 유틸 — 여기 안 두면 대부분의
+    # 스코프 키가 이 도구를 403으로 못 본다. vendored 사본과 동기화 필수
+    # (sprintable_mcp/toolset.py).
+    "sprintable_list_agent_cards",
 })
 
 # scope 토큰: 그룹명 외에 read/write(레거시·전체 비파괴 의미), admin/destructive(파괴적 허용)
@@ -354,8 +361,8 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_update_hypothesis", "sprintable_link_hypothesis", "sprintable_confirm_hypothesis",
     # loops (E-LOOP-LEDGER P1-S12)
     "sprintable_get_loop_context",
-    # a2a HITL writer (E-A2A-완성 S-A3)
-    "sprintable_link_gate_to_task",
+    # a2a HITL writer (E-A2A-완성 S-A3) + 발견 (story #2597, E-AGENT-ONBOARD·A2A발견 P0-1)
+    "sprintable_link_gate_to_task", "sprintable_list_agent_cards",
     # evidence (E-VERIFY V0-S1)
     "sprintable_add_evidence",
     # 판단 칸 (story #2268, D단계)

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -28,7 +28,9 @@ from .schemas import SprintableInput
 # E-MCP S4: 독립 패키지 디탱글 — backend(app/*) import 제거. 규칙은 vendored .toolset 사용
 # (백엔드 app/services/mcp_toolset.py와 동일 규칙 유지·SSOT는 백엔드 매니페스트).
 from .toolset import is_tool_allowed
-from .tools.a2a import LinkGateToTaskInput, link_gate_to_task
+from .tools.a2a import (
+    LinkGateToTaskInput, ListAgentCardsInput, link_gate_to_task, list_agent_cards,
+)
 from .tools.evidence import AddEvidenceInput, add_evidence
 from .tools.judgments import AddJudgmentInput, ListJudgmentsInput, add_judgment, list_judgments
 from .tools.session_context import SessionContextInput, get_session_context
@@ -625,6 +627,13 @@ _TOOL_DEFS: list[tuple] = [
      "이 gate가 이 A2A task를 블록한다고 명시 선언 — 외부 GetTask가 INPUT_REQUIRED로 승격되고,"
      " 사람이 gate를 승인/거부하면 task가 자동으로 WORKING/REJECTED 복귀한다.",
      LinkGateToTaskInput, link_gate_to_task),
+    # A2A 발견 (1) — E-AGENT-ONBOARD·A2A발견 P0-1(story #2597)
+    ("sprintable_list_agent_cards",
+     "org 내 활성 agent 전원의 A2A AgentCard 열거 — «누구에게 청할지» 발견. optional"
+     " skill(예: \"qa\")로 필터해 적임자 후보만 조회. 지시받지 않은 담당자를 스스로 찾아"
+     " 위임할 때(예: PR 완료 후 QA 담당 조회) 이 도구로 먼저 발견한 뒤"
+     " sprintable_send_chat_message로 청한다.",
+     ListAgentCardsInput, list_agent_cards),
     # Evidence 자기증명 (1) — E-VERIFY V0-S1
     ("sprintable_add_evidence",
      "done을 스스로 증명하는 자기 서명 첨부(PR·배포·지표·발행물 링크 등) — story/task에 evidence"

--- a/backend/sprintable_mcp/tools/a2a.py
+++ b/backend/sprintable_mcp/tools/a2a.py
@@ -1,4 +1,12 @@
-"""A2A HITL writer MCP 도구 (1개) — E-A2A-완성 S-A3(story 6d0454c3) + S-A5(story c140977f)."""
+"""A2A MCP 도구(2개) — E-A2A-완성 S-A3(story 6d0454c3) + S-A5(story c140977f) +
+E-AGENT-ONBOARD·A2A발견 P0-1(story #2597, 문서 e-a2a-discovery-spike-design 갭 A).
+
+story #2597: 발견 도구(list_agent_cards) 신설 전엔 이 파일에 `link_gate_to_task` 1개뿐이었다
+— `GET /api/v2/a2a/members`(백엔드 `app/routers/a2a.py:471`, story 5578a8e2 S3)는 이미
+org 내 활성 agent 전원의 AgentCard(+`?skill=` 필터)를 정확히 반환하는데, 이를 감싸는 MCP
+도구가 없어 MCP만 쓰는 에이전트는 "누가 QA인지" 같은 발견을 할 방법이 구조적으로 없었다
+(스파이크 doc 갭 A). 백엔드 라우터/스키마는 변경하지 않는다 — 이미 spec 정합(story 480e81fb).
+"""
 from __future__ import annotations
 
 from mcp.types import TextContent
@@ -29,6 +37,30 @@ async def link_gate_to_task(args: LinkGateToTaskInput) -> list[TextContent]:
             f"/api/v2/a2a/tasks/{args.task_id}/link-gate",
             json=payload,
         )
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))
+
+
+class ListAgentCardsInput(SprintableInput):
+    # story #2597 AC3: 서버측 `_skill_matches`(a2a.py) 로 그대로 전달 — id/tags/name/
+    # description 부분일치(대소문자 무시). 생략 시 org 내 활성 agent 전원 반환.
+    skill: str | None = None
+
+
+async def list_agent_cards(args: ListAgentCardsInput) -> list[TextContent]:
+    """지금 이 org에서 "누구에게 청할지" 발견한다 — org 내 활성 agent 전원의 A2A AgentCard
+    (표준 규격: name/skills/security 등)를 열거한다. `skill`을 주면(예: "qa", "backend")
+    서버가 각 카드의 skill id/name/description/tags를 부분일치로 걸러 후보만 돌려준다 —
+    "이 작업엔 누가 적임자인가"를 사람이 미리 알려주지 않아도 스스로 찾을 때 쓴다(예: PR을
+    올린 뒤 QA 담당을 모를 때 `skill="qa"`로 조회해 반환된 member_id에게
+    sprintable_send_chat_message 로 청한다). 자기 자신의 크리덴셜(org 스코프)로만 조회되며,
+    타 org의 카드는 보이지 않는다."""
+    try:
+        params: dict = {}
+        if args.skill:
+            params["skill"] = args.skill
+        result = await client.get("/api/v2/a2a/members", params=params or None)
         return ok(result)
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/toolset.py
+++ b/backend/sprintable_mcp/toolset.py
@@ -89,6 +89,12 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # app/services/mcp_toolset.py 참고 — role_template 특정 대신 범용 업무로 core 승격).
     "sprintable_get_standup", "sprintable_save_standup", "sprintable_list_standup_entries",
     "sprintable_standup_history", "sprintable_standup_missing",
+    # story #2597(E-AGENT-ONBOARD·A2A발견 P0-1): list_agent_cards — sprintable_list_team_members와
+    # 동형(read-only·org-scope 로스터 조회) core 취급. 특정 역할의 default_tool_groups 유무와
+    # 무관하게 "누구에게 청할지" 발견은 어떤 role이든 필요한 cross-cutting 협업 유틸이라 여기
+    # 안 두면 스코프 키(대부분의 role_template)에서 403으로 안 보인다. 백엔드 SSOT와 동기화
+    # (app/services/mcp_toolset.py).
+    "sprintable_list_agent_cards",
 })
 
 _LEGACY_SCOPES: frozenset[str] = frozenset({"read", "write"})

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -91,6 +91,8 @@ EXPECTED_TOOLS = {
     "sprintable_lock_files", "sprintable_unlock_files",
     # a2a HITL writer (1) — E-A2A-완성 S-A3
     "sprintable_link_gate_to_task",
+    # a2a 발견 (1) — E-AGENT-ONBOARD·A2A발견 P0-1(story #2597)
+    "sprintable_list_agent_cards",
     # evidence (1) — E-VERIFY V0-S1
     "sprintable_add_evidence",
     # 판단 칸 (2) — story #2268(D단계, E-CONNECT)
@@ -121,7 +123,9 @@ def test_total_tool_count():
     # 전용) — 112→113. story #2268(D단계): sprintable_add_judgment/list_judgments 2종 신설
     # (판단 칸 pull 진입점 MCP 노출) — 113→115. story #2268(C-10): sprintable_get_session_context
     # 1종 신설(세션 시작 컨텍스트 REST를 MCP로 노출 — PO 판정: REST뿐이면 못 쓴다) — 115→116.
-    assert len(_TOOLS) == 116
+    # story #2597(E-AGENT-ONBOARD·A2A발견 P0-1): sprintable_list_agent_cards 1종 신설
+    # (A2A AgentCard 발견 — 「누구에게 청할지」를 스스로 찾는 MCP 도구) — 116→117.
+    assert len(_TOOLS) == 117
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_2412_mcp_unknown_arg_rejection.py
+++ b/backend/tests/test_2412_mcp_unknown_arg_rejection.py
@@ -69,12 +69,13 @@ async def test_registered_standup_history_tool_still_accepts_known_args():
 
 
 def test_all_registered_tools_share_the_same_lockdown():
-    """AC2 카운트 — `_TOOL_DEFS` 115개 + ping 1개 = 116개 전부 arg_model이 extra=forbid로
-    잠겨 있어야 한다(상속 갈래 SprintableInput/BaseModel 안 가리고 전부)."""
+    """AC2 카운트 — `_TOOL_DEFS` 116개 + ping 1개 = 117개(story #2597: list_agent_cards 추가로
+    115→116) 전부 arg_model이 extra=forbid로 잠겨 있어야 한다(상속 갈래 SprintableInput/
+    BaseModel 안 가리고 전부)."""
     from sprintable_mcp import server as srv
 
     tools = srv.mcp._tool_manager.list_tools()
-    assert len(tools) == 116
+    assert len(tools) == 117
     unlocked = [
         t.name for t in tools
         if t.fn_metadata.arg_model.model_config.get("extra") != "forbid"

--- a/backend/tests/test_2597_mcp_list_agent_cards.py
+++ b/backend/tests/test_2597_mcp_list_agent_cards.py
@@ -1,0 +1,111 @@
+"""story #2597(E-AGENT-ONBOARD·A2A발견 P0-1, 문서 e-a2a-discovery-spike-design 갭 A):
+MCP sprintable_list_agent_cards — GET /api/v2/a2a/members 래퍼(순수 배선, 신규 백엔드
+로직 없음). AC1(도구 존재)·AC3(skill 필터 전달)·AC5(unit test)를 이 파일이 커버한다.
+AC2(agent 크리덴셜 org 스코프)는 기존 client 인증 배선을 그대로 타므로 재검증 대상 아님
+(client.get이 이미 sk_live_ Bearer를 항상 싣는다, 다른 모든 MCP 도구와 동형)."""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_list_agent_cards_without_skill_calls_bare_endpoint():
+    from sprintable_mcp.tools.a2a import ListAgentCardsInput, list_agent_cards
+
+    cards = [
+        {"name": "카디르", "skills": [{"id": "qa-automation", "name": "QA Automation 엔지니어",
+                                       "description": "...", "tags": []}]},
+    ]
+    calls: list[tuple[str, dict | None]] = []
+
+    async def fake_get(path, params=None):
+        calls.append((path, params))
+        return cards
+
+    with patch("sprintable_mcp.tools.a2a.client") as mock_client:
+        mock_client.get = AsyncMock(side_effect=fake_get)
+        out = await list_agent_cards(ListAgentCardsInput())
+
+    assert calls == [("/api/v2/a2a/members", None)]
+    parsed = json.loads(out[0].text)
+    assert parsed == cards
+
+
+@pytest.mark.anyio
+async def test_list_agent_cards_with_skill_passes_filter_param():
+    from sprintable_mcp.tools.a2a import ListAgentCardsInput, list_agent_cards
+
+    calls: list[tuple[str, dict | None]] = []
+
+    async def fake_get(path, params=None):
+        calls.append((path, params))
+        return []
+
+    with patch("sprintable_mcp.tools.a2a.client") as mock_client:
+        mock_client.get = AsyncMock(side_effect=fake_get)
+        await list_agent_cards(ListAgentCardsInput(skill="qa"))
+
+    assert calls == [("/api/v2/a2a/members", {"skill": "qa"})]
+
+
+@pytest.mark.anyio
+async def test_list_agent_cards_empty_skill_string_treated_as_no_filter():
+    """빈 문자열("")은 필터 의도가 아니다 — None과 동일하게 취급(서버 쿼리파람 오염 방지)."""
+    from sprintable_mcp.tools.a2a import ListAgentCardsInput, list_agent_cards
+
+    calls: list[tuple[str, dict | None]] = []
+
+    async def fake_get(path, params=None):
+        calls.append((path, params))
+        return []
+
+    with patch("sprintable_mcp.tools.a2a.client") as mock_client:
+        mock_client.get = AsyncMock(side_effect=fake_get)
+        await list_agent_cards(ListAgentCardsInput(skill=""))
+
+    assert calls == [("/api/v2/a2a/members", None)]
+
+
+@pytest.mark.anyio
+async def test_list_agent_cards_error_surfaces():
+    from sprintable_mcp.tools.a2a import ListAgentCardsInput, list_agent_cards
+
+    with patch("sprintable_mcp.tools.a2a.client") as mock_client:
+        mock_client.get = AsyncMock(side_effect=Exception("401 Unauthorized"))
+        out = await list_agent_cards(ListAgentCardsInput())
+
+    assert "error" in out[0].text.lower()
+
+
+def test_tool_registered_in_mcp_server():
+    from sprintable_mcp.server import _TOOL_DEFS
+
+    names = {name for name, *_ in _TOOL_DEFS}
+    assert "sprintable_list_agent_cards" in names
+
+
+def test_tool_always_allowed_regardless_of_scoped_key():
+    """role_template.default_tool_groups가 이 도구의 그룹을 안 가진 스코프 키(예: qa-automation의
+    ["stories","tasks","chat","docs","retro"])로도 호출 가능해야 한다 — 「누구에게 청할지」
+    발견은 어떤 role이든 필요한 cross-cutting 유틸이라 _ALWAYS_ALLOWED(core) 취급이 필수."""
+    from app.services.mcp_toolset import is_tool_allowed
+
+    narrow_scope = ["stories", "tasks", "chat", "docs", "retro"]
+    assert is_tool_allowed("sprintable_list_agent_cards", narrow_scope) is True
+
+
+def test_backend_and_vendored_toolset_stay_in_sync():
+    from app.services import mcp_toolset as backend
+    from sprintable_mcp import toolset as vendored
+
+    assert "sprintable_list_agent_cards" in backend._ALWAYS_ALLOWED
+    assert "sprintable_list_agent_cards" in vendored._ALWAYS_ALLOWED
+    assert "sprintable_list_agent_cards" in backend.ALL_TOOL_NAMES

--- a/backend/tests/test_2599_role_template_skills_backfill.py
+++ b/backend/tests/test_2599_role_template_skills_backfill.py
@@ -1,0 +1,140 @@
+"""story #2599(E-AGENT-ONBOARD·A2A발견 P1, 문서 e-a2a-discovery-spike-design 갭 D):
+role_templates.skills 최소 백필(qa-automation + backend/frontend/pm) 검증.
+
+realdb 파트는 DB env 없으면 skip(0166 realdb 패턴과 동형). 순수 SELECT — destructive_schema
+마커 사용 금지(0163 CI 회귀 교훈).
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+_BACKFILLED_SLUGS = {"qa-automation", "backend", "frontend", "pm"}
+
+
+def _load_migration_0240():
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "alembic" / "versions" / "0240_role_templates_skills_minimal_backfill.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_0240", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+# ── AC1/AC2: 콘텐츠 형태 — AgentSkill 스키마 정합 ──────────────────────────────
+
+def test_migration_skills_cover_exactly_the_minimal_set():
+    mod = _load_migration_0240()
+    assert set(mod._SKILLS.keys()) == _BACKFILLED_SLUGS
+
+
+def test_migration_skills_validate_as_agent_skill():
+    from app.schemas.a2a import AgentSkill
+
+    mod = _load_migration_0240()
+    for slug, skills in mod._SKILLS.items():
+        assert len(skills) >= 1, f"{slug}: skills 비어있음"
+        for raw in skills:
+            skill = AgentSkill(**raw)
+            assert skill.id, f"{slug}: id 비어있음"
+            assert skill.name, f"{slug}: name 비어있음"
+            assert skill.tags, f"{slug}: tags 비어있음(발견 매칭 재료 없음)"
+
+
+# ── AC4: `?skill=` 필터가 구조화 skills의 tags/id에도 매치(name뿐 아니라) ────────────
+
+def test_skill_filter_matches_via_tags_not_just_name():
+    """`_skill_matches`(a2a.py)는 name/description/tags substring OR 매칭이다 — 백필된
+    tags로만 검색해도(예: qa-automation은 name에 "test-automation"이 없음) 걸려야 한다."""
+    from app.routers.a2a import _skill_matches
+    from app.schemas.a2a import AgentCapabilities, AgentCard, AgentInterface, AgentSkill
+
+    mod = _load_migration_0240()
+
+    def _card_for(slug: str) -> AgentCard:
+        skills = [AgentSkill(**s) for s in mod._SKILLS[slug]]
+        return AgentCard(
+            name=slug,
+            description="test",
+            supported_interfaces=[
+                AgentInterface(url="http://x", protocol_binding="JSONRPC", protocol_version="1.0")
+            ],
+            version="0.1.0-poc",
+            capabilities=AgentCapabilities(),
+            default_input_modes=["text/plain"],
+            default_output_modes=["text/plain"],
+            skills=skills,
+        )
+
+    # 각 role의 tags 중 name에는 없는(순수 tag-only) 검색어로 매칭 확인.
+    assert _skill_matches(_card_for("qa-automation"), "test-automation")
+    assert _skill_matches(_card_for("backend"), "database")
+    assert _skill_matches(_card_for("frontend"), "react")
+    assert _skill_matches(_card_for("pm"), "roadmap")
+    # 교차 매칭은 없어야(qa 태그가 backend 카드엔 없음).
+    assert not _skill_matches(_card_for("backend"), "test-automation")
+
+
+# ── AC3/AC5: 실 Postgres — 백필 슬러그는 구조화, 그 외는 `[]` 그대로 ────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_backfilled_slugs_have_structured_skills_in_db():
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    engine = create_async_engine(_async_url())
+    try:
+        async with engine.connect() as conn:
+            rows = (await conn.execute(text(
+                "SELECT slug, skills FROM role_templates WHERE slug = ANY(:slugs)"
+            ), {"slugs": list(_BACKFILLED_SLUGS)})).mappings().all()
+        found = {r["slug"] for r in rows}
+        assert found == _BACKFILLED_SLUGS, f"백필 슬러그 일부 DB에 없음: {_BACKFILLED_SLUGS - found}"
+        empty = [r["slug"] for r in rows if not r["skills"]]
+        assert not empty, f"백필됐어야 할 슬러그가 여전히 빈 skills: {empty}"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_non_backfilled_slugs_remain_empty_skills():
+    """⛔범위 가드 — 전체 24 백필이 아니라 최소 셋만이라는 것을 실측으로 고정. 이 카운트가
+    24로 늘면(누군가 다른 마이그에서 전량 백필) 이 테스트가 빨개져 스코프 확대를 알린다."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    engine = create_async_engine(_async_url())
+    try:
+        async with engine.connect() as conn:
+            total = (await conn.execute(text("SELECT count(*) FROM role_templates"))).scalar_one()
+            non_empty = (await conn.execute(text(
+                "SELECT count(*) FROM role_templates WHERE skills != '[]'::jsonb"
+            ))).scalar_one()
+        assert total >= 24, f"role_templates seed 미적용?(count={total})"
+        assert non_empty == len(_BACKFILLED_SLUGS), (
+            f"skills 비어있지 않은 role_template 수={non_empty}, 기대={len(_BACKFILLED_SLUGS)} — "
+            "최소 백필 스코프를 벗어났을 수 있음(의도적이면 이 테스트도 같이 갱신)"
+        )
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_mcp_axis_prefix_b_surface.py
+++ b/backend/tests/test_mcp_axis_prefix_b_surface.py
@@ -23,6 +23,9 @@ _CORE_NO_PREFIX = {
     "sprintable_add_evidence", "sprintable_list_projects", "sprintable_set_default_project",
     "sprintable_add_judgment", "sprintable_list_judgments",
     "sprintable_get_session_context",
+    # story #2597: list_agent_cards — mcp_toolset.py _ALWAYS_ALLOWED와 동기화(core 취급 사유는
+    # 거기 주석 참조 — 어떤 role이든 필요한 cross-cutting 발견 유틸, 단일 축 아님).
+    "sprintable_list_agent_cards",
 }
 
 
@@ -45,7 +48,7 @@ def test_core_tools_have_no_axis_prefix():
 
 
 def test_bidirectional_coverage_no_silent_gap():
-    """전체 106개 중 core 제외 전부가 프리픽스 대상 — 한쪽만 확인하면 신규 툴 누락을 못 잡는다."""
+    """전체 도구 중 core 제외 전부가 프리픽스 대상 — 한쪽만 확인하면 신규 툴 누락을 못 잡는다."""
     prefixed = {n for n, d in _TOOLS.items() if d.startswith(_VALID_PREFIXES)}
     expected_prefixed = set(_TOOLS.keys()) - _CORE_NO_PREFIX
     assert prefixed == expected_prefixed
@@ -68,6 +71,7 @@ def test_tool_names_and_param_models_untouched():
     sprintable_delete_artifact 1종 신설(artifact soft delete, 생성자 전용) — 111→112. story #2268
     (D단계): sprintable_add_judgment/list_judgments 2종 신설(판단 칸 pull 진입점) — 112→114.
     story #2268(C-10): sprintable_get_session_context 1종 신설(세션 시작 컨텍스트 MCP 노출) —
-    114→115."""
-    assert len(_TOOL_DEFS) == 115
+    114→115. story #2597(E-AGENT-ONBOARD·A2A발견 P0-1): sprintable_list_agent_cards 1종
+    신설(A2A AgentCard 발견) — 115→116."""
+    assert len(_TOOL_DEFS) == 116
     assert all(name.startswith("sprintable_") for name in _TOOLS)


### PR DESCRIPTION
## Summary
develop→main 선별 승격. 계획 doc: [A2A 발견 축 격리 prod 배포 계획](entity:doc:50668684-7dc2-4fce-90a2-82b01d6a355e) — 페드루군 리뷰+승인 완료(2026-08-12).

**cherry-pick 3건, 원본 대비 diff 0(순수 cherry-pick), 충돌 0건:**
- `3b5e0ef1` — feat(#2597): MCP 발견 도구 신설 (원본 PR#2991)
- `bb1c517e` — feat(#2599): role_templates.skills 최소 백필 (원본 PR#2993, [[no-pr-for-data]] 승인 완료)
- `187f37a5` — docs(#2598): A2A discovery endpoint 문서화 + unauth/PoC stale 정정 (원본 PR#2992)

**추가 수정 1건(이 PR에서만)**: `0240` 마이그 `down_revision`을 develop 원본(`0239`)에서 main 실제 head(`0236`)로 재접합. main엔 0228~0239 파일 자체가 없음(결제 등 제외 커밋) — 0236 파일 자신의 선례(develop 0235 → main 0227 재접합)와 동일 패턴. **콘텐츠(UPDATE 대상 role_templates.skills)는 develop판과 byte-identical**, down_revision 한 줄만 다름.

#2600(찰스 e2e realdb 테스트)은 배포 대상 아님 — 테스트 코드는 이미지에 안 들어감, 이 PR에 포함 안 함.

## 검증(로컬, prod 접근 0회)
- `alembic upgrade head` — 로컬 disposable Postgres(pgvector/pgvector:pg16)에서 0227→0236→0240 clean 적용, 백필 데이터(qa-automation/backend/frontend/pm=구조화, 나머지=`[]`) 확認.
- 타겟 스위트(`test_a2a.py`·`test_mcp/test_contract.py`·`test_mcp_axis_prefix_b_surface.py`·`test_2412_mcp_unknown_arg_rejection.py`·`test_s2311_vendor_const_sync.py`·`test_2597_mcp_list_agent_cards.py`·`test_2599_role_template_skills_backfill.py`) — **104 passed**.
- 전체 non-realdb 스위트(4511개) — 11 failed·4511 passed. 그 11건 전부 vanilla `origin/main`(이 PR 무관)에서 동일 재현 확인(별도 worktree 대조) — 이 PR이 만든 신규 실패 0건.
- 라이브 curl: `https://sprintable-backend-prod-.../api/v2/a2a/members` → 401(UNAUTHORIZED) — 이미 서빙 중인 라우트 확인.

## 배포 경로(참고 — cloudbuild.yaml 실측)
main merge → `cloud-build.yml`(push:main) → `cloudbuild.yaml`: DB마이그(`run-migrate-job`, fail-closed) → backend 배포 → **MCP 자동 재태깅**(story #2426, 2026-08-02부로 자동화) → frontend 배포. 별도 수동 인프라 스텝 없음, 새 env var 0건.

## Test plan
- [x] cherry-pick 충돌 0건 확認
- [x] 0240 down_revision 재접합 + 로컬 마이그 왕복 확認
- [x] 타겟 스위트 104 passed
- [x] 전체 스위트 신규 실패 0건(vanilla main 대조)
- [x] 라이브 401 curl로 기존 라우트 서빙 확認
- [ ] 카디르 QA — cherry-pick이 원본 3 PR과 내용 동일한지·0240 재접합 안전한지·A2A 3커밋 외 안 딸리는지·llms-full.txt A2A 절만 변경인지
- [ ] 선생님 최종 확認(merge=배포는 페드루군)

⚠️draft 유지 — 선생님 확認 전 merge 보류.