### PR TITLE
[SID:1981] GNB 결재함 배지 = "내 결재 대기 수" — 안읽은 알림 카운트 교체

### DIFF
--- a/apps/web/src/components/nav/app-sidebar.test.tsx
+++ b/apps/web/src/components/nav/app-sidebar.test.tsx
@@ -166,13 +166,25 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1)', () =>
     expect(membersBtn?.hasAttribute('data-active')).toBe(false);
   });
 
-  it('unread 배지(inbox)가 카운트>0일 때만 렌더된다', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ data: { inboxUnreadCount: 3 } }), {
+  // story #1981 — 배지 소스가 "안 읽은 알림 수"에서 "내 결재 대기 수"(/api/gates?status=
+  // pending&assigned_to_me=true, mobile-tab-bar.tsx와 동일 계약)로 바뀌었다. 응답이 원시
+  // 배열이라 .length가 그대로 배지 숫자다.
+  it('결재 대기 배지(inbox)가 카운트>0일 때만 렌더된다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify([{ id: 'g1' }, { id: 'g2' }, { id: 'g3' }]), {
       status: 200, headers: { 'content-type': 'application/json' },
     })));
     await mount();
     const inboxBtn = [...container.querySelectorAll('[data-slot="sidebar-menu-button"]')].find((b) => b.textContent?.includes('알림'));
     expect(inboxBtn?.textContent).toContain('3');
+  });
+
+  it('결재 대기 0건이면 배지가 안 뜬다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify([]), {
+      status: 200, headers: { 'content-type': 'application/json' },
+    })));
+    await mount();
+    const inboxBtn = [...container.querySelectorAll('[data-slot="sidebar-menu-button"]')].find((b) => b.textContent?.includes('알림'));
+    expect(inboxBtn?.querySelector('[data-slot="sidebar-menu-badge"]')).toBeNull();
   });
 
   it('설정 그룹은 라벨 없는 유틸 그룹으로 유지된다(ia-4zone 확定)', async () => {

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -92,7 +92,12 @@ export function AppSidebar({
     if (isMobile) setOpenMobile(false);
   }, [pathname, isMobile, setOpenMobile]);
 
-  const [inboxUnreadCount, setInboxUnreadCount] = useState(0);
+  // story #1981 — GNB 결재함 배지 semantic 교체: "안 읽은 알림 수"(/api/notifications/count)
+  // 대신 "내가 승인 가능한 pending 게이트 수"(/api/gates?status=pending&assigned_to_me=true)로.
+  // mobile-tab-bar.tsx가 이미 같은 계약으로 쓰던 것(story #1974 개인화·#1960 held fix 반영,
+  // origin/main과 diff 0으로 prod에도 이미 있음, #1981 그라운딩 확認)을 그대로 재사용 — 새
+  // 집계 발명 없음.
+  const [inboxPendingCount, setInboxPendingCount] = useState(0);
   // story #1977(트랙B) GNB ③ 채팅 unread 총합 — story #2007로 dashboard-shell.tsx의 단일
   // useChatUnreadTotal() 호출 결과를 prop으로 받는다(MobileTabBar와 SSE 연결 중복 제거).
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -116,23 +121,24 @@ export function AppSidebar({
 
   useEffect(() => {
     let cancelled = false;
-    const fetchUnread = async () => {
+    const fetchPending = async () => {
       try {
-        // story #2160 — 30초 폴링이 401을 조용히 삼키던 자리(fetchWithAuth로 전환).
-        const res = await fetchWithAuth('/api/notifications/count');
+        // story #2160 — 30초 폴링이 401을 조용히 삼키던 자리(fetchWithAuth로 전환) — 그
+        // 규율은 story #1981의 새 엔드포인트에도 그대로 적용한다.
+        const res = await fetchWithAuth('/api/gates?status=pending&assigned_to_me=true');
         if (!res.ok || cancelled) return;
-        const json = await res.json() as { data?: { memoUnreadCount?: number; inboxUnreadCount?: number } };
+        const gates = await res.json() as unknown[];
         if (!cancelled) {
-          setInboxUnreadCount(json.data?.inboxUnreadCount ?? 0);
+          setInboxPendingCount(Array.isArray(gates) ? gates.length : 0);
         }
       } catch { /* noop */ }
     };
 
-    void fetchUnread();
-    intervalRef.current = setInterval(() => { void fetchUnread(); }, 30000);
+    void fetchPending();
+    intervalRef.current = setInterval(() => { void fetchPending(); }, 30000);
 
     const handleVisibility = () => {
-      if (!document.hidden) void fetchUnread();
+      if (!document.hidden) void fetchPending();
     };
     document.addEventListener('visibilitychange', handleVisibility);
 
@@ -186,7 +192,7 @@ export function AppSidebar({
                     ? { href: item.path, isActive: isActive(item.path) }
                     : resourceLink(item.path);
                   const Icon = item.icon;
-                  const badgeCount = item.badgeKey === 'inbox' ? inboxUnreadCount
+                  const badgeCount = item.badgeKey === 'inbox' ? inboxPendingCount
                     : item.badgeKey === 'chats' ? chatUnreadTotal
                     : 0;
                   const badgeCap = item.badgeKey === 'inbox' ? 9 : 99;


### PR DESCRIPTION
## 요약
선생님 결정(2026-07-17) — "안 읽은 알림이면 죽어날거인(99+) · 내 결재 대기 수가 현실적 · 안읽은 알림은 상단에 따로 보이니 중복." GNB 사이드바 결재함 아이콘 배지가 실제로는 "안 읽은 알림 수"(`/api/notifications/count`)를 세고 있어 아이콘의 semantic과 어긋났던 것을 고친다.

## 변경
- `app-sidebar.tsx`의 inbox 배지 소스를 `/api/notifications/count` → `/api/gates?status=pending&assigned_to_me=true`로 교체. **새 집계 발명 없음** — `mobile-tab-bar.tsx`가 story #1974(개인화)·#1960(held fix) 이후 이미 쓰던 것과 동일 계약 그대로 재사용(원시 배열 응답의 `.length`가 배지 숫자).
- 기존 30초 폴링 + `visibilitychange` 갱신 구조(story #2160 `fetchWithAuth` 규율 포함)는 그대로 유지 — PO 확인: "결재 처리 시 갱신은 폴링 주기 내 반영이면 충분."
- 알림 배지(상단 `NotificationBell`)는 무변경 — 별도 관심사로 분리 유지.

## prod 반영 경로 그라운딩(착수 전 PO 게이트 판정 필요 지점이었음)
`origin/main` vs `origin/develop`에서 `backend/app/routers/gates.py` 직접 diff: **완전 동일(0)**. `assigned_to_me`·held fix 모두 이미 prod에 있어 스토리 본문의 "develop-only 진화라 cherry-pick 필요" 전제는 07-17 작성 시점 기준으로 stale 확定(PO 승인, **(b) 최소 포팅** — 순수 FE, 신규 BE 작업 불요).

## AC 대조
- GNB 결재함 배지=내 승인 가능 pending 게이트 수 ✅(같은 엔드포인트를 이미 쓰는 mobile-tab-bar.tsx와 동일 계약이라 남의 것 안 셈도 그대로 상속)
- 결재 처리 시 갱신 ✅(30초 폴링 + focus 복귀 유지, PO 확인 "폴링 주기 내 충분")
- 안읽은 알림 배지와 분리 ✅(상단 NotificationBell 무변경)
- done-gate: dev 실측(내 결재 대기만)+prod 반영 — dev 배포 후 라이브 확認 예정

## 검증
- `pnpm exec tsc --noEmit` / `pnpm exec eslint .` — 통과, 0 warning
- `pnpm build` — 통과
- `pnpm exec vitest run` — 429 files / 3478 tests 전부 통과
- `verify-no-new-md-breakpoint.ts` / `verify-no-new-tint-color-text.ts` / `verify-no-i18n-phrase-collision.ts` — 신규 회귀 0건
- RED→GREEN: `git stash`로 fix 제거 후 배지 테스트 RED 확인 → `stash pop`으로 GREEN 복귀 확認

## 스크린샷
배지 숫자 소스 교체(레이아웃/스타일 무변경) — 라이브 확認(내 결재 대기 수 실측)은 dev 배포 후 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)