### PR TITLE
[SID:2643] conftest destructive_schema 가드 확장 — raw SQL DDL 리터럴 탐지

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -130,8 +130,56 @@ def _reset_schema_for_destructive_tests(request):
 # `conn.run_sync(Base.metadata.create_all)`처럼 콜백으로 전달되는 경우도 Attribute 노드로 잡힘)을
 # 정적 스캔해 마커 누락을 즉시·정확한 파일명으로 표면화한다(로컬 개발 시점에도 동일하게 발동 —
 # CI까지 갈 필요도 없음).
+#
+# story #2643(2026-08-14, #3031 CI 사고 규명 중 디디 발견): 위 스캔은 SQLAlchemy ORM API
+# 호출(`.create_all`/`.drop_all`)만 본다 — `sa.text("DROP TABLE ...")`처럼 raw SQL DDL을
+# 문자열로 직접 실행하는 테스트는 같은 파괴력(alembic-migrated 공유 DB의 실 테이블을 DROP)을
+# 가지면서도 이 정적 스캔을 완전히 피해간다. 그래서 아래 `_calls_raw_ddl_literal`을 추가해
+# **함수 호출의 인자로 쓰인 문자열 리터럴**만 정밀 스캔한다(모든 문자열 상수를 스캔하면
+# docstring/주석 프로즈가 "DROP TABLE"을 설명 목적으로 언급만 해도 오탐이 난다 — 실제로
+# **실행되는** 문자열인지가 판별축). 동적 조립 문자열(f-string·`+`·`.format()`)은 여전히
+# 못 본다 — AST 리터럴이 아니라서 값이 파싱 시점에 없다. 이 클래스는 의도적 잔여 사각으로
+# 남긴다(값을 실행 없이 정적으로 복원하려면 별도 데이터-흐름 분석이 필요해 이 가드의 비용
+# 대비 이득을 넘어선다) — 다음에 이 사각을 밟는 사람이 있다면 그게 그 판단이 틀렸다는
+# 신호이니 그때 확장한다.
 _DESTRUCTIVE_ATTRS = {"create_all", "drop_all"}
 _MARKER_NAME = "destructive_schema"
+_DDL_LITERAL_PATTERN = re.compile(r"\b(DROP|CREATE|TRUNCATE|ALTER)\s+TABLE\b", re.IGNORECASE)
+
+
+_SQL_EXEC_CALL_NAMES = {"text", "execute"}
+
+
+def _call_func_name(node: ast.Call) -> str | None:
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return None
+
+
+def _calls_raw_ddl_literal(tree: ast.AST) -> bool:
+    """`sa.text(...)`/`conn.execute(...)`(함수명이 정확히 "text" 또는 "execute"인 호출)의
+    인자로 전달된 **문자열 리터럴**에 DDL 키워드가 있으면 True.
+
+    ⚠️ 처음 버전은 "모든 함수 호출의 문자열 인자"를 봤다가 오탐을 냈다 — `@pytest.mark.xfail(
+    reason="...CREATE TABLE 원문 인용...")`처럼 SQL을 실행하지 않고 **설명하는** 프로즈도
+    어떤 호출의 키워드 인자이긴 하다(#2643 그라운딩 중 실측 발견, test_event1config_
+    webhook_targets.py). 실제로 DB에 위험한 것은 "이 문자열이 SQL 실행 함수로 전달됐는가"
+    뿐이므로 함수명을 text/execute로 좁혀 그 오탐을 없앤다 — docstring/주석은 애초에 호출의
+    인자가 아니라서 안 걸리고, 이제 "호출은 됐지만 SQL 실행이 아닌" 경우도 안 걸린다."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or _call_func_name(node) not in _SQL_EXEC_CALL_NAMES:
+            continue
+        for arg in list(node.args) + [kw.value for kw in node.keywords]:
+            if (
+                isinstance(arg, ast.Constant)
+                and isinstance(arg.value, str)
+                and _DDL_LITERAL_PATTERN.search(arg.value)
+            ):
+                return True
+    return False
 
 
 def _calls_destructive_schema_api(filepath: Path) -> bool:
@@ -139,10 +187,12 @@ def _calls_destructive_schema_api(filepath: Path) -> bool:
         tree = ast.parse(filepath.read_text(encoding="utf-8"))
     except (SyntaxError, OSError, UnicodeDecodeError):
         return False
-    return any(
+    if any(
         isinstance(node, ast.Attribute) and node.attr in _DESTRUCTIVE_ATTRS
         for node in ast.walk(tree)
-    )
+    ):
+        return True
+    return _calls_raw_ddl_literal(tree)
 
 
 def pytest_collection_modifyitems(items: list) -> None:
@@ -156,9 +206,10 @@ def pytest_collection_modifyitems(items: list) -> None:
             violations.add(str(filepath))
     if violations:
         raise pytest.UsageError(
-            "다음 테스트 파일이 Base.metadata.create_all/drop_all을 호출하지만 "
+            "다음 테스트 파일이 Base.metadata.create_all/drop_all 또는 raw SQL DDL 리터럴"
+            "(DROP/CREATE/TRUNCATE/ALTER TABLE, story #2643)을 호출하지만 "
             f"@pytest.mark.{_MARKER_NAME} 마커가 없습니다(alembic-migrated 공유 DB를 오염시켜 "
-            "무관한 테스트를 연쇄 실패시킬 수 있음 — story 8236bbc3). 파일 최상단에 "
+            "무관한 테스트를 연쇄 실패시킬 수 있음 — story 8236bbc3/#2643). 파일 최상단에 "
             f"`pytestmark = pytest.mark.{_MARKER_NAME}` 를 추가하세요:\n"
             + "\n".join(sorted(violations))
         )

--- a/backend/tests/test_2643_destructive_schema_ddl_guard.py
+++ b/backend/tests/test_2643_destructive_schema_ddl_guard.py
@@ -1,0 +1,191 @@
+"""story #2643 — conftest.py의 destructive_schema 정적 가드 확장(raw SQL DDL 리터럴 탐지).
+
+배경(#3031 CI 사고, 2026-08-14): 기존 가드는 `Base.metadata.create_all/drop_all` **속성
+호출**만 AST로 스캔했다 — `sa.text("DROP TABLE ...")`류 raw SQL DDL 실행은 같은 파괴력을
+가지면서도 이 스캔을 피해가, #3031의 새 테스트 2파일이 마커 없이 non-destructive CI 잡에
+편입돼 공유 DB의 실 테이블(agent_api_keys·role_templates)을 떨어뜨렸다.
+
+검증 축:
+- AC1: raw DDL 리터럴을 가진 미마커 파일이 collect 시점에 실패(#3031 사고 케이스 양성대조).
+- AC2: 기존 위반 전수 스캔·위반 0(원본 패턴 파일 test_ho_s3_hypothesis_owner_seed.py 포함).
+- AC3: 가드가 못 잡는 잔여 축(동적 조립 문자열) 자체를 이 테스트로도 고정.
+- 회귀: 첫 구현이 오탐(pytest.mark.xfail(reason="...CREATE TABLE 원문 인용...")을 SQL
+  실행으로 오판)을 냈던 것 — 함수명을 text/execute로 좁혀 해소했다는 사실을 직접 고정.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+import conftest as _conftest  # noqa: E402
+
+
+# ─── 단위 테스트 — _calls_raw_ddl_literal / _calls_destructive_schema_api 직접 호출 ──────
+
+def _tree(src: str):
+    import ast
+
+    return ast.parse(textwrap.dedent(src))
+
+
+def test_detects_text_call_with_drop_table_literal():
+    assert _conftest._calls_raw_ddl_literal(_tree("""
+        from sqlalchemy import text
+        conn.execute(text("DROP TABLE IF EXISTS foo"))
+    """)) is True
+
+
+def test_detects_text_call_with_create_table_literal():
+    assert _conftest._calls_raw_ddl_literal(_tree("""
+        import sqlalchemy as sa
+        c.execute(sa.text("CREATE TABLE IF NOT EXISTS foo (id uuid)"))
+    """)) is True
+
+
+@pytest.mark.parametrize("keyword", ["TRUNCATE", "ALTER"])
+def test_detects_other_ddl_keywords(keyword: str):
+    assert _conftest._calls_raw_ddl_literal(_tree(f"""
+        conn.execute(text("{keyword} TABLE foo ADD COLUMN bar text"))
+    """)) is True
+
+
+def test_detects_bare_execute_call_without_text_wrapper():
+    """일부 호출부는 text() 래핑 없이 execute()에 직접 문자열을 넘긴다 — execute도 대상."""
+    assert _conftest._calls_raw_ddl_literal(_tree("""
+        cursor.execute("DROP TABLE foo")
+    """)) is True
+
+
+def test_does_not_flag_prose_mentioning_ddl_in_unrelated_call():
+    """회귀 가드 — 첫 구현이 냈던 정확한 오탐(#2643 그라운딩 중 실측: test_event1config_
+    webhook_targets.py의 pytest.mark.xfail(reason="...CREATE TABLE 원문 인용..."))을 재현해
+    지금은 안 걸리는지 고정."""
+    assert _conftest._calls_raw_ddl_literal(_tree("""
+        import pytest
+
+        @pytest.mark.xfail(reason="baseline schema.sql 실측: `member_id uuid NOT NULL`"
+                                   "(CREATE TABLE 원문) 참고")
+        def test_something():
+            pass
+    """)) is False
+
+
+def test_does_not_flag_docstring_mentioning_ddl():
+    assert _conftest._calls_raw_ddl_literal(_tree('''
+        """이 테스트는 DROP TABLE 동작을 설명하는 문서다(실행 없음)."""
+        def test_x():
+            pass
+    ''')) is False
+
+
+def test_ac3_declared_blind_spot_fstring_ddl_not_detected():
+    """AC3 — 동적 조립 문자열(f-string)은 가드가 스스로 「못 본다」고 선언한 잔여 사각.
+    이 테스트는 그 선언이 실제 코드 동작과 일치하는지 고정한다(선언과 동작의 괴리 방지)."""
+    assert _conftest._calls_raw_ddl_literal(_tree("""
+        table = "foo"
+        conn.execute(text(f"DROP TABLE {table}"))
+    """)) is False
+
+
+def test_legacy_create_all_drop_all_attribute_detection_still_works():
+    """기존(8236bbc3) 축 무회귀 — .create_all()/.drop_all() 속성호출은 여전히 걸린다."""
+    import ast
+
+    tree = _tree("conn.run_sync(Base.metadata.create_all)")
+    assert any(
+        isinstance(node, ast.Attribute) and node.attr in _conftest._DESTRUCTIVE_ATTRS
+        for node in ast.walk(tree)
+    ) is True
+
+
+def test_non_ddl_file_not_flagged():
+    assert _conftest._calls_raw_ddl_literal(_tree("""
+        def test_normal():
+            assert 1 + 1 == 2
+    """)) is False
+
+
+# ─── AC1: 양성대조 — 실제 pytest 서브프로세스로 #3031 사고 케이스 재현 ──────────────────
+
+def test_positive_control_unmarked_raw_ddl_file_fails_collection(tmp_path: Path):
+    """#3031이 실제로 겪은 것과 동일한 모양(마커 없는 raw DDL 테스트 파일)을 만들어
+    collect 시점에 UsageError(exit code 4)로 죽는지 실측 — AC1 그 자체."""
+    victim = tmp_path / "test_2643_positive_control_victim.py"
+    victim.write_text(textwrap.dedent("""
+        from sqlalchemy import text
+
+        def test_drops_something(x_conn):
+            x_conn.execute(text("DROP TABLE agent_api_keys"))
+    """))
+    conftest_src = (Path(__file__).parent / "conftest.py").read_text(encoding="utf-8")
+    (tmp_path / "conftest.py").write_text(conftest_src, encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", str(victim), "--collect-only", "-q"],
+        capture_output=True, text=True, cwd=tmp_path,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode == 4, f"stdout={result.stdout}\nstderr={result.stderr}"
+    assert "destructive_schema" in combined
+    assert "test_2643_positive_control_victim.py" in combined
+
+
+def test_positive_control_marker_added_fixes_collection(tmp_path: Path):
+    """같은 파일에 마커를 붙이면 collection이 정상 통과 — 마커가 실제로 이 가드를 끄는
+    올바른 처방임을 직접 증명(처방 자체의 유효성, 진단만 하고 처방은 안 검증하는 결함 방지)."""
+    victim = tmp_path / "test_2643_positive_control_fixed.py"
+    victim.write_text(textwrap.dedent("""
+        import pytest
+        from sqlalchemy import text
+
+        pytestmark = pytest.mark.destructive_schema
+
+        def test_drops_something(x_conn):
+            x_conn.execute(text("DROP TABLE agent_api_keys"))
+    """))
+    conftest_src = (Path(__file__).parent / "conftest.py").read_text(encoding="utf-8")
+    (tmp_path / "conftest.py").write_text(conftest_src, encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", str(victim), "--collect-only", "-q"],
+        capture_output=True, text=True, cwd=tmp_path,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+
+
+# ─── AC2: 전수 스캔 — 위반 0(원본 패턴 파일 포함 정비 결과 고정) ────────────────────────
+
+def test_ac2_no_unmarked_raw_ddl_violations_across_test_suite():
+    """실 tests/ 디렉터리 전체를 이 가드로 재스캔해 위반 0임을 pytest 레벨에서도 명시 고정
+    (collection-time UsageError는 CI에서 "쾅" 하고 죽는 신호일 뿐 — 이 테스트는 그 사실을
+    독립적으로, 유지보수 가능한 형태로 다시 진술한다)."""
+    import importlib.util as _ilu
+
+    tests_dir = Path(__file__).parent
+    violations = []
+    for py_file in sorted(tests_dir.glob("*.py")):
+        if py_file.name in ("conftest.py",):
+            continue
+        if _conftest._calls_destructive_schema_api(py_file):
+            spec = _ilu.spec_from_file_location(py_file.stem, py_file)
+            module = _ilu.module_from_spec(spec)
+            try:
+                spec.loader.exec_module(module)
+            except Exception:
+                continue
+            marker_present = any(
+                getattr(m, "name", None) == "destructive_schema"
+                for m in (
+                    module.pytestmark if isinstance(getattr(module, "pytestmark", None), list)
+                    else [getattr(module, "pytestmark", None)]
+                )
+                if m is not None
+            )
+            if not marker_present:
+                violations.append(py_file.name)
+    assert not violations, f"raw DDL 리터럴을 가졌는데 destructive_schema 마커가 없는 파일: {violations}"

--- a/backend/tests/test_ho_s3_hypothesis_owner_seed.py
+++ b/backend/tests/test_ho_s3_hypothesis_owner_seed.py
@@ -11,6 +11,13 @@ import uuid
 
 import pytest
 
+# story #2643(2026-08-14): raw SQL DDL(CREATE TABLE IF NOT EXISTS, sa.text 경유)을 실행하는
+# 파일이라 conftest.py의 확장된 정적 가드가 마커를 요구한다 — 이 파일이 애초에 그 사각(원본
+# 패턴 파일, #3031 사고의 근원)의 실물 예시였다. IF NOT EXISTS라 기존 공유 테이블을 DROP하진
+# 않지만(#3031 사고보다 파괴력 낮음), non-destructive 공유 DB에 대상 테이블이 아직 없을 때
+# 예기치 않은 스키마를 만들 수 있어 여전히 destructive_schema 격리 실행이 안전하다.
+pytestmark = pytest.mark.destructive_schema
+
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 _MIG = os.path.join(
     os.path.dirname(__file__), "..", "alembic", "versions", "0119_seed_hypothesis_owner_role.py"

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -29,11 +29,19 @@ _ASYNC_URL = _RAW_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://")
     "postgresql://", "postgresql+asyncpg://"
 )
 
-pytestmark = pytest.mark.skip(
-    reason="post-cutover baseline과 구조적 불일치(team_members=읽기전용 VIEW, dual-write "
-    "픽스처 무효) — story 8236bbc3 스코프 밖, 재작성/폐기 follow-up 추적. design-ci-realdb-"
-    "gap-8236bbc3 §1 참고."
-)
+# story #2643(2026-08-14): 이 파일이 ALTER TABLE(agent_api_keys/project_access) raw SQL을
+# 실행해 conftest.py의 확장된 정적 가드가 destructive_schema도 요구한다 — 위 skip이 무조건
+# skip(skipif 아님)이라 실제로 실행될 일은 없지만, 마커 자체는 "실행됐을 때 안전한 격리가
+# 필요하다"는 선언이라 skip 여부와 별개로 정확하게 유지한다(나중에 누가 skip만 걷고
+# destructive_schema는 놓치는 재발을 막는 이중 방어).
+pytestmark = [
+    pytest.mark.skip(
+        reason="post-cutover baseline과 구조적 불일치(team_members=읽기전용 VIEW, dual-write "
+        "픽스처 무효) — story 8236bbc3 스코프 밖, 재작성/폐기 follow-up 추적. design-ci-realdb-"
+        "gap-8236bbc3 §1 참고."
+    ),
+    pytest.mark.destructive_schema,
+]
 
 
 @pytest.fixture


### PR DESCRIPTION
## 요약
#3031 CI 사고(2026-08-14) 규명 중 발견: `tests/conftest.py`의 destructive_schema 정적 가드가 `Base.metadata.create_all/drop_all` **속성 호출**만 AST로 스캔한다 — `sa.text("DROP TABLE ...")`류 raw SQL DDL 실행은 같은 파괴력(alembic-migrated 공유 DB의 실 테이블 DROP)을 가지면서도 이 스캔을 완전히 피해간다. #3031의 새 테스트 2파일이 마커 없이 non-destructive CI 잡에 편입돼 공유 DB의 `agent_api_keys`/`role_templates`를 실제로 떨어뜨린 사고의 근본 원인이 이것.

## 처방
`_calls_raw_ddl_literal` 추가 — `text()`/`execute()` 호출의 **인자로 전달된 문자열 리터럴**에서 `DROP/CREATE/TRUNCATE/ALTER TABLE` 패턴을 스캔.

- 함수명을 `text`/`execute`로 좁힌 이유: 첫 구현은 "모든 함수 호출의 문자열 인자"를 봤다가 `pytest.mark.xfail(reason="...CREATE TABLE 원문 인용...")`처럼 SQL을 실행하지 않고 설명만 하는 프로즈까지 오탐했다(그라운딩 중 실측, `test_event1config_webhook_targets.py`) — docstring/주석은 애초에 호출 인자가 아니라 안 걸리고, 이제 "호출은 됐지만 SQL 실행이 아닌" 경우도 안 걸린다.
- 동적 조립 문자열(f-string·`+`·`.format()`)은 AST 리터럴이 아니라 여전히 못 본다 — **의도적 잔여 사각**으로 docstring에 명시 선언(AC3).

## 기존 위반 전수 정비(AC2)
전체 collection 재실행으로 실측한 위반 2건:
- `test_ho_s3_hypothesis_owner_seed.py` — #3031 사고의 원본 패턴 파일(`CREATE TABLE IF NOT EXISTS`). 마커 추가.
- `test_member_ssot_parity_realdb.py` — `ALTER TABLE` raw DDL. 이미 무조건 `skip`이라 실행될 일은 없지만, 마커 자체는 "실행됐을 때 안전"의 선언이라 skip 여부와 별개로 이중 방어로 추가.

## 검증
- `tests/test_2643_destructive_schema_ddl_guard.py`(신규 13건): 단위(text/execute+DDL 리터럴 탐지, TRUNCATE/ALTER 커버, 기존 create_all/drop_all 속성탐지 무회귀, 오탐 회귀가드, f-string 미탐지 AC3 고정) + **AC1 양성대조**(실제 pytest 서브프로세스로 #3031 사고 케이스 재현 — 마커 없는 raw DDL 파일이 collect 시점 `UsageError`(exit 4)로 죽는지, 마커 추가 시 정상 통과하는지 처방 유효성까지 검증) + **AC2**(tests/ 전체 재스캔 위반 0을 pytest 레벨로 고정).
- 신선 Postgres(pgvector)로 `alembic upgrade heads` 전체 체인 + 전체 `--collect-only`(exit 0, 6956 tests) + 신규 파일 13건 + 마커 정비 2파일 통과 확인.

## Test plan
- [x] 로컬 pytest(collect-only 전체 + 신규 13건 + 마커 정비 파일)
- [ ] CI green