### PR TITLE
[P0] 0247 레거시 scope 오버리치 역회귀 fix-forward — fleet 키 부분 잠금 실사고

### DIFF
--- a/backend/alembic/versions/0248_fix_legacy_scope_events_overreach.py
+++ b/backend/alembic/versions/0248_fix_legacy_scope_events_overreach.py
@@ -73,11 +73,23 @@ def upgrade() -> None:
         "UPDATE agent_api_keys "
         "SET scope = array_remove(scope, 'events') "
         "WHERE revoked_at IS NULL "
+        "AND scope IS NOT NULL "
         "AND 'events' = ANY(scope) "
         f"AND NOT (scope && {vocab_array})"
     ))
 
 
 def downgrade() -> None:
-    """no-op — 0247.downgrade()가 이미 이 케이스를 포함해 더 넓게 되돌린다(위 docstring 참조)."""
-    pass
+    """0247.upgrade()와 동일 로직을 재적용 — 이 마이그가 벗겨낸 것과 정확히 같은 집합
+    (events가 없고 배열이 비어있지 않은 살아있는 키)에 다시 'events'를 append해 0248 적용
+    직전(=0247 직후) 상태로 복원한다. 단일 스텝(alembic downgrade -1)만으로도 정확히
+    되돌아가야 하므로 no-op이 아니라 이 재적용이 맞다(0247.downgrade까지 연쇄로 내려가는
+    경우에도 이 결과 위에 0247.downgrade가 그대로 적용돼 무해하다)."""
+    bind = op.get_bind()
+    bind.execute(sa.text(
+        "UPDATE agent_api_keys "
+        "SET scope = array_append(scope, 'events') "
+        "WHERE revoked_at IS NULL "
+        "AND scope IS NOT NULL AND array_length(scope, 1) > 0 "
+        "AND NOT ('events' = ANY(scope))"
+    ))

--- a/backend/alembic/versions/0248_fix_legacy_scope_events_overreach.py
+++ b/backend/alembic/versions/0248_fix_legacy_scope_events_overreach.py
@@ -1,0 +1,83 @@
+"""story #2648(P0, 2026-08-14 실사고 발견 — 디디 자신의 키가 실증 사례): 0247이 레거시
+`['read','write']` scope 키에 "events"를 잘못 append해 오히려 그 키를 events-그룹-전용으로
+좁혀버린 역회귀를 fix-forward로 원상복구한다.
+
+Revision ID: 0248
+Revises: 0247
+Create Date: 2026-08-14
+
+## 근본 원인(app/dependencies/auth.py + app/services/mcp_toolset.py 실측)
+`is_tool_allowed()`가 실제로 "이 scope는 무제한인가"를 판정하는 기준은 `explicit_groups =
+tokens & set(ALL_GROUPS)`가 **빈 집합인가**다 — 비어있으면 group_ok=True(그룹 무관 전부
+허용, 레거시/미스코프 키의 원래 동작). 0247은 이 진짜 기준 대신 `scope IS NOT NULL AND
+array_length(scope, 1) > 0`(배열 길이 휴리스틱)을 썼다 — NULL/빈 배열은 정확히 걸렀지만,
+**"비어있지 않지만 ALL_GROUPS와 교집합이 0인 배열"**(레거시 `['read','write']`처럼 그룹
+어휘 밖의 토큰만 든 경우)을 "이미 명시적으로 좁혀진 키"로 오분류했다.
+
+그 결과: `['read','write']`(길이 2, ALL_GROUPS 교집합 0=무제한) → 0247이 'events' append →
+`['read','write','events']`(길이 3, ALL_GROUPS 교집합={'events'}, **비어있지 않음**) →
+`explicit_groups={'events'}` → **오직 events 그룹 도구만 허용, 나머지(chat 포함) 전부
+403** — 이게 바로 0247의 docstring이 스스로 경계했던 "무제한 → 특정그룹 전용" 역회귀
+그 자체다. 다만 그 경계 가드(`array_length > 0`)가 잡아낸 건 NULL/빈 배열뿐이었고, 이
+"교집합 0인 비어있지 않은 배열" 축은 놓쳤다(디디 자신의 dev 키가 이 경로로 실제 사고났다 —
+`pgstat-probe-dev` 실측으로 원인 확定).
+
+## 처방
+0247을 되돌리지 않는다(히스토리 보존 — fix-forward). 판정 기준을 배열 길이 휴리스틱에서
+**`is_tool_allowed()`와 정확히 동형인 진짜 기준**(ALL_GROUPS ∪ {admin}과의 실제 교집합
+존재)으로 교체해, 0247이 잘못 건드린 행에서만 'events'를 걷어 원상복구한다.
+
+`_RESTRICTIVE_VOCAB`은 `app/services/mcp_toolset.ALL_GROUPS`(story #2634 이후: rewards·
+analytics·agent_runs·audit·webhooks·notifications·meetings·retro·standup·docs·chat·
+sprints·hypotheses·epics·tasks·stories·canvas·events·core) ∪ {"admin"}에서 **"events" 자체를
+뺀** 집합이다 — "events"를 포함시키면 0247이 건드린 모든 행이 그 'events' 토큰 하나만으로
+"교집합 있음"을 자동 통과해 이 마이그 자체가 무의미해진다(자기 자신을 검사 기준에 넣는
+순환 오류 — 이 마이그를 작성하며 처음에 실수할 뻔한 지점이라 명시 기록).
+
+## 대상
+`revoked_at IS NULL`(폐기 키는 재인증에 안 쓰여 무관) AND `'events' = ANY(scope)`(0247이
+건드렸을 가능성이 있는 행만) AND `scope`가 `_RESTRICTIVE_VOCAB`과 교집합이 없음(=events를
+빼면 순수 레거시/미지 토큰만 남는 행). 진짜 role-derived 키(예: `['stories','tasks',
+'events']`)는 'stories'/'tasks'가 교집합에 걸려 대상에서 제외 — 그대로 유지된다(0247의
+원래 의도, 회귀 없음).
+
+downgrade는 no-op이다(0247의 downgrade가 이미 이 케이스를 포함해 전부 되돌리는 더 넓은
+연산이라 — `agent_api_keys.scope`에서 `array_remove(scope, 'events')`를 revoked_at IS
+NULL·scope IS NOT NULL 전체에 적용, 이 마이그가 다시 뺄 것이 없다).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0248"
+down_revision = "0247"
+branch_labels = None
+depends_on = None
+
+# app/services/mcp_toolset.ALL_GROUPS ∪ {"admin"} − {"events"} — "events"를 넣으면 이 마이그
+# 자체가 무의미해진다(위 docstring 참조). 이 리스트가 실제 ALL_GROUPS와 갈리면(그룹 신설/
+# 폐지) 이 마이그는 그 시점의 스냅샷 기준으로만 옳다 — 데이터 백필이라 과거 시점 기준이
+# 맞다(향후 신설 그룹은 새 마이그가 새 스냅샷으로 처리).
+_RESTRICTIVE_VOCAB = (
+    "rewards", "analytics", "agent_runs", "audit", "webhooks", "notifications",
+    "meetings", "retro", "standup", "docs", "chat", "sprints", "hypotheses",
+    "epics", "tasks", "stories", "canvas", "core", "admin",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    vocab_array = "ARRAY[" + ",".join(f"'{g}'" for g in _RESTRICTIVE_VOCAB) + "]::text[]"
+    bind.execute(sa.text(
+        "UPDATE agent_api_keys "
+        "SET scope = array_remove(scope, 'events') "
+        "WHERE revoked_at IS NULL "
+        "AND 'events' = ANY(scope) "
+        f"AND NOT (scope && {vocab_array})"
+    ))
+
+
+def downgrade() -> None:
+    """no-op — 0247.downgrade()가 이미 이 케이스를 포함해 더 넓게 되돌린다(위 docstring 참조)."""
+    pass

--- a/backend/tests/test_2648_fix_legacy_scope_events_overreach.py
+++ b/backend/tests/test_2648_fix_legacy_scope_events_overreach.py
@@ -156,6 +156,31 @@ def test_ac2_real_role_derived_scope_is_not_touched():
 
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_ac2_mixed_legacy_and_real_group_keeps_events():
+    """레거시 read/write + 실제 그룹 토큰이 섞인 키(['read','write','stories','events'])는
+    'stories'가 ALL_GROUPS 소속이라 0247 이전부터 이미 명시적으로 좁혀진 상태였다 — 순수
+    레거시 케이스(AC1)와 정확히 갈리는 경계를 확인."""
+    import sqlalchemy as sa
+
+    sync_url = _REAL_DB_URL.replace("postgresql+asyncpg://", "postgresql+psycopg2://").replace(
+        "postgresql://", "postgresql+psycopg2://"
+    )
+    eng = sa.create_engine(sync_url)
+    mig = _load_migration()
+    try:
+        _setup_table(eng)
+        key_id = _insert(eng, key_hash="mixed", scope=["read", "write", "stories", "events"])
+
+        _run_migration_fn(eng, mig, "upgrade")
+
+        assert set(_get_scope(eng, key_id)) == {"read", "write", "stories", "events"}
+    finally:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS agent_api_keys"))
+        eng.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 def test_ac2_admin_only_scope_is_not_touched():
     """admin 토큰만 있는 scope도(is_tool_allowed 상 explicit_groups에 admin이 걸려 진짜
     restrictive) 대상 밖이어야 한다."""
@@ -227,7 +252,7 @@ def test_ac4_key_without_events_not_touched():
 
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
-def test_downgrade_is_noop_and_safe():
+def test_downgrade_leaves_already_events_key_untouched():
     import sqlalchemy as sa
 
     sync_url = _REAL_DB_URL.replace("postgresql+asyncpg://", "postgresql+psycopg2://").replace(
@@ -244,6 +269,43 @@ def test_downgrade_is_noop_and_safe():
         with eng.begin() as c:
             c.execute(sa.text("DROP TABLE IF EXISTS agent_api_keys"))
         eng.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_downgrade_restores_post_0247_state_for_fixed_key():
+    """단일 스텝 downgrade가 이 마이그가 벗겨낸 것과 정확히 같은 집합에 다시 events를
+    append해 0248 적용 직전(=0247 직후) 상태로 복원하는지 — no-op이 아니라 실제 재적용."""
+    import sqlalchemy as sa
+
+    sync_url = _REAL_DB_URL.replace("postgresql+asyncpg://", "postgresql+psycopg2://").replace(
+        "postgresql://", "postgresql+psycopg2://"
+    )
+    eng = sa.create_engine(sync_url)
+    mig = _load_migration()
+    try:
+        _setup_table(eng)
+        key_id = _insert(eng, key_hash="h-roundtrip", scope=["read", "write"])
+        _run_migration_fn(eng, mig, "downgrade")
+        assert set(_get_scope(eng, key_id)) == {"read", "write", "events"}
+    finally:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS agent_api_keys"))
+        eng.dispose()
+
+
+def test_migration_group_vocab_matches_live_all_groups():
+    """드리프트 가드 — 마이그의 하드코딩 리터럴(_RESTRICTIVE_VOCAB)이 실제 app/services/
+    mcp_toolset.ALL_GROUPS와 지금도 일치하는지 코드 레벨로 재확인. 그룹이 추가/삭제되면 이
+    테스트가 깨져 "0248의 리터럴도 갱신하라"는 신호를 준다(향후 그룹 신설 시 이 마이그를
+    복사해 쓸 사람을 위한 회귀 가드 — data-migration 스냅샷 특성상 이 마이그 자체는
+    과거 시점 기준으로 계속 옳지만, 패턴을 복제할 때 드리프트를 막는다)."""
+    from app.services.mcp_toolset import ALL_GROUPS
+
+    mig = _load_migration()
+    expected = (set(ALL_GROUPS) - {"events"}) | {"admin"}
+    assert set(mig._RESTRICTIVE_VOCAB) == expected, (
+        "0248의 _RESTRICTIVE_VOCAB이 app/services/mcp_toolset.py::ALL_GROUPS와 드리프트됐다"
+    )
 
 
 # ─── AC3: is_tool_allowed 왕복 — 수복 후 실제 무제한 동작이 돌아왔는지 ──────────────────

--- a/backend/tests/test_2648_fix_legacy_scope_events_overreach.py
+++ b/backend/tests/test_2648_fix_legacy_scope_events_overreach.py
@@ -1,0 +1,279 @@
+"""story #2648(P0) — migration 0248: 0247의 레거시 scope 오버리치 fix-forward.
+
+실사고(2026-08-14, 디디 자신의 dev 키): 0247이 `['read','write']`(레거시, 실제로는
+is_tool_allowed() 상 무제한)에 'events'를 append해 `['read','write','events']`가 됐고,
+그 결과 explicit_groups={'events'}(비어있지 않음)가 돼 events 밖 모든 도구가 403됐다.
+
+검증 축:
+- AC1(핵심 회귀 재현+수복): 레거시 scope가 0247 실행 후 겪은 정확한 상태를 재현하고, 0248이
+  'events'만 제거해 원상복구하는지.
+- AC2: 진짜 role-derived 키(실제 그룹 포함)는 손대지 않는지 — 0247의 원래 의도 보존.
+- AC3: is_tool_allowed() 왕복으로 "수복 후 실제로 무제한 동작이 돌아왔는지"까지 확인(문자열
+  조작만 보고 끝내지 않는다).
+- AC4: revoked 키·events 없는 키는 대상 밖.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+_MIG = os.path.join(
+    os.path.dirname(__file__), "..", "alembic", "versions", "0248_fix_legacy_scope_events_overreach.py"
+)
+
+pytestmark = pytest.mark.destructive_schema
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("mig0248", _MIG)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def _run_migration_fn(eng, mig, fn_name: str) -> None:
+    import sqlalchemy as sa
+    from alembic.operations import Operations
+    from alembic.runtime.migration import MigrationContext
+
+    with eng.begin() as c:
+        with Operations.context(MigrationContext.configure(c)):
+            getattr(mig, fn_name)()
+
+
+def _setup_table(eng) -> None:
+    import sqlalchemy as sa
+
+    with eng.begin() as c:
+        c.execute(sa.text("DROP TABLE IF EXISTS agent_api_keys"))
+        c.execute(sa.text(
+            "CREATE TABLE agent_api_keys (id uuid PRIMARY KEY, key_hash text NOT NULL, "
+            "scope text[], revoked_at timestamptz)"
+        ))
+
+
+def _insert(eng, *, key_hash: str, scope, revoked: bool = False) -> uuid.UUID:
+    import sqlalchemy as sa
+
+    key_id = uuid.uuid4()
+    with eng.begin() as c:
+        c.execute(sa.text(
+            "INSERT INTO agent_api_keys (id, key_hash, scope, revoked_at) "
+            "VALUES (:id, :key_hash, :scope, NULL)"
+        ), {"id": str(key_id), "key_hash": key_hash, "scope": scope})
+        if revoked:
+            c.execute(sa.text(
+                "UPDATE agent_api_keys SET revoked_at = now() WHERE id = :id"
+            ), {"id": str(key_id)})
+    return key_id
+
+
+def _get_scope(eng, key_id: uuid.UUID):
+    import sqlalchemy as sa
+
+    with eng.begin() as c:
+        row = c.execute(sa.text(
+            "SELECT scope FROM agent_api_keys WHERE id = :id"
+        ), {"id": str(key_id)}).fetchone()
+    return list(row[0]) if row[0] is not None else None
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_ac1_legacy_read_write_events_overreach_is_reverted():
+    """디디 자신의 dev 키가 겪은 정확한 시나리오 재현 — 0247 실행 직후 상태(['read','write',
+    'events'])를 직접 시드하고, 0248이 events만 제거해 ['read','write']로 복원하는지."""
+    import sqlalchemy as sa
+
+    sync_url = _REAL_DB_URL.replace("postgresql+asyncpg://", "postgresql+psycopg2://").replace(
+        "postgresql://", "postgresql+psycopg2://"
+    )
+    eng = sa.create_engine(sync_url)
+    mig = _load_migration()
+    try:
+        _setup_table(eng)
+        key_id = _insert(eng, key_hash="didi-real-key", scope=["read", "write", "events"])
+
+        _run_migration_fn(eng, mig, "upgrade")
+
+        assert _get_scope(eng, key_id) == ["read", "write"], (
+            "레거시 read/write 키에서 events가 정확히 제거돼 사고 이전 상태로 복원돼야 한다"
+        )
+    finally:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS agent_api_keys"))
+        eng.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_ac1_idempotent_rerun():
+    import sqlalchemy as sa
+
+    sync_url = _REAL_DB_URL.replace("postgresql+asyncpg://", "postgresql+psycopg2://").replace(
+        "postgresql://", "postgresql+psycopg2://"
+    )
+    eng = sa.create_engine(sync_url)
+    mig = _load_migration()
+    try:
+        _setup_table(eng)
+        key_id = _insert(eng, key_hash="k", scope=["read", "write", "events"])
+        _run_migration_fn(eng, mig, "upgrade")
+        _run_migration_fn(eng, mig, "upgrade")
+        assert _get_scope(eng, key_id) == ["read", "write"]
+    finally:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS agent_api_keys"))
+        eng.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_ac2_real_role_derived_scope_is_not_touched():
+    """진짜 role-derived 키(stories/tasks 같은 실 그룹 포함)는 0247의 원래 의도대로 events를
+    유지해야 한다 — 0248이 과교정해 정당한 부여까지 걷으면 그것도 회귀."""
+    import sqlalchemy as sa
+
+    sync_url = _REAL_DB_URL.replace("postgresql+asyncpg://", "postgresql+psycopg2://").replace(
+        "postgresql://", "postgresql+psycopg2://"
+    )
+    eng = sa.create_engine(sync_url)
+    mig = _load_migration()
+    try:
+        _setup_table(eng)
+        key_id = _insert(eng, key_hash="backend-agent", scope=["stories", "tasks", "chat", "events"])
+
+        _run_migration_fn(eng, mig, "upgrade")
+
+        assert set(_get_scope(eng, key_id)) == {"stories", "tasks", "chat", "events"}, (
+            "진짜 role-derived 키는 손대지 않아야 한다"
+        )
+    finally:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS agent_api_keys"))
+        eng.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_ac2_admin_only_scope_is_not_touched():
+    """admin 토큰만 있는 scope도(is_tool_allowed 상 explicit_groups에 admin이 걸려 진짜
+    restrictive) 대상 밖이어야 한다."""
+    import sqlalchemy as sa
+
+    sync_url = _REAL_DB_URL.replace("postgresql+asyncpg://", "postgresql+psycopg2://").replace(
+        "postgresql://", "postgresql+psycopg2://"
+    )
+    eng = sa.create_engine(sync_url)
+    mig = _load_migration()
+    try:
+        _setup_table(eng)
+        key_id = _insert(eng, key_hash="admin-agent", scope=["admin", "events"])
+
+        _run_migration_fn(eng, mig, "upgrade")
+
+        assert set(_get_scope(eng, key_id)) == {"admin", "events"}
+    finally:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS agent_api_keys"))
+        eng.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_ac4_revoked_key_not_touched():
+    import sqlalchemy as sa
+
+    sync_url = _REAL_DB_URL.replace("postgresql+asyncpg://", "postgresql+psycopg2://").replace(
+        "postgresql://", "postgresql+psycopg2://"
+    )
+    eng = sa.create_engine(sync_url)
+    mig = _load_migration()
+    try:
+        _setup_table(eng)
+        key_id = _insert(eng, key_hash="revoked", scope=["read", "write", "events"], revoked=True)
+
+        _run_migration_fn(eng, mig, "upgrade")
+
+        assert _get_scope(eng, key_id) == ["read", "write", "events"]
+    finally:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS agent_api_keys"))
+        eng.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_ac4_key_without_events_not_touched():
+    """이미 events가 없는 레거시 키(0247이 아직 안 건드렸거나 애초에 대상 아니었던 행)는
+    이 마이그가 손댈 이유가 없다 — 조건에 'events' = ANY(scope)가 있어 자연히 제외되지만
+    직접 확인."""
+    import sqlalchemy as sa
+
+    sync_url = _REAL_DB_URL.replace("postgresql+asyncpg://", "postgresql+psycopg2://").replace(
+        "postgresql://", "postgresql+psycopg2://"
+    )
+    eng = sa.create_engine(sync_url)
+    mig = _load_migration()
+    try:
+        _setup_table(eng)
+        key_id = _insert(eng, key_hash="no-events", scope=["read", "write"])
+
+        _run_migration_fn(eng, mig, "upgrade")
+
+        assert _get_scope(eng, key_id) == ["read", "write"]
+    finally:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS agent_api_keys"))
+        eng.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_downgrade_is_noop_and_safe():
+    import sqlalchemy as sa
+
+    sync_url = _REAL_DB_URL.replace("postgresql+asyncpg://", "postgresql+psycopg2://").replace(
+        "postgresql://", "postgresql+psycopg2://"
+    )
+    eng = sa.create_engine(sync_url)
+    mig = _load_migration()
+    try:
+        _setup_table(eng)
+        key_id = _insert(eng, key_hash="k2", scope=["stories", "events"])
+        _run_migration_fn(eng, mig, "downgrade")
+        assert set(_get_scope(eng, key_id)) == {"stories", "events"}
+    finally:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS agent_api_keys"))
+        eng.dispose()
+
+
+# ─── AC3: is_tool_allowed 왕복 — 수복 후 실제 무제한 동작이 돌아왔는지 ──────────────────
+
+def test_ac3_legacy_scope_before_bug_is_unrestricted():
+    """사고 이전(정상) 상태의 전제 자체를 코드로 재확인 — ['read','write']는 무제한이어야
+    한다(explicit_groups 공집합)."""
+    from app.services.mcp_toolset import is_tool_allowed
+
+    assert is_tool_allowed("sprintable_send_chat_message", ["read", "write"]) is True
+    assert is_tool_allowed("sprintable_publish_event", ["read", "write"]) is True
+
+
+def test_ac3_bug_state_incorrectly_narrows_to_events_only():
+    """사고 발생 상태(0247 실행 직후, 수복 전) — chat이 막히는 그 정확한 증상을 코드로
+    재확인(이 마이그의 존재 이유 자체)."""
+    from app.services.mcp_toolset import is_tool_allowed
+
+    buggy_scope = ["read", "write", "events"]
+    assert is_tool_allowed("sprintable_publish_event", buggy_scope) is True
+    assert is_tool_allowed("sprintable_send_chat_message", buggy_scope) is False, (
+        "이게 바로 디디 키가 실제로 겪은 403 — chat이 막혔다"
+    )
+
+
+def test_ac3_after_fix_restores_full_access():
+    """0248이 만드는 최종 상태(['read','write'])가 실제로 무제한을 복원하는지."""
+    from app.services.mcp_toolset import is_tool_allowed
+
+    fixed_scope = ["read", "write"]
+    assert is_tool_allowed("sprintable_send_chat_message", fixed_scope) is True
+    assert is_tool_allowed("sprintable_publish_event", fixed_scope) is True
+    assert is_tool_allowed("sprintable_claim_story", fixed_scope) is True


### PR DESCRIPTION
## P0 — 실사고, 발견 즉시 대응
디디(작성자) 본인의 dev API 키가 이 버그로 chat/stories 등 대부분의 도구가 403으로 막히는 사고를 실제로 겪었다(2026-08-13 16:40경). `pgstat-probe-dev`로 실측: `scope=['read','write','events']`, `role_templates.backend.default_tool_groups`엔 `events` 정상 포함 — 즉 0246은 정상, 0247이 문제.

## 근본 원인
`is_tool_allowed()`가 "무제한 scope"를 판정하는 진짜 기준은 `explicit_groups = tokens & ALL_GROUPS`가 **빈 집합인가**다(비어있으면 그룹 무관 전부 허용 — 레거시 키의 원래 동작). 0247은 이 대신 `array_length(scope,1) > 0`(길이 휴리스틱)을 썼다 — NULL/빈 배열은 정확히 걸렀지만, **레거시 `['read','write']`처럼 "비어있지 않지만 ALL_GROUPS와 교집합이 0인" 배열**을 "이미 명시적으로 좁혀진 키"로 오분류했다.

결과: `['read','write']`(무제한) → 0247이 events append → `['read','write','events']` → `explicit_groups={'events'}`(비어있지 않음!) → **오직 events 그룹 도구만 허용, chat 포함 나머지 전부 403**. 0247의 docstring이 스스로 경계했던 "무제한 → 특정그룹 전용" 역회귀가 다른 축(길이 vs 실제 교집합)에서 그대로 실현됨.

## 처방
0247은 되돌리지 않는다(히스토리 보존, fix-forward). 판정 기준을 `is_tool_allowed()`와 정확히 동형인 진짜 기준(`ALL_GROUPS ∪ {admin} − {events}`와의 실제 교집합 존재)으로 교체 — 0247이 잘못 건드린 행(교집합 0)에서만 `events`를 걷어 원상복구, 진짜 role-derived 키는 그대로 유지.

## 검증
신선 Postgres(pgvector) + `alembic upgrade heads` 전체 체인(0248까지) 실구동, 신규 10건 전부 통과:
- AC1: 디디 실제 사고 상태를 정확히 재현 → 복원 + 재실행 멱등.
- AC2: 진짜 role-derived/admin-only 키는 손대지 않음(과교정 방지).
- AC3: `is_tool_allowed()` 왕복 3단계(사고 전 무제한 → 사고 상태 chat 403 재현 → 수복 후 무제한 복원) 코드 레벨 고정.
- AC4: revoked/events-없는 키는 대상 밖.

## 다음 조치 필요(PO/인프라 lane)
- dev DB에 이 마이그 적용(수동 마이그 필요 — dev 관례).
- 적용 후 디디 키 실제 복구 확認(그때까지 챗 도구 403 지속 — 이 PR 본문·peer-agent 경로로 보고 중).
- fleet 전체에 같은 레거시 패턴 키가 더 있었는지 별도 실측 권고.

## Test plan
- [x] 로컬 pytest(신선 컨테이너, 10건 + 0246/0247 결합 회귀 23건)
- [ ] CI green
- [ ] dev 적용 후 디디 키 실제 복구 확認