### PR TITLE
feat(#2650): wire attachment_context into SSE payload — closes webhook/SSE parity gap

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -558,6 +558,34 @@ async def _dispatch_conversation_event(
 
     payload = _msg_payload(msg, sender)
 
+    # story #2650: SSE/webhook 패리티 — conversation_webhook.py가 이미 하는 첨부 컨텍스트 주입
+    # (attachment_context.py, IDOR-safe·conversation 스코프 게이트 포함)을 SSE 수신자에게도
+    # 재사용한다. webhook-covered 수신자는 아래 참여자 루프에서 스킵돼(webhook이 대신 전달)
+    # 이 주입은 순수 SSE-only 수신자 payload에만 실린다 — 중복 주입 없음. 이 함수 로컬
+    # `payload` dict만 변경하므로 _msg_payload()의 다른 호출부(list_messages 등 읽기 경로)엔
+    # 무영향(호출마다 새 dict). 실패는 best-effort(전달 자체는 막지 않음, webhook 경로와 동형) —
+    # 로그는 개수만(서명 URL 문자열은 어떤 로그에도 안 찍는다, PO 지적).
+    if msg.attachments:
+        try:
+            from app.services.attachment_context import build_attachment_context
+            _ctx, attachment_images = await build_attachment_context(
+                msg.attachments, project_id=conversation.project_id,
+                conversation_id=conversation.id, org_id=org_id,
+            )
+            if _ctx:
+                _base = payload.get("content") or ""
+                payload["content"] = (_base + _ctx) if _base else _ctx.lstrip()
+            payload["images"] = attachment_images
+            if _ctx or attachment_images:
+                logger.info(
+                    "attachment_context SSE 주입 message_id=%s attachment_count=%d images=%d",
+                    msg.id, len(msg.attachments), len(attachment_images),
+                )
+        except Exception:
+            logger.warning(
+                "attachment_context SSE 주입 실패 message_id=%s", msg.id, exc_info=True,
+            )
+
     # 참여자 조회
     rows = (await db.execute(
         select(ConversationParticipant.member_id)

--- a/backend/app/services/attachment_context.py
+++ b/backend/app/services/attachment_context.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import io
 import logging
 import os
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 from app.services.asset_registry import path_in_source_scope
 from app.services.storage import get_storage_provider
@@ -179,7 +179,14 @@ async def build_attachment_context(
                 continue
             if not _append(f"![{name}]({signed})"):
                 break
-            images.append({"url": signed, "name": name, "mime": ctype or f"image/{ext or 'png'}"})
+            # story #2650: 만료 시각 동반 — 소비자(플러그인 등)가 만료를 판별 못 하면 TTL(30분)
+            # 지난 뒤 조용한 403으로 fetch가 실패한다(PO 지적). 서명 URL 자체는 절대 로그에
+            # 안 찍는다(호출부도 동일 — count만 로깅).
+            expires_at = (datetime.now(timezone.utc) + _SIGNED_URL_TTL).isoformat()
+            images.append({
+                "url": signed, "name": name, "mime": ctype or f"image/{ext or 'png'}",
+                "expires_at": expires_at,
+            })
             continue
 
         # 미지원 형식 안내

--- a/backend/tests/test_2650_sse_attachment_context_parity.py
+++ b/backend/tests/test_2650_sse_attachment_context_parity.py
@@ -1,0 +1,193 @@
+"""story #2650 — SSE/webhook 패리티: conversation_webhook.py가 이미 하는 첨부 컨텍스트 주입
+(attachment_context.py, IDOR-safe·conversation 스코프)을 _dispatch_conversation_event()의
+SSE payload에도 재사용한다. AC1 재검증(디디 그라운딩)이 뒤집은 원 클레임("에이전트는 어디로도
+첨부 바이트를 못 받는다")을 "webhook 경로는 이미 되는데 SSE만 빠졌다"로 재정의한 뒤의 처방.
+
+이 파일은 tests/test_event1config_message_gating.py의 mocking 관례(_DB/_msg/_sender/_patches)를
+그대로 재사용 — 같은 함수를 다른 축(웹훅 게이팅이 아니라 첨부 주입)으로 가드한다."""
+from __future__ import annotations
+
+import contextlib
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import app.routers.conversations as conv
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _result_all(rows: list):
+    r = SimpleNamespace()
+    r.all = lambda: rows
+    return r
+
+
+def _msg(*, content="hi", attachments=None):
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        conversation_id=uuid.uuid4(),
+        thread_id=None,
+        reply_count=0,
+        last_reply_at=None,
+        content=content,
+        mentioned_ids=[],
+        attachments=attachments if attachments is not None else [],
+        created_at=datetime.now(timezone.utc),
+        deleted_at=None,
+    )
+
+
+def _sender():
+    return SimpleNamespace(id=uuid.uuid4(), name="송신자", type="human")
+
+
+async def _assign_seq(_db, event):
+    event.recipient_seq = 1
+
+
+class _DB:
+    def __init__(self, exec_rows: list):
+        self._exec_rows = list(exec_rows)
+        self.added: list = []
+        self.add = lambda ev: self.added.append(ev)
+        self.flush = AsyncMock()
+
+    async def execute(self, *_a, **_k):
+        return self._exec_rows.pop(0)
+
+
+def _patches():
+    return [
+        patch.object(conv, "assign_recipient_seq", _assign_seq),
+        patch("app.services.activity_stream.extract_activities_best_effort", AsyncMock()),
+        patch("app.services.presence_events.emit_conversation_working", new=AsyncMock(return_value=None)),
+        patch("app.services.presence_events.emit_presence", new=AsyncMock(return_value=None)),
+    ]
+
+
+async def _dispatch(db, conversation, msg, org_id, sender):
+    with contextlib.ExitStack() as stack:
+        for p in _patches():
+            stack.enter_context(p)
+        return await conv._dispatch_conversation_event(db, conversation, msg, org_id, sender)
+
+
+def _one_recipient_db():
+    """단일 human 참여자 — 첨부 주입 관찰에만 집중(웹훅 게이팅은 별개 테스트 관심사)."""
+    recipient = uuid.uuid4()
+    return recipient, _DB([
+        _result_all([(recipient,)]),           # participants
+        _result_all([(recipient, "human")]),    # types
+    ])
+
+
+# ── 첨부 있으면 build_attachment_context 호출 → content 병합 + images 실림 ──────
+@pytest.mark.anyio
+async def test_attachment_injection_merges_content_and_images():
+    org_id = uuid.uuid4()
+    sender = _sender()
+    recipient, db = _one_recipient_db()
+    conversation = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    msg = _msg(content="hi", attachments=[{"name": "chart.png", "content_type": "image/png", "url": "u", "size": 1}])
+
+    build = AsyncMock(return_value=(
+        "\n\n--- 첨부 내용 ---\n![chart.png](https://signed/url)",
+        [{"url": "https://signed/url", "name": "chart.png", "mime": "image/png", "expires_at": "2026-08-14T10:30:00+00:00"}],
+    ))
+    with patch("app.services.attachment_context.build_attachment_context", build):
+        out = await _dispatch(db, conversation, msg, org_id, sender)
+
+    build.assert_awaited_once_with(
+        msg.attachments, project_id=conversation.project_id,
+        conversation_id=conversation.id, org_id=org_id,
+    )
+    assert len(out) == 1
+    _pid, payload = out[0]
+    assert "![chart.png](https://signed/url)" in payload["content"]
+    assert payload["content"].startswith("hi")  # 원 content 뒤에 이어붙는다(webhook과 동형)
+    assert payload["images"] == [
+        {"url": "https://signed/url", "name": "chart.png", "mime": "image/png", "expires_at": "2026-08-14T10:30:00+00:00"},
+    ]
+
+
+# ── 첨부 없으면 build_attachment_context 자체를 안 부른다(무회귀 pin) ───────────
+@pytest.mark.anyio
+async def test_no_attachments_no_injection_attempted():
+    org_id = uuid.uuid4()
+    sender = _sender()
+    recipient, db = _one_recipient_db()
+    conversation = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    msg = _msg(content="plain message", attachments=[])
+
+    build = AsyncMock()
+    with patch("app.services.attachment_context.build_attachment_context", build):
+        out = await _dispatch(db, conversation, msg, org_id, sender)
+
+    build.assert_not_awaited()
+    _pid, payload = out[0]
+    assert payload["content"] == "plain message"
+    assert "images" not in payload  # 첨부 자체가 없으면 이 키를 아예 안 심는다
+
+
+# ── 주입 실패(best-effort) — 전달 자체는 막지 않는다, webhook 경로와 동형 ─────────
+@pytest.mark.anyio
+async def test_injection_failure_does_not_block_delivery():
+    org_id = uuid.uuid4()
+    sender = _sender()
+    recipient, db = _one_recipient_db()
+    conversation = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    msg = _msg(content="original content", attachments=[{"name": "x.pdf", "content_type": "application/pdf", "url": "u", "size": 1}])
+
+    build = AsyncMock(side_effect=RuntimeError("gcs down"))
+    with patch("app.services.attachment_context.build_attachment_context", build):
+        out = await _dispatch(db, conversation, msg, org_id, sender)
+
+    assert len(out) == 1  # Event는 그대로 생성됨 — 주입 실패가 발송 자체를 막지 않는다
+    _pid, payload = out[0]
+    assert payload["content"] == "original content"  # 원본 content 그대로 보존(오염 없음)
+    assert "images" not in payload
+
+
+# ── 첨부는 있지만 텍스트 추출/이미지 둘 다 빈 결과(예: 전부 접근범위 밖) — images는 빈 리스트로 실린다 ──
+@pytest.mark.anyio
+async def test_empty_extraction_result_still_sets_images_key_when_attachments_present():
+    org_id = uuid.uuid4()
+    sender = _sender()
+    recipient, db = _one_recipient_db()
+    conversation = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    msg = _msg(content="hi", attachments=[{"name": "x.png", "content_type": "image/png", "url": "u", "size": 1}])
+
+    build = AsyncMock(return_value=("", []))  # 예: scope 밖이라 안내 라인만 남고 총량 0(극단 케이스 시뮬)
+    with patch("app.services.attachment_context.build_attachment_context", build):
+        out = await _dispatch(db, conversation, msg, org_id, sender)
+
+    _pid, payload = out[0]
+    assert payload["content"] == "hi"  # 빈 _ctx면 원 content 그대로(치환 없음)
+    assert payload["images"] == []  # 첨부가 있었으므로 images 키는 심되 빈 리스트
+
+
+# ── 원 content가 빈 문자열이어도(첨부-단독 메시지) 병합이 안전하다 ────────────────
+@pytest.mark.anyio
+async def test_empty_original_content_with_attachment_uses_stripped_context():
+    org_id = uuid.uuid4()
+    sender = _sender()
+    recipient, db = _one_recipient_db()
+    conversation = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    msg = _msg(content="", attachments=[{"name": "chart.png", "content_type": "image/png", "url": "u", "size": 1}])
+
+    build = AsyncMock(return_value=("\n\n--- 첨부 내용 ---\n![chart.png](https://signed/url)", [
+        {"url": "https://signed/url", "name": "chart.png", "mime": "image/png", "expires_at": "x"},
+    ]))
+    with patch("app.services.attachment_context.build_attachment_context", build):
+        out = await _dispatch(db, conversation, msg, org_id, sender)
+
+    _pid, payload = out[0]
+    # webhook 경로와 동형: base가 비어있으면 lstrip()된 컨텍스트만 남는다(선행 개행 없음).
+    assert payload["content"] == "--- 첨부 내용 ---\n![chart.png](https://signed/url)"

--- a/backend/tests/test_attachment_context.py
+++ b/backend/tests/test_attachment_context.py
@@ -61,9 +61,29 @@ async def test_image_emits_signed_url_markdown_and_struct(monkeypatch):
     # content: 마크다운 이미지 링크(멀티모달 에이전트 fetch+view)
     assert "![chart.png](https://signed/url?sig=abc)" in text
     assert "이미지 분석은 준비 중" not in text  # 옛 placeholder 제거
-    # 구조화 images 필드
-    assert images == [{"url": "https://signed/url?sig=abc", "name": "chart.png", "mime": "image/png"}]
+    # 구조화 images 필드 — story #2650: expires_at 동반(소비자가 만료 판별 가능하게, PO 지적)
+    assert len(images) == 1
+    assert images[0]["url"] == "https://signed/url?sig=abc"
+    assert images[0]["name"] == "chart.png"
+    assert images[0]["mime"] == "image/png"
+    assert images[0]["expires_at"]  # ISO8601 문자열, 비어있지 않음
     fetch.assert_not_awaited()  # 이미지는 백엔드 다운로드/vision 안 함
+
+
+@pytest.mark.anyio
+async def test_image_expires_at_matches_ttl_window(monkeypatch):
+    """story #2650: expires_at이 _SIGNED_URL_TTL(30분) 근처의 실제 미래 시각인지 pin."""
+    from datetime import datetime, timezone
+
+    from app.services import attachment_context as ac
+
+    monkeypatch.setattr(ac, "_signed_read_url", AsyncMock(return_value="https://signed/url"))
+    before = datetime.now(timezone.utc)
+    _text, images = await _build(ac, [_att("chart.png", "image/png")])
+    after = datetime.now(timezone.utc)
+
+    expires_at = datetime.fromisoformat(images[0]["expires_at"])
+    assert before + ac._SIGNED_URL_TTL <= expires_at <= after + ac._SIGNED_URL_TTL
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## AC1 재검증 결과 (선행 필수, 스토리 본문에도 박제)
원 클레임("에이전트는 이 시스템 어디로도 첨부 바이트를 받을 방법이 구조적으로 없다")을 착수 前 코드 실측으로 재검증한 결과 **최강 형태로는 틀렸다**:
- 백엔드에 `GcsStorageProvider.signed_read_url()`(`app/services/storage/gcs.py`, IAM SignBlob V4, Cloud Run ADC — Next.js `getServerSession()`과 완전 무관)가 이미 존재.
- `app/services/attachment_context.py`(story 9d130c01/af66acee, "R2 S1")가 **conversation 첨부 전용 파이프라인을 이미 완비**: IDOR 게이트(`_is_scoped_to_conversation`) → 이미지 단기(30분) V4 서명 URL → "에이전트 런타임이 fetch→멀티모달 모델이 직접 view" — 정확히 이 스토리가 원하는 능력.
- 실제 배선처는 `app/services/conversation_webhook.py:335`(**webhook 경로에만**). SSE `/api/v2/agent/stream`(`agent_gateway.py`)는 전혀 안 부름(grep 재확認 0건).

→ 재정의: "부재"가 아니라 **"webhook 경로는 이미 되는데 SSE만 빠졌다"(패리티 갭)**. PO 판정: 처방을 "SSE payload 구성부에 검증된 attachment_context.py 재배선"으로 변경(신규 엔드포인트 발명 아님 — 새 인가 표면 0).

## 변경
- `app/routers/conversations.py::_dispatch_conversation_event()`: webhook과 동형으로 `build_attachment_context()` 호출 → SSE payload의 `content`(마크다운 이미지 링크/추출 텍스트)+`images`(구조화 목록) 채움. webhook-covered 수신자는 이 함수의 참여자 루프에서 이미 스킵되므로(webhook이 대신 전달) 이 주입은 SSE-only 수신자 payload에만 실림 — 중복 주입 없음. best-effort(webhook과 동형, 실패해도 전달 안 막음). 로그는 개수만(서명 URL 문자열은 어떤 로그에도 안 찍음).
- `app/services/attachment_context.py`: 이미지 dict에 `expires_at`(ISO8601) 추가 — 소비자가 30분 TTL 만료를 판별 못 하면 조용한 403 함정에 빠지는 것 방지(PO 지적). 공유 함수 변경이라 webhook 경로도 함께 혜택받음.

## Test plan
- [x] `tests/test_2650_sse_attachment_context_parity.py`(5종, mock 기반): content 병합·images 노출·무첨부 시 무영향(호출 자체 안 함)·주입실패 best-effort(전달 안 막힘)·빈 원문 content 병합 경계.
- [x] `tests/test_attachment_context.py` 갱신: `expires_at` 필드 pin(TTL 윈도 내 실제 미래 시각 검증 포함), 기존 exact-match 테스트도 함께 갱신.
- [x] 회귀 스윕(이중 발견) 165종(non-destructive)+10종(destructive_schema, 별도 fresh PG) 전부 통과.
- [ ] AC5(라이브 실측 — 실 agent 키 SSE로 선생님 image.png(asset acfb4573) 바이트 수신 확認)는 배포 후 진행(오늘 세션 표준 패턴).
- [ ] CI 전체런 green(모든 job terminal 상태 직접 확인 후 보고 예정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)