### PR TITLE
[SID:2672] DocSummaryResponse에 status 필드 추가 — 배치조회 칩 상태배지 공백 해소

### DIFF
--- a/backend/app/schemas/doc.py
+++ b/backend/app/schemas/doc.py
@@ -62,6 +62,11 @@ class DocSummaryResponse(BaseModel):
     icon: str | None = None
     sort_order: int
     doc_type: str
+    # story #2672(2026-08-15, 미르코 라이브 실측 발견) — 단건(DocResponse) 응답엔 있었는데 이
+    # 배치조회 응답엔 status가 아예 없었다. C-4 이래 챗 doc 참조 칩 상태 배지·#2669 CTA(draft
+    # 판별)가 전부 이 응답을 쓰는 경로라 필드 부재만으로 조용히 빈칸이었다 — FE 소비 로직은
+    # 이미 옳게 짜여 있었다(BE 필드 하나 누락이 근본원인). DocResponse와 동일 기본값(draft).
+    status: str = "draft"
     is_folder: bool
     tags: list[str]
     created_at: datetime

--- a/backend/tests/test_2262_batch_ids_realdb.py
+++ b/backend/tests/test_2262_batch_ids_realdb.py
@@ -110,11 +110,12 @@ async def _make_task(session, org_id, story_id, title="Task"):
     return task
 
 
-async def _make_doc(session, org_id, project_id, title="Doc", slug=None):
+async def _make_doc(session, org_id, project_id, title="Doc", slug=None, status=None):
     from app.models.doc import Doc
+    kwargs = {} if status is None else {"status": status}
     doc = Doc(
         id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title,
-        slug=slug or f"doc-{uuid.uuid4().hex[:8]}",
+        slug=slug or f"doc-{uuid.uuid4().hex[:8]}", **kwargs,
     )
     session.add(doc)
     await session.commit()
@@ -274,6 +275,36 @@ async def test_docs_ids_returns_set_and_excludes_inaccessible_project_realdb():
             ids = {row["id"] for row in body["data"]}
             assert ids == {str(doc_a.id)}, "접근권 없는 project B의 doc이 새면 안 된다"
             assert body["meta"] == {"has_more": False, "next_cursor": None}
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_docs_ids_includes_status_realdb():
+    """story #2672 — 배치조회(?ids=) 응답에 status가 있어야 챗 doc 참조 칩 상태 배지·#2669
+    CTA(draft 판별)가 산다(C-4 이래 필드 부재로 조용히 빈칸이었던 것). 양성대조: draft
+    기본값 하나만 찍으면 "필드는 있는데 항상 draft로 굳어있다" 회귀를 못 잡으므로 confirmed
+    doc도 같이 만들어 실제 컬럼값이 그대로 실린다는 것까지 확인한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            f = await _two_project_fixture(s)
+            doc_draft = await _make_doc(s, f["org_id"], f["project_a"], "Draft Doc")
+            doc_confirmed = await _make_doc(s, f["org_id"], f["project_a"], "Confirmed Doc", status="confirmed")
+
+        await _setup_app_human(app, Session, f["caller_user_id"], f["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/docs?ids={doc_draft.id},{doc_confirmed.id}")
+            assert resp.status_code == 200, resp.text
+            by_id = {row["id"]: row for row in resp.json()["data"]}
+            assert by_id[str(doc_draft.id)]["status"] == "draft"
+            assert by_id[str(doc_confirmed.id)]["status"] == "confirmed"
         finally:
             await client.aclose()
     finally:


### PR DESCRIPTION
## 배경
미르코 라이브 실측 발견(2026-08-15, #2669 진행 중) — `GET /api/docs?ids=` 등 배치조회 전 경로(list/tree/search/ids 공용 `DocSummaryResponse`)에 `status` 필드 자체가 없었다. 단건(`DocResponse`)엔 있어 사각이었고, C-4 이래 챗 doc 참조 칩 상태 배지·#2669 CTA(draft 판별)가 전부 이 응답을 쓰는 경로라 필드 부재만으로 조용히 빈칸이었다.

## 변경
- `DocSummaryResponse`에 `status: str = "draft"` 추가(`DocResponse`와 동일 기본값). `Doc.status`는 실 컬럼이라 `from_attributes`가 자동 매핑 — 모든 호출부가 이미 `.model_validate(doc)` 패턴이라 추가 배선 불요.
- FE 소비 로직(기존 C-4·신규 B2 칩)은 이미 옳게 짜여 있다는 게 스토리 그라운딩(미르코) — BE 필드 하나로 즉시 살아나는 스코프. FE 변경 없음.

## 테스트
`test_2262_batch_ids_realdb.py`에 `test_docs_ids_includes_status_realdb` 신규 — draft doc과 confirmed doc을 같이 만들어 배치조회 응답에 각각의 실제 status값이 그대로 실리는지 확인(양성대조 — "필드는 생겼는데 항상 draft로 고정" 같은 얕은 회귀를 방지). 로컬 disposable postgres@16 + alembic head(0251)로 실행: 신규 1건 포함 6/6 GREEN.

뮤테이션: `status` 필드를 되돌려 재실행 → 신규 테스트가 정확히 `KeyError: 'status'`로 RED. 원복 후 재확인 GREEN, `git diff` 클린.

회귀: `tests/ -k doc -m "not destructive_schema"` 308/309 GREEN(잔여 1건은 로컬 pg_pubsub 포트 미기동 — 이 워크트리 환경 무관, #2631/#3072에서도 동일 클래스로 확認된 바 있음).

## AC
1. ✅ `GET /api/docs?ids=` 응답 각 항목에 status 포함(단건과 동형)
2. dev 라이브 판정(CTA·상태배지 렌더)은 배포 후 PO/미르코 확인 — 이 PR은 BE 필드 단이 스코프
3. #2669 라이브 판정 재개 조건 충족(BE 배선 완료)