### PR TITLE
[SID:2685] design gate — 테스트/스토리북 전용 PR은 design:pass 요구 제외

### DIFF
--- a/.github/workflows/design-review-gate.yml
+++ b/.github/workflows/design-review-gate.yml
@@ -92,9 +92,21 @@ jobs:
           MATCHED="$(printf '%s\n' "${CHANGED}" \
             | grep -E '^apps/web/src/components/|^apps/web/messages/|^apps/web/src/app/' \
             | grep -Ev '^apps/web/src/app/api/' || true)"
-          if [ -n "${MATCHED}" ]; then
+          # story #2685 — 실사례(PR#3101): app-sidebar.test.tsx 41줄 «테스트 전용» PR도
+          # components/** 경로라 위 grep에 잡혀 design:pass를 요구했다(시각 표면 0인데).
+          # 경로만 보고 «내용 유형»은 안 가른 게 원인 — MATCHED 중 *.test.{ts,tsx}·*.stories.*
+          # 를 뺀 나머지(=실제 시각/문구 파일)가 하나라도 남아야 스코프 안이다. MATCHED 전부가
+          # 테스트/스토리북이면(하나라도 비테스트 시각 경로가 섞이면 그 즉시 여기 걸려 스코프
+          # 안 — 음성대조 AC2) out-of-scope로 내린다.
+          NON_TEST_MATCHED="$(printf '%s\n' "${MATCHED}" \
+            | grep -Ev '\.test\.(ts|tsx)$|\.stories\.' || true)"
+          if [ -n "${NON_TEST_MATCHED}" ]; then
             echo "in_scope=true" >> "$GITHUB_OUTPUT"
-            echo "This PR touches design-review paths:"
+            echo "This PR touches design-review paths (non-test):"
+            echo "${NON_TEST_MATCHED}"
+          elif [ -n "${MATCHED}" ]; then
+            echo "in_scope=false" >> "$GITHUB_OUTPUT"
+            echo "design-review 경로에 걸린 파일이 있지만 전부 테스트/스토리북(*.test.ts(x)·*.stories.*)이다 — 시각 표면 변경 0, 스코프 밖(story #2685):"
             echo "${MATCHED}"
           else
             echo "in_scope=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
실사례(PR#3101): `app-sidebar.test.tsx` 41줄(테스트 전용)이 `apps/web/src/components/` 경로 grep에 잡혀 `design:pass`를 요구했다 — 시각 표면 변경 0인데 유나군이 형식 스탬프를 찍어야 머지되는 반복 마찰(FE 테스트 보강 PR마다 재발).

## Fix
기존 경로 필터(`MATCHED`)는 그대로 두고, 그 안에서 `*.test.{ts,tsx}`·`*.stories.*`를 뺀 나머지(`NON_TEST_MATCHED`)가 하나라도 있어야 `in_scope=true` — `MATCHED`가 전부 테스트/스토리북이면 out-of-scope로 내린다. `MATCHED` 안에 비테스트 시각 파일이 하나라도 섞이면 그 즉시 여전히 라벨 요구(AC2 음성대조 — 혼합 PR 무회귀).

## Test plan
- [x] PR#3101 실 파일셋(test-only) → `in_scope=false` 확認
- [x] 혼합(test+tsx) → `in_scope=true`(무회귀) 확認
- [x] `*.stories.*` → skip 확認
- [x] 정상 src-only PR → 무회귀 확認
- [x] 무매치(docs) → 무회귀 확認
- [x] #2676의 head-match/미완 체크런 스텝은 `in_scope` 출력만 소비하므로(로직 무접촉) 상호작용 무회귀
- [x] actionlint + shellcheck 클린
- [x] CI 대기

🤖 Generated with [Claude Code](https://claude.com/claude-code)