### PR TITLE
[SID:2631] 게이트 해소 취소(오클릭 정정) + 「보류·논의」 상태

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -18,6 +18,8 @@ from app.models.pm import Story, Task
 from app.models.visual_artifact import VisualArtifact
 from app.routers.agent_gateway import wake_agent
 from app.services.gate_service import (
+    GateUndoNotSelfError,
+    GateUndoWindowExpiredError,
     RiskGrade,
     apply_gate_urgency_sort,
     create_gate,
@@ -25,8 +27,10 @@ from app.services.gate_service import (
     get_org_posture,
     hold_gate,
     is_known_project_agnostic_work_item_type,
+    request_gate_discussion,
     resolve_work_item_project_id,
     transition_gate,
+    undo_gate_resolution,
     unhold_gate,
     void_gate,
 )
@@ -294,6 +298,50 @@ async def _non_doc_can_approve(
     if gate_type == "artifact_canonicalize":
         return True
     return await _non_doc_gate_approvable(session, user_id, org_id, project_id)
+
+
+async def _authorize_gate_approve_equivalent(
+    session: AsyncSession, gate: Gate | None, resolved, auth, org_id: uuid.UUID,
+) -> None:
+    """story #2631 — transition_gate_endpoint 의 인가 블록(휴먼-only + doc/non-doc can_approve)을
+    그대로 추출한 것. request_gate_discussion_endpoint(«보류·논의»)는 승인/반려 옆 3번째 버튼이라
+    **같은 자격**을 요구한다(PO 판정 — "승인할 수 있는 사람만 논의도 요청할 수 있다", 승인 자격
+    없는 제3자가 게이트를 pending에 묶어두는 건 별개 취약이 된다). 로직 자체는 신규가 아니라
+    기존 transition 인가 규칙의 재사용 — 새 규칙을 만들지 않는다(DRY, 위 _non_doc_can_approve
+    표 주석과 같은 원칙)."""
+    if resolved.type != "human":
+        raise HTTPException(
+            status_code=403,
+            detail="게이트 승인/거부는 휴먼 멤버만 가능합니다 (에이전트 승인 불가).",
+        )
+    if gate is None:
+        return
+    if gate.gate_type == "doc_approval":  # doc.py DOC_GATE_TYPE
+        _reason = await can_approve_doc_gate_reason(
+            session, gate, resolved, uuid.UUID(auth.user_id), org_id
+        )
+        if _reason == "self_or_unverified":
+            raise HTTPException(
+                status_code=403,
+                detail="본인이 상신한 doc 결재는 본인이 승인/거부할 수 없습니다 (self-approval 금지·상신자 미검증 차단).",
+            )
+        if _reason is not None:
+            raise HTTPException(
+                status_code=403,
+                detail="doc 결재 권한이 없습니다 (대상 프로젝트 접근 필요).",
+            )
+    else:
+        _project_id = await resolve_work_item_project_id(
+            session, org_id, gate.work_item_type, gate.work_item_id,
+        )
+        if not await _non_doc_can_approve(session, gate.gate_type, uuid.UUID(auth.user_id), org_id, _project_id):
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "이 게이트를 승인/거부할 권한이 없습니다 (해당 프로젝트의 owner/admin이어야 "
+                    "합니다). 프로젝트 관리자에게 권한을 요청하세요."
+                ),
+            )
 
 
 @router.get("", response_model=list[GateResponse])
@@ -803,74 +851,13 @@ async def transition_gate_endpoint(
     # 게이트를 승인하면 "agent-assisted·human-validated" 웨지 전제가 무너지므로 차단(403).
     # 시스템 auto-resolution(resolve_gate_from_verdict)은 transition_gate 서비스 직호출이라 무영향.
     # ⭐RC#1: status 는 validator 가 approved/rejected 로 제한 → 도달하는 전이는 전부 사람 결재.
+    # E-DG 48f064e5 / #2198(까심 QA·오르테가 PO): doc/non-doc 인가 규칙 —
+    # story #2631 로 _authorize_gate_approve_equivalent 로 추출(discuss 액션과 공유, 위 정의부 주석 참고).
     resolved = await resolve_member(auth, org_id, session)
-    if resolved.type != "human":
-        raise HTTPException(
-            status_code=403,
-            detail="게이트 승인/거부는 휴먼 멤버만 가능합니다 (에이전트 승인 불가).",
-        )
-    # E-DG 48f064e5: doc 결재 게이트 BE-level can_approve 강제(FE 게이팅은 가시성뿐·실 authz는 BE).
-    # 룰(A·PO 결정): human(위) + 대상 doc project has_project_access + not-author(resolver≠requester).
-    # 89484c8c: rule 을 can_approve_doc_gate_reason 단일 규칙으로 추출 — list_gates per-caller can_approve
-    # 가시성과 **공용**(거동 분기 0·DRY). 거부사유별 403 메시지는 여기서 보존(self vs 권한). 휴먼 체크는
-    # 위에서 선행되므로 여기 not_human 미도달(방어적으로 권한 403 매핑). 비-doc 게이트는 기존 경로 무변경.
     _gate = (await session.execute(
         select(Gate).where(Gate.id == id, Gate.org_id == org_id)
     )).scalar_one_or_none()
-    if _gate is not None and _gate.gate_type == "doc_approval":  # doc.py DOC_GATE_TYPE
-        _reason = await can_approve_doc_gate_reason(
-            session, _gate, resolved, uuid.UUID(auth.user_id), org_id
-        )
-        # ① self-approval(SoD)·상신자 미기록(forged/이상 게이트) fail-closed.
-        if _reason == "self_or_unverified":
-            raise HTTPException(
-                status_code=403,
-                detail="본인이 상신한 doc 결재는 본인이 승인/거부할 수 없습니다 (self-approval 금지·상신자 미검증 차단).",
-            )
-        # ② can_approve 자격(no_project_access·삭제 doc·방어적 not_human): project-scope·random org-member 차단.
-        if _reason is not None:
-            raise HTTPException(
-                status_code=403,
-                detail="doc 결재 권한이 없습니다 (대상 프로젝트 접근 필요).",
-            )
-    elif _gate is not None:
-        # story #2198(까심 QA 적출·오르테가 PO 판정): non-doc 게이트(merge/pr_review/qa/deploy/
-        # artifact_canonicalize 등)는 이 분기 자체가 없어 **휴먼 org 멤버이기만 하면 통과**했다
-        # (위 not-human 체크뿐). 처방은 새 단일 규칙이 아니라 _non_doc_can_approve(위 정의)
-        # **타입별 표**를 여기 물리는 것 — artifact_canonicalize 는 첫 판정(rule B 균일 적용)
-        # 시도가 CI 에서 실 회귀로 드러나 갈렸다: E-CANVAS C4-S8 설계상 그 타입은 project
-        # owner/admin 이 아니라 **휴먼이면 승인 가능**이 계약이었다(테스트 픽스처가 무권한 org
-        # 멤버를 승인자로 seed 해 그 설계를 증언하고 있었음). 그 외 타입은 rule B(project
-        # owner/admin, project-무관 work_item 은 org owner/admin) 그대로.
-        #
-        # ⛔SoD(self-approval) 는 의도적으로 안 넣는다(오르테가 PO 판정, 2026-07-27) — 이유:
-        # ① doc 결재의 SoD 는 "저자성"(자기가 쓴 문서를 자기가 승인)을 막는 것인데 non-doc
-        #    게이트엔 그 저자성 관계가 같은 형태로 없다. ② non-doc 게이트 상신자는 사실상
-        #    에이전트이고 에이전트는 이미 승인 불가(93fc7aeb, 위 not-human 체크) — 사람 대
-        #    사람 SoD 가 붙을 자리가 실제로 거의 없다. ③ 넣으면 1인 org·소규모 팀에서 아무도
-        #    못 여는 교착이 생긴다(가정 아님 — PR #1998 이 그 교착을 고치는 물건). ④ 추적은
-        #    이미 확보돼 있다(resolver_id 를 body 무시하고 인증 caller 로 강제 기록, S23 RC①).
-        #    다음 사람이 "doc 엔 있는데 여긴 왜 없지"로 되돌아와 넣지 않도록 여기 남긴다.
-        _project_id = await resolve_work_item_project_id(
-            session, org_id, _gate.work_item_type, _gate.work_item_id,
-        )
-        # ⚠️_non_doc_gate_approvable(rule B, non-artifact_canonicalize 타입에만 적용)은
-        # `uuid.UUID(auth.user_id)`를 기대한다(get_project_role 이 users.id/project_access.
-        # member_id 로 매칭 — list_gates 의 _uid 와 동일 축). resolved.id(member row id)는
-        # doc_approval SoD 비교 전용 축이라 여기 쓰면 다른 사람으로 조회돼 fail-closed 오탐
-        # (정당한 owner/admin 이 403)이 난다 — 실제로 이 갭을 realdb 테스트가 잡았다.
-        if not await _non_doc_can_approve(session, _gate.gate_type, uuid.UUID(auth.user_id), org_id, _project_id):
-            # #2198(오르테가 PO, 라이브 측정 후 지시): 없던 바를 새로 세우는 변경이라 막히는
-            # 사람이 "무엇을 해야 하는지" 다음 발을 못 받으면 그 자리서 막막해진다(오늘 아침
-            # #2166 과 같은 자리 — 막는 것과 "다음 발을 주는 것"은 다른 일). 자격 기준(project
-            # owner/admin)과 다음 행동(관리자에게 권한 요청)까지 메시지에 명시.
-            raise HTTPException(
-                status_code=403,
-                detail=(
-                    "이 게이트를 승인/거부할 권한이 없습니다 (해당 프로젝트의 owner/admin이어야 "
-                    "합니다). 프로젝트 관리자에게 권한을 요청하세요."
-                ),
-            )
+    await _authorize_gate_approve_equivalent(session, _gate, resolved, auth, org_id)
     # story #2027(까심 QA 적출): 고위험(risk_grade=high) 게이트의 approved 전이는 사유(note) 서버측
     # 강제 — void_gate/override_gate 기존 관례(reason 없으면 ValueError→422, void_gate 참고)에
     # 맞추는 작업이다(신규 규칙 아님). 이전엔 FE 버튼 disable(evidenceViewed && reason.trim())만
@@ -978,6 +965,64 @@ async def unhold_gate_endpoint(
     resolved = await _require_gate_admin(session, auth, org_id)
     try:
         gate = await unhold_gate(session, org_id, id, resolved.id)
+        await session.commit()
+        # story #2459 회귀 동형 방어(2026-08-05): commit 後 model_validate 前 명시 refresh.
+        await session.refresh(gate)
+        return GateResponse.model_validate(gate)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+
+@router.post("/{id}/undo", response_model=GateResponse)
+async def undo_gate_resolution_endpoint(
+    id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> GateResponse:
+    """story #2631 AC1/AC3 — 오클릭 정정. 해소(approved/rejected) 직후 짧은 창 안에서
+    **해소자 본인만** 취소해 pending으로 되돌린다. 별도 role 게이팅 없음 — 본인 해소를
+    본인이 되돌린다는 사실 하나로 인가가 성립(void/hold 류 admin 액션과 다른 축, 서비스
+    docstring 참고). body 는 인증 caller 강제(S23 RC① 패턴 재사용) — actor_id 를 body 로
+    받지 않는다."""
+    resolved = await resolve_member(auth, org_id, session)
+    try:
+        gate = await undo_gate_resolution(session, org_id, id, resolved.id)
+        await session.commit()
+        # story #2459 회귀 동형 방어(2026-08-05): commit 後 model_validate 前 명시 refresh.
+        await session.refresh(gate)
+        return GateResponse.model_validate(gate)
+    except GateUndoNotSelfError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    except GateUndoWindowExpiredError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+
+class GateDiscussionRequest(BaseModel):
+    reason: str
+
+
+@router.post("/{id}/discuss", response_model=GateResponse)
+async def request_gate_discussion_endpoint(
+    id: uuid.UUID,
+    body: GateDiscussionRequest,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> GateResponse:
+    """story #2631 AC2 — 승인/거부 옆 3번째 응답: 「보류(논의 필요)」. 게이트는 pending
+    그대로(전이 없음) — 순수 회신+감사 기록. 인가는 승인/거부와 **동일 자격**
+    (_authorize_gate_approve_equivalent — 승인 못 하는 제3자가 게이트를 논의-보류로
+    묶어두는 것도 막아야 하므로)."""
+    resolved = await resolve_member(auth, org_id, session)
+    _gate = (await session.execute(
+        select(Gate).where(Gate.id == id, Gate.org_id == org_id)
+    )).scalar_one_or_none()
+    await _authorize_gate_approve_equivalent(session, _gate, resolved, auth, org_id)
+    try:
+        gate = await request_gate_discussion(session, org_id, id, resolved.id, body.reason)
         await session.commit()
         # story #2459 회귀 동형 방어(2026-08-05): commit 後 model_validate 前 명시 refresh.
         await session.refresh(gate)

--- a/backend/app/schemas/deeplink_manifest.py
+++ b/backend/app/schemas/deeplink_manifest.py
@@ -447,6 +447,22 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             ),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
         ),
+        DeepLinkManifestEntry(
+            # story #2631: 「보류(논의 필요)」 요청이 doc 결재 상신자에게 회신되는 벨 알림 —
+            # doc_approval_resolved와 동형(gate 경유·reference_id=gate_id)이나 게이트가 아직
+            # 결정 안 나고 pending인 채로 "3안 논의 요청"을 받은 것이라, 결재자가 그 카드로
+            # 착지해 응답(추가 승인/거부/재논의)할 수 있어야 한다 — 읽기전용 FYI가 아니라
+            # 조치 가능이므로 grade A2(요청 쪽 doc_approval_requested와 동일 등급).
+            app=DeepLinkAppFields(
+                type="doc_approval_discussion_requested", target="gate_detail",
+                parent_tab=ParentTab.approvals, target_promotion_pending=True,
+            ),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a2),
+        ),
 
         # --- dispatched(범용) — reference_type 5종 분기. entity_type 필수. ---
         # 정정(유나 3자 검토, 필수·조건부 GREEN의 조건): parentTab은 target의 순수 함수여야

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -261,3 +261,90 @@ async def dispatch_approval_result_reply(
             "approval-result 벨 알림 실패 doc=%s requester=%s",
             doc.id, requester_id, exc_info=True,
         )
+
+
+async def dispatch_approval_discussion_reply(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    doc: Doc,
+    gate_id: uuid.UUID,
+    requester_id: uuid.UUID,
+    resolver_id: uuid.UUID,
+    reason: str,
+) -> None:
+    """story #2631 — `dispatch_approval_result_reply`의 자매 함수. 승인/반려 둘 중 하나로
+    강제되지 않고 "보류(논의 필요)"를 표현하고 싶다는 게 원 실사용 요구(선생님 08-13
+    19:49) — 이 함수가 그 세 번째 회신 형태. 게이트는 pending 그대로라 gate.status를
+    참조하지 않는다(호출부 request_gate_discussion이 이미 pending 확인 완료).
+
+    구조는 dispatch_approval_result_reply와 동형(같은 DM·독립 SAVEPOINT 둘·human만 벨) —
+    `decision`/`message_kind`/알림 문구만 논의-요청 전용으로 갈린다."""
+    if not doc.project_id or resolver_id == requester_id:
+        return
+
+    from app.routers.conversations import _dispatch_conversation_event
+    from app.services.member_resolver import lookup_members_by_ids
+
+    resolver = (await lookup_members_by_ids({resolver_id}, db)).get(resolver_id)
+    if resolver is None:
+        logger.warning("approval-discussion 회신 스킵 — resolver 미확인 doc=%s", doc.id)
+        return
+
+    content = f"'{doc.title}' 문서 결재 — 논의 요청\n사유: {reason}"
+
+    try:
+        async with db.begin_nested():
+            conv = await _get_or_create_approval_dm(
+                db, org_id=org_id, project_id=doc.project_id,
+                requester_id=requester_id, approver_id=resolver_id,
+            )
+            msg = ConversationMessage(
+                conversation_id=conv.id,
+                sender_id=resolver_id,
+                content=content,
+                mentioned_ids=[requester_id],
+                msg_metadata={
+                    "activation": {
+                        "audience": [str(requester_id)],
+                        "kind": "discuss",
+                        "expects_response": True,
+                    },
+                    "approval_target": {
+                        "work_item_type": "doc",
+                        "work_item_id": str(doc.id),
+                        "gate_id": str(gate_id),
+                        "decision": "discuss",
+                        "resolution_note": reason,
+                    },
+                },
+            )
+            db.add(msg)
+            await db.flush()
+            await _dispatch_conversation_event(db, conv, msg, org_id, resolver)
+    except Exception:  # noqa: BLE001 — best-effort, 회신 실패가 논의 요청 자체를 막지 않음.
+        logger.warning(
+            "approval-discussion 회신 배달 실패 doc=%s requester=%s",
+            doc.id, requester_id, exc_info=True,
+        )
+        # dispatch_approval_result_reply와 동일 원칙 — DM 실패가 벨 알림까지 죽이지 않게
+        # return하지 않고 다음 블록으로 진행.
+
+    try:
+        requester = (await lookup_members_by_ids({requester_id}, db)).get(requester_id)
+        if requester is not None and requester.type == "human":
+            async with db.begin_nested():
+                from app.services.notification_dispatch import dispatch_notification
+                await dispatch_notification(
+                    db, org_id=org_id, event_type="doc_approval_discussion_requested",
+                    target_member_ids=[requester_id],
+                    title="문서 결재 — 논의 요청",
+                    body=reason or f"'{doc.title}' 문서 결재에 대해 논의를 요청받았습니다.",
+                    reference_type="gate", reference_id=gate_id,
+                    source_project_id=doc.project_id,
+                )
+    except Exception:  # noqa: BLE001 — 벨 알림 실패는 카드 배달과 독립.
+        logger.warning(
+            "approval-discussion 벨 알림 실패 doc=%s requester=%s",
+            doc.id, requester_id, exc_info=True,
+        )

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Literal
 
 from sqlalchemy import and_, case, func, literal, or_, select
@@ -532,6 +532,29 @@ async def transition_gate(
     if note:
         gate.resolution_note = note
 
+    # story #2631(PO 판정 ①, 2026-08-15): 게이트 해소 계열 액션(approve/reject/undo/
+    # discuss-request)을 ActivityLog(immutable)에 처음으로 구조화 기록 — 지금까지 gate 행
+    # (resolver_id/resolved_at/resolution_note)이 "현재 상태"만 담아, 취소(undo_gate_resolution
+    # 참조) 시 원 액션의 흔적이 통째로 사라지는 감사 갭이 있었다(취소 기능이 없어도 이미
+    # 결함이었음). 범위 절제: 게이트 해소 계열만 — 결재 감사 프레임워크 일반화는 이 스토리
+    # 밖(PO 판정).
+    from app.services.activity_log import ActivityLogService
+
+    await ActivityLogService(session).record(
+        org_id=org_id,
+        action=f"gate_{new_status}",
+        actor_id=resolver_id,
+        actor_type="human",  # authz(router)가 human만 통과시킨다 — 93fc7aeb.
+        entity_type="gate",
+        entity_id=gate.id,
+        context={
+            "gate_type": gate.gate_type,
+            "work_item_type": gate.work_item_type,
+            "work_item_id": str(gate.work_item_id),
+            "note": note,
+        },
+    )
+
     # H1-S7: 사람 게이트 해소(approve/reject)를 verdict로 기록 — trust로 환류.
     await _record_gate_review_verdict(session, org_id, gate, new_status, resolver_id)
 
@@ -587,6 +610,204 @@ async def transition_gate(
         )
 
     return gate
+
+
+# story #2631(2026-08-15, 선생님 실사용 발견 08-13 19:49): 반려 의도로 승인을 오클릭 —
+# 해소를 되돌릴 경로도, 「승인도 반려도 아닌」 상태도 없었다. 두 축을 더한다:
+# ① undo_gate_resolution — 해소자 본인이 짧은 창 안에서 자기 해소를 취소.
+# ② request_gate_discussion — 승인/반려 옆 3안, 게이트는 pending 유지한 채 상신자에게 회신.
+GATE_UNDO_WINDOW = timedelta(minutes=5)
+
+
+class GateUndoNotSelfError(Exception):
+    """취소 시도자가 원 해소자 본인이 아님 — 라우터가 403으로 매핑."""
+
+
+class GateUndoWindowExpiredError(Exception):
+    """취소 창(GATE_UNDO_WINDOW) 경과 — 라우터가 403으로 매핑."""
+
+
+async def undo_gate_resolution(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    gate_id: uuid.UUID,
+    actor_id: uuid.UUID,
+    *,
+    now: datetime | None = None,
+) -> Gate:
+    """AC1/AC3 — 해소(approved/rejected) 직후 짧은 창 안에서 **해소자 본인만** 취소해
+    pending으로 되돌린다. 오클릭 정정용이지 재심 경로가 아니다(SoD 불변 — 인가는 "본인
+    해소를 본인이 되돌린다"는 사실 하나로 성립, 새 권한을 안 연다).
+
+    ⛔범위 절제(PO 판정 ③, doc_approval이 1차 실증 대상): `_resolve_doc_gate`가 건 doc
+    status(confirmed/denied)는 여기서 되돌린다(안 되돌리면 gate=pending인데 doc=confirmed
+    인 화면 모순이 생긴다). **다른 부수효과**(workflow_line_resolution의 line 전진·
+    _advance_story_on_merge_approve의 story 진행·trust_pipeline stage 등)는 이 스토리
+    스코프 밖 — 되돌리지 않는다(가드가 못 잡는 것으로 명시. line-bound 게이트는 line이
+    이미 다음 스텝으로 넘어갔을 수 있어 "pending 복귀"가 그 자체로 안전을 보장 못 한다).
+    """
+    now = now or datetime.now(timezone.utc)
+    gate = (await session.execute(
+        select(Gate).where(Gate.id == gate_id, Gate.org_id == org_id)
+    )).scalar_one_or_none()
+    if gate is None:
+        raise ValueError(f"Gate {gate_id} not found")
+    if gate.status not in ("approved", "rejected"):
+        raise ValueError(
+            f"취소 불가: 게이트가 {gate.status} 상태입니다 (승인/반려된 게이트만 취소 가능)."
+        )
+    if gate.resolver_id != actor_id:
+        raise GateUndoNotSelfError("본인이 해소한 게이트만 취소할 수 있습니다.")
+    if gate.resolved_at is None or now - gate.resolved_at > GATE_UNDO_WINDOW:
+        raise GateUndoWindowExpiredError(
+            f"취소 창({int(GATE_UNDO_WINDOW.total_seconds() // 60)}분)이 지났습니다."
+        )
+
+    # 취소 전 원 액션 스냅샷 — status 를 pending 으로 되돌리면 gate 행 자체에선 사라지는 값이라
+    # ActivityLog context 에 남겨야 "원 액션이 무엇이었는지"가 취소 이력에서도 보인다.
+    _prev_status = gate.status
+    _prev_resolver_id = gate.resolver_id
+    _prev_resolved_at = gate.resolved_at
+    _prev_note = gate.resolution_note
+
+    from app.services.doc import DOC_GATE_TYPE, DOC_GATE_WORK_ITEM_TYPE
+    if gate.work_item_type == DOC_GATE_WORK_ITEM_TYPE and gate.gate_type == DOC_GATE_TYPE:
+        _expected_doc_status = "confirmed" if _prev_status == "approved" else "denied"
+        doc = (await session.execute(
+            select(Doc).where(
+                Doc.id == gate.work_item_id, Doc.org_id == org_id, Doc.deleted_at.is_(None),
+            )
+        )).scalar_one_or_none()
+        if doc is not None and doc.status == _expected_doc_status:
+            doc.status = "pending"  # 멱등 가드: 그 사이 다른 경로로 이미 바뀌었으면 안 건드림.
+
+    set_gate_status(gate, "pending", now=now)
+    gate.resolver_id = None
+    gate.resolved_at = None
+    gate.resolution_note = None
+
+    from app.services.activity_log import ActivityLogService
+
+    await ActivityLogService(session).record(
+        org_id=org_id,
+        action="gate_resolution_undone",
+        actor_id=actor_id,
+        actor_type="human",
+        entity_type="gate",
+        entity_id=gate.id,
+        context={
+            "gate_type": gate.gate_type,
+            "work_item_type": gate.work_item_type,
+            "work_item_id": str(gate.work_item_id),
+            "previous_status": _prev_status,
+            "previous_resolver_id": str(_prev_resolver_id) if _prev_resolver_id else None,
+            "previous_resolved_at": _prev_resolved_at.isoformat() if _prev_resolved_at else None,
+            "previous_note": _prev_note,
+        },
+    )
+
+    await session.flush()
+    await session.refresh(gate)
+    return gate
+
+
+async def request_gate_discussion(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    gate_id: uuid.UUID,
+    actor_id: uuid.UUID,
+    reason: str,
+    *,
+    now: datetime | None = None,
+) -> Gate:
+    """AC2 — 승인/변경요청 옆 3안. 게이트는 **pending 그대로**(전이 없음) — 순수 회신+감사
+    기록 액션. 사유는 `gate.neutral_facts["discussion_requested"]`에 얹는다(신규 컬럼/
+    마이그 없이 기존 JSONB 확장 — requested_by_member_id와 같은 자리에 쌓는 관례 재사용).
+
+    ⛔PO 판정 ③ — 액션 자체는 게이트 타입 무관(결재함 단일 UX). 회신은 requester 개념이
+    있는 타입(doc_approval)만 실제 전달되고, 없는 타입은 회신 스킵을 ActivityLog context에
+    명시(`requester_notified=False` + 사유) — 조용한 no-op 금지."""
+    now = now or datetime.now(timezone.utc)
+    if not (reason or "").strip():
+        raise ValueError("논의 요청 사유(reason)는 필수입니다.")
+
+    gate = (await session.execute(
+        select(Gate).where(Gate.id == gate_id, Gate.org_id == org_id)
+    )).scalar_one_or_none()
+    if gate is None:
+        raise ValueError(f"Gate {gate_id} not found")
+    if gate.status != "pending":
+        raise ValueError(f"논의 요청 불가: 게이트가 {gate.status} 상태입니다 (pending만 가능).")
+
+    facts = dict(gate.neutral_facts or {})
+    facts["discussion_requested"] = {
+        "reason": reason,
+        "requested_by_member_id": str(actor_id),
+        "requested_at": now.isoformat(),
+    }
+    gate.neutral_facts = facts
+
+    requester_notified = await _notify_gate_discussion_requester(session, gate, actor_id, reason)
+
+    from app.services.activity_log import ActivityLogService
+
+    await ActivityLogService(session).record(
+        org_id=org_id,
+        action="gate_discussion_requested",
+        actor_id=actor_id,
+        actor_type="human",
+        entity_type="gate",
+        entity_id=gate.id,
+        context={
+            "gate_type": gate.gate_type,
+            "work_item_type": gate.work_item_type,
+            "work_item_id": str(gate.work_item_id),
+            "reason": reason,
+            "requester_notified": requester_notified,
+        },
+    )
+
+    await session.flush()
+    await session.refresh(gate)
+    return gate
+
+
+async def _notify_gate_discussion_requester(
+    session: AsyncSession, gate: Gate, actor_id: uuid.UUID, reason: str,
+) -> bool:
+    """`_notify_doc_gate_requester`의 「논의 요청」 자매 함수 — doc_approval만 실제 회신
+    (requester 개념이 있는 유일한 타입, PO 판정 ③ 1차 실증 대상). 다른 타입은 회신 대상이
+    없다는 사실 자체를 반환값으로 명시(호출부가 ActivityLog에 `requester_notified` 로
+    남겨 "조용한 no-op"이 되지 않게 한다). best-effort — 실패해도 논의 요청 자체는 막지 않는다."""
+    try:
+        from app.services.doc import DOC_GATE_TYPE, DOC_GATE_WORK_ITEM_TYPE
+        if gate.work_item_type != DOC_GATE_WORK_ITEM_TYPE or gate.gate_type != DOC_GATE_TYPE:
+            return False
+
+        facts = gate.neutral_facts or {}
+        requester_raw = facts.get("requested_by_member_id")
+        if not requester_raw:
+            return False
+        requester_id = uuid.UUID(str(requester_raw))
+
+        doc = (await session.execute(
+            select(Doc).where(Doc.id == gate.work_item_id, Doc.org_id == gate.org_id)
+        )).scalar_one_or_none()
+        if doc is None:
+            return False
+
+        from app.services.approval_delivery import dispatch_approval_discussion_reply
+
+        await dispatch_approval_discussion_reply(
+            session, org_id=gate.org_id, doc=doc, gate_id=gate.id,
+            requester_id=requester_id, resolver_id=actor_id, reason=reason,
+        )
+        return True
+    except Exception:  # noqa: BLE001 — best-effort, 회신 실패가 논의 요청 자체를 막지 않는다.
+        logger.warning(
+            "approval-discussion 상신자 회신 실패 gate=%s", gate.id, exc_info=True,
+        )
+        return False
 
 
 async def void_gate(

--- a/backend/tests/test_1968_gate_project_id_threading.py
+++ b/backend/tests/test_1968_gate_project_id_threading.py
@@ -329,6 +329,7 @@ async def _override_session():
     import app.models  # noqa: F401
     import app.models.participation  # noqa: F401
     import app.models.workflow_line  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — #2631: override_gate()→transition_gate()가 ActivityLog를 씀.
 
     url = _REAL_DB_URL
     for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):

--- a/backend/tests/test_2027_gate_approval_reason_enforce.py
+++ b/backend/tests/test_2027_gate_approval_reason_enforce.py
@@ -52,6 +52,7 @@ async def _session_factory():
 
     from app.core.database import Base
     import app.models  # noqa: F401 — 전 모델 메타데이터 로드
+    import app.models.activity_log  # noqa: F401 — #2631: transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
 
     engine = create_async_engine(_async_url())
     async with engine.begin() as conn:

--- a/backend/tests/test_2058_hitl_human_only.py
+++ b/backend/tests/test_2058_hitl_human_only.py
@@ -49,6 +49,7 @@ async def _session_factory():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
     import app.models  # noqa: F401 — 전 모델 메타데이터 로드
+    import app.models.activity_log  # noqa: F401 — #2631: transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
     from app.core.database import Base
 
     # ⚠️fix(발견 2026-07-20, #2043 AC3 작업 중): 이 함수가 create_all을 호출하지 않고 있었다 —

--- a/backend/tests/test_2082_artifact_canonicalize_gate_inbox.py
+++ b/backend/tests/test_2082_artifact_canonicalize_gate_inbox.py
@@ -78,6 +78,7 @@ async def _session_factory():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
     import app.models  # noqa: F401 — 전 모델 메타데이터 로드
+    import app.models.activity_log  # noqa: F401 — #2631: transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
     from app.core.database import Base
 
     engine = create_async_engine(_async_url())

--- a/backend/tests/test_2631_gate_undo_discuss.py
+++ b/backend/tests/test_2631_gate_undo_discuss.py
@@ -1,0 +1,507 @@
+"""story #2631 — 오클릭 정정(undo_gate_resolution) + «보류·논의»(request_gate_discussion).
+
+축: ①undo=해소자 본인만·짧은 창(GATE_UNDO_WINDOW)·doc_approval doc.status 동반 복원·ActivityLog
+스냅샷. ②discuss=pending 그대로(전이 無)·neutral_facts 확장·requester 회신은 doc_approval만
+(다른 타입은 no-op을 requester_notified=False로 명시 — #2655 「조용한 재연결 루프」 교훈 재적용).
+③엔드포인트 인가: undo=body 무관 actor 강제(별도 role 없음, self-check은 서비스 레이어)·
+discuss=승인/거부와 동일 자격(_authorize_gate_approve_equivalent, transition과 DRY 공유).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.participation  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — #2201 후속: app.models 벌크 import 미등재 10개 중 하나.
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_resolved_gate(s, org, resolver, *, status="approved", resolved_at=None, gate_type="merge",
+                               work_item_type="story"):
+    from app.models.gate import Gate
+    now = resolved_at or datetime.now(timezone.utc)
+    gate = Gate(id=uuid.uuid4(), org_id=org, work_item_id=uuid.uuid4(), work_item_type=work_item_type,
+                gate_type=gate_type, status=status, resolver_id=resolver, resolved_at=now,
+                resolution_note="사유")
+    s.add(gate)
+    await s.flush()
+    return gate
+
+
+async def _seed_doc_gate(s, org, resolver, requester, *, gate_status="approved", doc_status="confirmed"):
+    from app.models.gate import Gate
+    from app.models.doc import Doc
+    from app.models.project import Project
+    proj = uuid.uuid4()
+    s.add(Project(id=proj, org_id=org, name="p"))
+    await s.flush()
+    doc = Doc(id=uuid.uuid4(), org_id=org, project_id=proj, title="t", slug=f"t-{uuid.uuid4().hex[:8]}",
+              status=doc_status)
+    s.add(doc)
+    await s.flush()
+    now = datetime.now(timezone.utc)
+    gate = Gate(id=uuid.uuid4(), org_id=org, work_item_id=doc.id, work_item_type="doc",
+                gate_type="doc_approval", status=gate_status, resolver_id=resolver, resolved_at=now,
+                resolution_note="사유", neutral_facts={"requested_by_member_id": str(requester)})
+    s.add(gate)
+    await s.flush()
+    return gate, doc
+
+
+# ── undo_gate_resolution(realdb) ────────────────────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_undo_reverts_to_pending_and_clears_resolver_fields():
+    from app.services.gate_service import undo_gate_resolution
+    engine, Session = await _session()
+    async with Session() as s:
+        org, resolver = uuid.uuid4(), uuid.uuid4()
+        gate = await _seed_resolved_gate(s, org, resolver)
+        await s.commit()
+        g = await undo_gate_resolution(s, org, gate.id, resolver)
+        await s.commit()
+        assert g.status == "pending"
+        assert g.resolver_id is None and g.resolved_at is None and g.resolution_note is None
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_undo_not_self_raises():
+    from app.services.gate_service import undo_gate_resolution, GateUndoNotSelfError
+    engine, Session = await _session()
+    async with Session() as s:
+        org, resolver = uuid.uuid4(), uuid.uuid4()
+        gate = await _seed_resolved_gate(s, org, resolver)
+        await s.commit()
+        with pytest.raises(GateUndoNotSelfError):
+            await undo_gate_resolution(s, org, gate.id, uuid.uuid4())  # 타인
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_undo_window_expired_raises():
+    from app.services.gate_service import undo_gate_resolution, GateUndoWindowExpiredError, GATE_UNDO_WINDOW
+    engine, Session = await _session()
+    async with Session() as s:
+        org, resolver = uuid.uuid4(), uuid.uuid4()
+        stale = datetime.now(timezone.utc) - GATE_UNDO_WINDOW - timedelta(seconds=1)
+        gate = await _seed_resolved_gate(s, org, resolver, resolved_at=stale)
+        await s.commit()
+        with pytest.raises(GateUndoWindowExpiredError):
+            await undo_gate_resolution(s, org, gate.id, resolver)
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_undo_within_window_still_succeeds_boundary():
+    """⚠️경계값: 창을 «넘지 않은» 경우(window - 1s)엔 여전히 통과해야 — off-by-one 핀."""
+    from app.services.gate_service import undo_gate_resolution, GATE_UNDO_WINDOW
+    engine, Session = await _session()
+    async with Session() as s:
+        org, resolver = uuid.uuid4(), uuid.uuid4()
+        almost_stale = datetime.now(timezone.utc) - GATE_UNDO_WINDOW + timedelta(seconds=1)
+        gate = await _seed_resolved_gate(s, org, resolver, resolved_at=almost_stale)
+        await s.commit()
+        g = await undo_gate_resolution(s, org, gate.id, resolver)
+        assert g.status == "pending"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_undo_pending_gate_rejected():
+    from app.services.gate_service import undo_gate_resolution
+    engine, Session = await _session()
+    async with Session() as s:
+        org, resolver = uuid.uuid4(), uuid.uuid4()
+        gate = await _seed_resolved_gate(s, org, resolver, status="pending")
+        await s.commit()
+        with pytest.raises(ValueError, match="취소 불가"):
+            await undo_gate_resolution(s, org, gate.id, resolver)
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_undo_doc_approval_reverts_doc_status_confirmed_to_pending():
+    from app.services.gate_service import undo_gate_resolution
+    from sqlalchemy import select
+    from app.models.doc import Doc
+    engine, Session = await _session()
+    async with Session() as s:
+        org, resolver, requester = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        gate, doc = await _seed_doc_gate(s, org, resolver, requester, gate_status="approved", doc_status="confirmed")
+        await s.commit()
+        await undo_gate_resolution(s, org, gate.id, resolver)
+        await s.commit()
+        d = (await s.execute(select(Doc).where(Doc.id == doc.id))).scalar_one()
+        assert d.status == "pending"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_undo_doc_approval_reverts_doc_status_denied_to_pending():
+    from app.services.gate_service import undo_gate_resolution
+    from sqlalchemy import select
+    from app.models.doc import Doc
+    engine, Session = await _session()
+    async with Session() as s:
+        org, resolver, requester = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        gate, doc = await _seed_doc_gate(s, org, resolver, requester, gate_status="rejected", doc_status="denied")
+        await s.commit()
+        await undo_gate_resolution(s, org, gate.id, resolver)
+        await s.commit()
+        d = (await s.execute(select(Doc).where(Doc.id == doc.id))).scalar_one()
+        assert d.status == "pending"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_undo_doc_status_already_changed_elsewhere_is_idempotent_guard():
+    """⭐멱등 가드: doc.status가 그 사이 다른 경로로 이미 바뀌어 있으면(기대값 불일치) 건드리지 않는다."""
+    from app.services.gate_service import undo_gate_resolution
+    from sqlalchemy import select
+    from app.models.doc import Doc
+    engine, Session = await _session()
+    async with Session() as s:
+        org, resolver, requester = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        # gate=approved(→기대 doc.status=confirmed) 인데 실제 doc.status는 이미 superseded로 바뀜.
+        gate, doc = await _seed_doc_gate(s, org, resolver, requester, gate_status="approved", doc_status="superseded")
+        await s.commit()
+        await undo_gate_resolution(s, org, gate.id, resolver)
+        await s.commit()
+        d = (await s.execute(select(Doc).where(Doc.id == doc.id))).scalar_one()
+        assert d.status == "superseded"  # 안 건드림
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_undo_writes_activity_log_snapshot():
+    from app.services.gate_service import undo_gate_resolution
+    from sqlalchemy import select
+    from app.models.activity_log import ActivityLog
+    engine, Session = await _session()
+    async with Session() as s:
+        org, resolver = uuid.uuid4(), uuid.uuid4()
+        gate = await _seed_resolved_gate(s, org, resolver, status="rejected")
+        await s.commit()
+        await undo_gate_resolution(s, org, gate.id, resolver)
+        await s.commit()
+        log = (await s.execute(
+            select(ActivityLog).where(ActivityLog.entity_id == gate.id, ActivityLog.action == "gate_resolution_undone")
+        )).scalar_one()
+        assert log.actor_id == resolver
+        assert log.context["previous_status"] == "rejected"
+        assert log.context["previous_resolver_id"] == str(resolver)
+    await engine.dispose()
+
+
+# ── request_gate_discussion(realdb) ─────────────────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_discuss_keeps_gate_pending_and_sets_neutral_facts():
+    from app.services.gate_service import request_gate_discussion
+    engine, Session = await _session()
+    async with Session() as s:
+        org, actor = uuid.uuid4(), uuid.uuid4()
+        gate = await _seed_resolved_gate(s, org, uuid.uuid4(), status="pending")
+        await s.commit()
+        g = await request_gate_discussion(s, org, gate.id, actor, "설계 재확인 필요")
+        await s.commit()
+        assert g.status == "pending"  # 전이 없음
+        assert g.neutral_facts["discussion_requested"]["reason"] == "설계 재확인 필요"
+        assert g.neutral_facts["discussion_requested"]["requested_by_member_id"] == str(actor)
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_discuss_non_pending_gate_rejected():
+    from app.services.gate_service import request_gate_discussion
+    engine, Session = await _session()
+    async with Session() as s:
+        org, actor = uuid.uuid4(), uuid.uuid4()
+        gate = await _seed_resolved_gate(s, org, uuid.uuid4(), status="approved")
+        await s.commit()
+        with pytest.raises(ValueError, match="pending만"):
+            await request_gate_discussion(s, org, gate.id, actor, "사유")
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_discuss_empty_reason_rejected():
+    from app.services.gate_service import request_gate_discussion
+    engine, Session = await _session()
+    async with Session() as s:
+        org, actor = uuid.uuid4(), uuid.uuid4()
+        gate = await _seed_resolved_gate(s, org, uuid.uuid4(), status="pending")
+        await s.commit()
+        with pytest.raises(ValueError, match="필수"):
+            await request_gate_discussion(s, org, gate.id, actor, "   ")
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_discuss_non_doc_gate_activity_log_notified_false():
+    """PO 판정 ③: requester 개념 없는 타입은 조용한 no-op 대신 requester_notified=False를 남긴다."""
+    from app.services.gate_service import request_gate_discussion
+    from sqlalchemy import select
+    from app.models.activity_log import ActivityLog
+    engine, Session = await _session()
+    async with Session() as s:
+        org, actor = uuid.uuid4(), uuid.uuid4()
+        gate = await _seed_resolved_gate(s, org, uuid.uuid4(), status="pending", gate_type="merge")
+        await s.commit()
+        await request_gate_discussion(s, org, gate.id, actor, "사유")
+        await s.commit()
+        log = (await s.execute(
+            select(ActivityLog).where(ActivityLog.entity_id == gate.id, ActivityLog.action == "gate_discussion_requested")
+        )).scalar_one()
+        assert log.context["requester_notified"] is False
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_discuss_doc_gate_dispatches_reply_and_logs_notified_true():
+    from app.services.gate_service import request_gate_discussion
+    from sqlalchemy import select
+    from app.models.activity_log import ActivityLog
+    engine, Session = await _session()
+    async with Session() as s:
+        org, actor, requester = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        gate, doc = await _seed_doc_gate(s, org, uuid.uuid4(), requester, gate_status="pending")
+        await s.commit()
+        with patch(
+            "app.services.approval_delivery.dispatch_approval_discussion_reply", new=AsyncMock()
+        ) as mock_dispatch:
+            await request_gate_discussion(s, org, gate.id, actor, "논의합시다")
+            await s.commit()
+        mock_dispatch.assert_awaited_once()
+        kw = mock_dispatch.await_args.kwargs
+        assert kw["requester_id"] == requester
+        assert kw["resolver_id"] == actor
+        assert kw["reason"] == "논의합시다"
+        log = (await s.execute(
+            select(ActivityLog).where(ActivityLog.entity_id == gate.id, ActivityLog.action == "gate_discussion_requested")
+        )).scalar_one()
+        assert log.context["requester_notified"] is True
+    await engine.dispose()
+
+
+# ── _notify_gate_discussion_requester(mock, no_db — #2624 패턴 재사용) ──────
+def _gate_sn(**overrides):
+    defaults = dict(
+        id=uuid.uuid4(), org_id=uuid.uuid4(), work_item_id=uuid.uuid4(),
+        work_item_type="doc", gate_type="doc_approval",
+        neutral_facts={"requested_by_member_id": str(uuid.uuid4())},
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.mark.anyio
+async def test_notify_discussion_non_doc_gate_is_noop_zero_db_calls():
+    from app.services.gate_service import _notify_gate_discussion_requester
+    session = AsyncMock()
+    gate = _gate_sn(work_item_type="story", gate_type="merge")
+    ok = await _notify_gate_discussion_requester(session, gate, uuid.uuid4(), "사유")
+    assert ok is False
+    session.execute.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_notify_discussion_missing_requester_in_facts_is_noop():
+    from app.services.gate_service import _notify_gate_discussion_requester
+    session = AsyncMock()
+    gate = _gate_sn(neutral_facts={})
+    ok = await _notify_gate_discussion_requester(session, gate, uuid.uuid4(), "사유")
+    assert ok is False
+    session.execute.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_notify_discussion_doc_not_found_returns_false():
+    from app.services.gate_service import _notify_gate_discussion_requester
+    session = AsyncMock()
+    result = AsyncMock()
+    result.scalar_one_or_none = lambda: None
+    session.execute = AsyncMock(return_value=result)
+    gate = _gate_sn()
+    ok = await _notify_gate_discussion_requester(session, gate, uuid.uuid4(), "사유")
+    assert ok is False
+
+
+@pytest.mark.anyio
+async def test_notify_discussion_dispatch_exception_swallowed_returns_false():
+    from app.services.gate_service import _notify_gate_discussion_requester
+    session = AsyncMock()
+    fake_doc = SimpleNamespace(id=uuid.uuid4(), title="T")
+    result = AsyncMock()
+    result.scalar_one_or_none = lambda: fake_doc
+    session.execute = AsyncMock(return_value=result)
+    gate = _gate_sn()
+    with patch(
+        "app.services.approval_delivery.dispatch_approval_discussion_reply",
+        new=AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        ok = await _notify_gate_discussion_requester(session, gate, uuid.uuid4(), "사유")
+    assert ok is False  # 예외 전파 없이 False
+
+
+# ── 엔드포인트(mock, CI-runnable) ────────────────────────────────────────────
+def _resolved_human(id_=None):
+    from app.services.member_resolver import ResolvedMember
+    return ResolvedMember(id=id_ or uuid.uuid4(), user_id=uuid.uuid4(), name="a", type="human",
+                          role="member", org_id=uuid.uuid4())
+
+
+@pytest.mark.anyio
+async def test_undo_endpoint_forces_actor_from_auth_no_admin_gate():
+    """⭐undo는 admin 게이팅이 없다(본인 해소를 본인이 되돌리는 축) — actor=인증 caller 강제."""
+    from app.routers import gates as gates_mod
+    from app.routers.gates import undo_gate_resolution_endpoint
+    caller = _resolved_human()
+    undofn = AsyncMock(return_value=SimpleNamespace())
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=caller)), \
+         patch.object(gates_mod, "undo_gate_resolution", undofn), \
+         patch.object(gates_mod.GateResponse, "model_validate", lambda g: "OK"):
+        await undo_gate_resolution_endpoint(id=uuid.uuid4(), session=AsyncMock(), org_id=uuid.uuid4(),
+                                            auth=SimpleNamespace(user_id=str(uuid.uuid4())))
+    # undo_gate_resolution(session, org_id, gate_id, actor_id) — actor=caller.id
+    assert undofn.call_args.args[3] == caller.id
+
+
+@pytest.mark.anyio
+async def test_undo_endpoint_maps_not_self_to_403():
+    from app.routers import gates as gates_mod
+    from app.routers.gates import undo_gate_resolution_endpoint, GateUndoNotSelfError
+    from fastapi import HTTPException
+    caller = _resolved_human()
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=caller)), \
+         patch.object(gates_mod, "undo_gate_resolution", AsyncMock(side_effect=GateUndoNotSelfError("본인만"))):
+        with pytest.raises(HTTPException) as ei:
+            await undo_gate_resolution_endpoint(id=uuid.uuid4(), session=AsyncMock(), org_id=uuid.uuid4(),
+                                                auth=SimpleNamespace(user_id=str(uuid.uuid4())))
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_undo_endpoint_maps_window_expired_to_403():
+    from app.routers import gates as gates_mod
+    from app.routers.gates import undo_gate_resolution_endpoint, GateUndoWindowExpiredError
+    from fastapi import HTTPException
+    caller = _resolved_human()
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=caller)), \
+         patch.object(gates_mod, "undo_gate_resolution", AsyncMock(side_effect=GateUndoWindowExpiredError("만료"))):
+        with pytest.raises(HTTPException) as ei:
+            await undo_gate_resolution_endpoint(id=uuid.uuid4(), session=AsyncMock(), org_id=uuid.uuid4(),
+                                                auth=SimpleNamespace(user_id=str(uuid.uuid4())))
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_discuss_endpoint_non_approver_403_service_not_called():
+    """⭐discuss는 승인/거부와 동일 자격 — non-doc 게이트에서 project owner/admin 아니면 403."""
+    from app.routers import gates as gates_mod
+    from app.routers.gates import request_gate_discussion_endpoint, GateDiscussionRequest
+    from fastapi import HTTPException
+    caller = _resolved_human()
+    fake_gate = SimpleNamespace(id=uuid.uuid4(), gate_type="merge", work_item_type="story",
+                                work_item_id=uuid.uuid4())
+    result = AsyncMock()
+    result.scalar_one_or_none = lambda: fake_gate
+    discussfn = AsyncMock()
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=caller)), \
+         patch.object(gates_mod, "resolve_work_item_project_id", AsyncMock(return_value=uuid.uuid4())), \
+         patch.object(gates_mod, "_non_doc_can_approve", AsyncMock(return_value=False)), \
+         patch.object(gates_mod, "request_gate_discussion", discussfn):
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=result)
+        with pytest.raises(HTTPException) as ei:
+            await request_gate_discussion_endpoint(
+                id=uuid.uuid4(), body=GateDiscussionRequest(reason="사유"), session=session,
+                org_id=uuid.uuid4(), auth=SimpleNamespace(user_id=str(uuid.uuid4())),
+            )
+    assert ei.value.status_code == 403
+    discussfn.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_discuss_endpoint_agent_caller_403():
+    """⭐승인/거부와 동일하게 에이전트(비휴먼)는 discuss 요청도 불가."""
+    from app.routers import gates as gates_mod
+    from app.routers.gates import request_gate_discussion_endpoint, GateDiscussionRequest
+    from fastapi import HTTPException
+    from app.services.member_resolver import ResolvedMember
+    caller = ResolvedMember(id=uuid.uuid4(), user_id=uuid.uuid4(), name="agent", type="agent",
+                            role="member", org_id=uuid.uuid4())
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=caller)):
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=SimpleNamespace(scalar_one_or_none=lambda: None))
+        with pytest.raises(HTTPException) as ei:
+            await request_gate_discussion_endpoint(
+                id=uuid.uuid4(), body=GateDiscussionRequest(reason="사유"), session=session,
+                org_id=uuid.uuid4(), auth=SimpleNamespace(user_id=str(uuid.uuid4())),
+            )
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_discuss_endpoint_forces_actor_from_auth():
+    from app.routers import gates as gates_mod
+    from app.routers.gates import request_gate_discussion_endpoint, GateDiscussionRequest
+    caller = _resolved_human()
+    fake_gate = SimpleNamespace(id=uuid.uuid4(), gate_type="artifact_canonicalize", work_item_type="visual_artifact",
+                                work_item_id=uuid.uuid4())
+    result = SimpleNamespace(scalar_one_or_none=lambda: fake_gate)
+    discussfn = AsyncMock(return_value=SimpleNamespace())
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=caller)), \
+         patch.object(gates_mod, "request_gate_discussion", discussfn), \
+         patch.object(gates_mod.GateResponse, "model_validate", lambda g: "OK"):
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=result)
+        await request_gate_discussion_endpoint(
+            id=uuid.uuid4(), body=GateDiscussionRequest(reason="사유"), session=session,
+            org_id=uuid.uuid4(), auth=SimpleNamespace(user_id=str(uuid.uuid4())),
+        )
+    # request_gate_discussion(session, org_id, gate_id, actor_id, reason) — actor=caller.id
+    assert discussfn.call_args.args[3] == caller.id

--- a/backend/tests/test_a2a_sa3_link_gate_to_task_realdb.py
+++ b/backend/tests/test_a2a_sa3_link_gate_to_task_realdb.py
@@ -28,6 +28,7 @@ async def _session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base
     import app.models  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — #2631: transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
 
     url = _REAL_DB_URL
     for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):

--- a/backend/tests/test_a2a_sa5_auth_required_realdb.py
+++ b/backend/tests/test_a2a_sa5_auth_required_realdb.py
@@ -30,6 +30,7 @@ async def _session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base
     import app.models  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — #2631: transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
 
     url = _REAL_DB_URL
     for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):

--- a/backend/tests/test_ccbcd9da_gate_wake_wiring_realdb.py
+++ b/backend/tests/test_ccbcd9da_gate_wake_wiring_realdb.py
@@ -37,6 +37,7 @@ async def _session():
     import app.models.participation  # noqa: F401
     import app.models.workflow_line  # noqa: F401
     import app.models.event  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — #2631: transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
     url = _REAL_DB_URL
     for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
         if url.startswith(prefix):

--- a/backend/tests/test_deeplink_manifest_contract.py
+++ b/backend/tests/test_deeplink_manifest_contract.py
@@ -88,13 +88,14 @@ def test_conversation_mention_lands_in_chat_tab():
     assert entry.app.parent_tab == ParentTab.chat
 
 
-def test_manifest_covers_all_27_dispatch_notification_event_types():
+def test_manifest_covers_all_28_dispatch_notification_event_types():
     """AC1 회귀 고정: story #1951 GATE1 전수 조사에서 확인한 dispatch_notification()
     event_type 리터럴이 전부 등재돼 있어야 한다. 새 알림 타입이 코드에 추가되고
     이 집합이 갱신 안 되면 이 테스트가 알려준다(양방향 대조 — 매니페스트 초과분도 잡음).
     story #2617: conversation.unsupervised_chain_expired 신설로 24→25.
     story #2624: doc_approval_resolved 신설로 25→26.
-    story #2630: conversation.circuit_breaker_opened 신설로 26→27."""
+    story #2630: conversation.circuit_breaker_opened 신설로 26→27.
+    story #2631: doc_approval_discussion_requested 신설로 27→28."""
     expected = {
         "sprint_closed", "task_completed", "story_assigned", "comment.created",
         "artifact.created", "artifact.exported", "artifact.updated", "artifact.canonicalized",
@@ -103,7 +104,7 @@ def test_manifest_covers_all_27_dispatch_notification_event_types():
         "gate.pending_approval", "gate_overridden", "gate_approval_requested", "gate_reassigned",
         "doc_approval_requested", "handoff_fallback", "story_status_changed",
         "conversation.unsupervised_chain_expired", "doc_approval_resolved",
-        "conversation.circuit_breaker_opened",
+        "conversation.circuit_breaker_opened", "doc_approval_discussion_requested",
     }
     actual = {e.app.type for e in DEEPLINK_MANIFEST.entries}
     missing = expected - actual

--- a/backend/tests/test_deeplink_manifest_endpoint.py
+++ b/backend/tests/test_deeplink_manifest_endpoint.py
@@ -48,7 +48,8 @@ async def test_deeplink_manifest_endpoint_returns_200_with_schema_version_and_lo
     # story #2617: conversation.unsupervised_chain_expired 신설로 33→34.
     # story #2624: doc_approval_resolved 신설로 34→35.
     # story #2630: conversation.circuit_breaker_opened 신설로 35→36.
-    assert isinstance(body["entries"], list) and len(body["entries"]) == 36
+    # story #2631: doc_approval_discussion_requested 신설로 36→37.
+    assert isinstance(body["entries"], list) and len(body["entries"]) == 37
 
     # 미르코 point ②: lookup_key = f"{type}:{entity_type}" (구분자 ":") 서빙 시점 파생.
     story_entry = next(

--- a/backend/tests/test_edg_s13_sla_processor.py
+++ b/backend/tests/test_edg_s13_sla_processor.py
@@ -31,6 +31,7 @@ async def _session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base
     import app.models  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — #2631: transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
     import app.models.workflow_line  # noqa: F401
     import app.models.participation  # noqa: F401 — gate_resolver FK 등록
     import app.models.gate  # noqa: F401

--- a/backend/tests/test_edg_s14_role_resolver.py
+++ b/backend/tests/test_edg_s14_role_resolver.py
@@ -28,6 +28,7 @@ async def _session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base
     import app.models  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — #2631: transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
     import app.models.workflow_line  # noqa: F401
     url = _REAL_DB_URL
     for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):

--- a/backend/tests/test_edg_s16_seed.py
+++ b/backend/tests/test_edg_s16_seed.py
@@ -25,6 +25,7 @@ async def _session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base
     import app.models  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — #2631: transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
     import app.models.workflow_line  # noqa: F401
     url = _REAL_DB_URL
     for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):

--- a/backend/tests/test_edg_s23_hypothesis_overlay.py
+++ b/backend/tests/test_edg_s23_hypothesis_overlay.py
@@ -74,6 +74,7 @@ async def _session():
     import app.models  # noqa: F401
     import app.models.participation  # noqa: F401 — org_gate_override FK 타깃(metadata 완전성·import 순서 무관)
     import app.models.workflow_line  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — #2631: transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
     url = _REAL_DB_URL
     for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
         if url.startswith(prefix):

--- a/backend/tests/test_edg_s29_dryrun_preview.py
+++ b/backend/tests/test_edg_s29_dryrun_preview.py
@@ -60,6 +60,7 @@ async def _session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base
     import app.models  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — #2631: transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
     import app.models.workflow_line  # noqa: F401
     url = _REAL_DB_URL
     for prefix in ("postgresql+psycopg2://", "postgresql://"):

--- a/backend/tests/test_edg_s2_config_governance.py
+++ b/backend/tests/test_edg_s2_config_governance.py
@@ -155,6 +155,7 @@ async def _make_engine_session():
 
     from app.core.database import Base
     import app.models  # noqa: F401 — 전 모델 등록(create_all)
+    import app.models.activity_log  # noqa: F401 — #2631: transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
     import app.models.workflow_line  # noqa: F401
 
     url = _REAL_DB_URL

--- a/backend/tests/test_edg_s31_hold.py
+++ b/backend/tests/test_edg_s31_hold.py
@@ -40,6 +40,7 @@ async def _session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base
     import app.models  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — #2631: transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
     import app.models.participation  # noqa: F401
     import app.models.workflow_line  # noqa: F401
     url = _REAL_DB_URL

--- a/backend/tests/test_edg_s32_reassign.py
+++ b/backend/tests/test_edg_s32_reassign.py
@@ -27,6 +27,7 @@ async def _session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base
     import app.models  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — #2631: transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
     import app.models.participation  # noqa: F401
     import app.models.workflow_line  # noqa: F401
     url = _REAL_DB_URL

--- a/backend/tests/test_edg_s33_override.py
+++ b/backend/tests/test_edg_s33_override.py
@@ -31,6 +31,7 @@ async def _session():
     import app.models  # noqa: F401
     import app.models.participation  # noqa: F401
     import app.models.workflow_line  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — #2631: override_gate()→transition_gate()가 ActivityLog를 씀.
     url = _REAL_DB_URL
     for prefix in ("postgresql+psycopg2://", "postgresql://"):
         if url.startswith(prefix):

--- a/backend/tests/test_edg_s34_line_versions.py
+++ b/backend/tests/test_edg_s34_line_versions.py
@@ -27,6 +27,7 @@ async def _session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base
     import app.models  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — #2631: transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
     import app.models.participation  # noqa: F401
     import app.models.workflow_line  # noqa: F401
     url = _REAL_DB_URL

--- a/backend/tests/test_edg_s9_parallel_quorum.py
+++ b/backend/tests/test_edg_s9_parallel_quorum.py
@@ -31,6 +31,7 @@ async def _session():
     import app.models.participation  # noqa: F401 — gate_resolver FK(participation_role) 등록
     import app.models.gate  # noqa: F401
     import app.models.hitl_config  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — #2631: transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
     url = _REAL_DB_URL
     for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
         if url.startswith(prefix):

--- a/backend/tests/test_h1_fix2_approve_advances_done.py
+++ b/backend/tests/test_h1_fix2_approve_advances_done.py
@@ -97,6 +97,7 @@ async def test_transition_approve_drives_story_done_real_db():
 
     from app.core.database import Base
     import app.models  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — #2631: transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
     from app.models.gate import Gate
     from app.models.participation import Participation, ParticipationRole
     from app.models.pm import Story

--- a/backend/tests/test_h1_s10_e2e.py
+++ b/backend/tests/test_h1_s10_e2e.py
@@ -34,6 +34,7 @@ async def test_h1_end_to_end_ready_to_done():
 
     from app.core.database import Base
     import app.models  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — #2631: transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
     from app.models.gate import Gate
     from app.models.hitl_config import OrgGatePolicy
     from app.models.participation import Participation, ParticipationRole

--- a/backend/tests/test_h1_s7_gate_verdict.py
+++ b/backend/tests/test_h1_s7_gate_verdict.py
@@ -147,6 +147,7 @@ async def test_human_review_verdict_reflected_in_trust_real_db():
 
     from app.core.database import Base
     import app.models  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — #2631: transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
     from app.models.gate import Gate
     from app.models.participation import Participation, ParticipationRole
     from app.models.pm import Story


### PR DESCRIPTION
## 배경
story #2631 — 선생님이 실사용 중 반려 의도로 승인 오클릭(2026-08-13 19:49). 되돌릴 경로도, 「승인도 반려도 아닌·논의 필요」를 표현할 경로도 없었다.

## 변경
- **`undo_gate_resolution`**(신규, `gate_service.py`): approved/rejected 직후 5분 창(`GATE_UNDO_WINDOW`) 안에서 **해소자 본인만** pending으로 되돌린다. void/hold와 같은 축(일반 `_VALID_TRANSITIONS` 밖 별도 guard 함수). doc_approval 게이트는 `doc.status`도 동반 복원 — 멱등 가드로 그 사이 다른 경로로 바뀐 경우는 안 건드림. **범위 절제**(PO 판정): `workflow_line_resolution`의 line 전진 등 다른 부수효과는 스코프 밖 — docstring에 명시.
- **`request_gate_discussion`**(신규): 승인/거부 옆 3번째 응답. 게이트는 **pending 유지**(전이 없음) — 사유를 `neutral_facts.discussion_requested`에 얹고 감사 로그를 남긴다. 인가는 승인/거부와 **동일 자격**(`_authorize_gate_approve_equivalent`로 `transition_gate_endpoint`의 기존 doc/non-doc 인가 블록을 추출해 공유 — 신규 규칙 아님, DRY). requester 개념이 있는 doc_approval만 실제 회신(`dispatch_approval_discussion_reply`, `dispatch_approval_result_reply`와 동형)하고, 그 외 타입은 회신 스킵 사실을 `requester_notified=False`로 ActivityLog에 명시(#2655 "조용한 재연결 루프" 교훈 재적용 — 조용한 no-op 금지).
- 두 액션 모두 `ActivityLogService`에 이전 상태 스냅샷 기록(gate 행 자체는 pending으로 되돌아가며 사라지는 값이라 감사 이력은 여기서만 보존). `transition_gate()`에도 동일 패턴의 ActivityLog 기록 추가.
- 신규 엔드포인트: `POST /gates/{id}/undo`, `POST /gates/{id}/discuss`.

## 검증
- **테스트**: `tests/test_2631_gate_undo_discuss.py` 24건 — service(realdb)/router(mock)/`_notify_gate_discussion_requester`(no_db mock, #2624 패턴) 3계층. Docker 데몬이 이 세션에서 계속 불안정해(이전 스토리들과 동일 이슈) `docker-compose`형 CI 픽스처 대신 **로컬 disposable postgres@16(브루)를 스크래치 디렉터리에 직접 initdb**해 실PG로 24건 전부 GREEN 확인 후 즉시 정리(재사용 오염 방지).
- **뮤테이션 킬 확인**: `undo_gate_resolution`의 본인-확인(`resolver_id != actor_id`)을 임시로 무력화(`if False:`)했더니 `test_undo_not_self_raises`가 실제로 RED — 가드가 SoD 우회를 진짜로 잡는다는 것을 직접 확인 후 원복.
- **회귀**: 같은 disposable DB로 `test_gate_transition_human_only.py`/`test_gate_can_approve_48f064e5.py`/`test_2624_gate_requester_reply_gating.py`/`test_edg_s31_hold.py`/`test_2027_gate_approval_reason_enforce.py` 재실행 — 전부 GREEN(`transition_gate_endpoint`의 인가 블록을 헬퍼로 추출한 리팩터가 기존 동작을 안 바꿨는지 확인). `test_2198_non_doc_gate_authz_realdb.py`는 이 파일 자체가 raw-SQL 시더에 `projects.violation_level` 등 실제 Alembic 마이그된 스키마를 전제해 이 disposable(비-마이그) DB에서 실행 불가 — 원본(수정 전 코드)도 동일하게 실패함을 확인해 이 PR로 인한 회귀가 아님을 확인. 이 파일은 CI의 마이그된 realdb job에서 검증 바람.
- Docker 재기동 계속 실패 중 — CI가 실제 판정자.