### PR TITLE
[SID:2670] fix: 테스트 발행 payload에 로그인 멤버 id 자동 충전

### DIFF
--- a/apps/web/src/app/(authenticated)/organization/events/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/events/page.test.tsx
@@ -32,11 +32,14 @@ function wrap(node: React.ReactNode) {
 
 const ORG_ID = 'org-1';
 
+const CURRENT_MEMBER_ID = 'member-me-1';
+
 function asAdmin() {
   useDashboardContextMock.mockReturnValue({
     orgId: ORG_ID,
     orgMemberships: [{ orgId: ORG_ID, orgName: '뭉클랩', orgSlug: 'moonklabs', role: 'admin' }],
     projectMemberships: [],
+    currentTeamMemberId: CURRENT_MEMBER_ID,
   });
 }
 
@@ -401,7 +404,37 @@ describe('OrganizationEventsPage — 이벤트 정의기(story #2670 A층)', () 
     await act(async () => { testBtn.click(); });
     const publishCall = calls.find((c) => c.url === '/api/events/publish');
     expect(publishCall).toBeDefined();
-    expect(JSON.parse(publishCall!.body!).definition_key).toBe('org.moonklabs.x');
+    const publishBody = JSON.parse(publishCall!.body!);
+    expect(publishBody.definition_key).toBe('org.moonklabs.x');
+    // PO 라이브 실측 회귀가드(review_changes) — 기본 routing(발행할 때 지정=payload_field,
+    // member_id_field=assignee_member_id)인데 테스트 발행 payload에 그 필드가 없으면 BE가
+    // 거부해 "나에게만 보내는 실 발행"(§4) 약속이 깨진다 — 로그인한 나로 자동 충전돼야 한다.
+    expect(publishBody.payload.assignee_member_id).toBe(CURRENT_MEMBER_ID);
+  });
+
+  it('routing이 「기록만」(server_derived)이면 테스트 발행 payload에 멤버 id를 안 넣는다(과다주입 금지)', async () => {
+    const calls = mockFetches([]);
+    await mount();
+    const createBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.organization.eventCreateCta)!;
+    await act(async () => { createBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => {
+      setInputValue(dialogContent().querySelector('#definer-key') as HTMLInputElement, 'y');
+    });
+    const recordOnlyRadio = [...dialogContent().querySelectorAll('button')].find((b) => b.textContent?.includes(koMessages.organization.definerRoutingRecordTitle)) as HTMLButtonElement;
+    await act(async () => { recordOnlyRadio.click(); });
+    const addStageBtn = [...dialogContent().querySelectorAll('button')].find((b) => b.textContent?.includes(koMessages.organization.definerAddStage))!;
+    await act(async () => { addStageBtn.click(); });
+    await act(async () => {
+      setInputValue(dialogContent().querySelector('input[placeholder="' + koMessages.organization.definerStageNamePlaceholder + '"]') as HTMLInputElement, 'a');
+    });
+    const submitBtn = [...dialogContent().querySelectorAll('button')].find((b) => b.textContent === koMessages.organization.eventCreateSubmit) as HTMLButtonElement;
+    await act(async () => { submitBtn.click(); });
+    const testBtn = [...dialogContent().querySelectorAll('button')].find((b) => b.textContent === koMessages.organization.definerTestPublishCta) as HTMLButtonElement;
+    await act(async () => { testBtn.click(); });
+
+    const publishCall = calls.find((c) => c.url === '/api/events/publish');
+    const publishBody = JSON.parse(publishCall!.body!);
+    expect(publishBody.payload.assignee_member_id).toBeUndefined();
   });
 
   it('키가 비었으면 저장 버튼이 비활성이다(fail-closed·서버 400 재생산 방지)', async () => {

--- a/apps/web/src/app/(authenticated)/organization/events/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/events/page.tsx
@@ -318,6 +318,7 @@ function EventFormDialog({
   tc: ReturnType<typeof useTranslations>;
   addToast: ReturnType<typeof useToast>['addToast'];
 }) {
+  const { currentTeamMemberId } = useDashboardContext();
   const prefix = `org.${orgSlug || '{org}'}.`;
   const [keySuffix, setKeySuffix] = useState('');
   const [payloadSchema, setPayloadSchema] = useState(DEFAULT_PAYLOAD_SCHEMA);
@@ -447,10 +448,18 @@ function EventFormDialog({
     setTestPublishResult(null);
     try {
       const derived = deriveDefinition(definerState, orgSlug);
+      // PO 라이브 실측(review_changes) — 「발행할 때 지정」routing(payload_field)은 BE가
+      // payload[member_id_field]에 실 멤버 id를 요구한다. 순수 파생 샘플엔 그 필드가 없어
+      // 테스트 발행이 "나에게만 보내는 실 발행"(§4 약속)을 어기고 항상 실패했다 — 지금
+      // 로그인한 나(currentTeamMemberId)를 여기서 채워 보낸다(파생 로직 자체는 순수 유지).
+      const broadcast = derived.routing.broadcast as { kind?: string; member_id_field?: string } | undefined;
+      const publishPayload = broadcast?.kind === 'payload_field' && broadcast.member_id_field && currentTeamMemberId
+        ? { ...derived.samplePayload, [broadcast.member_id_field]: currentTeamMemberId }
+        : derived.samplePayload;
       const res = await fetch('/api/events/publish', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ definition_key: savedKey, payload: derived.samplePayload }),
+        body: JSON.stringify({ definition_key: savedKey, payload: publishPayload }),
       });
       if (!res.ok) {
         const body = await res.json().catch(() => null) as { error?: { message?: string } } | null;


### PR DESCRIPTION
## Summary
PO 라이브 실측(gate_cycle review_changes, PR#3080 머지 후) 대응 — [story #2670](entity:story:6f7d886d-16ee-4536-b6d2-2606059f47ad) 판별자 AC4("휴먼 owner가 사이클형 1건을 화면만으로 정의→미리보기→테스트 발행까지") 실패 재현·수정.

**증상**: 기본 routing(「발행할 때 지정」= `payload_field`, `member_id_field: assignee_member_id`) 상태로 사이클형 정의를 저장한 뒤 테스트 발행을 누르면 BE가 `routing 요구 payload.assignee_member_id 없음`으로 거부. `deriveDefinition`이 만드는 순수 샘플 payload에는 그 필드가 애초에 없었음(스키마상 선언 필드가 아니라 routing 쪽에서만 요구하는 out-of-band 필드라 파생 로직이 몰랐음).

**수정**: `EventFormDialog`가 `useDashboardContext().currentTeamMemberId`를 가져와, 발행 직전(`testPublish()`)에 `routing.broadcast.kind === 'payload_field'`일 때만 `samplePayload` 사본에 `[member_id_field]: currentTeamMemberId`를 주입. 파생 로직 자체(`event-definer-logic.ts`, 이미 21개 유닛테스트로 고정된 모듈)는 순수 함수로 그대로 유지 — 부작용은 호출부 한 곳에만.

## Test plan
- [x] 신규 회귀테스트 2건: (1) 기본 routing에서 발행 payload에 `assignee_member_id`가 로그인 멤버로 채워지는지, (2) 「기록만」(server_derived) routing에서는 과다주입되지 않는지
- [x] `pnpm exec tsc --noEmit` — 클린
- [x] `pnpm exec eslint` — 경고 0
- [x] `pnpm run verify:no-new-md-breakpoint` — 그린
- [x] `pnpm exec vitest run` — 420 files / 3389 tests 전부 통과
- [x] `pnpm build` — exit 0
- [ ] 라이브 재확인(dev 배포 후 PO가 직접 판별자 AC4 재실측)

🤖 Generated with [Claude Code](https://claude.com/claude-code)