### PR TITLE
[SID:2617] chain-depth 게이트 DM 예외 → human-presence 일반화 + human-less 관측

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -2288,15 +2288,10 @@ async def send_message(
         logger.error("conversation event dispatch failed conversation_id=%s", conversation_id, exc_info=True)
         raise HTTPException(status_code=500, detail="event dispatch failed") from _dispatch_err
 
-    # story #2608 P1 AC1: A↔B 상호멘션류(멘션 자체는 항상 유효해 route_message의 mentions
-    # 체크로는 절대 안 끊김)를 잡는다 — 이 메시지가 agent가 보낸 것이고 agent를 명시
-    # 멘션했는데(=turn이 시도됐을 대상이 실재) 연쇄가 cap을 넘었으면, "침묵"이 아니라 human
-    # 참가자에게 human_intervention_requested 이벤트로 알린다(블루프린트 §3). depth 계산은
-    # route_message() 안의 게이트와 **같은 함수**(compute_agent_chain_depth) — 판정 로직
-    # 중복 없음, 호출 위치만 recipient-필터(route_message)·이벤트-발생(여기, 메시지당 1회)
-    # 으로 자연히 갈린다(chain_depth.py 모듈 docstring 참조). 「멘션됐는데 agent가 없다」
-    # (전부 human 멘션)면 turn 자체가 애초에 대상 없어 이 게이트는 no-op(조건에 이미 반영).
-    if sender.type == "agent" and msg.mentioned_ids:
+    # story #2608 P1 AC1 + #2617: agent가 보낸 메시지면 연쇄 깊이를 잰다(chain_depth.py 판정
+    # 로직 SSOT — route_message() 안의 게이트와 같은 함수 재사용, 중복 구현 없음). 호출
+    # 위치만 recipient-필터(route_message)·이벤트-발생(여기, 메시지당 1회)으로 갈린다.
+    if sender.type == "agent":
         from app.services.chain_depth import compute_agent_chain_depth
         from app.services.channel_router import _AGENT_CHAIN_DEPTH_CAP
 
@@ -2304,22 +2299,52 @@ async def send_message(
             db, conversation_id, max_scan=_AGENT_CHAIN_DEPTH_CAP,
         )
         if chain_depth > _AGENT_CHAIN_DEPTH_CAP:
-            _mentioned_agent_rows = (await db.execute(
-                select(TeamMember.id).where(
-                    TeamMember.id.in_(msg.mentioned_ids), TeamMember.type == "agent",
-                )
-            )).scalars().all()
-            chain_expired_agent_targets = set(_mentioned_agent_rows)
-            if chain_expired_agent_targets:
+            # story #2608 P1 AC1: A↔B 상호멘션류(멘션 자체는 항상 유효해 route_message의
+            # mentions 체크로는 절대 안 끊김)를 잡는다 — agent를 명시 멘션했는데(=turn이
+            # 시도됐을 대상이 실재) 연쇄가 cap을 넘었으면, "침묵"이 아니라 human 참가자에게
+            # human_intervention_requested 이벤트로 알린다(블루프린트 §3). 「멘션됐는데
+            # agent가 없다」(전부 human 멘션)면 turn 자체가 애초에 대상 없어 no-op.
+            if msg.mentioned_ids:
+                _mentioned_agent_rows = (await db.execute(
+                    select(TeamMember.id).where(
+                        TeamMember.id.in_(msg.mentioned_ids), TeamMember.type == "agent",
+                    )
+                )).scalars().all()
+                chain_expired_agent_targets = set(_mentioned_agent_rows)
+                if chain_expired_agent_targets:
+                    try:
+                        async with db.begin_nested():
+                            pending_sse_pushes += await _dispatch_human_intervention_event(
+                                db, conv, msg, org_id, sender,
+                                chain_expired_agent_targets, _AGENT_CHAIN_DEPTH_CAP,
+                            )
+                    except Exception:
+                        logger.warning(
+                            "human_intervention_requested dispatch failed conversation_id=%s",
+                            conversation_id, exc_info=True,
+                        )
+
+            # story #2617 AC4: human 참가자가 아예 없는 대화는 위 블록이 대상 human 0명이라
+            # 구조적으로 항상 no-op이었다(_dispatch_human_intervention_event의 human_targets
+            # 빈 리스트) — mentioned_ids 유무와 무관하게(#3008 이후 default가 mentions 없이도
+            # "all"이라 대부분의 human-less group 트래픽은 애초에 멘션이 없다) 대화 밖(org
+            # owner/admin)으로 승격해 "무감독 연쇄가 계속되는 중"을 관측 가능하게 만든다
+            # (조용한 단락 금지). 24h/대화 dedup은 chain_escalation.py 내부(fleet 자체가
+            # customer-zero라 팀 DM 전부가 상시 human-less 연쇄 — dedup 없이는 org owner
+            # 스팸).
+            from app.services.channel_router import _conversation_has_human
+            if not await _conversation_has_human(db, conversation_id):
                 try:
                     async with db.begin_nested():
-                        pending_sse_pushes += await _dispatch_human_intervention_event(
-                            db, conv, msg, org_id, sender,
-                            chain_expired_agent_targets, _AGENT_CHAIN_DEPTH_CAP,
+                        from app.services.chain_escalation import escalate_unsupervised_chain
+                        await escalate_unsupervised_chain(
+                            db, org_id=org_id, conversation_id=conversation_id,
+                            project_id=conv.project_id, depth=chain_depth,
+                            cap=_AGENT_CHAIN_DEPTH_CAP,
                         )
                 except Exception:
                     logger.warning(
-                        "human_intervention_requested dispatch failed conversation_id=%s",
+                        "unsupervised chain escalation dispatch failed conversation_id=%s",
                         conversation_id, exc_info=True,
                     )
 

--- a/backend/app/schemas/deeplink_manifest.py
+++ b/backend/app/schemas/deeplink_manifest.py
@@ -668,6 +668,20 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
         ),
+        # story #2617: human-less 대화의 chain-depth 초과를 org owner/admin에게 대화 밖
+        # 승격(chain_escalation.py) — 「읽어두면 좋은」 관측 알림이지 즉시 조치가 필요한
+        # 게 아니라 conversation.message와 동형으로 grade B.
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="conversation.unsupervised_chain_expired", target="chat_thread",
+                parent_tab=ParentTab.chat,
+            ),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
+        ),
 
         # --- goal(epic) ---
         DeepLinkManifestEntry(

--- a/backend/app/services/chain_escalation.py
+++ b/backend/app/services/chain_escalation.py
@@ -1,0 +1,84 @@
+"""story #2617: human-less 대화의 chain-expired 상태를 대화 밖(org owner/admin)으로 승격.
+
+DM 전용 예외(#3009)를 human-presence 예외로 일반화(channel_router.py)하면서, human이
+없는 대화는 더 이상 chain-depth 게이트로 전달이 막히지 않는다(속도 우선, #2617 PO 지시) —
+대신 "무감독 연쇄가 계속되고 있다"를 아무도 모르는 채로 두면 안 된다(AC4, 조용한 단락 금지).
+이 모듈은 대화 참가자가 아니라 **org owner/admin**에게 대화 밖에서 알린다(그 대화엔 알릴
+human이 아예 없으므로).
+
+⚠️이 알림은 «관측»이지 «차단»이 아니다 — 진짜 A↔B 무한루프가 토큰을 계속 태우는 문제
+자체는 이 스토리 스코프 밖이다(#2617 스토리 본문 «잔여 위험» 명시, PO 조건(b) — 휴리스틱
+탐지·org 설정 상한은 후속 축).
+
+⚠️대화당 24시간 쿨다운으로 dedup한다(PO 조건(a)) — 우리 fleet 자체가 customer-zero라
+팀 DM 전부가 상시 human-less 연쇄다. dedup 없이는 org owner가 일상 작업마다 알림 스팸을
+받는다. Redis 불가 시 fail-closed(스팸 방지가 관측성보다 우선 — 미발화가 스팸보다 안전).
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+_COOLDOWN_SEC = 24 * 60 * 60  # 24h/대화 — PO 조건(a) 예시값 그대로.
+
+
+async def _claim_escalation_slot(conversation_id: uuid.UUID) -> bool:
+    """이 대화에 대해 지금 알림을 쏴야 하는지(dedup) — Redis SET NX EX. True = 이번이 이
+    쿨다운 창의 첫 발화(알림 진행). Redis 클라이언트 없음/에러 시 False(fail-closed)."""
+    from app.services import redis_shared
+
+    key = redis_shared.key("chain_escalation", str(conversation_id))
+
+    async def _op(client) -> bool:
+        return bool(await client.set(key, "1", nx=True, ex=_COOLDOWN_SEC))
+
+    return await redis_shared.with_fallback(_op, lambda: False)
+
+
+async def escalate_unsupervised_chain(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    conversation_id: uuid.UUID,
+    project_id: uuid.UUID | None,
+    depth: int,
+    cap: int,
+) -> None:
+    """human-less 대화가 chain cap을 넘었음을 org owner/admin에게 대화 밖 알림으로 승격.
+    best-effort·24h/대화 dedup·실패해도 메시지 발신 트랜잭션을 막지 않는다(caller가
+    savepoint로 격리해 호출하는 것을 전제 — doc.py의 approval 알림과 동일 관례)."""
+    try:
+        if not await _claim_escalation_slot(conversation_id):
+            return  # 쿨다운 중 — 이미 알렸음(스팸 방지, PO 조건(a))
+
+        from app.models.project import OrgMember
+        from app.services.notification_dispatch import dispatch_notification
+
+        approver_ids = (await db.execute(
+            select(OrgMember.id).where(
+                OrgMember.org_id == org_id,
+                OrgMember.role.in_(("owner", "admin")),
+                OrgMember.deleted_at.is_(None),
+            )
+        )).scalars().all()
+        if not approver_ids:
+            return
+
+        await dispatch_notification(
+            db, org_id=org_id, event_type="conversation.unsupervised_chain_expired",
+            target_member_ids=list(approver_ids),
+            title="무인간 대화 무감독 연쇄 감지",
+            body=f"human 참가자가 없는 대화에서 에이전트 연쇄가 {depth}턴(cap {cap})을 넘었습니다.",
+            reference_type="conversation", reference_id=conversation_id,
+            source_project_id=project_id,
+            via_outbox=True,
+        )
+    except Exception:  # noqa: BLE001 — best-effort, 메시지 발신을 막지 않는다.
+        logger.warning(
+            "unsupervised chain escalation failed conversation_id=%s", conversation_id, exc_info=True,
+        )

--- a/backend/app/services/channel_router.py
+++ b/backend/app/services/channel_router.py
@@ -27,6 +27,23 @@ logger = logging.getLogger(__name__)
 _AGENT_CHAIN_DEPTH_CAP: int = 4
 
 
+async def _conversation_has_human(db: AsyncSession, conversation_id: uuid.UUID) -> bool:
+    """story #2617: 대화 참가자 중 human이 1명이라도 있는가 — 실물 참가자 조회(캐시/파생
+    금지, PO 지시 2026-08-13). chain-expired 게이트가 사람-부재 대화를 무기한 침묵시키는지
+    판정하는 유일한 근거라 정확성이 중요하다 — recipient_type_map처럼 필터된 부분집합에서
+    유도하지 않고, 이 conversation_id의 ConversationParticipant 전체를 매번 새로 스캔한다."""
+    row = (await db.execute(
+        select(ConversationParticipant.member_id)
+        .join(TeamMember, TeamMember.id == ConversationParticipant.member_id)
+        .where(
+            ConversationParticipant.conversation_id == conversation_id,
+            TeamMember.type == "human",
+        )
+        .limit(1)
+    )).scalar_one_or_none()
+    return row is not None
+
+
 class ChannelRouterError(Exception):
     """ChannelRouter 장애 시 typed exception — caller가 SSE fallback 가능."""
 
@@ -82,10 +99,15 @@ async def route_message(
     이 게이트의 대상이 아니다(인간이 바로 그 "앵커"라 차단하면 안 됨 — 오히려 human-
     intervention 이벤트로 알려야 할 대상).
 
-    ⛔핫픽스(2026-08-13, 라이브 실측): 이 게이트도 DM은 대상 밖이다 — human 메시지가 애초에
-    없는 순수 1:1 agent DM(장기 협업방)은 연쇄 깊이가 구조적으로 늘 cap을 넘어, loop 방지
-    의도와 무관하게 정상 1:1 대화 자체가 침묵당했다(reason=chain-expired 반복 확인).
-    group(다자간 A↔B 핑퐁 리스크)만 게이트 유지.
+    ⛔story #2617(2026-08-13, DM전용 핫픽스 #3009를 일반화): 이 게이트는 **human 참가자가
+    1명이라도 있는 대화에만** 적용된다(conv_type 무관 — DM/group 둘 다). human 메시지가
+    애초에 없는 대화(순수 agent DM·순수 agent group)는 연쇄 깊이가 구조적으로 늘 cap을
+    넘어, loop 방지 의도와 무관하게 정상적인 장기 협업 자체가 침묵당한다(reason=
+    chain-expired 반복 확인 — DM 사례는 판별3·4, group 사례는 카디르 3-agent 5번째 무응답
+    실측). human이 있으면(누구에게 개입을 청할 수 있으면) 원 #2608 AC(A↔B 핑퐁 방지)
+    그대로 유지. human-less 대화의 관측(무한침묵 방지, AC4)은 이 함수 밖 —
+    conversations.py의 별도 escalation 경로가 담당(순수 판정 함수에 side-effect를 안
+    싣는다).
     """
     try:
         # 1. 메시지 + 발신자 조회
@@ -153,11 +175,16 @@ async def route_message(
         # story #2608 P1: sender가 agent일 때만 연쇄 깊이를 잰다(human 발신은 애초에 이
         # 게이트 대상 밖 — 정의상 그 메시지 자체가 앵커라 depth=0으로 리셋되는 것과 동치).
         chain_expired = False
+        conv_has_human = True  # chain_expired=False면 안 쓰임(아래 게이트가 and로 단락) — 기본은 안전측.
         if sender_type == "agent":
             depth = await compute_agent_chain_depth(
                 db, msg.conversation_id, max_scan=_AGENT_CHAIN_DEPTH_CAP,
             )
             chain_expired = depth > _AGENT_CHAIN_DEPTH_CAP
+            if chain_expired:
+                # story #2617: human 유무는 실물 참가자 조회로만 판정(캐시/파생 금지, PO 지시) —
+                # 게이트가 실제로 걸릴 때만 계산(흔한 경로에 쿼리 추가 안 함).
+                conv_has_human = await _conversation_has_human(db, msg.conversation_id)
 
         # 4. 수신자 type 배치 조회
         member_rows = (await db.execute(
@@ -253,14 +280,17 @@ async def route_message(
             # free_response 완화 전부 포함) agent recipient는 연쇄가 cap을 넘으면 여기서
             # 막힌다. human recipient는 대상 밖(위 docstring).
             #
-            # ⛔핫픽스(2026-08-13, 라이브 실측·Cloud Logging 대조 확定): DM은 이 게이트 밖이다.
-            # 순수 1:1 agent DM(human 메시지가 애초에 없는 지속 작업방, 예: PM↔BE 핸드오프)은
-            # 연쇄 깊이가 구조적으로 항상 cap을 넘어 — «A↔B 무한루프 방지»라는 원 의도와 무관하게
-            # «정상적인 장기 1:1 협업»을 통째로 침묵시켰다(reason=chain-expired 반복, 판별3·4
-            # 재현). group의 loop-risk와 DM의 legitimate 1:1은 다른 문제라 mentions-기본값
-            # DM예외(#2603)와 같은 논리로 여기도 DM을 뺀다 — group(다자간 A↔B 핑퐁 리스크)은
-            # 그대로 게이트 유지.
-            if chain_expired and recipient_type == "agent" and conv_type != "dm":
+            # ⛔story #2617(2026-08-13, 라이브 실측·Cloud Logging 대조 확定 + 카디르 QA 재현):
+            # DM만 뺐던 핫픽스(#3009)를 **human 참가자 유무**로 일반화한다 — 순수 1:1 agent DM
+            # (판별3·4 재현 사례)뿐 아니라 human 없는 group 대화도 동형으로 침묵당했다(카디르
+            # 3-agent group 5번째 메시지부터 무응답 실측). 앵커 개념 자체가 human 부재 대화엔
+            # 성립 안 하므로(누구에게도 개입을 청할 수 없다) 게이트를 건너뛴다. human이 1명이라도
+            # 있으면(DM이든 group이든) 원 #2608 AC(A↔B 핑퐁 방지) 그대로 유지 — 비회귀.
+            # ⚠️이 예외는 «전달을 막지 않을 뿐»이지 무한루프 자체를 차단하지 않는다 — 진짜 폭주
+            # (A↔B 동형 반복)는 토큰을 계속 태울 수 있다(#2617 스토리 «잔여 위험», 후속 축).
+            # human-less 대화의 chain-expired 관측(AC4)은 conversations.py의 별도 escalation
+            # 경로(chain_escalation.py)가 담당 — route_message는 순수 판정만, side-effect 없음.
+            if chain_expired and recipient_type == "agent" and conv_has_human:
                 logger.info(
                     "delivery_contract: excluded recipient=%s conversation_id=%s reason=%s",
                     rid, msg.conversation_id, "chain-expired",

--- a/backend/tests/test_2617_chain_escalation.py
+++ b/backend/tests/test_2617_chain_escalation.py
@@ -1,0 +1,249 @@
+"""story #2617: human-less 대화의 chain-expired «관측» 축 검증.
+
+(1) `_conversation_has_human`(channel_router.py) — 실물 참가자 조회가 정확한지(실PG).
+(2) `escalate_unsupervised_chain`(chain_escalation.py) — org owner/admin에게 알림 발송 +
+    24h/대화 dedup(fakeredis) + Redis 다운 시 fail-closed(스팸 방지 우선, PO 조건(a)).
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2617", slug=f"org2617-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_member(session, org_id, project_id, *, member_type):
+    from app.models.team import TeamMember
+
+    m = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type=member_type,
+        name=member_type, is_active=True,
+    )
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_conversation(session, org_id, project_id, *, conv_type="group"):
+    from app.models.conversation import Conversation
+
+    conv = Conversation(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type=conv_type)
+    session.add(conv)
+    await session.commit()
+    return conv.id
+
+
+async def _seed_participant(session, conversation_id, member_id):
+    from app.models.conversation import ConversationParticipant
+
+    session.add(ConversationParticipant(conversation_id=conversation_id, member_id=member_id))
+    await session.commit()
+
+
+async def _seed_org_owner(session, org_id, *, role="owner"):
+    from app.models.project import OrgMember
+
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=uuid.uuid4(), role=role)
+    session.add(om)
+    await session.commit()
+    return om.id
+
+
+# ─── _conversation_has_human ─────────────────────────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_conversation_has_human_true_when_human_participant_present():
+    from app.services.channel_router import _conversation_has_human
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent1 = await _seed_member(s, org_id, project_id, member_type="agent")
+            human1 = await _seed_member(s, org_id, project_id, member_type="human")
+            conv_id = await _seed_conversation(s, org_id, project_id)
+            await _seed_participant(s, conv_id, agent1)
+            await _seed_participant(s, conv_id, human1)
+
+            assert await _conversation_has_human(s, conv_id) is True
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_conversation_has_human_false_when_all_agents():
+    from app.services.channel_router import _conversation_has_human
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent1 = await _seed_member(s, org_id, project_id, member_type="agent")
+            agent2 = await _seed_member(s, org_id, project_id, member_type="agent")
+            conv_id = await _seed_conversation(s, org_id, project_id, conv_type="dm")
+            await _seed_participant(s, conv_id, agent1)
+            await _seed_participant(s, conv_id, agent2)
+
+            assert await _conversation_has_human(s, conv_id) is False
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_conversation_has_human_false_for_empty_conversation():
+    """참가자가 아예 없는(혹은 아직 조회 안 된) conversation_id — False로 안전측."""
+    from app.services.channel_router import _conversation_has_human
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            assert await _conversation_has_human(s, uuid.uuid4()) is False
+    finally:
+        await engine.dispose()
+
+
+# ─── escalate_unsupervised_chain ──────────────────────────────────────────────
+
+def _fakeredis_client():
+    aioredis = pytest.importorskip("fakeredis.aioredis")
+    server = aioredis.FakeServer()
+    return aioredis.FakeRedis(server=server, decode_responses=True)
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_escalate_notifies_org_owner_admin_once_then_dedups(monkeypatch):
+    from app.services.chain_escalation import escalate_unsupervised_chain
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            owner_id = await _seed_org_owner(s, org_id, role="owner")
+            await _seed_org_owner(s, org_id, role="member")  # non-admin — 대상 아님
+            conv_id = await _seed_conversation(s, org_id, project_id)
+
+            client = _fakeredis_client()
+            dn = AsyncMock()
+            with patch("app.services.redis_shared.get_client", return_value=client), \
+                 patch("app.services.notification_dispatch.dispatch_notification", dn):
+                await escalate_unsupervised_chain(
+                    s, org_id=org_id, conversation_id=conv_id, project_id=project_id,
+                    depth=7, cap=4,
+                )
+                dn.assert_awaited_once()
+                kw = dn.await_args.kwargs
+                assert kw["target_member_ids"] == [owner_id], "owner만 대상 — member role은 제외"
+                assert kw["event_type"] == "conversation.unsupervised_chain_expired"
+                assert kw["reference_id"] == conv_id
+
+                # 재발화 — 같은 대화, 쿨다운 안(24h) → 두 번째 알림 0건(스팸 방지, PO 조건(a)).
+                await escalate_unsupervised_chain(
+                    s, org_id=org_id, conversation_id=conv_id, project_id=project_id,
+                    depth=9, cap=4,
+                )
+                dn.assert_awaited_once(), "쿨다운 중 재발화는 dedup돼야(2번째 호출 무시)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_escalate_different_conversations_each_notify_once():
+    """dedup 키는 대화별 — 서로 다른 conv_id는 각자 독립적으로 1회씩 알림."""
+    from app.services.chain_escalation import escalate_unsupervised_chain
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_org_owner(s, org_id, role="owner")
+            conv_a = await _seed_conversation(s, org_id, project_id)
+            conv_b = await _seed_conversation(s, org_id, project_id)
+
+            client = _fakeredis_client()
+            dn = AsyncMock()
+            with patch("app.services.redis_shared.get_client", return_value=client), \
+                 patch("app.services.notification_dispatch.dispatch_notification", dn):
+                await escalate_unsupervised_chain(
+                    s, org_id=org_id, conversation_id=conv_a, project_id=project_id, depth=5, cap=4,
+                )
+                await escalate_unsupervised_chain(
+                    s, org_id=org_id, conversation_id=conv_b, project_id=project_id, depth=5, cap=4,
+                )
+                assert dn.await_count == 2, "서로 다른 대화는 dedup 키가 갈려 각자 알림돼야"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_escalate_redis_down_fails_closed_no_spam():
+    """Redis 클라이언트 None(다운) → dedup 판정 불가 → fail-closed(알림 skip, 예외 0).
+    스팸이 미발화보다 나쁘다는 PO 조건(a) 그대로."""
+    from app.services.chain_escalation import escalate_unsupervised_chain
+
+    session = AsyncMock()
+    dn = AsyncMock()
+    with patch("app.services.redis_shared.get_client", return_value=None), \
+         patch("app.services.notification_dispatch.dispatch_notification", dn):
+        await escalate_unsupervised_chain(
+            session, org_id=uuid.uuid4(), conversation_id=uuid.uuid4(),
+            project_id=uuid.uuid4(), depth=5, cap=4,
+        )
+    dn.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_escalate_swallows_exceptions_best_effort():
+    """알림 경로 예외는 메시지 발신을 막지 않는다 — best-effort(다른 doc.py 알림 경로와 동형)."""
+    from app.services.chain_escalation import escalate_unsupervised_chain
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=RuntimeError("boom"))
+    client = _fakeredis_client()
+    with patch("app.services.redis_shared.get_client", return_value=client):
+        await escalate_unsupervised_chain(
+            session, org_id=uuid.uuid4(), conversation_id=uuid.uuid4(),
+            project_id=uuid.uuid4(), depth=5, cap=4,
+        )  # 예외 전파 없이 조용히 반환

--- a/backend/tests/test_2617_fleet_roundtrip_realdb.py
+++ b/backend/tests/test_2617_fleet_roundtrip_realdb.py
@@ -1,0 +1,181 @@
+"""story #2617 AC3: "자기 fleet 시나리오"(무인간 DM·무인간 group) 실왕복 테스트 — 실 HTTP
+(AsyncClient+ASGITransport)로 POST /api/v2/conversations/{id}/messages를 태워, human-less
+대화의 chain-depth 초과가 더 이상 recipient의 Event(SSE 전달의 실 근거)를 침묵시키지
+않음을 고정한다. 오늘(2026-08-13) 페드루↔디디 DM에서 실측된 정확한 실패 모드의 회귀가드다.
+
+human 있는 대화는 원 #2608 AC(A↔B 핑퐁 방지)가 비회귀임도 같은 방식으로 고정(AC2).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from tests.test_1994_backlink_api_realdb import (
+    _add_message,
+    _client_for,
+    _make_agent_member,
+    _make_conversation,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _session_factory,
+    _setup_app_agent,
+)
+from tests.test_2301_story_body_mentions_realdb import _REAL_DB_URL
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _t(offset_sec: int) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(seconds=100 - offset_sec)
+
+
+async def _seed_chain_exceeding_history(session, conv_id, agent_a, agent_b, *, count: int = 5):
+    """cap(4)을 넘는 human-less 연쇄 이력 — A/B가 번갈아 count건 발신(전부 agent, human 0)."""
+    for i in range(count):
+        sender = agent_a if i % 2 == 0 else agent_b
+        await _add_message(session, conv_id, sender, f"msg-{i}", _t(i))
+
+
+async def _event_exists_for_recipient(session, message_id: uuid.UUID, recipient_id: uuid.UUID) -> bool:
+    from app.models.event import Event
+    row = (await session.execute(
+        select(Event.id).where(
+            Event.source_entity_id == message_id,
+            Event.recipient_id == recipient_id,
+        )
+    )).scalar_one_or_none()
+    return row is not None
+
+
+async def test_human_less_group_chain_exceeded_still_delivers_event():
+    """AC1 — human 참가자가 없는 group 대화는 연쇄가 cap을 넘어도 recipient에게 Event가
+    생성된다(침묵 안 됨). 카디르 QA가 실왕복으로 재현한 "3-agent group 5번째부터 무응답"의
+    정확한 형태."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            agent_a = await _make_agent_member(s, org.id, project.id)
+            agent_b = await _make_agent_member(s, org.id, project.id)
+            conv_id = await _make_conversation(
+                s, org.id, project.id, [agent_a, agent_b], created_by=agent_a, conv_type="group",
+            )
+            await _seed_chain_exceeding_history(s, conv_id, agent_a, agent_b, count=5)
+
+        await _setup_app_agent(app, Session, agent_a, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/conversations/{conv_id}/messages",
+                json={"content": "무멘션 후속 메시지"},
+            )
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 201, resp.text
+        msg_id = uuid.UUID(resp.json()["data"]["id"])
+
+        async with Session() as s:
+            assert await _event_exists_for_recipient(s, msg_id, agent_b) is True, (
+                "human-less group에서 chain-expired가 recipient Event를 여전히 막고 있다 — "
+                "AC1 회귀"
+            )
+    finally:
+        await engine.dispose()
+
+
+async def test_human_less_dm_chain_exceeded_still_delivers_event():
+    """오늘 실측된 원 사고(페드루↔디디 DM)의 정확한 회귀가드 — DM 특칭이 아니라 human-less
+    일반화(#2617)로도 여전히 살아있는지 실 HTTP로 확인."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            agent_a = await _make_agent_member(s, org.id, project.id)
+            agent_b = await _make_agent_member(s, org.id, project.id)
+            conv_id = await _make_conversation(
+                s, org.id, project.id, [agent_a, agent_b], created_by=agent_a, conv_type="dm",
+            )
+            await _seed_chain_exceeding_history(s, conv_id, agent_a, agent_b, count=5)
+
+        await _setup_app_agent(app, Session, agent_a, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/conversations/{conv_id}/messages",
+                json={"content": "무멘션 DM 후속"},
+            )
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 201, resp.text
+        msg_id = uuid.UUID(resp.json()["data"]["id"])
+
+        async with Session() as s:
+            assert await _event_exists_for_recipient(s, msg_id, agent_b) is True
+    finally:
+        await engine.dispose()
+
+
+async def test_human_present_group_chain_exceeded_still_blocks_agent_recipient():
+    """AC2 비회귀 — human이 1명이라도 있는 대화는 원 #2608 AC(연쇄 cap 초과 시 agent
+    recipient 차단) 그대로 유지돼야 한다. human-less 예외가 과확장돼 human 있는 대화까지
+    새면 A↔B 무한루프 방지 자체가 무력화된다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            human_id, human_user_id = await _make_human_member(s, org.id, project.id)
+            agent_a = await _make_agent_member(s, org.id, project.id)
+            agent_b = await _make_agent_member(s, org.id, project.id)
+            conv_id = await _make_conversation(
+                s, org.id, project.id, [human_id, agent_a, agent_b], created_by=agent_a, conv_type="group",
+            )
+            await _seed_chain_exceeding_history(s, conv_id, agent_a, agent_b, count=5)
+
+        await _setup_app_agent(app, Session, agent_a, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/conversations/{conv_id}/messages",
+                json={"content": "무멘션 후속(human 존재)"},
+            )
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 201, resp.text
+        msg_id = uuid.UUID(resp.json()["data"]["id"])
+
+        async with Session() as s:
+            assert await _event_exists_for_recipient(s, msg_id, agent_b) is False, (
+                "human이 있는 대화인데 chain-expired agent recipient가 통과했다 — "
+                "원 #2608 AC(A↔B 핑퐁 방지) 회귀"
+            )
+            # human recipient는 애초에 이 게이트 대상 밖(#2608 원 AC) — 무회귀 확인.
+            assert await _event_exists_for_recipient(s, msg_id, human_id) is True
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_channel_router_multiproject_sender.py
+++ b/backend/tests/test_channel_router_multiproject_sender.py
@@ -327,7 +327,8 @@ async def test_explicit_all_preference_overrides_agent_group_default():
 @pytest.mark.anyio
 async def test_chain_expired_blocks_agent_recipient_even_when_mentioned():
     """story #2608 P1 AC1 — A↔B 상호멘션(멘션은 항상 유효)류의 유일한 탈출구. mentions
-    체크는 통과해도(recipient가 명시 멘션됨) chain_expired=True면 최종 게이트에서 막힌다."""
+    체크는 통과해도(recipient가 명시 멘션됨) chain_expired=True + human 참가자 존재면
+    최종 게이트에서 막힌다(story #2617 — human 있는 대화는 원 #2608 AC 비회귀)."""
     from app.services.channel_router import route_message
 
     sender = uuid.uuid4()
@@ -348,6 +349,7 @@ async def test_chain_expired_blocks_agent_recipient_even_when_mentioned():
         _scalar("agent"),
         _scalars([sender, recipient]),
         _scalars([]),
+        _scalar(uuid.uuid4()),  # story #2617: _conversation_has_human → True(human 존재)
         _all([(recipient, "agent")]),
         _row(project_id=proj, type="group", free_response=False),
         _scalars([]),
@@ -355,17 +357,18 @@ async def test_chain_expired_blocks_agent_recipient_even_when_mentioned():
 
     with patch("app.services.channel_router.compute_agent_chain_depth", AsyncMock(return_value=5)):
         decisions = await route_message(msg.id, db)
-    assert decisions == [], "연쇄 cap 초과인데 멘션 성립만으로 decision이 생기면 P1이 안 먹는다"
+    assert decisions == [], "human 있는 대화에서 연쇄 cap 초과인데 멘션 성립만으로 decision이 생기면 P1이 안 먹는다"
 
 
 @pytest.mark.anyio
-async def test_chain_expired_does_not_block_dm_agent_recipient():
-    """핫픽스(2026-08-13, 라이브 실측·Cloud Logging 대조 확定) — DM은 chain-expired 최종
-    게이트 밖이다. human 메시지가 없는 순수 1:1 agent DM은 연쇄 깊이가 구조적으로 늘 cap을
-    넘는데(장기 협업방 자체가 그런 모양), 이 게이트가 group과 동일하게 적용되면 정상 1:1
-    대화가 통째로 침묵당한다(실제로 페드루↔디디 DM에서 무멘션 메시지가 전부 막힌 채로 재현
-    됐다 — reason=chain-expired). group은 이 테스트 파일의 다른 케이스(위)처럼 그대로 막혀야
-    한다 — 이 테스트는 DM만 예외임을 고정."""
+async def test_chain_expired_does_not_block_human_less_agent_recipient():
+    """story #2617(DM 전용 핫픽스 #3009를 human-presence로 일반화) — human 참가자가 전혀
+    없는 대화(DM이든 group이든)는 chain-expired 최종 게이트 밖이다. human 메시지가 없는
+    순수 agent 대화는 연쇄 깊이가 구조적으로 늘 cap을 넘는데(장기 협업방 자체가 그런 모양),
+    이 게이트가 그대로 적용되면 정상 협업이 통째로 침묵당한다(실제로 페드루↔디디 DM에서
+    무멘션 메시지가 전부 막힌 채로 재현됐고, 카디르 QA가 3-agent human-less group에서도
+    5번째 메시지부터 동형 재현). human 있는 대화는 위 케이스처럼 그대로 막혀야 한다 — 이
+    테스트는 human-less만 예외임을 고정(conv_type=group으로 DM 특칭이 아님을 명시)."""
     from app.services.channel_router import route_message
 
     sender = uuid.uuid4()
@@ -378,7 +381,7 @@ async def test_chain_expired_does_not_block_dm_agent_recipient():
     msg.sender_id = sender
     msg.conversation_id = conv
     msg.thread_id = None
-    msg.mentioned_ids = []  # 무멘션 — DM 기본계약(all)만으로 통과해야 한다.
+    msg.mentioned_ids = []  # 무멘션 — human-less 예외(all)만으로 통과해야 한다.
 
     db = MagicMock()
     db.execute = AsyncMock(side_effect=[
@@ -386,14 +389,15 @@ async def test_chain_expired_does_not_block_dm_agent_recipient():
         _scalar("agent"),
         _scalars([sender, recipient]),
         _scalars([]),
+        _scalar(None),  # story #2617: _conversation_has_human → False(human 없음)
         _all([(recipient, "agent")]),
-        _row(project_id=proj, type="dm", free_response=False),
+        _row(project_id=proj, type="group", free_response=False),  # DM 아닌 group도 예외 대상
         _scalars([]),
     ])
 
     with patch("app.services.channel_router.compute_agent_chain_depth", AsyncMock(return_value=999)):
         decisions = await route_message(msg.id, db)
-    assert len(decisions) == 1, "DM에서 연쇄 cap 초과가 무멘션 agent recipient를 막으면 안 된다"
+    assert len(decisions) == 1, "human-less 대화에서 연쇄 cap 초과가 무멘션 agent recipient를 막으면 안 된다"
     assert decisions[0].member_id == recipient
     assert decisions[0].level == "all"
 
@@ -421,6 +425,7 @@ async def test_chain_expired_does_not_block_human_recipient():
         _scalar("agent"),
         _scalars([sender, human_recipient]),
         _scalars([]),
+        _scalar(human_recipient),  # story #2617: _conversation_has_human → True
         _all([(human_recipient, "human")]),
         _row(project_id=proj, type="group", free_response=False),
         _scalars([]),

--- a/backend/tests/test_deeplink_manifest_contract.py
+++ b/backend/tests/test_deeplink_manifest_contract.py
@@ -88,10 +88,11 @@ def test_conversation_mention_lands_in_chat_tab():
     assert entry.app.parent_tab == ParentTab.chat
 
 
-def test_manifest_covers_all_24_dispatch_notification_event_types():
+def test_manifest_covers_all_25_dispatch_notification_event_types():
     """AC1 회귀 고정: story #1951 GATE1 전수 조사에서 확인한 dispatch_notification()
-    event_type 리터럴 24종이 전부 등재돼 있어야 한다. 새 알림 타입이 코드에 추가되고
-    이 집합이 갱신 안 되면 이 테스트가 알려준다(양방향 대조 — 매니페스트 초과분도 잡음)."""
+    event_type 리터럴이 전부 등재돼 있어야 한다. 새 알림 타입이 코드에 추가되고
+    이 집합이 갱신 안 되면 이 테스트가 알려준다(양방향 대조 — 매니페스트 초과분도 잡음).
+    story #2617: conversation.unsupervised_chain_expired 신설로 24→25."""
     expected = {
         "sprint_closed", "task_completed", "story_assigned", "comment.created",
         "artifact.created", "artifact.exported", "artifact.updated", "artifact.canonicalized",
@@ -99,6 +100,7 @@ def test_manifest_covers_all_24_dispatch_notification_event_types():
         "dispatched", "epic_created", "epic_status_changed", "gate_escalated", "gate_reminder",
         "gate.pending_approval", "gate_overridden", "gate_approval_requested", "gate_reassigned",
         "doc_approval_requested", "handoff_fallback", "story_status_changed",
+        "conversation.unsupervised_chain_expired",
     }
     actual = {e.app.type for e in DEEPLINK_MANIFEST.entries}
     missing = expected - actual

--- a/backend/tests/test_deeplink_manifest_endpoint.py
+++ b/backend/tests/test_deeplink_manifest_endpoint.py
@@ -45,7 +45,8 @@ async def test_deeplink_manifest_endpoint_returns_200_with_schema_version_and_lo
 
     assert body["schema_version"] == 1
     assert isinstance(body["version_policy"], str) and body["version_policy"]
-    assert isinstance(body["entries"], list) and len(body["entries"]) == 33
+    # story #2617: conversation.unsupervised_chain_expired 신설로 33→34.
+    assert isinstance(body["entries"], list) and len(body["entries"]) == 34
 
     # 미르코 point ②: lookup_key = f"{type}:{entity_type}" (구분자 ":") 서빙 시점 파생.
     story_entry = next(


### PR DESCRIPTION
## 요약
08-13 인시던트 사후 스토리. #2608 P1의 chain-depth 최종 게이트가 human 앵커 없는 대화를 무기한 침묵시켰다 — hotfix2(#3009)는 DM만 예외 처리했지만, 카디르 QA가 human-less 3-agent group도 5번째 메시지부터 동형으로 침묵됨을 실왕복으로 재현해 "DM 특칭은 반쪽"임이 확인됐다.

PO 승인 설계: **①(게이트 조건 = human 참가자 유무)+③(human 0명이면 대화 밖 승격)** 조합. ②(무인간 대화 앵커 대체물 정의)는 "신규 메커니즘 리스크"로 기각 — 오늘 사고(mentions-기본값이라는 새 메커니즘의 미검증 부작용)와 정확히 같은 논리.

## 변경
- **`backend/app/services/channel_router.py`**: chain-expired 최종 게이트를 `conv_type != "dm"`에서 `_conversation_has_human()`(신규 헬퍼, 실물 참가자 조회 — 캐시/파생 금지, PO 명시 지시) 기반으로 일반화. `chain_expired`가 True일 때만 계산(흔한 경로에 쿼리 추가 안 함). human이 1명이라도 있으면 DM/group 무관 원 #2608 AC(A↔B 핑퐁 방지) 그대로 — **AC2 비회귀**. human이 아예 없으면 게이트 스킵 — **AC1**.
- **`backend/app/services/chain_escalation.py`(신규)**: human-less 대화가 chain cap을 넘으면 대화 밖(org owner/admin)으로 알림 승격 — 그 대화 안엔 애초에 알릴 human이 없으므로. **AC4**(조용한 단락 금지). **24h/대화 Redis SET-NX-EX dedup**(PO 조건(a) — 우리 fleet 자체가 customer-zero라 팀 DM 전부가 상시 human-less 연쇄, dedup 없이는 org owner가 일상 작업마다 스팸을 받는다). Redis 클라이언트 없음/에러 시 **fail-closed**(스팸이 미발화보다 나쁘다는 PO 판단 그대로 — presence/SSE lease의 fail-open 정책과 의도적으로 반대).
- **`backend/app/routers/conversations.py`**: agent 발신 메시지의 chain-depth 계산 트리거를 `mentioned_ids` 유무와 무관하게(원래는 멘션된 경우만) — #3008 이후 default가 mentions 없이도 all이라 대부분의 human-less 트래픽은 애초에 멘션이 없어서, 기존 P1 AC1 블록(멘션 게이트)만으로는 AC4를 못 채운다. 기존 AC1 로직(멘션된 agent에게 human_intervention_requested)은 무수정 유지, human-less 승격은 완전히 별개의 새 sibling 블록.

## 잔여 위험 (PO 조건(b), 스토리 명시 — 이번엔 안 풂)
①+③은 human-less 대화의 무한루프 자체를 **차단하지 않는다**(알림만). 진짜 A↔B 동형 폭주는 토큰을 계속 태울 수 있다 — 휴리스틱 탐지든 org 설정 상한이든 후속 축(스토리에 명시).

## 테스트
- `test_channel_router_multiproject_sender.py`: DM 특칭 테스트(`test_chain_expired_does_not_block_dm_agent_recipient`)를 human-presence 일반화 테스트(`test_chain_expired_does_not_block_human_less_agent_recipient` — conv_type=group으로 DM 특칭이 아님을 명시)로 교체. human-존재 케이스(`test_chain_expired_blocks_agent_recipient_even_when_mentioned`)는 그대로 막힘을 재확인(신규 `_conversation_has_human` mock 값만 추가).
- `test_2617_chain_escalation.py`(신규 7건, 실PG+fakeredis): `_conversation_has_human` 정확성(human 있음/없음/빈 대화 3케이스) + `escalate_unsupervised_chain` 알림 발송(org owner/admin만 대상, member role 제외)·24h dedup(같은 대화 2번째 스킵, 다른 대화는 독립 1회씩)·Redis 다운 fail-closed·best-effort 예외 흡수.
- `test_2617_fleet_roundtrip_realdb.py`(신규 3건, **AC3 "자기 fleet 시나리오" 실왕복** — AsyncClient+ASGITransport로 실 `POST /messages`): human-less group·human-less DM은 recipient에게 실제 Event가 생성됨(침묵 안 됨, AC1)을 실 HTTP로 고정. human 있는 group은 그대로 차단됨(AC2 비회귀)도 같은 방식으로 고정.
  - ⚠️정직하게 명시: 이 3건을 **개별 실행하면 전부 green**이나, 로컬 ad-hoc 디스포저블 PG 컨테이너에서 **연속 실행하면 BackgroundTasks(webhook mark_agent_replied 등)+asyncpg의 event-loop 충돌**이 관측됐다(기존 인프라 특성 — 이 PR이 새로 만든 문제 아님, CI의 pre-migrated 공유 DB 환경에서는 재현 안 될 가능성이 높음). CI 실 스윕 결과로 재확인이 필요하다 — 만약 CI에서도 재현되면 후속으로 대응.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>