### PR TITLE
fix(chat): entity-token regex didn't handle escaped-bracket titles — #2638 card never fired

### DIFF
--- a/apps/web/src/components/chat/intent-suggestion-card.compute.test.ts
+++ b/apps/web/src/components/chat/intent-suggestion-card.compute.test.ts
@@ -4,8 +4,11 @@ import type { EntityStatusFetchState } from '@/components/chat/entity-status-lab
 
 const DOC_ID = 'aabbccdd-1111-1111-1111-111111111111';
 const STORY_ID = '22222222-2222-2222-2222-222222222222';
-const docToken = (id: string) => `[제목](entity:doc:${id})`;
-const storyToken = (id: string) => `[제목](entity:story:${id})`;
+// PO 라이브 판정 RED(2026-08-15) — "심은 표본엔 아는 종류만" 교훈. 공용 헬퍼부터 실 정본
+// 이스케이프 토큰(제목에 대괄호 든 QA 폐기용 문서류·reference_token.py:_escape_title 산출물)
+// 으로 바꿔, 이 파일의 기존 시나리오 테스트 전부가 그 형태로 자동 재검증되게 한다.
+const docToken = (id: string) => `[\\[QA·폐기용\\] 제목](entity:doc:${id})`;
+const storyToken = (id: string) => `[\\[QA·폐기용\\] 제목](entity:story:${id})`;
 
 describe('computeSuggestion (story #2638) — AC1/AC3', () => {
   it('AC1 — PO 재발 메시지 재연: 승인 문구+draft doc 참조+게이트 부재 조합에서 제안이 뜬다', () => {

--- a/apps/web/src/components/chat/intent-suggestion-card.mount.test.tsx
+++ b/apps/web/src/components/chat/intent-suggestion-card.mount.test.tsx
@@ -38,7 +38,8 @@ vi.mock('@/app/dashboard/dashboard-shell', () => ({
 }));
 
 const DOC_ID = 'aabbccdd-1111-1111-1111-111111111111';
-const docToken = `[제목](entity:doc:${DOC_ID})`;
+// PO 라이브 판정 RED(2026-08-15) 회귀가드 — 실 정본 이스케이프 토큰 형태로.
+const docToken = `[\\[QA·폐기용\\] 제목](entity:doc:${DOC_ID})`;
 
 function jsonResponse(body: unknown, ok = true, status = ok ? 200 : 500) {
   return { ok, status, json: async () => body } as Response;

--- a/apps/web/src/lib/intent-suggestion-classifier.test.ts
+++ b/apps/web/src/lib/intent-suggestion-classifier.test.ts
@@ -41,6 +41,23 @@ describe('intent-suggestion-classifier (story #2638)', () => {
     expect(extractEntityRefs(null)).toEqual([]);
   });
 
+  // PO 라이브 판정 RED(2026-08-15) 회귀가드 — 정본 토큰(reference_token.py:_escape_title)은
+  // 제목의 \ [ ] ( ) 를 전부 백슬래시 이스케이프한다. 처음 심은 표본이 전부 "제목"류 무괄호
+  // 였던 탓에 이 케이스를 못 잡았다("심은 표본엔 아는 종류만" — PO 교훈). QA 폐기용 문서류
+  // ("[QA·폐기용] ...")가 실제 재현 사례였다.
+  it('extractEntityRefs — 제목에 대괄호가 든 정본 이스케이프 토큰(실 재현 사례)도 매치한다', () => {
+    const id = 'aabbccdd-1111-1111-1111-111111111111';
+    const content = `[\\[QA·폐기용\\] #2668 확認용 문서](entity:doc:${id}) 승인 주시면`;
+    expect(extractEntityRefs(content)).toEqual([{ type: 'doc', id }]);
+  });
+
+  it('extractEntityRefs — 제목에 괄호·백슬래시가 섞여도(이스케이프 5종 전부) 매치한다', () => {
+    const id = 'aabbccdd-2222-2222-2222-222222222222';
+    // 원제목: `기획(안) [v2] 검토\완료` → _escape_title이 ( ) [ ] \ 를 전부 이스케이프.
+    const content = `[기획\\(안\\) \\[v2\\] 검토\\\\완료](entity:doc:${id})`;
+    expect(extractEntityRefs(content)).toEqual([{ type: 'doc', id }]);
+  });
+
   it('firstRefOfType — 지정 타입 중 첫 매치만', () => {
     const refs = [
       { type: 'story', id: 's1' },

--- a/apps/web/src/lib/intent-suggestion-classifier.ts
+++ b/apps/web/src/lib/intent-suggestion-classifier.ts
@@ -16,10 +16,18 @@ export interface EntityRef {
   id: string;
 }
 
-const ENTITY_TOKEN_RE = /\[[^\]]*\]\(entity:([a-z]+):([0-9a-fA-F-]{36})\)/g;
+// PO 라이브 판정 RED(2026-08-15) — 정본 토큰(reference_token.py:_escape_title)은 제목 안의
+// `\` [ ] ( ) 다섯 글자를 전부 백슬래시로 이스케이프한다("[QA·폐기용] 제목" → "\[QA·폐기용\]
+// 제목"). 첫 버전 `[^\]]*`는 이스케이프된 `\]`의 `]` 문자 자체에서 멈춰버려(백슬래시를 못 봄)
+// 실 토큰(제목에 대괄호가 든 것 — QA 폐기용 문서류가 전형)에서 전부 매치 실패했다. chat-bubble.
+// tsx의 렌더은 react-markdown 실 파서(CommonMark 이스케이프 규칙 완전 준수)라 칩은 멀쩡히
+// 떴다 — 이 정규식만 그 규칙을 흉내 못 낸 것. `(?:[^\]\\]|\\.)*` — `]`도 `\`도 아닌 문자
+// 또는 "백슬래시+아무 문자 1개" 반복으로 고쳐 이스케이프 5종을 전부 통과시킨다.
+const ENTITY_TOKEN_RE = /\[(?:[^\]\\]|\\.)*\]\(entity:([a-z]+):([0-9a-fA-F-]{36})\)/g;
 
-/** content에서 `[title](entity:type:id)` 토큰을 전부 뽑는다(chat-bubble.tsx의 렌더 파서와
- * 동일 정규식 — 새 계약 발명 아님). 순서 보존, 중복 제거 안 함(호출부가 type별로 filter). */
+/** content에서 `[title](entity:type:id)` 토큰을 전부 뽑는다 — 제목의 `_escape_title`
+ * 이스케이프(reference_token.py)를 그대로 통과시킨다. 순서 보존, 중복 제거 안 함(호출부가
+ * type별로 filter). */
 export function extractEntityRefs(content: string | null | undefined): EntityRef[] {
   if (!content) return [];
   const refs: EntityRef[] = [];

--- a/apps/web/src/lib/reference-candidates.test.ts
+++ b/apps/web/src/lib/reference-candidates.test.ts
@@ -42,6 +42,17 @@ describe('findReferenceCandidates', () => {
     expect(result).toEqual([]);
   });
 
+  // story #2638 QA(2026-08-15) 파생 발견 — 정본 토큰(reference_token.py:_escape_title)이
+  // 만드는 실 이스케이프 제목("[QA·폐기용] #2668 ..." 류, \[ \] 백슬래시 이스케이프)에서
+  // 옛 정규식이 토큰 자체를 못 지워, 제목 속 "#2668"이 "이미 참조됨"인데도 다시 후보로
+  // 새던 실 재현 버그. 위 40행 테스트(무괄호 제목)만으로는 이 케이스가 안 잡혔다.
+  it('제목에 대괄호가 든 정본 이스케이프 entity 토큰도 후보에서 뺀다(실 재현 사례)', () => {
+    const result = findReferenceCandidates(
+      '[\\[QA·폐기용\\] #2668 확認용 문서](entity:doc:11111111-1111-1111-1111-111111111111) 승인 주시면',
+    );
+    expect(result).toEqual([]);
+  });
+
   it('entity 토큰과 평문 후보가 섞여 있으면 평문 것만 잡는다', () => {
     const result = findReferenceCandidates(
       '[제목](entity:story:11111111-1111-1111-1111-111111111111) 관련해서 #2250 도 봐줘',

--- a/apps/web/src/lib/reference-candidates.ts
+++ b/apps/web/src/lib/reference-candidates.ts
@@ -18,7 +18,13 @@ export interface ReferenceCandidate {
   value: string;
 }
 
-const ENTITY_TOKEN_RE = /\[[^\]]*\]\(entity:[a-z]+:[0-9a-fA-F-]+\)/g;
+// story #2638 QA(2026-08-15) 파생 발견 — 정본 토큰(reference_token.py:_escape_title)은
+// 제목의 \ [ ] ( ) 를 백슬래시로 이스케이프한다("[QA·폐기용] #2668 ..." 같은 실 제목이
+// 전형). `[^\]]*`는 이스케이프된 `\]`의 `]`에서 멈춰(백슬래시를 못 봄) 이 토큰을 아예 못
+// 지워, 제목 안의 "#2668" 같은 글자가 «이미 참조된 것»인데도 다시 「잇겠습니까?」 후보로
+// 새는 걸 이 파일 자신의 docstring(⛔이미 토큰인 것은 후보에서 뺀다)이 막으려던 바로 그
+// 케이스를 못 막았다. classifier.ts와 동형 수정(이스케이프 5종 전부 통과).
+const ENTITY_TOKEN_RE = /\[(?:[^\]\\]|\\.)*\]\(entity:[a-z]+:[0-9a-fA-F-]+\)/g;
 const NUMBER_RE = /#(\d{2,6})\b/g;
 // 슬러그: 최소 한 번의 하이픈을 요구해 일반 해시태그성 단어와 구분한다(이 코드베이스의
 // 실제 슬러그 관례 — 예: flow-map-blueprint-v1, provenance-attachment-point-inventory-...).


### PR DESCRIPTION
## Summary
PO's own live verification of #2638 caught it (RED, `review_changes`): the exact repro phrase ("승인 주시면") next to a real canonical entity token never produced a suggestion card. The chip and its CTA rendered fine — react-markdown's real CommonMark parser handles bracket-escaping correctly — but #2638's own regex-based `extractEntityRefs` silently found zero matches.

## Root cause
Real reference tokens (`reference_token.py:_escape_title`) backslash-escape any of `\ [ ] ( )` in the title. A title like `[QA·폐기용] #2668 확認용 문서` becomes `\[QA·폐기용\] #2668 확認용 문서` when embedded — the exact "QA 폐기용" doc-title shape used throughout today's session. `extractEntityRefs`'s regex used `[^\]]*` for the title portion, which stops at the first literal `]` character — including the one inside an escaped `\]`, since the regex has no concept of the preceding backslash.

Fixed to `(?:[^\]\\]|\\.)*` — "anything that isn't `]` or `\`, or a backslash followed by any single character" — correctly passes through all five characters `_escape_title` can produce.

## A second, pre-existing bug found while tracing this
Same root cause in `reference-candidates.ts` (#2283, unrelated feature) — its token-stripping step also failed on escaped-bracket titles, letting text like `#2668` inside an already-linked entity token's title leak through as a spurious bare-reference suggestion (exactly what that file's own `⛔이미 토큰인 것은 후보에서 뺀다` invariant exists to prevent). Fixed with the identical pattern.

## Verification
Per PO's own diagnosis ("심은 표본엔 아는 종류만" — seeded fixtures only exercised known-safe shapes), rewrote the *shared* test-fixture token helpers in `intent-suggestion-card.compute.test.ts`/`.mount.test.tsx` to use real escaped-bracket titles, so the existing scenario tests automatically re-validate against the real format rather than relying only on new isolated cases.

Mutation: reverted each fix independently — 9/22 tests (classifier + card suites) and 1/1 test (reference-candidates) go RED with the exact symptom PO reported / the exact spurious-candidate leak, respectively. Restored: 132/132 across both features' full test suites. `tsc --noEmit` and `eslint`: clean.

## QA note
Self-QA not possible here (author = reviewer conflict) — routing for cross-check.