### PR TITLE
[SID:2637] 이벤트 메시지 태깅(0-a) + block_template v1 게이트/시드 + 구독 event_key 축(0-c) — BE 절반

### DIFF
--- a/backend/alembic/versions/0249_event_definitions_preset_block_templates.py
+++ b/backend/alembic/versions/0249_event_definitions_preset_block_templates.py
@@ -1,0 +1,98 @@
+"""story #2637 §범위5(0-b 준용) — 프리셋 4종에 기본 block_template 시드.
+
+Revision ID: 0249
+Revises: 0248
+Create Date: 2026-08-14
+
+[[no-pr-for-data]] 게이트 — 프리셋 표현 콘텐츠 변경(0166/0167/0240 선례와 동일 규칙, 병합 전
+선생님 확認 필요할 수 있음).
+
+doc event-registry-p2-block-template-detail의 0-b 예시(preset.work.status_changed)를
+그대로 쓰고, 나머지 3종은 그 예시의 header/text/fields 패턴을 각 프리셋의 실 payload_schema
+필드(0245 시드 참조)에 맞춰 동형으로 짓는다 — "현행 제네릭보다 읽기 좋은 최소형"(스토리
+범위5 문구). actions 블록은 이번엔 안 심는다 — 0-b 예시의 actions.definition_key가
+"<발행할 key>" 플레이스홀더였고(실 값 미확定), 실제 발행 대상 없는 액션 버튼을 시드하면
+"눌러도 뭘 하는지 모르는 버튼"이 되는 게 더 나쁘다(story #2637 §범위4 "결재 카드 이관"이
+실제 액션 버튼을 갖는 첫 케이스 — 그건 별도 축, 이 마이그 범위 밖).
+
+치환 실패 시 명시 플레이스홀더(`⟨missing: payload.x⟩`)는 렌더러(FE, #2637)의 몫이라 여기
+시드 콘텐츠 자체엔 없다 — 이 마이그는 템플릿 구조만 심는다.
+"""
+from __future__ import annotations
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0249"
+down_revision = "0248"
+branch_labels = None
+depends_on = None
+
+_TEMPLATES: dict[str, dict] = {
+    "preset.gate.verdict": {
+        "blocks": [
+            {"type": "header", "text": "게이트 판정"},
+            {"type": "text", "text": "**{{payload.gate_type}}** 게이트 — **{{payload.verdict}}**"},
+            {"type": "fields", "fields": [
+                {"label": "대상", "value": "{{payload.work_item_id}}"},
+                {"label": "사유", "value": "{{payload.resolution_note}}"},
+            ]},
+        ],
+    },
+    "preset.work.status_changed": {
+        "blocks": [
+            {"type": "header", "text": "작업 상태 변경"},
+            {"type": "text", "text": "**{{payload.work_item_type}}** `{{payload.from_status}}` → `{{payload.to_status}}`"},
+            {"type": "fields", "fields": [
+                {"label": "대상", "value": "{{payload.work_item_id}}"},
+                {"label": "메모", "value": "{{payload.note}}"},
+            ]},
+        ],
+    },
+    "preset.work.assigned": {
+        "blocks": [
+            {"type": "header", "text": "작업 배정"},
+            {"type": "text", "text": "**{{payload.work_item_type}}** 이(가) 배정되었습니다."},
+            {"type": "fields", "fields": [
+                {"label": "대상", "value": "{{payload.work_item_id}}"},
+                {"label": "담당자", "value": "{{payload.assignee_member_id}}"},
+            ]},
+        ],
+    },
+    "preset.goal.measured": {
+        "blocks": [
+            {"type": "header", "text": "목표 측정치 갱신"},
+            {"type": "text", "text": "측정치 **{{payload.metric_value}}** {{payload.metric_unit}}"},
+            {"type": "fields", "fields": [
+                {"label": "목표", "value": "{{payload.goal_id}}"},
+                {"label": "출처", "value": "{{payload.source}}"},
+            ]},
+        ],
+    },
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    for key, template in _TEMPLATES.items():
+        bind.execute(
+            sa.text(
+                "UPDATE event_definitions SET block_template = :template "
+                "WHERE org_id IS NULL AND key = :key"
+            ),
+            {"template": json.dumps(template), "key": key},
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    for key in _TEMPLATES:
+        bind.execute(
+            sa.text(
+                "UPDATE event_definitions SET block_template = NULL "
+                "WHERE org_id IS NULL AND key = :key"
+            ),
+            {"key": key},
+        )

--- a/backend/alembic/versions/0250_notification_preferences_event_key.py
+++ b/backend/alembic/versions/0250_notification_preferences_event_key.py
@@ -1,0 +1,63 @@
+"""story #2637 §0-c(#2636서 이관) — notification_preferences에 event_key 구독 축 추가.
+
+Revision ID: 0250
+Revises: 0249
+Create Date: 2026-08-14
+
+event_key는 문자열(예: "org.acme.widget.made")이라 기존 scope_id(UUID)에 못 담는다 — 새
+nullable 컬럼으로 분리. scope_type="event_key"일 때 scope_id는 NULL(이벤트키 자체가
+식별자라 별도 UUID 불필요)이고 event_key 컬럼이 그 값을 담는다.
+
+기존 uq_notif_pref_global(scope_id IS NULL) 파티셜 유니크는 event_key IS NULL 조건을
+추가해 event_key-scope 행을 그 버킷에서 제외한다(안 그러면 서로 다른 event_key를 가진
+행들이 전부 "scope_id IS NULL" 하나의 유니크 버킷에 몰려 두 번째 event_key 등록부터
+충돌한다). event_key-scope 전용 파티셜 유니크(uq_notif_pref_event_key)를 새로 추가.
+
+소비는 app/services/channel_router.py — scope_type_order에 event_key 축을 conversation/
+project와 global 사이에 끼워 넣는다(사용자가 특정 대화를 명시로 커스텀했으면 그게 여전히
+이기고, 아무 대화-구조 축도 없으면 "이 이벤트타입 전체 mute"가 순수 global보다 먼저 이긴다).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0250"
+down_revision = "0249"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "notification_preferences",
+        sa.Column("event_key", sa.Text(), nullable=True),
+    )
+    op.drop_index("uq_notif_pref_global", table_name="notification_preferences")
+    op.create_index(
+        "uq_notif_pref_global",
+        "notification_preferences",
+        ["member_id", "scope_type", "channel"],
+        unique=True,
+        postgresql_where=sa.text("scope_id IS NULL AND event_key IS NULL"),
+    )
+    op.create_index(
+        "uq_notif_pref_event_key",
+        "notification_preferences",
+        ["member_id", "event_key", "channel"],
+        unique=True,
+        postgresql_where=sa.text("event_key IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_notif_pref_event_key", table_name="notification_preferences")
+    op.drop_index("uq_notif_pref_global", table_name="notification_preferences")
+    op.create_index(
+        "uq_notif_pref_global",
+        "notification_preferences",
+        ["member_id", "scope_type", "channel"],
+        unique=True,
+        postgresql_where=sa.text("scope_id IS NULL"),
+    )
+    op.drop_column("notification_preferences", "event_key")

--- a/backend/app/models/notification_preference.py
+++ b/backend/app/models/notification_preference.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, Text, func
+from sqlalchemy import DateTime, Index, Text, func, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -11,6 +11,28 @@ from app.models.base import TimestampMixin
 
 class NotificationPreference(Base, TimestampMixin):
     __tablename__ = "notification_preferences"
+    # story #2637 §0-c(디디 발견, 2026-08-14): 이 3개 파티셜 유니크 인덱스는 migration
+    # 0033/0250에서 raw op.create_index()로만 존재했고 __table_args__엔 한 번도 등록된 적이
+    # 없었다 — Base.metadata.create_all() 기반 realdb 테스트(이 코드베이스의 표준 create_all
+    # 패턴)가 upsert_preferences의 ON CONFLICT를 태우면 "no unique or exclusion constraint
+    # matching" 크래시로 조용히 못 잡던 사각이었다(원래 uq_notif_pref_global/scoped도 동일
+    # 사각 — 지금까지 이 라우터를 create_all로 테스트한 사례가 0건이라 안 드러났을 뿐).
+    # 여기 등록해 create_all()도 migration과 동일 제약을 재현하게 한다(순수 additive — 런타임
+    # migrated DB는 이미 같은 인덱스가 있어 무회귀).
+    __table_args__ = (
+        Index(
+            "uq_notif_pref_global", "member_id", "scope_type", "channel", unique=True,
+            postgresql_where=text("scope_id IS NULL AND event_key IS NULL"),
+        ),
+        Index(
+            "uq_notif_pref_scoped", "member_id", "scope_type", "scope_id", "channel", unique=True,
+            postgresql_where=text("scope_id IS NOT NULL"),
+        ),
+        Index(
+            "uq_notif_pref_event_key", "member_id", "event_key", "channel", unique=True,
+            postgresql_where=text("event_key IS NOT NULL"),
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     # E-MEMBER-SSOT AC2-2: team_members FK 완화 — grant-only 휴먼(org_member.id) 수용.
@@ -18,7 +40,10 @@ class NotificationPreference(Base, TimestampMixin):
     member_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), nullable=False, index=True
     )
-    scope_type: Mapped[str] = mapped_column(Text, nullable=False)  # global | project | conversation | thread
+    scope_type: Mapped[str] = mapped_column(Text, nullable=False)  # global | project | conversation | thread | event_key
     scope_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    # story #2637 §0-c: scope_type="event_key"일 때만 값을 가짐(scope_id는 그 경우 NULL —
+    # event_key는 UUID가 아닌 문자열이라 별도 컬럼, migration 0250 참조).
+    event_key: Mapped[str | None] = mapped_column(Text, nullable=True)
     channel: Mapped[str] = mapped_column(Text, nullable=False)  # sse | discord | telegram | in_app
     level: Mapped[str] = mapped_column(Text, nullable=False)  # all | mentions | mute

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -445,6 +445,8 @@ def _msg_payload(
     payload.update(_activation_payload(msg))
     # story #2604 P2: approval-request 카드 스키마 top-level 노출(없으면 None·additive).
     payload.update(_approval_payload(msg))
+    # story #2637 AC 0-a: 이벤트 발행 메시지 스키마 top-level 노출(없으면 None·additive).
+    payload.update(_event_payload(msg))
     return payload
 
 
@@ -463,6 +465,26 @@ def _activation_meta(req: "SendMessageRequest") -> dict | None:
     if req.expects_response is not None:
         act["expects_response"] = bool(req.expects_response)
     return {"activation": act} if act else None
+
+
+def _event_meta(req: "SendMessageRequest") -> dict | None:
+    """story #2637 AC 0-a: req.event_context({"event_key","payload"}) → msg_metadata['event'].
+    없으면 None(완전 additive) — publish_registry_event만 이 필드를 채운다."""
+    return {"event": req.event_context} if isinstance(req.event_context, dict) else None
+
+
+def _combined_msg_metadata(req: "SendMessageRequest") -> dict | None:
+    """_activation_meta/_event_meta 둘 다 독립 namespace라 병합 — 한쪽만 있어도, 둘 다
+    없어도(None), 이론상 둘 다 있어도 안전하게 합친다(현재 호출부는 상호배타적으로 쓰지만
+    강제하지 않음 — 필드 자체가 각자 optional이라 자연히 배타적이 된다)."""
+    merged: dict = {}
+    act = _activation_meta(req)
+    if act:
+        merged.update(act)
+    ev = _event_meta(req)
+    if ev:
+        merged.update(ev)
+    return merged or None
 
 
 def _activation_payload(msg: "ConversationMessage") -> dict:
@@ -487,6 +509,16 @@ def _approval_payload(msg: "ConversationMessage") -> dict:
     meta = (getattr(msg, "__dict__", None) or {}).get("msg_metadata")
     target = meta.get("approval_target") if isinstance(meta, dict) else None
     return {"approval_target": target if isinstance(target, dict) else None}
+
+
+def _event_payload(msg: "ConversationMessage") -> dict:
+    """story #2637 AC 0-a: msg_metadata['event'] → payload top-level(없으면 None).
+    _approval_payload와 동형(additive·__dict__ 전용 read — 동일 greenlet_spawn 회피 이유).
+    FE가 이 필드로 "이벤트 발행 메시지"임을 알고 event_key로 block_template을 찾는다
+    (#2637 렌더러 축, FE 레인) — 여기는 스키마만 실어 나른다."""
+    meta = (getattr(msg, "__dict__", None) or {}).get("msg_metadata")
+    event = meta.get("event") if isinstance(meta, dict) else None
+    return {"event": event if isinstance(event, dict) else None}
 
 
 async def _viewer_blocked_sender_ids(auth: AuthContext, org_id: uuid.UUID, db: AsyncSession) -> set[uuid.UUID]:
@@ -991,6 +1023,14 @@ class SendMessageRequest(BaseModel):
     audience: list[uuid.UUID] | None = None
     message_kind: str | None = None  # request | handoff | result | ack
     expects_response: bool | None = None
+    # story #2637 AC 0-a: publish_registry_event(#2633) 전용 additive 필드 — {"event_key":
+    # str, "payload": dict}. approval_target(approval_delivery.py)과 동형 namespace 패턴이지만
+    # 그쪽은 send_message()를 우회해 ConversationMessage를 직접 구성하는 반면(#2604의 승인
+    # 카드 전용 별도 경로, 그 자체가 명시적 예외), 이건 send_message()의 기존 확장 메커니즘
+    # (E-ACTIVATION S1의 typed-field→msg_metadata 패턴)을 그대로 따른다 — #2633 AC2(신규
+    # 전달 계통 금지)를 지키면서 publish_registry_event가 이 필드로 "이 메시지가 이벤트
+    # 발행분임"을 msg_metadata에 실을 수 있게 한다. 공개 REST 문서에는 안 실을 내부 필드.
+    event_context: dict | None = None
 
     @field_validator("attachments")
     @classmethod
@@ -2218,7 +2258,8 @@ async def send_message(
         # S7: client 제공 asset_id 는 strip(서버 권위·drift 방지·까심)·아래 sync url_map 으로만 역기입.
         attachments=[{**a.model_dump(), "asset_id": None} for a in body.attachments],
         # E-ACTIVATION S1: typed-activation(audience/kind/expects_response) → metadata(additive·마이그레이션 불요).
-        msg_metadata=_activation_meta(body),
+        # story #2637 AC 0-a: event_context → metadata['event'](additive, 둘 다 독립 namespace).
+        msg_metadata=_combined_msg_metadata(body),
     )
     db.add(msg)
 

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1037,9 +1037,13 @@ async def publish_registry_event(
 
     from app.routers.conversations import SendMessageRequest, send_message
 
+    # story #2637 AC 0-a: event_context → msg_metadata['event'](additive) — FE가 이 메시지를
+    # "이벤트 발행분"으로 인지하고 event_key로 event_definitions를 조회해 block_template
+    # 렌더러를 태울 근거. 렌더러 자체는 #2637 FE 레인(이 커밋은 스키마 배선만).
     send_body = SendMessageRequest(
         content=_render_event_message_content(definition.key, body.payload),
         mentioned_ids=list(escalation_ids),
+        event_context={"event_key": definition.key, "payload": body.payload},
     )
     msg_response = await send_message(
         conv.id, send_body, background_tasks, db=db, auth=auth, org_id=org_id,
@@ -1116,12 +1120,15 @@ class CreateEventDefinitionRequest(BaseModel):
     key: str
     payload_schema: dict
     routing: dict
+    # story #2637 §범위1/5: optional — 없으면 렌더러가 현행 제네릭 폴백을 쓴다(비회귀).
+    block_template: dict | None = None
 
 
 class UpdateEventDefinitionRequest(BaseModel):
     payload_schema: dict | None = None
     routing: dict | None = None
     enabled: bool | None = None
+    block_template: dict | None = None
 
 
 class EventDefinitionDetailResponse(BaseModel):
@@ -1172,9 +1179,11 @@ async def create_event_definition(
     """
     from app.models.event_definition import EventDefinition
     from app.services.event_definition_registry import (
+        InvalidBlockTemplateError,
         InvalidEventDefinitionKeyError,
         InvalidEventRoutingError,
         InvalidPayloadSchemaError,
+        validate_block_template,
         validate_event_definition_key,
         validate_event_payload_schema_shape,
         validate_event_routing,
@@ -1189,7 +1198,12 @@ async def create_event_definition(
         validate_event_definition_key(body.key, org_id=org_id, org_slug=org_slug)
         validate_event_payload_schema_shape(body.payload_schema)
         validate_event_routing(body.routing, allow_server_derived=False)
-    except (InvalidEventDefinitionKeyError, InvalidPayloadSchemaError, InvalidEventRoutingError) as e:
+        if body.block_template is not None:
+            validate_block_template(body.block_template)
+    except (
+        InvalidEventDefinitionKeyError, InvalidPayloadSchemaError,
+        InvalidEventRoutingError, InvalidBlockTemplateError,
+    ) as e:
         raise HTTPException(
             status_code=400, detail={"code": "invalid_definition", "message": str(e)},
         ) from e
@@ -1209,6 +1223,7 @@ async def create_event_definition(
     definition = EventDefinition(
         id=uuid.uuid4(), key=body.key, org_id=org_id,
         payload_schema=body.payload_schema, routing=body.routing,
+        block_template=body.block_template,
         created_by=sender.id,
     )
     db.add(definition)
@@ -1231,8 +1246,10 @@ async def update_event_definition(
     행만 대상(WHERE에 명시, 존재해도 org_id 안 맞으면 404로 정보 노출 0)."""
     from app.models.event_definition import EventDefinition
     from app.services.event_definition_registry import (
+        InvalidBlockTemplateError,
         InvalidEventRoutingError,
         InvalidPayloadSchemaError,
+        validate_block_template,
         validate_event_payload_schema_shape,
         validate_event_routing,
     )
@@ -1240,7 +1257,10 @@ async def update_event_definition(
     if not await _is_org_admin(db, org_id, uuid.UUID(auth.user_id)):
         raise HTTPException(status_code=403, detail="org admin/owner required")
 
-    if body.payload_schema is None and body.routing is None and body.enabled is None:
+    if (
+        body.payload_schema is None and body.routing is None
+        and body.enabled is None and body.block_template is None
+    ):
         raise HTTPException(status_code=400, detail="at least one field must be provided")
 
     definition = (await db.execute(
@@ -1269,6 +1289,15 @@ async def update_event_definition(
                 status_code=400, detail={"code": "invalid_definition", "message": str(e)},
             ) from e
         definition.routing = body.routing
+        content_changed = True
+    if body.block_template is not None:
+        try:
+            validate_block_template(body.block_template)
+        except InvalidBlockTemplateError as e:
+            raise HTTPException(
+                status_code=400, detail={"code": "invalid_definition", "message": str(e)},
+            ) from e
+        definition.block_template = body.block_template
         content_changed = True
     if body.enabled is not None:
         definition.enabled = body.enabled

--- a/backend/app/routers/notification_preferences.py
+++ b/backend/app/routers/notification_preferences.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import and_, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -20,7 +20,9 @@ router = APIRouter(prefix="/api/v2/notification-preferences", tags=["notificatio
 
 _VALID_CHANNELS = {"sse", "discord", "telegram", "in_app"}
 _VALID_LEVELS = {"all", "mentions", "mute"}
-_VALID_SCOPE_TYPES = {"global", "project", "conversation", "thread"}
+# story #2637 §0-c: "event_key" 신설 — 대화-구조 축(project/conversation/thread)과 다른
+# 별개 차원(이벤트 타입 축). scope_id는 안 쓰고 event_key 컬럼을 쓴다(migration 0250).
+_VALID_SCOPE_TYPES = {"global", "project", "conversation", "thread", "event_key"}
 
 
 # ─── Schemas ──────────────────────────────────────────────────────────────────
@@ -28,6 +30,8 @@ _VALID_SCOPE_TYPES = {"global", "project", "conversation", "thread"}
 class PreferenceItem(BaseModel):
     scope_type: str
     scope_id: uuid.UUID | None = None
+    # story #2637 §0-c: scope_type="event_key"일 때만 사용(그 외엔 반드시 None).
+    event_key: str | None = None
     channel: str
     level: str
 
@@ -67,6 +71,7 @@ def _pref_to_dict(p: NotificationPreference) -> dict:
         "member_id": str(p.member_id),
         "scope_type": p.scope_type,
         "scope_id": str(p.scope_id) if p.scope_id else None,
+        "event_key": p.event_key,
         "channel": p.channel,
         "level": p.level,
         "updated_at": p.updated_at.isoformat(),
@@ -108,6 +113,18 @@ async def upsert_preferences(
         if item.scope_type not in _VALID_SCOPE_TYPES:
             raise HTTPException(status_code=422, detail=f"Invalid scope_type '{item.scope_type}'.")
 
+        # story #2637 §0-c: event_key 축은 scope_id가 아니라 event_key 컬럼을 쓴다 — 둘의
+        # 상호배타를 여기서 강제(모호한 이중 스코프 조합을 저장하지 않는다).
+        if item.scope_type == "event_key":
+            if not item.event_key:
+                raise HTTPException(status_code=422, detail="scope_type='event_key'는 event_key가 필수입니다.")
+            if item.scope_id is not None:
+                raise HTTPException(status_code=422, detail="scope_type='event_key'는 scope_id를 가질 수 없습니다.")
+        elif item.event_key is not None:
+            raise HTTPException(
+                status_code=422, detail=f"scope_type='{item.scope_type}'는 event_key를 가질 수 없습니다.",
+            )
+
         # agent는 assigned conversation/thread에 mute 설정 불가
         if member.type == "agent" and item.level == "mute" and item.scope_type in ("conversation", "thread"):
             raise HTTPException(status_code=400, detail="Agent cannot mute assigned conversation or thread")
@@ -120,6 +137,7 @@ async def upsert_preferences(
                 member_id=member.id,
                 scope_type=item.scope_type,
                 scope_id=item.scope_id,
+                event_key=item.event_key,
                 channel=item.channel,
                 level=item.level,
                 created_at=now,
@@ -127,10 +145,18 @@ async def upsert_preferences(
             )
         )
         # partial unique index에 맞는 conflict target 선택
-        if item.scope_id is None:
+        if item.scope_type == "event_key":
+            stmt = stmt.on_conflict_do_update(
+                index_elements=["member_id", "event_key", "channel"],
+                index_where=NotificationPreference.event_key.isnot(None),
+                set_={"level": item.level, "updated_at": now},
+            )
+        elif item.scope_id is None:
             stmt = stmt.on_conflict_do_update(
                 index_elements=["member_id", "scope_type", "channel"],
-                index_where=NotificationPreference.scope_id.is_(None),
+                index_where=and_(
+                    NotificationPreference.scope_id.is_(None), NotificationPreference.event_key.is_(None),
+                ),
                 set_={"level": item.level, "updated_at": now},
             )
         else:

--- a/backend/app/services/channel_router.py
+++ b/backend/app/services/channel_router.py
@@ -203,12 +203,29 @@ async def route_message(
         conv_type: str = conv_row.type if conv_row else "group"
         conv_free_response: bool = bool(conv_row.free_response) if conv_row else False
 
-        scope_type_order: list[tuple[str, uuid.UUID | None]] = []
+        # story #2637 §0-c: msg_metadata['event']['event_key']가 있으면(이벤트 발행 메시지,
+        # #2637 AC 0-a가 태깅) "이 이벤트타입 전체 mute" 축을 conversation/project와 global
+        # 사이에 끼워 넣는다 — 사용자가 특정 대화를 명시로 커스텀했으면 그게 여전히 이기고
+        # (thread/conversation이 더 앞), 대화-구조 축이 전혀 없으면 event_key 축이 순수
+        # global보다 먼저 이긴다. __dict__ 전용 read는 _approval_payload와 동일 이유
+        # (getattr(msg, 'msg_metadata')의 미로드 컬럼 async lazy-load가 sync 컨텍스트에서
+        # greenlet_spawn 크래시를 낼 수 있어 회피).
+        event_key: str | None = None
+        _meta = (getattr(msg, "__dict__", None) or {}).get("msg_metadata")
+        if isinstance(_meta, dict):
+            _ev = _meta.get("event")
+            if isinstance(_ev, dict):
+                _ek = _ev.get("event_key")
+                event_key = _ek if isinstance(_ek, str) and _ek else None
+
+        scope_type_order: list[tuple[str, uuid.UUID | str | None]] = []
         if msg.thread_id:
             scope_type_order.append(("thread", msg.thread_id))
         scope_type_order.append(("conversation", msg.conversation_id))
         if conv_project_id:
             scope_type_order.append(("project", conv_project_id))
+        if event_key:
+            scope_type_order.append(("event_key", event_key))
         scope_type_order.append(("global", None))
 
         pref_rows = (await db.execute(
@@ -217,10 +234,13 @@ async def route_message(
             )
         )).scalars().all()
 
-        # member_id → {(scope_type, scope_id): NotificationPreference}
-        pref_map: dict[uuid.UUID, dict[tuple[str, uuid.UUID | None], NotificationPreference]] = {}
+        # member_id → {(scope_type, scope_id_or_event_key): NotificationPreference}. event_key-
+        # scope 행은 scope_id가 항상 NULL이라 그 자리에 event_key(str)를 대신 키로 쓴다 —
+        # scope_type_order도 동일 규약(("event_key", <str>))이라 조회가 그대로 맞아떨어진다.
+        pref_map: dict[uuid.UUID, dict[tuple[str, uuid.UUID | str | None], NotificationPreference]] = {}
         for p in pref_rows:
-            pref_map.setdefault(p.member_id, {})[(p.scope_type, p.scope_id)] = p
+            key_id = p.event_key if p.scope_type == "event_key" else p.scope_id
+            pref_map.setdefault(p.member_id, {})[(p.scope_type, key_id)] = p
 
         # 6. 수신자별 라우팅 결정 — sender_type 분기 없음(위 docstring, story #2603 P0).
         decisions: list[DeliveryDecision] = []

--- a/backend/app/services/event_definition_registry.py
+++ b/backend/app/services/event_definition_registry.py
@@ -42,6 +42,11 @@ class InvalidPayloadSchemaError(ValueError):
     다른 축)."""
 
 
+class InvalidBlockTemplateError(ValueError):
+    """story #2637 §범위1: block_template이 제한 어휘 4종(header/text/fields/actions) 계약을
+    위반 — 등록 시점 구조 게이트(치환 렌더링은 FE 몫, 여기는 구조만)."""
+
+
 class InvalidEventRoutingError(ValueError):
     """routing 선언이 두 부류 계약(model.py docstring)을 위반 — 등록 시점에 막아 #2633
     해석기가 절대 못 푸는 정의가 저장되는 것을 방지."""
@@ -124,6 +129,83 @@ def validate_event_routing(routing: dict, *, allow_server_derived: bool = True) 
         if not isinstance(leg, dict):
             raise InvalidEventRoutingError(f"routing.{leg_name}이 없거나 object가 아닙니다.")
         _validate_routing_leg(leg, leg_name=leg_name, allow_server_derived=allow_server_derived)
+
+
+_BLOCK_TYPES = frozenset({"header", "text", "fields", "actions"})
+# story #2637 범위3: 액션 v1 = 이벤트 발행 버튼만(다른 액션 종류는 후속 — 웹훅 액션은 명시
+# 제외 항목, doc event-registry-p2-block-template-detail §명시 제외).
+_ACTION_KINDS = frozenset({"publish"})
+_ACTION_AUTH_KEYS = frozenset({"human_only", "role"})
+
+
+def validate_block_template(template: dict) -> None:
+    """story #2637 §범위1: block_template v1 규격 — 제한 어휘 4종(header/text/fields/actions)
+    밖의 type은 등록 거부. 렌더 시 {{payload.field}} 치환 자체는 렌더러(FE) 몫이라 여기서
+    안 한다 — 이 함수는 등록 시점 **구조** 게이트만(어휘 4종·필수 필드·actions v1=publish만·
+    action_auth 키 화이트리스트). 소비자(렌더러) 없이 스키마+테스트만 먼저 굳히는 #2632
+    선례와 동형 — 실제 렌더링은 story #2637 FE 레인이 잇는다.
+
+    doc event-registry-p2-block-template-detail 0-b 예시가 이 함수의 실 계약 근거."""
+    if not isinstance(template, dict) or not isinstance(template.get("blocks"), list):
+        raise InvalidBlockTemplateError("block_template은 {'blocks': [...]} 형태의 object여야 합니다.")
+    blocks = template["blocks"]
+    if not blocks:
+        raise InvalidBlockTemplateError("block_template.blocks는 최소 1개 블록이 필요합니다.")
+    for i, block in enumerate(blocks):
+        if not isinstance(block, dict):
+            raise InvalidBlockTemplateError(f"blocks[{i}]은 object여야 합니다.")
+        block_type = block.get("type")
+        if block_type not in _BLOCK_TYPES:
+            raise InvalidBlockTemplateError(
+                f"blocks[{i}].type={block_type!r}은 제한 어휘 4종({sorted(_BLOCK_TYPES)}) 밖입니다."
+            )
+        if block_type in ("header", "text"):
+            if not isinstance(block.get("text"), str) or not block["text"]:
+                raise InvalidBlockTemplateError(f"blocks[{i}](type={block_type})는 비어있지 않은 text가 필요합니다.")
+        elif block_type == "fields":
+            fields = block.get("fields")
+            if not isinstance(fields, list) or not fields:
+                raise InvalidBlockTemplateError(f"blocks[{i}](type=fields)는 비어있지 않은 fields 목록이 필요합니다.")
+            for j, f in enumerate(fields):
+                if not isinstance(f, dict) or not isinstance(f.get("label"), str) or not isinstance(f.get("value"), str):
+                    raise InvalidBlockTemplateError(
+                        f"blocks[{i}].fields[{j}]는 {{'label': str, 'value': str}} 형태여야 합니다."
+                    )
+        elif block_type == "actions":
+            actions = block.get("actions")
+            if not isinstance(actions, list) or not actions:
+                raise InvalidBlockTemplateError(f"blocks[{i}](type=actions)는 비어있지 않은 actions 목록이 필요합니다.")
+            for j, a in enumerate(actions):
+                if not isinstance(a, dict):
+                    raise InvalidBlockTemplateError(f"blocks[{i}].actions[{j}]는 object여야 합니다.")
+                if a.get("action") not in _ACTION_KINDS:
+                    raise InvalidBlockTemplateError(
+                        f"blocks[{i}].actions[{j}].action={a.get('action')!r}은 v1 어휘"
+                        f"({sorted(_ACTION_KINDS)}) 밖입니다 — 웹훅 액션 등은 후속(명시 제외)."
+                    )
+                if not isinstance(a.get("label"), str) or not a["label"]:
+                    raise InvalidBlockTemplateError(f"blocks[{i}].actions[{j}]는 비어있지 않은 label이 필요합니다.")
+                if not isinstance(a.get("definition_key"), str) or not a["definition_key"]:
+                    raise InvalidBlockTemplateError(
+                        f"blocks[{i}].actions[{j}]는 발행할 definition_key(str)가 필요합니다."
+                    )
+                auth = a.get("auth")
+                if auth is not None:
+                    if not isinstance(auth, dict) or not set(auth.keys()) <= _ACTION_AUTH_KEYS:
+                        raise InvalidBlockTemplateError(
+                            f"blocks[{i}].actions[{j}].auth는 {sorted(_ACTION_AUTH_KEYS)} 키만 "
+                            "허용합니다(action_auth v1 어휘 — human_only·role)."
+                        )
+                    if "human_only" in auth and not isinstance(auth["human_only"], bool):
+                        raise InvalidBlockTemplateError(
+                            f"blocks[{i}].actions[{j}].auth.human_only은 bool이어야 합니다."
+                        )
+                    if "role" in auth and not (
+                        isinstance(auth["role"], list) and all(isinstance(r, str) for r in auth["role"])
+                    ):
+                        raise InvalidBlockTemplateError(
+                            f"blocks[{i}].actions[{j}].auth.role은 문자열 목록이어야 합니다."
+                        )
 
 
 def validate_event_payload_schema_shape(payload_schema: dict) -> None:

--- a/backend/tests/test_2637_block_template_registration.py
+++ b/backend/tests/test_2637_block_template_registration.py
@@ -1,0 +1,178 @@
+"""story #2637 §범위1/5 — POST/PATCH /api/v2/events/definitions의 block_template 등록 게이트.
+
+validate_block_template 단위 테스트(test_2637_block_template_validation.py)는 이미 구조
+계약을 고정했다 — 여기는 그게 실제 등록/수정 엔드포인트에 배선됐는지만 확인한다.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug="acme"):
+    from app.models.organization import Organization
+
+    org = Organization(id=uuid.uuid4(), name=f"Org-{slug}", slug=slug)
+    session.add(org)
+    await session.commit()
+    return org.id
+
+
+async def _seed_org_member(session, org_id, *, role="admin"):
+    from app.models.project import OrgMember
+
+    user_id = uuid.uuid4()
+    session.add(OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user_id, role=role))
+    await session.commit()
+    return user_id
+
+
+def _human_auth(user_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(user_id), email="admin@example.com",
+        claims={"app_metadata": {"org_id": str(org_id)}}, org_id=str(org_id),
+    )
+
+
+_VALID_SCHEMA = {"type": "object", "additionalProperties": False}
+_NONE_ROUTING = {
+    "escalation": {"kind": "server_derived", "target": "none"},
+    "broadcast": {"kind": "server_derived", "target": "none"},
+}
+_VALID_TEMPLATE = {"blocks": [{"type": "header", "text": "제목"}]}
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_register_with_valid_block_template():
+    from app.routers.events import CreateEventDefinitionRequest, create_event_definition
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_org_member(s, org_id, role="admin")
+
+            resp = await create_event_definition(
+                CreateEventDefinitionRequest(
+                    key="org.acme.widget.made", payload_schema=_VALID_SCHEMA,
+                    routing=_NONE_ROUTING, block_template=_VALID_TEMPLATE,
+                ),
+                db=s, auth=_human_auth(user_id, org_id), org_id=org_id,
+            )
+            assert resp.block_template == _VALID_TEMPLATE
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_register_without_block_template_stays_none():
+    """block_template 미지정 = 현행 제네릭 폴백(비회귀) — None으로 저장."""
+    from app.routers.events import CreateEventDefinitionRequest, create_event_definition
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_org_member(s, org_id, role="admin")
+
+            resp = await create_event_definition(
+                CreateEventDefinitionRequest(
+                    key="org.acme.widget.made", payload_schema=_VALID_SCHEMA, routing=_NONE_ROUTING,
+                ),
+                db=s, auth=_human_auth(user_id, org_id), org_id=org_id,
+            )
+            assert resp.block_template is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_register_rejects_invalid_block_template():
+    from app.routers.events import CreateEventDefinitionRequest, create_event_definition
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_org_member(s, org_id, role="admin")
+
+            with pytest.raises(HTTPException) as ei:
+                await create_event_definition(
+                    CreateEventDefinitionRequest(
+                        key="org.acme.widget.made", payload_schema=_VALID_SCHEMA,
+                        routing=_NONE_ROUTING, block_template={"blocks": [{"type": "carousel"}]},
+                    ),
+                    db=s, auth=_human_auth(user_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 400
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_patch_block_template_bumps_version_and_revalidates():
+    from app.routers.events import (
+        CreateEventDefinitionRequest, UpdateEventDefinitionRequest,
+        create_event_definition, update_event_definition,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_org_member(s, org_id, role="admin")
+
+            created = await create_event_definition(
+                CreateEventDefinitionRequest(
+                    key="org.acme.widget.made", payload_schema=_VALID_SCHEMA, routing=_NONE_ROUTING,
+                ),
+                db=s, auth=_human_auth(user_id, org_id), org_id=org_id,
+            )
+            updated = await update_event_definition(
+                uuid.UUID(created.id), UpdateEventDefinitionRequest(block_template=_VALID_TEMPLATE),
+                db=s, auth=_human_auth(user_id, org_id), org_id=org_id,
+            )
+            assert updated.version == 2
+            assert updated.block_template == _VALID_TEMPLATE
+
+            with pytest.raises(HTTPException) as ei:
+                await update_event_definition(
+                    uuid.UUID(created.id),
+                    UpdateEventDefinitionRequest(block_template={"blocks": []}),
+                    db=s, auth=_human_auth(user_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 400
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2637_block_template_validation.py
+++ b/backend/tests/test_2637_block_template_validation.py
@@ -1,0 +1,140 @@
+"""story #2637 §범위1 — validate_block_template(등록 시점 구조 게이트).
+
+doc event-registry-p2-block-template-detail 0-b 예시가 이 함수의 실 계약 근거. 어휘 4종
+(header/text/fields/actions) 밖 거부 + actions v1=publish만 + action_auth 키 화이트리스트
+(human_only·role)까지 검증. 렌더링({{payload.field}} 치환)은 FE 몫이라 여기선 안 다룬다.
+"""
+from __future__ import annotations
+
+import pytest
+
+_VALID_TEMPLATE = {
+    "blocks": [
+        {"type": "header", "text": "작업 상태 변경"},
+        {"type": "text", "text": "**{{payload.work_item_type}}** `{{payload.from_status}}` → `{{payload.to_status}}`"},
+        {"type": "fields", "fields": [
+            {"label": "대상", "value": "{{payload.work_item_id}}"},
+            {"label": "메모", "value": "{{payload.note}}"},
+        ]},
+        {"type": "actions", "actions": [
+            {"label": "확認", "action": "publish", "definition_key": "preset.work.status_changed",
+             "auth": {"human_only": True}},
+        ]},
+    ],
+}
+
+
+def test_accepts_doc_0b_reference_example():
+    from app.services.event_definition_registry import validate_block_template
+
+    validate_block_template(_VALID_TEMPLATE)  # no raise
+
+
+def test_rejects_non_dict_or_missing_blocks():
+    from app.services.event_definition_registry import InvalidBlockTemplateError, validate_block_template
+
+    with pytest.raises(InvalidBlockTemplateError):
+        validate_block_template({"not_blocks": []})
+    with pytest.raises(InvalidBlockTemplateError):
+        validate_block_template({"blocks": "not-a-list"})
+
+
+def test_rejects_empty_blocks():
+    from app.services.event_definition_registry import InvalidBlockTemplateError, validate_block_template
+
+    with pytest.raises(InvalidBlockTemplateError):
+        validate_block_template({"blocks": []})
+
+
+def test_rejects_unknown_block_type():
+    from app.services.event_definition_registry import InvalidBlockTemplateError, validate_block_template
+
+    with pytest.raises(InvalidBlockTemplateError):
+        validate_block_template({"blocks": [{"type": "image", "url": "x"}]})
+
+
+@pytest.mark.parametrize("block_type", ["header", "text"])
+def test_rejects_header_or_text_without_text_field(block_type):
+    from app.services.event_definition_registry import InvalidBlockTemplateError, validate_block_template
+
+    with pytest.raises(InvalidBlockTemplateError):
+        validate_block_template({"blocks": [{"type": block_type}]})
+    with pytest.raises(InvalidBlockTemplateError):
+        validate_block_template({"blocks": [{"type": block_type, "text": ""}]})
+
+
+def test_rejects_fields_without_label_or_value():
+    from app.services.event_definition_registry import InvalidBlockTemplateError, validate_block_template
+
+    with pytest.raises(InvalidBlockTemplateError):
+        validate_block_template({"blocks": [{"type": "fields", "fields": [{"label": "x"}]}]})
+    with pytest.raises(InvalidBlockTemplateError):
+        validate_block_template({"blocks": [{"type": "fields", "fields": []}]})
+
+
+def test_rejects_action_kind_outside_v1_vocabulary():
+    """액션 v1 = 이벤트 발행 버튼만 — 웹훅 액션 등은 명시 제외."""
+    from app.services.event_definition_registry import InvalidBlockTemplateError, validate_block_template
+
+    template = {"blocks": [{"type": "actions", "actions": [
+        {"label": "x", "action": "webhook", "definition_key": "k"},
+    ]}]}
+    with pytest.raises(InvalidBlockTemplateError):
+        validate_block_template(template)
+
+
+def test_rejects_action_without_definition_key():
+    from app.services.event_definition_registry import InvalidBlockTemplateError, validate_block_template
+
+    template = {"blocks": [{"type": "actions", "actions": [{"label": "x", "action": "publish"}]}]}
+    with pytest.raises(InvalidBlockTemplateError):
+        validate_block_template(template)
+
+
+def test_accepts_action_without_auth():
+    """auth는 optional — 없으면 통과(v1 human_only/role은 있을 때만 검증)."""
+    from app.services.event_definition_registry import validate_block_template
+
+    template = {"blocks": [{"type": "actions", "actions": [
+        {"label": "x", "action": "publish", "definition_key": "k"},
+    ]}]}
+    validate_block_template(template)  # no raise
+
+
+def test_rejects_auth_with_unknown_key():
+    from app.services.event_definition_registry import InvalidBlockTemplateError, validate_block_template
+
+    template = {"blocks": [{"type": "actions", "actions": [
+        {"label": "x", "action": "publish", "definition_key": "k", "auth": {"webhook_secret": "x"}},
+    ]}]}
+    with pytest.raises(InvalidBlockTemplateError):
+        validate_block_template(template)
+
+
+def test_rejects_human_only_wrong_type():
+    from app.services.event_definition_registry import InvalidBlockTemplateError, validate_block_template
+
+    template = {"blocks": [{"type": "actions", "actions": [
+        {"label": "x", "action": "publish", "definition_key": "k", "auth": {"human_only": "yes"}},
+    ]}]}
+    with pytest.raises(InvalidBlockTemplateError):
+        validate_block_template(template)
+
+
+def test_rejects_role_wrong_type():
+    from app.services.event_definition_registry import InvalidBlockTemplateError, validate_block_template
+
+    template = {"blocks": [{"type": "actions", "actions": [
+        {"label": "x", "action": "publish", "definition_key": "k", "auth": {"role": "owner"}},
+    ]}]}
+    with pytest.raises(InvalidBlockTemplateError):
+        validate_block_template(template)
+
+
+def test_accepts_role_list():
+    from app.services.event_definition_registry import validate_block_template
+
+    template = {"blocks": [{"type": "actions", "actions": [
+        {"label": "x", "action": "publish", "definition_key": "k", "auth": {"role": ["owner", "admin"]}},
+    ]}]}
+    validate_block_template(template)  # no raise

--- a/backend/tests/test_2637_event_msg_metadata_tagging.py
+++ b/backend/tests/test_2637_event_msg_metadata_tagging.py
@@ -1,0 +1,173 @@
+"""story #2637 AC 0-a — publish_registry_event가 ConversationMessage.msg_metadata에
+event_key+payload를 싣는다(approval_target 패턴과 동형 additive — send_message()의 기존
+확장 메커니즘, E-ACTIVATION S1의 typed-field→msg_metadata 패턴을 그대로 따름).
+
+이것 없으면 FE(#2637 렌더러 축)가 어떤 메시지가 "이벤트 발행분"인지 알 방법이 없다(미르코
+실측 — 스토리 AC 0-a 자체가 그 발견에서 나옴).
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import BackgroundTasks
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _load_seed_definitions():
+    import importlib.util
+    import os
+
+    spec = importlib.util.spec_from_file_location(
+        "_m0245tag", os.path.join(os.path.dirname(__file__), "..", "alembic", "versions", "0245_event_definitions.py"),
+    )
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return {key: (payload_schema, routing) for key, payload_schema, routing in m._SEED}
+
+
+async def _seed_preset_definitions(session):
+    from app.models.event_definition import EventDefinition
+
+    for key, (payload_schema, routing) in _load_seed_definitions().items():
+        session.add(EventDefinition(
+            id=uuid.uuid4(), key=key, org_id=None, payload_schema=payload_schema, routing=routing,
+        ))
+    await session.commit()
+
+
+async def _seed_org_project(session, *, slug="acme"):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2637tag", slug=slug)
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="agent"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True,
+    )
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_story(session, org_id, project_id, *, human_owner_member_id=None):
+    from app.models.pm import Story
+
+    story = Story(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="S",
+        human_owner_member_id=human_owner_member_id,
+    )
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+def _auth(agent_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(org_id),
+    )
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_publish_tags_message_with_event_key_and_payload():
+    from app.models.conversation import ConversationMessage
+    from app.routers.events import EventPublishRequest, publish_registry_event
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_preset_definitions(s)
+            publisher_id = await _seed_agent(s, org_id, project_id, name="publisher")
+            owner_id = await _seed_agent(s, org_id, project_id, name="owner")
+            story_id = await _seed_story(s, org_id, project_id, human_owner_member_id=owner_id)
+
+            body = EventPublishRequest(
+                definition_key="preset.gate.verdict",
+                payload={
+                    "work_item_type": "story", "work_item_id": str(story_id),
+                    "gate_type": "merge", "verdict": "approved",
+                },
+            )
+            resp = await publish_registry_event(
+                body, BackgroundTasks(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+
+            msg = (await s.execute(
+                select(ConversationMessage).where(ConversationMessage.id == uuid.UUID(resp["message_id"]))
+            )).scalar_one()
+            assert msg.msg_metadata is not None
+            assert msg.msg_metadata["event"]["event_key"] == "preset.gate.verdict"
+            assert msg.msg_metadata["event"]["payload"]["gate_type"] == "merge"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_regular_chat_message_has_no_event_metadata():
+    """일반 챗 메시지(이벤트 발행 아닌)는 msg_metadata['event']가 없어야 — additive 무회귀."""
+    from app.routers.conversations import SendMessageRequest, send_message
+    from app.models.conversation import ConversationMessage
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            publisher_id = await _seed_agent(s, org_id, project_id, name="publisher")
+
+            from app.routers.events import _get_or_create_event_conversation
+
+            conv = await _get_or_create_event_conversation(
+                s, org_id=org_id, project_id=project_id,
+                participant_ids={publisher_id}, created_by=publisher_id,
+            )
+            resp = await send_message(
+                conv.id, SendMessageRequest(content="그냥 챗"), BackgroundTasks(),
+                db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+            msg = (await s.execute(
+                select(ConversationMessage).where(ConversationMessage.id == uuid.UUID(resp["data"]["id"]))
+            )).scalar_one()
+            assert msg.msg_metadata is None
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2637_notification_preference_event_key.py
+++ b/backend/tests/test_2637_notification_preference_event_key.py
@@ -1,0 +1,185 @@
+"""story #2637 §0-c(#2636서 이관) — NotificationPreference event_key 축 + channel_router
+대조, "이 이벤트타입 mute" 실왕복.
+
+카디르 QA가 요구한 정확한 시나리오: 회원이 특정 event_key를 mute로 설정하면, 그 event_key로
+태깅된(#2637 AC 0-a) 메시지가 route_message()에서 그 회원에게만 DeliveryDecision을 안 낸다
+— 실 DB(NotificationPreference·ConversationMessage 둘 다 실 테이블)로 왕복 검증.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session, *, slug="acme"):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2637nk", slug=slug)
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="agent"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True,
+    )
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_group_conversation(session, org_id, project_id, *, participant_ids, created_by):
+    from app.routers.conversations import _create_conversation_record
+
+    return await _create_conversation_record(
+        session, org_id=org_id, project_id=project_id, member_ids=set(participant_ids),
+        conv_type="group", title=None, created_by=created_by,
+    )
+
+
+async def _seed_event_tagged_message(session, conv_id, sender_id, event_key: str):
+    from app.models.conversation import ConversationMessage
+
+    msg = ConversationMessage(
+        id=uuid.uuid4(), conversation_id=conv_id, sender_id=sender_id,
+        content="[이벤트] " + event_key,
+        msg_metadata={"event": {"event_key": event_key, "payload": {}}},
+    )
+    session.add(msg)
+    await session.commit()
+    return msg.id
+
+
+async def _seed_event_key_mute_pref(session, member_id, event_key: str, *, channel="sse"):
+    from app.models.notification_preference import NotificationPreference
+
+    p = NotificationPreference(
+        id=uuid.uuid4(), member_id=member_id, scope_type="event_key",
+        scope_id=None, event_key=event_key, channel=channel, level="mute",
+    )
+    session.add(p)
+    await session.commit()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_event_key_mute_excludes_recipient_from_delivery_decisions():
+    from app.services.channel_router import route_message
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            sender_id = await _seed_agent(s, org_id, project_id, name="publisher")
+            muter_id = await _seed_agent(s, org_id, project_id, name="muter")
+            other_id = await _seed_agent(s, org_id, project_id, name="other")
+
+            conv = await _seed_group_conversation(
+                s, org_id, project_id,
+                participant_ids={sender_id, muter_id, other_id}, created_by=sender_id,
+            )
+            await _seed_event_key_mute_pref(s, muter_id, "org.acme.widget.made")
+
+            msg_id = await _seed_event_tagged_message(s, conv.id, sender_id, "org.acme.widget.made")
+
+            decisions = await route_message(msg_id, s)
+            decided_ids = {d.member_id for d in decisions}
+
+            assert muter_id not in decided_ids, "event_key mute를 설정한 수신자는 제외돼야 한다"
+            assert other_id in decided_ids, "mute 안 한 수신자는 그대로 받아야 한다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_event_key_mute_does_not_affect_other_event_keys():
+    """특정 event_key만 mute — 다른 event_key로 태깅된 메시지는 그대로 받아야(범위 정밀성)."""
+    from app.services.channel_router import route_message
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            sender_id = await _seed_agent(s, org_id, project_id, name="publisher")
+            muter_id = await _seed_agent(s, org_id, project_id, name="muter")
+
+            conv = await _seed_group_conversation(
+                s, org_id, project_id, participant_ids={sender_id, muter_id}, created_by=sender_id,
+            )
+            await _seed_event_key_mute_pref(s, muter_id, "org.acme.widget.made")
+
+            other_msg_id = await _seed_event_tagged_message(s, conv.id, sender_id, "org.acme.thing.done")
+
+            decisions = await route_message(other_msg_id, s)
+            decided_ids = {d.member_id for d in decisions}
+            assert muter_id in decided_ids
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_conversation_scope_still_wins_over_event_key_scope():
+    """대화-구조 축(conversation)이 event_key 축보다 여전히 우선(더 구체적인 사용자 커스텀이
+    이긴다) — 이번엔 conversation-scope로 "all"을 명시했으면 event_key mute를 뒤집는다."""
+    from app.services.channel_router import route_message
+    from app.models.notification_preference import NotificationPreference
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            sender_id = await _seed_agent(s, org_id, project_id, name="publisher")
+            member_id = await _seed_agent(s, org_id, project_id, name="member")
+
+            conv = await _seed_group_conversation(
+                s, org_id, project_id, participant_ids={sender_id, member_id}, created_by=sender_id,
+            )
+            await _seed_event_key_mute_pref(s, member_id, "org.acme.widget.made")
+            s.add(NotificationPreference(
+                id=uuid.uuid4(), member_id=member_id, scope_type="conversation",
+                scope_id=conv.id, channel="sse", level="all",
+            ))
+            await s.commit()
+
+            msg_id = await _seed_event_tagged_message(s, conv.id, sender_id, "org.acme.widget.made")
+
+            decisions = await route_message(msg_id, s)
+            decided_ids = {d.member_id for d in decisions}
+            assert member_id in decided_ids, "conversation-scope 명시 커스텀이 event_key mute보다 우선해야 한다"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2637_notification_preference_router_event_key.py
+++ b/backend/tests/test_2637_notification_preference_router_event_key.py
@@ -1,0 +1,223 @@
+"""story #2637 §0-c — PUT /api/v2/notification-preferences의 event_key 축 CRUD 검증.
+
+scope_type="event_key"↔event_key 상호배타 강제, upsert 멱등(같은 (member, event_key,
+channel)로 재호출 시 update만).
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session, *, slug="acme"):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2637pref", slug=slug)
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="agent"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True,
+    )
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+def _auth(agent_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(org_id),
+    )
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_upsert_event_key_scope_succeeds():
+    from app.routers.notification_preferences import (
+        PreferenceItem, UpsertPreferencesRequest, upsert_preferences,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+            resp = await upsert_preferences(
+                UpsertPreferencesRequest(preferences=[
+                    PreferenceItem(scope_type="event_key", event_key="org.acme.widget.made",
+                                    channel="sse", level="mute"),
+                ]),
+                db=s, auth=_auth(agent_id, org_id), org_id=org_id,
+            )
+            assert resp["data"][0]["event_key"] == "org.acme.widget.made"
+            assert resp["data"][0]["scope_id"] is None
+            assert resp["data"][0]["level"] == "mute"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_upsert_event_key_scope_without_event_key_rejected():
+    from app.routers.notification_preferences import (
+        PreferenceItem, UpsertPreferencesRequest, upsert_preferences,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+            with pytest.raises(HTTPException) as ei:
+                await upsert_preferences(
+                    UpsertPreferencesRequest(preferences=[
+                        PreferenceItem(scope_type="event_key", channel="sse", level="mute"),
+                    ]),
+                    db=s, auth=_auth(agent_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 422
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_non_event_key_scope_with_event_key_rejected():
+    from app.routers.notification_preferences import (
+        PreferenceItem, UpsertPreferencesRequest, upsert_preferences,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+            with pytest.raises(HTTPException) as ei:
+                await upsert_preferences(
+                    UpsertPreferencesRequest(preferences=[
+                        PreferenceItem(scope_type="global", event_key="org.acme.widget.made",
+                                        channel="sse", level="mute"),
+                    ]),
+                    db=s, auth=_auth(agent_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 422
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_upsert_event_key_scope_is_idempotent_update():
+    from app.routers.notification_preferences import (
+        PreferenceItem, UpsertPreferencesRequest, upsert_preferences,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+            item = PreferenceItem(
+                scope_type="event_key", event_key="org.acme.widget.made", channel="sse", level="mute",
+            )
+            first = await upsert_preferences(
+                UpsertPreferencesRequest(preferences=[item]), db=s, auth=_auth(agent_id, org_id), org_id=org_id,
+            )
+            second = await upsert_preferences(
+                UpsertPreferencesRequest(preferences=[
+                    PreferenceItem(scope_type="event_key", event_key="org.acme.widget.made",
+                                    channel="sse", level="all"),
+                ]),
+                db=s, auth=_auth(agent_id, org_id), org_id=org_id,
+            )
+            assert first["data"][0]["id"] == second["data"][0]["id"]
+            assert second["data"][0]["level"] == "all"
+
+            from app.models.notification_preference import NotificationPreference
+            from sqlalchemy import select
+
+            count = (await s.execute(
+                select(NotificationPreference).where(NotificationPreference.member_id == agent_id)
+            )).scalars().all()
+            assert len(count) == 1
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_distinct_event_keys_do_not_collide():
+    from app.routers.notification_preferences import (
+        PreferenceItem, UpsertPreferencesRequest, upsert_preferences,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+            await upsert_preferences(
+                UpsertPreferencesRequest(preferences=[
+                    PreferenceItem(scope_type="event_key", event_key="org.acme.widget.made",
+                                    channel="sse", level="mute"),
+                ]),
+                db=s, auth=_auth(agent_id, org_id), org_id=org_id,
+            )
+            resp = await upsert_preferences(
+                UpsertPreferencesRequest(preferences=[
+                    PreferenceItem(scope_type="event_key", event_key="org.acme.thing.done",
+                                    channel="sse", level="mute"),
+                ]),
+                db=s, auth=_auth(agent_id, org_id), org_id=org_id,
+            )
+            assert resp["data"][0]["event_key"] == "org.acme.thing.done"
+
+            from app.routers.notification_preferences import get_preferences
+
+            all_prefs = await get_preferences(db=s, auth=_auth(agent_id, org_id), org_id=org_id)
+            assert len(all_prefs["data"]) == 2
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2637_preset_block_template_seed.py
+++ b/backend/tests/test_2637_preset_block_template_seed.py
@@ -1,0 +1,109 @@
+"""story #2637 §범위5(0-b 준용) — migration 0249: 프리셋 4종 block_template 시드.
+
+검증: 실 마이그 실행으로 4종 전부 block_template이 채워지는지 + 그 콘텐츠가 자체
+validate_block_template 게이트를 통과하는지(시드가 스스로 어긴 계약을 심으면 안 된다 —
+자기모순 방지) + 재실행 멱등(같은 값 재대입, 부작용 없음).
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+_MIG = os.path.join(
+    os.path.dirname(__file__), "..", "alembic", "versions", "0249_event_definitions_preset_block_templates.py"
+)
+
+pytestmark = pytest.mark.destructive_schema
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("mig0249", _MIG)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def test_all_seed_templates_pass_own_validation_gate():
+    """시드가 스스로 어긴 계약을 심으면 안 된다 — 자기모순 방지 회귀 가드."""
+    from app.services.event_definition_registry import validate_block_template
+
+    mig = _load_migration()
+    for key, template in mig._TEMPLATES.items():
+        validate_block_template(template)  # no raise
+
+
+def test_seed_covers_exactly_the_4_presets():
+    mig = _load_migration()
+    assert set(mig._TEMPLATES.keys()) == {
+        "preset.gate.verdict", "preset.work.status_changed",
+        "preset.work.assigned", "preset.goal.measured",
+    }
+
+
+def _run_migration_fn(eng, mig, fn_name: str) -> None:
+    import sqlalchemy as sa
+    from alembic.operations import Operations
+    from alembic.runtime.migration import MigrationContext
+
+    with eng.begin() as c:
+        with Operations.context(MigrationContext.configure(c)):
+            getattr(mig, fn_name)()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_migration_seeds_all_4_presets_and_is_idempotent():
+    import uuid
+    import sqlalchemy as sa
+
+    sync_url = _REAL_DB_URL.replace("postgresql+asyncpg://", "postgresql+psycopg2://").replace(
+        "postgresql://", "postgresql+psycopg2://"
+    )
+    eng = sa.create_engine(sync_url)
+    mig = _load_migration()
+    try:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS event_definitions"))
+            c.execute(sa.text(
+                "CREATE TABLE event_definitions (id uuid PRIMARY KEY, org_id uuid, key text NOT NULL, "
+                "block_template jsonb)"
+            ))
+            for key in mig._TEMPLATES:
+                c.execute(sa.text(
+                    "INSERT INTO event_definitions (id, org_id, key) VALUES (:id, NULL, :key)"
+                ), {"id": str(uuid.uuid4()), "key": key})
+            # org 커스텀 행(다른 org_id) — 이 마이그가 절대 안 건드려야 함(WHERE org_id IS NULL).
+            org_id = uuid.uuid4()
+            c.execute(sa.text(
+                "INSERT INTO event_definitions (id, org_id, key) VALUES (:id, :org_id, 'org.acme.thing.done')"
+            ), {"id": str(uuid.uuid4()), "org_id": str(org_id)})
+
+        _run_migration_fn(eng, mig, "upgrade")
+
+        with eng.begin() as c:
+            rows = c.execute(sa.text("SELECT key, block_template, org_id FROM event_definitions")).fetchall()
+        by_key = {r[0]: r[1] for r in rows}
+        for key, template in mig._TEMPLATES.items():
+            assert by_key[key] == template
+        # org 커스텀 행은 손대지 않음.
+        assert by_key["org.acme.thing.done"] is None
+
+        # 재실행 — 멱등(같은 값 재대입).
+        _run_migration_fn(eng, mig, "upgrade")
+        with eng.begin() as c:
+            rows2 = c.execute(sa.text("SELECT key, block_template FROM event_definitions")).fetchall()
+        assert {r[0]: r[1] for r in rows2} == by_key | {"org.acme.thing.done": None}
+
+        # downgrade — 전부 NULL로.
+        _run_migration_fn(eng, mig, "downgrade")
+        with eng.begin() as c:
+            rows3 = c.execute(sa.text("SELECT key, block_template FROM event_definitions")).fetchall()
+        for key, tmpl in rows3:
+            if key in mig._TEMPLATES:
+                assert tmpl is None
+    finally:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS event_definitions"))
+        eng.dispose()


### PR DESCRIPTION
## 요약
doc [P2 상세 분해](entity:doc:e6bbd8a0-228d-4555-90f4-f8eaa6333add) — 페드루군이 배분한 BE 절반 3항목. FE 절반(렌더러·액션 실행·결재 카드 이관, 미르코 레인)은 이 PR 상륙 후(0-a가 태깅 근거이므로) 별도로 잇는다.

## 0-a: 메시지 event_key 태깅
`publish_registry_event`가 `ConversationMessage.msg_metadata['event']`에 `event_key`+`payload`를 싣는다 — `approval_target` 패턴과 동형 additive namespace이지만, `approval_delivery.py`처럼 `send_message()`를 우회하지 않고 `SendMessageRequest.event_context` 필드를 통해 E-ACTIVATION S1의 typed-field→msg_metadata 확장 메커니즘을 그대로 따른다(#2633 AC2 "신규 전달 계통 금지" 준수). FE가 이 필드로 이벤트 발행 메시지를 인지해 block_template을 찾을 근거.

## §범위1/5: block_template v1 구조 게이트 + 프리셋 4종 시드(0-b 준용)
`validate_block_template` — 제한 어휘 4종(header/text/fields/actions) 밖 거부, actions는 v1=publish만(웹훅 등 명시 제외), action_auth 키 화이트리스트(human_only·role). #2636 등록/수정 엔드포인트에 배선 — 미지정 시 현행 제네릭 폴백 유지(비회귀). migration 0249가 프리셋 4종에 기본 템플릿 시드(0-b 예시 + 나머지 3종 동형 패턴, actions 블록은 미포함 — 실 발행 대상 없는 액션 버튼은 안 심는 게 낫다는 판단, 결재 카드 이관이 실 액션의 첫 케이스).

## §0-c(#2636서 이관): 구독 event_key 축 — "이 이벤트타입 mute" 실왕복
`NotificationPreference`에 `event_key` 컬럼(migration 0250) + `channel_router.py`의 `scope_type_order`에 event_key 축 삽입(conversation/project와 global 사이 — 명시 대화별 커스텀은 여전히 우선, 대화-구조 축이 없으면 이벤트타입별 mute가 순수 global보다 먼저 이김). #2636에서 "소비자 없는 컬럼"으로 기각됐던 (b)안의 문제를 해소 — 실제로 `route_message`가 이 축을 대조해 알림을 끊는다.

## 부수 발견·수정
`NotificationPreference` 모델이 3개 파티셜 유니크 인덱스를 `__table_args__`에 한 번도 등록한 적이 없었다(migration의 raw `op.create_index`로만 존재) — `Base.metadata.create_all()` 기반 realdb 테스트가 `upsert_preferences`의 ON CONFLICT를 태우면 크래시로 못 잡던 사각(이 라우터를 create_all로 테스트한 사례가 지금까지 0건이라 안 드러남). 등록해 create_all도 migration과 동일 제약을 재현하게 함(순수 additive, 실 migrated DB는 무회귀).

## 검증
신선 Postgres(pgvector) + `alembic upgrade heads` 전체 체인(0250까지) 재확인. 신규 7개 테스트 파일: destructive 66건 + non-destructive 120건 전부 통과. mute round-trip 3종(단순 mute·다른 event_key 무영향·conversation-scope 우선순위) 전부 실측 확인.

## Test plan
- [x] 로컬 pytest(신선 컨테이너, 신규 7파일 + 결합회귀 186건)
- [ ] CI green
- [ ] 미르코 FE 착수(렌더러) — 0-a 스키마 확인 후
- [ ] 카디르 QA(렌더→액션→인가 거부→mute 왕복 라이브, FE 결합 후)