### PR TITLE
[SID:2681] 단일 nav-config 추출 — 데스크톱 GNB+모바일 /more 공용 정의+정합 CI 가드

### DIFF
--- a/apps/web/scripts/verify-nav-config-routes.test.ts
+++ b/apps/web/scripts/verify-nav-config-routes.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { AlertCircle } from 'lucide-react';
+import { findBrokenNavEntries, fsRouteChecker, type RouteChecker } from './verify-nav-config-routes';
+import { NAV_GROUPS } from '../src/lib/nav-config';
+
+describe('verify-nav-config-routes — story #2681 AC3', () => {
+  it('실 NAV_GROUPS 전 항목이 실 라우트와 정합한다(회귀 0)', () => {
+    expect(findBrokenNavEntries(NAV_GROUPS, fsRouteChecker)).toEqual([]);
+  });
+
+  // AC3 「RED 실증」 — 진짜 파일시스템을 건드리지 않고(fsRouteChecker를 가짜 checker로
+  // 교체) 죽은 링크·미등재 목적지를 이 가드가 정확히 잡아내는지 확인한다.
+  it('죽은 static 링크를 정확히 잡아낸다(RED 실증)', () => {
+    const fakeGroups = [
+      { id: 'g1', labelKey: 'x', items: [{ id: 'dead', labelKey: 'x', icon: AlertCircle, kind: 'static' as const, path: '/no/such/route' }] },
+    ];
+    const alwaysMissing: RouteChecker = { staticExists: () => false, resourceExists: () => false };
+    expect(findBrokenNavEntries(fakeGroups, alwaysMissing)).toEqual([
+      { groupId: 'g1', itemId: 'dead', kind: 'static', path: '/no/such/route' },
+    ]);
+  });
+
+  it('미등재 resource 목적지를 정확히 잡아낸다(RED 실증)', () => {
+    const fakeGroups = [
+      { id: 'g1', items: [{ id: 'ghost', labelKey: 'x', icon: AlertCircle, kind: 'resource' as const, path: 'no_such_resource' }] },
+    ];
+    const alwaysMissing: RouteChecker = { staticExists: () => false, resourceExists: () => false };
+    expect(findBrokenNavEntries(fakeGroups, alwaysMissing)).toEqual([
+      { groupId: 'g1', itemId: 'ghost', kind: 'resource', path: 'no_such_resource' },
+    ]);
+  });
+
+  it('전부 정합하면 빈 배열을 낸다(양성대조)', () => {
+    const fakeGroups = [
+      { id: 'g1', items: [{ id: 'ok', labelKey: 'x', icon: AlertCircle, kind: 'static' as const, path: '/anything' }] },
+    ];
+    const alwaysPresent: RouteChecker = { staticExists: () => true, resourceExists: () => true };
+    expect(findBrokenNavEntries(fakeGroups, alwaysPresent)).toEqual([]);
+  });
+
+  it('fsRouteChecker.staticExists — 존재하는 (authenticated) 라우트는 true', () => {
+    expect(fsRouteChecker.staticExists('/organization/members')).toBe(true);
+  });
+
+  it('fsRouteChecker.staticExists — 존재하지 않는 경로는 false', () => {
+    expect(fsRouteChecker.staticExists('/no/such/page/at/all')).toBe(false);
+  });
+
+  it('fsRouteChecker.resourceExists — [ws]/[proj] 하위 실제 리소스는 true', () => {
+    expect(fsRouteChecker.resourceExists('flow')).toBe(true);
+  });
+
+  it('fsRouteChecker.resourceExists — 없는 리소스명은 false', () => {
+    expect(fsRouteChecker.resourceExists('no_such_resource_xyz')).toBe(false);
+  });
+});

--- a/apps/web/scripts/verify-nav-config-routes.ts
+++ b/apps/web/scripts/verify-nav-config-routes.ts
@@ -1,0 +1,66 @@
+/**
+ * story #2681(모바일 IA S1) 회귀가드 — nav-config.ts(src/lib/nav-config.ts)가 데스크톱
+ * GNB+모바일 /more(S2)의 유일한 목적지 출처가 됐다. 그 데이터가 실제 라우트와 정합하지
+ * 않으면(오타·삭제된 페이지·아직 안 만든 페이지) 죽은 링크가 두 서피스 모두에 동시에 퍼진다
+ * — SSOT화의 장점(drift 차단)이 단점(오류도 함께 전파)이 되지 않게 이 가드가 막는다.
+ *
+ * 'static' 항목은 route group(`(authenticated)` 등)을 무시하고 실제 `page.tsx`가 있는지,
+ * 'resource' 항목은 `(authenticated)/[ws]/[proj]/{resource}/page.tsx`가 있는지 검사한다.
+ */
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { NAV_GROUPS, type NavGroupConfig } from '../src/lib/nav-config';
+
+const APP_DIR = path.join(__dirname, '..', 'src', 'app');
+// 정적 항목이 살 수 있는 route group 후보 — '' = group 없는 app 바로 아래(예: /dashboard).
+const STATIC_ROUTE_ROOTS = ['(authenticated)', ''];
+
+export interface RouteChecker {
+  staticExists: (urlPath: string) => boolean;
+  resourceExists: (resource: string) => boolean;
+}
+
+function staticPathExists(urlPath: string): boolean {
+  const segments = urlPath.replace(/^\//, '').split('/');
+  return STATIC_ROUTE_ROOTS.some((root) => {
+    const dir = root ? path.join(APP_DIR, root, ...segments) : path.join(APP_DIR, ...segments);
+    return existsSync(path.join(dir, 'page.tsx'));
+  });
+}
+
+function resourcePathExists(resource: string): boolean {
+  return existsSync(path.join(APP_DIR, '(authenticated)', '[ws]', '[proj]', resource, 'page.tsx'));
+}
+
+export const fsRouteChecker: RouteChecker = {
+  staticExists: staticPathExists,
+  resourceExists: resourcePathExists,
+};
+
+export interface BrokenNavEntry {
+  groupId: string;
+  itemId: string;
+  kind: string;
+  path: string;
+}
+
+export function findBrokenNavEntries(groups: NavGroupConfig[], checker: RouteChecker): BrokenNavEntry[] {
+  const broken: BrokenNavEntry[] = [];
+  for (const group of groups) {
+    for (const item of group.items) {
+      const ok = item.kind === 'static' ? checker.staticExists(item.path) : checker.resourceExists(item.path);
+      if (!ok) broken.push({ groupId: group.id, itemId: item.id, kind: item.kind, path: item.path });
+    }
+  }
+  return broken;
+}
+
+if (require.main === module) {
+  const broken = findBrokenNavEntries(NAV_GROUPS, fsRouteChecker);
+  if (broken.length > 0) {
+    console.error(`FAIL: nav-config ${broken.length}건이 실제 라우트와 정합 안 됨:`);
+    for (const b of broken) console.error(`  - [${b.kind}] ${b.groupId}/${b.itemId} → ${b.path}`);
+    process.exit(1);
+  }
+  console.log(`OK: nav-config 전 ${NAV_GROUPS.flatMap((g) => g.items).length}항목이 실제 라우트와 정합.`);
+}

--- a/apps/web/src/components/nav/app-sidebar.test.tsx
+++ b/apps/web/src/components/nav/app-sidebar.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+//
+// story #2681(모바일 IA S1) — 데스크톱 GNB를 하드코딩 JSX에서 NAV_GROUPS 순회로 리팩터한
+// 회귀가드. AC1("렌더 결과 기존과 동일 — 시각 회귀 0")을 실 렌더로 잰다: 그룹 순서·라벨,
+// 항목 순서·라벨·href·active 판정·kbd힌트·배지가 리팩터 전과 동일한지.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+
+const { pathnameRef } = vi.hoisted(() => ({ pathnameRef: { current: '/dashboard' } }));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => pathnameRef.current,
+  useSearchParams: () => new URLSearchParams(''),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+const { AppSidebar } = await import('./app-sidebar');
+const { SidebarProvider } = await import('@/components/ui/sidebar');
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function withProviders(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      <SidebarProvider>{node}</SidebarProvider>
+    </NextIntlClientProvider>
+  );
+}
+
+function stubMatchMedia() {
+  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
+    matches: false, // 데스크톱 분기 고정(<1024 아님) — GNB 실 렌더 대상.
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+}
+
+function stubFetch() {
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ data: { inboxUnreadCount: 0 } }), {
+    status: 200, headers: { 'content-type': 'application/json' },
+  })));
+}
+
+function stubLocalStorage() {
+  const store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => { store.set(k, v); },
+    removeItem: (k: string) => { store.delete(k); },
+    clear: () => store.clear(),
+  });
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  stubMatchMedia();
+  stubFetch();
+  stubLocalStorage();
+  pathnameRef.current = '/dashboard';
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function mount() {
+  await act(async () => {
+    root.render(withProviders(
+      <AppSidebar projectMemberships={[]} chatUnreadTotal={0} />,
+    ));
+  });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+}
+
+// 리팩터 전 하드코딩 JSX의 그룹/항목 순서를 그대로 옮긴 기대값 — nav-config.ts 자체가 그
+// 원본에서 1:1로 추출된 것이라 이 표가 "리팩터 전 실제 마크업"의 정본이다.
+const EXPECTED_GROUPS: Array<{ labelKey: string | null; labels: string[] }> = [
+  { labelKey: 'zoneOrganization', labels: ['구성원', '워크포스', '권한', '신뢰', '기억', '이벤트'] },
+  { labelKey: 'zoneNow', labels: ['조직 브리핑', '알림', '대시보드', '채팅'] },
+  { labelKey: 'zoneWork', labels: ['흐름', '스프린트', '목표', '실험실', '스탠드업', '회고'] },
+  { labelKey: 'zoneTrust', labels: ['활동 로그'] },
+  { labelKey: 'zoneKnowledge', labels: ['문서', '산출물', '스토리지'] },
+  { labelKey: null, labels: ['설정'] },
+];
+
+describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1)', () => {
+  it('그룹 순서·라벨·항목 순서·라벨이 리팩터 전과 동일하다', async () => {
+    await mount();
+    const groupLabels = [...container.querySelectorAll('[data-slot="sidebar-group-label"]')].map((el) => el.textContent);
+    expect(groupLabels).toEqual(['조직', '홈', '작업', '신뢰', '지식']);
+
+    const groups = [...container.querySelectorAll('[data-slot="sidebar-group"]')];
+    expect(groups.length).toBe(EXPECTED_GROUPS.length);
+    groups.forEach((groupEl, i) => {
+      const itemLabels = [...groupEl.querySelectorAll('[data-slot="sidebar-menu-button"] span')].map((el) => el.textContent);
+      expect(itemLabels).toEqual(EXPECTED_GROUPS[i]!.labels);
+    });
+  });
+
+  it('정적 항목(조직 그룹)의 href가 리팩터 전과 동일하다', async () => {
+    await mount();
+    const membersLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.includes('구성원'));
+    expect(membersLink?.getAttribute('href')).toBe('/organization/members');
+    const eventsLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.includes('이벤트'));
+    expect(eventsLink?.getAttribute('href')).toBe('/organization/events');
+  });
+
+  it('리소스 항목(작업 그룹, org/project slug 없음)이 bare href로 폴백한다(기존 resourceLink 동작)', async () => {
+    await mount();
+    const flowLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.includes('흐름'));
+    expect(flowLink?.getAttribute('href')).toBe('/flow');
+  });
+
+  it('kbd 힌트(흐름=B·스탠드업=S·회고=R)가 항목별로 정확히 붙는다', async () => {
+    await mount();
+    const flowBtn = [...container.querySelectorAll('a')].find((a) => a.textContent?.includes('흐름'));
+    expect(flowBtn?.textContent).toContain('B');
+    const standupBtn = [...container.querySelectorAll('a')].find((a) => a.textContent?.includes('스탠드업'));
+    expect(standupBtn?.textContent).toContain('S');
+  });
+
+  it('현재 경로와 일치하는 정적 항목이 active로 표시된다(isActive 판정 보존)', async () => {
+    pathnameRef.current = '/organization/events';
+    await mount();
+    const eventsBtn = [...container.querySelectorAll('[data-slot="sidebar-menu-button"]')].find((b) => b.textContent?.includes('이벤트'));
+    expect(eventsBtn?.hasAttribute('data-active')).toBe(true);
+    const membersBtn = [...container.querySelectorAll('[data-slot="sidebar-menu-button"]')].find((b) => b.textContent?.includes('구성원'));
+    expect(membersBtn?.hasAttribute('data-active')).toBe(false);
+  });
+
+  it('unread 배지(inbox)가 카운트>0일 때만 렌더된다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ data: { inboxUnreadCount: 3 } }), {
+      status: 200, headers: { 'content-type': 'application/json' },
+    })));
+    await mount();
+    const inboxBtn = [...container.querySelectorAll('[data-slot="sidebar-menu-button"]')].find((b) => b.textContent?.includes('알림'));
+    expect(inboxBtn?.textContent).toContain('3');
+  });
+
+  it('설정 그룹은 라벨 없는 유틸 그룹으로 유지된다(ia-4zone 확定)', async () => {
+    await mount();
+    const settingsLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.includes('설정') && a.getAttribute('href') === '/settings');
+    expect(settingsLink).toBeDefined();
+  });
+});

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -4,37 +4,14 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import {
-  Award,
-  BookOpen,
-  Bot,
-  Brain,
-  CalendarRange,
-  CircleHelp,
-  ClipboardList,
-  FlaskConical,
-  GalleryVerticalEnd,
-  Gauge,
-  HardDrive,
-  Inbox,
-  Layers,
-  LayoutDashboard,
-  MessageSquare,
-  Newspaper,
-  Search,
-  Settings,
-  Shield,
-  Users,
-  Users2,
-  Workflow,
-  Zap,
-} from 'lucide-react';
+import { CircleHelp, Search } from 'lucide-react';
 import { LocaleSwitcher } from '@/components/locale-switcher';
 import { ThemeToggle } from '@/components/nav/theme-toggle';
 import { CommandPalette } from '@/components/command-palette/command-palette';
 import { ProfileMenu } from '@/components/nav/profile-menu';
 import { UnifiedSwitcher, type OrgSwitcherItem } from '@/components/nav/unified-switcher';
 import { fetchWithAuth } from '@/lib/db/client';
+import { NAV_GROUPS } from '@/lib/nav-config';
 import {
   Sidebar,
   SidebarContent,
@@ -93,14 +70,9 @@ export function AppSidebar({
       || Boolean(orgSlug && currentProjectSlug && pathname.startsWith(`/${orgSlug}/${currentProjectSlug}/${resource}`));
     return { href, isActive };
   }
+  // story #2681 — docsLink는 footer 도움말 링크가 루프 밖에서 따로 참조해 개별 바인딩을
+  // 유지한다(그 외 리소스 항목은 전부 NAV_GROUPS 순회 중 resourceLink()를 그 자리에서 호출).
   const docsLink = resourceLink('docs');
-  const standupLink = resourceLink('standup');
-  const retroLink = resourceLink('retro');
-  const loopsLink = resourceLink('loops');
-  const artifactsLink = resourceLink('artifacts');
-  const sprintsLink = resourceLink('sprints');
-  const storageLink = resourceLink('storage');
-  const goalsLink = resourceLink('goals');
   // story #2224(IA v2.2 §7-3, AC12) — 기본 진입은 /flow, 사이드바가 통합뷰를 가리킨다.
   // 칸반은 /flow?view=list로 흡수됐다(PR#2698, `/board` 라우트 자체는 삭제) — 사이드바에
   // board를 flow와 나란히 1Depth로 세우지 않는다("나란히 두면 「내렸다」가 무효가 된다" —
@@ -200,289 +172,48 @@ export function AppSidebar({
       </SidebarHeader>
 
       <SidebarContent>
-        {/* 조직 / Organization — 주체·구조 프레임(4구역=주의 모드와 별개 축). story c4980e70·
-            doc org-1st-class-surface-ia-design-b §1(다이어그램=조직이 4구역 위 프레임 — 유나
-            가디언 fix로 최상단 배치). 에이전트=1급 멤버·조직/워크포스 1차 홈(🔒확定).
-            신뢰·기억은 C 트랙 전 자리(slot)만 — no-fiction. */}
-        <SidebarGroup>
-          <SidebarGroupLabel>{t('zoneOrganization')}</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href="/organization/members" />}
-                  isActive={isActive('/organization/members')}
-                  tooltip={t('orgMembers')}
-                >
-                  <Users2 />
-                  <span>{t('orgMembers')}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href="/organization/workforce" />}
-                  isActive={isActive('/organization/workforce')}
-                  tooltip={t('workforce')}
-                >
-                  <Bot />
-                  <span>{t('workforce')}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href="/organization/roles" />}
-                  isActive={isActive('/organization/roles')}
-                  tooltip={t('orgRoles')}
-                >
-                  <Shield />
-                  <span>{t('orgRoles')}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href="/organization/trust" />}
-                  isActive={isActive('/organization/trust')}
-                  tooltip={t('orgTrust')}
-                >
-                  <Award />
-                  <span>{t('orgTrust')}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href="/organization/memory" />}
-                  isActive={isActive('/organization/memory')}
-                  tooltip={t('orgMemory')}
-                >
-                  <Brain />
-                  <span>{t('orgMemory')}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href="/organization/events" />}
-                  isActive={isActive('/organization/events')}
-                  tooltip={t('orgEvents')}
-                >
-                  <Zap />
-                  <span>{t('orgEvents')}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-
-        {/* ① 지금 / Now — 개입할 것(인박스·대시보드·채팅). ia-4zone SSOT 확定. */}
-        <SidebarGroup>
-          <SidebarGroupLabel>{t('zoneNow')}</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href="/org-briefing" />}
-                  isActive={isActive('/org-briefing')}
-                  tooltip={t('orgBriefing')}
-                >
-                  <Newspaper />
-                  <span>{t('orgBriefing')}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href="/inbox" />}
-                  isActive={isActive('/inbox')}
-                  tooltip={t('inbox')}
-                >
-                  <Inbox />
-                  <span>{t('inbox')}</span>
-                  {inboxUnreadCount > 0 ? (
-                    <SidebarMenuBadge>
-                      {inboxUnreadCount > 9 ? '9+' : inboxUnreadCount}
-                    </SidebarMenuBadge>
-                  ) : null}
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href="/dashboard" />}
-                  isActive={isActive('/dashboard')}
-                  tooltip={t('dashboard')}
-                >
-                  <LayoutDashboard />
-                  <span>{t('dashboard')}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href="/chats" />}
-                  isActive={isActive('/chats')}
-                  tooltip={t('chats')}
-                >
-                  <MessageSquare />
-                  <span>{t('chats')}</span>
-                  {/* story #1977(트랙B): 유나 시안 768e89b5 v2 ③ — 결재함 배지와 동일 brand,
-                      구분은 색이 아니라 아이콘+탭 순서(디자인 노트). */}
-                  {chatUnreadTotal > 0 ? (
-                    <SidebarMenuBadge>
-                      {chatUnreadTotal > 99 ? '99+' : chatUnreadTotal}
-                    </SidebarMenuBadge>
-                  ) : null}
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-
-        {/* ② 작업 / Work — 흐르는 일(흐름·스프린트·목표·Loop·스탠드업·회고). ia-4zone SSOT 확定.
-            board·glance는 /flow로 흡수되며 별도 1Depth 항목이 아니게 됐다(#2224, PR#2698). */}
-        <SidebarGroup>
-          <SidebarGroupLabel>{t('zoneWork')}</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href={flowLink.href} />}
-                  isActive={flowLink.isActive}
-                  tooltip={t('flow')}
-                >
-                  <Workflow />
-                  <span>{t('flow')}</span>
-                  <KbdHint>B</KbdHint>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href={sprintsLink.href} />}
-                  isActive={sprintsLink.isActive}
-                  tooltip={t('sprints')}
-                >
-                  <CalendarRange />
-                  <span>{t('sprints')}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href={goalsLink.href} />}
-                  isActive={goalsLink.isActive}
-                  tooltip={t('goals')}
-                >
-                  <Layers />
-                  <span>{t('goals')}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href={loopsLink.href} />}
-                  isActive={loopsLink.isActive}
-                  tooltip={t('loops')}
-                >
-                  <FlaskConical />
-                  <span>{t('loops')}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href={standupLink.href} />}
-                  isActive={standupLink.isActive}
-                  tooltip={t('standup')}
-                >
-                  <Users />
-                  <span>{t('standup')}</span>
-                  <KbdHint>S</KbdHint>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href={retroLink.href} />}
-                  isActive={retroLink.isActive}
-                  tooltip={t('retro')}
-                >
-                  <Gauge />
-                  <span>{t('retro')}</span>
-                  <KbdHint>R</KbdHint>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-
-        {/* ③ 신뢰 / Trust — 증명된 일(활동 로그·감사). 검증 표면 확장 자리(ia-4zone SSOT 확定). */}
-        <SidebarGroup>
-          <SidebarGroupLabel>{t('zoneTrust')}</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href="/activity" />}
-                  isActive={isActive('/activity')}
-                  tooltip={t('activity')}
-                >
-                  <ClipboardList />
-                  <span>{t('activity')}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-
-        {/* ④ 지식 / Knowledge — 팀 기억(문서·산출물·스토리지·에이전트). ia-4zone SSOT 확定.
-            산출물(story a15cea4f) — 스토리 귀속 ArtifactSection과 별개인 모아보기 발견 표면. */}
-        <SidebarGroup>
-          <SidebarGroupLabel>{t('zoneKnowledge')}</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href={docsLink.href} />}
-                  isActive={docsLink.isActive}
-                  tooltip={t('docs')}
-                >
-                  <BookOpen />
-                  <span>{t('docs')}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href={artifactsLink.href} />}
-                  isActive={artifactsLink.isActive}
-                  tooltip={t('artifacts')}
-                >
-                  <GalleryVerticalEnd />
-                  <span>{t('artifacts')}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href={storageLink.href} />}
-                  isActive={storageLink.isActive}
-                  tooltip={t('storage')}
-                >
-                  <HardDrive />
-                  <span>{t('storage')}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              {/* E-SETTINGS S5: Meetings 메뉴 숨김 — /meetings 진입 차단(route thin guard 404). */}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-
-        {/* 설정 — zone 밖·하단(ia-4zone 확定: 유틸 푸터·zone 라벨 없음). */}
-        <SidebarGroup>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href="/settings" />}
-                  isActive={isActive('/settings')}
-                  tooltip={t('settings')}
-                >
-                  <Settings />
-                  <span>{t('settings')}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
+        {/* story #2681 — 데스크톱 GNB와 모바일 /more 허브(S2)가 한 정의(NAV_GROUPS)에서
+            파생된다(doc mobile-ia-full-completion-2678 §2.5-3). 그룹·항목 목록 자체는
+            nav-config.ts가 유일한 출처이고, 여기선 오직 순회+렌더만 한다 — 순서·라벨·아이콘·
+            그룹핑은 이 리팩터 전과 동일(시각 회귀 0, AC1). */}
+        {NAV_GROUPS.map((group) => (
+          <SidebarGroup key={group.id}>
+            {group.labelKey ? <SidebarGroupLabel>{t(group.labelKey)}</SidebarGroupLabel> : null}
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {group.items.map((item) => {
+                  const link = item.kind === 'static'
+                    ? { href: item.path, isActive: isActive(item.path) }
+                    : resourceLink(item.path);
+                  const Icon = item.icon;
+                  const badgeCount = item.badgeKey === 'inbox' ? inboxUnreadCount
+                    : item.badgeKey === 'chats' ? chatUnreadTotal
+                    : 0;
+                  const badgeCap = item.badgeKey === 'inbox' ? 9 : 99;
+                  const label = t(item.labelKey);
+                  return (
+                    <SidebarMenuItem key={item.id}>
+                      <SidebarMenuButton
+                        render={<Link href={link.href} />}
+                        isActive={link.isActive}
+                        tooltip={label}
+                      >
+                        <Icon />
+                        <span>{label}</span>
+                        {item.kbdHint ? <KbdHint>{item.kbdHint}</KbdHint> : null}
+                        {item.badgeKey && badgeCount > 0 ? (
+                          <SidebarMenuBadge>
+                            {badgeCount > badgeCap ? `${badgeCap}+` : badgeCount}
+                          </SidebarMenuBadge>
+                        ) : null}
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  );
+                })}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        ))}
       </SidebarContent>
 
       <SidebarFooter className="space-y-2 p-2">

--- a/apps/web/src/lib/nav-config.ts
+++ b/apps/web/src/lib/nav-config.ts
@@ -1,0 +1,112 @@
+import {
+  Award,
+  BookOpen,
+  Bot,
+  Brain,
+  CalendarRange,
+  ClipboardList,
+  FlaskConical,
+  GalleryVerticalEnd,
+  HardDrive,
+  Inbox,
+  Layers,
+  LayoutDashboard,
+  MessageSquare,
+  Newspaper,
+  Settings,
+  Shield,
+  Users,
+  Users2,
+  Workflow,
+  Zap,
+  Gauge,
+  type LucideIcon,
+} from 'lucide-react';
+
+// story #2681(모바일 IA S1, doc mobile-ia-full-completion-2678) — 데스크톱 GNB(app-sidebar.tsx)와
+// 모바일 /more 허브(S2에서 착수)가 「한 정의」에서 파생되도록 이 파일이 그 SSOT다. 두 벌 목적지
+// 목록이 따로 살면 하나만 갱신되고 다른 하나가 뒤처지는 drift가 원천적으로 생긴다 — 이 파일이
+// 유일한 목적지 카탈로그이고, 렌더 쪽(app-sidebar.tsx)은 오직 이 데이터를 순회만 한다.
+//
+// kind 구분(app-sidebar.tsx의 기존 두 링크 계산 방식과 정확히 대응):
+//   'static'   — 절대 경로 그대로(org/project 슬러그와 무관). path = 전체 href.
+//   'resource' — /{ws}/{proj}/{resource} 파생 대상(resourceLink() 소비). path = resource 이름뿐
+//                (앞 슬래시 없음 — 슬래시 유무로 kind를 오인하지 않게 값 자체로 구분).
+export type NavItemKind = 'static' | 'resource';
+
+export interface NavItemConfig {
+  id: string;
+  labelKey: string;
+  icon: LucideIcon;
+  kind: NavItemKind;
+  path: string;
+  kbdHint?: string;
+  // 배지 소스 — 현재 카운트 자체는 컴포넌트 상태(폴링·SSE)라 여기 값이 아니라 렌더 쪽이 채운다.
+  badgeKey?: 'inbox' | 'chats';
+}
+
+export interface NavGroupConfig {
+  id: string;
+  // undefined = 라벨 없는 유틸 그룹(설정 footer — ia-4zone 확定: zone 라벨 없음).
+  labelKey?: string;
+  items: NavItemConfig[];
+}
+
+export const NAV_GROUPS: NavGroupConfig[] = [
+  {
+    id: 'organization',
+    labelKey: 'zoneOrganization',
+    items: [
+      { id: 'org-members', labelKey: 'orgMembers', icon: Users2, kind: 'static', path: '/organization/members' },
+      { id: 'org-workforce', labelKey: 'workforce', icon: Bot, kind: 'static', path: '/organization/workforce' },
+      { id: 'org-roles', labelKey: 'orgRoles', icon: Shield, kind: 'static', path: '/organization/roles' },
+      { id: 'org-trust', labelKey: 'orgTrust', icon: Award, kind: 'static', path: '/organization/trust' },
+      { id: 'org-memory', labelKey: 'orgMemory', icon: Brain, kind: 'static', path: '/organization/memory' },
+      { id: 'org-events', labelKey: 'orgEvents', icon: Zap, kind: 'static', path: '/organization/events' },
+    ],
+  },
+  {
+    id: 'now',
+    labelKey: 'zoneNow',
+    items: [
+      { id: 'org-briefing', labelKey: 'orgBriefing', icon: Newspaper, kind: 'static', path: '/org-briefing' },
+      { id: 'inbox', labelKey: 'inbox', icon: Inbox, kind: 'static', path: '/inbox', badgeKey: 'inbox' },
+      { id: 'dashboard', labelKey: 'dashboard', icon: LayoutDashboard, kind: 'static', path: '/dashboard' },
+      { id: 'chats', labelKey: 'chats', icon: MessageSquare, kind: 'static', path: '/chats', badgeKey: 'chats' },
+    ],
+  },
+  {
+    id: 'work',
+    labelKey: 'zoneWork',
+    items: [
+      { id: 'flow', labelKey: 'flow', icon: Workflow, kind: 'resource', path: 'flow', kbdHint: 'B' },
+      { id: 'sprints', labelKey: 'sprints', icon: CalendarRange, kind: 'resource', path: 'sprints' },
+      { id: 'goals', labelKey: 'goals', icon: Layers, kind: 'resource', path: 'goals' },
+      { id: 'loops', labelKey: 'loops', icon: FlaskConical, kind: 'resource', path: 'loops' },
+      { id: 'standup', labelKey: 'standup', icon: Users, kind: 'resource', path: 'standup', kbdHint: 'S' },
+      { id: 'retro', labelKey: 'retro', icon: Gauge, kind: 'resource', path: 'retro', kbdHint: 'R' },
+    ],
+  },
+  {
+    id: 'trust',
+    labelKey: 'zoneTrust',
+    items: [
+      { id: 'activity', labelKey: 'activity', icon: ClipboardList, kind: 'static', path: '/activity' },
+    ],
+  },
+  {
+    id: 'knowledge',
+    labelKey: 'zoneKnowledge',
+    items: [
+      { id: 'docs', labelKey: 'docs', icon: BookOpen, kind: 'resource', path: 'docs' },
+      { id: 'artifacts', labelKey: 'artifacts', icon: GalleryVerticalEnd, kind: 'resource', path: 'artifacts' },
+      { id: 'storage', labelKey: 'storage', icon: HardDrive, kind: 'resource', path: 'storage' },
+    ],
+  },
+  {
+    id: 'settings',
+    items: [
+      { id: 'settings', labelKey: 'settings', icon: Settings, kind: 'static', path: '/settings' },
+    ],
+  },
+];


### PR DESCRIPTION
## 요약
doc [mobile-ia-full-completion-2678](entity:doc:0b78e166-a34a-4808-b57b-9ad9b25e3b16)(선생님 결재 승인 2026-08-16) S1 — 모바일 IA 재설계 4단계(S1→S2→S3→S4)의 첫 착수. 데스크톱 GNB(app-sidebar.tsx)와 모바일 /more 허브(S2)가 **한 정의**에서 파생되도록 nav-config를 추출해 두 벌 목적지 목록의 drift를 원천 차단한다.

## 변경
- `src/lib/nav-config.ts`(신규) — 6개 그룹(조직/홈·지금/작업/신뢰/지식/설정) 21항목의 유일한 출처. `'static'`(절대 경로)/`'resource'`(`/{ws}/{proj}/{resource}` 파생) 두 kind로 app-sidebar.tsx의 기존 두 링크 계산 방식과 정확히 대응.
- `app-sidebar.tsx` — 하드코딩 JSX(6개 그룹 반복, ~285줄) → `NAV_GROUPS` 순회로 리팩터. href/active 판정·배지·kbd힌트 로직은 그대로 두고(순수 데이터 추출), 렌더 결과만 동일하게 유지.
- `scripts/verify-nav-config-routes.ts`(신규, CI 가드) — nav-config 각 항목이 실제 `page.tsx`와 정합하는지 검사. `RouteChecker`를 주입 가능하게 설계해 실 fs 접근 없이 죽은 링크·미등재 리소스를 정확히 잡아내는지 단위 테스트로 확인.
- `app-sidebar.test.tsx`(신규) — 그룹/항목 순서·라벨·href·active 판정·kbd힌트·배지·라벨없는 설정 그룹까지 리팩터 전 마크업과 1:1 대조.

## AC 대조
1. ✅ 단일 nav-config에서 데스크톱 GNB 파생(렌더 결과 기존과 동일) — 회귀가드 테스트로 확인
2. ✅ /more가 소비할 그룹 구조(5 zones + 설정) 정의 포함 — 실제 /more 배선은 S2
3. ✅ CI 정합 가드(정의↔라우트) — RED 실증 포함(가짜 checker로 죽은 링크 케이스 확인)
4. 카디르 QA·유나 design(구조 변화 없음 확認) 대기

## 검증
- `pnpm exec tsc --noEmit` / `pnpm exec eslint .` — 통과, 0 warning
- `pnpm build` — 통과
- `pnpm exec vitest run` — 422 files / 3430 tests 전부 통과(신규 15건 포함)
- `verify-no-new-md-breakpoint.ts` / `verify-no-new-tint-color-text.ts` / `verify-no-i18n-phrase-collision.ts` — 신규 회귀 0건
- `verify-nav-config-routes.ts` 직접 실행 — 전 21항목 실 라우트와 정합 확認
- 변별력 검증: `nav-config.ts` 항목 하나를 의도적으로 훼손 → 회귀가드 테스트가 정확히 잡아냄 → 원복 → GREEN 재확認(전형적 RED/GREEN 대신 "리팩터가 산출물을 안 바꿨다"는 성격이라 이 방식으로 신뢰도 확보)

## 스크린샷
순수 리팩터(신규 UI 없음) — 로컬 FE→dev 클라우드 BE는 JWT 불일치로 라이브 로그인 불가(기존 세션 규율), 라이브 픽셀 확認은 dev 배포 후 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)