### PR TITLE
[SID:2675] publish_registry_event 500→400: malformed UUID payload 명시 거부

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -877,17 +877,21 @@ async def _resolve_event_project_id(
     """이벤트가 속할 project_id — work_item_type/id가 있으면 그 작업의 project(gate_service.
     resolve_work_item_project_id 재사용, 신규 쿼리 만들지 않음), goal_id만 있으면(preset.
     goal.measured) Goal.project_id 직접. 둘 다 없으면 None(호출부가 400으로 거부)."""
+    from app.services.event_routing_resolver import _parse_uuid
+
     if payload.get("work_item_type") and payload.get("work_item_id"):
         from app.services.gate_service import resolve_work_item_project_id
 
         return await resolve_work_item_project_id(
-            db, org_id, payload["work_item_type"], uuid.UUID(payload["work_item_id"]),
+            db, org_id, payload["work_item_type"],
+            _parse_uuid(payload["work_item_id"], field_name="work_item_id"),
         )
     if payload.get("goal_id"):
         from app.models.pm import Goal
 
+        goal_id = _parse_uuid(payload["goal_id"], field_name="goal_id")
         return (await db.execute(
-            select(Goal.project_id).where(Goal.id == uuid.UUID(payload["goal_id"]), Goal.org_id == org_id)
+            select(Goal.project_id).where(Goal.id == goal_id, Goal.org_id == org_id)
         )).scalar_one_or_none()
     return None
 
@@ -1027,7 +1031,11 @@ async def publish_registry_event(
             detail={"code": "invalid_payload", "message": str(e), "errors": e.errors},
         ) from e
 
-    from app.services.event_routing_resolver import MissingRoutingPayloadFieldError, resolve_routing_leg
+    from app.services.event_routing_resolver import (
+        InvalidWorkItemReferenceError,
+        MissingRoutingPayloadFieldError,
+        resolve_routing_leg,
+    )
 
     try:
         escalation_ids = await resolve_routing_leg(
@@ -1036,7 +1044,7 @@ async def publish_registry_event(
         broadcast_ids = await resolve_routing_leg(
             definition.routing["broadcast"], payload=body.payload, org_id=org_id, db=db,
         )
-    except MissingRoutingPayloadFieldError as e:
+    except (MissingRoutingPayloadFieldError, InvalidWorkItemReferenceError) as e:
         raise HTTPException(
             status_code=400,
             detail={"code": "invalid_payload", "message": str(e), "errors": [str(e)]},
@@ -1047,7 +1055,13 @@ async def publish_registry_event(
 
         broadcast_ids |= await filter_org_member_ids(set(body.extra_broadcast_member_ids), org_id, db)
 
-    project_id = await _resolve_event_project_id(db, org_id=org_id, payload=body.payload)
+    try:
+        project_id = await _resolve_event_project_id(db, org_id=org_id, payload=body.payload)
+    except InvalidWorkItemReferenceError as e:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "invalid_payload", "message": str(e), "errors": [str(e)]},
+        ) from e
     if project_id is None:
         # story #2674 — «참조 필드 자체가 없음»과 «참조는 있는데 못 풂(dangling)»은 다른
         # 사건이다. 정의기(#2670)가 만드는 임의 payload 커스텀 이벤트(신호형·측정형류)는

--- a/backend/app/services/event_definition_registry.py
+++ b/backend/app/services/event_definition_registry.py
@@ -244,10 +244,19 @@ def validate_event_payload_schema_shape(payload_schema: dict) -> None:
 def validate_event_payload(payload_schema: dict, payload: dict) -> None:
     """AC3: payload_schema(JSON Schema) 대조 검증 — 스키마가 additionalProperties: false를
     선언한 한도 내에서 모르는 필드도 거부된다(선언 안 한 스키마는 이 함수가 대신 강제하지
-    않는다 — 스키마 저작 시점의 책임, 시드 4종은 전부 선언함)."""
+    않는다 — 스키마 저작 시점의 책임, 시드 4종은 전부 선언함).
+
+    story #2675: format_checker 없이 jsonschema Validator를 만들면 `"format": "uuid"` 선언이
+    있어도 «검증되지 않고 조용히 통과»한다(jsonschema의 기본 동작 — format은 검증기를 명시로
+    줘야 집행된다, 실측 확認). 이 코드베이스 event_definitions는 work_item_id/goal_id/
+    notify_member_id 등 거의 모든 payload UUID 필드에 format:uuid를 선언하는데, 그게 안 먹혀서
+    "pr-3084" 같은 비-UUID 문자열이 여기를 무사통과해 다운스트림 uuid.UUID() 파싱에서 처리
+    안 된 ValueError로 500을 냈다(카디르 2026-08-15 실측, 승격 PR류 gate_cycle 발행). FormatChecker()를
+    명시로 넘겨 이 스키마가 이미 선언한 계약을 실제로 집행 — 새 검증을 발명하는 게 아니라
+    기존 선언을 마침내 작동시키는 것."""
     validator_cls = jsonschema.validators.validator_for(payload_schema)
     validator_cls.check_schema(payload_schema)
-    validator = validator_cls(payload_schema)
+    validator = validator_cls(payload_schema, format_checker=jsonschema.FormatChecker())
     errors = [e.message for e in validator.iter_errors(payload)]
     if errors:
         raise InvalidEventPayloadError(

--- a/backend/app/services/event_routing_resolver.py
+++ b/backend/app/services/event_routing_resolver.py
@@ -24,6 +24,23 @@ class MissingRoutingPayloadFieldError(ValueError):
     빈 집합으로 넘기지 않고 발행 시점에 명시 오류(story #2633 AC4 "조용한 유실 금지")."""
 
 
+class InvalidWorkItemReferenceError(ValueError):
+    """work_item_id/goal_id/payload_field UUID 값이 문법적으로 유효한 UUID가 아님 — story
+    #2675: event_definition_registry.validate_event_payload가 format:uuid를 이제 집행하지만,
+    이 함수는 org 커스텀 정의(#2636)가 그 필드에 format:uuid 선언을 빠뜨린 경우까지 대비한
+    2차 방어선이다. uuid.UUID() 파싱 실패를 처리 안 된 ValueError로 흘려 500을 내지 않고
+    발행 시점에 명시 거부한다."""
+
+
+def _parse_uuid(value: str, *, field_name: str) -> uuid.UUID:
+    try:
+        return uuid.UUID(value)
+    except (ValueError, AttributeError, TypeError) as e:
+        raise InvalidWorkItemReferenceError(
+            f"payload.{field_name}이 올바른 UUID 형식이 아닙니다: {value!r}"
+        ) from e
+
+
 async def _resolve_work_item_stakeholders(
     db: AsyncSession, *, org_id: uuid.UUID, payload: dict,
 ) -> set[uuid.UUID]:
@@ -34,7 +51,7 @@ async def _resolve_work_item_stakeholders(
     work_item_id_raw = payload.get("work_item_id")
     if not work_item_type or not work_item_id_raw:
         return set()
-    work_item_id = uuid.UUID(work_item_id_raw)
+    work_item_id = _parse_uuid(work_item_id_raw, field_name="work_item_id")
 
     if work_item_type == "story":
         from app.models.pm import Story
@@ -85,8 +102,9 @@ async def _resolve_goal_owner(db: AsyncSession, *, org_id: uuid.UUID, payload: d
     goal_id_raw = payload.get("goal_id")
     if not goal_id_raw:
         return set()
+    goal_id = _parse_uuid(goal_id_raw, field_name="goal_id")
     assignee = (await db.execute(
-        select(Goal.assignee_id).where(Goal.id == uuid.UUID(goal_id_raw), Goal.org_id == org_id)
+        select(Goal.assignee_id).where(Goal.id == goal_id, Goal.org_id == org_id)
     )).scalar_one_or_none()
     return {assignee} if assignee else set()
 
@@ -121,7 +139,7 @@ async def resolve_routing_leg(
             raise MissingRoutingPayloadFieldError(
                 f"routing이 요구하는 payload.{field}가 없거나 비었습니다."
             )
-        return {uuid.UUID(value)}
+        return {_parse_uuid(value, field_name=field)}
 
     resolver = _SERVER_DERIVED_RESOLVERS[leg["target"]]
     return await resolver(db, org_id=org_id, payload=payload)

--- a/backend/tests/test_2675_publish_event_malformed_uuid_400.py
+++ b/backend/tests/test_2675_publish_event_malformed_uuid_400.py
@@ -1,0 +1,312 @@
+"""story #2675 — publish_registry_event가 payload의 malformed UUID 문자열(예: work_item_id=
+"pr-3084")을 400이 아니라 처리 안 된 500으로 뱉던 결함.
+
+카디르 실측(2026-08-15, 승격 PR #3084 QA 중): org.moonklabs.work.gate_cycle을 스토리 없는
+승격 PR에 발행하려니 매핑할 스토리 UUID가 없어 그 자리에 비-UUID 문자열을 넣었더니
+INTERNAL_ERROR(5xx)로 죽었다. 근본원인 그라운딩(디디, 2026-08-16 실 dev 왕복으로 재현):
+event_definition_registry.validate_event_payload가 jsonschema Validator를 FormatChecker
+없이 만들어서, payload_schema가 "format": "uuid"를 선언해도 실제로는 집행되지 않았다 —
+비-UUID 문자열이 스키마 검증을 무사통과해 다운스트림 uuid.UUID() 파싱에서 처리 안 된
+ValueError로 죽었다.
+
+처방 2단(벨트+서스펜더):
+①event_definition_registry.validate_event_payload — FormatChecker() 명시로 켜서 스키마가
+  이미 선언한 format:uuid 계약을 실제로 집행(선호 경로 — 구조화된 {code,message,errors}로
+  일찍 잡힘).
+②event_routing_resolver._parse_uuid — org 커스텀 정의(#2636)가 format:uuid 선언을 빠뜨린
+  경우까지 대비한 2차 방어선(uuid.UUID() 파싱 실패를 InvalidWorkItemReferenceError로 승격,
+  라우터가 400으로 매핑).
+
+AC 검증 축:
+- AC1: work_item_id·goal_id·payload_field(notify_member_id 등) 어느 경로든 malformed UUID가
+  400+명시 문구로 거부됨(5xx 아님).
+- AC2 무회귀: 정상 UUID 발행은 그대로 성공(기존 test_2633_event_publish.py가 이미 고정).
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _load_seed_definitions():
+    import importlib.util
+    import os
+
+    spec = importlib.util.spec_from_file_location(
+        "_m0245c", os.path.join(os.path.dirname(__file__), "..", "alembic", "versions", "0245_event_definitions.py"),
+    )
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return {key: (payload_schema, routing) for key, payload_schema, routing in m._SEED}
+
+
+async def _seed_preset_definitions(session):
+    from app.models.event_definition import EventDefinition
+
+    for key, (payload_schema, routing) in _load_seed_definitions().items():
+        session.add(EventDefinition(
+            id=uuid.uuid4(), key=key, org_id=None, payload_schema=payload_schema, routing=routing,
+        ))
+    await session.commit()
+
+
+async def _seed_gate_cycle_definition(session, org_id):
+    """org.moonklabs.work.gate_cycle 실물 스키마를 그대로 재현(카디르가 실제로 부딪힌 그
+    정의) — list_event_definitions 실측 그대로, 손으로 축약하지 않는다."""
+    from app.models.event_definition import EventDefinition
+
+    payload_schema = {
+        "type": "object",
+        "required": ["stage", "work_item_type", "work_item_id", "notify_member_id"],
+        "properties": {
+            "note": {"type": ["string", "null"]},
+            "stage": {"enum": [
+                "pushed", "pr_opened", "ci_green", "ci_red", "qa_requested", "merged",
+                "review_changes", "review_passed", "deployed",
+            ], "type": "string"},
+            "head_sha": {"type": ["string", "null"]},
+            "pr_number": {"type": ["integer", "null"]},
+            "work_item_id": {"type": "string", "format": "uuid"},
+            "work_item_type": {"type": "string"},
+            "notify_member_id": {"type": "string", "format": "uuid"},
+        },
+        "additionalProperties": False,
+    }
+    routing = {
+        "broadcast": {"kind": "payload_field", "target": "member", "member_id_field": "notify_member_id"},
+        "escalation": {"kind": "server_derived", "target": "none"},
+    }
+    d = EventDefinition(
+        id=uuid.uuid4(), key="org.moonklabs.work.gate_cycle", org_id=org_id,
+        payload_schema=payload_schema, routing=routing,
+    )
+    session.add(d)
+    await session.commit()
+    return d
+
+
+async def _seed_org_project(session, *, slug="acme2675"):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2675", slug=slug)
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="agent"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True,
+    )
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+def _auth(agent_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(org_id),
+    )
+
+
+def _fake_request() -> "StarletteRequest":
+    from starlette.requests import Request as StarletteRequest
+    return StarletteRequest(scope={"type": "http", "headers": []})
+
+
+# ─── AC1 핵심 — 카디르 실사고의 정확한 재현(org.moonklabs.work.gate_cycle, 승격 PR류에
+#     work_item_id로 비-UUID 문자열을 넣은 경우) ────────────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_publish_gate_cycle_malformed_work_item_id_400_not_500():
+    """⭐AC1 핵심 — 이 테스트가 처방 전이면 HTTPException이 아니라 처리 안 된 ValueError가
+    그대로 터져나온다(수정 전 상태에서 직접 확인함, #2675 grounding). 처방 후엔 400으로
+    명시 거부되고, detail에 malformed 값 자체(pr-3084)가 원인 문구로 실려야 한다."""
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_gate_cycle_definition(s, org_id)
+            publisher_id = await _seed_agent(s, org_id, project_id)
+
+            body = EventPublishRequest(
+                definition_key="org.moonklabs.work.gate_cycle",
+                payload={
+                    "stage": "pr_opened",
+                    "work_item_type": "story",
+                    "work_item_id": "pr-3084",  # 승격 PR — 매핑할 스토리 UUID가 없어 이렇게 넣음
+                    "notify_member_id": str(uuid.uuid4()),
+                    "pr_number": 3084,
+                },
+            )
+            with pytest.raises(HTTPException) as ei:
+                await publish_registry_event(
+                    body, BackgroundTasks(), _fake_request(),
+                    db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 400
+            assert ei.value.status_code != 500
+            detail = ei.value.detail
+            detail_text = detail if isinstance(detail, str) else str(detail)
+            assert "pr-3084" in detail_text or "uuid" in detail_text.lower()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_publish_malformed_goal_id_400_not_500():
+    """work_item_id와 별개 경로(goal_id)도 같은 결함 클래스였다 — _resolve_event_project_id의
+    두 번째 uuid.UUID() 호출부. 같은 처방(FormatChecker + _parse_uuid)이 이 축도 덮는지."""
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_preset_definitions(s)
+            publisher_id = await _seed_agent(s, org_id, project_id)
+
+            body = EventPublishRequest(
+                definition_key="preset.goal.measured",
+                payload={"goal_id": "not-a-uuid", "metric_value": 1},
+            )
+            with pytest.raises(HTTPException) as ei:
+                await publish_registry_event(
+                    body, BackgroundTasks(), _fake_request(),
+                    db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 400
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_publish_malformed_payload_field_member_id_400_not_500():
+    """payload_field routing(notify_member_id 등)의 malformed 값도 같은 클래스 — resolve_routing_leg
+    안의 uuid.UUID() 호출부."""
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_gate_cycle_definition(s, org_id)
+            publisher_id = await _seed_agent(s, org_id, project_id)
+
+            body = EventPublishRequest(
+                definition_key="org.moonklabs.work.gate_cycle",
+                payload={
+                    "stage": "pr_opened",
+                    "work_item_type": "story",
+                    "work_item_id": str(uuid.uuid4()),
+                    "notify_member_id": "not-a-uuid-either",
+                },
+            )
+            with pytest.raises(HTTPException) as ei:
+                await publish_registry_event(
+                    body, BackgroundTasks(), _fake_request(),
+                    db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 400
+    finally:
+        await engine.dispose()
+
+
+# ─── 단위 축 — 순수 함수, DB 불요 ────────────────────────────────────────────────
+
+def test_validate_event_payload_rejects_malformed_uuid_via_format_checker():
+    """FormatChecker() 없이 만들면 이 테스트가 RED다(수정 전 상태로 직접 확인) — format:uuid가
+    실제로 집행되는지 이 함수 하나로 고정."""
+    from app.services.event_definition_registry import InvalidEventPayloadError, validate_event_payload
+
+    schema = {
+        "type": "object",
+        "required": ["work_item_id"],
+        "properties": {"work_item_id": {"type": "string", "format": "uuid"}},
+        "additionalProperties": False,
+    }
+    with pytest.raises(InvalidEventPayloadError) as ei:
+        validate_event_payload(schema, {"work_item_id": "pr-3084"})
+    assert any("uuid" in e.lower() for e in ei.value.errors)
+
+
+def test_validate_event_payload_accepts_valid_uuid_no_regression():
+    from app.services.event_definition_registry import validate_event_payload
+
+    schema = {
+        "type": "object",
+        "required": ["work_item_id"],
+        "properties": {"work_item_id": {"type": "string", "format": "uuid"}},
+        "additionalProperties": False,
+    }
+    validate_event_payload(schema, {"work_item_id": str(uuid.uuid4())})  # raise 없으면 통과
+
+
+def test_parse_uuid_raises_domain_error_for_malformed_value():
+    from app.services.event_routing_resolver import InvalidWorkItemReferenceError, _parse_uuid
+
+    with pytest.raises(InvalidWorkItemReferenceError):
+        _parse_uuid("pr-3084", field_name="work_item_id")
+
+
+def test_parse_uuid_passthrough_for_valid_value():
+    from app.services.event_routing_resolver import _parse_uuid
+
+    val = str(uuid.uuid4())
+    assert str(_parse_uuid(val, field_name="work_item_id")) == val
+
+
+@pytest.mark.anyio
+async def test_resolve_routing_leg_payload_field_malformed_uuid_raises_domain_error():
+    """resolve_routing_leg 자체를 직접 호출(엔드포인트 레벨에선 대개 스키마 검증에 먼저
+    걸리므로) — 해석기 함수 단독 계약을 독립 검증."""
+    from unittest.mock import AsyncMock
+
+    from app.services.event_routing_resolver import InvalidWorkItemReferenceError, resolve_routing_leg
+
+    with pytest.raises(InvalidWorkItemReferenceError):
+        await resolve_routing_leg(
+            {"kind": "payload_field", "target": "member", "member_id_field": "notify_member_id"},
+            payload={"notify_member_id": "pr-3084"},
+            org_id=uuid.uuid4(), db=AsyncMock(),
+        )


### PR DESCRIPTION
## Summary
- 카디르 실측(2026-08-15, 승격 PR #3084 QA 중): 스토리 없는 승격 PR류에 `org.moonklabs.work.gate_cycle`을 발행하려니 매핑할 스토리 UUID가 없어 자리표시 문자열(`"pr-3084"`)을 `work_item_id`에 넣었더니 `INTERNAL_ERROR`(5xx)로 죽음 — 실 dev 왕복으로 그라운딩해 근본원인 특定.
- 근본원인: `validate_event_payload`가 `jsonschema` Validator를 `FormatChecker` 없이 생성 — 스키마가 이미 선언한 `"format": "uuid"`가 실제로는 집행되지 않아 비-UUID 문자열이 무사통과, 다운스트림 `uuid.UUID()` 파싱에서 처리 안 된 `ValueError`로 500.
- 처방 2단(벨트+서스펜더):
  1. `event_definition_registry.validate_event_payload` — `FormatChecker()` 명시로 켜서 기존 선언을 실제 집행(구조화된 `{code,message,errors}`로 조기 포착, 선호 경로).
  2. `event_routing_resolver._parse_uuid` — org 커스텀 정의(#2636)가 `format:uuid` 선언을 빠뜨릴 경우까지 대비한 2차 방어선. `_resolve_event_project_id`의 `work_item_id`/`goal_id` 두 경로, `resolve_routing_leg`의 `payload_field` 경로 전부 적용.
- AC2(승격 PR류 표기 규격)는 팀 프로토콜 결정 사항이라 별도로 페드루군에게 제안·논의 중.

## Test plan
- [x] 신규 테스트 8건(카디르 실사고의 실물 `gate_cycle` 스키마 그대로 재현 포함) — 로컬 실PG green
- [x] 기존 publish 관련 테스트 55건(test_2632/2633/2636/2637류) 전부 green — 무회귀
- [x] test_2665(publish-history) 6건도 green
- [x] 처방 2단 각각 독립 mutation-kill 확인(FormatChecker 제거 시 unit 1건 RED / `_parse_uuid` 방어 제거 시 unit 2건 RED — end-to-end 3건은 어느 한쪽만 있어도 잡혀 벨트+서스펜더가 실제 이중방어임을 증명)
- [x] CI 대기

🤖 Generated with [Claude Code](https://claude.com/claude-code)