### PR TITLE
feat(#2629): 본문의 맨 스토리 번호(#24류)를 서버가 entity 임베드로 자동 승격

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -2163,6 +2163,16 @@ async def send_message(
             if mid != sender.id and mid not in valid_mentioned_ids:
                 valid_mentioned_ids.append(mid)
 
+    # story #2629(P0의 @handle 파서와 동형 철학, 2026-08-14): 본문의 맨 스토리 번호(`#24`류)를
+    # entity 임베드 토큰으로 서버가 저장 시점에 승격 — 에이전트가 임베드 문법을 배우든 말든
+    # 흡수한다. @handle(`@word`)과 어휘상 안 겹쳐 위 블록과의 순서는 무관. body.content
+    # 재대입 지점은 이 함수 전체에서 여기 하나뿐이라(아래 ConversationMessage 생성이 유일한
+    # 소비처) 다른 호출부 변경 없이 자동 전파된다.
+    from app.services.story_ref_promoter import promote_bare_story_refs
+    body.content = await promote_bare_story_refs(
+        db, org_id=org_id, project_id=conv.project_id, content=body.content or "",
+    )
+
     # E-ACTIVATION S1(까디르 QA): audience 도 cross-org/삭제 id 차단 — mentioned_ids 와 동형 org 필터.
     # 안 하면 삭제·타조직 member_id 를 audience 에 넣어 «실 수신자 전원이 addressed=no» 메시지를 만들 수 있다.
     # 전량 필터돼 []가 되면 어댑터에서 `not audience`=True → all-addressed(현행)로 안전 degrade.

--- a/backend/app/services/story_ref_promoter.py
+++ b/backend/app/services/story_ref_promoter.py
@@ -1,0 +1,120 @@
+"""story #2629(챗·전달계약) — 본문의 맨 스토리 번호(`#24`류)를 서버가 entity 임베드로
+자동 승격한다. P0의 본문 `@handle` 파서(`handle_mention_parser.py`)와 정확히 동형 철학
+— 에이전트가 임베드 문법을 배우든 말든, 서버가 발신 시점에 흡수한다(규율/문서화로
+가르치지 않는다, 선생님 08-13 판정).
+
+`handle_mention_parser.py`와의 차이: 그쪽은 **read-only 해석**(본문은 그대로 두고
+mentioned_ids만 파생) — 이 모듈은 **본문 자체를 저장 시점에 치환**하는 첫 사례다(PO
+지적, 2026-08-14). 그래서 편집(edit) 경로가 있으면 같은 승격이 거기도 걸려야 하는데,
+grep 전수 확認 결과 `ConversationMessage.content` 재대입 지점은 전체 백엔드에 2곳뿐
+(생성 시점=이 모듈이 거는 자리, DELETE tombstone=story #2319의 `content = ""` 스크럽 —
+새 사용자 텍스트가 없어 승격 대상 자체가 없다) — PATCH/PUT류 "메시지 수정" 엔드포인트는
+0건이라 비대칭 표면 자체가 없다.
+
+오탐 경계(2026-08-14, dev 실측 — 심은 표본이 아니라 dev conversation_messages 45일치
+4000건·11,634 매치 GROUP BY): 이 팀 실사용에서 `#숫자`의 1위 오탐 축은 **헥스 컬러**
+(`#74747c` 등 — CSS/디자인 토큰 논의가 잦음)였다. 반면 **한글 조사 직결**(`#2629와`·
+`#2642로`)은 정상 매치의 다수 형태였다 — 공백 경계만 요구하면 실 사용례 다수를 놓친다.
+그래서 처방은 "매치 직후 문자가 라틴 알파벳이면 스킵"(헥스 컬러류 배제) + "한글/공백/
+문장부호/문자열 끝은 전부 통과"다."""
+from __future__ import annotations
+
+import re
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.reference_token import build_reference_token
+
+# `#` 뒤에 연속 숫자 — 앞에 또 다른 `#`이 오면 스킵(마크다운 `##` 헤더 등과의 혼동 방지,
+# lookbehind로 `##42`의 두 번째 `#`부터 매치 시작하는 것 자체를 막는다).
+_BARE_STORY_REF_RE = re.compile(r"(?<!#)#(\d+)")
+_LATIN_RE = re.compile(r"[A-Za-z]")
+
+# 보호 구간(스캔에서 제외) — fenced 코드블록·인라인 코드·이미 만들어진 entity 토큰.
+_FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
+_ENTITY_TOKEN_RE = re.compile(r"\[[^\]]*\]\(entity:[a-z_]+:[^)]+\)")
+
+
+def extract_bare_story_ref_candidates(content: str) -> list[tuple[int, int, int]]:
+    """본문에서 «#숫자» 후보 위치를 뽑는다(DB 조회 없는 순수 함수, resolve_handle_mentions의
+    `extract_handle_tokens`와 동형 — 모양만 본다, 존재 여부는 별도 async 함수의 몫).
+
+    반환: (start, end, story_number) 튜플 리스트. 매치 직후 문자가 라틴 알파벳이면
+    헥스 컬러류(`#74747c`)로 보고 그 후보 자체를 버린다(dev 실측 근거 — 모듈 docstring
+    참조). 코드블록/인라인코드/기존 entity 토큰 내부는 여기서 걸러지지 않는다 — 그건
+    `_protected_spans`가 별도로 처리(관심사 분리: 이 함수는 "무엇이 숫자 토큰처럼
+    생겼는가"만, 저건 "어디를 건드리면 안 되는가"만)."""
+    if not content:
+        return []
+    candidates: list[tuple[int, int, int]] = []
+    for m in _BARE_STORY_REF_RE.finditer(content):
+        end = m.end()
+        if end < len(content) and _LATIN_RE.match(content[end]):
+            continue
+        candidates.append((m.start(), end, int(m.group(1))))
+    return candidates
+
+
+def _protected_spans(content: str) -> list[tuple[int, int]]:
+    """fenced 코드블록·인라인 코드·기존 entity 토큰의 (start, end) 구간. 이 구간에서
+    시작하는 후보는 승격 대상에서 제외한다(AC2 — 코드블록 미변환·이중 변환 금지)."""
+    spans: list[tuple[int, int]] = []
+    for pat in (_FENCED_CODE_RE, _INLINE_CODE_RE, _ENTITY_TOKEN_RE):
+        spans.extend(m.span() for m in pat.finditer(content))
+    return spans
+
+
+def _in_protected_span(pos: int, spans: list[tuple[int, int]]) -> bool:
+    return any(start <= pos < end for start, end in spans)
+
+
+async def promote_bare_story_refs(
+    db: AsyncSession, *, org_id: uuid.UUID, project_id: uuid.UUID, content: str,
+) -> str:
+    """본문의 «#N» 후보를 org+project 스코프 story_number로 resolve해 entity 참조 토큰
+    (`build_reference_token`, #2282 SSOT 그대로 재사용 — 새 escape 규칙 발명 안 함)으로
+    치환한다.
+
+    resolve 실패(그 번호의 story가 없음·타 project 소속)면 **그 매치만** 원문 그대로
+    남긴다(전체 all-or-nothing 아님 — resolve_handle_mentions의 "매치 0건=조회도 없이
+    조기 반환" 관대함과 동형 철학, 성실한 오독에서도 메시지 발신 자체는 막지 않는다)."""
+    if not content:
+        return content
+    candidates = extract_bare_story_ref_candidates(content)
+    if not candidates:
+        return content
+    protected = _protected_spans(content)
+    candidates = [c for c in candidates if not _in_protected_span(c[0], protected)]
+    if not candidates:
+        return content
+
+    numbers = {c[2] for c in candidates}
+    from app.models.pm import Story
+
+    rows = (await db.execute(
+        select(Story.story_number, Story.id, Story.title).where(
+            Story.org_id == org_id,
+            Story.project_id == project_id,
+            Story.story_number.in_(numbers),
+            Story.deleted_at.is_(None),
+        )
+    )).all()
+    story_by_number = {number: (story_id, title) for number, story_id, title in rows}
+    if not story_by_number:
+        return content
+
+    # 뒤에서부터 치환 — 앞쪽 매치의 인덱스가 뒤 치환으로 밀리지 않게.
+    result = content
+    for start, end, number in sorted(candidates, key=lambda c: c[0], reverse=True):
+        found = story_by_number.get(number)
+        if found is None:
+            continue
+        story_id, title = found
+        token = build_reference_token("story", story_id, title)
+        if token is None:
+            continue
+        result = result[:start] + token + result[end:]
+    return result

--- a/backend/sprintable_mcp/tools/chat.py
+++ b/backend/sprintable_mcp/tools/chat.py
@@ -6,7 +6,7 @@ import re
 from typing import Literal
 
 from mcp.types import TextContent
-from pydantic import model_validator
+from pydantic import Field, model_validator
 
 from ..api_client import client
 from ..response import err, ok
@@ -146,7 +146,19 @@ class ConversationScopedInput(SprintableInput):
 
 
 class SendChatInput(ConversationScopedInput):
-    content: str
+    # story #2629(2026-08-14, 발견 표면 보조축): 「#24」류 맨 스토리 번호는 서버가 발신
+    # 시점에 자동으로 entity 임베드 카드로 승격한다(문법을 몰라도 됨) — 이 설명은 그
+    # 사실을 알리는 것이지, 아래 escape 규칙을 «가르치려는» 게 아니다(플랫폼이 흡수하는
+    # 축과 발견 표면 축은 별개 — 안 배워도 되지만, 알면 entity 토큰(`[제목](entity:type:id)`)
+    # 문법을 mentions 필드로 직접 구성할 수도 있다는 것도 알려 준다).
+    content: str = Field(
+        description=(
+            "메시지 본문. 「#24」처럼 맨 스토리 번호만 써도(코드블록/인라인코드 제외) "
+            "서버가 발신 시점에 자동으로 entity 임베드 카드로 승격한다 — 문법을 몰라도 됨. "
+            "doc/epic 등 다른 엔티티나 커스텀 표시 문구가 필요하면 `mentions` 필드로 "
+            "`[제목](entity:type:id)` 토큰을 직접 구성할 수도 있다."
+        ),
+    )
     reply_thread_id: str | None = None
     message_type: str | None = None
     review_type: str | None = None

--- a/backend/tests/test_2629_bare_story_ref_promotion.py
+++ b/backend/tests/test_2629_bare_story_ref_promotion.py
@@ -1,0 +1,365 @@
+"""story #2629(챗·전달계약) — 본문의 맨 스토리 번호(`#24`류)를 서버가 entity 임베드로
+자동 승격. P0의 본문 `@handle` 파서와 동형 철학(read-only 해석이 아니라 본문 자체를
+저장 시점에 치환하는 첫 사례).
+
+커버: ①순수 regex 후보 추출(dev 실측 오탐 경계 — 헥스 컬러 배제·한글 조사 결합 통과)
+②보호 구간(코드블록/인라인코드/기존 entity 토큰) ③실 DB resolve(org+project 스코프·
+실패 시 원문 유지·타 project 미스코프) ④send_message() 전체 경로에서 agent/human 양쪽
+동형 적용(AC3)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+# ── ① 순수 regex 후보 추출 — dev 실측 오탐 경계 그대로 고정 ─────────────────────
+def test_extract_bare_ref_plain_number():
+    from app.services.story_ref_promoter import extract_bare_story_ref_candidates
+    content = "보드 확인은 #24 참고"
+    cands = extract_bare_story_ref_candidates(content)
+    assert len(cands) == 1
+    start, end, number = cands[0]
+    assert number == 24
+    assert content[start:end] == "#24"
+
+
+def test_extract_bare_ref_korean_particle_attached():
+    """dev 실측 다수 형태 — #2629와 처럼 한글 조사가 공백 없이 바로 붙는 케이스."""
+    from app.services.story_ref_promoter import extract_bare_story_ref_candidates
+    content = "#2629와 #2642로 같이 보는"
+    cands = extract_bare_story_ref_candidates(content)
+    numbers = [c[2] for c in cands]
+    assert numbers == [2629, 2642]
+
+
+def test_extract_bare_ref_hex_color_excluded():
+    """dev 실측 1위 오탐 축 — 매치 직후 라틴 알파벳이면(헥스 컬러류) 통째로 제외."""
+    from app.services.story_ref_promoter import extract_bare_story_ref_candidates
+    assert extract_bare_story_ref_candidates("baseline `#74747c` 톤") == []
+    assert extract_bare_story_ref_candidates("색상 #95959c 확인") == []
+
+
+def test_extract_bare_ref_double_hash_excluded():
+    from app.services.story_ref_promoter import extract_bare_story_ref_candidates
+    assert extract_bare_story_ref_candidates("## 42 제목") == []
+
+
+def test_extract_bare_ref_multiple_and_none():
+    from app.services.story_ref_promoter import extract_bare_story_ref_candidates
+    assert extract_bare_story_ref_candidates("") == []
+    assert extract_bare_story_ref_candidates("아무 번호도 없음") == []
+    cands = extract_bare_story_ref_candidates("#1 그리고 #2 둘 다")
+    assert [c[2] for c in cands] == [1, 2]
+
+
+# ── ② 보호 구간 ────────────────────────────────────────────────────────────────
+async def test_promote_skips_fenced_code_block():
+    from app.services.story_ref_promoter import promote_bare_story_refs
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            story = await _seed_story(s, org.id, project.id, number=24, title="보드 리팩터")
+            content = "설명\n```\n# 24 이건 셸 주석\n```\n끝"
+            result = await promote_bare_story_refs(s, org_id=org.id, project_id=project.id, content=content)
+            assert result == content  # 코드블록 안이라 무변환
+    finally:
+        await engine.dispose()
+
+
+async def test_promote_skips_inline_code():
+    from app.services.story_ref_promoter import promote_bare_story_refs
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            await _seed_story(s, org.id, project.id, number=24, title="보드 리팩터")
+            content = "명령어 `git checkout #24` 참고"
+            result = await promote_bare_story_refs(s, org_id=org.id, project_id=project.id, content=content)
+            assert result == content
+    finally:
+        await engine.dispose()
+
+
+async def test_promote_skips_existing_entity_token():
+    from app.services.story_ref_promoter import promote_bare_story_refs
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            await _seed_story(s, org.id, project.id, number=24, title="보드 리팩터")
+            content = "[이슈 #24 수정](entity:story:11111111-1111-1111-1111-111111111111) 참고"
+            result = await promote_bare_story_refs(s, org_id=org.id, project_id=project.id, content=content)
+            assert result == content  # 이미 토큰 안 — 이중 변환 금지
+    finally:
+        await engine.dispose()
+
+
+# ── ③ 실 DB resolve ────────────────────────────────────────────────────────────
+async def test_promote_resolves_existing_story_to_entity_token():
+    from app.services.story_ref_promoter import promote_bare_story_refs
+    from app.services.reference_token import build_reference_token
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            story = await _seed_story(s, org.id, project.id, number=24, title="보드 리팩터")
+            result = await promote_bare_story_refs(
+                s, org_id=org.id, project_id=project.id, content="확인은 #24 참고",
+            )
+            expected_token = build_reference_token("story", story.id, "보드 리팩터")
+            assert result == f"확인은 {expected_token} 참고"
+    finally:
+        await engine.dispose()
+
+
+async def test_promote_unresolved_number_kept_verbatim():
+    """resolve 실패(그 번호 story 없음) — 그 매치만 원문 유지, all-or-nothing 아님."""
+    from app.services.story_ref_promoter import promote_bare_story_refs
+    from app.services.reference_token import build_reference_token
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            story = await _seed_story(s, org.id, project.id, number=24, title="보드 리팩터")
+            result = await promote_bare_story_refs(
+                s, org_id=org.id, project_id=project.id, content="#24 그리고 #9999",
+            )
+            expected_token = build_reference_token("story", story.id, "보드 리팩터")
+            assert result == f"{expected_token} 그리고 #9999"
+    finally:
+        await engine.dispose()
+
+
+async def test_promote_scoped_to_project_cross_project_not_resolved():
+    """같은 org 다른 project의 동일 story_number는 resolve 안 됨(스코프 경계)."""
+    from app.models.project import Project
+    from app.services.story_ref_promoter import promote_bare_story_refs
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            other_project = Project(id=uuid.uuid4(), org_id=org.id, name="Other")
+            s.add(other_project)
+            await s.commit()
+            await _seed_story(s, org.id, other_project.id, number=24, title="다른 프로젝트 스토리")
+
+            result = await promote_bare_story_refs(
+                s, org_id=org.id, project_id=project.id, content="#24 참고",
+            )
+            assert result == "#24 참고"  # 다른 project 소속이라 미승격
+    finally:
+        await engine.dispose()
+
+
+# ── ④ send_message() 전체 경로 — agent/human 양쪽 동형(AC3) ─────────────────────
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2629", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org, project
+
+
+async def _seed_story(session, org_id, project_id, *, number, title):
+    from app.models.pm import Story
+
+    story = Story(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title,
+        status="backlog", story_number=number,
+    )
+    session.add(story)
+    await session.commit()
+    return story
+
+
+async def _seed_agent(session, org_id, project_id, *, name="agent"):
+    from app.models.member import AgentProjectProfile, Member
+    from app.models.project_access import ProjectAccess
+
+    member_id = uuid.uuid4()
+    session.add(Member(id=member_id, org_id=org_id, type="agent", name=name))
+    await session.commit()
+    session.add(AgentProjectProfile(id=uuid.uuid4(), member_id=member_id, project_id=project_id))
+    session.add(ProjectAccess(id=uuid.uuid4(), project_id=project_id, member_id=member_id, permission="granted"))
+    await session.commit()
+    return member_id
+
+
+async def _seed_human(session, org_id, project_id):
+    """team_members는 실 migrated DB에선 VIEW(members ⋈ project_access, migration 0088)라
+    직접 INSERT 불가 — anchor 경로(Member+ProjectAccess.org_member_id)로 시드한다
+    (test_1994_backlink_api_realdb.py::_make_human_member와 동형 패턴)."""
+    from app.models.member import Member
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    session.add(User(id=user_id, email=f"h-{user_id.hex[:8]}@test.com", hashed_password="x"))
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user_id, role="member")
+    session.add(om)
+    await session.commit()
+    session.add(Member(id=om.id, org_id=org_id, type="human", user_id=user_id, name="Human"))
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_id, org_member_id=om.id, member_id=om.id,
+        permission="granted", role="member",
+    ))
+    await session.commit()
+    return user_id
+
+
+async def _seed_conversation(session, org_id, project_id, member_ids, created_by):
+    from app.models.conversation import Conversation, ConversationParticipant
+
+    conv = Conversation(
+        id=uuid.uuid4(), project_id=project_id, org_id=org_id, type="group",
+        title="Test", created_by=created_by,
+    )
+    session.add(conv)
+    await session.flush()
+    for mid in member_ids:
+        session.add(ConversationParticipant(conversation_id=conv.id, member_id=mid))
+    await session.commit()
+    return conv.id
+
+
+def _agent_auth(agent_id, org_id):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {"org_id": str(org_id), "api_key_id": str(uuid.uuid4())}},
+    )
+
+
+def _human_auth(user_id, org_id):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(user_id), email="human@test.com",
+        claims={"app_metadata": {"org_id": str(org_id)}},
+    )
+
+
+async def test_send_message_promotes_bare_ref_for_agent_sender():
+    from fastapi import BackgroundTasks
+    from app.routers.conversations import SendMessageRequest, send_message
+    from app.services.reference_token import build_reference_token
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org.id, project.id)
+            story = await _seed_story(s, org.id, project.id, number=24, title="보드 리팩터")
+            conv_id = await _seed_conversation(s, org.id, project.id, [agent_id], created_by=agent_id)
+
+        async with Session() as s:
+            result = await send_message(
+                conversation_id=conv_id,
+                body=SendMessageRequest(content="확인은 #24 참고"),
+                background_tasks=BackgroundTasks(),
+                db=s, auth=_agent_auth(agent_id, org.id), org_id=org.id,
+            )
+            expected_token = build_reference_token("story", story.id, "보드 리팩터")
+            assert result["data"]["content"] == f"확인은 {expected_token} 참고"
+    finally:
+        await engine.dispose()
+
+
+async def test_send_message_promotes_bare_ref_for_human_sender():
+    """AC3 — 사람 발신 메시지도 동형 동작(발신자 타입 무관)."""
+    from fastapi import BackgroundTasks
+    from app.routers.conversations import SendMessageRequest, send_message
+    from app.services.reference_token import build_reference_token
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            user_id = await _seed_human(s, org.id, project.id)
+            story = await _seed_story(s, org.id, project.id, number=24, title="보드 리팩터")
+            conv_id = await _seed_conversation(s, org.id, project.id, [user_id], created_by=user_id)
+
+        async with Session() as s:
+            result = await send_message(
+                conversation_id=conv_id,
+                body=SendMessageRequest(content="확인은 #24 참고"),
+                background_tasks=BackgroundTasks(),
+                db=s, auth=_human_auth(user_id, org.id), org_id=org.id,
+            )
+            expected_token = build_reference_token("story", story.id, "보드 리팩터")
+            assert result["data"]["content"] == f"확인은 {expected_token} 참고"
+    finally:
+        await engine.dispose()
+
+
+async def test_send_message_no_bare_ref_unaffected():
+    """무회귀 — 매치할 게 없으면 content가 그대로 저장된다."""
+    from fastapi import BackgroundTasks
+    from app.routers.conversations import SendMessageRequest, send_message
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org.id, project.id)
+            conv_id = await _seed_conversation(s, org.id, project.id, [agent_id], created_by=agent_id)
+
+        async with Session() as s:
+            result = await send_message(
+                conversation_id=conv_id,
+                body=SendMessageRequest(content="그냥 평문 메시지"),
+                background_tasks=BackgroundTasks(),
+                db=s, auth=_agent_auth(agent_id, org.id), org_id=org.id,
+            )
+            assert result["data"]["content"] == "그냥 평문 메시지"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
BYOA 에이전트들이 임베드 문법을 몰라 챗에 "#24 #42 #20" 맨 번호만 나열하는 실 고객 고통(2026-08-13 선생님 접수) — P0의 본문 `@handle` 파서(`handle_mention_parser.py`)와 동형 철학으로 서버 발신 시점에 흡수한다(규율/문서화로 가르치지 않는다).

- **`app/services/story_ref_promoter.py`(신규)**: `extract_bare_story_ref_candidates`(순수 regex, `handle_mention_parser.py`의 `extract_handle_tokens`와 동형) + `promote_bare_story_refs`(async, org+project 스코프 story_number resolve). `build_reference_token`(#2282 SSOT)을 그대로 재사용 — 새 escape 규칙 발명 안 함.
- **`app/routers/conversations.py::send_message`**: `resolve_handle_mentions` 호출부 바로 뒤에 `body.content` 재대입 — 이 함수 전체에서 `body.content` 읽기 지점이 정확히 2곳(여기·`ConversationMessage` 생성)뿐이라 다른 호출부 변경 없이 자동 전파.
- **편집(edit) 경로**: grep 전수 확인 결과 존재 자체가 없음(`ConversationMessage.content` 재대입 지점은 생성+DELETE tombstone 2곳뿐, tombstone은 빈 문자열 스크럽이라 승격 대상 자체가 없음) — "보낼 땐 임베드·고치면 맨 번호로 되돌아가는" 비대칭 표면이 성립하지 않는다(PO 지적 축, 코드로 확인 후 해당 없음으로 닫음).
- **`sprintable_mcp/tools/chat.py`**: `SendChatInput.content`에 발견 표면 설명 추가(AC4 — 임베드 문법을 몰라도 되지만 `mentions`로 직접 구성할 수도 있음을 명기).

## 오탐 경계 — dev 실측(심은 표본 아닌 실 데이터)
`conversation_messages` 45일치 4000건·11,634 매치를 GROUP BY로 실측(pgstat-probe-dev job 경유). 1위 오탐 축은 **헥스 컬러**(`#74747c` 류 — 이 팀 CSS/디자인 토큰 논의가 잦음) → 매치 직후 라틴 알파벳이면 그 토큰 전체 제외. 반면 **한글 조사 직결**(`#2629와`·`#2642로`)은 정상 매치의 다수 형태 → 공백 경계만 요구하면 실 사용례를 다수 놓친다. "매치 직후 라틴 알파벳이면 제외" 규칙 하나로 두 축 모두 정합.

## Test plan
- [x] `tests/test_2629_bare_story_ref_promotion.py`(14 tests): ①순수 regex 후보 추출(플레인 번호·한글조사 결합·헥스컬러 배제·이중해시 배제) ②보호구간(fenced 코드블록·인라인코드·기존 entity 토큰) ③실 DB resolve(성공·개별 매치 실패 시 원문 유지·타 project 스코프 미해소) ④`send_message()` 전체 경로로 agent/human 발신자 양쪽 동형 승격(AC3) + 무매치 무회귀.
- [x] 회귀 스윕(#2642에서 얻은 교훈 반영 — import-grep과 URL-path-string-grep 둘 다 병행): 비파괴 430건(fresh container) + 파괴 21건(별도 fresh container, 격리 실행) 전부 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)