### PR TITLE
[SID:2669] 문서 참조 칩에 상태별 결재 CTA 상시 부착 (B2)

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -19,8 +19,12 @@ import koMessages from '../../../messages/ko.json';
 
 // story #2637 — mutable로 둬 EventBlockCard의 human_only/role 게이팅 테스트가 값을 오버라이드
 // 할 수 있게 한다(기본값은 기존 50+ 테스트와 동일하게 human/무역할 — 비회귀).
-let mockDashboardContext: { projectId: string; currentTeamMemberId: string; currentMemberType?: 'human' | 'agent'; role?: string } = {
+let mockDashboardContext: {
+  projectId: string; currentTeamMemberId: string; currentMemberType?: 'human' | 'agent'; role?: string;
+  projectMemberships?: { projectId: string; projectName: string }[];
+} = {
   projectId: 'proj-1', currentTeamMemberId: 'member-1', currentMemberType: 'human', role: 'member',
+  projectMemberships: [],
 };
 vi.mock('@/app/dashboard/dashboard-shell', () => ({
   useDashboardContext: () => mockDashboardContext,
@@ -71,7 +75,7 @@ afterEach(async () => {
   await act(async () => { root.unmount(); });
   container.remove();
   vi.unstubAllGlobals();
-  mockDashboardContext = { projectId: 'proj-1', currentTeamMemberId: 'member-1', currentMemberType: 'human', role: 'member' };
+  mockDashboardContext = { projectId: 'proj-1', currentTeamMemberId: 'member-1', currentMemberType: 'human', role: 'member', projectMemberships: [] };
 });
 
 describe('ChatBubble — story #2263 AC6 유령 칩(stored 참조 대조)', () => {
@@ -1221,5 +1225,156 @@ describe('ChatBubble — story #2037 이미지 라이트박스 진입점', () =>
     expect(document.body.textContent).toContain('2 / 2');
     const openedImg = document.querySelector('img[data-next-image="true"][alt="shot-2.png"]');
     expect(openedImg?.getAttribute('src')).toBe('https://signed/shot-2.png');
+  });
+});
+
+// story #2669(B2) — 문서 참조 칩(EntityChip)에 상태별 결재 CTA 상시 부착. PO 근거: 챗에
+// 문서를 임베드하고 "승인 주시면"이라 말로 때움 — 기제가 «찾아가야 있는 것»이면 안 쓰인다.
+describe('ChatBubble — story #2669(B2) doc 칩 결재 CTA', () => {
+  const DOC_STATUS_KEY = `doc:${DOC_ID.toLowerCase()}`;
+
+  it('draft + project 멤버 — "결재로 올리기" 버튼이 뜨고 클릭하면 transition POST 후 pending으로 즉시 반영된다', async () => {
+    mockDashboardContext.projectMemberships = [{ projectId: 'doc-proj-1', projectName: 'Doc Project' }];
+    const calls: { url: string; method?: string; body?: string }[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: { method?: string; body?: string }) => {
+      calls.push({ url, method: init?.method, body: init?.body });
+      if (url.startsWith('/api/docs/preview')) return { ok: true, json: async () => ({ data: { projectId: 'doc-proj-1' } }) };
+      if (url === `/api/docs/${DOC_ID}/transition` && init?.method === 'POST') return { ok: true, json: async () => ({ data: {} }) };
+      return { ok: false, json: async () => ({}) };
+    }));
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, references: [{ target_type: 'doc', target_id: DOC_ID }] }}
+          isMine={false}
+          entityStatusByKey={{ [DOC_STATUS_KEY]: { kind: 'resolved', raw: 'draft' } }}
+        />,
+      ));
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+
+    const submitBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '결재로 올리기');
+    expect(submitBtn).toBeDefined();
+    await act(async () => {
+      submitBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+
+    const transitionCall = calls.find((c) => c.url === `/api/docs/${DOC_ID}/transition`);
+    expect(transitionCall?.method).toBe('POST');
+    expect(JSON.parse(transitionCall!.body!)).toEqual({ status: 'pending' });
+    // 재조회 없이 로컬 반영 — 배지가 "검토 중"으로, 버튼은 "결재로 올리기"에서 "결재함에서 보기"로.
+    expect(container.textContent).toContain('검토 중');
+    expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent === '결재로 올리기')).toBe(false);
+    expect(container.textContent).toContain('결재함에서 보기');
+  });
+
+  it('draft지만 doc의 project 멤버가 아니면 "결재로 올리기" 버튼이 안 뜬다(fail-closed)', async () => {
+    mockDashboardContext.projectMemberships = [{ projectId: 'other-proj', projectName: 'Other' }];
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.startsWith('/api/docs/preview')) return { ok: true, json: async () => ({ data: { projectId: 'doc-proj-1' } }) };
+      return { ok: false, json: async () => ({}) };
+    }));
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, references: [{ target_type: 'doc', target_id: DOC_ID }] }}
+          isMine={false}
+          entityStatusByKey={{ [DOC_STATUS_KEY]: { kind: 'resolved', raw: 'draft' } }}
+        />,
+      ));
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+    expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent === '결재로 올리기')).toBe(false);
+  });
+
+  it('draft + 권한조회(preview) 실패 — 조용히 무권한 취급(버튼 노출 안 함, 카드 자체는 안 죽음)', async () => {
+    mockDashboardContext.projectMemberships = [{ projectId: 'doc-proj-1', projectName: 'Doc Project' }];
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, json: async () => ({}) })));
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, references: [{ target_type: 'doc', target_id: DOC_ID }] }}
+          isMine={false}
+          entityStatusByKey={{ [DOC_STATUS_KEY]: { kind: 'resolved', raw: 'draft' } }}
+        />,
+      ));
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+    expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent === '결재로 올리기')).toBe(false);
+    expect(container.textContent).toContain('제안서.md');
+  });
+
+  it('pending — "결재함에서 보기" 딥링크가 /inbox?tab=gates로 간다(상신 버튼은 안 뜸)', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, references: [{ target_type: 'doc', target_id: DOC_ID }] }}
+          isMine={false}
+          entityStatusByKey={{ [DOC_STATUS_KEY]: { kind: 'resolved', raw: 'pending' } }}
+        />,
+      ));
+      await Promise.resolve(); await Promise.resolve();
+    });
+    const link = Array.from(container.querySelectorAll('a')).find((a) => a.textContent === '결재함에서 보기');
+    expect(link?.getAttribute('href')).toBe('/inbox?tab=gates');
+    expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent === '결재로 올리기')).toBe(false);
+  });
+
+  it('denied — 배지가 "반려됨"으로 정직하게 뜨고 CTA는 없다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, references: [{ target_type: 'doc', target_id: DOC_ID }] }}
+          isMine={false}
+          entityStatusByKey={{ [DOC_STATUS_KEY]: { kind: 'resolved', raw: 'denied' } }}
+        />,
+      ));
+      await Promise.resolve(); await Promise.resolve();
+    });
+    expect(container.textContent).toContain('반려됨');
+    expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent === '결재로 올리기')).toBe(false);
+    expect(Array.from(container.querySelectorAll('a')).some((a) => a.textContent === '결재함에서 보기')).toBe(false);
+  });
+
+  it('confirmed — 배지가 "확定"으로 뜨고 CTA는 없다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, references: [{ target_type: 'doc', target_id: DOC_ID }] }}
+          isMine={false}
+          entityStatusByKey={{ [DOC_STATUS_KEY]: { kind: 'resolved', raw: 'confirmed' } }}
+        />,
+      ));
+      await Promise.resolve(); await Promise.resolve();
+    });
+    expect(container.textContent).toContain('확定');
+    expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent === '결재로 올리기')).toBe(false);
+  });
+
+  it('상신 실패(transition 500) — 재시도 가능한 에러 문구를 보이고 버튼은 draft 그대로 남는다', async () => {
+    mockDashboardContext.projectMemberships = [{ projectId: 'doc-proj-1', projectName: 'Doc Project' }];
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: { method?: string }) => {
+      if (url.startsWith('/api/docs/preview')) return { ok: true, json: async () => ({ data: { projectId: 'doc-proj-1' } }) };
+      if (url === `/api/docs/${DOC_ID}/transition` && init?.method === 'POST') return { ok: false, json: async () => ({}) };
+      return { ok: false, json: async () => ({}) };
+    }));
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, references: [{ target_type: 'doc', target_id: DOC_ID }] }}
+          isMine={false}
+          entityStatusByKey={{ [DOC_STATUS_KEY]: { kind: 'resolved', raw: 'draft' } }}
+        />,
+      ));
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+    const submitBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '결재로 올리기') as HTMLButtonElement;
+    await act(async () => {
+      submitBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+    expect(container.textContent).toContain('상신 실패');
+    expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent === '결재로 올리기')).toBe(true);
   });
 });

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -10,6 +10,7 @@ import {
   Calendar, Image, FlaskConical, Paperclip, type LucideIcon,
 } from 'lucide-react';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { docViewUrl } from '@/components/docs/lib/doc-project-url';
 import { resolveScopedEntityHref, storyBoardUrl, goalUrl, sprintUrl, assetStorageUrl } from '@/lib/entity-project-url';
 import { initials } from '@/lib/storage/format';
@@ -734,7 +735,56 @@ export function EntityChip({
   const [showModal, setShowModal] = useState(false);
   const colorClass = ghost ? GRAY_STATE_COLOR : (ENTITY_COLORS[entityType] ?? GRAY_STATE_COLOR);
 
-  const statusLabel = ghost ? null : renderEntityStatusLabel(entityType, entityStatus ?? { kind: 'loading' });
+  // story #2669(B2) — doc이 chat-view.tsx 배치조회로 draft라고 확認되면, 상신 가능(project
+  // write access) 여부를 딱 그 경우에만 추가 조회한다(모든 doc 칩마다 매번 조회하면 N+1 —
+  // 대부분의 참조는 이미 confirmed라 draft만 걸러 조회 비용을 줄인다). 승인 직후엔 서버
+  // 재조회 없이 이 칩의 로컬 상태만 'pending'으로 넘겨 즉시 반영(배치조회 다음 폴백까지
+  // "결재로 올리기"가 다시 뜨는 깜빡임을 막는다).
+  const { projectMemberships } = useDashboardContext();
+  const [localDocStatus, setLocalDocStatus] = useState<string | null>(null);
+  const [canSubmit, setCanSubmit] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState(false);
+  const rawDocStatus = entityStatus?.kind === 'resolved' ? entityStatus.raw : null;
+  const effectiveDocStatus = localDocStatus ?? rawDocStatus;
+
+  useEffect(() => {
+    if (entityType !== 'doc' || !entityId || effectiveDocStatus !== 'draft') { setCanSubmit(false); return; }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(`/api/docs/preview?q=${encodeURIComponent(entityId)}`);
+        if (!res.ok) throw new Error();
+        const json = (await res.json()) as { data?: { projectId?: string } };
+        const docProjectId = json.data?.projectId;
+        if (!cancelled) setCanSubmit(!!docProjectId && projectMemberships.some((p) => p.projectId === docProjectId));
+      } catch {
+        if (!cancelled) setCanSubmit(false); // ㉠ 조회 실패=fail-closed(버튼 안 보임), 조용한 무권한 노출 금지.
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [entityType, entityId, effectiveDocStatus, projectMemberships]);
+
+  const submitForApproval = async () => {
+    if (!entityId || submitting) return;
+    setSubmitting(true);
+    setSubmitError(false);
+    try {
+      const res = await fetch(`/api/docs/${entityId}/transition`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'pending' }),
+      });
+      if (!res.ok) throw new Error();
+      setLocalDocStatus('pending');
+    } catch {
+      setSubmitError(true);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const statusLabel = ghost ? null : renderEntityStatusLabel(entityType, localDocStatus ? { kind: 'resolved', raw: localDocStatus } : (entityStatus ?? { kind: 'loading' }));
 
   const inner = (
     <span className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs font-medium ${colorClass}`}>
@@ -756,8 +806,31 @@ export function EntityChip({
   }
 
   if (entityId) {
+    // story #2669(B2) — "쓰던 자리에 이미 있어야 한다": 모달을 열지 않고도 칩 자체에 상태별
+    // CTA가 상시 붙는다. draft=상신 가능자에게만 「결재로 올리기」(fail-closed) · pending=
+    // 「결재함에서 보기」 딥링크. confirmed/denied는 위 statusLabel 배지로 이미 정직하게 표시.
+    const docCta = entityType === 'doc' && !ghost ? (
+      effectiveDocStatus === 'draft' && canSubmit ? (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); void submitForApproval(); }}
+          disabled={submitting}
+          className="inline-flex shrink-0 items-center rounded border border-primary/40 px-1.5 py-0.5 text-xs font-medium text-primary no-underline hover:bg-primary/10 disabled:opacity-60"
+        >
+          {submitting ? '...' : '결재로 올리기'}
+        </button>
+      ) : effectiveDocStatus === 'pending' ? (
+        <Link
+          href="/inbox?tab=gates"
+          onClick={(e) => e.stopPropagation()}
+          className="inline-flex shrink-0 items-center rounded border border-border px-1.5 py-0.5 text-xs font-medium text-muted-foreground no-underline hover:bg-muted"
+        >
+          결재함에서 보기
+        </Link>
+      ) : null
+    ) : null;
     return (
-      <>
+      <span className="inline-flex flex-wrap items-center gap-1">
         <button
           type="button"
           onClick={() => setShowModal(true)}
@@ -765,6 +838,8 @@ export function EntityChip({
         >
           {inner}
         </button>
+        {docCta}
+        {submitError ? <span className="text-xs text-destructive">상신 실패, 다시 시도해 주세요</span> : null}
         {showModal && (
           <EntityPreviewModal
             entityType={entityType}
@@ -775,7 +850,7 @@ export function EntityChip({
             onClose={() => setShowModal(false)}
           />
         )}
-      </>
+      </span>
     );
   }
 

--- a/apps/web/src/components/chat/entity-status-labels.ts
+++ b/apps/web/src/components/chat/entity-status-labels.ts
@@ -36,7 +36,10 @@ const STATUS_LABELS: Record<StatusBearingEntityType, Record<string, string>> = {
     backlog: '대기', 'ready-for-dev': '착수 대기', 'in-progress': '진행 중', 'in-review': '검토 중', done: '완료',
   },
   task: { todo: '할 일', 'in-progress': '진행 중', done: '완료' },
-  doc: { draft: '초안', pending: '검토 중', confirmed: '확定' },
+  // story #2669 — denied가 이 맵에 없어(원 누락) 반려된 doc 칩엔 상태 문구가 아예 안 그려졌다
+  // (translateEntityStatus가 매핑 없으면 null을 내는 설계라 조용히 빈칸이 됐다 — 원시값 노출은
+  // 아니었지만 "정직한 표시"에서 벗어난 결함). docGateDenied와 같은 어휘로 통일.
+  doc: { draft: '초안', pending: '검토 중', confirmed: '확定', denied: '반려됨' },
   hypothesis: {
     proposed: '제안', active: '검증 중', measuring: '측정 중', verified: '입증', falsified: '반증', archived: '보관',
   },


### PR DESCRIPTION
## Summary
- 챗 메시지 본문의 `[제목](entity:doc:id)` 참조 칩(`EntityChip`)에 문서 상태별 CTA를 상시 부착:
  - **draft**: 「결재로 올리기」— project 쓰기권한(멤버십) 있는 사용자에게만 노출(fail-closed). 클릭 1회로 `POST /api/docs/{id}/transition {status:'pending'}`, 성공 시 재조회 없이 로컬 즉시 pending 반영.
  - **pending**: 「결재함에서 보기」— `/inbox?tab=gates` 딥링크.
  - **confirmed/denied**: 기존 상태 배지만(신규 액션 없음).
- 인가: FE는 project 멤버십으로 버튼 노출을 게이팅(가시성)·최종 인가는 BE `_require_doc_project_access`(403)가 강제.

## 그라운딩 정정(착수 전, PO 승인)
스토리 본문이 지칭한 `EmbedCard`(embed-card.tsx export)는 **실 챗 렌더 경로에 미배선**(`<EmbedCard` JSX 호출 앱 전체 0건, 테스트 파일에서만 참조) — 실제 라이브 경로는 같은 파일의 `EntityChip`(`chat-bubble.tsx`가 마크다운 `a` 렌더러로 실제 사용)이라 그쪽에 CTA를 배선했다. `EmbedCard` 자체의 미배선은 이번 스토리 범위 밖(PO가 별도 스토리로 기록, 손대지 않음).

## 부수 수정
`entity-status-labels.ts`의 `STATUS_LABELS.doc`에 `denied` 매핑이 누락돼 있었다(반려된 문서 칩이 상태 배지 없이 조용히 빈칸이었던 결함) — 발견 즉시 추가.

## Test plan
- [x] `pnpm exec tsc --noEmit` — 클린
- [x] `pnpm exec eslint` — 경고 0
- [x] `pnpm exec vitest run` — 416 files / 3338 tests 전부 통과(신규 7개: 상신 성공/무권한/조회실패/pending딥링크/denied배지/confirmed배지/상신실패 재시도)
- [x] `pnpm build` — exit 0
- [ ] 라이브 픽셀(dev 배포 후 실제 draft 문서 참조로 상신 왕복) — CI green 후 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)