### PR TITLE
fix(chat): PR #N을 스토리 번호로 오승격하지 않음 (#2651)

### DIFF
--- a/backend/app/services/story_ref_promoter.py
+++ b/backend/app/services/story_ref_promoter.py
@@ -32,6 +32,15 @@ from app.services.reference_token import build_reference_token
 _BARE_STORY_REF_RE = re.compile(r"(?<!#)#(\d+)")
 _LATIN_RE = re.compile(r"[A-Za-z]")
 
+# story #2651 — PR 번호와 스토리 번호가 같은 `#N` 표기 공간을 공유(이 조직은 둘 다
+# 일상적으로 쓴다: PR 3033~3052 · 스토리 2637~2650). 직전 토큰이 「PR」/「pr」(대소문자
+# 무관, 단어 경계 — `SUPR #21`처럼 알파벳/숫자/밑줄 뒤에 곧장 붙은 것은 「PR」이 아니므로
+# 제외 대상이 아니다)이면 그 매치는 story 승격에서 제외한다. 실물 피해 2건(9e19d9b2 "PR
+# [E-01-S-07…]"·45e9e868 "PR [E-02-S-02…]") 전부 「PR #N」(공백+해시) 형태였다 — dev
+# 라이브 실측(2026-08-14, 착수 시 재검증)으로 「PR N」(해시 없는 형태)의 실사례는
+# 확인되지 않았다: 그 형태는 애초에 `_BARE_STORY_REF_RE`가 `#`을 요구해 매치 자체가 없다.
+_PR_PREFIX_RE = re.compile(r"(?<![A-Za-z0-9_])[Pp][Rr]\s*$")
+
 # 보호 구간(스캔에서 제외) — fenced 코드블록·인라인 코드·이미 만들어진 entity 토큰.
 _FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
 _INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
@@ -44,17 +53,21 @@ def extract_bare_story_ref_candidates(content: str) -> list[tuple[int, int, int]
 
     반환: (start, end, story_number) 튜플 리스트. 매치 직후 문자가 라틴 알파벳이면
     헥스 컬러류(`#74747c`)로 보고 그 후보 자체를 버린다(dev 실측 근거 — 모듈 docstring
-    참조). 코드블록/인라인코드/기존 entity 토큰 내부는 여기서 걸러지지 않는다 — 그건
-    `_protected_spans`가 별도로 처리(관심사 분리: 이 함수는 "무엇이 숫자 토큰처럼
-    생겼는가"만, 저건 "어디를 건드리면 안 되는가"만)."""
+    참조). 매치 직전 토큰이 「PR」/「pr」이면(story #2651) PR 번호로 보고 마찬가지로
+    버린다 — `_PR_PREFIX_RE` 참조. 코드블록/인라인코드/기존 entity 토큰 내부는 여기서
+    걸러지지 않는다 — 그건 `_protected_spans`가 별도로 처리(관심사 분리: 이 함수는
+    "무엇이 숫자 토큰처럼 생겼는가"만, 저건 "어디를 건드리면 안 되는가"만)."""
     if not content:
         return []
     candidates: list[tuple[int, int, int]] = []
     for m in _BARE_STORY_REF_RE.finditer(content):
+        start = m.start()
         end = m.end()
         if end < len(content) and _LATIN_RE.match(content[end]):
             continue
-        candidates.append((m.start(), end, int(m.group(1))))
+        if _PR_PREFIX_RE.search(content, 0, start):
+            continue
+        candidates.append((start, end, int(m.group(1))))
     return candidates
 
 

--- a/backend/tests/test_2629_bare_story_ref_promotion.py
+++ b/backend/tests/test_2629_bare_story_ref_promotion.py
@@ -87,6 +87,35 @@ def test_extract_bare_ref_multiple_and_none():
     assert [c[2] for c in cands] == [1, 2]
 
 
+# ── story #2651 — 「PR #N」오승격 회귀 pin (실피해 재현: 9e19d9b2·45e9e868) ─────────
+def test_extract_bare_ref_pr_prefixed_excluded():
+    """AC1 — 직전 토큰이 「PR」이면 승격 후보에서 제외. 실피해 그대로 재현."""
+    from app.services.story_ref_promoter import extract_bare_story_ref_candidates
+    assert extract_bare_story_ref_candidates("PR #19 리뷰 완료") == []
+    assert extract_bare_story_ref_candidates("PR [E-02-S-02…] 열었음(fix/x) — PR #21 열었음") == []
+
+
+def test_extract_bare_ref_pr_prefixed_case_insensitive_and_no_space():
+    from app.services.story_ref_promoter import extract_bare_story_ref_candidates
+    assert extract_bare_story_ref_candidates("pr #21 머지") == []
+    assert extract_bare_story_ref_candidates("PR#21 머지") == []
+
+
+def test_extract_bare_ref_bare_hash_still_promotes_no_regression():
+    """AC2 — 맨 `#N`(PR 접두 없음) 승격은 무회귀."""
+    from app.services.story_ref_promoter import extract_bare_story_ref_candidates
+    cands = extract_bare_story_ref_candidates("확인은 #24 참고")
+    assert [c[2] for c in cands] == [24]
+
+
+def test_extract_bare_ref_pr_lookalike_word_not_excluded():
+    """`SUPR #21`처럼 「PR」 앞에 다른 알파벳/숫자가 곧장 붙으면 PR 토큰이 아니다 — 과도한
+    제외 방지(단어 경계 lookbehind 회귀 pin)."""
+    from app.services.story_ref_promoter import extract_bare_story_ref_candidates
+    cands = extract_bare_story_ref_candidates("SUPR #21 확인")
+    assert [c[2] for c in cands] == [21]
+
+
 # ── ② 보호 구간 ────────────────────────────────────────────────────────────────
 async def test_promote_skips_fenced_code_block():
     from app.services.story_ref_promoter import promote_bare_story_refs
@@ -337,6 +366,47 @@ async def test_send_message_promotes_bare_ref_for_human_sender():
             )
             expected_token = build_reference_token("story", story.id, "보드 리팩터")
             assert result["data"]["content"] == f"확인은 {expected_token} 참고"
+    finally:
+        await engine.dispose()
+
+
+async def test_send_message_pr_prefixed_number_not_promoted_no_false_reference():
+    """story #2651 AC1/AC3 — 「PR #N」은 승격되지 않고, 그 결과 거짓 참조도 references
+    적재 레벨에서 0건이다(실피해 재현: 무관 스토리에 backlink가 실제로 꽂혔던 사고)."""
+    from fastapi import BackgroundTasks
+    from app.models.reference import Reference
+    from app.routers.conversations import SendMessageRequest, send_message
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org.id, project.id)
+            story = await _seed_story(s, org.id, project.id, number=24, title="무관 구스토리")
+            conv_id = await _seed_conversation(s, org.id, project.id, [agent_id], created_by=agent_id)
+
+        async with Session() as s:
+            result = await send_message(
+                conversation_id=conv_id,
+                body=SendMessageRequest(content="PR #24 리뷰 완료"),
+                background_tasks=BackgroundTasks(),
+                db=s, auth=_agent_auth(agent_id, org.id), org_id=org.id,
+            )
+            # AC1: 본문이 원문 그대로 저장(entity 토큰으로 안 바뀜)
+            assert result["data"]["content"] == "PR #24 리뷰 완료"
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Reference).where(
+                    Reference.org_id == org.id,
+                    Reference.source_id == uuid.UUID(result["data"]["id"]),
+                    Reference.target_type == "story",
+                    Reference.target_id == story.id,
+                )
+            )).scalars().all()
+            # AC3: 무관 스토리를 향한 거짓 참조가 적재되지 않았다
+            assert rows == []
     finally:
         await engine.dispose()
 


### PR DESCRIPTION
## Summary
- `story_ref_promoter`가 「#N」 직전 토큰이 `PR`/`pr`(대소문자 무관, 단어 경계)이면 story 승격 후보에서 제외
- PR 번호와 스토리 번호가 같은 `#N` 표기 공간을 공유해 GitHub PR 번호가 무관한 board story로 오승격 → 거짓 backlink가 실제로 적재되는 사고 실물 2건(conv 7256d5cc msg `9e19d9b2`·`45e9e868`)
- 맨 `#N` 승격은 무회귀

## Root cause
`_BARE_STORY_REF_RE = re.compile(r"(?<!#)#(\d+)")`가 직전 토큰 문맥을 안 봐서 `PR #19`의 `#19`도 그대로 매치됐다. `_PR_PREFIX_RE`로 직전 토큰이 PR/pr(단어 경계)인 매치만 걸러낸다.

`⚠️`(PO 지적, story 본문): "PR N"(해시 없는 형태)도 트리거되는지 dev 라이브 실측(conv 7256d5cc 채팅 이력 grep, msg `9e19d9b2`·`45e9e868` 원문 확인)으로 재검증 — 실사례 전부 `PR #N`(해시 있음) 형태였다. 해시 없는 형태는 애초에 `_BARE_STORY_REF_RE`가 `#`을 요구해 매치 자체가 불가능(구조적으로 안전).

## AC
1. 「PR #N」 미승격 — 실피해 문장 그대로 재현 pin (`test_extract_bare_ref_pr_prefixed_excluded`)
2. 맨 `#N` 승격 무회귀 (`test_extract_bare_ref_bare_hash_still_promotes_no_regression`)
3. 거짓 참조 미적재 — references 적재 레벨 검증 (`test_send_message_pr_prefixed_number_not_promoted_no_false_reference`, `entity_references` 0-row 확인)

## Test plan
- [x] 신규 pin 5종(대소문자·공백 유무·단어경계 오탐 방지 포함) — 실 alembic-migrated PG(로컬 disposable, head까지 마이그)로 19/19 통과
- [x] 기존 테스트(#2629) 무회귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)