### PR TITLE
[SID:2659] SIGPIPE at real scale — fix MAIN_WORKTREE awk early-exit

### DIFF
--- a/scripts/reclaim-merged-worktrees.sh
+++ b/scripts/reclaim-merged-worktrees.sh
@@ -114,7 +114,16 @@ is_worktree_clean() {
   [ -z "$(git -C "$path" status --porcelain 2>/dev/null)" ]
 }
 
-MAIN_WORKTREE="$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+# ⚠️실 스케일 함정(PO 첫 dry-run 실물 발견, 등록 worktree 264개 레포) — 여기 예전에
+# `awk '/^worktree /{print $2; exit}'`을 썼다. awk가 첫 매치에서 exit(0)하면 read
+# end가 즉시 닫히는데, git worktree list --porcelain 출력이 파이프 버퍼(보통 64KB)를
+# 넘는 실 스케일에서는 그 시점에 git이 아직 쓰는 중이라 SIGPIPE(141)를 맞고,
+# `set -euo pipefail`이 그걸 그대로 스크립트 전체 중단으로 전파했다 — exit=141,
+# 출력 0줄. 합성 테스트(worktree 몇 개=출력이 버퍼 안)에선 구조적으로 재현이
+# 안 된다(회귀가드는 reclaim-merged-worktrees.test.sh의 스트레스 시나리오 참고).
+# 고침: awk가 exit하지 않고 입력을 끝까지 그냥 다 읽게(첫 매치만 «출력»하고 계속
+# 읽기만 함) — git 쪽 write end가 스스로 EOF까지 안전하게 끝나게 둔다.
+MAIN_WORKTREE="$(git worktree list --porcelain | awk '/^worktree /{if(!f){print $2;f=1}}')"
 
 RECLAIMED=()
 KEPT=()

--- a/scripts/reclaim-merged-worktrees.test.sh
+++ b/scripts/reclaim-merged-worktrees.test.sh
@@ -134,6 +134,48 @@ assert_exists "$(wt unpushed)" "unpushed"
 assert_exists "$(wt unmerged)" "unmerged"
 
 echo
+echo "== 실 스케일 SIGPIPE 회귀가드(PO 첫 dry-run 실물 발견, 등록 264개 레포에서 exit=141) =="
+# 파이프 버퍼(보통 64KB)를 넘는 `git worktree list --porcelain` 출력을 만들어야 재현된다 —
+# 합성 시나리오 5개(worktree 소수)로는 구조적으로 못 잡는다. detached worktree는 브랜치
+# 배타성이 없어(같은 커밋을 여러 worktree가 동시에 가리켜도 됨) 빠르게 대량 생성 가능.
+STRESS_COUNT=450
+for i in $(seq 1 "$STRESS_COUNT"); do
+  git -C "$MAIN" worktree add -q --detach "$WORK/stress-$i" develop >/dev/null 2>&1
+done
+
+STRESS_PORCELAIN_BYTES="$(git -C "$MAIN" worktree list --porcelain | wc -c | tr -d ' ')"
+echo "  porcelain 출력 크기: ${STRESS_PORCELAIN_BYTES} bytes(생성 ${STRESS_COUNT}개, 목표 >65536)"
+
+if STRESS_OUT="$(cd "$MAIN" && RECLAIM_BASE_BRANCH=develop "$SCRIPT" 2>&1)"; then
+  STRESS_EC=0
+else
+  STRESS_EC=$?
+fi
+
+if [ "$STRESS_EC" -eq 0 ]; then
+  echo "  ok   대량 worktree(${STRESS_COUNT}개, ${STRESS_PORCELAIN_BYTES}B) dry-run이 SIGPIPE 없이 완주(exit=0)"
+else
+  echo "  FAIL 대량 worktree dry-run이 exit=${STRESS_EC}로 죽었다(141=SIGPIPE 재발)"
+  echo "$STRESS_OUT" | head -5
+  FAIL=1
+fi
+
+if [[ "$STRESS_OUT" != *"KEEP     $MAIN"* ]] && [[ "$STRESS_OUT" != *"WOULD-RECLAIM $MAIN"* ]]; then
+  echo "  ok   MAIN_WORKTREE($MAIN) 자신은 KEEP/RECLAIM 목록에 안 나타난다(자기 자신 제외 로직 건재)"
+else
+  echo "  FAIL MAIN_WORKTREE가 회수 후보 목록에 나타났다 — 자기 자신 삭제 위험"
+  FAIL=1
+fi
+
+DETACHED_COUNT="$(printf '%s\n' "$STRESS_OUT" | grep -c "detached HEAD" || true)"
+if [ "$DETACHED_COUNT" -ge "$STRESS_COUNT" ]; then
+  echo "  ok   detached worktree ${DETACHED_COUNT}개 전부 KEEP(수동확인) 분류됨"
+else
+  echo "  FAIL detached worktree가 ${DETACHED_COUNT}개만 KEEP으로 잡혔다(기대 >= ${STRESS_COUNT} — 파싱 누락 의심)"
+  FAIL=1
+fi
+
+echo
 if [ "$FAIL" -eq 0 ]; then
   echo "ALL PASS"
   exit 0


### PR DESCRIPTION
## 배경
PO가 머지된 #3061을 실 sprintable 레포(등록 worktree 264개)에 첫 dry-run으로 돌려 실물 결함을 잡았음(conv 32b8cff9) — CI/합성테스트 어느 쪽도 이 규모가 아니면 구조적으로 못 잡는 클래스였다.

## 근본 원인
```sh
MAIN_WORKTREE="$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
```
awk가 첫 매치에서 `exit`하면 read end가 즉시 닫힌다. `git worktree list --porcelain` 출력이 파이프 버퍼(보통 64KB)를 넘는 실 스케일에서는 그 시점에 git이 아직 쓰는 중이라 SIGPIPE(141)를 맞고, `set -euo pipefail`이 그걸 그대로 스크립트 전체 중단으로 전파 — exit=141, 출력 0줄. 합성 테스트(worktree 몇 개=출력이 버퍼 안)에선 구조적으로 재현 불가능한 클래스.

## 수정
awk가 `exit`하지 않고 입력을 끝까지 그냥 다 읽게(첫 매치만 「출력」하고 계속 읽기만 함) — git 쪽 write end가 스스로 EOF까지 안전하게 끝나게 둔다.
```sh
MAIN_WORKTREE="$(git worktree list --porcelain | awk '/^worktree /{if(!f){print $2;f=1}}')"
```

같은 「early-exit consumer가 큰 파이프 상류를 SIGPIPE로 죽이는」패턴이 다른 자리에 또 있는지 두 스크립트 전체 grep — 없음 확인(`check-disk-usage.sh`의 `df | tail -n 1`은 출력이 몇백 바이트뿐이라 이 결함 클래스에 노출 안 됨).

## 회귀가드 — 실 스케일 재현
`reclaim-merged-worktrees.test.sh`에 스트레스 시나리오 추가: detached worktree 450개 생성(브랜치 배타성 없어 빠르게 대량 생성 가능) → porcelain 출력 67167 bytes(64KB 라인 초과) → dry-run이 exit=0으로 완주하는지 확인.

- **수정 전 코드로 실행 → RED**: `exit=141`(SIGPIPE) 그대로 재현 확인, detached worktree 0개만 KEEP으로 잡힘(파싱이 통째로 안 됨)
- **수정 후 → GREEN**: exit=0, detached worktree 450개 전부 KEEP 분류, MAIN_WORKTREE 자기 자신 제외 로직도 건재

## 검증
- `bash scripts/reclaim-merged-worktrees.test.sh`: 8/8 pass(기존 5시나리오 + 신규 스트레스 3assertion)
- `bash scripts/check-disk-usage.test.sh`: 6/6 pass(무변경 확인)
- `bash -n` 양쪽 클린

## Test plan
- [x] 스트레스 테스트로 RED→GREEN 확인
- [x] 동형 패턴 grep 재발 방지 확인
- [ ] PO: 실 레포에서 재-dry-run 1회 재확인 후 cron 배선