### PR TITLE
[SID:2659] 워크스페이스 잔재 자동 회수 스크립트

### DIFF
--- a/scripts/RECLAIM-README.md
+++ b/scripts/RECLAIM-README.md
@@ -1,0 +1,75 @@
+# 워크스페이스 잔재 자동 회수 — story #2659
+
+2026-08-14 fleet 전면 장애(공유 Data 볼륨 926Gi 100%, 여유 117Mi — 전 에이전트 Bash 불능) 사후
+처방. 실측 원인: `git worktree add`로 스토리마다 만든 격리 작업공간(각 수백MB~GB
+`node_modules`)이 머지 확定 후에도 지워지지 않고 쌓였다(미르코 명명분 200개+ · 까디르
+`.qa-worktrees/*` 391개 — 전부 실측 확인) + Docker.raw 149G(그 QA worktree들의 일회 테스트
+Postgres 컨테이너 누적).
+
+## 오너십 분할 (PO 판정, 2026-08-14)
+
+- **설계+구현(이 디렉토리) = 미르코**: 스크립트 실물 + 안전검사 + 실측 테스트.
+- **머신 레벨 배선(cron/launchd 등록) = PO**: 이 스크립트가 서면 등록은 PO가 선생님과
+  무는다. 이 레포는 「돌릴 물건」까지만 책임진다.
+
+## 스크립트
+
+### `reclaim-merged-worktrees.sh`
+
+머지 확定+push 완료+clean(무커밋 잔여 0)인 worktree만 안전하게 회수(디렉토리만 — 브랜치는
+안 지움). 기본은 dry-run.
+
+```sh
+scripts/reclaim-merged-worktrees.sh              # dry-run — 무엇을 지울지만 보고
+scripts/reclaim-merged-worktrees.sh --apply       # 실제 삭제(+ docker-compose down 동반)
+```
+
+안전검사(전부 AND — 하나라도 걸리면 KEEP):
+1. worktree가 clean(추적/미추적 불문 무변경)
+2. HEAD sha 자체가 origin에 push됨(`git branch -r --contains <sha>` — 브랜치 존재가 아니라
+   **그 커밋 자체**가 실렸는지. 오늘 PO가 `--branches` 오스코프로 걸린 함정과 같은 급의 실수를
+   막는 게 이 체크의 존재 이유)
+3. 머지 확定 — `origin/develop` 조상관계 **또는** `gh pr list --state merged --head <branch>`
+   (OR 조건 필수: squash-merge된 브랜치는 조상관계로 안 잡힌다 — 실측:
+   `feature/1cb4ef97-goal-form`·`feature/5a9766eb-loop-board-ui` 둘 다 GitHub상 MERGED인데
+   `git merge-base --is-ancestor`는 UNMERGED로 오판)
+
+AC3(일회 docker 잔존 방지) — `--apply` 시 회수 대상 worktree에 `docker-compose.yml`이 있으면
+`git worktree remove` **전에** `docker compose down --volumes --remove-orphans`를 먼저 부른다
+(best-effort — 데몬이 죽어있어도 worktree 회수 자체는 막지 않음).
+
+### `check-disk-usage.sh`
+
+디스크 사용률 임계 초과 탐지(관측만 — 어디로 알릴지는 cron 배선 쪽 몫).
+
+```sh
+scripts/check-disk-usage.sh                       # 기본 90%, /System/Volumes/Data(macOS)
+scripts/check-disk-usage.sh --threshold 85 --mount /
+```
+
+`exit 0`=정상 / `exit 2`=임계 초과(경보 트리거) / `exit 1`=측정 실패. stdout에 JSON 한 줄
+(`{"mount":...,"used_percent":N,"threshold":N,"alert":bool}`) — cron 래퍼가 파이프로 소비.
+
+## 테스트
+
+`reclaim-merged-worktrees.test.sh`·`check-disk-usage.test.sh` — 진짜 sprintable 레포를 안
+건드리고 `/tmp`에 합성 git 원격+worktree로 5개 시나리오(머지-ancestor/머지-squash/dirty/
+unpushed/unmerged)를 재현해 KEEP/RECLAIM 판정을 **실행 결과로** 잰다(AC4 음성대조 포함).
+
+```sh
+bash scripts/reclaim-merged-worktrees.test.sh
+bash scripts/check-disk-usage.test.sh
+```
+
+## 배선 전 권장 순서 (PO 몫, 참고용)
+
+1. **첫 실행은 반드시 dry-run**으로 실제 레포에 돌려 판정 목록을 사람이 한 번 훑는다(200+ ·
+   391개 규모라 예상 밖 KEEP/RECLAIM이 있는지 육안 확인 가치가 있다).
+2. dry-run 결과가 납득되면 `--apply`를 cron/launchd에 등록.
+3. `check-disk-usage.sh`를 짧은 주기(예: 30분)로 돌려 임계 초과 시 fleet 채널로 포워딩.
+
+## AC5 — 재확인 시점
+
+cron 등록 완료 시점 기준 **7일 후** 1회, `git worktree list | wc -l` 규모가 재축적 없이
+안정(신규 스토리 착수분 외 잔재 0)됐는지 재확인한다. PO가 등록 시점을 알려주면 그 +7일에
+재확인 요청 바람.

--- a/scripts/check-disk-usage.sh
+++ b/scripts/check-disk-usage.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# story #2659(2026-08-14) — 2026-08-14 fleet 전면 장애 사후 처방 ⓑ. 그날 실제로 100%까지 찬
+# 볼륨은 `/`가 아니라 `/System/Volumes/Data`였다(macOS APFS 컨테이너 — `/`는 읽기전용 시스템
+# 볼륨이라 용량이 안 참다). 이 스크립트는 «탐지만» 한다 — 어디로 경보를 보낼지(Discord/Sprintable
+# 이벤트/기타)는 머신 레벨 배선(cron 등록 포함) 담당인 PO 쪽 스코프. 이 스크립트는 그 배선이
+# 파이프로 소비할 수 있게 종료코드+JSON 한 줄로만 결과를 낸다.
+#
+# 종료코드: 0=정상  2=임계 초과(경보 트리거)  1=측정 실패(df 파싱 불가 등 — 이것도 자체로
+#   이상신호이니 조용히 삼키지 않는다).
+#
+# 사용법:
+#   scripts/check-disk-usage.sh                    # 기본 90% 임계, /System/Volumes/Data(macOS)
+#   scripts/check-disk-usage.sh --threshold 85
+#   scripts/check-disk-usage.sh --mount /
+#
+# 오늘 사고 재현(AC2 "실측"): 사고 당시 `df -h /System/Volumes/Data` = 926Gi 중 900Gi 사용
+#   (100%, 여유 117Mi) — 이 스크립트를 그 수치로 되돌려 넣으면(아래 --self-test) alert=true를
+#   낸다. 실측 스모크는 check-disk-usage.test.sh 참고.
+
+set -euo pipefail
+
+THRESHOLD=90
+MOUNT="/System/Volumes/Data"
+SELF_TEST_PERCENT=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --threshold) THRESHOLD="$2"; shift 2 ;;
+    --mount) MOUNT="$2"; shift 2 ;;
+    --self-test-percent) SELF_TEST_PERCENT="$2"; shift 2 ;; # 테스트 전용 — df 우회, 고정 % 주입.
+    *) echo "unknown arg: $1" >&2; exit 64 ;;
+  esac
+done
+
+if [ -n "$SELF_TEST_PERCENT" ]; then
+  USED_PERCENT="$SELF_TEST_PERCENT"
+else
+  # df -P(POSIX 출력형식 — 컬럼 줄바꿈 없음, macOS/Linux 공통) 마지막 줄의 Capacity(%) 컬럼.
+  DF_LINE="$(df -P "$MOUNT" 2>/dev/null | tail -n 1)" || { echo '{"error":"df failed"}' >&2; exit 1; }
+  if [ -z "$DF_LINE" ]; then
+    echo '{"error":"no df output for mount '"$MOUNT"'"}' >&2
+    exit 1
+  fi
+  USED_PERCENT="$(printf '%s' "$DF_LINE" | awk '{print $5}' | tr -d '%')"
+fi
+
+if ! [ "$USED_PERCENT" -eq "$USED_PERCENT" ] 2>/dev/null; then
+  echo '{"error":"could not parse usage percent","raw":"'"${DF_LINE:-}"'"}' >&2
+  exit 1
+fi
+
+ALERT=false
+if [ "$USED_PERCENT" -ge "$THRESHOLD" ]; then
+  ALERT=true
+fi
+
+printf '{"mount":"%s","used_percent":%d,"threshold":%d,"alert":%s}\n' \
+  "$MOUNT" "$USED_PERCENT" "$THRESHOLD" "$ALERT"
+
+if [ "$ALERT" = true ]; then
+  exit 2
+fi
+exit 0

--- a/scripts/check-disk-usage.test.sh
+++ b/scripts/check-disk-usage.test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# story #2659 AC2 — check-disk-usage.sh가 오늘 사고 수치(100%, /System/Volumes/Data)로 실제
+# alert=true·exit 2를 내는지, 그리고 정상/경계값에서 조용한지 실행 결과로 잰다.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-disk-usage.sh"
+
+FAIL=0
+check() {
+  local label="$1" expect_exit="$2"; shift 2
+  local out
+  out="$("$@" 2>&1)"
+  local actual_exit=$?
+  if [ "$actual_exit" -eq "$expect_exit" ]; then
+    echo "  ok   $label (exit=$actual_exit) — $out"
+  else
+    echo "  FAIL $label — expected exit $expect_exit, got $actual_exit — $out"
+    FAIL=1
+  fi
+}
+
+echo "== check-disk-usage.sh =="
+# 오늘 사고 재현 — 917/926 = 100%(반올림) 시나리오, 기본 임계 90.
+check "사고 재현(100% 사용) → alert" 2 "$SCRIPT" --self-test-percent 100
+# 사고 진행 중 관측된 87% 지점(아직 90% 미만) → 조용해야 정상.
+check "87% 사용(임계 90 미만) → 조용" 0 "$SCRIPT" --self-test-percent 87 --threshold 90
+# 정확히 임계값 → 경보(>= 기준, 오늘처럼 "딱 그 순간"을 놓치지 않게).
+check "정확히 임계값(90%) → alert" 2 "$SCRIPT" --self-test-percent 90 --threshold 90
+# 커스텀 임계값도 존중되는지.
+check "커스텀 임계 85%에서 86% → alert" 2 "$SCRIPT" --self-test-percent 86 --threshold 85
+check "커스텀 임계 85%에서 84% → 조용" 0 "$SCRIPT" --self-test-percent 84 --threshold 85
+# 실제 df 경로(이 머신의 현재 상태) — exit 0 또는 2만 나오면 정상(파싱 실패인 exit 1이면 버그).
+out="$("$SCRIPT" 2>&1)"; ec=$?
+if [ "$ec" -eq 0 ] || [ "$ec" -eq 2 ]; then
+  echo "  ok   실 df 경로(현재 머신) 파싱 성공 — $out"
+else
+  echo "  FAIL 실 df 경로 파싱 실패(exit=$ec) — $out"
+  FAIL=1
+fi
+
+echo
+if [ "$FAIL" -eq 0 ]; then echo "ALL PASS"; exit 0; else echo "FAILURES ABOVE"; exit 1; fi

--- a/scripts/reclaim-merged-worktrees.sh
+++ b/scripts/reclaim-merged-worktrees.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# story #2659(2026-08-14) — 2026-08-14 fleet 전면 장애(공유 Data 볼륨 926Gi 100%) 사후 처방.
+#
+# 원인: 각 에이전트가 스토리마다 `git worktree add`로 격리 작업공간을 만들고(feedback-fresh
+# -worktree-per-story 규율) `pnpm install`로 수백MB~GB의 node_modules를 채우는데, 머지 확定
+# 후에도 그 worktree를 지우는 규율이 코드로 강제돼 있지 않았다 — "만든 쪽이 지운다"가 사람
+# 기억에만 의존해 200개 넘게 쌓였다.
+#
+# 이 스크립트가 하는 일: 이미 머지·push 완료된(=더는 필요 없는) worktree만 골라 자동 회수한다.
+#
+# ⛔이 스크립트가 «절대 하지 않는» 것(안전 경계):
+#   - dirty(커밋 안 된 변경 — 추적/미추적 불문) worktree는 절대 안 지운다.
+#   - HEAD가 origin에 안 실린(push 안 된) worktree는 절대 안 지운다.
+#   - 머지 확定(develop 조상 관계 OR merged PR)이 확인 안 되면 절대 안 지운다.
+#   - 브랜치 자체는 안 지운다(worktree 디렉토리만 — node_modules가 진짜 용량범인이라 이거면
+#     충분하고, 브랜치 삭제는 별도 판단 영역이라 이 스크립트 책임 밖).
+#
+# ⚠️오늘 실물로 걸린 함정 — «--branches 오스코프»: `git worktree list --branches` 같은 필터는
+#   이 스크립트가 신뢰하는 안전기준이 아니다. 반드시 `git worktree list --porcelain`으로 각
+#   worktree의 실제 HEAD sha를 얻어 «그 sha 자체»가 origin에 실렸는지(`git branch -r --contains
+#   <sha>`) 확인한다 — 브랜치 이름이 같아도 로컬 HEAD가 origin보다 앞서 있으면(unpushed commit)
+#   그 사실을 브랜치 존재 여부만으로는 못 잡는다.
+#
+# ⚠️squash-merge 함정 — `git merge-base --is-ancestor <branch> origin/develop`만으로는 GitHub
+#   squash-merge된 브랜치를 UNMERGED로 오판한다(실측: feature/1cb4ef97-goal-form·
+#   feature/5a9766eb-loop-board-ui 둘 다 `gh pr list --state merged`로는 MERGED인데
+#   ancestor-check는 UNMERGED로 나옴 — merge-base 커밋 그래프에 없기 때문). 그래서 이 스크립트는
+#   ancestor-check «또는» `gh pr list --state merged --head <branch>` 둘 중 하나라도 참이면
+#   머지로 인정한다(OR 조건 — 어느 한쪽만 신뢰하지 않는다).
+#
+# 사용법:
+#   scripts/reclaim-merged-worktrees.sh              # dry-run(기본) — 무엇을 지울지만 보고
+#   scripts/reclaim-merged-worktrees.sh --apply       # 실제 삭제
+#   scripts/reclaim-merged-worktrees.sh --apply --json  # 기계가 읽을 요약(JSON 한 줄)도 출력
+#
+# 환경변수:
+#   RECLAIM_BASE_BRANCH   기본 develop — 머지 판정 기준 브랜치(origin/<이 값>).
+#   RECLAIM_GH_TIMEOUT    기본 10(초) — gh pr list 1건당 타임아웃. gh 미설치/미인증이면
+#                          이 단계를 건너뛰고 ancestor-check만 쓴다(과소회수 방향 — 안전 우선).
+
+set -euo pipefail
+
+APPLY=false
+JSON_OUT=false
+for arg in "$@"; do
+  case "$arg" in
+    --apply) APPLY=true ;;
+    --json) JSON_OUT=true ;;
+    *) echo "unknown arg: $arg" >&2; exit 64 ;;
+  esac
+done
+
+BASE_BRANCH="${RECLAIM_BASE_BRANCH:-develop}"
+GH_TIMEOUT="${RECLAIM_GH_TIMEOUT:-10}"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+git fetch origin "$BASE_BRANCH" --quiet 2>/dev/null || {
+  echo "⚠️  origin/$BASE_BRANCH fetch 실패 — 네트워크 확인. 안전을 위해 중단한다." >&2
+  exit 1
+}
+
+HAS_GH=false
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  HAS_GH=true
+fi
+
+# macOS 기본 유저랜드엔 GNU coreutils `timeout`이 없다(실측: 이 스크립트 첫 버전이 바로 이걸로
+# gh 체크가 전부 조용히 무력화됐었다 — `timeout: command not found`가 non-zero exit이라
+# is_pr_merged가 매번 "미확인"으로 새서, 정작 검증하려던 squash-merge 케이스가 통째로 안 잡힘).
+# timeout/gtimeout(brew coreutils) 있으면 쓰고, 없으면 무제한으로 그냥 부른다 — gh CLI 자체
+# HTTP 타임아웃이 있어 무한hang 위험은 낮지만 0은 아님(알려진 트레이드오프로 남긴다).
+TIMEOUT_BIN=""
+if command -v timeout >/dev/null 2>&1; then TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then TIMEOUT_BIN="gtimeout"
+fi
+
+# gh pr list 결과를 캐시(같은 브랜치를 여러 worktree가 공유할 일은 드물지만, 반복 조회 비용 방지).
+declare -A GH_MERGED_CACHE
+
+is_pr_merged() {
+  local branch="$1"
+  if [ "$HAS_GH" != true ]; then return 1; fi
+  if [ -n "${GH_MERGED_CACHE[$branch]+x}" ]; then
+    [ "${GH_MERGED_CACHE[$branch]}" = "1" ]
+    return $?
+  fi
+  local result
+  local ok=false
+  if [ -n "$TIMEOUT_BIN" ]; then
+    if result=$("$TIMEOUT_BIN" "$GH_TIMEOUT" gh pr list --state merged --head "$branch" --json number --jq 'length' 2>/dev/null); then ok=true; fi
+  else
+    if result=$(gh pr list --state merged --head "$branch" --json number --jq 'length' 2>/dev/null); then ok=true; fi
+  fi
+  if [ "$ok" = true ] && [ "${result:-0}" -gt 0 ] 2>/dev/null; then
+    GH_MERGED_CACHE[$branch]="1"; return 0
+  fi
+  GH_MERGED_CACHE[$branch]="0"; return 1
+}
+
+is_head_pushed() {
+  local sha="$1"
+  [ -n "$(git branch -r --contains "$sha" 2>/dev/null)" ]
+}
+
+is_ancestor_of_base() {
+  local sha="$1"
+  git merge-base --is-ancestor "$sha" "origin/$BASE_BRANCH" 2>/dev/null
+}
+
+is_worktree_clean() {
+  local path="$1"
+  [ -z "$(git -C "$path" status --porcelain 2>/dev/null)" ]
+}
+
+MAIN_WORKTREE="$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+
+RECLAIMED=()
+KEPT=()
+
+# git worktree list --porcelain: "worktree <path>" / "HEAD <sha>" / "branch refs/heads/<name>"
+# (또는 "detached") 블록이 빈 줄로 구분된다. macOS 기본 awk는 다중문자 RS를 신뢰할 수 없게
+# 다뤄서(레코드 사이 구분자가 씹히는 실측 버그) awk RS 트릭 대신 순수 bash 라인 파서로 각
+# 블록을 누적·빈 줄에서 flush한다 — 이식성 우선.
+process_worktree_record() {
+  local wt_path="$1" wt_sha="$2" wt_branch_ref="$3"
+  [ -z "$wt_path" ] && return
+  [ "$wt_path" = "$MAIN_WORKTREE" ] && return
+
+  if [ ! -d "$wt_path" ]; then
+    return # prunable(이미 디스크에서 사라짐) — git worktree prune 몫, 이 스크립트 책임 밖.
+  fi
+
+  local branch="${wt_branch_ref#refs/heads/}"
+
+  if [ -z "$wt_branch_ref" ]; then
+    KEPT+=("$wt_path|detached HEAD — 수동 확인 필요")
+    return
+  fi
+
+  if ! is_worktree_clean "$wt_path"; then
+    KEPT+=("$wt_path|dirty(커밋 안 된 변경 존재)")
+    return
+  fi
+
+  if ! is_head_pushed "$wt_sha"; then
+    KEPT+=("$wt_path|HEAD($wt_sha) push 안 됨 — 로컬 유일 산출물일 수 있음")
+    return
+  fi
+
+  local merged=false
+  local merge_reason=""
+  if is_ancestor_of_base "$wt_sha"; then
+    merged=true; merge_reason="origin/$BASE_BRANCH 조상"
+  elif is_pr_merged "$branch"; then
+    merged=true; merge_reason="gh pr merged(squash 포함)"
+  fi
+
+  if [ "$merged" != true ]; then
+    KEPT+=("$wt_path|미머지([$branch] ancestor 아님 + gh merged 아님)")
+    return
+  fi
+
+  RECLAIMED+=("$wt_path|$branch|$merge_reason")
+}
+
+cur_path=""; cur_sha=""; cur_branch=""
+while IFS= read -r line; do
+  if [ -z "$line" ]; then
+    process_worktree_record "$cur_path" "$cur_sha" "$cur_branch"
+    cur_path=""; cur_sha=""; cur_branch=""
+    continue
+  fi
+  case "$line" in
+    "worktree "*) cur_path="${line#worktree }" ;;
+    "HEAD "*) cur_sha="${line#HEAD }" ;;
+    "branch "*) cur_branch="${line#branch }" ;;
+  esac
+done < <(git worktree list --porcelain; printf '\n') # 트레일링 빈줄로 마지막 블록도 flush 보장
+
+echo "== reclaim-merged-worktrees $( [ "$APPLY" = true ] && echo "(APPLY)" || echo "(dry-run)") — base=origin/$BASE_BRANCH gh=$HAS_GH =="
+
+for entry in "${KEPT[@]}"; do
+  path="${entry%%|*}"; reason="${entry#*|}"
+  echo "  KEEP     $path — $reason"
+done
+
+for entry in "${RECLAIMED[@]}"; do
+  IFS='|' read -r path branch reason <<< "$entry"
+  if [ "$APPLY" = true ]; then
+    # AC3 — 일회 docker 컨테이너/볼륨이 worktree 회수 후에도 잔존하지 않게: 이 worktree에
+    # docker-compose.yml이 있으면(실측: .qa-worktrees/* 391개 전부 해당 — Docker.raw 149G
+    # 누적의 실체) worktree 삭제 «전에» 먼저 내린다. docker 데몬이 죽어있거나 이미 안 떠 있는
+    # 스택이면 실패해도 무시(best-effort — worktree 회수 자체를 막지 않는다).
+    if [ -f "$path/docker-compose.yml" ] && command -v docker >/dev/null 2>&1; then
+      (cd "$path" && docker compose down --volumes --remove-orphans) >/dev/null 2>&1 || true
+    fi
+    if git worktree remove "$path" 2>/tmp/reclaim-worktree-err.$$; then
+      echo "  RECLAIMED $path [$branch] — $reason"
+    else
+      echo "  FAILED   $path [$branch] — git worktree remove 실패: $(cat /tmp/reclaim-worktree-err.$$)"
+      rm -f /tmp/reclaim-worktree-err.$$
+    fi
+  else
+    echo "  WOULD-RECLAIM $path [$branch] — $reason"
+  fi
+done
+
+if [ "$JSON_OUT" = true ]; then
+  printf '{"apply":%s,"kept":%d,"reclaimed":%d}\n' "$APPLY" "${#KEPT[@]}" "${#RECLAIMED[@]}"
+fi

--- a/scripts/reclaim-merged-worktrees.test.sh
+++ b/scripts/reclaim-merged-worktrees.test.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# story #2659 AC1+AC4 — reclaim-merged-worktrees.sh 안전검사 실측 스모크테스트.
+# 진짜 sprintable 레포를 건드리지 않고 /tmp에 던지는 합성(synthetic) git 원격+worktree
+# 시나리오로 KEEP/RECLAIM 판정을 잰다. AC4(과잉살상 음성대조)의 «절대 안 지워짐» 요구를
+# narrative가 아니라 실행 결과로 고정한다.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/reclaim-merged-worktrees.sh"
+
+WORK="$(mktemp -d)"
+WORK="$(cd "$WORK" && pwd -P)" # macOS: /var → /private/var 심볼릭 링크. git이 리포트하는 실제
+                                # worktree 경로는 이미 resolve된 형태라 $WORK도 맞춰야 문자열이 맞는다.
+trap 'rm -rf "$WORK"' EXIT
+
+FAIL=0
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  ok   $label"
+  else
+    echo "  FAIL $label — expected to find: $needle"
+    FAIL=1
+  fi
+}
+assert_exists() {
+  [ -d "$1" ] && echo "  ok   $2 (still exists)" || { echo "  FAIL $2 (should still exist, got removed!)"; FAIL=1; }
+}
+assert_not_exists() {
+  [ ! -d "$1" ] && echo "  ok   $2 (reclaimed)" || { echo "  FAIL $2 (should have been removed, still exists)"; FAIL=1; }
+}
+
+# ── 합성 origin + main 체크아웃 준비 ────────────────────────────────────────
+ORIGIN="$WORK/origin.git"
+git init --bare -q "$ORIGIN"
+
+MAIN="$WORK/main"
+git clone -q "$ORIGIN" "$MAIN"
+git -C "$MAIN" config user.email "test@example.com"
+git -C "$MAIN" config user.name "test"
+git -C "$MAIN" checkout -q -b develop
+echo "root" > "$MAIN/f.txt"
+git -C "$MAIN" add f.txt
+git -C "$MAIN" commit -q -m "root"
+git -C "$MAIN" push -q -u origin develop
+
+# 실제 스크립트가 origin에서 안전 판정에 쓰는 '가짜 gh' — GitHub 없이도 squash-merge
+# 경로(merge-base ancestor가 아니지만 실제로는 PR이 merged)를 재현한다.
+FAKE_BIN="$WORK/bin"
+mkdir -p "$FAKE_BIN"
+cat > "$FAKE_BIN/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then exit 0; fi
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  # --head 뒤 인자로 브랜치명을 받아, squash-merged-branch 만 merged로 응답한다.
+  branch=""
+  prev=""
+  for a in "$@"; do
+    if [ "$prev" = "--head" ]; then branch="$a"; fi
+    prev="$a"
+  done
+  if [ "$branch" = "squash-merged-branch" ]; then echo 1; else echo 0; fi
+  exit 0
+fi
+exit 1
+GHSTUB
+chmod +x "$FAKE_BIN/gh"
+export PATH="$FAKE_BIN:$PATH"
+
+wt() { echo "$WORK/wt-$1"; }
+
+# 1) MERGED(ancestor) — develop에 fast-forward로 실제 merge된 브랜치, push 완료, clean.
+git -C "$MAIN" checkout -q -b ancestor-merged-branch
+echo "a" >> "$MAIN/f.txt"; git -C "$MAIN" commit -q -am "a"
+git -C "$MAIN" checkout -q develop
+git -C "$MAIN" merge -q --no-ff ancestor-merged-branch -m "merge a"
+git -C "$MAIN" push -q origin develop
+git -C "$MAIN" push -q origin ancestor-merged-branch
+git -C "$MAIN" worktree add -q "$(wt ancestor-merged)" ancestor-merged-branch
+
+# 2) MERGED(squash — gh만 안다, merge-base ancestor 아님) — develop에 별도 커밋으로 흡수됐다고
+#    가정(squash-merge 시뮬레이션: 브랜치 자체는 develop 조상관계가 아님).
+git -C "$MAIN" checkout -q -b squash-merged-branch
+echo "b" >> "$MAIN/f.txt"; git -C "$MAIN" commit -q -am "b (will be squashed)"
+git -C "$MAIN" push -q origin squash-merged-branch
+git -C "$MAIN" checkout -q develop
+git -C "$MAIN" worktree add -q "$(wt squash-merged)" squash-merged-branch
+
+# 3) DIRTY — 커밋 안 된 변경이 있으면 그 자체로 즉시 KEEP(머지/push 상태와 무관하게 최우선
+#    안전검사). 별도 로컬 브랜치로 떠서 worktree #1(ancestor-merged-branch)과 브랜치 충돌 없게.
+git -C "$MAIN" worktree add -q -b dirty-branch "$(wt dirty)" ancestor-merged-branch
+echo "uncommitted" >> "$(wt dirty)/f.txt"
+
+# 4) UNPUSHED HEAD — 로컬에서 한 커밋 더 나갔지만 origin엔 없다(로컬 유일 산출물).
+git -C "$MAIN" checkout -q -b unpushed-branch
+echo "c" >> "$MAIN/f.txt"; git -C "$MAIN" commit -q -am "c"
+git -C "$MAIN" push -q origin unpushed-branch
+git -C "$MAIN" checkout -q develop
+git -C "$MAIN" worktree add -q "$(wt unpushed)" unpushed-branch
+echo "d local only" >> "$(wt unpushed)/f.txt"
+git -C "$(wt unpushed)" commit -q -am "d (never pushed)"
+
+# 5) UNMERGED(그냥 진행중) — push는 됐지만 develop에도 안 들어갔고 gh도 모른다.
+git -C "$MAIN" checkout -q -b unmerged-branch
+echo "e" >> "$MAIN/f.txt"; git -C "$MAIN" commit -q -am "e"
+git -C "$MAIN" push -q origin unmerged-branch
+git -C "$MAIN" checkout -q develop
+git -C "$MAIN" worktree add -q "$(wt unmerged)" unmerged-branch
+
+echo "== dry-run =="
+cd "$MAIN"
+DRY_OUT="$(RECLAIM_BASE_BRANCH=develop "$SCRIPT")"
+echo "$DRY_OUT"
+
+echo
+echo "-- dry-run 판정 검증 --"
+assert_contains "$DRY_OUT" "WOULD-RECLAIM $(wt ancestor-merged)" "ancestor-merged → WOULD-RECLAIM"
+assert_contains "$DRY_OUT" "WOULD-RECLAIM $(wt squash-merged)" "squash-merged(gh만 앎) → WOULD-RECLAIM"
+assert_contains "$DRY_OUT" "KEEP     $(wt dirty)" "dirty → KEEP"
+assert_contains "$DRY_OUT" "KEEP     $(wt unpushed)" "unpushed HEAD → KEEP"
+assert_contains "$DRY_OUT" "KEEP     $(wt unmerged)" "unmerged → KEEP"
+
+echo
+echo "== --apply =="
+APPLY_OUT="$(RECLAIM_BASE_BRANCH=develop "$SCRIPT" --apply)"
+echo "$APPLY_OUT"
+
+echo
+echo "-- 실제 디스크 상태 검증(AC4 음성대조: 진행중 worktree는 절대 안 지워짐) --"
+assert_not_exists "$(wt ancestor-merged)" "ancestor-merged"
+assert_not_exists "$(wt squash-merged)" "squash-merged"
+assert_exists "$(wt dirty)" "dirty"
+assert_exists "$(wt unpushed)" "unpushed"
+assert_exists "$(wt unmerged)" "unmerged"
+
+echo
+if [ "$FAIL" -eq 0 ]; then
+  echo "ALL PASS"
+  exit 0
+else
+  echo "FAILURES ABOVE"
+  exit 1
+fi


### PR DESCRIPTION
## 배경
2026-08-14 fleet 전면 장애(공유 Data 볼륨 926Gi 100%, 여유 117Mi — 전 에이전트 Bash 불능) 사후 처방. 오너십 분할(PO 판정, conv 32b8cff9): 스크립트 설계+구현=미르코, cron/launchd 등록(머신 레벨 배선)=PO.

## 변경 사항
- **`scripts/reclaim-merged-worktrees.sh`**: 머지 확定+push 완료+clean(무커밋 잔여 0)인 worktree만 안전 회수(디렉토리만, 브랜치는 안 지움). dry-run 기본, `--apply`로 실제 삭제.
  - HEAD sha 자체가 origin에 push됐는지 확인(브랜치 존재가 아니라 그 커밋이 실렸는지 — 오늘 PO가 `--branches` 오스코프로 걸린 함정과 동급 실수를 코드로 봉쇄)
  - 머지 판정 = `origin/develop` 조상관계 **OR** `gh pr list --state merged` (squash-merge 함정 실측 확인: `feature/1cb4ef97-goal-form`·`feature/5a9766eb-loop-board-ui` 둘 다 GitHub상 MERGED인데 `merge-base --is-ancestor`만으로는 UNMERGED 오판)
  - AC3: `--apply` 시 `docker-compose.yml` 있는 worktree는 삭제 전 `docker compose down --volumes --remove-orphans` 동반 — 실측으로 `.qa-worktrees/*` **391개**가 전부 docker-compose 동반(Docker.raw 149G 누적의 실체 발견)
- **`scripts/check-disk-usage.sh`**: Data 볼륨 사용률 임계(기본 90%) 감지, JSON+exit code로 cron 래퍼가 소비. 오늘 사고 수치(100%)로 self-test 재현.
- 테스트 2종: `/tmp` 합성 git 원격+worktree로 5개 시나리오(ancestor-merged/squash-merged/dirty/unpushed/unmerged) 실행 검증 — AC1+AC4(과잉살상 음성대조) narrative 아닌 실측.
- `scripts/RECLAIM-README.md`: 사용법+오너십 분할+배선 전 권장순서+AC5 재확인 시점(cron 등록 +7일) 명시.

## AC 대조
1. ✅ 머지 확定 worktree 무인 회수 — 안전검사(무커밋 0 + HEAD-scope push 확인) 스크립트로 구현+테스트
2. ✅ 디스크 임계 초과 감지(경보 전달 자체는 cron 배선 쪽 — 스크립트는 탐지+구조화 출력까지)
3. ✅ docker-compose 잔존 방지 — `--apply` 시 동반 `down --volumes`
4. ✅ 과잉살상 음성대조 — dirty/unpushed/unmerged 3종 전부 "절대 안 지워짐" 실행 결과로 확인
5. ✅ 재확인 시점 명시 — README에 "cron 등록 +7일" 고정

## 검증
- `bash scripts/reclaim-merged-worktrees.test.sh`: 5/5 pass
- `bash scripts/check-disk-usage.test.sh`: 6/6 pass
- `bash -n` 양쪽 스크립트 문법 클린
- 이 PR은 셸 스크립트만 추가라 `apps/web` 빌드/타입체크/린트 영향 없음(경로 밖)

## Test plan
- [x] 두 테스트 스크립트 green
- [x] macOS 타임아웃/경로 호환성 버그 2건 실측 발견+수정(timeout 미탑재, /var symlink)
- [ ] PO: 실 레포에 dry-run 1회 수동 확인 후 cron 등록(README 권장 순서)