### PR TITLE
fix(recruit): claude-code 온보딩 안내를 마켓플레이스 설치 경로로 정정 (#2653)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3673,6 +3673,7 @@
     "connectConfigVerifiedBadge": "Config saved · tool delivery unconfirmed",
     "kitOrientingWakeLabel": "② Wake up",
     "kitOrientingWakeBody_channel-plugin": "A channel plugin wakes the session. We don't publish a way to obtain it yet.",
+    "kitOrientingWakeBody_channel-plugin-marketplace": "A channel plugin wakes the session. Install it with: <code>{path}</code> (installing alone doesn't confirm the connection — check the badge for actual connection status)",
     "kitOrientingWakeBody_connector-host": "A connector host spawns and drives the session. We don't publish a way to obtain it yet.",
     "kitOrientingWakeBody_connector-sidecar": "A sidecar manages the run for cloud agents. We don't publish a way to obtain it yet.",
     "kitOrientingWakeBody_connector-sdk": "You wire this runtime in yourself. We don't publish the reference SDK yet.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3673,6 +3673,7 @@
     "connectConfigVerifiedBadge": "설정 저장됨 · 도구 전달 미확인",
     "kitOrientingWakeLabel": "② 깨우기",
     "kitOrientingWakeBody_channel-plugin": "채널 플러그인이 세션을 깨웁니다. 이 플러그인을 받는 경로는 아직 제공하지 않습니다.",
+    "kitOrientingWakeBody_channel-plugin-marketplace": "채널 플러그인이 세션을 깨웁니다. 아래 명령으로 설치합니다: <code>{path}</code> (설치 자체는 연결 확인이 아닙니다 — 실제 연결 여부는 배지로 확인합니다)",
     "kitOrientingWakeBody_connector-host": "커넥터 호스트가 세션을 구동합니다. 이 커넥터를 받는 경로는 아직 제공하지 않습니다.",
     "kitOrientingWakeBody_connector-sidecar": "사이드카가 클라우드 에이전트의 실행을 관리합니다. 이 사이드카를 받는 경로는 아직 제공하지 않습니다.",
     "kitOrientingWakeBody_connector-sdk": "직접 연동으로 세션을 구동합니다. 참조 SDK를 받는 경로는 아직 제공하지 않습니다.",

--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
@@ -1171,8 +1171,12 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
                           끝냈다가 실제로는 안 깨어나는" 오탐을 만든다. 사실형("…이 세션을
                           깨웁니다. 받는 경로는 아직 제공하지 않습니다")으로 정정 — path는 «명령
                           대상»이 아니라 «이름»으로 강등(t.rich path 태그: font-mono·작게·무채색,
-                          링크 색 금지 — 누를 수 있는 것처럼 보이면 안 된다). 디디군의 "한 줄
-                          설치"가 착지하면 이 문구 뒷문장을 그 설치 명령으로 되돌린다(만료조건). */}
+                          링크 색 금지 — 누를 수 있는 것처럼 보이면 안 된다).
+                          만료조건 착지(story #2653, 2026-08-14): claude-code는 마켓플레이스
+                          add→install 실왕복이 실측됐다 — 단 hermes/openclaw/opencode는 여전히
+                          "아직 제공하지 않습니다"가 사실이라 같은 'channel-plugin' 키를 못 씀.
+                          claude-code만 'channel-plugin-marketplace' method로 갈라 설치 명령을
+                          말한다(설치≠연결 확인 — 실 연결은 배지가 말한다, #2657과 역할 분리). */}
                       <p className="text-xs text-muted-foreground">
                         <WakeMethodBody method={wakeInfo.method} path={wakeInfo.path} />
                       </p>

--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.wake-method-body.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.wake-method-body.test.tsx
@@ -104,6 +104,30 @@ describe('WakeMethodBody (story #2434) — path가 실제로 DOM에 렌더되는
     expect(container.querySelector('span.font-mono')).toBeNull();
   });
 
+  // story #2653(2026-08-14) — claude-code만은 #2648/#2652가 걷어낸 "비-actionable 내부
+  // 경로"가 아니라 실제로 사용자가 실행 가능한 설치 명령을 갖는다(마켓플레이스 add→install
+  // 실왕복 실측 완료). 그래서 형제들과 반대로 여기서는 path가 «보여야» 한다 — 별도 method
+  // ('channel-plugin-marketplace')로 가른 이유가 바로 이 비대칭.
+  it('ko channel-plugin-marketplace: 설치 명령이 DOM에 실재하고 "아직 제공하지 않습니다" 문구가 안 섞인다', async () => {
+    const installCmd = 'claude plugin marketplace add moonklabs/sprintable-agent-plugins && claude plugin install sprintable@moonklabs';
+    await act(async () => {
+      root.render(wrap('ko', <WakeMethodBody method="channel-plugin-marketplace" path={installCmd} />));
+    });
+    expect(container.textContent).toContain(installCmd);
+    expect(container.textContent).not.toContain('아직 제공하지 않습니다');
+    expect(container.textContent).not.toContain('()');
+  });
+
+  it('en channel-plugin-marketplace: 설치 명령이 DOM에 실재하고 "not yet" 문구가 안 섞인다', async () => {
+    const installCmd = 'claude plugin marketplace add moonklabs/sprintable-agent-plugins && claude plugin install sprintable@moonklabs';
+    await act(async () => {
+      root.render(wrap('en', <WakeMethodBody method="channel-plugin-marketplace" path={installCmd} />));
+    });
+    expect(container.textContent).toContain(installCmd);
+    expect(container.textContent).not.toContain("don't publish a way to obtain it yet");
+    expect(container.textContent).not.toContain('()');
+  });
+
   it('unknown은 t.rich를 안 쓰고 plain 문구를 보여준다(path 태그 없음)', async () => {
     await act(async () => {
       root.render(wrap('ko', <WakeMethodBody method="unknown" path="" />));

--- a/apps/web/src/services/recruit.test.ts
+++ b/apps/web/src/services/recruit.test.ts
@@ -9,7 +9,10 @@ import koMessages from '../../messages/ko.json';
 
 describe('resolveRuntimeWakeInfo — story #2377 §2', () => {
   it('maps each of the 9 named runtimes + the generic connector slug to their real wake mechanism(onboarding-guide.txt Runtime catalog 표와 대조)', () => {
-    expect(resolveRuntimeWakeInfo('claude-code')).toEqual({ method: 'channel-plugin', path: 'packages/fakechat' });
+    expect(resolveRuntimeWakeInfo('claude-code')).toEqual({
+      method: 'channel-plugin-marketplace',
+      path: 'claude plugin marketplace add moonklabs/sprintable-agent-plugins && claude plugin install sprintable@moonklabs',
+    });
     expect(resolveRuntimeWakeInfo('codex')).toEqual({ method: 'connector-host', path: 'connectors/codex-sprintable/' });
     expect(resolveRuntimeWakeInfo('gemini')).toEqual({ method: 'connector-host', path: 'connectors/gemini-sprintable/' });
     expect(resolveRuntimeWakeInfo('grok')).toEqual({ method: 'connector-host', path: 'connectors/grok-sprintable/' });
@@ -54,6 +57,7 @@ describe('kitOrientingWakeBody_<method> i18n coverage — story #2377 (유나양
   // 타입이 실제로 하게 만든다.
   const NON_UNKNOWN_WAKE_METHOD_CHECK: Record<Exclude<RuntimeWakeMethod, 'unknown'>, true> = {
     'channel-plugin': true,
+    'channel-plugin-marketplace': true,
     'connector-host': true,
     'connector-sidecar': true,
     'connector-sdk': true,

--- a/apps/web/src/services/recruit.ts
+++ b/apps/web/src/services/recruit.ts
@@ -118,7 +118,7 @@ export interface RuntimeCapabilityItem {
  * 오프를 감수하는 이유는 이 정보가 «서버 상태»가 아니라 «연동 방식에 대한 고정 사실»이기
  * 때문이다(BE가 매 요청마다 계산할 것이 없다).
  */
-export type RuntimeWakeMethod = 'channel-plugin' | 'connector-host' | 'connector-sidecar' | 'connector-sdk' | 'unknown';
+export type RuntimeWakeMethod = 'channel-plugin' | 'channel-plugin-marketplace' | 'connector-host' | 'connector-sidecar' | 'connector-sdk' | 'unknown';
 
 export interface RuntimeWakeInfo {
   method: RuntimeWakeMethod;
@@ -130,7 +130,17 @@ export interface RuntimeWakeInfo {
  * 말한다」(§2). 침묵 대신 "아직 깨우는 방법이 없다"를 명시적으로 말할 수 있어야 한다는 것이
  * 이 스토리의 핵심 처방(A-1)이다. */
 export const RUNTIME_WAKE_MECHANISM: Record<string, RuntimeWakeInfo> = {
-  'claude-code': { method: 'channel-plugin', path: 'packages/fakechat' },
+  // story #2653(디디 「한 줄 설치」 착지, 2026-08-14) — marketplace add→install 실왕복
+  // 실측 완료(claude plugin marketplace add moonklabs/sprintable-agent-plugins →
+  // claude plugin install sprintable@moonklabs, 완전 격리 CLAUDE_CONFIG_DIR로 확認).
+  // method를 별도 축으로 가른 이유: hermes/openclaw/opencode는 여전히 배포 경로가
+  // 없어 그 사실을 그대로 말해야 하는데, claude-code만 이제 실제 명령이 있다 — 같은
+  // 'channel-plugin' 키를 공유하면 "받는 경로는 아직 제공하지 않습니다" 문장이 실제
+  // 명령과 모순되게 붙는다. path는 「명령 대상」이 아니라 그대로 노출되는 설치 명령.
+  'claude-code': {
+    method: 'channel-plugin-marketplace',
+    path: 'claude plugin marketplace add moonklabs/sprintable-agent-plugins && claude plugin install sprintable@moonklabs',
+  },
   hermes: { method: 'channel-plugin', path: 'connectors/hermes-sprintable/' },
   openclaw: { method: 'channel-plugin', path: 'connectors/openclaw-sprintable/' },
   opencode: { method: 'channel-plugin', path: 'connectors/opencode-sprintable/' },

--- a/connectors/README.md
+++ b/connectors/README.md
@@ -116,7 +116,7 @@ B=자식 프로세스 spawn 후 stdio, C=자식 프로세스 없이 원격 HTTP 
 
 | 카테고리 | 런타임 | 주입 방식 | 디렉토리 |
 |----------|--------|-----------|----------|
-| **A** | Claude Code | `notifications/claude/channel` emit (fakechat pairing 필요) | `packages/fakechat/server.ts` |
+| **A** | Claude Code | `notifications/claude/channel` emit | [`moonklabs/sprintable-agent-plugins`](https://github.com/moonklabs/sprintable-agent-plugins) `plugins/sprintable`(마켓플레이스 설치, story #2653) — `packages/fakechat/server.ts`는 같은 프로토콜의 로컬 테스트 하네스 |
 | **A** | Hermes Agent — dev (Python) | `handle_message()` → 세션 주입 | `connectors/hermes-sprintable/` |
 | **A** | Hermes Agent — prod (Python) | `handle_message()` → 세션 주입 (`SPRINTABLE_PROD_*`) | `connectors/hermes-sprintable-prod/` |
 | **A** | OpenClaw (TS, ChannelPlugin) | `runtime.channel.inbound` | `connectors/openclaw-sprintable/` |

--- a/docs/runtime-channel-map.md
+++ b/docs/runtime-channel-map.md
@@ -143,7 +143,7 @@ Claude Code 세션 (MCP stdio)
 
 | 에이전트 유형 | Outbound (보내기) | Inbound (받기) | 비고 |
 |--------------|------------------|----------------|------|
-| **Claude Code** | MCP (stdio) | fakechat — SSE dial-out→MCP notification 주입 | 이 harness 세션이 이 패턴 |
+| **Claude Code** | MCP (stdio) | `sprintable` 플러그인([`moonklabs/sprintable-agent-plugins`](https://github.com/moonklabs/sprintable-agent-plugins) `plugins/sprintable`) — SSE dial-out→MCP notification 주입 | 이 harness 세션이 이 패턴(story #2653 — `packages/fakechat`는 같은 프로토콜을 쓰는 로컬 테스트 하네스일 뿐, 배포 경로 아님) |
 | **Hermes** (장기 실행 서버) | MCP (stdio) | SSE (`GET /api/v2/events/stream`) | 상시 연결 유지, backfill 지원 |
 | **Webhook 에이전트** (서버리스·슬리핑) | MCP (stdio) | webhook (`webhook_configs.url` POST) | 이벤트 수신 시만 깨어남 |
 | **외부 통합** (Slack·Discord 봇 등) | MCP (stdio) | Inbox webhook (`/agent-inbox/{id}/webhook`) → EventBus → SSE relay | HMAC 검증 필수 |
@@ -197,7 +197,7 @@ message_created)        :message)
 
 - 내 에이전트가 **항상 켜져 있고 long-lived 프로세스**다 → SSE (`GET /api/v2/events/stream`)
 - 내 에이전트가 **이벤트가 올 때만 깨어나는** 서버리스/슬리핑 프로세스다 → webhook
-- 나는 **Claude Code harness** 안에서 실행 중이다 → fakechat (Bun shim 필요)
+- 나는 **Claude Code harness** 안에서 실행 중이다 → `sprintable` 플러그인(`moonklabs/sprintable-agent-plugins` 마켓플레이스로 설치, story #2653) — `packages/fakechat`는 로컬 SSE 브릿지 테스트 하네스일 뿐 배포 경로 아님
 - SSE를 열 수 없는 환경이다 → `poll_events` MCP tool
 
 **"어느 경로로 보내는가?"**
@@ -211,6 +211,7 @@ message_created)        :message)
 - [`docs/architecture-post-migration.md`](./architecture-post-migration.md) — GCP 인프라 전체 구조
 - [`docs/routing-rule-policy-enforcement.md`](./routing-rule-policy-enforcement.md) — 라우팅 규칙 정책
 - [`apps/web/public/llms-full.txt`](../apps/web/public/llms-full.txt) — LLM 에이전트용 전체 API 레퍼런스
-- [`packages/fakechat/server.ts`](../packages/fakechat/server.ts) — fakechat 구현체
+- [`moonklabs/sprintable-agent-plugins`](https://github.com/moonklabs/sprintable-agent-plugins) `plugins/sprintable` — Claude Code용 실 배포 채널 플러그인
+- [`packages/fakechat/server.ts`](../packages/fakechat/server.ts) — 같은 프로토콜의 로컬 SSE 브릿지 테스트 하네스(story #2653, 배포 경로 아님)
 - [`backend/sprintable_mcp/__main__.py`](../backend/sprintable_mcp/__main__.py) — MCP 서버 진입점
 - 구현 기반 스토리: S-COMM-01(SSE 인증), S-COMM-02(webhook 라우팅), S-COMM-04(send_chat_message 단일 경로), S-COMM-05(backfill+dedup), S-COMM-12(SSE/webhook 이벤트명 통일, backlog)

--- a/packages/fakechat/README.md
+++ b/packages/fakechat/README.md
@@ -1,0 +1,19 @@
+# fakechat
+
+**Local SSE bridge test harness** — not a product/deployment artifact. `package.json`'s own description says this plainly: "Fake chat MCP plugin — localhost UI for SSE bridge testing".
+
+story #2653 (2026-08-14) reclassified this package after grounding for `[플러그인·사본] packages/fakechat ↔ sprintable-agent-plugins 이중 사본 표류` found it wasn't a competing production implementation drifting behind the real one — it was always a test tool that docs (`docs/runtime-channel-map.md`, `apps/web/src/services/recruit.ts`) had mis-described as "the" Claude Code channel distribution path. That's fixed now: the onboarding kit points Claude Code users at the real distribution (`claude plugin marketplace add moonklabs/sprintable-agent-plugins` → `claude plugin install sprintable@moonklabs`, published from [`moonklabs/sprintable-agent-plugins`](https://github.com/moonklabs/sprintable-agent-plugins)'s `plugins/sprintable`), not this package.
+
+## What this is for
+
+`server.ts` is a real, working MCP stdio shim that dials out to the Sprintable Agent Gateway SSE stream (`GET /api/v2/agent/stream`) and injects inbound messages as `notifications/claude/channel` — same protocol the real plugin speaks. Use it to smoke-test the SSE bridge itself (backend changes to the gateway stream, envelope shape, ack semantics) without needing a full plugin marketplace install:
+
+```
+bun run server.ts   # or: bun start
+bun smoke.ts         # or: bun run smoke
+```
+
+## What this is not
+
+- Not kept in sync feature-for-feature with `plugins/sprintable/server.ts` (the real plugin) — it lags on purpose (`chat_id` explicit reply targeting, HITL `approval_prompt`, attachment support, credential file resolution, envelope rendering, audit logging are all real-plugin-only, per the #2653 grounding doc). Don't point users or automation at this package expecting plugin-parity behavior.
+- Not referenced by any launcher, deploy pipeline, or onboarding copy anymore (#2653) — if you find a new reference treating this as a distribution path, that's the bug #2653 fixed, reintroduced; point it at the real plugin instead.


### PR DESCRIPTION
## Summary
story #2653(사본표류 그라운딩) 재해석 결과 집행 — `packages/fakechat`는 「경쟁 프로덕션 사본」이 아니라 `package.json` 자기선언 그대로 "localhost UI for SSE bridge testing"인 **로컬 테스트 하네스**였다. `docs/runtime-channel-map.md`·`recruit.ts`가 이걸 "claude-code 채널 플러그인의 배포 경로"로 잘못 소개해 온 것이 실제 결함(#2739 pin이 그 오소개된 자리를 지키고 있었다).

## 근거(그라운딩 → PO 판정, 2026-08-14 페드루군)
- fakechat 자체 `package.json`: `"description": "Fake chat MCP plugin — localhost UI for SSE bridge testing"`.
- `docs/runtime-channel-map.md`가 "이 harness 세션(=이 PR을 쓰는 나)이 fakechat 패턴"이라 주장했으나, 실제로는 `moonklabs/sprintable-agent-plugins` 마켓플레이스로 설치된 `sprintable` 플러그인을 쓰고 있었다(`<channel source="plugin:sprintable:sprintable-channel">`로 실측 확인).
- 마켓플레이스 설치 실왕복 실측(완전 격리 `CLAUDE_CONFIG_DIR`): `claude plugin marketplace add moonklabs/sprintable-agent-plugins` → `claude plugin install sprintable@moonklabs` → `claude plugin list`에서 `sprintable@moonklabs v0.3.3 enabled` 확인.

## 변경
- `recruit.ts`: claude-code 항목을 실제 설치 명령으로 교체. `RuntimeWakeMethod`에 `'channel-plugin-marketplace'` 신설(기존 `'channel-plugin'` 재사용 안 함 — hermes/openclaw/opencode는 여전히 배포 경로가 없어 "아직 제공하지 않습니다"가 사실이라 같은 문구를 못 씀).
- 카피 경계 둘(PO 지시): ①설치 명령까지만 안내 — "설치=연결 완료"로 안 읽히게(실 연결 확인은 [#2657](https://sprintable.ai) 배지 몫으로 역할 분리) ②MCP 서버 신뢰 프롬프트 유무는 미확인이라 단정 안 실음.
- `packages/fakechat/README.md` 신설 — 로컬 테스트 하네스 역할 명문화 + 실 플러그인과 기능 패리티 안 맞는다는 것 명시.
- `docs/runtime-channel-map.md`·`connectors/README.md`의 오소개 정정.

쌍①(fakechat↔plugins/sprintable)은 이 재정의로 "사본쌍" 재분류 해제 — 역할 분리로 해소, 계약면 가드 불요.

## Test plan
- [x] `recruit.test.ts`(pinned 값 갱신 + method 완전성 타입체크) — pass
- [x] `recruiter-client.wake-method-body.test.tsx`(신규 pin 2종 — 설치명령 렌더+"아직 제공 안 함" 문구 비혼입) — pass
- [x] `recruiter-client.test.ts`(44)·`page.test.ts`(#2739 pin, 무관 서프라이즈라 무변경) — pass
- [x] 63/63 vitest 통과 + i18n phrase-collision 신규 0건 + tsc 클린(무관 EE 의존성 에러 1건만 사전 존재)

🤖 Generated with [Claude Code](https://claude.com/claude-code)