### PR TITLE
[SID:2624] 결재 결과 상신자 회신 — approval_delivery.py 반대 방향

### DIFF
--- a/backend/app/schemas/deeplink_manifest.py
+++ b/backend/app/schemas/deeplink_manifest.py
@@ -433,6 +433,20 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a2),
         ),
+        DeepLinkManifestEntry(
+            # story #2624: 결재 해소 결과가 상신자에게 회신되는 벨 알림 — doc_approval_
+            # requested와 동형(gate 경유, reference_id=gate_id)이나 이미 결정이 끝난
+            # 읽기 전용 FYI라 grade B(요청 쪽은 조치 필요라 A2인 것과 대비).
+            app=DeepLinkAppFields(
+                type="doc_approval_resolved", target="gate_detail", parent_tab=ParentTab.approvals,
+                target_promotion_pending=True,
+            ),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
+        ),
 
         # --- dispatched(범용) — reference_type 5종 분기. entity_type 필수. ---
         # 정정(유나 3자 검토, 필수·조건부 GREEN의 조건): parentTab은 target의 순수 함수여야

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -135,3 +135,102 @@ async def dispatch_approval_request_cards(
                 "approval-request 카드 배달 실패 doc=%s approver=%s",
                 doc.id, approver_id, exc_info=True,
             )
+
+
+async def dispatch_approval_result_reply(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    doc: Doc,
+    gate_id: uuid.UUID,
+    requester_id: uuid.UUID,
+    resolver_id: uuid.UUID,
+    decision: str,
+    resolution_note: str | None,
+) -> None:
+    """story #2624: 게이트 해소(승인/반려) 결과를 상신자에게 회신 — dispatch_approval_
+    request_cards의 반대 방향(승인자→상신자). P2(#3007)는 상신→승인자 카드 전방 경로만
+    만들었고 해소→상신자 회신 후방 경로가 없어, 상신자가 게이트를 폴링해야만 결과를 알 수
+    있었다(선생님 직접 지적, 실사례 2026-08-13 07:20 반려·상신자 무통지).
+
+    상신자↔해소자 기존 DM(같은 dm_pair_key — get_or_create가 인자 순서 무관하게 같은 방을
+    찾는다)에 message_kind="result" 카드 게시 + 기존 _dispatch_conversation_event 재사용
+    으로 메인 dispatch — 상신자가 agent면 **이 경로로** 도달한다(오늘 PO가 못 받았던 그
+    자리, AC1). human 상신자는 추가로 벨 알림까지(dispatch_notification, agent는 기존
+    관례대로 대상에서 제외 — approval_delivery.py의 dispatch_approval_request_cards와
+    동일 비대칭).
+
+    해소자 본인이 상신자인 경우(SoD가 정상적으로 막지만 방어심층) 자기-알림 스킵(AC3).
+    """
+    if not doc.project_id or resolver_id == requester_id:
+        return
+
+    from app.routers.conversations import _dispatch_conversation_event
+    from app.services.member_resolver import lookup_members_by_ids
+
+    resolver = (await lookup_members_by_ids({resolver_id}, db)).get(resolver_id)
+    if resolver is None:
+        logger.warning("approval-result 회신 스킵 — resolver 미확인 doc=%s", doc.id)
+        return
+
+    decision_label = "승인" if decision == "approved" else "반려"
+    content = f"'{doc.title}' 문서 결재 결과: {decision_label}"
+    if resolution_note:
+        content += f"\n사유: {resolution_note}"
+
+    try:
+        async with db.begin_nested():
+            conv = await _get_or_create_approval_dm(
+                db, org_id=org_id, project_id=doc.project_id,
+                requester_id=requester_id, approver_id=resolver_id,
+            )
+            msg = ConversationMessage(
+                conversation_id=conv.id,
+                sender_id=resolver_id,
+                content=content,
+                mentioned_ids=[requester_id],
+                msg_metadata={
+                    "activation": {
+                        "audience": [str(requester_id)],
+                        "kind": "result",
+                        "expects_response": False,
+                    },
+                    "approval_target": {
+                        "work_item_type": "doc",
+                        "work_item_id": str(doc.id),
+                        "gate_id": str(gate_id),
+                        "decision": decision,
+                        "resolution_note": resolution_note,
+                    },
+                },
+            )
+            db.add(msg)
+            await db.flush()
+            await _dispatch_conversation_event(db, conv, msg, org_id, resolver)
+    except Exception:  # noqa: BLE001 — best-effort, 회신 실패가 해소를 막지 않음.
+        logger.warning(
+            "approval-result 회신 배달 실패 doc=%s requester=%s",
+            doc.id, requester_id, exc_info=True,
+        )
+        return
+
+    # human 상신자에겐 벨 알림도(AC1). 위 DM dispatch와 별개 SAVEPOINT — 하나 실패해도 다른
+    # 하나는 그대로(doc.py의 벨-알림/카드-배달 독립 채널 관례와 동형).
+    try:
+        requester = (await lookup_members_by_ids({requester_id}, db)).get(requester_id)
+        if requester is not None and requester.type == "human":
+            async with db.begin_nested():
+                from app.services.notification_dispatch import dispatch_notification
+                await dispatch_notification(
+                    db, org_id=org_id, event_type="doc_approval_resolved",
+                    target_member_ids=[requester_id],
+                    title=f"문서 결재 결과: {decision_label}",
+                    body=resolution_note or f"'{doc.title}' 문서가 {decision_label}됐습니다.",
+                    reference_type="gate", reference_id=gate_id,
+                    source_project_id=doc.project_id,
+                )
+    except Exception:  # noqa: BLE001 — 벨 알림 실패는 카드 배달과 독립.
+        logger.warning(
+            "approval-result 벨 알림 실패 doc=%s requester=%s",
+            doc.id, requester_id, exc_info=True,
+        )

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -212,10 +212,14 @@ async def dispatch_approval_result_reply(
             "approval-result 회신 배달 실패 doc=%s requester=%s",
             doc.id, requester_id, exc_info=True,
         )
-        return
+        # ⛔카디르 QA(#3015): 여기 `return`이 있으면 DM 실패가 아래 벨 알림까지 같이
+        # 죽인다 — "별개 SAVEPOINT·독립"이라는 이 함수의 약속과 정반대(단방향 의존).
+        # 이 PR이 막으려던 "폴링 없인 결과 모름"이 정확히 이 실패모드에서 재발한다 —
+        # DM 실패해도 벨은 별도로 시도해야 하므로 return하지 않고 다음 블록으로 진행.
 
-    # human 상신자에겐 벨 알림도(AC1). 위 DM dispatch와 별개 SAVEPOINT — 하나 실패해도 다른
-    # 하나는 그대로(doc.py의 벨-알림/카드-배달 독립 채널 관례와 동형).
+    # human 상신자에겐 벨 알림도(AC1). 위 DM dispatch와 완전히 독립된 형제 try/except —
+    # 하나 실패해도 다른 하나는 그대로 시도된다(doc.py의 벨-알림/카드-배달 독립 채널 관례와
+    # 진짜 동형 — DM 블록의 실패가 여기로 전파되지 않는다).
     try:
         requester = (await lookup_members_by_ids({requester_id}, db)).get(requester_id)
         if requester is not None and requester.type == "human":

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -561,6 +561,10 @@ async def transition_gate(
         await _advance_story_on_merge_approve(session, gate, new_status)
         # E-DG doc-gate(48f064e5): doc 결재 게이트 approve→confirmed·reject→denied.
         await _resolve_doc_gate(session, gate, new_status)
+        # story #2624: 해소 결과를 상신자에게 회신(approval_delivery.py 반대 방향) — 선생님
+        # 직접 지적(폴링해야만 반려를 알던 실사례). doc.status 변경 후 호출돼도 무방(회신
+        # 내용은 gate 필드에서만 유도).
+        await _notify_doc_gate_requester(session, gate, new_status)
         # E-CANVAS C4-S8(story a5118cb0): 정본화 게이트 approve→anchor_version set·reject→재논의 코멘트.
         await _resolve_artifact_canonicalize_gate(session, gate, new_status)
         # HITL crux(story 7726a003) — A2A task INPUT_REQUIRED 복귀. writer 미배선이라 오늘은 no-op.
@@ -792,6 +796,48 @@ async def _resolve_doc_gate(session: AsyncSession, gate: Gate, new_status: str) 
         return  # 멱등·pending 아니면 no-op(double-resolve/취소 방어).
     doc.status = "confirmed" if new_status == "approved" else "denied"
     await session.flush()
+
+
+async def _notify_doc_gate_requester(session: AsyncSession, gate: Gate, new_status: str) -> None:
+    """story #2624: doc 결재 게이트 해소 결과를 상신자에게 회신 —
+    dispatch_approval_request_cards(상신→승인자)의 반대 방향. P2(#3007)는 전방 경로만
+    만들었고 해소→상신자 회신 후방 경로가 없어, 상신자가 게이트를 폴링해야만 결과를
+    알 수 있었다(선생님 직접 지적, 실사례 2026-08-13 07:20 반려·상신자 무통지).
+
+    best-effort — 이 함수의 실패가 게이트 해소 자체를 막지 않는다(호출부 transition_gate
+    가 이 함수를 await만 하고 별도 격리는 하지 않으므로, 예외를 여기서 전부 삼킨다 —
+    approval_delivery.dispatch_approval_result_reply 자체도 내부에서 SAVEPOINT로 이미
+    격리하지만, requester_id 파싱 등 그 앞 단계도 안전해야 한다)."""
+    try:
+        from app.services.doc import DOC_GATE_TYPE, DOC_GATE_WORK_ITEM_TYPE
+        if gate.work_item_type != DOC_GATE_WORK_ITEM_TYPE or gate.gate_type != DOC_GATE_TYPE:
+            return
+        if new_status not in ("approved", "rejected") or gate.resolver_id is None:
+            return
+
+        facts = gate.neutral_facts or {}
+        requester_raw = facts.get("requested_by_member_id")
+        if not requester_raw:
+            return
+        requester_id = uuid.UUID(str(requester_raw))
+
+        from app.models.doc import Doc
+        doc = (await session.execute(
+            select(Doc).where(Doc.id == gate.work_item_id, Doc.org_id == gate.org_id)
+        )).scalar_one_or_none()
+        if doc is None:
+            return
+
+        from app.services.approval_delivery import dispatch_approval_result_reply
+        await dispatch_approval_result_reply(
+            session, org_id=gate.org_id, doc=doc, gate_id=gate.id,
+            requester_id=requester_id, resolver_id=gate.resolver_id,
+            decision=new_status, resolution_note=gate.resolution_note,
+        )
+    except Exception:  # noqa: BLE001 — best-effort, 회신 실패가 게이트 해소를 막지 않는다.
+        logger.warning(
+            "approval-result 상신자 회신 실패 gate=%s", gate.id, exc_info=True,
+        )
 
 
 async def _resolve_artifact_canonicalize_gate(session: AsyncSession, gate: Gate, new_status: str) -> None:

--- a/backend/tests/test_2624_approval_result_reply.py
+++ b/backend/tests/test_2624_approval_result_reply.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import os
 import uuid
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -245,5 +245,51 @@ async def test_second_resolution_reuses_existing_dm():
             assert len(convs) == 1
             msgs = (await s.execute(select(ConversationMessage))).scalars().all()
             assert len(msgs) == 2
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_dm_delivery_failure_does_not_block_bell_notification():
+    """카디르 QA(#3015): DM 배달 블록의 except가 조기 return을 하면 벨 알림까지 같이
+    죽어 「폴링 없인 결과 모름」이 그 실패모드에서 재발한다 — 이 PR이 막으려던 바로 그
+    문제. DM dispatch(_dispatch_conversation_event)가 SQL 레벨에서 실패해도 human
+    상신자의 벨 알림은 독립적으로 시도돼야 한다(형제 try/except, 단방향 의존 금지)."""
+    from app.services.approval_delivery import dispatch_approval_result_reply
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            requester_id = await _seed_member(s, org_id, project_id, member_type="human", name="requester")
+            resolver_id = await _seed_member(s, org_id, project_id, member_type="human", name="resolver")
+            doc = await _seed_doc(s, org_id, project_id)
+            gate_id = uuid.uuid4()
+
+            dn = AsyncMock()
+            import app.services.notification_dispatch as nd_mod
+            orig = nd_mod.dispatch_notification
+            nd_mod.dispatch_notification = dn
+            try:
+                with patch(
+                    "app.routers.conversations._dispatch_conversation_event",
+                    new=AsyncMock(side_effect=RuntimeError("DM dispatch boom")),
+                ):
+                    await dispatch_approval_result_reply(
+                        s, org_id=org_id, doc=doc, gate_id=gate_id,
+                        requester_id=requester_id, resolver_id=resolver_id,
+                        decision="rejected", resolution_note="사유",
+                    )
+                await s.commit()
+            finally:
+                nd_mod.dispatch_notification = orig
+
+            dn.assert_awaited_once(), (
+                "DM dispatch 실패가 벨 알림까지 막으면 안 된다 — 형제 try/except 위반"
+            )
+            kw = dn.await_args.kwargs
+            assert kw["target_member_ids"] == [requester_id]
+            assert kw["event_type"] == "doc_approval_resolved"
     finally:
         await engine.dispose()

--- a/backend/tests/test_2624_approval_result_reply.py
+++ b/backend/tests/test_2624_approval_result_reply.py
@@ -1,0 +1,249 @@
+"""story #2624 — 결재 해소 결과의 상신자 회신(실 PG).
+
+dispatch_approval_request_cards(#2604 P2, 상신→승인자)의 반대 방향: 해소 결과가
+상신자↔해소자 DM에 message_kind="result" 카드로 게시되고 기존 _dispatch_conversation_event
+로 메인 dispatch(agent 상신자가 이 경로로 결과를 받는다, AC1) + human 상신자는 벨 알림까지
+(agent는 기존 관례대로 벨 대상에서 제외) + 해소자 본인=상신자면 자기-알림 스킵(AC3).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2624", slug=f"org2624-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_member(session, org_id, project_id, *, member_type, name="member"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type=member_type,
+        name=name, is_active=True,
+    )
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_doc(session, org_id, project_id, *, title="설계 문서"):
+    from app.models.doc import Doc
+
+    doc = Doc(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title,
+        content="본문", status="pending", slug=f"doc-{uuid.uuid4().hex[:8]}",
+    )
+    session.add(doc)
+    await session.commit()
+    return doc
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_human_requester_gets_dm_and_bell():
+    from app.services.approval_delivery import dispatch_approval_result_reply
+    from app.models.conversation import Conversation, ConversationMessage
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            requester_id = await _seed_member(s, org_id, project_id, member_type="human", name="requester")
+            resolver_id = await _seed_member(s, org_id, project_id, member_type="human", name="resolver")
+            doc = await _seed_doc(s, org_id, project_id)
+            gate_id = uuid.uuid4()
+
+            dn = AsyncMock()
+            import app.services.notification_dispatch as nd_mod
+            orig = nd_mod.dispatch_notification
+            nd_mod.dispatch_notification = dn
+            try:
+                await dispatch_approval_result_reply(
+                    s, org_id=org_id, doc=doc, gate_id=gate_id,
+                    requester_id=requester_id, resolver_id=resolver_id,
+                    decision="rejected", resolution_note="사유: 재작성 필요",
+                )
+                await s.commit()
+            finally:
+                nd_mod.dispatch_notification = orig
+
+            dn.assert_awaited_once()
+            kw = dn.await_args.kwargs
+            assert kw["target_member_ids"] == [requester_id]
+            assert kw["event_type"] == "doc_approval_resolved"
+            assert kw["reference_id"] == gate_id
+
+            from sqlalchemy import select
+
+            convs = (await s.execute(select(Conversation).where(Conversation.org_id == org_id))).scalars().all()
+            assert len(convs) == 1
+            assert convs[0].type == "dm"
+
+            msgs = (await s.execute(select(ConversationMessage))).scalars().all()
+            assert len(msgs) == 1
+            msg = msgs[0]
+            assert msg.sender_id == resolver_id
+            assert msg.msg_metadata["activation"]["kind"] == "result"
+            target = msg.msg_metadata["approval_target"]
+            assert target["decision"] == "rejected"
+            assert target["resolution_note"] == "사유: 재작성 필요"
+            assert target["gate_id"] == str(gate_id)
+            assert "재작성 필요" in msg.content
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_agent_requester_gets_dm_but_no_bell():
+    """agent 상신자는 메인 dispatch(Event) 경로로 결과를 받는다 — 벨 알림(dispatch_notification)
+    대상에서는 기존 관례대로 제외(approval_delivery.dispatch_approval_request_cards와 동일
+    human-only 비대칭)."""
+    from app.services.approval_delivery import dispatch_approval_result_reply
+    from app.models.conversation import ConversationMessage
+    from app.models.event import Event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            requester_id = await _seed_member(s, org_id, project_id, member_type="agent", name="po-agent")
+            resolver_id = await _seed_member(s, org_id, project_id, member_type="human", name="resolver")
+            doc = await _seed_doc(s, org_id, project_id)
+            gate_id = uuid.uuid4()
+
+            dn = AsyncMock()
+            import app.services.notification_dispatch as nd_mod
+            orig = nd_mod.dispatch_notification
+            nd_mod.dispatch_notification = dn
+            try:
+                await dispatch_approval_result_reply(
+                    s, org_id=org_id, doc=doc, gate_id=gate_id,
+                    requester_id=requester_id, resolver_id=resolver_id,
+                    decision="approved", resolution_note=None,
+                )
+                await s.commit()
+            finally:
+                nd_mod.dispatch_notification = orig
+
+            dn.assert_not_awaited(), "agent 상신자는 벨 대상이 아니어야(메인 dispatch로 충분)"
+
+            from sqlalchemy import select
+
+            msgs = (await s.execute(select(ConversationMessage))).scalars().all()
+            assert len(msgs) == 1
+
+            events = (await s.execute(
+                select(Event).where(Event.source_entity_id == msgs[0].id, Event.recipient_id == requester_id)
+            )).scalars().all()
+            assert len(events) == 1, "agent 상신자에게 메인 dispatch Event가 생성돼야(AC1)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_self_resolve_skips_notification():
+    """해소자 본인이 상신자인 경우(SoD가 정상적으로 막지만 방어심층) 자기-알림 스킵(AC3)."""
+    from app.services.approval_delivery import dispatch_approval_result_reply
+    from app.models.conversation import Conversation
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            same_id = await _seed_member(s, org_id, project_id, member_type="human", name="self")
+            doc = await _seed_doc(s, org_id, project_id)
+
+            await dispatch_approval_result_reply(
+                s, org_id=org_id, doc=doc, gate_id=uuid.uuid4(),
+                requester_id=same_id, resolver_id=same_id,
+                decision="approved", resolution_note=None,
+            )
+            await s.commit()
+
+            from sqlalchemy import select
+
+            convs = (await s.execute(select(Conversation).where(Conversation.org_id == org_id))).scalars().all()
+            assert convs == [], "해소자=상신자인데 회신 대화가 생성되면 안 된다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_second_resolution_reuses_existing_dm():
+    """같은 requester↔resolver 페어의 두 번째 회신(다른 doc)은 기존 DM을 재사용한다 —
+    dispatch_approval_request_cards의 get-or-create와 동일 관례(#2604)."""
+    from app.services.approval_delivery import dispatch_approval_result_reply
+    from app.models.conversation import Conversation, ConversationMessage
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            requester_id = await _seed_member(s, org_id, project_id, member_type="human", name="requester")
+            resolver_id = await _seed_member(s, org_id, project_id, member_type="human", name="resolver")
+            doc1 = await _seed_doc(s, org_id, project_id, title="문서1")
+            doc2 = await _seed_doc(s, org_id, project_id, title="문서2")
+
+            await dispatch_approval_result_reply(
+                s, org_id=org_id, doc=doc1, gate_id=uuid.uuid4(),
+                requester_id=requester_id, resolver_id=resolver_id,
+                decision="approved", resolution_note=None,
+            )
+            await s.commit()
+            await dispatch_approval_result_reply(
+                s, org_id=org_id, doc=doc2, gate_id=uuid.uuid4(),
+                requester_id=requester_id, resolver_id=resolver_id,
+                decision="rejected", resolution_note="두번째",
+            )
+            await s.commit()
+
+            from sqlalchemy import select
+
+            convs = (await s.execute(select(Conversation).where(Conversation.org_id == org_id))).scalars().all()
+            assert len(convs) == 1
+            msgs = (await s.execute(select(ConversationMessage))).scalars().all()
+            assert len(msgs) == 2
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2624_gate_requester_reply_gating.py
+++ b/backend/tests/test_2624_gate_requester_reply_gating.py
@@ -1,0 +1,128 @@
+"""story #2624 — gate_service._notify_doc_gate_requester 게이팅 로직(mock, no_db).
+
+각 no-op 조건(비-doc-gate·비-terminal 상태·resolver_id 없음·requested_by_member_id 없음)이
+DB 왕복 0으로 정확히 걸리는지 — dispatch_approval_result_reply 자체는 실PG로
+test_2624_approval_result_reply.py가 검증한다."""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.gate_service import _notify_doc_gate_requester
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _gate(**overrides):
+    defaults = dict(
+        id=uuid.uuid4(),
+        org_id=uuid.uuid4(),
+        work_item_id=uuid.uuid4(),
+        work_item_type="doc",
+        gate_type="doc_approval",
+        resolver_id=uuid.uuid4(),
+        resolution_note=None,
+        neutral_facts={"requested_by_member_id": str(uuid.uuid4())},
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.mark.anyio
+async def test_non_doc_gate_is_noop_zero_db_calls():
+    session = AsyncMock()
+    gate = _gate(work_item_type="story", gate_type="merge")
+    await _notify_doc_gate_requester(session, gate, "approved")
+    session.execute.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_non_doc_approval_gate_type_is_noop():
+    session = AsyncMock()
+    gate = _gate(gate_type="artifact_canonicalize")
+    await _notify_doc_gate_requester(session, gate, "approved")
+    session.execute.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_non_terminal_status_is_noop():
+    session = AsyncMock()
+    gate = _gate()
+    await _notify_doc_gate_requester(session, gate, "pending")
+    session.execute.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_missing_resolver_id_is_noop():
+    session = AsyncMock()
+    gate = _gate(resolver_id=None)
+    await _notify_doc_gate_requester(session, gate, "approved")
+    session.execute.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_missing_requested_by_in_facts_is_noop():
+    session = AsyncMock()
+    gate = _gate(neutral_facts={})
+    await _notify_doc_gate_requester(session, gate, "approved")
+    session.execute.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_doc_not_found_is_noop_no_delivery_call():
+    session = AsyncMock()
+    result = AsyncMock()
+    result.scalar_one_or_none = lambda: None
+    session.execute = AsyncMock(return_value=result)
+    gate = _gate()
+    with patch("app.services.approval_delivery.dispatch_approval_result_reply", new=AsyncMock()) as mock_dispatch:
+        await _notify_doc_gate_requester(session, gate, "approved")
+    mock_dispatch.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_valid_gate_calls_delivery_with_correct_args():
+    session = AsyncMock()
+    fake_doc = SimpleNamespace(id=uuid.uuid4(), title="T")
+    result = AsyncMock()
+    result.scalar_one_or_none = lambda: fake_doc
+    session.execute = AsyncMock(return_value=result)
+
+    requester_id = uuid.uuid4()
+    gate = _gate(neutral_facts={"requested_by_member_id": str(requester_id)}, resolution_note="사유")
+
+    with patch("app.services.approval_delivery.dispatch_approval_result_reply", new=AsyncMock()) as mock_dispatch:
+        await _notify_doc_gate_requester(session, gate, "rejected")
+
+    mock_dispatch.assert_awaited_once()
+    kw = mock_dispatch.await_args.kwargs
+    assert kw["org_id"] == gate.org_id
+    assert kw["doc"] is fake_doc
+    assert kw["gate_id"] == gate.id
+    assert kw["requester_id"] == requester_id
+    assert kw["resolver_id"] == gate.resolver_id
+    assert kw["decision"] == "rejected"
+    assert kw["resolution_note"] == "사유"
+
+
+@pytest.mark.anyio
+async def test_delivery_exception_swallowed_best_effort():
+    """dispatch_approval_result_reply가 터져도 게이트 해소 자체(호출부)로 예외가 새지 않는다."""
+    session = AsyncMock()
+    fake_doc = SimpleNamespace(id=uuid.uuid4(), title="T")
+    result = AsyncMock()
+    result.scalar_one_or_none = lambda: fake_doc
+    session.execute = AsyncMock(return_value=result)
+    gate = _gate()
+
+    with patch(
+        "app.services.approval_delivery.dispatch_approval_result_reply",
+        new=AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        await _notify_doc_gate_requester(session, gate, "approved")  # 예외 전파 없이 반환

--- a/backend/tests/test_deeplink_manifest_contract.py
+++ b/backend/tests/test_deeplink_manifest_contract.py
@@ -88,11 +88,12 @@ def test_conversation_mention_lands_in_chat_tab():
     assert entry.app.parent_tab == ParentTab.chat
 
 
-def test_manifest_covers_all_25_dispatch_notification_event_types():
+def test_manifest_covers_all_26_dispatch_notification_event_types():
     """AC1 회귀 고정: story #1951 GATE1 전수 조사에서 확인한 dispatch_notification()
     event_type 리터럴이 전부 등재돼 있어야 한다. 새 알림 타입이 코드에 추가되고
     이 집합이 갱신 안 되면 이 테스트가 알려준다(양방향 대조 — 매니페스트 초과분도 잡음).
-    story #2617: conversation.unsupervised_chain_expired 신설로 24→25."""
+    story #2617: conversation.unsupervised_chain_expired 신설로 24→25.
+    story #2624: doc_approval_resolved 신설로 25→26."""
     expected = {
         "sprint_closed", "task_completed", "story_assigned", "comment.created",
         "artifact.created", "artifact.exported", "artifact.updated", "artifact.canonicalized",
@@ -100,7 +101,7 @@ def test_manifest_covers_all_25_dispatch_notification_event_types():
         "dispatched", "epic_created", "epic_status_changed", "gate_escalated", "gate_reminder",
         "gate.pending_approval", "gate_overridden", "gate_approval_requested", "gate_reassigned",
         "doc_approval_requested", "handoff_fallback", "story_status_changed",
-        "conversation.unsupervised_chain_expired",
+        "conversation.unsupervised_chain_expired", "doc_approval_resolved",
     }
     actual = {e.app.type for e in DEEPLINK_MANIFEST.entries}
     missing = expected - actual

--- a/backend/tests/test_deeplink_manifest_endpoint.py
+++ b/backend/tests/test_deeplink_manifest_endpoint.py
@@ -46,7 +46,8 @@ async def test_deeplink_manifest_endpoint_returns_200_with_schema_version_and_lo
     assert body["schema_version"] == 1
     assert isinstance(body["version_policy"], str) and body["version_policy"]
     # story #2617: conversation.unsupervised_chain_expired 신설로 33→34.
-    assert isinstance(body["entries"], list) and len(body["entries"]) == 34
+    # story #2624: doc_approval_resolved 신설로 34→35.
+    assert isinstance(body["entries"], list) and len(body["entries"]) == 35
 
     # 미르코 point ②: lookup_key = f"{type}:{entity_type}" (구분자 ":") 서빙 시점 파생.
     story_entry = next(


### PR DESCRIPTION
## 요약
선생님 직접 지적(2026-08-13 07:22, 실사례 gate `34af76dc` 07:20:30 반려·사유 존재·상신자 무통지): P2(#3007/#3011)는 "상신→승인자 카드" 전방 경로만 만들었고 "해소→상신자 회신" 후방 경로가 없어, 상신자(PO)는 게이트를 폴링해야만 반려 사실과 사유를 알 수 있었다 — 루프가 반만 닫혀 있었다.

## 변경
- **`backend/app/services/approval_delivery.py::dispatch_approval_result_reply`(신규)**: `dispatch_approval_request_cards`(#2604 P2)의 반대 방향. 같은 requester↔resolver DM(`_get_or_create_approval_dm` 재사용 — `dm_pair_key`는 인자 순서 무관하게 같은 방을 찾는다)에 `message_kind="result"` 카드 게시 + 기존 `_dispatch_conversation_event` 재사용으로 메인 dispatch. **agent 상신자는 이 경로로 결과를 받는다**(오늘 PO가 못 받았던 그 자리, AC1) — human 상신자는 추가로 벨 알림까지(agent는 기존 관례대로 벨 대상 제외, `dispatch_approval_request_cards`와 동일 human-only 비대칭). 해소자 본인=상신자면 자기-알림 스킵(AC3 — SoD가 정상적으로 막지만 방어심층).
- **`backend/app/services/gate_service.py::_notify_doc_gate_requester`(신규)**: `_resolve_doc_gate` 바로 옆 sibling(같은 no-line-step 분기)에서 호출 — doc-approval 게이트·terminal 상태(approved/rejected)·`resolver_id` 존재·`neutral_facts.requested_by_member_id` 존재 4조건 게이팅(전부 DB 왕복 0의 순수 체크) 후 doc을 조회해 `dispatch_approval_result_reply`에 위임. best-effort — 회신 실패가 게이트 해소 자체를 막지 않는다.
- **deeplink manifest**: `doc_approval_resolved`(grade B — 이미 결정 끝난 읽기전용 FYI, 요청 쪽 `doc_approval_requested`의 A2와 대비) 등재 + 양방향 대조 테스트 갱신(25→26, 34→35 — story #2617이 남긴 34/25 베이스라인 위에 얹음).

## 테스트
- `test_2624_approval_result_reply.py`(신규 4건, 실PG): human 상신자는 DM+벨 둘 다, agent 상신자는 DM+메인dispatch Event만(벨 없음 확인), 자기-해소는 회신 대화 자체가 생성 안 됨, 재해소(다른 doc)는 기존 DM 재사용.
- `test_2624_gate_requester_reply_gating.py`(신규 8건, mock): 4가지 no-op 게이팅 조건(비-doc-gate·비-doc_approval·비-terminal·resolver_id 없음·requested_by 없음)이 DB 왕복 0으로 정확히 걸리는지 + 정상 경로 인자 전달 + best-effort 예외 흡수(호출부로 안 새는지).
- 기존 gate 관련 mock 테스트(`test_a2a.py`·`test_edg_doc_gate_inbox.py` 등 104건) 무회귀 확인 — 비-doc-gate는 `_notify_doc_gate_requester`의 첫 게이팅 체크에서 DB 호출 0으로 즉시 반환돼 기존 mock `session.execute` side_effect 시퀀스에 영향 없음.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>