### PR TITLE
[SID:2680] 결재 상신 REST 폴백 동봉 — 구 세션도 재연결 없이 완주

### DIFF
--- a/backend/sprintable_mcp/tools/docs.py
+++ b/backend/sprintable_mcp/tools/docs.py
@@ -166,11 +166,34 @@ def _attach_submit_for_approval_next_action(doc: object) -> None:
     원인). draft 문서 응답에 `next_action`을 `{tool, args}` 실행 가능 명세로 동봉한다 —
     BE의 next_action_code SSOT(app.services.next_action, 다중 소비자·PO 판정 이력 다수)는
     건드리지 않는다(이 스토리 범위는 MCP 표면 하나). status가 draft가 아니면(이미 상신됐거나
-    다른 상태) 아무것도 안 붙인다 — 없는 행동을 지어내지 않는다."""
+    다른 상태) 아무것도 안 붙인다 — 없는 행동을 지어내지 않는다.
+
+    story #2680 — `tool` 필드만으론 이 광고가 무효할 수 있다: sprintable_submit_for_approval
+    자체가 이 문서를 만든 그 `create_doc`/`update_doc`보다 «나중에» 추가된 도구라(B3),
+    이 서버가 tools/list_changed를 못 보내는 구조(SprintableFastMCP는
+    stateless_http=True — mcp SDK streamable_http_manager가 stateless 모드에서 요청마다
+    완전히 새 transport를 만들고 세션 트래킹 자체를 안 한다, 실측 확認: 서버가 밀어줄
+    «연결된 세션» 개념이 원리적으로 없다) 오래 연결된 세션은 이 tool을 영원히 못 본다 —
+    광고는 보여도 이행이 막힌다. `fallback_rest`를 같이 동봉해, 그 도구가 없는 세션도
+    (curl/HTTP 실행 능력만 있으면) REST를 직접 쳐 완주할 수 있게 한다 — 이 필드는 신규
+    도구 등록에 의존하지 않는다(create_doc/update_doc 자체는 이미 모든 세션에 있는
+    기존 도구이므로 이 응답 보강은 세션 나이와 무관하게 항상 도달)."""
     if isinstance(doc, dict) and doc.get("status") == "draft" and doc.get("id"):
+        doc_id = doc["id"]
         doc["next_action"] = {
             "tool": "sprintable_submit_for_approval",
-            "args": {"doc_id": doc["id"]},
+            "args": {"doc_id": doc_id},
+            "fallback_rest": {
+                "method": "POST",
+                "url": f"{client._base_url}/api/v2/docs/{doc_id}/transition",
+                "headers": {"Authorization": "Bearer <YOUR_SPRINTABLE_API_KEY>"},
+                "body": {"status": "pending"},
+                "note": (
+                    "sprintable_submit_for_approval 도구가 이 세션에 안 보이면(구 세션 —"
+                    " 이 도구가 등록된 뒤 재연결 안 한 경우) 이 REST 호출을 직접 실행해도"
+                    " 동일하게 상신된다."
+                ),
+            },
         }
 
 

--- a/backend/tests/test_2668_mcp_submit_for_approval.py
+++ b/backend/tests/test_2668_mcp_submit_for_approval.py
@@ -20,14 +20,38 @@ def anyio_backend():
 
 
 def test_attach_next_action_for_draft_doc():
-    from sprintable_mcp.tools.docs import _attach_submit_for_approval_next_action
+    from sprintable_mcp.tools.docs import client, _attach_submit_for_approval_next_action
 
-    doc = {"id": "doc-1", "status": "draft", "title": "x"}
-    _attach_submit_for_approval_next_action(doc)
+    with patch.object(client, "_base_url", "https://backend.example"):
+        doc = {"id": "doc-1", "status": "draft", "title": "x"}
+        _attach_submit_for_approval_next_action(doc)
     assert doc["next_action"] == {
         "tool": "sprintable_submit_for_approval",
         "args": {"doc_id": "doc-1"},
+        "fallback_rest": {
+            "method": "POST",
+            "url": "https://backend.example/api/v2/docs/doc-1/transition",
+            "headers": {"Authorization": "Bearer <YOUR_SPRINTABLE_API_KEY>"},
+            "body": {"status": "pending"},
+            "note": (
+                "sprintable_submit_for_approval 도구가 이 세션에 안 보이면(구 세션 —"
+                " 이 도구가 등록된 뒤 재연결 안 한 경우) 이 REST 호출을 직접 실행해도"
+                " 동일하게 상신된다."
+            ),
+        },
     }
+
+
+def test_attach_next_action_fallback_rest_survives_missing_client_config():
+    """story #2680 — 구 세션 상황을 재현할 때 client._base_url이 미설정(빈 문자열)이어도
+    크래시하지 않는다(fail-safe, «어떤 URL이든» 붙여 정보를 준다 — 완전히 못 주는 것보다
+    상대경로라도 주는 쪽이 낫다는 판단, 실 운영에선 client가 항상 configure()된다)."""
+    from sprintable_mcp.tools.docs import client, _attach_submit_for_approval_next_action
+
+    with patch.object(client, "_base_url", ""):
+        doc = {"id": "doc-2", "status": "draft", "title": "y"}
+        _attach_submit_for_approval_next_action(doc)
+    assert doc["next_action"]["fallback_rest"]["url"] == "/api/v2/docs/doc-2/transition"
 
 
 def test_no_next_action_for_non_draft_doc():
@@ -55,14 +79,19 @@ async def test_create_doc_response_carries_submit_for_approval_next_action():
 
     with patch("sprintable_mcp.tools.docs.client") as mock_client:
         mock_client.require_project_id = lambda: "proj"
+        mock_client._base_url = "https://backend.example"
         mock_client.post = AsyncMock(return_value={"id": "doc-1", "status": "draft", "title": "x"})
         out = await create_doc(CreateDocInput(title="x", slug="x"))
 
     parsed = json.loads(out[0].text)
-    assert parsed["next_action"] == {
-        "tool": "sprintable_submit_for_approval",
-        "args": {"doc_id": "doc-1"},
-    }
+    assert parsed["next_action"]["tool"] == "sprintable_submit_for_approval"
+    assert parsed["next_action"]["args"] == {"doc_id": "doc-1"}
+    # story #2680 — 구 세션(도구 미가시)도 상신을 완주할 수 있게 하는 실행 가능 REST 폴백.
+    assert parsed["next_action"]["fallback_rest"]["method"] == "POST"
+    assert parsed["next_action"]["fallback_rest"]["url"] == (
+        "https://backend.example/api/v2/docs/doc-1/transition"
+    )
+    assert parsed["next_action"]["fallback_rest"]["body"] == {"status": "pending"}
 
 
 @pytest.mark.anyio
@@ -70,11 +99,46 @@ async def test_update_doc_response_carries_submit_for_approval_next_action_when_
     from sprintable_mcp.tools.docs import UpdateDocInput, update_doc
 
     with patch("sprintable_mcp.tools.docs.client") as mock_client:
+        mock_client._base_url = "https://backend.example"
         mock_client.patch = AsyncMock(return_value={"id": "doc-1", "status": "draft", "title": "x2"})
         out = await update_doc(UpdateDocInput(doc_id="doc-1", title="x2"))
 
     parsed = json.loads(out[0].text)
     assert parsed["next_action"]["tool"] == "sprintable_submit_for_approval"
+    assert parsed["next_action"]["fallback_rest"]["url"] == (
+        "https://backend.example/api/v2/docs/doc-1/transition"
+    )
+
+
+# ─── story #2680 — fallback_rest가 실제 submit_for_approval의 REST 경로와 어긋나지 않는지 핀 ──
+
+
+@pytest.mark.anyio
+async def test_fallback_rest_path_matches_submit_for_approval_actual_call():
+    """⭐AC1/AC2 핵심 — fallback_rest가 광고하는 경로가 submit_for_approval() 자신이 실제로
+    호출하는 경로와 «바이트 단위로» 같아야 한다. 둘이 각자 하드코딩돼 있으면(지금 구조)
+    한쪽만 바뀌어도 조용히 갈라진다 — 이 테스트가 그 드리프트를 막는다(오늘 유나 사례를
+    구 세션으로 재현하는 대신, 두 경로가 애초에 같은 값임을 고정해 같은 보증을 준다)."""
+    from sprintable_mcp.tools.docs import (
+        SubmitForApprovalInput, _attach_submit_for_approval_next_action, client, submit_for_approval,
+    )
+
+    doc_id = "doc-parity-1"
+    with patch.object(client, "_base_url", "https://backend.example"):
+        doc = {"id": doc_id, "status": "draft", "title": "x"}
+        _attach_submit_for_approval_next_action(doc)
+        advertised_url = doc["next_action"]["fallback_rest"]["url"]
+        advertised_body = doc["next_action"]["fallback_rest"]["body"]
+
+        with patch("sprintable_mcp.tools.docs.client") as mock_client:
+            mock_client.post = AsyncMock(return_value={"id": doc_id, "status": "pending"})
+            mock_client.get = AsyncMock(return_value=[])
+            await submit_for_approval(SubmitForApprovalInput(doc_id=doc_id))
+
+    actual_path, actual_kwargs = mock_client.post.call_args
+    actual_full_url = f"https://backend.example{actual_path[0]}"
+    assert advertised_url == actual_full_url
+    assert advertised_body == actual_kwargs["json"]
 
 
 # ─── submit_for_approval — REST 래핑 + 게이트 실물 동봉 ────────────────────────


### PR DESCRIPTION
## Summary
2026-08-16 04:04 선생님 진단·오늘 실증 3회(PO 2·유나 1) — `submit_for_approval`(B3/#2668)이 `create_doc`/`update_doc`보다 나중 추가된 도구라, 그 도구 등재 전에 연결된 장수 MCP 세션은 `next_action`이 광고하는 `{tool: sprintable_submit_for_approval}`을 영원히 호출할 수 없다("광고는 보여도 이행이 막힘").

## 근본 그라운딩
이 서버(`SprintableFastMCP`)는 `stateless_http=True`로 구성돼 있고, mcp SDK `streamable_http_manager` 소스 확認 결과 stateless 모드는 "요청마다 완전히 새 transport를 만들고 세션 트래킹 자체를 안 한다" — 서버가 밀어줄 «연결된 세션» 개념이 원리적으로 없다. `tools/list_changed` notification(처방 ⓐ)은 이 아키텍처에서 전송할 대상 자체가 없어 구조적으로 불가능(SDK 한계가 아니라 이미 선택된 stateless 배포 모델과의 근본 불일치) — 그래서 처방 ⓑ(next_action에 실행 가능 REST 폴백 동봉)로 판별했습니다.

## Fix
`next_action`에 `fallback_rest({method, url, headers, body})`를 추가 — `create_doc`/`update_doc` 자체는 모든 세션이 이미 가진 기존 도구라(B3보다 먼저 존재), 이 응답 보강은 신규 도구 등록에 전혀 의존하지 않고 세션 나이와 무관하게 항상 도달합니다.

## Test plan
- [x] `fallback_rest` URL/body가 `submit_for_approval()` 자신의 실제 호출과 바이트 단위로 일치하는지 고정하는 드리프트 가드 테스트 신설
- [x] mutation-kill: 경로를 의도로 어긋나게 하니(예: `/transition`→`/submit`) 5건 정확히 RED 확認
- [x] 기존 13건(`test_2668_mcp_submit_for_approval.py`) + 관련 MCP 62건(`mcp/test_contract.py`·`test_2412`) green — 무회귀
- [x] BE `next_action_code` SSOT(`app.services.next_action`, 별개 개념)는 미접촉 — 관련 28건도 green
- [x] CI 대기

🤖 Generated with [Claude Code](https://claude.com/claude-code)