### PR TITLE
[SID:2612] cross-element tint×series-color text 상환 — guard baseline 21→0

### DIFF
--- a/apps/web/scripts/cross-element-tint-text-baseline.json
+++ b/apps/web/scripts/cross-element-tint-text-baseline.json
@@ -1,26 +1,4 @@
 {
   "_comment": "story #2590 (A) 교차-요소 가드 grandfather baseline — can only shrink",
-  "keys": [
-    "app/(authenticated)/[ws]/[proj]/standup/standup-client.tsx::destructive::font-medium text-destructive",
-    "app/(authenticated)/[ws]/[proj]/standup/standup-client.tsx::destructive::text-sm font-semibold text-destructive",
-    "app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx::destructive::text-xs text-destructive",
-    "app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx::info::min-w-0 truncate text-info",
-    "app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx::success::text-sm font-semibold text-success",
-    "app/(authenticated)/settings/page.tsx::destructive::mb-4 text-sm text-destructive/80",
-    "app/(authenticated)/settings/page.tsx::destructive::text-sm text-destructive/80",
-    "app/onboarding/connect-step.tsx::info::min-w-0 truncate text-info",
-    "components/cage/stuck-handoff-detail.tsx::destructive::text-destructive/70",
-    "components/cage/stuck-handoff-section.tsx::destructive::text-[11px] text-destructive",
-    "components/canvas/concurrency-prompt.tsx::info::rounded-md border border-info/40 px-2 py-0.5 font-semibold text-info hover:bg-info/10",
-    "components/canvas/concurrency-prompt.tsx::info::text-info",
-    "components/chat/chat-bubble.tsx::info::mb-1 flex items-center gap-1 text-[10px] font-medium text-info",
-    "components/chat/chat-bubble.tsx::info::text-info",
-    "components/docs/doc-gate-section.tsx::destructive::text-xs font-medium text-destructive",
-    "components/hypotheses/story-hypotheses-section.tsx::warning::inline-flex shrink-0 items-center gap-1 text-[11px] text-warning",
-    "components/inbox/decisions-waiting.tsx::destructive::mb-2 text-xs text-destructive",
-    "components/integrations/pr-link-section.tsx::warning::inline-flex shrink-0 items-center gap-1 text-warning",
-    "components/loops/context-pack-panel.tsx::info::whitespace-pre-line text-info/90",
-    "components/org-briefing/attention-cluster-board.tsx::info::shrink-0 rounded-full border border-info/30 bg-card px-2.5 py-0.5 text-xs font-semibold text-info",
-    "components/settings/workflow-execution-history-section.tsx::destructive::px-2 py-2 text-xs text-destructive"
-  ]
+  "keys": []
 }

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/standup/standup-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/standup/standup-client.tsx
@@ -592,12 +592,12 @@ export default function StandupPage({ projectId }: StandupClientProps) {
               {!loading && blockerEntries.length > 0 ? (
                 <div className="rounded-xl border border-destructive-border bg-destructive-bg p-4">
                   <div className="flex flex-wrap items-center gap-2">
-                    <h2 className="text-sm font-semibold text-destructive">{t('blockersRollupTitle', { count: blockerEntries.length })}</h2>
+                    <h2 className="text-sm font-semibold text-foreground">{t('blockersRollupTitle', { count: blockerEntries.length })}</h2>
                   </div>
                   <div className="mt-2 space-y-1.5">
                     {blockerEntries.map((entry) => (
                       <p key={entry.authorId} className="text-xs text-foreground/90">
-                        <span className="font-medium text-destructive">{entry.name}</span>
+                        <span className="font-medium text-foreground">{entry.name}</span>
                         <span className="text-muted-foreground"> · {entry.blockers}</span>
                       </p>
                     ))}

--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
@@ -1066,7 +1066,7 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
               {/* story #2105 2차 — 생성 성공도 결과다(#2096/#2105 1차와 동일 원칙). equipResult는 이
                   가드에서 최초 1회만 non-null이 되므로 polite 낭독으로 충분(흐름 차단 아님). */}
               <div role="status" aria-live="polite" aria-atomic="true" className="space-y-3 rounded-md border border-success-border bg-success-tint p-4">
-                <p className="text-sm font-semibold text-success">{t('equipCreatedTitle', { name: equipResult.name })}</p>
+                <p className="text-sm font-semibold text-foreground">{t('equipCreatedTitle', { name: equipResult.name })}</p>
                 {equipRuntimeSaveWarning && (
                   <p role="alert" className="flex items-start gap-1.5 rounded-md border border-warning-border bg-warning-tint p-2 text-xs text-foreground">
                     <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
@@ -1306,7 +1306,7 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
                   <div className="space-y-2 rounded-md border border-warning-border bg-warning-tint p-3">
                     <p className="text-xs font-semibold text-foreground">{t('rotateConfirmTitle')}</p>
                     <p className="text-xs leading-relaxed text-muted-foreground"><b className="text-foreground">{t('rotateConfirmBold')}</b> {t('rotateConfirmBody')}</p>
-                    {rotateError && <p role="alert" aria-live="assertive" aria-atomic="true" className="text-xs text-destructive">{rotateError}</p>}
+                    {rotateError && <p role="alert" aria-live="assertive" aria-atomic="true" className="text-xs text-foreground">{rotateError}</p>}
                     <div className="flex justify-end gap-2">
                       <Button variant="ghost" size="sm" onClick={() => setShowRotateConfirm(false)} disabled={rotating}>{t('cancel')}</Button>
                       <Button size="sm" className="bg-warning text-foreground hover:bg-warning/90" disabled={rotating} onClick={() => void handleRotateConfirmed()}>
@@ -1344,7 +1344,7 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
                   복사 가능한 한 줄로 그 자리에 쥐여 준다. */}
               {rail.showVerifyExamplePrompt && (
                 <div className="flex items-center justify-between gap-2 rounded-md border border-info-border bg-info-tint px-3 py-2 text-xs">
-                  <span className="min-w-0 truncate text-info">
+                  <span className="min-w-0 truncate text-foreground">
                     {t('verifyExampleLabel')} <span className="font-mono text-foreground">&ldquo;{t('verifyExamplePrompt')}&rdquo;</span>
                   </span>
                   <Button variant="outline" size="sm" onClick={() => void handleCopyVerifyPrompt()} className="shrink-0">

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -1090,7 +1090,7 @@ export default function SettingsPage() {
                   <SectionCardHeader className="border-b border-destructive/20">
                     <div className="space-y-1">
                       <h2 className="text-base font-semibold text-destructive">위험 구역</h2>
-                      <p className="text-sm text-destructive/80">Organization을 삭제하면 모든 Project, Member, 데이터가 영구적으로 제거됩니다.</p>
+                      <p className="text-sm text-foreground">Organization을 삭제하면 모든 Project, Member, 데이터가 영구적으로 제거됩니다.</p>
                     </div>
                   </SectionCardHeader>
                   <SectionCardBody>
@@ -1406,11 +1406,11 @@ export default function SettingsPage() {
                 <SectionCardHeader className="border-b border-destructive/20">
                   <div className="space-y-1">
                     <h2 className="text-base font-semibold text-destructive">{t('dangerZone')}</h2>
-                    <p className="text-sm text-destructive/80">{t('dangerDescription')}</p>
+                    <p className="text-sm text-foreground">{t('dangerDescription')}</p>
                   </div>
                 </SectionCardHeader>
                 <SectionCardBody>
-                  <p className="mb-4 text-sm text-destructive/80">{t('deleteAccountDesc')}</p>
+                  <p className="mb-4 text-sm text-foreground">{t('deleteAccountDesc')}</p>
                   <Button variant="destructive" size="lg" onClick={() => setShowDeleteConfirm(true)}>
                     {t('deleteAccount')}
                   </Button>

--- a/apps/web/src/app/onboarding/connect-step.tsx
+++ b/apps/web/src/app/onboarding/connect-step.tsx
@@ -401,7 +401,7 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
         )}
         {rail.showVerifyExamplePrompt && (
           <div className="flex items-center justify-between gap-2 rounded-md border border-info-border bg-info-tint px-3 py-2 text-xs">
-            <span className="min-w-0 truncate text-info">
+            <span className="min-w-0 truncate text-foreground">
               {t('verifyExampleLabel')} <span className="font-mono text-foreground">&ldquo;{t('verifyExamplePrompt')}&rdquo;</span>
             </span>
             <Button variant="outline" size="sm" onClick={() => void handleCopyVerifyPrompt()} className="shrink-0">

--- a/apps/web/src/components/cage/stuck-handoff-detail.tsx
+++ b/apps/web/src/components/cage/stuck-handoff-detail.tsx
@@ -40,7 +40,7 @@ export function StuckHandoffDetail({ step }: StuckHandoffDetailProps) {
         <div className="flex items-start gap-1.5 rounded-md border border-destructive/30 bg-destructive/5 px-2 py-1.5 text-[11px] text-foreground/85">
           <AlertCircle className="mt-0.5 size-3 shrink-0" />
           <span>
-            <span className="text-destructive/70">{t('deliveryError')}: </span>
+            <span className="text-foreground">{t('deliveryError')}: </span>
             <span className="font-mono">{step.delivery_error}</span>
           </span>
         </div>

--- a/apps/web/src/components/cage/stuck-handoff-section.tsx
+++ b/apps/web/src/components/cage/stuck-handoff-section.tsx
@@ -133,7 +133,7 @@ export function StuckHandoffSection({ storyId, memberMap = {} }: StuckHandoffSec
           </div>
         ) : withdraw === 'confirming' ? (
           <div className="space-y-1.5 rounded-md border border-destructive/40 bg-destructive/5 p-2">
-            <p className="text-[11px] text-destructive">{t('withdrawIrreversibleWarning')}</p>
+            <p className="text-[11px] text-foreground">{t('withdrawIrreversibleWarning')}</p>
             <div className="flex gap-1.5">
               <Button variant="ghost" size="sm" className="flex-1 text-muted-foreground" onClick={() => setWithdraw('idle')}>
                 {t('withdrawCancel')}

--- a/apps/web/src/components/canvas/concurrency-prompt.tsx
+++ b/apps/web/src/components/canvas/concurrency-prompt.tsx
@@ -17,12 +17,12 @@ export function ConcurrencyPrompt({ authorName, version, onView, onMergeOver, cl
   return (
     <div className={className}>
       <div className="flex items-center justify-between gap-3 rounded-lg border border-info/30 bg-info/5 px-3 py-2 text-[11px]">
-        <span className="text-info">{t('concurrencyArrived', { name: authorName, version })}</span>
+        <span className="text-foreground">{t('concurrencyArrived', { name: authorName, version })}</span>
         <span className="flex shrink-0 gap-1.5">
           <button type="button" onClick={onView} className="rounded-md border border-border px-2 py-0.5 text-muted-foreground hover:bg-muted">
             {t('concurrencyView')}
           </button>
-          <button type="button" onClick={onMergeOver} className="rounded-md border border-info/40 px-2 py-0.5 font-semibold text-info hover:bg-info/10">
+          <button type="button" onClick={onMergeOver} className="rounded-md border border-info/40 px-2 py-0.5 font-semibold text-foreground hover:bg-info/10">
             {t('concurrencyMerge')}
           </button>
         </span>

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -507,12 +507,12 @@ export function ChatBubble({
             />
           ) : isCmd ? (
             <div className={`min-w-0 max-w-full rounded-xl border border-info/30 bg-info/8 px-3.5 py-2 ${isMine ? 'rounded-tr-sm' : 'rounded-tl-sm'}`}>
-              <div className="mb-1 flex items-center gap-1 text-[10px] font-medium text-info">
+              <div className="mb-1 flex items-center gap-1 text-[10px] font-medium text-foreground">
                 <Terminal className="h-3 w-3" aria-hidden />
                 {t('commandTag')}
               </div>
               <code className="block whitespace-pre-wrap [overflow-wrap:anywhere] font-mono text-sm">
-                <span className="text-info">/{cmdName}</span>
+                <span className="text-foreground">/{cmdName}</span>
                 <span className="text-muted-foreground">{message.content.slice(1 + (cmdName?.length ?? 0))}</span>
               </code>
             </div>

--- a/apps/web/src/components/docs/doc-gate-section.tsx
+++ b/apps/web/src/components/docs/doc-gate-section.tsx
@@ -263,7 +263,7 @@ export function DocGateSection({
       {/* 반려 섹션: 사유 + 결재자 + 시각(현재 상태 prominent surface). */}
       {state === 'denied' ? (
         <div className="space-y-1.5 rounded-lg border border-destructive/30 bg-destructive/5 p-2.5">
-          <p className="text-xs font-medium text-destructive">{t('docGateDeniedReason')}</p>
+          <p className="text-xs font-medium text-foreground">{t('docGateDeniedReason')}</p>
           <p className="whitespace-pre-wrap text-xs text-foreground">{gate?.resolution_note?.trim() || t('docGateNoReason')}</p>
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
             <span className="inline-flex items-center gap-1"><User className="size-3" />{resolveName(gate?.resolver_id)}</span>

--- a/apps/web/src/components/inbox/decisions-waiting.tsx
+++ b/apps/web/src/components/inbox/decisions-waiting.tsx
@@ -151,7 +151,7 @@ export function DecisionsWaiting({ onChange }: DecisionsWaitingProps = {}) {
       </header>
 
       {error ? (
-        <p className="mb-2 text-xs text-destructive" role="alert">
+        <p className="mb-2 text-xs text-foreground" role="alert">
           {t('decisionsErrorRetry')}
         </p>
       ) : null}

--- a/apps/web/src/components/loops/context-pack-panel.tsx
+++ b/apps/web/src/components/loops/context-pack-panel.tsx
@@ -186,7 +186,7 @@ export function ContextPackPanel({ loopId }: { loopId: string }) {
           <>
             {/* L2 요약(위) → L3 제안(중간) → L1 근거 items(아래) — 유나 LOCK: 위계는 항상 결정 UI보다 낮게. */}
             {data.synthesis ? (
-              <div className="rounded-lg border border-info-border bg-info-tint p-2.5 text-xs text-info">
+              <div className="rounded-lg border border-info-border bg-info-tint p-2.5 text-xs text-foreground">
                 <div className="flex items-start gap-2">
                   <Sparkles className="mt-0.5 size-3.5 shrink-0" aria-hidden />
                   <div className="min-w-0 flex-1 space-y-1">
@@ -194,7 +194,7 @@ export function ContextPackPanel({ loopId }: { loopId: string }) {
                       <p className="font-semibold">{t('contextPackSynthesisTitle')}</p>
                       <AiAttributionRow confidence={data.synthesis_confidence} evidenceCount={data.evidence_count} />
                     </div>
-                    <p className="whitespace-pre-line text-info/90">{data.synthesis}</p>
+                    <p className="whitespace-pre-line text-foreground">{data.synthesis}</p>
                   </div>
                 </div>
                 <AiTransparencyLine className="border-info-border/60" />

--- a/apps/web/src/components/org-briefing/attention-cluster-board.tsx
+++ b/apps/web/src/components/org-briefing/attention-cluster-board.tsx
@@ -36,7 +36,7 @@ function ClusterShell({
           {/* story #2420 규칙 — tint 배경 위 글자는 계열색이 아니라 text-foreground. */}
           <p className="truncate text-[11px] text-foreground">{subtitle}</p>
         </div>
-        <span className="shrink-0 rounded-full border border-info/30 bg-card px-2.5 py-0.5 text-xs font-semibold text-info">
+        <span className="shrink-0 rounded-full border border-info/30 bg-card px-2.5 py-0.5 text-xs font-semibold text-foreground">
           {count}
         </span>
       </div>

--- a/apps/web/src/components/settings/workflow-execution-history-section.tsx
+++ b/apps/web/src/components/settings/workflow-execution-history-section.tsx
@@ -117,7 +117,7 @@ export function WorkflowExecutionHistorySection({ projectId }: { projectId: stri
                       </tr>
                       {expandedId === log.id && log.error_message ? (
                         <tr className="border-b border-border/50 bg-destructive/5">
-                          <td colSpan={5} className="px-2 py-2 text-xs text-destructive">
+                          <td colSpan={5} className="px-2 py-2 text-xs text-foreground">
                             {log.error_message}
                           </td>
                         </tr>


### PR DESCRIPTION
## [SID:2612] 교차-요소 tint×계열색 글자 가드 baseline 21건 상환

`#2590` (A) 정적 가드 baseline(`cross-element-tint-text-baseline.json`)에 grandfather 되어 있던 «부모 pale-tint bg × 자식 계열색 글자» 잔존분을 상환한다. 처방은 `#2420` SSOT 규칙 그대로 — **tint 배경 위 글자는 `--foreground`를 쓰고, 계열 정체성은 border/bg/아이콘이 유지한다.**

### 완료 계측 — baseline 21 → 0
- `verify:cross-element-tint-text` (A) 가드: `grandfathered baseline: 0건 / 검출 0건 / OK` (exit 0)
- `cross-element-tint-text-baseline.json` = `{ "keys": [] }`

### 수리 내역 (20 DOM 자리 / 19 unique key)
전부 `text-{destructive|info|success}` → `text-foreground`. 계열은 조상 tint·border·아이콘이 유지.

| 파일 | 자리 | before → after |
|---|---|---|
| standup-client.tsx | 블로커 롤업 제목·이름 | `text-destructive` → `text-foreground` |
| recruiter-client.tsx | equip 생성 성공·rotate 에러·verify 라벨 | `text-success`/`text-destructive`/`text-info` → `text-foreground` |
| settings/page.tsx | danger zone 설명 3자리 | `text-destructive/80` → `text-foreground` |
| onboarding/connect-step.tsx | verify 예시 라벨 | `text-info` → `text-foreground` |
| cage/stuck-handoff-detail.tsx | delivery error 라벨 | `text-destructive/70` → `text-foreground` |
| cage/stuck-handoff-section.tsx | withdraw 경고 | `text-destructive` → `text-foreground` |
| canvas/concurrency-prompt.tsx | 도착 안내·merge 버튼 | `text-info` → `text-foreground` |
| chat/chat-bubble.tsx | command 태그·command 이름 | `text-info` → `text-foreground` |
| docs/doc-gate-section.tsx | 반려 사유 라벨 | `text-destructive` → `text-foreground` |
| inbox/decisions-waiting.tsx | 에러 재시도 | `text-destructive` → `text-foreground` |
| loops/context-pack-panel.tsx | synthesis 컨테이너 base + 본문 | `text-info` → `text-foreground` |
| org-briefing/attention-cluster-board.tsx | count 배지 | `text-info` → `text-foreground` |
| settings/workflow-execution-history-section.tsx | error_message 행 | `text-destructive` → `text-foreground` |

### 판단 노트
- **color-is-value 예외 0건.** 20자리 모두 장식성(라벨·메시지·카운트·command 태그) — 의미는 조상 tint/border/아이콘이 운반하고, 글자 색을 회색화해도 잃는 정보가 없다(색맹 사용자에겐 애초에 무의미). 에러 alert 자리도 `role="alert"` + 텍스트가 의미를 운반하므로 foreground로 안전.
- **context-pack-panel synthesis 박스:** 컨테이너가 `text-info`를 base로 깔아 제목이 이를 상속했다. 가드는 명시 재선언한 자식(synthesis 본문)만 잡지만, 표면 전체 AA 정합을 위해 컨테이너 base도 foreground로 통일했다.
- **warning 계열 2키**(`story-hypotheses-section`·`pr-link-section`)는 이미 develop에서 수리되어 baseline과 라이브가 어긋난 stale 상태였다 — 코드 무접촉, baseline에서만 제거.

### AC 대조
| AC | 판정 | 근거 |
|---|---|---|
| 1. baseline 21 → 0 (부분 시 목록) | ✅ | (A) 가드 0건 OK · baseline `{keys:[]}` · 부분 아님(전량 상환) |
| 2. 두 테마 AA/비텍스트 문턱 | ✅ | 전 자리 `--foreground` — SSOT #2420 canvas 실측 15~18:1(light·dark 둘 다) |
| 3. destructive color-is-value 비회귀 | ✅ | 예외 자리 0(회색화한 것 중 색이 값인 자리 없음)·destructive 액션 버튼 등 기존 계열색 무접촉 |
| 4. (B) axe green 유지 | ✅ | 변경은 계열색 **제거**뿐 — 새 색쌍 유입 0. axe는 개선만 가능(런타임 (B)는 CI) |

### 검증 로그
- `verify:cross-element-tint-text` → OK (0/0)
- `verify-cross-element-tint-text.test.ts` → 12 pass
- 변경 컴포넌트 vitest → 91 pass
- eslint (13 파일) → clean

### 인접 소견 (비-blocker, 이번 스코프 밖)
- settings/page.tsx danger zone의 `<h2>` 제목(`text-base text-destructive`)은 가드가 «비-small»로 분류해 baseline에 없어 이번 대상이 아니다. 단 `text-base`(16px) 계열색은 대비상 별도 축(가드의 text-base 갭)이라, 필요 시 후속으로 올린다.
