### PR TITLE
hotfix2: chain-depth 게이트 DM/무인간 대화 예외 — 팀 A2A 메인 전달 경로 복구

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -158,6 +158,14 @@ class Settings(BaseSettings):
     # 파생(충돌 시 redis 우선+ERROR)·"pg"|"redis"=명시 강제. "잘못된 상태를 표현 불가능하게"(불린 2개 대신 enum).
     realtime_backplane: str = ""
 
+    # 핫픽스(2026-08-13, 선생님 직접 지시 — 페드루 경유): story #2603 P0가 그룹(비-DM) 대화의
+    # agent recipient 기본 delivery level을 all→mentions로 바꿨는데, free_response 오버라이드
+    # 규명 전에 팀 전체 통신이 막혀(require_mention 켜고 일하는 관례가 없다) 즉시 되돌린다.
+    # 기본 off = 사전 #2603 동작(agent group도 all) — 소급 mentions는 규명·수리 후 opt-in
+    # 재활성 대상. False가 아니면(레거시 지원 없음) channel_router.py의 mentions 분기가
+    # 활성화된다(테스트에서만 True로 켜 그 분기 자체는 계속 커버).
+    agent_group_default_mentions: bool = False
+
     # E-ARCH S2 정리(2026-07-21, LISTEN 제거 완료 후 발견): redis_consume_loop task 생성이
     # event_broker_redis_dual_publish_enabled 하나로만 게이트돼 있었다 — dual_publish(발행,
     # 모든 인스턴스가 필요)와 consume(구독+dispatch, SSE를 실제로 서빙하는 서비스만 필요)

--- a/backend/app/services/channel_router.py
+++ b/backend/app/services/channel_router.py
@@ -81,6 +81,11 @@ async def route_message(
     통과)를 막는 유일한 축이라 다른 판정보다 뒤에, 최종 게이트로 건다. human recipient는
     이 게이트의 대상이 아니다(인간이 바로 그 "앵커"라 차단하면 안 됨 — 오히려 human-
     intervention 이벤트로 알려야 할 대상).
+
+    ⛔핫픽스(2026-08-13, 라이브 실측): 이 게이트도 DM은 대상 밖이다 — human 메시지가 애초에
+    없는 순수 1:1 agent DM(장기 협업방)은 연쇄 깊이가 구조적으로 늘 cap을 넘어, loop 방지
+    의도와 무관하게 정상 1:1 대화 자체가 침묵당했다(reason=chain-expired 반복 확인).
+    group(다자간 A↔B 핑퐁 리스크)만 게이트 유지.
     """
     try:
         # 1. 메시지 + 발신자 조회
@@ -247,7 +252,15 @@ async def route_message(
             # story #2608 P1: 최종 게이트 — 그 외 모든 판정을 통과했어도(멘션 성립·all·
             # free_response 완화 전부 포함) agent recipient는 연쇄가 cap을 넘으면 여기서
             # 막힌다. human recipient는 대상 밖(위 docstring).
-            if chain_expired and recipient_type == "agent":
+            #
+            # ⛔핫픽스(2026-08-13, 라이브 실측·Cloud Logging 대조 확定): DM은 이 게이트 밖이다.
+            # 순수 1:1 agent DM(human 메시지가 애초에 없는 지속 작업방, 예: PM↔BE 핸드오프)은
+            # 연쇄 깊이가 구조적으로 항상 cap을 넘어 — «A↔B 무한루프 방지»라는 원 의도와 무관하게
+            # «정상적인 장기 1:1 협업»을 통째로 침묵시켰다(reason=chain-expired 반복, 판별3·4
+            # 재현). group의 loop-risk와 DM의 legitimate 1:1은 다른 문제라 mentions-기본값
+            # DM예외(#2603)와 같은 논리로 여기도 DM을 뺀다 — group(다자간 A↔B 핑퐁 리스크)은
+            # 그대로 게이트 유지.
+            if chain_expired and recipient_type == "agent" and conv_type != "dm":
                 logger.info(
                     "delivery_contract: excluded recipient=%s conversation_id=%s reason=%s",
                     rid, msg.conversation_id, "chain-expired",

--- a/backend/app/services/channel_router.py
+++ b/backend/app/services/channel_router.py
@@ -12,6 +12,7 @@ from typing import Sequence
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.notification_preference import NotificationPreference
 from app.models.team import TeamMember
@@ -62,6 +63,12 @@ async def route_message(
     agent이고 대화가 group(dm 아님)이며 그 recipient의 명시 preference 행이 없으면
     default level="mentions"(과거는 이 경우도 "all"이었다 — PO 소급 확定: 원 고통이 기존
     그룹챗에 있어 소급 없이는 반쪽 해법). human이거나 DM이면 기존과 동일 default="all".
+
+    ⛔핫픽스(2026-08-13, 선생님 직접 지시): 위 mentions 기본계약은 `settings.
+    agent_group_default_mentions`(기본 False)로 게이트된다 — free_response 오버라이드가
+    실 사용에서 안 먹는 게 규명 전에 팀 전체 A2A 통신을 막아, 규명·수리 전까지 소급 off로
+    되돌렸다(#2603 원 의도는 유효·재상륙은 opt-in). 플래그 False면 이 분기는 완전히
+    스킵되고 agent group도 기존처럼 default="all"이 된다.
 
     **free_response 대화 오버라이드**(AC2 옵트아웃): `conversation.free_response=true`면
     이 대화 한정으로 level="mentions"인 recipient는 "all"로 완화된다 — 단 명시 "mute"는
@@ -202,8 +209,11 @@ async def route_message(
             if pref is not None:
                 level = pref.level
                 reason = f"preference scope={matched_scope}"
-            elif recipient_type == "agent" and conv_type != "dm":
+            elif recipient_type == "agent" and conv_type != "dm" and settings.agent_group_default_mentions:
                 # story #2603 P0: 에이전트 그룹챗 기본계약(소급 적용, PO 확定) — 위 docstring.
+                # 핫픽스(2026-08-13): free_response 오버라이드 규명 전까지 기본 off로 되돌림
+                # (settings.agent_group_default_mentions) — 팀 전체 통신 차단이 근본원인 규명보다
+                # 급했다(선생님 직접 지시). 규명·수리 후 opt-in 재활성 대상.
                 level = "mentions"
                 reason = "agent group default: mentions"
             else:

--- a/backend/tests/test_channel_router_multiproject_sender.py
+++ b/backend/tests/test_channel_router_multiproject_sender.py
@@ -359,6 +359,46 @@ async def test_chain_expired_blocks_agent_recipient_even_when_mentioned():
 
 
 @pytest.mark.anyio
+async def test_chain_expired_does_not_block_dm_agent_recipient():
+    """핫픽스(2026-08-13, 라이브 실측·Cloud Logging 대조 확定) — DM은 chain-expired 최종
+    게이트 밖이다. human 메시지가 없는 순수 1:1 agent DM은 연쇄 깊이가 구조적으로 늘 cap을
+    넘는데(장기 협업방 자체가 그런 모양), 이 게이트가 group과 동일하게 적용되면 정상 1:1
+    대화가 통째로 침묵당한다(실제로 페드루↔디디 DM에서 무멘션 메시지가 전부 막힌 채로 재현
+    됐다 — reason=chain-expired). group은 이 테스트 파일의 다른 케이스(위)처럼 그대로 막혀야
+    한다 — 이 테스트는 DM만 예외임을 고정."""
+    from app.services.channel_router import route_message
+
+    sender = uuid.uuid4()
+    recipient = uuid.uuid4()
+    conv = uuid.uuid4()
+    proj = uuid.uuid4()
+
+    msg = MagicMock()
+    msg.id = uuid.uuid4()
+    msg.sender_id = sender
+    msg.conversation_id = conv
+    msg.thread_id = None
+    msg.mentioned_ids = []  # 무멘션 — DM 기본계약(all)만으로 통과해야 한다.
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=[
+        _scalar(msg),
+        _scalar("agent"),
+        _scalars([sender, recipient]),
+        _scalars([]),
+        _all([(recipient, "agent")]),
+        _row(project_id=proj, type="dm", free_response=False),
+        _scalars([]),
+    ])
+
+    with patch("app.services.channel_router.compute_agent_chain_depth", AsyncMock(return_value=999)):
+        decisions = await route_message(msg.id, db)
+    assert len(decisions) == 1, "DM에서 연쇄 cap 초과가 무멘션 agent recipient를 막으면 안 된다"
+    assert decisions[0].member_id == recipient
+    assert decisions[0].level == "all"
+
+
+@pytest.mark.anyio
 async def test_chain_expired_does_not_block_human_recipient():
     """human recipient는 연쇄 게이트 대상이 아니다 — human이 바로 그 개입 대상."""
     from app.services.channel_router import route_message

--- a/backend/tests/test_channel_router_multiproject_sender.py
+++ b/backend/tests/test_channel_router_multiproject_sender.py
@@ -20,6 +20,12 @@ _NOT_EXPIRED = patch(
     "app.services.channel_router.compute_agent_chain_depth", AsyncMock(return_value=1),
 )
 
+# 핫픽스(2026-08-13): agent 그룹챗 mentions 기본계약은 settings.agent_group_default_mentions
+# (기본 False)로 게이트됐다 — 그 분기 자체(메커니즘)를 계속 커버하는 테스트는 명시로 켠다.
+_MENTIONS_ON = patch(
+    "app.services.channel_router.settings.agent_group_default_mentions", True,
+)
+
 
 @pytest.fixture
 def anyio_backend():
@@ -98,7 +104,7 @@ async def test_multiproject_agent_sender_dispatches_without_crash():
         _scalars([]),                       # 6 preferences
     ])
 
-    with _NOT_EXPIRED:
+    with _NOT_EXPIRED, _MENTIONS_ON:
         decisions = await route_message(msg.id, db)
     # 발신자 제외·크래시/ChannelRouterError 없이 멘션된 recipient에게만 decision.
     assert len(decisions) == 1
@@ -137,9 +143,47 @@ async def test_agent_group_default_excludes_unmentioned_agent_recipient():
         _scalars([]),
     ])
 
-    with _NOT_EXPIRED:
+    with _NOT_EXPIRED, _MENTIONS_ON:
         decisions = await route_message(msg.id, db)
     assert decisions == [], "멘션 없는데 decision이 생기면 원 루프가 그대로 재현된다"
+
+
+@pytest.mark.anyio
+async def test_agent_group_default_is_all_when_mentions_flag_off():
+    """핫픽스(2026-08-13) — settings.agent_group_default_mentions 기본 False에서는 그룹챗
+    에이전트 recipient도 멘션 없이 all(사전 #2603 동작 복귀). 팀 전체 A2A 통신 차단 회피가
+    이 값의 존재 이유 — 회귀하면 다시 막힌다."""
+    from app.services.channel_router import route_message
+
+    sender = uuid.uuid4()
+    recipient = uuid.uuid4()
+    conv = uuid.uuid4()
+    proj = uuid.uuid4()
+
+    msg = MagicMock()
+    msg.id = uuid.uuid4()
+    msg.sender_id = sender
+    msg.conversation_id = conv
+    msg.thread_id = None
+    msg.mentioned_ids = []  # 멘션 없음 — 플래그 off면 그래도 통과해야 한다.
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=[
+        _scalar(msg),
+        _scalar("agent"),
+        _scalars([sender, recipient]),
+        _scalars([]),
+        _all([(recipient, "agent")]),
+        _row(project_id=proj, type="group", free_response=False),
+        _scalars([]),
+    ])
+
+    with _NOT_EXPIRED:  # _MENTIONS_ON 없음 — 기본값(False) 그대로.
+        decisions = await route_message(msg.id, db)
+    assert len(decisions) == 1
+    assert decisions[0].member_id == recipient
+    assert decisions[0].level == "all"
+    assert decisions[0].reason == "default: all"
 
 
 @pytest.mark.anyio
@@ -204,7 +248,7 @@ async def test_free_response_conversation_relaxes_mentions_to_all():
         _scalars([]),
     ])
 
-    with _NOT_EXPIRED:
+    with _NOT_EXPIRED, _MENTIONS_ON:
         decisions = await route_message(msg.id, db)
     assert len(decisions) == 1
     assert decisions[0].level == "all"

--- a/backend/tests/test_check_env_drift_settings_coverage.py
+++ b/backend/tests/test_check_env_drift_settings_coverage.py
@@ -162,6 +162,9 @@ def test_settings_field_env_keys_works_without_pydantic_settings_importable(monk
     # #2495(결제②-C4, PO 승인 2026-08-07): toss_webhook_secret 필드 신설로 92→93
     # (TOSS_WEBHOOK_SECRET 포함) — TossAdapter.verify_webhook의 HMAC 서명 검증 시크릿,
     # polar_webhook_secret 동형. 가드가 신규 필드를 설계대로 잡은 것.
+    # 핫픽스(2026-08-13, 선생님 직접 지시): agent_group_default_mentions 필드 신설로 93→94
+    # (AGENT_GROUP_DEFAULT_MENTIONS 포함) — #2603 그룹챗 mentions 기본계약을 opt-in으로
+    # 되돌리는 kill switch(기본 False). 가드가 신규 필드를 설계대로 잡은 것.
     assert "PRESENCE_REDIS_ENABLED" in keys and "SSE_TRANSIENT_REPLAY_ENABLED" in keys
     assert "REQUIRE_VERIFIED_EMAIL_FOR_ORG_CREATE" in keys
     assert "DATABASE_URL_READ" in keys
@@ -170,4 +173,5 @@ def test_settings_field_env_keys_works_without_pydantic_settings_importable(monk
     assert "TOSS_PAYMENTS_CRYPTO_KEY" in keys and "TOSS_MERCHANT_ID" in keys
     assert "ORG_BILLING_KEY_ENCRYPTION_KEY" in keys
     assert "TOSS_WEBHOOK_SECRET" in keys
-    assert len(keys) == 93
+    assert "AGENT_GROUP_DEFAULT_MENTIONS" in keys
+    assert len(keys) == 94


### PR DESCRIPTION
## 요약
#3008(이미 머지됨 a4cc8c846)의 브랜치에 디디가 push한 2번째 커밋을 새 PR로 태움 — 통신 두절 탓에 #3008 머지 사실이 그에게 미도달해 브랜치에 표류하던 것(PO가 PR만 개설·코드는 디디 작).

**진짜 근본**: P1(#3003)의 chain-depth 최종 게이트가 conv_type 무관하게 발화 — 인간 참가자가 없는 팀 상시 대화(agent↔agent)는 연속 agent 깊이가 항상 cap(4)을 넘고 인간 앵커 리셋이 영원히 없어 **메인 전달 경로가 전면 차단**됨(mentions 플래그·free_response와 무관 — 판별 실험과 정합·멘션 경로는 별도 dispatch라 생존했던 것).

**변경(디디 커밋)**: chain-expired 최종게이트에 `conv_type != "dm"` 예외 추가 + 회귀 테스트(depth=999 극단값에서도 DM 통과).

⚠️단 팀 대화는 type=group이라 dm 예외만으로 충분한지 배포 후 무멘션 왕복 실측으로 확認한다 — 부족하면 후속(무인간 대화 예외)을 즉시 얹는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)