### PR TITLE
fix(events): add id to EventDefinitionResponse — closes PATCH discoverability gap

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1095,6 +1095,10 @@ async def publish_registry_event(
 
 
 class EventDefinitionResponse(BaseModel):
+    # story #2663 — id가 없어 GET 목록에서 얻은 정의를 PATCH(uuid 필수)로 못 이어갔다(org
+    # admin도 DB를 직접 파야 하는 갭이었다 — 2026-08-15 P2 어휘 집행 중 실측). 값은
+    # EventDefinitionDetailResponse/_event_definition_detail과 동일하게 str(uuid).
+    id: str
     key: str
     org_id: str | None
     payload_schema: dict
@@ -1125,7 +1129,7 @@ async def list_event_definitions(
     )).scalars().all()
     return [
         EventDefinitionResponse(
-            key=r.key, org_id=str(r.org_id) if r.org_id else None,
+            id=str(r.id), key=r.key, org_id=str(r.org_id) if r.org_id else None,
             payload_schema=r.payload_schema, routing=r.routing,
             block_template=r.block_template, enabled=r.enabled, version=r.version,
         )

--- a/backend/tests/test_2634_event_definitions_list.py
+++ b/backend/tests/test_2634_event_definitions_list.py
@@ -69,6 +69,23 @@ async def _seed_org(session, *, slug):
     return org.id
 
 
+async def _seed_org_member(session, org_id, *, role="admin"):
+    from app.models.project import OrgMember
+
+    user_id = uuid.uuid4()
+    session.add(OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user_id, role=role))
+    await session.commit()
+    return user_id
+
+
+def _human_auth(user_id: uuid.UUID, org_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(user_id), email="admin@example.com",
+        claims={"app_metadata": {"org_id": str(org_id)}}, org_id=str(org_id),
+    )
+
+
 async def _seed_custom_definition(session, org_id, *, slug, key_suffix, enabled=True):
     from app.models.event_definition import EventDefinition
 
@@ -125,5 +142,55 @@ async def test_list_exposes_disabled_definitions_not_hidden():
             result = await list_event_definitions(db=s, org_id=org_id)
             match = next(r for r in result if r.key == "org.acme2.thing.done")
             assert match.enabled is False
+    finally:
+        await engine.dispose()
+
+
+# story #2663 — GET 목록에서 id가 빠져 있어 PATCH(uuid 필수)로 이어갈 수 없었다(org admin도
+# DB를 직접 파야 했던 갭). 아래 두 테스트: ①목록 각 항목에 id 존재 ②그 id로 실제 PATCH 200
+# 왕복(양성대조).
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_list_items_include_id():
+    from app.routers.events import list_event_definitions
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s, slug="acme3")
+            definition_id = await _seed_custom_definition(s, org_id, slug="acme3", key_suffix="widget.made")
+
+            result = await list_event_definitions(db=s, org_id=org_id)
+            match = next(r for r in result if r.key == "org.acme3.widget.made")
+            assert match.id == str(definition_id)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_list_id_round_trips_through_patch():
+    """AC2 양성대조: GET 목록에서 얻은 id 그대로 PATCH가 200으로 닿는다(존재하지 않는/변형된
+    id가 아니라, 실제 목록 응답의 그 값)."""
+    import uuid as _uuid
+
+    from app.routers.events import UpdateEventDefinitionRequest, list_event_definitions, update_event_definition
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s, slug="acme4")
+            admin_id = await _seed_org_member(s, org_id, role="admin")
+            await _seed_custom_definition(s, org_id, slug="acme4", key_suffix="widget.patched")
+
+            listed = await list_event_definitions(db=s, org_id=org_id)
+            match = next(r for r in listed if r.key == "org.acme4.widget.patched")
+
+            patched = await update_event_definition(
+                _uuid.UUID(match.id), UpdateEventDefinitionRequest(enabled=False),
+                db=s, auth=_human_auth(admin_id, org_id), org_id=org_id,
+            )
+            assert patched.id == match.id
+            assert patched.enabled is False
     finally:
         await engine.dispose()


### PR DESCRIPTION
## Summary
story #2663 (elevated: blocker for story #0f5285a5, the event-definitions management screen) — `GET /api/v2/events/definitions` never returned `id`, but `PATCH /api/v2/events/definitions/{definition_id}` requires it. Org admins browsing the list had no way to get a definition's id to patch it — during today's P2 vocabulary rollout, resolving the real `gate_cycle` definition's id required a one-off Cloud Run job reading dev DB directly (id `cca7948a-504e-...`).

## Fix
Added `id: str` to `EventDefinitionResponse`, populated the same way `EventDefinitionDetailResponse` already does (`str(uuid)`, via the existing `_event_definition_detail` convention) — no new pattern invented.

## Verified live on dev before fixing (bug is real, not theoretical)
```
GET /api/v2/events/definitions → 6 items, sample keys: ['key','org_id','payload_schema','routing','block_template','enabled','version'] — no `id`
```
Confirmed the real `org.moonklabs.work.gate_cycle` definition PO referenced is in that same unfixed list right now (`version: 2`) — once this deploys, PATCHing that exact id is the intended real-world positive control PO asked for (can't self-deploy to confirm here, needs a post-merge dev check).

## Tests
- `test_2634_event_definitions_list.py`: 2 new tests — `test_list_items_include_id` (list items carry the real id) and `test_list_id_round_trips_through_patch` (id from the list response is passed straight into `update_event_definition`, PATCH succeeds, field actually changes). Ran against a real disposable Postgres (native `postgresql@16`, Docker unavailable this session): 4/4 pass (2 new + 2 existing, no regression).
- Mutation: blanked the id (`id=""` instead of `id=str(r.id)`), re-ran the two new tests — both failed with `ValueError: badly formed hexadecimal UUID string`, the exact original failure mode when a caller tries to PATCH with a missing/blank id. Restored, re-ran: 4/4 GREEN again, `git diff` clean.

## AC
1. ✅ `GET /api/v2/events/definitions` items include `id`.
2. ✅ That id round-trips through `PATCH` (200, field change confirmed) — real test, not just schema presence.

## QA note
Self-QA not possible here (author = reviewer conflict, same pattern as recent stories today) — routing for cross-check.