### PR TITLE
[SID:2620] webhook 전달을 DeliveryDecision 단일 판정으로 통합

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -2208,6 +2208,10 @@ async def send_message(
     # (지도 ②③). preference_excluded_ids = 참가자였지만 route_message가 mute/mentions로
     # 걸러 decisions에 없는 대상 — 이제 이들은 discord 판정과 같은 자리에서 SSE Event
     # 생성 자체가 제외된다(막는 쪽과 하는 쪽이 같은 판정을 본다).
+    # story #2620: decisions는 discord_exclude_ids·preference_excluded_ids뿐 아니라 아래
+    # webhook_authorized_ids(resolve_conversation_webhook_targets)까지 먹이는 단일 snapshot이라
+    # try 실패 시에도(디폴트 []) 참조 가능하게 try 밖에서 미리 초기화한다.
+    decisions: list = []
     discord_exclude_ids: set[uuid.UUID] = set()
     preference_excluded_ids: set[uuid.UUID] = set()
     try:
@@ -2249,24 +2253,26 @@ async def send_message(
     except Exception:
         logger.warning("user_blocker_ids lookup failed message_id=%s — fail-open(no exclusion)", msg.id, exc_info=True)
 
-    # E-EVENT-1CONFIG: webhook 전달 대상을 요청 트랜잭션서 1회 산출(SSOT) — SSE-skip 결정과 실제
-    # webhook delivery 가 **같은 snapshot/결정**을 쓰게 해 TOCTOU silent loss 를 차단한다(산티아고
-    # Finding 1). 산출된 target 을 그대로 delivery task 로 넘기고(post-commit requery 0), 그로부터
-    # 도출한 covered member 집합을 SSE-skip 에 쓴다.
+    # E-EVENT-1CONFIG + story #2620(P3, DeliveryDecision 단일화): webhook 전달 대상을 요청
+    # 트랜잭션서 1회 산출(SSOT) — SSE-skip 결정과 실제 webhook delivery 가 **같은 snapshot**을
+    # 쓰게 해 TOCTOU silent loss 를 차단한다(산티아고 Finding 1). 산출된 target 을 그대로
+    # delivery task 로 넘기고(post-commit requery 0), 그로부터 도출한 covered member 집합을
+    # SSE-skip 에 쓴다. #2620부터는 authorized_member_ids 자체가 route_message()의 decisions
+    # (위, discord_exclude_ids/preference_excluded_ids와 같은 호출)에서 유도돼, webhook이 더
+    # 이상 자체 mentioned_ids 판정을 하지 않는다 — SSE·discord·webhook 셋 다 같은 판정 원천.
     from app.services.conversation_webhook import resolve_conversation_webhook_targets
     webhook_targets: list = []
-    if conv.project_id:
+    webhook_authorized_ids = {d.member_id for d in decisions} - {sender.id}
+    if conv.project_id and webhook_authorized_ids:
         try:
             # P0 message-loss savepoint 격리 — 위 blocks와 동일 근거.
             async with db.begin_nested():
                 webhook_targets = await resolve_conversation_webhook_targets(
                     db,
-                    conversation_id=conversation_id,
                     org_id=org_id,
                     project_id=conv.project_id,
                     sender_id=sender.id,
-                    mentioned_ids=list(msg.mentioned_ids) if msg.mentioned_ids else None,
-                    blocker_member_ids=user_blocker_ids,
+                    authorized_member_ids=webhook_authorized_ids,
                 )
         except Exception:
             logger.warning(

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -274,28 +274,29 @@ async def deliver_conversation_message_webhook(
     async with async_session_factory() as db:
         try:
             if targets is None:
-                # targets 미전달(구 호출자/방어) 경로 — 위 SSOT 호출부(conversations.py)처럼
-                # 미리 계산된 snapshot이 없으므로 여기서 직접 조회(fail-open, #2814/#2817과 동일 결).
-                blocker_member_ids: set[uuid.UUID] = set()
-                if sender_id:
-                    try:
-                        from app.models.user_block import UserBlock
-                        blocker_member_ids = set((await db.execute(
-                            select(UserBlock.blocker_member_id).where(UserBlock.blocked_member_id == sender_id)
-                        )).scalars().all())
-                    except Exception:
-                        logger.warning(
-                            "user_blocker_ids lookup failed conversation_id=%s — fail-open(no exclusion)",
-                            conversation_id, exc_info=True,
-                        )
+                # targets 미전달(구 호출자/방어) 경로 — a2a.py:716이 태우는 fallback(카디르 QA
+                # #2620, 실크래시 100% 재현). 위 SSOT 호출부(conversations.py)처럼 미리 계산된
+                # decisions snapshot이 없으므로, 여기서 **같은 판정 원천**(route_message)을
+                # 새로 1회 호출해 authorized_member_ids를 유도한다 — 이 함수/이 경로가 독자
+                # mentioned_ids·blocker 판정을 재도입하면 SSE·discord·webhook 3계통 병존으로
+                # 역행(#2620이 통합한 바로 그 문제). route_message가 mute/mentions-gate/
+                # chain-depth·UserBlock 제외를 이미 내부에서 반영하므로 여기선 그 결과만 소비.
+                authorized_member_ids: set[uuid.UUID] = set()
+                try:
+                    from app.services.channel_router import route_message as _route
+                    decisions = await _route(message_id, db)
+                    authorized_member_ids = {d.member_id for d in decisions if d.member_id != sender_id}
+                except Exception:
+                    logger.warning(
+                        "route_message fallback 재조회 실패 message_id=%s — fail-open(대상 0)",
+                        message_id, exc_info=True,
+                    )
                 targets = await resolve_conversation_webhook_targets(
                     db,
-                    conversation_id=conversation_id,
                     org_id=org_id,
                     project_id=project_id,
                     sender_id=sender_id,
-                    mentioned_ids=mentioned_ids,
-                    blocker_member_ids=blocker_member_ids,
+                    authorized_member_ids=authorized_member_ids,
                 )
 
             if not targets:

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -175,12 +175,10 @@ class _WebhookTarget(NamedTuple):
 async def resolve_conversation_webhook_targets(
     db,
     *,
-    conversation_id: uuid.UUID,
     org_id: uuid.UUID,
     project_id: uuid.UUID,
     sender_id: uuid.UUID | None,
-    mentioned_ids: list[uuid.UUID] | None,
-    blocker_member_ids: set[uuid.UUID],
+    authorized_member_ids: set[uuid.UUID],
 ) -> list[_WebhookTarget]:
     """conversation.message_created 의 실 전달 대상 webhook 을 결정하는 SSOT.
 
@@ -189,46 +187,35 @@ async def resolve_conversation_webhook_targets(
     snapshot/결정을 쓰게 함으로써 TOCTOU(skip 됐는데 post-commit requery 시 target 0 →
     silent loss)를 차단한다(산티아고 Finding 1).
 
-    authorized = mentioned 우선(**sender 제외**)·없으면 참가자 전원(sender 제외). member-bound
-    webhook 은 그 멤버가 authorized 일 때만, member_id=null 브로드캐스트는 무조건 포함(참가자
-    게이팅 c2dfb823). sender 제외로 자기 self-mention webhook 비대칭도 제거(Finding 2).
+    ⛔story #2620(P3, delivery-contract-blueprint-v0-1 §5, 2026-08-13, PO 확定): `authorized_
+    member_ids`는 **caller가 route_message()의 DeliveryDecision에서 뽑아 넘긴다** — 이 함수는
+    더 이상 「멘션 있으면 멘션만·없으면 전원」이라는 자체 판정을 하지 않는다. 예전엔 SSE 코어
+    (②, #2603 P0로 route_message 소비 전환)와 webhook 배달(④, 이 함수)이 「누가 받나」를 각자
+    다른 규칙으로 판정하는 3계통 병존이었다 — 멘션은 route_message의 계약 의미론상 «강조»지
+    «배제»가 아닌데, webhook만 비멘션 수신자를 빼는 계약 밖 행동을 했다(PO 판정, 2026-08-13).
+    이제 route_message 판정 결과가 SSE-skip·discord-exclude·webhook-authorized 셋 다를 먹이는
+    **단일 snapshot**이라, mentions 기본값이 재상륙하면(#3008) 세 채널이 같이 좁혀진다 — 그게
+    이 통합의 이득이다.
 
-    story #2349 AC3 — 라이브 검증(2026-08-03, PO+디디, 스레드 7256d5cc)에서 실측으로 발견:
-    이 함수가 실제 agent 게이트웨이 webhook 배달(ConversationWebhookDelivery)의 SSOT인데,
-    「이 발신자를 차단한 수신자」exclusion(user_blocker_ids, #2814)이 conversations.py의
-    _dispatch_conversation_event(Event/SSE)·mention_targets에만 흘러가고 여기(실 webhook 배달
-    대상 산출)엔 한 번도 안 걸렸다 — #2817(channel_router.py::route_message, discord-channel
-    WebhookConfig 아웃바운드용)과는 완전히 별개 지점이라 그 수정도 이 갭을 안 덮었다. PO 재확認
-    (2026-08-03, origin/develop 실측): 값이 없던 게 아니라 caller(conversations.py:2049~2053)가
-    바로 옆에서 이미 계산해두고도 «전달을 안 했던» 것 — 그래서 여기서 재조회하지 않고
-    `blocker_member_ids` 파라미터로 caller의 값을 그대로 받는다(TOCTOU-safe한 단일 snapshot
-    원칙 유지, 이 함수 안에서 새 쿼리를 추가하지 않는다).
+    ⛔행동 변경(PR 본문에도 명시): 멘션이 있고 비멘션 webhook-구독 agent가 있는 메시지는,
+    **수신 집합 자체는 그대로**(#3008 mentions-기본값이 현재 off라 route_message decisions가
+    이미 "거의 항상 전원") — 종전엔 그 비멘션 agent가 webhook 대상에서 빠져 SSE로만
+    받았는데(=SSE 폴백), 이제는 webhook으로 직접 받는다(파이프만 이동, webhook 트래픽 소폭
+    증가). SSE 쪽 webhook_covered_ids도 같은 authorized_member_ids에서 파생되므로 이중수신은
+    그대로 0(아래 대조 테스트 참조).
 
-    카디르 QA 재발견(2026-08-03) — 필수 키워드 인자로 승격: 옵셔널(기본값 None)이면 다음 caller가
-    또 "값은 있는데 전달을 잊는" 실수를 반복할 수 있다 — 타입 체커가 누락을 잡게 강제한다.
+    member-bound webhook 은 그 멤버가 authorized 일 때만, member_id=null 브로드캐스트는
+    무조건 포함(참가자 게이팅 c2dfb823).
+
+    story #2349 AC3(2620이 흡수) — 「이 발신자를 차단한 수신자」exclusion(user_blocker_ids,
+    #2814)은 이제 이 함수 밖에서도 별도로 안 넘어온다 — route_message()가 UserBlock 제외를
+    이미 내부에서 반영해 decisions를 산출하므로(#2349 원 수정), authorized_member_ids 자체가
+    이미 차단자 제외 상태다. caller가 "계산해놓고 전달을 잊는" 클래스(카디르 QA 2026-08-03
+    재발견 원인)가 파라미터 자체의 소거로 구조적으로 봉쇄된다.
     """
     from sqlalchemy import select
 
-    from app.models.conversation import ConversationParticipant
-
-    if mentioned_ids:
-        # 멘션 있으면 멘션 대상만 — sender 제외(자기 메시지를 자기 webhook 으로 되받지 않도록·
-        # SSE mention 경로[conversations.py]와 authorized set 통일). 멘션이 sender 뿐이면 전달 0.
-        member_ids_for_webhook: list[uuid.UUID] = [
-            m for m in mentioned_ids if m != sender_id and m not in blocker_member_ids
-        ]
-    else:
-        participant_member_ids = (await db.execute(
-            select(ConversationParticipant.member_id).where(
-                ConversationParticipant.conversation_id == conversation_id,
-                *([ConversationParticipant.member_id != sender_id] if sender_id else []),
-            )
-        )).scalars().all()
-        member_ids_for_webhook = [m for m in participant_member_ids if m not in blocker_member_ids]
-
-    authorized_member_ids: set[uuid.UUID] = {
-        mid for mid in member_ids_for_webhook if mid is not None
-    }
+    member_ids_for_webhook = [mid for mid in authorized_member_ids if mid is not None and mid != sender_id]
 
     # 프로젝트-스코프 활성 webhook + 참가자 게이팅(c2dfb823).
     wh_rows = (await db.execute(
@@ -238,7 +225,7 @@ async def resolve_conversation_webhook_targets(
             WebhookConfig.is_active.is_(True),
         )
     )).scalars().all()
-    target_configs = _select_project_scope_targets(wh_rows, authorized_member_ids)
+    target_configs = _select_project_scope_targets(wh_rows, set(member_ids_for_webhook))
 
     # member-bound webhook 은 글로벌·타 프로젝트에도 존재 가능 → member_id union(중복 id/url 차단).
     if member_ids_for_webhook:

--- a/backend/tests/test_2620_a2a_webhook_fallback_regression.py
+++ b/backend/tests/test_2620_a2a_webhook_fallback_regression.py
@@ -1,0 +1,222 @@
+"""story #2620(P3) 후속 — 카디르 QA 실크래시 100% 재현 회귀 가드.
+
+`resolve_conversation_webhook_targets`를 새 시그니처(`authorized_member_ids`)로 리팩터하며
+호출부 grep을 tests/*.py로만 좁혀서(스코프 실수) `conversation_webhook.py:291`(targets 미전달
+fallback — a2a.py:716이 태우는 그 경로, [[feedback_import_grep_misses_call_only_consumers]]
+동형)이 구 시그니처(conversation_id/mentioned_ids/blocker_member_ids)로 남았었다. webhook 설정
+agent로 가는 모든 A2A SendMessage task가 TypeError로 100% 크래시했다(카디르 실측). 이 테스트는
+`_handle_send_message`를 실제로 호출해(단위 함수 직접 호출이 아니라 그 진짜 caller를 통해) 그
+fallback 경로를 태운다 — fix 전으로 되돌리면 TypeError로 RED여야 한다(아래 mutation self-check).
+
+story #2004 관례(`test_2004_a2a_sendmessage_idempotency_realdb.py`) 그대로: `Base.metadata.
+create_all` 자체 스키마(FK 검증 끔) + 모듈-전역 engine 루프 격리(`_dispose_global_engine_after_
+test`) — `deliver_conversation_message_webhook`가 내부에서 `app.core.database.async_session_
+factory`(그 전역 engine)를 직접 열므로 이 관례가 그대로 필요하다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _engine_and_sessionmaker():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _bypass_fk(session) -> None:
+    from sqlalchemy import text as _text
+    await session.execute(_text("SET session_replication_role = replica"))
+
+
+async def _seed_webhook_agent_member(session) -> tuple[uuid.UUID, uuid.UUID, uuid.UUID]:
+    """a2a.py:716 fallback 진입 조건 — member-bound 활성 WebhookConfig가 있는 agent 1명
+    (a2a.py의 has_webhook 게이트가 이걸로 webhook 분기를 택한다)."""
+    from app.models.team import TeamMember
+    from app.models.webhook_config import WebhookConfig
+
+    await _bypass_fk(session)
+    org_id, project_id = uuid.uuid4(), uuid.uuid4()
+    member = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent",
+        name="A2A Webhook Fallback Test Agent", role="member", is_active=True,
+    )
+    session.add(member)
+    session.add(WebhookConfig(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, member_id=member.id,
+        url=f"https://example.invalid/{uuid.uuid4()}", is_active=True,
+        events=["conversation.message_created"],
+    ))
+    await session.commit()
+    return member.id, org_id, project_id
+
+
+async def _load_member(session, member_id: uuid.UUID):
+    from app.models.team import TeamMember
+
+    await _bypass_fk(session)
+    return (await session.execute(
+        select(TeamMember).where(TeamMember.id == member_id)
+    )).scalar_one()
+
+
+def _send_params(message_id: str, text: str) -> dict:
+    return {
+        "message": {
+            "messageId": message_id,
+            "role": "ROLE_USER",
+            "parts": [{"text": text}],
+        }
+    }
+
+
+@pytest.mark.anyio
+async def test_a2a_send_message_to_webhook_agent_does_not_crash():
+    """카디르 QA(#2620) 재현 — webhook-설정 agent로의 A2A SendMessage가 크래시 없이 완주하고,
+    fallback 경로(targets=None → route_message 재조회)가 실제로 올바른 target(그 agent의
+    webhook URL)으로 전달을 스케줄한다(`_retry_deliver` 스케줄 호출을 가로채 확인 — 실제
+    HTTP는 별개 fire-and-forget task라 스케줄 여부만 결정적으로 관측 가능).
+
+    fix 전(구 시그니처 잔존) 상태로 되돌리면 `_handle_send_message` 내부의
+    `deliver_conversation_message_webhook` 호출이 `resolve_conversation_webhook_targets()
+    got an unexpected keyword argument 'conversation_id'`로 TypeError — task 자체가 절대
+    반환되지 않는다(아래 mutation self-check가 이를 직접 재현·확인)."""
+    from app.routers.a2a import _handle_send_message
+
+    engine, Session = await _engine_and_sessionmaker()
+    try:
+        async with Session() as s:
+            member_id, org_id, project_id = await _seed_webhook_agent_member(s)
+
+        captured_urls: list[str] = []
+
+        def _fake_retry_deliver(delivery_id, url, secret, payload):  # noqa: ARG001
+            """실 HTTP는 `_retry_deliver`가 `fire_and_forget`으로 스케줄하는 별개 asyncio
+            task 안에서 나가(타이밍 레이스) — 그 task가 실제로 도는지가 아니라 «올바른 target
+            으로 스케줄이 됐는지»만 이 테스트의 관심사라, 스케줄 호출 자체(동기 시점)를
+            가로챈다. sync 함수가 즉시 캡처하고, fire_and_forget이 기대하는 awaitable만
+            돌려준다(무해 no-op 코루틴)."""
+            captured_urls.append(url)
+
+            async def _noop():
+                return None
+
+            return _noop()
+
+        import app.services.conversation_webhook as cw_mod
+        original_retry = cw_mod._retry_deliver
+        cw_mod._retry_deliver = _fake_retry_deliver
+        try:
+            async with Session() as s:
+                member = await _load_member(s, member_id)
+                result = await _handle_send_message(
+                    s, member, _send_params(str(uuid.uuid4()), "a2a webhook fallback regression"),
+                )
+        finally:
+            cw_mod._retry_deliver = original_retry
+
+        assert result["task"]["id"], "task가 정상 반환돼야(크래시 없이 완주)"
+        assert result["task"]["metadata"]["delivery_channel"] == "webhook", (
+            "이 테스트는 webhook 분기(has_webhook=True)를 태워야 — fakechat로 새면 이 경로가 검증 안 됨"
+        )
+        assert captured_urls, (
+            "webhook delivery가 시도되지 않음 — fallback의 route_message 재조회가 대상을 "
+            "못 찾았거나(authorized_member_ids 유도 실패) 애초에 도달 못 함"
+        )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mutation_self_check_stale_signature_goes_red_then_restored_green():
+    """mutation self-check — fallback 호출부를 구 시그니처(conversation_id/mentioned_ids/
+    blocker_member_ids)로 되돌리면 위 테스트와 동형 시나리오가 TypeError로 RED여야 한다(그래야
+    이 회귀 테스트가 실제로 그 시그니처 정합을 검증하고 있다는 증거). 그 다음 원복해 GREEN
+    재확인([[feedback_guard_must_declare_what_it_misses]])."""
+    import inspect
+    import app.services.conversation_webhook as cw_mod
+    from app.routers.a2a import _handle_send_message
+
+    original_fn = cw_mod.deliver_conversation_message_webhook
+
+    async def _stale_signature_fallback(
+        message_id, conversation_id, org_id, project_id, sender_id, thread_id, created_at,
+        mentioned_ids=None, content=None, targets=None,
+    ):
+        """fix 전 실제 프로덕션 코드가 하던 일 그대로 재현 — targets=None이면 구 kwarg로
+        resolve_conversation_webhook_targets를 호출해 TypeError를 강제한다."""
+        if targets is None:
+            await cw_mod.resolve_conversation_webhook_targets(
+                None,
+                conversation_id=conversation_id,
+                org_id=org_id,
+                project_id=project_id,
+                sender_id=sender_id,
+                mentioned_ids=mentioned_ids,
+                blocker_member_ids=set(),
+            )
+        raise AssertionError("도달하면 안 됨 — 위 호출에서 TypeError가 먼저 발생해야")
+
+    engine, Session = await _engine_and_sessionmaker()
+    try:
+        async with Session() as s:
+            member_id, org_id, project_id = await _seed_webhook_agent_member(s)
+
+        import app.routers.a2a as a2a_module
+        a2a_module.deliver_conversation_message_webhook = _stale_signature_fallback
+        try:
+            with pytest.raises(TypeError):
+                async with Session() as s:
+                    member = await _load_member(s, member_id)
+                    await _handle_send_message(
+                        s, member, _send_params(str(uuid.uuid4()), "red: stale signature"),
+                    )
+        finally:
+            a2a_module.deliver_conversation_message_webhook = original_fn
+
+        # GREEN 재확인 — 원복 후 새 message_id로 동일 시나리오가 정상 완주.
+        async with Session() as s:
+            member = await _load_member(s, member_id)
+            result = await _handle_send_message(
+                s, member, _send_params(str(uuid.uuid4()), "green: restored signature"),
+            )
+        assert result["task"]["id"]
+        assert inspect.iscoroutinefunction(a2a_module.deliver_conversation_message_webhook)
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2620_webhook_delivery_decision_unify.py
+++ b/backend/tests/test_2620_webhook_delivery_decision_unify.py
@@ -1,0 +1,204 @@
+"""story #2620(P3, delivery-contract-blueprint-v0-1 §5) — webhook 전달이 DeliveryDecision
+단일 판정을 소비하는지 실 HTTP 왕복(AsyncClient+ASGITransport)으로 고정.
+
+PO 확定 행동 변경(2026-08-13): 멘션이 있고 비멘션 webhook-구독 agent가 있어도, 수신 집합
+자체는(mentions-기본값 off라) 그대로 — 종전엔 비멘션 agent가 webhook 대상에서 빠져
+SSE로만 받았는데(SSE 폴백), 이제는 webhook으로 직접 받는다(파이프만 이동).
+
+AC 대응:
+①webhook authorized_member_ids ⊆ SSE 판정과 같은 decisions(대조 테스트)
+②이중수신 0 비회귀 — webhook_covered 확대가 SSE-skip 확대와 대칭이라 겹치지 않음
+③fleet 실왕복(human-less 대화 포함, 08-13 재상륙 조건 준용)
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from tests.test_1994_backlink_api_realdb import (
+    _client_for,
+    _make_agent_member,
+    _make_conversation,
+    _make_org,
+    _make_project,
+    _session_factory,
+    _setup_app_agent,
+)
+from tests.test_2301_story_body_mentions_realdb import _REAL_DB_URL
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _seed_webhook(session, *, org_id, project_id, member_id):
+    from app.models.webhook_config import WebhookConfig
+
+    session.add(WebhookConfig(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, member_id=member_id,
+        url=f"https://example.invalid/{uuid.uuid4()}", is_active=True,
+        events=["conversation.message_created"],
+    ))
+    await session.commit()
+
+
+async def test_mentioned_message_still_webhook_delivers_to_unmentioned_subscriber():
+    """행동 변경(PO 확定, 2026-08-13): sender가 agent_b만 멘션해도, webhook-구독
+    agent_c(무멘션)는 여전히 webhook 대상 — 수신 집합은 그대로(mentions-기본값 off),
+    파이프만 SSE→webhook으로 이동. 종전(멘션 있으면 멘션만) 규칙이었다면 agent_c는
+    webhook 목록에서 빠졌을 것 — 이 테스트가 그 회귀를 잠근다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            agent_sender = await _make_agent_member(s, org.id, project.id)
+            agent_b = await _make_agent_member(s, org.id, project.id)  # 멘션 대상
+            agent_c = await _make_agent_member(s, org.id, project.id)  # 무멘션 webhook 구독자
+            conv_id = await _make_conversation(
+                s, org.id, project.id, [agent_sender, agent_b, agent_c], created_by=agent_sender,
+            )
+            await _seed_webhook(s, org_id=org.id, project_id=project.id, member_id=agent_c)
+
+        captured: list = []
+
+        async def _fake_deliver(*args, **kwargs):
+            captured.append(kwargs.get("targets"))
+
+        from app.services import conversation_webhook as cw_mod
+        original = cw_mod.deliver_conversation_message_webhook
+        cw_mod.deliver_conversation_message_webhook = _fake_deliver
+        try:
+            from app.main import app
+            await _setup_app_agent(app, Session, agent_sender, org.id)
+            async with _client_for(app) as client:
+                resp = await client.post(
+                    f"/api/v2/conversations/{conv_id}/messages",
+                    json={"content": "@b만 멘션", "mentioned_ids": [str(agent_b)]},
+                )
+            app.dependency_overrides.clear()
+            assert resp.status_code == 201, resp.text
+        finally:
+            cw_mod.deliver_conversation_message_webhook = original
+
+        assert captured, "webhook delivery가 호출 안 됨 — 배선 확認 필요"
+        target_member_ids = {t.member_id for t in captured[0]}
+        assert agent_c in target_member_ids, (
+            "무멘션 webhook 구독자가 여전히 대상이어야(#2620 통합 후 mentions는 배제가 아님)"
+        )
+    finally:
+        await engine.dispose()
+
+
+async def test_webhook_covered_agent_gets_no_duplicate_sse_event():
+    """이중수신 0 비회귀(PO 조건②) — webhook 대상으로 잡힌 agent는 SSE Event가 안 생기고
+    (webhook_covered_ids 스킵), webhook 미구독 agent는 SSE Event가 생긴다. 두 집합이
+    같은 decisions에서 파생되므로 대칭 — 겹침도 누락도 없다."""
+    from app.models.conversation import ConversationMessage
+    from app.models.event import Event
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            agent_sender = await _make_agent_member(s, org.id, project.id)
+            agent_webhook = await _make_agent_member(s, org.id, project.id)   # webhook 구독
+            agent_sse_only = await _make_agent_member(s, org.id, project.id)  # webhook 미구독
+            conv_id = await _make_conversation(
+                s, org.id, project.id, [agent_sender, agent_webhook, agent_sse_only],
+                created_by=agent_sender,
+            )
+            await _seed_webhook(s, org_id=org.id, project_id=project.id, member_id=agent_webhook)
+
+        captured: list = []
+
+        async def _fake_deliver(*args, **kwargs):
+            captured.append(kwargs.get("targets"))
+
+        from app.services import conversation_webhook as cw_mod
+        original = cw_mod.deliver_conversation_message_webhook
+        cw_mod.deliver_conversation_message_webhook = _fake_deliver
+        try:
+            from app.main import app
+            await _setup_app_agent(app, Session, agent_sender, org.id)
+            async with _client_for(app) as client:
+                resp = await client.post(
+                    f"/api/v2/conversations/{conv_id}/messages",
+                    json={"content": "무멘션 브로드캐스트"},
+                )
+            app.dependency_overrides.clear()
+            assert resp.status_code == 201, resp.text
+            msg_id = uuid.UUID(resp.json()["data"]["id"])
+        finally:
+            cw_mod.deliver_conversation_message_webhook = original
+
+        target_member_ids = {t.member_id for t in captured[0]} if captured else set()
+        assert agent_webhook in target_member_ids
+
+        async with Session() as s:
+            events = (await s.execute(
+                select(Event.recipient_id).where(Event.source_entity_id == msg_id)
+            )).scalars().all()
+        event_recipients = set(events)
+        assert agent_webhook not in event_recipients, (
+            "webhook 대상 agent에게 SSE Event까지 생기면 이중수신(covered-skip 실패)"
+        )
+        assert agent_sse_only in event_recipients, (
+            "webhook 미구독 agent는 SSE로 받아야(둘 다 빠지면 침묵)"
+        )
+    finally:
+        await engine.dispose()
+
+
+async def test_human_less_conversation_webhook_fleet_roundtrip():
+    """AC③ fleet 실왕복(08-13 재상륙 조건 준용) — human 참가자가 없는 대화에서도 webhook
+    대상 산출·전달이 정상 동작한다(2620 리팩터가 human-presence 예외(#2617)와 충돌 없음을
+    실증)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            agent_sender = await _make_agent_member(s, org.id, project.id)
+            agent_b = await _make_agent_member(s, org.id, project.id)
+            conv_id = await _make_conversation(
+                s, org.id, project.id, [agent_sender, agent_b], created_by=agent_sender,
+                conv_type="dm",
+            )
+            await _seed_webhook(s, org_id=org.id, project_id=project.id, member_id=agent_b)
+
+        captured: list = []
+
+        async def _fake_deliver(*args, **kwargs):
+            captured.append(kwargs.get("targets"))
+
+        from app.services import conversation_webhook as cw_mod
+        original = cw_mod.deliver_conversation_message_webhook
+        cw_mod.deliver_conversation_message_webhook = _fake_deliver
+        try:
+            from app.main import app
+            await _setup_app_agent(app, Session, agent_sender, org.id)
+            async with _client_for(app) as client:
+                resp = await client.post(
+                    f"/api/v2/conversations/{conv_id}/messages",
+                    json={"content": "human-less DM webhook 실왕복"},
+                )
+            app.dependency_overrides.clear()
+            assert resp.status_code == 201, resp.text
+        finally:
+            cw_mod.deliver_conversation_message_webhook = original
+
+        assert captured, "human-less 대화에서 webhook delivery가 호출 안 됨"
+        target_member_ids = {t.member_id for t in captured[0]}
+        assert agent_b in target_member_ids
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_event1config_webhook_targets.py
+++ b/backend/tests/test_event1config_webhook_targets.py
@@ -1,8 +1,14 @@
-"""E-EVENT-1CONFIG: resolve_conversation_webhook_targets SSOT 가드.
+"""E-EVENT-1CONFIG + story #2620(P3, DeliveryDecision 단일화): resolve_conversation_webhook_targets SSOT 가드.
 
 이 함수가 SSE-skip covered set 과 실제 webhook delivery 대상의 단일 출처다(TOCTOU 차단).
-가드: ①sender self-mention 제외(Finding 2) ②mentioned 우선·없으면 participants(sender 제외)
-③member-bound project-독립 union ④member_id=null 브로드캐스트 포함하되 covered 엔 미포함.
+story #2620부터 「누가 authorized 인가」(멘션/참가자/차단 판정)는 caller가 route_message()의
+DeliveryDecision에서 뽑아 `authorized_member_ids`로 넘긴다 — 이 함수 자신은 더 이상 mentioned_ids
+판정도 blocker 조회도 하지 않는다(SSE·discord·webhook 셋 다 같은 판정 원천, PO 확定 2026-08-13).
+
+가드: ①sender self-exclusion(방어심층, Finding 2 — route_message가 이미 recipient_ids에서
+sender를 빼므로 정상 경로에선 no-op) ②authorized_member_ids 그대로 필터링(caller 위임)
+③member-bound project-독립 union ④member_id=null 브로드캐스트 포함하되 covered 엔 미포함
+⑤authorized 0건이면 member-global union 쿼리 자체를 안 함.
 """
 from __future__ import annotations
 
@@ -41,8 +47,9 @@ def _scalars(rows: list) -> MagicMock:
 
 
 @pytest.mark.anyio
-async def test_sender_excluded_from_mentioned_finding2():
-    """멘션에 sender 가 포함돼도 sender webhook 은 전달 대상 아님(skip authorized set 과 통일)."""
+async def test_sender_excluded_even_if_present_in_authorized_defensive():
+    """방어심층(Finding 2) — authorized_member_ids에 sender가 섞여 들어와도(정상 경로에선
+    route_message가 이미 제외해 안 일어나지만) member-bound 대상에서 빠진다."""
     org, proj, sender, agent_a = (uuid.uuid4() for _ in range(4))
     wh_sender = _wh(sender)
     wh_a = _wh(agent_a)
@@ -54,11 +61,11 @@ async def test_sender_excluded_from_mentioned_finding2():
     ]))
 
     targets = await resolve_conversation_webhook_targets(
-        db, conversation_id=uuid.uuid4(), org_id=org, project_id=proj,
-        sender_id=sender, mentioned_ids=[sender, agent_a], blocker_member_ids=set(),
+        db, org_id=org, project_id=proj,
+        sender_id=sender, authorized_member_ids={sender, agent_a},
     )
     member_ids = {t.member_id for t in targets}
-    assert sender not in member_ids, "sender self-mention 제외(Finding 2)"
+    assert sender not in member_ids, "sender는 authorized에 섞여도 방어심층으로 제외(Finding 2)"
     assert agent_a in member_ids
     assert None in member_ids, "member_id=null 브로드캐스트 포함"
     covered = {t.member_id for t in targets if t.member_id is not None}
@@ -66,64 +73,66 @@ async def test_sender_excluded_from_mentioned_finding2():
 
 
 @pytest.mark.anyio
-async def test_mention_only_sender_yields_no_member_target():
-    """sender 가 자기만 멘션 → authorized 0 → member-bound 대상 없음(broadcast 만 가능)."""
+async def test_empty_authorized_yields_broadcast_only_no_member_union_query():
+    """authorized_member_ids가 비면(route_message가 아무도 못 통과시킨 경우) member-bound
+    대상은 없고(broadcast만) member-global union 쿼리 자체를 안 한다(불필요 쿼리 회피)."""
     org, proj, sender = (uuid.uuid4() for _ in range(3))
-    wh_sender = _wh(sender)
     wh_bcast = _wh(None)
 
     db = SimpleNamespace(execute=AsyncMock(side_effect=[
-        _scalars([wh_sender, wh_bcast]),  # project-scope: sender 는 authorized 아님→제외, bcast 유지
-        # member-global union 은 member_ids_for_webhook=[] 이라 호출 안 됨
+        _scalars([wh_bcast]),  # project-scope만 — member-global union은 호출 안 됨
     ]))
 
     targets = await resolve_conversation_webhook_targets(
-        db, conversation_id=uuid.uuid4(), org_id=org, project_id=proj,
-        sender_id=sender, mentioned_ids=[sender], blocker_member_ids=set(),
+        db, org_id=org, project_id=proj,
+        sender_id=sender, authorized_member_ids=set(),
     )
-    assert {t.member_id for t in targets} == {None}, "broadcast 만 — sender member webhook 제외"
+    assert {t.member_id for t in targets} == {None}, "broadcast만 — authorized 0건"
+    assert db.execute.await_count == 1, "member-global union 쿼리가 스킵돼야(authorized 0건)"
 
 
 @pytest.mark.anyio
-async def test_no_mention_uses_participants_minus_sender():
-    """멘션 없으면 참가자(sender 제외) authorized — participant 쿼리 1발 선행."""
-    org, proj, conv_id, sender, agent_a = (uuid.uuid4() for _ in range(5))
+async def test_authorized_member_ids_passthrough_to_project_scope_targets():
+    """authorized_member_ids를 그대로 project-scope 게이팅에 쓴다 — caller(route_message
+    decisions)가 넘긴 집합이 곧 이 함수의 판정 근거 전부(자체 mentioned_ids/participant
+    재조회 없음, story #2620)."""
+    org, proj, sender, agent_a = (uuid.uuid4() for _ in range(4))
     wh_a = _wh(agent_a)
 
     db = SimpleNamespace(execute=AsyncMock(side_effect=[
-        _scalars([agent_a]),   # participant query (.scalars().all())
         _scalars([wh_a]),      # project-scope
         _scalars([wh_a]),      # member-global union
     ]))
 
     targets = await resolve_conversation_webhook_targets(
-        db, conversation_id=conv_id, org_id=org, project_id=proj,
-        sender_id=sender, mentioned_ids=None, blocker_member_ids=set(),
+        db, org_id=org, project_id=proj,
+        sender_id=sender, authorized_member_ids={agent_a},
     )
     assert {t.member_id for t in targets} == {agent_a}
 
 
 @pytest.mark.anyio
-async def test_blocker_member_ids_excludes_recipient_who_blocked_sender():
-    """story #2349 — 라이브 검증(2026-08-03)서 발견한 갭: sender를 차단한 수신자는 webhook 대상에서
-    빠져야 한다. caller(conversations.py)가 이미 계산한 user_blocker_ids를 그대로 받아 거른다 —
-    이 함수 안에서 새 쿼리를 추가하지 않는다(파라미터 미전달 시 기본 동작은 기존과 동일)."""
-    org, proj, conv_id, sender, blocker, agent_a = (uuid.uuid4() for _ in range(6))
+async def test_recipient_not_in_authorized_set_is_excluded():
+    """story #2349 AC3 계승 — 이제는 「누가 authorized인가」 자체가 caller 책임(route_message가
+    이미 blocker/mute/mentions-gate 반영)이라, 이 함수는 authorized_member_ids에 없는 멤버의
+    webhook을 project-scope 게이팅에서 그냥 걸러낸다(caller가 안 넘긴 이유는 이 함수가 몰라도
+    된다 — 판정 단일화의 핵심)."""
+    org, proj, sender, excluded_member, agent_a = (uuid.uuid4() for _ in range(5))
+    wh_excluded = _wh(excluded_member)
     wh_a = _wh(agent_a)
 
     db = SimpleNamespace(execute=AsyncMock(side_effect=[
-        _scalars([blocker, agent_a]),  # participant query (sender 제외 — blocker·agent_a 참가)
-        _scalars([wh_a]),              # project-scope — blocker webhook은 애초에 대상 아님
-        _scalars([wh_a]),              # member-global union
+        _scalars([wh_excluded, wh_a]),  # project-scope — excluded_member는 authorized 밖
+        _scalars([wh_a]),               # member-global union
     ]))
 
     targets = await resolve_conversation_webhook_targets(
-        db, conversation_id=conv_id, org_id=org, project_id=proj,
-        sender_id=sender, mentioned_ids=None, blocker_member_ids={blocker},
+        db, org_id=org, project_id=proj,
+        sender_id=sender, authorized_member_ids={agent_a},
     )
     member_ids = {t.member_id for t in targets}
-    assert blocker not in member_ids, "sender를 차단한 수신자는 webhook 대상에서 제외"
-    assert agent_a in member_ids, "차단과 무관한 수신자는 그대로 대상"
+    assert excluded_member not in member_ids, "authorized 밖 멤버의 webhook은 제외"
+    assert agent_a in member_ids
 
 
 # ─── 실DB 전체 predicate (project 독립·sender 제외·broadcast) ──────────────────
@@ -143,16 +152,16 @@ _requires_db = pytest.mark.skipif(
     reason="story 18eefc31 — 원래 xfail 사유(asyncpg 'attached to a different loop')는 "
     "테스트 전용 엔진으로 전환해 해결됐으나(다른 모든 realdb 테스트와 동일 관례), 그 뒤에서 "
     "별개의 진짜 product 버그가 드러났다: 이 테스트가 만드는 member_id=None 행(§AC2 "
-    "'project-wide broadcast webhook' — conversation_webhook.py:149-150,192에 문서화된 "
-    "핵심 로직, member_id IS NULL이면 무조건 포함)이 실 스키마에서 NotNullViolationError로 "
-    "거부된다. baseline/schema.sql 실측 확인: `member_id uuid NOT NULL`(CREATE TABLE 원문) "
-    "— ORM 모델(webhook_config.py: `member_id: Mapped[uuid.UUID]`, Optional 아님)과 "
-    "생성 스키마(schemas/webhook_config.py: `member_id: uuid.UUID`, 필수)까지 전부 동일하게 "
-    "NOT NULL/필수라 실제 API로 broadcast(member_id=NULL) webhook을 만들 방법 자체가 없다 "
-    "— 이 AC2 브랜치는 100% 도달 불가 dead code. 테스트를 고쳐서(real member_id로 치환) "
-    "통과시키는 건 이 발견을 숨기는 것이라 하지 않음 — product 판단(§AC2 폐기 vs "
-    "member_id nullable 마이그+생성경로 복구) 필요 — follow-up story 34b3a8fb(E-EVENT-1CONFIG·"
-    "backlog)로 분리, 그 story 의 결정·구현 완료 후 이 xfail 해소 예정. story 18eefc31 트래킹.",
+    "'project-wide broadcast webhook' — conversation_webhook.py 핵심 로직, member_id IS "
+    "NULL이면 무조건 포함)이 실 스키마에서 NotNullViolationError로 거부된다. baseline/"
+    "schema.sql 실측 확인: `member_id uuid NOT NULL`(CREATE TABLE 원문) — ORM 모델"
+    "(webhook_config.py: `member_id: Mapped[uuid.UUID]`, Optional 아님)과 생성 스키마"
+    "(schemas/webhook_config.py: `member_id: uuid.UUID`, 필수)까지 전부 동일하게 NOT NULL/"
+    "필수라 실제 API로 broadcast(member_id=NULL) webhook을 만들 방법 자체가 없다 — 이 AC2 "
+    "브랜치는 100% 도달 불가 dead code. 테스트를 고쳐서(real member_id로 치환) 통과시키는 건 "
+    "이 발견을 숨기는 것이라 하지 않음 — product 판단(§AC2 폐기 vs member_id nullable 마이그+"
+    "생성경로 복구) 필요 — follow-up story 34b3a8fb(E-EVENT-1CONFIG·backlog)로 분리, 그 "
+    "story의 결정·구현 완료 후 이 xfail 해소 예정. story 18eefc31 트래킹.",
 )
 @pytest.mark.anyio
 async def test_resolve_predicate_realdb():
@@ -191,12 +200,12 @@ async def test_resolve_predicate_realdb():
             await db.commit()
             try:
                 targets = await resolve_conversation_webhook_targets(
-                    db, conversation_id=uuid.uuid4(), org_id=org, project_id=proj_x,
-                    sender_id=sender, mentioned_ids=[sender, agent_a], blocker_member_ids=set(),
+                    db, org_id=org, project_id=proj_x,
+                    sender_id=sender, authorized_member_ids={agent_a},
                 )
                 member_ids = {t.member_id for t in targets}
                 assert agent_a in member_ids, "타 프로젝트 member-bound 도 union 으로 covered(project 독립)"
-                assert sender not in member_ids, "sender 제외(Finding 2)"
+                assert sender not in member_ids, "sender는 authorized에 안 넣었으니 애초에 대상 아님"
                 assert None in member_ids, "broadcast 포함"
             finally:
                 for mid in (agent_a, sender):


### PR DESCRIPTION
## 요약
블루프린트 P3 전반부(delivery-contract-blueprint-v0-1 §5). P0(#3000)가 SSE 코어를 ChannelRouter `DeliveryDecision` 소비로 단일화했으나 webhook 전달(`resolve_conversation_webhook_targets`)은 여전히 독자 규칙(멘션 있으면 멘션만·없으면 전원)으로 병존 — "막는 쪽과 하는 쪽이 다른 걸 보는" 구조의 마지막 잔재였다.

## 변경
- **`conversation_webhook.py::resolve_conversation_webhook_targets`**: 시그니처에서 `mentioned_ids`·`blocker_member_ids`·(미사용) `conversation_id`를 제거하고 `authorized_member_ids: set[uuid.UUID]`로 교체 — caller가 `route_message()`의 `DeliveryDecision`에서 뽑아 넘긴다. 함수 내부의 자체 mentioned-vs-participant 판정·blocker 재조회 로직을 전부 걷어냈다(caller 위임). #2349 AC3(blocker 제외)는 `route_message`가 이미 내부에서 `UserBlock`을 반영하므로 자동 승계 — "caller가 계산해놓고 전달을 잊는" 클래스(카디르 QA 2026-08-03 재발견 원인)가 파라미터 자체 소거로 구조적으로 봉쇄된다.
- **`conversations.py::send_message`**: `decisions`를 try 밖에서 미리 초기화(빈 리스트)해 `route_message` pre-check 실패 시에도 안전하게 재사용 가능하게 하고, webhook 대상 산출을 `authorized_member_ids = {d.member_id for d in decisions} - {sender.id}`로 교체 — `discord_exclude_ids`·`preference_excluded_ids`와 같은 `decisions` 스냅샷을 공유(E-EVENT-1CONFIG TOCTOU-safety 유지).

## 행동 변경 선언 (PO 확定, 2026-08-13)
멘션이 있고 비멘션 webhook-구독 agent가 있는 메시지 — **수신 집합은 그대로**(mentions 기본값이 현재 off라 `route_message` decisions가 이미 "거의 항상 전원") — 종전엔 그 비멘션 agent가 webhook 대상에서 빠져 SSE로만 받았는데(SSE 폴백), 이제는 webhook으로 직접 받는다(파이프만 이동, webhook 트래픽 소폭 증가). 멘션은 계약 의미론상 "강조"지 "배제"가 아니었다는 PO 판정 — mentions 기본값이 재상륙하면(#3008) SSE·discord·webhook 셋 다 같은 판정으로 동시에 좁혀지는 게 이 통합의 이득이다.

## 알려진 사전 갭 (이 PR이 만든 게 아님, 스코프 밖)
capability-gate로 차단된 agent(`blocked_agent_ids`, 미지원 런타임 커맨드)는 SSE `exclude_ids`엔 포함되는데 webhook `authorized_member_ids`엔 예전부터 반영 안 됐다 — 이 PR 이전에도 없던 축이라 그대로 유지(새 결함 아님, 정직하게 명시만 해 둔다).

## 테스트
- `test_event1config_webhook_targets.py`: 새 계약(`authorized_member_ids` 그대로 소비)에 맞춰 재작성 — self-exclusion 방어심층·authorized 0건 시 member-global union 쿼리 스킵·authorized 밖 멤버 제외·실DB predicate(기존 xfail 유지, 원인 무관 — §AC2 broadcast dead code).
- `test_2620_webhook_delivery_decision_unify.py`(신규 3건, 실PG+실HTTP AsyncClient+ASGITransport):
  1. 멘션이 있어도 무멘션 webhook 구독자가 여전히 대상(행동 변경을 직접 고정).
  2. webhook 대상으로 잡힌 agent에게는 SSE Event가 안 생기고, webhook 미구독 agent는 SSE로 받음(이중수신 0·누락 0 대조 테스트, PO 조건②).
  3. human 참가자가 없는 대화에서도 webhook 산출·전달이 정상 동작(AC③ fleet 실왕복, #2617의 human-presence 예외와 충돌 없음을 실증).
- 기존 webhook/blocker/gating 관련 실PG 테스트(`test_2349_user_blocks_realdb.py` 등, `test_p0_message_loss_savepoint_isolation_realdb.py`, `test_channel_router_multiproject_sender.py`, `test_2617_fleet_roundtrip_realdb.py` 포함) 64건 무회귀 확인 — 로컬 env(ALEMBIC_DATABASE_URL/DATABASE_URL 설정 + 마이그레이션 적용) 재검증.
- Settings/manifest 드리프트 가드(94/95 필드·34/35·25/26 엔트리) 무영향 확인(새 필드·notification 타입 추가 없음).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

## 후속 수정 (카디르 QA 실크래시, push f9d06e52a)
`conversation_webhook.py:291`(`deliver_conversation_message_webhook`의 `targets` 미전달 fallback — `a2a.py:716`이 webhook-설정 agent로의 A2A SendMessage에서 태우는 경로)이 리팩터 당시 구 시그니처(`conversation_id`/`mentioned_ids`/`blocker_member_ids`)로 남아 있어 100% TypeError 크래시였다. 콜사이트 grep을 tests/*.py로만 좁힌 스코프 실수(`grep -rn "resolve_conversation_webhook_targets" app/ --include="*.py"` 전수 재확인 — 콜사이트 정확히 2곳: `conversations.py:2270`(기존 수정 완료)·`conversation_webhook.py:291`(이번 수정), 잔존 없음).

fix: fallback 지점엔 caller가 미리 계산한 `decisions` 스냅샷이 없으므로, 그 자리서 `route_message()`를 새로 1회 호출해 `authorized_member_ids`를 유도(자체 mentioned_ids/blocker 판정 재도입 금지 — 단일 판정 원천 유지). `test_2620_a2a_webhook_fallback_regression.py` 신규(2건, 실PG): `_handle_send_message` 직접 호출로 a2a→webhook 폴백 경로를 실제로 태우는 회귀 테스트(`_retry_deliver` 스케줄 가로채기로 올바른 target 검증) + mutation self-check(구 시그니처로 되돌리면 TypeError로 RED, 원복 후 GREEN 재확인) — 카디르가 짚은 CI 사각 자체를 잠근다.
