### PR TITLE
[SID:2647] 대리 편집 모달 저장 실패 문구 — BE 400 사유 노출

### DIFF
--- a/apps/web/src/components/chat/delivery-contract-modal.test.tsx
+++ b/apps/web/src/components/chat/delivery-contract-modal.test.tsx
@@ -110,6 +110,79 @@ describe('DeliveryContractModal — story #2621 v1', () => {
     });
   });
 
+  it('story #2647 — PUT 400(정책 거부·agent mute 금지, #3048 조건④)은 BE 사유를 재구성 없이 그대로 보여준다("다시 시도" 안 붙임)', async () => {
+    const fetchMock = vi.fn(async (url: string, opts?: { method?: string }) => {
+      if (opts?.method === 'PUT') {
+        return { ok: false, status: 400, json: async () => ({ detail: 'Agent cannot mute assigned conversation or thread' }) };
+      }
+      return { ok: true, json: async () => ({ data: { data: [] }, error: null, meta: null }) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    await act(async () => {
+      root.render(wrap(
+        <DeliveryContractModal
+          conversationId={CONV_ID} conversationType="group" freeResponse={false}
+          onClose={() => {}} onFreeResponseChange={() => {}}
+        />,
+      ));
+    });
+    await act(async () => {});
+    const muteBtn = Array.from(document.body.querySelectorAll('button')).find((b) => b.textContent === '끄기')!;
+    await act(async () => { muteBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    expect(document.body.textContent).toContain('Agent cannot mute assigned conversation or thread');
+    expect(document.body.textContent).not.toContain('저장에 실패했습니다');
+    expect(document.body.textContent).not.toContain('다시 시도');
+    // 실패했으니 낙관 갱신을 되돌린다 — 버튼 선택 상태가 원래 값(전체)으로 복귀.
+    const allBtn = Array.from(document.body.querySelectorAll('button')).find((b) => b.textContent === '전체')!;
+    expect(allBtn.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('story #2647 AC2 — 5xx는 사유 유무와 무관하게 기존 일반 문구+재시도 안내를 유지한다(원인 모름 — 재시도가 유효할 수 있음)', async () => {
+    const fetchMock = vi.fn(async (url: string, opts?: { method?: string }) => {
+      if (opts?.method === 'PUT') {
+        return { ok: false, status: 500, json: async () => ({ detail: 'Internal Server Error' }) };
+      }
+      return { ok: true, json: async () => ({ data: { data: [] }, error: null, meta: null }) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    await act(async () => {
+      root.render(wrap(
+        <DeliveryContractModal
+          conversationId={CONV_ID} conversationType="group" freeResponse={false}
+          onClose={() => {}} onFreeResponseChange={() => {}}
+        />,
+      ));
+    });
+    await act(async () => {});
+    const muteBtn = Array.from(document.body.querySelectorAll('button')).find((b) => b.textContent === '끄기')!;
+    await act(async () => { muteBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    expect(document.body.textContent).toContain('저장에 실패했습니다');
+    expect(document.body.textContent).not.toContain('Internal Server Error');
+  });
+
+  it('story #2647 — 네트워크 실패(fetch 자체가 throw)도 기존 일반 문구+재시도 안내를 유지한다', async () => {
+    const fetchMock = vi.fn(async (url: string, opts?: { method?: string }) => {
+      if (opts?.method === 'PUT') throw new Error('network down');
+      return { ok: true, json: async () => ({ data: { data: [] }, error: null, meta: null }) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    await act(async () => {
+      root.render(wrap(
+        <DeliveryContractModal
+          conversationId={CONV_ID} conversationType="group" freeResponse={false}
+          onClose={() => {}} onFreeResponseChange={() => {}}
+        />,
+      ));
+    });
+    await act(async () => {});
+    const muteBtn = Array.from(document.body.querySelectorAll('button')).find((b) => b.textContent === '끄기')!;
+    await act(async () => { muteBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    expect(document.body.textContent).toContain('저장에 실패했습니다');
+  });
+
   it('dm 대화에서는 free_response 토글 자체가 안 보인다(항상 default=all이라 의미 없음)', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: { data: [] }, error: null, meta: null }) })));
     await act(async () => {

--- a/apps/web/src/components/chat/delivery-contract-modal.tsx
+++ b/apps/web/src/components/chat/delivery-contract-modal.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { Switch } from '@/components/ui/switch';
+import { extractBackendErrorMessage } from '@/lib/api-error-message';
 
 export type DeliveryLevel = 'all' | 'mentions' | 'mute';
 
@@ -102,7 +103,22 @@ export function DeliveryContractModal({
           ...(targetMemberId ? { member_id: targetMemberId } : {}),
         }),
       });
-      if (!res.ok) throw new Error('save failed');
+      if (!res.ok) {
+        // story #2647 — 4xx(정책 거부·예: 대리 편집 대상이 agent인데 mute 시도 → BE 400
+        // "Agent cannot mute assigned conversation or thread", #3048 조건④)는 BE가 이미
+        // 완성 문장으로 준 사유를 재구성 없이 그대로 보여준다(#2637 §범위3 EventPublishAction
+        // Button과 동형 패턴, extractBackendErrorMessage로 공통화) — "다시 시도해 주세요"를
+        // 안 붙인다(재시도해도 같은 정책 거부라 오도). 5xx/사유 미상은 기존 일반 문구+재시도
+        // 안내를 유지한다(원인 모름 — 재시도가 유효할 수 있어 그 안내가 정직하다).
+        const body = await res.json().catch(() => null);
+        const backendMsg = extractBackendErrorMessage(body);
+        if (backendMsg && res.status >= 400 && res.status < 500) {
+          setLevel(prev);
+          setError(backendMsg);
+          return;
+        }
+        throw new Error('save failed');
+      }
       setHasOverride(true);
     } catch {
       setLevel(prev);

--- a/apps/web/src/components/chat/event-block-card.tsx
+++ b/apps/web/src/components/chat/event-block-card.tsx
@@ -6,6 +6,7 @@ import { Send } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { renderBlockTemplate, type BlockTemplate, type BlockTemplateBlock } from '@/lib/block-template';
+import { extractBackendErrorMessage } from '@/lib/api-error-message';
 
 interface EventBlockCardProps {
   /** story #2637 AC2/PO 리뷰(head 80319636c ①) — 파싱은 chat-bubble.tsx가 미리 끝낸다. 이
@@ -223,9 +224,10 @@ function EventPublishActionButton({
       if (!res.ok) {
         // story #2637 §범위3/#3037 — 403 action_auth_denied는 BE가 이유를 완성 문장으로
         // 주므로(예: "이 이벤트(...)는 human 발행자만 허용합니다") FE가 재구성하지 않고
-        // 그대로 보여준다(BE가 실 권위이자 유일한 메시지 출처).
-        const body = await res.json().catch(() => null) as { error?: { message?: string }; detail?: { message?: string } | string } | null;
-        const msg = body?.error?.message ?? (typeof body?.detail === 'string' ? body.detail : body?.detail?.message) ?? `HTTP ${res.status}`;
+        // 그대로 보여준다(BE가 실 권위이자 유일한 메시지 출처). story #2647에서
+        // extractBackendErrorMessage로 공통화(DeliveryContractModal과 동형 패턴 공유).
+        const body = await res.json().catch(() => null);
+        const msg = extractBackendErrorMessage(body) ?? `HTTP ${res.status}`;
         throw new Error(msg);
       }
       setPublished(true);

--- a/apps/web/src/lib/api-error-message.test.ts
+++ b/apps/web/src/lib/api-error-message.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { extractBackendErrorMessage } from './api-error-message';
+
+describe('extractBackendErrorMessage — story #2647(공통화, #2637 §범위3 패턴 공유)', () => {
+  it('apiSuccess() 에러 모양({error:{message}})에서 그대로 뽑는다', () => {
+    expect(extractBackendErrorMessage({ error: { message: '이 이벤트는 human 발행자만 허용합니다.' } }))
+      .toBe('이 이벤트는 human 발행자만 허용합니다.');
+  });
+
+  it('FastAPI HTTPException을 그대로 통과시키는 문자열 detail에서 뽑는다', () => {
+    expect(extractBackendErrorMessage({ detail: 'Agent cannot mute assigned conversation or thread' }))
+      .toBe('Agent cannot mute assigned conversation or thread');
+  });
+
+  it('{detail:{message}} 모양에서도 뽑는다', () => {
+    expect(extractBackendErrorMessage({ detail: { message: 'Admin role required' } })).toBe('Admin role required');
+  });
+
+  it('세 자리 다 없으면 null(호출부가 자기 폴백을 쓴다 — 지어내지 않음)', () => {
+    expect(extractBackendErrorMessage({})).toBeNull();
+    expect(extractBackendErrorMessage(null)).toBeNull();
+    expect(extractBackendErrorMessage(undefined)).toBeNull();
+    expect(extractBackendErrorMessage('not an object')).toBeNull();
+    expect(extractBackendErrorMessage({ detail: { code: 'X' } })).toBeNull();
+  });
+
+  it('error.message 우선순위가 detail보다 높다(apiSuccess 경로가 있으면 그쪽이 정본)', () => {
+    expect(extractBackendErrorMessage({ error: { message: 'A' }, detail: 'B' })).toBe('A');
+  });
+});

--- a/apps/web/src/lib/api-error-message.ts
+++ b/apps/web/src/lib/api-error-message.ts
@@ -1,0 +1,18 @@
+/**
+ * story #2647(공통화, PO 재량 지시) — story #2637 §범위3의 EventPublishActionButton이 먼저
+ * 세운 패턴("BE가 이유를 완성 문장으로 주므로 FE가 재구성하지 않고 그대로 보여준다")을
+ * 여기로 뽑아 DeliveryContractModal(#2647)과 공유한다. BE 에러 응답은 두 모양이 섞여 있다
+ * (apiSuccess()가 감싼 `{error:{message}}`·FastAPI HTTPException을 그대로 통과시키는
+ * `{detail: string | {message: string}}`) — 이 함수는 그 세 자리를 순서대로 본다.
+ * 못 찾으면 null(호출부가 자기 폴백 문구를 쓴다 — 이 함수는 "찾았는지"만 정직하게 답한다).
+ */
+export function extractBackendErrorMessage(body: unknown): string | null {
+  if (!body || typeof body !== 'object') return null;
+  const b = body as { error?: { message?: unknown }; detail?: unknown };
+  if (typeof b.error?.message === 'string') return b.error.message;
+  if (typeof b.detail === 'string') return b.detail;
+  if (b.detail && typeof b.detail === 'object' && typeof (b.detail as { message?: unknown }).message === 'string') {
+    return (b.detail as { message: string }).message;
+  }
+  return null;
+}


### PR DESCRIPTION
## 요약
story #2647(PO 08-14, #2623 done 실측 중 발견) — admin이 agent를 대리 편집하며 conversation 레벨을 「끄기(mute)」로 바꾸면 BE가 400("Agent cannot mute assigned conversation or thread" — target 기준 룰, #3048 조건④의 정상 발동)으로 정확히 거부하는데, 모달은 일반 문구 "저장에 실패했습니다. 다시 시도해 주세요"만 보여줬다. 실 사유(정책 거부)가 가려지고, "다시 시도"가 오도(재시도해도 같은 400 — 정책이라 불변)했다.

## 변경
- **`extractBackendErrorMessage`**(신규, `lib/api-error-message.ts`) — story #2637 §범위3 `EventPublishActionButton`이 먼저 세운 "BE가 완성 문장으로 준 사유를 재구성하지 않고 그대로 보여준다" 패턴을 공통 유틸로 뽑았다(AC3, PO 재량 지시 — 공통화 채택). BE 에러 응답 3가지 모양(`apiSuccess` `{error:{message}}` · FastAPI HTTPException 통과 `{detail: string}` · `{detail:{message}}`)을 순서대로 본다.
- **`DeliveryContractModal.handleSaveLevel`** — PUT 실패 시 4xx면 BE 메시지를 그대로 노출하고 "다시 시도" 안내 없이 낙관 갱신만 되돌린다. 5xx/네트워크 실패는 기존 일반 문구+재시도 안내를 그대로 유지(원인 모름 — 재시도가 유효할 수 있어 그 안내가 정직하다, AC2가 요구하는 가르는 기준을 코드에 명시).
- **`event-block-card.tsx`**의 `EventPublishActionButton`도 동일 유틸로 교체(사본 제거, 두 호출부가 이제 하나의 진실 소스).

## 검증
- mutation test로 4xx/5xx 분기 유효성 확認 — 상태코드 조건을 제거하면 신규 5xx 테스트가 정확히 실패, 복원하면 그린.
- `pnpm vitest run` — 411 files(신규1) / 3267 tests pass(신규 9 — 유틸 5건+모달 4xx/5xx/네트워크 갈래 3건).
- `tsc --noEmit` clean · `eslint` clean.
- `verify:no-new-tint-color-text` · `verify:no-i18n-phrase-collision` · `verify:no-muted-foreground-alpha` · `verify:no-alpha-focus-ring` 전부 신규 0.

## 게이트
카디르 QA(재현 스텝 그대로 라이브 — agent 대상 mute 시도 시 실 사유 노출 확認). design은 문구/토큰 변화 없어(기존 배너 스타일 재사용) 경량 게이트로 충분해 보임(PO 지시).
