### PR TITLE
feat(#2637): action_auth 발행 시점 서버 집행

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -988,6 +988,30 @@ async def publish_registry_event(
             status_code=404, detail=f"event definition not found or disabled: {body.definition_key!r}",
         )
 
+    # story #2637 §범위3(미르코 발견 후속, 2026-08-14): action_auth 실 집행 — 정의에 걸려
+    # 있으면 발행 시점에 검사한다. 이전엔 block_template.actions[].auth가 등록 시점 구조
+    # 검증만 받고 발행 시점엔 아무도 안 봐서 "FE만 버튼을 숨기고 서버는 거부 안 함"이었다
+    # (#2091 클래스 — 금지 AC는 서버가 거부해야 성립). 이 엔드포인트가 버튼/REST/MCP 전부의
+    # 유일한 발행 경로(#2633 AC2 단일 파이프)라 여기 한 곳만 지키면 경로 무관하게 막힌다.
+    if definition.action_auth:
+        if definition.action_auth.get("human_only") and sender.type == "agent":
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "code": "action_auth_denied",
+                    "message": f"이 이벤트({definition.key})는 human 발행자만 허용합니다.",
+                },
+            )
+        allowed_roles = definition.action_auth.get("role")
+        if allowed_roles and sender.role not in allowed_roles:
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "code": "action_auth_denied",
+                    "message": f"이 이벤트({definition.key})는 {allowed_roles} role만 허용합니다.",
+                },
+            )
+
     from app.services.event_definition_registry import InvalidEventPayloadError, validate_event_payload
 
     try:
@@ -1122,6 +1146,11 @@ class CreateEventDefinitionRequest(BaseModel):
     routing: dict
     # story #2637 §범위1/5: optional — 없으면 렌더러가 현행 제네릭 폴백을 쓴다(비회귀).
     block_template: dict | None = None
+    # story #2637 §범위3(미르코 발견 후속, 2026-08-14): 정의 레벨 발행 인가 — 있으면
+    # publish_registry_event가 발행 시점에 실제로 집행한다(human_only·role). 경로 무관
+    # (버튼/REST/MCP 전부 이 단일 엔드포인트를 탄다 — #2633 AC2 단일 파이프 덕에 별도
+    # 집행 지점이 필요 없다).
+    action_auth: dict | None = None
 
 
 class UpdateEventDefinitionRequest(BaseModel):
@@ -1129,6 +1158,7 @@ class UpdateEventDefinitionRequest(BaseModel):
     routing: dict | None = None
     enabled: bool | None = None
     block_template: dict | None = None
+    action_auth: dict | None = None
 
 
 class EventDefinitionDetailResponse(BaseModel):
@@ -1138,6 +1168,7 @@ class EventDefinitionDetailResponse(BaseModel):
     payload_schema: dict
     routing: dict
     block_template: dict | None
+    action_auth: dict | None
     enabled: bool
     version: int
     created_by: str | None
@@ -1147,7 +1178,8 @@ def _event_definition_detail(d: "EventDefinition") -> EventDefinitionDetailRespo
     return EventDefinitionDetailResponse(
         id=str(d.id), key=d.key, org_id=str(d.org_id) if d.org_id else None,
         payload_schema=d.payload_schema, routing=d.routing,
-        block_template=d.block_template, enabled=d.enabled, version=d.version,
+        block_template=d.block_template, action_auth=d.action_auth,
+        enabled=d.enabled, version=d.version,
         created_by=str(d.created_by) if d.created_by else None,
     )
 
@@ -1179,10 +1211,12 @@ async def create_event_definition(
     """
     from app.models.event_definition import EventDefinition
     from app.services.event_definition_registry import (
+        InvalidActionAuthError,
         InvalidBlockTemplateError,
         InvalidEventDefinitionKeyError,
         InvalidEventRoutingError,
         InvalidPayloadSchemaError,
+        validate_action_auth,
         validate_block_template,
         validate_event_definition_key,
         validate_event_payload_schema_shape,
@@ -1200,9 +1234,11 @@ async def create_event_definition(
         validate_event_routing(body.routing, allow_server_derived=False)
         if body.block_template is not None:
             validate_block_template(body.block_template)
+        if body.action_auth is not None:
+            validate_action_auth(body.action_auth)
     except (
         InvalidEventDefinitionKeyError, InvalidPayloadSchemaError,
-        InvalidEventRoutingError, InvalidBlockTemplateError,
+        InvalidEventRoutingError, InvalidBlockTemplateError, InvalidActionAuthError,
     ) as e:
         raise HTTPException(
             status_code=400, detail={"code": "invalid_definition", "message": str(e)},
@@ -1223,7 +1259,7 @@ async def create_event_definition(
     definition = EventDefinition(
         id=uuid.uuid4(), key=body.key, org_id=org_id,
         payload_schema=body.payload_schema, routing=body.routing,
-        block_template=body.block_template,
+        block_template=body.block_template, action_auth=body.action_auth,
         created_by=sender.id,
     )
     db.add(definition)
@@ -1246,9 +1282,11 @@ async def update_event_definition(
     행만 대상(WHERE에 명시, 존재해도 org_id 안 맞으면 404로 정보 노출 0)."""
     from app.models.event_definition import EventDefinition
     from app.services.event_definition_registry import (
+        InvalidActionAuthError,
         InvalidBlockTemplateError,
         InvalidEventRoutingError,
         InvalidPayloadSchemaError,
+        validate_action_auth,
         validate_block_template,
         validate_event_payload_schema_shape,
         validate_event_routing,
@@ -1258,8 +1296,8 @@ async def update_event_definition(
         raise HTTPException(status_code=403, detail="org admin/owner required")
 
     if (
-        body.payload_schema is None and body.routing is None
-        and body.enabled is None and body.block_template is None
+        body.payload_schema is None and body.routing is None and body.enabled is None
+        and body.block_template is None and body.action_auth is None
     ):
         raise HTTPException(status_code=400, detail="at least one field must be provided")
 
@@ -1298,6 +1336,15 @@ async def update_event_definition(
                 status_code=400, detail={"code": "invalid_definition", "message": str(e)},
             ) from e
         definition.block_template = body.block_template
+        content_changed = True
+    if body.action_auth is not None:
+        try:
+            validate_action_auth(body.action_auth)
+        except InvalidActionAuthError as e:
+            raise HTTPException(
+                status_code=400, detail={"code": "invalid_definition", "message": str(e)},
+            ) from e
+        definition.action_auth = body.action_auth
         content_changed = True
     if body.enabled is not None:
         definition.enabled = body.enabled

--- a/backend/app/services/event_definition_registry.py
+++ b/backend/app/services/event_definition_registry.py
@@ -47,6 +47,12 @@ class InvalidBlockTemplateError(ValueError):
     위반 — 등록 시점 구조 게이트(치환 렌더링은 FE 몫, 여기는 구조만)."""
 
 
+class InvalidActionAuthError(ValueError):
+    """story #2637 §범위3(미르코 발견 후속, 2026-08-14): action_auth 어휘(human_only·role)
+    위반 — block_template.actions[].auth와 EventDefinition.action_auth 둘 다 이 함수 하나로
+    검증(shape 정합·중복 규칙 0)."""
+
+
 class InvalidEventRoutingError(ValueError):
     """routing 선언이 두 부류 계약(model.py docstring)을 위반 — 등록 시점에 막아 #2633
     해석기가 절대 못 푸는 정의가 저장되는 것을 방지."""
@@ -138,6 +144,25 @@ _ACTION_KINDS = frozenset({"publish"})
 _ACTION_AUTH_KEYS = frozenset({"human_only", "role"})
 
 
+def validate_action_auth(auth: dict) -> None:
+    """story #2637 §범위3 — action_auth v1 어휘(human_only·role) 화이트리스트. 두 소비처
+    양쪽에서 쓴다: ①block_template.actions[].auth(등록 시점 구조 게이트, validate_block_
+    template이 호출) ②EventDefinition.action_auth(발행 시점 실 집행 — publish_registry_
+    event가 이 shape을 그대로 신뢰하고 human_only/role을 검사, 미르코 발견 후속: "정의에
+    action_auth 있으면 서버가 거부"가 실제로 성립하려면 이 shape이 등록 시점에 이미 검증돼
+    있어야 한다)."""
+    if not isinstance(auth, dict) or not set(auth.keys()) <= _ACTION_AUTH_KEYS:
+        raise InvalidActionAuthError(
+            f"{sorted(_ACTION_AUTH_KEYS)} 키만 허용합니다(action_auth v1 어휘 — human_only·role)."
+        )
+    if "human_only" in auth and not isinstance(auth["human_only"], bool):
+        raise InvalidActionAuthError("human_only은 bool이어야 합니다.")
+    if "role" in auth and not (
+        isinstance(auth["role"], list) and all(isinstance(r, str) for r in auth["role"])
+    ):
+        raise InvalidActionAuthError("role은 문자열 목록이어야 합니다.")
+
+
 def validate_block_template(template: dict) -> None:
     """story #2637 §범위1: block_template v1 규격 — 제한 어휘 4종(header/text/fields/actions)
     밖의 type은 등록 거부. 렌더 시 {{payload.field}} 치환 자체는 렌더러(FE) 몫이라 여기서
@@ -191,21 +216,10 @@ def validate_block_template(template: dict) -> None:
                     )
                 auth = a.get("auth")
                 if auth is not None:
-                    if not isinstance(auth, dict) or not set(auth.keys()) <= _ACTION_AUTH_KEYS:
-                        raise InvalidBlockTemplateError(
-                            f"blocks[{i}].actions[{j}].auth는 {sorted(_ACTION_AUTH_KEYS)} 키만 "
-                            "허용합니다(action_auth v1 어휘 — human_only·role)."
-                        )
-                    if "human_only" in auth and not isinstance(auth["human_only"], bool):
-                        raise InvalidBlockTemplateError(
-                            f"blocks[{i}].actions[{j}].auth.human_only은 bool이어야 합니다."
-                        )
-                    if "role" in auth and not (
-                        isinstance(auth["role"], list) and all(isinstance(r, str) for r in auth["role"])
-                    ):
-                        raise InvalidBlockTemplateError(
-                            f"blocks[{i}].actions[{j}].auth.role은 문자열 목록이어야 합니다."
-                        )
+                    try:
+                        validate_action_auth(auth)
+                    except InvalidActionAuthError as e:
+                        raise InvalidBlockTemplateError(f"blocks[{i}].actions[{j}].auth: {e}") from e
 
 
 def validate_event_payload_schema_shape(payload_schema: dict) -> None:

--- a/backend/tests/test_2637_action_auth_enforcement.py
+++ b/backend/tests/test_2637_action_auth_enforcement.py
@@ -1,0 +1,276 @@
+"""story #2637 §범위3 후속(미르코 발견, 2026-08-14) — publish_registry_event가
+EventDefinition.action_auth를 발행 시점에 실제로 집행하는지.
+
+이전엔 block_template.actions[].auth가 등록 시점 구조 검증만 받고 발행 시점엔 아무도
+안 봤다 — FE만 버튼을 숨기면 "금지 AC=서버가 거부"가 성립하지 않는다(#2091 클래스). 이
+엔드포인트가 버튼/REST/MCP 전부의 유일한 발행 경로라 경로 구분 없이 여기 하나로 검증한다.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session, *, slug="acme"):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2637aa", slug=slug)
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="agent", role="member"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name,
+        is_active=True, role=role,
+    )
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_org_member_human(session, org_id, project_id, *, role="admin"):
+    """OrgMember(레거시 resolve_member 조회 축, id=team_members row와 동일 id 사용) +
+    TeamMember(type=human) 2종 세트.
+
+    team_members VIEW(migration 0088, members ⋈ project_access)는 real-migrated DB에만
+    존재한다 — 이 테스트는 Base.metadata.create_all()만 쓰므로 team_members는 그냥
+    TeamMember 모델이 그대로 만드는 리터럴 테이블이다. resolve_member()의 LEGACY 휴먼
+    분기는 sender.id=OrgMember.id를 conversations.created_by에 그대로 쓰므로, 그 id로
+    조회 가능한 TeamMember(type="human") 행이 있어야 FK가 통과한다(#2637 그라운딩 중
+    ForeignKeyViolationError로 실측 발견 — Member/ProjectAccess 3종 조합은 VIEW 전용이라
+    create_all 경로엔 무관했다)."""
+    from app.models.project import OrgMember
+    from app.models.team import TeamMember
+
+    user_id = uuid.uuid4()
+    member_id = uuid.uuid4()
+    session.add(OrgMember(id=member_id, org_id=org_id, user_id=user_id, role=role))
+    session.add(TeamMember(
+        id=member_id, org_id=org_id, project_id=project_id, type="human", name="Human",
+        role=role, is_active=True,
+    ))
+    await session.commit()
+    return user_id
+
+
+async def _seed_definition(session, org_id, *, key, action_auth):
+    from app.models.event_definition import EventDefinition
+
+    d = EventDefinition(
+        id=uuid.uuid4(), key=key, org_id=org_id,
+        payload_schema={
+            "type": "object", "additionalProperties": False,
+            "properties": {"goal_id": {"type": "string"}},
+        },
+        routing={
+            "escalation": {"kind": "server_derived", "target": "none"},
+            "broadcast": {"kind": "server_derived", "target": "none"},
+        },
+        action_auth=action_auth,
+    )
+    session.add(d)
+    await session.commit()
+    return d
+
+
+async def _seed_goal(session, org_id, project_id):
+    from app.models.pm import Goal
+
+    goal = Goal(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="G")
+    session.add(goal)
+    await session.commit()
+    return goal.id
+
+
+def _agent_auth(agent_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(org_id),
+    )
+
+
+def _human_auth(user_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(user_id), email="human@example.com",
+        claims={"app_metadata": {"org_id": str(org_id)}}, org_id=str(org_id),
+    )
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_human_only_blocks_agent_publisher():
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            await _seed_definition(s, org_id, key="org.acme.thing.done", action_auth={"human_only": True})
+
+            with pytest.raises(HTTPException) as ei:
+                await publish_registry_event(
+                    EventPublishRequest(definition_key="org.acme.thing.done", payload={}),
+                    BackgroundTasks(), db=s, auth=_agent_auth(agent_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 403
+            assert ei.value.detail["code"] == "action_auth_denied"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_human_only_allows_human_publisher():
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            human_id = await _seed_org_member_human(s, org_id, project_id)
+            goal_id = await _seed_goal(s, org_id, project_id)
+            await _seed_definition(s, org_id, key="org.acme.thing.done", action_auth={"human_only": True})
+
+            resp = await publish_registry_event(
+                EventPublishRequest(definition_key="org.acme.thing.done", payload={"goal_id": str(goal_id)}),
+                BackgroundTasks(), db=s, auth=_human_auth(human_id, org_id), org_id=org_id,
+            )
+            assert "message_id" in resp
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_role_mismatch_blocks_publisher():
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id, role="member")
+            await _seed_definition(
+                s, org_id, key="org.acme.thing.done", action_auth={"role": ["admin", "owner"]},
+            )
+
+            with pytest.raises(HTTPException) as ei:
+                await publish_registry_event(
+                    EventPublishRequest(definition_key="org.acme.thing.done", payload={}),
+                    BackgroundTasks(), db=s, auth=_agent_auth(agent_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 403
+            assert ei.value.detail["code"] == "action_auth_denied"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_role_match_allows_publisher():
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id, role="admin")
+            goal_id = await _seed_goal(s, org_id, project_id)
+            await _seed_definition(
+                s, org_id, key="org.acme.thing.done", action_auth={"role": ["admin", "owner"]},
+            )
+
+            resp = await publish_registry_event(
+                EventPublishRequest(definition_key="org.acme.thing.done", payload={"goal_id": str(goal_id)}),
+                BackgroundTasks(), db=s, auth=_agent_auth(agent_id, org_id), org_id=org_id,
+            )
+            assert "message_id" in resp
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_no_action_auth_is_unrestricted_non_regression():
+    """action_auth 없는 정의는 현행 그대로(비회귀) — agent도 자유롭게 발행."""
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id, role="member")
+            goal_id = await _seed_goal(s, org_id, project_id)
+            await _seed_definition(s, org_id, key="org.acme.thing.done", action_auth=None)
+
+            resp = await publish_registry_event(
+                EventPublishRequest(definition_key="org.acme.thing.done", payload={"goal_id": str(goal_id)}),
+                BackgroundTasks(), db=s, auth=_agent_auth(agent_id, org_id), org_id=org_id,
+            )
+            assert "message_id" in resp
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_combined_human_only_and_role_both_enforced():
+    """human_only+role 동시 지정 — human이어도 role 불일치면 여전히 거부(AND 결합)."""
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            human_id = await _seed_org_member_human(s, org_id, project_id, role="member")
+            await _seed_definition(
+                s, org_id, key="org.acme.thing.done",
+                action_auth={"human_only": True, "role": ["owner"]},
+            )
+
+            with pytest.raises(HTTPException) as ei:
+                await publish_registry_event(
+                    EventPublishRequest(definition_key="org.acme.thing.done", payload={}),
+                    BackgroundTasks(), db=s, auth=_human_auth(human_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 403
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- #2637 §범위3 후속 (미르코 발견, 2026-08-14): `publish_registry_event`가 `EventDefinition.action_auth`를 발행 시점에 실제로 검사하지 않고 있었다 — `block_template.actions[].auth`는 등록 시점 구조 검증만 받고 발행 시점엔 아무도 안 봐서, FE가 버튼만 숨기면 서버는 거부하지 않는 #2091 클래스 갭이었다.
- `publish_registry_event`에 definition-level 집행 추가: `action_auth.human_only: true` → 발행자가 agent면 403, `action_auth.role: [...]` → 발행자 role 불일치 시 403. 둘 다 `{code: "action_auth_denied", message}` shape.
- 이 엔드포인트가 버튼/REST/MCP 전부의 유일한 발행 경로(#2633 AC2 단일 파이프)라 여기 한 곳만 지키면 경로 무관하게 막힌다.
- `action_auth` 없는 정의는 비회귀(agent 자유 발행 그대로).
- `validate_action_auth` 검증기를 `event_definition_registry.py`에서 재사용(등록 시점 block_template 구조 검증과 동일 함수).

## Test plan
- [x] `tests/test_2637_action_auth_enforcement.py` (6 tests, destructive_schema): human_only가 agent 발행자를 차단/human 허용, role 불일치 차단/일치 허용, action_auth 없는 정의 비회귀, human_only+role 동시 지정 AND 결합.
- [x] fresh disposable Postgres 컨테이너에서 destructive_schema + non-destructive 전체 #2637 스위트(37 tests) 재검증.
- [x] events registry consumer sweep(#2632/#2633/#2634/#2636, 49 tests) 회귀 없음 확인.
- [x] notification_preference/channel_router consumer sweep(46 tests) 회귀 없음 확인.
- [x] develop 최신(f28884e6d, #3036 병합분 포함) 위에서 리베이스 후 재검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)