### PR TITLE
[SID:2670] fix: routing 대상 필드 schema 선언 + 수정 진입 이름 역파싱

### DIFF
--- a/apps/web/src/app/(authenticated)/organization/events/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/events/page.test.tsx
@@ -369,8 +369,10 @@ describe('OrganizationEventsPage — 이벤트 정의기(story #2670 A층)', () 
     expect(body.key).toBe('org.moonklabs.release_flow');
     expect(body.payload_schema).toEqual({
       type: 'object',
-      properties: { stage: { type: 'string', enum: ['draft', 'done'] } },
-      required: ['stage'],
+      // routing 기본값(발행할 때 지정)이라 대상 필드가 스키마에도 실린다(PO review_changes
+      // 2차 근인 — additionalProperties:false에서 스키마에 없는 필드는 실 발행이 거부됨).
+      properties: { stage: { type: 'string', enum: ['draft', 'done'] }, assignee_member_id: { type: 'string' } },
+      required: ['stage', 'assignee_member_id'],
       additionalProperties: false,
     });
     expect(body.routing).toEqual({
@@ -451,8 +453,9 @@ describe('OrganizationEventsPage — 이벤트 정의기(story #2670 A층)', () 
     mockFetches([customWithId({
       id: 'def-cycle',
       key: 'org.moonklabs.release_flow',
-      payload_schema: { type: 'object', properties: { stage: { type: 'string', enum: ['draft', 'done'] } }, required: ['stage'], additionalProperties: false },
+      payload_schema: { type: 'object', properties: { stage: { type: 'string', enum: ['draft', 'done'] }, assignee_member_id: { type: 'string' } }, required: ['stage', 'assignee_member_id'], additionalProperties: false },
       routing: { escalation: { kind: 'server_derived', target: 'none' }, broadcast: { kind: 'payload_field', member_id_field: 'assignee_member_id' } },
+      block_template: { blocks: [{ type: 'header', text: '릴리즈 흐름' }] },
     })]);
     await mount();
     const editBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.organization.eventEditCta)!;
@@ -460,9 +463,15 @@ describe('OrganizationEventsPage — 이벤트 정의기(story #2670 A층)', () 
 
     // 기본 탭이 활성(고급 전용 배지 없음) — #event-key(JSON탭 전용)는 안 보이고 폼 필드가 보인다.
     expect(dialogContent().textContent).not.toContain(koMessages.organization.definerAdvancedOnlyBadge);
-    expect(dialogContent().querySelector('#definer-name')).not.toBeNull();
+    // PO review_changes 2차 — 수정 진입 시 이름이 "이름 없음"으로 비던 유실 회귀가드.
+    expect((dialogContent().querySelector('#definer-name') as HTMLInputElement).value).toBe('릴리즈 흐름');
     const stageNameInputs = dialogContent().querySelectorAll('input[placeholder="' + koMessages.organization.definerStageNamePlaceholder + '"]') as NodeListOf<HTMLInputElement>;
     expect([...stageNameInputs].map((i) => i.value)).toEqual(['draft', 'done']);
+    // assignee_member_id(routing 파생 필드)는 ⑥ 추가 필드 편집 행으로 새어 나오면 안 된다
+    // (「이 폼이 파생하는 것」 요약 패널엔 정상적으로 스키마 키로 보이므로 dialog 전체가 아닌
+    // 입력 필드 값만 좁혀서 확認).
+    const inputValues = [...dialogContent().querySelectorAll('input')].map((i) => (i as HTMLInputElement).value);
+    expect(inputValues).not.toContain('assignee_member_id');
   });
 
   it('폼이 표현 못 하는 모양(routing이 커스텀에서 불가능한 target)의 기존 정의는 「고급 전용」으로 떨어진다(AC3)', async () => {

--- a/apps/web/src/app/(authenticated)/organization/events/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/events/page.tsx
@@ -353,7 +353,7 @@ function EventFormDialog({
       setHumanOnly(auth?.human_only ?? false);
       setRolesCsv((auth?.role ?? []).join(', '));
 
-      const parsed = orgSlug ? tryReverseParse(target.key, target.payload_schema, target.routing, target.action_auth ?? null, orgSlug) : null;
+      const parsed = orgSlug ? tryReverseParse(target.key, target.payload_schema, target.routing, target.action_auth ?? null, orgSlug, target.block_template) : null;
       if (parsed) { setDefinerState(parsed); setTab('basic'); setAdvancedOnly(false); }
       else { setDefinerState(emptyFormState()); setTab('advanced'); setAdvancedOnly(true); }
       setSavedKey(target.key);

--- a/apps/web/src/components/organization/event-definer-logic.test.ts
+++ b/apps/web/src/components/organization/event-definer-logic.test.ts
@@ -74,8 +74,11 @@ describe('deriveCycle — 서식① (핸드오프 스펙 §2 사이클형 예시
         stage: { type: 'string', enum: ['draft', 'review_requested', 'approved', 'deployed'] },
         release_note: { type: 'string' },
         pr_number: { type: 'number' },
+        // 유나 v1.1 §④ — 기본(발행할 때 지정)이면 대상 필드가 스키마에도 선언돼야
+        // additionalProperties:false에 안 걸린다(PO review_changes 2차 근인).
+        assignee_member_id: { type: 'string' },
       },
-      required: ['stage', 'release_note'],
+      required: ['stage', 'release_note', 'assignee_member_id'],
       additionalProperties: false,
     });
     // R4 — 기본(발행할 때 지정) = payload_field. R3 — escalation은 항상 명시(server_derived·none).
@@ -127,7 +130,8 @@ describe('deriveSignal — 서식②', () => {
       kind: { type: 'string', enum: ['verdict', 'scope'] },
       summary: { type: 'string' },
     });
-    expect(d.payload_schema.required).toEqual(['kind']);
+    // routing 기본값(assign_on_publish)이라 assignee_member_id도 필수로 실린다.
+    expect(d.payload_schema.required).toEqual(['kind', 'assignee_member_id']);
   });
 
   it('summary 미포함 시 properties에도 없다(지어내지 않음)', () => {
@@ -149,7 +153,65 @@ describe('deriveMeasure — 서식③', () => {
     const d = deriveMeasure(state, 'moonklabs');
     expect(d.payload_schema.properties).toMatchObject({ metric_value: { type: 'number' }, metric_unit: { type: 'string' } });
     expect(d.payload_schema.properties).not.toHaveProperty('source');
-    expect(d.payload_schema.required).toEqual(['metric_value']);
+    expect(d.payload_schema.required).toEqual(['metric_value', 'assignee_member_id']);
+  });
+});
+
+// PO 라이브 실측(review_changes 2차)이 제안한 판별 핀 — "파생 정의의 샘플 payload(주입
+// 포함)가 파생 schema를 자기 검증 통과". 이 핀이 있었으면 assignee_member_id 스키마 누락도
+// 오프라인에서 바로 잡혔을 것. 스키마 모양이 항상 평평한(nested 없는) object라 별도
+// 라이브러리 없이 최소 구조검사로 충분하다.
+function selfValidate(schema: Record<string, unknown>, payload: Record<string, unknown>): string[] {
+  const errors: string[] = [];
+  const properties = (schema.properties ?? {}) as Record<string, { type?: string; enum?: string[] }>;
+  const required = (schema.required as string[] | undefined) ?? [];
+  for (const key of required) {
+    if (!(key in payload)) errors.push(`missing required: ${key}`);
+  }
+  if (schema.additionalProperties === false) {
+    for (const key of Object.keys(payload)) {
+      if (!(key in properties)) errors.push(`unexpected key (additionalProperties:false): ${key}`);
+    }
+  }
+  for (const [key, def] of Object.entries(properties)) {
+    if (!(key in payload)) continue;
+    const value = payload[key];
+    const actualType = typeof value;
+    if (def.type && def.type !== actualType) errors.push(`${key}: expected ${def.type}, got ${actualType}`);
+    if (def.enum && !def.enum.includes(value as string)) errors.push(`${key}: "${String(value)}" not in enum ${JSON.stringify(def.enum)}`);
+  }
+  return errors;
+}
+
+describe('판별 핀 — 파생 샘플 payload가 파생 schema를 자기 검증 통과(assign_on_publish 주입 포함)', () => {
+  it('사이클형', () => {
+    const state = emptyFormState('cycle');
+    state.keySuffix = 'x';
+    state.stages = [{ id: makeId(), name: 'a', slug: 'a' }];
+    const d = deriveCycle(state, 'moonklabs');
+    expect(selfValidate(d.payload_schema, d.samplePayload)).toEqual([]);
+  });
+  it('신호형', () => {
+    const state = emptyFormState('signal');
+    state.keySuffix = 'x';
+    state.signalKinds = ['verdict'];
+    const d = deriveSignal(state, 'moonklabs');
+    expect(selfValidate(d.payload_schema, d.samplePayload)).toEqual([]);
+  });
+  it('측정형', () => {
+    const state = emptyFormState('measure');
+    state.keySuffix = 'x';
+    const d = deriveMeasure(state, 'moonklabs');
+    expect(selfValidate(d.payload_schema, d.samplePayload)).toEqual([]);
+  });
+  it('routing이 기록만(record_only)이면 assignee_member_id 없이도 자기검증 통과(과다 요구 금지)', () => {
+    const state = emptyFormState('cycle');
+    state.keySuffix = 'x';
+    state.stages = [{ id: makeId(), name: 'a', slug: 'a' }];
+    state.routing = 'record_only';
+    const d = deriveCycle(state, 'moonklabs');
+    expect(d.payload_schema.properties).not.toHaveProperty('assignee_member_id');
+    expect(selfValidate(d.payload_schema, d.samplePayload)).toEqual([]);
   });
 });
 
@@ -164,15 +226,18 @@ describe('tryReverseParse — AC3 JSON→폼 왕복(표현 가능 범위만, 못
     state.rolesCsv = 'owner';
     const d = deriveCycle(state, 'moonklabs');
 
-    const parsed = tryReverseParse(d.key, d.payload_schema, d.routing, d.action_auth, 'moonklabs');
+    const parsed = tryReverseParse(d.key, d.payload_schema, d.routing, d.action_auth, 'moonklabs', d.block_template as unknown as Record<string, unknown>);
     expect(parsed).not.toBeNull();
     expect(parsed!.format).toBe('cycle');
     expect(parsed!.keySuffix).toBe('release_flow');
     expect(parsed!.stages.map((s) => s.slug)).toEqual(['draft', 'done']);
+    // assignee_member_id(routing 파생 필드)는 사용자 필드로 안 새어 나온다(구조적 제외).
     expect(parsed!.fields).toEqual([{ id: expect.any(String), name: 'note', type: 'string', required: true }]);
     expect(parsed!.humanOnly).toBe(true);
     expect(parsed!.rolesCsv).toBe('owner');
     expect(parsed!.routing).toBe('assign_on_publish');
+    // PO review_changes 2차 — 수정 진입 시 이름이 "이름 없음"으로 비던 유실 회귀가드.
+    expect(parsed!.name).toBe('릴리즈');
   });
 
   it('deriveSignal/deriveMeasure도 자기 왕복된다', () => {
@@ -190,6 +255,28 @@ describe('tryReverseParse — AC3 JSON→폼 왕복(표현 가능 범위만, 못
     expect(parsedMeas?.format).toBe('measure');
     expect(parsedMeas?.includeMetricUnit).toBe(true);
     expect(parsedMeas?.includeSource).toBe(true);
+  });
+
+  it('block_template 없이 호출하면(옵션 인자 생략) 이름은 빈 문자열로 안전하게 떨어진다', () => {
+    const parsed = tryReverseParse(
+      'org.moonklabs.x',
+      { properties: { kind: { type: 'string', enum: ['a'] } }, required: ['kind'] },
+      { escalation: { kind: 'server_derived', target: 'none' }, broadcast: { kind: 'server_derived', target: 'none' } },
+      null,
+      'moonklabs',
+    );
+    expect(parsed?.name).toBe('');
+  });
+
+  it('routing이 payload_field여도 member_id_field가 폼이 안 쓰는 이름이면 null(고급 전용 — 손실 방지)', () => {
+    const parsed = tryReverseParse(
+      'org.moonklabs.x',
+      { properties: { stage: { type: 'string', enum: ['a'] }, custom_owner: { type: 'string' } }, required: ['stage', 'custom_owner'] },
+      { escalation: { kind: 'server_derived', target: 'none' }, broadcast: { kind: 'payload_field', member_id_field: 'custom_owner' } },
+      null,
+      'moonklabs',
+    );
+    expect(parsed).toBeNull();
   });
 
   it('routing이 폼이 못 만드는 모양(server_derived target=work_item_stakeholders)이면 null(고급 전용)', () => {

--- a/apps/web/src/components/organization/event-definer-logic.ts
+++ b/apps/web/src/components/organization/event-definer-logic.ts
@@ -115,15 +115,37 @@ function fieldsToProperties(fields: DefinerField[]): { properties: Record<string
   return { properties, required };
 }
 
+// PO 라이브 실측(review_changes 2차) — member_id_field 이름은 routing 파생과 schema 삽입
+// 양쪽이 반드시 같은 상수를 써야 한다(둘이 벌어지면 BE가 "그 필드가 스키마에 없다"로 거부).
+const ASSIGNEE_MEMBER_ID_FIELD = 'assignee_member_id';
+
 // R4 — routing 2택 파생. escalation leg는 R3 정정대로 항상 명시(server_derived·target=none,
 // 누락 금지 — 서버가 두 leg 모두 object를 요구).
 function deriveRouting(routing: DefinerRouting): Record<string, unknown> {
   const broadcast = routing === 'assign_on_publish'
-    ? { kind: 'payload_field', member_id_field: 'assignee_member_id' }
+    ? { kind: 'payload_field', member_id_field: ASSIGNEE_MEMBER_ID_FIELD }
     : { kind: 'server_derived', target: 'none' };
   return {
     escalation: { kind: 'server_derived', target: 'none' },
     broadcast,
+  };
+}
+
+// 유나 v1.1 §④ — 「발행 시 지정」을 고르면 그 대상 필드가 payload_schema에도 선언돼야 한다
+// (additionalProperties:false라 스키마에 없는 필드는 실 발행이 전부 거부된다 — PO 2차 RED
+// 근인). samplePayload에도 자리표시자를 심어 둔다: 실값(로그인 멤버 id)은 테스트 발행
+// 호출부(page.tsx testPublish)가 그 자리를 덮어쓴다 — 파생 자체는 순수 유지.
+function withAssigneeMemberField(
+  properties: Record<string, unknown>,
+  required: string[],
+  samplePayload: Record<string, unknown>,
+  routing: DefinerRouting,
+): { properties: Record<string, unknown>; required: string[]; samplePayload: Record<string, unknown> } {
+  if (routing !== 'assign_on_publish') return { properties, required, samplePayload };
+  return {
+    properties: { ...properties, [ASSIGNEE_MEMBER_ID_FIELD]: { type: 'string' } },
+    required: [...required, ASSIGNEE_MEMBER_ID_FIELD],
+    samplePayload: { ...samplePayload, [ASSIGNEE_MEMBER_ID_FIELD]: '예시 멤버 id' },
   };
 }
 
@@ -166,14 +188,20 @@ export function deriveCycle(state: DefinerFormState, orgSlug: string): DerivedDe
   const validStages = state.stages.filter((s) => s.name.trim() && s.slug.trim());
   const stageSlugs = validStages.map((s) => s.slug);
   const { properties: fieldProps, required: fieldRequired } = fieldsToProperties(state.fields);
+  const sampleStage = stageSlugs[stageSlugs.length - 1] ?? 'stage_1';
+  const withMember = withAssigneeMemberField(
+    { stage: { type: 'string', enum: stageSlugs }, ...fieldProps },
+    ['stage', ...fieldRequired],
+    { stage: sampleStage, ...extraFieldsSample(state.fields) },
+    state.routing,
+  );
   const payload_schema = {
     type: 'object',
-    properties: { stage: { type: 'string', enum: stageSlugs }, ...fieldProps },
-    required: ['stage', ...fieldRequired],
+    properties: withMember.properties,
+    required: withMember.required,
     additionalProperties: false,
   };
-  const sampleStage = stageSlugs[stageSlugs.length - 1] ?? 'stage_1';
-  const samplePayload = { stage: sampleStage, ...extraFieldsSample(state.fields) };
+  const samplePayload = withMember.samplePayload;
   const fieldsBlock = buildFieldsBlock(state.fields);
   const block_template: BlockTemplate = {
     blocks: [
@@ -199,9 +227,11 @@ export function deriveSignal(state: DefinerFormState, orgSlug: string): DerivedD
   const properties: Record<string, unknown> = { kind: { type: 'string', enum: kinds.length > 0 ? kinds : ['default'] }, ...fieldProps };
   const required = ['kind', ...fieldRequired];
   if (state.includeSummary) { properties.summary = { type: 'string' }; }
-  const payload_schema = { type: 'object', properties, required, additionalProperties: false };
-  const samplePayload: Record<string, unknown> = { kind: kinds[0] ?? 'default', ...extraFieldsSample(state.fields) };
-  if (state.includeSummary) samplePayload.summary = '예시 요약';
+  const samplePayloadBase: Record<string, unknown> = { kind: kinds[0] ?? 'default', ...extraFieldsSample(state.fields) };
+  if (state.includeSummary) samplePayloadBase.summary = '예시 요약';
+  const withMember = withAssigneeMemberField(properties, required, samplePayloadBase, state.routing);
+  const payload_schema = { type: 'object', properties: withMember.properties, required: withMember.required, additionalProperties: false };
+  const samplePayload = withMember.samplePayload;
   const signalFieldsBlock = buildFieldsBlock(state.fields);
   const block_template: BlockTemplate = {
     blocks: [
@@ -227,10 +257,12 @@ export function deriveMeasure(state: DefinerFormState, orgSlug: string): Derived
   const required = ['metric_value', ...fieldRequired];
   if (state.includeMetricUnit) properties.metric_unit = { type: 'string' };
   if (state.includeSource) properties.source = { type: 'string' };
-  const payload_schema = { type: 'object', properties, required, additionalProperties: false };
-  const samplePayload: Record<string, unknown> = { metric_value: 42, ...extraFieldsSample(state.fields) };
-  if (state.includeMetricUnit) samplePayload.metric_unit = '%';
-  if (state.includeSource) samplePayload.source = '예시 출처';
+  const samplePayloadBase: Record<string, unknown> = { metric_value: 42, ...extraFieldsSample(state.fields) };
+  if (state.includeMetricUnit) samplePayloadBase.metric_unit = '%';
+  if (state.includeSource) samplePayloadBase.source = '예시 출처';
+  const withMember = withAssigneeMemberField(properties, required, samplePayloadBase, state.routing);
+  const payload_schema = { type: 'object', properties: withMember.properties, required: withMember.required, additionalProperties: false };
+  const samplePayload = withMember.samplePayload;
   const fieldsBlock: { label: string; value: string }[] = [{ label: '측정치', value: state.includeMetricUnit ? '{{payload.metric_value}} {{payload.metric_unit}}' : '{{payload.metric_value}}' }];
   if (state.includeSource) fieldsBlock.push({ label: '출처', value: '{{payload.source}}' });
   for (const f of state.fields) { if (f.name.trim() && validateFieldName(f.name)) fieldsBlock.push({ label: f.name, value: `{{payload.${f.name}}}` }); }
@@ -256,6 +288,17 @@ export function deriveDefinition(state: DefinerFormState, orgSlug: string): Deri
   return deriveMeasure(state, orgSlug);
 }
 
+// PO 라이브 실측(review_changes 2차) — 수정 진입 시 이벤트 이름이 매번 "이름 없음"으로
+// 비어 있던 유실. payload_schema엔 name이 없다(그건 오직 block_template 첫 블록의 header
+// text로만 산다, deriveCycle/Signal/Measure 참조) — 그러니 역파싱도 거기서 되돌려야 한다.
+function extractNameFromBlockTemplate(block_template: Record<string, unknown> | null | undefined): string {
+  const blocks = block_template?.blocks;
+  if (!Array.isArray(blocks) || blocks.length === 0) return '';
+  const first = blocks[0] as { type?: string; text?: string } | undefined;
+  if (first?.type !== 'header' || typeof first.text !== 'string') return '';
+  return first.text === '(이름 없음)' ? '' : first.text;
+}
+
 // AC3 — JSON→폼 왕복. 폼이 표현할 수 있는 정확한 모양(이 파일의 derive* 함수들이 만드는 것과
 // 구조적으로 동형)일 때만 성공한다 — 조금이라도 벗어나면(사람이 고급 탭에서 직접 편집했거나,
 // 이 기능 이전에 만들어진 정의 등) null을 반환해 호출부가 "고급 전용" 배지로 정직하게
@@ -266,6 +309,7 @@ export function tryReverseParse(
   routing: Record<string, unknown>,
   action_auth: Record<string, unknown> | null,
   orgSlug: string,
+  block_template?: Record<string, unknown> | null,
 ): DefinerFormState | null {
   try {
     const prefix = `org.${orgSlug}.`;
@@ -276,13 +320,17 @@ export function tryReverseParse(
     if (!properties || typeof properties !== 'object') return null;
     const required = new Set((payload_schema.required as string[] | undefined) ?? []);
 
-    // routing 2택 역해석(R4) — 이 두 모양 밖이면 표현 불가.
+    // routing 2택 역해석(R4) — 이 두 모양 밖이면 표현 불가. payload_field면 member_id_field가
+    // 폼이 항상 쓰는 그 이름(ASSIGNEE_MEMBER_ID_FIELD)과 정확히 같아야 한다 — 다른 이름이면
+    // 고급 탭에서 손으로 바꾼 것이라 폼이 못 되돌린다(스키마에서 그 필드를 잃는 걸 막는다).
     const esc = routing.escalation as { kind?: string; target?: string } | undefined;
     const bc = routing.broadcast as { kind?: string; target?: string; member_id_field?: string } | undefined;
     if (esc?.kind !== 'server_derived' || esc.target !== 'none') return null;
     let derivedRouting: DefinerRouting;
-    if (bc?.kind === 'payload_field') derivedRouting = 'assign_on_publish';
-    else if (bc?.kind === 'server_derived' && bc.target === 'none') derivedRouting = 'record_only';
+    if (bc?.kind === 'payload_field') {
+      if (bc.member_id_field !== ASSIGNEE_MEMBER_ID_FIELD) return null;
+      derivedRouting = 'assign_on_publish';
+    } else if (bc?.kind === 'server_derived' && bc.target === 'none') derivedRouting = 'record_only';
     else return null;
 
     const humanOnly = action_auth?.human_only === true;
@@ -296,13 +344,18 @@ export function tryReverseParse(
     base.routing = derivedRouting;
     base.humanOnly = humanOnly;
     base.rolesCsv = rolesCsv;
+    base.name = extractNameFromBlockTemplate(block_template);
+
+    // routing이 assign_on_publish일 때만 스키마에 실리는 필드라, 있으면 "사용자가 만든 추가
+    // 필드"가 아니라 파생이 자동으로 얹은 것 — 셋 다에서 일반 필드 취급 대상에서 뺀다.
+    const structuralExclude = derivedRouting === 'assign_on_publish' ? [ASSIGNEE_MEMBER_ID_FIELD] : [];
 
     if ('stage' in properties && properties.stage?.enum) {
       const { stage, ...rest } = properties;
       void stage;
       base.format = 'cycle';
       base.stages = (properties.stage!.enum ?? []).map((slug) => ({ id: makeId(), name: slug, slug }));
-      base.fields = objectToFields(rest, required, new Set(['stage']));
+      base.fields = objectToFields(rest, required, new Set(['stage', ...structuralExclude]));
       return base;
     }
     if ('kind' in properties) {
@@ -311,7 +364,7 @@ export function tryReverseParse(
       base.signalKinds = kind?.enum ?? [];
       base.includeSummary = 'summary' in properties;
       void summary;
-      base.fields = objectToFields(rest, required, new Set(['kind', 'summary']));
+      base.fields = objectToFields(rest, required, new Set(['kind', 'summary', ...structuralExclude]));
       return base;
     }
     if ('metric_value' in properties) {
@@ -321,7 +374,7 @@ export function tryReverseParse(
       base.includeMetricUnit = 'metric_unit' in properties;
       base.includeSource = 'source' in properties;
       void metric_unit; void source;
-      base.fields = objectToFields(rest, required, new Set(['metric_value', 'metric_unit', 'source']));
+      base.fields = objectToFields(rest, required, new Set(['metric_value', 'metric_unit', 'source', ...structuralExclude]));
       return base;
     }
     return null;


### PR DESCRIPTION
## Summary
PO 라이브 실측 2차(gate_cycle review_changes, PR#3081 머지 후) 대응 — [story #2670](entity:story:6f7d886d-16ee-4536-b6d2-2606059f47ad) 판별자 재RED.

**버그①**: routing=「발행 시 지정」인데 `payload_schema.properties`에 `assignee_member_id`가 없어, PR#3081이 payload에 그 필드를 채워 보내도 `additionalProperties:false`에 걸려 스키마 위반 — 유나 v1.1 §④ "⑥에 대상 필드 자동 삽입" 조항이 실제로 미구현이었음(3서식 전부).
- fix: `withAssigneeMemberField`가 assign_on_publish일 때 3서식 전부에서 스키마/required/샘플에 같은 상수(`ASSIGNEE_MEMBER_ID_FIELD`)로 일관 주입.
- `tryReverseParse`도 이 필드를 사용자 필드로 오인하지 않게 구조적 제외 + member_id_field가 그 상수와 다르면(고급 탭 손질) null로 정직하게 고급 전용 처리.

**버그②**: 수정 진입 시 이름이 매번 "이름 없음" — `payload_schema`엔 name이 없고 오직 `block_template` 첫 header 블록에만 사는데 `tryReverseParse`가 그 인자를 안 받았음.
- fix: 옵션 `block_template` 인자 추가 + header text 역추출.

**PO 제안 판별 핀**: "파생 정의의 샘플 payload(주입 포함)가 파생 schema를 자기 검증 통과" — 유닛테스트 구조검증(`selfValidate`)으로 고정, 3서식×assign_on_publish 전부 통과 확認. 이 핀이 먼저 있었으면 버그①이 오프라인에서 잡혔을 것.

## Test plan
- [x] 신규 회귀테스트: 자기검증 핀 4건(사이클/신호/측정/기록만), 이름 역파싱 2건(정상+생략시 안전폴백), member_id_field 불일치→null 1건, 페이지 레벨 스키마/수정진입 어서션 갱신
- [x] `pnpm exec tsc --noEmit` — 클린
- [x] `pnpm exec eslint` — 경고 0
- [x] `pnpm run verify:no-new-md-breakpoint` — 그린
- [x] `pnpm exec vitest run` — 420 files / 3395 tests 전부 통과
- [x] `pnpm build` — exit 0
- [ ] 라이브 재확인(dev 배포 후 PO가 직접 판별자 AC4 3차 재실측)

🤖 Generated with [Claude Code](https://claude.com/claude-code)