### PR TITLE
[SID:2626] chain escalation notify — episode-based redesign, retire #3016 killswitch

### DIFF
--- a/backend/alembic/versions/0243_chain_escalation_org_config.py
+++ b/backend/alembic/versions/0243_chain_escalation_org_config.py
@@ -1,0 +1,43 @@
+"""story #2626: chain_escalation_org_config — 무감독 연쇄 알림 org 설정 표면.
+
+Revision ID: 0243
+Revises: 0242
+Create Date: 2026-08-13
+
+org_gate_policy(0066)와 동형 패턴 — org당 1행, 없으면 코드 기본값(300s/15건) 폴백.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0243"
+down_revision = "0242"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "chain_escalation_org_config",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", UUID(as_uuid=True), nullable=False, unique=True),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("window_seconds", sa.Integer(), nullable=False, server_default="300"),
+        sa.Column("threshold", sa.Integer(), nullable=False, server_default="15"),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+    )
+    op.create_index(
+        "ix_chain_escalation_org_config_org_id", "chain_escalation_org_config", ["org_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_chain_escalation_org_config_org_id", table_name="chain_escalation_org_config")
+    op.drop_table("chain_escalation_org_config")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -166,14 +166,6 @@ class Settings(BaseSettings):
     # 활성화된다(테스트에서만 True로 켜 그 분기 자체는 계속 커버).
     agent_group_default_mentions: bool = False
 
-    # 핫픽스(2026-08-13, 선생님 직접 지시 — 페드루 경유): story #2617의 human-less chain
-    # escalation 알림이 「무감독 연쇄 감지」 푸시 폭주를 냈다 — 근본 구조 결함(선생님 진단):
-    # 게이트 조건(depth > cap)이 무인간 대화에서 **영구 참인 상시 상태**라 에피소드 개념이
-    # 없고, 24h dedup은 스팸을 하루 단위로 미룰 뿐 모든 human-less 대화가 매일 재발화한다.
-    # agent_group_default_mentions와 동형 패턴 — 코드는 그대로 두고 발화만 차단(기본 False).
-    # 재설계(상시 상태가 아니라 «새 폭주 에피소드/이상 패턴» 기반)는 별도 스토리(페드루) 대상.
-    chain_escalation_notify_enabled: bool = False
-
     # E-ARCH S2 정리(2026-07-21, LISTEN 제거 완료 후 발견): redis_consume_loop task 생성이
     # event_broker_redis_dual_publish_enabled 하나로만 게이트돼 있었다 — dual_publish(발행,
     # 모든 인스턴스가 필요)와 consume(구독+dispatch, SSE를 실제로 서빙하는 서비스만 필요)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -95,6 +95,7 @@ from app.models.visual_artifact import ArtifactNode, ArtifactVersion, VisualArti
 # 완전히 격리된 새 프로세스로 도는 조건에서 처음 노출).
 from app.models.hitl_config import MemberGateOverride, OrgGateOverride, OrgGatePolicy
 from app.models.participation import Participation, ParticipationRole
+from app.models.chain_escalation_org_config import ChainEscalationOrgConfig
 
 __all__ = [
     "RoleTemplate",

--- a/backend/app/models/chain_escalation_org_config.py
+++ b/backend/app/models/chain_escalation_org_config.py
@@ -1,0 +1,38 @@
+"""story #2626: 무감독 연쇄 알림(에피소드 기반)의 org 설정 표면.
+
+`OrgGatePolicy`(hitl_config.py)와 동형 패턴 — org당 1행, 없으면 코드 기본값 폴백. #3016
+글로벌 killswitch(`settings.chain_escalation_notify_enabled`)를 이 org-level `enabled`가
+대체·은퇴한다(반쪽 은퇴 방지 — PO 조건①).
+"""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Integer, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+# 실측 근거(pgstat-probe-dev, 무인간 대화 44개·7일·3123메시지): 5분 윈도우 내 최대 메시지수
+# p50=3·p90=6·p99=8·관측 max=8. 기본 임계는 관측 max의 ~2배 여유(PO 승인 2026-08-13).
+DEFAULT_WINDOW_SECONDS = 300
+DEFAULT_THRESHOLD = 15
+
+
+class ChainEscalationOrgConfig(Base):
+    """org 수준 무감독 연쇄 알림 설정 — org당 1행. 없으면 위 DEFAULT_* 폴백."""
+    __tablename__ = "chain_escalation_org_config"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, unique=True, index=True)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
+    window_seconds: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=str(DEFAULT_WINDOW_SECONDS)
+    )
+    threshold: Mapped[int] = mapped_column(Integer, nullable=False, server_default=str(DEFAULT_THRESHOLD))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -2330,29 +2330,26 @@ async def send_message(
                             conversation_id, exc_info=True,
                         )
 
-            # story #2617 AC4: human 참가자가 아예 없는 대화는 위 블록이 대상 human 0명이라
-            # 구조적으로 항상 no-op이었다(_dispatch_human_intervention_event의 human_targets
-            # 빈 리스트) — mentioned_ids 유무와 무관하게(#3008 이후 default가 mentions 없이도
-            # "all"이라 대부분의 human-less group 트래픽은 애초에 멘션이 없다) 대화 밖(org
-            # owner/admin)으로 승격해 "무감독 연쇄가 계속되는 중"을 관측 가능하게 만든다
-            # (조용한 단락 금지). 24h/대화 dedup은 chain_escalation.py 내부(fleet 자체가
-            # customer-zero라 팀 DM 전부가 상시 human-less 연쇄 — dedup 없이는 org owner
-            # 스팸).
-            from app.services.channel_router import _conversation_has_human
-            if not await _conversation_has_human(db, conversation_id):
-                try:
-                    async with db.begin_nested():
-                        from app.services.chain_escalation import escalate_unsupervised_chain
-                        await escalate_unsupervised_chain(
-                            db, org_id=org_id, conversation_id=conversation_id,
-                            project_id=conv.project_id, depth=chain_depth,
-                            cap=_AGENT_CHAIN_DEPTH_CAP,
-                        )
-                except Exception:
-                    logger.warning(
-                        "unsupervised chain escalation dispatch failed conversation_id=%s",
-                        conversation_id, exc_info=True,
+        # story #2626(재설계, 2026-08-13 PO 승인): 무감독 연쇄 «알림»은 depth-cap(#2608,
+        # 위 블록·상시 상태)과 완전히 분리된 별도 트리거 — 속도 기반 이상 에피소드 감지로
+        # 교체했다(원 게이트 조건 depth > cap이 human-less 대화에서 영구 참이라 dedup만으론
+        # 소음을 못 없앴다, #3016 진단). 그래서 이 블록은 depth-cap 조건 밖으로 뺐다 — human-
+        # less 대화의 매 agent 메시지마다 속도를 평가한다(chain_escalation.py 내부에서 org
+        # 설정·임계·에피소드 마커·플래핑 쿨다운까지 전부 판단, 여기는 호출만).
+        from app.services.channel_router import _conversation_has_human
+        if not await _conversation_has_human(db, conversation_id):
+            try:
+                async with db.begin_nested():
+                    from app.services.chain_escalation import evaluate_unsupervised_chain_episode
+                    await evaluate_unsupervised_chain_episode(
+                        db, org_id=org_id, conversation_id=conversation_id,
+                        project_id=conv.project_id,
                     )
+            except Exception:
+                logger.warning(
+                    "unsupervised chain escalation dispatch failed conversation_id=%s",
+                    conversation_id, exc_info=True,
+                )
 
     # AC1: 멘션 대상에게 conversation:mention SSE 발송 (participant 여부 무관)
     #

--- a/backend/app/services/chain_escalation.py
+++ b/backend/app/services/chain_escalation.py
@@ -1,4 +1,4 @@
-"""story #2617: human-less 대화의 chain-expired 상태를 대화 밖(org owner/admin)으로 승격.
+"""story #2617/#2626: human-less 대화의 무감독 연쇄를 org 밖(owner/admin)으로 관측 승격.
 
 DM 전용 예외(#3009)를 human-presence 예외로 일반화(channel_router.py)하면서, human이
 없는 대화는 더 이상 chain-depth 게이트로 전달이 막히지 않는다(속도 우선, #2617 PO 지시) —
@@ -6,64 +6,140 @@ DM 전용 예외(#3009)를 human-presence 예외로 일반화(channel_router.py)
 이 모듈은 대화 참가자가 아니라 **org owner/admin**에게 대화 밖에서 알린다(그 대화엔 알릴
 human이 아예 없으므로).
 
-⚠️이 알림은 «관측»이지 «차단»이 아니다 — 진짜 A↔B 무한루프가 토큰을 계속 태우는 문제
-자체는 이 스토리 스코프 밖이다(#2617 스토리 본문 «잔여 위험» 명시, PO 조건(b) — 휴리스틱
-탐지·org 설정 상한은 후속 축).
+⛔재설계(story #2626, 2026-08-13 선생님 진단·PO 승인): 원 게이트 조건(depth > cap)은
+human-less 대화에서 **영구 참인 상시 상태**(휴먼 앵커가 없어 리셋 불가)라, 24h dedup은
+스팸의 «주기»만 정할 뿐 소음 자체를 못 없앴다(#3016 핫픽스로 킬스위치·기본 off). 여기서
+트리거를 depth 카운트에서 **속도 기반 이상 에피소드**로 완전히 교체한다:
+- 짧은 창(기본 5분, org 설정 가능) 안 메시지 수가 임계(기본 15, org 설정 가능)를 초과하면
+  «에피소드 시작» — Redis에 활성 마커를 세우고 그때만 발화.
+- 마커가 이미 있으면(같은 에피소드 진행 중) 재발화 없음.
+- 창 이하로 떨어지면(다음 평가 시점에) 마커를 지운다(해소, 무알림) — 이후 재초과가 «새
+  에피소드»로 재발화.
+- 마커에 TTL(창×2)을 걸고 활성일 때마다 갱신 — 폭주가 멈추고 대화 자체가 조용해지면(해소를
+  평가할 다음 메시지가 영영 안 옴) TTL이 자연 소멸시킨다. TTL 없이는 stale 마커가 다음
+  진짜 폭주의 알림을 영구 억제하는 «상태 자가회수 부재» 결함(PO 필수 조건, 2026-08-13)이
+  된다.
+- 위와 별개로 15분 플래핑 쿨다운(짧은 SET NX)을 한 겹 더 둔다 — 임계 바로 위/아래로
+  진동하는 신호가 에피소드를 빠르게 여닫아도 실 알림은 15분당 최대 1건.
 
-⚠️대화당 24시간 쿨다운으로 dedup한다(PO 조건(a)) — 우리 fleet 자체가 customer-zero라
-팀 DM 전부가 상시 human-less 연쇄다. dedup 없이는 org owner가 일상 작업마다 알림 스팸을
-받는다. Redis 불가 시 fail-closed(스팸 방지가 관측성보다 우선 — 미발화가 스팸보다 안전).
+정상 fleet 트래픽 실측(pgstat-probe-dev, 무인간 대화 44개·7일·3123메시지): 5분 창 내 최대
+메시지수 p50=3·p90=6·p99=8·관측 max=8 — 기본 임계 15는 관측 max의 ~2배 여유(AC1 안전).
+
+⚠️이 알림은 «관측»이지 «차단»이 아니다 — 진짜 A↔B 무한루프가 토큰을 계속 태우는 문제
+자체는 이 스토리 스코프 밖(#2617 스토리 본문 «잔여 위험» 명시, PO 조건(b) — 패턴/콘텐츠
+유사도 기반 탐지는 후속 축, 이번 스코프는 속도축 단독).
 """
 from __future__ import annotations
 
 import logging
 import uuid
+from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 
-_COOLDOWN_SEC = 24 * 60 * 60  # 24h/대화 — PO 조건(a) 예시값 그대로.
+_FLAP_COOLDOWN_SEC = 15 * 60  # 플래핑 방지 — 실 알림은 15분당 최대 1건(#2626, PO 승인).
 
 
-async def _claim_escalation_slot(conversation_id: uuid.UUID) -> bool:
-    """이 대화에 대해 지금 알림을 쏴야 하는지(dedup) — Redis SET NX EX. True = 이번이 이
-    쿨다운 창의 첫 발화(알림 진행). Redis 클라이언트 없음/에러 시 False(fail-closed)."""
+async def _get_org_config(db: AsyncSession, org_id: uuid.UUID) -> tuple[bool, int, int]:
+    """(enabled, window_seconds, threshold) — org 행 없으면 코드 기본값(DEFAULT_*) 폴백."""
+    from app.models.chain_escalation_org_config import (
+        DEFAULT_THRESHOLD,
+        DEFAULT_WINDOW_SECONDS,
+        ChainEscalationOrgConfig,
+    )
+
+    row = (await db.execute(
+        select(
+            ChainEscalationOrgConfig.enabled,
+            ChainEscalationOrgConfig.window_seconds,
+            ChainEscalationOrgConfig.threshold,
+        ).where(ChainEscalationOrgConfig.org_id == org_id)
+    )).one_or_none()
+    if row is None:
+        return True, DEFAULT_WINDOW_SECONDS, DEFAULT_THRESHOLD
+    return bool(row[0]), int(row[1]), int(row[2])
+
+
+async def _recent_message_velocity(
+    db: AsyncSession, conversation_id: uuid.UUID, window_seconds: int,
+) -> int:
+    """최근 window_seconds 안 이 대화의 메시지 수 — 속도축 실축. caller가 이미 human-less
+    대화임을 확인했으므로(호출부 관례) 발신자 전부 agent라 별도 type 필터 없이 전량 카운트."""
+    from app.models.conversation import ConversationMessage
+
+    since = datetime.now(timezone.utc) - timedelta(seconds=window_seconds)
+    return (await db.execute(
+        select(func.count()).select_from(ConversationMessage).where(
+            ConversationMessage.conversation_id == conversation_id,
+            ConversationMessage.created_at >= since,
+        )
+    )).scalar_one()
+
+
+async def _evaluate_episode_marker(
+    conversation_id: uuid.UUID, *, above_threshold: bool, ttl_seconds: int,
+) -> str:
+    """에피소드 마커 상태기계(Redis) — 반환값: "started"(새 에피소드)·"continuing"(진행
+    중, 마커 TTL 갱신)·"resolved"(방금 해소, 마커 삭제)·"idle"(평상). Redis 불가 시
+    "idle"(fail-closed — 미발화가 스팸보다 안전, #2617 PO 조건(a) 계승)."""
     from app.services import redis_shared
 
-    key = redis_shared.key("chain_escalation", str(conversation_id))
+    key = redis_shared.key("chain_escalation", "episode", str(conversation_id))
+
+    async def _op(client) -> str:
+        if above_threshold:
+            created = bool(await client.set(key, "1", nx=True, ex=ttl_seconds))
+            if created:
+                return "started"
+            await client.expire(key, ttl_seconds)  # 진행 중 — TTL 갱신(침묵 시 자연 소멸 보장)
+            return "continuing"
+        deleted = await client.delete(key)
+        return "resolved" if deleted else "idle"
+
+    return await redis_shared.with_fallback(_op, lambda: "idle")
+
+
+async def _claim_flap_cooldown_slot(conversation_id: uuid.UUID) -> bool:
+    """플래핑 방지 — 15분/대화. True = 이번이 쿨다운 창의 첫 발화(알림 진행)."""
+    from app.services import redis_shared
+
+    key = redis_shared.key("chain_escalation", "cooldown", str(conversation_id))
 
     async def _op(client) -> bool:
-        return bool(await client.set(key, "1", nx=True, ex=_COOLDOWN_SEC))
+        return bool(await client.set(key, "1", nx=True, ex=_FLAP_COOLDOWN_SEC))
 
     return await redis_shared.with_fallback(_op, lambda: False)
 
 
-async def escalate_unsupervised_chain(
+async def evaluate_unsupervised_chain_episode(
     db: AsyncSession,
     *,
     org_id: uuid.UUID,
     conversation_id: uuid.UUID,
     project_id: uuid.UUID | None,
-    depth: int,
-    cap: int,
 ) -> None:
-    """human-less 대화가 chain cap을 넘었음을 org owner/admin에게 대화 밖 알림으로 승격.
-    best-effort·24h/대화 dedup·실패해도 메시지 발신 트랜잭션을 막지 않는다(caller가
-    savepoint로 격리해 호출하는 것을 전제 — doc.py의 approval 알림과 동일 관례).
-
-    ⛔핫픽스(2026-08-13, 선생님 직접 지시): settings.chain_escalation_notify_enabled(기본
-    False)로 게이트 — 원 게이트 조건(depth > cap)이 human-less 대화에서 영구 참인 상시
-    상태라 에피소드 개념 없이 24h마다 전량 재발화해 알림 폭주를 냈다. 재설계(상시 상태가
-    아니라 새 폭주 에피소드/이상 패턴 기반) 전까지 발화만 차단(코드/dedup 로직은 유지 —
-    agent_group_default_mentions와 동형 패턴)."""
-    from app.core.config import settings
-    if not settings.chain_escalation_notify_enabled:
-        return
+    """human-less 대화의 매 agent 메시지마다 호출 — 속도 기반 이상 에피소드를 평가하고,
+    새 에피소드 시작에서만(+15분 플래핑 쿨다운 통과 시) org owner/admin에게 대화 밖 알림.
+    best-effort — 실패해도 메시지 발신 트랜잭션을 막지 않는다(caller가 savepoint로 격리해
+    호출하는 것을 전제, doc.py의 approval 알림과 동일 관례)."""
     try:
-        if not await _claim_escalation_slot(conversation_id):
-            return  # 쿨다운 중 — 이미 알렸음(스팸 방지, PO 조건(a))
+        enabled, window_seconds, threshold = await _get_org_config(db, org_id)
+        if not enabled:
+            return
+
+        velocity = await _recent_message_velocity(db, conversation_id, window_seconds)
+        above = velocity > threshold
+        marker_state = await _evaluate_episode_marker(
+            conversation_id, above_threshold=above, ttl_seconds=window_seconds * 2,
+        )
+        if marker_state != "started":
+            return  # continuing(이미 알림)·resolved(무알림 해소)·idle(평상) 전부 발화 없음
+
+        if not await _claim_flap_cooldown_slot(conversation_id):
+            return  # 새 에피소드지만 플래핑 쿨다운 중 — 발화 skip(마커는 이미 세워짐)
 
         from app.models.project import OrgMember
         from app.services.notification_dispatch import dispatch_notification
@@ -82,7 +158,10 @@ async def escalate_unsupervised_chain(
             db, org_id=org_id, event_type="conversation.unsupervised_chain_expired",
             target_member_ids=list(approver_ids),
             title="무인간 대화 무감독 연쇄 감지",
-            body=f"human 참가자가 없는 대화에서 에이전트 연쇄가 {depth}턴(cap {cap})을 넘었습니다.",
+            body=(
+                f"human 참가자가 없는 대화에서 최근 {window_seconds}초간 메시지 {velocity}건"
+                f"(임계 {threshold})이 발생했습니다."
+            ),
             reference_type="conversation", reference_id=conversation_id,
             source_project_id=project_id,
             via_outbox=True,

--- a/backend/tests/test_2617_chain_escalation.py
+++ b/backend/tests/test_2617_chain_escalation.py
@@ -1,25 +1,19 @@
-"""story #2617: human-less 대화의 chain-expired «관측» 축 검증.
+"""story #2617: human-less 대화 판정 축 — `_conversation_has_human`(channel_router.py) 검증.
 
-(1) `_conversation_has_human`(channel_router.py) — 실물 참가자 조회가 정확한지(실PG).
-(2) `escalate_unsupervised_chain`(chain_escalation.py) — org owner/admin에게 알림 발송 +
-    24h/대화 dedup(fakeredis) + Redis 다운 시 fail-closed(스팸 방지 우선, PO 조건(a)).
+무감독 연쇄 «알림» 자체(에피소드 상태기계·org 설정·쿨다운)는 story #2626 재설계로
+`chain_escalation.py`의 `evaluate_unsupervised_chain_episode`로 교체됐다 —
+test_2626_chain_escalation_episode.py 참조. 이 파일은 #2626이 안 건드린 human-presence
+판정 축(실물 참가자 조회)만 남긴다.
 """
 from __future__ import annotations
 
 import uuid
-from unittest.mock import AsyncMock, patch
 
 import pytest
 
 _REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
 
 pytestmark = pytest.mark.destructive_schema
-
-# 핫픽스(2026-08-13): escalate_unsupervised_chain은 settings.chain_escalation_notify_enabled
-# (기본 False)로 게이트됐다 — 알림 폭주 원인이 dedup 실패가 아니라 "human-less 대화는
-# depth>cap이 영구 참"이라는 게이트 조건 자체였음(에피소드 개념 부재). 메커니즘(dedup 등)을
-# 계속 커버하는 테스트는 명시로 켠다.
-_ESCALATION_ON = patch("app.core.config.settings.chain_escalation_notify_enabled", True)
 
 
 @pytest.fixture
@@ -84,15 +78,6 @@ async def _seed_participant(session, conversation_id, member_id):
     await session.commit()
 
 
-async def _seed_org_owner(session, org_id, *, role="owner"):
-    from app.models.project import OrgMember
-
-    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=uuid.uuid4(), role=role)
-    session.add(om)
-    await session.commit()
-    return om.id
-
-
 # ─── _conversation_has_human ─────────────────────────────────────────────────
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
@@ -147,131 +132,3 @@ async def test_conversation_has_human_false_for_empty_conversation():
             assert await _conversation_has_human(s, uuid.uuid4()) is False
     finally:
         await engine.dispose()
-
-
-# ─── escalate_unsupervised_chain ──────────────────────────────────────────────
-
-def _fakeredis_client():
-    aioredis = pytest.importorskip("fakeredis.aioredis")
-    server = aioredis.FakeServer()
-    return aioredis.FakeRedis(server=server, decode_responses=True)
-
-
-@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
-@pytest.mark.anyio
-async def test_escalate_notifies_org_owner_admin_once_then_dedups(monkeypatch):
-    from app.services.chain_escalation import escalate_unsupervised_chain
-
-    engine, Session = await _realdb_session()
-    try:
-        async with Session() as s:
-            org_id, project_id = await _seed_org_project(s)
-            owner_id = await _seed_org_owner(s, org_id, role="owner")
-            await _seed_org_owner(s, org_id, role="member")  # non-admin — 대상 아님
-            conv_id = await _seed_conversation(s, org_id, project_id)
-
-            client = _fakeredis_client()
-            dn = AsyncMock()
-            with _ESCALATION_ON, \
-                 patch("app.services.redis_shared.get_client", return_value=client), \
-                 patch("app.services.notification_dispatch.dispatch_notification", dn):
-                await escalate_unsupervised_chain(
-                    s, org_id=org_id, conversation_id=conv_id, project_id=project_id,
-                    depth=7, cap=4,
-                )
-                dn.assert_awaited_once()
-                kw = dn.await_args.kwargs
-                assert kw["target_member_ids"] == [owner_id], "owner만 대상 — member role은 제외"
-                assert kw["event_type"] == "conversation.unsupervised_chain_expired"
-                assert kw["reference_id"] == conv_id
-
-                # 재발화 — 같은 대화, 쿨다운 안(24h) → 두 번째 알림 0건(스팸 방지, PO 조건(a)).
-                await escalate_unsupervised_chain(
-                    s, org_id=org_id, conversation_id=conv_id, project_id=project_id,
-                    depth=9, cap=4,
-                )
-                dn.assert_awaited_once(), "쿨다운 중 재발화는 dedup돼야(2번째 호출 무시)"
-    finally:
-        await engine.dispose()
-
-
-@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
-@pytest.mark.anyio
-async def test_escalate_different_conversations_each_notify_once():
-    """dedup 키는 대화별 — 서로 다른 conv_id는 각자 독립적으로 1회씩 알림."""
-    from app.services.chain_escalation import escalate_unsupervised_chain
-
-    engine, Session = await _realdb_session()
-    try:
-        async with Session() as s:
-            org_id, project_id = await _seed_org_project(s)
-            await _seed_org_owner(s, org_id, role="owner")
-            conv_a = await _seed_conversation(s, org_id, project_id)
-            conv_b = await _seed_conversation(s, org_id, project_id)
-
-            client = _fakeredis_client()
-            dn = AsyncMock()
-            with _ESCALATION_ON, \
-                 patch("app.services.redis_shared.get_client", return_value=client), \
-                 patch("app.services.notification_dispatch.dispatch_notification", dn):
-                await escalate_unsupervised_chain(
-                    s, org_id=org_id, conversation_id=conv_a, project_id=project_id, depth=5, cap=4,
-                )
-                await escalate_unsupervised_chain(
-                    s, org_id=org_id, conversation_id=conv_b, project_id=project_id, depth=5, cap=4,
-                )
-                assert dn.await_count == 2, "서로 다른 대화는 dedup 키가 갈려 각자 알림돼야"
-    finally:
-        await engine.dispose()
-
-
-@pytest.mark.anyio
-async def test_escalate_redis_down_fails_closed_no_spam():
-    """Redis 클라이언트 None(다운) → dedup 판정 불가 → fail-closed(알림 skip, 예외 0).
-    스팸이 미발화보다 나쁘다는 PO 조건(a) 그대로."""
-    from app.services.chain_escalation import escalate_unsupervised_chain
-
-    session = AsyncMock()
-    dn = AsyncMock()
-    with _ESCALATION_ON, \
-         patch("app.services.redis_shared.get_client", return_value=None), \
-         patch("app.services.notification_dispatch.dispatch_notification", dn):
-        await escalate_unsupervised_chain(
-            session, org_id=uuid.uuid4(), conversation_id=uuid.uuid4(),
-            project_id=uuid.uuid4(), depth=5, cap=4,
-        )
-    dn.assert_not_awaited()
-
-
-@pytest.mark.anyio
-async def test_escalate_swallows_exceptions_best_effort():
-    """알림 경로 예외는 메시지 발신을 막지 않는다 — best-effort(다른 doc.py 알림 경로와 동형)."""
-    from app.services.chain_escalation import escalate_unsupervised_chain
-
-    session = AsyncMock()
-    session.execute = AsyncMock(side_effect=RuntimeError("boom"))
-    client = _fakeredis_client()
-    with _ESCALATION_ON, patch("app.services.redis_shared.get_client", return_value=client):
-        await escalate_unsupervised_chain(
-            session, org_id=uuid.uuid4(), conversation_id=uuid.uuid4(),
-            project_id=uuid.uuid4(), depth=5, cap=4,
-        )  # 예외 전파 없이 조용히 반환
-
-
-@pytest.mark.anyio
-async def test_escalate_noop_when_flag_off_by_default():
-    """핫픽스(2026-08-13, 선생님 직접 지시) — settings.chain_escalation_notify_enabled 기본
-    False에서는 dedup 판정조차 안 가고(Redis 왕복 0) 즉시 반환한다. 알림 폭주 재발 방지의
-    핵심 회귀가드 — 이 값이 실수로 다시 True 기본이 되면 이 테스트가 알려준다."""
-    from app.services.chain_escalation import escalate_unsupervised_chain
-
-    session = AsyncMock()
-    dn = AsyncMock()
-    with patch("app.services.redis_shared.get_client") as get_client_mock, \
-         patch("app.services.notification_dispatch.dispatch_notification", dn):
-        await escalate_unsupervised_chain(
-            session, org_id=uuid.uuid4(), conversation_id=uuid.uuid4(),
-            project_id=uuid.uuid4(), depth=999, cap=4,
-        )
-    dn.assert_not_awaited()
-    get_client_mock.assert_not_called(), "플래그 off면 dedup 판정 자체를 시도하면 안 된다(Redis 왕복 0)"

--- a/backend/tests/test_2626_chain_escalation_episode.py
+++ b/backend/tests/test_2626_chain_escalation_episode.py
@@ -1,0 +1,402 @@
+"""story #2626: 무감독 연쇄 알림 재설계 — 속도 기반 이상 에피소드.
+
+원 게이트 조건(#2617, depth > cap)이 human-less 대화에서 영구 참인 상시 상태라 24h dedup
+으로도 알림 폭주를 못 막았다(#3016 진단·킬스위치). 이 파일은 그 트리거를 대체한
+`evaluate_unsupervised_chain_episode`(chain_escalation.py)의 에피소드 상태기계를 검증한다:
+- AC1: 정상 fleet 속도(임계 이하)에서는 몇 메시지가 오가도 알림 0.
+- AC2: 폭주(임계 초과) 진입 시 1회만 발화 — 같은 에피소드 진행 중 재발화 없음.
+- AC3: 해소(임계 이하로 복귀) 후 재폭주만 재발화 — 상시 재통보 금지.
+- TTL: 마커에 TTL이 걸려 침묵으로 에피소드가 끝나도(해소를 평가할 다음 메시지가 안 옴)
+  자연 소멸한다(PO 필수 조건 — stale 마커가 다음 폭주를 영구 억제하는 결함 방지).
+- org 설정 표면: `chain_escalation_org_config` 행으로 임계/창/enabled를 org별 오버라이드.
+- 15분 플래핑 쿨다운: 에피소드가 빠르게 여닫혀도 실 알림은 쿨다운 창당 최대 1건.
+- Redis 다운 fail-closed(#2617 PO 조건(a) 계승).
+
+`_conversation_has_human`(channel_router.py, #2617에서 검증) 자체는 #2626이 안 건드려
+test_2617_chain_escalation.py에 그대로 남아 있다.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2626", slug=f"org2626-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_member(session, org_id, project_id, *, member_type="agent"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type=member_type,
+        name=member_type, is_active=True,
+    )
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_conversation(session, org_id, project_id, *, conv_type="group"):
+    from app.models.conversation import Conversation
+
+    conv = Conversation(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type=conv_type)
+    session.add(conv)
+    await session.commit()
+    return conv.id
+
+
+async def _seed_org_owner(session, org_id, *, role="owner"):
+    from app.models.project import OrgMember
+
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=uuid.uuid4(), role=role)
+    session.add(om)
+    await session.commit()
+    return om.id
+
+
+async def _seed_messages(session, conversation_id, sender_id, count, *, ages_seconds=0):
+    """`count`개 메시지를 이 대화에 만든다 — 전부 지금으로부터 `ages_seconds`초 전 시각으로
+    스탬프(속도 윈도우 안/밖 시뮬레이션용, TimestampMixin의 server_default를 명시값으로 override)."""
+    from app.models.conversation import ConversationMessage
+
+    ts = datetime.now(timezone.utc) - timedelta(seconds=ages_seconds)
+    for _ in range(count):
+        session.add(ConversationMessage(
+            id=uuid.uuid4(), conversation_id=conversation_id, sender_id=sender_id,
+            content="msg", created_at=ts,
+        ))
+    await session.commit()
+
+
+async def _seed_org_config(session, org_id, *, enabled=True, window_seconds=300, threshold=15):
+    from app.models.chain_escalation_org_config import ChainEscalationOrgConfig
+
+    session.add(ChainEscalationOrgConfig(
+        id=uuid.uuid4(), org_id=org_id, enabled=enabled,
+        window_seconds=window_seconds, threshold=threshold,
+    ))
+    await session.commit()
+
+
+def _fakeredis_client():
+    aioredis = pytest.importorskip("fakeredis.aioredis")
+    server = aioredis.FakeServer()
+    return aioredis.FakeRedis(server=server, decode_responses=True)
+
+
+# ─── AC1: 정상 fleet 속도 — 알림 0 ─────────────────────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_ac1_normal_velocity_never_notifies():
+    """실측 근거(p99=8/5분) 이하인 5건/5분 — 임계 15 미만이라 여러 번 평가해도 알림 0."""
+    from app.services.chain_escalation import evaluate_unsupervised_chain_episode
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_org_owner(s, org_id, role="owner")
+            agent_id = await _seed_member(s, org_id, project_id)
+            conv_id = await _seed_conversation(s, org_id, project_id)
+            await _seed_messages(s, conv_id, agent_id, 5, ages_seconds=30)  # 5건, 임계(15) 미만
+
+            client = _fakeredis_client()
+            dn = AsyncMock()
+            with patch("app.services.redis_shared.get_client", return_value=client), \
+                 patch("app.services.notification_dispatch.dispatch_notification", dn):
+                for _ in range(10):  # 여러 메시지 평가를 시뮬레이션
+                    await evaluate_unsupervised_chain_episode(
+                        s, org_id=org_id, conversation_id=conv_id, project_id=project_id,
+                    )
+                dn.assert_not_awaited()
+    finally:
+        await engine.dispose()
+
+
+# ─── AC2: 폭주 진입 1회 발화, 진행 중 재발화 없음 ───────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_ac2_burst_fires_once_no_refire_while_continuing():
+    from app.services.chain_escalation import evaluate_unsupervised_chain_episode
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            owner_id = await _seed_org_owner(s, org_id, role="owner")
+            agent_id = await _seed_member(s, org_id, project_id)
+            conv_id = await _seed_conversation(s, org_id, project_id)
+            await _seed_messages(s, conv_id, agent_id, 20, ages_seconds=10)  # 임계(15) 초과
+
+            client = _fakeredis_client()
+            dn = AsyncMock()
+            with patch("app.services.redis_shared.get_client", return_value=client), \
+                 patch("app.services.notification_dispatch.dispatch_notification", dn):
+                await evaluate_unsupervised_chain_episode(
+                    s, org_id=org_id, conversation_id=conv_id, project_id=project_id,
+                )
+                dn.assert_awaited_once()
+                kw = dn.await_args.kwargs
+                assert kw["target_member_ids"] == [owner_id]
+                assert kw["event_type"] == "conversation.unsupervised_chain_expired"
+
+                # 같은 에피소드 진행 중(여전히 폭주 상태) — 재평가해도 재발화 없음.
+                await evaluate_unsupervised_chain_episode(
+                    s, org_id=org_id, conversation_id=conv_id, project_id=project_id,
+                )
+                await evaluate_unsupervised_chain_episode(
+                    s, org_id=org_id, conversation_id=conv_id, project_id=project_id,
+                )
+                dn.assert_awaited_once(), "같은 에피소드 진행 중엔 재발화 금지"
+    finally:
+        await engine.dispose()
+
+
+# ─── AC3: 해소 후 재폭주만 재발화 ───────────────────────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_ac3_resolve_then_reburst_refires():
+    """해소(임계 이하로 복귀) 평가 — 무알림 clear. 그 다음 재폭주만 새 에피소드로 재발화.
+
+    이 테스트는 에피소드 마커의 resolve→refire 메커니즘 자체를 격리 검증한다 — 15분
+    플래핑 쿨다운(별도 축, test_flap_cooldown_*가 검증)은 실제로는 이 짧은 재발화 간격도
+    억제할 것이므로(의도된 동작, 플래핑 방지가 AC3보다 우선) 여기서는 쿨다운 클레임을
+    항상 성공으로 고정해 마커 상태기계만 본다."""
+    from app.services.chain_escalation import evaluate_unsupervised_chain_episode
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_org_owner(s, org_id, role="owner")
+            agent_id = await _seed_member(s, org_id, project_id)
+            conv_burst = await _seed_conversation(s, org_id, project_id)
+            await _seed_messages(s, conv_burst, agent_id, 20, ages_seconds=10)
+
+            client = _fakeredis_client()
+            dn = AsyncMock()
+            with patch("app.services.redis_shared.get_client", return_value=client), \
+                 patch("app.services.notification_dispatch.dispatch_notification", dn), \
+                 patch("app.services.chain_escalation._claim_flap_cooldown_slot", return_value=True):
+                await evaluate_unsupervised_chain_episode(
+                    s, org_id=org_id, conversation_id=conv_burst, project_id=project_id,
+                )
+                dn.assert_awaited_once()
+
+                # 해소 — 다음 평가 시점엔 이 conv의 최근 메시지가 창 밖(오래됨)이라 속도 0.
+                # 새 conversation_id로 "해소된 대화"를 시뮬레이션(같은 conv_id 재사용 시
+                # 이미 심은 20건이 계속 카운트돼 해소를 못 만든다 — 별도 conv로 클린 해소).
+                conv_resolved_key = conv_burst  # 마커는 conv_id 키니 같은 키로 낮은 속도 평가.
+
+                async def _low_velocity(db, conversation_id, window_seconds):  # noqa: ARG001
+                    return 2  # 임계(15) 미만
+
+                with patch(
+                    "app.services.chain_escalation._recent_message_velocity",
+                    side_effect=_low_velocity,
+                ):
+                    await evaluate_unsupervised_chain_episode(
+                        s, org_id=org_id, conversation_id=conv_resolved_key, project_id=project_id,
+                    )
+                dn.assert_awaited_once(), "해소 평가 자체는 무알림(clear만)"
+
+                # 재폭주 — 마커가 해소로 지워졌으니 새 에피소드로 재발화.
+                await evaluate_unsupervised_chain_episode(
+                    s, org_id=org_id, conversation_id=conv_burst, project_id=project_id,
+                )
+                assert dn.await_count == 2, "해소 후 재폭주는 새 에피소드로 재발화돼야"
+    finally:
+        await engine.dispose()
+
+
+# ─── TTL: 침묵 종료도 자연 소멸(stale 마커가 다음 폭주를 영구 억제하면 안 됨) ──────
+
+@pytest.mark.anyio
+async def test_episode_marker_ttl_set_and_refreshed():
+    """마커 생성 시 TTL=window*2, 재평가(진행 중)마다 TTL 갱신 — 침묵(다음 평가가 영영 안
+    옴)이어도 TTL이 지나면 Redis가 자연 소멸시켜 다음 폭주 알림을 억제하지 않는다."""
+    from app.services.chain_escalation import _evaluate_episode_marker
+
+    client = _fakeredis_client()
+    conv_id = uuid.uuid4()
+    with patch("app.services.redis_shared.get_client", return_value=client):
+        state = await _evaluate_episode_marker(conv_id, above_threshold=True, ttl_seconds=600)
+        assert state == "started"
+
+        from app.services import redis_shared
+        key = redis_shared.key("chain_escalation", "episode", str(conv_id))
+        ttl1 = await client.ttl(key)
+        assert 0 < ttl1 <= 600, "새 마커는 TTL이 걸려 있어야(침묵 시 자연 소멸)"
+
+        # 진행 중 재평가 — TTL이 갱신(리셋)돼야 폭주가 계속되는 동안은 안 죽는다.
+        state2 = await _evaluate_episode_marker(conv_id, above_threshold=True, ttl_seconds=600)
+        assert state2 == "continuing"
+        ttl2 = await client.ttl(key)
+        assert ttl2 > 0
+
+
+@pytest.mark.anyio
+async def test_episode_marker_resolved_deletes_key_idle_when_absent():
+    from app.services.chain_escalation import _evaluate_episode_marker
+
+    client = _fakeredis_client()
+    conv_id = uuid.uuid4()
+    with patch("app.services.redis_shared.get_client", return_value=client):
+        assert await _evaluate_episode_marker(conv_id, above_threshold=False, ttl_seconds=600) == "idle"
+        assert await _evaluate_episode_marker(conv_id, above_threshold=True, ttl_seconds=600) == "started"
+        assert await _evaluate_episode_marker(conv_id, above_threshold=False, ttl_seconds=600) == "resolved"
+        assert await _evaluate_episode_marker(conv_id, above_threshold=False, ttl_seconds=600) == "idle"
+
+
+# ─── org 설정 표면 ──────────────────────────────────────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_org_config_disabled_suppresses_even_above_default_threshold():
+    from app.services.chain_escalation import evaluate_unsupervised_chain_episode
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_org_owner(s, org_id, role="owner")
+            agent_id = await _seed_member(s, org_id, project_id)
+            conv_id = await _seed_conversation(s, org_id, project_id)
+            await _seed_messages(s, conv_id, agent_id, 50, ages_seconds=10)  # 명백한 폭주
+            await _seed_org_config(s, org_id, enabled=False)
+
+            client = _fakeredis_client()
+            dn = AsyncMock()
+            with patch("app.services.redis_shared.get_client", return_value=client), \
+                 patch("app.services.notification_dispatch.dispatch_notification", dn):
+                await evaluate_unsupervised_chain_episode(
+                    s, org_id=org_id, conversation_id=conv_id, project_id=project_id,
+                )
+                dn.assert_not_awaited(), "org enabled=False면 임계 초과여도 무발화"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_org_config_custom_threshold_overrides_default():
+    """org별 threshold=3으로 낮추면, 기본값(15)에서는 정상이었을 5건도 폭주로 판정."""
+    from app.services.chain_escalation import evaluate_unsupervised_chain_episode
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_org_owner(s, org_id, role="owner")
+            agent_id = await _seed_member(s, org_id, project_id)
+            conv_id = await _seed_conversation(s, org_id, project_id)
+            await _seed_messages(s, conv_id, agent_id, 5, ages_seconds=10)
+            await _seed_org_config(s, org_id, enabled=True, window_seconds=300, threshold=3)
+
+            client = _fakeredis_client()
+            dn = AsyncMock()
+            with patch("app.services.redis_shared.get_client", return_value=client), \
+                 patch("app.services.notification_dispatch.dispatch_notification", dn):
+                await evaluate_unsupervised_chain_episode(
+                    s, org_id=org_id, conversation_id=conv_id, project_id=project_id,
+                )
+                dn.assert_awaited_once(), "org 임계를 3으로 낮추면 5건도 폭주로 잡혀야"
+    finally:
+        await engine.dispose()
+
+
+# ─── 15분 플래핑 쿨다운 ─────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_flap_cooldown_blocks_rapid_reflare_but_marker_still_tracks():
+    """같은 15분 창 안 두 번째 «새 에피소드»(해소→재폭주 플래핑)는 마커는 정상 갱신되지만
+    실 알림은 쿨다운에 막힌다 — 플래핑이 알림 폭주로 안 새는 안전망."""
+    from app.services.chain_escalation import _claim_flap_cooldown_slot
+
+    client = _fakeredis_client()
+    conv_id = uuid.uuid4()
+    with patch("app.services.redis_shared.get_client", return_value=client):
+        assert await _claim_flap_cooldown_slot(conv_id) is True, "첫 클레임은 성공"
+        assert await _claim_flap_cooldown_slot(conv_id) is False, "쿨다운 중 재클레임은 실패"
+
+        other_conv = uuid.uuid4()
+        assert await _claim_flap_cooldown_slot(other_conv) is True, "쿨다운 키는 대화별 독립"
+
+
+# ─── Redis 다운 fail-closed ─────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_redis_down_fails_closed_no_notification():
+    from app.services.chain_escalation import evaluate_unsupervised_chain_episode
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=RuntimeError("should not query DB before redis check matters"))
+    dn = AsyncMock()
+
+    async def _fake_get_org_config(db, org_id):  # noqa: ARG001
+        return True, 300, 15
+
+    async def _fake_velocity(db, conversation_id, window_seconds):  # noqa: ARG001
+        return 999  # 명백한 폭주
+
+    with patch("app.services.redis_shared.get_client", return_value=None), \
+         patch("app.services.notification_dispatch.dispatch_notification", dn), \
+         patch("app.services.chain_escalation._get_org_config", side_effect=_fake_get_org_config), \
+         patch("app.services.chain_escalation._recent_message_velocity", side_effect=_fake_velocity):
+        await evaluate_unsupervised_chain_episode(
+            session, org_id=uuid.uuid4(), conversation_id=uuid.uuid4(), project_id=uuid.uuid4(),
+        )
+    dn.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_swallows_exceptions_best_effort():
+    """알림 경로 예외는 메시지 발신을 막지 않는다 — best-effort(다른 doc.py 알림 경로와 동형)."""
+    from app.services.chain_escalation import evaluate_unsupervised_chain_episode
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=RuntimeError("boom"))
+    await evaluate_unsupervised_chain_episode(
+        session, org_id=uuid.uuid4(), conversation_id=uuid.uuid4(), project_id=uuid.uuid4(),
+    )  # 예외 전파 없이 조용히 반환

--- a/backend/tests/test_check_env_drift_settings_coverage.py
+++ b/backend/tests/test_check_env_drift_settings_coverage.py
@@ -165,10 +165,11 @@ def test_settings_field_env_keys_works_without_pydantic_settings_importable(monk
     # 핫픽스(2026-08-13, 선생님 직접 지시): agent_group_default_mentions 필드 신설로 93→94
     # (AGENT_GROUP_DEFAULT_MENTIONS 포함) — #2603 그룹챗 mentions 기본계약을 opt-in으로
     # 되돌리는 kill switch(기본 False). 가드가 신규 필드를 설계대로 잡은 것.
-    # 핫픽스(2026-08-13, 선생님 직접 지시②): chain_escalation_notify_enabled 필드 신설로
-    # 94→95(CHAIN_ESCALATION_NOTIFY_ENABLED 포함) — #2617 human-less chain escalation
-    # 알림이 에피소드 개념 없이 상시 재발화해 폭주를 냈다 — 재설계 전까지 발화만 차단하는
-    # kill switch(기본 False). 가드가 신규 필드를 설계대로 잡은 것.
+    # story #2626(2026-08-13, PO 승인): chain_escalation_notify_enabled 필드 은퇴로 95→94
+    # (CHAIN_ESCALATION_NOTIFY_ENABLED 제거) — 무감독 연쇄 알림이 속도 기반 에피소드
+    # 탐지+org별 설정(chain_escalation_org_config 테이블)으로 재설계되며, 글로벌 killswitch가
+    # org-level enabled로 완전히 대체됐다(반쪽 은퇴 금지, PO 조건① — 필드·이 가드·테스트
+    # patch 전부 같이 걷었다). 가드가 필드 제거도 정확히 잡은 것(드리프트 양방향 커버).
     assert "PRESENCE_REDIS_ENABLED" in keys and "SSE_TRANSIENT_REPLAY_ENABLED" in keys
     assert "REQUIRE_VERIFIED_EMAIL_FOR_ORG_CREATE" in keys
     assert "DATABASE_URL_READ" in keys
@@ -178,5 +179,5 @@ def test_settings_field_env_keys_works_without_pydantic_settings_importable(monk
     assert "ORG_BILLING_KEY_ENCRYPTION_KEY" in keys
     assert "TOSS_WEBHOOK_SECRET" in keys
     assert "AGENT_GROUP_DEFAULT_MENTIONS" in keys
-    assert "CHAIN_ESCALATION_NOTIFY_ENABLED" in keys
-    assert len(keys) == 95
+    assert "CHAIN_ESCALATION_NOTIFY_ENABLED" not in keys
+    assert len(keys) == 94


### PR DESCRIPTION
## 요약
story #2626 — 무감독 연쇄 알림(#2617)의 트리거를 depth-cap(#2608, human-less 대화에서 영구 참인 상시 상태)에서 **속도 기반 이상 에피소드**로 완전 교체. #3016 킬스위치(`settings.chain_escalation_notify_enabled`, 기본 False) 완전 은퇴 — org-level 설정으로 대체.

## 배경
#2617의 escalation이 «무감독 연쇄 감지» 푸시 폭주를 냈다(선생님 실사용 제보). 라이브 진단(pgstat-probe-dev)으로 dedup 메커니즘 자체는 정상 작동을 확인했으나, 근본 원인은 게이트 조건(`depth > cap`)이 human-less 대화에서 **영구 참인 상시 상태**라는 구조 결함이었다 — 24h dedup은 스팸의 «주기»만 하루 단위로 미룰 뿐, 모든 human-less 대화가 매일 재발화했다. #3016으로 발화만 킬스위치 차단(기본 False)해 두고 이 PR로 재설계.

## 설계
- **감지축**: 속도(5분 슬라이딩 윈도우 메시지 수) 단독. 패턴/콘텐츠 유사도 축은 스코프 밖(story AC가 요구하는 "A↔B 고속 반복" 재현은 속도축으로 충분·오탐 리스크 큰 콘텐츠 판정은 별도 축).
- **임계값**: 기본 5분/15건 — 실측 근거(pgstat-probe-dev, 무인간 대화 44개·7일·3123메시지): 5분 윈도우 내 최대 메시지수 p50=3·p90=6·p99=8·관측 max=8. 기본 임계는 관측 max의 ~2배 여유.
- **에피소드 상태기계**(Redis, `chain_escalation.py::_evaluate_episode_marker`): 임계 초과+마커 없음→새 에피소드(발화)·마커 있음→진행 중(무발화, TTL만 갱신)·임계 이하+마커 있음→해소(무알림 삭제)·임계 이하+마커 없음→평상.
- **TTL(PO 필수 조건)**: 마커 TTL=윈도우×2, 활성 평가마다 갱신 — 폭주가 멈추고 대화 자체가 조용해지면(해소를 평가할 다음 메시지가 영영 안 옴) TTL이 자연 소멸시켜 stale 마커가 다음 진짜 폭주의 알림을 영구 억제하는 결함을 구조로 방지.
- **15분 플래핑 쿨다운**: 에피소드 상태와 별개 레이어 — 임계 바로 위/아래로 진동하는 신호가 에피소드를 빠르게 여닫아도 실 알림은 15분당 최대 1건(`_claim_flap_cooldown_slot`).
- **org 설정 표면**: `chain_escalation_org_config`(신규 테이블, `org_gate_policy`와 동형 패턴 — org_id unique, `enabled`/`window_seconds`/`threshold`, 행 없으면 코드 기본값 폴백).
- **트리거 위치**: `conversations.py`의 기존 호출부를 depth-cap 블록 밖으로 이동 — depth 카운트(#2608, human_intervention_requested용)와 완전히 분리된 독립 트리거. human-less 대화의 매 agent 메시지마다 평가.

## 행동 변경 선언 (PO 확定, 2026-08-13)
- **org 기본 `enabled=True`로 상륙** — #3016 글로벌 킬스위치(기본 off)를 org-level 설정이 대체하며 기본값이 뒤집힌다. AC1(정상 fleet 알림 0, 실측 임계 여유 2배)이 안전망.
- **후속 검증(필수, 확認②)**: 상륙 후 24h 우리 fleet 알림 0건을 실측으로 확認 — 별도로 보고.

## 킬스위치 완전 은퇴 (확認①)
`settings.chain_escalation_notify_enabled` 필드·drift-coverage 테스트 카운트(95→94)·`test_2617_chain_escalation.py`의 `_ESCALATION_ON` patch 전부 같이 제거 — 반쪽 은퇴("은퇴했는데 주소가 살아있다") 방지.

## 변경 파일
- `app/models/chain_escalation_org_config.py`(신규) + `alembic/versions/0243_chain_escalation_org_config.py`
- `app/services/chain_escalation.py` — `escalate_unsupervised_chain` → `evaluate_unsupervised_chain_episode`로 전면 재작성(에피소드 상태기계·org config·플래핑 쿨다운)
- `app/routers/conversations.py` — 호출부를 depth-cap 블록 밖으로 이동(트리거 완전 교체)
- `app/core/config.py` — `chain_escalation_notify_enabled` 필드 제거
- `tests/test_2617_chain_escalation.py` — `_conversation_has_human` 판정 축만 남기고 트리밍(에피소드 테스트는 신규 파일로 이전)
- `tests/test_2626_chain_escalation_episode.py`(신규, 10건) — AC1(정상 속도 무알림)·AC2(에피소드 1회 발화·진행 중 무재발화)·AC3(해소 후 재폭주 재발화)·TTL 생성/갱신/해소·org 설정 오버라이드(disabled·custom threshold)·플래핑 쿨다운·Redis 다운 fail-closed·예외 best-effort
- `tests/test_check_env_drift_settings_coverage.py` — 95→94, `CHAIN_ESCALATION_NOTIFY_ENABLED not in keys`

## 검증
- 신규 10건 + `_conversation_has_human` 3건 전부 실PG green.
- revert-and-confirm: `chain_escalation.py`를 되돌리면(구 `escalate_unsupervised_chain`) 신규 10건 전부 ImportError로 RED 확인 → 복원 후 GREEN.
- `test_2608_human_intervention_dispatch.py`·`test_2608_chain_depth.py`·`test_channel_router_multiproject_sender.py`·`test_2617_fleet_roundtrip_realdb.py`·`test_deeplink_manifest_*.py` 무회귀 확인(alembic 재마이그 후 재검증 — destructive_schema 테스트가 컨테이너 스키마를 create_all로 리셋해 alembic-migrated 스키마 의존 테스트와 순서 충돌하는 것 확인·재-migrate로 해소, 로컬 검증 특이사항).
- alembic upgrade head(0242→0243) 클린 적용 확인.
