### PR TITLE
[SID:2673] deploy_realtime_gce.sh — 배포 성공 후 옛 인스턴스 템플릿 자가 프루닝

### DIFF
--- a/backend/scripts/deploy_realtime_gce.sh
+++ b/backend/scripts/deploy_realtime_gce.sh
@@ -764,6 +764,41 @@ if ! gcloud compute backend-services describe "${GCLB_BACKEND_SERVICE}" --global
     exit 1
 fi
 
+# story #2673(2026-08-15, 실사고: dev 배포가 quota INSTANCE_TEMPLATES(한도 300)로 실패 —
+# 배포마다 이 스크립트가 새 템플릿을 만들고 옛것을 영구 방치했다. dev 게이트웨이만 463개
+# 누적, 실사용 1개. PO가 수동으로 460개 삭제 후 재실행해 복구) — 「상태 자가회수 부재」
+# 결함 클래스(worktree 디스크 사태와 동족) 재발 방지: 배포 본체가 성공적으로 끝난(트래픽
+# 부착까지 확認된) 지금, 같은 env 접두의 옛 템플릿을 최신 N개만 남기고 정리한다.
+#
+# ⛔AC2: 프루닝 실패가 배포 성공을 뒤집지 않는다 — 여기까지 오면 배포 자체는 이미 끝났다
+# (named-ports·backend-service 부착 확認 완료). 이 아래는 순수 정리 단계라 실패해도 경고만
+# 남기고 스크립트는 rc=0으로 마친다(set -e가 이 블록 전체를 죽이지 않도록 `|| true`로 감쌈).
+#
+# in-use 템플릿(현재 MIG가 참조 중)은 GCE가 삭제 요청 자체를 거부하므로 별도 방어 로직
+# 불요 — gcloud의 그 보장을 그대로 신뢰한다(재발명 안 함).
+PRUNE_KEEP="${GCE_TEMPLATE_PRUNE_KEEP:-5}"
+log "Pruning old instance templates (prefix=${TEMPLATE_PREFIX}-, keep latest ${PRUNE_KEEP})"
+_old_templates="$(gcloud compute instance-templates list \
+    --project="${GCP_PROJECT}" \
+    --filter="name~^${TEMPLATE_PREFIX}-" \
+    --sort-by=~creationTimestamp \
+    --format='value(name)' 2>/dev/null | tail -n +"$((PRUNE_KEEP + 1))")" || {
+    log "⚠️ Pruning skipped — could not list instance templates (gcloud error, non-fatal)"
+    _old_templates=""
+}
+if [ -n "${_old_templates}" ]; then
+    while IFS= read -r _tmpl; do
+        [ -z "${_tmpl}" ] && continue
+        if gcloud compute instance-templates delete "${_tmpl}" --project="${GCP_PROJECT}" --quiet 2>/dev/null; then
+            log "Pruned old instance template ${_tmpl}"
+        else
+            log "⚠️ Failed to prune instance template ${_tmpl} (likely still in-use — non-fatal, skipping)"
+        fi
+    done <<< "${_old_templates}"
+else
+    log "No old instance templates to prune (count within keep-${PRUNE_KEEP} window)"
+fi
+
 log "=== Deployment submitted ==="
 log "Instance template: ${TEMPLATE_NAME}"
 log "MIG: ${MIG_NAME} (region ${GCP_REGION})"

--- a/backend/tests/test_deploy_gce_template_pruning.py
+++ b/backend/tests/test_deploy_gce_template_pruning.py
@@ -1,0 +1,183 @@
+"""story #2673(2026-08-15, 실사고: dev 배포가 quota INSTANCE_TEMPLATES(한도 300) 소진으로
+실패 — 실측 470개, dev 게이트웨이만 463개·실사용 1개) — deploy_realtime_gce.sh가 배포 성공
+후 옛 인스턴스 템플릿을 스스로 정리하는지 확인하는 실행 기반(mock gcloud) 회귀가드.
+
+⚠️DRY_RUN=1은 이 로직 자체를 건너뛴다(gcloud 실 호출부 진입 前 exit 0) —
+test_deploy_gce_rolling_update_maxsurge_failfast.py와 동일 이유로 DRY_RUN=0 +
+PATH mock gcloud 패턴을 재사용한다(신규 발명 아님)."""
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+
+_SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "deploy_realtime_gce.sh")
+
+
+def _mock_gcloud_script(*, template_names: list[str], delete_should_fail_for: set[str] | None = None) -> str:
+    """rolling-update 분기(템플릿·MIG 둘 다 이미 존재)까지는 기존 회귀가드 파일과 동일
+    최소 mock — 그 뒤 프루닝 단계(list/delete)만 이 파일 전용으로 추가한다.
+
+    `instance-templates list`는 실 gcloud가 `--sort-by=~creationTimestamp`로 이미 최신순
+    정렬해 돌려주는 것을 흉내내 `template_names`를 그 순서 그대로(내림차순 가정) 반환한다
+    — 정렬 로직 자체는 gcloud 서버측 책임이라 mock 대상이 아니다(이 스크립트의 소비 로직
+    — tail로 앞 N개를 건너뛰는 것 — 만 검증 대상)."""
+    delete_should_fail_for = delete_should_fail_for or set()
+    names_lines = "\n".join(f'echo "{n}"' for n in template_names)
+    fail_cases = "\n".join(
+        f'*"instance-templates delete {n} "*) exit 1 ;;' for n in delete_should_fail_for
+    )
+    return textwrap.dedent(f"""\
+        #!/usr/bin/env bash
+        set -euo pipefail
+        args="$*"
+        echo "MOCK_GCLOUD_CALL: $args" >> "${{MOCK_GCLOUD_LOG}}"
+
+        case "$args" in
+            *"instance-templates describe"*)
+                exit 0  # 템플릿 이미 존재 — create 스킵.
+                ;;
+            *"instance-groups managed describe"*"format=json(distributionPolicy.zones)"*)
+                echo '{{"distributionPolicy": {{"zones": [{{"zone": "za"}}, {{"zone": "zb"}}, {{"zone": "zc"}}]}}}}'
+                exit 0
+                ;;
+            *"instance-groups managed describe"*)
+                exit 0  # MIG 이미 존재 — rolling-update 분기 진입.
+                ;;
+            *"rolling-action start-update"*)
+                exit 0
+                ;;
+            *"set-named-ports"*)
+                exit 0
+                ;;
+            *"backend-services describe"*)
+                echo "https://.../instanceGroups/${{MIG_NAME:-mig}}"
+                exit 0
+                ;;
+            *"instance-templates list "*)
+                echo "$args" >> "${{MOCK_TEMPLATES_LIST_ARGS_FILE}}"
+{textwrap.indent(names_lines, ' ' * 16) if names_lines else ''}
+                exit 0
+                ;;
+            {fail_cases}
+            *"instance-templates delete "*)
+                echo "$args" >> "${{MOCK_TEMPLATES_DELETE_ARGS_FILE}}"
+                exit 0
+                ;;
+            *)
+                exit 0
+                ;;
+        esac
+        """)
+
+
+def _run_script(tmp_path, *, template_names: list[str], delete_should_fail_for: set[str] | None = None,
+                 extra_env: dict | None = None):
+    mock_bin_dir = tmp_path / "mockbin"
+    mock_bin_dir.mkdir()
+    gcloud_path = mock_bin_dir / "gcloud"
+    gcloud_path.write_text(
+        _mock_gcloud_script(template_names=template_names, delete_should_fail_for=delete_should_fail_for)
+    )
+    gcloud_path.chmod(0o755)
+
+    log_file = tmp_path / "mock_calls.log"
+    list_args_file = tmp_path / "templates_list_args.txt"
+    delete_args_file = tmp_path / "templates_delete_args.txt"
+    for f in (log_file, list_args_file, delete_args_file):
+        f.write_text("")
+
+    env = {
+        **os.environ,
+        "PATH": f"{mock_bin_dir}:{os.environ['PATH']}",
+        "DRY_RUN": "0",
+        "COMMIT_SHA": "deadbeef",
+        "MIG_NAME": "sprintable-realtime-gateway-dev",
+        "MOCK_GCLOUD_LOG": str(log_file),
+        "MOCK_TEMPLATES_LIST_ARGS_FILE": str(list_args_file),
+        "MOCK_TEMPLATES_DELETE_ARGS_FILE": str(delete_args_file),
+    }
+    if extra_env:
+        env.update(extra_env)
+    proc = subprocess.run(["bash", _SCRIPT, "dev"], capture_output=True, text=True, env=env)
+    deleted = [l for l in delete_args_file.read_text().splitlines() if l.strip()]
+    list_args = list_args_file.read_text().strip()
+    return proc, deleted, list_args
+
+
+def _deleted_names(deleted_lines: list[str]) -> list[str]:
+    out = []
+    for line in deleted_lines:
+        # "compute instance-templates delete <name> --project=... --quiet"
+        parts = line.split()
+        idx = parts.index("delete")
+        out.append(parts[idx + 1])
+    return out
+
+
+def test_prune_keeps_latest_n_deletes_the_rest(tmp_path):
+    """AC1/AC3 — 최신순으로 이미 정렬돼 돌아온 8개 중 기본 keep=5를 넘는 뒤쪽 3개만 삭제된다."""
+    names = [f"sprintable-realtime-gateway-dev-{i:02d}" for i in range(8)]  # 00이 최신
+    proc, deleted, _ = _run_script(tmp_path, template_names=names)
+    assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    assert _deleted_names(deleted) == names[5:], f"got: {_deleted_names(deleted)!r}"
+
+
+def test_prune_within_keep_window_deletes_nothing(tmp_path):
+    """음성대조 — 템플릿 수가 keep 이하면 삭제 호출 자체가 0건."""
+    names = [f"sprintable-realtime-gateway-dev-{i:02d}" for i in range(3)]
+    proc, deleted, _ = _run_script(tmp_path, template_names=names)
+    assert proc.returncode == 0
+    assert deleted == []
+
+
+def test_prune_respects_env_override_keep_count(tmp_path):
+    """GCE_TEMPLATE_PRUNE_KEEP override — 기본 5가 아니라 명시값을 쓴다."""
+    names = [f"sprintable-realtime-gateway-dev-{i:02d}" for i in range(8)]
+    proc, deleted, _ = _run_script(tmp_path, template_names=names, extra_env={"GCE_TEMPLATE_PRUNE_KEEP": "2"})
+    assert proc.returncode == 0
+    assert _deleted_names(deleted) == names[2:]
+
+
+def test_prune_filter_scoped_to_this_env_prefix_only(tmp_path):
+    """음성대조 — list 호출의 --filter가 이 env(dev)의 TEMPLATE_PREFIX로만 좁혀져 있다
+    (prod 템플릿이 같은 목록에 섞여 삭제 대상이 되지 않는다는 것의 대리 확인 — mock
+    자체는 필터를 해석하지 않으므로, 스크립트가 gcloud에 «올바른 필터 문자열»을
+    넘기는지를 직접 확인한다)."""
+    _, _, list_args = _run_script(tmp_path, template_names=[])
+    assert "name~^sprintable-realtime-gateway-dev-" in list_args, f"got: {list_args!r}"
+    assert "prod" not in list_args
+
+
+def test_prune_delete_failure_is_non_fatal_deploy_still_succeeds(tmp_path):
+    """⭐AC2 핵심 — in-use 등으로 삭제가 거부돼도(비-0 종료) 전체 배포는 여전히 rc=0으로
+    끝나고 "Deployment submitted"까지 도달한다(프루닝은 배포 본체와 격리된 정리 단계)."""
+    names = [f"sprintable-realtime-gateway-dev-{i:02d}" for i in range(7)]
+    fail_targets = {names[5], names[6]}
+    proc, deleted, _ = _run_script(tmp_path, template_names=names, delete_should_fail_for=fail_targets)
+    assert proc.returncode == 0, f"프루닝 실패가 배포 성공을 뒤집으면 안 된다 — stderr={proc.stderr!r}"
+    assert "Deployment submitted" in proc.stderr
+    # 프루닝 대상 2개(names[5:])가 전부 fail_targets이므로 성공 로그(exit 1 케이스는
+    # MOCK_TEMPLATES_DELETE_ARGS_FILE에 안 적도록 mock을 설계했다)는 0건이어야 한다.
+    assert set(names[5:]) == fail_targets
+    assert deleted == [], f"둘 다 실패 지정이라 성공 로그는 0건이어야 — got {deleted!r}"
+
+
+def test_prune_no_templates_found_is_non_fatal(tmp_path):
+    """음성대조 — list가 빈 결과를 돌려줘도(신규 env·최초 배포 등) 정상 종료."""
+    proc, deleted, _ = _run_script(tmp_path, template_names=[])
+    assert proc.returncode == 0
+    assert deleted == []
+    assert "Deployment submitted" in proc.stderr
+
+
+def test_prune_runs_after_deployment_success_log_order(tmp_path):
+    """프루닝 로그가 실제로 "Deployment submitted" 이전(배포 본체 확定 後)에 나오는지 —
+    순서 자체가 AC1("배포 성공 확定 後")의 실행 증거."""
+    names = [f"sprintable-realtime-gateway-dev-{i:02d}" for i in range(6)]
+    proc, _, _ = _run_script(tmp_path, template_names=names)
+    stderr = proc.stderr
+    prune_idx = stderr.find("Pruning old instance templates")
+    submitted_idx = stderr.find("Deployment submitted")
+    assert prune_idx != -1 and submitted_idx != -1, f"stderr={stderr!r}"
+    assert prune_idx < submitted_idx


### PR DESCRIPTION
## 배경
실사고(2026-08-15): dev 배포(3078분·Cloud Build 910cd415)가 step10 `deploy-realtime-gce`에서 `Quota INSTANCE_TEMPLATES exceeded (limit 300)`로 실패. 원인 = `deploy_realtime_gce.sh`가 배포마다 새 인스턴스 템플릿(`sprintable-realtime-gateway-{env}-{sha}-{hash}`)을 만들고 옛것을 영구 방치 — 실측 470개(dev 게이트웨이만 463개, 실사용 1개). PO가 수동 회수(최신 3 보존·460개 삭제) 후 재실행으로 복구.

「상태 자가회수 부재」 결함 클래스 재발(worktree 디스크 사태와 동족) — 수동 회수는 대증, 근본은 배포 경로가 자기 잔재를 지우는 것.

## 변경
`deploy_realtime_gce.sh`의 배포 본체(템플릿 생성/rolling-update·named-ports 보장·backend-service 부착 확認)가 전부 끝난 뒤, `FATAL` 최종검증 통과 지점 바로 다음(=`=== Deployment submitted ===` 로그 직전)에 프루닝 단계 추가:

- 같은 env 접두(`TEMPLATE_PREFIX-`)의 인스턴스 템플릿을 `creationTimestamp` 내림차순으로 조회, 최신 **N개(기본 5, `GCE_TEMPLATE_PRUNE_KEEP` env로 override 가능)**만 남기고 나머지 삭제.
- in-use 템플릿(현재 MIG가 참조 중)은 GCE가 삭제 요청 자체를 거부하므로 별도 방어 로직 불요 — gcloud의 그 보장을 그대로 신뢰(재발명 안 함).
- **AC2**: 프루닝 실패(list 실패·개별 delete 거부)가 배포 성공을 뒤집지 않는다 — 이 시점 이후는 순수 정리 단계라 경고만 남기고 rc=0으로 마친다.
- **AC4**: dev/prod 둘 다 같은 코드 경로(`TEMPLATE_PREFIX`가 이미 상단 case 분기로 env별로 갈려 있어 별도 분기 불요).

## 테스트
`test_deploy_gce_rolling_update_maxsurge_failfast.py`의 기존 mock-gcloud 실행 하네스 패턴 재사용(DRY_RUN=0 + PATH에 mock `gcloud` — DRY_RUN=1은 이 로직 진입 전 exit하므로 기존 DRY_RUN 패턴으론 커버 불가, 신규 발명 아님).

`test_deploy_gce_template_pruning.py` 신규 7건:
1. keep-N(기본 5)을 넘는 뒤쪽만 정확히 삭제
2. keep 이하면 삭제 0건(음성대조)
3. `GCE_TEMPLATE_PRUNE_KEEP` override 반영
4. `--filter`가 이 env 접두로만 좁혀짐("prod" 미포함 확認 — 음성대조)
5. **⭐AC2 핵심**: 개별 delete 실패(in-use 시뮬레이션)해도 배포 전체는 rc=0·"Deployment submitted" 도달
6. 빈 템플릿 목록도 비치명적(신규 env·최초 배포)
7. 프루닝 로그가 "Deployment submitted"보다 먼저 나옴(AC1 "배포 성공 확定 後" 실행 순서 증거)

로컬 실행 52/52 GREEN(회귀 45건 포함, 기존 `test_deploy_gce_rolling_update_maxsurge_failfast.py`+`test_deploy_realtime_gce_env.py` 무영향).

**뮤테이션 2건 독립 확인**:
- `tail -n +$((KEEP+1))` 스킵 로직 제거(keep-N 무시하고 전부 조회) → 4건 정확히 RED.
- delete 실패를 if/else 가드 없이 방치해 `set -e`가 스크립트를 죽이게 함 → AC2 핵심 테스트가 정확히 RED(rc=1, "Deployment submitted" 미도달 — 원 사고와 대칭되는 실패 모드).
- 둘 다 원복 후 52/52 재확인, `git diff` 클린.

`shellcheck`: 추가 블록에서 신규 경고 0건(기존 경고는 무관 pre-existing).

## AC
1. ✅ 배포 성공 경로 끝에 옛 템플릿 프루닝(최신 N 보존·in-use 안전) 실행
2. ✅ 프루닝 실패가 배포 성공을 뒤집지 않음(경고만)
3. ⛔라이브 전용 판별자("배포 10회 후 템플릿 수 상수 수렴")는 이 PR 범위 밖 — mock 테스트로 로직 정확성만 증명, 실측 수렴은 파이프라인이 실제로 여러 번 돈 뒤 PO 관측 필요
4. ✅ prod 경로 동일 적용(코드 경로 공유)