### PR TITLE
[SID:2614] 챗 엔티티 멘션 클릭 미리보기 소비처 — artifact/hypothesis 반쪽 해소

### DIFF
--- a/apps/web/src/components/chat/embed-card.link-states.test.tsx
+++ b/apps/web/src/components/chat/embed-card.link-states.test.tsx
@@ -9,8 +9,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
 import { EmbedCard, getEntityHref } from './embed-card';
 import { translateEntityStatus } from './entity-status-labels';
+// story #2614 — artifact 몸통이 이제 ArtifactThumbnail(canvas 네임스페이스 useTranslations)을
+// 렌더하므로, 그 경로를 태우는 테스트만 NextIntlClientProvider로 감싼다(다른 기존 테스트는
+// i18n을 안 타 무변경).
+import koMessages from '../../../messages/ko.json';
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
@@ -119,18 +124,83 @@ describe('AC3/AC4 — artifact는 레코드마다 갈린다(FK 있으면 ②, �
   });
 });
 
-describe('AC4 — hypothesis는 고정 ③(fetch 자체를 안 함, 무한 스피너 자체발견 회귀가드)', () => {
-  it('hypothesis는 fetch를 시도하지 않고 즉시 "열 수 있는 화면이 없습니다"를 보인다(무한 스피너 아님)', async () => {
-    const fetchSpy = vi.fn();
-    vi.stubGlobal('fetch', fetchSpy);
+describe('story #2614 — hypothesis는 풋터(담긴 곳)는 여전히 없지만(다대다, ③ 고정 무변경) 몸통은 이제 fetch해 statement를 보인다', () => {
+  it('hypothesis는 fetch해 statement를 몸통에 보이면서도 풋터는 "열 수 있는 화면이 없습니다"를 유지한다(거짓 링크 금지는 그대로)', async () => {
+    stubFetch(async (url) => {
+      expect(url).toContain('/api/hypotheses/');
+      return { ok: true, json: async () => ({ data: { statement: '이 가설은 검증되면 전환율이 오른다', status: 'proposed' } }) };
+    });
     await act(async () => {
       root.render(<EmbedCard entity_type="hypothesis" entity_id="h1" title="가설 A" status={null} />);
     });
     await openCard();
     await flush();
-    expect(fetchSpy).not.toHaveBeenCalled();
-    expect(document.body.textContent).not.toContain('불러오는 중');
+    expect(document.body.textContent).toContain('이 가설은 검증되면 전환율이 오른다');
+    expect(document.body.textContent).not.toContain('이 엔티티는 별도 미리보기가 없습니다');
+    // AC3/AC4 — 다대다라 단일 부모를 못 고르는 사실은 안 바뀌었다: 풋터는 여전히 "갈 곳 없음".
+    expect(document.querySelectorAll('a[href^="/goals/"], a[href^="/board?story="], a[href^="/docs?id="]').length).toBe(0);
     expect(document.body.textContent).toContain('열 수 있는 화면이 없습니다');
+  });
+
+  it('hypothesis 조회가 실패하면(대상 사라짐) 여전히 "대상이 없습니다"로 정직하게 갈린다(무한 스피너였던 자체발견 회귀 재확認)', async () => {
+    stubFetch(async () => ({ ok: false, json: async () => ({}) }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="hypothesis" entity_id="h-gone" title="사라진 가설" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(document.body.textContent).not.toContain('불러오는 중');
+    expect(document.body.textContent).toContain('대상을 찾을 수 없습니다');
+  });
+});
+
+describe('story #2614 AC1/AC3 — artifact(부모 없는 독립 목업)는 몸통에서 실물이 보인다(회귀: "미리보기가 없습니다"가 지원 타입에서 뜨면 안 됨)', () => {
+  it('부모(story/epic/doc) 전부 null인 artifact도 썸네일이 렌더돼 "이 엔티티는 별도 미리보기가 없습니다"가 안 뜬다', async () => {
+    // ArtifactThumbnail 자신도 exports/version-detail을 따로 fetch한다(둘 다 /api/visual-artifacts/
+    // 하위 경로) — URL별로 분기해, exports는 빈 배열(PNG 없음)·version-detail은 404(간단히
+    // placeholder 경로로 떨어뜨림, 이 테스트의 관심사는 "썸네일 요소 자체가 뜨는가"이지 실 렌더
+    // 내용물이 아니다)로 응답해 ArtifactThumbnail이 안전하게 placeholder로 정착하게 한다.
+    stubFetch(async (url) => {
+      expect(url).toContain('/api/visual-artifacts/');
+      if (url.includes('/exports')) return { ok: true, json: async () => ({ data: [] }) };
+      if (url.includes('/versions/')) return { ok: false, json: async () => ({}) };
+      return {
+        ok: true,
+        json: async () => ({
+          data: { story_id: null, epic_id: null, doc_id: null, latest_version_number: 1, anchor_version: null },
+        }),
+      };
+    });
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+          <EmbedCard entity_type="artifact" entity_id="91eaf539" title="mockup" status={null} />
+        </NextIntlClientProvider>,
+      );
+    });
+    await openCard();
+    await flush();
+    // AC3 회귀 가드 — 지원 타입(artifact)에서 "미리보기 없음" 문구가 뜨면 빨간불.
+    expect(document.body.textContent).not.toContain('이 엔티티는 별도 미리보기가 없습니다');
+    expect(document.querySelector('[data-artifact-thumbnail]')).not.toBeNull();
+    // 부모가 없다는 사실 자체는 안 바뀌었다 — 풋터는 여전히 "갈 곳 없음"(거짓 링크 금지 유지).
+    expect(document.body.textContent).toContain('열 수 있는 화면이 없습니다');
+  });
+});
+
+// story #2614 AC3 — "이 엔티티는 별도 미리보기가 없습니다" 문구는 지원 타입(RICH_PREVIEW_TYPES:
+// story/epic/doc/artifact/hypothesis)에서 뜨면 회귀다. sprint/task/evidence/asset은 의도적으로
+// 이 Set 밖(sprint=own-href로 이미 열림+몸통에 보여줄 게 없음, task/evidence=via-parent로 이미
+// 열림, asset=별도 스토리지 화면). 이 테스트는 그 경계 자체를 고정한다.
+describe('story #2614 AC3 — "미리보기 없음" 문구는 미지원 타입(sprint)에만 정직하게 남는다', () => {
+  it('sprint는 own-href로 풋터가 열리면서도 몸통엔 여전히 "미리보기 없음"이 뜬다(의도된 것 — 회귀 아님)', async () => {
+    await act(async () => {
+      root.render(<EmbedCard entity_type="sprint" entity_id="sp1" title="스프린트 3" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(document.body.textContent).toContain('이 엔티티는 별도 미리보기가 없습니다');
+    expect(document.querySelector('a[href="/sprints?id=sp1"]')).not.toBeNull();
   });
 });
 

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -13,6 +13,7 @@ import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { docViewUrl } from '@/components/docs/lib/doc-project-url';
 import { initials } from '@/lib/storage/format';
 import { renderEntityStatusLabel, translateEntityStatus, type EntityStatusFetchState } from './entity-status-labels';
+import { ArtifactThumbnail } from '@/components/canvas/artifact-thumbnail';
 
 // story #2302 — 이 8종은 BE reference_registry.py ENTITY_RESOLVERS 와 키 집합이 같아야 한다
 // (AC2·AC5, entity-icons.registry-parity.test.ts 가 코드스캔으로 대조). `asset`은 registry
@@ -120,14 +121,28 @@ const ENTITY_API: Record<string, (id: string) => string> = {
   epic: (id) => `/api/goals/${id}`,
   asset: (id) => `/api/assets/${id}`,
   // story #2302 — task.story_id(항상 유일 부모)·artifact.{story_id,epic_id,doc_id}(최대 1개,
-  // 전부 nullable)를 읽어 ②/③을 레코드 단위로 판정하는 재료. hypothesis는 의도적으로 여기
-  // 없다(위 getEntityHref 주석 참고 — 애초에 fetch할 필요가 없는 고정 ③).
+  // 전부 nullable)를 읽어 ②/③을 레코드 단위로 판정하는 재료.
   task: (id) => `/api/tasks/${id}`,
   artifact: (id) => `/api/visual-artifacts/${id}`,
   // story #2314(2026-07-29): GET /api/v2/evidence/{id}가 신설돼 evidence도 fetch-eligible로
   // 승격 — 응답의 resolved_story_id를 EntityPreviewModal이 읽는다(아래 evidence 분기).
   evidence: (id) => `/api/evidence/${id}`,
+  // story #2614 — hypothesis는 §2302에서 "링크(풋터) 판정용으로 fetch할 필요가 없다"(다대다라
+  // 부모 하나를 못 고름, 그건 여전히 사실 — 아래 getEntityHref는 무변경)는 이유로 ENTITY_API
+  // 자체에서 빠졌었는데, 그 근거가 "몸통 content도 fetch 불필요"로 잘못 일반화됐다 — statement
+  // (§2.2.4 유일한 수동 텍스트 입력)는 실재하고 GET /api/hypotheses/{id}도 이미 있다(E-LOOP-LEDGER
+  // S6). 풋터(갈 곳 없음)와 몸통(내용 있음)은 별개 축 — 몸통만 이제 채운다.
+  hypothesis: (id) => `/api/hypotheses/${id}`,
 };
+
+// story #2614 AC2 — 멘션 합성 가능 8타입(story/doc/epic/task/sprint/artifact/hypothesis/
+// evidence) 전수표. 이 Set에 없는 타입은 "이 엔티티는 별도 미리보기가 없습니다"로 떨어진다 —
+// 그게 이 스토리가 고친 결함(만들 수는 있는데 몸통에서 아무것도 못 얻는 반쪽)이었다. sprint는
+// own-href(getEntityHref)로 풋터가 이미 열리고 몸통에 보여줄 필드가 없어(제목·기간 외 없음)
+// 의도적으로 이 Set 밖 — "미리보기 없음" 문구가 정확한 그 드문 경우(AC3의 "진짜 없는 것"에
+// sprint도 포함). 새 합성 가능 타입을 추가하면 이 Set도 같이 넓히거나(몸통 있음), 의도적으로
+// 빼면서 그 이유를 여기 한 줄 남길 것 — «만들 수 있는데 못 여는» 사각을 다시 만들지 않도록.
+const RICH_PREVIEW_TYPES = new Set(['story', 'epic', 'doc', 'artifact', 'hypothesis']);
 
 const MdBadge = ({ label }: { label: string }) => (
   <span className="rounded border px-1.5 py-0.5 text-[11px] font-medium border-border bg-muted text-muted-foreground">
@@ -161,7 +176,7 @@ const MdBody = ({ content }: { content: string }) => (
   </ReactMarkdown>
 );
 
-function EntityDetail({ entityType, detail }: { entityType: string; detail: Record<string, unknown> }) {
+function EntityDetail({ entityType, entityId, detail }: { entityType: string; entityId: string; detail: Record<string, unknown> }) {
   if (entityType === 'story') {
     const d = detail as { status?: string; priority?: string; story_points?: number; description?: string; acceptance_criteria?: string };
     const statusLabel = d.status ? translateEntityStatus('story', d.status) : null;
@@ -203,6 +218,43 @@ function EntityDetail({ entityType, detail }: { entityType: string; detail: Reco
   if (entityType === 'doc') {
     const d = detail as { content?: string };
     return d.content ? <MdBody content={d.content} /> : null;
+  }
+
+  // story #2614 — 부모(story/epic/doc)가 없는 독립 artifact(챗에 바로 올린 mockup 등)는 풋터에
+  // "갈 곳"이 없다(getEntityHref 주석 그대로, 변경 없음) — 그래도 몸통에서 실물을 보여주면
+  // 그 자체로 소비처가 선다. 갤러리가 이미 쓰는 ArtifactThumbnail을 그대로 재사용(PNG export
+  // 우선·라이브 렌더·placeholder 폴백 — 이 컴포넌트 자신의 no-fiction 규율 그대로 상속, 여기서
+  // 새로 흉내내지 않는다).
+  if (entityType === 'artifact') {
+    const d = detail as { latest_version_number?: number; anchor_version?: number | null };
+    if (d.latest_version_number == null) return null;
+    return (
+      <ArtifactThumbnail
+        artifactId={entityId}
+        latestVersionNumber={d.latest_version_number}
+        anchorVersion={d.anchor_version ?? null}
+        className="aspect-video w-full"
+      />
+    );
+  }
+
+  // story #2614 — hypothesis는 풋터(담긴 곳)가 여전히 없다(다대다·getEntityHref 무변경). 하지만
+  // statement(§2.2.4 유일한 수동 텍스트 입력)는 story description과 동형으로 몸통에 보일 수
+  // 있다 — "풋터에 갈 곳이 없다"와 "몸통에 보여줄 게 없다"는 별개였다는 게 이 스토리의 발견.
+  if (entityType === 'hypothesis') {
+    const d = detail as { status?: string; statement?: string };
+    const statusLabel = d.status ? translateEntityStatus('hypothesis', d.status) : null;
+    if (!statusLabel && !d.statement) return null;
+    return (
+      <div className="space-y-3">
+        {statusLabel && (
+          <div className="flex flex-wrap gap-1.5">
+            <MdBadge label={statusLabel} />
+          </div>
+        )}
+        {d.statement && <MdBody content={d.statement} />}
+      </div>
+    );
   }
 
   return null;
@@ -388,8 +440,8 @@ function EntityPreviewModal({
             </div>
           ) : notFound ? (
             <p className="text-xs text-muted-foreground py-4">대상을 찾을 수 없습니다.</p>
-          ) : detail && (entityType === 'story' || entityType === 'epic' || entityType === 'doc') ? (
-            <EntityDetail entityType={entityType} detail={detail} />
+          ) : detail && RICH_PREVIEW_TYPES.has(entityType) ? (
+            <EntityDetail entityType={entityType} entityId={entityId} detail={detail} />
           ) : (
             <p className="text-xs text-muted-foreground py-4">이 엔티티는 별도 미리보기가 없습니다.</p>
           )}


### PR DESCRIPTION
## Summary
PO 실사용 발견 재현(artifact mockup `entity:artifact:91eaf539…` 클릭 → "이 엔티티는 미리보기가 없습니다") — 멘션 **합성**은 8타입까지 확장됐는데(#2283/#2294/#2314) 클릭 **소비처**(`EmbedCard`의 `EntityPreviewModal`)는 3타입(story/epic/doc)만 아는 반쪽이었다.

## 8타입 전수표 (그라운딩 실측, AC2)
| 타입 | fetch(ENTITY_API) | 풋터 링크 | 몸통 rich content | 상태(fix 前) | 상태(fix 後) |
|---|---|---|---|---|---|
| story | ✅ | ✅ own | ✅ | 완전 | 무변경 |
| doc | ✅(2단계) | ✅ own | ✅ | 완전 | 무변경 |
| epic | ✅ | ✅ own | ✅ | 완전 | 무변경 |
| sprint | (불요, own href 정적) | ✅ own | ❌ | 열림(풋터)·몸통 빈 | **무변경(의도적)** — 풋터로 이미 열리고 보여줄 필드가 없음, "미리보기 없음"이 정직한 그 경우 |
| task | ✅ | ✅ via-parent | ❌ | 열림(풋터)·몸통 빈 | 무변경 — AC2 최소기준(사각 0) 이미 충족, 몸통 추가는 낮은 우선(제외) |
| evidence | ✅ | ✅ via-parent | ❌ | 열림(풋터)·몸통 빈 | 무변경 — 위와 동일 사유 |
| **artifact** | ✅ | ⛔ null(부모 없으면) | ❌ | **부모 없으면 완전 사각 — PO 재현 케이스** | **✅ 몸통에 `ArtifactThumbnail` 렌더 — 부모 없어도 실물이 보임** |
| **hypothesis** | ⛔ 항목 자체 없음 | ⛔ 고정 null | ❌ | **항상 완전 사각** | **✅ ENTITY_API 등재 + 몸통에 statement/status 렌더** |

## 근본원인 (PO 재현 케이스)
독립 챗 첨부 artifact(story_id/epic_id/doc_id 전부 null)라 풋터의 via-parent 링크가 애초에 안 생기는 것 자체는 **설계대로 정확**(#2302 판정, 거짓 링크 금지) — 진짜 결함은 `EntityDetail`에 artifact 분기가 아예 없어서 fetch가 성공해도(`/api/visual-artifacts/{id}`가 필요한 걸 다 갖고 있음) 몸통에 보여줄 게 없었던 것.

## 구현 (신규 딥링크 라우팅 없음 — 기존 부품 재사용)
- **artifact**: 갤러리가 이미 쓰는 `ArtifactThumbnail`(PNG export 우선·라이브 렌더·정직한 placeholder — 이 컴포넌트 자신의 no-fiction 규율 그대로 상속) 재사용. 응답에 `latest_version_number`/`anchor_version` 이미 있어 백엔드 변경 0.
- **hypothesis**: `GET /api/hypotheses/{id}`는 이미 존재(E-LOOP-LEDGER S6). "풋터가 못 여니 fetch도 불필요"였던 기존 근거가 몸통까지 잘못 일반화됐던 것 — statement(§2.2.4 유일한 수동 텍스트 입력)를 story/epic과 동형으로 렌더.
- `RICH_PREVIEW_TYPES` 명시 Set 신설(AC2가 요구한 "타입 전수 선언" 그 자체) — 새 합성 가능 타입이 생기면 이 Set도 같이 넓히거나, 의도적으로 빼면서 이유를 남기도록 주석에 못박음.

## AC 대조
1. ✅ artifact 클릭 시 열림(몸통에 실물) — PO 재현 케이스(91eaf539 shape) 유닛 테스트로 고정.
2. ✅ 8타입 전수표(위) PR 본문에 선언 — "만들 수 있는데 못 여는" 사각 0(sprint/task/evidence는 풋터로 이미 열려 있어 AC2 기준 충족, 몸통 콘텐츠 부재는 의도적 저우선).
3. ✅ 회귀 가드 — "미리보기가 없습니다" 문구가 지원 타입(RICH_PREVIEW_TYPES)에서 뜨면 실패하는 테스트 + sprint(미지원)에서는 여전히 뜨는 경계 테스트(양쪽 방향 다 고정).
4. ⚠️ 두 테마·모바일 — 재사용한 `ArtifactThumbnail`/`MdBadge`/`MdBody`는 갤러리·story/epic 몸통에서 이미 검증된 기존 컴포넌트라 새 위험은 낮다고 보나, 실브라우저 라이브 확認은 못 했음(정직하게 남김) — 유나 design 검수에서 시각 형태·placeholder 상태 확認 바람(페드루군이 이미 이 축을 design 검수로 넘기기로 함).

## Test plan
- [x] `embed-card.link-states.test.tsx` 18/18 pass(신규 3개: artifact 양성재현·hypothesis 몸통/풋터 분리·sprint 경계)
- [x] `embed-card.entity-registry-parity.test.ts` 3/3 pass(BE 레지스트리 정합 무영향)
- [x] `chat-bubble.test.tsx` 45/45 pass(EmbedCard 상위 소비처 무회귀)
- [x] `verify:no-new-tint-color-text` 신규 0건
- [x] tsc/eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
