### PR TITLE
fix(chat): GitHub repo-name#N 오승격 방지 — 레포명 허용목록 방식 (#2660)

### DIFF
--- a/backend/app/services/story_ref_promoter.py
+++ b/backend/app/services/story_ref_promoter.py
@@ -41,6 +41,24 @@ _LATIN_RE = re.compile(r"[A-Za-z]")
 # 확인되지 않았다: 그 형태는 애초에 `_BARE_STORY_REF_RE`가 `#`을 요구해 매치 자체가 없다.
 _PR_PREFIX_RE = re.compile(r"(?<![A-Za-z0-9_])[Pp][Rr]\s*$")
 
+# story #2660(#2651 후속) — GitHub 크로스레포 관례 "repo-name#N"(예: agent-plugins#25·
+# gemini#3)이 실피해로 재발(실측: 실제 원문은 `agent-plugins#25`·`gemini#3` — 백틱 無,
+# 카디르 05f52181 메시지 170c7b98, dev DB 조회 확인). 직전 토큰이 "PR"/"pr"이 아니라
+# 레포명류라 _PR_PREFIX_RE로는 안 걸린다.
+#
+# ⛔AC2 GROUP BY 양성대조(2026-08-14, dev conversation_messages 60일치 실측 —
+# pgstat-probe-dev job) 결과 «라틴 단어문자가 #N 직전에 붙는» 축을 통째로 막으면 안 된다는
+# 것이 확定됐다: "story#2588"(11건)·"BE#1839"/"FE#1840"(다수)류 정상 팀 표기가 같은
+# 표면(레터+#N, 공백 없음)을 쓴다 — 최초 설계(임의 라틴 단어문자/하이픈/점/언더스코어
+# 전부 제외)는 이 정상 표기까지 깨뜨리는 과잉 제외였다(#2629/#2651 선례의 "실측 우선"
+# 그대로 이 설계를 걷어냄). 대신 **이 조직이 실제 쓰는 레포 짧은 이름만** 등재 —
+# `INJECTABLE_EVENT_TYPES`(sprintable_sse.py)와 같은 성격의 닫힌 허용목록. 새 레포가
+# 생기면 이 목록에 추가할 것(자동 발견 불가 — 그 자체가 이 클래스의 한계, 가드가 못
+# 잡는 것으로 명시).
+_REPO_SHORTHAND_SUFFIX_RE = re.compile(
+    r"(?i:agent-plugins|gemini|admin|claude-plugin|mobile)$"
+)
+
 # 보호 구간(스캔에서 제외) — fenced 코드블록·인라인 코드·이미 만들어진 entity 토큰.
 _FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
 _INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
@@ -54,9 +72,12 @@ def extract_bare_story_ref_candidates(content: str) -> list[tuple[int, int, int]
     반환: (start, end, story_number) 튜플 리스트. 매치 직후 문자가 라틴 알파벳이면
     헥스 컬러류(`#74747c`)로 보고 그 후보 자체를 버린다(dev 실측 근거 — 모듈 docstring
     참조). 매치 직전 토큰이 「PR」/「pr」이면(story #2651) PR 번호로 보고 마찬가지로
-    버린다 — `_PR_PREFIX_RE` 참조. 코드블록/인라인코드/기존 entity 토큰 내부는 여기서
-    걸러지지 않는다 — 그건 `_protected_spans`가 별도로 처리(관심사 분리: 이 함수는
-    "무엇이 숫자 토큰처럼 생겼는가"만, 저건 "어디를 건드리면 안 되는가"만)."""
+    버린다 — `_PR_PREFIX_RE` 참조. 매치 직전이 알려진 레포 짧은이름 접미사로 끝나면
+    (story #2660) GitHub「repo-name#N」류로 보고 버린다 — `_REPO_SHORTHAND_SUFFIX_RE`
+    참조(⛔허용목록 방식 — "라틴 단어문자 전부"가 아니다. story#N/BE#N류 정상 팀 표기는
+    이 목록에 없어 계속 승격된다, #2660 GROUP BY 실측). 코드블록/인라인코드/기존 entity
+    토큰 내부는 여기서 걸러지지 않는다 — 그건 `_protected_spans`가 별도로 처리(관심사
+    분리: 이 함수는 "무엇이 숫자 토큰처럼 생겼는가"만, 저건 "어디를 건드리면 안 되는가"만)."""
     if not content:
         return []
     candidates: list[tuple[int, int, int]] = []
@@ -66,6 +87,8 @@ def extract_bare_story_ref_candidates(content: str) -> list[tuple[int, int, int]
         if end < len(content) and _LATIN_RE.match(content[end]):
             continue
         if _PR_PREFIX_RE.search(content, 0, start):
+            continue
+        if _REPO_SHORTHAND_SUFFIX_RE.search(content, 0, start):
             continue
         candidates.append((start, end, int(m.group(1))))
     return candidates

--- a/backend/tests/test_2629_bare_story_ref_promotion.py
+++ b/backend/tests/test_2629_bare_story_ref_promotion.py
@@ -116,6 +116,60 @@ def test_extract_bare_ref_pr_lookalike_word_not_excluded():
     assert [c[2] for c in cands] == [21]
 
 
+# ── story #2660(#2651 후속) — GitHub 「repo-name#N」 오승격 회귀 pin ────────────────
+def test_extract_bare_ref_repo_name_hash_excluded():
+    """실피해 문장 그대로(agent-plugins#25·gemini#3) — 레포명 직후 해시(공백 없음)는
+    GitHub 크로스레포 관례라 승격 제외."""
+    from app.services.story_ref_promoter import extract_bare_story_ref_candidates
+    assert extract_bare_story_ref_candidates("카디르 발신 「agent-plugins#25」") == []
+    assert extract_bare_story_ref_candidates("gemini#3 PR 확인 바라는") == []
+
+
+def test_extract_bare_ref_repo_shorthand_compound_prefix_excluded():
+    """`sprintable-`류 접두가 붙은 전체 레포명("sprintable-agent-plugins")도 접미사
+    매칭으로 같이 걸린다(하이픈 앞 토큰과 무관하게 "agent-plugins"로 끝나면 매치)."""
+    from app.services.story_ref_promoter import extract_bare_story_ref_candidates
+    assert extract_bare_story_ref_candidates("sprintable-agent-plugins#25 확인") == []
+    assert extract_bare_story_ref_candidates("sprintable-mobile#4 배포") == []
+    assert extract_bare_story_ref_candidates("sprintable-claude-plugin#1 확인") == []
+
+
+def test_extract_bare_ref_team_shorthand_hash_prefix_not_excluded():
+    """AC2 양성대조(GROUP BY 실측, story #2660) — 「story#N」/「BE#N」/「FE#N」류 팀 표기는
+    레포 짧은이름 허용목록에 없어 계속 승격된다(dev 60일 실측: story#N 11건·BE#N/FE#N
+    다수 확인 — 이 축을 깨는 설계는 #2629/#2651과 같은 "실측 없는 과잉 제외" 재발이었다,
+    최초 설계(임의 라틴 단어문자 전부 제외)에서 이 실측으로 걷어냄)."""
+    from app.services.story_ref_promoter import extract_bare_story_ref_candidates
+    assert [c[2] for c in extract_bare_story_ref_candidates("story#2588(As 이전")] == [2588]
+    assert [c[2] for c in extract_bare_story_ref_candidates("BE#1839 계약 확인")] == [1839]
+    assert [c[2] for c in extract_bare_story_ref_candidates("라이브 픽셀은 FE#1840+BE#1839 dep")] == [1840, 1839]
+
+
+def test_extract_bare_ref_unlisted_word_hash_prefix_not_excluded():
+    """허용목록에 없는 임의 라틴 단어("my_repo" 등)는 레포 짧은이름이 아니므로 승격
+    무회귀 — 허용목록 방식이 "라틴 단어문자 전부"가 아님을 명시적으로 고정."""
+    from app.services.story_ref_promoter import extract_bare_story_ref_candidates
+    assert [c[2] for c in extract_bare_story_ref_candidates("my_repo#7 이슈")] == [7]
+    assert [c[2] for c in extract_bare_story_ref_candidates("v1.2#3 릴리즈 노트")] == [3]
+
+
+def test_extract_bare_ref_korean_word_hash_prefix_not_excluded():
+    """양성대조 — 한글 단어가 «#N 앞»에 공백 없이 붙는 것은 GitHub repo-name 관례가
+    아니므로(그 관례는 라틴 식별자 문자셋뿐) 제외 대상이 아니다. 한글 조사는 원래
+    «#N 뒤»에 붙는 형태(모듈 docstring)이지만, 이 pin은 그 반대 방향(#N 앞)도 안전함을
+    명시적으로 고정한다."""
+    from app.services.story_ref_promoter import extract_bare_story_ref_candidates
+    cands = extract_bare_story_ref_candidates("확인#24 부탁")
+    assert [c[2] for c in cands] == [24]
+
+
+def test_extract_bare_ref_space_before_hash_still_promotes_no_regression():
+    """AC2 — 공백 하나만 있어도(레포명류가 아니라 진짜 단어 뒤 공백) 무회귀."""
+    from app.services.story_ref_promoter import extract_bare_story_ref_candidates
+    cands = extract_bare_story_ref_candidates("story #24 그리고 문서 #25")
+    assert [c[2] for c in cands] == [24, 25]
+
+
 # ── ② 보호 구간 ────────────────────────────────────────────────────────────────
 async def test_promote_skips_fenced_code_block():
     from app.services.story_ref_promoter import promote_bare_story_refs
@@ -406,6 +460,46 @@ async def test_send_message_pr_prefixed_number_not_promoted_no_false_reference()
                 )
             )).scalars().all()
             # AC3: 무관 스토리를 향한 거짓 참조가 적재되지 않았다
+            assert rows == []
+    finally:
+        await engine.dispose()
+
+
+async def test_send_message_repo_name_hash_not_promoted_no_false_reference():
+    """story #2660 AC1/AC3 — 「repo-name#N」(예: agent-plugins#25)은 승격되지 않고,
+    거짓 참조도 references 적재 레벨에서 0건이다(실피해 재현: 카디르 발신 메시지가
+    무관 스토리 3d740d8f/d99d4c20으로 오승격됐던 사고)."""
+    from fastapi import BackgroundTasks
+    from app.models.reference import Reference
+    from app.routers.conversations import SendMessageRequest, send_message
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org.id, project.id)
+            story = await _seed_story(s, org.id, project.id, number=25, title="무관 구스토리")
+            conv_id = await _seed_conversation(s, org.id, project.id, [agent_id], created_by=agent_id)
+
+        async with Session() as s:
+            result = await send_message(
+                conversation_id=conv_id,
+                body=SendMessageRequest(content="agent-plugins#25 QA 확인 바라는"),
+                background_tasks=BackgroundTasks(),
+                db=s, auth=_agent_auth(agent_id, org.id), org_id=org.id,
+            )
+            assert result["data"]["content"] == "agent-plugins#25 QA 확인 바라는"
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Reference).where(
+                    Reference.org_id == org.id,
+                    Reference.source_id == uuid.UUID(result["data"]["id"]),
+                    Reference.target_type == "story",
+                    Reference.target_id == story.id,
+                )
+            )).scalars().all()
             assert rows == []
     finally:
         await engine.dispose()


### PR DESCRIPTION
## Summary
#2651(「PR #N」 제외) 상륙 후에도 GitHub 크로스레포 shorthand(`agent-plugins#25`·`gemini#3`, 공백 없음)가 무관 스토리로 계속 오승격됐다. 직전 토큰이 「PR」이 아니라 레포명류라 #2651의 `_PR_PREFIX_RE`로는 안 걸림.

**실물 원문 확인** (dev DB 직접 조회, 카디르 메시지 170c7b98/5c40e47f): 원문은 백틱 無 순수 텍스트 `agent-plugins#25`·`gemini#3` — `_protected_spans`(인라인코드 보호)도 적용 안 됨. 진짜 코드 갭.

## ⚠️ 설계가 한 번 뒤집힌 이유 — AC2 실측이 최초 설계를 기각함
최초 설계는 "#N 직전에 공백 없이 라틴 단어문자/하이픈/점/언더스코어가 붙으면 전부 제외"였다. **PR을 열기 전** dev `conversation_messages` 60일치 GROUP BY 양성대조(pgstat-probe-dev job)를 돌린 결과:

- 레터-접두 `#N`(공백 없음) 2652건 중 2180건은 이미 `PR#N`(#2651이 처리) — 잔여 472건.
- 그 472건 중 **"story#2588"(11건)·"BE#1839"/"FE#1840"류 정상 팀 표기가 다수** — 최초 설계(임의 라틴 단어문자 전부 제외)를 그대로 적용했으면 이 정상 표기를 깨뜨렸을 것이다(#2629/#2651이 반복 경고한 "실측 없는 과잉 제외"의 세 번째 재발이 될 뻔함).
- 진짜 GitHub 레포명 패턴(`agent-plugins`·`gemini`·`admin`·`claude-plugin`·`sprintable-mobile`)만 걸러내는 **허용목록 방식**으로 재설계 — `INJECTABLE_EVENT_TYPES`(sprintable_sse.py)와 같은 성격의 닫힌 목록.

## AC
1. `agent-plugins#25`·`gemini#3` 등 레포 짧은이름 접미사 미승격 — 실피해 문장 그대로 pin
2. `story#N`/`BE#N`/`FE#N`류 정상 팀 표기 무회귀(GROUP BY 실측 양성대조) + 허용목록 밖 임의 단어(`my_repo#7` 등) 무회귀
3. 거짓 참조 미적재 — references 레벨 검증(`test_send_message_repo_name_hash_not_promoted_no_false_reference`)

## ⛔ 가드가 못 잡는 것 (명시 선언)
새 레포가 생기면(`sprintable-<new>`) `_REPO_SHORTHAND_SUFFIX_RE` 목록에 수동 추가 필요 — 자동 발견 불가.

## Test plan
- [x] 신규 pin 6종 + 기존 pin 전부 — regex 직접 실행 16/16 확인(순수 함수 레벨)
- [ ] **실PG 전체 스위트(async DB 테스트 포함) 미실행** — 로컬 docker daemon 장애(재기동 무반응)로 확인 못함. QA 단계에서 실PG 재확인 필요(#2651/#2655 선례와 동일 절차).

🤖 Generated with [Claude Code](https://claude.com/claude-code)