### PR TITLE
fix(#2594): warning 알파 변형 2곳 → text-warning-strong (sub-AA 후속)

### DIFF
--- a/apps/web/src/components/agents/agent-performance-panel.tsx
+++ b/apps/web/src/components/agents/agent-performance-panel.tsx
@@ -241,7 +241,7 @@ export function AgentPerformancePanel() {
                       key={agent.id}
                       className="flex items-center gap-3 px-3 py-2.5"
                     >
-                      <span className={`w-6 shrink-0 text-center text-sm font-bold ${idx === 0 ? 'text-warning-strong' : idx === 1 ? 'text-muted-foreground' : idx === 2 ? 'text-warning/70' : 'text-muted-foreground'}`}>
+                      <span className={`w-6 shrink-0 text-center text-sm font-bold ${idx === 0 ? 'text-warning-strong' : idx === 1 ? 'text-muted-foreground' : idx === 2 ? 'text-warning-strong' : 'text-muted-foreground'}`}>
                         {idx + 1}
                       </span>
                       <span className="flex-1 truncate text-sm font-medium text-foreground">{agent.name}</span>

--- a/apps/web/src/components/docs/doc-url-chip.tsx
+++ b/apps/web/src/components/docs/doc-url-chip.tsx
@@ -27,7 +27,7 @@ export function DocUrlChip({ slug, onEdit, onDeriveFromTitle, labels }: DocUrlCh
       <button
         type="button"
         onClick={onDeriveFromTitle}
-        className="inline-flex items-center gap-1.5 text-xs text-warning-strong transition-colors hover:text-warning/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-warning rounded"
+        className="inline-flex items-center gap-1.5 text-xs text-warning-strong transition-colors hover:text-warning-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-warning rounded"
       >
         <span className="max-w-[60vw] truncate font-mono md:max-w-md">/docs/{slug}</span>
         <span className="inline-flex items-center gap-1">


### PR DESCRIPTION
## #2594 후속 — warning 알파 변형 2곳 → `text-warning-strong`

#2594(warning-strong)에서 «별 판정 후속»으로 남긴 warning 알파 2곳을 처방대로 solid화. base = `develop`(warning-strong 토큰은 #2594 머지분).

### 변경
- **`components/agents/agent-performance-panel.tsx`** (rank idx2): `text-warning/70` → `text-warning-strong`.
  rank 구분은 숫자/위치가 짐 — faint 색이 아니다. `/70`은 sub-AA(라이트 2.98:1)라 3rd 랭크가 사실상 안 보였다.
- **`components/docs/doc-url-chip.tsx`** (hover): `hover:text-warning/80` → `hover:text-warning-strong`.
  **위계 역전 해소** — base가 이미 `text-warning-strong`(L0.52)인데 hover가 `warning/80`(L0.75)로 «더 연해»지던 것(hover가 rest보다 저대비 = 역전). 이제 hover도 strong.

### 결과
`apps/web/src`에 `text-warning/N` 알파 **0건**(warning 텍스트 전 상태 solid strong).

### 대비 재실측 (리포 oklch→sRGB)
`text-warning-strong` = 라이트 5.54:1 / 다크 6.98:1(다크는 strong=현 warning 동일값). 둘 다 AA(4.5) 통과.

### 🚨 카디르 QA 요청 (셀프스탬프 상쇄)
이 PR은 저자=디자인 가디언이 겹쳐 design 게이트가 셀프스탬프가 되는 지점이다. 이를 상쇄하기 위해 QA에 **「hover 포함 «층×상태» AA 대비 실측」**을 요청한다 — 특히 `doc-url-chip`의 **rest + hover 두 상태 × 라이트/다크 두 테마** 4점의 실 픽셀 대비를 독립 재도출해, hover가 rest 이상(≥strong)임을 확인 바란다.
