### PR TITLE
[SID:2625] 챗 내 완결 결재 — 고위험도 서명까지 챗 안에서

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3172,8 +3172,6 @@
     "approvalRequestNotFound": "The approval gate could not be found.",
     "approvalRequestLoadError": "Failed to load approval details.",
     "approvalRequestResolvedStatus": "Resolved — status: {status}",
-    "approvalRequestOpenForFullReview": "This approval needs a full review.",
-    "approvalRequestOpenInGates": "Open in gates",
     "sendFailed": "Failed to send message. Please try again.",
     "deleteMessageErrorTitle": "Delete failed",
     "deleteMessageErrorBody": "Couldn't delete the message. Please try again.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3172,8 +3172,6 @@
     "approvalRequestNotFound": "결재 게이트를 찾을 수 없습니다.",
     "approvalRequestLoadError": "결재 정보를 불러오지 못했습니다.",
     "approvalRequestResolvedStatus": "처리됨 — 상태: {status}",
-    "approvalRequestOpenForFullReview": "정밀 검토가 필요한 결재입니다.",
-    "approvalRequestOpenInGates": "결재함에서 열기",
     "sendFailed": "메시지 전송에 실패했습니다. 다시 시도해 주세요.",
     "deleteMessageErrorTitle": "삭제 실패",
     "deleteMessageErrorBody": "메시지를 삭제하지 못했습니다. 다시 시도해 주세요.",

--- a/apps/web/src/components/cage/gate-signature-approval.tsx
+++ b/apps/web/src/components/cage/gate-signature-approval.tsx
@@ -18,6 +18,7 @@ export function GateSignatureApproval({
   error,
   onApprove,
   onReject,
+  compact = false,
 }: {
   gate: GateItem;
   resolving: boolean;
@@ -28,6 +29,12 @@ export function GateSignatureApproval({
   error?: string | null;
   onApprove: (reason: string) => void;
   onReject: (reason: string) => void;
+  /** story #2625(유나 design 확定, 카디르 QA 320px 실측 대응) — 챗 카드 좁은 폭(실효 ~166px)
+   * 컨텍스트. 원 컨텍스트(gates 페이지 672px)는 가로 2버튼이 여유롭지만, 좁은 폭에서
+   * whitespace-nowrap+shrink-0(button.tsx 기본) 그대로면 라벨이 잘린다. truncate나
+   * 아이콘-only는 금지(중대 액션 라벨 온전 필수, PO 확定) — 대신 세로 스택으로 각 버튼이
+   * full-width를 갖게 한다. 컴포넌트를 포크하지 않고 이 prop 하나로 컨텍스트만 분기한다. */
+  compact?: boolean;
 }) {
   const t = useTranslations('cage');
   const [evidenceViewed, setEvidenceViewed] = useState(false);
@@ -77,10 +84,10 @@ export function GateSignatureApproval({
 
       <div className="flex flex-col gap-2">
         <p className="text-center text-[11px] text-muted-foreground">{t('sigConsequenceNote')}</p>
-        <div className="flex gap-2">
+        <div className={compact ? 'flex flex-col gap-2' : 'flex gap-2'}>
           <Button
             variant="outline"
-            className="min-h-12 flex-1 gap-1.5"
+            className={compact ? 'min-h-12 w-full gap-1.5' : 'min-h-12 flex-1 gap-1.5'}
             disabled={resolving}
             onClick={() => onReject(reason)}
           >
@@ -88,7 +95,7 @@ export function GateSignatureApproval({
             {t('sigRequestChanges')}
           </Button>
           <Button
-            className="min-h-12 flex-[1.4] gap-1.5"
+            className={compact ? 'min-h-12 w-full gap-1.5' : 'min-h-12 flex-[1.4] gap-1.5'}
             disabled={!canSign}
             onClick={() => onApprove(reason)}
           >

--- a/apps/web/src/components/chat/approval-request-card.tsx
+++ b/apps/web/src/components/chat/approval-request-card.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Check, ExternalLink, FileText, X } from 'lucide-react';
+import { Check, FileText, X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { GateSignatureApproval } from '@/components/cage/gate-signature-approval';
 import { deriveRiskLevel, usesSignatureFlow } from '@/components/cage/gate-risk';
 import type { GateItem } from '@/components/kanban/types';
 
@@ -29,15 +30,17 @@ type CardState =
 const WORK_ITEM_ICON: Record<string, typeof FileText> = { doc: FileText };
 
 /**
- * story #2604 P2 — chat approval-request 카드. BE(#3007)가 payload에 실은 `approval_target`
- * (work_item_type/work_item_id/gate_id/actions)을 렌더한다. 새 API는 만들지 않는다(AC③) —
- * 상태 조회는 기존 `GET /api/gates/{id}`, 액션은 기존 `POST /api/gates/{id}/transition`
- * 그대로(gates/[id]/page.tsx와 동일 계약·동일 envelope 언랩) — human-only SoD 인가는 그
- * 엔드포인트가 이미 지킨다(신규 인가 없음).
+ * story #2604 P2 → #2625(선생님 실사용 판정으로 확장) — chat approval-request 카드. BE(#3007)가
+ * payload에 실은 `approval_target`(work_item_type/work_item_id/gate_id/actions)을 렌더한다.
+ * 새 API는 만들지 않는다(AC③) — 상태 조회는 기존 `GET /api/gates/{id}`, 액션은 기존
+ * `POST /api/gates/{id}/transition` 그대로(gates/[id]/page.tsx와 동일 계약·동일 envelope
+ * 언랩) — human-only SoD 인가는 그 엔드포인트가 이미 지킨다(신규 인가 없음).
  *
- * 고위험(usesSignatureFlow)·무권한(can_approve=false)은 이 컴팩트 카드 안에서 서명플로우를
- * 재구현하지 않는다 — 결재함 상세(`/gates/{id}`)로 열기 링크만 준다(no-fiction: 챗 카드
- * 폭에 서명 플로우를 욱여넣는 대신 정직하게 위임).
+ * story #2625 — 고위험(usesSignatureFlow)도 이제 챗을 벗어나지 않고 완결된다. 원래는
+ * "결재함에서 열기" 링크로 위임했으나(#3011, no-fiction 원칙 하 재구현 회피), 선생님이
+ * 직접 실사용 중 그 네비게이션 자체를 UX 결함으로 판정(gate 34af76dc 반려 사유) — 서명
+ * 플로우(`GateSignatureApproval`)를 gates/[id]/page.tsx와 **그대로 공유 재사용**해 챗
+ * 카드 안에 얹는다(사본 분화 금지, AC③).
  */
 export function ApprovalRequestCard({ target }: ApprovalRequestCardProps) {
   const t = useTranslations('chats');
@@ -61,14 +64,14 @@ export function ApprovalRequestCard({ target }: ApprovalRequestCardProps) {
 
   useEffect(() => { void fetchGate(); }, [fetchGate]);
 
-  const transition = async (status: 'approved' | 'rejected') => {
+  const transition = async (status: 'approved' | 'rejected', note?: string) => {
     setResolving(true);
     setTransitionError(null);
     try {
       const res = await fetch(`/api/gates/${target.gate_id}/transition`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status, note: null }),
+        body: JSON.stringify({ status, note: note?.trim() || null }),
       });
       if (res.ok) { await fetchGate(); return; }
       const body = await res.json().catch(() => null) as { error?: { message?: string } } | null;
@@ -98,11 +101,10 @@ export function ApprovalRequestCard({ target }: ApprovalRequestCardProps) {
       ) : (
         <ApprovalRequestBody
           gate={state.gate}
-          gateId={target.gate_id}
           resolving={resolving}
           transitionError={transitionError}
-          onApprove={() => void transition('approved')}
-          onReject={() => void transition('rejected')}
+          onApprove={(reason) => void transition('approved', reason)}
+          onReject={(reason) => void transition('rejected', reason)}
         />
       )}
     </div>
@@ -110,14 +112,13 @@ export function ApprovalRequestCard({ target }: ApprovalRequestCardProps) {
 }
 
 function ApprovalRequestBody({
-  gate, gateId, resolving, transitionError, onApprove, onReject,
+  gate, resolving, transitionError, onApprove, onReject,
 }: {
   gate: GateItem;
-  gateId: string;
   resolving: boolean;
   transitionError: string | null;
-  onApprove: () => void;
-  onReject: () => void;
+  onApprove: (reason?: string) => void;
+  onReject: (reason?: string) => void;
 }) {
   const t = useTranslations('chats');
   // gates/[id]/page.tsx와 같은 문구를 쓴다(동일 개념=동일 어휘, DS 원칙) — 그 키들은 'cage'
@@ -126,18 +127,37 @@ function ApprovalRequestBody({
   const title = gate.work_item_summary?.title ?? `#${gate.work_item_id.slice(0, 8)}`;
   const riskLevel = deriveRiskLevel(gate);
   const needsFullFlow = usesSignatureFlow(riskLevel);
-  const canActInline = gate.status === 'pending' && gate.can_approve === true && !needsFullFlow;
+  const canAct = gate.status === 'pending' && gate.can_approve === true;
 
   return (
     <div className="space-y-2">
       <p className="truncate text-sm font-medium text-foreground">{title}</p>
+
+      {gate.status === 'pending' && (riskLevel === 'high' || riskLevel === 'unknown') ? (
+        <Badge variant={riskLevel === 'high' ? 'warning' : 'outline'} className={riskLevel === 'unknown' ? 'text-muted-foreground' : undefined}>
+          {riskLevel === 'high' ? tCage('riskHigh') : tCage('riskUnknown')}
+        </Badge>
+      ) : null}
 
       {gate.status !== 'pending' ? (
         <div className="flex items-center gap-1.5 text-xs font-medium text-foreground">
           {gate.status === 'approved' ? <Check className="h-3.5 w-3.5 text-primary" /> : <X className="h-3.5 w-3.5 text-destructive" />}
           {t('approvalRequestResolvedStatus', { status: gate.status })}
         </div>
-      ) : canActInline ? (
+      ) : !canAct ? (
+        // story #2091(P0)과 동일 fail-closed 규율 — can_approve=false(무권한 뷰어)는 액션을
+        // 렌더하지 않는다. 고위험도 이제 챗 안에서 완결되므로(#2625) 여기 남는 유일한
+        // "액션 불가" 사유는 무권한뿐이다.
+        <p className="text-[11px] text-muted-foreground">{tCage('gateReadonlyNotAuthorized')}</p>
+      ) : needsFullFlow ? (
+        <GateSignatureApproval
+          gate={gate}
+          resolving={resolving}
+          error={transitionError}
+          onApprove={onApprove}
+          onReject={onReject}
+        />
+      ) : (
         <>
           {transitionError ? (
             <p role="alert" aria-live="assertive" className="text-[11px] text-foreground">
@@ -145,38 +165,17 @@ function ApprovalRequestBody({
             </p>
           ) : null}
           <div className="flex gap-1.5">
-            <Button type="button" size="sm" onClick={onApprove} disabled={resolving} className="flex-1">
+            <Button type="button" size="sm" onClick={() => onApprove()} disabled={resolving} className="flex-1">
               <Check className="h-3.5 w-3.5" aria-hidden />
               {tCage('gateApprove')}
             </Button>
-            <Button type="button" size="sm" variant="destructive" onClick={onReject} disabled={resolving} className="flex-1">
+            <Button type="button" size="sm" variant="destructive" onClick={() => onReject()} disabled={resolving} className="flex-1">
               <X className="h-3.5 w-3.5" aria-hidden />
               {tCage('gateReject')}
             </Button>
           </div>
         </>
-      ) : (
-        <div className="flex items-center justify-between gap-2">
-          <p className="text-[11px] text-muted-foreground">
-            {gate.can_approve === false ? tCage('gateReadonlyNotAuthorized') : t('approvalRequestOpenForFullReview')}
-          </p>
-          {gate.can_approve !== false ? (
-            <a
-              href={`/gates/${gateId}`}
-              className="flex shrink-0 items-center gap-1 text-xs font-medium text-primary hover:underline"
-            >
-              {t('approvalRequestOpenInGates')}
-              <ExternalLink className="h-3 w-3" aria-hidden />
-            </a>
-          ) : null}
-        </div>
       )}
-
-      {gate.status === 'pending' && (riskLevel === 'high' || riskLevel === 'unknown') ? (
-        <Badge variant={riskLevel === 'high' ? 'warning' : 'outline'} className={riskLevel === 'unknown' ? 'text-muted-foreground' : undefined}>
-          {riskLevel === 'high' ? tCage('riskHigh') : tCage('riskUnknown')}
-        </Badge>
-      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/chat/approval-request-card.tsx
+++ b/apps/web/src/components/chat/approval-request-card.tsx
@@ -156,6 +156,7 @@ function ApprovalRequestBody({
           error={transitionError}
           onApprove={onApprove}
           onReject={onReject}
+          compact
         />
       ) : (
         <>

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -695,14 +695,42 @@ describe('ChatBubble — story #2604 P2 결재 요청(approval_target) 카드', 
     expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent?.includes('승인'))).toBe(false);
   });
 
-  it('고위험(risk_grade=high) — 인라인 버튼 대신 결재함으로 열기 링크만 보인다(서명 플로우 재구현 안 함)', async () => {
+  it('story #2625 — 고위험(risk_grade=high)도 챗 안에서 서명 플로우로 완결된다(링크 위임 아님)', async () => {
     stubGate({ risk_grade: 'high' });
     await act(async () => {
       root.render(wrap(<ChatBubble message={approvalMessage} isMine={false} />));
     });
-    expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent?.includes('승인'))).toBe(false);
-    const link = container.querySelector(`a[href="/gates/${GATE_ID}"]`);
-    expect(link).not.toBeNull();
+    // 링크 위임 UX는 선생님 실사용 판정으로 폐기됐다(gate 34af76dc) — 더 이상 없어야 한다.
+    expect(container.querySelector(`a[href="/gates/${GATE_ID}"]`)).toBeNull();
+    // GateSignatureApproval이 그대로(사본 아님) 얹힌다 — 근거 확인 체크박스+사유 textarea.
+    expect(container.textContent).toContain('위 근거를 확인했습니다');
+    const signBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('승인하고 서명'))!;
+    expect(signBtn).not.toBeUndefined();
+    // AC: 근거 확인+사유 전에는 서명 비활성(gate-signature-approval.tsx의 canSign 그대로 상속).
+    expect(signBtn.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('story #2625 — 근거 확인+사유 입력 후 «승인하고 서명»이 transition POST에 사유를 note로 싣는다', async () => {
+    stubGate({ risk_grade: 'high' });
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={approvalMessage} isMine={false} />));
+    });
+    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    await act(async () => {
+      checkbox.click();
+      const nativeSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')!.set!;
+      nativeSetter.call(textarea, '근거 확인함, 승인');
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    const signBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('승인하고 서명'))!;
+    expect(signBtn.hasAttribute('disabled')).toBe(false);
+    await act(async () => { signBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => {});
+
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    const transitionCall = fetchMock.mock.calls.find((call: unknown[]) => (call[0] as string).includes('/transition'));
+    expect(JSON.parse((transitionCall![1] as { body: string }).body)).toEqual({ status: 'approved', note: '근거 확인함, 승인' });
   });
 
   it('이미 처리된 게이트(status=approved)는 버튼 없이 처리됨 상태만 보인다', async () => {

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -706,6 +706,10 @@ describe('ChatBubble — story #2604 P2 결재 요청(approval_target) 카드', 
     expect(container.textContent).toContain('위 근거를 확인했습니다');
     const signBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('승인하고 서명'))!;
     expect(signBtn).not.toBeUndefined();
+    // 카디르 QA(320/375px 실측) 재발방지 — compact=true가 실제로 전달돼 버튼이 세로 스택
+    // full-width로 렌더되는지(가로 2버튼이면 라벨이 좁은 챗 폭에서 잘린다, 재발가드).
+    expect(signBtn.className).toContain('w-full');
+    expect(signBtn.parentElement?.className).toContain('flex-col');
     // AC: 근거 확인+사유 전에는 서명 비활성(gate-signature-approval.tsx의 canSign 그대로 상속).
     expect(signBtn.hasAttribute('disabled')).toBe(true);
   });


### PR DESCRIPTION
## 요약
선생님 실사용 판정(08-13 07:22, gate 34af76dc 반려): #2604/#3011의 고위험 분기(카드→"결재함에서 열기" 링크 위임)는 네비게이션을 추가해 사용자 손을 늘리는 잘못 잡힌 UX였다. "서명 플로우 재구현 금지(no-fiction)"는 PO 승인 사항이었으나 실사용 판정으로 뒤집혔다 — 서명 플로우를 챗 **안**으로 가져온다.

## 변경
`ApprovalRequestCard`(chat/approval-request-card.tsx) — 링크 위임 분기를 제거하고 `GateSignatureApproval`(gates/[id]/page.tsx가 쓰는 그 컴포넌트, cage/gate-signature-approval.tsx)을 **그대로 import**해 챗 카드 안에 얹는다(AC③: 사본 분화 없음, 새 파일 0).
- `canAct`(pending && can_approve) 판정만으로 액션 가능 여부를 가르고, 그 아래에서 `needsFullFlow`(usesSignatureFlow)로 저위험 2버튼 vs 고위험 서명플로우를 고른다.
- `transition()`에 optional `note` 파라미터 추가 — gates/[id]/page.tsx의 `transition()`과 동일 시그니처(status, note?). 저위험은 여전히 note 없이 호출(비회귀).
- can_approve=false(무권한) fail-closed 문구는 그대로 유지 — 이제 유일한 "액션 불가" 분기.
- 죽은 코드 정리: "결재함에서 열기" 링크 · `approvalRequestOpenForFullReview`/`approvalRequestOpenInGates` i18n 키(다른 소비처 0곳 확認 후 제거) · 미사용 `ExternalLink` import.

새 API **0**(AC②) — 기존 `POST /api/gates/{id}/transition` 그대로. 결재함(`/gates`)은 유지(제거 아님, 목록·감사 표면).

## AC 대응
| AC | 상태 |
|---|---|
| 1. 고위험 결재를 챗 안에서 완결(근거·사유·서명) | 이 PR — `GateSignatureApproval` 재사용 |
| 2. 해소 결과 카드 즉시 반영 | 기존 `fetchGate()` 재조회 그대로 유지(비회귀) |
| 3. gates/[id]와 로직 사본 분화 없음 | `GateSignatureApproval`을 새 컴포넌트로 안 만들고 그대로 import |
| 4. 저위험 인라인·무권한 fail-closed·404 비회귀 | 기존 테스트 그대로 유지+통과 |

## 검증
- `pnpm vitest run` — 406 files / 3177 tests pass(고위험 "링크" 테스트를 서명플로우 완결 테스트 2건으로 교체 — 렌더 확認 + 실제 POST payload에 사유가 `note`로 실리는지).
- `tsc --noEmit` clean · `eslint` clean.
- `verify:no-new-tint-color-text` · `verify:no-i18n-phrase-collision` · `verify:no-muted-foreground-alpha` · `verify:no-alpha-focus-ring` 전부 신규 0.

## ⚠️ 정직 캐비어트
챗 폭 안에서 서명 플로우(근거+체크박스+textarea+2버튼)의 시각 위계는 유나 design 게이트가 스토리에 명시돼 있고, 로컬에서 라이브 브라우저 확認은 못 했다 — 컴포넌트 자체는 재사용(신규 스타일 0)이라 위험은 낮다고 보지만 카디르 QA에 고위험 결재 챗 내 완결 실왕복 요청.


## 🔧 fix(카디르 QA·320/375px 실측 대응)
카디르 QA가 320/375px 실렌더에서 서명 버튼 텍스트 오버플로를 잡았다(reject scrollWidth 100>clientWidth 68px·approve 102>86px @320px) — `GateSignatureApproval`의 원 컨텍스트(gates 페이지 672px)에서는 문제없던 `whitespace-nowrap`+`shrink-0`이 챗 카드 좁은 폭(실효 ~166px)에서 노출된 회귀.

**유나 design 확定(라벨 truncate/아이콘-only 금지)**: `GateSignatureApproval`에 `compact` prop 추가(기본 false, gates/[id]/page.tsx 기존 호출부 무변경) — 챗 카드에서만 `compact`를 전달해 버튼 2개가 가로 대신 **세로 스택 full-width**로 렌더된다. 컴포넌트 포크 없음(사본 분화 방지 원칙 유지).

정적 HTML+실 Playwright(chromium)로 166px 컨텍스트를 격리 재현: compact 세로 스택 시 두 버튼 다 `scrollWidth === clientWidth`(134px, overflow 없음) 확認. 카디르 320px 재실측 요청.
