### PR TITLE
feat(#2603 P0): unify delivery decision — SSE core consumes ChannelRouter, agent group default=mentions

### DIFF
--- a/backend/alembic/versions/0241_delivery_contract_handle_free_response.py
+++ b/backend/alembic/versions/0241_delivery_contract_handle_free_response.py
@@ -1,0 +1,100 @@
+"""story #2603 P0(블루프린트 delivery-contract-blueprint-v0-1): 전달 계약 판정 단일화의 스키마 토대.
+
+두 컬럼:
+- `members.handle` — 에이전트의 안정적 @멘션 핸들(예: mooncli-sprintable). API/MCP 발신
+  메시지 본문의 `@handle` 텍스트를 구조화 mentioned_ids와 합집합하는 파서(handle_mention_
+  parser.py)가 조회 키로 쓴다. nullable(휴먼은 무의미) — org 내 non-null handle만 unique
+  (partial index, 대소문자 무관 충돌 방지를 위해 lower()에 건다).
+  **기존 에이전트 백필**: 이 컬럼이 NULL이면 그 에이전트는 @멘션으로 도달 불가능해져(신규
+  기본계약=mentions, PO 소급 확定) 사실상 그룹챗에서 말을 못 거는 상태가 된다 — 그래서
+  같은 마이그에서 기존 활성 에이전트 전원에게 name을 슬러그화해 handle을 채운다(결정론적·
+  가역적 — 순수 데이터 판단이 아니라 새 컬럼을 즉시 쓸 수 있게 만드는 구조 백필이라
+  no-pr-for-data 게이트(0166/0167/0240 선례) 대상은 아니라고 판단하나, 선생님 가시성을
+  위해 여기 명시한다).
+- `conversations.free_response` — AC2(옵트아웃 경로) 대화 스코프 오버라이드. true면 그
+  대화에서는 에이전트 recipient의 mentions 기본계약을 all로 완화(단, 그 에이전트가 명시
+  mute를 선택했으면 free_response도 mute를 못 뒤집는다 — 회원 자기 선택이 대화 기본값보다
+  우선). 기본 false(무회귀 — 신규/기존 대화 전부 지금 동작 유지, 명시 opt-in만 완화).
+
+Revision ID: 0241
+Revises: 0240
+Create Date: 2026-08-13
+"""
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0241"
+down_revision = "0240"
+branch_labels = None
+depends_on = None
+
+
+def _slugify(name: str) -> str:
+    """비ASCII(한글 등)는 버리고 영숫자/하이픈만 남긴다 — @handle 텍스트 파서가 word-boundary
+    정규식으로 매칭하므로 handle 자체는 ASCII 토큰이어야 안전하다. 결과가 빈 문자열이면
+    (이름이 전부 비ASCII) 호출부가 "agent"로 폴백한다."""
+    normalized = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode("ascii")
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", normalized).strip("-").lower()
+    return slug
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+
+    members_cols = {c["name"] for c in insp.get_columns("members")}
+    if "handle" not in members_cols:
+        op.add_column("members", sa.Column("handle", sa.Text(), nullable=True))
+        op.create_index(
+            "uq_members_org_handle_lower",
+            "members",
+            ["org_id", sa.text("lower(handle)")],
+            unique=True,
+            postgresql_where=sa.text("handle IS NOT NULL"),
+        )
+
+        # 기존 활성 에이전트 백필(위 docstring 참조) — org별로 slug 충돌 시 -2/-3... 접미사.
+        rows = conn.execute(sa.text(
+            "SELECT id, org_id, name FROM members WHERE type = 'agent' AND is_active = true "
+            "AND handle IS NULL ORDER BY org_id, created_at"
+        )).fetchall()
+        used_per_org: dict = {}
+        for member_id, org_id, name in rows:
+            base = _slugify(name) or "agent"
+            used = used_per_org.setdefault(org_id, set())
+            candidate = base
+            n = 2
+            while candidate in used:
+                candidate = f"{base}-{n}"
+                n += 1
+            used.add(candidate)
+            conn.execute(
+                sa.text("UPDATE members SET handle = :handle WHERE id = :id"),
+                {"handle": candidate, "id": member_id},
+            )
+
+    conversations_cols = {c["name"] for c in insp.get_columns("conversations")}
+    if "free_response" not in conversations_cols:
+        op.add_column(
+            "conversations",
+            sa.Column("free_response", sa.Boolean(), nullable=False, server_default=sa.false()),
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+
+    conversations_cols = {c["name"] for c in insp.get_columns("conversations")}
+    if "free_response" in conversations_cols:
+        op.drop_column("conversations", "free_response")
+
+    members_cols = {c["name"] for c in insp.get_columns("members")}
+    if "handle" in members_cols:
+        op.drop_index("uq_members_org_handle_lower", table_name="members")
+        op.drop_column("members", "handle")

--- a/backend/app/models/conversation.py
+++ b/backend/app/models/conversation.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Text, UniqueConstraint, func, text
+from sqlalchemy import Boolean, DateTime, ForeignKey, Text, UniqueConstraint, func, text
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -31,6 +31,10 @@ class Conversation(Base, OrgScopedMixin, TimestampMixin):
     resolved_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    # story #2603 P0(delivery-contract-blueprint-v0-1) AC2: 대화 스코프 옵트아웃 — true면 이
+    # 대화의 에이전트 recipient는 mentions 기본계약이 all로 완화된다(단 회원 자신의 명시
+    # mute는 이걸로 안 뒤집힘 — channel_router.py 참조). 기본 false(무회귀).
+    free_response: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     participants: Mapped[list["ConversationParticipant"]] = relationship(
         "ConversationParticipant", back_populates="conversation", lazy="select"

--- a/backend/app/models/member.py
+++ b/backend/app/models/member.py
@@ -43,6 +43,9 @@ class Member(Base):
     )
     name: Mapped[str] = mapped_column(Text, nullable=False)
     avatar_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # story #2603 P0(delivery-contract-blueprint-v0-1): 에이전트 안정 @멘션 핸들. org 내
+    # non-null 값만 unique(대소문자 무관, 0241 partial index). 휴먼은 NULL(무의미).
+    handle: Mapped[str | None] = mapped_column(Text, nullable=True)
     org_role: Mapped[str | None] = mapped_column(Text, nullable=True)
     # E-MSG-POLICY S1: agent DM 인가 모드(creator_only default|org_wide|list). 에이전트 단위 정책 —
     # canonical 위치(team_members 뷰가 m.message_policy_mode로 투영). 휴먼은 무의미(default 유지).

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -925,6 +925,9 @@ class UpdateStatusRequest(BaseModel):
 class UpdateConversationRequest(BaseModel):
     # EF-S2 (db75ecd0) AC3: 방 title 사용자 편집. title 제공 시만 갱신(기본 생성 title 보존).
     title: str | None = None
+    # story #2603 P0 AC2: free_response 대화 스코프 옵트아웃(channel_router.py 참조).
+    # 제공 시만 갱신 — 미제공은 기존값 보존(title과 동일 partial-update 규약).
+    free_response: bool | None = None
 
 
 class AddParticipantRequest(BaseModel):
@@ -1935,6 +1938,18 @@ async def send_message(
                 _seen.add(mid)
                 valid_mentioned_ids.append(mid)
 
+    # story #2603 P0(delivery-contract-blueprint-v0-1) ④: FE 구조화 mentioned_ids와 본문
+    # `@handle` 텍스트 파싱 결과를 합집합 — MCP/API 발신(SendChatInput엔 mentioned_ids 필드가
+    # 없다, #2602 지도 ⑦)도 여기서 같은 mentioned_ids 파이프에 실려 route_message/webhook
+    # targeting/notification 전부가 자동으로 handle 멘션을 본다(별도 소비처 변경 불요).
+    # org+type='agent' 스코프 정확 일치만(handle_mention_parser.py) — 부분 문자열 오매칭 없음.
+    from app.services.handle_mention_parser import resolve_handle_mentions
+    _handle_mentioned_ids = await resolve_handle_mentions(db, org_id=org_id, content=body.content or "")
+    if _handle_mentioned_ids:
+        for mid in _handle_mentioned_ids:
+            if mid != sender.id and mid not in valid_mentioned_ids:
+                valid_mentioned_ids.append(mid)
+
     # E-ACTIVATION S1(까디르 QA): audience 도 cross-org/삭제 id 차단 — mentioned_ids 와 동형 org 필터.
     # 안 하면 삭제·타조직 member_id 를 audience 에 넣어 «실 수신자 전원이 addressed=no» 메시지를 만들 수 있다.
     # 전량 필터돼 []가 되면 어댑터에서 `not audience`=True → all-addressed(현행)로 안전 degrade.
@@ -2086,12 +2101,28 @@ async def send_message(
     # ROLLBACK 처리되어(asyncpg 실측 확認) msg insert까지 통째로 사라졌다 — "성공 id 반환하는데
     # 저장 안 됨" 증상의 근본. `_dispatch_conversation_event` 호출부와 동형으로 begin_nested()
     # SAVEPOINT 격리 — 여기서 실패해도 이 nested만 롤백되고 바깥 트랜잭션(msg insert)은 안전.
+    # story #2603 P0(delivery-contract-blueprint-v0-1) ①: SSE 코어가 ChannelRouter의
+    # DeliveryDecision을 소비한다 — 예전엔 이 decisions가 discord 채널 판정에만 쓰이고
+    # `_dispatch_conversation_event`(실제 turn 트리거) 자체는 mute/mentions를 전혀 안 봤다
+    # (지도 ②③). preference_excluded_ids = 참가자였지만 route_message가 mute/mentions로
+    # 걸러 decisions에 없는 대상 — 이제 이들은 discord 판정과 같은 자리에서 SSE Event
+    # 생성 자체가 제외된다(막는 쪽과 하는 쪽이 같은 판정을 본다).
     discord_exclude_ids: set[uuid.UUID] = set()
+    preference_excluded_ids: set[uuid.UUID] = set()
     try:
         async with db.begin_nested():
             from app.services.channel_router import ChannelRouterError, route_message as _route
             decisions = await _route(msg.id, db)
             discord_exclude_ids = {d.member_id for d in decisions if d.channel == "discord"}
+            decided_ids = {d.member_id for d in decisions}
+            _participant_rows = (await db.execute(
+                select(ConversationParticipant.member_id).where(
+                    ConversationParticipant.conversation_id == conversation_id,
+                )
+            )).scalars().all()
+            preference_excluded_ids = {
+                pid for pid in _participant_rows if pid != sender.id and pid not in decided_ids
+            }
     except Exception:
         logger.warning("ChannelRouter pre-check failed message_id=%s — no SSE exclusion", msg.id)
 
@@ -2148,7 +2179,7 @@ async def send_message(
         async with db.begin_nested():
             pending_sse_pushes += await _dispatch_conversation_event(
                 db, conv, msg, org_id, sender,
-                exclude_ids=discord_exclude_ids | blocked_agent_ids | user_blocker_ids,
+                exclude_ids=discord_exclude_ids | blocked_agent_ids | user_blocker_ids | preference_excluded_ids,
                 webhook_covered_ids=webhook_covered_ids,
             )
     except Exception as _dispatch_err:
@@ -2534,9 +2565,10 @@ async def update_conversation(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
-    """PATCH /api/v2/conversations/{id} — 방 title 사용자 편집 (EF-S2 AC3·참여자 권한).
+    """PATCH /api/v2/conversations/{id} — 방 title·free_response 사용자 편집(EF-S2 AC3·
+    story #2603 P0 AC2·참여자 권한).
 
-    title 제공 시만 갱신(기본 생성 title 보존). status PATCH 와 동일 참여자 게이트.
+    각 필드는 제공 시만 갱신(기본값 보존). status PATCH 와 동일 참여자 게이트.
     """
     conv = (await db.execute(
         select(Conversation).where(Conversation.id == conversation_id, Conversation.org_id == org_id)
@@ -2557,7 +2589,11 @@ async def update_conversation(
     if body.title is not None:
         conv.title = body.title
         conv.updated_at = datetime.now(timezone.utc)
+    if body.free_response is not None:
+        conv.free_response = body.free_response
+        conv.updated_at = datetime.now(timezone.utc)
+    if body.title is not None or body.free_response is not None:
         await db.commit()
         await db.refresh(conv)
 
-    return {"id": str(conv.id), "title": conv.title}
+    return {"id": str(conv.id), "title": conv.title, "free_response": conv.free_response}

--- a/backend/app/services/agent_anchor_sync.py
+++ b/backend/app/services/agent_anchor_sync.py
@@ -60,6 +60,11 @@ async def sync_agent_anchor_on_create(
                 if not await ensure_human_member(session, owner_member_id):
                     owner_member_id = None
 
+    # story #2603 P0: 신규 에이전트는 생성 시점에 안정 @handle을 채번한다(NULL로 남기면
+    # mentions 기본계약 하에서 아무도 못 부르는 에이전트가 된다 — handle_mention_parser.py).
+    from app.services.handle_mention_parser import generate_unique_handle
+    handle = await generate_unique_handle(session, org_id=team_member.org_id, name=team_member.name)
+
     # 1. members (id=team_member.id, type='agent') — 0075 에이전트 백필 동형
     await session.execute(
         pg_insert(Member.__table__)
@@ -73,6 +78,7 @@ async def sync_agent_anchor_on_create(
             avatar_url=team_member.avatar_url,
             org_role=None,
             is_active=team_member.is_active,
+            handle=handle,
         )
         .on_conflict_do_nothing(index_elements=["id"])
     )

--- a/backend/app/services/channel_router.py
+++ b/backend/app/services/channel_router.py
@@ -36,11 +36,30 @@ async def route_message(
     message_id: uuid.UUID,
     db: AsyncSession,
 ) -> list[DeliveryDecision]:
-    """메시지 수신자별 DeliveryDecision 목록 반환.
+    """메시지 수신자별 DeliveryDecision 목록 반환 — 「전달 계약」의 단일 판정 지점
+    (delivery-contract-blueprint-v0-1, story #2603 P0).
 
     mute인 경우 해당 수신자 제외 (decision 미생성).
     mentions level인 경우 message content에 @{member_id} 없으면 제외.
-    agent↔agent: preference 무관 sse 강제.
+
+    story #2603 이전엔 여기 "agent↔agent → sse 강제(AC5)" 바이패스가 있어 sender·recipient가
+    둘 다 agent면 preference 조회 자체를 건너뛰고 무조건 level="all"을 반환했다 — Hermes↔
+    OpenClaw 같은 외부 런타임 에이전트가 서로에게 응답하는 무한 루프가 정확히 이 바이패스
+    때문에 구조적으로 안 끊겼다(원 커밋 39b96444a "S-A4" 확인 — AC 라벨 하나뿐, 서술적
+    근거가 커밋 메시지에 없음. "agent-to-agent forced sse"가 A2A 협업이 notification
+    preference 마찰로 막히는 걸 피하려던 의도였다고 추정은 되나 기록으로 확定되지 않음 —
+    낡은 전제로 판단해 걷어낸다). 지금은 recipient가 agent든 human이든 **같은 판정 경로**를
+    탄다 — sender_type은 더 이상 이 함수의 분기 조건이 아니다(단, DM 판정에는 conv_type을
+    쓴다 — 아래).
+
+    **에이전트 그룹챗 기본계약 = mentions**(1:1/DM = all, 비회귀·AC2): recipient_type이
+    agent이고 대화가 group(dm 아님)이며 그 recipient의 명시 preference 행이 없으면
+    default level="mentions"(과거는 이 경우도 "all"이었다 — PO 소급 확定: 원 고통이 기존
+    그룹챗에 있어 소급 없이는 반쪽 해법). human이거나 DM이면 기존과 동일 default="all".
+
+    **free_response 대화 오버라이드**(AC2 옵트아웃): `conversation.free_response=true`면
+    이 대화 한정으로 level="mentions"인 recipient는 "all"로 완화된다 — 단 명시 "mute"는
+    안 뒤집는다(회원 자신의 «아예 알림 원치 않음» 선택이 방 설정보다 우선).
     """
     try:
         # 1. 메시지 + 발신자 조회
@@ -112,10 +131,15 @@ async def route_message(
         member_type_map: dict[uuid.UUID, str] = {r[0]: r[1] for r in member_rows}
 
         # 5. preference 배치 조회 — thread/conversation/project/global 4 scope
-        # conversation의 project_id 조회 (project scope fallback용)
-        conv_project_id: uuid.UUID | None = (await db.execute(
-            select(Conversation.project_id).where(Conversation.id == msg.conversation_id)
-        )).scalar_one_or_none()
+        # conversation의 project_id·type·free_response 조회(각각 project scope fallback·
+        # DM 비회귀·free_response 오버라이드 판정용 — story #2603 P0로 type/free_response 추가).
+        conv_row = (await db.execute(
+            select(Conversation.project_id, Conversation.type, Conversation.free_response)
+            .where(Conversation.id == msg.conversation_id)
+        )).one_or_none()
+        conv_project_id: uuid.UUID | None = conv_row.project_id if conv_row else None
+        conv_type: str = conv_row.type if conv_row else "group"
+        conv_free_response: bool = bool(conv_row.free_response) if conv_row else False
 
         scope_type_order: list[tuple[str, uuid.UUID | None]] = []
         if msg.thread_id:
@@ -136,20 +160,10 @@ async def route_message(
         for p in pref_rows:
             pref_map.setdefault(p.member_id, {})[(p.scope_type, p.scope_id)] = p
 
-        # 6. 수신자별 라우팅 결정
+        # 6. 수신자별 라우팅 결정 — sender_type 분기 없음(위 docstring, story #2603 P0).
         decisions: list[DeliveryDecision] = []
         for rid in recipient_ids:
             recipient_type = member_type_map.get(rid, "human")
-
-            # agent↔agent → sse 강제 (AC5)
-            if sender_type == "agent" and recipient_type == "agent":
-                decisions.append(DeliveryDecision(
-                    member_id=rid,
-                    channel="sse",
-                    level="all",
-                    reason="agent-to-agent forced sse",
-                ))
-                continue
 
             # preference fallback: thread → conversation → global
             pref: NotificationPreference | None = None
@@ -162,22 +176,46 @@ async def route_message(
                     break
 
             channel = pref.channel if pref else "sse"
-            level = pref.level if pref else "all"
+            if pref is not None:
+                level = pref.level
+                reason = f"preference scope={matched_scope}"
+            elif recipient_type == "agent" and conv_type != "dm":
+                # story #2603 P0: 에이전트 그룹챗 기본계약(소급 적용, PO 확定) — 위 docstring.
+                level = "mentions"
+                reason = "agent group default: mentions"
+            else:
+                level = "all"
+                reason = "default: all"
+
+            # AC2: free_response 대화는 mentions만 all로 완화 — 명시 mute는 안 뒤집는다.
+            if conv_free_response and level == "mentions":
+                level = "all"
+                reason = f"{reason} + free_response override"
 
             # mute → skip (AC3)
             if level == "mute":
+                logger.info(
+                    "delivery_contract: excluded recipient=%s conversation_id=%s reason=%s",
+                    rid, msg.conversation_id, "mute",
+                )
                 continue
 
-            # CB-S1 AC3: mentioned_ids 배열 기반 mentions 판단 (content regex 폐기)
+            # CB-S1 AC3: mentioned_ids 배열 기반 mentions 판단(content regex 폐기) — story #2603
+            # P0로 handle_mention_parser가 API/MCP 발신 본문의 @handle을 mentioned_ids에 이미
+            # 합집합해 저장하므로(conversations.py send_message), 이 체크는 그대로 재사용된다.
             if level == "mentions":
                 if not (msg.mentioned_ids and rid in msg.mentioned_ids):
+                    logger.info(
+                        "delivery_contract: excluded recipient=%s conversation_id=%s reason=%s",
+                        rid, msg.conversation_id, "mentions level, not mentioned",
+                    )
                     continue
 
             decisions.append(DeliveryDecision(
                 member_id=rid,
                 channel=channel,
                 level=level,
-                reason=f"preference scope={matched_scope}",
+                reason=reason,
             ))
 
         return decisions

--- a/backend/app/services/handle_mention_parser.py
+++ b/backend/app/services/handle_mention_parser.py
@@ -1,0 +1,97 @@
+"""story #2603 P0(delivery-contract-blueprint-v0-1) — 에이전트 안정 @handle: 생성 + 파싱.
+
+FE 구조화 피커가 채우는 `ConversationMessage.mentioned_ids`(UUID 배열)는 API/MCP 발신
+경로엔 대응하는 필드가 없다(#2602 지도 ⑦ 발견 — `SendChatInput`엔 entity-mention용
+`mentions`만 있고 팀원 @멘션 필드가 없음). 그래서 Hermes/OpenClaw 같은 외부 런타임이
+응답 본문에 "@다른에이전트" 텍스트를 써도 서버는 그걸 구조화 신호로 못 본다 — require_mention/
+mentions 계약이 정확히 이 시나리오에서 헛돌게 되는 근본 갭. 이 모듈이 그 갭을 닫는다.
+
+`extract_handle_mentions`는 본문에서 `@handle` 토큰을 뽑아 `members.handle`(org+type='agent'
+스코프, 대소문자 무관 **정확 일치**)로 member_id를 해소한다 — 부분 문자열 오매칭 금지(AC4):
+word-boundary 정규식 + DB WHERE lower(handle)=lower(token) 정확 일치만 사용, LIKE/substring
+비교를 쓰지 않는다. 호출부(conversations.py)가 이 결과를 FE의 `mentioned_ids`와 **합집합**
+한다 — 이 모듈은 대체가 아니라 보완이다(entity-mention `mention_parser.py`와는 완전히
+별개 개념·문법·write-target — 저 모듈은 건드리지 않는다).
+"""
+from __future__ import annotations
+
+import re
+import unicodedata
+import uuid
+
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.member import Member
+
+# word-boundary: `@` 앞이 단어문자가 아니어야(이메일 `user@host`의 `@host`를 멘션으로 오인 안 함).
+# handle 문자셋은 슬러그 규칙(영숫자+하이픈)과 대칭 — generate_unique_handle이 만드는 형태만 매치.
+_HANDLE_TOKEN_RE = re.compile(r"(?<![\w@])@([a-zA-Z0-9][a-zA-Z0-9-]{0,63})\b")
+
+
+def extract_handle_tokens(content: str) -> list[str]:
+    """본문에서 `@handle` 토큰 후보를 순서 보존 + 중복 제거로 뽑는다(DB 조회 없는 순수 함수).
+    존재 여부/정확 일치는 `resolve_handle_mentions`가 DB에서 판정한다 — 이 함수는 모양만 본다."""
+    if not content:
+        return []
+    seen: set[str] = set()
+    result: list[str] = []
+    for m in _HANDLE_TOKEN_RE.finditer(content):
+        token = m.group(1)
+        key = token.lower()
+        if key not in seen:
+            seen.add(key)
+            result.append(token)
+    return result
+
+
+async def resolve_handle_mentions(
+    db: AsyncSession, *, org_id: uuid.UUID, content: str,
+) -> set[uuid.UUID]:
+    """본문의 `@handle` 토큰을 실재하는 에이전트 member_id 집합으로 해소한다.
+
+    정확 일치만(대소문자 무관) — 존재하지 않는 handle·휴먼(handle 없음)·타 org 에이전트는
+    자연히 매치 0(별도 존재-검사 불요, WHERE 자체가 org+type로 스코프됨). 빈 결과 = 빈 집합
+    (DB 왕복 없이 조기 반환 — 토큰이 없으면 조회도 없다)."""
+    tokens = extract_handle_tokens(content)
+    if not tokens:
+        return set()
+    lowered = {t.lower() for t in tokens}
+    rows = (await db.execute(
+        select(Member.id).where(
+            Member.org_id == org_id,
+            Member.type == "agent",
+            Member.handle.isnot(None),
+            func.lower(Member.handle).in_(lowered),
+        )
+    )).scalars().all()
+    return set(rows)
+
+
+def slugify_handle_base(name: str) -> str:
+    """이름 → ASCII 슬러그 후보(고유성 보장 전 base). 결과가 빈 문자열이면(이름이 전부
+    비ASCII, 예: 순한글 이름) 호출부가 "agent" 폴백을 쓴다 — @handle 파서가 word-boundary
+    정규식으로 매칭하므로 handle 자체는 ASCII 토큰이어야 안전(0241 마이그의 백필 로직과 동형,
+    런타임 신규 생성용으로 별도 보관 — 마이그는 훗날 재실행 안 되므로 독립 사본이 맞다)."""
+    normalized = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode("ascii")
+    return re.sub(r"[^a-zA-Z0-9]+", "-", normalized).strip("-").lower()
+
+
+async def generate_unique_handle(db: AsyncSession, *, org_id: uuid.UUID, name: str) -> str:
+    """신규 에이전트 생성 시 handle 자동 채번 — base가 org 내에서 겹치면 -2/-3...로 해소.
+
+    호출부(agent_anchor_sync.py)가 members INSERT **전에** 이 값을 계산해 넣는다(그 INSERT
+    자체는 ON CONFLICT DO NOTHING(id)뿐이라 handle 충돌은 여기서 미리 막아야 함 — DB의
+    partial unique index(uq_members_org_handle_lower)가 최종 방어선)."""
+    base = slugify_handle_base(name) or "agent"
+    existing = set((await db.execute(
+        select(func.lower(Member.handle)).where(
+            Member.org_id == org_id, Member.handle.isnot(None),
+        )
+    )).scalars().all())
+    candidate = base
+    n = 2
+    while candidate.lower() in existing:
+        candidate = f"{base}-{n}"
+        n += 1
+    return candidate

--- a/backend/tests/test_2603_handle_mention_parser.py
+++ b/backend/tests/test_2603_handle_mention_parser.py
@@ -1,0 +1,176 @@
+"""story #2603 P0 — handle_mention_parser.py: @handle 텍스트 파싱 + 안정 handle 채번.
+
+AC4 핵심 단언: 유사 이름·부분 문자열 오매칭이 없다(정확 일치만) + word-boundary(이메일
+user@host를 멘션으로 오인 안 함) + 신규 handle 채번의 org-scope 유일성."""
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+
+import pytest
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_extract_handle_tokens_word_boundary_and_dedup():
+    from app.services.handle_mention_parser import extract_handle_tokens
+
+    # 이메일의 @host는 멘션이 아니다(바로 앞이 단어문자) — word-boundary가 걸러야.
+    assert extract_handle_tokens("contact user@example.com for help") == []
+    # 정상 멘션 + 중복(대소문자 다름)은 첫 표기만 1건.
+    assert extract_handle_tokens("hey @mooncli-sprintable and @Mooncli-Sprintable again") == ["mooncli-sprintable"]
+    # 문장부호로 끝나는 멘션 — 토큰 자체는 손상 없이 뽑힌다(뒤의 콤마/마침표는 \b 밖).
+    assert extract_handle_tokens("cc @qa-bot, please review.") == ["qa-bot"]
+    assert extract_handle_tokens("no mentions here") == []
+    assert extract_handle_tokens("") == []
+
+
+def test_slugify_handle_base_strips_non_ascii():
+    from app.services.handle_mention_parser import slugify_handle_base
+
+    assert slugify_handle_base("Mooncli Sprintable") == "mooncli-sprintable"
+    assert slugify_handle_base("순한글이름") == ""  # 전부 비ASCII → 빈 문자열(호출부가 "agent" 폴백)
+    assert slugify_handle_base("QA-Bot_2") == "qa-bot-2"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, org_id):
+    from app.models.organization import Organization
+    session.add(Organization(id=org_id, name="Org", slug=f"org-{org_id.hex[:8]}"))
+    await session.commit()
+
+
+async def _seed_agent(session, org_id, name, handle):
+    from app.models.member import Member
+    m = Member(id=uuid.uuid4(), org_id=org_id, type="agent", name=name, handle=handle, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+@pytest.mark.anyio
+@pytest.mark.destructive_schema
+@pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+async def test_resolve_handle_mentions_exact_match_only_no_substring():
+    from app.services.handle_mention_parser import resolve_handle_mentions
+
+    engine, Session = await _realdb_session()
+    try:
+        org_id = uuid.uuid4()
+        async with Session() as s:
+            await _seed_org(s, org_id)
+            qa_id = await _seed_agent(s, org_id, "QA Bot", "qa-bot")
+            qa2_id = await _seed_agent(s, org_id, "QA Bot Two", "qa-bot-2")
+
+        async with Session() as s:
+            # "@qa-bot-2"를 부분 문자열로 "qa-bot"에 오매칭하면 안 된다(정확 일치만).
+            hits = await resolve_handle_mentions(s, org_id=org_id, content="cc @qa-bot-2 please look")
+            assert hits == {qa2_id}, "부분 문자열 오매칭 — @qa-bot-2가 qa-bot도 함께 잡으면 AC4 위반"
+
+        async with Session() as s:
+            hits = await resolve_handle_mentions(s, org_id=org_id, content="cc @qa-bot please look")
+            assert hits == {qa_id}
+
+        async with Session() as s:
+            # 존재하지 않는 handle — 매치 0(존재-검사 필요 없이 WHERE 자체가 스코프).
+            hits = await resolve_handle_mentions(s, org_id=org_id, content="cc @nonexistent-handle")
+            assert hits == set()
+
+        async with Session() as s:
+            # 대소문자 무관 정확 일치.
+            hits = await resolve_handle_mentions(s, org_id=org_id, content="cc @QA-BOT")
+            assert hits == {qa_id}
+    finally:
+        from app.core.database import Base
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.destructive_schema
+@pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+async def test_resolve_handle_mentions_scoped_to_org_and_agent_type():
+    from app.services.handle_mention_parser import resolve_handle_mentions
+    from app.models.member import Member
+
+    engine, Session = await _realdb_session()
+    try:
+        org_a = uuid.uuid4()
+        org_b = uuid.uuid4()
+        async with Session() as s:
+            await _seed_org(s, org_a)
+            await _seed_org(s, org_b)
+            await _seed_agent(s, org_b, "Bot", "bot")  # 다른 org의 동일 handle
+            human_id = uuid.uuid4()
+            s.add(Member(id=human_id, org_id=org_a, type="human", name="Human Bot", handle="bot", is_active=True))
+            await s.commit()
+            agent_a_id = await _seed_agent(s, org_a, "Bot A", "bot")
+
+        async with Session() as s:
+            # org_a 안에서 "bot" handle이 human과 agent 둘 다 있어도(unique index는 실제로 이걸
+            # 막지만, 여기선 순수 조회 스코프 검증이 목적) type='agent' 필터가 human을 제외한다.
+            hits = await resolve_handle_mentions(s, org_id=org_a, content="@bot")
+            assert agent_a_id in hits
+    finally:
+        from app.core.database import Base
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.destructive_schema
+@pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+async def test_generate_unique_handle_dedupes_within_org():
+    from app.services.handle_mention_parser import generate_unique_handle
+
+    engine, Session = await _realdb_session()
+    try:
+        org_id = uuid.uuid4()
+        async with Session() as s:
+            await _seed_org(s, org_id)
+            h1 = await generate_unique_handle(s, org_id=org_id, name="Mooncli Sprintable")
+            assert h1 == "mooncli-sprintable"
+            await _seed_agent(s, org_id, "Mooncli Sprintable", h1)
+
+        async with Session() as s:
+            h2 = await generate_unique_handle(s, org_id=org_id, name="Mooncli Sprintable")
+            assert h2 == "mooncli-sprintable-2", "같은 org 내 base 충돌 시 -2 접미사로 해소해야"
+
+        async with Session() as s:
+            # 다른 org는 독립 — 충돌 없이 base 그대로.
+            h3 = await generate_unique_handle(s, org_id=uuid.uuid4(), name="Mooncli Sprintable")
+            assert h3 == "mooncli-sprintable"
+
+        async with Session() as s:
+            # 전부 비ASCII 이름 — "agent" 폴백.
+            h4 = await generate_unique_handle(s, org_id=org_id, name="순한글이름")
+            assert h4 == "agent"
+    finally:
+        from app.core.database import Base
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()

--- a/backend/tests/test_channel_router_multiproject_sender.py
+++ b/backend/tests/test_channel_router_multiproject_sender.py
@@ -36,9 +36,35 @@ def _all(rows):
     return r
 
 
+def _pref(member_id, *, scope_type="global", scope_id=None, channel="sse", level="mute"):
+    p = MagicMock()
+    p.member_id = member_id
+    p.scope_type = scope_type
+    p.scope_id = scope_id
+    p.channel = channel
+    p.level = level
+    return p
+
+
+def _row(**attrs):
+    """story #2603 P0: conv_row 조회가 scalar 하나가 아니라 (project_id, type, free_response)
+    Row가 됐다 — .one_or_none()이 이 객체를 반환하고 호출부가 속성으로 읽는다."""
+    r = MagicMock()
+    row = MagicMock()
+    for k, v in attrs.items():
+        setattr(row, k, v)
+    r.one_or_none.return_value = row
+    return r
+
+
 @pytest.mark.anyio
 async def test_multiproject_agent_sender_dispatches_without_crash():
-    """멀티프로젝트 agent 발신 → sender_type .limit(1)='agent' → agent↔agent SSE dispatch(크래시 0)."""
+    """멀티프로젝트 agent 발신 → sender_type .limit(1)='agent' → dispatch(크래시 0).
+
+    story #2603 P0: agent↔agent 강제 sse/all 바이패스는 제거됐다(channel_router.py docstring
+    참조) — 이 테스트의 원래 목적(멀티프로젝트 sender의 team_members 뷰 다중행이 route_message
+    를 MultipleResultsFound로 깨지 않는지)은 그대로 지키되, recipient가 명시 멘션된 경우의
+    새 기본계약(agent group default: mentions, 멘션 매치로 decision 생성)으로 갱신한다."""
     from app.services.channel_router import route_message
 
     sender = uuid.uuid4()       # 멀티프로젝트 agent(team_members 뷰 다중행)
@@ -51,6 +77,7 @@ async def test_multiproject_agent_sender_dispatches_without_crash():
     msg.sender_id = sender
     msg.conversation_id = conv
     msg.thread_id = None
+    msg.mentioned_ids = [recipient]  # 명시 멘션 — 새 기본계약(mentions) 하에서 decision 발생 조건.
 
     db = MagicMock()
     db.execute = AsyncMock(side_effect=[
@@ -59,13 +86,182 @@ async def test_multiproject_agent_sender_dispatches_without_crash():
         _scalars([sender, recipient]),      # 3 participants(발신자 포함)
         _scalars([]),                       # 3b story #2349: user_blocker_ids 조회(차단 0건)
         _all([(recipient, "agent")]),       # 4 수신자 type 배치
-        _scalar(proj),                      # 5 conv project_id
+        _row(project_id=proj, type="group", free_response=False),  # 5 conv project_id/type/free_response
         _scalars([]),                       # 6 preferences
     ])
 
     decisions = await route_message(msg.id, db)
-    # 발신자 제외·agent↔agent 강제 SSE → 1 decision(크래시/ChannelRouterError 없이)
+    # 발신자 제외·크래시/ChannelRouterError 없이 멘션된 recipient에게만 decision.
     assert len(decisions) == 1
     assert decisions[0].member_id == recipient
     assert decisions[0].channel == "sse"
-    assert decisions[0].reason == "agent-to-agent forced sse"
+    assert decisions[0].level == "mentions"
+    assert decisions[0].reason == "agent group default: mentions"
+
+
+@pytest.mark.anyio
+async def test_agent_group_default_excludes_unmentioned_agent_recipient():
+    """story #2603 P0 AC1 — 그룹챗에서 멘션 없는 에이전트 발화는 상대 에이전트에게 decision을
+    만들지 않는다(= turn 트리거 자체가 없다). 원 접수 루프 시나리오의 핵심 단언."""
+    from app.services.channel_router import route_message
+
+    sender = uuid.uuid4()
+    recipient = uuid.uuid4()
+    conv = uuid.uuid4()
+    proj = uuid.uuid4()
+
+    msg = MagicMock()
+    msg.id = uuid.uuid4()
+    msg.sender_id = sender
+    msg.conversation_id = conv
+    msg.thread_id = None
+    msg.mentioned_ids = []  # 멘션 없음 — 원 루프 재현 시나리오.
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=[
+        _scalar(msg),
+        _scalar("agent"),
+        _scalars([sender, recipient]),
+        _scalars([]),
+        _all([(recipient, "agent")]),
+        _row(project_id=proj, type="group", free_response=False),
+        _scalars([]),
+    ])
+
+    decisions = await route_message(msg.id, db)
+    assert decisions == [], "멘션 없는데 decision이 생기면 원 루프가 그대로 재현된다"
+
+
+@pytest.mark.anyio
+async def test_dm_agent_recipient_defaults_to_all_no_mention_needed():
+    """AC2 비회귀 — 1:1(DM) 대화의 에이전트 recipient는 멘션 없이도 기존처럼 all(무회귀)."""
+    from app.services.channel_router import route_message
+
+    sender = uuid.uuid4()
+    recipient = uuid.uuid4()
+    conv = uuid.uuid4()
+    proj = uuid.uuid4()
+
+    msg = MagicMock()
+    msg.id = uuid.uuid4()
+    msg.sender_id = sender
+    msg.conversation_id = conv
+    msg.thread_id = None
+    msg.mentioned_ids = []
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=[
+        _scalar(msg),
+        _scalar("human"),
+        _scalars([sender, recipient]),
+        _scalars([]),
+        _all([(recipient, "agent")]),
+        _row(project_id=proj, type="dm", free_response=False),
+        _scalars([]),
+    ])
+
+    decisions = await route_message(msg.id, db)
+    assert len(decisions) == 1
+    assert decisions[0].level == "all"
+    assert decisions[0].reason == "default: all"
+
+
+@pytest.mark.anyio
+async def test_free_response_conversation_relaxes_mentions_to_all():
+    """AC2 옵트아웃 — free_response=true인 그룹 대화는 멘션 없어도 에이전트 recipient에게 간다."""
+    from app.services.channel_router import route_message
+
+    sender = uuid.uuid4()
+    recipient = uuid.uuid4()
+    conv = uuid.uuid4()
+    proj = uuid.uuid4()
+
+    msg = MagicMock()
+    msg.id = uuid.uuid4()
+    msg.sender_id = sender
+    msg.conversation_id = conv
+    msg.thread_id = None
+    msg.mentioned_ids = []
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=[
+        _scalar(msg),
+        _scalar("agent"),
+        _scalars([sender, recipient]),
+        _scalars([]),
+        _all([(recipient, "agent")]),
+        _row(project_id=proj, type="group", free_response=True),
+        _scalars([]),
+    ])
+
+    decisions = await route_message(msg.id, db)
+    assert len(decisions) == 1
+    assert decisions[0].level == "all"
+    assert "free_response override" in decisions[0].reason
+
+
+@pytest.mark.anyio
+async def test_explicit_mute_wins_over_free_response_and_mention():
+    """mute는 회원 자신의 명시 선택 — free_response 대화든 명시 멘션이든 mute를 못 뒤집는다."""
+    from app.services.channel_router import route_message
+
+    sender = uuid.uuid4()
+    recipient = uuid.uuid4()
+    conv = uuid.uuid4()
+    proj = uuid.uuid4()
+
+    msg = MagicMock()
+    msg.id = uuid.uuid4()
+    msg.sender_id = sender
+    msg.conversation_id = conv
+    msg.thread_id = None
+    msg.mentioned_ids = [recipient]  # 명시 멘션조차도 mute를 못 이긴다.
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=[
+        _scalar(msg),
+        _scalar("agent"),
+        _scalars([sender, recipient]),
+        _scalars([]),
+        _all([(recipient, "agent")]),
+        _row(project_id=proj, type="group", free_response=True),
+        _scalars([_pref(recipient, scope_type="global", level="mute")]),
+    ])
+
+    decisions = await route_message(msg.id, db)
+    assert decisions == [], "명시 mute 선택인데 decision이 생기면 회원 자기결정권 위반"
+
+
+@pytest.mark.anyio
+async def test_explicit_all_preference_overrides_agent_group_default():
+    """명시 preference 행이 있으면 그게 기본계약(mentions)보다 우선 — 에이전트가 스스로
+    all을 선택했다면 그 선택이 존중된다."""
+    from app.services.channel_router import route_message
+
+    sender = uuid.uuid4()
+    recipient = uuid.uuid4()
+    conv = uuid.uuid4()
+    proj = uuid.uuid4()
+
+    msg = MagicMock()
+    msg.id = uuid.uuid4()
+    msg.sender_id = sender
+    msg.conversation_id = conv
+    msg.thread_id = None
+    msg.mentioned_ids = []
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=[
+        _scalar(msg),
+        _scalar("agent"),
+        _scalars([sender, recipient]),
+        _scalars([]),
+        _all([(recipient, "agent")]),
+        _row(project_id=proj, type="group", free_response=False),
+        _scalars([_pref(recipient, scope_type="global", level="all", channel="sse")]),
+    ])
+
+    decisions = await route_message(msg.id, db)
+    assert len(decisions) == 1
+    assert decisions[0].level == "all"
+    assert decisions[0].reason == "preference scope=global"


### PR DESCRIPTION
## Summary
Blueprint: [delivery-contract-blueprint-v0-1](entity:doc:dd5154f3-d5be-4083-8c4b-3d03bdea0d0b). Root cause of the group-chat agent loop (Hermes↔OpenClaw mutual-response) was **not** a missing `require_mention` switch — three independent "who should receive this" computations already existed in the codebase (SSE core fan-out / ChannelRouter+`notification_preferences` / webhook targeting) and disagreed with each other. This PR lands P0: unify the SSE core with ChannelRouter's `DeliveryDecision` and remove the specific bypass that let agent-to-agent messages through completely unfiltered.

- **`channel_router.py`**: removed the `"agent↔agent → forced sse/all"` bypass (origin commit `39b96444a`, labeled `"S-A4"`/`AC5` — I checked; there's no rationale beyond the AC label in the original commit message, so I've treated it as a stale assumption per PO direction rather than a documented, still-valid constraint). Agent recipients in a **group** conversation now default to `level="mentions"` when they have no explicit preference row (1:1/DM stays `"all"` — non-regression, AC2). An explicit preference row (`mute` or `all`) always wins over the default — an agent that already opted in to `all` keeps that. `conversations.free_response=true` relaxes `mentions`→`all` for that conversation, but never overrides an explicit `mute` (a member's own opt-out beats the room setting).
- **`conversations.py`**: `_dispatch_conversation_event` (the actual SSE/Event turn-trigger) now excludes recipients that ChannelRouter's decision filtered out — previously that computation only fed discord-channel arbitration (`discord_exclude_ids`), so the core fan-out never consulted it at all (AC3: "막는 쪽과 하는 쪽이 다른 걸 보는" structure removed).
- **`handle_mention_parser.py`** (new): `members.handle` (new column, auto-generated at agent-creation time + backfilled for existing agents in the same migration) + a `@handle` text parser for API/MCP-originated messages, unioned into the same `mentioned_ids` pipe the FE picker already populates. Without this, MCP-originated messages (Hermes/OpenClaw — `SendChatInput` has no `mentioned_ids` field, only an unrelated entity-mention field) could never satisfy a mentions-gated contract at all — the gate would just always read "not mentioned." Exact match only (word-boundary regex + DB `WHERE`, no substring matching — AC4).

## Retroactive impact (AC6)
Every existing active agent gets a `handle` in this migration (deterministic slug from `name`, deduped per org). Every existing group conversation's agent participants now default to `mentions` instead of `all` **unless** `free_response` is set on that conversation (opt-out, ships in this same PR). I don't have dev/prod data access from here to state how many conversations/agents this actually touches — that measurement is for whoever promotes this to confirm before rollout.

## Out of scope (explicitly, per blueprint)
- Chain-depth cap for mutual-mention ping-pong (A mentions B, B mentions A) is **P1** (#2608) — not addressed here, and AC1's "1턴에 끊김" only covers the unmentioned-fan-out case, not the mutual-mention worst case.
- `_dispatch_mention_events` (the separate explicit-mention emphasis push) intentionally left unchanged — I did not wire `preference_excluded_ids` into it, so an explicitly-mentioned-but-muted member's behavior there is unchanged (a separate judgment call, not required by any AC here).
- `handle`/`free_response` are not yet exposed through read schemas (`TeamMemberResponse`/`team_members` view) or any FE UI — backend-functional only for this P0.

## Test plan
- [x] New `tests/test_channel_router_multiproject_sender.py` cases (6, all passing): bypass-removed default behavior, unmentioned agent excluded in group (AC1's core assertion), DM non-regression (AC2), `free_response` override, explicit `mute` wins over both `free_response` and an explicit mention, explicit `all` preference wins over the new default.
- [x] New `tests/test_2603_handle_mention_parser.py` (5, all passing, real PG): word-boundary parsing (no false-positive on `user@host` emails), exact-match-only resolution (no substring mismatch between e.g. `qa-bot` and `qa-bot-2`), org+type scoping, unique handle generation/dedup.
- [x] Full `tests/test_conversations.py` (15) green — no regression in `send_message` integration.
- [x] Agent-creation anchor-sync tests (`test_org_agent_create.py`, `test_member_ssot_ac3_1b.py`, `test_onboarding_member_anchor_0b115f5d.py`, 17 total) green — handle generation wired into `sync_agent_anchor_on_create` without breaking existing creation flows.
- [x] Fresh `alembic upgrade head` applies cleanly against a throwaway local PG, `handle`/`free_response` columns and the `uq_members_org_handle_lower` partial unique index verified via `\d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)