### PR TITLE
[SID:2636] org 커스텀 이벤트 등록 API — P1b 4축

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1045,12 +1045,25 @@ async def publish_registry_event(
         conv.id, send_body, background_tasks, db=db, auth=auth, org_id=org_id,
     )
 
-    return {
+    # story #2636(P1b) 갭 1호 처방 — 전환 실측(가동 1시간, 페드루군)에서 실제로 걸린
+    # 정황: work_item이 보드에 미배정이면 work_item_stakeholders 해석이 빈 집합이라 발행은
+    # 201로 "성공"하는데 escalation·broadcast 둘 다 아무도 못 받는다 — 응답만 보면 정상
+    # 발행처럼 보여 조용한 무도달이 된다. 여기서 명시 경고 필드를 싣는다(MCP 쪽은
+    # sprintable_publish_event가 이 필드를 사람 문장으로 강조 — tools/events.py).
+    zero_reach = not escalation_ids and not broadcast_ids
+    result = {
         "conversation_id": str(conv.id),
         "message_id": msg_response["data"]["id"],
         "escalation_member_ids": [str(i) for i in escalation_ids],
         "broadcast_member_ids": [str(i) for i in broadcast_ids],
+        "zero_reach_warning": zero_reach,
     }
+    if zero_reach:
+        result["warning"] = (
+            "발행은 성공했으나 escalation·broadcast 대상이 모두 0명입니다 — "
+            "work_item이 미배정이거나 routing이 아무도 가리키지 않습니다."
+        )
+    return result
 
 
 class EventDefinitionResponse(BaseModel):
@@ -1090,3 +1103,179 @@ async def list_event_definitions(
         )
         for r in rows
     ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# story #2636(P1b) — org 커스텀 이벤트 등록 API. doc event-registry-p1b-custom-registration-
+# detail. #2632가 확定해 둔 게이트 3종(validate_event_definition_key·validate_event_routing
+# (allow_server_derived=False)·validate_event_payload_schema_shape)을 그대로 소비한다 — 새
+# 검증 로직을 여기서 만들지 않는다(그 세 함수가 이미 실 계약이자 실 테스트 대상).
+# ─────────────────────────────────────────────────────────────────────────────
+
+class CreateEventDefinitionRequest(BaseModel):
+    key: str
+    payload_schema: dict
+    routing: dict
+
+
+class UpdateEventDefinitionRequest(BaseModel):
+    payload_schema: dict | None = None
+    routing: dict | None = None
+    enabled: bool | None = None
+
+
+class EventDefinitionDetailResponse(BaseModel):
+    id: str
+    key: str
+    org_id: str | None
+    payload_schema: dict
+    routing: dict
+    block_template: dict | None
+    enabled: bool
+    version: int
+    created_by: str | None
+
+
+def _event_definition_detail(d: "EventDefinition") -> EventDefinitionDetailResponse:
+    return EventDefinitionDetailResponse(
+        id=str(d.id), key=d.key, org_id=str(d.org_id) if d.org_id else None,
+        payload_schema=d.payload_schema, routing=d.routing,
+        block_template=d.block_template, enabled=d.enabled, version=d.version,
+        created_by=str(d.created_by) if d.created_by else None,
+    )
+
+
+async def _get_org_slug(db: AsyncSession, org_id: uuid.UUID) -> str:
+    from app.models.organization import Organization
+
+    slug = (await db.execute(
+        select(Organization.slug).where(Organization.id == org_id)
+    )).scalar_one_or_none()
+    if slug is None:
+        raise HTTPException(status_code=404, detail="organization not found")
+    return slug
+
+
+@router.post("/definitions", status_code=201, response_model=EventDefinitionDetailResponse)
+async def create_event_definition(
+    body: CreateEventDefinitionRequest,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> EventDefinitionDetailResponse:
+    """POST /api/v2/events/definitions — story #2636 AC1(스키마 gate)·AC2(escalation-none).
+
+    org admin/owner 전용(_is_org_admin, story #2391 S19와 동형 privilege 게이트). key
+    네임스페이스(org.{자기 slug}.*)·payload_schema shape(additionalProperties:false 필수)·
+    routing(server_derived 금지, target=none만 예외)을 #2632/#2636이 확定한 게이트 3종으로
+    검증 — 이 함수는 그 세 함수를 호출만 하고 새 규칙을 만들지 않는다.
+    """
+    from app.models.event_definition import EventDefinition
+    from app.services.event_definition_registry import (
+        InvalidEventDefinitionKeyError,
+        InvalidEventRoutingError,
+        InvalidPayloadSchemaError,
+        validate_event_definition_key,
+        validate_event_payload_schema_shape,
+        validate_event_routing,
+    )
+    from app.services.member_resolver import resolve_member
+
+    if not await _is_org_admin(db, org_id, uuid.UUID(auth.user_id)):
+        raise HTTPException(status_code=403, detail="org admin/owner required")
+
+    org_slug = await _get_org_slug(db, org_id)
+    try:
+        validate_event_definition_key(body.key, org_id=org_id, org_slug=org_slug)
+        validate_event_payload_schema_shape(body.payload_schema)
+        validate_event_routing(body.routing, allow_server_derived=False)
+    except (InvalidEventDefinitionKeyError, InvalidPayloadSchemaError, InvalidEventRoutingError) as e:
+        raise HTTPException(
+            status_code=400, detail={"code": "invalid_definition", "message": str(e)},
+        ) from e
+
+    existing = (await db.execute(
+        select(EventDefinition.id).where(
+            EventDefinition.org_id == org_id, EventDefinition.key == body.key,
+        )
+    )).scalar_one_or_none()
+    if existing is not None:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "definition_key_conflict", "message": f"key {body.key!r} already registered"},
+        )
+
+    sender = await resolve_member(auth, org_id, db)
+    definition = EventDefinition(
+        id=uuid.uuid4(), key=body.key, org_id=org_id,
+        payload_schema=body.payload_schema, routing=body.routing,
+        created_by=sender.id,
+    )
+    db.add(definition)
+    await db.commit()
+    await db.refresh(definition)
+    return _event_definition_detail(definition)
+
+
+@router.patch("/definitions/{definition_id}", response_model=EventDefinitionDetailResponse)
+async def update_event_definition(
+    definition_id: uuid.UUID,
+    body: UpdateEventDefinitionRequest,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> EventDefinitionDetailResponse:
+    """PATCH /api/v2/events/definitions/{id} — story #2636: 수정(payload_schema/routing 변경
+    시 version 범프) + 삭제(enabled=false, soft — 발행 이력이 정의를 참조하므로 hard delete
+    금지). 플랫폼 프리셋(org_id IS NULL)은 이 org-scoped 경로로 절대 patch 불가 — org_id 일치
+    행만 대상(WHERE에 명시, 존재해도 org_id 안 맞으면 404로 정보 노출 0)."""
+    from app.models.event_definition import EventDefinition
+    from app.services.event_definition_registry import (
+        InvalidEventRoutingError,
+        InvalidPayloadSchemaError,
+        validate_event_payload_schema_shape,
+        validate_event_routing,
+    )
+
+    if not await _is_org_admin(db, org_id, uuid.UUID(auth.user_id)):
+        raise HTTPException(status_code=403, detail="org admin/owner required")
+
+    if body.payload_schema is None and body.routing is None and body.enabled is None:
+        raise HTTPException(status_code=400, detail="at least one field must be provided")
+
+    definition = (await db.execute(
+        select(EventDefinition).where(
+            EventDefinition.id == definition_id, EventDefinition.org_id == org_id,
+        )
+    )).scalar_one_or_none()
+    if definition is None:
+        raise HTTPException(status_code=404, detail="event definition not found")
+
+    content_changed = False
+    if body.payload_schema is not None:
+        try:
+            validate_event_payload_schema_shape(body.payload_schema)
+        except InvalidPayloadSchemaError as e:
+            raise HTTPException(
+                status_code=400, detail={"code": "invalid_definition", "message": str(e)},
+            ) from e
+        definition.payload_schema = body.payload_schema
+        content_changed = True
+    if body.routing is not None:
+        try:
+            validate_event_routing(body.routing, allow_server_derived=False)
+        except InvalidEventRoutingError as e:
+            raise HTTPException(
+                status_code=400, detail={"code": "invalid_definition", "message": str(e)},
+            ) from e
+        definition.routing = body.routing
+        content_changed = True
+    if body.enabled is not None:
+        definition.enabled = body.enabled
+
+    if content_changed:
+        definition.version += 1
+
+    await db.commit()
+    await db.refresh(definition)
+    return _event_definition_detail(definition)

--- a/backend/app/services/event_definition_registry.py
+++ b/backend/app/services/event_definition_registry.py
@@ -36,6 +36,12 @@ class InvalidEventPayloadError(ValueError):
         self.errors = errors
 
 
+class InvalidPayloadSchemaError(ValueError):
+    """story #2636 AC1: payload_schema가 additionalProperties: false를 선언하지 않음 —
+    org 커스텀 등록 시점에 거부(스키마 저작 자체의 책임 소재 문제, 발행 시점 payload 위반과는
+    다른 축)."""
+
+
 class InvalidEventRoutingError(ValueError):
     """routing 선언이 두 부류 계약(model.py docstring)을 위반 — 등록 시점에 막아 #2633
     해석기가 절대 못 푸는 정의가 저장되는 것을 방지."""
@@ -89,12 +95,19 @@ def _validate_routing_leg(leg: dict, *, leg_name: str, allow_server_derived: boo
             f"routing.{leg_name}.kind='server_derived'는 member_id_field를 가질 수 없습니다 "
             "(payload 필드가 아니라 서버 파생 역할이므로)."
         )
-    if not allow_server_derived:
+    target = leg.get("target")
+    # story #2636 AC2(PO 확定 최소안, 2026-08-14): target="none"은 예외 — server_derived 금지
+    # 규약이 막으려는 것은 "서버가 해석 못 하는 파생 역할"인데, "none"은 애초에 아무 것도 해석
+    # 안 한다(event_routing_resolver._resolve_none — payload/DB 무관 즉시 빈 집합). org 커스텀이
+    # server_derived를 전혀 못 쓰면 «escalation 없음»조차 표현할 방법이 없어지는 쪽이 오히려
+    # 결함이었다(payload_field는 반드시 payload의 실 필드를 요구해 "의도적으로 없음"을 못 그림).
+    # allow_server_derived=False(org 커스텀 경로)에서도 target="none"만은 통과시킨다.
+    if not allow_server_derived and target != "none":
         raise InvalidEventRoutingError(
             f"routing.{leg_name}.kind='server_derived'는 org 커스텀 정의에 등록할 수 없습니다 "
-            "— 서버가 모르는 파생 역할은 해석 불가능한 정의를 만듭니다(payload_field만 허용)."
+            "— 서버가 모르는 파생 역할은 해석 불가능한 정의를 만듭니다(payload_field 또는 "
+            "target='none'만 허용)."
         )
-    target = leg.get("target")
     if target not in SERVER_DERIVED_TARGETS:
         raise InvalidEventRoutingError(
             f"routing.{leg_name}.target={target!r}은 server_derived 닫힌 어휘"
@@ -111,6 +124,25 @@ def validate_event_routing(routing: dict, *, allow_server_derived: bool = True) 
         if not isinstance(leg, dict):
             raise InvalidEventRoutingError(f"routing.{leg_name}이 없거나 object가 아닙니다.")
         _validate_routing_leg(leg, leg_name=leg_name, allow_server_derived=allow_server_derived)
+
+
+def validate_event_payload_schema_shape(payload_schema: dict) -> None:
+    """story #2636 AC1: org 커스텀 등록 시점에 payload_schema 자체가 유효한 JSON Schema이고
+    top-level `additionalProperties: false`를 명시했는지 강제. 미선언 스키마는 JSON Schema
+    기본값(관대 — 모르는 필드를 조용히 통과)이 그대로 새는데, 그 방임을 org 사용자의 저작
+    책임으로 돌릴 수 없으므로(플랫폼 프리셋 4종과 달리 리뷰가 없다) 등록 자체를 거부한다
+    (자동 주입은 안 한다 — 호출자가 실제로 무엇을 선언했는지와 서버에 저장된 내용이 갈리는
+    "조용한 대필"을 만들지 않기 위해, PO 확定: "게이트가 닫는다").
+
+    시드 4종(0245 마이그)과 동일 규약 — 그쪽은 플랫폼 저작이라 이 함수를 안 거치고, 이 함수는
+    #2636의 등록 엔드포인트(org 커스텀 경로)에서만 호출된다."""
+    validator_cls = jsonschema.validators.validator_for(payload_schema)
+    validator_cls.check_schema(payload_schema)
+    if payload_schema.get("additionalProperties") is not False:
+        raise InvalidPayloadSchemaError(
+            "payload_schema는 top-level 'additionalProperties: false'를 명시해야 합니다 — "
+            "미선언 스키마는 모르는 필드를 조용히 통과시켜 등록을 거부합니다."
+        )
 
 
 def validate_event_payload(payload_schema: dict, payload: dict) -> None:

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -41,12 +41,20 @@ _GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
     # (propose_canonical_version은 "artifact" substring이 없음)·"spec_pin"(핀 4종)까지 포괄.
     ("canvas", ("artifact", "canonical_version", "spec_pin")),
     ("admin", ("give_reward", "emit_event", "trigger_ai", "activate_sprint",
-               "close_sprint", "create_sprint", "upsert_webhook", "delete_webhook")),
+               "close_sprint", "create_sprint", "upsert_webhook", "delete_webhook",
+               # story #2636: 이벤트 레지스트리 "등록"(admin 그룹 — 등록=org 관리 행위, PO
+               # 확定 §범위5). "events" 그룹 키워드("event")보다 이 admin 항목이 먼저 매치돼야
+               # 하므로 반드시 이 admin 튜플 안에 둔다(순서 의존 — 아래 events 항목 주석 참고).
+               "register_event_definition", "update_event_definition")),
     # story #2634: 이벤트 레지스트리 발행 표면(publish_event/list_event_definitions) — "admin"
     # 뒤에 둔 이유는 순서 의존적이다: "emit_event"(admin 키워드)가 substring "event"를 포함하므로
     # "events" 그룹을 admin보다 앞에 두면 sprintable_emit_event의 기존 분류(admin)가 깨진다.
     # publish_event/list_event_definitions는 admin 키워드 어느 것과도 안 겹쳐 여기로 안전하게
     # 떨어진다(발행/구독은 admin급 파괴 작업이 아닌 일반 도메인 기능이라 admin에 안 묶는다).
+    # story #2636: register_event_definition/update_event_definition도 "event" substring을
+    # 포함하지만, 위 admin 튜플에 더 구체적인 키워드("register_event_definition"/
+    # "update_event_definition")가 먼저 있어 이 항목까지 안 내려온다(admin이 이 events보다
+    # 리스트 앞쪽 — tool_group()은 첫 매치를 반환).
     ("events", ("event",)),
 ]
 
@@ -393,6 +401,8 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_list_projects", "sprintable_set_default_project",
     # events (story #2634) — POST /api/v2/events/publish(#2633) 발행 + GET /definitions 카탈로그.
     "sprintable_publish_event", "sprintable_list_event_definitions",
+    # events registry 등록(story #2636) — POST/PATCH /api/v2/events/definitions(org 커스텀).
+    "sprintable_register_event_definition", "sprintable_update_event_definition",
 )
 
 # picker 표시 순서(비파괴 먼저). order 필드 힌트 + 배열 순서 둘 다 이 순서.

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -47,7 +47,9 @@ from .tools.agent_runs import (
     emit_event, poll_events, update_run_status,
 )
 from .tools.events import (
-    ListEventDefinitionsInput, PublishEventInput, list_event_definitions, publish_event,
+    ListEventDefinitionsInput, PublishEventInput, RegisterEventDefinitionInput,
+    UpdateEventDefinitionInput, list_event_definitions, publish_event,
+    register_event_definition, update_event_definition,
 )
 from .tools.analytics import (
     ActivityInput, AgentStatsInput, GoalProgressInput, OverdueMemberInput,
@@ -868,6 +870,16 @@ _TOOL_DEFS: list[tuple] = [
      "[조직] 발행 가능한 이벤트 정의 카탈로그 조회(프리셋 ∪ 이 org 커스텀). publish_event 호출 전 "
      "payload_schema 확인용.",
      ListEventDefinitionsInput, list_event_definitions),
+    # Events registry — org 커스텀 등록(2) — story #2636. publish/list(events 그룹)와 분리된
+    # admin 그룹(등록=org 관리 행위, toolset.py 키워드 참조).
+    ("sprintable_register_event_definition",
+     "[조직] org 커스텀 이벤트 정의 등록(admin/owner 전용). key 네임스페이스·payload_schema "
+     "additionalProperties 게이트·routing(payload_field 또는 target=none만)을 강제한다.",
+     RegisterEventDefinitionInput, register_event_definition),
+    ("sprintable_update_event_definition",
+     "[조직] org 커스텀 이벤트 정의 수정/비활성화(admin/owner 전용). enabled=false가 삭제 "
+     "수단(soft). payload_schema/routing 변경 시 재검증+version 범프.",
+     UpdateEventDefinitionInput, update_event_definition),
 ]
 
 for _name, _doc, _cls, _fn in _TOOL_DEFS:

--- a/backend/sprintable_mcp/tools/events.py
+++ b/backend/sprintable_mcp/tools/events.py
@@ -1,18 +1,24 @@
-"""이벤트 레지스트리 MCP 도구 (2개) — story #2634.
+"""이벤트 레지스트리 MCP 도구 (4개) — story #2634 + #2636.
 
 publish_event → POST /api/v2/events/publish(#2633, publish_registry_event) 래퍼.
-list_event_definitions → GET /api/v2/events/definitions(#2634) 래퍼. 둘 다 신규 백엔드
-로직 없음(순수 배선) — sprintable_emit_event(agent RUN 텔레메트리, POST /api/v2/agent-runs)와
-개념이 다르다: 그건 에이전트 실행 lifecycle 이벤트, 이건 event_definitions 카탈로그(#2632)
-기반 도메인 이벤트 발행/조회다. 이름이 비슷해 보여도 서로 무관한 두 개념(혼동 방지를 위해
-아래 각 함수 docstring에서 다시 한 번 명시).
+list_event_definitions → GET /api/v2/events/definitions(#2634) 래퍼.
+register_event_definition/update_event_definition → POST/PATCH /api/v2/events/definitions
+(#2636, org 커스텀 이벤트 등록) 래퍼 — "events" 그룹(publish/list)과 분리된 "admin" 그룹
+(등록=org 관리 행위, PO 확定 §범위5 — server.py 등록·toolset.py 키워드 참조).
+
+전부 신규 백엔드 로직 없음(순수 배선) — sprintable_emit_event(agent RUN 텔레메트리, POST
+/api/v2/agent-runs)와 개념이 다르다: 그건 에이전트 실행 lifecycle 이벤트, 이건 event_
+definitions 카탈로그(#2632) 기반 도메인 이벤트 발행/조회/등록이다. 이름이 비슷해 보여도
+서로 무관한 두 개념(혼동 방지를 위해 아래 각 함수 docstring에서 다시 한 번 명시).
 """
 from __future__ import annotations
+
+import json
 
 from mcp.types import TextContent
 
 from ..api_client import client
-from ..response import err, ok
+from ..response import _default_serializer, err, ok
 from ..schemas import SprintableInput
 
 
@@ -42,7 +48,20 @@ async def publish_event(args: PublishEventInput) -> list[TextContent]:
     if args.extra_broadcast_member_ids:
         body["extra_broadcast_member_ids"] = args.extra_broadcast_member_ids
     try:
-        return ok(await client.post("/api/v2/events/publish", json=body))
+        result = await client.post("/api/v2/events/publish", json=body)
+        # story #2636(P1b) 갭 1호 처방 — 백엔드가 zero_reach_warning을 JSON 필드로만 실으면
+        # 에이전트가 응답 JSON을 훑다가 그 한 필드를 놓치기 쉽다(발행 자체는 201·conversation_
+        # id·message_id까지 정상으로 보임). MCP 표면에서 사람이 읽는 문장으로 앞에 강조해
+        # "발행 성공·도달 0"이 조용히 지나가지 않게 한다.
+        if isinstance(result, dict) and result.get("zero_reach_warning"):
+            warning_line = (
+                f"[경고] {result.get('warning', '발행은 성공했으나 도달 대상이 0명입니다.')}\n\n"
+            )
+            return [TextContent(
+                type="text",
+                text=warning_line + json.dumps(result, indent=2, ensure_ascii=False, default=_default_serializer),
+            )]
+        return ok(result)
     except Exception as exc:
         return err(str(exc))
 
@@ -56,5 +75,60 @@ async def list_event_definitions(args: ListEventDefinitionsInput) -> list[TextCo
     """
     try:
         return ok(await client.get("/api/v2/events/definitions"))
+    except Exception as exc:
+        return err(str(exc))
+
+
+class RegisterEventDefinitionInput(SprintableInput):
+    key: str
+    payload_schema: dict
+    routing: dict
+
+
+class UpdateEventDefinitionInput(SprintableInput):
+    definition_id: str
+    payload_schema: dict | None = None
+    routing: dict | None = None
+    enabled: bool | None = None
+
+
+async def register_event_definition(args: RegisterEventDefinitionInput) -> list[TextContent]:
+    """org 커스텀 이벤트 정의 등록(story #2636) — org admin/owner 전용.
+
+    key는 `org.{이 org의 slug}.{도메인}.{동작}` 형태만 허용됩니다(타 org 네임스페이스 도용
+    자동 거부). payload_schema는 top-level `additionalProperties: false`를 반드시 선언해야
+    합니다(미선언 시 등록 거부 — 모르는 필드를 조용히 통과시키는 스키마를 org 사용자 책임으로
+    돌릴 수 없어서입니다). routing.escalation/broadcast는 각각 `{"kind":"payload_field",
+    "member_id_field":"..."}`(payload의 특정 필드를 대상 member_id로 사용) 또는
+    `{"kind":"server_derived","target":"none"}`(대상 없음 — org 커스텀에서 유일하게 허용되는
+    server_derived 값)만 등록 가능합니다.
+
+    ⚠️`sprintable_publish_event`(발행)와 별개 도구입니다 — 이건 org 관리 행위(admin 그룹),
+    발행은 events 그룹입니다.
+    """
+    try:
+        return ok(await client.post("/api/v2/events/definitions", json={
+            "key": args.key, "payload_schema": args.payload_schema, "routing": args.routing,
+        }))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def update_event_definition(args: UpdateEventDefinitionInput) -> list[TextContent]:
+    """org 커스텀 이벤트 정의 수정/비활성화(story #2636) — org admin/owner 전용.
+
+    payload_schema/routing을 바꾸면 등록 시점과 동일한 게이트로 재검증되고 version이
+    올라갑니다. `enabled=false`가 삭제 수단입니다(soft — 발행 이력이 이 정의를 참조하므로
+    hard delete는 없습니다). 플랫폼 프리셋(preset.*)은 이 경로로 수정할 수 없습니다.
+    """
+    body: dict = {}
+    if args.payload_schema is not None:
+        body["payload_schema"] = args.payload_schema
+    if args.routing is not None:
+        body["routing"] = args.routing
+    if args.enabled is not None:
+        body["enabled"] = args.enabled
+    try:
+        return ok(await client.patch(f"/api/v2/events/definitions/{args.definition_id}", json=body))
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/toolset.py
+++ b/backend/sprintable_mcp/toolset.py
@@ -42,7 +42,9 @@ _GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
     # 도구 자체가 이미 없다(원본 app/services/mcp_toolset.py에는 "제거했다"는 주석만 남아
     # 있었는데 vendored 사본에만 실제 키워드로 잔존해 있었다 — 원본과 동기화).
     ("admin", ("give_reward", "emit_event", "trigger_ai", "activate_sprint",
-               "close_sprint", "create_sprint", "upsert_webhook", "delete_webhook")),
+               "close_sprint", "create_sprint", "upsert_webhook", "delete_webhook",
+               # story #2636: 백엔드 SSOT와 동기화 — 이벤트 등록(admin 그룹, 등록=org 관리).
+               "register_event_definition", "update_event_definition")),
     # story #2634: 백엔드 SSOT(app/services/mcp_toolset.py)와 동기화 — publish_event/
     # list_event_definitions. admin 뒤에 두는 이유는 순서 의존(emit_event가 substring "event"를
     # 포함 — admin보다 앞에 두면 기존 sprintable_emit_event 분류가 깨진다).

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -108,6 +108,8 @@ EXPECTED_TOOLS = {
     "sprintable_delete_spec_pin", "sprintable_delete_artifact",
     # events (2) — story #2634: 이벤트 레지스트리 발행/카탈로그 조회.
     "sprintable_publish_event", "sprintable_list_event_definitions",
+    # events registry 등록(2) — story #2636: org 커스텀 이벤트 정의 등록/수정(admin 그룹).
+    "sprintable_register_event_definition", "sprintable_update_event_definition",
     # smoke
     "ping",
 }
@@ -128,8 +130,10 @@ def test_total_tool_count():
     # story #2597(E-AGENT-ONBOARD·A2A발견 P0-1): sprintable_list_agent_cards 1종 신설
     # (A2A AgentCard 발견 — 「누구에게 청할지」를 스스로 찾는 MCP 도구) — 116→117.
     # story #2634: sprintable_publish_event/sprintable_list_event_definitions 2종 신설
-    # (이벤트 레지스트리 발행/카탈로그 조회) — 117→119.
-    assert len(_TOOLS) == 119
+    # (이벤트 레지스트리 발행/카탈로그 조회) — 117→119. story #2636: sprintable_register_
+    # event_definition/sprintable_update_event_definition 2종 신설(org 커스텀 등록/수정) —
+    # 119→121.
+    assert len(_TOOLS) == 121
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_2412_mcp_unknown_arg_rejection.py
+++ b/backend/tests/test_2412_mcp_unknown_arg_rejection.py
@@ -69,13 +69,14 @@ async def test_registered_standup_history_tool_still_accepts_known_args():
 
 
 def test_all_registered_tools_share_the_same_lockdown():
-    """AC2 카운트 — `_TOOL_DEFS` 118개 + ping 1개 = 119개(story #2634: sprintable_publish_event/
-    sprintable_list_event_definitions 추가로 117→119) 전부 arg_model이 extra=forbid로 잠겨
-    있어야 한다(상속 갈래 SprintableInput/BaseModel 안 가리고 전부)."""
+    """AC2 카운트 — `_TOOL_DEFS` 120개 + ping 1개 = 121개(story #2634: sprintable_publish_event/
+    sprintable_list_event_definitions 추가로 117→119. story #2636: sprintable_register_
+    event_definition/sprintable_update_event_definition 추가로 119→121) 전부 arg_model이
+    extra=forbid로 잠겨 있어야 한다(상속 갈래 SprintableInput/BaseModel 안 가리고 전부)."""
     from sprintable_mcp import server as srv
 
     tools = srv.mcp._tool_manager.list_tools()
-    assert len(tools) == 119
+    assert len(tools) == 121
     unlocked = [
         t.name for t in tools
         if t.fn_metadata.arg_model.model_config.get("extra") != "forbid"

--- a/backend/tests/test_2632_event_definitions.py
+++ b/backend/tests/test_2632_event_definitions.py
@@ -358,11 +358,17 @@ def test_routing_server_derived_rejects_target_outside_closed_vocabulary():
 
 def test_routing_org_custom_rejects_server_derived_kind():
     """story #2636(org 커스텀 등록)은 allow_server_derived=False로 호출해야 — 서버가 모르는
-    파생 역할을 등록하게 두면 안 된다."""
+    파생 역할을 등록하게 두면 안 된다.
+
+    ⚠️story #2636 AC2(PO 확定, 2026-08-14) 후속 정정: target="none"은 이제 이 금지의
+    명시적 예외다(아무것도 해석 안 하는 target이라 "서버가 모르는 파생 역할" 문제 자체가
+    없음 — event_definition_registry.py _validate_routing_leg 참조). 그래서 이 테스트는
+    여전히 금지돼야 하는 다른 target(work_item_stakeholders)으로 교체 — target=none 예외
+    자체의 회귀 가드는 tests/test_2636_custom_event_registration.py가 별도로 고정한다."""
     from app.services.event_definition_registry import InvalidEventRoutingError, validate_event_routing
 
     routing = {
-        "escalation": {"kind": "server_derived", "target": "none"},
+        "escalation": {"kind": "server_derived", "target": "work_item_stakeholders"},
         "broadcast": {
             "kind": "payload_field", "target": "custom", "member_id_field": "owner_member_id",
         },

--- a/backend/tests/test_2636_custom_event_registration.py
+++ b/backend/tests/test_2636_custom_event_registration.py
@@ -1,0 +1,403 @@
+"""story #2636(P1b) — POST/PATCH /api/v2/events/definitions(org 커스텀 이벤트 등록).
+
+doc event-registry-p1b-custom-registration-detail. 검증 축:
+- AC1: additionalProperties 미선언 payload_schema는 등록 거부(양성·음성).
+- AC2: escalation-none 표현(target=none) 허용 — server_derived 그 외 target은 여전히 금지.
+- 네임스페이스 도용 차단(#2632 게이트 재사용 확인), org-admin/owner 게이트, 409 중복,
+  soft delete(enabled=false) + version 범프, cross-org 404.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug="acme"):
+    from app.models.organization import Organization
+
+    org = Organization(id=uuid.uuid4(), name=f"Org-{slug}", slug=slug)
+    session.add(org)
+    await session.commit()
+    return org.id
+
+
+async def _seed_org_member(session, org_id, *, role="admin"):
+    from app.models.project import OrgMember
+
+    user_id = uuid.uuid4()
+    session.add(OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user_id, role=role))
+    await session.commit()
+    return user_id
+
+
+def _human_auth(user_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(user_id), email="admin@example.com",
+        claims={"app_metadata": {"org_id": str(org_id)}}, org_id=str(org_id),
+    )
+
+
+_VALID_SCHEMA = {
+    "type": "object", "additionalProperties": False,
+    "properties": {"widget_id": {"type": "string"}}, "required": ["widget_id"],
+}
+_NONE_ROUTING = {
+    "escalation": {"kind": "server_derived", "target": "none"},
+    "broadcast": {"kind": "server_derived", "target": "none"},
+}
+
+
+# ─── AC1: additionalProperties 게이트 ───────────────────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_register_rejects_schema_without_additional_properties_false():
+    from app.routers.events import CreateEventDefinitionRequest, create_event_definition
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_org_member(s, org_id, role="admin")
+
+            body = CreateEventDefinitionRequest(
+                key="org.acme.widget.made",
+                payload_schema={"type": "object", "properties": {"widget_id": {"type": "string"}}},
+                routing=_NONE_ROUTING,
+            )
+            with pytest.raises(HTTPException) as ei:
+                await create_event_definition(body, db=s, auth=_human_auth(user_id, org_id), org_id=org_id)
+            assert ei.value.status_code == 400
+            assert ei.value.detail["code"] == "invalid_definition"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_register_accepts_schema_with_additional_properties_false():
+    from app.routers.events import CreateEventDefinitionRequest, create_event_definition
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_org_member(s, org_id, role="admin")
+
+            body = CreateEventDefinitionRequest(
+                key="org.acme.widget.made", payload_schema=_VALID_SCHEMA, routing=_NONE_ROUTING,
+            )
+            resp = await create_event_definition(body, db=s, auth=_human_auth(user_id, org_id), org_id=org_id)
+            assert resp.key == "org.acme.widget.made"
+            assert resp.enabled is True
+            assert resp.version == 1
+    finally:
+        await engine.dispose()
+
+
+# ─── AC2: escalation-none 표현 ───────────────────────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_register_allows_target_none_despite_server_derived_ban():
+    """target=none은 allow_server_derived=False에서도 예외적으로 통과해야 한다."""
+    from app.routers.events import CreateEventDefinitionRequest, create_event_definition
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_org_member(s, org_id, role="owner")
+
+            body = CreateEventDefinitionRequest(
+                key="org.acme.thing.done", payload_schema=_VALID_SCHEMA,
+                routing={
+                    "escalation": {"kind": "server_derived", "target": "none"},
+                    "broadcast": {"kind": "payload_field", "member_id_field": "actor_member_id"},
+                },
+            )
+            resp = await create_event_definition(body, db=s, auth=_human_auth(user_id, org_id), org_id=org_id)
+            assert resp.routing["escalation"]["target"] == "none"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_register_still_rejects_other_server_derived_targets():
+    """target=none 예외가 server_derived 전면 금지를 무너뜨리면 안 된다 — work_item_stakeholders
+    등 다른 target은 여전히 거부."""
+    from app.routers.events import CreateEventDefinitionRequest, create_event_definition
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_org_member(s, org_id, role="admin")
+
+            body = CreateEventDefinitionRequest(
+                key="org.acme.thing.escalated", payload_schema=_VALID_SCHEMA,
+                routing={
+                    "escalation": {"kind": "server_derived", "target": "work_item_stakeholders"},
+                    "broadcast": {"kind": "server_derived", "target": "none"},
+                },
+            )
+            with pytest.raises(HTTPException) as ei:
+                await create_event_definition(body, db=s, auth=_human_auth(user_id, org_id), org_id=org_id)
+            assert ei.value.status_code == 400
+    finally:
+        await engine.dispose()
+
+
+# ─── 네임스페이스 도용 차단(#2632 게이트 재사용 확인) ──────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_register_rejects_mismatched_org_slug_namespace():
+    from app.routers.events import CreateEventDefinitionRequest, create_event_definition
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s, slug="acme")
+            user_id = await _seed_org_member(s, org_id, role="admin")
+
+            body = CreateEventDefinitionRequest(
+                key="org.globex.widget.made", payload_schema=_VALID_SCHEMA, routing=_NONE_ROUTING,
+            )
+            with pytest.raises(HTTPException) as ei:
+                await create_event_definition(body, db=s, auth=_human_auth(user_id, org_id), org_id=org_id)
+            assert ei.value.status_code == 400
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_register_rejects_preset_prefixed_key():
+    from app.routers.events import CreateEventDefinitionRequest, create_event_definition
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_org_member(s, org_id, role="admin")
+
+            body = CreateEventDefinitionRequest(
+                key="preset.work.status_changed", payload_schema=_VALID_SCHEMA, routing=_NONE_ROUTING,
+            )
+            with pytest.raises(HTTPException) as ei:
+                await create_event_definition(body, db=s, auth=_human_auth(user_id, org_id), org_id=org_id)
+            assert ei.value.status_code == 400
+    finally:
+        await engine.dispose()
+
+
+# ─── org-admin 게이트 ───────────────────────────────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_register_rejects_non_admin_member():
+    from app.routers.events import CreateEventDefinitionRequest, create_event_definition
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_org_member(s, org_id, role="member")
+
+            body = CreateEventDefinitionRequest(
+                key="org.acme.widget.made", payload_schema=_VALID_SCHEMA, routing=_NONE_ROUTING,
+            )
+            with pytest.raises(HTTPException) as ei:
+                await create_event_definition(body, db=s, auth=_human_auth(user_id, org_id), org_id=org_id)
+            assert ei.value.status_code == 403
+    finally:
+        await engine.dispose()
+
+
+# ─── 409 중복 ────────────────────────────────────────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_register_duplicate_key_409():
+    from app.routers.events import CreateEventDefinitionRequest, create_event_definition
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_org_member(s, org_id, role="admin")
+
+            body = CreateEventDefinitionRequest(
+                key="org.acme.widget.made", payload_schema=_VALID_SCHEMA, routing=_NONE_ROUTING,
+            )
+            await create_event_definition(body, db=s, auth=_human_auth(user_id, org_id), org_id=org_id)
+            with pytest.raises(HTTPException) as ei:
+                await create_event_definition(body, db=s, auth=_human_auth(user_id, org_id), org_id=org_id)
+            assert ei.value.status_code == 409
+    finally:
+        await engine.dispose()
+
+
+# ─── PATCH: soft delete + version 범프 ───────────────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_patch_enabled_false_soft_deletes_without_version_bump():
+    from app.routers.events import (
+        CreateEventDefinitionRequest, UpdateEventDefinitionRequest,
+        create_event_definition, update_event_definition,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_org_member(s, org_id, role="admin")
+
+            created = await create_event_definition(
+                CreateEventDefinitionRequest(
+                    key="org.acme.widget.made", payload_schema=_VALID_SCHEMA, routing=_NONE_ROUTING,
+                ),
+                db=s, auth=_human_auth(user_id, org_id), org_id=org_id,
+            )
+            updated = await update_event_definition(
+                uuid.UUID(created.id), UpdateEventDefinitionRequest(enabled=False),
+                db=s, auth=_human_auth(user_id, org_id), org_id=org_id,
+            )
+            assert updated.enabled is False
+            assert updated.version == 1
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_patch_payload_schema_bumps_version_and_revalidates():
+    from app.routers.events import (
+        CreateEventDefinitionRequest, UpdateEventDefinitionRequest,
+        create_event_definition, update_event_definition,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_org_member(s, org_id, role="admin")
+
+            created = await create_event_definition(
+                CreateEventDefinitionRequest(
+                    key="org.acme.widget.made", payload_schema=_VALID_SCHEMA, routing=_NONE_ROUTING,
+                ),
+                db=s, auth=_human_auth(user_id, org_id), org_id=org_id,
+            )
+            new_schema = {**_VALID_SCHEMA, "properties": {
+                "widget_id": {"type": "string"}, "note": {"type": "string"},
+            }}
+            updated = await update_event_definition(
+                uuid.UUID(created.id), UpdateEventDefinitionRequest(payload_schema=new_schema),
+                db=s, auth=_human_auth(user_id, org_id), org_id=org_id,
+            )
+            assert updated.version == 2
+            assert "note" in updated.payload_schema["properties"]
+
+            # 재검증도 걸린다 — additionalProperties 빠뜨린 patch는 거부.
+            with pytest.raises(HTTPException) as ei:
+                await update_event_definition(
+                    uuid.UUID(created.id),
+                    UpdateEventDefinitionRequest(payload_schema={"type": "object"}),
+                    db=s, auth=_human_auth(user_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 400
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_patch_cross_org_definition_404():
+    from app.routers.events import (
+        CreateEventDefinitionRequest, UpdateEventDefinitionRequest,
+        create_event_definition, update_event_definition,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_a = await _seed_org(s, slug="acme")
+            org_b = await _seed_org(s, slug="globex")
+            user_a = await _seed_org_member(s, org_a, role="admin")
+            user_b = await _seed_org_member(s, org_b, role="admin")
+
+            created = await create_event_definition(
+                CreateEventDefinitionRequest(
+                    key="org.acme.widget.made", payload_schema=_VALID_SCHEMA, routing=_NONE_ROUTING,
+                ),
+                db=s, auth=_human_auth(user_a, org_a), org_id=org_a,
+            )
+            with pytest.raises(HTTPException) as ei:
+                await update_event_definition(
+                    uuid.UUID(created.id), UpdateEventDefinitionRequest(enabled=False),
+                    db=s, auth=_human_auth(user_b, org_b), org_id=org_b,
+                )
+            assert ei.value.status_code == 404
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_patch_preset_definition_not_reachable_via_org_scoped_route():
+    """org_id IS NULL(플랫폼 프리셋)은 이 org-scoped PATCH로 절대 안 잡힌다."""
+    from app.models.event_definition import EventDefinition
+    from app.routers.events import UpdateEventDefinitionRequest, update_event_definition
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_org_member(s, org_id, role="admin")
+            preset = EventDefinition(
+                id=uuid.uuid4(), key="preset.work.status_changed", org_id=None,
+                payload_schema=_VALID_SCHEMA, routing=_NONE_ROUTING,
+            )
+            s.add(preset)
+            await s.commit()
+
+            with pytest.raises(HTTPException) as ei:
+                await update_event_definition(
+                    preset.id, UpdateEventDefinitionRequest(enabled=False),
+                    db=s, auth=_human_auth(user_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 404
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2636_mcp_registration_tools.py
+++ b/backend/tests/test_2636_mcp_registration_tools.py
@@ -1,0 +1,184 @@
+"""story #2636(P1b) — MCP sprintable_register_event_definition/sprintable_update_event_definition.
+
+배선(순수 배선, 신규 백엔드 로직 없음): register → POST /api/v2/events/definitions,
+update → PATCH /api/v2/events/definitions/{id}. 여기선 MCP 레이어(입력 스키마·client 호출
+배선·admin 그룹 분류·미선언 인자 거부)만 검증 — 백엔드 축(gate 3종 소비·soft delete·version
+범프)은 test_2636_custom_event_registration.py가 실DB로 이미 검증했다.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_register_event_definition_posts_to_definitions_endpoint():
+    from sprintable_mcp.tools.events import RegisterEventDefinitionInput, register_event_definition
+
+    calls: list[tuple[str, dict | None]] = []
+
+    async def fake_post(path, json=None):
+        calls.append((path, json))
+        return {"id": "d1", "key": "org.acme.widget.made"}
+
+    with patch("sprintable_mcp.tools.events.client") as mock_client:
+        mock_client.post = AsyncMock(side_effect=fake_post)
+        out = await register_event_definition(RegisterEventDefinitionInput(
+            key="org.acme.widget.made",
+            payload_schema={"type": "object", "additionalProperties": False},
+            routing={
+                "escalation": {"kind": "server_derived", "target": "none"},
+                "broadcast": {"kind": "server_derived", "target": "none"},
+            },
+        ))
+
+    assert calls[0][0] == "/api/v2/events/definitions"
+    assert calls[0][1]["key"] == "org.acme.widget.made"
+    parsed = json.loads(out[0].text)
+    assert parsed["id"] == "d1"
+
+
+@pytest.mark.anyio
+async def test_register_event_definition_error_surfaces():
+    from sprintable_mcp.tools.events import RegisterEventDefinitionInput, register_event_definition
+
+    with patch("sprintable_mcp.tools.events.client") as mock_client:
+        mock_client.post = AsyncMock(side_effect=Exception("invalid_definition: bad key"))
+        out = await register_event_definition(RegisterEventDefinitionInput(
+            key="bad", payload_schema={}, routing={},
+        ))
+    assert "error" in out[0].text.lower()
+
+
+@pytest.mark.anyio
+async def test_update_event_definition_patches_by_id_only_provided_fields():
+    from sprintable_mcp.tools.events import UpdateEventDefinitionInput, update_event_definition
+
+    calls: list[tuple[str, dict | None]] = []
+
+    async def fake_patch(path, json=None):
+        calls.append((path, json))
+        return {"id": "d1", "enabled": False}
+
+    with patch("sprintable_mcp.tools.events.client") as mock_client:
+        mock_client.patch = AsyncMock(side_effect=fake_patch)
+        await update_event_definition(UpdateEventDefinitionInput(definition_id="d1", enabled=False))
+
+    assert calls[0][0] == "/api/v2/events/definitions/d1"
+    assert calls[0][1] == {"enabled": False}
+
+
+@pytest.mark.anyio
+async def test_update_event_definition_error_surfaces():
+    from sprintable_mcp.tools.events import UpdateEventDefinitionInput, update_event_definition
+
+    with patch("sprintable_mcp.tools.events.client") as mock_client:
+        mock_client.patch = AsyncMock(side_effect=Exception("404 not found"))
+        out = await update_event_definition(UpdateEventDefinitionInput(definition_id="ghost"))
+    assert "error" in out[0].text.lower()
+
+
+# ─── SprintableInput 계약(defense-in-depth) ─────────────────────────────────
+
+def test_register_input_rejects_unknown_field_direct_construction():
+    from pydantic import ValidationError
+    from sprintable_mcp.tools.events import RegisterEventDefinitionInput
+
+    with pytest.raises(ValidationError):
+        RegisterEventDefinitionInput(key="k", payload_schema={}, routing={}, totally_bogus_arg=1)
+
+
+def test_update_input_rejects_unknown_field_direct_construction():
+    from pydantic import ValidationError
+    from sprintable_mcp.tools.events import UpdateEventDefinitionInput
+
+    with pytest.raises(ValidationError):
+        UpdateEventDefinitionInput(definition_id="d1", totally_bogus_arg=1)
+
+
+# ─── 미선언 인자 거부 — 실제 MCP 호출 경로(Tool.run()) ──────────────────────────
+
+@pytest.mark.anyio
+async def test_registered_register_tool_rejects_unknown_arg():
+    from mcp.server.fastmcp.exceptions import ToolError
+    from sprintable_mcp import server as srv
+
+    tool = srv.mcp._tool_manager.get_tool("sprintable_register_event_definition")
+    with pytest.raises(ToolError) as ei:
+        await tool.run({"key": "k", "payload_schema": {}, "routing": {}, "totally_bogus_arg": 1})
+    assert "totally_bogus_arg" in str(ei.value)
+
+
+@pytest.mark.anyio
+async def test_registered_update_tool_rejects_unknown_arg():
+    from mcp.server.fastmcp.exceptions import ToolError
+    from sprintable_mcp import server as srv
+
+    tool = srv.mcp._tool_manager.get_tool("sprintable_update_event_definition")
+    with pytest.raises(ToolError) as ei:
+        await tool.run({"definition_id": "d1", "totally_bogus_arg": 1})
+    assert "totally_bogus_arg" in str(ei.value)
+
+
+# ─── 등록 + admin 그룹 분류 + 양쪽 SSOT 동기화 ────────────────────────────────
+
+def test_both_tools_registered_in_mcp_server():
+    from sprintable_mcp.server import _TOOL_DEFS
+
+    names = {name for name, *_ in _TOOL_DEFS}
+    assert "sprintable_register_event_definition" in names
+    assert "sprintable_update_event_definition" in names
+
+
+def test_tools_classified_into_admin_group_not_events():
+    """등록/수정은 admin 그룹(§범위5) — 발행/조회(events 그룹)와 분리."""
+    from app.services.mcp_toolset import tool_group as backend_tool_group
+    from sprintable_mcp.toolset import tool_group as vendored_tool_group
+
+    for name in ("sprintable_register_event_definition", "sprintable_update_event_definition"):
+        assert backend_tool_group(name) == "admin"
+        assert vendored_tool_group(name) == "admin"
+
+
+def test_publish_and_list_still_classified_into_events_group():
+    """admin 튜플에 새 키워드를 추가해도 publish/list(events 그룹) 분류가 안 깨지는지 —
+    순서 의존 회귀 가드(register/update 키워드가 emit_event 처럼 events 매치를 가로채면
+    안 된다는 원칙과 동형, 이번엔 반대 방향: events 매치가 register/update를 가로채면 안
+    된다는 것도 이미 위 test로 확認됐고, 여기선 그 역방향 무회귀)."""
+    from app.services.mcp_toolset import tool_group as backend_tool_group
+    from sprintable_mcp.toolset import tool_group as vendored_tool_group
+
+    for name in ("sprintable_publish_event", "sprintable_list_event_definitions"):
+        assert backend_tool_group(name) == "events"
+        assert vendored_tool_group(name) == "events"
+
+
+def test_emit_event_group_unaffected():
+    from app.services.mcp_toolset import tool_group as backend_tool_group
+    from sprintable_mcp.toolset import tool_group as vendored_tool_group
+
+    assert backend_tool_group("sprintable_emit_event") == "admin"
+    assert vendored_tool_group("sprintable_emit_event") == "admin"
+
+
+def test_registration_tools_require_admin_scope():
+    from app.services.mcp_toolset import is_tool_allowed
+
+    assert is_tool_allowed("sprintable_register_event_definition", ["events"]) is False
+    assert is_tool_allowed("sprintable_register_event_definition", ["admin"]) is True
+    assert is_tool_allowed("sprintable_update_event_definition", ["events"]) is False
+    assert is_tool_allowed("sprintable_update_event_definition", ["admin"]) is True
+
+
+def test_all_tool_names_includes_registration_tools():
+    from app.services.mcp_toolset import ALL_TOOL_NAMES
+
+    assert "sprintable_register_event_definition" in ALL_TOOL_NAMES
+    assert "sprintable_update_event_definition" in ALL_TOOL_NAMES

--- a/backend/tests/test_2636_mcp_zero_reach_emphasis.py
+++ b/backend/tests/test_2636_mcp_zero_reach_emphasis.py
@@ -1,0 +1,53 @@
+"""story #2636(P1b) 갭 1호 처방 — MCP sprintable_publish_event가 zero_reach_warning을
+사람이 읽는 문장으로 강조하는지(JSON 필드 하나로만 묻히지 않게)."""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_zero_reach_warning_prepends_human_sentence():
+    from sprintable_mcp.tools.events import PublishEventInput, publish_event
+
+    response_data = {
+        "conversation_id": "c1", "message_id": "m1",
+        "escalation_member_ids": [], "broadcast_member_ids": [],
+        "zero_reach_warning": True,
+        "warning": "발행은 성공했으나 escalation·broadcast 대상이 모두 0명입니다.",
+    }
+    with patch("sprintable_mcp.tools.events.client") as mock_client:
+        mock_client.post = AsyncMock(return_value=response_data)
+        out = await publish_event(PublishEventInput(definition_key="preset.gate.verdict", payload={}))
+
+    text = out[0].text
+    assert text.startswith("[경고]")
+    assert "대상이 모두 0명" in text
+    # JSON 데이터 자체도 그대로 뒤에 실려야(구조화 데이터 유실 없음).
+    json_part = text.split("\n\n", 1)[1]
+    assert json.loads(json_part) == response_data
+
+
+@pytest.mark.anyio
+async def test_normal_reach_no_warning_prefix():
+    from sprintable_mcp.tools.events import PublishEventInput, publish_event
+
+    response_data = {
+        "conversation_id": "c1", "message_id": "m1",
+        "escalation_member_ids": ["u1"], "broadcast_member_ids": ["u1", "u2"],
+        "zero_reach_warning": False,
+    }
+    with patch("sprintable_mcp.tools.events.client") as mock_client:
+        mock_client.post = AsyncMock(return_value=response_data)
+        out = await publish_event(PublishEventInput(definition_key="preset.gate.verdict", payload={}))
+
+    text = out[0].text
+    assert not text.startswith("[경고]")
+    assert json.loads(text) == response_data

--- a/backend/tests/test_2636_publish_zero_reach_warning.py
+++ b/backend/tests/test_2636_publish_zero_reach_warning.py
@@ -1,0 +1,165 @@
+"""story #2636(P1b) 갭 1호 처방 — 발행 응답 zero_reach_warning.
+
+전환 실측(가동 1시간, 페드루군 실제 사고): work_item 미배정 → work_item_stakeholders 해석이
+빈 집합 → 발행은 201로 "성공"하지만 escalation·broadcast 둘 다 아무도 못 받는다. 응답에
+명시 경고 필드(zero_reach_warning + warning 문장)를 실어 이 조용한 무도달을 봉쇄한다.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import BackgroundTasks
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _load_seed_definitions():
+    import importlib.util
+    import os
+
+    spec = importlib.util.spec_from_file_location(
+        "_m0245zr", os.path.join(os.path.dirname(__file__), "..", "alembic", "versions", "0245_event_definitions.py"),
+    )
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return {key: (payload_schema, routing) for key, payload_schema, routing in m._SEED}
+
+
+async def _seed_preset_definitions(session):
+    from app.models.event_definition import EventDefinition
+
+    for key, (payload_schema, routing) in _load_seed_definitions().items():
+        session.add(EventDefinition(
+            id=uuid.uuid4(), key=key, org_id=None, payload_schema=payload_schema, routing=routing,
+        ))
+    await session.commit()
+
+
+async def _seed_org_project(session, *, slug="acme"):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2636zr", slug=slug)
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="agent"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True,
+    )
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_story(session, org_id, project_id, *, assignee_id=None, human_owner_member_id=None):
+    from app.models.pm import Story
+
+    story = Story(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="S",
+        assignee_id=assignee_id, human_owner_member_id=human_owner_member_id,
+    )
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+def _auth(agent_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(org_id),
+    )
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_publish_unassigned_work_item_returns_zero_reach_warning():
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_preset_definitions(s)
+            publisher_id = await _seed_agent(s, org_id, project_id, name="publisher")
+            # 미배정 story — assignee/human_owner 둘 다 없음 → stakeholders 해석 빈 집합.
+            story_id = await _seed_story(s, org_id, project_id)
+
+            body = EventPublishRequest(
+                definition_key="preset.gate.verdict",
+                payload={
+                    "work_item_type": "story", "work_item_id": str(story_id),
+                    "gate_type": "merge", "verdict": "approved",
+                },
+            )
+            resp = await publish_registry_event(
+                body, BackgroundTasks(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+            assert resp["zero_reach_warning"] is True
+            assert "warning" in resp
+            assert resp["escalation_member_ids"] == []
+            assert resp["broadcast_member_ids"] == []
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_publish_assigned_work_item_no_warning():
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_preset_definitions(s)
+            publisher_id = await _seed_agent(s, org_id, project_id, name="publisher")
+            owner_id = await _seed_agent(s, org_id, project_id, name="owner")
+            story_id = await _seed_story(s, org_id, project_id, human_owner_member_id=owner_id)
+
+            body = EventPublishRequest(
+                definition_key="preset.gate.verdict",
+                payload={
+                    "work_item_type": "story", "work_item_id": str(story_id),
+                    "gate_type": "merge", "verdict": "approved",
+                },
+            )
+            resp = await publish_registry_event(
+                body, BackgroundTasks(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+            assert resp["zero_reach_warning"] is False
+            assert "warning" not in resp
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_mcp_axis_prefix_b_surface.py
+++ b/backend/tests/test_mcp_axis_prefix_b_surface.py
@@ -73,6 +73,8 @@ def test_tool_names_and_param_models_untouched():
     story #2268(C-10): sprintable_get_session_context 1종 신설(세션 시작 컨텍스트 MCP 노출) —
     114→115. story #2597(E-AGENT-ONBOARD·A2A발견 P0-1): sprintable_list_agent_cards 1종
     신설(A2A AgentCard 발견) — 115→116. story #2634: sprintable_publish_event/
-    sprintable_list_event_definitions 2종 신설(이벤트 레지스트리 발행/카탈로그) — 116→118."""
-    assert len(_TOOL_DEFS) == 118
+    sprintable_list_event_definitions 2종 신설(이벤트 레지스트리 발행/카탈로그) — 116→118.
+    story #2636: sprintable_register_event_definition/sprintable_update_event_definition
+    2종 신설(org 커스텀 이벤트 등록/수정) — 118→120."""
+    assert len(_TOOL_DEFS) == 120
     assert all(name.startswith("sprintable_") for name in _TOOLS)


### PR DESCRIPTION
## 요약
doc [P1b 상세 분해](entity:doc:06c315db-90fb-4f65-b5ff-350ce0786e9b) 5축 중 4축 구현. ③(notification_preferences event_key 구독 축)은 페드루군 판정(2026-08-14)으로 **#2637로 이관** — 메시지 event_key 태깅(msg_metadata)이 #2637 AC 0-a로 이미 확定돼 있어, 태깅+preference축+channel_router 소비를 한 몸으로 묶는 게 응집적이라는 근거. #2636은 4축으로 마감.

## ①등록 API
`POST/PATCH /api/v2/events/definitions`(org admin/owner 전용, `_is_org_admin`). #2632가 확定한 게이트 3종(`validate_event_definition_key`·`validate_event_routing`·신규 `validate_event_payload_schema_shape`)을 그대로 소비 — 새 검증 로직 미신설. PATCH는 payload_schema/routing 변경 시 재검증+version 범프, `enabled=false`가 soft delete(발행 이력 참조 보존). 플랫폼 프리셋은 이 org-scoped 경로로 절대 patch 불가(WHERE org_id 명시).

## ②확정 AC 2건
- **AC1**: payload_schema가 top-level `additionalProperties: false` 미선언이면 등록 거부(자동 주입 안 함 — PO 확定 "게이트가 닫는다").
- **AC2**: `target=none`은 `allow_server_derived=False`(org 커스텀)에서도 예외 허용 — `_resolve_none`이 애초에 아무 것도 해석 안 해 "서버가 모르는 파생 역할" 문제 자체가 없음. 그 외 server_derived target은 여전히 금지(회귀 테스트로 고정).

## ④갭1호 처방
전환 실측(가동 1시간, 페드루군)에서 실제로 걸린 정황 — work_item 미배정 → stakeholders 해석 빈 집합 → 발행은 201로 "성공"하지만 아무도 못 받음. `publish_registry_event` 응답에 `zero_reach_warning`(bool)+`warning`(문장) 필드 추가. MCP `sprintable_publish_event`가 이 필드를 `[경고] ...` 사람 문장으로 응답 맨 앞에 강조(마커 이모지 미사용 — 팀 관례 [[feedback_no_marker_emoji_in_chat]]).

## ⑤MCP 등록 도구
`sprintable_register_event_definition`/`sprintable_update_event_definition` — **"admin" 그룹**(등록=org 관리 행위, publish/list의 "events" 그룹과 분리, PO 확定 §범위5). 양쪽 toolset SSOT(백엔드+vendored) 동일 위치·순서로 키워드 추가 — `emit_event` 기존 분류 무회귀 + register/update가 "events" 그룹으로 새지 않는 무회귀 둘 다 테스트로 고정. 절대카운트 가드 3곳 재계산(`_TOOL_DEFS` 118→120, `list_tools()` 119→121, `test_contract.py` 119→121).

## 검증
신선 Postgres(pgvector) + `alembic upgrade heads` 전체 체인(0248까지) 재확인. 신규 테스트 4파일:
- `test_2636_custom_event_registration.py`(12건) — 등록/PATCH/AC1/AC2/네임스페이스 도용/org-admin 게이트/409/soft-delete/cross-org 404.
- `test_2636_publish_zero_reach_warning.py`(2건) — 미배정/배정 시나리오.
- `test_2636_mcp_zero_reach_emphasis.py`(2건) — MCP 강조 문장.
- `test_2636_mcp_registration_tools.py`(14건) — 배선·admin 그룹 분류·양쪽 SSOT 동기화·미선언 인자 거부.
- 기존 event-registry/toolset 결합 회귀(destructive 49건 + non-destructive 74건) 전부 통과.

## Test plan
- [x] 로컬 pytest(신선 컨테이너, 신규 4파일 + 결합회귀 123건)
- [ ] CI green
- [ ] 카디르 QA(등록→발행→수신 커스텀 이벤트 풀 왕복 라이브)