### PR TITLE
[SID:2642] 엔티티 칩 「전체 보기」 크로스프로젝트 착지

### DIFF
--- a/apps/web/src/components/chat/embed-card.link-states.test.tsx
+++ b/apps/web/src/components/chat/embed-card.link-states.test.tsx
@@ -62,6 +62,66 @@ describe('AC1 — epic 링크가 은퇴한 /epics/ 대신 실재 라우트로 �
   });
 });
 
+// story #2642(BE #3044) — own-href 타입(story/epic/asset)도 이제 자기 detail 응답의
+// org_slug/project_slug로 직행한다(#2168 doc own-href와 동형, task/artifact/evidence
+// via-parent에 이어 마지막 조각). fetch 전/실패는 기존 bare href prop 그대로(④ 원칙).
+describe('story #2642 — own-href(story/epic/asset)도 크로스프로젝트 직행 URL로 착지한다', () => {
+  it('story — org_slug/project_slug가 실려 오면 뷰어 현재 프로젝트 대신 그 project로 직행한다', async () => {
+    stubFetch(async () => ({ ok: true, json: async () => ({ data: { org_slug: 'acme', project_slug: 'content' } }) }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="story" entity_id="s-cross" title="스토리 X" status={null} />);
+    });
+    await openCard();
+    await flush();
+    const link = document.querySelector('a[href="/acme/content/board?story=s-cross"]');
+    expect(link).not.toBeNull();
+    expect(link!.textContent).toContain('전체 보기');
+    expect(document.querySelector('a[href="/board?story=s-cross"]')).toBeNull();
+  });
+
+  it('story — fetch 실패/미도착 시 기존 bare href로 우아하게 폴백한다(회귀 아님)', async () => {
+    stubFetch(async () => ({ ok: false, json: async () => ({}) }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="story" entity_id="s-fail" title="스토리 Y" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(document.body.textContent).toContain('대상을 찾을 수 없습니다');
+  });
+
+  it('epic — org_slug/project_slug가 실려 오면 그 project의 /goals/{id}로 직행한다', async () => {
+    stubFetch(async () => ({ ok: true, json: async () => ({ data: { org_slug: 'acme', project_slug: 'content' } }) }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="epic" entity_id="e-cross" title="에픽 X" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(document.querySelector('a[href="/acme/content/goals/e-cross"]')).not.toBeNull();
+    expect(document.querySelector('a[href="/goals/e-cross"]')).toBeNull();
+  });
+
+  it('asset — org_slug/project_slug가 실려 오면 그 project의 storage로 직행한다', async () => {
+    stubFetch(async () => ({ ok: true, json: async () => ({ data: { org_slug: 'acme', project_slug: 'content' } }) }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="asset" entity_id="ast-cross" title="자산 X" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(document.querySelector('a[href="/acme/content/storage?asset=ast-cross"]')).not.toBeNull();
+    expect(document.querySelector('a[href="/storage?asset=ast-cross"]')).toBeNull();
+  });
+
+  it('asset — org-level asset(project_id null→project_slug null)은 bare href로 폴백한다(④ 원칙, org-level은 project 스코프가 없다)', async () => {
+    stubFetch(async () => ({ ok: true, json: async () => ({ data: { org_slug: 'acme', project_slug: null } }) }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="asset" entity_id="ast-org" title="자산 Y" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(document.querySelector('a[href="/storage?asset=ast-org"]')).not.toBeNull();
+  });
+});
+
 describe('AC3/AC4 — task는 부모 story로("담긴 곳으로 갑니다")', () => {
   it('task 상세 fetch가 story_id를 주면 풋터가 파랑 링크 "담긴 곳으로 갑니다"·/board?story=로 간다', async () => {
     stubFetch(async (url) => {
@@ -76,6 +136,24 @@ describe('AC3/AC4 — task는 부모 story로("담긴 곳으로 갑니다")', ()
     const link = document.querySelector('a[href="/board?story=s-parent-1"]');
     expect(link).not.toBeNull();
     expect(link!.textContent).toContain('담긴 곳으로 갑니다');
+  });
+
+  // story #2642(BE #3044) — TaskResponse가 story_id→Story.project_id 1-hop을 이미 해소해
+  // org_slug/project_slug를 직접 싣는다(FE가 추가 조회 없이 그대로 쓴다).
+  it('task — org_slug/project_slug가 실려 오면 크로스프로젝트 부모 story로 직행한다(뷰어 현재 프로젝트 추측 안 거침)', async () => {
+    stubFetch(async () => ({
+      ok: true,
+      json: async () => ({ data: { story_id: 's-parent-2', org_slug: 'acme', project_slug: 'content' } }),
+    }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="task" entity_id="t2" title="작업 B" status={null} />);
+    });
+    await openCard();
+    await flush();
+    const link = document.querySelector('a[href="/acme/content/board?story=s-parent-2"]');
+    expect(link).not.toBeNull();
+    expect(link!.textContent).toContain('담긴 곳으로 갑니다');
+    expect(document.querySelector('a[href="/board?story=s-parent-2"]')).toBeNull();
   });
 });
 
@@ -106,6 +184,36 @@ describe('AC3/AC4 — artifact는 레코드마다 갈린다(FK 있으면 ②, �
     await openCard();
     await flush();
     expect(document.querySelector('a[href="/goals/e-9"]')).not.toBeNull();
+  });
+
+  // story #2642(BE #3044) — ArtifactResponse는 artifact 자기 행의 org_id/project_id를
+  // 직접 싣는다(부모 hop 불필요) — story_id/epic_id 분기 둘 다 이 값을 그대로 쓴다.
+  it('story_id + org_slug/project_slug가 있는 artifact는 크로스프로젝트 부모 story로 직행한다', async () => {
+    stubFetch(async () => ({
+      ok: true,
+      json: async () => ({ data: { story_id: 's-1', epic_id: null, doc_id: null, org_slug: 'acme', project_slug: 'content' } }),
+    }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="artifact" entity_id="a6" title="목업 E" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(document.querySelector('a[href="/acme/content/board?story=s-1"]')).not.toBeNull();
+    expect(document.querySelector('a[href="/board?story=s-1"]')).toBeNull();
+  });
+
+  it('epic_id + org_slug/project_slug가 있는 artifact는 크로스프로젝트 부모 epic으로 직행한다', async () => {
+    stubFetch(async () => ({
+      ok: true,
+      json: async () => ({ data: { story_id: null, epic_id: 'e-9', doc_id: null, org_slug: 'acme', project_slug: 'content' } }),
+    }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="artifact" entity_id="a7" title="목업 F" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(document.querySelector('a[href="/acme/content/goals/e-9"]')).not.toBeNull();
+    expect(document.querySelector('a[href="/goals/e-9"]')).toBeNull();
   });
 
   // story #2642(PO 08-14, «FE 단독 가능» 조각) — doc_id가 있는 artifact도 이제 #2168(doc
@@ -241,7 +349,10 @@ describe('story #2614 AC1/AC3 — artifact(부모 없는 독립 목업)는 몸�
 // 이 Set 밖(sprint=own-href로 이미 열림+몸통에 보여줄 게 없음, task/evidence=via-parent로 이미
 // 열림, asset=별도 스토리지 화면). 이 테스트는 그 경계 자체를 고정한다.
 describe('story #2614 AC3 — "미리보기 없음" 문구는 미지원 타입(sprint)에만 정직하게 남는다', () => {
-  it('sprint는 own-href로 풋터가 열리면서도 몸통엔 여전히 "미리보기 없음"이 뜬다(의도된 것 — 회귀 아님)', async () => {
+  // story #2642(BE #3044) — sprint도 이제 ENTITY_API에 항목이 생겨 자기 org_slug/project_slug를
+  // fetch한다(href 계산 재료로만 — RICH_PREVIEW_TYPES는 무변경, 몸통은 여전히 "미리보기 없음").
+  it('sprint — org_slug 없이 fetch 성공(옛 응답 모양·미백필 등)하면 여전히 "미리보기 없음"+bare href로 우아하게 폴백한다(회귀 아님)', async () => {
+    stubFetch(async () => ({ ok: true, json: async () => ({ data: {} }) }));
     await act(async () => {
       root.render(<EmbedCard entity_type="sprint" entity_id="sp1" title="스프린트 3" status={null} />);
     });
@@ -249,6 +360,30 @@ describe('story #2614 AC3 — "미리보기 없음" 문구는 미지원 타입(s
     await flush();
     expect(document.body.textContent).toContain('이 엔티티는 별도 미리보기가 없습니다');
     expect(document.querySelector('a[href="/sprints?id=sp1"]')).not.toBeNull();
+  });
+
+  it('sprint — fetch 자체가 실패하면(대상 사라짐 등) "대상을 찾을 수 없습니다"로 정직하게 갈린다(#2642로 sprint도 fetch-eligible 승격 — 이전엔 이 갈래가 아예 없었다)', async () => {
+    stubFetch(async () => ({ ok: false, json: async () => ({}) }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="sprint" entity_id="sp-gone" title="사라진 스프린트" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(document.body.textContent).toContain('대상을 찾을 수 없습니다');
+  });
+
+  it('sprint — org_slug/project_slug가 도착하면 크로스프로젝트 직행 URL로 바뀐다(#2642)', async () => {
+    stubFetch(async (url) => {
+      expect(url).toContain('/api/sprints/');
+      return { ok: true, json: async () => ({ data: { org_slug: 'acme', project_slug: 'content' } }) };
+    });
+    await act(async () => {
+      root.render(<EmbedCard entity_type="sprint" entity_id="sp2" title="스프린트 4" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(document.querySelector('a[href="/acme/content/sprints?id=sp2"]')).not.toBeNull();
+    expect(document.querySelector('a[href="/sprints?id=sp2"]')).toBeNull();
   });
 });
 
@@ -277,6 +412,24 @@ describe('AC3/AC4 — evidence는 부모 story로("담긴 곳으로 갑니다", 
     await flush();
     expect(document.querySelectorAll('a[href^="/board?story="]').length).toBe(0);
     expect(document.body.textContent).toContain('열 수 있는 화면이 없습니다');
+  });
+
+  // story #2642(BE #3044) — EvidenceResponse가 resolve 과정에서 이미 계산해 둔 project_id로
+  // org_slug/project_slug도 같이 싣는다(추가 join 없음).
+  it('evidence — org_slug/project_slug가 실려 오면 크로스프로젝트 부모 story로 직행한다', async () => {
+    stubFetch(async () => ({
+      ok: true,
+      json: async () => ({ data: { resolved_story_id: 's-parent-3', org_slug: 'acme', project_slug: 'content' } }),
+    }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="evidence" entity_id="ev3" title="증거 C" status={null} />);
+    });
+    await openCard();
+    await flush();
+    const link = document.querySelector('a[href="/acme/content/board?story=s-parent-3"]');
+    expect(link).not.toBeNull();
+    expect(link!.textContent).toContain('담긴 곳으로 갑니다');
+    expect(document.querySelector('a[href="/board?story=s-parent-3"]')).toBeNull();
   });
 });
 

--- a/apps/web/src/components/chat/embed-card.link-states.test.tsx
+++ b/apps/web/src/components/chat/embed-card.link-states.test.tsx
@@ -108,6 +108,54 @@ describe('AC3/AC4 — artifact는 레코드마다 갈린다(FK 있으면 ②, �
     expect(document.querySelector('a[href="/goals/e-9"]')).not.toBeNull();
   });
 
+  // story #2642(PO 08-14, «FE 단독 가능» 조각) — doc_id가 있는 artifact도 이제 #2168(doc
+  // own-href)과 동형으로 그 doc 자신이 속한 project로 직행한다. 이전엔 project 무관 bare
+  // `/docs?id=`(그나마도 [ws]/[proj]/docs 라이브 라우트가 `?id=`를 안 읽어 죽은 링크였다 —
+  // 이 처방이 그 사각도 같이 없앤다).
+  it('doc_id가 있는 artifact — 그 doc이 속한 project로 직행한다(#2168 재사용, 새 BE 없음)', async () => {
+    stubFetch(async (url) => {
+      if (url.includes('/api/visual-artifacts/')) {
+        if (url.includes('/exports')) return { ok: true, json: async () => ({ data: [] }) };
+        if (url.includes('/versions/')) return { ok: false, json: async () => ({}) };
+        return { ok: true, json: async () => ({ data: { story_id: null, epic_id: null, doc_id: 'doc-9' } }) };
+      }
+      if (url.includes('/api/docs/preview')) {
+        expect(url).toContain('doc-9');
+        return { ok: true, json: async () => ({ data: { slug: 'other-doc', orgSlug: 'acme', projectSlug: 'content', projectId: 'p-9' } }) };
+      }
+      return { ok: false, json: async () => ({}) };
+    });
+    await act(async () => {
+      root.render(<EmbedCard entity_type="artifact" entity_id="a4" title="목업 C" status={null} />);
+    });
+    await openCard();
+    await flush(8);
+    const link = document.querySelector('a[href="/acme/content/docs/other-doc/view"]');
+    expect(link).not.toBeNull();
+    expect(link!.textContent).toContain('담긴 곳으로 갑니다');
+    // 옛 project-무관 bare 링크가 더는 안 남아야 한다(진짜로 직행 링크로 교체됐는지 확認).
+    expect(document.querySelector('a[href="/docs?id=doc-9"]')).toBeNull();
+  });
+
+  it('doc_id가 있는 artifact — doc preview 조회 실패 시 기존 bare `/docs?id=`로 우아하게 폴백한다(회귀 아님, ④ 원칙)', async () => {
+    stubFetch(async (url) => {
+      if (url.includes('/api/visual-artifacts/')) {
+        if (url.includes('/exports')) return { ok: true, json: async () => ({ data: [] }) };
+        if (url.includes('/versions/')) return { ok: false, json: async () => ({}) };
+        return { ok: true, json: async () => ({ data: { story_id: null, epic_id: null, doc_id: 'doc-10' } }) };
+      }
+      return { ok: false, json: async () => ({}) }; // /api/docs/preview 도 이걸로 실패.
+    });
+    await act(async () => {
+      root.render(<EmbedCard entity_type="artifact" entity_id="a5" title="목업 D" status={null} />);
+    });
+    await openCard();
+    await flush(8);
+    const link = document.querySelector('a[href="/docs?id=doc-10"]');
+    expect(link).not.toBeNull();
+    expect(link!.textContent).toContain('담긴 곳으로 갑니다');
+  });
+
   it('전부 null(독립 artifact)이면 회색·행동0 "열 수 있는 화면이 없습니다"(거짓 링크 금지)', async () => {
     stubFetch(async () => ({
       ok: true,

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -369,6 +369,40 @@ export function EntityPreviewModal({
     return () => { cancelled = true; };
   }, [entityType, entityId, hasFetchStrategy]);
 
+  // story #2642(PO 08-14, «FE 단독 가능» 조각) — artifact의 부모가 doc이면(via-parent) 그
+  // doc이 실제로 속한 project로 직행한다 — #2168이 doc own-href에 이미 증명한 처방(/api/docs/
+  // preview 재사용, 새 BE 없음) 그대로 via-parent 경로에도 적용한다. 위 effect가 artifact
+  // 자신의 detail(story_id/epic_id/doc_id)을 먼저 채운 *뒤에* doc_id가 있으면 이 effect가
+  // 이어 붙는다(체이닝) — docPreview state를 재사용(모달이 열릴 때마다 언마운트→새 인스턴스라
+  // 이전 엔티티의 값이 새는 레이스 없음, 위 {showModal && <EntityPreviewModal .../>} 패턴).
+  useEffect(() => {
+    if (entityType !== 'artifact') return;
+    const docId = (detail as { doc_id?: string | null } | null)?.doc_id;
+    if (!docId) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const previewRes = await fetch(`/api/docs/preview?q=${encodeURIComponent(docId)}`);
+        if (!previewRes.ok) throw new Error();
+        const previewJson = (await previewRes.json()) as {
+          data?: { slug?: string; projectId?: string; orgSlug?: string; projectSlug?: string | null };
+        };
+        const slug = previewJson.data?.slug;
+        const docProjectId = previewJson.data?.projectId;
+        if (!slug || !docProjectId || cancelled) return;
+        setDocPreview({
+          slug, projectId: docProjectId,
+          orgSlug: previewJson.data?.orgSlug ?? '',
+          projectSlug: previewJson.data?.projectSlug ?? null,
+        });
+      } catch {
+        // 조용히 실패 — 아래 artifact 분기가 bare `/docs?id=` 폴백으로 떨어진다(④ 원칙,
+        // 카드 전체를 안 죽인다 — AC4와 동형).
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [entityType, detail]);
+
   const colorClass = ENTITY_COLORS[entityType] ?? GRAY_STATE_COLOR;
   const label = title ?? entityId;
   // story #2262 AC2(2026-08-08, 쉬운 절반) — 호출부(EntityChip)는 status를 모르고 항상
@@ -411,10 +445,17 @@ export function EntityPreviewModal({
     // 위험이 없다). 우선순위는 story>epic>doc — 동시에 여럿 있을 수 없어(모델 제약은 아니지만
     // 실질적으로 최대 1개라는 그라운딩 전제) 순서 자체가 결과를 바꾸지 않는다.
     const d = detail as { story_id?: string | null; epic_id?: string | null; doc_id?: string | null } | null;
+    // story #2642 — doc 부모는 위 effect가 선조회한 docPreview가 있으면 #2168과 동형으로
+    // 직행(`/{ws}/{proj}/docs/{slug}/view`) — 없으면(preview 아직/실패) 기존 bare `/docs?id=`
+    // 폴백(④ 원칙, 회귀 아님). story/epic 부모는 아직 BE denormalize 대기 중(#2642 나머지
+    // 조각) — 그때까지 bare 그대로.
     const parentHref = d?.story_id ? `/board?story=${d.story_id}`
       : d?.epic_id ? `/goals/${d.epic_id}`
-      : d?.doc_id ? `/docs?id=${d.doc_id}`
-      : null;
+      : d?.doc_id
+        ? (docPreview && docPreview.orgSlug && docPreview.projectSlug
+            ? docViewUrl(docPreview.orgSlug, docPreview.projectSlug, docPreview.slug)
+            : `/docs?id=${d.doc_id}`)
+        : null;
     resolvedHref = parentHref;
     linkKind = parentHref ? 'via-parent' : null;
   } else if (entityType === 'evidence') {

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { docViewUrl } from '@/components/docs/lib/doc-project-url';
+import { resolveScopedEntityHref, storyBoardUrl, goalUrl, sprintUrl, assetStorageUrl } from '@/lib/entity-project-url';
 import { initials } from '@/lib/storage/format';
 import { renderEntityStatusLabel, translateEntityStatus, type EntityStatusFetchState } from './entity-status-labels';
 import { ArtifactThumbnail } from '@/components/canvas/artifact-thumbnail';
@@ -120,6 +121,12 @@ const ENTITY_API: Record<string, (id: string) => string> = {
   story: (id) => `/api/stories/${id}`,
   epic: (id) => `/api/goals/${id}`,
   asset: (id) => `/api/assets/${id}`,
+  // story #2642 — sprint는 own-href(getEntityHref)라 이전엔 몸통 fetch 자체가 없었다(제목·기간
+  // 외 보여줄 게 없다는 판단, RICH_PREVIEW_TYPES 밖 그대로 유지). 그런데 크로스프로젝트 직행
+  // URL을 지으려면 sprint 자신의 org_slug/project_slug(BE #3044, SprintResponse 확장)를 알아야
+  // 해서 fetch 자체는 필요해졌다 — 몸통 렌더는 여전히 "미리보기 없음"(RICH_PREVIEW_TYPES 무변경,
+  // 아래 href 계산에서만 이 detail을 쓴다).
+  sprint: (id) => `/api/sprints/${id}`,
   // story #2302 — task.story_id(항상 유일 부모)·artifact.{story_id,epic_id,doc_id}(최대 1개,
   // 전부 nullable)를 읽어 ②/③을 레코드 단위로 판정하는 재료.
   task: (id) => `/api/tasks/${id}`,
@@ -436,21 +443,34 @@ export function EntityPreviewModal({
     linkKind = resolvedHref ? 'own' : null;
   } else if (entityType === 'task') {
     // ② — Task.story_id는 NOT NULL(항상 유일 부모). fetch 전이면 아직 null(풋터는 loading이 가림).
-    const storyId = (detail as { story_id?: string } | null)?.story_id ?? null;
-    resolvedHref = storyId ? `/board?story=${storyId}` : null;
+    // story #2642(BE #3044) — TaskResponse가 이제 org_slug/project_slug를 직접 싣는다(story_id→
+    // Story.project_id 1-hop을 BE가 이미 해소해 응답에 얹어 준다 — FE가 또 한 번 조회할 필요 없음).
+    const t = detail as { story_id?: string | null; org_slug?: string | null; project_slug?: string | null } | null;
+    resolvedHref = resolveScopedEntityHref(
+      t?.org_slug ? { orgSlug: t.org_slug, projectSlug: t.project_slug ?? null } : null,
+      t?.story_id ? `/board?story=${t.story_id}` : null,
+      (ws, proj) => storyBoardUrl(ws, proj, t!.story_id!),
+    );
     linkKind = resolvedHref ? 'via-parent' : null;
   } else if (entityType === 'artifact') {
     // 레코드마다 갈린다(story #2302 그라운딩) — story_id/epic_id/doc_id 전부 nullable·최대 1개
     // (hypothesis의 다대다 링크테이블과 다른 모양이라 "하나 고르면 나머지를 숨기는 거짓"이 될
     // 위험이 없다). 우선순위는 story>epic>doc — 동시에 여럿 있을 수 없어(모델 제약은 아니지만
     // 실질적으로 최대 1개라는 그라운딩 전제) 순서 자체가 결과를 바꾸지 않는다.
-    const d = detail as { story_id?: string | null; epic_id?: string | null; doc_id?: string | null } | null;
-    // story #2642 — doc 부모는 위 effect가 선조회한 docPreview가 있으면 #2168과 동형으로
-    // 직행(`/{ws}/{proj}/docs/{slug}/view`) — 없으면(preview 아직/실패) 기존 bare `/docs?id=`
-    // 폴백(④ 원칙, 회귀 아님). story/epic 부모는 아직 BE denormalize 대기 중(#2642 나머지
-    // 조각) — 그때까지 bare 그대로.
-    const parentHref = d?.story_id ? `/board?story=${d.story_id}`
-      : d?.epic_id ? `/goals/${d.epic_id}`
+    // story #2642(BE #3044) — ArtifactResponse는 org_id/project_id가 artifact 자기 행에 이미
+    // 있어(생성 시점 _assert_link_target_in_scope로 부모와 같은 org/project 보장) 부모 hop
+    // 없이 org_slug/project_slug를 직접 싣는다 — story_id/epic_id 분기 둘 다 이 값을 그대로 쓴다.
+    const d = detail as {
+      story_id?: string | null; epic_id?: string | null; doc_id?: string | null;
+      org_slug?: string | null; project_slug?: string | null;
+    } | null;
+    const ownerSlugs = d?.org_slug ? { orgSlug: d.org_slug, projectSlug: d.project_slug ?? null } : null;
+    // doc 부모만 예외 — docViewUrl은 doc 자신의 slug가 필요한데 artifact 응답엔 그게 없어(위
+    // effect가 /api/docs/preview로 별도 선조회한 docPreview를 쓴다, #2168 재사용 그대로).
+    const parentHref = d?.story_id
+      ? resolveScopedEntityHref(ownerSlugs, `/board?story=${d.story_id}`, (ws, proj) => storyBoardUrl(ws, proj, d.story_id!))
+      : d?.epic_id
+      ? resolveScopedEntityHref(ownerSlugs, `/goals/${d.epic_id}`, (ws, proj) => goalUrl(ws, proj, d.epic_id!))
       : d?.doc_id
         ? (docPreview && docPreview.orgSlug && docPreview.projectSlug
             ? docViewUrl(docPreview.orgSlug, docPreview.projectSlug, docPreview.slug)
@@ -461,17 +481,34 @@ export function EntityPreviewModal({
   } else if (entityType === 'evidence') {
     // ② — story #2314(2026-07-29): BE GET /{id}가 work_item_type이 story든 task든 이미
     // resolved_story_id 하나로 해소해 준다(task처럼 여기서 또 한 번 join할 필요가 없다).
-    const storyId = (detail as { resolved_story_id?: string | null } | null)?.resolved_story_id ?? null;
-    resolvedHref = storyId ? `/board?story=${storyId}` : null;
+    // story #2642(BE #3044) — EvidenceResponse가 그 resolve 과정에서 이미 계산해 둔
+    // project_id로 org_slug/project_slug도 같이 싣는다(추가 join 없음).
+    const ev = detail as { resolved_story_id?: string | null; org_slug?: string | null; project_slug?: string | null } | null;
+    resolvedHref = resolveScopedEntityHref(
+      ev?.org_slug ? { orgSlug: ev.org_slug, projectSlug: ev.project_slug ?? null } : null,
+      ev?.resolved_story_id ? `/board?story=${ev.resolved_story_id}` : null,
+      (ws, proj) => storyBoardUrl(ws, proj, ev!.resolved_story_id!),
+    );
     linkKind = resolvedHref ? 'via-parent' : null;
   } else if (entityType === 'hypothesis') {
     // ③ 고정 — 위 getEntityHref 주석 참고.
     resolvedHref = null;
     linkKind = null;
   } else {
-    // story·epic·sprint·asset — 전부 own-href를 동기로 아는 ①. href prop 그대로 신뢰.
-    resolvedHref = href;
-    linkKind = href ? 'own' : null;
+    // story·epic·sprint·asset — own-href ①. story #2642(BE #3044)부터 각 detail 응답이
+    // org_slug/project_slug를 직접 싣는다 — 엔티티 자신의 project로 직행(뷰어의 현재 프로젝트
+    // 추측을 proxy.ts::redirectLegacyResourcePath에 맡기지 않는다). fetch 전/실패(project_slug
+    // 없음 포함)는 기존 bare href prop 그대로(④ 원칙, 회귀 아님).
+    const own = detail as { org_slug?: string | null; project_slug?: string | null } | null;
+    const slugs = own?.org_slug ? { orgSlug: own.org_slug, projectSlug: own.project_slug ?? null } : null;
+    const buildScoped =
+      entityType === 'story' ? (ws: string, proj: string) => storyBoardUrl(ws, proj, entityId)
+      : entityType === 'epic' ? (ws: string, proj: string) => goalUrl(ws, proj, entityId)
+      : entityType === 'sprint' ? (ws: string, proj: string) => sprintUrl(ws, proj, entityId)
+      : entityType === 'asset' ? (ws: string, proj: string) => assetStorageUrl(ws, proj, entityId)
+      : null;
+    resolvedHref = buildScoped ? resolveScopedEntityHref(slugs, href, buildScoped) : href;
+    linkKind = resolvedHref ? 'own' : null;
   }
 
   return (

--- a/apps/web/src/lib/entity-project-url.test.ts
+++ b/apps/web/src/lib/entity-project-url.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { resolveScopedEntityHref, storyBoardUrl, goalUrl, sprintUrl, assetStorageUrl } from './entity-project-url';
+
+describe('storyBoardUrl / goalUrl / sprintUrl / assetStorageUrl — ws/proj-scoped 착지', () => {
+  it('story — /{ws}/{proj}/board?story={id}(next.config.ts redirects()가 flow로 자동 병합)', () => {
+    expect(storyBoardUrl('moonklabs', 'proj-a', 'story-1')).toBe('/moonklabs/proj-a/board?story=story-1');
+  });
+
+  it('epic(목표) — /{ws}/{proj}/goals/{id} 경로 파라미터', () => {
+    expect(goalUrl('moonklabs', 'proj-a', 'epic-1')).toBe('/moonklabs/proj-a/goals/epic-1');
+  });
+
+  it('sprint — /{ws}/{proj}/sprints?id={id} 딥링크 쿼리', () => {
+    expect(sprintUrl('moonklabs', 'proj-a', 'sprint-1')).toBe('/moonklabs/proj-a/sprints?id=sprint-1');
+  });
+
+  it('asset — /{ws}/{proj}/storage?asset={id} 딥링크 쿼리', () => {
+    expect(assetStorageUrl('moonklabs', 'proj-a', 'asset-1')).toBe('/moonklabs/proj-a/storage?asset=asset-1');
+  });
+});
+
+describe('resolveScopedEntityHref — 선조회 성공/실패 갈래(PO 08-14 ④ 폴백 원칙)', () => {
+  it('orgSlug+projectSlug 둘 다 있으면 스코프드 URL을 짓는다(뷰어 현재 프로젝트 추측 안 거침)', () => {
+    const href = resolveScopedEntityHref(
+      { orgSlug: 'moonklabs', projectSlug: 'proj-a' },
+      '/board?story=story-1',
+      (ws, proj) => storyBoardUrl(ws, proj, 'story-1'),
+    );
+    expect(href).toBe('/moonklabs/proj-a/board?story=story-1');
+  });
+
+  it('선조회 자체가 null(미도착/실패)이면 bare 폴백을 그대로 준다(더 나빠지지 않음)', () => {
+    const href = resolveScopedEntityHref(null, '/board?story=story-1', (ws, proj) => storyBoardUrl(ws, proj, 'story-1'));
+    expect(href).toBe('/board?story=story-1');
+  });
+
+  it('projectSlug가 null(옛 미백필 프로젝트)이면 bare 폴백으로 우아하게 떨어진다(#2168과 동형)', () => {
+    const href = resolveScopedEntityHref(
+      { orgSlug: 'moonklabs', projectSlug: null },
+      '/goals/epic-1',
+      (ws, proj) => goalUrl(ws, proj, 'epic-1'),
+    );
+    expect(href).toBe('/goals/epic-1');
+  });
+
+  it('orgSlug가 빈 문자열(계약 위반·방어)이면 bare 폴백으로 떨어진다', () => {
+    const href = resolveScopedEntityHref(
+      { orgSlug: '', projectSlug: 'proj-a' },
+      '/storage?asset=asset-1',
+      (ws, proj) => assetStorageUrl(ws, proj, 'asset-1'),
+    );
+    expect(href).toBe('/storage?asset=asset-1');
+  });
+
+  it('bare 폴백 자체가 null이면(원래도 갈 곳 없던 타입) null을 그대로 준다(지어내지 않음)', () => {
+    const href = resolveScopedEntityHref(null, null, (ws, proj) => goalUrl(ws, proj, 'epic-1'));
+    expect(href).toBeNull();
+  });
+});

--- a/apps/web/src/lib/entity-project-url.ts
+++ b/apps/web/src/lib/entity-project-url.ts
@@ -1,0 +1,62 @@
+/**
+ * story #2642 — 엔티티 칩 「전체 보기」가 뷰어의 현재 프로젝트로 착지하던 결함(다른 프로젝트
+ * 엔티티는 오정보/404)의 공통 처방. #2168(doc, doc-project-url.ts::docViewUrl)이 이미 증명한
+ * 패턴을 story/epic/sprint/asset(own-href)·task/evidence/artifact(via-parent)로 동형 확장한다
+ * — 엔티티 자신(또는 via-parent면 그 부모)이 속한 project의 org_slug/project_slug를 클릭
+ * 시점에 선조회해 `/{ws}/{proj}/{resource}...`로 직행, proxy.ts::redirectLegacyResourcePath의
+ * "뷰어의 현재 프로젝트 디폴트" 추측을 거치지 않는다.
+ *
+ * PO 08-14 확定 4조건:
+ * ① 스코프=동일 org·교차 project만(크로스 org는 명시 제외 — 별도 축).
+ * ② 처방=#2168 패턴 동형(own-href 자기 선조회·via-parent는 부모 기준).
+ * ③ 해석 시점=클릭 시점(모달 오픈 useEffect) 유지 — 렌더(칩 목록) 시점 선조회로 바꾸지
+ *    않는다(N+1 팬아웃 방지).
+ * ④ 폴백=현행 bare 경로(선조회 실패/project_slug 없음 시 더 나빠지지 않는다).
+ */
+
+/** DocPreviewResponse(#2168)와 동형 계약 — BE가 org_slug/project_slug를 additive로 얹어주는
+ * 모든 엔티티 preview/detail 응답이 이 shape를 따른다. project_slug는 nullable(Project.slug가
+ * nullable — 옛 미백필 프로젝트). */
+export interface EntityProjectSlugs {
+  orgSlug: string;
+  projectSlug: string | null;
+}
+
+/**
+ * 선조회 결과와 순수 문자열 폴백을 받아, 스코프드 URL을 만들 수 있으면 만들고 아니면 폴백을
+ * 그대로 준다(④ 폴백 원칙). `orgSlug`가 빈 문자열이거나 `projectSlug`가 null이면 스코프드
+ * URL을 지을 재료가 부족하다는 뜻이라 폴백으로 떨어진다(예: project.slug 미백필).
+ */
+export function resolveScopedEntityHref(
+  slugs: EntityProjectSlugs | null,
+  bareFallback: string | null,
+  buildScoped: (wsSlug: string, projSlug: string) => string,
+): string | null {
+  if (slugs?.orgSlug && slugs.projectSlug) {
+    return buildScoped(slugs.orgSlug, slugs.projectSlug);
+  }
+  return bareFallback;
+}
+
+/** story 착지 — next.config.ts의 `/:ws/:proj/board→/:ws/:proj/flow?view=list` redirects()가
+ * `?story=`를 자동 병합한다(story #2224 실측 확認·comment) — 이 함수는 그 리네이밍 관심사와
+ * 결합하지 않고 `/board`만 짓는다(IA 이름이 또 바뀌어도 이 파일은 안 바뀐다). */
+export function storyBoardUrl(wsSlug: string, projSlug: string, storyId: string): string {
+  return `/${wsSlug}/${projSlug}/board?story=${storyId}`;
+}
+
+/** epic(목표) 착지 — `[ws]/[proj]/goals/[id]/page.tsx` 경로 파라미터. */
+export function goalUrl(wsSlug: string, projSlug: string, epicId: string): string {
+  return `/${wsSlug}/${projSlug}/goals/${epicId}`;
+}
+
+/** sprint 착지 — `[ws]/[proj]/sprints/sprints-client.tsx`가 `?id=`로 자동선택한다(딥링크). */
+export function sprintUrl(wsSlug: string, projSlug: string, sprintId: string): string {
+  return `/${wsSlug}/${projSlug}/sprints?id=${sprintId}`;
+}
+
+/** asset 착지 — `[ws]/[proj]/storage/storage-view.tsx`가 `?asset=`으로 자동선택한다(딥링크,
+ * story #2302). */
+export function assetStorageUrl(wsSlug: string, projSlug: string, assetId: string): string {
+  return `/${wsSlug}/${projSlug}/storage?asset=${assetId}`;
+}


### PR DESCRIPTION
## 요약
story #2642(PO 08-14 확定, 4조건) — 엔티티 칩 「전체 보기」/「담긴 곳으로 갑니다」가 뷰어의 현재 프로젝트로 착지(`proxy.ts::redirectLegacyResourcePath`의 "현재 프로젝트 디폴트")하던 결함. doc own-href(#2168)만 이미 처방돼 있었고 나머지 타입(story/epic/sprint/asset/task/evidence/artifact)이 전부 같은 클래스로 남아있었다. BE #3044(org_slug/project_slug denormalize 7축)가 develop 상륙한 위에서 FE 전 타입을 배선한다.

## 조건 4개(PO 08-14 확定) 반영
1. **스코프 = 동일 org·교차 project만** — 크로스 org는 명시 제외(별도 축).
2. **처방 = #2168 패턴 동형** — own-href는 자기 slug 선조회→직행, via-parent는 부모(또는 자기 행에 denormalize된 부모 정보) 기준 동일 원칙.
3. **해석 시점 = 클릭 시점 유지**(모달 오픈 `useEffect`) — 렌더(칩 목록) 시점 선조회 아님(N+1 팬아웃 방지).
4. **폴백 = 현행 bare 경로** — 슬러그 부재/실패 시 더 나빠지지 않는다.

## 변경
- `entity-project-url.ts`(pre-work, 이 PR에 포함) — `resolveScopedEntityHref` 공통 유틸 + `storyBoardUrl`/`goalUrl`/`sprintUrl`/`assetStorageUrl` 4개 URL 빌더.
- `embed-card.tsx`:
  - **own-href(story/epic/asset)** — 각 detail 응답의 `org_slug`/`project_slug`로 직행. sprint는 own-href인데 지금까지 detail fetch 자체가 없었다(ENTITY_API 미등록) — 이번에 추가해 fetch-eligible로 승격(몸통 렌더는 `RICH_PREVIEW_TYPES` 무변경, href 계산 재료로만 사용).
  - **via-parent(task/evidence)** — BE가 1-hop 해소해 응답에 직접 실어 준 `org_slug`/`project_slug`를 그대로 소비(FE 추가 조회 없음).
  - **via-parent(artifact)** — `ArtifactResponse`가 artifact 자기 행의 org_id/project_id를 직접 실어(부모 hop 불필요, 생성 시점 `_assert_link_target_in_scope`가 이미 부모와 같은 org/project 보장) story_id/epic_id 분기 둘 다 이 값을 그대로 쓴다. doc_id 분기는 이전 조각(pre-work)의 `/api/docs/preview` 선조회 유지(doc 자신의 slug가 별도 필요 — artifact 응답엔 그게 없다).
  - 전 분기 공통 — `resolveScopedEntityHref`가 슬러그 부재/실패를 기존 bare href로 우아하게 폴백(④).

hypothesis는 그라운딩으로 스코프 밖 확定(`getEntityHref`가 애초에 null 반환 — 다대다 링크테이블이라 부모를 하나로 못 고르는 ③ 설계, story #2614) — 손 안 댐.

## 검증
- `pnpm vitest run` — 409 files / 3247 tests pass(신규 9 — task/evidence/artifact via-parent 크로스프로젝트 3건 + story/epic/asset own-href 크로스프로젝트·폴백·org-level asset 5건 + sprint fetch-eligible 승격 1건).
- 기존 embed-card 테스트 전부 무회귀(sprint 케이스만 fetch-eligible 승격에 맞춰 stub 보강, 동작 자체는 동형).
- `tsc --noEmit` clean · `eslint` clean.
- `verify:no-new-tint-color-text` · `verify:no-i18n-phrase-collision` · `verify:no-muted-foreground-alpha` · `verify:no-alpha-focus-ring` 전부 신규 0.

## 게이트
카디르 QA(교차 프로젝트 실왕복 — 다른 프로젝트 엔티티 칩→정확 착지) 필수. design은 URL 축이라 시각 변화 0 — 유나 스탬프 불요(PO 판정).
