### PR TITLE
feat(mcp): add sprintable_submit_for_approval + executable next_action on draft docs

### DIFF
--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -26,7 +26,11 @@ _GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
     ("meetings", ("meeting",)),
     ("retro", ("retro",)),
     ("standup", ("standup",)),
-    ("docs", ("doc", "search_docs")),
+    # story #2668: sprintable_submit_for_approval은 "doc" substring이 없다(propose_canonical_
+    # version/give_reward 등과 동형 함정) — "submit_for_approval" 명시 추가 없으면 core로 오분류
+    # 돼, role-scope 키(예 scope=["docs"])로 recruit된 에이전트가 이 도구를 호출 못 하는(403)
+    # 채로 조용히 회귀한다 — 이 스토리가 고치려던 "발견 못 함"과 결이 같은 새 차단이라 미리 막는다.
+    ("docs", ("doc", "search_docs", "submit_for_approval")),
     ("chat", ("chat", "message", "conversation")),
     ("sprints", ("sprint",)),
     ("hypotheses", ("hypothes",)),
@@ -357,6 +361,7 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_save_standup", "sprintable_search_docs", "sprintable_search_stories",
     "sprintable_send_chat_message", "sprintable_sprint_summary", "sprintable_standup_history",
     "sprintable_standup_missing",
+    "sprintable_submit_for_approval",
     # story #2010: sprintable_transition_goal — 목표 lifecycle 전이 전용 신설(구 _epic 별칭
     # 없음). tool_group()은 "goal" substring 매칭으로 "epics" 그룹에 귀속(add_goal/update_goal/
     # list_goals와 동일 그룹) — role_template.default_tool_groups의 "epics" literal이 그대로

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -70,8 +70,8 @@ from .tools.projects import (
 )
 from .tools.docs import (
     CreateDocInput, GetDocInput, ListDocsInput,
-    SearchDocsInput, UpdateDocInput,
-    create_doc, get_doc, list_docs, search_docs, update_doc,
+    SearchDocsInput, SubmitForApprovalInput, UpdateDocInput,
+    create_doc, get_doc, list_docs, search_docs, submit_for_approval, update_doc,
 )
 from .tools.goals import (
     AddGoalInput, ListGoalsInput, TransitionGoalInput, UpdateGoalInput,
@@ -553,11 +553,19 @@ _TOOL_DEFS: list[tuple] = [
      SearchDocsInput, search_docs),
     ("sprintable_create_doc",
      "[지식] 문서 생성. 응답 reference_token 필드가 이 문서를 가리키는 참조 토큰"
-     "([제목](entity:doc:id))을 준다 — 채팅 등에 그대로 쓰면 참조가 생긴다(story #2282).",
+     "([제목](entity:doc:id))을 준다 — 채팅 등에 그대로 쓰면 참조가 생긴다(story #2282). "
+     "결재가 필요한 문서(draft)면 응답 next_action에 sprintable_submit_for_approval 호출"
+     " 명세가 실린다 — 결재 상신은 REST가 아니라 그 도구로 한다.",
      CreateDocInput, create_doc),
     ("sprintable_update_doc",
-     "[지식] 문서 수정. 응답 reference_token은 sprintable_create_doc과 동일.",
+     "[지식] 문서 수정. 응답 reference_token은 sprintable_create_doc과 동일. next_action"
+     " 동봉 규칙도 동일.",
      UpdateDocInput, update_doc),
+    ("sprintable_submit_for_approval",
+     "[지식] 문서를 결재 상신한다(draft→pending, 승인 게이트 생성) — 문서 결재 상신은 이"
+     " 도구로 한다(REST POST /docs/{id}/transition을 직접 호출하지 않는다). 응답에 상신된"
+     " 문서와 그 상신이 실제로 만든 pending 게이트를 함께 반환.",
+     SubmitForApprovalInput, submit_for_approval),
     # Analytics (11)
     ("sprintable_get_project_overview",
      "[일감] 프로젝트 개요 통계 조회.",

--- a/backend/sprintable_mcp/tools/docs.py
+++ b/backend/sprintable_mcp/tools/docs.py
@@ -1,5 +1,6 @@
-"""문서 관련 MCP 도구 (5개) — E-SECURITY SEC-S1 확장: delete_doc 제거(에이전트 삭제 차단,
-delete_story와 동형 조치. 까심 적대적 QA 발견 갭)."""
+"""문서 관련 MCP 도구 (6개) — E-SECURITY SEC-S1 확장: delete_doc 제거(에이전트 삭제 차단,
+delete_story와 동형 조치. 까심 적대적 QA 발견 갭). story #2668(B3): submit_for_approval 추가
+— 결재 상신 REST(POST /{id}/transition)를 알아야만 상신 가능했던 걸 MCP 표면에 올린다."""
 from __future__ import annotations
 
 from typing import Literal
@@ -151,9 +152,26 @@ async def create_doc(args: CreateDocInput) -> list[TextContent]:
             body["is_folder"] = args.is_folder
         if args.tags is not None:
             body["tags"] = args.tags
-        return ok(await client.post("/api/v2/docs", json=body))
+        result = await client.post("/api/v2/docs", json=body)
+        _attach_submit_for_approval_next_action(result)
+        return ok(result)
     except Exception as exc:
         return err(str(exc))
+
+
+def _attach_submit_for_approval_next_action(doc: object) -> None:
+    """story #2668(B3) — next_action_code(`decision_pending`)는 사람이 읽는 문구고, 그걸 보고
+    "그래서 무슨 도구를 부르지"로 이어지는 경로가 없었다(REST `POST /{id}/transition`을
+    알아야만 상신 가능 — MCP 도구 목록엔 없어 발견 자체가 안 됐다, 오늘 PO 재발 2회의 구조
+    원인). draft 문서 응답에 `next_action`을 `{tool, args}` 실행 가능 명세로 동봉한다 —
+    BE의 next_action_code SSOT(app.services.next_action, 다중 소비자·PO 판정 이력 다수)는
+    건드리지 않는다(이 스토리 범위는 MCP 표면 하나). status가 draft가 아니면(이미 상신됐거나
+    다른 상태) 아무것도 안 붙인다 — 없는 행동을 지어내지 않는다."""
+    if isinstance(doc, dict) and doc.get("status") == "draft" and doc.get("id"):
+        doc["next_action"] = {
+            "tool": "sprintable_submit_for_approval",
+            "args": {"doc_id": doc["id"]},
+        }
 
 
 async def update_doc(args: UpdateDocInput) -> list[TextContent]:
@@ -182,6 +200,31 @@ async def update_doc(args: UpdateDocInput) -> list[TextContent]:
                     base_content = (current.get("content") or "") if isinstance(current, dict) else ""
                 snippets = "".join(a["embed_snippet"] for a in uploaded if isinstance(a, dict) and a.get("embed_snippet"))
                 updates["content"] = f"{base_content}\n{snippets}" if base_content else snippets
-        return ok(await client.patch(f"/api/v2/docs/{args.doc_id}", json=updates))
+        result = await client.patch(f"/api/v2/docs/{args.doc_id}", json=updates)
+        _attach_submit_for_approval_next_action(result)
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))
+
+
+class SubmitForApprovalInput(SprintableInput):
+    doc_id: str
+
+
+async def submit_for_approval(args: SubmitForApprovalInput) -> list[TextContent]:
+    """문서를 결재 상신(draft→pending) — `POST /{id}/transition`의 MCP 래퍼.
+
+    story #2668(B3): 응답에 doc(status=pending)뿐 아니라 그 상신이 실제로 만든 pending 게이트
+    (실물)를 동봉한다 — "호출은 200인데 게이트가 진짜 생겼는지"를 에이전트가 별도 조회 없이
+    이 한 번의 호출로 확認할 수 있게(AC1: MCP만으로 create_doc→submit_for_approval→pending
+    게이트 실물까지 왕복).
+    """
+    try:
+        doc = await client.post(f"/api/v2/docs/{args.doc_id}/transition", json={"status": "pending"})
+        gates = await client.get(
+            "/api/v2/gates", params={"work_item_id": args.doc_id, "work_item_type": "doc", "status": "pending"},
+        )
+        gate = gates[0] if isinstance(gates, list) and gates else None
+        return ok({"doc": doc, "gate": gate})
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/toolset.py
+++ b/backend/sprintable_mcp/toolset.py
@@ -25,7 +25,10 @@ _GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
     ("meetings", ("meeting",)),
     ("retro", ("retro",)),
     ("standup", ("standup",)),
-    ("docs", ("doc", "search_docs")),
+    # story #2668: sprintable_submit_for_approval — "doc" substring 없음, 명시 추가 필요
+    # (원본 app/services/mcp_toolset.py와 동기화 — 이 vendored 사본이 갈리면 story #2311
+    # 회귀가드가 잡는다).
+    ("docs", ("doc", "search_docs", "submit_for_approval")),
     ("chat", ("chat", "message", "conversation")),
     ("sprints", ("sprint",)),
     ("hypotheses", ("hypothes",)),

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -42,9 +42,10 @@ EXPECTED_TOOLS = {
     "sprintable_list_sprints", "sprintable_sprint_summary", "sprintable_activate_sprint",
     "sprintable_close_sprint", "sprintable_get_velocity", "sprintable_create_sprint",
     "sprintable_update_sprint",
-    # docs (5) — E-SECURITY SEC-S1(확장): delete_doc 의도적 제거(에이전트 삭제 차단)
+    # docs (6) — E-SECURITY SEC-S1(확장): delete_doc 의도적 제거(에이전트 삭제 차단). story #2668:
+    # submit_for_approval 추가(결재 상신 발견 축).
     "sprintable_list_docs", "sprintable_get_doc", "sprintable_search_docs",
-    "sprintable_create_doc", "sprintable_update_doc",
+    "sprintable_create_doc", "sprintable_update_doc", "sprintable_submit_for_approval",
     # analytics (11)
     "sprintable_get_project_overview", "sprintable_get_member_workload",
     "sprintable_get_sprint_velocity_history", "sprintable_search_stories",
@@ -132,8 +133,9 @@ def test_total_tool_count():
     # story #2634: sprintable_publish_event/sprintable_list_event_definitions 2종 신설
     # (이벤트 레지스트리 발행/카탈로그 조회) — 117→119. story #2636: sprintable_register_
     # event_definition/sprintable_update_event_definition 2종 신설(org 커스텀 등록/수정) —
-    # 119→121.
-    assert len(_TOOLS) == 121
+    # 119→121. story #2668(B3): sprintable_submit_for_approval 1종 신설(문서 결재 상신
+    # REST를 MCP로 노출 — 도구 목록에 없어 에이전트가 발견 못 하던 것) — 121→122.
+    assert len(_TOOLS) == 122
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_2412_mcp_unknown_arg_rejection.py
+++ b/backend/tests/test_2412_mcp_unknown_arg_rejection.py
@@ -69,14 +69,15 @@ async def test_registered_standup_history_tool_still_accepts_known_args():
 
 
 def test_all_registered_tools_share_the_same_lockdown():
-    """AC2 카운트 — `_TOOL_DEFS` 120개 + ping 1개 = 121개(story #2634: sprintable_publish_event/
+    """AC2 카운트 — `_TOOL_DEFS` 121개 + ping 1개 = 122개(story #2634: sprintable_publish_event/
     sprintable_list_event_definitions 추가로 117→119. story #2636: sprintable_register_
-    event_definition/sprintable_update_event_definition 추가로 119→121) 전부 arg_model이
+    event_definition/sprintable_update_event_definition 추가로 119→121. story #2668:
+    sprintable_submit_for_approval 추가로 121→122) 전부 arg_model이
     extra=forbid로 잠겨 있어야 한다(상속 갈래 SprintableInput/BaseModel 안 가리고 전부)."""
     from sprintable_mcp import server as srv
 
     tools = srv.mcp._tool_manager.list_tools()
-    assert len(tools) == 121
+    assert len(tools) == 122
     unlocked = [
         t.name for t in tools
         if t.fn_metadata.arg_model.model_config.get("extra") != "forbid"

--- a/backend/tests/test_2668_mcp_submit_for_approval.py
+++ b/backend/tests/test_2668_mcp_submit_for_approval.py
@@ -1,0 +1,156 @@
+"""story #2668(B3, human-event-definer-design-v1) — 결재 상신이 REST(POST /docs/{id}/transition)를
+알아야만 가능해 MCP 도구 목록만 봐서는 발견이 안 됐다(오늘 PO 재발 2회의 구조 원인). 신설
+`sprintable_submit_for_approval` MCP 도구 + create_doc/update_doc 응답의 next_action 실행
+가능 명세({tool, args}) 동봉을 고정한다.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ─── _attach_submit_for_approval_next_action — 순수 함수 축 ───────────────────
+
+
+def test_attach_next_action_for_draft_doc():
+    from sprintable_mcp.tools.docs import _attach_submit_for_approval_next_action
+
+    doc = {"id": "doc-1", "status": "draft", "title": "x"}
+    _attach_submit_for_approval_next_action(doc)
+    assert doc["next_action"] == {
+        "tool": "sprintable_submit_for_approval",
+        "args": {"doc_id": "doc-1"},
+    }
+
+
+def test_no_next_action_for_non_draft_doc():
+    from sprintable_mcp.tools.docs import _attach_submit_for_approval_next_action
+
+    doc = {"id": "doc-1", "status": "pending", "title": "x"}
+    _attach_submit_for_approval_next_action(doc)
+    assert "next_action" not in doc
+
+
+def test_no_next_action_without_id_defensive():
+    from sprintable_mcp.tools.docs import _attach_submit_for_approval_next_action
+
+    doc = {"status": "draft", "title": "x"}  # id 없는 비정상 응답
+    _attach_submit_for_approval_next_action(doc)
+    assert "next_action" not in doc
+
+
+# ─── create_doc / update_doc — next_action 동봉 실배선 ─────────────────────────
+
+
+@pytest.mark.anyio
+async def test_create_doc_response_carries_submit_for_approval_next_action():
+    from sprintable_mcp.tools.docs import CreateDocInput, create_doc
+
+    with patch("sprintable_mcp.tools.docs.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.post = AsyncMock(return_value={"id": "doc-1", "status": "draft", "title": "x"})
+        out = await create_doc(CreateDocInput(title="x", slug="x"))
+
+    parsed = json.loads(out[0].text)
+    assert parsed["next_action"] == {
+        "tool": "sprintable_submit_for_approval",
+        "args": {"doc_id": "doc-1"},
+    }
+
+
+@pytest.mark.anyio
+async def test_update_doc_response_carries_submit_for_approval_next_action_when_still_draft():
+    from sprintable_mcp.tools.docs import UpdateDocInput, update_doc
+
+    with patch("sprintable_mcp.tools.docs.client") as mock_client:
+        mock_client.patch = AsyncMock(return_value={"id": "doc-1", "status": "draft", "title": "x2"})
+        out = await update_doc(UpdateDocInput(doc_id="doc-1", title="x2"))
+
+    parsed = json.loads(out[0].text)
+    assert parsed["next_action"]["tool"] == "sprintable_submit_for_approval"
+
+
+# ─── submit_for_approval — REST 래핑 + 게이트 실물 동봉 ────────────────────────
+
+
+@pytest.mark.anyio
+async def test_submit_for_approval_calls_transition_and_attaches_real_pending_gate():
+    from sprintable_mcp.tools.docs import SubmitForApprovalInput, submit_for_approval
+
+    doc_resp = {"id": "doc-1", "status": "pending", "title": "x"}
+    gate_resp = [{"id": "gate-1", "status": "pending", "work_item_id": "doc-1", "work_item_type": "doc"}]
+    with patch("sprintable_mcp.tools.docs.client") as mock_client:
+        mock_client.post = AsyncMock(return_value=doc_resp)
+        mock_client.get = AsyncMock(return_value=gate_resp)
+        out = await submit_for_approval(SubmitForApprovalInput(doc_id="doc-1"))
+
+    mock_client.post.assert_awaited_once_with(
+        "/api/v2/docs/doc-1/transition", json={"status": "pending"},
+    )
+    mock_client.get.assert_awaited_once_with(
+        "/api/v2/gates",
+        params={"work_item_id": "doc-1", "work_item_type": "doc", "status": "pending"},
+    )
+    parsed = json.loads(out[0].text)
+    assert parsed["doc"] == doc_resp
+    assert parsed["gate"] == gate_resp[0]
+
+
+@pytest.mark.anyio
+async def test_submit_for_approval_gate_none_when_lookup_empty_no_crash():
+    """AC1의 "게이트 실물 확認"이 실패해도(레이스·조회 지연 등) 도구 자체는 크래시하지 않고
+    gate=None으로 정직하게 보고한다 — doc 전이 자체는 성공했으므로 그 결과는 살린다."""
+    from sprintable_mcp.tools.docs import SubmitForApprovalInput, submit_for_approval
+
+    doc_resp = {"id": "doc-2", "status": "pending", "title": "y"}
+    with patch("sprintable_mcp.tools.docs.client") as mock_client:
+        mock_client.post = AsyncMock(return_value=doc_resp)
+        mock_client.get = AsyncMock(return_value=[])
+        out = await submit_for_approval(SubmitForApprovalInput(doc_id="doc-2"))
+
+    parsed = json.loads(out[0].text)
+    assert parsed["doc"] == doc_resp
+    assert parsed["gate"] is None
+
+
+@pytest.mark.anyio
+async def test_submit_for_approval_transition_error_surfaces_as_err_not_crash():
+    from sprintable_mcp.tools.docs import SubmitForApprovalInput, submit_for_approval
+
+    with patch("sprintable_mcp.tools.docs.client") as mock_client:
+        mock_client.post = AsyncMock(side_effect=RuntimeError("HTTP 422: INVALID_DOC_TRANSITION"))
+        out = await submit_for_approval(SubmitForApprovalInput(doc_id="doc-3"))
+
+    assert out[0].text.startswith("Error:")
+    assert "INVALID_DOC_TRANSITION" in out[0].text
+
+
+# ─── mcp_toolset.py — tool_group 분류(핵심 회귀축, propose_canonical_version류 함정과 동형) ────
+
+
+def test_submit_for_approval_classified_into_docs_group_not_core():
+    """"submit_for_approval"엔 "doc" substring이 없다 — 키워드에 명시 추가가 안 됐으면 core로
+    떨어져 role-scope 키(scope=["docs"])로 recruit된 에이전트가 이 도구를 403으로 못 부른다.
+    이 스토리가 고치려던 "발견 못 함"과 같은 결의 새 차단을 미리 잡는다."""
+    from app.services.mcp_toolset import tool_group
+
+    assert tool_group("sprintable_submit_for_approval") == "docs"
+
+
+def test_docs_scope_key_is_allowed_to_call_submit_for_approval():
+    from app.services.mcp_toolset import is_tool_allowed
+
+    assert is_tool_allowed("sprintable_submit_for_approval", ["docs"]) is True
+
+
+def test_stories_only_scope_key_is_blocked_from_submit_for_approval():
+    from app.services.mcp_toolset import is_tool_allowed
+
+    assert is_tool_allowed("sprintable_submit_for_approval", ["stories"]) is False

--- a/backend/tests/test_mcp_axis_prefix_b_surface.py
+++ b/backend/tests/test_mcp_axis_prefix_b_surface.py
@@ -75,6 +75,7 @@ def test_tool_names_and_param_models_untouched():
     신설(A2A AgentCard 발견) — 115→116. story #2634: sprintable_publish_event/
     sprintable_list_event_definitions 2종 신설(이벤트 레지스트리 발행/카탈로그) — 116→118.
     story #2636: sprintable_register_event_definition/sprintable_update_event_definition
-    2종 신설(org 커스텀 이벤트 등록/수정) — 118→120."""
-    assert len(_TOOL_DEFS) == 120
+    2종 신설(org 커스텀 이벤트 등록/수정) — 118→120. story #2668(B3): sprintable_submit_
+    for_approval 1종 신설(문서 결재 상신 MCP 발견 경로) — 120→121."""
+    assert len(_TOOL_DEFS) == 121
     assert all(name.startswith("sprintable_") for name in _TOOLS)


### PR DESCRIPTION
## Summary
story #2668 (B3, design doc `human-event-definer-design-v1`) — approval submission was only reachable via REST (`POST /docs/{id}/transition`), absent from the MCP tool list entirely, so agents couldn't discover it (today's structural cause behind PO hitting this twice via a REST workaround).

## Scope
① New tool `sprintable_submit_for_approval` — wraps the transition-to-pending call, and enriches the response with the *real* pending gate it created (`GET /gates?work_item_id=...`) so a caller can confirm the gate actually exists in one round trip, not just that the HTTP call returned 200.
② `create_doc`/`update_doc` responses now carry `next_action: {tool, args}` when the doc is still `draft` — an executable spec, not a string nobody parses. Scoped to the MCP layer only — deliberately did **not** touch `app/services/next_action.py`'s `next_action_code` SSOT, which has multiple consumers and a long PO-decision history; this story's scope is the MCP surface.
③ Tool description explicitly says "결재 상신은 이 도구로" (submit-for-approval goes through this tool, not REST) — discoverability axis.

## A real gap caught while implementing, not just following the spec
`tool_group()` classifies by substring match on the tool name minus prefix — `"submit_for_approval"` has no `"doc"` substring, so without an explicit keyword it would fall through to `core`. For a role-scoped key (e.g. `scope=["docs"]`, exactly what recruit narrows keys to per #2631/#2667 work today), that means `is_tool_allowed` would return `False` — the tool would exist but be **403 for the exact agents meant to use it**, reproducing this story's own "can't discover/use approval submission" symptom in a new form. Added `"submit_for_approval"` to the `docs` group keywords (same pattern as the existing `propose_canonical_version`/`give_reward` exceptions already documented in that file).

## Tests
- 11 new unit tests (`test_2668_mcp_submit_for_approval.py`): `next_action` attach conditions (draft/non-draft/missing-id), `create_doc`/`update_doc` carry the spec, `submit_for_approval`'s BE call sequence (transition then gate lookup with the right params), graceful `gate: null` when the lookup races/misses, error passthrough (not a crash) on a transition failure, and the `tool_group`/`is_tool_allowed` scope-classification fix (2 tests — would have failed 403 without the keyword addition).
- Mutation: reverted the draft-status gate on `_attach_submit_for_approval_next_action` (caught, restored) and the `docs` group keyword addition (caught with the exact 403-discovery-gap symptom this story exists to prevent, restored).
- Regression: 66/66 across docs + all MCP surface/count pin tests (updated 3 hardcoded tool-count pins: 120→121, 121→122, `ALL_TOOL_NAMES` addition).
- **Live round trip on dev** (not mocked): `POST /docs` → `POST /{id}/transition` (status=pending) → `GET /gates?work_item_id=...&status=pending` — confirmed a real `doc_approval` gate exists with the matching `work_item_id`, `next_action_code` correctly goes to `null` post-submission (nothing more for the author to do). Left a disposable QA-labeled doc/gate on dev (title `[QA·폐기용] #2668 ...`) — needs a human to close it out (agent transition/gate-approval is human-only, same constraint hit in prior sessions today).

## QA note
Self-QA not possible here (author = reviewer conflict) — routing for cross-check.