### PR TITLE
fix(#2640): Cloud Build Dockerfile 베이스를 mirror.gcr.io로 전환

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,6 +1,12 @@
 # D-S2: Next.js standalone 빌드용 Dockerfile
 # 빌드 컨텍스트: 레포 루트 (cloudbuild.yaml에서 실행)
-FROM node:20-alpine AS base
+# story #2640(P0 실사고, 2026-08-13 21:05): docker.io 익명 pull이 429로 Cloud Build를
+# 죽였다(build beb26450) — mirror.gcr.io로 전환해 그 rate-limit 표면 자체를 없앤다.
+# Docker daemon registry-mirror 설정이 아니라 FROM에 직접 참조하는 방식(Cloud Build 표준
+# `gcr.io/cloud-builders/docker` 스텝은 daemon.json을 못 건드림) — 실측(2026-08-14, 디디):
+# 흔치 않은 태그(node:20.11.1-alpine3.19)도 온디맨드 fetch-through 성공, 존재하지 않는
+# 태그는 정상 404("not found") — 캐시 미스가 조용히 깨지는 새 실패 모드가 아님을 확認.
+FROM mirror.gcr.io/library/node:20-alpine AS base
 RUN corepack enable pnpm
 
 # ─── 의존성 설치 ──────────────────────────────────────────────────────────────
@@ -41,7 +47,9 @@ ENV NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED=${NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED}
 RUN pnpm build
 
 # ─── 런타임 ──────────────────────────────────────────────────────────────────
-FROM node:20-alpine AS runner
+# story #2640: 위 base 스테이지와 동일 이유(mirror.gcr.io) — runner는 base에서 파생되지
+# 않는 별도 스테이지라 여기도 따로 전환 필요.
+FROM mirror.gcr.io/library/node:20-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,11 @@
-FROM python:3.12-slim
+# story #2640(P0 실사고, 2026-08-13 21:05): docker.io 익명 pull이 429로 Cloud Build를
+# 죽였다(build beb26450) — mirror.gcr.io로 전환해 그 rate-limit 표면 자체를 없앤다.
+# Docker daemon registry-mirror 설정이 아니라 FROM에 직접 참조하는 방식(Cloud Build 표준
+# `gcr.io/cloud-builders/docker` 스텝은 daemon.json을 못 건드림) — 실측(2026-08-14, 디디):
+# 흔치 않은 태그도 온디맨드 fetch-through 성공, 존재하지 않는 태그는 정상 404("not found") —
+# 캐시 미스가 조용히 깨지는 새 실패 모드가 아님을 확認. ghcr.io(uv 바이너리, 아래)는
+# docker.io가 아니라 이번 스코프 밖(story AC가 docker.io만 대상).
+FROM mirror.gcr.io/library/python:3.12-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- 실사고(08-13 21:05): dev Cloud Build가 `docker.io/library/node:20-alpine` manifest fetch에서 **429 Too Many Requests**로 실패(build beb26450) — Docker Hub 익명 rate limit, 코드 무관. prod 배포도 같은 경로라 릴리스 타이밍에 재발 가능한 구조였다.
- `apps/web/Dockerfile`(base·runner 2곳)·`backend/Dockerfile`을 `mirror.gcr.io/library/*` 직접 참조로 전환해 이 rate-limit 표면을 없앤다.
- `cloudbuild.yaml`은 dev/prod 공용 단일 파일(`_DEPLOY_ENV`로 분기, 사본 없음)이라 파일 기준으로 두 환경 모두 자동 적용.
- **범위 제외**: 루트 `Dockerfile`(OSS 셀프호스트 docker-compose 전용)은 cloudbuild 무관이라 429 사고 표면이 아니고, 외부 셀프호스터에게 구글 인프라 의존을 강제하는 건 별개 트레이드오프라 이번 스코프에서 뺐다(PO 판정, story #2640 설명 참조).
- GAR remote-repository(mirror.gcr.io의 "캐시 보장 없음" 잔여리스크를 없애는 더 강한 해법)는 새 GCP 리소스 프로비저닝이 필요해 별도 후속으로 남긴다.

## 캐시-미스 동작 검증(PO 지적③)
FROM에 `mirror.gcr.io/library/*`를 직접 참조하는 방식은 Docker 공식 문서가 명시하는 daemon `registry-mirrors` 설정 방식과 다르다 — Cloud Build 표준 `gcr.io/cloud-builders/docker` 스텝은 `daemon.json`에 접근할 수 없어 daemon-mirror 방식 자체가 불가능하므로 직접 참조가 유일한 선택지다. 공식 문서는 이 직접-참조 패턴의 캐시-미스 동작을 다루지 않아, 실측으로 검증했다(2026-08-14):
- 흔치 않은 태그(`node:20.11.1-alpine3.19`, 로컬 미보유 확인 후 pull)도 온디맨드 fetch-through 성공(7.5s) — 정적 인기캐시가 아니라 실제 프록시 동작임을 확인.
- 존재하지 않는 태그는 `not found` 정상 404 — 조용히 깨지는 새 실패모드가 아님을 확인.

## Test plan
- [x] `docker build --no-cache -f backend/Dockerfile ./backend` 로컬 성공(25.7s), 로그에 `FROM mirror.gcr.io/library/python:3.12-slim@sha256:...` pull 라인 실물.
- [x] `docker build --no-cache -f apps/web/Dockerfile .` 로컬 성공(114.7s), 로그에 `FROM mirror.gcr.io/library/node:20-alpine@sha256:...` pull 라인 실물(base·runner 둘 다).
- [x] `grep docker.io apps/web/Dockerfile backend/Dockerfile` — FROM 라인 기준 0(남은 매치는 설명 주석뿐).
- [ ] dev Cloud Build 실배포 1회(머지 후 자동, GHA develop 트리거) — AC2 최종 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)