### PR TITLE
[SID:2666] 이벤트 정의 key 클라 선검증 — 고급 탭 문자셋 오진 방지

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -481,7 +481,7 @@
     "eventRoutingLabel": "routing",
     "eventBlockTemplateLabel": "block_template",
     "eventKeyLabel": "Key",
-    "eventKeyPrefixHint": "Custom definition keys must start with org.{org slug}.",
+    "eventKeyPrefixHint": "Custom definition keys must start with org.{slug}.",
     "eventActionAuthHumanOnlyLabel": "Human-only publish (human_only)",
     "eventActionAuthRolePlaceholder": "Roles allowed to publish (comma-separated, optional) — e.g. admin, owner",
     "eventCreateDialogTitle": "New event definition",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -481,7 +481,7 @@
     "eventRoutingLabel": "routing",
     "eventBlockTemplateLabel": "block_template",
     "eventKeyLabel": "키",
-    "eventKeyPrefixHint": "커스텀 정의 키는 org.{조직 slug}. 로 시작해야 합니다.",
+    "eventKeyPrefixHint": "커스텀 정의 키는 org.{slug}. 로 시작해야 합니다.",
     "eventActionAuthHumanOnlyLabel": "사람만 발행 가능(human_only)",
     "eventActionAuthRolePlaceholder": "발행 허용 역할(쉼표 구분, 선택) — 예: admin, owner",
     "eventCreateDialogTitle": "새 이벤트 정의",

--- a/apps/web/scripts/verify-no-i18n-phrase-collision.ts
+++ b/apps/web/scripts/verify-no-i18n-phrase-collision.ts
@@ -145,6 +145,10 @@ export function flattenMessages(obj: Record<string, unknown>, prefix = ''): Map<
 //   teamId     — Slack 워크스페이스 ID(문자열 식별자, 카운트 아님)
 //   dir        — 방향 기호(↑/↓), 수치 아님
 //   sources·excludes — 수집 범위를 나타내는 라벨 목록
+//   slug       — 조직 slug(예: "moonklabs" — teamId와 같은 축, 문자열 식별자·카운트 아님).
+//                story #2666 — eventKeyPrefixHint의 원래 값이 "org.{조직 slug}."처럼 ICU
+//                무효 자리표시자였던 걸 "org.{slug}."로 고치며 처음 이 가드에 노출됐다
+//                (전엔 파싱 실패로 스캔 자체가 이 문구를 못 봤다).
 // ⛔새 이름을 여기 더하기 前에(PO 지적, 2026-08-02): 그 이름이 실제로 채우는 ko.json 값을
 // 먼저 읽는다. 정말 이름·경로류(수가 아님)면 더한다. 그런데 만약 «숫자인» 값인데 여기 걸려
 // EXEMPT_PAIRS에 다시 나타난다면, 그건 denylist 후보가 아니라 «진짜 충돌»이다 — 그 경우
@@ -154,7 +158,7 @@ export function flattenMessages(obj: Record<string, unknown>, prefix = ''): Map<
 // 재는지 모르게 되는 것)이 재발한다.
 const NON_NUMBER_PLACEHOLDER_NAMES = new Set([
   'name', 'runtime', 'filename', 'promptFile', 'gate', 'role', 'project', 'teamId', 'dir',
-  'sources', 'excludes',
+  'sources', 'excludes', 'slug',
 ]);
 const PLACEHOLDER_NAME_RE = /\{([a-zA-Z_][a-zA-Z0-9_]*)\}/g;
 

--- a/apps/web/src/app/(authenticated)/organization/events/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/events/page.test.tsx
@@ -134,6 +134,14 @@ async function mount() {
   await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
 }
 
+// story #2670 — create는 「기본」(3서식 폼) 탭이 기본으로 열린다. 「고급」 탭 경로를 재는
+// 스위트들이 공유하는 헬퍼라 모듈 스코프로 둔다(describe 하나에 갇혀 있으면 다른
+// describe에서 못 쓴다 — story #2666 작업 중 실제로 겪은 스코프 버그).
+function switchToAdvancedTab() {
+  const tabBtn = [...document.body.querySelectorAll('[data-slot="dialog-content"] button')].find((b) => b.textContent?.startsWith(koMessages.organization.definerTabAdvanced)) as HTMLButtonElement;
+  tabBtn.click();
+}
+
 describe('OrganizationEventsPage', () => {
   it('프리셋·커스텀 그룹을 나눠 렌더하고 관리자에겐 새 정의 버튼이 뜬다', async () => {
     mockFetches([preset(), customWithId()]);
@@ -192,14 +200,6 @@ describe('OrganizationEventsPage', () => {
     await act(async () => { keyBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     expect(container.textContent).toContain('"work_item_stakeholders"');
   });
-
-  // story #2670 — create는 이제 「기본」(3서식 폼) 탭이 기본으로 열린다(AC1). 이 스위트의
-  // 기존 JSON-경로 테스트들은 「고급」 탭으로 명시 전환해야 그 시절 동작을 그대로 잰다 —
-  // 기본 탭 자체의 새 동작은 이 파일 하단 새 describe에서 별도로 잰다.
-  function switchToAdvancedTab() {
-    const tabBtn = [...document.body.querySelectorAll('[data-slot="dialog-content"] button')].find((b) => b.textContent?.startsWith(koMessages.organization.definerTabAdvanced)) as HTMLButtonElement;
-    tabBtn.click();
-  }
 
   it('생성 폼 제출 시 org.{slug}. 접두사가 자동으로 붙고 파싱된 JSON을 POST한다', async () => {
     const calls = mockFetches([]);
@@ -564,5 +564,74 @@ describe('OrganizationEventsPage — 발행 이력(story #2665)', () => {
     await act(async () => { keyBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
     expect(calls.some((c) => c.url.startsWith('/api/events/definitions/publish-history'))).toBe(false);
+  });
+});
+
+// story #2666 — 「고급」탭 key 입력이 「기본」탭과 같은 클라 선검증(validateKeySuffix)을
+// 받는다. 서버 메시지("...로 시작해야 합니다")가 문자셋 위반을 접두 문제로 오진시키던 것을
+// 클라에서 먼저 정확한 원인(문자셋)으로 막는다 — 서버 검증은 그대로 유지(우회 아님).
+describe('OrganizationEventsPage — 고급 탭 key 문자셋 클라 선검증(story #2666)', () => {
+  it('하이픈 포함 key는 정확한 문자셋 에러를 보이고 클라에서 막혀 서버 오진 메시지에 도달하지 않는다(AC1·AC2·AC3 양성대조)', async () => {
+    const calls = mockFetches([]);
+    await mount();
+    const createBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.organization.eventCreateCta)!;
+    await act(async () => { createBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { switchToAdvancedTab(); });
+
+    const keyInput = document.body.querySelector('#event-key') as HTMLInputElement;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+      // story #2666의 원 재현 — screen-check처럼 하이픈이 들어간 key.
+      setter.call(keyInput, 'screen-check');
+      keyInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    // 정확한 원인(문자셋)을 지목한다. 상단 정적 안내("org.{slug}. 로 시작해야 합니다")는
+    // 늘 떠 있는 별개 문구라 그 substring으로는 못 가른다 — 대신 실제로 서버까지 요청이
+    // 가서 서버의 오진 메시지("org 커스텀 정의의 key는...")를 받는 일 자체가 없는지
+    // (클라에서 막혀 POST가 0건인지)로 정확히 잰다.
+    expect(document.body.textContent).toContain(koMessages.organization.definerKeyErrorCharset);
+
+    const submitBtn = [...document.body.querySelectorAll('[data-slot="dialog-content"] button')].find((b) => b.textContent === koMessages.organization.eventCreateSubmit) as HTMLButtonElement;
+    expect(submitBtn.disabled).toBe(true);
+
+    // 클라에서 막혔으니 방어적으로 클릭해도(disabled 우회 시도) POST가 안 나간다.
+    await act(async () => { submitBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(calls.some((c) => c.method === 'POST' && c.url === '/api/events/definitions')).toBe(false);
+  });
+
+  it('유효한 key(스네이크)로 바꾸면 힌트 문구로 되돌아가고 저장이 다시 가능해진다', async () => {
+    mockFetches([]);
+    await mount();
+    const createBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.organization.eventCreateCta)!;
+    await act(async () => { createBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { switchToAdvancedTab(); });
+
+    const keyInput = document.body.querySelector('#event-key') as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(keyInput, 'bad-key');
+      keyInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(document.body.textContent).toContain(koMessages.organization.definerKeyErrorCharset);
+
+    await act(async () => {
+      setter.call(keyInput, 'good_key');
+      keyInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(document.body.textContent).not.toContain(koMessages.organization.definerKeyErrorCharset);
+    expect(document.body.textContent).toContain(koMessages.organization.definerKeyHint);
+    const submitBtn = [...document.body.querySelectorAll('[data-slot="dialog-content"] button')].find((b) => b.textContent === koMessages.organization.eventCreateSubmit) as HTMLButtonElement;
+    expect(submitBtn.disabled).toBe(false);
+  });
+
+  it('수정 모드(key 읽기전용)에서는 클라 선검증이 안 뜬다(회귀 0 — 기존 값은 항상 유효)', async () => {
+    mockFetches([customWithId({ id: 'def-9', key: 'org.moonklabs.existing-ish' })]);
+    await mount();
+    const editBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.organization.eventEditCta)!;
+    await act(async () => { editBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { switchToAdvancedTab(); });
+    expect(document.body.textContent).not.toContain(koMessages.organization.definerKeyErrorCharset);
+    expect(document.body.textContent).not.toContain(koMessages.organization.definerKeyHint);
   });
 });

--- a/apps/web/src/app/(authenticated)/organization/events/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/events/page.tsx
@@ -438,6 +438,11 @@ function EventFormDialog({
   }, [open, mode, target, orgSlug]);
 
   const definerKeyError = tab === 'basic' && mode === 'create' ? validateKeySuffix(definerState.keySuffix) : null;
+  // story #2666 — 「고급」탭도 「기본」탭과 같은 key 규격(_ORG_KEY_RE 접미 [a-z0-9_]+)이라
+  // 같은 클라 선검증을 재사용한다. 서버 메시지("...로 시작해야 합니다")가 문자셋 위반을
+  // 접두 문제로 오진시키던 것 — 클라에서 먼저 정확한 원인(문자셋)을 지목해 그 오진 문구에
+  // 도달할 일 자체를 줄인다(서버 검증은 그대로 유지 — 이건 안내일 뿐, 우회 아님).
+  const advancedKeyError = tab === 'advanced' && mode === 'create' ? validateKeySuffix(keySuffix) : null;
 
   const submit = async () => {
     setSaving(true);
@@ -455,6 +460,7 @@ function EventFormDialog({
         };
         if (mode === 'create') body.key = derived.key;
       } else {
+        if (advancedKeyError) throw new Error(advancedKeyError === 'empty' ? t('definerKeyErrorEmpty') : t('definerKeyErrorCharset'));
         const roles = rolesCsv.split(',').map((r) => r.trim()).filter(Boolean);
         const actionAuth = humanOnly || roles.length > 0 ? { human_only: humanOnly, role: roles } : null;
         body = {
@@ -563,7 +569,11 @@ function EventFormDialog({
               </button>
             </div>
           </div>
-          {tab === 'advanced' ? <DialogDescription>{t('eventKeyPrefixHint')}</DialogDescription> : null}
+          {/* story #2666(발견) — 원래 문구가 "org.{조직 slug}."처럼 한글 자리표시자를 ICU
+              변수 자리에 그대로 박아 놔 next-intl이 MALFORMED_ARGUMENT로 파싱 실패하던
+              것(콘솔 에러+깨진 렌더 — 이 다이얼로그를 열 때마다 항상 재현). ICU 유효 이름
+              (slug)으로 고치고 실제 org slug를 인자로 넘긴다. */}
+          {tab === 'advanced' ? <DialogDescription>{t('eventKeyPrefixHint', { slug: orgSlug || '{org}' })}</DialogDescription> : null}
         </DialogHeader>
         <div className="min-h-0 flex-1 overflow-y-auto px-1">
           {tab === 'basic' ? (
@@ -582,10 +592,19 @@ function EventFormDialog({
                   {t('eventKeyLabel')}
                 </label>
                 {mode === 'create' ? (
-                  <div className="flex items-center gap-1">
-                    <span className="shrink-0 font-mono text-xs text-muted-foreground">{prefix}</span>
-                    <Input id="event-key" value={keySuffix} onChange={(e) => setKeySuffix(e.target.value)} className="font-mono text-sm" />
-                  </div>
+                  <>
+                    <div className="flex items-center gap-1">
+                      <span className="shrink-0 font-mono text-xs text-muted-foreground">{prefix}</span>
+                      <Input id="event-key" value={keySuffix} onChange={(e) => setKeySuffix(e.target.value)} className="font-mono text-sm" />
+                    </div>
+                    {advancedKeyError ? (
+                      <p className="mt-1 text-[11px] text-destructive">
+                        {advancedKeyError === 'empty' ? t('definerKeyErrorEmpty') : t('definerKeyErrorCharset')}
+                      </p>
+                    ) : (
+                      <p className="mt-1 text-[11px] text-muted-foreground">{t('definerKeyHint')}</p>
+                    )}
+                  </>
                 ) : (
                   <Input id="event-key" value={target?.key ?? ''} readOnly disabled className="font-mono text-sm" />
                 )}
@@ -620,7 +639,7 @@ function EventFormDialog({
           {mode === 'create' && savedKey ? null : (
             <Button
               onClick={() => void submit()}
-              disabled={saving || (tab === 'advanced' ? mode === 'create' && !keySuffix.trim() : !!definerKeyError)}
+              disabled={saving || (tab === 'advanced' ? mode === 'create' && !!advancedKeyError : !!definerKeyError)}
             >
               {saving ? '...' : mode === 'create' ? t('eventCreateSubmit') : t('eventEditSubmit')}
             </Button>


### PR DESCRIPTION
## 요약
- FE 몫(AC2·AC3): 「고급(JSON)」탭 key 입력에 「기본」탭과 동일한 `validateKeySuffix` 클라 선검증을 적용. 하이픈 등 문자셋 위반을 제출 전에 정확히 지목(허용 문자셋 안내) — 서버의 "접두 불일치" 오진 메시지에 아예 도달하지 않게 막는다. 저장 버튼도 동일 조건으로 비활성.
- (작업 중 발견해 즉시 수정) `eventKeyPrefixHint` i18n 문구가 `"org.{조직 slug}."`처럼 ICU 무효 자리표시자를 쓰고 있어 고급 탭을 열 때마다 콘솔 `IntlError(MALFORMED_ARGUMENT)`가 나던 것 — `"org.{slug}."`로 고치고 실제 org slug를 인자로 넘기게 fix.
- 위 i18n fix로 해당 문구가 처음 문구충돌 가드(AC7, `verify-no-i18n-phrase-collision.ts`)에 파싱돼 노출돼(전엔 파싱 실패로 스캔이 아예 못 봄) 신규 2건이 걸림 — `slug`를 `NON_NUMBER_PLACEHOLDER_NAMES`에 추가해 해소(`teamId`와 같은 축: 문자열 식별자, 카운트 아님). EXEMPT_PAIRS가 아니라 이 목록에 넣은 이유는 파일 상단 주석에 근거 남김.

## 참고
- BE 몫(AC1 — `_ORG_KEY_RE` 불일치 분기에서 접두/문자셋 원인 분리)은 디디군 별도 PR.
- AC3(양성대조): `screen-check`(하이픈) 재현 케이스를 신규 테스트로 고정.

## 검증
- `pnpm exec tsc --noEmit` — 통과
- `pnpm exec eslint .` — 신규 파일 0 warning(기존 baseline 5건은 이 PR과 무관 — diff에 없음)
- `pnpm build` — 통과
- `pnpm exec vitest run` — 420 files / 3409 tests 전부 통과
- `verify-no-new-md-breakpoint.ts` / `verify-no-new-tint-color-text.ts` / `verify-no-i18n-phrase-collision.ts` — 신규 회귀 0건
- RED→GREEN: `git stash`로 fix 제거 후 신규 테스트 2건 RED 확인 → `stash pop`으로 GREEN 복귀 확인

## 스크린샷
UI 변경은 기존 입력 필드 아래 안내/에러 문구 추가뿐(레이아웃 변경 없음) — 라이브 확인은 dev 배포 후 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)