### PR TITLE
[SID:2684] 도달 depth 회귀 가드(주요 관리면 ≤2탭 CI 체크)

### DIFF
--- a/apps/web/scripts/verify-mobile-nav-depth.test.ts
+++ b/apps/web/scripts/verify-mobile-nav-depth.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { MOBILE_HUB_EXCLUDE_IDS, MOBILE_HUB_GROUP_ORDER, NAV_GROUPS } from '../src/lib/nav-config';
+import { computeMobileDepths, findDepthViolations, MAX_MOBILE_DEPTH, type DepthEntry } from './verify-mobile-nav-depth';
+
+describe('computeMobileDepths — story #2684', () => {
+  it('MOBILE_HUB_EXCLUDE_IDS 항목은 depth 1(바텀 탭 직행)', () => {
+    const groups = [{ id: 'work', items: [{ id: 'flow' }] }];
+    expect(computeMobileDepths(groups, new Set(['flow']), new Set(['work']))).toEqual([
+      { id: 'flow', groupId: 'work', depth: 1 },
+    ]);
+  });
+
+  it('제외 안 됐고 그룹이 허브 순서에 있으면 depth 2(전체 탭 1 + 허브 내 선택 1)', () => {
+    const groups = [{ id: 'organization', items: [{ id: 'org-events' }] }];
+    expect(computeMobileDepths(groups, new Set(), new Set(['organization']))).toEqual([
+      { id: 'org-events', groupId: 'organization', depth: 2 },
+    ]);
+  });
+
+  // story #2684 핵심 발견 — 항목을 실제로 3탭짜리 서브메뉴에 옮기는 것보다, nav-config.ts에
+  // 새 관리면을 추가하면서 MOBILE_HUB_GROUP_ORDER 갱신을 깜빡하는 실수가 훨씬 현실적이다.
+  // 그룹이 허브 순서 밖이면 그 그룹의 항목 전체가 «도달불가»(depth ∞)다.
+  it('그룹이 MOBILE_HUB_GROUP_ORDER 밖이면 도달불가(depth Infinity)', () => {
+    const groups = [{ id: 'organization', items: [{ id: 'org-events' }] }];
+    const entries = computeMobileDepths(groups, new Set(), new Set(['work'])); // 'organization' 없음
+    expect(entries).toEqual([{ id: 'org-events', groupId: 'organization', depth: Number.POSITIVE_INFINITY }]);
+  });
+});
+
+describe('findDepthViolations — story #2684 AC1(양성대조)', () => {
+  it('3탭으로 밀린 픽스처(depth 3)는 RED를 낸다', () => {
+    const fake: DepthEntry[] = [{ id: 'org-events', groupId: 'organization', depth: 3 }];
+    expect(findDepthViolations(fake, MAX_MOBILE_DEPTH)).toEqual(fake);
+  });
+
+  it('허브 순서에서 빠져 도달불가(Infinity)가 된 픽스처도 RED를 낸다', () => {
+    const fake: DepthEntry[] = [{ id: 'org-events', groupId: 'organization', depth: Number.POSITIVE_INFINITY }];
+    expect(findDepthViolations(fake, MAX_MOBILE_DEPTH)).toEqual(fake);
+  });
+
+  it('허용 depth 이하는 통과한다', () => {
+    const fake: DepthEntry[] = [
+      { id: 'flow', groupId: 'work', depth: 1 },
+      { id: 'org-events', groupId: 'organization', depth: 2 },
+    ];
+    expect(findDepthViolations(fake, MAX_MOBILE_DEPTH)).toEqual([]);
+  });
+
+  it('경계값(depth === maxDepth)은 위반이 아니다', () => {
+    expect(findDepthViolations([{ id: 'x', groupId: 'g', depth: 2 }], 2)).toEqual([]);
+  });
+});
+
+describe('실 NAV_GROUPS — story #2684 AC3 판별자(이벤트 포함 전 관리면 depth ≤2)', () => {
+  const hubGroupIds = new Set(MOBILE_HUB_GROUP_ORDER);
+
+  it('전 21항목이 depth ≤2다(회귀 0 — 도달불가 0건 포함)', () => {
+    const entries = computeMobileDepths(NAV_GROUPS, MOBILE_HUB_EXCLUDE_IDS, hubGroupIds);
+    expect(findDepthViolations(entries, MAX_MOBILE_DEPTH)).toEqual([]);
+  });
+
+  it('이벤트(판별자 자체)는 depth 2다', () => {
+    const entries = computeMobileDepths(NAV_GROUPS, MOBILE_HUB_EXCLUDE_IDS, hubGroupIds);
+    const events = entries.find((e) => e.id === 'org-events');
+    expect(events?.depth).toBe(2);
+  });
+
+  it('flow·inbox·chats는 depth 1이고 그 외는 전부 depth 2다(바텀 탭 축과 정확히 일치)', () => {
+    const entries = computeMobileDepths(NAV_GROUPS, MOBILE_HUB_EXCLUDE_IDS, hubGroupIds);
+    const depth1Ids = entries.filter((e) => e.depth === 1).map((e) => e.id).sort();
+    expect(depth1Ids).toEqual(['chats', 'flow', 'inbox']);
+    expect(entries.filter((e) => e.depth === 2).length).toBe(entries.length - 3);
+  });
+
+  it('NAV_GROUPS의 모든 그룹 id가 MOBILE_HUB_GROUP_ORDER에 있다(도달불가 0건 실증)', () => {
+    const navGroupIds = new Set(NAV_GROUPS.map((g) => g.id));
+    for (const id of navGroupIds) expect(hubGroupIds.has(id)).toBe(true);
+  });
+});

--- a/apps/web/scripts/verify-mobile-nav-depth.ts
+++ b/apps/web/scripts/verify-mobile-nav-depth.ts
@@ -1,0 +1,104 @@
+/**
+ * story #2684(모바일 IA S4, 4단계 중 마지막) 회귀가드 — doc mobile-ia-full-completion-2678의
+ * 판별자("주요 관리 화면 도달이 몇 탭인가")를 CI가 기계로 재는 자리. S1~S3가 4탭→2탭으로
+ * 좁힌 게 다시 조용히 벌어지는 걸(IA가 다시 깊어지는 회귀) 사람 손 재감사 없이 잡는다
+ * ("폐기 신호는 수렴을 잴 수 있어야" — doc §0 취지의 CI판).
+ *
+ * ── depth 모델(doc §2.2/§2.4) ──────────────────────────────────────────────
+ *   depth 1     — MOBILE_HUB_EXCLUDE_IDS(바텀 탭 직행: flow·inbox·chats). 탭 1회.
+ *   depth 2     — 그 외 항목 중 그룹이 MOBILE_HUB_GROUP_ORDER에 있다. 「전체」 탭 1회 +
+ *                 허브 안 항목 선택 1회. 전제: /more 허브가 아코디언 없는 단일 평면
+ *                 목록이라는 것(그 전제 자체는 이 가드가 아니라 more/page.test.tsx의 실
+ *                 렌더 테스트가 지킨다, story #2682 AC3 — [aria-expanded] 요소 0건 확認).
+ *   Infinity(도달불가) — 그룹이 MOBILE_HUB_GROUP_ORDER에서 빠졌다. more/page.tsx는
+ *                 `MOBILE_HUB_GROUP_ORDER.map((id) => NAV_GROUPS.find(...))`로 순회하므로
+ *                 그룹 id가 그 목록에서 빠지면 그 그룹 전체가 허브에서 조용히 사라진다 —
+ *                 «더 깊어짐»이 아니라 «도달 불가»이지만, 둘 다 판별자(몇 탭에 도달하는가)
+ *                 위반이라는 점은 같다(도달 불가 = depth ∞). 이 축이 실은 이 가드가 잡는
+ *                 가장 현실적인 회귀다 — nav-config.ts에 새 관리면을 추가하면서
+ *                 MOBILE_HUB_GROUP_ORDER 갱신을 깜빡하는 실수가, 항목 하나를 실제로 3탭짜리
+ *                 서브메뉴에 옮겨 넣는 실수보다 훨씬 일어나기 쉽다.
+ *
+ * ── AC2 — 이 가드가 «못 잡는 것» (선언 없이 초록이면 「전부 봤다」로 읽힌다) ──────────
+ *   ㉠런타임/조건부 depth — role·plan에 따라 메뉴 항목이 숨겨지거나 다른 경로로 재배치되는
+ *     경우(feature flag 등). nav-config.ts는 정적 카탈로그라 그런 분기를 표현 못 한다.
+ *   ㉡실 렌더 아코디언 회귀 — more/page.tsx가 언젠가 그룹을 <details>/Accordion으로 감싸
+ *     depth+1을 만들어도 이 가드(순수 데이터 스캔)는 못 본다. more/page.test.tsx의 별도
+ *     [aria-expanded] 부재 테스트가 그 축을 담당한다(가드 두 개가 서로 다른 축을 나눠 짐).
+ *   ㉢/more 자신의 depth — 「전체」 탭이 바텀 탭바에서 정확히 1탭 거리라는 전제 자체는 이
+ *     가드가 검증 안 한다(MobileTabBar 구조 변경은 별도 관심사).
+ *   ㉣페이지 내부 서브내비게이션 — [ws]/[proj]/<resource> 도달 «이후» 그 화면 안에서 또
+ *     몇 번 눌러야 하는지(예: workforce 하위 상세)는 이 가드의 스코프 밖(도달 depth=최상위
+ *     목적지까지만, doc §2.4 표와 동일 범위).
+ *   ㉤그룹 내부 항목 순서 — 이 가드는 항목이 그 그룹 안에 «있다/없다»만 본다. 항목이 그룹
+ *     안에서 몇 번째로 뜨는지(스크롤 위치)는 depth 개념이 아니라서 다루지 않는다.
+ */
+import { MOBILE_HUB_EXCLUDE_IDS, MOBILE_HUB_GROUP_ORDER, NAV_GROUPS } from '../src/lib/nav-config';
+
+export const MAX_MOBILE_DEPTH = 2;
+
+export interface DepthEntry {
+  id: string;
+  groupId: string;
+  depth: number;
+}
+
+// 이 함수가 실제로 쓰는 것만 구조로 요구한다(전체 NavGroupConfig가 아니라) — 테스트가
+// 최소 픽스처(id·items[].id)만으로 독립 검증할 수 있게(AC1 양성대조가 실 nav-config.ts
+// 타입에 묶이지 않는다).
+export interface MinimalGroup {
+  id: string;
+  items: { id: string }[];
+}
+
+export function computeMobileDepths(
+  groups: MinimalGroup[],
+  excludeIds: Set<string>,
+  hubGroupIds: Set<string>,
+): DepthEntry[] {
+  const entries: DepthEntry[] = [];
+  for (const group of groups) {
+    const inHub = hubGroupIds.has(group.id);
+    for (const item of group.items) {
+      const depth = excludeIds.has(item.id) ? 1 : inHub ? 2 : Number.POSITIVE_INFINITY;
+      entries.push({ id: item.id, groupId: group.id, depth });
+    }
+  }
+  return entries;
+}
+
+export function findDepthViolations(entries: DepthEntry[], maxDepth: number): DepthEntry[] {
+  return entries.filter((e) => e.depth > maxDepth);
+}
+
+function main(): void {
+  // computeMobileDepths/findDepthViolations은 순수 함수라 테스트가 가짜 입력으로 독립
+  // 검증한다(AC1 양성대조) — main()은 그 함수들에 실 NAV_GROUPS를 흘려보낼 뿐이다.
+  const entries = computeMobileDepths(NAV_GROUPS, MOBILE_HUB_EXCLUDE_IDS, new Set(MOBILE_HUB_GROUP_ORDER));
+  const violations = findDepthViolations(entries, MAX_MOBILE_DEPTH);
+
+  console.log(
+    `[AC9] 모바일 도달 depth 스캔 — 항목 ${entries.length}개(depth 1: ${entries.filter((e) => e.depth === 1).length}개 · ` +
+      `depth 2: ${entries.filter((e) => e.depth === 2).length}개) · 최대 허용 depth=${MAX_MOBILE_DEPTH}`,
+  );
+
+  if (violations.length > 0) {
+    console.error(`\n❌ depth 초과(도달불가 포함) ${violations.length}건:`);
+    for (const v of violations) {
+      const label = Number.isFinite(v.depth) ? `depth ${v.depth}` : '도달불가(그룹이 MOBILE_HUB_GROUP_ORDER 밖)';
+      console.error(`  - [${v.groupId}] ${v.id} → ${label}`);
+    }
+    console.error(
+      '\n→ nav-config.ts 항목이 MOBILE_HUB_EXCLUDE_IDS 밖인데 그 그룹이 MOBILE_HUB_GROUP_ORDER에 ' +
+        '없거나(도달불가), depth 계산 자체가 2를 넘는다. 새 관리면을 추가했다면 그 그룹이 ' +
+        'MOBILE_HUB_GROUP_ORDER에 있는지 먼저 확認.',
+    );
+    process.exit(1);
+  }
+
+  console.log(`OK: 전 항목 depth ≤${MAX_MOBILE_DEPTH}(doc §2.4 판별자 충족).`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/apps/web/src/app/(authenticated)/more/page.tsx
+++ b/apps/web/src/app/(authenticated)/more/page.tsx
@@ -3,31 +3,21 @@
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
-import { NAV_GROUPS } from '@/lib/nav-config';
+import { MOBILE_HUB_EXCLUDE_IDS, MOBILE_HUB_GROUP_ORDER, NAV_GROUPS } from '@/lib/nav-config';
 
 // story #2682(모바일 IA S2, doc mobile-ia-full-completion-2678 §2.3) — 임시 평면 stub(#1958·
 // #1965)을 데스크톱 GNB(app-sidebar.tsx) 5 zones를 그대로 미러하는 그룹형 허브로 재건한다.
 // 목적지 목록 자체는 새로 만들지 않는다 — S1이 추출한 NAV_GROUPS(nav-config.ts)를 그대로
-// 소비해 데스크톱과 drift 없이 항상 정합한다(SSOT).
-//
-// 그룹 순서는 데스크톱과 다르다(doc §2.3 명시) — 데스크톱은 "조직이 4구역 위 프레임"이라
-// 맨 위지만, 모바일 허브는 §2.2 분류(자주→가끔→관리) 순서를 따라 조직·설정(관리)이 뒤로
-// 간다: 홈·지금 / 작업 / 신뢰 / 지식 / 조직(이벤트 포함) / 설정.
-const MOBILE_GROUP_ORDER = ['now', 'work', 'trust', 'knowledge', 'organization', 'settings'];
-
-// flow·inbox·chats는 바텀 탭(지금/결재/채팅)이 이미 depth 1로 커버한다(doc §2.2 "자주" 축) —
-// 허브에 또 실으면 같은 목적지로 가는 진입점이 두 개가 되고 "몇 탭"의 의미가 흐려진다
-// (기존 stub도 board를 같은 이유로 뺐던 것과 같은 원칙, page.tsx 옛 주석 참조).
-const HUB_EXCLUDE_ITEM_IDS = new Set(['flow', 'inbox', 'chats']);
-
+// 소비해 데스크톱과 drift 없이 항상 정합한다(SSOT). 그룹 순서·제외 목록도 story #2684(S4)에서
+// nav-config.ts로 옮겨 depth 가드가 이 페이지 내부를 몰라도 SSOT 하나만 보고 판정할 수 있다.
 export default function MorePage() {
   const t = useTranslations('nav');
   const tMore = useTranslations('mobileTabBar');
 
-  const hubGroups = MOBILE_GROUP_ORDER
+  const hubGroups = MOBILE_HUB_GROUP_ORDER
     .map((groupId) => NAV_GROUPS.find((g) => g.id === groupId))
     .filter((g): g is NonNullable<typeof g> => !!g)
-    .map((g) => ({ ...g, items: g.items.filter((item) => !HUB_EXCLUDE_ITEM_IDS.has(item.id)) }))
+    .map((g) => ({ ...g, items: g.items.filter((item) => !MOBILE_HUB_EXCLUDE_IDS.has(item.id)) }))
     .filter((g) => g.items.length > 0);
 
   return (

--- a/apps/web/src/lib/nav-config.ts
+++ b/apps/web/src/lib/nav-config.ts
@@ -110,3 +110,16 @@ export const NAV_GROUPS: NavGroupConfig[] = [
     ],
   },
 ];
+
+// story #2682(S2)에서 more/page.tsx 로컬 상수였던 것을 story #2684(S4)에서 이리 옮긴다 —
+// 모바일 허브 그룹 순서·제외 목록도 nav-config.ts의 SSOT 일부다(그래야 depth 가드가 더보기
+// 렌더러 내부를 몰라도 이 파일 하나만 보고 「도달 depth ≤2」를 판정할 수 있다).
+//
+// 그룹 순서는 데스크톱과 다르다(doc mobile-ia-full-completion-2678 §2.3 명시) — 데스크톱은
+// "조직이 4구역 위 프레임"이라 맨 위지만, 모바일 허브는 §2.2 분류(자주→가끔→관리) 순서를
+// 따라 조직·설정(관리)이 뒤로 간다: 홈·지금 / 작업 / 신뢰 / 지식 / 조직(이벤트 포함) / 설정.
+export const MOBILE_HUB_GROUP_ORDER = ['now', 'work', 'trust', 'knowledge', 'organization', 'settings'];
+
+// flow·inbox·chats는 바텀 탭(지금/결재/채팅)이 이미 depth 1로 커버한다(doc §2.2 "자주" 축) —
+// 허브에 또 실으면 같은 목적지로 가는 진입점이 두 개가 되고 "몇 탭"의 의미가 흐려진다.
+export const MOBILE_HUB_EXCLUDE_IDS = new Set(['flow', 'inbox', 'chats']);


### PR DESCRIPTION
## 요약
doc [mobile-ia-full-completion-2678](entity:doc:0b78e166-a34a-4808-b57b-9ad9b25e3b16), S4(4단계 중 마지막·S2·S3 상륙 후). S1~S3가 「전 org 관리면 4탭→2탭」으로 좁힌 게 조용히 다시 벌어지는 회귀를(IA가 다시 깊어짐) 사람 손 재감사 없이 CI가 기계로 잡는다.

## 변경
- `nav-config.ts`: `more/page.tsx` 로컬 상수였던 `MOBILE_HUB_GROUP_ORDER`·`MOBILE_HUB_EXCLUDE_IDS`를 SSOT로 이전 — 깊이 가드가 더보기 렌더러 내부를 몰라도 이 파일 하나만 보고 판정할 수 있게.
- `scripts/verify-mobile-nav-depth.ts`(신규 CI 가드) — depth 모델: 바텀 탭 직행(flow·inbox·chats)=1, 그 외 허브 그룹 소속 항목=2, **그룹이 `MOBILE_HUB_GROUP_ORDER`에서 빠지면 도달불가(depth Infinity)**. 후자가 실은 이 가드가 잡는 가장 현실적인 회귀다 — 항목을 실제로 3탭짜리 서브메뉴에 옮기는 실수보다, 새 관리면을 `nav-config.ts`에 추가하면서 `MOBILE_HUB_GROUP_ORDER` 갱신을 깜빡하는 실수가 훨씬 일어나기 쉽다.
- AC2(가드 미포착 축) 파일 상단에 5축 선언 — 런타임/조건부 depth·실 렌더 아코디언 회귀(별도 가드 `[aria-expanded]` 테스트가 담당)·/more 자신의 탭 거리·페이지 내부 서브내비게이션·그룹 내 항목 순서.

## AC 대조
1. ✅ depth 가드 CI 상륙(양성대조: 픽스처 depth 3·도달불가 둘 다 RED 확인)
2. ✅ 가드 미포착 축 선언(주석)
3. 라이브 픽셀(유나, doc §2.4 표 전 행) — PO 지시로 별도 트랙, 이 PR 스코프 밖
4. 카디르 QA 대기

## 검증
- `pnpm exec tsc --noEmit` / `pnpm exec eslint .` — 통과, 0 warning
- `pnpm build` — 통과
- `pnpm exec vitest run` — 429 files / 3477 tests 전부 통과(신규 11건 포함)
- `verify-no-new-md-breakpoint.ts` / `verify-no-new-tint-color-text.ts` / `verify-no-i18n-phrase-collision.ts` / `verify-no-orphan-resource-routes.ts` / `verify-nav-config-routes.ts` — 신규 회귀 0건
- 픽스처(depth 3·도달불가) 양성대조 + **실 데이터 뮤테이션**(`MOBILE_HUB_GROUP_ORDER`에서 `'organization'` 제거 → 6항목 정확히 도달불가로 잡힘 → 원복)로 가드가 파이프라인 전체로 실제 작동함을 확認

## 스크린샷
CI 가드 스크립트 + SSOT 이전(순수 데이터/로직, 신규 UI 없음) — 라이브 픽셀은 별도 트랙.

🤖 Generated with [Claude Code](https://claude.com/claude-code)