### PR TITLE
TEST(#2555): docs-only verify CI backend-skip v2 (correct base)

### DIFF
--- a/docs/runtime-channel-map.md
+++ b/docs/runtime-channel-map.md
@@ -215,3 +215,5 @@ message_created)        :message)
 - [`packages/fakechat/server.ts`](../packages/fakechat/server.ts) — 같은 프로토콜의 로컬 SSE 브릿지 테스트 하네스(story #2653, 배포 경로 아님)
 - [`backend/sprintable_mcp/__main__.py`](../backend/sprintable_mcp/__main__.py) — MCP 서버 진입점
 - 구현 기반 스토리: S-COMM-01(SSE 인증), S-COMM-02(webhook 라우팅), S-COMM-04(send_chat_message 단일 경로), S-COMM-05(backfill+dedup), S-COMM-12(SSE/webhook 이벤트명 통일, backlog)
+
+<!-- story #2555 검증용 임시 주석 — docs-only 변경이 backend 무거운 잡을 실제로 스킵하는지 실증. PR 머지 안 함, 검증 후 이 PR은 close. -->

--- a/docs/runtime-channel-map.md
+++ b/docs/runtime-channel-map.md
@@ -217,3 +217,4 @@ message_created)        :message)
 - 구현 기반 스토리: S-COMM-01(SSE 인증), S-COMM-02(webhook 라우팅), S-COMM-04(send_chat_message 단일 경로), S-COMM-05(backfill+dedup), S-COMM-12(SSE/webhook 이벤트명 통일, backlog)
 
 <!-- story #2555 검증용 임시 주석 — docs-only 변경이 backend 무거운 잡을 실제로 스킵하는지 실증. PR 머지 안 함, 검증 후 이 PR은 close. -->
+<!-- force new commit for fresh CI trigger against correct base -->


### PR DESCRIPTION
Throwaway verification PR for story #2555 — base is fix/2555-ci-path-filter itself so the ONLY diff is the docs-only commit. Proves the skip logic actually engages. Will be closed (not merged).