### PR TITLE
[SID:2604] approval-request 챗 카드 배달(BE 절반) — 이벤트 템플릿·Gate 연결

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -443,6 +443,8 @@ def _msg_payload(
         payload["is_blocked_sender"] = bool(sender and sender.id in blocked_sender_ids)
     # E-ACTIVATION S1: typed activation 필드 top-level 노출(없으면 None). connector 헤더 주입용.
     payload.update(_activation_payload(msg))
+    # story #2604 P2: approval-request 카드 스키마 top-level 노출(없으면 None·additive).
+    payload.update(_approval_payload(msg))
     return payload
 
 
@@ -476,6 +478,15 @@ def _activation_payload(msg: "ConversationMessage") -> dict:
         "message_kind": act.get("kind"),
         "expects_response": act.get("expects_response"),
     }
+
+
+def _approval_payload(msg: "ConversationMessage") -> dict:
+    """story #2604 P2(delivery-contract-blueprint-v0-1): msg_metadata['approval_target'] →
+    payload top-level(없으면 None). _activation_payload와 동형(additive·__dict__ 전용 read —
+    동일 greenlet_spawn 회피 이유). 카드 *렌더*는 FE 몫 — 여기는 스키마만 실어 나른다."""
+    meta = (getattr(msg, "__dict__", None) or {}).get("msg_metadata")
+    target = meta.get("approval_target") if isinstance(meta, dict) else None
+    return {"approval_target": target if isinstance(target, dict) else None}
 
 
 async def _viewer_blocked_sender_ids(auth: AuthContext, org_id: uuid.UUID, db: AsyncSession) -> set[uuid.UUID]:
@@ -848,6 +859,37 @@ async def _dispatch_discord_outbound(
                 )
 
 
+async def _create_conversation_record(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID,
+    member_ids: set[uuid.UUID],
+    conv_type: str,
+    title: str | None,
+    created_by: uuid.UUID,
+) -> Conversation:
+    """story #2604 P2(delivery-contract-blueprint-v0-1) 추출: create_conversation 엔드포인트의
+    INSERT 로직(원본 그대로, 추출만 — 동작 불변) — 인가(_enforce_agent_creator_policy)·dedup
+    정책(EF-S2 항상-신규)은 호출부 책임. approval-request DM(get-or-create 배달 경로,
+    app/services/approval_delivery.py)이 이 프리미티브를 재사용한다."""
+    all_members = sorted(member_ids)
+    dm_pair_key = "|".join(str(m) for m in all_members) if conv_type == "dm" else None
+    conv = Conversation(
+        project_id=project_id,
+        org_id=org_id,
+        type=conv_type,
+        title=title,
+        created_by=created_by,
+        dm_pair_key=dm_pair_key,
+    )
+    db.add(conv)
+    await db.flush()
+    for mid in all_members:
+        db.add(ConversationParticipant(conversation_id=conv.id, member_id=mid))
+    return conv
+
+
 # ─── Schemas ──────────────────────────────────────────────────────────────────
 
 class CreateConversationRequest(BaseModel):
@@ -1035,21 +1077,17 @@ async def create_conversation(
     # thread=스토리. dm_pair_key 컬럼은 2인 룸 태깅용으로 유지(non-unique·dedup 아님).
     all_members = sorted({sender.id, *valid_participant_ids})
     is_dm = len(all_members) == 2
-    dm_pair_key = "|".join(str(m) for m in all_members) if is_dm else None
 
-    conv = Conversation(
-        project_id=body.project_id,
-        org_id=org_id,
-        type=("dm" if is_dm else body.type),
-        title=body.title,
-        created_by=sender.id,
-        dm_pair_key=dm_pair_key,
-    )
-    db.add(conv)
     try:
-        await db.flush()
-        for mid in all_members:
-            db.add(ConversationParticipant(conversation_id=conv.id, member_id=mid))
+        conv = await _create_conversation_record(
+            db,
+            org_id=org_id,
+            project_id=body.project_id,
+            member_ids=set(all_members),
+            conv_type=("dm" if is_dm else body.type),
+            title=body.title,
+            created_by=sender.id,
+        )
         await db.commit()
     except IntegrityError:
         # dedup unique 제거 후엔 DM pair 레이스 충돌 없음 — 잔여 무결성 오류는 reuse 없이 전파.

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -1,0 +1,137 @@
+"""story #2604 P2(delivery-contract-blueprint-v0-1): approval-request 챗 카드 배달 — BE 절반
+(이벤트 템플릿·Gate 연결까지). 카드 *렌더*는 미르코 FE(#2614) 몫. 카드 액션(승인/반려)은 새 API
+없이 기존 POST /api/v2/gates/{id}/transition 을 그대로 쓴다(AC③) — 여기는 그 gate로 이어지는
+길(승인자별 DM + message_kind="request" + approval_target 페이로드)만 만든다.
+
+⚠️AC3 정책(코드가 아니라 문서로 명문화 — PR 본문 + #2604 스토리 설명): 챗에서 "승인"이라고
+텍스트로만 답하는 건 게이트를 해소하지 않는다 — 오직 카드 액션(버튼, gates.py 기존 human-only
+SoD 인가 경유)만 유효하다. 이 모듈은 그 규칙을 코드로 강제하지 않는다(강제할 지점이 없다 —
+게이트 해소 자체가 이미 독립적으로 인가돼 있다). 여기서 하는 일은 그 카드가 승인자 눈앞에
+"보이게" 배달하는 것까지.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.conversation import Conversation, ConversationMessage
+from app.models.doc import Doc
+
+logger = logging.getLogger(__name__)
+
+
+async def _get_or_create_approval_dm(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID,
+    requester_id: uuid.UUID,
+    approver_id: uuid.UUID,
+) -> Conversation:
+    """requester↔approver 기존 dm 재사용(가장 최근 1개), 없으면 생성.
+
+    일반 create_conversation 엔드포인트의 "매 호출 신규" 정책(EF-S2, db75ecd0)과 의도적으로
+    다르다 — 승인자당 안정적 단일 스레드(카드 상태 갱신 대상)가 필요한 시스템 배달 경로라서,
+    여기 한정으로 get-or-create를 쓴다(엔드포인트 자체는 무변경).
+
+    _enforce_agent_creator_policy 미적용: 사용자가 여는 방이 아니라, 게이트가 이미 독립적으로
+    인가한(요청자=문서 상신자, 대상=org owner/admin) 시스템 발신 알림 배달이다.
+    """
+    pair_key = "|".join(str(m) for m in sorted((requester_id, approver_id)))
+    existing = (
+        await db.execute(
+            select(Conversation)
+            .where(
+                Conversation.org_id == org_id,
+                Conversation.type == "dm",
+                Conversation.dm_pair_key == pair_key,
+            )
+            .order_by(Conversation.created_at.desc())
+            .limit(1)
+        )
+    ).scalars().first()
+    if existing is not None:
+        return existing
+
+    from app.routers.conversations import _create_conversation_record
+
+    return await _create_conversation_record(
+        db,
+        org_id=org_id,
+        project_id=project_id,
+        member_ids={requester_id, approver_id},
+        conv_type="dm",
+        title=None,
+        created_by=requester_id,
+    )
+
+
+async def dispatch_approval_request_cards(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    doc: Doc,
+    gate_id: uuid.UUID,
+    requester_id: uuid.UUID,
+    approver_ids: list[uuid.UUID],
+) -> None:
+    """승인자별 DM에 message_kind="request" 카드 메시지 게시 + SSE 이벤트(AC1/AC2).
+
+    승인자별 SAVEPOINT 격리 — 한 승인자 배달 실패(예: DM insert 레이스)가 나머지 승인자
+    배달이나, 이 함수를 부르는 doc 상신 트랜잭션(gate 생성·doc.status='pending') 자체를
+    poison 하지 않는다([[feedback_savepoint_failopen_session_poison]] — bare flush 실패
+    후 세션 오염이 후속 write를 통째로 삼키는 클래스).
+
+    project_id 없는 doc(비정상 상태)은 배달 스킵(무대상, 조용히 반환).
+    """
+    if not doc.project_id or not approver_ids:
+        return
+
+    from app.routers.conversations import _dispatch_conversation_event
+    from app.services.member_resolver import lookup_members_by_ids
+
+    requester = (await lookup_members_by_ids({requester_id}, db)).get(requester_id)
+    if requester is None:
+        logger.warning("approval-request 카드 배달 스킵 — requester 미확인 doc=%s", doc.id)
+        return
+
+    for approver_id in approver_ids:
+        try:
+            async with db.begin_nested():
+                conv = await _get_or_create_approval_dm(
+                    db,
+                    org_id=org_id,
+                    project_id=doc.project_id,
+                    requester_id=requester_id,
+                    approver_id=approver_id,
+                )
+                msg = ConversationMessage(
+                    conversation_id=conv.id,
+                    sender_id=requester_id,
+                    content=f"'{doc.title}' 문서 결재 요청",
+                    mentioned_ids=[approver_id],
+                    msg_metadata={
+                        "activation": {
+                            "audience": [str(approver_id)],
+                            "kind": "request",
+                            "expects_response": True,
+                        },
+                        "approval_target": {
+                            "work_item_type": "doc",
+                            "work_item_id": str(doc.id),
+                            "gate_id": str(gate_id),
+                            "actions": ["approve", "reject"],
+                        },
+                    },
+                )
+                db.add(msg)
+                await db.flush()
+                await _dispatch_conversation_event(db, conv, msg, org_id, requester)
+        except Exception:  # noqa: BLE001 — best-effort, 개별 승인자 실패가 상신을 막지 않음.
+            logger.warning(
+                "approval-request 카드 배달 실패 doc=%s approver=%s",
+                doc.id, approver_id, exc_info=True,
+            )

--- a/backend/app/services/doc.py
+++ b/backend/app/services/doc.py
@@ -26,29 +26,51 @@ async def _notify_doc_approval_requested(
     session: AsyncSession, org_id: uuid.UUID, doc: Doc, gate_id: uuid.UUID, *, requester_id: uuid.UUID
 ) -> None:
     """doc-gate v2 갭2: doc 상신 → org owner/admin 휴먼 결재자에게 in-app 알림(상신자 본인 제외).
-    best-effort·비중단(알림 실패가 상신을 막지 않음). transition_gate 해소 알림과 대칭."""
+    best-effort·비중단(알림 실패가 상신을 막지 않음). transition_gate 해소 알림과 대칭.
+
+    story #2604 P2(delivery-contract-blueprint-v0-1): 벨 알림과 별개로, 같은 approver_ids에
+    대해 챗 승인요청 카드(승인자별 DM + message_kind="request")도 배달한다 — 둘은 독립 채널
+    (하나 실패해도 다른 하나는 그대로) [[project_...]] 카드 렌더 자체는 FE(미르코 #2614) 몫,
+    여기서는 이벤트 스키마·Gate 연결까지."""
+    approver_ids: list[uuid.UUID] = []
     try:
         from app.models.project import OrgMember
-        from app.services.notification_dispatch import dispatch_notification
-        approver_ids = (await session.execute(
+        approver_ids = list((await session.execute(
             select(OrgMember.id).where(
                 OrgMember.org_id == org_id,
                 OrgMember.role.in_(("owner", "admin")),
                 OrgMember.deleted_at.is_(None),  # 산티아고 RC: 삭제/탈퇴 owner/admin 제외(정보노출·실결재권자만)
                 OrgMember.id != requester_id,
             )
-        )).scalars().all()
-        if approver_ids:
-            await dispatch_notification(
-                session, org_id=org_id, event_type="doc_approval_requested",
-                target_member_ids=list(approver_ids),
-                title="문서 결재 요청",
-                body=f"'{doc.title}' 문서가 결재 대기 중입니다.",
-                reference_type="gate", reference_id=gate_id,
-                source_project_id=doc.project_id,
-            )
-    except Exception:  # noqa: BLE001 — 알림 실패는 상신 비중단.
-        logger.warning("doc 상신 결재자 알림 실패 doc=%s", doc.id, exc_info=True)
+        )).scalars().all())
+    except Exception:  # noqa: BLE001 — 조회 실패는 상신 비중단.
+        logger.warning("doc 상신 결재자 조회 실패 doc=%s", doc.id, exc_info=True)
+        return
+
+    if not approver_ids:
+        return
+
+    try:
+        from app.services.notification_dispatch import dispatch_notification
+        await dispatch_notification(
+            session, org_id=org_id, event_type="doc_approval_requested",
+            target_member_ids=approver_ids,
+            title="문서 결재 요청",
+            body=f"'{doc.title}' 문서가 결재 대기 중입니다.",
+            reference_type="gate", reference_id=gate_id,
+            source_project_id=doc.project_id,
+        )
+    except Exception:  # noqa: BLE001 — 벨 알림 실패는 상신 비중단.
+        logger.warning("doc 상신 결재자 벨 알림 실패 doc=%s", doc.id, exc_info=True)
+
+    try:
+        from app.services.approval_delivery import dispatch_approval_request_cards
+        await dispatch_approval_request_cards(
+            session, org_id=org_id, doc=doc, gate_id=gate_id,
+            requester_id=requester_id, approver_ids=approver_ids,
+        )
+    except Exception:  # noqa: BLE001 — 카드 배달 실패는 상신 비중단(Gate inbox 폴백 항상 존재).
+        logger.warning("doc 상신 결재자 카드(챗) 배달 실패 doc=%s", doc.id, exc_info=True)
 
 
 class DocTransitionError(Exception):

--- a/backend/tests/test_2604_approval_request_cards.py
+++ b/backend/tests/test_2604_approval_request_cards.py
@@ -1,0 +1,231 @@
+"""story #2604 P2(delivery-contract-blueprint-v0-1) — approval-request 챗 카드 배달(실 PG).
+
+BE 절반: (1) 승인자별 DM get-or-create가 진짜 재사용/생성을 하는지, (2) 카드 메시지가
+message_kind="request" + approval_target(work_item_id/gate_id/actions) 스키마로 실리는지,
+(3) 승인자 1명 배달 실패가 다른 승인자·doc 상신 트랜잭션을 poison하지 않는지
+([[feedback_savepoint_failopen_session_poison]] 클래스 회귀 방지) 검증.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2604", slug=f"org2604-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_human(session, org_id, project_id):
+    from app.models.team import TeamMember
+
+    m = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="human",
+        name="requester", is_active=True,
+    )
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_doc(session, org_id, project_id, *, title="설계 문서"):
+    from app.models.doc import Doc
+
+    doc = Doc(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title,
+        content="본문", status="pending", slug=f"doc-{uuid.uuid4().hex[:8]}",
+    )
+    session.add(doc)
+    await session.commit()
+    return doc
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_dispatch_creates_dm_and_request_card_per_approver():
+    from app.services.approval_delivery import dispatch_approval_request_cards
+    from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            requester_id = await _seed_human(s, org_id, project_id)
+            approver1 = await _seed_human(s, org_id, project_id)
+            approver2 = await _seed_human(s, org_id, project_id)
+            doc = await _seed_doc(s, org_id, project_id)
+            gate_id = uuid.uuid4()
+
+            await dispatch_approval_request_cards(
+                s, org_id=org_id, doc=doc, gate_id=gate_id,
+                requester_id=requester_id, approver_ids=[approver1, approver2],
+            )
+            await s.commit()
+
+            from sqlalchemy import select
+
+            convs = (await s.execute(select(Conversation).where(Conversation.org_id == org_id))).scalars().all()
+            assert len(convs) == 2, "승인자 2명 → DM 2개(각자 스레드)"
+            assert {c.type for c in convs} == {"dm"}
+
+            msgs = (await s.execute(select(ConversationMessage))).scalars().all()
+            assert len(msgs) == 2
+            for msg in msgs:
+                assert msg.msg_metadata["activation"]["kind"] == "request"
+                assert msg.msg_metadata["activation"]["expects_response"] is True
+                target = msg.msg_metadata["approval_target"]
+                assert target["work_item_type"] == "doc"
+                assert target["work_item_id"] == str(doc.id)
+                assert target["gate_id"] == str(gate_id)
+                assert target["actions"] == ["approve", "reject"]
+
+            parts = (await s.execute(select(ConversationParticipant))).scalars().all()
+            member_ids_per_conv: dict = {}
+            for p in parts:
+                member_ids_per_conv.setdefault(p.conversation_id, set()).add(p.member_id)
+            for conv in convs:
+                assert member_ids_per_conv[conv.id] == {requester_id, approver1} or \
+                    member_ids_per_conv[conv.id] == {requester_id, approver2}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_second_approval_reuses_existing_dm_not_new_room():
+    """같은 requester↔approver 페어에 대해 두 번째 상신은 기존 DM을 재사용(카드가 매번 새 방으로
+    흩어지면 승인자가 스레드를 잃는다) — 일반 create_conversation의 항상-신규 정책(EF-S2)과
+    의도적으로 다른 지점(get-or-create 전용 경로)임을 잠근다."""
+    from app.services.approval_delivery import dispatch_approval_request_cards
+    from app.models.conversation import Conversation, ConversationMessage
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            requester_id = await _seed_human(s, org_id, project_id)
+            approver_id = await _seed_human(s, org_id, project_id)
+            doc1 = await _seed_doc(s, org_id, project_id, title="문서1")
+            doc2 = await _seed_doc(s, org_id, project_id, title="문서2")
+
+            await dispatch_approval_request_cards(
+                s, org_id=org_id, doc=doc1, gate_id=uuid.uuid4(),
+                requester_id=requester_id, approver_ids=[approver_id],
+            )
+            await s.commit()
+            await dispatch_approval_request_cards(
+                s, org_id=org_id, doc=doc2, gate_id=uuid.uuid4(),
+                requester_id=requester_id, approver_ids=[approver_id],
+            )
+            await s.commit()
+
+            from sqlalchemy import select
+
+            convs = (await s.execute(select(Conversation).where(Conversation.org_id == org_id))).scalars().all()
+            assert len(convs) == 1, "같은 pair 재상신 → DM 재사용(신규 방 생성 금지)"
+            msgs = (await s.execute(select(ConversationMessage))).scalars().all()
+            assert len(msgs) == 2, "카드 메시지는 방마다가 아니라 상신마다 1건씩 쌓인다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_one_approver_failure_does_not_poison_session_for_others():
+    """승인자 1명(존재하지 않는 member_id — FK 위반 유도)의 카드 배달이 실패해도, 세션이
+    poison되지 않고 나머지 승인자 배달 + 이 함수를 부르는 트랜잭션의 후속 write가 그대로
+    성공해야 한다(SAVEPOINT 격리 검증 — begin_nested 없으면 여기서 PendingRollbackError)."""
+    from app.services.approval_delivery import dispatch_approval_request_cards
+    from app.models.conversation import Conversation, ConversationMessage
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            requester_id = await _seed_human(s, org_id, project_id)
+            good_approver = await _seed_human(s, org_id, project_id)
+            nonexistent_approver = uuid.uuid4()  # team_members에 없음 → FK 위반 유도
+            doc = await _seed_doc(s, org_id, project_id)
+
+            await dispatch_approval_request_cards(
+                s, org_id=org_id, doc=doc, gate_id=uuid.uuid4(),
+                requester_id=requester_id, approver_ids=[nonexistent_approver, good_approver],
+            )
+            # poison 됐다면 이 commit이나 후속 write가 즉시 실패한다.
+            await s.commit()
+
+            from sqlalchemy import select
+
+            convs = (await s.execute(select(Conversation).where(Conversation.org_id == org_id))).scalars().all()
+            assert len(convs) == 1, "실패한 승인자는 방 생성 0, 성공한 승인자만 방 1개"
+            msgs = (await s.execute(select(ConversationMessage))).scalars().all()
+            assert len(msgs) == 1
+
+            # 세션이 살아있음을 추가 write로 확인(poison이면 여기서 PendingRollbackError).
+            from app.models.organization import Organization
+            s.add(Organization(id=uuid.uuid4(), name="Sentinel", slug=f"sentinel-{uuid.uuid4().hex[:8]}"))
+            await s.commit()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_no_approvers_no_dm_created():
+    from app.services.approval_delivery import dispatch_approval_request_cards
+    from app.models.conversation import Conversation
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            requester_id = await _seed_human(s, org_id, project_id)
+            doc = await _seed_doc(s, org_id, project_id)
+
+            await dispatch_approval_request_cards(
+                s, org_id=org_id, doc=doc, gate_id=uuid.uuid4(),
+                requester_id=requester_id, approver_ids=[],
+            )
+            await s.commit()
+
+            from sqlalchemy import select
+
+            convs = (await s.execute(select(Conversation).where(Conversation.org_id == org_id))).scalars().all()
+            assert convs == []
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -128,6 +128,38 @@ def test_msg_payload_includes_summary():
     assert payload["summary"].startswith(f"{sender.name}: ")
 
 
+def test_msg_payload_exposes_approval_target_when_present():
+    """story #2604 P2: msg_metadata['approval_target']가 있으면 payload top-level에 그대로
+    노출된다(_activation_payload와 동형 additive 패턴) — 카드 렌더(FE)가 이 필드로 붙는다."""
+    from app.routers.conversations import _msg_payload
+    msg = _make_msg()
+    gate_id = uuid.uuid4()
+    doc_id = uuid.uuid4()
+    msg.msg_metadata = {
+        "activation": {"kind": "request", "expects_response": True},
+        "approval_target": {
+            "work_item_type": "doc", "work_item_id": str(doc_id),
+            "gate_id": str(gate_id), "actions": ["approve", "reject"],
+        },
+    }
+    sender = _make_member()
+    payload = _msg_payload(msg, sender)
+    assert payload["message_kind"] == "request"
+    assert payload["approval_target"] == {
+        "work_item_type": "doc", "work_item_id": str(doc_id),
+        "gate_id": str(gate_id), "actions": ["approve", "reject"],
+    }
+
+
+def test_msg_payload_approval_target_none_when_absent():
+    """기존(activation 없는) 메시지 — approval_target 키는 있되 값은 None(additive·회귀 없음)."""
+    from app.routers.conversations import _msg_payload
+    msg = _make_msg()
+    sender = _make_member()
+    payload = _msg_payload(msg, sender)
+    assert payload["approval_target"] is None
+
+
 # ─── AC1: Alembic migration 파일 + 테이블 확인 ───────────────────────────────
 
 def test_migration_file_exists():

--- a/backend/tests/test_edg_doc_gate_inbox.py
+++ b/backend/tests/test_edg_doc_gate_inbox.py
@@ -225,14 +225,20 @@ async def test_non_doc_gate_still_auto_passes():
 
 @pytest.mark.anyio
 async def test_submit_notifies_org_approvers():
-    """갭2: 상신 → org owner/admin 휴먼 결재자에게 dispatch_notification(상신자 제외·gate 참조)."""
+    """갭2: 상신 → org owner/admin 휴먼 결재자에게 dispatch_notification(상신자 제외·gate 참조).
+
+    story #2604 P2: 이 테스트는 벨 알림 경로만 스코프(카드 배달은 별도
+    test_2604_approval_request_cards.py) — dispatch_approval_request_cards를 patch해 동일
+    session.execute 목을 카드 배달의 lookup_members_by_ids 호출과 공유하지 않는다(공유 시
+    session.execute.await_args가 마지막 호출로 밀려 approver 쿼리 검증이 깨짐)."""
     from app.services.doc import _notify_doc_approval_requested
     org, requester, gate_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
     doc = MagicMock(id=uuid.uuid4(), title="설계 문서", project_id=uuid.uuid4())
     owners = [uuid.uuid4(), uuid.uuid4()]
     res = MagicMock(); res.scalars.return_value.all.return_value = owners
     session = AsyncMock(); session.execute = AsyncMock(return_value=res)
-    with patch("app.services.notification_dispatch.dispatch_notification", new=AsyncMock()) as dn:
+    with patch("app.services.notification_dispatch.dispatch_notification", new=AsyncMock()) as dn, \
+         patch("app.services.approval_delivery.dispatch_approval_request_cards", new=AsyncMock()):
         await _notify_doc_approval_requested(session, org, doc, gate_id, requester_id=requester)
     dn.assert_awaited_once()
     kw = dn.await_args.kwargs


### PR DESCRIPTION
## 요약
블루프린트 P2([[delivery-contract-blueprint-v0-1]], P0 #3000·P1 #3003 후행)의 BE 절반. 선생님 직접 지시("PO가 doc으로 보고하면 챗에 승인요청 UI가 동시에 그려지고 거기서 승인할 수 있게") — doc 상신 시 승인자별 DM에 `message_kind="request"` + `approval_target` 카드 메시지를 배달한다. 카드 **렌더** 자체는 미르코 FE 몫(#2604 잔여 FE 절반 — 후속 PR, 같은 SID)(그 위에 얹는 구조) — 이 PR은 이벤트 스키마·Gate 연결·배달 채널까지.

새 승인 API는 만들지 않았다(AC③) — 카드의 승인/반려 액션은 기존 `POST /api/v2/gates/{id}/transition`을 그대로 쓴다(human-only SoD 인가 기존 그대로).

## 변경
- **`backend/app/routers/conversations.py`**
  - `create_conversation` 엔드포인트의 INSERT 로직(Conversation+ConversationParticipant 생성)을 `_create_conversation_record`로 추출 — **추출만, 동작 불변**(기존 엔드포인트 테스트가 수정 없이 그대로 green, 아래 검증 참조). approval-request DM 배달이 이 프리미티브를 재사용한다.
  - `_approval_payload` 추가 — `msg_metadata['approval_target']` → payload top-level 노출. 기존 `_activation_payload`(E-ACTIVATION S1)와 완전히 동형인 additive 패턴(없으면 `None`, 기존 메시지 payload 회귀 없음).
- **`backend/app/services/approval_delivery.py`(신규)**
  - `_get_or_create_approval_dm`: requester↔approver 페어당 기존 DM 재사용(없으면 생성). 일반 `create_conversation` 엔드포인트의 "매 호출 신규"(EF-S2) 정책과 **의도적으로 다른 지점** — 승인자당 안정적 단일 스레드가 필요한 시스템 배달 경로라서 여기 한정 get-or-create. `_enforce_agent_creator_policy`는 미적용(사용자가 여는 방이 아니라 게이트가 이미 독립 인가한 시스템 발신 알림 배달).
  - `dispatch_approval_request_cards`: 승인자별로 DM get-or-create + 카드 메시지(`ConversationMessage`, `msg_metadata={activation:{kind:"request",...}, approval_target:{work_item_type,work_item_id,gate_id,actions}}`) 게시 + 기존 `_dispatch_conversation_event` 재사용으로 SSE push(신규 이벤트 타입 0 — `conversation.message_created`를 그대로 타되 payload가 `approval_target`을 싣는다).
  - **승인자별 `db.begin_nested()`(SAVEPOINT) 격리** — 한 승인자 배달이 실패(DM insert 레이스 등)해도 나머지 승인자 배달이나 이 함수를 부르는 doc 상신 트랜잭션(gate 생성·`doc.status='pending'`) 자체를 poison하지 않는다. 실PG 테스트로 이 계약을 직접 잠갔다(존재하지 않는 member_id로 FK 위반을 유도해 세션 생존을 확인).
- **`backend/app/services/doc.py::_notify_doc_approval_requested`**
  - 기존 벨 알림(approver_ids 조회 재사용)과 **독립 채널**로 카드 배달을 추가 — 하나 실패해도 다른 하나는 그대로(각자 own try/except).

## AC3 정책 명문화(코드 아님, 스토리 설명에도 동일 텍스트)
챗 카드 **액션(버튼)만** 게이트를 해소한다. 대화에서 "승인"이라고 텍스트로만 답하는 건 게이트 상태를 바꾸지 않는다 — 그 메시지는 평범한 대화 메시지로 남고 게이트는 pending 그대로 유지. 카드를 놓쳤거나 무시한 경우의 폴백(AC4 접점)은 기존 Gate inbox(`GET /api/v2/gates?status=pending`) — 카드가 안 보였어도 게이트 자체는 항상 조회/해소 가능(조용한 유실 0). 이 정책은 코드로 강제할 지점이 없다(게이트 해소가 이미 독립 인가돼 있음) — 이 문단이 그 정책의 SSOT.

## 알려진 한계(정직하게 명시)
- **레이스**: 같은 requester↔approver 페어에 동시 상신 2건이 오면 `_get_or_create_approval_dm`이 각각 "기존 DM 없음"을 보고 DM 2개를 만들 수 있다(unique 제약 없음 — 179db213 이후 `uq_conversations_dm_pair`는 이미 drop됨, EF-S2). 결재 상신은 저빈도 human-initiated 액션이라 advisory lock 등으로 미리 막지 않았다 — 발생해도 승인자가 카드를 놓치지 않는(둘 다 눈에 보임) 방향의 실패라 안전.
- **쿼리 비용**: 승인자 N명 = DM 조회 N + (신규 시) INSERT N + 메시지 INSERT N — 소수 org owner/admin 규모(보통 1~3명)라 문제 없음.

## 테스트
- `test_2604_approval_request_cards.py`(신규, 4건, 실PG `pgvector/pgvector:pg15` 디스포저블 컨테이너): 승인자별 DM+카드 생성, 재상신 시 DM 재사용(신규 방 생성 안 됨), 승인자 1명 실패해도 세션 미poison(SAVEPOINT 검증), 승인자 0명 no-op.
- `test_conversations.py`: `approval_target` payload 노출/부재(additive 회귀 없음) 2건 추가. 기존 `create_conversation`/`_msg_payload` 관련 테스트는 무수정으로 green(추출이 동작 불변임을 증명).
- `test_edg_doc_gate_inbox.py`: 기존 "벨 알림" 테스트(`test_submit_notifies_org_approvers`)가 신규 카드 배달과 mock session을 공유해 `session.execute.await_args` 어서션이 흔들리던 걸 카드 배달 `patch`로 스코프 격리(원래 의도한 벨-알림 전용 검증으로 복원).
- 전체 회귀는 conversations/doc/gates 영역만 로컬 검증(전체 realdb 스윕은 CI가 유지하는 alembic-migrated 공유 DB가 필요 — 로컬 ad-hoc 컨테이너로는 무관한 다수 파일이 스키마 미부트스트랩으로 false-fail함, 기존에 확인된 인프라 특성).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
