### PR TITLE
[SID:2627] 결재 카드에서 대상 문서 본문 챗 내 열람

### DIFF
--- a/apps/web/src/components/chat/approval-request-card.tsx
+++ b/apps/web/src/components/chat/approval-request-card.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Check, FileText, X } from 'lucide-react';
+import { Check, Eye, FileText, X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { GateSignatureApproval } from '@/components/cage/gate-signature-approval';
 import { deriveRiskLevel, usesSignatureFlow } from '@/components/cage/gate-risk';
+import { EntityPreviewModal, getEntityHref } from '@/components/chat/embed-card';
 import type { GateItem } from '@/components/kanban/types';
 
 export interface ApprovalTarget {
@@ -56,6 +57,13 @@ const RESOLVED_STATUS_LABEL_KEYS: Record<string, string> = {
  * 직접 실사용 중 그 네비게이션 자체를 UX 결함으로 판정(gate 34af76dc 반려 사유) — 서명
  * 플로우(`GateSignatureApproval`)를 gates/[id]/page.tsx와 **그대로 공유 재사용**해 챗
  * 카드 안에 얹는다(사본 분화 금지, AC③).
+ *
+ * story #2627 — 선생님 실사용 반려(gate 0db49ffc): "본문을 이 챗 UI 안에서 확인할 방법이
+ * 없다"는 지적. 액션(#2625)은 챗 안인데 판단 재료(doc 본문)가 밖이라 반쪽이었다 — 카드
+ * 제목을 `EntityPreviewModal`(embed-card.tsx, #2614에서 doc 본문 렌더를 이미 지원하도록
+ * 수리된 그 표면) 진입점으로 연결한다. 신규 뷰어 없음(export만 추가) · 서명 플로우
+ * (`GateSignatureApproval`)와 형제로 렌더돼 모달 열람/닫기가 그 로컬 state(근거확인·사유)를
+ * 건드리지 않는다(AC③, 언마운트 없음).
  */
 export function ApprovalRequestCard({ target }: ApprovalRequestCardProps) {
   const t = useTranslations('chats');
@@ -143,10 +151,26 @@ function ApprovalRequestBody({
   const riskLevel = deriveRiskLevel(gate);
   const needsFullFlow = usesSignatureFlow(riskLevel);
   const canAct = gate.status === 'pending' && gate.can_approve === true;
+  const [showPreview, setShowPreview] = useState(false);
+  // story #2627 AC④ — 미리보기 없는 타입(doc 외)은 기존 동작 그대로(제목=평문). EntityPreviewModal
+  // 자체가 doc 전용 fetch 전략을 가진 타입이라(embed-card.tsx `hasFetchStrategy`), 지금은 doc만
+  // 진짜 내용을 보여줄 수 있다 — 억지로 다른 타입에 진입점을 달아 빈 모달을 여는 거짓을 안 만든다.
+  const canPreview = gate.work_item_type === 'doc';
 
   return (
     <div className="space-y-2">
-      <p className="truncate text-sm font-medium text-foreground">{title}</p>
+      {canPreview ? (
+        <button
+          type="button"
+          onClick={() => setShowPreview(true)}
+          className="group/preview flex w-full min-w-0 items-center gap-1 text-left"
+        >
+          <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground group-hover/preview:underline">{title}</span>
+          <Eye className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+        </button>
+      ) : (
+        <p className="truncate text-sm font-medium text-foreground">{title}</p>
+      )}
 
       {gate.status === 'pending' && (riskLevel === 'high' || riskLevel === 'unknown') ? (
         <Badge variant={riskLevel === 'high' ? 'warning' : 'outline'} className={riskLevel === 'unknown' ? 'text-muted-foreground' : undefined}>
@@ -202,6 +226,17 @@ function ApprovalRequestBody({
             </Button>
           </div>
         </>
+      )}
+
+      {showPreview && (
+        <EntityPreviewModal
+          entityType={gate.work_item_type}
+          entityId={gate.work_item_id}
+          title={title}
+          status={null}
+          href={getEntityHref(gate.work_item_type, gate.work_item_id)}
+          onClose={() => setShowPreview(false)}
+        />
       )}
     </div>
   );

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -644,6 +644,14 @@ describe('ChatBubble — story #2604 P2 결재 요청(approval_target) 카드', 
       if (typeof url === 'string' && url === `/api/gates/${GATE_ID}`) {
         return { ok: true, json: async () => ({ data: gate }) };
       }
+      // story #2627 — 카드 제목 클릭 시 EntityPreviewModal(embed-card.tsx)이 doc 2단계
+      // fetch를 시도한다 — 그 경로도 여기서 같이 응답한다.
+      if (typeof url === 'string' && url.startsWith('/api/docs/preview')) {
+        return { ok: true, json: async () => ({ data: { slug: 'proposal', projectId: 'proj-1', orgSlug: 'org', projectSlug: 'proj' } }) };
+      }
+      if (typeof url === 'string' && url.startsWith('/api/docs?')) {
+        return { ok: true, json: async () => ({ data: { content: '# 제안서 본문\n\n승인 근거가 여기 있습니다.' } }) };
+      }
       return { ok: false, json: async () => ({}) };
     }));
     return gate;
@@ -777,6 +785,50 @@ describe('ChatBubble — story #2604 P2 결재 요청(approval_target) 카드', 
       root.render(wrap(<ChatBubble message={approvalMessage} isMine={false} />));
     });
     expect(container.textContent).toContain('찾을 수 없습니다');
+  });
+
+  it('story #2627 — 카드 제목 클릭 시 doc 본문이 챗 안 모달로 열린다(기존 EntityPreviewModal 재사용)', async () => {
+    stubGate({ risk_grade: 'high' });
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={approvalMessage} isMine={false} />));
+    });
+    const titleBtn = Array.from(document.body.querySelectorAll('button')).find((b) => b.textContent?.includes('제안서.md'))!;
+    await act(async () => { titleBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => {});
+    expect(document.body.querySelector('[role="dialog"]')).not.toBeNull();
+    expect(document.body.textContent).toContain('승인 근거가 여기 있습니다');
+  });
+
+  it('story #2627 AC③ — 모달 열람 후 닫아도 서명 플로우에 입력 중이던 근거확인·사유가 유실되지 않는다', async () => {
+    stubGate({ risk_grade: 'high' });
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={approvalMessage} isMine={false} />));
+    });
+    // 서명 플로우에 먼저 입력한다.
+    const checkbox = document.body.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    const textarea = document.body.querySelector('textarea') as HTMLTextAreaElement;
+    await act(async () => {
+      checkbox.click();
+      const nativeSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')!.set!;
+      nativeSetter.call(textarea, '본문 확인, 승인');
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    // 모달을 열었다 닫는다.
+    const titleBtn = Array.from(document.body.querySelectorAll('button')).find((b) => b.textContent?.includes('제안서.md'))!;
+    await act(async () => { titleBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => {});
+    const closeBtn = Array.from(document.body.querySelectorAll('button')).find((b) => b.querySelector('svg') && b.getAttribute('aria-label') === null && b.closest('[role="dialog"]'));
+    // Dialog의 닫기(X) 대신 Escape로 확실히 닫는다(base-ui Dialog가 내장 처리).
+    await act(async () => {
+      document.body.querySelector('[role="dialog"]')?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+    await act(async () => {});
+    void closeBtn;
+    // 체크박스·textarea 값이 그대로다 — 서명 플로우 컴포넌트가 언마운트되지 않았다.
+    expect((document.body.querySelector('input[type="checkbox"]') as HTMLInputElement).checked).toBe(true);
+    expect((document.body.querySelector('textarea') as HTMLTextAreaElement).value).toBe('본문 확인, 승인');
+    const signBtn = Array.from(document.body.querySelectorAll('button')).find((b) => b.textContent?.includes('승인하고 서명'))!;
+    expect(signBtn.hasAttribute('disabled')).toBe(false);
   });
 });
 

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -260,7 +260,10 @@ function EntityDetail({ entityType, entityId, detail }: { entityType: string; en
   return null;
 }
 
-function EntityPreviewModal({
+// story #2627 — 결재 카드(chat/approval-request-card.tsx)가 doc 본문 열람을 위해 그대로
+// 재사용한다(신규 뷰어 금지·사본 분화 금지, PO 확定). 이전엔 이 파일 내부(EntityChip)만
+// 소비하는 비-export 컴포넌트였다 — export만 추가, 내부 로직은 무변경.
+export function EntityPreviewModal({
   entityType,
   entityId,
   title,


### PR DESCRIPTION
## 요약
선생님 실사용 반려(gate 0db49ffc, 08-13 08:33): "본문을 이 챗 UI 안에서 확인할 방법이 없다." #2625로 액션(근거 확인·사유·서명)은 챗 안에서 완결됐지만, 결재 대상의 실제 문서 본문을 읽을 표면이 챗에 없어 판단 재료가 밖에 있는 반쪽 완결이었다.

## 그라운딩(착수 전)
`EntityPreviewModal`(embed-card.tsx)이 doc 타입 본문 렌더를 **이미 지원**한다(#2614에서 수리된 그 표면, `MdBody`로 마크다운 렌더) — 신규 뷰어 불요, **export만 추가**해 그대로 재사용한다.

## 변경
- `embed-card.tsx`: `EntityPreviewModal`을 export(내부 로직 무변경, `EntityChip`의 기존 소비 그대로 유지).
- `approval-request-card.tsx`: 카드 제목을 doc 타입(`gate.work_item_type==='doc'`)에서만 클릭 가능한 미리보기 진입점으로 — `EntityPreviewModal`을 `GateSignatureApproval`/저위험 버튼과 **형제**로 렌더한다(대체가 아니라 병렬 — 모달 열람/닫기가 서명 플로우 컴포넌트를 언마운트하지 않아 근거확인 체크·사유 textarea 상태가 자연히 보존된다, AC③). doc 외 타입은 기존처럼 평문 제목(AC④ 비회귀 — 억지로 빈 모달을 여는 거짓 진입점을 만들지 않음).

## AC 대응
| AC | 상태 |
|---|---|
| 1. 문서 본문을 챗을 벗어나지 않고 열람 | `EntityPreviewModal` 재사용 |
| 2. 기존 미리보기 표면 재사용(신규 뷰어 0) | export만 추가, 새 컴포넌트 0 |
| 3. 모달 열람 후 사유·체크 상태 유실 없음 | 형제 렌더(언마운트 없음) — 테스트로 고정 |
| 4. 미리보기 없는 타입 비회귀 | `canPreview` 게이트(doc만) — 그 외는 기존 평문 제목 |

## 검증
- `pnpm vitest run` — 406 files / 3179 tests pass(신규 2건: 모달 오픈+본문 렌더 확認, 열람→Escape로 닫기 후 체크박스/textarea 값·서명버튼 활성상태 유실 없음 확認).
- `tsc --noEmit` clean · `eslint` clean.
- `verify:no-new-tint-color-text` · `verify:no-i18n-phrase-collision` 전부 신규 0.

## ⚠️ 참고
`fix/2604-result-card-resolution-note`(#3017)와 `develop` 기준 시점이 달라 그 위에서 rebase 필요할 수 있음(같은 파일 `approval-request-card.tsx` 인접 수정) — merge 순서에 맞춰 처리하는.

카디르 QA: 열람→닫기→서명 완결까지 dev 실왕복.
