### PR TITLE
[SID:2641] vitest 워커 병렬도 flake — isolate:false 금지 가드

### DIFF
--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.equip-warning-mount.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.equip-warning-mount.test.tsx
@@ -9,9 +9,22 @@ import { createRoot, type Root } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 import { RecruiterClient } from './recruiter-client';
 
+// story #2641 — 이 vi.mock('next-intl', ...)이 module registry를 공유하는 워커(isolate:false,
+// 이 코드베이스 기본값은 아니지만 잠재 위험) 안에서 t.rich를 기대하는 다른 파일(예: recruiter-
+// client.connect-cli-body.test.tsx의 NextIntlClientProvider 실 렌더)로 새면 `t.rich is not a
+// function`으로 깨진다 — 실측 재현(isolate:false 3회전)으로 확認된 구체 충돌 사례. t.rich/
+// t.markup/t.raw까지 실 next-intl의 t 함수 shape에 맞춰 채워 부분 mock을 완전화한다(격리가
+// 약해져도 이 mock을 "빌려 쓰는" 다른 파일이 최소한 이 함수들 부재로는 안 깨지게).
 vi.mock('next-intl', () => ({
-  useTranslations: (ns: string) => (key: string, vars?: Record<string, unknown>) =>
-    vars ? `${ns}.${key}(${JSON.stringify(vars)})` : `${ns}.${key}`,
+  useTranslations: (ns: string) => {
+    const t = (key: string, vars?: Record<string, unknown>) =>
+      vars ? `${ns}.${key}(${JSON.stringify(vars)})` : `${ns}.${key}`;
+    t.rich = (key: string) => `${ns}.${key}`;
+    t.markup = (key: string) => `${ns}.${key}`;
+    t.raw = (key: string) => `${ns}.${key}`;
+    t.has = () => true;
+    return t;
+  },
   useLocale: () => 'ko',
 }));
 

--- a/vitest.config.test.ts
+++ b/vitest.config.test.ts
@@ -1,0 +1,32 @@
+// story #2641 — isolate:false 재현 실측 기록. 원 발견(#3023 QA, 카디르)은 doc-content-
+// renderer.test.tsx 간헐 RED(href="") — 재현 시도: 기본설정(isolate:true, 이 파일이 지키는
+// 그 기본값·CI의 `pnpm vitest run`과 동일, .github/workflows/ci.yml에 특수 pool/isolate
+// 플래그 없음) 전체 431파일/3460테스트 **11회 연속 100% GREEN**(재현율 0/11) — 원 증상은
+// 오늘 코드베이스에서 재현 불가로 정직하게 닫는다(«고쳤다» 선언 아님, «재현 안 됨» 기록).
+//
+// 대신 isolate:false로 강제하면(비정상 설정, 이 가드가 막는 바로 그것) **진짜 크로스파일
+// 오염이 확実히 재현**됐다 — 6회전 연속 시도(next-intl mock 완전화 적용 後에도) 매회
+// 완전히 다른, 서로 무관한 파일들이 무작위로 깨졌다: 1건→52건→20건→12건→16건→2건
+// (fastapi-proxy·embed-card·context-switcher-chip·use-unified-switcher·recruiter-client
+// 계열·llm/client·sse-multiplexer·oauth-handoff·chat-proof-section 등, 서로 접점 없음).
+// 원인: `vi.mock()`은 파일 경계 안에서만 유효하다는 게 vitest의 격리 전제인데, isolate:false는
+// 이 전제를 깨 module registry를 워커 안 전 파일이 공유한다 — 400+파일 전수가 서로 잠재
+// 충돌 상대가 되는 구조다. 소수 파일의 mock을 "완전화"(부족한 메서드 채우기)해도 다음 회차엔
+// 전혀 다른 무관한 쌍이 깨져 「0건」 자체가 이 스코프에서 달성 불가능함이 실증됐다(전면
+// mock 표준화=수주 단위 별건, 이 스토리 범위 밖 — 명시 제외).
+//
+// ⚠️이 가드가 못 잡는 것: vitest.config.ts 파일 자체의 `isolate` 키만 본다. CLI 플래그
+// (`vitest run --isolate=false`)나 CI 워크플로 YAML의 별도 오버라이드는 이 정규식 밖이라
+// 못 잡는다 — 그 경로로 isolate:false를 켜려는 시도가 있다면 이 파일과 story #2641을
+// 먼저 읽을 것(코드 리뷰가 그 자리에서 이 기록을 인용해야 한다).
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const CONFIG_SOURCE = readFileSync(path.resolve(__dirname, 'vitest.config.ts'), 'utf-8');
+
+describe('vitest.config.ts — isolate:false 금지 가드 (story #2641)', () => {
+  it('test.isolate가 false로 설정되지 않는다(설정 시 400+파일 상호충돌 지뢰밭 — 위 주석의 6회전 실측 참고)', () => {
+    expect(CONFIG_SOURCE).not.toMatch(/isolate\s*:\s*false/);
+  });
+});


### PR DESCRIPTION
## 요약
story #2641 — vitest 워커 병렬도 종속 flake(원 발견: `doc-content-renderer.test.tsx` 간헐 RED `href=""`, #3023 QA 카디르) 조사. PO 판정 2회 정정 끝에 **「조사 완료+안전망 고정」형**으로 닫는다.

## 재현 실측
- **기본설정(isolate:true, CI `pnpm vitest run`과 동일)** — 431파일/3460테스트 **11회 연속 100% GREEN**(재현율 0/11). doc-content-renderer만 targeted isolate:false 5회도 0/5.
- **원 증상은 오늘 코드베이스에서 재현 불가로 정직하게 닫는다** — 「고쳤다」 선언 아님, 「재현 안 됨」 기록. 08-13 이후 상륙분이 우연히 고쳤거나 로컬 특이 타이밍이었을 가능성.
- 대신 `isolate:false`로 강제하면 **진짜 크로스파일 `vi.mock` 오염을 확定 재현**했다. 최초 구체 사례(next-intl mock 불완전→`t.rich is not a function`)를 완전화했지만, 그 後에도 6회전 추가 재현에서 **매회 완전히 다른 무관한 파일이 무작위로 깨짐**(1/52/20/12/16/2건 — fastapi-proxy·embed-card·context-switcher-chip·use-unified-switcher·llm/client·sse-multiplexer·oauth-handoff·chat-proof-section 등). 400+파일이 module registry를 공유하는 워커 안에서 상호 잠재 충돌 상대라 **소수 mock fix로는 「0건」이 구조적으로 달성 불가능함이 실증**됐다.

## 상륙
- `recruiter-client.equip-warning-mount.test.tsx` — next-intl mock에 `rich`/`markup`/`raw`/`has` 추가(무해한 소폭 개선).
- `vitest.config.test.ts`(신규, repo root) — `vitest.config.ts`에 `isolate: false`가 들어오면 CI가 막는 1줄 기계판별 가드. 주석에 이 스토리의 6회전 실측(무작위 실패 목록)을 남겨, 미래에 속도 최적화로 `isolate:false`를 시도하는 사람이 그 자리에서 이 기록을 읽게 한다. 가드 한계도 명시(vitest.config.ts 파일 자체만 봄 — CLI 플래그/CI YAML 오버라이드는 정규식 밖).
- **명시 제외(착수 안 함)**: 전면 mock 표준화(400+파일 전수 완전화/공용 팩토리 전환) — 별도 대형 이니셔티브, 사유는 스토리 본문에 기록. isolate:true 기본에선 발현 불가(잠재 지뢰밭이지 실 사고 표면 아님)·가드가 신규 유입을 막으면 부채가 안 자람.

## 검증
- mutation test로 가드 유효성 확認 — `isolate: false`를 임시 주입하면 가드가 정확히 RED, 되돌리면 그린.
- `pnpm vitest run`(root) — 432 files(신규1)/3461 tests pass.
- `tsc --noEmit` clean(apps/web) · `eslint` clean(apps/web).

## 게이트
QA(카디르) — 가드 mutation-test 재현 검토. design 스탬프 불요(테스트 인프라 축, 시각 변화 0).
