### PR TITLE
[SID:2630] chain circuit breaker — block agent sends during unsupervised storm episodes

### DIFF
--- a/backend/alembic/versions/0244_chain_circuit_breaker.py
+++ b/backend/alembic/versions/0244_chain_circuit_breaker.py
@@ -1,0 +1,81 @@
+"""story #2630: chain_circuit_breaker + chain_escalation_org_config 서킷브레이커 설정.
+
+Revision ID: 0244
+Revises: 0243
+Create Date: 2026-08-13
+
+#2626 org 설정(chain_escalation_org_config)에 circuit_breaker_mode/circuit_breaker_release_mode
+2컬럼 추가 + 신규 chain_circuit_breaker 테이블(대화당 open 행 최대 1개, 부분 unique index).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0244"
+down_revision = "0243"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chain_escalation_org_config",
+        sa.Column("circuit_breaker_mode", sa.Text(), nullable=False, server_default="block"),
+    )
+    op.add_column(
+        "chain_escalation_org_config",
+        sa.Column("circuit_breaker_release_mode", sa.Text(), nullable=False, server_default="manual"),
+    )
+    op.create_check_constraint(
+        "ck_chain_escalation_org_config_circuit_breaker_mode",
+        "chain_escalation_org_config",
+        "circuit_breaker_mode IN ('block', 'notify_only')",
+    )
+    op.create_check_constraint(
+        "ck_chain_escalation_org_config_circuit_breaker_release_mode",
+        "chain_escalation_org_config",
+        "circuit_breaker_release_mode IN ('manual', 'auto')",
+    )
+
+    op.create_table(
+        "chain_circuit_breaker",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("conversation_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("opened_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("released_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("released_by", UUID(as_uuid=True), nullable=True),
+        sa.Column("release_reason", sa.Text(), nullable=True),
+    )
+    op.create_index("ix_chain_circuit_breaker_org_id", "chain_circuit_breaker", ["org_id"])
+    op.create_index("ix_chain_circuit_breaker_conversation_id", "chain_circuit_breaker", ["conversation_id"])
+    op.create_index(
+        "uq_chain_circuit_breaker_open_conversation",
+        "chain_circuit_breaker",
+        ["conversation_id"],
+        unique=True,
+        postgresql_where=sa.text("released_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_chain_circuit_breaker_open_conversation", table_name="chain_circuit_breaker")
+    op.drop_index("ix_chain_circuit_breaker_conversation_id", table_name="chain_circuit_breaker")
+    op.drop_index("ix_chain_circuit_breaker_org_id", table_name="chain_circuit_breaker")
+    op.drop_table("chain_circuit_breaker")
+
+    op.drop_constraint(
+        "ck_chain_escalation_org_config_circuit_breaker_release_mode",
+        "chain_escalation_org_config",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_chain_escalation_org_config_circuit_breaker_mode",
+        "chain_escalation_org_config",
+        type_="check",
+    )
+    op.drop_column("chain_escalation_org_config", "circuit_breaker_release_mode")
+    op.drop_column("chain_escalation_org_config", "circuit_breaker_mode")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -96,6 +96,7 @@ from app.models.visual_artifact import ArtifactNode, ArtifactVersion, VisualArti
 from app.models.hitl_config import MemberGateOverride, OrgGateOverride, OrgGatePolicy
 from app.models.participation import Participation, ParticipationRole
 from app.models.chain_escalation_org_config import ChainEscalationOrgConfig
+from app.models.chain_circuit_breaker import ChainCircuitBreaker
 
 __all__ = [
     "RoleTemplate",

--- a/backend/app/models/chain_circuit_breaker.py
+++ b/backend/app/models/chain_circuit_breaker.py
@@ -1,0 +1,48 @@
+"""story #2630: 폭주 에피소드 «자동 차단»(서킷브레이커) — human-less 대화 agent 발신 차단.
+
+#2626 에피소드 판별자(chain_escalation.py, Redis 마커) 위에 얹는 집행 계층. Redis TTL이
+아니라 이 테이블 행의 존재가 서킷 open의 SSOT다 — release_mode='manual'인 org는 에피소드가
+속도축에서 자연 해소(Redis 마커 삭제)돼도 서킷은 계속 열려 있어야 하는데(사람이 아직 안
+눌렀으니), TTL 붙은 캐시로는 그 요구를 못 담는다(자동 만료가 "해제"를 오독).
+
+conversation_id당 released_at IS NULL 행은 항상 최대 1개(부분 unique index, 아래) — 발신
+차단 체크(conversations.py send_message)가 이 인덱스로 O(1) 조회한다. 이 행이 human-less
+대화에서만 열리므로(오픈 호출부가 이미 그 조건을 확인한 뒤에만 부른다), 존재 자체가
+"이 대화는 human-less"를 함의한다 — 발신 체크가 별도 human 유무 조회를 안 해도 되는 이유.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Index, Text, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class ChainCircuitBreaker(Base):
+    """org당 다수(대화당 최대 1개 open) — 폭주 에피소드가 연 서킷의 open/release 기록."""
+    __tablename__ = "chain_circuit_breaker"
+    __table_args__ = (
+        Index(
+            "uq_chain_circuit_breaker_open_conversation",
+            "conversation_id",
+            unique=True,
+            postgresql_where=text("released_at IS NULL"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    conversation_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    opened_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=text("now()"), nullable=False
+    )
+    released_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # human-only(is_org_owner_or_admin) 릴리즈만 채운다 — auto-release(에피소드 자연 해소)는
+    # NULL로 남아 "누가 눌렀나"와 "자동 해소됐다"를 released_by 유무만으로 구분할 수 있다.
+    released_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    release_reason: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/models/chain_escalation_org_config.py
+++ b/backend/app/models/chain_escalation_org_config.py
@@ -1,13 +1,19 @@
-"""story #2626: 무감독 연쇄 알림(에피소드 기반)의 org 설정 표면.
+"""story #2626/#2630: 무감독 연쇄 알림(에피소드 기반) + 서킷브레이커(집행)의 org 설정 표면.
 
 `OrgGatePolicy`(hitl_config.py)와 동형 패턴 — org당 1행, 없으면 코드 기본값 폴백. #3016
 글로벌 killswitch(`settings.chain_escalation_notify_enabled`)를 이 org-level `enabled`가
 대체·은퇴한다(반쪽 은퇴 방지 — PO 조건①).
+
+story #2630: `circuit_breaker_mode`/`circuit_breaker_release_mode`는 #2626 판별자(에피소드)
+위에 얹는 집행 축 — `enabled`가 false면 판별 자체가 안 도니 이 둘은 안 쓰인다(판별 없이
+집행 없음). release_mode 기본이 'manual'인 근거: auto는 "차단이 만든 침묵을 해소로 오독"
+하는 되먹임이 있다(차단→velocity 하락→에피소드 해소→auto 해제→폭주 재개→재차단 — 폭주가
+안 죽고 듀티사이클로 산다, 페드루 판정 2026-08-13). auto는 org 옵트인.
 """
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, Integer, func
+from sqlalchemy import Boolean, CheckConstraint, DateTime, Integer, Text, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -17,11 +23,26 @@ from app.core.database import Base
 # p50=3·p90=6·p99=8·관측 max=8. 기본 임계는 관측 max의 ~2배 여유(PO 승인 2026-08-13).
 DEFAULT_WINDOW_SECONDS = 300
 DEFAULT_THRESHOLD = 15
+# story #2630: 기본 on(block) — 스토리 원문 AC3 "차단이 원 목표". notify_only는 관측만
+# 하던 #2626 구모드로 되돌리는 org 옵트아웃.
+DEFAULT_CIRCUIT_BREAKER_MODE = "block"
+# story #2630: 기본 manual — 위 모듈 docstring의 듀티사이클 되먹임 근거.
+DEFAULT_CIRCUIT_BREAKER_RELEASE_MODE = "manual"
 
 
 class ChainEscalationOrgConfig(Base):
-    """org 수준 무감독 연쇄 알림 설정 — org당 1행. 없으면 위 DEFAULT_* 폴백."""
+    """org 수준 무감독 연쇄 알림+서킷브레이커 설정 — org당 1행. 없으면 위 DEFAULT_* 폴백."""
     __tablename__ = "chain_escalation_org_config"
+    __table_args__ = (
+        CheckConstraint(
+            "circuit_breaker_mode IN ('block', 'notify_only')",
+            name="ck_chain_escalation_org_config_circuit_breaker_mode",
+        ),
+        CheckConstraint(
+            "circuit_breaker_release_mode IN ('manual', 'auto')",
+            name="ck_chain_escalation_org_config_circuit_breaker_release_mode",
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, unique=True, index=True)
@@ -30,6 +51,12 @@ class ChainEscalationOrgConfig(Base):
         Integer, nullable=False, server_default=str(DEFAULT_WINDOW_SECONDS)
     )
     threshold: Mapped[int] = mapped_column(Integer, nullable=False, server_default=str(DEFAULT_THRESHOLD))
+    circuit_breaker_mode: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=DEFAULT_CIRCUIT_BREAKER_MODE
+    )
+    circuit_breaker_release_mode: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=DEFAULT_CIRCUIT_BREAKER_RELEASE_MODE
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -2046,30 +2046,6 @@ async def send_message(
 
     sender = await _resolve_member(auth, org_id, db, project_id=conv.project_id)
 
-    # story #2630: 서킷브레이커 발신 차단 — human-less 대화에서 폭주 에피소드가 열려 있으면
-    # agent 발신을 여기서 막는다(참가자 auto-join 등 어떤 write도 하기 전, 최대한 이르게 —
-    # 막힌 시도가 부수 상태를 안 남기게). human 발신은 이 체크 대상이 아니다(페드루 필수수정
-    # 2026-08-13): 서킷이 연 방에 사람이 들어와 개입하려는 발화까지 막으면 안 된다 — 사람의
-    # 개입이 사태 수습의 정공 경로고, human 늦참여 자동해제를 v1 밖으로 미룬 것과도 정합
-    # (사람이 말은 할 수 있으니 해제 버튼 누를 판단도 대화 안에서 가능). breaker 행은
-    # human-less 대화에서만 열리므로(open 호출부 조건) 이 조회 결과가 있다는 것 자체가
-    # "이 대화는 human-less"를 함의 — 별도 human 유무 쿼리 불요.
-    if sender.type == "agent":
-        from app.services.chain_escalation import get_open_circuit_breaker_id
-
-        open_breaker_id = await get_open_circuit_breaker_id(db, conversation_id)
-        if open_breaker_id is not None:
-            raise HTTPException(
-                status_code=423,
-                detail={
-                    "error": "circuit_breaker_open",
-                    "message": "폭주 감지로 이 대화의 agent 발신이 일시 차단되었습니다 — "
-                                "org owner/admin의 해제 또는 자동 해소를 기다려주세요.",
-                    "conversation_id": str(conversation_id),
-                    "circuit_breaker_id": str(open_breaker_id),
-                },
-            )
-
     # 참여자 검증
     participant = (await db.execute(
         select(ConversationParticipant.id).where(
@@ -2086,6 +2062,31 @@ async def send_message(
             await db.flush()
         else:
             raise HTTPException(status_code=403, detail="Not a participant")
+
+    # story #2630: 서킷브레이커 발신 차단 — human-less 대화에서 폭주 에피소드가 열려 있으면
+    # agent 발신을 여기서 막는다. 참가자 검증 다음(비참여자는 그 이유로 이미 403 — 참여자
+    # 여부와 무관한 사실인 서킷 상태를 그보다 먼저 노출할 이유가 없다), 그 뒤의 실 side-effect
+    # (working clear 등) 이전 — 막힌 시도가 부수 상태를 안 남기게. human 발신은 이 체크
+    # 대상이 아니다(페드루 필수수정 2026-08-13): 서킷이 연 방에 사람이 들어와 개입하려는
+    # 발화까지 막으면 안 된다 — 사람의 개입이 사태 수습의 정공 경로고, human 늦참여
+    # 자동해제를 v1 밖으로 미룬 것과도 정합(사람이 말은 할 수 있으니 해제 버튼 누를 판단도
+    # 대화 안에서 가능). breaker 행은 human-less 대화에서만 열리므로(open 호출부 조건) 이
+    # 조회 결과가 있다는 것 자체가 "이 대화는 human-less"를 함의 — 별도 human 유무 쿼리 불요.
+    if sender.type == "agent":
+        from app.services.chain_escalation import get_open_circuit_breaker_id
+
+        open_breaker_id = await get_open_circuit_breaker_id(db, conversation_id)
+        if open_breaker_id is not None:
+            raise HTTPException(
+                status_code=423,
+                detail={
+                    "error": "circuit_breaker_open",
+                    "message": "폭주 감지로 이 대화의 agent 발신이 일시 차단되었습니다 — "
+                                "org owner/admin의 해제 또는 자동 해소를 기다려주세요.",
+                    "conversation_id": str(conversation_id),
+                    "circuit_breaker_id": str(open_breaker_id),
+                },
+            )
 
     # 1aeecdde P2: sender 가 이 conversation 에 메시지를 보냄 = 답장 생성 종료 → working clear.
     # fork 분기(아래) 전 **원본 conversation_id** 기준 — working 은 그 conversation 에 set 됐다.

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -40,7 +40,7 @@ from app.services.member_resolver import (
     resolve_member,
     resolve_member_identity,
 )
-from app.services.project_auth import project_access_valid_correlated
+from app.services.project_auth import is_org_owner_or_admin, project_access_valid_correlated
 from app.services.storage import get_storage_provider
 
 logger = logging.getLogger(__name__)
@@ -1050,6 +1050,12 @@ class MarkReadRequest(BaseModel):
     up_to: datetime | None = None
 
 
+class CircuitBreakerReleaseRequest(BaseModel):
+    """story #2630: 서킷브레이커 수동 해제 — reason은 감사 표시용(선택)."""
+
+    reason: str | None = None
+
+
 # ─── Endpoints ────────────────────────────────────────────────────────────────
 
 @router.post("", status_code=201)
@@ -1893,6 +1899,47 @@ async def mark_conversation_read(
     }
 
 
+@router.post("/{conversation_id}/circuit-breaker/release")
+async def release_circuit_breaker_endpoint(
+    conversation_id: uuid.UUID,
+    body: CircuitBreakerReleaseRequest,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """POST /api/v2/conversations/{id}/circuit-breaker/release — story #2630 수동 해제.
+
+    무감독 연쇄 알림(conversation.circuit_breaker_opened)의 «차단 해제» 액션이 이 엔드포인트를
+    친다. **human org owner/admin 전용**(gates.py transition_gate_endpoint의 93fc7aeb 선례와
+    동형 이유 — 서킷 open 대화는 정의상 human-less라 참가자 기반 authz가 성립 안 하고, 무엇보다
+    "agent가 자기 서킷을 스스로 풀 수 있으면 안전망 자체가 무의미"하다). `is_org_owner_or_admin`
+    은 human 전용을 명시 강제(agent auth는 애초에 매치 불가 — 함수 자체 불변식).
+
+    멱등: 이미 닫혀 있으면(중복 클릭·레이스) 200 + released=false로 응답, 에러 아님.
+    """
+    conv = (await db.execute(
+        select(Conversation).where(Conversation.id == conversation_id, Conversation.org_id == org_id)
+    )).scalar_one_or_none()
+    if conv is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    if not await is_org_owner_or_admin(db, uuid.UUID(auth.user_id), org_id):
+        raise HTTPException(
+            status_code=403,
+            detail="서킷브레이커 해제는 org owner/admin만 가능합니다.",
+        )
+
+    sender = await _resolve_member(auth, org_id, db, project_id=conv.project_id)
+
+    from app.services.chain_escalation import release_circuit_breaker
+
+    released = await release_circuit_breaker(
+        db, conversation_id=conversation_id, released_by=sender.id, reason=body.reason,
+    )
+    await db.commit()
+    return {"conversation_id": str(conversation_id), "released": released}
+
+
 @router.post("/{conversation_id}/participants", status_code=201)
 async def add_participant(
     conversation_id: uuid.UUID,
@@ -1998,6 +2045,30 @@ async def send_message(
         raise HTTPException(status_code=404, detail="Conversation not found")
 
     sender = await _resolve_member(auth, org_id, db, project_id=conv.project_id)
+
+    # story #2630: 서킷브레이커 발신 차단 — human-less 대화에서 폭주 에피소드가 열려 있으면
+    # agent 발신을 여기서 막는다(참가자 auto-join 등 어떤 write도 하기 전, 최대한 이르게 —
+    # 막힌 시도가 부수 상태를 안 남기게). human 발신은 이 체크 대상이 아니다(페드루 필수수정
+    # 2026-08-13): 서킷이 연 방에 사람이 들어와 개입하려는 발화까지 막으면 안 된다 — 사람의
+    # 개입이 사태 수습의 정공 경로고, human 늦참여 자동해제를 v1 밖으로 미룬 것과도 정합
+    # (사람이 말은 할 수 있으니 해제 버튼 누를 판단도 대화 안에서 가능). breaker 행은
+    # human-less 대화에서만 열리므로(open 호출부 조건) 이 조회 결과가 있다는 것 자체가
+    # "이 대화는 human-less"를 함의 — 별도 human 유무 쿼리 불요.
+    if sender.type == "agent":
+        from app.services.chain_escalation import get_open_circuit_breaker_id
+
+        open_breaker_id = await get_open_circuit_breaker_id(db, conversation_id)
+        if open_breaker_id is not None:
+            raise HTTPException(
+                status_code=423,
+                detail={
+                    "error": "circuit_breaker_open",
+                    "message": "폭주 감지로 이 대화의 agent 발신이 일시 차단되었습니다 — "
+                                "org owner/admin의 해제 또는 자동 해소를 기다려주세요.",
+                    "conversation_id": str(conversation_id),
+                    "circuit_breaker_id": str(open_breaker_id),
+                },
+            )
 
     # 참여자 검증
     participant = (await db.execute(

--- a/backend/app/schemas/deeplink_manifest.py
+++ b/backend/app/schemas/deeplink_manifest.py
@@ -696,6 +696,24 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
         ),
+        # story #2630: 서킷브레이커 open — 위 unsupervised_chain_expired와 달리 «관측»이
+        # 아니라 agent 발신이 실제로 막힌 상태다. org owner/admin이 해제(release) 액션을
+        # 취할 수 있어야 풀리므로(manual release_mode가 기본) A2(조치 필요·비긴급) —
+        # SLA성 즉시대응은 아니라 A1은 과함. reference_id는 conversation_id가 아니라
+        # chain_circuit_breaker.id(release 엔드포인트가 그 id로 타겟팅, chain_escalation.py
+        # evaluate_unsupervised_chain_episode 참조) — target은 그래도 chat_thread(탭하면
+        # 그 대화로 이동, 해제 액션 자체는 알림 카드에서).
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="conversation.circuit_breaker_opened", target="chat_thread",
+                parent_tab=ParentTab.chat,
+            ),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a2),
+        ),
 
         # --- goal(epic) ---
         DeepLinkManifestEntry(

--- a/backend/app/services/chain_escalation.py
+++ b/backend/app/services/chain_escalation.py
@@ -25,9 +25,17 @@ human-less 대화에서 **영구 참인 상시 상태**(휴먼 앵커가 없어 
 정상 fleet 트래픽 실측(pgstat-probe-dev, 무인간 대화 44개·7일·3123메시지): 5분 창 내 최대
 메시지수 p50=3·p90=6·p99=8·관측 max=8 — 기본 임계 15는 관측 max의 ~2배 여유(AC1 안전).
 
-⚠️이 알림은 «관측»이지 «차단»이 아니다 — 진짜 A↔B 무한루프가 토큰을 계속 태우는 문제
-자체는 이 스토리 스코프 밖(#2617 스토리 본문 «잔여 위험» 명시, PO 조건(b) — 패턴/콘텐츠
-유사도 기반 탐지는 후속 축, 이번 스코프는 속도축 단독).
+⚠️(story #2626 스코프) 이 알림은 «관측»이지 «차단»이 아니었다 — 집행(차단)은 story #2630
+(아래 `_open_circuit_breaker`/`_auto_close_circuit_breaker` + `chain_circuit_breaker.py`)이
+이 판별자 위에 얹는다. 진짜 A↔B 무한루프가 토큰을 계속 태우는 문제(패턴/콘텐츠 유사도 기반
+탐지)는 여전히 이 모듈 스코프 밖(#2617 스토리 본문 «잔여 위험», 후속 축) — #2630이 닫는
+것은 "속도축 에피소드가 열려 있는 동안 발신을 멈춘다"는 축 하나뿐이다.
+
+story #2630: 서킷브레이커 open/release는 이 모듈이 owns하는 판별 상태기계(에피소드 시작/
+진행/해소)의 **부작용**으로 트리거되지만, 코드는 분리한다(`_open_circuit_breaker`/
+`_auto_close_circuit_breaker`는 판별 로직을 전혀 안 건드리고 옆에서 호출만 받는다) — 위
+"이건 관측이지 차단이 아니다" 경계를 존중해 원 판별 함수(`_evaluate_episode_marker` 등)는
+차단 개념을 모른다.
 """
 from __future__ import annotations
 
@@ -35,7 +43,8 @@ import logging
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
@@ -43,9 +52,12 @@ logger = logging.getLogger(__name__)
 _FLAP_COOLDOWN_SEC = 15 * 60  # 플래핑 방지 — 실 알림은 15분당 최대 1건(#2626, PO 승인).
 
 
-async def _get_org_config(db: AsyncSession, org_id: uuid.UUID) -> tuple[bool, int, int]:
-    """(enabled, window_seconds, threshold) — org 행 없으면 코드 기본값(DEFAULT_*) 폴백."""
+async def _get_org_config(db: AsyncSession, org_id: uuid.UUID) -> tuple[bool, int, int, str, str]:
+    """(enabled, window_seconds, threshold, circuit_breaker_mode, circuit_breaker_release_mode) —
+    org 행 없으면 코드 기본값(DEFAULT_*) 폴백."""
     from app.models.chain_escalation_org_config import (
+        DEFAULT_CIRCUIT_BREAKER_MODE,
+        DEFAULT_CIRCUIT_BREAKER_RELEASE_MODE,
         DEFAULT_THRESHOLD,
         DEFAULT_WINDOW_SECONDS,
         ChainEscalationOrgConfig,
@@ -56,11 +68,60 @@ async def _get_org_config(db: AsyncSession, org_id: uuid.UUID) -> tuple[bool, in
             ChainEscalationOrgConfig.enabled,
             ChainEscalationOrgConfig.window_seconds,
             ChainEscalationOrgConfig.threshold,
+            ChainEscalationOrgConfig.circuit_breaker_mode,
+            ChainEscalationOrgConfig.circuit_breaker_release_mode,
         ).where(ChainEscalationOrgConfig.org_id == org_id)
     )).one_or_none()
     if row is None:
-        return True, DEFAULT_WINDOW_SECONDS, DEFAULT_THRESHOLD
-    return bool(row[0]), int(row[1]), int(row[2])
+        return True, DEFAULT_WINDOW_SECONDS, DEFAULT_THRESHOLD, DEFAULT_CIRCUIT_BREAKER_MODE, DEFAULT_CIRCUIT_BREAKER_RELEASE_MODE
+    return bool(row[0]), int(row[1]), int(row[2]), str(row[3]), str(row[4])
+
+
+async def _open_circuit_breaker(
+    db: AsyncSession, *, org_id: uuid.UUID, conversation_id: uuid.UUID, project_id: uuid.UUID | None,
+) -> uuid.UUID:
+    """story #2630: 서킷 open — 멱등(이미 열려 있으면 그 행을 그대로 반환, 중복 open 없음).
+
+    `chain_circuit_breaker`의 부분 unique index(conversation_id, WHERE released_at IS NULL)가
+    "대화당 open 행 최대 1개"를 DB 레벨로 강제한다. 이게 필요한 이유: release_mode='manual'
+    org에서 에피소드가 자연 해소(마커 삭제)돼도 breaker 행은 안 닫히므로, 다음 재폭주가
+    "started"를 다시 내면 이미 열린(미해제) 행이 있는 상태에서 또 열려는 시도가 된다 —
+    ON CONFLICT DO NOTHING으로 그 재시도를 조용히 흡수하고, 이어지는 SELECT로 (새로 만들었든
+    이미 있었든) 현재 open 행의 id를 얻는다 — 알림 reference_id로 그 id를 써야 하므로."""
+    from app.models.chain_circuit_breaker import ChainCircuitBreaker
+
+    await db.execute(
+        pg_insert(ChainCircuitBreaker.__table__)
+        .values(
+            id=uuid.uuid4(), org_id=org_id, conversation_id=conversation_id, project_id=project_id,
+        )
+        .on_conflict_do_nothing(
+            index_elements=["conversation_id"],
+            index_where=ChainCircuitBreaker.released_at.is_(None),
+        )
+    )
+    breaker_id = (await db.execute(
+        select(ChainCircuitBreaker.id).where(
+            ChainCircuitBreaker.conversation_id == conversation_id,
+            ChainCircuitBreaker.released_at.is_(None),
+        )
+    )).scalar_one()
+    return breaker_id
+
+
+async def _auto_close_circuit_breaker(db: AsyncSession, conversation_id: uuid.UUID) -> None:
+    """story #2630: release_mode='auto' org 전용 — 에피소드 자연 해소 시 열린 breaker를 닫는다.
+    released_by는 NULL로 남긴다(사람이 안 눌렀다는 사실 자체가 감사 대상)."""
+    from app.models.chain_circuit_breaker import ChainCircuitBreaker
+
+    await db.execute(
+        update(ChainCircuitBreaker)
+        .where(
+            ChainCircuitBreaker.conversation_id == conversation_id,
+            ChainCircuitBreaker.released_at.is_(None),
+        )
+        .values(released_at=func.now(), release_reason="auto: episode resolved+cooldown")
+    )
 
 
 async def _recent_message_velocity(
@@ -122,11 +183,16 @@ async def evaluate_unsupervised_chain_episode(
     project_id: uuid.UUID | None,
 ) -> None:
     """human-less 대화의 매 agent 메시지마다 호출 — 속도 기반 이상 에피소드를 평가하고,
-    새 에피소드 시작에서만(+15분 플래핑 쿨다운 통과 시) org owner/admin에게 대화 밖 알림.
-    best-effort — 실패해도 메시지 발신 트랜잭션을 막지 않는다(caller가 savepoint로 격리해
-    호출하는 것을 전제, doc.py의 approval 알림과 동일 관례)."""
+    (story #2630) circuit_breaker_mode='block'이면 에피소드 시작/해소에 서킷 open/auto-close를
+    걸고, 새 에피소드 시작에서만(+15분 플래핑 쿨다운 통과 시) org owner/admin에게 대화 밖
+    알림. best-effort — 실패해도 메시지 발신 트랜잭션을 막지 않는다(caller가 savepoint로
+    격리해 호출하는 것을 전제, doc.py의 approval 알림과 동일 관례).
+
+    ⚠️서킷 open/close는 알림 성패와 독립이다 — 아래에서 flap 쿨다운에 막혀 알림이 스킵돼도
+    breaker는 이미 열려/닫혀 있다(차단 자체는 스팸 방지 쿨다운의 대상이 아니다, "차단이
+    소리 없이 안 걸리는" 사고를 피하려는 순서)."""
     try:
-        enabled, window_seconds, threshold = await _get_org_config(db, org_id)
+        enabled, window_seconds, threshold, cb_mode, cb_release_mode = await _get_org_config(db, org_id)
         if not enabled:
             return
 
@@ -135,11 +201,23 @@ async def evaluate_unsupervised_chain_episode(
         marker_state = await _evaluate_episode_marker(
             conversation_id, above_threshold=above, ttl_seconds=window_seconds * 2,
         )
+
+        if marker_state == "resolved":
+            if cb_release_mode == "auto":
+                await _auto_close_circuit_breaker(db, conversation_id)
+            return  # 해소는 (기존과 동일) 무알림 — release_mode='manual'이면 breaker는 열린 채 남는다.
+
         if marker_state != "started":
-            return  # continuing(이미 알림)·resolved(무알림 해소)·idle(평상) 전부 발화 없음
+            return  # continuing(이미 처리됨)·idle(평상) — 발화도 open도 없음.
+
+        breaker_id: uuid.UUID | None = None
+        if cb_mode == "block":
+            breaker_id = await _open_circuit_breaker(
+                db, org_id=org_id, conversation_id=conversation_id, project_id=project_id,
+            )
 
         if not await _claim_flap_cooldown_slot(conversation_id):
-            return  # 새 에피소드지만 플래핑 쿨다운 중 — 발화 skip(마커는 이미 세워짐)
+            return  # 새 에피소드지만 플래핑 쿨다운 중 — 알림만 skip(breaker는 위에서 이미 열림)
 
         from app.models.project import OrgMember
         from app.services.notification_dispatch import dispatch_notification
@@ -154,15 +232,29 @@ async def evaluate_unsupervised_chain_episode(
         if not approver_ids:
             return
 
-        await dispatch_notification(
-            db, org_id=org_id, event_type="conversation.unsupervised_chain_expired",
-            target_member_ids=list(approver_ids),
-            title="무인간 대화 무감독 연쇄 감지",
-            body=(
+        if breaker_id is not None:
+            event_type = "conversation.circuit_breaker_opened"
+            title = "무인간 대화 자동 차단(서킷브레이커)"
+            body = (
+                f"human 참가자가 없는 대화에서 최근 {window_seconds}초간 메시지 {velocity}건"
+                f"(임계 {threshold})이 발생해 agent 발신이 일시 차단되었습니다. "
+                "이 알림의 «차단 해제»로 즉시 풀 수 있습니다."
+            )
+            reference_id = breaker_id
+        else:
+            event_type = "conversation.unsupervised_chain_expired"
+            title = "무인간 대화 무감독 연쇄 감지"
+            body = (
                 f"human 참가자가 없는 대화에서 최근 {window_seconds}초간 메시지 {velocity}건"
                 f"(임계 {threshold})이 발생했습니다."
-            ),
-            reference_type="conversation", reference_id=conversation_id,
+            )
+            reference_id = conversation_id
+
+        await dispatch_notification(
+            db, org_id=org_id, event_type=event_type,
+            target_member_ids=list(approver_ids),
+            title=title, body=body,
+            reference_type="conversation", reference_id=reference_id,
             source_project_id=project_id,
             via_outbox=True,
         )
@@ -170,3 +262,38 @@ async def evaluate_unsupervised_chain_episode(
         logger.warning(
             "unsupervised chain escalation failed conversation_id=%s", conversation_id, exc_info=True,
         )
+
+
+async def get_open_circuit_breaker_id(db: AsyncSession, conversation_id: uuid.UUID) -> uuid.UUID | None:
+    """story #2630: conversations.py send_message()의 발신-시점 차단 체크가 쓰는 조회.
+
+    이 대화에 released_at IS NULL인 breaker 행이 있으면 그 id, 없으면 None. 이 행은
+    human-less 대화에서만 열리므로(오픈 호출부 위 docstring), 존재 자체가 human-less를
+    함의한다 — caller가 별도로 human 유무를 조회할 필요가 없다."""
+    from app.models.chain_circuit_breaker import ChainCircuitBreaker
+
+    return (await db.execute(
+        select(ChainCircuitBreaker.id).where(
+            ChainCircuitBreaker.conversation_id == conversation_id,
+            ChainCircuitBreaker.released_at.is_(None),
+        )
+    )).scalar_one_or_none()
+
+
+async def release_circuit_breaker(
+    db: AsyncSession, *, conversation_id: uuid.UUID, released_by: uuid.UUID, reason: str | None,
+) -> bool:
+    """story #2630: 수동 해제(알림의 «차단 해제» 액션 → conversations.py release 엔드포인트가
+    호출). 반환값: True=닫힌 open 행이 있었음, False=이미 닫혀 있었음(멱등 — 중복 클릭도
+    에러 없이 no-op)."""
+    from app.models.chain_circuit_breaker import ChainCircuitBreaker
+
+    result = await db.execute(
+        update(ChainCircuitBreaker)
+        .where(
+            ChainCircuitBreaker.conversation_id == conversation_id,
+            ChainCircuitBreaker.released_at.is_(None),
+        )
+        .values(released_at=func.now(), released_by=released_by, release_reason=reason)
+    )
+    return result.rowcount > 0

--- a/backend/app/services/chain_escalation.py
+++ b/backend/app/services/chain_escalation.py
@@ -232,32 +232,37 @@ async def evaluate_unsupervised_chain_episode(
         if not approver_ids:
             return
 
+        # ⚠️deeplink_manifest_contract 스캐너(tests/deeplink_contract_lib.py)가 event_type=을
+        # 정적 분석으로 역추적한다 — 조건부로 만든 지역변수를 kwarg로 넘기면 못 잡는다(리터럴
+        # 아니면 "감싸는 함수의 파라미터"만 해석). 그래서 분기별로 event_type이 리터럴로 보이는
+        # 별도 호출 2개를 둔다(공유 로직 추출 대신 — 스캐너가 요구하는 형태, PR #3022 CI 적발).
         if breaker_id is not None:
-            event_type = "conversation.circuit_breaker_opened"
-            title = "무인간 대화 자동 차단(서킷브레이커)"
-            body = (
-                f"human 참가자가 없는 대화에서 최근 {window_seconds}초간 메시지 {velocity}건"
-                f"(임계 {threshold})이 발생해 agent 발신이 일시 차단되었습니다. "
-                "이 알림의 «차단 해제»로 즉시 풀 수 있습니다."
+            await dispatch_notification(
+                db, org_id=org_id, event_type="conversation.circuit_breaker_opened",
+                target_member_ids=list(approver_ids),
+                title="무인간 대화 자동 차단(서킷브레이커)",
+                body=(
+                    f"human 참가자가 없는 대화에서 최근 {window_seconds}초간 메시지 {velocity}건"
+                    f"(임계 {threshold})이 발생해 agent 발신이 일시 차단되었습니다. "
+                    "이 알림의 «차단 해제»로 즉시 풀 수 있습니다."
+                ),
+                reference_type="conversation", reference_id=breaker_id,
+                source_project_id=project_id,
+                via_outbox=True,
             )
-            reference_id = breaker_id
         else:
-            event_type = "conversation.unsupervised_chain_expired"
-            title = "무인간 대화 무감독 연쇄 감지"
-            body = (
-                f"human 참가자가 없는 대화에서 최근 {window_seconds}초간 메시지 {velocity}건"
-                f"(임계 {threshold})이 발생했습니다."
+            await dispatch_notification(
+                db, org_id=org_id, event_type="conversation.unsupervised_chain_expired",
+                target_member_ids=list(approver_ids),
+                title="무인간 대화 무감독 연쇄 감지",
+                body=(
+                    f"human 참가자가 없는 대화에서 최근 {window_seconds}초간 메시지 {velocity}건"
+                    f"(임계 {threshold})이 발생했습니다."
+                ),
+                reference_type="conversation", reference_id=conversation_id,
+                source_project_id=project_id,
+                via_outbox=True,
             )
-            reference_id = conversation_id
-
-        await dispatch_notification(
-            db, org_id=org_id, event_type=event_type,
-            target_member_ids=list(approver_ids),
-            title=title, body=body,
-            reference_type="conversation", reference_id=reference_id,
-            source_project_id=project_id,
-            via_outbox=True,
-        )
     except Exception:  # noqa: BLE001 — best-effort, 메시지 발신을 막지 않는다.
         logger.warning(
             "unsupervised chain escalation failed conversation_id=%s", conversation_id, exc_info=True,

--- a/backend/tests/test_2626_chain_escalation_episode.py
+++ b/backend/tests/test_2626_chain_escalation_episode.py
@@ -178,7 +178,11 @@ async def test_ac2_burst_fires_once_no_refire_while_continuing():
                 dn.assert_awaited_once()
                 kw = dn.await_args.kwargs
                 assert kw["target_member_ids"] == [owner_id]
-                assert kw["event_type"] == "conversation.unsupervised_chain_expired"
+                # story #2630: org config 미시딩 시 circuit_breaker_mode 기본값이 'block'이라
+                # (AC3 "기본 on이 원 목표") 이젠 서킷도 같이 열리고 이벤트 타입도 그걸 반영한다
+                # — 순수 관측-only 이벤트는 org가 'notify_only'로 명시 오버라이드한 경우만
+                # (test_2630_circuit_breaker.py의 notify_only 케이스가 그 옛 계약을 검증).
+                assert kw["event_type"] == "conversation.circuit_breaker_opened"
 
                 # 같은 에피소드 진행 중(여전히 폭주 상태) — 재평가해도 재발화 없음.
                 await evaluate_unsupervised_chain_episode(
@@ -375,7 +379,7 @@ async def test_redis_down_fails_closed_no_notification():
     dn = AsyncMock()
 
     async def _fake_get_org_config(db, org_id):  # noqa: ARG001
-        return True, 300, 15
+        return True, 300, 15, "block", "manual"  # story #2630: 5-tuple(+circuit breaker 축)
 
     async def _fake_velocity(db, conversation_id, window_seconds):  # noqa: ARG001
         return 999  # 명백한 폭주

--- a/backend/tests/test_2630_circuit_breaker.py
+++ b/backend/tests/test_2630_circuit_breaker.py
@@ -1,0 +1,524 @@
+"""story #2630: 폭주 에피소드 «자동 차단»(서킷브레이커) — #2626 판별자 위의 집행 계층.
+
+#2626이 만든 속도 기반 에피소드 판별(chain_escalation.py)은 «관측»만 했다 — 이 파일은 그
+위에 얹은 «집행»(chain_circuit_breaker 테이블 + send_message 발신 차단 + 수동/자동 해제)을
+검증한다:
+- circuit_breaker_mode='block'(기본): 에피소드 시작 시 서킷 open, 알림 event_type이
+  conversation.circuit_breaker_opened로 바뀐다(reference_id=breaker.id).
+- circuit_breaker_mode='notify_only': #2626 원 계약(서킷 안 열림·event_type 그대로) 보존.
+- 서킷 open은 멱등 — 이미 열려 있는 대화에 재폭주가 와도 중복 행이 안 생긴다(부분 unique
+  index, 마이그레이션 0244).
+- circuit_breaker_release_mode='manual'(기본): 에피소드가 속도축에서 자연 해소돼도 서킷은
+  안 닫힌다(사람이 안 눌렀으니) — auto는 org 옵트인일 때만 자연 해소를 따라 닫힌다.
+- send_message(): agent 발신은 열린 서킷에서 423(명시 오류, 조용한 유실 없음) — **human
+  발신은 서킷 상태와 무관하게 항상 통과**(페드루 필수수정 2026-08-13: 사람의 개입이 사태
+  수습의 정공 경로).
+- 해제 엔드포인트: human org owner/admin 전용, 멱등(중복 호출도 에러 없이 no-op).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2630", slug=f"org2630-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id):
+    from app.models.team import TeamMember
+
+    m = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent",
+        name="agent", is_active=True,
+    )
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_human(session, org_id, project_id=None, *, role="member"):
+    """User + OrgMember(레거시 신원 해소 경로) + 동일 id의 TeamMember(type=human) — 프로덕션
+    member-sync가 성립했을 때의 모양을 재현(conversation_participants.member_id FK가
+    team_members를 향하므로, 참가자로 실제 발화하려면 이 짝이 있어야 한다 — 없으면 그 자체가
+    별도 결함 클래스인 members_sync 갭이지 이 스토리의 스코프가 아니다)."""
+    from app.models.user import User
+    from app.models.project import OrgMember
+    from app.models.team import TeamMember
+
+    user_id = uuid.uuid4()
+    session.add(User(
+        id=user_id, email=f"{user_id.hex[:8]}@test.local", hashed_password="x",
+    ))
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user_id, role=role)
+    session.add(om)
+    session.add(TeamMember(
+        id=om.id, org_id=org_id, project_id=project_id, type="human",
+        name="human", is_active=True,
+    ))
+    await session.commit()
+    return user_id, om.id
+
+
+async def _seed_conversation(session, org_id, project_id, *, conv_type="group"):
+    from app.models.conversation import Conversation
+
+    conv = Conversation(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type=conv_type)
+    session.add(conv)
+    await session.commit()
+    return conv.id
+
+
+async def _add_participant(session, conversation_id, member_id):
+    from app.models.conversation import ConversationParticipant
+
+    session.add(ConversationParticipant(conversation_id=conversation_id, member_id=member_id))
+    await session.commit()
+
+
+async def _seed_org_owner(session, org_id, *, role="owner"):
+    from app.models.project import OrgMember
+
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=uuid.uuid4(), role=role)
+    session.add(om)
+    await session.commit()
+    return om.id
+
+
+async def _seed_messages(session, conversation_id, sender_id, count, *, ages_seconds=0):
+    from app.models.conversation import ConversationMessage
+
+    ts = datetime.now(timezone.utc) - timedelta(seconds=ages_seconds)
+    for _ in range(count):
+        session.add(ConversationMessage(
+            id=uuid.uuid4(), conversation_id=conversation_id, sender_id=sender_id,
+            content="msg", created_at=ts,
+        ))
+    await session.commit()
+
+
+async def _seed_org_config(session, org_id, **overrides):
+    from app.models.chain_escalation_org_config import ChainEscalationOrgConfig
+
+    session.add(ChainEscalationOrgConfig(id=uuid.uuid4(), org_id=org_id, **overrides))
+    await session.commit()
+
+
+def _fakeredis_client():
+    aioredis = pytest.importorskip("fakeredis.aioredis")
+    server = aioredis.FakeServer()
+    return aioredis.FakeRedis(server=server, decode_responses=True)
+
+
+def _agent_auth(agent_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(org_id),
+    )
+
+
+def _human_auth(user_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(user_id), email=None, claims={}, org_id=str(org_id))
+
+
+async def _open_breaker_count(session, conversation_id) -> int:
+    from sqlalchemy import select, func
+    from app.models.chain_circuit_breaker import ChainCircuitBreaker
+
+    return (await session.execute(
+        select(func.count()).select_from(ChainCircuitBreaker).where(
+            ChainCircuitBreaker.conversation_id == conversation_id,
+            ChainCircuitBreaker.released_at.is_(None),
+        )
+    )).scalar_one()
+
+
+# ─── 서킷 open — block 모드(기본) ────────────────────────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_block_mode_opens_breaker_and_notification_reflects_it():
+    """기본 org 설정(circuit_breaker_mode='block')에서 에피소드 시작 시 서킷이 열리고,
+    알림 event_type이 circuit_breaker_opened로·reference_id가 breaker.id로 바뀐다."""
+    from app.services.chain_escalation import evaluate_unsupervised_chain_episode
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            owner_id = await _seed_org_owner(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            conv_id = await _seed_conversation(s, org_id, project_id)
+            await _seed_messages(s, conv_id, agent_id, 20, ages_seconds=10)  # 임계(15) 초과
+
+            client = _fakeredis_client()
+            dn = AsyncMock()
+            with patch("app.services.redis_shared.get_client", return_value=client), \
+                 patch("app.services.notification_dispatch.dispatch_notification", dn):
+                await evaluate_unsupervised_chain_episode(
+                    s, org_id=org_id, conversation_id=conv_id, project_id=project_id,
+                )
+                dn.assert_awaited_once()
+                kw = dn.await_args.kwargs
+                assert kw["event_type"] == "conversation.circuit_breaker_opened"
+                assert kw["target_member_ids"] == [owner_id]
+
+                from app.services.chain_escalation import get_open_circuit_breaker_id
+                breaker_id = await get_open_circuit_breaker_id(s, conv_id)
+                assert breaker_id is not None
+                assert kw["reference_id"] == breaker_id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_notify_only_mode_preserves_2626_contract_no_breaker():
+    """org가 circuit_breaker_mode='notify_only'로 명시 오버라이드하면 #2626 원 계약(관측만·
+    서킷 안 열림·event_type=unsupervised_chain_expired) 그대로."""
+    from app.services.chain_escalation import evaluate_unsupervised_chain_episode
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_org_owner(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            conv_id = await _seed_conversation(s, org_id, project_id)
+            await _seed_messages(s, conv_id, agent_id, 20, ages_seconds=10)
+            await _seed_org_config(s, org_id, circuit_breaker_mode="notify_only")
+
+            client = _fakeredis_client()
+            dn = AsyncMock()
+            with patch("app.services.redis_shared.get_client", return_value=client), \
+                 patch("app.services.notification_dispatch.dispatch_notification", dn):
+                await evaluate_unsupervised_chain_episode(
+                    s, org_id=org_id, conversation_id=conv_id, project_id=project_id,
+                )
+                assert dn.await_args.kwargs["event_type"] == "conversation.unsupervised_chain_expired"
+            assert await _open_breaker_count(s, conv_id) == 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_reburst_while_already_open_is_idempotent_no_duplicate_row():
+    """release_mode 기본(manual)이라 해소돼도 안 닫히는 서킷에 재폭주가 와도(marker
+    started 재발화) 중복 open 행이 안 생긴다 — 부분 unique index(마이그레이션 0244) +
+    on_conflict_do_nothing 멱등."""
+    from app.services.chain_escalation import evaluate_unsupervised_chain_episode
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_org_owner(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            conv_id = await _seed_conversation(s, org_id, project_id)
+            await _seed_messages(s, conv_id, agent_id, 20, ages_seconds=10)
+
+            client = _fakeredis_client()
+            dn = AsyncMock()
+            with patch("app.services.redis_shared.get_client", return_value=client), \
+                 patch("app.services.notification_dispatch.dispatch_notification", dn), \
+                 patch("app.services.chain_escalation._claim_flap_cooldown_slot", return_value=True):
+                await evaluate_unsupervised_chain_episode(
+                    s, org_id=org_id, conversation_id=conv_id, project_id=project_id,
+                )
+                assert await _open_breaker_count(s, conv_id) == 1
+
+                async def _low_velocity(db, conversation_id, window_seconds):  # noqa: ARG001
+                    return 2
+
+                with patch(
+                    "app.services.chain_escalation._recent_message_velocity", side_effect=_low_velocity,
+                ):
+                    await evaluate_unsupervised_chain_episode(
+                        s, org_id=org_id, conversation_id=conv_id, project_id=project_id,
+                    )  # 해소 평가 — manual이라 breaker는 안 닫힘
+                assert await _open_breaker_count(s, conv_id) == 1, "manual release_mode는 해소돼도 서킷 유지"
+
+                # 재폭주 — started가 다시 뜬다. 이미 open인 서킷에 또 열려는 시도가 멱등해야.
+                await evaluate_unsupervised_chain_episode(
+                    s, org_id=org_id, conversation_id=conv_id, project_id=project_id,
+                )
+                assert await _open_breaker_count(s, conv_id) == 1, "재폭주가 중복 open 행을 만들면 안 됨"
+    finally:
+        await engine.dispose()
+
+
+# ─── 해제 — manual vs auto ───────────────────────────────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_release_mode_auto_closes_on_natural_resolution():
+    """org가 circuit_breaker_release_mode='auto'면 에피소드 자연 해소 시 서킷도 같이 닫힌다
+    (released_by는 NULL — 사람이 안 눌렀다는 사실 자체가 감사 대상)."""
+    from app.services.chain_escalation import evaluate_unsupervised_chain_episode, get_open_circuit_breaker_id
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_org_owner(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            conv_id = await _seed_conversation(s, org_id, project_id)
+            await _seed_messages(s, conv_id, agent_id, 20, ages_seconds=10)
+            await _seed_org_config(s, org_id, circuit_breaker_release_mode="auto")
+
+            client = _fakeredis_client()
+            dn = AsyncMock()
+            with patch("app.services.redis_shared.get_client", return_value=client), \
+                 patch("app.services.notification_dispatch.dispatch_notification", dn):
+                await evaluate_unsupervised_chain_episode(
+                    s, org_id=org_id, conversation_id=conv_id, project_id=project_id,
+                )
+                assert await get_open_circuit_breaker_id(s, conv_id) is not None
+
+                async def _low_velocity(db, conversation_id, window_seconds):  # noqa: ARG001
+                    return 2
+
+                with patch(
+                    "app.services.chain_escalation._recent_message_velocity", side_effect=_low_velocity,
+                ):
+                    await evaluate_unsupervised_chain_episode(
+                        s, org_id=org_id, conversation_id=conv_id, project_id=project_id,
+                    )
+                assert await get_open_circuit_breaker_id(s, conv_id) is None, "auto release_mode는 자연 해소로 닫혀야"
+
+                from sqlalchemy import select
+                from app.models.chain_circuit_breaker import ChainCircuitBreaker
+                row = (await s.execute(
+                    select(ChainCircuitBreaker).where(ChainCircuitBreaker.conversation_id == conv_id)
+                )).scalar_one()
+                assert row.released_by is None
+                assert row.release_reason.startswith("auto:")
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_release_circuit_breaker_realdb_idempotent():
+    from app.services.chain_escalation import (
+        evaluate_unsupervised_chain_episode, release_circuit_breaker, get_open_circuit_breaker_id,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_org_owner(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            conv_id = await _seed_conversation(s, org_id, project_id)
+            await _seed_messages(s, conv_id, agent_id, 20, ages_seconds=10)
+
+            client = _fakeredis_client()
+            with patch("app.services.redis_shared.get_client", return_value=client), \
+                 patch("app.services.notification_dispatch.dispatch_notification", AsyncMock()):
+                await evaluate_unsupervised_chain_episode(
+                    s, org_id=org_id, conversation_id=conv_id, project_id=project_id,
+                )
+
+            releaser_id = uuid.uuid4()
+            first = await release_circuit_breaker(
+                s, conversation_id=conv_id, released_by=releaser_id, reason="사람이 확인함",
+            )
+            assert first is True
+            assert await get_open_circuit_breaker_id(s, conv_id) is None
+
+            second = await release_circuit_breaker(
+                s, conversation_id=conv_id, released_by=uuid.uuid4(), reason="중복 클릭",
+            )
+            assert second is False, "이미 닫힌 서킷을 다시 닫으려는 호출은 no-op"
+    finally:
+        await engine.dispose()
+
+
+# ─── send_message() 발신 차단 — agent만, human은 항상 통과 ────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_send_message_blocked_for_agent_when_breaker_open():
+    from app.routers.conversations import SendMessageRequest, send_message
+    from app.services.chain_escalation import _open_circuit_breaker
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            conv_id = await _seed_conversation(s, org_id, project_id)
+            await _add_participant(s, conv_id, agent_id)
+            await _open_circuit_breaker(s, org_id=org_id, conversation_id=conv_id, project_id=project_id)
+            await s.commit()
+
+            body = SendMessageRequest(content="폭주 재시도")
+            with pytest.raises(HTTPException) as ei:
+                await send_message(
+                    conv_id, body, BackgroundTasks(), db=s,
+                    auth=_agent_auth(agent_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 423
+            assert ei.value.detail["error"] == "circuit_breaker_open"
+
+            from sqlalchemy import select, func
+            from app.models.conversation import ConversationMessage
+            cnt = (await s.execute(
+                select(func.count()).select_from(ConversationMessage).where(
+                    ConversationMessage.conversation_id == conv_id, ConversationMessage.content == "폭주 재시도",
+                )
+            )).scalar_one()
+            assert cnt == 0, "차단된 발신은 메시지로 남지 않는다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_send_message_allows_human_even_when_breaker_open():
+    """페드루 필수수정(2026-08-13): 서킷 open 대화에도 human 발신(개입)은 항상 통과."""
+    from app.routers.conversations import SendMessageRequest, send_message
+    from app.services.chain_escalation import _open_circuit_breaker
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            user_id, _om_id = await _seed_human(s, org_id, project_id, role="owner")
+            conv_id = await _seed_conversation(s, org_id, project_id, conv_type="group")
+            await _open_circuit_breaker(s, org_id=org_id, conversation_id=conv_id, project_id=project_id)
+            await s.commit()
+
+            body = SendMessageRequest(content="사람이 개입한다")
+            resp = await send_message(
+                conv_id, body, BackgroundTasks(), db=s,
+                auth=_human_auth(user_id, org_id), org_id=org_id,
+            )
+            assert resp["data"]["content"] == "사람이 개입한다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_send_message_allows_agent_when_no_breaker_open():
+    """회귀0 — 서킷이 안 열린 정상 대화에선 agent 발신이 평소대로 통과."""
+    from app.routers.conversations import SendMessageRequest, send_message
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            conv_id = await _seed_conversation(s, org_id, project_id)
+            await _add_participant(s, conv_id, agent_id)
+
+            body = SendMessageRequest(content="평상 발신")
+            resp = await send_message(
+                conv_id, body, BackgroundTasks(), db=s,
+                auth=_agent_auth(agent_id, org_id), org_id=org_id,
+            )
+            assert resp["data"]["content"] == "평상 발신"
+    finally:
+        await engine.dispose()
+
+
+# ─── 해제 엔드포인트 — human org owner/admin 전용 ──────────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_release_endpoint_requires_org_owner_admin():
+    from app.routers.conversations import CircuitBreakerReleaseRequest, release_circuit_breaker_endpoint
+    from app.services.chain_escalation import _open_circuit_breaker
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            member_user_id, _ = await _seed_human(s, org_id, project_id, role="member")  # owner/admin 아님
+            conv_id = await _seed_conversation(s, org_id, project_id)
+            await _open_circuit_breaker(s, org_id=org_id, conversation_id=conv_id, project_id=project_id)
+            await s.commit()
+
+            with pytest.raises(HTTPException) as ei:
+                await release_circuit_breaker_endpoint(
+                    conv_id, CircuitBreakerReleaseRequest(), db=s,
+                    auth=_human_auth(member_user_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 403
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_release_endpoint_owner_closes_breaker_idempotently():
+    from app.routers.conversations import CircuitBreakerReleaseRequest, release_circuit_breaker_endpoint
+    from app.services.chain_escalation import _open_circuit_breaker, get_open_circuit_breaker_id
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            owner_user_id, _ = await _seed_human(s, org_id, project_id, role="owner")
+            conv_id = await _seed_conversation(s, org_id, project_id)
+            await _open_circuit_breaker(s, org_id=org_id, conversation_id=conv_id, project_id=project_id)
+            await s.commit()
+
+            resp = await release_circuit_breaker_endpoint(
+                conv_id, CircuitBreakerReleaseRequest(reason="확인 완료"), db=s,
+                auth=_human_auth(owner_user_id, org_id), org_id=org_id,
+            )
+            assert resp["released"] is True
+            assert await get_open_circuit_breaker_id(s, conv_id) is None
+
+            resp2 = await release_circuit_breaker_endpoint(
+                conv_id, CircuitBreakerReleaseRequest(), db=s,
+                auth=_human_auth(owner_user_id, org_id), org_id=org_id,
+            )
+            assert resp2["released"] is False, "중복 해제 호출은 에러 없이 no-op"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_deeplink_manifest_contract.py
+++ b/backend/tests/test_deeplink_manifest_contract.py
@@ -88,12 +88,13 @@ def test_conversation_mention_lands_in_chat_tab():
     assert entry.app.parent_tab == ParentTab.chat
 
 
-def test_manifest_covers_all_26_dispatch_notification_event_types():
+def test_manifest_covers_all_27_dispatch_notification_event_types():
     """AC1 회귀 고정: story #1951 GATE1 전수 조사에서 확인한 dispatch_notification()
     event_type 리터럴이 전부 등재돼 있어야 한다. 새 알림 타입이 코드에 추가되고
     이 집합이 갱신 안 되면 이 테스트가 알려준다(양방향 대조 — 매니페스트 초과분도 잡음).
     story #2617: conversation.unsupervised_chain_expired 신설로 24→25.
-    story #2624: doc_approval_resolved 신설로 25→26."""
+    story #2624: doc_approval_resolved 신설로 25→26.
+    story #2630: conversation.circuit_breaker_opened 신설로 26→27."""
     expected = {
         "sprint_closed", "task_completed", "story_assigned", "comment.created",
         "artifact.created", "artifact.exported", "artifact.updated", "artifact.canonicalized",
@@ -102,6 +103,7 @@ def test_manifest_covers_all_26_dispatch_notification_event_types():
         "gate.pending_approval", "gate_overridden", "gate_approval_requested", "gate_reassigned",
         "doc_approval_requested", "handoff_fallback", "story_status_changed",
         "conversation.unsupervised_chain_expired", "doc_approval_resolved",
+        "conversation.circuit_breaker_opened",
     }
     actual = {e.app.type for e in DEEPLINK_MANIFEST.entries}
     missing = expected - actual

--- a/backend/tests/test_deeplink_manifest_endpoint.py
+++ b/backend/tests/test_deeplink_manifest_endpoint.py
@@ -47,7 +47,8 @@ async def test_deeplink_manifest_endpoint_returns_200_with_schema_version_and_lo
     assert isinstance(body["version_policy"], str) and body["version_policy"]
     # story #2617: conversation.unsupervised_chain_expired 신설로 33→34.
     # story #2624: doc_approval_resolved 신설로 34→35.
-    assert isinstance(body["entries"], list) and len(body["entries"]) == 35
+    # story #2630: conversation.circuit_breaker_opened 신설로 35→36.
+    assert isinstance(body["entries"], list) and len(body["entries"]) == 36
 
     # 미르코 point ②: lookup_key = f"{type}:{entity_type}" (구분자 ":") 서빙 시점 파생.
     story_entry = next(


### PR DESCRIPTION
## Summary
- #2626's speed-based episode discriminator only *notified* org owner/admin — the actual A↔B storm kept sending. This adds the execution layer on top: episode start opens a circuit (new `chain_circuit_breaker` table, one open row per conversation, enforced by a partial unique index), and `send_message()` rejects **agent** sends with `423` while the circuit is open (explicit error, no silent drop).
- **Human sends always pass** regardless of circuit state — human intervention is the recovery path, and blocking it would trap the room (review feedback, addressed).
- Release is **manual by default** — auto-release was rejected because the block's own silence (no messages → velocity drops → episode "resolves") would trigger auto-unblock → storm resumes → re-block, a duty cycle that never actually stops the storm. `circuit_breaker_release_mode='auto'` remains available as an org opt-in.
- org config surface (extends `chain_escalation_org_config`, story #2626's table): `circuit_breaker_mode` (`block`/`notify_only`, default `block`) and `circuit_breaker_release_mode` (`manual`/`auto`, default `manual`).
- `POST /api/v2/conversations/{id}/circuit-breaker/release` — human org owner/admin only (`is_org_owner_or_admin`, agent auth structurally excluded), idempotent.
- Notification (`conversation.circuit_breaker_opened`) reuses #2626's existing dispatch call site, `reference_id` now points at the breaker row id.

## Design note
`chain_circuit_breaker` row existence (not a Redis TTL) is the open/closed SSOT — manual release must survive the episode's own natural resolution, which a TTL-based cache can't represent. Breaker rows only ever open for human-less conversations (the same population #2617/#2626 already target), so the `send_message` hot-path check is a single indexed query with no extra human-participant lookup needed.

**Check order = information-exposure order.** The circuit-breaker check runs *after* the participant check, not before. A non-participant gets `403` without ever learning whether a circuit is open in that conversation — putting the breaker check first would leak room state (open/closed) to someone not in the room. This ordering also fixed a real CI regression (a mocked-session test expecting exactly 2 sequential `db.execute()` calls broke when the breaker check ran first), but the ordering is correct independent of that — reviewers/QA should treat "does this gate leak state to non-participants" as a checklist item whenever a new pre-write check gets added to `send_message()`.

## Scope
- **FE follow-up (out of scope here)**: wire the notification's "release" action to the new endpoint.

## Test plan
- [x] `test_2630_circuit_breaker.py` (10 new tests): block-mode open + notification reference_id, notify_only mode preserves #2626's old contract, idempotent reburst-while-open (no duplicate row), manual release_mode survives natural resolution, auto release_mode closes on resolution, send_message 423 for agent / always-pass for human / normal pass when no breaker, release endpoint authz (403 non-admin) + happy path + idempotent double-release.
- [x] `test_2626_chain_escalation_episode.py` updated for the new `_get_org_config` 5-tuple and the new default event_type (block mode is now the default, so the AC2 burst test now asserts `circuit_breaker_opened`); all other #2626 assertions unchanged and passing.
- [x] `test_2617_chain_escalation.py`, `test_2608_chain_depth.py`, `test_2608_human_intervention_dispatch.py` — unaffected, all green (human-present-conversation gate regression, AC5).
- [x] `test_conversations.py`, `test_e_security_sec_s8_v_conversation_agent_admin_bypass_realdb.py`, `test_2055_attachment_image_dimensions.py` — full conversations.py router regression sweep, all green against a fully-migrated fresh Postgres.
- [x] Migration 0244 verified round-trip (upgrade/downgrade/upgrade) against a disposable Postgres container with the full 0001→0244 chain applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
