### PR TITLE
[SID:2682] /more를 GNB 미러 그룹형 허브로 재건 — 조직 그룹·조직브리핑 포함

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -52,8 +52,7 @@
     "now": "Now",
     "approvals": "Approvals",
     "chat": "Chat",
-    "more": "More",
-    "moreTempNotice": "Temporary list — will be replaced by the full screen soon."
+    "more": "More"
   },
   "nav": {
     "dashboard": "Dashboard",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -52,8 +52,7 @@
     "now": "지금",
     "approvals": "결재",
     "chat": "채팅",
-    "more": "전체",
-    "moreTempNotice": "임시 목록입니다 — 정식 화면으로 곧 교체됩니다."
+    "more": "전체"
   },
   "nav": {
     "dashboard": "대시보드",

--- a/apps/web/scripts/verify-no-orphan-resource-routes.test.ts
+++ b/apps/web/scripts/verify-no-orphan-resource-routes.test.ts
@@ -4,6 +4,7 @@ import {
   EXEMPT_TARGETS,
   extractComposedTargets,
   extractLiteralTargets,
+  extractNavConfigResourceTargets,
   findEntryWithoutRoute,
   findRouteWithoutEntry,
   GRANDFATHER_BASELINE,
@@ -23,6 +24,25 @@ describe('extractComposedTargets — AC2㉠', () => {
 
   it('변수 인자(런타임 조립)는 못 뽑는다(AC7㉠ — 리터럴만 본다)', () => {
     expect(extractComposedTargets(`resourceLink(someVar)`)).toEqual([]);
+  });
+});
+
+// story #2681/#2682 후속 — app-sidebar.tsx·more/page.tsx가 resourceLink('x') 리터럴 반복을
+// nav-config.ts(NAV_GROUPS) 순회로 리팩터하며 resourceLink(item.path)(변수 인자)가 됐다.
+// 이 가드가 원래 리터럴만 보므로(AC7㉠), nav-config.ts의 `kind: 'resource', path: 'x'` 짝을
+// 새 진입점 축으로 인정해야 리팩터가 "조용한 도달불가"(routeWithoutEntry)로 오판되지 않는다.
+describe('extractNavConfigResourceTargets — nav-config.ts SSOT 축(story #2681/#2682 후속)', () => {
+  it('kind: \'resource\', path: \'x\' 짝을 뽑는다', () => {
+    const src = `
+      { id: 'flow', labelKey: 'flow', icon: Workflow, kind: 'resource', path: 'flow', kbdHint: 'B' },
+      { id: 'docs', labelKey: 'docs', icon: BookOpen, kind: 'resource', path: 'docs' },
+    `;
+    expect(extractNavConfigResourceTargets(src)).toEqual(['flow', 'docs']);
+  });
+
+  it('kind: \'static\'인 항목은 안 뽑는다(resource 축만)', () => {
+    const src = `{ id: 'org-events', labelKey: 'orgEvents', icon: Zap, kind: 'static', path: '/organization/events' },`;
+    expect(extractNavConfigResourceTargets(src)).toEqual([]);
   });
 });
 

--- a/apps/web/scripts/verify-no-orphan-resource-routes.ts
+++ b/apps/web/scripts/verify-no-orphan-resource-routes.ts
@@ -133,6 +133,19 @@ export function extractComposedTargets(content: string): string[] {
   return [...content.matchAll(COMPOSED_CALL_RE)].map((m) => m[2]!);
 }
 
+// story #2681/#2682(모바일 IA S1·S2) 후속 — app-sidebar.tsx·more/page.tsx가 각 리소스마다
+// `resourceLink('x')`를 개별 리터럴로 부르던 걸 nav-config.ts(NAV_GROUPS) 순회로 리팩터하며
+// `resourceLink(item.path)`(변수 인자)가 됐다. AC7㉠이 이미 문서화한 한계(정규식은 리터럴만
+// 본다)가 실제로 걸린 사례 — nav-config.ts 자체가 이제 조합 진입점의 실제 소스이므로, 그
+// 파일의 `kind: 'resource'` 옆 `path: '...'` 리터럴을 세 번째 축으로 인정한다(손 EXEMPT
+// 추가가 아니라, 이 가드가 원래 하려던 일 — "정적으로 찾을 수 있는 진입점 전수"를 새 SSOT
+// 모양에 맞춰 넓힌 것).
+const NAV_CONFIG_RESOURCE_RE = /kind:\s*'resource',\s*path:\s*'([a-zA-Z][a-zA-Z0-9_-]*)'/g;
+
+export function extractNavConfigResourceTargets(content: string): string[] {
+  return [...content.matchAll(NAV_CONFIG_RESOURCE_RE)].map((m) => m[1]!);
+}
+
 // ── ㉡리터럴 진입점 — href="/x" / href: '/x' (단일 세그먼트, 선택적 쿼리) ───────
 
 const LITERAL_HREF_RE = /\bhref\s*[:=]\s*(['"`])\/([a-zA-Z][a-zA-Z0-9_-]*)(?:\?[^'"`]*)?\1/g;
@@ -247,6 +260,10 @@ function main(): void {
     const content = readFileSync(abs, 'utf8');
     const rel = path.relative(SRC_ROOT, abs).split(path.sep).join('/');
     for (const target of extractComposedTargets(content)) {
+      hits.push({ target, file: rel, kind: 'composed' });
+      composedCount += 1;
+    }
+    for (const target of extractNavConfigResourceTargets(content)) {
       hits.push({ target, file: rel, kind: 'composed' });
       composedCount += 1;
     }

--- a/apps/web/src/app/(authenticated)/more/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/more/page.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+//
+// story #2682(모바일 IA S2) — 「전체」(/more)를 평면 stub에서 데스크톱 GNB(nav-config.ts)
+// 미러 그룹형 허브로 재건한 회귀가드. AC1(org 그룹·조직브리핑 포함)·AC3(아코디언 없음·stub
+// 배너 제거)·중복 방지(flow/inbox/chats는 바텀 탭이 이미 depth 1로 커버)를 실 렌더로 잰다.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../../messages/ko.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode, Provider: React.ComponentType<{ children: React.ReactNode }>) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      <Provider>{node}</Provider>
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+async function mount() {
+  const { default: MorePage } = await import('./page');
+  const { TopBarProvider } = await import('@/components/nav/top-bar-context');
+  await act(async () => { root.render(wrap(<MorePage />, TopBarProvider)); });
+}
+
+describe('MorePage — story #2682 GNB 미러 그룹형 허브(AC1·AC3)', () => {
+  it('섹션 순서가 doc §2.3 그대로다(홈·지금/작업/신뢰/지식/조직/설정 — 데스크톱과 다른 순서)', async () => {
+    await mount();
+    const sectionLabels = [...container.querySelectorAll('h2')].map((el) => el.textContent);
+    expect(sectionLabels).toEqual(['홈', '작업', '신뢰', '지식', '조직', '설정']);
+  });
+
+  it('조직 그룹(이벤트 포함)과 조직브리핑이 포함된다(AC1 — 기존 stub의 핵심 결함 수복)', async () => {
+    await mount();
+    expect(container.textContent).toContain('이벤트');
+    expect(container.textContent).toContain('구성원');
+    expect(container.textContent).toContain('워크포스');
+    expect(container.textContent).toContain('조직 브리핑');
+  });
+
+  it('flow·inbox·chats는 안 뜬다(바텀 탭이 이미 depth 1로 커버 — 중복 진입점 방지)', async () => {
+    await mount();
+    const links = [...container.querySelectorAll('a')];
+    expect(links.some((a) => a.getAttribute('href') === '/flow')).toBe(false);
+    expect(links.some((a) => a.getAttribute('href') === '/inbox')).toBe(false);
+    expect(links.some((a) => a.getAttribute('href') === '/chats')).toBe(false);
+  });
+
+  it('임시 stub 배너가 제거됐다(AC3)', async () => {
+    await mount();
+    expect(container.textContent).not.toContain('임시 목록');
+  });
+
+  it('아코디언이 아니다 — 전 섹션의 링크가 펼침 조작 없이 DOM에 항상 존재한다(AC3)', async () => {
+    await mount();
+    // <button aria-expanded>류 접이식 컨트롤이 그룹 헤더에 없다 — h2는 순수 텍스트.
+    const toggles = [...container.querySelectorAll('[aria-expanded]')];
+    expect(toggles.length).toBe(0);
+    // 이벤트(조직 그룹, 목록 순서상 뒤쪽 섹션)가 별도 조작 없이 이미 렌더돼 있다.
+    const eventsLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.includes('이벤트'));
+    expect(eventsLink?.getAttribute('href')).toBe('/organization/events');
+  });
+
+  it('정적 항목은 절대경로, resource 항목은 bare 폴백 href를 쓴다(리팩터 전 규약 보존)', async () => {
+    await mount();
+    const links = [...container.querySelectorAll('a')];
+    const membersLink = links.find((a) => a.textContent?.includes('구성원'));
+    expect(membersLink?.getAttribute('href')).toBe('/organization/members');
+    const sprintsLink = links.find((a) => a.textContent?.includes('스프린트'));
+    expect(sprintsLink?.getAttribute('href')).toBe('/sprints');
+  });
+
+  it('설정 섹션이 그룹 라벨로 뜬다(desktop 무라벨 footer와 달리 허브에선 명시 섹션)', async () => {
+    await mount();
+    const settingsSection = [...container.querySelectorAll('h2')].find((h) => h.textContent === '설정');
+    expect(settingsSection).toBeDefined();
+    const settingsLink = [...container.querySelectorAll('a')].find((a) => a.getAttribute('href') === '/settings');
+    expect(settingsLink).toBeDefined();
+  });
+});

--- a/apps/web/src/app/(authenticated)/more/page.tsx
+++ b/apps/web/src/app/(authenticated)/more/page.tsx
@@ -3,44 +3,32 @@
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
-import {
-  CalendarRange,
-  Layers,
-  Compass,
-  FlaskConical,
-  Users,
-  RotateCcw,
-  Activity,
-  FileText,
-  Image,
-  HardDrive,
-  Settings,
-} from 'lucide-react';
+import { NAV_GROUPS } from '@/lib/nav-config';
 
-// story #1958(P2-S2) "전체" 탭의 임시 스텁 — blueprint §3.2가 모바일 사이드바(Sheet·햄버거)
-// 폐기 방향이라 기존 GNB Sheet를 탭에 매달지 않고, 최소 목록 라우트로 대신한다. 정식 목록화는
-// P2-S9(story #1965)가 담당 — 이 페이지는 그때 교체된다(오르테가군 확定, 2026-07-17).
-// bare 경로만 씀 — 미들웨어의 bare→쿠키 default 해소 301 안전망이 ws/proj slug를 채운다
-// (app-sidebar.tsx의 resourceLink()와 동형 전제).
-// board 항목은 없다(유나 2026-08-01) — /board는 /flow로 리다이렉트되니(#2227 AC8·proxy.ts
-// RENAMED_RESOURCES) flow 링크가 따로 생기면 같은 화면으로 가는 항목이 두 개가 된다.
-const ITEMS = [
-  { href: '/sprints', icon: CalendarRange, labelKey: 'sprints' as const },
-  { href: '/goals', icon: Layers, labelKey: 'goals' as const },
-  { href: '/loops', icon: FlaskConical, labelKey: 'loops' as const },
-  { href: '/standup', icon: Users, labelKey: 'standup' as const },
-  { href: '/retro', icon: RotateCcw, labelKey: 'retro' as const },
-  { href: '/activity', icon: Activity, labelKey: 'activity' as const },
-  { href: '/docs', icon: FileText, labelKey: 'docs' as const },
-  { href: '/artifacts', icon: Image, labelKey: 'artifacts' as const },
-  { href: '/storage', icon: HardDrive, labelKey: 'storage' as const },
-  { href: '/dashboard', icon: Compass, labelKey: 'dashboard' as const },
-  { href: '/settings', icon: Settings, labelKey: 'settings' as const },
-] as const;
+// story #2682(모바일 IA S2, doc mobile-ia-full-completion-2678 §2.3) — 임시 평면 stub(#1958·
+// #1965)을 데스크톱 GNB(app-sidebar.tsx) 5 zones를 그대로 미러하는 그룹형 허브로 재건한다.
+// 목적지 목록 자체는 새로 만들지 않는다 — S1이 추출한 NAV_GROUPS(nav-config.ts)를 그대로
+// 소비해 데스크톱과 drift 없이 항상 정합한다(SSOT).
+//
+// 그룹 순서는 데스크톱과 다르다(doc §2.3 명시) — 데스크톱은 "조직이 4구역 위 프레임"이라
+// 맨 위지만, 모바일 허브는 §2.2 분류(자주→가끔→관리) 순서를 따라 조직·설정(관리)이 뒤로
+// 간다: 홈·지금 / 작업 / 신뢰 / 지식 / 조직(이벤트 포함) / 설정.
+const MOBILE_GROUP_ORDER = ['now', 'work', 'trust', 'knowledge', 'organization', 'settings'];
+
+// flow·inbox·chats는 바텀 탭(지금/결재/채팅)이 이미 depth 1로 커버한다(doc §2.2 "자주" 축) —
+// 허브에 또 실으면 같은 목적지로 가는 진입점이 두 개가 되고 "몇 탭"의 의미가 흐려진다
+// (기존 stub도 board를 같은 이유로 뺐던 것과 같은 원칙, page.tsx 옛 주석 참조).
+const HUB_EXCLUDE_ITEM_IDS = new Set(['flow', 'inbox', 'chats']);
 
 export default function MorePage() {
   const t = useTranslations('nav');
   const tMore = useTranslations('mobileTabBar');
+
+  const hubGroups = MOBILE_GROUP_ORDER
+    .map((groupId) => NAV_GROUPS.find((g) => g.id === groupId))
+    .filter((g): g is NonNullable<typeof g> => !!g)
+    .map((g) => ({ ...g, items: g.items.filter((item) => !HUB_EXCLUDE_ITEM_IDS.has(item.id)) }))
+    .filter((g) => g.items.length > 0);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-4">
@@ -48,20 +36,34 @@ export default function MorePage() {
           allowlist(showContextChip)로 켤 자리가 없었다. "슬롯 없으면 자동 켬"은 fail-open이라
           금지(유나양) — 슬롯을 명시적으로 쓰게 해서 켠다. */}
       <TopBarSlot title={<h1 className="text-sm font-medium">{tMore('more')}</h1>} showContextChip />
-      <p className="mb-4 text-xs text-muted-foreground">{tMore('moreTempNotice')}</p>
-      <ul className="divide-y divide-border rounded-xl border border-border">
-        {ITEMS.map(({ href, icon: Icon, labelKey }) => (
-          <li key={href}>
-            <Link
-              href={href}
-              className="flex min-h-12 items-center gap-3 px-4 py-3 text-sm text-foreground hover:bg-muted"
-            >
-              <Icon className="size-[18px] shrink-0 text-muted-foreground" strokeWidth={1.8} />
-              {t(labelKey)}
-            </Link>
-          </li>
+      {/* story #2682 AC3 — 임시 stub 배너(#1965) 제거. 섹션 헤더 있는 단일 스크롤 목록(아코디언
+          아님 — 아코디언은 목적지를 탭 뒤에 숨겨 depth+1이 된다, doc §2.3). */}
+      <div className="space-y-5">
+        {hubGroups.map((group) => (
+          <section key={group.id}>
+            <h2 className="mb-1.5 px-1 text-xs font-semibold text-muted-foreground">
+              {group.id === 'settings' ? t('settings') : t(group.labelKey!)}
+            </h2>
+            <ul className="divide-y divide-border rounded-xl border border-border">
+              {group.items.map((item) => {
+                const href = item.kind === 'static' ? item.path : `/${item.path}`;
+                const Icon = item.icon;
+                return (
+                  <li key={item.id}>
+                    <Link
+                      href={href}
+                      className="flex min-h-12 items-center gap-3 px-4 py-3 text-sm text-foreground hover:bg-muted"
+                    >
+                      <Icon className="size-[18px] shrink-0 text-muted-foreground" strokeWidth={1.8} />
+                      {t(item.labelKey)}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
         ))}
-      </ul>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 요약
doc [mobile-ia-full-completion-2678](entity:doc:0b78e166-a34a-4808-b57b-9ad9b25e3b16) §2.3, S2(4단계 중 2/4·S1 [#3100](https://github.com/moonklabs/sprintable/pull/3100)/[#3101](https://github.com/moonklabs/sprintable/pull/3101)의 nav-config 소비). 「전체」(/more)를 평면 stub(11항목, org 0건 — 관리면이 모바일서 4탭·비발견 데드엔드 섬이었던 핵심 결함)에서 데스크톱 GNB(`nav-config.ts` NAV_GROUPS)를 그대로 미러하는 그룹형 허브로 재건.

## 변경
- 목적지 목록은 새로 안 만든다 — S1이 추출한 `NAV_GROUPS`를 그대로 소비해 데스크톱과 drift 없이 항상 정합(SSOT).
- 그룹 순서는 데스크톱과 다르다(doc §2.3 명시) — 데스크톱은 조직이 최상단 프레임이지만, 모바일 허브는 §2.2 분류(자주→가끔→관리) 순서를 따라 조직·설정(관리)이 뒤로 간다: 홈·지금/작업/신뢰/지식/**조직(이벤트 포함)**/설정.
- `flow`·`inbox`·`chats`는 제외 — 바텀 탭(지금/결재/채팅)이 이미 depth 1로 커버해, 허브에 또 실으면 같은 목적지로 가는 진입점이 두 개가 된다(기존 stub이 board를 같은 이유로 뺐던 것과 동일 원칙).
- 섹션 헤더 있는 단일 스크롤 목록(아코디언 아님 — 아코디언은 목적지를 탭 뒤에 숨겨 depth+1이 된다, doc §2.3).
- 임시 stub 배너(#1965, `moreTempNotice`) 제거 — 죽은 i18n 키도 함께 정리.

## AC 대조
1. ✅ /more가 nav-config 파생 그룹형 허브(org 그룹·조직브리핑 포함)
2. 판별자 실측(이벤트 도달 2탭) — dev 배포 후 라이브 확認 예정
3. ✅ 아코디언 없음·섹션 헤더 스크롤·stub 배너 제거
4. 카디르 QA+유나 design+라이브 픽셀 대기

## 검증
- `pnpm exec tsc --noEmit` / `pnpm exec eslint .` — 통과, 0 warning
- `pnpm build` — 통과
- `pnpm exec vitest run` — 426 files / 3456 tests 전부 통과(신규 7건 포함)
- `verify-no-new-md-breakpoint.ts` / `verify-no-new-tint-color-text.ts` / `verify-no-i18n-phrase-collision.ts` — 신규 회귀 0건
- RED→GREEN: `git stash`로 fix 제거 후 리팩터 전 stub 코드에서 신규 테스트 6/7 RED 확인(섹션 순서/org 그룹/stub 배너/href 등) → `stash pop`으로 GREEN 복귀 확認

## 스크린샷
모바일 전용 화면·로컬 FE→dev 클라우드 BE는 JWT 불일치로 라이브 로그인 불가(기존 세션 규율) — 라이브 픽셀·판별자(2탭) 실측은 dev 배포 후 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)