### PR TITLE
fix(#2602): 429-rejected agent stream requests no longer leak per-key dict entries

### DIFF
--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -432,8 +432,13 @@ async def agent_stream(
     from app.services import sse_lease
     _lease_conn_id = str(uuid.uuid4())
     _pk_lease = await sse_lease.acquire(f"perkey:{agent_id_str}", _per_key_limit, _lease_conn_id)
+    # story #2602: `_agent_connections`는 defaultdict(set) — `[...]` 서브스크립트는 키가 없으면
+    # 빈 set을 **만들면서** 반환한다. 이 줄은 판정(길이 체크)일 뿐인데 거부(429)로 끝나는 요청도
+    # 매번 agent_id 하나를 이 dict에 영구 등록해버렸다("거부가 자원을 만드는" 결함 — len에는
+    # 무해(빈 set)지만 한 번이라도 한도초과 조회를 겪은 모든 agent_id가 dict key로 영구 잔류).
+    # `.get(..., ())` 로 조회를 read-only로 고정 — 존재하는 키만 세션 등록 시 만들어진다(L471).
     if _pk_lease is False or (
-        _pk_lease is None and len(_agent_connections[agent_id_str]) >= _per_key_limit
+        _pk_lease is None and len(_agent_connections.get(agent_id_str, ())) >= _per_key_limit
     ):
         # story #2582: flat _AGENT_STREAM_RETRY_AFTER(기본 5s)는 orphan lease(비정상 종료 —
         # kill -9 등으로 finally/release가 안 돈 연결)의 실제 자가회수 시한(sse_lease._TTL_SEC,

--- a/backend/app/services/sse_lease.py
+++ b/backend/app/services/sse_lease.py
@@ -7,6 +7,16 @@ per-key `len(_agent_connections[...])`)를 Redis ZSET 으로 공유 → 멀티�
   scope 예: "events_global"(브라우저 /events/stream 전역)·"agent_global"(/agent/stream 전역)·"perkey:{agent_id}".
 ⭐**TTL 주경로**: 좀비 연결(refresh 끊김)은 score 지나면 count 에서 자동 evict → #2128(disconnect 미감지·
   finally 미실행) 을 부분 완화(현재는 리퍼가 전혀 없어 3600s 까지 점유). 명시 release(finally)는 최적화.
+⚠️story #2602(2026-08-13, dev 라이브 재현): 위 "TTL 주경로"는 **refresh 가 실제로 멈춘 경우에만** 성립한다
+  — refresh(`agent_gateway.py` 30초 틱)는 `request.is_disconnected()` 로 게이트되는 같은 루프 안에서
+  돌고, 그 판정 자체가 이 코드베이스에서 이미 여러 번(#2183·까심 AC6) 불신뢰로 확認됐다. **클라가 죽었는데
+  서버가 그걸 못 알아챈 orphan**은 refresh 도 안 멈춘다 — 매 30초 틱마다 자기 lease 를 스스로 갱신해
+  `_TTL_SEC`(90초) 만료가 영영 안 온다. 이 실패군에서 실제 상한선은 이 TTL 이 아니라
+  `agent_gateway._AGENT_SSE_LIFESPAN_SEC`(+jitter, 기본 ~300~330초) 능동 종료뿐이다(disconnect 감지와
+  무관하게 발동 — #2128 참조). Retry-After 계산(`earliest_expiry`)이 "방금 갱신된 live" 구간을 만나면
+  flat default 로 폴백하는 것(#2582 PO 리뷰, 2026-08-12)은 **의도된 그대로**다 — 그 순간엔 live 세션과
+  이 orphan 을 스코어만으로 구분할 수 없어서다(구분 시도가 오히려 다른 세션의 빠른 정상종료를 못 보게
+  만든다). 그러니 이 TTL 을 "90초 안에 자연 회수"로 신뢰하지 말 것 — 실제 정직한 상한은 lifespan cap.
 ⭐**원자성**: check(evict+ZCARD)+조건부 ZADD 를 **Lua 1스크립트**로 실행(TOCTOU 방지 — 동시 acquire 가
   둘 다 count<limit 을 보고 초과 획득하는 것 차단).
 

--- a/backend/tests/test_2602_sse_lease_lifespan_reclaim.py
+++ b/backend/tests/test_2602_sse_lease_lifespan_reclaim.py
@@ -1,0 +1,170 @@
+"""story #2602: 「에이전트 로컬 프로세스 정상·하트비트 송신 중인데 웹 UI 오프라인 노출 +
+채팅 무응답」 진단에서 dev 라이브로 재현된 실패군을 고정한다.
+
+재현(2026-08-13, 은두카쿠·backend-dev 직접 curl): per-key SSE 슬롯(free=3)을 채운 뒤 client를
+kill -9(정상 종료 시퀀스 없이 종료 — 크래시 모사)하면, sse_lease.py 문서가 약속하는 90초
+TTL 자가회수가 지나도(115초 시점에도) 재접속이 계속 429였다. 원인 — refresh(30초 틱)가
+`request.is_disconnected()`로 게이트된 같은 루프 안에서 돌기 때문에, 클라가 죽었는데 서버가
+그걸 못 알아챈 orphan은 refresh도 안 멈춘다(매 틱마다 스스로 lease를 갱신) — 그래서 이
+실패군의 진짜 상한은 `sse_lease._TTL_SEC`(90초)가 아니라 disconnect 감지와 무관하게 발동하는
+`agent_gateway._AGENT_SSE_LIFESPAN_SEC`(+jitter, 기본 ~300~330초) 능동 종료뿐이다(#2128 본체).
+
+이 파일은 그 경로 — "TTL이 아니라 lifespan cap이 실제 회수 축" — 를 real PG(AgentGatewaySession
+등 generate() 내부 write 전부와 patch 없이) + fakeredis(sse_lease 실경로) 조합으로 처음 고정한다.
+기존 test_2128_sse_lifespan_cap.py는 lifespan cap이 카운터/세션row/큐를 정리하는 것만 검증했고
+sse_lease(Redis 공유 lease)는 건드리지 않았다 — 기존 test_2582_*.py는 반대로 sse_lease의 TTL
+자연만료(score를 과거로 조작)만 검증했고 lifespan-cap이 강제 종료하는 경로는 없었다. 이 갭을 닫는다.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+def _flag_on_fakeredis():
+    aioredis = pytest.importorskip("fakeredis.aioredis")
+    pytest.importorskip("lupa")
+    from app.services import sse_lease
+
+    server = aioredis.FakeServer()
+    client = aioredis.FakeRedis(server=server, decode_responses=True)
+    with patch.object(sse_lease.settings, "sse_lease_redis_enabled", True), \
+         patch.object(sse_lease.settings, "redis_url", "redis://fake"), \
+         patch("app.services.redis_shared.get_client", return_value=client):
+        yield client
+
+
+class _NeverDisconnects:
+    """story #2128 패턴 재사용 — is_disconnected()가 영원히 False. kill -9 후에도 ASGI 계층이
+    클라 사망을 못 알아채는 실측 상황(#2183·까심 AC6)의 결정론적 재현."""
+    headers: dict = {}
+
+    async def is_disconnected(self) -> bool:
+        return False
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project_agent(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.team import TeamMember
+
+    org = Organization(id=uuid.uuid4(), name="Org2602", slug=f"org2602-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    agent = TeamMember(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id, type="agent", name="agent",
+        is_active=True,
+    )
+    session.add(agent)
+    await session.commit()
+    return org.id, project.id, agent.id
+
+
+@pytest.mark.anyio
+@pytest.mark.destructive_schema
+@pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+async def test_undetected_orphan_reclaims_sse_lease_via_lifespan_cap_not_ttl(monkeypatch, _flag_on_fakeredis):
+    """핵심 회귀가드 — disconnect가 영영 감지 안 되는(kill -9 모사) 연결도, TTL(90s) 자연만료를
+    기다릴 필요 없이 lifespan cap(disconnect 감지와 무관하게 발동)이 끝나면 sse_lease per-key
+    lease가 실제로 release()되고, 그 즉시 같은 키의 새 연결이 성공한다."""
+    import app.routers.agent_gateway as gw_module
+    from app.services import sse_lease
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, agent_id = await _seed_org_project_agent(s)
+        agent_id_str = str(agent_id)
+        scope = f"perkey:{agent_id_str}"
+
+        auth_ctx = MagicMock()
+        auth_ctx.user_id = agent_id_str
+        auth_ctx.claims = {"app_metadata": {"api_key_id": "test-key"}}
+
+        @asynccontextmanager
+        async def _factory():
+            async with Session() as s:
+                yield s
+
+        with patch("app.core.database.async_session_factory", _factory), \
+             patch.object(gw_module, "_SSE_HEARTBEAT", 0.02), \
+             patch.object(gw_module, "_AGENT_SSE_LIFESPAN_SEC", 0.05), \
+             patch.object(gw_module, "_AGENT_SSE_LIFESPAN_JITTER_SEC", 0.0), \
+             patch("app.services.onboarding_funnel.emit_onboarding_event", AsyncMock()):
+
+            # 1) orphan 연결 하나를 생성 — is_disconnected()가 절대 False를 안 벗어나므로
+            #    (kill -9 후 서버가 클라 사망을 못 알아챈 상태와 동형) 오직 lifespan cap만이
+            #    이 연결을 끝낼 수 있다.
+            response = await gw_module.agent_stream(request=_NeverDisconnects(), auth=auth_ctx)
+
+            # 이 연결이 실제로 sse_lease를 잡았는지 먼저 확認(선행조건 — 안 잡았으면 이하 검증 무의미).
+            held_before = await sse_lease.count(scope)
+            assert held_before == 1, f"연결이 sse_lease를 획득 못함(held={held_before}) — 테스트 전제 붕괴"
+
+            started = time.monotonic()
+            saw_lifespan_event = False
+            async for chunk in response.body_iterator:
+                if "lifespan_reconnect" in chunk:
+                    saw_lifespan_event = True
+            elapsed = time.monotonic() - started
+
+        assert saw_lifespan_event, "disconnect 미감지 상태에서도 lifespan cap이 발동해야(#2128 본체)"
+        assert elapsed < 5.0, f"lifespan cap 반응이 너무 느림({elapsed}s)"
+
+        # 2) 회수 확認 — TTL(90s) 자연만료를 기다린 게 아니라(테스트는 <5s 안에 끝났다),
+        #    lifespan cap이 finally를 타고 sse_lease.release()를 실제로 호출한 것.
+        await asyncio.sleep(0.05)
+        held_after = await sse_lease.count(scope)
+        assert held_after == 0, (
+            f"lifespan cap 종료 후에도 sse_lease가 안 풀림(held={held_after}) — "
+            "disconnect 미감지 orphan이 영구 슬롯을 물고 있는 #2602 재현 그 자체"
+        )
+
+        # 3) 실사용자 체감 축 — 슬롯이 진짜 비었으므로 같은 키의 새 연결이 즉시 성공(429 아님).
+        with patch("app.core.database.async_session_factory", _factory), \
+             patch("app.services.onboarding_funnel.emit_onboarding_event", AsyncMock()):
+            second = await gw_module.agent_stream(request=_NeverDisconnects(), auth=auth_ctx)
+            assert second is not None
+            await second.body_iterator.aclose()
+    finally:
+        gw_module._agent_connections.pop(agent_id_str, None)
+        from app.core.database import Base
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+        from app.core import shutdown as _shutdown_module
+        _shutdown_module.reset_shutdown_event()

--- a/backend/tests/test_e_infra_s5_agent_stream_rate_limit.py
+++ b/backend/tests/test_e_infra_s5_agent_stream_rate_limit.py
@@ -91,3 +91,26 @@ async def test_tier_aware_paid_allows_more(monkeypatch):
         assert isinstance(resp, StreamingResponse)
     finally:
         ag._agent_connections.pop(aid_str, None)
+
+
+@pytest.mark.anyio
+async def test_global_cap_rejection_does_not_leak_per_key_dict_entry(monkeypatch):
+    """story #2602 ⓑ: `_agent_connections`는 defaultdict(set) — per-key 한도 체크의
+    `_agent_connections[agent_id_str]` 서브스크립트는 **조회만으로도** 빈 set 항목을 만든다.
+    이 agent는 기존 연결이 0개라 per-key 체크는 통과하지만(0 < limit), 뒤이은 전역 cap(503)에서
+    거부된다 — 이 요청이 실제 연결을 하나도 등록 못 했는데도(`.add(queue)`엔 도달 못 함) dict에
+    영구 흔적을 남기면 안 된다("거부가 자원을 만드는" 결함, 실제 slot 카운트엔 무해하지만
+    agent_id마다 무한정 쌓이는 dict key 누수)."""
+    aid = uuid.uuid4()
+    req, auth, aid_str = _patch(monkeypatch, aid, org_plan="free")
+    assert aid_str not in ag._agent_connections  # 사전조건 — 이 agent는 한 번도 등록된 적 없음
+    monkeypatch.setattr(ag, "_agent_sse_connection_count", ag._MAX_AGENT_SSE_CONNECTIONS)  # 전역 cap 초과
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await ag.agent_stream(req, auth=auth)
+        assert exc.value.status_code == 503
+        assert aid_str not in ag._agent_connections, (
+            "전역 cap에 거부된 요청이 per-key dict에 빈 항목을 남김(#2602 ⓑ 재발)"
+        )
+    finally:
+        ag._agent_connections.pop(aid_str, None)


### PR DESCRIPTION
## Summary
- Diagnosis for #2602 (agent looks online/heartbeat-alive but chat is unresponsive) is in the story description. This PR ships branch ① of the fix, per PO steer: the "채팅 무응답" root cause — the per-key SSE stream cap (free/default=3) can be starved by orphaned connections that the server never detects as dead (`request.is_disconnected()` is documented-unreliable in this codebase, #2183/까심 AC6), so `wake_agent()` has nowhere live to push events.
- Live-reproduced against `backend-dev` (curl, fill 3 slots, `kill -9`, observe 429 persist well past the 90s TTL) before writing any code.
- ⓑ real fix: `agent_gateway.py`'s per-key cap check subscripted `_agent_connections[agent_id_str]` (a `defaultdict(set)`) purely to read its length — that lookup auto-vivifies an empty entry as a side effect. Any agent that ever got 503'd by the *global* cap (after passing the per-key check) permanently registered a phantom key in that dict — "rejection creates a resource." Switched to `.get(agent_id_str, ())` (read-only).
- ⓐ documentation correction: `sse_lease.py`'s docstring oversold the 90s TTL as *the* self-recovery bound. It only holds if refresh actually stops. A connection whose client died without the server noticing keeps refreshing its own lease every 30s tick forever — the honest worst-case bound for that failure class is `agent_gateway._AGENT_SSE_LIFESPAN_SEC` (+jitter, ~300-330s active wall-clock cap from #2128), not this TTL. Left `_AGENT_SSE_LIFESPAN_SEC` itself untouched — changing that constant is a PO call per this file's own established convention, not something I unilaterally tuned here.
- Did **not** touch story #2582's Retry-After "live-full → flat default" fallback — that was a deliberate, PO-reviewed (2026-08-12) decision with its own passing regression test; my finding explains *why* that ambiguity is real (a zombie and a genuinely-live session refresh identically) but doesn't call for reopening it.

## Test plan
- [x] New `backend/tests/test_2602_sse_lease_lifespan_reclaim.py` — real local PG + fakeredis: a connection that never gets `is_disconnected()==True` (kill-9-without-detection simulation) still gets its `sse_lease` released once the active lifespan cap fires (not the TTL), and a subsequent connection on the same key then succeeds. Verified this closes a real gap (existing #2128 tests never touched `sse_lease`; existing #2582 tests only covered TTL-based natural expiry, not the lifespan-cap-forced path).
- [x] New `test_global_cap_rejection_does_not_leak_per_key_dict_entry` in `test_e_infra_s5_agent_stream_rate_limit.py` — sanity-checked it fails on the pre-fix code and passes after.
- [x] Full existing suites green: `test_sse_lease.py` (16), `test_2582_*` (4), `test_e_infra_s4_*` (4), `test_e_infra_s5_*` (5, incl. new), `test_2143_*` (1), `test_2128_*` agent realdb test (1) — all passing locally against a throwaway local PG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)