### PR TITLE
feat(#2594): --warning-strong 토큰 신설 + text-warning 이관 (라이트 대비 수리)

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx
@@ -573,7 +573,7 @@ export default function RetroSessionPage() {
   const CATEGORY_COLORS: Record<RetroItemCategory, string> = {
     good: 'text-success',
     bad: 'text-destructive',
-    improve: 'text-warning',
+    improve: 'text-warning-strong',
   };
   const CATEGORY_DOT_COLORS: Record<RetroItemCategory, string> = {
     good: 'bg-success',

--- a/apps/web/src/app/(authenticated)/organization/workforce/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/[id]/page.tsx
@@ -609,7 +609,7 @@ export default function AgentDetailPage() {
               </pre>
             </>
           ) : !hasActiveKey ? (
-            <p className="text-xs text-warning">{t('agentMcpKeyRequired')}</p>
+            <p className="text-xs text-warning-strong">{t('agentMcpKeyRequired')}</p>
           ) : (
             <p className="text-xs text-muted-foreground">{t('agentMcpSecurityNote')}</p>
           )}
@@ -655,7 +655,7 @@ export default function AgentDetailPage() {
               </code>
             </>
           ) : !hasActiveKey ? (
-            <p className="text-xs text-warning">{t('agentFakechatEnvKeyRequired')}</p>
+            <p className="text-xs text-warning-strong">{t('agentFakechatEnvKeyRequired')}</p>
           ) : (
             <p className="text-xs text-muted-foreground">{t('agentFakechatEnvKeySecurityNote')}</p>
           )}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -145,6 +145,7 @@
   --color-destructive: var(--destructive);
   --color-success: var(--success);
   --color-warning: var(--warning);
+  --color-warning-strong: var(--warning-strong);
   --color-info: var(--info);
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
@@ -301,6 +302,10 @@
   /* Semantic status tokens */
   --success: oklch(0.55 0.16 145);
   --warning: oklch(0.75 0.16 85);
+  /* story #2594: text-warning 전용 강조색 — 라이트 --warning(L0.75)은 흰 배경 2.25:1(AA 미달)이라
+     text에 못 쓴다. L0.52(5.54:1)로 낮춘 별 토큰. solid bg-warning은 밝은 앰버(L0.75) 정체성 유지,
+     text-warning → text-warning-strong 이관(선례: --brand-strong). --warning-tint/-bg/-border 무변경. */
+  --warning-strong: oklch(0.52 0.16 85);
   --info: oklch(0.55 0.18 250);
   /* story #2023(ⓐ): 신설 — L5(진행중·작업중·미읽음·측정·LLM 호출) 위반을 info로 교체하면서
      배경(bg-info) 위 텍스트가 올라가는 자리가 생긴다. 라이트/다크가 반대로 필요(핸드오프
@@ -441,6 +446,9 @@
   /* Semantic status tokens */
   --success: oklch(0.65 0.15 145);
   --warning: oklch(0.70 0.16 85);
+  /* story #2594: 다크는 현 --warning(L0.70)이 이미 흰 텍스트 배경 6.98:1로 AA 통과 → strong=동일값
+     (다크 무변경). 라이트와 값이 갈리는 건 의도(테마별 대비 헤드룸이 반대). */
+  --warning-strong: oklch(0.70 0.16 85);
   --info: oklch(0.65 0.18 250);
   /* story #2023(ⓐ): 라이트와 다른 값(어두운 남색) — 다크 bg-info는 밝은 파랑이라 밝은
      텍스트로는 AA 미달(실측 3.24:1). --primary-foreground 다크와 동일 보정 패턴. */

--- a/apps/web/src/components/agents/agent-performance-panel.tsx
+++ b/apps/web/src/components/agents/agent-performance-panel.tsx
@@ -176,7 +176,7 @@ export function AgentPerformancePanel() {
                         <div className="truncate text-sm font-semibold text-foreground">{agent.name}</div>
                         {agent.rank != null && (
                           <div className="mt-0.5 flex items-center gap-1">
-                            <Trophy className="size-3 text-warning" />
+                            <Trophy className="size-3 text-warning-strong" />
                             <span className="text-xs text-muted-foreground">#{agent.rank}</span>
                           </div>
                         )}
@@ -225,7 +225,7 @@ export function AgentPerformancePanel() {
           <SectionCard>
             <SectionCardHeader>
               <div className="flex items-center gap-2">
-                <Trophy className="size-4 text-warning" />
+                <Trophy className="size-4 text-warning-strong" />
                 <span className="text-sm font-semibold text-foreground">{t('leaderboardTitle')}</span>
               </div>
               <p className="mt-0.5 text-xs text-muted-foreground">{t('leaderboardDescription')}</p>
@@ -241,7 +241,7 @@ export function AgentPerformancePanel() {
                       key={agent.id}
                       className="flex items-center gap-3 px-3 py-2.5"
                     >
-                      <span className={`w-6 shrink-0 text-center text-sm font-bold ${idx === 0 ? 'text-warning' : idx === 1 ? 'text-muted-foreground' : idx === 2 ? 'text-warning/70' : 'text-muted-foreground'}`}>
+                      <span className={`w-6 shrink-0 text-center text-sm font-bold ${idx === 0 ? 'text-warning-strong' : idx === 1 ? 'text-muted-foreground' : idx === 2 ? 'text-warning/70' : 'text-muted-foreground'}`}>
                         {idx + 1}
                       </span>
                       <span className="flex-1 truncate text-sm font-medium text-foreground">{agent.name}</span>

--- a/apps/web/src/components/dashboard/command-center/action-zone.tsx
+++ b/apps/web/src/components/dashboard/command-center/action-zone.tsx
@@ -42,7 +42,7 @@ export function QueueRow({ item }: { item: QueueItem }) {
         href="/inbox?tab=gates"
         className={`flex items-center gap-2 rounded-lg border border-l-2 border-border bg-card p-2.5 text-xs transition hover:border-muted-foreground/30 ${PRIORITY_BORDER[item.priority]}`}
       >
-        <ShieldCheck className="size-3.5 shrink-0 text-warning" />
+        <ShieldCheck className="size-3.5 shrink-0 text-warning-strong" />
         <span className="min-w-0 flex-1 truncate text-foreground">
           {t('ccQueueGateApproval')}{ctx.gate_type ? <span className="text-muted-foreground"> · {gateLabel(t, ctx.gate_type)}</span> : null}{ctx.kind ? <span className="text-muted-foreground"> · {ctx.kind}</span> : null}
         </span>
@@ -58,7 +58,7 @@ export function QueueRow({ item }: { item: QueueItem }) {
         href={ctx.blocked_story_id ? `/board?story=${ctx.blocked_story_id}` : '/board'}
         className={`flex items-center gap-2 rounded-lg border border-l-2 border-border bg-card p-2.5 text-xs transition hover:border-muted-foreground/30 ${PRIORITY_BORDER[item.priority]}`}
       >
-        <Ban className="size-3.5 shrink-0 text-warning" />
+        <Ban className="size-3.5 shrink-0 text-warning-strong" />
         <span className="min-w-0 flex-1 truncate text-foreground">
           <span className="text-muted-foreground">{t('ccQueueMyBlocker')} · </span>{item.title ?? ctx.story_id?.slice(0, 6)}
         </span>

--- a/apps/web/src/components/dashboard/command-center/overview-zone.tsx
+++ b/apps/web/src/components/dashboard/command-center/overview-zone.tsx
@@ -28,7 +28,7 @@ function RecentRow({ change, resolveName, t }: { change: RecentChange; resolveNa
   const ago = mins < 60 ? t('ccMinAgo', { n: mins }) : mins < 1440 ? t('ccHourAgo', { n: Math.floor(mins / 60) }) : t('ccDayAgo', { n: Math.floor(mins / 1440) });
   return (
     <li className="flex items-center gap-2 text-[11px]">
-      {tone === 'warn' ? <AlertTriangle className="size-3 shrink-0 text-warning" /> : <CheckCircle2 className="size-3 shrink-0 text-success" />}
+      {tone === 'warn' ? <AlertTriangle className="size-3 shrink-0 text-warning-strong" /> : <CheckCircle2 className="size-3 shrink-0 text-success" />}
       <span className="min-w-0 flex-1 truncate text-foreground">{label}{resolved ? <span className="text-muted-foreground"> · {resolved}</span> : null}</span>
       <span className="shrink-0 tabular-nums text-muted-foreground/70">{ago}</span>
     </li>

--- a/apps/web/src/components/docs/doc-url-chip.tsx
+++ b/apps/web/src/components/docs/doc-url-chip.tsx
@@ -27,7 +27,7 @@ export function DocUrlChip({ slug, onEdit, onDeriveFromTitle, labels }: DocUrlCh
       <button
         type="button"
         onClick={onDeriveFromTitle}
-        className="inline-flex items-center gap-1.5 text-xs text-warning transition-colors hover:text-warning/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-warning rounded"
+        className="inline-flex items-center gap-1.5 text-xs text-warning-strong transition-colors hover:text-warning/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-warning rounded"
       >
         <span className="max-w-[60vw] truncate font-mono md:max-w-md">/docs/{slug}</span>
         <span className="inline-flex items-center gap-1">

--- a/apps/web/src/components/docs/doc-url-dialog.tsx
+++ b/apps/web/src/components/docs/doc-url-dialog.tsx
@@ -129,7 +129,7 @@ function DocUrlDialogForm({
         )}
 
         {suggestion ? (
-          <p className="text-xs text-warning">
+          <p className="text-xs text-warning-strong">
             {labels.slugTaken} →{' '}
             <button
               type="button"

--- a/apps/web/src/components/epics/epic-status-transition.tsx
+++ b/apps/web/src/components/epics/epic-status-transition.tsx
@@ -123,7 +123,7 @@ export function EpicStatusTransition({
               <DropdownMenuItem key={to} disabled={busy} onClick={() => void transition(to)}>
                 {t(LABEL_KEY[to] ?? to)}
                 {GATED.has(`${status}>${to}`) ? (
-                  <span className="ml-2 inline-flex items-center gap-0.5 text-[10px] text-warning" title={t('transitionGateHint')}>
+                  <span className="ml-2 inline-flex items-center gap-0.5 text-[10px] text-warning-strong" title={t('transitionGateHint')}>
                     <ShieldCheck className="size-3 shrink-0" />
                   </span>
                 ) : null}

--- a/apps/web/src/components/hypotheses/hypothesis-gate-badge.tsx
+++ b/apps/web/src/components/hypotheses/hypothesis-gate-badge.tsx
@@ -58,7 +58,7 @@ export function HypothesisGateBadge({ hypothesis, gate, resolveName = (id) => id
     if (state === 'confirmed') return null;
     return (
       <span title={t(meta.labelKey)} aria-label={t(meta.labelKey)} className="inline-flex shrink-0 items-center">
-        <MetaIcon className={`size-3.5 ${state === 'rejected' ? 'text-destructive' : 'text-warning'}`} />
+        <MetaIcon className={`size-3.5 ${state === 'rejected' ? 'text-destructive' : 'text-warning-strong'}`} />
       </span>
     );
   }

--- a/apps/web/src/components/hypotheses/story-hypotheses-section.tsx
+++ b/apps/web/src/components/hypotheses/story-hypotheses-section.tsx
@@ -157,7 +157,7 @@ export function StoryHypothesesSection({
               </span>
               {isCrossEpic(h) ? (
                 <span
-                  className="inline-flex shrink-0 items-center gap-1 text-[11px] text-warning"
+                  className="inline-flex shrink-0 items-center gap-1 text-[11px] text-warning-strong"
                   title={t('crossEpicHint')}
                 >
                   <AlertTriangle className="size-3" aria-hidden />
@@ -227,7 +227,7 @@ export function StoryHypothesesSection({
                     </span>
                     {isCrossEpic(h) ? (
                       <span
-                        className="inline-flex shrink-0 items-center gap-1 text-[11px] text-warning"
+                        className="inline-flex shrink-0 items-center gap-1 text-[11px] text-warning-strong"
                         title={t('crossEpicHint')}
                       >
                         <AlertTriangle className="size-3" aria-hidden />

--- a/apps/web/src/components/integrations/pr-link-section.tsx
+++ b/apps/web/src/components/integrations/pr-link-section.tsx
@@ -230,7 +230,7 @@ export function PrLinkSection({ storyId }: { storyId: string }) {
                   <span className="truncate">{l.repo_full_name} #{l.pr_number}</span>
                   <ExternalLink className="size-2.5 shrink-0" />
                 </a>
-                <span className="inline-flex shrink-0 items-center gap-1 text-warning">
+                <span className="inline-flex shrink-0 items-center gap-1 text-warning-strong">
                   <span aria-hidden className="size-1.5 rounded-full bg-warning" />
                   {t('estimated', { confidence: l.confidence })}
                 </span>

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -319,7 +319,7 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
             {(blockedBy.length > 0 && story.status !== 'done') || labels.length > 0 || lineBadge ? (
               <div className="mb-2 flex flex-wrap items-center gap-1.5">
                 {blockedBy.length > 0 && story.status !== 'done' ? (
-                  <span className="inline-flex items-center gap-1 text-[10px] text-warning">
+                  <span className="inline-flex items-center gap-1 text-[10px] text-warning-strong">
                     <span className="size-1.5 shrink-0 rounded-full bg-warning" aria-hidden="true" />
                     {t('blockedBy', { count: blockedBy.length })}
                   </span>
@@ -409,7 +409,7 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
                       className="flex h-5 w-5 items-center justify-center"
                     >
                       {lastExecution.status === 'matched' ? (
-                        <Zap className="h-3 w-3 text-warning" />
+                        <Zap className="h-3 w-3 text-warning-strong" />
                       ) : (
                         <ZapOff className="h-3 w-3 text-muted-foreground/40" />
                       )}

--- a/apps/web/src/components/meetings/audio-recorder.tsx
+++ b/apps/web/src/components/meetings/audio-recorder.tsx
@@ -306,7 +306,7 @@ export function AudioRecorder({
           실패(예: micDenied 반복)에서는 null 경유 없이 같은 문자열이 재설정될 수 있다 — 별도 잠재
           결함으로 기록(훅 내부 상태머신은 이 스토리에서 재구성하지 않음). */}
       {errorCode && <p key={errorNonce} role="alert" aria-live="assertive" aria-atomic="true" className="mb-2 text-xs text-destructive">{t(ERROR_I18N_MAP[errorCode])}</p>}
-      {sttError && <p role="alert" aria-live="assertive" aria-atomic="true" className="mb-2 text-xs text-warning">{sttError}</p>}
+      {sttError && <p role="alert" aria-live="assertive" aria-atomic="true" className="mb-2 text-xs text-warning-strong">{sttError}</p>}
       {fileError && <p role="alert" aria-live="assertive" aria-atomic="true" className="mb-2 text-xs text-destructive">{fileError}</p>}
 
       {/* 녹음 상태 (AC2 + AC11 모바일 반응형) */}

--- a/apps/web/src/components/settings/ai-settings.tsx
+++ b/apps/web/src/components/settings/ai-settings.tsx
@@ -211,7 +211,7 @@ export function AiSettingsSection({ projectId }: { projectId: string }) {
             className="w-full rounded border px-3 py-2 text-sm"
           />
           {requiresNewApiKey && (
-            <p className="mt-1 text-xs text-warning">{t('aiApiKeyProviderChangeRequired')}</p>
+            <p className="mt-1 text-xs text-warning-strong">{t('aiApiKeyProviderChangeRequired')}</p>
           )}
         </div>
 

--- a/apps/web/src/components/verify/evidence-section.test.tsx
+++ b/apps/web/src/components/verify/evidence-section.test.tsx
@@ -61,7 +61,7 @@ describe('EvidenceSection (SSR snapshot — §7 상태 매트릭스 + P0-04 Clai
       wrap(<EvidenceSection workItemId="s1" workItemType="story" selfReported={true} humanVerified={null} humanVerifiedBy={null} humanVerifiedAt={null} />),
     );
     expect(markup).toContain('에이전트 주장');
-    expect(markup).toContain('text-warning');
+    expect(markup).toContain('text-warning-strong');
     expect(markup).not.toContain('text-success');
     expect(markup).toContain('근거 보기');
     // 디디 BE 가이드: "근거 보기" 클릭 전엔 evidence 리스트를 부르지 않는다(카드마다 N+1 방지).

--- a/apps/web/src/components/verify/evidence-section.tsx
+++ b/apps/web/src/components/verify/evidence-section.tsx
@@ -157,7 +157,7 @@ export function EvidenceSection({
       <div className="rounded-lg border border-border p-2.5">
         <button type="button" onClick={handleToggle} className="flex w-full items-center gap-2 text-left">
           <Check
-            className={cn('h-3 w-3 shrink-0', trustStage === 'verified' ? 'text-success/85' : 'text-warning')}
+            className={cn('h-3 w-3 shrink-0', trustStage === 'verified' ? 'text-success/85' : 'text-warning-strong')}
             strokeWidth={2.6}
             aria-hidden
           />

--- a/apps/web/src/ee/components/billing/pricing-limits-table.tsx
+++ b/apps/web/src/ee/components/billing/pricing-limits-table.tsx
@@ -106,7 +106,7 @@ export function PricingLimitsTable({ currentTier }: { currentTier: TierId }) {
                   key={tierId}
                   className={cn(
                     'px-3 py-2.5 text-right text-xs font-semibold',
-                    TIER_DEFINITIONS[tierId].limits.canPurchasePacks ? 'text-success' : 'text-warning',
+                    TIER_DEFINITIONS[tierId].limits.canPurchasePacks ? 'text-success' : 'text-warning-strong',
                     tierId === currentTier && 'bg-brand-tint',
                   )}
                 >

--- a/apps/web/src/ee/components/billing/pricing-plan-card.tsx
+++ b/apps/web/src/ee/components/billing/pricing-plan-card.tsx
@@ -110,7 +110,7 @@ export function PricingPlanCard({
         </li>
       </ul>
 
-      <div className={cn('mt-3 border-t border-dashed border-border pt-3 text-[11px]', limits.canPurchasePacks ? 'text-success' : 'text-warning')}>
+      <div className={cn('mt-3 border-t border-dashed border-border pt-3 text-[11px]', limits.canPurchasePacks ? 'text-success' : 'text-warning-strong')}>
         {limits.canPurchasePacks ? t('reachGo') : t('reachStopFree')}
       </div>
     </div>


### PR DESCRIPTION
## story #2594 — `--warning-strong` (라이트 warning 텍스트 대비 수리)

선생님 승인 **옵션 ⓑ**. base = `develop`. 시안: visual artifact `91eaf539` (v2).

### 문제
라이트 `--warning`(L0.75)은 흰/muted/tint 배경 위 **2.25:1** — WCAG AA(4.5) 미달, large-text(3.0)도 미달. 다크(L0.70)는 이미 정상.

### 처방 (ⓑ — solid 정체성 보존)
- **`--warning-strong` 신설** — 라이트 `oklch(0.52 0.16 85)`(5.54:1), 다크 `oklch(0.70 0.16 85)`(= 현 warning·다크 무변경). `@theme`에 `--color-warning-strong` 등록. 선례 `--brand-strong`(L0.45/0.55)와 동형.
- **`text-warning` → `text-warning-strong` 이관 (23곳)** — 아래 목록.
- **solid 불변** — `bg-warning`·`border-warning`·`--warning-tint/-bg`는 밝은 앰버(L0.75) 정체성 유지.

### 재실측 (리포 oklch→sRGB 변환기)
| 배경 (라이트) | 현재 L0.75 | strong L0.52 |
|---|---|---|
| page / card | 2.25 ✕ | 5.54 ✓ |
| bg-muted | 2.04 ✕ | 5.04 ✓ |
| warning-tint | 2.08 ✕ | 5.14 ✓ |
| warning-bg | 2.05 ✕ | 5.07 ✓ |

다크(L0.70)는 전 배경 5.49~6.98로 이미 통과 → strong = warning 동일값(무변경).

### 이관 목록 (23곳, `text-warning` → `text-warning-strong`)
- `app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx:576` (improve 카테고리색)
- `app/(authenticated)/organization/workforce/[id]/page.tsx:612, 658` (키 필요 안내 텍스트)
- `components/agents/agent-performance-panel.tsx:179, 228, 244` (Trophy·rank idx0)
- `components/dashboard/command-center/action-zone.tsx:45, 61` (ShieldCheck·Ban 아이콘)
- `components/dashboard/command-center/overview-zone.tsx:31` (AlertTriangle 아이콘)
- `components/docs/doc-url-chip.tsx:30` (칩 텍스트)
- `components/docs/doc-url-dialog.tsx:132` (안내 텍스트)
- `components/epics/epic-status-transition.tsx:126` (gate 힌트 10px)
- `components/hypotheses/hypothesis-gate-badge.tsx:61` (MetaIcon)
- `components/hypotheses/story-hypotheses-section.tsx:160, 230` (11px 배지)
- `components/integrations/pr-link-section.tsx:233` (경고 인라인)
- `components/kanban/story-card.tsx:322, 412` (blocked 10px·Zap 아이콘)
- `components/meetings/audio-recorder.tsx:309` (STT 오류 alert)
- `components/settings/ai-settings.tsx:214` (프로바이더 변경 안내)
- `components/verify/evidence-section.tsx:160` (self-reported 아이콘)
- `ee/components/billing/pricing-limits-table.tsx:109` · `pricing-plan-card.tsx:113` (팩 불가 표기)

`+` 토큰: `apps/web/src/app/globals.css` · 테스트 갱신: `evidence-section.test.tsx:64` (`toContain('text-warning-strong')` 정밀화).

### 전수 검토 (design 자기 게이트)
23곳 전부 라이트 표면 warning 텍스트/아이콘. **"어두운 표면 위 밝은 앰버가 의도된"(strong 이관이 위계를 죽이는) 자리는 0** → 전부 이관. 코멘트 5곳(prose)·`not.toContain` negative 테스트는 미변경.

### 후속 (이 PR 밖)
warning **alpha** 2곳 — `agent-performance-panel` `text-warning/70`(rank), `doc-url-chip` `hover:text-warning/80` — 도 sub-AA지만 rank/hover 위계 표현이라 별 판정 필요. (B) v1 4페이지 밖이라 axe 가드엔 안 걸림.

### 검증
`type-check` ✓ · `lint` 0 error · `vitest` 45(영향 4파일) ✓ · 정적 대비 가드 3종(tint-fg·no-new-tint-color-text·cross-element) ✓. **(A) cross-element detected 21→20** — 이관이 warning 채무 1건 실제 상환. **(B) axe** 런타임서 색쌍으로 이중검증.
