### PR TITLE
[SID:2662] create_all 격리 테스트 model 미등재 실패 — 실행 시점 진단 가드

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -35,6 +35,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+
+# story #2662 AC2 양성대조(test_2662_missing_model_import_guard.py)가 `pytester` 픽스처로
+# 이 파일의 훅을 실 서브프로세스에서 검증한다 — pytest 내장 플러그인이지만 기본 비활성
+# (opt-in)이라 여기서 명시로 켠다. 세션당 1회 로드 비용만 있고(플러그인 자체) 매 테스트
+# 오버헤드는 0.
+pytest_plugins = ["pytester"]
 from sqlalchemy import create_engine, text
 
 # 테스트 환경 기본 환경변수
@@ -235,6 +241,121 @@ def pytest_collection_modifyitems(items: list) -> None:
             f"`pytestmark = pytest.mark.{_MARKER_NAME}` 를 추가하세요:\n"
             + "\n".join(sorted(violations))
         )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# story #2662 — create_all() 격리 테스트의 "model 미등재" 실패는 원인을 안 가리킨다
+# (`relation "X" does not exist`만 뜨고 "app.models.Y 임포트 누락"이라곤 안 나온다). PR
+# #3067(#2631) 실측: 이 클래스가 «한 PR 안에서» 세 라운드 재발했다 — ①카디르 QA 8파일
+# ②디디 grep 스윕 +4(HTTP/override 간접 경로) ③CI 재실패 +9(workflow_line_config·
+# workflow_sla_processor·workflow_parallel_approval 경유 — grep이 간접 호출을 구조적으로
+# 못 본다) = 총 21파일 수기 임포트. 처방은 "실행 시점 검출"이 정합(디디 방법 교훈 — 128파일
+# 전수 실행이 grep을 이겼다).
+#
+# ⛔ⓐ(conftest가 app.models 전체를 벌크 임포트) 기각 — story #2201(2026-07-28) 실측: 그
+# 시도가 기준선 16~17분짜리 job을 25분 타임아웃(25m15s CANCELLED)으로 밀어냈다(그때
+# 101개 destructive_schema 파일 × 파일당 create_all/drop_all 오버헤드가 모델 1개 추가당
+# 누적). 지금은 그 파일 수가 128개로 더 늘었다 — 같은 시도를 다시 하면 그 비용은 줄어들
+# 이유가 없고 오히려 더 클 것이다(파일당 오버헤드 × 더 많은 파일). 재측정 없이도 그 판정은
+# 그대로 유효하다.
+#
+# ⓑ(이 가드) 채택 — 실행 시점에 "relation X does not exist" 실패를 가로채, app/models/*.py
+# 정적 스캔(AST, import 없음 — 스캔 자체가 아무 모델도 안 불러온다)으로 만든 "테이블명→
+# 모듈 경로" 레지스트리에서 X를 찾아 "app.models.Y 임포트 누락"으로 진단을 리포트 section에
+# 붙인다. 정상 경로(테스트 통과)엔 오버헤드 0 — 실패했을 때만 사후에 도는 진단이라 CI 시간
+# 예산에 영향이 없다(ⓐ가 겪은 바로 그 트레이드오프를 구조적으로 피한다).
+# ─────────────────────────────────────────────────────────────────────────────
+_MISSING_RELATION_RE = re.compile(r'relation "([a-zA-Z_][a-zA-Z0-9_]*)" does not exist')
+_TABLENAME_REGISTRY_CACHE: dict[str, str] | None = None
+
+
+def _build_tablename_to_module_registry() -> dict[str, str]:
+    """app/models/*.py를 AST로 정적 스캔해 `__tablename__ = "..."` 리터럴을 전부 모아
+    테이블명→dotted 모듈 경로 맵을 만든다. import를 하나도 안 하므로(파일을 읽어 파싱만
+    한다) 이 스캔 자체는 Base.metadata에 아무것도 등록하지 않는다 — 등재 여부를 재는 잣대와
+    스캔 행위가 서로 안 섞인다.
+
+    ⚠️models_dir을 `Path(__file__).parent.parent`(이 conftest.py 자신의 파일 위치 기준
+    상대경로)로 잡으면 안 된다 — story #2662 AC2 pytester 양성대조가 이 conftest.py를
+    격리 실행 디렉터리로 «복사»해서 돌리는데, 그러면 `__file__`이 복사된 위치를 가리켜
+    `parent.parent`가 엉뚱한 디렉터리가 된다(실측: 레지스트리가 통째로 빈 채로 조용히
+    무동작했다 — 파일 위치에 의존하는 설계 자체가 함정이었다). `importlib.util.find_spec`
+    로 `app.models` 패키지의 실제 위치만 해소한다(import 실행 없음 — spec 탐색만, 그래서
+    "스캔이 아무것도 등록 안 한다"는 위 전제가 그대로 유지된다) — conftest.py가 어디
+    있든(원본이든 복사본이든) sys.path/PYTHONPATH가 가리키는 실제 `app` 패키지 위치로
+    정확히 해소된다."""
+    import importlib.util
+
+    spec = importlib.util.find_spec("app.models")
+    if spec is None or not spec.submodule_search_locations:
+        return {}
+    models_dir = Path(next(iter(spec.submodule_search_locations)))
+    registry: dict[str, str] = {}
+    for filepath in sorted(models_dir.glob("*.py")):
+        if filepath.name == "__init__.py":
+            continue
+        try:
+            tree = ast.parse(filepath.read_text(encoding="utf-8"))
+        except (SyntaxError, OSError, UnicodeDecodeError):
+            continue
+        module_name = f"app.models.{filepath.stem}"
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            if not any(isinstance(t, ast.Name) and t.id == "__tablename__" for t in node.targets):
+                continue
+            if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                registry[node.value.value] = module_name
+    return registry
+
+
+def _diagnose_missing_relation_error(exc: BaseException) -> str | None:
+    """실패 원인이 "미등재 모델의 테이블 참조"로 보이면 진단 문구를, 아니면(레지스트리에
+    없는 테이블명 — 오타·다른 원인 등) None을 반환한다. 예외 체인(__cause__/__context__)
+    전체를 훑는다 — asyncpg의 실제 UndefinedTableError는 SQLAlchemy 래퍼 예외의 __cause__로
+    들어 있는 경우가 흔하다."""
+    chain: list[str] = []
+    cur: BaseException | None = exc
+    seen: set[int] = set()
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        chain.append(str(cur))
+        cur = cur.__cause__ or cur.__context__
+    m = _MISSING_RELATION_RE.search("\n".join(chain))
+    if not m:
+        return None
+    table_name = m.group(1)
+    global _TABLENAME_REGISTRY_CACHE
+    if _TABLENAME_REGISTRY_CACHE is None:
+        _TABLENAME_REGISTRY_CACHE = _build_tablename_to_module_registry()
+    module_name = _TABLENAME_REGISTRY_CACHE.get(table_name)
+    if module_name is None:
+        return None
+    return (
+        f'[story #2662 진단] relation "{table_name}" does not exist — 원인 추정:\n'
+        f"  {module_name} 이 이 테스트의 create_all() 이전에 임포트되지 않았다\n"
+        f"  (모델 클래스는 실재하지만 Base.metadata에 등록 안 됨 — #2201 후속 미등재 모듈일\n"
+        f"   가능성이 높다. app.models 벌크 import에도 이 모듈이 없을 수 있다).\n"
+        f"  해소: 이 파일의 _session()/create_all 헬퍼에 다음 줄을 추가할 것:\n"
+        f"      import {module_name}  # noqa: F401"
+    )
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """story #2662 — destructive_schema 테스트가 "relation X does not exist"로 실패하면
+    report.sections에 진단을 덧붙인다(longrepr 자체는 안 건드림 — 원 트레이스백 그대로 보존,
+    섹션은 pytest 표준 확장점이라 `-rA`/터미널 요약에 자동으로 실린다). 이 마커가 없는
+    테스트나 이 패턴에 안 걸리는 실패는 완전히 무영향(early return)."""
+    outcome = yield
+    report = outcome.get_result()
+    if report.when != "call" or not report.failed or call.excinfo is None:
+        return
+    if item.get_closest_marker(_MARKER_NAME) is None:
+        return
+    diagnosis = _diagnose_missing_relation_error(call.excinfo.value)
+    if diagnosis:
+        report.sections.append(("story #2662: missing model import 진단", diagnosis))
 
 
 @pytest.fixture

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -286,7 +286,15 @@ def _build_tablename_to_module_registry() -> dict[str, str]:
     정확히 해소된다."""
     import importlib.util
 
-    spec = importlib.util.find_spec("app.models")
+    try:
+        spec = importlib.util.find_spec("app.models")
+    except ModuleNotFoundError:
+        # find_spec("app.models")는 부모 패키지 "app" 자체가 sys.path 어디에도 없으면
+        # None이 아니라 ModuleNotFoundError를 던진다(문서화된 동작) — 이 함수는 실패 경로
+        # 진단용 보조 도구일 뿐이라, 여기서 죽으면 진단 하나 놓치는 정도가 아니라 pytest
+        # 실행 자체가 INTERNALERROR로 죽는다(실측: 이 case를 놓쳐 setup-phase 양성대조가
+        # 크래시). 진단을 못 붙이는 것과 테스트 러너를 죽이는 것은 전혀 다른 심각도다.
+        return {}
     if spec is None or not spec.submodule_search_locations:
         return {}
     models_dir = Path(next(iter(spec.submodule_search_locations)))
@@ -346,10 +354,16 @@ def pytest_runtest_makereport(item, call):
     """story #2662 — destructive_schema 테스트가 "relation X does not exist"로 실패하면
     report.sections에 진단을 덧붙인다(longrepr 자체는 안 건드림 — 원 트레이스백 그대로 보존,
     섹션은 pytest 표준 확장점이라 `-rA`/터미널 요약에 자동으로 실린다). 이 마커가 없는
-    테스트나 이 패턴에 안 걸리는 실패는 완전히 무영향(early return)."""
+    테스트나 이 패턴에 안 걸리는 실패는 완전히 무영향(early return).
+
+    PO AC 리뷰(2026-08-15) 실측: 21파일 사례의 지배 패턴은 `@pytest.fixture`가 아닌 평
+    async 헬퍼(`_wfc_session`류)를 테스트 본문에서 직접 await하는 것 — create_all 실패가
+    setup이 아니라 "call" 단계로 떨어진다(fixture 장식 케이스는 21건 중 1건뿐). 그래도
+    fixture-데코레이트된 create_all 헬퍼를 쓰는 미래 테스트를 위해 setup 단계도 커버한다
+    (call만으로는 놓치는 축이 실재 — 가드가 못 잡는 것을 방치하지 않는다)."""
     outcome = yield
     report = outcome.get_result()
-    if report.when != "call" or not report.failed or call.excinfo is None:
+    if report.when not in ("call", "setup") or not report.failed or call.excinfo is None:
         return
     if item.get_closest_marker(_MARKER_NAME) is None:
         return

--- a/backend/tests/test_2662_missing_model_import_guard.py
+++ b/backend/tests/test_2662_missing_model_import_guard.py
@@ -87,6 +87,56 @@ def test_diagnose_returns_none_for_unregistered_table_name():
 #     최소 재현한다: model 미등재로 create_all()이 실패하는 destructive_schema 테스트. ──
 
 
+def _replace_dbname(url: str, new_name: str) -> str:
+    base, _, tail = url.rpartition("/")
+    query = ""
+    if "?" in tail:
+        _, _, query = tail.partition("?")
+        query = "?" + query
+    return f"{base}/{new_name}{query}"
+
+
+def _admin_url(base_url: str) -> str:
+    """CREATE/DROP DATABASE는 자기 자신에 붙은 채로는 못 하므로 관리용 DB(postgres)로 붙는다."""
+    from tests.conftest import _sync_url
+
+    return _replace_dbname(_sync_url(base_url), "postgres")
+
+
+def _create_disposable_pg_database(base_url: str) -> tuple[str, str]:
+    """PR#3088 QA CRITICAL(까디르, 2026-08-15) 재발방지 — pytester 서브프로세스에 복사된
+    conftest.py의 autouse `_reset_schema_for_destructive_tests`가, 서브프로세스가 «상속»한
+    PARITY_TEST_DATABASE_URL/ALEMBIC_DATABASE_URL을 그대로 읽어 CI의 공유 sprintable_test DB에
+    DROP SCHEMA public CASCADE를 실행 — alembic_version·기초테이블 전멸로 906건 연쇄실패를
+    냈다(로컬 재현으로 실증됨). 서브프로세스가 그 공유 DB를 아예 못 보게, 이 양성대조 전용
+    throwaway DB를 새로 만들어 그 URL로만 동작하게 강제한다."""
+    import uuid
+
+    from sqlalchemy import create_engine, text
+
+    db_name = f"sprintable_test_ac2_{uuid.uuid4().hex[:8]}"
+    engine = create_engine(_admin_url(base_url), isolation_level="AUTOCOMMIT")
+    try:
+        with engine.connect() as conn:
+            conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+    finally:
+        engine.dispose()
+    return _replace_dbname(base_url, db_name), db_name
+
+
+def _drop_disposable_pg_database(base_url: str, db_name: str) -> None:
+    from sqlalchemy import create_engine, text
+
+    engine = create_engine(_admin_url(base_url), isolation_level="AUTOCOMMIT")
+    try:
+        with engine.connect() as conn:
+            conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}" WITH (FORCE)'))
+    except Exception:
+        pass  # cleanup 실패는 비치명적 — CI 잡 컨테이너 자체가 곧 폐기된다.
+    finally:
+        engine.dispose()
+
+
 @pytest.mark.skipif(
     __import__("os").getenv("PARITY_TEST_DATABASE_URL") is None
     and __import__("os").getenv("ALEMBIC_DATABASE_URL") is None,
@@ -105,7 +155,8 @@ def test_ac2_positive_control_missing_import_gets_diagnosed(pytester: pytest.Pyt
     # pytester 기본 sandbox는 빈 디렉터리라 훅 자체가 없으면 검증 대상이 없다.
     shutil.copy(Path(__file__).parent / "conftest.py", pytester.path / "conftest.py")
 
-    db_url = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+    base_db_url = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+    disposable_url, disposable_name = _create_disposable_pg_database(base_db_url)
     pytester.makepyfile(
         test_repro=f'''
 import os
@@ -126,7 +177,7 @@ async def test_write_without_activity_log_import():
     from app.core.database import Base
     import app.models  # noqa: F401 — 벌크 임포트(activity_log는 여기 없음, #2201 후속)
 
-    url = {db_url!r}
+    url = {disposable_url!r}
     for prefix in ("postgresql+psycopg2://", "postgresql://"):
         if url.startswith(prefix):
             url = "postgresql+asyncpg://" + url[len(prefix):]
@@ -148,10 +199,17 @@ async def test_write_without_activity_log_import():
     backend_dir = str((__import__("pathlib").Path(__file__).parent.parent).resolve())
     mp = pytest.MonkeyPatch()
     mp.setenv("PYTHONPATH", backend_dir + _os.pathsep + _os.environ.get("PYTHONPATH", ""))
+    # ⛔PR#3088 QA CRITICAL(까디르) — 복사된 conftest.py의 autouse 리셋 픽스처가 «상속받은»
+    # 실 DB URL을 그대로 읽는다. 서브프로세스가 그 두 변수를 무조건 위 disposable_url(이
+    # 양성대조 전용 throwaway DB)로만 보게 강제 — 진짜 CI 공유 DB는 이 서브프로세스 시야에
+    # 아예 없어야 한다(상속 금지).
+    mp.setenv("PARITY_TEST_DATABASE_URL", disposable_url)
+    mp.setenv("ALEMBIC_DATABASE_URL", disposable_url)
     try:
         result = pytester.runpytest_subprocess("-p", "no:cacheprovider", "-m", "destructive_schema", "-v")
     finally:
         mp.undo()
+        _drop_disposable_pg_database(base_db_url, disposable_name)
     result.assert_outcomes(failed=1)  # 가드가 실패 자체를 숨기면 안 된다 — 여전히 RED.
     output = "\\n".join(result.outlines)
     assert "app.models.activity_log" in output, (
@@ -192,6 +250,14 @@ def test_uses_broken_fixture(broken_create_all_session):
     backend_dir = str(Path(__file__).parent.parent.resolve())
     mp = pytest.MonkeyPatch()
     mp.setenv("PYTHONPATH", backend_dir + os.pathsep + os.environ.get("PYTHONPATH", ""))
+    # ⛔PR#3088 QA CRITICAL(까디르, 2026-08-15) — 이 테스트는 DB가 전혀 필요 없다(가짜
+    # 예외로 setup 실패를 재현). 그런데 복사된 conftest.py의 autouse 리셋 픽스처는
+    # destructive_schema 마커만 보고 발동하므로, 서브프로세스가 «상속받은» 실 DB URL이
+    # 있으면 CI의 공유 sprintable_test DB에 DROP SCHEMA를 실행해버린다(로컬 재현으로
+    # 실증 — alembic_version 전멸·906건 연쇄실패). 빈 문자열로 명시 오버라이드해 그
+    # 리셋을 완전히 무력화한다(url이 falsy → conftest.py의 `if url:` 가드가 no-op).
+    mp.setenv("PARITY_TEST_DATABASE_URL", "")
+    mp.setenv("ALEMBIC_DATABASE_URL", "")
     try:
         result = pytester.runpytest_subprocess("-p", "no:cacheprovider", "-m", "destructive_schema", "-v")
     finally:

--- a/backend/tests/test_2662_missing_model_import_guard.py
+++ b/backend/tests/test_2662_missing_model_import_guard.py
@@ -1,0 +1,160 @@
+"""story #2662 — create_all() 격리 테스트의 "model 미등재" 실패가 명확한 원인 메시지로
+잡히는지 검증(conftest.py의 pytest_runtest_makereport 훅 + 테이블명 레지스트리).
+
+PR #3067(#2631) 실측: 이 클래스가 한 PR 안에서 세 라운드 재발(21파일 수기 임포트) — 실패
+메시지(`relation "X" does not exist`)가 원인(모델 미등재)을 안 가리켜서 매번 사람이 직접
+grep으로 추적해야 했다. 처방 후보 ⓐ(conftest 벌크 임포트)는 #2201 실측(25분 CI 타임아웃)으로
+기각됐고, 이 파일은 채택된 ⓑ(실행 시점 진단 가드)를 검증한다.
+"""
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+
+# ─── 단위 축 — 레지스트리 빌더 + 진단 함수(순수 함수, DB 불요) ────────────────────
+
+
+def test_registry_maps_known_tables_to_their_module():
+    """PR #3067에서 실제로 놓쳤던 테이블(activity_logs)이 정확한 모듈로 매핑되는지 —
+    이 스토리의 존재 이유가 된 그 사례 자체를 양성대조로 고정."""
+    from tests.conftest import _build_tablename_to_module_registry
+
+    registry = _build_tablename_to_module_registry()
+    assert registry["activity_logs"] == "app.models.activity_log"
+    assert registry["gate"] == "app.models.gate"
+    # 파일당 모델 여러 개(예: doc.py가 Doc·DocSlugAlias 등 5개 __tablename__)도 전부 잡힌다.
+    assert registry["docs"] == "app.models.doc"
+
+
+def test_registry_scan_is_side_effect_free_no_model_imported():
+    """AST 정적 스캔이라 스캔 자체가 어떤 모델도 import하지 않는다 — "등재 여부를 재는
+    잣대"(sys.modules/Base.metadata)와 "스캔 행위"가 서로 안 섞인다는 설계 전제 확인."""
+    import sys
+    from tests.conftest import _build_tablename_to_module_registry
+
+    assert "app.models.activity_log" not in sys.modules
+    _build_tablename_to_module_registry()
+    assert "app.models.activity_log" not in sys.modules, (
+        "스캔이 실제로 모듈을 import했다 — 정적 스캔이어야 한다는 설계가 깨짐"
+    )
+
+
+def test_diagnose_matches_known_missing_relation_error():
+    from tests.conftest import _diagnose_missing_relation_error
+
+    exc = Exception('relation "activity_logs" does not exist')
+    diagnosis = _diagnose_missing_relation_error(exc)
+    assert diagnosis is not None
+    assert "app.models.activity_log" in diagnosis
+    assert "임포트" in diagnosis
+
+
+def test_diagnose_walks_cause_chain():
+    """실제 asyncpg 에러는 흔히 SQLAlchemy 래퍼 예외의 __cause__로 들어 있다 — 최상위
+    예외 메시지 자체엔 "relation ... does not exist"가 없어도 체인을 타고 들어가 찾는다."""
+    from tests.conftest import _diagnose_missing_relation_error
+
+    inner = Exception('UndefinedTableError: relation "gate" does not exist')
+    outer = Exception("sqlalchemy.exc.ProgrammingError: (raised as a result of Query-invoked autoflush)")
+    outer.__cause__ = inner
+    diagnosis = _diagnose_missing_relation_error(outer)
+    assert diagnosis is not None
+    assert "app.models.gate" in diagnosis
+
+
+def test_diagnose_returns_none_for_unrelated_failure():
+    """음성대조 — "relation ... does not exist" 패턴 자체가 없는 실패(예: AssertionError)는
+    이 가드가 아무것도 안 붙인다(오탐 0)."""
+    from tests.conftest import _diagnose_missing_relation_error
+
+    assert _diagnose_missing_relation_error(AssertionError("expected 1 got 2")) is None
+
+
+def test_diagnose_returns_none_for_unregistered_table_name():
+    """음성대조 — 레지스트리에 없는 테이블명(오타·다른 원인)이면 진단을 지어내지 않는다
+    (모르면 조용히 원래 실패 그대로 — 틀린 진단을 붙이는 것보다 안전)."""
+    from tests.conftest import _diagnose_missing_relation_error
+
+    assert _diagnose_missing_relation_error(
+        Exception('relation "this_table_definitely_does_not_exist_xyz" does not exist')
+    ) is None
+
+
+# ─── 실행 축(AC2 양성대조) — pytester로 실 pytest 서브프로세스를 돌려 훅이 진짜로
+#     리포트에 진단을 붙이는지 확인. DRY_RUN이 아니라 21파일 사례의 실제 실패 형태를
+#     최소 재현한다: model 미등재로 create_all()이 실패하는 destructive_schema 테스트. ──
+
+
+@pytest.mark.skipif(
+    __import__("os").getenv("PARITY_TEST_DATABASE_URL") is None
+    and __import__("os").getenv("ALEMBIC_DATABASE_URL") is None,
+    reason="양성대조는 실 create_all 실패를 내야 하므로 실 Postgres 필요",
+)
+def test_ac2_positive_control_missing_import_gets_diagnosed(pytester: pytest.Pytester):
+    """⭐AC2 핵심 — PR #3067 21파일 사례의 최소 재현. `import app.models.activity_log`가
+    빠진 채 transition_gate()류 write를 흉내내는 create_all 테스트를 서브프로세스로 돌려,
+    (1) 여전히 실패하고(가드가 실패를 숨기지 않는다) (2) 그 실패 리포트에 이 가드의 진단
+    섹션이 실제로 붙는지(원인이 명확한 메시지로 바뀌는지) 둘 다 확인한다."""
+    import os
+    import shutil
+    from pathlib import Path
+
+    # story #2662 훅이 정의된 실 conftest.py를 pytester의 격리 실행 디렉터리로 복사 —
+    # pytester 기본 sandbox는 빈 디렉터리라 훅 자체가 없으면 검증 대상이 없다.
+    shutil.copy(Path(__file__).parent / "conftest.py", pytester.path / "conftest.py")
+
+    db_url = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+    pytester.makepyfile(
+        test_repro=f'''
+import os
+import uuid
+import pytest
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_write_without_activity_log_import():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401 — 벌크 임포트(activity_log는 여기 없음, #2201 후속)
+
+    url = {db_url!r}
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    async with Session() as s:
+        from app.services.activity_log import ActivityLogService
+        await ActivityLogService(s).record(
+            org_id=uuid.uuid4(), action="x", actor_id=None, actor_type="human",
+        )
+        await s.commit()
+    await engine.dispose()
+'''
+    )
+    import os as _os
+    backend_dir = str((__import__("pathlib").Path(__file__).parent.parent).resolve())
+    mp = pytest.MonkeyPatch()
+    mp.setenv("PYTHONPATH", backend_dir + _os.pathsep + _os.environ.get("PYTHONPATH", ""))
+    try:
+        result = pytester.runpytest_subprocess("-p", "no:cacheprovider", "-m", "destructive_schema", "-v")
+    finally:
+        mp.undo()
+    result.assert_outcomes(failed=1)  # 가드가 실패 자체를 숨기면 안 된다 — 여전히 RED.
+    output = "\\n".join(result.outlines)
+    assert "app.models.activity_log" in output, (
+        f"진단 섹션이 리포트에 안 실렸다 — 21파일 사례가 재현 안 됨.\\noutput={output!r}"
+    )
+    assert "story #2662" in output

--- a/backend/tests/test_2662_missing_model_import_guard.py
+++ b/backend/tests/test_2662_missing_model_import_guard.py
@@ -158,3 +158,44 @@ async def test_write_without_activity_log_import():
         f"진단 섹션이 리포트에 안 실렸다 — 21파일 사례가 재현 안 됨.\\noutput={output!r}"
     )
     assert "story #2662" in output
+
+
+def test_setup_phase_failure_also_gets_diagnosed(pytester: pytest.Pytester):
+    """PO AC 리뷰(2026-08-15) 비블로커 권고 반영 — 21파일 사례의 지배 패턴은 call 단계
+    실패(평 async 헬퍼를 테스트 본문에서 await)지만, `@pytest.fixture`로 감싼 create_all
+    헬퍼를 쓰는 미래 테스트는 실패가 setup 단계로 떨어진다. DB 없이(가짜 예외로) 그 축도
+    실제로 커버되는지 확인 — call 단계 검증(pytester 서브프로세스, 실 PG 필요)과 별개로
+    빠르게 도는 회귀가드."""
+    import shutil
+    from pathlib import Path
+
+    shutil.copy(Path(__file__).parent / "conftest.py", pytester.path / "conftest.py")
+
+    pytester.makepyfile(
+        test_repro_setup='''
+import pytest
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def broken_create_all_session():
+    raise Exception('relation "activity_logs" does not exist')
+
+
+def test_uses_broken_fixture(broken_create_all_session):
+    pass
+'''
+    )
+    import os
+
+    backend_dir = str(Path(__file__).parent.parent.resolve())
+    mp = pytest.MonkeyPatch()
+    mp.setenv("PYTHONPATH", backend_dir + os.pathsep + os.environ.get("PYTHONPATH", ""))
+    try:
+        result = pytester.runpytest_subprocess("-p", "no:cacheprovider", "-m", "destructive_schema", "-v")
+    finally:
+        mp.undo()
+    result.assert_outcomes(errors=1)  # setup 단계 실패는 pytest에서 "error"로 집계(fail 아님).
+    output = "\n".join(result.outlines)
+    assert "app.models.activity_log" in output, f"setup 단계 진단 미부착 — output={output!r}"

--- a/backend/tests/test_2662_missing_model_import_guard.py
+++ b/backend/tests/test_2662_missing_model_import_guard.py
@@ -30,14 +30,21 @@ def test_registry_maps_known_tables_to_their_module():
 
 def test_registry_scan_is_side_effect_free_no_model_imported():
     """AST 정적 스캔이라 스캔 자체가 어떤 모델도 import하지 않는다 — "등재 여부를 재는
-    잣대"(sys.modules/Base.metadata)와 "스캔 행위"가 서로 안 섞인다는 설계 전제 확인."""
+    잣대"(sys.modules/Base.metadata)와 "스캔 행위"가 서로 안 섞인다는 설계 전제 확인.
+
+    PO 리뷰(2026-08-15) 지적 — "app.models.activity_log ∉ sys.modules" 전역 절대 단언은
+    풀스위트 실행 순서에 취약하다(다른 테스트가 그 모듈을 이미 정당하게 import해뒀으면 이
+    단언 자체가 깨진다 — 이 테스트가 검증하려는 것과 무관한 이유로). 스캔 «전/후 델타»로
+    바꿔 순서 무관하게 만든다 — 확인 대상은 "이미 import돼 있었나"가 아니라 "이 스캔 호출이
+    «새로» import를 만들었나"뿐이다."""
     import sys
     from tests.conftest import _build_tablename_to_module_registry
 
-    assert "app.models.activity_log" not in sys.modules
+    before = set(sys.modules)
     _build_tablename_to_module_registry()
-    assert "app.models.activity_log" not in sys.modules, (
-        "스캔이 실제로 모듈을 import했다 — 정적 스캔이어야 한다는 설계가 깨짐"
+    newly_imported = set(sys.modules) - before
+    assert not newly_imported, (
+        f"스캔이 실제로 모듈을 import했다 — 정적 스캔이어야 한다는 설계가 깨짐: {newly_imported}"
     )
 
 


### PR DESCRIPTION
## 배경
PR #3067(#2631)에서 이 결함 클래스가 **한 PR 안에 세 라운드** 재발했다 — ①카디르 QA 8파일 ②디디 grep 스윕 +4(HTTP/override 간접 경로) ③CI 재실패 +9(`workflow_line_config`·`workflow_sla_processor`·`workflow_parallel_approval` 경유 — grep이 간접 호출을 구조적으로 못 봄) = 총 21파일 수기 임포트(#2201 후속 미등재 모듈의 파생). 실패 메시지(`relation "X" does not exist`)가 원인(모델 미등재)을 안 가리켜 매번 사람이 grep으로 직접 추적해야 했다.

## 처방 판별(AC3)
**⛔ⓐ(conftest가 `app.models` 전체 벌크 임포트) 기각** — story #2201(2026-07-28) 실측 인용: 그 시도가 기준선 16~17분짜리 job을 **25분 타임아웃(25m15s CANCELLED)**으로 밀어냈다(당시 101개 destructive_schema 파일 × 파일당 create_all/drop_all 오버헤드가 모델 1개 추가당 누적). 지금은 그 파일 수가 128개로 늘었다 — 같은 시도를 재측정 없이도, 그 비용이 줄었을 이유는 없다(오히려 더 클 것).

**ⓑ(채택) 실행 시점 진단 가드** — `tests/conftest.py`에 `pytest_runtest_makereport` 훅워퍼 추가: `destructive_schema` 마커 테스트가 `"relation X does not exist"`로 실패하면, `app/models/*.py` 정적 스캔(AST, **import 없음**)으로 만든 테이블명→모듈 경로 레지스트리에서 X를 찾아 `report.sections`에 `"app.models.Y 임포트 누락"`으로 진단을 붙인다. 정상 경로(테스트 통과)엔 오버헤드 0 — 진단 함수 자체가 `report.failed`일 때만 호출되므로, ⓐ가 겪은 CI-예산 트레이드오프를 구조적으로 피한다.

## 테스트(AC1/AC2)
`test_2662_missing_model_import_guard.py`:
- 단위 6건 — 레지스트리가 이 스토리의 실 사례(`activity_logs`→`app.models.activity_log`)를 정확히 매핑·스캔이 side-effect-free(import 0건)·진단 함수의 매치/예외체인 탐색/음성대조 2종(무관 실패·미등록 테이블명).
- **⭐AC2 핵심 — pytester 서브프로세스 양성대조 1건**: PR #3067 21파일 사례를 실제로 최소 재현 — `app.models.activity_log` 임포트가 빠진 `create_all` 테스트를 실 pytest 서브프로세스로 돌려 (1) 여전히 RED고(가드가 실패 자체를 숨기지 않음) (2) 그 실패 리포트에 진단이 실제로 붙는지 둘 다 확인.

**뮤테이션 확인**: 진단 부착 라인을 no-op으로 바꿔 재실행 → AC2 positive control이 정확히 RED. 원복 후 재확인 GREEN, `git diff` 클린.

## 회귀
로컬 disposable postgres@16 + alembic head(0251)로 전체 collection(7169건, import 에러 0) + `destructive_schema` 전수 스윕(828 passed, 13 failed — 전부 이 세션 반복 확인된 pg_pubsub 포트 54322 미기동 클래스, 이 가드와 무관, 새 실패 0건).

## AC
1. ✅ 새 모델이 서비스 경로에 추가돼 create_all 테스트가 깨지면 「명확한 원인 메시지」(임포트 누락 지목)로 반응
2. ✅ 21파일 사례를 pytester로 양성대조 재현(가드 적용 前=원인불명·가드 적용 後=진단 부착 확認)
3. ✅ CI 시간 예산 영향 실측 명시(#2201 재인용+현재 파일수 대조+정상경로 오버헤드 0의 구조적 근거)