### PR TITLE
[SID:2602] both-fix — heartbeat-advance-gated lease refresh + wipe-race suppression

### DIFF
--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -117,7 +117,8 @@ async def _mark_agent_online(agent_id: uuid.UUID, session_id: uuid.UUID) -> None
 
 
 async def _mark_agent_disconnected(
-    agent_id: uuid.UUID, session_id: uuid.UUID, org_id: str | None = None
+    agent_id: uuid.UUID, session_id: uuid.UUID, org_id: str | None = None,
+    *, heartbeat_baseline: "datetime | None" = None,
 ) -> None:
     """49fed0a1 AC2/AC3: SSE 연결 종료 cleanup — 연결-도출 offline 강등.
 
@@ -125,7 +126,14 @@ async def _mark_agent_disconnected(
     offline로 강등. 같은 API Key의 멀티세션(멀티인스턴스 Cloud Run)은 한 presence 그룹이므로
     **마지막 연결이 끊길 때만** offline (AC2). last_seen_at=None → presence_status 즉시 offline
     (schema 단락). MCP heartbeat·재연결 시 online 복귀(self-heal). finally 호출이라 예외 비전파.
-    """
+
+    story #2602 Fix②(wipe-race 억제): `heartbeat_baseline`(호출부가 자기 connect 시점을 넘김,
+    미지정 시 기존 동작 그대로·회귀 없음)보다 **새 heartbeat 신호**가 있으면 강등을 skip한다 —
+    내 연결이 끊기는 그 순간, 내가 시작한 뒤에 이 agent에게 heartbeat(PATCH /heartbeat) 또는
+    다른 연결의 connect-time write(둘 다 agent_project_profiles.last_seen_at을 건드림, AC2
+    무관하게 connect 시점엔 항상 씀 — 아래 참조)가 있었다는 뜻이라, 내 cleanup이 그보다 늦게
+    도착한 stale order다(row-존재 체크만으론 못 잡는 TOCTOU — B의 세션 row insert가 아직 이
+    쿼리 시야에 안 들어온 좁은 창)."""
     now = datetime.now(timezone.utc)
     from app.core.config import settings as _settings
     _ac2 = bool(_settings.presence_online_redis_enabled) and bool(_settings.redis_url)
@@ -163,6 +171,19 @@ async def _mark_agent_disconnected(
                 from app.services import presence_online
                 if await presence_online.is_online(agent_id) is False:
                     remaining = None
+
+                # story #2602 Fix②: heartbeat_baseline보다 새 last_seen_at이 있으면(내가 시작한
+                # 뒤 heartbeat 또는 다른 세션의 connect write가 있었다는 뜻) 강등을 skip한다 —
+                # remaining을 "존재하는 것으로" 취급(위 accel과 반대 방향, 억제 전용 — 이미 None이
+                # 아니면 원래도 강등 안 하니 이 축은 "강등하려던 상황을 되돌리는" 경우만 의미 있다).
+                if remaining is None and heartbeat_baseline is not None:
+                    from app.services.heartbeat_freshness import (
+                        get_agent_last_heartbeat, incr_wipe_suppressed_counter,
+                    )
+                    _latest_hb = await get_agent_last_heartbeat(db, agent_id)
+                    if _latest_hb is not None and _latest_hb > heartbeat_baseline:
+                        remaining = session_id  # sentinel — "잔여 있음" 재사용(실제 row id 아님)
+                        await incr_wipe_suppressed_counter()
             else:
                 # 기존 freshness 경로(30s틱 유지·flag off·무회귀).
                 fresh_cutoff = now - timedelta(seconds=_SESSION_FRESH_TTL)
@@ -522,6 +543,12 @@ async def agent_stream(
                 )
                 await _pdb.commit()
             _presence_wired = True
+            # story #2602 Fix①/②의 기준점 — 이 시점 이후의 last_seen_at 전진만 "내 connect
+            # write 이후에 일어난 일"로 인정한다(내 connect write 자체는 위에서 이미 커밋됨).
+            # Fix①: 연결 단위 무장 상태(전진을 한 번이라도 봤는지) — arm 후 stale 전환 시만 skip.
+            _heartbeat_baseline = datetime.now(timezone.utc)
+            _heartbeat_last_observed: "datetime | None" = None
+            _heartbeat_armed = False
             # #2120 AC2: 연결 즉시 online 키 SET(타노드 GET서 즉시 online 가시). flag off면 no-op.
             # connect DB write(위 세션 INSERT + profile online)는 내구/폴백용으로 유지.
             from app.services import presence_online
@@ -562,15 +589,43 @@ async def agent_stream(
                 _now = datetime.now(timezone.utc)
                 if (_now - last_presence_tick).total_seconds() >= _PRESENCE_TICK_INTERVAL:
                     from app.core.config import settings as _settings
-                    if _settings.presence_online_redis_enabled and _settings.redis_url:
+                    _ac2_on = bool(_settings.presence_online_redis_enabled) and bool(_settings.redis_url)
+                    if _ac2_on:
                         # #2120 AC2: online liveness를 Redis 키로 — hot-path DB write 0.
                         from app.services import presence_online
                         await presence_online.mark_online(agent_id)
                     else:
                         await _mark_agent_online(agent_id, session_id)  # 기존 DB 틱(flag off·무회귀)
+
+                    # story #2602 Fix① — refresh를 무조건 걸지 않고 heartbeat 전진 여부로 게이트.
+                    # AC2 off일 땐 위 else 분기가 이 루프 자신의 tick으로 last_seen_at을 쓰므로
+                    # (heartbeat_freshness.py 모듈 docstring의 회로형 함정) 이 게이트를 적용하지
+                    # 않는다 — AC2 on일 때만(그 분기는 last_seen_at을 안 건드리니 heartbeat
+                    # 엔드포인트 전용 신호가 성립, 페드루 판정 2026-08-13).
+                    _skip_refresh = False
+                    if _ac2_on:
+                        from app.services.heartbeat_freshness import (
+                            evaluate_advance, get_agent_last_heartbeat,
+                            incr_armed_counter, incr_refresh_skip_counter,
+                        )
+                        async with async_session_factory() as _hb_db:
+                            _current_hb = await get_agent_last_heartbeat(_hb_db, agent_id)
+                        _gate = evaluate_advance(
+                            current=_current_hb, last_observed=_heartbeat_last_observed,
+                            armed=_heartbeat_armed,
+                        )
+                        _heartbeat_armed = _gate.armed
+                        _heartbeat_last_observed = _gate.last_observed
+                        _skip_refresh = _gate.should_skip_refresh
+                        if _gate.newly_armed:
+                            await incr_armed_counter()
+                        if _gate.should_skip_refresh:
+                            await incr_refresh_skip_counter()
+
                     # #2121: lease score 재갱신(live 연결이 슬롯 유지·TTL 만료 방지). off/다운 no-op.
-                    await sse_lease.refresh("agent_global", _lease_conn_id)
-                    await sse_lease.refresh(f"perkey:{agent_id_str}", _lease_conn_id)
+                    if not _skip_refresh:
+                        await sse_lease.refresh("agent_global", _lease_conn_id)
+                        await sse_lease.refresh(f"perkey:{agent_id_str}", _lease_conn_id)
                     last_presence_tick = _now
                 get_task = asyncio.create_task(queue.get())
                 shutdown_task = asyncio.create_task(_shutdown_module.shutdown_event.wait())
@@ -642,7 +697,9 @@ async def agent_stream(
             # 49fed0a1 AC2/AC3: 연결 종료 → 세션 행 삭제 + 마지막 세션이면 presence offline 강등.
             # (presence 배선 성공한 연결만 — 세션 미생성 시 타 세션 presence 오염 방지.)
             if _presence_wired:
-                await _mark_agent_disconnected(agent_id, session_id, org_id_str)
+                await _mark_agent_disconnected(
+                    agent_id, session_id, org_id_str, heartbeat_baseline=_heartbeat_baseline,
+                )
 
     return StreamingResponse(
         generate(),

--- a/backend/app/services/heartbeat_freshness.py
+++ b/backend/app/services/heartbeat_freshness.py
@@ -65,13 +65,22 @@ def evaluate_advance(
     전혀 없어 이 파일 상단 docstring의 "전진 vs 신선함" 규칙을 부수효과 없이 직접 단위
     테스트한다(agent_gateway.py의 SSE 제너레이터 내부는 직접 호출 불가라 여기로 추출).
 
-    - current가 last_observed보다 전진(> ) 또는 last_observed가 아직 None(첫 관측) →
-      무장(armed=True)·refresh 진행·last_observed 갱신.
-    - 전진이 없고(current <= last_observed, 또는 current가 None) 이미 armed →
-      refresh skip(좀비 시그니처).
+    ⚠️(페드루 리뷰 지적, 2026-08-13 — #3028 head 497eafbd7 시점) **첫 관측은 무장으로
+    치지 않는다.** connect-time write(agent_gateway.py 세션 등록 블록)가 AC2 무관 보편적
+    이라 — dial-out 연결도 last_seen_at이 「있다」(connect 시점 1회). last_observed=None을
+    "전진"으로 취급하면 dial-out의 그 최초 값이 첫 tick에 무장을 트리거하고, 둘째 tick부터
+    (다시는 안 바뀌므로) 곧장 skip 판정으로 떨어져 정상 dial-out 연결의 lease가 회수되는
+    바로 그 역회귀가 재현된다. 그래서 last_observed가 **None이 아닐 때만** 전진을 인정한다
+    — 첫 tick은 기록만 하고 무장 판단을 유보(비용: 무장까지 1 tick 지연, 안전측).
+
+    - `last_observed is not None`이고 `current > last_observed`(진짜 전진) → 무장·refresh
+      진행·last_observed 갱신.
+    - 전진이 없고(current가 last_observed 이하, None, 또는 last_observed 자체가 아직
+      None=첫 관측) 이미 armed → refresh skip(좀비 시그니처 — 전진하다 멈춘 경우만 해당,
+      첫 관측은 위에서 armed=False로 시작하니 여기 안 옴).
     - 전진이 없고 아직 armed 아님(dial-out류·첫 heartbeat 전) → 현행대로 refresh 진행,
-      무장하지 않음(회귀 없음)."""
-    if current is not None and (last_observed is None or current > last_observed):
+      무장하지 않음(회귀 없음) — last_observed는 기록해 다음 tick 비교 기준으로 삼는다."""
+    if current is not None and last_observed is not None and current > last_observed:
         return HeartbeatGateResult(
             armed=True, should_skip_refresh=False,
             last_observed=current, newly_armed=not armed,
@@ -81,7 +90,8 @@ def evaluate_advance(
             armed=True, should_skip_refresh=True, last_observed=last_observed, newly_armed=False,
         )
     return HeartbeatGateResult(
-        armed=False, should_skip_refresh=False, last_observed=last_observed, newly_armed=False,
+        armed=False, should_skip_refresh=False,
+        last_observed=current if current is not None else last_observed, newly_armed=False,
     )
 
 

--- a/backend/app/services/heartbeat_freshness.py
+++ b/backend/app/services/heartbeat_freshness.py
@@ -1,0 +1,126 @@
+"""story #2602(both-fix, PO 승인 2026-08-13) — SSE 루프의 `is_disconnected()` 의존을
+독립 liveness 축(MCP heartbeat, `PATCH /team_members/{id}/heartbeat`)으로 보강한다.
+
+prod 관측(08-13 18:37, 페드루 gcloud 실측): ①/agent/stream 429 재시도 폭풍 ②「Truncated
+response」연속(SSE 비정상 사망을 서버가 못 앎) ③**429가 나는 동안 heartbeat는 200 흐름**
+(슬롯 판정과 heartbeat 판정이 서로 다른 진실을 봄 — 이 모듈이 메꾸는 그 간극) ④offline
+오노출(wipe-race 정황).
+
+⛔**"신선함"이 아니라 "전진"을 본다**: SSE 연결 자체가 connect 시점에 이미 `last_seen_at`을
+한 번 쓴다(agent_gateway.py 세션 등록 블록, AC2 플래그 무관) — 그래서 connect 직후 첫
+tick(~30s 후)엔 그 최초 write가 아직 "신선"해 보인다. dial-out 에이전트(Hermes 등, MCP
+heartbeat 미호출·agent_gateway.py 43-44행 주석 참조)는 그 최초 write 뒤로 last_seen_at이
+**영영 안 바뀐다** — 단순 "신선한가"만 보면 dial-out 연결도 첫 tick엔 "신선"으로 오판해
+무장(arm)되고, 몇 tick 뒤 그 최초 write가 자연히 낡으면 "무장된 채 stale"로 오판해 정상
+연결의 lease refresh를 부당하게 skip한다(고치려는 사고와 반대 방향의 신규 회귀). 그래서
+무장 조건은 "값이 이전 관측보다 **전진**했는가"다 — heartbeat가 실제로 반복 호출되는
+연결만 전진이 관측되고, dial-out은 최초 write 이후 영원히 같은 값이라 전진이 단 한 번도
+없다. **무장은 연결(커넥션) 단위**다 — agent 전역 과거 이력으로 무장하면 타입 전환·장기
+유휴에서 오판 여지가 생긴다(페드루 판정 2026-08-13).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.member import AgentProjectProfile
+from app.services import redis_shared
+
+_DOMAIN = "heartbeat_freshness"
+
+
+async def get_agent_last_heartbeat(db: AsyncSession, agent_id: uuid.UUID) -> datetime | None:
+    """이 agent의 agent_project_profiles.last_seen_at 최댓값(멀티프로젝트 agent는 profile
+    행이 여럿이나 sync_agent_profile_presence가 전부 동일값으로 UPDATE하므로 MAX로 충분).
+    행이 없으면 None(신규/미온보딩 — arm 대상 아님, 호출부가 "전진 없음"과 동일하게 처리)."""
+    return (await db.execute(
+        select(func.max(AgentProjectProfile.last_seen_at)).where(
+            AgentProjectProfile.member_id == agent_id
+        )
+    )).scalar_one_or_none()
+
+
+class HeartbeatGateResult:
+    """evaluate_advance()의 순수 판정 결과 — 부수효과(카운터 증가) 없이 다음 상태만."""
+
+    __slots__ = ("armed", "should_skip_refresh", "last_observed", "newly_armed")
+
+    def __init__(
+        self, *, armed: bool, should_skip_refresh: bool,
+        last_observed: datetime | None, newly_armed: bool,
+    ) -> None:
+        self.armed = armed
+        self.should_skip_refresh = should_skip_refresh
+        self.last_observed = last_observed
+        self.newly_armed = newly_armed
+
+
+def evaluate_advance(
+    *, current: datetime | None, last_observed: datetime | None, armed: bool,
+) -> HeartbeatGateResult:
+    """agent_gateway.py의 presence tick이 매번 호출하는 순수 상태전이 — Redis/DB I/O가
+    전혀 없어 이 파일 상단 docstring의 "전진 vs 신선함" 규칙을 부수효과 없이 직접 단위
+    테스트한다(agent_gateway.py의 SSE 제너레이터 내부는 직접 호출 불가라 여기로 추출).
+
+    - current가 last_observed보다 전진(> ) 또는 last_observed가 아직 None(첫 관측) →
+      무장(armed=True)·refresh 진행·last_observed 갱신.
+    - 전진이 없고(current <= last_observed, 또는 current가 None) 이미 armed →
+      refresh skip(좀비 시그니처).
+    - 전진이 없고 아직 armed 아님(dial-out류·첫 heartbeat 전) → 현행대로 refresh 진행,
+      무장하지 않음(회귀 없음)."""
+    if current is not None and (last_observed is None or current > last_observed):
+        return HeartbeatGateResult(
+            armed=True, should_skip_refresh=False,
+            last_observed=current, newly_armed=not armed,
+        )
+    if armed:
+        return HeartbeatGateResult(
+            armed=True, should_skip_refresh=True, last_observed=last_observed, newly_armed=False,
+        )
+    return HeartbeatGateResult(
+        armed=False, should_skip_refresh=False, last_observed=last_observed, newly_armed=False,
+    )
+
+
+async def incr_armed_counter() -> None:
+    """이 커넥션이 최초로 무장된 순간(전진 최초 관측) 1회 — prod에서 heartbeat-사용 fleet
+    비중을 관측(dial-out 제외가 실제로 걸리는지 확認, PO 조건). off/Redis 다운 → no-op."""
+    async def _op(client) -> None:
+        await client.incr(redis_shared.key(_DOMAIN, "armed_total"))
+    await redis_shared.with_fallback(_op, lambda: None)
+
+
+async def incr_refresh_skip_counter() -> None:
+    """무장된 연결이 stale(전진 정지)로 전환돼 lease refresh를 skip한 순간마다 1회 — Fix①."""
+    async def _op(client) -> None:
+        await client.incr(redis_shared.key(_DOMAIN, "refresh_skip_total"))
+    await redis_shared.with_fallback(_op, lambda: None)
+
+
+async def incr_wipe_suppressed_counter() -> None:
+    """`_mark_agent_disconnected`가 내 baseline보다 새 신호(heartbeat 또는 새 연결의 connect
+    write)를 보고 오프라인 강등을 skip한 순간마다 1회 — Fix②. prod에서 이 카운터가 실제로
+    오르는지가 ④(wipe-race 정황)의 원인이 ⓐ(이 클래스)인지 아니면 다른 ⓑ인지를 가른다."""
+    async def _op(client) -> None:
+        await client.incr(redis_shared.key(_DOMAIN, "wipe_suppressed_total"))
+    await redis_shared.with_fallback(_op, lambda: None)
+
+
+async def get_counters() -> dict[str, int | None]:
+    """관측용 — QA/운영 조회. 값이 None인 항목은 Redis 불가(집계 무의미, 별도 처리 불필요
+    — 카운터 자체가 fail-open no-op이라 상승이 없을 뿐 오차가 안 남)."""
+    client = redis_shared.get_client()
+    if client is None:
+        return {"armed_total": None, "refresh_skip_total": None, "wipe_suppressed_total": None}
+
+    async def _op(c) -> dict[str, int | None]:
+        keys = ["armed_total", "refresh_skip_total", "wipe_suppressed_total"]
+        vals = await c.mget([redis_shared.key(_DOMAIN, k) for k in keys])
+        return {k: (int(v) if v is not None else 0) for k, v in zip(keys, vals)}
+
+    return await redis_shared.with_fallback(
+        _op, lambda: {"armed_total": None, "refresh_skip_total": None, "wipe_suppressed_total": None},
+    )

--- a/backend/tests/test_2602_heartbeat_freshness.py
+++ b/backend/tests/test_2602_heartbeat_freshness.py
@@ -77,28 +77,43 @@ def test_evaluate_advance_never_seen_stays_unarmed_no_skip():
     assert r.newly_armed is False
 
 
-def test_evaluate_advance_frozen_value_after_arming_skips_refresh():
-    """connect-time 최초 write 하나만 있고 그 뒤로 다시는 안 바뀌는 값(같은 last_seen_at
-    반복 관측)은 최초 1회 무장 후 곧바로 skip 판정 — "heartbeat가 1번 오고 멈춘" 케이스의
-    핵심 회귀가드(신선함이 아니라 전진을 본다)."""
+def test_evaluate_advance_first_observation_only_records_never_arms():
+    """페드루 리뷰 지적(2026-08-13, #3028 head 497eafbd7) — 첫 관측(last_observed=None→값)은
+    기록만 하고 무장하지 않는다. connect-time write(agent_gateway.py 세션 등록 블록)가 AC2
+    무관 보편적이라, "첫 관측=전진"으로 치면 dial-out도 첫 tick에 무장되고 둘째 tick(값이
+    안 바뀌므로)부터 곧장 skip으로 떨어져 정상 dial-out 연결의 lease가 회수되는 그 역회귀가
+    재현된다 — 그래서 last_observed가 이미 값을 가진 뒤의 전진만 무장 사유로 인정한다."""
     from app.services.heartbeat_freshness import evaluate_advance
 
     frozen = datetime(2026, 8, 13, 12, 0, 0, tzinfo=timezone.utc)
     r1 = evaluate_advance(current=frozen, last_observed=None, armed=False)
-    assert r1.armed is True and r1.newly_armed is True
-    r2 = evaluate_advance(current=frozen, last_observed=r1.last_observed, armed=r1.armed)
-    assert r2.should_skip_refresh is True
+    assert r1.armed is False and r1.newly_armed is False and r1.should_skip_refresh is False
+    assert r1.last_observed == frozen  # 다음 tick 비교 기준으로는 기록됨
 
 
-def test_evaluate_advance_dial_out_realistic_never_arms():
-    """진짜 dial-out 재현 — get_agent_last_heartbeat가 애초에 None을 반환(heartbeat
-    엔드포인트를 한 번도 안 침, connect-time write는 last_seen_at이 아니라 별도 축이라고
-    가정 못 하는 최악 케이스도 커버: profile row 자체가 없거나 MAX가 None인 경우).
-    이 경로가 여러 tick 반복돼도 무장이 단 한 번도 안 걸려야 정상 refresh가 유지된다."""
+def test_evaluate_advance_dial_out_realistic_frozen_after_connect_never_arms():
+    """진짜 dial-out 재현 — connect-time write로 last_seen_at은 «있지만»(None이 아님)
+    그 이후 다시는 안 바뀐다(heartbeat 엔드포인트를 한 번도 안 침). 첫 tick은 기록만,
+    이후 여러 tick 반복돼도 값이 그대로라 무장이 단 한 번도 안 걸려야 정상 refresh가
+    유지된다 — Fix①의 핵심 회귀가드(구 버전은 여기서 실패했다, #3028 페드루 지적)."""
+    from app.services.heartbeat_freshness import evaluate_advance
+
+    frozen = datetime(2026, 8, 13, 12, 0, 0, tzinfo=timezone.utc)
+    armed, last_observed = False, None
+    for _ in range(5):  # 5 tick 시뮬레이션 — connect-write 값이 그대로 반복 관측됨
+        r = evaluate_advance(current=frozen, last_observed=last_observed, armed=armed)
+        armed, last_observed = r.armed, r.last_observed
+        assert r.should_skip_refresh is False
+    assert armed is False
+
+
+def test_evaluate_advance_no_profile_row_never_arms():
+    """profile row 자체가 없어 get_agent_last_heartbeat가 매번 None을 반환하는 최악
+    케이스도 무장 0(현행 refresh 유지)."""
     from app.services.heartbeat_freshness import evaluate_advance
 
     armed, last_observed = False, None
-    for _ in range(5):  # 5 tick 시뮬레이션 — 매번 current=None(heartbeat 신호 전무)
+    for _ in range(5):
         r = evaluate_advance(current=None, last_observed=last_observed, armed=armed)
         armed, last_observed = r.armed, r.last_observed
         assert r.should_skip_refresh is False
@@ -107,7 +122,8 @@ def test_evaluate_advance_dial_out_realistic_never_arms():
 
 def test_evaluate_advance_heartbeat_user_then_stops_arms_then_skips():
     """heartbeat가 반복 전진하다가(무장) 멈추면(전진 정지) 그 다음 tick부터 skip — Fix①의
-    핵심 시나리오(429 스톰의 원인이 된 실제 zombie 시그니처)."""
+    핵심 시나리오(429 스톰의 원인이 된 실제 zombie 시그니처). 무장은 «두 번째» 전진
+    관측부터(첫 관측은 기록만, 페드루 리뷰 반영)."""
     from app.services.heartbeat_freshness import evaluate_advance
 
     t0 = datetime(2026, 8, 13, 12, 0, 0, tzinfo=timezone.utc)
@@ -115,10 +131,10 @@ def test_evaluate_advance_heartbeat_user_then_stops_arms_then_skips():
     t2 = t0 + timedelta(seconds=60)
 
     r1 = evaluate_advance(current=t0, last_observed=None, armed=False)
-    assert r1.armed is True and r1.newly_armed is True and r1.should_skip_refresh is False
+    assert r1.armed is False and r1.newly_armed is False and r1.should_skip_refresh is False  # 첫 관측 — 기록만
 
-    r2 = evaluate_advance(current=t1, last_observed=r1.last_observed, armed=r1.armed)
-    assert r2.armed is True and r2.newly_armed is False and r2.should_skip_refresh is False  # 계속 전진 — 재무장 카운트 없음
+    r2 = evaluate_advance(current=t1, last_observed=r1.last_observed, armed=r1.armed)  # 진짜 전진(t0→t1)
+    assert r2.armed is True and r2.newly_armed is True and r2.should_skip_refresh is False
 
     r3 = evaluate_advance(current=t1, last_observed=r2.last_observed, armed=r2.armed)  # heartbeat 정지(같은 값)
     assert r3.should_skip_refresh is True

--- a/backend/tests/test_2602_heartbeat_freshness.py
+++ b/backend/tests/test_2602_heartbeat_freshness.py
@@ -1,0 +1,272 @@
+"""story #2602(both-fix, PO 승인 2026-08-13) — heartbeat 전진 기반 lease refresh 게이트(Fix①)
++ wipe-race 억제(Fix②).
+
+prod 관측(08-13 18:37): ①/agent/stream 429 재시도 폭풍 ②「Truncated response」연속(SSE
+비정상 사망을 서버가 못 앎) ③429가 나는 동안 heartbeat는 200 흐름(독립 liveness 축)
+④offline 오노출(wipe-race 정황).
+
+검증 축:
+- AC①: `evaluate_advance()` 순수 상태전이 — dial-out(전진 없음)은 영원히 미무장·정상 refresh
+  유지(회귀 0), heartbeat-user는 무장 후 stale 전환 시에만 skip.
+- AC②: 양 모드 분기 — AC2 on(게이트 작동)·off(현행 그대로, heartbeat_baseline 무시).
+- AC③: orphan 시나리오에서 lease가 실제로(fakeredis 실 TTL 경과) evict — refresh 보류=
+  #2630/#2622 QA式 라이브 재현과 동형 원리(메커니즘 자체를 짧은 TTL로 축소해 실측).
+- skip·무장 카운터 실물(Redis INCR).
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+AGENT_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _fakeredis_client():
+    aioredis = pytest.importorskip("fakeredis.aioredis")
+    server = aioredis.FakeServer()
+    return aioredis.FakeRedis(server=server, decode_responses=True)
+
+
+def _patch_session_factory(execute_results=None):
+    """test_agent_gateway.py의 헬퍼와 동형(파일 독립성 유지 — 다른 story 파일 재사용 관례,
+    #2630/#2632 선례와 동일 이유)."""
+    import contextlib
+
+    db = MagicMock()
+    results = list(execute_results or [])
+
+    async def _execute(*a, **k):
+        return results.pop(0) if results else MagicMock()
+
+    db.execute = AsyncMock(side_effect=_execute)
+    db.commit = AsyncMock()
+
+    def _factory():
+        @contextlib.asynccontextmanager
+        async def _cm():
+            yield db
+        return _cm()
+
+    return _factory, db
+
+
+def _ac2_settings_patches():
+    from app.core.config import settings
+    return (patch.object(settings, "presence_online_redis_enabled", True),
+            patch.object(settings, "redis_url", "redis://x"))
+
+
+# ─── AC①: evaluate_advance() 순수 상태전이 ──────────────────────────────────────
+
+def test_evaluate_advance_never_seen_stays_unarmed_no_skip():
+    """dial-out 첫 tick(아직 heartbeat 신호 자체가 없음) — 무장 안 함·skip 안 함."""
+    from app.services.heartbeat_freshness import evaluate_advance
+
+    r = evaluate_advance(current=None, last_observed=None, armed=False)
+    assert r.armed is False
+    assert r.should_skip_refresh is False
+    assert r.newly_armed is False
+
+
+def test_evaluate_advance_frozen_value_after_arming_skips_refresh():
+    """connect-time 최초 write 하나만 있고 그 뒤로 다시는 안 바뀌는 값(같은 last_seen_at
+    반복 관측)은 최초 1회 무장 후 곧바로 skip 판정 — "heartbeat가 1번 오고 멈춘" 케이스의
+    핵심 회귀가드(신선함이 아니라 전진을 본다)."""
+    from app.services.heartbeat_freshness import evaluate_advance
+
+    frozen = datetime(2026, 8, 13, 12, 0, 0, tzinfo=timezone.utc)
+    r1 = evaluate_advance(current=frozen, last_observed=None, armed=False)
+    assert r1.armed is True and r1.newly_armed is True
+    r2 = evaluate_advance(current=frozen, last_observed=r1.last_observed, armed=r1.armed)
+    assert r2.should_skip_refresh is True
+
+
+def test_evaluate_advance_dial_out_realistic_never_arms():
+    """진짜 dial-out 재현 — get_agent_last_heartbeat가 애초에 None을 반환(heartbeat
+    엔드포인트를 한 번도 안 침, connect-time write는 last_seen_at이 아니라 별도 축이라고
+    가정 못 하는 최악 케이스도 커버: profile row 자체가 없거나 MAX가 None인 경우).
+    이 경로가 여러 tick 반복돼도 무장이 단 한 번도 안 걸려야 정상 refresh가 유지된다."""
+    from app.services.heartbeat_freshness import evaluate_advance
+
+    armed, last_observed = False, None
+    for _ in range(5):  # 5 tick 시뮬레이션 — 매번 current=None(heartbeat 신호 전무)
+        r = evaluate_advance(current=None, last_observed=last_observed, armed=armed)
+        armed, last_observed = r.armed, r.last_observed
+        assert r.should_skip_refresh is False
+    assert armed is False
+
+
+def test_evaluate_advance_heartbeat_user_then_stops_arms_then_skips():
+    """heartbeat가 반복 전진하다가(무장) 멈추면(전진 정지) 그 다음 tick부터 skip — Fix①의
+    핵심 시나리오(429 스톰의 원인이 된 실제 zombie 시그니처)."""
+    from app.services.heartbeat_freshness import evaluate_advance
+
+    t0 = datetime(2026, 8, 13, 12, 0, 0, tzinfo=timezone.utc)
+    t1 = t0 + timedelta(seconds=30)
+    t2 = t0 + timedelta(seconds=60)
+
+    r1 = evaluate_advance(current=t0, last_observed=None, armed=False)
+    assert r1.armed is True and r1.newly_armed is True and r1.should_skip_refresh is False
+
+    r2 = evaluate_advance(current=t1, last_observed=r1.last_observed, armed=r1.armed)
+    assert r2.armed is True and r2.newly_armed is False and r2.should_skip_refresh is False  # 계속 전진 — 재무장 카운트 없음
+
+    r3 = evaluate_advance(current=t1, last_observed=r2.last_observed, armed=r2.armed)  # heartbeat 정지(같은 값)
+    assert r3.should_skip_refresh is True
+
+    r4 = evaluate_advance(current=t2, last_observed=r3.last_observed, armed=r3.armed)  # heartbeat 재개
+    assert r4.should_skip_refresh is False and r4.armed is True and r4.newly_armed is False
+
+
+# ─── AC②: _mark_agent_disconnected Fix② — wipe-race 억제(on 모드) ────────────────
+
+@pytest.mark.anyio
+async def test_wipe_suppressed_when_newer_heartbeat_after_baseline():
+    """내 connect(baseline) 이후 heartbeat가 실제로 왔으면 오프라인 강등 skip."""
+    from app.routers.agent_gateway import _mark_agent_disconnected
+
+    s1, s2 = _ac2_settings_patches()
+    no_remaining = MagicMock(); no_remaining.scalar_one_or_none.return_value = None
+    newer_hb = MagicMock()
+    baseline = datetime.now(timezone.utc) - timedelta(seconds=10)
+    newer_hb.scalar_one_or_none.return_value = datetime.now(timezone.utc)  # baseline보다 새것
+    factory, db = _patch_session_factory([MagicMock(), no_remaining, newer_hb])
+    with s1, s2, \
+         patch("app.routers.agent_gateway.async_session_factory", factory), \
+         patch("app.services.agent_anchor_sync.sync_agent_profile_presence", new=AsyncMock()) as mock_sync, \
+         patch("app.services.presence_online.is_online", new=AsyncMock(return_value=True)), \
+         patch("app.services.presence_online.clear_online", new=AsyncMock()) as mock_clear, \
+         patch("app.services.chat_presence.clear_member", new=AsyncMock(return_value=[])), \
+         patch("app.services.heartbeat_freshness.incr_wipe_suppressed_counter", new=AsyncMock()) as mock_incr:
+        await _mark_agent_disconnected(
+            AGENT_ID, uuid.uuid4(), heartbeat_baseline=baseline,
+        )
+    mock_sync.assert_not_awaited()   # 강등 skip
+    mock_clear.assert_not_awaited()
+    mock_incr.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_wipe_proceeds_when_no_newer_heartbeat():
+    """baseline 이후 새 신호가 없으면(내가 마지막) 기존대로 강등 진행."""
+    from app.routers.agent_gateway import _mark_agent_disconnected
+
+    s1, s2 = _ac2_settings_patches()
+    no_remaining = MagicMock(); no_remaining.scalar_one_or_none.return_value = None
+    older_hb = MagicMock()
+    baseline = datetime.now(timezone.utc)
+    older_hb.scalar_one_or_none.return_value = baseline - timedelta(seconds=5)  # baseline보다 오래됨
+    factory, db = _patch_session_factory([MagicMock(), no_remaining, older_hb])
+    with s1, s2, \
+         patch("app.routers.agent_gateway.async_session_factory", factory), \
+         patch("app.services.agent_anchor_sync.sync_agent_profile_presence", new=AsyncMock()) as mock_sync, \
+         patch("app.services.presence_online.is_online", new=AsyncMock(return_value=True)), \
+         patch("app.services.presence_online.clear_online", new=AsyncMock()) as mock_clear, \
+         patch("app.services.chat_presence.clear_member", new=AsyncMock(return_value=[])):
+        await _mark_agent_disconnected(
+            AGENT_ID, uuid.uuid4(), heartbeat_baseline=baseline,
+        )
+    mock_sync.assert_awaited_once()
+    _, kw = mock_sync.await_args
+    assert kw["agent_status"] == "offline"
+    mock_clear.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_wipe_check_skipped_when_baseline_not_provided():
+    """heartbeat_baseline 미지정(기존 호출부·회귀 없음) — Fix② 쿼리 자체를 안 하고 기존 로직
+    그대로(execute 호출 횟수가 기존과 동일해야 — 3번째 execute가 없어야 함)."""
+    from app.routers.agent_gateway import _mark_agent_disconnected
+
+    s1, s2 = _ac2_settings_patches()
+    no_remaining = MagicMock(); no_remaining.scalar_one_or_none.return_value = None
+    factory, db = _patch_session_factory([MagicMock(), no_remaining])  # 딱 2개만 — 3번째 있으면 MagicMock() 기본값 소비돼 조용히 통과하니 count로 명시 확인
+    with s1, s2, \
+         patch("app.routers.agent_gateway.async_session_factory", factory), \
+         patch("app.services.agent_anchor_sync.sync_agent_profile_presence", new=AsyncMock()) as mock_sync, \
+         patch("app.services.presence_online.is_online", new=AsyncMock(return_value=True)), \
+         patch("app.services.presence_online.clear_online", new=AsyncMock()):
+        await _mark_agent_disconnected(AGENT_ID, uuid.uuid4())  # heartbeat_baseline 생략
+    mock_sync.assert_awaited_once()  # 기존(2620/49fed0a1) 동작 그대로 강등
+    assert db.execute.await_count == 2  # Fix② 쿼리(3번째) 없음 — 진짜 no-op 확인
+
+
+@pytest.mark.anyio
+async def test_off_mode_ignores_heartbeat_baseline():
+    """AC2 off — heartbeat_baseline을 넘겨도 무시(회로형 함정 방지, 페드루 판정 2026-08-13
+    "off 모드 자기충족 루프" 우려에 대한 대칭 처리)."""
+    from app.routers.agent_gateway import _mark_agent_disconnected
+
+    no_remaining = MagicMock(); no_remaining.scalar_one_or_none.return_value = None
+    factory, db = _patch_session_factory([MagicMock(), no_remaining])
+    with patch("app.routers.agent_gateway.async_session_factory", factory), \
+         patch("app.services.agent_anchor_sync.sync_agent_profile_presence", new=AsyncMock()) as mock_sync:
+        await _mark_agent_disconnected(
+            AGENT_ID, uuid.uuid4(), heartbeat_baseline=datetime.now(timezone.utc),
+        )
+    mock_sync.assert_awaited_once()  # off 모드는 기존 freshness 경로 그대로 — 강등 진행
+    assert db.execute.await_count == 2  # AC2 분기(Fix② 포함) 자체를 안 탐
+
+
+# ─── AC③: orphan 시 lease가 실제로 자연 evict(refresh 보류 메커니즘 실측) ──────────
+
+@pytest.mark.anyio
+async def test_lease_naturally_evicts_when_refresh_withheld():
+    """Fix①이 refresh를 skip하면 sse_lease의 자기 TTL이 그 슬롯을 실제로 회수한다 — 좀비가
+    lease를 영구 점유하던 원 사고(#2602 관측①②)를 메커니즘 레벨에서 실측. _TTL_SEC을
+    축소(90s→1s)해 실 sleep으로 검증 — 값 자체는 축소해도 "refresh 안 하면 TTL이 회수한다"는
+    메커니즘은 동치(TTL 값 자체는 sse_lease.py 자기 상수이지 이 스토리의 변경 대상 아님)."""
+    from app.services import sse_lease
+    from app.core.config import settings
+
+    client = _fakeredis_client()
+    with patch.object(settings, "sse_lease_redis_enabled", True), \
+         patch.object(settings, "redis_url", "redis://x"), \
+         patch("app.services.redis_shared.get_client", return_value=client), \
+         patch.object(sse_lease, "_TTL_SEC", 1):
+        acquired = await sse_lease.acquire("test_2602_scope", 1, "orphan-conn")
+        assert acquired is True
+        assert await sse_lease.count("test_2602_scope") == 1
+
+        # orphan 시뮬레이션: Fix①이 skip 판정한 그 상황과 동형 — refresh를 의도적으로 안 침.
+        await asyncio.sleep(1.3)
+
+        assert await sse_lease.count("test_2602_scope") == 0  # TTL 자연만료로 evict
+        # 새 연결이 그 슬롯을 즉시 획득할 수 있어야(429 스톰 원인이던 좀비 점유가 실제로 풀림).
+        assert await sse_lease.acquire("test_2602_scope", 1, "new-conn") is True
+
+
+# ─── 카운터 실물 ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_counters_increment_via_redis():
+    from app.services import heartbeat_freshness as hf
+
+    client = _fakeredis_client()
+    with patch("app.services.redis_shared.get_client", return_value=client):
+        await hf.incr_armed_counter()
+        await hf.incr_armed_counter()
+        await hf.incr_refresh_skip_counter()
+        await hf.incr_wipe_suppressed_counter()
+        counts = await hf.get_counters()
+    assert counts["armed_total"] == 2
+    assert counts["refresh_skip_total"] == 1
+    assert counts["wipe_suppressed_total"] == 1
+
+
+@pytest.mark.anyio
+async def test_counters_redis_down_returns_none():
+    from app.services import heartbeat_freshness as hf
+
+    with patch("app.services.redis_shared.get_client", return_value=None):
+        counts = await hf.get_counters()
+    assert counts == {"armed_total": None, "refresh_skip_total": None, "wipe_suppressed_total": None}


### PR DESCRIPTION
## Summary
Prod observation (2026-08-13 18:37, gcloud): `/agent/stream` 429 retry storms, "Truncated response" streaks (server never learns an SSE stream died abnormally), heartbeat (`PATCH /team_members/{id}/heartbeat`) staying 200 the whole time a stream is 429ing, and offline mis-exposure consistent with a wipe-race. `sse_lease.py`'s own docstring already named the mechanism: `refresh()` runs inside the same `request.is_disconnected()`-gated loop that's supposed to detect the death it's refreshing against — an orphan whose disconnect goes undetected keeps renewing its own lease forever (up to the ~300-330s lifespan cap, never the 90s TTL).

### Fix① — gate `sse_lease.refresh()` on heartbeat *advance*, not raw freshness
Freshness alone doesn't work: the SSE connection's own connect-time setup writes `agent_project_profiles.last_seen_at` once, regardless of agent type. A freshness-only check would arm on tick 1 for every connection and then wrongly starve **dial-out agents** (Hermes etc., which never call the heartbeat endpoint — per this file's own pre-existing comment) once that one-time write ages past the TTL window. This was caught and fixed before landing, not after — requiring the value to have **advanced** since the last observation is what actually distinguishes an agent that's genuinely heartbeating from one that wrote once at connect and went silent. Arming happens once per connection, the first time an advance is observed; connections that never observe an advance (dial-out) stay unarmed and keep current behavior (always refresh) for their whole lifetime.

Gated on `presence_online_redis_enabled=true` (confirmed on in prod/dev by Pedro) — off-mode's own tick writes that same DB column, which would make the check self-referential (a circularity trap caught before implementation, see PR discussion history).

### Fix② — `_mark_agent_disconnected` suppresses offline demotion on a newer signal
If `agent_project_profiles.last_seen_at` has advanced past the caller's own connection-start baseline, someone newer than me touched presence (either a real heartbeat, or another session's own connect-time write) — my cleanup is running out of order (TOCTOU: the new session's row insert may not be visible to my query yet). Same AC2 gate for the same self-reference reason — confirmed with Pedro before implementing that off-mode would otherwise suppress demotion *forever*, since its own tick perpetually advances the timestamp past any baseline.

### Design note
The armed/skip decision is extracted into a pure function (`heartbeat_freshness.evaluate_advance`) specifically so the state machine — the part that had to be exactly right — is unit-testable without driving the actual SSE generator.

### Observability (PO condition)
Root cause ⓐ (wipe-race) vs an unnamed ⓑ for the offline mis-exposure observation can't be fully separated from code alone. Redis counters (`armed_total`/`refresh_skip_total`/`wipe_suppressed_total`, via `heartbeat_freshness.get_counters()`) are the prod-observation surface for telling them apart post-landing.

## Test plan
- [x] `test_2602_heartbeat_freshness.py` (11 tests): pure `evaluate_advance()` state machine (never-seen stays unarmed, realistic dial-out never arms across repeated ticks, heartbeat-user arms then skips on stall then re-arms on resumption), `_mark_agent_disconnected` Fix② (suppresses on newer heartbeat, proceeds when no newer signal, no-op when `heartbeat_baseline` omitted — exact query-count assertion, off-mode ignores baseline entirely), lease natural eviction mechanism (fakeredis, `_TTL_SEC` shrunk to 1s to keep the test fast — proves "withhold refresh → TTL reclaims the slot" is real, not just asserted), counter increment/Redis-down fallback.
- [x] `test_agent_gateway.py` (28 existing tests) — unaffected, all green (confirms `heartbeat_baseline=None` default keeps every existing call site's behavior byte-identical).
- [x] `test_sse_lease.py`/`test_2602_sse_lease_lifespan_reclaim.py` — unaffected, all green.
- [ ] Live `/agent/stream` reproduction against dev (kill -9 style, matching the original #2602 fix's own verification methodology) not done here — flagging for Kadir's QA pass, since the fakeredis mechanism test proves the eviction mechanism itself but not the full live wiring end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)