### PR TITLE
[SID:2632] event_definitions schema + 4 preset seeds + migration

### DIFF
--- a/backend/alembic/versions/0245_event_definitions.py
+++ b/backend/alembic/versions/0245_event_definitions.py
@@ -1,0 +1,183 @@
+"""story #2632(이벤트 레지스트리 P1a): event_definitions 테이블 + 프리셋 시드 4종.
+
+Revision ID: 0245
+Revises: 0244
+Create Date: 2026-08-13
+
+doc event-registry-core-p1-plan §2-1·§2-5. key 네임스페이스(preset.*/org.{slug}.*)를
+CHECK로 1차 방어(모양만 — slug가 호출자 자신의 것인지는 app 레이어, event_definition_
+registry.py가 강제). org_id NULL=프리셋 전역 유일·org_id NOT NULL=org당 유일(부분 unique
+index 2개, WebhookConfig의 project_id-nullable-scope 패턴과 동형).
+"""
+from __future__ import annotations
+
+import uuid
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0245"
+down_revision = "0244"
+branch_labels = None
+depends_on = None
+
+# (key, payload_schema, routing) — payload_schema는 전부 additionalProperties: false 명시
+# (모델 docstring 참조 — 스키마 저작 시점의 책임, AC3).
+_SEED = [
+    (
+        "preset.gate.verdict",
+        {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["work_item_type", "work_item_id", "gate_type", "verdict"],
+            "properties": {
+                "work_item_type": {"type": "string"},
+                "work_item_id": {"type": "string", "format": "uuid"},
+                "gate_type": {"type": "string"},
+                "verdict": {"type": "string", "enum": ["approved", "rejected"]},
+                "resolver_member_id": {"type": "string", "format": "uuid"},
+                "resolution_note": {"type": ["string", "null"]},
+            },
+        },
+        # 잠정 — 실 해석은 #2633(도달 3층 해석기)의 몫. verdict는 이미 일어난 결과 통지라
+        # escalation(개입 요청) 대상은 없고, 그 work_item의 이해관계자에게만 전파.
+        {
+            "escalation": {"target": "none"},
+            "broadcast": {"target": "work_item_stakeholders", "inherit_conversation_scope": True},
+        },
+    ),
+    (
+        "preset.work.status_changed",
+        {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["work_item_type", "work_item_id", "from_status", "to_status"],
+            "properties": {
+                "work_item_type": {"type": "string"},
+                "work_item_id": {"type": "string", "format": "uuid"},
+                "from_status": {"type": "string"},
+                "to_status": {"type": "string"},
+                "changed_by_member_id": {"type": "string", "format": "uuid"},
+                "note": {"type": ["string", "null"]},
+            },
+        },
+        {
+            "escalation": {"target": "none"},
+            "broadcast": {"target": "work_item_stakeholders", "inherit_conversation_scope": True},
+        },
+    ),
+    (
+        "preset.work.assigned",
+        {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["work_item_type", "work_item_id", "assignee_member_id"],
+            "properties": {
+                "work_item_type": {"type": "string"},
+                "work_item_id": {"type": "string", "format": "uuid"},
+                "assignee_member_id": {"type": "string", "format": "uuid"},
+                "assigned_by_member_id": {"type": ["string", "null"], "format": "uuid"},
+            },
+        },
+        # 배정 대상이 바로 개입(작업 착수)을 요청받는 사람 — escalation target=assignee.
+        {
+            "escalation": {"target": "assignee"},
+            "broadcast": {"target": "work_item_stakeholders", "inherit_conversation_scope": True},
+        },
+    ),
+    (
+        "preset.goal.measured",
+        {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["goal_id", "metric_value"],
+            "properties": {
+                "goal_id": {"type": "string", "format": "uuid"},
+                "metric_value": {"type": "number"},
+                "metric_unit": {"type": ["string", "null"]},
+                "source": {
+                    "type": ["string", "null"],
+                    "description": "실측치 출처(예: GA4·GitHub·수동) — 커넥터 없는 외부 연동의 관문(P1 플랜 §1.5).",
+                },
+                "measured_at": {"type": ["string", "null"], "format": "date-time"},
+            },
+        },
+        {
+            "escalation": {"target": "none"},
+            "broadcast": {"target": "goal_owner", "inherit_conversation_scope": False},
+        },
+    ),
+]
+
+_event_definitions = sa.table(
+    "event_definitions",
+    sa.column("id", postgresql.UUID(as_uuid=True)),
+    sa.column("key", sa.Text),
+    sa.column("org_id", postgresql.UUID(as_uuid=True)),
+    sa.column("payload_schema", postgresql.JSONB),
+    sa.column("routing", postgresql.JSONB),
+    sa.column("block_template", postgresql.JSONB),
+    sa.column("action_auth", postgresql.JSONB),
+    sa.column("enabled", sa.Boolean),
+    sa.column("version", sa.Integer),
+    sa.column("created_by", postgresql.UUID(as_uuid=True)),
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "event_definitions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("key", sa.Text(), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("payload_schema", postgresql.JSONB(), nullable=False),
+        sa.Column("routing", postgresql.JSONB(), nullable=False),
+        sa.Column("block_template", postgresql.JSONB(), nullable=True),
+        sa.Column("action_auth", postgresql.JSONB(), nullable=True),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("created_by", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.CheckConstraint(
+            r"(org_id IS NULL AND key ~ '^preset\.[a-z0-9_]+(\.[a-z0-9_]+)+$')"
+            r" OR (org_id IS NOT NULL AND key ~ '^org\.[a-z0-9-]+\.[a-z0-9_]+(\.[a-z0-9_]+)*$')",
+            name="ck_event_definitions_key_namespace",
+        ),
+    )
+    op.create_index("ix_event_definitions_org_id", "event_definitions", ["org_id"])
+    op.create_index(
+        "uq_event_definitions_preset_key", "event_definitions", ["key"],
+        unique=True, postgresql_where=sa.text("org_id IS NULL"),
+    )
+    op.create_index(
+        "uq_event_definitions_org_key", "event_definitions", ["org_id", "key"],
+        unique=True, postgresql_where=sa.text("org_id IS NOT NULL"),
+    )
+
+    op.bulk_insert(
+        _event_definitions,
+        [
+            {
+                "id": uuid.uuid4(),
+                "key": key,
+                "org_id": None,
+                "payload_schema": payload_schema,
+                "routing": routing,
+                "block_template": None,
+                "action_auth": None,
+                "enabled": True,
+                "version": 1,
+                "created_by": None,
+            }
+            for key, payload_schema, routing in _SEED
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_event_definitions_org_key", table_name="event_definitions")
+    op.drop_index("uq_event_definitions_preset_key", table_name="event_definitions")
+    op.drop_index("ix_event_definitions_org_id", table_name="event_definitions")
+    op.drop_table("event_definitions")

--- a/backend/alembic/versions/0245_event_definitions.py
+++ b/backend/alembic/versions/0245_event_definitions.py
@@ -41,10 +41,15 @@ _SEED = [
             },
         },
         # 잠정 — 실 해석은 #2633(도달 3층 해석기)의 몫. verdict는 이미 일어난 결과 통지라
-        # escalation(개입 요청) 대상은 없고, 그 work_item의 이해관계자에게만 전파.
+        # escalation(개입 요청) 대상은 없고, 그 work_item의 이해관계자에게만 전파. 둘 다
+        # kind=server_derived(닫힌 어휘) — payload 필드에서 못 뽑는 파생 역할(레지스트리
+        # docstring의 두 부류 규약 참조, 페드루 판정 2026-08-13).
         {
-            "escalation": {"target": "none"},
-            "broadcast": {"target": "work_item_stakeholders", "inherit_conversation_scope": True},
+            "escalation": {"kind": "server_derived", "target": "none"},
+            "broadcast": {
+                "kind": "server_derived", "target": "work_item_stakeholders",
+                "inherit_conversation_scope": True,
+            },
         },
     ),
     (
@@ -63,8 +68,11 @@ _SEED = [
             },
         },
         {
-            "escalation": {"target": "none"},
-            "broadcast": {"target": "work_item_stakeholders", "inherit_conversation_scope": True},
+            "escalation": {"kind": "server_derived", "target": "none"},
+            "broadcast": {
+                "kind": "server_derived", "target": "work_item_stakeholders",
+                "inherit_conversation_scope": True,
+            },
         },
     ),
     (
@@ -80,10 +88,17 @@ _SEED = [
                 "assigned_by_member_id": {"type": ["string", "null"], "format": "uuid"},
             },
         },
-        # 배정 대상이 바로 개입(작업 착수)을 요청받는 사람 — escalation target=assignee.
+        # 배정 대상이 바로 개입(작업 착수)을 요청받는 사람 — escalation kind=payload_field(payload의
+        # assignee_member_id에서 직접 뽑는다, 페드루 판정 2026-08-13: org 커스텀(P1b)도 이 부류만
+        # 등록 가능하게 열어 확장이 성립하는 축).
         {
-            "escalation": {"target": "assignee"},
-            "broadcast": {"target": "work_item_stakeholders", "inherit_conversation_scope": True},
+            "escalation": {
+                "kind": "payload_field", "target": "assignee", "member_id_field": "assignee_member_id",
+            },
+            "broadcast": {
+                "kind": "server_derived", "target": "work_item_stakeholders",
+                "inherit_conversation_scope": True,
+            },
         },
     ),
     (
@@ -104,8 +119,10 @@ _SEED = [
             },
         },
         {
-            "escalation": {"target": "none"},
-            "broadcast": {"target": "goal_owner", "inherit_conversation_scope": False},
+            "escalation": {"kind": "server_derived", "target": "none"},
+            "broadcast": {
+                "kind": "server_derived", "target": "goal_owner", "inherit_conversation_scope": False,
+            },
         },
     ),
 ]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -97,6 +97,7 @@ from app.models.hitl_config import MemberGateOverride, OrgGateOverride, OrgGateP
 from app.models.participation import Participation, ParticipationRole
 from app.models.chain_escalation_org_config import ChainEscalationOrgConfig
 from app.models.chain_circuit_breaker import ChainCircuitBreaker
+from app.models.event_definition import EventDefinition
 
 __all__ = [
     "RoleTemplate",

--- a/backend/app/models/event_definition.py
+++ b/backend/app/models/event_definition.py
@@ -17,8 +17,21 @@ event_definition_registry.py의 validate_event_definition_key가 진짜 강제 �
 관대해 조용히 통과한다 — 시드 4종 전부 명시 선언, event_definition_registry.py 참조).
 
 `routing`(상신선·전파선 선언)은 **선언**일 뿐 해석기가 아니다 — 실제 도달 계산(누구에게
-무엇으로)은 story #2633(발행 API + 도달 3층 해석기)의 몫. 여기 저장된 값의 shape은 그
-해석기의 계약이 확정되기 전까지 잠정(seed 주석 참조).
+무엇으로)은 story #2633(발행 API + 도달 3층 해석기)의 몫. 단 각 target의 **부류**는 여기서
+확定(페드루 판정 2026-08-13, doc event-registry-core-p1-plan §2-1 갱신):
+
+- `kind="payload_field"`: 역할을 payload의 특정 필드에서 직접 뽑는다 — `member_id_field`
+  필수(예: `{"kind":"payload_field","target":"assignee","member_id_field":
+  "assignee_member_id"}`). **org 커스텀(P1b, story #2636)이 등록 가능한 유일한 부류** —
+  스키마가 매핑을 선언하니 해석기가 제네릭으로 돈다("정의=데이터" 철학의 연장).
+- `kind="server_derived"`: payload 필드로 못 뽑는 파생 역할(예: `work_item_stakeholders`
+  — work_item_type+id로 그 타입별 이해관계자를 서버가 조회, `goal_owner`) — `member_id_
+  field` 없음. 해석기(#2633)의 **닫힌 어휘**로만 존재한다 — 그 어휘 밖 target 레이블은
+  발행 시 명시 오류(조용한 무해석 금지, event_definition_registry.py의 SERVER_DERIVED_
+  TARGETS 참조). org 커스텀은 이 부류를 등록할 수 없다(서버가 모르는 파생 역할이라 해석
+  불가능한 정의를 만들게 되므로).
+
+시드 4종의 실 예시는 alembic/versions/0245_event_definitions.py의 _SEED 참조.
 """
 from __future__ import annotations
 

--- a/backend/app/models/event_definition.py
+++ b/backend/app/models/event_definition.py
@@ -1,0 +1,69 @@
+"""story #2632(이벤트 레지스트리 P1a) — 「정의=데이터」. doc event-registry-core-p1-plan §2-1.
+
+`event_definitions`는 발행 가능한 이벤트 타입의 카탈로그다 — 플랫폼 프리셋(`preset.*`,
+org_id NULL)과 org 커스텀(`org.{slug}.*`, org_id NOT NULL)이 한 테이블에 공존한다.
+`key` 유일성 축은 org_id 유무에 따라 갈린다(WebhookConfig의 project_id-nullable-scope
+패턴과 동형 — 부분 unique index 2개로 "전역 1개 vs org당 1개"를 각각 강제):
+- org_id IS NULL: `key` 전역 유일(프리셋끼리 이름 충돌 금지).
+- org_id IS NOT NULL: `(org_id, key)` 유일(다른 org가 같은 커스텀 key를 써도 무관).
+
+CHECK 제약은 네임스페이스 접두사의 "모양"만 방어선으로 건다(preset.*는 org_id NULL과만,
+org.*는 org_id NOT NULL과만 짝지어짐) — **"org.{slug}.*"의 slug가 실제로 그 org 자신의
+slug인지는 DB가 모르는 사실이라 여기서 못 잡는다**(cross-org 도용 방지는 app 레이어,
+event_definition_registry.py의 validate_event_definition_key가 진짜 강제 지점 — AC2).
+
+`payload_schema`(JSON Schema)는 발행 시 payload를 검증한다 — 모르는 필드 거부는 스키마가
+`additionalProperties: false`를 선언해야 실제로 걸린다(선언 안 하면 JSON Schema 기본값이
+관대해 조용히 통과한다 — 시드 4종 전부 명시 선언, event_definition_registry.py 참조).
+
+`routing`(상신선·전파선 선언)은 **선언**일 뿐 해석기가 아니다 — 실제 도달 계산(누구에게
+무엇으로)은 story #2633(발행 API + 도달 3층 해석기)의 몫. 여기 저장된 값의 shape은 그
+해석기의 계약이 확정되기 전까지 잠정(seed 주석 참조).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, CheckConstraint, DateTime, Index, Integer, Text, func, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class EventDefinition(Base):
+    __tablename__ = "event_definitions"
+    __table_args__ = (
+        CheckConstraint(
+            r"(org_id IS NULL AND key ~ '^preset\.[a-z0-9_]+(\.[a-z0-9_]+)+$')"
+            r" OR (org_id IS NOT NULL AND key ~ '^org\.[a-z0-9-]+\.[a-z0-9_]+(\.[a-z0-9_]+)*$')",
+            name="ck_event_definitions_key_namespace",
+        ),
+        Index(
+            "uq_event_definitions_preset_key", "key", unique=True,
+            postgresql_where=text("org_id IS NULL"),
+        ),
+        Index(
+            "uq_event_definitions_org_key", "org_id", "key", unique=True,
+            postgresql_where=text("org_id IS NOT NULL"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    key: Mapped[str] = mapped_column(Text, nullable=False)
+    org_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    payload_schema: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    routing: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    # P2(story #2637)가 소비 — nullable=없으면 제네릭 카드 폴백(블루프린트 §2-1 표).
+    block_template: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    action_auth: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
+    version: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1")
+    created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/services/event_definition_registry.py
+++ b/backend/app/services/event_definition_registry.py
@@ -16,6 +16,13 @@ import jsonschema
 _PRESET_KEY_RE = re.compile(r"^preset\.[a-z0-9_]+(\.[a-z0-9_]+)+$")
 _ORG_KEY_RE = re.compile(r"^org\.([a-z0-9-]+)\.[a-z0-9_]+(\.[a-z0-9_]+)*$")
 
+# routing.{escalation,broadcast}.kind="server_derived"의 닫힌 어휘(model.py docstring 참조,
+# 페드루 판정 2026-08-13) — story #2633(해석기)이 실제로 이 target들을 member_id로 풀어야
+# 하므로, 여기 없는 target을 server_derived로 등록하면 해석기가 절대 못 푸는 정의가 만들어진다
+# — validate_event_routing이 등록 시점에 막는다(발행 시점에야 발견되는 것보다 이르게).
+SERVER_DERIVED_TARGETS = frozenset({"none", "work_item_stakeholders", "goal_owner"})
+_ROUTING_KINDS = frozenset({"payload_field", "server_derived"})
+
 
 class InvalidEventDefinitionKeyError(ValueError):
     """key 네임스페이스 규칙 위반 — AC2."""
@@ -27,6 +34,11 @@ class InvalidEventPayloadError(ValueError):
     def __init__(self, message: str, *, errors: list[str]) -> None:
         super().__init__(message)
         self.errors = errors
+
+
+class InvalidEventRoutingError(ValueError):
+    """routing 선언이 두 부류 계약(model.py docstring)을 위반 — 등록 시점에 막아 #2633
+    해석기가 절대 못 푸는 정의가 저장되는 것을 방지."""
 
 
 def validate_event_definition_key(
@@ -56,6 +68,49 @@ def validate_event_definition_key(
             f"key의 네임스페이스 slug({m.group(1)!r})가 호출자 org의 slug({org_slug!r})와 "
             "일치하지 않습니다 — 타 org 네임스페이스 도용 차단."
         )
+
+
+def _validate_routing_leg(leg: dict, *, leg_name: str, allow_server_derived: bool) -> None:
+    kind = leg.get("kind")
+    if kind not in _ROUTING_KINDS:
+        raise InvalidEventRoutingError(
+            f"routing.{leg_name}.kind는 {sorted(_ROUTING_KINDS)} 중 하나여야 합니다: {kind!r}"
+        )
+    if kind == "payload_field":
+        if not leg.get("member_id_field"):
+            raise InvalidEventRoutingError(
+                f"routing.{leg_name}.kind='payload_field'는 member_id_field가 필수입니다."
+            )
+        return
+
+    # kind == "server_derived"
+    if leg.get("member_id_field"):
+        raise InvalidEventRoutingError(
+            f"routing.{leg_name}.kind='server_derived'는 member_id_field를 가질 수 없습니다 "
+            "(payload 필드가 아니라 서버 파생 역할이므로)."
+        )
+    if not allow_server_derived:
+        raise InvalidEventRoutingError(
+            f"routing.{leg_name}.kind='server_derived'는 org 커스텀 정의에 등록할 수 없습니다 "
+            "— 서버가 모르는 파생 역할은 해석 불가능한 정의를 만듭니다(payload_field만 허용)."
+        )
+    target = leg.get("target")
+    if target not in SERVER_DERIVED_TARGETS:
+        raise InvalidEventRoutingError(
+            f"routing.{leg_name}.target={target!r}은 server_derived 닫힌 어휘"
+            f"({sorted(SERVER_DERIVED_TARGETS)}) 밖입니다 — #2633 해석기가 풀 수 없는 정의."
+        )
+
+
+def validate_event_routing(routing: dict, *, allow_server_derived: bool = True) -> None:
+    """routing.escalation·routing.broadcast 둘 다 두 부류 계약(model.py docstring)을 지키는지
+    확인 — 프리셋 시드는 allow_server_derived=True(기본), story #2636의 org 커스텀 등록
+    경로는 allow_server_derived=False로 호출해 payload_field만 허용해야 한다."""
+    for leg_name in ("escalation", "broadcast"):
+        leg = routing.get(leg_name)
+        if not isinstance(leg, dict):
+            raise InvalidEventRoutingError(f"routing.{leg_name}이 없거나 object가 아닙니다.")
+        _validate_routing_leg(leg, leg_name=leg_name, allow_server_derived=allow_server_derived)
 
 
 def validate_event_payload(payload_schema: dict, payload: dict) -> None:

--- a/backend/app/services/event_definition_registry.py
+++ b/backend/app/services/event_definition_registry.py
@@ -1,0 +1,72 @@
+"""story #2632 — event_definitions 네임스페이스 강제 + payload 검증 (AC2/AC3).
+
+이 모듈이 "서버 강제"의 진짜 지점이다(model.py의 CHECK 제약은 접두사 모양만 보는 방어선 —
+`org.{slug}.*`의 slug가 **호출자 자신의 org slug**인지는 CHECK가 알 도리가 없다, model
+docstring 참조). story #2636(커스텀 등록 API)이 실제로 이 함수들을 호출하는 콜사이트가
+될 것 — #2632는 함수와 그 계약을 확정하고 시드로 증명한다(#2630의 release_circuit_breaker
+선례와 동형: 소비 endpoint 없이 함수+테스트로 먼저 굳힘).
+"""
+from __future__ import annotations
+
+import re
+import uuid
+
+import jsonschema
+
+_PRESET_KEY_RE = re.compile(r"^preset\.[a-z0-9_]+(\.[a-z0-9_]+)+$")
+_ORG_KEY_RE = re.compile(r"^org\.([a-z0-9-]+)\.[a-z0-9_]+(\.[a-z0-9_]+)*$")
+
+
+class InvalidEventDefinitionKeyError(ValueError):
+    """key 네임스페이스 규칙 위반 — AC2."""
+
+
+class InvalidEventPayloadError(ValueError):
+    """payload가 payload_schema를 위반(모르는 필드 포함) — AC3."""
+
+    def __init__(self, message: str, *, errors: list[str]) -> None:
+        super().__init__(message)
+        self.errors = errors
+
+
+def validate_event_definition_key(
+    key: str, *, org_id: uuid.UUID | None, org_slug: str | None,
+) -> None:
+    """AC2: preset.*는 org_id 없을 때만(플랫폼 전용) · org.{slug}.*는 그 org 자신의 slug와
+    정확히 일치할 때만(타 org 도용 차단) — 이 둘 다 CHECK 제약이 못 잡는 축이라 여기가
+    진짜 게이트. org_id가 주어졌는데 org_slug가 없으면(호출부 실수) fail-closed."""
+    if org_id is None:
+        if not _PRESET_KEY_RE.match(key):
+            raise InvalidEventDefinitionKeyError(
+                f"프리셋 정의(org_id=None)의 key는 'preset.'로 시작해야 합니다: {key!r}"
+            )
+        return
+
+    if not org_slug:
+        raise InvalidEventDefinitionKeyError(
+            "org 커스텀 정의는 org_slug 없이 검증할 수 없습니다(fail-closed)."
+        )
+    m = _ORG_KEY_RE.match(key)
+    if m is None:
+        raise InvalidEventDefinitionKeyError(
+            f"org 커스텀 정의의 key는 'org.{{slug}}.'로 시작해야 합니다: {key!r}"
+        )
+    if m.group(1) != org_slug:
+        raise InvalidEventDefinitionKeyError(
+            f"key의 네임스페이스 slug({m.group(1)!r})가 호출자 org의 slug({org_slug!r})와 "
+            "일치하지 않습니다 — 타 org 네임스페이스 도용 차단."
+        )
+
+
+def validate_event_payload(payload_schema: dict, payload: dict) -> None:
+    """AC3: payload_schema(JSON Schema) 대조 검증 — 스키마가 additionalProperties: false를
+    선언한 한도 내에서 모르는 필드도 거부된다(선언 안 한 스키마는 이 함수가 대신 강제하지
+    않는다 — 스키마 저작 시점의 책임, 시드 4종은 전부 선언함)."""
+    validator_cls = jsonschema.validators.validator_for(payload_schema)
+    validator_cls.check_schema(payload_schema)
+    validator = validator_cls(payload_schema)
+    errors = [e.message for e in validator.iter_errors(payload)]
+    if errors:
+        raise InvalidEventPayloadError(
+            f"payload가 payload_schema를 위반합니다({len(errors)}건)", errors=errors,
+        )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -54,6 +54,10 @@ dependencies = [
     # lazy-import하고 있었는데 이 패키지가 선언돼 있지 않았다(rate_limit_backend가 항상 "memory"라
     # 한 번도 실행 경로를 안 타 드러나지 않은 잠재 ImportError) — 이 선언이 그 갭도 같이 닫는다.
     "redis>=5.0.0",
+    # story #2632(이벤트 레지스트리 P1a): event_definitions.payload_schema(JSON Schema) 런타임
+    # 검증. 기존에 uv.lock 전이 의존성(4.26.0)으로만 있었고 직접 import하는 곳이 없었다 — 첫
+    # 실사용처라 직접 선언.
+    "jsonschema>=4.26.0",
 ]
 
 [dependency-groups]

--- a/backend/tests/test_2632_event_definitions.py
+++ b/backend/tests/test_2632_event_definitions.py
@@ -55,7 +55,7 @@ async def _seed_org(session, *, slug="acme"):
 async def test_seed_four_presets_exist_with_valid_schema_roundtrip():
     from sqlalchemy import select
     from app.models.event_definition import EventDefinition
-    from app.services.event_definition_registry import validate_event_payload
+    from app.services.event_definition_registry import validate_event_payload, validate_event_routing
 
     engine, Session = await _realdb_session()
     try:
@@ -86,6 +86,7 @@ async def test_seed_four_presets_exist_with_valid_schema_roundtrip():
             for key, payload_schema, routing in m0245._SEED:
                 assert payload_schema.get("additionalProperties") is False, key
                 assert isinstance(routing, dict) and "escalation" in routing and "broadcast" in routing, key
+                validate_event_routing(routing)  # 두 부류 계약(payload_field/server_derived) 준수
 
                 ed = EventDefinition(
                     id=uuid.uuid4(), key=key, org_id=None,
@@ -306,3 +307,72 @@ def test_seed_schemas_validate_realistic_payloads(key, payload, valid):
     else:
         with pytest.raises(InvalidEventPayloadError):
             validate_event_payload(schema_by_key[key], payload)
+
+
+# ─── routing 두 부류 계약(payload_field/server_derived, 페드루 판정 2026-08-13) ───────
+
+def test_routing_payload_field_requires_member_id_field():
+    from app.services.event_definition_registry import InvalidEventRoutingError, validate_event_routing
+
+    routing = {
+        "escalation": {"kind": "payload_field", "target": "assignee"},  # member_id_field 누락
+        "broadcast": {"kind": "server_derived", "target": "none"},
+    }
+    with pytest.raises(InvalidEventRoutingError):
+        validate_event_routing(routing)
+
+
+def test_routing_payload_field_with_member_id_field_valid():
+    from app.services.event_definition_registry import validate_event_routing
+
+    routing = {
+        "escalation": {
+            "kind": "payload_field", "target": "assignee", "member_id_field": "assignee_member_id",
+        },
+        "broadcast": {"kind": "server_derived", "target": "work_item_stakeholders"},
+    }
+    validate_event_routing(routing)
+
+
+def test_routing_server_derived_rejects_member_id_field():
+    from app.services.event_definition_registry import InvalidEventRoutingError, validate_event_routing
+
+    routing = {
+        "escalation": {"kind": "server_derived", "target": "none", "member_id_field": "oops"},
+        "broadcast": {"kind": "server_derived", "target": "none"},
+    }
+    with pytest.raises(InvalidEventRoutingError):
+        validate_event_routing(routing)
+
+
+def test_routing_server_derived_rejects_target_outside_closed_vocabulary():
+    from app.services.event_definition_registry import InvalidEventRoutingError, validate_event_routing
+
+    routing = {
+        "escalation": {"kind": "server_derived", "target": "none"},
+        "broadcast": {"kind": "server_derived", "target": "made_up_target"},
+    }
+    with pytest.raises(InvalidEventRoutingError):
+        validate_event_routing(routing)
+
+
+def test_routing_org_custom_rejects_server_derived_kind():
+    """story #2636(org 커스텀 등록)은 allow_server_derived=False로 호출해야 — 서버가 모르는
+    파생 역할을 등록하게 두면 안 된다."""
+    from app.services.event_definition_registry import InvalidEventRoutingError, validate_event_routing
+
+    routing = {
+        "escalation": {"kind": "server_derived", "target": "none"},
+        "broadcast": {
+            "kind": "payload_field", "target": "custom", "member_id_field": "owner_member_id",
+        },
+    }
+    with pytest.raises(InvalidEventRoutingError):
+        validate_event_routing(routing, allow_server_derived=False)
+
+
+def test_routing_missing_leg_rejected():
+    from app.services.event_definition_registry import InvalidEventRoutingError, validate_event_routing
+
+    with pytest.raises(InvalidEventRoutingError):
+        validate_event_routing({"escalation": {"kind": "server_derived", "target": "none"}})

--- a/backend/tests/test_2632_event_definitions.py
+++ b/backend/tests/test_2632_event_definitions.py
@@ -1,0 +1,308 @@
+"""story #2632(이벤트 레지스트리 P1a) — event_definitions 스키마 + 프리셋 시드 4종.
+
+doc event-registry-core-p1-plan §2-1·§2-5. 검증 축:
+- AC1: 마이그레이션+모델+시드 4종이 실PG에서 정확(스키마 검증 왕복).
+- AC2: 네임스페이스 규칙 서버 강제 — preset.*는 org_id 없을 때만, org.{slug}.*는 호출자
+  자신의 org slug와 정확히 일치할 때만(타 org 도용 차단). model.py의 CHECK는 "모양"만
+  보는 방어선이라 별도(부분 unique index·app 레이어 검증기 둘 다 실측).
+- AC3: payload_schema 검증이 모르는 필드를 거부한다(양성·음성).
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug="acme"):
+    from app.models.organization import Organization
+
+    org = Organization(id=uuid.uuid4(), name="Org2632", slug=slug)
+    session.add(org)
+    await session.commit()
+    return org.id
+
+
+# ─── AC1: 마이그레이션+모델+시드 4종 ────────────────────────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_seed_four_presets_exist_with_valid_schema_roundtrip():
+    from sqlalchemy import select
+    from app.models.event_definition import EventDefinition
+    from app.services.event_definition_registry import validate_event_payload
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            # create_all은 CHECK/부분-unique-index까지 모델 metadata에서 재구축(Index·
+            # CheckConstraint가 __table_args__에 선언돼 있으므로) — 마이그레이션과 별개로
+            # ORM 경로에서도 시드를 직접 심어 model.py 자체의 정합을 확인한다(마이그레이션
+            # 실행 자체의 검증은 별도로 `alembic upgrade head` 실측, PR 본문 기재).
+            #
+            # 이 테스트는 create_all 스키마라 마이그레이션 시드가 없다 — 마이그레이션 파일의
+            # _SEED 리터럴을 직접 import해 "그 시드가 실제로 유효한 payload_schema인지"만
+            # 이 프로세스에서 검증한다(마이그레이션 실행 자체는 alembic upgrade head가 검증).
+            import importlib.util
+            import os
+            spec = importlib.util.spec_from_file_location(
+                "_m0245", os.path.join(os.path.dirname(__file__), "..", "alembic", "versions", "0245_event_definitions.py"),
+            )
+            m0245 = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(m0245)
+
+            assert len(m0245._SEED) == 4
+            keys = {row[0] for row in m0245._SEED}
+            assert keys == {
+                "preset.gate.verdict", "preset.work.status_changed",
+                "preset.work.assigned", "preset.goal.measured",
+            }
+
+            for key, payload_schema, routing in m0245._SEED:
+                assert payload_schema.get("additionalProperties") is False, key
+                assert isinstance(routing, dict) and "escalation" in routing and "broadcast" in routing, key
+
+                ed = EventDefinition(
+                    id=uuid.uuid4(), key=key, org_id=None,
+                    payload_schema=payload_schema, routing=routing,
+                )
+                s.add(ed)
+            await s.commit()
+
+            rows = (await s.execute(select(EventDefinition))).scalars().all()
+            assert len(rows) == 4
+    finally:
+        await engine.dispose()
+
+
+# ─── AC2: 네임스페이스 강제 — DB 제약(모양) ────────────────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_check_constraint_rejects_preset_key_with_org_id():
+    from sqlalchemy.exc import IntegrityError
+    from app.models.event_definition import EventDefinition
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            s.add(EventDefinition(
+                id=uuid.uuid4(), key="preset.gate.verdict", org_id=org_id,
+                payload_schema={"type": "object"}, routing={},
+            ))
+            with pytest.raises(IntegrityError):
+                await s.commit()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_check_constraint_rejects_org_prefixed_key_with_null_org_id():
+    from sqlalchemy.exc import IntegrityError
+    from app.models.event_definition import EventDefinition
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            s.add(EventDefinition(
+                id=uuid.uuid4(), key="org.acme.custom_event", org_id=None,
+                payload_schema={"type": "object"}, routing={},
+            ))
+            with pytest.raises(IntegrityError):
+                await s.commit()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_partial_unique_index_scopes_key_uniqueness_by_org():
+    """preset key는 전역 유일(org 무관 재사용 불가) · org 커스텀 key는 org별 독립(다른
+    org가 같은 key를 써도 충돌 없음)."""
+    from sqlalchemy.exc import IntegrityError
+    from app.models.event_definition import EventDefinition
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_a = await _seed_org(s, slug="acme")
+            org_b = await _seed_org(s, slug="globex")
+
+            s.add(EventDefinition(
+                id=uuid.uuid4(), key="org.acme.deploy_finished", org_id=org_a,
+                payload_schema={"type": "object"}, routing={},
+            ))
+            s.add(EventDefinition(
+                id=uuid.uuid4(), key="org.globex.deploy_finished", org_id=org_b,
+                payload_schema={"type": "object"}, routing={},
+            ))
+            await s.commit()  # 다른 org의 같은-모양 key는 충돌 없음
+
+            s.add(EventDefinition(
+                id=uuid.uuid4(), key="org.acme.deploy_finished", org_id=org_a,
+                payload_schema={"type": "object"}, routing={},
+            ))
+            with pytest.raises(IntegrityError):
+                await s.commit()  # 같은 org 안 중복 key는 거부
+    finally:
+        await engine.dispose()
+
+
+# ─── AC2: 네임스페이스 강제 — app 레이어(진짜 게이트, cross-org 도용 차단) ────────────
+
+def test_validate_key_accepts_preset_with_null_org():
+    from app.services.event_definition_registry import validate_event_definition_key
+
+    validate_event_definition_key("preset.gate.verdict", org_id=None, org_slug=None)
+
+
+def test_validate_key_rejects_preset_prefix_with_org_id():
+    from app.services.event_definition_registry import (
+        InvalidEventDefinitionKeyError, validate_event_definition_key,
+    )
+
+    with pytest.raises(InvalidEventDefinitionKeyError):
+        validate_event_definition_key(
+            "preset.gate.verdict", org_id=uuid.uuid4(), org_slug="acme",
+        )
+
+
+def test_validate_key_accepts_org_key_matching_own_slug():
+    from app.services.event_definition_registry import validate_event_definition_key
+
+    validate_event_definition_key(
+        "org.acme.deploy_finished", org_id=uuid.uuid4(), org_slug="acme",
+    )
+
+
+def test_validate_key_rejects_org_key_with_mismatched_slug():
+    """cross-org 네임스페이스 도용 차단 — CHECK 제약이 못 잡는 축(진짜 강제 지점)."""
+    from app.services.event_definition_registry import (
+        InvalidEventDefinitionKeyError, validate_event_definition_key,
+    )
+
+    with pytest.raises(InvalidEventDefinitionKeyError):
+        validate_event_definition_key(
+            "org.globex.deploy_finished", org_id=uuid.uuid4(), org_slug="acme",
+        )
+
+
+def test_validate_key_fails_closed_when_org_id_present_but_slug_missing():
+    from app.services.event_definition_registry import (
+        InvalidEventDefinitionKeyError, validate_event_definition_key,
+    )
+
+    with pytest.raises(InvalidEventDefinitionKeyError):
+        validate_event_definition_key(
+            "org.acme.deploy_finished", org_id=uuid.uuid4(), org_slug=None,
+        )
+
+
+# ─── AC3: payload_schema 검증 — 모르는 필드 거부(양성·음성) ────────────────────────
+
+def test_validate_payload_accepts_conforming_payload():
+    from app.services.event_definition_registry import validate_event_payload
+
+    schema = {
+        "type": "object", "additionalProperties": False,
+        "required": ["a"], "properties": {"a": {"type": "string"}},
+    }
+    validate_event_payload(schema, {"a": "ok"})  # raise 없으면 통과
+
+
+def test_validate_payload_rejects_unknown_field():
+    from app.services.event_definition_registry import InvalidEventPayloadError, validate_event_payload
+
+    schema = {
+        "type": "object", "additionalProperties": False,
+        "required": ["a"], "properties": {"a": {"type": "string"}},
+    }
+    with pytest.raises(InvalidEventPayloadError) as ei:
+        validate_event_payload(schema, {"a": "ok", "unexpected_field": "sneaky"})
+    assert ei.value.errors
+
+
+def test_validate_payload_rejects_missing_required_field():
+    from app.services.event_definition_registry import InvalidEventPayloadError, validate_event_payload
+
+    schema = {
+        "type": "object", "additionalProperties": False,
+        "required": ["a"], "properties": {"a": {"type": "string"}},
+    }
+    with pytest.raises(InvalidEventPayloadError):
+        validate_event_payload(schema, {})
+
+
+def test_validate_payload_rejects_wrong_type():
+    from app.services.event_definition_registry import InvalidEventPayloadError, validate_event_payload
+
+    schema = {
+        "type": "object", "additionalProperties": False,
+        "required": ["a"], "properties": {"a": {"type": "string"}},
+    }
+    with pytest.raises(InvalidEventPayloadError):
+        validate_event_payload(schema, {"a": 123})
+
+
+@pytest.mark.parametrize("key,payload,valid", [
+    ("preset.gate.verdict", {
+        "work_item_type": "story", "work_item_id": str(uuid.uuid4()),
+        "gate_type": "merge", "verdict": "approved",
+    }, True),
+    ("preset.gate.verdict", {
+        "work_item_type": "story", "work_item_id": str(uuid.uuid4()),
+        "gate_type": "merge", "verdict": "approved", "extra": "nope",
+    }, False),
+    ("preset.work.assigned", {
+        "work_item_type": "story", "work_item_id": str(uuid.uuid4()),
+        "assignee_member_id": str(uuid.uuid4()),
+    }, True),
+    ("preset.goal.measured", {"goal_id": str(uuid.uuid4()), "metric_value": 42.5}, True),
+    ("preset.goal.measured", {"goal_id": str(uuid.uuid4())}, False),  # metric_value 누락
+])
+def test_seed_schemas_validate_realistic_payloads(key, payload, valid):
+    """마이그레이션 시드 스키마 4종 실물이 realistic payload에 대해 올바르게 판정하는지."""
+    import importlib.util
+    import os
+
+    from app.services.event_definition_registry import InvalidEventPayloadError, validate_event_payload
+
+    spec = importlib.util.spec_from_file_location(
+        "_m0245b", os.path.join(os.path.dirname(__file__), "..", "alembic", "versions", "0245_event_definitions.py"),
+    )
+    m0245 = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m0245)
+    schema_by_key = {row[0]: row[1] for row in m0245._SEED}
+
+    if valid:
+        validate_event_payload(schema_by_key[key], payload)
+    else:
+        with pytest.raises(InvalidEventPayloadError):
+            validate_event_payload(schema_by_key[key], payload)


### PR DESCRIPTION
## Summary
First story of the event registry campaign (doc `event-registry-core-p1-plan`, doc `event-registry-full-spec-decomposition`, both PO-approved). `event_definitions` is the catalog of publishable event types:

- **Namespace**: `preset.*` (platform-owned, `org_id` NULL) and `org.{slug}.*` (org-custom, `org_id` set) coexist in one table. `key` uniqueness is scoped by `org_id` nullness via two partial unique indexes — same pattern as `WebhookConfig`'s `project_id`-nullable scoping (global-1 vs per-org-1).
- **Namespace enforcement is two layers**: a DB CHECK constraint defends the prefix *shape* only (it can't correlate a key's `{slug}` segment against the caller's actual org — that's a cross-table fact the DB doesn't have). `event_definition_registry.validate_event_definition_key` is the real gate — it rejects `org.{other-org-slug}.*` even when `org_id` is technically valid, closing the cross-org namespace-squatting hole the CHECK structurally can't cover (AC2).
- **`payload_schema` validation** (`validate_event_payload`) wraps `jsonschema` — first runtime consumer of it in this codebase (it was a transitive-only dependency before this; now declared directly in `pyproject.toml`). All 4 seed schemas set `additionalProperties: false` explicitly, since JSON Schema doesn't default to rejecting unknown fields (AC3).
- **4 preset seeds**: `preset.gate.verdict`, `preset.work.status_changed`, `preset.work.assigned`, `preset.goal.measured` (the last one is the no-connector external-metric-input path from the P1 plan's vision section — GA4/GitHub values an agent reads and republishes as this event).
- `routing` (escalation-line / broadcast-line declaration) is intentionally a thin declarative shape — the actual resolution algorithm is story #2633's job; this story only needs the storage contract to hold.

## Scope
- No publish API, no MCP surface, no resolution logic — those are #2633/#2634. This story is the data-definition layer only, proven by seeds + a validator function with no consumer endpoint yet (same shape as #2630's `release_circuit_breaker` landing before its endpoint existed).

## Test plan
- [x] `test_2632_event_definitions.py` (18 tests): migration+model+4-seed roundtrip, CHECK constraint rejects mismatched org_id/key-prefix pairing (both directions), partial-unique-index scopes key uniqueness correctly by org (same-shape keys in different orgs don't collide, same-org duplicate does), `validate_event_definition_key` positive/negative including the cross-org-slug-squatting case and fail-closed-on-missing-slug, `validate_event_payload` positive/negative (unknown field / missing required / wrong type), and all 4 seed schemas validated against realistic conforming/violating payloads.
- [x] Migration 0245 verified round-trip (upgrade/downgrade -1/upgrade) against a disposable Postgres with the full chain through 0244 applied.
- [x] Full non-destructive backend suite (6115 passed) + `test_2630_circuit_breaker.py`/`test_2626_chain_escalation_episode.py`/`test_2617_chain_escalation.py`/`test_2608_*.py`/deeplink manifest tests (66 total) re-verified against a fresh container on the correctly-rebased branch (based on develop post-#3022-merge, not the pre-squash history) — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)