### PR TITLE
[SID:2671] EmbedCard 실 렌더 경로 배선 — 단독 참조 문단은 카드로

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -38,6 +38,13 @@ vi.mock('next/image', () => ({
     <img src={src} alt={alt} data-next-image="true" />,
 }));
 
+// story #2671 — EmbedCard(단독 참조 문단 카드 렌더)가 doc 클릭 시 useRouter()를 쓴다.
+// 이 스위트의 baseMessage.content 자체가 단독 doc 참조라 라우터 컨텍스트 없이 렌더하면
+// "invariant expected app router to be mounted"로 죽는다.
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: () => {} }),
+}));
+
 let container: HTMLDivElement;
 let root: Root;
 
@@ -57,7 +64,11 @@ const baseMessage: ChatMessage = {
   created_by: 'agent-1',
   sender_name: '오르테가',
   sender_type: 'agent',
-  content: `[제안서.md](entity:doc:${DOC_ID})`,
+  // story #2671 — 링크 하나뿐인 문단은 이제 EmbedCard(카드)로 렌더된다(신규 기능, 아래
+  // 전용 describe에서 검증). 이 파일의 나머지 스위트는 전부 EntityChip 특화 동작(사실성
+  // 표기·상태 배지·결재 CTA·모달 재렌더 생존 등)을 재는 게 목적이라 앞에 문맥어를 붙여
+  // "단독 문단"이 아니게 만든다 — 카드 스왑에 영향받지 않고 원래 의도 그대로 유지.
+  content: `문서 첨부: [제안서.md](entity:doc:${DOC_ID})`,
   attachments: [],
   created_at: '2026-07-20T00:00:00.000Z',
 };
@@ -177,7 +188,7 @@ describe('ChatBubble — story #2262 AC2 PR② 1단계(2026-08-07 유나양 카�
     await act(async () => {
       root.render(wrap(
         <ChatBubble
-          message={{ ...baseMessage, content: `[가설 A](entity:hypothesis:${hypothesisId})`, references: undefined }}
+          message={{ ...baseMessage, content: `가설 첨부: [가설 A](entity:hypothesis:${hypothesisId})`, references: undefined }}
           isMine={false}
         />,
       ));
@@ -1376,5 +1387,85 @@ describe('ChatBubble — story #2669(B2) doc 칩 결재 CTA', () => {
     });
     expect(container.textContent).toContain('상신 실패');
     expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent === '결재로 올리기')).toBe(true);
+  });
+});
+
+// story #2671 — EmbedCard(ME-S5 원조 카드, "메모 기능 퇴역" PR#924 이후 실 렌더 경로 0건이던
+// built-but-nowhere-to-run)를 되살린 지점. 참조 링크 하나뿐인 문단만 카드로 바뀐다 — 본문에
+// 섞인 인라인 참조는 위 스위트 전부가 그대로 증명하듯 EntityChip 그대로다(회귀 0).
+describe('ChatBubble — story #2671 EmbedCard 단독 참조 문단 카드 렌더', () => {
+  it('참조 링크 하나뿐인 문단(doc)은 EmbedCard로 렌더된다(카드 전용 미리보기 아이콘 버튼 존재)', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, content: `[제안서.md](entity:doc:${DOC_ID})`, references: [{ target_type: 'doc', target_id: DOC_ID }] }}
+          isMine={false}
+        />,
+      ));
+    });
+    // EmbedCard doc 분기 전용 마커 — EntityChip엔 이 아이콘 버튼이 없다.
+    expect(container.querySelector('button[aria-label="미리보기"]')).not.toBeNull();
+    // 카드(block, rounded-md) — 칩(inline, rounded)과 다른 시각 클래스.
+    expect(container.querySelector('.rounded-md')).not.toBeNull();
+    expect(container.textContent).toContain('제안서.md');
+  });
+
+  it('참조 링크 하나뿐인 문단(story·non-doc)도 EmbedCard로 렌더된다', async () => {
+    const storyId = '33333333-3333-3333-3333-333333333333';
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, content: `[스토리 제목](entity:story:${storyId})`, references: [{ target_type: 'story', target_id: storyId }] }}
+          isMine={false}
+        />,
+      ));
+    });
+    expect(container.querySelector('.rounded-md')).not.toBeNull();
+    // non-doc 분기엔 미리보기 아이콘이 없다(doc 전용) — 카드 자체를 눌러 모달을 연다.
+    expect(container.querySelector('button[aria-label="미리보기"]')).toBeNull();
+    expect(container.textContent).toContain('스토리 제목');
+  });
+
+  it('참조가 유령(stored 참조에 없음)이면 단독 문단이어도 카드가 아니라 유령 칩(행동 0)이다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, content: `[제안서.md](entity:doc:${DOC_ID})`, references: [] }}
+          isMine={false}
+        />,
+      ));
+    });
+    expect(container.querySelector('.rounded-md')).toBeNull();
+    expect(container.querySelector('button')).toBeNull();
+    expect(container.textContent).toContain('대상이 없습니다');
+  });
+
+  it('asset 토큰은 단독 문단이어도 기존 AssetEmbedCard 그대로다(EmbedCard로 안 새어간다)', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, content: `[파일.png](entity:asset:${DOC_ID})`, references: [] }}
+          isMine={false}
+        />,
+      ));
+    });
+    // AssetEmbedCard도 카드형이라 rounded-md를 쓸 수 있으므로, 대신 EmbedCard 전용 마커
+    // (미리보기 버튼)의 부재로 "EmbedCard로 안 갔다"만 정확히 잰다.
+    expect(container.querySelector('button[aria-label="미리보기"]')).toBeNull();
+  });
+
+  it('같은 문단에 참조 외 텍스트가 섞여 있으면(단독 아님) 카드가 아니라 인라인 칩이다(회귀 0)', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, content: `참고: [제안서.md](entity:doc:${DOC_ID})`, references: [{ target_type: 'doc', target_id: DOC_ID }] }}
+          isMine={false}
+        />,
+      ));
+    });
+    expect(container.querySelector('.rounded-md')).toBeNull();
+    expect(container.querySelector('button[aria-label="미리보기"]')).toBeNull();
+    expect(container.textContent).toContain('참고:');
+    expect(container.textContent).toContain('제안서.md');
   });
 });

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -1441,17 +1441,25 @@ describe('ChatBubble — story #2671 EmbedCard 단독 참조 문단 카드 렌�
   });
 
   it('asset 토큰은 단독 문단이어도 기존 AssetEmbedCard 그대로다(EmbedCard로 안 새어간다)', async () => {
+    // 카디르군 QA 지적(PR#3086) — references:[](유령)를 쓰면 유령가드가 먼저 막아버려서
+    // asset 제외 분기(`m[1] !== 'asset'`) 자체는 한 번도 안 거친 채로 그린이 뜬다(뮤테이션
+    // 해서 그 분기를 지워도 이 테스트는 안 빨개짐). 실제 asset 제외를 재는 재현은 asset이
+    // «유령이 아닌» 상태여야 한다 — stored 참조에 asset 엔트리를 실어 ghost가 false가 되게
+    // 하고, AssetEmbedCard 전용 렌더(자산 조회 실패 폴백 문구)로 「EmbedCard로 안 갔다」를
+    // 직접 확認한다(부재 아닌 양성 마커).
     await act(async () => {
       root.render(wrap(
         <ChatBubble
-          message={{ ...baseMessage, content: `[파일.png](entity:asset:${DOC_ID})`, references: [] }}
+          message={{ ...baseMessage, content: `[파일.png](entity:asset:${DOC_ID})`, references: [{ target_type: 'asset', target_id: DOC_ID }] }}
           isMine={false}
         />,
       ));
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
     });
-    // AssetEmbedCard도 카드형이라 rounded-md를 쓸 수 있으므로, 대신 EmbedCard 전용 마커
-    // (미리보기 버튼)의 부재로 "EmbedCard로 안 갔다"만 정확히 잰다.
     expect(container.querySelector('button[aria-label="미리보기"]')).toBeNull();
+    expect(container.querySelector('.rounded-md')).not.toBeNull();
+    // AssetEmbedCard의 실 렌더 마커(자산 조회 실패 폴백 문구) — EmbedCard로 샜다면 절대 안 뜬다.
+    expect(container.textContent).toContain('자산을 찾을 수 없습니다');
   });
 
   it('같은 문단에 참조 외 텍스트가 섞여 있으면(단독 아님) 카드가 아니라 인라인 칩이다(회귀 0)', async () => {

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -8,7 +8,7 @@ import { Bot, Check, Copy, MessageSquare, Terminal, User } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
 import { commandName, dequoteLiteral, isCommand } from '@/lib/command-classifier';
-import { EntityChip, getEntityHref } from '@/components/chat/embed-card';
+import { EmbedCard, EntityChip, getEntityHref } from '@/components/chat/embed-card';
 import type { EntityStatusFetchState } from '@/components/chat/entity-status-labels';
 import { AssetEmbedCard } from '@/components/chat/asset-embed-card';
 import { getFileIcon } from '@/lib/file-icon';
@@ -105,6 +105,29 @@ function findReferenceMeta(
   return { form: match.form, referencedAt: match.referenced_at };
 }
 
+// story #2671 — EmbedCard(ME-S5 원조 카드 렌더)가 실 렌더 경로에 미배선이던 것을 여기서
+// 되살린다: 문단이 참조 링크 «하나뿐»(다른 텍스트 0)이면 인라인 EntityChip 대신 카드로
+// 그린다 — Slack/Discord/Notion의 "단독 링크→언퍼얼 카드" 관례와 같은 자리. react-markdown
+// v10은 hast-util-to-jsx-runtime에 `passNode:true`를 내부 고정해 커스텀 컴포넌트에 원본
+// hast 노드를 항상 건네준다(옵션 켤 필요 없음) — 그 `node.children`(렌더된 React가 아닌
+// 원본 AST)으로만 "링크 하나뿐"을 정확히 잰다(렌더된 children으로는 이미 자식 컴포넌트
+// 타입이 뭉개져 있어 못 잰다).
+type HastTextLike = { type?: string; value?: string; children?: HastTextLike[] };
+type HastElementLike = { type?: string; tagName?: string; properties?: { href?: unknown }; children?: HastTextLike[] };
+
+function soleLinkChild(node: HastElementLike | undefined): HastElementLike | null {
+  const kids = node?.children;
+  if (!kids || kids.length !== 1) return null;
+  const only = kids[0] as HastElementLike;
+  return only?.type === 'element' && only.tagName === 'a' ? only : null;
+}
+
+function hastNodeText(node: HastTextLike | undefined): string {
+  if (!node) return '';
+  if (node.type === 'text') return node.value ?? '';
+  return (node.children ?? []).map(hastNodeText).join('');
+}
+
 // Convert @name tokens to markdown links so react-markdown v10 can render them via the `a` component.
 // Uses negative lookbehind to skip already-linked mentions (e.g. inside [...]).
 function prepareMentions(content: string): string {
@@ -185,7 +208,19 @@ function ChatMarkdown({ content, isMine, references, entityStatusByKey }: {
   // 한 참조를 고정해 react-markdown이 같은 컴포넌트 인스턴스를 재사용하게 한다. hasMarkdown이
   // false인 이른 return보다 위에 둬 훅 호출 순서를 무조건화한다(rules-of-hooks).
   const components = useMemo(() => ({
-    p: ({ children }: { children?: React.ReactNode }) => <p className={`mb-1.5 [overflow-wrap:anywhere] text-sm leading-relaxed last:mb-0 ${text}`}>{children}</p>,
+    p: ({ children, node }: { children?: React.ReactNode; node?: HastElementLike }) => {
+      // story #2671 — 참조 링크 하나가 문단의 전부면(다른 텍스트 0) 카드 임베드로.
+      const link = soleLinkChild(node);
+      const href = link?.properties?.href;
+      const m = typeof href === 'string' ? href.match(/^entity:(\w+):([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i) : null;
+      if (m && m[1]!.toLowerCase() !== 'asset' && !isGhostReference(references, m[1]!, m[2]!)) {
+        const statusFetch = entityStatusByKey?.[`${m[1]!.toLowerCase()}:${m[2]!.toLowerCase()}`];
+        const status = statusFetch?.kind === 'resolved' ? statusFetch.raw : null;
+        const label = hastNodeText(link!.children?.[0]) || m[2]!;
+        return <EmbedCard entity_type={m[1]!} entity_id={m[2]!} title={label} status={status} />;
+      }
+      return <p className={`mb-1.5 [overflow-wrap:anywhere] text-sm leading-relaxed last:mb-0 ${text}`}>{children}</p>;
+    },
     strong: ({ children }: { children?: React.ReactNode }) => <strong className={`font-semibold ${text}`}>{children}</strong>,
     em: ({ children }: { children?: React.ReactNode }) => <em className={`italic ${text}`}>{children}</em>,
     code: ({ className, children }: { className?: string; children?: React.ReactNode }) => {

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -216,7 +216,10 @@ function ChatMarkdown({ content, isMine, references, entityStatusByKey }: {
       if (m && m[1]!.toLowerCase() !== 'asset' && !isGhostReference(references, m[1]!, m[2]!)) {
         const statusFetch = entityStatusByKey?.[`${m[1]!.toLowerCase()}:${m[2]!.toLowerCase()}`];
         const status = statusFetch?.kind === 'resolved' ? statusFetch.raw : null;
-        const label = hastNodeText(link!.children?.[0]) || m[2]!;
+        // PO 리뷰 지적 — 링크 라벨이 여러 자식(예: **강조** 섞인 텍스트)으로 쪼개질 수
+        // 있어 첫 자식만 읽으면 라벨이 잘린다. 전 자식을 이어붙인다(hastNodeText가
+        // 재귀로 하듯 여기도 동일 패턴).
+        const label = (link!.children ?? []).map(hastNodeText).join('') || m[2]!;
         return <EmbedCard entity_type={m[1]!} entity_id={m[2]!} title={label} status={status} />;
       }
       return <p className={`mb-1.5 [overflow-wrap:anywhere] text-sm leading-relaxed last:mb-0 ${text}`}>{children}</p>;

--- a/apps/web/src/components/chat/thread-panel.test.tsx
+++ b/apps/web/src/components/chat/thread-panel.test.tsx
@@ -23,6 +23,13 @@ vi.mock('@/app/dashboard/dashboard-shell', () => ({
   useDashboardContext: () => ({ projectId: 'proj-1', currentTeamMemberId: 'member-1' }),
 }));
 
+// story #2671 — 참조 링크 하나뿐인 문단은 EmbedCard(카드)로 렌더된다. EmbedCard doc 클릭
+// 핸들러가 useRouter()를 쓰므로 라우터 컨텍스트 없이 렌더하면 죽는다(같은 mock을
+// chat-bubble.test.tsx에서도 씀).
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: () => {} }),
+}));
+
 let container: HTMLDivElement;
 let root: Root;
 


### PR DESCRIPTION
## Summary
[story #2671](entity:story:1f527e49-88d9-4b15-918b-8118c1a5c616) — `EmbedCard`가 JSX 호출 0건·테스트만 참조하던 built-but-nowhere-to-run 상태를 정리.

**AC1 (원 용도·단절 시점, git 고고학)**: `EmbedCard`는 ME-S5(`bced2fa6a`, "memo 상세 embed 프리뷰 카드 렌더링")에서 만들어져 `memo-detail.tsx`에서 실 렌더됐다. "메모 기능 퇴역 S1-2"(`64176f408`, PR#924, 2026-05-22)가 `memo-detail.tsx`를 포함한 memo 컴포넌트 11개를 삭제하며 유일한 호출부가 사라졌다 — `embed-card.tsx` 자체는 같은 파일의 `EntityChip`을 `chat-bubble.tsx`가 계속 써서 살아남았을 뿐(0-diff 이동).

**AC2 (배선, 제거 대신 되살림)**: `EntityChip`(인라인 칩)·`EmbedCard`(블록 카드)는 원래 다른 문맥을 위한 쌍이었다(ME-S5 원안). 참조 링크 하나뿐인 문단(다른 텍스트 0)은 이제 `EmbedCard`로, 인라인 참조는 그대로 `EntityChip`으로 렌더된다 — Slack/Discord/Notion의 "단독 링크→언퍼얼 카드" 관례.

구현은 react-markdown v10이 커스텀 컴포넌트에 항상 건네는 원본 hast `node`(`hast-util-to-jsx-runtime`의 `passNode:true` 내부 고정)를 `p` 오버라이드에서 검사 — `node.children`이 정확히 하나이고 `entity:type:id` 링크면 스왑. 유령 참조·asset 토큰은 제외(기존 동작 유지).

**스코프**: EmbedCard에 EntityChip이 그 뒤로 얻은 기능(사실성/지점 표기·doc 결재 CTA)은 백포트하지 않음 — AC가 "배선 또는 제거로 종결"뿐이라 기능 이식은 별도 스코프로 판단.

## Test plan
- [x] 회귀: 공유 테스트 픽스처(`baseMessage`)가 우연히 단독 참조라 32건 연쇄 실패 → router mock 추가 + 픽스처에 문맥어 삽입으로 원 의도 복원(EntityChip 특화 동작 검증 유지)
- [x] 신규: #2671 전용 5건(doc/story 카드 렌더·유령은 카드 아님·asset 미영향·인라인은 칩 그대로)
- [x] `thread-panel.test.tsx` 1건도 같은 원인, router mock으로 해결
- [x] `pnpm exec tsc --noEmit` — 클린
- [x] `pnpm exec eslint` — 경고 0
- [x] `pnpm run verify:no-new-md-breakpoint` — 그린
- [x] `pnpm exec vitest run` — 420 files / 3400 tests 전부 통과
- [x] `pnpm build` — exit 0
- [x] 라이브(dev): pre-fix 베이스라인 확認(단독 참조가 여전히 칩으로 렌더됨, 미배선 재현) — PO가 배포 후 카드 실렌더로 재검

🤖 Generated with [Claude Code](https://claude.com/claude-code)