### PR TITLE
[SID:2661] toolPermissions 그룹 라벨 누락(canvas/events) + FE 폴백 카탈로그 드리프트

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2434,7 +2434,9 @@
         "audit": "Audit",
         "agent_runs": "Agent runs",
         "admin": "Danger zone (Admin)",
-        "hypotheses": "Hypotheses"
+        "hypotheses": "Hypotheses",
+        "canvas": "Artifacts",
+        "events": "Events"
       }
     },
     "statusEyebrow": "STATUS DASHBOARD",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2434,7 +2434,9 @@
         "audit": "감사",
         "agent_runs": "에이전트 런",
         "admin": "위험 작업 (Admin)",
-        "hypotheses": "가설"
+        "hypotheses": "가설",
+        "canvas": "아티팩트",
+        "events": "이벤트"
       }
     },
     "statusEyebrow": "STATUS DASHBOARD",

--- a/apps/web/src/lib/toolset-catalog.test.ts
+++ b/apps/web/src/lib/toolset-catalog.test.ts
@@ -1,0 +1,46 @@
+// story #2661 — kitOrientingWakeBody 커버리지 pin(recruiter-client.test.tsx)과 동형: 새 그룹키가
+// mcp_toolset.py(BE SSOT)나 TEMP_TOOLSET_CATALOG(FE 폴백)에 추가되고도 i18n 라벨이 안 따라오면
+// tool-permission-picker.tsx가 `t('toolPermissions.groups.<key>')`를 콘솔 MISSING_MESSAGE와 함께
+// 원시 키/폴백으로 그대로 노출한다(canvas·events가 실제로 이렇게 샜다). 소스 텍스트 매칭이 아니라
+// ko/en 메시지 객체를 직접 인덱싱해 누락 시 이 테스트가 red로 고정한다.
+import { describe, expect, it } from 'vitest';
+import koMessages from '../../messages/ko.json';
+import enMessages from '../../messages/en.json';
+import { TEMP_TOOLSET_CATALOG } from './toolset-catalog';
+
+// backend/app/services/mcp_toolset.py의 ALL_GROUPS(SSOT) — "admin"은 별도(ALL_GROUPS에서 제외되지만
+// FE UI는 dangerTitle 섹션으로 자체 노출하므로 라벨은 여전히 필요) + "core"(_CORE, 항상 포함).
+// 이 목록이 BE와 벌어지면(신규 그룹 추가) 이 테스트가 먼저 알아채도록 손으로 미러링한다 — 자동
+// 동기화는 이 스토리 스코프 밖(별도 계약테스트 후보로 남긴다).
+const BE_ALL_GROUPS = [
+  'core', 'rewards', 'analytics', 'agent_runs', 'audit', 'webhooks', 'notifications',
+  'meetings', 'retro', 'standup', 'docs', 'chat', 'sprints', 'hypotheses', 'epics',
+  'tasks', 'stories', 'canvas', 'events', 'admin',
+] as const;
+
+type MessagesShape = { agents: { toolPermissions: { groups: Record<string, string> } } };
+
+describe('toolPermissions.groups i18n 커버리지 (story #2661)', () => {
+  it.each(BE_ALL_GROUPS)('그룹 "%s" — ko/en 라벨이 둘 다 존재하고 비어있지 않다', (key) => {
+    const ko = (koMessages as MessagesShape).agents.toolPermissions.groups;
+    const en = (enMessages as MessagesShape).agents.toolPermissions.groups;
+    expect(ko[key], `ko.agents.toolPermissions.groups.${key}`).toBeTruthy();
+    expect(en[key], `en.agents.toolPermissions.groups.${key}`).toBeTruthy();
+  });
+
+  it('TEMP_TOOLSET_CATALOG(FE 폴백)의 모든 group.key도 ko/en 라벨을 갖는다(BE 미준비/실패 시 화면)', () => {
+    const ko = (koMessages as MessagesShape).agents.toolPermissions.groups;
+    const en = (enMessages as MessagesShape).agents.toolPermissions.groups;
+    for (const g of TEMP_TOOLSET_CATALOG.groups) {
+      expect(ko[g.key], `ko.agents.toolPermissions.groups.${g.key}`).toBeTruthy();
+      expect(en[g.key], `en.agents.toolPermissions.groups.${g.key}`).toBeTruthy();
+    }
+  });
+
+  it('TEMP_TOOLSET_CATALOG이 canvas·events·hypotheses를 포함한다(BE ALL_GROUPS 드리프트 회귀가드)', () => {
+    const keys = TEMP_TOOLSET_CATALOG.groups.map((g) => g.key);
+    expect(keys).toContain('canvas');
+    expect(keys).toContain('events');
+    expect(keys).toContain('hypotheses');
+  });
+});

--- a/apps/web/src/lib/toolset-catalog.ts
+++ b/apps/web/src/lib/toolset-catalog.ts
@@ -47,6 +47,13 @@ export const TEMP_TOOLSET_CATALOG: ToolsetCatalog = {
     { key: 'rewards', is_core: false, is_destructive: false, tools: ['sprintable_get_wallet'] },
     { key: 'audit', is_core: false, is_destructive: false, tools: ['sprintable_list_audit_logs'] },
     { key: 'agent_runs', is_core: false, is_destructive: false, tools: ['sprintable_update_run_status'] },
+    // story #2661 — mcp_toolset.py의 ALL_GROUPS(SSOT)에 canvas(story b4027b2e)·events(#2634)·
+    // hypotheses가 이미 있었는데 이 폴백 상수엔 반영이 안 돼 있었다. i18n 라벨 누락(canvas·events)
+    // 도 이 드리프트의 다른 증상이라 같이 잡는다 — BE 실측 없이도 group.key가 이 상수에서
+    // 나온다면 3종 다 최소 렌더는 되게.
+    { key: 'hypotheses', is_core: false, is_destructive: false, tools: ['sprintable_create_hypothesis', 'sprintable_confirm_hypothesis', 'sprintable_link_hypothesis'] },
+    { key: 'canvas', is_core: false, is_destructive: false, tools: ['sprintable_create_artifact', 'sprintable_edit_artifact', 'sprintable_create_spec_pin'] },
+    { key: 'events', is_core: false, is_destructive: false, tools: ['sprintable_publish_event', 'sprintable_list_event_definitions'] },
     { key: 'admin', is_core: false, is_destructive: true, tools: ['sprintable_delete_sprint', 'sprintable_close_sprint', 'sprintable_give_reward', 'sprintable_upsert_webhook_config', 'sprintable_activate_sprint'] },
   ],
 };


### PR DESCRIPTION
## 배경
PO 퍼펫티어 실측(dev 65063e60, `/organization/workforce/[id]`)에서 콘솔에 `MISSING_MESSAGE: agents.toolPermissions.groups.canvas (ko)` / `...events (ko)` 반복 확인. 실측 결과 화면엔 raw i18n 키 문자열(`toolPermissions.groups.canvas`)이 그대로 노출됨을 착수 전 직접 재현.

## 변경 사항
- `apps/web/messages/{ko,en}.json`: `agents.toolPermissions.groups`에 `canvas`("아티팩트"/"Artifacts")·`events`("이벤트"/"Events") 추가
  - "캔버스"가 아니라 "아티팩트"로 명명한 이유: BE `mcp_toolset.py`에서 이 그룹의 실제 키워드는 `artifact`/`canonical_version`/`spec_pin`(E-CANVAS 비주얼 아티팩트) — 앱 안에 이미 다른 의미의 "캔버스"(workflow 라우팅 캔버스, `workflowCanvasTitle` 등)가 있어 그대로 쓰면 두 기능이 혼동됨
- `apps/web/src/lib/toolset-catalog.ts`: `TEMP_TOOLSET_CATALOG`(BE 엔드포인트 미준비 시 FE 폴백)도 같은 드리프트 클래스로 `canvas`/`events`/`hypotheses` 3개 그룹이 누락돼 있던 것을 발견해 함께 수정(BE `ALL_GROUPS`와 재정합)
- `apps/web/src/lib/toolset-catalog.test.ts` 신규 — 커버리지 pin 테스트(recruiter-client.test.tsx의 kitOrientingWakeBody 방식과 동형): BE `ALL_GROUPS`(mcp_toolset.py 미러링) 전체 + `TEMP_TOOLSET_CATALOG`의 모든 `group.key`가 ko/en 라벨을 갖는지 `it.each`로 개별 검증

## AC 대조
1. ✅ `agents.toolPermissions.groups.*` 전 그룹 키 ko/en 완비 + 누락 시 red되는 커버리지 pin(22개 assertion)
2. ✅ 실화면 재현(착수 전 raw key 노출 확인) — 배포 후 정상 렌더는 dev 배포 후 재확인 예정

## 검증
- `pnpm exec vitest run toolset-catalog.test.ts`: **수정 전 코드로 실행 → RED**(누락 라벨 3건 정확히 실패: canvas/events 라벨 + TEMP_TOOLSET_CATALOG 포함여부) → **복원 후 GREEN**
- `agents/` 컴포넌트 스위트: 무회귀
- `pnpm exec tsc --noEmit`: 클린
- `pnpm exec eslint`: 0 warnings
- `pnpm build`: exit 0(실제 종료코드 확인)
- 반응형: 문구 텍스트만 추가(레이아웃 변경 없음) — 별도 스크린샷 없음, 착수 전 라이브 재현 스크린샷은 puppeteer DOM 텍스트 확인으로 대체

## Test plan
- [x] 커버리지 pin RED→GREEN 확인
- [x] tsc/eslint/build 클린
- [ ] 유나 design 게이트
- [ ] 카디르 QA
- [ ] dev 배포 후 실화면 재확인(콘솔 MISSING_MESSAGE 0)