### PR TITLE
fix(events): publish project resolution falls back to caller context for reference-less custom events

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -947,6 +947,7 @@ def _render_event_message_content(definition_key: str, payload: dict) -> str:
 async def publish_registry_event(
     body: EventPublishRequest,
     background_tasks: BackgroundTasks,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
@@ -1048,10 +1049,38 @@ async def publish_registry_event(
 
     project_id = await _resolve_event_project_id(db, org_id=org_id, payload=body.payload)
     if project_id is None:
-        raise HTTPException(
-            status_code=400,
-            detail="payload에서 project를 해소할 수 없습니다(work_item_type+work_item_id 또는 goal_id 필요).",
+        # story #2674 — «참조 필드 자체가 없음»과 «참조는 있는데 못 풂(dangling)»은 다른
+        # 사건이다. 정의기(#2670)가 만드는 임의 payload 커스텀 이벤트(신호형·측정형류)는
+        # 전자(work_item/goal 키가 애초에 없음) — 이땐 호출 컨텍스트(X-Project-Id 헤더/API키
+        # 앵커/멤버 기본 프로젝트)로 폴백한다. 후자(goal_id는 줬는데 그 goal이 존재하지 않는
+        # 등)는 사용자가 뭔가를 참조하려다 실패한 것이라 컨텍스트로 조용히 다른 프로젝트를
+        # 골라주면 더 헷갈린다 — 그대로 명시 거부(test_publish_unresolvable_project_400의
+        # 기존 계약, AC2 무회귀).
+        attempted_reference = bool(
+            (body.payload.get("work_item_type") and body.payload.get("work_item_id"))
+            or body.payload.get("goal_id")
         )
+        if attempted_reference:
+            raise HTTPException(
+                status_code=400,
+                detail="payload에서 project를 해소할 수 없습니다(work_item_type+work_item_id 또는 goal_id 필요).",
+            )
+
+        # resolve_required_project_id(app/dependencies/project_scope.py)는 MCP api_client.py의
+        # require_project_id()와 동일 계약인 기존 SSOT 폴백 사슬이라 새로 발명하지 않는다.
+        # 라우팅 의미론(escalation/broadcast 해소)은 이 프로젝트 폴백과 무관 — payload_field/
+        # server_derived 어느 쪽도 project_id를 참조하지 않는다(model.py docstring 참조).
+        from app.dependencies.project_scope import resolve_required_project_id
+
+        try:
+            project_id = await resolve_required_project_id(db, request, auth, org_id)
+        except HTTPException:
+            # 컨텍스트도 없으면(예: 멀티프로젝트 키인데 헤더도 기본 프로젝트도 없음) 현행
+            # 문구 그대로 거부한다 — 음성대조(AC): 참조도 컨텍스트도 없으면 여전히 명시 거부.
+            raise HTTPException(
+                status_code=400,
+                detail="payload에서 project를 해소할 수 없습니다(work_item_type+work_item_id 또는 goal_id 필요).",
+            ) from None
 
     participant_ids = {sender.id} | escalation_ids | broadcast_ids
     conv = await _get_or_create_event_conversation(

--- a/backend/tests/test_2633_event_publish.py
+++ b/backend/tests/test_2633_event_publish.py
@@ -117,6 +117,18 @@ def _auth(agent_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
     )
 
 
+def _fake_request(*, project_id_header: uuid.UUID | None = None) -> "StarletteRequest":
+    """story #2674 — publish_registry_event가 이제 request(X-Project-Id 헤더 폴백)를 받는다.
+    test_2274_cron_orphan_check_realdb.py의 기존 관례(최소 ASGI scope)와 동일 패턴 — 신규
+    발명 아님. headers는 ASGI 규약대로 (byte, byte) 튜플 목록."""
+    from starlette.requests import Request as StarletteRequest
+
+    headers = []
+    if project_id_header is not None:
+        headers.append((b"x-project-id", str(project_id_header).encode()))
+    return StarletteRequest(scope={"type": "http", "headers": headers})
+
+
 # ─── AC1: 프리셋 발행 실왕복 — escalation/broadcast 구분 ───────────────────────────
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
@@ -143,7 +155,7 @@ async def test_publish_work_assigned_escalation_is_assignee_mentioned():
                 },
             )
             resp = await publish_registry_event(
-                body, BackgroundTasks(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
             )
             assert resp["escalation_member_ids"] == [str(assignee_id)]
             assert str(assignee_id) in resp["broadcast_member_ids"]  # story_stakeholders에도 포함
@@ -178,7 +190,7 @@ async def test_publish_gate_verdict_no_escalation_broadcasts_to_stakeholders():
                 },
             )
             resp = await publish_registry_event(
-                body, BackgroundTasks(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
             )
             assert resp["escalation_member_ids"] == []  # verdict는 결과 통지, 개입 요청 없음
             assert str(stakeholder_id) in resp["broadcast_member_ids"]
@@ -205,7 +217,7 @@ async def test_publish_goal_measured_resolves_goal_owner():
                 payload={"goal_id": str(goal_id), "metric_value": 12.5},
             )
             resp = await publish_registry_event(
-                body, BackgroundTasks(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
             )
             assert resp["broadcast_member_ids"] == [str(owner_id)]
     finally:
@@ -239,13 +251,180 @@ async def test_publish_reuses_conversation_for_same_participant_set():
                 )
 
             resp1 = await publish_registry_event(
-                _body(), BackgroundTasks(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                _body(), BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
             )
             resp2 = await publish_registry_event(
-                _body(), BackgroundTasks(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                _body(), BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
             )
             assert resp1["conversation_id"] == resp2["conversation_id"]
             assert resp1["message_id"] != resp2["message_id"]
+    finally:
+        await engine.dispose()
+
+
+# ─── story #2674 — work_item/goal 참조 없는 커스텀 이벤트의 project 폴백 ──────────────
+# #2670 정의기 판별자 3차 실측(2026-08-16)이 특정한 실사고: 신호형·측정형류(work_item 참조
+# 필드 자체가 없음)를 테스트 발행하면 project 해소가 항상 400이었다. 폴백 사슬(호출 컨텍스트
+# — X-Project-Id 헤더/멤버 단일 접근가능 프로젝트)이 실제로 동작하는지, 그리고 기존
+# 참조기반 해소·dangling 참조 거부(AC2 무회귀)는 안 깨지는지 검증.
+
+async def _seed_custom_signal_definition(session, org_id, *, key="org.acme.acceptance_check_cycle"):
+    """work_item/goal 참조 필드가 아예 없는 정의기 신호형류 — #2670의 실 재현 모양
+    (payload_schema에 kind만 있고 work_item_type/id·goal_id 부재)."""
+    from app.models.event_definition import EventDefinition
+
+    session.add(EventDefinition(
+        id=uuid.uuid4(), key=key, org_id=org_id,
+        payload_schema={
+            "type": "object", "properties": {"kind": {"type": "string", "enum": ["ok"]}},
+            "required": ["kind"], "additionalProperties": False,
+        },
+        routing={
+            "escalation": {"kind": "server_derived", "target": "none"},
+            "broadcast": {"kind": "server_derived", "target": "none"},
+        },
+    ))
+    await session.commit()
+
+
+async def _seed_human_org_admin(session, org_id, project_id, *, name="admin"):
+    """#2670은 화면(FE 관리자 페이지, isAdmin 전용) 발행이라 실 재현 caller는 JWT 휴먼이다.
+    org owner/admin은 has_project_access/accessible_project_ids_in_org 양쪽의 admin_branch로
+    org 내 모든 project에 접근한다(project_access.py 참조) — 프로젝트별 grant를 따로 안 심어도
+    되는 가장 단순한 실증 caller. resolve_member의 human 분기가 반환하는 id는 org_member.id인데
+    conversations.created_by는 team_members FK라, om.id와 동일한 id의 team_member(human)도
+    같이 심는다(휴먼 신원의 org/project 두 표가 같은 id를 공유하는 이 코드베이스의 관례)."""
+    from app.models.user import User
+    from app.models.project import OrgMember
+    from app.models.team import TeamMember
+
+    user_id = uuid.uuid4()
+    session.add(User(id=user_id, email=f"{name}-{user_id.hex[:8]}@test.com", hashed_password="x"))
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user_id, role="admin")
+    session.add(om)
+    session.add(TeamMember(
+        id=om.id, org_id=org_id, project_id=project_id, type="human", user_id=user_id,
+        name=name, is_active=True,
+    ))
+    await session.commit()
+    return user_id
+
+
+def _human_auth(user_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
+    """JWT 휴먼 — _auth(에이전트 API키)와 대칭. api_key_id 없음이 resolve_member의 human 분기
+    판별자(member_resolver.py:_resolve_member_legacy)."""
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(user_id), email=None, claims={"app_metadata": {}}, org_id=str(org_id))
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_publish_no_reference_resolves_project_via_header():
+    """AC1 — work_item/goal 참조가 없어도 X-Project-Id 헤더가 있으면 그 프로젝트로 발행 성공
+    (#2670 화면 재현 caller=JWT 휴먼 admin)."""
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_custom_signal_definition(s, org_id)
+            user_id = await _seed_human_org_admin(s, org_id, project_id)
+
+            body = EventPublishRequest(definition_key="org.acme.acceptance_check_cycle", payload={"kind": "ok"})
+            resp = await publish_registry_event(
+                body, BackgroundTasks(), _fake_request(project_id_header=project_id),
+                db=s, auth=_human_auth(user_id, org_id), org_id=org_id,
+            )
+            assert resp["message_id"]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_publish_no_reference_resolves_project_via_single_accessible_project():
+    """AC1 변형 — 헤더도 없지만(#2670 FE가 실제로 안 보내는 케이스) 발행자가 이 org에서
+    접근 가능한 project가 단 하나면 그 프로젝트로 폴백 성공(멤버 기본/단일 접근가능
+    프로젝트 tier — resolve_required_project_id의 _resolve_project_default)."""
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_custom_signal_definition(s, org_id)
+            user_id = await _seed_human_org_admin(s, org_id, project_id)
+
+            body = EventPublishRequest(definition_key="org.acme.acceptance_check_cycle", payload={"kind": "ok"})
+            resp = await publish_registry_event(
+                body, BackgroundTasks(), _fake_request(), db=s, auth=_human_auth(user_id, org_id), org_id=org_id,
+            )
+            assert resp["message_id"]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_publish_no_reference_no_context_still_400():
+    """음성대조(AC) — 참조도 컨텍스트도(헤더 없음·발행자가 이 org의 org_member조차 아님)
+    없으면 여전히 현행 문구 그대로 명시 거부한다(폴백이 뭐든 조용히 골라주지 않는다)."""
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, _project_id = await _seed_org_project(s)
+            await _seed_custom_signal_definition(s, org_id)
+            from app.models.user import User
+
+            # org_member 행이 아예 없는 유저 — accessible_project_ids_in_org가 0건, resolve_member도
+            # "Organization member not found"로 먼저 거부할 수 있어 그 경우까지 400 하나로 포용.
+            phantom_user_id = uuid.uuid4()
+            s.add(User(id=phantom_user_id, email=f"phantom-{phantom_user_id.hex[:8]}@test.com", hashed_password="x"))
+            await s.commit()
+
+            body = EventPublishRequest(definition_key="org.acme.acceptance_check_cycle", payload={"kind": "ok"})
+            with pytest.raises(HTTPException) as ei:
+                await publish_registry_event(
+                    body, BackgroundTasks(), _fake_request(),
+                    db=s, auth=_human_auth(phantom_user_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 400
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_publish_dangling_goal_reference_still_400_no_context_fallback():
+    """AC2 무회귀 — goal_id를 «줬는데» 그 goal이 존재하지 않는 경우(참조 시도는 있었음)는
+    컨텍스트 폴백을 안 타고 그대로 즉시 거부한다(test_publish_unresolvable_project_400과
+    동일 계약 — 참조 필드 부재와 참조 실패를 다른 사건으로 가르는 #2674의 핵심 구분).
+    발행자는 X-Project-Id 헤더까지 보내는 org admin(폴백이 있었다면 100% 성공했을 가장
+    강한 조건) — attempted_reference 게이트가 실제로 그 성공 경로를 막는지까지 검증한다."""
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_preset_definitions(s)
+            user_id = await _seed_human_org_admin(s, org_id, project_id)
+
+            body = EventPublishRequest(
+                definition_key="preset.goal.measured",
+                payload={"goal_id": str(uuid.uuid4()), "metric_value": 1},  # 존재하지 않는 goal
+            )
+            with pytest.raises(HTTPException) as ei:
+                await publish_registry_event(
+                    body, BackgroundTasks(), _fake_request(project_id_header=project_id),
+                    db=s, auth=_human_auth(user_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 400
+            assert "project를 해소할 수 없습니다" in str(ei.value.detail)
     finally:
         await engine.dispose()
 
@@ -266,7 +445,7 @@ async def test_publish_unknown_definition_key_404():
             body = EventPublishRequest(definition_key="preset.does.not_exist", payload={})
             with pytest.raises(HTTPException) as ei:
                 await publish_registry_event(
-                    body, BackgroundTasks(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                    body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
                 )
             assert ei.value.status_code == 404
     finally:
@@ -291,7 +470,7 @@ async def test_publish_schema_violation_400():
             )
             with pytest.raises(HTTPException) as ei:
                 await publish_registry_event(
-                    body, BackgroundTasks(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                    body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
                 )
             assert ei.value.status_code == 400
             # story #2634 후속(#2633 정합): api_client.py의 _extract_error_message가 인식하는
@@ -338,7 +517,7 @@ async def test_publish_unresolvable_project_400():
             )
             with pytest.raises(HTTPException) as ei:
                 await publish_registry_event(
-                    body, BackgroundTasks(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                    body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
                 )
             assert ei.value.status_code == 400
     finally:

--- a/backend/tests/test_2636_publish_zero_reach_warning.py
+++ b/backend/tests/test_2636_publish_zero_reach_warning.py
@@ -103,6 +103,15 @@ def _auth(agent_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
     )
 
 
+def _fake_request() -> "StarletteRequest":
+    """story #2674 — publish_registry_event가 이제 request(X-Project-Id 헤더 폴백)를 받는다.
+    이 파일의 테스트들은 전부 work_item 참조가 있어 project 해소가 그 경로에서 끝나므로
+    헤더 없는 최소 요청으로 충분(신규 파라미터 자리만 채운다)."""
+    from starlette.requests import Request as StarletteRequest
+
+    return StarletteRequest(scope={"type": "http", "headers": []})
+
+
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
 async def test_publish_unassigned_work_item_returns_zero_reach_warning():
@@ -125,7 +134,7 @@ async def test_publish_unassigned_work_item_returns_zero_reach_warning():
                 },
             )
             resp = await publish_registry_event(
-                body, BackgroundTasks(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
             )
             assert resp["zero_reach_warning"] is True
             assert "warning" in resp
@@ -157,7 +166,7 @@ async def test_publish_assigned_work_item_no_warning():
                 },
             )
             resp = await publish_registry_event(
-                body, BackgroundTasks(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
             )
             assert resp["zero_reach_warning"] is False
             assert "warning" not in resp

--- a/backend/tests/test_2637_action_auth_enforcement.py
+++ b/backend/tests/test_2637_action_auth_enforcement.py
@@ -133,6 +133,15 @@ def _human_auth(user_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
     )
 
 
+def _fake_request() -> "StarletteRequest":
+    """story #2674 — publish_registry_event가 이제 request(X-Project-Id 헤더 폴백)를 받는다.
+    이 파일의 테스트들은 전부 work_item 참조가 있어 project 해소가 그 경로에서 끝나므로
+    헤더 없는 최소 요청으로 충분(신규 파라미터 자리만 채운다)."""
+    from starlette.requests import Request as StarletteRequest
+
+    return StarletteRequest(scope={"type": "http", "headers": []})
+
+
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
 async def test_human_only_blocks_agent_publisher():
@@ -148,7 +157,7 @@ async def test_human_only_blocks_agent_publisher():
             with pytest.raises(HTTPException) as ei:
                 await publish_registry_event(
                     EventPublishRequest(definition_key="org.acme.thing.done", payload={}),
-                    BackgroundTasks(), db=s, auth=_agent_auth(agent_id, org_id), org_id=org_id,
+                    BackgroundTasks(), _fake_request(), db=s, auth=_agent_auth(agent_id, org_id), org_id=org_id,
                 )
             assert ei.value.status_code == 403
             assert ei.value.detail["code"] == "action_auth_denied"
@@ -171,7 +180,7 @@ async def test_human_only_allows_human_publisher():
 
             resp = await publish_registry_event(
                 EventPublishRequest(definition_key="org.acme.thing.done", payload={"goal_id": str(goal_id)}),
-                BackgroundTasks(), db=s, auth=_human_auth(human_id, org_id), org_id=org_id,
+                BackgroundTasks(), _fake_request(), db=s, auth=_human_auth(human_id, org_id), org_id=org_id,
             )
             assert "message_id" in resp
     finally:
@@ -195,7 +204,7 @@ async def test_role_mismatch_blocks_publisher():
             with pytest.raises(HTTPException) as ei:
                 await publish_registry_event(
                     EventPublishRequest(definition_key="org.acme.thing.done", payload={}),
-                    BackgroundTasks(), db=s, auth=_agent_auth(agent_id, org_id), org_id=org_id,
+                    BackgroundTasks(), _fake_request(), db=s, auth=_agent_auth(agent_id, org_id), org_id=org_id,
                 )
             assert ei.value.status_code == 403
             assert ei.value.detail["code"] == "action_auth_denied"
@@ -220,7 +229,7 @@ async def test_role_match_allows_publisher():
 
             resp = await publish_registry_event(
                 EventPublishRequest(definition_key="org.acme.thing.done", payload={"goal_id": str(goal_id)}),
-                BackgroundTasks(), db=s, auth=_agent_auth(agent_id, org_id), org_id=org_id,
+                BackgroundTasks(), _fake_request(), db=s, auth=_agent_auth(agent_id, org_id), org_id=org_id,
             )
             assert "message_id" in resp
     finally:
@@ -243,7 +252,7 @@ async def test_no_action_auth_is_unrestricted_non_regression():
 
             resp = await publish_registry_event(
                 EventPublishRequest(definition_key="org.acme.thing.done", payload={"goal_id": str(goal_id)}),
-                BackgroundTasks(), db=s, auth=_agent_auth(agent_id, org_id), org_id=org_id,
+                BackgroundTasks(), _fake_request(), db=s, auth=_agent_auth(agent_id, org_id), org_id=org_id,
             )
             assert "message_id" in resp
     finally:
@@ -269,7 +278,7 @@ async def test_combined_human_only_and_role_both_enforced():
             with pytest.raises(HTTPException) as ei:
                 await publish_registry_event(
                     EventPublishRequest(definition_key="org.acme.thing.done", payload={}),
-                    BackgroundTasks(), db=s, auth=_human_auth(human_id, org_id), org_id=org_id,
+                    BackgroundTasks(), _fake_request(), db=s, auth=_human_auth(human_id, org_id), org_id=org_id,
                 )
             assert ei.value.status_code == 403
     finally:

--- a/backend/tests/test_2637_event_msg_metadata_tagging.py
+++ b/backend/tests/test_2637_event_msg_metadata_tagging.py
@@ -104,6 +104,15 @@ def _auth(agent_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
     )
 
 
+def _fake_request() -> "StarletteRequest":
+    """story #2674 — publish_registry_event가 이제 request(X-Project-Id 헤더 폴백)를 받는다.
+    이 파일의 테스트들은 전부 work_item 참조가 있어 project 해소가 그 경로에서 끝나므로
+    헤더 없는 최소 요청으로 충분(신규 파라미터 자리만 채운다)."""
+    from starlette.requests import Request as StarletteRequest
+
+    return StarletteRequest(scope={"type": "http", "headers": []})
+
+
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
 async def test_publish_tags_message_with_event_key_and_payload():
@@ -128,7 +137,7 @@ async def test_publish_tags_message_with_event_key_and_payload():
                 },
             )
             resp = await publish_registry_event(
-                body, BackgroundTasks(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
             )
 
             msg = (await s.execute(


### PR DESCRIPTION
## Summary
story #2674 — #2670's live 3rd-round verification (2026-08-16) found: custom events built by the definer that have no `work_item`/`goal` reference in their payload (signal/measure formats — the entire reason the definer exists) can never publish. `_resolve_event_project_id` only ever resolved project scope from `work_item_type`+`work_item_id` or `goal_id` payload fields; every preset and today's org vocabulary happened to carry a work_item reference, so this structural gap stayed latent until the definer's own AC exposed it.

## Fix
When the payload never attempted a work_item/goal reference at all, fall back to the caller's context (X-Project-Id header → member's default/single-accessible project) before giving up. Reuses `resolve_required_project_id` (`app/dependencies/project_scope.py`) — the same SSOT fallback chain MCP's `api_client.py:require_project_id()` already uses — rather than inventing a new one.

Crucially: a reference that **was** attempted but fails to resolve (e.g. `goal_id` pointing at a goal that doesn't exist) still gets rejected immediately, unchanged — falling back to caller context there would silently publish to the wrong project instead of surfacing the real "you referenced something broken" error. `test_publish_unresolvable_project_400` (pre-existing) still passes unmodified.

## A real access-control asymmetry found along the way
`resolve_required_project_id`'s agent branch requires an explicit `Member`+`ProjectAccess` grant — a plain `TeamMember.project_id` (how most agents are provisioned) doesn't satisfy it, confirmed by reading `has_project_access`/`accessible_project_ids_in_org`'s SQL directly. Since #2670's own reproduction is screen-driven (JWT human, admin-only page), this is out of scope here, but worth flagging: an agent calling this same endpoint without a granted `ProjectAccess` row would still hit the final 400 even under the new fallback.

## Test plan
- 4 new tests: header fallback succeeds, single-accessible-project fallback succeeds, no reference + no context still 400, dangling goal reference still rejects immediately (no fallback).
- Mutation: reverted the `attempted_reference` gate and independently the `resolve_required_project_id` call itself — both correctly turned the new tests RED with the exact symptom, restored GREEN.
- `publish_registry_event` gained a required `request: Request` param; updated all 9 existing direct-call sites across 4 test files accordingly (`request=` a minimal Starlette `Request` where the new fallback path isn't exercised).
- Regression: the 4 touched test files — 23/23 GREEN.
- Confirmed 23 unrelated pre-existing failures elsewhere in the suite (artifact-created-event, read-state, webhook-mute, etc.) reproduce identically with my diff `git stash`ed — not caused by this change (environment fixture gap, out of scope).

## QA note
Self-QA not possible here (author = reviewer conflict) — routing for cross-check.