### PR TITLE
fix(#2637): preset.gate.verdict 정정 — 대상 필드 work_item_id→work_item_title (AC4 선행)

### DIFF
--- a/backend/alembic/versions/0251_gate_verdict_work_item_title.py
+++ b/backend/alembic/versions/0251_gate_verdict_work_item_title.py
@@ -1,0 +1,126 @@
+"""story #2637 AC4 후속(페드루 지시, 2026-08-14) — preset.gate.verdict 정정 2건.
+
+Revision ID: 0251
+Revises: 0250
+Create Date: 2026-08-14
+
+[[no-pr-for-data]] 게이트 — 프리셋 표현 콘텐츠 변경(0166/0167/0240/0249 선례와 동일 규칙,
+병합 전 선생님 확認 필요할 수 있음).
+
+정정 근거(페드루, 2026-08-14): 0249 시드의 block_template이 결재 카드 실물 대조 없이
+만들어진 얕은 원본이었다 — 실 승인 카드는 work_item의 **title**을 그리는데(UUID를 그대로
+보여주지 않는다), 0249는 "대상" 필드 value를 `{{payload.work_item_id}}`로 심었다. 이
+정의(preset.gate.verdict)는 아직 발행처 0건(backend/app 전체에 publish 호출 없음, 페드루
+실측)이라 계약을 공짜로 고칠 수 있는 지금이 적기다.
+
+두 가지를 한 UPDATE로 묶는다(PATCH /api/v2/events/definitions의 version 범프 규율과
+동형 — 여러 필드가 한 논리적 변경에 같이 바뀌어도 version은 1만 오른다, `content_changed`
+불리언 하나가 payload_schema/routing/block_template/action_auth 전체를 대표하는 events.py
+::update_event_definition 패턴 그대로):
+1. block_template.fields[0]("대상") value: `{{payload.work_item_id}}` →
+   `{{payload.work_item_title}}`.
+2. payload_schema.properties에 `work_item_title` 추가(additive) — **required엔 안 넣는다**.
+   발행처가 아직 없어 강제할 실 데이터가 없고, 치환 실패는 FE의 `⟨missing: payload.x⟩`
+   플레이스홀더(apps/web/src/lib/block-template.ts::substituteMustache, #3038)가 정직하게
+   드러내므로 여기서 required로 조기 강제할 필요가 없다.
+"""
+from __future__ import annotations
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0251"
+down_revision = "0250"
+branch_labels = None
+depends_on = None
+
+_KEY = "preset.gate.verdict"
+
+_OLD_BLOCK_TEMPLATE = {
+    "blocks": [
+        {"type": "header", "text": "게이트 판정"},
+        {"type": "text", "text": "**{{payload.gate_type}}** 게이트 — **{{payload.verdict}}**"},
+        {"type": "fields", "fields": [
+            {"label": "대상", "value": "{{payload.work_item_id}}"},
+            {"label": "사유", "value": "{{payload.resolution_note}}"},
+        ]},
+    ],
+}
+
+_NEW_BLOCK_TEMPLATE = {
+    "blocks": [
+        {"type": "header", "text": "게이트 판정"},
+        {"type": "text", "text": "**{{payload.gate_type}}** 게이트 — **{{payload.verdict}}**"},
+        {"type": "fields", "fields": [
+            {"label": "대상", "value": "{{payload.work_item_title}}"},
+            {"label": "사유", "value": "{{payload.resolution_note}}"},
+        ]},
+    ],
+}
+
+# 0245 원본 그대로 + work_item_title 추가(additive, required 아님) — 나머지 필드/구조는
+# 무손실 보존(부분 jsonb merge 대신 전체 리터럴 교체, 0249와 동일 스타일 — 드리프트 방지).
+_OLD_PAYLOAD_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["work_item_type", "work_item_id", "gate_type", "verdict"],
+    "properties": {
+        "work_item_type": {"type": "string"},
+        "work_item_id": {"type": "string", "format": "uuid"},
+        "gate_type": {"type": "string"},
+        "verdict": {"type": "string", "enum": ["approved", "rejected"]},
+        "resolver_member_id": {"type": "string", "format": "uuid"},
+        "resolution_note": {"type": ["string", "null"]},
+    },
+}
+
+_NEW_PAYLOAD_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["work_item_type", "work_item_id", "gate_type", "verdict"],
+    "properties": {
+        "work_item_type": {"type": "string"},
+        "work_item_id": {"type": "string", "format": "uuid"},
+        "work_item_title": {"type": ["string", "null"]},
+        "gate_type": {"type": "string"},
+        "verdict": {"type": "string", "enum": ["approved", "rejected"]},
+        "resolver_member_id": {"type": "string", "format": "uuid"},
+        "resolution_note": {"type": ["string", "null"]},
+    },
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            "UPDATE event_definitions "
+            "SET block_template = :block_template, payload_schema = :payload_schema, "
+            "    version = version + 1 "
+            "WHERE org_id IS NULL AND key = :key"
+        ),
+        {
+            "block_template": json.dumps(_NEW_BLOCK_TEMPLATE),
+            "payload_schema": json.dumps(_NEW_PAYLOAD_SCHEMA),
+            "key": _KEY,
+        },
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            "UPDATE event_definitions "
+            "SET block_template = :block_template, payload_schema = :payload_schema, "
+            "    version = version - 1 "
+            "WHERE org_id IS NULL AND key = :key"
+        ),
+        {
+            "block_template": json.dumps(_OLD_BLOCK_TEMPLATE),
+            "payload_schema": json.dumps(_OLD_PAYLOAD_SCHEMA),
+            "key": _KEY,
+        },
+    )

--- a/backend/tests/test_2637_gate_verdict_title_fix.py
+++ b/backend/tests/test_2637_gate_verdict_title_fix.py
@@ -1,0 +1,150 @@
+"""story #2637 AC4 후속(페드루 지시, 2026-08-14) — migration 0251: preset.gate.verdict
+block_template의 "대상" 필드를 work_item_id → work_item_title로 정정 + payload_schema에
+work_item_title 추가(additive·non-required).
+
+검증: 새 block_template/payload_schema가 자체 검증 게이트를 통과하는지(자기모순 방지) +
+실 마이그 실행으로 preset.gate.verdict «만» 바뀌고(다른 3개 프리셋·org 커스텀 행은 무변경) +
+version이 PATCH 엔드포인트와 동형으로 1만 오르는지 + downgrade가 원상복구(version 포함)하는지.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+_MIG = os.path.join(
+    os.path.dirname(__file__), "..", "alembic", "versions", "0251_gate_verdict_work_item_title.py"
+)
+
+pytestmark = pytest.mark.destructive_schema
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("mig0251", _MIG)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def test_new_block_template_passes_own_validation_gate():
+    from app.services.event_definition_registry import validate_block_template
+
+    mig = _load_migration()
+    validate_block_template(mig._NEW_BLOCK_TEMPLATE)  # no raise
+
+
+def test_new_payload_schema_is_valid_and_additionalproperties_false():
+    import jsonschema
+
+    mig = _load_migration()
+    validator_cls = jsonschema.validators.validator_for(mig._NEW_PAYLOAD_SCHEMA)
+    validator_cls.check_schema(mig._NEW_PAYLOAD_SCHEMA)  # no raise
+    assert mig._NEW_PAYLOAD_SCHEMA["additionalProperties"] is False
+
+
+def test_work_item_title_added_but_not_required():
+    mig = _load_migration()
+    assert "work_item_title" in mig._NEW_PAYLOAD_SCHEMA["properties"]
+    assert "work_item_title" not in mig._NEW_PAYLOAD_SCHEMA["required"]
+
+
+def test_target_field_value_switches_from_id_to_title():
+    mig = _load_migration()
+    fields = mig._NEW_BLOCK_TEMPLATE["blocks"][2]["fields"]
+    target_field = next(f for f in fields if f["label"] == "대상")
+    assert target_field["value"] == "{{payload.work_item_title}}"
+    old_fields = mig._OLD_BLOCK_TEMPLATE["blocks"][2]["fields"]
+    old_target = next(f for f in old_fields if f["label"] == "대상")
+    assert old_target["value"] == "{{payload.work_item_id}}"
+
+
+def _run_migration_fn(eng, mig, fn_name: str) -> None:
+    import sqlalchemy as sa  # noqa: F401
+    from alembic.operations import Operations
+    from alembic.runtime.migration import MigrationContext
+
+    with eng.begin() as c:
+        with Operations.context(MigrationContext.configure(c)):
+            getattr(mig, fn_name)()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_migration_updates_only_gate_verdict_and_bumps_version_by_one():
+    import uuid
+    import sqlalchemy as sa
+
+    sync_url = _REAL_DB_URL.replace("postgresql+asyncpg://", "postgresql+psycopg2://").replace(
+        "postgresql://", "postgresql+psycopg2://"
+    )
+    eng = sa.create_engine(sync_url)
+    mig = _load_migration()
+    other_preset_key = "preset.work.status_changed"
+    try:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS event_definitions"))
+            c.execute(sa.text(
+                "CREATE TABLE event_definitions (id uuid PRIMARY KEY, org_id uuid, key text NOT NULL, "
+                "block_template jsonb, payload_schema jsonb, version integer NOT NULL DEFAULT 1)"
+            ))
+            c.execute(sa.text(
+                "INSERT INTO event_definitions (id, org_id, key, block_template, payload_schema, version) "
+                "VALUES (:id, NULL, :key, :bt, :ps, 1)"
+            ), {
+                "id": str(uuid.uuid4()), "key": mig._KEY,
+                "bt": __import__("json").dumps(mig._OLD_BLOCK_TEMPLATE),
+                "ps": __import__("json").dumps(mig._OLD_PAYLOAD_SCHEMA),
+            })
+            # 다른 프리셋 행 — 이 마이그가 절대 안 건드려야 함(WHERE key = 'preset.gate.verdict').
+            c.execute(sa.text(
+                "INSERT INTO event_definitions (id, org_id, key, block_template, payload_schema, version) "
+                "VALUES (:id, NULL, :key, NULL, NULL, 1)"
+            ), {"id": str(uuid.uuid4()), "key": other_preset_key})
+            # org 커스텀 행(동일 key, 다른 org_id) — WHERE org_id IS NULL 밖이라 무변경이어야 함.
+            org_id = uuid.uuid4()
+            c.execute(sa.text(
+                "INSERT INTO event_definitions (id, org_id, key, block_template, payload_schema, version) "
+                "VALUES (:id, :org_id, :key, NULL, NULL, 1)"
+            ), {"id": str(uuid.uuid4()), "org_id": str(org_id), "key": mig._KEY})
+
+        _run_migration_fn(eng, mig, "upgrade")
+
+        with eng.begin() as c:
+            rows = {
+                r[0]: dict(org_id=r[1], block_template=r[2], payload_schema=r[3], version=r[4])
+                for r in c.execute(sa.text(
+                    "SELECT key, org_id, block_template, payload_schema, version FROM event_definitions"
+                )).fetchall()
+                if r[1] is None
+            }
+        gate = rows[mig._KEY]
+        assert gate["block_template"] == mig._NEW_BLOCK_TEMPLATE
+        assert gate["payload_schema"] == mig._NEW_PAYLOAD_SCHEMA
+        assert gate["version"] == 2  # 1 -> 2, single bump despite 2 fields changed (PATCH 동형)
+
+        other = rows[other_preset_key]
+        assert other["block_template"] is None
+        assert other["payload_schema"] is None
+        assert other["version"] == 1  # 무변경
+
+        with eng.begin() as c:
+            org_row = c.execute(sa.text(
+                "SELECT block_template, payload_schema, version FROM event_definitions WHERE org_id = :org_id"
+            ), {"org_id": str(org_id)}).fetchone()
+        assert org_row == (None, None, 1)  # org 커스텀 행 무변경
+
+        # downgrade — 원상복구(version 포함).
+        _run_migration_fn(eng, mig, "downgrade")
+        with eng.begin() as c:
+            gate_after = c.execute(sa.text(
+                "SELECT block_template, payload_schema, version FROM event_definitions "
+                "WHERE org_id IS NULL AND key = :key"
+            ), {"key": mig._KEY}).fetchone()
+        assert gate_after[0] == mig._OLD_BLOCK_TEMPLATE
+        assert gate_after[1] == mig._OLD_PAYLOAD_SCHEMA
+        assert gate_after[2] == 1
+    finally:
+        with eng.begin() as c:
+            c.execute(sa.text("DROP TABLE IF EXISTS event_definitions"))
+        eng.dispose()


### PR DESCRIPTION
## Summary
- #2637 AC4(미르코군 FE 카드 소비) 선행 조각 — 0249 시드의 `block_template`이 결재 카드 실물 대조 없이 만들어진 얕은 원본이었다. 실 카드는 work_item의 **title**을 그리는데(UUID를 그대로 노출하지 않는다) "대상" 필드 value가 `{{payload.work_item_id}}`로 심어져 있었다.
- 이 정의(`preset.gate.verdict`)는 아직 발행처 0건(backend/app 전체에 publish 호출 없음, PO 실측)이라 계약을 공짜로 고칠 수 있는 지금이 적기.
- `block_template.fields[0]("대상")` value: `{{payload.work_item_id}}` → `{{payload.work_item_title}}`.
- `payload_schema.properties`에 `work_item_title` 추가(additive, **required 아님** — 치환 실패는 FE의 `⟨missing: payload.x⟩` 플레이스홀더가 정직하게 드러낸다, `apps/web/src/lib/block-template.ts::substituteMustache` #3038).
- **version 범프 규율 확인·적용**: `PATCH /api/v2/events/definitions`의 `content_changed` 규율(여러 필드가 한 논리적 변경에 같이 바뀌어도 version은 1만 오름, `app/routers/events.py::update_event_definition`)과 동형으로, 이 마이그도 block_template+payload_schema 두 필드를 같이 바꾸지만 `version += 1` 한 번만.
- 다른 3개 프리셋·org 커스텀 행(`WHERE org_id IS NULL AND key = 'preset.gate.verdict'` 밖)은 무변경 — 테스트로 고정.

## Test plan
- [x] `tests/test_2637_gate_verdict_title_fix.py`(5 tests): 새 block_template/payload_schema가 자체 검증 게이트 통과(자기모순 방지) · `work_item_title` additive-non-required 고정 · 대상 필드 값 전환 고정 · 실 마이그 실행으로 gate.verdict만 변경+version 1→2, 다른 프리셋/org 커스텀 행 무변경, downgrade 원상복구(version 포함) 회귀 가드.
- [x] 기존 `tests/test_2637_preset_block_template_seed.py`(0249) 비회귀 확인.
- [x] fresh disposable Postgres에서 `alembic upgrade heads`(0251까지) 실 마이그 실행 후 `psql`로 라이브 row 직접 대조(version=2·target_field=work_item_title·payload_schema.properties.work_item_title 존재) 실측.
- [x] events registry consumer sweep(#2632/#2633, block_template validation) 41+14 tests 회귀 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)