### PR TITLE
[SID:2593] story-detail-panel.tsx org-switch 잔여 레이스 stale-guard

### DIFF
--- a/apps/web/src/components/kanban/story-detail-panel.test.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.test.tsx
@@ -12,6 +12,7 @@ import { NextIntlClientProvider } from 'next-intl';
 import { StoryDetailPanel } from './story-detail-panel';
 import type { KanbanStory } from './types';
 import koMessages from '../../../messages/ko.json';
+import { bumpOrgSyncVersion } from '@/lib/project-context-client';
 
 const { useDashboardContextMock } = vi.hoisted(() => ({ useDashboardContextMock: vi.fn() }));
 vi.mock('@/app/dashboard/dashboard-shell', () => ({
@@ -123,5 +124,48 @@ describe('StoryDetailPanel — #2528 본문 스크롤바 가시성', () => {
     });
     const body = Array.from(container.querySelectorAll('div')).find((d) => d.className.includes('overflow-y-auto'));
     expect(body?.className).toContain('scrollbar-visible');
+  });
+});
+
+// story #2593(#2545 후속) — kanban `?story=` 딥링크로 이 패널이 콜드 하드네비 직후 열리면
+// comments/activities/labels/references/dependencies/gates 6개 auto-mount fetch effect가
+// switch-org 완료 前에 구 org_id로 먼저 발사될 수 있다. #2946과 동형 stale-guard(orgSyncVersion
+// deps + cancelled 플래그)를 얹었는지를, "org-switch 신호 → 재요청 → 늦게 도착한 구 응답이
+// 새 응답을 덮지 않는다"는 실제 레이스로 검증한다(대표로 comments effect 사용).
+describe('StoryDetailPanel — org-switch 잔여 레이스 stale-guard (story #2593, #2545 후속)', () => {
+  it('org-switch 재요청 이후 늦게 도착한 구 org 응답이 새 org 응답을 덮지 않는다', async () => {
+    let resolveFirst: ((v: unknown) => void) | undefined;
+    let resolveSecond: ((v: unknown) => void) | undefined;
+    let commentsCallCount = 0;
+    vi.stubGlobal('fetch', vi.fn((url: string) => {
+      if (typeof url === 'string' && url.includes('/comments?limit=20')) {
+        commentsCallCount += 1;
+        if (commentsCallCount === 1) return new Promise((resolve) => { resolveFirst = resolve; });
+        return new Promise((resolve) => { resolveSecond = resolve; });
+      }
+      return Promise.resolve({ ok: false, json: async () => null });
+    }));
+
+    await act(async () => {
+      root.render(wrap(<StoryDetailPanel story={makeStory()} tasks={[]} onClose={() => {}} />));
+    });
+    expect(commentsCallCount).toBe(1); // 최초 마운트 — 구 org 요청(1st) 발사
+
+    // DashboardShell의 switch-org 성공 신호 — orgSyncVersion 구독 effect가 재요청되어야 한다.
+    await act(async () => { bumpOrgSyncVersion(); });
+    expect(commentsCallCount).toBe(2); // 신 org 요청(2nd) 발사 확인 — 재요청 자체가 안 되면 여기서 실패(구코드 회귀)
+
+    // 신 org 응답(2nd)이 먼저 도착
+    await act(async () => {
+      resolveSecond?.({ ok: true, json: async () => ({ data: [{ id: 'fresh', content: 'FRESH_ORG_COMMENT', created_by: 'u', created_at: '2026-01-01' }] }) });
+    });
+    const trigger = () => Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.startsWith('Comments'));
+    expect(trigger()?.textContent).toBe('Comments (1)');
+
+    // 구 org 응답(1st)이 뒤늦게 도착 — cancelled라 무시돼야 fresh 상태가 안 덮인다.
+    await act(async () => {
+      resolveFirst?.({ ok: true, json: async () => ({ data: [{ id: 'stale', content: 'STALE_ORG_COMMENT', created_by: 'u', created_at: '2026-01-01' }] }) });
+    });
+    expect(trigger()?.textContent).toBe('Comments (1)'); // 여전히 1 — stale 응답이 2번째로 덮어쓰지 않았다
   });
 });

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -48,6 +48,7 @@ import { ToastContainer, useToast } from '@/components/ui/toast';
 import { useSyntheticParentTabHistory } from '@/hooks/use-synthetic-parent-tab-history';
 import { useFocusTrap } from '@/hooks/use-focus-trap';
 import { HumanOnlyAction } from '@/components/ui/human-only-action';
+import { useOrgSyncVersion } from '@/lib/project-context-client';
 
 export interface Task {
   id: string;
@@ -430,6 +431,13 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
 
   const titleInputRef = useRef<HTMLInputElement>(null);
 
+  // story #2593(#2545 후속) — kanban `?story=` 딥링크로 이 패널이 콜드 하드네비 직후 열리면,
+  // 아래 auto-mount fetch effect들(labels/references/dependencies/gates/comments/activities)이
+  // switch-org 완료 前에 구 org_id 토큰으로 먼저 발사될 수 있다. #2946과 동일한 opt-in 패턴
+  // (orgSyncVersion을 각 effect deps에 얹어 switch-org 완료 시 재요청 + cancelled 플래그로
+  // 늦게 도착한 구 요청이 새 요청을 덮지 않게).
+  const orgSyncVersion = useOrgSyncVersion();
+
   useEffect(() => {
     setTitleDraft(story.title);
     setDescriptionDraft(story.description ?? '');
@@ -444,12 +452,14 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   }, [editingTitle]);
 
   useEffect(() => {
+    let cancelled = false;
     setLoadingLabels(true);
     Promise.all([
       fetch(`/api/item-labels?item_type=story&item_id=${story.id}`).then((r) => r.ok ? r.json() : []),
       fetch('/api/labels').then((r) => r.ok ? r.json() : []),
     ])
       .then(([itemLabels, allLabels]) => {
+        if (cancelled) return;
         const all = allLabels as LabelData[];
         setOrgLabels(all);
         const labelMap = Object.fromEntries(all.map((l) => [l.id, l]));
@@ -460,8 +470,9 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
         setStoryLabels(attached);
       })
       .catch(() => {})
-      .finally(() => setLoadingLabels(false));
-  }, [story.id]);
+      .finally(() => { if (!cancelled) setLoadingLabels(false); });
+    return () => { cancelled = true; };
+  }, [story.id, orgSyncVersion]);
 
   // description/AC 본문의 entity: 링크 유령 판정용 outgoing 참조 목록. ChatProofSection과
   // 같은 엔드포인트(GET /{id}/references?direction=outgoing)를 재사용한다(전용 라우트
@@ -496,7 +507,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
       })
       .catch(() => { /* undefined 유지 — 유령/치환 판정 보류 */ });
     return () => { cancelled = true; };
-  }, [story.id]);
+  }, [story.id, orgSyncVersion]);
 
   const handleAttachLabel = async (labelId: string) => {
     if (storyLabels.some((l) => l.id === labelId)) return;
@@ -674,16 +685,19 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   };
 
   useEffect(() => {
+    let cancelled = false;
     setLoadingDeps(true);
     fetch(`/api/dependencies?item_type=story&item_id=${story.id}`)
       .then((r) => (r.ok ? r.json() : null))
       .then((json) => {
+        if (cancelled) return;
         const raw = Array.isArray(json) ? json : [];
         setDeps(raw as DependencyEdge[]);
       })
       .catch(() => {})
-      .finally(() => setLoadingDeps(false));
-  }, [story.id]);
+      .finally(() => { if (!cancelled) setLoadingDeps(false); });
+    return () => { cancelled = true; };
+  }, [story.id, orgSyncVersion]);
 
   // P0-04 in-flight 신뢰 칩 — StoryMergeGate와 동형 데이터소스(work_item_id 필터, BE 추가 0).
   useEffect(() => {
@@ -693,7 +707,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
       .then((gates) => { if (!cancelled) setChipGates(Array.isArray(gates) ? gates : []); })
       .catch(() => {});
     return () => { cancelled = true; };
-  }, [story.id]);
+  }, [story.id, orgSyncVersion]);
 
   // Keep the locally-displayed status synced when a different story is selected or the
   // board pushes an external update. Optimistic in-panel changes set it directly (handler),
@@ -939,12 +953,15 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
 
   // Fetch comments
   useEffect(() => {
+    let cancelled = false;
     async function fetchComments() {
       setLoadingComments(true);
       try {
         const res = await fetch(`/api/stories/${story.id}/comments?limit=20`);
+        if (cancelled) return;
         if (res.ok) {
           const json = await res.json();
+          if (cancelled) return;
           setComments(json.data ?? []);
           // story #2230: BE meta 필드는 snake_case(next_cursor) — camelCase 로 읽어 항상
           // undefined였던 것이 커서가 죽어 보이던 세 번째 원인(BE 미반영·프록시 이중포장과 직렬).
@@ -952,22 +969,26 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
           setNextCommentsCursor(parseCursorMeta(json.meta, 'story-detail-panel:comments').nextCursor);
         }
       } catch {
-        setComments([]);
+        if (!cancelled) setComments([]);
       } finally {
-        setLoadingComments(false);
+        if (!cancelled) setLoadingComments(false);
       }
     }
     void fetchComments();
-  }, [story.id]);
+    return () => { cancelled = true; };
+  }, [story.id, orgSyncVersion]);
 
   // Fetch activities
   useEffect(() => {
+    let cancelled = false;
     async function fetchActivities() {
       setLoadingActivities(true);
       try {
         const res = await fetch(`/api/stories/${story.id}/activities?limit=20`);
+        if (cancelled) return;
         if (res.ok) {
           const json = await res.json();
+          if (cancelled) return;
           setActivities(json.data ?? []);
           // story #2231 AC4: BE list_activities는 아직 cursor를 안 낸다(CAPPED-NO-NEXT-PAGE) —
           // 지금은 meta가 없어 "더 없음"으로 낙하하는 게 맞지만, 조용히가 아니라 console.error로
@@ -975,13 +996,14 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
           setNextActivitiesCursor(parseCursorMeta(json.meta, 'story-detail-panel:activities').nextCursor);
         }
       } catch {
-        setActivities([]);
+        if (!cancelled) setActivities([]);
       } finally {
-        setLoadingActivities(false);
+        if (!cancelled) setLoadingActivities(false);
       }
     }
     void fetchActivities();
-  }, [story.id]);
+    return () => { cancelled = true; };
+  }, [story.id, orgSyncVersion]);
 
   // ESC 키로 닫기
   useEffect(() => {


### PR DESCRIPTION
## 변경 사항
부모 `#2545`(org-switch 토큰 재발급)의 `#2946` 스윕(6곳+2곳)에서 카디르 5라운드 QA가 정직히 미완으로 남긴 유일 잔여 — kanban `?story=` 딥링크로 열리는 `story-detail-panel.tsx`가 orgSyncVersion 재구독 스윕에서 빠져 있었다.

콜드 하드네비 + org_id 위조 토큰 상태에서 이 패널의 auto-mount fetch effect들이 switch-org 완료 前에 구 org_id 토큰으로 먼저 발사되면, switch-org 완료 후에도 재요청되지 않아 미스라우트/스톰 가능성이 있었다(다른 6곳과 동형 패턴).

`#2946`의 기존 opt-in 패턴(`useOrgSyncVersion()` deps + `cancelled` 플래그)을 이 파일의 auto-mount 전용 6개 effect에 적용했다(사용자 상호작용으로 게이트되는 검색/후보 조회 effect 2곳은 콜드 하드네비 레이스 대상이 아니라 스코프 밖으로 명시 제외):
- labels (item-labels + labels)
- references (outgoing, 기존 cancelled 패턴에 orgSyncVersion만 추가)
- dependencies
- gates (기존 cancelled 패턴에 orgSyncVersion만 추가)
- comments
- activities

## 검증
- 신규 회귀 테스트(comments effect 대표) — org-switch 신호(`bumpOrgSyncVersion()`) 후 재요청 확인 + 늦게 도착한 구 org 응답이 새 응답을 안 덮는지 확인. **수정 전 코드에 git stash로 되돌려 RED 확인(재요청 자체가 안 돼 실패) → 복원 후 GREEN** 전환 확인.
- `pnpm exec vitest run story-detail-panel.test.tsx`: 6/6 pass
- `pnpm exec tsc --noEmit`: 클린
- `pnpm exec eslint`: 0 warnings
- `pnpm build`: exit 0(실제 종료코드 확인)
- 반응형: 로직 변경만(레이아웃/스타일 무변경)이라 별도 스크린샷 없음

## Test plan
- [x] vitest green (6/6, RED→GREEN 확인)
- [x] tsc 클린
- [x] eslint 0 warnings
- [x] next build 성공
- [ ] 유나 design 게이트(관례상 필요 시)
- [ ] 카디르 QA — 딥링크 콜드 하드네비 org-switch 레이스 재현