### PR TITLE
[SID:2628] approval DM 재사용 — 참가자 집합 기준(dm_pair_key 갭 수정)

### DIFF
--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -14,10 +14,10 @@ from __future__ import annotations
 import logging
 import uuid
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.conversation import Conversation, ConversationMessage
+from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.doc import Doc
 
 logger = logging.getLogger(__name__)
@@ -31,25 +31,48 @@ async def _get_or_create_approval_dm(
     requester_id: uuid.UUID,
     approver_id: uuid.UUID,
 ) -> Conversation:
-    """requester↔approver 기존 dm 재사용(가장 최근 1개), 없으면 생성.
+    """requester↔approver 기존 dm 재사용(참가자 집합 기준, 가장 최근 활성 1개), 없으면 생성.
 
     일반 create_conversation 엔드포인트의 "매 호출 신규" 정책(EF-S2, db75ecd0)과 의도적으로
     다르다 — 승인자당 안정적 단일 스레드(카드 상태 갱신 대상)가 필요한 시스템 배달 경로라서,
     여기 한정으로 get-or-create를 쓴다(엔드포인트 자체는 무변경).
 
+    ⛔story #2628(2026-08-13, 선생님 실사용 지적): dm_pair_key **단독** 매치는 안 쓴다 — 그
+    컬럼이 없는(백필 갭·프로덕트 초기 생성 등) 기존 방을 "기존 페어 DM 없음"으로 오판해 새
+    DM을 만들어 대화가 쪼개지는 사고가 났다(선생님↔PO 실 사례: 방 97ee5509는 type=dm이나
+    dm_pair_key가 비어 카드가 새 방 59cda904로 흘러감). 표식(키)과 실물(참가자 집합)이
+    갈리면 실물이 정본이라, 조회를 "이 conversation의 참가자가 정확히 {requester_id,
+    approver_id} 2인"(ConversationParticipant 실물 조회 — 인원수 정확히 2·둘 다 매치)으로
+    바꾼다. dm_pair_key는 이제 조회에 전혀 안 쓴다(신설 시 태깅만 유지 — `_create_conversation_
+    record`가 이미 하는 일, 향후 최적화 여지로 남겨둠). 최근 활성 우선은 `updated_at DESC`
+    (메시지가 올 때마다 갱신되는 값 — `created_at`보다 "활성" 의미에 더 맞는다).
+
     _enforce_agent_creator_policy 미적용: 사용자가 여는 방이 아니라, 게이트가 이미 독립적으로
     인가한(요청자=문서 상신자, 대상=org owner/admin) 시스템 발신 알림 배달이다.
     """
-    pair_key = "|".join(str(m) for m in sorted((requester_id, approver_id)))
+    target_ids = (requester_id, approver_id)
+    matched_conv_ids = (
+        select(ConversationParticipant.conversation_id)
+        .where(ConversationParticipant.member_id.in_(target_ids))
+        .group_by(ConversationParticipant.conversation_id)
+        .having(func.count(ConversationParticipant.member_id.distinct()) == 2)
+    ).scalar_subquery()
+    exactly_two_participants = (
+        select(ConversationParticipant.conversation_id)
+        .where(ConversationParticipant.conversation_id.in_(matched_conv_ids))
+        .group_by(ConversationParticipant.conversation_id)
+        .having(func.count() == 2)
+    ).scalar_subquery()
+
     existing = (
         await db.execute(
             select(Conversation)
             .where(
                 Conversation.org_id == org_id,
                 Conversation.type == "dm",
-                Conversation.dm_pair_key == pair_key,
+                Conversation.id.in_(exactly_two_participants),
             )
-            .order_by(Conversation.created_at.desc())
+            .order_by(Conversation.updated_at.desc())
             .limit(1)
         )
     ).scalars().first()

--- a/backend/tests/test_2628_approval_dm_participant_set_lookup.py
+++ b/backend/tests/test_2628_approval_dm_participant_set_lookup.py
@@ -1,0 +1,304 @@
+"""story #2628 — approval DM 재사용을 참가자 집합 기준으로(dm_pair_key 단독 매치 갭 수정).
+
+선생님 실사용 사고 재현: 기존 requester↔approver 2인 dm이 dm_pair_key 없이(초기 생성·백필
+갭) 존재해도 `_get_or_create_approval_dm`이 그 방을 찾아 재사용해야 한다 — 못 찾으면 새
+방을 만들어 대화가 쪼개진다(97ee5509→59cda904 사고). 결과 회신(dispatch_approval_result_
+reply)도 같은 헬퍼를 쓰므로 fix가 양방향에 동시 적용됨을 확인한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2628", slug=f"org2628-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_member(session, org_id, project_id, *, member_type="human", name="m"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type=member_type,
+        name=name, is_active=True,
+    )
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_dm_no_pair_key(session, org_id, project_id, member_ids, *, created_by):
+    """dm_pair_key가 NULL인 기존 방 — 97ee5509류 초기 생성/백필 갭 재현."""
+    from app.models.conversation import Conversation, ConversationParticipant
+
+    conv = Conversation(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="dm",
+        dm_pair_key=None, created_by=created_by,
+    )
+    session.add(conv)
+    await session.flush()
+    for mid in member_ids:
+        session.add(ConversationParticipant(conversation_id=conv.id, member_id=mid))
+    await session.commit()
+    return conv.id
+
+
+async def _seed_group(session, org_id, project_id, member_ids, *, created_by):
+    from app.models.conversation import Conversation, ConversationParticipant
+
+    conv = Conversation(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="group",
+        created_by=created_by,
+    )
+    session.add(conv)
+    await session.flush()
+    for mid in member_ids:
+        session.add(ConversationParticipant(conversation_id=conv.id, member_id=mid))
+    await session.commit()
+    return conv.id
+
+
+async def _seed_dm_with_third_participant(session, org_id, project_id, member_ids, *, created_by):
+    """type='dm'이지만 참가자가 3인 이상인 기형 데이터 — 오재사용 금지 확인용."""
+    return await _seed_dm_no_pair_key(session, org_id, project_id, member_ids, created_by=created_by)
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_reuses_existing_dm_without_pair_key_ac1():
+    """AC1 — 97ee5509 시나리오: dm_pair_key 없는 기존 2인 dm이 있으면 그 방을 재사용한다."""
+    from app.services.approval_delivery import _get_or_create_approval_dm
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            requester_id = await _seed_member(s, org_id, project_id, name="requester")
+            approver_id = await _seed_member(s, org_id, project_id, name="approver")
+            legacy_conv_id = await _seed_dm_no_pair_key(
+                s, org_id, project_id, [requester_id, approver_id], created_by=requester_id,
+            )
+
+            conv = await _get_or_create_approval_dm(
+                s, org_id=org_id, project_id=project_id,
+                requester_id=requester_id, approver_id=approver_id,
+            )
+            await s.commit()
+
+            assert conv.id == legacy_conv_id, "dm_pair_key 없는 기존 방을 못 찾고 새로 만들면 안 된다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_creates_new_dm_when_none_exists_then_reuses_it_ac2():
+    """AC2 — 기존 방이 정말 없을 때만 신설, 신설 방은 이후 안정적으로 재사용된다."""
+    from app.services.approval_delivery import _get_or_create_approval_dm
+    from app.models.conversation import Conversation
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            requester_id = await _seed_member(s, org_id, project_id, name="requester")
+            approver_id = await _seed_member(s, org_id, project_id, name="approver")
+
+            conv1 = await _get_or_create_approval_dm(
+                s, org_id=org_id, project_id=project_id,
+                requester_id=requester_id, approver_id=approver_id,
+            )
+            await s.commit()
+            conv2 = await _get_or_create_approval_dm(
+                s, org_id=org_id, project_id=project_id,
+                requester_id=requester_id, approver_id=approver_id,
+            )
+            await s.commit()
+
+            assert conv1.id == conv2.id, "신설 방이 다음 호출에서 안정적으로 재사용돼야"
+
+            from sqlalchemy import select
+            all_convs = (await s.execute(
+                select(Conversation).where(Conversation.org_id == org_id)
+            )).scalars().all()
+            assert len(all_convs) == 1
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_does_not_match_group_conversation_ac3():
+    """AC3 — 같은 두 사람이 속한 group(3인 이상)은 매치 안 됨(오재사용 금지) — dm만 대상."""
+    from app.services.approval_delivery import _get_or_create_approval_dm
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            requester_id = await _seed_member(s, org_id, project_id, name="requester")
+            approver_id = await _seed_member(s, org_id, project_id, name="approver")
+            third_id = await _seed_member(s, org_id, project_id, name="third")
+            group_conv_id = await _seed_group(
+                s, org_id, project_id, [requester_id, approver_id, third_id], created_by=requester_id,
+            )
+
+            conv = await _get_or_create_approval_dm(
+                s, org_id=org_id, project_id=project_id,
+                requester_id=requester_id, approver_id=approver_id,
+            )
+            await s.commit()
+
+            assert conv.id != group_conv_id, "group 대화를 dm으로 오재사용하면 안 된다"
+            assert conv.type == "dm"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_does_not_match_dm_with_third_participant_ac3():
+    """AC3 — type='dm'이라도 참가자가 3인 이상(기형 데이터)이면 매치 안 됨."""
+    from app.services.approval_delivery import _get_or_create_approval_dm
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            requester_id = await _seed_member(s, org_id, project_id, name="requester")
+            approver_id = await _seed_member(s, org_id, project_id, name="approver")
+            third_id = await _seed_member(s, org_id, project_id, name="third")
+            malformed_conv_id = await _seed_dm_with_third_participant(
+                s, org_id, project_id, [requester_id, approver_id, third_id], created_by=requester_id,
+            )
+
+            conv = await _get_or_create_approval_dm(
+                s, org_id=org_id, project_id=project_id,
+                requester_id=requester_id, approver_id=approver_id,
+            )
+            await s.commit()
+
+            assert conv.id != malformed_conv_id, "3인 이상 dm(기형)은 오재사용하면 안 된다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_does_not_match_different_pair_dm():
+    """AC3 — requester가 겹쳐도 approver가 다른 기존 dm은 매치 안 됨(참가자 집합 불일치)."""
+    from app.services.approval_delivery import _get_or_create_approval_dm
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            requester_id = await _seed_member(s, org_id, project_id, name="requester")
+            approver_id = await _seed_member(s, org_id, project_id, name="approver")
+            other_approver_id = await _seed_member(s, org_id, project_id, name="other")
+            other_pair_conv_id = await _seed_dm_no_pair_key(
+                s, org_id, project_id, [requester_id, other_approver_id], created_by=requester_id,
+            )
+
+            conv = await _get_or_create_approval_dm(
+                s, org_id=org_id, project_id=project_id,
+                requester_id=requester_id, approver_id=approver_id,
+            )
+            await s.commit()
+
+            assert conv.id != other_pair_conv_id, "다른 approver와의 dm을 오재사용하면 안 된다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_fix_applies_bidirectionally_request_and_result_reply():
+    """양방향 동시 적용 확인 — dispatch_approval_request_cards(상신→승인자)와
+    dispatch_approval_result_reply(해소→상신자)가 같은 _get_or_create_approval_dm을 쓰므로,
+    dm_pair_key 없는 기존 방이 있으면 둘 다 그 방으로 간다(카드→회신이 같은 스레드에 쌓임)."""
+    from app.services.approval_delivery import (
+        dispatch_approval_request_cards,
+        dispatch_approval_result_reply,
+    )
+    from app.models.conversation import Conversation, ConversationMessage
+    from app.models.doc import Doc
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            requester_id = await _seed_member(s, org_id, project_id, name="requester")
+            approver_id = await _seed_member(s, org_id, project_id, name="approver")
+            legacy_conv_id = await _seed_dm_no_pair_key(
+                s, org_id, project_id, [requester_id, approver_id], created_by=requester_id,
+            )
+
+            doc = Doc(
+                id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="설계 문서",
+                content="본문", status="pending", slug=f"doc-{uuid.uuid4().hex[:8]}",
+            )
+            s.add(doc)
+            await s.commit()
+            gate_id = uuid.uuid4()
+
+            await dispatch_approval_request_cards(
+                s, org_id=org_id, doc=doc, gate_id=gate_id,
+                requester_id=requester_id, approver_ids=[approver_id],
+            )
+            await s.commit()
+            await dispatch_approval_result_reply(
+                s, org_id=org_id, doc=doc, gate_id=gate_id,
+                requester_id=requester_id, resolver_id=approver_id,
+                decision="approved", resolution_note=None,
+            )
+            await s.commit()
+
+            from sqlalchemy import select
+
+            convs = (await s.execute(select(Conversation).where(Conversation.org_id == org_id))).scalars().all()
+            assert len(convs) == 1, "카드·회신 둘 다 기존 방으로 가야(신규 방 생성 0)"
+            assert convs[0].id == legacy_conv_id
+
+            msgs = (await s.execute(
+                select(ConversationMessage).where(ConversationMessage.conversation_id == legacy_conv_id)
+            )).scalars().all()
+            assert len(msgs) == 2, "카드 1건 + 회신 1건이 같은 기존 방에 쌓여야"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 요약
선생님 실사용 지적(2026-08-13 08:34, 실사례): "왜 이 채팅방에 게이트가 안 올라오고 다른 채팅방에 올라오는지?" — PO 실측: 기존 선생님↔PO 대화(`97ee5509`)는 `type=dm`이나 초기 생성/백필 갭으로 `dm_pair_key`가 NULL이라, `_get_or_create_approval_dm`의 `dm_pair_key` 단독 조회가 "기존 페어 DM 없음"으로 오판 → 새 DM(`59cda904`)을 만들어 대화가 쪼개졌다. **표식(키)과 실물(참가자 집합)이 갈리면 실물이 정본**이라는 클래스의 실전 사례.

## 변경
`_get_or_create_approval_dm`(`approval_delivery.py`)의 조회를 `dm_pair_key` 단독 매치에서 `ConversationParticipant` 실물 조회(참가자가 정확히 `{requester_id, approver_id}` 2인)로 교체 — 매치 conv_id를 뽑는 서브쿼리 + 총 참가자 수 2명 확인하는 서브쿼리 2단으로 "정확히 이 2인뿐"을 보장(3인 이상 group·다른 pair와 오재사용 없음). 정렬 기준도 `created_at`→`updated_at DESC`로(메시지가 올 때마다 갱신되는 값이 "최근 활성" 의미에 더 맞는다). `dm_pair_key`는 신설 시 태깅만 유지(조회엔 더 이상 안 씀 — 향후 백필+인덱스 최적화 여지로 남겨둠, 이 PR 스코프 밖).

`dispatch_approval_request_cards`(#2604, 상신→승인자)와 `dispatch_approval_result_reply`(#2624, 해소→상신자) 둘 다 같은 `_get_or_create_approval_dm`을 쓰므로 fix가 양방향에 동시 적용된다.

## 테스트 (신규 6건, 실PG)
- **AC1**: `dm_pair_key` 없는 기존 2인 dm을 정확히 찾아 재사용(97ee5509 시나리오 재현) — fix 되돌려 재현 실패(새 방 생성) 확인 후 복원(자가검증).
- **AC2**: 기존 방이 없을 때만 신설, 신설 방은 이후 안정적으로 재사용.
- **AC3**: group(3인 이상)·기형 3인 `dm`·다른 pair(같은 requester, 다른 approver) 전부 오재사용 안 됨.
- **양방향 동시 적용**: 카드(#2604) + 회신(#2624)이 같은 기존 방으로 가고 신규 방 0 — 카드→회신이 같은 스레드에 쌓임을 확인.
- 기존 #2604/#2624 테스트 스위트(9건) 무회귀 확인.

## 참고 (스코프 밖, 명시만)
스토리 본문의 "(검토) 기존 dm에 dm_pair_key 백필 마이그레이션"은 participant-set 조회로 조회 자체는 해결돼 필수는 아니다 — 성능 최적화 여지로만 남겨둔다(별도 판단 필요 시 후속).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>