### PR TITLE
fix(docs): 문서 본문 entity: 참조 링크를 앱 내 엔티티로 잇는다 (#2639)

### DIFF
--- a/apps/web/src/components/chat/embed-card.mdbody-entity.test.tsx
+++ b/apps/web/src/components/chat/embed-card.mdbody-entity.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { MdBody } from './embed-card';
+
+// story #2639(미르코 리뷰 ⑤) — 결재 카드 문서 미리보기(EntityPreviewModal→EntityDetail doc
+// 분기)가 쓰는 경량 렌더러 MdBody도 entity: 참조를 앱 내 엔티티로 잇는다(doc-content-renderer와
+// 동형). 최소셋: 칩 렌더 + 보안 차단.
+describe('MdBody entity: wiring (story #2639)', () => {
+  it('renders entity refs as interactive chips (not dead links) — story·epic·doc', () => {
+    const uuid = '11111111-1111-1111-1111-111111111111';
+    const markup = renderToStaticMarkup(
+      <MdBody
+        content={`[스토리제목](entity:story:${uuid}) [에픽제목](entity:epic:${uuid}) [문서제목](entity:doc:${uuid})`}
+      />,
+    );
+
+    // 죽은 앵커가 아니라 상호작용 칩(button)으로 렌더. 라벨 3종 모두 살아 있다.
+    expect(markup).toContain('<button type="button"');
+    expect(markup).toContain('스토리제목');
+    expect(markup).toContain('에픽제목');
+    expect(markup).toContain('문서제목');
+    // 유효 UUID 3종은 전부 칩으로 흡수 → entity: 원시 스킴이 앵커 href로 새지 않는다.
+    expect(markup).not.toContain('href="entity:');
+  });
+
+  // 뮤테이션 가드 — MdBody의 urlTransform이 빠지면 href가 지워져 정규식 매칭 실패,
+  // 평문 링크로 떨어지고 이 assertion(button)이 깨진다.
+  it('mutation guard: entity: scheme preserved by urlTransform', () => {
+    const uuid = '22222222-2222-2222-2222-222222222222';
+    const markup = renderToStaticMarkup(<MdBody content={`[칩라벨](entity:story:${uuid})`} />);
+    expect(markup).toContain('<button type="button"');
+    expect(markup).toContain('칩라벨');
+  });
+
+  // 보안 비회귀 — entity: 예외가 다른 위험 스킴을 함께 열어주지 않는다.
+  it('security non-regression: javascript:/data: hrefs are still stripped', () => {
+    const markup = renderToStaticMarkup(
+      <MdBody content={'[x](javascript:alert(1)) [y](data:text/plain,hi)'} />,
+    );
+    expect(markup).not.toContain('javascript:');
+    expect(markup).not.toContain('data:text/plain');
+  });
+});

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
   ExternalLink, X, FileText, File, Layers, CheckSquare, Eye,
@@ -139,7 +139,21 @@ const MdBadge = ({ label }: { label: string }) => (
 // 새 함수 참조가 되어 react-markdown이 서브트리를 리마운트한다(chat-bubble 근본원인과 동형).
 // 이 객체는 props/상태에 의존하지 않는 순수 상수이고 자식도 전부 stateless라 useMemo조차
 // 불필요 — 모듈 스코프로 끌어올려 참조를 영구 고정한다.
+// story #2639 — 본문 엔티티 참조 토큰 `[제목](entity:타입:id)`의 href 매칭(id는 UUID만).
+// doc-content-renderer.tsx·chat-bubble.tsx의 파싱 규칙과 문자 그대로 동일(드리프트 방지).
+const MDBODY_ENTITY_REF_RE = /^entity:(\w+):([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
+
 const mdBodyComponents = {
+  // story #2639(미르코 리뷰 ⑤) — 결재 카드 문서 미리보기(EntityPreviewModal→EntityDetail doc
+  // 분기)가 이 경량 렌더러를 쓴다. doc-content-renderer와 동일하게 entity: 참조를 EntityChip으로
+  // 잇는다(같은 파일의 EntityChip 재사용·사본 0). 비-UUID/asset은 평문 링크 폴백(무동작 0).
+  a: ({ href, children }: { href?: string; children?: React.ReactNode }) => {
+    const m = href?.match(MDBODY_ENTITY_REF_RE);
+    if (m && m[1]!.toLowerCase() !== 'asset') {
+      return <EntityChip entityType={m[1]!} entityId={m[2]!} label={String(children)} href={getEntityHref(m[1]!, m[2]!)} />;
+    }
+    return <a href={href} target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">{children}</a>;
+  },
   p: ({ children }: { children?: React.ReactNode }) => <p className="mb-2 text-sm leading-6">{children}</p>,
   h1: ({ children }: { children?: React.ReactNode }) => <h1 className="mb-2 text-lg font-bold">{children}</h1>,
   h2: ({ children }: { children?: React.ReactNode }) => <h2 className="mb-2 text-base font-bold">{children}</h2>,
@@ -155,8 +169,14 @@ const mdBodyComponents = {
   em: ({ children }: { children?: React.ReactNode }) => <em className="italic">{children}</em>,
 };
 
-const MdBody = ({ content }: { content: string }) => (
-  <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdBodyComponents}>
+// story #2639 — entity: 스킴 보존(이 렌더러는 rehype-sanitize를 안 써서 이 한 겹이면 충분).
+// 그 외 스킴은 기본 sanitize 유지(javascript:/data: 차단). export: MdBody 격리 테스트용.
+export const MdBody = ({ content }: { content: string }) => (
+  <ReactMarkdown
+    remarkPlugins={[remarkGfm]}
+    urlTransform={(url) => (url.startsWith('entity:') ? url : defaultUrlTransform(url))}
+    components={mdBodyComponents}
+  >
     {content}
   </ReactMarkdown>
 );

--- a/apps/web/src/components/docs/doc-content-renderer.test.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.test.tsx
@@ -85,4 +85,54 @@ describe('DocContentRenderer', () => {
     // safe inline tags inside heading inner are preserved by sanitizeHeadingInner
     expect(markup).toContain('<strong>ok</strong>');
   });
+
+  // story #2639 — 본문 entity: 참조가 죽은 링크(스타일만·href 지워짐)로 떨어지던 갭. 이제
+  // chat/story-panel과 동일하게 EntityChip(상호작용 버튼)으로 렌더돼 앱 내 엔티티로 잇는다.
+  it('story #2639: renders entity refs as interactive chips (not dead links) — story·epic·doc', () => {
+    const uuid = '11111111-1111-1111-1111-111111111111';
+    const markup = renderToStaticMarkup(
+      <DocContentRenderer
+        content={`참조: [스토리제목](entity:story:${uuid}) [에픽제목](entity:epic:${uuid}) [문서제목](entity:doc:${uuid})`}
+        contentFormat="markdown"
+      />,
+    );
+
+    // 죽은 앵커가 아니라 상호작용 칩(button)으로 렌더. 라벨 텍스트는 3종 모두 살아 있다.
+    expect(markup).toContain('<button type="button"');
+    expect(markup).toContain('스토리제목');
+    expect(markup).toContain('에픽제목');
+    expect(markup).toContain('문서제목');
+    // 유효 UUID 3종은 전부 칩으로 흡수 → entity: 원시 스킴이 앵커 href로 새지 않는다.
+    expect(markup).not.toContain('href="entity:');
+  });
+
+  // 뮤테이션 자가검증 — 두 겹 필터(urlTransform + rehype-sanitize protocols.href) 중 하나라도
+  // 빠지면 href가 지워져 정규식 매칭이 실패, 평문 링크로 떨어지고 이 assertion이 깨진다.
+  it('story #2639 mutation guard: entity: scheme survives BOTH the urlTransform and sanitize filters', () => {
+    const uuid = '22222222-2222-2222-2222-222222222222';
+    const markup = renderToStaticMarkup(
+      <DocContentRenderer content={`[칩라벨](entity:story:${uuid})`} contentFormat="markdown" />,
+    );
+    expect(markup).toContain('<button type="button"');
+    expect(markup).toContain('칩라벨');
+  });
+
+  // 보안 비회귀 — entity: 예외가 다른 위험 스킴을 함께 열어주지 않는다(기본 sanitize 유지).
+  it('story #2639 security non-regression: javascript:/data: hrefs are still stripped', () => {
+    const markup = renderToStaticMarkup(
+      <DocContentRenderer content={'[x](javascript:alert(1)) [y](data:text/plain,hi)'} contentFormat="markdown" />,
+    );
+    expect(markup).not.toContain('javascript:');
+    expect(markup).not.toContain('data:text/plain');
+  });
+
+  // public share 뷰어 — 내부 엔티티 참조는 비활성 평문(메타 유출 경계·wikiLink publicMode와 동일).
+  it('story #2639: public share viewer renders entity refs inert (no chip button)', () => {
+    const uuid = '33333333-3333-3333-3333-333333333333';
+    const markup = renderToStaticMarkup(
+      <DocContentRenderer content={`[내부참조](entity:story:${uuid})`} contentFormat="markdown" publicMode />,
+    );
+    expect(markup).toContain('내부참조');
+    expect(markup).not.toContain('<button type="button"');
+  });
 });

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -6,7 +6,7 @@ import { getShikiHighlighter, resolveLanguage } from './lib/shiki-highlighter';
 import { detectEmbedService } from './extensions/embed-node';
 import { renderKatex } from './extensions/math-node';
 import { renderMermaid } from './lib/mermaid-renderer';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import type { Components } from 'react-markdown';
 import DOMPurify from 'dompurify';
 import remarkGfm from 'remark-gfm';
@@ -16,6 +16,8 @@ import NextImage from 'next/image';
 import { ImageOff } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { extractDocHeadings, slugifyHeading } from './doc-heading-utils';
+// story #2639 — 본문 entity: 참조 링크를 앱 내 엔티티로 잇는다(chat/story-panel과 동일 자산 재사용).
+import { EntityChip, getEntityHref } from '@/components/chat/embed-card';
 
 interface DocContentRendererProps {
   content: string;
@@ -68,7 +70,20 @@ const docMarkdownSanitizeSchema = {
       'dataSlug',
     ],
   },
+  // story #2639 — entity: 참조 링크(`[제목](entity:타입:id)`)의 href가 두 겹 필터에 지워지지
+  // 않게 한다. rehype-sanitize의 protocols.href 허용목록에 'entity'만 추가로 열고
+  // javascript:/data: 등은 원래 막던 대로 둔다(story-detail-panel #2269와 동형 처방·둘째 겹).
+  // 첫째 겹은 아래 <ReactMarkdown urlTransform>.
+  protocols: {
+    ...defaultSchema.protocols,
+    href: [...(defaultSchema.protocols?.href ?? []), 'entity'],
+  },
 };
+
+// story #2639 — 본문 엔티티 참조 토큰 `[제목](entity:타입:id)`의 href 매칭(id는 UUID만 —
+// 비-UUID는 매칭 실패→평문 링크 폴백). chat-bubble.tsx·story-detail-panel.tsx의 파싱 규칙과
+// 문자 그대로 동일하게 둔다(정의가 세 곳에 흩어지면 그 자체가 드리프트 위험).
+const ENTITY_REF_RE = /^entity:(\w+):([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
 
 // asset-ref 식별 — react-markdown 은 hast node(properties.dataAssetId) + data-* prop 양쪽을 줄 수 있어
 // 둘 다 확인한다(스키마 통과분만 도달).
@@ -519,6 +534,27 @@ export function DocContentRenderer({
   // 매겨져야 하는데 메모이즈된 클로저에 넣으면 그 리셋이 깨진다 — 그래서 h1/h2/h3는 아래
   // components 병합 시 매 렌더 새로 만드는 채로 둔다(무해 remount).
   const stableMarkdownComponents = useMemo<Components>(() => ({
+    // story #2639 — 본문 entity: 참조를 EntityChip으로 잇는다(chat/story-panel과 동일 상호작용:
+    // 탭→엔티티 프리뷰 모달·그 안에 전체 열기 링크). getEntityHref가 story→/board?story=·
+    // epic→/goals/·doc→/docs?id= 동일오리진 라우트를 준다(웹뷰서 SPA 착지·셸 무변경).
+    // 매핑 없는 타입은 getEntityHref=null→모달만 뜨고(무동작 0), 비-UUID/asset은 평문 링크 폴백.
+    a: ({ href, children }: { href?: string; children?: ReactNode }) => {
+      const m = href?.match(ENTITY_REF_RE);
+      // asset은 story-detail-panel과 동일하게 칩 경로에서 제외한다(자산 임베드는 별 경로).
+      if (m && m[1]!.toLowerCase() !== 'asset') {
+        // public share 뷰어: 내부 참조는 비활성 평문(메타 유출 경계 — wikiLink publicMode와 동일).
+        if (publicMode) return <span className="text-sm text-muted-foreground">{children}</span>;
+        return (
+          <EntityChip
+            entityType={m[1]!}
+            entityId={m[2]!}
+            label={String(children)}
+            href={getEntityHref(m[1]!, m[2]!)}
+          />
+        );
+      }
+      return <a href={href}>{children}</a>;
+    },
     blockquote: ({ children }: { children?: ReactNode }) => <blockquote>{children}</blockquote>,
     img: (props) => {
       const { src, alt } = props as { src?: unknown; alt?: string };
@@ -605,6 +641,9 @@ export function DocContentRenderer({
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeRaw, [rehypeSanitize, docMarkdownSanitizeSchema]]}
+        // story #2639 — entity: 스킴 보존(첫째 겹). 그 외는 기본 sanitize 유지 —
+        // javascript:/data: 는 여전히 빈 문자열로 지워진다(뮤테이션 테스트로 고정).
+        urlTransform={(url) => (url.startsWith('entity:') ? url : defaultUrlTransform(url))}
         components={{
           h1: ({ children }) => {
             const heading = headings[headingIndex++];


### PR DESCRIPTION
## 스토리
#2639 [모바일·딥링크] 문서 본문 내 엔티티 참조 탭 → 앱 내 해당 화면 이동 — 링크로 보이는데 안 움직이는 갭
선생님 실사용 발견(08-13·모바일 앱).

## 근본 원인 (그라운딩 실측)
결재 문서 본문의 엔티티 참조는 마크다운 링크 `[제목](entity:타입:id)`인데, 문서 본문 렌더러 `doc-content-renderer.tsx`에 **`entity:` 스킴 배선이 없다** — `urlTransform` 스킴 보존도, `a` 오버라이드도 없어 react-markdown 기본 sanitizer/urlTransform이 href를 걷어내 **스타일만 링크인 죽은 앵커**로 렌더된다. 채팅(`chat-bubble.tsx`)·스토리 패널(`story-detail-panel.tsx`)엔 이 배선이 이미 있어 정상 이동 — **doc 렌더러만 누락**이었다.

킥오프 초기 가정(네이티브 딥링크 매니페스트 재사용)은 그라운딩으로 뒤집혔다. 실제 재사용 대상은 웹 SSOT `getEntityHref`이고, **네이티브 셸 변경은 불요**(아래).

## 변경 (검증된 패턴 이식 · 신규 체계 0)
`doc-content-renderer.tsx` 마크다운 경로에 chat/story-panel과 동일 배선:
- **두 겹 필터 개방**: rehype-sanitize `protocols.href`에 `'entity'` 추가(둘째 겹) + `<ReactMarkdown urlTransform>`에서 `entity:` 보존(첫째 겹). `javascript:`/`data:` 등은 원래대로 차단.
- **`a` 오버라이드 → `EntityChip`**: `getEntityHref` 재사용(story→`/board?story=`, epic→`/goals/`, doc→`/docs?id=`). 상호작용은 chat/story-panel과 동일(탭→엔티티 프리뷰 모달·그 안 전체 열기 링크).
- **무동작 0**: 매핑 없는 타입은 `getEntityHref=null`→프리뷰 모달, 비-UUID/asset은 평문 폴백. **public share 뷰어는 비활성 평문**(메타 유출 경계·wikiLink publicMode와 동일).

**셸(sprintable-mobile) 변경 없음**: 결과 라우트가 전부 동일오리진이라 웹뷰 nav 게이트(`classifyNavigation`)가 이미 `allow` — 웹데스크톱+모바일 웹뷰가 동시 착지한다.

## 검증 (웹 렌더 계층 — 완료)
- `doc-content-renderer.test.tsx` **9/9 pass** (기존 5 + 신규 4: 칩 렌더 story·epic·doc / 뮤테이션 가드 / 보안 비회귀 js·data 차단 / publicMode 비활성).
- **뮤테이션 자가검증**: 두 겹 필터를 각각 깨면 정확히 2건 RED(각 필터 load-bearing 실증) → 원복. 공허 어서션 아님.
- 비회귀: `doc-content-renderer.asset-ref` + `embed-card.entity-registry-parity` pass.
- `tsc --noEmit` **0 error** (전체 web) · `eslint` 변경 파일 clean.

## 미검증 (다음 단계 · 이 PR 머지 전 첨부 예정)
- [ ] **AC1 iOS·Android 실기기 tap→land 3종(story·epic·doc)** 실측 증거(스크린 녹화) — 프리뷰/로컬 대상.
- [ ] **AC2 "결재 카드 본문 모달" 경로 확認**: 그라운딩상 결재 문서 본문도 동일 `DocContentRenderer` 경로. 실측으로 최종 확認(별도 렌더러 발견 시 같은 PR 커버).
- [ ] 웹 렌더 비회귀 visual(데스크톱+모바일 뷰포트) · PO 라이브 done-gate(왕복 착지).

## 게이트
웹 코어 레인 — **미르코 리뷰 필수**(PO 콜) + 카디르 QA → PO 머지.


---
## 클릭 동작 = modal-first (설계 확定 · PO 판정 2026-08-13)
두 렌더러 다 `EntityChip` 재사용. mapped 3종(story·epic·doc) **칩 탭 → `EntityPreviewModal`(미리보기) → 풋터 "전체 보기" Link → 해당 화면 착지**. 1-탭 직행이 **아니다** — 문서 읽던 맥락 유지가 선생님 UX 원칙과 정합하고 앱 전역(chat·story-panel)과 동일 패턴이라 **의도된 설계**다. 원 지적 「안 움직인다」=탭이 죽어 있던 것이고, 탭→모달→전체 보기→착지가 성립하면 AC 충족. (1-탭 직행이 필요하면 «전 칩 표면» 별도 스토리 감.)
