### PR TITLE
[SID:2552] 게이트 에러 폴백을 사람말로 — raw HTTP 상태코드 노출 제거

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3469,6 +3469,7 @@
     "gateInboxLoading": "Loading gates...",
     "gateInboxEmpty": "No pending gates",
     "gateInboxEmptyHint": "Gates awaiting your review will appear here",
+    "gateTransitionErrorGeneric": "Failed to process the gate. Please try again.",
     "gateRejectedHistory": "Recent rejection reasons",
     "voidAction": "Void",
     "voidConfirmTitle": "Void approval gate",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3469,6 +3469,7 @@
     "gateInboxLoading": "게이트 조회 중...",
     "gateInboxEmpty": "대기 중인 게이트 없음",
     "gateInboxEmptyHint": "검수 대기 중인 게이트가 여기 표시됩니다",
+    "gateTransitionErrorGeneric": "게이트 처리에 실패했습니다. 다시 시도해 주세요.",
     "gateRejectedHistory": "최근 반려 사유",
     "voidAction": "무효화",
     "voidConfirmTitle": "결재 무효화",

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
@@ -149,4 +149,27 @@ describe('GateDetailPage — transition 실패 사유 노출 (story #2500)', () 
     expect(container.textContent).not.toContain('HTTP 422');
     expect(container.textContent).toContain('고위험(risk_grade=high) 게이트 승인은 사유(note) 입력이 필수입니다.');
   });
+
+  // story #2552 — BE가 사람이 읽을 message를 안 주는 예외(네트워크·예상외 500 등)엔 raw
+  // "HTTP {status}"가 아니라 사람말 공통 폴백(gateTransitionErrorGeneric)을 보여준다.
+  it('BE가 message를 안 주면(500 등) raw "HTTP 500" 대신 사람말 폴백을 보여준다 (story #2552)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === '/api/gates/gate-1' && !init) return { ok: true, status: 200, json: async () => ({ data: gate({ can_approve: true, risk_grade: 'low' }) }) };
+      if (url === '/api/gates/gate-1/transition') {
+        return { ok: false, status: 500, json: async () => ({ data: null, error: null, meta: null }) };
+      }
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+    const { default: GateDetailPage } = await import('./page');
+    const { TopBarProvider } = await import('@/components/nav/top-bar-context');
+    await act(async () => { root.render(wrap(<GateDetailPage />, TopBarProvider)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    const approveBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes(koMessages.cage.gateApprove));
+    await act(async () => { approveBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).not.toContain('HTTP 500');
+    expect(container.textContent).toContain(koMessages.cage.gateTransitionErrorGeneric);
+  });
 });

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -126,12 +126,12 @@ export default function GateDetailPage() {
       // 평문 문자열이지만 handler가 error.message로 재포장한다, gates.py:885). 올바른
       // 필드로 교정 — #2027의 "고위험 승인 사유 필수" 문구가 실제로 화면에 뜨게 된다.
       const body = await res.json().catch(() => null) as { error?: { message?: string } } | null;
-      const reason = body?.error?.message ?? `HTTP ${res.status}`;
+      const reason = body?.error?.message ?? t('gateTransitionErrorGeneric');
       setTransitionError(reason);
     } finally {
       setResolving(false);
     }
-  }, [gate, router]);
+  }, [gate, router, t]);
 
   return (
     <>

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -144,7 +144,7 @@ export function ApprovalsQueue() {
         setResolvedGates((prev) => ({ ...prev, [id]: status }));
       } else {
         const body = await res.json().catch(() => null) as { error?: { message?: string } } | null;
-        setGateErrors((prev) => ({ ...prev, [id]: body?.error?.message ?? `HTTP ${res.status}` }));
+        setGateErrors((prev) => ({ ...prev, [id]: body?.error?.message ?? t('gateTransitionErrorGeneric') }));
       }
     } finally {
       setResolvingIds((prev) => { const next = new Set(prev); next.delete(id); return next; });


### PR DESCRIPTION
## [SID:2552] 게이트 에러 카피 사람말 폴백 — 큐+상세 동시 (원문 HTTP 상태코드 노출 제거)

BE가 사람이 읽을 `error.message`를 안 주는 예외 케이스(네트워크 오류·예상외 500·422 스키마 밖 등)에 `HTTP {status}` 원문 상태코드가 화면에 그대로 노출되던 것을, 두 자리에서 **함께** 사람말 공통 폴백으로 교체한다.

배경: `#1961`(P2-S5) design:pass 리뷰 중 발견(🟡 minor·비차단·후속 합의). 한쪽만 고치면 «큐 ≠ 상세» 에러 UX가 갈려 더 나쁘므로(단일 UX 규율) 두 자리를 함께 처리.

### 변경
| 자리 | before | after |
|---|---|---|
| `gates/[id]/page.tsx` (게이트 상세·transition 실패) | `?? \`HTTP ${res.status}\`` | `?? t('gateTransitionErrorGeneric')` |
| `inbox/approvals-queue.tsx` (결재함 인라인 승인) | `?? \`HTTP ${res.status}\`` | `?? t('gateTransitionErrorGeneric')` |

- 신규 i18n `gateTransitionErrorGeneric` (cage ns·ko/en):
  - ko: `게이트 처리에 실패했습니다. 다시 시도해 주세요.`
  - en: `Failed to process the gate. Please try again.`
  - `createLoopErrorGeneric` 패턴(「X에 실패했습니다. 다시 시도해 주세요.」) 계승.
- 두 자리 **동일 키** = 단일 UX(AC3).
- useCallback deps에 `t` 추가(exhaustive-deps·next-intl `t`는 stable이라 재렌더 무영향).

### AC 대조
| AC | 판정 | 근거 |
|---|---|---|
| 1. 두 곳 `HTTP {status}` → 사람말 공통 폴백(ko/en) | ✅ | 두 파일 모두 `t('gateTransitionErrorGeneric')` |
| 2. BE message 준 경우 그대로(무회귀) | ✅ | `body?.error?.message` 우선 유지 · 기존 422 메시지 테스트 통과 |
| 3. 두 자리 폴백 동일(단일 UX) | ✅ | 동일 키 사용 |
| 4. 기존 vitest 무회귀 | ✅ | gates + approvals-queue **32 pass** (+폴백 가드 테스트 추가) |

### 판단 노트
- 원문 `HTTP 500`은 사용자에게 **actionable 정보가 아니다** — 상태코드는 개발자용. 사람말 폴백이 net 개선.
- 「다시 시도」 affordance는 정직: 이 폴백은 **BE가 message를 안 줄 때만** 발화(네트워크·예상외) = 재시도가 유효할 수 있는 케이스. 권한/정책 거부(403 등)는 BE가 message를 주므로 그 문구가 대신 뜬다(#3051 「재시도 유효한 데만 제안」 정신과 정합).

### 검증 로그
- `gates/[id]/page.test.tsx` + `approvals-queue.test.tsx` vitest → 32 pass (폴백 가드 테스트 「500 무메시지 → 사람말·HTTP 500 미노출」 포함)
- eslint (3 파일) → clean
- en/ko JSON valid
