### PR TITLE
fix(#2635): agent_api_keys events-scope 0247 오버슛 원상복구 — migration 0248

### DIFF
--- a/backend/alembic/versions/0248_agent_api_keys_events_scope_overshoot_fix.py
+++ b/backend/alembic/versions/0248_agent_api_keys_events_scope_overshoot_fix.py
@@ -1,0 +1,95 @@
+"""0247 판정 오류 fix-forward — 0247의 WHERE 절(`scope IS NOT NULL AND array_length(scope,
+1) > 0`)은 "무제한 scope"를 배열 길이 휴리스틱으로 판정했다. 그러나 실제 무제한 판정은
+`is_tool_allowed()`(app/services/mcp_toolset.py)의 `explicit_groups = tokens &
+set(ALL_GROUPS) | (tokens & {"admin"})`가 **빈 집합인가**다 — 레거시 `['read','write']`
+scope 키는 배열 길이가 2(비어있지 않음)라 0247의 WHERE를 통과해 'events'가 append됐지만,
+'read'/'write'는 ALL_GROUPS 소속이 아니므로 append 전 explicit_groups는 원래 빈 집합
+(무제한)이었다. append 후에는 explicit_groups={'events'}(비어있지 않음)가 돼
+`group_ok = group in tokens`로 판정이 바뀌고, 'events' 그룹 밖의 모든 도구(chat/stories/
+tasks 등 전부)가 거부되는 **정반대 방향 재발**(무제한 → events전용)이 실제로 발생했다
+(디디/은두카쿠 자신의 레거시 read/write 키가 실증 사례 — fleet 전체의 동형 레거시 키도
+동일하게 영향받았을 것으로 추정).
+
+Revision ID: 0248
+Revises: 0247
+Create Date: 2026-08-14
+
+[[no-pr-for-data]] 게이트 — 0246/0247과 동일 승인 경로(P1 플랜 범위 PO 판정, 선생님께
+승격 보고에 얹어 통보). 이 마이그는 fix-forward다: 0247 자체는 히스토리 보존을 위해 그대로
+두고(리버트하지 않음), 이 파일이 그 결과 중 실수로 좁혀진 부분만 원상복구한다.
+
+⛔**판정 기준을 배열 길이가 아니라 실제 그룹 어휘와의 교집합으로 바꾼다** — `is_tool_allowed`와
+정확히 동형이 되도록, "이 키가 이미 명시적으로 좁혀져 있었는가"를
+`array_remove(scope, 'events') && (ALL_GROUPS ∪ {'admin'})`(교집합 존재)로 판정한다.
+교집합이 있으면(예: `['chat','stories']` → events가 추가돼 `['chat','stories','events']`가
+된 키, 또는 `['admin']` 키) 그 키는 0247 이전부터 이미 명시 그룹으로 좁혀져 있었다는 뜻이므로
+0247의 "events로 넓힌다"는 의도가 정확히 맞았던 케이스 — 손대지 않는다. 교집합이 없으면(레거시
+`['read','write']`만 있던 키, 또는 사람이 실수로 넣은 그룹-아닌 토큰만 있던 키) 0247이 이
+키를 무제한→events전용으로 잘못 좁힌 것이므로 'events'만 제거해 원상복구한다.
+
+ALL_GROUPS 리터럴은 `app/services/mcp_toolset.py`의 `ALL_GROUPS`(= `_GROUP_KEYWORDS`에서
+"admin" 제외 + "core")를 이 작성 시점 기준으로 그대로 복사했다 — 마이그는 app 모듈을 import하지
+않는 관례(0246/0247과 동일)라 이후 그룹이 추가/삭제되면 이 리스트는 수동 동기화가 필요하다
+(현재 시점 기준 드리프트 없음 확인 완료).
+
+⚠️**알려진 한계(솔직히 기록)**: 이 판정은 "현재 scope에 events만 있고 다른 그룹이 없다"는
+사실만으로 되돌린다 — 0247이 실수로 events를 넣은 경우와, 애초부터 의도적으로
+`scope=['events']`(events 그룹 전용) 로 발급된 키가 우연히 동일한 최종 상태를 만들었을
+경우를 데이터만으로는 구분할 수 없다(0247이 남긴 별도 audit 백업이 없음). 다만 이 케이스는
+role_template.default_tool_groups가 events 단독으로 구성된 role이 현재 카탈로그에
+존재하는지에 달려 있고(catalog 관례상 각 role은 통상 복수 도메인 그룹을 가짐), 병합 전
+선생님/PO가 라이브 조회로 `scope = ARRAY['events']`인 키가 0247 이전부터 그 상태였는지
+확인하는 것을 권장한다(이 마이그 자체는 fleet 규모상 유의미한 그런 키가 없다는 가정 하에
+진행 — 있다면 이 마이그 적용 전 별도 예외 처리 필요).
+
+⛔**키 재발급(rotate) 미사용** — 0247과 동일 이유(app/repositories/api_key.py 참조):
+scope 컬럼값만 UPDATE, key_hash/plaintext 불변이라 배포된 키는 그대로 살아있고 다음 요청부터
+바로잡힌 scope로 인증된다.
+
+범위: revoked_at IS NULL(살아있는 키만) AND 'events' = ANY(scope) — 현재 살아있고 events를
+보유한 모든 키를 재평가한다(0247이 실제로 건드린 행으로 한정하지 않음 — 판정 기준이
+`is_tool_allowed`와 동형이라 이력과 무관하게 현재 상태만으로 자기교정적이다).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0248"
+down_revision = "0247"
+branch_labels = None
+depends_on = None
+
+# app/services/mcp_toolset.py::ALL_GROUPS ∪ {"admin"} 리터럴 스냅샷(2026-08-14 기준).
+# 그룹이 추가/삭제되면 이 리스트도 함께 갱신할 것 — 마이그는 app 모듈을 import하지 않는다.
+_REAL_GROUP_TOKENS = (
+    "rewards", "analytics", "agent_runs", "audit", "webhooks", "notifications",
+    "meetings", "retro", "standup", "docs", "chat", "sprints", "hypotheses",
+    "epics", "tasks", "stories", "canvas", "core", "admin",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    group_array_literal = "ARRAY[" + ",".join(f"'{g}'" for g in _REAL_GROUP_TOKENS) + "]::text[]"
+    bind.execute(sa.text(
+        "UPDATE agent_api_keys "
+        "SET scope = array_remove(scope, 'events') "
+        "WHERE revoked_at IS NULL "
+        "AND scope IS NOT NULL "
+        "AND 'events' = ANY(scope) "
+        f"AND NOT (array_remove(scope, 'events') && {group_array_literal})"
+    ))
+
+
+def downgrade() -> None:
+    # 0247.upgrade()와 동일 로직 재적용 — upgrade()가 벗겨낸 것과 정확히 같은 집합(events가
+    # 없고 array가 비어있지 않은 살아있는 키)에 다시 events를 append해 0248 적용 전 상태로 복원.
+    bind = op.get_bind()
+    bind.execute(sa.text(
+        "UPDATE agent_api_keys "
+        "SET scope = array_append(scope, 'events') "
+        "WHERE revoked_at IS NULL "
+        "AND scope IS NOT NULL AND array_length(scope, 1) > 0 "
+        "AND NOT ('events' = ANY(scope))"
+    ))

--- a/backend/tests/test_2635_agent_api_keys_events_scope_overshoot_fix.py
+++ b/backend/tests/test_2635_agent_api_keys_events_scope_overshoot_fix.py
@@ -1,0 +1,254 @@
+"""story #2635 fix-forward — migration 0248: 0247이 잘못 좁힌 레거시 scope 원상복구.
+
+카디르가 담당한 0247 테스트(test_2635_agent_api_keys_events_backfill.py)는 NULL scope와
+빈 배열 scope의 "무제한 유지"만 pin했다 — **레거시 `['read','write']`(비어있지 않은 배열이지만
+ALL_GROUPS 소속 토큰이 하나도 없는 경우)는 어느 테스트에도 없었다**. 이게 정확히 0247의
+WHERE(`array_length(scope,1) > 0`)가 통과시켜 사고를 낸 그 케이스다 — 이 파일의 첫 번째
+테스트가 그 갭을 메운다(디디/은두카쿠 자신의 레거시 키가 실증 사례).
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import uuid
+
+import pytest
+
+# 0247 테스트와 동일 이유 — raw DDL(DROP/CREATE TABLE)이라 정적 가드가 못 잡는다.
+pytestmark = pytest.mark.destructive_schema
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+_MIG = os.path.join(
+    os.path.dirname(__file__), "..", "alembic", "versions",
+    "0248_agent_api_keys_events_scope_overshoot_fix.py",
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("mig0248", _MIG)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def _sync_url() -> str:
+    return _REAL_DB_URL.replace("postgresql+asyncpg://", "postgresql+psycopg2://").replace(
+        "postgresql://", "postgresql+psycopg2://"
+    )
+
+
+def _run_migration_fn(eng, mig, fn_name: str) -> None:
+    import sqlalchemy as sa
+    from alembic.operations import Operations
+    from alembic.runtime.migration import MigrationContext
+
+    with eng.begin() as c:
+        with Operations.context(MigrationContext.configure(c)):
+            getattr(mig, fn_name)()
+
+
+def _setup_table(eng) -> None:
+    import sqlalchemy as sa
+
+    with eng.begin() as c:
+        c.execute(sa.text("DROP TABLE IF EXISTS agent_api_keys"))
+        c.execute(sa.text(
+            "CREATE TABLE agent_api_keys (id uuid PRIMARY KEY, key_hash text NOT NULL, "
+            "scope text[], revoked_at timestamptz)"
+        ))
+
+
+def _insert(eng, *, key_hash: str, scope, revoked: bool = False) -> uuid.UUID:
+    import sqlalchemy as sa
+
+    key_id = uuid.uuid4()
+    with eng.begin() as c:
+        c.execute(sa.text(
+            "INSERT INTO agent_api_keys (id, key_hash, scope, revoked_at) "
+            "VALUES (:id, :key_hash, :scope, NULL)"
+        ), {"id": str(key_id), "key_hash": key_hash, "scope": scope})
+        if revoked:
+            c.execute(sa.text(
+                "UPDATE agent_api_keys SET revoked_at = now() WHERE id = :id"
+            ), {"id": str(key_id)})
+    return key_id
+
+
+def _get_scope(eng, key_id: uuid.UUID):
+    import sqlalchemy as sa
+
+    with eng.begin() as c:
+        row = c.execute(sa.text(
+            "SELECT scope FROM agent_api_keys WHERE id = :id"
+        ), {"id": str(key_id)}).fetchone()
+    return list(row[0]) if row[0] is not None else None
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_legacy_read_write_key_events_overshoot_reverted():
+    """핵심 회귀 가드 — 0247이 놓친 바로 그 갭. scope=['read','write']는 배열 길이>0이라
+    0247의 WHERE를 통과해 'events'가 append됐지만, read/write는 ALL_GROUPS 밖이라
+    append 전 explicit_groups는 빈 집합(무제한)이었다. 0248이 이걸 되돌려야 한다."""
+    import sqlalchemy as sa
+
+    eng = sa.create_engine(_sync_url())
+    mig247_path = os.path.join(
+        os.path.dirname(__file__), "..", "alembic", "versions",
+        "0247_agent_api_keys_events_scope_backfill.py",
+    )
+    spec = importlib.util.spec_from_file_location("mig0247b", mig247_path)
+    mig247 = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mig247)
+    mig248 = _load_migration()
+    try:
+        _setup_table(eng)
+        key_id = _insert(eng, key_hash="h-legacy-rw", scope=["read", "write"])
+
+        # 0247 먼저 적용 — 버그 재현(events가 잘못 붙어 events-only로 좁혀짐).
+        _run_migration_fn(eng, mig247, "upgrade")
+        assert set(_get_scope(eng, key_id)) == {"read", "write", "events"}
+
+        # 0248 적용 — read/write 외 실 그룹 토큰이 없으므로 events 제거해 원상복구.
+        _run_migration_fn(eng, mig248, "upgrade")
+        assert set(_get_scope(eng, key_id)) == {"read", "write"}, (
+            "레거시 read/write 전용 키는 0248 이후 events가 제거돼 무제한 상태로 돌아와야 한다"
+        )
+    finally:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS agent_api_keys"))
+        eng.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_legitimately_role_scoped_key_keeps_events():
+    """이미 명시적으로 좁혀진 키(예: ['chat','stories'])는 0247의 "넓힌다" 의도가 정확히
+    맞았던 케이스 — 0248이 이걸 건드리면 안 된다(events 유지)."""
+    import sqlalchemy as sa
+
+    eng = sa.create_engine(_sync_url())
+    mig = _load_migration()
+    try:
+        _setup_table(eng)
+        # 0247이 이미 붙여놓은 상태를 직접 시뮬레이션(0247을 다시 로드하지 않고 최종 상태만 시딩).
+        key_id = _insert(eng, key_hash="h-role-scoped", scope=["chat", "stories", "events"])
+        _run_migration_fn(eng, mig, "upgrade")
+        assert set(_get_scope(eng, key_id)) == {"chat", "stories", "events"}, (
+            "정당하게 그룹-스코프된 키는 0248이 손대면 안 된다"
+        )
+    finally:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS agent_api_keys"))
+        eng.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_admin_scoped_key_keeps_events():
+    """admin은 ALL_GROUPS엔 없지만 explicit_groups 계산에 별도로 OR돼 들어간다
+    (`tokens & {"admin"}`) — 0248의 실그룹 토큰 리스트에도 반드시 포함돼야 한다."""
+    import sqlalchemy as sa
+
+    eng = sa.create_engine(_sync_url())
+    mig = _load_migration()
+    try:
+        _setup_table(eng)
+        key_id = _insert(eng, key_hash="h-admin", scope=["admin", "events"])
+        _run_migration_fn(eng, mig, "upgrade")
+        assert set(_get_scope(eng, key_id)) == {"admin", "events"}
+    finally:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS agent_api_keys"))
+        eng.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_mixed_legacy_and_group_key_keeps_events():
+    """레거시 read/write + 실제 그룹 토큰이 섞인 키(['read','write','stories'])는 stories가
+    ALL_GROUPS 소속이라 0247 이전부터 이미 명시적으로 좁혀진 상태였다 — events 유지해야 한다."""
+    import sqlalchemy as sa
+
+    eng = sa.create_engine(_sync_url())
+    mig = _load_migration()
+    try:
+        _setup_table(eng)
+        key_id = _insert(eng, key_hash="h-mixed", scope=["read", "write", "stories", "events"])
+        _run_migration_fn(eng, mig, "upgrade")
+        assert set(_get_scope(eng, key_id)) == {"read", "write", "stories", "events"}
+    finally:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS agent_api_keys"))
+        eng.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_null_and_empty_and_no_events_untouched():
+    """events가 아예 없는 행(NULL/빈배열/미보유)은 조건절 `'events' = ANY(scope)`에서
+    바로 걸러져 손대지 않는다 — no-op 확인."""
+    import sqlalchemy as sa
+
+    eng = sa.create_engine(_sync_url())
+    mig = _load_migration()
+    try:
+        _setup_table(eng)
+        null_key = _insert(eng, key_hash="h-null", scope=None)
+        empty_key = _insert(eng, key_hash="h-empty", scope=[])
+        no_events_key = _insert(eng, key_hash="h-noevents", scope=["read", "write"])
+        _run_migration_fn(eng, mig, "upgrade")
+        assert _get_scope(eng, null_key) is None
+        assert _get_scope(eng, empty_key) == []
+        assert _get_scope(eng, no_events_key) == ["read", "write"]
+    finally:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS agent_api_keys"))
+        eng.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_revoked_key_untouched_even_with_events():
+    import sqlalchemy as sa
+
+    eng = sa.create_engine(_sync_url())
+    mig = _load_migration()
+    try:
+        _setup_table(eng)
+        key_id = _insert(eng, key_hash="h-revoked", scope=["read", "write", "events"], revoked=True)
+        _run_migration_fn(eng, mig, "upgrade")
+        assert set(_get_scope(eng, key_id)) == {"read", "write", "events"}, (
+            "폐기된 키는 0248이 손대지 않는다(다시 인증에 쓰이지 않으므로 무관)"
+        )
+    finally:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS agent_api_keys"))
+        eng.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_downgrade_restores_post_0247_state_for_fixed_key():
+    """downgrade는 0247.upgrade()와 동일 로직 재적용 — 0248이 벗겨낸 것과 정확히 같은
+    집합(events 없고 배열 비어있지 않은 살아있는 키)에 다시 events를 append한다."""
+    import sqlalchemy as sa
+
+    eng = sa.create_engine(_sync_url())
+    mig = _load_migration()
+    try:
+        _setup_table(eng)
+        key_id = _insert(eng, key_hash="h-roundtrip", scope=["read", "write"])
+        _run_migration_fn(eng, mig, "downgrade")
+        assert set(_get_scope(eng, key_id)) == {"read", "write", "events"}
+    finally:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS agent_api_keys"))
+        eng.dispose()
+
+
+def test_semantics_match_is_tool_allowed_explicit_groups_axis():
+    """마이그 SQL의 실그룹 토큰 리스트(_REAL_GROUP_TOKENS)가 is_tool_allowed의
+    ALL_GROUPS ∪ {"admin"}과 실제로 동형인지 코드 레벨로 재확인 — 드리프트 시 이 테스트가
+    깨진다(그룹이 추가/삭제되면 0248의 리터럴도 갱신해야 한다는 신호)."""
+    from app.services.mcp_toolset import ALL_GROUPS
+
+    mig = _load_migration()
+    expected = (set(ALL_GROUPS) - {"events"}) | {"admin"}
+    assert set(mig._REAL_GROUP_TOKENS) == expected, (
+        "0248의 _REAL_GROUP_TOKENS가 app/services/mcp_toolset.py::ALL_GROUPS와 드리프트됐다 — "
+        "그룹이 추가/삭제된 뒤 이 마이그 상수를 갱신하지 않은 것"
+    )


### PR DESCRIPTION
## Summary
- 0247의 WHERE(`array_length(scope,1) > 0`)는 "무제한 scope"를 배열 길이로 판정했는데, 실제 무제한 판정 기준은 `is_tool_allowed()`(`app/services/mcp_toolset.py`)의 `explicit_groups = tokens & ALL_GROUPS | (tokens & {"admin"})`가 빈 집합인지 여부다.
- 레거시 `['read','write']` scope 키는 배열 길이가 2(>0)라 0247을 통과해 `'events'`가 append됐다. `read`/`write`는 `ALL_GROUPS` 밖이므로 append 전 `explicit_groups`는 빈 집합(무제한)이었는데, append 후엔 `{events}`(비어있지 않음)가 돼 `group_ok = group in tokens`로 판정이 바뀌면서 **events 밖의 모든 도구가 거부되는 정반대 방향 재발**(무제한 → events전용)이 실제로 발생했다.
- migration 0248은 판정 기준을 `array_remove(scope, 'events') && (ALL_GROUPS ∪ {admin})`(is_tool_allowed와 동형)로 바꿔, 실제 그룹 토큰이 하나도 없던 키에서만 `events`를 제거한다. 0247 자체는 히스토리 보존을 위해 그대로 둔다(fix-forward, revert 아님).
- 알려진 한계 하나를 docstring에 정직하게 기록: `scope=['events']`만 있던 사전-존재 키(0247 이전부터 events 단독)와 0247이 실수로 만든 events-only 상태는 데이터만으로 구분 불가 — 병합 전 PO/선생님 라이브 조회 권장.

## Test plan
- [x] 로컬 fresh disposable Postgres(docker, `pgvector/pgvector:pg15`)에서 `agent_api_keys` 미니멀 테이블로 upgrade/downgrade를 Operations API 직구동(`MigrationContext`/`Operations.context`)으로 검증 — 레거시 read/write(fix 대상), 이미 그룹-스코프(chat/stories, admin, read+write+stories 혼합), NULL/빈배열/revoked(no-op) 8케이스 전부 확인.
- [x] 신규 `backend/tests/test_2635_agent_api_keys_events_scope_overshoot_fix.py` 8건 전부 PASS(로컬 realdb, `ALEMBIC_DATABASE_URL`/`DATABASE_URL` 지정). 그 중 하나는 0248의 `_REAL_GROUP_TOKENS` 리터럴이 실제 `ALL_GROUPS`와 드리프트되지 않았는지 코드 레벨로 재확인하는 가드 테스트.
- [x] 기존 0247 테스트(`test_2635_agent_api_keys_events_backfill.py`) 9건 회귀 없이 그대로 PASS.
- [ ] 병합 전: 선생님/PO 명시 승인([[feedback_data_migration_sensitive_needs_teacher_ok]]) + `scope=['events']`-only 라이브 키 존재 여부 확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)