### PR TITLE
feat(#2608 P1): agent chain-depth cap — human-anchor-less A2A ping-pong stopper

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -652,6 +652,69 @@ async def _dispatch_mention_events(
             for pid_str, event in events_to_push]
 
 
+async def _dispatch_human_intervention_event(
+    db: AsyncSession,
+    conversation: Conversation,
+    msg: ConversationMessage,
+    org_id: uuid.UUID,
+    sender: TeamMember,
+    blocked_agent_recipient_ids: set[uuid.UUID],
+    chain_depth_cap: int,
+) -> list[tuple[str, dict]]:
+    """story #2608 P1 AC1: 연쇄 cap 초과로 agent recipient가 막힌 메시지를, 그 대화의 human
+    참가자 전원에게 `conversation.human_intervention_requested` Event로 알린다 — "왜 조용한가"
+    가 항상 답 가능해야 한다(블루프린트 §3, 침묵이 아니라 이벤트로 전환).
+
+    `_dispatch_mention_events`와 동형 구조(Event INSERT + flush, commit 후 push) — 대상만
+    human 참가자로 다르다. human은 recipient_seq 개념이 없어(agent 전용 gap-free 커서)
+    assign_recipient_seq를 안 부른다(_dispatch_conversation_event의 기존 관례와 동일).
+    """
+    if not conversation.project_id:
+        return []
+
+    participant_rows = (await db.execute(
+        select(ConversationParticipant.member_id, TeamMember.type)
+        .join(TeamMember, TeamMember.id == ConversationParticipant.member_id)
+        .where(ConversationParticipant.conversation_id == conversation.id)
+    )).all()
+    human_targets = {pid for pid, m_type in participant_rows if m_type == "human"}
+    if not human_targets:
+        return []
+
+    payload = {
+        **_msg_payload(msg, sender),
+        "blocked_recipient_ids": [str(rid) for rid in sorted(blocked_agent_recipient_ids)],
+        "chain_depth_cap": chain_depth_cap,
+        "reason": "chain-expired",
+    }
+
+    events_to_push: list[tuple[str, Event]] = []
+    for pid in sorted(human_targets):  # deadlock 방지: 일관 락 순서
+        event = Event(
+            project_id=conversation.project_id,
+            org_id=org_id,
+            event_type="conversation.human_intervention_requested",
+            source_entity_type="conversation_message",
+            source_entity_id=msg.id,
+            sender_id=sender.id,
+            recipient_id=pid,
+            recipient_type="human",
+            payload=payload,
+            status="pending",
+        )
+        db.add(event)
+        events_to_push.append((str(pid), event))
+
+    await db.flush()
+    from app.services.activity_stream import extract_activities_best_effort
+    await extract_activities_best_effort(db, [event.id for _, event in events_to_push])
+    return [
+        (pid_str, {"event_id": str(event.id), "event_type": "conversation.human_intervention_requested",
+                   **payload, "recipient_id": pid_str})
+        for pid_str, event in events_to_push
+    ]
+
+
 async def _command_capability_gate(
     db: AsyncSession,
     conv: Conversation,
@@ -2186,6 +2249,41 @@ async def send_message(
         # dispatch 실패를 삼키지 않고 surface — 게이트웨이 이벤트 미생성 무음 방지
         logger.error("conversation event dispatch failed conversation_id=%s", conversation_id, exc_info=True)
         raise HTTPException(status_code=500, detail="event dispatch failed") from _dispatch_err
+
+    # story #2608 P1 AC1: A↔B 상호멘션류(멘션 자체는 항상 유효해 route_message의 mentions
+    # 체크로는 절대 안 끊김)를 잡는다 — 이 메시지가 agent가 보낸 것이고 agent를 명시
+    # 멘션했는데(=turn이 시도됐을 대상이 실재) 연쇄가 cap을 넘었으면, "침묵"이 아니라 human
+    # 참가자에게 human_intervention_requested 이벤트로 알린다(블루프린트 §3). depth 계산은
+    # route_message() 안의 게이트와 **같은 함수**(compute_agent_chain_depth) — 판정 로직
+    # 중복 없음, 호출 위치만 recipient-필터(route_message)·이벤트-발생(여기, 메시지당 1회)
+    # 으로 자연히 갈린다(chain_depth.py 모듈 docstring 참조). 「멘션됐는데 agent가 없다」
+    # (전부 human 멘션)면 turn 자체가 애초에 대상 없어 이 게이트는 no-op(조건에 이미 반영).
+    if sender.type == "agent" and msg.mentioned_ids:
+        from app.services.chain_depth import compute_agent_chain_depth
+        from app.services.channel_router import _AGENT_CHAIN_DEPTH_CAP
+
+        chain_depth = await compute_agent_chain_depth(
+            db, conversation_id, max_scan=_AGENT_CHAIN_DEPTH_CAP,
+        )
+        if chain_depth > _AGENT_CHAIN_DEPTH_CAP:
+            _mentioned_agent_rows = (await db.execute(
+                select(TeamMember.id).where(
+                    TeamMember.id.in_(msg.mentioned_ids), TeamMember.type == "agent",
+                )
+            )).scalars().all()
+            chain_expired_agent_targets = set(_mentioned_agent_rows)
+            if chain_expired_agent_targets:
+                try:
+                    async with db.begin_nested():
+                        pending_sse_pushes += await _dispatch_human_intervention_event(
+                            db, conv, msg, org_id, sender,
+                            chain_expired_agent_targets, _AGENT_CHAIN_DEPTH_CAP,
+                        )
+                except Exception:
+                    logger.warning(
+                        "human_intervention_requested dispatch failed conversation_id=%s",
+                        conversation_id, exc_info=True,
+                    )
 
     # AC1: 멘션 대상에게 conversation:mention SSE 발송 (participant 여부 무관)
     #

--- a/backend/app/services/chain_depth.py
+++ b/backend/app/services/chain_depth.py
@@ -1,0 +1,72 @@
+"""story #2608 P1(delivery-contract-blueprint-v0-1) — 인간 앵커 없는 에이전트 연쇄의 깊이.
+
+블루프린트 §3: "인간 앵커 없는 에이전트 연쇄에서 전달 계약은 깊이 N까지 유효하다"를
+**새 카운터 컬럼이 아니라 매번 유도되는 조회**로 표현한다(디디 그라운딩, PO 승인 08-13).
+`conversation_messages`는 이미 conversation_id 인덱스 + created_at을 갖고 있어, 최근
+N+1건을 최신순으로 가져와 맨 앞부터 "발신자 type='agent'"인 것만 세다가 처음 human(또는
+발신자 없음)을 만나면 멈추는 단일 쿼리(LIMIT N+1, O(N))로 "지금 이 순간의 연쇄 깊이"를
+그때그때 다시 계산한다.
+
+state를 안 만드는 것 자체가 요점이다 — 별도 카운터 컬럼이었다면 "언제 리셋하나"가 그 자체로
+버그 표면(놓치면 영구 증가·이중 리셋 등)이었을 것을, 매번 human 메시지 유무를 다시 보는
+조회로 대체해 그 표면 자체를 없앤다. human 메시지가 오면 다음 조회가 자동으로 그걸 반영
+(별도 리셋 로직 불요).
+
+이 모듈은 route_message()(recipient별 필터)와 conversations.py의 human-intervention 이벤트
+판정(연쇄당 1회) 양쪽에서 **같은 함수**를 호출한다 — "판정이 단일 함수에서 이루어진다"(AC3)는
+계산 로직이 하나라는 뜻이지 호출 지점이 하나여야 한다는 뜻이 아니다(호출부가 둘인 이유:
+recipient 필터는 recipient별 반복 안에서, 이벤트 발생은 메시지당 1회만 필요해 자연히
+호출 위치가 갈린다 — 로직 자체의 복제는 없다)."""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.conversation import ConversationMessage
+from app.models.team import TeamMember
+
+
+async def compute_agent_chain_depth(
+    db: AsyncSession, conversation_id: uuid.UUID, *, max_scan: int,
+) -> int:
+    """이 대화의 "가장 최근 메시지부터 역순으로, human 메시지가 나오기 전까지의 연속 agent
+    발신 메시지 수"를 반환한다 — 방금 전송된(호출 시점에 이미 flush된) 메시지 자신도 그
+    발신자가 agent면 이 카운트에 포함된다(그게 바로 "이 메시지까지 포함해서 몇 번째 연쇄
+    hop인가"라는 질문의 정답이다).
+
+    최신순으로 최대 `max_scan + 1`건만 본다(그 이상은 어차피 cap 판정에 필요 없다 — 조기
+    종료로 쿼리·순회 비용을 O(max_scan)으로 고정). **cap 초과 판정은 호출부가 `depth >
+    max_scan`으로 한다**(등호 없음 — 정확히 max_scan번째 hop까지는 유효, max_scan+1번째부터
+    차단). 발신자가 없거나(시스템 메시지 등) team_members에서 조회 안 되는 경우는 human과
+    동형으로 취급(연쇄를 끊음 — 애매하면 더 보수적인 쪽, 즉 "덜 막는" 쪽이 아니라 "확실히
+    안전한" 쪽을 택한다)."""
+    rows = (
+        await db.execute(
+            select(ConversationMessage.sender_id)
+            .where(ConversationMessage.conversation_id == conversation_id)
+            .order_by(ConversationMessage.created_at.desc())
+            .limit(max_scan + 1)
+        )
+    ).scalars().all()
+    if not rows:
+        return 0
+
+    sender_ids = {sid for sid in rows if sid is not None}
+    type_map: dict[uuid.UUID, str] = {}
+    if sender_ids:
+        type_rows = (
+            await db.execute(
+                select(TeamMember.id, TeamMember.type).where(TeamMember.id.in_(sender_ids))
+            )
+        ).all()
+        type_map = {r[0]: r[1] for r in type_rows}
+
+    depth = 0
+    for sender_id in rows:
+        if sender_id is not None and type_map.get(sender_id) == "agent":
+            depth += 1
+        else:
+            break
+    return depth

--- a/backend/app/services/channel_router.py
+++ b/backend/app/services/channel_router.py
@@ -16,8 +16,14 @@ from app.models.conversation import Conversation, ConversationMessage, Conversat
 from app.models.notification_preference import NotificationPreference
 from app.models.team import TeamMember
 from app.models.user_block import UserBlock
+from app.services.chain_depth import compute_agent_chain_depth
 
 logger = logging.getLogger(__name__)
+
+# story #2608 P1: 인간 앵커 없는 에이전트 연쇄가 유효한 최대 hop 수. 실측 근거(정상 A2A
+# 협업 사슬 길이 분포)가 아직 없어 4로 시작한다(PM→BE→FE→QA류 짧은 핸드오프 사슬은
+# 통과·A↔B 무한 핑퐁류는 몇 초 안에 걸림) — 값 자체는 PO 판단 대상(PR 참조).
+_AGENT_CHAIN_DEPTH_CAP: int = 4
 
 
 class ChannelRouterError(Exception):
@@ -60,6 +66,14 @@ async def route_message(
     **free_response 대화 오버라이드**(AC2 옵트아웃): `conversation.free_response=true`면
     이 대화 한정으로 level="mentions"인 recipient는 "all"로 완화된다 — 단 명시 "mute"는
     안 뒤집는다(회원 자신의 «아예 알림 원치 않음» 선택이 방 설정보다 우선).
+
+    story #2608 P1: agent가 보낸 메시지이고, 이 대화의 최근 연쇄 깊이(compute_agent_chain_
+    depth, human 메시지 나올 때까지 역순 카운트)가 `_AGENT_CHAIN_DEPTH_CAP`을 넘으면, agent
+    recipient는 **mentions/all/free_response 판정과 무관하게** 제외된다(reason="chain-
+    expired") — A↔B가 서로를 계속 유효하게 멘션하는 최악 케이스(mentions 조건 자체는 항상
+    통과)를 막는 유일한 축이라 다른 판정보다 뒤에, 최종 게이트로 건다. human recipient는
+    이 게이트의 대상이 아니다(인간이 바로 그 "앵커"라 차단하면 안 됨 — 오히려 human-
+    intervention 이벤트로 알려야 할 대상).
     """
     try:
         # 1. 메시지 + 발신자 조회
@@ -123,6 +137,15 @@ async def route_message(
 
         if not recipient_ids:
             return []
+
+        # story #2608 P1: sender가 agent일 때만 연쇄 깊이를 잰다(human 발신은 애초에 이
+        # 게이트 대상 밖 — 정의상 그 메시지 자체가 앵커라 depth=0으로 리셋되는 것과 동치).
+        chain_expired = False
+        if sender_type == "agent":
+            depth = await compute_agent_chain_depth(
+                db, msg.conversation_id, max_scan=_AGENT_CHAIN_DEPTH_CAP,
+            )
+            chain_expired = depth > _AGENT_CHAIN_DEPTH_CAP
 
         # 4. 수신자 type 배치 조회
         member_rows = (await db.execute(
@@ -210,6 +233,16 @@ async def route_message(
                         rid, msg.conversation_id, "mentions level, not mentioned",
                     )
                     continue
+
+            # story #2608 P1: 최종 게이트 — 그 외 모든 판정을 통과했어도(멘션 성립·all·
+            # free_response 완화 전부 포함) agent recipient는 연쇄가 cap을 넘으면 여기서
+            # 막힌다. human recipient는 대상 밖(위 docstring).
+            if chain_expired and recipient_type == "agent":
+                logger.info(
+                    "delivery_contract: excluded recipient=%s conversation_id=%s reason=%s",
+                    rid, msg.conversation_id, "chain-expired",
+                )
+                continue
 
             decisions.append(DeliveryDecision(
                 member_id=rid,

--- a/backend/app/services/handle_mention_parser.py
+++ b/backend/app/services/handle_mention_parser.py
@@ -24,9 +24,20 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.member import Member
 
+# story #2608 후속(카디르 QA 발견, #2603 종결부): 64자 초과 handle + 그 65번째 문자가
+# 하이픈인 엣지에서, 정규식이 그 64번째 문자에서 word-boundary(\b)를 만족해(하이픈은 \w가
+# 아니라 alnum→hyphen 전환이 곧 경계) **긴 handle을 64자로 자른 접두사**를 캡처하고, 그
+# 접두사가 우연히 다른(짧은) 에이전트의 실 handle과 정확 일치하면 엉뚱한 상대에게 멘션이
+# 가는 오매칭이 난다(AC4 위반 — 부분 문자열 오매칭 금지). 정규식의 캡처 상한(_MAX_HANDLE_LEN)
+# 과 채번측 상한(generate_unique_handle)을 같은 상수로 묶어, "생성되는 handle은 절대 파서의
+# 캡처 한도를 넘지 않는다"를 구조적으로 보장한다(둘이 따로 드리프트할 수 없음).
+_MAX_HANDLE_LEN = 64
+
 # word-boundary: `@` 앞이 단어문자가 아니어야(이메일 `user@host`의 `@host`를 멘션으로 오인 안 함).
 # handle 문자셋은 슬러그 규칙(영숫자+하이픈)과 대칭 — generate_unique_handle이 만드는 형태만 매치.
-_HANDLE_TOKEN_RE = re.compile(r"(?<![\w@])@([a-zA-Z0-9][a-zA-Z0-9-]{0,63})\b")
+_HANDLE_TOKEN_RE = re.compile(
+    r"(?<![\w@])@([a-zA-Z0-9][a-zA-Z0-9-]{0," + str(_MAX_HANDLE_LEN - 1) + r"})\b"
+)
 
 
 def extract_handle_tokens(content: str) -> list[str]:
@@ -68,13 +79,25 @@ async def resolve_handle_mentions(
     return set(rows)
 
 
+# "-" + 최대 3자리 카운터(-999)까지 여유 — 그 이상 겹치는 org는 실사용에서 안 봤고, 설령
+# 그래도 아래 while이 -1000, -1001...로 계속 길이를 넘길 일은 없다(_SUFFIX_RESERVE가 그
+# 자릿수보다 넉넉해 조기 오버플로우 없음).
+_SUFFIX_RESERVE = 6
+
+
 def slugify_handle_base(name: str) -> str:
     """이름 → ASCII 슬러그 후보(고유성 보장 전 base). 결과가 빈 문자열이면(이름이 전부
     비ASCII, 예: 순한글 이름) 호출부가 "agent" 폴백을 쓴다 — @handle 파서가 word-boundary
     정규식으로 매칭하므로 handle 자체는 ASCII 토큰이어야 안전(0241 마이그의 백필 로직과 동형,
-    런타임 신규 생성용으로 별도 보관 — 마이그는 훗날 재실행 안 되므로 독립 사본이 맞다)."""
+    런타임 신규 생성용으로 별도 보관 — 마이그는 훗날 재실행 안 되므로 독립 사본이 맞다).
+
+    story #2608 후속(카디르 QA #2603 종결부 발견): `-N` 접미사가 붙을 여유(_SUFFIX_RESERVE)를
+    남기고 `_MAX_HANDLE_LEN`으로 자른다 — 생성되는 handle이 파서의 캡처 상한을 넘으면 그 자체가
+    "자기 자신을 완전히 멘션할 수 없는 handle"이 되는 모순이라(위 _HANDLE_TOKEN_RE 주석), 원천
+    차단이 근본 fix다(사후 파서 보정이 아니라)."""
     normalized = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode("ascii")
-    return re.sub(r"[^a-zA-Z0-9]+", "-", normalized).strip("-").lower()
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", normalized).strip("-").lower()
+    return slug[: _MAX_HANDLE_LEN - _SUFFIX_RESERVE].strip("-")
 
 
 async def generate_unique_handle(db: AsyncSession, *, org_id: uuid.UUID, name: str) -> str:

--- a/backend/tests/test_2603_handle_mention_parser.py
+++ b/backend/tests/test_2603_handle_mention_parser.py
@@ -174,3 +174,30 @@ async def test_generate_unique_handle_dedupes_within_org():
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)
         await engine.dispose()
+
+
+def test_handle_generation_never_exceeds_parser_capture_cap():
+    """story #2608 후속(카디르 QA 발견, #2603 종결부) — 64자 초과 handle + 65번째 문자가
+    하이픈인 엣지에서 파서가 긴 handle을 잘라 다른(짧은) 에이전트와 오매칭할 수 있었다.
+    생성 측(slugify_handle_base)이 파서의 캡처 상한(_MAX_HANDLE_LEN)보다 항상 짧게 만들면
+    이 클래스의 오매칭 자체가 구조적으로 불가능해진다."""
+    from app.services.handle_mention_parser import (
+        _MAX_HANDLE_LEN,
+        _HANDLE_TOKEN_RE,
+        slugify_handle_base,
+    )
+
+    very_long_name = "This Is An Extremely Long Agent Name That Goes Well Past Sixty Four Characters In Total Length"
+    base = slugify_handle_base(very_long_name)
+    assert len(base) < _MAX_HANDLE_LEN, "base 하나만으로도 이미 상한 밑이어야(접미사 여유 포함 전)"
+
+    # -N 접미사가 붙어도(현실적 충돌 자릿수 내) 여전히 상한 밑 — 그래서 그 handle 전체를
+    # "@" + handle로 써도 파서가 정확히 전체를 캡처할 수 있어야 한다(자기 자신을 완전히
+    # 멘션 못 하는 handle이 생기면 안 됨).
+    for suffix in ("", "-2", "-99"):
+        candidate = f"{base}{suffix}"
+        assert len(candidate) <= _MAX_HANDLE_LEN, f"{candidate!r} 길이 {len(candidate)}가 상한 초과"
+        m = _HANDLE_TOKEN_RE.match(f"@{candidate} hello")
+        assert m is not None and m.group(1) == candidate, (
+            f"자기 자신을 완전히 캡처 못함 — {candidate!r}"
+        )

--- a/backend/tests/test_2608_chain_depth.py
+++ b/backend/tests/test_2608_chain_depth.py
@@ -1,0 +1,192 @@
+"""story #2608 P1 — compute_agent_chain_depth 핵심 알고리즘(실 PG).
+
+"최근 human 메시지 이후 연속 agent 발신 메시지 수"를 상태(카운터 컬럼) 없이 매번 유도하는
+쿼리의 정확성을 검증한다 — depth 산정이 틀리면 P1 전체(cap 판정·human-intervention 발생
+여부)가 틀린다."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2608", slug=f"org2608-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_member(session, org_id, project_id, *, member_type):
+    from app.models.team import TeamMember
+
+    m = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type=member_type,
+        name=member_type, is_active=True,
+    )
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_conversation(session, org_id, project_id):
+    from app.models.conversation import Conversation
+
+    conv = Conversation(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="group")
+    session.add(conv)
+    await session.commit()
+    return conv.id
+
+
+async def _seed_message(session, conversation_id, sender_id, *, seq_offset):
+    from datetime import datetime, timedelta, timezone
+    from app.models.conversation import ConversationMessage
+
+    msg = ConversationMessage(
+        id=uuid.uuid4(), conversation_id=conversation_id, sender_id=sender_id,
+        content=f"msg-{seq_offset}",
+        # 명시 created_at으로 최신순 정렬을 결정론적으로 고정(같은 트랜잭션 내 여러 insert가
+        # server_default now()로 동시각/역전될 위험 제거).
+        created_at=datetime(2026, 8, 13, tzinfo=timezone.utc) + timedelta(seconds=seq_offset),
+    )
+    session.add(msg)
+    await session.commit()
+
+
+@pytest.mark.anyio
+@pytest.mark.destructive_schema
+@pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+async def test_depth_counts_consecutive_agent_messages_from_most_recent():
+    from app.services.chain_depth import compute_agent_chain_depth
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            human_id = await _seed_member(s, org_id, project_id, member_type="human")
+            agent_a = await _seed_member(s, org_id, project_id, member_type="agent")
+            agent_b = await _seed_member(s, org_id, project_id, member_type="agent")
+            conv_id = await _seed_conversation(s, org_id, project_id)
+
+            await _seed_message(s, conv_id, human_id, seq_offset=0)
+            await _seed_message(s, conv_id, agent_a, seq_offset=1)
+            await _seed_message(s, conv_id, agent_b, seq_offset=2)
+            await _seed_message(s, conv_id, agent_a, seq_offset=3)
+
+        async with Session() as s:
+            depth = await compute_agent_chain_depth(s, conv_id, max_scan=10)
+            assert depth == 3, "human 이후 agent 3연속(A·B·A) — 그 앞의 human까지는 안 세야"
+    finally:
+        from app.core.database import Base
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.destructive_schema
+@pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+async def test_human_message_resets_depth_to_zero():
+    from app.services.chain_depth import compute_agent_chain_depth
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            human_id = await _seed_member(s, org_id, project_id, member_type="human")
+            agent_a = await _seed_member(s, org_id, project_id, member_type="agent")
+            conv_id = await _seed_conversation(s, org_id, project_id)
+
+            await _seed_message(s, conv_id, agent_a, seq_offset=0)
+            await _seed_message(s, conv_id, agent_a, seq_offset=1)
+            await _seed_message(s, conv_id, human_id, seq_offset=2)  # 가장 최근 = human
+
+        async with Session() as s:
+            depth = await compute_agent_chain_depth(s, conv_id, max_scan=10)
+            assert depth == 0, "가장 최근 메시지가 human이면(=바로 그 앵커) depth는 0이어야"
+    finally:
+        from app.core.database import Base
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.destructive_schema
+@pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+async def test_depth_bounded_by_max_scan_when_no_human_in_window():
+    """human 메시지가 max_scan 범위 밖에 있으면(또는 아예 없으면) depth는 max_scan+1에서
+    멈춘다(그 이상 스캔 안 함 — O(max_scan) 비용 상한이 실제로 지켜지는지)."""
+    from app.services.chain_depth import compute_agent_chain_depth
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_a = await _seed_member(s, org_id, project_id, member_type="agent")
+            conv_id = await _seed_conversation(s, org_id, project_id)
+
+            for i in range(10):  # human 없이 agent만 10개
+                await _seed_message(s, conv_id, agent_a, seq_offset=i)
+
+        async with Session() as s:
+            depth = await compute_agent_chain_depth(s, conv_id, max_scan=4)
+            assert depth == 5, "LIMIT max_scan+1(=5)까지만 보고 그 값 그대로 반환해야"
+    finally:
+        from app.core.database import Base
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.destructive_schema
+@pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+async def test_empty_conversation_depth_zero():
+    from app.services.chain_depth import compute_agent_chain_depth
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            conv_id = await _seed_conversation(s, org_id, project_id)
+
+        async with Session() as s:
+            depth = await compute_agent_chain_depth(s, conv_id, max_scan=10)
+            assert depth == 0
+    finally:
+        from app.core.database import Base
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()

--- a/backend/tests/test_2608_human_intervention_dispatch.py
+++ b/backend/tests/test_2608_human_intervention_dispatch.py
@@ -1,0 +1,123 @@
+"""story #2608 P1 AC1 — _dispatch_human_intervention_event 격리 가드(mock DB, test_event1config_
+message_gating.py와 동일 패턴). "연쇄 cap 초과 시 침묵이 아니라 이벤트로"의 이벤트 생성부만
+좁게 검증 — target 산출(human만·agent/sender 제외)과 payload 형태(blocked_recipient_ids·
+chain_depth_cap·reason)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import app.routers.conversations as conv
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _result_all(rows: list):
+    r = SimpleNamespace()
+    r.all = lambda: rows
+    return r
+
+
+def _msg(mentioned=None):
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        conversation_id=uuid.uuid4(),
+        thread_id=None,
+        reply_count=0,
+        last_reply_at=None,
+        content="hi",
+        mentioned_ids=list(mentioned or []),
+        attachments=[],
+        created_at=datetime.now(timezone.utc),
+        deleted_at=None,
+    )
+
+
+def _sender():
+    return SimpleNamespace(id=uuid.uuid4(), name="에이전트A", type="agent")
+
+
+class _DB:
+    def __init__(self, exec_rows: list):
+        self._exec_rows = list(exec_rows)
+        self.added: list = []
+        self.add = lambda ev: self.added.append(ev)
+        self.flush = AsyncMock()
+
+    async def execute(self, *_a, **_k):
+        return self._exec_rows.pop(0)
+
+
+def _patches():
+    return [patch("app.services.activity_stream.extract_activities_best_effort", AsyncMock())]
+
+
+@pytest.mark.anyio
+async def test_only_human_participants_receive_intervention_event():
+    conversation = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    msg = _msg()
+    sender = _sender()
+    human1, human2, agent_other = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    blocked = {uuid.uuid4()}  # 상대 agent(연쇄 게이트에 막힌 agent recipient)
+
+    db = _DB([
+        _result_all([(human1, "human"), (human2, "human"), (agent_other, "agent")]),
+    ])
+
+    import contextlib
+    with contextlib.ExitStack() as stack:
+        for p in _patches():
+            stack.enter_context(p)
+        result = await conv._dispatch_human_intervention_event(
+            db, conversation, msg, uuid.uuid4(), sender, blocked, chain_depth_cap=4,
+        )
+
+    assert len(db.added) == 2, "human 참가자 2명에게만 Event가 만들어져야(agent는 제외)"
+    recipient_ids = {ev.recipient_id for ev in db.added}
+    assert recipient_ids == {human1, human2}
+    for ev in db.added:
+        assert ev.event_type == "conversation.human_intervention_requested"
+        assert ev.recipient_type == "human"
+        assert ev.payload["reason"] == "chain-expired"
+        assert ev.payload["chain_depth_cap"] == 4
+        assert ev.payload["blocked_recipient_ids"] == [str(next(iter(blocked)))]
+    assert len(result) == 2
+
+
+@pytest.mark.anyio
+async def test_no_human_participants_no_event_and_no_db_roundtrip():
+    """human이 대화에 아무도 없으면(전부 agent) — 조회 1회 후 바로 빈 결과, INSERT 0건."""
+    conversation = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    msg = _msg()
+    sender = _sender()
+    agent_only = uuid.uuid4()
+
+    db = _DB([_result_all([(agent_only, "agent")])])
+
+    result = await conv._dispatch_human_intervention_event(
+        db, conversation, msg, uuid.uuid4(), sender, {uuid.uuid4()}, chain_depth_cap=4,
+    )
+    assert result == []
+    assert db.added == []
+
+
+@pytest.mark.anyio
+async def test_no_project_id_returns_empty_without_query():
+    """project_id 없는 conversation은 조회조차 안 한다(_dispatch_conversation_event와 동일
+    선행 가드 — DM 미배정 등 edge case)."""
+    conversation = SimpleNamespace(id=uuid.uuid4(), project_id=None)
+    msg = _msg()
+    sender = _sender()
+
+    db = _DB([])  # execute가 호출되면 IndexError로 즉시 실패 — 조회 0회를 강제.
+    result = await conv._dispatch_human_intervention_event(
+        db, conversation, msg, uuid.uuid4(), sender, {uuid.uuid4()}, chain_depth_cap=4,
+    )
+    assert result == []

--- a/backend/tests/test_channel_router_multiproject_sender.py
+++ b/backend/tests/test_channel_router_multiproject_sender.py
@@ -8,9 +8,17 @@ route_message 가 MultipleResultsFound 로 안 깨지고 dispatch 되는지(send
 from __future__ import annotations
 
 import uuid
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+# story #2608 P1: route_message()은 sender_type=="agent"면 compute_agent_chain_depth를 추가로
+# 호출한다(그 함수 자체가 내부적으로 db.execute를 더 쓴다) — 기존 db.execute side_effect
+# 리스트를 안 건드리려고 그 함수 자체를 patch해 고정 depth를 준다. depth=1(<=cap)로 두면
+# 이 파일의 기존(P1 이전) 시나리오들은 전부 무회귀로 그대로 통과한다.
+_NOT_EXPIRED = patch(
+    "app.services.channel_router.compute_agent_chain_depth", AsyncMock(return_value=1),
+)
 
 
 @pytest.fixture
@@ -90,7 +98,8 @@ async def test_multiproject_agent_sender_dispatches_without_crash():
         _scalars([]),                       # 6 preferences
     ])
 
-    decisions = await route_message(msg.id, db)
+    with _NOT_EXPIRED:
+        decisions = await route_message(msg.id, db)
     # 발신자 제외·크래시/ChannelRouterError 없이 멘션된 recipient에게만 decision.
     assert len(decisions) == 1
     assert decisions[0].member_id == recipient
@@ -128,7 +137,8 @@ async def test_agent_group_default_excludes_unmentioned_agent_recipient():
         _scalars([]),
     ])
 
-    decisions = await route_message(msg.id, db)
+    with _NOT_EXPIRED:
+        decisions = await route_message(msg.id, db)
     assert decisions == [], "멘션 없는데 decision이 생기면 원 루프가 그대로 재현된다"
 
 
@@ -194,7 +204,8 @@ async def test_free_response_conversation_relaxes_mentions_to_all():
         _scalars([]),
     ])
 
-    decisions = await route_message(msg.id, db)
+    with _NOT_EXPIRED:
+        decisions = await route_message(msg.id, db)
     assert len(decisions) == 1
     assert decisions[0].level == "all"
     assert "free_response override" in decisions[0].reason
@@ -228,7 +239,8 @@ async def test_explicit_mute_wins_over_free_response_and_mention():
         _scalars([_pref(recipient, scope_type="global", level="mute")]),
     ])
 
-    decisions = await route_message(msg.id, db)
+    with _NOT_EXPIRED:
+        decisions = await route_message(msg.id, db)
     assert decisions == [], "명시 mute 선택인데 decision이 생기면 회원 자기결정권 위반"
 
 
@@ -261,7 +273,112 @@ async def test_explicit_all_preference_overrides_agent_group_default():
         _scalars([_pref(recipient, scope_type="global", level="all", channel="sse")]),
     ])
 
-    decisions = await route_message(msg.id, db)
+    with _NOT_EXPIRED:
+        decisions = await route_message(msg.id, db)
     assert len(decisions) == 1
     assert decisions[0].level == "all"
     assert decisions[0].reason == "preference scope=global"
+
+
+@pytest.mark.anyio
+async def test_chain_expired_blocks_agent_recipient_even_when_mentioned():
+    """story #2608 P1 AC1 — A↔B 상호멘션(멘션은 항상 유효)류의 유일한 탈출구. mentions
+    체크는 통과해도(recipient가 명시 멘션됨) chain_expired=True면 최종 게이트에서 막힌다."""
+    from app.services.channel_router import route_message
+
+    sender = uuid.uuid4()
+    recipient = uuid.uuid4()
+    conv = uuid.uuid4()
+    proj = uuid.uuid4()
+
+    msg = MagicMock()
+    msg.id = uuid.uuid4()
+    msg.sender_id = sender
+    msg.conversation_id = conv
+    msg.thread_id = None
+    msg.mentioned_ids = [recipient]  # 유효한 멘션 — 그런데도 막혀야 한다.
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=[
+        _scalar(msg),
+        _scalar("agent"),
+        _scalars([sender, recipient]),
+        _scalars([]),
+        _all([(recipient, "agent")]),
+        _row(project_id=proj, type="group", free_response=False),
+        _scalars([]),
+    ])
+
+    with patch("app.services.channel_router.compute_agent_chain_depth", AsyncMock(return_value=5)):
+        decisions = await route_message(msg.id, db)
+    assert decisions == [], "연쇄 cap 초과인데 멘션 성립만으로 decision이 생기면 P1이 안 먹는다"
+
+
+@pytest.mark.anyio
+async def test_chain_expired_does_not_block_human_recipient():
+    """human recipient는 연쇄 게이트 대상이 아니다 — human이 바로 그 개입 대상."""
+    from app.services.channel_router import route_message
+
+    sender = uuid.uuid4()
+    human_recipient = uuid.uuid4()
+    conv = uuid.uuid4()
+    proj = uuid.uuid4()
+
+    msg = MagicMock()
+    msg.id = uuid.uuid4()
+    msg.sender_id = sender
+    msg.conversation_id = conv
+    msg.thread_id = None
+    msg.mentioned_ids = [human_recipient]
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=[
+        _scalar(msg),
+        _scalar("agent"),
+        _scalars([sender, human_recipient]),
+        _scalars([]),
+        _all([(human_recipient, "human")]),
+        _row(project_id=proj, type="group", free_response=False),
+        _scalars([]),
+    ])
+
+    with patch("app.services.channel_router.compute_agent_chain_depth", AsyncMock(return_value=5)):
+        decisions = await route_message(msg.id, db)
+    assert len(decisions) == 1
+    assert decisions[0].member_id == human_recipient
+
+
+@pytest.mark.anyio
+async def test_chain_within_cap_delivers_normally():
+    """정상 A2A 협업(깊이 cap 이내)은 비회귀(AC4) — depth가 cap과 같아도(등호 없음) 통과."""
+    from app.services.channel_router import route_message, _AGENT_CHAIN_DEPTH_CAP
+
+    sender = uuid.uuid4()
+    recipient = uuid.uuid4()
+    conv = uuid.uuid4()
+    proj = uuid.uuid4()
+
+    msg = MagicMock()
+    msg.id = uuid.uuid4()
+    msg.sender_id = sender
+    msg.conversation_id = conv
+    msg.thread_id = None
+    msg.mentioned_ids = [recipient]
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=[
+        _scalar(msg),
+        _scalar("agent"),
+        _scalars([sender, recipient]),
+        _scalars([]),
+        _all([(recipient, "agent")]),
+        _row(project_id=proj, type="group", free_response=False),
+        _scalars([]),
+    ])
+
+    with patch(
+        "app.services.channel_router.compute_agent_chain_depth",
+        AsyncMock(return_value=_AGENT_CHAIN_DEPTH_CAP),
+    ):
+        decisions = await route_message(msg.id, db)
+    assert len(decisions) == 1, "정확히 cap과 같은 깊이(등호)는 아직 유효해야 한다"


### PR DESCRIPTION
## Summary
Blueprint: [delivery-contract-blueprint-v0-1](entity:doc:dd5154f3-d5be-4083-8c4b-3d03bdea0d0b) P1, building on #2603 (merged, #3000). P0's `mentions` default alone doesn't stop the mutual-mention worst case (A always mentions B, B always mentions A — the mentions condition never fails, so it never gets filtered by P0's gate). This closes that gap as a **contract validity condition, not counter-state**.

- **`chain_depth.py`** (new): `compute_agent_chain_depth()` derives "consecutive agent-sent messages since the last human message" fresh on every call — `ORDER BY created_at DESC LIMIT max_scan+1` on `conversation_messages` (`conversation_id`-indexed), **O(max_scan) bounded, no new column**. No stored counter means no reset-logic bug surface: a human message simply changes what the next query sees, there's nothing to explicitly reset.
- **`channel_router.py`**: `route_message()` calls this once per agent-sent message (only when `sender_type=="agent"` — human-sent messages never pay the query) and gates every agent recipient behind it as the **final** check, after mentions/all/free_response all resolve to "would otherwise deliver." That ordering is what actually stops the A↔B case: no matter how valid the mention, `depth > cap` blocks it. Human recipients are exempt — they're the anchor, not a link in the chain being capped.
- **`conversations.py`**: new `_dispatch_human_intervention_event()` emits `conversation.human_intervention_requested` to the conversation's human participants when a same-message explicit agent-mention gets capped — "why is it quiet" stays answerable via an event, not just a log line. Reuses the *exact same* `compute_agent_chain_depth()` call `route_message()` uses (not a second way of measuring depth) — it's called from a second site only because recipient-filtering needs it per-recipient inside a loop, while the event only needs it once per message.
- **`_AGENT_CHAIN_DEPTH_CAP = 4`**: no measured data on normal A2A hand-off chain lengths exists yet, so this is a reasoned starting point (a PM→BE→FE→QA short hand-off chain survives; A↔B ping-pong gets caught within a few hops), **not a fabricated number** — flagging for PO to confirm or override before this ships further.

## Query cost (as requested)
`compute_agent_chain_depth` runs `SELECT sender_id FROM conversation_messages WHERE conversation_id = ? ORDER BY created_at DESC LIMIT N+1` (N = `_AGENT_CHAIN_DEPTH_CAP` = 4, so `LIMIT 5`) on the already-indexed `conversation_id` column, plus a bounded `WHERE id IN (...)` lookup against `team_members` for at most those 5 sender ids. It runs **once per agent-authored message dispatch** (not per-recipient) inside `route_message()`, which itself already runs once per message send — this adds one small indexed query to an existing per-message code path, not a new per-recipient or unbounded cost.

## Also fixed (Kadir QA finding on #2603's tail, non-blocking)
Handle generation had no length cap, so a >64 char name could produce a handle longer than the `@handle` parser's capture window (regex bounded at 64 chars to stay AC4 exact-match-safe). A hyphen landing right at the 65th character let the parser silently truncate to a 64-char prefix that could then exact-match an unrelated shorter agent's real handle. `slugify_handle_base()` now caps output against the same `_MAX_HANDLE_LEN` constant the parser regex uses, so the two can't drift apart again. **Prevention only** — does not retroactively re-truncate any already-backfilled handle from migration 0241 (out of scope here, and I have no visibility into whether current data actually hit this edge).

## Test plan
- [x] `tests/test_2608_chain_depth.py` (4, real PG): depth counts consecutive agent messages correctly, human message resets to 0, bounded by `max_scan` when no human is in the scan window, empty conversation → 0.
- [x] `tests/test_channel_router_multiproject_sender.py` — 3 new cases: chain-expired blocks an agent recipient *even when validly mentioned* (AC1's core assertion), chain-expiry does not block human recipients, depth exactly equal to the cap (no strict inequality) still delivers (AC4 non-regression). Existing 6 cases updated to patch `compute_agent_chain_depth` (fixed depth=1) rather than thread extra DB mocks through — 9/9 green.
- [x] `tests/test_2608_human_intervention_dispatch.py` (3): only human participants get the event, no-humans-in-conversation short-circuits with zero DB writes, no-`project_id` conversation short-circuits before any query.
- [x] `tests/test_2603_handle_mention_parser.py` — 1 new case for the length-cap fix, confirmed it fails against the pre-fix code and passes after.
- [x] Broader regression sweep green: `test_conversations.py` (15), `test_2349_user_blocks_realdb.py` + `test_event1config_*` (27) — confirmed in isolation from the `create_all`/`drop_all`-based test files in this session (mixing them in one pytest run against a shared throwaway DB caused unrelated failures from DB-reuse across test files, not from this change — reproduced and diagnosed before ruling it out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)