### PR TITLE
fix(test-infra): guard destructive_schema reset against shared sprintable_test DB

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -65,6 +65,17 @@ _TEST_DB_SIGNAL_RE = re.compile(
     re.IGNORECASE,
 )
 
+# story ebfd8252(2026-08-14, 카디르 자수 3연발 — #2998/#3000/#3003 QA에서 각각) — 위
+# `_TEST_DB_SIGNAL_RE`는 "이게 실 dev/prod가 아니라 테스트류 DB인가"만 본다. `sprintable_test`는
+# 그 축은 통과하지만(토큰 경계 "test" 포함) **동시에 이 조직의 로컬 realdb 관례 기본값**이라 —
+# 사람/에이전트 여럿이 같은 로컬 postgres 서버의 같은 DB명을 동시에 가리키는 일이 흔하다. CI에서는
+# 안전하다(job마다 완전히 새로운 격리 postgres 서비스 컨테이너를 매번 띄우고 그 안에서만
+# `sprintable_test`라는 이름을 쓰므로 "공유"가 구조적으로 불가능 — GitHub Actions가 항상
+# `CI=true`를 심어주는 것을 신호로 구분한다, 이 conftest 밖에서도 이미 쓰는 관례:
+# test_s6_4_dod.py·test_s7_2_epic_dod.py 참조). CI 밖에서 이 이름을 향한 파괴적 리셋은 —
+# 격리를 사람이 «기억」해야 하는 바로 그 자리라 opt-in을 강제한다.
+_SHARED_CONVENTION_DB_NAMES = frozenset({"sprintable_test"})
+
 
 def _db_name(url: str) -> str:
     return url.rsplit("/", 1)[-1].split("?")[0] if "/" in url else url
@@ -84,6 +95,17 @@ def assert_disposable_test_db(url: str) -> None:
         raise RuntimeError(
             f"안전가드: DROP SCHEMA는 테스트 DB(이름에 test/parity/ci 등) 또는 "
             f"ALLOW_DESTRUCTIVE_SCHEMA_RESET=1 일 때만 허용 — 거부(DB='{name}')."
+        )
+    is_ci = bool(os.environ.get("CI"))
+    allow_shared_flag = os.environ.get("ALLOW_DESTRUCTIVE_ON_SHARED") == "1"
+    if name in _SHARED_CONVENTION_DB_NAMES and not is_ci and not allow_shared_flag:
+        raise RuntimeError(
+            f"안전가드: '{name}'은 이 조직의 공유 로컬 DB 관례명 — 여러 사람/에이전트가 같은 "
+            "postgres 서버의 이 DB를 동시에 realdb 테스트로 쓰고 있을 수 있어 DROP SCHEMA로 "
+            "리셋하면 다른 세션의 진행 중인 realdb 스위트가 연쇄로 깨집니다. 전용 throwaway "
+            "DB를 새로 만들어 가리키세요(예: `createdb sprintable_test_$(whoami)_$$` 후 그 URL로 "
+            f"ALEMBIC_DATABASE_URL/PARITY_TEST_DATABASE_URL을 설정) — 정말 이 공유 DB를 갈아엎어도 "
+            f"된다는 걸 알고 있다면 ALLOW_DESTRUCTIVE_ON_SHARED=1로 우회하세요(DB='{name}')."
         )
 
 

--- a/backend/tests/test_schema_reset_safety_guard.py
+++ b/backend/tests/test_schema_reset_safety_guard.py
@@ -71,9 +71,38 @@ def test_rejects_substring_fail_open_names(url):
     "postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test",
     "postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test_iso",
 ])
-def test_allows_ci_db_names(url):
-    """CI가 쓰는 sprintable_test / sprintable_test_iso는 test 온전 토큰이라 허용(guard가 CI를 막지 않음)."""
-    assert_disposable_test_db(url)
+def test_allows_ci_db_names(url, monkeypatch):
+    """CI가 쓰는 sprintable_test / sprintable_test_iso는 CI 환경(CI=true, GitHub Actions가
+    항상 심어줌)에서는 job마다 완전 격리된 신선 postgres 컨테이너뿐이라 허용된다."""
+    monkeypatch.setenv("CI", "true")
+    assert_disposable_test_db(url)  # should not raise
+
+
+# story ebfd8252(2026-08-14) — sprintable_test는 이 조직의 로컬 realdb 관례 기본값이라
+# «테스트류 DB인가»(_TEST_DB_SIGNAL_RE)는 통과해도 CI 밖에서는 여러 세션이 동시에 같은
+# 서버의 같은 DB를 가리키고 있을 위험이 있다 — 그 자체로는 opt-in 없이 통과시키지 않는다.
+def test_rejects_shared_convention_db_outside_ci(monkeypatch):
+    """CI 밖(CI 미설정)에서 정확히 'sprintable_test'는 opt-in 없이 거부 — 실사고 3연발
+    (#2998·#3000·#3003 QA)의 근본원인 그대로 재현·봉인."""
+    monkeypatch.delenv("CI", raising=False)
+    with pytest.raises(RuntimeError, match="공유 로컬 DB 관례명"):
+        assert_disposable_test_db("postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test")
+
+
+def test_shared_convention_db_optin_allows_outside_ci(monkeypatch):
+    """ALLOW_DESTRUCTIVE_ON_SHARED=1이면 CI 밖에서도 정확히 'sprintable_test'를 갈아엎을 수
+    있다(사람이 «정말 그럴 의도」임을 명시했을 때만 — 실수 방지는 opt-in 부재 시에만 작동)."""
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("ALLOW_DESTRUCTIVE_ON_SHARED", "1")
+    assert_disposable_test_db("postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test")  # ok with flag
+
+
+def test_shared_convention_check_scoped_to_exact_name_not_suffixed_variants(monkeypatch):
+    """'sprintable_test_iso'처럼 접미사가 붙은 변형은 공유 관례명 정확매치가 아니라 이 신규
+    체크 대상이 아니다(CI 밖에서도 opt-in 없이 허용 — 과잉거부 방지, 이미 스코프된 이름이라
+    우발적 동시-공유 위험이 낮다는 판단)."""
+    monkeypatch.delenv("CI", raising=False)
+    assert_disposable_test_db("postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test_iso")
 
 
 def test_optin_flag_allows_unrecognized(monkeypatch):


### PR DESCRIPTION
## Summary
story `ebfd8252` — `destructive_schema` marker tests DROP SCHEMA-reset their target DB before running (`conftest.py::_reset_schema_for_destructive_tests`). The existing safety net (`assert_disposable_test_db`) already screens for "is this a dev/prod DB" (hard deny) and "does the name look test-ish" (`_TEST_DB_SIGNAL_RE`) — but `sprintable_test` passes that second check while *also* being this org's default local realdb DB name, which multiple people/agents routinely point at simultaneously on the same running postgres server.

I hit this exact pitfall 3 times in one day (2026-08-13, self-reported during QA on PR #2998/#3000/#3003) — another session's `destructive_schema` test reset the shared DB mid-flight and wiped out an in-progress realdb suite.

## Fix
A second, narrower check on top of the existing one: the literal name `sprintable_test` additionally requires either:
- a CI environment (`CI` env var — GitHub Actions always sets this; each CI job gets its own fresh, isolated postgres service container, so cross-session sharing is structurally impossible there), or
- an explicit `ALLOW_DESTRUCTIVE_ON_SHARED=1` opt-in.

Scoped to the exact name only (not a broader pattern) — `sprintable_test_iso` (the name the CI destructive-schema shard actually uses for its per-file isolated runs) is unaffected, since it's already a distinct, scoped name unlikely to collide by accident.

## Why no CI workflow changes
Checked `.github/workflows/ci.yml` directly: the `backend-test-destructive` shard job's per-file loop overrides `ALEMBIC_DATABASE_URL`/`PARITY_TEST_DATABASE_URL`/`DATABASE_URL` to `sprintable_test_iso` (createdb/dropdb per file) — it never touches bare `sprintable_test` for the actual destructive test runs. The main `Backend pytest` job runs `pytest -q -m "not destructive_schema"`, so it never triggers this fixture at all. `CI=true` is also set automatically by GitHub Actions as defense-in-depth for any other future path.

## AC
1. ✅ Shared-DB-name destructive reset aborts before touching the schema (RuntimeError raised inside `assert_disposable_test_db`, before `DROP SCHEMA` executes) — opt-in only bypass.
2. ✅ Error message names the correct fix (create a dedicated throwaway DB, gives an example command) and the opt-in flag.
3. ✅ CI 4-shard + local throwaway path non-regression — confirmed via workflow read (no bare `sprintable_test` destructive runs exist), not just assumed.
4. ✅ Positive control (guard-removed reproduces the original incident): temporarily disabled the new check (`if False and name in ...`), re-ran `test_rejects_shared_convention_db_outside_ci` — failed with `DID NOT RAISE`, i.e. the exact silent-pass condition that caused the original incidents. Restored, re-ran: green again, diff clean.

## Verification
- `pytest tests/test_schema_reset_safety_guard.py -v`: 23/23 pass (19 existing + 4 new: reject-outside-CI, optin-allows-outside-CI, CI-context-allows via `CI=true` monkeypatch, exact-name-scoping for `_iso` variant).
- Mutation (AC4, described above): guard-disabled → RED (incident reproduces) → restored → GREEN.
- Broader smoke: `pytest -m "not destructive_schema and not realdb" -k "conftest or schema_reset"` — 51 passed, 1 xfailed (pre-existing, unrelated), 0 new failures.

## QA note
Self-QA not possible here (author = reviewer conflict, same pattern as story #2592 today) — routing for cross-check.