### PR TITLE
hotfix: #2617 chain escalation notify → kill switch (default off)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -166,6 +166,14 @@ class Settings(BaseSettings):
     # 활성화된다(테스트에서만 True로 켜 그 분기 자체는 계속 커버).
     agent_group_default_mentions: bool = False
 
+    # 핫픽스(2026-08-13, 선생님 직접 지시 — 페드루 경유): story #2617의 human-less chain
+    # escalation 알림이 「무감독 연쇄 감지」 푸시 폭주를 냈다 — 근본 구조 결함(선생님 진단):
+    # 게이트 조건(depth > cap)이 무인간 대화에서 **영구 참인 상시 상태**라 에피소드 개념이
+    # 없고, 24h dedup은 스팸을 하루 단위로 미룰 뿐 모든 human-less 대화가 매일 재발화한다.
+    # agent_group_default_mentions와 동형 패턴 — 코드는 그대로 두고 발화만 차단(기본 False).
+    # 재설계(상시 상태가 아니라 «새 폭주 에피소드/이상 패턴» 기반)는 별도 스토리(페드루) 대상.
+    chain_escalation_notify_enabled: bool = False
+
     # E-ARCH S2 정리(2026-07-21, LISTEN 제거 완료 후 발견): redis_consume_loop task 생성이
     # event_broker_redis_dual_publish_enabled 하나로만 게이트돼 있었다 — dual_publish(발행,
     # 모든 인스턴스가 필요)와 consume(구독+dispatch, SSE를 실제로 서빙하는 서비스만 필요)

--- a/backend/app/services/chain_escalation.py
+++ b/backend/app/services/chain_escalation.py
@@ -51,7 +51,16 @@ async def escalate_unsupervised_chain(
 ) -> None:
     """human-less 대화가 chain cap을 넘었음을 org owner/admin에게 대화 밖 알림으로 승격.
     best-effort·24h/대화 dedup·실패해도 메시지 발신 트랜잭션을 막지 않는다(caller가
-    savepoint로 격리해 호출하는 것을 전제 — doc.py의 approval 알림과 동일 관례)."""
+    savepoint로 격리해 호출하는 것을 전제 — doc.py의 approval 알림과 동일 관례).
+
+    ⛔핫픽스(2026-08-13, 선생님 직접 지시): settings.chain_escalation_notify_enabled(기본
+    False)로 게이트 — 원 게이트 조건(depth > cap)이 human-less 대화에서 영구 참인 상시
+    상태라 에피소드 개념 없이 24h마다 전량 재발화해 알림 폭주를 냈다. 재설계(상시 상태가
+    아니라 새 폭주 에피소드/이상 패턴 기반) 전까지 발화만 차단(코드/dedup 로직은 유지 —
+    agent_group_default_mentions와 동형 패턴)."""
+    from app.core.config import settings
+    if not settings.chain_escalation_notify_enabled:
+        return
     try:
         if not await _claim_escalation_slot(conversation_id):
             return  # 쿨다운 중 — 이미 알렸음(스팸 방지, PO 조건(a))

--- a/backend/tests/test_2617_chain_escalation.py
+++ b/backend/tests/test_2617_chain_escalation.py
@@ -15,6 +15,12 @@ _REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__
 
 pytestmark = pytest.mark.destructive_schema
 
+# 핫픽스(2026-08-13): escalate_unsupervised_chain은 settings.chain_escalation_notify_enabled
+# (기본 False)로 게이트됐다 — 알림 폭주 원인이 dedup 실패가 아니라 "human-less 대화는
+# depth>cap이 영구 참"이라는 게이트 조건 자체였음(에피소드 개념 부재). 메커니즘(dedup 등)을
+# 계속 커버하는 테스트는 명시로 켠다.
+_ESCALATION_ON = patch("app.core.config.settings.chain_escalation_notify_enabled", True)
+
 
 @pytest.fixture
 def anyio_backend():
@@ -166,7 +172,8 @@ async def test_escalate_notifies_org_owner_admin_once_then_dedups(monkeypatch):
 
             client = _fakeredis_client()
             dn = AsyncMock()
-            with patch("app.services.redis_shared.get_client", return_value=client), \
+            with _ESCALATION_ON, \
+                 patch("app.services.redis_shared.get_client", return_value=client), \
                  patch("app.services.notification_dispatch.dispatch_notification", dn):
                 await escalate_unsupervised_chain(
                     s, org_id=org_id, conversation_id=conv_id, project_id=project_id,
@@ -204,7 +211,8 @@ async def test_escalate_different_conversations_each_notify_once():
 
             client = _fakeredis_client()
             dn = AsyncMock()
-            with patch("app.services.redis_shared.get_client", return_value=client), \
+            with _ESCALATION_ON, \
+                 patch("app.services.redis_shared.get_client", return_value=client), \
                  patch("app.services.notification_dispatch.dispatch_notification", dn):
                 await escalate_unsupervised_chain(
                     s, org_id=org_id, conversation_id=conv_a, project_id=project_id, depth=5, cap=4,
@@ -225,7 +233,8 @@ async def test_escalate_redis_down_fails_closed_no_spam():
 
     session = AsyncMock()
     dn = AsyncMock()
-    with patch("app.services.redis_shared.get_client", return_value=None), \
+    with _ESCALATION_ON, \
+         patch("app.services.redis_shared.get_client", return_value=None), \
          patch("app.services.notification_dispatch.dispatch_notification", dn):
         await escalate_unsupervised_chain(
             session, org_id=uuid.uuid4(), conversation_id=uuid.uuid4(),
@@ -242,8 +251,27 @@ async def test_escalate_swallows_exceptions_best_effort():
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=RuntimeError("boom"))
     client = _fakeredis_client()
-    with patch("app.services.redis_shared.get_client", return_value=client):
+    with _ESCALATION_ON, patch("app.services.redis_shared.get_client", return_value=client):
         await escalate_unsupervised_chain(
             session, org_id=uuid.uuid4(), conversation_id=uuid.uuid4(),
             project_id=uuid.uuid4(), depth=5, cap=4,
         )  # 예외 전파 없이 조용히 반환
+
+
+@pytest.mark.anyio
+async def test_escalate_noop_when_flag_off_by_default():
+    """핫픽스(2026-08-13, 선생님 직접 지시) — settings.chain_escalation_notify_enabled 기본
+    False에서는 dedup 판정조차 안 가고(Redis 왕복 0) 즉시 반환한다. 알림 폭주 재발 방지의
+    핵심 회귀가드 — 이 값이 실수로 다시 True 기본이 되면 이 테스트가 알려준다."""
+    from app.services.chain_escalation import escalate_unsupervised_chain
+
+    session = AsyncMock()
+    dn = AsyncMock()
+    with patch("app.services.redis_shared.get_client") as get_client_mock, \
+         patch("app.services.notification_dispatch.dispatch_notification", dn):
+        await escalate_unsupervised_chain(
+            session, org_id=uuid.uuid4(), conversation_id=uuid.uuid4(),
+            project_id=uuid.uuid4(), depth=999, cap=4,
+        )
+    dn.assert_not_awaited()
+    get_client_mock.assert_not_called(), "플래그 off면 dedup 판정 자체를 시도하면 안 된다(Redis 왕복 0)"

--- a/backend/tests/test_check_env_drift_settings_coverage.py
+++ b/backend/tests/test_check_env_drift_settings_coverage.py
@@ -165,6 +165,10 @@ def test_settings_field_env_keys_works_without_pydantic_settings_importable(monk
     # 핫픽스(2026-08-13, 선생님 직접 지시): agent_group_default_mentions 필드 신설로 93→94
     # (AGENT_GROUP_DEFAULT_MENTIONS 포함) — #2603 그룹챗 mentions 기본계약을 opt-in으로
     # 되돌리는 kill switch(기본 False). 가드가 신규 필드를 설계대로 잡은 것.
+    # 핫픽스(2026-08-13, 선생님 직접 지시②): chain_escalation_notify_enabled 필드 신설로
+    # 94→95(CHAIN_ESCALATION_NOTIFY_ENABLED 포함) — #2617 human-less chain escalation
+    # 알림이 에피소드 개념 없이 상시 재발화해 폭주를 냈다 — 재설계 전까지 발화만 차단하는
+    # kill switch(기본 False). 가드가 신규 필드를 설계대로 잡은 것.
     assert "PRESENCE_REDIS_ENABLED" in keys and "SSE_TRANSIENT_REPLAY_ENABLED" in keys
     assert "REQUIRE_VERIFIED_EMAIL_FOR_ORG_CREATE" in keys
     assert "DATABASE_URL_READ" in keys
@@ -174,4 +178,5 @@ def test_settings_field_env_keys_works_without_pydantic_settings_importable(monk
     assert "ORG_BILLING_KEY_ENCRYPTION_KEY" in keys
     assert "TOSS_WEBHOOK_SECRET" in keys
     assert "AGENT_GROUP_DEFAULT_MENTIONS" in keys
-    assert len(keys) == 94
+    assert "CHAIN_ESCALATION_NOTIFY_ENABLED" in keys
+    assert len(keys) == 95


### PR DESCRIPTION
## 요약
선생님 직접 지시(2026-08-13, "무감독 연쇄 감지" 푸시 폭주 후 구조 결함 진단): #2617이 도입한 human-less 대화의 chain-depth escalation 알림 게이트 조건(`depth > cap`)이 human-less 대화에서 **영구 참인 상시 상태** — 24h dedup은 스팸을 하루 단위로 미룰 뿐, 모든 human-less 대화가 매일 최초 1회씩은 무조건 재발화하는 구조다.

## 변경
`settings.chain_escalation_notify_enabled`(기본 False) 추가 — `agent_group_default_mentions`(#3008)과 동형 패턴: 코드/dedup 로직은 그대로 두고 **발화만 차단**. 재설계(상시 상태가 아니라 "새 폭주 에피소드/이상 패턴" 기반)는 페드루가 별도 스토리로 연다.

## dedup 실측 확인 (dev, `pgstat-probe-dev` job — read-only 진단)
선생님 체감("자주")이 dedup 자체의 결함일 가능성도 배제 못 해 확인 요청받았다 — dev `notifications` 테이블 직접 조회 결과, **dedup은 정확히 설계대로 동작했다**:
- 4개의 서로 다른 human-less 대화가 각각 정확히 **1회씩만** 발화(같은 대화 내 재발화 0건).
- org owner/admin 3명에게 팬아웃돼 대화당 3행(동일 타임스탬프)이 생겼다 — 총 12행 = 4대화 × 3수신자, "재발화"가 아니라 "팬아웃"이었다.
- **dedup 로직 자체는 결함 없음** — 문제는 선생님 원 진단 그대로: "human-less 대화마다 매일 최초 1회씩은 무조건 쏜다"는 상시-참 게이트 조건 그 자체.

## 테스트
- `test_2617_chain_escalation.py`: 메커니즘(dedup 등)을 검증하던 기존 4건은 `settings.chain_escalation_notify_enabled=True` 명시 패치로 커버 유지. 신규 `test_escalate_noop_when_flag_off_by_default` — 플래그 기본값(False)에서 Redis 왕복 자체가 0(dedup 판정 시도 안 함)임을 고정(회귀가드).
- `test_check_env_drift_settings_coverage.py`: Settings 필드 개수 94→95 갱신.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>