### PR TITLE
[SID:2637] AC4 — approval-request-card resolved 분기 block_template 부분 소비

### DIFF
--- a/apps/web/src/components/chat/approval-request-card.tsx
+++ b/apps/web/src/components/chat/approval-request-card.tsx
@@ -9,6 +9,8 @@ import { GateSignatureApproval } from '@/components/cage/gate-signature-approval
 import { deriveRiskLevel, usesSignatureFlow } from '@/components/cage/gate-risk';
 import { EntityPreviewModal, getEntityHref } from '@/components/chat/embed-card';
 import type { GateItem } from '@/components/kanban/types';
+import { parseBlockTemplate, renderBlockTemplate, type EventDefinitionSummary } from '@/lib/block-template';
+import { renderStaticEventBlock } from '@/components/chat/event-block-card';
 
 export interface ApprovalTarget {
   work_item_type: string;
@@ -23,6 +25,11 @@ export interface ApprovalTarget {
 
 interface ApprovalRequestCardProps {
   target: ApprovalTarget;
+  /** story #2637 AC4(PO 08-14 확定) — chat-view.tsx가 대화당 1회 배치조회한 event_definitions
+   * 카탈로그를 그대로 물려받는다(eventDefinitionsByKey와 동일 패턴, 별도 fetch 안 만든다).
+   * resolved(회신) 분기가 이 카탈로그의 preset.gate.verdict 항목을 찾아 정적 표현부(text·
+   * fields)만 소비한다 — pending(요청·서명·버튼) 분기는 그대로다. */
+  eventDefinitionsByKey?: Record<string, EventDefinitionSummary> | null;
 }
 
 type CardState =
@@ -65,7 +72,7 @@ const RESOLVED_STATUS_LABEL_KEYS: Record<string, string> = {
  * (`GateSignatureApproval`)와 형제로 렌더돼 모달 열람/닫기가 그 로컬 state(근거확인·사유)를
  * 건드리지 않는다(AC③, 언마운트 없음).
  */
-export function ApprovalRequestCard({ target }: ApprovalRequestCardProps) {
+export function ApprovalRequestCard({ target, eventDefinitionsByKey }: ApprovalRequestCardProps) {
   const t = useTranslations('chats');
   const [state, setState] = useState<CardState>({ kind: 'loading' });
   const [resolving, setResolving] = useState(false);
@@ -128,6 +135,7 @@ export function ApprovalRequestCard({ target }: ApprovalRequestCardProps) {
           transitionError={transitionError}
           onApprove={(reason) => void transition('approved', reason)}
           onReject={(reason) => void transition('rejected', reason)}
+          eventDefinitionsByKey={eventDefinitionsByKey}
         />
       )}
     </div>
@@ -135,19 +143,42 @@ export function ApprovalRequestCard({ target }: ApprovalRequestCardProps) {
 }
 
 function ApprovalRequestBody({
-  gate, resolving, transitionError, onApprove, onReject,
+  gate, resolving, transitionError, onApprove, onReject, eventDefinitionsByKey,
 }: {
   gate: GateItem;
   resolving: boolean;
   transitionError: string | null;
   onApprove: (reason?: string) => void;
   onReject: (reason?: string) => void;
+  eventDefinitionsByKey?: Record<string, EventDefinitionSummary> | null;
 }) {
   const t = useTranslations('chats');
   // gates/[id]/page.tsx와 같은 문구를 쓴다(동일 개념=동일 어휘, DS 원칙) — 그 키들은 'cage'
   // 네임스페이스에 있다('chats'엔 없음, 그라운딩 중 확認).
   const tCage = useTranslations('cage');
   const title = gate.work_item_summary?.title ?? `#${gate.work_item_id.slice(0, 8)}`;
+
+  // story #2637 AC4(PO 08-14 확定, Q2/Q3 그라운딩) — resolved(회신) 분기만 preset.gate.verdict
+  // block_template을 부분 소비(text·fields만 — header/actions는 안 씀, 「결재 요청」 라벨은
+  // 그대로 카드 정체성으로 남는다). fetchGate()의 실물 데이터를 payload 동형 객체로 "합성"한다
+  // (Pedro 표현) — 원본 gate.status/work_item_id를 날것 그대로 흘려보내지 않고, title 폴백은
+  // 현행 로직 그대로 재사용(work_item_title 자리), verdict도 현행 RESOLVED_STATUS_LABEL_KEYS
+  // 번역을 그대로 재사용(raw "approved"/"rejected" 영문 노출은 시각 퇴보 — Q2가 work_item_id
+  // 건에서 확定한 "시각 동일 우선" 원칙을 verdict 필드에도 동형 적용). 템플릿 없음/파싱 실패는
+  // 조용히 죽지 않고 아래 기존 하드코딩 렌더로 폴백(AC2 폴백 원칙과 동형 방어).
+  const resolvedStaticBlocks = gate.status !== 'pending' ? (() => {
+    const definition = eventDefinitionsByKey?.['preset.gate.verdict'];
+    const parsed = definition?.block_template ? parseBlockTemplate(definition.block_template) : null;
+    if (!parsed) return null;
+    const verdictLabel = RESOLVED_STATUS_LABEL_KEYS[gate.status] ? t(RESOLVED_STATUS_LABEL_KEYS[gate.status]!) : gate.status;
+    const payload: Record<string, unknown> = {
+      gate_type: gate.gate_type,
+      verdict: verdictLabel,
+      work_item_title: title,
+      resolution_note: gate.resolution_note ?? null,
+    };
+    return renderBlockTemplate(parsed, payload).filter((b) => b.type === 'text' || b.type === 'fields');
+  })() : null;
   const riskLevel = deriveRiskLevel(gate);
   const needsFullFlow = usesSignatureFlow(riskLevel);
   const canAct = gate.status === 'pending' && gate.can_approve === true;
@@ -179,21 +210,36 @@ function ApprovalRequestBody({
       ) : null}
 
       {gate.status !== 'pending' ? (
-        <div className="space-y-1">
-          <div className="flex items-center gap-1.5 text-xs font-medium text-foreground">
-            {gate.status === 'approved' ? <Check className="h-3.5 w-3.5 text-primary" /> : <X className="h-3.5 w-3.5 text-destructive" />}
-            {t('approvalRequestResolvedStatus', {
-              status: RESOLVED_STATUS_LABEL_KEYS[gate.status] ? t(RESOLVED_STATUS_LABEL_KEYS[gate.status]!) : gate.status,
-            })}
+        resolvedStaticBlocks ? (
+          // story #2637 AC4 — 아이콘은 그대로 뱃지처럼 앞에 두고(어휘 4종 밖의 순수 UI 크롬,
+          // 템플릿이 대신할 수 없다), text·fields 블록은 EventBlockCard와 동일한 자기 고유
+          // 크기(text-sm/text-xs)로 그대로 둔다 — 억지로 기존 text-xs 한 줄에 욱여넣지 않는다
+          // (사이즈 클래스 충돌로 인한 시각 왜곡 방지).
+          <div className="space-y-1.5">
+            <div className="flex items-center gap-1.5">
+              {gate.status === 'approved' ? <Check className="h-3.5 w-3.5 text-primary" /> : <X className="h-3.5 w-3.5 text-destructive" />}
+              {resolvedStaticBlocks.filter((b) => b.type === 'text').map((b, i) => renderStaticEventBlock(b, i))}
+            </div>
+            {resolvedStaticBlocks.filter((b) => b.type === 'fields').map((b, i) => renderStaticEventBlock(b, i))}
           </div>
-          {/* story #2624 — 상신자가 결과를 회신 카드로 받아도 사유(resolution_note)가 안
-              보이면 "사유는 남겨놨는데" 인시던트가 human 웹 표면에서 재발한다. gate는 항상
-              fetchGate()로 실측한 최신 값이라 어느 메시지(request/result)를 눌러 들어왔든
-              같은 값을 보여준다. */}
-          {gate.resolution_note ? (
-            <p className="text-[11px] text-muted-foreground">{t('approvalRequestResolutionNote', { note: gate.resolution_note })}</p>
-          ) : null}
-        </div>
+        ) : (
+          <div className="space-y-1">
+            <div className="flex items-center gap-1.5 text-xs font-medium text-foreground">
+              {gate.status === 'approved' ? <Check className="h-3.5 w-3.5 text-primary" /> : <X className="h-3.5 w-3.5 text-destructive" />}
+              {t('approvalRequestResolvedStatus', {
+                status: RESOLVED_STATUS_LABEL_KEYS[gate.status] ? t(RESOLVED_STATUS_LABEL_KEYS[gate.status]!) : gate.status,
+              })}
+            </div>
+            {/* story #2624 — 상신자가 결과를 회신 카드로 받아도 사유(resolution_note)가 안
+                보이면 "사유는 남겨놨는데" 인시던트가 human 웹 표면에서 재발한다. gate는 항상
+                fetchGate()로 실측한 최신 값이라 어느 메시지(request/result)를 눌러 들어왔든
+                같은 값을 보여준다.
+                story #2637 AC4 — 템플릿 없음/파싱실패 시 폴백(비회귀 안전망, AC2와 동형). */}
+            {gate.resolution_note ? (
+              <p className="text-[11px] text-muted-foreground">{t('approvalRequestResolutionNote', { note: gate.resolution_note })}</p>
+            ) : null}
+          </div>
+        )
       ) : !canAct ? (
         // story #2091(P0)과 동일 fail-closed 규율 — can_approve=false(무권한 뷰어)는 액션을
         // 렌더하지 않는다. 고위험도 이제 챗 안에서 완결되므로(#2625) 여기 남는 유일한

--- a/apps/web/src/components/chat/approval-request-card.tsx
+++ b/apps/web/src/components/chat/approval-request-card.tsx
@@ -177,7 +177,17 @@ function ApprovalRequestBody({
       work_item_title: title,
       resolution_note: gate.resolution_note ?? null,
     };
-    return renderBlockTemplate(parsed, payload).filter((b) => b.type === 'text' || b.type === 'fields');
+    // PO 리뷰(head 81f7e4a7e) — resolution_note 없음은 템플릿 저자 실수(⟨missing⟩ 마커
+    // 대상)가 아니라 정상적인 「선택값 부재」다(기존 카드도 사유 없으면 그 줄 자체를 안
+    // 그렸다 — story #2624). fields 블록에서 payload.resolution_note를 참조하는 항목을
+    // 렌더 *전에* 통째로 걸러내 ⟨missing⟩ 마커가 아예 뜨지 않게 한다(사유가 있을 땐 그대로
+    // 통과 — filter는 no-op).
+    const blocksToRender = gate.resolution_note
+      ? parsed.blocks
+      : parsed.blocks.map((b) => (
+        b.type === 'fields' ? { ...b, fields: b.fields.filter((f) => f.value !== '{{payload.resolution_note}}') } : b
+      ));
+    return renderBlockTemplate({ blocks: blocksToRender }, payload).filter((b) => b.type === 'text' || b.type === 'fields');
   })() : null;
   const riskLevel = deriveRiskLevel(gate);
   const needsFullFlow = usesSignatureFlow(riskLevel);

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -867,6 +867,16 @@ describe('ChatBubble — story #2604 P2 결재 요청(approval_target) 카드', 
       expect(container.textContent).toContain('제안서.md');
     });
 
+    it('PO 리뷰(head 81f7e4a7e) — resolved + 템플릿 있음 + resolution_note 없음(승인·사유 미기재) — 사유 행 자체가 안 뜬다(⟨missing⟩ 마커 노출 금지, 기존 카드와 동형 비회귀)', async () => {
+      stubGate({ status: 'approved', title: '제안서.md', resolution_note: null });
+      await act(async () => {
+        root.render(wrap(<ChatBubble message={approvalMessage} isMine={false} eventDefinitionsByKey={withGateVerdictCatalog} />));
+      });
+      expect(container.textContent).toContain('승인됨');
+      expect(container.textContent).not.toContain('⟨missing');
+      expect(container.textContent).not.toContain('사유:');
+    });
+
     it('resolved + 카탈로그에 preset.gate.verdict 없음(구정의·미시딩) — 기존 하드코딩 렌더로 폴백(비회귀)', async () => {
       stubGate({ status: 'rejected', resolution_note: '근거가 불충분합니다' });
       await act(async () => {

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -836,6 +836,58 @@ describe('ChatBubble — story #2604 P2 결재 요청(approval_target) 카드', 
     const signBtn = Array.from(document.body.querySelectorAll('button')).find((b) => b.textContent?.includes('승인하고 서명'))!;
     expect(signBtn.hasAttribute('disabled')).toBe(false);
   });
+
+  describe('story #2637 AC4(PO 08-14 확定) — resolved 분기 preset.gate.verdict block_template 부분 소비', () => {
+    // 0251 마이그(develop 상륙) 실물 그대로 — 대상 필드 value가 work_item_title로 정정된 것.
+    const GATE_VERDICT_TEMPLATE = {
+      blocks: [
+        { type: 'header', text: '게이트 판정' },
+        { type: 'text', text: '**{{payload.gate_type}}** 게이트 — **{{payload.verdict}}**' },
+        { type: 'fields', fields: [
+          { label: '대상', value: '{{payload.work_item_title}}' },
+          { label: '사유', value: '{{payload.resolution_note}}' },
+        ] },
+      ],
+    };
+    const withGateVerdictCatalog = { 'preset.gate.verdict': { key: 'preset.gate.verdict', org_id: null, payload_schema: {}, routing: {}, block_template: GATE_VERDICT_TEMPLATE, enabled: true, version: 2 } };
+
+    it('resolved + 카탈로그에 템플릿 있음 — 대상은 UUID가 아니라 fetched title, 사유는 fields로, 상태는 한글 verdict 라벨로 렌더된다(header는 부분소비 제외)', async () => {
+      stubGate({ status: 'approved', title: '제안서.md', resolution_note: '근거가 충분합니다' });
+      await act(async () => {
+        root.render(wrap(<ChatBubble message={approvalMessage} isMine={false} eventDefinitionsByKey={withGateVerdictCatalog} />));
+      });
+      expect(container.textContent).toContain('결재 요청'); // Q3 — 카드 라벨은 그대로.
+      expect(container.textContent).not.toContain('게이트 판정'); // header는 부분소비 제외.
+      expect(container.textContent).not.toContain(DOC_ID); // Q2 — UUID 노출 금지.
+      expect(container.textContent).toContain('doc_approval');
+      expect(container.textContent).toContain('승인됨'); // verdict 합성값 = 현행 한글 라벨.
+      expect(container.textContent).toContain('근거가 충분합니다');
+      // '제안서.md'는 카드 상단 제목(기존)과 fields 대상 값(신규) 둘 다에 나타난다 — 중복 등장 자체가
+      // 정상(같은 개념 두 자리 표시), 최소 1회 이상만 확認.
+      expect(container.textContent).toContain('제안서.md');
+    });
+
+    it('resolved + 카탈로그에 preset.gate.verdict 없음(구정의·미시딩) — 기존 하드코딩 렌더로 폴백(비회귀)', async () => {
+      stubGate({ status: 'rejected', resolution_note: '근거가 불충분합니다' });
+      await act(async () => {
+        root.render(wrap(<ChatBubble message={approvalMessage} isMine={false} eventDefinitionsByKey={{}} />));
+      });
+      expect(container.textContent).toContain('반려됨');
+      expect(container.textContent).toContain('근거가 불충분합니다');
+      expect(container.textContent).not.toContain('게이트 판정');
+    });
+
+    it('Q1 — pending 상태는 카탈로그에 템플릿이 있어도 영향받지 않는다(제목·뱃지·버튼 그대로)', async () => {
+      stubGate({});
+      await act(async () => {
+        root.render(wrap(<ChatBubble message={approvalMessage} isMine={false} eventDefinitionsByKey={withGateVerdictCatalog} />));
+      });
+      expect(container.textContent).toContain('제안서.md');
+      expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent?.includes('승인'))).toBe(true);
+      expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent?.includes('반려'))).toBe(true);
+      expect(container.textContent).not.toContain('게이트 판정');
+    });
+  });
 });
 
 describe('ChatBubble — story #2637 event_definitions block_template 카드', () => {

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -492,7 +492,7 @@ export function ChatBubble({
               </button>
             </div>
           ) : approvalTarget ? (
-            <ApprovalRequestCard target={approvalTarget} />
+            <ApprovalRequestCard target={approvalTarget} eventDefinitionsByKey={eventDefinitionsByKey} />
           ) : eventTarget && eventBlockTemplate ? (
             <EventBlockCard
               template={eventBlockTemplate}

--- a/apps/web/src/components/chat/event-block-card.tsx
+++ b/apps/web/src/components/chat/event-block-card.tsx
@@ -112,27 +112,26 @@ function isActionAuthorized(
   return true;
 }
 
-function EventBlockRow({
-  block, payload, currentMemberType, currentRole, t,
-}: {
-  block: BlockTemplateBlock;
-  payload: Record<string, unknown>;
-  currentMemberType: 'human' | 'agent' | undefined;
-  currentRole: string | undefined;
-  t: ReturnType<typeof useTranslations>;
-}) {
+/**
+ * story #2637 AC4 — header/text/fields 3종(비-action)만 그린다. approval-request-card.tsx가
+ * preset.gate.verdict 템플릿을 「부분 소비」할 때 재사용한다(actions는 그쪽 카드가 자기 고유의
+ * 서명/버튼 분기를 유지하므로 여기서 다루지 않는다 — null 반환, 호출부가 filter로 걸러도 되고
+ * 안 걸러도 안전). EventBlockCard와 approval-request-card 둘 다 이 함수로 동일한 시각 어휘를
+ * 공유한다(DS 원칙 "동일 개념=동일 어휘" — 사본 분화 금지).
+ */
+export function renderStaticEventBlock(block: BlockTemplateBlock, key: number): React.ReactNode {
   // story #2637 — 유나 design 스티어: 4블록 시각 위계(header 최상위 > fields 구조데이터 >
   // text 본문 > actions 하단 액션열) — 렌더 «순서»는 템플릿 저자가 선언한 그대로 따르되
   // (임의 재배열 안 함), 각 블록 타입의 폰트 크기/굵기로 위계만 표현한다.
   if (block.type === 'header') {
-    return <p className="text-base font-semibold text-foreground">{renderTextWithMissingMarkers(block.text)}</p>;
+    return <p key={key} className="text-base font-semibold text-foreground">{renderTextWithMissingMarkers(block.text)}</p>;
   }
   if (block.type === 'text') {
-    return <p className="text-sm leading-relaxed text-foreground [overflow-wrap:anywhere]">{renderTextWithMissingMarkers(block.text)}</p>;
+    return <p key={key} className="text-sm leading-relaxed text-foreground [overflow-wrap:anywhere]">{renderTextWithMissingMarkers(block.text)}</p>;
   }
   if (block.type === 'fields') {
     return (
-      <dl className="space-y-1.5 rounded-lg bg-muted/40 px-2.5 py-2">
+      <dl key={key} className="space-y-1.5 rounded-lg bg-muted/40 px-2.5 py-2">
         {block.fields.map((f, i) => (
           <div key={i} className="flex gap-2 text-xs">
             <dt className="shrink-0 font-medium text-muted-foreground">{f.label}</dt>
@@ -142,7 +141,21 @@ function EventBlockRow({
       </dl>
     );
   }
-  // actions
+  return null;
+}
+
+function EventBlockRow({
+  block, payload, currentMemberType, currentRole, t,
+}: {
+  block: BlockTemplateBlock;
+  payload: Record<string, unknown>;
+  currentMemberType: 'human' | 'agent' | undefined;
+  currentRole: string | undefined;
+  t: ReturnType<typeof useTranslations>;
+}) {
+  if (block.type !== 'actions') {
+    return renderStaticEventBlock(block, 0);
+  }
   return (
     <div className="flex flex-wrap items-center gap-2 pt-0.5">
       {block.actions.map((a, i) => {


### PR DESCRIPTION
## 요약
story #2637 §범위4/AC4 — 결재 카드 「이관」의 마지막 조각(3라운드 그라운딩 후 PO 08-14 확定 범위 그대로). #2637의 진짜 마지막 조각.

**사본 아닌 이관**: `approval-request-card.tsx`의 **resolved(회신) 분기 정적 표현부만** `preset.gate.verdict` block_template(0249 시드 + 0251 정정, #3040) 경로로 전환한다. pending(요청·서명/버튼·HITL 상호작용)은 그 이벤트에 대응물이 자체가 없어(그라운딩 Q1) 기존 코드 그대로다.

## 그라운딩 3문 → PO 확定
- **Q1**: resolved 분기만. pending UI(title/뱃지/버튼/서명플로우)는 무관.
- **Q2**: `fields.대상` 값이 원래 `{{payload.work_item_id}}`(UUID)였던 게 시각 퇴보 신호 — PO가 근본 원인(시드가 카드 실물 대조 없이 만들어진 「얕은 원본」)으로 판정, 디디군이 **#3040(migration 0251)**으로 시드 자체를 `work_item_title`로 정정(선행 병합됨). 이 PR은 그 위에서 `title`/`verdict` 둘 다 raw 값이 아니라 **기존 표시 로직 그대로 합성**한 값을 payload에 채운다.
- **Q3**: 카드 정체성 라벨(「결재 요청」)은 그대로. 템플릿 header(「게이트 판정」)는 렌더 안 함(부분소비 — text·fields만).

## 변경
- `event-block-card.tsx`: header/text/fields 3종(actions 제외) 렌더를 `renderStaticEventBlock`로 export — `EventBlockCard`와 `approval-request-card`가 동일 시각 어휘 공유(DS "동일 개념=동일 어휘", 사본 분화 금지).
- `approval-request-card.tsx`: `eventDefinitionsByKey`(chat-view.tsx 대화당 1회 배치조회 캐시, `entityStatusByKey`와 동일 패턴 — 새 fetch 없음)를 물려받아 resolved 분기에서 `preset.gate.verdict` 정의를 찾는다.
  - payload 합성: `work_item_title`←기존 title 폴백(`work_item_summary?.title ?? #UUID8자`) · `verdict`←기존 `RESOLVED_STATUS_LABEL_KEYS` 한글 번역 · `gate_type`/`resolution_note`는 gate 실물 그대로.
  - 아이콘(✓/✗)은 어휘 4종 밖 순수 UI 크롬이라 템플릿과 무관하게 유지.
  - 템플릿 없음/파싱 실패는 기존 하드코딩 렌더로 폴백(AC2 폴백 원칙과 동형 방어망 — 새 fetch 실패·구버전 캐시에도 안전).

## 검증
- `pnpm vitest run` — 408 files / 3224 tests pass(신규 3 — 템플릿 소비 렌더·폴백·pending 비영향).
- 기존 #2604/#2624/#2625/#2627 테스트 **전부 무수정 그린**(eventDefinitionsByKey 미전달 시 자동 폴백이라 회귀 없음 — 실제로 확認).
- `tsc --noEmit` clean · `eslint` clean.
- `verify:no-new-tint-color-text` · `verify:no-i18n-phrase-collision` · `verify:no-muted-foreground-alpha` · `verify:no-alpha-focus-ring` · `verify:muted-foreground-contrast` 전부 신규 0 / AA 통과.

## 게이트
유나 design(비회귀 시각 대조) + 카디르 QA(결재 실왕복 비회귀) 둘 다 필수.
