### PR TITLE
hotfix: agent-group mentions default → opt-in (팀 A2A 통신 차단 즉시 해소)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -158,6 +158,14 @@ class Settings(BaseSettings):
     # 파생(충돌 시 redis 우선+ERROR)·"pg"|"redis"=명시 강제. "잘못된 상태를 표현 불가능하게"(불린 2개 대신 enum).
     realtime_backplane: str = ""
 
+    # 핫픽스(2026-08-13, 선생님 직접 지시 — 페드루 경유): story #2603 P0가 그룹(비-DM) 대화의
+    # agent recipient 기본 delivery level을 all→mentions로 바꿨는데, free_response 오버라이드
+    # 규명 전에 팀 전체 통신이 막혀(require_mention 켜고 일하는 관례가 없다) 즉시 되돌린다.
+    # 기본 off = 사전 #2603 동작(agent group도 all) — 소급 mentions는 규명·수리 후 opt-in
+    # 재활성 대상. False가 아니면(레거시 지원 없음) channel_router.py의 mentions 분기가
+    # 활성화된다(테스트에서만 True로 켜 그 분기 자체는 계속 커버).
+    agent_group_default_mentions: bool = False
+
     # E-ARCH S2 정리(2026-07-21, LISTEN 제거 완료 후 발견): redis_consume_loop task 생성이
     # event_broker_redis_dual_publish_enabled 하나로만 게이트돼 있었다 — dual_publish(발행,
     # 모든 인스턴스가 필요)와 consume(구독+dispatch, SSE를 실제로 서빙하는 서비스만 필요)

--- a/backend/app/services/channel_router.py
+++ b/backend/app/services/channel_router.py
@@ -12,6 +12,7 @@ from typing import Sequence
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.notification_preference import NotificationPreference
 from app.models.team import TeamMember
@@ -62,6 +63,12 @@ async def route_message(
     agent이고 대화가 group(dm 아님)이며 그 recipient의 명시 preference 행이 없으면
     default level="mentions"(과거는 이 경우도 "all"이었다 — PO 소급 확定: 원 고통이 기존
     그룹챗에 있어 소급 없이는 반쪽 해법). human이거나 DM이면 기존과 동일 default="all".
+
+    ⛔핫픽스(2026-08-13, 선생님 직접 지시): 위 mentions 기본계약은 `settings.
+    agent_group_default_mentions`(기본 False)로 게이트된다 — free_response 오버라이드가
+    실 사용에서 안 먹는 게 규명 전에 팀 전체 A2A 통신을 막아, 규명·수리 전까지 소급 off로
+    되돌렸다(#2603 원 의도는 유효·재상륙은 opt-in). 플래그 False면 이 분기는 완전히
+    스킵되고 agent group도 기존처럼 default="all"이 된다.
 
     **free_response 대화 오버라이드**(AC2 옵트아웃): `conversation.free_response=true`면
     이 대화 한정으로 level="mentions"인 recipient는 "all"로 완화된다 — 단 명시 "mute"는
@@ -202,8 +209,11 @@ async def route_message(
             if pref is not None:
                 level = pref.level
                 reason = f"preference scope={matched_scope}"
-            elif recipient_type == "agent" and conv_type != "dm":
+            elif recipient_type == "agent" and conv_type != "dm" and settings.agent_group_default_mentions:
                 # story #2603 P0: 에이전트 그룹챗 기본계약(소급 적용, PO 확定) — 위 docstring.
+                # 핫픽스(2026-08-13): free_response 오버라이드 규명 전까지 기본 off로 되돌림
+                # (settings.agent_group_default_mentions) — 팀 전체 통신 차단이 근본원인 규명보다
+                # 급했다(선생님 직접 지시). 규명·수리 후 opt-in 재활성 대상.
                 level = "mentions"
                 reason = "agent group default: mentions"
             else:

--- a/backend/tests/test_channel_router_multiproject_sender.py
+++ b/backend/tests/test_channel_router_multiproject_sender.py
@@ -20,6 +20,12 @@ _NOT_EXPIRED = patch(
     "app.services.channel_router.compute_agent_chain_depth", AsyncMock(return_value=1),
 )
 
+# 핫픽스(2026-08-13): agent 그룹챗 mentions 기본계약은 settings.agent_group_default_mentions
+# (기본 False)로 게이트됐다 — 그 분기 자체(메커니즘)를 계속 커버하는 테스트는 명시로 켠다.
+_MENTIONS_ON = patch(
+    "app.services.channel_router.settings.agent_group_default_mentions", True,
+)
+
 
 @pytest.fixture
 def anyio_backend():
@@ -98,7 +104,7 @@ async def test_multiproject_agent_sender_dispatches_without_crash():
         _scalars([]),                       # 6 preferences
     ])
 
-    with _NOT_EXPIRED:
+    with _NOT_EXPIRED, _MENTIONS_ON:
         decisions = await route_message(msg.id, db)
     # 발신자 제외·크래시/ChannelRouterError 없이 멘션된 recipient에게만 decision.
     assert len(decisions) == 1
@@ -137,9 +143,47 @@ async def test_agent_group_default_excludes_unmentioned_agent_recipient():
         _scalars([]),
     ])
 
-    with _NOT_EXPIRED:
+    with _NOT_EXPIRED, _MENTIONS_ON:
         decisions = await route_message(msg.id, db)
     assert decisions == [], "멘션 없는데 decision이 생기면 원 루프가 그대로 재현된다"
+
+
+@pytest.mark.anyio
+async def test_agent_group_default_is_all_when_mentions_flag_off():
+    """핫픽스(2026-08-13) — settings.agent_group_default_mentions 기본 False에서는 그룹챗
+    에이전트 recipient도 멘션 없이 all(사전 #2603 동작 복귀). 팀 전체 A2A 통신 차단 회피가
+    이 값의 존재 이유 — 회귀하면 다시 막힌다."""
+    from app.services.channel_router import route_message
+
+    sender = uuid.uuid4()
+    recipient = uuid.uuid4()
+    conv = uuid.uuid4()
+    proj = uuid.uuid4()
+
+    msg = MagicMock()
+    msg.id = uuid.uuid4()
+    msg.sender_id = sender
+    msg.conversation_id = conv
+    msg.thread_id = None
+    msg.mentioned_ids = []  # 멘션 없음 — 플래그 off면 그래도 통과해야 한다.
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=[
+        _scalar(msg),
+        _scalar("agent"),
+        _scalars([sender, recipient]),
+        _scalars([]),
+        _all([(recipient, "agent")]),
+        _row(project_id=proj, type="group", free_response=False),
+        _scalars([]),
+    ])
+
+    with _NOT_EXPIRED:  # _MENTIONS_ON 없음 — 기본값(False) 그대로.
+        decisions = await route_message(msg.id, db)
+    assert len(decisions) == 1
+    assert decisions[0].member_id == recipient
+    assert decisions[0].level == "all"
+    assert decisions[0].reason == "default: all"
 
 
 @pytest.mark.anyio
@@ -204,7 +248,7 @@ async def test_free_response_conversation_relaxes_mentions_to_all():
         _scalars([]),
     ])
 
-    with _NOT_EXPIRED:
+    with _NOT_EXPIRED, _MENTIONS_ON:
         decisions = await route_message(msg.id, db)
     assert len(decisions) == 1
     assert decisions[0].level == "all"

--- a/backend/tests/test_check_env_drift_settings_coverage.py
+++ b/backend/tests/test_check_env_drift_settings_coverage.py
@@ -162,6 +162,9 @@ def test_settings_field_env_keys_works_without_pydantic_settings_importable(monk
     # #2495(결제②-C4, PO 승인 2026-08-07): toss_webhook_secret 필드 신설로 92→93
     # (TOSS_WEBHOOK_SECRET 포함) — TossAdapter.verify_webhook의 HMAC 서명 검증 시크릿,
     # polar_webhook_secret 동형. 가드가 신규 필드를 설계대로 잡은 것.
+    # 핫픽스(2026-08-13, 선생님 직접 지시): agent_group_default_mentions 필드 신설로 93→94
+    # (AGENT_GROUP_DEFAULT_MENTIONS 포함) — #2603 그룹챗 mentions 기본계약을 opt-in으로
+    # 되돌리는 kill switch(기본 False). 가드가 신규 필드를 설계대로 잡은 것.
     assert "PRESENCE_REDIS_ENABLED" in keys and "SSE_TRANSIENT_REPLAY_ENABLED" in keys
     assert "REQUIRE_VERIFIED_EMAIL_FOR_ORG_CREATE" in keys
     assert "DATABASE_URL_READ" in keys
@@ -170,4 +173,5 @@ def test_settings_field_env_keys_works_without_pydantic_settings_importable(monk
     assert "TOSS_PAYMENTS_CRYPTO_KEY" in keys and "TOSS_MERCHANT_ID" in keys
     assert "ORG_BILLING_KEY_ENCRYPTION_KEY" in keys
     assert "TOSS_WEBHOOK_SECRET" in keys
-    assert len(keys) == 93
+    assert "AGENT_GROUP_DEFAULT_MENTIONS" in keys
+    assert len(keys) == 94


### PR DESCRIPTION
## 요약
선생님 직접 지시(2026-08-13, 페드루 경유): 팀은 require_mention 없이 일하는 관례인데, #2603 P0(PR #3000)가 도입한 "그룹챗 agent recipient 기본 delivery level = mentions" 계약이 팀 전체 A2A 통신을 막았다. **규명·수리는 후속 별건으로 미루고 지금은 속도가 전부** — 즉시 소급 off.

**추가(2번째 커밋)**: hotfix ①을 병합해도 페드루↔디디 DM은 여전히 무멘션 메시지가 막혔다 — Cloud Logging 실측(04:58:47/05:01:52, 정확히 판별 메시지 발신 시각)으로 진범이 **#2608 P1의 chain-depth 최종 게이트**였음을 확定. 그것도 같이 고쳤다(아래 변경 ②).

## 변경
① `backend/app/core/config.py` + `backend/app/services/channel_router.py`: `agent_group_default_mentions: bool = False` 추가, `route_message()`의 `recipient_type=="agent" and conv_type!="dm"` mentions 분기에 `and settings.agent_group_default_mentions` 조건 추가. **코드 삭제가 아니라 플래그로 감쌌다** — #2603의 원 의도(A↔B 무한 루프 방지)는 유효하고, 규명·수리 후 opt-in으로 재활성할 수 있게 보존한다. off(기본값)면 agent group도 human/DM과 동일하게 `default="all"`(#2603 이전 동작)로 복귀.

② `backend/app/services/channel_router.py`: #2608 P1의 chain-depth 최종 게이트(`chain_expired and recipient_type=="agent"`)에 `and conv_type != "dm"` 추가. **근본원인**: human 메시지가 하나도 없는 순수 1:1 agent DM은 연쇄 깊이가 구조적으로 늘 cap(4)을 넘어, "A↔B 무한루프 방지"라는 원 의도와 무관하게 정상적인 장기 1:1 협업 자체를 침묵시켰다(멘션 있는 메시지만 살아있던 이유는 `_dispatch_mention_events`가 이 게이트를 안 타는 별개 경로라서). group(다자간 핑퐁 리스크)은 게이트 유지. P0/P1 배선 전체 원복은 하지 않았다 — mute-제외·AC5-관측 개선을 같이 잃을 이유가 없어서, 원인이 좁혀진 지점만 최소 수정.

## 스코프 밖(후속 별건)
- 애초 의심했던 `conversation.free_response=true` 오버라이드 자체는 정적으로 읽었을 때 구조상 맞았고(실제로 버그가 아니었을 가능성 높음 — 진범은 chain-depth였다), 별도 재확인 필요.
- MCP `sprintable_send_chat_message`(`SendChatInput`)에 member 라우팅용 `mentioned_ids` 필드 자체가 없어 MCP발 메시지는 전부 `mentioned_ids=[]`로 나가는 구조적 갭 — 이번 두 hotfix로 당장 영향은 없으나 재상륙 시 같이 닫아야 한다.
- `_dispatch_mention_events`가 chain-depth 게이트를 안 타는 것 자체(멘션이 loop-방지를 우회) — #2608 원 설계 문서(comment)의 의도("mentions 조건 자체는 항상 통과"를 막으려던 것)와 실제 배선이 어긋나 있다. 오늘 급한 불은 아니라 별건 트래킹.

## 테스트
- `test_channel_router_multiproject_sender.py`: mentions-기본계약 메커니즘 검증 3건은 `settings.agent_group_default_mentions=True` 명시 패치로 커버 유지. 신규 `test_agent_group_default_is_all_when_mentions_flag_off`(플래그 off에서 그룹챗 무멘션 agent가 all로 통과 — 회귀 가드) + 신규 `test_chain_expired_does_not_block_dm_agent_recipient`(depth=999에서도 DM 무멘션 agent recipient는 통과 — 오늘 재현된 버그의 회귀 가드). 기존 group chain-expired 케이스는 무수정으로 계속 막힘 확인(회귀 0).
- `test_check_env_drift_settings_coverage.py`: Settings 필드 개수 드리프트 가드(93→94) 갱신.
- 관련 스윕(`channel_router`/`2608`/`event1config`/`2603`/`config` 키워드) 로컬 green 확인.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>