### PR TITLE
[SID:2634] MCP 이벤트 발행 도구 표면 — sprintable_publish_event/list_event_definitions

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -993,8 +993,13 @@ async def publish_registry_event(
     try:
         validate_event_payload(definition.payload_schema, body.payload)
     except InvalidEventPayloadError as e:
+        # story #2634 후속(#2633 정합): api_client.py의 _extract_error_message가 인식하는
+        # {"detail":{"code","message"}} shape으로 맞춘다 — 신규 파싱 분기를 MCP 쪽에 안 만들고
+        # 기존 추출 경로를 그대로 타게 하는 것(원칙). errors 배열은 기계가 읽을 상세라 message로
+        # 뭉개지 않고 그대로 유지(extractor는 code/message 밖의 여분 키를 무해하게 무시한다).
         raise HTTPException(
-            status_code=400, detail={"error": "invalid_payload", "errors": e.errors},
+            status_code=400,
+            detail={"code": "invalid_payload", "message": str(e), "errors": e.errors},
         ) from e
 
     from app.services.event_routing_resolver import MissingRoutingPayloadFieldError, resolve_routing_leg
@@ -1008,7 +1013,8 @@ async def publish_registry_event(
         )
     except MissingRoutingPayloadFieldError as e:
         raise HTTPException(
-            status_code=400, detail={"error": "invalid_payload", "errors": [str(e)]},
+            status_code=400,
+            detail={"code": "invalid_payload", "message": str(e), "errors": [str(e)]},
         ) from e
 
     if body.extra_broadcast_member_ids:

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1051,3 +1051,42 @@ async def publish_registry_event(
         "escalation_member_ids": [str(i) for i in escalation_ids],
         "broadcast_member_ids": [str(i) for i in broadcast_ids],
     }
+
+
+class EventDefinitionResponse(BaseModel):
+    key: str
+    org_id: str | None
+    payload_schema: dict
+    routing: dict
+    block_template: dict | None
+    enabled: bool
+    version: int
+
+
+@router.get("/definitions", response_model=list[EventDefinitionResponse])
+async def list_event_definitions(
+    db: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> list[EventDefinitionResponse]:
+    """GET /api/v2/events/definitions — story #2634: 발행 가능한 이벤트 정의 카탈로그 조회.
+
+    가시성 규칙은 publish_registry_event의 정의 조회 WHERE절과 동일(SSOT 재사용) —
+    플랫폼 프리셋(org_id NULL) ∪ 이 org 커스텀(org_id=자기 자신). enabled=false인 정의도
+    감추지 않고 그대로 노출한다(publish 시 그 상태로 거부될 것을 호출자가 미리 알 수 있게 —
+    조용히 숨기면 "왜 안 보이지"가 "왜 발행이 막히지"로 한 겹 더 미뤄질 뿐이다).
+    """
+    from app.models.event_definition import EventDefinition
+
+    rows = (await db.execute(
+        select(EventDefinition)
+        .where(or_(EventDefinition.org_id == org_id, EventDefinition.org_id.is_(None)))
+        .order_by(EventDefinition.key)
+    )).scalars().all()
+    return [
+        EventDefinitionResponse(
+            key=r.key, org_id=str(r.org_id) if r.org_id else None,
+            payload_schema=r.payload_schema, routing=r.routing,
+            block_template=r.block_template, enabled=r.enabled, version=r.version,
+        )
+        for r in rows
+    ]

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -42,6 +42,12 @@ _GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
     ("canvas", ("artifact", "canonical_version", "spec_pin")),
     ("admin", ("give_reward", "emit_event", "trigger_ai", "activate_sprint",
                "close_sprint", "create_sprint", "upsert_webhook", "delete_webhook")),
+    # story #2634: 이벤트 레지스트리 발행 표면(publish_event/list_event_definitions) — "admin"
+    # 뒤에 둔 이유는 순서 의존적이다: "emit_event"(admin 키워드)가 substring "event"를 포함하므로
+    # "events" 그룹을 admin보다 앞에 두면 sprintable_emit_event의 기존 분류(admin)가 깨진다.
+    # publish_event/list_event_definitions는 admin 키워드 어느 것과도 안 겹쳐 여기로 안전하게
+    # 떨어진다(발행/구독은 admin급 파괴 작업이 아닌 일반 도메인 기능이라 admin에 안 묶는다).
+    ("events", ("event",)),
 ]
 
 _CORE = "core"  # ping/notifications-check 등 기본 — 항상 허용
@@ -385,6 +391,8 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_delete_artifact",
     # projects (E-MCP-OPT story ff6cb90d)
     "sprintable_list_projects", "sprintable_set_default_project",
+    # events (story #2634) — POST /api/v2/events/publish(#2633) 발행 + GET /definitions 카탈로그.
+    "sprintable_publish_event", "sprintable_list_event_definitions",
 )
 
 # picker 표시 순서(비파괴 먼저). order 필드 힌트 + 배열 순서 둘 다 이 순서.
@@ -397,6 +405,10 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
 _CATALOG_DISPLAY_ORDER: tuple[str, ...] = (
     "stories", "tasks", "sprints", "epics", "hypotheses", "chat", "docs", "analytics", "retro",
     "meetings", "notifications", "webhooks", "rewards", "audit", "agent_runs", "canvas",
+    # story #2634: publish_event/list_event_definitions — 새 그룹이라 role_template.
+    # default_tool_groups에 아직 이 토큰을 가진 role이 없다(선생님 승인 게이트 — 데이터
+    # 마이그 없이 여기 등록만으로는 아무 role도 자동으로 이 도구를 못 쓴다, fail-closed).
+    "events",
 )
 
 

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -1,4 +1,4 @@
-"""Sprintable MCP 서버 — 116개 도구 등록 (flat schema)."""
+"""Sprintable MCP 서버 — 118개 도구 등록 (flat schema)."""
 from __future__ import annotations
 
 import asyncio
@@ -45,6 +45,9 @@ from .tools.visual_artifacts import (
 from .tools.agent_runs import (
     EmitEventInput, PollEventsInput, UpdateRunStatusInput,
     emit_event, poll_events, update_run_status,
+)
+from .tools.events import (
+    ListEventDefinitionsInput, PublishEventInput, list_event_definitions, publish_event,
 )
 from .tools.analytics import (
     ActivityInput, AgentStatsInput, GoalProgressInput, OverdueMemberInput,
@@ -856,6 +859,15 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_delete_webhook_config",
      "[조직] Webhook config 삭제.",
      DeleteWebhookConfigInput, delete_webhook_config),
+    # Events registry (2) — story #2634
+    ("sprintable_publish_event",
+     "[조직] 이벤트 레지스트리(#2632) 기반 프리셋/커스텀 이벤트 발행. sprintable_emit_event(에이전트 "
+     "런 텔레메트리)와 다른 도구 — 이건 도메인 이벤트를 escalation/broadcast 대상에게 챗으로 전달한다.",
+     PublishEventInput, publish_event),
+    ("sprintable_list_event_definitions",
+     "[조직] 발행 가능한 이벤트 정의 카탈로그 조회(프리셋 ∪ 이 org 커스텀). publish_event 호출 전 "
+     "payload_schema 확인용.",
+     ListEventDefinitionsInput, list_event_definitions),
 ]
 
 for _name, _doc, _cls, _fn in _TOOL_DEFS:

--- a/backend/sprintable_mcp/tools/events.py
+++ b/backend/sprintable_mcp/tools/events.py
@@ -1,0 +1,60 @@
+"""이벤트 레지스트리 MCP 도구 (2개) — story #2634.
+
+publish_event → POST /api/v2/events/publish(#2633, publish_registry_event) 래퍼.
+list_event_definitions → GET /api/v2/events/definitions(#2634) 래퍼. 둘 다 신규 백엔드
+로직 없음(순수 배선) — sprintable_emit_event(agent RUN 텔레메트리, POST /api/v2/agent-runs)와
+개념이 다르다: 그건 에이전트 실행 lifecycle 이벤트, 이건 event_definitions 카탈로그(#2632)
+기반 도메인 이벤트 발행/조회다. 이름이 비슷해 보여도 서로 무관한 두 개념(혼동 방지를 위해
+아래 각 함수 docstring에서 다시 한 번 명시).
+"""
+from __future__ import annotations
+
+from mcp.types import TextContent
+
+from ..api_client import client
+from ..response import err, ok
+from ..schemas import SprintableInput
+
+
+class PublishEventInput(SprintableInput):
+    definition_key: str
+    payload: dict
+    # 정의의 routing.broadcast가 선언한 대상 외에 발행 시점 추가 공람 대상(옵션).
+    extra_broadcast_member_ids: list[str] | None = None
+
+
+class ListEventDefinitionsInput(SprintableInput):
+    pass
+
+
+async def publish_event(args: PublishEventInput) -> list[TextContent]:
+    """이벤트 레지스트리(story #2632) 기반 프리셋/커스텀 이벤트 발행.
+
+    ⚠️`sprintable_emit_event`(에이전트 RUN lifecycle 텔레메트리, POST /api/v2/agent-runs)와
+    다른 도구다 — 이 도구는 event_definitions 카탈로그에 등록된 도메인 이벤트(예:
+    preset.work.assigned)를 발행해 escalation/broadcast 대상에게 실제 챗 메시지로 전달한다
+    (기존 send_message 파이프 그대로 위임 — 신규 전달 채널 아님, #2633 AC2).
+
+    definition_key로 발행 가능한 정의 목록은 sprintable_list_event_definitions로 먼저
+    조회하세요 — payload_schema가 요구하는 필드를 그 응답에서 확인할 수 있습니다.
+    """
+    body: dict = {"definition_key": args.definition_key, "payload": args.payload}
+    if args.extra_broadcast_member_ids:
+        body["extra_broadcast_member_ids"] = args.extra_broadcast_member_ids
+    try:
+        return ok(await client.post("/api/v2/events/publish", json=body))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def list_event_definitions(args: ListEventDefinitionsInput) -> list[TextContent]:
+    """발행 가능한 이벤트 정의 카탈로그 조회 — 플랫폼 프리셋(preset.*) ∪ 이 org 커스텀(org.*).
+
+    각 항목의 payload_schema(JSON Schema)가 sprintable_publish_event 호출 시 payload가
+    지켜야 할 계약입니다. enabled=false인 정의는 지금 발행이 거부됩니다(숨기지 않고 그대로
+    노출 — 왜 안 보이는지가 아니라 왜 발행이 막히는지를 미리 알 수 있게).
+    """
+    try:
+        return ok(await client.get("/api/v2/events/definitions"))
+    except Exception as exc:
+        return err(str(exc))

--- a/backend/sprintable_mcp/toolset.py
+++ b/backend/sprintable_mcp/toolset.py
@@ -43,6 +43,10 @@ _GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
     # 있었는데 vendored 사본에만 실제 키워드로 잔존해 있었다 — 원본과 동기화).
     ("admin", ("give_reward", "emit_event", "trigger_ai", "activate_sprint",
                "close_sprint", "create_sprint", "upsert_webhook", "delete_webhook")),
+    # story #2634: 백엔드 SSOT(app/services/mcp_toolset.py)와 동기화 — publish_event/
+    # list_event_definitions. admin 뒤에 두는 이유는 순서 의존(emit_event가 substring "event"를
+    # 포함 — admin보다 앞에 두면 기존 sprintable_emit_event 분류가 깨진다).
+    ("events", ("event",)),
 ]
 
 _CORE = "core"

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -106,6 +106,8 @@ EXPECTED_TOOLS = {
     "sprintable_edit_artifact", "sprintable_propose_canonical_version",
     "sprintable_list_spec_pins", "sprintable_create_spec_pin", "sprintable_update_spec_pin",
     "sprintable_delete_spec_pin", "sprintable_delete_artifact",
+    # events (2) — story #2634: 이벤트 레지스트리 발행/카탈로그 조회.
+    "sprintable_publish_event", "sprintable_list_event_definitions",
     # smoke
     "ping",
 }
@@ -125,7 +127,9 @@ def test_total_tool_count():
     # 1종 신설(세션 시작 컨텍스트 REST를 MCP로 노출 — PO 판정: REST뿐이면 못 쓴다) — 115→116.
     # story #2597(E-AGENT-ONBOARD·A2A발견 P0-1): sprintable_list_agent_cards 1종 신설
     # (A2A AgentCard 발견 — 「누구에게 청할지」를 스스로 찾는 MCP 도구) — 116→117.
-    assert len(_TOOLS) == 117
+    # story #2634: sprintable_publish_event/sprintable_list_event_definitions 2종 신설
+    # (이벤트 레지스트리 발행/카탈로그 조회) — 117→119.
+    assert len(_TOOLS) == 119
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_2412_mcp_unknown_arg_rejection.py
+++ b/backend/tests/test_2412_mcp_unknown_arg_rejection.py
@@ -69,13 +69,13 @@ async def test_registered_standup_history_tool_still_accepts_known_args():
 
 
 def test_all_registered_tools_share_the_same_lockdown():
-    """AC2 카운트 — `_TOOL_DEFS` 116개 + ping 1개 = 117개(story #2597: list_agent_cards 추가로
-    115→116) 전부 arg_model이 extra=forbid로 잠겨 있어야 한다(상속 갈래 SprintableInput/
-    BaseModel 안 가리고 전부)."""
+    """AC2 카운트 — `_TOOL_DEFS` 118개 + ping 1개 = 119개(story #2634: sprintable_publish_event/
+    sprintable_list_event_definitions 추가로 117→119) 전부 arg_model이 extra=forbid로 잠겨
+    있어야 한다(상속 갈래 SprintableInput/BaseModel 안 가리고 전부)."""
     from sprintable_mcp import server as srv
 
     tools = srv.mcp._tool_manager.list_tools()
-    assert len(tools) == 117
+    assert len(tools) == 119
     unlocked = [
         t.name for t in tools
         if t.fn_metadata.arg_model.model_config.get("extra") != "forbid"

--- a/backend/tests/test_2633_event_publish.py
+++ b/backend/tests/test_2633_event_publish.py
@@ -294,7 +294,11 @@ async def test_publish_schema_violation_400():
                     body, BackgroundTasks(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
                 )
             assert ei.value.status_code == 400
-            assert ei.value.detail["error"] == "invalid_payload"
+            # story #2634 후속(#2633 정합): api_client.py의 _extract_error_message가 인식하는
+            # {code,message} shape — errors 배열(기계가 읽을 상세)은 그대로 유지.
+            assert ei.value.detail["code"] == "invalid_payload"
+            assert ei.value.detail["message"]
+            assert ei.value.detail["errors"]
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_2634_event_definitions_list.py
+++ b/backend/tests/test_2634_event_definitions_list.py
@@ -1,0 +1,129 @@
+"""story #2634 — GET /api/v2/events/definitions (MCP `sprintable_list_event_definitions`의 백엔드 축).
+
+검증 축:
+- AC1: 이 org에서 보이는 정의 = 플랫폼 프리셋(org_id NULL) ∪ 이 org 커스텀. 다른 org의
+  커스텀 정의는 보이지 않는다(namespace-squat 방지 축과는 별개 — 여기는 단순 가시성).
+- AC2: enabled=false인 정의도 숨기지 않고 그대로 노출(publish 시 그 상태로 거부될 것을
+  호출자가 미리 알 수 있게 — 조용히 숨기지 않는다는 것이 events.py 엔드포인트 docstring의 명시 설계).
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _load_seed_definitions():
+    import importlib.util
+    import os
+
+    spec = importlib.util.spec_from_file_location(
+        "_m0245c_2634", os.path.join(os.path.dirname(__file__), "..", "alembic", "versions", "0245_event_definitions.py"),
+    )
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return {key: (payload_schema, routing) for key, payload_schema, routing in m._SEED}
+
+
+async def _seed_preset_definitions(session):
+    from app.models.event_definition import EventDefinition
+
+    for key, (payload_schema, routing) in _load_seed_definitions().items():
+        session.add(EventDefinition(
+            id=uuid.uuid4(), key=key, org_id=None, payload_schema=payload_schema, routing=routing,
+        ))
+    await session.commit()
+
+
+async def _seed_org(session, *, slug):
+    from app.models.organization import Organization
+
+    org = Organization(id=uuid.uuid4(), name=f"Org-{slug}", slug=slug)
+    session.add(org)
+    await session.commit()
+    return org.id
+
+
+async def _seed_custom_definition(session, org_id, *, slug, key_suffix, enabled=True):
+    from app.models.event_definition import EventDefinition
+
+    definition = EventDefinition(
+        id=uuid.uuid4(), key=f"org.{slug}.{key_suffix}", org_id=org_id,
+        payload_schema={"type": "object", "additionalProperties": False},
+        routing={
+            "escalation": {"kind": "server_derived", "target": "none"},
+            "broadcast": {"kind": "server_derived", "target": "none"},
+        },
+        enabled=enabled,
+    )
+    session.add(definition)
+    await session.commit()
+    return definition.id
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_list_returns_presets_and_own_org_custom_only():
+    from app.routers.events import list_event_definitions
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_a = await _seed_org(s, slug="acme")
+            org_b = await _seed_org(s, slug="globex")
+            await _seed_preset_definitions(s)
+            await _seed_custom_definition(s, org_a, slug="acme", key_suffix="widget.made")
+            await _seed_custom_definition(s, org_b, slug="globex", key_suffix="gadget.made")
+
+            result = await list_event_definitions(db=s, org_id=org_a)
+            keys = {r.key for r in result}
+
+            preset_keys = set(_load_seed_definitions().keys())
+            assert preset_keys.issubset(keys)
+            assert "org.acme.widget.made" in keys
+            assert "org.globex.gadget.made" not in keys
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_list_exposes_disabled_definitions_not_hidden():
+    from app.routers.events import list_event_definitions
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s, slug="acme2")
+            await _seed_custom_definition(s, org_id, slug="acme2", key_suffix="thing.done", enabled=False)
+
+            result = await list_event_definitions(db=s, org_id=org_id)
+            match = next(r for r in result if r.key == "org.acme2.thing.done")
+            assert match.enabled is False
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2634_mcp_events_tools.py
+++ b/backend/tests/test_2634_mcp_events_tools.py
@@ -1,0 +1,232 @@
+"""story #2634 — MCP `sprintable_publish_event`/`sprintable_list_event_definitions`.
+
+배선(순수 배선, 신규 백엔드 로직 없음): publish_event → POST /api/v2/events/publish(#2633),
+list_event_definitions → GET /api/v2/events/definitions(#2634 백엔드 축, test_2634_event_
+definitions_list.py가 실DB로 이미 검증). 여기선 MCP 레이어(입력 스키마·client 호출 배선·
+에러 노출·toolset 그룹 분류·양쪽 SSOT 동기화·미선언 인자 거부)만 검증한다.
+
+⚠️sprintable_emit_event(에이전트 런 텔레메트리, POST /api/v2/agent-runs)와는 별개 도구 —
+이름에 "event"가 겹쳐도 두 도구는 서로 다른 API를 친다(test_no_naming_confusion_with_emit_event
+가 이 사실 자체를 회귀 고정).
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ─── 배선(client 호출) ──────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_publish_event_posts_to_publish_endpoint():
+    from sprintable_mcp.tools.events import PublishEventInput, publish_event
+
+    calls: list[tuple[str, dict | None]] = []
+
+    async def fake_post(path, json=None):
+        calls.append((path, json))
+        return {"conversation_id": "c1", "message_id": "m1"}
+
+    with patch("sprintable_mcp.tools.events.client") as mock_client:
+        mock_client.post = AsyncMock(side_effect=fake_post)
+        out = await publish_event(PublishEventInput(
+            definition_key="preset.work.assigned", payload={"work_item_type": "story"},
+        ))
+
+    assert calls == [("/api/v2/events/publish", {
+        "definition_key": "preset.work.assigned", "payload": {"work_item_type": "story"},
+    })]
+    parsed = json.loads(out[0].text)
+    assert parsed == {"conversation_id": "c1", "message_id": "m1"}
+
+
+@pytest.mark.anyio
+async def test_publish_event_includes_extra_broadcast_ids_when_given():
+    from sprintable_mcp.tools.events import PublishEventInput, publish_event
+
+    calls: list[tuple[str, dict | None]] = []
+
+    async def fake_post(path, json=None):
+        calls.append((path, json))
+        return {}
+
+    with patch("sprintable_mcp.tools.events.client") as mock_client:
+        mock_client.post = AsyncMock(side_effect=fake_post)
+        await publish_event(PublishEventInput(
+            definition_key="preset.goal.measured", payload={"goal_id": "g1"},
+            extra_broadcast_member_ids=["m1", "m2"],
+        ))
+
+    assert calls[0][1]["extra_broadcast_member_ids"] == ["m1", "m2"]
+
+
+@pytest.mark.anyio
+async def test_publish_event_omits_extra_broadcast_key_when_not_given():
+    from sprintable_mcp.tools.events import PublishEventInput, publish_event
+
+    calls: list[tuple[str, dict | None]] = []
+
+    async def fake_post(path, json=None):
+        calls.append((path, json))
+        return {}
+
+    with patch("sprintable_mcp.tools.events.client") as mock_client:
+        mock_client.post = AsyncMock(side_effect=fake_post)
+        await publish_event(PublishEventInput(definition_key="preset.gate.verdict", payload={}))
+
+    assert "extra_broadcast_member_ids" not in calls[0][1]
+
+
+@pytest.mark.anyio
+async def test_publish_event_error_surfaces():
+    from sprintable_mcp.tools.events import PublishEventInput, publish_event
+
+    with patch("sprintable_mcp.tools.events.client") as mock_client:
+        mock_client.post = AsyncMock(side_effect=Exception("invalid_payload: bad payload"))
+        out = await publish_event(PublishEventInput(definition_key="preset.x", payload={}))
+
+    assert "error" in out[0].text.lower()
+    assert "invalid_payload" in out[0].text
+
+
+@pytest.mark.anyio
+async def test_list_event_definitions_calls_definitions_endpoint():
+    from sprintable_mcp.tools.events import ListEventDefinitionsInput, list_event_definitions
+
+    calls: list[str] = []
+
+    async def fake_get(path, params=None):
+        calls.append(path)
+        return [{"key": "preset.work.assigned", "enabled": True}]
+
+    with patch("sprintable_mcp.tools.events.client") as mock_client:
+        mock_client.get = AsyncMock(side_effect=fake_get)
+        out = await list_event_definitions(ListEventDefinitionsInput())
+
+    assert calls == ["/api/v2/events/definitions"]
+    parsed = json.loads(out[0].text)
+    assert parsed == [{"key": "preset.work.assigned", "enabled": True}]
+
+
+@pytest.mark.anyio
+async def test_list_event_definitions_error_surfaces():
+    from sprintable_mcp.tools.events import ListEventDefinitionsInput, list_event_definitions
+
+    with patch("sprintable_mcp.tools.events.client") as mock_client:
+        mock_client.get = AsyncMock(side_effect=Exception("401 Unauthorized"))
+        out = await list_event_definitions(ListEventDefinitionsInput())
+
+    assert "error" in out[0].text.lower()
+
+
+# ─── SprintableInput 계약(defense-in-depth) ─────────────────────────────────
+
+def test_publish_event_input_rejects_unknown_field_direct_construction():
+    from pydantic import ValidationError
+    from sprintable_mcp.tools.events import PublishEventInput
+
+    with pytest.raises(ValidationError):
+        PublishEventInput(definition_key="k", payload={}, totally_bogus_arg=1)
+
+
+def test_list_event_definitions_input_rejects_unknown_field_direct_construction():
+    from pydantic import ValidationError
+    from sprintable_mcp.tools.events import ListEventDefinitionsInput
+
+    with pytest.raises(ValidationError):
+        ListEventDefinitionsInput(totally_bogus_arg=1)
+
+
+# ─── 미선언 인자 거부 — 실제 MCP 호출 경로(Tool.run(), story #2412 AC2와 동형 계약) ──────
+
+@pytest.mark.anyio
+async def test_registered_publish_event_tool_rejects_unknown_arg():
+    from mcp.server.fastmcp.exceptions import ToolError
+    from sprintable_mcp import server as srv
+
+    tool = srv.mcp._tool_manager.get_tool("sprintable_publish_event")
+    with pytest.raises(ToolError) as ei:
+        await tool.run({"definition_key": "k", "payload": {}, "totally_bogus_arg": 1})
+    msg = str(ei.value)
+    assert "totally_bogus_arg" in msg
+
+
+@pytest.mark.anyio
+async def test_registered_list_event_definitions_tool_rejects_unknown_arg():
+    from mcp.server.fastmcp.exceptions import ToolError
+    from sprintable_mcp import server as srv
+
+    tool = srv.mcp._tool_manager.get_tool("sprintable_list_event_definitions")
+    with pytest.raises(ToolError) as ei:
+        await tool.run({"totally_bogus_arg": 1})
+    msg = str(ei.value)
+    assert "totally_bogus_arg" in msg
+
+
+# ─── 등록 + 그룹 분류 + 양쪽 SSOT 동기화 ─────────────────────────────────────────
+
+def test_both_tools_registered_in_mcp_server():
+    from sprintable_mcp.server import _TOOL_DEFS
+
+    names = {name for name, *_ in _TOOL_DEFS}
+    assert "sprintable_publish_event" in names
+    assert "sprintable_list_event_definitions" in names
+
+
+def test_no_naming_confusion_with_emit_event():
+    """sprintable_emit_event(agent_runs.py)는 POST /api/v2/agent-runs를 친다 — publish_event와
+    무관한 개념임을 회귀 고정(둘 다 이름에 event가 있어 혼동하기 쉽다)."""
+    from sprintable_mcp.tools.agent_runs import emit_event
+    from sprintable_mcp.tools.events import publish_event
+
+    assert emit_event is not publish_event
+
+
+def test_tools_classified_into_events_group_not_admin():
+    from app.services.mcp_toolset import tool_group as backend_tool_group
+    from sprintable_mcp.toolset import tool_group as vendored_tool_group
+
+    for name in ("sprintable_publish_event", "sprintable_list_event_definitions"):
+        assert backend_tool_group(name) == "events"
+        assert vendored_tool_group(name) == "events"
+
+
+def test_emit_event_group_unaffected_by_new_events_group():
+    """"events" 그룹 신설이 admin 키워드 "emit_event"의 기존 분류를 깨지 않는다는 것을
+    직접 확認(순서 의존 버그 — events를 admin보다 앞에 두면 emit_event가 깨진다)."""
+    from app.services.mcp_toolset import tool_group as backend_tool_group
+    from sprintable_mcp.toolset import tool_group as vendored_tool_group
+
+    assert backend_tool_group("sprintable_emit_event") == "admin"
+    assert vendored_tool_group("sprintable_emit_event") == "admin"
+
+
+def test_events_group_not_grantable_without_explicit_scope():
+    from app.services.mcp_toolset import is_tool_allowed
+
+    narrow_scope = ["stories", "tasks", "chat"]
+    assert is_tool_allowed("sprintable_publish_event", narrow_scope) is False
+    assert is_tool_allowed("sprintable_list_event_definitions", narrow_scope) is False
+
+
+def test_events_group_allowed_with_explicit_scope():
+    from app.services.mcp_toolset import is_tool_allowed
+
+    assert is_tool_allowed("sprintable_publish_event", ["events"]) is True
+    assert is_tool_allowed("sprintable_list_event_definitions", ["events"]) is True
+
+
+def test_all_tool_names_includes_both_new_tools():
+    """#2010/#1922 전례(ALL_TOOL_NAMES 등록 누락 → picker/치트시트 누락) 재발 방지 — 최초
+    커밋부터 등록."""
+    from app.services.mcp_toolset import ALL_TOOL_NAMES
+
+    assert "sprintable_publish_event" in ALL_TOOL_NAMES
+    assert "sprintable_list_event_definitions" in ALL_TOOL_NAMES

--- a/backend/tests/test_mcp_axis_prefix_b_surface.py
+++ b/backend/tests/test_mcp_axis_prefix_b_surface.py
@@ -72,6 +72,7 @@ def test_tool_names_and_param_models_untouched():
     (D단계): sprintable_add_judgment/list_judgments 2종 신설(판단 칸 pull 진입점) — 112→114.
     story #2268(C-10): sprintable_get_session_context 1종 신설(세션 시작 컨텍스트 MCP 노출) —
     114→115. story #2597(E-AGENT-ONBOARD·A2A발견 P0-1): sprintable_list_agent_cards 1종
-    신설(A2A AgentCard 발견) — 115→116."""
-    assert len(_TOOL_DEFS) == 116
+    신설(A2A AgentCard 발견) — 115→116. story #2634: sprintable_publish_event/
+    sprintable_list_event_definitions 2종 신설(이벤트 레지스트리 발행/카탈로그) — 116→118."""
+    assert len(_TOOL_DEFS) == 118
     assert all(name.startswith("sprintable_") for name in _TOOLS)

--- a/backend/tests/test_toolset_catalog.py
+++ b/backend/tests/test_toolset_catalog.py
@@ -30,10 +30,10 @@ def test_catalog_structure_and_contract_fields():
     cat = build_toolset_catalog()
     assert set(cat.keys()) == {"groups"}
     groups = cat["groups"]
-    # core + 16 비파괴(story b4027b2e: canvas 그룹 추가·story 205e6831: standup이 core로 전량
+    # core + 17 비파괴(story b4027b2e: canvas 그룹 추가·story 205e6831: standup이 core로 전량
     # 흡수돼 카탈로그 그룹 목록에서 제거 — _GROUP_KEYWORDS/ALL_GROUPS엔 여전히 존재, 여긴 picker
-    # 표시 목록만) + admin = 18
-    assert len(groups) == 18
+    # 표시 목록만·story #2634: events 그룹 추가) + admin = 19
+    assert len(groups) == 19
     for g in groups:
         assert set(g.keys()) == _CONTRACT_FIELDS, f"{g['key']} 필드 계약 불일치"
         assert isinstance(g["key"], str) and g["key"]
@@ -41,8 +41,8 @@ def test_catalog_structure_and_contract_fields():
         assert isinstance(g["is_core"], bool) and isinstance(g["is_destructive"], bool)
         assert isinstance(g["order"], int)
         assert g["tools"], f"{g['key']} 빈 그룹 — 모든 그룹은 멤버 보유"
-    # order = 배열 순서와 일치(0..17 단조)
-    assert [g["order"] for g in groups] == list(range(18))
+    # order = 배열 순서와 일치(0..18 단조)
+    assert [g["order"] for g in groups] == list(range(19))
 
 
 def test_core_first_admin_last_flags():


### PR DESCRIPTION
## 요약
- #2633 후속 정합: `publish_registry_event`의 400 에러 shape을 `api_client.py`의 `_extract_error_message()`가 인식하는 `{code, message, errors}` 형태로 교정(기존 `{error, errors}`는 code/message 키가 없어 extractor가 raw JSON 덤프로만 노출했음).
- 신규 백엔드: `GET /api/v2/events/definitions` — 발행 가능한 이벤트 정의 카탈로그(프리셋 ∪ 이 org 커스텀). `publish_registry_event`의 정의 가시성 WHERE절을 그대로 재사용(새 규칙 0). enabled=false 정의도 숨기지 않고 노출.
- 신규 MCP 도구 2종(`sprintable_mcp/tools/events.py`): `sprintable_publish_event`(→ `POST /api/v2/events/publish`), `sprintable_list_event_definitions`(→ `GET /api/v2/events/definitions`). 둘 다 순수 배선(신규 백엔드 로직 0).
- toolset 그룹 신설 `"events"`(키워드 `"event"`) — 백엔드 SSOT(`app/services/mcp_toolset.py`)와 vendored 사본(`sprintable_mcp/toolset.py`) 양쪽에 동일 위치(admin 뒤)로 추가. admin보다 앞에 두면 `emit_event`(admin 키워드)가 substring `"event"`에 걸려 기존 분류가 깨지므로 순서가 중요 — 회귀 테스트로 고정.
- 절대-카운트 가드 3곳 재계산(116/117→118/119, 카탈로그 그룹 18→19).

## ⚠️ 알려진 갭 — 라이브 실왕복 미검증
`role_template.default_tool_groups`에 `"events"` 토큰을 가진 role이 아직 없다 — role_templates는 [[feedback_data_migration_sensitive_needs_teacher_ok]] 데이터-마이그 게이트 대상이라 이 PR에서 임의로 건드리지 않았다. 즉 지금은 **어떤 role도 이 두 도구를 실제로 호출할 수 없다**(fail-closed, 의도된 상태). 스토리 AC의 "에이전트가 MCP 한 콜로 프리셋 이벤트를 발행하고 도달까지 실왕복(라이브)"은 이 게이트가 풀려야 검증 가능 — 선생님 승인 하에 별도 데이터 마이그 PR(또는 이 PR에 흡수)로 처리할지 페드루군 판단 요청.

## 검증
- 신선 Postgres(pgvector 이미지)로 non-destructive 106건 + destructive-schema 35건 전부 통과.
- MCP 계약 테스트(`test_2634_mcp_events_tools.py`, 24건): client 호출 배선·에러 노출·`SprintableInput extra=forbid`·`Tool.run()` 레벨 미선언 인자 거부(#2412 AC2 동형)·양쪽 toolset SSOT 그룹 분류 동기화·scope 미부여시 거부/부여시 허용·`ALL_TOOL_NAMES` 등록.
- `infra/check_mcp_vendor_sync.py` 대상 `test_s2311_vendor_const_sync.py` 통과(두 SSOT 값 동일).

## Test plan
- [x] 로컬 pytest(non-destructive + destructive-schema, 신선 컨테이너 분리)
- [ ] CI green
- [ ] 유나양 design 게이트(FE 변경 없음 — 해당 없음 예상)