### PR TITLE
[SID:2611] muted-foreground 알파 변형 89곳 solid 이관 — (B) baseline 채무 상환

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -719,6 +719,12 @@ jobs:
       - name: "Verify no alpha on focus ring (story #2057 regression guard)"
         run: pnpm --filter web verify:no-alpha-focus-ring
 
+      # story #2611(유나 확定) 회귀가드: text-muted-foreground/{alpha}는 모든 알파 레벨에서
+      # AA 미달이다(solid만 통과). 텍스트+아이콘 89곳을 solid로 이관했고, 재도입되면 이 스텝이
+      # 실패한다. 예외(큰 순수 장식)는 `// muted-alpha-ok: <이유>` 주석으로만 통과한다.
+      - name: "Verify no text-muted-foreground alpha (story #2611 regression guard)"
+        run: pnpm --filter web verify:no-muted-foreground-alpha
+
       # story #2061 회귀가드: 손수 구현된 `fixed inset-0` 모달(role="dialog"/aria-modal/
       # 포커스트랩 없음)이 새로 들어오면 이 스텝이 실패한다. 공용 <Dialog>/<Sheet> 또는
       # useFocusTrap으로 배선된 것은 통과한다.

--- a/apps/web/e2e/contrast-axe-baseline.json
+++ b/apps/web/e2e/contrast-axe-baseline.json
@@ -3,19 +3,10 @@
     "story #2590 (B) — axe color-contrast 런타임 가드 baseline(can only shrink).",
     "키 = page::theme::색쌍(fg/bg). 셀렉터는 axe가 클래스 순서를 런마다 바꿔 비결정적이라 뺐다",
     "(spec의 violationKeys 주석 참조). 색쌍은 위반의 결정적 정체다.",
-    "아래는 첫 CI 런(rest 스캔)이 드러낸 현 위반 — 전부 text-muted-foreground 알파 변형의 저대비.",
-    "grandfather로 얼려 신규 «색쌍»만 빨간불. 이 채무 자체 수리는 별건 DS 스토리(muted-fg 대비 개선).",
-    "story #2607 (v2) — hover 키는 같은 규약으로 page::theme::hover::색쌍 형태로 이 같은 배열에",
-    "얹는다(rest와 네임스페이스로 구분). 첫 hover CI 런(PR#3002)이 /settings::dark::hover에서",
-    "#74747c/#111114를 드러냈다 — 위 rest 키(/settings::dark::#74747c/#111114)와 «같은 색쌍».",
-    "새 hover-only 결함이 아니라, axe가 페이지 전체를 스캔하는 이상(rest 스캔도 동일 방식) 이미",
-    "grandfather된 rest 채무가 hover 스캔 시점에도 화면에 그대로 남아있어(sidebar help 링크 하나만",
-    "hover해도 나머지 페이지의 기존 위반은 안 사라짐) hover 네임스페이스 아래서도 다시 걸린 것 —",
-    "rest 쪽과 동일하게 grandfather한다(수리는 별건 DS 스토리)."
+    "story #2611(유나 확定) — 위 rest 2키(/settings light·dark) + #3002가 시드한 hover 1키",
+    "(/settings::dark::hover)는 전부 같은 물리적 색쌍(text-muted-foreground/70 저대비)이었다.",
+    "89곳 solid 이관(story #2611)으로 근본 수리돼 baseline 3키가 전부 비었다 — coupling대로",
+    "rest+hover 동반 소멸(can-only-shrink가 실제로 줄어드는 자리, CI axe 재실측이 최종 확認)."
   ],
-  "keys": [
-    "/settings::light::#95959c/#ffffff",
-    "/settings::dark::#74747c/#111114",
-    "/settings::dark::hover::#74747c/#111114"
-  ]
+  "keys": []
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "verify:no-new-tint-color-text": "tsx scripts/verify-no-new-tint-color-text.ts",
     "verify:cross-element-tint-text": "tsx scripts/verify-cross-element-tint-text.ts",
     "verify:muted-foreground-contrast": "tsx scripts/verify-muted-foreground-contrast.ts",
+    "verify:no-muted-foreground-alpha": "tsx scripts/verify-no-muted-foreground-alpha.ts",
     "verify:no-raw-error-message": "tsx scripts/verify-no-raw-error-message.ts",
     "e2e": "playwright test",
     "e2e:contrast": "playwright test contrast-guard.spec.ts",

--- a/apps/web/scripts/verify-no-muted-foreground-alpha.test.ts
+++ b/apps/web/scripts/verify-no-muted-foreground-alpha.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { findUnexemptedAlphaLines } from './verify-no-muted-foreground-alpha';
+
+describe('findUnexemptedAlphaLines (story #2611 regression guard)', () => {
+  it('flags text-muted-foreground/60', () => {
+    expect(findUnexemptedAlphaLines('<p className="text-xs text-muted-foreground/60">x</p>')).toEqual([1]);
+  });
+
+  it('flags an icon usage the same as text (유나 확定: 아이콘도 같은 규칙)', () => {
+    expect(findUnexemptedAlphaLines('<ArrowRight className="size-3 text-muted-foreground/40" />')).toEqual([1]);
+  });
+
+  it('flags every alpha level (/40–/80)', () => {
+    for (const alpha of [40, 50, 60, 70, 80]) {
+      expect(findUnexemptedAlphaLines(`<p className="text-muted-foreground/${alpha}" />`)).toEqual([1]);
+    }
+  });
+
+  it('flags a hover-prefixed alpha variant too', () => {
+    expect(findUnexemptedAlphaLines('<p className="text-foreground hover:text-muted-foreground/70" />')).toEqual([1]);
+  });
+
+  it('reports the correct line number in a multi-line file', () => {
+    const content = ['const a = 1;', '<p className="text-muted-foreground/60">x</p>', 'const b = 2;'].join('\n');
+    expect(findUnexemptedAlphaLines(content)).toEqual([2]);
+  });
+
+  it('does not flag solid text-muted-foreground (already migrated)', () => {
+    expect(findUnexemptedAlphaLines('<p className="text-muted-foreground">x</p>')).toEqual([]);
+  });
+
+  it('does not flag an unrelated alpha token (border-border/50)', () => {
+    expect(findUnexemptedAlphaLines('<div className="border-border/50" />')).toEqual([]);
+  });
+
+  it('allows an exception with a same-line muted-alpha-ok comment', () => {
+    const line = '<div className="text-muted-foreground/40" /> {/* muted-alpha-ok: 배경 워터마크·aria-hidden·인접 텍스트 없음 */}';
+    expect(findUnexemptedAlphaLines(line)).toEqual([]);
+  });
+
+  it('allows an exception with a muted-alpha-ok comment on the previous line', () => {
+    const content = [
+      '{/* muted-alpha-ok: 큰 배경 워터마크, aria-hidden, 인접 텍스트 없음 */}',
+      '<div className="text-muted-foreground/40" />',
+    ].join('\n');
+    expect(findUnexemptedAlphaLines(content)).toEqual([]);
+  });
+
+  it('does not treat a bare "muted-alpha-ok" with no reason as a valid valve', () => {
+    const line = '<div className="text-muted-foreground/40" /> {/* muted-alpha-ok */}';
+    expect(findUnexemptedAlphaLines(line)).toEqual([1]);
+  });
+});

--- a/apps/web/scripts/verify-no-muted-foreground-alpha.ts
+++ b/apps/web/scripts/verify-no-muted-foreground-alpha.ts
@@ -1,0 +1,91 @@
+/**
+ * story #2611(유나 확定) 회귀가드 — `text-muted-foreground/{alpha}`는 모든 알파 레벨에서
+ * AA(4.5:1) 미달이다(실측: 라이트 /80=3.61·/70=2.98·/60=2.48…·solid(/100)만 5.51 통과, 다크도
+ * /80조차 bg-muted선 4.18로 깨짐) — `--muted-foreground`(L0.52) 자체가 이미 "AA 겨우 넘는
+ * 가장 흐린 본문색"이라 그 아래 legible한 회색은 물리적으로 없다. 더 흐린 위계가 필요하면
+ * 대비가 아니라 크기(11px)·굵기(500)·간격으로 표현한다. 89곳(텍스트+아이콘 전부, 유나 확定:
+ * 아이콘도 같은 규칙 — "더 조용히"는 알파가 아니라 크기)을 solid로 이관했다.
+ *
+ * 예외 = "큰 순수 장식"(배경 워터마크류·aria-hidden·인접 텍스트 없음)뿐이고, 그 자리엔
+ * `// muted-alpha-ok: <이유>` 주석이 반드시 있어야 통과한다 — 스캐너 자체에 예외를 하드코딩하지
+ * 않는다(밸브는 주석으로만, PO 확定). 이유 없는 알파는 없는 셈이다.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+export const MUTED_FG_ALPHA = /text-muted-foreground\/[0-9]+/g;
+export const ALPHA_OK_VALVE = /muted-alpha-ok:\s*\S/;
+
+export function findUnexemptedAlphaLines(content: string): number[] {
+  const lines = content.split('\n');
+  const hits: number[] = [];
+  lines.forEach((line, i) => {
+    if (!MUTED_FG_ALPHA.test(line)) return;
+    MUTED_FG_ALPHA.lastIndex = 0;
+    // 밸브는 같은 줄이나 바로 위 줄(JSX 속성 앞 주석 관용구) 둘 다 허용한다.
+    const sameLine = line;
+    const prevLine = i > 0 ? lines[i - 1]! : '';
+    if (ALPHA_OK_VALVE.test(sameLine) || ALPHA_OK_VALVE.test(prevLine)) return;
+    hits.push(i + 1);
+  });
+  return hits;
+}
+
+const EXT_RE = /\.(tsx?|jsx?)$/;
+const TEST_RE = /\.test\.[tj]sx?$/;
+
+function walk(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walk(full, out);
+    } else if (EXT_RE.test(entry) && !TEST_RE.test(entry)) {
+      out.push(full);
+    }
+  }
+}
+
+// verify-no-alpha-focus-ring.ts와 동일 규율 — walk가 조용히 0개를 담으면 위반 0건과 구분이
+// 안 돼 헛돌면서 초록불을 내는 사고가 난다. 현재 대상 파일이 894개 안팎이라 500을 하한으로.
+const MIN_EXPECTED_FILES = 500;
+
+function main(): void {
+  const srcRoot = path.resolve(process.cwd(), 'src');
+  const files: string[] = [];
+  walk(srcRoot, files);
+
+  if (files.length < MIN_EXPECTED_FILES) {
+    console.error(
+      `FAIL: 검사 대상 파일이 ${files.length}개뿐 — 경로/실행 위치가 틀렸을 가능성. 가드가 헛돌고 있다.`,
+    );
+    console.error(`  srcRoot=${srcRoot} (기대 최소 ${MIN_EXPECTED_FILES}개)`);
+    process.exit(1);
+  }
+
+  const violations: { file: string; lines: number[] }[] = [];
+  for (const abs of files) {
+    const rel = path.relative(srcRoot, abs).split(path.sep).join('/');
+    const content = readFileSync(abs, 'utf8');
+    const lines = findUnexemptedAlphaLines(content);
+    if (lines.length > 0) violations.push({ file: rel, lines });
+  }
+
+  if (violations.length > 0) {
+    console.error('FAIL: text-muted-foreground 알파 변형 회귀 발견(story #2611):');
+    for (const v of violations) console.error(`  - ${v.file}:${v.lines.join(',')}`);
+    console.error(
+      '\ntext-muted-foreground/{alpha}는 모든 레벨에서 AA 미달이다(solid만 통과). `/NN` 접미사를' +
+        ' 제거하고, 더 흐린 위계가 필요하면 크기·굵기·간격으로 표현한다.' +
+        ' 정말 큰 순수 장식(워터마크류·aria-hidden·인접 텍스트 없음)이면 같은 줄이나 바로 위 줄에' +
+        ' `// muted-alpha-ok: <이유>` 주석을 남긴다 — 이유 없는 예외는 잡힌다.',
+    );
+    process.exit(1);
+  }
+
+  console.log('OK: text-muted-foreground 알파 회귀 0건');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
@@ -21,7 +21,7 @@ import { EmptyState } from '@/components/ui/empty-state';
 // 금지 — 점+원뿐, 라벨 없음(그룹핑 자체가 메시지).
 function GoalGroupHint() {
   return (
-    <svg viewBox="0 0 48 24" className="size-6 w-12 text-muted-foreground/50" aria-hidden="true">
+    <svg viewBox="0 0 48 24" className="size-6 w-12 text-muted-foreground" aria-hidden="true">
       <circle cx="10" cy="8" r="2" fill="currentColor" opacity="0.5" />
       <circle cx="10" cy="16" r="2" fill="currentColor" opacity="0.5" />
       <circle cx="4" cy="12" r="2" fill="currentColor" opacity="0.5" />
@@ -549,7 +549,7 @@ function GoalRow({ epic, isSelected, onClick, onDeleteRequest, sortable }: GoalR
           type="button"
           aria-label={t('steerReorderAria', { title: epic.title })}
           onClick={(e) => e.stopPropagation()}
-          className="mt-0.5 flex shrink-0 cursor-grab items-center text-muted-foreground/50 transition-colors hover:text-muted-foreground active:cursor-grabbing"
+          className="mt-0.5 flex shrink-0 cursor-grab items-center text-muted-foreground transition-colors hover:text-muted-foreground active:cursor-grabbing"
           {...attributes}
           {...listeners}
         >
@@ -572,7 +572,7 @@ function GoalRow({ epic, isSelected, onClick, onDeleteRequest, sortable }: GoalR
                   {t('steerCurated')} {epic.position}
                 </span>
               ) : (
-                <span className="text-[10px] font-medium text-muted-foreground/70">{t('steerAuto')}</span>
+                <span className="text-[10px] font-medium text-muted-foreground">{t('steerAuto')}</span>
               )
             ) : null}
             {/* Loop 제안 hook — source_loop_id 배선(P3/v2) 전엔 미표시(no-fiction·sparkle 0·claimed amber 언어). */}
@@ -1095,7 +1095,7 @@ export function GoalsClient({ projectId, orgId }: GoalsClientProps) {
                   />
                 ))}
                 {capped ? (
-                  <p className="pt-1 text-center text-[11px] text-muted-foreground/70">{t('steerCappedNote', { count: STEER_LIMIT })}</p>
+                  <p className="pt-1 text-center text-[11px] text-muted-foreground">{t('steerCappedNote', { count: STEER_LIMIT })}</p>
                 ) : null}
               </div>
             </SortableContext>

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/loops/loops-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/loops/loops-client.tsx
@@ -23,17 +23,17 @@ function LoopCycleFlow({ t }: { t: (key: 'loopNodeHypothesis' | 'loopNodeExecute
     { Icon: Sparkles, label: t('loopNodeLearn') },
   ];
   return (
-    <div className="flex items-center gap-1.5 text-muted-foreground/70" aria-hidden="true">
+    <div className="flex items-center gap-1.5 text-muted-foreground" aria-hidden="true">
       {nodes.map(({ Icon, label }, i) => (
         <span key={label} className="flex items-center gap-1.5">
-          {i > 0 ? <ArrowRight className="size-3 shrink-0 text-muted-foreground/40" /> : null}
+          {i > 0 ? <ArrowRight className="size-3 shrink-0 text-muted-foreground" /> : null}
           <span className="flex flex-col items-center gap-1">
             <Icon className="size-4" />
             <span className="text-[10px] leading-none">{label}</span>
           </span>
         </span>
       ))}
-      <ArrowRight className="size-3 shrink-0 text-muted-foreground/40" />
+      <ArrowRight className="size-3 shrink-0 text-muted-foreground" />
       <span className="flex flex-col items-center gap-1">
         <RotateCcw className="size-4" />
         <span className="text-[10px] leading-none">{t('loopNodeNext')}</span>

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx
@@ -16,7 +16,7 @@ import { TopBarSlot } from '@/components/nav/top-bar-slot';
 // 바(bounded bar) 형태. 과설명 금지 — 시작/종합 라벨 2개뿐.
 function SprintCycleBar({ startLabel, endLabel }: { startLabel: string; endLabel: string }) {
   return (
-    <div className="flex items-center gap-2 text-muted-foreground/70" aria-hidden="true">
+    <div className="flex items-center gap-2 text-muted-foreground" aria-hidden="true">
       <span className="text-[10px] leading-none">{startLabel}</span>
       <div className="h-2 w-24 rounded-full bg-gradient-to-r from-info/60 to-info/20" />
       <span className="text-[10px] leading-none">{endLabel}</span>

--- a/apps/web/src/app/(authenticated)/organization/trust/trust-utils.tsx
+++ b/apps/web/src/app/(authenticated)/organization/trust/trust-utils.tsx
@@ -129,7 +129,7 @@ export function sparklinePoints(values: number[], width = 120, height = 24, pad 
 export function Sparkline({ values }: { values: number[] }) {
   if (values.length < 2) return null;
   return (
-    <svg width={120} height={24} viewBox="0 0 120 24" className="text-muted-foreground/60" aria-hidden="true">
+    <svg width={120} height={24} viewBox="0 0 120 24" className="text-muted-foreground" aria-hidden="true">
       <polyline points={sparklinePoints(values)} fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -692,7 +692,7 @@ export default function SettingsPage() {
         <div className={`shrink-0 border-r overflow-y-auto p-4 flex-col w-52 ${lnbOpen ? 'flex' : 'hidden'} md:flex`}>
           <h1 className="mb-4 px-2 text-sm font-semibold">{t('title')}</h1>
           <TabsList variant="line" className="w-full flex-col items-stretch">
-            <span className="px-2 pb-1 pt-1 text-[10px] font-medium text-muted-foreground/70">{t('myAccount')}</span>
+            <span className="px-2 pb-1 pt-1 text-[10px] font-medium text-muted-foreground">{t('myAccount')}</span>
             <TabsTrigger value="profile">
               <User className="h-4 w-4" />
               {t('tabProfile')}
@@ -706,7 +706,7 @@ export default function SettingsPage() {
               {t('tabNotifications')}
             </TabsTrigger>
 
-            <span className="px-2 pb-1 pt-4 text-[10px] font-medium text-muted-foreground/70">{t('projectSettings')}</span>
+            <span className="px-2 pb-1 pt-4 text-[10px] font-medium text-muted-foreground">{t('projectSettings')}</span>
             {currentProjectId && !HIDDEN_SETTINGS_TABS.has('ai') ? (
               <TabsTrigger value="ai">
                 <Bot className="h-4 w-4" />
@@ -734,7 +734,7 @@ export default function SettingsPage() {
 
             {adminChecked ? (
               <>
-                <span className="truncate px-2 pb-1 pt-4 text-[10px] font-medium text-muted-foreground/70">{t('organizationSettings')}</span>
+                <span className="truncate px-2 pb-1 pt-4 text-[10px] font-medium text-muted-foreground">{t('organizationSettings')}</span>
                 <TabsTrigger value="organization">
                   <FolderKanban className="h-4 w-4" />
                   {t('tabOrganization')}
@@ -753,7 +753,7 @@ export default function SettingsPage() {
 
             {adminChecked && isAdmin ? (
               <>
-                <span className="truncate px-2 pb-1 pt-4 text-[10px] font-medium text-muted-foreground/70">{t('billing')}</span>
+                <span className="truncate px-2 pb-1 pt-4 text-[10px] font-medium text-muted-foreground">{t('billing')}</span>
                 {isEEEnabled() && (
                   <TabsTrigger value="subscription">
                     <CreditCard className="h-4 w-4" />
@@ -774,7 +774,7 @@ export default function SettingsPage() {
             ) : null}
 
             {/* E-GHAPP: 연동 — 자체 섹션(결제와 분리·향후 slack/jira 등 통합 표준 위치)·서브라우트 `/settings/integrations`(install-callback 타깃·탭 아닌 발견성 진입점) */}
-            <span className="px-2 pb-1 pt-4 text-[10px] font-medium text-muted-foreground/70">{t('tabIntegrations')}</span>
+            <span className="px-2 pb-1 pt-4 text-[10px] font-medium text-muted-foreground">{t('tabIntegrations')}</span>
             <Link
               href="/settings/integrations"
               className="flex w-full items-center gap-2 px-3 py-2 text-sm text-muted-foreground transition hover:text-foreground"
@@ -783,7 +783,7 @@ export default function SettingsPage() {
               {t('tabIntegrations')}
             </Link>
 
-            <span className="px-2 pb-1 pt-4 text-[10px] font-medium text-muted-foreground/70">{t('dangerZone')}</span>
+            <span className="px-2 pb-1 pt-4 text-[10px] font-medium text-muted-foreground">{t('dangerZone')}</span>
             <TabsTrigger
               value="danger"
               className="text-destructive hover:text-destructive data-active:text-destructive data-active:bg-destructive/10"

--- a/apps/web/src/app/invite/accept/invite-accept-client.tsx
+++ b/apps/web/src/app/invite/accept/invite-accept-client.tsx
@@ -54,7 +54,7 @@ export function InviteAcceptClient({ token, orgName, role, email, projects }: In
           <p className="text-sm text-muted-foreground">
             {tInvite('invitedByOrg', { org: orgName })}
           </p>
-          {email && <p className="text-xs text-muted-foreground/60">{tInvite('signupEmail', { email })}</p>}
+          {email && <p className="text-xs text-muted-foreground">{tInvite('signupEmail', { email })}</p>}
         </div>
 
         <div className="rounded-lg border border-border bg-muted px-4 py-3">

--- a/apps/web/src/app/invite/page.tsx
+++ b/apps/web/src/app/invite/page.tsx
@@ -260,7 +260,7 @@ export default function InvitePage() {
                   type="text"
                   placeholder={t('namePlaceholder')}
                   autoComplete="name"
-                  className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-brand"
+                  className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand"
                   value={displayName}
                   onChange={(e) => setDisplayName(e.target.value)}
                   disabled={submitting}
@@ -270,7 +270,7 @@ export default function InvitePage() {
                 type="email"
                 placeholder={t2('email')}
                 autoComplete="email"
-                className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-brand"
+                className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 disabled={submitting}
@@ -279,7 +279,7 @@ export default function InvitePage() {
                 type="password"
                 placeholder={t2('password')}
                 autoComplete={authMode === 'signup' ? 'new-password' : 'current-password'}
-                className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-brand"
+                className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 onKeyDown={(e) => e.key === 'Enter' && void handleSubmit()}
@@ -323,7 +323,7 @@ export default function InvitePage() {
           <div className="space-y-3 animate-in fade-in slide-in-from-bottom-2 duration-500 delay-400 fill-mode-backwards">
             <div className="relative flex items-center">
               <div className="flex-grow border-t border-border/50" />
-              <span className="mx-3 flex-shrink text-xs text-muted-foreground/60">{t2('orContinueWith')}</span>
+              <span className="mx-3 flex-shrink text-xs text-muted-foreground">{t2('orContinueWith')}</span>
               <div className="flex-grow border-t border-border/50" />
             </div>
             <a

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -197,7 +197,7 @@ export default function LoginPage() {
           <div className="space-y-3">
             <div className="relative flex items-center">
               <div className="flex-grow border-t border-border/50" />
-              <span className="mx-3 flex-shrink text-xs text-muted-foreground/60">{t('orContinueWith')}</span>
+              <span className="mx-3 flex-shrink text-xs text-muted-foreground">{t('orContinueWith')}</span>
               <div className="flex-grow border-t border-border/50" />
             </div>
 
@@ -211,7 +211,7 @@ export default function LoginPage() {
               {t('google')}
             </a>
 
-            <p className="text-center text-xs text-muted-foreground/60">
+            <p className="text-center text-xs text-muted-foreground">
               {t('termsPrefix')}{' '}
               <a href="/terms" target="_blank" className="underline hover:text-foreground/60">{t('termsOfService')}</a>
               {' '}{t('and')}{' '}

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -15,7 +15,7 @@ export default function PrivacyPage() {
         </div>
 
         <div className="rounded-2xl bg-background p-8 shadow-sm space-y-6 text-sm text-muted-foreground leading-relaxed">
-          <p className="text-xs text-muted-foreground/60">Last updated: May 2026</p>
+          <p className="text-xs text-muted-foreground">Last updated: May 2026</p>
 
           <section className="space-y-2">
             <h2 className="font-semibold text-foreground">1. Information We Collect</h2>
@@ -52,7 +52,7 @@ export default function PrivacyPage() {
             <p>For privacy inquiries, contact us at <a href="mailto:privacy@moonklabs.com" className="text-brand hover:underline">privacy@moonklabs.com</a>.</p>
           </section>
 
-          <p className="text-xs text-muted-foreground/60 pt-4 border-t border-border/50">
+          <p className="text-xs text-muted-foreground pt-4 border-t border-border/50">
             This is a placeholder document. Full privacy policy will be provided before public launch.
           </p>
         </div>

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -125,7 +125,7 @@ export default function RegisterPage() {
           {showRules && (
             <ul className="space-y-1 text-xs">
               <RuleItem met={rules.length} label={t('ruleLength')} />
-              <li className={`flex items-center gap-1.5 ${categoriesMet >= 3 ? 'text-success' : 'text-muted-foreground/60'}`}>
+              <li className={`flex items-center gap-1.5 ${categoriesMet >= 3 ? 'text-success' : 'text-muted-foreground'}`}>
                 <span>{categoriesMet >= 3 ? '✓' : '○'}</span>
                 <span>{t('ruleCategories', { count: categoriesMet })}</span>
               </li>
@@ -170,7 +170,7 @@ export default function RegisterPage() {
           <div className="space-y-3">
             <div className="relative flex items-center">
               <div className="flex-grow border-t border-border/50" />
-              <span className="mx-3 flex-shrink text-xs text-muted-foreground/60">{t('orContinueWith')}</span>
+              <span className="mx-3 flex-shrink text-xs text-muted-foreground">{t('orContinueWith')}</span>
               <div className="flex-grow border-t border-border/50" />
             </div>
 
@@ -203,7 +203,7 @@ export default function RegisterPage() {
 
 function RuleItem({ met, label }: { met: boolean; label: string }) {
   return (
-    <li className={`flex items-center gap-1.5 ${met ? 'text-success' : 'text-muted-foreground/60'}`}>
+    <li className={`flex items-center gap-1.5 ${met ? 'text-success' : 'text-muted-foreground'}`}>
       <span>{met ? '✓' : '○'}</span>
       <span>{label}</span>
     </li>

--- a/apps/web/src/app/reset-password/page.tsx
+++ b/apps/web/src/app/reset-password/page.tsx
@@ -124,10 +124,10 @@ export default function ResetPasswordPage() {
             />
             {touched && password.length > 0 && (
               <ul className="space-y-1 text-xs">
-                <li className={rules.length ? 'text-success' : 'text-muted-foreground/60'}>
+                <li className={rules.length ? 'text-success' : 'text-muted-foreground'}>
                   {rules.length ? '✓' : '○'} {t('lengthHint')}
                 </li>
-                <li className={categoriesMet >= 3 ? 'text-success' : 'text-muted-foreground/60'}>
+                <li className={categoriesMet >= 3 ? 'text-success' : 'text-muted-foreground'}>
                   {categoriesMet >= 3 ? '✓' : '○'} {t('strengthHint', { met: categoriesMet })}
                 </li>
               </ul>

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -15,7 +15,7 @@ export default function TermsPage() {
         </div>
 
         <div className="rounded-2xl bg-background p-8 shadow-sm space-y-6 text-sm text-muted-foreground leading-relaxed">
-          <p className="text-xs text-muted-foreground/60">Last updated: May 2026</p>
+          <p className="text-xs text-muted-foreground">Last updated: May 2026</p>
 
           <section className="space-y-2">
             <h2 className="font-semibold text-foreground">1. Acceptance of Terms</h2>
@@ -52,7 +52,7 @@ export default function TermsPage() {
             <p>For questions about these terms, contact us at <a href="mailto:legal@moonklabs.com" className="text-brand hover:underline">legal@moonklabs.com</a>.</p>
           </section>
 
-          <p className="text-xs text-muted-foreground/60 pt-4 border-t border-border/50">
+          <p className="text-xs text-muted-foreground pt-4 border-t border-border/50">
             This is a placeholder document. Full terms will be provided before public launch.
           </p>
         </div>

--- a/apps/web/src/components/activity/team-activity-view.tsx
+++ b/apps/web/src/components/activity/team-activity-view.tsx
@@ -377,7 +377,7 @@ export function TeamActivityView({ projectId }: { projectId: string }) {
           ) : items.length === 0 ? (
             <div className="flex h-64 items-center justify-center">
               <EmptyState
-                icon={<Inbox className="size-8 text-muted-foreground/60" />}
+                icon={<Inbox className="size-8 text-muted-foreground" />}
                 title={t('emptyTitle')}
                 description={t('emptyDesc')}
               />

--- a/apps/web/src/components/cage/gate-evidence.tsx
+++ b/apps/web/src/components/cage/gate-evidence.tsx
@@ -167,7 +167,7 @@ export function GateEvidence({ gate, className }: { gate: GateItem; className?: 
     return (
       <div className={className}>
         {decisionBadge}
-        <p className="mt-1.5 text-[11.5px] italic text-muted-foreground/60">{t('evidenceNonePrompt')}</p>
+        <p className="mt-1.5 text-[11.5px] italic text-muted-foreground">{t('evidenceNonePrompt')}</p>
       </div>
     );
   }
@@ -182,7 +182,7 @@ export function GateEvidence({ gate, className }: { gate: GateItem; className?: 
         <div className="mt-1.5 grid grid-cols-1 gap-2 text-[11.5px] sm:grid-cols-2 sm:gap-3">
           {/* 좌: 납품(delivery 신호 — 기계 검증). S5(GitHub앱) PR·AC·위험 슬롯 자리. */}
           <div className="space-y-0.5">
-            <p className="text-[10px] font-medium text-muted-foreground/70">{t('deliveryColLabel')}</p>
+            <p className="text-[10px] font-medium text-muted-foreground">{t('deliveryColLabel')}</p>
             <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-muted-foreground">
               {ci !== null ? <CiSignal ci={ci} /> : null}
               {trust !== null ? <TrustValue trust={trust} selfReportOnly={selfReportOnly} /> : null}
@@ -192,12 +192,12 @@ export function GateEvidence({ gate, className }: { gate: GateItem; className?: 
           </div>
           {/* 우: 판단("옳았다 판정"). gate엔 정밀 hit_rate 없음 → 임시 예측만(억지 % X). */}
           <div className="space-y-0.5">
-            <p className="text-[10px] font-medium text-muted-foreground/70">{t('outcomeColLabel')}</p>
+            <p className="text-[10px] font-medium text-muted-foreground">{t('outcomeColLabel')}</p>
             <div className="text-muted-foreground">
               {seedKey ? (
                 <Badge variant="chip" className="shrink-0">{t(seedKey)}</Badge>
               ) : (
-                <span className="italic text-muted-foreground/80">{t('coldStartProvisional')}</span>
+                <span className="italic text-muted-foreground">{t('coldStartProvisional')}</span>
               )}
             </div>
           </div>
@@ -222,7 +222,7 @@ export function GateEvidence({ gate, className }: { gate: GateItem; className?: 
         <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11.5px] text-muted-foreground">
           {facts.map((node, i) => (
             <Fragment key={i}>
-              {i > 0 ? <span aria-hidden className="text-muted-foreground/50">·</span> : null}
+              {i > 0 ? <span aria-hidden className="text-muted-foreground">·</span> : null}
               {node}
             </Fragment>
           ))}

--- a/apps/web/src/components/cage/gate-line-context.tsx
+++ b/apps/web/src/components/cage/gate-line-context.tsx
@@ -72,7 +72,7 @@ export function GateLineContext({ step, resolveName, className }: GateLineContex
         {step.from_status ? (
           <span className="text-muted-foreground">{step.from_status}</span>
         ) : null}
-        {step.from_status ? <ArrowRight className="size-3 shrink-0 text-muted-foreground/70" /> : null}
+        {step.from_status ? <ArrowRight className="size-3 shrink-0 text-muted-foreground" /> : null}
         <span className="font-medium text-foreground">{step.to_status}</span>
       </div>
 
@@ -111,7 +111,7 @@ export function GateLineContext({ step, resolveName, className }: GateLineContex
 
       {/* ⑤ engine_degraded/grandfathered: BE observability_note 렌더(하드코딩X)·null/빈값=중립 폴백 */}
       {step.engine_degraded || step.grandfathered ? (
-        <p className="flex items-start gap-1 pt-0.5 text-[10px] text-muted-foreground/80">
+        <p className="flex items-start gap-1 pt-0.5 text-[10px] text-muted-foreground">
           <EyeOff className="mt-0.5 size-3 shrink-0" />
           <span>{step.observability_note?.trim() || t('lineObservabilityFallback')}</span>
         </p>

--- a/apps/web/src/components/cage/trust-score-card.tsx
+++ b/apps/web/src/components/cage/trust-score-card.tsx
@@ -55,7 +55,7 @@ function TrustScoreEmpty({ compact }: { compact?: boolean }) {
   return (
     <div className="rounded-xl border border-dashed border-border bg-muted/20 px-4 py-5 text-center">
       <p className="text-sm font-medium text-muted-foreground">{t('trustScoreNoData')}</p>
-      <p className="mt-1 text-xs text-muted-foreground/60">{t('trustScoreNoDataHint')}</p>
+      <p className="mt-1 text-xs text-muted-foreground">{t('trustScoreNoDataHint')}</p>
     </div>
   );
 }

--- a/apps/web/src/components/canvas/artifact-gallery-view.tsx
+++ b/apps/web/src/components/canvas/artifact-gallery-view.tsx
@@ -267,7 +267,7 @@ export function ArtifactGalleryView({ projectId }: { projectId: string }) {
           type="button"
           disabled
           title={t('galleryFeatureAxisUnsupported')}
-          className="cursor-not-allowed rounded-md px-2.5 py-1.5 text-xs font-semibold text-muted-foreground/40"
+          className="cursor-not-allowed rounded-md px-2.5 py-1.5 text-xs font-semibold text-muted-foreground"
         >
           {t('galleryAxisFeature')}
         </button>
@@ -321,7 +321,7 @@ export function ArtifactGalleryView({ projectId }: { projectId: string }) {
         </div>
       ) : artifacts.length === 0 ? (
         <div className="flex flex-col items-center gap-2 rounded-xl border border-border bg-card px-6 py-12 text-center">
-          <Frame className="size-6 text-muted-foreground/60" aria-hidden="true" />
+          <Frame className="size-6 text-muted-foreground" aria-hidden="true" />
           <p className="text-sm font-medium text-foreground">{t('galleryEmptyTitle')}</p>
           <p className="max-w-sm text-xs text-muted-foreground">{t('emptyHint')}</p>
           {/* story 64010b05 §2 — 임포트=그리기와 co-located 2번째 입구. 갤러리는 스토리 귀속이

--- a/apps/web/src/components/canvas/artifact-section.tsx
+++ b/apps/web/src/components/canvas/artifact-section.tsx
@@ -214,7 +214,7 @@ export function ArtifactSection({ storyId, memberMap = {}, className }: Artifact
           <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
             {t('sectionLabel')}
           </div>
-          <PenLine className="size-6 text-muted-foreground/60" aria-hidden="true" />
+          <PenLine className="size-6 text-muted-foreground" aria-hidden="true" />
           <p className="text-sm font-medium text-foreground">{t('emptyTitle')}</p>
           <p className="max-w-sm text-xs text-muted-foreground">{t('emptyHint')}</p>
           {/* story 64010b05 §2 — 임포트는 "그리기"와 co-located된 2번째 입구(별도 숨은 경로 X). */}

--- a/apps/web/src/components/canvas/artifact-thumbnail.tsx
+++ b/apps/web/src/components/canvas/artifact-thumbnail.tsx
@@ -131,7 +131,7 @@ export function ArtifactThumbnail({ artifactId, latestVersionNumber, anchorVersi
         (() => {
           const Icon = FORMAT_ICON[state.format];
           return (
-            <div className="flex size-full flex-col items-center justify-center gap-0.5 text-muted-foreground/60">
+            <div className="flex size-full flex-col items-center justify-center gap-0.5 text-muted-foreground">
               <Icon className="size-4" aria-hidden />
               <span className="text-[8px] font-semibold uppercase tracking-wide">
                 {t(`galleryFormat${state.format[0]!.toUpperCase()}${state.format.slice(1)}`)}

--- a/apps/web/src/components/canvas/artifact-version-rail.tsx
+++ b/apps/web/src/components/canvas/artifact-version-rail.tsx
@@ -82,7 +82,7 @@ export function ArtifactVersionRail({ artifact, versions, selectedVersion, onSel
         {descOpen ? <ChevronUp className="h-3 w-3" aria-hidden /> : <ChevronDown className="h-3 w-3" aria-hidden />}
       </button>
       {descOpen ? (
-        descriptionSlot ?? <p className="mt-1.5 text-[11px] text-muted-foreground/80">{t('descriptionPaneComingSoon')}</p>
+        descriptionSlot ?? <p className="mt-1.5 text-[11px] text-muted-foreground">{t('descriptionPaneComingSoon')}</p>
       ) : null}
     </div>
   );

--- a/apps/web/src/components/canvas/comment-thread-card.tsx
+++ b/apps/web/src/components/canvas/comment-thread-card.tsx
@@ -76,7 +76,7 @@ export function CommentThreadCard({
         ) : null}
 
         {resolved && thread.resolved_by ? (
-          <p className="text-[10px] text-muted-foreground/80">{t('resolvedByNote', { name: memberMap[thread.resolved_by]?.name ?? '—' })}</p>
+          <p className="text-[10px] text-muted-foreground">{t('resolvedByNote', { name: memberMap[thread.resolved_by]?.name ?? '—' })}</p>
         ) : null}
 
         {!resolved ? (

--- a/apps/web/src/components/canvas/description-pane.tsx
+++ b/apps/web/src/components/canvas/description-pane.tsx
@@ -22,7 +22,7 @@ export function DescriptionPane({ description, elementLabel, className }: Descri
           {description}
         </p>
       ) : (
-        <p className="text-[11px] text-muted-foreground/70">{t('descriptionEmptyState')}</p>
+        <p className="text-[11px] text-muted-foreground">{t('descriptionEmptyState')}</p>
       )}
     </div>
   );

--- a/apps/web/src/components/canvas/export-dialog.tsx
+++ b/apps/web/src/components/canvas/export-dialog.tsx
@@ -105,7 +105,7 @@ export function ExportDialog({ open, onOpenChange, artifactId, versionNumber, ca
           >
             <p>{t('exportFailedNote')}</p>
             {errorDetail ? (
-              <p className="break-words font-mono text-[10px] leading-[13px] text-muted-foreground/70">{errorDetail}</p>
+              <p className="break-words font-mono text-[10px] leading-[13px] text-muted-foreground">{errorDetail}</p>
             ) : null}
           </div>
         ) : (
@@ -123,7 +123,7 @@ export function ExportDialog({ open, onOpenChange, artifactId, versionNumber, ca
                   </button>
                 ))}
               </div>
-              {!pngAllowed ? <p className="mt-1 text-[10px] text-muted-foreground/70">{t('exportPngUnavailableForHtml')}</p> : null}
+              {!pngAllowed ? <p className="mt-1 text-[10px] text-muted-foreground">{t('exportPngUnavailableForHtml')}</p> : null}
             </div>
             {format === 'png' ? (
               <div>

--- a/apps/web/src/components/canvas/property-panel.tsx
+++ b/apps/web/src/components/canvas/property-panel.tsx
@@ -19,7 +19,7 @@ export function PropertyPanel({ node, onChangeText, onDelete, className }: Prope
   if (!node) {
     return (
       <div className={className}>
-        <p className="text-[11px] text-muted-foreground/70">{t('propertyPanelEmpty')}</p>
+        <p className="text-[11px] text-muted-foreground">{t('propertyPanelEmpty')}</p>
       </div>
     );
   }

--- a/apps/web/src/components/chat/asset-embed-card.tsx
+++ b/apps/web/src/components/chat/asset-embed-card.tsx
@@ -64,7 +64,7 @@ export function AssetEmbedCard({ entityId, label, ownMessage }: AssetEmbedCardPr
   const cardSurface = ownMessage ? 'border-white/20 bg-white/12 hover:bg-white/20' : 'border-border bg-card hover:bg-muted';
   const nameTone = ownMessage ? 'text-white' : 'text-foreground';
   const metaTone = ownMessage ? 'text-white/70' : 'text-muted-foreground';
-  const arrowTone = ownMessage ? 'text-white/80' : 'text-muted-foreground/50';
+  const arrowTone = ownMessage ? 'text-white/80' : 'text-muted-foreground';
 
   // ── 로딩: 스켈레톤 카드 ──
   if (loading) {

--- a/apps/web/src/components/chat/asset-picker-popover.tsx
+++ b/apps/web/src/components/chat/asset-picker-popover.tsx
@@ -147,7 +147,7 @@ export function AssetPickerPopover({ projectId, currentFolderId, onSelect, onClo
 
       {/* 검색 */}
       <div className="mx-[13px] mb-2 flex items-center gap-2 rounded-md border border-border bg-card px-2.5 py-[7px]">
-        <Search className="size-3.5 shrink-0 text-muted-foreground/60" aria-hidden />
+        <Search className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
         <input
           ref={searchRef}
           type="text"

--- a/apps/web/src/components/chat/attachment-media.tsx
+++ b/apps/web/src/components/chat/attachment-media.tsx
@@ -155,7 +155,7 @@ export function AttachmentMedia({ storedUrl, conversationId, storyId, label, kin
           <Play className="h-3.5 w-3.5 fill-current" aria-hidden />
         </span>
       )}
-      {kind === 'video' ? <KindIcon className="h-4 w-4 text-muted-foreground/60" aria-hidden /> : null}
+      {kind === 'video' ? <KindIcon className="h-4 w-4 text-muted-foreground" aria-hidden /> : null}
       <span className="min-w-0 flex-1 truncate text-left text-xs text-muted-foreground">{label}</span>
     </button>
   );

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -566,7 +566,7 @@ export function ChatBubble({
             </div>
           )}
 
-          <time className="text-[10px] text-muted-foreground/70">{time}</time>
+          <time className="text-[10px] text-muted-foreground">{time}</time>
 
           {/* AC5: 답글 수 표시 — reply_count > 0 */}
           {replyCount > 0 && (

--- a/apps/web/src/components/dashboard/command-center/action-zone.tsx
+++ b/apps/web/src/components/dashboard/command-center/action-zone.tsx
@@ -203,7 +203,7 @@ export function ActionZone({ data, resolveName, epicTitles }: {
                 <AttentionRow key={`${a.entity_id}-${i}`} item={a} resolveName={resolveName} epicTitles={epicTitles} />
               ))}
               {/* pending 감지(CC-BE.2) — mock 0·미세 "준비중"만 */}
-              {hasPending ? <p className="text-[10px] text-muted-foreground/60">{t('ccAttentionMorePending')}</p> : null}
+              {hasPending ? <p className="text-[10px] text-muted-foreground">{t('ccAttentionMorePending')}</p> : null}
             </div>
           ) : null}
 

--- a/apps/web/src/components/dashboard/command-center/command-center.tsx
+++ b/apps/web/src/components/dashboard/command-center/command-center.tsx
@@ -96,11 +96,11 @@ export function CommandCenter({ projectName }: { projectName?: string | null }) 
                   PendingData가 아니다). isPending에 걸면 이 실 객체와 영원히 안 맞아
                   아래 실측값이 렌더 코드에 도달하지 못했다(#2338이 잡은 사고). */}
               {!isPending(fleet.status_breakdown) ? (
-                <span className="text-muted-foreground/70">
+                <span className="text-muted-foreground">
                   · {t('ccFleetOnlineWorking', { online: fleet.status_breakdown.online, working: fleet.status_breakdown.working })}
                 </span>
               ) : (
-                <span className="text-muted-foreground/70">· {t('ccFleetBreakdownPending')}</span>
+                <span className="text-muted-foreground">· {t('ccFleetBreakdownPending')}</span>
               )}
             </div>
           ) : null}

--- a/apps/web/src/components/dashboard/command-center/overview-zone.tsx
+++ b/apps/web/src/components/dashboard/command-center/overview-zone.tsx
@@ -16,7 +16,7 @@ const VERB_META: Record<string, { key: string; tone: 'ok' | 'warn' }> = {
 };
 
 function PendingSlot({ label }: { label: string }) {
-  return <p className="text-[11px] text-muted-foreground/60">{label}</p>;
+  return <p className="text-[11px] text-muted-foreground">{label}</p>;
 }
 
 function RecentRow({ change, resolveName, t }: { change: RecentChange; resolveName: (id: string | null | undefined) => string | null; t: ReturnType<typeof useTranslations<'dashboard'>> }) {
@@ -30,7 +30,7 @@ function RecentRow({ change, resolveName, t }: { change: RecentChange; resolveNa
     <li className="flex items-center gap-2 text-[11px]">
       {tone === 'warn' ? <AlertTriangle className="size-3 shrink-0 text-warning-strong" /> : <CheckCircle2 className="size-3 shrink-0 text-success" />}
       <span className="min-w-0 flex-1 truncate text-foreground">{label}{resolved ? <span className="text-muted-foreground"> · {resolved}</span> : null}</span>
-      <span className="shrink-0 tabular-nums text-muted-foreground/70">{ago}</span>
+      <span className="shrink-0 tabular-nums text-muted-foreground">{ago}</span>
     </li>
   );
 }
@@ -128,7 +128,7 @@ export function OverviewZone({ data, resolveName }: {
       {/* story #2338 후속 — §11-5 문안 확定 그대로: "아직 표시하지 않는 것 — {항목}" 한 줄 +
           "준비되는 대로 표시됩니다." 시점 약속·사과 없음. 항목 0개면 칸 자체를 안 그린다. */}
       {notYetShown.length > 0 ? (
-        <p className="border-t border-border pt-3 text-[11px] text-muted-foreground/60">
+        <p className="border-t border-border pt-3 text-[11px] text-muted-foreground">
           {t('ccNotYetShownLabel', { items: notYetShown.join(' · ') })}
           <br />
           {t('ccNotYetShownFooter')}

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -385,7 +385,7 @@ export function DocEditor({
             placeholder={titlePlaceholder ?? 'Untitled'}
             autoFocus={titleAutoFocus}
             rows={1}
-            className="min-w-[7rem] flex-1 resize-none overflow-hidden whitespace-nowrap bg-transparent text-lg font-bold leading-snug outline-none placeholder:text-muted-foreground/40"
+            className="min-w-[7rem] flex-1 resize-none overflow-hidden whitespace-nowrap bg-transparent text-lg font-bold leading-snug outline-none placeholder:text-muted-foreground"
           />
         ) : null}
         {metaSlot ? <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline-flex">{metaSlot}</span> : null}
@@ -566,7 +566,7 @@ export function DocEditor({
             {/* 빈 문서 힌트 — 첨부 진입 discoverability(+ · / · DnD). 콘텐츠를 따라가는 것이
                 맞다 — 안쪽 relative(스크롤 컨테이너) 기준 그대로 둔다. */}
             {editable && isEmpty ? (
-              <p className="pointer-events-none absolute left-9 top-3 select-none text-sm text-muted-foreground/50">
+              <p className="pointer-events-none absolute left-9 top-3 select-none text-sm text-muted-foreground">
                 {tEditor('attachEmptyHint')}
               </p>
             ) : null}

--- a/apps/web/src/components/docs/doc-gate-section.tsx
+++ b/apps/web/src/components/docs/doc-gate-section.tsx
@@ -283,7 +283,7 @@ export function DocGateSection({
           >
             <History className="size-3 shrink-0" />
             {t('docGateAuditTitle')}
-            <span className="text-muted-foreground/70">({auditEvents.length})</span>
+            <span className="text-muted-foreground">({auditEvents.length})</span>
             <ChevronDown className={`size-3 shrink-0 transition-transform ${auditOpen ? 'rotate-180' : ''}`} />
           </button>
           {auditOpen ? (

--- a/apps/web/src/components/docs/extensions/embed-node.tsx
+++ b/apps/web/src/components/docs/extensions/embed-node.tsx
@@ -82,7 +82,7 @@ function EmbedView({ node, updateAttributes, selected }: ReactNodeViewProps) {
             onKeyDown={handleKeyDown}
             onBlur={applyUrl}
             placeholder="URL 입력 후 Enter"
-            className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground/60"
+            className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
           />
         </div>
       )}

--- a/apps/web/src/components/docs/tree-search-input.tsx
+++ b/apps/web/src/components/docs/tree-search-input.tsx
@@ -38,7 +38,7 @@ export function TreeSearchInput({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
-          className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/60"
+          className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
         />
         {isSearching && (
           <button

--- a/apps/web/src/components/flow/flow-lane.tsx
+++ b/apps/web/src/components/flow/flow-lane.tsx
@@ -79,7 +79,7 @@ export function FlowLane({ rows, totalEpicCount }: FlowLaneProps) {
                 </span>
               </div>
               {!row.hasLaneData ? (
-                <p className="text-[10px] text-muted-foreground/70">{t('laneUnknown')}</p>
+                <p className="text-[10px] text-muted-foreground">{t('laneUnknown')}</p>
               ) : flags.length === 0 ? (
                 // PO 지적(2026-07-30) — 플래그 넷이 다 0인 것은 "완료"(done===total)와 "아직
                 // 아무도 안 잡음"(done<total, 백로그뿐)의 서로 다른 두 사실을 가릴 수 있다.
@@ -106,7 +106,7 @@ export function FlowLane({ rows, totalEpicCount }: FlowLaneProps) {
       </ul>
       {/* 유나 목업(eacf5b50) L2 footer 고지 — 퍼센트를 안 쓰는 이유를 이 자리에서 한 번만
           말한다(행마다 반복하지 않음). */}
-      <p className="px-1 text-[10px] text-muted-foreground/70">{t('laneWarnMsg')}</p>
+      <p className="px-1 text-[10px] text-muted-foreground">{t('laneWarnMsg')}</p>
     </div>
   );
 }

--- a/apps/web/src/components/integrations/pr-link-section.tsx
+++ b/apps/web/src/components/integrations/pr-link-section.tsx
@@ -216,7 +216,7 @@ export function PrLinkSection({ storyId }: { storyId: string }) {
       {/* 추천 후보(suggestion·med/low) — 강하게 분리·기본 비활성·명시 confirm해야 승격 */}
       {suggestions.length > 0 ? (
         <div className="space-y-1.5">
-          <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">{t('suggestionLabel')}</p>
+          <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">{t('suggestionLabel')}</p>
           <ul className="space-y-1.5">
             {suggestions.map((l) => (
               <li key={l.id} className="flex flex-wrap items-center gap-2 rounded-lg border border-dashed border-border bg-muted/10 p-2 text-[11px]">
@@ -247,7 +247,7 @@ export function PrLinkSection({ storyId }: { storyId: string }) {
               </li>
             ))}
           </ul>
-          <p className="text-[10px] text-muted-foreground/70">{t('promoteHint')}</p>
+          <p className="text-[10px] text-muted-foreground">{t('promoteHint')}</p>
         </div>
       ) : null}
 
@@ -264,7 +264,7 @@ export function PrLinkSection({ storyId }: { storyId: string }) {
             onChange={(e) => setRepoName(e.target.value)}
             placeholder={t('repoPlaceholder')}
             aria-label={t('repoAria')}
-            className="min-w-0 flex-1 bg-transparent font-mono text-foreground outline-none placeholder:text-muted-foreground/50"
+            className="min-w-0 flex-1 bg-transparent font-mono text-foreground outline-none placeholder:text-muted-foreground"
           />
         </div>
         <div className="flex shrink-0 items-center gap-1 rounded-lg border border-border bg-background px-2 py-1 text-[11px]">
@@ -275,7 +275,7 @@ export function PrLinkSection({ storyId }: { storyId: string }) {
             inputMode="numeric"
             placeholder={t('prPlaceholder')}
             aria-label={t('prAria')}
-            className="w-16 bg-transparent text-foreground outline-none placeholder:text-muted-foreground/50"
+            className="w-16 bg-transparent text-foreground outline-none placeholder:text-muted-foreground"
           />
         </div>
         <Button
@@ -290,7 +290,7 @@ export function PrLinkSection({ storyId }: { storyId: string }) {
         </Button>
       </div>
 
-      <p className="text-[10px] text-muted-foreground/70">{t('riskHint')}</p>
+      <p className="text-[10px] text-muted-foreground">{t('riskHint')}</p>
       {error ? (
         <p
           className="inline-flex items-center gap-1 text-[11px] text-destructive"

--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -152,7 +152,7 @@ export function KanbanColumn({
                 type="button"
                 aria-label="Expand done column"
                 onClick={onToggleCollapse}
-                className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground/60 transition hover:text-foreground"
+                className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground transition hover:text-foreground"
               >
                 <ChevronDown className="h-3.5 w-3.5" />
               </button>
@@ -189,7 +189,7 @@ export function KanbanColumn({
                   aria-label={t('wipLimitSet')}
                   title={t('wipLimitSet')}
                   onClick={onWipLimitEdit}
-                  className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground/60 transition hover:text-foreground"
+                  className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground transition hover:text-foreground"
                 >
                   <svg width="12" height="12" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                     <path d="M11.013 1.427a1.75 1.75 0 012.474 2.474L4.92 12.47l-3.265.905.905-3.265 8.453-8.683z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
@@ -201,7 +201,7 @@ export function KanbanColumn({
                     type="button"
                     aria-label="Collapse done column"
                     onClick={onToggleCollapse}
-                    className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground/60 transition hover:text-foreground"
+                    className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground transition hover:text-foreground"
                   >
                     <ChevronUp className="h-3.5 w-3.5" />
                   </button>
@@ -212,7 +212,7 @@ export function KanbanColumn({
                     aria-label={t('addStory')}
                     title={t('addStory')}
                     onClick={startCompose}
-                    className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground/60 transition hover:bg-muted hover:text-foreground"
+                    className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground transition hover:bg-muted hover:text-foreground"
                   >
                     <Plus className="h-3.5 w-3.5" />
                   </button>
@@ -298,7 +298,7 @@ export function KanbanColumn({
             <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-y-auto p-1.5 [&>*]:shrink-0">
               {stories.length === 0 && !composing ? (
                 <div className="flex min-h-[100px] items-center justify-center px-4 text-center">
-                  <p className="text-xs text-muted-foreground/60">{t('noStories')}</p>
+                  <p className="text-xs text-muted-foreground">{t('noStories')}</p>
                 </div>
               ) : null}
               {stories.map((story) => (

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -411,7 +411,7 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
                       {lastExecution.status === 'matched' ? (
                         <Zap className="h-3 w-3 text-warning-strong" />
                       ) : (
-                        <ZapOff className="h-3 w-3 text-muted-foreground/40" />
+                        <ZapOff className="h-3 w-3 text-muted-foreground" />
                       )}
                     </span>
                   ) : null}
@@ -420,7 +420,7 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
                       onClick={(e) => void handleKickoff(e)}
                       disabled={triggering}
                       title={t('kickoff')}
-                      className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground/60 hover:text-primary hover:bg-primary/10 disabled:opacity-40 transition"
+                      className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-primary hover:bg-primary/10 disabled:opacity-40 transition"
                     >
                       {triggering ? (
                         <span className="h-3 w-3 animate-spin rounded-full border border-current border-t-transparent" />

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -1598,7 +1598,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                       ))}
                     </div>
                   ) : (
-                    <p className="mb-2 text-xs text-muted-foreground/60">라벨 없음</p>
+                    <p className="mb-2 text-xs text-muted-foreground">라벨 없음</p>
                   )}
 
                   {showLabelPicker && (

--- a/apps/web/src/components/meetings/audio-recorder.tsx
+++ b/apps/web/src/components/meetings/audio-recorder.tsx
@@ -106,7 +106,7 @@ function DropZone({ onFile, t }: { onFile: (file: File) => void; t: (key: string
     >
       <span className="text-2xl">📁</span>
       <span className="mt-1 text-xs text-muted-foreground">{t('dropAudioFile')}</span>
-      <span className="text-[10px] text-muted-foreground/60">{t('supportedFormats')}</span>
+      <span className="text-[10px] text-muted-foreground">{t('supportedFormats')}</span>
       <input
         ref={inputRef}
         type="file"

--- a/apps/web/src/components/org-briefing/workforce-face.tsx
+++ b/apps/web/src/components/org-briefing/workforce-face.tsx
@@ -66,7 +66,7 @@ function WorkforceRow({ item, memberNames, t }: { item: WorkforceFaceItem; membe
           <span className="text-[11px] text-muted-foreground">{t('workforceTogether')}</span>
         </div>
       ) : (
-        <span className="text-[11px] italic text-muted-foreground/70">{t('workforceUnassigned')}</span>
+        <span className="text-[11px] italic text-muted-foreground">{t('workforceUnassigned')}</span>
       )}
     </div>
   );
@@ -109,7 +109,7 @@ export function WorkforceFace({ projectId }: { projectId: string }) {
         </>
       ) : data.items.length === 0 ? (
         <div className="space-y-2 py-6 text-center">
-          <div className="flex items-center justify-center gap-1.5 text-muted-foreground/50" aria-hidden="true">
+          <div className="flex items-center justify-center gap-1.5 text-muted-foreground" aria-hidden="true">
             <Users className="size-4" />
             <Bot className="size-4" />
           </div>

--- a/apps/web/src/components/settings/workflow-line-editor-section.tsx
+++ b/apps/web/src/components/settings/workflow-line-editor-section.tsx
@@ -265,7 +265,7 @@ export function WorkflowLineEditorSection({ projectId }: { projectId?: string | 
                 <span className="font-mono text-xs text-foreground">v{v.version}</span>
                 <Badge variant={STATUS_VARIANT[v.status] ?? 'chip'}>{v.status}</Badge>
                 <span className="text-[10px] text-muted-foreground">{t('lineEditorLintLabel')}: {v.lint_status}</span>
-                {v.updated_at ? <span className="text-[10px] text-muted-foreground/70">{new Date(v.updated_at).toLocaleString()}</span> : null}
+                {v.updated_at ? <span className="text-[10px] text-muted-foreground">{new Date(v.updated_at).toLocaleString()}</span> : null}
                 {v.status === 'draft' ? (
                   <Button size="sm" variant="ghost" className="ml-auto h-7 gap-1" onClick={() => void openVersion(v.id)}>
                     <Pencil className="size-3.5" />{t('lineEditorEditAction')}

--- a/apps/web/src/components/settings/workflow-template-gallery-section.tsx
+++ b/apps/web/src/components/settings/workflow-template-gallery-section.tsx
@@ -204,7 +204,7 @@ export function WorkflowTemplateGallerySection({
                   )}
                 </div>
               </div>
-              <p className="mt-2 text-[10px] text-muted-foreground/70">
+              <p className="mt-2 text-[10px] text-muted-foreground">
                 프리셋 {Object.keys(tmpl.presets ?? {}).length}종
               </p>
             </button>

--- a/apps/web/src/components/storage/storage-source-usage-list.tsx
+++ b/apps/web/src/components/storage/storage-source-usage-list.tsx
@@ -93,7 +93,7 @@ export function StorageSourceUsageList({ links, compact = false }: StorageSource
                 </span>
               ) : null}
             </span>
-            {isLinked ? <ArrowUpRight className="mt-[3px] size-4 shrink-0 text-muted-foreground/40" /> : null}
+            {isLinked ? <ArrowUpRight className="mt-[3px] size-4 shrink-0 text-muted-foreground" /> : null}
           </>
         );
 

--- a/apps/web/src/components/ui/empty-state.tsx
+++ b/apps/web/src/components/ui/empty-state.tsx
@@ -16,7 +16,7 @@ export function EmptyState({
   return (
     <div className={cn('rounded-2xl bg-muted/50 px-6 py-10 text-center', className)}>
       <div className="mx-auto max-w-md space-y-3">
-        {icon ? <div className="mb-3 flex justify-center text-muted-foreground/60">{icon}</div> : null}
+        {icon ? <div className="mb-3 flex justify-center text-muted-foreground">{icon}</div> : null}
         <h3 className="text-base font-semibold tracking-tight text-foreground">{title}</h3>
         {description ? <p className="text-sm leading-6 text-muted-foreground">{description}</p> : null}
         {action ? <div className="pt-2.5">{action}</div> : null}

--- a/apps/web/src/components/verify/evidence-section.tsx
+++ b/apps/web/src/components/verify/evidence-section.tsx
@@ -205,12 +205,12 @@ export function EvidenceSection({
                               className="flex items-center gap-1 text-xs font-medium text-foreground hover:underline"
                             >
                               <span className="truncate">{primaryText}</span>
-                              <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground/70" aria-hidden />
+                              <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground" aria-hidden />
                             </a>
                           ) : (
                             <span className="block truncate text-xs font-medium text-foreground">{primaryText}</span>
                           )}
-                          {item.source ? <p className="truncate text-[11px] text-muted-foreground/80">{item.source}</p> : null}
+                          {item.source ? <p className="truncate text-[11px] text-muted-foreground">{item.source}</p> : null}
                         </div>
                         <span className="mt-0.5 shrink-0 text-[10px] font-semibold text-muted-foreground">
                           {t(TYPE_LABEL_KEY[item.type] ?? 'evidenceTypeUrl')}


### PR DESCRIPTION
## 요약
(B) contrast 가드(#2590/#2997)가 실픽셀로 적출한 `text-muted-foreground/{alpha}` 저대비 채무 상환. 유나 확定(08-13, story #2611 SSOT): `--muted-foreground`(L0.52)는 이미 "AA 겨우 넘는 가장 흐린 본문색"이라 그 위에 알파를 얹으면 **모든 레벨**(/40~/80)에서 4.5:1 미달 — solid(/100)만 5.51:1 통과. 더 흐린 위계가 필요하면 대비가 아니라 크기(11px)·굵기(500)·간격으로 표현한다.

## 처방
1. **89곳(텍스트+아이콘) 전부** `/[0-9]+` 접미사 제거 → solid `text-muted-foreground`. 아이콘도 텍스트와 같은 규칙(유나 확定: "더 조용히"는 알파가 아니라 크기).
2. 예외 = 큰 순수 장식(배경 워터마크류·aria-hidden·인접 텍스트 없음)뿐 — `// muted-alpha-ok: <이유>` 주석 밸브로만 통과. **89곳 전수 스캔 결과 이 예외에 해당하는 자리 0건**(size-16 이상/watermark 패턴 grep 0매치).
3. 신설 정적 회귀가드 `scripts/verify-no-muted-foreground-alpha.ts`(형제 가드 `verify-no-alpha-focus-ring.ts`와 동일 규율) — `text-muted-foreground/{alpha}` 재도입 시 CI 실패. CI(`ci.yml`) 배선 완료.
4. `(B) contrast-axe-baseline.json` 3키(`/settings::light`, `/settings::dark`, `/settings::dark::hover`) 제거 — 물리 색쌍은 2개(dark의 rest/hover가 같은 hex 공유)·QA(카디르) diff 실측으로 정정 — can-only-shrink가 실제로 줄어드는 자리(근본 원인이 전부 이 알파 변형이었음).

## 이관 목록 (파일:라인(알파값) — 47파일·89곳)
| 파일 | 건수 | 라인(알파값) |
|---|---|---|
| app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx | 4 | 24(/50), 552(/50), 575(/70), 1098(/70) |
| app/(authenticated)/[ws]/[proj]/loops/loops-client.tsx | 3 | 26(/70), 29(/40), 36(/40) |
| app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx | 1 | 19(/70) |
| app/(authenticated)/organization/trust/trust-utils.tsx | 1 | 132(/60) |
| app/(authenticated)/settings/page.tsx | 6 | 695(/70), 709(/70), 737(/70), 756(/70), 777(/70), 786(/70) |
| app/invite/accept/invite-accept-client.tsx | 1 | 57(/60) |
| app/invite/page.tsx | 4 | 263(/60), 273(/60), 282(/60), 326(/60) |
| app/login/page.tsx | 2 | 200(/60), 214(/60) |
| app/privacy/page.tsx | 2 | 18(/60), 55(/60) |
| app/register/page.tsx | 3 | 128(/60), 173(/60), 206(/60) |
| app/reset-password/page.tsx | 2 | 127(/60), 130(/60) |
| app/terms/page.tsx | 2 | 18(/60), 55(/60) |
| components/activity/team-activity-view.tsx | 1 | 380(/60) |
| components/cage/gate-evidence.tsx | 5 | 170(/60), 185(/70), 195(/70), 200(/80), 225(/50) |
| components/cage/gate-line-context.tsx | 2 | 75(/70), 114(/80) |
| components/cage/trust-score-card.tsx | 1 | 58(/60) |
| components/canvas/artifact-gallery-view.tsx | 2 | 270(/40), 324(/60) |
| components/canvas/artifact-section.tsx | 1 | 217(/60) |
| components/canvas/artifact-thumbnail.tsx | 1 | 134(/60) |
| components/canvas/artifact-version-rail.tsx | 1 | 85(/80) |
| components/canvas/comment-thread-card.tsx | 1 | 79(/80) |
| components/canvas/description-pane.tsx | 1 | 25(/70) |
| components/canvas/export-dialog.tsx | 2 | 108(/70), 126(/70) |
| components/canvas/property-panel.tsx | 1 | 22(/70) |
| components/chat/asset-embed-card.tsx | 1 | 67(/50) |
| components/chat/asset-picker-popover.tsx | 1 | 150(/60) |
| components/chat/attachment-media.tsx | 1 | 158(/60) |
| components/chat/chat-bubble.tsx | 1 | 569(/70) |
| components/dashboard/command-center/action-zone.tsx | 1 | 206(/60) |
| components/dashboard/command-center/command-center.tsx | 2 | 99(/70), 103(/70) |
| components/dashboard/command-center/overview-zone.tsx | 3 | 19(/60), 33(/70), 131(/60) |
| components/docs/doc-editor.tsx | 2 | 388(/40), 569(/50) |
| components/docs/doc-gate-section.tsx | 1 | 286(/70) |
| components/docs/extensions/embed-node.tsx | 1 | 85(/60) |
| components/docs/tree-search-input.tsx | 1 | 41(/60) |
| components/flow/flow-lane.tsx | 2 | 82(/70), 109(/70) |
| components/integrations/pr-link-section.tsx | 5 | 219(/70), 250(/70), 267(/50), 278(/50), 293(/70) |
| components/kanban/kanban-column.tsx | 5 | 155(/60), 192(/60), 204(/60), 215(/60), 301(/60) |
| components/kanban/story-card.tsx | 2 | 414(/40), 423(/60) |
| components/kanban/story-detail-panel.tsx | 1 | 1601(/60) |
| components/meetings/audio-recorder.tsx | 1 | 109(/60) |
| components/org-briefing/workforce-face.tsx | 2 | 69(/70), 112(/50) |
| components/settings/workflow-line-editor-section.tsx | 1 | 268(/70) |
| components/settings/workflow-template-gallery-section.tsx | 1 | 207(/70) |
| components/storage/storage-source-usage-list.tsx | 1 | 96(/40) |
| components/ui/empty-state.tsx | 1 | 19(/60) |
| components/verify/evidence-section.tsx | 2 | 208(/70), 213(/80) |

## 검증
- `pnpm vitest run` — 405 files / 3157 tests pass (신규 10건 = 가드 자체 테스트).
- `tsc --noEmit` clean · `eslint` clean.
- `verify:no-new-tint-color-text` — 신규 0건(교차 영향 없음, 별개 가드 계열).
- `verify:no-muted-foreground-alpha` 신설 가드 자체 실행 — `OK: text-muted-foreground 알파 회귀 0건`.

## ⚠️ 정직 캐비어트
- (B) axe 런타임 재실측(baseline 3키 소멸 확認)은 CI의 실브라우저 스캔에서 확정된다 — 로컬에서는 정적 grep/코드리뷰로 근본원인 제거를 확認했을 뿐, 실측 grep 값 자체는 CI가 최종 권위.
- 시각 위계(muted 존재 이유)가 죽지 않았는지는 AC4 — 유나 design 검수 요청(«캡션↔라벨 안 갈리는 자리»·11px 과소 의심 자리는 이 PR에 없었음, 대다수가 이미 `text-[10px]`/`text-xs` + `font-medium` 조합으로 크기·굵기 위계를 갖추고 있어 solid 전환만으로 위계 원리 자체는 그대로).
- 카디르 QA: 두 테마 라이브 스크린샷.

