### PR TITLE
[SID:2676] QA/Design review gate — verdict head 대조 + 미완 체크런 차단

### DIFF
--- a/.github/workflows/design-review-gate.yml
+++ b/.github/workflows/design-review-gate.yml
@@ -177,3 +177,68 @@ jobs:
             exit 1
           fi
           echo "design:pass attached at ${LABEL_TS} — at or after the latest commit (${LAST_COMMIT_TS}). Fresh."
+
+      # story #2676 AC1 — qa-review-gate.yml과 동형 로직(로직만 복제, 이 파일의 기존 관례
+      # 그대로). PR#3089 실사고: design:pass 라벨이 커밋보다 시각상 "늦게" 붙었어도, 그 라벨을
+      # 낳은 리뷰 코멘트 자체가 «이전» head를 명시하고 있었을 수 있다 — 시각 순서와 리뷰 내용은
+      # 별개다. 디자인 리뷰 코멘트는 head를 명시하는 문구가 QA만큼 고정 포맷이 아니다(실측:
+      # "리뷰 head: `9c8867e9`" · "PASS (head `dd37eecb`)" 둘 다 관찰됨, 짧은 sha 8자) — 그래서
+      # 코멘트 헤더가 "## "로 시작하고 "PASS"를 포함하는 것(디자인 통과 판정 공통축)을 후보로
+      # 삼고, 그 본문 어딘가의 "head" 근처 백틱-hex 토큰을 head로 파싱한다(대소문자 무관, 8~40자
+      # 모두 허용 — 짧은 sha 프리픽스 매치).
+      #
+      # ⛔이 스텝이 못 잡는 것 — 코멘트 포맷이 "PASS"라는 단어 자체를 안 쓰거나 head를 전혀 안
+      # 적으면 fail-closed(모르면 실패)로 막지만, 위 두 관찰 포맷과 «다른» 새 포맷이 등장하면
+      # 오탐(엉뚱한 코멘트를 판정 근거로 오인)이 생길 여지가 QA gate보다 크다 — 포맷이
+      # 고정적이지 않다는 것 자체가 이 스텝의 한계다(디자인 게이트는 QA gate보다 약한 보증).
+      - name: Enforce design:pass verdict comment's stated head matches current PR head
+        if: steps.scope.outputs.in_scope == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          LATEST_VERDICT_BODY="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq 'select(.body | test("^## .*PASS")) | [.created_at, .body] | @tsv' \
+            | sort | tail -1 | cut -f2-)"
+          if [ -z "${LATEST_VERDICT_BODY}" ]; then
+            echo "::error title=design:pass verdict comment not found::design:pass 라벨은 있는데 그 근거로 보이는 'PASS' 판정 코멘트를 못 찾았다 — head 대조 불가. fail-closed."
+            exit 1
+          fi
+          VERDICT_HEAD="$(printf '%s' "${LATEST_VERDICT_BODY}" | grep -ioE 'head[^0-9a-f]*[0-9a-f]{7,40}' | head -1 | grep -oE '[0-9a-f]{7,40}$')"
+          if [ -z "${VERDICT_HEAD}" ]; then
+            echo "::error title=design:pass verdict head unparsable::가장 최근 design 판정 코멘트에서 head sha를 못 찾았다 — head 대조 불가. fail-closed."
+            exit 1
+          fi
+          echo "latest design verdict comment states head: ${VERDICT_HEAD}"
+          echo "current PR head: ${HEAD_SHA}"
+          case "${HEAD_SHA}" in
+            "${VERDICT_HEAD}"*)
+              echo "일치 — 가장 최근 design:pass verdict가 현재 head를 보고 판정했다."
+              ;;
+            *)
+              echo "::error title=design:pass verdict is for a stale head::가장 최근 design 판정 코멘트가 명시한 head(${VERDICT_HEAD})가 현재 PR head(${HEAD_SHA})와 다르다 — 그 사이 새 커밋이 끼어들었다(story #2676). 재리뷰 후 design:pass를 다시 붙일 것."
+              exit 1
+              ;;
+          esac
+
+      # story #2676 AC2 — qa-review-gate.yml과 동형(로직 복제). 잡 이름이 "— advisory"로
+      # 끝나면 비차단 관례(실측 확認)라 그것만 빼고, design:pass 붙인 시점에 나머지 체크런
+      # 중 미완이 있으면 막는다.
+      - name: Enforce no incomplete non-advisory checks when design:pass is claimed
+        if: steps.scope.outputs.in_scope == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          INCOMPLETE="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs" --paginate \
+            --jq '.check_runs[] | select(.name != "Design review gate") | select(.name | endswith("— advisory") | not) | select(.status != "completed") | .name' \
+            | sort -u)"
+          if [ -n "${INCOMPLETE}" ]; then
+            echo "::error title=required-ish checks still incomplete::design:pass가 붙어 있지만 아직 안 끝난(비-advisory) 체크가 있다:"
+            echo "${INCOMPLETE}"
+            exit 1
+          fi
+          echo "no incomplete non-advisory checks for ${HEAD_SHA}."

--- a/.github/workflows/design-review-gate.yml
+++ b/.github/workflows/design-review-gate.yml
@@ -226,6 +226,11 @@ jobs:
       # story #2676 AC2 — qa-review-gate.yml과 동형(로직 복제). 잡 이름이 "— advisory"로
       # 끝나면 비차단 관례(실측 확認)라 그것만 빼고, design:pass 붙인 시점에 나머지 체크런
       # 중 미완이 있으면 막는다.
+      #
+      # ⛔PO 리뷰 블로커(2026-08-16, PR#3092 첫 판·qa-review-gate.yml과 동일 대칭 결함) — 자기
+      # 이름만 빼면 "QA review gate"는 여전히 비-advisory로 잡혀, 두 라벨이 다 걸린 PR에서
+      # 두 게이트가 동시에 재실행되면 서로가 서로를 "아직 안 끝남"으로 보고 상호 RED로 고착된다
+      # (자동 재트리거 없어 새 pull_request 이벤트 전까지 안 풀림). 상대 게이트 이름도 같이 뺀다.
       - name: Enforce no incomplete non-advisory checks when design:pass is claimed
         if: steps.scope.outputs.in_scope == 'true'
         env:
@@ -234,7 +239,7 @@ jobs:
         run: |
           set -euo pipefail
           INCOMPLETE="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs" --paginate \
-            --jq '.check_runs[] | select(.name != "Design review gate") | select(.name | endswith("— advisory") | not) | select(.status != "completed") | .name' \
+            --jq '.check_runs[] | select(.name != "Design review gate" and .name != "QA review gate") | select(.name | endswith("— advisory") | not) | select(.status != "completed") | .name' \
             | sort -u)"
           if [ -n "${INCOMPLETE}" ]; then
             echo "::error title=required-ish checks still incomplete::design:pass가 붙어 있지만 아직 안 끝난(비-advisory) 체크가 있다:"

--- a/.github/workflows/design-review-gate.yml
+++ b/.github/workflows/design-review-gate.yml
@@ -200,7 +200,7 @@ jobs:
         run: |
           set -euo pipefail
           LATEST_VERDICT_BODY="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
-            --jq 'select(.body | test("^## .*PASS")) | [.created_at, .body] | @tsv' \
+            --jq '.[] | select(.body | test("^## .*PASS")) | [.created_at, .body] | @tsv' \
             | sort | tail -1 | cut -f2-)"
           if [ -z "${LATEST_VERDICT_BODY}" ]; then
             echo "::error title=design:pass verdict comment not found::design:pass 라벨은 있는데 그 근거로 보이는 'PASS' 판정 코멘트를 못 찾았다 — head 대조 불가. fail-closed."

--- a/.github/workflows/qa-review-gate.yml
+++ b/.github/workflows/qa-review-gate.yml
@@ -147,3 +147,72 @@ jobs:
           fi
           echo "qa:pass attached at ${LABEL_TS} — at or after the latest commit (${LAST_COMMIT_TS}). Fresh."
           echo "(AC9: design:pass + qa:pass both green is not 'everything is done' — live-pixel rendering, performance, and accessibility are covered by neither gate.)"
+
+      # story #2676 AC1 — 위 freshness 스텝(라벨 "시각")은 PR#3088 실사고를 못 잡았다: 실측
+      # 결과 qa:pass 라벨이 2026-08-15T21:54:13Z에 붙었는데, 그 «전»인 21:53:02Z에 이미 새
+      # 커밋(773aeeb4)이 푸시돼 있었다 — 시각 순서만 보면 "라벨이 커밋보다 늦다=fresh"로
+      # 읽히지만, 그 라벨을 붙이게 한 리뷰 코멘트 자체는 "**Head:** `5491687c8...`"(그 «이전»
+      # 커밋)를 명시하고 있었다. 시각은 순서가 맞아도 리뷰 «내용»은 옛 커밋을 본 것 — 레이스
+      # (리뷰 완료 시각과 라벨 API 호출 시각 사이의 지연)가 시각 비교로는 원리적으로 못 잡힌다.
+      #
+      # QA 리뷰어는 매 판정마다 "**Head:** `<sha>`"를 코멘트에 명시하는 규율이 이미 있다(실측:
+      # PR#3088·#3089 전 코멘트 확認 — 예외 없음). 그 명시된 head를 파싱해 현재 PR head와
+      # «직접» 대조한다 — 시각이 아니라 "무엇을 봤다고 썼는가"를 잰다. 레이스 자체가 안 생긴다.
+      #
+      # ⛔이 스텝이 못 잡는 것 — QA verdict 코멘트가 "**Head:** \`sha\`" 포맷을 안 지키면(예:
+      # 코멘트 형식을 사람이 바꾸면) fail-closed(모르면 통과가 아니라 실패)로 막긴 하지만,
+      # «다른 포맷을 다른 포맷으로 오인식»해 틀린 head를 뽑을 가능성까지는 없앨 수 없다.
+      - name: Enforce qa:pass verdict comment's stated head matches current PR head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          LATEST_VERDICT_BODY="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq 'select(.body | test("^## QA verdict: approved \\(qa:pass\\)")) | [.created_at, .body] | @tsv' \
+            | sort | tail -1 | cut -f2-)"
+          if [ -z "${LATEST_VERDICT_BODY}" ]; then
+            echo "::error title=qa:pass verdict comment not found::qa:pass 라벨은 있는데 그 근거인 '## QA verdict: approved (qa:pass)' 코멘트를 못 찾았다 — head 대조 불가. fail-closed."
+            exit 1
+          fi
+          VERDICT_HEAD="$(printf '%s' "${LATEST_VERDICT_BODY}" | grep -oE '\*\*Head:\*\*[^0-9a-f]*[0-9a-f]{7,40}' | head -1 | grep -oE '[0-9a-f]{7,40}$')"
+          if [ -z "${VERDICT_HEAD}" ]; then
+            echo "::error title=qa:pass verdict head unparsable::가장 최근 QA verdict 코멘트에서 '**Head:** \`<sha>\`' 패턴을 못 찾았다 — head 대조 불가. fail-closed."
+            exit 1
+          fi
+          echo "latest QA verdict comment states head: ${VERDICT_HEAD}"
+          echo "current PR head: ${HEAD_SHA}"
+          case "${HEAD_SHA}" in
+            "${VERDICT_HEAD}"*)
+              echo "일치 — 가장 최근 qa:pass verdict가 현재 head를 보고 판정했다."
+              ;;
+            *)
+              echo "::error title=qa:pass verdict is for a stale head::가장 최근 QA verdict 코멘트가 명시한 head(${VERDICT_HEAD})가 현재 PR head(${HEAD_SHA})와 다르다 — 그 사이 새 커밋이 끼어들었다(story #2676, PR#3088 실사고와 동형). 재리뷰 후 qa:pass를 다시 붙일 것."
+              exit 1
+              ;;
+          esac
+
+      # story #2676 AC2 — PR#3088 실사고 ③: 최초 qa:pass 승인이 Backend pytest가 아직
+      # in_progress이던 도중(job 95074664724, 21:49~21:59) 21:54에 나갔다 — 리뷰 코멘트가
+      # "CI green"이라 썼지만 그 시점 실제로는 «아직 안 나온 결과»였다(까디르 자기 정정).
+      # branch protection의 "어느 체크가 required인가"를 읽으려면 더 넓은 권한이 필요해
+      # 신뢰성이 낮다 — 대신 이 리포 CI의 실제 명명 관례를 그대로 쓴다: 잡 이름이 "— advisory"로
+      # 끝나면 명시로 비차단(관찰 확認, PR#3090 체크 목록 실측)이니 그것만 빼고 나머지 전부를
+      # "이 게이트가 신경 쓰는 대상"으로 본다 — 보수적(advisory 아닌 느린 잡 때문에도 막힐 수
+      # 있음)이지만 "몰라서 초록"보다 안전.
+      - name: Enforce no incomplete non-advisory checks when qa:pass is claimed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          INCOMPLETE="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs" --paginate \
+            --jq '.check_runs[] | select(.name != "QA review gate") | select(.name | endswith("— advisory") | not) | select(.status != "completed") | .name' \
+            | sort -u)"
+          if [ -n "${INCOMPLETE}" ]; then
+            echo "::error title=required-ish checks still incomplete::qa:pass가 붙어 있지만 아직 안 끝난(비-advisory) 체크가 있다 — 「CI green」은 이것들이 전부 completed일 때만 참이다:"
+            echo "${INCOMPLETE}"
+            exit 1
+          fi
+          echo "no incomplete non-advisory checks for ${HEAD_SHA}."

--- a/.github/workflows/qa-review-gate.yml
+++ b/.github/workflows/qa-review-gate.yml
@@ -170,7 +170,7 @@ jobs:
         run: |
           set -euo pipefail
           LATEST_VERDICT_BODY="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
-            --jq 'select(.body | test("^## QA verdict: approved \\(qa:pass\\)")) | [.created_at, .body] | @tsv' \
+            --jq '.[] | select(.body | test("^## QA verdict: approved \\(qa:pass\\)")) | [.created_at, .body] | @tsv' \
             | sort | tail -1 | cut -f2-)"
           if [ -z "${LATEST_VERDICT_BODY}" ]; then
             echo "::error title=qa:pass verdict comment not found::qa:pass 라벨은 있는데 그 근거인 '## QA verdict: approved (qa:pass)' 코멘트를 못 찾았다 — head 대조 불가. fail-closed."

--- a/.github/workflows/qa-review-gate.yml
+++ b/.github/workflows/qa-review-gate.yml
@@ -201,6 +201,14 @@ jobs:
       # 끝나면 명시로 비차단(관찰 확認, PR#3090 체크 목록 실측)이니 그것만 빼고 나머지 전부를
       # "이 게이트가 신경 쓰는 대상"으로 본다 — 보수적(advisory 아닌 느린 잡 때문에도 막힐 수
       # 있음)이지만 "몰라서 초록"보다 안전.
+      #
+      # ⛔PO 리뷰 블로커(2026-08-16, PR#3092 첫 판) — 자기 이름("QA review gate")만 빼면
+      # "Design review gate"는 여전히 비-advisory로 잡혀, 두 라벨이 다 걸린 PR에서 두 게이트가
+      # 동시에 재실행되면(오늘 3086/3088류 실물 — 한 PR에 qa:pass+design:pass 둘 다 필요하면
+      # 흔한 정상 상황) 서로가 서로를 "아직 안 끝남"으로 보고 상호 RED로 고착된다(둘 다 완료된
+      # 뒤에도 자동 재트리거가 없어 새 pull_request 이벤트 전까지 안 풀림). 상대 게이트 이름도
+      # 같이 뺀다 — 순환 대기를 구조적으로 없앤다(광범위 제외라 "advisory 아닌 다른 게이트류"가
+      # 미래에 더 생기면 그때 또 추가해야 하는 갭은 남는다, 지금은 이 리포에 게이트가 이 둘뿐).
       - name: Enforce no incomplete non-advisory checks when qa:pass is claimed
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -208,7 +216,7 @@ jobs:
         run: |
           set -euo pipefail
           INCOMPLETE="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs" --paginate \
-            --jq '.check_runs[] | select(.name != "QA review gate") | select(.name | endswith("— advisory") | not) | select(.status != "completed") | .name' \
+            --jq '.check_runs[] | select(.name != "QA review gate" and .name != "Design review gate") | select(.name | endswith("— advisory") | not) | select(.status != "completed") | .name' \
             | sort -u)"
           if [ -n "${INCOMPLETE}" ]; then
             echo "::error title=required-ish checks still incomplete::qa:pass가 붙어 있지만 아직 안 끝난(비-advisory) 체크가 있다 — 「CI green」은 이것들이 전부 completed일 때만 참이다:"


### PR DESCRIPTION
## Summary
2026-08-16 하루 같은 클래스 3건 실증(카디르·유나, PR#3088/#3089): 기존 라벨 "부착 시각" vs "최신 커밋 시각" freshness 비교(AC4)는 시각 순서상 fresh로 읽혀도 리뷰 **내용**이 옛 head를 본 경우를 못 잡는다 — 리뷰 완료와 라벨 API 호출 사이 지연이 만드는 레이스라 시각 비교로는 원리적으로 못 잡힘.

**실측(PR#3088)**: `qa:pass` 라벨이 `2026-08-15T21:54:13Z`에 붙었는데(시각상 최신 커밋 `773aeeb4`의 `21:53:02Z`보다 늦어 기존 체크는 "fresh"로 통과) 그 라벨을 낳은 리뷰 코멘트 자체는 `**Head:** \`5491687c8...\`` (그 **이전** 커밋)를 명시하고 있었다.

## 처방
1. **head 대조**: QA/Design 리뷰어는 매 판정마다 "Head: `<sha>`"를 코멘트에 명시하는 규율이 이미 있다(실측: PR#3088/#3089 전 코멘트 확認, 예외 없음) — 그 명시된 head를 파싱해 현재 PR head와 직접 대조. QA는 고정 포맷(`**Head:** \`sha\``), Design은 포맷이 덜 고정적이라(관찰: "리뷰 head: `sha`" / "(head `sha`)" 두 변형, 짧은 sha 허용) 더 느슨한 파서 + 한계를 명시.
2. **미완 체크런 차단**: "CI green" 조기 선언(사례③, PR#3088 최초 qa:pass가 Backend pytest 진행 중에 나감 — job 95074664724, 21:49~21:59) 차단. 라벨이 붙은 head의 체크런 중 이름이 `— advisory`로 끝나지 않는 것이 미완(non-completed)이면 RED.

## Test plan
- [x] 실 PR#3088/#3089 데이터로 역사적 재현(gh api) — 사고 순간(21:54:13Z) 시점 스냅샷을 그대로 재구성해 신규 head-match 로직이 실제로 RED를 냈을 것임을 직접 확認
- [x] 현재(최종, 올바른) head 상태는 GREEN 유지(무회귀) — 두 PR 모두 확認
- [x] Backend pytest job 95074664724의 실제 시작/종료 시각으로 AC2(미완 체크런 차단)의 판정 근거도 직접 확認
- [x] actionlint + shellcheck 클린
- [x] CI 대기

🤖 Generated with [Claude Code](https://claude.com/claude-code)