### PR TITLE
[SID:2683] SidebarTrigger 단일문 폐기 — 태블릿 전용 GNB 트리거로 이전

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -74,6 +74,7 @@
     "sprints": "Sprints",
     "search": "Search…",
     "help": "Help",
+    "openGlobalNav": "Open menu",
     "chats": "Chats",
     "activity": "Activity Log",
     "goals": "Goals",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -74,6 +74,7 @@
     "sprints": "스프린트",
     "search": "검색…",
     "help": "도움말",
+    "openGlobalNav": "전체 메뉴 열기",
     "chats": "채팅",
     "activity": "활동 로그",
     "goals": "목표",

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -35,7 +35,6 @@ import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { OperatorInput } from '@/components/ui/operator-control';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
-import { SidebarTrigger } from '@/components/ui/sidebar';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { NOTIFICATION_TYPES } from '@/lib/notification-types';
 import { isEEEnabled } from '@/lib/ee';
@@ -796,9 +795,10 @@ export default function SettingsPage() {
 
         {/* Right content */}
         <div className="focus-inset flex-1 min-w-0 overflow-y-auto">
-          {/* Mobile toggle button */}
+          {/* Mobile toggle button — story #2683(모바일 IA S3): 전역 GNB 유일문(SidebarTrigger)
+              폐기(AC1). 그 문은 top-bar.tsx로 옮겨(태블릿 전용) 두 토글 혼동을 없앴다 — 이
+              헤더에 남는 건 설정 내부 LNB 토글 하나뿐이다. */}
           <div className="lg:hidden flex items-center gap-2 border-b px-4 py-2">
-            <SidebarTrigger className="mr-1" />
             <button
               type="button"
               onClick={() => setLnbOpen((v) => !v)}

--- a/apps/web/src/components/nav/top-bar.test.tsx
+++ b/apps/web/src/components/nav/top-bar.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+//
+// story #2683(모바일 IA S3) — settings/page.tsx 안에만 있던 전역 GNB 유일문(SidebarTrigger)을
+// 폐기하며 태블릿(768~1023)만을 위한 새 문을 top-bar.tsx로 옮겼다(doc §2.6① PO 승인 권고).
+// 이 트리거가 태블릿에서만 뜨고 폰·데스크톱에서는 없는지(폰=Sheet GNB 폐기, 데스크톱=이미
+// 도킹 사이드바가 상시 보임이라 트리거 불필요) 실 렌더로 잰다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function stubViewport(width: number) {
+  vi.stubGlobal('innerWidth', width);
+  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+}
+
+function stubFetch() {
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ data: {} }), {
+    status: 200, headers: { 'content-type': 'application/json' },
+  })));
+}
+
+function stubLocalStorage() {
+  const store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => { store.set(k, v); },
+    removeItem: (k: string) => { store.delete(k); },
+    clear: () => store.clear(),
+  });
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  stubFetch();
+  stubLocalStorage();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function mount(width: number) {
+  stubViewport(width);
+  const { TopBar } = await import('./top-bar');
+  const { TopBarProvider } = await import('./top-bar-context');
+  const { SidebarProvider } = await import('@/components/ui/sidebar');
+  await act(async () => {
+    root.render(
+      <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+        <TopBarProvider>
+          <SidebarProvider>
+            <TopBar />
+          </SidebarProvider>
+        </TopBarProvider>
+      </NextIntlClientProvider>,
+    );
+  });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('TopBar — story #2683 태블릿 전용 GNB 트리거', () => {
+  it('태블릿(768px)에서는 트리거가 뜬다', async () => {
+    vi.resetModules();
+    await mount(768);
+    expect(container.querySelector('[data-slot="sidebar-trigger"]')).not.toBeNull();
+  });
+
+  it('폰(375px)에서는 트리거가 없다(Sheet GNB 폐기, doc §2.6①)', async () => {
+    vi.resetModules();
+    await mount(375);
+    expect(container.querySelector('[data-slot="sidebar-trigger"]')).toBeNull();
+  });
+
+  it('데스크톱(1280px)에서는 트리거가 없다(도킹 사이드바 상시 노출)', async () => {
+    vi.resetModules();
+    await mount(1280);
+    expect(container.querySelector('[data-slot="sidebar-trigger"]')).toBeNull();
+  });
+});

--- a/apps/web/src/components/nav/top-bar.tsx
+++ b/apps/web/src/components/nav/top-bar.tsx
@@ -1,11 +1,14 @@
 'use client';
 
+import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 import { NotificationBell } from './notification-bell';
 import { WhatsNewButton } from '@/components/release-notes/whats-new-button';
 import { PresenceToggleButton } from '@/components/presence/team-presence-toggle';
 import { useTopBar } from './top-bar-context';
 import { ContextSwitcherChip } from './context-switcher-chip';
+import { SidebarTrigger } from '@/components/ui/sidebar';
+import { useIsTablet } from '@/hooks/use-mobile';
 import type { OrgSwitcherItem } from './unified-switcher';
 
 interface TopBarProps {
@@ -21,6 +24,8 @@ interface TopBarProps {
 
 export function TopBar({ className, orgId, orgMemberships = [], projectId, projectMemberships = [] }: TopBarProps) {
   const { title, actions, hidden, showContextChip } = useTopBar();
+  const t = useTranslations('nav');
+  const isTablet = useIsTablet();
   return (
     <div
       className={cn(
@@ -40,6 +45,14 @@ export function TopBar({ className, orgId, orgMemberships = [], projectId, proje
           근본 재구현(2076 회귀 후속, 유나양 규격): 기본 숨김·표시할 루트 화면만 showContextChip
           으로 명시 — "숨길 것 명시" 방식이 새 상세 화면마다 빠뜨리는 fail-open이었던 것을
           "표시할 것만 명시·기본 숨김"으로 뒤집었다(상세 화면은 이미 뒤로가기로 맥락이 있다). */}
+      {/* story #2683(모바일 IA S3) — settings/page.tsx 안에만 있던 전역 GNB 유일문
+          (SidebarTrigger)을 폐기하며(AC1), 태블릿(768~1023, doc §2.6① PO 승인 권고로 Sheet
+          GNB 존치)만 새 문을 여기 둔다. 폰(<768)은 문이 없다 — /more 허브(S2)가 이미 전
+          목적지를 2탭으로 커버해 Sheet GNB 자체가 불필요(doc 판별자). useIsTablet()은 JS
+          판정이라 `md:` Tailwind 브레이크포인트 신규 사용 금지 규율을 건드리지 않는다. */}
+      {isTablet && (
+        <SidebarTrigger aria-label={t('openGlobalNav')} />
+      )}
       {showContextChip && (
         <ContextSwitcherChip
           orgs={orgMemberships}

--- a/apps/web/src/hooks/use-mobile.test.tsx
+++ b/apps/web/src/hooks/use-mobile.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+//
+// story #2683(모바일 IA S3) — useIsTablet()이 768~1023 문턱을 정확히 가르는지 잰다. TopBar의
+// 새 GNB 트리거(Sheet GNB 폰 폐기·태블릿 존치, doc §2.6①)가 이 훅 하나에 전적으로 의존하므로
+// 경계값(767/768/1023/1024)에서 틀리면 그 즉시 폰에 문이 새로 생기거나 태블릿에서 문이
+// 사라진다.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useIsTablet } from './use-mobile';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function stubViewport(width: number) {
+  vi.stubGlobal('innerWidth', width);
+  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+}
+
+function Probe() {
+  const isTablet = useIsTablet();
+  return <span data-testid="result">{String(isTablet)}</span>;
+}
+
+async function readResult(width: number): Promise<string> {
+  stubViewport(width);
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  await act(async () => { root.render(<Probe />); });
+  const text = container.querySelector('[data-testid="result"]')?.textContent ?? '';
+  await act(async () => { root.unmount(); });
+  container.remove();
+  return text;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useIsTablet — story #2683 768~1023 경계', () => {
+  it('767px(폰)는 false', async () => {
+    expect(await readResult(767)).toBe('false');
+  });
+
+  it('768px(태블릿 하한)는 true', async () => {
+    expect(await readResult(768)).toBe('true');
+  });
+
+  it('1023px(태블릿 상한)는 true', async () => {
+    expect(await readResult(1023)).toBe('true');
+  });
+
+  it('1024px(데스크톱, MOBILE_BREAKPOINT)는 false', async () => {
+    expect(await readResult(1024)).toBe('false');
+  });
+
+  it('375px(일반 폰 폭)는 false', async () => {
+    expect(await readResult(375)).toBe('false');
+  });
+});

--- a/apps/web/src/hooks/use-mobile.ts
+++ b/apps/web/src/hooks/use-mobile.ts
@@ -19,3 +19,32 @@ export function useIsMobile() {
 
   return !!isMobile
 }
+
+// story #2683(모바일 IA S3, doc mobile-ia-full-completion-2678 §2.6①) — 폰(<768)은 /more
+// 허브(S2)가 전 목적지 도달을 이미 커버해 Sheet GNB 문이 필요 없다(PO 승인 권고). 태블릿
+// (768~1023)은 화면 여력이 있어 Sheet GNB를 존치한다 — 그런데 그 문(SidebarTrigger)이 지금껏
+// settings 페이지 안에만 있었다(§1.4 실측: 전 앱 유일 진입점). 그 문을 지우면서(AC1) 태블릿만
+// 「폰과 똑같이 문이 없어지는」 회귀를 막으려면 폰/태블릿을 가르는 별도 판정이 필요하다.
+// ⚠️CLAUDE.md 프로젝트 규율 — `md:`(768) Tailwind 브레이크포인트 신규 사용 금지(GNB SSOT는
+// lg뿐). 그래서 CSS 클래스가 아니라 이 훅처럼 JS 판정으로 768 문턱을 다룬다(useIsMobile()과
+// 같은 패턴 — 훅은 이미 브레이크포인트를 다루는 정당한 통로다).
+export const TABLET_BREAKPOINT = 768
+
+export function useIsTablet() {
+  const [isTablet, setIsTablet] = React.useState<boolean | undefined>(undefined)
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(
+      `(min-width: ${TABLET_BREAKPOINT}px) and (max-width: ${MOBILE_BREAKPOINT - 1}px)`,
+    )
+    const onChange = () => {
+      const width = window.innerWidth
+      setIsTablet(width >= TABLET_BREAKPOINT && width < MOBILE_BREAKPOINT)
+    }
+    mql.addEventListener("change", onChange)
+    onChange()
+    return () => mql.removeEventListener("change", onChange)
+  }, [])
+
+  return !!isTablet
+}


### PR DESCRIPTION
## 요약
doc [mobile-ia-full-completion-2678](entity:doc:0b78e166-a34a-4808-b57b-9ad9b25e3b16) §2.6①, S3(4단계 중 3/4·S2 상륙 후 안전 — org 관리면이 /more로 직접 도달하게 된 뒤에만). `settings/page.tsx`의 라벨 없는 `SidebarTrigger`(모바일 전역 GNB 유일문, doc §1.4 실측)를 폐기.

## 변경
- `SidebarTrigger` 삭제(`settings/page.tsx`) — 설정 헤더엔 이제 LNB 토글(설정 내부 탭 전환) 하나만 남는다(AC1, 두 토글 혼동 해소).
- 폰(<768)은 문이 없다 — /more 허브(S2)가 이미 전 목적지를 2탭으로 커버해 Sheet GNB 자체가 불필요(doc 판별자).
- 태블릿(768~1023)은 Sheet GNB를 존치한다(doc §2.6① PO 승인 권고 — 화면 밀도 여력). 그 문을 `top-bar.tsx`(전 인증 화면 공용 상단바)로 옮겨 어디서든 열 수 있게 한다.
- 폰/태블릿 구분은 `useIsTablet()`(신규, `use-mobile.ts`) — JS 판정이라 CLAUDE.md `md:` Tailwind 브레이크포인트 신규 사용 금지 규율을 건드리지 않는다(`useIsMobile()`과 같은 SSOT 패턴).
- 새 트리거에 `aria-label` 부여(i18n `nav.openGlobalNav`) — doc이 지적한 "라벨 없는" 결함을 옮기는 김에 함께 고쳤다.

## AC 대조
1. ✅ SidebarTrigger 단일문 제거·설정 헤더 토글 1개(LNB)만
2. ✅ Sheet GNB: <768 미노출·768~1023 유지(`useIsTablet()` 경계값 테스트로 실측 고정)
3. 음성대조(폐기 후 org 관리면 2탭 도달 유지) — dev 배포 후 라이브 확認 예정
4. 카디르 QA+유나 design 대기

## 검증
- `pnpm exec tsc --noEmit` / `pnpm exec eslint .` — 통과, 0 warning
- `pnpm build` — 통과
- `pnpm exec vitest run` — 428 files / 3466 tests 전부 통과(신규 8건 포함)
- `verify-no-new-md-breakpoint.ts` / `verify-no-new-tint-color-text.ts` / `verify-no-i18n-phrase-collision.ts` / `verify-no-orphan-resource-routes.ts` — 신규 회귀 0건
- RED→GREEN: `git stash`로 fix 제거 후 신규 테스트(useIsTablet 경계값 5건+TopBar 트리거 3건) 6/8 RED 확인 → `stash pop`으로 GREEN 복귀 확認

## 스크린샷
브레이크포인트별 실제 화면은 로컬 FE→dev 클라우드 BE JWT 불일치로 라이브 로그인 불가(기존 세션 규율) — 라이브 픽셀·AC3(음성대조) 실측은 dev 배포 후 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)